### PR TITLE
fix: sweep the LOW audit findings classified gaps

### DIFF
--- a/pkg/block/blockstoretest/conformance.go
+++ b/pkg/block/blockstoretest/conformance.go
@@ -34,6 +34,10 @@ type Factory func(t *testing.T) (block.Store, func())
 //
 //   - Put + Get round-trip with no-aliasing of internal storage.
 //   - Get on an unstored hash returns block.ErrChunkNotFound.
+//   - Has on an unstored hash returns (false, nil) — a definitive miss,
+//     never (false, err).
+//   - Head on an unstored hash returns block.ErrChunkNotFound.
+//   - GetRange on an unstored hash returns block.ErrChunkNotFound.
 //   - GetRange returns the requested byte sub-range.
 //   - Delete is durable and is observable via a subsequent Get miss.
 //   - Walk enumerates every object with non-zero LastModified.
@@ -63,6 +67,9 @@ func BlockStoreConformance(t *testing.T, factory Factory) {
 	t.Helper()
 	t.Run("Put_Get_Roundtrip", func(t *testing.T) { testPutGetRoundtrip(t, factory) })
 	t.Run("Get_NotFound", func(t *testing.T) { testGetNotFound(t, factory) })
+	t.Run("Has_NotFound", func(t *testing.T) { testHasNotFound(t, factory) })
+	t.Run("Head_NotFound", func(t *testing.T) { testHeadNotFound(t, factory) })
+	t.Run("GetRange_NotFound", func(t *testing.T) { testGetRangeNotFound(t, factory) })
 	t.Run("GetRange", func(t *testing.T) { testGetRange(t, factory) })
 	t.Run("Delete", func(t *testing.T) { testDelete(t, factory) })
 	t.Run("Walk", func(t *testing.T) { testWalk(t, factory) })
@@ -132,13 +139,7 @@ func testGetNotFound(t *testing.T, factory Factory) {
 	t.Cleanup(cleanup)
 	ctx := context.Background()
 
-	// Non-zero arbitrary hash so the assertion does not collide with any
-	// hypothetical "all-zero hash" sentinel a backend might special-case.
-	var missing block.ContentHash
-	missing[0] = 0xDE
-	missing[31] = 0xAD
-
-	data, err := bs.Get(ctx, missing)
+	data, err := bs.Get(ctx, missingHash())
 	if err == nil {
 		t.Fatalf("Get on missing hash: expected error, got nil (data len=%d)", len(data))
 	}
@@ -149,6 +150,69 @@ func testGetNotFound(t *testing.T, factory Factory) {
 	}
 	if data != nil {
 		t.Fatalf("Get on missing hash: want nil data, got %d bytes", len(data))
+	}
+}
+
+// missingHash returns a non-zero hash no fixture in this suite stores, so a
+// miss assertion cannot collide with an "all-zero hash" sentinel a backend
+// might special-case.
+func missingHash() block.ContentHash {
+	var h block.ContentHash
+	h[0] = 0xDE
+	h[31] = 0xAD
+	return h
+}
+
+func testHasNotFound(t *testing.T, factory Factory) {
+	bs, cleanup := factory(t)
+	t.Cleanup(cleanup)
+	ctx := context.Background()
+
+	// Store an unrelated object first: a backend that answers Has from a
+	// bulk listing must still report a definitive miss for a key it does
+	// not hold, not "the store is empty so anything goes".
+	other := []byte("has-not-found: unrelated resident object")
+	if err := bs.Put(ctx, blake3Sum(other), other); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	// BlockStore contract: (false, nil) is a confirmed miss; an error means
+	// the backend could not answer. Callers distinguish the two, so a
+	// backend that folds a miss into an error breaks them.
+	ok, err := bs.Has(ctx, missingHash())
+	if err != nil {
+		t.Fatalf("Has on missing hash: want (false, nil), got error %v", err)
+	}
+	if ok {
+		t.Fatal("Has on missing hash: want false, got true")
+	}
+}
+
+func testHeadNotFound(t *testing.T, factory Factory) {
+	bs, cleanup := factory(t)
+	t.Cleanup(cleanup)
+	ctx := context.Background()
+
+	m, err := bs.Head(ctx, missingHash())
+	if err == nil {
+		t.Fatalf("Head on missing hash: expected error, got nil (meta=%+v)", m)
+	}
+	if !errors.Is(err, block.ErrChunkNotFound) {
+		t.Fatalf("Head on missing hash: want ErrChunkNotFound, got %v", err)
+	}
+}
+
+func testGetRangeNotFound(t *testing.T, factory Factory) {
+	bs, cleanup := factory(t)
+	t.Cleanup(cleanup)
+	ctx := context.Background()
+
+	data, err := bs.GetRange(ctx, missingHash(), 0, 8)
+	if err == nil {
+		t.Fatalf("GetRange on missing hash: expected error, got nil (data len=%d)", len(data))
+	}
+	if !errors.Is(err, block.ErrChunkNotFound) {
+		t.Fatalf("GetRange on missing hash: want ErrChunkNotFound, got %v", err)
 	}
 }
 

--- a/pkg/block/engine/sync_health.go
+++ b/pkg/block/engine/sync_health.go
@@ -143,6 +143,15 @@ func (hm *HealthMonitor) monitorLoop(ctx context.Context) {
 	for {
 		select {
 		case <-ticker.C:
+			// A tick queued while the previous probe was running is still
+			// pending when a stop arrives, and select picks randomly between
+			// the two. Re-check the stop first so Stop's join never waits on
+			// one more probe round-trip against an unreachable remote.
+			select {
+			case <-hm.stopCh:
+				return
+			default:
+			}
 			err := hm.probeFunc(ctx)
 			if err != nil {
 				// Don't count context cancellation as a health failure — we're shutting down.

--- a/pkg/block/engine/sync_health_test.go
+++ b/pkg/block/engine/sync_health_test.go
@@ -240,3 +240,58 @@ func TestHealthMonitor_OutageDuration(t *testing.T) {
 		t.Fatalf("expected 0 outage duration after recovery, got %v", d)
 	}
 }
+
+// TestHealthMonitor_StopJoinsProbe pins that Stop() waits for an in-flight
+// probe. The probe dials the remote store, and Syncer.Close() stops the monitor
+// right before the owning Store closes that remote — a Stop that only signalled
+// would leave a probe reading a closed store.
+func TestHealthMonitor_StopJoinsProbe(t *testing.T) {
+	// Each probe publishes its own release channel and blocks on it, so the
+	// test controls exactly when a probe finishes without racing on shared
+	// channel variables.
+	probes := make(chan chan struct{}, 4)
+
+	hm := NewHealthMonitor(func(context.Context) error {
+		rel := make(chan struct{})
+		probes <- rel
+		<-rel
+		return nil
+	}, fastHealthConfig())
+
+	// Start runs an eager synchronous probe before launching the loop; let it
+	// through so the probe pinned below is the ticker-driven one.
+	go hm.Start(context.Background())
+	select {
+	case rel := <-probes:
+		close(rel)
+	case <-time.After(5 * time.Second):
+		t.Fatal("eager probe never ran")
+	}
+
+	var pinned chan struct{}
+	select {
+	case pinned = <-probes:
+	case <-time.After(5 * time.Second):
+		t.Fatal("loop probe never ran")
+	}
+
+	stopDone := make(chan struct{})
+	go func() {
+		hm.Stop()
+		close(stopDone)
+	}()
+
+	select {
+	case <-stopDone:
+		t.Fatal("HealthMonitor.Stop returned while a probe was still in flight — monitorLoop was not joined")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	close(pinned)
+
+	select {
+	case <-stopDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("HealthMonitor.Stop did not return after the probe was released")
+	}
+}

--- a/pkg/block/engine/syncer_shutdown_test.go
+++ b/pkg/block/engine/syncer_shutdown_test.go
@@ -121,3 +121,63 @@ func TestSyncerClose_JoinsInFlightDownloadWorker(t *testing.T) {
 		t.Fatal("metadata store was accessed after Close — download worker outlived Syncer.Close (#1722)")
 	}
 }
+
+// TestSyncerClose_JoinsCarveDispatcher pins the second half of the shutdown
+// contract: Close() must not return while the background carve dispatcher is
+// still inside the local store. The dispatcher touches local (and, through it,
+// the remote) and the owning Store closes both immediately after Close returns,
+// so an unjoined pass is a use-after-close.
+//
+// Deterministic: the fixture's Carve blocks until the test releases it, and the
+// syncer has no remote (DrainAllUploads short-circuits) and no queue, so the
+// goroutine join is the only thing Close can block on.
+func TestSyncerClose_JoinsCarveDispatcher(t *testing.T) {
+	fl := &carveFanoutLocal{
+		files:   []string{"pinned"},
+		started: make(chan string, 1),
+		release: make(chan struct{}),
+		carved:  map[string]int{},
+	}
+
+	cfg := DefaultConfig()
+	cfg.UploadInterval = time.Millisecond
+	m := &Syncer{
+		local:         fl,
+		uploadLimiter: newDynamicSemaphore(2),
+		stopCh:        make(chan struct{}),
+		config:        cfg,
+	}
+	m.carveActive.Store(true)
+
+	m.startPeriodicUploader(context.Background())
+
+	select {
+	case <-fl.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("carve dispatcher never entered local.Carve")
+	}
+
+	closeDone := make(chan struct{})
+	go func() {
+		_ = m.Close()
+		close(closeDone)
+	}()
+
+	select {
+	case <-closeDone:
+		t.Fatal("Syncer.Close returned while a carve pass was still inside the local store — the carve dispatcher was not joined")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	close(fl.release)
+
+	select {
+	case <-closeDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Syncer.Close did not return after the carve was released")
+	}
+
+	if n := fl.inFlight.Load(); n != 0 {
+		t.Fatalf("carve still in flight after Close returned: %d", n)
+	}
+}

--- a/pkg/controlplane/runtime/blockstore_init.go
+++ b/pkg/controlplane/runtime/blockstore_init.go
@@ -1,12 +1,15 @@
 package runtime
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/marmos91/dittofs/internal/pathutil"
+	"github.com/marmos91/dittofs/pkg/block/encryption"
+	"github.com/marmos91/dittofs/pkg/block/encryption/keyprovider"
 	"github.com/marmos91/dittofs/pkg/block/engine"
 	s3store "github.com/marmos91/dittofs/pkg/block/remote/s3"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
@@ -97,6 +100,9 @@ func ValidateBlockStoreConfig(kind models.BlockStoreKind, storeType string, cfg 
 			if err := validateParallelUploads(config); err != nil {
 				return err
 			}
+			if err := validateEncryptionSubconfig(config); err != nil {
+				return err
+			}
 			return nil
 		default:
 			return fmt.Errorf("unsupported remote block store type: %s", storeType)
@@ -154,6 +160,49 @@ func validateParallelUploads(config map[string]any) error {
 	}
 	if n < 0 || n > engine.MaxParallelUploads {
 		return fmt.Errorf("parallel_uploads: must be between 0 and %d (got %d)", engine.MaxParallelUploads, int(n))
+	}
+	return nil
+}
+
+// validateEncryptionSubconfig accepts the parsed `encryption` value from a
+// BlockStoreConfig and verifies its shape. An absent key is allowed
+// (encryption is opt-in). When present, the value is run through the same
+// encryption.ParsePolicy the attach path uses — so the accepted object shape
+// and AEAD names never drift from it — and the key config is then checked for
+// the fields its provider kind requires. Reachability (opening the key file,
+// dialling the KMIP server) is left to attach time.
+func validateEncryptionSubconfig(config map[string]any) error {
+	raw, ok := config["encryption"]
+	if !ok {
+		return nil
+	}
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return fmt.Errorf("encryption: %w", err)
+	}
+	policy, err := encryption.ParsePolicy(encoded)
+	if err != nil {
+		return err
+	}
+	switch policy.Key.Kind {
+	case keyprovider.KindLocal:
+		if policy.Key.File == "" {
+			return errors.New("encryption.key.file is required for the local key provider")
+		}
+	case keyprovider.KindKMIP:
+		if policy.Key.Endpoint == "" {
+			return errors.New("encryption.key.endpoint is required for the kmip key provider")
+		}
+		if policy.Key.KeyUID == "" {
+			return errors.New("encryption.key.key_uid is required for the kmip key provider")
+		}
+		if policy.Key.ClientCert == "" || policy.Key.ClientKey == "" {
+			return errors.New("encryption.key.client_cert and encryption.key.client_key are required for the kmip key provider")
+		}
+	case "":
+		return errors.New("encryption.key.kind is required (want local or kmip)")
+	default:
+		return fmt.Errorf("encryption.key.kind: unsupported value %q (want local or kmip)", policy.Key.Kind)
 	}
 	return nil
 }

--- a/pkg/controlplane/runtime/blockstore_init_test.go
+++ b/pkg/controlplane/runtime/blockstore_init_test.go
@@ -117,3 +117,86 @@ func TestValidateParallelUploads(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateEncryptionSubconfig(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     map[string]any
+		wantErr string // substring; "" means accept
+	}{
+		{"absent", map[string]any{}, ""},
+		{"local_ok", map[string]any{"encryption": map[string]any{
+			"key": map[string]any{"kind": "local", "file": "/etc/dittofs/share.key"},
+		}}, ""},
+		{"local_with_aead", map[string]any{"encryption": map[string]any{
+			"aead": "xchacha20-poly1305",
+			"key":  map[string]any{"kind": "local", "file": "/k"},
+		}}, ""},
+		{"kmip_ok", map[string]any{"encryption": map[string]any{
+			"key": map[string]any{
+				"kind": "kmip", "endpoint": "kmip.example:5696", "key_uid": "uid-1",
+				"client_cert": "/c.pem", "client_key": "/c.key",
+			},
+		}}, ""},
+		{"wrong_type_block", map[string]any{"encryption": "on"}, "expected JSON object"},
+		{"unknown_aead", map[string]any{"encryption": map[string]any{
+			"aead": "rot13",
+			"key":  map[string]any{"kind": "local", "file": "/k"},
+		}}, "unsupported aead"},
+		{"missing_kind", map[string]any{"encryption": map[string]any{}}, "kind is required"},
+		{"unknown_kind", map[string]any{"encryption": map[string]any{
+			"key": map[string]any{"kind": "vault"},
+		}}, "unsupported value"},
+		{"local_missing_file", map[string]any{"encryption": map[string]any{
+			"key": map[string]any{"kind": "local"},
+		}}, "file is required"},
+		{"kmip_missing_endpoint", map[string]any{"encryption": map[string]any{
+			"key": map[string]any{"kind": "kmip", "key_uid": "uid-1"},
+		}}, "endpoint is required"},
+		{"kmip_missing_key_uid", map[string]any{"encryption": map[string]any{
+			"key": map[string]any{"kind": "kmip", "endpoint": "kmip.example:5696"},
+		}}, "key_uid is required"},
+		{"kmip_missing_client_cert", map[string]any{"encryption": map[string]any{
+			"key": map[string]any{
+				"kind": "kmip", "endpoint": "kmip.example:5696", "key_uid": "uid-1",
+				"client_key": "/c.key",
+			},
+		}}, "client_cert"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateEncryptionSubconfig(tc.cfg)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q does not contain %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestValidateBlockStoreConfig_S3_RejectsBadEncryption pins that the s3 case
+// actually calls the encryption validator — a validator nobody wires up is
+// dead code, and the bad config would only surface at share-attach time.
+func TestValidateBlockStoreConfig_S3_RejectsBadEncryption(t *testing.T) {
+	cfg := configMap{
+		"bucket":            "b",
+		"access_key_id":     "ak",
+		"secret_access_key": "sk",
+		"encryption":        map[string]any{"key": map[string]any{"kind": "vault"}},
+	}
+	err := ValidateBlockStoreConfig(models.BlockStoreKindRemote, "s3", cfg)
+	if err == nil {
+		t.Fatal("want error for an unsupported key provider kind, got nil")
+	}
+	if !strings.Contains(err.Error(), "encryption.key.kind") {
+		t.Fatalf("error %q does not mention encryption.key.kind", err)
+	}
+}

--- a/pkg/metadata/auth_identity.go
+++ b/pkg/metadata/auth_identity.go
@@ -289,17 +289,30 @@ func ApplyIdentityMapping(identity *Identity, mapping *IdentityMapping) *Identit
 
 	// Map privileged users to anonymous (root squashing)
 	if mapping.MapPrivilegedToAnonymous {
+		squashed := false
+
 		// Unix: Check for root (UID 0)
 		if result.UID != nil && *result.UID == 0 {
 			result.UID = mapping.AnonymousUID
 			result.GID = mapping.AnonymousGID
 			result.GIDs = nil
+			squashed = true
 		}
 
 		// Windows: Check for Administrator SID
 		if result.SID != nil && IsAdministratorSID(*result.SID) {
 			result.SID = mapping.AnonymousSID
 			result.GroupSIDs = nil
+			squashed = true
+		}
+
+		// Drop the named principal along with the numeric identity: ACL
+		// evaluation matches ACEs on Username/Domain too, so leaving them set
+		// would let an ACE naming the squashed principal re-grant exactly the
+		// privilege the squash removed.
+		if squashed {
+			result.Username = ""
+			result.Domain = ""
 		}
 	}
 

--- a/pkg/metadata/authentication_test.go
+++ b/pkg/metadata/authentication_test.go
@@ -247,6 +247,71 @@ func TestApplyIdentityMapping(t *testing.T) {
 		assert.Equal(t, "testuser", result.Username)
 		assert.Equal(t, "EXAMPLE", result.Domain)
 	})
+
+	t.Run("MapPrivilegedToAnonymous clears Username and Domain for root", func(t *testing.T) {
+		t.Parallel()
+		identity := &Identity{
+			UID:      Uint32Ptr(0),
+			GID:      Uint32Ptr(0),
+			Username: "root",
+			Domain:   "EXAMPLE",
+		}
+		mapping := &IdentityMapping{
+			MapPrivilegedToAnonymous: true,
+			AnonymousUID:             &anonUID,
+			AnonymousGID:             &anonGID,
+		}
+
+		result := ApplyIdentityMapping(identity, mapping)
+
+		// ACL evaluation resolves Who from Username/Domain, so a squashed
+		// identity that keeps them can still match an ACE naming the
+		// privileged principal — re-granting what the squash removed.
+		assert.Empty(t, result.Username)
+		assert.Empty(t, result.Domain)
+	})
+
+	t.Run("MapPrivilegedToAnonymous clears Username and Domain for administrator SID", func(t *testing.T) {
+		t.Parallel()
+		adminSID := "S-1-5-32-544"
+		identity := &Identity{
+			SID:      &adminSID,
+			Username: "Administrator",
+			Domain:   "CORP",
+		}
+		mapping := &IdentityMapping{
+			MapPrivilegedToAnonymous: true,
+			AnonymousSID:             &anonSID,
+		}
+
+		result := ApplyIdentityMapping(identity, mapping)
+
+		assert.Empty(t, result.Username)
+		assert.Empty(t, result.Domain)
+	})
+
+	t.Run("MapPrivilegedToAnonymous keeps Username and Domain for unprivileged identity", func(t *testing.T) {
+		t.Parallel()
+		userSID := "S-1-5-21-1-2-3-1001"
+		identity := &Identity{
+			UID:      Uint32Ptr(1000),
+			GID:      Uint32Ptr(1000),
+			SID:      &userSID,
+			Username: "testuser",
+			Domain:   "EXAMPLE",
+		}
+		mapping := &IdentityMapping{
+			MapPrivilegedToAnonymous: true,
+			AnonymousUID:             &anonUID,
+			AnonymousGID:             &anonGID,
+			AnonymousSID:             &anonSID,
+		}
+
+		result := ApplyIdentityMapping(identity, mapping)
+
+		assert.Equal(t, "testuser", result.Username)
+		assert.Equal(t, "EXAMPLE", result.Domain)
+	})
 }
 
 // ============================================================================

--- a/pkg/metadata/file_remove.go
+++ b/pkg/metadata/file_remove.go
@@ -170,8 +170,10 @@ func (s *Service) RemoveFile(ctx *AuthContext, parentHandle FileHandle, name str
 		// detection so a racing writer triggers an automatic retry.
 		linkCount, lcErr := tx.GetLinkCount(ctx.Context, fileHandle)
 		if lcErr != nil {
-			// If we can't get link count, assume 1.
-			linkCount = 1
+			// Never guess the count. Assuming "last link" would report the
+			// content free while another hard link still references it, so an
+			// unreadable count aborts the remove.
+			return lcErr
 		}
 
 		// Handle link count

--- a/pkg/metadata/store/badger/read_cache_test.go
+++ b/pkg/metadata/store/badger/read_cache_test.go
@@ -99,3 +99,49 @@ func BenchmarkGetFileForRead_Cached(b *testing.B) {
 		}
 	}
 }
+
+// TestCreateRootDirectory_InvalidatesRootReadCache guards the re-attach path:
+// CreateRootDirectory reconciles an existing root's mode/UID/GID against the
+// configured attrs with a raw txn.Set, which bypasses the dirty-file tracking
+// that normally drops read-cache entries. A cached root must not survive that
+// rewrite, or every later lookup serves the previous ownership.
+func TestCreateRootDirectory_InvalidatesRootReadCache(t *testing.T) {
+	s, err := NewBadgerMetadataStoreWithDefaults(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = s.Close() }()
+	ctx := context.Background()
+
+	attr := &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o755, UID: 1000, GID: 1000}
+	root, err := s.CreateRootDirectory(ctx, "/s", attr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handle, err := metadata.EncodeFileHandle(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seeded, err := s.GetFileForRead(ctx, handle)
+	if err != nil {
+		t.Fatalf("seed read: %v", err)
+	}
+	if seeded.UID != 1000 {
+		t.Fatalf("seed read: uid=%d, want 1000", seeded.UID)
+	}
+
+	// Re-attach the share with different ownership, as a config change does.
+	reattached := &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o755, UID: 2000, GID: 2000}
+	if _, err := s.CreateRootDirectory(ctx, "/s", reattached); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.GetFileForRead(ctx, handle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.UID != 2000 || got.GID != 2000 {
+		t.Fatalf("stale root served from cache after re-attach: uid=%d gid=%d, want 2000/2000", got.UID, got.GID)
+	}
+}

--- a/pkg/metadata/store/badger/shares.go
+++ b/pkg/metadata/store/badger/shares.go
@@ -450,8 +450,17 @@ func (s *BadgerMetadataStore) CreateRootDirectory(ctx context.Context, shareName
 	}
 
 	// Both branches (createNewRoot / loadExistingRoot) rewrite the share record,
-	// so drop any cached options for it after the commit.
+	// so drop any cached options for it after the commit. loadExistingRoot may
+	// also rewrite the root inode (mode/UID/GID reconciliation against the
+	// configured attrs), a write that bypasses WithTransaction's dirty-file
+	// tracking — so drop the root's own cache entries too, or a re-attach with
+	// changed ownership keeps serving the previous UID/GID.
 	s.shareCache.invalidate(shareName)
+	if rootFile != nil {
+		id := rootFile.ID.String()
+		s.readCache.invalidate(id)
+		s.parentCache.invalidate(id)
+	}
 
 	return rootFile, nil
 }

--- a/pkg/metadata/tx_integrity_test.go
+++ b/pkg/metadata/tx_integrity_test.go
@@ -114,6 +114,10 @@ func TestRemoveFile_ConcurrentCreateHardLink(t *testing.T) {
 // called for the targeted file ID.
 var errPutFileInjected = errors.New("injected PutFile failure")
 
+// errLinkCountInjected is returned by the fault-injecting tx when GetLinkCount
+// is called for the targeted file ID.
+var errLinkCountInjected = errors.New("injected GetLinkCount failure")
+
 // faultyStore wraps a MetadataStore and, inside WithTransaction, makes
 // tx.PutFile fail for a single targeted file ID. Everything else delegates to
 // the real store so the rest of the rename runs normally up to the injected
@@ -123,17 +127,24 @@ var errPutFileInjected = errors.New("injected PutFile failure")
 type faultyStore struct {
 	metadata.Store
 	failID uuid.UUID // file ID whose PutFile should fail
+	// failLinkCountID is the file ID whose in-transaction GetLinkCount fails.
+	failLinkCountID uuid.UUID
 }
 
 func (f *faultyStore) WithTransaction(ctx context.Context, fn func(tx metadata.Transaction) error) error {
 	return f.Store.WithTransaction(ctx, func(tx metadata.Transaction) error {
-		return fn(&faultyTx{Transaction: tx, failID: f.failID})
+		return fn(&faultyTx{
+			Transaction:     tx,
+			failID:          f.failID,
+			failLinkCountID: f.failLinkCountID,
+		})
 	})
 }
 
 type faultyTx struct {
 	metadata.Transaction
-	failID uuid.UUID
+	failID          uuid.UUID
+	failLinkCountID uuid.UUID
 }
 
 func (t *faultyTx) PutFile(ctx context.Context, file *metadata.File) error {
@@ -141,6 +152,15 @@ func (t *faultyTx) PutFile(ctx context.Context, file *metadata.File) error {
 		return errPutFileInjected
 	}
 	return t.Transaction.PutFile(ctx, file)
+}
+
+func (t *faultyTx) GetLinkCount(ctx context.Context, handle metadata.FileHandle) (uint32, error) {
+	if t.failLinkCountID != uuid.Nil {
+		if _, id, err := metadata.DecodeFileHandle(handle); err == nil && id == t.failLinkCountID {
+			return 0, errLinkCountInjected
+		}
+	}
+	return t.Transaction.GetLinkCount(ctx, handle)
 }
 
 // TestMove_RollsBackOnPutFileFailure asserts the rename is atomic: when the
@@ -214,4 +234,45 @@ func TestMove_RollsBackOnPutFileFailure(t *testing.T) {
 	// ...and the destination name was NOT created.
 	_, err = store.GetChild(ctx, destHandle, "moved.txt")
 	require.Error(t, err, "destination entry must not exist after rollback")
+}
+
+// TestRemoveFile_LinkCountReadFailureAborts pins that an unreadable link count
+// aborts the remove instead of being guessed as "last link". Guessing reports
+// the content free (a non-empty PayloadID the caller reaps) while a second hard
+// link still references it, so the blocks vanish out from under that link.
+func TestRemoveFile_LinkCountReadFailureAborts(t *testing.T) {
+	t.Parallel()
+	fx := newTestFixture(t)
+	ctx := context.Background()
+
+	faulty := &faultyStore{Store: fx.store}
+	svc := metadata.New()
+	require.NoError(t, svc.RegisterStoreForShare(fx.shareName, faulty))
+	authCtx := fx.rootContext()
+
+	_, _, err := svc.CreateFile(authCtx, fx.rootHandle, "a.txt", &metadata.FileAttr{Mode: 0644})
+	require.NoError(t, err)
+	target, err := fx.store.GetChild(ctx, fx.rootHandle, "a.txt")
+	require.NoError(t, err)
+	_, err = svc.CreateHardLink(authCtx, fx.rootHandle, "b.txt", target)
+	require.NoError(t, err)
+
+	_, targetID, err := metadata.DecodeFileHandle(target)
+	require.NoError(t, err)
+
+	// Arm the fault on the removed inode's link-count read, after setup.
+	faulty.failLinkCountID = targetID
+
+	removed, _, err := svc.RemoveFile(authCtx, fx.rootHandle, "a.txt")
+	require.ErrorIs(t, err, errLinkCountInjected, "an unreadable link count must abort the remove")
+	assert.Nil(t, removed, "no file record may be returned when the remove aborted")
+
+	// The entry survives, so the second link still resolves the content the
+	// caller would otherwise have reaped.
+	faulty.failLinkCountID = uuid.Nil
+	_, err = fx.store.GetChild(ctx, fx.rootHandle, "a.txt")
+	require.NoError(t, err, "the entry must survive an aborted remove")
+	lc, err := fx.store.GetLinkCount(ctx, target)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(2), lc, "link count must be untouched by the aborted remove")
 }


### PR DESCRIPTION
Sweeps the 11 LOW audit findings classified `gaps` (missing coverage / missing handling). Each was re-verified against current `develop` before acting — several turned out to be already closed, covered elsewhere, or out of scope for a sweep.

> **Merge order: after #1972.** The empty-manifest defect in `GetFileByPayloadID`'s legacy scan is fixed there, not here. #1972 routes both the tx-level and store-level payload-ID fallbacks through `loadEnrichedFileByID` — removing the drift between the two copies that produced the bug — which is the better fix. My inline `loadManifest` patch and its test have been dropped from this branch, so `pkg/metadata/store/badger/transaction.go` and `payload_index_test.go` are untouched here.

## Closed

- `pkg/block/blockstoretest/conformance.go` — **CLOSED.** The suite pinned `Get` on a missing hash but never `Has`/`Head`/`GetRange`, despite the interface pinning `(false, nil)` / `ErrChunkNotFound` for exactly those. Added `Has_NotFound`, `Head_NotFound`, `GetRange_NotFound`; `Has_NotFound` stores an unrelated object first so a backend answering from a listing must still report a definitive miss.
- `pkg/metadata/auth_identity.go` — **CLOSED.** `MapPrivilegedToAnonymous` squashed UID/SID but left `Username`/`Domain`. ACL evaluation resolves `Who` from those, so an ACE naming the squashed principal re-granted exactly the privilege the squash removed. Now cleared whenever the squash fires, matching the `MapAllToAnonymous` branch. A negative-control test asserts an unprivileged identity keeps its principal.
- `pkg/metadata/store/badger/shares.go` — **CLOSED.** `CreateRootDirectory`'s UID/GID reconciliation writes the root inode with a raw `txn.Set`, bypassing the dirty-file tracking that drops read-cache entries. A re-attach with changed ownership kept serving the old UID/GID. Now invalidates `readCache`/`parentCache` for the root alongside `shareCache`. (#1972 also touches this file, but only the `db.Update` → `updateWithConflictRetry` swap and the link-count helper in `loadExistingRoot` — no overlap with this hunk.)
- `pkg/metadata/file_remove.go` — **CLOSED.** `RemoveFile` fell back to `linkCount = 1` when `tx.GetLinkCount` errored, reporting the content free while another hard link still referenced it. Now returns the error. Safe: every backend reports a missing count as `(0, nil)`, which this function already treats as the last link — only genuine backend failures change behaviour. #1972 does not touch `RemoveFile`; its link-count test covers `CreateDirectory`.
- `pkg/controlplane/runtime/blockstore_init.go` — **CLOSED.** `ValidateBlockStoreConfig` shape-checked `compression` and `parallel_uploads` but not `encryption`. New `validateEncryptionSubconfig` runs the same `encryption.ParsePolicy` the attach path uses (so accepted shapes and AEAD names cannot drift) and then checks the fields each provider kind requires, including the KMIP client certificate pair.

## Already covered / refuted / superseded

- `pkg/metadata/store/badger/transaction.go` — **SUPERSEDED BY #1972.** See the note above.
- `pkg/block/engine/syncer.go` — **ALREADY-COVERED.** `develop` grew the `bgWG` / `waitBounded` join and the `HealthMonitor` join after the audit tree. No test pinned it, so this adds two: one keeps a carve pass inside `local.Carve` and asserts `Close()` does not return, the other pins a probe and asserts `Stop()` does not return. Both fail against the pre-fix build. Also lets a pending stop win over an already-queued probe tick, so the new join never waits on one more round-trip against an unreachable remote.
- `pkg/metadata/store/badger/reset.go` — **REFUTED.** `Reset()` already zeroes `usedBytes` and resets the quota cache. `failRestore` is consistent too: the restore precondition is an empty store, the write batch bypasses the counters, so a wiped partial restore leaves them at the zero `Reset` set.
- `pkg/metadata/file_remove.go` (link-count status note) — the report marked this fixed by #1901, but #1901 only made the SQL backends propagate their errors, which makes the guess **more** reachable, not less. Fixed here.

## Left for issues (design changes, not sweep items)

- **Journal record CRC does not cover `FileID`** (`pkg/block/journal/record.go`). Confirmed: the header CRC covers `Magic..Version` only, and the trailing CRC covers the payload only, so bit rot in the `FileID` bytes silently misattributes a record to another file. Both proposed fixes change the on-disk record format and cannot read journals written by the current code — that needs a format version and a migration, not a sweep commit.
- **Client registry has no post-registration update path** (`pkg/controlplane/runtime/clients/service.go`). Confirmed: the type documents that an entry's fields are set at `Register` and never mutated, so per-client protocol/identity details stay at their connect-time stubs. Closing it means new `Registry` mutators plus wiring both the NFS and SMB adapters to call them once the real version/dialect/signing/identity is known — new production behaviour across two protocol layers.
- **First-boot machine-SID persist failure is swallowed** (`pkg/controlplane/runtime/lifecycle/service.go`). Confirmed: the failure is logged and serving continues with an in-memory-only SID. Making it fatal is a policy decision — a transient control-plane DB hiccup would stop the server from starting at all, including for NFS, which does not use the SID — so it belongs in an issue rather than a sweep.

## Notes for the #1972 merge

The `RemoveFile` link-count test needs a `GetLinkCount` fault injector. Rather than adding a parallel one, it extends the `faultyStore` / `faultyTx` already in `tx_integrity_test.go`, using the same `failLinkCountID` field and `errLinkCountInjected` name that #1972 introduces. Whichever lands second, the two definitions are textually identical — resolve by keeping one copy; only `TestRemoveFile_LinkCountReadFailureAborts` is net-new here.

## Verification

`gofmt -l .` clean, `go build ./...`, `go vet`, `go test ./...`, `-race` on every changed package, `golangci-lint run` on the changed packages — all green.
