### PR TITLE
fix(metadata): close the MED audit findings in the SQL stores

### DIFF
--- a/pkg/controlplane/runtime/init.go
+++ b/pkg/controlplane/runtime/init.go
@@ -142,6 +142,10 @@ func CreateMetadataStoreFromConfig(ctx context.Context, storeType string, cfg in
 		if minConns, ok := config["min_conns"].(float64); ok {
 			pgCfg.MinConns = int32(minConns)
 		}
+		// Prepared statements stay on unless the operator turns them off, so the
+		// zero value is the shipped behaviour and a store built without this key
+		// keeps the cache.
+		pgCfg.DisablePreparedStatements = configBoolDefault(config, "disable_prepared_statements", false)
 
 		pgCfg.AutoMigrate = true
 

--- a/pkg/metadata/block_record_store.go
+++ b/pkg/metadata/block_record_store.go
@@ -41,7 +41,9 @@ func ManifestToChunkRefs(rows []*block.FileChunk) []block.ChunkRef {
 // keeps the last one — the single row the store retains. Rows with an
 // unparseable ID, or addressing another payload, are skipped, matching what the
 // full projection's list-and-sort ignores.
-func mergeCommittedRefs(refs []block.ChunkRef, payloadID string, rows []*block.FileChunk) []block.ChunkRef {
+// It also returns the offsets it touched — always non-nil, so callers can hand
+// the store the exact set that may differ from the rows it already holds.
+func mergeCommittedRefs(refs []block.ChunkRef, payloadID string, rows []*block.FileChunk) ([]block.ChunkRef, []uint64) {
 	byOffset := make(map[uint64]block.ChunkRef, len(rows))
 	for _, r := range rows {
 		if r == nil {
@@ -53,12 +55,14 @@ func mergeCommittedRefs(refs []block.ChunkRef, payloadID string, rows []*block.F
 		}
 		byOffset[off] = block.ChunkRef{Hash: r.Hash, Offset: off, Size: r.DataSize}
 	}
-	if len(byOffset) == 0 {
-		return refs
-	}
 	added := make([]block.ChunkRef, 0, len(byOffset))
-	for _, ref := range byOffset {
+	changed := make([]uint64, 0, len(byOffset))
+	for off, ref := range byOffset {
 		added = append(added, ref)
+		changed = append(changed, off)
+	}
+	if len(added) == 0 {
+		return refs, changed
 	}
 	// Offsets are unique here, so this total order is the one the full
 	// projection's sort produces.
@@ -80,7 +84,7 @@ func mergeCommittedRefs(refs []block.ChunkRef, payloadID string, rows []*block.F
 			j++
 		}
 	}
-	return append(append(merged, refs[i:]...), added[j:]...)
+	return append(append(merged, refs[i:]...), added[j:]...), changed
 }
 
 // ProjectCommittedChunks folds the manifest rows a caller just wrote into
@@ -105,7 +109,8 @@ func ProjectCommittedChunks(ctx context.Context, tx Transaction, payloadID strin
 	if len(file.Blocks) == 0 {
 		return reprojectFile(ctx, tx, file, payloadID)
 	}
-	return putProjection(ctx, tx, file, mergeCommittedRefs(file.Blocks, payloadID, rows))
+	merged, changed := mergeCommittedRefs(file.Blocks, payloadID, rows)
+	return putProjection(ctx, tx, file, merged, changed)
 }
 
 // ProjectManifestToBlocks re-materializes File.Blocks for payloadID from the
@@ -149,16 +154,27 @@ func reprojectFile(ctx context.Context, tx Transaction, file *File, payloadID st
 	if err != nil {
 		return fmt.Errorf("project blocks: list manifest for %s: %w", payloadID, err)
 	}
-	return putProjection(ctx, tx, file, ManifestToChunkRefs(rows))
+	// A full re-derivation says nothing about which offsets moved, so the
+	// store gets no scope and diffs everything.
+	return putProjection(ctx, tx, file, ManifestToChunkRefs(rows), nil)
 }
 
-func putProjection(ctx context.Context, tx Transaction, file *File, refs []block.ChunkRef) error {
+// putProjection persists refs as the file's manifest projection. changed, when
+// non-nil, is the only set of offsets that can differ from what the store
+// already holds; nil leaves the store to work that out for itself.
+func putProjection(ctx context.Context, tx Transaction, file *File, refs []block.ChunkRef, changed []uint64) error {
 	file.Blocks = refs
 	// A projection from the manifest IS a manifest write — persist it. This
-	// funnels carve/rollup commit (DefaultCommitBlock), the #953 reap+re-carve
+	// funnels carve/rollup commit (DefaultCommitBlock), the reap+re-carve
 	// (ReapSupersededManifest), and coordinator.ReprojectBlocks.
 	file.BlocksDirty = true
-	return tx.PutFile(ctx, file)
+	file.BlocksDirtyOffsets = changed
+	err := tx.PutFile(ctx, file)
+	// The scope describes this write only — clearing it stops a caller that
+	// reuses the struct for a wider manifest mutation from inheriting a promise
+	// that no longer holds.
+	file.BlocksDirtyOffsets = nil
+	return err
 }
 
 // chunkPayloadID returns the payload prefix of a manifest row ID — everything

--- a/pkg/metadata/file_create.go
+++ b/pkg/metadata/file_create.go
@@ -447,6 +447,11 @@ func (s *Service) createEntry(
 			}
 		}
 
+		// The inode ID was minted for this create and the guard above found no
+		// entry under this name, so no row can exist yet and the store can
+		// insert without probing for one.
+		newFile.NewInode = true
+
 		// Store the entry
 		if err := tx.PutFile(ctx.Context, newFile); err != nil {
 			return err
@@ -482,6 +487,11 @@ func (s *Service) createEntry(
 		return nil
 	})
 	unlockCreateName()
+
+	// The hint describes the insert that just ran. Clear it before the struct
+	// escapes into the read cache and the caller, so a later update through the
+	// same struct cannot inherit a promise that no longer holds.
+	newFile.NewInode = false
 
 	if err != nil {
 		return nil, nil, err

--- a/pkg/metadata/file_types.go
+++ b/pkg/metadata/file_types.go
@@ -114,6 +114,27 @@ type FileAttr struct {
 	// hold Blocks inline.
 	BlocksDirty bool `json:"-"`
 
+	// BlocksDirtyOffsets narrows BlocksDirty to the offsets that can possibly
+	// differ from what the SQL backends already store, so their manifest diff
+	// costs the changed range rather than the whole file. Transient and
+	// request-scoped like BlocksDirty, and never persisted.
+	//
+	// nil means "unknown": the backend must diff the entire stored manifest.
+	// Non-nil (empty included) is a promise that every offset outside the set
+	// is already stored exactly as Blocks holds it — so the backend may read,
+	// upsert and delete only within the set. Only a caller that folded a known
+	// row set into an already-coherent Blocks projection can make that promise;
+	// a caller that re-derived Blocks from scratch must leave this nil.
+	BlocksDirtyOffsets []uint64 `json:"-"`
+
+	// NewInode marks a File the caller has just constructed and knows has no
+	// row yet, so a store that would otherwise probe for one can insert
+	// straight away. Transient, request-scoped and never persisted. Only a
+	// caller holding the create's exclusivity guarantee may set it: a store is
+	// entitled to skip its existence check, and an inode that does exist then
+	// surfaces as a duplicate-key error rather than an update.
+	NewInode bool `json:"-"`
+
 	// ObjectID is the BLAKE3 Merkle root over ChunkRef.Hash values sorted
 	// by Offset, populated lazily at the post-Flush coordinator hook
 	// (). All-zero sentinel means

--- a/pkg/metadata/store/memory/reset.go
+++ b/pkg/metadata/store/memory/reset.go
@@ -34,6 +34,7 @@ func (s *MemoryMetadataStore) Reset(ctx context.Context) error {
 	s.pendingWrites = make(map[string]*metadata.WriteOperation)
 	s.sessions = make(map[string]*ShareSession)
 	s.objectIndex = make(map[block.ContentHash]string)
+	s.blockRecords = make(map[string]*block.BlockRecord)
 	s.serverConfig = metadata.MetadataServerConfig{}
 
 	s.fileChunkData = nil

--- a/pkg/metadata/store/memory/snapshot_store.go
+++ b/pkg/metadata/store/memory/snapshot_store.go
@@ -62,6 +62,12 @@ type memoryBackupSnapshot struct {
 	SyncedLocators map[block.ContentHash]block.ChunkLocator
 	ObjectIndex    map[block.ContentHash]string
 
+	// BlockRecords carries each block's sync state and live-chunk count.
+	// Nothing rebuilds those from the file manifest, so dropping them across
+	// a restore leaves the GC and the syncer blind to every existing block.
+	// Additive gob field: an older dump decodes it to nil.
+	BlockRecords map[string]*block.BlockRecord
+
 	// ServerConfigCustomSettingsJSON holds the JSON-encoded form of
 	// ServerConfig.CustomSettings. Gob cannot encode map[string]any
 	// out of the box; we JSON-encode here and decode on restore.
@@ -126,6 +132,7 @@ func (s *MemoryMetadataStore) WriteSnapshot(ctx context.Context, w io.Writer) (*
 		Capabilities:  s.capabilities,
 		StoreID:       s.storeID,
 		ObjectIndex:   s.objectIndex,
+		BlockRecords:  s.blockRecords,
 	}
 
 	// Acquire syncedMu to read synced safely — governed by its own mutex, not
@@ -346,6 +353,7 @@ func (s *MemoryMetadataStore) RestoreSnapshot(ctx context.Context, r io.Reader) 
 	s.syncedMu.Unlock()
 
 	s.objectIndex = snap.ObjectIndex
+	s.blockRecords = snap.BlockRecords
 
 	// Ensure nil maps are initialized to empty (store invariant).
 	if s.shares == nil {
@@ -371,6 +379,9 @@ func (s *MemoryMetadataStore) RestoreSnapshot(ctx context.Context, r io.Reader) 
 	}
 	if s.objectIndex == nil {
 		s.objectIndex = make(map[block.ContentHash]string)
+	}
+	if s.blockRecords == nil {
+		s.blockRecords = make(map[string]*block.BlockRecord)
 	}
 
 	// Restore lazy sub-stores (nil snapshot = never initialized).

--- a/pkg/metadata/store/postgres/client_recovery.go
+++ b/pkg/metadata/store/postgres/client_recovery.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
@@ -21,12 +20,12 @@ import (
 // Thread Safety:
 // All operations are single statements executed against the connection pool.
 type postgresRecoveryStore struct {
-	pool *pgxpool.Pool
+	st *PostgresMetadataStore
 }
 
 // newPostgresRecoveryStore creates a new PostgreSQL client recovery store.
-func newPostgresRecoveryStore(pool *pgxpool.Pool) *postgresRecoveryStore {
-	return &postgresRecoveryStore{pool: pool}
+func newPostgresRecoveryStore(st *PostgresMetadataStore) *postgresRecoveryStore {
+	return &postgresRecoveryStore{st: st}
 }
 
 // PutClientRecovery stores or replaces the record for a confirmed client using
@@ -53,7 +52,7 @@ func (s *postgresRecoveryStore) PutClientRecovery(ctx context.Context, rec *lock
 			reclaim_complete = EXCLUDED.reclaim_complete
 	`
 
-	_, err := s.pool.Exec(ctx, query,
+	_, err := s.st.exec(ctx, query,
 		rec.ClientIDString,
 		int64(rec.ClientID),
 		rec.BootVerifier[:], // [8]byte -> BYTEA
@@ -68,7 +67,7 @@ func (s *postgresRecoveryStore) PutClientRecovery(ctx context.Context, rec *lock
 // DeleteClientRecovery removes the record for a client.
 func (s *postgresRecoveryStore) DeleteClientRecovery(ctx context.Context, clientIDString string) error {
 	query := `DELETE FROM v4_client_recovery WHERE clientid_string = $1`
-	_, err := s.pool.Exec(ctx, query, clientIDString)
+	_, err := s.st.exec(ctx, query, clientIDString)
 	return err
 }
 
@@ -109,7 +108,7 @@ func (s *postgresRecoveryStore) ListClientRecovery(ctx context.Context) ([]*lock
 		ORDER BY confirmed_at
 	`
 
-	rows, err := s.pool.Query(ctx, query)
+	rows, err := s.st.query(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +132,7 @@ func (s *postgresRecoveryStore) ListClientRecovery(ctx context.Context) ([]*lock
 // record is a no-op (RowsAffected == 0), not an error.
 func (s *postgresRecoveryStore) RecordReclaimComplete(ctx context.Context, clientIDString string) error {
 	query := `UPDATE v4_client_recovery SET reclaim_complete = TRUE WHERE clientid_string = $1`
-	_, err := s.pool.Exec(ctx, query, clientIDString)
+	_, err := s.st.exec(ctx, query, clientIDString)
 	return err
 }
 
@@ -149,7 +148,7 @@ func (s *PostgresMetadataStore) getRecoveryStore() *postgresRecoveryStore {
 	s.recoveryStoreMu.Lock()
 	defer s.recoveryStoreMu.Unlock()
 	if s.recoveryStore == nil {
-		s.recoveryStore = newPostgresRecoveryStore(s.pool)
+		s.recoveryStore = newPostgresRecoveryStore(s)
 	}
 	return s.recoveryStore
 }

--- a/pkg/metadata/store/postgres/clients.go
+++ b/pkg/metadata/store/postgres/clients.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
@@ -26,13 +25,13 @@ import (
 // Thread Safety:
 // All operations use database transactions for atomicity.
 type postgresClientStore struct {
-	pool *pgxpool.Pool
+	st *PostgresMetadataStore
 }
 
 // newPostgresClientStore creates a new PostgreSQL client registration store.
-func newPostgresClientStore(pool *pgxpool.Pool) *postgresClientStore {
+func newPostgresClientStore(st *PostgresMetadataStore) *postgresClientStore {
 	return &postgresClientStore{
-		pool: pool,
+		st: st,
 	}
 }
 
@@ -55,7 +54,7 @@ func (s *postgresClientStore) PutClientRegistration(ctx context.Context, reg *lo
 			server_epoch = EXCLUDED.server_epoch
 	`
 
-	_, err := s.pool.Exec(ctx, query,
+	_, err := s.st.exec(ctx, query,
 		reg.ClientID,
 		reg.MonName,
 		reg.Priv[:], // Convert [16]byte to slice
@@ -81,7 +80,7 @@ func (s *postgresClientStore) GetClientRegistration(ctx context.Context, clientI
 	var reg lock.PersistedClientRegistration
 	var privBytes []byte
 
-	err := s.pool.QueryRow(ctx, query, clientID).Scan(
+	err := s.st.queryRow(ctx, query, clientID).Scan(
 		&reg.ClientID,
 		&reg.MonName,
 		&privBytes,
@@ -111,7 +110,7 @@ func (s *postgresClientStore) GetClientRegistration(ctx context.Context, clientI
 // DeleteClientRegistration removes a registration by client ID.
 func (s *postgresClientStore) DeleteClientRegistration(ctx context.Context, clientID string) error {
 	query := `DELETE FROM nsm_client_registrations WHERE client_id = $1`
-	_, err := s.pool.Exec(ctx, query, clientID)
+	_, err := s.st.exec(ctx, query, clientID)
 	return err
 }
 
@@ -124,7 +123,7 @@ func (s *postgresClientStore) ListClientRegistrations(ctx context.Context) ([]*l
 		ORDER BY registered_at
 	`
 
-	rows, err := s.pool.Query(ctx, query)
+	rows, err := s.st.query(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +166,7 @@ func (s *postgresClientStore) ListClientRegistrations(ctx context.Context) ([]*l
 // DeleteAllClientRegistrations removes all registrations.
 func (s *postgresClientStore) DeleteAllClientRegistrations(ctx context.Context) (int, error) {
 	query := `DELETE FROM nsm_client_registrations`
-	result, err := s.pool.Exec(ctx, query)
+	result, err := s.st.exec(ctx, query)
 	if err != nil {
 		return 0, err
 	}
@@ -177,7 +176,7 @@ func (s *postgresClientStore) DeleteAllClientRegistrations(ctx context.Context) 
 // DeleteClientRegistrationsByMonName removes all registrations monitoring a specific host.
 func (s *postgresClientStore) DeleteClientRegistrationsByMonName(ctx context.Context, monName string) (int, error) {
 	query := `DELETE FROM nsm_client_registrations WHERE mon_name = $1`
-	result, err := s.pool.Exec(ctx, query, monName)
+	result, err := s.st.exec(ctx, query, monName)
 	if err != nil {
 		return 0, err
 	}
@@ -196,7 +195,7 @@ func (s *PostgresMetadataStore) getClientStore() *postgresClientStore {
 	s.clientStoreMu.Lock()
 	defer s.clientStoreMu.Unlock()
 	if s.clientStore == nil {
-		s.clientStore = newPostgresClientStore(s.pool)
+		s.clientStore = newPostgresClientStore(s)
 	}
 	return s.clientStore
 }

--- a/pkg/metadata/store/postgres/config.go
+++ b/pkg/metadata/store/postgres/config.go
@@ -29,9 +29,13 @@ type PostgresMetadataStoreConfig struct {
 	QueryTimeout   time.Duration `mapstructure:"query_timeout"`   // Default: 30s
 
 	// Features
-	PrepareStatements bool          `mapstructure:"prepare_statements"` // Default: true
-	AutoMigrate       bool          `mapstructure:"auto_migrate"`       // Default: false (manual control)
-	StatsCacheTTL     time.Duration `mapstructure:"stats_cache_ttl"`    // Default: 5s
+
+	// DisablePreparedStatements turns off pgx's per-connection prepared-statement
+	// cache, which a pooler in transaction-pooling mode cannot serve. Default
+	// false: statements are prepared and cached.
+	DisablePreparedStatements bool          `mapstructure:"disable_prepared_statements"`
+	AutoMigrate               bool          `mapstructure:"auto_migrate"`    // Default: false (manual control)
+	StatsCacheTTL             time.Duration `mapstructure:"stats_cache_ttl"` // Default: 5s
 
 	// RelaxedDurability defers commit-time WAL flush for pure-namespace metadata
 	// writes via SET LOCAL synchronous_commit=off, honoring the same
@@ -79,9 +83,6 @@ func (c *PostgresMetadataStoreConfig) ApplyDefaults() {
 	}
 
 	// Feature defaults
-	// PrepareStatements defaults to false (Go zero value), but we want true
-	// So we'll explicitly set it in the factory function if not specified by user
-
 	if c.StatsCacheTTL == 0 {
 		c.StatsCacheTTL = 5 * time.Second
 	}

--- a/pkg/metadata/store/postgres/connection.go
+++ b/pkg/metadata/store/postgres/connection.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -34,6 +35,18 @@ func createConnectionPool(ctx context.Context, cfg *PostgresMetadataStoreConfig,
 	// Set query timeout as statement timeout
 	if cfg.QueryTimeout > 0 {
 		poolConfig.ConnConfig.RuntimeParams["statement_timeout"] = fmt.Sprintf("%dms", cfg.QueryTimeout.Milliseconds())
+	}
+
+	// By default pgx keeps a per-connection prepared-statement cache, which
+	// names statements on the server. A pooler in transaction-pooling mode hands
+	// a different backend to each transaction, so those names resolve on the
+	// wrong session and queries fail with "prepared statement does not exist".
+	// Disabling the cache switches to unnamed extended-protocol statements,
+	// which carry no server-side name while still binding parameters
+	// server-side (unlike the simple protocol, which interpolates them
+	// client-side).
+	if cfg.DisablePreparedStatements {
+		poolConfig.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeExec
 	}
 
 	// Configure logging (optional, can be adjusted)

--- a/pkg/metadata/store/postgres/durable_handles.go
+++ b/pkg/metadata/store/postgres/durable_handles.go
@@ -6,18 +6,17 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
 // postgresDurableStore implements lock.DurableHandleStore using PostgreSQL.
 type postgresDurableStore struct {
-	pool *pgxpool.Pool
+	st *PostgresMetadataStore
 }
 
-func newPostgresDurableStore(pool *pgxpool.Pool) *postgresDurableStore {
+func newPostgresDurableStore(st *PostgresMetadataStore) *postgresDurableStore {
 	return &postgresDurableStore{
-		pool: pool,
+		st: st,
 	}
 }
 
@@ -233,7 +232,7 @@ func (s *postgresDurableStore) PutDurableHandle(ctx context.Context, handle *loc
 			client_guid = EXCLUDED.client_guid
 	`
 
-	_, err := s.pool.Exec(ctx, query,
+	_, err := s.st.exec(ctx, query,
 		handle.ID,
 		handle.FileID[:],
 		handle.Path,
@@ -289,17 +288,17 @@ func (s *postgresDurableStore) PutDurableHandle(ctx context.Context, handle *loc
 
 func (s *postgresDurableStore) GetDurableHandle(ctx context.Context, id string) (*lock.PersistedDurableHandle, error) {
 	query := `SELECT ` + durableHandleColumns + ` FROM durable_handles WHERE id = $1`
-	return scanDurableHandle(s.pool.QueryRow(ctx, query, id))
+	return scanDurableHandle(s.st.queryRow(ctx, query, id))
 }
 
 func (s *postgresDurableStore) GetDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
 	query := `SELECT ` + durableHandleColumns + ` FROM durable_handles WHERE file_id = $1 ORDER BY id LIMIT 1`
-	return scanDurableHandle(s.pool.QueryRow(ctx, query, fileID[:]))
+	return scanDurableHandle(s.st.queryRow(ctx, query, fileID[:]))
 }
 
 func (s *postgresDurableStore) GetDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
 	query := `SELECT ` + durableHandleColumns + ` FROM durable_handles WHERE create_guid = $1 LIMIT 1`
-	return scanDurableHandle(s.pool.QueryRow(ctx, query, createGuid[:]))
+	return scanDurableHandle(s.st.queryRow(ctx, query, createGuid[:]))
 }
 
 // ConsumeDurableHandleByFileID atomically fetches and deletes via
@@ -309,18 +308,18 @@ func (s *postgresDurableStore) GetDurableHandleByCreateGuid(ctx context.Context,
 // file's other handles untouched.
 func (s *postgresDurableStore) ConsumeDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
 	query := `DELETE FROM durable_handles WHERE id = (SELECT id FROM durable_handles WHERE file_id = $1 ORDER BY id LIMIT 1) RETURNING ` + durableHandleColumns
-	return scanDurableHandle(s.pool.QueryRow(ctx, query, fileID[:]))
+	return scanDurableHandle(s.st.queryRow(ctx, query, fileID[:]))
 }
 
 // ConsumeDurableHandleByCreateGuid is the V2 counterpart.
 func (s *postgresDurableStore) ConsumeDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
 	query := `DELETE FROM durable_handles WHERE create_guid = $1 RETURNING ` + durableHandleColumns
-	return scanDurableHandle(s.pool.QueryRow(ctx, query, createGuid[:]))
+	return scanDurableHandle(s.st.queryRow(ctx, query, createGuid[:]))
 }
 
 func (s *postgresDurableStore) GetDurableHandlesByAppInstanceId(ctx context.Context, appInstanceId [16]byte) ([]*lock.PersistedDurableHandle, error) {
 	query := `SELECT ` + durableHandleColumns + ` FROM durable_handles WHERE app_instance_id = $1 ORDER BY created_at`
-	rows, err := s.pool.Query(ctx, query, appInstanceId[:])
+	rows, err := s.st.query(ctx, query, appInstanceId[:])
 	if err != nil {
 		return nil, err
 	}
@@ -329,7 +328,7 @@ func (s *postgresDurableStore) GetDurableHandlesByAppInstanceId(ctx context.Cont
 
 func (s *postgresDurableStore) GetDurableHandlesByFileHandle(ctx context.Context, fileHandle []byte) ([]*lock.PersistedDurableHandle, error) {
 	query := `SELECT ` + durableHandleColumns + ` FROM durable_handles WHERE metadata_handle = $1 ORDER BY created_at`
-	rows, err := s.pool.Query(ctx, query, fileHandle)
+	rows, err := s.st.query(ctx, query, fileHandle)
 	if err != nil {
 		return nil, err
 	}
@@ -338,13 +337,13 @@ func (s *postgresDurableStore) GetDurableHandlesByFileHandle(ctx context.Context
 
 func (s *postgresDurableStore) DeleteDurableHandle(ctx context.Context, id string) error {
 	query := `DELETE FROM durable_handles WHERE id = $1`
-	_, err := s.pool.Exec(ctx, query, id)
+	_, err := s.st.exec(ctx, query, id)
 	return err
 }
 
 func (s *postgresDurableStore) ListDurableHandles(ctx context.Context) ([]*lock.PersistedDurableHandle, error) {
 	query := `SELECT ` + durableHandleColumns + ` FROM durable_handles ORDER BY created_at`
-	rows, err := s.pool.Query(ctx, query)
+	rows, err := s.st.query(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -353,7 +352,7 @@ func (s *postgresDurableStore) ListDurableHandles(ctx context.Context) ([]*lock.
 
 func (s *postgresDurableStore) ListDurableHandlesByShare(ctx context.Context, shareName string) ([]*lock.PersistedDurableHandle, error) {
 	query := `SELECT ` + durableHandleColumns + ` FROM durable_handles WHERE share_name = $1 ORDER BY created_at`
-	rows, err := s.pool.Query(ctx, query, shareName)
+	rows, err := s.st.query(ctx, query, shareName)
 	if err != nil {
 		return nil, err
 	}
@@ -365,7 +364,7 @@ func (s *postgresDurableStore) DeleteExpiredDurableHandles(ctx context.Context, 
 		DELETE FROM durable_handles
 		WHERE disconnected_at + (timeout_ms || ' milliseconds')::interval <= $1
 	`
-	result, err := s.pool.Exec(ctx, query, now)
+	result, err := s.st.exec(ctx, query, now)
 	if err != nil {
 		return 0, err
 	}
@@ -380,7 +379,7 @@ func (s *PostgresMetadataStore) getDurableStore() *postgresDurableStore {
 	s.durableStoreMu.Lock()
 	defer s.durableStoreMu.Unlock()
 	if s.durableStore == nil {
-		s.durableStore = newPostgresDurableStore(s.pool)
+		s.durableStore = newPostgresDurableStore(s)
 	}
 	return s.durableStore
 }

--- a/pkg/metadata/store/postgres/file_block_refs.go
+++ b/pkg/metadata/store/postgres/file_block_refs.go
@@ -43,13 +43,17 @@ import (
 //
 // hasPriorRefs lets a freshly-inserted file skip the stored-row query: with no
 // prior rows every incoming ref is a plain insert.
-func putFileChunkRefs(ctx context.Context, tx pgx.Tx, fileID uuid.UUID, blocks []block.ChunkRef, hasPriorRefs bool) (bool, error) {
-	upserts, deletes, err := fileChunkRefsDelta(ctx, tx, fileID, blocks, hasPriorRefs)
+//
+// scope, when non-nil, restricts the whole delta to those offsets — see
+// fileChunkRefsDelta. The returned count is how many stored rows the diff had
+// to read, which is what a scope bounds.
+func putFileChunkRefs(ctx context.Context, tx pgx.Tx, fileID uuid.UUID, blocks []block.ChunkRef, hasPriorRefs bool, scope []uint64) (bool, int, error) {
+	upserts, deletes, scanned, err := fileChunkRefsDelta(ctx, tx, fileID, blocks, hasPriorRefs, scope)
 	if err != nil {
-		return false, err
+		return false, scanned, err
 	}
 	if len(upserts) == 0 && len(deletes) == 0 {
-		return false, nil
+		return false, scanned, nil
 	}
 
 	batch := &pgx.Batch{}
@@ -77,10 +81,10 @@ func putFileChunkRefs(ctx context.Context, tx pgx.Tx, fileID uuid.UUID, blocks [
 	}
 	for i := 0; i < statements; i++ {
 		if _, err := br.Exec(); err != nil {
-			return false, fmt.Errorf("apply file_block_refs delta: %w", err)
+			return false, scanned, fmt.Errorf("apply file_block_refs delta: %w", err)
 		}
 	}
-	return true, nil
+	return true, scanned, nil
 }
 
 // storedChunkRef is a stored file_block_refs row minus its offset (the map key).
@@ -95,15 +99,37 @@ type storedChunkRef struct {
 // stored set is known-empty, so the query is skipped and every ref is an
 // upsert. Offsets are unique under the (file_id, "offset") PK, so keying the
 // diff on offset is sound.
-func fileChunkRefsDelta(ctx context.Context, tx pgx.Tx, fileID uuid.UUID, blocks []block.ChunkRef, hasPriorRefs bool) ([]block.ChunkRef, []int64, error) {
+//
+// scope, when non-nil, is the caller's promise that no offset outside it can
+// differ from what is stored. The stored-row query, the incoming scan and the
+// delete set are then all confined to it, so a commit that touches a handful of
+// chunks costs a handful of rows instead of the file's entire manifest. A nil
+// scope keeps the full diff, which is what a caller that re-derived the
+// manifest from scratch needs.
+func fileChunkRefsDelta(ctx context.Context, tx pgx.Tx, fileID uuid.UUID, blocks []block.ChunkRef, hasPriorRefs bool, scope []uint64) ([]block.ChunkRef, []int64, int, error) {
+	var inScope map[int64]struct{}
+	if scope != nil {
+		inScope = make(map[int64]struct{}, len(scope))
+		for _, off := range scope {
+			inScope[int64(off)] = struct{}{}
+		}
+	}
+
 	stored := make(map[int64]storedChunkRef)
-	if hasPriorRefs {
-		rows, err := tx.Query(ctx,
-			`SELECT "offset", size, hash FROM file_block_refs WHERE file_id = $1`,
-			fileID,
-		)
+	if hasPriorRefs && (inScope == nil || len(inScope) > 0) {
+		query := `SELECT "offset", size, hash FROM file_block_refs WHERE file_id = $1`
+		args := []any{fileID}
+		if inScope != nil {
+			query += ` AND "offset" = ANY($2)`
+			offsets := make([]int64, 0, len(inScope))
+			for off := range inScope {
+				offsets = append(offsets, off)
+			}
+			args = append(args, offsets)
+		}
+		rows, err := tx.Query(ctx, query, args...)
 		if err != nil {
-			return nil, nil, fmt.Errorf("query file_block_refs for %s: %w", fileID, err)
+			return nil, nil, len(stored), fmt.Errorf("query file_block_refs for %s: %w", fileID, err)
 		}
 		defer rows.Close()
 		for rows.Next() {
@@ -111,14 +137,14 @@ func fileChunkRefsDelta(ctx context.Context, tx pgx.Tx, fileID uuid.UUID, blocks
 			var sz int32
 			var raw []byte
 			if err := rows.Scan(&off, &sz, &raw); err != nil {
-				return nil, nil, fmt.Errorf("scan file_block_ref: %w", err)
+				return nil, nil, len(stored), fmt.Errorf("scan file_block_ref: %w", err)
 			}
 			h := make([]byte, len(raw))
 			copy(h, raw)
 			stored[off] = storedChunkRef{size: sz, hash: h}
 		}
 		if err := rows.Err(); err != nil {
-			return nil, nil, fmt.Errorf("iterate file_block_refs: %w", err)
+			return nil, nil, len(stored), fmt.Errorf("iterate file_block_refs: %w", err)
 		}
 	}
 
@@ -126,6 +152,11 @@ func fileChunkRefsDelta(ctx context.Context, tx pgx.Tx, fileID uuid.UUID, blocks
 	incoming := make(map[int64]struct{}, len(blocks))
 	for _, b := range blocks {
 		off := int64(b.Offset)
+		if inScope != nil {
+			if _, ok := inScope[off]; !ok {
+				continue
+			}
+		}
 		incoming[off] = struct{}{}
 		if s, ok := stored[off]; ok && s.size == int32(b.Size) && bytes.Equal(s.hash, b.Hash[:]) {
 			continue // identical row already stored — no write
@@ -138,7 +169,7 @@ func fileChunkRefsDelta(ctx context.Context, tx pgx.Tx, fileID uuid.UUID, blocks
 			deletes = append(deletes, off)
 		}
 	}
-	return upserts, deletes, nil
+	return upserts, deletes, len(stored), nil
 }
 
 // PutFileChunkRefsCallCount returns how many times PutFile actually wrote
@@ -147,6 +178,14 @@ func fileChunkRefsDelta(ctx context.Context, tx pgx.Tx, fileID uuid.UUID, blocks
 // re-projections of an unchanged manifest perform ZERO manifest writes.
 func (s *PostgresMetadataStore) PutFileChunkRefsCallCount() int64 {
 	return s.manifestWrites.Load()
+}
+
+// PutFileChunkRefsManifestRowsScanned returns how many stored file_block_refs
+// rows PutFile's manifest diff has read since store open. Test-only — proves a
+// scoped commit's read cost tracks the changed offsets, not the file's total
+// chunk count.
+func (s *PostgresMetadataStore) PutFileChunkRefsManifestRowsScanned() int64 {
+	return s.manifestRowsScanned.Load()
 }
 
 // deleteFileChunkRefs removes all rows for fileID. The FK cascade

--- a/pkg/metadata/store/postgres/files.go
+++ b/pkg/metadata/store/postgres/files.go
@@ -465,14 +465,15 @@ func (s *PostgresMetadataStore) GetFileByPayloadID(ctx context.Context, payloadI
 			f.atime, f.mtime, f.ctime, f.creation_time,
 			f.content_id, f.link_target, f.device_major, f.device_minor,
 			f.hidden, f.acl, f.eas, f.object_id,
-			f.deleted_at, f.original_path, f.deleted_by, f.nlink
+			f.deleted_at, f.original_path, f.deleted_by, f.nlink,
+			` + blockRefsAggExpr + `
 		FROM inodes f
 		WHERE f.content_id_hash = md5($1)
 		LIMIT 1
 	`
 
 	row := s.queryRow(ctx, query, string(payloadID))
-	file, err := sqlcodec.FileRowToFileWithNlink(row)
+	file, err := sqlcodec.FileRowToFileWithNlinkAndBlocks(row, true)
 	if err != nil {
 		return nil, mapPgError(err, "GetFileByPayloadID", string(payloadID))
 	}

--- a/pkg/metadata/store/postgres/objects.go
+++ b/pkg/metadata/store/postgres/objects.go
@@ -156,32 +156,27 @@ func (s *PostgresMetadataStore) DecrementRefCount(ctx context.Context, id string
 // DecrementRefCountAndReap atomically decrements ref_count and, when it hits 0,
 // deletes the row — both statements run inside ONE transaction so the
 // decrement-and-reap is atomic and TOCTOU-free against a concurrent AddRef
-// (which takes the same row lock). The conditional `ref_count = 0` predicate on
-// the DELETE means a concurrent bump that landed between the two statements
-// (impossible within the row lock, but defended anyway) leaves the row alive.
-// Returns (0, nil) when the row is already absent — a swept row is not a caller
-// error.
+// (which takes the same row lock). Returns (0, nil) when the row is already
+// absent — a swept row is not a caller error. Running through WithTransaction
+// also gives a serialization failure or deadlock the package's bounded retry
+// instead of surfacing it as a hard error.
 func (s *PostgresMetadataStore) DecrementRefCountAndReap(ctx context.Context, id string) (uint32, error) {
-	tx, err := s.beginTx(ctx)
-	if err != nil {
-		return 0, fmt.Errorf("decrement-and-reap begin tx: %w", err)
-	}
-	defer func() { _ = tx.Rollback(ctx) }()
-
-	newCount, err := decrementAndReapTx(ctx, tx, id)
+	var newCount uint32
+	err := s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		var txErr error
+		newCount, txErr = tx.DecrementRefCountAndReap(ctx, id)
+		return txErr
+	})
 	if err != nil {
 		return 0, err
-	}
-	if err := tx.Commit(ctx); err != nil {
-		return 0, fmt.Errorf("decrement-and-reap commit: %w", err)
 	}
 	return newCount, nil
 }
 
 // decrementAndReapTx runs the -1 UPDATE then a conditional DELETE on the given
-// pgx.Tx. Shared by the pool-backed store method and the postgresTransaction
-// method so both surfaces behave identically. Returns ErrFileChunkNotFound
-// mapped to (0, nil) — i.e. a missing row is tolerated.
+// pgx.Tx. The `ref_count = 0` predicate on the DELETE means a bump that landed
+// between the two statements leaves the row alive. Returns (0, nil) for an
+// already-swept row rather than ErrFileChunkNotFound.
 func decrementAndReapTx(ctx context.Context, tx pgx.Tx, id string) (uint32, error) {
 	var newCount uint32
 	err := tx.QueryRow(ctx,

--- a/pkg/metadata/store/postgres/pool_helpers.go
+++ b/pkg/metadata/store/postgres/pool_helpers.go
@@ -32,6 +32,11 @@ const poolConnectionAcquireTimeout = 10 * time.Second
 // All operations use the same poolConnectionAcquireTimeout (10s) as WithTransaction
 // for consistency.
 
+// rowQuerier is the single-row query surface an open transaction (pgx.Tx.QueryRow)
+// and the pool wrapper (PostgresMetadataStore.queryRow) both satisfy, so one
+// query body can run on either.
+type rowQuerier func(ctx context.Context, sql string, args ...any) pgx.Row
+
 // queryRow executes a query that returns at most one row with connection acquire timeout.
 // This prevents indefinite blocking when the pool is exhausted.
 func (s *PostgresMetadataStore) queryRow(ctx context.Context, sql string, args ...any) pgx.Row {
@@ -127,32 +132,6 @@ func (s *PostgresMetadataStore) exec(ctx context.Context, sql string, args ...an
 		return pgconn.CommandTag{}, mapPgError(err, "exec", sql)
 	}
 	return tag, nil
-}
-
-// beginTx starts a transaction with connection acquire timeout.
-// This prevents indefinite blocking when the pool is exhausted.
-// Caller MUST commit or rollback the returned transaction.
-func (s *PostgresMetadataStore) beginTx(ctx context.Context) (pgx.Tx, error) {
-	// Check context before acquiring connection
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	// Apply connection acquire timeout
-	acquireCtx, cancel := context.WithTimeout(ctx, poolConnectionAcquireTimeout)
-	defer cancel()
-
-	// Begin transaction (this acquires a connection)
-	tx, err := s.pool.Begin(acquireCtx)
-	if err != nil {
-		if acquireCtx.Err() == context.DeadlineExceeded && ctx.Err() == nil {
-			// Acquire timed out, not the parent context
-			return nil, fmt.Errorf("connection acquire timeout after %v: pool may be exhausted", poolConnectionAcquireTimeout)
-		}
-		return nil, mapPgError(err, "beginTx", "")
-	}
-
-	return tx, nil
 }
 
 // ============================================================================

--- a/pkg/metadata/store/postgres/schema_ops.go
+++ b/pkg/metadata/store/postgres/schema_ops.go
@@ -57,7 +57,7 @@ func (s *PostgresMetadataStore) ListSchemasByPrefix(ctx context.Context, prefix 
 		WHERE schema_name LIKE $1
 		ORDER BY schema_name
 	`
-	rows, err := s.pool.Query(ctx, query, prefix+"%")
+	rows, err := s.query(ctx, query, prefix+"%")
 	if err != nil {
 		return nil, fmt.Errorf("query schemata: %w", err)
 	}
@@ -109,7 +109,7 @@ func (s *PostgresMetadataStore) DropSchema(ctx context.Context, schemaName strin
 	// by never contain `"`; this is defense in depth only.
 	safe := `"` + strings.ReplaceAll(schemaName, `"`, `""`) + `"`
 	sql := fmt.Sprintf(`DROP SCHEMA IF EXISTS %s CASCADE`, safe)
-	if _, err := s.pool.Exec(ctx, sql); err != nil {
+	if _, err := s.exec(ctx, sql); err != nil {
 		return fmt.Errorf("drop schema %q: %w", schemaName, err)
 	}
 	return nil

--- a/pkg/metadata/store/postgres/server.go
+++ b/pkg/metadata/store/postgres/server.go
@@ -71,48 +71,7 @@ func (s *PostgresMetadataStore) SetFilesystemCapabilities(capabilities metadata.
 	// Update database (best effort - don't fail if it errors)
 	// This is called during initialization, so database updates are non-critical
 	ctx := context.Background()
-	query := `
-		INSERT INTO filesystem_capabilities (
-			id, max_read_size, preferred_read_size, max_write_size, preferred_write_size,
-			max_file_size, max_filename_len, max_path_len, max_hard_link_count,
-			supports_hard_links, supports_symlinks, case_sensitive, case_preserving,
-			supports_acls, time_resolution
-		) VALUES (
-			1, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14
-		)
-		ON CONFLICT (id) DO UPDATE SET
-			max_read_size = EXCLUDED.max_read_size,
-			preferred_read_size = EXCLUDED.preferred_read_size,
-			max_write_size = EXCLUDED.max_write_size,
-			preferred_write_size = EXCLUDED.preferred_write_size,
-			max_file_size = EXCLUDED.max_file_size,
-			max_filename_len = EXCLUDED.max_filename_len,
-			max_path_len = EXCLUDED.max_path_len,
-			max_hard_link_count = EXCLUDED.max_hard_link_count,
-			supports_hard_links = EXCLUDED.supports_hard_links,
-			supports_symlinks = EXCLUDED.supports_symlinks,
-			case_sensitive = EXCLUDED.case_sensitive,
-			case_preserving = EXCLUDED.case_preserving,
-			supports_acls = EXCLUDED.supports_acls,
-			time_resolution = EXCLUDED.time_resolution
-	`
-
-	_, err := s.exec(ctx, query,
-		capabilities.MaxReadSize,
-		capabilities.PreferredReadSize,
-		capabilities.MaxWriteSize,
-		capabilities.PreferredWriteSize,
-		capabilities.MaxFileSize,
-		capabilities.MaxFilenameLen,
-		capabilities.MaxPathLen,
-		capabilities.MaxHardLinkCount,
-		capabilities.SupportsHardLinks,
-		capabilities.SupportsSymlinks,
-		capabilities.CaseSensitive,
-		capabilities.CasePreserving,
-		capabilities.SupportsACLs,
-		capabilities.TimestampResolution,
-	)
+	_, err := s.exec(ctx, upsertCapabilitiesSQL, capabilityArgs(capabilities)...)
 
 	// Log error but don't fail - capabilities are already cached
 	if err != nil {

--- a/pkg/metadata/store/postgres/shares.go
+++ b/pkg/metadata/store/postgres/shares.go
@@ -100,7 +100,7 @@ func (s *PostgresMetadataStore) CreateShare(ctx context.Context, share *metadata
 	// primary key (the ON CONFLICT upsert just re-points root_file_id, leaving
 	// at most one root). (Production also serializes share creation upstream in
 	// the control plane.)
-	existing, err := s.getExistingRootDirectory(ctx, share.Name)
+	existing, err := s.getExistingRootDirectory(ctx, s.queryRow, share.Name)
 	if err != nil {
 		return fmt.Errorf("create share %q: check existing: %w", share.Name, err)
 	}
@@ -208,7 +208,12 @@ func (s *PostgresMetadataStore) ListShares(ctx context.Context) ([]string, error
 // Root Directory Operations
 // ============================================================================
 
-// CreateRootDirectory creates the root directory for a share
+// CreateRootDirectory creates the root directory for a share.
+//
+// The whole probe-then-create sequence runs in one transaction through
+// WithTransaction, so a serialization failure or deadlock retries under the
+// package's backoff and a concurrent caller cannot slip between the probe and
+// the insert and leave an orphaned root inode behind.
 func (s *PostgresMetadataStore) CreateRootDirectory(
 	ctx context.Context,
 	shareName string,
@@ -221,6 +226,26 @@ func (s *PostgresMetadataStore) CreateRootDirectory(
 		}
 	}
 
+	var root *metadata.File
+	err := s.WithTransaction(ctx, func(mtx metadata.Transaction) error {
+		var txErr error
+		root, txErr = s.createRootDirectoryTx(ctx, mtx.(*postgresTransaction).tx, shareName, attr)
+		return txErr
+	})
+	if err != nil {
+		return nil, err
+	}
+	return root, nil
+}
+
+// createRootDirectoryTx holds the probe/reconcile/create body, run against the
+// caller's transaction.
+func (s *PostgresMetadataStore) createRootDirectoryTx(
+	ctx context.Context,
+	tx pgx.Tx,
+	shareName string,
+	attr *metadata.FileAttr,
+) (*metadata.File, error) {
 	// Apply defaults
 	uid := attr.UID
 	gid := attr.GID
@@ -236,7 +261,7 @@ func (s *PostgresMetadataStore) CreateRootDirectory(
 	)
 
 	// Check if root directory already exists (idempotent behavior)
-	existingRoot, err := s.getExistingRootDirectory(ctx, shareName)
+	existingRoot, err := s.getExistingRootDirectory(ctx, tx.QueryRow, shareName)
 	if err == nil && existingRoot != nil {
 		// Check if root directory attributes need to be updated from config
 		// This handles the case where the config changed since the share was first created
@@ -273,7 +298,7 @@ func (s *PostgresMetadataStore) CreateRootDirectory(
 				SET mode = $1, uid = $2, gid = $3, ctime = $4
 				WHERE id = $5
 			`
-			_, err := s.exec(ctx, updateQuery,
+			_, err := tx.Exec(ctx, updateQuery,
 				int32(existingRoot.Mode),
 				int32(existingRoot.UID),
 				int32(existingRoot.GID),
@@ -295,13 +320,6 @@ func (s *PostgresMetadataStore) CreateRootDirectory(
 		}
 		return existingRoot, nil
 	}
-
-	// Begin transaction with connection acquire timeout
-	tx, err := s.beginTx(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = tx.Rollback(ctx) }()
 
 	// Generate UUID for root directory
 	rootID := uuid.New()
@@ -359,11 +377,6 @@ func (s *PostgresMetadataStore) CreateRootDirectory(
 		return nil, mapPgError(err, "CreateRootDirectory", shareName)
 	}
 
-	// Commit transaction
-	if err := tx.Commit(ctx); err != nil {
-		return nil, mapPgError(err, "CreateRootDirectory", shareName)
-	}
-
 	s.logger.Info("Root directory created successfully",
 		"share", shareName,
 		"root_id", rootID,
@@ -393,7 +406,7 @@ func (s *PostgresMetadataStore) CreateRootDirectory(
 
 // getExistingRootDirectory checks if a root directory already exists for the share
 // and returns it if found. Returns nil, nil if not found.
-func (s *PostgresMetadataStore) getExistingRootDirectory(ctx context.Context, shareName string) (*metadata.File, error) {
+func (s *PostgresMetadataStore) getExistingRootDirectory(ctx context.Context, queryRow rowQuerier, shareName string) (*metadata.File, error) {
 	// Resolve the root inode via shares.root_file_id (the share row is the
 	// authoritative pointer to its root) now that the path column is gone (#1166).
 	query := `
@@ -418,7 +431,7 @@ func (s *PostgresMetadataStore) getExistingRootDirectory(ctx context.Context, sh
 		nlink        int32
 	)
 
-	err := s.queryRow(ctx, query, shareName).Scan(
+	err := queryRow(ctx, query, shareName).Scan(
 		&id,
 		&fileType,
 		&mode,

--- a/pkg/metadata/store/postgres/store.go
+++ b/pkg/metadata/store/postgres/store.go
@@ -37,6 +37,12 @@ type PostgresMetadataStore struct {
 	// of the same M rows leaves the same count). Never read in production.
 	manifestWrites atomic.Int64
 
+	// manifestRowsScanned counts the stored file_block_refs rows the manifest
+	// diff has had to read since open. Test-only observability: it is what
+	// BlocksDirtyOffsets bounds, so a test can prove a scoped commit reads the
+	// changed offsets rather than the whole file. Never read in production.
+	manifestRowsScanned atomic.Int64
+
 	// ctx is the store context (for graceful shutdown)
 	ctx context.Context
 
@@ -167,7 +173,7 @@ func NewPostgresMetadataStore(
 		"database", cfg.Database,
 		"max_conns", cfg.MaxConns,
 		"stats_cache_ttl", cfg.StatsCacheTTL,
-		"prepare_statements", cfg.PrepareStatements,
+		"prepared_statements", !cfg.DisablePreparedStatements,
 	)
 
 	return store, nil
@@ -328,46 +334,38 @@ func (s *PostgresMetadataStore) Close() error {
 	return nil
 }
 
-// initializeFilesystemCapabilities inserts or updates filesystem capabilities in the database
-func initializeFilesystemCapabilities(ctx context.Context, pool *pgxpool.Pool, caps metadata.FilesystemCapabilities) error {
-	query := `
-		INSERT INTO filesystem_capabilities (
-			id,
-			max_read_size,
-			preferred_read_size,
-			max_write_size,
-			preferred_write_size,
-			max_file_size,
-			max_filename_len,
-			max_path_len,
-			max_hard_link_count,
-			supports_hard_links,
-			supports_symlinks,
-			case_sensitive,
-			case_preserving,
-			supports_acls,
-			time_resolution
-		) VALUES (
-			1, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14
-		)
-		ON CONFLICT (id) DO UPDATE SET
-			max_read_size = EXCLUDED.max_read_size,
-			preferred_read_size = EXCLUDED.preferred_read_size,
-			max_write_size = EXCLUDED.max_write_size,
-			preferred_write_size = EXCLUDED.preferred_write_size,
-			max_file_size = EXCLUDED.max_file_size,
-			max_filename_len = EXCLUDED.max_filename_len,
-			max_path_len = EXCLUDED.max_path_len,
-			max_hard_link_count = EXCLUDED.max_hard_link_count,
-			supports_hard_links = EXCLUDED.supports_hard_links,
-			supports_symlinks = EXCLUDED.supports_symlinks,
-			case_sensitive = EXCLUDED.case_sensitive,
-			case_preserving = EXCLUDED.case_preserving,
-			supports_acls = EXCLUDED.supports_acls,
-			time_resolution = EXCLUDED.time_resolution
-	`
+// upsertCapabilitiesSQL writes the single filesystem_capabilities row. Shared
+// by store construction and SetFilesystemCapabilities so the two can never
+// persist a different column set.
+const upsertCapabilitiesSQL = `
+	INSERT INTO filesystem_capabilities (
+		id, max_read_size, preferred_read_size, max_write_size, preferred_write_size,
+		max_file_size, max_filename_len, max_path_len, max_hard_link_count,
+		supports_hard_links, supports_symlinks, case_sensitive, case_preserving,
+		supports_acls, time_resolution
+	) VALUES (
+		1, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14
+	)
+	ON CONFLICT (id) DO UPDATE SET
+		max_read_size = EXCLUDED.max_read_size,
+		preferred_read_size = EXCLUDED.preferred_read_size,
+		max_write_size = EXCLUDED.max_write_size,
+		preferred_write_size = EXCLUDED.preferred_write_size,
+		max_file_size = EXCLUDED.max_file_size,
+		max_filename_len = EXCLUDED.max_filename_len,
+		max_path_len = EXCLUDED.max_path_len,
+		max_hard_link_count = EXCLUDED.max_hard_link_count,
+		supports_hard_links = EXCLUDED.supports_hard_links,
+		supports_symlinks = EXCLUDED.supports_symlinks,
+		case_sensitive = EXCLUDED.case_sensitive,
+		case_preserving = EXCLUDED.case_preserving,
+		supports_acls = EXCLUDED.supports_acls,
+		time_resolution = EXCLUDED.time_resolution
+`
 
-	_, err := pool.Exec(ctx, query,
+// capabilityArgs binds a capability set to upsertCapabilitiesSQL's placeholders.
+func capabilityArgs(caps metadata.FilesystemCapabilities) []any {
+	return []any{
 		caps.MaxReadSize,
 		caps.PreferredReadSize,
 		caps.MaxWriteSize,
@@ -382,7 +380,11 @@ func initializeFilesystemCapabilities(ctx context.Context, pool *pgxpool.Pool, c
 		caps.CasePreserving,
 		caps.SupportsACLs,
 		caps.TimestampResolution,
-	)
+	}
+}
 
+// initializeFilesystemCapabilities inserts or updates filesystem capabilities in the database
+func initializeFilesystemCapabilities(ctx context.Context, pool *pgxpool.Pool, caps metadata.FilesystemCapabilities) error {
+	_, err := pool.Exec(ctx, upsertCapabilitiesSQL, capabilityArgs(caps)...)
 	return err
 }

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -360,23 +360,28 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 	// pgx.ErrNoRows means it did not, so we fall through to INSERT.
 	var oldSizeVal sql.NullInt64
 	var oldUIDVal, oldGIDVal, oldTypeVal sql.NullInt64
-	updated := true
-	scanErr := tx.tx.QueryRow(ctx, updateQuery,
-		file.Type, file.Mode, file.UID, file.GID, file.Size,
-		sqlcodec.TimeToFiletime(file.Atime), sqlcodec.TimeToFiletime(file.Mtime),
-		sqlcodec.TimeToFiletime(file.Ctime), sqlcodec.TimeToFiletime(file.CreationTime),
-		payloadIDPtr, linkTargetPtr, deviceMajor, deviceMinor,
-		file.Hidden, aclJSON, easJSON, objectIDArg,
-		deletedAtArg, file.OriginalPath, file.DeletedBy,
-		file.ID, file.ShareName,
-	).Scan(&oldSizeVal, &oldUIDVal, &oldGIDVal, &oldTypeVal)
-	switch {
-	case scanErr == nil:
-		// Row existed and was updated; oldSizeVal holds the pre-update size.
-	case errors.Is(scanErr, pgx.ErrNoRows):
-		updated = false
-	default:
-		return mapPgError(scanErr, "PutFile", "")
+	// A caller that knows the inode is new skips the probe entirely: on a
+	// create the round-trip can only ever report "no such row", and a stale
+	// claim surfaces as the INSERT's duplicate-key error.
+	updated := !file.NewInode
+	if updated {
+		scanErr := tx.tx.QueryRow(ctx, updateQuery,
+			file.Type, file.Mode, file.UID, file.GID, file.Size,
+			sqlcodec.TimeToFiletime(file.Atime), sqlcodec.TimeToFiletime(file.Mtime),
+			sqlcodec.TimeToFiletime(file.Ctime), sqlcodec.TimeToFiletime(file.CreationTime),
+			payloadIDPtr, linkTargetPtr, deviceMajor, deviceMinor,
+			file.Hidden, aclJSON, easJSON, objectIDArg,
+			deletedAtArg, file.OriginalPath, file.DeletedBy,
+			file.ID, file.ShareName,
+		).Scan(&oldSizeVal, &oldUIDVal, &oldGIDVal, &oldTypeVal)
+		switch {
+		case scanErr == nil:
+			// Row existed and was updated; oldSizeVal holds the pre-update size.
+		case errors.Is(scanErr, pgx.ErrNoRows):
+			updated = false
+		default:
+			return mapPgError(scanErr, "PutFile", "")
+		}
 	}
 
 	// Track size delta for regular files after a successful update.
@@ -462,7 +467,8 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 		// manifest, so putFileChunkRefs writes nothing and reports wrote=false.
 		// Freshly-inserted rows (!updated) have no prior refs, so every ref is
 		// a plain insert. The counter tracks manifests that truly changed.
-		wrote, err := putFileChunkRefs(ctx, tx.tx, file.ID, file.Blocks, updated)
+		wrote, scanned, err := putFileChunkRefs(ctx, tx.tx, file.ID, file.Blocks, updated, file.BlocksDirtyOffsets)
+		tx.store.manifestRowsScanned.Add(int64(scanned))
 		if err != nil {
 			return mapPgError(err, "PutFile", "blocks")
 		}
@@ -1378,14 +1384,15 @@ func (tx *postgresTransaction) GetFileByPayloadID(ctx context.Context, payloadID
 			f.atime, f.mtime, f.ctime, f.creation_time,
 			f.content_id, f.link_target, f.device_major, f.device_minor,
 			f.hidden, f.acl, f.eas, f.object_id,
-			f.deleted_at, f.original_path, f.deleted_by, f.nlink
+			f.deleted_at, f.original_path, f.deleted_by, f.nlink,
+			` + blockRefsAggExpr + `
 		FROM inodes f
 		WHERE f.content_id_hash = md5($1)
 		LIMIT 1
 	`
 
 	row := tx.tx.QueryRow(ctx, query, string(payloadID))
-	file, err := sqlcodec.FileRowToFileWithNlink(row)
+	file, err := sqlcodec.FileRowToFileWithNlinkAndBlocks(row, true)
 	if err != nil {
 		return nil, mapPgError(err, "GetFileByPayloadID", string(payloadID))
 	}

--- a/pkg/metadata/store/sqlite/config.go
+++ b/pkg/metadata/store/sqlite/config.go
@@ -21,9 +21,6 @@ type SQLiteMetadataStoreConfig struct {
 	// than fail. Default: 5s.
 	BusyTimeout time.Duration `mapstructure:"busy_timeout"`
 
-	// QueryTimeout bounds an individual statement. Default: 30s.
-	QueryTimeout time.Duration `mapstructure:"query_timeout"`
-
 	// AutoMigrate runs embedded migrations on open when true. Default: false
 	// (the factory enables it explicitly, matching the Postgres backend).
 	AutoMigrate bool `mapstructure:"auto_migrate"`
@@ -37,9 +34,6 @@ type SQLiteMetadataStoreConfig struct {
 func (c *SQLiteMetadataStoreConfig) ApplyDefaults() {
 	if c.BusyTimeout == 0 {
 		c.BusyTimeout = 5 * time.Second
-	}
-	if c.QueryTimeout == 0 {
-		c.QueryTimeout = 30 * time.Second
 	}
 	if c.StatsCacheTTL == 0 {
 		c.StatsCacheTTL = 5 * time.Second

--- a/pkg/metadata/store/sqlite/file_block_refs.go
+++ b/pkg/metadata/store/sqlite/file_block_refs.go
@@ -42,24 +42,28 @@ import (
 //
 // hasPriorRefs lets a freshly-inserted file skip the stored-row query: with no
 // prior rows every incoming ref is a plain insert.
-func putFileChunkRefs(ctx context.Context, tx execer, fileID uuid.UUID, blocks []block.ChunkRef, hasPriorRefs bool) (bool, error) {
-	upserts, deletes, err := fileChunkRefsDelta(ctx, tx, fileID, blocks, hasPriorRefs)
+//
+// scope, when non-nil, restricts the whole delta to those offsets — see
+// fileChunkRefsDelta. The returned count is how many stored rows the diff had
+// to read, which is what a scope bounds.
+func putFileChunkRefs(ctx context.Context, tx execer, fileID uuid.UUID, blocks []block.ChunkRef, hasPriorRefs bool, scope []uint64) (bool, int, error) {
+	upserts, deletes, scanned, err := fileChunkRefsDelta(ctx, tx, fileID, blocks, hasPriorRefs, scope)
 	if err != nil {
-		return false, err
+		return false, scanned, err
 	}
 	if len(upserts) == 0 && len(deletes) == 0 {
-		return false, nil
+		return false, scanned, nil
 	}
 	// DELETE removed offsets, then UPSERT changed/new ones. Order is
 	// immaterial (disjoint offset sets) but delete-first keeps a shrink's row
 	// count from transiently peaking.
 	if err := deleteChunkRefOffsets(ctx, tx, fileID, deletes); err != nil {
-		return false, err
+		return false, scanned, err
 	}
 	if err := upsertChunkRefs(ctx, tx, fileID, upserts); err != nil {
-		return false, err
+		return false, scanned, err
 	}
-	return true, nil
+	return true, scanned, nil
 }
 
 // storedChunkRef is a stored file_block_refs row minus its offset (the map key).
@@ -74,30 +78,26 @@ type storedChunkRef struct {
 // stored set is known-empty, so the query is skipped and every ref is an
 // upsert. Offsets are unique under the (file_id, "offset") PK, so keying the
 // diff on offset is sound.
-func fileChunkRefsDelta(ctx context.Context, tx execer, fileID uuid.UUID, blocks []block.ChunkRef, hasPriorRefs bool) ([]block.ChunkRef, []int64, error) {
+//
+// scope, when non-nil, is the caller's promise that no offset outside it can
+// differ from what is stored. The stored-row query, the incoming scan and the
+// delete set are then all confined to it, so a commit that touches a handful of
+// chunks costs a handful of rows instead of the file's entire manifest. A nil
+// scope keeps the full diff, which is what a caller that re-derived the
+// manifest from scratch needs.
+func fileChunkRefsDelta(ctx context.Context, tx execer, fileID uuid.UUID, blocks []block.ChunkRef, hasPriorRefs bool, scope []uint64) ([]block.ChunkRef, []int64, int, error) {
+	var inScope map[int64]struct{}
+	if scope != nil {
+		inScope = make(map[int64]struct{}, len(scope))
+		for _, off := range scope {
+			inScope[int64(off)] = struct{}{}
+		}
+	}
+
 	stored := make(map[int64]storedChunkRef)
 	if hasPriorRefs {
-		rows, err := tx.Query(ctx,
-			`SELECT "offset", size, hash FROM file_block_refs WHERE file_id = ?1`,
-			fileID,
-		)
-		if err != nil {
-			return nil, nil, fmt.Errorf("query file_block_refs for %s: %w", fileID, err)
-		}
-		defer rows.Close()
-		for rows.Next() {
-			var off int64
-			var sz int32
-			var raw []byte
-			if err := rows.Scan(&off, &sz, &raw); err != nil {
-				return nil, nil, fmt.Errorf("scan file_block_ref: %w", err)
-			}
-			h := make([]byte, len(raw))
-			copy(h, raw)
-			stored[off] = storedChunkRef{size: sz, hash: h}
-		}
-		if err := rows.Err(); err != nil {
-			return nil, nil, fmt.Errorf("iterate file_block_refs: %w", err)
+		if err := scanStoredChunkRefs(ctx, tx, fileID, inScope, stored); err != nil {
+			return nil, nil, len(stored), err
 		}
 	}
 
@@ -105,6 +105,11 @@ func fileChunkRefsDelta(ctx context.Context, tx execer, fileID uuid.UUID, blocks
 	incoming := make(map[int64]struct{}, len(blocks))
 	for _, b := range blocks {
 		off := int64(b.Offset)
+		if inScope != nil {
+			if _, ok := inScope[off]; !ok {
+				continue
+			}
+		}
 		incoming[off] = struct{}{}
 		if s, ok := stored[off]; ok && s.size == int32(b.Size) && bytes.Equal(s.hash, b.Hash[:]) {
 			continue // identical row already stored — no write
@@ -117,7 +122,67 @@ func fileChunkRefsDelta(ctx context.Context, tx execer, fileID uuid.UUID, blocks
 			deletes = append(deletes, off)
 		}
 	}
-	return upserts, deletes, nil
+	return upserts, deletes, len(stored), nil
+}
+
+// scanStoredChunkRefs loads the stored rows for fileID into out. A nil inScope
+// reads the whole manifest; otherwise only those offsets are read, in IN-list
+// batches capped the same way as the write helpers so the bound-parameter count
+// stays under SQLite's default limit.
+func scanStoredChunkRefs(ctx context.Context, tx execer, fileID uuid.UUID, inScope map[int64]struct{}, out map[int64]storedChunkRef) error {
+	const selectRefs = `SELECT "offset", size, hash FROM file_block_refs WHERE file_id = ?`
+	if inScope == nil {
+		return scanChunkRefBatch(ctx, tx, fileID, selectRefs, []any{fileID}, out)
+	}
+
+	offsets := make([]int64, 0, len(inScope))
+	for off := range inScope {
+		offsets = append(offsets, off)
+	}
+	const perBatch = 200
+	for start := 0; start < len(offsets); start += perBatch {
+		batch := offsets[start:min(start+perBatch, len(offsets))]
+		var sb strings.Builder
+		sb.WriteString(selectRefs)
+		sb.WriteString(` AND "offset" IN (`)
+		args := make([]any, 0, len(batch)+1)
+		args = append(args, fileID)
+		for i, off := range batch {
+			if i > 0 {
+				sb.WriteByte(',')
+			}
+			sb.WriteByte('?')
+			args = append(args, off)
+		}
+		sb.WriteByte(')')
+		if err := scanChunkRefBatch(ctx, tx, fileID, sb.String(), args, out); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func scanChunkRefBatch(ctx context.Context, tx execer, fileID uuid.UUID, query string, args []any, out map[int64]storedChunkRef) error {
+	rows, err := tx.Query(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("query file_block_refs for %s: %w", fileID, err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var off int64
+		var sz int32
+		var raw []byte
+		if err := rows.Scan(&off, &sz, &raw); err != nil {
+			return fmt.Errorf("scan file_block_ref: %w", err)
+		}
+		h := make([]byte, len(raw))
+		copy(h, raw)
+		out[off] = storedChunkRef{size: sz, hash: h}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate file_block_refs: %w", err)
+	}
+	return nil
 }
 
 // deleteChunkRefOffsets removes the given offsets for fileID. Offsets are
@@ -188,6 +253,14 @@ func upsertChunkRefs(ctx context.Context, tx execer, fileID uuid.UUID, refs []bl
 // re-projections of an unchanged manifest perform ZERO manifest writes.
 func (s *SQLiteMetadataStore) PutFileChunkRefsCallCount() int64 {
 	return s.manifestWrites.Load()
+}
+
+// PutFileChunkRefsManifestRowsScanned returns how many stored file_block_refs
+// rows PutFile's manifest diff has read since store open. Test-only — proves a
+// scoped commit's read cost tracks the changed offsets, not the file's total
+// chunk count.
+func (s *SQLiteMetadataStore) PutFileChunkRefsManifestRowsScanned() int64 {
+	return s.manifestRowsScanned.Load()
 }
 
 // deleteFileChunkRefs removes all rows for fileID. The FK cascade

--- a/pkg/metadata/store/sqlite/files.go
+++ b/pkg/metadata/store/sqlite/files.go
@@ -461,14 +461,15 @@ func (s *SQLiteMetadataStore) GetFileByPayloadID(ctx context.Context, payloadID 
 			f.atime, f.mtime, f.ctime, f.creation_time,
 			f.content_id, f.link_target, f.device_major, f.device_minor,
 			f.hidden, f.acl, f.eas, f.object_id,
-			f.deleted_at, f.original_path, f.deleted_by, f.nlink
+			f.deleted_at, f.original_path, f.deleted_by, f.nlink,
+			` + blockRefsAggExpr + `
 		FROM inodes f
 		WHERE f.content_id = ?1
 		LIMIT 1
 	`
 
 	row := s.queryRow(ctx, query, string(payloadID))
-	file, err := sqlcodec.FileRowToFileWithNlink(row)
+	file, err := sqlcodec.FileRowToFileWithNlinkAndBlocks(row, true)
 	if err != nil {
 		return nil, mapDBError(err, "GetFileByPayloadID", string(payloadID))
 	}

--- a/pkg/metadata/store/sqlite/manifest_delta_scope_test.go
+++ b/pkg/metadata/store/sqlite/manifest_delta_scope_test.go
@@ -1,0 +1,127 @@
+package sqlite_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/sqlite"
+)
+
+// TestScopedManifestCommitDoesNotScaleWithChunkCount asserts that folding a
+// single committed chunk into a file's manifest reads a bounded number of
+// stored file_block_refs rows regardless of how many chunks the file already
+// has. Before the commit path carried its changed-offset set, the diff read
+// every stored row, so this cost grew with the file.
+func TestScopedManifestCommitDoesNotScaleWithChunkCount(t *testing.T) {
+	small := scopedCommitRowsScanned(t, 64)
+	large := scopedCommitRowsScanned(t, 4096)
+
+	if small != large || large > 4 {
+		t.Fatalf("scoped commit read %d stored rows on a 64-chunk file and %d on a 4096-chunk file; want an equal count bounded by the changed offsets", small, large)
+	}
+}
+
+// scopedCommitRowsScanned seeds a file with chunks chunk refs, then commits one
+// replacement chunk through the projection path and reports how many stored
+// manifest rows that commit's diff read.
+func scopedCommitRowsScanned(t *testing.T, chunks int) int64 {
+	t.Helper()
+	ctx := t.Context()
+
+	store, err := sqlite.NewSQLiteMetadataStore(ctx, &sqlite.SQLiteMetadataStoreConfig{
+		Path:        t.TempDir() + "/m.db",
+		AutoMigrate: true,
+	}, sqliteTestCapabilities())
+	if err != nil {
+		t.Fatalf("NewSQLiteMetadataStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	const share = "/scope"
+	if _, err := store.CreateRootDirectory(ctx, share, &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory, Mode: 0o755,
+	}); err != nil {
+		t.Fatalf("CreateRootDirectory: %v", err)
+	}
+
+	handle, err := store.GenerateHandle(ctx, share, "/f")
+	if err != nil {
+		t.Fatalf("GenerateHandle: %v", err)
+	}
+	_, id, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		t.Fatalf("DecodeFileHandle: %v", err)
+	}
+
+	const payloadID = "payload-scope"
+	const chunkSize = 4096
+	refs := make([]block.ChunkRef, chunks)
+	for i := range refs {
+		refs[i] = block.ChunkRef{
+			Hash:   hashOf(1, byte(i), byte(i>>8)),
+			Offset: uint64(i) * chunkSize,
+			Size:   chunkSize,
+		}
+	}
+
+	// Seed the manifest in one unscoped write — the state a large file reaches
+	// before the commit under test.
+	if err := store.PutFile(ctx, &metadata.File{
+		ShareName: share,
+		Path:      "/f",
+		ID:        id,
+		FileAttr: metadata.FileAttr{
+			Type:        metadata.FileTypeRegular,
+			Mode:        0o644,
+			Size:        uint64(chunks) * chunkSize,
+			PayloadID:   metadata.PayloadID(payloadID),
+			Blocks:      refs,
+			BlocksDirty: true,
+		},
+	}); err != nil {
+		t.Fatalf("PutFile (seed %d chunks): %v", chunks, err)
+	}
+
+	// Commit a single replacement chunk in the middle of the file, the way a
+	// carve commit does.
+	target := refs[chunks/2]
+	target.Hash = hashOf(2, 0xff, 0xff)
+	baseline := store.PutFileChunkRefsManifestRowsScanned()
+	if err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return metadata.ProjectCommittedChunks(ctx, tx, payloadID, []*block.FileChunk{{
+			ID:       fmt.Sprintf("%s/%d", payloadID, target.Offset),
+			Hash:     target.Hash,
+			DataSize: target.Size,
+		}})
+	}); err != nil {
+		t.Fatalf("ProjectCommittedChunks: %v", err)
+	}
+	scanned := store.PutFileChunkRefsManifestRowsScanned() - baseline
+
+	// The replacement must be visible, and every other offset untouched.
+	got, err := store.GetFile(ctx, handle)
+	if err != nil {
+		t.Fatalf("GetFile: %v", err)
+	}
+	if len(got.Blocks) != chunks {
+		t.Fatalf("manifest length changed: got %d blocks, want %d", len(got.Blocks), chunks)
+	}
+	for i, ref := range got.Blocks {
+		want := refs[i]
+		if i == chunks/2 {
+			want.Hash = target.Hash
+		}
+		if ref != want {
+			t.Fatalf("block %d: got %+v, want %+v", i, ref, want)
+		}
+	}
+	return scanned
+}
+
+func hashOf(b ...byte) block.ContentHash {
+	var h block.ContentHash
+	copy(h[:], b)
+	return h
+}

--- a/pkg/metadata/store/sqlite/objects.go
+++ b/pkg/metadata/store/sqlite/objects.go
@@ -44,18 +44,7 @@ var _ block.FileChunkStore = (*SQLiteMetadataStore)(nil)
 // FileChunkStore interface; kept as a backend
 // method for engine-internal callers.
 func (s *SQLiteMetadataStore) GetFileChunk(ctx context.Context, id string) (*metadata.FileChunk, error) {
-	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
-		FROM file_blocks WHERE id = ?1`
-	row := s.queryRow(ctx, query, id)
-
-	block, err := scanFileChunk(row)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, metadata.ErrFileChunkNotFound
-	}
-	if err != nil {
-		return nil, fmt.Errorf("get file chunk: %w", err)
-	}
-	return block, nil
+	return getFileChunkTx(ctx, s.conn(), id)
 }
 
 // Put stores or updates a file chunk.
@@ -71,29 +60,84 @@ func (s *SQLiteMetadataStore) GetFileChunk(ctx context.Context, id string) (*met
 // and badger backends always store the hash inline on the row, so this
 // matches their behavior.
 func (s *SQLiteMetadataStore) Put(ctx context.Context, block *metadata.FileChunk) error {
+	return putFileChunkTx(ctx, s.conn(), block)
+}
+
+// Delete removes a file chunk by its ID.
+func (s *SQLiteMetadataStore) Delete(ctx context.Context, id string) error {
+	return deleteFileChunkTx(ctx, s.conn(), id)
+}
+
+// IncrementRefCount atomically increments a block's RefCount.
+func (s *SQLiteMetadataStore) IncrementRefCount(ctx context.Context, id string) error {
+	return incrementRefCountTx(ctx, s.conn(), id)
+}
+
+// DecrementRefCount atomically decrements a block's RefCount.
+func (s *SQLiteMetadataStore) DecrementRefCount(ctx context.Context, id string) (uint32, error) {
+	return decrementRefCountTx(ctx, s.conn(), id)
+}
+
+// DecrementRefCountAndReap atomically decrements ref_count and, when it hits 0,
+// deletes the row — both statements run inside ONE transaction so the
+// decrement-and-reap is atomic and TOCTOU-free against a concurrent AddRef
+// (which takes the same row lock). Returns (0, nil) when the row is already
+// absent — a swept row is not a caller error. Running through WithTransaction
+// also gives a SQLITE_BUSY collision the package's bounded retry instead of
+// surfacing it as a hard error.
+func (s *SQLiteMetadataStore) DecrementRefCountAndReap(ctx context.Context, id string) (uint32, error) {
+	var newCount uint32
+	err := s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		var txErr error
+		newCount, txErr = tx.DecrementRefCountAndReap(ctx, id)
+		return txErr
+	})
+	if err != nil {
+		return 0, err
+	}
+	return newCount, nil
+}
+
+// The bodies below carry the file_blocks CRUD SQL once. Both the pool path and
+// the transaction path run them over their own executor, so the two surfaces
+// cannot drift apart.
+
+// getFileChunkTx reads one chunk row by ID, mapping a missing row to
+// ErrFileChunkNotFound.
+func getFileChunkTx(ctx context.Context, x execer, id string) (*metadata.FileChunk, error) {
+	row := x.QueryRow(ctx, `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
+		FROM file_blocks WHERE id = ?1`, id)
+	chunk, err := scanFileChunk(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, metadata.ErrFileChunkNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get file chunk: %w", err)
+	}
+	return chunk, nil
+}
+
+// putFileChunkTx inserts or updates one chunk row.
+//
+// ref_count is omitted from the ON CONFLICT update list so a concurrent
+// IncrementRefCount / DecrementRefCount (atomic SQL +1 / -1 UPDATEs) cannot be
+// overwritten by a stale in-memory RefCount; the INSERT path still writes the
+// caller's value verbatim. hash uses COALESCE so a zero-hash Put never NULLs a
+// previously persisted good hash. LastSyncAttemptAt persists as NULL when zero
+// so the janitor's `last_sync_attempt_at < cutoff` predicate skips
+// never-claimed rows instead of matching every Pending row.
+func putFileChunkTx(ctx context.Context, x execer, chunk *metadata.FileChunk) error {
 	var hashStr *string
-	if !block.Hash.IsZero() {
-		h := block.Hash.String()
+	if !chunk.Hash.IsZero() {
+		h := chunk.Hash.String()
 		hashStr = &h
 	}
-	// persist LastSyncAttemptAt as NULL when zero so the
-	// janitor's WHERE last_sync_attempt_at < cutoff predicate excludes
-	// never-claimed rows naturally instead of matching every Pending row.
 	var lastSyncAttemptAt *time.Time
-	if !block.LastSyncAttemptAt.IsZero() {
-		t := block.LastSyncAttemptAt
+	if !chunk.LastSyncAttemptAt.IsZero() {
+		t := chunk.LastSyncAttemptAt
 		lastSyncAttemptAt = &t
 	}
-
-	// Omit ref_count from the ON CONFLICT UPDATE list so concurrent
-	// IncrementRefCount / DecrementRefCount (which run as atomic SQL `+1` /
-	// `-1` UPDATEs) cannot be silently overwritten by a stale
-	// Put-with-in-memory-RefCount. RefCount on the INSERT path is still set
-	// verbatim from the caller's *FileChunk (matches the contract for new
-	// rows). For existing rows, RefCount mutates exclusively through
-	// Increment/Decrement. hash uses COALESCE so a zero-hash Put never NULLs
-	// a previously-persisted good hash.
-	query := `
+	_, err := x.Exec(ctx, `
 		INSERT INTO file_blocks (id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at)
 		VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
 		ON CONFLICT (id) DO UPDATE SET
@@ -101,48 +145,47 @@ func (s *SQLiteMetadataStore) Put(ctx context.Context, block *metadata.FileChunk
 			data_size = EXCLUDED.data_size,
 			last_access = EXCLUDED.last_access,
 			state = EXCLUDED.state,
-			last_sync_attempt_at = EXCLUDED.last_sync_attempt_at`
-	_, err := s.exec(ctx, query,
-		block.ID, hashStr, block.DataSize,
-		block.RefCount, block.LastAccess, block.CreatedAt, block.State, lastSyncAttemptAt)
+			last_sync_attempt_at = EXCLUDED.last_sync_attempt_at`,
+		chunk.ID, hashStr, chunk.DataSize,
+		chunk.RefCount, chunk.LastAccess, chunk.CreatedAt, chunk.State, lastSyncAttemptAt)
 	if err != nil {
 		return fmt.Errorf("put file chunk: %w", err)
 	}
 	return nil
 }
 
-// Delete removes a file chunk by its ID. Renamed from DeleteFileChunk in
-func (s *SQLiteMetadataStore) Delete(ctx context.Context, id string) error {
-	result, err := s.exec(ctx, `DELETE FROM file_blocks WHERE id = ?1`, id)
+// deleteFileChunkTx removes one chunk row, reporting ErrFileChunkNotFound when
+// no row matched.
+func deleteFileChunkTx(ctx context.Context, x execer, id string) error {
+	result, err := x.Exec(ctx, `DELETE FROM file_blocks WHERE id = ?1`, id)
 	if err != nil {
 		return fmt.Errorf("delete file chunk: %w", err)
 	}
-	rows := result.RowsAffected()
-	if rows == 0 {
+	if result.RowsAffected() == 0 {
 		return metadata.ErrFileChunkNotFound
 	}
 	return nil
 }
 
-// IncrementRefCount atomically increments a block's RefCount.
-func (s *SQLiteMetadataStore) IncrementRefCount(ctx context.Context, id string) error {
-	result, err := s.exec(ctx,
-		`UPDATE file_blocks SET ref_count = ref_count + 1 WHERE id = ?1`, id)
+// incrementRefCountTx bumps one chunk's ref_count by 1.
+func incrementRefCountTx(ctx context.Context, x execer, id string) error {
+	result, err := x.Exec(ctx, `UPDATE file_blocks SET ref_count = ref_count + 1 WHERE id = ?1`, id)
 	if err != nil {
 		return fmt.Errorf("increment ref count: %w", err)
 	}
-	rows := result.RowsAffected()
-	if rows == 0 {
+	if result.RowsAffected() == 0 {
 		return metadata.ErrFileChunkNotFound
 	}
 	return nil
 }
 
-// DecrementRefCount atomically decrements a block's RefCount.
-func (s *SQLiteMetadataStore) DecrementRefCount(ctx context.Context, id string) (uint32, error) {
-	query := `UPDATE file_blocks SET ref_count = MAX(ref_count - 1, 0) WHERE id = ?1 RETURNING ref_count`
+// decrementRefCountTx drops one chunk's ref_count by 1, flooring at 0, and
+// returns the remaining count.
+func decrementRefCountTx(ctx context.Context, x execer, id string) (uint32, error) {
 	var newCount uint32
-	err := s.queryRow(ctx, query, id).Scan(&newCount)
+	err := x.QueryRow(ctx,
+		`UPDATE file_blocks SET ref_count = MAX(ref_count - 1, 0) WHERE id = ?1 RETURNING ref_count`,
+		id).Scan(&newCount)
 	if errors.Is(err, sql.ErrNoRows) {
 		return 0, metadata.ErrFileChunkNotFound
 	}
@@ -152,35 +195,40 @@ func (s *SQLiteMetadataStore) DecrementRefCount(ctx context.Context, id string) 
 	return newCount, nil
 }
 
-// DecrementRefCountAndReap atomically decrements ref_count and, when it hits 0,
-// deletes the row — both statements run inside ONE transaction so the
-// decrement-and-reap is atomic and TOCTOU-free against a concurrent AddRef
-// (which takes the same row lock). The conditional `ref_count = 0` predicate on
-// the DELETE means a concurrent bump that landed between the two statements
-// (impossible within the row lock, but defended anyway) leaves the row alive.
-// Returns (0, nil) when the row is already absent — a swept row is not a caller
-// error.
-func (s *SQLiteMetadataStore) DecrementRefCountAndReap(ctx context.Context, id string) (uint32, error) {
-	rawTx, err := s.db.BeginTx(ctx, nil)
+// addRefTx bumps ref_count on every Remote row carrying hash, reporting
+// ErrUnknownHash when none does.
+func addRefTx(ctx context.Context, x execer, hash block.ContentHash) error {
+	result, err := x.Exec(ctx,
+		`UPDATE file_blocks SET ref_count = ref_count + 1 WHERE hash = ?1 AND state = 2 /* Remote */`,
+		hash.String())
 	if err != nil {
-		return 0, fmt.Errorf("decrement-and-reap begin tx: %w", err)
+		return fmt.Errorf("add ref: %w", err)
 	}
-	defer func() { _ = rawTx.Rollback() }()
-
-	newCount, err := decrementAndReapTx(ctx, execer{e: rawTx, op: "DecrementRefCountAndReap"}, id)
-	if err != nil {
-		return 0, err
+	if result.RowsAffected() == 0 {
+		return metadata.ErrUnknownHash
 	}
-	if err := rawTx.Commit(); err != nil {
-		return 0, fmt.Errorf("decrement-and-reap commit: %w", err)
-	}
-	return newCount, nil
+	return nil
 }
 
-// decrementAndReapTx runs the -1 UPDATE then a conditional DELETE on the given
-// pgx.Tx. Shared by the pool-backed store method and the sqliteTransaction
-// method so both surfaces behave identically. Returns ErrFileChunkNotFound
-// mapped to (0, nil) — i.e. a missing row is tolerated.
+// getByHashTx resolves a Remote chunk by content hash, returning (nil, nil)
+// when none matches.
+func getByHashTx(ctx context.Context, x execer, hash metadata.ContentHash) (*metadata.FileChunk, error) {
+	row := x.QueryRow(ctx, `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
+		FROM file_blocks WHERE hash = ?1 AND state = 2 /* Remote */`, hash.String())
+	chunk, err := scanFileChunk(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("find file chunk by hash: %w", err)
+	}
+	return chunk, nil
+}
+
+// decrementAndReapTx runs the -1 UPDATE then a conditional DELETE. The
+// `ref_count = 0` predicate on the DELETE means a bump that landed between the
+// two statements leaves the row alive. Returns (0, nil) for an already-swept
+// row rather than ErrFileChunkNotFound.
 func decrementAndReapTx(ctx context.Context, tx execer, id string) (uint32, error) {
 	var newCount uint32
 	err := tx.QueryRow(ctx,
@@ -238,16 +286,7 @@ func (s *SQLiteMetadataStore) AddRef(ctx context.Context, hash block.ContentHash
 	// not a valid dedup donor, so AddRef must miss it and return
 	// ErrUnknownHash exactly as before, letting the caller fall back to
 	// the full Put path.
-	result, err := s.exec(ctx,
-		`UPDATE file_blocks SET ref_count = ref_count + 1 WHERE hash = ?1 AND state = 2 /* Remote */`,
-		hash.String())
-	if err != nil {
-		return fmt.Errorf("add ref: %w", err)
-	}
-	if result.RowsAffected() == 0 {
-		return metadata.ErrUnknownHash
-	}
-	return nil
+	return addRefTx(ctx, s.conn(), hash)
 }
 
 // GetByHash looks up a finalized block by its content hash.
@@ -256,18 +295,7 @@ func (s *SQLiteMetadataStore) AddRef(ctx context.Context, hash block.ContentHash
 // Pending or Syncing rows have not been confirmed on the remote and
 // are unsafe dedup targets.
 func (s *SQLiteMetadataStore) GetByHash(ctx context.Context, hash metadata.ContentHash) (*metadata.FileChunk, error) {
-	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
-		FROM file_blocks WHERE hash = ?1 AND state = 2 /* Remote */`
-	row := s.queryRow(ctx, query, hash.String())
-
-	block, err := scanFileChunk(row)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("find file chunk by hash: %w", err)
-	}
-	return block, nil
+	return getByHashTx(ctx, s.conn(), hash)
 }
 
 // ListFileChunks returns all blocks belonging to a file, ordered by block index.
@@ -509,167 +537,56 @@ func scanFileChunkRows(rows scanRows) ([]*metadata.FileChunk, error) {
 // Ensure sqliteTransaction implements FileChunkStore
 var _ block.FileChunkStore = (*sqliteTransaction)(nil)
 
-// The FileChunkStore methods on
-// sqliteTransaction MUST execute against the txn's own pgx.Tx, not the
-// public store's connection-pool helpers. Previously every method just
-// called `tx.store.X(...)` which routed through the pool — defeating
-// rollback for any caller that bumped RefCount inside WithTransaction
-// then encountered a downstream PutFile failure (silent
-// leak). All proxies below are now tx-bound; non-mutating
-// helpers keep the pool path because no caller mutates state through them.
+// Every FileChunkStore method below runs on the transaction's own executor,
+// never the store's pool helpers: a pool connection cannot see the
+// transaction's uncommitted writes and would survive its rollback, so a caller
+// that bumped RefCount inside WithTransaction and then hit a downstream
+// PutFile failure would leak the bump.
 
 func (tx *sqliteTransaction) GetFileChunk(ctx context.Context, id string) (*metadata.FileChunk, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
-		FROM file_blocks WHERE id = ?1`
-	row := tx.tx.QueryRow(ctx, query, id)
-	block, err := scanFileChunk(row)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, metadata.ErrFileChunkNotFound
-	}
-	if err != nil {
-		return nil, fmt.Errorf("get file chunk: %w", err)
-	}
-	return block, nil
+	return getFileChunkTx(ctx, tx.tx, id)
 }
 
 func (tx *sqliteTransaction) Put(ctx context.Context, block *metadata.FileChunk) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	var hashStr *string
-	if !block.Hash.IsZero() {
-		h := block.Hash.String()
-		hashStr = &h
-	}
-	var lastSyncAttemptAt *time.Time
-	if !block.LastSyncAttemptAt.IsZero() {
-		t := block.LastSyncAttemptAt
-		lastSyncAttemptAt = &t
-	}
-	// Omit ref_count from the ON CONFLICT update list (matches the pool-path
-	// Put). RefCount mutates only via Increment/Decrement. hash uses COALESCE
-	// so a zero-hash Put never NULLs a previously-persisted good hash.
-	query := `
-		INSERT INTO file_blocks (id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at)
-		VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
-		ON CONFLICT (id) DO UPDATE SET
-			hash = COALESCE(EXCLUDED.hash, file_blocks.hash),
-			data_size = EXCLUDED.data_size,
-			last_access = EXCLUDED.last_access,
-			state = EXCLUDED.state,
-			last_sync_attempt_at = EXCLUDED.last_sync_attempt_at`
-	_, err := tx.tx.Exec(ctx, query,
-		block.ID, hashStr, block.DataSize,
-		block.RefCount, block.LastAccess, block.CreatedAt, block.State, lastSyncAttemptAt)
-	if err != nil {
-		return fmt.Errorf("put file chunk: %w", err)
-	}
-	return nil
+	return putFileChunkTx(ctx, tx.tx, block)
 }
 
 func (tx *sqliteTransaction) Delete(ctx context.Context, id string) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	result, err := tx.tx.Exec(ctx, `DELETE FROM file_blocks WHERE id = ?1`, id)
-	if err != nil {
-		return fmt.Errorf("delete file chunk: %w", err)
-	}
-	if result.RowsAffected() == 0 {
-		return metadata.ErrFileChunkNotFound
-	}
-	return nil
+	return deleteFileChunkTx(ctx, tx.tx, id)
 }
 
-// IncrementRefCount runs the +1 UPDATE on the active pgx.Tx so a
-// subsequent rollback undoes the bump (fix). Production callers
-// route here through metadataCoordinator.IncrementRefCount when ctx
-// carries an active tx via metadata.WithTx.
+// IncrementRefCount bumps ref_count on the active transaction so a subsequent
+// rollback undoes it. Production callers reach here through
+// metadataCoordinator.IncrementRefCount when ctx carries an active tx.
 func (tx *sqliteTransaction) IncrementRefCount(ctx context.Context, id string) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	result, err := tx.tx.Exec(ctx,
-		`UPDATE file_blocks SET ref_count = ref_count + 1 WHERE id = ?1`, id)
-	if err != nil {
-		return fmt.Errorf("increment ref count: %w", err)
-	}
-	if result.RowsAffected() == 0 {
-		return metadata.ErrFileChunkNotFound
-	}
-	return nil
+	return incrementRefCountTx(ctx, tx.tx, id)
 }
 
-// DecrementRefCount runs the -1 UPDATE on the active pgx.Tx so a
-// subsequent rollback undoes the decrement (fix).
+// DecrementRefCount drops ref_count on the active transaction so a subsequent
+// rollback undoes it.
 func (tx *sqliteTransaction) DecrementRefCount(ctx context.Context, id string) (uint32, error) {
-	if err := ctx.Err(); err != nil {
-		return 0, err
-	}
-	query := `UPDATE file_blocks SET ref_count = MAX(ref_count - 1, 0) WHERE id = ?1 RETURNING ref_count`
-	var newCount uint32
-	err := tx.tx.QueryRow(ctx, query, id).Scan(&newCount)
-	if errors.Is(err, sql.ErrNoRows) {
-		return 0, metadata.ErrFileChunkNotFound
-	}
-	if err != nil {
-		return 0, fmt.Errorf("decrement ref count: %w", err)
-	}
-	return newCount, nil
+	return decrementRefCountTx(ctx, tx.tx, id)
 }
 
-// DecrementRefCountAndReap runs the -1 UPDATE + reap-at-zero DELETE on the
-// active pgx.Tx so a subsequent rollback undoes both. Returns (0, nil) when the
-// row is already absent.
+// DecrementRefCountAndReap runs the -1 UPDATE and the reap-at-zero DELETE on
+// the active transaction so a subsequent rollback undoes both. Returns
+// (0, nil) when the row is already absent.
 func (tx *sqliteTransaction) DecrementRefCountAndReap(ctx context.Context, id string) (uint32, error) {
-	if err := ctx.Err(); err != nil {
-		return 0, err
-	}
 	return decrementAndReapTx(ctx, tx.tx, id)
 }
 
-// AddRef runs the +1 UPDATE keyed by hash on the active pgx.Tx so a
-// subsequent rollback undoes the bump (parity for the
-// LRU hit path). Returns metadata.ErrUnknownHash when no row matches.
+// AddRef bumps ref_count keyed by hash on the active transaction so a
+// subsequent rollback undoes it. Returns metadata.ErrUnknownHash when no row
+// matches.
 func (tx *sqliteTransaction) AddRef(ctx context.Context, hash block.ContentHash, _ string, _ block.ChunkRef) error {
 	// payloadID + blockRef accepted for future GC traceability;
 	// postgres backend records ref count only — parameters intentionally
 	// blanked.
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	// state = 2 (Remote) scoping mirrors the pool-path AddRef and the
-	// memory/badger backends — a Pending row is not a valid dedup donor.
-	result, err := tx.tx.Exec(ctx,
-		`UPDATE file_blocks SET ref_count = ref_count + 1 WHERE hash = ?1 AND state = 2 /* Remote */`,
-		hash.String())
-	if err != nil {
-		return fmt.Errorf("add ref: %w", err)
-	}
-	if result.RowsAffected() == 0 {
-		return metadata.ErrUnknownHash
-	}
-	return nil
+	return addRefTx(ctx, tx.tx, hash)
 }
 
 func (tx *sqliteTransaction) GetByHash(ctx context.Context, hash metadata.ContentHash) (*metadata.FileChunk, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
-		FROM file_blocks WHERE hash = ?1 AND state = 2 /* Remote */`
-	row := tx.tx.QueryRow(ctx, query, hash.String())
-	block, err := scanFileChunk(row)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("find file chunk by hash: %w", err)
-	}
-	return block, nil
+	return getByHashTx(ctx, tx.tx, hash)
 }
 
 // ListFileChunks / EnumerateFileChunks run on the active

--- a/pkg/metadata/store/sqlite/server.go
+++ b/pkg/metadata/store/sqlite/server.go
@@ -83,48 +83,7 @@ func (s *SQLiteMetadataStore) SetFilesystemCapabilities(capabilities metadata.Fi
 	// Update database (best effort - don't fail if it errors)
 	// This is called during initialization, so database updates are non-critical
 	ctx := context.Background()
-	query := `
-		INSERT INTO filesystem_capabilities (
-			id, max_read_size, preferred_read_size, max_write_size, preferred_write_size,
-			max_file_size, max_filename_len, max_path_len, max_hard_link_count,
-			supports_hard_links, supports_symlinks, case_sensitive, case_preserving,
-			supports_acls, time_resolution
-		) VALUES (
-			1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14
-		)
-		ON CONFLICT (id) DO UPDATE SET
-			max_read_size = EXCLUDED.max_read_size,
-			preferred_read_size = EXCLUDED.preferred_read_size,
-			max_write_size = EXCLUDED.max_write_size,
-			preferred_write_size = EXCLUDED.preferred_write_size,
-			max_file_size = EXCLUDED.max_file_size,
-			max_filename_len = EXCLUDED.max_filename_len,
-			max_path_len = EXCLUDED.max_path_len,
-			max_hard_link_count = EXCLUDED.max_hard_link_count,
-			supports_hard_links = EXCLUDED.supports_hard_links,
-			supports_symlinks = EXCLUDED.supports_symlinks,
-			case_sensitive = EXCLUDED.case_sensitive,
-			case_preserving = EXCLUDED.case_preserving,
-			supports_acls = EXCLUDED.supports_acls,
-			time_resolution = EXCLUDED.time_resolution
-	`
-
-	_, err := s.exec(ctx, query,
-		capabilities.MaxReadSize,
-		capabilities.PreferredReadSize,
-		capabilities.MaxWriteSize,
-		capabilities.PreferredWriteSize,
-		capabilities.MaxFileSize,
-		capabilities.MaxFilenameLen,
-		capabilities.MaxPathLen,
-		capabilities.MaxHardLinkCount,
-		capabilities.SupportsHardLinks,
-		capabilities.SupportsSymlinks,
-		capabilities.CaseSensitive,
-		capabilities.CasePreserving,
-		capabilities.SupportsACLs,
-		capabilities.TimestampResolution,
-	)
+	_, err := s.exec(ctx, upsertCapabilitiesSQL, capabilityArgs(capabilities)...)
 
 	// Log error but don't fail - capabilities are already cached
 	if err != nil {

--- a/pkg/metadata/store/sqlite/shares.go
+++ b/pkg/metadata/store/sqlite/shares.go
@@ -100,7 +100,7 @@ func (s *SQLiteMetadataStore) CreateShare(ctx context.Context, share *metadata.S
 	// primary key (the ON CONFLICT upsert just re-points root_file_id, leaving
 	// at most one root). (Production also serializes share creation upstream in
 	// the control plane.)
-	existing, err := s.getExistingRootDirectory(ctx, share.Name)
+	existing, err := s.getExistingRootDirectory(ctx, s.conn(), share.Name)
 	if err != nil {
 		return fmt.Errorf("create share %q: check existing: %w", share.Name, err)
 	}
@@ -208,7 +208,12 @@ func (s *SQLiteMetadataStore) ListShares(ctx context.Context) ([]string, error) 
 // Root Directory Operations
 // ============================================================================
 
-// CreateRootDirectory creates the root directory for a share
+// CreateRootDirectory creates the root directory for a share.
+//
+// The whole probe-then-create sequence runs in one transaction through
+// WithTransaction, so a SQLITE_BUSY collision retries under the package's
+// backoff and a concurrent caller cannot slip between the probe and the
+// insert and leave an orphaned root inode behind.
 func (s *SQLiteMetadataStore) CreateRootDirectory(
 	ctx context.Context,
 	shareName string,
@@ -221,6 +226,26 @@ func (s *SQLiteMetadataStore) CreateRootDirectory(
 		}
 	}
 
+	var root *metadata.File
+	err := s.WithTransaction(ctx, func(mtx metadata.Transaction) error {
+		var txErr error
+		root, txErr = s.createRootDirectoryTx(ctx, mtx.(*sqliteTransaction).tx, shareName, attr)
+		return txErr
+	})
+	if err != nil {
+		return nil, err
+	}
+	return root, nil
+}
+
+// createRootDirectoryTx holds the probe/reconcile/create body, run against the
+// caller's transaction.
+func (s *SQLiteMetadataStore) createRootDirectoryTx(
+	ctx context.Context,
+	tx execer,
+	shareName string,
+	attr *metadata.FileAttr,
+) (*metadata.File, error) {
 	// Apply defaults
 	uid := attr.UID
 	gid := attr.GID
@@ -236,7 +261,7 @@ func (s *SQLiteMetadataStore) CreateRootDirectory(
 	)
 
 	// Check if root directory already exists (idempotent behavior)
-	existingRoot, err := s.getExistingRootDirectory(ctx, shareName)
+	existingRoot, err := s.getExistingRootDirectory(ctx, tx, shareName)
 	if err == nil && existingRoot != nil {
 		// Check if root directory attributes need to be updated from config
 		// This handles the case where the config changed since the share was first created
@@ -273,7 +298,7 @@ func (s *SQLiteMetadataStore) CreateRootDirectory(
 				SET mode = ?1, uid = ?2, gid = ?3, ctime = ?4
 				WHERE id = ?5
 			`
-			_, err := s.exec(ctx, updateQuery,
+			_, err := tx.Exec(ctx, updateQuery,
 				int32(existingRoot.Mode),
 				int32(existingRoot.UID),
 				int32(existingRoot.GID),
@@ -295,19 +320,6 @@ func (s *SQLiteMetadataStore) CreateRootDirectory(
 		}
 		return existingRoot, nil
 	}
-
-	// Begin transaction.
-	rawTx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return nil, mapDBError(err, "CreateRootDirectory", shareName)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = rawTx.Rollback()
-		}
-	}()
-	tx := execer{e: rawTx, op: "CreateRootDirectory"}
 
 	// Generate UUID for root directory
 	rootID := uuid.New()
@@ -365,12 +377,6 @@ func (s *SQLiteMetadataStore) CreateRootDirectory(
 		return nil, mapDBError(err, "CreateRootDirectory", shareName)
 	}
 
-	// Commit transaction
-	if err := rawTx.Commit(); err != nil {
-		return nil, mapDBError(err, "CreateRootDirectory", shareName)
-	}
-	committed = true
-
 	s.logger.Info("Root directory created successfully",
 		"share", shareName,
 		"root_id", rootID,
@@ -400,7 +406,7 @@ func (s *SQLiteMetadataStore) CreateRootDirectory(
 
 // getExistingRootDirectory checks if a root directory already exists for the share
 // and returns it if found. Returns nil, nil if not found.
-func (s *SQLiteMetadataStore) getExistingRootDirectory(ctx context.Context, shareName string) (*metadata.File, error) {
+func (s *SQLiteMetadataStore) getExistingRootDirectory(ctx context.Context, tx execer, shareName string) (*metadata.File, error) {
 	// Resolve the root inode via shares.root_file_id (the share row is the
 	// authoritative pointer to its root) now that the path column is gone (#1166).
 	query := `
@@ -425,7 +431,7 @@ func (s *SQLiteMetadataStore) getExistingRootDirectory(ctx context.Context, shar
 		nlink        int32
 	)
 
-	err := s.queryRow(ctx, query, shareName).Scan(
+	err := tx.QueryRow(ctx, query, shareName).Scan(
 		&id,
 		&fileType,
 		&mode,

--- a/pkg/metadata/store/sqlite/snapshot_store.go
+++ b/pkg/metadata/store/sqlite/snapshot_store.go
@@ -27,7 +27,9 @@ const sqliteEngineTag = "sqlite"
 // file_blocks IS in backupTables, so the dumped row shape changes one column.
 // v4 drops the dead block_store_key column from file_blocks (migration 000008);
 // file_blocks IS in backupTables, so the dumped row shape changes one column.
-const sqliteSchemaVersion uint32 = 4
+// v5 adds the block_records section, matching what the postgres backend has
+// always dumped; RestoreSnapshot rejects the older streams that lack it.
+const sqliteSchemaVersion uint32 = 5
 
 // backupTables lists every table dumped by WriteSnapshot and reloaded by RestoreSnapshot, in a
 // FK-safe order for restore (parents before children). inodes must precede
@@ -48,6 +50,10 @@ var backupTables = []string{
 	"server_config",
 	"server_epoch",
 	"filesystem_capabilities",
+	// block_records has no foreign keys, so it restores anywhere in the
+	// order. Omitting it dropped every block's sync state and live-chunk
+	// count across snapshot/restore and left them behind on Reset.
+	"block_records",
 }
 
 // isKnownTable guards Restore against an unexpected table name in the stream.

--- a/pkg/metadata/store/sqlite/store.go
+++ b/pkg/metadata/store/sqlite/store.go
@@ -63,6 +63,12 @@ type SQLiteMetadataStore struct {
 	// of the same M rows leaves the same count). Never read in production.
 	manifestWrites atomic.Int64
 
+	// manifestRowsScanned counts the stored file_block_refs rows the manifest
+	// diff has had to read since open. Test-only observability: it is what
+	// BlocksDirtyOffsets bounds, so a test can prove a scoped commit reads the
+	// changed offsets rather than the whole file. Never read in production.
+	manifestRowsScanned atomic.Int64
+
 	// quota tracks per-identity usage (bytes + file count) for regular files,
 	// keyed by owner uid / gid. Seeded from a GROUP BY query on startup and
 	// updated from each committed transaction's deltas. Guarded by quotaMu.
@@ -300,46 +306,38 @@ func (s *SQLiteMetadataStore) Close() error {
 	return nil
 }
 
-// initializeFilesystemCapabilities inserts or updates filesystem capabilities.
-func initializeFilesystemCapabilities(ctx context.Context, db *sql.DB, caps metadata.FilesystemCapabilities) error {
-	query := `
-		INSERT INTO filesystem_capabilities (
-			id,
-			max_read_size,
-			preferred_read_size,
-			max_write_size,
-			preferred_write_size,
-			max_file_size,
-			max_filename_len,
-			max_path_len,
-			max_hard_link_count,
-			supports_hard_links,
-			supports_symlinks,
-			case_sensitive,
-			case_preserving,
-			supports_acls,
-			time_resolution
-		) VALUES (
-			1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
-		)
-		ON CONFLICT (id) DO UPDATE SET
-			max_read_size = excluded.max_read_size,
-			preferred_read_size = excluded.preferred_read_size,
-			max_write_size = excluded.max_write_size,
-			preferred_write_size = excluded.preferred_write_size,
-			max_file_size = excluded.max_file_size,
-			max_filename_len = excluded.max_filename_len,
-			max_path_len = excluded.max_path_len,
-			max_hard_link_count = excluded.max_hard_link_count,
-			supports_hard_links = excluded.supports_hard_links,
-			supports_symlinks = excluded.supports_symlinks,
-			case_sensitive = excluded.case_sensitive,
-			case_preserving = excluded.case_preserving,
-			supports_acls = excluded.supports_acls,
-			time_resolution = excluded.time_resolution
-	`
+// upsertCapabilitiesSQL writes the single filesystem_capabilities row. Shared
+// by store construction and SetFilesystemCapabilities so the two can never
+// persist a different column set.
+const upsertCapabilitiesSQL = `
+	INSERT INTO filesystem_capabilities (
+		id, max_read_size, preferred_read_size, max_write_size, preferred_write_size,
+		max_file_size, max_filename_len, max_path_len, max_hard_link_count,
+		supports_hard_links, supports_symlinks, case_sensitive, case_preserving,
+		supports_acls, time_resolution
+	) VALUES (
+		1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14
+	)
+	ON CONFLICT (id) DO UPDATE SET
+		max_read_size = excluded.max_read_size,
+		preferred_read_size = excluded.preferred_read_size,
+		max_write_size = excluded.max_write_size,
+		preferred_write_size = excluded.preferred_write_size,
+		max_file_size = excluded.max_file_size,
+		max_filename_len = excluded.max_filename_len,
+		max_path_len = excluded.max_path_len,
+		max_hard_link_count = excluded.max_hard_link_count,
+		supports_hard_links = excluded.supports_hard_links,
+		supports_symlinks = excluded.supports_symlinks,
+		case_sensitive = excluded.case_sensitive,
+		case_preserving = excluded.case_preserving,
+		supports_acls = excluded.supports_acls,
+		time_resolution = excluded.time_resolution
+`
 
-	_, err := db.ExecContext(ctx, query,
+// capabilityArgs binds a capability set to upsertCapabilitiesSQL's placeholders.
+func capabilityArgs(caps metadata.FilesystemCapabilities) []any {
+	return []any{
 		caps.MaxReadSize,
 		caps.PreferredReadSize,
 		caps.MaxWriteSize,
@@ -354,6 +352,11 @@ func initializeFilesystemCapabilities(ctx context.Context, db *sql.DB, caps meta
 		caps.CasePreserving,
 		caps.SupportsACLs,
 		caps.TimestampResolution,
-	)
+	}
+}
+
+// initializeFilesystemCapabilities inserts or updates filesystem capabilities.
+func initializeFilesystemCapabilities(ctx context.Context, db *sql.DB, caps metadata.FilesystemCapabilities) error {
+	_, err := db.ExecContext(ctx, upsertCapabilitiesSQL, capabilityArgs(caps)...)
 	return err
 }

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -299,27 +299,32 @@ func (tx *sqliteTransaction) PutFile(ctx context.Context, file *metadata.File) e
 	// so we fall through to INSERT.
 	var oldSizeVal sql.NullInt64
 	var oldUIDVal, oldGIDVal, oldTypeVal sql.NullInt64
-	updated := true
-	scanErr := tx.tx.QueryRow(ctx, selectOldQuery, file.ID, file.ShareName).
-		Scan(&oldSizeVal, &oldUIDVal, &oldGIDVal, &oldTypeVal)
-	switch {
-	case scanErr == nil:
-		// Row exists; update it in place.
-		if _, err := tx.tx.Exec(ctx, updateQuery,
-			file.Type, file.Mode, file.UID, file.GID, file.Size,
-			sqlcodec.TimeToFiletime(file.Atime), sqlcodec.TimeToFiletime(file.Mtime),
-			sqlcodec.TimeToFiletime(file.Ctime), sqlcodec.TimeToFiletime(file.CreationTime),
-			payloadIDPtr, linkTargetPtr, deviceMajor, deviceMinor,
-			file.Hidden, aclJSON, easJSON, objectIDArg,
-			deletedAtArg, file.OriginalPath, file.DeletedBy,
-			file.ID, file.ShareName,
-		); err != nil {
-			return mapDBError(err, "PutFile", "")
+	// A caller that knows the inode is new skips the probe entirely: on a
+	// create the round-trip can only ever report "no such row", and a stale
+	// claim surfaces as the INSERT's duplicate-key error.
+	updated := !file.NewInode
+	if updated {
+		scanErr := tx.tx.QueryRow(ctx, selectOldQuery, file.ID, file.ShareName).
+			Scan(&oldSizeVal, &oldUIDVal, &oldGIDVal, &oldTypeVal)
+		switch {
+		case scanErr == nil:
+			// Row exists; update it in place.
+			if _, err := tx.tx.Exec(ctx, updateQuery,
+				file.Type, file.Mode, file.UID, file.GID, file.Size,
+				sqlcodec.TimeToFiletime(file.Atime), sqlcodec.TimeToFiletime(file.Mtime),
+				sqlcodec.TimeToFiletime(file.Ctime), sqlcodec.TimeToFiletime(file.CreationTime),
+				payloadIDPtr, linkTargetPtr, deviceMajor, deviceMinor,
+				file.Hidden, aclJSON, easJSON, objectIDArg,
+				deletedAtArg, file.OriginalPath, file.DeletedBy,
+				file.ID, file.ShareName,
+			); err != nil {
+				return mapDBError(err, "PutFile", "")
+			}
+		case errors.Is(scanErr, sql.ErrNoRows):
+			updated = false
+		default:
+			return mapDBError(scanErr, "PutFile", "")
 		}
-	case errors.Is(scanErr, sql.ErrNoRows):
-		updated = false
-	default:
-		return mapDBError(scanErr, "PutFile", "")
 	}
 
 	// Track size delta for regular files after a successful update.
@@ -405,7 +410,8 @@ func (tx *sqliteTransaction) PutFile(ctx context.Context, file *metadata.File) e
 		// manifest, so putFileChunkRefs writes nothing and reports wrote=false.
 		// Freshly-inserted rows (!updated) have no prior refs, so every ref is
 		// a plain insert. The counter tracks manifests that truly changed.
-		wrote, err := putFileChunkRefs(ctx, tx.tx, file.ID, file.Blocks, updated)
+		wrote, scanned, err := putFileChunkRefs(ctx, tx.tx, file.ID, file.Blocks, updated, file.BlocksDirtyOffsets)
+		tx.store.manifestRowsScanned.Add(int64(scanned))
 		if err != nil {
 			return mapDBError(err, "PutFile", "blocks")
 		}
@@ -1331,14 +1337,15 @@ func (tx *sqliteTransaction) GetFileByPayloadID(ctx context.Context, payloadID m
 			f.atime, f.mtime, f.ctime, f.creation_time,
 			f.content_id, f.link_target, f.device_major, f.device_minor,
 			f.hidden, f.acl, f.eas, f.object_id,
-			f.deleted_at, f.original_path, f.deleted_by, f.nlink
+			f.deleted_at, f.original_path, f.deleted_by, f.nlink,
+			` + blockRefsAggExpr + `
 		FROM inodes f
 		WHERE f.content_id = ?1
 		LIMIT 1
 	`
 
 	row := tx.tx.QueryRow(ctx, query, string(payloadID))
-	file, err := sqlcodec.FileRowToFileWithNlink(row)
+	file, err := sqlcodec.FileRowToFileWithNlinkAndBlocks(row, true)
 	if err != nil {
 		return nil, mapDBError(err, "GetFileByPayloadID", string(payloadID))
 	}

--- a/pkg/metadata/storetest/reset_conformance.go
+++ b/pkg/metadata/storetest/reset_conformance.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
@@ -38,6 +39,20 @@ func ResetThenRestoreConformance(t *testing.T, factory SnapshotableStoreFactory)
 	// reuses the same backing DB across the Snapshot suite and this suite.
 	shareName, uniqueHashes := populateTestData(t, store, "rst")
 
+	// Block records live outside the file tree, so Reset and Restore have to
+	// carry them explicitly — nothing rebuilds a block's sync state or
+	// live-chunk count from the manifest.
+	blockRec := block.BlockRecord{
+		BlockID:        "rst-blk-001",
+		BlockHash:      block.ContentHash{5, 5, 5},
+		Length:         8192,
+		LiveChunkCount: 2,
+		SyncState:      block.BlockStateRemote,
+	}
+	if err := store.PutBlockRecord(ctx, blockRec); err != nil {
+		t.Fatalf("PutBlockRecord: %v", err)
+	}
+
 	// 1. Back up the populated store into a buffer.
 	var dumpBuf bytes.Buffer
 	hs, err := b.WriteSnapshot(ctx, &dumpBuf)
@@ -51,6 +66,12 @@ func ResetThenRestoreConformance(t *testing.T, factory SnapshotableStoreFactory)
 	// 2. Reset the SAME store in place — no close/reopen.
 	if err := r.Reset(ctx); err != nil {
 		t.Fatalf("Reset: %v", err)
+	}
+
+	if _, found, err := store.GetBlockRecord(ctx, blockRec.BlockID); err != nil {
+		t.Fatalf("post-Reset GetBlockRecord: %v", err)
+	} else if found {
+		t.Errorf("block record %q survived Reset", blockRec.BlockID)
 	}
 
 	// Reset must clear the per-identity quota cache too, not just the
@@ -74,6 +95,14 @@ func ResetThenRestoreConformance(t *testing.T, factory SnapshotableStoreFactory)
 	//    ErrRestoreDestinationNotEmpty precondition so Restore must succeed.
 	if err := b.RestoreSnapshot(ctx, &dumpBuf); err != nil {
 		t.Fatalf("Restore post-Reset: %v", err)
+	}
+
+	if got, found, err := store.GetBlockRecord(ctx, blockRec.BlockID); err != nil {
+		t.Fatalf("post-Restore GetBlockRecord: %v", err)
+	} else if !found {
+		t.Errorf("block record %q missing after Restore", blockRec.BlockID)
+	} else if got != blockRec {
+		t.Errorf("restored block record = %+v, want %+v", got, blockRec)
 	}
 
 	// Restore must reseed the quota cache from the restored files, not leave

--- a/pkg/metadata/storetest/snapshot_conformance.go
+++ b/pkg/metadata/storetest/snapshot_conformance.go
@@ -341,6 +341,19 @@ func testSnapshot_RoundTrip(t *testing.T, factory SnapshotableStoreFactory) {
 
 	ctx := t.Context()
 
+	// Block records carry sync state and live-chunk counts the GC and syncer
+	// rebuild nothing from, so they have to survive the round trip too.
+	blockRec := block.BlockRecord{
+		BlockID:        "rt-blk-001",
+		BlockHash:      block.ContentHash{7, 7, 7},
+		Length:         4096,
+		LiveChunkCount: 3,
+		SyncState:      block.BlockStateRemote,
+	}
+	if err := srcStore.PutBlockRecord(ctx, blockRec); err != nil {
+		t.Fatalf("PutBlockRecord: %v", err)
+	}
+
 	// Snapshot to buffer.
 	var buf bytes.Buffer
 	hashes, err := srcB.WriteSnapshot(ctx, &buf)
@@ -415,6 +428,17 @@ func testSnapshot_RoundTrip(t *testing.T, factory SnapshotableStoreFactory) {
 	}
 	if len(betaFile.Blocks) != 2 {
 		t.Fatalf("beta.Blocks len = %d, want 2", len(betaFile.Blocks))
+	}
+
+	gotRec, found, err := dstStore.GetBlockRecord(ctx, blockRec.BlockID)
+	if err != nil {
+		t.Fatalf("GetBlockRecord after restore: %v", err)
+	}
+	if !found {
+		t.Fatalf("block record %q missing after restore", blockRec.BlockID)
+	}
+	if gotRec != blockRec {
+		t.Errorf("restored block record = %+v, want %+v", gotRec, blockRec)
 	}
 }
 

--- a/pkg/metadata/storetest/store_surface.go
+++ b/pkg/metadata/storetest/store_surface.go
@@ -3,9 +3,11 @@ package storetest
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"testing"
 
+	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/health"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
@@ -501,6 +503,11 @@ func testGetFileByPayloadID(t *testing.T, factory StoreFactory) {
 		t.Fatalf("GetFile() failed: %v", err)
 	}
 	file.PayloadID = payloadID
+	file.Blocks = []block.ChunkRef{
+		{Hash: hashOfSeed("pid-b0"), Offset: 0, Size: 4096},
+		{Hash: hashOfSeed("pid-b1"), Offset: 4096, Size: 2048},
+	}
+	file.BlocksDirty = true
 	if err := store.PutFile(ctx, file); err != nil {
 		t.Fatalf("PutFile() with PayloadID failed: %v", err)
 	}
@@ -515,12 +522,38 @@ func testGetFileByPayloadID(t *testing.T, factory StoreFactory) {
 	if got.PayloadID != payloadID {
 		t.Errorf("GetFileByPayloadID returned PayloadID %q, want %q", got.PayloadID, payloadID)
 	}
+	// Manifest projection reads the file back by payload ID and merges the rows
+	// it just wrote into Blocks, so a backend that hands back an empty list
+	// silently degrades into a full re-derivation. Both variants must carry it.
+	assertPayloadBlocks(t, "store", got, file.Blocks)
+
+	if err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		txGot, txErr := tx.GetFileByPayloadID(ctx, payloadID)
+		if txErr != nil {
+			return txErr
+		}
+		assertPayloadBlocks(t, "transaction", txGot, file.Blocks)
+		return nil
+	}); err != nil {
+		t.Fatalf("tx GetFileByPayloadID(known) failed: %v", err)
+	}
 
 	// Miss: an unknown PayloadID returns not-found.
 	if _, err := store.GetFileByPayloadID(ctx, metadata.PayloadID("does-not-exist")); err == nil {
 		t.Error("GetFileByPayloadID(unknown) should fail")
 	} else if !metadata.IsNotFoundError(err) {
 		t.Errorf("GetFileByPayloadID(unknown): got %v, want not-found", err)
+	}
+}
+
+// assertPayloadBlocks reports whether got carries exactly want, offset-ordered.
+func assertPayloadBlocks(t *testing.T, variant string, got *metadata.File, want []block.ChunkRef) {
+	t.Helper()
+	if got == nil {
+		t.Fatalf("%s GetFileByPayloadID returned nil file", variant)
+	}
+	if !slices.Equal(got.Blocks, want) {
+		t.Errorf("%s GetFileByPayloadID Blocks: got %+v, want %+v", variant, got.Blocks, want)
 	}
 }
 


### PR DESCRIPTION
Works through the MED findings scoped to the SQL metadata stores in the
2026-08-05 data-plane audit report. Relates to #1900.

## Correctness

**`GetFileByPayloadID` never returned the block manifest on either SQL backend.**
Both the pool-path and the transaction-path variants selected 24 inode columns
and stopped, so every caller got a `File` with an empty `Blocks`. That made the
manifest-delta work below dead on arrival: `ProjectCommittedChunks` reads the
file back by payload ID and merges the just-written rows into `Blocks`, and its
`len(file.Blocks) == 0` guard sent every single commit down the full
re-derivation path, where the scope hint is deliberately dropped. The memory
and badger backends both return the manifest here, so the two SQL backends were
the odd ones out. Both variants now fold in `blockRefsAggExpr`, and the
conformance suite asserts the manifest round-trips through
`GetFileByPayloadID` on the store and the transaction surface alike.

**sqlite `backupTables` omitted `block_records`.** Snapshot, restore and reset
silently dropped every block's sync state and live-chunk count — postgres has
always dumped that table. The memory backend had the same hole in its gob
payload. Both fixed; the snapshot conformance round-trip now asserts a block
record survives. sqlite's snapshot schema version goes to 5.

**`CreateRootDirectory` and `DecrementRefCountAndReap` bypassed the packages'
own retry wrappers.** `CreateRootDirectory` hand-rolled a transaction for the
create branch and issued a bare pool `UPDATE` for the config-reconcile branch,
so a serialization failure or `SQLITE_BUSY` surfaced as a hard error instead of
retrying; the probe also sat outside the transaction, leaving a window where two
racing callers each insert a root inode. Both branches now run inside one
`WithTransaction`. `DecrementRefCountAndReap` collapses onto the transaction
implementation that already existed, which drops its hand-rolled begin/commit
and makes the now-unused postgres `beginTx` helper deletable.

## Performance

**Manifest diff scoped to the changed range.** `putFileChunkRefs` re-read and
re-compared the entire stored manifest on every `BlocksDirty` `PutFile`, so a
multi-GB file re-read 10k+ rows per commit — O(N) per write, O(N²) over the
file's life. `FileAttr.BlocksDirtyOffsets` carries the offsets a caller
actually touched; nil still means "diff everything", which is what a full
re-derivation must say.

**`PutFile` no longer pays a guaranteed-miss probe on create.** The create path
holds the exclusivity guarantee, so `FileAttr.NewInode` lets the store skip
straight to the INSERT. A stale claim surfaces as a duplicate-key error rather
than a silent update.

**`prepare_statements=false` now does something.** It was validated, defaulted
and logged, but never reached the pool config — the pooler escape hatch was a
no-op. It now selects an exec mode that carries no server-side statement name.

## Structure

- The postgres durable-handle, client and client-recovery sub-stores held the
  raw pool and bypassed the acquire-timeout wrapper that exists precisely to
  stop them blocking forever on an exhausted pool. They go through the wrapper.
- The `filesystem_capabilities` upsert existed twice per backend — once in the
  constructor, once in `SetFilesystemCapabilities` — with the same 15 columns
  and 14 args. One `upsertCapabilitiesSQL` + `capabilityArgs` per backend.
- sqlite's `file_blocks` CRUD carried byte-identical query literals on the pool
  path and the transaction path. Both now run the same `execer`-parameterized
  bodies, following the `decrementAndReapTx` pattern already in that file.
- The dead sqlite `QueryTimeout` knob is gone. It was operator-settable via
  `query_timeout`, documented as bounding a statement, and never read by
  anything — not the DSN pragmas, not a context deadline.

## Deliberately not in this PR

The postgres pool-vs-tx duplication of `ListChildren` / `GetChild` /
`GetParent` / `GetLinkCount` / `GetFilesystemMeta` / `GetFile`, and the ~180
lines of root-directory config reconciliation duplicated between the two
backends, are the exact seams the planned SQL-family unification collapses.
They are pure-structure findings with no behaviour change, and a large
mechanical refactor here would only collide with that work.

## Verification

`go build ./...`, `go vet ./...` and `gofmt -l .` are clean.
`go test` and `go test -race` pass on `./pkg/metadata/...`, `./pkg/block/...`,
`./pkg/controlplane/...` and `./pkg/snapshot/...`. The postgres conformance
suite needs a live database and runs in CI; the postgres edits mirror the
sqlite ones statement for statement.

Also fixed during review: the memory backend left block records behind on
`Reset`, and the `NewInode` hint stayed set on the struct after the insert,
where the read cache and the caller could inherit it.
