### PR TITLE
fix(smb-conformance): excuse the self-contradictory channel-sequence CSN draw

### DIFF
--- a/internal/adapter/smb/handlers/channel_sequence_test.go
+++ b/internal/adapter/smb/handlers/channel_sequence_test.go
@@ -114,3 +114,34 @@ func TestVerifyChannelSequence_SeedNonZero(t *testing.T) {
 		t.Fatal("write below seeded csn should be rejected")
 	}
 }
+
+// TestVerifyChannelSequence_ForwardBoundary pins the largest difference that
+// still counts as a forward step. MS-SMB2 §3.3.5.2.10 updates the Open when the
+// unsigned 16-bit difference "is less than or equal to 0x7FFF", so 0x7fff ahead
+// of the tracked sequence is accepted and 0x8000 ahead is not. Samba draws two
+// of its channel-sequence table rows at random from ranges that include 0x7fff
+// while expecting a rejection, which is why that draw can never pass.
+func TestVerifyChannelSequence_ForwardBoundary(t *testing.T) {
+	f := &OpenFile{}
+	if !f.VerifyChannelSequence(0, true) {
+		t.Fatal("seed write at csn=0 should be allowed")
+	}
+	if !f.VerifyChannelSequence(0x7fff, true) {
+		t.Fatal("csn=0x7fff is a forward step and must be allowed")
+	}
+	if f.channelSeq != 0x7fff {
+		t.Fatalf("expected tracked csn to advance to 0x7fff, got 0x%04x", f.channelSeq)
+	}
+	// Resending on the now-current sequence is still allowed.
+	if !f.VerifyChannelSequence(0x7fff, true) {
+		t.Fatal("write on the current csn should be allowed")
+	}
+	// One past the boundary reads as a wrapped (stale) counter, not a step.
+	g := &OpenFile{}
+	if !g.VerifyChannelSequence(0, true) {
+		t.Fatal("seed write at csn=0 should be allowed")
+	}
+	if g.VerifyChannelSequence(0x8000, true) {
+		t.Fatal("csn=0x8000 exceeds the forward window and must be rejected")
+	}
+}

--- a/internal/adapter/smb/handlers/channel_sequence_test.go
+++ b/internal/adapter/smb/handlers/channel_sequence_test.go
@@ -7,6 +7,10 @@ import "testing"
 // for a modifying opcode (WRITE/SET_INFO/IOCTL) and asserts the accept/reject
 // decision matches the upstream expected NT_STATUS at every step. This is the
 // authoritative spec for smb2.replay.channel-sequence.
+//
+// Rows i3 and i8 stand in for two values the test draws at random from ranges
+// that both include 0x7fff while expecting a rejection — the value row i5
+// requires to succeed. That draw demands both outcomes and can never pass.
 func TestVerifyChannelSequence_SambaTable(t *testing.T) {
 	// allow == true means the op is expected to succeed (NT_STATUS_OK);
 	// allow == false means it must be rejected (NT_STATUS_FILE_NOT_AVAILABLE).
@@ -112,36 +116,5 @@ func TestVerifyChannelSequence_SeedNonZero(t *testing.T) {
 	// A stale write below the seed is rejected.
 	if f.VerifyChannelSequence(0x1233, true) {
 		t.Fatal("write below seeded csn should be rejected")
-	}
-}
-
-// TestVerifyChannelSequence_ForwardBoundary pins the largest difference that
-// still counts as a forward step. MS-SMB2 §3.3.5.2.10 updates the Open when the
-// unsigned 16-bit difference "is less than or equal to 0x7FFF", so 0x7fff ahead
-// of the tracked sequence is accepted and 0x8000 ahead is not. Samba draws two
-// of its channel-sequence table rows at random from ranges that include 0x7fff
-// while expecting a rejection, which is why that draw can never pass.
-func TestVerifyChannelSequence_ForwardBoundary(t *testing.T) {
-	f := &OpenFile{}
-	if !f.VerifyChannelSequence(0, true) {
-		t.Fatal("seed write at csn=0 should be allowed")
-	}
-	if !f.VerifyChannelSequence(0x7fff, true) {
-		t.Fatal("csn=0x7fff is a forward step and must be allowed")
-	}
-	if f.channelSeq != 0x7fff {
-		t.Fatalf("expected tracked csn to advance to 0x7fff, got 0x%04x", f.channelSeq)
-	}
-	// Resending on the now-current sequence is still allowed.
-	if !f.VerifyChannelSequence(0x7fff, true) {
-		t.Fatal("write on the current csn should be allowed")
-	}
-	// One past the boundary reads as a wrapped (stale) counter, not a step.
-	g := &OpenFile{}
-	if !g.VerifyChannelSequence(0, true) {
-		t.Fatal("seed write at csn=0 should be allowed")
-	}
-	if g.VerifyChannelSequence(0x8000, true) {
-		t.Fatal("csn=0x8000 exceeds the forward window and must be rejected")
 	}
 }

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -333,6 +333,39 @@ These entries remain in CI's known-failure set (so they don't break the build) b
 
 ## Changelog
 
+### 2026-08-18 — #1923 `channel-sequence`: excuse the self-contradictory random CSN draw
+
+`smb2.replay.channel-sequence` flipped the badger-fs verdict between two runs of
+a byte-identical binary. It is not a product bug and not a KNOWN_FAILURES row —
+the test contradicts itself on one draw in 32768.
+
+`test_channel_sequence_table` in `source4/torture/smb2/replay.c` runs a
+16-row table of ChannelSequence values against one Open. Fourteen rows are
+fixed; two are drawn at random — `rand() % 0x8000 + 0x7fff` (range
+`[0x7fff, 0xfffe]`) and `rand() % 0x8000` (range `[0, 0x7fff]`) — and both
+expect `STATUS_FILE_NOT_AVAILABLE` on the grounds that the value is stale or
+too far ahead. Both ranges include `0x7fff`, which is neither: MS-SMB2
+§3.3.5.2.10 updates the Open when the unsigned 16-bit difference "is less than
+or equal to 0x7FFF", and row 5 of the very same table asserts a fixed `0x7fff`
+against the same tracked value must return `STATUS_SUCCESS`. When a draw lands
+on the boundary the two rows demand opposite answers, so no conformant server
+can pass. Samba's own `smbd_smb2_request_dispatch_update_counts` flips the
+comparison only when `abs(cmp) > INT16_MAX`, which is false at `0x7fff`, so
+Samba returns success there too and fails the row as well.
+
+The failing run drew it directly:
+
+```
+Testing setinfo (replay: true) with CSN 0x7fff, expecting: NT_STATUS_FILE_NOT_AVAILABLE
+WARNING!: replay.c:4627: status was NT_STATUS_OK, expected NT_STATUS_FILE_NOT_AVAILABLE
+```
+
+`parse-results.sh` now reclassifies a `channel-sequence` failure to `skip:`
+only when that exact draw was printed during the test, in the same pre-pass
+that already excuses connection flakes. Any other channel-sequence failure —
+including a genuine regression in the mechanism — is graded normally, and the
+test stays off the blacklist.
+
 ### 2026-07-21 — replay6 re-added as a Windows-specific known failure (bucket 10)
 
 `smb2.replay.replay6` resurfaces once the harness runs the tail of the

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -367,6 +367,21 @@ Testing setinfo (replay: true) with CSN 0x7fff, expecting: NT_STATUS_FILE_NOT_AV
 WARNING!: replay.c:4627: status was NT_STATUS_OK, expected NT_STATUS_FILE_NOT_AVAILABLE
 ```
 
+Confirmed against real Samba, not just derived from its source. smbtorture
+4.22.6 was run against smbd 4.22.6 (`quay.io/samba.org/samba-server:v0.8`) with
+libc `rand()` forced to 0 via `LD_PRELOAD`, which makes `csn_rand_high` draw
+exactly `0x7fff` every time:
+
+```
+Testing write (replay: false) with CSN 0x7fff, expecting: NT_STATUS_FILE_NOT_AVAILABLE
+WARNING!: replay.c:4627: status was NT_STATUS_OK, expected NT_STATUS_FILE_NOT_AVAILABLE
+```
+
+Same file, same line, same expected/actual pair as the DittoFS failure. Without
+the preload the same Samba passes the whole table, including the fixed `0x7fff`
+row that requires `STATUS_SUCCESS` — which is the contradiction, observed on
+upstream's own server.
+
 `parse-results.sh` now reclassifies a `channel-sequence` failure to `skip:`
 only when that exact draw was printed during the test, in the same pre-pass
 that already excuses connection flakes. Any other channel-sequence failure —

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -346,12 +346,19 @@ fixed; two are drawn at random — `rand() % 0x8000 + 0x7fff` (range
 expect `STATUS_FILE_NOT_AVAILABLE` on the grounds that the value is stale or
 too far ahead. Both ranges include `0x7fff`, which is neither: MS-SMB2
 §3.3.5.2.10 updates the Open when the unsigned 16-bit difference "is less than
-or equal to 0x7FFF", and row 5 of the very same table asserts a fixed `0x7fff`
-against the same tracked value must return `STATUS_SUCCESS`. When a draw lands
-on the boundary the two rows demand opposite answers, so no conformant server
-can pass. Samba's own `smbd_smb2_request_dispatch_update_counts` flips the
-comparison only when `abs(cmp) > INT16_MAX`, which is false at `0x7fff`, so
-Samba returns success there too and fails the row as well.
+or equal to 0x7FFF".
+
+The table is unsatisfiable when a draw lands there, whichever way a server
+resolves a `+0x7fff` difference. Accept it and the drawn row fails, because it
+demanded a rejection. Reject it and rows 5, 6 and 10 — fixed rows that pass
+today — fail instead, because each depends on `+0x7fff` being a forward step.
+No deterministic server passes both arms.
+
+Samba is in the first camp: `smbd_smb2_request_dispatch_update_counts` flips
+the comparison only when `abs(cmp) > INT16_MAX`, which is false at `0x7fff`, so
+it accepts and fails the drawn row too. Its `pre_request_count` gate cannot
+save it either — `smbd_smb2_request_reply_update_counts` drains the gauges on
+every reply, and no earlier row takes the branch that raises them.
 
 The failing run drew it directly:
 

--- a/test/smb-conformance/smbtorture/parse-results.sh
+++ b/test/smb-conformance/smbtorture/parse-results.sh
@@ -181,6 +181,9 @@ while IFS= read -r line; do
         if [[ "$line" =~ ^(failure|error):[[:space:]]+ ]]; then
             pending_block=("$line")
             if $csn_boundary_drawn && [[ "$line" == *channel-sequence* ]]; then
+                # One draw excuses one failure; a second block in the same
+                # test is graded normally.
+                csn_boundary_drawn=false
                 pending_is_flake=true
             fi
         else

--- a/test/smb-conformance/smbtorture/parse-results.sh
+++ b/test/smb-conformance/smbtorture/parse-results.sh
@@ -125,6 +125,21 @@ get_known_reason() { kf_reason "$1"; }
 # --------------------------------------------------------------------------
 CONN_FAIL_PATTERN="Establishing SMB2 connection failed"
 NO_MEMORY_PATTERN="NT_STATUS_NO_MEMORY"
+
+# smb2.replay.channel-sequence draws two of its sixteen ChannelSequence values
+# at random from [0x7fff, 0xfffe] and [0, 0x7fff] and expects
+# STATUS_FILE_NOT_AVAILABLE for both. Each range includes 0x7fff, which is not
+# stale: MS-SMB2 3.3.5.2.10 updates the Open when the unsigned 16-bit
+# difference "is less than or equal to 0x7FFF", and the same table asserts a
+# fixed 0x7fff row must return STATUS_SUCCESS against the same tracked value.
+# When a draw lands on that boundary the two rows contradict each other and no
+# conformant server can satisfy both — Samba's own server returns success there
+# too. The test prints the drawn value before running each row, so the
+# contradiction is identifiable and only that draw is excused; a
+# channel-sequence failure without it is graded normally.
+CSN_BOUNDARY_PATTERN="CSN 0x7fff, expecting: NT_STATUS_FILE_NOT_AVAILABLE"
+CSN_TEST_PATTERN="channel-sequence"
+
 TEMP_OUTPUT=$(mktemp)
 
 # is_result_marker LINE — true if LINE begins a new test/result record, i.e.
@@ -134,14 +149,21 @@ is_result_marker() {
 }
 
 # Buffer holding a pending failure/error header plus its detail lines while we
-# decide whether the block is a connection flake. pending_block is non-empty
-# iff we are inside a failure/error block.
+# decide whether the block is an environment flake rather than a real failure.
+# pending_block is non-empty iff we are inside a failure/error block.
 declare -a pending_block=()
-pending_is_connflake=false
+pending_is_flake=false
+
+# Set while the currently running test has printed the self-contradictory
+# ChannelSequence draw described above; cleared at every test boundary.
+csn_boundary_drawn=false
 
 flush_pending() {
     [[ ${#pending_block[@]} -eq 0 ]] && return
-    if $pending_is_connflake; then
+    if $csn_boundary_drawn && [[ "${pending_block[0]}" == *"$CSN_TEST_PATTERN"* ]]; then
+        pending_is_flake=true
+    fi
+    if $pending_is_flake; then
         # Reclassify the header (failure:/error:) to skip:; emit detail verbatim.
         local header="${pending_block[0]}"
         header="${header/#failure:/skip:}"
@@ -155,7 +177,7 @@ flush_pending() {
         printf '%s\n' "${pending_block[@]}" >> "$TEMP_OUTPUT"
     fi
     pending_block=()
-    pending_is_connflake=false
+    pending_is_flake=false
 }
 
 while IFS= read -r line; do
@@ -167,6 +189,7 @@ while IFS= read -r line; do
         if [[ "$line" =~ ^(failure|error):[[:space:]]+ ]]; then
             pending_block=("$line")
         else
+            [[ "$line" == test:* ]] && csn_boundary_drawn=false
             printf '%s\n' "$line" >> "$TEMP_OUTPUT"
         fi
         continue
@@ -176,13 +199,14 @@ while IFS= read -r line; do
         # Inside a pending failure/error detail block.
         pending_block+=("$line")
         if [[ "$line" == *"$CONN_FAIL_PATTERN"* || "$line" == *"$NO_MEMORY_PATTERN"* ]]; then
-            pending_is_connflake=true
+            pending_is_flake=true
         fi
         # A closing "]" ends the bracketed detail block.
         [[ "$line" == "]" ]] && flush_pending
         continue
     fi
 
+    [[ "$line" == *"$CSN_BOUNDARY_PATTERN"* ]] && csn_boundary_drawn=true
     printf '%s\n' "$line" >> "$TEMP_OUTPUT"
 done < "$OUTPUT_FILE"
 flush_pending

--- a/test/smb-conformance/smbtorture/parse-results.sh
+++ b/test/smb-conformance/smbtorture/parse-results.sh
@@ -127,18 +127,13 @@ CONN_FAIL_PATTERN="Establishing SMB2 connection failed"
 NO_MEMORY_PATTERN="NT_STATUS_NO_MEMORY"
 
 # smb2.replay.channel-sequence draws two of its sixteen ChannelSequence values
-# at random from [0x7fff, 0xfffe] and [0, 0x7fff] and expects
-# STATUS_FILE_NOT_AVAILABLE for both. Each range includes 0x7fff, which is not
-# stale: MS-SMB2 3.3.5.2.10 updates the Open when the unsigned 16-bit
-# difference "is less than or equal to 0x7FFF", and the same table asserts a
-# fixed 0x7fff row must return STATUS_SUCCESS against the same tracked value.
-# When a draw lands on that boundary the two rows contradict each other and no
-# conformant server can satisfy both — Samba's own server returns success there
-# too. The test prints the drawn value before running each row, so the
-# contradiction is identifiable and only that draw is excused; a
-# channel-sequence failure without it is graded normally.
+# at random and expects STATUS_FILE_NOT_AVAILABLE for both, but both ranges
+# include 0x7fff — the largest legal forward step, which another row of the
+# same table requires to succeed. That draw contradicts itself, so no server
+# can pass it. The test prints the drawn value before running the row, and
+# only a failure carrying that line is excused; every other
+# channel-sequence failure is graded normally.
 CSN_BOUNDARY_PATTERN="CSN 0x7fff, expecting: NT_STATUS_FILE_NOT_AVAILABLE"
-CSN_TEST_PATTERN="channel-sequence"
 
 TEMP_OUTPUT=$(mktemp)
 
@@ -160,9 +155,6 @@ csn_boundary_drawn=false
 
 flush_pending() {
     [[ ${#pending_block[@]} -eq 0 ]] && return
-    if $csn_boundary_drawn && [[ "${pending_block[0]}" == *"$CSN_TEST_PATTERN"* ]]; then
-        pending_is_flake=true
-    fi
     if $pending_is_flake; then
         # Reclassify the header (failure:/error:) to skip:; emit detail verbatim.
         local header="${pending_block[0]}"
@@ -188,6 +180,9 @@ while IFS= read -r line; do
         flush_pending
         if [[ "$line" =~ ^(failure|error):[[:space:]]+ ]]; then
             pending_block=("$line")
+            if $csn_boundary_drawn && [[ "$line" == *channel-sequence* ]]; then
+                pending_is_flake=true
+            fi
         else
             [[ "$line" == test:* ]] && csn_boundary_drawn=false
             printf '%s\n' "$line" >> "$TEMP_OUTPUT"

--- a/test/smb-conformance/smbtorture/parse-results_test.sh
+++ b/test/smb-conformance/smbtorture/parse-results_test.sh
@@ -175,6 +175,17 @@ failed to test CSN with replay flag
 ]
 EOF
 
+run_case "one draw excuses only one failure block" 1 <<'EOF'
+test: smb2.replay.channel-sequence
+Testing setinfo (replay: true) with CSN 0x7fff, expecting: NT_STATUS_FILE_NOT_AVAILABLE
+failure: smb2.replay.channel-sequence [
+failed to test CSN with replay flag
+]
+failure: smb2.replay.channel-sequence [
+a second, unrelated failure
+]
+EOF
+
 run_case "the excused draw does not leak into the next test" 1 <<'EOF'
 test: smb2.replay.channel-sequence
 Testing setinfo (replay: true) with CSN 0x7fff, expecting: NT_STATUS_FILE_NOT_AVAILABLE

--- a/test/smb-conformance/smbtorture/parse-results_test.sh
+++ b/test/smb-conformance/smbtorture/parse-results_test.sh
@@ -155,6 +155,36 @@ failure: smb2.lock.lock1 [ expected ]
 EOF
 assert_not_output "flapping name withheld" "### Known failures that now PASS"
 
+# -- smb2.replay.channel-sequence draws a ChannelSequence at random and, once
+# in 32768 draws, lands on 0x7fff while expecting STATUS_FILE_NOT_AVAILABLE —
+# a value the same table elsewhere requires to succeed. That draw is excused;
+# any other channel-sequence failure is graded normally. --
+run_case "self-contradictory CSN draw does not fail the job" 0 <<'EOF'
+test: smb2.replay.channel-sequence
+Testing setinfo (replay: true) with CSN 0x7fff, expecting: NT_STATUS_FILE_NOT_AVAILABLE
+failure: smb2.replay.channel-sequence [
+failed to test CSN with replay flag
+]
+EOF
+
+run_case "channel-sequence failure without the draw still fails" 1 <<'EOF'
+test: smb2.replay.channel-sequence
+Testing setinfo (replay: true) with CSN 0x7ffe, expecting: NT_STATUS_FILE_NOT_AVAILABLE
+failure: smb2.replay.channel-sequence [
+failed to test CSN with replay flag
+]
+EOF
+
+run_case "the excused draw does not leak into the next test" 1 <<'EOF'
+test: smb2.replay.channel-sequence
+Testing setinfo (replay: true) with CSN 0x7fff, expecting: NT_STATUS_FILE_NOT_AVAILABLE
+failure: smb2.replay.channel-sequence [
+failed to test CSN with replay flag
+]
+test: smb2.replay.replay3
+failure: smb2.replay.replay3 [ unrelated ]
+EOF
+
 echo ""
 if [[ "$FAILURES" -eq 0 ]]; then
     echo "PASS: all parse-results.sh grading tests passed"


### PR DESCRIPTION
## Root cause: an upstream torture-test defect, not a DittoFS bug

`smb2.replay.channel-sequence` flipped the badger-fs verdict between two runs of a
byte-identical binary (#1923). The failing run's log names the exact input:

```
Testing setinfo (replay: true) with CSN 0x7fff, expecting: NT_STATUS_FILE_NOT_AVAILABLE
WARNING!: replay.c:4627: status was NT_STATUS_OK, expected NT_STATUS_FILE_NOT_AVAILABLE
```

`test_channel_sequence_table` (samba `source4/torture/smb2/replay.c`) runs a 16-row
ChannelSequence table against one Open. Fourteen rows are fixed; two are drawn at
random — `rand() % 0x8000 + 0x7fff` giving `[0x7fff, 0xfffe]`, and `rand() % 0x8000`
giving `[0, 0x7fff]` — and both expect `STATUS_FILE_NOT_AVAILABLE` on the grounds
that the value is stale or too far ahead. Both ranges include `0x7fff`, which is
neither: MS-SMB2 §3.3.5.2.10 updates the Open when the unsigned 16-bit difference
"is less than or equal to 0x7FFF".

**The table is unsatisfiable when a draw lands there, whichever way a server resolves
a `+0x7fff` difference.** Accept it and the drawn row fails, because it demanded a
rejection. Reject it and rows 5, 6 and 10 — fixed rows that pass today — fail
instead, because each depends on `+0x7fff` being a forward step. No deterministic
server passes both arms. I verified this by running both policies over the full
table rather than reasoning about it.

Samba is in the first camp: `smbd_smb2_request_dispatch_update_counts` flips the
comparison only when `abs(cmp) > INT16_MAX`, which is false at `0x7fff`, so it
accepts and fails the drawn row too. Its `pre_request_count` gate cannot save it
either — `smbd_smb2_request_reply_update_counts` drains the gauges on every reply,
and no earlier row takes the branch that raises them.

DittoFS's `VerifyChannelSequence` matches Samba's arithmetic bit-for-bit at this
boundary. **No product code changes here.**

## Empirically confirmed on upstream Samba

The diagnosis does not rest on reading Samba's source. smbtorture 4.22.6 was run against
**smbd 4.22.6** (`quay.io/samba.org/samba-server:v0.8` — the same Samba build as the pinned
torture binary), with libc `rand()` forced to 0 via `LD_PRELOAD` so `csn_rand_high` draws
exactly `0x7fff` every time instead of 1-in-32768.

**Control, unmodified `rand()`** — Samba runs the full 16-row table and passes, including:

```
Testing write (replay: false) with CSN 0x7fff, expecting: NT_STATUS_OK
```

so Samba does treat `+0x7fff` from tracked `0` as a legal forward step.

**Forced boundary draw, same server, same binary:**

```
Testing write (replay: false) with CSN 0x7fff, expecting: NT_STATUS_FILE_NOT_AVAILABLE
WARNING!: replay.c:4627: status was NT_STATUS_OK, expected NT_STATUS_FILE_NOT_AVAILABLE
```

Same file, same line, same expected/actual pair as the DittoFS failure in #1923.
**Samba fails its own test on that draw**, while the same server passes the row demanding
the opposite answer.

Reproduction needs `durable handles = yes`, `kernel oplocks = no`, `kernel share modes = no`,
`posix locking = no`, and `smbd -F --no-process-group`.

## Frequency cross-check

If the real failure rate were higher than 1-in-32768 per draw, the diagnosis would be
incomplete. Across the last 60 SMB-conformance runs there were 192 `smbtorture / <profile>`
jobs: 145 completed successfully, 1 failed, and that failure was
`smb2.dirlease.unlink_same_set_and_close` — unrelated. So `channel-sequence` failed
**0 times in ~1750 draws**, against a model predicting 0.05 expected failures.

The single failure in #1923 is explained by selection bias: that run was examined *because*
it failed, not sampled at random.

## The change

`parse-results.sh` reclassifies a `channel-sequence` failure to `skip:` **only** when
that exact draw was printed during the test, in the same pre-pass that already
excuses connection flakes. The excuse is one-shot per draw. The test stays off
`KNOWN_FAILURES.md`, per the issue's explicit instruction not to blacklist it — any
other channel-sequence failure, including a genuine regression in the mechanism, is
still graded normally and still fails CI.

## Verification

Replayed both real CI logs from #1923 through the parser:

| | before | after |
|---|---|---|
| failing run (attempt 1 of `31014070873`) | exit 1, 1 new failure | exit 0, all known |
| passing run (`31011120983`) | exit 0, 498/38/40 | exit 0, 498/38/40 — identical |

Note the referenced `31014070873` looks green in the UI because attempt 2 was a
rerun; attempt 1 is the failure.

Plus 4 new `parse-results_test.sh` cases pinning the gate: the excused draw, a
channel-sequence failure *without* the draw (still red), one draw excusing only one
block, and no leak into the next test. `go test ./internal/adapter/smb/...` green;
shellcheck clean.

## Follow-up

Worth reporting upstream to Samba — the fix is to start the `csn_rand_high` range at
`0x8000` and end `csn_rand_low` at `0x7ffe`. Not filed yet.

Closes #1923
