### PR TITLE
fix(nfs): register with the system rpcbind without an adapter restart

### DIFF
--- a/pkg/adapter/nfs/adapter.go
+++ b/pkg/adapter/nfs/adapter.go
@@ -152,6 +152,15 @@ type NFSAdapter struct {
 	// Stop() may race Serve() (Stop is documented safe to call concurrently).
 	sysregActive atomic.Bool
 
+	// sysregReconciling guards the background registration reconcile so a burst
+	// of settings applies (one per accepted connection) collapses into a single
+	// in-flight transition instead of a goroutine per call.
+	sysregReconciling atomic.Bool
+
+	// sysregAddr overrides the system rpcbind dial address. Empty means the
+	// well-known one; a test sets it to keep the host's rpcbind untouched.
+	sysregAddr string
+
 	// udpConn is the UDP listener serving NLM/NSM/MOUNT when the UDP transport
 	// is enabled (adapters.nfs.udp.enabled). nil when UDP is disabled.
 	udpConn *net.UDPConn

--- a/pkg/adapter/nfs/auxservices.go
+++ b/pkg/adapter/nfs/auxservices.go
@@ -33,13 +33,8 @@ func (s *NFSAdapter) startEnabledAuxServices(ctx context.Context) {
 		logger.Info("Portmapper disabled by configuration")
 	}
 
-	// System rpcbind registration (port 111). Best-effort and time-bounded;
-	// sysregSidecar.Start never returns an error, so the branch is defensive.
-	if s.registerWithSystemEnabled() {
-		if err := s.sidecars.Start(sysregSidecar{s}); err != nil {
-			logger.Debug("System rpcbind registration sidecar failed to start", "error", err)
-		}
-	}
+	// System rpcbind registration (port 111). Best-effort and time-bounded.
+	s.reconcileSysreg()
 
 	// UDP transport for NLM/NSM/MOUNT (issue #1353). Non-fatal: TCP continues.
 	if s.isUDPEnabled() {
@@ -125,11 +120,36 @@ func (p portmapSidecar) Name() string                    { return "portmapper" }
 func (p portmapSidecar) Start(ctx context.Context) error { return p.a.startPortmapper(ctx) }
 func (p portmapSidecar) Stop(context.Context) error      { p.a.stopPortmapper(); return nil }
 
+// reconcileSysreg starts or stops the host-rpcbind registration to match the
+// live setting, so toggling it takes effect without restarting the adapter.
+// Called from Serve (initial start) and from applyNFSSettings (live toggle);
+// Group.Reconcile is a no-op until Serve has seeded the group.
+//
+// The transition itself talks to rpcbind and is bounded by systemRegTimeout, so
+// it runs in the background: the callers are the accept loop and the
+// settings-watcher goroutine, and an unreachable rpcbind must not stall either.
+// Reconcile tolerates a start racing shutdown, and the state check keeps the
+// steady-state call (every accepted connection) allocation-free.
+func (s *NFSAdapter) reconcileSysreg() {
+	if s.sidecars.IsRunning(sysregSidecarName) == s.registerWithSystemEnabled() {
+		return
+	}
+	go func() {
+		err := s.sidecars.Reconcile(sysregSidecarName, s.registerWithSystemEnabled(),
+			func() auxsvc.Service { return sysregSidecar{s} })
+		if err != nil {
+			logger.Debug("System rpcbind registration sidecar failed to start", "error", err)
+		}
+	}()
+}
+
+const sysregSidecarName = "sysreg"
+
 // sysregSidecar wraps registration of DittoFS's services with the host rpcbind.
 // Start registers; Stop unregisters. Both are best-effort and self-gating.
 type sysregSidecar struct{ a *NFSAdapter }
 
-func (r sysregSidecar) Name() string { return "sysreg" }
+func (r sysregSidecar) Name() string { return sysregSidecarName }
 func (r sysregSidecar) Start(ctx context.Context) error {
 	r.a.startSystemPortmapRegistration(ctx)
 	return nil

--- a/pkg/adapter/nfs/auxservices.go
+++ b/pkg/adapter/nfs/auxservices.go
@@ -131,11 +131,21 @@ func (p portmapSidecar) Stop(context.Context) error      { p.a.stopPortmapper();
 // Reconcile tolerates a start racing shutdown, and the state check keeps the
 // steady-state call (every accepted connection) allocation-free.
 func (s *NFSAdapter) reconcileSysreg() {
-	if s.sidecars.IsRunning(sysregSidecarName) == s.registerWithSystemEnabled() {
+	// Read the setting once, on the caller's goroutine: applyNFSSettings writes
+	// it, so the background transition must not read it again.
+	want := s.registerWithSystemEnabled()
+	if s.sidecars.IsRunning(sysregSidecarName) == want {
+		return
+	}
+	// One transition at a time: the callers fire per accepted connection, and
+	// the running state only flips once the transition finishes. A flip that
+	// arrives mid-transition is picked up by the next apply.
+	if !s.sysregReconciling.CompareAndSwap(false, true) {
 		return
 	}
 	go func() {
-		err := s.sidecars.Reconcile(sysregSidecarName, s.registerWithSystemEnabled(),
+		defer s.sysregReconciling.Store(false)
+		err := s.sidecars.Reconcile(sysregSidecarName, want,
 			func() auxsvc.Service { return sysregSidecar{s} })
 		if err != nil {
 			logger.Debug("System rpcbind registration sidecar failed to start", "error", err)

--- a/pkg/adapter/nfs/portmap.go
+++ b/pkg/adapter/nfs/portmap.go
@@ -98,9 +98,13 @@ func (s *NFSAdapter) registerWithSystemEnabled() bool {
 	return *s.config.Portmapper.RegisterWithSystem
 }
 
-// systemPortmapAddr is the dial address of the host's system rpcbind. A var so
-// a test can point the registration at a dead address instead of the host's.
-var systemPortmapAddr = fmt.Sprintf("127.0.0.1:%d", sysreg.SystemPortmapPort)
+// systemPortmapAddr is the dial address of the host's system rpcbind.
+func (s *NFSAdapter) systemPortmapAddr() string {
+	if s.sysregAddr != "" {
+		return s.sysregAddr
+	}
+	return fmt.Sprintf("127.0.0.1:%d", sysreg.SystemPortmapPort)
+}
 
 // startSystemPortmapRegistration registers DittoFS's services with the host's
 // system rpcbind (port 111) when adapters.nfs.portmapper.register_with_system is
@@ -138,7 +142,7 @@ func (s *NFSAdapter) startSystemPortmapRegistration(ctx context.Context) {
 	ctx, cancel := context.WithTimeout(ctx, systemRegTimeout)
 	defer cancel()
 
-	addr := systemPortmapAddr
+	addr := s.systemPortmapAddr()
 	if err := sysreg.Ping(ctx, addr); err != nil {
 		logger.Warn("No system portmapper reachable; NFSv3 locking needs `nolock`",
 			"addr", addr, "error", err)
@@ -176,7 +180,7 @@ func (s *NFSAdapter) stopSystemPortmapRegistration() {
 	defer cancel()
 
 	mappings := s.systemRegMappings()
-	if err := sysreg.Unregister(ctx, systemPortmapAddr, mappings); err != nil {
+	if err := sysreg.Unregister(ctx, s.systemPortmapAddr(), mappings); err != nil {
 		logger.Warn("Failed to unregister services from system portmapper", "error", err)
 		return
 	}

--- a/pkg/adapter/nfs/portmap.go
+++ b/pkg/adapter/nfs/portmap.go
@@ -98,10 +98,9 @@ func (s *NFSAdapter) registerWithSystemEnabled() bool {
 	return *s.config.Portmapper.RegisterWithSystem
 }
 
-// systemPortmapAddr is the dial address of the host's system rpcbind.
-func systemPortmapAddr() string {
-	return fmt.Sprintf("127.0.0.1:%d", sysreg.SystemPortmapPort)
-}
+// systemPortmapAddr is the dial address of the host's system rpcbind. A var so
+// a test can point the registration at a dead address instead of the host's.
+var systemPortmapAddr = fmt.Sprintf("127.0.0.1:%d", sysreg.SystemPortmapPort)
 
 // startSystemPortmapRegistration registers DittoFS's services with the host's
 // system rpcbind (port 111) when adapters.nfs.portmapper.register_with_system is
@@ -139,7 +138,7 @@ func (s *NFSAdapter) startSystemPortmapRegistration(ctx context.Context) {
 	ctx, cancel := context.WithTimeout(ctx, systemRegTimeout)
 	defer cancel()
 
-	addr := systemPortmapAddr()
+	addr := systemPortmapAddr
 	if err := sysreg.Ping(ctx, addr); err != nil {
 		logger.Warn("No system portmapper reachable; NFSv3 locking needs `nolock`",
 			"addr", addr, "error", err)
@@ -177,7 +176,7 @@ func (s *NFSAdapter) stopSystemPortmapRegistration() {
 	defer cancel()
 
 	mappings := s.systemRegMappings()
-	if err := sysreg.Unregister(ctx, systemPortmapAddr(), mappings); err != nil {
+	if err := sysreg.Unregister(ctx, systemPortmapAddr, mappings); err != nil {
 		logger.Warn("Failed to unregister services from system portmapper", "error", err)
 		return
 	}

--- a/pkg/adapter/nfs/settings.go
+++ b/pkg/adapter/nfs/settings.go
@@ -97,9 +97,10 @@ func (s *NFSAdapter) applyNFSSettings(rt *runtime.Runtime) {
 	s.config.UDP.Enabled = &udpEnabled
 	logger.Debug("NFS adapter: applied UDP transport setting from DB", "enabled", settings.UDPEnabled)
 
-	// mDNS advertiser: unlike portmapper/UDP (which take effect on the next
-	// restart), the mDNS sidecar is toggled live here — start or stop it to
-	// match the setting. No-op until Serve has started the auxsvc group.
+	// The host-rpcbind registration and the mDNS advertiser are toggled live to
+	// match the settings; the embedded portmapper and the UDP listener still
+	// take effect on the next restart.
+	s.reconcileSysreg()
 	s.reconcileDiscovery()
 }
 

--- a/pkg/adapter/nfs/sysreg_reconcile_test.go
+++ b/pkg/adapter/nfs/sysreg_reconcile_test.go
@@ -1,0 +1,46 @@
+package nfs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/adapter/auxsvc"
+)
+
+// Toggling the register-with-system setting must start and stop the sysreg
+// sidecar on a running adapter, without a restart.
+func TestReconcileSysregTogglesSidecar(t *testing.T) {
+	prev := systemPortmapAddr
+	// Dead address: registration finds no portmapper and gives up immediately.
+	systemPortmapAddr = "127.0.0.1:1"
+	t.Cleanup(func() { systemPortmapAddr = prev })
+
+	a := &NFSAdapter{sidecars: auxsvc.NewGroup()}
+	a.sidecars.SetBaseContext(context.Background())
+
+	a.reconcileSysreg()
+	waitSysreg(t, a, false, "sysreg sidecar running while register-with-system is unset")
+
+	enabled := true
+	a.config.Portmapper.RegisterWithSystem = &enabled
+	a.reconcileSysreg()
+	waitSysreg(t, a, true, "sysreg sidecar not started after enabling register-with-system")
+
+	enabled = false
+	a.reconcileSysreg()
+	waitSysreg(t, a, false, "sysreg sidecar still running after disabling register-with-system")
+}
+
+// waitSysreg waits for the sysreg sidecar to reach want; the reconcile applies
+// the transition in the background.
+func waitSysreg(t *testing.T, a *NFSAdapter, want bool, msg string) {
+	t.Helper()
+	for deadline := time.Now().Add(5 * time.Second); time.Now().Before(deadline); {
+		if a.sidecars.IsRunning(sysregSidecarName) == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal(msg)
+}

--- a/pkg/adapter/nfs/sysreg_reconcile_test.go
+++ b/pkg/adapter/nfs/sysreg_reconcile_test.go
@@ -11,12 +11,8 @@ import (
 // Toggling the register-with-system setting must start and stop the sysreg
 // sidecar on a running adapter, without a restart.
 func TestReconcileSysregTogglesSidecar(t *testing.T) {
-	prev := systemPortmapAddr
 	// Dead address: registration finds no portmapper and gives up immediately.
-	systemPortmapAddr = "127.0.0.1:1"
-	t.Cleanup(func() { systemPortmapAddr = prev })
-
-	a := &NFSAdapter{sidecars: auxsvc.NewGroup()}
+	a := &NFSAdapter{sidecars: auxsvc.NewGroup(), sysregAddr: "127.0.0.1:1"}
 	a.sidecars.SetBaseContext(context.Background())
 
 	a.reconcileSysreg()

--- a/test/e2e/blocks_flip_test.go
+++ b/test/e2e/blocks_flip_test.go
@@ -214,11 +214,16 @@ func runBlocksFlipSuite(t *testing.T, cli *helpers.CLIRunner, lsHelper *framewor
 	require.Empty(t, helpers.ListCASKeys(t, lsHelper, bucket),
 		"[%s] GC must not introduce cas/ objects", io.proto)
 
+	// local_disk_used is the physical journal footprint, so the unlink's
+	// tombstone record and its segment header survive GC. What must be gone is
+	// the payload: anything under the framing allowance holds no file data.
+	const framingAllowance int64 = 64 << 10
 	statsAfterGC := helpers.GetBlockStats(t, cli, shareName)
-	require.Zero(t, statsAfterGC.Totals.LocalDiskUsed,
-		"[%s] GC must free the local block too (local disk used should be 0, got %d)",
+	require.LessOrEqual(t, statsAfterGC.Totals.LocalDiskUsed, framingAllowance,
+		"[%s] GC must free the local block too (local disk used should be framing only, got %d of %d written)",
+		io.proto, statsAfterGC.Totals.LocalDiskUsed, payloadSize)
+	t.Logf("[%s] step 3: GC freed the block on both tiers (remote blocks/ empty, local disk %d bytes of framing)",
 		io.proto, statsAfterGC.Totals.LocalDiskUsed)
-	t.Logf("[%s] step 3: GC freed the block on both tiers (remote blocks/ empty, local disk 0)", io.proto)
 
 	// ---- Step 4: corruption — tamper a remote block → read fails closed ----
 	exerciseBlocksCorruption(t, cli, lsHelper, bucket, shareName, io)

--- a/test/e2e/testdata/nlm/nlm_axis_interop.sh
+++ b/test/e2e/testdata/nlm/nlm_axis_interop.sh
@@ -102,11 +102,11 @@ dctl adapter enable smb --port $SMBP || { log "smb enable FAIL"; exit 1; }
 # register-with-system setting up from the settings poll, so wait rather than
 # sampling once.
 for _ in $(seq 1 60); do
-  $NS rpcinfo -p $SIP 2>/dev/null | grep -q 100021 && break
+  $NS rpcinfo -p $SIP 2>/dev/null | grep -qE "^ *100021 " && break
   sleep 0.5
 done
-if $NS rpcinfo -p $SIP 2>/dev/null | grep -q 100021; then
-  log "NLM registered:"; $NS rpcinfo -p $SIP 2>/dev/null | grep 100021 | sed 's/^/[nlm]   /'
+if $NS rpcinfo -p $SIP 2>/dev/null | grep -qE "^ *100021 "; then
+  log "NLM registered:"; $NS rpcinfo -p $SIP 2>/dev/null | grep -E "^ *100021 " | sed 's/^/[nlm]   /'
 else
   log "NLM NOT registered in sns rpcbind"; $NS rpcinfo -p $SIP 2>/dev/null | sed 's/^/[nlm]   /'; exit 1
 fi

--- a/test/e2e/testdata/nlm/nlm_axis_interop.sh
+++ b/test/e2e/testdata/nlm/nlm_axis_interop.sh
@@ -98,9 +98,13 @@ dctl share nfs-config set /export --squash root_to_admin 2>/dev/null || dctl sha
 dctl adapter settings nfs update --portmapper-register-with-system --udp-enabled || { log "nfs settings FAIL"; exit 1; }
 dctl adapter enable nfs --port $NFSP || { log "nfs enable FAIL"; exit 1; }
 dctl adapter enable smb --port $SMBP || { log "smb enable FAIL"; exit 1; }
-sleep 1
-
-# NLM (100021) must be registered in sns's rpcbind
+# NLM (100021) must be registered in sns's rpcbind. The adapter picks the
+# register-with-system setting up from the settings poll, so wait rather than
+# sampling once.
+for _ in $(seq 1 60); do
+  $NS rpcinfo -p $SIP 2>/dev/null | grep -q 100021 && break
+  sleep 0.5
+done
 if $NS rpcinfo -p $SIP 2>/dev/null | grep -q 100021; then
   log "NLM registered:"; $NS rpcinfo -p $SIP 2>/dev/null | grep 100021 | sed 's/^/[nlm]   /'
 else


### PR DESCRIPTION
Addresses the two failures in #1936. Both root causes were confirmed on a
Linux VM with the real netns harness, not from reading code.

## 1. NLM never registers with rpcbind — real product bug

`register_with_system` was only consumed when the NFS adapter (re)started.
#1810 stopped restarting an adapter whose bind address and enabled state are
unchanged, so the E2E driver's `adapter settings nfs update
--portmapper-register-with-system` followed by `adapter enable nfs --port 12049`
(the default port, on an already-enabled adapter) became a no-op reload: the
sysreg sidecar never ran and nothing — NFS, MOUNT or NLM — was registered.

Bisected on hardware: the case passes at `9ed1a163` and fails from `ca4761fc`
(#1810) onward, which matches the first red E2E run on 2026-07-21.

`applyNFSSettings` now reconciles the `sysreg` sidecar live, the way it already
does for the mDNS advertiser, so the setting takes effect on a running adapter
whoever toggles it. The transition talks to rpcbind and is bounded by
`systemRegTimeout`, so it runs in the background: the callers are the accept
loop and the settings-watcher goroutine, and neither may block on it.

Verified on a fresh Ubuntu 24.04 VM:

- before (origin/develop): `[nlm] NLM NOT registered in sns rpcbind` — the exact CI failure
- after: `100021 1/3/4 tcp+udp 12049 nlockmgr`, and all four interop cases run

The driver now polls for program 100021 instead of sampling once a second after
enable, since the setting arrives via the settings-watcher poll rather than an
adapter restart.

## 2. blocks-flip GC assertion — test bug

#1890 deliberately changed `local_disk_used` from payload accounting to the
journal's physical segment footprint. The unlink's tombstone record and its
segment header are real bytes that survive GC by design; that PR already relaxed
the equivalent unit assertion in `coldread_delete_reclaim_test.go` to a 64 KiB
framing allowance and could not update the E2E, which does not run on PRs. The
observed residue is 1024 (NFS) / 937 (SMB) bytes against a 16 MiB payload, so no
file data is retained. The assertion now matches the unit test's.

## Still red, tracked separately

With registration fixed, `TestNLMAxisInterop` gets past the rpcbind gate and
fails later, on the lock cases themselves. That is a distinct problem this PR
does not claim to fix, and the hardware runs show the test's expectations are
order-dependent — the same commit reports `BLOCKED` or `ACQUIRED` for the same
case depending on whether the NFSv4 client has taken any earlier lock. Filed
separately with the evidence.
