### PR TITLE
fix(metadata): purge the badger share cache on Reset and RestoreSnapshot

### DIFF
--- a/pkg/metadata/store/badger/reset.go
+++ b/pkg/metadata/store/badger/reset.go
@@ -14,6 +14,11 @@ var _ metadata.Resetable = (*BadgerMetadataStore)(nil)
 // up with Snapshotable.RestoreSnapshot. The cfg:store_id key is dropped along with
 // everything else and gets repopulated by the next operation that needs
 // it (typically the restore dump that follows).
+//
+// Every in-memory structure derived from the dropped keys is re-derived here
+// too: the share read cache would otherwise keep answering GetShareOptions
+// from entries whose backing records no longer exist, which is a wrong
+// permission decision.
 func (s *BadgerMetadataStore) Reset(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return fmt.Errorf("badger reset cancelled: %w", err)
@@ -21,6 +26,7 @@ func (s *BadgerMetadataStore) Reset(ctx context.Context) error {
 	if err := s.db.DropAll(); err != nil {
 		return fmt.Errorf("badger reset: drop all: %w", err)
 	}
+	s.shareCache.invalidateAll()
 	s.usedBytes.Store(0)
 	s.quotaMu.Lock()
 	s.quota.Reset()

--- a/pkg/metadata/store/badger/share_read_cache.go
+++ b/pkg/metadata/store/badger/share_read_cache.go
@@ -74,6 +74,15 @@ func (c *shareReadCache) invalidate(shareName string) {
 	c.m.Delete(shareName)
 }
 
+// invalidateAll drops every entry, for callers that replace the whole backing
+// store rather than a single share record (Reset, RestoreSnapshot). Same
+// ordering rule as invalidate: bump gen first so an in-flight populate against
+// the pre-wipe generation cannot re-insert after the clear.
+func (c *shareReadCache) invalidateAll() {
+	c.gen.Add(1)
+	c.m.Clear()
+}
+
 // cloneShareOptions returns a caller-owned deep copy of opts: the struct is
 // copied and every reference-bearing field (three string slices and the
 // IdentityMapping pointee, itself holding *uint32/*uint32/*string) is cloned so

--- a/pkg/metadata/store/badger/snapshot_store.go
+++ b/pkg/metadata/store/badger/snapshot_store.go
@@ -188,6 +188,11 @@ func (s *BadgerMetadataStore) RestoreSnapshot(ctx context.Context, r io.Reader) 
 		return metadata.ErrRestoreDestinationNotEmpty
 	}
 
+	// The restored records replace whatever the share read cache was built
+	// from, and the failure path drops everything again — either way an
+	// entry that outlives this call is a wrong permission decision.
+	defer s.shareCache.invalidateAll()
+
 	// Read envelope header.
 	engineTag, payloadReader, acc, err := backup.ReadHeader(r)
 	if err != nil {

--- a/pkg/metadata/storetest/reset_conformance.go
+++ b/pkg/metadata/storetest/reset_conformance.go
@@ -63,11 +63,24 @@ func ResetThenRestoreConformance(t *testing.T, factory SnapshotableStoreFactory)
 		t.Fatalf("WriteSnapshot HashSet.Len() = %d, want %d", hs.Len(), len(uniqueHashes))
 	}
 
+	// Read the share options once before Reset so any share-options cache the
+	// backend keeps is warm, and the post-Reset check below exercises the
+	// cache rather than the backing store.
+	if _, err := store.GetShareOptions(ctx, shareName); err != nil {
+		t.Fatalf("GetShareOptions(%q) pre-Reset: %v", shareName, err)
+	}
+
 	// 2. Reset the SAME store in place — no close/reopen.
 	if err := r.Reset(ctx); err != nil {
 		t.Fatalf("Reset: %v", err)
 	}
 
+	// Reset must re-derive every in-memory structure built from the dropped
+	// records, not just the durable ones. A surviving share-options entry is a
+	// permission decision made against a share that no longer exists.
+	if _, err := store.GetShareOptions(ctx, shareName); err == nil {
+		t.Fatalf("post-Reset GetShareOptions(%q) succeeded, want an error", shareName)
+	}
 	if _, found, err := store.GetBlockRecord(ctx, blockRec.BlockID); err != nil {
 		t.Fatalf("post-Reset GetBlockRecord: %v", err)
 	} else if found {


### PR DESCRIPTION
Closes #1941. Contributes to #1945.

**Scope shrank after a rebase.** This PR originally carried three fixes; #1949 landed two of them independently (memory `blockRecords` cleared in `Reset`, and sqlite's missing `block_records` in `backupTables`). What remains is the one instance #1949 did not touch: badger's share read cache.

## The bug

`shareCache.invalidate` is called from every share-record write path (`shares.go`, `transaction.go`) but never from `reset.go`, and `RestoreSnapshot` never touched it either. Both replace the durable records wholesale, so a surviving entry answers `GetShareOptions` for a share whose record has just been dropped. The field's own comment already states the stakes — a stale entry is a wrong permission decision — and the reported symptom was a restored read-only share still serving `ReadOnly=false`.

## The fix

`invalidateAll` uses the same ordering rule as `invalidate` (bump `gen`, then clear), so an in-flight `store()` holding the pre-wipe generation is rejected rather than re-inserting a stale entry after the clear. Called from `Reset`, and deferred in `RestoreSnapshot` so the `DropAll` failure path is covered too.

## Test

`ResetThenRestoreConformance` now reads the share options once before `Reset` — warming whatever cache the backend keeps, so the assertion exercises the cache rather than the backing store — then asserts they are gone afterwards. It sits alongside the block-record assertions #1949 added, so the suite now covers both derived structures for every backend.

Deliberately out of scope: badger's `statsCache` (5s TTL, self-heals) and memory's gob payload, which has no `blockRecords` field — `Reset` clearing it is enough for a dev/test backend, and adding a field would move `memorySchemaVersion`.

## Verification

`go test -race ./pkg/metadata/store/... ./pkg/metadata/storetest/... -count=1` green. Postgres skips without a live server locally, so its run of the new assertion is proven in CI.