### PR TITLE
fix(runtime): surface adapter restart failures, hold entries until stopped, drop dead client tracking

### DIFF
--- a/cmd/dfsctl/commands/client/client.go
+++ b/cmd/dfsctl/commands/client/client.go
@@ -11,7 +11,7 @@ var Cmd = &cobra.Command{
 	Short: "Manage connected clients",
 	Long: `Manage connected NFS and SMB clients on the DittoFS server.
 
-Use these commands to inspect which clients are currently connected, filter by protocol or share, and forcefully disconnect misbehaving sessions. All operations require admin privileges.
+Use these commands to inspect which clients are currently connected, filter by protocol, and forcefully disconnect misbehaving sessions. All operations require admin privileges.
 
 Examples:
   # List all connected clients across NFS and SMB
@@ -19,9 +19,6 @@ Examples:
 
   # Show only NFS clients
   dfsctl client list --protocol nfs
-
-  # Show clients connected to a specific share
-  dfsctl client list --share myshare
 
   # Disconnect a specific client by its ID
   dfsctl client disconnect nfs-42 --force`,

--- a/cmd/dfsctl/commands/client/list.go
+++ b/cmd/dfsctl/commands/client/list.go
@@ -11,17 +11,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	protocolFlag string
-	shareFlag    string
-)
+var protocolFlag string
 
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List connected clients",
 	Long: `List all clients currently connected to the DittoFS server.
 
-Each row shows the client ID, protocol (NFS or SMB), remote address, authenticated user, mounted shares, and how long the client has been connected. Use --protocol or --share to narrow the output.
+Each row shows the client ID, protocol (NFS or SMB), remote address, and how long the client has been connected. Use --protocol to narrow the output.
 
 Examples:
   # List all connected clients
@@ -30,9 +27,6 @@ Examples:
   # Show only NFS clients
   dfsctl client list --protocol nfs
 
-  # Show only clients connected to a specific share
-  dfsctl client list --share myshare
-
   # Get the client list as JSON
   dfsctl client list -o json`,
 	RunE: runList,
@@ -40,7 +34,6 @@ Examples:
 
 func init() {
 	listCmd.Flags().StringVar(&protocolFlag, "protocol", "", "Filter by protocol (nfs, smb)")
-	listCmd.Flags().StringVar(&shareFlag, "share", "", "Filter by share name")
 }
 
 // ClientList is a list of clients for table rendering.
@@ -48,25 +41,18 @@ type ClientList []apiclient.ClientInfo
 
 // Headers implements TableRenderer.
 func (cl ClientList) Headers() []string {
-	return []string{"CLIENT_ID", "PROTOCOL", "ADDRESS", "USER", "SHARES", "CONNECTED"}
+	return []string{"CLIENT_ID", "PROTOCOL", "ADDRESS", "CONNECTED"}
 }
 
 // Rows implements TableRenderer.
 func (cl ClientList) Rows() [][]string {
 	rows := make([][]string, 0, len(cl))
 	for _, c := range cl {
-		shares := "-"
-		if len(c.Shares) > 0 {
-			shares = strings.Join(c.Shares, ", ")
-		}
-		connected := time.Since(c.ConnectedAt).Truncate(time.Second).String()
 		rows = append(rows, []string{
 			c.ClientID,
 			strings.ToUpper(c.Protocol),
 			c.Address,
-			cmdutil.EmptyOr(c.User, "-"),
-			shares,
-			connected,
+			time.Since(c.ConnectedAt).Truncate(time.Second).String(),
 		})
 	}
 	return rows
@@ -81,9 +67,6 @@ func runList(cmd *cobra.Command, args []string) error {
 	var opts []apiclient.ListClientsOption
 	if protocolFlag != "" {
 		opts = append(opts, apiclient.WithProtocol(protocolFlag))
-	}
-	if shareFlag != "" {
-		opts = append(opts, apiclient.WithShare(shareFlag))
 	}
 
 	clients, err := client.ListClients(opts...)

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -1480,7 +1480,7 @@ List connected clients
 
 List all clients currently connected to the DittoFS server.
 
-Each row shows the client ID, protocol (NFS or SMB), remote address, authenticated user, mounted shares, and how long the client has been connected. Use --protocol or --share to narrow the output.
+Each row shows the client ID, protocol (NFS or SMB), remote address, and how long the client has been connected. Use --protocol to narrow the output.
 
 ```
 dfsctl client list [flags]
@@ -1495,9 +1495,6 @@ dfsctl client list
 # Show only NFS clients
 dfsctl client list --protocol nfs
 
-# Show only clients connected to a specific share
-dfsctl client list --share myshare
-
 # Get the client list as JSON
 dfsctl client list -o json
 ```
@@ -1506,7 +1503,6 @@ Flags:
 
 ```
       --protocol string   Filter by protocol (nfs, smb)
-      --share string      Filter by share name
 ```
 
 Global flags:

--- a/internal/controlplane/api/handlers/clients.go
+++ b/internal/controlplane/api/handlers/clients.go
@@ -24,34 +24,15 @@ func NewClientHandler(rt *runtime.Runtime) *ClientHandler {
 }
 
 // List handles GET /api/v1/clients.
-// Supports ?protocol=nfs|smb and ?share=/export query filters.
+// Supports a ?protocol=nfs|smb query filter.
 func (h *ClientHandler) List(w http.ResponseWriter, r *http.Request) {
-	protocol := r.URL.Query().Get("protocol")
-	share := r.URL.Query().Get("share")
-
 	registry := h.rt.Clients()
 
-	switch {
-	case protocol != "" && share != "":
-		// Filter by protocol first, then by share in-handler.
-		byProto := registry.ListByProtocol(protocol)
-		filtered := make([]*runtime.ClientRecord, 0, len(byProto))
-		for _, rec := range byProto {
-			for _, s := range rec.Shares {
-				if s == share {
-					filtered = append(filtered, rec)
-					break
-				}
-			}
-		}
-		WriteJSONOK(w, filtered)
-	case protocol != "":
+	if protocol := r.URL.Query().Get("protocol"); protocol != "" {
 		WriteJSONOK(w, registry.ListByProtocol(protocol))
-	case share != "":
-		WriteJSONOK(w, registry.ListByShare(share))
-	default:
-		WriteJSONOK(w, registry.List())
+		return
 	}
+	WriteJSONOK(w, registry.List())
 }
 
 // Disconnect handles DELETE /api/v1/clients/{id}.

--- a/pkg/apiclient/clients.go
+++ b/pkg/apiclient/clients.go
@@ -11,29 +11,20 @@ type ClientRecord struct {
 	ClientID     string      `json:"client_id"`
 	Protocol     string      `json:"protocol"`
 	Address      string      `json:"address"`
-	User         string      `json:"user"`
 	ConnectedAt  time.Time   `json:"connected_at"`
 	LastActivity time.Time   `json:"last_activity"`
-	Shares       []string    `json:"shares"`
 	NFS          *NfsDetails `json:"nfs,omitempty"`
 	SMB          *SmbDetails `json:"smb,omitempty"`
 }
 
 // NfsDetails holds NFS-specific client information.
 type NfsDetails struct {
-	Version    string `json:"version"`
-	AuthFlavor string `json:"auth_flavor"`
-	UID        uint32 `json:"uid"`
-	GID        uint32 `json:"gid"`
+	Version string `json:"version"`
 }
 
 // SmbDetails holds SMB-specific client information.
 type SmbDetails struct {
 	SessionID uint64 `json:"session_id"`
-	Dialect   string `json:"dialect"`
-	Domain    string `json:"domain,omitempty"`
-	Signed    bool   `json:"signed"`
-	Encrypted bool   `json:"encrypted"`
 }
 
 // ListClientsOption configures a ListClients call.
@@ -41,17 +32,11 @@ type ListClientsOption func(*listClientsOpts)
 
 type listClientsOpts struct {
 	protocol string
-	share    string
 }
 
 // WithProtocol filters client list by protocol ("nfs" or "smb").
 func WithProtocol(protocol string) ListClientsOption {
 	return func(o *listClientsOpts) { o.protocol = protocol }
-}
-
-// WithShare filters client list by share name.
-func WithShare(share string) ListClientsOption {
-	return func(o *listClientsOpts) { o.share = share }
 }
 
 // ListClients returns all connected clients, optionally filtered.
@@ -64,9 +49,6 @@ func (c *Client) ListClients(opts ...ListClientsOption) ([]ClientRecord, error) 
 	query := url.Values{}
 	if o.protocol != "" {
 		query.Set("protocol", o.protocol)
-	}
-	if o.share != "" {
-		query.Set("share", o.share)
 	}
 
 	path := "/api/v1/clients"

--- a/pkg/controlplane/runtime/adapters/service.go
+++ b/pkg/controlplane/runtime/adapters/service.go
@@ -50,6 +50,13 @@ type adapterEntry struct {
 	// stopping marks a teardown in progress: the entry is still in the map,
 	// but the adapter is on its way out. Guarded by Service.mu.
 	stopping bool
+
+	// cancelled records that the entry's context was already cancelled by a
+	// teardown that then timed out waiting for the serve goroutine. The entry
+	// stays in the map to keep holding the type against a competing start, but
+	// the adapter behind it is no longer serving, so it must never be treated as
+	// a live listener that a reload can reuse. Guarded by Service.mu.
+	cancelled bool
 }
 
 // Service manages protocol adapter lifecycle.
@@ -149,7 +156,7 @@ func (s *Service) UpdateAdapter(ctx context.Context, cfg *models.AdapterConfig) 
 
 	s.mu.RLock()
 	entry, ok := s.entries[cfg.Type]
-	running := ok && !entry.stopping
+	running := ok && !entry.stopping && !entry.cancelled
 	s.mu.RUnlock()
 
 	if running && cfg.Enabled && sameListenAddr(entry, cfg) {
@@ -305,6 +312,7 @@ func (s *Service) stopAdapter(adapterType string) error {
 	case <-ctx.Done():
 		s.mu.Lock()
 		entry.stopping = false
+		entry.cancelled = true
 		s.mu.Unlock()
 		logger.Warn("Adapter stop timed out", "type", adapterType)
 		return fmt.Errorf("adapter %s stop timed out", adapterType)

--- a/pkg/controlplane/runtime/adapters/service.go
+++ b/pkg/controlplane/runtime/adapters/service.go
@@ -43,7 +43,6 @@ type AdapterFactory func(cfg *models.AdapterConfig) (ProtocolAdapter, error)
 type adapterEntry struct {
 	adapter ProtocolAdapter
 	config  *models.AdapterConfig
-	ctx     context.Context
 	cancel  context.CancelFunc
 	errCh   chan error
 
@@ -156,10 +155,12 @@ func (s *Service) UpdateAdapter(ctx context.Context, cfg *models.AdapterConfig) 
 
 	s.mu.RLock()
 	entry, ok := s.entries[cfg.Type]
-	running := ok && !entry.stopping && !entry.cancelled
+	// A stopping or cancelled entry is on its way out, so its listener is not
+	// reusable even though the entry is still in the map.
+	serving := ok && !entry.stopping && !entry.cancelled
 	s.mu.RUnlock()
 
-	if running && cfg.Enabled && sameListenAddr(entry, cfg) {
+	if serving && cfg.Enabled && sameListenAddr(entry, cfg) {
 		logger.Info("Adapter listen address unchanged; preserving listener across reload",
 			"type", cfg.Type, "port", entry.adapter.Port())
 		return nil
@@ -252,11 +253,8 @@ func (s *Service) startAdapter(cfg *models.AdapterConfig) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if e, exists := s.entries[cfg.Type]; exists {
-		if e.stopping {
-			return fmt.Errorf("adapter %s is still stopping", cfg.Type)
-		}
-		return fmt.Errorf("adapter %s already running", cfg.Type)
+	if err := s.typeClaimedLocked(cfg.Type); err != nil {
+		return err
 	}
 
 	if s.factory == nil {
@@ -397,11 +395,8 @@ func (s *Service) AddAdapter(adapter ProtocolAdapter) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if e, exists := s.entries[adapterType]; exists {
-		if e.stopping {
-			return fmt.Errorf("adapter %s is still stopping", adapterType)
-		}
-		return fmt.Errorf("adapter %s already running", adapterType)
+	if err := s.typeClaimedLocked(adapterType); err != nil {
+		return err
 	}
 
 	cfg := &models.AdapterConfig{Type: adapterType, Port: adapter.Port(), Enabled: true}
@@ -431,6 +426,24 @@ func (s *Service) ForceCloseClientConnection(protocol, addr string) bool {
 	return false
 }
 
+// typeClaimedLocked returns an error when an entry still holds adapterType, so
+// no new adapter of that type may claim it: either one is serving, or a teardown
+// has not yet released the listening socket. Returns nil when the type is free.
+// Caller must hold mu.
+func (s *Service) typeClaimedLocked(adapterType string) error {
+	e, exists := s.entries[adapterType]
+	switch {
+	case !exists:
+		return nil
+	case e.stopping:
+		return fmt.Errorf("adapter %s is still stopping", adapterType)
+	case e.cancelled:
+		return fmt.Errorf("adapter %s did not confirm shutdown and still holds its socket", adapterType)
+	default:
+		return fmt.Errorf("adapter %s already running", adapterType)
+	}
+}
+
 // registerAndRunAdapterLocked starts the adapter in a goroutine. Caller must hold mu.
 func (s *Service) registerAndRunAdapterLocked(adp ProtocolAdapter, cfg *models.AdapterConfig) {
 	if setter, ok := adp.(RuntimeSetter); ok && s.runtime != nil {
@@ -452,7 +465,6 @@ func (s *Service) registerAndRunAdapterLocked(adp ProtocolAdapter, cfg *models.A
 	s.entries[cfg.Type] = &adapterEntry{
 		adapter: adp,
 		config:  cfg,
-		ctx:     ctx,
 		cancel:  cancel,
 		errCh:   errCh,
 	}

--- a/pkg/controlplane/runtime/adapters/service.go
+++ b/pkg/controlplane/runtime/adapters/service.go
@@ -46,6 +46,10 @@ type adapterEntry struct {
 	ctx     context.Context
 	cancel  context.CancelFunc
 	errCh   chan error
+
+	// stopping marks a teardown in progress: the entry is still in the map,
+	// but the adapter is on its way out. Guarded by Service.mu.
+	stopping bool
 }
 
 // Service manages protocol adapter lifecycle.
@@ -134,13 +138,18 @@ func (s *Service) DeleteAdapter(ctx context.Context, adapterType string) error {
 // settings reload path or on the next rebind. This keeps a config change
 // (e.g. re-enabling an already-running adapter) from momentarily dropping the
 // accept socket and cutting existing sessions.
+//
+// A failed restart is returned, not logged: the caller must not see success for
+// an adapter that is down. The new config stays persisted — it is the requested
+// state, and the next start retries it from the store.
 func (s *Service) UpdateAdapter(ctx context.Context, cfg *models.AdapterConfig) error {
 	if err := s.store.UpdateAdapter(ctx, cfg); err != nil {
 		return fmt.Errorf("failed to update adapter config: %w", err)
 	}
 
 	s.mu.RLock()
-	entry, running := s.entries[cfg.Type]
+	entry, ok := s.entries[cfg.Type]
+	running := ok && !entry.stopping
 	s.mu.RUnlock()
 
 	if running && cfg.Enabled && sameListenAddr(entry, cfg) {
@@ -152,7 +161,7 @@ func (s *Service) UpdateAdapter(ctx context.Context, cfg *models.AdapterConfig) 
 	_ = s.stopAdapter(cfg.Type)
 	if cfg.Enabled {
 		if err := s.startAdapter(cfg); err != nil {
-			logger.Warn("Failed to restart adapter after update", "type", cfg.Type, "error", err)
+			return fmt.Errorf("failed to restart adapter after update: %w", err)
 		}
 	}
 
@@ -236,7 +245,10 @@ func (s *Service) startAdapter(cfg *models.AdapterConfig) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.entries[cfg.Type]; exists {
+	if e, exists := s.entries[cfg.Type]; exists {
+		if e.stopping {
+			return fmt.Errorf("adapter %s is still stopping", cfg.Type)
+		}
 		return fmt.Errorf("adapter %s already running", cfg.Type)
 	}
 
@@ -253,6 +265,12 @@ func (s *Service) startAdapter(cfg *models.AdapterConfig) error {
 	return nil
 }
 
+// stopAdapter tears down the running adapter of the given type. Its entry stays
+// in the map for the whole teardown and is dropped only once the serve goroutine
+// confirms it exited, so a concurrent start of the same type is refused instead
+// of racing the outgoing adapter for its listening socket. A stop that times out
+// keeps the entry too — the adapter is still alive — and only clears the
+// stopping mark so a later attempt can retry.
 func (s *Service) stopAdapter(adapterType string) error {
 	s.mu.Lock()
 	entry, exists := s.entries[adapterType]
@@ -260,7 +278,11 @@ func (s *Service) stopAdapter(adapterType string) error {
 		s.mu.Unlock()
 		return fmt.Errorf("adapter %s not running", adapterType)
 	}
-	delete(s.entries, adapterType)
+	if entry.stopping {
+		s.mu.Unlock()
+		return fmt.Errorf("adapter %s is already stopping", adapterType)
+	}
+	entry.stopping = true
 	s.mu.Unlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), s.shutdownTimeout)
@@ -275,9 +297,15 @@ func (s *Service) stopAdapter(adapterType string) error {
 	entry.cancel()
 	select {
 	case <-entry.errCh:
+		s.mu.Lock()
+		delete(s.entries, adapterType)
+		s.mu.Unlock()
 		logger.Info("Adapter stopped", "type", adapterType)
 		return nil
 	case <-ctx.Done():
+		s.mu.Lock()
+		entry.stopping = false
+		s.mu.Unlock()
 		logger.Warn("Adapter stop timed out", "type", adapterType)
 		return fmt.Errorf("adapter %s stop timed out", adapterType)
 	}
@@ -361,7 +389,10 @@ func (s *Service) AddAdapter(adapter ProtocolAdapter) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.entries[adapterType]; exists {
+	if e, exists := s.entries[adapterType]; exists {
+		if e.stopping {
+			return fmt.Errorf("adapter %s is still stopping", adapterType)
+		}
 		return fmt.Errorf("adapter %s already running", adapterType)
 	}
 

--- a/pkg/controlplane/runtime/adapters/service_test.go
+++ b/pkg/controlplane/runtime/adapters/service_test.go
@@ -2,6 +2,7 @@ package adapters
 
 import (
 	"context"
+	"errors"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -261,5 +262,124 @@ func TestUpdateAdapter_ZeroPortRebindsFromNonDefault(t *testing.T) {
 
 	if err := svc.StopAllAdapters(); err != nil {
 		t.Fatalf("StopAllAdapters: %v", err)
+	}
+}
+
+// slowStopAdapter keeps its serve goroutine alive after Stop returns, so a test
+// can observe the window between "stop requested" and "adapter actually gone".
+type slowStopAdapter struct {
+	protocol   string
+	port       int
+	stopCalled chan struct{}
+	release    chan struct{}
+}
+
+func newSlowStopAdapter(protocol string, port int) *slowStopAdapter {
+	return &slowStopAdapter{
+		protocol:   protocol,
+		port:       port,
+		stopCalled: make(chan struct{}),
+		release:    make(chan struct{}),
+	}
+}
+
+func (a *slowStopAdapter) Serve(ctx context.Context) error {
+	<-ctx.Done()
+	<-a.release
+	return ctx.Err()
+}
+
+func (a *slowStopAdapter) Stop(context.Context) error {
+	close(a.stopCalled)
+	return nil
+}
+
+func (a *slowStopAdapter) Protocol() string                          { return a.protocol }
+func (a *slowStopAdapter) Port() int                                 { return a.port }
+func (a *slowStopAdapter) Healthcheck(context.Context) health.Report { return health.Report{} }
+
+// TestStopAdapter_HoldsEntryUntilAdapterConfirmsStopped proves the registry
+// keeps describing an adapter that is still alive: a start of the same type
+// issued mid-teardown is refused rather than racing the outgoing adapter for
+// its listening socket, and the entry disappears only once the serve goroutine
+// has exited.
+func TestStopAdapter_HoldsEntryUntilAdapterConfirmsStopped(t *testing.T) {
+	svc := New(newFakeAdapterStore(), 5*time.Second)
+
+	outgoing := newSlowStopAdapter("nfs", 12049)
+	if err := svc.AddAdapter(outgoing); err != nil {
+		t.Fatalf("AddAdapter: %v", err)
+	}
+
+	stopped := make(chan error, 1)
+	go func() { stopped <- svc.stopAdapter("nfs") }()
+
+	select {
+	case <-outgoing.stopCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stopAdapter never reached the adapter's Stop")
+	}
+
+	// Teardown is in flight and the serve goroutine still holds the socket.
+	if !svc.IsAdapterRunning("nfs") {
+		t.Fatal("adapter reported as not running while its serve goroutine is still alive")
+	}
+	replacement := newSlowStopAdapter("nfs", 12049)
+	if err := svc.AddAdapter(replacement); err == nil {
+		t.Fatal("AddAdapter admitted a second nfs adapter while the previous one was still stopping")
+	}
+
+	close(outgoing.release)
+	if err := <-stopped; err != nil {
+		t.Fatalf("stopAdapter: %v", err)
+	}
+
+	if svc.IsAdapterRunning("nfs") {
+		t.Fatal("entry not removed after the adapter confirmed it stopped")
+	}
+	if err := svc.AddAdapter(replacement); err != nil {
+		t.Fatalf("AddAdapter after confirmed stop: %v", err)
+	}
+
+	close(replacement.release)
+	if err := svc.StopAllAdapters(); err != nil {
+		t.Fatalf("StopAllAdapters: %v", err)
+	}
+}
+
+// TestUpdateAdapter_ReturnsRestartFailure proves a failed restart is reported to
+// the caller instead of leaving it with a success response for an adapter that
+// is down, and that the requested config stays persisted so the next start
+// retries it.
+func TestUpdateAdapter_ReturnsRestartFailure(t *testing.T) {
+	st := newFakeAdapterStore()
+	svc := New(st, time.Second)
+
+	var factoryCalls atomic.Int32
+	svc.SetAdapterFactory(func(cfg *models.AdapterConfig) (ProtocolAdapter, error) {
+		if factoryCalls.Add(1) > 1 {
+			return nil, errors.New("listen: address already in use")
+		}
+		return newFakeListenerAdapter(cfg.Type, cfg.Port), nil
+	})
+
+	ctx := context.Background()
+	if err := svc.CreateAdapter(ctx, &models.AdapterConfig{Type: "smb", Enabled: true, Port: 14445}); err != nil {
+		t.Fatalf("CreateAdapter: %v", err)
+	}
+
+	err := svc.UpdateAdapter(ctx, &models.AdapterConfig{Type: "smb", Enabled: true, Port: 14446})
+	if err == nil {
+		t.Fatal("UpdateAdapter reported success although the adapter failed to restart")
+	}
+	if svc.IsAdapterRunning("smb") {
+		t.Fatal("adapter reported as running after a failed restart")
+	}
+
+	st.mu.Lock()
+	persisted := st.byType["smb"]
+	st.mu.Unlock()
+	if persisted == nil || persisted.Port != 14446 {
+		t.Fatalf("requested config not persisted after failed restart: %+v", persisted)
 	}
 }

--- a/pkg/controlplane/runtime/adapters/service_test.go
+++ b/pkg/controlplane/runtime/adapters/service_test.go
@@ -268,8 +268,11 @@ func TestUpdateAdapter_ZeroPortRebindsFromNonDefault(t *testing.T) {
 // slowStopAdapter keeps its serve goroutine alive after Stop returns, so a test
 // can observe the window between "stop requested" and "adapter actually gone".
 type slowStopAdapter struct {
-	protocol   string
-	port       int
+	protocol string
+	port     int
+	// stopOnce guards stopCalled: a teardown that times out leaves the entry in
+	// place, so a later attempt calls Stop on the same adapter again.
+	stopOnce   sync.Once
 	stopCalled chan struct{}
 	release    chan struct{}
 }
@@ -290,7 +293,7 @@ func (a *slowStopAdapter) Serve(ctx context.Context) error {
 }
 
 func (a *slowStopAdapter) Stop(context.Context) error {
-	close(a.stopCalled)
+	a.stopOnce.Do(func() { close(a.stopCalled) })
 	return nil
 }
 
@@ -382,4 +385,38 @@ func TestUpdateAdapter_ReturnsRestartFailure(t *testing.T) {
 	if persisted == nil || persisted.Port != 14446 {
 		t.Fatalf("requested config not persisted after failed restart: %+v", persisted)
 	}
+}
+
+// TestUpdateAdapter_NoPreservedListenerAfterStopTimeout proves that a reload
+// following a teardown that timed out does not report success by claiming to
+// preserve a listener. The timed-out stop has already cancelled the entry's
+// context, so the adapter behind it is on its way out and its socket is not
+// reusable; treating the retained entry as a live listener would hand the caller
+// a success for an adapter that is going away.
+func TestUpdateAdapter_NoPreservedListenerAfterStopTimeout(t *testing.T) {
+	svc := New(newFakeAdapterStore(), 50*time.Millisecond)
+
+	stuck := newSlowStopAdapter("nfs", 12049)
+	if err := svc.AddAdapter(stuck); err != nil {
+		t.Fatalf("AddAdapter: %v", err)
+	}
+
+	// The serve goroutine never returns, so the stop cannot confirm and times out.
+	if err := svc.stopAdapter("nfs"); err == nil {
+		t.Fatal("stopAdapter reported success while the serve goroutine was still running")
+	}
+
+	// The entry is deliberately still held, so a competing start stays refused.
+	if err := svc.AddAdapter(newSlowStopAdapter("nfs", 12049)); err == nil {
+		t.Fatal("AddAdapter admitted a second nfs adapter over a cancelled entry")
+	}
+
+	err := svc.UpdateAdapter(context.Background(), &models.AdapterConfig{
+		Type: "nfs", Port: 12049, Enabled: true,
+	})
+	if err == nil {
+		t.Fatal("UpdateAdapter returned success for an adapter whose context was already cancelled")
+	}
+
+	close(stuck.release)
 }

--- a/pkg/controlplane/runtime/clients/service.go
+++ b/pkg/controlplane/runtime/clients/service.go
@@ -4,7 +4,6 @@ package clients
 
 import (
 	"context"
-	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -19,29 +18,20 @@ type ClientRecord struct {
 	ClientID     string      `json:"client_id"`
 	Protocol     string      `json:"protocol"` // "nfs" or "smb"
 	Address      string      `json:"address"`
-	User         string      `json:"user"`
 	ConnectedAt  time.Time   `json:"connected_at"`
 	LastActivity time.Time   `json:"last_activity"`
-	Shares       []string    `json:"shares"`
 	NFS          *NfsDetails `json:"nfs,omitempty"`
 	SMB          *SmbDetails `json:"smb,omitempty"`
 }
 
 // NfsDetails holds NFS-specific client information.
 type NfsDetails struct {
-	Version    string `json:"version"`     // "3", "4.0", "4.1"
-	AuthFlavor string `json:"auth_flavor"` // "AUTH_UNIX", "AUTH_NULL", "RPCSEC_GSS"
-	UID        uint32 `json:"uid"`
-	GID        uint32 `json:"gid"`
+	Version string `json:"version"` // "3", "4.0", "4.1"
 }
 
 // SmbDetails holds SMB-specific client information.
 type SmbDetails struct {
 	SessionID uint64 `json:"session_id"`
-	Dialect   string `json:"dialect"` // "3.1.1", "3.0.2", "3.0", "2.1", "2.0.2"
-	Domain    string `json:"domain,omitempty"`
-	Signed    bool   `json:"signed"`
-	Encrypted bool   `json:"encrypted"`
 }
 
 // clientEntry is the map value. It holds the record's structural fields plus a
@@ -55,7 +45,8 @@ type clientEntry struct {
 // Registry provides thread-safe client tracking with TTL-based stale cleanup.
 // It follows the same sub-service pattern as mounts.Tracker.
 //
-// mu guards the map structure and each entry's non-atomic fields (Shares).
+// mu guards the map structure; an entry's remaining fields are set at Register
+// and never mutated again.
 // The per-request activity bump (UpdateActivity) takes only a shared read lock
 // for map safety and stores into the entry's atomic timestamp, so the
 // highest-fan-in call in the system no longer serializes on the write lock.
@@ -135,39 +126,6 @@ func (r *Registry) UpdateActivity(clientID string) {
 	}
 }
 
-// AddShare adds a share to the client's shares list if not already present.
-// No-op if the client does not exist.
-func (r *Registry) AddShare(clientID, share string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	e, ok := r.clients[clientID]
-	if !ok {
-		return
-	}
-	if !slices.Contains(e.Shares, share) {
-		e.Shares = append(e.Shares, share)
-	}
-}
-
-// RemoveShare removes a share from the client's shares list.
-// No-op if the client or share does not exist.
-func (r *Registry) RemoveShare(clientID, share string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	e, ok := r.clients[clientID]
-	if !ok {
-		return
-	}
-	for i, s := range e.Shares {
-		if s == share {
-			e.Shares = append(e.Shares[:i], e.Shares[i+1:]...)
-			return
-		}
-	}
-}
-
 // List returns deep copies of all client records.
 func (r *Registry) List() []*ClientRecord {
 	return r.collect(nil)
@@ -177,14 +135,6 @@ func (r *Registry) List() []*ClientRecord {
 func (r *Registry) ListByProtocol(protocol string) []*ClientRecord {
 	return r.collect(func(c *ClientRecord) bool {
 		return c.Protocol == protocol
-	})
-}
-
-// ListByShare returns deep copies of client records that are connected to the
-// given share.
-func (r *Registry) ListByShare(share string) []*ClientRecord {
-	return r.collect(func(c *ClientRecord) bool {
-		return slices.Contains(c.Shares, share)
 	})
 }
 
@@ -265,13 +215,10 @@ func copyRecord(e *clientEntry) *ClientRecord {
 	return &dst
 }
 
-// deepCopyRefs replaces the reference-typed fields of rec (the Shares slice and
-// the NFS/SMB detail pointers) with independent copies, so the record no longer
-// aliases the caller's or the registry's data.
+// deepCopyRefs replaces the reference-typed fields of rec (the NFS/SMB detail
+// pointers) with independent copies, so the record no longer aliases the
+// caller's or the registry's data.
 func deepCopyRefs(rec *ClientRecord) {
-	if rec.Shares != nil {
-		rec.Shares = append([]string(nil), rec.Shares...)
-	}
 	if rec.NFS != nil {
 		nfsCopy := *rec.NFS
 		rec.NFS = &nfsCopy

--- a/pkg/controlplane/runtime/clients/service_test.go
+++ b/pkg/controlplane/runtime/clients/service_test.go
@@ -12,14 +12,7 @@ func TestRegisterAndList(t *testing.T) {
 		ClientID: "client-1",
 		Protocol: "nfs",
 		Address:  "192.168.1.1:1234",
-		User:     "alice",
-		Shares:   []string{"/export"},
-		NFS: &NfsDetails{
-			Version:    "4.1",
-			AuthFlavor: "AUTH_UNIX",
-			UID:        1000,
-			GID:        1000,
-		},
+		NFS:      &NfsDetails{Version: "4.1"},
 	}
 	reg.Register(rec)
 
@@ -36,9 +29,6 @@ func TestRegisterAndList(t *testing.T) {
 	}
 	if c.Address != "192.168.1.1:1234" {
 		t.Errorf("expected address, got %s", c.Address)
-	}
-	if c.User != "alice" {
-		t.Errorf("expected alice, got %s", c.User)
 	}
 	if c.ConnectedAt.IsZero() {
 		t.Error("ConnectedAt should be set automatically")
@@ -91,42 +81,28 @@ func TestListByProtocol(t *testing.T) {
 	}
 }
 
-func TestListByShare(t *testing.T) {
-	reg := NewRegistry(0)
-	reg.Register(&ClientRecord{ClientID: "c1", Protocol: "nfs", Shares: []string{"/export", "/data"}})
-	reg.Register(&ClientRecord{ClientID: "c2", Protocol: "smb", Shares: []string{"/data"}})
-
-	exportClients := reg.ListByShare("/export")
-	if len(exportClients) != 1 {
-		t.Fatalf("expected 1 client on /export, got %d", len(exportClients))
-	}
-	if exportClients[0].ClientID != "c1" {
-		t.Errorf("expected c1, got %s", exportClients[0].ClientID)
-	}
-
-	dataClients := reg.ListByShare("/data")
-	if len(dataClients) != 2 {
-		t.Fatalf("expected 2 clients on /data, got %d", len(dataClients))
-	}
-}
-
 func TestGet(t *testing.T) {
 	reg := NewRegistry(0)
-	reg.Register(&ClientRecord{ClientID: "c1", Protocol: "nfs", User: "bob"})
+	reg.Register(&ClientRecord{ClientID: "c1", Protocol: "nfs", NFS: &NfsDetails{Version: "3"}})
 
 	c := reg.Get("c1")
 	if c == nil {
 		t.Fatal("expected record, got nil")
 	}
-	if c.User != "bob" {
-		t.Errorf("expected bob, got %s", c.User)
+	if c.NFS == nil || c.NFS.Version != "3" {
+		t.Fatalf("expected NFS version 3, got %+v", c.NFS)
 	}
 
-	// Get returns copy — mutating should not affect registry.
-	c.User = "changed"
+	// Get returns a deep copy — mutating it must not reach the registry, and
+	// the detail pointers must not alias the stored ones either.
+	c.Protocol = "changed"
+	c.NFS.Version = "changed"
 	c2 := reg.Get("c1")
-	if c2.User != "bob" {
-		t.Error("Get should return copy, mutation should not affect registry")
+	if c2.Protocol != "nfs" {
+		t.Error("Get should return a copy; protocol mutation reached the registry")
+	}
+	if c2.NFS.Version != "3" {
+		t.Error("Get should deep-copy NFS details; mutation reached the registry")
 	}
 
 	// Non-existent returns nil.
@@ -150,51 +126,6 @@ func TestUpdateActivity(t *testing.T) {
 
 	// No-op for non-existent.
 	reg.UpdateActivity("nope")
-}
-
-func TestAddShare(t *testing.T) {
-	reg := NewRegistry(0)
-	reg.Register(&ClientRecord{ClientID: "c1", Protocol: "nfs", Shares: []string{"/export"}})
-
-	reg.AddShare("c1", "/data")
-	c := reg.Get("c1")
-	if len(c.Shares) != 2 {
-		t.Fatalf("expected 2 shares, got %d", len(c.Shares))
-	}
-
-	// Adding duplicate should not create duplicates.
-	reg.AddShare("c1", "/data")
-	c = reg.Get("c1")
-	if len(c.Shares) != 2 {
-		t.Fatalf("expected 2 shares (no dup), got %d", len(c.Shares))
-	}
-
-	// No-op for non-existent.
-	reg.AddShare("nope", "/x")
-}
-
-func TestRemoveShare(t *testing.T) {
-	reg := NewRegistry(0)
-	reg.Register(&ClientRecord{ClientID: "c1", Protocol: "nfs", Shares: []string{"/export", "/data"}})
-
-	reg.RemoveShare("c1", "/export")
-	c := reg.Get("c1")
-	if len(c.Shares) != 1 {
-		t.Fatalf("expected 1 share, got %d", len(c.Shares))
-	}
-	if c.Shares[0] != "/data" {
-		t.Errorf("expected /data, got %s", c.Shares[0])
-	}
-
-	// Removing non-existent share is no-op.
-	reg.RemoveShare("c1", "/nope")
-	c = reg.Get("c1")
-	if len(c.Shares) != 1 {
-		t.Fatalf("expected 1 share still, got %d", len(c.Shares))
-	}
-
-	// No-op for non-existent client.
-	reg.RemoveShare("nope", "/data")
 }
 
 func TestSweep(t *testing.T) {
@@ -250,33 +181,13 @@ func TestCount(t *testing.T) {
 	}
 }
 
-func TestCopyOnReadSharesSlice(t *testing.T) {
-	reg := NewRegistry(0)
-	reg.Register(&ClientRecord{ClientID: "c1", Protocol: "nfs", Shares: []string{"/a", "/b"}})
-
-	c := reg.Get("c1")
-	c.Shares[0] = "MUTATED"
-
-	c2 := reg.Get("c1")
-	if c2.Shares[0] != "/a" {
-		t.Error("copy-on-read failed: shares slice was mutated through returned copy")
-	}
-}
-
 func TestSmbDetails(t *testing.T) {
 	reg := NewRegistry(0)
 	reg.Register(&ClientRecord{
 		ClientID: "smb-1",
 		Protocol: "smb",
 		Address:  "10.0.0.1:445",
-		User:     "DOMAIN\\admin",
-		SMB: &SmbDetails{
-			SessionID: 12345,
-			Dialect:   "3.1.1",
-			Domain:    "EXAMPLE",
-			Signed:    true,
-			Encrypted: true,
-		},
+		SMB:      &SmbDetails{SessionID: 12345},
 	})
 
 	c := reg.Get("smb-1")
@@ -285,14 +196,5 @@ func TestSmbDetails(t *testing.T) {
 	}
 	if c.SMB.SessionID != 12345 {
 		t.Errorf("expected session 12345, got %d", c.SMB.SessionID)
-	}
-	if c.SMB.Dialect != "3.1.1" {
-		t.Errorf("expected 3.1.1, got %s", c.SMB.Dialect)
-	}
-	if !c.SMB.Signed {
-		t.Error("expected signed=true")
-	}
-	if !c.SMB.Encrypted {
-		t.Error("expected encrypted=true")
 	}
 }

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -168,13 +169,13 @@ type Runtime struct {
 	runtimeCtx    context.Context
 	runtimeCancel context.CancelFunc
 
-	identityChangeCallbacks []func()
+	identityChangeCallbacks callbackList
 
 	// identityProviderChangeCallbacks fire when an identity provider's
 	// configuration (LDAP/Kerberos) is changed via the API. Adapters register a
 	// closure that rebuilds and re-injects their identity resolver so a new
-	// directory config takes effect without a restart. Guarded by mu.
-	identityProviderChangeCallbacks []func()
+	// directory config takes effect without a restart.
+	identityProviderChangeCallbacks callbackList
 
 	// ldapConfig is the optional LDAP/AD identity provider configuration set at
 	// startup from the server config. When present and Enabled, BuildIdentityResolver
@@ -1114,34 +1115,50 @@ func (r *Runtime) NetlogonController() *netlogon.Controller {
 	return c
 }
 
-// OnIdentityMappingChange registers a callback invoked when identity mappings
-// are created or deleted via the API. Adapters use this to invalidate their
-// identity resolver caches. Returns an unsubscribe function.
-func (r *Runtime) OnIdentityMappingChange(fn func()) func() {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.identityChangeCallbacks = append(r.identityChangeCallbacks, fn)
-	idx := len(r.identityChangeCallbacks) - 1
+// callbackList is a subscribe/notify list of parameterless callbacks. The zero
+// value is ready to use. Unsubscribing nils the slot rather than removing it,
+// so indices handed to earlier subscribers stay valid; notify snapshots the
+// slice and fires outside the lock, so a callback may re-enter the list.
+type callbackList struct {
+	mu  sync.Mutex
+	fns []func()
+}
+
+// add registers fn and returns a function that unsubscribes it.
+func (c *callbackList) add(fn func()) func() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.fns = append(c.fns, fn)
+	idx := len(c.fns) - 1
 	return func() {
-		r.mu.Lock()
-		defer r.mu.Unlock()
-		if idx < len(r.identityChangeCallbacks) {
-			r.identityChangeCallbacks[idx] = nil
-		}
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		c.fns[idx] = nil
 	}
 }
 
-// NotifyIdentityMappingChange fires all registered identity change callbacks.
-func (r *Runtime) NotifyIdentityMappingChange() {
-	r.mu.RLock()
-	cbs := make([]func(), len(r.identityChangeCallbacks))
-	copy(cbs, r.identityChangeCallbacks)
-	r.mu.RUnlock()
-	for _, fn := range cbs {
+// notify fires every registered callback.
+func (c *callbackList) notify() {
+	c.mu.Lock()
+	fns := slices.Clone(c.fns)
+	c.mu.Unlock()
+	for _, fn := range fns {
 		if fn != nil {
 			fn()
 		}
 	}
+}
+
+// OnIdentityMappingChange registers a callback invoked when identity mappings
+// are created or deleted via the API. Adapters use this to invalidate their
+// identity resolver caches. Returns an unsubscribe function.
+func (r *Runtime) OnIdentityMappingChange(fn func()) func() {
+	return r.identityChangeCallbacks.add(fn)
+}
+
+// NotifyIdentityMappingChange fires all registered identity change callbacks.
+func (r *Runtime) NotifyIdentityMappingChange() {
+	r.identityChangeCallbacks.notify()
 }
 
 // OnIdentityProviderConfigChange registers a callback invoked when an identity
@@ -1149,31 +1166,13 @@ func (r *Runtime) NotifyIdentityMappingChange() {
 // and re-inject their identity resolver so a new LDAP directory config takes
 // effect without a restart. Returns an unsubscribe function.
 func (r *Runtime) OnIdentityProviderConfigChange(fn func()) func() {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.identityProviderChangeCallbacks = append(r.identityProviderChangeCallbacks, fn)
-	idx := len(r.identityProviderChangeCallbacks) - 1
-	return func() {
-		r.mu.Lock()
-		defer r.mu.Unlock()
-		if idx < len(r.identityProviderChangeCallbacks) {
-			r.identityProviderChangeCallbacks[idx] = nil
-		}
-	}
+	return r.identityProviderChangeCallbacks.add(fn)
 }
 
 // NotifyIdentityProviderConfigChange fires all registered identity-provider
 // config change callbacks.
 func (r *Runtime) NotifyIdentityProviderConfigChange() {
-	r.mu.RLock()
-	cbs := make([]func(), len(r.identityProviderChangeCallbacks))
-	copy(cbs, r.identityProviderChangeCallbacks)
-	r.mu.RUnlock()
-	for _, fn := range cbs {
-		if fn != nil {
-			fn()
-		}
-	}
+	r.identityProviderChangeCallbacks.notify()
 }
 
 // --- Settings Access ---

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -2858,42 +2858,24 @@ func (s *Service) GetWarm(jobID string) (*WarmJob, bool) {
 	return s.warmJobs.get(jobID)
 }
 
-// deriveGCStateRoot returns the per-share gc-state directory used by the
-// GC engine to persist its run state and last-run.json. Mirrors the path
-// layout used in CreateLocalStoreFromConfig for fs-backed local stores
-// (`<basePath>/shares/<sanitized>/gc-state`). Returns "" for any non-fs
-// backend or when the config does not yield a usable absolute path —
-// engine.PersistLastRunSummary treats "" as "do not persist".
+// deriveGCStateRoot returns the per-share gc-state directory used by the GC
+// engine to persist its run state and last-run.json: the share's local store
+// directory plus a `gc-state` suffix. Returns "" whenever that directory is
+// unresolvable — engine.PersistLastRunSummary treats "" as "do not persist".
 func deriveGCStateRoot(localCfg interface {
 	GetConfig() (map[string]any, error)
 }, shareName string) string {
-	if localCfg == nil {
+	dir := deriveLocalStoreDir(localCfg, shareName)
+	if dir == "" {
 		return ""
 	}
-	cfg, err := localCfg.GetConfig()
-	if err != nil {
-		return ""
-	}
-	basePath, ok := cfg["path"].(string)
-	if !ok || basePath == "" {
-		return ""
-	}
-	expanded, err := pathutil.ExpandPath(basePath)
-	if err != nil {
-		return ""
-	}
-	if !filepath.IsAbs(expanded) {
-		return ""
-	}
-	return filepath.Join(expanded, "shares", sanitizeShareName(shareName), "gc-state")
+	return filepath.Join(dir, "gc-state")
 }
 
 // deriveLocalStoreDir returns the per-share on-disk data directory the
 // migration tool uses to host `.migration-state.jsonl` and the rolling
-// snapshot. Mirrors deriveGCStateRoot's path-extraction logic for
-// fs-backed local stores; returns "" for in-memory or unresolvable
-// configs (the REST status handler treats "" as "no journal available",
-// not an error).
+// snapshot. Returns "" for in-memory or unresolvable configs (the REST
+// status handler treats "" as "no journal available", not an error).
 //
 // Path layout: `<basePath>/shares/<sanitized>/`. Note the absence of a
 // "blocks" or "gc-state" suffix — the migration journal lives at the


### PR DESCRIPTION
Three findings from the data-plane audit, all in the Runtime composition layer.

## Adapter restart failures were swallowed

`adapters.Service` restarted an adapter and discarded the error, so a restart that
failed left the entry marked running with nothing behind it. The error now
propagates, and the registry entry is held until the adapter has actually stopped
rather than being dropped at the start of teardown. New tests in
`adapters/service_test.go` cover both the failed-restart and the
stopped-before-removal orderings.

## Client registry tracked shares nothing ever populated

`clients.Registry` carried an `AddShare` / `RemoveShare` / `ListByShare` trio and a
`Shares` slice on every record. No caller outside the package ever invoked them, so
`Shares` was empty on every record the API returned. The same applies to
`ClientRecord.User` and to most of the protocol detail structs: `NfsDetails`
`AuthFlavor` / `UID` / `GID` and `SmbDetails` `Dialect` / `Domain` / `Signed` /
`Encrypted` were declared, serialized, and never assigned.

`GET /clients`, `GET /clients?share=`, and `dfsctl client list` were therefore
reporting permanently blank columns as though they were real state. The dead
methods and fields are removed along with the tests that covered them, which drops
the `mu`-guarded mutable field set to nothing — an entry's fields are now written
at `Register` and never mutated again, so the lock comment matches what the lock
actually protects.

**This changes the shape of the client JSON payload and the `dfsctl client list`
output.** Every field removed was always empty or zero, so no information is lost,
but a consumer parsing those keys will no longer find them.

`docs/guide/cli.md` is regenerated from the Cobra change, not hand-edited.

## Verification

`go build ./...`, `go vet ./...`, and the runtime / API-handler / dfsctl package
trees all pass. `go run ./cmd/gendocs` produces no diff against the committed
`cli.md`.
