### PR TITLE
fix(audit): close the LOW bug and security findings across block, metadata and control plane

### DIFF
--- a/pkg/block/engine/sync_health_test.go
+++ b/pkg/block/engine/sync_health_test.go
@@ -240,32 +240,3 @@ func TestHealthMonitor_OutageDuration(t *testing.T) {
 		t.Fatalf("expected 0 outage duration after recovery, got %v", d)
 	}
 }
-
-// A hung remote must not block Start: the eager probe runs on the monitor
-// goroutine, so the caller (which may hold a lock) returns immediately.
-func TestHealthMonitor_StartDoesNotBlockOnSlowProbe(t *testing.T) {
-	release := make(chan struct{})
-	probe := func(ctx context.Context) error {
-		<-release
-		return nil
-	}
-
-	hm := NewHealthMonitor(probe, fastHealthConfig())
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	done := make(chan struct{})
-	go func() {
-		hm.Start(ctx)
-		close(done)
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("Start blocked on the eager probe")
-	}
-
-	close(release)
-	hm.Stop()
-}

--- a/pkg/block/engine/sync_health_test.go
+++ b/pkg/block/engine/sync_health_test.go
@@ -240,3 +240,32 @@ func TestHealthMonitor_OutageDuration(t *testing.T) {
 		t.Fatalf("expected 0 outage duration after recovery, got %v", d)
 	}
 }
+
+// A hung remote must not block Start: the eager probe runs on the monitor
+// goroutine, so the caller (which may hold a lock) returns immediately.
+func TestHealthMonitor_StartDoesNotBlockOnSlowProbe(t *testing.T) {
+	release := make(chan struct{})
+	probe := func(ctx context.Context) error {
+		<-release
+		return nil
+	}
+
+	hm := NewHealthMonitor(probe, fastHealthConfig())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		hm.Start(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start blocked on the eager probe")
+	}
+
+	close(release)
+	hm.Stop()
+}

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -705,11 +705,6 @@ func (m *Syncer) startPeriodicUploader(ctx context.Context) {
 	}
 	m.periodicStarted = true
 
-	interval := m.config.UploadInterval
-	if interval <= 0 {
-		interval = 2 * time.Second
-	}
-	_ = interval
 	// Carve collaborators are wired by recomputeCarveActive once all deps are
 	// present; launch the dispatcher that periodically packs the journal's dirty
 	// ranges into remote blocks.

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -643,6 +643,18 @@ func (m *Syncer) Delete(ctx context.Context, payloadID string) error {
 // Must be called after New() to enable async uploads.
 // When remoteStore is nil (local-only mode), the periodic syncer is skipped.
 func (m *Syncer) Start(ctx context.Context) {
+	// The health monitor's eager probe is a network round trip, so it runs
+	// after m.mu is released: every read and flush path takes that lock, and
+	// holding it for a remote timeout stalls them all. Start still returns only
+	// once the probe has settled, so callers may read the health state.
+	if hm := m.startLocked(ctx); hm != nil {
+		hm.Start(ctx)
+	}
+}
+
+// startLocked performs the locked half of Start and returns the health monitor
+// still to be started, or nil in local-only mode.
+func (m *Syncer) startLocked(ctx context.Context) *HealthMonitor {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -652,7 +664,7 @@ func (m *Syncer) Start(ctx context.Context) {
 
 	if m.remoteStore == nil {
 		logger.Info("Syncer started in local-only mode (no remote store)")
-		return
+		return nil
 	}
 
 	// one-shot janitor pass before the periodic uploader
@@ -667,13 +679,14 @@ func (m *Syncer) Start(ctx context.Context) {
 	// (its recovered interval index re-marks every not-yet-carved record dirty
 	// on Open), so the carve dispatcher re-drains them without a reconcile walk.
 
-	m.startHealthMonitor(ctx)
+	hm := m.newHealthMonitorLocked()
 	m.startPeriodicUploader(ctx)
+	return hm
 }
 
-// startHealthMonitor creates and starts the health monitor for the remote store.
-// Must be called with m.mu held.
-func (m *Syncer) startHealthMonitor(ctx context.Context) {
+// newHealthMonitorLocked creates and wires the health monitor for the remote
+// store, without starting it. Must be called with m.mu held.
+func (m *Syncer) newHealthMonitorLocked() *HealthMonitor {
 	m.healthMonitor = NewHealthMonitor(m.remoteStore.HealthCheck, m.config)
 	// Wrap the user's callback to also reset the offline-read WARN flag
 	// on each healthy->unhealthy transition.
@@ -686,7 +699,7 @@ func (m *Syncer) startHealthMonitor(ctx context.Context) {
 			userCallback(healthy)
 		}
 	})
-	m.healthMonitor.Start(ctx)
+	return m.healthMonitor
 }
 
 // startPeriodicUploader launches the carve dispatcher and the maintenance
@@ -1003,17 +1016,32 @@ func (m *Syncer) HealthCheck(ctx context.Context) error {
 // (seedPendingFromDisk), not immediately. Not currently wired into any
 // production control-plane path; Start() is the seeded entry point.
 func (m *Syncer) SetRemoteStore(ctx context.Context, remoteStore remote.RemoteStore) error {
+	hm, err := m.setRemoteStoreLocked(ctx, remoteStore)
+	if err != nil {
+		return err
+	}
+
+	// Eager probe outside m.mu; see Start.
+	hm.Start(ctx)
+
+	logger.Info("Remote store attached, periodic syncer started")
+	return nil
+}
+
+// setRemoteStoreLocked performs the locked half of SetRemoteStore and returns
+// the health monitor still to be started.
+func (m *Syncer) setRemoteStoreLocked(ctx context.Context, remoteStore remote.RemoteStore) (*HealthMonitor, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	if m.closed {
-		return ErrClosed
+		return nil, ErrClosed
 	}
 	if m.remoteStore != nil {
-		return errors.New("remote store already set")
+		return nil, errors.New("remote store already set")
 	}
 	if remoteStore == nil {
-		return errors.New("remoteStore must not be nil")
+		return nil, errors.New("remoteStore must not be nil")
 	}
 
 	m.remoteStore = remoteStore
@@ -1021,9 +1049,7 @@ func (m *Syncer) SetRemoteStore(ctx context.Context, remoteStore remote.RemoteSt
 	m.recomputeCarveActive()
 	m.local.SetEvictionEnabled(true)
 
-	m.startHealthMonitor(ctx)
+	hm := m.newHealthMonitorLocked()
 	m.startPeriodicUploader(ctx)
-
-	logger.Info("Remote store attached, periodic syncer started")
-	return nil
+	return hm, nil
 }

--- a/pkg/block/engine/syncer_start_lock_test.go
+++ b/pkg/block/engine/syncer_start_lock_test.go
@@ -1,0 +1,49 @@
+package engine
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	memorylocal "github.com/marmos91/dittofs/pkg/block/local/memory"
+	"github.com/marmos91/dittofs/pkg/block/remote"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+)
+
+// probeHookRemote runs an arbitrary function in place of the remote's health
+// check, so a test can observe what the caller holds while the probe runs.
+type probeHookRemote struct {
+	remote.RemoteStore
+	probe func(ctx context.Context) error
+}
+
+func (r *probeHookRemote) HealthCheck(ctx context.Context) error { return r.probe(ctx) }
+
+// The eager health probe is a network round trip. Start must not hold the
+// syncer lock across it, or every read and flush stalls for a remote timeout
+// while a share comes up.
+func TestSyncerStart_EagerProbeDoesNotHoldLock(t *testing.T) {
+	var m *Syncer
+	rem := &probeHookRemote{
+		RemoteStore: remotememory.New(),
+		probe: func(context.Context) error {
+			// Takes the syncer lock: deadlocks if Start still holds it.
+			m.SetHealthCallback(nil)
+			return nil
+		},
+	}
+	m = NewSyncer(memorylocal.New(), rem, newStubFileChunkStore(), DefaultConfig())
+
+	done := make(chan struct{})
+	go func() {
+		m.Start(context.Background())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Syncer.Start held its lock across the eager health probe")
+	}
+	_ = m.Close()
+}

--- a/pkg/controlplane/runtime/adapters/service.go
+++ b/pkg/controlplane/runtime/adapters/service.go
@@ -228,6 +228,17 @@ func (s *Service) EnableAdapter(ctx context.Context, adapterType string) error {
 	}
 
 	if err := s.startAdapter(cfg); err != nil {
+		// Roll back the persisted flag so the store does not advertise an
+		// adapter that never started. Use a fresh bounded context, not the
+		// caller's: the request may already be canceled, and that must not
+		// abort the cleanup.
+		rbCtx, cancel := context.WithTimeout(context.Background(), s.shutdownTimeout)
+		defer cancel()
+		cfg.Enabled = false
+		if rbErr := s.store.UpdateAdapter(rbCtx, cfg); rbErr != nil {
+			logger.Warn("Failed to roll back adapter enabled flag after start failure",
+				"type", adapterType, "error", rbErr)
+		}
 		return fmt.Errorf("failed to start adapter: %w", err)
 	}
 

--- a/pkg/controlplane/runtime/adapters/service.go
+++ b/pkg/controlplane/runtime/adapters/service.go
@@ -229,9 +229,8 @@ func (s *Service) EnableAdapter(ctx context.Context, adapterType string) error {
 
 	if err := s.startAdapter(cfg); err != nil {
 		// Roll back the persisted flag so the store does not advertise an
-		// adapter that never started. Use a fresh bounded context, not the
-		// caller's: the request may already be canceled, and that must not
-		// abort the cleanup.
+		// adapter that never started. A fresh context keeps an already-canceled
+		// request from aborting the cleanup.
 		rbCtx, cancel := context.WithTimeout(context.Background(), s.shutdownTimeout)
 		defer cancel()
 		cfg.Enabled = false

--- a/pkg/controlplane/runtime/adapters/service_test.go
+++ b/pkg/controlplane/runtime/adapters/service_test.go
@@ -43,6 +43,17 @@ func (f *fakeAdapterStore) UpdateAdapter(_ context.Context, a *models.AdapterCon
 	return nil
 }
 
+func (f *fakeAdapterStore) GetAdapter(_ context.Context, t string) (*models.AdapterConfig, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	a, ok := f.byType[t]
+	if !ok {
+		return nil, errors.New("adapter not found")
+	}
+	cp := *a
+	return &cp, nil
+}
+
 func (f *fakeAdapterStore) DeleteAdapter(_ context.Context, t string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -419,4 +430,37 @@ func TestUpdateAdapter_NoPreservedListenerAfterStopTimeout(t *testing.T) {
 	}
 
 	close(stuck.release)
+}
+
+// A failed start must not leave the persisted config claiming the adapter is
+// enabled.
+func TestEnableAdapter_RollsBackEnabledOnStartFailure(t *testing.T) {
+	st := newFakeAdapterStore()
+	svc := New(st, time.Second)
+
+	startFails := false
+	svc.SetAdapterFactory(func(cfg *models.AdapterConfig) (ProtocolAdapter, error) {
+		if startFails {
+			return nil, errors.New("boom")
+		}
+		return newFakeListenerAdapter(cfg.Type, cfg.Port), nil
+	})
+
+	ctx := context.Background()
+	if err := svc.CreateAdapter(ctx, &models.AdapterConfig{Type: "nfs", Enabled: false, Port: 14449}); err != nil {
+		t.Fatalf("CreateAdapter: %v", err)
+	}
+
+	startFails = true
+	if err := svc.EnableAdapter(ctx, "nfs"); err == nil {
+		t.Fatal("expected EnableAdapter to fail when the adapter cannot start")
+	}
+
+	stored, err := st.GetAdapter(ctx, "nfs")
+	if err != nil {
+		t.Fatalf("GetAdapter: %v", err)
+	}
+	if stored.Enabled {
+		t.Fatal("persisted config still claims the adapter is enabled after a failed start")
+	}
 }

--- a/pkg/controlplane/runtime/identity/service.go
+++ b/pkg/controlplane/runtime/identity/service.go
@@ -29,7 +29,7 @@ func New() *Service { return &Service{} }
 func (s *Service) ApplyIdentityMapping(shareName string, identity *metadata.Identity, provider ShareProvider) (*metadata.Identity, error) {
 	info, err := provider.GetShareIdentityInfo(shareName)
 	if err != nil {
-		return nil, fmt.Errorf("share %q not found", shareName)
+		return nil, fmt.Errorf("share %q: %w", shareName, err)
 	}
 
 	effective := &metadata.Identity{

--- a/pkg/controlplane/runtime/mounts/service.go
+++ b/pkg/controlplane/runtime/mounts/service.go
@@ -14,27 +14,33 @@ type MountInfo struct {
 	AdapterData any // Protocol-specific details (e.g., NFS mount path, SMB session ID)
 }
 
+// mountKey identifies one mount. The three components are separate fields
+// rather than a joined string so a value containing the separator (an IPv6
+// client address, a share name with a colon) cannot collide with a different
+// triple.
+type mountKey struct {
+	Protocol   string
+	ClientAddr string
+	ShareName  string
+}
+
 // Tracker provides thread-safe mount tracking across all protocol adapters.
 type Tracker struct {
 	mu     sync.RWMutex
-	mounts map[string]*MountInfo // keyed by protocol:client:share
+	mounts map[mountKey]*MountInfo
 }
 
 func NewTracker() *Tracker {
 	return &Tracker{
-		mounts: make(map[string]*MountInfo),
+		mounts: make(map[mountKey]*MountInfo),
 	}
-}
-
-func mountKey(protocol, clientAddr, shareName string) string {
-	return protocol + ":" + clientAddr + ":" + shareName
 }
 
 func (mt *Tracker) Record(clientAddr, protocol, shareName string, adapterData any) {
 	mt.mu.Lock()
 	defer mt.mu.Unlock()
 
-	key := mountKey(protocol, clientAddr, shareName)
+	key := mountKey{Protocol: protocol, ClientAddr: clientAddr, ShareName: shareName}
 	mt.mounts[key] = &MountInfo{
 		ClientAddr:  clientAddr,
 		Protocol:    protocol,
@@ -48,7 +54,7 @@ func (mt *Tracker) Remove(clientAddr, protocol, shareName string) bool {
 	mt.mu.Lock()
 	defer mt.mu.Unlock()
 
-	key := mountKey(protocol, clientAddr, shareName)
+	key := mountKey{Protocol: protocol, ClientAddr: clientAddr, ShareName: shareName}
 	if _, exists := mt.mounts[key]; exists {
 		delete(mt.mounts, key)
 		return true
@@ -90,7 +96,7 @@ func (mt *Tracker) RemoveAll() int {
 	defer mt.mu.Unlock()
 
 	count := len(mt.mounts)
-	mt.mounts = make(map[string]*MountInfo)
+	mt.mounts = make(map[mountKey]*MountInfo)
 	return count
 }
 

--- a/pkg/controlplane/runtime/mounts/service.go
+++ b/pkg/controlplane/runtime/mounts/service.go
@@ -14,10 +14,9 @@ type MountInfo struct {
 	AdapterData any // Protocol-specific details (e.g., NFS mount path, SMB session ID)
 }
 
-// mountKey identifies one mount. The three components are separate fields
-// rather than a joined string so a value containing the separator (an IPv6
-// client address, a share name with a colon) cannot collide with a different
-// triple.
+// mountKey identifies one mount. The components stay separate fields rather
+// than a joined string so a value containing the separator (an IPv6 client
+// address, a share name with a colon) cannot collide with a different triple.
 type mountKey struct {
 	Protocol   string
 	ClientAddr string

--- a/pkg/controlplane/runtime/mounts/service_test.go
+++ b/pkg/controlplane/runtime/mounts/service_test.go
@@ -152,3 +152,21 @@ func TestTrackerConcurrent(t *testing.T) {
 	// race detector finding no data races.
 	_ = mt.Count()
 }
+
+// Distinct (protocol, client, share) triples must not share a slot when a
+// component contains the key separator.
+func TestTracker_ColonInComponentsDoesNotCollide(t *testing.T) {
+	mt := NewTracker()
+	mt.Record("1.2.3.4:111", "nfs", "export", nil)
+	mt.Record("1.2.3.4", "nfs", "111:export", nil)
+
+	if got := mt.Count(); got != 2 {
+		t.Fatalf("expected 2 distinct mounts, got %d", got)
+	}
+	if !mt.Remove("1.2.3.4:111", "nfs", "export") {
+		t.Fatal("failed to remove the first mount")
+	}
+	if got := mt.Count(); got != 1 {
+		t.Fatalf("expected 1 mount left, got %d", got)
+	}
+}

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -1383,6 +1383,10 @@ func (s *Service) RebindShareBlockStore(
 	oldRemoteConfigID := share.remoteConfigID
 	s.mu.RUnlock()
 
+	// Cancel any in-flight warm job for this share so it cannot keep fetching
+	// into the block store that is about to be drained and closed.
+	s.warmJobs.cancelForShare(name)
+
 	// Flush pending uploads to the OLD remote before teardown so switching or
 	// detaching a remote does not strand unmirrored blocks. Best-effort: a drain
 	// error must not block the rebind.

--- a/pkg/metadata/quota_enforce.go
+++ b/pkg/metadata/quota_enforce.go
@@ -1,6 +1,10 @@
 package metadata
 
-import "time"
+import (
+	"time"
+
+	"github.com/marmos91/dittofs/internal/logger"
+)
 
 // quotaDimension is one enforceable axis of a quota check (bytes or inodes).
 type quotaDimension struct {
@@ -50,7 +54,11 @@ func (s *Service) checkIdentityQuotas(shareName string, store Store, uid, gid ui
 func (s *Service) enforceOne(shareName string, store Store, scope QuotaScope, usageID uint32, iq IdentityQuota, byteDelta, fileDelta int64) error {
 	usage, err := store.GetQuotaUsage(scope, usageID)
 	if err != nil {
-		// Usage lookup failure must not wedge writes; treat as no-quota.
+		// Usage lookup failure must not wedge writes; treat as no-quota. Log it
+		// so a persistently broken usage counter is visible instead of silently
+		// disabling enforcement.
+		logger.Error("quota: usage lookup failed, allowing write",
+			"share", shareName, "scope", scope.String(), "id", usageID, "error", err)
 		return nil
 	}
 

--- a/pkg/metadata/store/badger/durable_handles.go
+++ b/pkg/metadata/store/badger/durable_handles.go
@@ -29,7 +29,9 @@ const (
 	// Index by FileHandle: dh:fh:{hex}:{id} -> id (string)
 	prefixDHFileHandle = "dh:fh:"
 
-	// Index by Share: dh:share:{name}:{id} -> id (string)
+	// Index by Share: dh:share:{hex(name)}:{id} -> id (string). The share name
+	// is hex-encoded so a ':' inside it cannot forge an extra key segment
+	// (see shareIndexPrefix).
 	prefixDHShare = "dh:share:"
 )
 
@@ -56,6 +58,19 @@ func hexEncodeBytes(b []byte) string {
 }
 
 var zeroGUID [16]byte
+
+// shareIndexPrefix returns the Share index prefix covering every durable handle
+// of one share. Hex-encoding the name keeps the ':' separator unambiguous, so a
+// share whose name embeds ':' cannot plant entries that a prefix scan for
+// another share matches.
+//
+// The format change needs no on-disk migration: durable handles are ephemeral
+// reconnect state with a bounded timeout, and the primary dh:id:{uuid} records
+// (which every other lookup uses) are untouched, so entries left by a
+// pre-upgrade run are unreachable by the new scans and expire on their own.
+func shareIndexPrefix(shareName string) string {
+	return prefixDHShare + hex.EncodeToString([]byte(shareName)) + ":"
+}
 
 // fileIDIndexScanPrefix returns the prefix covering every FileID index entry
 // for a file. A file can hold several durable handles at once, so entries are
@@ -136,7 +151,7 @@ func (s *badgerDurableStore) putDurableHandleTx(txn *badgerdb.Txn, handle *lock.
 		}
 	}
 
-	shareKey := []byte(prefixDHShare + handle.ShareName + ":" + handle.ID)
+	shareKey := []byte(shareIndexPrefix(handle.ShareName) + handle.ID)
 	if err := txn.Set(shareKey, []byte(handle.ID)); err != nil {
 		return err
 	}
@@ -191,7 +206,7 @@ func (s *badgerDurableStore) deleteIndicesTx(txn *badgerdb.Txn, handle *lock.Per
 		}
 	}
 
-	shareKey := []byte(prefixDHShare + handle.ShareName + ":" + handle.ID)
+	shareKey := []byte(shareIndexPrefix(handle.ShareName) + handle.ID)
 	if err := txn.Delete(shareKey); err != nil && err != badgerdb.ErrKeyNotFound {
 		return err
 	}
@@ -502,7 +517,7 @@ func (s *badgerDurableStore) ListDurableHandlesByShare(ctx context.Context, shar
 	var result []*lock.PersistedDurableHandle
 	err := s.db.View(func(txn *badgerdb.Txn) error {
 		var err error
-		result, err = s.getHandlesByPrefix(txn, []byte(prefixDHShare+shareName+":"))
+		result, err = s.getHandlesByPrefix(txn, []byte(shareIndexPrefix(shareName)))
 		return err
 	})
 	if err != nil {

--- a/pkg/metadata/store/badger/durable_handles.go
+++ b/pkg/metadata/store/badger/durable_handles.go
@@ -29,9 +29,7 @@ const (
 	// Index by FileHandle: dh:fh:{hex}:{id} -> id (string)
 	prefixDHFileHandle = "dh:fh:"
 
-	// Index by Share: dh:share:{hex(name)}:{id} -> id (string). The share name
-	// is hex-encoded so a ':' inside it cannot forge an extra key segment
-	// (see shareIndexPrefix).
+	// Index by Share: dh:share:{hex(name)}:{id} -> id (string)
 	prefixDHShare = "dh:share:"
 )
 
@@ -61,13 +59,9 @@ var zeroGUID [16]byte
 
 // shareIndexPrefix returns the Share index prefix covering every durable handle
 // of one share. Hex-encoding the name keeps the ':' separator unambiguous, so a
-// share whose name embeds ':' cannot plant entries that a prefix scan for
-// another share matches.
-//
-// The format change needs no on-disk migration: durable handles are ephemeral
-// reconnect state with a bounded timeout, and the primary dh:id:{uuid} records
-// (which every other lookup uses) are untouched, so entries left by a
-// pre-upgrade run are unreachable by the new scans and expire on their own.
+// share whose name embeds ':' cannot plant entries that a scan for another
+// share matches. Index entries written before the encoding are unreachable by
+// these scans and expire with the handles themselves.
 func shareIndexPrefix(shareName string) string {
 	return prefixDHShare + hex.EncodeToString([]byte(shareName)) + ":"
 }

--- a/pkg/metadata/store/badger/durable_share_index_test.go
+++ b/pkg/metadata/store/badger/durable_share_index_test.go
@@ -1,0 +1,51 @@
+package badger
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// A share name containing the key separator must not leak its handles into
+// another share's listing.
+func TestListDurableHandlesByShare_SeparatorInShareName(t *testing.T) {
+	s := newDurableStoreForTest(t)
+	ctx := context.Background()
+
+	nested := durableHandleForFile("nested", [16]byte{1})
+	nested.ShareName = "export:sub"
+	if err := s.PutDurableHandle(ctx, nested); err != nil {
+		t.Fatalf("put nested handle: %v", err)
+	}
+
+	own := durableHandleForFile("own", [16]byte{2})
+	own.ShareName = "export"
+	if err := s.PutDurableHandle(ctx, own); err != nil {
+		t.Fatalf("put own handle: %v", err)
+	}
+
+	handles, err := s.ListDurableHandlesByShare(ctx, "export")
+	if err != nil {
+		t.Fatalf("list by share: %v", err)
+	}
+	if len(handles) != 1 || handles[0].ID != "own" {
+		t.Fatalf("expected only the \"export\" handle, got %v", handleIDs(handles))
+	}
+
+	nestedHandles, err := s.ListDurableHandlesByShare(ctx, "export:sub")
+	if err != nil {
+		t.Fatalf("list nested share: %v", err)
+	}
+	if len(nestedHandles) != 1 || nestedHandles[0].ID != "nested" {
+		t.Fatalf("expected only the \"export:sub\" handle, got %v", handleIDs(nestedHandles))
+	}
+}
+
+func handleIDs(handles []*lock.PersistedDurableHandle) []string {
+	ids := make([]string, 0, len(handles))
+	for _, h := range handles {
+		ids = append(ids, h.ID)
+	}
+	return ids
+}

--- a/pkg/metadata/store/sqlite/snapshot_cell_test.go
+++ b/pkg/metadata/store/sqlite/snapshot_cell_test.go
@@ -1,0 +1,32 @@
+package sqlite
+
+import (
+	"bytes"
+	"encoding/binary"
+	"runtime"
+	"testing"
+)
+
+// A corrupt cell length must not be trusted for the allocation: decoding a
+// truncated stream fails without reserving the declared size.
+func TestReadCell_TruncatedLengthDoesNotPreallocate(t *testing.T) {
+	for _, kind := range []byte{cellText, cellBlob} {
+		var stream bytes.Buffer
+		stream.WriteByte(kind)
+		var lenBuf [4]byte
+		binary.LittleEndian.PutUint32(lenBuf[:], 1<<30)
+		stream.Write(lenBuf[:])
+		stream.WriteString("short")
+
+		var before, after runtime.MemStats
+		runtime.ReadMemStats(&before)
+		if _, err := readCell(bytes.NewReader(stream.Bytes())); err == nil {
+			t.Fatalf("kind %d: expected an error on a truncated cell", kind)
+		}
+		runtime.ReadMemStats(&after)
+
+		if allocated := after.TotalAlloc - before.TotalAlloc; allocated > 1<<20 {
+			t.Fatalf("kind %d: decoder allocated %d bytes from the declared length", kind, allocated)
+		}
+	}
+}

--- a/pkg/metadata/store/sqlite/snapshot_cell_test.go
+++ b/pkg/metadata/store/sqlite/snapshot_cell_test.go
@@ -19,6 +19,7 @@ func TestReadCell_TruncatedLengthDoesNotPreallocate(t *testing.T) {
 		stream.WriteString("short")
 
 		var before, after runtime.MemStats
+		runtime.GC()
 		runtime.ReadMemStats(&before)
 		if _, err := readCell(bytes.NewReader(stream.Bytes())); err == nil {
 			t.Fatalf("kind %d: expected an error on a truncated cell", kind)

--- a/pkg/metadata/store/sqlite/snapshot_store.go
+++ b/pkg/metadata/store/sqlite/snapshot_store.go
@@ -1,7 +1,6 @@
 package sqlite
 
 import (
-	"bytes"
 	"context"
 	"database/sql"
 	"encoding/binary"
@@ -492,21 +491,23 @@ func readCell(r io.Reader) (any, error) {
 	}
 }
 
-// readSized reads a u32-length-prefixed byte run. The length comes from an
-// unverified stream (the envelope CRC only covers the whole payload, so it is
-// checked after the rows are parsed), so the buffer grows as bytes arrive
-// instead of being allocated from the declared length up front: a corrupt or
-// truncated stream fails on EOF having used only the bytes it actually held.
+// readSized reads a u32-length-prefixed byte run. The declared length is not
+// trusted for the allocation - the envelope CRC covers the whole payload and is
+// only verified once the rows are parsed - so the buffer grows as bytes arrive
+// and a truncated stream fails having used only the bytes it actually held.
 func readSized(r io.Reader) ([]byte, error) {
 	n, err := readU32(r)
 	if err != nil {
 		return nil, err
 	}
-	var buf bytes.Buffer
-	if _, err := io.CopyN(&buf, r, int64(n)); err != nil {
+	buf, err := io.ReadAll(io.LimitReader(r, int64(n)))
+	if err != nil {
 		return nil, err
 	}
-	return buf.Bytes(), nil
+	if uint32(len(buf)) != n {
+		return nil, io.ErrUnexpectedEOF
+	}
+	return buf, nil
 }
 
 func writeString(w io.Writer, s string) error {

--- a/pkg/metadata/store/sqlite/snapshot_store.go
+++ b/pkg/metadata/store/sqlite/snapshot_store.go
@@ -1,6 +1,7 @@
 package sqlite
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/binary"
@@ -475,28 +476,37 @@ func readCell(r io.Reader) (any, error) {
 		}
 		return math.Float64frombits(binary.LittleEndian.Uint64(b[:])), nil
 	case cellText:
-		n, err := readU32(r)
+		buf, err := readSized(r)
 		if err != nil {
-			return nil, err
-		}
-		buf := make([]byte, n)
-		if _, err := io.ReadFull(r, buf); err != nil {
 			return nil, err
 		}
 		return string(buf), nil
 	case cellBlob:
-		n, err := readU32(r)
+		buf, err := readSized(r)
 		if err != nil {
-			return nil, err
-		}
-		buf := make([]byte, n)
-		if _, err := io.ReadFull(r, buf); err != nil {
 			return nil, err
 		}
 		return buf, nil
 	default:
 		return nil, fmt.Errorf("unknown cell kind %d", kind[0])
 	}
+}
+
+// readSized reads a u32-length-prefixed byte run. The length comes from an
+// unverified stream (the envelope CRC only covers the whole payload, so it is
+// checked after the rows are parsed), so the buffer grows as bytes arrive
+// instead of being allocated from the declared length up front: a corrupt or
+// truncated stream fails on EOF having used only the bytes it actually held.
+func readSized(r io.Reader) ([]byte, error) {
+	n, err := readU32(r)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	if _, err := io.CopyN(&buf, r, int64(n)); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 func writeString(w io.Writer, s string) error {


### PR DESCRIPTION
Sweep of the 12 LOW-severity `bugs` / `security` findings from the data-plane audit. Each claim was re-verified against current `develop` before any code was touched; two had already been closed by unrelated work.

## Verdicts

- `internal/adapter/nfs/v3/handlers/commit.go:211` — **ALREADY-FIXED**. COMMIT now calls `logAuthCtxError` and fails the RPC with `authDenialStatus(err)` (commit.go:152-164, landed in #1932). The silent-continue path the finding describes no longer exists.
- `pkg/block/engine/syncer.go:664` — **FIXED**, differently from the suggested fix. `Syncer.Start` split into a locked half plus the probe: the eager health probe now runs after `m.mu` is released, so a hung remote no longer stalls every read/flush that takes that lock. Deliberately *not* made asynchronous — `engine.go:269` reconciles local eviction from `syncer.IsRemoteHealthy()` right after `Start` returns, and an async probe would leave eviction enabled while the remote is actually down (the exact data-loss window `TestEngineHealthEvictionSuspended_RemoteUnhealthyAtStart` guards). `SetRemoteStore` gets the same treatment. New test `TestSyncerStart_EagerProbeDoesNotHoldLock` deadlocks-then-times-out without the fix.
- `pkg/block/engine/syncer.go:702` — **FIXED**. Dead `UploadInterval` computation removed; `carveDispatcher` (carve_dispatch.go:35) is the single owner of that config read.
- `pkg/metadata/quota_enforce.go:51` — **FIXED**. A `GetQuotaUsage` failure now logs at Error before falling through to "no quota", so a persistently broken usage counter is visible instead of silently disabling enforcement.
- `pkg/metadata/store/badger/durable_handles.go:125` — **FIXED**. The share name is hex-encoded into the `dh:share:` index key via a new `shareIndexPrefix` helper, mirroring the existing `lockIndexPrefix` / `monNameIndexPrefix` pattern; applied to all three sites (put, delete, list). No migration needed: the primary `dh:id:{uuid}` records are untouched and durable handles are ephemeral, bounded-timeout reconnect state. New test proves a `':'`-bearing share name no longer leaks handles into another share's listing.
- `pkg/metadata/store/postgres/config.go:32` — **ALREADY-FIXED**. The knob is now `DisablePreparedStatements` and is wired to `poolConfig.ConnConfig.DefaultQueryExecMode` (connection.go:48-49, landed in #1949).
- `pkg/metadata/store/sqlite/snapshot_store.go:476` and `:471` — **FIXED** (one fix, both findings). Snapshot cell decoding no longer allocates from the declared u32 length before reading; `readSized` grows the buffer as bytes arrive and reports `io.ErrUnexpectedEOF` on a short run, so a corrupt or truncated stream costs only the bytes it actually held. The CRC still covers the whole payload and is still verified before commit. New test asserts the decoder does not allocate from a 1 GiB declared length on a 5-byte stream.
- `pkg/controlplane/runtime/adapters/service.go:208` — **FIXED**. `EnableAdapter` rolls the persisted `Enabled` flag back on a start failure, using a fresh bounded context so an already-canceled request cannot abort the cleanup — mirroring `CreateAdapter`'s rollback. New test.
- `pkg/controlplane/runtime/identity/service.go:30` — **FIXED**. The provider error is wrapped instead of discarded and replaced with a fabricated "not found".
- `pkg/controlplane/runtime/mounts/service.go:29` — **FIXED**. The tracker map is keyed by a `mountKey` struct instead of a colon-joined string, so no separator-bearing component can collide with a different triple. New test.
- `pkg/controlplane/runtime/shares/service.go:1348` — **FIXED**. `RebindShareBlockStore` cancels in-flight warm jobs before draining/closing the old block store, matching `RemoveShare`'s ordering. Placed after the new-binding pre-validation so a rebind that fails fast does not needlessly kill a running warm.

## Verification

`gofmt -l .` clean, `go build ./...`, `go vet`, `go test ./...`, `-race` on every changed package, and `golangci-lint run` on the changed trees — all green.
