### PR TITLE
fix(smb): claim durable handles by ID on reconnect

### DIFF
--- a/internal/adapter/smb/handlers/durable_context.go
+++ b/internal/adapter/smb/handlers/durable_context.go
@@ -509,10 +509,9 @@ func processV1Reconnect(
 	// Non-destructive lookup: validation-failure paths (share/path/username/
 	// access mismatch) must leave the persisted handle reclaimable until
 	// expiry — a transient mismatched retry should not destroy a valid
-	// durable open. The TOCTOU window is closed on the *success* path
-	// (claimDurableHandleByFileID below) which atomically re-reads via
-	// Consume; a second concurrent reconnect that also passes validation
-	// will find the handle already gone and return OBJECT_NAME_NOT_FOUND.
+	// durable open. The success path claims this exact handle by ID
+	// (validateAndRestore); a second concurrent reconnect that also passes
+	// validation finds it gone and returns OBJECT_NAME_NOT_FOUND.
 	handle, err := durableStore.GetDurableHandleByFileID(ctx, fileID)
 	if err != nil {
 		logger.Warn("processV1Reconnect: store error", "error", err)
@@ -547,10 +546,7 @@ func processV1Reconnect(
 	checkPath := persistedHasLease
 
 	openFile, status, restoreErr := validateAndRestore(ctx, durableStore, metaSvc, handle, sessionID, username,
-		sessionKeyHash, shareName, filename, checkPath,
-		func(ctx context.Context) (*lock.PersistedDurableHandle, error) {
-			return durableStore.ConsumeDurableHandleByFileID(ctx, fileID)
-		})
+		sessionKeyHash, shareName, filename, checkPath)
 	return openFile, handle.LeaseState, handle.LeaseEpoch, handle.OriginalFileID, status, restoreErr
 }
 
@@ -676,16 +672,8 @@ func processV2Reconnect(
 	// open, junk fname on reconnect) MUST succeed. The path check stays on only for
 	// lease-backed reconnects, where a wrong-fname-with-lease reconnect is the final
 	// negative-ladder rung that yields INVALID_PARAMETER.
-	consume := func(ctx context.Context) (*lock.PersistedDurableHandle, error) {
-		if zeroCreateGuid {
-			// V1-via-DH2C reconnect: consume by FileID (the CreateGuid is
-			// zero and unusable as a key — see the lookup branch above).
-			return durableStore.ConsumeDurableHandleByFileID(ctx, lookupFileID)
-		}
-		return durableStore.ConsumeDurableHandleByCreateGuid(ctx, createGuid)
-	}
 	openFile, status, restoreErr := validateAndRestore(ctx, durableStore, metaSvc, handle, sessionID, username,
-		sessionKeyHash, shareName, filename, persistedHasLease, consume)
+		sessionKeyHash, shareName, filename, persistedHasLease)
 	return openFile, handle.LeaseState, handle.LeaseEpoch, handle.OriginalFileID, status, restoreErr
 }
 
@@ -700,11 +688,12 @@ func processV2Reconnect(
 // checked reopens only, via checkPath), handle expiry, and backing-file
 // existence.
 //
-// consume is invoked on the success path to atomically remove the persisted
-// record. If consume returns nil, another goroutine has already claimed the
-// handle — the reconnect fails with OBJECT_NAME_NOT_FOUND. This is the only
-// place that mutates the durable store on reconnect, which is what makes the
-// path safe against the V1/V2 reconnect TOCTOU window.
+// On the success path the persisted record is claimed by ID, so the row
+// removed is the one just validated even if a sibling handle on the same file
+// appears or is reaped meanwhile. If it is already gone another goroutine
+// claimed it and the reconnect fails with OBJECT_NAME_NOT_FOUND. This is the
+// only place that mutates the durable store on reconnect, which is what makes
+// the path safe against the V1/V2 reconnect TOCTOU window.
 //
 // The share/path/identity matching itself lives in the lock domain
 // (PersistedDurableHandle.ValidateReconnect, pkg/metadata/lock) per CLAUDE.md
@@ -720,7 +709,6 @@ func validateAndRestore(
 	shareName string,
 	filename string,
 	checkPath bool,
-	consume func(ctx context.Context) (*lock.PersistedDurableHandle, error),
 ) (*OpenFile, types.Status, error) {
 	// Identity/path/share matching is owned by the lock domain. Map the typed
 	// mismatch back to the SMB status the reconnect ladder expects (share →
@@ -796,11 +784,11 @@ func validateAndRestore(
 		}
 	}
 
-	// All checks passed — atomically consume the persisted record. If
+	// All checks passed — atomically consume the record just validated. If
 	// somebody else (a concurrent reconnect from a retrying client) already
-	// claimed it, consume returns nil and we fail OBJECT_NAME_NOT_FOUND
-	// rather than handing out a second OpenFile against the same handle.
-	consumed, err := consume(ctx)
+	// claimed it, this returns nil and we fail OBJECT_NAME_NOT_FOUND rather
+	// than handing out a second OpenFile against the same handle.
+	consumed, err := durableStore.ConsumeDurableHandle(ctx, handle.ID)
 	if err != nil {
 		logger.Warn("validateAndRestore: consume failed", "error", err)
 		return nil, types.StatusInternalError, err

--- a/internal/adapter/smb/handlers/durable_context_test.go
+++ b/internal/adapter/smb/handlers/durable_context_test.go
@@ -1593,10 +1593,10 @@ func TestProcessDurableHandleContext_V2RejectZeroCreateGuid(t *testing.T) {
 }
 
 // TestProcessDurableReconnectContext_ConsumeAtomicV1 verifies that the V1
-// reconnect path claims through ConsumeDurableHandle — i.e. two concurrent
-// reconnect attempts for the same persisted FileID cannot both succeed.
-// Mocks a store that releases its internal lock between Get and Delete
-// would expose a TOCTOU window; the Consume contract closes it.
+// reconnect path claims through ConsumeDurableHandle, so two reconnect
+// attempts for the same persisted FileID cannot both succeed. A store that
+// released its lock between a separate Get and Delete would leave a TOCTOU
+// window; claiming through Consume closes it.
 func TestProcessDurableReconnectContext_ConsumeAtomicV1(t *testing.T) {
 	store := newMockDurableStore()
 	ctx := context.Background()

--- a/internal/adapter/smb/handlers/durable_context_test.go
+++ b/internal/adapter/smb/handlers/durable_context_test.go
@@ -1593,7 +1593,7 @@ func TestProcessDurableHandleContext_V2RejectZeroCreateGuid(t *testing.T) {
 }
 
 // TestProcessDurableReconnectContext_ConsumeAtomicV1 verifies that the V1
-// reconnect path uses ConsumeDurableHandleByFileID — i.e. two concurrent
+// reconnect path claims through ConsumeDurableHandle — i.e. two concurrent
 // reconnect attempts for the same persisted FileID cannot both succeed.
 // Mocks a store that releases its internal lock between Get and Delete
 // would expose a TOCTOU window; the Consume contract closes it.

--- a/internal/adapter/smb/handlers/durable_scavenger_test.go
+++ b/internal/adapter/smb/handlers/durable_scavenger_test.go
@@ -67,28 +67,15 @@ func (s *mockDurableStore) GetDurableHandleByCreateGuid(_ context.Context, guid 
 	return nil, nil
 }
 
-func (s *mockDurableStore) ConsumeDurableHandleByFileID(_ context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
+func (s *mockDurableStore) ConsumeDurableHandle(_ context.Context, id string) (*lock.PersistedDurableHandle, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	for id, h := range s.handles {
-		if h.FileID == fileID {
-			delete(s.handles, id)
-			return h, nil
-		}
+	h, ok := s.handles[id]
+	if !ok {
+		return nil, nil
 	}
-	return nil, nil
-}
-
-func (s *mockDurableStore) ConsumeDurableHandleByCreateGuid(_ context.Context, guid [16]byte) (*lock.PersistedDurableHandle, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	for id, h := range s.handles {
-		if h.CreateGuid == guid {
-			delete(s.handles, id)
-			return h, nil
-		}
-	}
-	return nil, nil
+	delete(s.handles, id)
+	return h, nil
 }
 
 func (s *mockDurableStore) GetDurableHandlesByAppInstanceId(_ context.Context, appInstanceId [16]byte) ([]*lock.PersistedDurableHandle, error) {

--- a/pkg/metadata/lock/durable_store.go
+++ b/pkg/metadata/lock/durable_store.go
@@ -218,17 +218,15 @@ type DurableHandleStore interface {
 	GetDurableHandle(ctx context.Context, id string) (*PersistedDurableHandle, error)
 	GetDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*PersistedDurableHandle, error)
 	GetDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*PersistedDurableHandle, error)
-	// ConsumeDurableHandleByFileID atomically fetches and deletes the
-	// persisted handle keyed by the original FileID, returning the previous
-	// record (or nil if no match). Used on V1 reconnect (DHnC) to prevent
-	// the TOCTOU window where two concurrent reconnects from the same
-	// retrying client could both succeed a Get-then-Delete sequence and end
-	// up with two live opens claiming the same persisted handle.
-	// MS-SMB2 §3.3.5.9.7.
-	ConsumeDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*PersistedDurableHandle, error)
-	// ConsumeDurableHandleByCreateGuid is the V2 (DH2C) counterpart of
-	// ConsumeDurableHandleByFileID. MS-SMB2 §3.3.5.9.12.
-	ConsumeDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*PersistedDurableHandle, error)
+	// ConsumeDurableHandle atomically fetches and deletes the persisted
+	// handle with this ID, returning the previous record (or nil if it is
+	// already gone). Reconnect (V1 DHnC and V2 DH2C alike) claims through
+	// this rather than re-selecting by FileID or CreateGuid, so the record
+	// destroyed is exactly the one validation ran against even when a
+	// sibling handle on the same file is inserted or reaped in between.
+	// It also keeps two concurrent reconnects from both claiming one
+	// handle. MS-SMB2 §3.3.5.9.7 and §3.3.5.9.12.
+	ConsumeDurableHandle(ctx context.Context, id string) (*PersistedDurableHandle, error)
 	GetDurableHandlesByAppInstanceId(ctx context.Context, appInstanceId [16]byte) ([]*PersistedDurableHandle, error)
 	GetDurableHandlesByFileHandle(ctx context.Context, fileHandle []byte) ([]*PersistedDurableHandle, error)
 	DeleteDurableHandle(ctx context.Context, id string) error

--- a/pkg/metadata/store/badger/durable_handles.go
+++ b/pkg/metadata/store/badger/durable_handles.go
@@ -207,24 +207,35 @@ func (s *badgerDurableStore) GetDurableHandle(ctx context.Context, id string) (*
 	var handle *lock.PersistedDurableHandle
 
 	err := s.db.View(func(txn *badgerdb.Txn) error {
-		item, err := txn.Get([]byte(prefixDHID + id))
-		if err == badgerdb.ErrKeyNotFound {
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-
-		return item.Value(func(val []byte) error {
-			handle = &lock.PersistedDurableHandle{}
-			return json.Unmarshal(val, handle)
-		})
+		var err error
+		handle, err = s.getDurableHandleTx(txn, id)
+		return err
 	})
 
 	if err != nil {
 		return nil, err
 	}
 	return handle, nil
+}
+
+// getDurableHandleTx reads the primary record for an ID, returning nil when it
+// does not exist. Callers supply the transaction.
+func (s *badgerDurableStore) getDurableHandleTx(txn *badgerdb.Txn, id string) (*lock.PersistedDurableHandle, error) {
+	item, err := txn.Get([]byte(prefixDHID + id))
+	if err == badgerdb.ErrKeyNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var handle lock.PersistedDurableHandle
+	if err := item.Value(func(val []byte) error {
+		return json.Unmarshal(val, &handle)
+	}); err != nil {
+		return nil, err
+	}
+	return &handle, nil
 }
 
 func (s *badgerDurableStore) getHandleByIndex(txn *badgerdb.Txn, indexKey []byte) (*lock.PersistedDurableHandle, error) {
@@ -338,21 +349,7 @@ func (s *badgerDurableStore) resolveIndexEntry(txn *badgerdb.Txn, item *badgerdb
 		return nil, err
 	}
 
-	primaryItem, err := txn.Get([]byte(prefixDHID + id))
-	if err == badgerdb.ErrKeyNotFound {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	var handle lock.PersistedDurableHandle
-	if err := primaryItem.Value(func(val []byte) error {
-		return json.Unmarshal(val, &handle)
-	}); err != nil {
-		return nil, err
-	}
-	return &handle, nil
+	return s.getDurableHandleTx(txn, id)
 }
 
 // firstHandleByPrefix returns the lowest-keyed live handle under a secondary
@@ -379,41 +376,18 @@ func (s *badgerDurableStore) firstHandleByPrefix(txn *badgerdb.Txn, prefix []byt
 	return nil, nil
 }
 
-func (s *badgerDurableStore) ConsumeDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
+func (s *badgerDurableStore) ConsumeDurableHandle(ctx context.Context, id string) (*lock.PersistedDurableHandle, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 
 	var handle *lock.PersistedDurableHandle
 	err := s.db.Update(func(txn *badgerdb.Txn) error {
-		found, err := s.firstHandleByPrefix(txn, fileIDIndexScanPrefix(fileID))
+		found, err := s.getDurableHandleTx(txn, id)
 		if err != nil || found == nil {
 			return err
 		}
-		if err := s.deleteDurableHandleTx(txn, found.ID); err != nil {
-			return err
-		}
-		handle = found
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return handle, nil
-}
-
-func (s *badgerDurableStore) ConsumeDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	var handle *lock.PersistedDurableHandle
-	err := s.db.Update(func(txn *badgerdb.Txn) error {
-		found, err := s.getHandleByIndex(txn, []byte(prefixDHCreateGuid+hexEncode16(createGuid)))
-		if err != nil || found == nil {
-			return err
-		}
-		if err := s.deleteDurableHandleTx(txn, found.ID); err != nil {
+		if err := s.deleteDurableHandleTx(txn, id); err != nil {
 			return err
 		}
 		handle = found
@@ -636,12 +610,8 @@ func (s *BadgerMetadataStore) GetDurableHandleByCreateGuid(ctx context.Context, 
 	return s.getDurableStore().GetDurableHandleByCreateGuid(ctx, createGuid)
 }
 
-func (s *BadgerMetadataStore) ConsumeDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().ConsumeDurableHandleByFileID(ctx, fileID)
-}
-
-func (s *BadgerMetadataStore) ConsumeDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().ConsumeDurableHandleByCreateGuid(ctx, createGuid)
+func (s *BadgerMetadataStore) ConsumeDurableHandle(ctx context.Context, id string) (*lock.PersistedDurableHandle, error) {
+	return s.getDurableStore().ConsumeDurableHandle(ctx, id)
 }
 
 func (s *BadgerMetadataStore) GetDurableHandlesByAppInstanceId(ctx context.Context, appInstanceId [16]byte) ([]*lock.PersistedDurableHandle, error) {

--- a/pkg/metadata/store/badger/durable_handles.go
+++ b/pkg/metadata/store/badger/durable_handles.go
@@ -218,8 +218,8 @@ func (s *badgerDurableStore) GetDurableHandle(ctx context.Context, id string) (*
 	return handle, nil
 }
 
-// getDurableHandleTx reads the primary record for an ID, returning nil when it
-// does not exist. Callers supply the transaction.
+// getDurableHandleTx reads the primary record for an ID inside the caller's
+// transaction, returning nil when it does not exist.
 func (s *badgerDurableStore) getDurableHandleTx(txn *badgerdb.Txn, id string) (*lock.PersistedDurableHandle, error) {
 	item, err := txn.Get([]byte(prefixDHID + id))
 	if err == badgerdb.ErrKeyNotFound {
@@ -444,23 +444,12 @@ func (s *badgerDurableStore) DeleteDurableHandle(ctx context.Context, id string)
 }
 
 func (s *badgerDurableStore) deleteDurableHandleTx(txn *badgerdb.Txn, id string) error {
-	item, err := txn.Get([]byte(prefixDHID + id))
-	if err == badgerdb.ErrKeyNotFound {
-		return nil // Already gone
-	}
-	if err != nil {
-		return err
+	handle, err := s.getDurableHandleTx(txn, id)
+	if err != nil || handle == nil {
+		return err // nil handle means already gone
 	}
 
-	var handle lock.PersistedDurableHandle
-	err = item.Value(func(val []byte) error {
-		return json.Unmarshal(val, &handle)
-	})
-	if err != nil {
-		return err
-	}
-
-	if err := s.deleteIndicesTx(txn, &handle); err != nil {
+	if err := s.deleteIndicesTx(txn, handle); err != nil {
 		return err
 	}
 

--- a/pkg/metadata/store/memory/durable_handles.go
+++ b/pkg/metadata/store/memory/durable_handles.go
@@ -73,8 +73,8 @@ func (s *memoryDurableStore) GetDurableHandleByFileID(ctx context.Context, fileI
 
 // lowestHandleForFileID returns the handle with the smallest ID among those
 // held on a file, or nil when the file holds none. A file can carry several
-// durable handles at once, so Get and Consume pick by ID rather than by map
-// order to agree on which one they mean. Callers hold the lock.
+// durable handles at once, so the pick is by ID rather than by map order to
+// stay stable across repeated lookups. Callers hold the lock.
 func (s *memoryDurableStore) lowestHandleForFileID(fileID [16]byte) *lock.PersistedDurableHandle {
 	var lowest *lock.PersistedDurableHandle
 	for _, handle := range s.handles {
@@ -107,46 +107,20 @@ func (s *memoryDurableStore) GetDurableHandleByCreateGuid(ctx context.Context, c
 	return nil, nil
 }
 
-func (s *memoryDurableStore) ConsumeDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
+func (s *memoryDurableStore) ConsumeDurableHandle(ctx context.Context, id string) (*lock.PersistedDurableHandle, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
-	}
-
-	if fileID == ([16]byte{}) {
-		return nil, nil
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	handle := s.lowestHandleForFileID(fileID)
-	if handle == nil {
+	handle, exists := s.handles[id]
+	if !exists {
 		return nil, nil
 	}
-	delete(s.handles, handle.ID)
+	delete(s.handles, id)
 	return cloneDurableHandle(handle), nil
-}
-
-func (s *memoryDurableStore) ConsumeDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	if createGuid == ([16]byte{}) {
-		return nil, nil
-	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	for id, handle := range s.handles {
-		if handle.CreateGuid == createGuid {
-			delete(s.handles, id)
-			return cloneDurableHandle(handle), nil
-		}
-	}
-
-	return nil, nil
 }
 
 func (s *memoryDurableStore) GetDurableHandlesByAppInstanceId(ctx context.Context, appInstanceId [16]byte) ([]*lock.PersistedDurableHandle, error) {
@@ -331,12 +305,8 @@ func (s *MemoryMetadataStore) GetDurableHandleByCreateGuid(ctx context.Context, 
 	return s.getDurableStore().GetDurableHandleByCreateGuid(ctx, createGuid)
 }
 
-func (s *MemoryMetadataStore) ConsumeDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().ConsumeDurableHandleByFileID(ctx, fileID)
-}
-
-func (s *MemoryMetadataStore) ConsumeDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().ConsumeDurableHandleByCreateGuid(ctx, createGuid)
+func (s *MemoryMetadataStore) ConsumeDurableHandle(ctx context.Context, id string) (*lock.PersistedDurableHandle, error) {
+	return s.getDurableStore().ConsumeDurableHandle(ctx, id)
 }
 
 func (s *MemoryMetadataStore) GetDurableHandlesByAppInstanceId(ctx context.Context, appInstanceId [16]byte) ([]*lock.PersistedDurableHandle, error) {

--- a/pkg/metadata/store/postgres/durable_handles.go
+++ b/pkg/metadata/store/postgres/durable_handles.go
@@ -301,20 +301,12 @@ func (s *postgresDurableStore) GetDurableHandleByCreateGuid(ctx context.Context,
 	return scanDurableHandle(s.st.queryRow(ctx, query, createGuid[:]))
 }
 
-// ConsumeDurableHandleByFileID atomically fetches and deletes via
-// `DELETE ... RETURNING`, closing the V1 reconnect TOCTOU window. A file can
-// hold several durable handles at once and DELETE takes no LIMIT, so the
-// subquery pins the delete to the single row being claimed and leaves the
-// file's other handles untouched.
-func (s *postgresDurableStore) ConsumeDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
-	query := `DELETE FROM durable_handles WHERE id = (SELECT id FROM durable_handles WHERE file_id = $1 ORDER BY id LIMIT 1) RETURNING ` + durableHandleColumns
-	return scanDurableHandle(s.st.queryRow(ctx, query, fileID[:]))
-}
-
-// ConsumeDurableHandleByCreateGuid is the V2 counterpart.
-func (s *postgresDurableStore) ConsumeDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
-	query := `DELETE FROM durable_handles WHERE create_guid = $1 RETURNING ` + durableHandleColumns
-	return scanDurableHandle(s.st.queryRow(ctx, query, createGuid[:]))
+// ConsumeDurableHandle atomically fetches and deletes via
+// `DELETE ... RETURNING`. Keying on the primary key claims exactly the row the
+// caller validated and leaves the file's other handles untouched.
+func (s *postgresDurableStore) ConsumeDurableHandle(ctx context.Context, id string) (*lock.PersistedDurableHandle, error) {
+	query := `DELETE FROM durable_handles WHERE id = $1 RETURNING ` + durableHandleColumns
+	return scanDurableHandle(s.st.queryRow(ctx, query, id))
 }
 
 func (s *postgresDurableStore) GetDurableHandlesByAppInstanceId(ctx context.Context, appInstanceId [16]byte) ([]*lock.PersistedDurableHandle, error) {
@@ -400,12 +392,8 @@ func (s *PostgresMetadataStore) GetDurableHandleByCreateGuid(ctx context.Context
 	return s.getDurableStore().GetDurableHandleByCreateGuid(ctx, createGuid)
 }
 
-func (s *PostgresMetadataStore) ConsumeDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().ConsumeDurableHandleByFileID(ctx, fileID)
-}
-
-func (s *PostgresMetadataStore) ConsumeDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().ConsumeDurableHandleByCreateGuid(ctx, createGuid)
+func (s *PostgresMetadataStore) ConsumeDurableHandle(ctx context.Context, id string) (*lock.PersistedDurableHandle, error) {
+	return s.getDurableStore().ConsumeDurableHandle(ctx, id)
 }
 
 func (s *PostgresMetadataStore) GetDurableHandlesByAppInstanceId(ctx context.Context, appInstanceId [16]byte) ([]*lock.PersistedDurableHandle, error) {

--- a/pkg/metadata/store/sqlite/durable_handles.go
+++ b/pkg/metadata/store/sqlite/durable_handles.go
@@ -301,20 +301,12 @@ func (s *sqliteDurableStore) GetDurableHandleByCreateGuid(ctx context.Context, c
 	return scanDurableHandle(s.pool.QueryRow(ctx, query, createGuid[:]))
 }
 
-// ConsumeDurableHandleByFileID atomically fetches and deletes via
-// `DELETE ... RETURNING`, closing the V1 reconnect TOCTOU window. A file can
-// hold several durable handles at once and DELETE takes no LIMIT, so the
-// subquery pins the delete to the single row being claimed and leaves the
-// file's other handles untouched.
-func (s *sqliteDurableStore) ConsumeDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
-	query := `DELETE FROM durable_handles WHERE id = (SELECT id FROM durable_handles WHERE file_id = ?1 ORDER BY id LIMIT 1) RETURNING ` + durableHandleColumns
-	return scanDurableHandle(s.pool.QueryRow(ctx, query, fileID[:]))
-}
-
-// ConsumeDurableHandleByCreateGuid is the V2 counterpart.
-func (s *sqliteDurableStore) ConsumeDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
-	query := `DELETE FROM durable_handles WHERE create_guid = ?1 RETURNING ` + durableHandleColumns
-	return scanDurableHandle(s.pool.QueryRow(ctx, query, createGuid[:]))
+// ConsumeDurableHandle atomically fetches and deletes via
+// `DELETE ... RETURNING`. Keying on the primary key claims exactly the row the
+// caller validated and leaves the file's other handles untouched.
+func (s *sqliteDurableStore) ConsumeDurableHandle(ctx context.Context, id string) (*lock.PersistedDurableHandle, error) {
+	query := `DELETE FROM durable_handles WHERE id = ?1 RETURNING ` + durableHandleColumns
+	return scanDurableHandle(s.pool.QueryRow(ctx, query, id))
 }
 
 func (s *sqliteDurableStore) GetDurableHandlesByAppInstanceId(ctx context.Context, appInstanceId [16]byte) ([]*lock.PersistedDurableHandle, error) {
@@ -426,12 +418,8 @@ func (s *SQLiteMetadataStore) GetDurableHandleByCreateGuid(ctx context.Context, 
 	return s.getDurableStore().GetDurableHandleByCreateGuid(ctx, createGuid)
 }
 
-func (s *SQLiteMetadataStore) ConsumeDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().ConsumeDurableHandleByFileID(ctx, fileID)
-}
-
-func (s *SQLiteMetadataStore) ConsumeDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().ConsumeDurableHandleByCreateGuid(ctx, createGuid)
+func (s *SQLiteMetadataStore) ConsumeDurableHandle(ctx context.Context, id string) (*lock.PersistedDurableHandle, error) {
+	return s.getDurableStore().ConsumeDurableHandle(ctx, id)
 }
 
 func (s *SQLiteMetadataStore) GetDurableHandlesByAppInstanceId(ctx context.Context, appInstanceId [16]byte) ([]*lock.PersistedDurableHandle, error) {

--- a/pkg/metadata/storetest/durable_handles.go
+++ b/pkg/metadata/storetest/durable_handles.go
@@ -61,8 +61,8 @@ func RunDurableHandleStoreTests(t *testing.T, factory StoreFactory) {
 		testDurableDeleteKeepsSiblingOnSameFileID(t, factory)
 	})
 
-	t.Run("ConsumeKeepsSibling", func(t *testing.T) {
-		testDurableConsumeKeepsSibling(t, factory)
+	t.Run("Consume", func(t *testing.T) {
+		testDurableConsume(t, factory)
 	})
 
 	t.Run("GetByCreateGuid", func(t *testing.T) {
@@ -91,10 +91,6 @@ func RunDurableHandleStoreTests(t *testing.T, factory StoreFactory) {
 
 	t.Run("DeleteExpiredKeepsActive", func(t *testing.T) {
 		testDurableDeleteExpiredKeepsActive(t, factory)
-	})
-
-	t.Run("ConsumeAtomic", func(t *testing.T) {
-		testDurableConsumeAtomic(t, factory)
 	})
 }
 
@@ -427,23 +423,15 @@ func testDurableDeleteKeepsSiblingOnSameFileID(t *testing.T, factory StoreFactor
 	if got != nil {
 		t.Fatalf("deleted handle still resolves: %+v", got)
 	}
-
-	// The reconnect path reaches the survivor too, not just the plain lookup.
-	consumed, err := ds.ConsumeDurableHandle(ctx, second.ID)
-	if err != nil {
-		t.Fatalf("ConsumeDurableHandle() error: %v", err)
-	}
-	if consumed == nil {
-		t.Fatal("consume returned nil for the surviving handle")
-	}
-	assertDurableHandleEqual(t, second, consumed)
 }
 
-// testDurableConsumeKeepsSibling covers a reconnect against a file that
-// carries two durable handles. Consume names the handle by ID, so it claims
+// testDurableConsume covers a reconnect against a file that carries two
+// durable handles. Consume names the handle by ID, so it atomically claims
 // exactly the one validation ran against and never a sibling — even when the
-// named handle is already gone and a sibling on the same file remains.
-func testDurableConsumeKeepsSibling(t *testing.T, factory StoreFactory) {
+// named handle is already gone and a sibling on the same file remains. A
+// second consume of the same ID reports nothing, so two concurrent reconnects
+// cannot both succeed.
+func testDurableConsume(t *testing.T, factory StoreFactory) {
 	ds := getDurableStore(t, factory)
 	ctx := context.Background()
 
@@ -467,7 +455,15 @@ func testDurableConsumeKeepsSibling(t *testing.T, factory StoreFactory) {
 	}
 	assertDurableHandleEqual(t, first, consumed)
 
-	got, err := ds.GetDurableHandle(ctx, second.ID)
+	got, err := ds.GetDurableHandle(ctx, first.ID)
+	if err != nil {
+		t.Fatalf("GetDurableHandle(consumed) error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("primary key still resolves after consume: %+v", got)
+	}
+
+	got, err = ds.GetDurableHandle(ctx, second.ID)
 	if err != nil {
 		t.Fatalf("GetDurableHandle(survivor) error: %v", err)
 	}
@@ -760,47 +756,5 @@ func testDurableDeleteExpiredKeepsActive(t *testing.T, factory StoreFactory) {
 	// Boundary handles should be expired (DisconnectedAt + TimeoutMs == now means expired)
 	if count != 1 {
 		t.Fatalf("expected boundary handle to be expired, got count %d", count)
-	}
-}
-
-// testDurableConsumeAtomic verifies that ConsumeDurableHandle atomically
-// returns the persisted record and removes it, so a second concurrent
-// reconnect claiming the same handle cannot also succeed. Closes the TOCTOU
-// window present in the old Get-then-Delete pattern.
-func testDurableConsumeAtomic(t *testing.T, factory StoreFactory) {
-	ds := getDurableStore(t, factory)
-	ctx := context.Background()
-
-	handle := makeDurableHandle("consume-1", "/export")
-	if err := ds.PutDurableHandle(ctx, handle); err != nil {
-		t.Fatalf("PutDurableHandle() error: %v", err)
-	}
-
-	// First consume returns the record.
-	got, err := ds.ConsumeDurableHandle(ctx, handle.ID)
-	if err != nil {
-		t.Fatalf("ConsumeDurableHandle() error: %v", err)
-	}
-	if got == nil {
-		t.Fatal("first consume returned nil; expected record")
-	}
-	assertDurableHandleEqual(t, handle, got)
-
-	// Second consume sees nothing.
-	got, err = ds.ConsumeDurableHandle(ctx, handle.ID)
-	if err != nil {
-		t.Fatalf("second ConsumeDurableHandle() error: %v", err)
-	}
-	if got != nil {
-		t.Errorf("second consume returned a record, want nil — atomicity broken")
-	}
-
-	// Primary GetDurableHandle also reports gone.
-	got, err = ds.GetDurableHandle(ctx, handle.ID)
-	if err != nil {
-		t.Fatalf("GetDurableHandle() error: %v", err)
-	}
-	if got != nil {
-		t.Errorf("primary key still resolves after consume: %+v", got)
 	}
 }

--- a/pkg/metadata/storetest/durable_handles.go
+++ b/pkg/metadata/storetest/durable_handles.go
@@ -61,8 +61,8 @@ func RunDurableHandleStoreTests(t *testing.T, factory StoreFactory) {
 		testDurableDeleteKeepsSiblingOnSameFileID(t, factory)
 	})
 
-	t.Run("ConsumeByFileIDKeepsSibling", func(t *testing.T) {
-		testDurableConsumeByFileIDKeepsSibling(t, factory)
+	t.Run("ConsumeKeepsSibling", func(t *testing.T) {
+		testDurableConsumeKeepsSibling(t, factory)
 	})
 
 	t.Run("GetByCreateGuid", func(t *testing.T) {
@@ -93,12 +93,8 @@ func RunDurableHandleStoreTests(t *testing.T, factory StoreFactory) {
 		testDurableDeleteExpiredKeepsActive(t, factory)
 	})
 
-	t.Run("ConsumeByFileIDAtomic", func(t *testing.T) {
-		testDurableConsumeByFileIDAtomic(t, factory)
-	})
-
-	t.Run("ConsumeByCreateGuidAtomic", func(t *testing.T) {
-		testDurableConsumeByCreateGuidAtomic(t, factory)
+	t.Run("ConsumeAtomic", func(t *testing.T) {
+		testDurableConsumeAtomic(t, factory)
 	})
 }
 
@@ -433,9 +429,9 @@ func testDurableDeleteKeepsSiblingOnSameFileID(t *testing.T, factory StoreFactor
 	}
 
 	// The reconnect path reaches the survivor too, not just the plain lookup.
-	consumed, err := ds.ConsumeDurableHandleByFileID(ctx, second.FileID)
+	consumed, err := ds.ConsumeDurableHandle(ctx, second.ID)
 	if err != nil {
-		t.Fatalf("ConsumeDurableHandleByFileID() error: %v", err)
+		t.Fatalf("ConsumeDurableHandle() error: %v", err)
 	}
 	if consumed == nil {
 		t.Fatal("consume returned nil for the surviving handle")
@@ -443,10 +439,11 @@ func testDurableDeleteKeepsSiblingOnSameFileID(t *testing.T, factory StoreFactor
 	assertDurableHandleEqual(t, second, consumed)
 }
 
-// testDurableConsumeByFileIDKeepsSibling covers a reconnect against a file that
-// carries two durable handles. Consume claims exactly one of them; the other
-// must survive as a complete record, since it still backs a live open.
-func testDurableConsumeByFileIDKeepsSibling(t *testing.T, factory StoreFactory) {
+// testDurableConsumeKeepsSibling covers a reconnect against a file that
+// carries two durable handles. Consume names the handle by ID, so it claims
+// exactly the one validation ran against and never a sibling — even when the
+// named handle is already gone and a sibling on the same file remains.
+func testDurableConsumeKeepsSibling(t *testing.T, factory StoreFactory) {
 	ds := getDurableStore(t, factory)
 	ctx := context.Background()
 
@@ -461,58 +458,46 @@ func testDurableConsumeByFileIDKeepsSibling(t *testing.T, factory StoreFactory) 
 		t.Fatalf("PutDurableHandle(second) error: %v", err)
 	}
 
-	// A reconnect validates the handle Get reports and then claims one with
-	// Consume, so the two must name the same handle while both are present.
-	peeked, err := ds.GetDurableHandleByFileID(ctx, first.FileID)
+	consumed, err := ds.ConsumeDurableHandle(ctx, first.ID)
 	if err != nil {
-		t.Fatalf("GetDurableHandleByFileID() error: %v", err)
-	}
-	if peeked == nil {
-		t.Fatal("FileID lookup returned nil while two handles exist for the FileID")
-	}
-
-	consumed, err := ds.ConsumeDurableHandleByFileID(ctx, first.FileID)
-	if err != nil {
-		t.Fatalf("ConsumeDurableHandleByFileID() error: %v", err)
+		t.Fatalf("ConsumeDurableHandle() error: %v", err)
 	}
 	if consumed == nil {
-		t.Fatal("consume returned nil while two handles exist for the FileID")
+		t.Fatal("consume returned nil for a live handle")
 	}
-	if consumed.ID != peeked.ID {
-		t.Fatalf("consume claimed %q but the FileID lookup reported %q; a reconnect would validate one handle and claim another", consumed.ID, peeked.ID)
-	}
+	assertDurableHandleEqual(t, first, consumed)
 
-	survivor := second
-	if consumed.ID == second.ID {
-		survivor = first
-	}
-
-	got, err := ds.GetDurableHandle(ctx, survivor.ID)
+	got, err := ds.GetDurableHandle(ctx, second.ID)
 	if err != nil {
 		t.Fatalf("GetDurableHandle(survivor) error: %v", err)
 	}
 	if got == nil {
-		t.Fatalf("consuming %q also destroyed sibling %q on the same FileID", consumed.ID, survivor.ID)
+		t.Fatalf("consuming %q also destroyed sibling %q on the same FileID", first.ID, second.ID)
 	}
-	assertDurableHandleEqual(t, survivor, got)
+	assertDurableHandleEqual(t, second, got)
 
 	// The survivor is still the answer for the FileID, so a later reconnect
 	// against the same file can still claim it.
-	got, err = ds.GetDurableHandleByFileID(ctx, survivor.FileID)
+	got, err = ds.GetDurableHandleByFileID(ctx, second.FileID)
 	if err != nil {
 		t.Fatalf("GetDurableHandleByFileID() error: %v", err)
 	}
-	if got == nil || got.ID != survivor.ID {
-		t.Fatalf("FileID lookup after consume returned %+v, want %q", got, survivor.ID)
+	if got == nil || got.ID != second.ID {
+		t.Fatalf("FileID lookup after consume returned %+v, want %q", got, second.ID)
 	}
 
-	// The consumed handle is gone for good.
-	got, err = ds.GetDurableHandle(ctx, consumed.ID)
+	// Re-consuming the claimed ID reports nothing rather than falling through
+	// to the sibling: a reconnect whose validated handle was reaped meanwhile
+	// must fail, not claim an unvalidated handle.
+	got, err = ds.ConsumeDurableHandle(ctx, first.ID)
 	if err != nil {
-		t.Fatalf("GetDurableHandle(consumed) error: %v", err)
+		t.Fatalf("second ConsumeDurableHandle() error: %v", err)
 	}
 	if got != nil {
-		t.Fatalf("consumed handle still resolves: %+v", got)
+		t.Fatalf("consuming a gone handle claimed %q instead of reporting nil", got.ID)
+	}
+	if got, err = ds.GetDurableHandle(ctx, second.ID); err != nil || got == nil {
+		t.Fatalf("sibling lost to a consume naming a gone handle (err=%v)", err)
 	}
 }
 
@@ -778,24 +763,23 @@ func testDurableDeleteExpiredKeepsActive(t *testing.T, factory StoreFactory) {
 	}
 }
 
-// testDurableConsumeByFileIDAtomic verifies that ConsumeDurableHandleByFileID
-// atomically returns the persisted record and removes it from the store, so
-// a second concurrent reconnect attempt for the same FileID cannot also
-// claim the handle. Closes the TOCTOU window present in the old
-// Get-then-Delete pattern.
-func testDurableConsumeByFileIDAtomic(t *testing.T, factory StoreFactory) {
+// testDurableConsumeAtomic verifies that ConsumeDurableHandle atomically
+// returns the persisted record and removes it, so a second concurrent
+// reconnect claiming the same handle cannot also succeed. Closes the TOCTOU
+// window present in the old Get-then-Delete pattern.
+func testDurableConsumeAtomic(t *testing.T, factory StoreFactory) {
 	ds := getDurableStore(t, factory)
 	ctx := context.Background()
 
-	handle := makeDurableHandle("consume-fid-1", "/export")
+	handle := makeDurableHandle("consume-1", "/export")
 	if err := ds.PutDurableHandle(ctx, handle); err != nil {
 		t.Fatalf("PutDurableHandle() error: %v", err)
 	}
 
 	// First consume returns the record.
-	got, err := ds.ConsumeDurableHandleByFileID(ctx, handle.FileID)
+	got, err := ds.ConsumeDurableHandle(ctx, handle.ID)
 	if err != nil {
-		t.Fatalf("ConsumeDurableHandleByFileID() error: %v", err)
+		t.Fatalf("ConsumeDurableHandle() error: %v", err)
 	}
 	if got == nil {
 		t.Fatal("first consume returned nil; expected record")
@@ -803,52 +787,15 @@ func testDurableConsumeByFileIDAtomic(t *testing.T, factory StoreFactory) {
 	assertDurableHandleEqual(t, handle, got)
 
 	// Second consume sees nothing.
-	got, err = ds.ConsumeDurableHandleByFileID(ctx, handle.FileID)
+	got, err = ds.ConsumeDurableHandle(ctx, handle.ID)
 	if err != nil {
-		t.Fatalf("second ConsumeDurableHandleByFileID() error: %v", err)
+		t.Fatalf("second ConsumeDurableHandle() error: %v", err)
 	}
 	if got != nil {
 		t.Errorf("second consume returned a record, want nil — atomicity broken")
 	}
 
 	// Primary GetDurableHandle also reports gone.
-	got, err = ds.GetDurableHandle(ctx, handle.ID)
-	if err != nil {
-		t.Fatalf("GetDurableHandle() error: %v", err)
-	}
-	if got != nil {
-		t.Errorf("primary key still resolves after consume: %+v", got)
-	}
-}
-
-// testDurableConsumeByCreateGuidAtomic is the V2 counterpart of
-// testDurableConsumeByFileIDAtomic.
-func testDurableConsumeByCreateGuidAtomic(t *testing.T, factory StoreFactory) {
-	ds := getDurableStore(t, factory)
-	ctx := context.Background()
-
-	handle := makeDurableHandle("consume-cguid-1", "/export")
-	if err := ds.PutDurableHandle(ctx, handle); err != nil {
-		t.Fatalf("PutDurableHandle() error: %v", err)
-	}
-
-	got, err := ds.ConsumeDurableHandleByCreateGuid(ctx, handle.CreateGuid)
-	if err != nil {
-		t.Fatalf("ConsumeDurableHandleByCreateGuid() error: %v", err)
-	}
-	if got == nil {
-		t.Fatal("first consume returned nil; expected record")
-	}
-	assertDurableHandleEqual(t, handle, got)
-
-	got, err = ds.ConsumeDurableHandleByCreateGuid(ctx, handle.CreateGuid)
-	if err != nil {
-		t.Fatalf("second ConsumeDurableHandleByCreateGuid() error: %v", err)
-	}
-	if got != nil {
-		t.Errorf("second consume returned a record, want nil — atomicity broken")
-	}
-
 	got, err = ds.GetDurableHandle(ctx, handle.ID)
 	if err != nil {
 		t.Fatalf("GetDurableHandle() error: %v", err)


### PR DESCRIPTION
Closes #1931.

## Problem

On the SMB durable-handle reconnect path, `Get` and `Consume` were two separate store calls, each keyed independently by a *secondary* index — FileID for V1 (DHnC), CreateGuid for V2 (DH2C). The handler validated the handle `Get` returned, then claimed one via `Consume`. Nothing held a lock across the pair, so a sibling handle inserted or reaped in that window could be claimed instead of the one that was validated.

#1926 made multiple durable handles per file persist correctly and fixed the *deterministic* half (both sides now select the lowest-keyed live entry). What remained was the genuinely concurrent case: the selection was consistent, but not atomic.

## Fix

Take the first option the issue suggests — consume by handle ID rather than by FileID/CreateGuid. The handler already holds the record `Get` returned, so naming it closes the window with no new store API surface.

`ConsumeDurableHandleByFileID` + `ConsumeDurableHandleByCreateGuid` collapse into one `ConsumeDurableHandle(ctx, id string)`:

- **memory** — map lookup + delete under the existing mutex.
- **badger** — `getDurableHandleTx` + `deleteDurableHandleTx` inside one `db.Update` txn.
- **sqlite / postgres** — `DELETE FROM durable_handles WHERE id = $1 RETURNING …`, keyed on the primary key instead of a subquery over a secondary index.

`validateAndRestore` loses its `consume` closure parameter and calls `durableStore.ConsumeDurableHandle(ctx, handle.ID)` directly — both reconnect paths now share one claim, so the V1/V2 asymmetry in the closure disappears. The V1-via-DH2C fallback (zero CreateGuid) still *looks up* by FileID; only the claim changes.

Net −164 lines across interface, four backends, and the conformance suite.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt` clean.
- `go test -count=1 ./pkg/metadata/... ./internal/adapter/smb/...` green.
- Conformance `DurableHandles/Consume` passes on memory, badger, sqlite, **and postgres** (run against a local 18.6 instance with `-tags=integration`). It asserts a sibling on the same FileID survives, stays reachable by FileID afterward, and that re-consuming an already-claimed ID reports nil rather than falling through to the sibling — the exact substitution this fixes.
- The two `TestPostgresPutFile_*` integration failures seen locally reproduce identically on unmodified `develop` (unrelated env config, "host is required").
