### PR TITLE
fix(nfs4): consume the owner seqid when a sequenced operation fails

### DIFF
--- a/internal/adapter/nfs/v4/state/close_seqid_test.go
+++ b/internal/adapter/nfs/v4/state/close_seqid_test.go
@@ -1,0 +1,81 @@
+package state
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// ============================================================================
+// Open-owner seqid must advance on a failed CLOSE
+// ============================================================================
+
+// TestCloseFile_LocksHeldStillAdvancesSeqid pins the sequencing rule for a
+// CLOSE that fails because byte-range locks are still held.
+//
+// RFC 7530 Section 9.1.7 advances the owner's seqid on every operation that
+// reaches seqid checking, whether or not it then succeeds. Only a short list of
+// errors leaves the seqid untouched — NFS4ERR_STALE_CLIENTID,
+// NFS4ERR_STALE_STATEID, NFS4ERR_BAD_STATEID, NFS4ERR_BAD_SEQID,
+// NFS4ERR_BADXDR, NFS4ERR_RESOURCE, NFS4ERR_NOFILEHANDLE and NFS4ERR_MOVED —
+// because those mean the request was never attributable to the owner in the
+// first place. NFS4ERR_LOCKS_HELD is not among them: the owner and its seqid
+// were both valid, and the server simply declined the close.
+//
+// A client that gets NFS4ERR_LOCKS_HELD therefore moves on to the next seqid.
+// If the server does not, the two disagree permanently, and every later
+// operation for that owner is answered NFS4ERR_BAD_SEQID — an error the client
+// cannot recover from without tearing down the owner, so it surfaces as an I/O
+// error to whatever was using the file.
+//
+// The sequence below is the one a WAL database produces: lock, close while
+// still holding the lock, unlock, close again.
+func TestCloseFile_LocksHeldStillAdvancesSeqid(t *testing.T) {
+	lm := lock.NewManager()
+	sm := NewStateManager(90 * time.Second)
+	sm.SetLockManager(lm)
+
+	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
+
+	// Take a byte-range lock so the CLOSE below has something to trip over.
+	lockSeqid := uint32(1)
+	openSeqid++
+	lockRes, err := sm.LockNew(context.Background(),
+		clientID, []byte("lock-owner"), lockSeqid,
+		openStateid, openSeqid,
+		fileHandle, types.WRITE_LT, 0, 100, false,
+	)
+	if err != nil {
+		t.Fatalf("LockNew failed: %v", err)
+	}
+
+	// CLOSE with locks outstanding: expected to fail, and expected to consume
+	// its seqid on the way out.
+	openSeqid++
+	_, err = sm.CloseFile(openStateid, openSeqid)
+	var stateErr *NFS4StateError
+	if !errors.As(err, &stateErr) || stateErr.Status != types.NFS4ERR_LOCKS_HELD {
+		t.Fatalf("CLOSE with locks held: got %v, want NFS4ERR_LOCKS_HELD", err)
+	}
+
+	// Release the lock, as a client does on being told LOCKS_HELD.
+	if _, err := sm.UnlockFile(&lockRes.Stateid, lockSeqid+1, types.WRITE_LT, 0, 100); err != nil {
+		t.Fatalf("UnlockFile failed: %v", err)
+	}
+
+	// The retry carries the next seqid. It must be accepted: the server owes
+	// the client agreement about where the sequence got to.
+	openSeqid++
+	if _, err := sm.CloseFile(openStateid, openSeqid); err != nil {
+		if errors.Is(err, ErrBadSeqid) {
+			t.Fatalf("CLOSE after LOCKS_HELD rejected with NFS4ERR_BAD_SEQID: "+
+				"the failed CLOSE did not advance the open-owner seqid, so the "+
+				"client and server disagree about it from here on (seqid=%d)", openSeqid)
+		}
+		t.Fatalf("CLOSE after releasing locks failed: %v", err)
+	}
+}

--- a/internal/adapter/nfs/v4/state/close_seqid_test.go
+++ b/internal/adapter/nfs/v4/state/close_seqid_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"testing"
@@ -77,5 +78,108 @@ func TestCloseFile_LocksHeldStillAdvancesSeqid(t *testing.T) {
 				"client and server disagree about it from here on (seqid=%d)", openSeqid)
 		}
 		t.Fatalf("CLOSE after releasing locks failed: %v", err)
+	}
+}
+
+// ============================================================================
+// Errors exempt under RFC 7530 Section 9.1.7 must leave the seqid alone
+// ============================================================================
+
+// TestCloseFile_BadSeqidLeavesOwnerSeqidUntouched pins the seqid across a
+// rejected CLOSE. NFS4ERR_BAD_SEQID is on the exempt list of RFC 7530 Section
+// 9.1.7: the client does not advance its sequence after one, so neither may the
+// server.
+func TestCloseFile_BadSeqidLeavesOwnerSeqidUntouched(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	sm.SetLockManager(lock.NewManager())
+
+	_, _, openStateid, openSeqid := setupClientAndOpenState(t, sm)
+
+	// A seqid the owner never reached: neither the expected next one nor a
+	// replay of the last.
+	if _, err := sm.CloseFile(openStateid, openSeqid+7); !errors.Is(err, ErrBadSeqid) {
+		t.Fatalf("CLOSE at an out-of-sequence seqid: got %v, want NFS4ERR_BAD_SEQID", err)
+	}
+
+	// The client is still at the seqid it was, and so must the server be.
+	if _, err := sm.CloseFile(openStateid, openSeqid+1); err != nil {
+		t.Fatalf("CLOSE at the expected seqid after a rejected one failed: %v "+
+			"(the rejected request advanced the open-owner seqid; it must not)", err)
+	}
+}
+
+// TestUnlockFile_BadStateidLeavesLockOwnerSeqidUntouched pins the seqid across a
+// LOCKU whose stateid seqid runs ahead of the server's. NFS4ERR_BAD_STATEID is
+// on the exempt list of RFC 7530 Section 9.1.7: the client leaves its sequence
+// where it was, so the server must too.
+func TestUnlockFile_BadStateidLeavesLockOwnerSeqidUntouched(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	sm.SetLockManager(lock.NewManager())
+
+	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
+
+	lockSeqid := uint32(1)
+	lockRes, err := sm.LockNew(context.Background(),
+		clientID, []byte("lock-owner"), lockSeqid,
+		openStateid, openSeqid+1,
+		fileHandle, types.WRITE_LT, 0, 100, false,
+	)
+	if err != nil {
+		t.Fatalf("LockNew failed: %v", err)
+	}
+
+	ahead := lockRes.Stateid
+	ahead.Seqid = nextSeqID(ahead.Seqid)
+	if _, err := sm.UnlockFile(&ahead, lockSeqid+1, types.WRITE_LT, 0, 100); !errors.Is(err, ErrBadStateid) {
+		t.Fatalf("LOCKU with a stateid ahead of the server's: got %v, want NFS4ERR_BAD_STATEID", err)
+	}
+
+	// The retry carries the right stateid at the same lock-owner seqid, which
+	// the server must still be expecting.
+	if _, err := sm.UnlockFile(&lockRes.Stateid, lockSeqid+1, types.WRITE_LT, 0, 100); err != nil {
+		t.Fatalf("LOCKU retried after NFS4ERR_BAD_STATEID failed: %v "+
+			"(the rejected request advanced the lock-owner seqid; it must not)", err)
+	}
+}
+
+// TestDowngradeOpen_ReplayLeavesOwnerSeqidUntouched pins the seqid and the
+// reply cache across a retransmit. RFC 7530 Section 9.1.7 returns the stored
+// response for a request at the last seqid without re-executing it, so it moves
+// neither.
+func TestDowngradeOpen_ReplayLeavesOwnerSeqidUntouched(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+
+	clientID, _, openStateid, openSeqid := setupClientAndOpenState(t, sm)
+
+	seqid := openSeqid + 1
+	if _, err := sm.DowngradeOpen(openStateid, seqid,
+		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE); err != nil {
+		t.Fatalf("OPEN_DOWNGRADE failed: %v", err)
+	}
+
+	// As the handler does on success: cache the encoded reply for replay.
+	cached := []byte("encoded OPEN_DOWNGRADE reply")
+	sm.CacheOpenOwnerResult(clientID, []byte("open-owner"), types.NFS4_OK, cached)
+
+	// Every retransmit gets that reply back, not just the first.
+	for i := range 2 {
+		_, err := sm.DowngradeOpen(openStateid, seqid,
+			types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE)
+		var replayErr *ReplayError
+		if !errors.As(err, &replayErr) {
+			t.Fatalf("retransmit %d of OPEN_DOWNGRADE: got %v, want a replay", i+1, err)
+		}
+		if replayErr.Status != types.NFS4_OK || !bytes.Equal(replayErr.Data, cached) {
+			t.Fatalf("retransmit %d replayed status=%d data=%q, want status=%d data=%q "+
+				"(the replay consumed the seqid and overwrote the cached reply)",
+				i+1, replayErr.Status, replayErr.Data, types.NFS4_OK, cached)
+		}
+	}
+
+	// The sequence is still where the successful OPEN_DOWNGRADE left it.
+	if _, err := sm.DowngradeOpen(openStateid, seqid+1,
+		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE); err != nil {
+		t.Fatalf("OPEN_DOWNGRADE after replays failed: %v "+
+			"(a replay advanced the open-owner seqid; it must not)", err)
 	}
 }

--- a/internal/adapter/nfs/v4/state/lockowner.go
+++ b/internal/adapter/nfs/v4/state/lockowner.go
@@ -26,12 +26,8 @@ type LockOwner struct {
 	// OwnerData is the opaque owner identifier from the client.
 	OwnerData []byte
 
-	// LastSeqID is the last successfully processed seqid for this owner.
-	LastSeqID uint32
-
-	// LastResult is the cached result of the last operation on this owner.
-	// Used for replay detection (same seqid returns cached result).
-	LastResult *CachedResult
+	// ownerSeq carries this owner's seqid sequence and replay cache.
+	ownerSeq
 
 	// ClientRecord is a back-reference to the owning client record.
 	ClientRecord *ClientRecord
@@ -50,25 +46,6 @@ func (lo *LockOwner) Key() lockOwnerKey {
 		return makeLockOwnerKey(lo.ClientID, lo.OwnerData)
 	}
 	return lo.key
-}
-
-// ValidateSeqID checks whether a seqid is valid for this lock-owner.
-//
-// Uses the same algorithm as OpenOwner.ValidateSeqID:
-//   - Expected = LastSeqID + 1 (with wrap: 0xFFFFFFFF -> 1, not 0)
-//   - seqid == expected -> SeqIDOK
-//   - seqid == LastSeqID -> SeqIDReplay
-//   - else -> SeqIDBad
-func (lo *LockOwner) ValidateSeqID(seqid uint32) SeqIDValidation {
-	expected := nextSeqID(lo.LastSeqID)
-
-	if seqid == expected {
-		return SeqIDOK
-	}
-	if seqid == lo.LastSeqID {
-		return SeqIDReplay
-	}
-	return SeqIDBad
 }
 
 // ============================================================================

--- a/internal/adapter/nfs/v4/state/lockowner_test.go
+++ b/internal/adapter/nfs/v4/state/lockowner_test.go
@@ -14,28 +14,28 @@ import (
 // ============================================================================
 
 func TestLockOwnerValidateSeqID_OK(t *testing.T) {
-	lo := &LockOwner{LastSeqID: 5}
+	lo := &LockOwner{ownerSeq: ownerSeq{LastSeqID: 5}}
 	if v := lo.ValidateSeqID(6); v != SeqIDOK {
 		t.Errorf("ValidateSeqID(6) = %d, want SeqIDOK", v)
 	}
 }
 
 func TestLockOwnerValidateSeqID_Replay(t *testing.T) {
-	lo := &LockOwner{LastSeqID: 5}
+	lo := &LockOwner{ownerSeq: ownerSeq{LastSeqID: 5}}
 	if v := lo.ValidateSeqID(5); v != SeqIDReplay {
 		t.Errorf("ValidateSeqID(5) = %d, want SeqIDReplay", v)
 	}
 }
 
 func TestLockOwnerValidateSeqID_Bad(t *testing.T) {
-	lo := &LockOwner{LastSeqID: 5}
+	lo := &LockOwner{ownerSeq: ownerSeq{LastSeqID: 5}}
 	if v := lo.ValidateSeqID(10); v != SeqIDBad {
 		t.Errorf("ValidateSeqID(10) = %d, want SeqIDBad", v)
 	}
 }
 
 func TestLockOwnerValidateSeqID_WrapAround(t *testing.T) {
-	lo := &LockOwner{LastSeqID: 0xFFFFFFFF}
+	lo := &LockOwner{ownerSeq: ownerSeq{LastSeqID: 0xFFFFFFFF}}
 	// Wrap: 0xFFFFFFFF + 1 = 1 (not 0)
 	if v := lo.ValidateSeqID(1); v != SeqIDOK {
 		t.Errorf("ValidateSeqID(1) after 0xFFFFFFFF = %d, want SeqIDOK", v)
@@ -664,16 +664,17 @@ func TestCloseFile_LocksHeld(t *testing.T) {
 		t.Fatalf("UnlockFile failed: %v", unlockErr)
 	}
 
-	// Now CLOSE should succeed (lock state still exists but no active locks)
-	// However, LockStates slice still has the LockState entry (it persists after LOCKU).
-	// We need to RELEASE_LOCKOWNER first to clean up the LockStates list.
+	// The lock stateid outlives the LOCKU, so RELEASE_LOCKOWNER is the client's
+	// way to retire it. CLOSE no longer depends on that having happened -- it
+	// asks the lock manager for outstanding ranges, not for lock stateids.
 	relErr := sm.ReleaseLockOwner(clientID, []byte("close-lock-owner"))
 	if relErr != nil {
 		t.Fatalf("ReleaseLockOwner failed: %v", relErr)
 	}
 
-	// Now CLOSE should succeed
-	closedRes, closeErr := sm.CloseFile(openStateid, openSeqid+2)
+	// The retry carries the NEXT seqid: the failed CLOSE consumed openSeqid+2,
+	// so resending that one would (correctly) replay its NFS4ERR_LOCKS_HELD.
+	closedRes, closeErr := sm.CloseFile(openStateid, openSeqid+3)
 	if closeErr != nil {
 		t.Fatalf("CloseFile after unlock+release failed: %v", closeErr)
 	}

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -760,19 +760,7 @@ func (sm *StateManager) onLeaseExpired(clientID uint64) {
 				delete(sm.lockStateByOther, lockState.Stateid.Other)
 
 				// Remove actual locks from unified lock manager
-				if lm := sm.lockManagerFor(lockState.FileHandle); lm != nil {
-					ownerID := lockState.LockOwner.LockManagerOwnerID()
-					handleKey := string(lockState.FileHandle)
-					locks := lm.ListUnifiedLocks(handleKey)
-					for _, l := range locks {
-						if l.Owner.OwnerID == ownerID {
-							_ = lm.RemoveUnifiedLock(
-								handleKey,
-								l.Owner, l.Offset, l.Length,
-							)
-						}
-					}
-				}
+				sm.removeOwnerLocksLocked(lockState)
 
 				// Remove lock-owner from lockOwners map
 				if lockState.LockOwner != nil {
@@ -1077,7 +1065,7 @@ func (sm *StateManager) OpenFile(
 	fileHandle []byte,
 	shareAccess, shareDeny uint32,
 	claimType uint32,
-) (*OpenFileResult, error) {
+) (result *OpenFileResult, err error) {
 	// Grace period checks (before acquiring sm.mu)
 	switch claimType {
 	case types.CLAIM_NULL:
@@ -1158,9 +1146,9 @@ func (sm *StateManager) OpenFile(
 		// New owner: create it
 		clientRecord := sm.clientsByID[clientID]
 		owner = &OpenOwner{
-			ClientID:     clientID,
-			OwnerData:    make([]byte, len(ownerData)),
-			LastSeqID:    0, // Will be set to seqid after success
+			ClientID:  clientID,
+			OwnerData: make([]byte, len(ownerData)),
+
 			Confirmed:    false,
 			OpenStates:   make([]*OpenState, 0),
 			ClientRecord: clientRecord,
@@ -1174,6 +1162,11 @@ func (sm *StateManager) OpenFile(
 			clientRecord.OpenOwners[string(ownerData)] = owner
 		}
 	}
+
+	// The seqid is now this owner's, whatever the OPEN goes on to return: a
+	// failure below (share reservation conflict) consumes it just as success
+	// does, and the client advances either way.
+	defer func() { owner.consumeSeqidOnError(seqid, err) }()
 
 	// Enforce share reservations across open-owners (RFC 7530 Section 9.7 /
 	// Section 16.16.5; Linux nfsd nfs4_share_conflict). This runs AFTER the
@@ -1383,7 +1376,7 @@ func (sm *StateManager) CacheLockOwnerResult(clientID uint64, ownerData []byte, 
 //   - Increments the stateid seqid
 //
 // Caller must NOT hold sm.mu.
-func (sm *StateManager) ConfirmOpen(stateid *types.Stateid4, seqid uint32) (*OpenSeqResult, error) {
+func (sm *StateManager) ConfirmOpen(stateid *types.Stateid4, seqid uint32) (result *OpenSeqResult, err error) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
@@ -1397,6 +1390,10 @@ func (sm *StateManager) ConfirmOpen(stateid *types.Stateid4, seqid uint32) (*Ope
 	}
 
 	owner := openState.Owner
+
+	// The request is attributable to this owner, so any failure below consumes
+	// its seqid (RFC 7530 Section 9.1.7).
+	defer func() { owner.consumeSeqidOnError(seqid, err) }()
 
 	// Validate seqid on the owner
 	// seqid=0 is the v4.1 bypass convention: slot table provides replay protection
@@ -1473,7 +1470,7 @@ func (sm *StateManager) ConfirmOpenV41(stateid *types.Stateid4) error {
 //   - Returns a zeroed stateid
 //
 // Caller must NOT hold sm.mu.
-func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32) (*OpenSeqResult, error) {
+func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32) (result *OpenSeqResult, err error) {
 	// Handle special stateids (all-zeros, all-ones): no state to clean up
 	if stateid.IsSpecialStateid() {
 		return &OpenSeqResult{}, nil
@@ -1501,6 +1498,13 @@ func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32) (*OpenS
 
 	owner := openState.Owner
 
+	// The request is attributable to this owner, so any failure below consumes
+	// its seqid (RFC 7530 Section 9.1.7). NFS4ERR_LOCKS_HELD is the case that
+	// matters in practice: a database closing a file while byte-range locks are
+	// outstanding hits it routinely, and leaving the seqid behind would answer
+	// every later CLOSE and LOCK for this owner with NFS4ERR_BAD_SEQID.
+	defer func() { owner.consumeSeqidOnError(seqid, err) }()
+
 	// Validate seqid on the owner
 	// seqid=0 is the v4.1 bypass convention: slot table provides replay protection
 	if seqid != 0 {
@@ -1519,10 +1523,9 @@ func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32) (*OpenS
 		}
 	}
 
-	// Check for held locks before closing
-	// Per RFC 7530, CLOSE MUST fail if byte-range locks are held.
-	// Client must LOCKU all locks before CLOSE.
-	if len(openState.LockStates) > 0 {
+	// Refuse while ranges are genuinely held -- RFC 7530 Section 16.2.4 permits
+	// refusing or freeing, and this server refuses.
+	if sm.hasOutstandingLocksLocked(openState) {
 		return nil, &NFS4StateError{
 			Status:  types.NFS4ERR_LOCKS_HELD,
 			Message: "cannot close: byte-range locks still held, use LOCKU first",
@@ -1532,6 +1535,16 @@ func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32) (*OpenS
 	// Remove the open state from the "other" map and per-file index.
 	delete(sm.openStateByOther, stateid.Other)
 	sm.removeOpenStateFromFileLocked(openState)
+
+	// The open's lock stateids die with it: they hold no ranges (checked above)
+	// and nothing may use them once the open they derive from is gone.
+	for _, lockState := range openState.LockStates {
+		delete(sm.lockStateByOther, lockState.Stateid.Other)
+	}
+	for _, lockState := range openState.LockStates {
+		sm.dropLockOwnerIfUnreferencedLocked(lockState.LockOwner)
+	}
+	openState.LockStates = nil
 
 	// Remember which retained owner this now-closed stateid belonged to so a
 	// retransmitted CLOSE can still resolve the owner's cached reply.
@@ -1577,6 +1590,67 @@ func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32) (*OpenS
 	}, nil
 }
 
+// hasOutstandingLocksLocked reports whether any byte-range lock derived from
+// openState is still held in the lock manager. Not the same question as whether
+// openState has lock stateids: one stays valid after LOCKU frees its last range
+// (RFC 7530 Section 9.1.4.4), so that count never drops back to zero.
+//
+// Caller must hold sm.mu.
+func (sm *StateManager) hasOutstandingLocksLocked(openState *OpenState) bool {
+	for _, lockState := range openState.LockStates {
+		if lockState.LockOwner == nil {
+			continue
+		}
+		lm := sm.lockManagerFor(lockState.FileHandle)
+		if lm == nil {
+			continue
+		}
+		ownerID := lockState.LockOwner.LockManagerOwnerID()
+		for _, l := range lm.ListUnifiedLocks(string(lockState.FileHandle)) {
+			if l.Owner.OwnerID == ownerID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// removeOwnerLocksLocked releases every byte-range lock that lockState's owner
+// holds on lockState's file.
+//
+// Caller must hold sm.mu.
+func (sm *StateManager) removeOwnerLocksLocked(lockState *LockState) {
+	lm := sm.lockManagerFor(lockState.FileHandle)
+	if lm == nil || lockState.LockOwner == nil {
+		return
+	}
+	ownerID := lockState.LockOwner.LockManagerOwnerID()
+	handleKey := string(lockState.FileHandle)
+	for _, l := range lm.ListUnifiedLocks(handleKey) {
+		if l.Owner.OwnerID == ownerID {
+			_ = lm.RemoveUnifiedLock(handleKey, l.Owner, l.Offset, l.Length)
+		}
+	}
+}
+
+// dropLockOwnerIfUnreferencedLocked removes a lock-owner from the owner table
+// once no lock state references it any more. A lock-owner is shared across the
+// opens it locked (one lock state per open-state/file), so dropping it with the
+// first of them would blind replay detection for the ones still live.
+//
+// Caller must hold sm.mu.
+func (sm *StateManager) dropLockOwnerIfUnreferencedLocked(lockOwner *LockOwner) {
+	if lockOwner == nil {
+		return
+	}
+	for _, ls := range sm.lockStateByOther {
+		if ls.LockOwner == lockOwner {
+			return
+		}
+	}
+	delete(sm.lockOwners, lockOwner.Key())
+}
+
 // DowngradeOpen implements the OPEN_DOWNGRADE operation's state management.
 //
 // Per RFC 7530 Section 16.19:
@@ -1587,7 +1661,7 @@ func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32) (*OpenS
 //   - Increments the stateid seqid
 //
 // Caller must NOT hold sm.mu.
-func (sm *StateManager) DowngradeOpen(stateid *types.Stateid4, seqid uint32, newShareAccess, newShareDeny uint32) (*OpenSeqResult, error) {
+func (sm *StateManager) DowngradeOpen(stateid *types.Stateid4, seqid uint32, newShareAccess, newShareDeny uint32) (result *OpenSeqResult, err error) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
@@ -1601,6 +1675,10 @@ func (sm *StateManager) DowngradeOpen(stateid *types.Stateid4, seqid uint32, new
 	}
 
 	owner := openState.Owner
+
+	// The request is attributable to this owner, so any failure below consumes
+	// its seqid (RFC 7530 Section 9.1.7), the NFS4ERR_INVAL rejections included.
+	defer func() { owner.consumeSeqidOnError(seqid, err) }()
 
 	// Validate seqid on the owner
 	// seqid=0 is the v4.1 bypass convention: slot table provides replay protection
@@ -1816,7 +1894,7 @@ func (sm *StateManager) LockNew(
 	lockClientID uint64, lockOwnerData []byte, lockSeqid uint32,
 	openStateid *types.Stateid4, openSeqid uint32,
 	fileHandle []byte, lockType uint32, offset, length uint64, reclaim bool,
-) (*LockResult, error) {
+) (result *LockResult, err error) {
 	// Grace period check (before acquiring sm.mu)
 	if !reclaim {
 		if err := sm.CheckGraceForNewState(); err != nil {
@@ -1833,12 +1911,17 @@ func (sm *StateManager) LockNew(
 		return nil, ErrBadStateid
 	}
 
+	// The request is attributable to this open-owner, so any failure below
+	// consumes its seqid (RFC 7530 Section 9.1.7). The lock-owner's own seqid is
+	// dealt with once that owner exists, further down.
+	defer func() { openState.Owner.consumeSeqidOnError(openSeqid, err) }()
+
 	// 2. Validate open-owner seqid.
 	// In the open_to_lock_owner4 (LockNew) path the LOCK advances BOTH the
 	// open-owner and lock-owner seqids, so a retransmit is a replay against
 	// both. The authoritative cached reply lives on the lock-owner (it is the
 	// LOCK reply), so on an open-owner replay we do not fail here; we resolve
-	// the lock-owner below (step 6) and return its cached result.
+	// the lock-owner below (step 4) and return its cached result.
 	// seqid=0 is the v4.1 bypass convention: slot table provides replay protection
 	openSeqIsReplay := false
 	if openSeqid != 0 {
@@ -1853,12 +1936,7 @@ func (sm *StateManager) LockNew(
 		}
 	}
 
-	// 3. Validate open mode for lock type
-	if err := validateOpenModeForLock(openState, lockType); err != nil {
-		return nil, err
-	}
-
-	// 4. Probe the lock-owner WITHOUT allocating. Seqid validation (step 6)
+	// 3. Probe the lock-owner WITHOUT allocating. Seqid validation (step 4)
 	// must run before any state is inserted into the maps; otherwise a bad
 	// lock seqid would strand a freshly-allocated lock-owner / lock-state
 	// (they would be reused by a later valid LOCK with a wrong LastSeqID=0
@@ -1866,7 +1944,7 @@ func (sm *StateManager) LockNew(
 	loKey := makeLockOwnerKey(lockClientID, lockOwnerData)
 	lockOwner, ownerExists := sm.lockOwners[loKey]
 
-	// 6. Validate lock seqid on lock-owner BEFORE any allocation.
+	// 4. Validate lock seqid on lock-owner BEFORE any allocation.
 	// seqid=0 is the v4.1 bypass convention: slot table provides replay protection
 	if lockSeqid != 0 {
 		if ownerExists {
@@ -1903,13 +1981,13 @@ func (sm *StateManager) LockNew(
 		return nil, ErrBadSeqid
 	}
 
-	// 4b. Find or create lock-owner -- only after seqid validation passes.
+	// 5. Find or create lock-owner -- only after seqid validation passes.
 	if !ownerExists {
 		clientRecord := sm.clientsByID[lockClientID]
 		lockOwner = &LockOwner{
-			ClientID:     lockClientID,
-			OwnerData:    make([]byte, len(lockOwnerData)),
-			LastSeqID:    0,
+			ClientID:  lockClientID,
+			OwnerData: make([]byte, len(lockOwnerData)),
+
 			ClientRecord: clientRecord,
 			key:          loKey,
 		}
@@ -1917,7 +1995,19 @@ func (sm *StateManager) LockNew(
 		sm.lockOwners[loKey] = lockOwner
 	}
 
-	// 5. Find or create lock state for (lock-owner, open-state) pair
+	// The lock-owner now exists, so its seqid can be consumed like the
+	// open-owner's above. Nothing is lost by starting here: every failure before
+	// this point is a seqid verdict, and those are exempt anyway.
+	defer func() { lockOwner.consumeSeqidOnError(lockSeqid, err) }()
+
+	// 6. Validate open mode for lock type. This runs after both seqid checks so
+	// a bad seqid, which must leave the sequence untouched, outranks
+	// NFS4ERR_OPENMODE, which consumes it.
+	if err := validateOpenModeForLock(openState, lockType); err != nil {
+		return nil, err
+	}
+
+	// 7. Find or create lock state for (lock-owner, open-state) pair
 	var lockState *LockState
 	for _, ls := range openState.LockStates {
 		if ls.LockOwner == lockOwner {
@@ -1945,7 +2035,7 @@ func (sm *StateManager) LockNew(
 		sm.lockStateByOther[other] = lockState
 	}
 
-	// 7. Acquire the lock via unified lock manager
+	// 8. Acquire the lock via unified lock manager
 	denied, err := sm.acquireLock(ctx, lockState, lockType, offset, length, reclaim)
 	if err != nil {
 		return nil, err
@@ -1962,7 +2052,7 @@ func (sm *StateManager) LockNew(
 		}, nil
 	}
 
-	// 8. Success: update state
+	// 9. Success: update state
 	lockState.Stateid.Seqid = nextSeqID(lockState.Stateid.Seqid)
 	lockOwner.LastSeqID = lockSeqid
 	openState.Owner.LastSeqID = openSeqid
@@ -1984,7 +2074,7 @@ func (sm *StateManager) LockExisting(
 	ctx context.Context,
 	lockStateid *types.Stateid4, lockSeqid uint32,
 	fileHandle []byte, lockType uint32, offset, length uint64, reclaim bool,
-) (*LockResult, error) {
+) (result *LockResult, err error) {
 	// Grace period check
 	if !reclaim {
 		if err := sm.CheckGraceForNewState(); err != nil {
@@ -2005,6 +2095,11 @@ func (sm *StateManager) LockExisting(
 	}
 
 	lockOwner := lockState.LockOwner
+
+	// The request is attributable to this lock-owner, so any failure below
+	// consumes its seqid (RFC 7530 Section 9.1.7), the stateid and open-mode
+	// rejections included.
+	defer func() { lockOwner.consumeSeqidOnError(lockSeqid, err) }()
 
 	// 2. Validate lock seqid on lock-owner FIRST.
 	// A LOCK replay resends the original (pre-LOCK) lock stateid, whose seqid is
@@ -2276,7 +2371,7 @@ func (sm *StateManager) TestLock(
 func (sm *StateManager) UnlockFile(
 	lockStateid *types.Stateid4, seqid uint32,
 	lockType uint32, offset, length uint64,
-) (*LockResult, error) {
+) (result *LockResult, err error) {
 	// Special stateids cannot be used with LOCKU
 	if lockStateid.IsSpecialStateid() {
 		return nil, ErrBadStateid
@@ -2296,6 +2391,11 @@ func (sm *StateManager) UnlockFile(
 	}
 
 	lockOwner := lockState.LockOwner
+
+	// The request is attributable to this lock-owner, so any failure below
+	// consumes its seqid (RFC 7530 Section 9.1.7), the stateid rejections
+	// included.
+	defer func() { lockOwner.consumeSeqidOnError(seqid, err) }()
 
 	// 2. Validate seqid on lock-owner FIRST.
 	// A LOCKU replay resends the original (pre-LOCKU) lock stateid, whose seqid

--- a/internal/adapter/nfs/v4/state/openowner.go
+++ b/internal/adapter/nfs/v4/state/openowner.go
@@ -1,7 +1,9 @@
 package state
 
 import (
+	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
@@ -27,6 +29,114 @@ const (
 )
 
 // ============================================================================
+// Owner Sequence
+// ============================================================================
+
+// ownerSeq is the seqid sequence an open- or lock-owner carries: the last seqid
+// processed and the reply cached for replaying it. Both owner kinds embed it, so
+// the sequencing rules of RFC 7530 Section 9.1.7 are written once — as Linux
+// nfsd writes them once on the struct nfs4_stateowner both its owner kinds
+// embed.
+type ownerSeq struct {
+	// LastSeqID is the last seqid processed for this owner. Failed operations
+	// advance it too; see consumeSeqidOnError.
+	LastSeqID uint32
+
+	// LastResult is the cached result of the last operation on this owner.
+	// Used for replay detection (same seqid returns cached result).
+	LastResult *CachedResult
+}
+
+// ValidateSeqID checks whether a seqid is valid for this owner.
+//
+// Per RFC 7530 Section 9.1.7:
+//   - Expected = LastSeqID + 1 (with wrap: 0xFFFFFFFF -> 1, not 0)
+//   - seqid == expected -> SeqIDOK
+//   - seqid == LastSeqID -> SeqIDReplay
+//   - else -> SeqIDBad
+func (os *ownerSeq) ValidateSeqID(seqid uint32) SeqIDValidation {
+	expected := nextSeqID(os.LastSeqID)
+
+	if seqid == expected {
+		return SeqIDOK
+	}
+	if seqid == os.LastSeqID {
+		return SeqIDReplay
+	}
+	return SeqIDBad
+}
+
+// consumeSeqidOnError advances this owner's sequence to seqid and caches the
+// failed reply, for an operation that failed after reaching seqid checking. It
+// is a no-op on success — the success paths advance the seqid themselves, and
+// the handler caches the encoded reply — and on the errors failedSeqidReply
+// exempts.
+//
+// Operations defer it as soon as they resolve the owner, so it covers every
+// outcome below that point including ones added later. That is safe before the
+// seqid check itself because its two verdicts, NFS4ERR_BAD_SEQID and a replay,
+// are both exempt; nfsd relies on the same property to call nfsd4_bump_seqid
+// unconditionally from a single exit point per operation.
+func (os *ownerSeq) consumeSeqidOnError(seqid uint32, err error) {
+	if status, consumed := failedSeqidReply(err); consumed {
+		os.LastSeqID = seqid
+		os.LastResult = &CachedResult{Status: status, Data: encodeStatusReply(status)}
+	}
+}
+
+// failedSeqidReply reports the status to record for an operation that failed
+// after reaching seqid checking, and whether that failure consumes the seqid at
+// all.
+//
+// Per RFC 7530 Section 9.1.7 an owner's sequence advances on every operation
+// that reaches seqid checking, whether or not it then succeeds. Only the errors
+// listed below leave it untouched, because they mean the request was never
+// attributable to the owner and the client does not advance its own sequence
+// either. Everything else — NFS4ERR_LOCKS_HELD, NFS4ERR_SHARE_DENIED,
+// NFS4ERR_OPENMODE, NFS4ERR_INVAL, … — consumes the seqid: a server that keeps
+// it falls permanently one behind the client, and every later operation for that
+// owner is answered NFS4ERR_BAD_SEQID, which the client can only escape by
+// tearing the owner down. The list matches nfsd's seqid_mutating_err().
+func failedSeqidReply(err error) (status uint32, consumed bool) {
+	if err == nil {
+		return 0, false
+	}
+
+	// A replay returns the previous operation's reply; it neither re-runs that
+	// operation nor moves the sequence on.
+	var replayErr *ReplayError
+	if errors.As(err, &replayErr) {
+		return replayErr.Status, false
+	}
+
+	var stateErr *NFS4StateError
+	if !errors.As(err, &stateErr) {
+		// Unclassified failure: the client sees NFS4ERR_SERVERFAULT, which is not
+		// exempt, so the seqid is consumed like any other failure.
+		return types.NFS4ERR_SERVERFAULT, true
+	}
+
+	switch stateErr.Status {
+	case types.NFS4ERR_STALE_CLIENTID, types.NFS4ERR_STALE_STATEID,
+		types.NFS4ERR_BAD_STATEID, types.NFS4ERR_BAD_SEQID,
+		types.NFS4ERR_BADXDR, types.NFS4ERR_RESOURCE,
+		types.NFS4ERR_NOFILEHANDLE, types.NFS4ERR_MOVED:
+		return stateErr.Status, false
+	}
+	return stateErr.Status, true
+}
+
+// encodeStatusReply encodes the reply body of a failed operation: the status
+// alone, which is all an NFSv4 operation carries when it fails. It must stay
+// byte-identical to what the handlers return for an error (encodeStatusOnly), so
+// a replay of the failed request reproduces the original response exactly.
+func encodeStatusReply(status uint32) []byte {
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, status)
+	return b
+}
+
+// ============================================================================
 // OpenOwner
 // ============================================================================
 
@@ -45,12 +155,8 @@ type OpenOwner struct {
 	// OwnerData is the opaque owner identifier from the client.
 	OwnerData []byte
 
-	// LastSeqID is the last successfully processed seqid for this owner.
-	LastSeqID uint32
-
-	// LastResult is the cached result of the last operation on this owner.
-	// Used for replay detection (same seqid returns cached result).
-	LastResult *CachedResult
+	// ownerSeq carries this owner's seqid sequence and replay cache.
+	ownerSeq
 
 	// Confirmed indicates whether OPEN_CONFIRM has been called for this owner.
 	// New owners created by OPEN must be confirmed before the open state is usable.
@@ -78,25 +184,6 @@ func (oo *OpenOwner) Key() openOwnerKey {
 		return makeOwnerKey(oo.ClientID, oo.OwnerData)
 	}
 	return oo.key
-}
-
-// ValidateSeqID checks whether a seqid is valid for this open-owner.
-//
-// Per RFC 7530 Section 9.1.7:
-//   - Expected = LastSeqID + 1 (with wrap: 0xFFFFFFFF -> 1, not 0)
-//   - seqid == expected -> SeqIDOK
-//   - seqid == LastSeqID -> SeqIDReplay
-//   - else -> SeqIDBad
-func (oo *OpenOwner) ValidateSeqID(seqid uint32) SeqIDValidation {
-	expected := nextSeqID(oo.LastSeqID)
-
-	if seqid == expected {
-		return SeqIDOK
-	}
-	if seqid == oo.LastSeqID {
-		return SeqIDReplay
-	}
-	return SeqIDBad
 }
 
 // ============================================================================

--- a/internal/adapter/nfs/v4/state/openowner.go
+++ b/internal/adapter/nfs/v4/state/openowner.go
@@ -54,13 +54,13 @@ type ownerSeq struct {
 //   - seqid == expected -> SeqIDOK
 //   - seqid == LastSeqID -> SeqIDReplay
 //   - else -> SeqIDBad
-func (os *ownerSeq) ValidateSeqID(seqid uint32) SeqIDValidation {
-	expected := nextSeqID(os.LastSeqID)
+func (seq *ownerSeq) ValidateSeqID(seqid uint32) SeqIDValidation {
+	expected := nextSeqID(seq.LastSeqID)
 
 	if seqid == expected {
 		return SeqIDOK
 	}
-	if seqid == os.LastSeqID {
+	if seqid == seq.LastSeqID {
 		return SeqIDReplay
 	}
 	return SeqIDBad
@@ -77,10 +77,10 @@ func (os *ownerSeq) ValidateSeqID(seqid uint32) SeqIDValidation {
 // seqid check itself because its two verdicts, NFS4ERR_BAD_SEQID and a replay,
 // are both exempt; nfsd relies on the same property to call nfsd4_bump_seqid
 // unconditionally from a single exit point per operation.
-func (os *ownerSeq) consumeSeqidOnError(seqid uint32, err error) {
+func (seq *ownerSeq) consumeSeqidOnError(seqid uint32, err error) {
 	if status, consumed := failedSeqidReply(err); consumed {
-		os.LastSeqID = seqid
-		os.LastResult = &CachedResult{Status: status, Data: encodeStatusReply(status)}
+		seq.LastSeqID = seqid
+		seq.LastResult = &CachedResult{Status: status, Data: encodeStatusReply(status)}
 	}
 }
 

--- a/internal/adapter/nfs/v4/state/stateid.go
+++ b/internal/adapter/nfs/v4/state/stateid.go
@@ -465,33 +465,10 @@ func (sm *StateManager) freeLockStateidLocked(clientID uint64, stateid *types.St
 	delete(sm.lockStateByOther, stateid.Other)
 
 	// Remove actual locks from unified lock manager
-	if lm := sm.lockManagerFor(lockState.FileHandle); lm != nil && lockState.LockOwner != nil {
-		ownerID := lockState.LockOwner.LockManagerOwnerID()
-		handleKey := string(lockState.FileHandle)
-		for _, l := range lm.ListUnifiedLocks(handleKey) {
-			if l.Owner.OwnerID == ownerID {
-				_ = lm.RemoveUnifiedLock(handleKey, l.Owner, l.Offset, l.Length)
-			}
-		}
-	}
+	sm.removeOwnerLocksLocked(lockState)
 
-	// Remove lock-owner from lockOwners map only when no other LockState
-	// still references this owner (reference-count to zero). A LockOwner can
-	// be shared across multiple LockState entries (one per open-state/file),
-	// so deleting it on the first free would blind replay-detection and the
-	// owner caches for the still-live lock states.
-	if lockState.LockOwner != nil {
-		ownerStillReferenced := false
-		for _, ls := range sm.lockStateByOther {
-			if ls.LockOwner == lockState.LockOwner {
-				ownerStillReferenced = true
-				break
-			}
-		}
-		if !ownerStillReferenced {
-			delete(sm.lockOwners, lockState.LockOwner.Key())
-		}
-	}
+	// Drop the lock-owner once nothing references it any more.
+	sm.dropLockOwnerIfUnreferencedLocked(lockState.LockOwner)
 
 	// Remove from parent open state's LockStates slice
 	if lockState.OpenState != nil {

--- a/internal/adapter/nfs/v4/state/stateid_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_test.go
@@ -947,7 +947,7 @@ func TestDowngradeOpen_ZeroAccess(t *testing.T) {
 // ============================================================================
 
 func TestOpenOwner_ValidateSeqID(t *testing.T) {
-	owner := &OpenOwner{LastSeqID: 5}
+	owner := &OpenOwner{ownerSeq: ownerSeq{LastSeqID: 5}}
 
 	tests := []struct {
 		name     string


### PR DESCRIPTION
# Description

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Changes Made

* Seqid should advance even in case of some errors. RFC:
```
The client MUST advance the sequence number for the CLOSE, LOCK, LOCKU, OPEN,
OPEN_CONFIRM, and OPEN_DOWNGRADE operations. This is true even in the event
that the previous operation that used the sequence number received an error.
The only exception to this rule is if the previous operation received one of
the following errors: NFS4ERR_STALE_CLIENTID, NFS4ERR_STALE_STATEID,
NFS4ERR_BAD_STATEID, NFS4ERR_BAD_SEQID, NFS4ERR_BADXDR, NFS4ERR_RESOURCE,
NFS4ERR_NOFILEHANDLE, or NFS4ERR_MOVED.
```

* CLOSE can fail when byte-range locks are actually held - not merely when lock stateids exist, since a lock stateid stays valid after LOCKU for as long as the file remains open.

In theory, CLOSE can automatically close the locks instead of returning NFS4ERR_LOCKS_HELD, this is what the Linux NFS server does.

## Testing

<!-- Please describe the tests that you ran to verify your changes: -->

- [X] Unit tests pass (`go test ./...`)
- [ ] Manual testing performed
- [ ] Integration testing performed

## Testing Instructions

<!-- Describe how reviewers can test your changes: -->

It's not easy - usually RELEASE_LOCKOWNER is sent before CLOSE. I can reproduce this error only by running a long test suite. Unfortunately, I cannot provide a short reproduction besides unit tests.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published
