### PR TITLE
fix(journal): cover the framed FileID with the record CRC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- **Journal record CRC now covers the framed FileID.** A record's trailing CRC
+  summed only the payload, leaving the FileID bytes outside every checksum: bit
+  rot or a torn write there verified clean and recovery replayed the payload
+  under whatever file the damaged bytes spelled. The trailing CRC now covers
+  `FileID || payload`, and the record magic byte carries the framing version so
+  readers pick the matching CRC domain per record. Journals written by earlier
+  builds are read unchanged; GC repack re-frames surviving records as it copies
+  them forward. Downgrading after this change is one-way — an older build reads
+  a new record as a torn tail and truncates the segment there.
+
 ### Added
 
 - **Block-level compression on remote stores (opt-in).** A new

--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -955,7 +955,7 @@ func writeDataRecord(seg *segmentMeta, id FileID, fileOff int64, version uint64,
 		return 0, fmt.Errorf("journal: repack write payload: %w", err)
 	}
 	var crcBuf [payloadCRCSize]byte
-	binary.LittleEndian.PutUint32(crcBuf[:], crc(data))
+	binary.LittleEndian.PutUint32(crcBuf[:], recordCRC(fileID, data))
 	if _, err = seg.fd.WriteAt(crcBuf[:], payloadOff+int64(len(data))); err != nil {
 		return 0, fmt.Errorf("journal: repack write CRC: %w", err)
 	}

--- a/pkg/block/journal/record.go
+++ b/pkg/block/journal/record.go
@@ -70,7 +70,7 @@ func crc(b []byte) uint32 { return crc32.Checksum(b, crcTable) }
 // copying a large payload, so the sum is chained rather than taken over one
 // contiguous buffer.
 func recordCRC(fileID, payload []byte) uint32 {
-	return crc32.Update(crc32.Checksum(fileID, crcTable), crcTable, payload)
+	return crc32.Update(crc(fileID), crcTable, payload)
 }
 
 // recordHeader is the decoded fixed-size portion of a record.
@@ -238,7 +238,7 @@ func readRecordAt(r io.ReaderAt, off, maxPayload int64, scratch []byte) (record,
 }
 
 // readVerifiedRecord reads the record at recOff and returns it only once its
-// header CRC, payload CRC and framed FileID all check out. Every path that
+// header CRC, body CRC and framed FileID all check out. Every path that
 // copies a payload forward reads through it: each one re-hashes or re-CRCs the
 // bytes it copies, so an unverified read would turn on-disk bit rot into content
 // that passes every later integrity check.

--- a/pkg/block/journal/record.go
+++ b/pkg/block/journal/record.go
@@ -15,7 +15,7 @@ import (
 // On-disk header layout (recordHeaderSize bytes), little-endian:
 //
 //	off  size  field
-//	0    1     MagicByte     0xD5, torn-write scan anchor
+//	0    1     MagicByte     framing version, torn-write scan anchor
 //	1    1     HeaderLen     currently recordHeaderSize
 //	2    2     FileIDLen
 //	4    8     FileOffset
@@ -25,13 +25,22 @@ import (
 //	25   4     HeaderCRC32   covers bytes [0,24) — deliberately EXCLUDES Flags
 //
 // then FileIDLen bytes of FileID, PayloadLen bytes of payload, then a trailing
-// PayloadCRC32 (4 bytes) over the payload only.
+// BodyCRC32 (4 bytes). The magic byte says what that trailing CRC covers.
 //
 // HeaderCRC32 excluding Flags is load-bearing: carve completion flips the
 // synced bit in place with a single one-byte pwrite without invalidating the
 // header CRC or rewriting the record.
 const (
-	recordMagic      = 0xD5
+	// recordMagicV1 anchors the original framing, whose trailing CRC covered the
+	// payload alone — the FileID bytes fell outside every sum, so a flipped
+	// FileID still verified and handed the payload to the wrong file.
+	// recordMagicV2 anchors the current framing, whose trailing CRC covers the
+	// FileID bytes followed by the payload. Reads accept both and pick the
+	// matching CRC domain from the magic byte; every write emits V2, and GC
+	// repack re-frames surviving V1 records as V2 as it copies them forward.
+	recordMagicV1 = 0xD5
+	recordMagicV2 = 0xD6
+
 	recordHeaderSize = 29 // Magic..HeaderCRC32 inclusive
 	headerCRCCovers  = 24 // Magic..Version, excludes Flags
 	payloadCRCSize   = 4
@@ -55,6 +64,15 @@ var crcTable = crc32.MakeTable(crc32.Castagnoli)
 
 func crc(b []byte) uint32 { return crc32.Checksum(b, crcTable) }
 
+// recordCRC returns a record's trailing CRC: one sum over the FileID bytes
+// followed by the payload, so a flipped FileID fails verification exactly the
+// way a flipped payload byte does. Writers frame the two separately to avoid
+// copying a large payload, so the sum is chained rather than taken over one
+// contiguous buffer.
+func recordCRC(fileID, payload []byte) uint32 {
+	return crc32.Update(crc32.Checksum(fileID, crcTable), crcTable, payload)
+}
+
 // recordHeader is the decoded fixed-size portion of a record.
 type recordHeader struct {
 	FileIDLen  uint16
@@ -75,7 +93,7 @@ func recordLen(fileIDLen, payloadLen int) int64 {
 // large payload is never copied.
 func encodeHeader(h recordHeader, fileID []byte) []byte {
 	buf := make([]byte, recordHeaderSize+len(fileID))
-	buf[0] = recordMagic
+	buf[0] = recordMagicV2
 	buf[1] = recordHeaderSize
 	binary.LittleEndian.PutUint16(buf[2:4], h.FileIDLen)
 	binary.LittleEndian.PutUint64(buf[4:12], h.FileOffset)
@@ -94,7 +112,7 @@ func decodeHeader(buf []byte) (recordHeader, error) {
 	if len(buf) < recordHeaderSize {
 		return recordHeader{}, fmt.Errorf("journal: short record header: %d bytes", len(buf))
 	}
-	if buf[0] != recordMagic {
+	if buf[0] != recordMagicV1 && buf[0] != recordMagicV2 {
 		return recordHeader{}, fmt.Errorf("journal: bad record magic 0x%02x", buf[0])
 	}
 	if buf[1] != recordHeaderSize {
@@ -115,7 +133,7 @@ func decodeHeader(buf []byte) (recordHeader, error) {
 
 // errTornRecord marks a record that fails structural validation: bad magic,
 // header CRC, an implausible PayloadLen, a payload that runs past the written
-// bytes, or a payload CRC mismatch. A recovery tail-scan stops at the first
+// bytes, or a body CRC mismatch. A recovery tail-scan stops at the first
 // torn record and truncates there. A clean end-of-data (nothing left to read)
 // surfaces as io.EOF, distinct from corruption.
 var errTornRecord = errors.New("journal: torn record")
@@ -154,7 +172,8 @@ type record struct {
 // It is the single point that decides a record is trustworthy: it validates the
 // header CRC, then rejects any PayloadLen above maxPayload BEFORE allocating so
 // a header CRC that validates by coincidence on a torn tail can never make the
-// reader trust a bogus length and blow up memory, then verifies the payload CRC.
+// reader trust a bogus length and blow up memory, then verifies the body CRC
+// over the framed FileID and payload.
 // A torn or corrupt record returns errTornRecord; a clean boundary (no bytes
 // left) returns io.EOF. On success it also returns the offset of the next
 // record so a scan can advance.
@@ -199,8 +218,15 @@ func readRecordAt(r io.ReaderAt, off, maxPayload int64, scratch []byte) (record,
 	payloadEnd := int64(h.FileIDLen) + int64(h.PayloadLen)
 	payload := buf[h.FileIDLen:payloadEnd]
 	wantCRC := binary.LittleEndian.Uint32(buf[payloadEnd:])
-	if got := crc(payload); got != wantCRC {
-		return record{}, 0, fmt.Errorf("%w: payload CRC mismatch", errTornRecord)
+	// The magic byte selects the CRC domain: V2 folds the FileID in ahead of the
+	// payload, V1 covered the payload alone. buf holds FileID and payload
+	// contiguously, so the V2 sum is just the leading slice of it.
+	summed := payload
+	if hdrBuf[0] == recordMagicV2 {
+		summed = buf[:payloadEnd]
+	}
+	if got := crc(summed); got != wantCRC {
+		return record{}, 0, fmt.Errorf("%w: body CRC mismatch", errTornRecord)
 	}
 	return record{
 		header:  h,
@@ -217,9 +243,9 @@ func readRecordAt(r io.ReaderAt, off, maxPayload int64, scratch []byte) (record,
 // bytes it copies, so an unverified read would turn on-disk bit rot into content
 // that passes every later integrity check.
 //
-// The header and payload CRCs deliberately do not cover the FileID bytes, so a
-// flipped FileID — or a stale recOff landing on another file's record — passes
-// readRecordAt while handing back the wrong file's payload. Comparing the framed
+// The CRCs catch a flipped FileID but say nothing about which file the caller
+// meant: a stale recOff landing squarely on another file's intact record passes
+// readRecordAt while handing back that file's payload. Comparing the framed
 // FileID against the caller's closes that gap.
 func readVerifiedRecord(r io.ReaderAt, recOff, maxPayload int64, id FileID, scratch []byte) (record, error) {
 	rec, _, err := readRecordAt(r, recOff, maxPayload, scratch)

--- a/pkg/block/journal/record_test.go
+++ b/pkg/block/journal/record_test.go
@@ -177,11 +177,10 @@ var _ io.ReaderAt = (*bytes.Reader)(nil)
 // trailing CRC over the payload alone. Journals written before the FileID
 // joined the CRC domain still hold records shaped like this.
 func frameRecordV1(id string, offset int64, payload []byte, version uint64, flags uint8) []byte {
-	fileID := []byte(id)
 	out := frameRecord(id, offset, payload, version, flags)
 	out[0] = recordMagicV1
 	binary.LittleEndian.PutUint32(out[25:29], crc(out[:headerCRCCovers]))
-	binary.LittleEndian.PutUint32(out[recordHeaderSize+len(fileID)+len(payload):], crc(payload))
+	binary.LittleEndian.PutUint32(out[recordHeaderSize+len(id)+len(payload):], crc(payload))
 	return out
 }
 

--- a/pkg/block/journal/record_test.go
+++ b/pkg/block/journal/record_test.go
@@ -20,7 +20,7 @@ func frameRecord(id string, offset int64, payload []byte, version uint64, flags 
 		Flags:      flags,
 	}, fileID)
 	var crcBuf [payloadCRCSize]byte
-	binary.LittleEndian.PutUint32(crcBuf[:], crc(payload))
+	binary.LittleEndian.PutUint32(crcBuf[:], recordCRC(fileID, payload))
 	out := make([]byte, 0, len(hdr)+len(payload)+payloadCRCSize)
 	out = append(out, hdr...)
 	out = append(out, payload...)
@@ -172,3 +172,73 @@ func TestScanValidRecordsCleanEnd(t *testing.T) {
 
 // io.ReaderAt sanity: the reader must not mutate the source slice.
 var _ io.ReaderAt = (*bytes.Reader)(nil)
+
+// frameRecordV1 builds a record in the original framing: magic 0xD5 and a
+// trailing CRC over the payload alone. Journals written before the FileID
+// joined the CRC domain still hold records shaped like this.
+func frameRecordV1(id string, offset int64, payload []byte, version uint64, flags uint8) []byte {
+	fileID := []byte(id)
+	out := frameRecord(id, offset, payload, version, flags)
+	out[0] = recordMagicV1
+	binary.LittleEndian.PutUint32(out[25:29], crc(out[:headerCRCCovers]))
+	binary.LittleEndian.PutUint32(out[recordHeaderSize+len(fileID)+len(payload):], crc(payload))
+	return out
+}
+
+func TestReadRecordAcceptsV1Framing(t *testing.T) {
+	payload := bytes.Repeat([]byte("v1"), 64)
+	seg := segmentBytes(frameRecordV1("legacy-file", 8192, payload, 3, flagSynced))
+
+	got, next, err := readRecordAt(bytes.NewReader(seg), segHeaderSize, int64(len(seg)), nil)
+	if err != nil {
+		t.Fatalf("readRecordAt on V1 record: %v", err)
+	}
+	if string(got.fileID) != "legacy-file" || got.header.FileOffset != 8192 || got.header.Version != 3 {
+		t.Fatalf("V1 record decoded wrong: %+v id=%q", got.header, got.fileID)
+	}
+	if !bytes.Equal(got.payload, payload) {
+		t.Fatalf("V1 payload mismatch")
+	}
+	if want := int64(len(seg)); next != want {
+		t.Fatalf("next = %d want %d", next, want)
+	}
+}
+
+func TestReadRecordCorruptFileID(t *testing.T) {
+	rec := frameRecord("file-abc", 0, bytes.Repeat([]byte("z"), 64), 1, 0)
+	// Flip a bit inside the framed FileID. The header CRC does not cover these
+	// bytes, so only the body CRC can catch it.
+	rec[recordHeaderSize+2] ^= 0x01
+	seg := segmentBytes(rec)
+
+	if _, _, err := readRecordAt(bytes.NewReader(seg), segHeaderSize, 1<<20, nil); !errors.Is(err, errTornRecord) {
+		t.Fatalf("expected errTornRecord on flipped FileID, got %v", err)
+	}
+}
+
+func TestWrittenRecordsUseV2Framing(t *testing.T) {
+	rec := frameRecord("f", 0, []byte("hello"), 1, 0)
+	if rec[0] != recordMagicV2 {
+		t.Fatalf("encodeHeader wrote magic 0x%02x, want 0x%02x", rec[0], recordMagicV2)
+	}
+}
+
+// TestReadRecordV1CorruptFileIDUndetected pins the residual exposure the V2
+// framing was introduced to close: in a V1 record no CRC covers the FileID, so
+// a flipped byte there still verifies and the payload comes back attributed to
+// whatever file the damaged bytes now spell. Records already on disk cannot be
+// retroactively covered; repack re-frames them as V2 as it copies them forward.
+func TestReadRecordV1CorruptFileIDUndetected(t *testing.T) {
+	payload := bytes.Repeat([]byte("z"), 64)
+	rec := frameRecordV1("file-abc", 0, payload, 1, 0)
+	rec[recordHeaderSize+2] ^= 0x01
+	seg := segmentBytes(rec)
+
+	got, _, err := readRecordAt(bytes.NewReader(seg), segHeaderSize, 1<<20, nil)
+	if err != nil {
+		t.Fatalf("V1 framing unexpectedly rejected a flipped FileID: %v", err)
+	}
+	if string(got.fileID) == "file-abc" {
+		t.Fatalf("FileID was not actually corrupted by the test")
+	}
+}

--- a/pkg/block/journal/recovery_test.go
+++ b/pkg/block/journal/recovery_test.go
@@ -445,3 +445,66 @@ func TestConcurrentReadWriteAfterRecovery(t *testing.T) {
 		}
 	}
 }
+
+// TestRecoveryReadsV1FramedRecords models opening a journal that a build
+// predating the FileID's inclusion in the record CRC left behind: the segment
+// holds V1-framed records ahead of, and interleaved with, records this build
+// writes. Recovery must replay both and every byte must read back.
+func TestRecoveryReadsV1FramedRecords(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Open(dir, Config{ShardCount: 1}, newFakeRemote(), SystemClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	ctx := context.Background()
+
+	current := bytes.Repeat([]byte("current-"), 100)
+	if err := s.WriteAt(ctx, "current-file", 0, current); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if err := s.Commit(ctx, "current-file"); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	segPath := s.segPath(0)
+	cfg, clock := s.cfg, s.clock
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Splice a V1-framed record for a second file onto the segment's tail, the
+	// way the older build would have written it.
+	legacy := bytes.Repeat([]byte("legacy-"), 200)
+	fd, err := os.OpenFile(segPath, os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatalf("open segment: %v", err)
+	}
+	if _, err := fd.Write(frameRecordV1("legacy-file", 0, legacy, 1<<20, 0)); err != nil {
+		t.Fatalf("append V1 record: %v", err)
+	}
+	if err := fd.Close(); err != nil {
+		t.Fatalf("close segment: %v", err)
+	}
+
+	r, err := Open(dir, cfg, newFakeRemote(), clock)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+
+	if got := readAll(t, r, "legacy-file", len(legacy)); !bytes.Equal(got, legacy) {
+		t.Fatalf("V1-framed record did not survive recovery")
+	}
+	if got := readAll(t, r, "current-file", len(current)); !bytes.Equal(got, current) {
+		t.Fatalf("V2-framed record corrupted by V1 recovery")
+	}
+
+	// A write after recovery lands in the same segment behind the V1 record and
+	// must read back too, proving mixed framing in one segment is fine.
+	more := bytes.Repeat([]byte("after-"), 50)
+	if err := r.WriteAt(ctx, "after-file", 0, more); err != nil {
+		t.Fatalf("WriteAt after recovery: %v", err)
+	}
+	if got := readAll(t, r, "after-file", len(more)); !bytes.Equal(got, more) {
+		t.Fatalf("post-recovery write corrupted")
+	}
+}

--- a/pkg/block/journal/segment.go
+++ b/pkg/block/journal/segment.go
@@ -319,7 +319,7 @@ func (s *Store) appendRecord(ctx context.Context, id FileID, offset int64, data 
 		return fmt.Errorf("journal: write payload: %w", err)
 	}
 	var crcBuf [payloadCRCSize]byte
-	binary.LittleEndian.PutUint32(crcBuf[:], crc(data))
+	binary.LittleEndian.PutUint32(crcBuf[:], recordCRC(fileID, data))
 	if _, err := seg.fd.WriteAt(crcBuf[:], payloadOff+int64(len(data))); err != nil {
 		return fmt.Errorf("journal: write payload CRC: %w", err)
 	}
@@ -523,7 +523,7 @@ func writeTruncateRecord(seg *segmentMeta, id FileID, version uint64, newSize in
 		return 0, fmt.Errorf("journal: write truncate header: %w", err)
 	}
 	var crcBuf [payloadCRCSize]byte
-	binary.LittleEndian.PutUint32(crcBuf[:], crc(nil))
+	binary.LittleEndian.PutUint32(crcBuf[:], recordCRC(fileID, nil))
 	if _, err = seg.fd.WriteAt(crcBuf[:], recStart+int64(len(hdr))); err != nil {
 		return 0, fmt.Errorf("journal: write truncate CRC: %w", err)
 	}
@@ -545,7 +545,7 @@ func writeTombstoneRecord(seg *segmentMeta, id FileID, version uint64) (recStart
 		return 0, fmt.Errorf("journal: write tombstone header: %w", err)
 	}
 	var crcBuf [payloadCRCSize]byte
-	binary.LittleEndian.PutUint32(crcBuf[:], crc(nil))
+	binary.LittleEndian.PutUint32(crcBuf[:], recordCRC(fileID, nil))
 	if _, err = seg.fd.WriteAt(crcBuf[:], recStart+int64(len(hdr))); err != nil {
 		return 0, fmt.Errorf("journal: write tombstone CRC: %w", err)
 	}


### PR DESCRIPTION
## What was wrong

A journal record frames `header | FileID | payload | CRC32`. Two checksums guard it:

- `HeaderCRC32` covers header bytes `[0,24)` — deliberately stopping short of the `Flags`
  byte so carve can flip the synced bit with a single one-byte pwrite without invalidating it.
- The trailing CRC covered **the payload only**.

The FileID bytes sit between the two and were summed by neither. Bit rot or a torn write
there verified perfectly clean, and the recovery scan — which rebuilds the whole index from
the record stream, not from the `.idx` sidecar — replayed the payload under whatever file the
damaged bytes now spelled. For a tombstone or truncate marker (zero payload, FileID is the
entire meaning of the record) a single flipped byte buries or size-downs a different file.

The warm read path was already covered: `readVerifiedRecord` compares the framed FileID
against the caller's expectation. Recovery has no expectation to compare against, so nothing
protected it there.

## The fix

The trailing CRC now covers `FileID || payload`. The record's magic byte carries the framing
version — `0xD5` for the original payload-only domain, `0xD6` for the current one — and
`readRecordAt` picks the matching domain per record.

## On-disk format and the upgrade path

The byte layout is unchanged: same field offsets, same record length, same header. Only what
the trailing CRC sums changed, and the magic byte says which. That gives per-record
discrimination rather than per-segment, which matters because an unsealed segment written by
an older build keeps being appended to after the upgrade — one segment legitimately holds both
framings, and every reader handles that without knowing anything about when the store was
opened.

Consequences:

- **Upgrade needs no migration.** Existing journals open and read exactly as before. There is
  no format-version gate to fail, no re-scan, no rewrite pass.
- **Old records organically disappear.** Repack re-frames every record it copies forward
  (`writeDataRecord` / `writeTruncateRecord` / `writeTombstoneRecord` all go through the same
  encoder), so V1 records age out through normal GC.
- **Records already on disk keep the gap.** Their FileID bytes were never summed and cannot be
  retroactively covered. `TestReadRecordV1CorruptFileIDUndetected` pins that exposure
  explicitly so it is visible rather than assumed.
- **Downgrade is one-way.** An older binary reading a `0xD6` record rejects it as bad magic,
  treats it as a torn tail and truncates the segment there. That is a data-loss-on-rollback
  hazard, but it fails closed — the old build never *misreads* a new record. Every possible
  way of closing this gap has that property: any change to a CRC domain makes the old reader
  compute a mismatch and truncate. Bumping the magic at least makes the rejection explicit
  rather than a checksum coincidence.

The magic byte itself is inside `HeaderCRC32`'s span, so a bit flip that turned one framing
version into the other fails the header CRC and is rejected as a torn record rather than being
read under the wrong CRC domain.

The carve invariant is untouched: `HeaderCRC32` still stops before `Flags`, so the in-place
one-byte synced-bit pwrite still does not invalidate anything.

## Evidence

`TestReadRecordCorruptFileID` flips a bit inside a framed FileID and asserts `errTornRecord`.
Its twin, `TestReadRecordV1CorruptFileIDUndetected`, frames the same corruption the old way and
asserts it is accepted — that is the pre-fix behaviour, so the pair is the before/after.

`TestRecoveryReadsV1FramedRecords` builds the actual upgrade shape on disk: a store writes and
commits, is closed, a V1-framed record for a second file is spliced onto the segment's tail the
way the old build would have written it, and the store is reopened. Both files read back, and a
write issued after recovery lands behind the V1 record in the same segment and reads back too.
Removing V1 acceptance from `decodeHeader` fails both that test and
`TestReadRecordAcceptsV1Framing`, which is what makes them real checks rather than tautologies.

`go build ./... && go vet ./... && gofmt -l` clean; `go test ./...` and `go test -race
./pkg/block/...` green.

Closes #1976
