### PR TITLE
feat(encryption): support master-key rotation via a retired-key set

### DIFF
--- a/docs/guide/encryption.md
+++ b/docs/guide/encryption.md
@@ -65,14 +65,26 @@ encryption:
     kind: local               # local | kmip
     # kind=local
     file: /etc/dittofs/keys/share.key
+    retired_files:            # optional, decrypt-only (see rotation below)
+      - /etc/dittofs/keys/share-2026-02.key
     # kind=kmip
     endpoint: kms.example.com:5696
     server_ca: /etc/dittofs/kmip/ca.pem
     client_cert: /etc/dittofs/kmip/client.pem
     client_key:  /etc/dittofs/kmip/client.key
     key_uid: 12345-abcde-...
+    retired_key_uids:         # optional, decrypt-only
+      - 09876-zyxwv-...
     timeout_ms: 5000
 ```
+
+`file` / `key_uid` name the **current** master key: everything written from
+now on is wrapped under it. `retired_files` / `retired_key_uids` name keys
+that are used for decryption only. Both retired lists default to empty, so
+a config written before rotation existed keeps behaving exactly as it did.
+
+All retired keys share the current key's passphrase
+(`DITTOFS_ENCRYPTION_PASSPHRASE`); there is no per-file passphrase.
 
 ### AEAD cipher choices
 
@@ -98,11 +110,45 @@ Adding an `encryption` block to a remote store that already contains plaintext b
 
 Recommendation: create new remote stores with encryption enabled, migrate data across, then decommission the unencrypted store.
 
-### Master-key rotation requires a full re-encrypt
+### Retiring a master key is one-way — you cannot un-retire what you deleted
 
-There is no key-rotation tooling in this release. Every stored frame records the master-key identifier that wrapped its block key; after rotating to a new master key (writing a new `key_file` or registering a new KMIP key UID), `Unwrap` will return `ErrWrongMasterKey` for every block written under the prior key. The data is **not recoverable** without the prior master key.
+Rotation is supported, and does not re-encrypt any data. Every stored frame
+records the identifier of the master key that wrapped its block key, so
+`Unwrap` routes each block to the key it was written under.
 
-If you must rotate today: keep the old master key available, stage a new remote store under the new key, and copy data across before retiring the old store. A future release will ship a bulk re-wrap command and multi-key `Unwrap`.
+To rotate:
+
+1. Generate the new key file the same way you generated the first one (the
+   `GenerateKeyFile` helper above — there is no dedicated subcommand), or
+   register the new key UID with the HSM.
+2. Move the **current** `file` / `key_uid` value into `retired_files` /
+   `retired_key_uids`.
+3. Point `file` / `key_uid` at the new key.
+4. Restart the share.
+
+From that point, new blocks are wrapped under the new key and old blocks
+keep decrypting under the retired one. Nothing is ever wrapped under a
+retired key again.
+
+The hazard is step 2 in reverse. Dropping a key from `retired_files`, or
+deleting the key file it names, makes every block still wrapped under that
+key **permanently unreadable** — there is no bulk re-wrap command yet, so
+there is no supported way to move existing blocks onto the current key and
+no way to enumerate which blocks still reference an old one. Until that
+ships, treat retired keys as keep-forever: leave them configured and keep
+the key material backed up. Retiring a key costs one HSM fetch or one file
+read at startup, so a handful of them is not a burden worth trimming.
+
+Two operational notes:
+
+- A retired key that cannot be read at startup is logged and skipped rather
+  than being fatal — blocks under it become unreadable, but the share (and
+  every other share on the daemon) still starts. A missing **current** key
+  is still fatal.
+- Two keys claiming the same identifier is rejected at startup, because
+  which one `Unwrap` picks would otherwise be arbitrary. This is what
+  listing the same file twice, or listing the current key as retired, will
+  produce.
 
 ### AAD is per-block, not per-share
 
@@ -110,7 +156,7 @@ The associated data bound into the AEAD is the 32-byte BLAKE3 plaintext hash. It
 
 ## What's not in scope (yet)
 
-- **Master-key rotation tooling** — the frame already records `master_key_id`, so a future bulk rewrite job can re-wrap.
+- **Bulk re-wrap** — rotation works (see above), but there is no job that reads blocks under a retired key and rewrites them under the current one, and no way to enumerate which blocks still reference a given key. Both are required before a retired key can ever be safely dropped.
 - **Filename / size / timestamp encryption** — out of scope; metadata stays unencrypted.
 - **Encrypted disk cache tier** — current cache holds plaintext in RAM / disk; use an encrypted filesystem underneath if needed.
 - **FIPS 140-3 mode** — would require swapping Argon2id for PBKDF2-SHA256, pinning AES-only AEADs, and building with the BoringCrypto tag.

--- a/docs/internals/encryption-design.md
+++ b/docs/internals/encryption-design.md
@@ -4,7 +4,7 @@
 
 ## Envelope encryption design
 
-Standard envelope encryption, following the same shape as AWS SSE-KMS, MinIO + KES, and HashiCorp Vault Transit. Note that unlike those services, DittoFS keeps no retired master keys and therefore does not support rotation — see [Master-key rotation is not supported](#master-key-rotation-is-not-supported) below.
+Standard envelope encryption, following the same shape as AWS SSE-KMS, MinIO + KES, and HashiCorp Vault Transit:
 
 1. A **master key** is held by a key provider (local file or KMIP-speaking HSM). The master key never directly encrypts a block.
 2. For each block, a fresh 32-byte **block key** is generated from `crypto/rand` and used with an AEAD to encrypt the payload.
@@ -49,15 +49,7 @@ master key  (held by key provider; local file or KMIP HSM)
                      └── AEAD-encrypts ──► block payload
 ```
 
-Each frame records the identifier of the master key that wrapped its block key. Today that identifier is only used to *reject* a frame wrapped under a different master key, with `ErrWrongMasterKey`. It leaves room for a multi-key `Unwrap` to be added later without changing the frame format, but no such lookup exists.
-
-## Master-key rotation is not supported
-
-A `KeyProvider` holds exactly one master key. There is no retired-key set: `Unwrap` returns `ErrWrongMasterKey` for every frame whose recorded identifier is not the single one held.
-
-**Changing a share's master key destroys access to all data already written under the old key.** This applies to every provider — writing a new key file, or pointing `key_uid` at a different HSM key. There is no recovery path once the old key is gone, and no re-wrap tooling ships today.
-
-Rotating safely would mean reading every block with a provider holding the old key, re-writing it with one holding the new key, and only then decommissioning the old key. Until that exists, treat a share's master key as fixed for the life of its data. `docs/guide/encryption.md` carries the operator-facing version of this warning.
+The master key identifier stored in each frame is what makes rotation possible without changing the frame format: `Wrap` always uses the current master key and records its id, while `Unwrap` resolves the recorded id against the current key plus a configured set of retired, decrypt-only keys. In NIST SP 800-57 terms that split is the key-wrapping key's originator-usage period (encrypt) versus its longer recipient-usage period (decrypt).
 
 ## KMIP provider behavior and HSM integration
 
@@ -65,7 +57,9 @@ The KMIP provider fetches the configured master key from the HSM at startup usin
 
 This is a real KMIP integration (mutual-TLS, KMIP 1.4 protocol via `github.com/gemalto/kmip-go`) but it is **not** HSM-resident envelope encryption — the master-key bytes do live in the daemon's address space while it runs. A future iteration can move wrap / unwrap into the HSM via KMIP `Encrypt` / `Decrypt` operations without changing the `KeyProvider` interface; the public surface stays the same.
 
-Pointing `key_uid` at a different HSM key is **not** a rotation procedure: only the newly fetched key is held, so every block wrapped under the previous key becomes permanently unreadable. See [Master-key rotation is not supported](#master-key-rotation-is-not-supported).
+Retired uids are fetched the same way at startup, one `Get` each, so the cost of keeping a key retired is one extra fetch per daemon start.
+
+To rotate: write a new key to the HSM, move the outgoing `key_uid` into `retired_key_uids`, set `key_uid` to the new key, and restart the share. Existing blocks stay decryptable because every frame carries the identifier of the master key that wrapped its block key, and that key is still configured. Dropping the uid from `retired_key_uids` instead — or deleting it from the HSM — makes those blocks unreadable, and no bulk re-wrap exists yet to move them off it.
 
 ### Validating against a KMIP server
 

--- a/pkg/block/encryption/doc.go
+++ b/pkg/block/encryption/doc.go
@@ -13,14 +13,14 @@
 //   - On read: decode header → unwrap block key via the provider →
 //     authenticated-decrypt the payload.
 //
-// # Master-key rotation is not supported
+// # Master-key rotation
 //
-// A provider holds exactly one master key and rejects any frame wrapped
-// under a different one, so changing a share's master key makes every
-// block written under the previous key permanently unreadable. Unlike
-// key-management services that keep retired key versions live for
-// decrypt, this package has no retired-key set and no re-wrap tooling.
-// Treat a share's master key as fixed for the life of its data; see
+// A provider holds one current master key plus a set of retired,
+// decrypt-only ones. Frames record the id of the key that wrapped them,
+// so retiring a key keeps existing blocks readable while new writes move
+// onto the new key. There is no re-wrap tooling, so a retired key must
+// stay configured for as long as any block references it; dropping it
+// makes those blocks permanently unreadable. See
 // [github.com/marmos91/dittofs/pkg/block/encryption/keyprovider] for the
 // full behaviour.
 //

--- a/pkg/block/encryption/keyprovider/kmip.go
+++ b/pkg/block/encryption/keyprovider/kmip.go
@@ -59,14 +59,37 @@ func newKMIPProvider(ctx context.Context, cfg Config) (*kmipProvider, error) {
 	if cfg.TimeoutMS > 0 {
 		timeout = time.Duration(cfg.TimeoutMS) * time.Millisecond
 	}
-	key, err := fetchKMIPSymmetricKey(ctx, cfg.Endpoint, tlsCfg, cfg.KeyUID, timeout)
+	key, err := fetchKMIPKey(ctx, cfg, tlsCfg, cfg.KeyUID, timeout)
+	if err != nil {
+		return nil, err
+	}
+	// A KMIP key is identified by the uid the operator configured, so a
+	// retired uid is its own master key id with nothing to look up.
+	retired, err := loadRetiredKeys(cfg.KeyUID, cfg.RetiredKeyUIDs, func(uid string) (string, []byte, error) {
+		k, err := fetchKMIPKey(ctx, cfg, tlsCfg, uid, timeout)
+		return uid, k, err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &kmipProvider{aesGCMKEK: aesGCMKEK{
+		masterKey:   key,
+		masterKeyID: cfg.KeyUID,
+		retired:     retired,
+	}}, nil
+}
+
+// fetchKMIPKey retrieves one symmetric key from the HSM and enforces the
+// AES-256 length the wrap layer requires.
+func fetchKMIPKey(ctx context.Context, cfg Config, tlsCfg *tls.Config, uid string, timeout time.Duration) ([]byte, error) {
+	key, err := fetchKMIPSymmetricKey(ctx, cfg.Endpoint, tlsCfg, uid, timeout)
 	if err != nil {
 		return nil, err
 	}
 	if len(key) != 32 {
-		return nil, fmt.Errorf("%w: kmip key has unexpected length %d (want 32 for AES-256)", ErrInvalidConfig, len(key))
+		return nil, fmt.Errorf("%w: kmip key %q has unexpected length %d (want 32 for AES-256)", ErrInvalidConfig, uid, len(key))
 	}
-	return &kmipProvider{aesGCMKEK: aesGCMKEK{masterKey: key, masterKeyID: cfg.KeyUID}}, nil
+	return key, nil
 }
 
 func buildKMIPTLSConfig(cfg Config) (*tls.Config, error) {

--- a/pkg/block/encryption/keyprovider/kmip.go
+++ b/pkg/block/encryption/keyprovider/kmip.go
@@ -70,6 +70,7 @@ func newKMIPProvider(ctx context.Context, cfg Config) (*kmipProvider, error) {
 		return uid, k, err
 	})
 	if err != nil {
+		zeroKey(key)
 		return nil, err
 	}
 	return &kmipProvider{aesGCMKEK: aesGCMKEK{

--- a/pkg/block/encryption/keyprovider/kmip_fake_test.go
+++ b/pkg/block/encryption/keyprovider/kmip_fake_test.go
@@ -144,26 +144,41 @@ func kmipFailureResponse(t *testing.T) ttlv.TTLV {
 // startFakeKMIP runs a TLS listener that answers one connection with resp.
 func startFakeKMIP(t *testing.T, tlsCfg *tls.Config, resp ttlv.TTLV) *fakeKMIPServer {
 	t.Helper()
+	return startFakeKMIPSeq(t, tlsCfg, resp)
+}
+
+// startFakeKMIPSeq answers one connection per response, in order. Each
+// fetchKMIPSymmetricKey call dials afresh, so a provider that fetches a
+// current key plus N retired uids consumes N+1 responses in the order the
+// uids are configured. Callers that need only one exchange use
+// startFakeKMIP.
+func startFakeKMIPSeq(t *testing.T, tlsCfg *tls.Config, resps ...ttlv.TTLV) *fakeKMIPServer {
+	t.Helper()
 	ln, err := tls.Listen("tcp", "127.0.0.1:0", tlsCfg)
 	if err != nil {
 		t.Fatalf("tls.Listen: %v", err)
 	}
-	s := &fakeKMIPServer{ln: ln, resp: resp}
+	s := &fakeKMIPServer{ln: ln}
+	if len(resps) > 0 {
+		s.resp = resps[0]
+	}
 	s.wg.Add(1)
 	go func() {
 		defer s.wg.Done()
-		conn, err := ln.Accept()
-		if err != nil {
-			return // listener closed
+		for _, resp := range resps {
+			conn, err := ln.Accept()
+			if err != nil {
+				return // listener closed
+			}
+			_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+			// Drain the request: read one framed TTLV so we don't reply
+			// before the client finishes writing (avoids a RST on some
+			// platforms).
+			if _, err := readOneFrame(conn); err == nil {
+				_, _ = conn.Write(resp)
+			}
+			_ = conn.Close()
 		}
-		defer func() { _ = conn.Close() }()
-		_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
-		// Drain the request: read one framed TTLV so we don't reply before
-		// the client finishes writing (avoids a RST on some platforms).
-		if _, err := readOneFrame(conn); err != nil {
-			return
-		}
-		_, _ = conn.Write(s.resp)
 	}()
 	t.Cleanup(func() {
 		_ = ln.Close()

--- a/pkg/block/encryption/keyprovider/local.go
+++ b/pkg/block/encryption/keyprovider/local.go
@@ -90,6 +90,7 @@ func newLocalProvider(cfg Config) (*localProvider, error) {
 		return loadLocalKeyFile(path, passphrase)
 	})
 	if err != nil {
+		zeroKey(masterKey)
 		return nil, err
 	}
 	return &localProvider{aesGCMKEK: aesGCMKEK{
@@ -322,16 +323,9 @@ func (k *aesGCMKEK) Unwrap(_ context.Context, wrapped []byte, masterKeyID string
 // Best-effort — the Go runtime makes no guarantee the bytes are not
 // retained on a GC heap.
 func (k *aesGCMKEK) Close() error {
-	for i := range k.masterKey {
-		k.masterKey[i] = 0
-	}
+	zeroKey(k.masterKey)
 	k.masterKey = nil
-	for id, key := range k.retired {
-		for i := range key {
-			key[i] = 0
-		}
-		delete(k.retired, id)
-	}
+	zeroKeys(k.retired)
 	return nil
 }
 

--- a/pkg/block/encryption/keyprovider/local.go
+++ b/pkg/block/encryption/keyprovider/local.go
@@ -82,19 +82,41 @@ func newLocalProvider(cfg Config) (*localProvider, error) {
 	if passphrase == "" {
 		return nil, ErrPassphraseMissing
 	}
-	raw, err := os.ReadFile(cfg.File)
+	masterKeyID, masterKey, err := loadLocalKeyFile(cfg.File, passphrase)
 	if err != nil {
-		return nil, fmt.Errorf("keyprovider: read key file: %w", err)
+		return nil, err
+	}
+	retired, err := loadRetiredKeys(masterKeyID, cfg.RetiredFiles, func(path string) (string, []byte, error) {
+		return loadLocalKeyFile(path, passphrase)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &localProvider{aesGCMKEK: aesGCMKEK{
+		masterKey:   masterKey,
+		masterKeyID: masterKeyID,
+		retired:     retired,
+	}}, nil
+}
+
+// loadLocalKeyFile reads one passphrase-protected key file and returns
+// the master key id it records alongside the unwrapped key material.
+// Every key file carries its own id, so a retired file identifies itself
+// without the operator restating it in config.
+func loadLocalKeyFile(path, passphrase string) (string, []byte, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", nil, fmt.Errorf("keyprovider: read key file: %w", err)
 	}
 	kf, err := decodeKeyFile(raw)
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
 	masterKey, err := unwrapMasterKey(kf, passphrase)
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
-	return &localProvider{aesGCMKEK: aesGCMKEK{masterKey: masterKey, masterKeyID: kf.MasterKeyID}}, nil
+	return kf.MasterKeyID, masterKey, nil
 }
 
 // GenerateKeyFile produces the bytes of a fresh passphrase-protected key
@@ -225,12 +247,37 @@ func unwrapMasterKey(kf *localKeyFile, passphrase string) ([]byte, error) {
 // aesGCMKEK is the shared Wrap / Unwrap / Close implementation used by
 // any provider that holds an in-memory 32-byte symmetric KEK. The
 // wrapped layout is `nonce || ciphertext-with-tag` under AES-256-GCM.
+//
+// Wrap always uses masterKey and records masterKeyID. Unwrap resolves the
+// id recorded in the frame against the current key plus retired, so a
+// block wrapped under a previous master key stays readable after the
+// current key changes. Retired keys are decrypt-only: nothing is ever
+// wrapped under them again.
 type aesGCMKEK struct {
 	masterKey   []byte
 	masterKeyID string
+
+	// retired maps a master key id to decrypt-only key material. Written
+	// once during construction and read-only thereafter, so it needs no
+	// lock alongside the concurrent Wrap / Unwrap calls.
+	retired map[string][]byte
 }
 
 func (k *aesGCMKEK) CurrentMasterKeyID() string { return k.masterKeyID }
+
+// keyForID returns the master key that wrapped a frame recording
+// masterKeyID. An empty id means the frame predates id recording and can
+// only have come from the current key.
+func (k *aesGCMKEK) keyForID(masterKeyID string) ([]byte, error) {
+	if masterKeyID == "" || masterKeyID == k.masterKeyID {
+		return k.masterKey, nil
+	}
+	if key, ok := k.retired[masterKeyID]; ok {
+		return key, nil
+	}
+	return nil, fmt.Errorf("%w: frame wrapped under %q, have current %q and %d retired",
+		ErrWrongMasterKey, masterKeyID, k.masterKeyID, len(k.retired))
+}
 
 func (k *aesGCMKEK) Wrap(_ context.Context, blockKey []byte) ([]byte, string, error) {
 	if len(blockKey) == 0 {
@@ -251,10 +298,11 @@ func (k *aesGCMKEK) Wrap(_ context.Context, blockKey []byte) ([]byte, string, er
 }
 
 func (k *aesGCMKEK) Unwrap(_ context.Context, wrapped []byte, masterKeyID string) ([]byte, error) {
-	if masterKeyID != "" && masterKeyID != k.masterKeyID {
-		return nil, fmt.Errorf("%w: have %q want %q", ErrWrongMasterKey, k.masterKeyID, masterKeyID)
+	masterKey, err := k.keyForID(masterKeyID)
+	if err != nil {
+		return nil, err
 	}
-	aead, err := newGCM(k.masterKey)
+	aead, err := newGCM(masterKey)
 	if err != nil {
 		return nil, err
 	}
@@ -270,13 +318,20 @@ func (k *aesGCMKEK) Unwrap(_ context.Context, wrapped []byte, masterKeyID string
 	return plain, nil
 }
 
-// Close zeros the master key bytes in memory. Best-effort — the Go
-// runtime makes no guarantee the bytes are not retained on a GC heap.
+// Close zeros the master key bytes in memory, retired keys included.
+// Best-effort — the Go runtime makes no guarantee the bytes are not
+// retained on a GC heap.
 func (k *aesGCMKEK) Close() error {
 	for i := range k.masterKey {
 		k.masterKey[i] = 0
 	}
 	k.masterKey = nil
+	for id, key := range k.retired {
+		for i := range key {
+			key[i] = 0
+		}
+		delete(k.retired, id)
+	}
 	return nil
 }
 

--- a/pkg/block/encryption/keyprovider/provider.go
+++ b/pkg/block/encryption/keyprovider/provider.go
@@ -8,21 +8,13 @@
 // plain names "master key" and "block key" are used throughout this
 // package's prose to keep the role of each thing obvious.
 //
-// # Master-key rotation is NOT supported
-//
-// Every implementation holds exactly one master key. There is no keyring
-// of retired keys: Unwrap returns ErrWrongMasterKey whenever the id
-// recorded in a block's frame header differs from the single id the
-// provider holds. Pointing a running share at a different master key
-// therefore makes every block wrapped under the previous one
-// permanently unreadable — there is no recovery path once the old key
-// is gone.
-//
-// Rotating safely would mean re-wrapping every existing block under the
-// new master key (read with a provider holding the old key, write with
-// one holding the new) and only decommissioning the old key once that
-// pass has completed. No such tool ships today, so treat a share's
-// master key as fixed for the life of its data.
+// A provider holds one current master key plus any number of retired
+// ones. Wrap always uses the current key and records its identifier in
+// the frame; Unwrap resolves that identifier against current-plus-retired
+// and fails only when it matches none. Retiring a key therefore keeps
+// existing blocks readable while new writes move onto the new key. There
+// is no bulk re-wrap, so a retired key must stay configured for as long
+// as any block references it.
 package keyprovider
 
 import (
@@ -39,16 +31,14 @@ type KeyProvider interface {
 	// Wrap protects a block key (typically 32 bytes) under the provider's
 	// master key. Returns the wrapped bytes plus the stable identifier of
 	// the master key used; the identifier is recorded in the on-wire
-	// frame header so Unwrap can reject a block that was wrapped under a
-	// different master key instead of failing with an opaque
-	// authentication error.
+	// frame header so Unwrap can route the block to the master key that
+	// wrapped it, current or retired.
 	Wrap(ctx context.Context, blockKey []byte) (wrapped []byte, masterKeyID string, err error)
 
 	// Unwrap recovers the original block key. masterKeyID is the value
-	// recorded by an earlier Wrap. Every implementation holds exactly one
-	// master key, so Unwrap returns ErrWrongMasterKey whenever the
-	// recorded id is not that one; blocks wrapped under any other key
-	// cannot be recovered (see the package doc on rotation).
+	// recorded by an earlier Wrap. Unwrap resolves it against the current
+	// master key and any retired ones, and returns ErrWrongMasterKey only
+	// when it matches none of them.
 	Unwrap(ctx context.Context, wrapped []byte, masterKeyID string) ([]byte, error)
 
 	// CurrentMasterKeyID returns the identifier that Wrap will record.
@@ -80,6 +70,13 @@ type Config struct {
 	// Local-specific fields (Kind == KindLocal).
 	File string `json:"file,omitempty"`
 
+	// RetiredFiles lists key files whose master keys are decrypt-only:
+	// blocks wrapped under them stay readable, but nothing is wrapped
+	// under them again. Rotating means pointing File at a new key file
+	// and moving the previous path into this list. Empty by default, so
+	// a config written before rotation existed behaves as it always did.
+	RetiredFiles []string `json:"retired_files,omitempty"`
+
 	// KMIP-specific fields (Kind == KindKMIP).
 	Endpoint   string `json:"endpoint,omitempty"`
 	ServerCA   string `json:"server_ca,omitempty"`
@@ -87,6 +84,10 @@ type Config struct {
 	ClientKey  string `json:"client_key,omitempty"`
 	KeyUID     string `json:"key_uid,omitempty"`
 	TimeoutMS  int    `json:"timeout_ms,omitempty"`
+
+	// RetiredKeyUIDs is the KMIP counterpart of RetiredFiles: uids the
+	// HSM still holds, fetched at startup for decrypt only.
+	RetiredKeyUIDs []string `json:"retired_key_uids,omitempty"`
 }
 
 // Sentinel errors. All provider implementations wrap these so callers can
@@ -97,8 +98,8 @@ var (
 	ErrInvalidConfig = errors.New("keyprovider: invalid config")
 
 	// ErrWrongMasterKey indicates the masterKeyID recorded in the wrapped
-	// payload does not match the master key currently held by the
-	// provider.
+	// payload matches neither the current master key nor any retired one
+	// held by the provider.
 	ErrWrongMasterKey = errors.New("keyprovider: master key id mismatch")
 
 	// ErrUnwrapFailed indicates the wrapped bytes failed authenticated

--- a/pkg/block/encryption/keyprovider/retired.go
+++ b/pkg/block/encryption/keyprovider/retired.go
@@ -33,11 +33,18 @@ func loadRetiredKeys(currentID string, refs []string, load retiredKeyLoader) (ma
 				"ref", ref, "error", err)
 			continue
 		}
+		// Both rejections below happen after the key material is already
+		// in memory, so zero what was loaded before unwinding — a failed
+		// construction has no Close to do it later.
 		if masterKeyID == currentID {
+			zeroKey(key)
+			zeroKeys(retired)
 			return nil, fmt.Errorf("%w: retired key %q has the same id %q as the current key",
 				ErrInvalidConfig, ref, masterKeyID)
 		}
 		if _, dup := retired[masterKeyID]; dup {
+			zeroKey(key)
+			zeroKeys(retired)
 			return nil, fmt.Errorf("%w: two retired keys share the id %q (second was %q)",
 				ErrInvalidConfig, masterKeyID, ref)
 		}
@@ -47,4 +54,20 @@ func loadRetiredKeys(currentID string, refs []string, load retiredKeyLoader) (ma
 		return nil, nil
 	}
 	return retired, nil
+}
+
+// zeroKey overwrites key material in place. Best-effort, same caveat as
+// aesGCMKEK.Close: the Go runtime may still hold copies on the GC heap.
+func zeroKey(key []byte) {
+	for i := range key {
+		key[i] = 0
+	}
+}
+
+// zeroKeys zeroes and drops every entry in an id → key map.
+func zeroKeys(keys map[string][]byte) {
+	for id, key := range keys {
+		zeroKey(key)
+		delete(keys, id)
+	}
 }

--- a/pkg/block/encryption/keyprovider/retired.go
+++ b/pkg/block/encryption/keyprovider/retired.go
@@ -1,0 +1,50 @@
+package keyprovider
+
+import (
+	"fmt"
+
+	"github.com/marmos91/dittofs/internal/logger"
+)
+
+// retiredKeyLoader resolves one configured retired-key reference (a file
+// path for the local provider, a uid for KMIP) into the master key id it
+// records and its 32-byte material.
+type retiredKeyLoader func(ref string) (masterKeyID string, key []byte, err error)
+
+// loadRetiredKeys builds the decrypt-only id → key map from the
+// configured references.
+//
+// A reference that fails to load is logged and skipped rather than
+// failing construction: the frames wrapped under it become unreadable,
+// which is the state the daemon was already in before the key was
+// configured, and refusing to start would take every other share's data
+// offline with it. A reference that resolves to an id already in use is
+// a config error and does fail construction, because two keys claiming
+// one id makes which one Unwrap picks a coin toss.
+func loadRetiredKeys(currentID string, refs []string, load retiredKeyLoader) (map[string][]byte, error) {
+	if len(refs) == 0 {
+		return nil, nil
+	}
+	retired := make(map[string][]byte, len(refs))
+	for _, ref := range refs {
+		masterKeyID, key, err := load(ref)
+		if err != nil {
+			logger.Warn("retired master key unreadable, blocks wrapped under it cannot be decrypted",
+				"ref", ref, "error", err)
+			continue
+		}
+		if masterKeyID == currentID {
+			return nil, fmt.Errorf("%w: retired key %q has the same id %q as the current key",
+				ErrInvalidConfig, ref, masterKeyID)
+		}
+		if _, dup := retired[masterKeyID]; dup {
+			return nil, fmt.Errorf("%w: two retired keys share the id %q (second was %q)",
+				ErrInvalidConfig, masterKeyID, ref)
+		}
+		retired[masterKeyID] = key
+	}
+	if len(retired) == 0 {
+		return nil, nil
+	}
+	return retired, nil
+}

--- a/pkg/block/encryption/keyprovider/rotation_test.go
+++ b/pkg/block/encryption/keyprovider/rotation_test.go
@@ -1,0 +1,216 @@
+package keyprovider
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeKeyFileAt stages a fresh key file at a caller-chosen name so a
+// test can hold several at once, which writeKeyFile's fixed basename
+// cannot do.
+func writeKeyFileAt(t *testing.T, dir, name, passphrase string) string {
+	t.Helper()
+	keyFileBytes, err := GenerateKeyFile(passphrase)
+	if err != nil {
+		t.Fatalf("GenerateKeyFile: %v", err)
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, keyFileBytes, 0o600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+	return path
+}
+
+// TestLocal_RetiredKeyStillUnwraps is the property the whole retired-key
+// map exists for: a block wrapped before rotation stays readable after
+// the current key changes, provided the old key file is retired rather
+// than discarded.
+func TestLocal_RetiredKeyStillUnwraps(t *testing.T) {
+	dir := t.TempDir()
+	oldPath := writeKeyFileAt(t, dir, "old.key", testPassphrase)
+	newPath := writeKeyFileAt(t, dir, "new.key", testPassphrase)
+	t.Setenv(localPassphraseEnv, testPassphrase)
+
+	// Wrap a block under the old key, as a pre-rotation daemon would.
+	before, err := newLocalProvider(Config{Kind: KindLocal, File: oldPath})
+	if err != nil {
+		t.Fatalf("newLocalProvider(old): %v", err)
+	}
+	blockKey := bytes.Repeat([]byte{0x11}, 32)
+	wrapped, oldID, err := before.Wrap(context.Background(), blockKey)
+	if err != nil {
+		t.Fatalf("Wrap under old key: %v", err)
+	}
+	_ = before.Close()
+
+	// Rotate: new key becomes current, old key is retired.
+	after, err := newLocalProvider(Config{
+		Kind:         KindLocal,
+		File:         newPath,
+		RetiredFiles: []string{oldPath},
+	})
+	if err != nil {
+		t.Fatalf("newLocalProvider(rotated): %v", err)
+	}
+	t.Cleanup(func() { _ = after.Close() })
+
+	if after.CurrentMasterKeyID() == oldID {
+		t.Fatal("rotated provider still reports the old master key id as current")
+	}
+
+	got, err := after.Unwrap(context.Background(), wrapped, oldID)
+	if err != nil {
+		t.Fatalf("Unwrap of pre-rotation block: %v", err)
+	}
+	if !bytes.Equal(got, blockKey) {
+		t.Fatalf("Unwrap returned %x, want %x", got, blockKey)
+	}
+
+	// New writes go under the new key and read back through the same
+	// provider, so rotation does not strand the current key either.
+	freshWrapped, freshID, err := after.Wrap(context.Background(), blockKey)
+	if err != nil {
+		t.Fatalf("Wrap under new key: %v", err)
+	}
+	if freshID != after.CurrentMasterKeyID() {
+		t.Fatalf("Wrap recorded id %q, want current %q", freshID, after.CurrentMasterKeyID())
+	}
+	if _, err := after.Unwrap(context.Background(), freshWrapped, freshID); err != nil {
+		t.Fatalf("Unwrap of post-rotation block: %v", err)
+	}
+}
+
+// TestLocal_DiscardedKeyStillRejected keeps the failure mode honest: an
+// id belonging to no configured key is still ErrWrongMasterKey, so the
+// lookup did not turn into a silent accept-anything.
+func TestLocal_DiscardedKeyStillRejected(t *testing.T) {
+	dir := t.TempDir()
+	oldPath := writeKeyFileAt(t, dir, "old.key", testPassphrase)
+	newPath := writeKeyFileAt(t, dir, "new.key", testPassphrase)
+	t.Setenv(localPassphraseEnv, testPassphrase)
+
+	before, err := newLocalProvider(Config{Kind: KindLocal, File: oldPath})
+	if err != nil {
+		t.Fatalf("newLocalProvider(old): %v", err)
+	}
+	wrapped, oldID, err := before.Wrap(context.Background(), bytes.Repeat([]byte{0x22}, 32))
+	if err != nil {
+		t.Fatalf("Wrap: %v", err)
+	}
+	_ = before.Close()
+
+	// Rotate WITHOUT retiring the old key — the data-loss case the issue
+	// describes.
+	after, err := newLocalProvider(Config{Kind: KindLocal, File: newPath})
+	if err != nil {
+		t.Fatalf("newLocalProvider(rotated): %v", err)
+	}
+	t.Cleanup(func() { _ = after.Close() })
+
+	if _, err := after.Unwrap(context.Background(), wrapped, oldID); !errors.Is(err, ErrWrongMasterKey) {
+		t.Fatalf("Unwrap error = %v, want ErrWrongMasterKey", err)
+	}
+}
+
+// TestLocal_UnreadableRetiredKeyDegrades pins the startup decision: a
+// retired key that cannot be loaded costs access to the blocks under it
+// but does not take the provider (and every other share) down with it.
+func TestLocal_UnreadableRetiredKeyDegrades(t *testing.T) {
+	dir := t.TempDir()
+	newPath := writeKeyFileAt(t, dir, "new.key", testPassphrase)
+	t.Setenv(localPassphraseEnv, testPassphrase)
+
+	p, err := newLocalProvider(Config{
+		Kind:         KindLocal,
+		File:         newPath,
+		RetiredFiles: []string{filepath.Join(dir, "does-not-exist.key")},
+	})
+	if err != nil {
+		t.Fatalf("newLocalProvider with an unreadable retired key: %v, want success", err)
+	}
+	t.Cleanup(func() { _ = p.Close() })
+
+	// The current key still works.
+	blockKey := bytes.Repeat([]byte{0x33}, 32)
+	wrapped, id, err := p.Wrap(context.Background(), blockKey)
+	if err != nil {
+		t.Fatalf("Wrap: %v", err)
+	}
+	if _, err := p.Unwrap(context.Background(), wrapped, id); err != nil {
+		t.Fatalf("Unwrap: %v", err)
+	}
+}
+
+// TestLocal_DuplicateRetiredIDRejected covers the other half of the
+// startup decision: an ambiguous id is a config error, because which key
+// Unwrap would pick is otherwise arbitrary.
+func TestLocal_DuplicateRetiredIDRejected(t *testing.T) {
+	dir := t.TempDir()
+	oldPath := writeKeyFileAt(t, dir, "old.key", testPassphrase)
+	newPath := writeKeyFileAt(t, dir, "new.key", testPassphrase)
+	t.Setenv(localPassphraseEnv, testPassphrase)
+
+	t.Run("same key listed twice", func(t *testing.T) {
+		_, err := newLocalProvider(Config{
+			Kind:         KindLocal,
+			File:         newPath,
+			RetiredFiles: []string{oldPath, oldPath},
+		})
+		if !errors.Is(err, ErrInvalidConfig) {
+			t.Fatalf("error = %v, want ErrInvalidConfig", err)
+		}
+	})
+
+	t.Run("current key also listed as retired", func(t *testing.T) {
+		_, err := newLocalProvider(Config{
+			Kind:         KindLocal,
+			File:         newPath,
+			RetiredFiles: []string{newPath},
+		})
+		if !errors.Is(err, ErrInvalidConfig) {
+			t.Fatalf("error = %v, want ErrInvalidConfig", err)
+		}
+	})
+}
+
+// TestLocal_CloseZeroesRetiredKeys guards the Close contract: retired
+// material is key material too, and leaving it live after Close would
+// keep it resident for the process lifetime.
+func TestLocal_CloseZeroesRetiredKeys(t *testing.T) {
+	dir := t.TempDir()
+	oldPath := writeKeyFileAt(t, dir, "old.key", testPassphrase)
+	newPath := writeKeyFileAt(t, dir, "new.key", testPassphrase)
+	t.Setenv(localPassphraseEnv, testPassphrase)
+
+	p, err := newLocalProvider(Config{
+		Kind:         KindLocal,
+		File:         newPath,
+		RetiredFiles: []string{oldPath},
+	})
+	if err != nil {
+		t.Fatalf("newLocalProvider: %v", err)
+	}
+	if len(p.retired) != 1 {
+		t.Fatalf("retired set holds %d keys, want 1", len(p.retired))
+	}
+	// Keep a handle on the backing array so the zeroing is observable
+	// after the map entry is dropped.
+	var retainedKey []byte
+	for _, k := range p.retired {
+		retainedKey = k
+	}
+
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if len(p.retired) != 0 {
+		t.Fatalf("retired set still holds %d keys after Close", len(p.retired))
+	}
+	if !bytes.Equal(retainedKey, make([]byte, len(retainedKey))) {
+		t.Fatalf("retired key material not zeroed after Close: %x", retainedKey)
+	}
+}

--- a/pkg/block/encryption/keyprovider/rotation_test.go
+++ b/pkg/block/encryption/keyprovider/rotation_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/gemalto/kmip-go/ttlv"
 )
 
 // writeKeyFileAt stages a fresh key file at a caller-chosen name so a
@@ -213,4 +215,214 @@ func TestLocal_CloseZeroesRetiredKeys(t *testing.T) {
 	if !bytes.Equal(retainedKey, make([]byte, len(retainedKey))) {
 		t.Fatalf("retired key material not zeroed after Close: %x", retainedKey)
 	}
+}
+
+// kmipRotationEnv stages the TLS material and returns a Config template
+// plus a helper that starts a fake serving the given responses in order.
+func kmipRotationEnv(t *testing.T) (Config, func(...ttlv.TTLV) *fakeKMIPServer) {
+	t.Helper()
+	dir := t.TempDir()
+	srvCert, srvKey, srvPEM := genSelfSigned(t, dir, "server")
+	cliCert, cliKey, _ := genSelfSigned(t, dir, "client")
+	caPath := filepath.Join(dir, "ca.pem")
+	if err := os.WriteFile(caPath, srvPEM, 0o600); err != nil {
+		t.Fatalf("write ca: %v", err)
+	}
+	cfg := Config{
+		Kind:       KindKMIP,
+		ClientCert: cliCert,
+		ClientKey:  cliKey,
+		ServerCA:   caPath,
+		TimeoutMS:  5000,
+	}
+	return cfg, func(resps ...ttlv.TTLV) *fakeKMIPServer {
+		return startFakeKMIPSeq(t, serverTLSConfig(t, srvCert, srvKey), resps...)
+	}
+}
+
+// TestKMIP_RetiredUIDStillUnwraps mirrors the local rotation test across
+// the KMIP wiring: retired uids are fetched at startup, each uid is its
+// own master key id, and a block wrapped under the retired key still
+// unwraps once the current uid has moved on.
+func TestKMIP_RetiredUIDStillUnwraps(t *testing.T) {
+	cfg, serve := kmipRotationEnv(t)
+	oldMaterial := bytes.Repeat([]byte{0xA1}, 32)
+	newMaterial := bytes.Repeat([]byte{0xB2}, 32)
+
+	// Pre-rotation daemon: only the old uid is configured.
+	srv := serve(kmipSuccessResponse(t, "uid-old", oldMaterial))
+	oldCfg := cfg
+	oldCfg.Endpoint = srv.addr()
+	oldCfg.KeyUID = "uid-old"
+	before, err := newKMIPProvider(context.Background(), oldCfg)
+	if err != nil {
+		t.Fatalf("newKMIPProvider(old): %v", err)
+	}
+	blockKey := bytes.Repeat([]byte{0x44}, 32)
+	wrapped, oldID, err := before.Wrap(context.Background(), blockKey)
+	if err != nil {
+		t.Fatalf("Wrap under old key: %v", err)
+	}
+	if oldID != "uid-old" {
+		t.Fatalf("Wrap recorded id %q, want the configured uid", oldID)
+	}
+	_ = before.Close()
+
+	// Rotate: current uid becomes uid-new, uid-old is retired. The
+	// provider fetches the current key first, then each retired uid in
+	// order, so the fake answers new-then-old.
+	srv2 := serve(
+		kmipSuccessResponse(t, "uid-new", newMaterial),
+		kmipSuccessResponse(t, "uid-old", oldMaterial),
+	)
+	rotated := cfg
+	rotated.Endpoint = srv2.addr()
+	rotated.KeyUID = "uid-new"
+	rotated.RetiredKeyUIDs = []string{"uid-old"}
+	after, err := newKMIPProvider(context.Background(), rotated)
+	if err != nil {
+		t.Fatalf("newKMIPProvider(rotated): %v", err)
+	}
+	t.Cleanup(func() { _ = after.Close() })
+
+	if !bytes.Equal(after.masterKey, newMaterial) {
+		t.Fatalf("current key = %x, want the new material", after.masterKey)
+	}
+	if got, ok := after.retired["uid-old"]; !ok || !bytes.Equal(got, oldMaterial) {
+		t.Fatalf("retired[uid-old] = %x (present=%v), want the old material", got, ok)
+	}
+
+	got, err := after.Unwrap(context.Background(), wrapped, oldID)
+	if err != nil {
+		t.Fatalf("Unwrap of pre-rotation block: %v", err)
+	}
+	if !bytes.Equal(got, blockKey) {
+		t.Fatalf("Unwrap returned %x, want %x", got, blockKey)
+	}
+}
+
+// TestKMIP_RetiredUIDValidation covers the two startup rejections on the
+// KMIP path, where the uid is the id and duplicates are therefore visible
+// in config rather than only inside the key material.
+func TestKMIP_RetiredUIDValidation(t *testing.T) {
+	material := bytes.Repeat([]byte{0xC3}, 32)
+
+	t.Run("current uid also listed as retired", func(t *testing.T) {
+		cfg, serve := kmipRotationEnv(t)
+		srv := serve(
+			kmipSuccessResponse(t, "uid-1", material),
+			kmipSuccessResponse(t, "uid-1", material),
+		)
+		cfg.Endpoint = srv.addr()
+		cfg.KeyUID = "uid-1"
+		cfg.RetiredKeyUIDs = []string{"uid-1"}
+		if _, err := newKMIPProvider(context.Background(), cfg); !errors.Is(err, ErrInvalidConfig) {
+			t.Fatalf("error = %v, want ErrInvalidConfig", err)
+		}
+	})
+
+	t.Run("same retired uid listed twice", func(t *testing.T) {
+		cfg, serve := kmipRotationEnv(t)
+		srv := serve(
+			kmipSuccessResponse(t, "uid-new", material),
+			kmipSuccessResponse(t, "uid-old", material),
+			kmipSuccessResponse(t, "uid-old", material),
+		)
+		cfg.Endpoint = srv.addr()
+		cfg.KeyUID = "uid-new"
+		cfg.RetiredKeyUIDs = []string{"uid-old", "uid-old"}
+		if _, err := newKMIPProvider(context.Background(), cfg); !errors.Is(err, ErrInvalidConfig) {
+			t.Fatalf("error = %v, want ErrInvalidConfig", err)
+		}
+	})
+}
+
+// TestKMIP_UnreadableRetiredUIDDegrades pins the same startup decision as
+// the local case: a retired uid the HSM will not serve costs access to
+// the blocks under it, not the whole provider.
+func TestKMIP_UnreadableRetiredUIDDegrades(t *testing.T) {
+	cfg, serve := kmipRotationEnv(t)
+	material := bytes.Repeat([]byte{0xD4}, 32)
+	// Only one response staged, so the retired uid's fetch connects and
+	// then waits for a reply that never comes. A short timeout keeps the
+	// test from sitting on the default five seconds.
+	srv := serve(kmipSuccessResponse(t, "uid-new", material))
+	cfg.Endpoint = srv.addr()
+	cfg.KeyUID = "uid-new"
+	cfg.RetiredKeyUIDs = []string{"uid-gone"}
+	cfg.TimeoutMS = 300
+
+	p, err := newKMIPProvider(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("newKMIPProvider with an unfetchable retired uid: %v, want success", err)
+	}
+	t.Cleanup(func() { _ = p.Close() })
+
+	if len(p.retired) != 0 {
+		t.Fatalf("retired set holds %d keys, want 0", len(p.retired))
+	}
+	blockKey := bytes.Repeat([]byte{0x55}, 32)
+	wrapped, id, err := p.Wrap(context.Background(), blockKey)
+	if err != nil {
+		t.Fatalf("Wrap: %v", err)
+	}
+	if _, err := p.Unwrap(context.Background(), wrapped, id); err != nil {
+		t.Fatalf("Unwrap: %v", err)
+	}
+}
+
+// TestLoadRetiredKeys_ZeroesOnRejection covers the construction-failure
+// path directly: both rejections happen after key material is already in
+// memory, and a provider that never gets built has no Close to clean up
+// after it, so loadRetiredKeys has to zero what it loaded on the way out.
+func TestLoadRetiredKeys_ZeroesOnRejection(t *testing.T) {
+	// stubLoader hands out key material the test keeps a handle on, so the
+	// zeroing is observable after loadRetiredKeys has dropped its own
+	// references.
+	newStub := func(ids ...string) (retiredKeyLoader, *[][]byte) {
+		issued := make([][]byte, 0, len(ids))
+		i := 0
+		return func(string) (string, []byte, error) {
+			key := bytes.Repeat([]byte{0xEE}, 32)
+			issued = append(issued, key)
+			id := ids[i]
+			i++
+			return id, key, nil
+		}, &issued
+	}
+
+	assertAllZeroed := func(t *testing.T, issuedPtr *[][]byte) {
+		t.Helper()
+		issued := *issuedPtr
+		if len(issued) == 0 {
+			t.Fatal("loader was never called")
+		}
+		for n, key := range issued {
+			if !bytes.Equal(key, make([]byte, len(key))) {
+				t.Fatalf("key %d not zeroed after rejection: %x", n, key)
+			}
+		}
+	}
+
+	t.Run("duplicate retired id", func(t *testing.T) {
+		load, issued := newStub("dup", "dup")
+		_, err := loadRetiredKeys("current", []string{"a", "b"}, func(ref string) (string, []byte, error) {
+			return load(ref)
+		})
+		if !errors.Is(err, ErrInvalidConfig) {
+			t.Fatalf("error = %v, want ErrInvalidConfig", err)
+		}
+		assertAllZeroed(t, issued)
+	})
+
+	t.Run("retired id collides with current", func(t *testing.T) {
+		load, issued := newStub("retired-ok", "current")
+		_, err := loadRetiredKeys("current", []string{"a", "b"}, func(ref string) (string, []byte, error) {
+			return load(ref)
+		})
+		if !errors.Is(err, ErrInvalidConfig) {
+			t.Fatalf("error = %v, want ErrInvalidConfig", err)
+		}
+		assertAllZeroed(t, issued)
+	})
 }


### PR DESCRIPTION
Closes #1944.

Implements the design decided in [this comment](https://github.com/marmos91/dittofs/issues/1944#issuecomment-5316205324).

## The change

`Wrap` is unchanged — always the current master key, recording its id. `Unwrap` now resolves the id recorded in the frame against `{current} ∪ {retired...}` and returns `ErrWrongMasterKey` only when it matches none. No frame bytes change; the id was already on the wire and was previously used only to reject.

```yaml
encryption:
  key:
    kind: local
    file: /etc/dittofs/keys/2026-08.key    # current — everything new is wrapped here
    retired_files:                         # decrypt-only
      - /etc/dittofs/keys/2026-02.key
```

KMIP mirrors it with `key_uid` + `retired_key_uids`. Both retired lists are additive and default to empty, so every existing config behaves exactly as it did.

## One correction to the issue's premise

The issue says the id is "derived from the key material", and that this makes operator-assigned ids expensive. That is not what the code does — `local` generates a UUID once in `GenerateKeyFile` and stores it *in* the key file as `master_key_id`; `kmip` uses the operator-supplied `key_uid` verbatim. Both are already assigned-at-generation and travel with the key, which is the Tink/KMS model. So a retired key identifies itself and nothing in config restates an id. This makes the change smaller than the issue anticipated and removes that open question entirely.

## Startup behaviour

- **Unreadable retired key** — logged and skipped, not fatal. Blocks under it become unreadable, which is the state the daemon was already in before it was configured; refusing to start would take every other share offline with it. A missing *current* key stays fatal.
- **Duplicate id** — rejected. Two keys claiming one id makes which one `Unwrap` picks arbitrary. Covers both "same file listed twice" and "current key also listed as retired".
- Retired keys share the current key's passphrase (one `DITTOFS_ENCRYPTION_PASSPHRASE` env var); documented, not changed here.

## Tests

`rotation_test.go` covers the property the whole thing exists for — a block wrapped under the old key still unwraps after rotation — plus: an id belonging to no configured key is still `ErrWrongMasterKey` (the lookup did not become accept-anything), unreadable-retired degrades, duplicate ids are rejected, and `Close` zeroes retired material too.

No KMIP-specific rotation test: those round-trips need a live HSM and are skipped in CI, and the fake server serves one canned key. The shared path (`loadRetiredKeys`, `keyForID`) is exercised by the local tests; the KMIP side only adds "fetch N uids".

## Still missing, and the docs now say so

No bulk re-wrap and no way to enumerate which blocks reference a given key. Until both exist there is no supported way to move blocks off a retired key, so a retired key must be treated as keep-forever — dropping it from the config or deleting the material is still unrecoverable data loss. `docs/guide/encryption.md` leads with that hazard rather than burying it.

## Verification

`go test -race ./pkg/block/encryption/... ./pkg/controlplane/runtime/... -count=1` green. `golangci-lint` clean on the changed packages.