### PR TITLE
fix(smb): publish the OpenFile name triple as one atomic value

### DIFF
--- a/internal/adapter/smb/handlers/auth_priming_test.go
+++ b/internal/adapter/smb/handlers/auth_priming_test.go
@@ -57,7 +57,7 @@ func TestClose_PrimesAuthContextFromOpenFile(t *testing.T) {
 		TreeID:    treeID,
 		SessionID: sess.SessionID,
 		// No MetadataHandle / PayloadID — Close skips the BlockStore /
-		// metadata-flush paths entirely, but Step 2b primer still runs.,
+		// metadata-flush paths entirely, but Step 2b primer still runs.
 	}).WithName(OpenName{Path: "/share/a.txt"})
 	h.StoreOpenFile(openFile)
 
@@ -181,7 +181,7 @@ func TestRead_DeniesOnGrantedAccessStripped(t *testing.T) {
 	openFile := (&OpenFile{
 		FileID:        [16]byte{0xDE, 0xAD},
 		DesiredAccess: uint32(types.FileReadData), // requested
-		GrantedAccess: 0,                          // DACL stripped it,
+		GrantedAccess: 0,                          // DACL stripped it
 	}).WithName(OpenName{Path: "/share/secret.txt"})
 	h.StoreOpenFile(openFile)
 
@@ -207,7 +207,7 @@ func TestRead_AllowsOnGrantedAccess(t *testing.T) {
 	openFile := (&OpenFile{
 		FileID:        [16]byte{0xBE, 0xEF},
 		DesiredAccess: 0,                          // pre-DACL not relevant
-		GrantedAccess: uint32(types.FileReadData), // DACL granted,
+		GrantedAccess: uint32(types.FileReadData), // DACL granted
 	}).WithName(OpenName{Path: "/share/public.txt"})
 	h.StoreOpenFile(openFile)
 
@@ -234,7 +234,7 @@ func TestWrite_DeniesOnGrantedAccessStripped(t *testing.T) {
 	openFile := (&OpenFile{
 		FileID:        [16]byte{0xCA, 0xFE},
 		DesiredAccess: uint32(types.FileWriteData), // requested
-		GrantedAccess: 0,                           // DACL stripped it,
+		GrantedAccess: 0,                           // DACL stripped it
 	}).WithName(OpenName{Path: "/share/ro.txt"})
 	h.StoreOpenFile(openFile)
 

--- a/internal/adapter/smb/handlers/auth_priming_test.go
+++ b/internal/adapter/smb/handlers/auth_priming_test.go
@@ -52,14 +52,13 @@ func TestClose_PrimesAuthContextFromOpenFile(t *testing.T) {
 		ShareName: "/share",
 	})
 
-	openFile := &OpenFile{
+	openFile := (&OpenFile{
 		FileID:    [16]byte{0x01, 0x02},
 		TreeID:    treeID,
 		SessionID: sess.SessionID,
-		Path:      "/share/a.txt",
 		// No MetadataHandle / PayloadID — Close skips the BlockStore /
-		// metadata-flush paths entirely, but Step 2b primer still runs.
-	}
+		// metadata-flush paths entirely, but Step 2b primer still runs.,
+	}).WithName(OpenName{Path: "/share/a.txt"})
 	h.StoreOpenFile(openFile)
 
 	// Build a ctx with zero session/tree state — mirrors the dispatcher,
@@ -121,12 +120,11 @@ func TestFlush_PrimesAuthContextFromOpenFile(t *testing.T) {
 		ShareName: "/share2",
 	})
 
-	openFile := &OpenFile{
+	openFile := (&OpenFile{
 		FileID:    [16]byte{0x10, 0x20},
 		TreeID:    treeID,
 		SessionID: sess.SessionID,
-		Path:      "/share2/b.txt",
-	}
+	}).WithName(OpenName{Path: "/share2/b.txt"})
 
 	ctx := NewSMBHandlerContext(context.TODO(), "127.0.0.1:0", 0, 0, 1)
 	if ctx.User != nil {
@@ -180,12 +178,11 @@ func TestFlush_PrimesAuthContextFromOpenFile(t *testing.T) {
 func TestRead_DeniesOnGrantedAccessStripped(t *testing.T) {
 	h := NewHandler()
 
-	openFile := &OpenFile{
+	openFile := (&OpenFile{
 		FileID:        [16]byte{0xDE, 0xAD},
-		Path:          "/share/secret.txt",
 		DesiredAccess: uint32(types.FileReadData), // requested
-		GrantedAccess: 0,                          // DACL stripped it
-	}
+		GrantedAccess: 0,                          // DACL stripped it,
+	}).WithName(OpenName{Path: "/share/secret.txt"})
 	h.StoreOpenFile(openFile)
 
 	ctx := NewSMBHandlerContext(context.TODO(), "127.0.0.1:0", 0, 0, 1)
@@ -207,12 +204,11 @@ func TestRead_DeniesOnGrantedAccessStripped(t *testing.T) {
 func TestRead_AllowsOnGrantedAccess(t *testing.T) {
 	h := NewHandler()
 
-	openFile := &OpenFile{
+	openFile := (&OpenFile{
 		FileID:        [16]byte{0xBE, 0xEF},
-		Path:          "/share/public.txt",
 		DesiredAccess: 0,                          // pre-DACL not relevant
-		GrantedAccess: uint32(types.FileReadData), // DACL granted
-	}
+		GrantedAccess: uint32(types.FileReadData), // DACL granted,
+	}).WithName(OpenName{Path: "/share/public.txt"})
 	h.StoreOpenFile(openFile)
 
 	ctx := NewSMBHandlerContext(context.TODO(), "127.0.0.1:0", 0, 0, 1)
@@ -235,12 +231,11 @@ func TestRead_AllowsOnGrantedAccess(t *testing.T) {
 func TestWrite_DeniesOnGrantedAccessStripped(t *testing.T) {
 	h := NewHandler()
 
-	openFile := &OpenFile{
+	openFile := (&OpenFile{
 		FileID:        [16]byte{0xCA, 0xFE},
-		Path:          "/share/ro.txt",
 		DesiredAccess: uint32(types.FileWriteData), // requested
-		GrantedAccess: 0,                           // DACL stripped it
-	}
+		GrantedAccess: 0,                           // DACL stripped it,
+	}).WithName(OpenName{Path: "/share/ro.txt"})
 	h.StoreOpenFile(openFile)
 
 	ctx := NewSMBHandlerContext(context.TODO(), "127.0.0.1:0", 0, 0, 1)

--- a/internal/adapter/smb/handlers/change_notify_test.go
+++ b/internal/adapter/smb/handlers/change_notify_test.go
@@ -1762,16 +1762,15 @@ func TestChangeNotify_HandlePermissions_GrantedAccessGate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			h := NewHandler()
 
-			h.StoreOpenFile(&OpenFile{
+			h.StoreOpenFile((&OpenFile{
 				FileID:        fileID,
 				TreeID:        treeID,
 				SessionID:     sessionID,
-				Path:          "/HPERM",
 				ShareName:     "share1",
 				DesiredAccess: tc.desiredAccess,
 				GrantedAccess: tc.grantedAccess,
 				IsDirectory:   true,
-			})
+			}).WithName(OpenName{Path: "/HPERM"}))
 
 			ctx := &SMBHandlerContext{
 				SessionID:       sessionID,
@@ -1847,16 +1846,15 @@ func TestChangeNotify_StickyMaxBufferSize_SubsumesValidReq(t *testing.T) {
 	var fileID [16]byte
 	copy(fileID[:], []byte{0x77, 0x88})
 
-	openFile := &OpenFile{
+	openFile := (&OpenFile{
 		FileID:        fileID,
 		IsDirectory:   true,
 		ShareName:     "share1",
-		Path:          "/dir",
 		SessionID:     1,
 		TreeID:        1,
 		DesiredAccess: 0x00000001, // FILE_LIST_DIRECTORY
 		GrantedAccess: 0x00000001,
-	}
+	}).WithName(OpenName{Path: "/dir"})
 	h.StoreOpenFile(openFile)
 
 	makeCtx := func() *SMBHandlerContext {
@@ -1931,10 +1929,9 @@ func TestChangeNotify_FirstLargeBuffer_ThenSmallUsesRequest(t *testing.T) {
 	h.MaxTransactSize = 1 << 20
 
 	fileID := [16]byte{0x11}
-	openFile := &OpenFile{
-		FileID: fileID, IsDirectory: true, ShareName: "share1",
-		Path: "/dir", SessionID: 1, TreeID: 1, DesiredAccess: 0x00000001, GrantedAccess: 0x00000001,
-	}
+	openFile := (&OpenFile{
+		FileID: fileID, IsDirectory: true, ShareName: "share1", SessionID: 1, TreeID: 1, DesiredAccess: 0x00000001, GrantedAccess: 0x00000001,
+	}).WithName(OpenName{Path: "/dir"})
 	h.StoreOpenFile(openFile)
 
 	makeCtx := func() *SMBHandlerContext {
@@ -1991,10 +1988,9 @@ func TestChangeNotify_FirstZeroBuffer_StickyAtZero(t *testing.T) {
 	h.MaxTransactSize = 1 << 20
 
 	fileID := [16]byte{0x99}
-	openFile := &OpenFile{
-		FileID: fileID, IsDirectory: true, ShareName: "share1",
-		Path: "/dir", SessionID: 1, TreeID: 1, DesiredAccess: 0x00000001, GrantedAccess: 0x00000001,
-	}
+	openFile := (&OpenFile{
+		FileID: fileID, IsDirectory: true, ShareName: "share1", SessionID: 1, TreeID: 1, DesiredAccess: 0x00000001, GrantedAccess: 0x00000001,
+	}).WithName(OpenName{Path: "/dir"})
 	h.StoreOpenFile(openFile)
 
 	makeCtx := func() *SMBHandlerContext {
@@ -2161,11 +2157,10 @@ func TestChangeNotify_PreArrivalCancel_HandlerReturnsCancelledSync(t *testing.T)
 	h.MaxTransactSize = 1 << 20
 
 	fileID := [16]byte{0x42}
-	openFile := &OpenFile{
-		FileID: fileID, IsDirectory: true, ShareName: "share1",
-		Path: "/dir", SessionID: 1, TreeID: 1,
+	openFile := (&OpenFile{
+		FileID: fileID, IsDirectory: true, ShareName: "share1", SessionID: 1, TreeID: 1,
 		DesiredAccess: 0x00000001, GrantedAccess: 0x00000001,
-	}
+	}).WithName(OpenName{Path: "/dir"})
 	h.StoreOpenFile(openFile)
 
 	ctx := &SMBHandlerContext{

--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -212,7 +212,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	// on a live handle, so reading it per use would let a rename landing
 	// mid-close produce log lines, a delete target and a parent path that each
 	// name a different file.
-	closePath := openFile.GetPath()
+	closePath := openFile.Name().Path
 
 	var flushFailStatus types.Status
 	payloadID := openFile.GetPayloadID()
@@ -401,6 +401,9 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	}
 
 	if openFile.DeletePending || openFile.BaseFileDeletePending {
+		// One snapshot of the name: the delete below must not mix the parent
+		// directory from one rename with the file name from another.
+		docName := openFile.Name()
 		// Per MS-FSA 2.1.5.4: delete-on-close only removes the file when the
 		// LAST handle closes. If other handles on the same file exist, propagate
 		// the DOC flag + the original DOC-setter's parent key to remaining handles
@@ -412,7 +415,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 		// stream handles — are closed. The stream handles are marked with
 		// BaseFileDeletePending so the CLOSE of the last stream triggers the
 		// base file removal (smbtorture smb2.streams.delete).
-		isBaseFile := !strings.Contains(openFile.FileName, ":")
+		isBaseFile := !strings.Contains(docName.FileName, ":")
 		otherHandleExists := false
 		streamHandleExists := false
 
@@ -432,8 +435,8 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 
 		// For base file DOC: also check for open stream handles.
 		if !otherHandleExists && isBaseFile && !openFile.BaseFileDeletePending {
-			basePrefix := openFile.FileName + ":"
-			h.rangeStreamsOfBase(openFile.FileID, openFile.ParentHandle, basePrefix, func(other *OpenFile) bool {
+			basePrefix := docName.FileName + ":"
+			h.rangeStreamsOfBase(openFile.FileID, docName.ParentHandle, basePrefix, func(other *OpenFile) bool {
 				streamHandleExists = true
 				return false
 			})
@@ -482,15 +485,15 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 			// 2.1.5.4 / 2.1.5.9.7, defer the actual deletion until all
 			// stream handles close. Mark them with BaseFileDeletePending so
 			// the last stream CLOSE triggers the base file removal.
-			basePrefix := openFile.FileName + ":"
-			h.rangeStreamsOfBase(openFile.FileID, openFile.ParentHandle, basePrefix, func(other *OpenFile) bool {
+			basePrefix := docName.FileName + ":"
+			h.rangeStreamsOfBase(openFile.FileID, docName.ParentHandle, basePrefix, func(other *OpenFile) bool {
 				// Guard the write: concurrent readers on the stream handle
 				// (QUERY_INFO / open path via isFileOrBaseDeletePending) may be
 				// reading these fields on `other`.
 				other.mu.Lock()
 				other.BaseFileDeletePending = true
-				other.BaseFileDeleteParentHandle = openFile.ParentHandle
-				other.BaseFileDeleteFileName = openFile.FileName
+				other.BaseFileDeleteParentHandle = docName.ParentHandle
+				other.BaseFileDeleteFileName = docName.FileName
 				other.DeleteOnCloseParentKey = openFile.DeleteOnCloseParentKey
 				other.HasDeleteOnCloseParentKey = openFile.HasDeleteOnCloseParentKey
 				other.mu.Unlock()
@@ -504,8 +507,8 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 			//
 			// If this is a stream handle with BaseFileDeletePending, delete the
 			// base file (not the stream — the stream is a child of the base).
-			deleteParentHandle := openFile.ParentHandle
-			deleteFileName := openFile.FileName
+			deleteParentHandle := docName.ParentHandle
+			deleteFileName := docName.FileName
 			isBaseFileDelete := false
 			if openFile.BaseFileDeletePending {
 				deleteParentHandle = openFile.BaseFileDeleteParentHandle
@@ -592,11 +595,12 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 						// Use a synthetic OpenFile with the base file's info.
 						cascadeOF := openFile
 						if isBaseFileDelete {
-							cascadeOF = &OpenFile{
-								ParentHandle: deleteParentHandle,
-								FileName:     deleteFileName,
+							cascadeOF = &OpenFile{}
+							cascadeOF.SetName(OpenName{
 								Path:         closePath,
-							}
+								FileName:     deleteFileName,
+								ParentHandle: deleteParentHandle,
+							})
 						}
 						h.cascadeDeleteADSStreams(authCtx, metaSvc, cascadeOF)
 					}
@@ -854,7 +858,7 @@ func (h *Handler) releaseHandleLeaseRecord(ctx context.Context, openFile *OpenFi
 
 	if hasOtherOpenSameFile {
 		logger.Debug(caller+": lease handle closed (other opens share lease key on same file)",
-			"path", openFile.Path)
+			"path", openFile.Name().Path)
 		return
 	}
 
@@ -862,12 +866,12 @@ func (h *Handler) releaseHandleLeaseRecord(ctx context.Context, openFile *OpenFi
 	// lease record. Other files sharing the key keep theirs.
 	if err := h.LeaseManager.ReleaseLeaseForHandle(ctx, lock.FileHandle(openFile.MetadataHandle), leaseKey, openFile.ShareName); err != nil {
 		logger.Debug(caller+": failed to release lease",
-			"path", openFile.Path,
+			"path", openFile.Name().Path,
 			"leaseKey", fmt.Sprintf("%x", leaseKey),
 			"error", err)
 	} else {
 		logger.Debug(caller+": released lease (last open on this file)",
-			"path", openFile.Path,
+			"path", openFile.Name().Path,
 			"leaseKey", fmt.Sprintf("%x", leaseKey))
 	}
 	// Unregister oplock FileID mapping if this was a traditional oplock.
@@ -915,7 +919,7 @@ func (h *Handler) checkAndConvertMFsymlink(ctx *SMBHandlerContext, openFile *Ope
 	// Read content to verify MFsymlink format
 	content, err := h.readMFsymlinkContent(ctx, openFile)
 	if err != nil {
-		logger.Debug("CLOSE: failed to read MFsymlink content", "path", openFile.Path, "error", err)
+		logger.Debug("CLOSE: failed to read MFsymlink content", "path", openFile.Name().Path, "error", err)
 		return false, nil // Not fatal, just don't convert
 	}
 
@@ -927,7 +931,7 @@ func (h *Handler) checkAndConvertMFsymlink(ctx *SMBHandlerContext, openFile *Ope
 	// Parse the symlink target
 	target, err := mfsymlink.Decode(content)
 	if err != nil {
-		logger.Debug("CLOSE: invalid MFsymlink format", "path", openFile.Path, "error", err)
+		logger.Debug("CLOSE: invalid MFsymlink format", "path", openFile.Name().Path, "error", err)
 		return false, nil // Don't convert invalid MFsymlinks
 	}
 
@@ -935,7 +939,7 @@ func (h *Handler) checkAndConvertMFsymlink(ctx *SMBHandlerContext, openFile *Ope
 	err = h.convertToRealSymlink(ctx, openFile, target)
 	if err != nil {
 		logger.Warn("CLOSE: failed to convert MFsymlink to symlink",
-			"path", openFile.Path,
+			"path", openFile.Name().Path,
 			"target", target,
 			"error", err)
 		return false, err
@@ -971,7 +975,8 @@ func (h *Handler) readMFsymlinkContent(ctx *SMBHandlerContext, openFile *OpenFil
 // convertToRealSymlink removes the regular file and creates a symlink in its place.
 func (h *Handler) convertToRealSymlink(ctx *SMBHandlerContext, openFile *OpenFile, target string) error {
 	// Validate required fields
-	if len(openFile.ParentHandle) == 0 || openFile.FileName == "" {
+	name := openFile.Name()
+	if len(name.ParentHandle) == 0 || name.FileName == "" {
 		return fmt.Errorf("missing parent handle or filename for MFsymlink conversion")
 	}
 
@@ -994,8 +999,8 @@ func (h *Handler) convertToRealSymlink(ctx *SMBHandlerContext, openFile *OpenFil
 	}
 
 	// Get the parent handle and filename for removal and creation
-	parentHandle := openFile.ParentHandle
-	fileName := openFile.FileName
+	parentHandle := name.ParentHandle
+	fileName := name.FileName
 
 	// Remove the regular file
 	metaSvc := h.Registry.GetMetadataService()
@@ -1010,7 +1015,7 @@ func (h *Handler) convertToRealSymlink(ctx *SMBHandlerContext, openFile *OpenFil
 	if removed != nil {
 		removedPayloadID = removed.PayloadID
 	}
-	h.purgeBlockStorePayload(ctx.Context, openFile.MetadataHandle, removedPayloadID, openFile.Path, "CLOSE")
+	h.purgeBlockStorePayload(ctx.Context, openFile.MetadataHandle, removedPayloadID, name.Path, "CLOSE")
 
 	// Create the real symlink with default attributes
 	// Pass empty FileAttr - CreateSymlink will apply defaults
@@ -1021,7 +1026,7 @@ func (h *Handler) convertToRealSymlink(ctx *SMBHandlerContext, openFile *OpenFil
 	}
 
 	logger.Debug("CLOSE: converted MFsymlink",
-		"path", openFile.Path,
+		"path", openFile.Name().Path,
 		"target", target)
 
 	return nil
@@ -1039,10 +1044,11 @@ func (h *Handler) rangeStreamsOfBase(selfFileID [16]byte, parentHandle metadata.
 		if other.FileID == selfFileID || other.IsPipe {
 			return true
 		}
-		if !bytes.Equal(other.ParentHandle, parentHandle) {
+		otherName := other.Name()
+		if !bytes.Equal(otherName.ParentHandle, parentHandle) {
 			return true
 		}
-		if len(other.FileName) <= len(basePrefix) || !strings.EqualFold(other.FileName[:len(basePrefix)], basePrefix) {
+		if len(otherName.FileName) <= len(basePrefix) || !strings.EqualFold(otherName.FileName[:len(basePrefix)], basePrefix) {
 			return true
 		}
 		return fn(other)
@@ -1054,21 +1060,22 @@ func (h *Handler) rangeStreamsOfBase(selfFileID [16]byte, parentHandle metadata.
 // in the parent directory with names like "baseFile:streamName:$DATA".
 // Per MS-FSA 2.1.5.9.7, deleting a file deletes all its streams.
 func (h *Handler) cascadeDeleteADSStreams(authCtx *metadata.AuthContext, metaSvc *metadata.Service, openFile *OpenFile) {
-	prefix := openFile.FileName + ":"
+	name := openFile.Name()
+	prefix := name.FileName + ":"
 
 	// Enumerate parent directory children to find ADS entries.
 	// Use ReadDirectory with a large buffer to get all entries.
-	page, err := metaSvc.ReadDirectory(authCtx, openFile.ParentHandle, 0, 1<<20)
+	page, err := metaSvc.ReadDirectory(authCtx, name.ParentHandle, 0, 1<<20)
 	if err != nil {
 		logger.Debug("CLOSE: cascade ADS delete: failed to read parent directory",
-			"path", openFile.Path,
+			"path", name.Path,
 			"error", err)
 		return
 	}
 
 	for _, entry := range page.Entries {
 		if len(entry.Name) > len(prefix) && strings.EqualFold(entry.Name[:len(prefix)], prefix) {
-			_, _, deleteErr := metaSvc.RemoveFile(authCtx, openFile.ParentHandle, entry.Name)
+			_, _, deleteErr := metaSvc.RemoveFile(authCtx, name.ParentHandle, entry.Name)
 			if deleteErr != nil {
 				logger.Debug("CLOSE: cascade ADS delete: failed to remove stream",
 					"stream", entry.Name,

--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -595,8 +595,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 						// Use a synthetic OpenFile with the base file's info.
 						cascadeOF := openFile
 						if isBaseFileDelete {
-							cascadeOF = &OpenFile{}
-							cascadeOF.SetName(OpenName{
+							cascadeOF = (&OpenFile{}).WithName(OpenName{
 								Path:         closePath,
 								FileName:     deleteFileName,
 								ParentHandle: deleteParentHandle,
@@ -1026,7 +1025,7 @@ func (h *Handler) convertToRealSymlink(ctx *SMBHandlerContext, openFile *OpenFil
 	}
 
 	logger.Debug("CLOSE: converted MFsymlink",
-		"path", openFile.Name().Path,
+		"path", name.Path,
 		"target", target)
 
 	return nil

--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -208,10 +208,10 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	// (silent write truncation, #1267). The mapped status is recorded and
 	// applied to the response below; handle teardown still runs unconditionally
 	// so the failed flush does not leak the open-file/lease state.
-	// Snapshot the path once for the rest of CLOSE. SET_INFO rename rewrites it
-	// on a live handle, so reading it per use would let a rename landing
-	// mid-close produce log lines, a delete target and a parent path that each
-	// name a different file.
+	// Snapshot the path once so the flush and teardown log lines below all
+	// name the same file even if a rename lands mid-close. The delete block
+	// takes its own snapshot: the delete must act on the handle's name as of
+	// the delete, not as of CLOSE entry.
 	closePath := openFile.Name().Path
 
 	var flushFailStatus types.Status
@@ -479,7 +479,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 				return true
 			})
 			logger.Debug("CLOSE: DOC propagated to other handles (not last)",
-				"path", closePath)
+				"path", docName.Path)
 		} else if streamHandleExists {
 			// Base file has DOC but open stream handles remain. Per MS-FSA
 			// 2.1.5.4 / 2.1.5.9.7, defer the actual deletion until all
@@ -501,7 +501,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 				return true
 			})
 			logger.Debug("CLOSE: base file DOC deferred to stream handles",
-				"path", closePath)
+				"path", docName.Path)
 		} else {
 			// Last handle: perform the actual delete.
 			//
@@ -578,14 +578,14 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 						resp.Status = common.MapToSMB(deleteErr)
 					}
 					logger.Debug("CLOSE: failed to delete",
-						"path", closePath,
+						"path", docName.Path,
 						"isDir", openFile.IsDirectory,
 						"deleteTarget", deleteFileName,
 						"status", resp.Status,
 						"error", deleteErr)
 				} else {
 					logger.Debug("CLOSE: deleted",
-						"path", closePath,
+						"path", docName.Path,
 						"deleteTarget", deleteFileName,
 						"isDir", openFile.IsDirectory,
 						"isBaseFileDelete", isBaseFileDelete)
@@ -596,7 +596,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 						cascadeOF := openFile
 						if isBaseFileDelete {
 							cascadeOF = (&OpenFile{}).WithName(OpenName{
-								Path:         closePath,
+								Path:         docName.Path,
 								FileName:     deleteFileName,
 								ParentHandle: deleteParentHandle,
 							})
@@ -604,7 +604,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 						h.cascadeDeleteADSStreams(authCtx, metaSvc, cascadeOF)
 					}
 
-					h.purgeBlockStorePayload(ctx.Context, deleteTargetHandle, removedPayloadID, closePath, "CLOSE")
+					h.purgeBlockStorePayload(ctx.Context, deleteTargetHandle, removedPayloadID, docName.Path, "CLOSE")
 					h.restoreParentDirFrozenTimestamps(authCtx, deleteParentHandle)
 
 					// Removing the entry already broke the parent directory's
@@ -619,7 +619,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 					// duplicate LEASE_BREAK for one logical change.
 
 					if h.NotifyRegistry != nil {
-						parentPath := GetParentPath(closePath)
+						parentPath := GetParentPath(docName.Path)
 						// Use the resolved delete-target type (base file's, not
 						// the stream open's) and the actual deleteFileName.
 						// NameChangeFilterFor routes ADS names via

--- a/internal/adapter/smb/handlers/close_dirlease_break_order_test.go
+++ b/internal/adapter/smb/handlers/close_dirlease_break_order_test.go
@@ -113,16 +113,14 @@ func TestClose_DirLeaseRelease_AfterOpenFileRemoval(t *testing.T) {
 	}
 
 	// Register the holder's OpenFile (the conflicting dst-parent dir handle).
-	openFile := &OpenFile{
+	openFile := (&OpenFile{
 		FileID:         fileID,
-		FileName:       "dst-parent",
-		Path:           "/share/dst-parent",
 		IsDirectory:    true,
 		ShareName:      shareName,
 		OplockLevel:    OplockLevelLease,
 		LeaseKey:       leaseKey,
 		MetadataHandle: dirMetaHandle,
-	}
+	}).WithName(OpenName{Path: "/share/dst-parent", FileName: "dst-parent"})
 	h.StoreOpenFile(openFile)
 
 	ctx := &SMBHandlerContext{

--- a/internal/adapter/smb/handlers/close_flush_error_test.go
+++ b/internal/adapter/smb/handlers/close_flush_error_test.go
@@ -144,19 +144,16 @@ func setupWriteTestShare(t *testing.T, metaStore metadata.Store) (*Handler, *SMB
 	})
 
 	fileID := [16]byte{7}
-	openFile := &OpenFile{
+	openFile := (&OpenFile{
 		FileID:         fileID,
 		TreeID:         treeID,
 		SessionID:      sess.SessionID,
-		Path:           fileName,
 		ShareName:      shareName,
 		DesiredAccess:  uint32(types.FileReadData | types.FileWriteData),
 		GrantedAccess:  uint32(types.FileReadData | types.FileWriteData),
 		MetadataHandle: fileHandle,
 		PayloadID:      committed.PayloadID,
-		ParentHandle:   rootHandle,
-		FileName:       fileName,
-	}
+	}).WithName(OpenName{Path: fileName, FileName: fileName, ParentHandle: rootHandle})
 	h.StoreOpenFile(openFile)
 
 	smbCtx := &SMBHandlerContext{
@@ -246,7 +243,7 @@ func TestClose_FlushFailure_WinsOverDeleteFailure(t *testing.T) {
 		Identity:        &metadata.Identity{UID: &uid, GID: &gid},
 		HasDeleteAccess: true,
 	}
-	if _, _, err := metaSvc.RemoveFile(authCtx, openFile.ParentHandle, openFile.FileName); err != nil {
+	if _, _, err := metaSvc.RemoveFile(authCtx, openFile.Name().ParentHandle, openFile.Name().FileName); err != nil {
 		t.Fatalf("out-of-band RemoveFile: %v", err)
 	}
 

--- a/internal/adapter/smb/handlers/close_mfsymlink_test.go
+++ b/internal/adapter/smb/handlers/close_mfsymlink_test.go
@@ -160,19 +160,16 @@ func setupMFsymlinkShare(t *testing.T, allowMFsymlink bool, target string) (*Han
 	})
 
 	fileID := [16]byte{1}
-	openFile := &OpenFile{
+	openFile := (&OpenFile{
 		FileID:         fileID,
 		TreeID:         treeID,
 		SessionID:      sess.SessionID,
-		Path:           fileName,
 		ShareName:      shareName,
 		DesiredAccess:  uint32(types.FileReadData | types.FileWriteData),
 		GrantedAccess:  uint32(types.FileReadData | types.FileWriteData),
 		MetadataHandle: fileHandle,
 		PayloadID:      committed.PayloadID,
-		ParentHandle:   rootHandle,
-		FileName:       fileName,
-	}
+	}).WithName(OpenName{Path: fileName, FileName: fileName, ParentHandle: rootHandle})
 	h.StoreOpenFile(openFile)
 
 	smbCtx := &SMBHandlerContext{

--- a/internal/adapter/smb/handlers/close_notify_test.go
+++ b/internal/adapter/smb/handlers/close_notify_test.go
@@ -27,14 +27,12 @@ func TestClose_PendingNotifyCleanup_DeferredViaPostSend(t *testing.T) {
 	copy(fileID[:], []byte{0xab, 0xcd, 0xef, 0x01})
 
 	// Install a directory open file so the CLOSE handler reaches step 10.
-	openFile := &OpenFile{
+	openFile := (&OpenFile{
 		FileID:      fileID,
-		FileName:    "watched-dir",
-		Path:        "/share/watched-dir",
 		IsDirectory: true,
 		ShareName:   "share",
 		OplockLevel: OplockLevelNone,
-	}
+	}).WithName(OpenName{Path: "/share/watched-dir", FileName: "watched-dir"})
 	h.StoreOpenFile(openFile)
 
 	// Register a pending CHANGE_NOTIFY with a callback that flips an atomic
@@ -132,14 +130,12 @@ func TestClose_NoPendingNotify_PostSendNil(t *testing.T) {
 	var fileID [16]byte
 	copy(fileID[:], []byte{0x11, 0x22, 0x33, 0x44})
 
-	openFile := &OpenFile{
+	openFile := (&OpenFile{
 		FileID:      fileID,
-		FileName:    "plain-dir",
-		Path:        "/share/plain-dir",
 		IsDirectory: true,
 		ShareName:   "share",
 		OplockLevel: OplockLevelNone,
-	}
+	}).WithName(OpenName{Path: "/share/plain-dir", FileName: "plain-dir"})
 	h.StoreOpenFile(openFile)
 
 	ctx := &SMBHandlerContext{

--- a/internal/adapter/smb/handlers/create.go
+++ b/internal/adapter/smb/handlers/create.go
@@ -1799,7 +1799,6 @@ func (h *Handler) handlePipeCreate(ctx *SMBHandlerContext, req *CreateRequest, t
 		FileID:        smbFileID,
 		TreeID:        ctx.TreeID,
 		SessionID:     ctx.SessionID,
-		Path:          req.FileName,
 		ShareName:     tree.ShareName,
 		OpenTime:      time.Now(),
 		DesiredAccess: req.DesiredAccess,
@@ -1809,6 +1808,7 @@ func (h *Handler) handlePipeCreate(ctx *SMBHandlerContext, req *CreateRequest, t
 		IsPipe:        true,
 		PipeName:      pipeName,
 	}
+	openFile.SetName(OpenName{Path: req.FileName})
 	h.StoreOpenFile(openFile)
 
 	logger.Debug("CREATE pipe successful",
@@ -1928,7 +1928,6 @@ func (h *Handler) handleOpenRootCreate(
 		FileID:         smbFileID,
 		TreeID:         ctx.TreeID,
 		SessionID:      ctx.SessionID,
-		Path:           "",
 		ShareName:      tree.ShareName,
 		OpenTime:       time.Now(),
 		DesiredAccess:  req.DesiredAccess,

--- a/internal/adapter/smb/handlers/create.go
+++ b/internal/adapter/smb/handlers/create.go
@@ -1795,7 +1795,7 @@ func (h *Handler) handlePipeCreate(ctx *SMBHandlerContext, req *CreateRequest, t
 	h.PipeManager.CreatePipe(smbFileID, pipeName)
 
 	// Store open file entry for the pipe
-	openFile := &OpenFile{
+	openFile := (&OpenFile{
 		FileID:        smbFileID,
 		TreeID:        ctx.TreeID,
 		SessionID:     ctx.SessionID,
@@ -1807,8 +1807,7 @@ func (h *Handler) handlePipeCreate(ctx *SMBHandlerContext, req *CreateRequest, t
 		IsDirectory:   false,
 		IsPipe:        true,
 		PipeName:      pipeName,
-	}
-	openFile.SetName(OpenName{Path: req.FileName})
+	}).WithName(OpenName{Path: req.FileName})
 	h.StoreOpenFile(openFile)
 
 	logger.Debug("CREATE pipe successful",

--- a/internal/adapter/smb/handlers/create_dacl_enforcement_test.go
+++ b/internal/adapter/smb/handlers/create_dacl_enforcement_test.go
@@ -662,16 +662,15 @@ func runDestructiveShareViolationCase(t *testing.T, fname string, disposition ty
 		t.Fatalf("EncodeFileHandle: %v", err)
 	}
 	firstFileID := h.GenerateFileID()
-	h.StoreOpenFile(&OpenFile{
+	h.StoreOpenFile((&OpenFile{
 		FileID:         firstFileID,
 		TreeID:         smbCtx.TreeID,
 		SessionID:      smbCtx.SessionID,
-		Path:           fname,
 		ShareName:      smbCtx.ShareName,
 		DesiredAccess:  fileReadData,
 		ShareAccess:    fileShareRead,
 		MetadataHandle: encHandle,
-	})
+	}).WithName(OpenName{Path: fname}))
 
 	// Second handle: destructive disposition, READ_DATA, SHARE_READ.
 	draft := makeDraftWithShareAccess(t, tree, requesterAuth, rootHandle, existingFile, fname,
@@ -755,16 +754,15 @@ func TestCreate_OpenWithReadShareDoesNotConflictExistingHolder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EncodeFileHandle: %v", err)
 	}
-	h.StoreOpenFile(&OpenFile{
+	h.StoreOpenFile((&OpenFile{
 		FileID:         h.GenerateFileID(),
 		TreeID:         smbCtx.TreeID,
 		SessionID:      smbCtx.SessionID,
-		Path:           "open_share.txt",
 		ShareName:      smbCtx.ShareName,
 		DesiredAccess:  fileReadData,
 		ShareAccess:    fileShareRead,
 		MetadataHandle: encHandle,
-	})
+	}).WithName(OpenName{Path: "open_share.txt"}))
 
 	draft := makeDraftWithShareAccess(t, tree, requesterAuth, rootHandle, existingFile, "open_share.txt",
 		fileReadData, fileShareRead, types.FileOpen, types.FileOpened)

--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -1276,7 +1276,6 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 		FileID:               smbFileID,
 		TreeID:               ctx.TreeID,
 		SessionID:            ctx.SessionID,
-		Path:                 filename,
 		ShareName:            tree.ShareName,
 		OpenTime:             time.Now(),
 		DesiredAccess:        req.DesiredAccess,
@@ -1284,8 +1283,6 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 		IsDirectory:          file.Type == metadata.FileTypeDirectory,
 		MetadataHandle:       fileHandle,
 		PayloadID:            file.PayloadID,
-		ParentHandle:         parentHandle,
-		FileName:             baseName,
 		OplockLevel:          grantedOplock,
 		ShareAccess:          req.ShareAccess,
 		CreateOptions:        req.CreateOptions,
@@ -1303,6 +1300,7 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 		// but its CREATE must still be replay-cacheable (MS-SMB2 §3.3.5.9).
 		ReplayCreateGuid: dh2qCreateGuid(req),
 	}
+	openFile.SetName(OpenName{Path: filename, FileName: baseName, ParentHandle: parentHandle})
 
 	if leaseResponse != nil && leaseResponse.LeaseState != lock.LeaseStateNone {
 		openFile.LeaseKey = leaseResponse.LeaseKey

--- a/internal/adapter/smb/handlers/create_race_recovery_gates_test.go
+++ b/internal/adapter/smb/handlers/create_race_recovery_gates_test.go
@@ -217,16 +217,15 @@ func TestCreate_RaceRecovery_OverwriteIfDeniedByShareMode(t *testing.T) {
 		fileReadData      uint32 = 0x00000001
 		fileShareReadOnly uint32 = 0x00000001
 	)
-	h.StoreOpenFile(&OpenFile{
+	h.StoreOpenFile((&OpenFile{
 		FileID:         h.GenerateFileID(),
 		TreeID:         smbCtx.TreeID,
 		SessionID:      smbCtx.SessionID,
-		Path:           "winner.txt",
 		ShareName:      smbCtx.ShareName,
 		DesiredAccess:  fileReadData,
 		ShareAccess:    fileShareReadOnly,
 		MetadataHandle: winnerHandle,
-	})
+	}).WithName(OpenName{Path: "winner.txt"}))
 
 	requesterUID := uint32(0)
 	requesterGID := uint32(0)

--- a/internal/adapter/smb/handlers/durable_context.go
+++ b/internal/adapter/smb/handlers/durable_context.go
@@ -830,7 +830,6 @@ func validateAndRestore(
 	restored := &OpenFile{
 		FileID:        restoreFileID,
 		SessionID:     sessionID,
-		Path:          handle.Path,
 		ShareName:     handle.ShareName,
 		DesiredAccess: handle.DesiredAccess,
 		// Restore the original DACL-evaluated GrantedAccess persisted at
@@ -871,8 +870,6 @@ func validateAndRestore(
 		IsPersistent:  handle.IsPersistent,
 		OpenTime:      handle.CreatedAt,
 		DeletePending: handle.DeletePending,
-		ParentHandle:  handle.ParentHandle,
-		FileName:      handle.FileName,
 		IsDirectory:   handle.IsDirectory,
 		PositionInfo:  handle.PositionInfo,
 		// Restore the ClientGUID recorded at the original CREATE so a
@@ -892,6 +889,11 @@ func validateAndRestore(
 		RequestedAllocSize: handle.RequestedAllocSize,
 		// IsDurable is NOT set on restore -- client must re-request durability
 	}
+	restored.SetName(OpenName{
+		Path:         handle.Path,
+		FileName:     handle.FileName,
+		ParentHandle: handle.ParentHandle,
+	})
 
 	// Persisted record was removed by the consume() call above; no
 	// further store mutation is required here.
@@ -1022,11 +1024,11 @@ func ProcessAppInstanceId(
 		if handler != nil {
 			cleanupFile := &OpenFile{
 				FileID:         h.FileID,
-				Path:           h.Path,
 				ShareName:      h.ShareName,
 				MetadataHandle: h.MetadataHandle,
 				PayloadID:      metadata.PayloadID(h.PayloadID),
 			}
+			cleanupFile.SetName(OpenName{Path: h.Path})
 			handler.flushFileCache(ctx, cleanupFile)
 			if len(h.MetadataHandle) > 0 && handler.Registry != nil {
 				if metaSvc := handler.Registry.GetMetadataService(); metaSvc != nil {
@@ -1061,13 +1063,13 @@ func buildPersistedDurableHandle(
 	leaseState uint32,
 	leaseEpoch uint16,
 ) *lock.PersistedDurableHandle {
-	// The handle lock is held across the whole snapshot rather than per field.
-	// SET_INFO rename rewrites Path, FileName and ParentHandle together, and
-	// this row is replayed on reconnect: reading them at different instants
-	// could persist one rename's name against another's parent, which no later
-	// operation would correct. Field reads and copies only, no store I/O.
+	// The handle lock covers the other mutable fields read below. The name
+	// triple comes from a single load, so the persisted row — which is
+	// replayed on reconnect — cannot mix one rename's name with another's
+	// parent. Field reads and copies only, no store I/O.
 	openFile.mu.RLock()
 	defer openFile.mu.RUnlock()
+	name := openFile.Name()
 
 	// Clone MetadataHandle to avoid aliasing the live OpenFile's slice
 	metaHandle := make([]byte, len(openFile.MetadataHandle))
@@ -1075,9 +1077,9 @@ func buildPersistedDurableHandle(
 
 	// Clone ParentHandle to avoid aliasing
 	var parentHandle []byte
-	if len(openFile.ParentHandle) > 0 {
-		parentHandle = make([]byte, len(openFile.ParentHandle))
-		copy(parentHandle, openFile.ParentHandle)
+	if len(name.ParentHandle) > 0 {
+		parentHandle = make([]byte, len(name.ParentHandle))
+		copy(parentHandle, name.ParentHandle)
 	}
 
 	// Per MS-SMB2 3.2.4.4: when the client reconnects via DHnC, the volatile
@@ -1090,7 +1092,7 @@ func buildPersistedDurableHandle(
 	return &lock.PersistedDurableHandle{
 		ID:              uuid.New().String(),
 		FileID:          persistentFileID,
-		Path:            openFile.Path,
+		Path:            name.Path,
 		ShareName:       openFile.ShareName,
 		DesiredAccess:   openFile.DesiredAccess,
 		GrantedAccess:   openFile.GrantedAccess,
@@ -1114,7 +1116,7 @@ func buildPersistedDurableHandle(
 		ServerStartTime: serverStartTime,
 		DeletePending:   openFile.DeletePending,
 		ParentHandle:    parentHandle,
-		FileName:        openFile.FileName,
+		FileName:        name.FileName,
 		IsDirectory:     openFile.IsDirectory,
 		PositionInfo:    openFile.PositionInfo,
 		OriginalFileID:  openFile.FileID,

--- a/internal/adapter/smb/handlers/durable_context.go
+++ b/internal/adapter/smb/handlers/durable_context.go
@@ -1022,13 +1022,12 @@ func ProcessAppInstanceId(
 
 	for _, h := range existing {
 		if handler != nil {
-			cleanupFile := &OpenFile{
+			cleanupFile := (&OpenFile{
 				FileID:         h.FileID,
 				ShareName:      h.ShareName,
 				MetadataHandle: h.MetadataHandle,
 				PayloadID:      metadata.PayloadID(h.PayloadID),
-			}
-			cleanupFile.SetName(OpenName{Path: h.Path})
+			}).WithName(OpenName{Path: h.Path})
 			handler.flushFileCache(ctx, cleanupFile)
 			if len(h.MetadataHandle) > 0 && handler.Registry != nil {
 				if metaSvc := handler.Registry.GetMetadataService(); metaSvc != nil {

--- a/internal/adapter/smb/handlers/durable_context_test.go
+++ b/internal/adapter/smb/handlers/durable_context_test.go
@@ -581,8 +581,8 @@ func TestProcessDurableReconnectContext_V1Success(t *testing.T) {
 	if restored == nil {
 		t.Fatal("Expected restored ReconnectResult, got nil")
 	}
-	if restored.OpenFile.Path != "test.txt" {
-		t.Errorf("Path = %s, want test.txt", restored.OpenFile.Path)
+	if restored.OpenFile.Name().Path != "test.txt" {
+		t.Errorf("Path = %s, want test.txt", restored.OpenFile.Name().Path)
 	}
 	if restored.OpenFile.DesiredAccess != 0x12019F {
 		t.Errorf("DesiredAccess = 0x%x, want 0x12019F", restored.OpenFile.DesiredAccess)
@@ -733,8 +733,8 @@ func TestProcessDurableReconnectContext_V2Success(t *testing.T) {
 	if restored == nil {
 		t.Fatal("Expected restored ReconnectResult, got nil")
 	}
-	if restored.OpenFile.Path != "report.docx" {
-		t.Errorf("Path = %s, want report.docx", restored.OpenFile.Path)
+	if restored.OpenFile.Name().Path != "report.docx" {
+		t.Errorf("Path = %s, want report.docx", restored.OpenFile.Name().Path)
 	}
 	if !restored.IsV2 {
 		t.Error("Expected IsV2=true for V2 reconnect")
@@ -956,7 +956,7 @@ func TestProcessDurableReconnectContext_V2OplockJunkFnameIgnored(t *testing.T) {
 	if status != types.StatusSuccess {
 		t.Fatalf("Expected STATUS_SUCCESS (non-lease V2 ignores fname), got %s", status)
 	}
-	if restored == nil || restored.OpenFile.Path != "test.txt" {
+	if restored == nil || restored.OpenFile.Name().Path != "test.txt" {
 		t.Fatalf("expected restored open with original path test.txt, got %+v", restored)
 	}
 	// Reconnect restores the ORIGINAL granted access, never the request's.
@@ -1753,8 +1753,8 @@ func TestProcessDurableReconnectContext_V1OplockIgnoresPath(t *testing.T) {
 	if res == nil || res.OpenFile == nil {
 		t.Fatal("Expected restored OpenFile")
 	}
-	if res.OpenFile.Path != "real.dat" {
-		t.Errorf("Restored Path = %q, want %q", res.OpenFile.Path, "real.dat")
+	if res.OpenFile.Name().Path != "real.dat" {
+		t.Errorf("Restored Path = %q, want %q", res.OpenFile.Name().Path, "real.dat")
 	}
 }
 
@@ -2041,8 +2041,8 @@ func assertReopen2OK(t *testing.T, res *ReconnectResult, status types.Status, er
 		t.Errorf("GrantedAccess = 0x%x, want original 0x%x (junk request access must be ignored)",
 			res.OpenFile.GrantedAccess, wantGranted)
 	}
-	if res.OpenFile.Path != "reopen2.dat" {
-		t.Errorf("Path = %q, want original reopen2.dat", res.OpenFile.Path)
+	if res.OpenFile.Name().Path != "reopen2.dat" {
+		t.Errorf("Path = %q, want original reopen2.dat", res.OpenFile.Name().Path)
 	}
 }
 

--- a/internal/adapter/smb/handlers/fileid_test.go
+++ b/internal/adapter/smb/handlers/fileid_test.go
@@ -41,15 +41,12 @@ func TestFileID_StableAcrossViews(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EncodeFileHandle: %v", err)
 	}
-	openFile := &OpenFile{
+	openFile := (&OpenFile{
 		FileID:         [16]byte{1},
 		MetadataHandle: fileHandle,
-		ParentHandle:   rootHandle,
-		FileName:       "foo",
-		Path:           "foo",
 		ShareName:      "/fid",
 		GrantedAccess:  0x001F01FF,
-	}
+	}).WithName(OpenName{Path: "foo", FileName: "foo", ParentHandle: rootHandle})
 
 	t.Run("QFid", func(t *testing.T) {
 		qfid := h.baseFileUUID(authCtx, rootHandle, "foo", file.ID)
@@ -141,15 +138,12 @@ func TestFileID_StreamMatchesBase(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EncodeFileHandle: %v", err)
 	}
-	openStream := &OpenFile{
+	openStream := (&OpenFile{
 		FileID:         [16]byte{2},
 		MetadataHandle: streamHandle,
-		ParentHandle:   rootHandle,
-		FileName:       "foo:bar",
-		Path:           "foo:bar",
 		ShareName:      "/fid",
 		GrantedAccess:  0x001F01FF,
-	}
+	}).WithName(OpenName{Path: "foo:bar", FileName: "foo:bar", ParentHandle: rootHandle})
 
 	qfid := h.baseFileUUID(authCtx, rootHandle, "foo:bar", stream.ID)
 	if got := binary.LittleEndian.Uint64(qfid[:8]); got != expected {
@@ -208,11 +202,10 @@ func TestFileID_UniqueAcrossSiblings(t *testing.T) {
 			}
 			info, err := h.buildFileInfoFromStore(
 				authCtx, f,
-				&OpenFile{
-					MetadataHandle: fh, ParentHandle: rootHandle,
-					FileName: name, Path: name, ShareName: "/fid",
+				(&OpenFile{
+					MetadataHandle: fh, ShareName: "/fid",
 					GrantedAccess: 0x001F01FF,
-				},
+				}).WithName(OpenName{Path: name, FileName: name, ParentHandle: rootHandle}),
 				types.FileInternalInformation,
 			)
 			if err != nil {
@@ -240,16 +233,13 @@ func readFirstNamedEntryFileID(
 ) uint64 {
 	t.Helper()
 
-	dirOpen := &OpenFile{
+	dirOpen := (&OpenFile{
 		FileID:         [16]byte{0xDD},
 		MetadataHandle: dirHandle,
-		ParentHandle:   dirHandle,
-		FileName:       "",
-		Path:           "",
 		ShareName:      "/fid",
 		IsDirectory:    true,
 		GrantedAccess:  0x001F01FF,
-	}
+	}).WithName(OpenName{Path: "", FileName: "", ParentHandle: dirHandle})
 	h.StoreOpenFile(dirOpen)
 
 	req := &QueryDirectoryRequest{

--- a/internal/adapter/smb/handlers/flush.go
+++ b/internal/adapter/smb/handlers/flush.go
@@ -213,20 +213,20 @@ func (h *Handler) Flush(ctx *SMBHandlerContext, req *FlushRequest) (*FlushRespon
 	metaSvc := h.Registry.GetMetadataService()
 	blockStore, err := h.Registry.GetBlockStoreForShare(openFile.ShareName)
 	if err != nil {
-		logger.Warn("FLUSH: block store not available for handle", "path", openFile.Path, "error", err)
+		logger.Warn("FLUSH: block store not available for handle", "path", openFile.Name().Path, "error", err)
 		return &FlushResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInternalError}}, nil
 	}
 
 	// Verify file exists
 	file, err := metaSvc.GetFileForRead(ctx.Context, openFile.MetadataHandle)
 	if err != nil {
-		logger.Debug("FLUSH: file not found", "path", openFile.Path, "error", err)
+		logger.Debug("FLUSH: file not found", "path", openFile.Name().Path, "error", err)
 		return &FlushResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(err)}}, nil
 	}
 
 	// Check if there's content to flush
 	if file.PayloadID == "" {
-		logger.Debug("FLUSH: no content to flush", "path", openFile.Path)
+		logger.Debug("FLUSH: no content to flush", "path", openFile.Name().Path)
 		return &FlushResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess}}, nil
 	}
 
@@ -236,7 +236,7 @@ func (h *Handler) Flush(ctx *SMBHandlerContext, req *FlushRequest) (*FlushRespon
 
 	_, flushErr := blockStore.Flush(ctx.Context, string(file.PayloadID))
 	if flushErr != nil {
-		logger.Warn("FLUSH: failed", "path", openFile.Path, "error", flushErr)
+		logger.Warn("FLUSH: failed", "path", openFile.Name().Path, "error", flushErr)
 		// FLUSH is a content-path op (same as NFS COMMIT): MapContentToSMB
 		// maps a closed-store error (the share was removed/hot-reloaded
 		// mid-flush) to STATUS_FILE_CLOSED and preserves the
@@ -262,16 +262,16 @@ func (h *Handler) Flush(ctx *SMBHandlerContext, req *FlushRequest) (*FlushRespon
 
 	authCtx, authErr := BuildAuthContext(ctx)
 	if authErr != nil {
-		logger.Warn("FLUSH: failed to build auth context for metadata flush", "path", openFile.Path, "error", authErr)
+		logger.Warn("FLUSH: failed to build auth context for metadata flush", "path", openFile.Name().Path, "error", authErr)
 	} else {
 		// STRICT (durable=true): SMB FLUSH is an explicit client fsync request, so
 		// the metadata commit must fsync inline — deliberately NOT relaxed (#1687).
 		flushed, metaErr := metaSvc.FlushPendingWriteForFile(authCtx, openFile.MetadataHandle, true)
 		if metaErr != nil {
-			logger.Warn("FLUSH: metadata flush failed", "path", openFile.Path, "error", metaErr)
+			logger.Warn("FLUSH: metadata flush failed", "path", openFile.Name().Path, "error", metaErr)
 			// Continue - content is flushed, metadata will be fixed eventually
 		} else if flushed {
-			logger.Debug("FLUSH: metadata flushed", "path", openFile.Path)
+			logger.Debug("FLUSH: metadata flushed", "path", openFile.Name().Path)
 		}
 	}
 
@@ -281,7 +281,7 @@ func (h *Handler) Flush(ctx *SMBHandlerContext, req *FlushRequest) (*FlushRespon
 	flushSmbDelayedWrite(openFile)
 	h.StoreOpenFile(openFile)
 
-	logger.Debug("FLUSH successful", "path", openFile.Path)
+	logger.Debug("FLUSH successful", "path", openFile.Name().Path)
 
 	// ========================================================================
 	// Step 5: Return success response

--- a/internal/adapter/smb/handlers/flush.go
+++ b/internal/adapter/smb/handlers/flush.go
@@ -206,6 +206,8 @@ func (h *Handler) Flush(ctx *SMBHandlerContext, req *FlushRequest) (*FlushRespon
 		return &FlushResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusFileClosed}}, nil
 	}
 
+	path := openFile.Name().Path
+
 	// ========================================================================
 	// Step 2: Get services and verify file exists
 	// ========================================================================
@@ -213,20 +215,20 @@ func (h *Handler) Flush(ctx *SMBHandlerContext, req *FlushRequest) (*FlushRespon
 	metaSvc := h.Registry.GetMetadataService()
 	blockStore, err := h.Registry.GetBlockStoreForShare(openFile.ShareName)
 	if err != nil {
-		logger.Warn("FLUSH: block store not available for handle", "path", openFile.Name().Path, "error", err)
+		logger.Warn("FLUSH: block store not available for handle", "path", path, "error", err)
 		return &FlushResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInternalError}}, nil
 	}
 
 	// Verify file exists
 	file, err := metaSvc.GetFileForRead(ctx.Context, openFile.MetadataHandle)
 	if err != nil {
-		logger.Debug("FLUSH: file not found", "path", openFile.Name().Path, "error", err)
+		logger.Debug("FLUSH: file not found", "path", path, "error", err)
 		return &FlushResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(err)}}, nil
 	}
 
 	// Check if there's content to flush
 	if file.PayloadID == "" {
-		logger.Debug("FLUSH: no content to flush", "path", openFile.Name().Path)
+		logger.Debug("FLUSH: no content to flush", "path", path)
 		return &FlushResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess}}, nil
 	}
 
@@ -236,7 +238,7 @@ func (h *Handler) Flush(ctx *SMBHandlerContext, req *FlushRequest) (*FlushRespon
 
 	_, flushErr := blockStore.Flush(ctx.Context, string(file.PayloadID))
 	if flushErr != nil {
-		logger.Warn("FLUSH: failed", "path", openFile.Name().Path, "error", flushErr)
+		logger.Warn("FLUSH: failed", "path", path, "error", flushErr)
 		// FLUSH is a content-path op (same as NFS COMMIT): MapContentToSMB
 		// maps a closed-store error (the share was removed/hot-reloaded
 		// mid-flush) to STATUS_FILE_CLOSED and preserves the
@@ -262,16 +264,16 @@ func (h *Handler) Flush(ctx *SMBHandlerContext, req *FlushRequest) (*FlushRespon
 
 	authCtx, authErr := BuildAuthContext(ctx)
 	if authErr != nil {
-		logger.Warn("FLUSH: failed to build auth context for metadata flush", "path", openFile.Name().Path, "error", authErr)
+		logger.Warn("FLUSH: failed to build auth context for metadata flush", "path", path, "error", authErr)
 	} else {
 		// STRICT (durable=true): SMB FLUSH is an explicit client fsync request, so
 		// the metadata commit must fsync inline — deliberately NOT relaxed (#1687).
 		flushed, metaErr := metaSvc.FlushPendingWriteForFile(authCtx, openFile.MetadataHandle, true)
 		if metaErr != nil {
-			logger.Warn("FLUSH: metadata flush failed", "path", openFile.Name().Path, "error", metaErr)
+			logger.Warn("FLUSH: metadata flush failed", "path", path, "error", metaErr)
 			// Continue - content is flushed, metadata will be fixed eventually
 		} else if flushed {
-			logger.Debug("FLUSH: metadata flushed", "path", openFile.Name().Path)
+			logger.Debug("FLUSH: metadata flushed", "path", path)
 		}
 	}
 
@@ -281,7 +283,7 @@ func (h *Handler) Flush(ctx *SMBHandlerContext, req *FlushRequest) (*FlushRespon
 	flushSmbDelayedWrite(openFile)
 	h.StoreOpenFile(openFile)
 
-	logger.Debug("FLUSH successful", "path", openFile.Name().Path)
+	logger.Debug("FLUSH successful", "path", path)
 
 	// ========================================================================
 	// Step 5: Return success response

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -783,9 +783,6 @@ type OpenFile struct {
 	OpenerIsNull  bool
 }
 
-// OpenID returns a unique identifier for this open file handle.
-// This is used for per-open byte-range lock ownership per MS-SMB2.
-// The identifier is derived from the SMB FileID, which is unique per open.
 // OpenName is the name triple of an open handle: full path, name within the
 // parent, and parent directory handle. SET_INFO rename replaces all three at
 // once, so they are published and read as one immutable value.
@@ -820,6 +817,9 @@ func (f *OpenFile) WithName(n OpenName) *OpenFile {
 	return f
 }
 
+// OpenID returns a unique identifier for this open file handle.
+// This is used for per-open byte-range lock ownership per MS-SMB2.
+// The identifier is derived from the SMB FileID, which is unique per open.
 func (f *OpenFile) OpenID() string {
 	if f.cachedOpenID == "" {
 		f.cachedOpenID = fmt.Sprintf("%x", f.FileID)
@@ -2334,7 +2334,8 @@ func (h *Handler) isFileOrBaseDeletePending(fileHandle metadata.FileHandle, file
 		if !bdp {
 			return true
 		}
-		existingBase := adsBasePath(existing.Name().Path)
+		existingPath := existing.Name().Path
+		existingBase := adsBasePath(existingPath)
 		if openBase == "" {
 			// Opening a base file: match against any stream of this base.
 			if strings.EqualFold(existingBase, filePath) {
@@ -2345,7 +2346,7 @@ func (h *Handler) isFileOrBaseDeletePending(fileHandle metadata.FileHandle, file
 			// Opening a stream: match against a sibling stream sharing the
 			// same base path, or against a base-file handle of that base.
 			if strings.EqualFold(existingBase, openBase) ||
-				strings.EqualFold(existing.Name().Path, openBase) {
+				strings.EqualFold(existingPath, openBase) {
 				pending = true
 				return false
 			}
@@ -2431,12 +2432,13 @@ func (h *Handler) checkShareModeConflict(fileHandle metadata.FileHandle, newDesi
 		sameFile := bytes.Equal(existing.MetadataHandle, fileHandle)
 		crossStream := false
 		if !sameFile {
-			existingBase := adsBasePath(existing.Name().Path)
+			existingPath := existing.Name().Path
+			existingBase := adsBasePath(existingPath)
 			baseVsStream := false
 			if newBase == "" && existingBase != "" {
 				baseVsStream = strings.EqualFold(existingBase, filePath)
 			} else if newBase != "" && existingBase == "" {
-				baseVsStream = strings.EqualFold(newBase, existing.Name().Path)
+				baseVsStream = strings.EqualFold(newBase, existingPath)
 			}
 			if !baseVsStream {
 				return true
@@ -2655,10 +2657,11 @@ func (h *Handler) snapshotOpenChildren(dirHandle metadata.FileHandle) []metadata
 	var children []metadata.FileHandle
 	h.files.Range(func(_, value any) bool {
 		of := value.(*OpenFile)
-		if len(of.Name().ParentHandle) == 0 || len(of.MetadataHandle) == 0 {
+		parent := of.Name().ParentHandle
+		if len(parent) == 0 || len(of.MetadataHandle) == 0 {
 			return true
 		}
-		if !bytes.Equal(of.Name().ParentHandle, dirHandle) {
+		if !bytes.Equal(parent, dirHandle) {
 			return true
 		}
 		children = append(children, of.MetadataHandle)
@@ -2674,10 +2677,11 @@ func (h *Handler) anyOpenChild(dirHandle metadata.FileHandle) bool {
 	open := false
 	h.files.Range(func(_, value any) bool {
 		of := value.(*OpenFile)
-		if len(of.Name().ParentHandle) == 0 {
+		parent := of.Name().ParentHandle
+		if len(parent) == 0 {
 			return true
 		}
-		if !bytes.Equal(of.Name().ParentHandle, dirHandle) {
+		if !bytes.Equal(parent, dirHandle) {
 			return true
 		}
 		open = true

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -420,11 +420,11 @@ type TreeConnection struct {
 // fields (FileID/TreeID/SessionID/MetadataHandle/CreateOptions) are safe to
 // access without the mutex.
 //
-// PayloadID, Path, FileName and ParentHandle are NOT immutable: the first WRITE
-// on a file created empty caches the payload the metadata store allocated,
+// PayloadID and the name triple are NOT immutable: the first WRITE on a file
+// created empty caches the payload the metadata store allocated,
 // SET_REPARSE_POINT and COPYCHUNK replace it, and SET_INFO rename rewrites the
-// name/path/parent triple. Reach them through GetPayloadID / SetPayloadID and
-// GetFileName, or under `mu` directly.
+// name/path/parent triple. Reach the payload through GetPayloadID /
+// SetPayloadID and the triple through Name / SetName.
 type OpenFile struct {
 	// mu guards the mutable fields listed in the struct comment above. Held
 	// across QueryDirectory enumeration R-M-W, freeze/thaw bookkeeping in
@@ -432,10 +432,12 @@ type OpenFile struct {
 	// QUERY_INFO frozen/delayed-write overlay reads.
 	mu sync.RWMutex
 
+	// name is the current OpenName. Read via Name, publish via SetName.
+	name atomic.Pointer[OpenName]
+
 	FileID        [16]byte
 	TreeID        uint32
 	SessionID     uint64
-	Path          string
 	ShareName     string
 	cachedOpenID  string // cached hex(FileID) for hot-path lock operations
 	OpenTime      time.Time
@@ -532,10 +534,8 @@ type OpenFile struct {
 	// CLOSE time. Required by smbtorture smb2.dirlease.{unlink_same,
 	// unlink_different}_initial_and_close which open a file with initial
 	// DOC and then immediately open a SECOND handle to it (must succeed).
-	DeletePending        bool                // committed shared DOC (visible to other opens)
-	InitialDeleteOnClose bool                // per-handle initial DOC from CREATE FILE_DELETE_ON_CLOSE
-	ParentHandle         metadata.FileHandle // Parent directory handle for deletion
-	FileName             string              // File name within parent for deletion
+	DeletePending        bool // committed shared DOC (visible to other opens)
+	InitialDeleteOnClose bool // per-handle initial DOC from CREATE FILE_DELETE_ON_CLOSE
 
 	// ShareAccess stores the sharing mode from the CREATE request.
 	// Used for share mode conflict checking during rename and other operations.
@@ -786,6 +786,40 @@ type OpenFile struct {
 // OpenID returns a unique identifier for this open file handle.
 // This is used for per-open byte-range lock ownership per MS-SMB2.
 // The identifier is derived from the SMB FileID, which is unique per open.
+// OpenName is the name triple of an open handle: full path, name within the
+// parent, and parent directory handle. SET_INFO rename replaces all three at
+// once, so they are published and read as one immutable value.
+type OpenName struct {
+	Path         string
+	FileName     string
+	ParentHandle metadata.FileHandle
+}
+
+// emptyOpenName is what Name reports for a handle that was never named.
+var emptyOpenName = &OpenName{}
+
+// Name returns the current name triple. Never nil, and safe to call while
+// holding the handle lock.
+func (f *OpenFile) Name() *OpenName {
+	if n := f.name.Load(); n != nil {
+		return n
+	}
+	return emptyOpenName
+}
+
+// SetName publishes a new name triple. Callers renaming a live handle must
+// hold `mu` across the read-modify-write so two renames cannot interleave.
+func (f *OpenFile) SetName(n OpenName) {
+	f.name.Store(&n)
+}
+
+// WithName publishes n and returns f, so a handle can be built and named in a
+// single expression.
+func (f *OpenFile) WithName(n OpenName) *OpenFile {
+	f.SetName(n)
+	return f
+}
+
 func (f *OpenFile) OpenID() string {
 	if f.cachedOpenID == "" {
 		f.cachedOpenID = fmt.Sprintf("%x", f.FileID)
@@ -870,25 +904,6 @@ func (f *OpenFile) SetPayloadID(id metadata.PayloadID) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.PayloadID = id
-}
-
-// GetFileName returns the name within the parent directory under the read lock.
-// SET_INFO rename rewrites it on a live handle, so a caller needing the name
-// alongside Path or ParentHandle must snapshot the group under RLock instead.
-func (f *OpenFile) GetFileName() string {
-	f.mu.RLock()
-	defer f.mu.RUnlock()
-	return f.FileName
-}
-
-// GetPath returns the full path under the read lock. SET_INFO rename rewrites
-// it on a live handle, so a caller needing the path alongside FileName or
-// ParentHandle must snapshot the group under RLock instead of calling this
-// once per field.
-func (f *OpenFile) GetPath() string {
-	f.mu.RLock()
-	defer f.mu.RUnlock()
-	return f.Path
 }
 
 // IsMtimeFrozen returns the MtimeFrozen flag under the read lock.
@@ -1227,7 +1242,7 @@ func (h *Handler) ReleaseAllLocksForSession(ctx context.Context, sessionID uint6
 		if unlockErr := metaSvc.UnlockAllForOpen(ctx, openFile.MetadataHandle, openFile.OpenID()); unlockErr != nil {
 			logger.Warn("ReleaseAllLocksForSession: failed to release locks",
 				"share", openFile.ShareName,
-				"path", openFile.Path,
+				"path", openFile.Name().Path,
 				"error", unlockErr)
 		}
 
@@ -1373,7 +1388,7 @@ func (h *Handler) closeFilesWithFilter(
 			persistGated := !shouldPersistDurableOnDisconnect(leaseState, openHasLocks(metaSvc, openFile))
 			if persistGated {
 				logger.Debug(caller+": durable persist refused (BR-lock without W lease)",
-					"path", openFile.Path,
+					"path", openFile.Name().Path,
 					"leaseState", fmt.Sprintf("0x%x", leaseState),
 					"hasBRLocks", true)
 			} else {
@@ -1391,12 +1406,12 @@ func (h *Handler) closeFilesWithFilter(
 				h.durablePurgeMu.Unlock()
 				if err != nil {
 					logger.Warn(caller+": failed to persist durable handle",
-						"path", openFile.Path,
+						"path", openFile.Name().Path,
 						"error", err)
 					// Fall through to normal close on persistence failure
 				} else {
 					logger.Debug(caller+": durable handle persisted for reconnect",
-						"path", openFile.Path,
+						"path", openFile.Name().Path,
 						"fileID", fmt.Sprintf("%x", openFile.FileID),
 						"timeout", openFile.DurableTimeoutMs)
 					// Do NOT release locks, flush caches, or execute delete-on-close
@@ -1488,11 +1503,12 @@ func (h *Handler) closeFilesWithFilter(
 					return true
 				})
 				logger.Debug(caller+": initial DOC propagated to other handles (not last)",
-					"path", openFile.Path)
+					"path", openFile.Name().Path)
 				isInitialDocOnly = false // delete handled by remaining sibling
 			}
 		}
-		if (openFile.DeletePending || isInitialDocOnly) && len(openFile.ParentHandle) > 0 && openFile.FileName != "" {
+		docName := openFile.Name()
+		if (openFile.DeletePending || isInitialDocOnly) && len(docName.ParentHandle) > 0 && docName.FileName != "" {
 			h.handleDeleteOnClose(ctx, sess, openFile, caller)
 		}
 
@@ -1645,6 +1661,7 @@ func (h *Handler) purgeBlockStorePayload(ctx context.Context, handle metadata.Fi
 // would deadlock — the holder can only ack after the triggering request
 // returns.
 func (h *Handler) handleDeleteOnClose(ctx context.Context, sess *session.Session, openFile *OpenFile, caller string) {
+	name := openFile.Name()
 	authCtx := h.buildCleanupAuthContext(ctx, sess)
 	// Thread the closing handle's RqLs ParentLeaseKey so notifyDirChange can
 	// apply the MS-SMB2 §3.3.4.20 / Samba `dirlease_should_break` parent-key
@@ -1660,24 +1677,24 @@ func (h *Handler) handleDeleteOnClose(ctx context.Context, sess *session.Session
 		// smb2.lease.v1_bug15148 to count=2).
 		excludeOwner := &lock.LockOwner{ClientID: fmt.Sprintf("smb:%d", openFile.SessionID)}
 		if breakErr := h.LeaseManager.BreakFileHandleLeasesOnDelete(lockFileHandle, openFile.ShareName, excludeOwner); breakErr != nil {
-			logger.Debug(caller+": file Handle lease break on delete failed", "path", openFile.Path, "error", breakErr)
+			logger.Debug(caller+": file Handle lease break on delete failed", "path", name.Path, "error", breakErr)
 		}
 	}
 
 	var deleted bool
 	if openFile.IsDirectory {
-		if _, err := metaSvc.RemoveDirectory(authCtx, openFile.ParentHandle, openFile.FileName); err != nil {
-			logger.Debug(caller+": failed to delete directory", "path", openFile.Path, "error", err)
+		if _, err := metaSvc.RemoveDirectory(authCtx, name.ParentHandle, name.FileName); err != nil {
+			logger.Debug(caller+": failed to delete directory", "path", name.Path, "error", err)
 		} else {
-			logger.Debug(caller+": directory deleted", "path", openFile.Path)
+			logger.Debug(caller+": directory deleted", "path", name.Path)
 			deleted = true
 		}
 	} else {
-		removed, _, err := metaSvc.RemoveFile(authCtx, openFile.ParentHandle, openFile.FileName)
+		removed, _, err := metaSvc.RemoveFile(authCtx, name.ParentHandle, name.FileName)
 		if err != nil {
-			logger.Debug(caller+": failed to delete file", "path", openFile.Path, "error", err)
+			logger.Debug(caller+": failed to delete file", "path", name.Path, "error", err)
 		} else {
-			logger.Debug(caller+": file deleted", "path", openFile.Path)
+			logger.Debug(caller+": file deleted", "path", name.Path)
 			deleted = true
 			// Purge content via RemoveFile's RETURNED PayloadID — empty when
 			// content must survive (surviving hard link / recycle to trash).
@@ -1685,7 +1702,7 @@ func (h *Handler) handleDeleteOnClose(ctx context.Context, sess *session.Session
 			if removed != nil {
 				removedPayloadID = removed.PayloadID
 			}
-			h.purgeBlockStorePayload(ctx, openFile.MetadataHandle, removedPayloadID, openFile.Path, caller)
+			h.purgeBlockStorePayload(ctx, openFile.MetadataHandle, removedPayloadID, name.Path, caller)
 		}
 	}
 
@@ -1957,7 +1974,7 @@ func (h *Handler) flushFileCache(ctx context.Context, openFile *OpenFile) {
 	}
 	// Snapshot once: a rename landing mid-flush would otherwise let the three
 	// log lines below name different paths for the same operation.
-	path := openFile.GetPath()
+	path := openFile.Name().Path
 
 	blockStore, err := h.Registry.GetBlockStoreForShare(openFile.ShareName)
 	if err != nil {
@@ -2035,6 +2052,13 @@ func (h *Handler) GenerateTreeID() uint32 {
 // AsyncIds must be unique within a connection and non-zero.
 func (h *Handler) generateAsyncId() uint64 {
 	return h.nextAsyncId.Add(1)
+}
+
+// notifyOpenFileModified emits a FileActionModified notification for the
+// handle, taking the parent path and stream name from one name snapshot.
+func (h *Handler) notifyOpenFileModified(openFile *OpenFile, filter uint32) {
+	name := openFile.Name()
+	h.NotifyRegistry.NotifyChange(openFile.ShareName, GetParentPath(name.Path), notifyStreamName(name.FileName), FileActionModified, filter)
 }
 
 // baseFileUUID returns the base file's UUID for an ADS path, or fallback for non-ADS.
@@ -2310,7 +2334,7 @@ func (h *Handler) isFileOrBaseDeletePending(fileHandle metadata.FileHandle, file
 		if !bdp {
 			return true
 		}
-		existingBase := adsBasePath(existing.Path)
+		existingBase := adsBasePath(existing.Name().Path)
 		if openBase == "" {
 			// Opening a base file: match against any stream of this base.
 			if strings.EqualFold(existingBase, filePath) {
@@ -2321,7 +2345,7 @@ func (h *Handler) isFileOrBaseDeletePending(fileHandle metadata.FileHandle, file
 			// Opening a stream: match against a sibling stream sharing the
 			// same base path, or against a base-file handle of that base.
 			if strings.EqualFold(existingBase, openBase) ||
-				strings.EqualFold(existing.Path, openBase) {
+				strings.EqualFold(existing.Name().Path, openBase) {
 				pending = true
 				return false
 			}
@@ -2407,12 +2431,12 @@ func (h *Handler) checkShareModeConflict(fileHandle metadata.FileHandle, newDesi
 		sameFile := bytes.Equal(existing.MetadataHandle, fileHandle)
 		crossStream := false
 		if !sameFile {
-			existingBase := adsBasePath(existing.Path)
+			existingBase := adsBasePath(existing.Name().Path)
 			baseVsStream := false
 			if newBase == "" && existingBase != "" {
 				baseVsStream = strings.EqualFold(existingBase, filePath)
 			} else if newBase != "" && existingBase == "" {
-				baseVsStream = strings.EqualFold(newBase, existing.Path)
+				baseVsStream = strings.EqualFold(newBase, existing.Name().Path)
 			}
 			if !baseVsStream {
 				return true
@@ -2557,11 +2581,11 @@ func logRenameConflictHolder(gate string, renamer, holder *OpenFile) {
 	logger.Debug("SET_INFO rename conflict holder",
 		"gate", gate,
 		"renamerFileID", fmt.Sprintf("%x", renamer.FileID),
-		"renamerPath", renamer.Path,
+		"renamerPath", renamer.Name().Path,
 		"renamerSession", renamer.SessionID,
 		"renamerTree", renamer.TreeID,
 		"holderFileID", fmt.Sprintf("%x", holder.FileID),
-		"holderPath", holder.Path,
+		"holderPath", holder.Name().Path,
 		"holderShare", holder.ShareName,
 		"holderSession", holder.SessionID,
 		"holderTree", holder.TreeID,
@@ -2631,10 +2655,10 @@ func (h *Handler) snapshotOpenChildren(dirHandle metadata.FileHandle) []metadata
 	var children []metadata.FileHandle
 	h.files.Range(func(_, value any) bool {
 		of := value.(*OpenFile)
-		if len(of.ParentHandle) == 0 || len(of.MetadataHandle) == 0 {
+		if len(of.Name().ParentHandle) == 0 || len(of.MetadataHandle) == 0 {
 			return true
 		}
-		if !bytes.Equal(of.ParentHandle, dirHandle) {
+		if !bytes.Equal(of.Name().ParentHandle, dirHandle) {
 			return true
 		}
 		children = append(children, of.MetadataHandle)
@@ -2650,10 +2674,10 @@ func (h *Handler) anyOpenChild(dirHandle metadata.FileHandle) bool {
 	open := false
 	h.files.Range(func(_, value any) bool {
 		of := value.(*OpenFile)
-		if len(of.ParentHandle) == 0 {
+		if len(of.Name().ParentHandle) == 0 {
 			return true
 		}
-		if !bytes.Equal(of.ParentHandle, dirHandle) {
+		if !bytes.Equal(of.Name().ParentHandle, dirHandle) {
 			return true
 		}
 		open = true

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -792,16 +792,14 @@ type OpenName struct {
 	ParentHandle metadata.FileHandle
 }
 
-// emptyOpenName is what Name reports for a handle that was never named.
-var emptyOpenName = &OpenName{}
-
-// Name returns the current name triple. Never nil, and safe to call while
-// holding the handle lock.
-func (f *OpenFile) Name() *OpenName {
+// Name returns the current name triple, zero if the handle was never named.
+// Returned by value so callers cannot mutate the published name; safe to call
+// while holding the handle lock.
+func (f *OpenFile) Name() OpenName {
 	if n := f.name.Load(); n != nil {
-		return n
+		return *n
 	}
-	return emptyOpenName
+	return OpenName{}
 }
 
 // SetName publishes a new name triple. Callers renaming a live handle must

--- a/internal/adapter/smb/handlers/handler_test.go
+++ b/internal/adapter/smb/handlers/handler_test.go
@@ -399,14 +399,13 @@ func TestOpenFileStorage(t *testing.T) {
 		h := NewHandler()
 
 		fileID := h.GenerateFileID()
-		file := &OpenFile{
+		file := (&OpenFile{
 			FileID:      fileID,
 			TreeID:      1,
 			SessionID:   100,
-			Path:        "/test/file.txt",
 			ShareName:   "export",
 			IsDirectory: false,
-		}
+		}).WithName(OpenName{Path: "/test/file.txt"})
 
 		h.StoreOpenFile(file)
 
@@ -415,7 +414,7 @@ func TestOpenFileStorage(t *testing.T) {
 			t.Fatal("OpenFile not found")
 		}
 
-		if retrieved.Path != file.Path {
+		if retrieved.Name().Path != file.Name().Path {
 			t.Errorf("Path mismatch")
 		}
 	})
@@ -567,12 +566,11 @@ func TestConcurrentFileOperations(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			fileID := h.GenerateFileID()
-			file := &OpenFile{
+			file := (&OpenFile{
 				FileID:    fileID,
 				TreeID:    1,
 				SessionID: 1,
-				Path:      "/test/file.txt",
-			}
+			}).WithName(OpenName{Path: "/test/file.txt"})
 			h.StoreOpenFile(file)
 
 			// Read back
@@ -707,13 +705,12 @@ func TestCheckShareModeConflict_ADSCrossStream(t *testing.T) {
 		h := NewHandler()
 
 		const deleteAccess = uint32(0x00010000)
-		h.StoreOpenFile(&OpenFile{
+		h.StoreOpenFile((&OpenFile{
 			FileID:         h.GenerateFileID(),
-			Path:           "file.txt:stream1",
 			DesiredAccess:  fileReadData,
 			ShareAccess:    fileShareRead, // no FILE_SHARE_DELETE
 			MetadataHandle: []byte{0x01},
-		})
+		}).WithName(OpenName{Path: "file.txt:stream1"}))
 
 		conflict := h.checkShareModeConflict(
 			[]byte{0x02},
@@ -729,13 +726,12 @@ func TestCheckShareModeConflict_ADSCrossStream(t *testing.T) {
 	t.Run("BaseFileVsStream_ReadWriteNoConflict", func(t *testing.T) {
 		h := NewHandler()
 
-		h.StoreOpenFile(&OpenFile{
+		h.StoreOpenFile((&OpenFile{
 			FileID:         h.GenerateFileID(),
-			Path:           "file.txt:stream1",
 			DesiredAccess:  fileReadData,
 			ShareAccess:    fileShareRead, // no write sharing
 			MetadataHandle: []byte{0x01},
-		})
+		}).WithName(OpenName{Path: "file.txt:stream1"}))
 
 		conflict := h.checkShareModeConflict(
 			[]byte{0x02},
@@ -751,13 +747,12 @@ func TestCheckShareModeConflict_ADSCrossStream(t *testing.T) {
 	t.Run("TwoADS_NoConflict_DifferentStreams", func(t *testing.T) {
 		h := NewHandler()
 
-		h.StoreOpenFile(&OpenFile{
+		h.StoreOpenFile((&OpenFile{
 			FileID:         h.GenerateFileID(),
-			Path:           "file.txt:stream1",
 			DesiredAccess:  fileReadData,
 			ShareAccess:    fileShareRead,
 			MetadataHandle: []byte{0x01},
-		})
+		}).WithName(OpenName{Path: "file.txt:stream1"}))
 
 		conflict := h.checkShareModeConflict(
 			[]byte{0x02},
@@ -773,13 +768,12 @@ func TestCheckShareModeConflict_ADSCrossStream(t *testing.T) {
 	t.Run("SameADS_Conflict", func(t *testing.T) {
 		h := NewHandler()
 
-		h.StoreOpenFile(&OpenFile{
+		h.StoreOpenFile((&OpenFile{
 			FileID:         h.GenerateFileID(),
-			Path:           "file.txt:stream1",
 			DesiredAccess:  fileReadData,
 			ShareAccess:    fileShareRead,
 			MetadataHandle: []byte{0x01},
-		})
+		}).WithName(OpenName{Path: "file.txt:stream1"}))
 
 		conflict := h.checkShareModeConflict(
 			[]byte{0x01},
@@ -795,13 +789,12 @@ func TestCheckShareModeConflict_ADSCrossStream(t *testing.T) {
 	t.Run("DifferentBaseFiles_NoConflict", func(t *testing.T) {
 		h := NewHandler()
 
-		h.StoreOpenFile(&OpenFile{
+		h.StoreOpenFile((&OpenFile{
 			FileID:         h.GenerateFileID(),
-			Path:           "file1.txt",
 			DesiredAccess:  fileReadData | fileWriteData,
 			ShareAccess:    0,
 			MetadataHandle: []byte{0x01},
-		})
+		}).WithName(OpenName{Path: "file1.txt"}))
 
 		conflict := h.checkShareModeConflict(
 			[]byte{0x02},
@@ -818,13 +811,12 @@ func TestCheckShareModeConflict_ADSCrossStream(t *testing.T) {
 		h := NewHandler()
 
 		const fileReadAttributes = uint32(0x00000080)
-		h.StoreOpenFile(&OpenFile{
+		h.StoreOpenFile((&OpenFile{
 			FileID:         h.GenerateFileID(),
-			Path:           "file.txt",
 			DesiredAccess:  fileReadAttributes,
 			ShareAccess:    0,
 			MetadataHandle: []byte{0x01},
-		})
+		}).WithName(OpenName{Path: "file.txt"}))
 
 		conflict := h.checkShareModeConflict(
 			[]byte{0x01},
@@ -840,13 +832,12 @@ func TestCheckShareModeConflict_ADSCrossStream(t *testing.T) {
 	t.Run("NonConflictingExistingAccess_NoConstraint", func(t *testing.T) {
 		const writeDac = uint32(0x00040000)
 		h := NewHandler()
-		h.StoreOpenFile(&OpenFile{
+		h.StoreOpenFile((&OpenFile{
 			FileID:         h.GenerateFileID(),
-			Path:           "file.txt",
 			DesiredAccess:  writeDac,
 			ShareAccess:    0,
 			MetadataHandle: []byte{0x01},
-		})
+		}).WithName(OpenName{Path: "file.txt"}))
 		if h.checkShareModeConflict([]byte{0x01}, fileReadData|fileWriteData, fileShareRead|fileShareWrite, "file.txt") {
 			t.Error("Expected no conflict: WRITE_DAC-only existing open must not impose share-mode constraint")
 		}
@@ -855,13 +846,12 @@ func TestCheckShareModeConflict_ADSCrossStream(t *testing.T) {
 	t.Run("PipesSkipped", func(t *testing.T) {
 		h := NewHandler()
 
-		h.StoreOpenFile(&OpenFile{
+		h.StoreOpenFile((&OpenFile{
 			FileID:        h.GenerateFileID(),
-			Path:          "srvsvc",
 			DesiredAccess: fileReadData | fileWriteData,
 			ShareAccess:   0,
 			IsPipe:        true,
-		})
+		}).WithName(OpenName{Path: "srvsvc"}))
 
 		conflict := h.checkShareModeConflict(
 			[]byte{0x01},
@@ -896,13 +886,12 @@ func TestCheckShareModeConflict_MaximumAllowed(t *testing.T) {
 	t.Run("ExistingMaxAllowed_NewNoWriteShare_WriteConflict", func(t *testing.T) {
 		h := NewHandler()
 		// Existing MAXIMUM_ALLOWED handle that does NOT share write.
-		h.StoreOpenFile(&OpenFile{
+		h.StoreOpenFile((&OpenFile{
 			FileID:         h.GenerateFileID(),
-			Path:           "file.txt",
 			DesiredAccess:  maximumAllowed,
 			ShareAccess:    fileShareRead, // no FILE_SHARE_WRITE
 			MetadataHandle: []byte{0x01},
-		})
+		}).WithName(OpenName{Path: "file.txt"}))
 		// New writer with full sharing must conflict: the existing
 		// MAXIMUM_ALLOWED handle holds write and does not share it.
 		if !h.checkShareModeConflict([]byte{0x01}, fileWriteData, fileShareRead|fileShareWrite|fileShareDelete, "file.txt") {
@@ -913,13 +902,12 @@ func TestCheckShareModeConflict_MaximumAllowed(t *testing.T) {
 	t.Run("ExistingMaxAllowed_NewNoDeleteShare_DeleteConflict", func(t *testing.T) {
 		h := NewHandler()
 		const deleteAccess = uint32(0x00010000)
-		h.StoreOpenFile(&OpenFile{
+		h.StoreOpenFile((&OpenFile{
 			FileID:         h.GenerateFileID(),
-			Path:           "file.txt",
 			DesiredAccess:  maximumAllowed,
 			ShareAccess:    fileShareRead | fileShareWrite, // no FILE_SHARE_DELETE
 			MetadataHandle: []byte{0x01},
-		})
+		}).WithName(OpenName{Path: "file.txt"}))
 		if !h.checkShareModeConflict([]byte{0x01}, deleteAccess, fileShareRead|fileShareWrite|fileShareDelete, "file.txt") {
 			t.Error("Expected conflict: existing MAXIMUM_ALLOWED holds delete but does not share it")
 		}
@@ -928,13 +916,12 @@ func TestCheckShareModeConflict_MaximumAllowed(t *testing.T) {
 	t.Run("NewMaxAllowed_ExistingNoWriteShare_WriteConflict", func(t *testing.T) {
 		h := NewHandler()
 		// Existing read handle that does NOT share write.
-		h.StoreOpenFile(&OpenFile{
+		h.StoreOpenFile((&OpenFile{
 			FileID:         h.GenerateFileID(),
-			Path:           "file.txt",
 			DesiredAccess:  fileReadData,
 			ShareAccess:    fileShareRead, // no FILE_SHARE_WRITE
 			MetadataHandle: []byte{0x01},
-		})
+		}).WithName(OpenName{Path: "file.txt"}))
 		// New MAXIMUM_ALLOWED opener implies write; the existing handle does
 		// not share write, so this must conflict.
 		if !h.checkShareModeConflict([]byte{0x01}, maximumAllowed, fileShareRead|fileShareWrite|fileShareDelete, "file.txt") {
@@ -944,13 +931,12 @@ func TestCheckShareModeConflict_MaximumAllowed(t *testing.T) {
 
 	t.Run("NewMaxAllowed_ExistingNoDeleteShare_DeleteConflict", func(t *testing.T) {
 		h := NewHandler()
-		h.StoreOpenFile(&OpenFile{
+		h.StoreOpenFile((&OpenFile{
 			FileID:         h.GenerateFileID(),
-			Path:           "file.txt",
 			DesiredAccess:  fileReadData,
 			ShareAccess:    fileShareRead | fileShareWrite, // no FILE_SHARE_DELETE
 			MetadataHandle: []byte{0x01},
-		})
+		}).WithName(OpenName{Path: "file.txt"}))
 		if !h.checkShareModeConflict([]byte{0x01}, maximumAllowed, fileShareRead|fileShareWrite|fileShareDelete, "file.txt") {
 			t.Error("Expected conflict: new MAXIMUM_ALLOWED implies delete, existing handle does not share delete")
 		}
@@ -1011,16 +997,15 @@ func TestOpenFile(t *testing.T) {
 		var fileID [16]byte
 		fileID[0] = 0x01
 
-		file := &OpenFile{
+		file := (&OpenFile{
 			FileID:      fileID,
 			TreeID:      1,
 			SessionID:   100,
-			Path:        "/test/file.txt",
 			ShareName:   "export",
 			IsDirectory: false,
-		}
+		}).WithName(OpenName{Path: "/test/file.txt"})
 
-		if file.Path != "/test/file.txt" {
+		if file.Name().Path != "/test/file.txt" {
 			t.Error("Path not set correctly")
 		}
 		if file.IsDirectory {

--- a/internal/adapter/smb/handlers/ioctl_copychunk.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk.go
@@ -104,7 +104,7 @@ func (h *Handler) handleSrvRequestResumeKey(ctx *SMBHandlerContext, body []byte)
 	// FSCTL_SRV_COPYCHUNK operation, not at resume key issuance time.
 
 	logger.Debug("IOCTL FSCTL_SRV_REQUEST_RESUME_KEY",
-		"path", openFile.Path,
+		"path", openFile.Name().Path,
 		"fileID", fmt.Sprintf("%x", fileID))
 
 	// Generate an opaque resume key and store the mapping
@@ -183,7 +183,7 @@ func (h *Handler) handleSrvCopyChunk(ctx *SMBHandlerContext, body []byte) (*Hand
 
 	logger.Debug("IOCTL FSCTL_SRV_COPYCHUNK",
 		"ctlCode", fmt.Sprintf("0x%08X", ctlCode),
-		"dstPath", dstOpen.Path,
+		"dstPath", dstOpen.Name().Path,
 		"chunkCount", chunkCount)
 
 	// Resolve source file from resume key via the opaque key store
@@ -208,11 +208,11 @@ func (h *Handler) handleSrvCopyChunk(ctx *SMBHandlerContext, body []byte) (*Hand
 
 	// Validate that neither source nor destination is a directory or pipe
 	if srcOpen.IsDirectory || srcOpen.IsPipe {
-		logger.Debug("COPYCHUNK: source is directory or pipe", "path", srcOpen.Path)
+		logger.Debug("COPYCHUNK: source is directory or pipe", "path", srcOpen.Name().Path)
 		return NewErrorResult(types.StatusInvalidDeviceRequest), nil
 	}
 	if dstOpen.IsDirectory || dstOpen.IsPipe {
-		logger.Debug("COPYCHUNK: destination is directory or pipe", "path", dstOpen.Path)
+		logger.Debug("COPYCHUNK: destination is directory or pipe", "path", dstOpen.Name().Path)
 		return NewErrorResult(types.StatusInvalidDeviceRequest), nil
 	}
 
@@ -253,21 +253,21 @@ func validateCopyChunkAccess(ctlCode uint32, src, dst *OpenFile) types.Status {
 	// Source must have read or execute
 	if srcAccess&types.FileReadData == 0 && srcAccess&types.FileExecute == 0 {
 		logger.Debug("COPYCHUNK: source lacks read/execute access",
-			"path", src.Path, "access", fmt.Sprintf("0x%08X", src.GrantedAccess))
+			"path", src.Name().Path, "access", fmt.Sprintf("0x%08X", src.GrantedAccess))
 		return types.StatusAccessDenied
 	}
 
 	// Destination must have write or append
 	if dstAccess&types.FileWriteData == 0 && dstAccess&types.FileAppendData == 0 {
 		logger.Debug("COPYCHUNK: destination lacks write access",
-			"path", dst.Path, "access", fmt.Sprintf("0x%08X", dst.GrantedAccess))
+			"path", dst.Name().Path, "access", fmt.Sprintf("0x%08X", dst.GrantedAccess))
 		return types.StatusAccessDenied
 	}
 
 	// FSCTL_SRV_COPYCHUNK (not _WRITE) also requires read on destination
 	if ctlCode == FsctlSrvCopyChunk && dstAccess&types.FileReadData == 0 {
 		logger.Debug("COPYCHUNK: destination lacks read access (required for non-WRITE variant)",
-			"path", dst.Path, "access", fmt.Sprintf("0x%08X", dst.GrantedAccess))
+			"path", dst.Name().Path, "access", fmt.Sprintf("0x%08X", dst.GrantedAccess))
 		return types.StatusAccessDenied
 	}
 
@@ -362,20 +362,20 @@ func (h *Handler) executeCopyChunks(
 	// Get source block store and file metadata
 	srcBlockStore, err := h.Registry.GetBlockStoreForShare(srcOpen.ShareName)
 	if err != nil {
-		logger.Warn("COPYCHUNK: source block store unavailable", "path", srcOpen.Path, "error", err)
+		logger.Warn("COPYCHUNK: source block store unavailable", "path", srcOpen.Name().Path, "error", err)
 		return NewErrorResult(types.StatusInternalError), nil
 	}
 
 	srcFile, err := metaSvc.GetFileForRead(ctx.Context, srcOpen.MetadataHandle)
 	if err != nil {
-		logger.Debug("COPYCHUNK: failed to get source file", "path", srcOpen.Path, "error", err)
+		logger.Debug("COPYCHUNK: failed to get source file", "path", srcOpen.Name().Path, "error", err)
 		return NewErrorResult(common.MapToSMB(err)), nil
 	}
 
 	// Get destination block store
 	dstBlockStore, err := h.Registry.GetBlockStoreForShare(dstOpen.ShareName)
 	if err != nil {
-		logger.Warn("COPYCHUNK: destination block store unavailable", "path", dstOpen.Path, "error", err)
+		logger.Warn("COPYCHUNK: destination block store unavailable", "path", dstOpen.Name().Path, "error", err)
 		return NewErrorResult(types.StatusInternalError), nil
 	}
 
@@ -407,7 +407,7 @@ func (h *Handler) executeCopyChunks(
 	if h.LeaseManager != nil {
 		lockFileHandle := lock.FileHandle(dstOpen.MetadataHandle)
 		if breakErr := h.LeaseManager.BreakReadLeasesOnWrite(lockFileHandle, dstOpen.ShareName, dstOpen.LeaseKey); breakErr != nil {
-			logger.Debug("COPYCHUNK: oplock break failed (non-fatal)", "path", dstOpen.Path, "error", breakErr)
+			logger.Debug("COPYCHUNK: oplock break failed (non-fatal)", "path", dstOpen.Name().Path, "error", breakErr)
 		}
 	}
 
@@ -439,7 +439,7 @@ func (h *Handler) executeCopyChunks(
 		// durability from the journal reconcile on restart; CLOSE/FLUSH stay strict.
 		if _, flushErr := metaSvc.FlushPendingWriteForFile(authCtx, dstOpen.MetadataHandle, false); flushErr != nil {
 			logger.Debug("COPYCHUNK: deferred metadata flush failed (non-fatal)",
-				"dstPath", dstOpen.Path, "error", flushErr)
+				"dstPath", dstOpen.Name().Path, "error", flushErr)
 		}
 	}
 
@@ -483,7 +483,7 @@ func (h *Handler) executeCopyChunks(
 		n, err := srcBlockStore.ReadAt(ctx.Context, srcPayloadID, nil, data, chunk.SourceOffset)
 		if err != nil {
 			logger.Warn("COPYCHUNK: source read failed",
-				"chunk", i, "srcPath", srcOpen.Path, "error", err)
+				"chunk", i, "srcPath", srcOpen.Name().Path, "error", err)
 			// COPYCHUNK source read is a content-path op: MapContentToSMB
 			// maps a closed-store error (source share removed
 			// mid-copy) to STATUS_FILE_CLOSED and preserves the
@@ -511,7 +511,7 @@ func (h *Handler) executeCopyChunks(
 		writeOp, err := metaSvc.PrepareWrite(authCtx, dstOpen.MetadataHandle, newSize)
 		if err != nil {
 			logger.Warn("COPYCHUNK: prepare write failed",
-				"chunk", i, "dstPath", dstOpen.Path, "error", err)
+				"chunk", i, "dstPath", dstOpen.Name().Path, "error", err)
 			flushCommitted()
 			return copyChunkPartialResponse(ctlCode, dstFileID,
 				common.MapToSMB(err), chunksWritten, totalBytesWritten), nil
@@ -523,7 +523,7 @@ func (h *Handler) executeCopyChunks(
 		// thread the destination's FileAttr.Blocks update.
 		if _, err := dstBlockStore.WriteAt(ctx.Context, string(writeOp.PayloadID), nil, data, chunk.TargetOffset); err != nil {
 			logger.Warn("COPYCHUNK: destination write failed",
-				"chunk", i, "dstPath", dstOpen.Path, "error", err)
+				"chunk", i, "dstPath", dstOpen.Name().Path, "error", err)
 			// COPYCHUNK destination write is a content-path op:
 			// MapContentToSMB maps a closed-store error (dest share removed
 			// mid-copy) to STATUS_FILE_CLOSED and preserves the
@@ -537,7 +537,7 @@ func (h *Handler) executeCopyChunks(
 		// Commit write metadata
 		if _, err := metaSvc.CommitWrite(authCtx, writeOp); err != nil {
 			logger.Warn("COPYCHUNK: commit write failed",
-				"chunk", i, "dstPath", dstOpen.Path, "error", err)
+				"chunk", i, "dstPath", dstOpen.Name().Path, "error", err)
 			flushCommitted()
 			return copyChunkPartialResponse(ctlCode, dstFileID,
 				types.StatusInternalError, chunksWritten, totalBytesWritten), nil
@@ -567,13 +567,13 @@ func (h *Handler) executeCopyChunks(
 	if !dstOpen.IsAtimeFrozen() {
 		_, _ = metaSvc.SetFileAttributes(authCtx, dstOpen.MetadataHandle, &metadata.SetAttrs{Atime: &now})
 	}
-	if len(dstOpen.ParentHandle) > 0 {
-		_, _ = metaSvc.SetFileAttributes(authCtx, dstOpen.ParentHandle, &metadata.SetAttrs{Atime: &now})
-		h.restoreParentDirFrozenTimestamps(authCtx, dstOpen.ParentHandle)
+	if dstParent := dstOpen.Name().ParentHandle; len(dstParent) > 0 {
+		_, _ = metaSvc.SetFileAttributes(authCtx, dstParent, &metadata.SetAttrs{Atime: &now})
+		h.restoreParentDirFrozenTimestamps(authCtx, dstParent)
 	}
 
 	logger.Debug("COPYCHUNK: completed successfully",
-		"srcPath", srcOpen.Path, "dstPath", dstOpen.Path,
+		"srcPath", srcOpen.Name().Path, "dstPath", dstOpen.Name().Path,
 		"chunks", chunksWritten, "totalBytes", totalBytesWritten)
 
 	return copyChunkSuccessResponse(ctlCode, dstFileID, chunksWritten, totalBytesWritten), nil

--- a/internal/adapter/smb/handlers/ioctl_copychunk.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk.go
@@ -247,27 +247,28 @@ func (h *Handler) handleSrvCopyChunk(ctx *SMBHandlerContext, body []byte) (*Hand
 // Destination requires FILE_WRITE_DATA or FILE_APPEND_DATA.
 // For FSCTL_SRV_COPYCHUNK (not COPYCHUNK_WRITE), destination also requires FILE_READ_DATA.
 func validateCopyChunkAccess(ctlCode uint32, src, dst *OpenFile) types.Status {
+	srcPath, dstPath := src.Name().Path, dst.Name().Path
 	srcAccess := types.AccessMask(src.GrantedAccess)
 	dstAccess := types.AccessMask(dst.GrantedAccess)
 
 	// Source must have read or execute
 	if srcAccess&types.FileReadData == 0 && srcAccess&types.FileExecute == 0 {
 		logger.Debug("COPYCHUNK: source lacks read/execute access",
-			"path", src.Name().Path, "access", fmt.Sprintf("0x%08X", src.GrantedAccess))
+			"path", srcPath, "access", fmt.Sprintf("0x%08X", src.GrantedAccess))
 		return types.StatusAccessDenied
 	}
 
 	// Destination must have write or append
 	if dstAccess&types.FileWriteData == 0 && dstAccess&types.FileAppendData == 0 {
 		logger.Debug("COPYCHUNK: destination lacks write access",
-			"path", dst.Name().Path, "access", fmt.Sprintf("0x%08X", dst.GrantedAccess))
+			"path", dstPath, "access", fmt.Sprintf("0x%08X", dst.GrantedAccess))
 		return types.StatusAccessDenied
 	}
 
 	// FSCTL_SRV_COPYCHUNK (not _WRITE) also requires read on destination
 	if ctlCode == FsctlSrvCopyChunk && dstAccess&types.FileReadData == 0 {
 		logger.Debug("COPYCHUNK: destination lacks read access (required for non-WRITE variant)",
-			"path", dst.Name().Path, "access", fmt.Sprintf("0x%08X", dst.GrantedAccess))
+			"path", dstPath, "access", fmt.Sprintf("0x%08X", dst.GrantedAccess))
 		return types.StatusAccessDenied
 	}
 
@@ -357,25 +358,27 @@ func (h *Handler) executeCopyChunks(
 	srcOpen, dstOpen *OpenFile,
 	chunks []copyChunk,
 ) (*HandlerResult, error) {
+	srcPath, dstPath := srcOpen.Name().Path, dstOpen.Name().Path
+
 	metaSvc := h.Registry.GetMetadataService()
 
 	// Get source block store and file metadata
 	srcBlockStore, err := h.Registry.GetBlockStoreForShare(srcOpen.ShareName)
 	if err != nil {
-		logger.Warn("COPYCHUNK: source block store unavailable", "path", srcOpen.Name().Path, "error", err)
+		logger.Warn("COPYCHUNK: source block store unavailable", "path", srcPath, "error", err)
 		return NewErrorResult(types.StatusInternalError), nil
 	}
 
 	srcFile, err := metaSvc.GetFileForRead(ctx.Context, srcOpen.MetadataHandle)
 	if err != nil {
-		logger.Debug("COPYCHUNK: failed to get source file", "path", srcOpen.Name().Path, "error", err)
+		logger.Debug("COPYCHUNK: failed to get source file", "path", srcPath, "error", err)
 		return NewErrorResult(common.MapToSMB(err)), nil
 	}
 
 	// Get destination block store
 	dstBlockStore, err := h.Registry.GetBlockStoreForShare(dstOpen.ShareName)
 	if err != nil {
-		logger.Warn("COPYCHUNK: destination block store unavailable", "path", dstOpen.Name().Path, "error", err)
+		logger.Warn("COPYCHUNK: destination block store unavailable", "path", dstPath, "error", err)
 		return NewErrorResult(types.StatusInternalError), nil
 	}
 
@@ -407,7 +410,7 @@ func (h *Handler) executeCopyChunks(
 	if h.LeaseManager != nil {
 		lockFileHandle := lock.FileHandle(dstOpen.MetadataHandle)
 		if breakErr := h.LeaseManager.BreakReadLeasesOnWrite(lockFileHandle, dstOpen.ShareName, dstOpen.LeaseKey); breakErr != nil {
-			logger.Debug("COPYCHUNK: oplock break failed (non-fatal)", "path", dstOpen.Name().Path, "error", breakErr)
+			logger.Debug("COPYCHUNK: oplock break failed (non-fatal)", "path", dstPath, "error", breakErr)
 		}
 	}
 
@@ -439,7 +442,7 @@ func (h *Handler) executeCopyChunks(
 		// durability from the journal reconcile on restart; CLOSE/FLUSH stay strict.
 		if _, flushErr := metaSvc.FlushPendingWriteForFile(authCtx, dstOpen.MetadataHandle, false); flushErr != nil {
 			logger.Debug("COPYCHUNK: deferred metadata flush failed (non-fatal)",
-				"dstPath", dstOpen.Name().Path, "error", flushErr)
+				"dstPath", dstPath, "error", flushErr)
 		}
 	}
 
@@ -483,7 +486,7 @@ func (h *Handler) executeCopyChunks(
 		n, err := srcBlockStore.ReadAt(ctx.Context, srcPayloadID, nil, data, chunk.SourceOffset)
 		if err != nil {
 			logger.Warn("COPYCHUNK: source read failed",
-				"chunk", i, "srcPath", srcOpen.Name().Path, "error", err)
+				"chunk", i, "srcPath", srcPath, "error", err)
 			// COPYCHUNK source read is a content-path op: MapContentToSMB
 			// maps a closed-store error (source share removed
 			// mid-copy) to STATUS_FILE_CLOSED and preserves the
@@ -511,7 +514,7 @@ func (h *Handler) executeCopyChunks(
 		writeOp, err := metaSvc.PrepareWrite(authCtx, dstOpen.MetadataHandle, newSize)
 		if err != nil {
 			logger.Warn("COPYCHUNK: prepare write failed",
-				"chunk", i, "dstPath", dstOpen.Name().Path, "error", err)
+				"chunk", i, "dstPath", dstPath, "error", err)
 			flushCommitted()
 			return copyChunkPartialResponse(ctlCode, dstFileID,
 				common.MapToSMB(err), chunksWritten, totalBytesWritten), nil
@@ -523,7 +526,7 @@ func (h *Handler) executeCopyChunks(
 		// thread the destination's FileAttr.Blocks update.
 		if _, err := dstBlockStore.WriteAt(ctx.Context, string(writeOp.PayloadID), nil, data, chunk.TargetOffset); err != nil {
 			logger.Warn("COPYCHUNK: destination write failed",
-				"chunk", i, "dstPath", dstOpen.Name().Path, "error", err)
+				"chunk", i, "dstPath", dstPath, "error", err)
 			// COPYCHUNK destination write is a content-path op:
 			// MapContentToSMB maps a closed-store error (dest share removed
 			// mid-copy) to STATUS_FILE_CLOSED and preserves the
@@ -537,7 +540,7 @@ func (h *Handler) executeCopyChunks(
 		// Commit write metadata
 		if _, err := metaSvc.CommitWrite(authCtx, writeOp); err != nil {
 			logger.Warn("COPYCHUNK: commit write failed",
-				"chunk", i, "dstPath", dstOpen.Name().Path, "error", err)
+				"chunk", i, "dstPath", dstPath, "error", err)
 			flushCommitted()
 			return copyChunkPartialResponse(ctlCode, dstFileID,
 				types.StatusInternalError, chunksWritten, totalBytesWritten), nil
@@ -573,7 +576,7 @@ func (h *Handler) executeCopyChunks(
 	}
 
 	logger.Debug("COPYCHUNK: completed successfully",
-		"srcPath", srcOpen.Name().Path, "dstPath", dstOpen.Name().Path,
+		"srcPath", srcPath, "dstPath", dstPath,
 		"chunks", chunksWritten, "totalBytes", totalBytesWritten)
 
 	return copyChunkSuccessResponse(ctlCode, dstFileID, chunksWritten, totalBytesWritten), nil

--- a/internal/adapter/smb/handlers/ioctl_copychunk_sparse_integration_test.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk_sparse_integration_test.go
@@ -150,30 +150,26 @@ func TestCopyChunk_SparseDest_LeadingGapReadsZeros(t *testing.T) {
 	const treeID uint32 = 1
 	h.StoreTree(&TreeConnection{TreeID: treeID, SessionID: sess.SessionID, ShareName: shareName})
 
-	srcOpen := &OpenFile{
+	srcOpen := (&OpenFile{
 		FileID:         [16]byte{1},
 		TreeID:         treeID,
 		SessionID:      sess.SessionID,
-		Path:           "src",
 		ShareName:      shareName,
 		DesiredAccess:  uint32(types.FileReadData | types.FileWriteData),
 		GrantedAccess:  uint32(types.FileReadData | types.FileWriteData),
 		MetadataHandle: srcHandle,
 		PayloadID:      srcFile.PayloadID,
-	}
-	dstOpen := &OpenFile{
+	}).WithName(OpenName{Path: "src"})
+	dstOpen := (&OpenFile{
 		FileID:         [16]byte{2},
 		TreeID:         treeID,
 		SessionID:      sess.SessionID,
-		Path:           "dst",
 		ShareName:      shareName,
 		DesiredAccess:  uint32(types.FileReadData | types.FileWriteData),
 		GrantedAccess:  uint32(types.FileReadData | types.FileWriteData),
 		MetadataHandle: dstHandle,
 		PayloadID:      dstFile.PayloadID,
-		ParentHandle:   rootHandle,
-		FileName:       "dst",
-	}
+	}).WithName(OpenName{Path: "dst", FileName: "dst", ParentHandle: rootHandle})
 	h.StoreOpenFile(srcOpen)
 	h.StoreOpenFile(dstOpen)
 
@@ -355,17 +351,16 @@ func TestCopyChunk_SparseDest_SurvivesPriorPayloadReuse(t *testing.T) {
 	const treeID uint32 = 1
 	h.StoreTree(&TreeConnection{TreeID: treeID, SessionID: sess.SessionID, ShareName: shareName})
 
-	srcOpen := &OpenFile{
+	srcOpen := (&OpenFile{
 		FileID:         [16]byte{1},
 		TreeID:         treeID,
 		SessionID:      sess.SessionID,
-		Path:           "src",
 		ShareName:      shareName,
 		DesiredAccess:  uint32(types.FileReadData | types.FileWriteData),
 		GrantedAccess:  uint32(types.FileReadData | types.FileWriteData),
 		MetadataHandle: srcHandle,
 		PayloadID:      srcFile.PayloadID,
-	}
+	}).WithName(OpenName{Path: "src"})
 	h.StoreOpenFile(srcOpen)
 
 	smbCtx := &SMBHandlerContext{
@@ -392,19 +387,16 @@ func TestCopyChunk_SparseDest_SurvivesPriorPayloadReuse(t *testing.T) {
 		if err != nil {
 			t.Fatalf("EncodeFileHandle dst: %v", err)
 		}
-		of := &OpenFile{
+		of := (&OpenFile{
 			FileID:         fileID,
 			TreeID:         treeID,
 			SessionID:      sess.SessionID,
-			Path:           "dst",
 			ShareName:      shareName,
 			DesiredAccess:  uint32(types.FileReadData | types.FileWriteData | types.Delete),
 			GrantedAccess:  uint32(types.FileReadData | types.FileWriteData | types.Delete),
 			MetadataHandle: dstHandle,
 			PayloadID:      dstFile.PayloadID,
-			ParentHandle:   rootHandle,
-			FileName:       "dst",
-		}
+		}).WithName(OpenName{Path: "dst", FileName: "dst", ParentHandle: rootHandle})
 		h.StoreOpenFile(of)
 		return of, dstHandle
 	}

--- a/internal/adapter/smb/handlers/ioctl_fsctl.go
+++ b/internal/adapter/smb/handlers/ioctl_fsctl.go
@@ -71,7 +71,7 @@ func (h *Handler) handleSetCompression(ctx *SMBHandlerContext, body []byte) (*Ha
 	// FILE_WRITE_DATA bit check matches Samba's semantics.
 	if openFile.GrantedAccess&uint32(types.FileWriteData) == 0 {
 		logger.Debug("IOCTL FSCTL_SET_COMPRESSION: missing FILE_WRITE_DATA",
-			"path", openFile.Path,
+			"path", openFile.Name().Path,
 			"grantedAccess", fmt.Sprintf("0x%x", openFile.GrantedAccess))
 		return NewErrorResult(types.StatusAccessDenied), nil
 	}
@@ -175,7 +175,7 @@ func (h *Handler) buildObjectIDResponse(ctlCode uint32, body []byte) (*HandlerRe
 		return NewErrorResult(types.StatusInvalidParameter), nil
 	}
 
-	logger.Debug("IOCTL object ID", "ctlCode", ctlCode, "path", openFile.Path)
+	logger.Debug("IOCTL object ID", "ctlCode", ctlCode, "path", openFile.Name().Path)
 
 	// FILE_OBJECTID_BUFFER: ObjectId(16) + BirthVolumeId(16) + BirthObjectId(16) + DomainId(16)
 	output := make([]byte, 64)
@@ -203,7 +203,7 @@ func (h *Handler) handleMarkHandle(ctx *SMBHandlerContext, body []byte) (*Handle
 		return NewErrorResult(types.StatusFileClosed), nil
 	}
 
-	logger.Debug("IOCTL FSCTL_MARK_HANDLE", "path", openFile.Path, "isDir", openFile.IsDirectory)
+	logger.Debug("IOCTL FSCTL_MARK_HANDLE", "path", openFile.Name().Path, "isDir", openFile.IsDirectory)
 
 	// Per MS-FSA 2.1.5.9.20: if StreamType == DirectoryStream, fail
 	if openFile.IsDirectory {
@@ -227,7 +227,7 @@ func (h *Handler) handleQueryFileRegions(ctx *SMBHandlerContext, body []byte) (*
 		return NewErrorResult(types.StatusFileClosed), nil
 	}
 
-	logger.Debug("IOCTL FSCTL_QUERY_FILE_REGIONS", "path", openFile.Path)
+	logger.Debug("IOCTL FSCTL_QUERY_FILE_REGIONS", "path", openFile.Name().Path)
 
 	// Get file size from metadata
 	metaSvc := h.Registry.GetMetadataService()

--- a/internal/adapter/smb/handlers/ioctl_set_compression_test.go
+++ b/internal/adapter/smb/handlers/ioctl_set_compression_test.go
@@ -54,13 +54,12 @@ func TestHandleSetCompression_AccessGate_DeniesWithoutWriteData(t *testing.T) {
 	}
 
 	fileID := [16]byte{0x01, 0x02, 0x03, 0x04}
-	h.StoreOpenFile(&OpenFile{
+	h.StoreOpenFile((&OpenFile{
 		FileID: fileID,
-		Path:   "compress_perms_no_write_data",
 		// FILE_APPEND_DATA | FILE_WRITE_ATTRIBUTES — the smbtorture-shaped
 		// mask that strips FILE_WRITE_DATA from SEC_RIGHTS_FILE_WRITE.
 		GrantedAccess: uint32(types.FileAppendData) | uint32(types.FileWriteAttributes),
-	})
+	}).WithName(OpenName{Path: "compress_perms_no_write_data"}))
 
 	// CompressionFormat=COMPRESSION_FORMAT_DEFAULT (matches one of the two
 	// formats smbtorture submits before asserting ACCESS_DENIED).
@@ -89,11 +88,10 @@ func TestHandleSetCompression_AccessGate_DeniesReadOnly(t *testing.T) {
 	}
 
 	fileID := [16]byte{0x05, 0x06, 0x07, 0x08}
-	h.StoreOpenFile(&OpenFile{
+	h.StoreOpenFile((&OpenFile{
 		FileID:        fileID,
-		Path:          "compress_perms_read_only",
 		GrantedAccess: uint32(types.FileReadData) | uint32(types.FileReadAttributes),
-	})
+	}).WithName(OpenName{Path: "compress_perms_read_only"}))
 
 	body := buildSetCompressionRequest(fileID, []byte{0x00, 0x00}) // COMPRESSION_FORMAT_NONE
 
@@ -123,11 +121,10 @@ func TestHandleSetCompression_AccessGate_PassesWithWriteData(t *testing.T) {
 	}
 
 	fileID := [16]byte{0x09, 0x0A, 0x0B, 0x0C}
-	h.StoreOpenFile(&OpenFile{
+	h.StoreOpenFile((&OpenFile{
 		FileID:        fileID,
-		Path:          "compress_perms_with_write_data",
 		GrantedAccess: uint32(types.FileWriteData),
-	})
+	}).WithName(OpenName{Path: "compress_perms_with_write_data"}))
 
 	// Zero-length InputBuffer — gate must pass first, then
 	// parseIoctlInputData rejects on len < 2.

--- a/internal/adapter/smb/handlers/ioctl_smbtorture_test.go
+++ b/internal/adapter/smb/handlers/ioctl_smbtorture_test.go
@@ -143,7 +143,7 @@ func TestIoctl_SmbtortureFspAsyncSleep_RespectsSleepDuration(t *testing.T) {
 	}
 
 	fileID := [16]byte{0xAB, 0xCD, 0xEF}
-	h.StoreOpenFile(&OpenFile{FileID: fileID, Path: "bug14769"})
+	h.StoreOpenFile((&OpenFile{FileID: fileID}).WithName(OpenName{Path: "bug14769"}))
 
 	const delayMs uint8 = 30
 	body := buildSmbtortureFspAsyncSleepRequest(fileID, delayMs)
@@ -174,7 +174,7 @@ func TestIoctl_SmbtortureFspAsyncSleep_BadInputLengthInvalidParameter(t *testing
 	}
 
 	fileID := [16]byte{0x11, 0x22, 0x33}
-	h.StoreOpenFile(&OpenFile{FileID: fileID, Path: "bad-input"})
+	h.StoreOpenFile((&OpenFile{FileID: fileID}).WithName(OpenName{Path: "bad-input"}))
 
 	// 0-byte InputBuffer (InputCount=0). Envelope is just the fixed 56 bytes.
 	body := buildSmbtortureIoctlRequest(FsctlSmbtortureFspAsyncSleep)

--- a/internal/adapter/smb/handlers/ioctl_sparse.go
+++ b/internal/adapter/smb/handlers/ioctl_sparse.go
@@ -57,12 +57,13 @@ func (h *Handler) handleSetSparse(ctx *SMBHandlerContext, body []byte) (*Handler
 		logger.Debug("IOCTL FSCTL_SET_SPARSE: file handle not found", "fileID", fmt.Sprintf("%x", fileID))
 		return NewErrorResult(types.StatusFileClosed), nil
 	}
+	path := openFile.Name().Path
 
 	// FSCTL_SET_SPARSE is a file-only operation. Directories take
 	// STATUS_INVALID_PARAMETER per MS-FSA §2.1.5.9.36 and Windows behaviour.
 	if openFile.IsDirectory {
 		logger.Debug("IOCTL FSCTL_SET_SPARSE: rejected on directory",
-			"path", openFile.Name().Path)
+			"path", path)
 		return NewErrorResult(types.StatusInvalidParameter), nil
 	}
 
@@ -77,7 +78,7 @@ func (h *Handler) handleSetSparse(ctx *SMBHandlerContext, body []byte) (*Handler
 		uint32(types.FileWriteAttributes)
 	if openFile.GrantedAccess&setSparseGate == 0 {
 		logger.Debug("IOCTL FSCTL_SET_SPARSE: handle lacks WRITE_DATA/APPEND_DATA/WRITE_ATTRIBUTES",
-			"path", openFile.Name().Path,
+			"path", path,
 			"granted", fmt.Sprintf("0x%08X", openFile.GrantedAccess))
 		return NewErrorResult(types.StatusAccessDenied), nil
 	}
@@ -104,12 +105,12 @@ func (h *Handler) handleSetSparse(ctx *SMBHandlerContext, body []byte) (*Handler
 	attrs := modeBitMaskAttrs(modeDOSSparse, setSparse)
 	if _, err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &attrs); err != nil {
 		logger.Warn("IOCTL FSCTL_SET_SPARSE: failed to persist mode",
-			"path", openFile.Name().Path, "error", err)
+			"path", path, "error", err)
 		return NewErrorResult(common.MapToSMB(err)), nil
 	}
 
 	logger.Debug("IOCTL FSCTL_SET_SPARSE: applied",
-		"path", openFile.Name().Path, "sparse", setSparse)
+		"path", path, "sparse", setSparse)
 	resp := buildIoctlResponse(FsctlSetSparse, fileID, nil)
 	return NewResult(types.StatusSuccess, resp), nil
 }
@@ -146,11 +147,12 @@ func (h *Handler) handleQueryAllocatedRanges(ctx *SMBHandlerContext, body []byte
 		logger.Debug("IOCTL FSCTL_QUERY_ALLOCATED_RANGES: file handle not found", "fileID", fmt.Sprintf("%x", fileID))
 		return NewErrorResult(types.StatusFileClosed), nil
 	}
+	path := openFile.Name().Path
 
 	// MS-FSA §2.1.5.10.4 / Samba `fsctl_qar`: requires FILE_READ_DATA.
 	if openFile.GrantedAccess&uint32(types.FileReadData) == 0 {
 		logger.Debug("IOCTL FSCTL_QUERY_ALLOCATED_RANGES: handle lacks FILE_READ_DATA",
-			"path", openFile.Name().Path,
+			"path", path,
 			"granted", fmt.Sprintf("0x%08X", openFile.GrantedAccess))
 		return NewErrorResult(types.StatusAccessDenied), nil
 	}
@@ -202,7 +204,7 @@ func (h *Handler) handleQueryAllocatedRanges(ctx *SMBHandlerContext, body []byte
 			ranges, err = h.scanAllocatedRanges(authCtx, openFile, &file.FileAttr, allocStart, allocEnd)
 			if err != nil {
 				logger.Warn("IOCTL FSCTL_QUERY_ALLOCATED_RANGES: scan failed",
-					"path", openFile.Name().Path, "error", err)
+					"path", path, "error", err)
 				return NewErrorResult(common.MapContentToSMB(err)), nil
 			}
 		} else {
@@ -223,7 +225,7 @@ func (h *Handler) handleQueryAllocatedRanges(ctx *SMBHandlerContext, body []byte
 	// STATUS_BUFFER_TOO_SMALL. Samba fsctl_qar gates the same way.
 	if maxOut < fileAllocatedRangeBufSize {
 		logger.Debug("IOCTL FSCTL_QUERY_ALLOCATED_RANGES: buffer too small",
-			"path", openFile.Name().Path, "maxOut", maxOut)
+			"path", path, "maxOut", maxOut)
 		return NewErrorResult(types.StatusBufferTooSmall), nil
 	}
 
@@ -374,6 +376,7 @@ func (h *Handler) handleSetZeroData(ctx *SMBHandlerContext, body []byte) (*Handl
 		logger.Debug("IOCTL FSCTL_SET_ZERO_DATA: file handle not found", "fileID", fmt.Sprintf("%x", fileID))
 		return NewErrorResult(types.StatusFileClosed), nil
 	}
+	path := openFile.Name().Path
 	if openFile.IsDirectory || openFile.IsPipe {
 		return NewErrorResult(types.StatusInvalidDeviceRequest), nil
 	}
@@ -381,7 +384,7 @@ func (h *Handler) handleSetZeroData(ctx *SMBHandlerContext, body []byte) (*Handl
 	// MS-FSA §2.1.5.10.35: SET_ZERO_DATA requires FILE_WRITE_DATA.
 	if openFile.GrantedAccess&uint32(types.FileWriteData) == 0 {
 		logger.Debug("IOCTL FSCTL_SET_ZERO_DATA: handle lacks FILE_WRITE_DATA",
-			"path", openFile.Name().Path,
+			"path", path,
 			"granted", fmt.Sprintf("0x%08X", openFile.GrantedAccess))
 		return NewErrorResult(types.StatusAccessDenied), nil
 	}
@@ -406,7 +409,7 @@ func (h *Handler) handleSetZeroData(ctx *SMBHandlerContext, body []byte) (*Handl
 	}
 	if beyond > zeroDataMaxFileSize {
 		logger.Debug("IOCTL FSCTL_SET_ZERO_DATA: range exceeds MAXFILESIZE",
-			"path", openFile.Name().Path, "beyond", beyond)
+			"path", path, "beyond", beyond)
 		return NewErrorResult(types.StatusInvalidParameter), nil
 	}
 
@@ -451,7 +454,7 @@ func (h *Handler) handleSetZeroData(ctx *SMBHandlerContext, body []byte) (*Handl
 		true, // isWrite
 	); err != nil {
 		logger.Debug("IOCTL FSCTL_SET_ZERO_DATA: blocked by lock",
-			"path", openFile.Name().Path, "offset", fileOffset, "length", beyond-fileOffset)
+			"path", path, "offset", fileOffset, "length", beyond-fileOffset)
 		return NewErrorResult(types.StatusFileLockConflict), nil
 	}
 
@@ -462,7 +465,7 @@ func (h *Handler) handleSetZeroData(ctx *SMBHandlerContext, body []byte) (*Handl
 		lockFileHandle := lock.FileHandle(openFile.MetadataHandle)
 		if breakErr := h.LeaseManager.BreakReadLeasesOnWrite(lockFileHandle, openFile.ShareName, openFile.LeaseKey); breakErr != nil {
 			logger.Debug("IOCTL FSCTL_SET_ZERO_DATA: oplock break failed (non-fatal)",
-				"path", openFile.Name().Path, "error", breakErr)
+				"path", path, "error", breakErr)
 		}
 	}
 
@@ -471,7 +474,7 @@ func (h *Handler) handleSetZeroData(ctx *SMBHandlerContext, body []byte) (*Handl
 			return NewErrorResult(types.StatusCancelled), nil
 		}
 		logger.Warn("IOCTL FSCTL_SET_ZERO_DATA: write failed",
-			"path", openFile.Name().Path, "error", err)
+			"path", path, "error", err)
 		return NewErrorResult(common.MapContentToSMB(err)), nil
 	}
 
@@ -482,7 +485,7 @@ func (h *Handler) handleSetZeroData(ctx *SMBHandlerContext, body []byte) (*Handl
 	// journal size reconcile on restart; CLOSE/FLUSH remain strict.
 	if _, flushErr := metaSvc.FlushPendingWriteForFile(authCtx, openFile.MetadataHandle, false); flushErr != nil {
 		logger.Debug("IOCTL FSCTL_SET_ZERO_DATA: deferred metadata flush failed (non-fatal)",
-			"path", openFile.Name().Path, "error", flushErr)
+			"path", path, "error", flushErr)
 	}
 
 	resp := buildIoctlResponse(FsctlSetZeroData, fileID, nil)

--- a/internal/adapter/smb/handlers/ioctl_sparse.go
+++ b/internal/adapter/smb/handlers/ioctl_sparse.go
@@ -62,7 +62,7 @@ func (h *Handler) handleSetSparse(ctx *SMBHandlerContext, body []byte) (*Handler
 	// STATUS_INVALID_PARAMETER per MS-FSA §2.1.5.9.36 and Windows behaviour.
 	if openFile.IsDirectory {
 		logger.Debug("IOCTL FSCTL_SET_SPARSE: rejected on directory",
-			"path", openFile.Path)
+			"path", openFile.Name().Path)
 		return NewErrorResult(types.StatusInvalidParameter), nil
 	}
 
@@ -77,7 +77,7 @@ func (h *Handler) handleSetSparse(ctx *SMBHandlerContext, body []byte) (*Handler
 		uint32(types.FileWriteAttributes)
 	if openFile.GrantedAccess&setSparseGate == 0 {
 		logger.Debug("IOCTL FSCTL_SET_SPARSE: handle lacks WRITE_DATA/APPEND_DATA/WRITE_ATTRIBUTES",
-			"path", openFile.Path,
+			"path", openFile.Name().Path,
 			"granted", fmt.Sprintf("0x%08X", openFile.GrantedAccess))
 		return NewErrorResult(types.StatusAccessDenied), nil
 	}
@@ -104,12 +104,12 @@ func (h *Handler) handleSetSparse(ctx *SMBHandlerContext, body []byte) (*Handler
 	attrs := modeBitMaskAttrs(modeDOSSparse, setSparse)
 	if _, err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &attrs); err != nil {
 		logger.Warn("IOCTL FSCTL_SET_SPARSE: failed to persist mode",
-			"path", openFile.Path, "error", err)
+			"path", openFile.Name().Path, "error", err)
 		return NewErrorResult(common.MapToSMB(err)), nil
 	}
 
 	logger.Debug("IOCTL FSCTL_SET_SPARSE: applied",
-		"path", openFile.Path, "sparse", setSparse)
+		"path", openFile.Name().Path, "sparse", setSparse)
 	resp := buildIoctlResponse(FsctlSetSparse, fileID, nil)
 	return NewResult(types.StatusSuccess, resp), nil
 }
@@ -150,7 +150,7 @@ func (h *Handler) handleQueryAllocatedRanges(ctx *SMBHandlerContext, body []byte
 	// MS-FSA §2.1.5.10.4 / Samba `fsctl_qar`: requires FILE_READ_DATA.
 	if openFile.GrantedAccess&uint32(types.FileReadData) == 0 {
 		logger.Debug("IOCTL FSCTL_QUERY_ALLOCATED_RANGES: handle lacks FILE_READ_DATA",
-			"path", openFile.Path,
+			"path", openFile.Name().Path,
 			"granted", fmt.Sprintf("0x%08X", openFile.GrantedAccess))
 		return NewErrorResult(types.StatusAccessDenied), nil
 	}
@@ -202,7 +202,7 @@ func (h *Handler) handleQueryAllocatedRanges(ctx *SMBHandlerContext, body []byte
 			ranges, err = h.scanAllocatedRanges(authCtx, openFile, &file.FileAttr, allocStart, allocEnd)
 			if err != nil {
 				logger.Warn("IOCTL FSCTL_QUERY_ALLOCATED_RANGES: scan failed",
-					"path", openFile.Path, "error", err)
+					"path", openFile.Name().Path, "error", err)
 				return NewErrorResult(common.MapContentToSMB(err)), nil
 			}
 		} else {
@@ -223,7 +223,7 @@ func (h *Handler) handleQueryAllocatedRanges(ctx *SMBHandlerContext, body []byte
 	// STATUS_BUFFER_TOO_SMALL. Samba fsctl_qar gates the same way.
 	if maxOut < fileAllocatedRangeBufSize {
 		logger.Debug("IOCTL FSCTL_QUERY_ALLOCATED_RANGES: buffer too small",
-			"path", openFile.Path, "maxOut", maxOut)
+			"path", openFile.Name().Path, "maxOut", maxOut)
 		return NewErrorResult(types.StatusBufferTooSmall), nil
 	}
 
@@ -381,7 +381,7 @@ func (h *Handler) handleSetZeroData(ctx *SMBHandlerContext, body []byte) (*Handl
 	// MS-FSA §2.1.5.10.35: SET_ZERO_DATA requires FILE_WRITE_DATA.
 	if openFile.GrantedAccess&uint32(types.FileWriteData) == 0 {
 		logger.Debug("IOCTL FSCTL_SET_ZERO_DATA: handle lacks FILE_WRITE_DATA",
-			"path", openFile.Path,
+			"path", openFile.Name().Path,
 			"granted", fmt.Sprintf("0x%08X", openFile.GrantedAccess))
 		return NewErrorResult(types.StatusAccessDenied), nil
 	}
@@ -406,7 +406,7 @@ func (h *Handler) handleSetZeroData(ctx *SMBHandlerContext, body []byte) (*Handl
 	}
 	if beyond > zeroDataMaxFileSize {
 		logger.Debug("IOCTL FSCTL_SET_ZERO_DATA: range exceeds MAXFILESIZE",
-			"path", openFile.Path, "beyond", beyond)
+			"path", openFile.Name().Path, "beyond", beyond)
 		return NewErrorResult(types.StatusInvalidParameter), nil
 	}
 
@@ -451,7 +451,7 @@ func (h *Handler) handleSetZeroData(ctx *SMBHandlerContext, body []byte) (*Handl
 		true, // isWrite
 	); err != nil {
 		logger.Debug("IOCTL FSCTL_SET_ZERO_DATA: blocked by lock",
-			"path", openFile.Path, "offset", fileOffset, "length", beyond-fileOffset)
+			"path", openFile.Name().Path, "offset", fileOffset, "length", beyond-fileOffset)
 		return NewErrorResult(types.StatusFileLockConflict), nil
 	}
 
@@ -462,7 +462,7 @@ func (h *Handler) handleSetZeroData(ctx *SMBHandlerContext, body []byte) (*Handl
 		lockFileHandle := lock.FileHandle(openFile.MetadataHandle)
 		if breakErr := h.LeaseManager.BreakReadLeasesOnWrite(lockFileHandle, openFile.ShareName, openFile.LeaseKey); breakErr != nil {
 			logger.Debug("IOCTL FSCTL_SET_ZERO_DATA: oplock break failed (non-fatal)",
-				"path", openFile.Path, "error", breakErr)
+				"path", openFile.Name().Path, "error", breakErr)
 		}
 	}
 
@@ -471,7 +471,7 @@ func (h *Handler) handleSetZeroData(ctx *SMBHandlerContext, body []byte) (*Handl
 			return NewErrorResult(types.StatusCancelled), nil
 		}
 		logger.Warn("IOCTL FSCTL_SET_ZERO_DATA: write failed",
-			"path", openFile.Path, "error", err)
+			"path", openFile.Name().Path, "error", err)
 		return NewErrorResult(common.MapContentToSMB(err)), nil
 	}
 
@@ -482,7 +482,7 @@ func (h *Handler) handleSetZeroData(ctx *SMBHandlerContext, body []byte) (*Handl
 	// journal size reconcile on restart; CLOSE/FLUSH remain strict.
 	if _, flushErr := metaSvc.FlushPendingWriteForFile(authCtx, openFile.MetadataHandle, false); flushErr != nil {
 		logger.Debug("IOCTL FSCTL_SET_ZERO_DATA: deferred metadata flush failed (non-fatal)",
-			"path", openFile.Path, "error", flushErr)
+			"path", openFile.Name().Path, "error", flushErr)
 	}
 
 	resp := buildIoctlResponse(FsctlSetZeroData, fileID, nil)

--- a/internal/adapter/smb/handlers/ioctl_sparse_test.go
+++ b/internal/adapter/smb/handlers/ioctl_sparse_test.go
@@ -65,13 +65,12 @@ func TestSetSparse_AccessDenied(t *testing.T) {
 	for i := range fileID {
 		fileID[i] = byte(0x10 + i)
 	}
-	h.StoreOpenFile(&OpenFile{
+	h.StoreOpenFile((&OpenFile{
 		FileID:        fileID,
-		Path:          "/sparse_perms",
 		ShareName:     "share1",
 		DesiredAccess: uint32(types.FileReadData),
 		GrantedAccess: uint32(types.FileReadData),
-	})
+	}).WithName(OpenName{Path: "/sparse_perms"}))
 	ctx := &SMBHandlerContext{Context: context.Background()}
 
 	body := buildSparseIoctlRequest(FsctlSetSparse, fileID, nil)
@@ -93,14 +92,13 @@ func TestSetSparse_DirectoryRejected(t *testing.T) {
 	for i := range fileID {
 		fileID[i] = byte(0x20 + i)
 	}
-	h.StoreOpenFile(&OpenFile{
+	h.StoreOpenFile((&OpenFile{
 		FileID:        fileID,
-		Path:          "/sparse_dir",
 		ShareName:     "share1",
 		DesiredAccess: uint32(types.FileWriteData),
 		GrantedAccess: uint32(types.FileWriteData),
 		IsDirectory:   true,
-	})
+	}).WithName(OpenName{Path: "/sparse_dir"}))
 	ctx := &SMBHandlerContext{Context: context.Background()}
 
 	body := buildSparseIoctlRequest(FsctlSetSparse, fileID, nil)
@@ -126,13 +124,12 @@ func TestQueryAllocatedRanges_MalformedInput(t *testing.T) {
 	for i := range fileID {
 		fileID[i] = byte(0x40 + i)
 	}
-	h.StoreOpenFile(&OpenFile{
+	h.StoreOpenFile((&OpenFile{
 		FileID:        fileID,
-		Path:          "/qar_malformed",
 		ShareName:     "share1",
 		DesiredAccess: uint32(types.FileReadData),
 		GrantedAccess: uint32(types.FileReadData),
-	})
+	}).WithName(OpenName{Path: "/qar_malformed"}))
 	ctx := &SMBHandlerContext{Context: context.Background()}
 
 	// 8 bytes is half the required size.
@@ -155,13 +152,12 @@ func TestQueryAllocatedRanges_NegativeOffset(t *testing.T) {
 	for i := range fileID {
 		fileID[i] = byte(0x50 + i)
 	}
-	h.StoreOpenFile(&OpenFile{
+	h.StoreOpenFile((&OpenFile{
 		FileID:        fileID,
-		Path:          "/qar_ob1",
 		ShareName:     "share1",
 		DesiredAccess: uint32(types.FileReadData),
 		GrantedAccess: uint32(types.FileReadData),
-	})
+	}).WithName(OpenName{Path: "/qar_ob1"}))
 	ctx := &SMBHandlerContext{Context: context.Background()}
 
 	// Set high bit on FileOffset (negative when treated as int64).
@@ -187,13 +183,12 @@ func TestSetZeroData_AccessDenied(t *testing.T) {
 	for i := range fileID {
 		fileID[i] = byte(0x60 + i)
 	}
-	h.StoreOpenFile(&OpenFile{
+	h.StoreOpenFile((&OpenFile{
 		FileID:        fileID,
-		Path:          "/zero_perms",
 		ShareName:     "share1",
 		DesiredAccess: uint32(types.FileReadData),
 		GrantedAccess: uint32(types.FileReadData),
-	})
+	}).WithName(OpenName{Path: "/zero_perms"}))
 	ctx := &SMBHandlerContext{Context: context.Background()}
 
 	input := make([]byte, 16) // 16 zero bytes — fileOffset = beyond = 0
@@ -215,13 +210,12 @@ func TestSetZeroData_InverseRange(t *testing.T) {
 	for i := range fileID {
 		fileID[i] = byte(0x70 + i)
 	}
-	h.StoreOpenFile(&OpenFile{
+	h.StoreOpenFile((&OpenFile{
 		FileID:        fileID,
-		Path:          "/zero_inverse",
 		ShareName:     "share1",
 		DesiredAccess: uint32(types.FileWriteData),
 		GrantedAccess: uint32(types.FileWriteData),
-	})
+	}).WithName(OpenName{Path: "/zero_inverse"}))
 	ctx := &SMBHandlerContext{Context: context.Background()}
 
 	// FileOffset = 100, BeyondFinalZero = 50.
@@ -248,13 +242,12 @@ func TestSetZeroData_ZeroLengthIsNoop(t *testing.T) {
 	for i := range fileID {
 		fileID[i] = byte(0x80 + i)
 	}
-	h.StoreOpenFile(&OpenFile{
+	h.StoreOpenFile((&OpenFile{
 		FileID:        fileID,
-		Path:          "/zero_noop",
 		ShareName:     "share1",
 		DesiredAccess: uint32(types.FileWriteData),
 		GrantedAccess: uint32(types.FileWriteData),
-	})
+	}).WithName(OpenName{Path: "/zero_noop"}))
 	ctx := &SMBHandlerContext{Context: context.Background()}
 
 	w := smbenc.NewWriter(16)

--- a/internal/adapter/smb/handlers/lock.go
+++ b/internal/adapter/smb/handlers/lock.go
@@ -239,7 +239,7 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 
 	// Pipes don't support locking
 	if openFile.IsPipe {
-		logger.Debug("LOCK: pipes don't support locking", "path", openFile.Path)
+		logger.Debug("LOCK: pipes don't support locking", "path", openFile.Name().Path)
 		return NewErrorResult(types.StatusInvalidDeviceRequest), nil
 	}
 
@@ -351,7 +351,7 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 		if breakErr := h.LeaseManager.BreakLeasesOnByteRangeLock(lockFileHandle, openFile.ShareName, &lock.LockOwner{
 			ExcludeLeaseKey: openFile.LeaseKey,
 		}); breakErr != nil {
-			logger.Debug("LOCK: lease break failed (non-fatal)", "path", openFile.Path, "error", breakErr)
+			logger.Debug("LOCK: lease break failed (non-fatal)", "path", openFile.Name().Path, "error", breakErr)
 		}
 	}
 

--- a/internal/adapter/smb/handlers/openfile_concurrency_test.go
+++ b/internal/adapter/smb/handlers/openfile_concurrency_test.go
@@ -70,13 +70,12 @@ func setupConcurrentDirTest(t *testing.T, nChildren int) (*Handler, *OpenFile, *
 	const treeID uint32 = 1
 	h.StoreTree(&TreeConnection{TreeID: treeID, ShareName: shareName})
 
-	open := &OpenFile{
+	open := (&OpenFile{
 		FileID:         h.GenerateFileID(),
 		TreeID:         treeID,
-		Path:           shareName,
 		IsDirectory:    true,
 		MetadataHandle: rootHandle,
-	}
+	}).WithName(OpenName{Path: shareName})
 	h.StoreOpenFile(open)
 
 	smbCtx := &SMBHandlerContext{
@@ -315,6 +314,51 @@ func TestBaseFileDeletePending_ConcurrentClose_NoRace(t *testing.T) {
 			stream.mu.RUnlock()
 		}
 	}()
+
+	wg.Wait()
+}
+
+// TestOpenName_ConcurrentRenameAndRead_NoRace pins the name triple: readers
+// racing a rename must never see a path from one rename against the file name
+// or parent handle of another, and must never trip the race detector.
+func TestOpenName_ConcurrentRenameAndRead_NoRace(t *testing.T) {
+	openFile := &OpenFile{}
+	openFile.SetName(OpenName{Path: "/dir0/f0", FileName: "f0", ParentHandle: metadata.FileHandle("p0")})
+
+	const iterations = 500
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := range iterations {
+			n := fmt.Sprintf("f%d", i)
+			openFile.SetName(OpenName{
+				Path:         fmt.Sprintf("/dir%d/%s", i, n),
+				FileName:     n,
+				ParentHandle: metadata.FileHandle(fmt.Sprintf("p%d", i)),
+			})
+		}
+	}()
+
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				name := openFile.Name()
+				suffix := name.FileName[1:]
+				if name.Path != "/dir"+suffix+"/"+name.FileName {
+					t.Errorf("torn name: path %q, fileName %q", name.Path, name.FileName)
+					return
+				}
+				if string(name.ParentHandle) != "p"+suffix {
+					t.Errorf("torn name: parent %q, fileName %q", name.ParentHandle, name.FileName)
+					return
+				}
+			}
+		}()
+	}
 
 	wg.Wait()
 }

--- a/internal/adapter/smb/handlers/query_directory.go
+++ b/internal/adapter/smb/handlers/query_directory.go
@@ -287,7 +287,7 @@ func (h *Handler) QueryDirectory(ctx *SMBHandlerContext, req *QueryDirectoryRequ
 	defer h.ReleaseOpenFile(req.FileID)
 
 	if !openFile.IsDirectory {
-		logger.Debug("QUERY_DIRECTORY: not a directory", "path", openFile.Path)
+		logger.Debug("QUERY_DIRECTORY: not a directory", "path", openFile.Name().Path)
 		return &QueryDirectoryResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}, nil
 	}
 
@@ -392,7 +392,7 @@ func (h *Handler) QueryDirectory(ctx *SMBHandlerContext, req *QueryDirectoryRequ
 	// (#728) where one handle deletes files mid-enumeration on another.
 	page, err := metaSvc.ReadDirectory(authCtx, openFile.MetadataHandle, 0, maxDirectoryReadBytes)
 	if err != nil {
-		logger.Debug("QUERY_DIRECTORY: failed to read directory", "path", openFile.Path, "error", err)
+		logger.Debug("QUERY_DIRECTORY: failed to read directory", "path", openFile.Name().Path, "error", err)
 		return &QueryDirectoryResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(err)}}, nil
 	}
 
@@ -587,7 +587,7 @@ doneLoop:
 	}
 
 	logger.Debug("QUERY_DIRECTORY successful",
-		"path", openFile.Path,
+		"path", openFile.Name().Path,
 		"bufferSize", len(result),
 		"entries", entriesReturned)
 

--- a/internal/adapter/smb/handlers/query_directory_accessbased_integration_test.go
+++ b/internal/adapter/smb/handlers/query_directory_accessbased_integration_test.go
@@ -230,18 +230,15 @@ func TestSetSecurityInfoThenQueryDirectory_AccessBasedHidesPartialMask(t *testin
 			// setSecurityInfo (handle must hold WRITE_DAC per
 			// MS-SMB2 §3.3.5.21.3) is satisfied. Mirrors smbtorture which
 			// opens with SEC_RIGHTS_FILE_ALL before the SETINFO.
-			fileOpen := &OpenFile{
+			fileOpen := (&OpenFile{
 				FileID:         h.GenerateFileID(),
 				TreeID:         smbCtx.TreeID,
 				SessionID:      smbCtx.SessionID,
 				ShareName:      "/hideunread",
 				MetadataHandle: childHandle,
-				ParentHandle:   baseDirHandle,
-				FileName:       "testfile",
-				Path:           "/hideunread/smb2-testsd/testfile",
 				DesiredAccess:  secRightsFileFull,
 				GrantedAccess:  secRightsFileFull,
-			}
+			}).WithName(OpenName{Path: "/hideunread/smb2-testsd/testfile", FileName: "testfile", ParentHandle: baseDirHandle})
 			h.StoreOpenFile(fileOpen)
 
 			// Build and apply the wire SD via the same handler entrypoint
@@ -277,18 +274,16 @@ func TestSetSecurityInfoThenQueryDirectory_AccessBasedHidesPartialMask(t *testin
 			// smbtorture `torture_smb2_testdir(tree1, BASEDIR, &dhandle)`
 			// step where the enumeration happens against the subdirectory,
 			// not the share root.
-			dirOpen := &OpenFile{
+			dirOpen := (&OpenFile{
 				FileID:         h.GenerateFileID(),
 				TreeID:         smbCtx.TreeID,
 				SessionID:      smbCtx.SessionID,
 				ShareName:      "/hideunread",
 				MetadataHandle: baseDirHandle,
-				ParentHandle:   rootHandle,
-				Path:           "/hideunread/smb2-testsd",
 				IsDirectory:    true,
 				DesiredAccess:  secRightsFileFull,
 				GrantedAccess:  secRightsFileFull,
-			}
+			}).WithName(OpenName{Path: "/hideunread/smb2-testsd", ParentHandle: rootHandle})
 			h.StoreOpenFile(dirOpen)
 
 			qResp := callABEQuery(t, h, smbCtx, dirOpen.FileID)

--- a/internal/adapter/smb/handlers/query_directory_test.go
+++ b/internal/adapter/smb/handlers/query_directory_test.go
@@ -133,13 +133,12 @@ func setupABEQueryDirTest(t *testing.T, abe bool, callerUID, callerGID uint32, c
 		AccessBasedEnumeration: abe,
 	})
 
-	open := &OpenFile{
+	open := (&OpenFile{
 		FileID:         h.GenerateFileID(),
 		TreeID:         treeID,
-		Path:           shareName,
 		IsDirectory:    true,
 		MetadataHandle: rootHandle,
-	}
+	}).WithName(OpenName{Path: shareName})
 	h.StoreOpenFile(open)
 
 	// SMB session carries a User struct (callerUID / callerGID);
@@ -326,12 +325,11 @@ func setupQueryDirTest(t *testing.T, names []string) (*Handler, *OpenFile, *meta
 	h := NewHandler()
 	h.Registry = rt
 
-	open := &OpenFile{
+	open := (&OpenFile{
 		FileID:         h.GenerateFileID(),
-		Path:           shareName,
 		IsDirectory:    true,
 		MetadataHandle: rootHandle,
-	}
+	}).WithName(OpenName{Path: shareName})
 	h.StoreOpenFile(open)
 
 	smbCtx := &SMBHandlerContext{Context: context.Background()}

--- a/internal/adapter/smb/handlers/query_info.go
+++ b/internal/adapter/smb/handlers/query_info.go
@@ -662,8 +662,8 @@ func (h *Handler) resolveBaseFileAttrForADS(authCtx *metadata.AuthContext, openF
 
 // buildFileInfoFromStore builds file information based on class using metadata store.
 func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *metadata.File, openFile *OpenFile, class types.FileInfoClass) ([]byte, error) {
-	// One snapshot for every arm below: the response must describe a single
-	// name, not a path from before a rename and a file name from after it.
+	// One snapshot for every arm below, so the response cannot mix a path
+	// from before a rename with a file name from after it.
 	name := openFile.Name()
 	switch class {
 	case types.FileBasicInformation:
@@ -1013,14 +1013,14 @@ func (h *Handler) buildFileStreamInformation(authCtx *metadata.AuthContext, file
 
 	// Enumerate ADS entries from the parent directory.
 	// ADS are stored as children with names like "baseName:streamname:$DATA".
-	if len(openFile.Name().ParentHandle) > 0 {
+	if len(name.ParentHandle) > 0 {
 		metaSvc := h.Registry.GetMetadataService()
 		store, storeErr := metaSvc.GetStoreForShare(shareNameForOpenFile(openFile))
 		if storeErr == nil {
 			prefix := baseName + ":"
 			cursor := ""
 			for {
-				entries, nextCursor, listErr := store.ListChildren(ctx, openFile.Name().ParentHandle, cursor, 1000)
+				entries, nextCursor, listErr := store.ListChildren(ctx, name.ParentHandle, cursor, 1000)
 				if listErr != nil {
 					break
 				}

--- a/internal/adapter/smb/handlers/query_info.go
+++ b/internal/adapter/smb/handlers/query_info.go
@@ -291,7 +291,7 @@ func (h *Handler) QueryInfo(ctx *SMBHandlerContext, req *QueryInfoRequest) (*Que
 
 	file, err := metaSvc.GetFile(ctx.Context, openFile.MetadataHandle)
 	if err != nil {
-		logger.Debug("QUERY_INFO: failed to get file", "path", openFile.Path, "error", err)
+		logger.Debug("QUERY_INFO: failed to get file", "path", openFile.Name().Path, "error", err)
 		return &QueryInfoResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(err)}}, nil
 	}
 
@@ -627,13 +627,14 @@ func (h *Handler) handlePipeFileInfo(req *QueryInfoRequest, openFile *OpenFile) 
 // The returned FileAttr is a copy with the stream handle's frozen timestamp
 // overrides applied so QUERY_INFO returns the correct value for frozen handles.
 func (h *Handler) resolveBaseFileAttrForADS(authCtx *metadata.AuthContext, openFile *OpenFile) *metadata.FileAttr {
-	colonIdx := strings.Index(openFile.FileName, ":")
-	if colonIdx <= 0 || len(openFile.ParentHandle) == 0 {
+	name := openFile.Name()
+	colonIdx := strings.Index(name.FileName, ":")
+	if colonIdx <= 0 || len(name.ParentHandle) == 0 {
 		return nil
 	}
 	metaSvc := h.Registry.GetMetadataService()
-	baseFileName := openFile.FileName[:colonIdx]
-	baseFile, _, _ := h.lookupCaseInsensitive(authCtx, metaSvc, openFile.ParentHandle, baseFileName)
+	baseFileName := name.FileName[:colonIdx]
+	baseFile, _, _ := h.lookupCaseInsensitive(authCtx, metaSvc, name.ParentHandle, baseFileName)
 	if baseFile == nil {
 		return nil
 	}
@@ -661,6 +662,9 @@ func (h *Handler) resolveBaseFileAttrForADS(authCtx *metadata.AuthContext, openF
 
 // buildFileInfoFromStore builds file information based on class using metadata store.
 func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *metadata.File, openFile *OpenFile, class types.FileInfoClass) ([]byte, error) {
+	// One snapshot for every arm below: the response must describe a single
+	// name, not a path from before a rename and a file name from after it.
+	name := openFile.Name()
 	switch class {
 	case types.FileBasicInformation:
 		// Per NTFS: ADS (alternate data streams) share the base file's
@@ -687,7 +691,7 @@ func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *me
 
 	case types.FileInternalInformation:
 		// FILE_INTERNAL_INFORMATION [MS-FSCC] 2.4.20 (8 bytes)
-		fileID := h.baseFileUUID(authCtx, openFile.ParentHandle, openFile.FileName, file.ID)
+		fileID := h.baseFileUUID(authCtx, name.ParentHandle, name.FileName, file.ID)
 		w := smbenc.NewWriter(8)
 		w.WriteUint64(binary.LittleEndian.Uint64(fileID[:8]))
 		return w.Bytes(), nil
@@ -763,7 +767,7 @@ func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *me
 
 	case types.FileNameInformation:
 		// FILE_NAME_INFORMATION [MS-FSCC] 2.4.26 (4 bytes + variable)
-		nameBytes := encodeUTF16LE(toSMBPath(openFile.Path))
+		nameBytes := encodeUTF16LE(toSMBPath(name.Path))
 		w := smbenc.NewWriter(4 + len(nameBytes))
 		w.WriteUint32(uint32(len(nameBytes))) // FileNameLength
 		w.WriteBytes(nameBytes)
@@ -772,10 +776,10 @@ func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *me
 	case types.FileAlternateNameInformation:
 		// FILE_ALTERNATE_NAME_INFORMATION [MS-FSCC] 2.4.5 (4 bytes + variable)
 		// Returns the 8.3 short name
-		shortNameBytes := generate83ShortName(openFile.FileName)
+		shortNameBytes := generate83ShortName(name.FileName)
 		if shortNameBytes == nil {
 			// For root or entries without a short name, use the filename itself
-			shortNameBytes = encodeUTF16LE(openFile.FileName)
+			shortNameBytes = encodeUTF16LE(name.FileName)
 		}
 		w := smbenc.NewWriter(4 + len(shortNameBytes))
 		w.WriteUint32(uint32(len(shortNameBytes))) // FileNameLength
@@ -795,7 +799,7 @@ func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *me
 		// directory, the name is empty.
 		filePath := file.Path
 		if filePath == "" {
-			filePath = openFile.Path
+			filePath = name.Path
 		}
 		// Strip the share-root leading separator: file.Path is stored as
 		// "/dir/name" but the normalized form is share-relative (matches
@@ -820,7 +824,7 @@ func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *me
 		// ADS handles report the base file's UUID so a client comparing this
 		// against FileInternalInformation on the same handle gets a consistent
 		// 128-bit identity (refs #478).
-		fileID := h.baseFileUUID(authCtx, openFile.ParentHandle, openFile.FileName, file.ID)
+		fileID := h.baseFileUUID(authCtx, name.ParentHandle, name.FileName, file.ID)
 		w := smbenc.NewWriter(24)
 		w.WriteUint64(ntfsVolumeSerialNumber) // VolumeSerialNumber
 		w.WriteBytes(fileID[:16])             // FileId (128-bit)
@@ -908,10 +912,12 @@ func (h *Handler) buildFileAllInformationFromStore(authCtx *metadata.AuthContext
 	if baseAttr := h.resolveBaseFileAttrForADS(authCtx, openFile); baseAttr != nil {
 		attr = baseAttr
 	}
+	// One snapshot: this response carries both the path and the file name.
+	name := openFile.Name()
 	basicInfo := FileAttrToFileBasicInfoWithName(attr, basenameForHidden(openFile))
 	standardInfo := FileAttrToFileStandardInfo(&file.FileAttr, openFile.DeletePending)
 	standardInfo.AllocationSize = effectiveAllocationSize(standardInfo.EndOfFile, openFile.RequestedAllocSize)
-	nameBytes := encodeUTF16LE(toSMBPath(openFile.Path))
+	nameBytes := encodeUTF16LE(toSMBPath(name.Path))
 
 	// Fixed part: 96 bytes + NameInformation header (4 bytes for length) + name data
 	// Minimum total per Linux kernel requirement: 104 bytes (100 fixed + 4 for FileNameLength)
@@ -927,7 +933,7 @@ func (h *Handler) buildFileAllInformationFromStore(authCtx *metadata.AuthContext
 	copy(info[40:64], standardBytes)
 
 	// Build remaining fields sequentially using smbenc Writer
-	internalFileID := h.baseFileUUID(authCtx, openFile.ParentHandle, openFile.FileName, file.ID)
+	internalFileID := h.baseFileUUID(authCtx, name.ParentHandle, name.FileName, file.ID)
 	fileIndex := binary.LittleEndian.Uint64(internalFileID[:8])
 
 	w := smbenc.NewWriter(36)
@@ -961,7 +967,8 @@ func (h *Handler) buildFileStreamInformation(authCtx *metadata.AuthContext, file
 	ctx := authCtx.Context
 	// Determine the base file name. If the open file is itself an ADS
 	// (e.g., "file.txt:stream1:$DATA"), find the base file first.
-	baseName := openFile.FileName
+	name := openFile.Name()
+	baseName := name.FileName
 	if colonIdx := strings.Index(baseName, ":"); colonIdx > 0 {
 		baseName = baseName[:colonIdx]
 	}
@@ -984,9 +991,9 @@ func (h *Handler) buildFileStreamInformation(authCtx *metadata.AuthContext, file
 	// Look up the base file to determine its type.
 	isBaseDirectory := openFile.IsDirectory
 	var defaultSize uint64
-	if !isBaseDirectory && strings.Contains(openFile.FileName, ":") && len(openFile.ParentHandle) > 0 {
+	if !isBaseDirectory && strings.Contains(name.FileName, ":") && len(name.ParentHandle) > 0 {
 		metaSvc := h.Registry.GetMetadataService()
-		if baseFile, _, _ := h.lookupCaseInsensitive(authCtx, metaSvc, openFile.ParentHandle, baseName); baseFile != nil {
+		if baseFile, _, _ := h.lookupCaseInsensitive(authCtx, metaSvc, name.ParentHandle, baseName); baseFile != nil {
 			if baseFile.Type == metadata.FileTypeDirectory {
 				isBaseDirectory = true
 			}
@@ -1006,14 +1013,14 @@ func (h *Handler) buildFileStreamInformation(authCtx *metadata.AuthContext, file
 
 	// Enumerate ADS entries from the parent directory.
 	// ADS are stored as children with names like "baseName:streamname:$DATA".
-	if len(openFile.ParentHandle) > 0 {
+	if len(openFile.Name().ParentHandle) > 0 {
 		metaSvc := h.Registry.GetMetadataService()
 		store, storeErr := metaSvc.GetStoreForShare(shareNameForOpenFile(openFile))
 		if storeErr == nil {
 			prefix := baseName + ":"
 			cursor := ""
 			for {
-				entries, nextCursor, listErr := store.ListChildren(ctx, openFile.ParentHandle, cursor, 1000)
+				entries, nextCursor, listErr := store.ListChildren(ctx, openFile.Name().ParentHandle, cursor, 1000)
 				if listErr != nil {
 					break
 				}
@@ -1374,10 +1381,11 @@ func basenameForHidden(openFile *OpenFile) string {
 	if openFile == nil {
 		return ""
 	}
-	if openFile.FileName != "" {
-		return openFile.FileName
+	name := openFile.Name()
+	if name.FileName != "" {
+		return name.FileName
 	}
-	p := openFile.Path
+	p := name.Path
 	if i := strings.LastIndexAny(p, "/\\"); i >= 0 {
 		return p[i+1:]
 	}

--- a/internal/adapter/smb/handlers/query_info_test.go
+++ b/internal/adapter/smb/handlers/query_info_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestFileCompressionInformation(t *testing.T) {
 	h := NewHandler()
-	openFileStub := &OpenFile{FileName: "test.txt", Path: "test.txt"}
+	openFileStub := (&OpenFile{}).WithName(OpenName{Path: "test.txt", FileName: "test.txt"})
 
 	t.Run("RegularFile", func(t *testing.T) {
 		file := &metadata.File{
@@ -112,7 +112,7 @@ func TestFileCompressionInformation(t *testing.T) {
 
 func TestFileAttributeTagInformation(t *testing.T) {
 	h := NewHandler()
-	openFileStub := &OpenFile{FileName: "test.txt", Path: "test.txt"}
+	openFileStub := (&OpenFile{}).WithName(OpenName{Path: "test.txt", FileName: "test.txt"})
 
 	t.Run("RegularFile", func(t *testing.T) {
 		file := &metadata.File{
@@ -170,7 +170,7 @@ func TestBuildFileInfoFromStore_FileStreamInformation(t *testing.T) {
 	h := NewHandler()
 
 	// OpenFile stub used for tests that don't depend on OpenFile fields.
-	openFileStub := &OpenFile{FileName: "test.txt", Path: "test.txt"}
+	openFileStub := (&OpenFile{}).WithName(OpenName{Path: "test.txt", FileName: "test.txt"})
 
 	t.Run("RegularFile", func(t *testing.T) {
 		file := &metadata.File{
@@ -341,12 +341,10 @@ func TestFileAccessInformation_ReturnsGrantedAccess(t *testing.T) {
 	// standard rights. This is the exact 0x00070080 the GENERIC test asks
 	// for; the pre-fix code would have returned 0x001F01FF (FILE_ALL_ACCESS).
 	const expected uint32 = 0x00070080
-	openFile := &OpenFile{
-		FileName:      "test.txt",
-		Path:          "test.txt",
+	openFile := (&OpenFile{
 		DesiredAccess: uint32(types.MaximumAllowed),
 		GrantedAccess: expected,
-	}
+	}).WithName(OpenName{Path: "test.txt", FileName: "test.txt"})
 	info, err := h.buildFileInfoFromStore(
 		&metadata.AuthContext{Context: context.Background(), Identity: &metadata.Identity{}},
 		file, openFile, types.FileAccessInformation,
@@ -382,12 +380,10 @@ func TestFileAllInformation_AccessInformationReturnsGrantedAccess(t *testing.T) 
 	// Mirrors the FileAccessInformation test: open made with MAXIMUM_ALLOWED
 	// whose effective DACL grant is 0x00070080, not FILE_ALL_ACCESS.
 	const expected uint32 = 0x00070080
-	openFile := &OpenFile{
-		FileName:      "test.txt",
-		Path:          "test.txt",
+	openFile := (&OpenFile{
 		DesiredAccess: uint32(types.MaximumAllowed),
 		GrantedAccess: expected,
-	}
+	}).WithName(OpenName{Path: "test.txt", FileName: "test.txt"})
 	info, err := h.buildFileInfoFromStore(
 		&metadata.AuthContext{Context: context.Background(), Identity: &metadata.Identity{}},
 		file, openFile, types.FileAllInformation,
@@ -420,10 +416,7 @@ func TestFilePositionInformation_RoundTrip(t *testing.T) {
 			Size: 0,
 		},
 	}
-	openFile := &OpenFile{
-		FileName: "test.txt",
-		Path:     "test.txt",
-	}
+	openFile := (&OpenFile{}).WithName(OpenName{Path: "test.txt", FileName: "test.txt"})
 	authCtx := &metadata.AuthContext{Context: context.Background(), Identity: &metadata.Identity{}}
 
 	// Drive the full SET → QUERY round-trip through the actual handlers so

--- a/internal/adapter/smb/handlers/read.go
+++ b/internal/adapter/smb/handlers/read.go
@@ -177,6 +177,8 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 		return h.handlePipeRead(ctx, req, openFile)
 	}
 
+	path := openFile.Name().Path
+
 	// ========================================================================
 	// Step 2b: Validate read access
 	// ========================================================================
@@ -195,7 +197,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 
 	if !hasReadAccess(openFile.GrantedAccess) {
 		logger.Debug("READ: no read access on handle",
-			"path", openFile.Name().Path,
+			"path", path,
 			"grantedAccess", fmt.Sprintf("0x%x", openFile.GrantedAccess))
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusAccessDenied}}, nil
 	}
@@ -205,7 +207,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	// ========================================================================
 
 	if openFile.IsDirectory {
-		logger.Debug("READ: cannot read from directory", "path", openFile.Name().Path)
+		logger.Debug("READ: cannot read from directory", "path", path)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidDeviceRequest}}, nil
 	}
 
@@ -217,12 +219,12 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	// exceeding INT64_MAX are invalid. Windows returns STATUS_INVALID_PARAMETER.
 	const int64Max = uint64(1<<63 - 1) // 0x7FFFFFFFFFFFFFFF
 	if req.Offset > int64Max {
-		logger.Debug("READ: invalid offset (high bit set)", "path", openFile.Name().Path, "offset", req.Offset)
+		logger.Debug("READ: invalid offset (high bit set)", "path", path, "offset", req.Offset)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}, nil
 	}
 	if req.Length > 0 && req.Offset > int64Max-uint64(req.Length) {
 		// offset + length would exceed INT64_MAX
-		logger.Debug("READ: offset+length exceeds INT64_MAX", "path", openFile.Name().Path,
+		logger.Debug("READ: offset+length exceeds INT64_MAX", "path", path,
 			"offset", req.Offset, "length", req.Length)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}, nil
 	}
@@ -237,7 +239,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	// the clamp never rejects every read.
 	if h.MaxReadSize > 0 && req.Length > h.MaxReadSize {
 		logger.Debug("READ: length exceeds negotiated MaxReadSize",
-			"path", openFile.Name().Path, "length", req.Length, "maxReadSize", h.MaxReadSize)
+			"path", path, "length", req.Length, "maxReadSize", h.MaxReadSize)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}, nil
 	}
 
@@ -271,7 +273,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	metaSvc := h.Registry.GetMetadataService()
 	blockStore, err := common.ResolveForRead(ctx.Context, h.Registry, openFile.MetadataHandle)
 	if err != nil {
-		logger.Warn("READ: block store not available for handle", "path", openFile.Name().Path, "error", err)
+		logger.Warn("READ: block store not available for handle", "path", path, "error", err)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInternalError}}, nil
 	}
 
@@ -293,7 +295,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	// reads file.Path (loggers use openFile.Path, symlink uses file.LinkTarget).
 	file, err := metaSvc.GetFileForRead(authCtx.Context, openFile.MetadataHandle)
 	if err != nil {
-		logger.Debug("READ: failed to get file metadata", "path", openFile.Name().Path, "error", err)
+		logger.Debug("READ: failed to get file metadata", "path", path, "error", err)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(err)}}, nil
 	}
 
@@ -311,13 +313,13 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 		if file.Type == metadata.FileTypeDirectory {
 			rerr = &metadata.StoreError{Code: metadata.ErrIsDirectory, Message: "cannot read directory"}
 		}
-		logger.Debug("READ: not a regular file", "path", openFile.Name().Path, "type", file.Type)
+		logger.Debug("READ: not a regular file", "path", path, "type", file.Type)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(rerr)}}, nil
 	}
 
 	// Validate read permission on the already-loaded file (no re-fetch).
 	if err := metaSvc.CheckReadPermissionFile(authCtx, openFile.MetadataHandle, file); err != nil {
-		logger.Debug("READ: permission check failed", "path", openFile.Name().Path, "error", err)
+		logger.Debug("READ: permission check failed", "path", path, "error", err)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(err)}}, nil
 	}
 
@@ -338,7 +340,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 			uint64(req.Length),
 			false, // isWrite = false for read operations
 		); err != nil {
-			logger.Debug("READ: blocked by lock", "path", openFile.Name().Path, "offset", req.Offset, "length", req.Length)
+			logger.Debug("READ: blocked by lock", "path", path, "offset", req.Offset, "length", req.Length)
 			return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusFileLockConflict}}, nil
 		}
 	}
@@ -355,7 +357,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	//   - Non-zero length read at/past EOF: STATUS_END_OF_FILE
 	//   - Non-zero length read on empty file (no payload): STATUS_END_OF_FILE
 	if req.Length == 0 && req.MinimumCount == 0 {
-		logger.Debug("READ: zero-length read (success)", "path", openFile.Name().Path,
+		logger.Debug("READ: zero-length read (success)", "path", path,
 			"offset", req.Offset, "size", fileSize)
 		// MS-FSA 2.1.5.2: even a zero-byte successful READ advances
 		// CurrentByteOffset to req.Offset (offset + 0 bytes returned).
@@ -369,7 +371,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	}
 
 	if file.PayloadID == "" || fileSize == 0 || req.Offset >= fileSize {
-		logger.Debug("READ: at or beyond EOF", "path", openFile.Name().Path,
+		logger.Debug("READ: at or beyond EOF", "path", path,
 			"offset", req.Offset, "size", fileSize,
 			"hasPayload", file.PayloadID != "")
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusEndOfFile}}, nil
@@ -385,7 +387,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	// Per MS-SMB2: if actual bytes available < MinimumCount, return EOF.
 	// This handles cases where min_count exceeds what's readable from the file.
 	if req.MinimumCount > 0 && actualLength < req.MinimumCount {
-		logger.Debug("READ: available bytes less than MinimumCount", "path", openFile.Name().Path,
+		logger.Debug("READ: available bytes less than MinimumCount", "path", path,
 			"available", actualLength, "minCount", req.MinimumCount)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusEndOfFile}}, nil
 	}
@@ -402,7 +404,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	// already returns the buffer internally, so ReleaseData stays nil.
 	readResult, err := common.ReadFromBlockStore(authCtx.Context, blockStore, file.PayloadID, req.Offset, actualLength)
 	if err != nil {
-		logger.Warn("READ: content read failed", "path", openFile.Name().Path, "error", err)
+		logger.Warn("READ: content read failed", "path", path, "error", err)
 		// common.MapContentToSMB mirrors the old ContentErrorToSMBStatus
 		// behavior and handles ErrRemoteUnavailable. ReleaseData stays nil
 		// because ReadFromBlockStore has already released the pooled buffer
@@ -411,7 +413,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	}
 
 	logger.Debug("READ successful",
-		"path", openFile.Name().Path,
+		"path", path,
 		"offset", req.Offset,
 		"requested", req.Length,
 		"actual", len(readResult.Data))
@@ -487,11 +489,13 @@ func (h *Handler) handleSymlinkRead(
 	file *metadata.File,
 	req *ReadRequest,
 ) (*ReadResponse, error) {
+	path := openFile.Name().Path
+
 	// Generate MFsymlink content from the symlink target
 	mfsymlinkData, err := mfsymlink.Encode(file.LinkTarget)
 	if err != nil {
 		logger.Warn("READ: failed to encode MFsymlink",
-			"path", openFile.Name().Path,
+			"path", path,
 			"target", file.LinkTarget,
 			"error", err)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInternalError}}, nil
@@ -502,7 +506,7 @@ func (h *Handler) handleSymlinkRead(
 	// Handle offset beyond EOF
 	if req.Offset >= fileSize {
 		logger.Debug("READ: symlink offset beyond EOF",
-			"path", openFile.Name().Path,
+			"path", path,
 			"offset", req.Offset,
 			"size", fileSize)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusEndOfFile}}, nil
@@ -515,7 +519,7 @@ func (h *Handler) handleSymlinkRead(
 	data := mfsymlinkData[req.Offset:readEnd]
 
 	logger.Debug("READ: symlink (MFsymlink)",
-		"path", openFile.Name().Path,
+		"path", path,
 		"target", file.LinkTarget,
 		"offset", req.Offset,
 		"requested", req.Length,

--- a/internal/adapter/smb/handlers/read.go
+++ b/internal/adapter/smb/handlers/read.go
@@ -292,7 +292,8 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	// ========================================================================
 
 	// GetFileForRead skips the expensive File.Path derivation; read.go never
-	// reads file.Path (loggers use openFile.Path, symlink uses file.LinkTarget).
+	// reads file.Path (loggers use the handle's own name, symlink uses
+	// file.LinkTarget).
 	file, err := metaSvc.GetFileForRead(authCtx.Context, openFile.MetadataHandle)
 	if err != nil {
 		logger.Debug("READ: failed to get file metadata", "path", path, "error", err)

--- a/internal/adapter/smb/handlers/read.go
+++ b/internal/adapter/smb/handlers/read.go
@@ -195,7 +195,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 
 	if !hasReadAccess(openFile.GrantedAccess) {
 		logger.Debug("READ: no read access on handle",
-			"path", openFile.Path,
+			"path", openFile.Name().Path,
 			"grantedAccess", fmt.Sprintf("0x%x", openFile.GrantedAccess))
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusAccessDenied}}, nil
 	}
@@ -205,7 +205,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	// ========================================================================
 
 	if openFile.IsDirectory {
-		logger.Debug("READ: cannot read from directory", "path", openFile.Path)
+		logger.Debug("READ: cannot read from directory", "path", openFile.Name().Path)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidDeviceRequest}}, nil
 	}
 
@@ -217,12 +217,12 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	// exceeding INT64_MAX are invalid. Windows returns STATUS_INVALID_PARAMETER.
 	const int64Max = uint64(1<<63 - 1) // 0x7FFFFFFFFFFFFFFF
 	if req.Offset > int64Max {
-		logger.Debug("READ: invalid offset (high bit set)", "path", openFile.Path, "offset", req.Offset)
+		logger.Debug("READ: invalid offset (high bit set)", "path", openFile.Name().Path, "offset", req.Offset)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}, nil
 	}
 	if req.Length > 0 && req.Offset > int64Max-uint64(req.Length) {
 		// offset + length would exceed INT64_MAX
-		logger.Debug("READ: offset+length exceeds INT64_MAX", "path", openFile.Path,
+		logger.Debug("READ: offset+length exceeds INT64_MAX", "path", openFile.Name().Path,
 			"offset", req.Offset, "length", req.Length)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}, nil
 	}
@@ -237,7 +237,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	// the clamp never rejects every read.
 	if h.MaxReadSize > 0 && req.Length > h.MaxReadSize {
 		logger.Debug("READ: length exceeds negotiated MaxReadSize",
-			"path", openFile.Path, "length", req.Length, "maxReadSize", h.MaxReadSize)
+			"path", openFile.Name().Path, "length", req.Length, "maxReadSize", h.MaxReadSize)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}, nil
 	}
 
@@ -271,7 +271,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	metaSvc := h.Registry.GetMetadataService()
 	blockStore, err := common.ResolveForRead(ctx.Context, h.Registry, openFile.MetadataHandle)
 	if err != nil {
-		logger.Warn("READ: block store not available for handle", "path", openFile.Path, "error", err)
+		logger.Warn("READ: block store not available for handle", "path", openFile.Name().Path, "error", err)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInternalError}}, nil
 	}
 
@@ -293,7 +293,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	// reads file.Path (loggers use openFile.Path, symlink uses file.LinkTarget).
 	file, err := metaSvc.GetFileForRead(authCtx.Context, openFile.MetadataHandle)
 	if err != nil {
-		logger.Debug("READ: failed to get file metadata", "path", openFile.Path, "error", err)
+		logger.Debug("READ: failed to get file metadata", "path", openFile.Name().Path, "error", err)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(err)}}, nil
 	}
 
@@ -311,13 +311,13 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 		if file.Type == metadata.FileTypeDirectory {
 			rerr = &metadata.StoreError{Code: metadata.ErrIsDirectory, Message: "cannot read directory"}
 		}
-		logger.Debug("READ: not a regular file", "path", openFile.Path, "type", file.Type)
+		logger.Debug("READ: not a regular file", "path", openFile.Name().Path, "type", file.Type)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(rerr)}}, nil
 	}
 
 	// Validate read permission on the already-loaded file (no re-fetch).
 	if err := metaSvc.CheckReadPermissionFile(authCtx, openFile.MetadataHandle, file); err != nil {
-		logger.Debug("READ: permission check failed", "path", openFile.Path, "error", err)
+		logger.Debug("READ: permission check failed", "path", openFile.Name().Path, "error", err)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(err)}}, nil
 	}
 
@@ -338,7 +338,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 			uint64(req.Length),
 			false, // isWrite = false for read operations
 		); err != nil {
-			logger.Debug("READ: blocked by lock", "path", openFile.Path, "offset", req.Offset, "length", req.Length)
+			logger.Debug("READ: blocked by lock", "path", openFile.Name().Path, "offset", req.Offset, "length", req.Length)
 			return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusFileLockConflict}}, nil
 		}
 	}
@@ -355,7 +355,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	//   - Non-zero length read at/past EOF: STATUS_END_OF_FILE
 	//   - Non-zero length read on empty file (no payload): STATUS_END_OF_FILE
 	if req.Length == 0 && req.MinimumCount == 0 {
-		logger.Debug("READ: zero-length read (success)", "path", openFile.Path,
+		logger.Debug("READ: zero-length read (success)", "path", openFile.Name().Path,
 			"offset", req.Offset, "size", fileSize)
 		// MS-FSA 2.1.5.2: even a zero-byte successful READ advances
 		// CurrentByteOffset to req.Offset (offset + 0 bytes returned).
@@ -369,7 +369,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	}
 
 	if file.PayloadID == "" || fileSize == 0 || req.Offset >= fileSize {
-		logger.Debug("READ: at or beyond EOF", "path", openFile.Path,
+		logger.Debug("READ: at or beyond EOF", "path", openFile.Name().Path,
 			"offset", req.Offset, "size", fileSize,
 			"hasPayload", file.PayloadID != "")
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusEndOfFile}}, nil
@@ -385,7 +385,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	// Per MS-SMB2: if actual bytes available < MinimumCount, return EOF.
 	// This handles cases where min_count exceeds what's readable from the file.
 	if req.MinimumCount > 0 && actualLength < req.MinimumCount {
-		logger.Debug("READ: available bytes less than MinimumCount", "path", openFile.Path,
+		logger.Debug("READ: available bytes less than MinimumCount", "path", openFile.Name().Path,
 			"available", actualLength, "minCount", req.MinimumCount)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusEndOfFile}}, nil
 	}
@@ -402,7 +402,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	// already returns the buffer internally, so ReleaseData stays nil.
 	readResult, err := common.ReadFromBlockStore(authCtx.Context, blockStore, file.PayloadID, req.Offset, actualLength)
 	if err != nil {
-		logger.Warn("READ: content read failed", "path", openFile.Path, "error", err)
+		logger.Warn("READ: content read failed", "path", openFile.Name().Path, "error", err)
 		// common.MapContentToSMB mirrors the old ContentErrorToSMBStatus
 		// behavior and handles ErrRemoteUnavailable. ReleaseData stays nil
 		// because ReadFromBlockStore has already released the pooled buffer
@@ -411,7 +411,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	}
 
 	logger.Debug("READ successful",
-		"path", openFile.Path,
+		"path", openFile.Name().Path,
 		"offset", req.Offset,
 		"requested", req.Length,
 		"actual", len(readResult.Data))
@@ -491,7 +491,7 @@ func (h *Handler) handleSymlinkRead(
 	mfsymlinkData, err := mfsymlink.Encode(file.LinkTarget)
 	if err != nil {
 		logger.Warn("READ: failed to encode MFsymlink",
-			"path", openFile.Path,
+			"path", openFile.Name().Path,
 			"target", file.LinkTarget,
 			"error", err)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInternalError}}, nil
@@ -502,7 +502,7 @@ func (h *Handler) handleSymlinkRead(
 	// Handle offset beyond EOF
 	if req.Offset >= fileSize {
 		logger.Debug("READ: symlink offset beyond EOF",
-			"path", openFile.Path,
+			"path", openFile.Name().Path,
 			"offset", req.Offset,
 			"size", fileSize)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusEndOfFile}}, nil
@@ -515,7 +515,7 @@ func (h *Handler) handleSymlinkRead(
 	data := mfsymlinkData[req.Offset:readEnd]
 
 	logger.Debug("READ: symlink (MFsymlink)",
-		"path", openFile.Path,
+		"path", openFile.Name().Path,
 		"target", file.LinkTarget,
 		"offset", req.Offset,
 		"requested", req.Length,

--- a/internal/adapter/smb/handlers/read_test.go
+++ b/internal/adapter/smb/handlers/read_test.go
@@ -72,9 +72,7 @@ func TestRead_SymlinkRead_LeavesReleaseDataNil(t *testing.T) {
 		Length: 1067, // MFsymlink spec size
 		Offset: 0,
 	}
-	openFile := &OpenFile{
-		Path: "/test/link",
-	}
+	openFile := (&OpenFile{}).WithName(OpenName{Path: "/test/link"})
 	file := &metadata.File{
 		Path: "/test/link",
 		FileAttr: metadata.FileAttr{
@@ -150,7 +148,7 @@ func TestHandleSymlinkRead_AdvancesPositionInfo(t *testing.T) {
 		Length: 100,
 		Offset: 10,
 	}
-	openFile := &OpenFile{Path: "/test/link"}
+	openFile := (&OpenFile{}).WithName(OpenName{Path: "/test/link"})
 	file := &metadata.File{
 		Path: "/test/link",
 		FileAttr: metadata.FileAttr{

--- a/internal/adapter/smb/handlers/readwrite_maxsize_clamp_test.go
+++ b/internal/adapter/smb/handlers/readwrite_maxsize_clamp_test.go
@@ -18,11 +18,10 @@ func TestRead_ClampsLengthToMaxReadSize(t *testing.T) {
 	}
 
 	fileID := [16]byte{0x11}
-	h.StoreOpenFile(&OpenFile{
+	h.StoreOpenFile((&OpenFile{
 		FileID:        fileID,
-		Path:          "/file",
 		GrantedAccess: uint32(types.FileReadData),
-	})
+	}).WithName(OpenName{Path: "/file"}))
 
 	// Length one byte over the advertised maximum.
 	req := &ReadRequest{
@@ -49,11 +48,10 @@ func TestRead_AtMaxReadSizeNotRejectedByClamp(t *testing.T) {
 	h := NewHandler()
 
 	fileID := [16]byte{0x22}
-	h.StoreOpenFile(&OpenFile{
+	h.StoreOpenFile((&OpenFile{
 		FileID:        fileID,
-		Path:          "/file",
 		GrantedAccess: uint32(types.FileReadData),
-	})
+	}).WithName(OpenName{Path: "/file"}))
 
 	req := &ReadRequest{
 		FileID: fileID,
@@ -84,11 +82,10 @@ func TestWrite_ClampsLengthToMaxWriteSize(t *testing.T) {
 	}
 
 	fileID := [16]byte{0x33}
-	h.StoreOpenFile(&OpenFile{
+	h.StoreOpenFile((&OpenFile{
 		FileID:        fileID,
-		Path:          "/file",
 		GrantedAccess: uint32(types.FileWriteData),
-	})
+	}).WithName(OpenName{Path: "/file"}))
 
 	req := &WriteRequest{
 		FileID: fileID,

--- a/internal/adapter/smb/handlers/rename_scan_close_race_test.go
+++ b/internal/adapter/smb/handlers/rename_scan_close_race_test.go
@@ -36,12 +36,13 @@ func storeHolder(h *Handler, metaHandle, parentHandle metadata.FileHandle) (hold
 		FileID:         holderID,
 		MetadataHandle: metaHandle,
 		ShareAccess:    0,                  // lacks FILE_SHARE_DELETE → checkShareDeleteConflict trips
-		DesiredAccess:  uint32(0x00010000), // DELETE → checkParentDirRenameConflict trips,
+		DesiredAccess:  uint32(0x00010000), // DELETE → checkParentDirRenameConflict trips
 	}).WithName(OpenName{ParentHandle: parentHandle}))
 	childID = h.GenerateFileID()
 	h.StoreOpenFile((&OpenFile{
 		FileID:         childID,
-		MetadataHandle: metadata.FileHandle{0xCC}, // child of the directory being renamed,
+		MetadataHandle: metadata.FileHandle{0xCC},
+		// parent handle below makes it a child of the directory being renamed
 	}).WithName(OpenName{ParentHandle: metaHandle}))
 	return holderID, childID
 }

--- a/internal/adapter/smb/handlers/rename_scan_close_race_test.go
+++ b/internal/adapter/smb/handlers/rename_scan_close_race_test.go
@@ -32,19 +32,17 @@ import (
 // rename conflict scans see a live conflict until the holder is removed.
 func storeHolder(h *Handler, metaHandle, parentHandle metadata.FileHandle) (holderID, childID [16]byte) {
 	holderID = h.GenerateFileID()
-	h.StoreOpenFile(&OpenFile{
+	h.StoreOpenFile((&OpenFile{
 		FileID:         holderID,
 		MetadataHandle: metaHandle,
-		ParentHandle:   parentHandle,
 		ShareAccess:    0,                  // lacks FILE_SHARE_DELETE → checkShareDeleteConflict trips
-		DesiredAccess:  uint32(0x00010000), // DELETE → checkParentDirRenameConflict trips
-	})
+		DesiredAccess:  uint32(0x00010000), // DELETE → checkParentDirRenameConflict trips,
+	}).WithName(OpenName{ParentHandle: parentHandle}))
 	childID = h.GenerateFileID()
-	h.StoreOpenFile(&OpenFile{
+	h.StoreOpenFile((&OpenFile{
 		FileID:         childID,
-		MetadataHandle: metadata.FileHandle{0xCC},
-		ParentHandle:   metaHandle, // child of the directory being renamed
-	})
+		MetadataHandle: metadata.FileHandle{0xCC}, // child of the directory being renamed,
+	}).WithName(OpenName{ParentHandle: metaHandle}))
 	return holderID, childID
 }
 
@@ -63,12 +61,11 @@ func TestRenameScan_vs_Close_Serialized_NoRace(t *testing.T) {
 
 	// The renamer's own directory open (IsDirectory so anyOpenChild applies).
 	renamerID := h.GenerateFileID()
-	h.StoreOpenFile(&OpenFile{
+	h.StoreOpenFile((&OpenFile{
 		FileID:         renamerID,
 		MetadataHandle: metaHandle,
 		IsDirectory:    true,
-		ParentHandle:   parentHandle,
-	})
+	}).WithName(OpenName{ParentHandle: parentHandle}))
 
 	const iters = 2000
 	var torn atomic.Bool         // true while a CLOSE is mid-removal under the mutex
@@ -154,12 +151,11 @@ func TestRenameScan_vs_Close_NegativeControl(t *testing.T) {
 		h := NewHandler()
 
 		renamerID := h.GenerateFileID()
-		h.StoreOpenFile(&OpenFile{
+		h.StoreOpenFile((&OpenFile{
 			FileID:         renamerID,
 			MetadataHandle: metaHandle,
 			IsDirectory:    true,
-			ParentHandle:   parentHandle,
-		})
+		}).WithName(OpenName{ParentHandle: parentHandle}))
 		renamer, _ := h.files.Load(string(renamerID[:]))
 		of := renamer.(*OpenFile)
 

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -358,7 +358,7 @@ func (h *Handler) setFileInfoFromStore(
 		ctimeFT := ftR.ReadUint64()
 
 		logger.Debug("SET_INFO: FileBasicInformation raw FILETIME values",
-			"path", openFile.Path,
+			"path", openFile.Name().Path,
 			"creationFT", fmt.Sprintf("0x%016X", creationFT),
 			"atimeFT", fmt.Sprintf("0x%016X", atimeFT),
 			"mtimeFT", fmt.Sprintf("0x%016X", mtimeFT),
@@ -403,17 +403,18 @@ func (h *Handler) setFileInfoFromStore(
 		var preFile *metadata.File
 		if needPreFile {
 			var err error
-			if colonIdx := strings.Index(openFile.FileName, ":"); colonIdx > 0 && len(openFile.ParentHandle) > 0 {
+			name := openFile.Name()
+			if colonIdx := strings.Index(name.FileName, ":"); colonIdx > 0 && len(name.ParentHandle) > 0 {
 				// ADS: capture base file timestamps.
-				baseFileName := openFile.FileName[:colonIdx]
-				if baseFile, _, _ := h.lookupCaseInsensitive(authCtx, metaSvc, openFile.ParentHandle, baseFileName); baseFile != nil {
+				baseFileName := name.FileName[:colonIdx]
+				if baseFile, _, _ := h.lookupCaseInsensitive(authCtx, metaSvc, name.ParentHandle, baseFileName); baseFile != nil {
 					preFile = baseFile
 				}
 			}
 			if preFile == nil {
 				preFile, err = metaSvc.GetFile(authCtx.Context, openFile.MetadataHandle)
 				if err != nil {
-					logger.Warn("SET_INFO: failed to read file for freeze/unfreeze", "path", openFile.Path, "error", err)
+					logger.Warn("SET_INFO: failed to read file for freeze/unfreeze", "path", openFile.Name().Path, "error", err)
 				}
 			}
 		}
@@ -479,7 +480,7 @@ func (h *Handler) setFileInfoFromStore(
 
 		if _, err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, setAttrs); err != nil {
 			openFile.mu.Unlock() // release before returning; refs #606.
-			logger.Debug("SET_INFO: failed to set basic info", "path", openFile.Path, "error", err)
+			logger.Debug("SET_INFO: failed to set basic info", "path", openFile.Name().Path, "error", err)
 			return setInfoStatus(common.MapToSMB(err)), nil
 		}
 
@@ -513,9 +514,10 @@ func (h *Handler) setFileInfoFromStore(
 		// propagate is logged at the metadata layer and does not roll back
 		// the stream's own SET_INFO (the stream is the explicitly-targeted
 		// handle and its write has already succeeded above).
-		if colonIdx := strings.Index(openFile.FileName, ":"); colonIdx > 0 && len(openFile.ParentHandle) > 0 {
-			baseFileName := openFile.FileName[:colonIdx]
-			if baseFile, _, _ := h.lookupCaseInsensitive(authCtx, metaSvc, openFile.ParentHandle, baseFileName); baseFile != nil {
+		adsName := openFile.Name()
+		if colonIdx := strings.Index(adsName.FileName, ":"); colonIdx > 0 && len(adsName.ParentHandle) > 0 {
+			baseFileName := adsName.FileName[:colonIdx]
+			if baseFile, _, _ := h.lookupCaseInsensitive(authCtx, metaSvc, adsName.ParentHandle, baseFileName); baseFile != nil {
 				basePropagate := &metadata.SetAttrs{
 					Mtime:        setAttrs.Mtime,
 					Ctime:        setAttrs.Ctime,
@@ -555,7 +557,7 @@ func (h *Handler) setFileInfoFromStore(
 			case filetimeFreeze:
 				openFile.BtimeFrozen = true
 				openFile.FrozenBtime = &preFile.CreationTime
-				logger.Debug("SET_INFO: froze CreationTime", "path", openFile.Path, "value", preFile.CreationTime)
+				logger.Debug("SET_INFO: froze CreationTime", "path", openFile.Name().Path, "value", preFile.CreationTime)
 			case filetimeUnfreeze:
 				openFile.BtimeFrozen = false
 				openFile.FrozenBtime = nil
@@ -566,7 +568,7 @@ func (h *Handler) setFileInfoFromStore(
 			case filetimeFreeze:
 				openFile.MtimeFrozen = true
 				openFile.FrozenMtime = &preFile.Mtime
-				logger.Debug("SET_INFO: froze LastWriteTime", "path", openFile.Path, "value", preFile.Mtime)
+				logger.Debug("SET_INFO: froze LastWriteTime", "path", openFile.Name().Path, "value", preFile.Mtime)
 			case filetimeUnfreeze:
 				openFile.MtimeFrozen = false
 				openFile.FrozenMtime = nil
@@ -577,7 +579,7 @@ func (h *Handler) setFileInfoFromStore(
 			case filetimeFreeze:
 				openFile.CtimeFrozen = true
 				openFile.FrozenCtime = &preFile.Ctime
-				logger.Debug("SET_INFO: froze ChangeTime", "path", openFile.Path, "value", preFile.Ctime)
+				logger.Debug("SET_INFO: froze ChangeTime", "path", openFile.Name().Path, "value", preFile.Ctime)
 			case filetimeUnfreeze:
 				openFile.CtimeFrozen = false
 				openFile.FrozenCtime = nil
@@ -618,7 +620,7 @@ func (h *Handler) setFileInfoFromStore(
 			v := *val
 			*frozen = true
 			*frozenVal = &v
-			logger.Debug("SET_INFO: explicit set pins timestamp", "field", label, "path", openFile.Path, "value", v)
+			logger.Debug("SET_INFO: explicit set pins timestamp", "field", label, "path", openFile.Name().Path, "value", v)
 		}
 		freezeOnExplicitSet(creationFT, &openFile.BtimeFrozen, &openFile.FrozenBtime, setAttrs.CreationTime, "CreationTime")
 		freezeOnExplicitSet(mtimeFT, &openFile.MtimeFrozen, &openFile.FrozenMtime, setAttrs.Mtime, "LastWriteTime")
@@ -666,7 +668,7 @@ func (h *Handler) setFileInfoFromStore(
 				nf |= FileNotifyChangeLastWrite
 			}
 			if nf != 0 {
-				h.NotifyRegistry.NotifyChange(openFile.ShareName, GetParentPath(openFile.Path), notifyStreamName(openFile.FileName), FileActionModified, nf)
+				h.notifyOpenFileModified(openFile, nf)
 			}
 		}
 
@@ -685,7 +687,7 @@ func (h *Handler) setFileInfoFromStore(
 		// the pre-DACL DesiredAccess — same fix class as #616 (ChangeNotify).
 		if !hasDeleteAccess(openFile.GrantedAccess) {
 			logger.Debug("SET_INFO: rename without DELETE access",
-				"path", openFile.Path,
+				"path", openFile.Name().Path,
 				"grantedAccess", fmt.Sprintf("0x%x", openFile.GrantedAccess))
 			return setInfoStatus(types.StatusAccessDenied), nil
 		}
@@ -706,7 +708,7 @@ func (h *Handler) setFileInfoFromStore(
 		h.renameScanMu.Unlock()
 		if shareDeleteConflict {
 			logger.Debug("SET_INFO: rename blocked by sharing violation",
-				"path", openFile.Path,
+				"path", openFile.Name().Path,
 				"fileID", fmt.Sprintf("%x", openFile.FileID))
 			return setInfoStatus(types.StatusSharingViolation), nil
 		}
@@ -725,7 +727,7 @@ func (h *Handler) setFileInfoFromStore(
 		if strings.HasPrefix(newPath, ":") {
 			// Extract the base file name from the current open file name.
 			// The current file is an ADS: "basefile:streamname"
-			baseName := openFile.FileName
+			baseName := openFile.Name().FileName
 			if colonIdx := strings.Index(baseName, ":"); colonIdx > 0 {
 				baseName = baseName[:colonIdx]
 			}
@@ -737,11 +739,11 @@ func (h *Handler) setFileInfoFromStore(
 
 			// Build new child name: basefile + new stream suffix
 			toName := baseName + newPath
-			toDir := openFile.ParentHandle
+			toDir := openFile.Name().ParentHandle
 
 			// Save old path info for notification before modification
-			oldPath := openFile.Path
-			oldFileName := openFile.FileName
+			oldPath := openFile.Name().Path
+			oldFileName := openFile.Name().FileName
 			oldParentPath := GetParentPath(oldPath)
 
 			// Per MS-FSA 2.1.5.14.10: Save mtime/ctime before rename
@@ -749,10 +751,10 @@ func (h *Handler) setFileInfoFromStore(
 
 			// Perform the rename
 			metaSvc := h.Registry.GetMetadataService()
-			_, err = metaSvc.Move(authCtx, toDir, openFile.FileName, toDir, toName)
+			_, err = metaSvc.Move(authCtx, toDir, openFile.Name().FileName, toDir, toName)
 			if err != nil {
 				logger.Debug("SET_INFO: stream rename failed",
-					"from", openFile.FileName,
+					"from", openFile.Name().FileName,
 					"to", toName,
 					"error", err)
 				return setInfoStatus(common.MapToSMB(err)), nil
@@ -768,7 +770,7 @@ func (h *Handler) setFileInfoFromStore(
 			if h.NotifyRegistry != nil {
 				tree, ok := h.GetTree(openFile.TreeID)
 				if ok {
-					newParentPath := GetParentPath(openFile.Path)
+					newParentPath := GetParentPath(openFile.Name().Path)
 					if newParentPath == "" || newParentPath == "." {
 						newParentPath = "/"
 					}
@@ -780,17 +782,19 @@ func (h *Handler) setFileInfoFromStore(
 				}
 			}
 
-			// Update open file state. Ops pipelined on this handle read the
-			// name/path pair concurrently (WRITE classifies an ADS write from
-			// it), so read and republish the pair under the handle lock.
+			// Update open file state. The handle lock serializes this
+			// read-modify-write against a concurrent rename on the same handle.
 			openFile.mu.Lock()
-			parentPath := GetParentPath(openFile.Path)
+			cur := openFile.Name()
+			newName := *cur
+			newName.FileName = toName
+			parentPath := GetParentPath(cur.Path)
 			if parentPath == "" || parentPath == "/" || parentPath == "." {
-				openFile.Path = toName
+				newName.Path = toName
 			} else {
-				openFile.Path = parentPath + "/" + toName
+				newName.Path = parentPath + "/" + toName
 			}
-			openFile.FileName = toName
+			openFile.SetName(newName)
 			openFile.mu.Unlock()
 			h.StoreOpenFile(openFile)
 
@@ -821,7 +825,7 @@ func (h *Handler) setFileInfoFromStore(
 			// to directory handles, so fall back to same-directory rename.
 			logger.Debug("SET_INFO: rename with non-zero RootDirectory (using same-dir fallback)",
 				"rootDirectory", fmt.Sprintf("%x", renameInfo.RootDirectory))
-			toDir = openFile.ParentHandle
+			toDir = openFile.Name().ParentHandle
 			toName = path.Base(newPath)
 		} else {
 			// RootDirectory is zero: FileName is a full path from the share root.
@@ -854,8 +858,8 @@ func (h *Handler) setFileInfoFromStore(
 		}
 
 		// Validate we have source info
-		if len(openFile.ParentHandle) == 0 {
-			logger.Debug("SET_INFO: cannot rename root directory", "path", openFile.Path)
+		if len(openFile.Name().ParentHandle) == 0 {
+			logger.Debug("SET_INFO: cannot rename root directory", "path", openFile.Name().Path)
 			return setInfoStatus(types.StatusAccessDenied), nil
 		}
 
@@ -907,7 +911,7 @@ func (h *Handler) setFileInfoFromStore(
 			h.renameScanMu.Unlock()
 			if openChild {
 				logger.Debug("SET_INFO: dir rename blocked by open child",
-					"dir", openFile.Path)
+					"dir", openFile.Name().Path)
 				return setInfoStatus(types.StatusAccessDenied), nil
 			}
 		}
@@ -946,7 +950,7 @@ func (h *Handler) setFileInfoFromStore(
 		h.renameScanMu.Lock()
 		conflict := h.checkParentDirRenameConflict(openFile.FileID, toDir)
 		h.renameScanMu.Unlock()
-		if conflict && !bytes.Equal(toDir, openFile.ParentHandle) {
+		if conflict && !bytes.Equal(toDir, openFile.Name().ParentHandle) {
 			h.breakDstParentDirHandleLeasesForRename(authCtx, toDir, openFile)
 			// Re-check after the strip-H break drained (the holder's break
 			// handler may have closed its conflicting open). If the
@@ -961,7 +965,7 @@ func (h *Handler) setFileInfoFromStore(
 		}
 		if conflict {
 			logger.Debug("SET_INFO: rename blocked by destination-parent sharing violation",
-				"path", openFile.Path,
+				"path", openFile.Name().Path,
 				"toDir", fmt.Sprintf("%x", toDir),
 				"fileID", fmt.Sprintf("%x", openFile.FileID))
 			return setInfoStatus(types.StatusSharingViolation), nil
@@ -1037,7 +1041,7 @@ func (h *Handler) setFileInfoFromStore(
 					true, // RENAME break_to strips H.
 				); purged > 0 {
 					logger.Debug("SET_INFO: purged disconnected handles on rename",
-						"src", openFile.Path,
+						"src", openFile.Name().Path,
 						"dst", newPath,
 						"count", purged)
 				}
@@ -1089,20 +1093,20 @@ func (h *Handler) setFileInfoFromStore(
 			h.renameScanMu.Unlock()
 			if dstStillOpen {
 				logger.Debug("SET_INFO: rename overwrite blocked by open handle on destination",
-					"src", openFile.Path,
+					"src", openFile.Name().Path,
 					"dst", newPath)
 				return setInfoStatus(types.StatusAccessDenied), nil
 			}
 		}
 
-		// Save old path info for notification before modification
-		oldPath := openFile.Path
-		oldFileName := openFile.FileName
+		// Save the pre-rename name for notification and for the post-rename
+		// dir-lease break on the source parent, which the update below
+		// replaces with toDir.
+		oldName := openFile.Name()
+		oldPath := oldName.Path
+		oldFileName := oldName.FileName
 		oldParentPath := GetParentPath(oldPath)
-		// Snapshot src-parent handle so the post-rename dir-lease break can
-		// fire on the source parent (line 862 update below overwrites
-		// openFile.ParentHandle to toDir).
-		srcParentHandle := openFile.ParentHandle
+		srcParentHandle := oldName.ParentHandle
 
 		// Per MS-FSA 2.1.5.14.10: Save mtime/ctime before rename so we can
 		// restore them after. Rename should NOT update the file's timestamps.
@@ -1123,10 +1127,10 @@ func (h *Handler) setFileInfoFromStore(
 		}
 
 		// Perform the rename/move
-		_, err = metaSvc.Move(authCtx, openFile.ParentHandle, openFile.FileName, toDir, toName)
+		_, err = metaSvc.Move(authCtx, srcParentHandle, oldFileName, toDir, toName)
 		if err != nil {
 			logger.Debug("SET_INFO: rename failed",
-				"from", openFile.Path,
+				"from", openFile.Name().Path,
 				"to", newPath,
 				"error", err)
 			return setInfoStatus(common.MapToSMB(err)), nil
@@ -1137,8 +1141,8 @@ func (h *Handler) setFileInfoFromStore(
 
 		// Per MS-FSA 2.1.5.14.2: Restore frozen timestamps on parent directories.
 		// Move updates both source and destination parent directory timestamps.
-		h.restoreParentDirFrozenTimestamps(authCtx, openFile.ParentHandle)
-		if !bytes.Equal(toDir, openFile.ParentHandle) {
+		h.restoreParentDirFrozenTimestamps(authCtx, srcParentHandle)
+		if !bytes.Equal(toDir, srcParentHandle) {
 			h.restoreParentDirFrozenTimestamps(authCtx, toDir)
 		}
 
@@ -1172,7 +1176,7 @@ func (h *Handler) setFileInfoFromStore(
 			} else {
 				logger.Debug("SET_INFO: rename notifications skipped, tree lookup failed",
 					"treeID", openFile.TreeID,
-					"from", openFile.Path,
+					"from", openFile.Name().Path,
 					"to", newPath)
 			}
 		}
@@ -1183,20 +1187,17 @@ func (h *Handler) setFileInfoFromStore(
 		actualNewPath := newPath
 		if !bytes.Equal(renameInfo.RootDirectory[:], zeroRootDir[:]) {
 			// Handle-relative rename: build path from parent path + new name
-			parentPath := GetParentPath(openFile.Path)
+			parentPath := GetParentPath(openFile.Name().Path)
 			if parentPath == "" || parentPath == "/" {
 				actualNewPath = toName
 			} else {
 				actualNewPath = parentPath + "/" + toName
 			}
 		}
-		// Ops pipelined on this handle read the name/path/parent triple
-		// concurrently (WRITE snapshots it), so publish all three together
-		// under the handle lock.
+		// The handle lock serializes this against a concurrent rename on the
+		// same handle; readers get the triple from the single atomic swap.
 		openFile.mu.Lock()
-		openFile.Path = actualNewPath
-		openFile.FileName = toName
-		openFile.ParentHandle = toDir
+		openFile.SetName(OpenName{Path: actualNewPath, FileName: toName, ParentHandle: toDir})
 		openFile.mu.Unlock()
 		h.StoreOpenFile(openFile)
 
@@ -1243,8 +1244,8 @@ func (h *Handler) setFileInfoFromStore(
 		wasDeletePending := openFile.DeletePending
 
 		// Validate we have parent info for deletion
-		if deletePending && len(openFile.ParentHandle) == 0 {
-			logger.Debug("SET_INFO: cannot delete root directory", "path", openFile.Path)
+		if deletePending && len(openFile.Name().ParentHandle) == 0 {
+			logger.Debug("SET_INFO: cannot delete root directory", "path", openFile.Name().Path)
 			return setInfoStatus(types.StatusAccessDenied), nil
 		}
 
@@ -1254,7 +1255,7 @@ func (h *Handler) setFileInfoFromStore(
 		if deletePending {
 			if !hasDeleteAccess(openFile.GrantedAccess) {
 				logger.Debug("SET_INFO: delete disposition without DELETE access",
-					"path", openFile.Path,
+					"path", openFile.Name().Path,
 					"grantedAccess", fmt.Sprintf("0x%x", openFile.GrantedAccess))
 				return setInfoStatus(types.StatusAccessDenied), nil
 			}
@@ -1266,7 +1267,7 @@ func (h *Handler) setFileInfoFromStore(
 				if fileErr == nil {
 					attrs := FileAttrToSMBAttributes(&file.FileAttr)
 					if attrs&types.FileAttributeReadonly != 0 {
-						logger.Debug("SET_INFO: delete disposition on read-only file", "path", openFile.Path)
+						logger.Debug("SET_INFO: delete disposition on read-only file", "path", openFile.Name().Path)
 						return setInfoStatus(types.StatusCannotDelete), nil
 					}
 				}
@@ -1291,7 +1292,7 @@ func (h *Handler) setFileInfoFromStore(
 				lockFileHandle, openFile.ShareName, excludeOwner,
 			); breakErr != nil {
 				logger.Debug("SET_INFO: delete-disposition handle lease break failed",
-					"path", openFile.Path, "error", breakErr)
+					"path", openFile.Name().Path, "error", breakErr)
 			}
 		}
 
@@ -1305,7 +1306,7 @@ func (h *Handler) setFileInfoFromStore(
 		h.StoreOpenFile(openFile)
 
 		logger.Debug("SET_INFO: delete disposition set",
-			"path", openFile.Path,
+			"path", openFile.Name().Path,
 			"deletePending", deletePending,
 			"class", class)
 		return setInfoStatus(types.StatusSuccess), nil
@@ -1331,7 +1332,7 @@ func (h *Handler) setFileInfoFromStore(
 		if h.LeaseManager != nil && len(openFile.MetadataHandle) > 0 {
 			lockFileHandle := lock.FileHandle(openFile.MetadataHandle)
 			if breakErr := h.LeaseManager.BreakReadLeasesOnWrite(lockFileHandle, openFile.ShareName, openFile.LeaseKey); breakErr != nil {
-				logger.Debug("SET_INFO: oplock break on EOF set failed (non-fatal)", "path", openFile.Path, "error", breakErr)
+				logger.Debug("SET_INFO: oplock break on EOF set failed (non-fatal)", "path", openFile.Name().Path, "error", breakErr)
 			}
 			// MS-SMB2 §3.3.4.18: truncation is a data-modifying op that
 			// breaks Level-II Read leases to NONE — purge any disconnected
@@ -1344,7 +1345,7 @@ func (h *Handler) setFileInfoFromStore(
 					true,
 				); purged > 0 {
 					logger.Debug("SET_INFO: purged disconnected handles on EOF set",
-						"path", openFile.Path,
+						"path", openFile.Name().Path,
 						"count", purged)
 				}
 			}
@@ -1366,7 +1367,7 @@ func (h *Handler) setFileInfoFromStore(
 			true,
 		); err != nil {
 			logger.Debug("SET_INFO: truncation blocked by lock",
-				"path", openFile.Path, "newSize", newSize)
+				"path", openFile.Name().Path, "newSize", newSize)
 			return setInfoStatus(types.StatusFileLockConflict), nil
 		}
 
@@ -1382,7 +1383,7 @@ func (h *Handler) setFileInfoFromStore(
 
 		_, err = metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, setAttrs)
 		if err != nil {
-			logger.Debug("SET_INFO: failed to set EOF", "path", openFile.Path, "error", err)
+			logger.Debug("SET_INFO: failed to set EOF", "path", openFile.Name().Path, "error", err)
 			return setInfoStatus(common.MapToSMB(err)), nil
 		}
 
@@ -1393,7 +1394,7 @@ func (h *Handler) setFileInfoFromStore(
 		// SETATTR/CREATE-truncate drive the same common helper.
 		if rErr := common.ReclaimTruncatedBlocks(authCtx.Context, h.Registry, openFile.MetadataHandle, preFile, newSize); rErr != nil {
 			logger.Warn("SET_INFO: block store truncate reclaim failed",
-				"path", openFile.Path, "size", newSize, "error", rErr)
+				"path", openFile.Name().Path, "size", newSize, "error", rErr)
 		}
 
 		// Restore frozen timestamps after truncation (which updates Mtime/Ctime)
@@ -1411,7 +1412,7 @@ func (h *Handler) setFileInfoFromStore(
 		h.breakParentDirLeasesForContentChange(ctx, authCtx, openFile)
 
 		if h.NotifyRegistry != nil {
-			h.NotifyRegistry.NotifyChange(openFile.ShareName, GetParentPath(openFile.Path), notifyStreamName(openFile.FileName), FileActionModified, FileNotifyChangeSize)
+			h.notifyOpenFileModified(openFile, FileNotifyChangeSize)
 		}
 
 		return setInfoStatus(types.StatusSuccess), nil
@@ -1445,7 +1446,7 @@ func (h *Handler) setFileInfoFromStore(
 		if h.LeaseManager != nil && len(openFile.MetadataHandle) > 0 {
 			lockFileHandle := lock.FileHandle(openFile.MetadataHandle)
 			if breakErr := h.LeaseManager.BreakReadLeasesOnWrite(lockFileHandle, openFile.ShareName, openFile.LeaseKey); breakErr != nil {
-				logger.Debug("SET_INFO: oplock break on allocation set failed (non-fatal)", "path", openFile.Path, "error", breakErr)
+				logger.Debug("SET_INFO: oplock break on allocation set failed (non-fatal)", "path", openFile.Name().Path, "error", breakErr)
 			}
 		}
 		// Record the requested reservation per-handle so a later QUERY_INFO on
@@ -1477,7 +1478,7 @@ func (h *Handler) setFileInfoFromStore(
 						Size: &requested,
 					}); err != nil {
 						logger.Debug("SET_INFO: allocation-driven truncate failed",
-							"path", openFile.Path, "error", err)
+							"path", openFile.Name().Path, "error", err)
 						return setInfoStatus(common.MapToSMB(err)), nil
 					}
 					// Discard block data past the new EOF (curFile is the pre-op
@@ -1486,14 +1487,14 @@ func (h *Handler) setFileInfoFromStore(
 					// bytes as content instead of zeros.
 					if rErr := common.ReclaimTruncatedBlocks(authCtx.Context, h.Registry, openFile.MetadataHandle, curFile, requested); rErr != nil {
 						logger.Warn("SET_INFO: allocation-driven block truncate reclaim failed",
-							"path", openFile.Path, "size", requested, "error", rErr)
+							"path", openFile.Name().Path, "size", requested, "error", rErr)
 					}
 					h.restoreFrozenTimestamps(authCtx, openFile)
 					flushSmbDelayedWrite(openFile)
 					h.StoreOpenFile(openFile)
 					h.breakParentDirLeasesForContentChange(ctx, authCtx, openFile)
 					if h.NotifyRegistry != nil {
-						h.NotifyRegistry.NotifyChange(openFile.ShareName, GetParentPath(openFile.Path), notifyStreamName(openFile.FileName), FileActionModified, FileNotifyChangeSize)
+						h.notifyOpenFileModified(openFile, FileNotifyChangeSize)
 					}
 				}
 			}
@@ -1548,13 +1549,13 @@ func (h *Handler) setFileInfoFromStore(
 		entries, decErr := decodeFullEaEntries(buffer)
 		if decErr != nil {
 			logger.Debug("SET_INFO: FileFullEaInformation decode failed",
-				"path", openFile.Path, "error", decErr)
+				"path", openFile.Name().Path, "error", decErr)
 			return setInfoStatus(types.StatusInvalidParameter), nil
 		}
 		for _, e := range entries {
 			if isReservedACLXattrName(e.name) {
 				logger.Debug("SET_INFO: FileFullEaInformation reserved name rejected",
-					"path", openFile.Path, "name", e.name)
+					"path", openFile.Name().Path, "name", e.name)
 				return setInfoStatus(types.StatusAccessDenied), nil
 			}
 		}
@@ -1567,14 +1568,14 @@ func (h *Handler) setFileInfoFromStore(
 		setAttrs := &metadata.SetAttrs{EAMutations: eaMutationsFromEntries(entries)}
 		if _, err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, setAttrs); err != nil {
 			logger.Debug("SET_INFO: FileFullEaInformation persist failed",
-				"path", openFile.Path, "error", err)
+				"path", openFile.Name().Path, "error", err)
 			return setInfoStatus(common.MapToSMB(err)), nil
 		}
 
 		logger.Debug("SET_INFO: FileFullEaInformation persisted",
-			"path", openFile.Path, "count", len(entries))
+			"path", openFile.Name().Path, "count", len(entries))
 		if h.NotifyRegistry != nil {
-			h.NotifyRegistry.NotifyChange(openFile.ShareName, GetParentPath(openFile.Path), notifyStreamName(openFile.FileName), FileActionModified, FileNotifyChangeEa)
+			h.notifyOpenFileModified(openFile, FileNotifyChangeEa)
 		}
 		return setInfoStatus(types.StatusSuccess), nil
 
@@ -1665,7 +1666,7 @@ func (h *Handler) restoreFrozenTimestamps(authCtx *metadata.AuthContext, openFil
 	openFile.mu.RUnlock()
 
 	logger.Debug("restoreFrozenTimestamps: restoring",
-		"path", openFile.Path,
+		"path", openFile.Name().Path,
 		"mtimeFrozen", mtimeFrozen,
 		"ctimeFrozen", ctimeFrozen,
 		"atimeFrozen", atimeFrozen,
@@ -1675,7 +1676,7 @@ func (h *Handler) restoreFrozenTimestamps(authCtx *metadata.AuthContext, openFil
 
 	metaSvc := h.Registry.GetMetadataService()
 	if _, err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, restoreAttrs); err != nil {
-		logger.Debug("restoreFrozenTimestamps: failed", "path", openFile.Path, "error", err)
+		logger.Debug("restoreFrozenTimestamps: failed", "path", openFile.Name().Path, "error", err)
 		return
 	}
 
@@ -1720,13 +1721,13 @@ func (h *Handler) restoreParentDirFrozenTimestamps(authCtx *metadata.AuthContext
 		metaSvc := h.Registry.GetMetadataService()
 		if _, err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, restoreAttrs); err != nil {
 			logger.Debug("restoreParentDirFrozenTimestamps: failed",
-				"path", openFile.Path, "error", err)
+				"path", openFile.Name().Path, "error", err)
 		} else {
 			// IsMtimeFrozen / IsCtimeFrozen / IsAtimeFrozen each take
 			// openFile.mu (read); see #606. Cheap because the parent-dir
 			// frozen log line is debug-gated.
 			logger.Debug("restoreParentDirFrozenTimestamps: restored",
-				"path", openFile.Path,
+				"path", openFile.Name().Path,
 				"mtimeFrozen", openFile.IsMtimeFrozen(),
 				"ctimeFrozen", openFile.IsCtimeFrozen(),
 				"atimeFrozen", openFile.IsAtimeFrozen())
@@ -1831,7 +1832,7 @@ func (h *Handler) setSecurityInfo(
 	// already captured the DACL-evaluated rights at CREATE time.
 	if status, ok := checkSetInfoSecurityAccess(openFile.GrantedAccess, additionalInfo); !ok {
 		logger.Debug("SET_INFO Security: handle lacks required access",
-			"path", openFile.Path,
+			"path", openFile.Name().Path,
 			"additionalInfo", fmt.Sprintf("0x%x", additionalInfo),
 			"grantedAccess", fmt.Sprintf("0x%x", openFile.GrantedAccess))
 		return setInfoStatus(status), nil
@@ -1844,7 +1845,7 @@ func (h *Handler) setSecurityInfo(
 
 	ownerUID, ownerGID, fileACL, err := ParseSecurityDescriptorWithOptions(buffer, opts)
 	if err != nil {
-		logger.Debug("SET_INFO: failed to parse security descriptor", "path", openFile.Path, "error", err)
+		logger.Debug("SET_INFO: failed to parse security descriptor", "path", openFile.Name().Path, "error", err)
 		return setInfoStatus(types.StatusInvalidParameter), nil
 	}
 
@@ -1887,11 +1888,11 @@ func (h *Handler) setSecurityInfo(
 				curUID, curGID = cur.UID, cur.GID
 			}
 			if ownerReject && !isCurrentOwnerSID(reqOwnerSID, curUID) {
-				logger.Debug("SET_INFO Security: owner change requested with foreign-domain SID", "path", openFile.Path)
+				logger.Debug("SET_INFO Security: owner change requested with foreign-domain SID", "path", openFile.Name().Path)
 				return setInfoStatus(types.StatusInvalidOwner), nil
 			}
 			if groupReject && !isCurrentGroupSID(reqGroupSID, curGID) {
-				logger.Debug("SET_INFO Security: group change requested with foreign-domain SID", "path", openFile.Path)
+				logger.Debug("SET_INFO Security: group change requested with foreign-domain SID", "path", openFile.Name().Path)
 				return setInfoStatus(types.StatusNoneMapped), nil
 			}
 		}
@@ -1940,19 +1941,19 @@ func (h *Handler) setSecurityInfo(
 
 	if !changed {
 		if h.NotifyRegistry != nil {
-			h.NotifyRegistry.NotifyChange(openFile.ShareName, GetParentPath(openFile.Path), notifyStreamName(openFile.FileName), FileActionModified, FileNotifyChangeSecurity)
+			h.notifyOpenFileModified(openFile, FileNotifyChangeSecurity)
 		}
 		return setInfoStatus(types.StatusSuccess), nil
 	}
 
 	_, err = metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, setAttrs)
 	if err != nil {
-		logger.Debug("SET_INFO: failed to set security info", "path", openFile.Path, "error", err)
+		logger.Debug("SET_INFO: failed to set security info", "path", openFile.Name().Path, "error", err)
 		return setInfoStatus(common.MapToSMB(err)), nil
 	}
 
 	if h.NotifyRegistry != nil {
-		h.NotifyRegistry.NotifyChange(openFile.ShareName, GetParentPath(openFile.Path), notifyStreamName(openFile.FileName), FileActionModified, FileNotifyChangeSecurity)
+		h.notifyOpenFileModified(openFile, FileNotifyChangeSecurity)
 	}
 
 	return setInfoStatus(types.StatusSuccess), nil
@@ -2072,10 +2073,10 @@ func checkSetInfoSecurityAccess(grantedAccess, additionalInfo uint32) (types.Sta
 // after the triggering request's response, matching Samba's tevent-cycle
 // `send_break_to_none` semantics.
 func (h *Handler) breakParentDirLeasesForContentChange(ctx *SMBHandlerContext, authCtx *metadata.AuthContext, openFile *OpenFile) {
-	if len(openFile.ParentHandle) == 0 {
+	if len(openFile.Name().ParentHandle) == 0 {
 		return
 	}
-	h.breakParentDirLeasesForContentChangeOn(ctx, authCtx, openFile.ParentHandle, openFile)
+	h.breakParentDirLeasesForContentChangeOn(ctx, authCtx, openFile.Name().ParentHandle, openFile)
 }
 
 // breakParentDirLeasesForContentChangeOn is the multi-parent variant used by
@@ -2113,7 +2114,7 @@ func (h *Handler) breakParentDirLeasesForContentChangeOn(ctx *SMBHandlerContext,
 	// exclusion — same-client breaks fire when the key doesn't match.
 	excludeParentKey := openFile.ParentLeaseKey
 	hasExcludeKey := openFile.HasParentLeaseKey
-	path := openFile.Path
+	path := openFile.Name().Path
 	parentDbg := fmt.Sprintf("%x", parentHandle)
 	shareName := openFile.ShareName
 
@@ -2166,7 +2167,7 @@ func (h *Handler) breakDstParentDirHandleLeasesForRename(authCtx *metadata.AuthC
 	excludeParentKey := openFile.ParentLeaseKey
 	hasExcludeKey := openFile.HasParentLeaseKey
 	if breakErr := h.LeaseManager.BreakParentHandleLeasesOnCreate(authCtx.Context, parentLockHandle, openFile.ShareName, "", excludeParentKey, hasExcludeKey); breakErr != nil {
-		logger.Debug("SET_INFO: dst-parent dir Handle lease pre-break failed", "path", openFile.Path, "dstParent", fmt.Sprintf("%x", dstParent), "error", breakErr)
+		logger.Debug("SET_INFO: dst-parent dir Handle lease pre-break failed", "path", openFile.Name().Path, "dstParent", fmt.Sprintf("%x", dstParent), "error", breakErr)
 	}
 }
 
@@ -2247,7 +2248,7 @@ func (h *Handler) handleFileLinkInformation(
 	// Hard-linking a directory is forbidden (MS-FSA 2.1.5.14.5).
 	if openFile.IsDirectory {
 		logger.Debug("SET_INFO: hardlink on directory rejected",
-			"path", openFile.Path)
+			"path", openFile.Name().Path)
 		return setInfoStatus(types.StatusFileIsADirectory), nil
 	}
 
@@ -2270,7 +2271,7 @@ func (h *Handler) handleFileLinkInformation(
 		// fall back to same-directory link.
 		logger.Debug("SET_INFO: hardlink with non-zero RootDirectory (using same-dir fallback)",
 			"rootDirectory", fmt.Sprintf("%x", linkInfo.RootDirectory))
-		dstDir = openFile.ParentHandle
+		dstDir = openFile.Name().ParentHandle
 		linkName = path.Base(newPath)
 	} else {
 		tree, ok := h.GetTree(openFile.TreeID)
@@ -2321,7 +2322,7 @@ func (h *Handler) handleFileLinkInformation(
 
 	if _, err := metaSvc.CreateHardLink(authCtx, dstDir, linkName, openFile.MetadataHandle); err != nil {
 		logger.Debug("SET_INFO: CreateHardLink failed",
-			"src", openFile.Path, "dst", newPath, "error", err)
+			"src", openFile.Name().Path, "dst", newPath, "error", err)
 		return setInfoStatus(common.MapToSMB(err)), nil
 	}
 
@@ -2375,7 +2376,7 @@ func (h *Handler) handleFileLinkInformation(
 	}
 
 	logger.Debug("SET_INFO: hardlink created",
-		"src", openFile.Path, "dst", newPath, "name", linkName)
+		"src", openFile.Name().Path, "dst", newPath, "name", linkName)
 	return setInfoStatus(types.StatusSuccess), nil
 }
 

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -788,10 +788,9 @@ func (h *Handler) setFileInfoFromStore(
 			// Update open file state. The handle lock serializes this
 			// read-modify-write against a concurrent rename on the same handle.
 			openFile.mu.Lock()
-			cur := openFile.Name()
-			newName := *cur
+			newName := openFile.Name()
+			parentPath := GetParentPath(newName.Path)
 			newName.FileName = toName
-			parentPath := GetParentPath(cur.Path)
 			if parentPath == "" || parentPath == "/" || parentPath == "." {
 				newName.Path = toName
 			} else {

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -727,7 +727,10 @@ func (h *Handler) setFileInfoFromStore(
 		if strings.HasPrefix(newPath, ":") {
 			// Extract the base file name from the current open file name.
 			// The current file is an ADS: "basefile:streamname"
-			baseName := openFile.Name().FileName
+			// One snapshot: the move below must not take its directory from
+			// one rename and its name from another.
+			oldName := openFile.Name()
+			baseName := oldName.FileName
 			if colonIdx := strings.Index(baseName, ":"); colonIdx > 0 {
 				baseName = baseName[:colonIdx]
 			}
@@ -739,22 +742,21 @@ func (h *Handler) setFileInfoFromStore(
 
 			// Build new child name: basefile + new stream suffix
 			toName := baseName + newPath
-			toDir := openFile.Name().ParentHandle
+			toDir := oldName.ParentHandle
 
 			// Save old path info for notification before modification
-			oldPath := openFile.Name().Path
-			oldFileName := openFile.Name().FileName
-			oldParentPath := GetParentPath(oldPath)
+			oldFileName := oldName.FileName
+			oldParentPath := GetParentPath(oldName.Path)
 
 			// Per MS-FSA 2.1.5.14.10: Save mtime/ctime before rename
 			restoreTimestamps := h.saveTimestamps(authCtx, openFile.MetadataHandle)
 
 			// Perform the rename
 			metaSvc := h.Registry.GetMetadataService()
-			_, err = metaSvc.Move(authCtx, toDir, openFile.Name().FileName, toDir, toName)
+			_, err = metaSvc.Move(authCtx, toDir, oldFileName, toDir, toName)
 			if err != nil {
 				logger.Debug("SET_INFO: stream rename failed",
-					"from", openFile.Name().FileName,
+					"from", oldFileName,
 					"to", toName,
 					"error", err)
 				return setInfoStatus(common.MapToSMB(err)), nil
@@ -770,7 +772,8 @@ func (h *Handler) setFileInfoFromStore(
 			if h.NotifyRegistry != nil {
 				tree, ok := h.GetTree(openFile.TreeID)
 				if ok {
-					newParentPath := GetParentPath(openFile.Name().Path)
+					// A stream rename stays in the same directory.
+					newParentPath := oldParentPath
 					if newParentPath == "" || newParentPath == "." {
 						newParentPath = "/"
 					}
@@ -858,8 +861,8 @@ func (h *Handler) setFileInfoFromStore(
 		}
 
 		// Validate we have source info
-		if len(openFile.Name().ParentHandle) == 0 {
-			logger.Debug("SET_INFO: cannot rename root directory", "path", openFile.Name().Path)
+		if srcName := openFile.Name(); len(srcName.ParentHandle) == 0 {
+			logger.Debug("SET_INFO: cannot rename root directory", "path", srcName.Path)
 			return setInfoStatus(types.StatusAccessDenied), nil
 		}
 
@@ -1244,8 +1247,8 @@ func (h *Handler) setFileInfoFromStore(
 		wasDeletePending := openFile.DeletePending
 
 		// Validate we have parent info for deletion
-		if deletePending && len(openFile.Name().ParentHandle) == 0 {
-			logger.Debug("SET_INFO: cannot delete root directory", "path", openFile.Name().Path)
+		if delName := openFile.Name(); deletePending && len(delName.ParentHandle) == 0 {
+			logger.Debug("SET_INFO: cannot delete root directory", "path", delName.Path)
 			return setInfoStatus(types.StatusAccessDenied), nil
 		}
 
@@ -2073,10 +2076,11 @@ func checkSetInfoSecurityAccess(grantedAccess, additionalInfo uint32) (types.Sta
 // after the triggering request's response, matching Samba's tevent-cycle
 // `send_break_to_none` semantics.
 func (h *Handler) breakParentDirLeasesForContentChange(ctx *SMBHandlerContext, authCtx *metadata.AuthContext, openFile *OpenFile) {
-	if len(openFile.Name().ParentHandle) == 0 {
+	parentHandle := openFile.Name().ParentHandle
+	if len(parentHandle) == 0 {
 		return
 	}
-	h.breakParentDirLeasesForContentChangeOn(ctx, authCtx, openFile.Name().ParentHandle, openFile)
+	h.breakParentDirLeasesForContentChangeOn(ctx, authCtx, parentHandle, openFile)
 }
 
 // breakParentDirLeasesForContentChangeOn is the multi-parent variant used by

--- a/internal/adapter/smb/handlers/set_info_ads_attrs_test.go
+++ b/internal/adapter/smb/handlers/set_info_ads_attrs_test.go
@@ -100,15 +100,12 @@ func setupADSAttrPropagationTest(t *testing.T, basePOSIXMode uint32) (
 	h := NewHandler()
 	h.Registry = rt
 
-	streamOpen := &OpenFile{
+	streamOpen := (&OpenFile{
 		FileID:         [16]byte{0xAD, 0x5A, 0x77, 0x52, 0xC0, 0x01},
 		MetadataHandle: streamHandle,
-		ParentHandle:   rootHandle,
-		FileName:       "base.txt:s",
-		Path:           "base.txt:s",
 		ShareName:      shareName,
 		DesiredAccess:  uint32(types.FileWriteAttributes) | uint32(types.FileWriteData) | uint32(types.FileReadData),
-	}
+	}).WithName(OpenName{Path: "base.txt:s", FileName: "base.txt:s", ParentHandle: rootHandle})
 	h.StoreOpenFile(streamOpen)
 
 	return h, authCtx, baseHandle, streamHandle, streamOpen

--- a/internal/adapter/smb/handlers/set_info_ea_persist_test.go
+++ b/internal/adapter/smb/handlers/set_info_ea_persist_test.go
@@ -61,18 +61,15 @@ func setupEATest(t *testing.T) (*Handler, *metadata.AuthContext, *OpenFile) {
 	h := NewHandler()
 	h.Registry = rt
 
-	open := &OpenFile{
+	open := (&OpenFile{
 		FileID:         [16]byte{0xEA, 0x01},
 		MetadataHandle: handle,
-		ParentHandle:   rootHandle,
-		FileName:       "ea.txt",
-		Path:           "ea.txt",
 		ShareName:      shareName,
 		GrantedAccess: uint32(types.FileWriteEA) | uint32(types.FileReadEA) |
 			uint32(types.FileWriteAttributes) | uint32(types.FileReadAttributes) |
 			uint32(types.Delete),
 		DesiredAccess: uint32(types.FileWriteEA) | uint32(types.FileReadEA),
-	}
+	}).WithName(OpenName{Path: "ea.txt", FileName: "ea.txt", ParentHandle: rootHandle})
 	h.StoreOpenFile(open)
 	return h, authCtx, open
 }

--- a/internal/adapter/smb/handlers/set_info_security_authz_test.go
+++ b/internal/adapter/smb/handlers/set_info_security_authz_test.go
@@ -71,15 +71,12 @@ func setupSecurityAuthzTest(t *testing.T) (*Handler, *OpenFile, *metadata.AuthCo
 	h := NewHandler()
 	h.Registry = rt
 
-	openFile := &OpenFile{
+	openFile := (&OpenFile{
 		FileID:         [16]byte{9, 9, 9, 9},
 		MetadataHandle: fileHandle,
-		ParentHandle:   rootHandle,
-		FileName:       "g.dat",
-		Path:           "g.dat",
 		ShareName:      shareName,
-		// GrantedAccess intentionally zero; caller stamps per test.
-	}
+		// GrantedAccess intentionally zero; caller stamps per test.,
+	}).WithName(OpenName{Path: "g.dat", FileName: "g.dat", ParentHandle: rootHandle})
 	h.StoreOpenFile(openFile)
 	return h, openFile, authCtx
 }

--- a/internal/adapter/smb/handlers/set_info_security_authz_test.go
+++ b/internal/adapter/smb/handlers/set_info_security_authz_test.go
@@ -75,7 +75,7 @@ func setupSecurityAuthzTest(t *testing.T) (*Handler, *OpenFile, *metadata.AuthCo
 		FileID:         [16]byte{9, 9, 9, 9},
 		MetadataHandle: fileHandle,
 		ShareName:      shareName,
-		// GrantedAccess intentionally zero; caller stamps per test.,
+		// GrantedAccess intentionally zero; caller stamps per test.
 	}).WithName(OpenName{Path: "g.dat", FileName: "g.dat", ParentHandle: rootHandle})
 	h.StoreOpenFile(openFile)
 	return h, openFile, authCtx

--- a/internal/adapter/smb/handlers/set_info_security_toggle_test.go
+++ b/internal/adapter/smb/handlers/set_info_security_toggle_test.go
@@ -68,18 +68,15 @@ func setupACLToggleTest(t *testing.T, shareName string, canonicalize bool) (*Han
 	h := NewHandler()
 	h.Registry = rt
 
-	openFile := &OpenFile{
+	openFile := (&OpenFile{
 		FileID:         [16]byte{1, 2, 3, 4},
 		MetadataHandle: fileHandle,
-		ParentHandle:   rootHandle,
-		FileName:       "f.dat",
-		Path:           "f.dat",
 		ShareName:      shareName,
 		DesiredAccess:  uint32(types.FileWriteAttributes) | uint32(types.WriteDac),
 		// Refs #559: setSecurityInfo gates on the open's GrantedAccess
 		// (Samba fsp->access_mask); SECINFO_DACL requires WRITE_DAC.
 		GrantedAccess: uint32(types.FileWriteAttributes) | uint32(types.WriteDac),
-	}
+	}).WithName(OpenName{Path: "f.dat", FileName: "f.dat", ParentHandle: rootHandle})
 	h.StoreOpenFile(openFile)
 
 	return h, openFile, authCtx

--- a/internal/adapter/smb/handlers/set_info_sparse_preservation_test.go
+++ b/internal/adapter/smb/handlers/set_info_sparse_preservation_test.go
@@ -83,15 +83,12 @@ func setupSparsePreservationTest(t *testing.T, seedFSCTLBits uint32) (
 	h := NewHandler()
 	h.Registry = rt
 
-	open := &OpenFile{
+	open := (&OpenFile{
 		FileID:         [16]byte{0x59, 0x9A, 0x12, 0x33},
 		MetadataHandle: fileHandle,
-		ParentHandle:   rootHandle,
-		FileName:       "sparse.txt",
-		Path:           "sparse.txt",
 		ShareName:      shareName,
 		DesiredAccess:  uint32(types.FileWriteAttributes),
-	}
+	}).WithName(OpenName{Path: "sparse.txt", FileName: "sparse.txt", ParentHandle: rootHandle})
 	h.StoreOpenFile(open)
 
 	return h, authCtx, fileHandle, open

--- a/internal/adapter/smb/handlers/set_info_timestamp_preservation_test.go
+++ b/internal/adapter/smb/handlers/set_info_timestamp_preservation_test.go
@@ -76,15 +76,12 @@ func setupBasicInfoTimestampTest(t *testing.T) (
 	h := NewHandler()
 	h.Registry = rt
 
-	open := &OpenFile{
+	open := (&OpenFile{
 		FileID:         [16]byte{0x75, 0x73, 0x31},
 		MetadataHandle: fileHandle,
-		ParentHandle:   rootHandle,
-		FileName:       "ts.txt",
-		Path:           "ts.txt",
 		ShareName:      shareName,
 		DesiredAccess:  uint32(types.FileWriteAttributes) | uint32(types.FileReadAttributes),
-	}
+	}).WithName(OpenName{Path: "ts.txt", FileName: "ts.txt", ParentHandle: rootHandle})
 	h.StoreOpenFile(open)
 
 	return h, authCtx, fileHandle, open

--- a/internal/adapter/smb/handlers/set_info_truncate_reclaim_test.go
+++ b/internal/adapter/smb/handlers/set_info_truncate_reclaim_test.go
@@ -85,17 +85,14 @@ func setupTruncateTest(t *testing.T) (*Handler, *metadata.AuthContext, *OpenFile
 	h := NewHandler()
 	h.Registry = rt
 
-	open := &OpenFile{
+	open := (&OpenFile{
 		FileID:         [16]byte{0x7C, 0x01},
 		MetadataHandle: handle,
-		ParentHandle:   rootHandle,
-		FileName:       "repro.bin",
-		Path:           "repro.bin",
 		ShareName:      shareName,
 		GrantedAccess: uint32(types.FileWriteData) | uint32(types.FileReadData) |
 			uint32(types.FileWriteAttributes) | uint32(types.FileReadAttributes),
 		DesiredAccess: uint32(types.FileWriteData) | uint32(types.FileReadData),
-	}
+	}).WithName(OpenName{Path: "repro.bin", FileName: "repro.bin", ParentHandle: rootHandle})
 	h.StoreOpenFile(open)
 	return h, authCtx, open
 }

--- a/internal/adapter/smb/handlers/set_reparse_point.go
+++ b/internal/adapter/smb/handlers/set_reparse_point.go
@@ -94,11 +94,11 @@ func (h *Handler) handleSetReparsePoint(ctx *SMBHandlerContext, body []byte) (*H
 
 	if err := h.convertOpenFileToNativeSymlink(ctx, openFile, target); err != nil {
 		logger.Warn("IOCTL SET_REPARSE_POINT: failed to create symlink",
-			"path", openFile.Path, "target", target, "error", err)
+			"path", openFile.Name().Path, "target", target, "error", err)
 		return NewErrorResult(common.MapToSMB(err)), nil
 	}
 
-	logger.Debug("IOCTL SET_REPARSE_POINT: created symlink", "path", openFile.Path, "target", target)
+	logger.Debug("IOCTL SET_REPARSE_POINT: created symlink", "path", openFile.Name().Path, "target", target)
 
 	// FSCTL_SET_REPARSE_POINT has no output buffer.
 	resp := buildIoctlResponse(FsctlSetReparsePoint, fileID, nil)
@@ -196,7 +196,8 @@ func stripReparsePrefix(s string) string {
 // skip and step 6 (POSTQUERY GetFile) resolve the symlink. The client does not
 // set DELETE_ON_CLOSE here, so no delete fires.
 func (h *Handler) convertOpenFileToNativeSymlink(ctx *SMBHandlerContext, openFile *OpenFile, target string) error {
-	if len(openFile.ParentHandle) == 0 || openFile.FileName == "" {
+	name := openFile.Name()
+	if len(name.ParentHandle) == 0 || name.FileName == "" {
 		return fmt.Errorf("missing parent handle or filename for symlink conversion")
 	}
 
@@ -210,8 +211,8 @@ func (h *Handler) convertOpenFileToNativeSymlink(ctx *SMBHandlerContext, openFil
 		return err
 	}
 
-	parentHandle := openFile.ParentHandle
-	fileName := openFile.FileName
+	parentHandle := name.ParentHandle
+	fileName := name.FileName
 
 	metaSvc := h.Registry.GetMetadataService()
 	removed, _, err := metaSvc.RemoveFile(authCtx, parentHandle, fileName)
@@ -225,7 +226,7 @@ func (h *Handler) convertOpenFileToNativeSymlink(ctx *SMBHandlerContext, openFil
 	if removed != nil {
 		removedPayloadID = removed.PayloadID
 	}
-	h.purgeBlockStorePayload(ctx.Context, openFile.MetadataHandle, removedPayloadID, openFile.Path, "SET_REPARSE_POINT")
+	h.purgeBlockStorePayload(ctx.Context, openFile.MetadataHandle, removedPayloadID, openFile.Name().Path, "SET_REPARSE_POINT")
 
 	symlink, _, err := metaSvc.CreateSymlink(authCtx, parentHandle, fileName, target, &metadata.FileAttr{})
 	if err != nil {
@@ -237,7 +238,7 @@ func (h *Handler) convertOpenFileToNativeSymlink(ctx *SMBHandlerContext, openFil
 			Type: metadata.FileTypeRegular, Mode: 0o644,
 		}); reErr != nil {
 			logger.Warn("SET_REPARSE_POINT: symlink create failed and placeholder rollback failed",
-				"path", openFile.Path, "createErr", err, "rollbackErr", reErr)
+				"path", openFile.Name().Path, "createErr", err, "rollbackErr", reErr)
 		}
 		return fmt.Errorf("failed to create symlink: %w", err)
 	}
@@ -259,7 +260,7 @@ func (h *Handler) convertOpenFileToNativeSymlink(ctx *SMBHandlerContext, openFil
 	// Notify directory watchers of the placeholder→symlink replacement so client
 	// directory views (Finder/Explorer) refresh without a full re-enumeration.
 	if h.NotifyRegistry != nil {
-		parentPath := GetParentPath(openFile.Path)
+		parentPath := GetParentPath(openFile.Name().Path)
 		h.NotifyRegistry.NotifyChange(openFile.ShareName, parentPath, fileName, FileActionRemoved, FileNotifyChangeFileName)
 		h.NotifyRegistry.NotifyChange(openFile.ShareName, parentPath, fileName, FileActionAdded, FileNotifyChangeFileName)
 	}

--- a/internal/adapter/smb/handlers/set_reparse_point.go
+++ b/internal/adapter/smb/handlers/set_reparse_point.go
@@ -226,7 +226,7 @@ func (h *Handler) convertOpenFileToNativeSymlink(ctx *SMBHandlerContext, openFil
 	if removed != nil {
 		removedPayloadID = removed.PayloadID
 	}
-	h.purgeBlockStorePayload(ctx.Context, openFile.MetadataHandle, removedPayloadID, openFile.Name().Path, "SET_REPARSE_POINT")
+	h.purgeBlockStorePayload(ctx.Context, openFile.MetadataHandle, removedPayloadID, name.Path, "SET_REPARSE_POINT")
 
 	symlink, _, err := metaSvc.CreateSymlink(authCtx, parentHandle, fileName, target, &metadata.FileAttr{})
 	if err != nil {
@@ -238,7 +238,7 @@ func (h *Handler) convertOpenFileToNativeSymlink(ctx *SMBHandlerContext, openFil
 			Type: metadata.FileTypeRegular, Mode: 0o644,
 		}); reErr != nil {
 			logger.Warn("SET_REPARSE_POINT: symlink create failed and placeholder rollback failed",
-				"path", openFile.Name().Path, "createErr", err, "rollbackErr", reErr)
+				"path", name.Path, "createErr", err, "rollbackErr", reErr)
 		}
 		return fmt.Errorf("failed to create symlink: %w", err)
 	}
@@ -260,7 +260,7 @@ func (h *Handler) convertOpenFileToNativeSymlink(ctx *SMBHandlerContext, openFil
 	// Notify directory watchers of the placeholder→symlink replacement so client
 	// directory views (Finder/Explorer) refresh without a full re-enumeration.
 	if h.NotifyRegistry != nil {
-		parentPath := GetParentPath(openFile.Name().Path)
+		parentPath := GetParentPath(name.Path)
 		h.NotifyRegistry.NotifyChange(openFile.ShareName, parentPath, fileName, FileActionRemoved, FileNotifyChangeFileName)
 		h.NotifyRegistry.NotifyChange(openFile.ShareName, parentPath, fileName, FileActionAdded, FileNotifyChangeFileName)
 	}

--- a/internal/adapter/smb/handlers/set_reparse_point_test.go
+++ b/internal/adapter/smb/handlers/set_reparse_point_test.go
@@ -110,18 +110,15 @@ func setupReparseShare(t *testing.T) (*Handler, *SMBHandlerContext, metadata.Fil
 	})
 
 	fileID := [16]byte{1}
-	openFile := &OpenFile{
+	openFile := (&OpenFile{
 		FileID:         fileID,
 		TreeID:         treeID,
 		SessionID:      sess.SessionID,
-		Path:           fileName,
 		ShareName:      shareName,
 		DesiredAccess:  uint32(types.FileReadData | types.FileWriteData),
 		GrantedAccess:  uint32(types.FileReadData | types.FileWriteData),
 		MetadataHandle: fileHandle,
-		ParentHandle:   rootHandle,
-		FileName:       fileName,
-	}
+	}).WithName(OpenName{Path: fileName, FileName: fileName, ParentHandle: rootHandle})
 	h.StoreOpenFile(openFile)
 
 	smbCtx := &SMBHandlerContext{

--- a/internal/adapter/smb/handlers/state_debug.go
+++ b/internal/adapter/smb/handlers/state_debug.go
@@ -95,7 +95,7 @@ func (h *Handler) AuditSessionCleanup(sessionID uint64) int {
 			logger.Warn("LEAKED open file after session cleanup",
 				"sessionID", sessionID,
 				"fileID", fmt.Sprintf("%x", f.FileID),
-				"path", f.Path,
+				"path", f.Name().Path,
 				"shareName", f.ShareName,
 				"openTime", f.OpenTime,
 			)

--- a/internal/adapter/smb/handlers/stub_handlers.go
+++ b/internal/adapter/smb/handlers/stub_handlers.go
@@ -128,7 +128,7 @@ func (h *Handler) handleGetReparsePoint(ctx *SMBHandlerContext, body []byte) (*H
 	target, _, err := metaSvc.ReadSymlink(authCtx, openFile.MetadataHandle)
 	if err != nil {
 		logger.Debug("IOCTL GET_REPARSE_POINT: not a symlink or read failed",
-			"path", openFile.Path, "error", err)
+			"path", openFile.Name().Path, "error", err)
 		// Check if it's not a symlink
 		if storeErr, ok := err.(*metadata.StoreError); ok && storeErr.Code == metadata.ErrInvalidArgument {
 			return NewErrorResult(types.StatusNotAReparsePoint), nil
@@ -136,7 +136,7 @@ func (h *Handler) handleGetReparsePoint(ctx *SMBHandlerContext, body []byte) (*H
 		return NewErrorResult(common.MapToSMB(err)), nil
 	}
 
-	logger.Debug("IOCTL GET_REPARSE_POINT: symlink target", "path", openFile.Path, "target", target)
+	logger.Debug("IOCTL GET_REPARSE_POINT: symlink target", "path", openFile.Name().Path, "target", target)
 
 	// Build SYMBOLIC_LINK_REPARSE_DATA_BUFFER [MS-FSCC] 2.1.2.4
 	reparseData := buildSymlinkReparseBuffer(target)
@@ -467,7 +467,7 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 
 	// Verify it's a directory
 	if !openFile.IsDirectory {
-		logger.Debug("CHANGE_NOTIFY: not a directory", "path", openFile.Path)
+		logger.Debug("CHANGE_NOTIFY: not a directory", "path", openFile.Name().Path)
 		return NewErrorResult(types.StatusInvalidParameter), nil
 	}
 
@@ -507,7 +507,7 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 	const fileListDirectory uint32 = 0x00000001
 	if openFile.GrantedAccess&fileListDirectory == 0 {
 		logger.Debug("CHANGE_NOTIFY: missing FILE_LIST_DIRECTORY access",
-			"path", openFile.Path,
+			"path", openFile.Name().Path,
 			"grantedAccess", fmt.Sprintf("0x%x", openFile.GrantedAccess),
 			"desiredAccess", fmt.Sprintf("0x%x", openFile.DesiredAccess))
 		return NewErrorResult(types.StatusAccessDenied), nil
@@ -520,7 +520,7 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 	}
 
 	// Build the watch path (share-relative)
-	watchPath := openFile.Path
+	watchPath := openFile.Name().Path
 	if watchPath == "" {
 		watchPath = "/"
 	}
@@ -1010,7 +1010,7 @@ func (h *Handler) handleReadFileUsnData(ctx *SMBHandlerContext, body []byte) (*H
 
 	useV3 := maxMajorVersion >= 3
 
-	fileNameBytes := encodeUTF16LE(openFile.FileName)
+	fileNameBytes := encodeUTF16LE(openFile.Name().FileName)
 	fileAttrs := uint32(FileAttrToSMBAttributes(&file.FileAttr))
 
 	// Note: Usn, TimeStamp, Reason, SourceInfo, SecurityId are stub zeros.
@@ -1077,7 +1077,7 @@ func (h *Handler) handleReadFileUsnData(ctx *SMBHandlerContext, body []byte) (*H
 		usnVersion = 3
 	}
 	logger.Debug("IOCTL READ_FILE_USN_DATA: success",
-		"path", openFile.Path,
+		"path", openFile.Name().Path,
 		"version", usnVersion)
 	return NewResult(types.StatusSuccess, resp), nil
 }
@@ -1120,7 +1120,7 @@ func (h *Handler) handlePipeTransceive(ctx *SMBHandlerContext, body []byte) (*Ha
 
 	if !openFile.IsPipe {
 		logger.Debug("IOCTL PIPE_TRANSCEIVE: not a pipe",
-			"path", openFile.Path)
+			"path", openFile.Name().Path)
 		return NewErrorResult(types.StatusInvalidDeviceRequest), nil
 	}
 

--- a/internal/adapter/smb/handlers/timestamps_test.go
+++ b/internal/adapter/smb/handlers/timestamps_test.go
@@ -58,15 +58,12 @@ func setupTimestampTest(t *testing.T) (*Handler, *metadata.AuthContext, metadata
 	h := NewHandler()
 	h.Registry = rt
 
-	openFile := &OpenFile{
+	openFile := (&OpenFile{
 		FileID:         [16]byte{1, 2, 3, 4},
 		MetadataHandle: fileHandle,
-		ParentHandle:   rootHandle,
-		FileName:       "f.dat",
-		Path:           "f.dat",
 		ShareName:      shareName,
 		DesiredAccess:  uint32(types.FileWriteAttributes) | uint32(types.FileWriteData) | uint32(types.FileReadData) | uint32(types.Delete),
-	}
+	}).WithName(OpenName{Path: "f.dat", FileName: "f.dat", ParentHandle: rootHandle})
 	h.StoreOpenFile(openFile)
 
 	return h, authCtx, fileHandle, openFile
@@ -512,16 +509,13 @@ func TestDirFreezeTimestamps_ChildCreate_AllFrozen(t *testing.T) {
 	h.Registry = rt
 
 	// Step 2: "Open" the directory (create an OpenFile).
-	dirOpenFile := &OpenFile{
+	dirOpenFile := (&OpenFile{
 		FileID:         [16]byte{0xAA},
 		MetadataHandle: dirHandle,
-		ParentHandle:   rootHandle,
-		FileName:       "testdir",
-		Path:           "testdir",
 		ShareName:      shareName,
 		IsDirectory:    true,
 		DesiredAccess:  uint32(types.FileWriteAttributes) | uint32(types.FileReadAttributes),
-	}
+	}).WithName(OpenName{Path: "testdir", FileName: "testdir", ParentHandle: rootHandle})
 	h.StoreOpenFile(dirOpenFile)
 
 	// Step 3: Freeze all four timestamps via SET_INFO(-1).
@@ -657,16 +651,13 @@ func TestDirFreezeTimestamps_ChildCreate_WalkPath(t *testing.T) {
 
 	h := NewHandler()
 	h.Registry = rt
-	dirOpenFile := &OpenFile{
+	dirOpenFile := (&OpenFile{
 		FileID:         [16]byte{0xCC},
 		MetadataHandle: dirHandle,
-		ParentHandle:   rootHandle,
-		FileName:       "testdir",
-		Path:           "testdir",
 		ShareName:      shareName,
 		IsDirectory:    true,
 		DesiredAccess:  uint32(types.FileWriteAttributes) | uint32(types.FileReadAttributes),
-	}
+	}).WithName(OpenName{Path: "testdir", FileName: "testdir", ParentHandle: rootHandle})
 	h.StoreOpenFile(dirOpenFile)
 
 	freezeAll := makeBasicInfoBuffer(filetimeFreeze, filetimeFreeze, filetimeFreeze, filetimeFreeze, 0)
@@ -815,16 +806,13 @@ func TestDirFreezeTimestamps_ChildCreate_SingleField(t *testing.T) {
 
 			h := NewHandler()
 			h.Registry = rt
-			dirOpenFile := &OpenFile{
+			dirOpenFile := (&OpenFile{
 				FileID:         [16]byte{0xBB},
 				MetadataHandle: dirHandle,
-				ParentHandle:   rootHandle,
-				FileName:       "testdir",
-				Path:           "testdir",
 				ShareName:      shareName,
 				IsDirectory:    true,
 				DesiredAccess:  uint32(types.FileWriteAttributes) | uint32(types.FileReadAttributes),
-			}
+			}).WithName(OpenName{Path: "testdir", FileName: "testdir", ParentHandle: rootHandle})
 			h.StoreOpenFile(dirOpenFile)
 
 			// Freeze only the target timestamp.
@@ -934,22 +922,19 @@ func TestUpdateBaseObjectTimestampsForADSWrite_PreservesBaseCtimeWhenFrozen(t *t
 
 	h := NewHandler()
 	h.Registry = rt
-	adsOpen := &OpenFile{
+	adsOpen := (&OpenFile{
 		FileID:         [16]byte{0xAD, 0x5C},
 		MetadataHandle: streamHandle,
-		ParentHandle:   rootHandle,
-		FileName:       "basedir:streamname",
-		Path:           "basedir:streamname",
 		ShareName:      shareName,
 		IsDirectory:    false,
 		DesiredAccess:  uint32(types.FileWriteData) | uint32(types.FileWriteAttributes),
 		CtimeFrozen:    true, // SET_INFO -1 on ChangeTime
 		FrozenCtime:    &pinned,
-	}
+	}).WithName(OpenName{Path: "basedir:streamname", FileName: "basedir:streamname", ParentHandle: rootHandle})
 	h.StoreOpenFile(adsOpen)
 
 	// Trigger the WRITE-path base-timestamp update.
-	h.updateBaseObjectTimestampsForADSWrite(authCtx, metaSvc, adsOpen, adsOpen.ParentHandle, "basedir")
+	h.updateBaseObjectTimestampsForADSWrite(authCtx, metaSvc, adsOpen, adsOpen.Name().ParentHandle, "basedir")
 
 	// Verify the base directory's Ctime is unchanged but Mtime was advanced
 	// (because only Ctime is frozen on the ADS handle).

--- a/internal/adapter/smb/handlers/write.go
+++ b/internal/adapter/smb/handlers/write.go
@@ -190,6 +190,8 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 		return h.handlePipeWrite(ctx, req, openFile)
 	}
 
+	path := openFile.Name().Path
+
 	// ========================================================================
 	// Step 2b: Validate write access
 	// ========================================================================
@@ -205,7 +207,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 
 	if !hasWriteAccess(openFile.GrantedAccess) {
 		logger.Debug("WRITE: no write access on handle",
-			"path", openFile.Name().Path,
+			"path", path,
 			"grantedAccess", fmt.Sprintf("0x%x", openFile.GrantedAccess))
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusAccessDenied}}, nil
 	}
@@ -215,7 +217,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	// ========================================================================
 
 	if openFile.IsDirectory {
-		logger.Debug("WRITE: cannot write to directory", "path", openFile.Name().Path)
+		logger.Debug("WRITE: cannot write to directory", "path", path)
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidDeviceRequest}}, nil
 	}
 
@@ -231,24 +233,24 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	const int64Max = uint64(1<<63 - 1)        // 0x7FFFFFFFFFFFFFFF
 	const maxFileSize = uint64(0xFFFFFFF0000) // NTFS max file size (~16TB)
 	if req.Offset > int64Max {
-		logger.Debug("WRITE: invalid offset (high bit set)", "path", openFile.Name().Path, "offset", req.Offset)
+		logger.Debug("WRITE: invalid offset (high bit set)", "path", path, "offset", req.Offset)
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}, nil
 	}
 	if len(req.Data) > 0 {
 		writeEnd := req.Offset + uint64(len(req.Data))
 		if writeEnd < req.Offset || writeEnd > int64Max {
-			logger.Debug("WRITE: offset+length overflow or exceeds INT64_MAX", "path", openFile.Name().Path,
+			logger.Debug("WRITE: offset+length overflow or exceeds INT64_MAX", "path", path,
 				"offset", req.Offset, "length", len(req.Data))
 			return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}, nil
 		}
 		if writeEnd > maxFileSize {
-			logger.Debug("WRITE: offset+length exceeds MAXFILESIZE", "path", openFile.Name().Path,
+			logger.Debug("WRITE: offset+length exceeds MAXFILESIZE", "path", path,
 				"offset", req.Offset, "length", len(req.Data), "maxFileSize", maxFileSize)
 			return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}, nil
 		}
 		if writeEnd == maxFileSize {
 			// Writing right up to MAXFILESIZE boundary: Windows returns DISK_FULL
-			logger.Debug("WRITE: at MAXFILESIZE boundary", "path", openFile.Name().Path,
+			logger.Debug("WRITE: at MAXFILESIZE boundary", "path", path,
 				"offset", req.Offset, "length", len(req.Data))
 			return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusDiskFull}}, nil
 		}
@@ -261,7 +263,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	// value so the clamp never rejects every write.
 	if h.MaxWriteSize > 0 && uint32(len(req.Data)) > h.MaxWriteSize {
 		logger.Debug("WRITE: length exceeds negotiated MaxWriteSize",
-			"path", openFile.Name().Path, "length", len(req.Data), "maxWriteSize", h.MaxWriteSize)
+			"path", path, "length", len(req.Data), "maxWriteSize", h.MaxWriteSize)
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}, nil
 	}
 
@@ -294,7 +296,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	// ========================================================================
 
 	if !HasWritePermission(ctx) {
-		logger.Debug("WRITE: access denied", "path", openFile.Name().Path, "permission", ctx.Permission)
+		logger.Debug("WRITE: access denied", "path", path, "permission", ctx.Permission)
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusAccessDenied}}, nil
 	}
 
@@ -305,7 +307,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	// Per MS-SMB2: zero-length writes are valid no-ops that return success
 	// with 0 bytes written. Skip the prepare/write/commit cycle.
 	if len(req.Data) == 0 {
-		logger.Debug("WRITE: zero-length write (no-op)", "path", openFile.Name().Path, "offset", req.Offset)
+		logger.Debug("WRITE: zero-length write (no-op)", "path", path, "offset", req.Offset)
 		return &WriteResponse{
 			SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess},
 			Count:           0,
@@ -320,7 +322,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	metaSvc := h.Registry.GetMetadataService()
 	blockStore, err := common.ResolveForWrite(ctx.Context, h.Registry, openFile.MetadataHandle)
 	if err != nil {
-		logger.Warn("WRITE: block store not available for handle", "path", openFile.Name().Path, "error", err)
+		logger.Warn("WRITE: block store not available for handle", "path", path, "error", err)
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInternalError}}, nil
 	}
 
@@ -358,7 +360,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 		uint64(len(req.Data)),
 		true, // isWrite = true for write operations
 	); err != nil {
-		logger.Debug("WRITE: blocked by lock", "path", openFile.Name().Path, "offset", req.Offset, "length", len(req.Data))
+		logger.Debug("WRITE: blocked by lock", "path", path, "offset", req.Offset, "length", len(req.Data))
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusFileLockConflict}}, nil
 	}
 
@@ -373,7 +375,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	if h.LeaseManager != nil {
 		lockFileHandle := lock.FileHandle(openFile.MetadataHandle)
 		if breakErr := h.LeaseManager.BreakReadLeasesOnWrite(lockFileHandle, openFile.ShareName, openFile.LeaseKey); breakErr != nil {
-			logger.Debug("WRITE: oplock break failed (non-fatal)", "path", openFile.Name().Path, "error", breakErr)
+			logger.Debug("WRITE: oplock break failed (non-fatal)", "path", path, "error", breakErr)
 		}
 	}
 
@@ -391,7 +393,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 			true, // WRITE breaks Read leases to NONE — break_to lacks H.
 		); purged > 0 {
 			logger.Debug("WRITE: purged disconnected handles on data change",
-				"path", openFile.Name().Path,
+				"path", path,
 				"count", purged)
 		}
 	}
@@ -421,7 +423,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	newSize := req.Offset + uint64(len(req.Data))
 	writeOp, err := metaSvc.PrepareWrite(authCtx, openFile.MetadataHandle, newSize)
 	if err != nil {
-		logger.Debug("WRITE: prepare failed", "path", openFile.Name().Path, "error", err)
+		logger.Debug("WRITE: prepare failed", "path", path, "error", err)
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(err)}}, nil
 	}
 
@@ -433,7 +435,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	// plumbing lands in one place (see common/doc.go).
 	err = common.WriteToBlockStore(authCtx.Context, blockStore, writeOp.PayloadID, req.Data, req.Offset)
 	if err != nil {
-		logger.Warn("WRITE: content write failed", "path", openFile.Name().Path, "error", err)
+		logger.Warn("WRITE: content write failed", "path", path, "error", err)
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: common.MapContentToSMB(err)}}, nil
 	}
 
@@ -443,7 +445,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 
 	_, err = metaSvc.CommitWrite(authCtx, writeOp)
 	if err != nil {
-		logger.Warn("WRITE: commit failed", "path", openFile.Name().Path, "error", err)
+		logger.Warn("WRITE: commit failed", "path", path, "error", err)
 		// Data was written but metadata not updated - this is an inconsistent state
 		// but we still report the error
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(err)}}, nil
@@ -472,10 +474,10 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 		// metadata fsync — and fail the request rather than ack a durability
 		// guarantee that does not hold.
 		if _, flushErr := blockStore.Flush(authCtx.Context, string(writeOp.PayloadID)); flushErr != nil {
-			logger.Warn("WRITE: write-through content flush failed", "path", openFile.Name().Path, "error", flushErr)
+			logger.Warn("WRITE: write-through content flush failed", "path", path, "error", flushErr)
 			writeStatus = common.MapContentToSMB(flushErr)
 		} else if _, flushErr := metaSvc.FlushPendingWriteForFile(authCtx, openFile.MetadataHandle, true); flushErr != nil {
-			logger.Warn("WRITE: write-through metadata flush failed", "path", openFile.Name().Path, "error", flushErr)
+			logger.Warn("WRITE: write-through metadata flush failed", "path", path, "error", flushErr)
 			writeStatus = common.MapToSMB(flushErr)
 		}
 	} else {
@@ -487,7 +489,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 		// per-WRITE ack path. CLOSE and FLUSH remain strict for durability; a crash
 		// before the background fsync is caught by the journal size reconcile.
 		if _, flushErr := metaSvc.FlushPendingWriteForFile(authCtx, openFile.MetadataHandle, false); flushErr != nil {
-			logger.Debug("WRITE: deferred metadata flush failed (non-fatal)", "path", openFile.Name().Path, "error", flushErr)
+			logger.Debug("WRITE: deferred metadata flush failed (non-fatal)", "path", path, "error", flushErr)
 		}
 	}
 
@@ -500,11 +502,9 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	armSmbDelayedWrite(openFile, preWriteMtime, writeOp.NewMtime)
 	h.StoreOpenFile(openFile)
 
-	// Detect ADS writes once for timestamp propagation and change notification.
-	// A SET_INFO rename on another channel can rewrite the name, the path and
-	// the parent mid-WRITE, so snapshot all three together: re-reading would let
-	// the ADS classification, the parent-atime bump and the change notification
-	// below describe different names.
+	// One snapshot of the triple: the ADS classification, the parent-atime
+	// bump and the change notification below must describe the same name even
+	// when a rename commits mid-WRITE.
 	name := openFile.Name()
 	fileName, filePath, parentHandle := name.FileName, name.Path, name.ParentHandle
 	isADSWrite := false
@@ -569,7 +569,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	}
 
 	logger.Debug("WRITE successful",
-		"path", openFile.Name().Path,
+		"path", path,
 		"offset", req.Offset,
 		"bytes", len(req.Data))
 

--- a/internal/adapter/smb/handlers/write.go
+++ b/internal/adapter/smb/handlers/write.go
@@ -205,7 +205,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 
 	if !hasWriteAccess(openFile.GrantedAccess) {
 		logger.Debug("WRITE: no write access on handle",
-			"path", openFile.Path,
+			"path", openFile.Name().Path,
 			"grantedAccess", fmt.Sprintf("0x%x", openFile.GrantedAccess))
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusAccessDenied}}, nil
 	}
@@ -215,7 +215,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	// ========================================================================
 
 	if openFile.IsDirectory {
-		logger.Debug("WRITE: cannot write to directory", "path", openFile.Path)
+		logger.Debug("WRITE: cannot write to directory", "path", openFile.Name().Path)
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidDeviceRequest}}, nil
 	}
 
@@ -231,24 +231,24 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	const int64Max = uint64(1<<63 - 1)        // 0x7FFFFFFFFFFFFFFF
 	const maxFileSize = uint64(0xFFFFFFF0000) // NTFS max file size (~16TB)
 	if req.Offset > int64Max {
-		logger.Debug("WRITE: invalid offset (high bit set)", "path", openFile.Path, "offset", req.Offset)
+		logger.Debug("WRITE: invalid offset (high bit set)", "path", openFile.Name().Path, "offset", req.Offset)
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}, nil
 	}
 	if len(req.Data) > 0 {
 		writeEnd := req.Offset + uint64(len(req.Data))
 		if writeEnd < req.Offset || writeEnd > int64Max {
-			logger.Debug("WRITE: offset+length overflow or exceeds INT64_MAX", "path", openFile.Path,
+			logger.Debug("WRITE: offset+length overflow or exceeds INT64_MAX", "path", openFile.Name().Path,
 				"offset", req.Offset, "length", len(req.Data))
 			return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}, nil
 		}
 		if writeEnd > maxFileSize {
-			logger.Debug("WRITE: offset+length exceeds MAXFILESIZE", "path", openFile.Path,
+			logger.Debug("WRITE: offset+length exceeds MAXFILESIZE", "path", openFile.Name().Path,
 				"offset", req.Offset, "length", len(req.Data), "maxFileSize", maxFileSize)
 			return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}, nil
 		}
 		if writeEnd == maxFileSize {
 			// Writing right up to MAXFILESIZE boundary: Windows returns DISK_FULL
-			logger.Debug("WRITE: at MAXFILESIZE boundary", "path", openFile.Path,
+			logger.Debug("WRITE: at MAXFILESIZE boundary", "path", openFile.Name().Path,
 				"offset", req.Offset, "length", len(req.Data))
 			return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusDiskFull}}, nil
 		}
@@ -261,7 +261,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	// value so the clamp never rejects every write.
 	if h.MaxWriteSize > 0 && uint32(len(req.Data)) > h.MaxWriteSize {
 		logger.Debug("WRITE: length exceeds negotiated MaxWriteSize",
-			"path", openFile.Path, "length", len(req.Data), "maxWriteSize", h.MaxWriteSize)
+			"path", openFile.Name().Path, "length", len(req.Data), "maxWriteSize", h.MaxWriteSize)
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}, nil
 	}
 
@@ -294,7 +294,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	// ========================================================================
 
 	if !HasWritePermission(ctx) {
-		logger.Debug("WRITE: access denied", "path", openFile.Path, "permission", ctx.Permission)
+		logger.Debug("WRITE: access denied", "path", openFile.Name().Path, "permission", ctx.Permission)
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusAccessDenied}}, nil
 	}
 
@@ -305,7 +305,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	// Per MS-SMB2: zero-length writes are valid no-ops that return success
 	// with 0 bytes written. Skip the prepare/write/commit cycle.
 	if len(req.Data) == 0 {
-		logger.Debug("WRITE: zero-length write (no-op)", "path", openFile.Path, "offset", req.Offset)
+		logger.Debug("WRITE: zero-length write (no-op)", "path", openFile.Name().Path, "offset", req.Offset)
 		return &WriteResponse{
 			SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess},
 			Count:           0,
@@ -320,7 +320,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	metaSvc := h.Registry.GetMetadataService()
 	blockStore, err := common.ResolveForWrite(ctx.Context, h.Registry, openFile.MetadataHandle)
 	if err != nil {
-		logger.Warn("WRITE: block store not available for handle", "path", openFile.Path, "error", err)
+		logger.Warn("WRITE: block store not available for handle", "path", openFile.Name().Path, "error", err)
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInternalError}}, nil
 	}
 
@@ -358,7 +358,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 		uint64(len(req.Data)),
 		true, // isWrite = true for write operations
 	); err != nil {
-		logger.Debug("WRITE: blocked by lock", "path", openFile.Path, "offset", req.Offset, "length", len(req.Data))
+		logger.Debug("WRITE: blocked by lock", "path", openFile.Name().Path, "offset", req.Offset, "length", len(req.Data))
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusFileLockConflict}}, nil
 	}
 
@@ -373,7 +373,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	if h.LeaseManager != nil {
 		lockFileHandle := lock.FileHandle(openFile.MetadataHandle)
 		if breakErr := h.LeaseManager.BreakReadLeasesOnWrite(lockFileHandle, openFile.ShareName, openFile.LeaseKey); breakErr != nil {
-			logger.Debug("WRITE: oplock break failed (non-fatal)", "path", openFile.Path, "error", breakErr)
+			logger.Debug("WRITE: oplock break failed (non-fatal)", "path", openFile.Name().Path, "error", breakErr)
 		}
 	}
 
@@ -391,7 +391,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 			true, // WRITE breaks Read leases to NONE — break_to lacks H.
 		); purged > 0 {
 			logger.Debug("WRITE: purged disconnected handles on data change",
-				"path", openFile.Path,
+				"path", openFile.Name().Path,
 				"count", purged)
 		}
 	}
@@ -421,7 +421,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	newSize := req.Offset + uint64(len(req.Data))
 	writeOp, err := metaSvc.PrepareWrite(authCtx, openFile.MetadataHandle, newSize)
 	if err != nil {
-		logger.Debug("WRITE: prepare failed", "path", openFile.Path, "error", err)
+		logger.Debug("WRITE: prepare failed", "path", openFile.Name().Path, "error", err)
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(err)}}, nil
 	}
 
@@ -433,7 +433,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	// plumbing lands in one place (see common/doc.go).
 	err = common.WriteToBlockStore(authCtx.Context, blockStore, writeOp.PayloadID, req.Data, req.Offset)
 	if err != nil {
-		logger.Warn("WRITE: content write failed", "path", openFile.Path, "error", err)
+		logger.Warn("WRITE: content write failed", "path", openFile.Name().Path, "error", err)
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: common.MapContentToSMB(err)}}, nil
 	}
 
@@ -443,7 +443,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 
 	_, err = metaSvc.CommitWrite(authCtx, writeOp)
 	if err != nil {
-		logger.Warn("WRITE: commit failed", "path", openFile.Path, "error", err)
+		logger.Warn("WRITE: commit failed", "path", openFile.Name().Path, "error", err)
 		// Data was written but metadata not updated - this is an inconsistent state
 		// but we still report the error
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: common.MapToSMB(err)}}, nil
@@ -472,10 +472,10 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 		// metadata fsync — and fail the request rather than ack a durability
 		// guarantee that does not hold.
 		if _, flushErr := blockStore.Flush(authCtx.Context, string(writeOp.PayloadID)); flushErr != nil {
-			logger.Warn("WRITE: write-through content flush failed", "path", openFile.Path, "error", flushErr)
+			logger.Warn("WRITE: write-through content flush failed", "path", openFile.Name().Path, "error", flushErr)
 			writeStatus = common.MapContentToSMB(flushErr)
 		} else if _, flushErr := metaSvc.FlushPendingWriteForFile(authCtx, openFile.MetadataHandle, true); flushErr != nil {
-			logger.Warn("WRITE: write-through metadata flush failed", "path", openFile.Path, "error", flushErr)
+			logger.Warn("WRITE: write-through metadata flush failed", "path", openFile.Name().Path, "error", flushErr)
 			writeStatus = common.MapToSMB(flushErr)
 		}
 	} else {
@@ -487,7 +487,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 		// per-WRITE ack path. CLOSE and FLUSH remain strict for durability; a crash
 		// before the background fsync is caught by the journal size reconcile.
 		if _, flushErr := metaSvc.FlushPendingWriteForFile(authCtx, openFile.MetadataHandle, false); flushErr != nil {
-			logger.Debug("WRITE: deferred metadata flush failed (non-fatal)", "path", openFile.Path, "error", flushErr)
+			logger.Debug("WRITE: deferred metadata flush failed (non-fatal)", "path", openFile.Name().Path, "error", flushErr)
 		}
 	}
 
@@ -505,9 +505,8 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	// the parent mid-WRITE, so snapshot all three together: re-reading would let
 	// the ADS classification, the parent-atime bump and the change notification
 	// below describe different names.
-	openFile.RLock()
-	fileName, filePath, parentHandle := openFile.FileName, openFile.Path, openFile.ParentHandle
-	openFile.RUnlock()
+	name := openFile.Name()
+	fileName, filePath, parentHandle := name.FileName, name.Path, name.ParentHandle
 	isADSWrite := false
 	var baseFileName string
 	if colonIdx := strings.Index(fileName, ":"); colonIdx > 0 {
@@ -570,7 +569,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	}
 
 	logger.Debug("WRITE successful",
-		"path", openFile.Path,
+		"path", openFile.Name().Path,
 		"offset", req.Offset,
 		"bytes", len(req.Data))
 

--- a/internal/adapter/smb/handlers/write_through_test.go
+++ b/internal/adapter/smb/handlers/write_through_test.go
@@ -187,12 +187,11 @@ func TestPipeWrite_WriteThroughFlags(t *testing.T) {
 			h.MaxDialect = tc.maxDialect
 
 			pipeID := [16]byte{9}
-			h.StoreOpenFile(&OpenFile{
+			h.StoreOpenFile((&OpenFile{
 				FileID:   pipeID,
 				IsPipe:   true,
 				PipeName: "srvsvc",
-				Path:     "srvsvc",
-			})
+			}).WithName(OpenName{Path: "srvsvc"}))
 
 			resp, err := h.Write(smbCtx, &WriteRequest{
 				FileID: pipeID,


### PR DESCRIPTION
Closes #1940.

`OpenFile.Path`, `.FileName` and `.ParentHandle` were mutable exported fields. SET_INFO rename rewrites all three on a live handle, while the rest of the handler package read them with no lock from ~280 sites.

## Approach

The issue proposed unexporting the fields so the compiler forces every access through an accessor. That does not work here: all 156 files are `package handlers`, so unexported fields stay directly reachable and the compiler enforces nothing. Unexporting would have bought a one-time sweep and no lasting guarantee.

Instead the three fields become one immutable `OpenName` published through an `atomic.Pointer`:

```go
type OpenName struct {
	Path         string
	FileName     string
	ParentHandle metadata.FileHandle
}

func (f *OpenFile) Name() *OpenName   // never nil, safe under the handle lock
func (f *OpenFile) SetName(n OpenName)
```

A single load yields all three fields from the same rename. That removes the whole class rather than the named instances, and it disposes of both hazards the issue calls out:

- **Torn pairing** — `GetPath()` then `GetFileName()` could straddle a rename. There is now one load, so a caller that needs two or three fields takes one snapshot and cannot mix generations.
- **Reentrancy deadlock** — `RLock` is not safely reentrant with a writer queued, so an accessor could not be called while already holding `mu`. An atomic load has no such constraint; `buildPersistedDurableHandle` no longer needs its direct-field-read workaround.

Call sites were rewritten from compiler error positions rather than by text matching, so no site was missed and none was rewritten by accident.

## Torn pairings actually found and fixed

These were live bugs, not just unguarded reads:

- **CLOSE delete-on-close** (`close.go`) — the removal notification built its parent path from the CLOSE-entry snapshot while the delete target came from a later one, with a metadata flush in between. A rename landing in that window made the notification name the new file under the old parent.
- **SET_INFO stream rename** (`set_info.go`) — six separate reads: the destination directory from one, the move's source name from another, the notification path from a third. A concurrent rename would have moved the wrong child out of the wrong directory.
- **`checkShareModeConflict` / `isFileOrBaseDeletePending`** (`handler.go`) — a path derived from one read, compared against a second read of the same field.
- **`buildFileStreamInformation`** (`query_info.go`) — `baseName` from the function snapshot, but the ADS enumeration re-read the parent, so streams could be listed under a different parent than the base name came from.
- **MFsymlink conversion** (`close.go`, `set_reparse_point.go`) — the purge and notification re-read the path *after* the file had been removed under a different snapshot's name.

`buildPersistedDurableHandle` still holds `mu` across the row build (it reads other mutable fields), and both rename sites still hold `mu` across their read-modify-write so two renames cannot interleave. The `durablePurgeMu` → `openFile.mu` ordering is unchanged.

## Verification

- `TestOpenName_ConcurrentRenameAndRead_NoRace` hammers `SetName` against four concurrent readers and asserts the triple always agrees with itself. Confirmed it fails — data race plus torn-name assertion — when the atomic is swapped back for a plain pointer, so it pins the invariant rather than merely passing.
- `go build ./...`, `go vet ./...`, `golangci-lint`, `gofmt` clean.
- `go test -race ./internal/adapter/smb/...` green across all 12 packages.
