### PR TITLE
fix(block): journal reclaim/recovery correctness and local-store cleanups

### DIFF
--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -329,8 +329,9 @@ Under disk pressure the journal evicts whole **fully-synced** segments
 approx-LRU; only ranges already carved to the remote qualify, so eviction
 never destroys the only copy of dirty bytes. Eviction is health-gated: while
 the remote is unhealthy, cold-marking a range would strand unrecoverable
-bytes, so eviction is paused. There is no pin/ttl/lru retention knob
-(`SetRetentionPolicy` is a no-op on the journal-native store).
+bytes, so eviction is paused. The journal-native store has no pin/ttl/lru
+retention knob; only the pin/non-pin distinction reaches it, as the switch that
+enables or disables eviction.
 
 The journal's own garbage collection (repack) only relocates live cache bytes
 between local segments to reclaim dead space — it **never** touches the remote

--- a/docs/internals/implementing-stores.md
+++ b/docs/internals/implementing-stores.md
@@ -457,8 +457,7 @@ type LocalStore interface {
     UnsyncedBytes() int64
     Evict(ctx context.Context, targetBytes int64) (journal.EvictResult, error)
     SetEvictionEnabled(enabled bool)
-    // ... plus lifecycle (Start, Close), Stats, Healthcheck, and a
-    // no-op SetRetentionPolicy retained for admin-path compatibility.
+    // ... plus lifecycle (Start, Close), Stats, and Healthcheck.
 }
 ```
 

--- a/pkg/block/blockstore.go
+++ b/pkg/block/blockstore.go
@@ -164,7 +164,7 @@ type Store interface {
 //
 // Note: the narrowed LocalStore interface that lands keeps
 // additional lifecycle / admin methods (Truncate, EvictMemory
-// SetRetentionPolicy, SetEvictionEnabled, Stats, ListFiles
+// SetEvictionEnabled, Stats, ListFiles
 // GetStoredFileSize, Healthcheck, SyncFileChunks, SyncFileChunksForFile
 // Flush, Start, Close) as a strict admin-superset of BlockStoreAppend.
 // Those methods belong on LocalStore (boot-path / observability /

--- a/pkg/block/engine/api_accessors_test.go
+++ b/pkg/block/engine/api_accessors_test.go
@@ -3,9 +3,7 @@ package engine
 import (
 	"context"
 	"testing"
-	"time"
 
-	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/health"
 )
 
@@ -75,13 +73,10 @@ func TestStore_Accessors(t *testing.T) {
 	_ = bs.LocalStats()
 }
 
-// TestStore_RetentionAndEvictionSetters exercises the delegating setters
-// (they must not panic and must accept valid policies).
-func TestStore_RetentionAndEvictionSetters(t *testing.T) {
+// TestStore_EvictionSetter exercises the delegating setter (it must not panic).
+func TestStore_EvictionSetter(t *testing.T) {
 	bs := newTestEngine(t, 64*1024*1024, 0)
 
-	bs.SetRetentionPolicy(block.RetentionLRU, time.Hour)
-	bs.SetRetentionPolicy(block.RetentionPin, 0)
 	bs.SetEvictionEnabled(true)
 	bs.SetEvictionEnabled(false)
 }

--- a/pkg/block/engine/health.go
+++ b/pkg/block/engine/health.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/health"
 )
 
@@ -80,12 +79,6 @@ func (bs *Store) Healthcheck(ctx context.Context) health.Report {
 // HasRemoteStore returns true if this Store has a remote store configured.
 func (bs *Store) HasRemoteStore() bool {
 	return bs.remote != nil
-}
-
-// SetRetentionPolicy updates the retention policy on the underlying local store.
-// Delegates to the local store's SetRetentionPolicy method.
-func (bs *Store) SetRetentionPolicy(policy block.RetentionPolicy, ttl time.Duration) {
-	bs.local.SetRetentionPolicy(policy, ttl)
 }
 
 // SetEvictionEnabled controls whether the local store can evict blocks to free disk space.

--- a/pkg/block/engine/stats.go
+++ b/pkg/block/engine/stats.go
@@ -76,15 +76,17 @@ func (bs *Store) Stats() (*block.Stats, error) {
 		return nil, err
 	}
 	defer bs.closeMu.RUnlock()
+	// FileCount comes from the same Stats snapshot; listing every payload ID
+	// just to take its length would walk (and lock) the whole local index a
+	// second time for a number already in hand.
 	localStats := bs.local.Stats()
-	files := bs.local.ListFiles(context.Background())
 	used := uint64(localStats.DiskUsed)
 	total := uint64(localStats.MaxDisk)
 	avail := uint64(0)
 	if total > used {
 		avail = total - used
 	}
-	count := uint64(len(files))
+	count := uint64(localStats.FileCount)
 	avg := uint64(0)
 	if count > 0 {
 		avg = used / count
@@ -144,7 +146,7 @@ func (bs *Store) getStats(withBlockCounts bool) BlockStoreStats {
 		// FileCount is the cheap local-only count here; the full-stats path
 		// (withBlockCounts) overwrites it with the authoritative distinct-payload
 		// count from the metadata so it reflects rolled-up files too (#1374).
-		FileCount:           len(bs.local.ListFiles(context.Background())),
+		FileCount:           localStats.FileCount,
 		LocalDiskUsed:       localStats.DiskUsed,
 		LocalDiskMax:        localStats.MaxDisk,
 		LocalMemUsed:        localStats.MemUsed,

--- a/pkg/block/journal/index.go
+++ b/pkg/block/journal/index.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"sync"
+
+	"github.com/marmos91/dittofs/pkg/block/chunker"
 )
 
 // SegmentLocation points at a record payload inside a shared segment. It
@@ -352,6 +355,16 @@ func (s *Store) ReadAt(ctx context.Context, id FileID, offset int64, dst []byte)
 	return len(dst), cold, nil
 }
 
+// maxPooledRecordScratch bounds what a verified read hands back to the pool. A
+// record is at most one FastCDC chunk, and the chunker's 16 MiB hard ceiling is
+// far above the average cut — retaining a buffer that big would pin it for the
+// process lifetime to serve a read that almost never repeats, so an oversized
+// one is dropped for the GC instead.
+const maxPooledRecordScratch = chunker.AvgChunkSize
+
+// recordScratchPool recycles the whole-record buffers verified reads need.
+var recordScratchPool = sync.Pool{New: func() any { return new([]byte) }}
+
 // verifiedRead serves a warm piece with integrity verification: it re-reads the
 // whole record that owns the piece (at p.recOff) and validates it via
 // readVerifiedRecord, then copies the requested sub-range out of the verified
@@ -362,7 +375,19 @@ func (s *Store) ReadAt(ctx context.Context, id FileID, offset int64, dst []byte)
 // store or fails closed; it never copies unverified bytes into out.
 func (s *Store) verifiedRead(seg *segmentMeta, p piece, out []byte, id FileID, readOff int64) error {
 	corrupt := &CorruptRangeError{FileID: id, Offset: readOff + p.dstStart, Len: p.dstEnd - p.dstStart}
-	rec, err := readVerifiedRecord(seg.fd, p.recOff, s.cfg.SegmentSize, id)
+	// The whole record is read to verify it, so the scratch buffer is sized to a
+	// record, not to the request. Recycling it keeps a warm read from allocating
+	// (and the GC from collecting) one of those per piece per read.
+	scratch := recordScratchPool.Get().(*[]byte)
+	defer func() {
+		if cap(*scratch) <= maxPooledRecordScratch {
+			recordScratchPool.Put(scratch)
+		}
+	}()
+	rec, err := readVerifiedRecord(seg.fd, p.recOff, s.cfg.SegmentSize, id, *scratch)
+	if rec.buf != nil {
+		*scratch = rec.buf // keep a buffer the read had to grow
+	}
 	if err != nil {
 		return corrupt
 	}

--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -234,14 +234,35 @@ func (s *Store) evictSegment(sh *shard, seg *segmentMeta) (freed int64, err erro
 	}
 	sh.mu.Unlock()
 
+	// The files this segment backs are exactly the ones the scan produced an
+	// entry for, deduplicated.
+	backed := make(map[FileID]struct{}, len(entries))
+	for _, e := range entries {
+		backed[e.id] = struct{}{}
+	}
+
 	if err = s.appendCold(entries); err != nil {
 		// Without a durable marker the range would come back from a restart as a
 		// hole, so keep the segment (and its bytes) instead of evicting blind.
 		return 0, err
 	}
 
+	// Flip only the files the scan above found backed by this segment, rather
+	// than walking the shard index a second time. No file can join that set in
+	// between: the segment is sealed (nothing appends to it) and claimed, so no
+	// repack can repoint an interval into it either. A file that LEFT the set —
+	// its interval superseded while the cold log was being written — simply has
+	// nothing left to flip.
+	//
+	// ponytail: one full index walk remains, in the scan above. Removing it needs
+	// a segment→intervals reverse index, worth building only if eviction shows up
+	// in a profile.
 	sh.mu.Lock()
-	for _, fi := range sh.index {
+	for id := range backed {
+		fi := sh.index[id]
+		if fi == nil {
+			continue
+		}
 		for k := range fi.ivs {
 			if fi.ivs[k].loc.SegmentID == seg.id && !fi.ivs[k].cold {
 				fi.ivs[k].cold = true
@@ -489,13 +510,19 @@ func (s *Store) gcShard(ctx context.Context, sh *shard, opts GCOptions) (reclaim
 	sh.carveMu.Lock()
 	defer sh.carveMu.Unlock()
 
+	// Live bytes per segment are summed once for the whole pass instead of per
+	// victim: rebuilding them means walking every interval of every file under
+	// the same lock the read path takes, and a repack only changes the two
+	// segments it touches. repackSegment keeps the map in step as it goes.
+	live := shardLiveBytes(sh)
+
 	// Bounded: each repack removes one victim from the sealed set, and the fresh
 	// target it writes carries no dead bytes, so it is never re-picked.
 	for {
 		if err := ctx.Err(); err != nil {
 			return reclaimed, count, err
 		}
-		victim := s.pickVictim(sh, opts)
+		victim := s.pickVictim(sh, opts, live)
 		if victim == nil {
 			return reclaimed, count, nil
 		}
@@ -504,7 +531,7 @@ func (s *Store) gcShard(ctx context.Context, sh *shard, opts GCOptions) (reclaim
 		if !victim.busy.CompareAndSwap(false, true) {
 			continue
 		}
-		net, err := s.repackSegment(sh, victim)
+		net, err := s.repackSegment(sh, victim, live)
 		victim.busy.Store(false)
 		if err != nil {
 			return reclaimed, count, err
@@ -532,30 +559,37 @@ func (s *Store) pinned(seg *segmentMeta) bool {
 	return mv != 0 && mv <= pv
 }
 
+// shardLiveBytes sums each segment's still-live (non-cold) indexed bytes in one
+// pass over the shard's interval index. Cold intervals are excluded: their bytes
+// no longer occupy the segment, and counting them would make an evicted segment
+// look live. Caller holds no lock.
+func shardLiveBytes(sh *shard) map[uint64]int64 {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	live := make(map[uint64]int64, len(sh.sealed))
+	for _, fi := range sh.index {
+		for _, iv := range fi.ivs {
+			if !iv.cold {
+				live[iv.loc.SegmentID] += iv.length
+			}
+		}
+	}
+	return live
+}
+
 // pickVictim returns the sealed segment with the highest dead fraction, or nil
 // if none qualifies. A segment carrying no dead bytes is never a victim (there
 // is nothing to reclaim), which is also what keeps a tombstone-only segment from
-// being repacked into an identical one forever. Live bytes are summed
-// authoritatively from the interval index (robust to the recovery-time deadBytes
-// approximation and to the extra dead a crash-during-repack leaves behind); a
-// segment's dead fraction is dead/occupied. Without Force, a victim must reach
-// GCDeadRatioForce.
-func (s *Store) pickVictim(sh *shard, opts GCOptions) *segmentMeta {
+// being repacked into an identical one forever. live carries each segment's
+// still-live indexed bytes, summed authoritatively from the interval index
+// (robust to the recovery-time deadBytes approximation and to the extra dead a
+// crash-during-repack leaves behind); a segment's dead fraction is
+// dead/occupied. Without Force, a victim must reach GCDeadRatioForce.
+func (s *Store) pickVictim(sh *shard, opts GCOptions, live map[uint64]int64) *segmentMeta {
 	sh.mu.Lock()
 	defer sh.mu.Unlock()
 	if len(sh.sealed) == 0 {
 		return nil
-	}
-	live := make(map[uint64]int64, len(sh.sealed))
-	for _, fi := range sh.index {
-		for _, iv := range fi.ivs {
-			if iv.cold {
-				continue
-			}
-			if _, ok := sh.sealed[iv.loc.SegmentID]; ok {
-				live[iv.loc.SegmentID] += iv.length
-			}
-		}
 	}
 
 	var best *segmentMeta
@@ -615,14 +649,26 @@ type liveRec struct {
 	recOff  int64 // owning record's header offset in the victim
 }
 
+// movesByVersion buckets a repack's moves by record Version so the index-repoint
+// loop can find a move's covering range without rescanning the whole slice per
+// interval. A Version identifies one written record, so a bucket holds only the
+// remnants a later overwrite split that record into — a handful, not len(moves).
+func movesByVersion(moves []liveRec) map[uint64][]int {
+	byVer := make(map[uint64][]int, len(moves))
+	for i := range moves {
+		byVer[moves[i].version] = append(byVer[moves[i].version], i)
+	}
+	return byVer
+}
+
 // findMove returns the index of the move whose logical range fully contains
 // [lo, hi) at the given version, or -1. A concurrent overwrite may have trimmed
 // or split a victim interval since the snapshot; the trimmed remnant is still a
 // sub-range of exactly one original move, so this repoints it to the right byte.
-func findMove(moves []liveRec, lo, hi int64, ver uint64) int {
-	for i := range moves {
+func findMove(moves []liveRec, byVer map[uint64][]int, lo, hi int64, ver uint64) int {
+	for _, i := range byVer[ver] {
 		m := moves[i]
-		if m.version == ver && m.fileOff <= lo && hi <= m.fileOff+m.length {
+		if m.fileOff <= lo && hi <= m.fileOff+m.length {
 			return i
 		}
 	}
@@ -644,7 +690,10 @@ func findMove(moves []liveRec, lo, hi int64, ver uint64) int {
 // byte-identically and the next GC pass (seeing the victim fully superseded)
 // reclaims it. Version and the synced flag are copied verbatim, never reissued,
 // so newest-wins survives the physical move.
-func (s *Store) repackSegment(sh *shard, victim *segmentMeta) (int64, error) {
+// live is the caller's per-segment live-byte view: repackSegment retires the
+// victim's entry and records the target's so a following pickVictim sees the
+// move without re-summing the shard.
+func (s *Store) repackSegment(sh *shard, victim *segmentMeta, live map[uint64]int64) (int64, error) {
 	// 1a. Snapshot the victim's live intervals under the shard lock.
 	sh.mu.Lock()
 	var moves []liveRec
@@ -705,7 +754,7 @@ func (s *Store) repackSegment(sh *shard, victim *segmentMeta) (int64, error) {
 		// stamps a fresh CRC over whatever it is handed, so an unverified copy
 		// would launder on-disk bit rot into a record that passes every later
 		// integrity check. One record in RAM at a time.
-		rec, rerr := readVerifiedRecord(victim.fd, m.recOff, s.cfg.SegmentSize, m.id)
+		rec, rerr := readVerifiedRecord(victim.fd, m.recOff, s.cfg.SegmentSize, m.id, nil)
 		if rerr != nil {
 			cleanup()
 			return 0, quarantine(fmt.Errorf("journal: repack verify victim %d record %d for %q@%d: %w",
@@ -756,15 +805,17 @@ func (s *Store) repackSegment(sh *shard, victim *segmentMeta) (int64, error) {
 	s.diskBytes.Add(target.tail.Load() - segHeaderSize)
 
 	// 4. Repoint the index, skipping intervals a concurrent write superseded.
+	byVer := movesByVersion(moves)
 	sh.mu.Lock()
 	remaining := 0
+	relocatedLive := int64(0)
 	for _, fi := range sh.index {
 		for k := range fi.ivs {
 			iv := &fi.ivs[k]
 			if iv.cold || iv.loc.SegmentID != victim.id {
 				continue
 			}
-			mi := findMove(moves, iv.fileOff, iv.end(), iv.version)
+			mi := findMove(moves, byVer, iv.fileOff, iv.end(), iv.version)
 			if mi < 0 {
 				// No source move covers it — must never drop the victim while a
 				// live interval still points into it.
@@ -775,6 +826,7 @@ func (s *Store) repackSegment(sh *shard, victim *segmentMeta) (int64, error) {
 			iv.loc.SegmentID = target.id
 			iv.loc.Offset = newOff[mi] + delta
 			iv.recOff = newOff[mi] - recordHeaderSize - int64(len(moves[mi].id))
+			relocatedLive += iv.length
 		}
 	}
 	sh.sealed[target.id] = target
@@ -800,6 +852,11 @@ func (s *Store) repackSegment(sh *shard, victim *segmentMeta) (int64, error) {
 	if _, err := s.retireSegment(sh, victim); err != nil {
 		return 0, err
 	}
+	// The victim is gone and the target now holds its survivors. Every early
+	// return above leaves the victim in place, so its entry stays valid there.
+	// live is private to the GC pass, which is single-goroutine under gcMu.
+	delete(live, victim.id)
+	live[target.id] = relocatedLive
 
 	net := occupied - relocated
 	if net < 0 {

--- a/pkg/block/journal/record.go
+++ b/pkg/block/journal/record.go
@@ -139,11 +139,14 @@ func (e *CorruptRangeError) Error() string {
 }
 
 // record is a fully decoded and CRC-verified record read back from a segment.
+// fileID and payload alias buf, so a caller that recycles buf must be done with
+// all three.
 type record struct {
 	header  recordHeader
 	fileID  []byte
 	payload []byte
-	segOff  int64 // record start offset within the segment
+	buf     []byte // backing store for fileID and payload
+	segOff  int64  // record start offset within the segment
 }
 
 // readRecordAt reads and fully validates the record at segment offset off.
@@ -155,7 +158,11 @@ type record struct {
 // A torn or corrupt record returns errTornRecord; a clean boundary (no bytes
 // left) returns io.EOF. On success it also returns the offset of the next
 // record so a scan can advance.
-func readRecordAt(r io.ReaderAt, off, maxPayload int64) (record, int64, error) {
+//
+// scratch, when it has the capacity, backs the record body instead of a fresh
+// allocation; the returned record's buf reports what was actually used so a
+// pooling caller can recycle it. Pass nil to always allocate.
+func readRecordAt(r io.ReaderAt, off, maxPayload int64, scratch []byte) (record, int64, error) {
 	var hdrBuf [recordHeaderSize]byte
 	n, err := r.ReadAt(hdrBuf[:], off)
 	if err != nil {
@@ -179,7 +186,11 @@ func readRecordAt(r io.ReaderAt, off, maxPayload int64) (record, int64, error) {
 	if int64(int(body)) != body {
 		return record{}, 0, fmt.Errorf("%w: record length %d out of range", errTornRecord, body)
 	}
-	buf := make([]byte, body)
+	buf := scratch[:0]
+	if int64(cap(buf)) < body {
+		buf = make([]byte, body)
+	}
+	buf = buf[:body]
 	if _, err := r.ReadAt(buf, off+recordHeaderSize); err != nil {
 		// A truncated payload (torn write) shows up as EOF here, mid-record —
 		// corruption, not a clean boundary.
@@ -195,6 +206,7 @@ func readRecordAt(r io.ReaderAt, off, maxPayload int64) (record, int64, error) {
 		header:  h,
 		fileID:  buf[:h.FileIDLen],
 		payload: payload,
+		buf:     buf,
 		segOff:  off,
 	}, off + recordHeaderSize + body, nil
 }
@@ -209,8 +221,8 @@ func readRecordAt(r io.ReaderAt, off, maxPayload int64) (record, int64, error) {
 // flipped FileID — or a stale recOff landing on another file's record — passes
 // readRecordAt while handing back the wrong file's payload. Comparing the framed
 // FileID against the caller's closes that gap.
-func readVerifiedRecord(r io.ReaderAt, recOff, maxPayload int64, id FileID) (record, error) {
-	rec, _, err := readRecordAt(r, recOff, maxPayload)
+func readVerifiedRecord(r io.ReaderAt, recOff, maxPayload int64, id FileID, scratch []byte) (record, error) {
+	rec, _, err := readRecordAt(r, recOff, maxPayload, scratch)
 	if err != nil {
 		return record{}, err
 	}
@@ -239,7 +251,9 @@ func (rec record) payloadRange(segOff, n int64) (b []byte, ok bool) {
 func scanValidRecords(r io.ReaderAt, segSize, maxPayload int64) (recs []record, validUpTo int64) {
 	off := int64(segHeaderSize)
 	for off < segSize {
-		rec, next, err := readRecordAt(r, off, maxPayload)
+		// No scratch: recovery keeps every payload it scans, so the records must
+		// not share one recycled buffer.
+		rec, next, err := readRecordAt(r, off, maxPayload, nil)
 		if err != nil {
 			break
 		}

--- a/pkg/block/journal/record_test.go
+++ b/pkg/block/journal/record_test.go
@@ -42,7 +42,7 @@ func TestReadRecordRoundTrip(t *testing.T) {
 	rec := frameRecord("file-xyz", 4096, bytes.Repeat([]byte("payload"), 300), 7, flagSynced)
 	seg := segmentBytes(rec)
 
-	got, next, err := readRecordAt(bytes.NewReader(seg), segHeaderSize, int64(len(seg)))
+	got, next, err := readRecordAt(bytes.NewReader(seg), segHeaderSize, int64(len(seg)), nil)
 	if err != nil {
 		t.Fatalf("readRecordAt: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestReadRecordTruncatedHeader(t *testing.T) {
 	// Cut the record mid-header: only a few header bytes survive. A partial
 	// header (n>0 then EOF) is a torn write, NOT a clean boundary.
 	seg := segmentBytes(rec[:5])
-	_, _, err := readRecordAt(bytes.NewReader(seg), segHeaderSize, 1<<20)
+	_, _, err := readRecordAt(bytes.NewReader(seg), segHeaderSize, 1<<20, nil)
 	if !errors.Is(err, errTornRecord) {
 		t.Fatalf("expected errTornRecord on partial header, got %v", err)
 	}
@@ -79,7 +79,7 @@ func TestReadRecordCleanEOF(t *testing.T) {
 	seg := segmentBytes(rec)
 	// Reading exactly at the end of the stream (zero bytes available) is a clean
 	// boundary: io.EOF, distinct from a torn record.
-	_, _, err := readRecordAt(bytes.NewReader(seg), int64(len(seg)), 1<<20)
+	_, _, err := readRecordAt(bytes.NewReader(seg), int64(len(seg)), 1<<20, nil)
 	if !errors.Is(err, io.EOF) || errors.Is(err, errTornRecord) {
 		t.Fatalf("expected clean io.EOF at stream end, got %v", err)
 	}
@@ -89,7 +89,7 @@ func TestReadRecordTruncatedPayload(t *testing.T) {
 	rec := frameRecord("f", 0, bytes.Repeat([]byte("z"), 1000), 1, 0)
 	// Drop the trailing payload + CRC: header is whole, body is torn.
 	seg := segmentBytes(rec[:recordHeaderSize+1+100])
-	_, _, err := readRecordAt(bytes.NewReader(seg), segHeaderSize, 1<<20)
+	_, _, err := readRecordAt(bytes.NewReader(seg), segHeaderSize, 1<<20, nil)
 	if !errors.Is(err, errTornRecord) {
 		t.Fatalf("expected errTornRecord on truncated payload, got %v", err)
 	}
@@ -100,7 +100,7 @@ func TestReadRecordCorruptPayload(t *testing.T) {
 	seg := segmentBytes(rec)
 	// Flip a payload byte in place: header still validates, payload CRC must not.
 	seg[segHeaderSize+recordHeaderSize+1+10] ^= 0xFF
-	_, _, err := readRecordAt(bytes.NewReader(seg), segHeaderSize, 1<<20)
+	_, _, err := readRecordAt(bytes.NewReader(seg), segHeaderSize, 1<<20, nil)
 	if !errors.Is(err, errTornRecord) {
 		t.Fatalf("expected errTornRecord on corrupt payload, got %v", err)
 	}
@@ -122,7 +122,7 @@ func TestReadRecordPayloadLenCeiling(t *testing.T) {
 	}, fileID)
 	seg := segmentBytes(hdr) // no real payload follows
 
-	_, _, err := readRecordAt(bytes.NewReader(seg), segHeaderSize, 4<<20 /* 4 MiB ceiling */)
+	_, _, err := readRecordAt(bytes.NewReader(seg), segHeaderSize, 4<<20 /* 4 MiB ceiling */, nil)
 	if !errors.Is(err, errTornRecord) {
 		t.Fatalf("expected errTornRecord from PayloadLen ceiling, got %v", err)
 	}

--- a/pkg/block/journal/recovery.go
+++ b/pkg/block/journal/recovery.go
@@ -293,57 +293,8 @@ func (s *Store) recover() error {
 	// issued LSN exactly max(observed)+1 — strictly past every replayed record.
 	s.version.Store(maxVersion)
 
-	// Honor tombstones: a delete's tombstone Version exceeds every prior write to
-	// that file, so drop the file's intervals older than it. A rewrite after the
-	// delete carries a higher Version and survives, recreating the file.
-	for _, idxMap := range indexByShard {
-		for fid, fi := range idxMap {
-			tv, deleted := tombstones[fid]
-			if !deleted {
-				continue
-			}
-			kept := fi.ivs[:0]
-			for _, iv := range fi.ivs {
-				if iv.version > tv {
-					kept = append(kept, iv)
-				}
-			}
-			if len(kept) == 0 {
-				delete(idxMap, fid)
-			} else {
-				fi.ivs = kept
-			}
-		}
-	}
-
-	// Honor truncate markers: a size-down's marker Version exceeds every write it
-	// buries, so drop the file's intervals past newSize (and clip a straddling
-	// one) for every interval at or below the marker. A write that raced past the
-	// truncate carries a higher Version and survives, re-extending the file.
-	for _, idxMap := range indexByShard {
-		for fid, fi := range idxMap {
-			tm, ok := truncations[fid]
-			if !ok {
-				continue
-			}
-			kept := fi.ivs[:0]
-			for _, iv := range fi.ivs {
-				if iv.version > tm.version || iv.end() <= tm.newSize {
-					kept = append(kept, iv)
-					continue
-				}
-				if iv.fileOff < tm.newSize {
-					kept = append(kept, iv.clamp(iv.fileOff, tm.newSize))
-				}
-				// else entirely past newSize: drop it.
-			}
-			if len(kept) == 0 {
-				delete(idxMap, fid)
-			} else {
-				fi.ivs = kept
-			}
-		}
-	}
+	applyTombstones(indexByShard, tombstones)
+	applyTruncations(indexByShard, truncations)
 
 	// Compact the cold log once the live set has drifted well below what the log
 	// holds: entries superseded by a later hydrate, buried by a tombstone or
@@ -451,6 +402,66 @@ func (s *Store) recover() error {
 	s.diskBytes.Store(disk)
 	ok = true
 	return nil
+}
+
+// applyTombstones drops each deleted file's intervals older than its tombstone.
+// A delete's tombstone Version exceeds every prior write to that file, so a
+// rewrite after the delete carries a higher Version, survives, and recreates the
+// file.
+func applyTombstones(indexByShard []map[FileID]*fileIndex, tombstones map[FileID]uint64) {
+	for _, idxMap := range indexByShard {
+		for fid, fi := range idxMap {
+			tv, deleted := tombstones[fid]
+			if !deleted {
+				continue
+			}
+			keepIntervals(idxMap, fid, fi, func(iv interval) (interval, bool) {
+				return iv, iv.version > tv
+			})
+		}
+	}
+}
+
+// applyTruncations drops (or clips) each truncated file's intervals past
+// newSize. A size-down's marker Version exceeds every write it buries, so a
+// write that raced past the truncate carries a higher Version, survives, and
+// re-extends the file.
+func applyTruncations(indexByShard []map[FileID]*fileIndex, truncations map[FileID]truncMark) {
+	for _, idxMap := range indexByShard {
+		for fid, fi := range idxMap {
+			tm, ok := truncations[fid]
+			if !ok {
+				continue
+			}
+			keepIntervals(idxMap, fid, fi, func(iv interval) (interval, bool) {
+				switch {
+				case iv.version > tm.version || iv.end() <= tm.newSize:
+					return iv, true
+				case iv.fileOff < tm.newSize: // straddles newSize: clip it
+					return iv.clamp(iv.fileOff, tm.newSize), true
+				default: // entirely past newSize
+					return iv, false
+				}
+			})
+		}
+	}
+}
+
+// keepIntervals rewrites fi's intervals in place to those keep accepts, dropping
+// the file from idxMap when nothing survives — an empty fileIndex would read as
+// a file that exists and holds no bytes rather than as no file at all.
+func keepIntervals(idxMap map[FileID]*fileIndex, fid FileID, fi *fileIndex, keep func(interval) (interval, bool)) {
+	kept := fi.ivs[:0]
+	for _, iv := range fi.ivs {
+		if out, ok := keep(iv); ok {
+			kept = append(kept, out)
+		}
+	}
+	if len(kept) == 0 {
+		delete(idxMap, fid)
+		return
+	}
+	fi.ivs = kept
 }
 
 // idxMissing reports whether a segment's .idx sidecar is absent.

--- a/pkg/block/journal/segment.go
+++ b/pkg/block/journal/segment.go
@@ -434,9 +434,12 @@ func (s *Store) appendTombstone(ctx context.Context, id FileID) (uint64, error) 
 			Flags:      flagTombstone,
 		}.encode())
 	}
-	fd := seg.fd
 	sh.mu.Unlock()
-	if err := fd.Sync(); err != nil {
+	// Durability goes through the shard's commit leader rather than a private
+	// fd.Sync: the record is already written, so a barrier that starts now covers
+	// it, and a burst of concurrent deletes on one shard rides a single fsync
+	// instead of one each.
+	if err := sh.groupCommit(); err != nil {
 		return 0, fmt.Errorf("journal: fsync tombstone: %w", err)
 	}
 	return version, nil
@@ -490,9 +493,10 @@ func (s *Store) appendTruncateMarker(ctx context.Context, id FileID, newSize int
 			Flags:      flagTruncate,
 		}.encode())
 	}
-	fd := seg.fd
 	sh.mu.Unlock()
-	if err := fd.Sync(); err != nil {
+	// Same commit-leader path as the tombstone: the marker's bytes are written,
+	// so any barrier that starts after this point makes them durable.
+	if err := sh.groupCommit(); err != nil {
 		return 0, fmt.Errorf("journal: fsync truncate marker: %w", err)
 	}
 	return version, nil
@@ -563,7 +567,7 @@ func (s *Store) readRecord(sh *shard, segID uint64, recOff int64, id FileID) (re
 		return record{}, fmt.Errorf("journal: unknown segment %d", segID)
 	}
 	seg.lastAccess.Store(s.clock.Now().UnixNano())
-	rec, err := readVerifiedRecord(seg.fd, recOff, s.cfg.SegmentSize, id)
+	rec, err := readVerifiedRecord(seg.fd, recOff, s.cfg.SegmentSize, id, nil)
 	if err != nil {
 		return record{}, fmt.Errorf("journal: read segment %d record %d: %w", segID, recOff, err)
 	}

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -686,6 +686,20 @@ func (s *Store) SetEvictionEnabled(enabled bool) {
 	s.evictionDisabled.Store(!enabled)
 }
 
+// FileCount reports how many files the journal indexes. It is what a caller that
+// only wants the count should use: ListFiles builds and returns a slice of every
+// FileID to answer the same question, which on a large store allocates (and
+// grows) a slice under every shard lock the read path also takes.
+func (s *Store) FileCount() int {
+	n := 0
+	for _, sh := range s.shards {
+		sh.mu.Lock()
+		n += len(sh.index)
+		sh.mu.Unlock()
+	}
+	return n
+}
+
 // ListFiles returns every FileID with a live index entry across all shards, in
 // no guaranteed order. It lets a caller drive a bulk reset (Delete every file)
 // without tracking IDs itself.
@@ -968,7 +982,7 @@ func (s *Store) RestoreToVersion(ctx context.Context, v uint64) error {
 			// Re-materializing rewrites these bytes as fresh records under a fresh
 			// CRC, so they are verified against the source record first — restoring
 			// a snapshot must not turn on-disk bit rot into trusted content.
-			rec, rerr := readVerifiedRecord(seg.fd, iv.recOff, s.cfg.SegmentSize, id)
+			rec, rerr := readVerifiedRecord(seg.fd, iv.recOff, s.cfg.SegmentSize, id, nil)
 			if rerr != nil {
 				return fmt.Errorf("journal: restore: read %q@%d from segment %d: %w", id, iv.fileOff, iv.loc.SegmentID, rerr)
 			}

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -222,7 +222,18 @@ func (s *FSStore) Truncate(ctx context.Context, payloadID string, newSize int64)
 	return s.Store.Truncate(ctx, journal.FileID(payloadID), newSize)
 }
 
+// FileSize drains the payload's archived legacy log first for the same reason
+// ReadAt does: until those records land in the journal the file's high-water
+// mark reads back as zero (or short), which is indistinguishable from a file
+// that genuinely holds no bytes. The signature carries no error, so a drain
+// failure reports "not found" — the caller then falls back to its own size
+// source rather than trusting a truncated answer.
 func (s *FSStore) FileSize(ctx context.Context, payloadID string) (int64, bool) {
+	if err := s.materializeLegacy(payloadID); err != nil {
+		logger.Error("local store: draining an archived legacy payload for a size query",
+			"payload_id", payloadID, "error", err)
+		return 0, false
+	}
 	return s.Store.FileSize(ctx, journal.FileID(payloadID))
 }
 
@@ -230,7 +241,14 @@ func (s *FSStore) DurableExtent(ctx context.Context, payloadID string) (int64, b
 	return s.Store.DurableExtent(ctx, journal.FileID(payloadID))
 }
 
+// DataExtents drains the payload's archived legacy log first. SEEK_DATA and
+// READ_PLUS answer from these extents without ever issuing a read, so an
+// un-drained range would be reported as a genuine sparse hole and a sparse-aware
+// copy would skip bytes the file actually holds.
 func (s *FSStore) DataExtents(ctx context.Context, payloadID string, fileSize int64) ([][2]uint64, error) {
+	if err := s.materializeLegacy(payloadID); err != nil {
+		return nil, err
+	}
 	return s.Store.DataExtents(ctx, journal.FileID(payloadID), fileSize)
 }
 
@@ -248,10 +266,6 @@ func (s *FSStore) ListFiles(ctx context.Context) []string {
 // Start is a no-op: the journal has no background goroutines of its own (carve
 // and eviction are driven by the engine's syncer).
 func (s *FSStore) Start(context.Context) {}
-
-// SetRetentionPolicy is a no-op: the journal evicts whole fully-synced segments
-// approx-LRU and honors no pin/ttl/lru knob.
-func (s *FSStore) SetRetentionPolicy(block.RetentionPolicy, time.Duration) {}
 
 // SetMetrics is a no-op today — journal eviction/backpressure metrics are not
 // wired through the local tier. ponytail: wire journal counters here if the
@@ -277,7 +291,7 @@ func (s *FSStore) Stats() local.Stats {
 		DiskUsed:    js.DiskBytes,
 		MaxDisk:     s.maxDisk,
 		MaxLogBytes: s.maxLogBytes,
-		FileCount:   len(s.Store.ListFiles(context.Background())),
+		FileCount:   s.Store.FileCount(),
 	}
 }
 

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -291,7 +291,7 @@ func (s *FSStore) Stats() local.Stats {
 		DiskUsed:    js.DiskBytes,
 		MaxDisk:     s.maxDisk,
 		MaxLogBytes: s.maxLogBytes,
-		FileCount:   s.Store.FileCount(),
+		FileCount:   s.FileCount(),
 	}
 }
 

--- a/pkg/block/local/fs/legacy_migrate_test.go
+++ b/pkg/block/local/fs/legacy_migrate_test.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/block/journal"
@@ -177,6 +178,50 @@ func TestLegacyLocalOnly_MigratesFaultsInAndFinishes(t *testing.T) {
 	}
 	if b := journalRead(t, s2, p1, len(want1)); !bytes.Equal(b, want1) {
 		t.Fatalf("after re-open p1 = %q, want %q", b, want1)
+	}
+}
+
+// TestLegacyLocalOnly_SizeAndExtentsFaultIn covers the two queries that answer
+// without ever issuing a read. An un-drained payload must not report a zero size
+// or an empty extent list: SEEK_DATA/READ_PLUS take the extents as authoritative,
+// so a missing extent is a genuine sparse hole and a sparse-aware copy silently
+// drops the bytes behind it. Each query gets its own payload because the drain is
+// once-per-payload — sharing one would let the first call hide the second's bug.
+func TestLegacyLocalOnly_SizeAndExtentsFaultIn(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	// A gap between the two records makes the extent answer non-trivial: the
+	// middle really is a hole, the two ends really are not.
+	recs := []legacyRec{
+		{off: 0, payload: []byte("head")},
+		{off: 4096, payload: []byte("tail")},
+	}
+	const wantSize = 4096 + 4
+
+	sizePayload := "share/size.bin"
+	extentPayload := "share/extent.bin"
+	writeLegacyLog(t, filepath.Join(dir, "logs", sizePayload+".log"), 0, recs)
+	writeLegacyLog(t, filepath.Join(dir, "logs", extentPayload+".log"), 0, recs)
+
+	s, err := NewWithOptions(dir, 1<<30, nil, FSStoreOptions{MigrateLegacyLocalOnly: true})
+	if err != nil {
+		t.Fatalf("NewWithOptions(MigrateLegacyLocalOnly): %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	got, ok := s.FileSize(ctx, sizePayload)
+	if !ok || got != wantSize {
+		t.Fatalf("FileSize(un-drained) = (%d, %v), want (%d, true)", got, ok, wantSize)
+	}
+
+	extents, err := s.DataExtents(ctx, extentPayload, wantSize)
+	if err != nil {
+		t.Fatalf("DataExtents(un-drained): %v", err)
+	}
+	want := [][2]uint64{{0, 4}, {4096, 4100}}
+	if !reflect.DeepEqual(extents, want) {
+		t.Fatalf("DataExtents(un-drained) = %v, want %v", extents, want)
 	}
 }
 

--- a/pkg/block/local/local.go
+++ b/pkg/block/local/local.go
@@ -2,9 +2,7 @@ package local
 
 import (
 	"context"
-	"time"
 
-	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/journal"
 	"github.com/marmos91/dittofs/pkg/health"
 )
@@ -104,11 +102,6 @@ type LocalStore interface {
 	// unhealthy, cold-marking a range would strand unrecoverable bytes, so
 	// eviction is paused.
 	SetEvictionEnabled(enabled bool)
-
-	// SetRetentionPolicy is a compatibility no-op on the journal-native local
-	// store: the journal evicts whole fully-synced segments approx-LRU and does
-	// not honor a pin/ttl/lru knob. Retained so the health/admin path compiles.
-	SetRetentionPolicy(policy block.RetentionPolicy, ttl time.Duration)
 
 	// --- Lifecycle ---
 

--- a/pkg/block/local/memory/memory.go
+++ b/pkg/block/local/memory/memory.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"lukechampine.com/blake3"
 
@@ -59,9 +58,11 @@ func (s *MemoryStore) writeLocked(payloadID string, offset int64, data []byte) i
 	}
 	end := offset + int64(len(data))
 	if int64(len(f.buf)) < end {
-		grown := make([]byte, end)
-		copy(grown, f.buf)
-		f.buf = grown
+		// Extend through append so the runtime's geometric growth amortizes the
+		// copy. Allocating exactly `end` each time would re-copy the whole buffer
+		// on every extending write, making a sequential file O(n^2) to fill. The
+		// appended bytes are zero, which keeps the gap-filling semantics.
+		f.buf = append(f.buf, make([]byte, end-int64(len(f.buf)))...)
 	}
 	copy(f.buf[offset:end], data)
 	return int64(len(data))
@@ -281,9 +282,6 @@ func (s *MemoryStore) Evict(context.Context, int64) (journal.EvictResult, error)
 
 // SetEvictionEnabled is a no-op.
 func (s *MemoryStore) SetEvictionEnabled(bool) {}
-
-// SetRetentionPolicy is a no-op.
-func (s *MemoryStore) SetRetentionPolicy(block.RetentionPolicy, time.Duration) {}
 
 // Start is a no-op.
 func (s *MemoryStore) Start(context.Context) {}

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1106,7 +1106,6 @@ func (s *Service) createBlockStoreForShare(
 	localStore.SetEvictionEnabled(remoteStore != nil && config.RetentionPolicy != block.RetentionPin)
 	// Note: SetSkipFsync was removed. Local-disk durability is now
 	// unconditional (the syncer will refetch from S3 on the rare crash path).
-	localStore.SetRetentionPolicy(config.RetentionPolicy, config.RetentionTTL)
 
 	syncerCfg := buildSyncerConfigFromDefaults(syncerDefaults)
 	// A per-remote parallel_uploads override pins the carver's upload window;
@@ -1794,11 +1793,10 @@ func (s *Service) UpdateShare(name string, readOnly *bool, defaultPermission *st
 		share.RetentionTTL = *retentionTTL
 	}
 
-	// Propagate retention policy changes to the BlockStore at runtime.
-	// The policy applies lazily on the next eviction cycle.
+	// Only the pin/non-pin distinction reaches the block store: the local tier
+	// evicts whole fully-synced segments approx-LRU and has no ttl or lru knob to
+	// receive, so the rest of the policy is metadata the API reports back.
 	if (retentionPolicy != nil || retentionTTL != nil) && share.BlockStore != nil {
-		share.BlockStore.SetRetentionPolicy(share.RetentionPolicy, share.RetentionTTL)
-
 		// Pin mode disables eviction; switching away from pin re-enables it
 		// (unless the share is local-only, in which case eviction stays disabled).
 		if share.RetentionPolicy == block.RetentionPin {


### PR DESCRIPTION
Batch of MED findings from the 2026-08-05 data-plane audit, covering the journal's reclaim/recovery paths and the local-store tier. Relates to #1900.

## Correctness

**`FSStore.FileSize` and `DataExtents` skipped the legacy fault-in seam.** `WriteAt`, `ReadAt`, `Delete` and `Truncate` each drain a payload's archived pre-journal log via `materializeLegacy` before touching it; these two delegated straight through. Both answer without ever issuing a read, so an un-drained payload reported a zero/short size and an empty extent list — and NFSv4.2 SEEK/READ_PLUS take the extents as authoritative, so a missing extent reads as a genuine sparse hole and a sparse-aware copy silently drops the bytes behind it. `FileSize` has no error in its signature, so a drain failure now reports "not found" and the caller falls back to its own size source rather than trusting a truncated answer. `DurableExtent` is deliberately left alone: it only ever under-reports durability, which is the safe direction for that contract.

**Tombstone and truncate-marker durability now goes through the shard commit leader.** Both paths issued a private `fd.Sync()` instead of `sh.groupCommit()`, so a burst of concurrent deletes hashing to one shard paid a full disk barrier each — exactly what the group-commit leader exists to eliminate. The record's bytes are written under `sh.mu` before the call, and `groupCommit`'s contract already covers rotation (`sealInPlace` fsyncs the segment it seals), so durability is unchanged.

**`evictSegment` now flips cold only the files it logged.** The cold-marker scan already collects every file backed by the segment; the second pass re-walked the whole shard index. It now flips exactly the set it wrote cold-log entries for. Safe because the segment is sealed and busy-claimed, so nothing can append to it and no repack can repoint into it during the unlocked `appendCold` window. This also tightens the invariant: the flipped set is now a subset of the durably-logged set, where the full re-walk could in principle mark an interval cold that had no cold-log entry behind it.

## Reclaim and read-path cost

- `pickVictim` rebuilt the entire shard live-byte map on every call, making a GC pass O(victims x intervals) under the same lock the read path takes. It is now summed once per pass by `shardLiveBytes`, and `repackSegment` keeps the map in step as it retires a victim and records its target. The pass holds `carveMu` throughout, and stale entries can only under-report dead bytes, which is conservative in the safe direction.
- `findMove` linear-scanned `moves` once per repointed interval, giving O(moves^2) under `sh.mu` for a heavily-overwritten victim. Now bucketed by record Version, which identifies a single written record.
- `verifiedRead` allocated a whole-record buffer per piece per read. `readRecordAt`/`readVerifiedRecord` take an optional scratch buffer and report what they used, and warm reads recycle it through a pool capped at the chunker's average cut. Recovery passes nil, since it keeps every payload it scans and the records must not share one buffer.

## Local-store cleanups

- `journal.Store.FileCount()` replaces `len(ListFiles(...))` in the two Stats paths. `ListFiles` built and returned a slice of every FileID under every shard lock just to take its length — on the metrics scrape path, which documented itself as O(1)-ish.
- `SetRetentionPolicy` was a no-op in every `LocalStore` implementation while remaining a required interface method that live callers invoked with real config. Removed from the interface, both implementations, the engine, and the shares service. Only the pin/non-pin distinction ever reached the block store; the rest is metadata the API reports back, and `UpdateShare` now says so. The two internals docs that described the no-op are updated.
- `MemoryStore` grew its buffer by allocating exactly the new size and copying, making a sequential file O(n^2) to fill. Extends through `append` so the runtime's geometric growth amortizes the copy.

## Notes for review

This branch was recovered from a raw git index after the previous session was killed between `reset --soft` and its squash commit. It was re-verified from scratch and audited for recovery artifacts; two were found and fixed (an import-grouping artifact in `journal/index.go`, and the `ListFiles` doc comment displaced onto the new `FileCount`). A follow-up pass found no others.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .` clean. `go test ./...` passes; `go test -race ./pkg/block/...` passes.
