### PR TITLE
fix(block): block the legacy cas/ purge when a configured share is not registered

### DIFF
--- a/pkg/controlplane/runtime/blockgc.go
+++ b/pkg/controlplane/runtime/blockgc.go
@@ -657,6 +657,38 @@ func (r *Runtime) sharesForRemote(configID string) []string {
 	return nil
 }
 
+// configuredSharesForRemote counts the persisted share rows that reference a
+// remote-store config, whether or not they are registered. A share can be
+// configured yet absent from the registry — its metadata store is missing, or
+// AddShare failed and LoadSharesFromStore only warned and skipped it — and such
+// a share never ran its cas→blocks migration, so its chunks are exactly the
+// standalone cas/<hash> objects a purge would delete.
+//
+// Returns 0 for a Runtime with no config store and for the test-only remote
+// binding, neither of which has persisted shares to disagree about.
+func (r *Runtime) configuredSharesForRemote(ctx context.Context, configID string) (int, error) {
+	if r.store == nil || configID == "" {
+		return 0, nil
+	}
+	cfg, err := r.store.GetBlockStoreByID(ctx, configID)
+	if err != nil {
+		return 0, fmt.Errorf("resolve remote block store %s: %w", configID, err)
+	}
+	rows, err := r.store.ListShares(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("list configured shares: %w", err)
+	}
+	var n int
+	for _, sh := range rows {
+		// Rows written before block stores were referenced by UUID hold the
+		// config name instead, and both forms resolve to this one store.
+		if ref := derefString(sh.RemoteBlockStoreID); ref == configID || ref == cfg.Name {
+			n++
+		}
+	}
+	return n, nil
+}
+
 // purgeLegacyCASForEntry reclaims what is left of the pre-flip cas/ namespace
 // on one remote. The namespace is content-addressed and NOT scoped per share,
 // so a cas/<hash> object is reclaimable only once no share on this remote can
@@ -699,6 +731,21 @@ func (r *Runtime) purgeLegacyCASForEntry(ctx context.Context, entry shares.Remot
 	if len(shareNames) == 0 {
 		logger.Info("GC: legacy cas/ purge skipped — no registered share claims this remote",
 			"configID", entry.ConfigID)
+		return
+	}
+	// Deleting is the irreversible side, so an unexplained gap between the
+	// configured and the registered share set blocks the purge outright rather
+	// than gating on a share list that disagrees with the registry the
+	// enumeration below walks.
+	configured, err := r.configuredSharesForRemote(ctx, entry.ConfigID)
+	if err != nil {
+		logger.Warn("GC: legacy cas/ purge skipped — configured shares for this remote could not be read",
+			"configID", entry.ConfigID, "err", err)
+		return
+	}
+	if configured > len(shareNames) {
+		logger.Info("GC: legacy cas/ purge skipped — a configured share on this remote is not registered, so its chunks may still be un-migrated",
+			"configID", entry.ConfigID, "configured", configured, "registered", len(shareNames))
 		return
 	}
 	for _, shareName := range shareNames {

--- a/pkg/controlplane/runtime/blockgc.go
+++ b/pkg/controlplane/runtime/blockgc.go
@@ -12,6 +12,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/engine"
 	"github.com/marmos91/dittofs/pkg/block/remote"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime/shares"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
@@ -659,8 +660,8 @@ func (r *Runtime) sharesForRemote(configID string) []string {
 }
 
 // unregisteredConfiguredShare names a share whose persisted row references a
-// remote-store config while the registry does not carry it — disabled at boot,
-// unknown metadata store, or an AddShare that LoadSharesFromStore only warned
+// remote-store config while the registry does not carry it — an unknown
+// metadata store, or any other AddShare failure LoadSharesFromStore only warned
 // about and skipped. Such a share never ran its cas→blocks migration, so its
 // chunks are exactly the standalone cas/<hash> objects a purge would delete.
 //
@@ -675,22 +676,37 @@ func (r *Runtime) unregisteredConfiguredShare(ctx context.Context, configID stri
 	if err != nil {
 		return "", fmt.Errorf("resolve remote block store %s: %w", configID, err)
 	}
+	remotes, err := r.store.ListBlockStores(ctx, models.BlockStoreKindRemote)
+	if err != nil {
+		return "", fmt.Errorf("list remote block stores: %w", err)
+	}
 	rows, err := r.store.ListShares(ctx)
 	if err != nil {
 		return "", fmt.Errorf("list configured shares: %w", err)
 	}
 	for _, sh := range rows {
-		// Rows written before block stores were referenced by UUID hold the
-		// config name instead, and both forms resolve to this one store.
 		ref := derefString(sh.RemoteBlockStoreID)
-		if ref != configID && ref != cfg.Name {
+		if ref == "" || slices.Contains(registered, sh.Name) {
 			continue
 		}
-		if !slices.Contains(registered, sh.Name) {
+		// Rows written before block stores were referenced by UUID hold the
+		// config name instead, and both forms resolve to this one store. A
+		// reference matching no remote at all is treated as this one's: it is
+		// most likely a stale name for a since-renamed config, and the share
+		// that carries it is exactly the one that failed to register.
+		if ref == configID || ref == cfg.Name || !knownRemoteRef(remotes, ref) {
 			return sh.Name, nil
 		}
 	}
 	return "", nil
+}
+
+// knownRemoteRef reports whether a share row's remote reference resolves to one
+// of the configured remote block stores, by UUID or by legacy name.
+func knownRemoteRef(remotes []*models.BlockStoreConfig, ref string) bool {
+	return slices.ContainsFunc(remotes, func(c *models.BlockStoreConfig) bool {
+		return c.ID == ref || c.Name == ref
+	})
 }
 
 // purgeLegacyCASForEntry reclaims what is left of the pre-flip cas/ namespace

--- a/pkg/controlplane/runtime/blockgc.go
+++ b/pkg/controlplane/runtime/blockgc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -657,36 +658,39 @@ func (r *Runtime) sharesForRemote(configID string) []string {
 	return nil
 }
 
-// configuredSharesForRemote counts the persisted share rows that reference a
-// remote-store config, whether or not they are registered. A share can be
-// configured yet absent from the registry — its metadata store is missing, or
-// AddShare failed and LoadSharesFromStore only warned and skipped it — and such
-// a share never ran its cas→blocks migration, so its chunks are exactly the
-// standalone cas/<hash> objects a purge would delete.
+// unregisteredConfiguredShare names a share whose persisted row references a
+// remote-store config while the registry does not carry it — disabled at boot,
+// unknown metadata store, or an AddShare that LoadSharesFromStore only warned
+// about and skipped. Such a share never ran its cas→blocks migration, so its
+// chunks are exactly the standalone cas/<hash> objects a purge would delete.
 //
-// Returns 0 for a Runtime with no config store and for the test-only remote
-// binding, neither of which has persisted shares to disagree about.
-func (r *Runtime) configuredSharesForRemote(ctx context.Context, configID string) (int, error) {
+// Empty when every configured share on the remote is registered, and for a
+// Runtime with no config store or a test-only remote binding, neither of which
+// has persisted rows to disagree about.
+func (r *Runtime) unregisteredConfiguredShare(ctx context.Context, configID string, registered []string) (string, error) {
 	if r.store == nil || configID == "" {
-		return 0, nil
+		return "", nil
 	}
 	cfg, err := r.store.GetBlockStoreByID(ctx, configID)
 	if err != nil {
-		return 0, fmt.Errorf("resolve remote block store %s: %w", configID, err)
+		return "", fmt.Errorf("resolve remote block store %s: %w", configID, err)
 	}
 	rows, err := r.store.ListShares(ctx)
 	if err != nil {
-		return 0, fmt.Errorf("list configured shares: %w", err)
+		return "", fmt.Errorf("list configured shares: %w", err)
 	}
-	var n int
 	for _, sh := range rows {
 		// Rows written before block stores were referenced by UUID hold the
 		// config name instead, and both forms resolve to this one store.
-		if ref := derefString(sh.RemoteBlockStoreID); ref == configID || ref == cfg.Name {
-			n++
+		ref := derefString(sh.RemoteBlockStoreID)
+		if ref != configID && ref != cfg.Name {
+			continue
+		}
+		if !slices.Contains(registered, sh.Name) {
+			return sh.Name, nil
 		}
 	}
-	return n, nil
+	return "", nil
 }
 
 // purgeLegacyCASForEntry reclaims what is left of the pre-flip cas/ namespace
@@ -733,19 +737,17 @@ func (r *Runtime) purgeLegacyCASForEntry(ctx context.Context, entry shares.Remot
 			"configID", entry.ConfigID)
 		return
 	}
-	// Deleting is the irreversible side, so an unexplained gap between the
-	// configured and the registered share set blocks the purge outright rather
-	// than gating on a share list that disagrees with the registry the
-	// enumeration below walks.
-	configured, err := r.configuredSharesForRemote(ctx, entry.ConfigID)
+	// The enumeration below only walks registered shares, so a configured one
+	// missing from that set blocks the purge outright.
+	unregistered, err := r.unregisteredConfiguredShare(ctx, entry.ConfigID, shareNames)
 	if err != nil {
 		logger.Warn("GC: legacy cas/ purge skipped — configured shares for this remote could not be read",
 			"configID", entry.ConfigID, "err", err)
 		return
 	}
-	if configured > len(shareNames) {
+	if unregistered != "" {
 		logger.Info("GC: legacy cas/ purge skipped — a configured share on this remote is not registered, so its chunks may still be un-migrated",
-			"configID", entry.ConfigID, "configured", configured, "registered", len(shareNames))
+			"configID", entry.ConfigID, "share", unregistered)
 		return
 	}
 	for _, shareName := range shareNames {

--- a/pkg/controlplane/runtime/blockgc_test.go
+++ b/pkg/controlplane/runtime/blockgc_test.go
@@ -355,18 +355,13 @@ func TestPurgeLegacyCAS_ConfiguredShareNotRegistered(t *testing.T) {
 		}
 	})
 
-	metaIDs := map[string]string{}
-	for _, name := range []string{"meta-a", "meta-b"} {
-		id, err := cp.CreateMetadataStore(ctx, &models.MetadataStoreConfig{Name: name, Type: "memory"})
-		if err != nil {
-			t.Fatalf("CreateMetadataStore(%s): %v", name, err)
-		}
-		metaIDs[name] = id
-		if err := rt.RegisterMetadataStore(name, metadatamemory.NewMemoryMetadataStoreWithDefaults()); err != nil {
-			t.Fatalf("RegisterMetadataStore(%s): %v", name, err)
-		}
+	metaID, err := cp.CreateMetadataStore(ctx, &models.MetadataStoreConfig{Name: "meta", Type: "memory"})
+	if err != nil {
+		t.Fatalf("CreateMetadataStore: %v", err)
 	}
-
+	if err := rt.RegisterMetadataStore("meta", metadatamemory.NewMemoryMetadataStoreWithDefaults()); err != nil {
+		t.Fatalf("RegisterMetadataStore: %v", err)
+	}
 	remoteID, err := cp.CreateBlockStore(ctx, &models.BlockStoreConfig{
 		Name: "shared-remote", Kind: models.BlockStoreKindRemote, Type: "memory",
 	})
@@ -375,44 +370,43 @@ func TestPurgeLegacyCAS_ConfiguredShareNotRegistered(t *testing.T) {
 	}
 
 	// Both shares are configured against that one remote.
-	type shareFixture struct{ name, meta, local string }
-	fixtures := []shareFixture{
-		{"/share-a", "meta-a", createFSLocalBlockStore(t, cp, "fs-a")},
-		{"/share-b", "meta-b", createFSLocalBlockStore(t, cp, "fs-b")},
+	locals := map[string]string{
+		"/share-a": createFSLocalBlockStore(t, cp, "fs-a"),
+		"/share-b": createFSLocalBlockStore(t, cp, "fs-b"),
 	}
-	for _, sh := range fixtures {
+	for name, local := range locals {
 		if _, err := cp.CreateShare(ctx, &models.Share{
-			Name:               sh.name,
-			MetadataStoreID:    metaIDs[sh.meta],
-			LocalBlockStoreID:  sh.local,
+			Name:               name,
+			MetadataStoreID:    metaID,
+			LocalBlockStoreID:  local,
 			RemoteBlockStoreID: &remoteID,
 			Enabled:            true,
 		}); err != nil {
-			t.Fatalf("CreateShare(%s): %v", sh.name, err)
+			t.Fatalf("CreateShare(%s): %v", name, err)
 		}
 	}
 
-	register := func(sh shareFixture) {
+	register := func(name string) {
 		t.Helper()
 		if err := rt.AddShare(ctx, &ShareConfig{
-			Name:               sh.name,
-			MetadataStore:      sh.meta,
-			LocalBlockStoreID:  sh.local,
+			Name:               name,
+			MetadataStore:      "meta",
+			LocalBlockStoreID:  locals[name],
 			RemoteBlockStoreID: remoteID,
 			Enabled:            true,
 		}); err != nil {
-			t.Fatalf("AddShare(%s): %v", sh.name, err)
+			t.Fatalf("AddShare(%s): %v", name, err)
 		}
 	}
 	// Only the first share registers — the second stands for one that is
 	// disabled at boot or whose AddShare failed and was warn-and-skipped.
-	register(fixtures[0])
+	register("/share-a")
 
 	rs := &recordingLegacyRemote{
 		fakeRemoteStore: &fakeRemoteStore{name: "s3-shared"},
 		objects:         []block.ContentHash{{1}, {2}},
 	}
-	entry := shares.RemoteStoreEntry{Store: rs, ConfigID: remoteID, Shares: []string{fixtures[0].name}}
+	entry := shares.RemoteStoreEntry{Store: rs, ConfigID: remoteID, Shares: []string{"/share-a"}}
 
 	rt.purgeLegacyCASForEntry(ctx, entry, false, &engine.GCStats{})
 	if rs.deleted != 0 {
@@ -420,7 +414,7 @@ func TestPurgeLegacyCAS_ConfiguredShareNotRegistered(t *testing.T) {
 	}
 
 	// With every configured share registered and migrated, the purge proceeds.
-	register(fixtures[1])
+	register("/share-b")
 	rt.purgeLegacyCASForEntry(ctx, entry, false, &engine.GCStats{})
 	if rs.deleted != len(rs.objects) {
 		t.Fatalf("purged %d cas objects, want %d", rs.deleted, len(rs.objects))

--- a/pkg/controlplane/runtime/blockgc_test.go
+++ b/pkg/controlplane/runtime/blockgc_test.go
@@ -349,11 +349,6 @@ func TestPurgeLegacyCAS_ConfiguredShareNotRegistered(t *testing.T) {
 	t.Cleanup(func() { _ = cp.Close() })
 
 	rt := New(cp)
-	t.Cleanup(func() {
-		for _, name := range rt.ListShares() {
-			_ = rt.RemoveShare(name)
-		}
-	})
 
 	metaID, err := cp.CreateMetadataStore(ctx, &models.MetadataStoreConfig{Name: "meta", Type: "memory"})
 	if err != nil {
@@ -374,6 +369,14 @@ func TestPurgeLegacyCAS_ConfiguredShareNotRegistered(t *testing.T) {
 		"/share-a": createFSLocalBlockStore(t, cp, "fs-a"),
 		"/share-b": createFSLocalBlockStore(t, cp, "fs-b"),
 	}
+	// Registered AFTER the local stores so t.Cleanup's LIFO order closes each
+	// share's block store — releasing its journal fds — before those stores'
+	// t.TempDir() is removed. On Windows an open handle blocks the unlink.
+	t.Cleanup(func() {
+		for _, name := range rt.ListShares() {
+			_ = rt.RemoveShare(name)
+		}
+	})
 	for name, local := range locals {
 		if _, err := cp.CreateShare(ctx, &models.Share{
 			Name:               name,

--- a/pkg/controlplane/runtime/blockgc_test.go
+++ b/pkg/controlplane/runtime/blockgc_test.go
@@ -398,8 +398,8 @@ func TestPurgeLegacyCAS_ConfiguredShareNotRegistered(t *testing.T) {
 			t.Fatalf("AddShare(%s): %v", name, err)
 		}
 	}
-	// Only the first share registers — the second stands for one that is
-	// disabled at boot or whose AddShare failed and was warn-and-skipped.
+	// Only the first share registers — the second stands for one whose
+	// AddShare failed and was warn-and-skipped.
 	register("/share-a")
 
 	rs := &recordingLegacyRemote{
@@ -411,6 +411,27 @@ func TestPurgeLegacyCAS_ConfiguredShareNotRegistered(t *testing.T) {
 	rt.purgeLegacyCASForEntry(ctx, entry, false, &engine.GCStats{})
 	if rs.deleted != 0 {
 		t.Fatalf("purged %d cas objects while a configured share was unregistered", rs.deleted)
+	}
+
+	// A row whose remote reference resolves to no configured store blocks the
+	// purge too: it is most likely a stale name for this since-renamed remote.
+	rows, err := cp.ListShares(ctx)
+	if err != nil {
+		t.Fatalf("ListShares: %v", err)
+	}
+	for _, row := range rows {
+		if row.Name != "/share-b" {
+			continue
+		}
+		stale := "renamed-away"
+		row.RemoteBlockStoreID = &stale
+		if err := cp.UpdateShare(ctx, row); err != nil {
+			t.Fatalf("UpdateShare: %v", err)
+		}
+	}
+	rt.purgeLegacyCASForEntry(ctx, entry, false, &engine.GCStats{})
+	if rs.deleted != 0 {
+		t.Fatalf("purged %d cas objects while a share held an unresolvable remote reference", rs.deleted)
 	}
 
 	// With every configured share registered and migrated, the purge proceeds.

--- a/pkg/controlplane/runtime/blockgc_test.go
+++ b/pkg/controlplane/runtime/blockgc_test.go
@@ -8,7 +8,9 @@ import (
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/engine"
 	"github.com/marmos91/dittofs/pkg/block/remote"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime/shares"
+	cpstore "github.com/marmos91/dittofs/pkg/controlplane/store"
 	"github.com/marmos91/dittofs/pkg/health"
 	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
@@ -327,5 +329,100 @@ func TestPurgeLegacyCAS_IgnoresStaleShareSnapshot(t *testing.T) {
 	rt.purgeLegacyCASForEntry(ctx, stale, false, &engine.GCStats{})
 	if rs.deleted != 0 {
 		t.Fatalf("purged %d cas objects using a stale share snapshot", rs.deleted)
+	}
+}
+
+// TestPurgeLegacyCAS_ConfiguredShareNotRegistered asserts the gate refuses to
+// purge while a share configured against the remote is absent from the
+// registry. Such a share never ran its cas→blocks migration, so the standalone
+// objects the purge would delete are exactly its live data.
+func TestPurgeLegacyCAS_ConfiguredShareNotRegistered(t *testing.T) {
+	ctx := context.Background()
+
+	cp, err := cpstore.New(&cpstore.Config{
+		Type:   cpstore.DatabaseTypeSQLite,
+		SQLite: cpstore.SQLiteConfig{Path: ":memory:"},
+	})
+	if err != nil {
+		t.Fatalf("cpstore.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cp.Close() })
+
+	rt := New(cp)
+	t.Cleanup(func() {
+		for _, name := range rt.ListShares() {
+			_ = rt.RemoveShare(name)
+		}
+	})
+
+	metaIDs := map[string]string{}
+	for _, name := range []string{"meta-a", "meta-b"} {
+		id, err := cp.CreateMetadataStore(ctx, &models.MetadataStoreConfig{Name: name, Type: "memory"})
+		if err != nil {
+			t.Fatalf("CreateMetadataStore(%s): %v", name, err)
+		}
+		metaIDs[name] = id
+		if err := rt.RegisterMetadataStore(name, metadatamemory.NewMemoryMetadataStoreWithDefaults()); err != nil {
+			t.Fatalf("RegisterMetadataStore(%s): %v", name, err)
+		}
+	}
+
+	remoteID, err := cp.CreateBlockStore(ctx, &models.BlockStoreConfig{
+		Name: "shared-remote", Kind: models.BlockStoreKindRemote, Type: "memory",
+	})
+	if err != nil {
+		t.Fatalf("CreateBlockStore(remote): %v", err)
+	}
+
+	// Both shares are configured against that one remote.
+	type shareFixture struct{ name, meta, local string }
+	fixtures := []shareFixture{
+		{"/share-a", "meta-a", createFSLocalBlockStore(t, cp, "fs-a")},
+		{"/share-b", "meta-b", createFSLocalBlockStore(t, cp, "fs-b")},
+	}
+	for _, sh := range fixtures {
+		if _, err := cp.CreateShare(ctx, &models.Share{
+			Name:               sh.name,
+			MetadataStoreID:    metaIDs[sh.meta],
+			LocalBlockStoreID:  sh.local,
+			RemoteBlockStoreID: &remoteID,
+			Enabled:            true,
+		}); err != nil {
+			t.Fatalf("CreateShare(%s): %v", sh.name, err)
+		}
+	}
+
+	register := func(sh shareFixture) {
+		t.Helper()
+		if err := rt.AddShare(ctx, &ShareConfig{
+			Name:               sh.name,
+			MetadataStore:      sh.meta,
+			LocalBlockStoreID:  sh.local,
+			RemoteBlockStoreID: remoteID,
+			Enabled:            true,
+		}); err != nil {
+			t.Fatalf("AddShare(%s): %v", sh.name, err)
+		}
+	}
+	// Only the first share registers — the second stands for one that is
+	// disabled at boot or whose AddShare failed and was warn-and-skipped.
+	register(fixtures[0])
+
+	rs := &recordingLegacyRemote{
+		fakeRemoteStore: &fakeRemoteStore{name: "s3-shared"},
+		objects:         []block.ContentHash{{1}, {2}},
+	}
+	entry := shares.RemoteStoreEntry{Store: rs, ConfigID: remoteID, Shares: []string{fixtures[0].name}}
+
+	rt.purgeLegacyCASForEntry(ctx, entry, false, &engine.GCStats{})
+	if rs.deleted != 0 {
+		t.Fatalf("purged %d cas objects while a configured share was unregistered", rs.deleted)
+	}
+
+	// With every configured share registered and migrated, the purge proceeds.
+	register(fixtures[1])
+	rt.purgeLegacyCASForEntry(ctx, entry, false, &engine.GCStats{})
+	if rs.deleted != len(rs.objects) {
+		t.Fatalf("purged %d cas objects, want %d", rs.deleted, len(rs.objects))
 	}
 }


### PR DESCRIPTION
Closes #1930.

## The gap

`Runtime.purgeLegacyCASForEntry` answered "has every share on this remote finished migrating?" from the **registered** share set. A share that is configured in the control plane but never registered is invisible to that question — and it is precisely the share that never ran its cas→blocks migration, so the standalone `cas/<hash>` objects the purge deletes are its live data.

Worth correcting the issue's framing: a *disabled* share is not the case. `LoadSharesFromStore` calls `AddShare` regardless of `shares.enabled`, so a disabled share is registered and does block the purge today. The shares that actually go missing are the warn-and-skipped ones: an unknown metadata store, or any other `AddShare` failure at boot.

## The fix

Option **(b)** from the issue, tightened from a count to set membership.

`Runtime.unregisteredConfiguredShare` walks the persisted share rows that reference the remote config and returns the first one the registry does not carry; a non-empty result skips the purge, and any error reading that set skips it too. A plain `configured > registered` count would have been fooled by a registered share with no DB row (a programmatic `AddShare` persists none): configured `{B,C}` against registered `{A,B}` is `2 > 2` = false, purging while `C` sits configured, unregistered and un-migrated.

A row whose remote reference resolves to no configured remote at all also blocks. Rows predating UUID references hold the config *name*, and a since-renamed config leaves such a row matching neither form — a share in that state is exactly one that fails to register, so the unresolvable reference is treated as this remote's.

Ordering is unchanged and every gate stays fail-closed: pending registrations → fresh registered set (not the caller's snapshot) → this gate → per-share standalone-locator enumeration, all under the same per-remote GC lock.

## Deliberately not done

The issue's scope note asks whether the same guard belongs on the ordinary `blocks/<id>` GC path. Left alone: the legacy purge is one-time reclamation, so blocking it leaks a bounded amount of space until an operator fixes the share, whereas the same gate on routine GC would stop reclamation forever in any deployment that permanently keeps a share unregistered — trading a data-loss risk for an unbounded leak.

## Tests

`TestPurgeLegacyCAS_ConfiguredShareNotRegistered` — two shares configured against one remote over a real sqlite control-plane store, walking three states:

1. only the first registered → nothing deleted (verified failing before the fix: `purged 2 cas objects while a configured share was unregistered`);
2. the second row pointed at an unresolvable remote reference → still nothing deleted (verified failing with the resolution check stubbed out);
3. both registered and migrated → the namespace is reclaimed.

`go test ./pkg/controlplane/runtime/...` green, `go vet` and `gofmt` clean.
