### PR TITLE
fix(metadata): close five MED write-path audit findings

### DIFF
--- a/pkg/metadata/file_create.go
+++ b/pkg/metadata/file_create.go
@@ -477,11 +477,16 @@ func (s *Service) createEntry(
 		// mkdirs in one directory serialize on it — acceptable, mkdir is rare
 		// relative to file create, which is fully disjoint above.
 		if fileType == FileTypeDirectory {
+			// The read is tx-critical: a failed GetLinkCount must roll the
+			// whole create back rather than commit the new directory with the
+			// parent's ".." count left un-incremented, which permanently
+			// under-reports the parent's nlink.
 			parentLinkCount, err := tx.GetLinkCount(ctx.Context, parentHandle)
-			if err == nil {
-				if err := tx.SetLinkCount(ctx.Context, parentHandle, parentLinkCount+1); err != nil {
-					return err
-				}
+			if err != nil {
+				return err
+			}
+			if err := tx.SetLinkCount(ctx.Context, parentHandle, parentLinkCount+1); err != nil {
+				return err
 			}
 		}
 		return nil

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -800,14 +800,13 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 	now := time.Now()
 	txErr := withRelaxedTransaction(store, ctx.Context, func(tx Transaction) error {
 		// The GetChild lookups above ran outside this transaction and are
-		// advisory only: a concurrent rename or unlink can retarget or remove
-		// either name in the gap, and no lock covers a file rename. Re-resolve
-		// both namespace edges through the transaction and abort when they no
-		// longer match what was read, so two renames onto the same destination
-		// cannot both commit and orphan an inode. Reading the child keys
-		// through the transaction also enters them in its read set, which lets
-		// an optimistic backend detect the write-write conflict it otherwise
-		// cannot see.
+		// advisory only: no lock covers a file rename, so a concurrent rename
+		// or unlink can retarget either name in the gap. Re-resolve both
+		// namespace edges here and abort when they no longer match, so two
+		// renames onto the same destination cannot both commit and orphan an
+		// inode. Reading the child keys through the transaction also enters
+		// them in its read set, which is what lets an optimistic backend see
+		// the write-write conflict at all.
 		txSrcHandle, srcErr := tx.GetChild(ctx.Context, fromDir, fromName)
 		if srcErr != nil {
 			return srcErr

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -799,6 +799,40 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 	// persists), never corrupt data.
 	now := time.Now()
 	txErr := withRelaxedTransaction(store, ctx.Context, func(tx Transaction) error {
+		// The GetChild lookups above ran outside this transaction and are
+		// advisory only: a concurrent rename or unlink can retarget or remove
+		// either name in the gap, and no lock covers a file rename. Re-resolve
+		// both namespace edges through the transaction and abort when they no
+		// longer match what was read, so two renames onto the same destination
+		// cannot both commit and orphan an inode. Reading the child keys
+		// through the transaction also enters them in its read set, which lets
+		// an optimistic backend detect the write-write conflict it otherwise
+		// cannot see.
+		txSrcHandle, srcErr := tx.GetChild(ctx.Context, fromDir, fromName)
+		if srcErr != nil {
+			return srcErr
+		}
+		if string(txSrcHandle) != string(srcHandle) {
+			return &StoreError{
+				Code:    ErrConflict,
+				Message: "source entry changed during rename",
+				Path:    fromName,
+			}
+		}
+		txDstHandle, dstErr := tx.GetChild(ctx.Context, toDir, toName)
+		if dstErr != nil && !IsNotFoundError(dstErr) {
+			return dstErr
+		}
+		dstNowExists := dstErr == nil
+		if dstNowExists != (dstFile != nil) ||
+			(dstNowExists && string(txDstHandle) != string(dstHandle)) {
+			return &StoreError{
+				Code:    ErrConflict,
+				Message: "destination entry changed during rename",
+				Path:    toName,
+			}
+		}
+
 		// Re-read the source/destination directories inside the transaction so
 		// the pre-op snapshots and the timestamp mutations derive from the same
 		// committed state (After then monotonic w.r.t. Before).

--- a/pkg/metadata/store/badger/conflict_classification_test.go
+++ b/pkg/metadata/store/badger/conflict_classification_test.go
@@ -1,0 +1,72 @@
+package badger
+
+import (
+	"context"
+	"testing"
+
+	badgerdb "github.com/dgraph-io/badger/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// TestUpdateWithConflictRetry_ClassifiesExhaustedConflict pins the two retry
+// loops to the same contract. Both withTransaction and updateWithConflictRetry
+// give up after maxTransactionRetries consecutive SSI aborts, and what they
+// return then has to be recognizable: IsConflictError matches only a
+// *StoreError carrying ErrConflict, so returning badger's bare sentinel would
+// leave an exhausted conflict unclassified on this backend while the SQL
+// backends classify the same condition. Each abort must also reach the shared
+// counter, which is what tests read to assert a workload stayed conflict-free.
+func TestUpdateWithConflictRetry_ClassifiesExhaustedConflict(t *testing.T) {
+	ctx := context.Background()
+	store, err := NewBadgerMetadataStoreWithDefaults(ctx, t.TempDir())
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+
+	restore := SetMaxTransactionRetriesForTest(3)
+	defer restore()
+
+	before := store.TransactionConflictsForTest()
+
+	attempts := 0
+	err = store.updateWithConflictRetry(ctx, func(*badgerdb.Txn) error {
+		attempts++
+		return badgerdb.ErrConflict
+	})
+
+	require.Error(t, err)
+	require.Equal(t, 3, attempts, "every configured attempt should run")
+	require.True(t, metadata.IsConflictError(err),
+		"exhausted conflict must classify as ErrConflict, got %#v", err)
+
+	var storeErr *metadata.StoreError
+	require.ErrorAs(t, err, &storeErr)
+	require.Equal(t, metadata.ErrConflict, storeErr.Code)
+	require.ErrorIs(t, err, badgerdb.ErrConflict,
+		"the raw sentinel must stay reachable through the unwrap chain")
+
+	require.Equal(t, before+3, store.TransactionConflictsForTest(),
+		"each abort should reach the shared conflict counter")
+}
+
+// TestUpdateWithConflictRetry_PassesThroughNonConflict confirms the mapping
+// added for the exhausted case does not swallow or reclassify an unrelated
+// failure, which short-circuits without retrying.
+func TestUpdateWithConflictRetry_PassesThroughNonConflict(t *testing.T) {
+	ctx := context.Background()
+	store, err := NewBadgerMetadataStoreWithDefaults(ctx, t.TempDir())
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+
+	attempts := 0
+	sentinel := badgerdb.ErrKeyNotFound
+	err = store.updateWithConflictRetry(ctx, func(*badgerdb.Txn) error {
+		attempts++
+		return sentinel
+	})
+
+	require.ErrorIs(t, err, sentinel)
+	require.Equal(t, 1, attempts, "a non-conflict error must not retry")
+	require.False(t, metadata.IsConflictError(err))
+}

--- a/pkg/metadata/store/badger/files.go
+++ b/pkg/metadata/store/badger/files.go
@@ -191,25 +191,7 @@ func (s *BadgerMetadataStore) GetFileByPayloadID(ctx context.Context, payloadID 
 				}
 
 				if file.PayloadID == payloadID {
-					// Look up link count for this file
-					linkItem, linkErr := txn.Get(keyLinkCount(file.ID))
-					switch linkErr {
-					case nil:
-						_ = linkItem.Value(func(linkVal []byte) error {
-							count, countErr := decodeUint32(linkVal)
-							if countErr == nil {
-								file.Nlink = count
-							}
-							return nil
-						})
-					case badgerdb.ErrKeyNotFound:
-						// Default based on file type
-						if file.Type == metadata.FileTypeDirectory {
-							file.Nlink = 2
-						} else {
-							file.Nlink = 1
-						}
-					}
+					file.Nlink = fileLinkCountTxn(txn, file)
 					// Derive Path from the parent keyspace (#1166) so a
 					// rename/relink can never surface a stale stored path.
 					btx := &badgerTransaction{store: s, txn: txn}

--- a/pkg/metadata/store/badger/files.go
+++ b/pkg/metadata/store/badger/files.go
@@ -184,6 +184,7 @@ func (s *BadgerMetadataStore) GetFileByPayloadID(ctx context.Context, payloadID 
 			}
 
 			item := it.Item()
+			var matchID uuid.UUID
 			err := item.Value(func(val []byte) error {
 				file, err := decodeFile(val)
 				if err != nil {
@@ -191,22 +192,18 @@ func (s *BadgerMetadataStore) GetFileByPayloadID(ctx context.Context, payloadID 
 				}
 
 				if file.PayloadID == payloadID {
-					file.Nlink = fileLinkCountTxn(txn, file)
-					// Derive Path from the parent keyspace (#1166) so a
-					// rename/relink can never surface a stale stored path.
-					btx := &badgerTransaction{store: s, txn: txn}
-					file.Path = btx.derivePath(file.ID)
-					if err := loadManifest(txn, file); err != nil {
-						return err
-					}
-					result = file
+					matchID = file.ID
 					return errFound
 				}
 				return nil
 			})
 
 			if err == errFound {
-				return nil
+				// Re-load through the shared enrichment path so an unindexed
+				// row returns the same shape as the fast path: link count,
+				// derived path and the chunk manifest from the fm: key.
+				result, err = btx.loadEnrichedFileByID(matchID)
+				return err
 			}
 			if err != nil {
 				return err

--- a/pkg/metadata/store/badger/objects.go
+++ b/pkg/metadata/store/badger/objects.go
@@ -166,6 +166,10 @@ func (s *BadgerMetadataStore) updateWithConflictRetry(ctx context.Context, fn fu
 		}
 		if err == badger.ErrConflict {
 			lastErr = err
+			// Record the SSI abort on the same counter WithTransaction uses,
+			// so a workload's conflict rate is visible no matter which retry
+			// loop it went through.
+			s.txnConflicts.Add(1)
 			baseDelay := time.Duration(1+attempt) * time.Millisecond
 			jitter := time.Duration(attempt) * time.Millisecond
 			time.Sleep(baseDelay + jitter)
@@ -173,7 +177,12 @@ func (s *BadgerMetadataStore) updateWithConflictRetry(ctx context.Context, fn fu
 		}
 		return err
 	}
-	return lastErr
+	// Retries exhausted. Map the raw sentinel to StoreError{Code: ErrConflict}
+	// the way WithTransaction does: IsConflictError and the object-ID conflict
+	// rules match only the wrapped form, so returning the bare sentinel would
+	// leave an exhausted conflict unclassified on this backend while the SQL
+	// backends classify the same condition.
+	return mapBadgerError(lastErr, "updateWithConflictRetry", "")
 }
 
 // IncrementRefCount atomically increments a block's RefCount. Retries

--- a/pkg/metadata/store/badger/payload_index_test.go
+++ b/pkg/metadata/store/badger/payload_index_test.go
@@ -159,3 +159,40 @@ func TestPayloadIndex_MovesOnPayloadIDChange(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, fileID, got.ID)
 }
+
+// TestPayloadIndex_TxScanFallbackReturnsManifest pins the transaction-scoped
+// GetFileByPayloadID scan fallback to the same shape as its index fast path.
+// The scan branch used to build the result inline and returned without loading
+// the sibling fm: manifest, so an unindexed row resolved inside a transaction
+// came back with an empty Blocks slice — a silently truncated manifest for
+// every caller that reads File.Blocks off it.
+func TestPayloadIndex_TxScanFallbackReturnsManifest(t *testing.T) {
+	ctx := context.Background()
+	store, err := NewBadgerMetadataStoreWithDefaults(ctx, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	const shareName = "/s"
+	root := mkPayloadShare(t, store, shareName)
+	handle := mkChunkedFile(t, store, shareName, root, "big.bin", "/big.bin", 4)
+	_, fileID, err := metadata.DecodeFileHandle(handle)
+	require.NoError(t, err)
+	pid := metadata.PayloadID("/big.bin")
+
+	// Drop the pl: entry so the lookup takes the legacy full-scan branch.
+	require.NoError(t, store.db.Update(func(txn *badgerdb.Txn) error {
+		return txn.Delete(keyPayloadID(pid))
+	}))
+
+	require.NoError(t, store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		got, err := tx.GetFileByPayloadID(ctx, pid)
+		if err != nil {
+			return err
+		}
+		require.Equal(t, fileID, got.ID)
+		require.Len(t, got.Blocks, 4, "scan fallback must load the fm: manifest")
+		require.Equal(t, uint32(1), got.Nlink, "scan fallback must resolve the link count")
+		require.Equal(t, "/big.bin", got.Path, "scan fallback must derive the path")
+		return nil
+	}))
+}

--- a/pkg/metadata/store/badger/shares.go
+++ b/pkg/metadata/store/badger/shares.go
@@ -507,21 +507,9 @@ func (s *BadgerMetadataStore) loadExistingRoot(txn *badgerdb.Txn, item *badgerdb
 		return fmt.Errorf("failed to decode existing root file: %w", err)
 	}
 
-	// Look up link count for the root file
-	linkItem, linkErr := txn.Get(keyLinkCount(rootID))
-	switch linkErr {
-	case nil:
-		_ = linkItem.Value(func(linkVal []byte) error {
-			count, countErr := decodeUint32(linkVal)
-			if countErr == nil {
-				(*rootFile).Nlink = count
-			}
-			return nil
-		})
-	case badgerdb.ErrKeyNotFound:
-		// Root directories always have at least 2 links
-		(*rootFile).Nlink = 2
-	}
+	// A root directory with no stored link count falls back to the directory
+	// default of 2.
+	(*rootFile).Nlink = fileLinkCountTxn(txn, *rootFile)
 
 	// Update attributes if config changed
 	needsUpdate := false

--- a/pkg/metadata/store/badger/shares.go
+++ b/pkg/metadata/store/badger/shares.go
@@ -110,7 +110,7 @@ func (s *BadgerMetadataStore) CreateShare(ctx context.Context, share *metadata.S
 		return err
 	}
 
-	err := s.db.Update(func(txn *badgerdb.Txn) error {
+	err := s.updateWithConflictRetry(ctx, func(txn *badgerdb.Txn) error {
 		_, err := txn.Get(keyShare(share.Name))
 		if err == nil {
 			return &metadata.StoreError{
@@ -148,7 +148,7 @@ func (s *BadgerMetadataStore) UpdateShareOptions(ctx context.Context, shareName 
 		return err
 	}
 
-	err := s.db.Update(func(txn *badgerdb.Txn) error {
+	err := s.updateWithConflictRetry(ctx, func(txn *badgerdb.Txn) error {
 		item, err := txn.Get(keyShare(shareName))
 		if err != nil {
 			return mapBadgerError(err, "share", shareName)
@@ -191,7 +191,7 @@ func (s *BadgerMetadataStore) DeleteShare(ctx context.Context, shareName string)
 
 	var freedBytes int64
 	var quotaFreed map[quota.Key]metadata.UsageStat
-	err := s.db.Update(func(txn *badgerdb.Txn) error {
+	err := s.updateWithConflictRetry(ctx, func(txn *badgerdb.Txn) error {
 		_, err := txn.Get(keyShare(shareName))
 		if err != nil {
 			return mapBadgerError(err, "share", shareName)
@@ -243,8 +243,8 @@ func (s *BadgerMetadataStore) applyQuotaDelta(delta map[quota.Key]metadata.Usage
 // deleteShareFiles returns the total regular-file bytes it removed (freedBytes)
 // rather than mutating usedBytes inline. The caller applies the decrement once
 // after a successful commit — the tx-path accumulates it into the transaction's
-// pendingDelta and the pool-path applies it after db.Update returns nil — so a
-// conflict/serialization retry that re-runs the enclosing Update never
+// pendingDelta and the pool-path applies it only once updateWithConflictRetry
+// returns nil — so a conflict retry that re-runs the enclosing Update never
 // double-counts. The counter is statfs-only, not quota-enforcing.
 func (s *BadgerMetadataStore) deleteShareFiles(txn *badgerdb.Txn, shareName string) (freedBytes int64, quotaFreed map[quota.Key]metadata.UsageStat, err error) {
 	type doomed struct {
@@ -433,7 +433,7 @@ func (s *BadgerMetadataStore) CreateRootDirectory(ctx context.Context, shareName
 
 	var rootFile *metadata.File
 
-	err := s.db.Update(func(txn *badgerdb.Txn) error {
+	err := s.updateWithConflictRetry(ctx, func(txn *badgerdb.Txn) error {
 		// Check if share already exists
 		item, err := txn.Get(keyShare(shareName))
 		if err == nil {

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -262,26 +262,9 @@ func (tx *badgerTransaction) getFile(ctx context.Context, handle metadata.FileHa
 		return nil, err
 	}
 
-	// Look up the link count and set Nlink on the returned file
-	// The link count is stored separately to support hard links
-	linkItem, linkErr := tx.txn.Get(keyLinkCount(fileID))
-	switch linkErr {
-	case nil:
-		_ = linkItem.Value(func(val []byte) error {
-			count, decErr := decodeUint32(val)
-			if decErr == nil {
-				file.Nlink = count
-			}
-			return nil
-		})
-	case badgerdb.ErrKeyNotFound:
-		// No link count stored - use default based on file type
-		if file.Type == metadata.FileTypeDirectory {
-			file.Nlink = 2
-		} else {
-			file.Nlink = 1
-		}
-	}
+	// The link count is stored separately to support hard links; a missing
+	// key falls back to the type default.
+	file.Nlink = fileLinkCountTxn(tx.txn, file)
 
 	// Derive File.Path from the parent/children keyspace rather than trusting
 	// the stored proto field (#1166): parent edges are the sole source of
@@ -799,25 +782,7 @@ func (tx *badgerTransaction) ListChildren(ctx context.Context, dirHandle metadat
 				if decErr != nil {
 					return decErr
 				}
-				// Look up link count for this file
-				linkItem, linkErr := tx.txn.Get(keyLinkCount(childID))
-				switch linkErr {
-				case nil:
-					_ = linkItem.Value(func(linkVal []byte) error {
-						count, countErr := decodeUint32(linkVal)
-						if countErr == nil {
-							file.Nlink = count
-						}
-						return nil
-					})
-				case badgerdb.ErrKeyNotFound:
-					// Default based on file type
-					if file.Type == metadata.FileTypeDirectory {
-						file.Nlink = 2
-					} else {
-						file.Nlink = 1
-					}
-				}
+				file.Nlink = fileLinkCountTxn(tx.txn, file)
 				entry.Attr = &file.FileAttr
 				return nil
 			})
@@ -1224,21 +1189,9 @@ func (tx *badgerTransaction) CreateRootDirectory(ctx context.Context, shareName 
 			return nil, err
 		}
 
-		// Look up link count for the root file
-		linkItem, linkErr := tx.txn.Get(keyLinkCount(rootID))
-		switch linkErr {
-		case nil:
-			_ = linkItem.Value(func(linkVal []byte) error {
-				count, countErr := decodeUint32(linkVal)
-				if countErr == nil {
-					rootFile.Nlink = count
-				}
-				return nil
-			})
-		case badgerdb.ErrKeyNotFound:
-			// Root directories always have at least 2 links
-			rootFile.Nlink = 2
-		}
+		// A root directory with no stored link count falls back to the
+		// directory default of 2.
+		rootFile.Nlink = fileLinkCountTxn(tx.txn, rootFile)
 
 		return rootFile, nil
 	} else if err != badgerdb.ErrKeyNotFound {
@@ -1533,24 +1486,10 @@ func (tx *badgerTransaction) loadEnrichedFileByID(fileID uuid.UUID) (*metadata.F
 		return nil, err
 	}
 
-	// The link count is secondary data stored under a separate key. Mirror
-	// GetFile and the legacy scan path: a missing or unreadable link-count key
-	// never fails the lookup. Seed the type default first so any such case
-	// returns a sensible Nlink rather than 0 (#1435 review), then override it
-	// with the stored count when the key reads and decodes cleanly.
-	if file.Type == metadata.FileTypeDirectory {
-		file.Nlink = 2
-	} else {
-		file.Nlink = 1
-	}
-	if linkItem, linkErr := tx.txn.Get(keyLinkCount(fileID)); linkErr == nil {
-		_ = linkItem.Value(func(linkVal []byte) error {
-			if count, cErr := decodeUint32(linkVal); cErr == nil {
-				file.Nlink = count
-			}
-			return nil
-		})
-	}
+	// The link count is secondary data stored under a separate key. A missing
+	// or unreadable key never fails the lookup: it falls back to the type
+	// default so the file never comes back with Nlink 0.
+	file.Nlink = fileLinkCountTxn(tx.txn, file)
 
 	// GetFileByPayloadID returns the manifest inline (callers such as the flush
 	// coordinator read File.Blocks off it); load it from fm: like GetFile does.
@@ -1625,7 +1564,7 @@ func (tx *badgerTransaction) GetFileByPayloadID(ctx context.Context, payloadID m
 		}
 
 		item := it.Item()
-		var result *metadata.File
+		var matchID uuid.UUID
 		err := item.Value(func(val []byte) error {
 			file, decErr := decodeFile(val)
 			if decErr != nil {
@@ -1633,37 +1572,25 @@ func (tx *badgerTransaction) GetFileByPayloadID(ctx context.Context, payloadID m
 			}
 
 			if file.PayloadID == payloadID {
-				// Look up link count for this file
-				linkItem, linkErr := tx.txn.Get(keyLinkCount(file.ID))
-				switch linkErr {
-				case nil:
-					_ = linkItem.Value(func(linkVal []byte) error {
-						count, countErr := decodeUint32(linkVal)
-						if countErr == nil {
-							file.Nlink = count
-						}
-						return nil
-					})
-				case badgerdb.ErrKeyNotFound:
-					// Default based on file type
-					if file.Type == metadata.FileTypeDirectory {
-						file.Nlink = 2
-					} else {
-						file.Nlink = 1
-					}
-				}
-				// Derive Path from the parent keyspace (#1166) so a
-				// rename/relink can never surface a stale stored path —
-				// consistent with the store-level GetFileByPayloadID and GetFile.
-				file.Path = tx.derivePath(file.ID)
-				result = file
+				matchID = file.ID
 				return errFound
 			}
 			return nil
 		})
 
 		if err == errFound {
-			return result, nil
+			// Re-load through the shared enrichment path so an unindexed row
+			// returns the same shape as the fast path: link count, derived
+			// path and — critically for callers that read File.Blocks — the
+			// chunk manifest from the sibling fm: key.
+			file, lErr := tx.loadEnrichedFileByID(matchID)
+			if lErr != nil {
+				return nil, lErr
+			}
+			if file != nil {
+				return file, nil
+			}
+			break
 		}
 		if err != nil {
 			return nil, err

--- a/pkg/metadata/tx_integrity_test.go
+++ b/pkg/metadata/tx_integrity_test.go
@@ -129,12 +129,12 @@ type faultyStore struct {
 	failID uuid.UUID // file ID whose PutFile should fail
 	// failLinkCountID is the file ID whose in-transaction GetLinkCount fails.
 	failLinkCountID uuid.UUID
-	// getChild, when set, intercepts in-transaction GetChild lookups. It
-	// returns the substituted result plus ok=true to override, or ok=false to
-	// fall through to the real transaction. This simulates a concurrent
+	// getChild, when set, intercepts in-transaction GetChild lookups by name.
+	// It returns the substituted result plus ok=true to override, or ok=false
+	// to fall through to the real transaction. This simulates a concurrent
 	// rename/unlink retargeting a name in the window between the advisory
 	// pre-transaction read and the transaction body.
-	getChild func(dir metadata.FileHandle, name string) (metadata.FileHandle, error, bool)
+	getChild func(name string) (metadata.FileHandle, error, bool)
 }
 
 func (f *faultyStore) WithTransaction(ctx context.Context, fn func(tx metadata.Transaction) error) error {
@@ -152,7 +152,7 @@ type faultyTx struct {
 	metadata.Transaction
 	failID          uuid.UUID
 	failLinkCountID uuid.UUID
-	getChild        func(dir metadata.FileHandle, name string) (metadata.FileHandle, error, bool)
+	getChild        func(name string) (metadata.FileHandle, error, bool)
 }
 
 func (t *faultyTx) PutFile(ctx context.Context, file *metadata.File) error {
@@ -173,93 +173,16 @@ func (t *faultyTx) GetLinkCount(ctx context.Context, handle metadata.FileHandle)
 
 func (t *faultyTx) GetChild(ctx context.Context, dir metadata.FileHandle, name string) (metadata.FileHandle, error) {
 	if t.getChild != nil {
-		if handle, err, ok := t.getChild(dir, name); ok {
+		if handle, err, ok := t.getChild(name); ok {
 			return handle, err
 		}
 	}
 	return t.Transaction.GetChild(ctx, dir, name)
 }
 
-// TestMove_RollsBackOnPutFileFailure asserts the rename is atomic: when the
-// PutFile(srcFile) ctime write fails mid-transaction, the whole Move rolls
-// back — the source stays at its original name and the destination name is not
-// created. Previously Move discarded these errors with `_ =` and committed a
-// partial rename (entry relinked but the inode write lost).
-func TestMove_RollsBackOnPutFileFailure(t *testing.T) {
-	t.Parallel()
-
-	store := memory.NewMemoryMetadataStoreWithDefaults()
-	ctx := context.Background()
-	shareName := "/test"
-
-	rootFile, err := store.CreateRootDirectory(ctx, shareName, &metadata.FileAttr{
-		Type: metadata.FileTypeDirectory,
-		Mode: 0777,
-	})
-	require.NoError(t, err)
-	rootHandle, err := metadata.EncodeShareHandle(shareName, rootFile.ID)
-	require.NoError(t, err)
-
-	svc := metadata.New()
-	// Register a store that, once armed, fails the moved file's ctime PutFile.
-	// The fault is keyed on the inode's ID (stable across the rename) rather
-	// than File.Path, which is no longer mutated/persisted by Move (#1166). Arm
-	// it only just before the Move so setup CREATEs are unaffected.
-	faulty := &faultyStore{Store: store}
-	require.NoError(t, svc.RegisterStoreForShare(shareName, faulty))
-
-	rootCtx := &metadata.AuthContext{
-		Context:    ctx,
-		AuthMethod: "unix",
-		Identity: &metadata.Identity{
-			UID:  metadata.Uint32Ptr(0),
-			GID:  metadata.Uint32Ptr(0),
-			GIDs: []uint32{0},
-		},
-		ClientAddr: "127.0.0.1",
-	}
-
-	_, _, err = svc.CreateFile(rootCtx, rootHandle, "myfile.txt", &metadata.FileAttr{Mode: 0644})
-	require.NoError(t, err)
-	_, _, err = svc.CreateDirectory(rootCtx, rootHandle, "dest", &metadata.FileAttr{Mode: 0755})
-	require.NoError(t, err)
-	destHandle, err := store.GetChild(ctx, rootHandle, "dest")
-	require.NoError(t, err)
-
-	srcHandle, err := store.GetChild(ctx, rootHandle, "myfile.txt")
-	require.NoError(t, err)
-	_, srcID, err := metadata.DecodeFileHandle(srcHandle)
-	require.NoError(t, err)
-
-	// Arm the fault: the moved inode's ctime PutFile (keyed by inode ID).
-	faulty.failID = srcID
-
-	// The move must fail with the injected error.
-	_, err = svc.Move(rootCtx, rootHandle, "myfile.txt", destHandle, "moved.txt")
-	require.Error(t, err, "Move must surface the injected PutFile failure, not swallow it")
-	require.ErrorIs(t, err, errPutFileInjected)
-
-	// Full rollback: source still at its original name/path...
-	stillThere, err := store.GetChild(ctx, rootHandle, "myfile.txt")
-	require.NoError(t, err, "source entry must survive the rolled-back rename")
-	assert.Equal(t, string(srcHandle), string(stillThere))
-
-	srcFile, err := store.GetFile(ctx, srcHandle)
-	require.NoError(t, err)
-	assert.Equal(t, "/myfile.txt", srcFile.Path, "File.Path must not be left at the new (uncommitted) path")
-
-	// ...and the destination name was NOT created.
-	_, err = store.GetChild(ctx, destHandle, "moved.txt")
-	require.Error(t, err, "destination entry must not exist after rollback")
-}
-
-// ============================================================================
-// In-transaction rechecks of state read before the transaction
-// ============================================================================
-
-// faultyFixture builds a service backed by a fault-injectable store, with a
-// share root already created. Callers arm the fault just before the operation
-// under test so setup writes run unimpeded.
+// faultyFixture is newTestFixture with the store wrapped so faults can be
+// injected into the transaction body. Callers arm the fault just before the
+// operation under test so setup writes run unimpeded.
 type faultyFixture struct {
 	store  *memory.MemoryMetadataStore
 	faulty *faultyStore
@@ -270,39 +193,69 @@ type faultyFixture struct {
 
 func newFaultyFixture(t *testing.T) *faultyFixture {
 	t.Helper()
-	ctx := context.Background()
-	const shareName = "/test"
 
-	store := memory.NewMemoryMetadataStoreWithDefaults()
-	rootFile, err := store.CreateRootDirectory(ctx, shareName, &metadata.FileAttr{
-		Type: metadata.FileTypeDirectory,
-		Mode: 0777,
-	})
-	require.NoError(t, err)
-	rootHandle, err := metadata.EncodeShareHandle(shareName, rootFile.ID)
-	require.NoError(t, err)
-
-	faulty := &faultyStore{Store: store}
+	base := newTestFixture(t)
+	faulty := &faultyStore{Store: base.store}
 	svc := metadata.New()
-	require.NoError(t, svc.RegisterStoreForShare(shareName, faulty))
+	require.NoError(t, svc.RegisterStoreForShare(base.shareName, faulty))
 
 	return &faultyFixture{
-		store:  store,
+		store:  base.store,
 		faulty: faulty,
 		svc:    svc,
-		root:   rootHandle,
-		ctx: &metadata.AuthContext{
-			Context:    ctx,
-			AuthMethod: "unix",
-			Identity: &metadata.Identity{
-				UID:  metadata.Uint32Ptr(0),
-				GID:  metadata.Uint32Ptr(0),
-				GIDs: []uint32{0},
-			},
-			ClientAddr: "127.0.0.1",
-		},
+		root:   base.rootHandle,
+		ctx:    base.rootContext(),
 	}
 }
+
+// TestMove_RollsBackOnPutFileFailure asserts the rename is atomic: when the
+// PutFile(srcFile) ctime write fails mid-transaction, the whole Move rolls
+// back — the source stays at its original name and the destination name is not
+// created. Previously Move discarded these errors with `_ =` and committed a
+// partial rename (entry relinked but the inode write lost).
+func TestMove_RollsBackOnPutFileFailure(t *testing.T) {
+	t.Parallel()
+	fx := newFaultyFixture(t)
+	ctx := context.Background()
+
+	_, _, err := fx.svc.CreateFile(fx.ctx, fx.root, "myfile.txt", &metadata.FileAttr{Mode: 0644})
+	require.NoError(t, err)
+	_, _, err = fx.svc.CreateDirectory(fx.ctx, fx.root, "dest", &metadata.FileAttr{Mode: 0755})
+	require.NoError(t, err)
+	destHandle, err := fx.store.GetChild(ctx, fx.root, "dest")
+	require.NoError(t, err)
+
+	srcHandle, err := fx.store.GetChild(ctx, fx.root, "myfile.txt")
+	require.NoError(t, err)
+	_, srcID, err := metadata.DecodeFileHandle(srcHandle)
+	require.NoError(t, err)
+
+	// Arm the fault on the moved inode's ctime PutFile. It is keyed on the
+	// inode ID (stable across the rename) rather than File.Path, which Move no
+	// longer mutates/persists (#1166).
+	fx.faulty.failID = srcID
+
+	// The move must fail with the injected error.
+	_, err = fx.svc.Move(fx.ctx, fx.root, "myfile.txt", destHandle, "moved.txt")
+	require.ErrorIs(t, err, errPutFileInjected, "Move must surface the injected PutFile failure, not swallow it")
+
+	// Full rollback: source still at its original name/path...
+	stillThere, err := fx.store.GetChild(ctx, fx.root, "myfile.txt")
+	require.NoError(t, err, "source entry must survive the rolled-back rename")
+	assert.Equal(t, string(srcHandle), string(stillThere))
+
+	srcFile, err := fx.store.GetFile(ctx, srcHandle)
+	require.NoError(t, err)
+	assert.Equal(t, "/myfile.txt", srcFile.Path, "File.Path must not be left at the new (uncommitted) path")
+
+	// ...and the destination name was NOT created.
+	_, err = fx.store.GetChild(ctx, destHandle, "moved.txt")
+	require.Error(t, err, "destination entry must not exist after rollback")
+}
+
+// ============================================================================
+// In-transaction rechecks of state read before the transaction
+// ============================================================================
 
 // TestCreateDirectory_AbortsOnParentLinkCountFailure asserts that a failed
 // parent GetLinkCount rolls the whole mkdir back. Previously the error was
@@ -320,30 +273,11 @@ func TestCreateDirectory_AbortsOnParentLinkCountFailure(t *testing.T) {
 	fx.faulty.failLinkCountID = rootID
 
 	_, _, err = fx.svc.CreateDirectory(fx.ctx, fx.root, "sub", &metadata.FileAttr{Mode: 0755})
-	require.Error(t, err, "mkdir must surface the parent link-count read failure")
-	require.ErrorIs(t, err, errLinkCountInjected)
+	require.ErrorIs(t, err, errLinkCountInjected, "mkdir must surface the parent link-count read failure")
 
 	// Full rollback: the directory entry was not created.
 	_, err = fx.store.GetChild(ctx, fx.root, "sub")
 	require.Error(t, err, "the new directory must not survive the rolled-back mkdir")
-}
-
-// TestCreateDirectory_BumpsParentLinkCount is the baseline: with no fault, the
-// parent's link count still gains the new "..".
-func TestCreateDirectory_BumpsParentLinkCount(t *testing.T) {
-	t.Parallel()
-	fx := newFaultyFixture(t)
-	ctx := context.Background()
-
-	before, err := fx.store.GetLinkCount(ctx, fx.root)
-	require.NoError(t, err)
-
-	_, _, err = fx.svc.CreateDirectory(fx.ctx, fx.root, "sub", &metadata.FileAttr{Mode: 0755})
-	require.NoError(t, err)
-
-	after, err := fx.store.GetLinkCount(ctx, fx.root)
-	require.NoError(t, err)
-	assert.Equal(t, before+1, after, "mkdir must bump the parent's link count")
 }
 
 // TestMove_AbortsWhenSourceEntryChangedInTransaction asserts Move re-resolves
@@ -360,7 +294,7 @@ func TestMove_AbortsWhenSourceEntryChangedInTransaction(t *testing.T) {
 	require.NoError(t, err)
 
 	// The source name vanishes between the advisory read and the transaction.
-	fx.faulty.getChild = func(dir metadata.FileHandle, name string) (metadata.FileHandle, error, bool) {
+	fx.faulty.getChild = func(name string) (metadata.FileHandle, error, bool) {
 		if name == "myfile.txt" {
 			return nil, &metadata.StoreError{Code: metadata.ErrNotFound, Message: "concurrently unlinked"}, true
 		}
@@ -396,7 +330,7 @@ func TestMove_AbortsWhenDestinationAppearedInTransaction(t *testing.T) {
 
 	// A racing rename claimed the destination name after the advisory read
 	// reported it free.
-	fx.faulty.getChild = func(dir metadata.FileHandle, name string) (metadata.FileHandle, error, bool) {
+	fx.faulty.getChild = func(name string) (metadata.FileHandle, error, bool) {
 		if name == "moved.txt" {
 			return winner, nil, true
 		}

--- a/pkg/metadata/tx_integrity_test.go
+++ b/pkg/metadata/tx_integrity_test.go
@@ -129,6 +129,12 @@ type faultyStore struct {
 	failID uuid.UUID // file ID whose PutFile should fail
 	// failLinkCountID is the file ID whose in-transaction GetLinkCount fails.
 	failLinkCountID uuid.UUID
+	// getChild, when set, intercepts in-transaction GetChild lookups. It
+	// returns the substituted result plus ok=true to override, or ok=false to
+	// fall through to the real transaction. This simulates a concurrent
+	// rename/unlink retargeting a name in the window between the advisory
+	// pre-transaction read and the transaction body.
+	getChild func(dir metadata.FileHandle, name string) (metadata.FileHandle, error, bool)
 }
 
 func (f *faultyStore) WithTransaction(ctx context.Context, fn func(tx metadata.Transaction) error) error {
@@ -137,6 +143,7 @@ func (f *faultyStore) WithTransaction(ctx context.Context, fn func(tx metadata.T
 			Transaction:     tx,
 			failID:          f.failID,
 			failLinkCountID: f.failLinkCountID,
+			getChild:        f.getChild,
 		})
 	})
 }
@@ -145,6 +152,7 @@ type faultyTx struct {
 	metadata.Transaction
 	failID          uuid.UUID
 	failLinkCountID uuid.UUID
+	getChild        func(dir metadata.FileHandle, name string) (metadata.FileHandle, error, bool)
 }
 
 func (t *faultyTx) PutFile(ctx context.Context, file *metadata.File) error {
@@ -161,6 +169,15 @@ func (t *faultyTx) GetLinkCount(ctx context.Context, handle metadata.FileHandle)
 		}
 	}
 	return t.Transaction.GetLinkCount(ctx, handle)
+}
+
+func (t *faultyTx) GetChild(ctx context.Context, dir metadata.FileHandle, name string) (metadata.FileHandle, error) {
+	if t.getChild != nil {
+		if handle, err, ok := t.getChild(dir, name); ok {
+			return handle, err
+		}
+	}
+	return t.Transaction.GetChild(ctx, dir, name)
 }
 
 // TestMove_RollsBackOnPutFileFailure asserts the rename is atomic: when the
@@ -234,6 +251,168 @@ func TestMove_RollsBackOnPutFileFailure(t *testing.T) {
 	// ...and the destination name was NOT created.
 	_, err = store.GetChild(ctx, destHandle, "moved.txt")
 	require.Error(t, err, "destination entry must not exist after rollback")
+}
+
+// ============================================================================
+// In-transaction rechecks of state read before the transaction
+// ============================================================================
+
+// faultyFixture builds a service backed by a fault-injectable store, with a
+// share root already created. Callers arm the fault just before the operation
+// under test so setup writes run unimpeded.
+type faultyFixture struct {
+	store  *memory.MemoryMetadataStore
+	faulty *faultyStore
+	svc    *metadata.Service
+	root   metadata.FileHandle
+	ctx    *metadata.AuthContext
+}
+
+func newFaultyFixture(t *testing.T) *faultyFixture {
+	t.Helper()
+	ctx := context.Background()
+	const shareName = "/test"
+
+	store := memory.NewMemoryMetadataStoreWithDefaults()
+	rootFile, err := store.CreateRootDirectory(ctx, shareName, &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory,
+		Mode: 0777,
+	})
+	require.NoError(t, err)
+	rootHandle, err := metadata.EncodeShareHandle(shareName, rootFile.ID)
+	require.NoError(t, err)
+
+	faulty := &faultyStore{Store: store}
+	svc := metadata.New()
+	require.NoError(t, svc.RegisterStoreForShare(shareName, faulty))
+
+	return &faultyFixture{
+		store:  store,
+		faulty: faulty,
+		svc:    svc,
+		root:   rootHandle,
+		ctx: &metadata.AuthContext{
+			Context:    ctx,
+			AuthMethod: "unix",
+			Identity: &metadata.Identity{
+				UID:  metadata.Uint32Ptr(0),
+				GID:  metadata.Uint32Ptr(0),
+				GIDs: []uint32{0},
+			},
+			ClientAddr: "127.0.0.1",
+		},
+	}
+}
+
+// TestCreateDirectory_AbortsOnParentLinkCountFailure asserts that a failed
+// parent GetLinkCount rolls the whole mkdir back. Previously the error was
+// discarded and the transaction still committed the new directory and its
+// parent edge, leaving the parent's ".." link count permanently one short.
+func TestCreateDirectory_AbortsOnParentLinkCountFailure(t *testing.T) {
+	t.Parallel()
+	fx := newFaultyFixture(t)
+	ctx := context.Background()
+
+	_, rootID, err := metadata.DecodeFileHandle(fx.root)
+	require.NoError(t, err)
+
+	// Arm the fault on the parent's link-count read.
+	fx.faulty.failLinkCountID = rootID
+
+	_, _, err = fx.svc.CreateDirectory(fx.ctx, fx.root, "sub", &metadata.FileAttr{Mode: 0755})
+	require.Error(t, err, "mkdir must surface the parent link-count read failure")
+	require.ErrorIs(t, err, errLinkCountInjected)
+
+	// Full rollback: the directory entry was not created.
+	_, err = fx.store.GetChild(ctx, fx.root, "sub")
+	require.Error(t, err, "the new directory must not survive the rolled-back mkdir")
+}
+
+// TestCreateDirectory_BumpsParentLinkCount is the baseline: with no fault, the
+// parent's link count still gains the new "..".
+func TestCreateDirectory_BumpsParentLinkCount(t *testing.T) {
+	t.Parallel()
+	fx := newFaultyFixture(t)
+	ctx := context.Background()
+
+	before, err := fx.store.GetLinkCount(ctx, fx.root)
+	require.NoError(t, err)
+
+	_, _, err = fx.svc.CreateDirectory(fx.ctx, fx.root, "sub", &metadata.FileAttr{Mode: 0755})
+	require.NoError(t, err)
+
+	after, err := fx.store.GetLinkCount(ctx, fx.root)
+	require.NoError(t, err)
+	assert.Equal(t, before+1, after, "mkdir must bump the parent's link count")
+}
+
+// TestMove_AbortsWhenSourceEntryChangedInTransaction asserts Move re-resolves
+// the source name inside the transaction. The pre-transaction GetChild is
+// advisory: a concurrent rename or unlink can drop the name in the gap, and
+// without the recheck Move would relink the stale handle under the destination
+// name, resurrecting an entry that no longer exists.
+func TestMove_AbortsWhenSourceEntryChangedInTransaction(t *testing.T) {
+	t.Parallel()
+	fx := newFaultyFixture(t)
+	ctx := context.Background()
+
+	_, _, err := fx.svc.CreateFile(fx.ctx, fx.root, "myfile.txt", &metadata.FileAttr{Mode: 0644})
+	require.NoError(t, err)
+
+	// The source name vanishes between the advisory read and the transaction.
+	fx.faulty.getChild = func(dir metadata.FileHandle, name string) (metadata.FileHandle, error, bool) {
+		if name == "myfile.txt" {
+			return nil, &metadata.StoreError{Code: metadata.ErrNotFound, Message: "concurrently unlinked"}, true
+		}
+		return nil, nil, false
+	}
+
+	_, err = fx.svc.Move(fx.ctx, fx.root, "myfile.txt", fx.root, "moved.txt")
+	require.Error(t, err, "Move must abort when the source entry changed inside the transaction")
+
+	// The destination name was never created.
+	_, err = fx.store.GetChild(ctx, fx.root, "moved.txt")
+	require.Error(t, err, "destination entry must not exist after the aborted rename")
+}
+
+// TestMove_AbortsWhenDestinationAppearedInTransaction asserts Move re-resolves
+// the destination name inside the transaction. Two renames onto the same
+// destination both saw it absent before their transactions; without the
+// recheck both SetChild and the loser's inode is orphaned.
+func TestMove_AbortsWhenDestinationAppearedInTransaction(t *testing.T) {
+	t.Parallel()
+	fx := newFaultyFixture(t)
+	ctx := context.Background()
+
+	_, _, err := fx.svc.CreateFile(fx.ctx, fx.root, "myfile.txt", &metadata.FileAttr{Mode: 0644})
+	require.NoError(t, err)
+	_, _, err = fx.svc.CreateFile(fx.ctx, fx.root, "winner.txt", &metadata.FileAttr{Mode: 0644})
+	require.NoError(t, err)
+
+	srcHandle, err := fx.store.GetChild(ctx, fx.root, "myfile.txt")
+	require.NoError(t, err)
+	winner, err := fx.store.GetChild(ctx, fx.root, "winner.txt")
+	require.NoError(t, err)
+
+	// A racing rename claimed the destination name after the advisory read
+	// reported it free.
+	fx.faulty.getChild = func(dir metadata.FileHandle, name string) (metadata.FileHandle, error, bool) {
+		if name == "moved.txt" {
+			return winner, nil, true
+		}
+		return nil, nil, false
+	}
+
+	_, err = fx.svc.Move(fx.ctx, fx.root, "myfile.txt", fx.root, "moved.txt")
+	require.Error(t, err, "Move must abort when the destination appeared inside the transaction")
+	var storeErr *metadata.StoreError
+	require.ErrorAs(t, err, &storeErr)
+	assert.Equal(t, metadata.ErrConflict, storeErr.Code)
+
+	// The source entry survives the aborted rename.
+	stillThere, err := fx.store.GetChild(ctx, fx.root, "myfile.txt")
+	require.NoError(t, err, "source entry must survive the aborted rename")
+	assert.Equal(t, string(srcHandle), string(stillThere))
 }
 
 // TestRemoveFile_LinkCountReadFailureAborts pins that an unreadable link count

--- a/pkg/metadata/tx_integrity_test.go
+++ b/pkg/metadata/tx_integrity_test.go
@@ -118,12 +118,13 @@ var errPutFileInjected = errors.New("injected PutFile failure")
 // is called for the targeted file ID.
 var errLinkCountInjected = errors.New("injected GetLinkCount failure")
 
-// faultyStore wraps a MetadataStore and, inside WithTransaction, makes
-// tx.PutFile fail for a single targeted file ID. Everything else delegates to
-// the real store so the rest of the rename runs normally up to the injected
-// failure. Keying on the inode ID (not File.Path) keeps the fault stable: Path
-// is now always derived on read (#1166), so it is no longer a reliable
-// discriminator at PutFile time.
+// faultyStore wraps a MetadataStore and, inside WithTransaction, injects
+// targeted failures into tx.PutFile, tx.GetLinkCount and tx.GetChild — each
+// keyed by its own field, so a test arms only the one it needs. Everything
+// else delegates to the real store, so the operation under test runs normally
+// up to the injected failure. The faults key on the inode ID rather than
+// File.Path, because Path is always derived on read and so is not a reliable
+// discriminator at call time.
 type faultyStore struct {
 	metadata.Store
 	failID uuid.UUID // file ID whose PutFile should fail


### PR DESCRIPTION
Closes a batch of MED findings from the data-plane audit (`.planning/audits/2026-08-05-dataplane/report.md`). Each finding was re-verified against current `develop` before any change.

- **`createEntry` dropped the parent's `..` link-count bump on mkdir** (`pkg/metadata/file_create.go`) — FIXED. A failed `tx.GetLinkCount(parent)` was discarded with `if err == nil`, so the transaction still committed the new directory and its parent edge while the parent's nlink stayed one short — permanently, and silently. On postgres/sqlite the same read collapses errors into `(0, nil)`, so the parent was set to 1 instead. The read is now tx-critical and propagates, matching how `Move` and `RemoveDirectory` already treat it.

- **`Move` had no in-transaction recheck of the source/destination entries** (`pkg/metadata/file_modify.go`) — FIXED. Both names were resolved with `store.GetChild` *outside* the transaction; the transaction body re-read only the two directory inodes and then acted on the stale handles. No lock covers a file rename (`lockCreateName` is create-only, `lockParentLinks` only fires for cross-parent directory renames), so two concurrent renames onto the same destination both `SetChild` — last writer wins and the loser's inode is orphaned. Badger's SSI could not see it either, because the child key was never read through the transaction. Both edges are now re-resolved via `tx.GetChild` inside the transaction and the rename aborts with `ErrConflict` if either changed; that also enters the child keys in the transaction's read set so an optimistic backend detects the conflict.

- **`WaitForGraph` check-then-act pair** (`pkg/metadata/lock/deadlock.go`) — ALREADY-FIXED, no change. The separate `WouldCauseCycle` + `AddWaiter` pair no longer exists: `adb8bf02` (#1935) collapsed them into `TryAddWaiter`, which holds one write lock across the cycle check and the edge insert, and the only caller (`internal/adapter/smb/handlers/lock_async.go:55`) uses it. This is exactly the fix the report recommended.

- **Share-lifecycle writes bypassed the store's own SSI-conflict retry** (`pkg/metadata/store/badger/shares.go`) — FIXED. `CreateShare`, `UpdateShareOptions`, `DeleteShare` and `CreateRootDirectory` called `s.db.Update` directly, so a single `badger.ErrConflict` aborted the operation and escaped unmapped. `DeleteShare` is the worst case — `deleteShareFiles` reads every `f:` row into the transaction's read set, the highest conflict probability in the package, unretried. All four now go through the existing `s.updateWithConflictRetry`. Their closures assign (never accumulate into) the post-commit `freedBytes`/`quotaFreed`/`rootFile` outputs, so a retry cannot double-count. `deleteShareFiles`' doc comment, which asserted a retry that did not exist on this path, is corrected rather than deleted — it is now true.

- **Link-count-with-type-default lookup reinvented 6 times + a real manifest bug** (`pkg/metadata/store/badger/`) — FIXED. The `Get(keyLinkCount)` → nil/`ErrKeyNotFound` → default 2 (dir) / 1 block was open-coded at six sites while `fileLinkCountTxn` implemented exactly it; all six now call the helper (~100 lines deleted). The bug hiding in the duplication: the transaction-scoped `GetFileByPayloadID` legacy full-scan branch built its result inline and returned **without `loadManifest`**, so a row not present in the `pl:` index resolved inside a transaction came back with an empty `Blocks` slice — a silently truncated manifest for `runtime/shares/service.go`, `shares/coordinator.go` and `metadata/block_record_store.go`, all of which read `File.Blocks` off it. The store-level twin did call it. The scan branch now routes through `loadEnrichedFileByID`, the same path the index fast path uses.

## Tests

Each behavioural fix has a test that fails when the fix is reverted (verified):

- `TestCreateDirectory_AbortsOnParentLinkCountFailure`
- `TestMove_AbortsWhenSourceEntryChangedInTransaction`
- `TestMove_AbortsWhenDestinationAppearedInTransaction`
- `TestPayloadIndex_TxScanFallbackReturnsManifest` — fails pre-fix with `"[]" should have 4 item(s), but has 0`

The existing `faultyStore`/`faultyTx` harness in `tx_integrity_test.go` was extended with `GetLinkCount` and `GetChild` interception rather than adding a second harness, and its fixture now builds on `newTestFixture` instead of hand-rolling a second one (which also de-duplicated the pre-existing `TestMove_RollsBackOnPutFileFailure` setup).

The store-level `GetFileByPayloadID` scan fallback was routed through `loadEnrichedFileByID` as well, so both surfaces share one enrichment implementation — the drift between them is what produced the missing-manifest bug in the first place.

## Verification

`gofmt -l .` clean · `go build ./...` · `go test ./pkg/metadata/...` · `go test -race ./pkg/metadata/ ./pkg/metadata/store/badger/ ./pkg/metadata/lock/` · `golangci-lint run ./pkg/metadata/ ./pkg/metadata/store/badger/` — all green.
