### PR TITLE
fix(metadata): close small MED audit findings in the memory and badger stores

### DIFF
--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -37,13 +37,15 @@ import (
 // The store is safe for concurrent use from multiple goroutines, but it holds
 // no store-wide mutex. The metadata data path is serialized by BadgerDB's own
 // MVCC transactions: conflicting writers fail to commit and are retried by
-// withTransaction. Only the in-memory side state carries explicit locks, each
-// scoped to the subsystem it guards (capabilities, the lazily built lock /
-// client / durable / recovery sub-stores, quotas, and the stats cache).
+// withTransaction. In-memory side state is guarded per subsystem rather than
+// globally: a mutex each for capabilities, the lazily built lock / client /
+// durable / recovery sub-stores, quotas, and the stats cache, while the read /
+// parent / dirent / share caches are lock-free (sync.Map plus generation
+// counters).
 //
 // Storage Model:
 // The store uses a key-value model with namespaced prefixes to organize different
-// data types (see keys.go for detailed schema documentation). This approach provides:
+// data types (see encoding.go for detailed schema documentation). This approach provides:
 //   - No schema conflicts between data types
 //   - Efficient point lookups (O(1))
 //   - Fast range scans for directory listings and sessions
@@ -52,8 +54,9 @@ import (
 // File Handle Strategy:
 // GenerateHandle ignores the path it is given and mints a fresh random UUID
 // handle scoped to the share, so a handle is independent of the name a file is
-// reachable under and survives renames. See encoding.go for the handle layout
-// and the key namespace it indexes.
+// reachable under and survives renames. The handle layout is owned by
+// metadata.EncodeShareHandle; the UUID it carries is what every key namespace
+// in encoding.go is indexed by.
 type BadgerMetadataStore struct {
 	// db is the BadgerDB database handle (thread-safe, uses internal MVCC)
 	db *badger.DB

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -29,16 +29,17 @@ import (
 //
 // Key Features:
 //   - Persistent storage with crash recovery (WAL-based)
-//   - Path-based file handles for import/export capability
+//   - UUID file handles, stable across renames and restarts
 //   - ACID transactions for complex operations
 //   - Efficient range scans for directory listings
-//   - Concurrent access with proper locking
 //
 // Thread Safety:
-// All operations are protected by a single read-write mutex (mu), making the
-// store safe for concurrent access from multiple goroutines. This coarse-grained
-// locking is simple and correct, though fine-grained locking could improve
-// concurrency for high-throughput scenarios.
+// The store is safe for concurrent use from multiple goroutines, but it holds
+// no store-wide mutex. The metadata data path is serialized by BadgerDB's own
+// MVCC transactions: conflicting writers fail to commit and are retried by
+// withTransaction. Only the in-memory side state carries explicit locks, each
+// scoped to the subsystem it guards (capabilities, the lazily built lock /
+// client / durable / recovery sub-stores, quotas, and the stats cache).
 //
 // Storage Model:
 // The store uses a key-value model with namespaced prefixes to organize different
@@ -49,15 +50,10 @@ import (
 //   - Self-documenting database structure
 //
 // File Handle Strategy:
-// File handles are generated from filesystem paths, providing deterministic and
-// reversible handle generation. This enables:
-//   - Importing existing filesystems into DittoFS
-//   - Reconstructing metadata from content stores
-//   - Debugging with human-readable handles
-//   - Stable handles across server restarts
-//
-// For paths exceeding NFS limits (64 bytes), handles are automatically converted
-// to hash-based format with reverse mapping stored in the database.
+// GenerateHandle ignores the path it is given and mints a fresh random UUID
+// handle scoped to the share, so a handle is independent of the name a file is
+// reachable under and survives renames. See encoding.go for the handle layout
+// and the key namespace it indexes.
 type BadgerMetadataStore struct {
 	// db is the BadgerDB database handle (thread-safe, uses internal MVCC)
 	db *badger.DB

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -55,8 +55,8 @@ import (
 // GenerateHandle ignores the path it is given and mints a fresh random UUID
 // handle scoped to the share, so a handle is independent of the name a file is
 // reachable under and survives renames. The handle layout is owned by
-// metadata.EncodeShareHandle; the UUID it carries is what every key namespace
-// in encoding.go is indexed by.
+// metadata.EncodeShareHandle; the UUID it carries is what the per-file key
+// namespaces in encoding.go are indexed by.
 type BadgerMetadataStore struct {
 	// db is the BadgerDB database handle (thread-safe, uses internal MVCC)
 	db *badger.DB

--- a/pkg/metadata/store/memory/reset.go
+++ b/pkg/metadata/store/memory/reset.go
@@ -30,8 +30,6 @@ func (s *MemoryMetadataStore) Reset(ctx context.Context) error {
 	s.parents = make(map[string]metadata.FileHandle)
 	s.children = make(map[string]map[string]metadata.FileHandle)
 	s.linkCounts = make(map[string]uint32)
-	s.deviceNumbers = make(map[string]*deviceNumber)
-	s.pendingWrites = make(map[string]*metadata.WriteOperation)
 	s.sessions = make(map[string]*ShareSession)
 	s.objectIndex = make(map[block.ContentHash]string)
 	s.blockRecords = make(map[string]*block.BlockRecord)

--- a/pkg/metadata/store/memory/snapshot_store.go
+++ b/pkg/metadata/store/memory/snapshot_store.go
@@ -39,17 +39,15 @@ const (
 // caches (sessions) and config limits
 // (maxStorageBytes, maxFiles) are excluded.
 type memoryBackupSnapshot struct {
-	Shares        map[string]*shareData
-	Files         map[string]*fileData
-	Parents       map[string]metadata.FileHandle
-	Children      map[string]map[string]metadata.FileHandle
-	LinkCounts    map[string]uint32
-	DeviceNumbers map[string]*deviceNumber
-	PendingWrites map[string]*metadata.WriteOperation
-	ServerConfig  metadata.MetadataServerConfig
-	Capabilities  metadata.FilesystemCapabilities
-	StoreID       string
-	Synced        map[block.ContentHash]time.Time
+	Shares       map[string]*shareData
+	Files        map[string]*fileData
+	Parents      map[string]metadata.FileHandle
+	Children     map[string]map[string]metadata.FileHandle
+	LinkCounts   map[string]uint32
+	ServerConfig metadata.MetadataServerConfig
+	Capabilities metadata.FilesystemCapabilities
+	StoreID      string
+	Synced       map[block.ContentHash]time.Time
 	// SyncedLocators preserves the remote block locator for synced hashes packed
 	// into a block (#1414). Without it a restore keeps the synced SET but drops
 	// each hash's BlockID, so a block-resident hash resolves as standalone and its
@@ -122,17 +120,15 @@ func (s *MemoryMetadataStore) WriteSnapshot(ctx context.Context, w io.Writer) (*
 	// held in the snapshot, so we keep the lock through encoding
 	// to ensure snapshot isolation (ConcurrentWriter conformance).
 	snap := memoryBackupSnapshot{
-		Shares:        s.shares,
-		Files:         s.files,
-		Parents:       s.parents,
-		Children:      s.children,
-		LinkCounts:    s.linkCounts,
-		DeviceNumbers: s.deviceNumbers,
-		PendingWrites: s.pendingWrites,
-		Capabilities:  s.capabilities,
-		StoreID:       s.storeID,
-		ObjectIndex:   s.objectIndex,
-		BlockRecords:  s.blockRecords,
+		Shares:       s.shares,
+		Files:        s.files,
+		Parents:      s.parents,
+		Children:     s.children,
+		LinkCounts:   s.linkCounts,
+		Capabilities: s.capabilities,
+		StoreID:      s.storeID,
+		ObjectIndex:  s.objectIndex,
+		BlockRecords: s.blockRecords,
 	}
 
 	// Acquire syncedMu to read synced safely — governed by its own mutex, not
@@ -341,8 +337,6 @@ func (s *MemoryMetadataStore) RestoreSnapshot(ctx context.Context, r io.Reader) 
 	s.parents = snap.Parents
 	s.children = snap.Children
 	s.linkCounts = snap.LinkCounts
-	s.deviceNumbers = snap.DeviceNumbers
-	s.pendingWrites = snap.PendingWrites
 	s.serverConfig = snap.ServerConfig
 	s.capabilities = snap.Capabilities
 	s.storeID = snap.StoreID
@@ -370,12 +364,6 @@ func (s *MemoryMetadataStore) RestoreSnapshot(ctx context.Context, r io.Reader) 
 	}
 	if s.linkCounts == nil {
 		s.linkCounts = make(map[string]uint32)
-	}
-	if s.deviceNumbers == nil {
-		s.deviceNumbers = make(map[string]*deviceNumber)
-	}
-	if s.pendingWrites == nil {
-		s.pendingWrites = make(map[string]*metadata.WriteOperation)
 	}
 	if s.objectIndex == nil {
 		s.objectIndex = make(map[block.ContentHash]string)

--- a/pkg/metadata/store/memory/store.go
+++ b/pkg/metadata/store/memory/store.go
@@ -69,10 +69,11 @@ type ShareSession struct {
 //   - Systems where persistence is handled by external mechanisms
 //
 // Thread Safety:
-// All operations are protected by a single read-write mutex (mu), making the
-// store safe for concurrent access from multiple goroutines. This coarse-grained
-// locking is simple and correct, though fine-grained locking could improve
-// concurrency for high-throughput scenarios.
+// The store is safe for concurrent use from multiple goroutines. A store-wide
+// read-write mutex (mu) covers the metadata maps below, taken for read on
+// queries and for write on mutations. Two subsystems are deliberately kept off
+// it so they do not contend with unrelated metadata operations: per-identity
+// quota usage (quotaMu) and the SyncedHashStore sync markers (syncedMu).
 //
 // Storage Model:
 //
@@ -115,8 +116,6 @@ type ShareSession struct {
 //   - Every file in 'files' has an entry in 'linkCounts' (≥ 1 for regular files)
 //   - Every file in 'files' has an entry in 'parents' (except root directories)
 //   - Every entry in 'children' corresponds to a valid file in 'files'
-//   - Every symlink in 'files' has an entry in 'symlinkTargets'
-//   - Every regular file in 'files' has an entry in 'payloadIDs'
 //   - Parent-child relationships are bidirectional (if A is parent of B, then B is in A's children)
 //
 // These invariants are maintained by all operations and can be verified by

--- a/pkg/metadata/store/memory/store.go
+++ b/pkg/metadata/store/memory/store.go
@@ -104,19 +104,10 @@ type ShareSession struct {
 //
 // Handle Generation:
 //
-// File handles are generated using path-based identifiers in the format:
-// "shareName:fullPath" (e.g., "/export:/images/photo.jpg").
-//
-// This approach ensures:
-//   - Determinism: Same path always generates the same handle
-//   - Reversibility: Path can be extracted from handle for import/export
-//   - Stability: Handles remain stable across server restarts
-//   - Human-readable: Easy to debug and inspect
-//   - Import-ready: Enables future filesystem import features
-//
-// The path-based approach matches the BadgerDB metadata store implementation,
-// ensuring consistent behavior across all metadata store backends. This
-// consistency is critical for implementing metadata import/export features.
+// generateFileHandle ignores the path it is given and encodes a fresh UUID
+// against the share name via metadata.EncodeShareHandle, so a handle is
+// independent of the name a file is reachable under and survives renames.
+// The badger backend mints handles the same way.
 //
 // Consistency Guarantees:
 //

--- a/pkg/metadata/store/memory/store.go
+++ b/pkg/metadata/store/memory/store.go
@@ -45,12 +45,6 @@ type fileData struct {
 	ShareName string
 }
 
-// deviceNumber stores major and minor device numbers for special files.
-type deviceNumber struct {
-	Major uint32
-	Minor uint32
-}
-
 // ShareSession represents an active client session on a share. Sessions are
 // informational only (monitoring and DUMP) and do not affect access control;
 // the memory store is the only backend that tracks them.
@@ -105,12 +99,7 @@ type ShareSession struct {
 //     to them. When linkCounts reaches 0, the file's content can be deleted.
 //     Directories always have linkCounts ≥ 2 (parent entry + "." self-reference).
 //
-//     7. Write Operations (pendingWrites):
-//     Tracks in-flight write operations for the two-phase write protocol.
-//     Maps operation IDs to WriteOperation structs containing the file handle,
-//     new size, and other metadata needed to commit the write.
-//
-//     8. Server Configuration (serverConfig):
+//     5. Server Configuration (serverConfig):
 //     Stores global server settings that apply across all shares and operations.
 //
 // Handle Generation:
@@ -179,21 +168,6 @@ type MemoryMetadataStore struct {
 	//   - Directories start at 2 ("." and parent's entry), increment with subdirectories
 	//   - When count reaches 0, file content can be deleted
 	linkCounts map[string]uint32
-
-	// deviceNumbers stores major and minor device numbers for block and character devices.
-	// Key: string representation of FileHandle
-	// Value: struct containing major and minor numbers
-	// Note: Only populated for FileTypeBlockDevice and FileTypeCharDevice
-	deviceNumbers map[string]*deviceNumber
-
-	// pendingWrites tracks in-flight write operations for two-phase writes.
-	// Key: operation ID (opaque string, typically UUID)
-	// Value: WriteOperation struct with file handle, new size, timestamps, etc.
-	// Notes:
-	//   - Created by PrepareWrite
-	//   - Consumed by CommitWrite
-	//   - Should be cleaned up on timeout/cancellation
-	pendingWrites map[string]*metadata.WriteOperation
 
 	// serverConfig stores global server configuration.
 	// This includes settings that apply across all shares and operations.
@@ -350,8 +324,6 @@ func NewMemoryMetadataStore(config MemoryMetadataStoreConfig) *MemoryMetadataSto
 		parents:         make(map[string]metadata.FileHandle),
 		children:        make(map[string]map[string]metadata.FileHandle),
 		linkCounts:      make(map[string]uint32),
-		deviceNumbers:   make(map[string]*deviceNumber),
-		pendingWrites:   make(map[string]*metadata.WriteOperation),
 		capabilities:    config.Capabilities,
 		maxStorageBytes: config.MaxStorageBytes,
 		maxFiles:        config.MaxFiles,

--- a/pkg/metadata/store/memory/store.go
+++ b/pkg/metadata/store/memory/store.go
@@ -71,9 +71,10 @@ type ShareSession struct {
 // Thread Safety:
 // The store is safe for concurrent use from multiple goroutines. A store-wide
 // read-write mutex (mu) covers the metadata maps below, taken for read on
-// queries and for write on mutations. Two subsystems are deliberately kept off
-// it so they do not contend with unrelated metadata operations: per-identity
-// quota usage (quotaMu) and the SyncedHashStore sync markers (syncedMu).
+// queries and for write on mutations. It is not the only lock: quota usage
+// (quotaMu), the SyncedHashStore markers (syncedMu) and each lazily built
+// sub-store (lock, client, durable, recovery) carry their own, and usedBytes is
+// atomic — all kept off mu so they do not contend with unrelated metadata ops.
 //
 // Storage Model:
 //
@@ -121,8 +122,9 @@ type ShareSession struct {
 // These invariants are maintained by all operations and can be verified by
 // consistency checking tools.
 type MemoryMetadataStore struct {
-	// mu protects all fields in this struct for concurrent access.
-	// Operations acquire read locks for queries and write locks for mutations.
+	// mu guards the metadata maps in this struct; fields carrying their own lock
+	// (quotaMu, syncedMu, the lazy sub-stores) and the atomic counters are not
+	// covered. Read locks are taken for queries, write locks for mutations.
 	mu sync.RWMutex
 
 	// shares maps share names to their configuration and root handles.

--- a/pkg/metadata/store/memory/transaction.go
+++ b/pkg/metadata/store/memory/transaction.go
@@ -59,13 +59,12 @@ type syncedTxState struct {
 // the rest are replaced (not mutated) by the tx methods, but copying keeps
 // the snapshot robust against future in-place edits.
 type txSnapshot struct {
-	shares        map[string]*shareData
-	files         map[string]*fileData
-	parents       map[string]metadata.FileHandle
-	children      map[string]map[string]metadata.FileHandle
-	linkCounts    map[string]uint32
-	deviceNumbers map[string]*deviceNumber
-	objectIndex   map[block.ContentHash]string
+	shares      map[string]*shareData
+	files       map[string]*fileData
+	parents     map[string]metadata.FileHandle
+	children    map[string]map[string]metadata.FileHandle
+	linkCounts  map[string]uint32
+	objectIndex map[block.ContentHash]string
 	// hadFileChunkData records whether fileChunkData was allocated at snapshot
 	// time. If the closure lazily allocated it (initFileChunkData) and then
 	// failed, restore must reset the struct's maps to non-nil empties (or it
@@ -90,16 +89,15 @@ func (store *MemoryMetadataStore) snapshotLocked() *txSnapshot {
 		// CreateRootDirectory set RootHandle) — a shallow map clone would share
 		// those pointers and let the mutation leak into the snapshot, defeating
 		// rollback. Copy each struct (same discipline as fileChunkData.blocks).
-		shares:        make(map[string]*shareData, len(store.shares)),
-		files:         maps.Clone(store.files),
-		parents:       maps.Clone(store.parents),
-		children:      make(map[string]map[string]metadata.FileHandle, len(store.children)),
-		linkCounts:    maps.Clone(store.linkCounts),
-		deviceNumbers: maps.Clone(store.deviceNumbers),
-		objectIndex:   maps.Clone(store.objectIndex),
-		serverConfig:  store.serverConfig,
-		capabilities:  store.capabilities,
-		blockRecords:  make(map[string]*block.BlockRecord, len(store.blockRecords)),
+		shares:       make(map[string]*shareData, len(store.shares)),
+		files:        maps.Clone(store.files),
+		parents:      maps.Clone(store.parents),
+		children:     make(map[string]map[string]metadata.FileHandle, len(store.children)),
+		linkCounts:   maps.Clone(store.linkCounts),
+		objectIndex:  maps.Clone(store.objectIndex),
+		serverConfig: store.serverConfig,
+		capabilities: store.capabilities,
+		blockRecords: make(map[string]*block.BlockRecord, len(store.blockRecords)),
 	}
 	for k, v := range store.shares {
 		sc := *v
@@ -134,7 +132,6 @@ func (store *MemoryMetadataStore) restoreLocked(snap *txSnapshot) {
 	store.parents = snap.parents
 	store.children = snap.children
 	store.linkCounts = snap.linkCounts
-	store.deviceNumbers = snap.deviceNumbers
 	store.objectIndex = snap.objectIndex
 	store.serverConfig = snap.serverConfig
 	store.capabilities = snap.capabilities
@@ -402,7 +399,6 @@ func (tx *memoryTransaction) DeleteFile(ctx context.Context, handle metadata.Fil
 	delete(tx.store.parents, key)
 	delete(tx.store.children, key)
 	delete(tx.store.linkCounts, key)
-	delete(tx.store.deviceNumbers, key)
 
 	return nil
 }
@@ -758,7 +754,6 @@ func (tx *memoryTransaction) DeleteShare(ctx context.Context, shareName string) 
 			delete(tx.store.parents, key)
 			delete(tx.store.children, key)
 			delete(tx.store.linkCounts, key)
-			delete(tx.store.deviceNumbers, key)
 		}
 	}
 


### PR DESCRIPTION
Closes a batch of small MED findings from the data-plane audit
(`.planning/audits/2026-08-05-dataplane/report.md`). Every finding was re-verified
against current `develop` before any edit — the report was written against
`7eeec0da` and several findings have since been closed by unrelated work.

### Fixed

- **`pendingWrites` map is fully dead state** (`pkg/metadata/store/memory/store.go:196`) — no `PrepareWrite`/`CommitWrite` producer or consumer exists in the package, so the map could only ever be empty. Removes the field and its alloc/reset/snapshot plumbing, including the `Snapshot.PendingWrites` gob field. The live `PendingWritesTracker` on `pkg/metadata/service.go` is a different type and is untouched.
- **`deviceNumbers` map + `deviceNumber` struct are fully dead** (`pkg/metadata/store/memory/store.go:187`) — no insertion site exists anywhere in the repo; the only references were alloc, reset, `maps.Clone`, restore and two `delete()` calls. Device major/minor actually ride on `FileAttr.Rdev` via `MakeRdev`. Removes the map, the struct and all its plumbing.
- **Struct doc claims a single mutex that doesn't exist** (`pkg/metadata/store/badger/store.go:38`) — `BadgerMetadataStore` has no `mu` field. The data path is serialized by BadgerDB MVCC with conflicts retried in `withTransaction`; the only explicit locks are per-subsystem, and the read/parent/dirent/share caches are lock-free (`sync.Map` + generation counter). Doc now says that.
- **Stale "File Handle Strategy" doc** (`pkg/metadata/store/badger/store.go:51`) — claimed path-derived, reversible handles with a hash fallback over 64 bytes. `GenerateHandle` ignores its `path` argument and returns `metadata.GenerateNewHandle(shareName)`, a random UUID. Doc now says that, and the matching "Path-based file handles" bullet is gone.
- **The same two stale claims in the memory backend** (`pkg/metadata/store/memory/store.go:71,105,123`) — not in the original finding list, but fixing the badger copies exposed them: the memory package doc carried the identical single-mutex sentence and the identical path-based-handle claim, and explicitly cross-referenced the badger paragraph as "matching" it. `generateFileHandle` also ignores its `fullPath` argument and encodes a fresh UUID. Left alone, this batch would have shipped a dangling reference to a paragraph it had just rewritten, and closed the finding on one backend while the identical false sentence survived on its sibling. Also drops two consistency invariants over `symlinkTargets`/`payloadIDs`, neither of which is a field on the store.

Removing the two gob fields is **decode-compatible, verified rather than assumed**: a standalone harness gob-encoded the *old* snapshot struct (both maps empty, populated, and nil) and decoded it into the *new* struct — clean in every case, since gob discards stream fields absent from the target. The reverse direction is covered by the old code's nil-init guards. `memorySchemaVersion` is deliberately **not** bumped: old snapshots stay readable and lose nothing, so bumping would only reject valid v1 dumps.

### Already fixed — no change

- **WRITE issues two extra unbatched `SetFileAttributes` round trips** (`internal/adapter/smb/handlers/write.go:481`) — closed by #1938, which added the `noteSmbAccess` / `noteSmbParentAccess` per-handle coalescing window, i.e. the "defer/debounce" option the report proposed.
- **`write_codec.go` reimplements `xdr.EncodeWccData` inline** (`internal/adapter/nfs/v3/handlers/write_codec.go:192`) — closed by #1939; `WriteResponse.Encode` already calls `xdr.EncodeWccData`. The report's byte-identity claim was **proved, not trusted**: a throwaway test encoded six cases (pre-op present/absent × post-op present/absent × OK/error) through both the old inline routine and the new call and asserted `bytes.Equal` — identical in all six. Not kept, since it would only pin a reimplementation of deleted code.

### Deferred — structural

- **`Service` struct is a god object** (`pkg/metadata/service.go:40`) — the finding holds, but the fix does not fit this batch. Extracting `QuotaManager` and `LockManagerRegistry` crosses 128 `func (s *Service)` receivers, and quota state, lock managers, unified views, `removeGen` and the dir-change notifiers are all guarded by the same `s.mu`. That is a lock-ownership redesign, not a field move, and it must preserve two subtle documented invariants: the `removeGen` register/remove TOCTOU and the grace-coordinator lockstep with the NFSv4 `StateManager` grace machine. Worth its own PR.

Verified: `gofmt -l` clean, `go build ./...`, `go test ./pkg/metadata/... ./internal/adapter/...`, `-race` on the touched packages, `golangci-lint run` — all green. Simplifier and reviewer passes both run; the reviewer caught two overstatements in my own replacement comments (an "every key namespace" claim and an undercount of the locks outside `mu`), both corrected in the final commit.
