### PR TITLE
fix(block): make the covering-row check overflow-safe

### DIFF
--- a/pkg/block/engine/read_internal.go
+++ b/pkg/block/engine/read_internal.go
@@ -131,7 +131,7 @@ type rowWithOffset struct {
 // take a file that reads correctly apart from one damaged range and make all of
 // it unavailable.
 //
-// When two rows cover target the greatest start wins, which is what the indexed
+// When two rows cover target, the greatest start wins, which is what the indexed
 // badger lookup returns. Returning whichever row the walk reached first made the
 // answer depend on ListFileChunks ordering, so the same read could serve
 // different bytes on different backends. Overlap is not hypothetical: a truncate
@@ -153,7 +153,9 @@ func findRowCoveringOffset(rows []*block.FileChunk, target uint64) (*rowWithOffs
 			}
 			continue
 		}
-		if target >= abs && target < abs+uint64(fb.DataSize) {
+		// target-abs is overflow-free because target >= abs is checked first;
+		// abs+DataSize would wrap on an absurd offset.
+		if target >= abs && target-abs < uint64(fb.DataSize) {
 			if hit == nil || abs > hit.absOffset {
 				hit = &rowWithOffset{fb: fb, absOffset: abs}
 			}

--- a/pkg/metadata/store/badger/objects.go
+++ b/pkg/metadata/store/badger/objects.go
@@ -452,8 +452,9 @@ func loadFileChunkAtIndexOffset(txn *badger.Txn, payloadID string, off uint64) (
 // unmarshal, no sort), then two point Gets fetch the winning row.
 //
 // Largest-start only decides anything if rows overlap, which a truncate followed
-// by a re-carving write can produce. It resolves to the newer row, and the
-// engine's ListFileChunks fallback picks the same one so both paths answer a
+// by a re-carving write can produce: the narrowed survivor starts before the row
+// the later carve emits, so the greater start is the newer row there. The
+// engine's ListFileChunks fallback picks the same row, so both paths answer a
 // read alike.
 //
 // ponytail: O(n) keys-only scan per read; upgrade to a big-endian fb-off index


### PR DESCRIPTION
Follow-up to #1953, which merged before these two review points were applied.

Copilot raised both as suppressed comments on the final state of that PR:

- **Overflow in the coverage check.** `target < abs+uint64(fb.DataSize)` wraps if a row ID carries an absurd offset. Pre-existing, but it is the predicate #1953 changed, and badger's `GetFileChunkAtOffset` already uses the safe `off-abs` form. Now `target-abs < uint64(fb.DataSize)`, which is exact because the `target >= abs` check precedes it.
- **Missing comma** in the comment #1953 added.

Also states *why* greatest-start is the newer row in the badger doc comment, rather than asserting it — the index carries no version information, so the claim only holds via the mechanism that produces the overlap (a truncate narrows a straddling row, and the later carve emits a row starting after it).

No behaviour change: the two predicates are equivalent for every non-wrapping offset, which is every offset a carve produces.