### PR TITLE
fix(lifecycle): abort startup when the machine SID is not durable

### DIFF
--- a/pkg/controlplane/runtime/lifecycle/service.go
+++ b/pkg/controlplane/runtime/lifecycle/service.go
@@ -67,7 +67,9 @@ type RollupStopper interface {
 // MachineSIDStore provides access to the SettingsStore for machine SID
 // persistence. The lifecycle service uses this to load or generate the
 // machine SID on first boot, ensuring consistent identity mapping across
-// restarts.
+// restarts. A read or write failure aborts startup: the SID has to be durable
+// before any identity is served, or the mapping silently changes on the next
+// boot.
 type MachineSIDStore interface {
 	GetSetting(ctx context.Context, key string) (string, error)
 	SetSetting(ctx context.Context, key, value string) error
@@ -178,8 +180,11 @@ func (s *Service) initMachineSID(ctx context.Context, store MachineSIDStore) err
 
 	stored, err := store.GetSetting(ctx, machineSIDKey)
 	if err != nil {
-		logger.Warn("Failed to read machine SID from store, generating new one", "error", err)
-		stored = ""
+		// A read failure is not an empty store. Falling through to the
+		// first-boot branch would generate a fresh SID and overwrite the one
+		// still recorded, rebinding every local UID->SID encoding and orphaning
+		// the security descriptors already written against the old machine.
+		return fmt.Errorf("failed to read machine SID: %w", err)
 	}
 
 	if stored != "" {
@@ -195,15 +200,19 @@ func (s *Service) initMachineSID(ctx context.Context, store MachineSIDStore) err
 		}
 	}
 
-	// First boot: generate and persist
-	s.sidMapper = sid.GenerateMachineSID()
-	sidStr := s.sidMapper.MachineSIDString()
+	// First boot: generate and persist. The mapper is published only once the
+	// SID is durable — an in-memory-only SID is replaced by a different random
+	// one on the next boot, so every security descriptor written in between
+	// would name a machine that no longer exists.
+	mapper := sid.GenerateMachineSID()
+	sidStr := mapper.MachineSIDString()
 
 	if err := store.SetSetting(ctx, machineSIDKey, sidStr); err != nil {
-		logger.Error("Failed to persist machine SID", "sid", sidStr, "error", err)
-	} else {
-		logger.Info("Generated and persisted machine SID", "sid", sidStr)
+		return fmt.Errorf("failed to persist machine SID %s: %w", sidStr, err)
 	}
+
+	s.sidMapper = mapper
+	logger.Info("Generated and persisted machine SID", "sid", sidStr)
 	return nil
 }
 

--- a/pkg/controlplane/runtime/lifecycle/service.go
+++ b/pkg/controlplane/runtime/lifecycle/service.go
@@ -67,9 +67,7 @@ type RollupStopper interface {
 // MachineSIDStore provides access to the SettingsStore for machine SID
 // persistence. The lifecycle service uses this to load or generate the
 // machine SID on first boot, ensuring consistent identity mapping across
-// restarts. A read or write failure aborts startup: the SID has to be durable
-// before any identity is served, or the mapping silently changes on the next
-// boot.
+// restarts. A read or write failure aborts startup.
 type MachineSIDStore interface {
 	GetSetting(ctx context.Context, key string) (string, error)
 	SetSetting(ctx context.Context, key, value string) error
@@ -180,10 +178,9 @@ func (s *Service) initMachineSID(ctx context.Context, store MachineSIDStore) err
 
 	stored, err := store.GetSetting(ctx, machineSIDKey)
 	if err != nil {
-		// A read failure is not an empty store. Falling through to the
-		// first-boot branch would generate a fresh SID and overwrite the one
-		// still recorded, rebinding every local UID->SID encoding and orphaning
-		// the security descriptors already written against the old machine.
+		// A read failure is not an empty store: falling through would generate
+		// a fresh SID over the stored one, rebinding every local UID->SID
+		// encoding and orphaning the descriptors written against the old machine.
 		return fmt.Errorf("failed to read machine SID: %w", err)
 	}
 
@@ -200,15 +197,14 @@ func (s *Service) initMachineSID(ctx context.Context, store MachineSIDStore) err
 		}
 	}
 
-	// First boot: generate and persist. The mapper is published only once the
-	// SID is durable — an in-memory-only SID is replaced by a different random
-	// one on the next boot, so every security descriptor written in between
-	// would name a machine that no longer exists.
+	// First boot: generate, persist, then publish. An in-memory-only SID is
+	// replaced by a different random one on the next boot, leaving every
+	// descriptor written in between naming a machine that no longer exists.
 	mapper := sid.GenerateMachineSID()
 	sidStr := mapper.MachineSIDString()
 
 	if err := store.SetSetting(ctx, machineSIDKey, sidStr); err != nil {
-		return fmt.Errorf("failed to persist machine SID %s: %w", sidStr, err)
+		return fmt.Errorf("failed to persist machine SID: %w", err)
 	}
 
 	s.sidMapper = mapper

--- a/pkg/controlplane/runtime/lifecycle/service.go
+++ b/pkg/controlplane/runtime/lifecycle/service.go
@@ -67,7 +67,8 @@ type RollupStopper interface {
 // MachineSIDStore provides access to the SettingsStore for machine SID
 // persistence. The lifecycle service uses this to load or generate the
 // machine SID on first boot, ensuring consistent identity mapping across
-// restarts. A read or write failure aborts startup.
+// restarts. When the SID is not operator-pinned, a read or write failure
+// aborts startup.
 type MachineSIDStore interface {
 	GetSetting(ctx context.Context, key string) (string, error)
 	SetSetting(ctx context.Context, key, value string) error

--- a/pkg/controlplane/runtime/lifecycle/service_test.go
+++ b/pkg/controlplane/runtime/lifecycle/service_test.go
@@ -51,6 +51,7 @@ type fakeSIDStore struct {
 	mu     sync.Mutex
 	vals   map[string]string
 	getErr error
+	setErr error
 	setHit bool
 }
 
@@ -64,6 +65,9 @@ func (f *fakeSIDStore) GetSetting(ctx context.Context, key string) (string, erro
 }
 
 func (f *fakeSIDStore) SetSetting(ctx context.Context, key, value string) error {
+	if f.setErr != nil {
+		return f.setErr
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.setHit = true
@@ -313,13 +317,32 @@ func TestInitMachineSIDInvalidStoredRegenerates(t *testing.T) {
 	}
 }
 
-// A read error from the store is tolerated: a SID is still generated.
-func TestInitMachineSIDReadErrorGenerates(t *testing.T) {
+// A read error is not an empty store: initialization fails instead of
+// generating a replacement SID that would overwrite the stored one.
+func TestInitMachineSIDReadErrorFails(t *testing.T) {
 	s := New(0)
 	store := &fakeSIDStore{getErr: errors.New("db down")}
-	mustInitMachineSID(t, s, store)
-	if s.SIDMapper() == nil {
-		t.Error("SID mapper should still be generated despite read error")
+	if err := s.initMachineSID(context.Background(), store); err == nil {
+		t.Fatal("read error must return an error, not generate a replacement")
+	}
+	if s.SIDMapper() != nil {
+		t.Error("no SID mapper should be set when the store cannot be read")
+	}
+	if store.setHit {
+		t.Error("a read error must not overwrite the stored machine SID")
+	}
+}
+
+// A first-boot persist failure aborts: an in-memory-only SID would be replaced
+// by a different one on the next boot.
+func TestInitMachineSIDPersistErrorFails(t *testing.T) {
+	s := New(0)
+	store := &fakeSIDStore{vals: map[string]string{}, setErr: errors.New("db down")}
+	if err := s.initMachineSID(context.Background(), store); err == nil {
+		t.Fatal("persist failure must return an error, not serve an ephemeral SID")
+	}
+	if s.SIDMapper() != nil {
+		t.Error("no SID mapper should be published when the SID is not durable")
 	}
 }
 

--- a/pkg/controlplane/runtime/lifecycle/service_test.go
+++ b/pkg/controlplane/runtime/lifecycle/service_test.go
@@ -337,7 +337,7 @@ func TestInitMachineSIDReadErrorFails(t *testing.T) {
 // by a different one on the next boot.
 func TestInitMachineSIDPersistErrorFails(t *testing.T) {
 	s := New(0)
-	store := &fakeSIDStore{vals: map[string]string{}, setErr: errors.New("db down")}
+	store := &fakeSIDStore{setErr: errors.New("db down")}
 	if err := s.initMachineSID(context.Background(), store); err == nil {
 		t.Fatal("persist failure must return an error, not serve an ephemeral SID")
 	}


### PR DESCRIPTION
## The issue's premise is wrong, and the real defect is worse

#1977 is titled "Lifecycle service swallows the error when a protocol adapter fails to register". It does not. `pkg/controlplane/runtime/lifecycle/service.go:202` has nothing to do with adapters — it is the machine-SID persist. The audit entry carrying `STATUS: TRACKED as #1977` is:

> **[LOW] First-boot machine-SID persist failure is silently swallowed, breaking the documented restart-stability invariant** — `pkg/controlplane/runtime/lifecycle/service.go:202`

The adapter wording came from that entry's STATUS line, which was written against the wrong finding. Adapter registration is already fatal to startup: `adapters.Service.LoadAdaptersFromStore` returns on the first failed `startAdapter`, and `lifecycle.serve` propagates it; #1943 separately fixed the swallowed *restart* failure inside `adapters.Service`. There is nothing to fix on the adapter side.

The availability argument in that STATUS line ("making it fatal would stop the server starting for every other protocol") also does not apply here. `initMachineSID` runs before anything is started, and an operator who cannot tolerate a hard failure has an escape hatch that bypasses the store entirely: a pinned machine SID in config.

## What was actually broken

`GORMStore.GetSetting` returns `("", nil)` for a missing key, so a non-nil error is a genuine store failure. Two paths in `initMachineSID` treated that as "no SID yet":

1. **Read failure clobbered a good SID.** `GetSetting` error → log a warning, set `stored = ""`, fall through to the first-boot branch, generate a fresh machine SID and `SetSetting` it — **overwriting the SID still recorded in the settings table**. A transient control-plane DB read error therefore destroyed the machine SID permanently. This is the more severe sibling of the reported finding and was not in the report.
2. **Write failure left an ephemeral SID.** First-boot `SetSetting` error → logged at Error, `s.sidMapper` already assigned, `return nil`. The server ran on an in-memory-only SID; the next boot generated a different random one.

Either way the local UID→SID encoding changes across a restart, so every SMB security descriptor written in between names a machine that no longer exists.

## The fix

Both paths return an error, aborting `Serve()` — matching the invalid-pin precedent already in this function — and the mapper is published only after the SID is durable. The "invalid stored SID → regenerate" branch falls through the same generate-and-persist block, so it inherits the fatal persist behaviour for free.

Deliberately unchanged, and worth naming because the same file now treats two superficially similar spots differently:

- **The pinned-SID branch still logs and continues on a `SetSetting` failure.** A pin is re-derived deterministically from config on every restart, so its durability does not depend on the store; a failed persist there causes no identity drift. Its `prior, _ := GetSetting(...)` is likewise harmless — a failed read just re-writes the pin rather than clobbering a good value.
- **`store == nil`** still yields an ephemeral SID (tests / ephemeral runtimes).
- **A corrupt stored SID** still regenerates and overwrites. That is a data problem, not a store failure, and it self-heals into a durable SID on that same boot.

## Verification

Both new tests fail on `origin/develop` and pass here:

```
=== RUN   TestInitMachineSIDReadErrorFails
    service_test.go:326: read error must return an error, not generate a replacement
--- FAIL: TestInitMachineSIDReadErrorFails (0.00s)
=== RUN   TestInitMachineSIDPersistErrorFails
    service_test.go:342: persist failure must return an error, not serve an ephemeral SID
--- FAIL: TestInitMachineSIDPersistErrorFails (0.00s)
```

`go build ./...`, `go vet`, `gofmt`, `go test ./pkg/controlplane/... ./cmd/...` and `go test -race ./pkg/controlplane/runtime/lifecycle/` all pass. No generated docs affected.

Closes #1977
