### PR TITLE
perf: sweep the LOW perf findings on the data-plane hot paths

### DIFF
--- a/internal/adapter/nfs/v3/handlers/commit.go
+++ b/internal/adapter/nfs/v3/handlers/commit.go
@@ -90,15 +90,15 @@ func (h *Handler) Commit(
 	// Extract client IP for logging
 	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
-	logger.DebugCtx(ctx.Context, "COMMIT", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", req.Offset, "count", req.Count, "client", clientIP, "auth", ctx.AuthFlavor)
+	logger.DebugCtx(ctx.Context, "COMMIT", "handle", xdr.LazyHandle(req.Handle), "offset", req.Offset, "count", req.Count, "client", clientIP, "auth", ctx.AuthFlavor)
 
 	if ctx.isContextCancelled() {
-		logger.WarnCtx(ctx.Context, "COMMIT cancelled", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", req.Offset, "count", req.Count, "client", clientIP, "error", ctx.Context.Err())
+		logger.WarnCtx(ctx.Context, "COMMIT cancelled", "handle", xdr.LazyHandle(req.Handle), "offset", req.Offset, "count", req.Count, "client", clientIP, "error", ctx.Context.Err())
 		return &CommitResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil
 	}
 
 	if err := validateCommitRequest(req); err != nil {
-		logger.WarnCtx(ctx.Context, "COMMIT validation failed", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", req.Offset, "count", req.Count, "client", clientIP, "error", err)
+		logger.WarnCtx(ctx.Context, "COMMIT validation failed", "handle", xdr.LazyHandle(req.Handle), "offset", req.Offset, "count", req.Count, "client", clientIP, "error", err)
 		return &CommitResponse{NFSResponseBase: NFSResponseBase{Status: err.nfsStatus}}, nil
 	}
 
@@ -112,13 +112,13 @@ func (h *Handler) Commit(
 
 	// Check context before store call
 	if ctx.isContextCancelled() {
-		logger.WarnCtx(ctx.Context, "COMMIT cancelled before GetFile", "handle", fmt.Sprintf("0x%x", req.Handle), "client", clientIP, "error", ctx.Context.Err())
+		logger.WarnCtx(ctx.Context, "COMMIT cancelled before GetFile", "handle", xdr.LazyHandle(req.Handle), "client", clientIP, "error", ctx.Context.Err())
 		return &CommitResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil
 	}
 
 	file, err := metaSvc.GetFileCached(ctx.Context, handle)
 	if err != nil {
-		logger.WarnCtx(ctx.Context, "COMMIT failed: file not found", "handle", fmt.Sprintf("0x%x", req.Handle), "client", clientIP, "error", err)
+		logger.WarnCtx(ctx.Context, "COMMIT failed: file not found", "handle", xdr.LazyHandle(req.Handle), "client", clientIP, "error", err)
 		return &CommitResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrNoEnt}}, nil
 	}
 
@@ -127,7 +127,7 @@ func (h *Handler) Commit(
 
 	// Verify this is not a directory
 	if file.Type == metadata.FileTypeDirectory {
-		logger.WarnCtx(ctx.Context, "COMMIT failed: handle is a directory", "handle", fmt.Sprintf("0x%x", req.Handle), "client", clientIP)
+		logger.WarnCtx(ctx.Context, "COMMIT failed: handle is a directory", "handle", xdr.LazyHandle(req.Handle), "client", clientIP)
 
 		wccAfter := h.convertFileAttrToNFS(handle, &file.FileAttr)
 
@@ -156,7 +156,7 @@ func (h *Handler) Commit(
 			return nil, ctx.Context.Err()
 		}
 		logAuthCtxError(ctx.Context, err, "COMMIT",
-			"handle", fmt.Sprintf("0x%x", req.Handle), "client", clientIP)
+			"handle", xdr.LazyHandle(req.Handle), "client", clientIP)
 		return &CommitResponse{
 			NFSResponseBase: NFSResponseBase{Status: authDenialStatus(err)},
 			AttrBefore:      wccBefore,
@@ -169,7 +169,7 @@ func (h *Handler) Commit(
 			return nil, err
 		}
 		status := common.MapToNFS3(err)
-		logger.DebugCtx(ctx.Context, "COMMIT denied", "handle", fmt.Sprintf("0x%x", req.Handle), "status", status, "client", clientIP, "error", err)
+		logger.DebugCtx(ctx.Context, "COMMIT denied", "handle", xdr.LazyHandle(req.Handle), "status", status, "client", clientIP, "error", err)
 		return &CommitResponse{
 			NFSResponseBase: NFSResponseBase{Status: status},
 			AttrBefore:      wccBefore,
@@ -179,7 +179,7 @@ func (h *Handler) Commit(
 
 	// Check context before potentially long flush operation
 	if ctx.isContextCancelled() {
-		logger.WarnCtx(ctx.Context, "COMMIT cancelled before flush", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", req.Offset, "count", req.Count, "client", clientIP, "error", ctx.Context.Err())
+		logger.WarnCtx(ctx.Context, "COMMIT cancelled before flush", "handle", xdr.LazyHandle(req.Handle), "offset", req.Offset, "count", req.Count, "client", clientIP, "error", ctx.Context.Err())
 
 		// Get updated attributes for WCC data (best effort)
 		var wccAfter *types.NFSFileAttr
@@ -200,7 +200,7 @@ func (h *Handler) Commit(
 	// Check if there's content to flush
 	if file.PayloadID == "" {
 		logger.DebugCtx(ctx.Context, "COMMIT: no content to flush")
-		logger.DebugCtx(ctx.Context, "COMMIT successful (no content)", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", req.Offset, "count", req.Count, "client", clientIP)
+		logger.DebugCtx(ctx.Context, "COMMIT successful (no content)", "handle", xdr.LazyHandle(req.Handle), "offset", req.Offset, "count", req.Count, "client", clientIP)
 		return &CommitResponse{
 			NFSResponseBase: NFSResponseBase{Status: types.NFS3OK},
 			AttrBefore:      wccBefore,
@@ -236,7 +236,7 @@ func (h *Handler) Commit(
 	// plumbing lands in one place (see common/doc.go).
 	flushErr := common.CommitBlockStore(ctx.Context, blockStore, file.PayloadID)
 	if flushErr != nil {
-		logError(ctx.Context, flushErr, "COMMIT failed: flush error", "handle", fmt.Sprintf("0x%x", req.Handle), "payload_id", file.PayloadID, "client", clientIP)
+		logError(ctx.Context, flushErr, "COMMIT failed: flush error", "handle", xdr.LazyHandle(req.Handle), "payload_id", file.PayloadID, "client", clientIP)
 
 		// Try to get updated attributes for error response
 		if updatedFile, getErr := metaSvc.GetFile(ctx.Context, handle); getErr == nil {
@@ -256,10 +256,10 @@ func (h *Handler) Commit(
 	// the journal size reconcile on restart as the crash-safety net.
 	flushed, metaErr := metaSvc.FlushPendingWriteForFile(authCtx, handle, false)
 	if metaErr != nil {
-		logger.WarnCtx(ctx.Context, "COMMIT: metadata flush failed", "handle", fmt.Sprintf("0x%x", req.Handle), "error", metaErr)
+		logger.WarnCtx(ctx.Context, "COMMIT: metadata flush failed", "handle", xdr.LazyHandle(req.Handle), "error", metaErr)
 		// Continue - content is flushed, metadata will be fixed eventually
 	} else if flushed {
-		logger.DebugCtx(ctx.Context, "COMMIT: flushed pending metadata", "handle", fmt.Sprintf("0x%x", req.Handle))
+		logger.DebugCtx(ctx.Context, "COMMIT: flushed pending metadata", "handle", xdr.LazyHandle(req.Handle))
 	}
 
 	// wccAfter is already correct: GetFileCached returned the file with pending

--- a/internal/adapter/nfs/v3/handlers/read.go
+++ b/internal/adapter/nfs/v3/handlers/read.go
@@ -106,17 +106,17 @@ func (h *Handler) Read(
 	// Check if the client has disconnected or the request has timed out
 	// before we start any expensive operations.
 	if ctx.isContextCancelled() {
-		logger.DebugCtx(ctx.Context, "READ: request cancelled at entry", "handle", fmt.Sprintf("0x%x", req.Handle), "client", ctx.ClientAddr, "error", ctx.Context.Err())
+		logger.DebugCtx(ctx.Context, "READ: request cancelled at entry", "handle", xdr.LazyHandle(req.Handle), "client", ctx.ClientAddr, "error", ctx.Context.Err())
 		return nil, ctx.Context.Err()
 	}
 
 	// Extract client IP for logging
 	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
-	logger.DebugCtx(ctx.Context, "READ", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", bytesize.ByteSize(req.Offset), "count", bytesize.ByteSize(req.Count), "client", clientIP, "auth", ctx.AuthFlavor)
+	logger.DebugCtx(ctx.Context, "READ", "handle", xdr.LazyHandle(req.Handle), "offset", bytesize.ByteSize(req.Offset), "count", bytesize.ByteSize(req.Count), "client", clientIP, "auth", ctx.AuthFlavor)
 
 	if err := validateReadRequest(req); err != nil {
-		logger.WarnCtx(ctx.Context, "READ validation failed", "handle", fmt.Sprintf("0x%x", req.Handle), "client", clientIP, "error", err)
+		logger.WarnCtx(ctx.Context, "READ validation failed", "handle", xdr.LazyHandle(req.Handle), "client", clientIP, "error", err)
 		return &ReadResponse{NFSResponseBase: NFSResponseBase{Status: err.nfsStatus}}, nil
 	}
 
@@ -143,7 +143,7 @@ func (h *Handler) Read(
 
 	// Verify it's a regular file (not a directory or special file)
 	if file.Type != metadata.FileTypeRegular {
-		logger.WarnCtx(ctx.Context, "READ failed: not a regular file", "handle", fmt.Sprintf("0x%x", req.Handle), "type", file.Type, "client", clientIP)
+		logger.WarnCtx(ctx.Context, "READ failed: not a regular file", "handle", xdr.LazyHandle(req.Handle), "type", file.Type, "client", clientIP)
 
 		// Return file attributes even on error for cache consistency
 		nfsAttr := h.convertFileAttrToNFS(fileHandle, &file.FileAttr)
@@ -157,7 +157,7 @@ func (h *Handler) Read(
 	// Context Cancellation Check - After Metadata Lookup
 	// Check again before opening content (which may be expensive)
 	if ctx.isContextCancelled() {
-		logger.DebugCtx(ctx.Context, "READ: request cancelled after metadata lookup", "handle", fmt.Sprintf("0x%x", req.Handle), "client", clientIP)
+		logger.DebugCtx(ctx.Context, "READ: request cancelled after metadata lookup", "handle", xdr.LazyHandle(req.Handle), "client", clientIP)
 		return nil, ctx.Context.Err()
 	}
 
@@ -171,7 +171,7 @@ func (h *Handler) Read(
 			return nil, ctx.Context.Err()
 		}
 		logAuthCtxError(ctx.Context, err, "READ",
-			"handle", fmt.Sprintf("0x%x", req.Handle), "client", clientIP)
+			"handle", xdr.LazyHandle(req.Handle), "client", clientIP)
 		return &ReadResponse{
 			NFSResponseBase: NFSResponseBase{Status: authDenialStatus(err)},
 			Attr:            h.convertFileAttrToNFS(fileHandle, &file.FileAttr),
@@ -196,7 +196,7 @@ func (h *Handler) Read(
 			return nil, err
 		}
 		status := common.MapToNFS3(err)
-		logger.DebugCtx(ctx.Context, "READ denied", "handle", fmt.Sprintf("0x%x", req.Handle), "status", status, "client", clientIP, "error", err)
+		logger.DebugCtx(ctx.Context, "READ denied", "handle", xdr.LazyHandle(req.Handle), "status", status, "client", clientIP, "error", err)
 		return &ReadResponse{
 			NFSResponseBase: NFSResponseBase{Status: status},
 			Attr:            h.convertFileAttrToNFS(fileHandle, &file.FileAttr),
@@ -213,7 +213,7 @@ func (h *Handler) Read(
 
 	// If file has no content, return empty data with EOF
 	if file.PayloadID == "" || file.Size == 0 {
-		logger.DebugCtx(ctx.Context, "READ: empty file", "handle", fmt.Sprintf("0x%x", req.Handle), "size", bytesize.ByteSize(file.Size), "client", clientIP)
+		logger.DebugCtx(ctx.Context, "READ: empty file", "handle", xdr.LazyHandle(req.Handle), "size", bytesize.ByteSize(file.Size), "client", clientIP)
 
 		nfsAttr := h.convertFileAttrToNFS(fileHandle, &file.FileAttr)
 
@@ -228,7 +228,7 @@ func (h *Handler) Read(
 
 	// If offset is at or beyond EOF, return empty data with EOF
 	if req.Offset >= file.Size {
-		logger.DebugCtx(ctx.Context, "READ: offset beyond EOF", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", bytesize.ByteSize(req.Offset), "size", bytesize.ByteSize(file.Size), "client", clientIP)
+		logger.DebugCtx(ctx.Context, "READ: offset beyond EOF", "handle", xdr.LazyHandle(req.Handle), "offset", bytesize.ByteSize(req.Offset), "size", bytesize.ByteSize(file.Size), "client", clientIP)
 
 		nfsAttr := h.convertFileAttrToNFS(fileHandle, &file.FileAttr)
 
@@ -270,17 +270,17 @@ func (h *Handler) Read(
 
 	// All reads go through BlockStore.ReadAt which reads from block store.
 
-	logger.DebugCtx(ctx.Context, "READ: reading from BlockStore", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", req.Offset, "count", actualLength, "payload_id", file.PayloadID)
+	logger.DebugCtx(ctx.Context, "READ: reading from BlockStore", "handle", xdr.LazyHandle(req.Handle), "offset", req.Offset, "count", actualLength, "payload_id", file.PayloadID)
 	readResult, readErr := common.ReadFromBlockStore(ctx.Context, blockStore, file.PayloadID, req.Offset, actualLength)
 	if readErr != nil {
 		// Check if cancellation error
 		if errors.Is(readErr, context.Canceled) || errors.Is(readErr, context.DeadlineExceeded) {
-			logger.DebugCtx(ctx.Context, "READ: request cancelled during ReadAt", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", req.Offset, "client", clientIP)
+			logger.DebugCtx(ctx.Context, "READ: request cancelled during ReadAt", "handle", xdr.LazyHandle(req.Handle), "offset", req.Offset, "client", clientIP)
 			return nil, readErr
 		}
 
 		// I/O error
-		logError(ctx.Context, readErr, "READ failed", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", req.Offset, "client", clientIP)
+		logError(ctx.Context, readErr, "READ failed", "handle", xdr.LazyHandle(req.Handle), "offset", req.Offset, "client", clientIP)
 		nfsAttr := h.convertFileAttrToNFS(fileHandle, &file.FileAttr)
 		return &ReadResponse{
 			NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO},
@@ -299,7 +299,7 @@ func (h *Handler) Read(
 
 	nfsAttr := h.convertFileAttrToNFS(fileHandle, &file.FileAttr)
 
-	logger.DebugCtx(ctx.Context, "READ successful", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", bytesize.ByteSize(req.Offset), "requested", bytesize.ByteSize(req.Count), "read", bytesize.ByteSize(n), "eof", eof, "client", clientIP)
+	logger.DebugCtx(ctx.Context, "READ successful", "handle", xdr.LazyHandle(req.Handle), "offset", bytesize.ByteSize(req.Offset), "requested", bytesize.ByteSize(req.Count), "read", bytesize.ByteSize(n), "eof", eof, "client", clientIP)
 
 	logger.DebugCtx(ctx.Context, "READ details", "size", bytesize.ByteSize(file.Size), "type", nfsAttr.Type, "mode", fmt.Sprintf("%o", file.Mode))
 

--- a/internal/adapter/nfs/v3/handlers/write.go
+++ b/internal/adapter/nfs/v3/handlers/write.go
@@ -124,10 +124,10 @@ func (h *Handler) Write(
 	// Extract client IP for logging
 	clientIP := xdr.LazyClientIP(ctx.ClientAddr)
 
-	logger.DebugCtx(ctx.Context, "WRITE", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", bytesize.ByteSize(req.Offset), "count", bytesize.ByteSize(req.Count), "stable", req.Stable, "client", clientIP, "auth", ctx.AuthFlavor)
+	logger.DebugCtx(ctx.Context, "WRITE", "handle", xdr.LazyHandle(req.Handle), "offset", bytesize.ByteSize(req.Offset), "count", bytesize.ByteSize(req.Count), "stable", req.Stable, "client", clientIP, "auth", ctx.AuthFlavor)
 
 	if ctx.isContextCancelled() {
-		logWarn(ctx.Context, ctx.Context.Err(), "WRITE cancelled", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", req.Offset, "count", req.Count, "client", clientIP)
+		logWarn(ctx.Context, ctx.Context.Err(), "WRITE cancelled", "handle", xdr.LazyHandle(req.Handle), "offset", req.Offset, "count", req.Count, "client", clientIP)
 		return &WriteResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil
 	}
 
@@ -135,7 +135,7 @@ func (h *Handler) Write(
 	// is applied as a short-write below, derived from the advertised wtmax.
 
 	if err := validateWriteRequest(req); err != nil {
-		logWarn(ctx.Context, err, "WRITE validation failed", "handle", fmt.Sprintf("0x%x", req.Handle), "client", clientIP)
+		logWarn(ctx.Context, err, "WRITE validation failed", "handle", xdr.LazyHandle(req.Handle), "client", clientIP)
 		return &WriteResponse{NFSResponseBase: NFSResponseBase{Status: err.nfsStatus}}, nil
 	}
 
@@ -199,11 +199,11 @@ func (h *Handler) Write(
 	if err != nil {
 		// Check if the error is due to context cancellation
 		if ctx.Context.Err() != nil {
-			logger.DebugCtx(ctx.Context, "WRITE cancelled during auth context building", "handle", fmt.Sprintf("0x%x", req.Handle), "client", clientIP, "error", ctx.Context.Err())
+			logger.DebugCtx(ctx.Context, "WRITE cancelled during auth context building", "handle", xdr.LazyHandle(req.Handle), "client", clientIP, "error", ctx.Context.Err())
 			return &WriteResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, ctx.Context.Err()
 		}
 
-		logAuthCtxError(ctx.Context, err, "WRITE", "handle", fmt.Sprintf("0x%x", req.Handle), "client", clientIP)
+		logAuthCtxError(ctx.Context, err, "WRITE", "handle", xdr.LazyHandle(req.Handle), "client", clientIP)
 
 		// No WCC data available - we haven't called PrepareWrite yet
 		return &WriteResponse{
@@ -225,7 +225,7 @@ func (h *Handler) Write(
 
 	// Check context before store call
 	if ctx.isContextCancelled() {
-		logger.WarnCtx(ctx.Context, "WRITE cancelled before PrepareWrite", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", req.Offset, "count", req.Count, "client", clientIP, "error", ctx.Context.Err())
+		logger.WarnCtx(ctx.Context, "WRITE cancelled before PrepareWrite", "handle", xdr.LazyHandle(req.Handle), "offset", req.Offset, "count", req.Count, "client", clientIP, "error", ctx.Context.Err())
 
 		// No WCC data available - we haven't called PrepareWrite yet
 		return &WriteResponse{
@@ -238,7 +238,7 @@ func (h *Handler) Write(
 		// Map store error to NFS status
 		status := common.MapToNFS3(err)
 
-		logger.WarnCtx(ctx.Context, "WRITE failed: PrepareWrite error", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", req.Offset, "count", len(req.Data), "client", clientIP, "error", err)
+		logger.WarnCtx(ctx.Context, "WRITE failed: PrepareWrite error", "handle", xdr.LazyHandle(req.Handle), "offset", req.Offset, "count", len(req.Data), "client", clientIP, "error", err)
 
 		// No WCC data available - PrepareWrite failed so we don't have file attributes
 		return h.buildWriteErrorResponse(status, fileHandle, nil, nil), nil
@@ -249,7 +249,7 @@ func (h *Handler) Write(
 
 	// Check context before write operation
 	if ctx.isContextCancelled() {
-		logger.WarnCtx(ctx.Context, "WRITE cancelled before write", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", req.Offset, "count", req.Count, "client", clientIP, "error", ctx.Context.Err())
+		logger.WarnCtx(ctx.Context, "WRITE cancelled before write", "handle", xdr.LazyHandle(req.Handle), "offset", req.Offset, "count", req.Count, "client", clientIP, "error", ctx.Context.Err())
 		return h.buildWriteErrorResponse(types.NFS3ErrIO, fileHandle, writeIntent.PreWriteAttr, writeIntent.PreWriteAttr), nil
 	}
 
@@ -258,7 +258,7 @@ func (h *Handler) Write(
 	// plumbing lands in one place (see common/doc.go).
 	err = common.WriteToBlockStore(ctx.Context, blockStore, writeIntent.PayloadID, req.Data, req.Offset)
 	if err != nil {
-		logError(ctx.Context, err, "WRITE failed: BlockStore write error", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", req.Offset, "count", len(req.Data), "payload_id", writeIntent.PayloadID, "client", clientIP)
+		logError(ctx.Context, err, "WRITE failed: BlockStore write error", "handle", xdr.LazyHandle(req.Handle), "offset", req.Offset, "count", len(req.Data), "payload_id", writeIntent.PayloadID, "client", clientIP)
 		status := common.MapContentToNFS3(err)
 		return h.buildWriteErrorResponse(status, fileHandle, writeIntent.PreWriteAttr, writeIntent.PreWriteAttr), nil
 	}
@@ -266,7 +266,7 @@ func (h *Handler) Write(
 
 	updatedFile, err := metaSvc.CommitWrite(authCtx, writeIntent)
 	if err != nil {
-		logError(ctx.Context, err, "WRITE failed: CommitWrite error (content written but metadata not updated)", "handle", fmt.Sprintf("0x%x", req.Handle), "offset", req.Offset, "count", len(req.Data), "client", clientIP)
+		logError(ctx.Context, err, "WRITE failed: CommitWrite error (content written but metadata not updated)", "handle", xdr.LazyHandle(req.Handle), "offset", req.Offset, "count", len(req.Data), "client", clientIP)
 
 		// Content is written but metadata not updated - this is an inconsistent state
 		// Map error to NFS status
@@ -299,7 +299,7 @@ func (h *Handler) Write(
 	if req.Stable >= DataSyncWrite {
 		if err := h.flushStableWrite(ctx, metaSvc, blockStore, fileHandle, writeIntent.PayloadID, authCtx, req.Stable); err != nil {
 			logError(ctx.Context, err, "WRITE: stable flush failed, downgrading to UNSTABLE",
-				"handle", fmt.Sprintf("0x%x", req.Handle), "stable_requested", req.Stable, "client", clientIP)
+				"handle", xdr.LazyHandle(req.Handle), "stable_requested", req.Stable, "client", clientIP)
 		} else {
 			committed = req.Stable
 		}
@@ -359,7 +359,7 @@ func (h *Handler) flushStableWrite(
 			return err
 		}
 		logger.WarnCtx(ctx.Context, "WRITE: DATA_SYNC metadata flush failed (data durable, will reconcile)",
-			"handle", fmt.Sprintf("0x%x", handle), "error", err)
+			"handle", xdr.LazyHandle(handle), "error", err)
 	}
 	return nil
 }

--- a/internal/adapter/nfs/v4/handlers/read_plus.go
+++ b/internal/adapter/nfs/v4/handlers/read_plus.go
@@ -216,21 +216,34 @@ func (h *Handler) buildReadPlusContents(ctx *types.CompoundContext, file *metada
 // encodeReadPlusResok encodes a successful READ_PLUS reply: status, eof, and the
 // content array (each member tagged NFS4_CONTENT_DATA or NFS4_CONTENT_HOLE).
 func encodeReadPlusResok(eof bool, contents []readPlusContent) *types.CompoundResult {
-	var buf bytes.Buffer
-	_ = xdr.WriteUint32(&buf, types.NFS4_OK)
-	_ = xdr.WriteBool(&buf, eof)
-	_ = xdr.WriteUint32(&buf, uint32(len(contents)))
+	// Pre-size the buffer to the exact wire size so encoding does not grow (and
+	// reallocate) the backing slice mid-write:
+	//   status(4) + eof bool(4) + content count(4), then per member either a
+	//   hole (tag 4 + offset 8 + length 8) or data (tag 4 + offset 8 +
+	//   opaque-length 4 + bytes + XDR pad 0-3).
+	size := 12
+	for i := range contents {
+		if contents[i].Hole {
+			size += 20
+			continue
+		}
+		size += 16 + len(contents[i].Data) + 3
+	}
+	buf := bytes.NewBuffer(make([]byte, 0, size))
+	_ = xdr.WriteUint32(buf, types.NFS4_OK)
+	_ = xdr.WriteBool(buf, eof)
+	_ = xdr.WriteUint32(buf, uint32(len(contents)))
 	for i := range contents {
 		c := &contents[i]
 		if c.Hole {
-			_ = xdr.WriteUint32(&buf, types.NFS4_CONTENT_HOLE)
-			_ = xdr.WriteUint64(&buf, c.Offset)
-			_ = xdr.WriteUint64(&buf, c.Length)
+			_ = xdr.WriteUint32(buf, types.NFS4_CONTENT_HOLE)
+			_ = xdr.WriteUint64(buf, c.Offset)
+			_ = xdr.WriteUint64(buf, c.Length)
 			continue
 		}
-		_ = xdr.WriteUint32(&buf, types.NFS4_CONTENT_DATA)
-		_ = xdr.WriteUint64(&buf, c.Offset)
-		_ = xdr.WriteXDROpaque(&buf, c.Data)
+		_ = xdr.WriteUint32(buf, types.NFS4_CONTENT_DATA)
+		_ = xdr.WriteUint64(buf, c.Offset)
+		_ = xdr.WriteXDROpaque(buf, c.Data)
 	}
 	return &types.CompoundResult{Status: types.NFS4_OK, OpCode: types.OP_READ_PLUS, Data: buf.Bytes()}
 }

--- a/internal/adapter/nfs/v4/handlers/read_plus.go
+++ b/internal/adapter/nfs/v4/handlers/read_plus.go
@@ -216,11 +216,9 @@ func (h *Handler) buildReadPlusContents(ctx *types.CompoundContext, file *metada
 // encodeReadPlusResok encodes a successful READ_PLUS reply: status, eof, and the
 // content array (each member tagged NFS4_CONTENT_DATA or NFS4_CONTENT_HOLE).
 func encodeReadPlusResok(eof bool, contents []readPlusContent) *types.CompoundResult {
-	// Pre-size the buffer to the exact wire size so encoding does not grow (and
-	// reallocate) the backing slice mid-write:
-	//   status(4) + eof bool(4) + content count(4), then per member either a
-	//   hole (tag 4 + offset 8 + length 8) or data (tag 4 + offset 8 +
-	//   opaque-length 4 + bytes + XDR pad 0-3).
+	// Pre-size the buffer so encoding never regrows it: status + eof + count,
+	// then per member a hole (tag + offset + length) or data (tag + offset +
+	// opaque length + bytes + up to 3 bytes of XDR padding).
 	size := 12
 	for i := range contents {
 		if contents[i].Hole {

--- a/internal/adapter/nfs/xdr/loghandle.go
+++ b/internal/adapter/nfs/xdr/loghandle.go
@@ -1,0 +1,24 @@
+package xdr
+
+import (
+	"encoding/hex"
+	"log/slog"
+)
+
+// LazyHandle wraps a raw file handle and defers its "0x…" hex rendering to
+// log-emit time via slog.LogValuer. Handlers build one per op on the READ /
+// WRITE / COMMIT hot path, where most ops never emit at their log level, so
+// the formatting and its allocation are skipped entirely. It renders exactly
+// like fmt.Sprintf("0x%x", handle).
+type LazyHandle []byte
+
+// LogValue implements slog.LogValuer so the hex string is built only when a
+// record is actually emitted (skipped for filtered-out levels).
+func (h LazyHandle) LogValue() slog.Value {
+	return slog.StringValue(h.String())
+}
+
+// String renders the handle eagerly, for the rare non-logging caller.
+func (h LazyHandle) String() string {
+	return "0x" + hex.EncodeToString(h)
+}

--- a/internal/adapter/nfs/xdr/loghandle.go
+++ b/internal/adapter/nfs/xdr/loghandle.go
@@ -7,18 +7,12 @@ import (
 
 // LazyHandle wraps a raw file handle and defers its "0x…" hex rendering to
 // log-emit time via slog.LogValuer. Handlers build one per op on the READ /
-// WRITE / COMMIT hot path, where most ops never emit at their log level, so
-// the formatting and its allocation are skipped entirely. It renders exactly
-// like fmt.Sprintf("0x%x", handle).
+// WRITE / COMMIT hot path, where most ops never emit at their log level, so the
+// formatting and its allocation are skipped. It renders like
+// fmt.Sprintf("0x%x", handle).
 type LazyHandle []byte
 
-// LogValue implements slog.LogValuer so the hex string is built only when a
-// record is actually emitted (skipped for filtered-out levels).
+// LogValue implements slog.LogValuer.
 func (h LazyHandle) LogValue() slog.Value {
-	return slog.StringValue(h.String())
-}
-
-// String renders the handle eagerly, for the rare non-logging caller.
-func (h LazyHandle) String() string {
-	return "0x" + hex.EncodeToString(h)
+	return slog.StringValue("0x" + hex.EncodeToString(h))
 }

--- a/internal/adapter/nfs/xdr/loghandle_test.go
+++ b/internal/adapter/nfs/xdr/loghandle_test.go
@@ -1,0 +1,20 @@
+package xdr
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestLazyHandleMatchesEager guards that the deferred rendering is byte-for-byte
+// what the eager fmt.Sprintf at the call sites produced.
+func TestLazyHandleMatchesEager(t *testing.T) {
+	for _, h := range [][]byte{nil, {}, {0x00}, {0xde, 0xad, 0xbe, 0xef}, []byte("share:file")} {
+		want := fmt.Sprintf("0x%x", h)
+		if got := LazyHandle(h).String(); got != want {
+			t.Errorf("String() = %q, want %q", got, want)
+		}
+		if got := LazyHandle(h).LogValue().String(); got != want {
+			t.Errorf("LogValue() = %q, want %q", got, want)
+		}
+	}
+}

--- a/internal/adapter/nfs/xdr/loghandle_test.go
+++ b/internal/adapter/nfs/xdr/loghandle_test.go
@@ -10,9 +10,6 @@ import (
 func TestLazyHandleMatchesEager(t *testing.T) {
 	for _, h := range [][]byte{nil, {}, {0x00}, {0xde, 0xad, 0xbe, 0xef}, []byte("share:file")} {
 		want := fmt.Sprintf("0x%x", h)
-		if got := LazyHandle(h).String(); got != want {
-			t.Errorf("String() = %q, want %q", got, want)
-		}
 		if got := LazyHandle(h).LogValue().String(); got != want {
 			t.Errorf("LogValue() = %q, want %q", got, want)
 		}

--- a/internal/adapter/smb/handlers/logfileid.go
+++ b/internal/adapter/smb/handlers/logfileid.go
@@ -7,13 +7,11 @@ import (
 
 // lazyFileID wraps an SMB2 file identifier and defers its hex rendering to
 // log-emit time via slog.LogValuer. The READ and WRITE handlers build one per
-// request, where most requests never emit at Debug level, so the formatting
-// and its allocation are skipped entirely. It renders exactly like
-// fmt.Sprintf("%x", id).
+// request, where most requests never emit at Debug level, so the formatting and
+// its allocation are skipped. It renders like fmt.Sprintf("%x", id).
 type lazyFileID [16]byte
 
-// LogValue implements slog.LogValuer so the hex string is built only when a
-// record is actually emitted (skipped for filtered-out levels).
+// LogValue implements slog.LogValuer.
 func (id lazyFileID) LogValue() slog.Value {
 	return slog.StringValue(hex.EncodeToString(id[:]))
 }

--- a/internal/adapter/smb/handlers/logfileid.go
+++ b/internal/adapter/smb/handlers/logfileid.go
@@ -1,0 +1,19 @@
+package handlers
+
+import (
+	"encoding/hex"
+	"log/slog"
+)
+
+// lazyFileID wraps an SMB2 file identifier and defers its hex rendering to
+// log-emit time via slog.LogValuer. The READ and WRITE handlers build one per
+// request, where most requests never emit at Debug level, so the formatting
+// and its allocation are skipped entirely. It renders exactly like
+// fmt.Sprintf("%x", id).
+type lazyFileID [16]byte
+
+// LogValue implements slog.LogValuer so the hex string is built only when a
+// record is actually emitted (skipped for filtered-out levels).
+func (id lazyFileID) LogValue() slog.Value {
+	return slog.StringValue(hex.EncodeToString(id[:]))
+}

--- a/internal/adapter/smb/handlers/logfileid_test.go
+++ b/internal/adapter/smb/handlers/logfileid_test.go
@@ -1,0 +1,22 @@
+package handlers
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestLazyFileIDMatchesEager guards that the deferred rendering is byte-for-byte
+// what the eager fmt.Sprintf at the call sites produced.
+func TestLazyFileIDMatchesEager(t *testing.T) {
+	ids := [][16]byte{
+		{},
+		{0x01},
+		{0xde, 0xad, 0xbe, 0xef, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff},
+	}
+	for _, id := range ids {
+		want := fmt.Sprintf("%x", id)
+		if got := lazyFileID(id).LogValue().String(); got != want {
+			t.Errorf("LogValue() = %q, want %q", got, want)
+		}
+	}
+}

--- a/internal/adapter/smb/handlers/read.go
+++ b/internal/adapter/smb/handlers/read.go
@@ -155,7 +155,7 @@ func recordReadProgress(open *OpenFile, offset uint64, bytesReturned uint64) {
 // is at or beyond EOF.
 func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse, error) {
 	logger.Debug("READ request",
-		"fileID", fmt.Sprintf("%x", req.FileID),
+		"fileID", lazyFileID(req.FileID),
 		"offset", req.Offset,
 		"length", req.Length)
 
@@ -165,7 +165,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 
 	openFile, ok := h.GetOpenFile(req.FileID)
 	if !ok {
-		logger.Debug("READ: file handle not found (closed)", "fileID", fmt.Sprintf("%x", req.FileID))
+		logger.Debug("READ: file handle not found (closed)", "fileID", lazyFileID(req.FileID))
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusFileClosed}}, nil
 	}
 
@@ -560,7 +560,7 @@ func (h *Handler) handlePipeRead(ctx *SMBHandlerContext, req *ReadRequest, openF
 	// Get pipe state
 	pipe := h.PipeManager.GetPipe(req.FileID)
 	if pipe == nil {
-		logger.Debug("READ: pipe not found", "fileID", fmt.Sprintf("%x", req.FileID))
+		logger.Debug("READ: pipe not found", "fileID", lazyFileID(req.FileID))
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidHandle}}, nil
 	}
 

--- a/internal/adapter/smb/handlers/write.go
+++ b/internal/adapter/smb/handlers/write.go
@@ -168,7 +168,7 @@ func (resp *WriteResponse) Encode() ([]byte, error) {
 // bytes successfully written.
 func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteResponse, error) {
 	logger.Debug("WRITE request",
-		"fileID", fmt.Sprintf("%x", req.FileID),
+		"fileID", lazyFileID(req.FileID),
 		"offset", req.Offset,
 		"length", req.Length)
 
@@ -178,7 +178,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 
 	openFile, ok := h.GetOpenFile(req.FileID)
 	if !ok {
-		logger.Debug("WRITE: file handle not found (closed)", "fileID", fmt.Sprintf("%x", req.FileID))
+		logger.Debug("WRITE: file handle not found (closed)", "fileID", lazyFileID(req.FileID))
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusFileClosed}}, nil
 	}
 
@@ -602,7 +602,7 @@ func (h *Handler) handlePipeWrite(ctx *SMBHandlerContext, req *WriteRequest, ope
 	// Get pipe state
 	pipe := h.PipeManager.GetPipe(req.FileID)
 	if pipe == nil {
-		logger.Debug("WRITE: pipe not found", "fileID", fmt.Sprintf("%x", req.FileID))
+		logger.Debug("WRITE: pipe not found", "fileID", lazyFileID(req.FileID))
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidHandle}}, nil
 	}
 

--- a/pkg/block/compression/decorator.go
+++ b/pkg/block/compression/decorator.go
@@ -89,8 +89,14 @@ func (d *Decorator) SealChunk(ctx context.Context, hash block.ContentHash, plain
 // compressed body when that is strictly smaller than the input, otherwise the
 // raw plaintext (incompressible blocks skip the frame).
 func (d *Decorator) sealLayer(data []byte) ([]byte, error) {
-	var compressed bytes.Buffer
-	enc, err := d.codec.EncodeStream(&compressed)
+	// Reserve the frame header up front and let the codec stream the compressed
+	// body straight after it, so the buffer already holds the wire form when the
+	// frame wins — no second allocate-and-copy of the whole body. The buffer
+	// still grows on demand from there, so an incompressible block costs no more
+	// than the body it produces.
+	origSize := uint64(len(data))
+	framed := bytes.NewBuffer(appendFrameHeader(make([]byte, 0, FrameHeaderFixedSize+maxOrigSizeVarint), d.algo, origSize))
+	enc, err := d.codec.EncodeStream(framed)
 	if err != nil {
 		return nil, fmt.Errorf("compression: EncodeStream: %w", err)
 	}
@@ -102,13 +108,12 @@ func (d *Decorator) sealLayer(data []byte) ([]byte, error) {
 		return nil, fmt.Errorf("compression: encoder close: %w", err)
 	}
 
-	wire := data
-	body := compressed.Bytes()
-	origSize := uint64(len(data))
-	if frameOverhead(origSize)+len(body) < len(data) {
-		wire = encodeFrame(d.algo, origSize, body)
+	// framed.Len() is header + body, the exact byte count the frame would put on
+	// the wire; incompressible blocks skip the frame and travel as plaintext.
+	if framed.Len() < len(data) {
+		return framed.Bytes(), nil
 	}
-	return wire, nil
+	return data, nil
 }
 
 // --- read path ----------------------------------------------------------

--- a/pkg/block/compression/decorator.go
+++ b/pkg/block/compression/decorator.go
@@ -91,11 +91,9 @@ func (d *Decorator) SealChunk(ctx context.Context, hash block.ContentHash, plain
 func (d *Decorator) sealLayer(data []byte) ([]byte, error) {
 	// Reserve the frame header up front and let the codec stream the compressed
 	// body straight after it, so the buffer already holds the wire form when the
-	// frame wins — no second allocate-and-copy of the whole body. The buffer
-	// still grows on demand from there, so an incompressible block costs no more
-	// than the body it produces.
-	origSize := uint64(len(data))
-	framed := bytes.NewBuffer(appendFrameHeader(make([]byte, 0, FrameHeaderFixedSize+maxOrigSizeVarint), d.algo, origSize))
+	// frame wins — no second allocate-and-copy of the whole body.
+	header := appendFrameHeader(make([]byte, 0, FrameHeaderFixedSize+maxOrigSizeVarint), d.algo, uint64(len(data)))
+	framed := bytes.NewBuffer(header)
 	enc, err := d.codec.EncodeStream(framed)
 	if err != nil {
 		return nil, fmt.Errorf("compression: EncodeStream: %w", err)
@@ -108,8 +106,8 @@ func (d *Decorator) sealLayer(data []byte) ([]byte, error) {
 		return nil, fmt.Errorf("compression: encoder close: %w", err)
 	}
 
-	// framed.Len() is header + body, the exact byte count the frame would put on
-	// the wire; incompressible blocks skip the frame and travel as plaintext.
+	// framed.Len() is header + body, the byte count the frame would put on the
+	// wire; incompressible blocks skip the frame and travel as plaintext.
 	if framed.Len() < len(data) {
 		return framed.Bytes(), nil
 	}

--- a/pkg/block/compression/frame.go
+++ b/pkg/block/compression/frame.go
@@ -32,18 +32,28 @@ func frameOverhead(origSize uint64) int {
 	return FrameHeaderFixedSize + n
 }
 
+// appendFrameHeader appends the frame header for a body declaring origSize
+// plaintext bytes. The body follows it directly on the wire:
+//
+//	[magic | algo | uvarint(origSize) | body]
+//
+// Appending lets the caller reserve the header in the same buffer the codec
+// streams the body into, so no second allocate-and-copy is needed.
+func appendFrameHeader(out []byte, algo Algo, origSize uint64) []byte {
+	out = append(out, FrameMagic[:]...)
+	out = append(out, byte(algo))
+	var sizeBuf [maxOrigSizeVarint]byte
+	n := binary.PutUvarint(sizeBuf[:], origSize)
+	return append(out, sizeBuf[:n]...)
+}
+
 // encodeFrame builds the wire form for a compressed body
 //
 //	[magic | algo | uvarint(origSize) | body]
 func encodeFrame(algo Algo, origSize uint64, body []byte) []byte {
 	out := make([]byte, 0, FrameHeaderFixedSize+maxOrigSizeVarint+len(body))
-	out = append(out, FrameMagic[:]...)
-	out = append(out, byte(algo))
-	var sizeBuf [maxOrigSizeVarint]byte
-	n := binary.PutUvarint(sizeBuf[:], origSize)
-	out = append(out, sizeBuf[:n]...)
-	out = append(out, body...)
-	return out
+	out = appendFrameHeader(out, algo, origSize)
+	return append(out, body...)
 }
 
 // hasFrameMagic reports whether b begins with the 5-byte DFCMP prefix.

--- a/pkg/block/compression/frame.go
+++ b/pkg/block/compression/frame.go
@@ -23,8 +23,8 @@ const maxOrigSizeVarint = binary.MaxVarintLen64
 // generous vs FastCDC's ~16 MiB max chunk; tune if larger chunks land.
 const MaxFramedPlaintextSize = 64 * 1024 * 1024
 
-// appendFrameHeader appends the frame header for a body declaring origSize
-// plaintext bytes. The body follows it directly on the wire:
+// appendFrameHeader appends the header of a frame declaring origSize plaintext
+// bytes; the compressed body follows it directly on the wire:
 //
 //	[magic | algo | uvarint(origSize) | body]
 //
@@ -36,15 +36,6 @@ func appendFrameHeader(out []byte, algo Algo, origSize uint64) []byte {
 	var sizeBuf [maxOrigSizeVarint]byte
 	n := binary.PutUvarint(sizeBuf[:], origSize)
 	return append(out, sizeBuf[:n]...)
-}
-
-// encodeFrame builds the wire form for a compressed body
-//
-//	[magic | algo | uvarint(origSize) | body]
-func encodeFrame(algo Algo, origSize uint64, body []byte) []byte {
-	out := make([]byte, 0, FrameHeaderFixedSize+maxOrigSizeVarint+len(body))
-	out = appendFrameHeader(out, algo, origSize)
-	return append(out, body...)
 }
 
 // hasFrameMagic reports whether b begins with the 5-byte DFCMP prefix.

--- a/pkg/block/compression/frame.go
+++ b/pkg/block/compression/frame.go
@@ -23,15 +23,6 @@ const maxOrigSizeVarint = binary.MaxVarintLen64
 // generous vs FastCDC's ~16 MiB max chunk; tune if larger chunks land.
 const MaxFramedPlaintextSize = 64 * 1024 * 1024
 
-// frameOverhead returns the header byte count for a frame declaring
-// the given plaintext size. Used by callers that need to know the
-// total wire size of a hypothetical frame without building it.
-func frameOverhead(origSize uint64) int {
-	var buf [maxOrigSizeVarint]byte
-	n := binary.PutUvarint(buf[:], origSize)
-	return FrameHeaderFixedSize + n
-}
-
 // appendFrameHeader appends the frame header for a body declaring origSize
 // plaintext bytes. The body follows it directly on the wire:
 //

--- a/pkg/block/compression/frame_test.go
+++ b/pkg/block/compression/frame_test.go
@@ -8,6 +8,13 @@ import (
 	"testing"
 )
 
+// encodeFrame builds the full wire form for a compressed body, the way the
+// seal path does by streaming the body onto appendFrameHeader's output.
+func encodeFrame(algo Algo, origSize uint64, body []byte) []byte {
+	out := make([]byte, 0, FrameHeaderFixedSize+maxOrigSizeVarint+len(body))
+	return append(appendFrameHeader(out, algo, origSize), body...)
+}
+
 func TestEncodeDecodeFrame_RoundTrip(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/pkg/block/encryption/decorator.go
+++ b/pkg/block/encryption/decorator.go
@@ -100,17 +100,19 @@ func (d *EncryptedRemote) sealLayer(ctx context.Context, hash block.ContentHash,
 	if _, err := rand.Read(nonce); err != nil {
 		return nil, fmt.Errorf("encryption: read nonce: %w", err)
 	}
-	ciphertext := aead.Seal(nil, nonce, data, hash[:])
 
 	wrappedKey, masterKeyID, err := d.provider.Wrap(ctx, blockKey)
 	if err != nil {
 		return nil, fmt.Errorf("encryption: wrap block key: %w", err)
 	}
-	wire, err := encodeFrame(d.aead, masterKeyID, wrappedKey, nonce, ciphertext)
+	// Build the frame header first and seal straight onto it: Seal appends the
+	// ciphertext into the space the header reserved, so the wire frame costs one
+	// buffer instead of a standalone ciphertext plus a copy of it.
+	wire, err := appendFrameHeader(nil, d.aead, masterKeyID, wrappedKey, nonce, len(data)+aead.Overhead())
 	if err != nil {
 		return nil, err
 	}
-	return wire, nil
+	return aead.Seal(wire, nonce, data, hash[:]), nil
 }
 
 // Get returns the plaintext for the block identified by hash.

--- a/pkg/block/encryption/decorator.go
+++ b/pkg/block/encryption/decorator.go
@@ -105,9 +105,9 @@ func (d *EncryptedRemote) sealLayer(ctx context.Context, hash block.ContentHash,
 	if err != nil {
 		return nil, fmt.Errorf("encryption: wrap block key: %w", err)
 	}
-	// Build the frame header first and seal straight onto it: Seal appends the
-	// ciphertext into the space the header reserved, so the wire frame costs one
-	// buffer instead of a standalone ciphertext plus a copy of it.
+	// Seal straight onto the header: Seal appends the ciphertext into the space
+	// the header reserved, so the wire frame costs one buffer instead of a
+	// standalone ciphertext plus a copy of it.
 	wire, err := appendFrameHeader(nil, d.aead, masterKeyID, wrappedKey, nonce, len(data)+aead.Overhead())
 	if err != nil {
 		return nil, err

--- a/pkg/block/encryption/frame.go
+++ b/pkg/block/encryption/frame.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"slices"
 )
 
 // FrameMagic is the 5-byte prefix every encrypted block starts with.
@@ -71,24 +72,17 @@ func frameHeaderSize(b []byte) (headerLen int, framed bool, err error) {
 	return len(b) - len(view.ciphertext), true, nil
 }
 
-// encodeFrame builds the wire form for an encrypted block
+// appendFrameHeader appends everything up to (but excluding) the ciphertext to
+// out, sized so a ciphertext of ciphertextLen bytes appended afterwards fits
+// without regrowing:
 //
 //	[magic | version | aead | wrap | uvarint(len(masterKeyID)) | masterKeyID
 //	 | uvarint(len(wrappedKey)) | wrappedKey
 //	 | byte(len(nonce)) | nonce
 //	 | ciphertext+tag]
-func encodeFrame(aead AEAD, masterKeyID string, wrappedKey, nonce, ciphertext []byte) ([]byte, error) {
-	out, err := appendFrameHeader(nil, aead, masterKeyID, wrappedKey, nonce, len(ciphertext))
-	if err != nil {
-		return nil, err
-	}
-	return append(out, ciphertext...), nil
-}
-
-// appendFrameHeader appends everything up to (but excluding) the ciphertext to
-// out, sized so a ciphertext of ciphertextLen bytes appended afterwards fits
-// without regrowing. Sealing directly into the returned buffer produces the
-// wire frame without a separate ciphertext allocation and copy.
+//
+// Sealing directly into the returned buffer produces the wire frame without a
+// separate ciphertext allocation and copy.
 func appendFrameHeader(
 	out []byte,
 	aead AEAD,
@@ -106,12 +100,7 @@ func appendFrameHeader(
 		return nil, fmt.Errorf("encryption: nonce length %d out of range (1..%d)", len(nonce), MaxNonceSize)
 	}
 
-	frameCap := frameHeaderFixedSize + maxVarint + len(masterKeyID) + maxVarint + len(wrappedKey) + 1 + len(nonce) + ciphertextLen
-	if cap(out)-len(out) < frameCap {
-		grown := make([]byte, len(out), len(out)+frameCap)
-		copy(grown, out)
-		out = grown
-	}
+	out = slices.Grow(out, frameHeaderFixedSize+maxVarint+len(masterKeyID)+maxVarint+len(wrappedKey)+1+len(nonce)+ciphertextLen)
 	out = append(out, FrameMagic[:]...)
 	out = append(out, FrameVersion, byte(aead), wrapKindKeyProvider)
 

--- a/pkg/block/encryption/frame.go
+++ b/pkg/block/encryption/frame.go
@@ -78,6 +78,24 @@ func frameHeaderSize(b []byte) (headerLen int, framed bool, err error) {
 //	 | byte(len(nonce)) | nonce
 //	 | ciphertext+tag]
 func encodeFrame(aead AEAD, masterKeyID string, wrappedKey, nonce, ciphertext []byte) ([]byte, error) {
+	out, err := appendFrameHeader(nil, aead, masterKeyID, wrappedKey, nonce, len(ciphertext))
+	if err != nil {
+		return nil, err
+	}
+	return append(out, ciphertext...), nil
+}
+
+// appendFrameHeader appends everything up to (but excluding) the ciphertext to
+// out, sized so a ciphertext of ciphertextLen bytes appended afterwards fits
+// without regrowing. Sealing directly into the returned buffer produces the
+// wire frame without a separate ciphertext allocation and copy.
+func appendFrameHeader(
+	out []byte,
+	aead AEAD,
+	masterKeyID string,
+	wrappedKey, nonce []byte,
+	ciphertextLen int,
+) ([]byte, error) {
 	if len(masterKeyID) > MaxMasterKeyIDSize {
 		return nil, fmt.Errorf("encryption: master_key_id length %d exceeds cap %d", len(masterKeyID), MaxMasterKeyIDSize)
 	}
@@ -88,8 +106,12 @@ func encodeFrame(aead AEAD, masterKeyID string, wrappedKey, nonce, ciphertext []
 		return nil, fmt.Errorf("encryption: nonce length %d out of range (1..%d)", len(nonce), MaxNonceSize)
 	}
 
-	headerCap := frameHeaderFixedSize + maxVarint + len(masterKeyID) + maxVarint + len(wrappedKey) + 1 + len(nonce) + len(ciphertext)
-	out := make([]byte, 0, headerCap)
+	frameCap := frameHeaderFixedSize + maxVarint + len(masterKeyID) + maxVarint + len(wrappedKey) + 1 + len(nonce) + ciphertextLen
+	if cap(out)-len(out) < frameCap {
+		grown := make([]byte, len(out), len(out)+frameCap)
+		copy(grown, out)
+		out = grown
+	}
 	out = append(out, FrameMagic[:]...)
 	out = append(out, FrameVersion, byte(aead), wrapKindKeyProvider)
 
@@ -104,7 +126,6 @@ func encodeFrame(aead AEAD, masterKeyID string, wrappedKey, nonce, ciphertext []
 
 	out = append(out, byte(len(nonce)))
 	out = append(out, nonce...)
-	out = append(out, ciphertext...)
 	return out, nil
 }
 

--- a/pkg/block/encryption/frame_test.go
+++ b/pkg/block/encryption/frame_test.go
@@ -6,6 +6,16 @@ import (
 	"testing"
 )
 
+// encodeFrame builds the full wire frame, the way the seal path does by
+// sealing the ciphertext onto appendFrameHeader's output.
+func encodeFrame(aead AEAD, masterKeyID string, wrappedKey, nonce, ciphertext []byte) ([]byte, error) {
+	out, err := appendFrameHeader(nil, aead, masterKeyID, wrappedKey, nonce, len(ciphertext))
+	if err != nil {
+		return nil, err
+	}
+	return append(out, ciphertext...), nil
+}
+
 func TestFrame_RoundTrip(t *testing.T) {
 	masterID := "01234567-89ab-cdef-0123-456789abcdef"
 	wrappedKey := bytes.Repeat([]byte{0xA1}, 60)

--- a/pkg/block/engine/readahead.go
+++ b/pkg/block/engine/readahead.go
@@ -44,10 +44,15 @@ func (m *Syncer) planWindow(payloadID string, start, end uint64) (from, to uint6
 	}
 
 	// Lock-free per-payload lookup. A gosync.Map keeps the read hot path free of
-	// the global mutex that previously serialized every read here.
-	v, loaded := m.readahead.LoadOrStore(payloadID, &raState{})
-	if !loaded && m.readaheadN.Add(1) > maxReadaheadEntries {
-		m.pruneReadahead()
+	// the global mutex that previously serialized every read here. Load first so
+	// the steady-state hit does not build a throwaway raState per read; only a
+	// miss falls through to LoadOrStore.
+	v, loaded := m.readahead.Load(payloadID)
+	if !loaded {
+		v, loaded = m.readahead.LoadOrStore(payloadID, &raState{})
+		if !loaded && m.readaheadN.Add(1) > maxReadaheadEntries {
+			m.pruneReadahead()
+		}
 	}
 	st := v.(*raState)
 

--- a/pkg/block/engine/readahead.go
+++ b/pkg/block/engine/readahead.go
@@ -45,8 +45,7 @@ func (m *Syncer) planWindow(payloadID string, start, end uint64) (from, to uint6
 
 	// Lock-free per-payload lookup. A gosync.Map keeps the read hot path free of
 	// the global mutex that previously serialized every read here. Load first so
-	// the steady-state hit does not build a throwaway raState per read; only a
-	// miss falls through to LoadOrStore.
+	// the steady-state hit does not build a throwaway raState per read.
 	v, loaded := m.readahead.Load(payloadID)
 	if !loaded {
 		v, loaded = m.readahead.LoadOrStore(payloadID, &raState{})

--- a/pkg/block/local/memory/memory.go
+++ b/pkg/block/local/memory/memory.go
@@ -114,12 +114,17 @@ func (s *MemoryStore) ReadAt(_ context.Context, payloadID string, offset int64, 
 	if s.closed {
 		return 0, journal.ReadState{}, ErrStoreClosed
 	}
-	clear(dst)
 	f := s.files[payloadID]
 	if f == nil || offset >= int64(len(f.buf)) {
+		clear(dst)
 		return len(dst), journal.ReadState{Hole: true}, nil
 	}
+	// Zero only the tail the file does not cover; the copied prefix is
+	// overwritten anyway, so pre-clearing it would write those bytes twice.
 	n := copy(dst, f.buf[offset:])
+	if n < len(dst) {
+		clear(dst[n:])
+	}
 	return len(dst), journal.ReadState{Hole: n < len(dst)}, nil
 }
 

--- a/pkg/block/local/memory/memory.go
+++ b/pkg/block/local/memory/memory.go
@@ -119,8 +119,8 @@ func (s *MemoryStore) ReadAt(_ context.Context, payloadID string, offset int64, 
 		clear(dst)
 		return len(dst), journal.ReadState{Hole: true}, nil
 	}
-	// Zero only the tail the file does not cover; the copied prefix is
-	// overwritten anyway, so pre-clearing it would write those bytes twice.
+	// Zero only the tail the copy does not cover; pre-clearing the whole of dst
+	// would write the copied prefix twice.
 	n := copy(dst, f.buf[offset:])
 	if n < len(dst) {
 		clear(dst[n:])

--- a/pkg/block/remote/memory/store.go
+++ b/pkg/block/remote/memory/store.go
@@ -64,8 +64,7 @@ func New() *Store {
 
 // PutBlock writes the content of r under blocks/<blockID>. Implements
 // remote.RemoteBlockStore. Idempotent: a second call overwrites silently.
-// io.ReadAll returns a freshly allocated buffer owned by this store, so callers
-// may reuse r after return.
+// io.ReadAll allocates the stored buffer, so callers may reuse r after return.
 func (s *Store) PutBlock(_ context.Context, blockID string, r io.Reader) error {
 	data, err := io.ReadAll(r)
 	if err != nil {

--- a/pkg/block/remote/memory/store.go
+++ b/pkg/block/remote/memory/store.go
@@ -64,7 +64,8 @@ func New() *Store {
 
 // PutBlock writes the content of r under blocks/<blockID>. Implements
 // remote.RemoteBlockStore. Idempotent: a second call overwrites silently.
-// A defensive copy is taken via io.ReadAll; callers may reuse r after return.
+// io.ReadAll returns a freshly allocated buffer owned by this store, so callers
+// may reuse r after return.
 func (s *Store) PutBlock(_ context.Context, blockID string, r io.Reader) error {
 	data, err := io.ReadAll(r)
 	if err != nil {
@@ -78,9 +79,7 @@ func (s *Store) PutBlock(_ context.Context, blockID string, r io.Reader) error {
 	if s.blocksByID == nil {
 		s.blocksByID = make(map[string]*memBlock)
 	}
-	copied := make([]byte, len(data))
-	copy(copied, data)
-	s.blocksByID[blockID] = &memBlock{data: copied, lastModified: s.nowFn()}
+	s.blocksByID[blockID] = &memBlock{data: data, lastModified: s.nowFn()}
 	return nil
 }
 

--- a/pkg/metadata/cookies.go
+++ b/pkg/metadata/cookies.go
@@ -57,27 +57,23 @@ func NewCookieManager() *CookieManager {
 	}
 }
 
-// FNV-1a 64-bit constants.
 const (
-	fnvOffset64 = 14695981039346656037
-	fnvPrime64  = 1099511628211
+	fnvOffset64 uint64 = 14695981039346656037
+	fnvPrime64  uint64 = 1099511628211
 )
 
-// fnv1a64 is the FNV-1a 64-bit hash of handle followed by name. It is written
-// out as a plain loop rather than through hash/fnv so a READDIR page hashing
-// one cookie per directory entry allocates nothing: the hash.Hash64 box and
-// the string-to-[]byte conversion its Write would need both disappear. The
-// digest is byte-for-byte the same as hash/fnv produces for the same input,
-// so cookies stay stable across restarts.
+// fnv1a64 is the FNV-1a 64-bit hash of handle followed by name. Written as a
+// plain loop rather than through hash/fnv so a READDIR page hashing one cookie
+// per directory entry allocates nothing: the hash.Hash64 box and the
+// string-to-[]byte conversion its Write would need both disappear. The digest
+// matches hash/fnv byte-for-byte, so cookies stay stable across restarts.
 func fnv1a64(handle FileHandle, name string) uint64 {
-	h := uint64(fnvOffset64)
+	h := fnvOffset64
 	for _, b := range handle {
-		h ^= uint64(b)
-		h *= fnvPrime64
+		h = (h ^ uint64(b)) * fnvPrime64
 	}
-	for i := 0; i < len(name); i++ {
-		h ^= uint64(name[i])
-		h *= fnvPrime64
+	for _, b := range []byte(name) {
+		h = (h ^ uint64(b)) * fnvPrime64
 	}
 	return h
 }

--- a/pkg/metadata/cookies.go
+++ b/pkg/metadata/cookies.go
@@ -2,7 +2,6 @@ package metadata
 
 import (
 	"container/list"
-	"hash/fnv"
 	"sync"
 )
 
@@ -58,6 +57,31 @@ func NewCookieManager() *CookieManager {
 	}
 }
 
+// FNV-1a 64-bit constants.
+const (
+	fnvOffset64 = 14695981039346656037
+	fnvPrime64  = 1099511628211
+)
+
+// fnv1a64 is the FNV-1a 64-bit hash of handle followed by name. It is written
+// out as a plain loop rather than through hash/fnv so a READDIR page hashing
+// one cookie per directory entry allocates nothing: the hash.Hash64 box and
+// the string-to-[]byte conversion its Write would need both disappear. The
+// digest is byte-for-byte the same as hash/fnv produces for the same input,
+// so cookies stay stable across restarts.
+func fnv1a64(handle FileHandle, name string) uint64 {
+	h := uint64(fnvOffset64)
+	for _, b := range handle {
+		h ^= uint64(b)
+		h *= fnvPrime64
+	}
+	for i := 0; i < len(name); i++ {
+		h ^= uint64(name[i])
+		h *= fnvPrime64
+	}
+	return h
+}
+
 // GenerateCookie creates a unique cookie for a directory entry.
 // The cookie is based on the directory handle and entry name.
 // Returns 0 if the name is empty (indicating end of directory).
@@ -70,10 +94,7 @@ func (cm *CookieManager) GenerateCookie(dirHandle FileHandle, name string) uint6
 	}
 
 	// Generate cookie by hashing dirHandle + name
-	h := fnv.New64a()
-	h.Write([]byte(dirHandle))
-	h.Write([]byte(name))
-	cookie := h.Sum64()
+	cookie := fnv1a64(dirHandle, name)
 
 	// Ensure cookie is never 0 (reserved for start of directory)
 	if cookie == 0 {

--- a/pkg/metadata/cookies_test.go
+++ b/pkg/metadata/cookies_test.go
@@ -2,6 +2,7 @@ package metadata
 
 import (
 	"fmt"
+	"hash/fnv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -244,4 +245,23 @@ func TestCookieManager_RoundTrip(t *testing.T) {
 			seen[cookie] = true
 		}
 	})
+}
+
+// TestFNV1a64MatchesHashFNV pins the inlined digest to hash/fnv's output.
+// Cookies are handed to clients and must resolve after a restart, so the
+// hash must never drift from the one that produced the stored mappings.
+func TestFNV1a64MatchesHashFNV(t *testing.T) {
+	handles := []FileHandle{nil, {}, {0x00}, {0xde, 0xad, 0xbe, 0xef}, []byte("share:0123456789abcdef")}
+	names := []string{"", ".", "..", "a", "file.txt", "a very long entry name with spaces and ünïcödé"}
+
+	for _, h := range handles {
+		for _, n := range names {
+			want := fnv.New64a()
+			want.Write([]byte(h))
+			want.Write([]byte(n))
+			if got := fnv1a64(h, n); got != want.Sum64() {
+				t.Errorf("fnv1a64(%q, %q) = %d, want %d", h, n, got, want.Sum64())
+			}
+		}
+	}
 }

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -183,9 +183,8 @@ func (tx *sqliteTransaction) GetFile(ctx context.Context, handle metadata.FileHa
 		return nil, mapDBError(err, "GetFile", "")
 	}
 
-	// Debug logging to trace file type issues. Gated so the id formatting and
-	// variadic boxing are skipped entirely when Debug is off — GetFile runs on
-	// every lookup.
+	// Debug logging to trace file type issues, gated so the id formatting and
+	// variadic boxing are skipped when Debug is off.
 	if tx.store.logger.Enabled(ctx, slog.LevelDebug) {
 		tx.store.logger.Debug("GetFile retrieved",
 			"id", id.String(),
@@ -518,8 +517,8 @@ func (tx *sqliteTransaction) GetChild(ctx context.Context, dirHandle metadata.Fi
 		return nil, mapDBError(err, "GetChild", name)
 	}
 
-	// Debug logging to trace child lookup. Gated so the parent-id formatting is
-	// skipped when Debug is off — GetChild runs on every path component.
+	// Debug logging to trace child lookup, gated so the parent-id formatting is
+	// skipped when Debug is off.
 	if tx.store.logger.Enabled(ctx, slog.LevelDebug) {
 		tx.store.logger.Debug("GetChild found",
 			"parent_id", parentID.String(),

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
@@ -182,13 +183,17 @@ func (tx *sqliteTransaction) GetFile(ctx context.Context, handle metadata.FileHa
 		return nil, mapDBError(err, "GetFile", "")
 	}
 
-	// Debug logging to trace file type issues
-	tx.store.logger.Debug("GetFile retrieved",
-		"id", id.String(),
-		"share", shareName,
-		"path", file.Path,
-		"file_type", int(file.Type),
-		"size", file.Size)
+	// Debug logging to trace file type issues. Gated so the id formatting and
+	// variadic boxing are skipped entirely when Debug is off — GetFile runs on
+	// every lookup.
+	if tx.store.logger.Enabled(ctx, slog.LevelDebug) {
+		tx.store.logger.Debug("GetFile retrieved",
+			"id", id.String(),
+			"share", shareName,
+			"path", file.Path,
+			"file_type", int(file.Type),
+			"size", file.Size)
+	}
 
 	return file, nil
 }
@@ -399,13 +404,16 @@ func (tx *sqliteTransaction) PutFile(ctx context.Context, file *metadata.File) e
 			tx.quota.Add(file.UID, file.GID, int64(file.Size), 1)
 		}
 
-		// Debug logging for new file inserts
-		tx.store.logger.Debug("PutFile inserted",
-			"id", file.ID.String(),
-			"share", file.ShareName,
-			"path", file.Path,
-			"file_type", int(file.Type),
-			"size", file.Size)
+		// Debug logging for new file inserts, gated so the id formatting is
+		// skipped when Debug is off.
+		if tx.store.logger.Enabled(ctx, slog.LevelDebug) {
+			tx.store.logger.Debug("PutFile inserted",
+				"id", file.ID.String(),
+				"share", file.ShareName,
+				"path", file.Path,
+				"file_type", int(file.Type),
+				"size", file.Size)
+		}
 	}
 
 	// persist FileAttr.Blocks into file_block_refs — but ONLY when the caller
@@ -510,12 +518,15 @@ func (tx *sqliteTransaction) GetChild(ctx context.Context, dirHandle metadata.Fi
 		return nil, mapDBError(err, "GetChild", name)
 	}
 
-	// Debug logging to trace child lookup
-	tx.store.logger.Debug("GetChild found",
-		"parent_id", parentID.String(),
-		"child_name", name,
-		"child_id", childID,
-		"share", shareName)
+	// Debug logging to trace child lookup. Gated so the parent-id formatting is
+	// skipped when Debug is off — GetChild runs on every path component.
+	if tx.store.logger.Enabled(ctx, slog.LevelDebug) {
+		tx.store.logger.Debug("GetChild found",
+			"parent_id", parentID.String(),
+			"child_name", name,
+			"child_id", childID,
+			"share", shareName)
+	}
 
 	return encodeFileHandle(shareName, childID)
 }


### PR DESCRIPTION
Sweep of the 21 LOW `perf` findings from the data-plane audit. Each was verified against current `develop` first — these carried no independent verification, so several turned out not to be worth a diff. Bar applied: the path must be genuinely per-request / per-block / per-directory-entry, and the fix must be small and obviously behaviour-preserving.

## Changed

- `internal/adapter/nfs/v3/handlers/read.go:116` — **FIXED**. Handle hex was formatted on every READ/WRITE/COMMIT regardless of level; routed through a new `xdr.LazyHandle` slog.LogValuer so the string is built only when a record is emitted.
- `internal/adapter/nfs/v4/handlers/read_plus.go:216` — **FIXED**. Reply buffer now pre-sized to the exact wire size, matching `encodeRead4resok`.
- `internal/adapter/smb/handlers/write.go:161` — **FIXED**. Same treatment for the SMB READ/WRITE entry logs via a `lazyFileID` LogValuer.
- `pkg/block/compression/frame.go:45` — **FIXED**. The frame header is reserved in the buffer the codec streams into, so the framed body is no longer allocated and copied a second time. Measured on a 4 MiB semi-compressible block: 20.6 MB → 14.7 MB allocated per Put. The frame-vs-plaintext decision is numerically unchanged.
- `pkg/block/encryption/frame.go:107` — **FIXED**. Header is built first and `aead.Seal` appends the ciphertext in place, dropping the standalone ciphertext allocation plus its copy.
- `pkg/block/engine/readahead.go:48` — **FIXED**. `Load` before `LoadOrStore`, so a steady-state read no longer builds a throwaway `raState`.
- `pkg/block/local/memory/memory.go:114` — **FIXED**. Zero only the tail the copy does not cover.
- `pkg/block/remote/memory/store.go:69` — **FIXED**. Dropped the redundant second copy; `io.ReadAll` already returns a private buffer and every read path copies on the way out.
- `pkg/metadata/cookies.go:73` — **FIXED**. FNV-1a inlined as a plain loop, dropping all 3 allocations per directory entry. Pinned to `hash/fnv`'s output by a new test — cookies must stay stable across restarts.
- `pkg/metadata/store/sqlite/transaction.go:496` — **FIXED**. The three ad-hoc `Debug` logs on GetFile/PutFile/GetChild are gated on `logger.Enabled`, so the id formatting is skipped when Debug is off.

## Not changed

- `pkg/block/engine/warm.go:95` — **REFUTED**. The code already carries a comment explaining the probe is impossible: the journal is not hash-keyed. `WarmAll` is also an operator-triggered one-shot.
- `pkg/block/encryption/keyprovider/local.go:239` — **WONTFIX**. Real, but `cipher.NewGCM` is dwarfed by the per-chunk AEAD seal it sits next to, and a cached AEAD would outlive `Close()`'s key zeroization.
- `pkg/block/engine/compaction.go:237` — **WONTFIX**. Background GC pass, not a request path; a pre-built locator snapshot would also change the freshness the move decision relies on.
- `pkg/metadata/auth_permissions.go:489` — **WONTFIX**. The loop only evaluates the bits actually requested (normally one). Folding masks into one `EvaluateGranted` risks DENY / owner-implicit semantics drift for no measurable gain.
- `pkg/metadata/store/badger/durable_handles.go:324` — **WONTFIX**. SMB durable-handle reconnect and the expiry janitor, not a per-request path.
- `pkg/metadata/store/badger/transaction.go:438` — **WONTFIX**. A transient "manifest externalized" flag that goes stale means a manifest silently not written — data loss risk far outweighing one point-Get.
- `pkg/metadata/store/badger/transaction.go:795` — **WONTFIX**. Real N+1, but an attrs-optional variant means changing the store interface and the conformance suite across every backend.
- `pkg/metadata/store/memory/files.go:362`, `store.go:557`, `transaction.go:87` — **WONTFIX**. The memory metadata store clones the entire store on every mutation by design; one O(n) among many does not move a real workload.
- `pkg/controlplane/runtime/metrics.go:27` — **WONTFIX**. Per-scrape, N = number of shares; batching needs a new store API.
