### PR TITLE
refactor(metadata): reuse quota.Delta for the memory restore reseed

### DIFF
--- a/pkg/metadata/store/memory/snapshot_store.go
+++ b/pkg/metadata/store/memory/snapshot_store.go
@@ -14,6 +14,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/backup"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
+	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
 )
 
 const (
@@ -408,40 +409,24 @@ func (s *MemoryMetadataStore) RestoreSnapshot(ctx context.Context, r io.Reader) 
 
 	// Re-initialize transient state.
 	s.sessions = make(map[string]*ShareSession)
-	groupUsage := make(map[uint32]*metadata.UsageStat)
-	userUsage := make(map[uint32]*metadata.UsageStat)
 
-	// Recompute usedBytes from files (only regular files count)
-	// and reconstruct the quota cache from the restored files
-	// since UNIX/NFS stores based on user and group, we need to aggregate the usage stats for each user and group.
+	// Recompute both usage mirrors from the restored regular files: the
+	// store-wide byte total and the per-owner buckets the quota cache serves.
+	// A cache left at its pre-restore contents reports usage for files that
+	// no longer exist.
 	var totalBytes int64
+	var usage quota.Delta
 	for _, fd := range s.files {
 		if fd.Attr != nil && fd.Attr.Type == metadata.FileTypeRegular {
 			totalBytes += int64(fd.Attr.Size)
-
-			u := userUsage[fd.Attr.UID]
-			if u == nil {
-				u = &metadata.UsageStat{}
-				userUsage[fd.Attr.UID] = u
-			}
-
-			u.Bytes += int64(fd.Attr.Size)
-			u.Files++
-
-			g := groupUsage[fd.Attr.GID]
-			if g == nil {
-				g = &metadata.UsageStat{}
-				groupUsage[fd.Attr.GID] = g
-			}
-
-			g.Bytes += int64(fd.Attr.Size)
-			g.Files++
+			usage.Add(fd.Attr.UID, fd.Attr.GID, int64(fd.Attr.Size), 1)
 		}
 	}
 	s.usedBytes.Store(totalBytes)
 
 	s.quotaMu.Lock()
-	s.quota.Seed(userUsage, groupUsage)
+	s.quota.Reset()
+	s.quota.Apply(usage.Map())
 	s.quotaMu.Unlock()
 
 	return nil

--- a/pkg/metadata/storetest/reset_conformance.go
+++ b/pkg/metadata/storetest/reset_conformance.go
@@ -53,9 +53,9 @@ func ResetThenRestoreConformance(t *testing.T, factory SnapshotableStoreFactory)
 		t.Fatalf("Reset: %v", err)
 	}
 
-	// Quota assertion: Reset must clear the per-identity cache, not just the
-	// share/file maps. A stale cache here would silently keep enforcing
-	// limits against data that no longer exists.
+	// Reset must clear the per-identity quota cache too, not just the
+	// share/file maps: a stale cache keeps enforcing limits against data
+	// that no longer exists.
 	if u, err := store.GetQuotaUsage(metadata.QuotaScopeUser, 1000); err != nil || u.Bytes != 0 || u.Files != 0 {
 		t.Fatalf("post-Reset GetQuotaUsage(user, 1000) = %+v, err=%v, want zero", u, err)
 	}
@@ -76,9 +76,9 @@ func ResetThenRestoreConformance(t *testing.T, factory SnapshotableStoreFactory)
 		t.Fatalf("Restore post-Reset: %v", err)
 	}
 
-	// Quota assertion: Restore must reseed the cache from the restored files,
-	// not leave it at the post-Reset zero state.
-	const wantBytes = PopulateTestDataUsedBytes // 14 MiB total
+	// Restore must reseed the quota cache from the restored files, not leave
+	// it at the post-Reset zero state.
+	const wantBytes = populateTestDataUsedBytes
 	if u, err := store.GetQuotaUsage(metadata.QuotaScopeUser, 1000); err != nil || u.Bytes != wantBytes || u.Files != 2 {
 		t.Fatalf("post-Restore GetQuotaUsage(user, 1000) = %+v, err=%v, want {Bytes:%d Files:2}", u, err, wantBytes)
 	}

--- a/pkg/metadata/storetest/snapshot_conformance.go
+++ b/pkg/metadata/storetest/snapshot_conformance.go
@@ -73,30 +73,25 @@ func RunSnapshotConformanceSuite(t *testing.T, factory SnapshotableStoreFactory)
 		testSnapshot_ExcludesUnlinkedFileChunks(t, factory)
 	})
 
-	t.Run("UsedBytesAfterRestore", func(t *testing.T) {
-		testSnapshot_UsedBytesAfterRestore(t, factory)
-	})
-
-	t.Run("QuotaUsageAfterRestore", func(t *testing.T) {
-		testSnapshot_QuotaUsageAfterRestore(t, factory)
+	t.Run("UsageCountersAfterRestore", func(t *testing.T) {
+		testSnapshot_UsageCountersAfterRestore(t, factory)
 	})
 }
 
-// testSnapshot_UsedBytesAfterRestore pins the quota-counter invariant: after
-// Restore the in-memory usedBytes counter MUST reflect the restored regular-file
-// bytes, not the destination's pre-restore value. GetUsedBytes feeds the quota
-// guard in metadata/io.go; a stale 0 (the value a freshly-opened store holds on
-// an empty DB) silently disables quota enforcement until the process restarts.
-// The postgres restore path failed to recompute the counter; memory and badger
-// recompute it. This conformance test catches the divergence for every backend.
-func testSnapshot_UsedBytesAfterRestore(t *testing.T, factory SnapshotableStoreFactory) {
+// testSnapshot_UsageCountersAfterRestore pins both usage mirrors: after
+// Restore the store-wide usedBytes counter AND the per-identity quota cache
+// MUST reflect the restored regular files, not the destination's pre-restore
+// values. GetUsedBytes feeds the quota guard in metadata/io.go and
+// GetQuotaUsage feeds per-user/per-group enforcement; a stale 0 (the value a
+// freshly-opened store holds on an empty DB) silently disables enforcement
+// until the process restarts.
+func testSnapshot_UsageCountersAfterRestore(t *testing.T, factory SnapshotableStoreFactory) {
 	srcStore := factory(t)
 	srcB := asSnapshotable(t, srcStore)
 	ctx := t.Context()
 
-	// populateTestData writes two regular files of 8 MiB and 6 MiB.
 	populateTestData(t, srcStore, "ub")
-	const wantBytes = PopulateTestDataUsedBytes
+	const wantBytes = populateTestDataUsedBytes
 
 	if got := srcStore.GetUsedBytes(); got != wantBytes {
 		t.Fatalf("source GetUsedBytes() = %d, want %d (fixture sanity)", got, wantBytes)
@@ -107,7 +102,7 @@ func testSnapshot_UsedBytesAfterRestore(t *testing.T, factory SnapshotableStoreF
 		t.Fatalf("Snapshot: %v", err)
 	}
 
-	// Restore into a fresh store, whose usedBytes counter starts at 0.
+	// Restore into a fresh store, whose usage counters start at 0.
 	dstStore := factory(t)
 	dstB := asSnapshotable(t, dstStore)
 	if err := dstB.RestoreSnapshot(ctx, &buf); err != nil {
@@ -115,7 +110,18 @@ func testSnapshot_UsedBytesAfterRestore(t *testing.T, factory SnapshotableStoreF
 	}
 
 	if got := dstStore.GetUsedBytes(); got != wantBytes {
-		t.Fatalf("restored GetUsedBytes() = %d, want %d — restore did not recompute the quota counter", got, wantBytes)
+		t.Errorf("restored GetUsedBytes() = %d, want %d — restore did not recompute the store-wide counter", got, wantBytes)
+	}
+
+	for _, scope := range []metadata.QuotaScope{metadata.QuotaScopeUser, metadata.QuotaScopeGroup} {
+		got, err := dstStore.GetQuotaUsage(scope, 1000)
+		if err != nil {
+			t.Fatalf("GetQuotaUsage(%v, 1000): %v", scope, err)
+		}
+		if got.Bytes != wantBytes || got.Files != 2 {
+			t.Errorf("restored GetQuotaUsage(%v, 1000) = %+v, want {Bytes:%d Files:2} — restore did not reseed the quota cache",
+				scope, got, wantBytes)
+		}
 	}
 }
 
@@ -267,12 +273,10 @@ func asSnapshotable(t *testing.T, store metadata.Store) metadata.Snapshotable {
 	return b
 }
 
-// PopulateTestDataUsedBytes is the total logical size (8 MiB + 6 MiB) of the
-// two regular files populateTestData creates, the single source of truth
-// for assertions that depend on that fixture's size, so a future change to
-// the fixture can't silently leave a stale assertion passing for the wrong
-// reason.
-const PopulateTestDataUsedBytes = int64((8 << 20) + (6 << 20))
+// populateTestDataUsedBytes is the total logical size of the two regular
+// files populateTestData creates (8 MiB + 6 MiB); both are owned by
+// uid/gid 1000.
+const populateTestDataUsedBytes = int64((8 << 20) + (6 << 20))
 
 // populateTestData creates a share with two files carrying ChunkRef hashes.
 // Returns the share name and the list of unique hashes used.
@@ -871,44 +875,5 @@ func testSnapshot_HashSet_Dedup(t *testing.T, factory SnapshotableStoreFactory) 
 	}
 	if !gotHS.Contains(sharedHash) {
 		t.Fatalf("HashSet does not contain the shared hash %x", sharedHash[:8])
-	}
-}
-
-// testSnapshot_QuotaUsageAfterRestore pins the same invariant as
-// UsedBytesAfterRestore, but for the per-identity quota cache: after Restore,
-// GetQuotaUsage for the fixture's owner (uid/gid 1000) MUST reflect the
-// restored files, not a stale or zeroed cache. A backend that recomputes
-// usedBytes but not quota (or that Resets the quota cache instead of
-// reseeding it) passes UsedBytesAfterRestore while silently disabling
-// per-identity quota enforcement this test catches that divergence.
-func testSnapshot_QuotaUsageAfterRestore(t *testing.T, factory SnapshotableStoreFactory) {
-	srcStore := factory(t)
-	srcB := asSnapshotable(t, srcStore)
-	ctx := t.Context()
-
-	populateTestData(t, srcStore, "qb")
-	const wantBytes = PopulateTestDataUsedBytes // 14 MiB
-	const wantFiles = int64(2)
-
-	var buf bytes.Buffer
-	if _, err := srcB.WriteSnapshot(ctx, &buf); err != nil {
-		t.Fatalf("Snapshot: %v", err)
-	}
-
-	dstStore := factory(t)
-	dstB := asSnapshotable(t, dstStore)
-	if err := dstB.RestoreSnapshot(ctx, &buf); err != nil {
-		t.Fatalf("Restore: %v", err)
-	}
-
-	for _, scope := range []metadata.QuotaScope{metadata.QuotaScopeUser, metadata.QuotaScopeGroup} {
-		got, err := dstStore.GetQuotaUsage(scope, 1000)
-		if err != nil {
-			t.Fatalf("GetQuotaUsage(%v, 1000): %v", scope, err)
-		}
-		if got.Bytes != wantBytes || got.Files != wantFiles {
-			t.Fatalf("restored GetQuotaUsage(%v, 1000) = %+v, want {Bytes:%d Files:%d}",
-				scope, got, wantBytes, wantFiles)
-		}
 	}
 }


### PR DESCRIPTION
Two cleanups written on top of the #1883 rebase. #1883 merged from its original
pre-rebase head, so these did not land with it. No behaviour change.

## Reuse quota.Delta for the memory restore reseed

`RestoreSnapshot` hand-rolled the per-owner aggregation into two
`map[uint32]*metadata.UsageStat`, one for users and one for groups, then handed
both to `quota.Cache.Seed`. `quota.Delta` already does that double-bucketing:
`Add(uid, gid, bytes, files)` accumulates into both scopes at once. The loop now
accumulates into a `Delta` and folds it in with `Reset` + `Apply`.

`Seed` and `Reset`+`Apply` are different primitives, so the equivalence is worth
stating. For the inputs this call site can produce they agree:

- `Delta.Add`'s no-op guard cannot fire — `files` is the literal 1 on every call,
  so a zero-byte regular file still contributes `Files:1, Bytes:0`, matching the
  old unconditional `u.Files++`.
- `Reset` empties both maps, and `Apply` creates a fresh `UsageStat` for any key
  not yet present, which is what the old code did when building the maps from
  nothing.
- `Apply`'s negative clamp and delete-on-zero branches are unreachable here:
  every accumulated value is non-negative and any key present has `Files >= 1`,
  so no bucket can round to zero and be dropped. Those branches exist for the
  transactional-delta callers, not for restore.
- The `FileTypeRegular` guard is unchanged, so non-regular files are excluded
  identically.

## Fold two cloned conformance subtests

`QuotaUsageAfterRestore` was a line-for-line clone of `UsedBytesAfterRestore` —
same populate, snapshot and restore cycle, different assertions at the end. They
are now one `UsageCountersAfterRestore` asserting both, which saves a full
snapshot/restore cycle per backend. Every assertion from both originals is
preserved; the only change is that they share one fixture populate instead of
two, and `populateTestDataUsedBytes` is unexported now that nothing outside the
package refers to it.

## Verification

`gofmt`, `go build ./...`, `go vet ./...` clean. `go test -race` green on
`pkg/metadata/store/memory` and `pkg/metadata/storetest`.

Relates to #1883
