### PR TITLE
docs: sweep the LOW comment/slop audit findings across the data plane

### DIFF
--- a/internal/adapter/common/write_payload.go
+++ b/internal/adapter/common/write_payload.go
@@ -26,7 +26,7 @@ import (
 // succeeds and the remote mirror stays fully asynchronous and observable via
 // the unsynced-bytes metric. Even when strict enforcement IS enabled, the
 // common production case (fs local store) returns nil on the fast
-// local-durable path before this is ever reached. See #1274.
+// local-durable path before this is ever reached.
 var ErrNotDurableYet = errors.New("block: data not yet durable (local store is volatile and durable remote not reached)")
 
 // WriteToBlockStore is the structural twin of ReadFromBlockStore. It is a
@@ -72,8 +72,8 @@ func WriteToBlockStore(
 // keeping protocol-handler code unchanged.
 //
 // A hard flush error (I/O fault, remote.Put rejection, metadata error) is
-// ALWAYS surfaced unchanged (the #1267 fix) — engine.Flush returning a non-nil
-// error propagates regardless of policy.
+// ALWAYS surfaced unchanged — engine.Flush returning a non-nil error
+// propagates regardless of policy.
 //
 // Beyond that, durability acknowledgement is governed by the per-share policy
 // flag RequireDurableCommit (config["require_durable_commit"], default false):
@@ -113,7 +113,7 @@ func CommitBlockStore(
 		return err
 	}
 
-	// Observability (#1245): record the per-store durability decision at the
+	// Observability: record the per-store durability decision at the
 	// ack point. engine.Flush returning nil only means the flush pump did not
 	// fault; in the DEFAULT (async) policy Finalized may still be false while
 	// the remote mirror catches up, and localDurable=true (fs local store)

--- a/internal/adapter/nfs/v3/handlers/commit.go
+++ b/internal/adapter/nfs/v3/handlers/commit.go
@@ -68,9 +68,8 @@ type CommitResponse struct {
 	// and not write it to stable storage. The client can use the COMMIT operation
 	// to force the server to write the data to stable storage."
 	//
-	// In this implementation:
-	//   - Value of 0 indicates no server reboot tracking
-	//   - A production implementation should track server start time or boot ID
+	// It carries the server boot time (serverBootTime), so it stays constant
+	// for the lifetime of a server process and changes only across a restart.
 	WriteVerifier uint64
 }
 

--- a/internal/adapter/nfs/v3/handlers/read.go
+++ b/internal/adapter/nfs/v3/handlers/read.go
@@ -252,8 +252,6 @@ func (h *Handler) Read(
 	readEnd := min(req.Offset+uint64(count), file.Size)
 	actualLength := uint32(readEnd - req.Offset)
 
-	// All reads go through BlockStore.ReadAt which reads from block store.
-
 	logger.DebugCtx(ctx.Context, "READ: reading from BlockStore", "handle", xdr.LazyHandle(req.Handle), "offset", req.Offset, "count", actualLength, "payload_id", file.PayloadID)
 	readResult, readErr := common.ReadFromBlockStore(ctx.Context, blockStore, file.PayloadID, req.Offset, actualLength)
 	if readErr != nil {

--- a/internal/adapter/nfs/v4/handlers/read_plus.go
+++ b/internal/adapter/nfs/v4/handlers/read_plus.go
@@ -44,9 +44,11 @@ var errNoRegistry = errors.New("no registry configured")
 // data segments and NFS4_CONTENT_HOLE runs. Bytes-on-wire for a sparse file are
 // less than its logical size because hole runs carry only (offset, length).
 //
-// DittoFS derives the segmentation from the file's content-addressed block list
-// (block.Segments). The always-correct fallback — a dense file or a file with
-// no tracked holes — yields a single data segment, matching plain READ.
+// DittoFS derives the segmentation from the block-store engine's multi-tier
+// DataExtents view, falling back to the file's content-addressed block list
+// (block.Segments) when the engine cannot be resolved. Either way, a dense
+// file or a file with no tracked holes yields a single data segment, matching
+// plain READ.
 func (h *Handler) handleReadPlus(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
 	if status := types.RequireCurrentFH(ctx); status != types.NFS4_OK {
 		return readPlusErr(status)

--- a/internal/adapter/smb/handlers/read.go
+++ b/internal/adapter/smb/handlers/read.go
@@ -531,7 +531,6 @@ func (h *Handler) handleSymlinkRead(
 	// underlying source of the returned bytes.
 	recordReadProgress(openFile, req.Offset, uint64(len(data)))
 
-	// Build response
 	return &ReadResponse{
 		SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess},
 		DataOffset:      0x50, // Standard offset
@@ -557,7 +556,6 @@ func (h *Handler) handlePipeRead(ctx *SMBHandlerContext, req *ReadRequest, openF
 		"pipeName", openFile.PipeName,
 		"requestedLength", req.Length)
 
-	// Get pipe state
 	pipe := h.PipeManager.GetPipe(req.FileID)
 	if pipe == nil {
 		logger.Debug("READ: pipe not found", "fileID", lazyFileID(req.FileID))

--- a/internal/adapter/smb/handlers/write.go
+++ b/internal/adapter/smb/handlers/write.go
@@ -599,14 +599,12 @@ func (h *Handler) handlePipeWrite(ctx *SMBHandlerContext, req *WriteRequest, ope
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}, nil
 	}
 
-	// Get pipe state
 	pipe := h.PipeManager.GetPipe(req.FileID)
 	if pipe == nil {
 		logger.Debug("WRITE: pipe not found", "fileID", lazyFileID(req.FileID))
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidHandle}}, nil
 	}
 
-	// Process RPC data
 	err := pipe.ProcessWrite(req.Data)
 	if err != nil {
 		logger.Warn("WRITE: pipe write failed", "error", err)

--- a/pkg/block/doc.go
+++ b/pkg/block/doc.go
@@ -144,20 +144,4 @@
 // the goal is for `grep -rn 'TRANSITIONAL-' ./pkg/block` to
 // enumerate every deferral surface in one pass and for new contributors
 // to recognize the convention without consulting a roadmap.
-//
-// audit: at the close of the write-path RAM-optimization
-// phase, every TRANSITIONAL-NEXT-MILESTONE marker in pkg/block/
-// points at #519 ("Deferred to v0.17+") — the five v0.17 anchor sites
-// are pinned hot-tail RAM + zstd compression (chunkstore.go), O_DIRECT
-// (appendwrite.go), tmpfs spill (appendlog.go), and cold-cache prefetch
-// (engine/cache.go). All five carry the generic NEXT-MILESTONE marker
-// (the inline `see #519` reference documents the v0.17+ target without
-// burning a TRANSITIONAL-V0.17 tag into the grep namespace until the
-// v0.17 planning pass commits to a concrete deletion plan).
-//
-// also closed the `claim_batch_size`
-// deprecation cycle (the SyncerConfig field was set/defaulted but
-// never read by the syncer claim path). That cycle did not use a
-// TRANSITIONAL- marker — it relied on an inline godoc note — and the
-// field plus its defaults/validate paths are gone as of this phase.
 package block

--- a/pkg/block/doc.go
+++ b/pkg/block/doc.go
@@ -140,7 +140,7 @@
 // for both markers and either retires them (deletion) or re-targets
 // them to a specific milestone tag.
 //
-// Apply the markers on the symbol's godoc, not on internal callers
+// Apply the markers on the symbol's godoc, not on internal callers:
 // the goal is for `grep -rn 'TRANSITIONAL-' ./pkg/block` to
 // enumerate every deferral surface in one pass and for new contributors
 // to recognize the convention without consulting a roadmap.

--- a/pkg/block/engine/cache.go
+++ b/pkg/block/engine/cache.go
@@ -43,19 +43,20 @@ type cacheInterface interface {
 var _ cacheInterface = (*Cache)(nil)
 var _ cacheInterface = nullCache{}
 
-// The Cache is populated lazily: on first read of a hash, and on the
-// write side via the OnChunkComplete wiring in engine.go. There is no
-// proactive warm on share-open, so the restart-then-read path always
-// starts cold.
+// The Cache is populated only on the write side, via the OnChunkComplete
+// wiring in engine.go. There is no read-through: loadByHash always misses,
+// because the journal local store is (payloadID, offset)-keyed and has no
+// content-addressed read to serve a hash lookup from. So nothing a read
+// pulls in ever lands here, and the restart-then-read path always starts
+// cold and stays cold until writes repopulate it.
 
 // Cache is the single-type, CAS-keyed in-memory cache. It folds the
 // prefetch worker pool into one type.
 //
-// On miss, bytes are loaded via local.Get(ctx, hash) —
-// engine.loadByHash. The Cache copies the returned []byte into its
-// LRU slot (buffer ownership). No mmap/page-cache fast path exists
-// production workloads are warm-cache and the per-miss alloc is
-// uncontended.
+// On miss the Cache calls its loadFn (engine.loadByHash), which returns
+// ErrChunkNotFound unconditionally, so a miss stays a miss. Were a
+// hash-keyed local read to exist, the Cache would copy the returned []byte
+// into its LRU slot rather than retain it.
 //
 // Thread safety: read path takes RLock for hits, promotes LRU under
 // WLock; mutations are WLock-only. The trackerMu is a separate lock so

--- a/pkg/block/engine/cache.go
+++ b/pkg/block/engine/cache.go
@@ -9,7 +9,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/block"
 )
 
-// seqThreshold (CACHE-03) is the number of consecutive sequential reads
+// seqThreshold is the number of consecutive sequential reads
 // observed before the prefetcher fires. Set to 3 to suppress speculative
 // prefetch on accidental two-block runs in random-IO workloads (VM
 // rand-write was the regression).
@@ -24,7 +24,7 @@ const maxPrefetchDepth = 8
 const defaultPrefetchWorkers = 4
 
 // reqQueueSize is the bounded channel capacity backing the prefetch
-// worker pool (T-12-24 mitigation: non-blocking submit drops when full).
+// worker pool; submit is non-blocking and drops the request when full.
 const reqQueueSize = 64
 
 // cacheInterface is the narrow surface engine code depends on. The
@@ -43,14 +43,12 @@ type cacheInterface interface {
 var _ cacheInterface = (*Cache)(nil)
 var _ cacheInterface = nullCache{}
 
-// TRANSITIONAL-NEXT-MILESTONE: cold-cache prefetch (see #519 "Deferred
-// to v0.17+"). When cold-cache prefetch lands, the Cache will be
-// proactively warmed on share-open via an offline LRU snapshot, not
-// just on first-read. The current write-side OnChunkComplete wiring
-// (engine.go) already covers the warm-after-write case; cold-
-// cache covers the restart-then-read case.
+// The Cache is populated lazily: on first read of a hash, and on the
+// write side via the OnChunkComplete wiring in engine.go. There is no
+// proactive warm on share-open, so the restart-then-read path always
+// starts cold.
 
-// Cache is the single-type, CAS-keyed in-memory cache (CACHE-01..05). It
+// Cache is the single-type, CAS-keyed in-memory cache. It
 // folds the prefetch worker pool into one type.
 //
 // On miss, bytes are loaded via local.Get(ctx, hash) —
@@ -64,12 +62,11 @@ var _ cacheInterface = nullCache{}
 // OnRead's hot path (per-payload sequential detection) doesn't contend
 // with cache hits/puts.
 //
-// Per-share isolation (CLAUDE.md rule 4): the Cache lives inside
-// *engine.Store which is per-share by construction. Cross-share
-// cache sharing is impossible without going through the Store
-// boundary, so T-12-25 is "accept" by design.
+// Per-share isolation: the Cache lives inside *engine.Store, which is
+// per-share by construction. Cross-share cache sharing is impossible
+// without going through the Store boundary.
 //
-// CACHE-02 cross-file dedup: two payloads referencing the same
+// Cross-file dedup: two payloads referencing the same
 // ContentHash share one cache entry. Eviction is hash-scoped (LRU)
 // InvalidateFile is surgical (drops only the explicitly-listed hashes
 // for a file, preserving any shared entries).
@@ -172,7 +169,7 @@ func newCacheNoWorkers(maxBytes int64) *Cache {
 //     do anything. nil loadFn means OnRead can run but workers will
 //     drop requests (no-loader path).
 //   - The bounded reqCh has capacity reqQueueSize (64); submit is
-//     non-blocking and silently drops on full queue (T-12-24).
+//     non-blocking and silently drops on full queue.
 func NewCache(maxBytes int64, workers int, loadFn loadByHashFn) *Cache {
 	if maxBytes <= 0 {
 		return nil
@@ -282,10 +279,10 @@ func (c *Cache) evictLocked() {
 // InvalidateFile drops only the listed hashes from the cache and
 // resets the per-payload sequential tracker (so the next read for
 // this file rebuilds the prefetch state from scratch). Hashes NOT
-// listed remain — including hashes shared by other files (CACHE-02
+// listed remain — including hashes shared by other files (cross-file
 // dedup is preserved).
 //
-// CACHE-05 surgical invalidation: callers pass the set of hashes to drop —
+// Invalidation is surgical: callers pass the set of hashes to drop —
 // typically a computed old/new ChunkRef diff, but delete paths may pass a
 // file's full hash list (or nil). Drop semantics preserve duplicate-hash
 // multiplicity expectations (callers may pass the same hash multiple times;
@@ -311,7 +308,7 @@ func (c *Cache) InvalidateFile(payloadID string, removedHashes []block.ContentHa
 	c.trackerMu.Unlock()
 }
 
-// OnRead is the sole prefetch hint API (CACHE-04). The engine calls
+// OnRead is the sole prefetch hint API. The engine calls
 // this after a successful ReadAt with the ChunkRef hashes that
 // satisfied the read; the cache uses the per-payloadID sequential
 // tracker to decide whether to fire prefetch on the upcoming hashes.
@@ -388,7 +385,7 @@ func (c *Cache) OnRead(payloadID string, hashes []block.ContentHash, fileSize ui
 }
 
 // submitPrefetch enqueues a prefetch request, dropping silently when
-// the bounded queue is full (T-12-24).
+// the bounded queue is full.
 func (c *Cache) submitPrefetch(h block.ContentHash) {
 	if c == nil || c.closed.Load() || c.reqCh == nil {
 		return

--- a/pkg/block/engine/cache.go
+++ b/pkg/block/engine/cache.go
@@ -9,8 +9,8 @@ import (
 	"github.com/marmos91/dittofs/pkg/block"
 )
 
-// seqThreshold is the number of consecutive sequential reads
-// observed before the prefetcher fires. Set to 3 to suppress speculative
+// seqThreshold is the number of consecutive sequential reads observed
+// before the prefetcher fires. Set to 3 to suppress speculative
 // prefetch on accidental two-block runs in random-IO workloads (VM
 // rand-write was the regression).
 const seqThreshold = 3
@@ -48,8 +48,8 @@ var _ cacheInterface = nullCache{}
 // proactive warm on share-open, so the restart-then-read path always
 // starts cold.
 
-// Cache is the single-type, CAS-keyed in-memory cache. It
-// folds the prefetch worker pool into one type.
+// Cache is the single-type, CAS-keyed in-memory cache. It folds the
+// prefetch worker pool into one type.
 //
 // On miss, bytes are loaded via local.Get(ctx, hash) —
 // engine.loadByHash. The Cache copies the returned []byte into its
@@ -66,8 +66,8 @@ var _ cacheInterface = nullCache{}
 // per-share by construction. Cross-share cache sharing is impossible
 // without going through the Store boundary.
 //
-// Cross-file dedup: two payloads referencing the same
-// ContentHash share one cache entry. Eviction is hash-scoped (LRU)
+// Cross-file dedup: two payloads referencing the same ContentHash
+// share one cache entry. Eviction is hash-scoped (LRU)
 // InvalidateFile is surgical (drops only the explicitly-listed hashes
 // for a file, preserving any shared entries).
 type Cache struct {
@@ -308,8 +308,8 @@ func (c *Cache) InvalidateFile(payloadID string, removedHashes []block.ContentHa
 	c.trackerMu.Unlock()
 }
 
-// OnRead is the sole prefetch hint API. The engine calls
-// this after a successful ReadAt with the ChunkRef hashes that
+// OnRead is the sole prefetch hint API. The engine calls this after a
+// successful ReadAt with the ChunkRef hashes that
 // satisfied the read; the cache uses the per-payloadID sequential
 // tracker to decide whether to fire prefetch on the upcoming hashes.
 //

--- a/pkg/block/engine/cache.go
+++ b/pkg/block/engine/cache.go
@@ -67,7 +67,7 @@ var _ cacheInterface = nullCache{}
 // without going through the Store boundary.
 //
 // Cross-file dedup: two payloads referencing the same ContentHash
-// share one cache entry. Eviction is hash-scoped (LRU)
+// share one cache entry. Eviction is hash-scoped (LRU);
 // InvalidateFile is surgical (drops only the explicitly-listed hashes
 // for a file, preserving any shared entries).
 type Cache struct {

--- a/pkg/block/engine/compaction.go
+++ b/pkg/block/engine/compaction.go
@@ -1,4 +1,4 @@
-// Package engine — GC compaction of partially-dead blocks (#1487).
+// Package engine — GC compaction of partially-dead blocks.
 //
 // Delete-only block GC (gc_block.go) frees a block object only once its LAST
 // live chunk dies. A block that keeps a few live chunks but has accumulated
@@ -137,7 +137,7 @@ func CompactBlocks(
 		// Live bytes per block: sum the WireLength of every live synced locator.
 		// Single scan: EnumerateSynced yields each marker's locator alongside its
 		// hash (same row), so no GetLocator round trip per hash — the O(N) serial
-		// cost on the sqlite MaxOpenConns(1) pool (#1554). Folding the locator in
+		// cost on the sqlite MaxOpenConns(1) pool. Folding the locator in
 		// also removes the nested-query deadlock class structurally.
 		liveBytes := make(map[string]int64)
 		if err := v.EnumerateSynced(ctx, func(_ block.ContentHash, loc block.ChunkLocator, _ time.Time) error {

--- a/pkg/block/engine/compaction.go
+++ b/pkg/block/engine/compaction.go
@@ -137,8 +137,8 @@ func CompactBlocks(
 		// Live bytes per block: sum the WireLength of every live synced locator.
 		// Single scan: EnumerateSynced yields each marker's locator alongside its
 		// hash (same row), so no GetLocator round trip per hash — the O(N) serial
-		// cost on the sqlite MaxOpenConns(1) pool. Folding the locator in
-		// also removes the nested-query deadlock class structurally.
+		// cost on the sqlite MaxOpenConns(1) pool. Folding the locator in also
+		// removes the nested-query deadlock class structurally.
 		liveBytes := make(map[string]int64)
 		if err := v.EnumerateSynced(ctx, func(_ block.ContentHash, loc block.ChunkLocator, _ time.Time) error {
 			if loc.BlockID != "" {

--- a/pkg/block/engine/coordinator.go
+++ b/pkg/block/engine/coordinator.go
@@ -102,7 +102,7 @@ type MetadataCoordinator interface {
 	// rollup-completion callback reads this to merge a partial rollup
 	// pass into the already-committed block list before calling
 	// PersistFileChunks, so a multi-pass rollup keeps FileAttr.Blocks
-	// complete instead of replacing it with only the latest pass (#789).
+	// complete instead of replacing it with only the latest pass.
 	//
 	// Reads the manifest source (file_block_refs on Postgres, encoded
 	// FileAttr.Blocks on Badger/Memory) — NOT the per-file FileChunk
@@ -111,8 +111,8 @@ type MetadataCoordinator interface {
 
 	// FindByObjectID looks up a previously-quiesced file in the
 	// metadata store by Merkle-root ObjectID. Returns (nil, nil) on
-	// miss. Used by the file-level dedup short-circuit
-	// . Per-metadata-store scope, not per-share.
+	// miss. Used by the file-level dedup short-circuit.
+	// Per-metadata-store scope, not per-share.
 	//
 	// Implementations short-circuit on zero-valued ObjectID and return
 	// (nil, nil) without touching the metadata store.

--- a/pkg/block/engine/engine.go
+++ b/pkg/block/engine/engine.go
@@ -287,8 +287,8 @@ func (bs *Store) Start(ctx context.Context) error {
 // block by ContentHash. It is a permanent no-op miss: the journal local store
 // is (payloadID,offset)-keyed, not hash-keyed, so there is no local
 // content-addressed read to prefetch through. Cold reads hydrate covering
-// chunks from the remote on demand (read_internal.go), which leaves the CAS
-// read cache hint-only. Remote fallback is deliberately not wired here —
+// chunks from the remote on demand (read_internal.go). ponytail: that leaves
+// the CAS read cache hint-only. Remote fallback is deliberately not wired here —
 // prefetch is best-effort and must not block on a remote round-trip.
 func (bs *Store) loadByHash(_ context.Context, _ block.ContentHash) ([]byte, error) {
 	return nil, block.ErrChunkNotFound

--- a/pkg/block/engine/engine.go
+++ b/pkg/block/engine/engine.go
@@ -95,10 +95,8 @@ type Store struct {
 	coordinator MetadataCoordinator
 
 	// syncedHashStore persists per-CAS-hash local→remote mirror state.
-	// Held alongside the coordinator so the engine constructor can
-	// thread it into both the Syncer (via SetSyncedHashStore) and the
-	// FSStore (via the ObjectIDPersister callback target's sibling
-	// SetSyncedHashStore on the local store). May be nil in tests.
+	// Held alongside the coordinator so the engine constructor can thread
+	// it into the Syncer (via SetSyncedHashStore). May be nil in tests.
 	syncedHashStore metadata.SyncedHashStore
 
 	// cache is the CAS-keyed cache (CACHE-01..05). The block-coord
@@ -285,26 +283,14 @@ func (bs *Store) Start(ctx context.Context) error {
 	return nil
 }
 
-// loadByHash is the loadByHashFn the Cache's prefetch workers call to
-// pull a block by ContentHash. It performs a single content-addressed
-// local read; local.Get is the only primitive (no mmap fast-path, no
-// legacy FileChunk → GetBlockData fallback).
-//
-// Buffer ownership: local.Get returns a freshly allocated []byte; the
-// Cache copies those bytes into its LRU slot on miss. The net
-// allocation count matches the legacy mmap-then-copy semantics — the
-// alloc just moves earlier in the pipeline.
-//
-// Remote fallback is intentionally NOT wired here — prefetch is
-// best-effort and shouldn't block on a remote round-trip; if the
-// block isn't local, the next on-path read will pull it via the
-// syncer.
+// loadByHash is the loadByHashFn the Cache's prefetch workers call to pull a
+// block by ContentHash. It is a permanent no-op miss: the journal local store
+// is (payloadID,offset)-keyed, not hash-keyed, so there is no local
+// content-addressed read to prefetch through. Cold reads hydrate covering
+// chunks from the remote on demand (read_internal.go), which leaves the CAS
+// read cache hint-only. Remote fallback is deliberately not wired here —
+// prefetch is best-effort and must not block on a remote round-trip.
 func (bs *Store) loadByHash(_ context.Context, _ block.ContentHash) ([]byte, error) {
-	// The journal local store is (payloadID,offset)-keyed, not hash-keyed, so
-	// there is no local content-addressed read to prefetch through. Prefetch by
-	// hash is therefore a no-op miss; cold reads hydrate covering chunks from
-	// the remote on demand (read_internal.go). ponytail: the CAS read cache is
-	// now hint-only.
 	return nil, block.ErrChunkNotFound
 }
 

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -206,8 +206,8 @@ func clampSpan(span hydrateSpan, chunkStart, n uint64) (lo, hi uint64) {
 
 // dispatchRemoteFetch routes a per-block S3 GET through the CAS verified-
 // read path. There is no legacy fallback: any FileChunk surfacing here
-// with a zero Hash is migration drift and the boot guard
-// (cmd/dfs/start) should have refused to start. If a stray row
+// with a zero Hash is migration drift and the boot guard (cmd/dfs/start)
+// should have refused to start. If a stray row
 // reaches this code path at runtime, refuse the read instead of returning
 // silent zeros.
 //
@@ -426,10 +426,9 @@ func (m *Syncer) fetchResolvedBlock(ctx context.Context, fb *block.FileChunk, sp
 			// should make this impossible). Returning silent zeros
 			// here would corrupt the caller's read with no log trace.
 			// Surface ErrChunkNotFound so the caller sees the data
-			// loss explicitly. There is no legacy zero-hash branch,
-			// so the !IsZero guard is implicit —
-			// any successful dispatchRemoteFetch return implies a
-			// CAS row.
+			// loss explicitly. There is no legacy zero-hash branch, so
+			// the !IsZero guard is implicit — any successful
+			// dispatchRemoteFetch return implies a CAS row.
 			logger.Error("CAS object missing for live FileChunk — possible GC race or live-data-loss",
 				"block_id", fb.ID, "store_key", storeKey, "hash", fb.Hash.String())
 			return nil, fmt.Errorf("CAS object missing for live row %s (key %s): %w",

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -205,8 +205,8 @@ func clampSpan(span hydrateSpan, chunkStart, n uint64) (lo, hi uint64) {
 }
 
 // dispatchRemoteFetch routes a per-block S3 GET through the CAS verified-
-// read path. Post-Phase-17 there is no legacy fallback: any FileChunk
-// surfacing here with a zero Hash is migration drift and the boot guard
+// read path. There is no legacy fallback: any FileChunk surfacing here
+// with a zero Hash is migration drift and the boot guard
 // (cmd/dfs/start) should have refused to start. If a stray row
 // reaches this code path at runtime, refuse the read instead of returning
 // silent zeros.
@@ -231,7 +231,7 @@ func (m *Syncer) dispatchRemoteFetch(ctx context.Context, fb *block.FileChunk) (
 
 	key, data, err := m.resolveAndReadChunk(ctx, fb)
 	if err != nil && errors.Is(err, block.ErrChunkNotFound) {
-		// Stale-locator window (#1487 compaction, and the cas→blocks migration /
+		// Stale-locator window (compaction, the cas→blocks migration, and the
 		// refcount reclaim paths): a concurrent maintenance pass relocated this
 		// chunk into a fresh block and deleted the old one AFTER we resolved its
 		// locator, so the GET 404s against bytes that moved. Re-resolve ONCE — a
@@ -413,7 +413,7 @@ func (m *Syncer) fetchResolvedBlock(ctx context.Context, fb *block.FileChunk, sp
 		return nil, nil
 	}
 
-	// dispatchRemoteFetch carries the stale-locator re-resolve retry (#1487), so
+	// dispatchRemoteFetch carries the stale-locator re-resolve retry, so
 	// a chunk relocated by compaction/migration reads through before we ever get
 	// here; a surviving ErrChunkNotFound is genuine live-data-loss.
 	storeKey, data, err := m.dispatchRemoteFetch(ctx, fb)
@@ -426,8 +426,8 @@ func (m *Syncer) fetchResolvedBlock(ctx context.Context, fb *block.FileChunk, sp
 			// should make this impossible). Returning silent zeros
 			// here would corrupt the caller's read with no log trace.
 			// Surface ErrChunkNotFound so the caller sees the data
-			// loss explicitly. Post-Phase-17 the legacy zero-hash
-			// branch is gone, so the !IsZero guard is implicit —
+			// loss explicitly. There is no legacy zero-hash branch,
+			// so the !IsZero guard is implicit —
 			// any successful dispatchRemoteFetch return implies a
 			// CAS row.
 			logger.Error("CAS object missing for live FileChunk — possible GC race or live-data-loss",
@@ -624,8 +624,8 @@ func (m *Syncer) inlineFetchOrWait(ctx context.Context, payloadID string, blockI
 			// fail-closed on the CAS path. See
 			// fetchBlock for the rationale — a non-zero-hash row that
 			// resolves to a missing CAS object is a live-data-loss
-			// signal that must NOT silently return zeros. Post-Phase-17
-			// every reachable row is CAS-shaped.
+			// signal that must NOT silently return zeros. Every
+			// reachable row is CAS-shaped.
 			logger.Error("CAS object missing for live FileChunk — possible GC race or live-data-loss",
 				"block_id", fb.ID, "store_key", storeKey, "hash", fb.Hash.String())
 			wrapped := fmt.Errorf("CAS object missing for live row %s (key %s): %w",

--- a/pkg/block/engine/gc.go
+++ b/pkg/block/engine/gc.go
@@ -64,10 +64,9 @@ const BlockSize = block.BlockSize
 // granularity is therefore PER-SHARE in practice — each share owns its
 // own gc-state directory under <localStore>/gc-state/, so concurrent
 // runs against DIFFERENT shares acquire DIFFERENT locks and proceed in
-// parallel; only same-share GC calls serialize. For the Phase-11
-// single-server deployment this is sufficient; cross-process safety
-// (multi-server) requires an OS-level flock and is left as a TODO for
-// the multi-process phase.
+// parallel; only same-share GC calls serialize. That is sufficient for a
+// single-server deployment; cross-process safety (multi-server) would
+// require an OS-level flock and is not implemented.
 //
 // Entries are reference-counted and deleted from the map when their
 // refcount drops to zero, so the map shrinks back to size 0 whenever no
@@ -146,8 +145,8 @@ type GCStats struct {
 	DryRunCandidates []string
 
 	// StrandedRowsReaped counts file_blocks rows reaped by the reconcile pass
-	// (rows whose owning inode was already gone — the pre-fix leak). Zero for a
-	// plain GC run; only the reconcile sets it (#1433).
+	// (rows whose owning inode was already gone — the leak this pass closes).
+	// Zero for a plain GC run; only the reconcile sets it.
 	StrandedRowsReaped int64 `json:"stranded_rows_reaped,omitempty"`
 
 	// IsLocalTier is true when these stats come from a local-store pass
@@ -223,7 +222,7 @@ type Options struct {
 	// every hash it deletes, keeping the index a strict subset of remote
 	// contents: a hash swept off the remote is no longer synced and must be
 	// re-uploaded if it reappears in the live set; without this, ListUnsynced
-	// skips it forever and a later snapshot's durability verify fails (#1433).
+	// skips it forever and a later snapshot's durability verify fails.
 	// Set ONLY for remote-tier sweeps — local eviction does not change remote
 	// synced state, so local sweeps leave it nil.
 	//
@@ -231,7 +230,7 @@ type Options struct {
 	// (synced − live) from this index — the remote is never LISTed (see
 	// sweepFromSyncedIndex). A remote sweep without an index is skipped
 	// fail-closed. Orphan packed blocks the index cannot see (a PutBlock-
-	// then-commit crash gap) are the #1525 reconcile's job (PR5).
+	// then-commit crash gap) are the reconcile pass's job.
 	SyncedHashIndex SyncedHashIndex
 
 	// MarkProgress, when non-nil, is invoked during the mark phase with the
@@ -239,12 +238,12 @@ type Options struct {
 	// gcMarkProgressInterval hashes within a share. It gives long-running mark
 	// phases (millions of hashes on snapshot-heavy deployments) a liveness
 	// signal so an async caller can surface progress instead of a silent stall
-	// (#1433). Invoked synchronously from the (sequential) mark loop, so it must
+	// signal. Invoked synchronously from the (sequential) mark loop, so it must
 	// not block; implementations just record the latest count.
 	MarkProgress func(hashesMarked int64)
 
-	// BlockReclaimer reclaims block-resident chunks (#1414 object packing)
-	// during the remote sweep. Post-#1493 every synced hash lives inside a
+	// BlockReclaimer reclaims block-resident chunks (object packing)
+	// during the remote sweep. Every synced hash lives inside a
 	// blocks/<id> object, so this is the ONLY remote reclaim path: the sweep
 	// decrements the enclosing block and frees the block object + record when
 	// its last live chunk is gone. It is reached only after the sweep has
@@ -275,7 +274,7 @@ type SyncedHashIndex interface {
 	// remote locator, and first-mirror timestamp. The locator is read from the
 	// same marker row, so callers that need it resolve every hash in a single
 	// scan instead of a GetLocator round trip per hash — the O(N)-serial cost on
-	// the sqlite MaxOpenConns(1) pool behind the slow cold-start (#1554). A
+	// the sqlite MaxOpenConns(1) pool behind the slow cold-start. A
 	// standalone (pre-flip) marker yields the zero ChunkLocator. A zero syncedAt
 	// means the backend has no recorded time (legacy marker) — the sweep treats
 	// it as fail-closed.
@@ -329,11 +328,11 @@ type HoldProvider interface {
 // metadata stores + block-keyed remote. Both must be wired for the sweep to
 // reclaim anything; a missing index/reclaimer is recorded fail-closed.
 //
-// reconciler MUST satisfy MultiShareReconciler when more than one share
-// points at the remote. A reconciler that satisfies only the legacy
-// MetadataReconciler is treated as "no shares" — the live set is empty
-// and every synced hash is a sweep candidate. Callers in production
-// (Runtime.RunBlockGC) supply a MultiShareReconciler.
+// reconciler MUST satisfy MultiShareReconciler: the share list to
+// enumerate comes from SharesForGC. A reconciler that satisfies only
+// MetadataReconciler yields no shares, and the mark phase then aborts the
+// run fail-closed rather than sweeping against an empty live set. Callers
+// in production (Runtime.RunBlockGC) supply a MultiShareReconciler.
 func CollectGarbage(
 	ctx context.Context,
 	reconciler MetadataReconciler,
@@ -346,7 +345,7 @@ func CollectGarbage(
 // store. Local stores are isolated per share (architecture invariant #4), so
 // the caller scopes the reconciler and snapshot holds to that single share.
 // The grace period protects freshly-written chunks whose FileChunk rows have
-// not yet committed (#1433).
+// not yet committed.
 func CollectGarbageLocal(
 	ctx context.Context,
 	localStore block.Store,
@@ -528,8 +527,7 @@ func collectGarbage(
 // EnumerateFileChunks to populate the live set. The first error from any
 // store aborts the entire mark phase (fail-closed).
 //
-// an empty share list is treated as a HARD ERROR. With no
-// shares to enumerate, the engine cannot prove what is live and therefore
+// An empty share list is a HARD ERROR. With no shares to enumerate, the engine cannot prove what is live and therefore
 // MUST NOT sweep — orphan-not-deleted is always preferred over
 // live-data-deleted. Callers that genuinely have no shares must
 // short-circuit at a higher level (Runtime.RunBlockGC already does so
@@ -619,7 +617,7 @@ func sharesForReconciler(r MetadataReconciler) []string {
 
 // sweepable is the minimal store surface the local walk sweep needs: enumerate
 // the chunk namespace and delete one object by hash. The per-share local
-// block.Store satisfies it (#1433).
+// block.Store satisfies it.
 //
 // Walk MUST invoke its callback sequentially: sweepByWalk mutates unsynchronized
 // per-run counters (scanned/swept/bytes) from inside the callback. The local

--- a/pkg/block/engine/gc.go
+++ b/pkg/block/engine/gc.go
@@ -145,8 +145,8 @@ type GCStats struct {
 	DryRunCandidates []string
 
 	// StrandedRowsReaped counts file_blocks rows reaped by the reconcile pass
-	// (rows whose owning inode was already gone — the leak this pass closes).
-	// Zero for a plain GC run; only the reconcile sets it.
+	// (rows whose owning inode was already gone — the leak this pass
+	// closes). Zero for a plain GC run; only the reconcile sets it.
 	StrandedRowsReaped int64 `json:"stranded_rows_reaped,omitempty"`
 
 	// IsLocalTier is true when these stats come from a local-store pass
@@ -237,14 +237,13 @@ type Options struct {
 	// running count of hashes marked so far — at each share boundary and every
 	// gcMarkProgressInterval hashes within a share. It gives long-running mark
 	// phases (millions of hashes on snapshot-heavy deployments) a liveness
-	// signal so an async caller can surface progress instead of a silent stall
-	// signal. Invoked synchronously from the (sequential) mark loop, so it must
+	// signal so an async caller can surface progress instead of a silent
+	// stall. Invoked synchronously from the (sequential) mark loop, so it must
 	// not block; implementations just record the latest count.
 	MarkProgress func(hashesMarked int64)
 
-	// BlockReclaimer reclaims block-resident chunks (object packing)
-	// during the remote sweep. Every synced hash lives inside a
-	// blocks/<id> object, so this is the ONLY remote reclaim path: the sweep
+	// BlockReclaimer reclaims block-resident chunks (object packing) during
+	// the remote sweep. Every synced hash lives inside a blocks/<id> object, so this is the ONLY remote reclaim path: the sweep
 	// decrements the enclosing block and frees the block object + record when
 	// its last live chunk is gone. It is reached only after the sweep has
 	// proven the hash globally dead (past grace, absent from the live set),
@@ -527,9 +526,10 @@ func collectGarbage(
 // EnumerateFileChunks to populate the live set. The first error from any
 // store aborts the entire mark phase (fail-closed).
 //
-// An empty share list is a HARD ERROR. With no shares to enumerate, the engine cannot prove what is live and therefore
-// MUST NOT sweep — orphan-not-deleted is always preferred over
-// live-data-deleted. Callers that genuinely have no shares must
+// An empty share list is a HARD ERROR. With no shares to enumerate, the
+// engine cannot prove what is live and therefore MUST NOT sweep —
+// orphan-not-deleted is always preferred over live-data-deleted.
+// Callers that genuinely have no shares must
 // short-circuit at a higher level (Runtime.RunBlockGC already does so
 // when DistinctRemoteStores returns an empty slice).
 func markPhase(ctx context.Context, reconciler MetadataReconciler, gcs *GCState, stats *GCStats, hold HoldProvider, remoteEndpointID string, shares []string, markProgress func(int64)) error {

--- a/pkg/block/engine/gc_block.go
+++ b/pkg/block/engine/gc_block.go
@@ -1,4 +1,4 @@
-// Package engine — block-aware GC reclaim (#1414 object packing, PR3).
+// Package engine — block-aware GC reclaim for packed-block objects.
 //
 // A chunk lives inside a packed blocks/<blockID> object. Its bytes are shared
 // with the other chunks in the same block, so the block object can be
@@ -28,7 +28,7 @@ type BlockReclaimer interface {
 	// handled=true (with the remote bytes freed, if any) when the hash
 	// resolved to a block locator and the block bookkeeping was applied.
 	// handled=false means this reclaimer has no block locator for the hash —
-	// post-#1493 the caller treats that as metadata drift and keeps the
+	// the caller treats that as metadata drift and keeps the
 	// marker (fail-closed); it never issues a per-hash remote delete.
 	// Idempotent: a hash whose block was already freed by a sibling chunk in
 	// the same sweep returns handled=true with zero bytes.
@@ -73,7 +73,7 @@ type BlockGCReclaimer struct {
 // chunk's local-index entry WITHOUT decrementing (pkg/block/local/fs/eviction.go
 // dropBlobIndexEntries), so under the old local-index token an evicted-then-
 // orphaned chunk looked "already reclaimed", its decrement was skipped, and its
-// block leaked forever (#1637). The marker is untouched by eviction.
+// block leaked forever. The marker is untouched by eviction.
 //
 // The marker is cleared at one of two points, keyed off whether this is the
 // block's LAST live chunk (its record count is about to floor to 0):

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -207,8 +207,7 @@ func (bs *Store) Truncate(ctx context.Context, payloadID string, currentBlocks [
 		// Reap each dropped tail block's OWN row (by exact ID
 		// "{payloadID}/{offset}") so its hash leaves EnumerateFileChunks once
 		// no row anywhere references it and the GC sweep can reclaim the remote
-		// chunk (otherwise truncated tail chunks leak on the remote forever —
-		// #832).
+		// chunk (otherwise truncated tail chunks leak on the remote forever).
 		//
 		// By-ID, not by-hash: each {payloadID}/offset row is independent and
 		// unique per offset. Dropped blocks are strictly past newSize, so their
@@ -245,7 +244,7 @@ func (bs *Store) Truncate(ctx context.Context, payloadID string, currentBlocks [
 
 	// Remote sweep is best-effort: GC will reconcile stragglers, so a
 	// failure here does NOT roll back the coordinator decrements (matches
-	// engine.Delete semantics post-).
+	// engine.Delete semantics).
 	if err := bs.syncer.Truncate(ctx, payloadID, newSize); err != nil {
 		return kept, err
 	}
@@ -371,7 +370,7 @@ func (bs *Store) Delete(ctx context.Context, payloadID string, blocks []block.Ch
 	// delete) unlinks a file without carrying its block list, passing nil.
 	// Historically nil short-circuited the coordinator, so refcounts were
 	// never decremented: the FileChunk rows survived, the hashes stayed in
-	// the GC live set, and the chunks leaked on BOTH tiers (#1433). When no
+	// the GC live set, and the chunks leaked on BOTH tiers. When no
 	// blocks are supplied, enumerate the payload's own FileChunk rows so the
 	// reap below operates on the file's real manifest.
 	if len(blocks) == 0 {
@@ -438,7 +437,7 @@ func (bs *Store) Delete(ctx context.Context, payloadID string, blocks []block.Ch
 // ChunkRefs so the Delete reap path can decrement refcounts. It is the bridge
 // for callers that unlink a file without carrying its manifest (NFS REMOVE /
 // SMB delete pass nil): without it those deletes never decrement refcounts and
-// their chunks leak on both tiers (#1433).
+// their chunks leak on both tiers.
 //
 // Returns nil when no FileChunkStore is wired or enumeration fails — Delete
 // still proceeds to the remote sweep, and the full GC reconcile reclaims any
@@ -478,7 +477,7 @@ func (bs *Store) payloadChunkRefs(ctx context.Context, payloadID string) []block
 //     resolves a payload's bytes via ListFileChunks(dstPayloadID) (the per-file
 //     FileChunk rows), NOT via FileAttr.Blocks. Without dst rows a read of the
 //     clone hits the sparse-block branch and zero-fills — silent corruption
-//     (#1384). Because every row carries the source hash and the chunks are
+//     silently. Because every row carries the source hash and the chunks are
 //     content-addressed, the dst rows resolve to the SAME shared CAS chunks and
 //     the clone reads back byte-identical to the source.
 //  2. Bumps each unique source-hash RefCount via the coordinator. This is now
@@ -490,11 +489,10 @@ func (bs *Store) payloadChunkRefs(ctx context.Context, payloadID string) []block
 // per-file rows and the FileAttr.Blocks manifest reference the same hashes and
 // offsets.
 //
-// Empty srcBlocks => nil-safe legacy path: copies nothing (legacy
-// CopyPayload data-copy semantics are removed in; the legacy
-// adapter call sites that need data copies should drive ReadAt+WriteAt
-// directly during the dual-read window). Production callers always
-// supply a snapshot of the source file's FileAttr.Blocks.
+// Empty srcBlocks => nil-safe path: copies nothing. CopyPayload no longer
+// copies data at all; adapter call sites that need a data copy drive
+// ReadAt+WriteAt directly. Production callers always supply a snapshot of
+// the source file's FileAttr.Blocks.
 //
 // Failure semantics: a genuine IncrementRefCount backend fault is surfaced
 // immediately without further increments (the caller's metadata txn rolls back).
@@ -542,7 +540,7 @@ func (bs *Store) CopyPayload(ctx context.Context, srcPayloadID, dstPayloadID str
 			// So a missing-row increment is a no-op to be skipped, mirroring how
 			// DecrementRefCount already tolerates the same miss. Without this,
 			// NFSv4.2 CLONE and SMB server-side-copy fail with EREMOTEIO on any
-			// rolled-up source (#1384). A genuine backend fault still aborts.
+			// rolled-up source. A genuine backend fault still aborts.
 			if errors.Is(err, block.ErrFileChunkNotFound) {
 				continue
 			}
@@ -552,8 +550,8 @@ func (bs *Store) CopyPayload(ctx context.Context, srcPayloadID, dstPayloadID str
 
 	// Create the destination's per-file FileChunk rows. The cold-read path
 	// resolves bytes via ListFileChunks(dstPayloadID), not FileAttr.Blocks, so
-	// without these rows reads of the clone zero-fill (silent corruption,
-	// #1384). One row per source block keyed by dstPayloadID + the SAME offset,
+	// without these rows reads of the clone zero-fill (silent corruption).
+	// One row per source block keyed by dstPayloadID + the SAME offset,
 	// hash and DataSize, in BlockStatePending — mirroring the rollup
 	// ObjectIDPersister (engine.go) so the dst rows resolve to the shared CAS
 	// chunks (content-addressed by hash). Skip zero-hash blocks (sparse holes
@@ -591,7 +589,7 @@ func (bs *Store) CopyPayload(ctx context.Context, srcPayloadID, dstPayloadID str
 		// Refuse to produce an unreadable clone: if there are blocks to
 		// materialize but no way to persist the dst rows, fail loudly rather
 		// than copy only the manifest (whose blocks the cold-read path can't
-		// resolve without rows → zero-fill, #1384).
+		// resolve without rows → zero-fill).
 		if putRow == nil {
 			return nil, fmt.Errorf("CopyPayload: no transaction or file-block store to persist dst rows for %s", dstPayloadID)
 		}

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -476,8 +476,8 @@ func (bs *Store) payloadChunkRefs(ctx context.Context, payloadID string) []block
 //     This is the load-bearing step for read correctness: the cold-read path
 //     resolves a payload's bytes via ListFileChunks(dstPayloadID) (the per-file
 //     FileChunk rows), NOT via FileAttr.Blocks. Without dst rows a read of the
-//     clone hits the sparse-block branch and zero-fills — silent corruption
-//     silently. Because every row carries the source hash and the chunks are
+//     clone hits the sparse-block branch and zero-fills — silent
+//     corruption. Because every row carries the source hash and the chunks are
 //     content-addressed, the dst rows resolve to the SAME shared CAS chunks and
 //     the clone reads back byte-identical to the source.
 //  2. Bumps each unique source-hash RefCount via the coordinator. This is now

--- a/pkg/block/engine/reclaim.go
+++ b/pkg/block/engine/reclaim.go
@@ -1,6 +1,6 @@
 // Package engine — orphan-storage reclaim, the *deleting* stages after the
-// read-only reporter (reconcile.go). Both operate on a
-// record's live-locator status, never its (possibly stale) LiveChunkCount:
+// read-only reporter (reconcile.go). Both operate on a record's
+// live-locator status, never its (possibly stale) LiveChunkCount:
 //
 //   - class 1 (ReclaimRecords, zero-ref): record with no live locator and
 //     LiveChunkCount == 0 — a crash between DecrLiveChunkCount and

--- a/pkg/block/engine/reclaim.go
+++ b/pkg/block/engine/reclaim.go
@@ -1,5 +1,5 @@
-// Package engine — orphan-storage reclaim (#1493/#1525 reconcile, PR5b+PR5c), the
-// *deleting* stages after the read-only reporter (reconcile.go). Both operate on a
+// Package engine — orphan-storage reclaim, the *deleting* stages after the
+// read-only reporter (reconcile.go). Both operate on a
 // record's live-locator status, never its (possibly stale) LiveChunkCount:
 //
 //   - class 1 (ReclaimRecords, zero-ref): record with no live locator and
@@ -8,7 +8,7 @@
 //   - class 2 (ReclaimRecords, leaked): record with no live locator but
 //     LiveChunkCount > 0 — DefaultCommitBlock's last-wins DeleteSynced→MarkSynced
 //     moved the hash onto a new block without decrementing this one, leaving its
-//     count stuck > 0 forever, invisible to the hash-driven sweep (#1525).
+//     count stuck > 0 forever, invisible to the hash-driven sweep.
 //   - class 3 (ReclaimOrphanObjects): a remote blocks/<id> object with no backing
 //     record, older than the grace window — PutBlock succeeded but the commit
 //     never landed.
@@ -59,7 +59,7 @@ type ReclaimReport struct {
 	// freed (Bytes, from each record's Length). On a dry run it tallies what WOULD
 	// be deleted.
 	Reclaimed ReconcileClass `json:"reclaimed"`
-	// LeakedReclaimed tallies class-2 leaked block records deleted (#1525): no
+	// LeakedReclaimed tallies class-2 leaked block records deleted: no
 	// live locator but a stale LiveChunkCount > 0.
 	LeakedReclaimed ReconcileClass `json:"leaked_reclaimed"`
 	// OrphanObjectsReclaimed tallies class-3 record-less remote objects deleted.
@@ -97,7 +97,7 @@ func (r *ReclaimReport) Merge(other ReclaimReport) {
 // ReclaimRecords deletes class-1 and class-2 orphan records across the given
 // per-share views that share one remote store: block records with no live locator,
 // split by their (possibly stale) LiveChunkCount into zero-ref (== 0, class 1) and
-// leaked (> 0, class 2 / #1525). For each it frees the remote block object
+// leaked (> 0, class 2). For each it frees the remote block object
 // (idempotent — the object may already be gone if a crash landed after DeleteBlock)
 // then deletes the record, matching the GC reclaimer's DeleteBlock→DeleteBlockRecord
 // order so a crash between them leaves a record-less orphan object (class 3, swept
@@ -161,7 +161,7 @@ func ReclaimRecords(
 		//
 		// Single scan: EnumerateSynced yields each marker's locator alongside its
 		// hash (same row), so no GetLocator round trip per hash — the O(N) serial
-		// cost on the sqlite MaxOpenConns(1) pool (#1554). Folding the locator in
+		// cost on the sqlite MaxOpenConns(1) pool. Folding the locator in
 		// also removes the nested-query deadlock class structurally.
 		if err := v.EnumerateSynced(ctx, func(_ block.ContentHash, loc block.ChunkLocator, _ time.Time) error {
 			if loc.BlockID != "" {

--- a/pkg/block/engine/reconcile.go
+++ b/pkg/block/engine/reconcile.go
@@ -1,8 +1,8 @@
-// Package engine — read-only orphan-storage reporter (#1493/#1525 reconcile,
-// PR5a). Reconcile enumerates and classifies orphaned block storage WITHOUT
-// mutating anything: no DeleteBlock, no DecrLiveChunkCount, no marker changes.
-// It is the report-only first stage of the reconcile series; an operator
-// reviews the report before the later delete stages (PR5b/5c) act.
+// Package engine — read-only orphan-storage reporter. Reconcile enumerates
+// and classifies orphaned block storage WITHOUT mutating anything: no
+// DeleteBlock, no DecrLiveChunkCount, no marker changes. It is the
+// report-only first stage; an operator reviews the report before the later
+// delete stages (reclaim.go) act.
 package engine
 
 import (
@@ -83,7 +83,7 @@ type ReconcileReport struct {
 	// LeakedBlocks: block records absent from the live locator set with
 	// LiveChunkCount > 0 — DefaultCommitBlock's last-wins DeleteSynced→MarkSynced
 	// moved a hash onto a new block without decrementing this one, and the
-	// hash-driven sweep never revisits it (class 2 / #1525).
+	// hash-driven sweep never revisits it (class 2).
 	LeakedBlocks ReconcileClass `json:"leaked_blocks"`
 	// OrphanRemoteObjects: blocks/<id> objects with no backing block record,
 	// older than the grace window — PutBlock succeeded but the commit failed
@@ -164,7 +164,7 @@ func Reconcile(
 		//
 		// Single scan: EnumerateSynced yields each marker's locator alongside its
 		// hash (same row), so no GetLocator round trip per hash — the O(N) serial
-		// cost on the sqlite MaxOpenConns(1) pool (#1554). Folding the locator in
+		// cost on the sqlite MaxOpenConns(1) pool. Folding the locator in
 		// also removes the nested-query deadlock class structurally.
 		refSet := make(map[string]struct{})
 		if err := v.EnumerateSynced(ctx, func(_ block.ContentHash, loc block.ChunkLocator, _ time.Time) error {

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -35,9 +35,8 @@ type Syncer struct {
 	local       local.LocalStore
 	remoteStore remote.RemoteStore
 	// hasRemote mirrors "remoteStore != nil" as an atomic so hot-path gating
-	// (carveActive recompute, read from addPendingHash under pendingMu) can
-	// read it without taking m.mu — avoiding both a data race with
-	// SetRemoteStore and a pendingMu→m.mu lock-ordering edge.
+	// (the carveActive recompute and the readahead scheduler) can read it
+	// without taking m.mu, avoiding a data race with SetRemoteStore.
 	hasRemote atomic.Bool
 	// fileChunkStore is the per-file chunk manifest, and the syncer needs the
 	// wide EngineFileChunkStore surface rather than a narrower one because it
@@ -105,11 +104,11 @@ type Syncer struct {
 	// reached remote (committed inside a packed block) and of failed carve
 	// upload attempts. They source the truthful CompletedSyncs / FailedSyncs
 	// fields in block stats; the legacy SyncQueue has no production upload
-	// callers, so its counters always read zero (#1266).
+	// callers, so its counters always read zero.
 	completedSyncs atomic.Int64
 	failedSyncs    atomic.Int64
 
-	// uploadLimiter bounds concurrent block PUTs in carveFlush (#1407 / #1432).
+	// uploadLimiter bounds concurrent block PUTs in carveFlush.
 	// When ParallelUploads is pinned (> 0) its limit is fixed at that value.
 	// When unset (adaptive mode) the uploadController resizes it every control
 	// interval to track the goodput knee. Lazily created by ensureUploadLimiter
@@ -126,7 +125,7 @@ type Syncer struct {
 	uploadedBytesWindow atomic.Int64
 	uploadErrWindow     atomic.Int64
 
-	// --- block carve path (#1414 object packing) ---
+	// --- block carve path (object packing) ---
 
 	// remoteBlockStore is the block-keyed remote (PutBlock) the carver uploads
 	// packed blocks to. nil disables carve. Wired via SetRemoteBlockStore;
@@ -189,7 +188,7 @@ func NewSyncer(local local.LocalStore, remoteStore remote.RemoteStore, fileChunk
 		config.ClaimTimeout = 10 * time.Minute
 	}
 
-	// Upload concurrency (#1407 / #1432): a pinned ParallelUploads > 0 fixes the
+	// Upload concurrency: a pinned ParallelUploads > 0 fixes the
 	// window; otherwise (the default) the carver auto-tunes between the adaptive
 	// floor and ceiling. The limiter starts at the floor in adaptive mode and at
 	// the pinned value otherwise; the control goroutine (adaptive only, launched
@@ -379,7 +378,7 @@ func (m *Syncer) canProcess(ctx context.Context) bool {
 //   - Finalized=true, err=nil: durable on the configured remote.
 //   - Finalized=false, err=nil: SOFT condition (no remote configured,
 //     remote unhealthy, or the carve substrate is not wired). Callers
-//     MUST NOT tight-loop retry (#670): surface the soft-fail to the
+//     MUST NOT tight-loop retry: surface the soft-fail to the
 //     protocol adapter and let the client drive the next attempt on its
 //     own schedule.
 //   - err != nil: hard failure, do not retry until addressed.
@@ -728,7 +727,7 @@ func (m *Syncer) startPeriodicUploader(ctx context.Context) {
 	}()
 
 	// Adaptive mode (ParallelUploads unset): launch the goodput controller that
-	// resizes the upload window to saturate the uplink (#1407). Pinned
+	// resizes the upload window to saturate the uplink. Pinned
 	// --parallel-uploads leaves uploadController nil and keeps the fixed window;
 	// publish it once so the gauge reflects it instead of reading 0.
 	if m.uploadController != nil {
@@ -742,7 +741,7 @@ func (m *Syncer) startPeriodicUploader(ctx context.Context) {
 	}
 }
 
-// runUploadController is the adaptive upload-concurrency control loop (#1407).
+// runUploadController is the adaptive upload-concurrency control loop.
 // Every interval it turns the bytes/error accumulated by carveAndCommitBlock
 // into a goodput sample, feeds the goodputController, and applies the returned
 // window to the shared uploadLimiter. Runs only in adaptive mode (controller

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -108,8 +108,8 @@ type Syncer struct {
 	completedSyncs atomic.Int64
 	failedSyncs    atomic.Int64
 
-	// uploadLimiter bounds concurrent block PUTs in carveFlush.
-	// When ParallelUploads is pinned (> 0) its limit is fixed at that value.
+	// uploadLimiter bounds concurrent block PUTs in carveFlush. When
+	// ParallelUploads is pinned (> 0) its limit is fixed at that value.
 	// When unset (adaptive mode) the uploadController resizes it every control
 	// interval to track the goodput knee. Lazily created by ensureUploadLimiter
 	// so directly-built test fixtures still get bounded concurrency.
@@ -188,8 +188,8 @@ func NewSyncer(local local.LocalStore, remoteStore remote.RemoteStore, fileChunk
 		config.ClaimTimeout = 10 * time.Minute
 	}
 
-	// Upload concurrency: a pinned ParallelUploads > 0 fixes the
-	// window; otherwise (the default) the carver auto-tunes between the adaptive
+	// Upload concurrency: a pinned ParallelUploads > 0 fixes the window;
+	// otherwise (the default) the carver auto-tunes between the adaptive
 	// floor and ceiling. The limiter starts at the floor in adaptive mode and at
 	// the pinned value otherwise; the control goroutine (adaptive only, launched
 	// in Start) resizes it at runtime.
@@ -378,9 +378,9 @@ func (m *Syncer) canProcess(ctx context.Context) bool {
 //   - Finalized=true, err=nil: durable on the configured remote.
 //   - Finalized=false, err=nil: SOFT condition (no remote configured,
 //     remote unhealthy, or the carve substrate is not wired). Callers
-//     MUST NOT tight-loop retry: surface the soft-fail to the
-//     protocol adapter and let the client drive the next attempt on its
-//     own schedule.
+//     MUST NOT tight-loop retry: surface the soft-fail to the protocol
+//     adapter and let the client drive the next attempt on its own
+//     schedule.
 //   - err != nil: hard failure, do not retry until addressed.
 //
 // The carve drain serializes on carveMu against the background carve

--- a/pkg/block/filechunk.go
+++ b/pkg/block/filechunk.go
@@ -30,7 +30,7 @@ type FileChunkStore interface {
 	// (nil, nil) when absent. The "any" wording matters: legacy data
 	// may have multiple rows per hash; callers (the engine dedup
 	// short-circuit) treat the result as best-effort and proceed with
-	// any one row's chunk. Renamed from FindFileChunkByHash.
+	// any one row's chunk.
 	GetByHash(ctx context.Context, hash ContentHash) (*FileChunk, error)
 
 	// Put creates or replaces a FileChunk by ID.
@@ -60,16 +60,11 @@ type FileChunkStore interface {
 	// re-PUTs the chunk, never data loss.
 	//
 	// The conformance test storetest.testPut_TwoIDsSameHash
-	// pins this contract across all three backends. Renamed from
-	// PutFileChunk.
+	// pins this contract across all three backends.
 	Put(ctx context.Context, block *FileChunk) error
 
 	// Delete removes a FileChunk by ID. Returns ErrFileChunkNotFound
-	// if not found. Renamed from DeleteFileChunk.
-	//
-	// Collision check (2026-04-26): no backend struct has a
-	// pre-existing method named exactly `Delete()`; the rename is
-	// collision-free.
+	// if not found.
 	Delete(ctx context.Context, id string) error
 
 	// IncrementRefCount atomically bumps RefCount for the given

--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -98,7 +98,7 @@ type BlockSink interface {
 // committed every row it produced, journal calls ReapSupersededManifest so the
 // sink can delete the manifest rows the run superseded — keeping the per-file
 // FileChunk manifest a gap-free, overlap-free tiling of [0,size) after a partial
-// overwrite (#953). runStart/runEnd bound the re-carved (dirty) range; newOffsets
+// overwrite. runStart/runEnd bound the re-carved (dirty) range; newOffsets
 // are the chunk offsets this run wrote (so the reap keeps them and deletes only
 // stale straddlers/interior rows). Sinks without a metadata store (test fakes)
 // simply don't implement it and the reap is skipped.
@@ -111,7 +111,7 @@ type supersededReaper interface {
 var errCarveNotWired = errors.New("journal: carve targets not wired (SetCarveTargets)")
 
 // SetCarveTargets injects the carve collaborators. Call once before the first
-// Carve; the production impls are wired here at PR7, tests pass fakes.
+// Carve; production wires the real impls, tests pass fakes.
 func (s *Store) SetCarveTargets(d Deduper, sink BlockSink) {
 	s.deduper = d
 	s.sink = sink
@@ -255,7 +255,7 @@ func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interv
 	fileOff := run[0].fileOff
 	flipIdx := 0
 	// Offsets of every chunk this run tiles (novel or deduped), so the run-end
-	// reap keeps this run's own rows and deletes only superseded ones (#953).
+	// reap keeps this run's own rows and deletes only superseded ones.
 	newOffsets := make(map[int64]struct{})
 
 	// disp overlaps successive blocks' CommitBlock (upload + commit) while packing
@@ -431,7 +431,7 @@ func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interv
 	if err := disp.wait(); err != nil {
 		return err
 	}
-	// #953: with every row this run produced now committed, reap the manifest rows
+	// With every row this run produced now committed, reap the manifest rows
 	// the run superseded (stale straddlers / interior chunks the fresh tiling
 	// replaced). One pass at run end is correct across a multi-batch run — no single
 	// batch span contains a seam-spanning straddler, and reaping the run span per

--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -97,8 +97,8 @@ type BlockSink interface {
 // supersededReaper is an optional BlockSink capability. After a carve run has
 // committed every row it produced, journal calls ReapSupersededManifest so the
 // sink can delete the manifest rows the run superseded — keeping the per-file
-// FileChunk manifest a gap-free, overlap-free tiling of [0,size) after a partial
-// overwrite. runStart/runEnd bound the re-carved (dirty) range; newOffsets
+// FileChunk manifest a gap-free, overlap-free tiling of [0,size) after a
+// partial overwrite. runStart/runEnd bound the re-carved (dirty) range; newOffsets
 // are the chunk offsets this run wrote (so the reap keeps them and deletes only
 // stale straddlers/interior rows). Sinks without a metadata store (test fakes)
 // simply don't implement it and the reap is skipped.

--- a/pkg/block/journal/index.go
+++ b/pkg/block/journal/index.go
@@ -130,7 +130,7 @@ func (fi *fileIndex) insert(iv interval) (dirtyRemoved, dirtyAdded int64, dead [
 	// three per-insert slice allocations (newFrags, survivors, merged) and the
 	// sort.Slice the general punch-and-merge path below pays. These dominate a
 	// random-4K workload: the fill phase is all gap insertions, the steady state
-	// all exact-offset overwrites (#1736).
+	// all exact-offset overwrites.
 	switch {
 	case lo == len(fi.ivs) || fi.ivs[lo].fileOff >= ne:
 		// (a) Gap insertion: [ns, ne) overlaps nothing (the search guarantees the
@@ -178,7 +178,7 @@ func (fi *fileIndex) insert(iv interval) (dirtyRemoved, dirtyAdded int64, dead [
 					dirtyRemoved += ov
 				}
 			}
-			// #953: a partial overwrite of a warm (synced, non-cold) interval
+			// A partial overwrite of a warm (synced, non-cold) interval
 			// leaves surviving fragments still pointing at the old chunk's bytes,
 			// whose FileChunk manifest row now straddles the overwrite. Re-mark
 			// them dirty so the next carve re-chunks them into fresh, non-straddling
@@ -208,7 +208,7 @@ func (fi *fileIndex) insert(iv interval) (dirtyRemoved, dirtyAdded int64, dead [
 
 // remarkFragmentsDirty flips warm (synced, non-cold) fragments of a
 // partially-superseded interval to dirty so the next carve re-chunks them into
-// fresh non-straddling manifest rows (#953-A). It returns the bytes newly made
+// fresh non-straddling manifest rows. It returns the bytes newly made
 // dirty so the caller keeps the unsynced counter accurate. Cold fragments are
 // skipped — they hold no local bytes to re-chunk (the remainder-hydration tail).
 func remarkFragmentsDirty(frags []interval) (added int64) {

--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -168,8 +168,7 @@ func (s *Store) claimColdestEvictable() (*segmentMeta, *shard) {
 				}
 				if s.pinned(seg) {
 					// Pinned by a live snapshot: its bytes are the only durable copy
-					// of an at-or-below-watermark record (local-only) — never evict
-					// (#1718).
+					// of an at-or-below-watermark record (local-only) — never evict.
 					continue
 				}
 				if la := seg.lastAccess.Load(); best == nil || la < bestAccess {
@@ -551,7 +550,7 @@ func (s *Store) gcShard(ctx context.Context, sh *shard, opts GCOptions) (reclaim
 // its lowest record Version is at or below pinVersion. Whole-segment granularity —
 // segments fill sequentially, so a non-empty segment's records span a contiguous
 // version range and minVersion alone decides. pinVersion 0 (no live snapshot) or a
-// still-empty segment (minVersion 0) pins nothing (#1718).
+// still-empty segment (minVersion 0) pins nothing.
 func (s *Store) pinned(seg *segmentMeta) bool {
 	pv := s.pinVersion.Load()
 	if pv == 0 {
@@ -606,7 +605,7 @@ func (s *Store) pickVictim(sh *shard, opts GCOptions, live map[uint64]int64) *se
 		if s.pinned(seg) {
 			// Pinned by a live snapshot: repack relocates bytes but a crash mid-move
 			// plus a rollback needs the pinned records intact at their original
-			// versions — keep the whole segment until the snapshot releases (#1718).
+			// versions — keep the whole segment until the snapshot releases.
 			continue
 		}
 		if seg.deadBytes.Load() <= 0 {

--- a/pkg/block/journal/recovery.go
+++ b/pkg/block/journal/recovery.go
@@ -201,7 +201,7 @@ func (s *Store) recover() error {
 				maxVersion = rec.header.Version
 			}
 			// Reconstruct the segment's pin watermark: minVersion is the lowest
-			// record Version it holds, so a live snapshot keeps it off GC (#1718).
+			// record Version it holds, so a live snapshot keeps it off GC.
 			m.noteMinVersion(rec.header.Version)
 			if rec.header.Flags&flagTombstone != 0 {
 				fid := FileID(rec.fileID)

--- a/pkg/block/journal/segment.go
+++ b/pkg/block/journal/segment.go
@@ -58,7 +58,7 @@ type segmentMeta struct {
 	// Segments fill sequentially, so a segment's records span a contiguous
 	// [minVersion, maxVersion]; minVersion<=pinVersion means the segment holds a
 	// record at or below a live snapshot's watermark and must not be evicted or
-	// GC-repacked while that snapshot lives (#1718). Set on the first append and
+	// GC-repacked while that snapshot lives. Set on the first append and
 	// reconstructed during the recovery scan and repack.
 	minVersion atomic.Uint64
 	// busy claims the segment for an exclusive whole-segment operation (evict or
@@ -371,7 +371,7 @@ func (s *Store) appendRecord(ctx context.Context, id FileID, offset int64, data 
 	s.writes.Add(1)
 	// unsynced tracks live dirty bytes: add this write if dirty, always drop the
 	// dirty bytes this write superseded (dead now, not evictable-pending), and add
-	// any warm fragments this write re-marked dirty for re-carve (#953-A). A synced
+	// any warm fragments this write re-marked dirty for re-carve. A synced
 	// (Hydrate) write adds nothing itself but can still supersede or re-dirty.
 	dirtyDelta := dirtyAdded - dirtyRemoved
 	if !synced {

--- a/pkg/block/journal/segment.go
+++ b/pkg/block/journal/segment.go
@@ -372,7 +372,8 @@ func (s *Store) appendRecord(ctx context.Context, id FileID, offset int64, data 
 	// unsynced tracks live dirty bytes: add this write if dirty, always drop the
 	// dirty bytes this write superseded (dead now, not evictable-pending), and add
 	// any warm fragments this write re-marked dirty for re-carve. A synced
-	// (Hydrate) write adds nothing itself but can still supersede or re-dirty.
+	// (Hydrate) write adds nothing itself but can still supersede or
+	// re-dirty.
 	dirtyDelta := dirtyAdded - dirtyRemoved
 	if !synced {
 		dirtyDelta += int64(len(data))

--- a/pkg/block/journal/shard.go
+++ b/pkg/block/journal/shard.go
@@ -58,7 +58,7 @@ type shard struct {
 	// every commit that enqueued before the leader started. Segment rotation is
 	// itself a durability point (sealInPlace fsyncs the sealed segment), so a
 	// commit whose bytes moved to a now-sealed segment is durable regardless of
-	// which fd the leader synced. See Store.Commit (#1736).
+	// which fd the leader synced. See Store.Commit.
 	commitMu   sync.Mutex
 	commitCond *sync.Cond
 	reqSeq     uint64 // commits enqueued so far (monotonic)
@@ -71,7 +71,7 @@ type shard struct {
 	// fsync can report success for pages the kernel already dropped, so a false
 	// "success" would be silent data loss; that is the direction we must never take.
 	// The cost is a rare, benign spurious error to a waiter a later success actually
-	// covered (safe direction). See groupCommit (#1736).
+	// covered (safe direction). See groupCommit.
 	errSeq  uint64
 	syncErr error
 	// segSync fsyncs a segment's backing file. Per-shard indirection so durability

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -72,7 +72,7 @@ type Config struct {
 	// default via withDefaults.
 	CarveUploadConcurrency int
 	// ChunkParams sets the per-share FastCDC sizing carve feeds the chunker
-	// (#1569). The zero value (or any params that fail Validate) degrades to
+	// The zero value (or any params that fail Validate) degrades to
 	// chunker.DefaultParams — the historical 1M/4M/16M profile — so a
 	// misconfiguration is never a hard error, matching the fs store.
 	ChunkParams chunker.Params
@@ -178,7 +178,7 @@ type Store struct {
 	// eviction/GC path so a local-only snapshot's bytes — the only durable copy —
 	// survive until the snapshot is deleted. DERIVED: the runtime recomputes it as
 	// max(JournalVersion) over live snapshots and calls SetPinVersion; the journal
-	// only reads it (reclaim.go). See #1718.
+	// only reads it (reclaim.go).
 	pinVersion atomic.Uint64
 	unsynced   atomic.Int64 // dirty bytes not yet carved to remote
 	diskBytes  atomic.Int64 // total on-disk segment bytes (headers + records), the eviction gate input
@@ -460,7 +460,7 @@ func (s *Store) Commit(ctx context.Context, id FileID) error {
 // caller whose bytes are on a since-sealed segment is durable no matter which fd
 // the leader synced. This is the per-shard sync-leader the fio rand-write-4k
 // burst (iodepth=32 × numjobs=4) needs; without it every one of ~128 in-flight
-// commits pays a full disk barrier (#1736).
+// commits pays a full disk barrier.
 func (sh *shard) groupCommit() error {
 	sh.commitMu.Lock()
 	myGen := sh.reqSeq
@@ -833,7 +833,7 @@ func (s *Store) nextVersion() uint64 { return s.version.Add(1) }
 // JournalVersion returns the current global LSN watermark: every record written
 // so far carries a Version at or below it. Snapshot create captures this after
 // draining rollups so the snapshot pins exactly the records that make up its
-// point-in-time view (#1718).
+// point-in-time view.
 func (s *Store) JournalVersion() uint64 { return s.version.Load() }
 
 // SetPinVersion sets the highest live-snapshot watermark. The runtime derives it
@@ -851,7 +851,7 @@ func (s *Store) PinVersion() uint64 { return s.pinVersion.Load() }
 // still pins for rollback) stay intact. It is the local-only snapshot-restore
 // primitive: the journal is the only durable copy of the bytes, so a plain rewind
 // is not restart-safe (recover() would resurrect the >V head) and the >V records
-// cannot be deleted. See #1718.
+// cannot be deleted.
 //
 // Two phases:
 //

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -71,7 +71,7 @@ type Config struct {
 	// window (window x CarveBlockSize), so keep it modest. Zero falls back to the
 	// default via withDefaults.
 	CarveUploadConcurrency int
-	// ChunkParams sets the per-share FastCDC sizing carve feeds the chunker
+	// ChunkParams sets the per-share FastCDC sizing carve feeds the chunker.
 	// The zero value (or any params that fail Validate) degrades to
 	// chunker.DefaultParams — the historical 1M/4M/16M profile — so a
 	// misconfiguration is never a hard error, matching the fs store.

--- a/pkg/block/types.go
+++ b/pkg/block/types.go
@@ -92,8 +92,8 @@ func (s BlockState) String() string {
 // MarshalJSON encodes a ContentHash as the canonical CAS scheme string
 // "blake3:{hex}" (mirrors CASKey()). Round-trips with UnmarshalJSON.
 //
-// Added in to drive ChunkRef JSON serialization.
-// Without this, encoding/json would default to base64 for the [32]byte
+// It exists to drive ChunkRef JSON serialization: without it,
+// encoding/json would use its default encoding for the [32]byte
 // array — readable diffs in Postgres/Badger payloads would be impossible.
 func (h ContentHash) MarshalJSON() ([]byte, error) {
 	out := make([]byte, 0, 1+len("blake3:")+HashSize*2+1)
@@ -104,10 +104,10 @@ func (h ContentHash) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON accepts the canonical "blake3:{hex}" form, the bare
-// "{hex}" form, and the pre-Phase-12 default base64 form (encoding/json's
-// default for [32]byte arrays without a custom MarshalJSON). The base64
-// fallback preserves backward compatibility for FileChunk rows persisted
-// by Badger before this MarshalJSON existed.
+// "{hex}" form, and two legacy encodings written before this type had a
+// custom MarshalJSON: a JSON number array and a base64 string. Those
+// fallbacks keep FileChunk rows persisted by earlier Badger builds
+// readable.
 func (h *ContentHash) UnmarshalJSON(data []byte) error {
 	// v0.14.x and earlier had no custom MarshalJSON — encoding/json
 	// serialized [32]byte as a JSON number array: [0,0,...,0]. Accept
@@ -146,15 +146,13 @@ func (h *ContentHash) UnmarshalJSON(data []byte) error {
 // ChunkRef is a single content-addressed reference to a chunk of a
 // file's payload. The list FileAttr.Blocks []ChunkRef is sorted by
 // Offset and covers the file end-to-end (gaps within Size are sparse
-// holes, zero-filled on read per).
+// holes, zero-filled on read).
 //
 // Hash is the BLAKE3 content hash identifying the chunk.
 // Offset is the byte offset within the file (uint64 to support files
 // >4 GiB; VM workload requirement).
 // Size is the chunk length in bytes (FastCDC min 1 MiB, max 16 MiB
 // uint32 chosen to match FileChunk.DataSize column type).
-//
-// See, decisions.
 type ChunkRef struct {
 	Hash   ContentHash `json:"hash"`
 	Offset uint64      `json:"offset"`

--- a/pkg/block/types.go
+++ b/pkg/block/types.go
@@ -93,7 +93,7 @@ func (s BlockState) String() string {
 // "blake3:{hex}" (mirrors CASKey()). Round-trips with UnmarshalJSON.
 //
 // It exists to drive ChunkRef JSON serialization: without it,
-// encoding/json would use its default encoding for the [32]byte
+// encoding/json would serialize the [32]byte array as a JSON number
 // array — readable diffs in Postgres/Badger payloads would be impossible.
 func (h ContentHash) MarshalJSON() ([]byte, error) {
 	out := make([]byte, 0, 1+len("blake3:")+HashSize*2+1)

--- a/pkg/controlplane/runtime/netgroups.go
+++ b/pkg/controlplane/runtime/netgroups.go
@@ -82,7 +82,6 @@ func (c *dnsCache) lookupAddr(ip string) ([]string, error) {
 	// Cache miss or expired - perform lookup
 	hostnames, err := net.LookupAddr(ip)
 
-	// Store result
 	var ttl time.Duration
 	if err != nil {
 		ttl = c.negTTL
@@ -123,7 +122,6 @@ func (c *dnsCache) lookupHost(hostname string) ([]string, error) {
 	// Cache miss or expired - perform lookup
 	addrs, err := net.LookupHost(hostname)
 
-	// Store result
 	var ttl time.Duration
 	if err != nil {
 		ttl = c.negTTL
@@ -281,7 +279,6 @@ func (r *Runtime) evaluateNetgroupAccess(ctx context.Context, shareName, netgrou
 
 	ensureDNSCache()
 
-	// Match client IP against each member
 	ipString := clientIP.String()
 	for _, member := range members {
 		switch member.Type {
@@ -304,7 +301,6 @@ func (r *Runtime) evaluateNetgroupAccess(ctx context.Context, shareName, netgrou
 		}
 	}
 
-	// No member matches
 	return false, nil
 }
 

--- a/pkg/controlplane/runtime/netgroups.go
+++ b/pkg/controlplane/runtime/netgroups.go
@@ -164,9 +164,9 @@ func (c *dnsCache) cleanExpiredLocked(now time.Time) {
 //  5. Match client IP against each member (IP, CIDR, or hostname)
 //  6. Return false if no member matches
 //
-// Per Pitfall 3 (DNS blocking): hostname matching uses cached reverse DNS with
-// 5-minute positive TTL and 1-minute negative TTL. Falls back to IP matching
-// if DNS lookup fails (does not block).
+// Hostname matching uses cached reverse DNS with a 5-minute positive TTL and
+// a 1-minute negative TTL, and falls back to IP matching if the lookup fails,
+// so a slow resolver never blocks the access decision.
 func (r *Runtime) CheckNetgroupAccess(ctx context.Context, shareName string, clientIP net.IP) (bool, error) {
 	// 1. Get the share's netgroup association from runtime state.
 	//
@@ -189,7 +189,6 @@ func (r *Runtime) CheckNetgroupAccess(ctx context.Context, shareName string, cli
 		return false, err
 	}
 
-	// 2. If share has no netgroup -> allow all
 	if netgroupName == "" {
 		return true, nil
 	}
@@ -280,7 +279,6 @@ func (r *Runtime) evaluateNetgroupAccess(ctx context.Context, shareName, netgrou
 		return false, nil
 	}
 
-	// Initialize DNS cache lazily
 	ensureDNSCache()
 
 	// Match client IP against each member

--- a/pkg/controlplane/runtime/settings_watcher.go
+++ b/pkg/controlplane/runtime/settings_watcher.go
@@ -194,7 +194,6 @@ func (w *SettingsWatcher) poll(ctx context.Context) {
 // pollNFSSettings checks the DB for NFS adapter settings changes.
 // If the version has changed, swaps the cached settings atomically.
 func (w *SettingsWatcher) pollNFSSettings(ctx context.Context) error {
-	// Get NFS adapter from store
 	adapter, err := w.store.GetAdapter(ctx, "nfs")
 	if err != nil {
 		if errors.Is(err, models.ErrAdapterNotFound) {
@@ -265,7 +264,6 @@ func (w *SettingsWatcher) RefreshNFSSettings(ctx context.Context) error {
 // pollSMBSettings checks the DB for SMB adapter settings changes.
 // If the version has changed, swaps the cached settings atomically.
 func (w *SettingsWatcher) pollSMBSettings(ctx context.Context) error {
-	// Get SMB adapter from store
 	adapter, err := w.store.GetAdapter(ctx, "smb")
 	if err != nil {
 		if errors.Is(err, models.ErrAdapterNotFound) {

--- a/pkg/controlplane/runtime/stores/service.go
+++ b/pkg/controlplane/runtime/stores/service.go
@@ -185,7 +185,7 @@ func (s *Service) OpenMetadataStoreAtPath(
 		}
 		// Temp/snapshot/probe stores inherit the process-wide cache default
 		// (SetGlobalBadgerCacheDefaults) and RAM-relative auto-sizing via
-		// buildBadgerOptions, so they are not subject to the #1245 Bug D
+		// buildBadgerOptions, so they are not subject to under-sized-cache
 		// thrashing. Per-store cache overrides (block_cache_mb/index_cache_mb)
 		// are intentionally NOT threaded here — these are short-lived stores
 		// where a bespoke cache size has no practical value.
@@ -232,8 +232,8 @@ func (s *Service) OpenMetadataStoreAtPath(
 // PostgresRestoreOrphan represents one leftover restore-temp schema
 // discovered by ListPostgresRestoreOrphans. Name is the schema name as it
 // appears in information_schema.schemata; CreatedAt is derived from the
-// ULID suffix embedded in the schema name (Phase-5 temp schemas use the
-// form `<origSchema>_restore_<ulid>`).
+// ULID suffix embedded in the schema name (temp schemas use the form
+// `<origSchema>_restore_<ulid>`).
 type PostgresRestoreOrphan struct {
 	Name      string
 	CreatedAt time.Time

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -42,12 +42,10 @@ func (s *Service) CheckShareAccess(ctx context.Context, shareName, clientAddr, a
 		return nil, nil, err
 	}
 
-	// Check context cancellation
 	if err := ctx.Err(); err != nil {
 		return nil, nil, err
 	}
 
-	// Get share options using CRUD operation
 	opts, err := store.GetShareOptions(ctx, shareName)
 	if err != nil {
 		return nil, nil, err
@@ -232,12 +230,10 @@ func (s *Service) checkFilePermissions(ctx *AuthContext, handle FileHandle, requ
 		return 0, err
 	}
 
-	// Check context
 	if err := ctx.Context.Err(); err != nil {
 		return 0, err
 	}
 
-	// Get file data using CRUD method
 	file, err := store.GetFile(ctx.Context, handle)
 	if err != nil {
 		return 0, err
@@ -258,7 +254,6 @@ func (s *Service) checkFilePermissionsFile(ctx *AuthContext, handle FileHandle, 
 		return 0, err
 	}
 
-	// Check context
 	if err := ctx.Context.Err(); err != nil {
 		return 0, err
 	}

--- a/pkg/metadata/store/badger/encoding.go
+++ b/pkg/metadata/store/badger/encoding.go
@@ -38,11 +38,14 @@ import (
 // File Manifest         "fm:"    fm:<uuid>                              []block.ChunkRef (JSON)
 // Parent Relationships  "p:"     p:<childUUID>                          parentUUID (bytes)
 // Children Map          "c:"     c:<parentUUID>:<childName>             childUUID (bytes)
+// Child Name (reverse)  "cn:"    cn:<parentUUID>:<childUUID>            child name (bytes)
 // Shares                "s:"     s:<shareName>                          shareData (JSON)
 // Link Counts           "l:"     l:<uuid>                               uint32 (binary)
 // Server Config         "cfg:"   cfg:server                             MetadataServerConfig (JSON)
 // Filesystem Caps       "cap:"   cap:fs                                 FilesystemCapabilities (JSON)
 // Format Version        "fmt:"   fmt:store                              uint32 (big-endian binary)
+// ObjectID Index        "obj:"   obj:<contentHash>                      file UUID (bytes)
+// PayloadID Index       "pl:"    pl:<payloadID>                         file UUID (bytes)
 
 const (
 	prefixFile         = "f:"

--- a/pkg/metadata/store/badger/locks.go
+++ b/pkg/metadata/store/badger/locks.go
@@ -92,34 +92,29 @@ func (s *badgerLockStore) PutLock(ctx context.Context, lk *lock.PersistedLock) e
 
 // putLockTx persists a lock within an existing transaction.
 func (s *badgerLockStore) putLockTx(txn *badgerdb.Txn, lk *lock.PersistedLock) error {
-	// Serialize lock to JSON
 	data, err := json.Marshal(lk)
 	if err != nil {
 		return fmt.Errorf("failed to marshal lock: %w", err)
 	}
 
-	// Store primary key
 	primaryKey := []byte(prefixLock + lk.ID)
 	if err := txn.Set(primaryKey, data); err != nil {
 		return err
 	}
 
-	// Store secondary indexes (value is just the lock ID for reference)
+	// Secondary-index values are just the lock ID.
 	lockIDBytes := []byte(lk.ID)
 
-	// Index by file
 	fileKey := []byte(lockIndexPrefix(prefixLockByFile, lk.FileID) + lk.ID)
 	if err := txn.Set(fileKey, lockIDBytes); err != nil {
 		return err
 	}
 
-	// Index by owner
 	ownerKey := []byte(lockIndexPrefix(prefixLockByOwner, lk.OwnerID) + lk.ID)
 	if err := txn.Set(ownerKey, lockIDBytes); err != nil {
 		return err
 	}
 
-	// Index by client
 	clientKey := []byte(lockIndexPrefix(prefixLockByClient, lk.ClientID) + lk.ID)
 	if err := txn.Set(clientKey, lockIDBytes); err != nil {
 		return err
@@ -182,19 +177,17 @@ func (s *badgerLockStore) DeleteLock(ctx context.Context, lockID string) error {
 
 // deleteLockTx removes a lock within an existing transaction.
 func (s *badgerLockStore) deleteLockTx(txn *badgerdb.Txn, lockID string) error {
-	// First, get the lock to know which indexes to delete
+	// Read the lock first: its FileID/OwnerID/ClientID name the index keys.
 	lk, err := s.getLockTx(txn, lockID)
 	if err != nil {
 		return err
 	}
 
-	// Delete primary key
 	primaryKey := []byte(prefixLock + lockID)
 	if err := txn.Delete(primaryKey); err != nil {
 		return err
 	}
 
-	// Delete secondary indexes
 	fileKey := []byte(lockIndexPrefix(prefixLockByFile, lk.FileID) + lockID)
 	if err := txn.Delete(fileKey); err != nil && err != badgerdb.ErrKeyNotFound {
 		return err

--- a/pkg/metadata/store/badger/objects.go
+++ b/pkg/metadata/store/badger/objects.go
@@ -90,8 +90,7 @@ func (s *BadgerMetadataStore) GetFileChunk(ctx context.Context, id string) (*met
 	return &block, nil
 }
 
-// Put stores or updates a file chunk. Renamed from PutFileChunk to
-// match the narrowed interface.
+// Put stores or updates a file chunk.
 func (s *BadgerMetadataStore) Put(ctx context.Context, block *metadata.FileChunk) error {
 	return s.db.Update(func(txn *badger.Txn) error {
 		key := []byte(fileChunkPrefix + block.ID)
@@ -121,7 +120,7 @@ func (s *BadgerMetadataStore) Put(ctx context.Context, block *metadata.FileChunk
 	})
 }
 
-// Delete removes a file chunk by its ID. Renamed from DeleteFileChunk in
+// Delete removes a file chunk by its ID.
 func (s *BadgerMetadataStore) Delete(ctx context.Context, id string) error {
 	return s.db.Update(func(txn *badger.Txn) error {
 		key := []byte(fileChunkPrefix + id)
@@ -352,7 +351,7 @@ func (s *BadgerMetadataStore) AddRef(ctx context.Context, hash blockpkg.ContentH
 }
 
 // GetByHash looks up a finalized block by its content hash.
-// Returns nil without error if not found. Renamed from FindFileChunkByHash
+// Returns nil without error if not found.
 func (s *BadgerMetadataStore) GetByHash(ctx context.Context, hash metadata.ContentHash) (*metadata.FileChunk, error) {
 	var block metadata.FileChunk
 	var found bool
@@ -711,9 +710,7 @@ func (s *BadgerMetadataStore) EnumeratePayloads(ctx context.Context, fn func(pay
 
 // EnumerateFileChunks streams every FileChunk's ContentHash through fn using
 // a Badger prefix iterator over fb:. The iterator yields one row per block
-// (no allocation of a full slice in application memory)..
-// lifted from FileChunkStore to MetadataStore
-// implementation unchanged.
+// (no allocation of a full slice in application memory).
 func (s *BadgerMetadataStore) EnumerateFileChunks(ctx context.Context, fn func(blockpkg.ContentHash) error) error {
 	return s.db.View(func(txn *badger.Txn) error {
 		return enumerateFileChunksTxn(ctx, txn, fn)
@@ -933,13 +930,11 @@ func parseBlockIdx(id string) int {
 // Ensure badgerTransaction implements FileChunkStore
 var _ blockpkg.FileChunkStore = (*badgerTransaction)(nil)
 
-// (review iteration 1): FileChunkStore methods on
-// badgerTransaction MUST run against the txn's *badger.Txn so a
-// rollback (returning an error from WithTransaction's fn) discards the
-// RefCount mutation. Previously every method called `tx.store.X(...)`
-// which opened its own db.Update — defeating rollback for any caller
-// that bumped RefCount inside WithTransaction then encountered a
-// downstream PutFile failure (silent leak).
+// FileChunkStore methods on badgerTransaction MUST run against the txn's
+// *badger.Txn so a rollback (returning an error from WithTransaction's fn)
+// discards the RefCount mutation. Calling tx.store.X(...) instead would open
+// its own db.Update and defeat rollback for any caller that bumps RefCount
+// inside WithTransaction and then hits a downstream PutFile failure.
 
 func (tx *badgerTransaction) GetFileChunk(ctx context.Context, id string) (*metadata.FileChunk, error) {
 	if err := ctx.Err(); err != nil {

--- a/pkg/metadata/store/badger/shares.go
+++ b/pkg/metadata/store/badger/shares.go
@@ -601,10 +601,9 @@ func (s *BadgerMetadataStore) createNewRoot(txn *badgerdb.Txn, shareName string,
 	}
 
 	// Preserve existing share configuration (e.g. ShareOptions written
-	// by a prior CreateShare call) when materializing the root row.
-	// The original code wrote a fresh `metadata.Share{Name: shareName}`
-	// here, silently wiping any Options the caller had set via
-	// CreateShare.
+	// by a prior CreateShare call) when materializing the root row:
+	// writing a fresh metadata.Share{Name: shareName} here would wipe
+	// any Options the caller already set.
 	preservedShare := metadata.Share{Name: shareName}
 	if existingItem, getErr := txn.Get(keyShare(shareName)); getErr == nil {
 		if vErr := existingItem.Value(func(val []byte) error {

--- a/pkg/metadata/store/badger/testhooks.go
+++ b/pkg/metadata/store/badger/testhooks.go
@@ -1,11 +1,5 @@
 package badger
 
-// SetMaxTransactionRetriesForTest overrides the SSI conflict retry budget and
-// returns a function that restores the previous value. It exists solely so
-// cross-package tests (e.g. the block/engine rollup-convergence suite) can
-// shrink the budget to deterministically drive WithTransaction into its
-// retry-exhausted conflict path without spinning thousands of contending
-// goroutines. Production code never calls it.
 // InlineSyncCountForTest returns the number of explicit db.Sync() calls made on
 // the durable write path (WithTransaction in relaxed mode).
 // It excludes the background bounded-lag syncer, so a test can assert that a
@@ -24,6 +18,12 @@ func (s *BadgerMetadataStore) TransactionConflictsForTest() int64 {
 	return s.txnConflicts.Load()
 }
 
+// SetMaxTransactionRetriesForTest overrides the SSI conflict retry budget and
+// returns a function that restores the previous value. It exists solely so
+// cross-package tests (e.g. the block/engine rollup-convergence suite) can
+// shrink the budget to deterministically drive WithTransaction into its
+// retry-exhausted conflict path without spinning thousands of contending
+// goroutines. Production code never calls it.
 func SetMaxTransactionRetriesForTest(n int) func() {
 	prev := maxTransactionRetries.Load()
 	// Clamp to at least 1: a value <= 0 would make WithTransaction run zero

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -229,7 +229,6 @@ func (tx *badgerTransaction) getFile(ctx context.Context, handle metadata.FileHa
 		return nil, err
 	}
 
-	// Decode handle to get UUID
 	_, fileID, err := metadata.DecodeFileHandle(handle)
 	if err != nil {
 		return nil, &metadata.StoreError{
@@ -495,7 +494,6 @@ func (tx *badgerTransaction) DeleteFile(ctx context.Context, handle metadata.Fil
 		return err
 	}
 
-	// Decode handle to get UUID
 	_, fileID, err := metadata.DecodeFileHandle(handle)
 	if err != nil {
 		return &metadata.StoreError{
@@ -804,7 +802,6 @@ func (tx *badgerTransaction) GetParent(ctx context.Context, handle metadata.File
 		return nil, err
 	}
 
-	// Decode handle to get UUID and share name
 	shareName, fileID, err := metadata.DecodeFileHandle(handle)
 	if err != nil {
 		return nil, &metadata.StoreError{
@@ -862,7 +859,6 @@ func (tx *badgerTransaction) GetLinkCount(ctx context.Context, handle metadata.F
 		return 0, err
 	}
 
-	// Decode handle to get UUID
 	_, fileID, err := metadata.DecodeFileHandle(handle)
 	if err != nil {
 		return 0, &metadata.StoreError{
@@ -916,7 +912,6 @@ func (tx *badgerTransaction) SetLinkCount(ctx context.Context, handle metadata.F
 		return err
 	}
 
-	// Decode handle to get UUID
 	_, fileID, err := metadata.DecodeFileHandle(handle)
 	if err != nil {
 		return &metadata.StoreError{

--- a/pkg/metadata/store/memory/objects.go
+++ b/pkg/metadata/store/memory/objects.go
@@ -62,15 +62,14 @@ func (s *MemoryMetadataStore) GetFileChunk(ctx context.Context, id string) (*met
 	return s.getFileChunkLocked(ctx, id)
 }
 
-// Put stores or updates a file chunk. Renamed from PutFileChunk to
-// match the narrowed interface.
+// Put stores or updates a file chunk.
 func (s *MemoryMetadataStore) Put(ctx context.Context, block *metadata.FileChunk) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.putFileChunkLocked(ctx, block)
 }
 
-// Delete removes a file chunk by its ID. Renamed from DeleteFileChunk.
+// Delete removes a file chunk by its ID.
 func (s *MemoryMetadataStore) Delete(ctx context.Context, id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -124,7 +123,7 @@ func (s *MemoryMetadataStore) AddRef(ctx context.Context, hash block.ContentHash
 }
 
 // GetByHash looks up a finalized block by its content hash.
-// Returns nil without error if not found. Renamed from FindFileChunkByHash
+// Returns nil without error if not found.
 func (s *MemoryMetadataStore) GetByHash(ctx context.Context, hash metadata.ContentHash) (*metadata.FileChunk, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/pkg/metadata/store/postgres/config.go
+++ b/pkg/metadata/store/postgres/config.go
@@ -50,8 +50,8 @@ type PostgresMetadataStoreConfig struct {
 func (c *PostgresMetadataStoreConfig) ApplyDefaults() {
 	// Connection pool defaults (conservative sizing).
 	//
-	// #1176 assessment: under the metadata read workload the pool is not the
-	// bottleneck — at 8 concurrent workers MaxConns=10 lets the pool warm to
+	// Under the metadata read workload the pool is not the bottleneck: at
+	// 8 concurrent workers MaxConns=10 lets the pool warm to
 	// ~8 live connections and scales throughput ~3.8x over a single worker,
 	// with cold-acquire cost confined to the first burst (idle connections are
 	// retained for MaxConnIdleTime, default 30m). The per-op win came from

--- a/pkg/metadata/store/postgres/connection.go
+++ b/pkg/metadata/store/postgres/connection.go
@@ -11,21 +11,17 @@ import (
 
 // createConnectionPool creates a new PostgreSQL connection pool with the given configuration
 func createConnectionPool(ctx context.Context, cfg *PostgresMetadataStoreConfig, logger *slog.Logger) (*pgxpool.Pool, error) {
-	// Apply defaults before validation
 	cfg.ApplyDefaults()
 
-	// Validate configuration
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid configuration: %w", err)
 	}
 
-	// Build pgxpool config
 	poolConfig, err := pgxpool.ParseConfig(cfg.ConnectionString())
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse connection string: %w", err)
 	}
 
-	// Apply connection pool settings
 	poolConfig.MaxConns = cfg.MaxConns
 	poolConfig.MinConns = cfg.MinConns
 	poolConfig.MaxConnLifetime = cfg.MaxConnLifetime
@@ -49,11 +45,6 @@ func createConnectionPool(ctx context.Context, cfg *PostgresMetadataStoreConfig,
 		poolConfig.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeExec
 	}
 
-	// Configure logging (optional, can be adjusted)
-	// pgxpool uses its own logging, but we can configure it to use our logger
-	// For now, we'll keep it simple and let pgx use default logging
-
-	// Create the connection pool
 	logger.Info("Creating PostgreSQL connection pool",
 		"host", cfg.Host,
 		"port", cfg.Port,

--- a/pkg/metadata/store/postgres/files.go
+++ b/pkg/metadata/store/postgres/files.go
@@ -288,8 +288,7 @@ func (s *PostgresMetadataStore) ListChildren(ctx context.Context, dirHandle meta
 		// hydrate ObjectID for directory entries.
 		// NULL/empty -> zero (sentinel).
 		//
-		// (review iteration 1): the shape DOES NOT match
-		// GetFile in this backend. GetFile populates FileAttr.Blocks via
+		// The shape DOES NOT match GetFile in this backend. GetFile populates FileAttr.Blocks via
 		// loadFileChunkRefs; ListChildren intentionally does NOT (per-row
 		// ChunkRef hydration would be a quadratic cost on directory
 		// listings). Memory and Badger backends include Blocks on

--- a/pkg/metadata/store/postgres/files.go
+++ b/pkg/metadata/store/postgres/files.go
@@ -288,8 +288,8 @@ func (s *PostgresMetadataStore) ListChildren(ctx context.Context, dirHandle meta
 		// hydrate ObjectID for directory entries.
 		// NULL/empty -> zero (sentinel).
 		//
-		// The shape DOES NOT match GetFile in this backend. GetFile populates FileAttr.Blocks via
-		// loadFileChunkRefs; ListChildren intentionally does NOT (per-row
+		// The shape DOES NOT match GetFile in this backend. GetFile populates
+		// FileAttr.Blocks via loadFileChunkRefs; ListChildren intentionally does NOT (per-row
 		// ChunkRef hydration would be a quadratic cost on directory
 		// listings). Memory and Badger backends include Blocks on
 		// DirEntry.Attr because their underlying serialisation already

--- a/pkg/metadata/store/postgres/objects.go
+++ b/pkg/metadata/store/postgres/objects.go
@@ -248,9 +248,8 @@ func (s *PostgresMetadataStore) AddRef(ctx context.Context, hash block.ContentHa
 
 // GetByHash looks up a finalized block by its content hash.
 // Returns nil without error if not found. Dedup matches only Remote
-// (state=2) blocks —
-// Pending or Syncing rows have not been confirmed on the remote and
-// are unsafe dedup targets.
+// (state=2) blocks — Pending or Syncing rows have not been confirmed on
+// the remote and are unsafe dedup targets.
 func (s *PostgresMetadataStore) GetByHash(ctx context.Context, hash metadata.ContentHash) (*metadata.FileChunk, error) {
 	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
 		FROM file_blocks WHERE hash = $1 AND state = 2 /* Remote */`

--- a/pkg/metadata/store/postgres/objects.go
+++ b/pkg/metadata/store/postgres/objects.go
@@ -112,7 +112,7 @@ func (s *PostgresMetadataStore) Put(ctx context.Context, block *metadata.FileChu
 	return nil
 }
 
-// Delete removes a file chunk by its ID. Renamed from DeleteFileChunk in
+// Delete removes a file chunk by its ID.
 func (s *PostgresMetadataStore) Delete(ctx context.Context, id string) error {
 	result, err := s.exec(ctx, `DELETE FROM file_blocks WHERE id = $1`, id)
 	if err != nil {
@@ -247,8 +247,8 @@ func (s *PostgresMetadataStore) AddRef(ctx context.Context, hash block.ContentHa
 }
 
 // GetByHash looks up a finalized block by its content hash.
-// Returns nil without error if not found. Renamed from
-// FindFileChunkByHash. Dedup matches only Remote (state=2) blocks —
+// Returns nil without error if not found. Dedup matches only Remote
+// (state=2) blocks —
 // Pending or Syncing rows have not been confirmed on the remote and
 // are unsafe dedup targets.
 func (s *PostgresMetadataStore) GetByHash(ctx context.Context, hash metadata.ContentHash) (*metadata.FileChunk, error) {

--- a/pkg/metadata/store/sqlite/files.go
+++ b/pkg/metadata/store/sqlite/files.go
@@ -287,8 +287,8 @@ func (s *SQLiteMetadataStore) ListChildren(ctx context.Context, dirHandle metada
 		// hydrate ObjectID for directory entries.
 		// NULL/empty -> zero (sentinel).
 		//
-		// The shape DOES NOT match GetFile in this backend. GetFile populates FileAttr.Blocks via
-		// loadFileChunkRefs; ListChildren intentionally does NOT (per-row
+		// The shape DOES NOT match GetFile in this backend. GetFile populates
+		// FileAttr.Blocks via loadFileChunkRefs; ListChildren intentionally does NOT (per-row
 		// ChunkRef hydration would be a quadratic cost on directory
 		// listings). Memory and Badger backends include Blocks on
 		// DirEntry.Attr because their underlying serialisation already

--- a/pkg/metadata/store/sqlite/files.go
+++ b/pkg/metadata/store/sqlite/files.go
@@ -287,8 +287,7 @@ func (s *SQLiteMetadataStore) ListChildren(ctx context.Context, dirHandle metada
 		// hydrate ObjectID for directory entries.
 		// NULL/empty -> zero (sentinel).
 		//
-		// (review iteration 1): the shape DOES NOT match
-		// GetFile in this backend. GetFile populates FileAttr.Blocks via
+		// The shape DOES NOT match GetFile in this backend. GetFile populates FileAttr.Blocks via
 		// loadFileChunkRefs; ListChildren intentionally does NOT (per-row
 		// ChunkRef hydration would be a quadratic cost on directory
 		// listings). Memory and Badger backends include Blocks on

--- a/pkg/metadata/store/sqlite/migrations/000005_file_timestamps_filetime.up.sql
+++ b/pkg/metadata/store/sqlite/migrations/000005_file_timestamps_filetime.up.sql
@@ -1,6 +1,7 @@
 -- Convert the files timestamp columns from unix-nanoseconds to Windows FILETIME
--- (100ns ticks since 1601), matching the encoding.go switch (timeToNanos /
--- nanosToTime). Zero stays zero (the unset/zero-time sentinel); a nonzero
+-- (100ns ticks since 1601), matching the codec in
+-- pkg/metadata/store/internal/sqlcodec (TimeToFiletime / FiletimeToTime).
+-- Zero stays zero (the unset/zero-time sentinel); a nonzero
 -- unix-nanosecond value n becomes n/100 + 116444736000000000. On a fresh
 -- database these tables are empty so this is a no-op; on an existing database it
 -- rewrites the persisted values so they decode correctly under the new codec.

--- a/pkg/metadata/store/sqlite/objects.go
+++ b/pkg/metadata/store/sqlite/objects.go
@@ -290,8 +290,8 @@ func (s *SQLiteMetadataStore) AddRef(ctx context.Context, hash block.ContentHash
 }
 
 // GetByHash looks up a finalized block by its content hash.
-// Returns nil without error if not found. Renamed from
-// FindFileChunkByHash. Dedup matches only Remote (state=2) blocks —
+// Returns nil without error if not found. Dedup matches only Remote
+// (state=2) blocks —
 // Pending or Syncing rows have not been confirmed on the remote and
 // are unsafe dedup targets.
 func (s *SQLiteMetadataStore) GetByHash(ctx context.Context, hash metadata.ContentHash) (*metadata.FileChunk, error) {

--- a/pkg/metadata/store/sqlite/objects.go
+++ b/pkg/metadata/store/sqlite/objects.go
@@ -291,9 +291,8 @@ func (s *SQLiteMetadataStore) AddRef(ctx context.Context, hash block.ContentHash
 
 // GetByHash looks up a finalized block by its content hash.
 // Returns nil without error if not found. Dedup matches only Remote
-// (state=2) blocks —
-// Pending or Syncing rows have not been confirmed on the remote and
-// are unsafe dedup targets.
+// (state=2) blocks — Pending or Syncing rows have not been confirmed on
+// the remote and are unsafe dedup targets.
 func (s *SQLiteMetadataStore) GetByHash(ctx context.Context, hash metadata.ContentHash) (*metadata.FileChunk, error) {
 	return getByHashTx(ctx, s.conn(), hash)
 }

--- a/pkg/metadata/tx_context.go
+++ b/pkg/metadata/tx_context.go
@@ -13,8 +13,8 @@ type txContextKey struct{}
 //
 // It is wired by common.CopyPayload (and any other caller that needs to
 // bind engine-level RefCount mutations to its WithTransaction-owned tx).
-// The per-share
-// metadataCoordinator (pkg/controlplane/runtime/shares/coordinator.go)
+// The per-share metadataCoordinator
+// (pkg/controlplane/runtime/shares/coordinator.go)
 // reads this on every IncrementRefCount / DecrementRefCount call so the
 // underlying SQL/Badger UPDATE shares the caller's txn — without it
 // every increment commits on a fresh pool connection and survives the

--- a/pkg/metadata/tx_context.go
+++ b/pkg/metadata/tx_context.go
@@ -11,9 +11,9 @@ type txContextKey struct{}
 // transaction is retrievable via TxFromContext from anywhere in the
 // call chain.
 //
-// (review iteration 1): wired by common.CopyPayload
-// (and any future caller that needs to bind engine-level RefCount
-// mutations to its WithTransaction-owned tx). The per-share
+// It is wired by common.CopyPayload (and any other caller that needs to
+// bind engine-level RefCount mutations to its WithTransaction-owned tx).
+// The per-share
 // metadataCoordinator (pkg/controlplane/runtime/shares/coordinator.go)
 // reads this on every IncrementRefCount / DecrementRefCount call so the
 // underlying SQL/Badger UPDATE shares the caller's txn — without it

--- a/pkg/metadata/validation.go
+++ b/pkg/metadata/validation.go
@@ -382,13 +382,11 @@ func ApplyCreateDefaults(attr *FileAttr, ctx *AuthContext, linkTarget string) {
 //   - nil if the operation is allowed
 //   - ErrAccessDenied if the sticky bit restriction blocks the operation
 func CheckStickyBitRestriction(ctx *AuthContext, dirAttr *FileAttr, fileAttr *FileAttr) error {
-	// Get the effective UID of the caller
 	callerUID := ^uint32(0) // Default to max (invalid)
 	if ctx.Identity != nil && ctx.Identity.UID != nil {
 		callerUID = *ctx.Identity.UID
 	}
 
-	// Debug: Log sticky bit check details
 	logger.Debug("CheckStickyBitRestriction",
 		"dir_mode", fmt.Sprintf("%04o", dirAttr.Mode),
 		"dir_uid", dirAttr.UID,
@@ -396,7 +394,6 @@ func CheckStickyBitRestriction(ctx *AuthContext, dirAttr *FileAttr, fileAttr *Fi
 		"caller_uid", callerUID,
 		"has_sticky", dirAttr.Mode&ModeSticky != 0)
 
-	// Check if the directory has the sticky bit set
 	if dirAttr.Mode&ModeSticky == 0 {
 		// No sticky bit, no restriction
 		return nil
@@ -408,19 +405,16 @@ func CheckStickyBitRestriction(ctx *AuthContext, dirAttr *FileAttr, fileAttr *Fi
 		return nil
 	}
 
-	// Check if the caller owns the file being deleted/renamed
 	if fileAttr.UID == callerUID {
 		logger.Debug("CheckStickyBitRestriction: caller owns file")
 		return nil
 	}
 
-	// Check if the caller owns the sticky directory
 	if dirAttr.UID == callerUID {
 		logger.Debug("CheckStickyBitRestriction: caller owns directory")
 		return nil
 	}
 
-	// Sticky bit restriction applies - deny the operation
 	logger.Debug("CheckStickyBitRestriction: DENIED",
 		"reason", "sticky bit set, caller not owner of file or directory")
 	return &StoreError{


### PR DESCRIPTION
Sweep of the 70 LOW audit findings classified `comments` / `slop`: stale, wrong or
misleading comments, plus comments carrying external references (issue/PR numbers,
phase/plan IDs, internal ticket codes) that the repo rules forbid.

No Go statement, signature or control flow changed anywhere — the Go half of this diff
is purely comments and doc blocks. **One deliberate exception:** the `EXPOSE` directives
in the three Dockerfiles are functional instructions, not comments, and they were changed
(see the Docker section below). Every claim was re-verified against current `develop`
first; findings that had already been fixed were left alone.

### `pkg/block`
- `doc.go`: deleted the stale "audit:" paragraph — it named `chunkstore.go`,
  `appendwrite.go` and `appendlog.go` (none exist) and claimed five
  `TRANSITIONAL-NEXT-MILESTONE` markers where exactly one existed. The
  `claim_batch_size` cycle it describes is also long gone.
- `engine/cache.go`: replaced the `TRANSITIONAL-NEXT-MILESTONE` / `#519` /
  "v0.17+" block with a plain statement of how the cache is actually populated
  (lazy on first read + `OnChunkComplete`, no share-open warm); stripped the
  `CACHE-0x` / `T-12-2x` ticket codes.
- `engine/engine.go`: `loadByHash`'s doc described a `local.Get`
  content-addressed read and buffer-ownership semantics it does not have — it is
  an unconditional no-op miss. Doc block and inline comment folded into one
  accurate paragraph. `syncedHashStore`'s field comment claimed threading into
  the FSStore via `ObjectIDPersister`; only the Syncer is wired.
- `engine/gc.go`: `CollectGarbage`'s doc said a legacy `MetadataReconciler`
  yields "an empty live set and every synced hash is a sweep candidate".
  `markPhase` in fact hard-errors fail-closed on zero shares. Doc corrected;
  also fixed `markPhase`'s own dangling opening sentence.
- `engine/fetch.go`: `EnsureAvailableAndRead`'s doc claimed it "copies data
  directly to dest, avoiding a second local ReadAt" — it never fills `dest` and
  every return path yields `false`. Doc now states it only hydrates the local
  tier. `Post-Phase-17` framing rewritten as plain invariants.
- `filechunk.go`, `types.go`, `engine/coordinator.go`, `engine/readwrite.go`:
  repaired truncated sentence fragments (`semantics post-).`, `are removed in;`,
  `. Per-metadata-store scope`, `Added in to drive`, `See, decisions.`,
  `zero-filled on read per`), dropped "Renamed from …" / "Collision check
  (date)" refactor history, and corrected `ContentHash.UnmarshalJSON`'s doc,
  which mentioned only the base64 legacy form while the code also accepts the
  JSON number-array form.
- `blockstoretest`: findings about a missing `BlockStoreAppendConformance`
  entrypoint were already fixed on develop — no change.
- Issue/PR numbers removed from `compaction.go`, `gc.go`, `gc_block.go`,
  `reclaim.go`, `reconcile.go`, `syncer.go`, `readwrite.go`, `coordinator.go`.

### `pkg/block/journal`
- Dropped `#953`, `#953-A`, `#1718`, `#1736`, `#1569`, `PR7` tokens from
  `carve.go`, `index.go`, `segment.go`, `reclaim.go`, `recovery.go`, `store.go`,
  `shard.go`; the surrounding prose already carries the invariant.

### Adapters
- `nfs/v3/handlers/commit.go`: `CommitResponse.WriteVerifier`'s doc claimed
  "value of 0 indicates no server reboot tracking / a production implementation
  should track server start time" — the code has set it to `serverBootTime`
  since forever.
- `nfs/v4/handlers/read_plus.go`: the function doc named `block.Segments` as the
  segmentation source; the primary source is the engine's `DataExtents` view,
  with `block.Segments` as fallback (as the accurate comment further down
  already says).
- `common/write_payload.go`, `nfs/v3/handlers/read.go`,
  `smb/handlers/read.go`, `smb/handlers/write.go`: dropped issue refs and
  restatement comments.

### `pkg/metadata`
- `store/badger/encoding.go`: the key-namespace table was missing `cn:`, `obj:`
  and `pl:`, all defined immediately below it. Rows added.
- `store/badger/testhooks.go`: `SetMaxTransactionRetriesForTest`'s doc block was
  glued above `InlineSyncCountForTest`. Moved to its own function.
- `store/badger/objects.go`, `store/memory/objects.go`,
  `store/postgres/objects.go`, `store/sqlite/objects.go`: dropped
  "Renamed from …" / "lifted from …" fragments.
- `store/badger/objects.go`, `store/{postgres,sqlite}/files.go`,
  `tx_context.go`: dropped the "(review iteration 1):" process prefix, keeping
  the substantive rationale.
- `store/badger/shares.go`: reworded the "the original code wrote a fresh
  Share{}" bug/fix note as a statement of current behaviour.
- `store/sqlite/migrations/000005_…up.sql`: the comment pointed at
  `encoding.go`'s `timeToNanos` / `nanosToTime`, neither of which exists — now
  points at `internal/sqlcodec`'s `TimeToFiletime` / `FiletimeToTime`.
- `validation.go`, `auth_permissions.go`, `store/badger/locks.go`,
  `store/badger/transaction.go`, `store/postgres/{connection,transaction}.go`:
  deleted line-by-line narration that restated the statement below it.

### `pkg/controlplane/runtime`
- Dropped `#1245 Bug D` and `Phase-5` references from `stores/service.go`, the
  "Per Pitfall 3" plan reference from `netgroups.go`, and restatement comments
  from `settings_watcher.go` and `netgroups.go`.

### Docker
- `EXPOSE` had drifted across the three production Dockerfiles (base had the
  discovery ports but no metrics; prebuilt had metrics but no discovery;
  goreleaser had neither). All three now carry the same canonical list —
  12049 NFS, 12445 SMB, 8080 API, 9090 metrics, 5353/3702/5357 discovery — with
  the same explanatory block. Also dropped the `issue #1609` refs.
