### PR TITLE
fix(block): write manifest rows for deduped carve chunks

### DIFF
--- a/pkg/block/engine/blocksink.go
+++ b/pkg/block/engine/blocksink.go
@@ -95,42 +95,56 @@ type localBlockSink struct {
 	commitLocks *carveCommitLocks
 }
 
+// manifestRows projects a carve batch into its per-file FileChunk rows. Data is
+// nil for a deduped chunk, so the row length comes from Size.
+func manifestRows(chunks []journal.CarveChunk) []*block.FileChunk {
+	rows := make([]*block.FileChunk, 0, len(chunks))
+	for i := range chunks {
+		c := chunks[i]
+		size := len(c.Data)
+		if c.Data == nil {
+			size = c.Size
+		}
+		rows = append(rows, &block.FileChunk{
+			ID:       fmt.Sprintf("%s/%d", c.FileID, c.FileOffset),
+			Hash:     block.ContentHash(c.Hash),
+			DataSize: uint32(size),
+			State:    block.BlockStatePending,
+		})
+	}
+	return rows
+}
+
+// commitManifestRows writes a batch's manifest rows and re-materializes
+// File.Blocks in one txn — the entire output of the local sink, and of a remote
+// batch whose chunks all deduped. Merging only this batch's rows keeps a
+// multi-batch carve from re-listing and re-sorting the whole growing manifest
+// per batch; superseded rows are reaped once at run end.
+func commitManifestRows(ctx context.Context, committer blockCommitter, locks *carveCommitLocks, payloadID string, rows []*block.FileChunk) error {
+	if committer == nil {
+		return fmt.Errorf("carve: no transactional committer wired")
+	}
+	// Serialize this file's commits so overlapping dispatcher calls don't abort
+	// on the shared File-row projection under SSI.
+	if mu := locks.forKey(payloadID); mu != nil {
+		mu.Lock()
+		defer mu.Unlock()
+	}
+	return committer.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		for _, fc := range rows {
+			if err := tx.Put(ctx, fc); err != nil {
+				return fmt.Errorf("carve: put manifest row %s: %w", fc.ID, err)
+			}
+		}
+		return metadata.ProjectCommittedChunks(ctx, tx, payloadID, rows)
+	})
+}
+
 func (s localBlockSink) CommitBlock(ctx context.Context, chunks []journal.CarveChunk) error {
 	if len(chunks) == 0 {
 		return nil
 	}
-	if s.committer == nil {
-		return fmt.Errorf("local carve: no transactional committer wired")
-	}
-	payloadID := string(chunks[0].FileID)
-	fileChunks := make([]*block.FileChunk, 0, len(chunks))
-	for i := range chunks {
-		c := chunks[i]
-		fileChunks = append(fileChunks, &block.FileChunk{
-			ID:       fmt.Sprintf("%s/%d", c.FileID, c.FileOffset),
-			Hash:     block.ContentHash(c.Hash),
-			DataSize: uint32(len(c.Data)),
-			State:    block.BlockStatePending,
-		})
-	}
-	// Serialize this file's commits so overlapping dispatcher calls don't abort
-	// on the shared File-row projection under SSI.
-	if mu := s.commitLocks.forKey(payloadID); mu != nil {
-		mu.Lock()
-		defer mu.Unlock()
-	}
-	return s.committer.WithTransaction(ctx, func(tx metadata.Transaction) error {
-		for _, fc := range fileChunks {
-			if err := tx.Put(ctx, fc); err != nil {
-				return fmt.Errorf("local carve: put manifest row %s: %w", fc.ID, err)
-			}
-		}
-		// Materialize File.Blocks from the manifest — same txn (R), merging only
-		// this batch's rows so a multi-batch carve does not re-list and re-sort
-		// the whole growing manifest per batch. Superseded-row reaping runs once
-		// at run end (ReapSupersededManifest), not per batch.
-		return metadata.ProjectCommittedChunks(ctx, tx, payloadID, fileChunks)
-	})
+	return commitManifestRows(ctx, s.committer, s.commitLocks, string(chunks[0].FileID), manifestRows(chunks))
 }
 
 // ReapSupersededManifest implements journal's optional run-end reap: once a carve
@@ -178,20 +192,33 @@ func (s engineBlockSink) CommitBlock(ctx context.Context, chunks []journal.Carve
 		return nil
 	}
 
+	// Rows cover the whole batch; only chunks carrying bytes are framed and
+	// uploaded. A deduped chunk is already remote-durable, so its row is all that
+	// is missing — and it must land, or the run-end reap leaves the range with no
+	// manifest coverage.
+	fileChunks := manifestRows(chunks)
+	var rawBytes int64
+	novel := 0
+	for i := range chunks {
+		if chunks[i].Data != nil {
+			novel++
+			rawBytes += int64(len(chunks[i].Data))
+		}
+	}
+	if novel == 0 {
+		return commitManifestRows(ctx, s.committer, s.commitLocks, string(chunks[0].FileID), fileChunks)
+	}
+
 	blockID, err := newBlockID()
 	if err != nil {
 		return err
 	}
 
-	var rawBytes int64
-	for i := range chunks {
-		rawBytes += int64(len(chunks[i].Data))
-	}
 	var buf bytes.Buffer
 	// Pre-size so the block lands in one backing array: raw bytes plus per-chunk
 	// codec/seal headroom. Best-effort — skipped on an absurd size rather than
 	// risk a negative int conversion.
-	if grow := rawBytes + int64(len(chunks))*256 + 512; grow > 0 && grow <= math.MaxInt {
+	if grow := rawBytes + int64(novel)*256 + 512; grow > 0 && grow <= math.MaxInt {
 		buf.Grow(int(grow))
 	}
 	// nil header-sealer: bodies are sealed per-chunk below, matching the carver.
@@ -200,10 +227,12 @@ func (s engineBlockSink) CommitBlock(ctx context.Context, chunks []journal.Carve
 		return fmt.Errorf("carve: new builder: %w", err)
 	}
 
-	commits := make([]block.BlockChunkCommit, 0, len(chunks))
-	fileChunks := make([]*block.FileChunk, 0, len(chunks))
+	commits := make([]block.BlockChunkCommit, 0, novel)
 	for i := range chunks {
 		c := chunks[i]
+		if c.Data == nil {
+			continue // deduped: manifest row only, nothing to frame
+		}
 		h := block.ContentHash(c.Hash)
 
 		wire := c.Data
@@ -220,12 +249,6 @@ func (s engineBlockSink) CommitBlock(ctx context.Context, chunks []journal.Carve
 		// Local stays zero — the journal owns the local bytes, so there is no
 		// log-blob location to record (DefaultCommitBlock treats zero as "none").
 		commits = append(commits, block.BlockChunkCommit{Hash: h, Remote: chunkLoc})
-		fileChunks = append(fileChunks, &block.FileChunk{
-			ID:       fmt.Sprintf("%s/%d", c.FileID, c.FileOffset),
-			Hash:     h,
-			DataSize: uint32(len(c.Data)),
-			State:    block.BlockStatePending,
-		})
 	}
 	if _, err := builder.Finish(); err != nil {
 		return fmt.Errorf("carve: finish block: %w", err)

--- a/pkg/block/engine/carve_dedup_manifest_test.go
+++ b/pkg/block/engine/carve_dedup_manifest_test.go
@@ -1,0 +1,106 @@
+package engine_test
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// TestCarveDedupedChunk_KeepsManifestRow: a carve run whose chunks all dedup
+// against already-durable hashes must still write their manifest rows. Without
+// them the run-end reap (which treats every carved offset as covered) deletes
+// the rows that used to back the range, and the cold read resolves a stale
+// straddler or a gap.
+func TestCarveDedupedChunk_KeepsManifestRow(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	bs := newEngineWithRemote(t, ms, remotememory.New())
+	root := createShare(t, ms, "dedup")
+	pid, _ := createRealFile(t, ms, "dedup", "dup.bin", root)
+
+	const half = 4 * 1024 * 1024
+	data := make([]byte, half)
+	rand.New(rand.NewSource(0xD00D)).Read(data) //nolint:gosec // deterministic fixture
+
+	if _, err := bs.WriteAt(ctx, pid, nil, data, 0); err != nil {
+		t.Fatalf("first WriteAt: %v", err)
+	}
+	carve(t, bs, ctx, pid)
+
+	// The same bytes at a fresh offset: every chunk hashes to an already-durable
+	// chunk, so the whole run dedups.
+	if _, err := bs.WriteAt(ctx, pid, nil, data, half); err != nil {
+		t.Fatalf("duplicate WriteAt: %v", err)
+	}
+	carve(t, bs, ctx, pid)
+
+	if _, err := bs.DrainLocalSynced(ctx); err != nil {
+		t.Fatalf("DrainLocalSynced: %v", err)
+	}
+	got := make([]byte, half)
+	if _, err := bs.ReadAt(ctx, pid, nil, got, half); err != nil {
+		t.Fatalf("cold ReadAt: %v", err)
+	}
+	if i := firstDiff(data, got); i >= 0 {
+		t.Fatalf("cold read of the deduped copy differs at byte %d (abs %d): got %d want %d",
+			i, half+i, got[i], data[i])
+	}
+}
+
+// TestPunchHole_RepunchReadsBackZerosCold: re-punching a range re-carves zeros
+// that already dedup, so the run packs no novel chunk. The range must still read
+// back as zeros after eviction (RFC 7862 DEALLOCATE).
+func TestPunchHole_RepunchReadsBackZerosCold(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	bs := newEngineWithRemote(t, ms, remotememory.New())
+	root := createShare(t, ms, "punch2")
+	pid, _ := createRealFile(t, ms, "punch2", "p.bin", root)
+
+	const size = 8 * 1024 * 1024
+	data := make([]byte, size)
+	rand.New(rand.NewSource(0xF00D)).Read(data) //nolint:gosec // deterministic fixture
+	if _, err := bs.WriteAt(ctx, pid, nil, data, 0); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	carve(t, bs, ctx, pid)
+
+	punch := func(off, length uint64) {
+		t.Helper()
+		if _, err := bs.PunchHole(ctx, pid, manifestRefs(t, ms, pid), off, length); err != nil {
+			t.Fatalf("PunchHole(%d,%d): %v", off, length, err)
+		}
+		carve(t, bs, ctx, pid)
+		clear(data[off : off+length])
+	}
+	// Re-punching the same range is idempotent per RFC 7862; the second pass
+	// re-carves the identical zeros, so every chunk dedups and the run packs no
+	// novel chunk at all.
+	punch(1<<20, 2<<20)
+	punch(1<<20, 2<<20)
+
+	if _, err := bs.DrainLocalSynced(ctx); err != nil {
+		t.Fatalf("DrainLocalSynced: %v", err)
+	}
+	got := make([]byte, size)
+	if _, err := bs.ReadAt(ctx, pid, nil, got, 0); err != nil {
+		t.Fatalf("cold ReadAt: %v", err)
+	}
+	if i := firstDiff(data, got); i >= 0 {
+		t.Fatalf("cold read mismatch at byte %d: got %d want %d", i, got[i], data[i])
+	}
+}
+
+// firstDiff returns the index of the first byte where want and got differ, or
+// -1 when they are identical. Both must be the same length.
+func firstDiff(want, got []byte) int {
+	for i := range want {
+		if want[i] != got[i] {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -75,7 +75,8 @@ type CarveChunk struct {
 	Hash       ChunkHash
 	FileID     FileID
 	FileOffset int64  // logical offset of the chunk within the file
-	Data       []byte // plaintext; the sink seals it before framing
+	Size       int    // chunk length; authoritative when Data is nil
+	Data       []byte // plaintext; nil when the chunk deduped (nothing to upload)
 }
 
 // BlockSink seals, frames, uploads (PutBlock) and atomically commits one block's
@@ -277,11 +278,15 @@ func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interv
 	// first novel chunk claims a pool buffer and a concurrency slot); arenaOff is
 	// the fill cursor. On any early exit these are returned to disp so the slot and
 	// buffer are not leaked.
+	// batchBytes counts the run bytes this batch tiles, deduped chunks included,
+	// so a fully deduped batch (empty arena) is still bounded and committed on the
+	// same cadence as one carrying bytes.
 	var (
-		pending  []CarveChunk
-		arenap   *[]byte
-		arena    []byte
-		arenaOff int
+		pending    []CarveChunk
+		arenap     *[]byte
+		arena      []byte
+		arenaOff   int
+		batchBytes int64
 	)
 	ensureArena := func() error {
 		if arenap != nil {
@@ -301,7 +306,7 @@ func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interv
 	// dispatcher, so the local arena state resets to "no block".
 	flush := func(watermark int64) {
 		disp.submit(pending, arenap, arena, watermark)
-		pending, arenap, arena, arenaOff = nil, nil, nil, 0
+		pending, arenap, arena, arenaOff, batchBytes = nil, nil, nil, 0, 0
 	}
 
 	// buf accumulates bytes for the chunker; it never exceeds one max chunk, so
@@ -367,6 +372,10 @@ func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interv
 			packErr = err
 			break
 		}
+		// A deduped chunk has nothing to upload but still needs its manifest row:
+		// the run-end reap deletes every row in the run span the run did not write,
+		// so dropping it here leaves the range on a stale straddler or on nothing.
+		cc := CarveChunk{Hash: h, FileID: id, FileOffset: fileOff, Size: boundary}
 		if !durable {
 			if err := ensureArena(); err != nil {
 				packErr = err
@@ -386,14 +395,16 @@ func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interv
 			data := arena[arenaOff : arenaOff+boundary : arenaOff+boundary]
 			copy(data, buf[:boundary])
 			arenaOff += boundary
-			pending = append(pending, CarveChunk{Hash: h, FileID: id, FileOffset: fileOff, Data: data})
+			cc.Data = data
 			res.BytesCarved += int64(boundary)
 		}
+		pending = append(pending, cc)
+		batchBytes += int64(boundary)
 		newOffsets[fileOff] = struct{}{}
 		fileOff += int64(boundary)
 		buf = append(buf[:0], buf[boundary:]...)
 
-		if int64(arenaOff) >= s.cfg.CarveBlockSize {
+		if batchBytes >= s.cfg.CarveBlockSize {
 			flush(fileOff)
 		}
 		if eof && len(buf) == 0 {

--- a/pkg/block/journal/carve_dispatch.go
+++ b/pkg/block/journal/carve_dispatch.go
@@ -87,22 +87,35 @@ func (d *carveDispatcher) acquire(arenaCap int) (*[]byte, error) {
 // block's final backing slice (it may have grown past the pooled buffer while
 // packing), stored back into the pool on completion.
 func (d *carveDispatcher) submit(chunks []CarveChunk, arenap *[]byte, arena []byte, watermark int64) {
+	// A batch of only deduped chunks holds no arena and so has claimed no slot in
+	// acquire; take one here so its commit is throttled like any other. Giving up
+	// on a cancelled context is safe: the commit below fails on the same context.
+	slot := arenap != nil
+	if !slot && len(chunks) > 0 {
+		select {
+		case d.sem <- struct{}{}:
+			slot = true
+		case <-d.ctx.Done():
+		}
+	}
 	mine := make(chan bool, 1)
 	prev := d.prev
 	d.prev = mine
 	d.wg.Add(1)
-	go d.commitAndFlip(chunks, arenap, arena, watermark, prev, mine)
+	go d.commitAndFlip(chunks, arenap, arena, watermark, prev, mine, slot)
 }
 
-func (d *carveDispatcher) commitAndFlip(chunks []CarveChunk, arenap *[]byte, arena []byte, watermark int64, prev, mine chan bool) {
+func (d *carveDispatcher) commitAndFlip(chunks []CarveChunk, arenap *[]byte, arena []byte, watermark int64, prev, mine chan bool, slot bool) {
 	defer d.wg.Done()
+	if slot {
+		// Release the slot only after CommitBlock has consumed the Data slices
+		// (the sink copies them before returning) and the flip ran.
+		defer func() { <-d.sem }()
+	}
 	if arenap != nil {
-		// Free the buffer and the slot only after CommitBlock has consumed the
-		// Data slices (the sink copies them before returning) and the flip ran.
 		defer func() {
 			*arenap = arena
 			carveArenaPool.Put(arenap)
-			<-d.sem
 		}()
 	}
 
@@ -126,7 +139,9 @@ func (d *carveDispatcher) commitAndFlip(chunks []CarveChunk, arenap *[]byte, are
 		if err := d.s.flipUpTo(d.sh, d.id, d.run, d.flipIdx, watermark); err != nil {
 			d.setErr(err)
 			ok = false
-		} else if len(chunks) > 0 {
+		} else if arenap != nil {
+			// An arena is claimed only by a chunk carrying bytes: a batch of purely
+			// deduped chunks writes manifest rows but no block.
 			d.res.BlocksWritten++
 		}
 	case proceed && commitErr != nil:

--- a/pkg/block/journal/carve_dispatch_test.go
+++ b/pkg/block/journal/carve_dispatch_test.go
@@ -101,6 +101,16 @@ func (s *ctrlSink) releaseAll() {
 	}
 }
 
+// reset re-gates the sink and clears its counters so a second carve pass can be
+// observed on its own.
+func (s *ctrlSink) reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.openAll = false
+	s.blocks, s.inFlight, s.maxInFlight = 0, 0, 0
+	s.arrived = make(chan int64, 512)
+}
+
 func (s *ctrlSink) peak() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -301,5 +311,49 @@ func TestCarveConcurrentCommitErrorStopsWatermark(t *testing.T) {
 	}
 	if f := recRawFlags(t, s, "f", failAt); f&flagSynced != 0 {
 		t.Fatalf("failed block's record flipped synced: off=%d flags=%#x", failAt, f)
+	}
+}
+
+// TestCarveConcurrencyBoundedWhenDeduped: a re-carve whose chunks all dedup
+// packs no bytes, so its batches carry manifest rows only and claim no arena.
+// They must still be throttled by the upload window — otherwise a large punched
+// range, where every zero chunk dedups, submits a commit per batch unthrottled.
+func TestCarveConcurrencyBoundedWhenDeduped(t *testing.T) {
+	const window = 4
+	s, sink := ctrlStore(t, window)
+	writeAdjacent(t, s, "f", 128, 4<<10)
+
+	// First pass ungated: it marks every hash durable, so the re-carve dedups.
+	sink.releaseAll()
+	if _, err := s.Carve(context.Background(), CarveOptions{Force: true}); err != nil {
+		t.Fatalf("first carve: %v", err)
+	}
+	sink.reset()
+
+	forceDirty(t, s, "f")
+	done := carveAsync(s)
+
+	for i := 0; i < window; i++ {
+		select {
+		case <-sink.arrived:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("only %d of %d row-only commits reached the sink", i, window)
+		}
+	}
+	select {
+	case off := <-sink.arrived:
+		t.Fatalf("more than window=%d row-only commits in flight (extra at off %d)", window, off)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	sink.releaseAll()
+	if err := <-done; err != nil {
+		t.Fatalf("re-carve: %v", err)
+	}
+	if got := sink.peak(); got != window {
+		t.Fatalf("peak in-flight row-only commits = %d, want exactly the window %d", got, window)
+	}
+	if s.UnsyncedBytes() != 0 {
+		t.Fatalf("post-carve unsynced=%d want 0", s.UnsyncedBytes())
 	}
 }

--- a/pkg/block/journal/carve_test.go
+++ b/pkg/block/journal/carve_test.go
@@ -80,12 +80,21 @@ func (s *fakeSink) CommitBlock(_ context.Context, chunks []CarveChunk) error {
 		return failErr
 	}
 	s.mu.Lock()
-	s.blocks++
+	// A batch whose chunks all deduped carries manifest rows only (Data nil): the
+	// real sink frames and uploads nothing for it, so it is not a written block.
+	wroteBlock := false
 	for _, c := range chunks {
+		if c.Data == nil {
+			continue
+		}
 		cp := make([]byte, len(c.Data))
 		copy(cp, c.Data)
 		s.chunks[c.FileOffset] = cp
 		s.dedup.markDurable(c.Hash)
+		wroteBlock = true
+	}
+	if wroteBlock {
+		s.blocks++
 	}
 	s.mu.Unlock()
 	return nil

--- a/pkg/block/local/memory/memory.go
+++ b/pkg/block/local/memory/memory.go
@@ -239,19 +239,21 @@ func (s *MemoryStore) Carve(ctx context.Context, opts journal.CarveOptions) (jou
 			continue
 		}
 		h := journal.ChunkHash(blake3.Sum256(data))
+		cc := journal.CarveChunk{Hash: h, FileID: journal.FileID(id), FileOffset: 0, Size: len(data), Data: data}
 		if d != nil {
+			// Already remote-durable: hand the sink a row-only chunk so the manifest
+			// still records it, but upload nothing.
 			if durable, err := d.IsChunkDurable(ctx, h); err == nil && durable {
-				s.markCarved(id)
-				continue
+				cc.Data = nil
 			}
 		}
-		if err := sink.CommitBlock(ctx, []journal.CarveChunk{{
-			Hash: h, FileID: journal.FileID(id), FileOffset: 0, Data: data,
-		}}); err != nil {
+		if err := sink.CommitBlock(ctx, []journal.CarveChunk{cc}); err != nil {
 			return res, err
 		}
-		res.BlocksWritten++
-		res.BytesCarved += int64(len(data))
+		if cc.Data != nil {
+			res.BlocksWritten++
+			res.BytesCarved += int64(len(data))
+		}
 		s.markCarved(id)
 	}
 	return res, nil


### PR DESCRIPTION
## Root cause

`carveRun` skipped a chunk whose hash the deduper reported already remote-durable — it was
never appended to `pending`, so it never reached `BlockSink.CommitBlock`, **the only writer of
per-file `FileChunk` manifest rows**. Its offset *was* recorded in `newOffsets`, and the
run-end `ReapSupersededManifest` deletes every row starting in `[runStart, runEnd)` that is not
in `newOffsets`. So the reap treated the range as freshly tiled and deleted the rows that
actually backed it.

While the local bytes are still warm the read is served from the journal and looks fine. Once
they are evicted (or the process restarts) the range resolves to a stale straddling row —
pre-overwrite bytes — or to nothing, which zero-fills. Silent wrong data, no error.

`PunchHole` hits it constantly because zeros dedup globally, but it is not punch-specific: a
plain duplicate write reproduces it. `TestCarveDedupedChunk_KeepsManifestRow` writes 4 MiB,
carves, writes the *same* 4 MiB at a fresh offset, carves, evicts, and reads the second copy
back — pre-fix it reads back as **zeros**.

## Fix

Deduped chunks are handed to the sink as row-only chunks (`Data` nil, `Size` set):

- `engineBlockSink.CommitBlock` builds manifest rows for the whole batch, frames/seals/uploads
  only chunks carrying bytes, and when a batch has no novel chunk writes the rows plus the
  `File.Blocks` projection in one txn — no `PutBlock`, no block record. A re-carve of
  already-durable content stays upload-free, which is what the dedup oracle is for.
- Batches are bounded by the run bytes they tile rather than by arena fill, so an all-deduped
  batch commits on the same cadence as one carrying bytes, and it claims an upload-window slot
  like any other. Without that a fully deduped run — exactly the large-punch case — submits its
  commits unthrottled; `TestCarveConcurrencyBoundedWhenDeduped` pins the bound and fails
  without the slot.
- `pkg/block/local/memory`'s carve loop skipped deduped chunks the same way and now emits a
  row-only chunk too.

`fakeSink.blockCount()` now counts batches that actually carry bytes, matching the real sinks;
the two dedup no-op tests still assert a re-carve uploads nothing and re-flips.

## Verification

- New `TestCarveDedupedChunk_KeepsManifestRow` (root cause) and
  `TestPunchHole_RepunchReadsBackZerosCold` (an all-deduped punch carve); the first fails on
  develop.
- New `TestCarveConcurrencyBoundedWhenDeduped`; fails without the slot acquisition.
- The 24-seed randomized mutation soak from #1956: **24/24 pass** (5 failed pre-fix).
- `go test ./...`, `go vet ./...`, `gofmt` clean; `-race` green on `pkg/block/journal`,
  `pkg/block/engine`, `pkg/block/local/...`.

## Not closed by this PR

Under `-race` the soak drops from **8/24 failing on develop to 1/24** with this change. The
remaining seed is a second, independent defect: a stale row that straddles a carve seam shadows
the fresh row's head on a cold sequential read. It reproduces deterministically on unmodified
develop, so it is not a regression here — filed as **#1974** with the repro. #1956 should stay
open until that lands; the soak is held out of the tree for the same reason and should land
with #1974.

Refs #1956
