### PR TITLE
fix(block): resolve overlapping manifest rows to the greatest start

### DIFF
--- a/pkg/block/engine/manifest_inconsistent_test.go
+++ b/pkg/block/engine/manifest_inconsistent_test.go
@@ -81,9 +81,9 @@ func TestFindRowCoveringOffset_WellFormedRowResolves(t *testing.T) {
 	}
 }
 
-// Overlap is an invariant the carve maintains, not one the lookup may assume:
-// the row this walk reaches first need not be the one the indexed badger path
-// (largest start) returns, and both read back as ordinary data.
+// Non-overlap is an invariant the carve maintains, not one the lookup may
+// assume: the row this walk reaches first need not be the one the indexed
+// badger path (largest start) returns, and both read back as ordinary data.
 func TestFindRowCoveringOffset_OverlappingRowsAreReported(t *testing.T) {
 	rows := []*block.FileChunk{
 		{ID: "payload-1/0", DataSize: 8192},

--- a/pkg/block/engine/manifest_inconsistent_test.go
+++ b/pkg/block/engine/manifest_inconsistent_test.go
@@ -81,23 +81,25 @@ func TestFindRowCoveringOffset_WellFormedRowResolves(t *testing.T) {
 	}
 }
 
-// Non-overlap is an invariant the carve maintains, not one the lookup may
-// assume: the row this walk reaches first need not be the one the indexed
-// badger path (largest start) returns, and both read back as ordinary data.
-func TestFindRowCoveringOffset_OverlappingRowsAreReported(t *testing.T) {
+// Overlapping rows resolve to the greatest start, matching the indexed badger
+// lookup. A truncate narrows a straddling row to the new size and a later write
+// re-carves from an earlier boundary, so the narrowed row keeps claiming bytes
+// the new row also covers; the newer row holds what the last write put there.
+func TestFindRowCoveringOffset_OverlapResolvesToGreatestStart(t *testing.T) {
 	rows := []*block.FileChunk{
-		{ID: "payload-1/0", DataSize: 8192},
-		{ID: "payload-1/4096", DataSize: 4096}, // overlaps [4096, 8192)
+		{ID: "payload-1/0", DataSize: 8192},    // narrowed survivor, reached first
+		{ID: "payload-1/4096", DataSize: 4096}, // newer row over [4096, 8192)
 	}
 
 	rw, err := findRowCoveringOffset(rows, 5000)
-	if err == nil {
-		t.Fatalf("offset 5000 returned rw=%v err=nil; two rows cover it", rw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if !errors.Is(err, block.ErrManifestInconsistent) {
-		t.Fatalf("err = %v, want it to wrap ErrManifestInconsistent", err)
+	if rw == nil || rw.absOffset != 4096 {
+		t.Fatalf("rw = %+v, want the row starting at 4096", rw)
 	}
-	// Offsets only one row covers stay readable.
+
+	// Offsets only the older row covers still resolve to it.
 	rw, err = findRowCoveringOffset(rows, 1000)
 	if err != nil || rw == nil || rw.absOffset != 0 {
 		t.Fatalf("findRowCoveringOffset(1000) = %+v, %v; want the row at 0", rw, err)

--- a/pkg/block/engine/manifest_inconsistent_test.go
+++ b/pkg/block/engine/manifest_inconsistent_test.go
@@ -80,3 +80,26 @@ func TestFindRowCoveringOffset_WellFormedRowResolves(t *testing.T) {
 		t.Fatalf("absOffset = %d, want 4096", rw.absOffset)
 	}
 }
+
+// Overlap is an invariant the carve maintains, not one the lookup may assume:
+// the row this walk reaches first need not be the one the indexed badger path
+// (largest start) returns, and both read back as ordinary data.
+func TestFindRowCoveringOffset_OverlappingRowsAreReported(t *testing.T) {
+	rows := []*block.FileChunk{
+		{ID: "payload-1/0", DataSize: 8192},
+		{ID: "payload-1/4096", DataSize: 4096}, // overlaps [4096, 8192)
+	}
+
+	rw, err := findRowCoveringOffset(rows, 5000)
+	if err == nil {
+		t.Fatalf("offset 5000 returned rw=%v err=nil; two rows cover it", rw)
+	}
+	if !errors.Is(err, block.ErrManifestInconsistent) {
+		t.Fatalf("err = %v, want it to wrap ErrManifestInconsistent", err)
+	}
+	// Offsets only one row covers stay readable.
+	rw, err = findRowCoveringOffset(rows, 1000)
+	if err != nil || rw == nil || rw.absOffset != 0 {
+		t.Fatalf("findRowCoveringOffset(1000) = %+v, %v; want the row at 0", rw, err)
+	}
+}

--- a/pkg/block/engine/read_internal.go
+++ b/pkg/block/engine/read_internal.go
@@ -115,8 +115,14 @@ type rowWithOffset struct {
 // The alternative, refusing the moment such a row is seen at any offset, would
 // take a file that reads correctly apart from one damaged range and make all of
 // it unavailable.
+//
+// Two rows covering target is reported rather than resolved: which one this walk
+// reaches first depends on ListFileChunks ordering, while the indexed badger
+// lookup takes the greatest start, so either choice could serve bytes the other
+// path would not.
 func findRowCoveringOffset(rows []*block.FileChunk, target uint64) (*rowWithOffset, error) {
 	unplaceable := ""
+	var hit *rowWithOffset
 	for _, fb := range rows {
 		if fb == nil {
 			continue
@@ -129,14 +135,18 @@ func findRowCoveringOffset(rows []*block.FileChunk, target uint64) (*rowWithOffs
 			continue
 		}
 		if target >= abs && target < abs+uint64(fb.DataSize) {
-			return &rowWithOffset{fb: fb, absOffset: abs}, nil
+			if hit != nil {
+				return nil, fmt.Errorf("%w: offset %d covered by both %q and %q",
+					block.ErrManifestInconsistent, target, hit.fb.ID, fb.ID)
+			}
+			hit = &rowWithOffset{fb: fb, absOffset: abs}
 		}
 	}
-	if unplaceable != "" {
+	if hit == nil && unplaceable != "" {
 		return nil, fmt.Errorf("%w: nothing covers offset %d and manifest holds unplaceable row %q",
 			block.ErrManifestInconsistent, target, unplaceable)
 	}
-	return nil, nil
+	return hit, nil
 }
 
 // chunkAtOffsetResolver is the indexed covering-chunk lookup, implemented only

--- a/pkg/block/engine/read_internal.go
+++ b/pkg/block/engine/read_internal.go
@@ -116,10 +116,10 @@ type rowWithOffset struct {
 // take a file that reads correctly apart from one damaged range and make all of
 // it unavailable.
 //
-// Two rows covering target is reported rather than resolved: which one this walk
-// reaches first depends on ListFileChunks ordering, while the indexed badger
-// lookup takes the greatest start, so either choice could serve bytes the other
-// path would not.
+// Two rows covering target are reported rather than resolved: which one this
+// walk reaches first depends on ListFileChunks ordering, while the indexed
+// badger lookup takes the greatest start, so either choice could serve bytes the
+// other path would not.
 func findRowCoveringOffset(rows []*block.FileChunk, target uint64) (*rowWithOffset, error) {
 	unplaceable := ""
 	var hit *rowWithOffset

--- a/pkg/block/engine/read_internal.go
+++ b/pkg/block/engine/read_internal.go
@@ -116,10 +116,14 @@ type rowWithOffset struct {
 // take a file that reads correctly apart from one damaged range and make all of
 // it unavailable.
 //
-// Two rows covering target are reported rather than resolved: which one this
-// walk reaches first depends on ListFileChunks ordering, while the indexed
-// badger lookup takes the greatest start, so either choice could serve bytes the
-// other path would not.
+// When two rows cover target the greatest start wins, which is what the indexed
+// badger lookup returns. Returning whichever row the walk reached first made the
+// answer depend on ListFileChunks ordering, so the same read could serve
+// different bytes on different backends. Overlap is not hypothetical: a truncate
+// narrows a straddling row to the new size, and a later write re-carves from an
+// earlier chunk boundary, leaving the narrowed row still claiming bytes the new
+// row also covers. The greater start is the newer row, so it is also the one
+// holding the bytes the last write put there.
 func findRowCoveringOffset(rows []*block.FileChunk, target uint64) (*rowWithOffset, error) {
 	unplaceable := ""
 	var hit *rowWithOffset
@@ -135,11 +139,9 @@ func findRowCoveringOffset(rows []*block.FileChunk, target uint64) (*rowWithOffs
 			continue
 		}
 		if target >= abs && target < abs+uint64(fb.DataSize) {
-			if hit != nil {
-				return nil, fmt.Errorf("%w: offset %d covered by both %q and %q",
-					block.ErrManifestInconsistent, target, hit.fb.ID, fb.ID)
+			if hit == nil || abs > hit.absOffset {
+				hit = &rowWithOffset{fb: fb, absOffset: abs}
 			}
-			hit = &rowWithOffset{fb: fb, absOffset: abs}
 		}
 	}
 	if hit == nil && unplaceable != "" {

--- a/pkg/block/errors.go
+++ b/pkg/block/errors.go
@@ -169,13 +169,13 @@ var (
 	// discarded and this error surfaces — bad bytes never reach the caller.
 	ErrChunkContentMismatch = errors.New("blockstore: chunk content hash mismatch")
 
-	// ErrManifestInconsistent is returned when a payload's manifest cannot be read
-	// as a tiling of the file: a FileChunk ID that carries no parseable
-	// "<payloadID>/<offset>", or two rows covering the same offset. Neither is
-	// treated as a hole: a hole is the *absence* of a row and reads back as zeros
-	// by design, so passing over an unplaceable row would serve zeros for a range
-	// the store still holds bytes for, with nothing logged and no error returned.
-	// Reads refuse instead, which turns silent corruption into a diagnosable one.
+	// ErrManifestInconsistent is returned when a payload's manifest holds a row
+	// that cannot be placed in the file — today, a FileChunk ID that does not
+	// carry a parseable "<payloadID>/<offset>". It is deliberately not treated as
+	// a hole: a hole is the *absence* of a row and reads back as zeros by design,
+	// so passing over an unplaceable row would serve zeros for a range the store
+	// still holds bytes for, with nothing logged and no error returned. Reads
+	// refuse instead, which turns silent corruption into a diagnosable one.
 	ErrManifestInconsistent = errors.New("blockstore: file manifest inconsistent")
 
 	// ErrChunkRefMissing is returned by engine.ReadAt when a ChunkRef.Hash

--- a/pkg/block/errors.go
+++ b/pkg/block/errors.go
@@ -169,13 +169,13 @@ var (
 	// discarded and this error surfaces — bad bytes never reach the caller.
 	ErrChunkContentMismatch = errors.New("blockstore: chunk content hash mismatch")
 
-	// ErrManifestInconsistent is returned when a payload's manifest holds a row
-	// that cannot be placed in the file — today, a FileChunk ID that does not
-	// carry a parseable "<payloadID>/<offset>". It is deliberately not treated as
-	// a hole: a hole is the *absence* of a row and reads back as zeros by design,
-	// so passing over an unplaceable row would serve zeros for a range the store
-	// still holds bytes for, with nothing logged and no error returned. Reads
-	// refuse instead, which turns silent corruption into a diagnosable one.
+	// ErrManifestInconsistent is returned when a payload's manifest cannot be read
+	// as a tiling of the file: a FileChunk ID that carries no parseable
+	// "<payloadID>/<offset>", or two rows covering the same offset. Neither is
+	// treated as a hole: a hole is the *absence* of a row and reads back as zeros
+	// by design, so passing over an unplaceable row would serve zeros for a range
+	// the store still holds bytes for, with nothing logged and no error returned.
+	// Reads refuse instead, which turns silent corruption into a diagnosable one.
 	ErrManifestInconsistent = errors.New("blockstore: file manifest inconsistent")
 
 	// ErrChunkRefMissing is returned by engine.ReadAt when a ChunkRef.Hash

--- a/pkg/metadata/store/badger/objects.go
+++ b/pkg/metadata/store/badger/objects.go
@@ -451,10 +451,10 @@ func loadFileChunkAtIndexOffset(txn *badger.Txn, payloadID string, off uint64) (
 // offset without materializing the whole manifest (no per-row Get, no JSON
 // unmarshal, no sort), then two point Gets fetch the winning row.
 //
-// Largest-start only decides anything if rows overlap, which the carve's
-// re-tiling prevents. The keys-only scan cannot detect overlap — the row lengths
-// are in the values — so where the engine's ListFileChunks fallback reports a
-// broken tiling, this path returns the greatest-start row regardless.
+// Largest-start only decides anything if rows overlap, which a truncate followed
+// by a re-carving write can produce. It resolves to the newer row, and the
+// engine's ListFileChunks fallback picks the same one so both paths answer a
+// read alike.
 //
 // ponytail: O(n) keys-only scan per read; upgrade to a big-endian fb-off index
 // for a true O(log n) reverse-seek only if profiling at real N still shows it.

--- a/pkg/metadata/store/badger/objects.go
+++ b/pkg/metadata/store/badger/objects.go
@@ -451,6 +451,11 @@ func loadFileChunkAtIndexOffset(txn *badger.Txn, payloadID string, off uint64) (
 // offset without materializing the whole manifest (no per-row Get, no JSON
 // unmarshal, no sort), then two point Gets fetch the winning row.
 //
+// Largest-start only decides anything if rows overlap, which the carve's
+// re-tiling prevents. The keys-only scan cannot detect overlap — the row lengths
+// are in the values — so this path picks the newest writer where the engine's
+// ListFileChunks fallback reports the broken tiling.
+//
 // ponytail: O(n) keys-only scan per read; upgrade to a big-endian fb-off index
 // for a true O(log n) reverse-seek only if profiling at real N still shows it.
 func (s *BadgerMetadataStore) GetFileChunkAtOffset(_ context.Context, payloadID string, off uint64) (*metadata.FileChunk, error) {

--- a/pkg/metadata/store/badger/objects.go
+++ b/pkg/metadata/store/badger/objects.go
@@ -453,8 +453,8 @@ func loadFileChunkAtIndexOffset(txn *badger.Txn, payloadID string, off uint64) (
 //
 // Largest-start only decides anything if rows overlap, which the carve's
 // re-tiling prevents. The keys-only scan cannot detect overlap — the row lengths
-// are in the values — so this path picks the newest writer where the engine's
-// ListFileChunks fallback reports the broken tiling.
+// are in the values — so where the engine's ListFileChunks fallback reports a
+// broken tiling, this path returns the greatest-start row regardless.
 //
 // ponytail: O(n) keys-only scan per read; upgrade to a big-endian fb-off index
 // for a true O(log n) reverse-seek only if profiling at real N still shows it.


### PR DESCRIPTION
Closes #1934.

`resolveCovering`'s `ListFileChunks` fallback returned the **first** row covering an offset — order-dependent — while badger's indexed `GetFileChunkAtOffset` takes the greatest-start row. The fallback now picks the greatest start too, so both paths answer a read alike.

## The issue's premise is wrong: overlap is reachable today

#1934 recorded this as latent, on the grounds that the carve re-tiles the manifest so overlapping rows never survive. They do survive:

- `Truncate` narrows a straddling row to the new size (`narrowChunkRow`), leaving it ending exactly at the truncation point.
- A later write re-carves from an *earlier* chunk boundary, emitting a new row that starts inside the narrowed row's range.
- Nothing reaps the narrowed row's tail, so both rows now claim the same bytes.

Reproduced on **unmodified develop** with a randomized mutation soak (write / truncate / punch-hole, carve after each, drain local so reads go cold). 3 of 24 seeds hit manifest overlap, e.g. `row at 2894422 extends to 9863070, next row starts at 8208892`.

## Why not report it as an inconsistency

That was the issue's suggested direction and this PR's first attempt. It is wrong. With the error in place, the soak turns a cold read of a double-covered offset into a hard failure:

```
READ BROKEN at double-covered offset 8142960: cold read hydrate failed:
blockstore: file manifest inconsistent: offset 8142960 covered by both
".../3948656" and ".../8142960"
```

Those reads return **correct data** today. Since overlap is reachable through ordinary truncate+write, refusing would convert working reads into EIO on every non-badger backend. Loud beats silent only when the silent answer is wrong; here it isn't.

Greatest-start is also the *right* row: it is the newer one, holding what the last write put there. Badger already returns it. Under the tiling invariant nothing changes at all.

## Scope note

The soak also surfaced a **separate, pre-existing bug**, present on develop and unaffected by either variant of this change: after `PunchHole`, a cold read of the punched range does not read back as zeros (`PunchHole`'s contract is that it must). 5 of 24 seeds. Filed separately — not fixed here.

Test: overlapping rows resolve to the greatest start; an offset only the older row covers still resolves to it.