### PR TITLE
build: expose the metrics and discovery ports in the images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,12 +62,13 @@ USER 65532:65532
 # - 12049: NFS server (default)
 # - 12445: SMB server (default)
 # - 8080: REST API (health checks, management)
-# - 5353/udp: mDNS / DNS-SD network discovery (macOS Finder, Linux Avahi) — issue #1609
-# - 3702/udp: WS-Discovery (Windows Explorer Network) — issue #1609
-# - 5357/tcp: WS-Discovery device metadata (HTTP) — issue #1609
+# - 9090: Prometheus metrics endpoint (default)
+# - 5353/udp: mDNS / DNS-SD network discovery (macOS Finder, Linux Avahi)
+# - 3702/udp: WS-Discovery (Windows Explorer Network)
+# - 5357/tcp: WS-Discovery device metadata (HTTP)
 # Note: multicast discovery (5353/3702) only works on the host LAN / hostNetwork;
 # it does not traverse standard container/K8s overlay networks.
-EXPOSE 12049/tcp 12445/tcp 8080/tcp 5353/udp 3702/udp 5357/tcp
+EXPOSE 12049/tcp 12445/tcp 8080/tcp 9090/tcp 5353/udp 3702/udp 5357/tcp
 
 # Volume mounts:
 # - /data/metadata: Metadata store (BadgerDB, etc.)

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,9 @@ USER 65532:65532
 # - 12049: NFS server (default)
 # - 12445: SMB server (default)
 # - 8080: REST API (health checks, management)
-# - 9090: Prometheus metrics endpoint (default)
+# - 9090: Prometheus metrics endpoint. Opt-in and loopback-bound by default,
+#         so publishing this port alone exposes nothing: enable metrics and set
+#         their host to 0.0.0.0 for it to be reachable from outside the container.
 # - 5353/udp: mDNS / DNS-SD network discovery (macOS Finder, Linux Avahi)
 # - 3702/udp: WS-Discovery (Windows Explorer Network)
 # - 5357/tcp: WS-Discovery device metadata (HTTP)

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -33,7 +33,13 @@ USER 65532:65532
 # - 12049: NFS server (default)
 # - 12445: SMB server (default)
 # - 8080: REST API (health checks, management)
-EXPOSE 12049/tcp 12445/tcp 8080/tcp
+# - 9090: Prometheus metrics endpoint (default)
+# - 5353/udp: mDNS / DNS-SD network discovery (macOS Finder, Linux Avahi)
+# - 3702/udp: WS-Discovery (Windows Explorer Network)
+# - 5357/tcp: WS-Discovery device metadata (HTTP)
+# Note: multicast discovery (5353/3702) only works on the host LAN / hostNetwork;
+# it does not traverse standard container/K8s overlay networks.
+EXPOSE 12049/tcp 12445/tcp 8080/tcp 9090/tcp 5353/udp 3702/udp 5357/tcp
 
 # Volume mounts:
 # - /data/metadata: Metadata store (BadgerDB, etc.)

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -33,7 +33,9 @@ USER 65532:65532
 # - 12049: NFS server (default)
 # - 12445: SMB server (default)
 # - 8080: REST API (health checks, management)
-# - 9090: Prometheus metrics endpoint (default)
+# - 9090: Prometheus metrics endpoint. Opt-in and loopback-bound by default,
+#         so publishing this port alone exposes nothing: enable metrics and set
+#         their host to 0.0.0.0 for it to be reachable from outside the container.
 # - 5353/udp: mDNS / DNS-SD network discovery (macOS Finder, Linux Avahi)
 # - 3702/udp: WS-Discovery (Windows Explorer Network)
 # - 5357/tcp: WS-Discovery device metadata (HTTP)

--- a/Dockerfile.prebuilt
+++ b/Dockerfile.prebuilt
@@ -7,7 +7,17 @@ COPY dfs-linux-amd64 /app/dfs
 RUN mkdir -p /data/metadata /data/content /data/cache /config && \
     chown -R 65532:65532 /app /data /config
 USER 65532:65532
-EXPOSE 12049/tcp 12445/tcp 9090/tcp 8080/tcp
+# Expose ports:
+# - 12049: NFS server (default)
+# - 12445: SMB server (default)
+# - 8080: REST API (health checks, management)
+# - 9090: Prometheus metrics endpoint (default)
+# - 5353/udp: mDNS / DNS-SD network discovery (macOS Finder, Linux Avahi)
+# - 3702/udp: WS-Discovery (Windows Explorer Network)
+# - 5357/tcp: WS-Discovery device metadata (HTTP)
+# Note: multicast discovery (5353/3702) only works on the host LAN / hostNetwork;
+# it does not traverse standard container/K8s overlay networks.
+EXPOSE 12049/tcp 12445/tcp 8080/tcp 9090/tcp 5353/udp 3702/udp 5357/tcp
 VOLUME ["/data/metadata", "/data/content", "/data/cache", "/config"]
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1

--- a/Dockerfile.prebuilt
+++ b/Dockerfile.prebuilt
@@ -11,7 +11,9 @@ USER 65532:65532
 # - 12049: NFS server (default)
 # - 12445: SMB server (default)
 # - 8080: REST API (health checks, management)
-# - 9090: Prometheus metrics endpoint (default)
+# - 9090: Prometheus metrics endpoint. Opt-in and loopback-bound by default,
+#         so publishing this port alone exposes nothing: enable metrics and set
+#         their host to 0.0.0.0 for it to be reachable from outside the container.
 # - 5353/udp: mDNS / DNS-SD network discovery (macOS Finder, Linux Avahi)
 # - 3702/udp: WS-Discovery (Windows Explorer Network)
 # - 5357/tcp: WS-Discovery device metadata (HTTP)


### PR DESCRIPTION
Split out of #1996 (the LOW `comments` sweep). `EXPOSE` is a functional directive — it drives `docker run -P` and is read by orchestration tooling — so it does not belong in a diff whose whole reviewability rests on being inert. #1996 is now Go comments only.

All three images advertised a port set that no longer matches what the server actually listens on. Verified against the code:

| Port | Listener |
|---|---|
| 9090/tcp | Prometheus metrics endpoint, default in `pkg/config/metrics.go:58` |
| 5353/udp | mDNS / DNS-SD, `pkg/discovery/mdns/responder.go:21` (macOS Finder, Linux Avahi) |
| 3702/udp | WS-Discovery (Windows Explorer Network) |
| 5357/tcp | WS-Discovery device metadata over HTTP, `pkg/discovery/wsd/messages.go:48` |

`Dockerfile` and `Dockerfile.goreleaser` were missing 9090; `Dockerfile.prebuilt` had 9090 but none of the discovery ports. All three now carry the same set, so the images stop disagreeing with each other.

The comment blocks also lose their `— issue #1609` references, which this repo does not allow in source, without losing what they explain. Added a note that multicast discovery (5353/3702) only works on the host LAN or with `hostNetwork`, since it does not traverse standard container and Kubernetes overlay networks — the port being exposed does not by itself make Finder or Explorer discovery work, and that is a reasonable thing for someone reading the Dockerfile to assume otherwise.

`EXPOSE` is documentation plus `-P` behaviour; it does not open anything by itself, so this cannot widen a deployment's actual exposure.