### PR TITLE
fix(block): reach the unplaceable-row guard from every read path, not just cold ones

### DIFF
--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -310,11 +310,16 @@ dispatcher is suppressed and `Flush`/`SyncNow` are the sole carve drivers.
 
 `ReadAt` resolves by `(payloadID, offset)`. A range present in the journal is
 served straight from its segment. A range that was written but has since been
-evicted returns `cold=true`; the engine then resolves the chunk's remote
-locator from the FileChunk manifest, ranged-GETs its enclosing `blocks/<id>`
-object, decodes the wire frame, recomputes BLAKE3 over the chunk bytes, and —
-on success — hydrates the verified bytes back into the journal so subsequent
-reads are warm.
+evicted reports `ReadState.Cold`, and a range the journal has no interval for
+reports `ReadState.Hole`; the engine reconciles both against the FileChunk
+manifest, since the journal alone cannot tell a never-written range from one
+whose interval it lost. For each covering row it resolves the remote locator,
+ranged-GETs the enclosing `blocks/<id>` object, decodes the wire frame,
+recomputes BLAKE3 over the chunk bytes, and — on success — hydrates the verified
+bytes back into the journal so subsequent reads are warm. A range no row covers
+is a genuine sparse hole and stays zero-filled, unless the payload holds a row
+whose ID carries no offset: that range is unknown, so the read refuses with
+`ErrManifestInconsistent` rather than inventing zeros.
 
 Integrity is fail-closed: every remote fetch is BLAKE3-verified before the
 bytes reach the caller, and a mismatch is returned as an error (and counted),

--- a/docs/internals/implementing-stores.md
+++ b/docs/internals/implementing-stores.md
@@ -462,8 +462,9 @@ type LocalStore interface {
 ```
 
 A write buffers a dirty range and local-acks without fsync; `Commit` is the
-durability point. On a cold read `ReadAt` returns `cold=true` and the engine
-`Hydrate`s the range back from the remote store. `Carve` packs a file's dirty
+durability point. `ReadAt` reports both evicted (`ReadState.Cold`) and uncovered
+(`ReadState.Hole`) ranges; the engine reconciles either against the FileChunk
+manifest and `Hydrate`s whatever the manifest says is remote-resident. `Carve` packs a file's dirty
 ranges into remote blocks via the injected `BlockSink` (see the carve pass in
 [the architecture doc](architecture.md#carve-local--remote)); `Evict` frees
 whole fully-synced segments under pressure.

--- a/docs/internals/implementing-stores.md
+++ b/docs/internals/implementing-stores.md
@@ -442,7 +442,7 @@ and per-method contract; the representative methods are:
 type LocalStore interface {
     // --- Data plane (payloadID + offset keyed) ---
     WriteAt(ctx context.Context, payloadID string, offset int64, data []byte) error
-    ReadAt(ctx context.Context, payloadID string, offset int64, dst []byte) (n int, cold bool, err error)
+    ReadAt(ctx context.Context, payloadID string, offset int64, dst []byte) (n int, st journal.ReadState, err error)
     Hydrate(ctx context.Context, payloadID string, offset int64, data []byte) error // fill from remote on cold read
     Commit(ctx context.Context, payloadID string) error                             // fsync buffered writes
     FileSize(ctx context.Context, payloadID string) (int64, bool)
@@ -464,10 +464,10 @@ type LocalStore interface {
 A write buffers a dirty range and local-acks without fsync; `Commit` is the
 durability point. `ReadAt` reports both evicted (`ReadState.Cold`) and uncovered
 (`ReadState.Hole`) ranges; the engine reconciles either against the FileChunk
-manifest and `Hydrate`s whatever the manifest says is remote-resident. `Carve` packs a file's dirty
-ranges into remote blocks via the injected `BlockSink` (see the carve pass in
-[the architecture doc](architecture.md#carve-local--remote)); `Evict` frees
-whole fully-synced segments under pressure.
+manifest and `Hydrate`s whatever the manifest says is remote-resident. `Carve`
+packs a file's dirty ranges into remote blocks via the injected `BlockSink` (see
+the carve pass in [the architecture doc](architecture.md#carve-local--remote));
+`Evict` frees whole fully-synced segments under pressure.
 
 ### Reference Implementation
 

--- a/pkg/block/engine/blockseed_test.go
+++ b/pkg/block/engine/blockseed_test.go
@@ -39,7 +39,7 @@ func putChunkBlock(t testing.TB, ctx context.Context, rbs remote.RemoteBlockStor
 // through the remote's ChunkReader. Returns the chunk's content hash.
 func seedSyncedRemoteChunk(
 	t testing.TB,
-	fbs *stubFileChunkStore,
+	fbs block.FileChunkStore,
 	rbs remote.RemoteBlockStore,
 	shs metadata.SyncedHashStore,
 	payloadID string,

--- a/pkg/block/engine/cold_read_hole_test.go
+++ b/pkg/block/engine/cold_read_hole_test.go
@@ -107,11 +107,11 @@ func TestEnsureAvailableAndRead_ChunkAfterHoleIsFetched(t *testing.T) {
 
 			// Poison the destination so an unhydrated range fails instead of hiding in zeros.
 			got := bytes.Repeat([]byte{0xAA}, chunkSize)
-			n, cold, err := loc.ReadAt(ctx, payloadID, holeEnd, got)
+			n, st, err := loc.ReadAt(ctx, payloadID, holeEnd, got)
 			if err != nil {
 				t.Fatalf("local ReadAt after fetch: %v", err)
 			}
-			if cold {
+			if st.Cold {
 				t.Fatalf("local ReadAt reports cold after fetch; chunk at %d was never hydrated", holeEnd)
 			}
 			if n != chunkSize {

--- a/pkg/block/engine/dataextents.go
+++ b/pkg/block/engine/dataextents.go
@@ -10,8 +10,9 @@ import (
 // DataExtents returns the sorted, non-overlapping byte ranges [start, end)
 // within [0, fileSize) that hold data across ALL tiers the engine reads from:
 // the local append log + in-memory buffer (via local.DataExtents) UNION the
-// persisted CAS FileChunk manifest. This is the same data view ReadAt
-// reconstructs, expressed as a hole map.
+// persisted CAS FileChunk manifest. This is the same union readAtInternal
+// reconstructs — it reconciles an uncovered read against the manifest too —
+// expressed as a hole map, so SEEK and READ agree on where the data is.
 //
 // NFSv4.2 SEEK and READ_PLUS use it instead of deriving holes from the
 // persisted CAS block list alone: that list is empty/partial for

--- a/pkg/block/engine/dataextents.go
+++ b/pkg/block/engine/dataextents.go
@@ -11,8 +11,8 @@ import (
 // within [0, fileSize) that hold data across ALL tiers the engine reads from:
 // the local append log + in-memory buffer (via local.DataExtents) UNION the
 // persisted CAS FileChunk manifest. This is the same union readAtInternal
-// reconstructs — it reconciles an uncovered read against the manifest too —
-// expressed as a hole map, so SEEK and READ agree on where the data is.
+// reconstructs, expressed as a hole map, so SEEK and READ agree on where the
+// data is.
 //
 // NFSv4.2 SEEK and READ_PLUS use it instead of deriving holes from the
 // persisted CAS block list alone: that list is empty/partial for

--- a/pkg/block/engine/dataextents.go
+++ b/pkg/block/engine/dataextents.go
@@ -19,6 +19,11 @@ import (
 // written-but-not-yet-rolled-up data, so a CAS-only map reports a hole where
 // data exists — which RFC 7862 forbids (a sparse-copy client skips the real
 // data, silently losing it). #1481.
+//
+// The map may over-report data but must never under-report it. Both callers
+// ignore an error from here and fall back to the CAS block list, which cannot
+// see an unplaceable row either, so a row whose range is unknown widens the map
+// to the whole file rather than failing.
 func (bs *Store) DataExtents(ctx context.Context, payloadID string, fileSize uint64) ([][2]uint64, error) {
 	if err := bs.enter(); err != nil {
 		return nil, err
@@ -41,11 +46,23 @@ func (bs *Store) DataExtents(ctx context.Context, payloadID string, fileSize uin
 			return nil, lerr
 		}
 		for _, fb := range rows {
-			if fb == nil || fb.Hash.IsZero() {
-				continue // pending/incomplete chunk — no committed bytes yet
+			if fb == nil {
+				continue
 			}
 			off, ok := block.ParseChunkOffset(fb.ID)
-			if !ok || off >= fileSize {
+			if !ok {
+				// The row's range is unknown, so no extent can stand for it, and
+				// leaving it out would call its bytes hole. Report the whole file
+				// as data instead: over-reporting is the RFC-safe direction, and it
+				// keeps a sparse-copy client from skipping the range on SEEK alone —
+				// the READ it is then forced to issue refuses with
+				// ErrManifestInconsistent rather than inventing zeros.
+				return [][2]uint64{{0, fileSize}}, nil
+			}
+			if fb.Hash.IsZero() {
+				continue // pending/incomplete chunk — no committed bytes yet
+			}
+			if off >= fileSize {
 				continue
 			}
 			end := off + uint64(fb.DataSize)

--- a/pkg/block/engine/fetch_window_test.go
+++ b/pkg/block/engine/fetch_window_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/journal"
 	"github.com/marmos91/dittofs/pkg/block/local"
 	memorylocal "github.com/marmos91/dittofs/pkg/block/local/memory"
 	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
@@ -71,11 +72,11 @@ func TestFetchBlock_StagesEveryChunkInBlock(t *testing.T) {
 				// Poison the destination so an unhydrated range fails loudly
 				// instead of matching a zero-filled read.
 				got := bytes.Repeat([]byte{0xAA}, chunkSize)
-				n, cold, err := loc.ReadAt(ctx, payloadID, want.offset, got)
+				n, st, err := loc.ReadAt(ctx, payloadID, want.offset, got)
 				if err != nil {
 					t.Fatalf("local ReadAt at %d: %v", want.offset, err)
 				}
-				if cold {
+				if st.Cold {
 					t.Fatalf("chunk at %d still cold: prefetch skipped it", want.offset)
 				}
 				if n != chunkSize {
@@ -97,8 +98,8 @@ type alwaysColdLocal struct {
 	local.LocalStore
 }
 
-func (alwaysColdLocal) ReadAt(_ context.Context, _ string, _ int64, dst []byte) (int, bool, error) {
-	return len(dst), true, nil
+func (alwaysColdLocal) ReadAt(_ context.Context, _ string, _ int64, dst []byte) (int, journal.ReadState, error) {
+	return len(dst), journal.ReadState{Cold: true}, nil
 }
 
 // TestReadAtInternal_StillColdAfterHydrateFailsClosed pins the post-hydrate

--- a/pkg/block/engine/read_internal.go
+++ b/pkg/block/engine/read_internal.go
@@ -21,18 +21,32 @@ func blockRefHashes(refs []block.ChunkRef) []block.ContentHash {
 }
 
 // readAtInternal reads from the primary payloadID via the journal-backed local
-// tier. journal.ReadAt fills dst with the file's local bytes and zero-fills
-// never-written holes; if any requested byte was written-but-evicted it reports
-// cold=true. On a cold read the engine hydrates the covering chunks from the
-// remote store (verified) back into the journal and re-reads, so a warm re-read
-// serves the fetched bytes. A genuinely sparse hole (no remote chunk) stays
-// zero-filled — RFC-safe.
+// tier. journal.ReadAt fills dst with the file's local bytes, zero-fills the
+// rest, and reports whether the window held evicted (cold) or uncovered (hole)
+// ranges. Either way the engine reconciles against the CAS manifest: it hydrates
+// every covering chunk from the remote store (verified) back into the journal
+// and re-reads, so the re-read serves the fetched bytes. A range no manifest row
+// covers is a genuinely sparse hole and stays zero-filled — RFC-safe.
+//
+// A hole is reconciled for the same reason a cold range is: the local tier alone
+// cannot tell a never-written range from one whose interval the tier lost — a
+// snapshot restore or a pre-journal upgrade re-seeds cold intervals from the
+// manifest and cannot seed a row whose ID does not parse. Consulting the
+// manifest on a hole is what puts such a payload in front of the covering walk's
+// ErrManifestInconsistent guard instead of serving its zeros. It also makes this
+// view and DataExtents' the same union of journal and manifest, which is what
+// keeps NFSv4.2 SEEK and READ from disagreeing about where the data is.
+//
+// A fully warm read — every byte covered by a live local interval — returns
+// without touching the manifest, so the hot path is unchanged. So does any hole
+// on a local-only share: with no remote there is nothing to hydrate and nothing
+// carves manifest rows, so the reconcile would only re-read the same zeros.
 func (bs *Store) readAtInternal(ctx context.Context, payloadID string, data []byte, offset uint64) (int, error) {
 	if len(data) == 0 {
 		return 0, nil
 	}
 
-	n, cold, err := bs.local.ReadAt(ctx, payloadID, int64(offset), data)
+	n, st, err := bs.local.ReadAt(ctx, payloadID, int64(offset), data)
 	if err != nil {
 		var corrupt *journal.CorruptRangeError
 		if errors.As(err, &corrupt) {
@@ -43,12 +57,10 @@ func (bs *Store) readAtInternal(ctx context.Context, payloadID string, data []by
 		}
 		return 0, fmt.Errorf("local read failed: %w", err)
 	}
-	if !cold {
+	if !st.Cold && !(st.Hole && bs.HasRemoteStore()) {
 		return n, nil
 	}
 
-	// Cold: some requested bytes are written-but-evicted. Fetch + hydrate the
-	// covering remote chunks, then re-read the now-warm window.
 	if err := bs.ensureAndReadFromLocal(ctx, payloadID, data, offset); err != nil {
 		return 0, err
 	}
@@ -75,9 +87,11 @@ func (bs *Store) healCorruptWarmRead(ctx context.Context, payloadID string, data
 
 // ensureAndReadFromLocal hydrates every remote-resident chunk covering the
 // window into the local journal, then re-reads. EnsureAvailableAndRead resolves
-// the covering FileChunk rows, does one BLAKE3-verified ranged read per chunk,
-// and Hydrates the plaintext at the chunk's file offset; a range with no remote
-// chunk (genuine sparse hole) is left for ReadAt's zero-fill below.
+// the covering FileChunk rows — refusing with ErrManifestInconsistent when an
+// uncovered offset sits on a payload holding an unplaceable row — does one
+// BLAKE3-verified ranged read per chunk, and Hydrates the plaintext at the
+// chunk's file offset; a range with no remote chunk (genuine sparse hole) is
+// left for ReadAt's zero-fill below.
 //
 // The re-read's cold flag is the post-condition, not a leftover: hydration is
 // supposed to have made every written-but-evicted byte in the window local
@@ -90,13 +104,13 @@ func (bs *Store) healCorruptWarmRead(ctx context.Context, payloadID string, data
 // regardless, so the guard has nothing to fail open on.
 func (bs *Store) ensureAndReadFromLocal(ctx context.Context, payloadID string, dest []byte, offset uint64) error {
 	if _, err := bs.syncer.EnsureAvailableAndRead(ctx, payloadID, offset, uint32(len(dest)), dest); err != nil {
-		return fmt.Errorf("cold read hydrate failed: %w", err)
+		return fmt.Errorf("manifest reconcile for %s at offset %d failed: %w", payloadID, offset, err)
 	}
-	_, cold, err := bs.local.ReadAt(ctx, payloadID, int64(offset), dest)
+	_, st, err := bs.local.ReadAt(ctx, payloadID, int64(offset), dest)
 	if err != nil {
 		return fmt.Errorf("read after hydrate failed: %w", err)
 	}
-	if cold {
+	if st.Cold {
 		return fmt.Errorf("window for %s at offset %d (%d bytes) is still cold after hydrate: %w",
 			payloadID, offset, len(dest), block.ErrChunkNotFound)
 	}

--- a/pkg/block/engine/read_internal.go
+++ b/pkg/block/engine/read_internal.go
@@ -31,9 +31,9 @@ func blockRefHashes(refs []block.ChunkRef) []block.ContentHash {
 // A hole is reconciled because the local tier cannot tell a never-written range
 // from one whose cold interval it lost: cold seeding cannot place a manifest row
 // whose ID carries no offset, so that range arrives here as a plain hole and
-// only the manifest can say its zeros would be invented. It also makes this view
-// and DataExtents' the same union of journal and manifest, so SEEK and READ
-// agree on where the data is.
+// only the manifest can say its zeros would be invented. DataExtents widens its
+// map to the whole file for such a row, so SEEK reports data where READ refuses
+// — never a hole where READ would have refused.
 //
 // A fully warm read never consults the manifest, and neither does a hole on a
 // local-only share, where there is no remote to hydrate from.

--- a/pkg/block/engine/read_internal.go
+++ b/pkg/block/engine/read_internal.go
@@ -23,24 +23,20 @@ func blockRefHashes(refs []block.ChunkRef) []block.ContentHash {
 // readAtInternal reads from the primary payloadID via the journal-backed local
 // tier. journal.ReadAt fills dst with the file's local bytes, zero-fills the
 // rest, and reports whether the window held evicted (cold) or uncovered (hole)
-// ranges. Either way the engine reconciles against the CAS manifest: it hydrates
-// every covering chunk from the remote store (verified) back into the journal
-// and re-reads, so the re-read serves the fetched bytes. A range no manifest row
-// covers is a genuinely sparse hole and stays zero-filled — RFC-safe.
+// ranges. Both are reconciled against the CAS manifest: the covering chunks are
+// hydrated from the remote store (verified) back into the journal and re-read. A
+// range no manifest row covers is a genuinely sparse hole and stays zero-filled
+// — RFC-safe.
 //
-// A hole is reconciled for the same reason a cold range is: the local tier alone
-// cannot tell a never-written range from one whose interval the tier lost — a
-// snapshot restore or a pre-journal upgrade re-seeds cold intervals from the
-// manifest and cannot seed a row whose ID does not parse. Consulting the
-// manifest on a hole is what puts such a payload in front of the covering walk's
-// ErrManifestInconsistent guard instead of serving its zeros. It also makes this
-// view and DataExtents' the same union of journal and manifest, which is what
-// keeps NFSv4.2 SEEK and READ from disagreeing about where the data is.
+// A hole is reconciled because the local tier cannot tell a never-written range
+// from one whose cold interval it lost: cold seeding cannot place a manifest row
+// whose ID carries no offset, so that range arrives here as a plain hole and
+// only the manifest can say its zeros would be invented. It also makes this view
+// and DataExtents' the same union of journal and manifest, so SEEK and READ
+// agree on where the data is.
 //
-// A fully warm read — every byte covered by a live local interval — returns
-// without touching the manifest, so the hot path is unchanged. So does any hole
-// on a local-only share: with no remote there is nothing to hydrate and nothing
-// carves manifest rows, so the reconcile would only re-read the same zeros.
+// A fully warm read never consults the manifest, and neither does a hole on a
+// local-only share, where there is no remote to hydrate from.
 func (bs *Store) readAtInternal(ctx context.Context, payloadID string, data []byte, offset uint64) (int, error) {
 	if len(data) == 0 {
 		return 0, nil
@@ -57,7 +53,8 @@ func (bs *Store) readAtInternal(ctx context.Context, payloadID string, data []by
 		}
 		return 0, fmt.Errorf("local read failed: %w", err)
 	}
-	if !st.Cold && !(st.Hole && bs.HasRemoteStore()) {
+	reconcile := st.Cold || (st.Hole && bs.HasRemoteStore())
+	if !reconcile {
 		return n, nil
 	}
 

--- a/pkg/block/engine/unplaceable_row_read_test.go
+++ b/pkg/block/engine/unplaceable_row_read_test.go
@@ -1,0 +1,156 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	memorylocal "github.com/marmos91/dittofs/pkg/block/local/memory"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatabadger "github.com/marmos91/dittofs/pkg/metadata/store/badger"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// manifestBackend names one of the two shapes the covering walk can take: the
+// ListFileChunks fallback, and badger's offset-indexed lookups. Neither can lean
+// on the other — a payload holding an unplaceable row must refuse on both.
+type manifestBackend struct {
+	name  string
+	build func(t *testing.T) (block.EngineFileChunkStore, metadata.SyncedHashStore)
+}
+
+func manifestBackends() []manifestBackend {
+	return []manifestBackend{
+		{"ListFileChunksFallback", func(t *testing.T) (block.EngineFileChunkStore, metadata.SyncedHashStore) {
+			return newStubFileChunkStore(), metadatamemory.NewMemoryMetadataStoreWithDefaults()
+		}},
+		{"OffsetIndexed", func(t *testing.T) (block.EngineFileChunkStore, metadata.SyncedHashStore) {
+			ms, err := metadatabadger.NewBadgerMetadataStoreWithDefaults(context.Background(), t.TempDir())
+			if err != nil {
+				t.Fatalf("NewBadgerMetadataStoreWithDefaults: %v", err)
+			}
+			// Registered before the engine is built so cleanups run LIFO and the
+			// syncer's workers are joined before badger closes under them.
+			t.Cleanup(func() { _ = ms.Close() })
+			return ms, ms
+		}},
+	}
+}
+
+// newRemoteBackedEngine builds a Store with a real (memory) remote so
+// HasRemoteStore reports true and an uncovered read reconciles against the
+// manifest.
+func newRemoteBackedEngine(t *testing.T, b manifestBackend) (*Store, block.EngineFileChunkStore, *remotememory.Store, metadata.SyncedHashStore) {
+	t.Helper()
+	fbs, shs := b.build(t)
+	localStore := memorylocal.New()
+	rs := remotememory.New()
+
+	syncer := NewSyncer(localStore, rs, fbs, DefaultConfig())
+	syncer.SetSyncedHashStore(shs)
+	syncer.SetRemoteBlockStore(rs)
+
+	bs, err := New(BlockStoreConfig{
+		Local:           localStore,
+		Remote:          rs,
+		Syncer:          syncer,
+		FileChunkStore:  fbs,
+		SyncedHashStore: shs,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := bs.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = bs.Close() })
+	return bs, fbs, rs, shs
+}
+
+// TestReadAt_UncoveredOffsetOnUnplaceableRowRefuses pins the composition of the
+// covering walk's guard with the cold seeding that skips unplaceable rows.
+// Seeding cannot place such a row, so the range it describes gets no cold
+// interval and the local tier calls it a plain hole. Classifying the read on the
+// cold flag alone would then never reach the guard, and the very rows it was
+// written for would be the ones served as zeros for good.
+//
+// The read must refuse instead: nothing covers the offset and the manifest holds
+// a row whose range is unknown, so the zeros would be invented.
+func TestReadAt_UncoveredOffsetOnUnplaceableRowRefuses(t *testing.T) {
+	for _, b := range manifestBackends() {
+		t.Run(b.name, func(t *testing.T) {
+			ctx := context.Background()
+			bs, fbs, _, _ := newRemoteBackedEngine(t, b)
+			const payloadID = "payload-unplaceable-read"
+
+			if err := fbs.Put(ctx, &block.FileChunk{ID: payloadID + "/not-an-offset", DataSize: 4096}); err != nil {
+				t.Fatalf("seed unplaceable row: %v", err)
+			}
+
+			got := bytes.Repeat([]byte{0xAA}, 4096)
+			_, err := bs.ReadAt(ctx, payloadID, nil, got, 0)
+			if !errors.Is(err, block.ErrManifestInconsistent) {
+				t.Fatalf("ReadAt = %v; want ErrManifestInconsistent (served zeros: %v)",
+					err, bytes.Equal(got, make([]byte, 4096)))
+			}
+		})
+	}
+}
+
+// TestReadAt_CoveredOffsetIgnoresUnplaceableRow keeps the guard scoped to the
+// reads it must fail. One bad row makes an unknown range unreadable, not the
+// whole payload: an offset some other row covers still answers from that row.
+func TestReadAt_CoveredOffsetIgnoresUnplaceableRow(t *testing.T) {
+	for _, b := range manifestBackends() {
+		t.Run(b.name, func(t *testing.T) {
+			ctx := context.Background()
+			bs, fbs, rs, shs := newRemoteBackedEngine(t, b)
+			const payloadID = "payload-partly-unplaceable"
+
+			want := bytes.Repeat([]byte{0x5A}, 4096)
+			seedSyncedRemoteChunk(t, fbs, rs, shs, payloadID, 0, want)
+			if err := fbs.Put(ctx, &block.FileChunk{ID: payloadID + "/not-an-offset", DataSize: 4096}); err != nil {
+				t.Fatalf("seed unplaceable row: %v", err)
+			}
+
+			got := make([]byte, len(want))
+			if _, err := bs.ReadAt(ctx, payloadID, nil, got, 0); err != nil {
+				t.Fatalf("ReadAt over a covered offset: %v", err)
+			}
+			if !bytes.Equal(got, want) {
+				t.Fatalf("covered offset served %x…; want %x…", got[:16], want[:16])
+			}
+		})
+	}
+}
+
+// TestReadAt_GenuineHoleStillZeroFills guards the other side: reconciling a hole
+// against the manifest must not turn a sparse file into an error. With no row
+// covering the window and no unplaceable row to cast doubt, the hole is real.
+func TestReadAt_GenuineHoleStillZeroFills(t *testing.T) {
+	for _, b := range manifestBackends() {
+		t.Run(b.name, func(t *testing.T) {
+			ctx := context.Background()
+			bs, fbs, rs, shs := newRemoteBackedEngine(t, b)
+			const payloadID = "payload-genuine-hole"
+
+			// Data at [4096, 8192) only, so [0, 4096) is a real sparse hole.
+			seedSyncedRemoteChunk(t, fbs, rs, shs, payloadID, 4096, bytes.Repeat([]byte{0x5A}, 4096))
+
+			got := bytes.Repeat([]byte{0xAA}, 4096)
+			n, err := bs.ReadAt(ctx, payloadID, nil, got, 0)
+			if err != nil {
+				t.Fatalf("ReadAt over a sparse hole: %v", err)
+			}
+			if n != len(got) {
+				t.Fatalf("ReadAt n = %d; want %d", n, len(got))
+			}
+			if !bytes.Equal(got, make([]byte, 4096)) {
+				t.Fatalf("sparse hole not zero-filled")
+			}
+		})
+	}
+}

--- a/pkg/block/engine/unplaceable_row_read_test.go
+++ b/pkg/block/engine/unplaceable_row_read_test.go
@@ -154,3 +154,39 @@ func TestReadAt_GenuineHoleStillZeroFills(t *testing.T) {
 		})
 	}
 }
+
+// TestDataExtents_UnplaceableRowReportsWholeFileAsData closes the other op on
+// the same seam. SEEK and READ_PLUS derive their hole map from DataExtents and
+// never call READ for a range it calls hole, so the covering walk's guard cannot
+// protect them: a sparse-copy client would skip the range on SEEK alone and lose
+// the bytes. An unplaceable row therefore widens the map to the whole file —
+// over-reporting data is the RFC-safe direction, and it forces the READ that
+// refuses.
+//
+// Both callers drop an error from DataExtents and fall back to the CAS block
+// list, which cannot see the row either, so refusing here would change nothing.
+func TestDataExtents_UnplaceableRowReportsWholeFileAsData(t *testing.T) {
+	for _, b := range manifestBackends() {
+		t.Run(b.name, func(t *testing.T) {
+			ctx := context.Background()
+			bs, fbs, rs, shs := newRemoteBackedEngine(t, b)
+			const payloadID = "payload-extents-unplaceable"
+			const fileSize = 16384
+
+			// Real data at [0, 4096) plus a row whose range cannot be placed.
+			seedSyncedRemoteChunk(t, fbs, rs, shs, payloadID, 0, bytes.Repeat([]byte{0x5A}, 4096))
+			if err := fbs.Put(ctx, &block.FileChunk{ID: payloadID + "/not-an-offset", DataSize: 4096}); err != nil {
+				t.Fatalf("seed unplaceable row: %v", err)
+			}
+
+			ext, err := bs.DataExtents(ctx, payloadID, fileSize)
+			if err != nil {
+				t.Fatalf("DataExtents: %v", err)
+			}
+			want := [][2]uint64{{0, fileSize}}
+			if len(ext) != 1 || ext[0] != want[0] {
+				t.Fatalf("DataExtents = %v; want %v (a hole here is a range SEEK lets a client skip)", ext, want)
+			}
+		})
+	}
+}

--- a/pkg/block/journal/carve_test.go
+++ b/pkg/block/journal/carve_test.go
@@ -236,8 +236,8 @@ func TestCarveRoundTripAndFlip(t *testing.T) {
 	}
 	// Warm read still returns the data unchanged.
 	got := make([]byte, len(data))
-	if _, cold, err := s.ReadAt(ctx, "f", 0, got); err != nil || cold {
-		t.Fatalf("ReadAt: err=%v cold=%v", err, cold)
+	if _, st, err := s.ReadAt(ctx, "f", 0, got); err != nil || st.Cold {
+		t.Fatalf("ReadAt: err=%v cold=%v", err, st.Cold)
 	}
 	if string(got) != string(data) {
 		t.Fatalf("warm read mismatch after carve")

--- a/pkg/block/journal/cold_test.go
+++ b/pkg/block/journal/cold_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // allZero reports whether b is entirely zero bytes — the shape a silent
-// zero-fill takes when a cold range is mistaken for a POSIX hole.
+// zero-fill takes when a st.Cold range is mistaken for a POSIX hole.
 func allZero(b []byte) bool {
 	for _, c := range b {
 		if c != 0 {
@@ -20,8 +20,8 @@ func allZero(b []byte) bool {
 }
 
 // TestColdIntervalSurvivesReopen is the regression for a share serving all-zeros
-// after a restart. A cold interval owns no record, so if it is only held in
-// memory the reopened store sees a hole, ReadAt zero-fills and reports cold=false
+// after a restart. A st.Cold interval owns no record, so if it is only held in
+// memory the reopened store sees a hole, ReadAt zero-fills and reports st.Cold=false
 // — the engine never fetches, and the read silently returns zeros for data that
 // is safe on the remote.
 func TestColdIntervalSurvivesReopen(t *testing.T) {
@@ -38,18 +38,18 @@ func TestColdIntervalSurvivesReopen(t *testing.T) {
 	fillUntilSealed(t, s, "f", true, 2)
 
 	// Drain the shard: a large target evicts every qualifying segment, including
-	// the force-sealed active, so offset 0 is unambiguously cold afterwards.
+	// the force-sealed active, so offset 0 is unambiguously st.Cold afterwards.
 	if _, err := s.Evict(ctx, 1<<30); err != nil {
 		t.Fatalf("Evict: %v", err)
 	}
 
 	dst := make([]byte, chunk256)
-	_, cold, err := s.ReadAt(ctx, "f", 0, dst)
+	_, st, err := s.ReadAt(ctx, "f", 0, dst)
 	if err != nil {
 		t.Fatalf("ReadAt before reopen: %v", err)
 	}
-	if !cold {
-		t.Fatal("ReadAt before reopen: cold=false, want true after evicting the range")
+	if !st.Cold {
+		t.Fatal("ReadAt before reopen: st.Cold=false, want true after evicting the range")
 	}
 	if err := s.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
@@ -62,20 +62,20 @@ func TestColdIntervalSurvivesReopen(t *testing.T) {
 	defer func() { _ = s2.Close() }()
 
 	dst2 := make([]byte, chunk256)
-	n, cold, err := s2.ReadAt(ctx, "f", 0, dst2)
+	n, st, err := s2.ReadAt(ctx, "f", 0, dst2)
 	if err != nil {
 		t.Fatalf("ReadAt after reopen: %v", err)
 	}
-	if !cold {
-		t.Errorf("ReadAt after reopen: cold=false — the evicted range reads as a hole, so the caller returns %d zero bytes without fetching from the remote", n)
+	if !st.Cold {
+		t.Errorf("ReadAt after reopen: st.Cold=false — the evicted range reads as a hole, so the caller returns %d zero bytes without fetching from the remote", n)
 	}
 	if !allZero(dst2) {
-		t.Errorf("ReadAt after reopen: cold range should still zero-fill its placeholder bytes")
+		t.Errorf("ReadAt after reopen: st.Cold range should still zero-fill its placeholder bytes")
 	}
 }
 
 // TestSeedColdSurvivesReopen covers the seeded flavor: an upgrade that archives a
-// pre-journal layout aside (or a snapshot restore) seeds cold intervals from the
+// pre-journal layout aside (or a snapshot restore) seeds st.Cold intervals from the
 // surviving manifest against an otherwise empty journal. Losing them on restart
 // is what left a migrated share serving zeros.
 func TestSeedColdSurvivesReopen(t *testing.T) {
@@ -101,14 +101,14 @@ func TestSeedColdSurvivesReopen(t *testing.T) {
 	defer func() { _ = s2.Close() }()
 
 	dst := make([]byte, 4096)
-	if _, cold, err := s2.ReadAt(ctx, "f", 0, dst); err != nil {
+	if _, st, err := s2.ReadAt(ctx, "f", 0, dst); err != nil {
 		t.Fatalf("ReadAt after reopen: %v", err)
-	} else if !cold {
-		t.Error("ReadAt after reopen: cold=false — a seeded cold range reads as a hole, so reads return zeros with no remote fetch")
+	} else if !st.Cold {
+		t.Error("ReadAt after reopen: st.Cold=false — a seeded st.Cold range reads as a hole, so reads return zeros with no remote fetch")
 	}
 }
 
-// TestColdLogSupersededByLaterWrite checks the version ordering: a cold entry
+// TestColdLogSupersededByLaterWrite checks the version ordering: a st.Cold entry
 // replayed at recovery must not shadow a warm write that landed after it.
 func TestColdLogSupersededByLaterWrite(t *testing.T) {
 	ctx := context.Background()
@@ -140,12 +140,12 @@ func TestColdLogSupersededByLaterWrite(t *testing.T) {
 	defer func() { _ = s2.Close() }()
 
 	got := make([]byte, 4096)
-	_, cold, err := s2.ReadAt(ctx, "f", 0, got)
+	_, st, err := s2.ReadAt(ctx, "f", 0, got)
 	if err != nil {
 		t.Fatalf("ReadAt after reopen: %v", err)
 	}
-	if cold {
-		t.Error("ReadAt after reopen: cold=true — the stale cold entry shadowed the newer local write")
+	if st.Cold {
+		t.Error("ReadAt after reopen: st.Cold=true — the stale st.Cold entry shadowed the newer local write")
 	}
 	if !bytes.Equal(got, want) {
 		t.Error("ReadAt after reopen: did not return the bytes written after the seed")
@@ -177,10 +177,10 @@ func TestColdLogTornTailKeepsIntactEntries(t *testing.T) {
 	path := filepath.Join(dir, coldLogName)
 	raw, err := os.ReadFile(path)
 	if err != nil {
-		t.Fatalf("read cold log: %v", err)
+		t.Fatalf("read st.Cold log: %v", err)
 	}
 	if err := os.WriteFile(path, raw[:len(raw)-1], 0o644); err != nil {
-		t.Fatalf("truncate cold log: %v", err)
+		t.Fatalf("truncate st.Cold log: %v", err)
 	}
 
 	s2, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
@@ -190,15 +190,15 @@ func TestColdLogTornTailKeepsIntactEntries(t *testing.T) {
 	defer func() { _ = s2.Close() }()
 
 	dst := make([]byte, 4096)
-	if _, cold, err := s2.ReadAt(ctx, "f", 0, dst); err != nil {
+	if _, st, err := s2.ReadAt(ctx, "f", 0, dst); err != nil {
 		t.Fatalf("ReadAt: %v", err)
-	} else if !cold {
+	} else if !st.Cold {
 		t.Error("the entry before the torn tail was dropped; only the torn one should be lost")
 	}
 }
 
 // TestSeedColdLeavesLocalBytesAlone is what makes a re-seed safe to run against a
-// store that is only partly missing its markers. A cold interval carries a fresh
+// store that is only partly missing its markers. A st.Cold interval carries a fresh
 // version, so seeding a range the journal already holds would shadow those bytes
 // — and a chunk not yet on the remote cannot be fetched back, so the read would
 // fail or return zeros for data that exists only locally.
@@ -223,21 +223,21 @@ func TestSeedColdLeavesLocalBytesAlone(t *testing.T) {
 	}
 
 	got := make([]byte, 4096)
-	_, cold, err := s.ReadAt(ctx, "f", 4096, got)
+	_, st, err := s.ReadAt(ctx, "f", 4096, got)
 	if err != nil {
 		t.Fatalf("ReadAt over the written range: %v", err)
 	}
-	if cold {
+	if st.Cold {
 		t.Error("the seed shadowed a range the journal holds locally; the read now needs a remote copy that may not exist")
 	}
 	if !bytes.Equal(got, want) {
 		t.Error("the seed replaced locally-written bytes")
 	}
-	// The ranges on either side had nothing local, so they must be cold.
+	// The ranges on either side had nothing local, so they must be st.Cold.
 	for _, off := range []int64{0, 8192} {
-		if _, cold, err := s.ReadAt(ctx, "f", off, make([]byte, 4096)); err != nil {
+		if _, st, err := s.ReadAt(ctx, "f", off, make([]byte, 4096)); err != nil {
 			t.Fatalf("ReadAt at %d: %v", off, err)
-		} else if !cold {
+		} else if !st.Cold {
 			t.Errorf("range at %d was not seeded, so it reads as a hole and returns zeros with no remote fetch", off)
 		}
 	}
@@ -263,14 +263,14 @@ func TestSeedColdIsIdempotent(t *testing.T) {
 	}
 	first, err := os.Stat(filepath.Join(dir, coldLogName))
 	if err != nil {
-		t.Fatalf("stat cold log: %v", err)
+		t.Fatalf("stat st.Cold log: %v", err)
 	}
 	if err := s.SeedCold(ctx, "f", extents); err != nil {
 		t.Fatalf("SeedCold again: %v", err)
 	}
 	second, err := os.Stat(filepath.Join(dir, coldLogName))
 	if err != nil {
-		t.Fatalf("stat cold log: %v", err)
+		t.Fatalf("stat st.Cold log: %v", err)
 	}
 	if second.Size() != first.Size() {
 		t.Errorf("re-seeding appended %d bytes for ranges already covered; the log grows on every open",

--- a/pkg/block/journal/cold_test.go
+++ b/pkg/block/journal/cold_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // allZero reports whether b is entirely zero bytes — the shape a silent
-// zero-fill takes when a st.Cold range is mistaken for a POSIX hole.
+// zero-fill takes when a cold range is mistaken for a POSIX hole.
 func allZero(b []byte) bool {
 	for _, c := range b {
 		if c != 0 {
@@ -20,8 +20,8 @@ func allZero(b []byte) bool {
 }
 
 // TestColdIntervalSurvivesReopen is the regression for a share serving all-zeros
-// after a restart. A st.Cold interval owns no record, so if it is only held in
-// memory the reopened store sees a hole, ReadAt zero-fills and reports st.Cold=false
+// after a restart. A cold interval owns no record, so if it is only held in
+// memory the reopened store sees a hole, ReadAt zero-fills and reports cold=false
 // — the engine never fetches, and the read silently returns zeros for data that
 // is safe on the remote.
 func TestColdIntervalSurvivesReopen(t *testing.T) {
@@ -38,7 +38,7 @@ func TestColdIntervalSurvivesReopen(t *testing.T) {
 	fillUntilSealed(t, s, "f", true, 2)
 
 	// Drain the shard: a large target evicts every qualifying segment, including
-	// the force-sealed active, so offset 0 is unambiguously st.Cold afterwards.
+	// the force-sealed active, so offset 0 is unambiguously cold afterwards.
 	if _, err := s.Evict(ctx, 1<<30); err != nil {
 		t.Fatalf("Evict: %v", err)
 	}
@@ -49,7 +49,7 @@ func TestColdIntervalSurvivesReopen(t *testing.T) {
 		t.Fatalf("ReadAt before reopen: %v", err)
 	}
 	if !st.Cold {
-		t.Fatal("ReadAt before reopen: st.Cold=false, want true after evicting the range")
+		t.Fatal("ReadAt before reopen: cold=false, want true after evicting the range")
 	}
 	if err := s.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
@@ -67,15 +67,15 @@ func TestColdIntervalSurvivesReopen(t *testing.T) {
 		t.Fatalf("ReadAt after reopen: %v", err)
 	}
 	if !st.Cold {
-		t.Errorf("ReadAt after reopen: st.Cold=false — the evicted range reads as a hole, so the caller returns %d zero bytes without fetching from the remote", n)
+		t.Errorf("ReadAt after reopen: cold=false — the evicted range reads as a hole, so the caller returns %d zero bytes without fetching from the remote", n)
 	}
 	if !allZero(dst2) {
-		t.Errorf("ReadAt after reopen: st.Cold range should still zero-fill its placeholder bytes")
+		t.Errorf("ReadAt after reopen: cold range should still zero-fill its placeholder bytes")
 	}
 }
 
 // TestSeedColdSurvivesReopen covers the seeded flavor: an upgrade that archives a
-// pre-journal layout aside (or a snapshot restore) seeds st.Cold intervals from the
+// pre-journal layout aside (or a snapshot restore) seeds cold intervals from the
 // surviving manifest against an otherwise empty journal. Losing them on restart
 // is what left a migrated share serving zeros.
 func TestSeedColdSurvivesReopen(t *testing.T) {
@@ -104,11 +104,11 @@ func TestSeedColdSurvivesReopen(t *testing.T) {
 	if _, st, err := s2.ReadAt(ctx, "f", 0, dst); err != nil {
 		t.Fatalf("ReadAt after reopen: %v", err)
 	} else if !st.Cold {
-		t.Error("ReadAt after reopen: st.Cold=false — a seeded st.Cold range reads as a hole, so reads return zeros with no remote fetch")
+		t.Error("ReadAt after reopen: cold=false — a seeded cold range reads as a hole, so reads return zeros with no remote fetch")
 	}
 }
 
-// TestColdLogSupersededByLaterWrite checks the version ordering: a st.Cold entry
+// TestColdLogSupersededByLaterWrite checks the version ordering: a cold entry
 // replayed at recovery must not shadow a warm write that landed after it.
 func TestColdLogSupersededByLaterWrite(t *testing.T) {
 	ctx := context.Background()
@@ -145,7 +145,7 @@ func TestColdLogSupersededByLaterWrite(t *testing.T) {
 		t.Fatalf("ReadAt after reopen: %v", err)
 	}
 	if st.Cold {
-		t.Error("ReadAt after reopen: st.Cold=true — the stale st.Cold entry shadowed the newer local write")
+		t.Error("ReadAt after reopen: cold=true — the stale cold entry shadowed the newer local write")
 	}
 	if !bytes.Equal(got, want) {
 		t.Error("ReadAt after reopen: did not return the bytes written after the seed")
@@ -177,10 +177,10 @@ func TestColdLogTornTailKeepsIntactEntries(t *testing.T) {
 	path := filepath.Join(dir, coldLogName)
 	raw, err := os.ReadFile(path)
 	if err != nil {
-		t.Fatalf("read st.Cold log: %v", err)
+		t.Fatalf("read cold log: %v", err)
 	}
 	if err := os.WriteFile(path, raw[:len(raw)-1], 0o644); err != nil {
-		t.Fatalf("truncate st.Cold log: %v", err)
+		t.Fatalf("truncate cold log: %v", err)
 	}
 
 	s2, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
@@ -198,7 +198,7 @@ func TestColdLogTornTailKeepsIntactEntries(t *testing.T) {
 }
 
 // TestSeedColdLeavesLocalBytesAlone is what makes a re-seed safe to run against a
-// store that is only partly missing its markers. A st.Cold interval carries a fresh
+// store that is only partly missing its markers. A cold interval carries a fresh
 // version, so seeding a range the journal already holds would shadow those bytes
 // — and a chunk not yet on the remote cannot be fetched back, so the read would
 // fail or return zeros for data that exists only locally.
@@ -233,7 +233,7 @@ func TestSeedColdLeavesLocalBytesAlone(t *testing.T) {
 	if !bytes.Equal(got, want) {
 		t.Error("the seed replaced locally-written bytes")
 	}
-	// The ranges on either side had nothing local, so they must be st.Cold.
+	// The ranges on either side had nothing local, so they must be cold.
 	for _, off := range []int64{0, 8192} {
 		if _, st, err := s.ReadAt(ctx, "f", off, make([]byte, 4096)); err != nil {
 			t.Fatalf("ReadAt at %d: %v", off, err)
@@ -263,14 +263,14 @@ func TestSeedColdIsIdempotent(t *testing.T) {
 	}
 	first, err := os.Stat(filepath.Join(dir, coldLogName))
 	if err != nil {
-		t.Fatalf("stat st.Cold log: %v", err)
+		t.Fatalf("stat cold log: %v", err)
 	}
 	if err := s.SeedCold(ctx, "f", extents); err != nil {
 		t.Fatalf("SeedCold again: %v", err)
 	}
 	second, err := os.Stat(filepath.Join(dir, coldLogName))
 	if err != nil {
-		t.Fatalf("stat st.Cold log: %v", err)
+		t.Fatalf("stat cold log: %v", err)
 	}
 	if second.Size() != first.Size() {
 		t.Errorf("re-seeding appended %d bytes for ranges already covered; the log grows on every open",

--- a/pkg/block/journal/evict_test.go
+++ b/pkg/block/journal/evict_test.go
@@ -230,11 +230,11 @@ func TestEvictedRangeReadsCold(t *testing.T) {
 
 	// The evicted range must read back as cold (not a zero-filled hole).
 	dst := make([]byte, chunk256)
-	_, cold, err := s.ReadAt(ctx, "f", 0, dst)
+	_, st, err := s.ReadAt(ctx, "f", 0, dst)
 	if err != nil {
 		t.Fatalf("ReadAt: %v", err)
 	}
-	if !cold {
+	if !st.Cold {
 		t.Fatalf("evicted range must report cold, not a hole")
 	}
 	// DataExtents must still report the evicted range as present.
@@ -331,9 +331,9 @@ func TestEvictForceSealsSyncedActive(t *testing.T) {
 	}
 	// The reclaimed range must read back cold (remote-backed), never as a hole.
 	dst := make([]byte, chunk256)
-	if _, cold, err := s.ReadAt(ctx, "f", 0, dst); err != nil {
+	if _, st, err := s.ReadAt(ctx, "f", 0, dst); err != nil {
 		t.Fatalf("ReadAt: %v", err)
-	} else if !cold {
+	} else if !st.Cold {
 		t.Fatalf("evicted range must report cold, not a hole")
 	}
 }

--- a/pkg/block/journal/gc_test.go
+++ b/pkg/block/journal/gc_test.go
@@ -147,8 +147,8 @@ func TestGCForcedRepackPreservesData(t *testing.T) {
 
 	// keep survives byte-identically; gone stays deleted.
 	got := make([]byte, len(keep))
-	if _, cold, err := s.ReadAt(ctx, "keep", 0, got); err != nil || cold {
-		t.Fatalf("ReadAt keep: err=%v cold=%v", err, cold)
+	if _, st, err := s.ReadAt(ctx, "keep", 0, got); err != nil || st.Cold {
+		t.Fatalf("ReadAt keep: err=%v cold=%v", err, st.Cold)
 	}
 	if !bytes.Equal(got, keep) {
 		t.Fatalf("keep not byte-identical after repack")
@@ -243,8 +243,8 @@ func TestGCCrashBeforeUnlinkOrphanSwept(t *testing.T) {
 	defer func() { _ = r.Close() }()
 
 	got := make([]byte, len(keep))
-	if _, cold, err := r.ReadAt(ctx, "keep", 0, got); err != nil || cold {
-		t.Fatalf("ReadAt keep after recovery: err=%v cold=%v", err, cold)
+	if _, st, err := r.ReadAt(ctx, "keep", 0, got); err != nil || st.Cold {
+		t.Fatalf("ReadAt keep after recovery: err=%v cold=%v", err, st.Cold)
 	}
 	if !bytes.Equal(got, keep) {
 		t.Fatalf("keep not byte-identical after crash-before-unlink recovery")

--- a/pkg/block/journal/index.go
+++ b/pkg/block/journal/index.go
@@ -279,22 +279,31 @@ func (fi *fileIndex) plan(offset, n int64) []piece {
 	return pieces
 }
 
+// ReadState reports what the local tier found under a read window. Cold ranges
+// were written but evicted, so the caller hydrates from the remote store and
+// retries. Hole ranges have no local interval at all: the journal zero-fills
+// them, but only the manifest can say whether they are genuinely sparse.
+type ReadState struct {
+	Cold bool
+	Hole bool
+}
+
 // ReadAt fills dst with the file's bytes at offset. Ranges never written locally
-// are POSIX holes and are zero-filled. Ranges written but evicted are reported
-// via cold so the caller can hydrate from the remote store and retry; their dst
-// bytes are zero-filled as a placeholder until that cold-read path is wired.
-func (s *Store) ReadAt(ctx context.Context, id FileID, offset int64, dst []byte) (n int, cold bool, err error) {
+// are POSIX holes and are zero-filled; ranges written but evicted are zero-filled
+// as a placeholder. Both are reported through the returned ReadState so the
+// caller can reconcile them against the CAS manifest.
+func (s *Store) ReadAt(ctx context.Context, id FileID, offset int64, dst []byte) (n int, st ReadState, err error) {
 	if err := ctx.Err(); err != nil {
-		return 0, false, err
+		return 0, ReadState{}, err
 	}
 	if s.closed.Load() {
-		return 0, false, errClosed
+		return 0, ReadState{}, errClosed
 	}
 	if offset < 0 {
-		return 0, false, fmt.Errorf("journal: negative offset %d", offset)
+		return 0, ReadState{}, fmt.Errorf("journal: negative offset %d", offset)
 	}
 	if len(dst) == 0 {
-		return 0, false, nil
+		return 0, ReadState{}, nil
 	}
 	s.reads.Add(1)
 
@@ -304,7 +313,7 @@ func (s *Store) ReadAt(ctx context.Context, id FileID, offset int64, dst []byte)
 	if fi == nil { // unknown file: all hole
 		sh.mu.Unlock()
 		clear(dst)
-		return len(dst), false, nil
+		return len(dst), ReadState{Hole: true}, nil
 	}
 	pieces := fi.plan(offset, int64(len(dst)))
 	// Resolve and read-guard each data piece's segment while the index and the
@@ -321,7 +330,7 @@ func (s *Store) ReadAt(ctx context.Context, id FileID, offset int64, dst []byte)
 		if seg == nil {
 			sh.mu.Unlock()
 			releaseGuards(segs)
-			return int(p.dstStart), false, fmt.Errorf("journal: unknown segment %d", p.loc.SegmentID)
+			return int(p.dstStart), ReadState{}, fmt.Errorf("journal: unknown segment %d", p.loc.SegmentID)
 		}
 		seg.readGuard.RLock()
 		segs[i] = seg
@@ -334,25 +343,26 @@ func (s *Store) ReadAt(ctx context.Context, id FileID, offset int64, dst []byte)
 		switch {
 		case p.hole:
 			clear(out)
+			st.Hole = true
 		case p.cold:
 			clear(out)
-			cold = true
+			st.Cold = true
 			s.coldReads.Add(1)
 		default:
 			seg := segs[i]
 			seg.lastAccess.Store(s.clock.Now().UnixNano())
 			if s.verifyReads.Load() {
 				if rerr := s.verifiedRead(seg, p, out, id, offset); rerr != nil {
-					return int(p.dstStart), false, rerr
+					return int(p.dstStart), ReadState{}, rerr
 				}
 				continue
 			}
 			if _, rerr := seg.fd.ReadAt(out, p.loc.Offset+p.subOff); rerr != nil {
-				return int(p.dstStart), false, fmt.Errorf("journal: read segment %d@%d: %w", p.loc.SegmentID, p.loc.Offset+p.subOff, rerr)
+				return int(p.dstStart), ReadState{}, fmt.Errorf("journal: read segment %d@%d: %w", p.loc.SegmentID, p.loc.Offset+p.subOff, rerr)
 			}
 		}
 	}
-	return len(dst), cold, nil
+	return len(dst), st, nil
 }
 
 // maxPooledRecordScratch bounds what a verified read hands back to the pool. A

--- a/pkg/block/journal/index_test.go
+++ b/pkg/block/journal/index_test.go
@@ -145,19 +145,22 @@ func TestColdMarkerReadAndExtents(t *testing.T) {
 
 	// Reading the cold range reports cold; reading a true hole does not.
 	dst := make([]byte, 10)
-	_, cold, err := s.ReadAt(ctx, "f", 100, dst)
+	_, st, err := s.ReadAt(ctx, "f", 100, dst)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !cold {
+	if !st.Cold {
 		t.Fatalf("expected cold read over evicted range")
 	}
-	_, cold, err = s.ReadAt(ctx, "f", 50, dst) // gap between the two writes
+	_, st, err = s.ReadAt(ctx, "f", 50, dst) // gap between the two writes
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cold {
+	if st.Cold {
 		t.Fatalf("hole must not report cold")
+	}
+	if !st.Hole {
+		t.Fatalf("gap between two writes must report a hole")
 	}
 
 	// Both the warm and the evicted range are present in DataExtents.

--- a/pkg/block/journal/journal_test.go
+++ b/pkg/block/journal/journal_test.go
@@ -61,11 +61,11 @@ func TestAppendReadRoundTrip(t *testing.T) {
 
 	// Full read back.
 	got := make([]byte, len(payload))
-	n, cold, err := s.ReadAt(ctx, "file-a", 0, got)
+	n, st, err := s.ReadAt(ctx, "file-a", 0, got)
 	if err != nil {
 		t.Fatalf("ReadAt: %v", err)
 	}
-	if cold {
+	if st.Cold {
 		t.Fatalf("unexpected cold read")
 	}
 	if n != len(payload) || !bytes.Equal(got, payload) {

--- a/pkg/block/journal/verify_read_test.go
+++ b/pkg/block/journal/verify_read_test.go
@@ -56,8 +56,8 @@ func TestVerifiedReadDetectsCorruption(t *testing.T) {
 
 	// Baseline: a verified read of the intact record round-trips.
 	got := make([]byte, len(payload))
-	if _, cold, err := s.ReadAt(ctx, "f1", 0, got); err != nil || cold {
-		t.Fatalf("baseline verified read: err=%v cold=%v", err, cold)
+	if _, st, err := s.ReadAt(ctx, "f1", 0, got); err != nil || st.Cold {
+		t.Fatalf("baseline verified read: err=%v cold=%v", err, st.Cold)
 	}
 	if !bytes.Equal(got, payload) {
 		t.Fatalf("baseline verified read mismatch")
@@ -66,12 +66,12 @@ func TestVerifiedReadDetectsCorruption(t *testing.T) {
 	corruptFirstPayloadByte(t, s, "f1")
 
 	clear(got)
-	_, cold, err := s.ReadAt(ctx, "f1", 0, got)
+	_, st, err := s.ReadAt(ctx, "f1", 0, got)
 	var cre *CorruptRangeError
 	if !errors.As(err, &cre) {
 		t.Fatalf("want *CorruptRangeError, got err=%v", err)
 	}
-	if cold {
+	if st.Cold {
 		t.Fatalf("a corrupt range must never be reported cold (cold zero-fills)")
 	}
 	if cre.FileID != "f1" {
@@ -118,12 +118,12 @@ func TestVerifiedReadDetectsFileIDCorruption(t *testing.T) {
 	_ = f.Close()
 
 	got := make([]byte, len(payload))
-	_, cold, err := s.ReadAt(ctx, "f1", 0, got)
+	_, st, err := s.ReadAt(ctx, "f1", 0, got)
 	var cre *CorruptRangeError
 	if !errors.As(err, &cre) {
 		t.Fatalf("want *CorruptRangeError for flipped FileID, got err=%v", err)
 	}
-	if cold {
+	if st.Cold {
 		t.Fatalf("a corrupt range must never be reported cold")
 	}
 }
@@ -143,9 +143,9 @@ func TestUnverifiedReadReturnsRawBytes(t *testing.T) {
 	corruptFirstPayloadByte(t, s, "f1")
 
 	got := make([]byte, len(payload))
-	n, cold, err := s.ReadAt(ctx, "f1", 0, got)
-	if err != nil || cold || n != len(payload) {
-		t.Fatalf("raw read: err=%v cold=%v n=%d", err, cold, n)
+	n, st, err := s.ReadAt(ctx, "f1", 0, got)
+	if err != nil || st.Cold || n != len(payload) {
+		t.Fatalf("raw read: err=%v cold=%v n=%d", err, st.Cold, n)
 	}
 	if bytes.Equal(got, payload) {
 		t.Fatalf("expected the corrupted byte to leak through the unverified fast path")

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -193,9 +193,9 @@ func (s *FSStore) WriteAt(ctx context.Context, payloadID string, offset int64, d
 	return s.Store.WriteAt(ctx, journal.FileID(payloadID), offset, data)
 }
 
-func (s *FSStore) ReadAt(ctx context.Context, payloadID string, offset int64, dst []byte) (int, bool, error) {
+func (s *FSStore) ReadAt(ctx context.Context, payloadID string, offset int64, dst []byte) (int, journal.ReadState, error) {
 	if err := s.materializeLegacy(payloadID); err != nil {
-		return 0, false, err
+		return 0, journal.ReadState{}, err
 	}
 	return s.Store.ReadAt(ctx, journal.FileID(payloadID), offset, dst)
 }

--- a/pkg/block/local/fs/legacy_migrate_test.go
+++ b/pkg/block/local/fs/legacy_migrate_test.go
@@ -130,11 +130,11 @@ func TestLegacyLocalOnly_MigratesFaultsInAndFinishes(t *testing.T) {
 	// Fault-in: a read of p1 materializes just that payload and returns the real
 	// bytes (would be zeros before the fix).
 	got1 := make([]byte, len(want1))
-	n, cold, err := s.ReadAt(ctx, p1, 0, got1)
+	n, st, err := s.ReadAt(ctx, p1, 0, got1)
 	if err != nil {
 		t.Fatalf("ReadAt(p1): %v", err)
 	}
-	if cold {
+	if st.Cold {
 		t.Fatal("ReadAt(p1) reported cold on a local-only store")
 	}
 	if n < len(want1) || !bytes.Equal(got1, want1) {

--- a/pkg/block/local/local.go
+++ b/pkg/block/local/local.go
@@ -35,11 +35,11 @@ type LocalStore interface {
 	// durability is a separate Commit.
 	WriteAt(ctx context.Context, payloadID string, offset int64, data []byte) error
 
-	// ReadAt fills dst with the file's bytes at offset. Never-written ranges are
-	// POSIX holes and are zero-filled. Ranges written but evicted return
-	// cold=true (dst zero-filled as a placeholder) so the caller hydrates from
-	// the remote store and retries.
-	ReadAt(ctx context.Context, payloadID string, offset int64, dst []byte) (n int, cold bool, err error)
+	// ReadAt fills dst with the file's bytes at offset. Never-written ranges and
+	// evicted ranges are both zero-filled and reported through ReadState, so the
+	// caller can hydrate a cold range from the remote store and reconcile a hole
+	// against the CAS manifest before trusting the zeros.
+	ReadAt(ctx context.Context, payloadID string, offset int64, dst []byte) (n int, st journal.ReadState, err error)
 
 	// Hydrate writes bytes fetched from the remote store during a cold read.
 	// Same append primitive as WriteAt, but the record is born clean (already

--- a/pkg/block/local/memory/memory.go
+++ b/pkg/block/local/memory/memory.go
@@ -99,26 +99,28 @@ func (s *MemoryStore) Hydrate(_ context.Context, payloadID string, offset int64,
 }
 
 // ReadAt copies bytes into dst; never-written ranges are zero-filled holes.
-// Memory never evicts, so cold is always false.
-func (s *MemoryStore) ReadAt(_ context.Context, payloadID string, offset int64, dst []byte) (int, bool, error) {
+// Memory never evicts, so Cold is always false. The flat buffer cannot record
+// which bytes were written, so Hole is reported only for the part of the window
+// past the buffer's end — interior holes are indistinguishable from zeros here.
+func (s *MemoryStore) ReadAt(_ context.Context, payloadID string, offset int64, dst []byte) (int, journal.ReadState, error) {
 	if offset < 0 {
-		return 0, false, block.ErrInvalidOffset
+		return 0, journal.ReadState{}, block.ErrInvalidOffset
 	}
 	if len(dst) == 0 {
-		return 0, false, nil
+		return 0, journal.ReadState{}, nil
 	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.closed {
-		return 0, false, ErrStoreClosed
+		return 0, journal.ReadState{}, ErrStoreClosed
 	}
 	clear(dst)
 	f := s.files[payloadID]
 	if f == nil || offset >= int64(len(f.buf)) {
-		return len(dst), false, nil
+		return len(dst), journal.ReadState{Hole: true}, nil
 	}
-	copy(dst, f.buf[offset:])
-	return len(dst), false, nil
+	n := copy(dst, f.buf[offset:])
+	return len(dst), journal.ReadState{Hole: n < len(dst)}, nil
 }
 
 // Commit is a no-op: memory has no durable substrate.

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -3131,15 +3131,13 @@ func SeedColdFromManifest(ctx context.Context, bs *engine.Store, metaStore metad
 			}
 			off, ok := block.ParseChunkOffset(row.ID)
 			if !ok {
-				// Report rather than pass over in silence. Which range this row
-				// describes cannot be recovered — that is what makes it unplaceable
-				// — so the row is logged verbatim and seeding continues. The boot is
-				// not failed: one such row in a large store is not worth stranding
-				// every other share. Leaving the range unseeded is safe because the
-				// engine reconciles an uncovered read against the manifest whether or
-				// not the range is cold, so a read that finds nothing covering the
-				// offset it wants refuses with ErrManifestInconsistent rather than
-				// serving zeros.
+				// Which range this row describes cannot be recovered — that is what
+				// makes it unplaceable — so it is logged verbatim and seeding
+				// continues: one such row is not worth stranding every other share.
+				// Leaving the range unseeded is safe because the engine reconciles an
+				// uncovered read against the manifest whether or not the range is
+				// cold, so it refuses with ErrManifestInconsistent rather than serving
+				// zeros.
 				logger.Error("cold seed: unplaceable manifest row, range will not be seeded",
 					"payload", payloadID, "row", row.ID, "size", row.DataSize)
 				report.unplaceable++

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -3135,9 +3135,11 @@ func SeedColdFromManifest(ctx context.Context, bs *engine.Store, metaStore metad
 				// describes cannot be recovered — that is what makes it unplaceable
 				// — so the row is logged verbatim and seeding continues. The boot is
 				// not failed: one such row in a large store is not worth stranding
-				// every other share. A later read that finds nothing covering the
-				// offset it wants, on a payload holding a row like this, refuses with
-				// ErrManifestInconsistent rather than serving zeros.
+				// every other share. Leaving the range unseeded is safe because the
+				// engine reconciles an uncovered read against the manifest whether or
+				// not the range is cold, so a read that finds nothing covering the
+				// offset it wants refuses with ErrManifestInconsistent rather than
+				// serving zeros.
 				logger.Error("cold seed: unplaceable manifest row, range will not be seeded",
 					"payload", payloadID, "row", row.ID, "size", row.DataSize)
 				report.unplaceable++

--- a/pkg/metadata/store/badger/objects.go
+++ b/pkg/metadata/store/badger/objects.go
@@ -443,6 +443,42 @@ func loadFileChunkAtIndexOffset(txn *badger.Txn, payloadID string, off uint64) (
 	return &fc, nil
 }
 
+// scanChunkIndexOffsets walks the keys-only fb-file:{payloadID}: index and
+// returns the offset best keeps, plus the first key suffix that does not parse
+// as one. Such a suffix is a row ID's suffix verbatim, so the row sits at an
+// unknown offset and its caller must refuse rather than report a hole the reader
+// would zero-fill.
+func scanChunkIndexOffsets(txn *badger.Txn, payloadID string, keep func(cand, best uint64, have bool) bool) (bestOff uint64, found bool, unplaceable string) {
+	prefix := []byte(fileChunkFilePrefix + payloadID + ":")
+	opts := badger.DefaultIteratorOptions
+	opts.Prefix = prefix
+	opts.PrefetchValues = false // keys only — the offset lives in the key
+	it := txn.NewIterator(opts)
+	defer it.Close()
+
+	for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+		suffix := string(it.Item().Key()[len(prefix):])
+		cand, perr := strconv.ParseUint(suffix, 10, 64)
+		if perr != nil {
+			if unplaceable == "" {
+				unplaceable = suffix
+			}
+			continue
+		}
+		if keep(cand, bestOff, found) {
+			bestOff, found = cand, true
+		}
+	}
+	return bestOff, found, unplaceable
+}
+
+// errUnplaceableRow reports that off cannot be resolved because the manifest
+// holds a row whose range is unknown.
+func errUnplaceableRow(payloadID, suffix string, off uint64) error {
+	return fmt.Errorf("%w: cannot resolve offset %d for payload %q: manifest holds unplaceable row %q",
+		blockpkg.ErrManifestInconsistent, off, payloadID, payloadID+"/"+suffix)
+}
+
 // GetFileChunkAtOffset returns the FileChunk covering absolute byte offset off
 // for payloadID — the row with the largest chunkOffset <= off whose range
 // [chunkOffset, chunkOffset+DataSize) contains off — or (nil, nil) for a sparse
@@ -456,50 +492,25 @@ func loadFileChunkAtIndexOffset(txn *badger.Txn, payloadID string, off uint64) (
 // engine's ListFileChunks fallback picks the same one so both paths answer a
 // read alike.
 //
-// An index key whose suffix does not parse belongs to a row whose ID does not
-// parse — the index suffix is the ID's suffix verbatim — so the row sits at an
-// unknown offset. Skipping it would report a hole the caller zero-fills, which
-// invents data the file may never have had. It is reported instead, but only
-// when nothing else covers off: one bad row must not make a whole payload
-// unreadable. This mirrors findRowCoveringOffset, the walk used by the backends
-// with no such index.
+// An unplaceable row only matters when nothing else covers off: one bad row must
+// not make a whole payload unreadable. This mirrors findRowCoveringOffset, the
+// walk used by the backends with no such index.
 //
 // ponytail: O(n) keys-only scan per read; upgrade to a big-endian fb-off index
 // for a true O(log n) reverse-seek only if profiling at real N still shows it.
 func (s *BadgerMetadataStore) GetFileChunkAtOffset(_ context.Context, payloadID string, off uint64) (*metadata.FileChunk, error) {
 	var result *metadata.FileChunk
 	err := s.db.View(func(txn *badger.Txn) error {
-		prefix := []byte(fileChunkFilePrefix + payloadID + ":")
-		opts := badger.DefaultIteratorOptions
-		opts.Prefix = prefix
-		opts.PrefetchValues = false // keys only — the offset lives in the key
-		it := txn.NewIterator(opts)
-		defer it.Close()
-
-		var (
-			bestOff     uint64
-			found       bool
-			unplaceable string
-		)
-		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
-			suffix := it.Item().Key()[len(prefix):]
-			cand, perr := strconv.ParseUint(string(suffix), 10, 64)
-			if perr != nil {
-				if unplaceable == "" {
-					unplaceable = string(suffix)
-				}
-				continue
-			}
-			if cand <= off && (!found || cand > bestOff) {
-				bestOff, found = cand, true
-			}
-		}
+		bestOff, found, unplaceable := scanChunkIndexOffsets(txn, payloadID,
+			func(cand, best uint64, have bool) bool {
+				return cand <= off && (!have || cand > best)
+			})
+		// A hole, unless an unplaceable row leaves it in doubt.
 		uncovered := func() error {
 			if unplaceable == "" {
 				return nil
 			}
-			return fmt.Errorf("%w: nothing covers offset %d for payload %q and the manifest holds unplaceable row %q",
-				blockpkg.ErrManifestInconsistent, off, payloadID, payloadID+"/"+unplaceable)
+			return errUnplaceableRow(payloadID, unplaceable, off)
 		}
 		if !found {
 			return uncovered()
@@ -547,34 +558,12 @@ func (s *BadgerMetadataStore) GetFileChunkAtOffset(_ context.Context, payloadID 
 func (s *BadgerMetadataStore) GetFileChunkAtOrAfterOffset(_ context.Context, payloadID string, off uint64) (*metadata.FileChunk, error) {
 	var result *metadata.FileChunk
 	err := s.db.View(func(txn *badger.Txn) error {
-		prefix := []byte(fileChunkFilePrefix + payloadID + ":")
-		opts := badger.DefaultIteratorOptions
-		opts.Prefix = prefix
-		opts.PrefetchValues = false // keys only — the offset lives in the key
-		it := txn.NewIterator(opts)
-		defer it.Close()
-
-		var (
-			bestOff     uint64
-			found       bool
-			unplaceable string
-		)
-		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
-			suffix := it.Item().Key()[len(prefix):]
-			cand, perr := strconv.ParseUint(string(suffix), 10, 64)
-			if perr != nil {
-				if unplaceable == "" {
-					unplaceable = string(suffix)
-				}
-				continue
-			}
-			if cand >= off && (!found || cand < bestOff) {
-				bestOff, found = cand, true
-			}
-		}
+		bestOff, found, unplaceable := scanChunkIndexOffsets(txn, payloadID,
+			func(cand, best uint64, have bool) bool {
+				return cand >= off && (!have || cand < best)
+			})
 		if unplaceable != "" {
-			return fmt.Errorf("%w: nothing covers offset %d for payload %q and the manifest holds unplaceable row %q",
-				blockpkg.ErrManifestInconsistent, off, payloadID, payloadID+"/"+unplaceable)
+			return errUnplaceableRow(payloadID, unplaceable, off)
 		}
 		if !found {
 			return nil // nothing starts at or after off — past the last chunk

--- a/pkg/metadata/store/badger/objects.go
+++ b/pkg/metadata/store/badger/objects.go
@@ -456,6 +456,14 @@ func loadFileChunkAtIndexOffset(txn *badger.Txn, payloadID string, off uint64) (
 // engine's ListFileChunks fallback picks the same one so both paths answer a
 // read alike.
 //
+// An index key whose suffix does not parse belongs to a row whose ID does not
+// parse — the index suffix is the ID's suffix verbatim — so the row sits at an
+// unknown offset. Skipping it would report a hole the caller zero-fills, which
+// invents data the file may never have had. It is reported instead, but only
+// when nothing else covers off: one bad row must not make a whole payload
+// unreadable. This mirrors findRowCoveringOffset, the walk used by the backends
+// with no such index.
+//
 // ponytail: O(n) keys-only scan per read; upgrade to a big-endian fb-off index
 // for a true O(log n) reverse-seek only if profiling at real N still shows it.
 func (s *BadgerMetadataStore) GetFileChunkAtOffset(_ context.Context, payloadID string, off uint64) (*metadata.FileChunk, error) {
@@ -469,21 +477,32 @@ func (s *BadgerMetadataStore) GetFileChunkAtOffset(_ context.Context, payloadID 
 		defer it.Close()
 
 		var (
-			bestOff uint64
-			found   bool
+			bestOff     uint64
+			found       bool
+			unplaceable string
 		)
 		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
 			suffix := it.Item().Key()[len(prefix):]
 			cand, perr := strconv.ParseUint(string(suffix), 10, 64)
 			if perr != nil {
-				continue // tolerate a malformed index row, like parseBlockIdx
+				if unplaceable == "" {
+					unplaceable = string(suffix)
+				}
+				continue
 			}
 			if cand <= off && (!found || cand > bestOff) {
 				bestOff, found = cand, true
 			}
 		}
+		uncovered := func() error {
+			if unplaceable == "" {
+				return nil
+			}
+			return fmt.Errorf("%w: nothing covers offset %d for payload %q and the manifest holds unplaceable row %q",
+				blockpkg.ErrManifestInconsistent, off, payloadID, payloadID+"/"+unplaceable)
+		}
 		if !found {
-			return nil // nothing starts at or before off — hole
+			return uncovered()
 		}
 
 		fc, ferr := loadFileChunkAtIndexOffset(txn, payloadID, bestOff)
@@ -491,7 +510,7 @@ func (s *BadgerMetadataStore) GetFileChunkAtOffset(_ context.Context, payloadID 
 			return ferr
 		}
 		if fc == nil {
-			return nil // stale index entry — treat as a hole
+			return uncovered() // stale index entry — treat as a hole
 		}
 		// Covering guard keyed on the row's OWN start offset (the source of
 		// truth), not the index key, so an inconsistent index can't serve a
@@ -499,7 +518,7 @@ func (s *BadgerMetadataStore) GetFileChunkAtOffset(_ context.Context, payloadID 
 		// the scan guarantees abs <= off.
 		abs, ok := blockpkg.ParseChunkOffset(fc.ID)
 		if !ok || off < abs || off-abs >= uint64(fc.DataSize) {
-			return nil
+			return uncovered()
 		}
 		result = fc
 		return nil
@@ -518,6 +537,11 @@ func (s *BadgerMetadataStore) GetFileChunkAtOffset(_ context.Context, payloadID 
 // and stale-index-as-absent semantics as GetFileChunkAtOffset. No covering guard:
 // the successor is returned regardless of whether it contains off.
 //
+// An unplaceable row is fatal here whatever else the scan finds, unlike in
+// GetFileChunkAtOffset: sitting at an unknown offset, it may be the true
+// successor, and returning a later one would reclassify the bytes it holds as
+// hole for the caller to zero-fill.
+//
 // ponytail: O(n) keys-only scan per hole; shares the fb-off-index upgrade path
 // with GetFileChunkAtOffset if profiling at real N ever demands O(log n).
 func (s *BadgerMetadataStore) GetFileChunkAtOrAfterOffset(_ context.Context, payloadID string, off uint64) (*metadata.FileChunk, error) {
@@ -531,18 +555,26 @@ func (s *BadgerMetadataStore) GetFileChunkAtOrAfterOffset(_ context.Context, pay
 		defer it.Close()
 
 		var (
-			bestOff uint64
-			found   bool
+			bestOff     uint64
+			found       bool
+			unplaceable string
 		)
 		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
 			suffix := it.Item().Key()[len(prefix):]
 			cand, perr := strconv.ParseUint(string(suffix), 10, 64)
 			if perr != nil {
-				continue // tolerate a malformed index row, like parseBlockIdx
+				if unplaceable == "" {
+					unplaceable = string(suffix)
+				}
+				continue
 			}
 			if cand >= off && (!found || cand < bestOff) {
 				bestOff, found = cand, true
 			}
+		}
+		if unplaceable != "" {
+			return fmt.Errorf("%w: nothing covers offset %d for payload %q and the manifest holds unplaceable row %q",
+				blockpkg.ErrManifestInconsistent, off, payloadID, payloadID+"/"+unplaceable)
 		}
 		if !found {
 			return nil // nothing starts at or after off — past the last chunk

--- a/pkg/metadata/storetest/file_block_ops.go
+++ b/pkg/metadata/storetest/file_block_ops.go
@@ -73,6 +73,12 @@ func runFileChunkOpsTests(t *testing.T, factory StoreFactory) {
 		testGetFileChunkAtOrAfterOffset(t, factory)
 	})
 
+	// An unplaceable row must be reported by both indexed lookups rather than
+	// skipped, so the read path can refuse instead of zero-filling.
+	t.Run("IndexedLookups_UnplaceableRow", func(t *testing.T) {
+		testIndexedLookups_UnplaceableRow(t, factory)
+	})
+
 	// the syncer claim cycle stamps
 	// LastSyncAttemptAt = now when flipping a block to Syncing, and the
 	// restart-recovery janitor compares it against ClaimTimeout. Every
@@ -448,6 +454,55 @@ func testGetFileChunkAtOffset(t *testing.T, factory StoreFactory) {
 		t.Fatalf("GetFileChunkAtOffset(unknown): %v", err)
 	} else if got != nil {
 		t.Errorf("GetFileChunkAtOffset(unknown payload) = %q, want nil", got.ID)
+	}
+}
+
+// testIndexedLookups_UnplaceableRow pins what an indexed backend must do with a
+// row whose ID carries no parseable offset: its range is unknown, so reporting a
+// hole there would have the caller zero-fill bytes the file may hold.
+//
+// The covering lookup is scoped — one bad row must not make a whole payload
+// unreadable, so an offset another row covers still answers from that row and
+// only an uncovered offset refuses. The successor lookup is not scoped: an
+// unplaceable row sits at an unknown offset, so it may be the true successor and
+// returning a later one would widen the hole.
+func testIndexedLookups_UnplaceableRow(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+
+	covering, hasCovering := store.(chunkAtOffsetProbe)
+	successor, hasSuccessor := store.(chunkAtOrAfterProbe)
+	if !hasCovering && !hasSuccessor {
+		t.Skipf("backend %T implements neither indexed lookup", store)
+	}
+
+	const payloadID = "file-unplaceable"
+	rows := []*block.FileChunk{
+		{ID: payloadID + "/0", State: block.BlockStatePending, DataSize: 20, RefCount: 1, LastAccess: time.Now(), CreatedAt: time.Now()},
+		{ID: payloadID + "/not-an-offset", State: block.BlockStatePending, DataSize: 20, RefCount: 1, LastAccess: time.Now(), CreatedAt: time.Now()},
+	}
+	for _, b := range rows {
+		if err := store.Put(ctx, b); err != nil {
+			t.Fatalf("Put(%s): %v", b.ID, err)
+		}
+	}
+
+	if hasCovering {
+		got, err := covering.GetFileChunkAtOffset(ctx, payloadID, 0)
+		if err != nil {
+			t.Fatalf("GetFileChunkAtOffset(0) over a covered offset: %v", err)
+		}
+		if got == nil || got.ID != payloadID+"/0" {
+			t.Errorf("GetFileChunkAtOffset(0) = %v, want %s", got, payloadID+"/0")
+		}
+		if _, err := covering.GetFileChunkAtOffset(ctx, payloadID, 100); !errors.Is(err, block.ErrManifestInconsistent) {
+			t.Errorf("GetFileChunkAtOffset(100) = %v, want ErrManifestInconsistent", err)
+		}
+	}
+	if hasSuccessor {
+		if _, err := successor.GetFileChunkAtOrAfterOffset(ctx, payloadID, 0); !errors.Is(err, block.ErrManifestInconsistent) {
+			t.Errorf("GetFileChunkAtOrAfterOffset(0) = %v, want ErrManifestInconsistent", err)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #1888.

## The composition

#1881 added a guard so a manifest row whose ID carries no parseable offset ("unplaceable") makes an uncovered read refuse with `ErrManifestInconsistent` instead of being zero-filled. But `SeedColdFromManifest` skips exactly those rows, so they get no cold interval. A range with no interval is a plain hole, and `readAtInternal` returned at `if !cold` without ever consulting the manifest. The rows the guard was written for were the ones it could never see.

## Wider than the issue described

Two things turned up that the issue did not have:

**The engine fix alone is a no-op on badger, the default backend.** `GetFileChunkAtOffset` and `GetFileChunkAtOrAfterOffset` silently `continue` past a malformed index key, so the unplaceable row is invisible to both indexed lookups — verified with a throwaway probe: `resolveCovering` returns `(nil, nil)` and `resolveNextChunkStart` returns no successor. Shipping only the read-path change would have repeated #1881's mistake.

**`DataExtents` had the same blind spot, on an op the guard cannot reach.** It dropped an unplaceable row (`if !ok || off >= fileSize { continue }`), so SEEK_HOLE and READ_PLUS report the range as hole. Neither op calls READ for a hole segment, so a sparse-aware copier (`rsync --sparse`, `cp --sparse=always`) skips the range on SEEK alone and loses the bytes — the #1888 failure mode via a different door. Returning an error from `DataExtents` does not fix it: both callers (`seek.go:110`, `read_plus.go:162`) drop the error and fall back to the CAS block list, which is equally blind.

## The change

- `journal.Store.ReadAt` returns `ReadState{Cold, Hole}` instead of `cold bool`. The interval walk already classified each piece, so the bit is free. Returning a struct rather than a fourth value keeps every `_, _, err :=` call site compiling.
- `readAtInternal` reconciles a hole against the manifest, not just a cold range. A fully warm read still returns without touching the manifest, and a hole on a local-only share is skipped — there is no remote to hydrate from and nothing carves manifest rows there.
- Badger's two indexed lookups report `ErrManifestInconsistent` rather than skipping a malformed index key: the key's suffix is the row ID's suffix verbatim, so it is exactly the unplaceable row. Scoped for coverage (one bad row must not make a whole payload unreadable), unconditional for succession (an unplaceable row may be the true successor) — mirroring the `ListFileChunks` fallback.
- `DataExtents` widens its map to the whole file when it meets such a row. Over-reporting data is the RFC 7862-safe direction and forces the READ that refuses.
- Corrected the comment at `shares/service.go` that asserted the safety property the code did not have, and `dataextents.go`'s "same data view ReadAt reconstructs" claim.

## Verification

Each half is load-bearing, confirmed by reverting it:

- Without the engine change: `TestReadAt_UncoveredOffsetOnUnplaceableRowRefuses` returns `err=nil` with an all-zero buffer.
- Without the badger change: the same test's `OffsetIndexed` subtest fails while the fallback passes.
- Without the `DataExtents` change: `DataExtents = [[0 4096]]`, i.e. a hole SEEK lets a client skip.

`TestReadAt_CoveredOffsetIgnoresUnplaceableRow` also failed before the fix — that is the `DataExtents` ⊃ `ReadAt` asymmetry the issue flags as related, and the leading-zeros signature from #1879, so this closes it too.

Tests run both manifest-store shapes (`ListFileChunks` fallback and badger's offset index); the unplaceable-row contract is pinned in the `storetest` conformance suite so any future indexed backend inherits it. Full suite and `-race` green.

## Not done

Nothing establishes that the #1879 reporter's store actually holds an unplaceable row — that still needs the manifest dump. This closes the mechanism, not that diagnosis.
