### PR TITLE
fix(nfs): deny NFSv4 delegations over cross-protocol byte-range locks

### DIFF
--- a/internal/adapter/nfs/v4/state/delegation.go
+++ b/internal/adapter/nfs/v4/state/delegation.go
@@ -229,7 +229,10 @@ func (sm *StateManager) deleteDelegByOtherLocked(other [types.NFS4_OTHER_SIZE]by
 // DelegationState, and stores it in both the delegByOther and
 // delegByFile maps.
 //
-// Returns the DelegationState for the caller to encode in the OPEN response.
+// Returns the DelegationState for the caller to encode in the OPEN response,
+// or nil when the delegation is refused — the per-client limit is reached, or
+// the unified lock manager rejects it because the file already carries a
+// conflicting lease or byte-range lock. A nil return means OPEN_DELEGATE_NONE.
 //
 // Caller must NOT hold sm.mu (method acquires it).
 func (sm *StateManager) GrantDelegation(clientID uint64, fileHandle []byte, delegType uint32) *DelegationState {

--- a/internal/adapter/nfs/v4/state/delegation.go
+++ b/internal/adapter/nfs/v4/state/delegation.go
@@ -3,7 +3,6 @@ package state
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -266,11 +265,12 @@ func (sm *StateManager) GrantDelegation(clientID uint64, fileHandle []byte, dele
 
 	fhKey := string(fileHandle)
 
-	// Register with the unified lock manager BEFORE publishing any local state.
-	// The manager owns the cross-protocol view — leases, and byte-range locks
-	// taken over NLM, NFSv4 and SMB — so its refusal is authoritative: a client
-	// that got a delegation the manager rejected would satisfy byte-range locks
-	// locally and never observe the conflicting lock the manager knows about.
+	// Register with the unified lock manager before the delegation is published
+	// into delegByOther/delegByFile. The manager owns the cross-protocol view —
+	// leases, and byte-range locks taken over NLM, NFSv4 and SMB — so its
+	// refusal is authoritative: a client that got a delegation the manager
+	// rejected would satisfy byte-range locks locally and never observe the
+	// conflicting lock the manager knows about.
 	if lm := sm.lockManagerFor(fileHandle); lm != nil {
 		lmDelegType := lock.DelegTypeRead
 		if deleg.DelegType == types.OPEN_DELEGATE_WRITE {
@@ -281,7 +281,10 @@ func (sm *StateManager) GrantDelegation(clientID uint64, fileHandle []byte, dele
 		// This reduces observability in LockManager logs but does not affect
 		// correctness. To add share context, GrantDelegation would need to
 		// accept a shareName parameter threaded from the OPEN handler.
-		lockDeleg := lock.NewDelegation(lmDelegType, fmt.Sprintf("%d", clientID), "", false)
+		// The client identity matches the one v4 byte-range lock owners carry
+		// (see acquireLock), so break paths that exclude by client can tell a
+		// client's own delegation from another client's.
+		lockDeleg := lock.NewDelegation(lmDelegType, nfsClientIdentity(clientID), "", false)
 		if err := lm.GrantDelegation(fhKey, lockDeleg); err != nil {
 			logger.Debug("delegation denied by lock manager",
 				"client_id", clientID,

--- a/internal/adapter/nfs/v4/state/delegation.go
+++ b/internal/adapter/nfs/v4/state/delegation.go
@@ -261,11 +261,13 @@ func (sm *StateManager) GrantDelegation(clientID uint64, fileHandle []byte, dele
 		DelegType:  delegType,
 	}
 
-	sm.delegByOther[other] = deleg
-
 	fhKey := string(fileHandle)
-	sm.delegByFile[fhKey] = append(sm.delegByFile[fhKey], deleg)
 
+	// Register with the unified lock manager BEFORE publishing any local state.
+	// The manager owns the cross-protocol view — leases, and byte-range locks
+	// taken over NLM, NFSv4 and SMB — so its refusal is authoritative: a client
+	// that got a delegation the manager rejected would satisfy byte-range locks
+	// locally and never observe the conflicting lock the manager knows about.
 	if lm := sm.lockManagerFor(fileHandle); lm != nil {
 		lmDelegType := lock.DelegTypeRead
 		if deleg.DelegType == types.OPEN_DELEGATE_WRITE {
@@ -278,13 +280,18 @@ func (sm *StateManager) GrantDelegation(clientID uint64, fileHandle []byte, dele
 		// accept a shareName parameter threaded from the OPEN handler.
 		lockDeleg := lock.NewDelegation(lmDelegType, fmt.Sprintf("%d", clientID), "", false)
 		if err := lm.GrantDelegation(fhKey, lockDeleg); err != nil {
-			logger.Debug("LockManager delegation grant failed, continuing with local state",
+			logger.Debug("delegation denied by lock manager",
+				"client_id", clientID,
+				"deleg_type", delegType,
 				"error", err)
-		} else {
-			sm.delegStateidMap[lockDeleg.DelegationID] = stateid
-			deleg.LockManagerDelegID = lockDeleg.DelegationID
+			return nil
 		}
+		sm.delegStateidMap[lockDeleg.DelegationID] = stateid
+		deleg.LockManagerDelegID = lockDeleg.DelegationID
 	}
+
+	sm.delegByOther[other] = deleg
+	sm.delegByFile[fhKey] = append(sm.delegByFile[fhKey], deleg)
 
 	logger.Info("Delegation granted",
 		"client_id", clientID,

--- a/internal/adapter/nfs/v4/state/delegation_test.go
+++ b/internal/adapter/nfs/v4/state/delegation_test.go
@@ -1633,3 +1633,31 @@ func TestGrantDelegation_DeniedWhileForeignByteRangeLockHeld(t *testing.T) {
 		t.Fatal("expected the NFSv4 LOCK to be denied by the conflicting NLM lock")
 	}
 }
+
+// TestLockT_IgnoresOwnDelegation keeps LOCKT and LOCK answering alike while a
+// delegation is outstanding: the holder's own delegation is not a conflict it
+// would ever hit, but another client's still is.
+func TestLockT_IgnoresOwnDelegation(t *testing.T) {
+	lm := lock.NewManager()
+	sm := NewStateManager(90 * time.Second)
+	sm.SetLockManagerResolver(func(_ []byte) lock.LockManager { return lm })
+
+	clientID, fileHandle, _, _ := setupClientAndOpenState(t, sm)
+	setCBPathUp(sm, clientID)
+
+	if deleg := sm.GrantDelegation(clientID, fileHandle, types.OPEN_DELEGATE_WRITE); deleg == nil {
+		t.Fatal("expected the delegation to be granted on an unlocked file")
+	}
+
+	denied, err := sm.TestLock(clientID, []byte("nfs-owner"), fileHandle, types.WRITE_LT, 0, 100)
+	if err != nil {
+		t.Fatalf("TestLock returned error: %v", err)
+	}
+	if denied != nil {
+		t.Fatal("LOCKT must not report the client's own delegation as a conflict")
+	}
+
+	if denied, err = sm.TestLock(clientID+1, []byte("other-owner"), fileHandle, types.WRITE_LT, 0, 100); err != nil || denied == nil {
+		t.Fatalf("LOCKT from another client must see the delegation; denied=%v err=%v", denied, err)
+	}
+}

--- a/internal/adapter/nfs/v4/state/delegation_test.go
+++ b/internal/adapter/nfs/v4/state/delegation_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"io"
 	"net"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
 // ============================================================================
@@ -1580,5 +1582,54 @@ func TestSendRecallV41_StopCh(t *testing.T) {
 		// OK -- exited promptly.
 	case <-time.After(2 * time.Second):
 		t.Fatal("sendRecallV41 goroutine did not exit within 2s after sender.Stop()")
+	}
+}
+
+// TestGrantDelegation_DeniedWhileForeignByteRangeLockHeld covers the
+// cross-protocol path an NFSv4 client takes when a kernel NFSv3 client already
+// holds an NLM lock on the file. A delegated client answers its own byte-range
+// locks locally and never sends LOCK, so granting a delegation over the NLM
+// lock would let the NFSv4 client take a conflicting lock the server never
+// sees. The delegation must be refused, which forces the LOCK onto the wire
+// where the unified manager denies it.
+func TestGrantDelegation_DeniedWhileForeignByteRangeLockHeld(t *testing.T) {
+	lm := lock.NewManager()
+	sm := NewStateManager(90 * time.Second)
+	sm.SetLockManagerResolver(func(_ []byte) lock.LockManager { return lm })
+
+	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
+	setCBPathUp(sm, clientID)
+
+	// A kernel NFSv3 client holds an exclusive NLM lock on bytes [0,100).
+	if err := lm.AddUnifiedLock(string(fileHandle), &lock.UnifiedLock{
+		ID:         "nlm-lock",
+		Owner:      lock.LockOwner{OwnerID: "nlm:client-v3:1:aa", ClientID: "nlm:client-v3"},
+		FileHandle: lock.FileHandle(fileHandle),
+		Offset:     0,
+		Length:     100,
+		Type:       lock.LockTypeExclusive,
+		AcquiredAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("seeding NLM lock failed: %v", err)
+	}
+
+	if deleg := sm.GrantDelegation(clientID, fileHandle, types.OPEN_DELEGATE_WRITE); deleg != nil {
+		t.Fatal("delegation must not be granted while another protocol holds a byte-range lock")
+	}
+	if delegs := lm.ListDelegations(string(fileHandle)); len(delegs) != 0 {
+		t.Fatalf("expected no delegation registered, got %d", len(delegs))
+	}
+
+	// The client, undelegated, sends the LOCK — which the NLM lock denies.
+	res, err := sm.LockNew(context.Background(),
+		clientID, []byte("nfs-owner"), 1,
+		openStateid, openSeqid,
+		fileHandle, types.WRITE_LT, 0, 100, false,
+	)
+	if err != nil {
+		t.Fatalf("LockNew returned error: %v", err)
+	}
+	if res == nil || res.Denied == nil {
+		t.Fatal("expected the NFSv4 LOCK to be denied by the conflicting NLM lock")
 	}
 }

--- a/internal/adapter/nfs/v4/state/dir_delegation.go
+++ b/internal/adapter/nfs/v4/state/dir_delegation.go
@@ -103,21 +103,25 @@ func (sm *StateManager) GrantDirDelegation(clientID uint64, dirFH []byte, notifM
 		CookieVerf:       cookieVerf,
 	}
 
-	sm.delegByOther[other] = deleg
-	sm.delegByFile[fhKey] = append(sm.delegByFile[fhKey], deleg)
-
+	// The lock manager decides first: a delegation it rejects must not reach the
+	// client, which would otherwise cache directory state the conflicting holder
+	// keeps changing. See GrantDelegation.
 	if lm := sm.lockManagerFor(fhCopy); lm != nil {
 		// See GrantDelegation comment: NFS delegations lack share context at this layer.
-		lockDeleg := lock.NewDelegation(lock.DelegTypeRead, fmt.Sprintf("%d", clientID), "", true)
+		lockDeleg := lock.NewDelegation(lock.DelegTypeRead, nfsClientIdentity(clientID), "", true)
 		lockDeleg.NotificationMask = notifMask
 		if err := lm.GrantDelegation(fhKey, lockDeleg); err != nil {
-			logger.Debug("LockManager directory delegation grant failed, continuing with local state",
+			logger.Debug("directory delegation denied by lock manager",
+				"client_id", clientID,
 				"error", err)
-		} else {
-			sm.delegStateidMap[lockDeleg.DelegationID] = stateid
-			deleg.LockManagerDelegID = lockDeleg.DelegationID
+			return nil, err
 		}
+		sm.delegStateidMap[lockDeleg.DelegationID] = stateid
+		deleg.LockManagerDelegID = lockDeleg.DelegationID
 	}
+
+	sm.delegByOther[other] = deleg
+	sm.delegByFile[fhKey] = append(sm.delegByFile[fhKey], deleg)
 
 	logger.Info("Directory delegation granted",
 		"client_id", clientID,

--- a/internal/adapter/nfs/v4/state/lockowner.go
+++ b/internal/adapter/nfs/v4/state/lockowner.go
@@ -88,6 +88,14 @@ func makeLockOwnerKey(clientID uint64, ownerData []byte) lockOwnerKey {
 // other protocols (e.g. SMB) sharing the unified lock map.
 const lockManagerOwnerIDPrefix = "nfs4:"
 
+// nfsClientIdentity builds the LockManager client identity for an NFSv4 client.
+// Every row this StateManager puts in the unified lock map — byte-range locks
+// and delegations alike — carries it, so break paths that exclude by client can
+// tell a client's own state from another client's.
+func nfsClientIdentity(clientID uint64) string {
+	return fmt.Sprintf("%s%d", lockManagerOwnerIDPrefix, clientID)
+}
+
 // lockManagerOwnerID builds the LockManager owner ID for an NFSv4 lock-owner.
 // It is exactly lockManagerOwnerIDPrefix + makeLockOwnerKey(...) so the lock
 // manager identity stays in lock-step with the internal lock-owner map key:

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -2184,7 +2184,7 @@ func (sm *StateManager) acquireLock(ctx context.Context, lockState *LockState, l
 	// Build the protocol-agnostic lock owner
 	owner := lock.LockOwner{
 		OwnerID:   lockState.LockOwner.LockManagerOwnerID(),
-		ClientID:  fmt.Sprintf("nfs4:%d", lockState.LockOwner.ClientID),
+		ClientID:  nfsClientIdentity(lockState.LockOwner.ClientID),
 		ShareName: "",
 	}
 
@@ -2438,7 +2438,7 @@ func (sm *StateManager) UnlockFile(
 	if lm := sm.lockManagerFor(lockState.FileHandle); lm != nil {
 		owner := lock.LockOwner{
 			OwnerID:   lockOwner.LockManagerOwnerID(),
-			ClientID:  fmt.Sprintf("nfs4:%d", lockOwner.ClientID),
+			ClientID:  nfsClientIdentity(lockOwner.ClientID),
 			ShareName: "",
 		}
 

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -2311,9 +2311,11 @@ func (sm *StateManager) TestLock(
 		mappedType = lock.LockTypeExclusive
 	}
 
-	// Create a temporary test lock (not added to the manager)
+	// Create a temporary test lock (not added to the manager). It carries the
+	// same client identity an actual LOCK would, so LOCKT reports the client's
+	// own delegation as free rather than as a conflict it would never hit.
 	testLock := &lock.UnifiedLock{
-		Owner:  lock.LockOwner{OwnerID: ownerID},
+		Owner:  lock.LockOwner{OwnerID: ownerID, ClientID: nfsClientIdentity(clientID)},
 		Offset: offset,
 		Length: length,
 		Type:   mappedType,

--- a/pkg/metadata/lock/delegation_manager_test.go
+++ b/pkg/metadata/lock/delegation_manager_test.go
@@ -523,3 +523,56 @@ func TestManager_BreakLeasesForByteRangeLock_RecallsDelegation(t *testing.T) {
 	assert.True(t, delegations[0].Breaking, "delegation should be recalled by a byte-range lock")
 	assert.Len(t, delegRecalls.getRecalls(), 1, "OnDelegationRecall should have been called")
 }
+
+// TestManager_AddUnifiedLock_SameClientAsOwnDelegation covers what a client
+// must be able to do on recall: send the LOCK operations for the locks it
+// granted locally while its delegation is still outstanding. Its own delegation
+// must not deny them, while another client's still does.
+func TestManager_AddUnifiedLock_SameClientAsOwnDelegation(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	require.NoError(t, lm.GrantDelegation("file1", NewDelegation(DelegTypeWrite, "nfs4:5", "/export", false)))
+
+	require.NoError(t, lm.AddUnifiedLock("file1", &UnifiedLock{
+		ID:         "own-lock",
+		Owner:      LockOwner{OwnerID: "nfs4:5:aa", ClientID: "nfs4:5"},
+		FileHandle: FileHandle("file1"),
+		Offset:     0,
+		Length:     100,
+		Type:       LockTypeExclusive,
+	}))
+
+	err := lm.AddUnifiedLock("file1", &UnifiedLock{
+		ID:         "foreign-lock",
+		Owner:      LockOwner{OwnerID: "nlm:client-v3:1:aa", ClientID: "nlm:client-v3"},
+		FileHandle: FileHandle("file1"),
+		Offset:     0,
+		Length:     100,
+		Type:       LockTypeExclusive,
+	})
+	require.Error(t, err, "another client's lock is still denied by the delegation")
+}
+
+// TestManager_BreakLeasesForByteRangeLock_SkipsOwnDelegation pins the exclusion
+// the recall relies on: a client taking a byte-range lock must not recall its
+// own delegation, which it identifies by the client identity both rows carry.
+func TestManager_BreakLeasesForByteRangeLock_SkipsOwnDelegation(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	delegRecalls := &delegationRecallTracker{}
+	lm.RegisterBreakCallbacks(delegRecalls)
+
+	require.NoError(t, lm.GrantDelegation("file1", NewDelegation(DelegTypeWrite, "nfs4:5", "/export", false)))
+
+	require.NoError(t, lm.BreakLeasesForByteRangeLock("file1", &LockOwner{
+		OwnerID:  "nfs4:5:aa",
+		ClientID: "nfs4:5",
+	}))
+
+	delegations := lm.ListDelegations("file1")
+	require.Len(t, delegations, 1)
+	assert.False(t, delegations[0].Breaking, "a client's own delegation must not be recalled by its own lock")
+	assert.Empty(t, delegRecalls.getRecalls())
+}

--- a/pkg/metadata/lock/delegation_manager_test.go
+++ b/pkg/metadata/lock/delegation_manager_test.go
@@ -422,3 +422,104 @@ func (d *delegationRecallTracker) getRecalls() []delegationRecallEvent {
 	copy(result, d.recalls)
 	return result
 }
+
+// ============================================================================
+// Delegation vs byte-range lock
+// ============================================================================
+
+// TestManager_GrantDelegation_DeniedByByteRangeLock covers the cross-protocol
+// invariant a delegation must not break: a client holding a delegation may
+// satisfy byte-range locks locally, so a delegation granted over an existing
+// NLM/NFSv4 lock hides that lock from the delegated client entirely.
+func TestManager_GrantDelegation_DeniedByByteRangeLock(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+
+	// A kernel NFSv3 client holds an exclusive NLM lock on the whole file.
+	require.NoError(t, lm.AddUnifiedLock("file1", &UnifiedLock{
+		ID:         "nlm-lock",
+		Owner:      LockOwner{OwnerID: "nlm:client-v3:1:aa", ClientID: "nlm:client-v3"},
+		FileHandle: FileHandle("file1"),
+		Offset:     0,
+		Length:     0,
+		Type:       LockTypeExclusive,
+	}))
+
+	err := lm.GrantDelegation("file1", NewDelegation(DelegTypeWrite, "5", "/export", false))
+	require.Error(t, err, "write delegation must be denied while an NLM lock is held")
+	assert.Empty(t, lm.ListDelegations("file1"))
+
+	err = lm.GrantDelegation("file1", NewDelegation(DelegTypeRead, "5", "/export", false))
+	require.Error(t, err, "read delegation must be denied while an exclusive NLM lock is held")
+	assert.Empty(t, lm.ListDelegations("file1"))
+}
+
+// TestManager_GrantDelegation_DeniedBySMBByteRangeLock covers the same rule for
+// the SMB byte-range map, which is separate from unifiedLocks.
+func TestManager_GrantDelegation_DeniedBySMBByteRangeLock(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+
+	require.NoError(t, lm.Lock("file1", FileLock{
+		SessionID: 7,
+		OpenID:    "open-1",
+		Offset:    0,
+		Length:    100,
+		Exclusive: true,
+		ClientID:  "smb:7",
+	}))
+
+	err := lm.GrantDelegation("file1", NewDelegation(DelegTypeWrite, "5", "/export", false))
+	require.Error(t, err, "write delegation must be denied while an SMB byte-range lock is held")
+	assert.Empty(t, lm.ListDelegations("file1"))
+}
+
+// TestManager_GrantDelegation_ReadDelegationAllowedWithSharedLock pins the
+// other half of the rule: a shared lock does not conflict with the shared
+// whole-file row a read delegation records, so read caching stays available.
+func TestManager_GrantDelegation_ReadDelegationAllowedWithSharedLock(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+
+	require.NoError(t, lm.AddUnifiedLock("file1", &UnifiedLock{
+		ID:         "nlm-shared",
+		Owner:      LockOwner{OwnerID: "nlm:client-v3:1:aa", ClientID: "nlm:client-v3"},
+		FileHandle: FileHandle("file1"),
+		Offset:     0,
+		Length:     100,
+		Type:       LockTypeShared,
+	}))
+
+	require.NoError(t, lm.GrantDelegation("file1", NewDelegation(DelegTypeRead, "5", "/export", false)))
+	assert.Len(t, lm.ListDelegations("file1"), 1)
+}
+
+// TestManager_BreakLeasesForByteRangeLock_RecallsDelegation covers the reverse
+// direction: a byte-range lock arriving after a delegation was granted must
+// recall it. Without the recall the delegation's whole-file row denies the lock
+// for as long as the delegation lives, so the lock stays denied even after the
+// original holder released.
+func TestManager_BreakLeasesForByteRangeLock_RecallsDelegation(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	delegRecalls := &delegationRecallTracker{}
+	lm.RegisterBreakCallbacks(delegRecalls)
+
+	require.NoError(t, lm.GrantDelegation("file1", NewDelegation(DelegTypeWrite, "5", "/export", false)))
+
+	// An NLM client now takes a byte-range lock on the same file.
+	err := lm.BreakLeasesForByteRangeLock("file1", &LockOwner{
+		OwnerID:  "nlm:client-v3:1:aa",
+		ClientID: "nlm:client-v3",
+	})
+	require.NoError(t, err)
+
+	delegations := lm.ListDelegations("file1")
+	require.Len(t, delegations, 1)
+	assert.True(t, delegations[0].Breaking, "delegation should be recalled by a byte-range lock")
+	assert.Len(t, delegRecalls.getRecalls(), 1, "OnDelegationRecall should have been called")
+}

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -166,7 +166,7 @@ type LockManager interface {
 	// ========================================================================
 
 	// GrantDelegation grants a delegation on a file.
-	// Returns error if conflicting leases exist.
+	// Returns error if a conflicting lease or byte-range lock exists.
 	GrantDelegation(handleKey string, delegation *Delegation) error
 
 	// RevokeDelegation force-revokes a delegation, removing it from the lock map.
@@ -2930,7 +2930,8 @@ func (lm *Manager) mirrorBreakStageLocked(sibling *UnifiedLock, canonical *OpLoc
 // ============================================================================
 
 // GrantDelegation grants a delegation on a file.
-// Returns error if conflicting leases exist or the file was recently broken.
+// Returns error if a conflicting lease or byte-range lock exists, or the file
+// was recently broken.
 func (lm *Manager) GrantDelegation(handleKey string, delegation *Delegation) error {
 	lm.mu.Lock()
 	defer lm.mu.Unlock()

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -2978,13 +2978,8 @@ func (lm *Manager) GrantDelegation(handleKey string, delegation *Delegation) err
 	// lock it stands in for, so a write delegation (exclusive) is denied by any
 	// foreign lock and a read delegation (shared) only by a foreign exclusive
 	// one — the same rule byte-range locks apply to each other.
-	asByteRange := &UnifiedLock{
-		Owner:      newLock.Owner,
-		FileHandle: newLock.FileHandle,
-		Offset:     0,
-		Length:     0,
-		Type:       newLock.Type,
-	}
+	asByteRange := *newLock
+	asByteRange.Delegation = nil
 	for _, lock := range locks {
 		if lock.Lease != nil || lock.Delegation != nil {
 			continue
@@ -2996,7 +2991,7 @@ func (lm *Manager) GrantDelegation(handleKey string, delegation *Delegation) err
 	}
 	smbLocks := lm.locks[handleKey]
 	for i := range smbLocks {
-		if fileLockConflictsWithUnified(&smbLocks[i], asByteRange) {
+		if fileLockConflictsWithUnified(&smbLocks[i], &asByteRange) {
 			return fmt.Errorf("delegation conflicts with existing SMB byte-range lock (owner=%s)",
 				lockOwnerID(&smbLocks[i]))
 		}

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -2117,7 +2117,7 @@ func (lm *Manager) BreakLeasesForByteRangeLock(handleKey string, excludeOwner *L
 	// delegation's whole-file row also blocks the lock in AddUnifiedLock, so
 	// without the recall the lock stays denied until the delegation's lease
 	// expires — even after the original holder released.
-	lm.breakDelegations(handleKey, excludeOwner, func(_ *Delegation) bool {
+	lm.breakDelegations(handleKey, excludeOwner, func(*Delegation) bool {
 		return true
 	})
 
@@ -2218,11 +2218,12 @@ func (lm *Manager) WaitForBreakCompletionExceptKey(ctx context.Context, handleKe
 // DELEGRETURN, whose handler must take the StateManager mutex; waiting for it
 // here while that same mutex is held would be a circular wait (only force-
 // broken after the bounded timeout, then re-stalled on the next LOCK, since
-// forceCompleteBreaksExceptKey only force-completes leases). Skipping
-// delegations is also correct: BreakLeasesForByteRangeLock never marks a
-// delegation Breaking, and a byte-range lock never conflicts with a delegation
-// (UnifiedLock.ConflictsWith ignores delegations), so there is nothing to wait
-// for. On timeout the breaking leases are force-downgraded to None (Samba
+// forceCompleteBreaksExceptKey only force-completes leases). Not waiting stays
+// correct: BreakLeasesForByteRangeLock has already dispatched the recall by the
+// time this runs, and the delegation's whole-file row keeps AddUnifiedLock
+// denying the acquire until the client returns it, so the lock is retried
+// rather than granted alongside an unrecalled delegation. On timeout the
+// breaking leases are force-downgraded to None (Samba
 // lease_timeout parity) and ctx.Err() is returned.
 func (lm *Manager) WaitForByteRangeLeaseBreak(ctx context.Context, handleKey string) error {
 	for {
@@ -2947,11 +2948,9 @@ func (lm *Manager) GrantDelegation(handleKey string, delegation *Delegation) err
 	// one write delegation per file) are enforced by the protocol layer (NFS
 	// state manager, SMB handler) before calling GrantDelegation.
 	for _, lock := range locks {
-		if lock.Lease != nil {
-			if DelegationConflictsWithLease(delegation, lock.Lease) {
-				return fmt.Errorf("delegation conflicts with existing lease (state=%s)",
-					LeaseStateToString(lock.Lease.LeaseState))
-			}
+		if lock.Lease != nil && DelegationConflictsWithLease(delegation, lock.Lease) {
+			return fmt.Errorf("delegation conflicts with existing lease (state=%s)",
+				LeaseStateToString(lock.Lease.LeaseState))
 		}
 	}
 
@@ -2981,18 +2980,22 @@ func (lm *Manager) GrantDelegation(handleKey string, delegation *Delegation) err
 	// SMB locks in locks. The delegation is weighed as the whole-file byte-range
 	// lock it stands in for, so a write delegation (exclusive) is denied by any
 	// foreign lock and a read delegation (shared) only by a foreign exclusive
-	// one — the same rule byte-range locks apply to each other.
-	asByteRange := *newLock
-	asByteRange.Delegation = nil
+	// one — the same rule byte-range locks apply to each other, including its
+	// exemption for the holder's own client.
 	for _, lock := range locks {
 		if lock.Lease != nil || lock.Delegation != nil {
 			continue
 		}
-		if asByteRange.ConflictsWith(lock) {
+		if newLock.ConflictsWith(lock) {
 			return fmt.Errorf("delegation conflicts with existing byte-range lock (owner=%s)",
 				lock.Owner.OwnerID)
 		}
 	}
+	// The SMB map needs a plain byte-range stand-in: fileLockConflictsWithUnified
+	// excludes delegation rows by design. SMB locks never share a client with an
+	// NFS delegation, so no same-client exemption applies here.
+	asByteRange := *newLock
+	asByteRange.Delegation = nil
 	smbLocks := lm.locks[handleKey]
 	for i := range smbLocks {
 		if fileLockConflictsWithUnified(&smbLocks[i], &asByteRange) {

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -2108,6 +2108,16 @@ func (lm *Manager) CheckAndBreakLeasesForSMBOpen(handleKey string, excludeOwner 
 // disallows in practice) are skipped: there is no read cache to flush.
 // The break target is None — full revocation — not "strip W" or "strip H".
 func (lm *Manager) BreakLeasesForByteRangeLock(handleKey string, excludeOwner *LockOwner) error {
+	// An outstanding NFSv4 delegation is recalled for the same reason: the
+	// delegated client handles byte-range locks locally, so while it holds the
+	// delegation it can neither see this lock nor have its own locks seen. The
+	// delegation's whole-file row also blocks the lock in AddUnifiedLock, so
+	// without the recall the lock stays denied until the delegation's lease
+	// expires — even after the original holder released.
+	lm.breakDelegations(handleKey, excludeOwner, func(_ *Delegation) bool {
+		return true
+	})
+
 	return lm.breakOpLocks(handleKey, excludeOwner, LeaseStateNone, BreakReasonUnspecified, func(lease *OpLock) bool {
 		return lease.HasRead()
 	})
@@ -2954,6 +2964,42 @@ func (lm *Manager) GrantDelegation(handleKey string, delegation *Delegation) err
 		Type:       delegationToLockType(delegation.DelegType),
 		AcquiredAt: time.Now(),
 		Delegation: delegation,
+	}
+
+	// A byte-range lock already held on this file denies the delegation. A
+	// delegated client is entitled to satisfy its own byte-range locks locally,
+	// without ever asking the server, so handing out a delegation over an
+	// existing lock makes that lock invisible to the delegated client — the
+	// cross-protocol conflict that AddUnifiedLock enforces in the other
+	// direction would simply never be evaluated.
+	//
+	// Both lock maps are consulted: NLM/NFSv4 locks live in unifiedLocks and
+	// SMB locks in locks. The delegation is weighed as the whole-file byte-range
+	// lock it stands in for, so a write delegation (exclusive) is denied by any
+	// foreign lock and a read delegation (shared) only by a foreign exclusive
+	// one — the same rule byte-range locks apply to each other.
+	asByteRange := &UnifiedLock{
+		Owner:      newLock.Owner,
+		FileHandle: newLock.FileHandle,
+		Offset:     0,
+		Length:     0,
+		Type:       newLock.Type,
+	}
+	for _, lock := range locks {
+		if lock.Lease != nil || lock.Delegation != nil {
+			continue
+		}
+		if asByteRange.ConflictsWith(lock) {
+			return fmt.Errorf("delegation conflicts with existing byte-range lock (owner=%s)",
+				lock.Owner.OwnerID)
+		}
+	}
+	smbLocks := lm.locks[handleKey]
+	for i := range smbLocks {
+		if fileLockConflictsWithUnified(&smbLocks[i], asByteRange) {
+			return fmt.Errorf("delegation conflicts with existing SMB byte-range lock (owner=%s)",
+				lockOwnerID(&smbLocks[i]))
+		}
 	}
 
 	lm.unifiedLocks[handleKey] = append(locks, newLock)

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -216,6 +216,9 @@ type LockManager interface {
 	// Leases without Read caching (None, W-only) are not broken: they cannot
 	// be caching reads. The locker's own lease must be excluded via
 	// excludeOwner.ExcludeLeaseKey ("nobreakself" per MS-SMB2 3.3.5.9).
+	// Outstanding NFSv4 delegations on the file are recalled as well: a
+	// delegated client answers byte-range locks locally, so it can neither
+	// see this lock nor have its own locks seen.
 	BreakLeasesForByteRangeLock(handleKey string, excludeOwner *LockOwner) error
 
 	// BreakLeasesOnOpenConflict breaks existing leases before an SMB CREATE

--- a/pkg/metadata/lock/types.go
+++ b/pkg/metadata/lock/types.go
@@ -336,6 +336,17 @@ func (ul *UnifiedLock) ConflictsWith(other *UnifiedLock) bool {
 		return false
 	}
 
+	// A delegation stands for its holder's caching rights over the whole file,
+	// not for a lock, so it never conflicts with a byte-range lock the same
+	// client takes: on recall the client must send the LOCK operations for the
+	// locks it granted locally (RFC 7530 Section 10.4.4), and those must not be
+	// denied by the delegation it is about to return. Different clients still
+	// conflict, which is what keeps a delegation and a foreign lock apart.
+	if (ul.IsDelegation() || other.IsDelegation()) &&
+		ul.Owner.ClientID != "" && ul.Owner.ClientID == other.Owner.ClientID {
+		return false
+	}
+
 	// Both shared = no conflict.
 	if ul.Type == LockTypeShared && other.Type == LockTypeShared {
 		return false


### PR DESCRIPTION
## The premise is wrong: this is not about when the share was created

The issue reports that an NFSv4 LOCK is granted while a kernel NFSv3 client holds a
conflicting NLM lock, and identifies the discriminator as "the share was added after the
NFS adapter started" (measured as: `adapter disable` + `enable` fixes it, 3/3).

Nothing in the delegation or lock-resolution path depends on when a share was created.
`GetLockManagerForHandle` reads the same `Service.lockManagers` map that
`RegisterStoreForShare` populates identically at boot and at runtime, and
`SetLockManagerResolver` resolves it per operation. The defect below is unconditional.

What the restart plausibly changes is whether the NFSv4 client got a **delegation**, which
is what actually decides the outcome. `ShouldGrantDelegation` requires `client.CBPathUp`,
and that flag is set by a one-shot **asynchronous** CB_NULL probe fired from
SETCLIENTID_CONFIRM (`internal/adapter/nfs/v4/state/manager.go`). If the probe loses the
race against the client's callback service — or fails for any reason — that client never
receives a delegation for its whole lifetime, its byte-range locks all go to the server,
and the case passes. Any timing shift earlier in the harness (an adapter restart plus
`sleep 1` before the mounts) can flip that race deterministically on a given machine. That
part is a hypothesis I could not test without the netns rig; the part below is verified.

## Root cause

The server hands out an NFSv4 delegation on a file that already carries a byte-range lock
taken over another protocol.

A delegated client is entitled to stop asking the server. RFC 7530 §10.4.2: *"When a client
holds an OPEN_DELEGATE_WRITE delegation, lock operations may be performed locally. […] This
can be done since the delegation implies that there can be no conflicting locks."* Linux
implements exactly that — `nfs4_proc_lock` satisfies `fcntl` byte-range locks from the local
lock table whenever `NFS_DELEGATED_STATE` is set on the open state, without emitting a LOCK
RPC. So the unified lock manager's cross-protocol conflict check, which is correct and does
fire for SMB, is simply never reached: the NFSv4 client answers its own lock locally and
reports ACQUIRED.

`ShouldGrantDelegation` checked delegations-enabled, the client record, `CBPathUp`,
recent recalls, other clients' opens and other delegations — but never byte-range locks. So
did `lock.Manager.GrantDelegation`, which enforced lease conflicts only. SMB leases have had
the equivalent rule all along (`opLockConflictsWithByteLock`); delegations were the gap.

The mirror direction was missing too. `BreakLeasesForByteRangeLock` — called by all three
byte-range acquire paths (NFSv4 `acquireLock`, NLM `LockFileNLM`, the SMB lease manager) —
broke leases but never recalled delegations. Since a delegation is recorded as a whole-file
row in `unifiedLocks`, `AddUnifiedLock` then denies every foreign byte-range lock on that
file for as long as the delegation lives. That is the "never released" column in the issue's
matrix: once the NFSv4 client picked up a delegation on `lock.dat`, every later NLM attempt
stayed BLOCKED even after the holder released, because the lingering delegation — not the
holder — was the thing denying it.

## The fix

- `lock.Manager.GrantDelegation` weighs the delegation as the whole-file byte-range lock it
  stands in for and refuses it against **both** lock maps (`unifiedLocks` for NLM/NFSv4,
  `locks` for SMB). A write delegation (exclusive) is denied by any foreign lock; a read
  delegation (shared) only by a foreign exclusive one — the same rule byte-range locks apply
  to each other, so read caching alongside shared readers is unaffected.
- `state.GrantDelegation` registers with the lock manager **before** publishing local state
  and returns nil on refusal, so a rejected delegation is never handed to the client. It
  previously logged the failure and continued with local-only state, which is the worst of
  both worlds: the manager does not know about the delegation, and the client behaves as if
  it holds one. `GrantDirDelegation` had the same shape and now follows the same ordering.
- `BreakLeasesForByteRangeLock` — the one function all three byte-range acquire paths call —
  also recalls outstanding delegations, so a lock arriving after a delegation was granted
  drives a CB_RECALL instead of being denied until the delegation's lease expires. RFC 7530
  §10.4.4 permits recall at any time.

Two follow-on gaps had to be closed for that recall to converge, both found in review:

- A delegation row and the byte-range locks of the same NFSv4 client carried **different**
  client identity strings (`"5"` vs `"nfs4:5"`), so the exclusion in `breakDelegations` could
  never match and a client's own lock would recall its own delegation. Both now go through
  one `nfsClientIdentity` helper, which is where the drift came from.
- `UnifiedLock.ConflictsWith` treated a delegation row as a whole-file exclusive lock even
  against its own holder, so a delegated client's LOCK was denied by its own delegation. That
  is exactly the operation RFC 7530 §10.4.4 requires on recall — *"if there are granted file
  locks, the corresponding LOCK operations must be sent"* — so without the exemption the
  client could not return the delegation cleanly and the waiting NLM lock would never be
  granted. Foreign clients still conflict, which is the whole point.

## Verification

Reproduced and fixed at the Go level, red before / green after (`go test` on unmodified
`develop` fails these; they pass with the change):

```
--- FAIL: TestGrantDelegation_DeniedWhileForeignByteRangeLockHeld
    [INFO] Delegation granted client_id=... deleg_type=2 stateid_seqid=1
    delegation_test.go: delegation must not be granted while another protocol holds a byte-range lock
--- FAIL: TestManager_GrantDelegation_DeniedByByteRangeLock
    Error: An error is expected but got nil.
    Messages: write delegation must be denied while an NLM lock is held
--- FAIL: TestManager_GrantDelegation_DeniedBySMBByteRangeLock
    Error: An error is expected but got nil.
--- FAIL: TestManager_BreakLeasesForByteRangeLock_RecallsDelegation
    Error: Should be true
    Messages: delegation should be recalled by a byte-range lock
```

The NFSv4-level test walks the reported path end to end: an NLM lock is seeded in the
share's manager, the delegation is refused, and the LOCK the client is then forced to put on
the wire comes back DENIED. Two more tests pin the same-client half — a client's own lock
does not recall its own delegation, and its own delegation does not deny its own lock, while
a foreign lock is still denied.

`go build ./...`, `go vet ./...`, `go test ./...` and `go test -race` over
`pkg/metadata/lock`, `internal/adapter/nfs/v4`, `internal/adapter/smb/lease` and
`pkg/adapter/nfs` are green; `golangci-lint` reports 0 issues.

Not run here: `test/e2e/testdata/nlm/nlm_axis_interop.sh` needs a Linux netns rig with a
kernel NFSv3 client, so the four-case matrix has not been re-measured on hardware. The
expectation is that cases 1, 2 and 4 come out correct (no delegation is granted over the NLM
lock; in case 4 the NLM attempt now recalls the delegation, so the retry after release
succeeds).

Closes #1968.
