### PR TITLE
fix(block): stage whole blocks on readahead, fail closed on a cold re-read

### DIFF
--- a/internal/adapter/common/copy_payload_test.go
+++ b/internal/adapter/common/copy_payload_test.go
@@ -75,6 +75,10 @@ func (f *fakeCoordinator) FindByObjectID(_ context.Context, _ block.ObjectID) ([
 // Syncer.Flush short-circuit path; returning the zero ObjectID + nil is
 // the "never quiesced" disposition that keeps the interface satisfied
 // without affecting any assertions.
+// ReprojectBlocks is a no-op: this fake does not model the Blocks
+// projection.
+func (f *fakeCoordinator) ReprojectBlocks(_ context.Context, _ string) error { return nil }
+
 func (f *fakeCoordinator) GetFileObjectID(_ context.Context, _ string) (block.ObjectID, error) {
 	return block.ObjectID{}, nil
 }

--- a/pkg/block/engine/audit_state.go
+++ b/pkg/block/engine/audit_state.go
@@ -215,6 +215,13 @@ func walkAuditShareFiles(ctx context.Context, store metadata.Store, dirHandle me
 			return fmt.Errorf("list children: %w", err)
 		}
 		for _, e := range entries {
+			// The per-entry GetFile is load-bearing, not an oversight: e.Attr is
+			// the READDIRPLUS projection, and the relational backends leave its
+			// Blocks slice and PayloadID unloaded because hydrating ChunkRefs per
+			// row would make a listing quadratic. Building the file from e.Attr
+			// would hand the audit an empty manifest for every file and report a
+			// clean zero-ref result on a share full of dangling refs — the audit
+			// would fail open on exactly the corruption it exists to find.
 			child, err := store.GetFile(ctx, e.Handle)
 			if err != nil {
 				return fmt.Errorf("get file %q: %w", e.Name, err)

--- a/pkg/block/engine/coordinator.go
+++ b/pkg/block/engine/coordinator.go
@@ -64,11 +64,23 @@ type MetadataCoordinator interface {
 	// not a caller error.
 	DecrementRefCountAndReap(ctx context.Context, payloadID string, offset uint64) (uint32, error)
 
+	// ReprojectBlocks re-materializes FileAttr.Blocks from the file's
+	// surviving FileChunk manifest. Engine invokes it after the Truncate
+	// and PunchHole reap loops, where dropping manifest rows leaves the
+	// Blocks projection stale and snapshot/audit over-counting.
+	//
+	// Required, not optional: a coordinator that skips the reprojection
+	// leaves that over-count in place, and making it part of the interface
+	// is what turns "forgot to reproject" into a compile error rather than
+	// a silently drifting projection.
+	ReprojectBlocks(ctx context.Context, payloadID string) error
+
 	// PersistFileChunks updates FileAttr.Blocks AND FileAttr.ObjectID
-	// for a given file in a single metadata txn. Engine invokes this
-	// from the local store's rollup-completion callback (the
-	// ObjectIDPersister wired in engine.New). The runtime wrapper
-	// resolves payloadID → fileHandle and runs PutFile in one txn.
+	// for a given file in a single metadata txn. It is invoked by the
+	// runtime coordinator wrapper (which resolves payloadID → fileHandle
+	// and runs PutFile in one txn) after a Flush persists a file's chunk
+	// manifest — the engine itself no longer drives it from a local-store
+	// chunk-lifecycle hook, of which none remain.
 	//
 	// ObjectID is the BLAKE3 Merkle root over blocks (computed by
 	// block.ComputeObjectID at rollup commit time). Pass an

--- a/pkg/block/engine/coordinator_test.go
+++ b/pkg/block/engine/coordinator_test.go
@@ -175,6 +175,10 @@ func (f *fakeCoordinator) FindByObjectID(_ context.Context, oid block.ObjectID) 
 // sentinel + nil when the map is unset / payload absent. Mirrors the
 // runtime coordinator's "no row → zero ObjectID" disposition so unit
 // tests exercise the same trigger-condition code path as production.
+// ReprojectBlocks is a no-op: this fake does not model the Blocks
+// projection.
+func (f *fakeCoordinator) ReprojectBlocks(_ context.Context, _ string) error { return nil }
+
 func (f *fakeCoordinator) GetFileObjectID(_ context.Context, payloadID string) (block.ObjectID, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/pkg/block/engine/drain_persist_test.go
+++ b/pkg/block/engine/drain_persist_test.go
@@ -139,6 +139,10 @@ func (c *testCoordinator) FindByObjectID(ctx context.Context, objectID block.Obj
 	return c.store.FindByObjectID(ctx, objectID)
 }
 
+// ReprojectBlocks is a no-op: this fake does not model the Blocks
+// projection.
+func (c *testCoordinator) ReprojectBlocks(_ context.Context, _ string) error { return nil }
+
 func (c *testCoordinator) GetFileObjectID(ctx context.Context, payloadID string) (block.ObjectID, error) {
 	var zero block.ObjectID
 	file, err := c.store.GetFileByPayloadID(ctx, metadata.PayloadID(payloadID))

--- a/pkg/block/engine/engine_delete_test.go
+++ b/pkg/block/engine/engine_delete_test.go
@@ -125,6 +125,10 @@ func (c *refcountCoordinator) FindByObjectID(_ context.Context, _ block.ObjectID
 	return nil, nil
 }
 
+// ReprojectBlocks is a no-op: this fake does not model the Blocks
+// projection.
+func (c *refcountCoordinator) ReprojectBlocks(_ context.Context, _ string) error { return nil }
+
 func (c *refcountCoordinator) GetFileObjectID(_ context.Context, _ string) (block.ObjectID, error) {
 	return block.ObjectID{}, nil
 }

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -36,26 +36,63 @@ func (m *Syncer) fetchGroup(ctx context.Context) (*errgroup.Group, context.Conte
 	return g, gctx
 }
 
-// resolveFileChunk returns the FileChunk whose chunk range covers the
-// byte window [blockIdx*BlockSize, (blockIdx+1)*BlockSize) for payloadID
-// or (nil, nil) if no row covers that window (sparse / not yet uploaded).
+// coveringChunk pairs a manifest row with the block index its first byte falls
+// in, which is the in-flight dedup slot the fetch registers under.
+type coveringChunk struct {
+	blockIdx uint64
+	fb       *block.FileChunk
+}
+
+// collectCoveringChunks returns every manifest row covering [start, end), in
+// ascending offset order. It is the shared window walk behind the cold-read
+// demand fetch and the readahead prefetch.
 //
-// Post-Phase-18 the engine writers (ObjectIDPersister, ChunkEmitter)
-// encode the chunk's absolute byte Offset in the trailing component of
-// the FileChunk ID — not a synthetic blockIdx — because FastCDC chunk
-// boundaries do not align to BlockSize. Looking up by
-// "{payloadID}/{blockIdx*BlockSize}" therefore misses every non-first
-// chunk in a multi-chunk file. We instead enumerate the per-payload row
-// list and find the row whose [absOffset, absOffset+DataSize) interval
-// covers blockIdx*BlockSize, mirroring readLocalByHash's
-// findRowCoveringOffset walk.
+// Resolving one row per BlockSize-aligned offset is not enough: the engine
+// writers encode a chunk's absolute byte offset in the trailing component of its
+// FileChunk ID, and FastCDC boundaries do not align to BlockSize, so an 8 MiB
+// block routinely holds several chunks. A walk that resolved only the row at the
+// block-aligned offset would see the block's first chunk and silently drop every
+// chunk behind it.
 //
-// Post-Phase-17 the engine read path is CAS-only — fb.Hash MUST be non-
-// zero for any reachable block; the dispatchRemoteFetch helper enforces
-// this.
-func (m *Syncer) resolveFileChunk(ctx context.Context, payloadID string, blockIdx uint64) (*block.FileChunk, error) {
-	fb, _, err := resolveCovering(ctx, m.fileChunkStore, payloadID, blockIdx*uint64(BlockSize))
-	return fb, err
+// A hole steps to the next chunk that STARTS after the uncovered offset, not to
+// the next block boundary, because a hole can be followed by real data inside
+// the same block. A row that claims zero or too few bytes still advances the
+// cursor by one byte, so a degenerate manifest cannot spin the walk; it can only
+// make the walk re-probe, never make it terminate early and report the rest of
+// the window as hole.
+func (m *Syncer) collectCoveringChunks(ctx context.Context, payloadID string, start, end uint64) ([]coveringChunk, error) {
+	if m.fileChunkStore == nil {
+		return nil, nil
+	}
+	// One resolver for the whole walk: on a backend without the chunk-offset
+	// index every lookup falls back to a full per-payload manifest scan, and the
+	// resolver's snapshot turns K of those into one.
+	res := newChunkWindowResolver(m.fileChunkStore, payloadID)
+	var out []coveringChunk
+	for cur := start; cur < end; {
+		fb, absOff, err := res.covering(ctx, cur)
+		if err != nil {
+			return nil, err
+		}
+		if fb == nil {
+			next, ok, err := res.nextStart(ctx, cur)
+			if err != nil {
+				return nil, err
+			}
+			if !ok || next >= end {
+				break // nothing starts inside the window past cur — the rest is hole
+			}
+			cur = next
+			continue
+		}
+		out = append(out, coveringChunk{blockIdx: absOff / uint64(BlockSize), fb: fb})
+		next := absOff + uint64(fb.DataSize)
+		if next <= cur {
+			next = cur + 1 // a zero/short DataSize row must still advance the walk
+		}
+		cur = next
+	}
+	return out, nil
 }
 
 // listFileChunksSnapshot returns a point-in-time snapshot of the whole
@@ -245,50 +282,62 @@ func (m *Syncer) readChunkVerified(ctx context.Context, loc block.ChunkLocator, 
 	return data, nil
 }
 
-// fetchBlock downloads a single block from the remote store and writes it to the
-// local store. It backs the SyncQueue's prefetch/download workers, so it is the
-// engine's readahead fetch path (scheduleReadahead).
-// Returns nil data for sparse blocks (no FileChunk entry or missing S3 object).
-// Returns nil data when remoteStore is nil (local-only mode -- no remote data
-// exists) or when the block is already resident locally (nothing to fetch).
+// fetchBlock stages every chunk of one block into the local store. It backs the
+// SyncQueue's prefetch/download workers, so it is the engine's readahead fetch
+// path (scheduleReadahead), and the downloaded bytes are consumed by the
+// subsequent local read, not returned here.
 //
-// The fetch is routed through inlineFetchOrWait so it registers in the in-flight
-// dedup map: a concurrent demand read for the same block piggybacks on this
-// prefetch instead of issuing its own S3 GET. That shared budget is what keeps
-// total remote concurrency bounded when the readahead window overlaps demand.
-func (m *Syncer) fetchBlock(ctx context.Context, payloadID string, blockIdx uint64) ([]byte, error) {
+// It stages the whole block, not just the chunk at the block-aligned offset. A
+// block spans BlockSize bytes while FastCDC chunks are typically far smaller, so
+// resolving a single covering row left everything behind that row's first chunk
+// cold: readahead promised a block of lookahead and delivered one chunk of it,
+// and the demand read then paid the remote round-trips readahead exists to hide.
+//
+// A sparse block (no covering rows) and local-only mode (nil remoteStore) are
+// both nothing-to-do successes. Each chunk's fetch routes through
+// inlineFetchOrWait so it registers in the in-flight dedup map: a concurrent
+// demand read for the same chunk piggybacks on this prefetch instead of issuing
+// its own S3 GET. That shared budget is what keeps total remote concurrency
+// bounded when the readahead window overlaps demand.
+func (m *Syncer) fetchBlock(ctx context.Context, payloadID string, blockIdx uint64) error {
 	if !m.canProcess(ctx) {
-		return nil, ErrClosed
+		return ErrClosed
 	}
 
 	if m.remoteStore == nil {
 		logger.Debug("syncer: skipping fetchBlock, no remote store")
-		return nil, nil // No remote data exists
+		return nil // No remote data exists
 	}
 
 	// Health gate: fail fast when remote is unreachable
 	if !m.IsRemoteHealthy() {
 		m.offlineReadsBlocked.Add(1)
 		m.logOfflineRead("fetchBlock", payloadID, blockIdx)
-		return nil, m.remoteUnavailableError()
+		return m.remoteUnavailableError()
 	}
 
-	fb, err := m.resolveFileChunk(ctx, payloadID, blockIdx)
+	start := blockIdx * uint64(BlockSize)
+	chunks, err := m.collectCoveringChunks(ctx, payloadID, start, start+uint64(BlockSize))
 	if err != nil {
-		return nil, err
-	}
-	if fb == nil {
-		return nil, nil
+		return err
 	}
 
 	// ponytail: no local-presence probe — the journal is (payloadID,offset)-
 	// keyed, not hash-keyed, so there is no cheap per-hash Has(). Prefetch just
 	// fetches; the in-flight dedup collapses concurrent duplicates and Hydrate
-	// is idempotent, so a re-fetch of an already-warm block is at worst a
+	// is idempotent, so a re-fetch of an already-warm chunk is at worst a
 	// redundant GET (best-effort readahead). Add a journal residency probe here
 	// if redundant prefetch GETs ever show up in profiles.
-	data, _, err := m.inlineFetchOrWait(ctx, payloadID, blockIdx, fb)
-	return data, err
+	//
+	// Chunks are staged serially: this already runs on a SyncQueue worker, and
+	// fanning out here would multiply the pool's concurrency by the chunks per
+	// block behind the window that bounds it.
+	for _, c := range chunks {
+		if _, _, err := m.inlineFetchOrWait(ctx, payloadID, c.blockIdx, c.fb); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // fetchResolvedBlock downloads the already-resolved FileChunk row from the
@@ -365,51 +414,15 @@ func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, o
 	end := offset + uint64(length)
 
 	// Resolve EVERY chunk covering [offset, end), not just the chunk at each
-	// 8 MiB block-aligned offset. FastCDC chunks are typically smaller than
-	// BlockSize, so a block holds several chunks and a read window routinely
-	// spans chunk boundaries. The old loop iterated block indices and resolved
-	// only the chunk covering blockIdx*BlockSize, so every read window past a
-	// block's first chunk went unfetched — served as zeros/stale bytes — and
-	// only the block-aligned chunks were staged locally. Walk the actual
-	// covering chunks (mirrors readLocalByHash / fillFromCASManifest) so the
-	// whole window is downloaded.
-	type pending struct {
-		blockIdx uint64
-		fb       *block.FileChunk
-	}
-	var toFetch []pending
-	for cur := offset; cur < end; {
-		fb, absOff, err := resolveCovering(ctx, m.fileChunkStore, payloadID, cur)
-		if err != nil {
-			return false, err
-		}
-		if fb == nil {
-			// Sparse hole at cur: no chunk covers it. Chunk boundaries do not
-			// align to BlockSize, so a hole can be followed by real data inside
-			// the same block; advance to the next chunk that starts after cur
-			// rather than to the next block boundary. Skipping to the boundary
-			// would drop those chunks from the fetch list and the caller's
-			// re-read would then serve them as zeros.
-			next, ok, err := resolveNextChunkStart(ctx, m.fileChunkStore, payloadID, cur)
-			if err != nil {
-				return false, err
-			}
-			if !ok {
-				break // nothing starts past cur — the rest of the window is hole
-			}
-			cur = next
-			continue
-		}
-		// ponytail: no per-hash local-presence probe (journal is not hash-keyed);
-		// the caller only reaches here after journal.ReadAt reported the window
-		// cold, so fetch every covering chunk. Hydrate is idempotent for any
-		// already-warm sub-range.
-		toFetch = append(toFetch, pending{blockIdx: absOff / uint64(BlockSize), fb: fb})
-		next := absOff + uint64(fb.DataSize)
-		if next <= cur {
-			next = cur + 1 // guard: a zero/short DataSize row must still advance
-		}
-		cur = next
+	// 8 MiB block-aligned offset (see collectCoveringChunks).
+	//
+	// ponytail: no per-hash local-presence probe (journal is not hash-keyed);
+	// the caller only reaches here after journal.ReadAt reported the window
+	// cold, so fetch every covering chunk. Hydrate is idempotent for any
+	// already-warm sub-range.
+	toFetch, err := m.collectCoveringChunks(ctx, payloadID, offset, end)
+	if err != nil {
+		return false, err
 	}
 	if len(toFetch) == 0 {
 		// Nothing to fetch (pure hole) — the caller re-reads and zero-fills.

--- a/pkg/block/engine/fetch_test.go
+++ b/pkg/block/engine/fetch_test.go
@@ -104,9 +104,9 @@ func TestInlineFetchOrWait_LocalPutError_PropagatesToCaller(t *testing.T) {
 
 	m := newFetchSyncer(loc, rs, fbs, mds)
 
-	fb, err := m.resolveFileChunk(ctx, payloadID, 0)
+	fb, _, err := resolveCovering(ctx, m.fileChunkStore, payloadID, 0)
 	if err != nil {
-		t.Fatalf("resolveFileChunk: %v", err)
+		t.Fatalf("resolveCovering: %v", err)
 	}
 
 	gotData, downloaded, err := m.inlineFetchOrWait(ctx, payloadID, 0, fb)
@@ -152,9 +152,9 @@ func TestInlineFetchOrWait_LocalPutError_PropagatesToWaiter(t *testing.T) {
 
 	m := newFetchSyncer(loc, rs, fbs, mds)
 
-	fb, err := m.resolveFileChunk(ctx, payloadID, 0)
+	fb, _, err := resolveCovering(ctx, m.fileChunkStore, payloadID, 0)
 	if err != nil {
-		t.Fatalf("resolveFileChunk: %v", err)
+		t.Fatalf("resolveCovering: %v", err)
 	}
 
 	// Goroutine A: enters inlineFetchOrWait first, registers the in-flight

--- a/pkg/block/engine/fetch_window_test.go
+++ b/pkg/block/engine/fetch_window_test.go
@@ -1,0 +1,141 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"math/rand"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/local"
+	memorylocal "github.com/marmos91/dittofs/pkg/block/local/memory"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// TestFetchBlock_StagesEveryChunkInBlock pins the readahead prefetch to the
+// whole block it was asked for. A block spans BlockSize while FastCDC chunks
+// average well under that, so a block routinely holds several chunks; here two
+// 2 MiB chunks sit at offsets 0 and 2 MiB, both inside block 0.
+//
+// Resolving a single row at the block-aligned offset finds only the first chunk
+// and leaves the rest of the block cold, which quietly turns a block of
+// lookahead into a chunk of lookahead: the demand read that follows pays the
+// remote round-trips the prefetch was supposed to have already hidden. Both
+// chunks must be staged.
+//
+// Both store shapes are exercised because they resolve coverage by different
+// means — an offset index versus a manifest walk.
+func TestFetchBlock_StagesEveryChunkInBlock(t *testing.T) {
+	const (
+		oneMiB    = 1024 * 1024
+		chunkSize = 2 * oneMiB
+	)
+
+	for _, tc := range []struct {
+		name string
+		wrap func(*stubFileChunkStore) block.EngineFileChunkStore
+	}{
+		{"ListFileChunksFallback", func(s *stubFileChunkStore) block.EngineFileChunkStore { return s }},
+		{"OffsetIndexed", func(s *stubFileChunkStore) block.EngineFileChunkStore { return &indexedChunkStore{s} }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			payloadID := "payload-prefetch-multi-chunk"
+
+			first := make([]byte, chunkSize)
+			second := make([]byte, chunkSize)
+			rng := rand.New(rand.NewSource(0xFEED)) //nolint:gosec // deterministic fixture
+			rng.Read(first)
+			rng.Read(second)
+
+			loc := memorylocal.New()
+			rs := remotememory.New()
+			stub := newStubFileChunkStore()
+			mds := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+
+			seedSyncedRemoteChunk(t, stub, rs, mds, payloadID, 0, first)
+			seedSyncedRemoteChunk(t, stub, rs, mds, payloadID, chunkSize, second)
+
+			m := newFetchSyncer(loc, rs, tc.wrap(stub), mds)
+
+			if err := m.fetchBlock(ctx, payloadID, 0); err != nil {
+				t.Fatalf("fetchBlock: %v", err)
+			}
+
+			for _, want := range []struct {
+				offset int64
+				data   []byte
+			}{{0, first}, {chunkSize, second}} {
+				// Poison the destination so an unhydrated range fails loudly
+				// instead of matching a zero-filled read.
+				got := bytes.Repeat([]byte{0xAA}, chunkSize)
+				n, cold, err := loc.ReadAt(ctx, payloadID, want.offset, got)
+				if err != nil {
+					t.Fatalf("local ReadAt at %d: %v", want.offset, err)
+				}
+				if cold {
+					t.Fatalf("chunk at %d still cold: prefetch skipped it", want.offset)
+				}
+				if n != chunkSize {
+					t.Fatalf("local ReadAt at %d n = %d; want %d", want.offset, n, chunkSize)
+				}
+				if !bytes.Equal(got, want.data) {
+					t.Fatalf("chunk at %d not staged: got %x…, want %x…", want.offset, got[:16], want.data[:16])
+				}
+			}
+		})
+	}
+}
+
+// alwaysColdLocal reports every read as cold, standing in for a window whose
+// bytes the hydrate could not bring back — an evicted range whose manifest row
+// no longer resolves, or an eviction racing the hydrate. Only ReadAt is
+// exercised, so the embedded interface stays nil.
+type alwaysColdLocal struct {
+	local.LocalStore
+}
+
+func (alwaysColdLocal) ReadAt(_ context.Context, _ string, _ int64, dst []byte) (int, bool, error) {
+	return len(dst), true, nil
+}
+
+// TestReadAtInternal_StillColdAfterHydrateFailsClosed pins the post-hydrate
+// re-read to its own cold flag. Hydration is meant to make every
+// written-but-evicted byte in the window local again, so a re-read still
+// reporting cold means bytes the manifest claims were written could not be
+// brought back.
+//
+// journal.ReadAt zero-fills whatever it cannot serve, so ignoring that flag
+// returns a full-length success made of zeros — the silent-hole failure mode,
+// with no error at any layer. It must surface as ErrChunkNotFound instead.
+//
+// A never-written hole does not report cold, so a genuinely sparse file is
+// unaffected; a zero-length read returns before the hydrate path and cannot
+// reach the guard at all.
+func TestReadAtInternal_StillColdAfterHydrateFailsClosed(t *testing.T) {
+	ctx := context.Background()
+
+	// No remote: EnsureAvailableAndRead returns without hydrating anything, so
+	// the window is still cold on the re-read.
+	bs := &Store{
+		local:  alwaysColdLocal{},
+		syncer: &Syncer{stopCh: make(chan struct{}), config: DefaultConfig()},
+	}
+
+	data := bytes.Repeat([]byte{0xAA}, 4096)
+	n, err := bs.readAtInternal(ctx, "payload-still-cold", data, 0)
+	if err == nil {
+		t.Fatalf("readAtInternal returned (%d, nil) for a window still cold after hydrate; want an error", n)
+	}
+	if !errors.Is(err, block.ErrChunkNotFound) {
+		t.Fatalf("err = %v; want errors.Is(block.ErrChunkNotFound)", err)
+	}
+
+	// A zero-length read has no window to be cold about and must stay a
+	// no-error no-op rather than tripping the new guard.
+	if n, err := bs.readAtInternal(ctx, "payload-still-cold", nil, 0); err != nil || n != 0 {
+		t.Fatalf("readAtInternal(empty) = (%d, %v); want (0, nil)", n, err)
+	}
+}

--- a/pkg/block/engine/gc_test.go
+++ b/pkg/block/engine/gc_test.go
@@ -354,6 +354,10 @@ func (c *reapCoordinator) FindByObjectID(_ context.Context, _ block.ObjectID) ([
 	return nil, nil
 }
 
+// ReprojectBlocks is a no-op: this fake does not model the Blocks
+// projection.
+func (c *reapCoordinator) ReprojectBlocks(_ context.Context, _ string) error { return nil }
+
 func (c *reapCoordinator) GetFileObjectID(_ context.Context, _ string) (block.ObjectID, error) {
 	return block.ObjectID{}, nil
 }

--- a/pkg/block/engine/nil_remotestore_test.go
+++ b/pkg/block/engine/nil_remotestore_test.go
@@ -223,11 +223,7 @@ func TestNilRemoteStoreFetchBlock(t *testing.T) {
 	defer cleanup()
 	ctx := context.Background()
 
-	data, err := m.fetchBlock(ctx, "test/file.bin", 0)
-	if err != nil {
+	if err := m.fetchBlock(ctx, "test/file.bin", 0); err != nil {
 		t.Fatalf("fetchBlock with nil remoteStore should not error, got: %v", err)
-	}
-	if data != nil {
-		t.Error("fetchBlock with nil remoteStore should return nil data")
 	}
 }

--- a/pkg/block/engine/read_internal.go
+++ b/pkg/block/engine/read_internal.go
@@ -78,12 +78,27 @@ func (bs *Store) healCorruptWarmRead(ctx context.Context, payloadID string, data
 // the covering FileChunk rows, does one BLAKE3-verified ranged read per chunk,
 // and Hydrates the plaintext at the chunk's file offset; a range with no remote
 // chunk (genuine sparse hole) is left for ReadAt's zero-fill below.
+//
+// The re-read's cold flag is the post-condition, not a leftover: hydration is
+// supposed to have made every written-but-evicted byte in the window local
+// again, so a window still reporting cold means some byte the manifest claims
+// was written could not be brought back. ReadAt zero-fills what it cannot serve,
+// so accepting a cold re-read would hand the caller zeros for real data with no
+// error anywhere. Fail closed instead. A never-written hole does not report
+// cold, so a genuinely sparse file still reads as zeros; a zero-length window
+// never reaches here (readAtInternal returns early), and would report cold=false
+// regardless, so the guard has nothing to fail open on.
 func (bs *Store) ensureAndReadFromLocal(ctx context.Context, payloadID string, dest []byte, offset uint64) error {
 	if _, err := bs.syncer.EnsureAvailableAndRead(ctx, payloadID, offset, uint32(len(dest)), dest); err != nil {
 		return fmt.Errorf("cold read hydrate failed: %w", err)
 	}
-	if _, _, err := bs.local.ReadAt(ctx, payloadID, int64(offset), dest); err != nil {
+	_, cold, err := bs.local.ReadAt(ctx, payloadID, int64(offset), dest)
+	if err != nil {
 		return fmt.Errorf("read after hydrate failed: %w", err)
+	}
+	if cold {
+		return fmt.Errorf("window for %s at offset %d (%d bytes) is still cold after hydrate: %w",
+			payloadID, offset, len(dest), block.ErrChunkNotFound)
 	}
 	return nil
 }
@@ -146,32 +161,63 @@ type chunkAtOffsetResolver interface {
 	GetFileChunkAtOffset(ctx context.Context, payloadID string, off uint64) (*block.FileChunk, error)
 }
 
-// resolveCovering returns the FileChunk covering absolute byte offset off and
-// its parsed absolute start offset, or (nil, 0, nil) for a hole. When the store
-// implements chunkAtOffsetResolver (badger) it uses the indexed single-chunk
-// lookup that avoids enumerating the whole per-payload manifest; otherwise it
-// falls back to ListFileChunks + findRowCoveringOffset (memory/sqlite/postgres —
-// not the profiled hot path).
-func resolveCovering(ctx context.Context, store block.EngineFileChunkStore, payloadID string, off uint64) (*block.FileChunk, uint64, error) {
-	if store == nil {
-		return nil, 0, nil
+// chunkWindowResolver answers covering and successor lookups for one payload
+// across a whole window walk. A backend that indexes the lookup is asked per
+// offset, exactly as a single-shot resolve would. A backend without the index
+// falls back to a ListFileChunks scan, and a walk crossing K chunks would then
+// pay K full per-payload manifest fetches; the resolver takes that scan once and
+// answers every offset of the walk from the same rows, so the walk costs one
+// fetch regardless of how many chunks it spans.
+//
+// The snapshot is deliberately scoped to a single walk. A manifest mutating
+// mid-walk yields a torn view either way, and one consistent view is the safer
+// of the two.
+type chunkWindowResolver struct {
+	store     block.EngineFileChunkStore
+	payloadID string
+	rows      []*block.FileChunk
+	listed    bool
+}
+
+func newChunkWindowResolver(store block.EngineFileChunkStore, payloadID string) *chunkWindowResolver {
+	return &chunkWindowResolver{store: store, payloadID: payloadID}
+}
+
+// list returns the payload's manifest rows, scanning at most once per resolver.
+// A payload with no rows caches the empty snapshot too, so a sparse payload is
+// not re-scanned on every offset of the walk.
+func (r *chunkWindowResolver) list(ctx context.Context) ([]*block.FileChunk, error) {
+	if r.listed {
+		return r.rows, nil
 	}
-	if r, ok := store.(chunkAtOffsetResolver); ok {
-		fb, err := r.GetFileChunkAtOffset(ctx, payloadID, off)
+	rows, err := r.store.ListFileChunks(ctx, r.payloadID)
+	if err != nil {
+		if errors.Is(err, block.ErrFileChunkNotFound) {
+			r.listed = true
+			return nil, nil
+		}
+		return nil, err
+	}
+	r.rows, r.listed = rows, true
+	return rows, nil
+}
+
+// covering returns the FileChunk covering absolute byte offset off and its
+// parsed absolute start offset, or (nil, 0, nil) for a hole.
+func (r *chunkWindowResolver) covering(ctx context.Context, off uint64) (*block.FileChunk, uint64, error) {
+	if idx, ok := r.store.(chunkAtOffsetResolver); ok {
+		fb, err := idx.GetFileChunkAtOffset(ctx, r.payloadID, off)
 		if err != nil || fb == nil {
 			return nil, 0, err
 		}
-		abs, ok := block.ParseChunkOffset(fb.ID)
-		if !ok {
+		abs, parsed := block.ParseChunkOffset(fb.ID)
+		if !parsed {
 			return nil, 0, fmt.Errorf("%w: malformed FileChunk ID %q", block.ErrManifestInconsistent, fb.ID)
 		}
 		return fb, abs, nil
 	}
-	rows, err := store.ListFileChunks(ctx, payloadID)
+	rows, err := r.list(ctx)
 	if err != nil {
-		if errors.Is(err, block.ErrFileChunkNotFound) {
-			return nil, 0, nil
-		}
 		return nil, 0, err
 	}
 	rw, err := findRowCoveringOffset(rows, off)
@@ -182,6 +228,20 @@ func resolveCovering(ctx context.Context, store block.EngineFileChunkStore, payl
 		return nil, 0, nil
 	}
 	return rw.fb, rw.absOffset, nil
+}
+
+// resolveCovering returns the FileChunk covering absolute byte offset off and
+// its parsed absolute start offset, or (nil, 0, nil) for a hole. When the store
+// implements chunkAtOffsetResolver (badger) it uses the indexed single-chunk
+// lookup that avoids enumerating the whole per-payload manifest; otherwise it
+// falls back to ListFileChunks + findRowCoveringOffset (memory/sqlite/postgres —
+// not the profiled hot path). Callers walking a whole window should hold a
+// chunkWindowResolver instead so the fallback scan is paid once.
+func resolveCovering(ctx context.Context, store block.EngineFileChunkStore, payloadID string, off uint64) (*block.FileChunk, uint64, error) {
+	if store == nil {
+		return nil, 0, nil
+	}
+	return newChunkWindowResolver(store, payloadID).covering(ctx, off)
 }
 
 // chunkAtOrAfterOffsetResolver is the indexed successor lookup, implemented only
@@ -208,34 +268,36 @@ type chunkAtOrAfterOffsetResolver interface {
 // over. Unlike coverage, the successor answer is not scoped to a single row: an
 // unplaceable row sits at an unknown offset, so it may be the true successor,
 // and returning a later one would silently reclassify the bytes it holds as hole
-// for the caller to zero-fill. The two lookups here and in resolveCovering are
-// independent — a backend may index coverage without indexing succession, and
-// each walk is its own ListFileChunks snapshot — so the guard cannot be borrowed
-// from findRowCoveringOffset having already run.
+// for the caller to zero-fill. The coverage and succession lookups are
+// independent — a backend may index coverage without indexing succession — so
+// the guard cannot be borrowed from findRowCoveringOffset having already run,
+// even when both fall back to the same snapshot.
 func resolveNextChunkStart(ctx context.Context, store block.EngineFileChunkStore, payloadID string, off uint64) (uint64, bool, error) {
 	if store == nil {
 		return 0, false, nil
 	}
+	return newChunkWindowResolver(store, payloadID).nextStart(ctx, off)
+}
+
+// nextStart is resolveNextChunkStart over this resolver's snapshot.
+func (r *chunkWindowResolver) nextStart(ctx context.Context, off uint64) (uint64, bool, error) {
 	if off == math.MaxUint64 {
 		return 0, false, nil // nothing can start after the last representable offset
 	}
-	if r, ok := store.(chunkAtOrAfterOffsetResolver); ok {
-		fb, err := r.GetFileChunkAtOrAfterOffset(ctx, payloadID, off+1)
+	if idx, ok := r.store.(chunkAtOrAfterOffsetResolver); ok {
+		fb, err := idx.GetFileChunkAtOrAfterOffset(ctx, r.payloadID, off+1)
 		if err != nil || fb == nil {
 			return 0, false, err
 		}
-		abs, ok := block.ParseChunkOffset(fb.ID)
-		if !ok {
+		abs, parsed := block.ParseChunkOffset(fb.ID)
+		if !parsed {
 			return 0, false, fmt.Errorf("%w: nothing covers offset %d and the next chunk is unplaceable row %q",
 				block.ErrManifestInconsistent, off, fb.ID)
 		}
 		return abs, true, nil
 	}
-	rows, err := store.ListFileChunks(ctx, payloadID)
+	rows, err := r.list(ctx)
 	if err != nil {
-		if errors.Is(err, block.ErrFileChunkNotFound) {
-			return 0, false, nil
-		}
 		return 0, false, err
 	}
 	var (

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -119,14 +119,6 @@ func (bs *Store) WriteAt(ctx context.Context, payloadID string, currentBlocks []
 // hash. The new []ChunkRef list is returned for the caller to persist
 // via PutFile. When currentBlocks is empty the legacy path runs and
 // the returned slice is empty (dual-read shim semantics).
-// blocksReprojector is an optional coordinator capability: re-materialize
-// FileAttr.Blocks from the surviving FileChunk manifest after a reap. The
-// production metadataCoordinator implements it; unit-test coordinator fakes that
-// don't touch Blocks projection simply don't, and the reproject is skipped.
-type blocksReprojector interface {
-	ReprojectBlocks(ctx context.Context, payloadID string) error
-}
-
 // narrowChunkRow shrinks a manifest row to the surviving prefix of its chunk so
 // coverage lookups stop resolving it for bytes the file no longer holds and a
 // hydrate writes back only that prefix. The remote chunk is untouched — its hash
@@ -225,13 +217,11 @@ func (bs *Store) Truncate(ctx context.Context, payloadID string, currentBlocks [
 					return currentBlocks, fmt.Errorf("reap block on truncate-drop %s/%d: %w", payloadID, b.Offset, err)
 				}
 			}
-			// Re-materialize File.Blocks from the surviving manifest (R): the reap
-			// dropped the tail rows, so the projection must catch up or snapshot/audit
-			// over-count. Optional capability — test fakes skip it.
-			if rp, ok := bs.coordinator.(blocksReprojector); ok {
-				if err := rp.ReprojectBlocks(ctx, payloadID); err != nil {
-					return currentBlocks, fmt.Errorf("reproject after truncate %s: %w", payloadID, err)
-				}
+			// Re-materialize File.Blocks from the surviving manifest: the reap
+			// dropped the tail rows, so the projection must catch up or
+			// snapshot/audit over-count.
+			if err := bs.coordinator.ReprojectBlocks(ctx, payloadID); err != nil {
+				return currentBlocks, fmt.Errorf("reproject after truncate %s: %w", payloadID, err)
 			}
 		}
 	}
@@ -320,12 +310,10 @@ func (bs *Store) PunchHole(ctx context.Context, payloadID string, currentBlocks 
 					return currentBlocks, fmt.Errorf("reap block on punch %s/%d: %w", payloadID, b.Offset, err)
 				}
 			}
-			// Re-materialize File.Blocks from the surviving manifest (R) after the
-			// reap dropped the punched rows. Optional capability — test fakes skip it.
-			if rp, ok := bs.coordinator.(blocksReprojector); ok {
-				if err := rp.ReprojectBlocks(ctx, payloadID); err != nil {
-					return currentBlocks, fmt.Errorf("reproject after punch %s: %w", payloadID, err)
-				}
+			// Re-materialize File.Blocks from the surviving manifest after the
+			// reap dropped the punched rows.
+			if err := bs.coordinator.ReprojectBlocks(ctx, payloadID); err != nil {
+				return currentBlocks, fmt.Errorf("reproject after punch %s: %w", payloadID, err)
 			}
 		}
 	}

--- a/pkg/block/engine/sync_health.go
+++ b/pkg/block/engine/sync_health.go
@@ -38,6 +38,9 @@ type HealthMonitor struct {
 
 	stopCh   chan struct{}
 	stopOnce gosync.Once
+	// wg counts the monitor loop so Stop can join it, keeping a probe from
+	// running against a remote store the caller is about to close.
+	wg gosync.WaitGroup
 }
 
 // NewHealthMonitor creates a new HealthMonitor. If probeFunc is nil, the monitor
@@ -90,14 +93,24 @@ func (hm *HealthMonitor) Start(ctx context.Context) {
 		logger.Info("Remote store initial probe succeeded")
 	}
 
-	go hm.monitorLoop(ctx)
+	hm.wg.Add(1)
+	go func() {
+		defer hm.wg.Done()
+		hm.monitorLoop(ctx)
+	}()
 }
 
-// Stop signals the health monitor goroutine to exit. Safe to call multiple times.
+// Stop signals the health monitor goroutine to exit and waits for it. Safe to
+// call multiple times. The wait is bounded because the loop can be inside a
+// probe against an unreachable remote; a monitor that outlives its budget is
+// logged rather than allowed to wedge shutdown.
 func (hm *HealthMonitor) Stop() {
 	hm.stopOnce.Do(func() {
 		close(hm.stopCh)
 	})
+	if !waitBounded(&hm.wg, defaultShutdownTimeout) {
+		logger.Warn("Health monitor did not exit before shutdown timeout")
+	}
 }
 
 // IsHealthy returns the current health state. Always true if probeFunc is nil.

--- a/pkg/block/engine/sync_queue.go
+++ b/pkg/block/engine/sync_queue.go
@@ -297,6 +297,5 @@ func (q *SyncQueue) processDownload(ctx context.Context, req TransferRequest) er
 		return nil
 	}
 
-	_, err := q.manager.fetchBlock(ctx, req.PayloadID, req.BlockIndex)
-	return err
+	return q.manager.fetchBlock(ctx, req.PayloadID, req.BlockIndex)
 }

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -85,8 +85,10 @@ type Syncer struct {
 
 	stopCh chan struct{} // Signals periodic uploader to stop
 	// bgWG counts the long-lived loops started by startPeriodicUploader. Close
-	// joins them so it cannot return while one is still calling into the local
-	// or remote store, which the engine closes as soon as Close returns.
+	// joins them so it does not return while one is still calling into the
+	// local or remote store, which the engine closes as soon as Close returns.
+	// The join is bounded: a loop parked in a remote call past the shutdown
+	// timeout is logged and left behind rather than allowed to wedge shutdown.
 	bgWG   gosync.WaitGroup
 	closed bool
 	mu     gosync.RWMutex

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -39,11 +39,11 @@ type Syncer struct {
 	// read it without taking m.mu — avoiding both a data race with
 	// SetRemoteStore and a pendingMu→m.mu lock-ordering edge.
 	hasRemote atomic.Bool
-	// the syncer is one of the engine-internal
-	// callers that still reaches into the wider EngineFileChunkStore
-	// surface (GetFileChunk for dual-read resolve, ListFileChunks for
-	// GetFileSize/Exists). routes reads through
-	// FileAttr.Blocks and lets us drop the wider interface.
+	// fileChunkStore is the per-file chunk manifest, and the syncer needs the
+	// wide EngineFileChunkStore surface rather than a narrower one because it
+	// reads the manifest three different ways: GetFileChunk to resolve a single
+	// row, ListFileChunks to enumerate a payload for GetFileSize/Exists and the
+	// window walks, and the offset-indexed lookups where a backend offers them.
 	fileChunkStore block.EngineFileChunkStore // Required: enables content-addressed deduplication
 
 	// syncedHashStore persists per-CAS-hash local→remote sync state. The
@@ -84,6 +84,10 @@ type Syncer struct {
 	readaheadPruning atomic.Bool  // single-pruner guard for the bound
 
 	stopCh chan struct{} // Signals periodic uploader to stop
+	// bgWG counts the long-lived loops started by startPeriodicUploader. Close
+	// joins them so it cannot return while one is still calling into the local
+	// or remote store, which the engine closes as soon as Close returns.
+	bgWG   gosync.WaitGroup
 	closed bool
 	mu     gosync.RWMutex
 
@@ -581,16 +585,16 @@ func (m *Syncer) Exists(ctx context.Context, payloadID string) (bool, error) {
 	return false, nil
 }
 
-// Truncate removes blocks beyond the new size from the remote store.
+// Truncate is a no-op on the remote side; the CAS objects a truncate orphans
+// are reclaimed by the GC sweep.
 //
 // Post-Phase-17 the engine is CAS-keyed: there is no per-file remote key
 // prefix to enumerate. Truncate's metadata-side RefCount decrement runs
 // inside engine.Truncate (which prunes FileAttr.Blocks and decrements per
-// dropped hash); orphan CAS objects are reclaimed by the GC sweep. This
-// method therefore becomes a no-op at the remote-side after
-// kept as a stable seam for callers (engine.Truncate invokes it
-// unconditionally) and so the legacy prefix-scan pattern is unambiguously
-// gone.
+// dropped hash), which is what makes a hash sweepable. This method is kept as
+// a stable seam for callers — engine.Truncate invokes it unconditionally — and
+// so the absence of the legacy prefix scan is explicit rather than inferred
+// from a missing call.
 func (m *Syncer) Truncate(ctx context.Context, payloadID string, newSize uint64) error {
 	if err := m.checkReady(ctx); err != nil {
 		return err
@@ -609,13 +613,13 @@ func (m *Syncer) Truncate(ctx context.Context, payloadID string, newSize uint64)
 	return nil
 }
 
-// Delete removes all blocks for a file from the remote store.
+// Delete is a no-op on the remote side; engine.Delete drives the deletion.
 //
 // Post-Phase-17 the engine is CAS-keyed: file deletion routes through the
-// refcount path (engine.Delete decrements RefCount per ChunkRef hash and
-// orphan CAS objects are reclaimed by GC). The legacy per-file prefix
-// sweep is gone — Delete now records the deletion intent and lets
-// the refcount + GC mechanism do the work.
+// refcount path — engine.Delete decrements RefCount per ChunkRef hash, and the
+// GC sweep reclaims the CAS objects that leaves orphaned. Nothing is removed or
+// recorded here. The legacy per-file prefix sweep is gone, and this method is
+// kept as a stable seam for the call in engine.Delete.
 func (m *Syncer) Delete(ctx context.Context, payloadID string) error {
 	if err := m.checkReady(ctx); err != nil {
 		return err
@@ -707,14 +711,22 @@ func (m *Syncer) startPeriodicUploader(ctx context.Context) {
 	// Carve collaborators are wired by recomputeCarveActive once all deps are
 	// present; launch the dispatcher that periodically packs the journal's dirty
 	// ranges into remote blocks.
-	go m.carveDispatcher(ctx)
+	m.bgWG.Add(1)
+	go func() {
+		defer m.bgWG.Done()
+		m.carveDispatcher(ctx)
+	}()
 
 	// Adaptive mode (ParallelUploads unset): launch the goodput controller that
 	// resizes the upload window to saturate the uplink (#1407). Pinned
 	// --parallel-uploads leaves uploadController nil and keeps the fixed window;
 	// publish it once so the gauge reflects it instead of reading 0.
 	if m.uploadController != nil {
-		go m.runUploadController(ctx, uploadControlInterval)
+		m.bgWG.Add(1)
+		go func() {
+			defer m.bgWG.Done()
+			m.runUploadController(ctx, uploadControlInterval)
+		}()
 	} else if mx := m.dataplaneMetrics(); mx != nil && m.uploadLimiter != nil {
 		mx.SetUploadWindow(m.uploadLimiter.Limit())
 	}
@@ -939,7 +951,33 @@ func (m *Syncer) Close() error {
 		m.queue.Stop(defaultShutdownTimeout)
 	}
 
+	// Join the background loops LAST. They observe stopCh, but a carve pass can
+	// be parked in an upload that only the drain and queue stop above release,
+	// so joining earlier would deadlock. Joining at all is what stops Close from
+	// returning while a pass is still reading the local store or writing the
+	// remote — the engine closes both the moment Close returns.
+	if !waitBounded(&m.bgWG, defaultShutdownTimeout) {
+		logger.Warn("Syncer background loops did not exit before shutdown timeout")
+	}
+
 	return nil
+}
+
+// waitBounded waits for wg, reporting whether it drained before timeout. The
+// wait is bounded because a background loop can be parked in a remote call with
+// its own retry budget: shutdown logs and proceeds rather than wedging on it.
+func waitBounded(wg *gosync.WaitGroup, timeout time.Duration) bool {
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
 }
 
 // HealthCheck verifies the remote store is accessible.

--- a/pkg/block/engine/warm.go
+++ b/pkg/block/engine/warm.go
@@ -11,10 +11,12 @@ import (
 	"github.com/marmos91/dittofs/pkg/block/journal"
 )
 
-// WarmResult summarizes a WarmAll run: how many chunks were fetched from the
-// remote tier and how many bytes that fetch moved. Every enumerated chunk is
-// fetched, so BlocksFetched is also the run's total work — see WarmAll for why
-// there is no already-local count.
+// WarmResult summarizes a WarmAll run: how many chunks came back from the
+// remote tier and how many bytes they moved. Every enumerated chunk is
+// attempted, but a chunk that is sparse or not yet synced returns no data and
+// is not counted, so BlocksFetched is what landed, not the size of the work
+// list — callers that need the enumerated total read it from the progress
+// callback. See WarmAll for why there is no already-local count.
 type WarmResult struct {
 	BlocksFetched int64 `json:"blocks_fetched"`
 	BytesFetched  int64 `json:"bytes_fetched"`

--- a/pkg/block/engine/warm.go
+++ b/pkg/block/engine/warm.go
@@ -11,13 +11,13 @@ import (
 	"github.com/marmos91/dittofs/pkg/block/journal"
 )
 
-// WarmResult summarizes a WarmAll run: how many blocks were fetched from the
-// remote tier, how many bytes that fetch moved, and how many blocks were
-// already physically present locally (skipped without a remote round-trip).
+// WarmResult summarizes a WarmAll run: how many chunks were fetched from the
+// remote tier and how many bytes that fetch moved. Every enumerated chunk is
+// fetched, so BlocksFetched is also the run's total work — see WarmAll for why
+// there is no already-local count.
 type WarmResult struct {
-	BlocksFetched      int64 `json:"blocks_fetched"`
-	BytesFetched       int64 `json:"bytes_fetched"`
-	BlocksAlreadyLocal int64 `json:"blocks_already_local"`
+	BlocksFetched int64 `json:"blocks_fetched"`
+	BytesFetched  int64 `json:"bytes_fetched"`
 }
 
 // warmTarget identifies one FileChunk row that must be fetched. It carries the
@@ -33,17 +33,24 @@ type warmTarget struct {
 // WarmAll proactively materializes every block of every payload in this share
 // onto the local CAS tier by reusing the per-block fetch primitive
 // (fetchResolvedBlock). It enumerates payloads from the authoritative metadata
-// (fileChunkStore.EnumeratePayloads) and the per-payload FileChunk rows, skips
-// any block already present locally, and fetches the rest with bounded
-// concurrency (SyncerConfig.ParallelDownloads). Enumerating the metadata rather
-// than the local store's ListFiles is what lets warm materialize payloads whose
-// append log was discarded after rollup — their FileChunk rows survive, but
+// (fileChunkStore.EnumeratePayloads) and the per-payload FileChunk rows, and
+// fetches every one of them with bounded concurrency
+// (SyncerConfig.ParallelDownloads). Enumerating the metadata rather than the
+// local store's ListFiles is what lets warm materialize payloads whose append
+// log was discarded after rollup — their FileChunk rows survive, but
 // local.ListFiles no longer reports them, so the old surface made warm a silent
 // no-op on rolled-up shares (#1374).
 //
+// Already-local chunks are re-fetched rather than skipped. The local tier is
+// keyed by (payloadID, offset) and exposes no per-range residency probe: its
+// DataExtents reports evicted ranges as data, so using it to decide "already
+// local" would skip exactly the cold chunks warm exists to fetch. Re-hydrating a
+// warm chunk is idempotent, so the cost of not knowing is a redundant GET, while
+// the cost of guessing wrong is a warm run that silently does nothing.
+//
 // progress (may be nil) is invoked after each block is processed with the
 // running (done, total) counts so callers can drive a poll/UI. total is the
-// number of NOT-already-local blocks (the blocks this run will actually fetch).
+// number of enumerated chunks, which is what this run will fetch.
 //
 // A nil remote tier is an error: there is nothing to warm from. A fetch that
 // fails with fs.ErrDiskFull is terminal — the bounded local tier cannot hold
@@ -57,14 +64,13 @@ func (m *Syncer) WarmAll(ctx context.Context, progress func(done, total int64)) 
 		return WarmResult{}, errors.New("warm: share has no remote tier to warm from")
 	}
 
-	// Enumerate all FileChunk rows and split into already-local (counted,
-	// skipped) and to-fetch (the work list). The enumeration walks the same
-	// surface as populateBlockCounts: fileChunkStore.EnumeratePayloads ->
+	// Enumerate all FileChunk rows into the work list. The enumeration walks the
+	// same surface as populateBlockCounts: fileChunkStore.EnumeratePayloads ->
 	// per-payload ListFileChunks (the authoritative metadata, which survives
-	// rollup). Each to-fetch target carries the resolved row so the worker
-	// fetches by the row in hand (fetchResolvedBlock) instead of round-tripping
-	// through a BlockSize-aligned blockIdx lookup, which would miss every
-	// non-aligned FastCDC chunk (#1374).
+	// rollup). Each target carries the resolved row so the worker fetches by the
+	// row in hand (fetchResolvedBlock) instead of round-tripping through a
+	// BlockSize-aligned blockIdx lookup, which would miss every non-aligned
+	// FastCDC chunk (#1374).
 	var payloadIDs []string
 	if err := m.fileChunkStore.EnumeratePayloads(ctx, func(payloadID string) error {
 		payloadIDs = append(payloadIDs, payloadID)
@@ -73,10 +79,7 @@ func (m *Syncer) WarmAll(ctx context.Context, progress func(done, total int64)) 
 		return WarmResult{}, fmt.Errorf("warm: enumerate payloads: %w", err)
 	}
 
-	var (
-		targets      []warmTarget
-		alreadyLocal int64
-	)
+	var targets []warmTarget
 	for _, payloadID := range payloadIDs {
 		if err := ctx.Err(); err != nil {
 			return WarmResult{}, err
@@ -92,9 +95,6 @@ func (m *Syncer) WarmAll(ctx context.Context, progress func(done, total int64)) 
 			if _, ok := block.ParseChunkOffset(fb.ID); !ok {
 				continue
 			}
-			// ponytail: no per-hash local-presence probe (journal is not
-			// hash-keyed), so warm every covering chunk. Re-hydrating an
-			// already-warm chunk is idempotent — a redundant GET at worst.
 			targets = append(targets, warmTarget{payloadID: payloadID, fb: fb})
 		}
 	}
@@ -104,7 +104,7 @@ func (m *Syncer) WarmAll(ctx context.Context, progress func(done, total int64)) 
 		progress(0, total)
 	}
 	if total == 0 {
-		return WarmResult{BlocksAlreadyLocal: alreadyLocal}, nil
+		return WarmResult{}, nil
 	}
 
 	var (
@@ -163,17 +163,11 @@ func (m *Syncer) WarmAll(ctx context.Context, progress func(done, total int64)) 
 		})
 	}
 
-	if err := g.Wait(); err != nil {
-		return WarmResult{
-			BlocksFetched:      blocksFetched.Load(),
-			BytesFetched:       bytesFetched.Load(),
-			BlocksAlreadyLocal: alreadyLocal,
-		}, err
-	}
-
+	// Counts are read after Wait so both the success and failure returns report
+	// everything that actually landed.
+	err := g.Wait()
 	return WarmResult{
-		BlocksFetched:      blocksFetched.Load(),
-		BytesFetched:       bytesFetched.Load(),
-		BlocksAlreadyLocal: alreadyLocal,
-	}, nil
+		BlocksFetched: blocksFetched.Load(),
+		BytesFetched:  bytesFetched.Load(),
+	}, err
 }

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -2843,9 +2843,8 @@ func (s *Service) StartWarm(_ context.Context, shareName string) (*WarmJob, erro
 	job := s.warmJobs.start(shareName, usedBytes, func(ctx context.Context, progress func(done, total int64)) (warmAllResult, error) {
 		res, err := bs.WarmAll(ctx, progress)
 		return warmAllResult{
-			BlocksFetched:      res.BlocksFetched,
-			BytesFetched:       res.BytesFetched,
-			BlocksAlreadyLocal: res.BlocksAlreadyLocal,
+			BlocksFetched: res.BlocksFetched,
+			BytesFetched:  res.BytesFetched,
 		}, err
 	})
 	return job, nil

--- a/pkg/controlplane/runtime/shares/warm.go
+++ b/pkg/controlplane/runtime/shares/warm.go
@@ -96,10 +96,10 @@ type warmAllResult struct {
 // share, the existing job is returned and run is not invoked.
 //
 // usedBytes is the share's currently-stored byte count (captured by the
-// caller before launching). When the run completes with zero enumerable
-// blocks (nothing fetched) but usedBytes > 0, the job's Warning field is set:
-// a non-empty share with no warmable blocks is a strong hint that block
-// metadata is missing (#1374).
+// caller before launching). When the run completes having enumerated zero
+// blocks but usedBytes > 0, the job's Warning field is set: a non-empty share
+// with no warmable blocks is a strong hint that block metadata is missing
+// (#1374).
 func (r *warmRegistry) start(shareName string, usedBytes int64, run func(ctx context.Context, progress func(done, total int64)) (warmAllResult, error)) *WarmJob {
 	r.mu.Lock()
 	if existingID, ok := r.active[shareName]; ok {
@@ -166,12 +166,16 @@ func (r *warmRegistry) start(shareName string, usedBytes int64, run func(ctx con
 		case err == nil:
 			j.State = WarmStateDone
 			j.BlocksDone = j.BlocksTotal
-			// Warm fetches every enumerated block, so BlocksFetched is the
-			// run's total enumerable blocks. If that is zero yet the share
-			// reports stored bytes, the warm found nothing to do on a
-			// non-empty share — surface a warning (#1374) rather than a
-			// silent no-op success.
-			if res.BlocksFetched == 0 && usedBytes > 0 {
+			// The gate is the ENUMERATED total, not the fetched count: a row
+			// that is sparse or not yet synced to the remote is enumerated and
+			// walked but fetches no bytes, so keying off BlocksFetched would
+			// warn about missing metadata on a share whose metadata is fine.
+			// j.BlocksTotal is the target count the run reported through
+			// progress, and stays 0 only when the enumeration itself found
+			// nothing. If that is zero yet the share reports stored bytes, the
+			// warm found nothing to do on a non-empty share — surface a
+			// warning (#1374) rather than a silent no-op success.
+			if j.BlocksTotal == 0 && usedBytes > 0 {
 				j.Warning = fmt.Sprintf(
 					"warm found 0 enumerable blocks for share %s but it has %d bytes on the local disk tier — block metadata may be missing",
 					shareName, usedBytes)

--- a/pkg/controlplane/runtime/shares/warm.go
+++ b/pkg/controlplane/runtime/shares/warm.go
@@ -86,9 +86,8 @@ func newWarmRegistry() *warmRegistry {
 // warmAllResult mirrors engine.WarmResult without coupling the registry to the
 // engine package. The adapter in StartWarm bridges the two.
 type warmAllResult struct {
-	BlocksFetched      int64
-	BytesFetched       int64
-	BlocksAlreadyLocal int64
+	BlocksFetched int64
+	BytesFetched  int64
 }
 
 // start launches a warm run for shareName against run on a DETACHED context
@@ -98,9 +97,9 @@ type warmAllResult struct {
 //
 // usedBytes is the share's currently-stored byte count (captured by the
 // caller before launching). When the run completes with zero enumerable
-// blocks (nothing fetched AND nothing already-local) but usedBytes > 0, the
-// job's Warning field is set: a non-empty share with no warmable blocks is a
-// strong hint that block metadata is missing (#1374).
+// blocks (nothing fetched) but usedBytes > 0, the job's Warning field is set:
+// a non-empty share with no warmable blocks is a strong hint that block
+// metadata is missing (#1374).
 func (r *warmRegistry) start(shareName string, usedBytes int64, run func(ctx context.Context, progress func(done, total int64)) (warmAllResult, error)) *WarmJob {
 	r.mu.Lock()
 	if existingID, ok := r.active[shareName]; ok {
@@ -167,11 +166,12 @@ func (r *warmRegistry) start(shareName string, usedBytes int64, run func(ctx con
 		case err == nil:
 			j.State = WarmStateDone
 			j.BlocksDone = j.BlocksTotal
-			// Total enumerable blocks for the run = fetched + already-local.
-			// If that is zero yet the share reports stored bytes, the warm
-			// found nothing to do on a non-empty share — surface a warning
-			// (#1374) rather than a silent no-op success.
-			if res.BlocksFetched+res.BlocksAlreadyLocal == 0 && usedBytes > 0 {
+			// Warm fetches every enumerated block, so BlocksFetched is the
+			// run's total enumerable blocks. If that is zero yet the share
+			// reports stored bytes, the warm found nothing to do on a
+			// non-empty share — surface a warning (#1374) rather than a
+			// silent no-op success.
+			if res.BlocksFetched == 0 && usedBytes > 0 {
 				j.Warning = fmt.Sprintf(
 					"warm found 0 enumerable blocks for share %s but it has %d bytes on the local disk tier — block metadata may be missing",
 					shareName, usedBytes)

--- a/pkg/controlplane/runtime/shares/warm_test.go
+++ b/pkg/controlplane/runtime/shares/warm_test.go
@@ -121,8 +121,12 @@ func TestWarmRegistry_WarnsOnEmptyEnumerationNonEmptyShare(t *testing.T) {
 	}
 
 	// A run that DID enumerate blocks must not warn even if used bytes > 0.
-	jobOK := r.start("/full", 4096, func(_ context.Context, _ func(done, total int64)) (warmAllResult, error) {
-		return warmAllResult{BlocksFetched: 3}, nil
+	jobOK := r.start("/full", 4096, func(_ context.Context, progress func(done, total int64)) (warmAllResult, error) {
+		// Enumerated three chunks and fetched none of them: every row was
+		// already synced or sparse. That is a healthy run, not missing
+		// metadata, so it must not warn.
+		progress(3, 3)
+		return warmAllResult{}, nil
 	})
 	waitFor(t, func() bool {
 		j, _ := r.get(jobOK.ID)

--- a/pkg/controlplane/runtime/shares/warm_test.go
+++ b/pkg/controlplane/runtime/shares/warm_test.go
@@ -122,7 +122,7 @@ func TestWarmRegistry_WarnsOnEmptyEnumerationNonEmptyShare(t *testing.T) {
 
 	// A run that DID enumerate blocks must not warn even if used bytes > 0.
 	jobOK := r.start("/full", 4096, func(_ context.Context, _ func(done, total int64)) (warmAllResult, error) {
-		return warmAllResult{BlocksAlreadyLocal: 3}, nil
+		return warmAllResult{BlocksFetched: 3}, nil
 	})
 	waitFor(t, func() bool {
 		j, _ := r.get(jobOK.ID)


### PR DESCRIPTION
Last of the five per-package batches from the 2026-08-05 data-plane audit (`.planning/audits/2026-08-05-dataplane/report.md`). The other four landed as #1943, #1946, #1948, #1949. 12 MED/LOW findings in `pkg/block/engine/`.

### Readahead staged one chunk of a block

`fetchBlock` resolved the single manifest row covering the block-aligned offset, but FastCDC boundaries do not align to `BlockSize`, so an 8 MiB block routinely holds several chunks and everything behind the first stayed cold — the demand read then paid the round-trips readahead exists to hide. It now stages every covering chunk, and the window walk the cold-read demand path already had is extracted as `collectCoveringChunks` so both paths resolve a window the same way. `fetchBlock`'s return value was always discarded, so it no longer builds one.

### N+1 manifest scan per covering chunk

That walk cost a full per-payload `ListFileChunks` per covering chunk on every backend without the offset index. `chunkWindowResolver` takes the scan once per walk, so a walk spanning K chunks costs one fetch instead of K. Indexed backends (badger) are still asked per offset. `resolveCovering` / `resolveNextChunkStart` keep their signatures on top of it.

### Cold re-read after hydrate failed open

`ensureAndReadFromLocal` discarded the cold flag of its own post-hydrate re-read. A window still cold after hydration means a byte the manifest claims was written could not be brought back, and `ReadAt` zero-fills what it cannot serve — the caller got zeros for real data with no error anywhere. Now fails closed. A never-written hole does not report cold, so sparse files still read as zeros.

### `WarmResult.BlocksAlreadyLocal` was always 0

The local tier is keyed by `(payloadID, offset)` with no per-range residency probe, and its `DataExtents` reports evicted ranges as data — so the skip the field advertised could not be implemented without skipping exactly the cold chunks warm exists to fetch. Field and godoc dropped, the `#1374` warning gate reads the fetched count, and both `WarmAll` returns now report what landed instead of dropping the counts on the error path.

### Smaller

- `ReprojectBlocks` moves from an optional interface type-asserted at the call site to a `MetadataCoordinator` method, so skipping the post-reap reprojection is a compile error rather than a silently drifting `Blocks` projection.
- `HealthMonitor.Stop` and `Syncer.Close` join the goroutines they signal, under a bounded wait that logs rather than wedges shutdown. Either could previously return while a probe or carve pass was still touching stores the engine closes the moment `Close` returns. The syncer join goes last — a carve pass can be parked in an upload that only the drain and queue stop release.
- Comments only: the audit walk's per-entry `GetFile` reads as a removable N+1 but is load-bearing (the READDIRPLUS projection leaves `Blocks`/`PayloadID` unloaded on the relational backends, so building from it would report a clean result on a share full of dangling refs). `Syncer.Truncate`, `Syncer.Delete` and the `fileChunkStore` field carried truncated or stale godoc.

### Verification

Rebased onto develop `29928f16` — clean, despite the collision with #1948 flagged in the handoff. `go build ./...`, `go vet ./...`, `gofmt` and `golangci-lint` clean; `go test ./pkg/block/... ./pkg/controlplane/runtime/... ./internal/adapter/common/...` green; `go test -race ./pkg/block/engine/... ./pkg/controlplane/runtime/shares/...` green.

New `fetch_window_test.go` pins the multi-chunk window walk.

### Note for merge order

#1953 also edits `read_internal.go`, but only inside `findRowCoveringOffset`, which this PR does not touch — the hunks are disjoint and should auto-merge. Whichever lands second, re-run `./pkg/block/engine/...`.