### PR TITLE
test(metadata): split the combined error and value check in the read-cache test

### DIFF
--- a/pkg/metadata/store/badger/read_cache_test.go
+++ b/pkg/metadata/store/badger/read_cache_test.go
@@ -42,8 +42,11 @@ func TestReadCache_NoStaleReadAfterMutation(t *testing.T) {
 	handle := putFileForTest(t, s, "/s", "/f", 0o644, 4)
 
 	got, err := s.GetFileForRead(ctx, handle) // populates the cache
-	if err != nil || got.Mode != 0o644 {
-		t.Fatalf("first read: mode=%o err=%v", got.Mode, err)
+	if err != nil {
+		t.Fatalf("first read: %v", err)
+	}
+	if got.Mode != 0o644 {
+		t.Fatalf("first read: mode=%o, want 644", got.Mode)
 	}
 
 	// Mutate via PutFile — must invalidate the cache.


### PR DESCRIPTION
TestReadCache_NoStaleReadAfterMutation combined the error and value check:

    if err != nil || got.Mode != 0o644 {
        t.Fatalf("first read: mode=%o err=%v", got.Mode, err)
    }

On a non-nil error GetFileForRead returns a nil file, so evaluating the Fatalf arguments dereferences it and the test panics before the message prints — the failure mode the assertion exists to report is exactly the one it cannot report.

Split into two checks. Test-only; predates #1975 (from #1654). Raised by Copilot on #1975, which squash-merged before the fix was pushed to its branch.