### PR TITLE
docs(skills): add fix-issue and solve-issues workflow skills

### DIFF
--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -1,0 +1,274 @@
+---
+name: fix-issue
+description: End-to-end workflow for taking a DittoFS GitHub issue from report to merged fix — read the issue, test its premise, reproduce, fix the root cause, verify, open a PR against develop, babysit Copilot and CI, squash-merge, and close the issue. Use this whenever a DittoFS issue is referenced by number or URL and any work on it is implied ("fix #1934", "address issue 1888", "look into 1923", "what's going on with https://github.com/.../issues/1956"), including when the ask is only to investigate — the investigation half applies either way. Also use when resuming an in-flight issue branch or PR.
+---
+
+# Fixing a DittoFS issue
+
+Take the issue from report to merged, autonomously. The stop conditions at the
+end are the only places to come back.
+
+The most expensive failure mode here is **a confident fix for the wrong
+problem**. Issues describe symptoms and often carry a theory about the cause;
+that theory is frequently wrong — sometimes written by a past agent that read
+code without running it.
+
+## 1. Set up an isolated workspace
+
+Other agents work this repo concurrently. Never build in the primary checkout.
+
+```bash
+cd /Users/marmos91/Projects/dittofs
+git fetch origin && git log --oneline -1 origin/develop   # know your base
+git worktree add ~/dittofs-worktrees/<slug> -b fix/<issue>-<slug> origin/develop
+```
+
+`<slug>` is 2-4 words naming the defect (`1934-resolve-covering`,
+`1888-unplaceable-guard`); use `feat/` instead of `fix/` for feature issues.
+Branch from `origin/develop`, never from a local `develop` that may be stale and
+never from a stash. Worktrees live in `~/dittofs-worktrees/`, never `/tmp` —
+they outlive the session and you may need to come back to one.
+
+## 2. Read the issue, then distrust it
+
+```bash
+gh issue view <N> --comments
+```
+
+Keep three things separate:
+
+- **The observed symptom** — what someone actually saw. This is evidence.
+- **The claimed cause** — what the issue says is happening. This is a hypothesis.
+- **The claimed reachability** — "latent", "cannot happen today", "only affects
+  X". This is the most load-bearing and least verified claim in most issues.
+
+**Verify the premise before building on it.** Whether a defect is reachable
+decides which fix is correct, so a wrong premise doesn't just waste time — it
+produces a fix that is wrong in a way that passes review. #1934 was filed as
+latent-and-unreachable; a randomized mutation soak on unmodified `develop` hit
+it in 3 of 24 seeds, and that discovery flipped the fix from "return an error"
+(which broke live reads) to "resolve to the greatest start".
+
+Verify refutations with the same rigor as confirmations. Concluding "this can't
+happen" closes a door quietly, and a wrong refutation is invisible. Prefer
+structural arguments (this call path has no caller; this field is never written)
+over numeric ones (I ran it 100 times and it didn't reproduce).
+
+If the premise turns out to be wrong, say so plainly in the PR body — that
+finding is often worth more than the diff.
+
+## 3. Investigate
+
+Start with the knowledge graph; it returns a scoped subgraph far smaller than
+grep output or the full architecture report:
+
+```bash
+graphify query "<the question you actually have>"
+graphify path "<A>" "<B>"      # how two things relate
+graphify explain "<concept>"   # focused concept
+```
+
+Then read the specific code. `docs/internals/architecture.md` is the map;
+`docs/internals/debugging.md` has the SMB/NFS pcap-diff playbook. Use
+`superpowers:systematic-debugging` for a stubborn bug.
+
+Respect the invariants in `CLAUDE.md` — protocol handlers stay protocol-only,
+every op carries an `*metadata.AuthContext`, file handles are opaque, block
+stores are per-share, errors are `metadata.ExportError` values. A fix that
+violates one of these will be correct and still get rejected.
+
+**For protocol questions, go to the source of truth** — guessing at wire
+behaviour is how interop bugs are born:
+
+- RFCs for NFS — RFC 1813 (v3), RFC 7530 (v4.0), RFC 8881 (v4.1).
+- MS-SMB2 and MS-FSCC on Microsoft Learn for SMB2/3 — use the
+  `microsoft-docs` skill, which searches the official docs directly.
+- Samba and nfs-ganesha source for "what do real implementations actually do
+  when the spec is ambiguous". If Samba also fails a conformance case, that
+  case is likely testing something unimplementable, not a DittoFS bug (#1923,
+  #1832 both resolved this way).
+
+## 4. Reproduce deterministically before fixing
+
+A fix you cannot demonstrate failing before and passing after is a guess. Build
+the smallest reliable reproduction you can, and prefer one that lives in the
+repo afterward as a regression test. For races and CI-only failures, invest in
+determinism rather than retrying — #1701's dir-lease double-break only became
+fixable once it reproduced on demand.
+
+Two traps that have bitten repeatedly:
+
+- **Fake sinks and in-memory doubles do not validate durability or ordering
+  work.** A green unit suite (with `-race`) sat alongside a rig that wedged on
+  real hardware. If the change touches carve/flip, journal, fsync ordering, or
+  eviction, the reproduction has to run against something real.
+- **Reading code is not verifying behaviour.** Say "predicted" until a
+  checksummed read-back, a packet capture, or a failing assertion confirms it.
+
+## 5. Fix the root cause
+
+Grep every caller of the function you are about to change. The symptom named in
+the issue is usually one of several paths through a shared seam, and patching
+only the named path leaves the siblings broken — one guard in the shared
+function is both smaller and more correct than a guard per caller.
+
+When the seam is an access point (a fault-in, a cache lookup, a handle
+resolution), enumerate **all** the operations that cross it — read, write,
+truncate, delete, clone — not just the one in the report. A review that checked
+only `ReadAt` shipped #1831 with `WriteAt`, `Delete` and `Truncate` still broken.
+
+Keep the change small and match the surrounding style. **Comments describe
+behaviour only** — no issue or PR numbers, no CI or OS names, no phase or plan
+IDs in source; that context belongs in the commit message and PR body.
+
+Commit signed as you go, in small steps — long runs get killed by watchdogs and
+rate limits, and uncommitted work dies with them:
+
+```bash
+git commit -S -m "fix(block): ..."
+# if SSH signing fails with "Couldn't get agent socket":
+git -c user.signingkey=$HOME/.ssh/id_rsa.pub commit -S -m "..."
+```
+
+## 6. Verify
+
+Climb only as far as the change requires — each tier costs an order of
+magnitude more than the last.
+
+```bash
+go build ./... && go vet ./... && go fmt ./...
+go test ./...            # then -race on anything concurrent
+```
+
+Docker is available locally for protocol conformance. Pick the suite that
+matches the change — they cover different things:
+
+```bash
+cd test/smb-conformance && ./run.sh     # SMB2/3: WPTS BVT, Samba-derived
+cd test/nfs-conformance && ./run.sh     # Kerberos/sec=krb5 mounts ONLY, not general NFS
+sudo ./test/posix/run-posix.sh          # pjdfstest: the real NFS-side FS-semantics suite
+```
+
+`test/posix/` is where an NFSv3/v4 semantics change gets proven — `setup-posix.sh`
+first, `teardown-posix.sh` after. `test/e2e/` needs sudo and a kernel NFS client:
+`cd test/e2e && sudo ./run-e2e.sh`. **Never run two suites concurrently** — they
+collide on ports and mounts.
+
+If the change is about crash behaviour, device loss, real kernel-client
+interaction, or throughput, a laptop cannot prove it. Read
+`references/scw-vm.md` before provisioning anything — it covers the recipe and
+the teardown check that keeps you from destroying a development VM.
+
+If a listed known-failure starts passing, or a new one fails, do not edit the
+list on a hunch — CI is the authority on what actually fails there. There are
+several, one per suite: `test/posix/KNOWN_FAILURES.md` and
+`KNOWN_FAILURES_V4.md`, `test/smb-conformance/KNOWN_FAILURES.md`, and
+`test/smb-conformance/smbtorture/KNOWN_FAILURES{,_KERBEROS}.md`. Flakes get
+fixed, never retried.
+
+## 7. Simplify and review before the PR
+
+Two agents, in this order, every time. They catch different things and both
+have caught real bugs that a self-review missed.
+
+```
+Agent(subagent_type: "code-simplifier:code-simplifier")
+Agent(subagent_type: "feature-dev:code-reviewer")
+```
+
+The reviewer **cannot see a branch that exists only in your worktree** — it has
+no git access to your working state. Hand it the actual diff content and
+absolute file paths, not "review branch fix/1934-...". Otherwise it reviews
+`develop` and reports nothing.
+
+Then update whatever documentation the change invalidates. If any Cobra command
+or flag moved, regenerate — never hand-edit the generated file:
+
+```bash
+go run ./cmd/gendocs      # rewrites docs/guide/cli.md
+```
+
+## 8. Open the PR
+
+Rebase onto current `origin/develop` — never merge `develop` in.
+
+```bash
+git fetch origin && git rebase origin/develop
+git push -u origin fix/<issue>-<slug>
+gh pr create --base develop --assignee marmos91 --title "..." --body "..."
+```
+
+The PR body must contain a closing keyword (`Closes #<N>`). GitHub's auto-close
+never fires for us — it only triggers on the default branch, and we merge to
+`develop` — so `.github/workflows/close-linked-issues.yml` greps PR bodies
+instead, at release time. The keyword is what makes that work.
+
+Write the body for a reviewer who has not read the issue: what was actually
+wrong, why the obvious fix is wrong if it is, and what evidence you have. If you
+refuted the issue's premise, lead with that. Include the reproduction output.
+Never mention Claude Code, AI tooling, or add `Co-Authored-By` lines for AI.
+
+## 9. Babysit the PR
+
+Stay with the PR until it merges.
+
+**Copilot review.** Wait for it and read every comment. It has repeatedly caught
+real bugs that both the reviewer agent and I missed (#1837, #1838, #1831).
+Address what is real; reply explaining why on what is not.
+
+```bash
+gh pr view <PR> --comments
+gh pr diff <PR>
+```
+
+**CI.** Ten workflows run per PR — `unit-tests`, `lint`, `integration-tests`,
+`posix-tests`, `smb-conformance`, `operator-tests`, `windows-build`,
+`secret-scan`, `ci-health`, and `nfs-kerberos` (path-scoped to the kerberos and
+NFS adapter trees). The protocol suites are slow.
+
+```bash
+gh pr checks <PR> --watch
+```
+
+Do not wait on `e2e-tests`, `smb-client-compat`, or `ad-dc` — they are
+postsubmit/nightly only and never appear on a PR. Waiting for them hangs step 9
+forever.
+
+When a check goes red, investigate the actual failure rather than re-running.
+Pull the failing job's log, find the assertion, and check whether the same job
+fails on `origin/develop` before assuming it is yours — `develop` is
+occasionally red for unrelated reasons, which is not cause for alarm.
+
+A flaky SMB-conformance run is a known condition and does not block. Everything
+else that is red gets fixed, on this branch, and the loop returns to step 6.
+
+## 10. Merge and close
+
+When CI is green and every Copilot comment is addressed:
+
+```bash
+gh pr merge <PR> --squash --delete-branch
+gh issue close <N> --comment "Fixed in #<PR>."     # manual — see step 8
+graphify update .                                   # keep the graph current
+git worktree remove ~/dittofs-worktrees/<slug>
+```
+
+Closing is manual because that automation only fires when work reaches `main` at
+release time. An issue left open here stays open for weeks.
+
+## When to stop and come back
+
+Autonomy ends where a decision is not yours to make:
+
+- The fix contradicts a documented decision — a `KNOWN_FAILURES.md` entry
+  justified as architectural, an ADR, an invariant in `CLAUDE.md`. #1832's
+  replay6 case is mutually exclusive with conformant durable-handle behaviour
+  and Samba fails it too; re-attempting it wastes a day. Report, don't re-litigate.
+- The change needs to touch `main`, rewrite published history, or force-push a
+  protected branch.
+- The issue is a duplicate, already fixed, or its premise collapses entirely and
+  there is nothing left to fix.
+- A VM teardown target fails the identity check in `references/scw-vm.md`.
+
+In each case: post what you found on the issue, leave the worktree in place, and
+report back.

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -18,7 +18,7 @@ code without running it.
 Other agents work this repo concurrently. Never build in the primary checkout.
 
 ```bash
-cd /Users/marmos91/Projects/dittofs
+cd "$(git rev-parse --show-toplevel)"
 git fetch origin && git log --oneline -1 origin/develop   # know your base
 git worktree add ~/dittofs-worktrees/<slug> -b fix/<issue>-<slug> origin/develop
 ```

--- a/.claude/skills/fix-issue/references/scw-vm.md
+++ b/.claude/skills/fix-issue/references/scw-vm.md
@@ -18,9 +18,12 @@ Destroying someone's development VM is unrecoverable, so the rule is absolute:
 you created it.**
 
 ```bash
-cat .bench-vm.json          # note server_id
+[ -f .bench-vm.json ] && cat .bench-vm.json || echo "no .bench-vm.json — nothing recorded"
 scw instance server list    # confirm name/tags match the VM you created
 ```
+
+No `.bench-vm.json` means no VM is recorded, so there is nothing to tear down —
+that is a clean state, not an error.
 
 If the recorded `server_id` is not the one you provisioned, do not tear down.
 Stop and report — this is one of the skill's hard stop conditions.

--- a/.claude/skills/fix-issue/references/scw-vm.md
+++ b/.claude/skills/fix-issue/references/scw-vm.md
@@ -1,0 +1,106 @@
+# Running a fix on real hardware (Scaleway)
+
+Read this only when a laptop genuinely cannot prove the fix: crash and
+device-loss behaviour, real kernel NFS/SMB client interaction, throughput, or
+anything where an in-memory double would lie. Everything else stays local —
+a VM costs real money per hour and adds an hour of setup.
+
+The `scw` CLI is already authenticated.
+
+## Before you touch any VM: the identity check
+
+`.bench-vm.json` in the repo root records the *most recent* provisioned VM. It
+is not necessarily yours. Development VMs have been recorded there, and
+`dfsbench teardown` will happily terminate whatever it finds.
+
+Destroying someone's development VM is unrecoverable, so the rule is absolute:
+**never tear down a server whose `server_id` you did not personally record when
+you created it.**
+
+```bash
+cat .bench-vm.json          # note server_id
+scw instance server list    # confirm name/tags match the VM you created
+```
+
+If the recorded `server_id` is not the one you provisioned, do not tear down.
+Stop and report — this is one of the skill's hard stop conditions.
+
+## Provisioning
+
+For benchmark-shaped work, `dfsbench` owns the whole lifecycle and writes
+`.bench-vm.json` itself:
+
+```bash
+dfsbench setup      # SCW_* env selects type/zone/image
+dfsbench teardown   # terminates the VM in .bench-vm.json — after the identity check
+```
+
+Environment that shapes the instance:
+
+```
+SCW_ZONE=fr-par-1
+SCW_INSTANCE_TYPE=POP2-8C-32G
+SCW_IMAGE=ubuntu_noble
+SCW_ROOT_VOLUME=sbs:100GB:5000
+SCW_NAME=<something identifying this issue, e.g. dfs-1909-crash>
+SCW_SSH_KEY=<key>
+```
+
+Name the VM after the issue — that name is how anyone later tells your VM from a
+development one.
+
+For a plain repro box unrelated to benchmarking, provision directly with
+`scw instance server create` and record the returned ID somewhere you control
+rather than overwriting `.bench-vm.json`.
+
+## SSH
+
+User is `root`. The Scaleway key lives in the **1Password agent**, which refuses
+to sign for ssh invoked from the Bash tool. Start a dedicated agent instead:
+
+```bash
+ssh-agent -a "$HOME/.dfsb.sock" >/dev/null
+SSH_AUTH_SOCK=$HOME/.dfsb.sock ssh-add ~/.ssh/<scw-key>
+SSH_AUTH_SOCK=$HOME/.dfsb.sock ssh root@<ip>
+```
+
+## Long runs
+
+Anything longer than a few minutes runs detached on the VM. Poll it; do not
+block on it — a `--remote` poller hangs silently when the remote side stalls.
+
+Aborting a detached `dfsbench` run needs two kills — the local poller and the
+remote binary:
+
+```bash
+pkill -f 'dfsbench run'                          # local
+ssh root@<ip> 'pkill -9 -x dfsbench; pkill -9 -x fio'   # remote
+```
+
+Use `-x` (exact name) on the remote side. `pkill -f dfsbench` matches your own
+ssh command line and kills the session before the command runs.
+
+## Two-build verification
+
+When the question is "does this fix actually change behaviour", one build proves
+nothing. Push both a pre-fix and a post-fix binary to the same VM and run the
+same reproduction against each. A repro that fails on the old build and passes
+on the new one is evidence; a repro that only passes on the new one is a guess.
+
+## Teardown
+
+Tear down as soon as the evidence is captured — pull results back first, because
+the VM's disk goes with it.
+
+```bash
+dfsbench teardown     # or: scw instance server terminate <your-server-id> with-block=true
+```
+
+Verify it is gone rather than trusting the exit code:
+
+```bash
+scw instance server list
+```
+
+If teardown fails because the server is already gone, that is fine. If it fails
+for any other reason, retry — a leaked VM bills until someone notices.

--- a/.claude/skills/solve-issues/SKILL.md
+++ b/.claude/skills/solve-issues/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: solve-issues
+description: Work several DittoFS issues at once by fanning out one subagent per issue, each running the fix-issue skill in its own worktree, then serializing the merges back into develop. Use whenever more than one DittoFS issue number is handed over in a single ask ("/solve-issues 1823 1843", "fix 1888 and 1923", "clear these four issues", "work through the audit backlog"), or when a list or milestone of issues should be worked in parallel. For a single issue, use fix-issue directly instead.
+---
+
+# Solving several issues in parallel
+
+This is an orchestrator. All the actual work — investigation, reproduction,
+fixing, verification, PR authoring, CI babysitting — lives in the `fix-issue`
+skill, and each subagent runs that skill unchanged. Your job is the three things
+`fix-issue` cannot do from inside a single issue's context: decide what can
+safely run at once, keep the agents off each other's shared resources, and land
+the results in an order that leaves `develop` green.
+
+## 1. Triage before fanning out
+
+Read every issue first, in one pass:
+
+```bash
+for n in <issues>; do gh issue view $n --json number,title,labels,state,body \
+  -q '"#\(.number) [\(.state)] \(.title)"'; done
+```
+
+Drop anything already closed or already covered by an open PR
+(`gh pr list --search "<N>"`) before spending an agent on it. Then group by the
+code they touch — `graphify query` on each issue's subject area is fast and
+tells you which ones land in the same files.
+
+**Issues that touch the same code go to one agent, sequentially.** Two agents
+editing the same file produce two PRs that each pass CI alone and conflict on
+merge, and the second one to rebase inherits a mess it has no context for. One
+agent holding both issues writes one coherent change, or two commits that stack
+cleanly. Independent issues each get their own agent.
+
+## 2. Fan out
+
+One `Agent` call per group, all in a single message so they run concurrently.
+Each prompt says explicitly which skill to run and where the boundaries are:
+
+```
+Use the fix-issue skill to work DittoFS issue(s) #<N>[, #<M> in order].
+
+Worktree: ~/dittofs-worktrees/<slug>   (create it yourself, branch off origin/develop)
+
+Deviations from fix-issue for this parallel run:
+- STOP after the PR is green and every Copilot comment is addressed.
+  Do NOT merge. Report the PR number and a one-paragraph summary of the
+  root cause. Merges are serialized by the orchestrator.
+- Do NOT run test/e2e/run-e2e.sh, test/smb-conformance/run.sh, or
+  test/nfs-conformance/run.sh without asking me first — they collide on
+  ports, mounts and sudo, and only one agent may hold them at a time.
+- Do NOT provision or tear down any Scaleway VM. Ask me instead.
+
+Commit signed and often; report back even if you conclude there is nothing
+to fix.
+```
+
+Those three carve-outs are the only genuinely shared state: the protocol suites
+bind fixed ports and mount points, there is one `scw` account and one
+`.bench-vm.json`, and `develop` is a single branch. Worktrees, builds,
+`go test` and graphify queries all parallelize fine.
+
+## 3. Broker the shared resources
+
+While agents run, you hold the contended resources. When one asks:
+
+- **Conformance or e2e suite** — grant to one agent at a time. Tell the others
+  to wait rather than to skip; a skipped protocol suite is how interop
+  regressions ship.
+- **A VM** — read `.claude/skills/fix-issue/references/scw-vm.md`, provision one
+  yourself, and hand the agent the IP. Share a single VM across agents if their
+  reproductions do not conflict. You own the teardown, including the identity
+  check that stops a development VM being destroyed.
+
+## 4. Merge serially
+
+Never merge concurrently. Each squash-merge moves `develop`, which invalidates
+every other branch's base — CI green on a stale base proves nothing about the
+tree that actually results.
+
+Order by blast radius, smallest first, so the risky change rebases onto known-good
+work rather than the reverse. For each PR in turn:
+
+```bash
+gh pr checks <PR>                                  # still green on the current base?
+gh pr merge <PR> --squash --delete-branch
+gh issue close <N> --comment "Fixed in #<PR>."     # manual — auto-close only fires on main
+```
+
+Then, before the next one:
+
+```bash
+cd ~/dittofs-worktrees/<next-slug>
+git fetch origin && git rebase origin/develop && git push --force-with-lease
+```
+
+and wait for its checks again. If a rebase produces conflicts or turns a check
+red, hand it back to that issue's agent with the failure — it has the context
+you do not.
+
+Once everything is landed:
+
+```bash
+graphify update .
+git worktree remove ~/dittofs-worktrees/<slug>     # for each
+```
+
+## 5. Report
+
+A short table, one row per issue: number, what was actually wrong, PR, merged or
+blocked. Call out separately any issue whose **premise turned out to be false** —
+that finding often matters more than the fix, and it is the thing most likely to
+be lost when several issues are reported at once.
+
+Do not report an issue as done until its PR is merged and the issue is closed.


### PR DESCRIPTION
Adds two repo-local Claude Code skills under `.claude/skills/`.

## fix-issue

Takes one issue from report to merged: isolated worktree off `origin/develop`, premise verification, deterministic repro, root-cause fix, the simplifier/reviewer pass, a PR against `develop` carrying a closing keyword, Copilot and CI babysitting, squash-merge, and the manual `gh issue close`.

The manual close is not an oversight. GitHub's auto-close only fires for PRs targeting the default branch; ours target `develop`, so `close-linked-issues.yml` greps PR bodies at release time when work reaches `main`. An issue not closed by hand stays open until the next release.

Most of the file is the reasoning behind each step rather than the step itself, because the failure mode being defended against is a confident fix for the wrong problem. The worked examples are ours: #1934's "latent" premise that a mutation soak refuted, #1831 shipped with `WriteAt`/`Delete`/`Truncate` still broken after a `ReadAt`-only review, #1923 and #1832 where Samba fails the same conformance case, and the green `-race` suite that sat alongside a rig wedged on real hardware.

## solve-issues

Fans `fix-issue` across several issues. It groups issues touching the same code into one agent, keeps the agents off the three genuinely shared resources (the protocol suites bind fixed ports and mounts, there is one `scw` account and one `.bench-vm.json`, and `develop` is one branch), and serializes the merges so each branch rebases onto a landed `develop` instead of a stale base.

## references/scw-vm.md

Hardware verification, and specifically the identity check before teardown: `dfsbench teardown` terminates whatever `server_id` `.bench-vm.json` records and has no ownership check of its own, so the manual check is the only thing standing between an agent and someone's development VM.

## Validation

Dry-run against three closed-out issues (#1934, #1888, #1923), each with a no-skill baseline, stopping before push. All six arms passed every assertion, so the measured pass-rate delta is 0.00 — the investigation-quality instructions codify what a capable agent already does on a well-written issue, and the assertions did not discriminate. The untested half is the PR/CI/merge pipeline, which the dry run deliberately disabled; that is being exercised now on live issues.

Two findings fell out of the dry run and are worth their own issues independent of this PR: badger's `GetFileChunkAtOffset` appears to return a false hole for a nested shorter row, and the reap leaves a manifest gap for rows extending past `runEnd`. Both were found independently by two agents.