### PR TITLE
fix(block): share decorator passthrough, drop dead append contract, correct rotation docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,9 @@ composition layer over six sub-services: `adapters/`, `stores/`, `shares/`, `mou
 
 7. **Store contracts** live in `pkg/metadata/storetest/` — any new metadata backend must pass
    that conformance suite. Block stores have a unified suite in `pkg/block/blockstoretest/`
-   (`BlockStoreConformance` + `BlockStoreAppendConformance`).
+   (`BlockStoreConformance` for the hash-keyed `block.Store` surface,
+   `RemoteBlockStoreConformance` for the block-keyed one). The local tier is
+   payload-keyed and is covered by its own package tests, not by that suite.
 
 ## Code comments
 

--- a/docs/internals/contributing.md
+++ b/docs/internals/contributing.md
@@ -287,17 +287,17 @@ DittoFS uses a Service-oriented architecture where **stores are simple CRUD inte
 
 **Block Store (Local):**
 
-1. Implement `pkg/block/local.LocalStore` interface. It embeds the
-   content-addressed `block.BlockStoreAppend` surface (`Put`, `Get`,
-   `GetRange`, `Has`, `Delete`, `Head`, `Walk`, plus `AppendWrite` /
-   `DeleteAppendLog`) and adds per-payload admin, lifecycle, rollup-drain,
-   and retention methods — see `pkg/block/local/local.go` for the full list.
-2. Storage is content-addressed (keyed by `block.ContentHash`), not by
-   block ID/offset
+1. Implement the `pkg/block/local.LocalStore` interface. It is the
+   journal-native surface keyed by `(payloadID, offset)` — `WriteAt`,
+   `ReadAt`, `Hydrate`, `Commit`, `Truncate`, `Delete` — plus carve,
+   eviction, lifecycle and retention methods. See `pkg/block/local/local.go`
+   for the full list.
+2. Storage is payload-keyed, NOT content-addressed: the local tier is a
+   per-file byte cache, so it does not implement `block.Store`.
 3. Each share gets an isolated local storage directory
-4. Test with the conformance suite in `pkg/block/blockstoretest/`
-   (`BlockStoreConformance` for the CAS contract, `BlockStoreAppendConformance`
-   for the append-write absorber)
+4. The `pkg/block/blockstoretest/` suites do not apply here — they target the
+   hash-keyed and block-keyed remote surfaces. Model tests on the existing
+   package tests under `pkg/block/local/` and `pkg/block/journal/`.
 
 **Block Store (Remote):**
 

--- a/docs/internals/encryption-design.md
+++ b/docs/internals/encryption-design.md
@@ -4,7 +4,7 @@
 
 ## Envelope encryption design
 
-Standard envelope encryption, matching AWS SSE-KMS, MinIO + KES, and HashiCorp Vault Transit:
+Standard envelope encryption, following the same shape as AWS SSE-KMS, MinIO + KES, and HashiCorp Vault Transit. Note that unlike those services, DittoFS keeps no retired master keys and therefore does not support rotation — see [Master-key rotation is not supported](#master-key-rotation-is-not-supported) below.
 
 1. A **master key** is held by a key provider (local file or KMIP-speaking HSM). The master key never directly encrypts a block.
 2. For each block, a fresh 32-byte **block key** is generated from `crypto/rand` and used with an AEAD to encrypt the payload.
@@ -49,7 +49,15 @@ master key  (held by key provider; local file or KMIP HSM)
                      └── AEAD-encrypts ──► block payload
 ```
 
-The master key identifier stored in each frame allows future multi-key `Unwrap` support (needed for key rotation) without changing the frame format.
+Each frame records the identifier of the master key that wrapped its block key. Today that identifier is only used to *reject* a frame wrapped under a different master key, with `ErrWrongMasterKey`. It leaves room for a multi-key `Unwrap` to be added later without changing the frame format, but no such lookup exists.
+
+## Master-key rotation is not supported
+
+A `KeyProvider` holds exactly one master key. There is no retired-key set: `Unwrap` returns `ErrWrongMasterKey` for every frame whose recorded identifier is not the single one held.
+
+**Changing a share's master key destroys access to all data already written under the old key.** This applies to every provider — writing a new key file, or pointing `key_uid` at a different HSM key. There is no recovery path once the old key is gone, and no re-wrap tooling ships today.
+
+Rotating safely would mean reading every block with a provider holding the old key, re-writing it with one holding the new key, and only then decommissioning the old key. Until that exists, treat a share's master key as fixed for the life of its data. `docs/guide/encryption.md` carries the operator-facing version of this warning.
 
 ## KMIP provider behavior and HSM integration
 
@@ -57,7 +65,7 @@ The KMIP provider fetches the configured master key from the HSM at startup usin
 
 This is a real KMIP integration (mutual-TLS, KMIP 1.4 protocol via `github.com/gemalto/kmip-go`) but it is **not** HSM-resident envelope encryption — the master-key bytes do live in the daemon's address space while it runs. A future iteration can move wrap / unwrap into the HSM via KMIP `Encrypt` / `Decrypt` operations without changing the `KeyProvider` interface; the public surface stays the same.
 
-To rotate: write a new key to the HSM, update the `key_uid` in the remote config, and restart the share. Existing blocks remain decryptable because every frame carries the master-key identifier that wrapped its block key.
+Pointing `key_uid` at a different HSM key is **not** a rotation procedure: only the newly fetched key is held, so every block wrapped under the previous key becomes permanently unreadable. See [Master-key rotation is not supported](#master-key-rotation-is-not-supported).
 
 ### Validating against a KMIP server
 

--- a/docs/internals/implementing-stores.md
+++ b/docs/internals/implementing-stores.md
@@ -482,7 +482,7 @@ the two-tier local design.
 
 The journal-native `LocalStore` surface is `(payloadID, offset)`-keyed, not the
 content-addressed `block.Store` surface, so the `blockstoretest` suites below
-(`BlockStoreConformance` / `BlockStoreAppendConformance`) do **not** apply to a
+(`BlockStoreConformance` / `RemoteBlockStoreConformance`) do **not** apply to a
 local store — they target the CAS `block.Store` surface that remote stores
 implement (see [Implementing a Remote Store](#implementing-a-remote-store)). The
 in-tree local stores are exercised by their own package tests under

--- a/pkg/block/blockstore.go
+++ b/pkg/block/blockstore.go
@@ -2,9 +2,9 @@
 //
 // This file declares the single CAS-keyed surface that replaces the
 // split LocalStore (22 methods) + RemoteStore (12 methods) of v0.15.
-// BlockStoreAppend extends BlockStore with the random-write absorber
-// tier (per-file append log + rollup) used by the fs backend only;
-// s3 and memory backends implement only BlockStore.
+// It covers the hash-keyed tier only. The local random-write absorber
+// (per-file append log + rollup) is payload-keyed, not hash-keyed, and
+// is declared on pkg/block/local.LocalStore instead.
 //
 // The on-disk format-version stamp and the boot guard that refuses state
 // from a newer release (ErrFutureFormat) live in doc.go and errors.go.
@@ -39,8 +39,8 @@ type Meta struct {
 	LastModified time.Time
 }
 
-// Store is the content-addressed block storage contract for the LOCAL tier.
-// Every implementation is keyed by ContentHash (BLAKE3-256, 32 bytes)
+// Store is the content-addressed block storage contract. Every
+// implementation is keyed by ContentHash (BLAKE3-256, 32 bytes)
 // no opaque "block key" strings appear on this surface.
 //
 // The production REMOTE tier no longer exposes this hash-keyed surface — it is
@@ -52,8 +52,13 @@ type Meta struct {
 // this interface.
 //
 // Implementations
-//   - pkg/block/local/fs.FSStore (also implements BlockStoreAppend)
 //   - pkg/block/remote/s3.Store, pkg/block/remote/memory.Store (legacy-CAS only)
+//   - the compression / encryption decorators, which forward this surface
+//     inward through remote.Passthrough
+//
+// The local tier does NOT implement this interface: pkg/block/local/fs.FSStore
+// is payload-keyed (WriteAt / ReadAt / Hydrate / Commit) and satisfies
+// pkg/block/local.LocalStore instead.
 //
 // All methods take ctx context.Context as the first argument and MUST
 // honor cancellation. All hash arguments are the full 32-byte
@@ -150,64 +155,6 @@ type Store interface {
 	//
 	// See block.ErrStopWalk for the sentinel doc.
 	Walk(ctx context.Context, fn func(hash ContentHash, meta Meta) error) error
-}
-
-// BlockStoreAppend extends BlockStore with the random-write absorber
-// tier used by the local fs backend only. The append log absorbs
-// adapter writes that arrive out-of-order or below the FastCDC chunk
-// boundary; a background rollup loop chunks the log into CAS objects
-// via Put and then trims the log via DeleteAppendLog (or implicitly
-// during the rollup, backend's choice).
-//
-// Remote backends (s3, memory) do NOT implement this interface — they
-// only see the rolled-up Put calls.
-//
-// Note: the narrowed LocalStore interface that lands keeps
-// additional lifecycle / admin methods (Truncate, EvictMemory
-// SetEvictionEnabled, Stats, ListFiles
-// GetStoredFileSize, Healthcheck, SyncFileChunks, SyncFileChunksForFile
-// Flush, Start, Close) as a strict admin-superset of BlockStoreAppend.
-// Those methods belong on LocalStore (boot-path / observability /
-// retention), NOT on BlockStoreAppend — the append surface here is
-// strictly the byte-level write-absorber contract.
-type BlockStoreAppend interface {
-	Store
-
-	// AppendWrite stages random-offset bytes for payloadID into the
-	// per-file append log. Subsequent FastCDC rollup consumes the log
-	// after the stabilization window and emits CAS chunks via Put.
-	//
-	// The interval [offset, offset+len(data)) is tracked so the rollup
-	// can later compute a deterministic chunking over the consolidated
-	// stream. Implementations MUST be safe under concurrent calls for
-	// the same payloadID (per-file mutex; see *fs.FSStore.AppendWrite
-	// godoc for the full pressure / tombstone / mutex semantics).
-	//
-	// Empty data is a no-op (returns nil). Context cancellation while
-	// waiting on log-bytes pressure surfaces as ctx.Err().
-	AppendWrite(ctx context.Context, payloadID string, data []byte, offset uint64) error
-
-	// DeleteAppendLog removes the per-file append log and its tracked
-	// intervals for payloadID. The engine invokes this on a file-level
-	// dedup hit to discard speculative chunks the syncer was about to
-	// upload.
-	//
-	// Implementations MUST be safe to call when no log exists for the
-	// payload (no-op return nil). After DeleteAppendLog returns, the
-	// payload's append-log state is fully reset; a subsequent
-	// AppendWrite for the same payloadID MUST succeed and start a
-	// fresh log (recreate semantics). Files created after #1166 PR-3
-	// get a UUID-based PayloadID (metadata/file_helpers.go
-	// buildPayloadID), so 'unlink + create at same path' allocates a
-	// fresh content_id rather than reusing one; this method is still
-	// invoked on delete with the deleted file's own PayloadID to reclaim
-	// its append-log state. Backends that maintain a tombstone for
-	// race-safety reasons MUST clear it before DeleteAppendLog returns.
-	//
-	// Orphan content-addressed chunks already emitted by a prior
-	// rollup are NOT removed here — they are swept by the mark-sweep
-	// GC.
-	DeleteAppendLog(ctx context.Context, payloadID string) error
 }
 
 // DurabilityReporter is an optional capability a block store (local or

--- a/pkg/block/blockstoretest/conformance.go
+++ b/pkg/block/blockstoretest/conformance.go
@@ -17,8 +17,8 @@ import (
 // registers cleanup via t.Cleanup so subtests do not share state.
 //
 // The cleanup closure is responsible for closing the store and removing
-// any backing storage (e.g. tempdir teardown for the fs backend). It
-// MUST be safe to invoke when the store has not yet performed any I/O.
+// any backing storage (e.g. tempdir teardown for a disk-backed backend).
+// It MUST be safe to invoke when the store has not yet performed any I/O.
 //
 // Factory is intentionally a defined type (not a type alias) so the
 // conformance suite can refer to it by name in godoc and so backends
@@ -59,9 +59,6 @@ type Factory func(t *testing.T) (block.Store, func())
 //   - Put accepts a payload whose bytes do not match the supplied hash:
 //     the no-verify-on-Put contract is the caller's responsibility, and
 //     Get returns whatever bytes were stored under that key.
-//
-// Backends that also implement BlockStoreAppend additionally call
-// BlockStoreAppendConformance.
 func BlockStoreConformance(t *testing.T, factory Factory) {
 	t.Helper()
 	t.Run("Put_Get_Roundtrip", func(t *testing.T) { testPutGetRoundtrip(t, factory) })
@@ -81,11 +78,8 @@ func BlockStoreConformance(t *testing.T, factory Factory) {
 	t.Run("Put_WrongHash_NoVerify", func(t *testing.T) { testPutWrongHashNoVerify(t, factory) })
 }
 
-// blake3Sum is the conformance suite's shared hashing helper. It mirrors
-// blake3ContentHash at pkg/block/local/fs/rollup.go:449 — the
-// rollup loop hashes chunk bytes the same way before storing them, so
-// the suite's fixtures share the rollup's content-address contract.
-// Shared with appendlog.go (same package, no import needed).
+// blake3Sum is the conformance suite's hashing helper: BLAKE3-256 over
+// the fixture bytes, the same content-address key the stores use.
 func blake3Sum(b []byte) block.ContentHash {
 	var h block.ContentHash
 	sum := blake3.Sum256(b)

--- a/pkg/block/blockstoretest/doc.go
+++ b/pkg/block/blockstoretest/doc.go
@@ -1,10 +1,10 @@
 // Package blockstoretest provides a unified conformance suite for the
-// BlockStore contract declared in pkg/block/blockstore.go.
+// block.Store contract declared in pkg/block/blockstore.go.
 //
 // Two top-level entrypoints are exposed:
 //
 //   - BlockStoreConformance(t, factory) — runs the CAS-keyed contract
-//     suite against any BlockStore implementation. The s3 and memory
+//     suite against any block.Store implementation. The s3 and memory
 //     backends and the compression / encryption decorators call it.
 //   - RemoteBlockStoreConformance(t, factory) — runs the block-keyed
 //     (non-CAS) contract suite against any RemoteBlockStore
@@ -14,7 +14,7 @@
 // There is no append-log conformance entrypoint. The local tier
 // (*fs.FSStore) is not hash-keyed — it exposes the payload-keyed
 // local.LocalStore surface (WriteAt / ReadAt / Hydrate / Commit) and so
-// implements neither BlockStore nor RemoteBlockStore. It is covered by
+// implements neither block.Store nor RemoteBlockStore. It is covered by
 // its own package-local tests in pkg/block/local/fs and by the journal
 // suites, not by anything here.
 //

--- a/pkg/block/blockstoretest/doc.go
+++ b/pkg/block/blockstoretest/doc.go
@@ -1,30 +1,25 @@
 // Package blockstoretest provides a unified conformance suite for the
-// BlockStore and BlockStoreAppend contracts declared in
-// pkg/block/blockstore.go.
+// BlockStore contract declared in pkg/block/blockstore.go.
 //
-// Three top-level entrypoints are exposed:
+// Two top-level entrypoints are exposed:
 //
 //   - BlockStoreConformance(t, factory) — runs the CAS-keyed contract
-//     suite against any BlockStore implementation. The fs, s3, and
-//     memory backends all call this entrypoint.
-//   - BlockStoreAppendConformance(t, factory) — runs the random-write
-//     absorber suite against any BlockStoreAppend implementation. Only
-//     the fs backend implements BlockStoreAppend and therefore calls
-//     this entrypoint.
+//     suite against any BlockStore implementation. The s3 and memory
+//     backends and the compression / encryption decorators call it.
 //   - RemoteBlockStoreConformance(t, factory) — runs the block-keyed
 //     (non-CAS) contract suite against any RemoteBlockStore
 //     implementation. The memory and s3 backends both call this
 //     entrypoint.
 //
-// This package replaces pkg/block/local/localtest and
-// pkg/block/remote/remotetest. The three fs-internal scenarios
-// that cannot be expressed through the interface surface
-// (PressureChannel_INV05, TornWriteRecovery_LSL06,
-// RollupOffsetMonotone_INV03) live in
-// pkg/block/local/fs/appendlog_internals_test.go.
+// There is no append-log conformance entrypoint. The local tier
+// (*fs.FSStore) is not hash-keyed — it exposes the payload-keyed
+// local.LocalStore surface (WriteAt / ReadAt / Hydrate / Commit) and so
+// implements neither BlockStore nor RemoteBlockStore. It is covered by
+// its own package-local tests in pkg/block/local/fs and by the journal
+// suites, not by anything here.
 //
-// Each scenario uses a factory that returns a fresh (BlockStore
-// cleanup) pair per subtest, so subtests do not share state and
-// teardown is deterministic. See conformance.go and appendlog.go for
-// the factory type definitions.
+// Each scenario uses a factory that returns a fresh (store, cleanup)
+// pair per subtest, so subtests do not share state and teardown is
+// deterministic. See conformance.go and remoteblock.go for the factory
+// type definitions.
 package blockstoretest

--- a/pkg/block/compression/decorator.go
+++ b/pkg/block/compression/decorator.go
@@ -21,6 +21,9 @@ import (
 // 5-byte DFCMP magic prefix.
 type Decorator struct {
 	remote.Passthrough
+	// inner is the wrapped store, held separately because Passthrough keeps
+	// its own copy unexported to stay off this type's public surface.
+	inner remote.RemoteStore
 	algo  Algo
 	codec codec
 }
@@ -36,7 +39,8 @@ func NewRemote(inner remote.RemoteStore, p CompressionPolicy) (*Decorator, error
 		return nil, err
 	}
 	return &Decorator{
-		Passthrough: remote.Passthrough{Inner: inner},
+		Passthrough: remote.NewPassthrough(inner),
+		inner:       inner,
 		algo:        p.Algo,
 		codec:       c,
 	}, nil
@@ -56,7 +60,7 @@ func (d *Decorator) Put(ctx context.Context, hash block.ContentHash, data []byte
 	if err != nil {
 		return err
 	}
-	cs, err := remote.CASInner(d.Inner)
+	cs, err := remote.CASInner(d.inner)
 	if err != nil {
 		return err
 	}
@@ -73,7 +77,7 @@ func (d *Decorator) SealChunk(ctx context.Context, hash block.ContentHash, plain
 	if err != nil {
 		return nil, err
 	}
-	sealer, ok := d.Inner.(remote.ChunkSealer)
+	sealer, ok := d.inner.(remote.ChunkSealer)
 	if !ok {
 		return nil, remote.ErrChunkReadUnsupported
 	}
@@ -111,7 +115,7 @@ func (d *Decorator) sealLayer(data []byte) ([]byte, error) {
 
 // Get returns the plaintext for the block identified by hash.
 func (d *Decorator) Get(ctx context.Context, hash block.ContentHash) ([]byte, error) {
-	cs, err := remote.CASInner(d.Inner)
+	cs, err := remote.CASInner(d.inner)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +181,7 @@ func (d *Decorator) GetRange(ctx context.Context, hash block.ContentHash, offset
 // framed blocks this requires a short range-GET to parse the frame
 // header.
 func (d *Decorator) Head(ctx context.Context, hash block.ContentHash) (block.Meta, error) {
-	cs, err := remote.CASInner(d.Inner)
+	cs, err := remote.CASInner(d.inner)
 	if err != nil {
 		return block.Meta{}, err
 	}
@@ -208,7 +212,7 @@ func (d *Decorator) plaintextSizeFor(ctx context.Context, hash block.ContentHash
 	if probeLen <= 0 {
 		return wireSize, nil
 	}
-	cs, err := remote.CASInner(d.Inner)
+	cs, err := remote.CASInner(d.inner)
 	if err != nil {
 		return 0, err
 	}
@@ -230,7 +234,7 @@ func (d *Decorator) plaintextSizeFor(ctx context.Context, hash block.ContentHash
 // for each framed block before invoking the user callback. Per-block
 // probe errors halt the walk and are surfaced to the caller.
 func (d *Decorator) Walk(ctx context.Context, fn func(hash block.ContentHash, meta block.Meta) error) error {
-	cs, err := remote.CASInner(d.Inner)
+	cs, err := remote.CASInner(d.inner)
 	if err != nil {
 		return err
 	}
@@ -252,7 +256,7 @@ func (d *Decorator) Walk(ctx context.Context, fn func(hash block.ContentHash, me
 // the engine verifies the BLAKE3 after the full stack. hash is unused at this
 // layer. Implements remote.ChunkReader (#1414).
 func (d *Decorator) ReadChunk(ctx context.Context, blockID string, offset, length int64, hash block.ContentHash) ([]byte, error) {
-	pcr, ok := d.Inner.(remote.ChunkReader)
+	pcr, ok := d.inner.(remote.ChunkReader)
 	if !ok {
 		return nil, remote.ErrChunkReadUnsupported
 	}

--- a/pkg/block/compression/decorator.go
+++ b/pkg/block/compression/decorator.go
@@ -3,13 +3,11 @@ package compression
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/remote"
-	"github.com/marmos91/dittofs/pkg/health"
 )
 
 // Decorator wraps a remote.RemoteStore and transparently compresses
@@ -22,7 +20,7 @@ import (
 // plaintext with no header. Get detects framed vs raw by checking the
 // 5-byte DFCMP magic prefix.
 type Decorator struct {
-	inner remote.RemoteStore
+	remote.Passthrough
 	algo  Algo
 	codec codec
 }
@@ -37,7 +35,11 @@ func NewRemote(inner remote.RemoteStore, p CompressionPolicy) (*Decorator, error
 	if err != nil {
 		return nil, err
 	}
-	return &Decorator{inner: inner, algo: p.Algo, codec: c}, nil
+	return &Decorator{
+		Passthrough: remote.Passthrough{Inner: inner},
+		algo:        p.Algo,
+		codec:       c,
+	}, nil
 }
 
 // --- write path ---------------------------------------------------------
@@ -54,7 +56,7 @@ func (d *Decorator) Put(ctx context.Context, hash block.ContentHash, data []byte
 	if err != nil {
 		return err
 	}
-	cs, err := d.casInner()
+	cs, err := remote.CASInner(d.Inner)
 	if err != nil {
 		return err
 	}
@@ -71,7 +73,7 @@ func (d *Decorator) SealChunk(ctx context.Context, hash block.ContentHash, plain
 	if err != nil {
 		return nil, err
 	}
-	sealer, ok := d.inner.(remote.ChunkSealer)
+	sealer, ok := d.Inner.(remote.ChunkSealer)
 	if !ok {
 		return nil, remote.ErrChunkReadUnsupported
 	}
@@ -109,7 +111,7 @@ func (d *Decorator) sealLayer(data []byte) ([]byte, error) {
 
 // Get returns the plaintext for the block identified by hash.
 func (d *Decorator) Get(ctx context.Context, hash block.ContentHash) ([]byte, error) {
-	cs, err := d.casInner()
+	cs, err := remote.CASInner(d.Inner)
 	if err != nil {
 		return nil, err
 	}
@@ -168,37 +170,14 @@ func (d *Decorator) GetRange(ctx context.Context, hash block.ContentHash, offset
 	if err != nil {
 		return nil, err
 	}
-	if offset < 0 || offset > int64(len(full)) {
-		return nil, fmt.Errorf("%w: offset %d out of bounds (size %d)", block.ErrInvalidOffset, offset, len(full))
-	}
-	end := min(offset+length, int64(len(full)))
-	out := make([]byte, end-offset)
-	copy(out, full[offset:end])
-	return out, nil
-}
-
-// Has reports presence by probing inner.Head. NotFound errors map to
-// (false, nil); any other backend error propagates.
-func (d *Decorator) Has(ctx context.Context, hash block.ContentHash) (bool, error) {
-	cs, err := d.casInner()
-	if err != nil {
-		return false, err
-	}
-	_, err = cs.Head(ctx, hash)
-	if err == nil {
-		return true, nil
-	}
-	if errors.Is(err, block.ErrChunkNotFound) {
-		return false, nil
-	}
-	return false, err
+	return remote.SliceRange(full, offset, length)
 }
 
 // Head returns Meta whose Size is the plaintext byte length. For
 // framed blocks this requires a short range-GET to parse the frame
 // header.
 func (d *Decorator) Head(ctx context.Context, hash block.ContentHash) (block.Meta, error) {
-	cs, err := d.casInner()
+	cs, err := remote.CASInner(d.Inner)
 	if err != nil {
 		return block.Meta{}, err
 	}
@@ -229,7 +208,7 @@ func (d *Decorator) plaintextSizeFor(ctx context.Context, hash block.ContentHash
 	if probeLen <= 0 {
 		return wireSize, nil
 	}
-	cs, err := d.casInner()
+	cs, err := remote.CASInner(d.Inner)
 	if err != nil {
 		return 0, err
 	}
@@ -251,7 +230,7 @@ func (d *Decorator) plaintextSizeFor(ctx context.Context, hash block.ContentHash
 // for each framed block before invoking the user callback. Per-block
 // probe errors halt the walk and are surfaced to the caller.
 func (d *Decorator) Walk(ctx context.Context, fn func(hash block.ContentHash, meta block.Meta) error) error {
-	cs, err := d.casInner()
+	cs, err := remote.CASInner(d.Inner)
 	if err != nil {
 		return err
 	}
@@ -265,15 +244,6 @@ func (d *Decorator) Walk(ctx context.Context, fn func(hash block.ContentHash, me
 	})
 }
 
-// Delete is a straight passthrough.
-func (d *Decorator) Delete(ctx context.Context, hash block.ContentHash) error {
-	cs, err := d.casInner()
-	if err != nil {
-		return err
-	}
-	return cs.Delete(ctx, hash)
-}
-
 // ReadChunk reads the chunk's compressed wire bytes from the inner store's
 // block object and decompresses them, returning the next layer's input (or the
 // engine's plaintext). A block stores each chunk's full self-framed compression
@@ -282,7 +252,7 @@ func (d *Decorator) Delete(ctx context.Context, hash block.ContentHash) error {
 // the engine verifies the BLAKE3 after the full stack. hash is unused at this
 // layer. Implements remote.ChunkReader (#1414).
 func (d *Decorator) ReadChunk(ctx context.Context, blockID string, offset, length int64, hash block.ContentHash) ([]byte, error) {
-	pcr, ok := d.inner.(remote.ChunkReader)
+	pcr, ok := d.Inner.(remote.ChunkReader)
 	if !ok {
 		return nil, remote.ErrChunkReadUnsupported
 	}
@@ -291,101 +261,6 @@ func (d *Decorator) ReadChunk(ctx context.Context, blockID string, offset, lengt
 		return nil, err
 	}
 	return d.decode(raw)
-}
-
-// Close releases inner resources.
-func (d *Decorator) Close() error { return d.inner.Close() }
-
-// HealthCheck delegates to inner.
-func (d *Decorator) HealthCheck(ctx context.Context) error { return d.inner.HealthCheck(ctx) }
-
-// Healthcheck delegates to inner.
-func (d *Decorator) Healthcheck(ctx context.Context) health.Report {
-	return d.inner.Healthcheck(ctx)
-}
-
-// Durable delegates to the wrapped store via block.IsDurable. Compressing block
-// bodies does not change where the bytes ultimately land, so a durable inner
-// store stays durable through the decorator; a wrapped store that does not
-// report durability falls back to the conservative default (false).
-func (d *Decorator) Durable() bool {
-	return block.IsDurable(d.inner)
-}
-
-// --- remote.RemoteBlockStore passthrough (#1414) ---
-//
-// Packed block objects carry per-chunk wire bodies that were already sealed via
-// SealChunk; the assembled block must NOT be re-transformed at the block level.
-// So every block-keyed operation passes through verbatim to the inner store.
-// This lets a decorated remote satisfy remote.RemoteBlockStore (the carve path
-// asserts it) while the per-chunk transform stays in SealChunk/ReadChunk.
-
-// blockInner returns the inner store as a remote.RemoteBlockStore, or an error
-// when the wrapped store does not support block-keyed objects.
-func (d *Decorator) blockInner() (remote.RemoteBlockStore, error) {
-	rbs, ok := d.inner.(remote.RemoteBlockStore)
-	if !ok {
-		return nil, remote.ErrChunkReadUnsupported
-	}
-	return rbs, nil
-}
-
-// casInner exposes the inner store's hash-keyed CAS surface (block.Store),
-// used only by the legacy standalone-CAS read path (block.Store methods +
-// ReadBlockVerified in legacy_cas_migration.go). Every shipped remote backend
-// and decorator implements block.Store, so the assertion succeeds in practice;
-// it returns an error rather than panicking for defense in depth.
-func (d *Decorator) casInner() (block.Store, error) {
-	cs, ok := d.inner.(block.Store)
-	if !ok {
-		return nil, remote.ErrChunkReadUnsupported
-	}
-	return cs, nil
-}
-
-// PutBlock stores the assembled block verbatim (already-sealed bodies).
-func (d *Decorator) PutBlock(ctx context.Context, blockID string, r io.Reader) error {
-	rbs, err := d.blockInner()
-	if err != nil {
-		return err
-	}
-	return rbs.PutBlock(ctx, blockID, r)
-}
-
-// GetBlock returns the raw block object verbatim.
-func (d *Decorator) GetBlock(ctx context.Context, blockID string) ([]byte, error) {
-	rbs, err := d.blockInner()
-	if err != nil {
-		return nil, err
-	}
-	return rbs.GetBlock(ctx, blockID)
-}
-
-// GetBlockRange returns raw block bytes verbatim; per-chunk decode is ReadChunk.
-func (d *Decorator) GetBlockRange(ctx context.Context, blockID string, offset, length int64) ([]byte, error) {
-	rbs, err := d.blockInner()
-	if err != nil {
-		return nil, err
-	}
-	return rbs.GetBlockRange(ctx, blockID, offset, length)
-}
-
-// DeleteBlock removes the block object.
-func (d *Decorator) DeleteBlock(ctx context.Context, blockID string) error {
-	rbs, err := d.blockInner()
-	if err != nil {
-		return err
-	}
-	return rbs.DeleteBlock(ctx, blockID)
-}
-
-// WalkBlocks enumerates block objects.
-func (d *Decorator) WalkBlocks(ctx context.Context, fn func(blockID string, meta block.Meta) error) error {
-	rbs, err := d.blockInner()
-	if err != nil {
-		return err
-	}
-	return rbs.WalkBlocks(ctx, fn)
 }
 
 // Compile-time interface assertions.

--- a/pkg/block/compression/decorator_test.go
+++ b/pkg/block/compression/decorator_test.go
@@ -298,3 +298,23 @@ func TestPut_AllocBounded(t *testing.T) {
 	}
 	t.Logf("alloc per 4 MiB Put: %d bytes (budget %d)", allocPerPut, budget)
 }
+
+// TestGetRange_InvalidLengthOnAbsentBlock pins the order of the two checks: an
+// invalid length is rejected before the block is fetched, so a caller passing a
+// bad length learns that rather than being told the block is missing. Asserting
+// this needs a block that does not exist — when the block is present, a length
+// check placed after the fetch returns ErrInvalidSize just the same, and the
+// ordering goes untested.
+func TestGetRange_InvalidLengthOnAbsentBlock(t *testing.T) {
+	d, err := NewRemote(remotememory.New(), CompressionPolicy{Algo: AlgoZstd})
+	if err != nil {
+		t.Fatal(err)
+	}
+	absent := hashOf([]byte("never stored"))
+	for _, length := range []int64{0, -1, -1024} {
+		_, err := d.GetRange(context.Background(), absent, 0, length)
+		if !errors.Is(err, block.ErrInvalidSize) {
+			t.Errorf("length=%d: got %v, want wraps ErrInvalidSize", length, err)
+		}
+	}
+}

--- a/pkg/block/compression/legacy_cas_migration.go
+++ b/pkg/block/compression/legacy_cas_migration.go
@@ -31,11 +31,6 @@ func (d *Decorator) ReadLegacyChunkVerified(ctx context.Context, hash block.Cont
 	return d.ReadBlockVerified(ctx, hash, hash)
 }
 
-// DeleteLegacyChunk implements remote.LegacyCASStore.
-func (d *Decorator) DeleteLegacyChunk(ctx context.Context, hash block.ContentHash) error {
-	return d.Delete(ctx, hash)
-}
-
 // ReadBlockVerified GETs the standalone object, decodes it, then re-verifies
 // the BLAKE3 hash over the plaintext. Streaming verification over the wire
 // bytes is not possible once the body is compressed.

--- a/pkg/block/doc.go
+++ b/pkg/block/doc.go
@@ -1,28 +1,26 @@
 // Package blockstore defines the unified content-addressed block storage
 // contract DittoFS uses across every storage tier. It is the
 // single source of truth for FileChunk, BlockState, ContentHash, BlockSize
-// the BlockStore + BlockStoreAppend interfaces, the minimal Meta struct
-// the error sentinels (ErrStopWalk, ErrFutureFormat
+// the Store interface, the minimal Meta struct, the error sentinels
+// (ErrStopWalk, ErrFutureFormat
 // ErrChunkNotFound, …), and the on-disk format-version convention.
 //
 // # Interface roles
 //
-// Two interfaces, both keyed by ContentHash, replace the earlier
-// v0.15 split (LocalStore: 22 methods, RemoteStore: 12 methods):
+// One hash-keyed interface replaces the earlier v0.15 split
+// (LocalStore: 22 methods, RemoteStore: 12 methods):
 //
-//   - BlockStore — the unified surface for content-addressed CRUD
+//   - Store — the unified surface for content-addressed CRUD
 //     (Put / Get / GetRange / Has / Delete / Head / Walk). Idempotent
 //     same-bytes Put, no opaque "block key" strings, every method
 //     takes a context.Context first. Implemented by:
-//     *pkg/block/local/fs.FSStore (local CAS chunks);
-//     *pkg/block/remote/s3.Store (S3-backed CAS);
-//     *pkg/block/remote/memory.Store (in-memory CAS for tests).
+//     *pkg/block/remote/s3.Store and *pkg/block/remote/memory.Store
+//     (behind the migration-only legacy-CAS path), and by the
+//     compression / encryption decorators.
 //
-//   - BlockStoreAppend — embeds BlockStore and adds AppendWrite +
-//     DeleteAppendLog for the random-write absorber tier (the per-file
-//     append log + FastCDC rollup loop on the fs backend). s3 and
-//     memory backends do NOT implement this — they only see rolled-up
-//     Put calls.
+// The local random-write absorber tier (per-file append log + FastCDC
+// rollup on the fs backend) is payload-keyed, not hash-keyed: it lives
+// on pkg/block/local.LocalStore and is not part of this contract.
 //
 // Meta (the value returned by Head and surfaced via Walk) carries
 // minimal fields:
@@ -102,14 +100,15 @@
 //
 // # Sub-packages
 //
-//   - local: LocalStore admin-superset interface + the *fs.FSStore
-//     implementation (the only BlockStoreAppend).
-//   - remote: Remote backend implementations (s3, memory) that
-//     implement BlockStore only.
-//   - blockstoretest: Unified conformance suite. Two entrypoints —
-//     BlockStoreConformance(t, factory) and
-//     BlockStoreAppendConformance(t, factory) — let backends opt
-//     into the contract surface they claim.
+//   - local: the payload-keyed LocalStore interface + the *fs.FSStore
+//     implementation.
+//   - remote: the block-keyed RemoteStore contract, its backend
+//     implementations (s3, memory), and Passthrough, the forwarding
+//     base the compression / encryption decorators embed.
+//   - blockstoretest: conformance suites — BlockStoreConformance for
+//     the hash-keyed Store surface and RemoteBlockStoreConformance for
+//     the block-keyed one — let backends opt into the contract surface
+//     they claim.
 //   - engine: BlockStore engine composing local store + syncer +
 //     unified Cache + metadata.
 //   - chunker: FastCDC chunker used by both writes and by the

--- a/pkg/block/encryption/decorator.go
+++ b/pkg/block/encryption/decorator.go
@@ -20,6 +20,9 @@ import (
 // unchanged from the perspective of callers above the decorator.
 type EncryptedRemote struct {
 	remote.Passthrough
+	// inner is the wrapped store, held separately because Passthrough keeps
+	// its own copy unexported to stay off this type's public surface.
+	inner    remote.RemoteStore
 	aead     AEAD
 	provider keyprovider.KeyProvider
 }
@@ -38,7 +41,8 @@ func NewRemote(inner remote.RemoteStore, policy EncryptionPolicy, provider keypr
 		return nil, err
 	}
 	return &EncryptedRemote{
-		Passthrough: remote.Passthrough{Inner: inner},
+		Passthrough: remote.NewPassthrough(inner),
+		inner:       inner,
 		aead:        policy.AEAD,
 		provider:    provider,
 	}, nil
@@ -55,7 +59,7 @@ func (d *EncryptedRemote) Put(ctx context.Context, hash block.ContentHash, data 
 	if err != nil {
 		return err
 	}
-	cs, err := remote.CASInner(d.Inner)
+	cs, err := remote.CASInner(d.inner)
 	if err != nil {
 		return err
 	}
@@ -72,7 +76,7 @@ func (d *EncryptedRemote) SealChunk(ctx context.Context, hash block.ContentHash,
 	if err != nil {
 		return nil, err
 	}
-	sealer, ok := d.Inner.(remote.ChunkSealer)
+	sealer, ok := d.inner.(remote.ChunkSealer)
 	if !ok {
 		return nil, remote.ErrChunkReadUnsupported
 	}
@@ -111,7 +115,7 @@ func (d *EncryptedRemote) sealLayer(ctx context.Context, hash block.ContentHash,
 
 // Get returns the plaintext for the block identified by hash.
 func (d *EncryptedRemote) Get(ctx context.Context, hash block.ContentHash) ([]byte, error) {
-	cs, err := remote.CASInner(d.Inner)
+	cs, err := remote.CASInner(d.inner)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +146,7 @@ func (d *EncryptedRemote) GetRange(ctx context.Context, hash block.ContentHash, 
 // 16-byte authentication tag, so plaintext_size = wire_size -
 // header_size - aeadTagSize.
 func (d *EncryptedRemote) Head(ctx context.Context, hash block.ContentHash) (block.Meta, error) {
-	cs, err := remote.CASInner(d.Inner)
+	cs, err := remote.CASInner(d.inner)
 	if err != nil {
 		return block.Meta{}, err
 	}
@@ -161,7 +165,7 @@ func (d *EncryptedRemote) Head(ctx context.Context, hash block.ContentHash) (blo
 // Walk rewrites Meta.Size to plaintext size for each block via the same
 // range-GET probe as Head. Per-block probe errors halt the walk.
 func (d *EncryptedRemote) Walk(ctx context.Context, fn func(hash block.ContentHash, meta block.Meta) error) error {
-	cs, err := remote.CASInner(d.Inner)
+	cs, err := remote.CASInner(d.inner)
 	if err != nil {
 		return err
 	}
@@ -184,7 +188,7 @@ func (d *EncryptedRemote) plaintextSizeFor(ctx context.Context, hash block.Conte
 	if probeLen <= 0 {
 		return 0, ErrCiphertextWithoutFrame
 	}
-	cs, err := remote.CASInner(d.Inner)
+	cs, err := remote.CASInner(d.inner)
 	if err != nil {
 		return 0, err
 	}
@@ -214,7 +218,7 @@ func (d *EncryptedRemote) plaintextSizeFor(ctx context.Context, hash block.Conte
 // standalone object. No verification here — the engine verifies the BLAKE3 after
 // the full stack. Implements remote.ChunkReader (#1414).
 func (d *EncryptedRemote) ReadChunk(ctx context.Context, blockID string, offset, length int64, hash block.ContentHash) ([]byte, error) {
-	pcr, ok := d.Inner.(remote.ChunkReader)
+	pcr, ok := d.inner.(remote.ChunkReader)
 	if !ok {
 		return nil, remote.ErrChunkReadUnsupported
 	}

--- a/pkg/block/encryption/decorator.go
+++ b/pkg/block/encryption/decorator.go
@@ -5,16 +5,13 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
-	"errors"
 	"fmt"
-	"io"
 
 	"golang.org/x/crypto/chacha20poly1305"
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/encryption/keyprovider"
 	"github.com/marmos91/dittofs/pkg/block/remote"
-	"github.com/marmos91/dittofs/pkg/health"
 )
 
 // EncryptedRemote wraps a remote.RemoteStore and transparently encrypts
@@ -22,7 +19,7 @@ import (
 // remains the CAS key — dedup, GC, and verification semantics are
 // unchanged from the perspective of callers above the decorator.
 type EncryptedRemote struct {
-	inner    remote.RemoteStore
+	remote.Passthrough
 	aead     AEAD
 	provider keyprovider.KeyProvider
 }
@@ -40,7 +37,11 @@ func NewRemote(inner remote.RemoteStore, policy EncryptionPolicy, provider keypr
 	if _, err := newAEAD(policy.AEAD, make([]byte, 32)); err != nil {
 		return nil, err
 	}
-	return &EncryptedRemote{inner: inner, aead: policy.AEAD, provider: provider}, nil
+	return &EncryptedRemote{
+		Passthrough: remote.Passthrough{Inner: inner},
+		aead:        policy.AEAD,
+		provider:    provider,
+	}, nil
 }
 
 // Put encrypts data and stores the framed result under hash. The block
@@ -54,7 +55,7 @@ func (d *EncryptedRemote) Put(ctx context.Context, hash block.ContentHash, data 
 	if err != nil {
 		return err
 	}
-	cs, err := d.casInner()
+	cs, err := remote.CASInner(d.Inner)
 	if err != nil {
 		return err
 	}
@@ -71,7 +72,7 @@ func (d *EncryptedRemote) SealChunk(ctx context.Context, hash block.ContentHash,
 	if err != nil {
 		return nil, err
 	}
-	sealer, ok := d.inner.(remote.ChunkSealer)
+	sealer, ok := d.Inner.(remote.ChunkSealer)
 	if !ok {
 		return nil, remote.ErrChunkReadUnsupported
 	}
@@ -110,7 +111,7 @@ func (d *EncryptedRemote) sealLayer(ctx context.Context, hash block.ContentHash,
 
 // Get returns the plaintext for the block identified by hash.
 func (d *EncryptedRemote) Get(ctx context.Context, hash block.ContentHash) ([]byte, error) {
-	cs, err := d.casInner()
+	cs, err := remote.CASInner(d.Inner)
 	if err != nil {
 		return nil, err
 	}
@@ -132,30 +133,7 @@ func (d *EncryptedRemote) GetRange(ctx context.Context, hash block.ContentHash, 
 	if err != nil {
 		return nil, err
 	}
-	if offset < 0 || offset > int64(len(full)) {
-		return nil, fmt.Errorf("%w: offset %d out of bounds (size %d)", block.ErrInvalidOffset, offset, len(full))
-	}
-	end := min(offset+length, int64(len(full)))
-	out := make([]byte, end-offset)
-	copy(out, full[offset:end])
-	return out, nil
-}
-
-// Has reports presence by probing inner.Head. NotFound errors map to
-// (false, nil); any other backend error propagates.
-func (d *EncryptedRemote) Has(ctx context.Context, hash block.ContentHash) (bool, error) {
-	cs, err := d.casInner()
-	if err != nil {
-		return false, err
-	}
-	_, err = cs.Head(ctx, hash)
-	if err == nil {
-		return true, nil
-	}
-	if errors.Is(err, block.ErrChunkNotFound) {
-		return false, nil
-	}
-	return false, err
+	return remote.SliceRange(full, offset, length)
 }
 
 // Head returns Meta whose Size is the plaintext byte length, derived
@@ -164,7 +142,7 @@ func (d *EncryptedRemote) Has(ctx context.Context, hash block.ContentHash) (bool
 // 16-byte authentication tag, so plaintext_size = wire_size -
 // header_size - aeadTagSize.
 func (d *EncryptedRemote) Head(ctx context.Context, hash block.ContentHash) (block.Meta, error) {
-	cs, err := d.casInner()
+	cs, err := remote.CASInner(d.Inner)
 	if err != nil {
 		return block.Meta{}, err
 	}
@@ -183,7 +161,7 @@ func (d *EncryptedRemote) Head(ctx context.Context, hash block.ContentHash) (blo
 // Walk rewrites Meta.Size to plaintext size for each block via the same
 // range-GET probe as Head. Per-block probe errors halt the walk.
 func (d *EncryptedRemote) Walk(ctx context.Context, fn func(hash block.ContentHash, meta block.Meta) error) error {
-	cs, err := d.casInner()
+	cs, err := remote.CASInner(d.Inner)
 	if err != nil {
 		return err
 	}
@@ -206,7 +184,7 @@ func (d *EncryptedRemote) plaintextSizeFor(ctx context.Context, hash block.Conte
 	if probeLen <= 0 {
 		return 0, ErrCiphertextWithoutFrame
 	}
-	cs, err := d.casInner()
+	cs, err := remote.CASInner(d.Inner)
 	if err != nil {
 		return 0, err
 	}
@@ -228,15 +206,6 @@ func (d *EncryptedRemote) plaintextSizeFor(ctx context.Context, hash block.Conte
 	return plain, nil
 }
 
-// Delete is a straight passthrough.
-func (d *EncryptedRemote) Delete(ctx context.Context, hash block.ContentHash) error {
-	cs, err := d.casInner()
-	if err != nil {
-		return err
-	}
-	return cs.Delete(ctx, hash)
-}
-
 // ReadChunk reads the chunk's encrypted wire bytes from the inner store's
 // block object and decrypts them against hash as the AEAD AAD, returning the
 // plaintext (for the next layer up / the engine). A block stores each chunk's
@@ -245,7 +214,7 @@ func (d *EncryptedRemote) Delete(ctx context.Context, hash block.ContentHash) er
 // standalone object. No verification here — the engine verifies the BLAKE3 after
 // the full stack. Implements remote.ChunkReader (#1414).
 func (d *EncryptedRemote) ReadChunk(ctx context.Context, blockID string, offset, length int64, hash block.ContentHash) ([]byte, error) {
-	pcr, ok := d.inner.(remote.ChunkReader)
+	pcr, ok := d.Inner.(remote.ChunkReader)
 	if !ok {
 		return nil, remote.ErrChunkReadUnsupported
 	}
@@ -258,102 +227,12 @@ func (d *EncryptedRemote) ReadChunk(ctx context.Context, blockID string, offset,
 
 // Close releases inner resources and the provider.
 func (d *EncryptedRemote) Close() error {
-	innerErr := d.inner.Close()
+	innerErr := d.Passthrough.Close()
 	provErr := d.provider.Close()
 	if innerErr != nil {
 		return innerErr
 	}
 	return provErr
-}
-
-func (d *EncryptedRemote) HealthCheck(ctx context.Context) error { return d.inner.HealthCheck(ctx) }
-
-func (d *EncryptedRemote) Healthcheck(ctx context.Context) health.Report {
-	return d.inner.Healthcheck(ctx)
-}
-
-// Durable delegates to the wrapped store via block.IsDurable. Encrypting block
-// bodies does not change where the bytes ultimately land, so a durable inner
-// store stays durable through the decorator; a wrapped store that does not
-// report durability falls back to the conservative default (false).
-func (d *EncryptedRemote) Durable() bool {
-	return block.IsDurable(d.inner)
-}
-
-// --- remote.RemoteBlockStore passthrough (#1414) ---
-//
-// Packed block objects carry per-chunk wire frames that were already sealed via
-// SealChunk; the assembled block must NOT be re-encrypted at the block level.
-// So every block-keyed operation passes through verbatim to the inner store.
-// This lets a decorated remote satisfy remote.RemoteBlockStore (the carve path
-// asserts it) while the per-chunk transform stays in SealChunk/ReadChunk.
-
-// blockInner returns the inner store as a remote.RemoteBlockStore, or an error
-// when the wrapped store does not support block-keyed objects.
-func (d *EncryptedRemote) blockInner() (remote.RemoteBlockStore, error) {
-	rbs, ok := d.inner.(remote.RemoteBlockStore)
-	if !ok {
-		return nil, remote.ErrChunkReadUnsupported
-	}
-	return rbs, nil
-}
-
-// casInner exposes the inner store's hash-keyed CAS surface (block.Store),
-// used only by the legacy standalone-CAS read path (block.Store methods +
-// ReadBlockVerified in legacy_cas_migration.go). Every shipped remote backend
-// and decorator implements block.Store, so the assertion succeeds in practice;
-// it returns an error rather than panicking for defense in depth.
-func (d *EncryptedRemote) casInner() (block.Store, error) {
-	cs, ok := d.inner.(block.Store)
-	if !ok {
-		return nil, remote.ErrChunkReadUnsupported
-	}
-	return cs, nil
-}
-
-// PutBlock stores the assembled block verbatim (already-sealed frames).
-func (d *EncryptedRemote) PutBlock(ctx context.Context, blockID string, r io.Reader) error {
-	rbs, err := d.blockInner()
-	if err != nil {
-		return err
-	}
-	return rbs.PutBlock(ctx, blockID, r)
-}
-
-// GetBlock returns the raw block object verbatim.
-func (d *EncryptedRemote) GetBlock(ctx context.Context, blockID string) ([]byte, error) {
-	rbs, err := d.blockInner()
-	if err != nil {
-		return nil, err
-	}
-	return rbs.GetBlock(ctx, blockID)
-}
-
-// GetBlockRange returns raw block bytes verbatim; per-chunk decrypt is ReadChunk.
-func (d *EncryptedRemote) GetBlockRange(ctx context.Context, blockID string, offset, length int64) ([]byte, error) {
-	rbs, err := d.blockInner()
-	if err != nil {
-		return nil, err
-	}
-	return rbs.GetBlockRange(ctx, blockID, offset, length)
-}
-
-// DeleteBlock removes the block object.
-func (d *EncryptedRemote) DeleteBlock(ctx context.Context, blockID string) error {
-	rbs, err := d.blockInner()
-	if err != nil {
-		return err
-	}
-	return rbs.DeleteBlock(ctx, blockID)
-}
-
-// WalkBlocks enumerates block objects.
-func (d *EncryptedRemote) WalkBlocks(ctx context.Context, fn func(blockID string, meta block.Meta) error) error {
-	rbs, err := d.blockInner()
-	if err != nil {
-		return err
-	}
-	return rbs.WalkBlocks(ctx, fn)
 }
 
 // decrypt parses the frame, unwraps the block key, and authenticated-

--- a/pkg/block/encryption/decorator_test.go
+++ b/pkg/block/encryption/decorator_test.go
@@ -310,3 +310,23 @@ func TestNewRemote_RejectsNilInputs(t *testing.T) {
 		t.Fatal("want error for unknown AEAD")
 	}
 }
+
+// TestGetRange_InvalidLengthOnAbsentBlock pins the order of the two checks: an
+// invalid length is rejected before the block is fetched, so a caller passing a
+// bad length learns that rather than being told the block is missing. Asserting
+// this needs a block that does not exist — when the block is present, a length
+// check placed after the fetch returns ErrInvalidSize just the same, and the
+// ordering goes untested.
+func TestGetRange_InvalidLengthOnAbsentBlock(t *testing.T) {
+	d, err := NewRemote(remotememory.New(), EncryptionPolicy{AEAD: AEADAES256GCM}, newProvider(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	absent := hashOf([]byte("never stored"))
+	for _, length := range []int64{0, -1, -1024} {
+		_, err := d.GetRange(context.Background(), absent, 0, length)
+		if !errors.Is(err, block.ErrInvalidSize) {
+			t.Errorf("length=%d: got %v, want wraps ErrInvalidSize", length, err)
+		}
+	}
+}

--- a/pkg/block/encryption/doc.go
+++ b/pkg/block/encryption/doc.go
@@ -2,8 +2,7 @@
 // encrypts block payloads before they leave the host and decrypts them
 // on the way back, preserving the BLAKE3-over-plaintext CAS key.
 //
-// The design is standard envelope encryption (matches AWS SSE-KMS
-// MinIO+KES, HashiCorp Vault Transit)
+// The design is standard envelope encryption:
 //
 //   - A master key is held by a [keyprovider.KeyProvider] (local key file
 //     or external KMIP HSM). The master key never directly encrypts a
@@ -13,6 +12,17 @@
 //     master key (the wrapped bytes live in the frame header).
 //   - On read: decode header → unwrap block key via the provider →
 //     authenticated-decrypt the payload.
+//
+// # Master-key rotation is not supported
+//
+// A provider holds exactly one master key and rejects any frame wrapped
+// under a different one, so changing a share's master key makes every
+// block written under the previous key permanently unreadable. Unlike
+// key-management services that keep retired key versions live for
+// decrypt, this package has no retired-key set and no re-wrap tooling.
+// Treat a share's master key as fixed for the life of its data; see
+// [github.com/marmos91/dittofs/pkg/block/encryption/keyprovider] for the
+// full behaviour.
 //
 // The decorator should sit BELOW any compression decorator: compress on
 // the way down, then encrypt; decrypt on the way up, then decompress.

--- a/pkg/block/encryption/keyprovider/kmip.go
+++ b/pkg/block/encryption/keyprovider/kmip.go
@@ -30,10 +30,13 @@ const kmipDefaultTimeout = 5 * time.Second
 // Trade-off vs full HSM-resident envelope ops (KMIP Encrypt / Decrypt)
 // the master-key bytes live in process memory while the daemon runs, so
 // a compromise of the daemon's address space recovers the key. The HSM
-// is still the canonical custodian — operators rotate by writing a new
-// key to the HSM and restarting the daemon. A follow-up can move Wrap
-// inside the HSM via KMIP Encrypt / Decrypt without changing this
-// package's public surface (the KeyProvider interface stays the same).
+// is still the canonical custodian. A follow-up can move Wrap inside the
+// HSM via KMIP Encrypt / Decrypt without changing this package's public
+// surface (the KeyProvider interface stays the same).
+//
+// Pointing KeyUID at a different HSM key does NOT rotate the master key:
+// only the newly fetched key is held, so every block wrapped under the
+// previous key becomes permanently unreadable. See the package doc.
 type kmipProvider struct {
 	aesGCMKEK
 }

--- a/pkg/block/encryption/keyprovider/provider.go
+++ b/pkg/block/encryption/keyprovider/provider.go
@@ -7,6 +7,22 @@
 // (KEK) and the per-block data key is a Data-Encryption-Key (DEK). The
 // plain names "master key" and "block key" are used throughout this
 // package's prose to keep the role of each thing obvious.
+//
+// # Master-key rotation is NOT supported
+//
+// Every implementation holds exactly one master key. There is no keyring
+// of retired keys: Unwrap returns ErrWrongMasterKey whenever the id
+// recorded in a block's frame header differs from the single id the
+// provider holds. Pointing a running share at a different master key
+// therefore makes every block wrapped under the previous one
+// permanently unreadable — there is no recovery path once the old key
+// is gone.
+//
+// Rotating safely would mean re-wrapping every existing block under the
+// new master key (read with a provider holding the old key, write with
+// one holding the new) and only decommissioning the old key once that
+// pass has completed. No such tool ships today, so treat a share's
+// master key as fixed for the life of its data.
 package keyprovider
 
 import (
@@ -23,14 +39,16 @@ type KeyProvider interface {
 	// Wrap protects a block key (typically 32 bytes) under the provider's
 	// master key. Returns the wrapped bytes plus the stable identifier of
 	// the master key used; the identifier is recorded in the on-wire
-	// frame header so Unwrap can route to the right master key after a
-	// future rotation.
+	// frame header so Unwrap can reject a block that was wrapped under a
+	// different master key instead of failing with an opaque
+	// authentication error.
 	Wrap(ctx context.Context, blockKey []byte) (wrapped []byte, masterKeyID string, err error)
 
 	// Unwrap recovers the original block key. masterKeyID is the value
-	// recorded by an earlier Wrap; single-key providers may ignore it.
-	// Returns ErrWrongMasterKey if the recorded id does not match any
-	// master key this provider knows about.
+	// recorded by an earlier Wrap. Every implementation holds exactly one
+	// master key, so Unwrap returns ErrWrongMasterKey whenever the
+	// recorded id is not that one; blocks wrapped under any other key
+	// cannot be recovered (see the package doc on rotation).
 	Unwrap(ctx context.Context, wrapped []byte, masterKeyID string) ([]byte, error)
 
 	// CurrentMasterKeyID returns the identifier that Wrap will record.

--- a/pkg/block/encryption/legacy_cas_migration.go
+++ b/pkg/block/encryption/legacy_cas_migration.go
@@ -31,11 +31,6 @@ func (d *EncryptedRemote) ReadLegacyChunkVerified(ctx context.Context, hash bloc
 	return d.ReadBlockVerified(ctx, hash, hash)
 }
 
-// DeleteLegacyChunk implements remote.LegacyCASStore.
-func (d *EncryptedRemote) DeleteLegacyChunk(ctx context.Context, hash block.ContentHash) error {
-	return d.Delete(ctx, hash)
-}
-
 // ReadBlockVerified GETs the standalone object, decrypts it, then re-verifies
 // the BLAKE3 hash over the plaintext.
 func (d *EncryptedRemote) ReadBlockVerified(ctx context.Context, hash block.ContentHash, expected block.ContentHash) ([]byte, error) {

--- a/pkg/block/remote/doc.go
+++ b/pkg/block/remote/doc.go
@@ -1,9 +1,0 @@
-// Package remote defines the RemoteStore interface for durable block storage
-// backends (S3, filesystem, memory).
-//
-// RemoteStore provides low-level block operations (read, write, delete, list)
-// against a persistent storage backend. Blocks are immutable chunks of data
-// (up to BlockSize) stored with a string key.
-//
-// Key format: "{payloadID}/block-{blockIdx}"
-package remote

--- a/pkg/block/remote/memory/store_test.go
+++ b/pkg/block/remote/memory/store_test.go
@@ -17,8 +17,8 @@ import (
 
 // TestStore_BlockStoreConformance runs the unified
 // BlockStoreConformance suite against the in-memory remote backend.
-// Per the remote backends implement only BlockStore (no
-// BlockStoreAppend); only BlockStoreConformance runs here.
+// The remote backends expose the hash-keyed Store surface only behind
+// the legacy-CAS path, so BlockStoreConformance runs here.
 //
 // The inline TestStore_* tests below remain in place as a fine-grained
 // per-method baseline (data-isolation defensive copies, closed-store

--- a/pkg/block/remote/passthrough.go
+++ b/pkg/block/remote/passthrough.go
@@ -80,9 +80,13 @@ func SliceRange(full []byte, offset, length int64) ([]byte, error) {
 	if offset < 0 || offset > int64(len(full)) {
 		return nil, fmt.Errorf("%w: offset %d out of bounds (size %d)", block.ErrInvalidOffset, offset, len(full))
 	}
-	end := min(offset+length, int64(len(full)))
-	out := make([]byte, end-offset)
-	copy(out, full[offset:end])
+	// Clamp the count rather than the end offset: offset+length overflows for a
+	// large length and wraps negative, which would size the copy negatively.
+	// offset is already bounded by len(full), so the remaining count cannot go
+	// negative and offset+n cannot exceed len(full).
+	n := min(length, int64(len(full))-offset)
+	out := make([]byte, n)
+	copy(out, full[offset:offset+n])
 	return out, nil
 }
 

--- a/pkg/block/remote/passthrough.go
+++ b/pkg/block/remote/passthrough.go
@@ -1,0 +1,177 @@
+package remote
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/health"
+)
+
+// Passthrough forwards the parts of the RemoteStore surface that a
+// per-chunk transform decorator does not touch straight through to the
+// store it wraps. Decorators embed it and override only the operations
+// their transform actually changes.
+//
+// The block-keyed operations forward verbatim by design: a packed block
+// object carries per-chunk wire bodies that were already transformed by
+// SealChunk, so the assembled block must NOT be transformed again at the
+// block level. Forwarding them here is what lets a decorated store
+// satisfy RemoteBlockStore (the carve path asserts it) while the
+// transform stays confined to SealChunk / ReadChunk.
+//
+// Close, HealthCheck, Healthcheck and Durable forward because a
+// transform changes the shape of the bytes, not where they land or
+// whether the backend is reachable. Has and Delete forward because both
+// key off the content hash, which a transform leaves unchanged.
+type Passthrough struct {
+	// Inner is the wrapped store. Decorators read it directly to reach
+	// capabilities their transform participates in (ChunkReader,
+	// ChunkSealer).
+	Inner RemoteStore
+}
+
+// blockInner returns the inner store as a RemoteBlockStore, or an error
+// when the wrapped store does not support block-keyed objects.
+func (p Passthrough) blockInner() (RemoteBlockStore, error) {
+	rbs, ok := p.Inner.(RemoteBlockStore)
+	if !ok {
+		return nil, ErrChunkReadUnsupported
+	}
+	return rbs, nil
+}
+
+// CASInner exposes s's hash-keyed CAS surface (block.Store), used only by
+// the legacy standalone-CAS read path (block.Store methods +
+// ReadBlockVerified in each decorator's legacy_cas_migration.go). Every
+// shipped remote backend and decorator implements block.Store, so the
+// assertion succeeds in practice; it returns an error rather than
+// panicking for defense in depth.
+//
+// A plain function rather than a method on Passthrough: promoting it
+// would put an exported handle on the untransformed CAS surface into
+// every decorator's public method set.
+func CASInner(s RemoteStore) (block.Store, error) {
+	cs, ok := s.(block.Store)
+	if !ok {
+		return nil, ErrChunkReadUnsupported
+	}
+	return cs, nil
+}
+
+// SliceRange returns [offset, offset+length) of full, clamped to its end.
+// Used by decorators whose transform has no random access into the stored
+// wire bytes: they materialise the whole plaintext, then slice it here so
+// the bounds contract cannot drift between them. Callers reject a
+// non-positive length before fetching, so reaching that branch here means
+// the caller skipped its own guard.
+func SliceRange(full []byte, offset, length int64) ([]byte, error) {
+	if length <= 0 {
+		return nil, fmt.Errorf("%w: length %d", block.ErrInvalidSize, length)
+	}
+	if offset < 0 || offset > int64(len(full)) {
+		return nil, fmt.Errorf("%w: offset %d out of bounds (size %d)", block.ErrInvalidOffset, offset, len(full))
+	}
+	end := min(offset+length, int64(len(full)))
+	out := make([]byte, end-offset)
+	copy(out, full[offset:end])
+	return out, nil
+}
+
+// PutBlock stores the assembled block verbatim (already-sealed bodies).
+func (p Passthrough) PutBlock(ctx context.Context, blockID string, r io.Reader) error {
+	rbs, err := p.blockInner()
+	if err != nil {
+		return err
+	}
+	return rbs.PutBlock(ctx, blockID, r)
+}
+
+// GetBlock returns the raw block object verbatim.
+func (p Passthrough) GetBlock(ctx context.Context, blockID string) ([]byte, error) {
+	rbs, err := p.blockInner()
+	if err != nil {
+		return nil, err
+	}
+	return rbs.GetBlock(ctx, blockID)
+}
+
+// GetBlockRange returns raw block bytes verbatim; the per-chunk inverse
+// transform is ReadChunk.
+func (p Passthrough) GetBlockRange(ctx context.Context, blockID string, offset, length int64) ([]byte, error) {
+	rbs, err := p.blockInner()
+	if err != nil {
+		return nil, err
+	}
+	return rbs.GetBlockRange(ctx, blockID, offset, length)
+}
+
+// DeleteBlock removes the block object.
+func (p Passthrough) DeleteBlock(ctx context.Context, blockID string) error {
+	rbs, err := p.blockInner()
+	if err != nil {
+		return err
+	}
+	return rbs.DeleteBlock(ctx, blockID)
+}
+
+// WalkBlocks enumerates block objects.
+func (p Passthrough) WalkBlocks(ctx context.Context, fn func(blockID string, meta block.Meta) error) error {
+	rbs, err := p.blockInner()
+	if err != nil {
+		return err
+	}
+	return rbs.WalkBlocks(ctx, fn)
+}
+
+// Has reports presence by probing inner.Head. NotFound errors map to
+// (false, nil); any other backend error propagates.
+func (p Passthrough) Has(ctx context.Context, hash block.ContentHash) (bool, error) {
+	cs, err := CASInner(p.Inner)
+	if err != nil {
+		return false, err
+	}
+	if _, err := cs.Head(ctx, hash); err != nil {
+		if errors.Is(err, block.ErrChunkNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// Delete removes the standalone object keyed by hash.
+func (p Passthrough) Delete(ctx context.Context, hash block.ContentHash) error {
+	cs, err := CASInner(p.Inner)
+	if err != nil {
+		return err
+	}
+	return cs.Delete(ctx, hash)
+}
+
+// DeleteLegacyChunk implements LegacyCASStore. The legacy standalone
+// object is keyed by the plaintext hash, which no transform changes, so
+// this is the same removal as Delete.
+func (p Passthrough) DeleteLegacyChunk(ctx context.Context, hash block.ContentHash) error {
+	return p.Delete(ctx, hash)
+}
+
+// Close releases inner resources. A decorator holding resources of its
+// own overrides this and closes both.
+func (p Passthrough) Close() error { return p.Inner.Close() }
+
+// HealthCheck delegates to inner.
+func (p Passthrough) HealthCheck(ctx context.Context) error { return p.Inner.HealthCheck(ctx) }
+
+// Healthcheck delegates to inner.
+func (p Passthrough) Healthcheck(ctx context.Context) health.Report {
+	return p.Inner.Healthcheck(ctx)
+}
+
+// Durable delegates to the wrapped store via block.IsDurable. Transforming
+// block bodies does not change where the bytes ultimately land, so a durable
+// inner store stays durable through a decorator; a wrapped store that does not
+// report durability falls back to the conservative default (false).
+func (p Passthrough) Durable() bool { return block.IsDurable(p.Inner) }

--- a/pkg/block/remote/passthrough.go
+++ b/pkg/block/remote/passthrough.go
@@ -27,16 +27,22 @@ import (
 // whether the backend is reachable. Has and Delete forward because both
 // key off the content hash, which a transform leaves unchanged.
 type Passthrough struct {
-	// Inner is the wrapped store. Decorators read it directly to reach
-	// capabilities their transform participates in (ChunkReader,
-	// ChunkSealer).
-	Inner RemoteStore
+	// inner is the wrapped store. It stays unexported so that embedding
+	// Passthrough cannot promote a handle to the untransformed store into a
+	// decorator's public surface: a caller holding that handle could read and
+	// write bytes straight past the transform. Decorators that need the store
+	// to reach a capability their transform participates in (ChunkReader,
+	// ChunkSealer) keep their own reference.
+	inner RemoteStore
 }
+
+// NewPassthrough builds a Passthrough forwarding to inner.
+func NewPassthrough(inner RemoteStore) Passthrough { return Passthrough{inner: inner} }
 
 // blockInner returns the inner store as a RemoteBlockStore, or an error
 // when the wrapped store does not support block-keyed objects.
 func (p Passthrough) blockInner() (RemoteBlockStore, error) {
-	rbs, ok := p.Inner.(RemoteBlockStore)
+	rbs, ok := p.inner.(RemoteBlockStore)
 	if !ok {
 		return nil, ErrChunkReadUnsupported
 	}
@@ -129,7 +135,7 @@ func (p Passthrough) WalkBlocks(ctx context.Context, fn func(blockID string, met
 // Has reports presence by probing inner.Head. NotFound errors map to
 // (false, nil); any other backend error propagates.
 func (p Passthrough) Has(ctx context.Context, hash block.ContentHash) (bool, error) {
-	cs, err := CASInner(p.Inner)
+	cs, err := CASInner(p.inner)
 	if err != nil {
 		return false, err
 	}
@@ -144,7 +150,7 @@ func (p Passthrough) Has(ctx context.Context, hash block.ContentHash) (bool, err
 
 // Delete removes the standalone object keyed by hash.
 func (p Passthrough) Delete(ctx context.Context, hash block.ContentHash) error {
-	cs, err := CASInner(p.Inner)
+	cs, err := CASInner(p.inner)
 	if err != nil {
 		return err
 	}
@@ -160,18 +166,18 @@ func (p Passthrough) DeleteLegacyChunk(ctx context.Context, hash block.ContentHa
 
 // Close releases inner resources. A decorator holding resources of its
 // own overrides this and closes both.
-func (p Passthrough) Close() error { return p.Inner.Close() }
+func (p Passthrough) Close() error { return p.inner.Close() }
 
 // HealthCheck delegates to inner.
-func (p Passthrough) HealthCheck(ctx context.Context) error { return p.Inner.HealthCheck(ctx) }
+func (p Passthrough) HealthCheck(ctx context.Context) error { return p.inner.HealthCheck(ctx) }
 
 // Healthcheck delegates to inner.
 func (p Passthrough) Healthcheck(ctx context.Context) health.Report {
-	return p.Inner.Healthcheck(ctx)
+	return p.inner.Healthcheck(ctx)
 }
 
 // Durable delegates to the wrapped store via block.IsDurable. Transforming
 // block bodies does not change where the bytes ultimately land, so a durable
 // inner store stays durable through a decorator; a wrapped store that does not
 // report durability falls back to the conservative default (false).
-func (p Passthrough) Durable() bool { return block.IsDurable(p.Inner) }
+func (p Passthrough) Durable() bool { return block.IsDurable(p.inner) }

--- a/pkg/block/remote/passthrough_test.go
+++ b/pkg/block/remote/passthrough_test.go
@@ -1,0 +1,53 @@
+package remote
+
+import (
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+)
+
+// TestSliceRangeHugeLengthDoesNotPanic covers the arithmetic rather than the
+// contract: a length near MaxInt64 makes offset+length wrap negative, and sizing
+// the copy from that wrapped value panics before any error can be returned. A
+// non-zero offset is required — at offset 0 the sum still fits.
+func TestSliceRangeHugeLengthDoesNotPanic(t *testing.T) {
+	full := []byte("0123456789")
+	for _, tc := range []struct {
+		name           string
+		offset, length int64
+		want           string
+	}{
+		{"max length at nonzero offset", 1, math.MaxInt64, "123456789"},
+		{"max length at zero offset", 0, math.MaxInt64, "0123456789"},
+		{"max length at final offset", int64(len(full)), math.MaxInt64, ""},
+		{"length past end clamps", 6, 100, "6789"},
+		{"exact tail", 6, 4, "6789"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := SliceRange(full, tc.offset, tc.length)
+			if err != nil {
+				t.Fatalf("SliceRange(%d, %d): %v", tc.offset, tc.length, err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSliceRangeRejectsInvalidInput keeps the two guards ahead of the copy.
+func TestSliceRangeRejectsInvalidInput(t *testing.T) {
+	full := []byte("0123456789")
+	for _, length := range []int64{0, -1, math.MinInt64} {
+		if _, err := SliceRange(full, 0, length); !errors.Is(err, block.ErrInvalidSize) {
+			t.Errorf("length=%d: got %v, want wraps ErrInvalidSize", length, err)
+		}
+	}
+	for _, offset := range []int64{-1, int64(len(full)) + 1} {
+		if _, err := SliceRange(full, offset, 4); !errors.Is(err, block.ErrInvalidOffset) {
+			t.Errorf("offset=%d: got %v, want wraps ErrInvalidOffset", offset, err)
+		}
+	}
+}

--- a/pkg/block/remote/s3/store_test.go
+++ b/pkg/block/remote/s3/store_test.go
@@ -46,7 +46,7 @@ func TestNormalizeEndpoint(t *testing.T) {
 // path. CI wires Localstack; local developers may run with `make
 // e2e-s3` or by exporting the env directly.
 //
-// Per the S3 backend does NOT implement BlockStoreAppend; only
+// The S3 backend is hash-keyed only behind the legacy-CAS path, so
 // BlockStoreConformance runs here. The x-amz-meta-content-hash
 // header round-trip is exercised by verifier_test.go (the header is an
 // fs-internal defense-in-depth marker and is not part of the unified


### PR DESCRIPTION
Closes the MED-severity findings scoped to the block-store decorator layer from the 2026-08-05 data-plane audit.

## 1. Shared decorator passthrough

`EncryptedRemote` (`pkg/block/encryption`) and `Decorator` (`pkg/block/compression`) carried ~150 lines of plumbing that was byte-identical apart from the receiver name — the block-keyed forwards, the CAS/block inner assertions, `Has`, `Delete`, `DeleteLegacyChunk`, `Close`, `HealthCheck`, `Healthcheck`, `Durable`, and `GetRange`.

That plumbing now lives once in `remote.Passthrough`, an embeddable struct in the new `pkg/block/remote/passthrough.go`, alongside two package-level helpers:

- `remote.CASInner(s)` — a function rather than a method, so embedding does not put an exported handle on the untransformed CAS surface into either decorator's public method set.
- `remote.SliceRange(full, offset, length)` — the shared bounds/clamp contract, so the two `GetRange` error contracts can no longer drift apart. The conformance suite asserts those sentinels for both decorators.

Each decorator now keeps only what its transform actually changes: `Put`, `Get`, `GetRange`, `Head`, `Walk`, `SealChunk`, `ReadChunk`, `sealLayer`. Encryption still overrides `Close` so it closes its key provider as well as the inner store; compression inherits the forward, having no store-level resource of its own.

The exported method sets of both decorators are unchanged — verified by reflecting over both types on this branch and on `develop` and diffing the results.

## 2. Dead `block.BlockStoreAppend` contract

`block.BlockStoreAppend` had zero implementations and zero consumers, and its godoc asserted that `pkg/block/local/fs.FSStore` implemented it. It does not: `FSStore` is payload-keyed (`WriteAt` / `ReadAt` / `Hydrate` / `Commit`) and satisfies neither `BlockStoreAppend` nor `block.Store`. `blockstoretest` also documented a `BlockStoreAppendConformance` entrypoint that was never written.

The interface is deleted and the claims that repeated it are corrected across `pkg/block/blockstore.go`, `pkg/block/doc.go`, `pkg/block/blockstoretest/`, `docs/internals/contributing.md`, `docs/internals/implementing-stores.md`, and the store-contract rule in `CLAUDE.md`.

Also removed: `pkg/block/remote/doc.go`, a second `// Package remote` comment that contradicted the accurate one in `remote.go` on both the backend list (it named a filesystem remote that does not exist) and the key format.

Two more comments that were false on every claim they made are cut back to what is true — the `blake3Sum` provenance note in `blockstoretest/conformance.go` cited a file, a symbol, and a caller that all do not exist.

## 3. Master-key rotation documented truthfully

Every `KeyProvider` holds exactly one master key. `Unwrap` returns `ErrWrongMasterKey` whenever a frame's recorded key id is not that one, and there is no keyring of retired keys. An operator following the rotation procedure previously documented in the KMIP provider — write a new key, restart — would permanently orphan every block wrapped under the old key. `docs/internals/encryption-design.md` compounded it by stating outright that "existing blocks remain decryptable", and the package docs claimed parity with key-management services that keep retired key versions decryptable.

This PR makes the documentation truthful rather than implementing rotation: the rotation procedure and the parity claim are removed, and the package docs, the design doc, and the KMIP provider now state plainly that rotation is unsupported and that changing a share's master key destroys access to everything already written under the old one.

Implementing the retired-key map is deliberately out of scope — the config surface (how retired keys are supplied, identified, and retained) is an open design question. Tracked separately.

Relates to #1944

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l .` — all clean
- `go test ./...` — full suite green
- `go test -race` on `pkg/block`, `pkg/block/compression`, `pkg/block/encryption/...`, `pkg/block/remote/...` — green
- `blockstoretest.BlockStoreConformance` still runs against both decorators (all three AEADs, both compression algorithms) and both remote backends; `RemoteBlockStoreConformance` still runs against the memory and s3 backends
- Exported method sets of both decorators diffed against `develop`: identical

No Cobra command or flag changed, so `docs/guide/cli.md` is untouched.
