### PR TITLE
fix(badger): resolve a missing link-count key to the type-based default

### DIFF
--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -188,8 +188,9 @@ type BadgerMetadataStore struct {
 	// durable/relaxed classification is wired correctly.
 	inlineSyncs atomic.Int64
 
-	// txnConflicts counts SSI ErrConflict aborts observed by the withTransaction
-	// retry loop (one per retried attempt). It is a pure contention fingerprint:
+	// txnConflicts counts SSI ErrConflict aborts observed by the retry loops
+	// (withTransaction and updateWithConflictRetry), one per retried attempt.
+	// It is a pure contention fingerprint:
 	// transactions that touch disjoint keys never bump it, so concurrent writers
 	// sharing a hot key (e.g. a parent inode) are the only thing that drives it
 	// up. Tests read it to assert a workload stays conflict-free.

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -873,7 +873,27 @@ func (tx *badgerTransaction) GetLinkCount(ctx context.Context, handle metadata.F
 
 	item, err := tx.txn.Get(keyLinkCount(fileID))
 	if err == badgerdb.ErrKeyNotFound {
-		return 0, nil
+		// The count lives outside the inode record, so an existing inode whose
+		// l: key was never written resolves to the same default-by-type GetFile
+		// overlays: reporting 0 for a live entry contradicts GetFile on the same
+		// row and reads as "fully unlinked" to callers that treat the count as a
+		// liveness signal. Only a missing inode record is genuinely 0.
+		fileItem, fileErr := tx.txn.Get(keyFile(fileID))
+		if fileErr == badgerdb.ErrKeyNotFound {
+			return 0, nil
+		}
+		if fileErr != nil {
+			return 0, fileErr
+		}
+		raw, valErr := fileItem.ValueCopy(nil)
+		if valErr != nil {
+			return 0, valErr
+		}
+		file, decErr := decodeFile(raw)
+		if decErr != nil {
+			return 0, decErr
+		}
+		return fileLinkCountTxn(tx.txn, file), nil
 	}
 	if err != nil {
 		return 0, err

--- a/pkg/metadata/storetest/dir_ops.go
+++ b/pkg/metadata/storetest/dir_ops.go
@@ -16,6 +16,7 @@ func runDirOpsTests(t *testing.T, factory StoreFactory) {
 	t.Run("RemoveEmptyDirectory", func(t *testing.T) { testRemoveEmptyDirectory(t, factory) })
 	t.Run("NestedDirectories", func(t *testing.T) { testNestedDirectories(t, factory) })
 	t.Run("RootDirectoryIdempotent", func(t *testing.T) { testRootDirectoryIdempotent(t, factory) })
+	t.Run("LinkCountAgreesWithGetFile", func(t *testing.T) { testLinkCountAgreesWithGetFile(t, factory) })
 }
 
 // testCreateDirectory verifies that creating a directory results in the correct type and link count.
@@ -291,5 +292,84 @@ func testRootDirectoryIdempotent(t *testing.T, factory StoreFactory) {
 	// Both should return the same file (at least same share)
 	if root1.ShareName != root2.ShareName {
 		t.Errorf("ShareName mismatch: %q vs %q", root1.ShareName, root2.ShareName)
+	}
+}
+
+// testLinkCountAgreesWithGetFile verifies that GetLinkCount reports the same
+// hard-link count as GetFile for an inode whose count was never explicitly
+// stored. Backends keep the count outside the inode record (a separate key or
+// a nullable column), so "never written" is a state both surfaces must resolve
+// the same way: a GetLinkCount answering 0 while GetFile answers 2 makes
+// read-modify-write callers persist a wrong count, and 0 reads as "fully
+// unlinked" to anything treating the count as a liveness signal.
+func testLinkCountAgreesWithGetFile(t *testing.T, factory StoreFactory) {
+	cases := []struct {
+		name  string
+		ftype metadata.FileType
+	}{
+		{"Directory", metadata.FileTypeDirectory},
+		{"RegularFile", metadata.FileTypeRegular},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := factory(t)
+			rootHandle := createTestShare(t, store, "/test")
+			ctx := t.Context()
+
+			const name = "nolinkcount"
+			fullPath := childFullPath(t, store, rootHandle, name)
+
+			handle, err := store.GenerateHandle(ctx, "/test", fullPath)
+			if err != nil {
+				t.Fatalf("GenerateHandle() failed: %v", err)
+			}
+			_, id, err := metadata.DecodeFileHandle(handle)
+			if err != nil {
+				t.Fatalf("DecodeFileHandle() failed: %v", err)
+			}
+
+			// SetLinkCount is deliberately never called, which is what leaves
+			// the count unwritten.
+			entry := &metadata.File{
+				ShareName: "/test",
+				Path:      fullPath,
+				FileAttr: metadata.FileAttr{
+					Type: tc.ftype,
+					Mode: 0755,
+					UID:  1000,
+					GID:  1000,
+				},
+			}
+			entry.ID = id
+			if err := store.PutFile(ctx, entry); err != nil {
+				t.Fatalf("PutFile() failed: %v", err)
+			}
+			// Both namespace edges, so the only thing left unset is the link
+			// count. Backends that derive File.Path from parent edges otherwise
+			// see an entry that is reachable by name but has no parent.
+			if err := store.SetParent(ctx, handle, rootHandle); err != nil {
+				t.Fatalf("SetParent() failed: %v", err)
+			}
+			if err := store.SetChild(ctx, rootHandle, name, handle); err != nil {
+				t.Fatalf("SetChild() failed: %v", err)
+			}
+
+			file, err := store.GetFile(ctx, handle)
+			if err != nil {
+				t.Fatalf("GetFile() failed: %v", err)
+			}
+			count, err := store.GetLinkCount(ctx, handle)
+			if err != nil {
+				t.Fatalf("GetLinkCount() failed: %v", err)
+			}
+
+			if count == 0 {
+				t.Errorf("GetLinkCount() = 0 for a live %v; a live entry is never fully unlinked", tc.ftype)
+			}
+			if count != file.Nlink {
+				t.Errorf("GetLinkCount() = %d, GetFile().Nlink = %d; both surfaces must agree", count, file.Nlink)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Closes #1973.

**Scope note:** this branch was cut to close #1973 *and* #1980. While it was in review, #1972 merged and fixed #1980 completely — `updateWithConflictRetry` now bumps `txnConflicts` and maps the exhausted sentinel through `mapBadgerError`, with `conflict_classification_test.go` covering both the exhausted and the non-conflict-passthrough cases. That commit has been dropped from this branch; #1980 can be closed against #1972. The one leftover is the second commit here: `txnConflicts`' field comment still named only `withTransaction` after both loops started bumping it.

---

## `GetLinkCount` returned 0 for a live inode

`badgerTransaction.GetLinkCount` mapped a missing `l:<uuid>` key to `(0, nil)`. Every other surface in the package resolves that same absent key to the type-based default — 2 for a directory, 1 otherwise — and after #1972's consolidation they all route through `fileLinkCountTxn`. `GetLinkCount` was the last call site left open-coding the wrong answer, so one inode reported nlink 0 or nlink 2 depending on which helper the caller reached for. 0 is not a benign default: it reads as "fully unlinked" to anything treating the count as a liveness signal.

**The `(0, nil)` was itself the bug at the call sites**, not just an inconsistency:

- `directory.go` rmdir guards the parent decrement on `parentLinkCount > 0`, so a 0 silently skipped the parent's nlink decrement entirely.
- `file_create.go` mkdir and `file_modify.go` rename both do `SetLinkCount(dir, count+1)`, persisting 1 where the parent should have gone to 3.

The fix routes the missing-key case through `fileLinkCountTxn`, which already owns that default, so the two cannot drift again. A missing `f:` record still resolves to 0 — no inode, no links — matching sqlite and postgres. A real read error is propagated rather than fabricated as 0.

**Reachability.** No resurrected state: `deleteFileKeys` removes `f:` and `l:` together, and the last-link unlink in `file_remove.go` *writes* `l: = 0` rather than deleting it, so a genuinely unlinked file never enters the new branch. It is reached only by an inode whose `f:` record exists but whose `l:` key was never written — exactly the state the other overlays in this package already special-case.

## Contract

The conformance suite never covered this: `createTestDir` / `createTestFile` always call `SetLinkCount`, so "PutFile without SetLinkCount" was untested on every backend. Added `DirOps/LinkCountAgreesWithGetFile` to `pkg/metadata/storetest/`, asserting `GetLinkCount == GetFile().Nlink` and non-zero for such an inode. It deliberately pins agreement rather than a fixed number, since the SQL backends land on 1 via the `nlink INTEGER NOT NULL DEFAULT 1` column default while badger derives 2 for a directory.

Before the fix:

```
--- FAIL: TestConformance/DirOps/LinkCountAgreesWithGetFile/Directory
--- FAIL: TestConformance/DirOps/LinkCountAgreesWithGetFile/RegularFile
ok  	pkg/metadata/store/memory
ok  	pkg/metadata/store/sqlite
```

Memory and sqlite already satisfied it; badger was the only backend that did not. Postgres shares sqlite's DDL default and an identical inode INSERT that omits `nlink`, so it passes for the same reason (CI covers it under the integration tag).

## Verification

`go build ./...`, `go vet ./pkg/...`, `gofmt`, `golangci-lint run ./pkg/metadata/...` (0 issues), `go test ./pkg/metadata/... ./pkg/block/...`, and `go test -race` on the badger conformance tests. Protocol suites not run — the change touches no wire behaviour.
