### PR TITLE
refactor: sweep the LOW bloat findings (dead fields, params, duplicated helpers)

### DIFF
--- a/internal/adapter/common/clone.go
+++ b/internal/adapter/common/clone.go
@@ -181,7 +181,7 @@ func materializeLocalClone(
 		if want > copyChunk {
 			want = copyChunk
 		}
-		n, rerr := blockStore.ReadAt(ctx, string(srcFile.PayloadID), nil, buf[:want], off)
+		n, rerr := blockStore.ReadAt(ctx, string(srcFile.PayloadID), buf[:want], off)
 		if n > 0 {
 			if _, werr := blockStore.WriteAt(ctx, string(dstPayloadID), nil, buf[:n], off); werr != nil {
 				return fmt.Errorf("materialize clone: write dst payload: %w", werr)

--- a/internal/adapter/common/commit_durability_test.go
+++ b/internal/adapter/common/commit_durability_test.go
@@ -222,7 +222,7 @@ func TestCommitBlockStore_Strict_ConfigOverride_FlipsBehavior(t *testing.T) {
 	// And the inverse: fs local forced durable=false under strict mode now
 	// requires a durable remote that it does not have → ErrNotDurableYet.
 	fsBS := strict(newTestEngine(t))
-	if fsLocal := fsBS.LocalForTest(); fsLocal != nil {
+	if fsLocal := fsBS.Local(); fsLocal != nil {
 		if setter, ok := fsLocal.(interface{ SetDurable(bool) }); ok {
 			setter.SetDurable(false)
 		} else {

--- a/internal/adapter/common/read_payload.go
+++ b/internal/adapter/common/read_payload.go
@@ -41,11 +41,6 @@ func (r *BlockReadResult) Release() {
 // SMB SMBHandlerContext, NFSv4 compound ctx). Structural logging fields
 // (clientIP, handle bytes) are logged at the call site, not here, because
 // they are protocol-specific and common/ cannot couple to those types.
-//
-// When FileAttr.Blocks becomes []ChunkRef and engine.Store.ReadAt
-// takes []ChunkRef, this function body gains the "fetch FileAttr.Blocks →
-// slice to [offset, offset+len) → pass resolved refs" logic. Call-site
-// code (protocol handlers) does not change.
 func ReadFromBlockStore(
 	ctx context.Context,
 	blockStore *engine.Store,
@@ -54,11 +49,6 @@ func ReadFromBlockStore(
 	count uint32,
 ) (BlockReadResult, error) {
 	data := pool.Get(int(count))
-	// Pass nil []ChunkRef so the engine routes through the dual-read
-	// shim. The caller-snapshot []ChunkRef from FileAttr.Blocks will
-	// thread here in a later adapter-helper refactor; until then the
-	// engine resolves via the legacy {payloadID}/block-{N} path and the
-	// result is identical.
 	n, readErr := blockStore.ReadAt(ctx, string(payloadID), data, offset)
 
 	if readErr == io.EOF || readErr == io.ErrUnexpectedEOF {

--- a/internal/adapter/common/read_payload.go
+++ b/internal/adapter/common/read_payload.go
@@ -59,7 +59,7 @@ func ReadFromBlockStore(
 	// thread here in a later adapter-helper refactor; until then the
 	// engine resolves via the legacy {payloadID}/block-{N} path and the
 	// result is identical.
-	n, readErr := blockStore.ReadAt(ctx, string(payloadID), nil, data, offset)
+	n, readErr := blockStore.ReadAt(ctx, string(payloadID), data, offset)
 
 	if readErr == io.EOF || readErr == io.ErrUnexpectedEOF {
 		return BlockReadResult{Data: data[:n], EOF: true}, nil

--- a/internal/adapter/common/write_payload_test.go
+++ b/internal/adapter/common/write_payload_test.go
@@ -79,7 +79,7 @@ func TestWriteToBlockStore_Passthrough(t *testing.T) {
 
 	// Round-trip: read back via engine.ReadAt and compare bytes.
 	readBack := make([]byte, len(data))
-	n, readErr := bs.ReadAt(ctx, payloadID, nil, readBack, 0)
+	n, readErr := bs.ReadAt(ctx, payloadID, readBack, 0)
 	if readErr != nil {
 		t.Fatalf("engine.ReadAt after WriteToBlockStore failed: %v", readErr)
 	}
@@ -109,7 +109,7 @@ func TestWriteToBlockStore_OffsetRespected(t *testing.T) {
 	forceRollup(t, bs, payloadID)
 
 	readBack := make([]byte, len(data))
-	n, readErr := bs.ReadAt(ctx, payloadID, nil, readBack, offset)
+	n, readErr := bs.ReadAt(ctx, payloadID, readBack, offset)
 	if readErr != nil {
 		t.Fatalf("engine.ReadAt at offset %d failed: %v", offset, readErr)
 	}

--- a/internal/adapter/nfs/v3/handlers/read.go
+++ b/internal/adapter/nfs/v3/handlers/read.go
@@ -211,30 +211,14 @@ func (h *Handler) Read(
 		}
 	}
 
-	// If file has no content, return empty data with EOF
-	if file.PayloadID == "" || file.Size == 0 {
-		logger.DebugCtx(ctx.Context, "READ: empty file", "handle", xdr.LazyHandle(req.Handle), "size", bytesize.ByteSize(file.Size), "client", clientIP)
-
-		nfsAttr := h.convertFileAttrToNFS(fileHandle, &file.FileAttr)
-
-		return &ReadResponse{
-			NFSResponseBase: NFSResponseBase{Status: types.NFS3OK},
-			Attr:            nfsAttr,
-			Count:           0,
-			Eof:             true,
-			Data:            []byte{},
-		}, nil
-	}
-
-	// If offset is at or beyond EOF, return empty data with EOF
-	if req.Offset >= file.Size {
-		logger.DebugCtx(ctx.Context, "READ: offset beyond EOF", "handle", xdr.LazyHandle(req.Handle), "offset", bytesize.ByteSize(req.Offset), "size", bytesize.ByteSize(file.Size), "client", clientIP)
-
-		nfsAttr := h.convertFileAttrToNFS(fileHandle, &file.FileAttr)
+	// Nothing to serve: the file has no payload, or the read starts at or past
+	// EOF (which covers a zero-size file). Both answer with an empty, EOF reply.
+	if file.PayloadID == "" || req.Offset >= file.Size {
+		logger.DebugCtx(ctx.Context, "READ: nothing to serve", "handle", xdr.LazyHandle(req.Handle), "offset", bytesize.ByteSize(req.Offset), "size", bytesize.ByteSize(file.Size), "client", clientIP)
 
 		return &ReadResponse{
 			NFSResponseBase: NFSResponseBase{Status: types.NFS3OK},
-			Attr:            nfsAttr,
+			Attr:            h.convertFileAttrToNFS(fileHandle, &file.FileAttr),
 			Count:           0,
 			Eof:             true,
 			Data:            []byte{},

--- a/internal/adapter/nfs/v3/handlers/testing/fixtures.go
+++ b/internal/adapter/nfs/v3/handlers/testing/fixtures.go
@@ -462,7 +462,6 @@ func (f *HandlerTestFixture) ReadContent(path string) []byte {
 
 	// Read content using BlockStore
 	content := make([]byte, size)
-	// Nil []ChunkRef => dual-read shim path.
 	n, err := f.BlockStore.ReadAt(ctx, string(file.PayloadID), content, 0)
 	if err != nil {
 		f.t.Fatalf("Failed to read content from %q: %v", path, err)

--- a/internal/adapter/nfs/v3/handlers/testing/fixtures.go
+++ b/internal/adapter/nfs/v3/handlers/testing/fixtures.go
@@ -463,7 +463,7 @@ func (f *HandlerTestFixture) ReadContent(path string) []byte {
 	// Read content using BlockStore
 	content := make([]byte, size)
 	// Nil []ChunkRef => dual-read shim path.
-	n, err := f.BlockStore.ReadAt(ctx, string(file.PayloadID), nil, content, 0)
+	n, err := f.BlockStore.ReadAt(ctx, string(file.PayloadID), content, 0)
 	if err != nil {
 		f.t.Fatalf("Failed to read content from %q: %v", path, err)
 	}

--- a/internal/adapter/nfs/v4/handlers/commit.go
+++ b/internal/adapter/nfs/v4/handlers/commit.go
@@ -20,39 +20,23 @@ import (
 func (h *Handler) handleCommit(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
 	// Require current filehandle
 	if status := types.RequireCurrentFH(ctx); status != types.NFS4_OK {
-		return &types.CompoundResult{
-			Status: status,
-			OpCode: types.OP_COMMIT,
-			Data:   encodeStatusOnly(status),
-		}
+		return commitErr(status)
 	}
 
 	// Pseudo-fs is read-only
 	if pseudofs.IsPseudoFSHandle(ctx.CurrentFH) {
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_ROFS,
-			OpCode: types.OP_COMMIT,
-			Data:   encodeStatusOnly(types.NFS4ERR_ROFS),
-		}
+		return commitErr(types.NFS4ERR_ROFS)
 	}
 
 	// Decode COMMIT4args
 	offset, err := xdr.DecodeUint64(reader)
 	if err != nil {
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_BADXDR,
-			OpCode: types.OP_COMMIT,
-			Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
-		}
+		return commitErr(types.NFS4ERR_BADXDR)
 	}
 
 	count, err := xdr.DecodeUint32(reader)
 	if err != nil {
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_BADXDR,
-			OpCode: types.OP_COMMIT,
-			Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
-		}
+		return commitErr(types.NFS4ERR_BADXDR)
 	}
 
 	logger.Debug("NFSv4 COMMIT",
@@ -65,21 +49,13 @@ func (h *Handler) handleCommit(ctx *types.CompoundContext, reader io.Reader) *ty
 	if err != nil {
 		logger.Debug("NFSv4 COMMIT auth context failed", "error", err, "client", ctx.ClientAddr)
 		st := nfs4StatusForAuthError(err)
-		return &types.CompoundResult{
-			Status: st,
-			OpCode: types.OP_COMMIT,
-			Data:   encodeStatusOnly(st),
-		}
+		return commitErr(st)
 	}
 
 	// Get metadata service to look up PayloadID
 	metaSvc, err := getMetadataServiceForCtx(h)
 	if err != nil {
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_SERVERFAULT,
-			OpCode: types.OP_COMMIT,
-			Data:   encodeStatusOnly(types.NFS4ERR_SERVERFAULT),
-		}
+		return commitErr(types.NFS4ERR_SERVERFAULT)
 	}
 
 	fileHandle := metadata.FileHandle(ctx.CurrentFH)
@@ -87,11 +63,7 @@ func (h *Handler) handleCommit(ctx *types.CompoundContext, reader io.Reader) *ty
 	file, err := metaSvc.GetFileForRead(authCtx.Context, fileHandle)
 	if err != nil {
 		status := common.MapToNFS4(err)
-		return &types.CompoundResult{
-			Status: status,
-			OpCode: types.OP_COMMIT,
-			Data:   encodeStatusOnly(status),
-		}
+		return commitErr(status)
 	}
 
 	// Enforce write permission before forcing anything to stable storage.
@@ -103,11 +75,7 @@ func (h *Handler) handleCommit(ctx *types.CompoundContext, reader io.Reader) *ty
 	if err := metaSvc.CheckWritePermissionFile(authCtx, fileHandle, file); err != nil {
 		status := common.MapToNFS4(err)
 		logger.Debug("NFSv4 COMMIT denied", "status", status, "error", err, "client", ctx.ClientAddr)
-		return &types.CompoundResult{
-			Status: status,
-			OpCode: types.OP_COMMIT,
-			Data:   encodeStatusOnly(status),
-		}
+		return commitErr(status)
 	}
 
 	// If no content, just return success
@@ -120,20 +88,12 @@ func (h *Handler) handleCommit(ctx *types.CompoundContext, reader io.Reader) *ty
 	// (previously lived inside the local getBlockStoreForHandle).
 	if h.Registry == nil {
 		logger.Debug("NFSv4 COMMIT no registry configured", "client", ctx.ClientAddr)
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_SERVERFAULT,
-			OpCode: types.OP_COMMIT,
-			Data:   encodeStatusOnly(types.NFS4ERR_SERVERFAULT),
-		}
+		return commitErr(types.NFS4ERR_SERVERFAULT)
 	}
 	// Get per-share block store and flush
 	blockStore, err := common.ResolveForWrite(ctx.Context, h.Registry, metadata.FileHandle(ctx.CurrentFH))
 	if err != nil {
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_SERVERFAULT,
-			OpCode: types.OP_COMMIT,
-			Data:   encodeStatusOnly(types.NFS4ERR_SERVERFAULT),
-		}
+		return commitErr(types.NFS4ERR_SERVERFAULT)
 	}
 
 	// Routed through common.CommitBlockStore so any future []ChunkRef
@@ -144,11 +104,7 @@ func (h *Handler) handleCommit(ctx *types.CompoundContext, reader io.Reader) *ty
 			"error", flushErr,
 			"payloadID", file.PayloadID,
 			"client", ctx.ClientAddr)
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_IO,
-			OpCode: types.OP_COMMIT,
-			Data:   encodeStatusOnly(types.NFS4ERR_IO),
-		}
+		return commitErr(types.NFS4ERR_IO)
 	}
 
 	// Flush pending metadata writes (deferred commit optimization)
@@ -161,7 +117,7 @@ func (h *Handler) handleCommit(ctx *types.CompoundContext, reader io.Reader) *ty
 		logger.Error("NFSv4 COMMIT metadata flush failed",
 			"error", metaErr,
 			"client", ctx.ClientAddr)
-		return encodeCommit4resError(types.NFS4ERR_SERVERFAULT)
+		return commitErr(types.NFS4ERR_SERVERFAULT)
 	} else if flushed {
 		logger.Debug("NFSv4 COMMIT flushed pending metadata",
 			"client", ctx.ClientAddr)
@@ -174,14 +130,12 @@ func (h *Handler) handleCommit(ctx *types.CompoundContext, reader io.Reader) *ty
 	return encodeCommit4resok()
 }
 
-// encodeCommit4resError encodes a failed COMMIT4 response.
-func encodeCommit4resError(status uint32) *types.CompoundResult {
-	var buf bytes.Buffer
-	_ = xdr.WriteUint32(&buf, status)
+// commitErr builds a COMMIT error result (status only).
+func commitErr(status uint32) *types.CompoundResult {
 	return &types.CompoundResult{
 		Status: status,
 		OpCode: types.OP_COMMIT,
-		Data:   buf.Bytes(),
+		Data:   encodeStatusOnly(status),
 	}
 }
 

--- a/internal/adapter/nfs/v4/handlers/read.go
+++ b/internal/adapter/nfs/v4/handlers/read.go
@@ -22,48 +22,28 @@ import (
 func (h *Handler) handleRead(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
 	// Require current filehandle
 	if status := types.RequireCurrentFH(ctx); status != types.NFS4_OK {
-		return &types.CompoundResult{
-			Status: status,
-			OpCode: types.OP_READ,
-			Data:   encodeStatusOnly(status),
-		}
+		return readErr(status)
 	}
 
 	// Pseudo-fs only has directories
 	if pseudofs.IsPseudoFSHandle(ctx.CurrentFH) {
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_ISDIR,
-			OpCode: types.OP_READ,
-			Data:   encodeStatusOnly(types.NFS4ERR_ISDIR),
-		}
+		return readErr(types.NFS4ERR_ISDIR)
 	}
 
 	// Decode READ4args
 	stateid, err := types.DecodeStateid4(reader)
 	if err != nil {
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_BADXDR,
-			OpCode: types.OP_READ,
-			Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
-		}
+		return readErr(types.NFS4ERR_BADXDR)
 	}
 
 	offset, err := xdr.DecodeUint64(reader)
 	if err != nil {
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_BADXDR,
-			OpCode: types.OP_READ,
-			Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
-		}
+		return readErr(types.NFS4ERR_BADXDR)
 	}
 
 	count, err := xdr.DecodeUint32(reader)
 	if err != nil {
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_BADXDR,
-			OpCode: types.OP_READ,
-			Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
-		}
+		return readErr(types.NFS4ERR_BADXDR)
 	}
 
 	// Validate stateid via StateManager.
@@ -78,11 +58,7 @@ func (h *Handler) handleRead(ctx *types.CompoundContext, reader io.Reader) *type
 			"error", stateErr,
 			"nfs_status", nfsStatus,
 			"client", ctx.ClientAddr)
-		return &types.CompoundResult{
-			Status: nfsStatus,
-			OpCode: types.OP_READ,
-			Data:   encodeStatusOnly(nfsStatus),
-		}
+		return readErr(nfsStatus)
 	}
 
 	// Enforce the open's share-access mode: a regular open stateid must have
@@ -93,11 +69,7 @@ func (h *Handler) handleRead(ctx *types.CompoundContext, reader io.Reader) *type
 		logger.Debug("NFSv4 READ rejected: write-only open",
 			"share_access", openState.ShareAccess,
 			"client", ctx.ClientAddr)
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_OPENMODE,
-			OpCode: types.OP_READ,
-			Data:   encodeStatusOnly(types.NFS4ERR_OPENMODE),
-		}
+		return readErr(types.NFS4ERR_OPENMODE)
 	}
 
 	logger.Debug("NFSv4 READ",
@@ -112,21 +84,13 @@ func (h *Handler) handleRead(ctx *types.CompoundContext, reader io.Reader) *type
 	if err != nil {
 		logger.Debug("NFSv4 READ auth context failed", "error", err, "client", ctx.ClientAddr)
 		st := nfs4StatusForAuthError(err)
-		return &types.CompoundResult{
-			Status: st,
-			OpCode: types.OP_READ,
-			Data:   encodeStatusOnly(st),
-		}
+		return readErr(st)
 	}
 
 	// Get services
 	metaSvc, err := getMetadataServiceForCtx(h)
 	if err != nil {
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_SERVERFAULT,
-			OpCode: types.OP_READ,
-			Data:   encodeStatusOnly(types.NFS4ERR_SERVERFAULT),
-		}
+		return readErr(types.NFS4ERR_SERVERFAULT)
 	}
 
 	// Get file attributes
@@ -135,21 +99,13 @@ func (h *Handler) handleRead(ctx *types.CompoundContext, reader io.Reader) *type
 	file, err := metaSvc.GetFileForRead(authCtx.Context, fileHandle)
 	if err != nil {
 		status := common.MapToNFS4(err)
-		return &types.CompoundResult{
-			Status: status,
-			OpCode: types.OP_READ,
-			Data:   encodeStatusOnly(status),
-		}
+		return readErr(status)
 	}
 
 	// Verify it's a regular file
 	if file.Type != metadata.FileTypeRegular {
 		status := readTypeError(file.Type)
-		return &types.CompoundResult{
-			Status: status,
-			OpCode: types.OP_READ,
-			Data:   encodeStatusOnly(status),
-		}
+		return readErr(status)
 	}
 
 	// Empty file or no content
@@ -174,19 +130,11 @@ func (h *Handler) handleRead(ctx *types.CompoundContext, reader io.Reader) *type
 	// avoids leaking an NFSv4 concern into common.ResolveForRead.
 	if h.Registry == nil {
 		logger.Debug("NFSv4 READ no registry configured", "client", ctx.ClientAddr)
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_SERVERFAULT,
-			OpCode: types.OP_READ,
-			Data:   encodeStatusOnly(types.NFS4ERR_SERVERFAULT),
-		}
+		return readErr(types.NFS4ERR_SERVERFAULT)
 	}
 	blockStore, err := common.ResolveForRead(ctx.Context, h.Registry, metadata.FileHandle(ctx.CurrentFH))
 	if err != nil {
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_SERVERFAULT,
-			OpCode: types.OP_READ,
-			Data:   encodeStatusOnly(types.NFS4ERR_SERVERFAULT),
-		}
+		return readErr(types.NFS4ERR_SERVERFAULT)
 	}
 
 	// NOTE: NFSv4 READ now allocates via internal/adapter/pool (through
@@ -196,11 +144,7 @@ func (h *Handler) handleRead(ctx *types.CompoundContext, reader io.Reader) *type
 	readResult, err := common.ReadFromBlockStore(ctx.Context, blockStore, file.PayloadID, offset, uint32(actualLen))
 	if err != nil {
 		logger.Debug("NFSv4 READ payload error", "error", err, "client", ctx.ClientAddr)
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_IO,
-			OpCode: types.OP_READ,
-			Data:   encodeStatusOnly(types.NFS4ERR_IO),
-		}
+		return readErr(types.NFS4ERR_IO)
 	}
 	// Release the pooled buffer after the compound result has been encoded.
 	// encodeRead4resok copies readResult.Data into a fresh bytes.Buffer before
@@ -260,5 +204,14 @@ func encodeRead4resok(eof bool, data []byte) *types.CompoundResult {
 		Status: types.NFS4_OK,
 		OpCode: types.OP_READ,
 		Data:   buf.Bytes(),
+	}
+}
+
+// readErr builds a READ error result (status only).
+func readErr(status uint32) *types.CompoundResult {
+	return &types.CompoundResult{
+		Status: status,
+		OpCode: types.OP_READ,
+		Data:   encodeStatusOnly(status),
 	}
 }

--- a/internal/adapter/nfs/v4/handlers/write.go
+++ b/internal/adapter/nfs/v4/handlers/write.go
@@ -53,13 +53,7 @@ func BumpBootVerifier() {
 // caller can safely embed it in a response buffer without aliasing
 // the atomic's pointer.
 func bootVerifierBytes() [8]byte {
-	v := serverBootVerifier.Load()
-	if v == nil {
-		// Defensive: init() ran, so this should never trigger.
-		var zero [8]byte
-		return zero
-	}
-	return *v
+	return *serverBootVerifier.Load()
 }
 
 // handleWrite implements the WRITE operation (RFC 7530 Section 16.36).
@@ -70,57 +64,33 @@ func bootVerifierBytes() [8]byte {
 func (h *Handler) handleWrite(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
 	// Require current filehandle
 	if status := types.RequireCurrentFH(ctx); status != types.NFS4_OK {
-		return &types.CompoundResult{
-			Status: status,
-			OpCode: types.OP_WRITE,
-			Data:   encodeStatusOnly(status),
-		}
+		return writeErr(status)
 	}
 
 	// Pseudo-fs is read-only
 	if pseudofs.IsPseudoFSHandle(ctx.CurrentFH) {
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_ROFS,
-			OpCode: types.OP_WRITE,
-			Data:   encodeStatusOnly(types.NFS4ERR_ROFS),
-		}
+		return writeErr(types.NFS4ERR_ROFS)
 	}
 
 	// Decode WRITE4args
 	stateid, err := types.DecodeStateid4(reader)
 	if err != nil {
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_BADXDR,
-			OpCode: types.OP_WRITE,
-			Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
-		}
+		return writeErr(types.NFS4ERR_BADXDR)
 	}
 
 	offset, err := xdr.DecodeUint64(reader)
 	if err != nil {
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_BADXDR,
-			OpCode: types.OP_WRITE,
-			Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
-		}
+		return writeErr(types.NFS4ERR_BADXDR)
 	}
 
 	stable, err := xdr.DecodeUint32(reader)
 	if err != nil {
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_BADXDR,
-			OpCode: types.OP_WRITE,
-			Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
-		}
+		return writeErr(types.NFS4ERR_BADXDR)
 	}
 
 	data, err := xdr.DecodeOpaque(reader)
 	if err != nil {
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_BADXDR,
-			OpCode: types.OP_WRITE,
-			Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
-		}
+		return writeErr(types.NFS4ERR_BADXDR)
 	}
 
 	// Validate stateid via StateManager for a write-family operation.
@@ -136,11 +106,7 @@ func (h *Handler) handleWrite(ctx *types.CompoundContext, reader io.Reader) *typ
 			"error", stateErr,
 			"nfs_status", nfsStatus,
 			"client", ctx.ClientAddr)
-		return &types.CompoundResult{
-			Status: nfsStatus,
-			OpCode: types.OP_WRITE,
-			Data:   encodeStatusOnly(nfsStatus),
-		}
+		return writeErr(nfsStatus)
 	}
 
 	// Check that the open state includes WRITE access (OPEN4_SHARE_ACCESS_WRITE or BOTH).
@@ -150,11 +116,7 @@ func (h *Handler) handleWrite(ctx *types.CompoundContext, reader io.Reader) *typ
 			logger.Debug("NFSv4 WRITE rejected: read-only open",
 				"share_access", openState.ShareAccess,
 				"client", ctx.ClientAddr)
-			return &types.CompoundResult{
-				Status: types.NFS4ERR_OPENMODE,
-				OpCode: types.OP_WRITE,
-				Data:   encodeStatusOnly(types.NFS4ERR_OPENMODE),
-			}
+			return writeErr(types.NFS4ERR_OPENMODE)
 		}
 	}
 
@@ -170,51 +132,31 @@ func (h *Handler) handleWrite(ctx *types.CompoundContext, reader io.Reader) *typ
 	if err != nil {
 		logger.Debug("NFSv4 WRITE auth context failed", "error", err, "client", ctx.ClientAddr)
 		st := nfs4StatusForAuthError(err)
-		return &types.CompoundResult{
-			Status: st,
-			OpCode: types.OP_WRITE,
-			Data:   encodeStatusOnly(st),
-		}
+		return writeErr(st)
 	}
 
 	// Get services
 	metaSvc, err := getMetadataServiceForCtx(h)
 	if err != nil {
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_SERVERFAULT,
-			OpCode: types.OP_WRITE,
-			Data:   encodeStatusOnly(types.NFS4ERR_SERVERFAULT),
-		}
+		return writeErr(types.NFS4ERR_SERVERFAULT)
 	}
 
 	// Preserve the NFSv4-specific nil-Registry guard at the call site
 	// (previously lived inside the local getBlockStoreForHandle).
 	if h.Registry == nil {
 		logger.Debug("NFSv4 WRITE no registry configured", "client", ctx.ClientAddr)
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_SERVERFAULT,
-			OpCode: types.OP_WRITE,
-			Data:   encodeStatusOnly(types.NFS4ERR_SERVERFAULT),
-		}
+		return writeErr(types.NFS4ERR_SERVERFAULT)
 	}
 	blockStore, err := common.ResolveForWrite(ctx.Context, h.Registry, metadata.FileHandle(ctx.CurrentFH))
 	if err != nil {
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_SERVERFAULT,
-			OpCode: types.OP_WRITE,
-			Data:   encodeStatusOnly(types.NFS4ERR_SERVERFAULT),
-		}
+		return writeErr(types.NFS4ERR_SERVERFAULT)
 	}
 
 	// Calculate new size with overflow check
 	newSize := offset + uint64(len(data))
 	if newSize < offset {
 		// Overflow
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_FBIG,
-			OpCode: types.OP_WRITE,
-			Data:   encodeStatusOnly(types.NFS4ERR_FBIG),
-		}
+		return writeErr(types.NFS4ERR_FBIG)
 	}
 
 	fileHandle := metadata.FileHandle(ctx.CurrentFH)
@@ -226,11 +168,7 @@ func (h *Handler) handleWrite(ctx *types.CompoundContext, reader io.Reader) *typ
 			"error", err,
 			"status", status,
 			"client", ctx.ClientAddr)
-		return &types.CompoundResult{
-			Status: status,
-			OpCode: types.OP_WRITE,
-			Data:   encodeStatusOnly(status),
-		}
+		return writeErr(status)
 	}
 
 	// Trace SUID/SGID-related writes for debugging
@@ -255,11 +193,7 @@ func (h *Handler) handleWrite(ctx *types.CompoundContext, reader io.Reader) *typ
 			"error", err,
 			"payloadID", intent.PayloadID,
 			"client", ctx.ClientAddr)
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_IO,
-			OpCode: types.OP_WRITE,
-			Data:   encodeStatusOnly(types.NFS4ERR_IO),
-		}
+		return writeErr(types.NFS4ERR_IO)
 	}
 
 	_, err = metaSvc.CommitWrite(authCtx, intent)
@@ -269,11 +203,7 @@ func (h *Handler) handleWrite(ctx *types.CompoundContext, reader io.Reader) *typ
 			"error", err,
 			"status", status,
 			"client", ctx.ClientAddr)
-		return &types.CompoundResult{
-			Status: status,
-			OpCode: types.OP_WRITE,
-			Data:   encodeStatusOnly(status),
-		}
+		return writeErr(status)
 	}
 
 	logger.Debug("NFSv4 WRITE successful",
@@ -300,5 +230,14 @@ func (h *Handler) handleWrite(ctx *types.CompoundContext, reader io.Reader) *typ
 		Status: types.NFS4_OK,
 		OpCode: types.OP_WRITE,
 		Data:   buf.Bytes(),
+	}
+}
+
+// writeErr builds a WRITE error result (status only).
+func writeErr(status uint32) *types.CompoundResult {
+	return &types.CompoundResult{
+		Status: status,
+		OpCode: types.OP_WRITE,
+		Data:   encodeStatusOnly(status),
 	}
 }

--- a/internal/adapter/smb/handlers/ioctl_copychunk.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk.go
@@ -483,7 +483,7 @@ func (h *Handler) executeCopyChunks(
 		// Nil []ChunkRef triggers the dual-read shim. A later refactor
 		// will thread the source's FileAttr.Blocks here.
 		data := buf[:chunk.Length]
-		n, err := srcBlockStore.ReadAt(ctx.Context, srcPayloadID, nil, data, chunk.SourceOffset)
+		n, err := srcBlockStore.ReadAt(ctx.Context, srcPayloadID, data, chunk.SourceOffset)
 		if err != nil {
 			logger.Warn("COPYCHUNK: source read failed",
 				"chunk", i, "srcPath", srcPath, "error", err)

--- a/internal/adapter/smb/handlers/ioctl_copychunk.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk.go
@@ -480,8 +480,6 @@ func (h *Handler) executeCopyChunks(
 		}
 
 		// Read from source using pre-allocated buffer.
-		// Nil []ChunkRef triggers the dual-read shim. A later refactor
-		// will thread the source's FileAttr.Blocks here.
 		data := buf[:chunk.Length]
 		n, err := srcBlockStore.ReadAt(ctx.Context, srcPayloadID, data, chunk.SourceOffset)
 		if err != nil {

--- a/internal/adapter/smb/handlers/ioctl_copychunk_sparse_integration_test.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk_sparse_integration_test.go
@@ -577,7 +577,7 @@ func TestPurgeBlockStorePayload_PreservesHardLinkedContent(t *testing.T) {
 
 	// The surviving "b" link must still read the full pattern.
 	dst := make([]byte, 4096)
-	n, err := bs.ReadAt(ctx, string(file.PayloadID), nil, dst, 0)
+	n, err := bs.ReadAt(ctx, string(file.PayloadID), dst, 0)
 	if err != nil {
 		t.Fatalf("ReadAt surviving link: %v", err)
 	}

--- a/internal/controlplane/api/handlers/health.go
+++ b/internal/controlplane/api/handlers/health.go
@@ -106,7 +106,7 @@ func (h *HealthHandler) Readiness(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Include grace period info if NFS adapter is configured
-	if graceHandler := NewGraceHandlerFromProvider(h.registry.NFSClientProvider()); graceHandler != nil {
+	if graceHandler := NewGraceHandlerFromProvider(h.registry.GetAdapterProvider("nfs")); graceHandler != nil {
 		info := graceHandler.sm.GraceStatus()
 		data["grace_period"] = map[string]any{
 			"active":            info.Active,

--- a/pkg/adapter/nfs/adapter.go
+++ b/pkg/adapter/nfs/adapter.go
@@ -575,7 +575,7 @@ func (s *NFSAdapter) SetRuntime(rtAny any) {
 	s.v4Handler.KerberosEnabled = s.kerberosConfig != nil
 
 	// Expose StateManager to REST API via runtime (for /clients endpoint and /health server info)
-	rt.SetNFSClientProvider(v4StateManager)
+	rt.SetAdapterProvider("nfs", v4StateManager)
 
 	// Designate a server-global durable client-recovery store (area-4 H8): the
 	// first share's metadata store implementing lock.ClientRecoveryStore,

--- a/pkg/block/engine/api_accessors_test.go
+++ b/pkg/block/engine/api_accessors_test.go
@@ -39,7 +39,7 @@ func TestStore_GetSize_Exists(t *testing.T) {
 
 // TestStore_Accessors covers the cheap public accessor surface that the
 // runtime and snapshot layers depend on: HasRemoteStore, RemoteStore,
-// LocalForTest, ListFiles, and LocalStats.
+// Local, ListFiles, and LocalStats.
 func TestStore_Accessors(t *testing.T) {
 	bs := newTestEngine(t, 64*1024*1024, 0)
 	ctx := context.Background()
@@ -50,8 +50,8 @@ func TestStore_Accessors(t *testing.T) {
 	if bs.RemoteStore() != nil {
 		t.Error("RemoteStore: want nil for local-only engine")
 	}
-	if bs.LocalForTest() == nil {
-		t.Error("LocalForTest: want non-nil local store")
+	if bs.Local() == nil {
+		t.Error("Local: want non-nil local store")
 	}
 
 	const payloadID = "share/listed-file"

--- a/pkg/block/engine/api_blockref_test.go
+++ b/pkg/block/engine/api_blockref_test.go
@@ -309,7 +309,7 @@ func TestPunchHole_ReadsBackAsZeros(t *testing.T) {
 	}
 
 	buf := make([]byte, 300)
-	if _, err := bs.ReadAt(ctx, payloadID, nil, buf, 0); err != nil {
+	if _, err := bs.ReadAt(ctx, payloadID, buf, 0); err != nil {
 		t.Fatalf("ReadAt: %v", err)
 	}
 	for i := 0; i < 100; i++ {

--- a/pkg/block/engine/carve_dedup_manifest_test.go
+++ b/pkg/block/engine/carve_dedup_manifest_test.go
@@ -41,7 +41,7 @@ func TestCarveDedupedChunk_KeepsManifestRow(t *testing.T) {
 		t.Fatalf("DrainLocalSynced: %v", err)
 	}
 	got := make([]byte, half)
-	if _, err := bs.ReadAt(ctx, pid, nil, got, half); err != nil {
+	if _, err := bs.ReadAt(ctx, pid, got, half); err != nil {
 		t.Fatalf("cold ReadAt: %v", err)
 	}
 	if i := firstDiff(data, got); i >= 0 {
@@ -86,7 +86,7 @@ func TestPunchHole_RepunchReadsBackZerosCold(t *testing.T) {
 		t.Fatalf("DrainLocalSynced: %v", err)
 	}
 	got := make([]byte, size)
-	if _, err := bs.ReadAt(ctx, pid, nil, got, 0); err != nil {
+	if _, err := bs.ReadAt(ctx, pid, got, 0); err != nil {
 		t.Fatalf("cold ReadAt: %v", err)
 	}
 	if i := firstDiff(data, got); i >= 0 {

--- a/pkg/block/engine/clone_localonly_test.go
+++ b/pkg/block/engine/clone_localonly_test.go
@@ -57,7 +57,7 @@ func newLocalOnlyEngine(t *testing.T, ms metadata.Store) *engine.Store {
 func readWhole(t *testing.T, bs *engine.Store, payloadID string, size int) []byte {
 	t.Helper()
 	out := make([]byte, size)
-	n, err := bs.ReadAt(context.Background(), payloadID, nil, out, 0)
+	n, err := bs.ReadAt(context.Background(), payloadID, out, 0)
 	if err != nil && err != io.EOF {
 		t.Fatalf("ReadAt(%s): %v", payloadID, err)
 	}

--- a/pkg/block/engine/close_gate_test.go
+++ b/pkg/block/engine/close_gate_test.go
@@ -69,7 +69,7 @@ func TestStore_CloseDrainsInFlightReadAt(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			buf := make([]byte, 10)
-			_, readErr = bs.ReadAt(ctx, payloadID, nil, buf, 0)
+			_, readErr = bs.ReadAt(ctx, payloadID, buf, 0)
 		}()
 		go func() {
 			defer wg.Done()
@@ -133,7 +133,7 @@ func TestStore_OpAfterCloseReturnsErrStoreClosed(t *testing.T) {
 	})
 	t.Run("ReadAt", func(t *testing.T) {
 		buf := make([]byte, 4)
-		if _, err := bs.ReadAt(ctx, "p", nil, buf, 0); !errors.Is(err, ErrStoreClosed) {
+		if _, err := bs.ReadAt(ctx, "p", buf, 0); !errors.Is(err, ErrStoreClosed) {
 			t.Fatalf("want ErrStoreClosed, got %v", err)
 		}
 	})

--- a/pkg/block/engine/cold_read_carve_seam_test.go
+++ b/pkg/block/engine/cold_read_carve_seam_test.go
@@ -54,7 +54,7 @@ func TestColdReadAtCarveSeam_PunchedRangeStaysZero(t *testing.T) {
 	}
 
 	got := make([]byte, length)
-	if _, err := bs.ReadAt(ctx, pid, nil, got, off); err != nil {
+	if _, err := bs.ReadAt(ctx, pid, got, off); err != nil {
 		t.Fatalf("cold read: %v", err)
 	}
 	for i, b := range got {

--- a/pkg/block/engine/cold_read_demand_concurrency_test.go
+++ b/pkg/block/engine/cold_read_demand_concurrency_test.go
@@ -44,8 +44,7 @@ func TestColdRead_DemandFetchIsConcurrent(t *testing.T) {
 	m := newFetchSyncer(loc, rs, fbs, mds)
 	m.config.PrefetchBlocks = 0 // isolate the demand loop from the prefetch pump
 
-	dest := make([]byte, nBlocks*BlockSize)
-	if err := m.EnsureAvailableAndRead(ctx, "p", 0, uint32(len(dest)), dest); err != nil {
+	if err := m.EnsureAvailableAndRead(ctx, "p", 0, uint32(nBlocks*BlockSize)); err != nil {
 		t.Fatalf("EnsureAvailableAndRead: %v", err)
 	}
 

--- a/pkg/block/engine/cold_read_demand_concurrency_test.go
+++ b/pkg/block/engine/cold_read_demand_concurrency_test.go
@@ -12,7 +12,7 @@ import (
 // TestColdRead_DemandFetchIsConcurrent pins the cold-read fix: a single read
 // spanning many not-local blocks must fetch them from the remote CONCURRENTLY,
 // not one blocking S3 GET per block. Before the fix the demand loop in
-// EnsureAvailableAndRead was serial, which pinned cold-read throughput at
+// EnsureAvailable was serial, which pinned cold-read throughput at
 // blockSize/latency (one GET per round-trip — the ~159 MB/s wall).
 //
 // The assertion is STRUCTURAL, not wall-clock timing: the latency-injecting
@@ -44,8 +44,8 @@ func TestColdRead_DemandFetchIsConcurrent(t *testing.T) {
 	m := newFetchSyncer(loc, rs, fbs, mds)
 	m.config.PrefetchBlocks = 0 // isolate the demand loop from the prefetch pump
 
-	if err := m.EnsureAvailableAndRead(ctx, "p", 0, uint32(nBlocks*BlockSize)); err != nil {
-		t.Fatalf("EnsureAvailableAndRead: %v", err)
+	if err := m.EnsureAvailable(ctx, "p", 0, uint32(nBlocks*BlockSize)); err != nil {
+		t.Fatalf("EnsureAvailable: %v", err)
 	}
 
 	if got := rs.gets.Load(); got != nBlocks {

--- a/pkg/block/engine/cold_read_demand_concurrency_test.go
+++ b/pkg/block/engine/cold_read_demand_concurrency_test.go
@@ -45,7 +45,7 @@ func TestColdRead_DemandFetchIsConcurrent(t *testing.T) {
 	m.config.PrefetchBlocks = 0 // isolate the demand loop from the prefetch pump
 
 	dest := make([]byte, nBlocks*BlockSize)
-	if _, err := m.EnsureAvailableAndRead(ctx, "p", 0, uint32(len(dest)), dest); err != nil {
+	if err := m.EnsureAvailableAndRead(ctx, "p", 0, uint32(len(dest)), dest); err != nil {
 		t.Fatalf("EnsureAvailableAndRead: %v", err)
 	}
 

--- a/pkg/block/engine/cold_read_demand_timeout_test.go
+++ b/pkg/block/engine/cold_read_demand_timeout_test.go
@@ -85,7 +85,7 @@ func TestColdRead_DemandFetchFailsFastWhenRemoteStalls(t *testing.T) {
 	dest := make([]byte, 4096)
 	done := make(chan error, 1)
 	go func() {
-		_, err := m.EnsureAvailableAndRead(ctx, "p", 0, uint32(len(dest)), dest)
+		err := m.EnsureAvailableAndRead(ctx, "p", 0, uint32(len(dest)), dest)
 		done <- err
 	}()
 

--- a/pkg/block/engine/cold_read_demand_timeout_test.go
+++ b/pkg/block/engine/cold_read_demand_timeout_test.go
@@ -82,10 +82,9 @@ func TestColdRead_DemandFetchFailsFastWhenRemoteStalls(t *testing.T) {
 	m.config.PrefetchBlocks = 0                          // isolate the demand loop
 	m.config.DemandFetchTimeout = 200 * time.Millisecond // short fail-fast budget under test
 
-	dest := make([]byte, 4096)
 	done := make(chan error, 1)
 	go func() {
-		err := m.EnsureAvailableAndRead(ctx, "p", 0, uint32(len(dest)), dest)
+		err := m.EnsureAvailableAndRead(ctx, "p", 0, 4096)
 		done <- err
 	}()
 

--- a/pkg/block/engine/cold_read_demand_timeout_test.go
+++ b/pkg/block/engine/cold_read_demand_timeout_test.go
@@ -49,7 +49,7 @@ var (
 // TestNewSyncer_DefaultsDemandFetchTimeout guards against the bound being dead
 // in production: a config that leaves DemandFetchTimeout unset (every path that
 // does not thread the field, e.g. pkg/config) must still get the default, or
-// EnsureAvailableAndRead would run unbounded and the hang would return.
+// EnsureAvailable would run unbounded and the hang would return.
 func TestNewSyncer_DefaultsDemandFetchTimeout(t *testing.T) {
 	fbs := newStubFileChunkStore()
 	m := NewSyncer(memorylocal.New(), remotememory.New(), fbs, SyncerConfig{})
@@ -62,7 +62,7 @@ func TestNewSyncer_DefaultsDemandFetchTimeout(t *testing.T) {
 // TestColdRead_DemandFetchFailsFastWhenRemoteStalls pins the fix for the
 // client-visible hang: a demand cold read must not block indefinitely on a
 // stalled remote just because the caller's context carries no sub-deadline.
-// EnsureAvailableAndRead bounds its own hydration to DemandFetchTimeout and
+// EnsureAvailable bounds its own hydration to DemandFetchTimeout and
 // surfaces ErrRemoteUnavailable when that budget is exceeded, so the protocol
 // layer returns a fast error instead of the mount wedging. Before the fix the
 // demand fan-out ran on the caller's unbounded context, so with a background
@@ -84,7 +84,7 @@ func TestColdRead_DemandFetchFailsFastWhenRemoteStalls(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		err := m.EnsureAvailableAndRead(ctx, "p", 0, 4096)
+		err := m.EnsureAvailable(ctx, "p", 0, 4096)
 		done <- err
 	}()
 

--- a/pkg/block/engine/cold_read_hole_test.go
+++ b/pkg/block/engine/cold_read_hole_test.go
@@ -100,8 +100,7 @@ func TestEnsureAvailableAndRead_ChunkAfterHoleIsFetched(t *testing.T) {
 
 			m := newFetchSyncer(loc, rs, tc.wrap(stub), mds)
 
-			dest := make([]byte, readLength)
-			if err := m.EnsureAvailableAndRead(ctx, payloadID, 0, readLength, dest); err != nil {
+			if err := m.EnsureAvailableAndRead(ctx, payloadID, 0, readLength); err != nil {
 				t.Fatalf("EnsureAvailableAndRead: %v", err)
 			}
 

--- a/pkg/block/engine/cold_read_hole_test.go
+++ b/pkg/block/engine/cold_read_hole_test.go
@@ -54,7 +54,7 @@ func (s *indexedChunkStore) GetFileChunkAtOrAfterOffset(ctx context.Context, pay
 	return best, nil
 }
 
-// TestEnsureAvailableAndRead_ChunkAfterHoleIsFetched pins the sparse-hole step
+// TestEnsureAvailable_ChunkAfterHoleIsFetched pins the sparse-hole step
 // in the per-window fetch loop. The payload is a hole over [0, 1 MiB) with a
 // real remote-resident chunk at [1 MiB, 3 MiB) — both inside the first 8 MiB
 // block, which is the routine shape because FastCDC chunks average well under
@@ -68,7 +68,7 @@ func (s *indexedChunkStore) GetFileChunkAtOrAfterOffset(ctx context.Context, pay
 //
 // Both store shapes are exercised because they resolve the successor by
 // different means — an offset index versus a manifest walk.
-func TestEnsureAvailableAndRead_ChunkAfterHoleIsFetched(t *testing.T) {
+func TestEnsureAvailable_ChunkAfterHoleIsFetched(t *testing.T) {
 	const (
 		oneMiB     = 1024 * 1024
 		holeEnd    = 1 * oneMiB
@@ -100,8 +100,8 @@ func TestEnsureAvailableAndRead_ChunkAfterHoleIsFetched(t *testing.T) {
 
 			m := newFetchSyncer(loc, rs, tc.wrap(stub), mds)
 
-			if err := m.EnsureAvailableAndRead(ctx, payloadID, 0, readLength); err != nil {
-				t.Fatalf("EnsureAvailableAndRead: %v", err)
+			if err := m.EnsureAvailable(ctx, payloadID, 0, readLength); err != nil {
+				t.Fatalf("EnsureAvailable: %v", err)
 			}
 
 			// Poison the destination so an unhydrated range fails instead of hiding in zeros.

--- a/pkg/block/engine/cold_read_hole_test.go
+++ b/pkg/block/engine/cold_read_hole_test.go
@@ -101,7 +101,7 @@ func TestEnsureAvailableAndRead_ChunkAfterHoleIsFetched(t *testing.T) {
 			m := newFetchSyncer(loc, rs, tc.wrap(stub), mds)
 
 			dest := make([]byte, readLength)
-			if _, err := m.EnsureAvailableAndRead(ctx, payloadID, 0, readLength, dest); err != nil {
+			if err := m.EnsureAvailableAndRead(ctx, payloadID, 0, readLength, dest); err != nil {
 				t.Fatalf("EnsureAvailableAndRead: %v", err)
 			}
 

--- a/pkg/block/engine/cold_read_overlap_test.go
+++ b/pkg/block/engine/cold_read_overlap_test.go
@@ -77,7 +77,7 @@ func TestEnsureAvailableAndRead_StraddlerDoesNotShadowLaterRow(t *testing.T) {
 					end = laterEnd
 				}
 				dest := make([]byte, end-straddlerOff)
-				if _, err := m.EnsureAvailableAndRead(ctx, payloadID, straddlerOff, uint32(len(dest)), dest); err != nil {
+				if err := m.EnsureAvailableAndRead(ctx, payloadID, straddlerOff, uint32(len(dest)), dest); err != nil {
 					t.Fatalf("EnsureAvailableAndRead: %v", err)
 				}
 

--- a/pkg/block/engine/cold_read_overlap_test.go
+++ b/pkg/block/engine/cold_read_overlap_test.go
@@ -76,8 +76,7 @@ func TestEnsureAvailableAndRead_StraddlerDoesNotShadowLaterRow(t *testing.T) {
 				if laterEnd > end {
 					end = laterEnd
 				}
-				dest := make([]byte, end-straddlerOff)
-				if err := m.EnsureAvailableAndRead(ctx, payloadID, straddlerOff, uint32(len(dest)), dest); err != nil {
+				if err := m.EnsureAvailableAndRead(ctx, payloadID, straddlerOff, uint32(end-straddlerOff)); err != nil {
 					t.Fatalf("EnsureAvailableAndRead: %v", err)
 				}
 

--- a/pkg/block/engine/cold_read_overlap_test.go
+++ b/pkg/block/engine/cold_read_overlap_test.go
@@ -10,7 +10,7 @@ import (
 	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
 )
 
-// TestEnsureAvailableAndRead_StraddlerDoesNotShadowLaterRow pins what a cold
+// TestEnsureAvailable_StraddlerDoesNotShadowLaterRow pins what a cold
 // read does with two manifest rows that overlap.
 //
 // Coverage resolves an overlap to the greatest start, so from a later row's
@@ -35,7 +35,7 @@ import (
 //
 // Both store shapes are exercised because they resolve coverage and succession
 // by different means — an offset index versus a manifest walk.
-func TestEnsureAvailableAndRead_StraddlerDoesNotShadowLaterRow(t *testing.T) {
+func TestEnsureAvailable_StraddlerDoesNotShadowLaterRow(t *testing.T) {
 	const oneMiB = 1024 * 1024
 
 	for _, shape := range []struct {
@@ -76,8 +76,8 @@ func TestEnsureAvailableAndRead_StraddlerDoesNotShadowLaterRow(t *testing.T) {
 				if laterEnd > end {
 					end = laterEnd
 				}
-				if err := m.EnsureAvailableAndRead(ctx, payloadID, straddlerOff, uint32(end-straddlerOff)); err != nil {
-					t.Fatalf("EnsureAvailableAndRead: %v", err)
+				if err := m.EnsureAvailable(ctx, payloadID, straddlerOff, uint32(end-straddlerOff)); err != nil {
+					t.Fatalf("EnsureAvailable: %v", err)
 				}
 
 				// The straddler's bytes are expected everywhere it is still the

--- a/pkg/block/engine/cold_read_overwrite_test.go
+++ b/pkg/block/engine/cold_read_overwrite_test.go
@@ -17,7 +17,7 @@ import (
 // file, carve re-chunks ONLY the dirty sub-range and never reaps the superseded
 // FileChunk rows. The per-file FileChunk manifest is the SOLE resolver for cold
 // (evicted) reads — an evicted interval carries no remote locator, so
-// EnsureAvailableAndRead / GetFileChunkAtOffset must find a covering row. So a
+// EnsureAvailable / GetFileChunkAtOffset must find a covering row. So a
 // manifest that no longer tiles [0, fileSize) exactly is silent data corruption:
 //
 //   - a GAP  → cold read of the uncovered range returns zero-fill (shrink case)

--- a/pkg/block/engine/cold_read_subblock_test.go
+++ b/pkg/block/engine/cold_read_subblock_test.go
@@ -17,7 +17,7 @@ import (
 // chunks. After DrainLocalSynced evicts the local tier, the whole file is read
 // back in 1 MiB windows (SMB's max-read shape).
 //
-// Before the fix, EnsureAvailableAndRead iterated 8 MiB block indices and
+// Before the fix, EnsureAvailable iterated 8 MiB block indices and
 // resolved only the chunk covering blockIdx*BlockSize, so every read window
 // past a block's first chunk was never fetched — served as zeros/stale bytes
 // (and only the block-aligned chunks were staged locally). SMB exercises this

--- a/pkg/block/engine/cold_read_subblock_test.go
+++ b/pkg/block/engine/cold_read_subblock_test.go
@@ -63,7 +63,7 @@ func TestColdReadIntegrity_SubBlockChunks(t *testing.T) {
 			buf[j] = 0xAA // poison so an unfilled window fails instead of hiding in zeros
 		}
 		off := uint64(i) * oneMiB
-		n, err := bs.ReadAt(ctx, pid, nil, buf, off)
+		n, err := bs.ReadAt(ctx, pid, buf, off)
 		if err != nil {
 			t.Fatalf("ReadAt off=%d: %v", off, err)
 		}

--- a/pkg/block/engine/coordinator.go
+++ b/pkg/block/engine/coordinator.go
@@ -34,11 +34,6 @@ type MetadataCoordinator interface {
 	// (under the caller's metadata txn).
 	IncrementRefCount(ctx context.Context, hash block.ContentHash) error
 
-	// DecrementRefCount atomically decrements; returns the new count.
-	// Engine invokes this from dedup/rollback bookkeeping. Plain decrement
-	// — the FileChunk index row survives at RefCount 0.
-	DecrementRefCount(ctx context.Context, hash block.ContentHash) (uint32, error)
-
 	// DecrementRefCountAndReap atomically decrements and, when the new count
 	// is 0, deletes the FileChunk index row identified by the exact block ID
 	// "{payloadID}/{offset}" so its hash leaves EnumerateFileChunks once no

--- a/pkg/block/engine/coordinator_test.go
+++ b/pkg/block/engine/coordinator_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/block"
 )
 
-// fakeCoordinator records every IncrementRefCount/DecrementRefCount/
+// fakeCoordinator records every IncrementRefCount/DecrementRefCountAndReap/
 // PersistFileChunks/FindByObjectID call so engine tests can assert what
 // the engine invoked (and with what arguments) without coupling to the
 // real metadata-store wiring.
@@ -18,7 +18,6 @@ type fakeCoordinator struct {
 	mu sync.Mutex
 
 	incHashes    []block.ContentHash
-	decHashes    []block.ContentHash
 	reapIDs      []string
 	persistCalls []persistRecord
 
@@ -107,21 +106,10 @@ func (f *fakeCoordinator) IncrementRefCount(_ context.Context, hash block.Conten
 
 // errInducedDecrement is a sentinel returned by failOnNthDecrement so
 // tests can assert errors.Is on the rollback path.
-var errInducedDecrement = errors.New("fakeCoordinator: induced DecrementRefCount failure")
-
-func (f *fakeCoordinator) DecrementRefCount(_ context.Context, hash block.ContentHash) (uint32, error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.decCallCount++
-	if f.failOnNthDecrement > 0 && f.decCallCount == f.failOnNthDecrement {
-		return 0, errInducedDecrement
-	}
-	f.decHashes = append(f.decHashes, hash)
-	return 0, nil
-}
+var errInducedDecrement = errors.New("fakeCoordinator: induced decrement failure")
 
 // DecrementRefCountAndReap records reap-path invocations (engine Delete /
-// Truncate reclaim) separately from plain DecrementRefCount (dedup / rollback
+// Truncate reclaim) separately from the increment path (dedup / rollback
 // bookkeeping) so tests can assert which path the engine took. The reap path is
 // keyed by EXACT ID "{payloadID}/{offset}" (never by hash), so the recorded
 // reapIDs reflect the unambiguous per-file row identity. Honours the same
@@ -217,7 +205,7 @@ func TestMetadataCoordinator_NilTolerated(t *testing.T) {
 // TestMetadataCoordinator_AcceptsFakeCoordinator asserts that a *Store
 // can be constructed with a non-nil coordinator and that the field is
 // stored verbatim. Full integration assertions (the engine actually
-// invoking IncrementRefCount/DecrementRefCount/PersistFileChunks during
+// invoking IncrementRefCount/DecrementRefCountAndReap/PersistFileChunks during
 // CopyPayload/Delete/Truncate/syncer-post-Flush) live in Task 2 tests.
 func TestMetadataCoordinator_AcceptsFakeCoordinator(t *testing.T) {
 	fc := &fakeCoordinator{}
@@ -238,12 +226,11 @@ func TestMetadataCoordinator_FakeImpl_RecordsCalls(t *testing.T) {
 	ctx := context.Background()
 
 	h1 := block.ContentHash{0xAA}
-	h2 := block.ContentHash{0xBB}
 
 	if err := fc.IncrementRefCount(ctx, h1); err != nil {
 		t.Fatalf("Increment: %v", err)
 	}
-	if _, err := fc.DecrementRefCount(ctx, h2); err != nil {
+	if _, err := fc.DecrementRefCountAndReap(ctx, "pid", 0); err != nil {
 		t.Fatalf("Decrement: %v", err)
 	}
 	if err := fc.PersistFileChunks(ctx, "pid", []block.ChunkRef{{Hash: h1, Offset: 0, Size: 1}}, block.ObjectID{}); err != nil {
@@ -253,8 +240,8 @@ func TestMetadataCoordinator_FakeImpl_RecordsCalls(t *testing.T) {
 	if len(fc.incHashes) != 1 || fc.incHashes[0] != h1 {
 		t.Errorf("incHashes=%v, want [h1]", fc.incHashes)
 	}
-	if len(fc.decHashes) != 1 || fc.decHashes[0] != h2 {
-		t.Errorf("decHashes=%v, want [h2]", fc.decHashes)
+	if len(fc.reapIDs) != 1 || fc.reapIDs[0] != "pid/0" {
+		t.Errorf("reapIDs=%v, want [pid/0]", fc.reapIDs)
 	}
 	if len(fc.persistCalls) != 1 || fc.persistCalls[0].payloadID != "pid" {
 		t.Errorf("persistCalls=%v, want one call with pid", fc.persistCalls)

--- a/pkg/block/engine/copychunk_sparse_dest_test.go
+++ b/pkg/block/engine/copychunk_sparse_dest_test.go
@@ -37,7 +37,7 @@ func TestWriteAt_SparseDest_ReadsLeadingGapAsZeros(t *testing.T) {
 	// The Samba test reads exactly [0, 4096) — entirely inside the hole —
 	// and asserts all-zeros with STATUS_OK.
 	hole := make([]byte, 4096)
-	n, err := bs.ReadAt(ctx, payloadID, nil, hole, 0)
+	n, err := bs.ReadAt(ctx, payloadID, hole, 0)
 	if err != nil {
 		t.Fatalf("ReadAt [0,4096): %v", err)
 	}
@@ -52,7 +52,7 @@ func TestWriteAt_SparseDest_ReadsLeadingGapAsZeros(t *testing.T) {
 
 	// And the copied region [4096, 8192) must equal the written pattern.
 	copied := make([]byte, 4096)
-	if _, err := bs.ReadAt(ctx, payloadID, nil, copied, 4096); err != nil {
+	if _, err := bs.ReadAt(ctx, payloadID, copied, 4096); err != nil {
 		t.Fatalf("ReadAt [4096,8192): %v", err)
 	}
 	if !bytes.Equal(copied, pattern) {

--- a/pkg/block/engine/drain_persist_test.go
+++ b/pkg/block/engine/drain_persist_test.go
@@ -39,17 +39,6 @@ func (c *testCoordinator) IncrementRefCount(ctx context.Context, hash block.Cont
 	return c.store.IncrementRefCount(ctx, fb.ID)
 }
 
-func (c *testCoordinator) DecrementRefCount(ctx context.Context, hash block.ContentHash) (uint32, error) {
-	fb, err := c.store.GetByHash(ctx, hash)
-	if err != nil {
-		return 0, err
-	}
-	if fb == nil {
-		return 0, nil
-	}
-	return c.store.DecrementRefCount(ctx, fb.ID)
-}
-
 func (c *testCoordinator) DecrementRefCountAndReap(ctx context.Context, payloadID string, offset uint64) (uint32, error) {
 	// By EXACT ID — mirrors the production coordinator (no hash resolution).
 	id := fmt.Sprintf("%s/%d", payloadID, offset)

--- a/pkg/block/engine/engine.go
+++ b/pkg/block/engine/engine.go
@@ -434,15 +434,6 @@ func (bs *Store) SetMetrics(rec local.MetricsRecorder) {
 	}
 }
 
-// --- Test helpers ---
-
-// LocalForTest returns the engine's underlying local store as the
-// local.LocalStore interface. Used by cross-package test fixtures
-// (e.g. internal/adapter/common) that need to drive rollup or other
-// admin paths against the concrete *fs.FSStore via a type assertion.
-// Do not use in production code.
-func (bs *Store) LocalForTest() local.LocalStore { return bs.local }
-
 // Local returns the engine's underlying local store (the journal-backed tier),
 // or nil if the store has no local tier. Used by share startup to reconcile
 // metadata file sizes against the journal's durable high-water mark (#1687).

--- a/pkg/block/engine/engine_delete_test.go
+++ b/pkg/block/engine/engine_delete_test.go
@@ -58,25 +58,6 @@ func (c *refcountCoordinator) IncrementRefCount(_ context.Context, hash block.Co
 	return nil
 }
 
-func (c *refcountCoordinator) DecrementRefCount(_ context.Context, hash block.ContentHash) (uint32, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.decrementErr != nil && c.decrementErrHash == hash {
-		err := c.decrementErr
-		c.decrementErr = nil
-		return 0, err
-	}
-	cur := c.counts[hash]
-	if cur == 0 {
-		// Treat as already-zero; mirrors backend semantics where
-		// underflow is clamped.
-		return 0, nil
-	}
-	cur--
-	c.counts[hash] = cur
-	return cur, nil
-}
-
 // DecrementRefCountAndReap is keyed by EXACT ID "{payloadID}/{offset}" (the
 // production reap-path contract). It resolves the ID to the hash it bookkeeps,
 // then mirrors DecrementRefCount (including the single-shot error injection) and

--- a/pkg/block/engine/engine_test.go
+++ b/pkg/block/engine/engine_test.go
@@ -193,7 +193,7 @@ func TestReadAt_BasicRoundtrip(t *testing.T) {
 	}
 
 	buf := make([]byte, len(data))
-	n, err := bs.ReadAt(ctx, payloadID, nil, buf, 0)
+	n, err := bs.ReadAt(ctx, payloadID, buf, 0)
 	if err != nil {
 		t.Fatalf("ReadAt failed: %v", err)
 	}
@@ -220,7 +220,7 @@ func TestReadAt_CacheDisabled(t *testing.T) {
 	}
 
 	buf := make([]byte, len(data))
-	n, err := bs.ReadAt(ctx, payloadID, nil, buf, 0)
+	n, err := bs.ReadAt(ctx, payloadID, buf, 0)
 	if err != nil {
 		t.Fatalf("ReadAt failed: %v", err)
 	}
@@ -258,12 +258,8 @@ func TestReadAt_DoesNotInvokeCacheOnReadPath(t *testing.T) {
 	rec := &recordingCache{}
 	bs.cache = rec
 
-	// A non-empty []ChunkRef used to force the old OnRead hint; it is now ignored.
-	refs := []block.ChunkRef{
-		{Hash: hashN(0xAA), Offset: 0, Size: uint32(len(data))},
-	}
 	buf := make([]byte, len(data))
-	if _, err := bs.ReadAt(ctx, payloadID, refs, buf, 0); err != nil {
+	if _, err := bs.ReadAt(ctx, payloadID, buf, 0); err != nil {
 		t.Fatalf("ReadAt failed: %v", err)
 	}
 	if !bytes.Equal(buf, data) {
@@ -298,7 +294,7 @@ func TestEngine_NullCache_NoNilChecks(t *testing.T) {
 		t.Fatalf("WriteAt panicked or errored: %v", err)
 	}
 	buf := make([]byte, len(data))
-	if _, err := bs.ReadAt(ctx, payloadID, nil, buf, 0); err != nil {
+	if _, err := bs.ReadAt(ctx, payloadID, buf, 0); err != nil {
 		t.Fatalf("ReadAt panicked or errored: %v", err)
 	}
 	if _, err := bs.Truncate(ctx, payloadID, nil, uint64(len(data))); err != nil {

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -457,10 +457,10 @@ func blockRange(offset uint64, length uint32) (start, end uint64) {
 	return offset / uint64(BlockSize), (offset + uint64(length) - 1) / uint64(BlockSize)
 }
 
-// EnsureAvailableAndRead hydrates the local tier for [offset, offset+length) so
+// EnsureAvailable hydrates the local tier for [offset, offset+length) so
 // the caller's subsequent local read is served warm. Demanded chunks are
 // downloaded inline in the caller's goroutine; prefetch uses the worker pool.
-func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, offset uint64, length uint32) error {
+func (m *Syncer) EnsureAvailable(ctx context.Context, payloadID string, offset uint64, length uint32) error {
 	if length == 0 {
 		return nil
 	}
@@ -492,7 +492,7 @@ func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, o
 	// Health gate: fail fast when remote is unreachable
 	if !m.IsRemoteHealthy() {
 		m.offlineReadsBlocked.Add(1)
-		m.logOfflineRead("EnsureAvailableAndRead", payloadID, offset/uint64(BlockSize))
+		m.logOfflineRead("EnsureAvailable", payloadID, offset/uint64(BlockSize))
 		return m.remoteUnavailableError()
 	}
 
@@ -548,7 +548,7 @@ func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, o
 		// rather than a generic read failure; anything else is returned unchanged.
 		if fetchCtx.Err() != nil && ctx.Err() == nil {
 			m.offlineReadsBlocked.Add(1)
-			m.logOfflineRead("EnsureAvailableAndRead", payloadID, offset/uint64(BlockSize))
+			m.logOfflineRead("EnsureAvailable", payloadID, offset/uint64(BlockSize))
 			return m.remoteUnavailableError()
 		}
 		return err
@@ -616,7 +616,7 @@ func (m *Syncer) inlineFetchOrWait(ctx context.Context, payloadID string, blockI
 		return nil, true, nil
 	}
 
-	// Caller (EnsureAvailableAndRead) already verified remoteStore != nil.
+	// Caller (EnsureAvailable) already verified remoteStore != nil.
 	// CAS verified-read dispatch — legacy branch has been removed.
 	storeKey, data, err := m.dispatchRemoteFetch(ctx, fb)
 	if err != nil {

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -460,7 +460,7 @@ func blockRange(offset uint64, length uint32) (start, end uint64) {
 // EnsureAvailableAndRead hydrates the local tier for [offset, offset+length) so
 // the caller's subsequent local read is served warm. Demanded chunks are
 // downloaded inline in the caller's goroutine; prefetch uses the worker pool.
-func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, offset uint64, length uint32, dest []byte) error {
+func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, offset uint64, length uint32) error {
 	if length == 0 {
 		return nil
 	}
@@ -502,8 +502,8 @@ func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, o
 	// wall. fetchGroup bounds the fan-out by ParallelDownloads; inlineFetchOrWait
 	// stages each chunk into the local tier and dedups concurrent callers (now
 	// keyed per chunk), so the fan-out is race-free and the first error cancels
-	// the rest via gctx. We deliberately do NOT copy to dest here: a chunk can
-	// start mid-window, so a block-relative copy is wrong — the caller's
+	// the rest via gctx. Hydration never fills the caller's buffer: a chunk can
+	// start mid-window, so a block-relative copy would be wrong — the caller's
 	// readLocalByHash does the correct per-offset assembly from the now-local
 	// chunks. The extra local pass is cheap next to the S3 GETs just eliminated.
 	//

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -457,18 +457,18 @@ func blockRange(offset uint64, length uint32) (start, end uint64) {
 	return offset / uint64(BlockSize), (offset + uint64(length) - 1) / uint64(BlockSize)
 }
 
-// EnsureAvailableAndRead downloads blocks and copies data directly to dest, avoiding
-// a second local ReadAt. Demanded blocks are downloaded inline in the caller's goroutine
-// prefetch uses the worker pool. Returns (filled, error).
-func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, offset uint64, length uint32, dest []byte) (bool, error) {
+// EnsureAvailableAndRead hydrates the local tier for [offset, offset+length) so
+// the caller's subsequent local read is served warm. Demanded chunks are
+// downloaded inline in the caller's goroutine; prefetch uses the worker pool.
+func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, offset uint64, length uint32, dest []byte) error {
 	if length == 0 {
-		return false, nil
+		return nil
 	}
 	if !m.canProcess(ctx) {
-		return false, ErrClosed
+		return ErrClosed
 	}
 	if m.remoteStore == nil {
-		return false, nil // Local-only: all data must be in local store, no downloads possible
+		return nil // Local-only: all data must be in local store, no downloads possible
 	}
 
 	end := offset + uint64(length)
@@ -482,18 +482,18 @@ func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, o
 	// already-warm sub-range.
 	toFetch, err := m.collectCoveringChunks(ctx, payloadID, offset, end)
 	if err != nil {
-		return false, err
+		return err
 	}
 	if len(toFetch) == 0 {
 		// Nothing to fetch (pure hole) — the caller re-reads and zero-fills.
-		return false, nil
+		return nil
 	}
 
 	// Health gate: fail fast when remote is unreachable
 	if !m.IsRemoteHealthy() {
 		m.offlineReadsBlocked.Add(1)
 		m.logOfflineRead("EnsureAvailableAndRead", payloadID, offset/uint64(BlockSize))
-		return false, m.remoteUnavailableError()
+		return m.remoteUnavailableError()
 	}
 
 	// Download the missing chunks concurrently rather than one S3 round-trip at
@@ -549,14 +549,14 @@ func (m *Syncer) EnsureAvailableAndRead(ctx context.Context, payloadID string, o
 		if fetchCtx.Err() != nil && ctx.Err() == nil {
 			m.offlineReadsBlocked.Add(1)
 			m.logOfflineRead("EnsureAvailableAndRead", payloadID, offset/uint64(BlockSize))
-			return false, m.remoteUnavailableError()
+			return m.remoteUnavailableError()
 		}
-		return false, err
+		return err
 	}
 
 	// Bytes are now local (or genuinely sparse); the caller re-reads via
 	// readLocalByHash for the correct assembly.
-	return false, nil
+	return nil
 }
 
 // inlineFetchOrWait downloads a block inline or waits for an in-flight download.

--- a/pkg/block/engine/fetch_window_test.go
+++ b/pkg/block/engine/fetch_window_test.go
@@ -118,7 +118,7 @@ func (alwaysColdLocal) ReadAt(_ context.Context, _ string, _ int64, dst []byte) 
 func TestReadAtInternal_StillColdAfterHydrateFailsClosed(t *testing.T) {
 	ctx := context.Background()
 
-	// No remote: EnsureAvailableAndRead returns without hydrating anything, so
+	// No remote: EnsureAvailable returns without hydrating anything, so
 	// the window is still cold on the re-read.
 	bs := &Store{
 		local:  alwaysColdLocal{},

--- a/pkg/block/engine/gc.go
+++ b/pkg/block/engine/gc.go
@@ -158,16 +158,6 @@ type GCStats struct {
 
 	// Legacy aggregator fields (compat aliases — see finalizeStats).
 
-	// Deprecated: SharesScanned is retained on the REST/dfsctl wire for
-	// compatibility with older clients but is never populated by the
-	// mark-sweep engine and will always be zero. New consumers should
-	// rely on HashesMarked / the per-share log lines instead.
-	SharesScanned int
-	// Deprecated: BlocksScanned is retained on the REST/dfsctl wire for
-	// compatibility with older clients but is never populated by the
-	// mark-sweep engine and will always be zero. New consumers should
-	// rely on ObjectsSwept / HashesMarked instead.
-	BlocksScanned  int
 	OrphanFiles    int   // = ObjectsSwept.
 	OrphanBlocks   int   // = ObjectsSwept.
 	BytesReclaimed int64 // = BytesFreed.
@@ -178,11 +168,6 @@ type GCStats struct {
 type Options struct {
 	// DryRun if true, only reports orphans without deleting.
 	DryRun bool
-
-	// MaxOrphansPerShare is preserved for API compatibility but has no
-	// effect in the mark-sweep algorithm — the sweep runs to completion.
-	// A future plan can repurpose this if a cap becomes useful.
-	MaxOrphansPerShare int
 
 	// ProgressCallback is called periodically with progress updates.
 	// May be nil. Invoked once per completed sweep pass.

--- a/pkg/block/engine/gc_test.go
+++ b/pkg/block/engine/gc_test.go
@@ -318,14 +318,6 @@ func (c *reapCoordinator) IncrementRefCount(ctx context.Context, hash block.Cont
 	return c.store.IncrementRefCount(ctx, fb.ID)
 }
 
-func (c *reapCoordinator) DecrementRefCount(ctx context.Context, hash block.ContentHash) (uint32, error) {
-	fb, err := c.store.GetByHash(ctx, hash)
-	if err != nil || fb == nil {
-		return 0, err
-	}
-	return c.store.DecrementRefCount(ctx, fb.ID)
-}
-
 func (c *reapCoordinator) DecrementRefCountAndReap(ctx context.Context, payloadID string, offset uint64) (uint32, error) {
 	// Mirrors the production coordinator: reap by EXACT ID — no hash resolution.
 	// The engine rollup creates per-chunk rows keyed "{payloadID}/{offset}" in

--- a/pkg/block/engine/hydrate_extent_test.go
+++ b/pkg/block/engine/hydrate_extent_test.go
@@ -29,9 +29,9 @@ func hydrateFixture(t *testing.T, share, name string) (*engine.Store, *fs.FSStor
 	bs := newEngineWithRemote(t, ms, remotememory.New())
 	root := createShare(t, ms, share)
 	pid, _ := createRealFile(t, ms, share, name, root)
-	local, ok := bs.LocalForTest().(*fs.FSStore)
+	local, ok := bs.Local().(*fs.FSStore)
 	if !ok {
-		t.Fatalf("local tier is %T, not the journal-backed store the eviction path needs", bs.LocalForTest())
+		t.Fatalf("local tier is %T, not the journal-backed store the eviction path needs", bs.Local())
 	}
 	return bs, local, ms, pid
 }
@@ -75,10 +75,10 @@ func evictAll(t *testing.T, local *fs.FSStore) {
 	}
 }
 
-func readAt(t *testing.T, bs *engine.Store, pid string, refs []block.ChunkRef, off uint64, n int) []byte {
+func readAt(t *testing.T, bs *engine.Store, pid string, off uint64, n int) []byte {
 	t.Helper()
 	buf := make([]byte, n)
-	if _, err := bs.ReadAt(context.Background(), pid, refs, buf, off); err != nil {
+	if _, err := bs.ReadAt(context.Background(), pid, buf, off); err != nil {
 		t.Fatalf("ReadAt at %d: %v", off, err)
 	}
 	return buf
@@ -121,8 +121,7 @@ func TestColdReadAfterTruncate_KeepsRemovedTailZeroed(t *testing.T) {
 	}
 	newSize := last.Offset + uint64(last.Size)/2
 
-	kept, err := bs.Truncate(ctx, pid, refs, newSize)
-	if err != nil {
+	if _, err := bs.Truncate(ctx, pid, refs, newSize); err != nil {
 		t.Fatalf("Truncate: %v", err)
 	}
 	for _, r := range manifestRefs(t, ms, pid) {
@@ -135,7 +134,7 @@ func TestColdReadAfterTruncate_KeepsRemovedTailZeroed(t *testing.T) {
 
 	// Cold read of the surviving prefix: resolves the straddling row, fetches
 	// the whole chunk from the remote, and hydrates.
-	got := readAt(t, bs, pid, kept, newSize-4096, 4096)
+	got := readAt(t, bs, pid, newSize-4096, 4096)
 	if !bytes.Equal(got, orig[newSize-4096:newSize]) {
 		t.Fatal("surviving prefix did not read back after the cold read")
 	}
@@ -148,8 +147,8 @@ func TestColdReadAfterTruncate_KeepsRemovedTailZeroed(t *testing.T) {
 	}
 	refs = manifestRefs(t, ms, pid)
 
-	assertZeros(t, readAt(t, bs, pid, refs, newSize, holeLen), "re-extended hole")
-	if !bytes.Equal(readAt(t, bs, pid, refs, newSize+holeLen, 4096), tailData) {
+	assertZeros(t, readAt(t, bs, pid, newSize, holeLen), "re-extended hole")
+	if !bytes.Equal(readAt(t, bs, pid, newSize+holeLen, 4096), tailData) {
 		t.Fatal("re-extending write did not read back")
 	}
 }
@@ -190,12 +189,12 @@ func TestColdReadAfterPunchHole_KeepsHoleZeroed(t *testing.T) {
 
 	evictAll(t, local)
 
-	assertZeros(t, readAt(t, bs, pid, refs, holeOff, holeLen), "punched range")
+	assertZeros(t, readAt(t, bs, pid, holeOff, holeLen), "punched range")
 	// The bytes on either side of the hole are untouched and must still read.
-	if !bytes.Equal(readAt(t, bs, pid, refs, holeOff-4096, 4096), orig[holeOff-4096:holeOff]) {
+	if !bytes.Equal(readAt(t, bs, pid, holeOff-4096, 4096), orig[holeOff-4096:holeOff]) {
 		t.Fatal("bytes before the hole did not survive")
 	}
-	if !bytes.Equal(readAt(t, bs, pid, refs, holeOff+holeLen, 4096), orig[holeOff+holeLen:holeOff+holeLen+4096]) {
+	if !bytes.Equal(readAt(t, bs, pid, holeOff+holeLen, 4096), orig[holeOff+holeLen:holeOff+holeLen+4096]) {
 		t.Fatal("bytes after the hole did not survive")
 	}
 }
@@ -206,7 +205,7 @@ func TestColdReadAfterPunchHole_KeepsHoleZeroed(t *testing.T) {
 // untouched range in front of it has to keep reading as zeros.
 func TestColdReadSparseFile_HydratesAtHighOffset(t *testing.T) {
 	ctx := context.Background()
-	bs, local, ms, pid := hydrateFixture(t, "sparse", "sparse.bin")
+	bs, local, _, pid := hydrateFixture(t, "sparse", "sparse.bin")
 
 	const dataOff = 2 << 20
 	data := make([]byte, 256<<10)
@@ -216,13 +215,12 @@ func TestColdReadSparseFile_HydratesAtHighOffset(t *testing.T) {
 	}
 	carve(t, bs, ctx, pid)
 
-	refs := manifestRefs(t, ms, pid)
 	evictAll(t, local)
 
-	if got := readAt(t, bs, pid, refs, dataOff, len(data)); !bytes.Equal(got, data) {
+	if got := readAt(t, bs, pid, dataOff, len(data)); !bytes.Equal(got, data) {
 		t.Fatal("high-offset data did not hydrate back")
 	}
-	assertZeros(t, readAt(t, bs, pid, refs, 0, 4096), "leading hole")
-	assertZeros(t, readAt(t, bs, pid, refs, dataOff-4096, 4096), "hole in front of the data")
-	assertZeros(t, readAt(t, bs, pid, refs, dataOff+uint64(len(data)), 4096), "hole past the data")
+	assertZeros(t, readAt(t, bs, pid, 0, 4096), "leading hole")
+	assertZeros(t, readAt(t, bs, pid, dataOff-4096, 4096), "hole in front of the data")
+	assertZeros(t, readAt(t, bs, pid, dataOff+uint64(len(data)), 4096), "hole past the data")
 }

--- a/pkg/block/engine/hydrate_extent_test.go
+++ b/pkg/block/engine/hydrate_extent_test.go
@@ -145,8 +145,6 @@ func TestColdReadAfterTruncate_KeepsRemovedTailZeroed(t *testing.T) {
 	if _, err := bs.WriteAt(ctx, pid, nil, tailData, newSize+holeLen); err != nil {
 		t.Fatalf("re-extend WriteAt: %v", err)
 	}
-	refs = manifestRefs(t, ms, pid)
-
 	assertZeros(t, readAt(t, bs, pid, newSize, holeLen), "re-extended hole")
 	if !bytes.Equal(readAt(t, bs, pid, newSize+holeLen, 4096), tailData) {
 		t.Fatal("re-extending write did not read back")
@@ -179,7 +177,6 @@ func TestColdReadAfterPunchHole_KeepsHoleZeroed(t *testing.T) {
 	// The zeros land through the local write path, so they must be carved and
 	// uploaded before anything can be evicted.
 	carve(t, bs, ctx, pid)
-	refs = manifestRefs(t, ms, pid)
 
 	// Structural counterpart to the read assertions: the re-carved zeros
 	// supersede the punched rows, so nothing in the manifest still covers the

--- a/pkg/block/engine/legacy_migration.go
+++ b/pkg/block/engine/legacy_migration.go
@@ -99,7 +99,7 @@ func (m *Syncer) migrateLegacyCASRemote(ctx context.Context) error {
 	// The legacy accessor lives on the raw (unwrapped) remote stack — the same
 	// object SetRemoteBlockStore received — because the nonClosingRemote
 	// wrapper deliberately proxies only the RemoteStore surface.
-	legacy, hasLegacy := rbs.(remote.LegacyCASStore)
+	legacy, _ := rbs.(remote.LegacyCASStore)
 
 	// Phase R — collect every synced hash whose locator is still standalone.
 	// Hashes are collected first (32 B each; bounded by the synced set) so no
@@ -131,7 +131,7 @@ func (m *Syncer) migrateLegacyCASRemote(ctx context.Context) error {
 		logger.Warn("cas→blocks migration: re-packing standalone chunks — "+
 			"one-way, the previous release cannot read the result; snapshot the remote bucket before upgrading",
 			"chunks_total", len(standalone))
-		if err := m.repackStandaloneChunks(ctx, legacy, hasLegacy, sealer, committer, standalone); err != nil {
+		if err := m.repackStandaloneChunks(ctx, legacy, sealer, committer, standalone); err != nil {
 			return err
 		}
 		logger.Info("cas→blocks migration complete; the legacy cas/ objects stay until block GC reclaims them",
@@ -152,7 +152,6 @@ type migrationChunk struct {
 func (m *Syncer) repackStandaloneChunks(
 	ctx context.Context,
 	legacy remote.LegacyCASStore,
-	hasLegacy bool,
 	sealer remote.ChunkSealer,
 	committer blockCommitter,
 	standalone []block.ContentHash,
@@ -196,7 +195,7 @@ func (m *Syncer) repackStandaloneChunks(
 				"chunks_done", i, "chunks_total", len(standalone), "chunks_repacked", repacked,
 				"elapsed", time.Since(started).Round(time.Second))
 		}
-		data, err := m.migrationChunkBytes(ctx, legacy, hasLegacy, h)
+		data, err := m.migrationChunkBytes(ctx, legacy, h)
 		if err != nil {
 			if errors.Is(err, block.ErrChunkNotFound) {
 				// Pre-existing data loss: the marker points at an object that no
@@ -241,14 +240,13 @@ func (m *Syncer) repackStandaloneChunks(
 func (m *Syncer) migrationChunkBytes(
 	ctx context.Context,
 	legacy remote.LegacyCASStore,
-	hasLegacy bool,
 	h block.ContentHash,
 ) ([]byte, error) {
 	// The journal local tier is (payloadID,offset)-keyed, not hash-keyed, so
 	// there is no local-first read here: the migration reads standalone chunks
 	// straight from the legacy remote. Pre-flip local per-chunk files no longer
 	// exist under the journal store.
-	if !hasLegacy {
+	if legacy == nil {
 		return nil, fmt.Errorf("chunk %s: %w", h, block.ErrChunkNotFound)
 	}
 	return legacy.ReadLegacyChunkVerified(ctx, h)

--- a/pkg/block/engine/perf_bench_phase12_test.go
+++ b/pkg/block/engine/perf_bench_phase12_test.go
@@ -167,7 +167,6 @@ func newPerfTestEngine(tb testing.TB, readBufferBytes int64, prefetchWorkers int
 func BenchmarkRandRead_Phase12(b *testing.B) {
 	fixture := setupPerfFixture(b)
 	defer fixture.Close()
-	blocks := fixture.AllChunkRefs()
 	dest := make([]byte, phase12ReadSize)
 	rng := rand.New(rand.NewSource(phase12RandSeed)) //nolint:gosec // bench
 	ctx := context.Background()
@@ -179,7 +178,7 @@ func BenchmarkRandRead_Phase12(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		offset := uint64(rng.Intn(maxOffset))
-		if _, err := fixture.Store.ReadAt(ctx, fixture.PayloadID, blocks, dest, offset); err != nil {
+		if _, err := fixture.Store.ReadAt(ctx, fixture.PayloadID, dest, offset); err != nil {
 			b.Fatalf("ReadAt: %v", err)
 		}
 	}
@@ -212,7 +211,6 @@ func BenchmarkRandRead_Phase12(b *testing.B) {
 func BenchmarkPerfGate_Phase12RandReadRegression(b *testing.B) {
 	fixture := setupPerfFixture(b)
 	defer fixture.Close()
-	blocks := fixture.AllChunkRefs()
 	dest := make([]byte, phase12ReadSize)
 	rng := rand.New(rand.NewSource(phase12RandSeed)) //nolint:gosec // bench
 	ctx := context.Background()
@@ -224,7 +222,7 @@ func BenchmarkPerfGate_Phase12RandReadRegression(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		offset := uint64(rng.Intn(maxOffset))
-		if _, err := fixture.Store.ReadAt(ctx, fixture.PayloadID, blocks, dest, offset); err != nil {
+		if _, err := fixture.Store.ReadAt(ctx, fixture.PayloadID, dest, offset); err != nil {
 			b.Fatalf("ReadAt: %v", err)
 		}
 	}

--- a/pkg/block/engine/read_internal.go
+++ b/pkg/block/engine/read_internal.go
@@ -100,7 +100,7 @@ func (bs *Store) healCorruptWarmRead(ctx context.Context, payloadID string, data
 // never reaches here (readAtInternal returns early), and would report cold=false
 // regardless, so the guard has nothing to fail open on.
 func (bs *Store) ensureAndReadFromLocal(ctx context.Context, payloadID string, dest []byte, offset uint64) error {
-	if err := bs.syncer.EnsureAvailableAndRead(ctx, payloadID, offset, uint32(len(dest)), dest); err != nil {
+	if err := bs.syncer.EnsureAvailableAndRead(ctx, payloadID, offset, uint32(len(dest))); err != nil {
 		return fmt.Errorf("manifest reconcile for %s at offset %d failed: %w", payloadID, offset, err)
 	}
 	_, st, err := bs.local.ReadAt(ctx, payloadID, int64(offset), dest)

--- a/pkg/block/engine/read_internal.go
+++ b/pkg/block/engine/read_internal.go
@@ -100,7 +100,7 @@ func (bs *Store) healCorruptWarmRead(ctx context.Context, payloadID string, data
 // never reaches here (readAtInternal returns early), and would report cold=false
 // regardless, so the guard has nothing to fail open on.
 func (bs *Store) ensureAndReadFromLocal(ctx context.Context, payloadID string, dest []byte, offset uint64) error {
-	if _, err := bs.syncer.EnsureAvailableAndRead(ctx, payloadID, offset, uint32(len(dest)), dest); err != nil {
+	if err := bs.syncer.EnsureAvailableAndRead(ctx, payloadID, offset, uint32(len(dest)), dest); err != nil {
 		return fmt.Errorf("manifest reconcile for %s at offset %d failed: %w", payloadID, offset, err)
 	}
 	_, st, err := bs.local.ReadAt(ctx, payloadID, int64(offset), dest)

--- a/pkg/block/engine/read_internal.go
+++ b/pkg/block/engine/read_internal.go
@@ -83,7 +83,7 @@ func (bs *Store) healCorruptWarmRead(ctx context.Context, payloadID string, data
 }
 
 // ensureAndReadFromLocal hydrates every remote-resident chunk covering the
-// window into the local journal, then re-reads. EnsureAvailableAndRead resolves
+// window into the local journal, then re-reads. EnsureAvailable resolves
 // the covering FileChunk rows — refusing with ErrManifestInconsistent when an
 // uncovered offset sits on a payload holding an unplaceable row — does one
 // BLAKE3-verified ranged read per chunk, and Hydrates the plaintext at the
@@ -100,7 +100,7 @@ func (bs *Store) healCorruptWarmRead(ctx context.Context, payloadID string, data
 // never reaches here (readAtInternal returns early), and would report cold=false
 // regardless, so the guard has nothing to fail open on.
 func (bs *Store) ensureAndReadFromLocal(ctx context.Context, payloadID string, dest []byte, offset uint64) error {
-	if err := bs.syncer.EnsureAvailableAndRead(ctx, payloadID, offset, uint32(len(dest))); err != nil {
+	if err := bs.syncer.EnsureAvailable(ctx, payloadID, offset, uint32(len(dest))); err != nil {
 		return fmt.Errorf("manifest reconcile for %s at offset %d failed: %w", payloadID, offset, err)
 	}
 	_, st, err := bs.local.ReadAt(ctx, payloadID, int64(offset), dest)

--- a/pkg/block/engine/readahead.go
+++ b/pkg/block/engine/readahead.go
@@ -29,7 +29,7 @@ type raState struct {
 // should be scheduled.
 //
 // Unlike the old geometric planReadahead (which ramped 1->2->4 and only ran on
-// a local miss inside EnsureAvailableAndRead), this keeps a FULL fixed window of
+// a local miss inside EnsureAvailable), this keeps a FULL fixed window of
 // config.PrefetchBlocks blocks in flight ahead of the frontier and is driven on
 // EVERY read (local hits included) via scheduleReadahead. A sequential reader
 // serving from the local tier therefore keeps the window sliding forward instead
@@ -135,7 +135,7 @@ func (m *Syncer) scheduleReadahead(payloadID string, offset uint64, length uint3
 	}
 	// Best-effort enqueue: EnqueuePrefetch drops when the SyncQueue is saturated.
 	// A dropped block is NOT a window hole — the reader's own demand fetch
-	// (EnsureAvailableAndRead) still serves it, just without the prefetch head
+	// (EnsureAvailable) still serves it, just without the prefetch head
 	// start. We deliberately do NOT roll scheduledUpTo back on a drop: under a
 	// saturated queue, degrading prefetch to demand is the correct backpressure,
 	// and re-enqueue churn on every read would only deepen the saturation. The

--- a/pkg/block/engine/readahead_test.go
+++ b/pkg/block/engine/readahead_test.go
@@ -117,7 +117,7 @@ func drainPrefetch(q *SyncQueue) []uint64 {
 // probes whether a block is local. This is exactly what the two prior refuted
 // attempts lacked (they only advanced on a local MISS, so a sequential reader
 // serving from the local tier stalled). Fails on develop, where readahead was
-// driven from the on-miss path in EnsureAvailableAndRead.
+// driven from the on-miss path in EnsureAvailable.
 //
 // NOTE: a structural guard is necessary but NOT sufficient — the throughput win
 // must be confirmed by a real-VM cold-read A/B (see the design doc's method).

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -16,10 +16,9 @@ import (
 //
 // After a successful read the engine drives the offset-based readahead window
 // (Syncer.scheduleReadahead) so a sequential reader keeps the local read-serving
-// tier populated ahead of the read frontier. This fires on EVERY read — the
-// `blocks` argument is ignored here (the hot NFS/SMB path passes nil), so the
+// tier populated ahead of the read frontier. This fires on EVERY read; the
 // window is computed purely from offset+len(data).
-func (bs *Store) ReadAt(ctx context.Context, payloadID string, blocks []block.ChunkRef, data []byte, offset uint64) (int, error) {
+func (bs *Store) ReadAt(ctx context.Context, payloadID string, data []byte, offset uint64) (int, error) {
 	if err := bs.enter(); err != nil {
 		return 0, err
 	}
@@ -28,7 +27,6 @@ func (bs *Store) ReadAt(ctx context.Context, payloadID string, blocks []block.Ch
 	if err != nil {
 		return n, err
 	}
-	_ = blocks // opaque to the readahead driver; kept for interface symmetry
 	bs.syncer.scheduleReadahead(payloadID, offset, uint32(len(data)))
 	return n, nil
 }
@@ -614,10 +612,6 @@ func (bs *Store) CopyPayload(ctx context.Context, srcPayloadID, dstPayloadID str
 	// persists this as dst's FileAttr.Blocks in the same metadata txn, so the
 	// rows above and this manifest stay consistent (same hashes + offsets).
 	dst := append([]block.ChunkRef(nil), srcBlocks...)
-
-	// srcPayloadID is retained in the signature for future use (cache prefetch
-	// hints, identity-based dedup) and to match the public Writer interface.
-	_ = srcPayloadID
 
 	return dst, nil
 }

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -10,9 +10,8 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// ReadAt reads data from storage at the given offset into dest.
-// a non-nil/non-empty []ChunkRef carries the CAS hashes covering the
-// requested range (zero-filling sparse holes).
+// ReadAt reads data from storage at the given offset into dest, zero-filling
+// sparse holes.
 //
 // After a successful read the engine drives the offset-based readahead window
 // (Syncer.scheduleReadahead) so a sequential reader keeps the local read-serving

--- a/pkg/block/engine/unplaceable_row_read_test.go
+++ b/pkg/block/engine/unplaceable_row_read_test.go
@@ -91,7 +91,7 @@ func TestReadAt_UncoveredOffsetOnUnplaceableRowRefuses(t *testing.T) {
 			}
 
 			got := bytes.Repeat([]byte{0xAA}, 4096)
-			_, err := bs.ReadAt(ctx, payloadID, nil, got, 0)
+			_, err := bs.ReadAt(ctx, payloadID, got, 0)
 			if !errors.Is(err, block.ErrManifestInconsistent) {
 				t.Fatalf("ReadAt = %v; want ErrManifestInconsistent (served zeros: %v)",
 					err, bytes.Equal(got, make([]byte, 4096)))
@@ -117,7 +117,7 @@ func TestReadAt_CoveredOffsetIgnoresUnplaceableRow(t *testing.T) {
 			}
 
 			got := make([]byte, len(want))
-			if _, err := bs.ReadAt(ctx, payloadID, nil, got, 0); err != nil {
+			if _, err := bs.ReadAt(ctx, payloadID, got, 0); err != nil {
 				t.Fatalf("ReadAt over a covered offset: %v", err)
 			}
 			if !bytes.Equal(got, want) {
@@ -141,7 +141,7 @@ func TestReadAt_GenuineHoleStillZeroFills(t *testing.T) {
 			seedSyncedRemoteChunk(t, fbs, rs, shs, payloadID, 4096, bytes.Repeat([]byte{0x5A}, 4096))
 
 			got := bytes.Repeat([]byte{0xAA}, 4096)
-			n, err := bs.ReadAt(ctx, payloadID, nil, got, 0)
+			n, err := bs.ReadAt(ctx, payloadID, got, 0)
 			if err != nil {
 				t.Fatalf("ReadAt over a sparse hole: %v", err)
 			}

--- a/pkg/block/engine/warm_read_integrity_test.go
+++ b/pkg/block/engine/warm_read_integrity_test.go
@@ -143,7 +143,7 @@ func runWarmReadIntegrity(t *testing.T, ms metadata.Store) {
 		for i := range buf {
 			buf[i] = 0xAA // poison
 		}
-		n, err := bs.ReadAt(ctx, pid, nil, buf, off)
+		n, err := bs.ReadAt(ctx, pid, buf, off)
 		if err != nil {
 			fail("ReadAt off=%d len=%d: %v", off, len(buf), err)
 			return

--- a/pkg/block/engine/warm_read_selfheal_test.go
+++ b/pkg/block/engine/warm_read_selfheal_test.go
@@ -143,7 +143,7 @@ func TestWarmReadSelfHeal_RemoteHeals(t *testing.T) {
 	corruptSegmentByte(t, filepath.Join(dir, "journal"))
 
 	got := make([]byte, size)
-	n, err := bs.ReadAt(ctx, pid, nil, got, 0)
+	n, err := bs.ReadAt(ctx, pid, got, 0)
 	if err != nil {
 		t.Fatalf("ReadAt after corruption should self-heal, got: %v", err)
 	}
@@ -185,7 +185,7 @@ func TestWarmReadSelfHeal_LocalOnlyFailsClosed(t *testing.T) {
 	corruptSegmentByte(t, filepath.Join(dir, "journal"))
 
 	got := make([]byte, size)
-	_, err := bs.ReadAt(ctx, pid, nil, got, 0)
+	_, err := bs.ReadAt(ctx, pid, got, 0)
 	if err == nil {
 		t.Fatalf("local-only corrupt read must fail closed, got nil error")
 	}

--- a/pkg/block/engine/write_bench_test.go
+++ b/pkg/block/engine/write_bench_test.go
@@ -226,7 +226,7 @@ func BenchmarkMixedRW(b *testing.B) {
 			}
 			continue
 		}
-		if _, err := bs.ReadAt(ctx, pid, nil, rbuf, off); err != nil {
+		if _, err := bs.ReadAt(ctx, pid, rbuf, off); err != nil {
 			b.Fatalf("ReadAt i=%d: %v", i, err)
 		}
 	}

--- a/pkg/block/filechunk.go
+++ b/pkg/block/filechunk.go
@@ -168,15 +168,11 @@ type EngineFileChunkStore interface {
 
 // Reader defines read operations on the block store.
 //
-// read operations thread a caller-supplied
-// []ChunkRef snapshot of the file's FileAttr.Blocks. Empty/nil blocks
-// triggers the dual-read shim — engine routes through
-// the legacy {payloadID}/block-{N} resolver. Non-empty blocks routes
-// through the CAS path: findBlocksForRange + cache.OnRead.
+// Reads resolve the covering chunks from the store's own manifest, so no
+// caller-supplied []ChunkRef snapshot is threaded through the read path.
 type Reader interface {
 	// ReadAt reads data from storage at the given offset into dest.
-	// Empty blocks => dual-read shim (path).
-	ReadAt(ctx context.Context, payloadID string, blocks []ChunkRef, dest []byte, offset uint64) (int, error)
+	ReadAt(ctx context.Context, payloadID string, dest []byte, offset uint64) (int, error)
 
 	// GetSize returns the stored size of a payload.
 	GetSize(ctx context.Context, payloadID string) (uint64, error)

--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -104,6 +104,17 @@ func (s *Store) evict(ctx context.Context, targetBytes int64, allowActiveSeal bo
 	}
 }
 
+// sealableActive reports whether act can be force-sealed: it holds at least one
+// record, every record is synced (remote-durable), no other pass has claimed it,
+// and no live snapshot pins its bytes. records raises monotonically and
+// syncedRecords only rises toward it, so the fully-synced check is stable while
+// the caller holds the shard lock.
+func (s *Store) sealableActive(act *segmentMeta) bool {
+	return act != nil && act.records.Load() > 0 &&
+		act.syncedRecords.Load() == act.records.Load() &&
+		!act.busy.Load() && !s.pinned(act)
+}
+
 // sealSyncedActives force-seals each shard's active segment when it holds only
 // synced (remote-durable) records, moving it into the sealed set so eviction can
 // reclaim it. It never seals an empty active (nothing to gain, and a spin would
@@ -121,13 +132,7 @@ func (s *Store) sealSyncedActives(ctx context.Context) (bool, error) {
 			return sealedAny, err
 		}
 		sh.mu.Lock()
-		act := sh.active
-		// records is frozen while sh.mu is held (appends need it), and carve only
-		// ever raises syncedRecords toward records, so the fully-synced check is
-		// stable across the seal.
-		if act != nil && act.records.Load() > 0 &&
-			act.syncedRecords.Load() == act.records.Load() &&
-			!act.busy.Load() && !s.pinned(act) {
+		if s.sealableActive(sh.active) {
 			err := s.sealSegment(sh)
 			sh.mu.Unlock()
 			if err != nil {
@@ -407,11 +412,8 @@ func (s *Store) reclaimEmptied(sh *shard) error {
 		}
 	}
 	// Seal a fully-dead, fully-synced active segment so the retire below can drop
-	// it. records raises monotonically and syncedRecords only rises toward it, so
-	// the fully-synced check is stable under the shard lock.
-	if act := sh.active; act != nil && act.records.Load() > 0 &&
-		act.syncedRecords.Load() == act.records.Load() &&
-		!act.busy.Load() && !s.pinned(act) {
+	// it.
+	if act := sh.active; s.sealableActive(act) {
 		if _, live := liveSegs[act.id]; !live {
 			if err := s.sealSegment(sh); err != nil {
 				sh.mu.Unlock()

--- a/pkg/block/local/memory/memory.go
+++ b/pkg/block/local/memory/memory.go
@@ -21,9 +21,6 @@ var (
 	_ block.DurabilityReporter = (*MemoryStore)(nil)
 )
 
-// ErrStoreClosed is an alias for block.ErrStoreClosed for backward compatibility.
-var ErrStoreClosed = block.ErrStoreClosed
-
 // memFile is one file's byte buffer plus its not-yet-carved byte count.
 type memFile struct {
 	buf      []byte
@@ -76,7 +73,7 @@ func (s *MemoryStore) WriteAt(_ context.Context, payloadID string, offset int64,
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {
-		return ErrStoreClosed
+		return block.ErrStoreClosed
 	}
 	n := s.writeLocked(payloadID, offset, data)
 	s.files[payloadID].unsynced += n
@@ -92,7 +89,7 @@ func (s *MemoryStore) Hydrate(_ context.Context, payloadID string, offset int64,
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {
-		return ErrStoreClosed
+		return block.ErrStoreClosed
 	}
 	s.writeLocked(payloadID, offset, data)
 	return nil
@@ -112,7 +109,7 @@ func (s *MemoryStore) ReadAt(_ context.Context, payloadID string, offset int64, 
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.closed {
-		return 0, journal.ReadState{}, ErrStoreClosed
+		return 0, journal.ReadState{}, block.ErrStoreClosed
 	}
 	f := s.files[payloadID]
 	if f == nil || offset >= int64(len(f.buf)) {

--- a/pkg/block/types.go
+++ b/pkg/block/types.go
@@ -275,11 +275,6 @@ func (b *FileChunk) IsRemote() bool {
 	return b.State == BlockStateRemote
 }
 
-// IsFinalized returns true if the chunk's upload is complete (State==Remote).
-func (b *FileChunk) IsFinalized() bool {
-	return b.State == BlockStateRemote
-}
-
 // ParseBlockID extracts the payloadID and block index from an internal
 // blockID string. BlockID format: "{payloadID}/{blockIdx}" where payloadID
 // may itself contain '/' characters (only the LAST '/' separates the index).

--- a/pkg/controlplane/api/router.go
+++ b/pkg/controlplane/api/router.go
@@ -552,7 +552,7 @@ func newNfsClientHandler(rt *runtime.Runtime) *handlers.NfsClientHandler {
 	if rt == nil {
 		return nil
 	}
-	return handlers.NewNfsClientHandlerFromProvider(rt.NFSClientProvider())
+	return handlers.NewNfsClientHandlerFromProvider(rt.GetAdapterProvider("nfs"))
 }
 
 // newGraceHandler returns a GraceHandler if an NFS adapter with state management is configured.
@@ -560,7 +560,7 @@ func newGraceHandler(rt *runtime.Runtime) *handlers.GraceHandler {
 	if rt == nil {
 		return nil
 	}
-	return handlers.NewGraceHandlerFromProvider(rt.NFSClientProvider())
+	return handlers.NewGraceHandlerFromProvider(rt.GetAdapterProvider("nfs"))
 }
 
 // isHealthPath returns true if the request path is a healthcheck endpoint.

--- a/pkg/controlplane/runtime/blockgc.go
+++ b/pkg/controlplane/runtime/blockgc.go
@@ -437,9 +437,6 @@ func accumulateGCStats(total, stats *engine.GCStats, includeDryRunMeta bool) eng
 	total.BytesFreed += s.BytesFreed
 	total.ErrorCount += s.ErrorCount
 	total.StrandedRowsReaped += s.StrandedRowsReaped
-	// SharesScanned / BlocksScanned are deprecated REST wire fields that
-	// are never populated by the mark-sweep engine — accumulation would
-	// always be zero, so it is skipped here. See engine.GCStats godoc.
 	total.OrphanFiles += s.OrphanFiles
 	total.OrphanBlocks += s.OrphanBlocks
 	total.BytesReclaimed += s.BytesReclaimed

--- a/pkg/controlplane/runtime/blockgc.go
+++ b/pkg/controlplane/runtime/blockgc.go
@@ -40,19 +40,13 @@ func gcResult(total *engine.GCStats) string {
 // Without this, two shares sharing one remote would each delete the
 // other's CAS objects.
 //
-// Arguments:
-//   - sharePrefix: HISTORICAL — preserved in the signature for callers
-//     that still pass it, but engine.Options.SharePrefix was removed
-//     because the mark-sweep design has a global live set and per-share
-//     scoping no longer makes sense. A non-empty value is logged at WARN
-//     so operators see that the flag is no longer honored, then ignored.
-//   - dryRun: if true, report orphans without deleting.
+// dryRun reports orphans without deleting.
 //
 // Returns the summed *engine.GCStats across all per-remote invocations and any
 // fatal error.
-func (r *Runtime) RunBlockGC(ctx context.Context, sharePrefix string, dryRun bool) (*engine.GCStats, error) {
+func (r *Runtime) RunBlockGC(ctx context.Context, dryRun bool) (*engine.GCStats, error) {
 	// Index-based remote sweep (synced − live), no S3 LIST.
-	return r.runBlockGCSweep(ctx, sharePrefix, dryRun, nil)
+	return r.runBlockGCSweep(ctx, dryRun, nil)
 }
 
 // applyGCProgress wires an optional progress sink into engine.Options so a
@@ -77,11 +71,7 @@ func applyGCProgress(opts *engine.Options, progress func(engine.GCStats)) {
 // Markers are cleared on reclaim, preserving the synced ⊆ remote invariant
 // (#1433). Orphan block objects the index cannot see (a PutBlock-then-commit
 // crash gap) are the #1525 reconcile sweep's job (PR5).
-func (r *Runtime) runBlockGCSweep(ctx context.Context, sharePrefix string, dryRun bool, progress func(engine.GCStats)) (*engine.GCStats, error) {
-	if sharePrefix != "" {
-		logger.Warn("RunBlockGC: sharePrefix is no longer honored — mark-sweep uses a global live set across every cas/XX prefix",
-			"ignored_sharePrefix", sharePrefix)
-	}
+func (r *Runtime) runBlockGCSweep(ctx context.Context, dryRun bool, progress func(engine.GCStats)) (*engine.GCStats, error) {
 	// Enumerate distinct underlying remote stores. Dedup is by configID (not
 	// by the per-share nonClosingRemote wrapper pointer), so two shares that
 	// reference the same remote-store config produce one GC invocation.
@@ -234,7 +224,7 @@ func (r *Runtime) runLocalGC(ctx context.Context, shareFilter string, dryRun boo
 			"gracePeriod", opts.GracePeriod,
 		)
 
-		rec := &singleShareReconciler{rt: r, shareName: entry.ShareName}
+		rec := &perRemoteReconciler{rt: r, shares: []string{entry.ShareName}}
 		stats := collectGarbageLocalFn(ctx, entry.Store, rec, opts)
 		s := accumulateGCStats(total, stats, true)
 		logger.Info("local GC: complete",
@@ -246,21 +236,6 @@ func (r *Runtime) runLocalGC(ctx context.Context, shareFilter string, dryRun boo
 			"errors", s.ErrorCount,
 		)
 	}
-}
-
-// singleShareReconciler scopes the GC mark phase to exactly one share, for the
-// per-share local sweep. Implements engine.MultiShareReconciler.
-type singleShareReconciler struct {
-	rt        *Runtime
-	shareName string
-}
-
-// SharesForGC implements engine.MultiShareReconciler.
-func (s *singleShareReconciler) SharesForGC() []string { return []string{s.shareName} }
-
-// GetMetadataStoreForShare implements engine.MultiShareReconciler.
-func (s *singleShareReconciler) GetMetadataStoreForShare(shareName string) (metadata.Store, error) {
-	return s.rt.GetMetadataStoreForShare(shareName)
 }
 
 // perRemoteReconciler scopes the GC mark phase to the shares pointing at

--- a/pkg/controlplane/runtime/blockgc_reclaim_test.go
+++ b/pkg/controlplane/runtime/blockgc_reclaim_test.go
@@ -147,7 +147,7 @@ func TestBlockGC_SerializesPerRemote(t *testing.T) {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		if _, err := rt.RunBlockGC(context.Background(), "", false); err != nil {
+		if _, err := rt.RunBlockGC(context.Background(), false); err != nil {
 			t.Errorf("RunBlockGC: %v", err)
 		}
 	}()

--- a/pkg/controlplane/runtime/blockgc_reconcile.go
+++ b/pkg/controlplane/runtime/blockgc_reconcile.go
@@ -68,7 +68,7 @@ func (r *Runtime) runBlockGCReconcile(ctx context.Context, dryRun bool, progress
 	// tier sweeps from the synced-hash index; orphan block objects the index
 	// cannot see (a PutBlock-then-commit crash gap) are the #1525 reconcile
 	// sweep's job (PR5).
-	sweep, err := r.runBlockGCSweep(ctx, "", dryRun, progress)
+	sweep, err := r.runBlockGCSweep(ctx, dryRun, progress)
 	// Record reaped rows regardless of the sweep result: the rows are already
 	// deleted from the metadata store, so the counter must reflect that even if
 	// the downstream sweep (e.g. S3 unreachable) then fails. Skip on dry-run —

--- a/pkg/controlplane/runtime/blockgc_scheduler.go
+++ b/pkg/controlplane/runtime/blockgc_scheduler.go
@@ -45,7 +45,7 @@ func (r *Runtime) StartScheduledGC(ctx context.Context, interval time.Duration) 
 // Errors are logged, never fatal — the scheduler keeps running.
 func (r *Runtime) runScheduledGCOnce(ctx context.Context) {
 	start := time.Now()
-	stats, err := r.RunBlockGC(ctx, "", false)
+	stats, err := r.RunBlockGC(ctx, false)
 	if err != nil {
 		logger.Error("auto-GC: run failed", "err", err)
 		return

--- a/pkg/controlplane/runtime/blockgc_test.go
+++ b/pkg/controlplane/runtime/blockgc_test.go
@@ -156,7 +156,7 @@ func TestRunBlockGC_DedupesSharedRemoteStores(t *testing.T) {
 		"/share-b": sharedRS, // same pointer
 	})
 
-	if _, err := rt.RunBlockGC(context.Background(), "", false); err != nil {
+	if _, err := rt.RunBlockGC(context.Background(), false); err != nil {
 		t.Fatalf("RunBlockGC: %v", err)
 	}
 	if len(*captured) != 1 {
@@ -165,10 +165,7 @@ func TestRunBlockGC_DedupesSharedRemoteStores(t *testing.T) {
 }
 
 // TestRunBlockGC_DryRunPropagates asserts dryRun flows into the Options
-// struct passed to CollectGarbage. engine.Options.SharePrefix was
-// removed because the mark-sweep design has a global live set; the
-// historical sharePrefix argument on RunBlockGC is preserved for
-// caller compatibility but ignored.
+// struct passed to CollectGarbage.
 func TestRunBlockGC_DryRunPropagates(t *testing.T) {
 	captured := installCollectGarbageSpy(t)
 
@@ -177,7 +174,7 @@ func TestRunBlockGC_DryRunPropagates(t *testing.T) {
 		"/share-a": rs,
 	})
 
-	if _, err := rt.RunBlockGC(context.Background(), "/prefix", true); err != nil {
+	if _, err := rt.RunBlockGC(context.Background(), true); err != nil {
 		t.Fatalf("RunBlockGC: %v", err)
 	}
 	if len(*captured) != 1 {
@@ -195,7 +192,7 @@ func TestRunBlockGC_NoRemoteShares(t *testing.T) {
 
 	rt := newRuntimeForGC(t, nil)
 
-	stats, err := rt.RunBlockGC(context.Background(), "", false)
+	stats, err := rt.RunBlockGC(context.Background(), false)
 	if err != nil {
 		t.Fatalf("RunBlockGC: %v", err)
 	}
@@ -256,7 +253,7 @@ func TestRunBlockGC_LegacyCASPurgeWaitsForEveryShare(t *testing.T) {
 	if err := mds.MarkSynced(ctx, standalone, block.ChunkLocator{}); err != nil {
 		t.Fatalf("MarkSynced: %v", err)
 	}
-	if _, err := rt.RunBlockGC(ctx, "", false); err != nil {
+	if _, err := rt.RunBlockGC(ctx, false); err != nil {
 		t.Fatalf("RunBlockGC: %v", err)
 	}
 	if rs.deleted != 0 {
@@ -272,7 +269,7 @@ func TestRunBlockGC_LegacyCASPurgeWaitsForEveryShare(t *testing.T) {
 	if err := mds.MarkSynced(ctx, standalone, block.ChunkLocator{BlockID: "blk-1"}); err != nil {
 		t.Fatalf("MarkSynced (migrated): %v", err)
 	}
-	if _, err := rt.RunBlockGC(ctx, "", false); err != nil {
+	if _, err := rt.RunBlockGC(ctx, false); err != nil {
 		t.Fatalf("RunBlockGC (post-migration): %v", err)
 	}
 	if rs.deleted != len(rs.objects) {

--- a/pkg/controlplane/runtime/init_test.go
+++ b/pkg/controlplane/runtime/init_test.go
@@ -124,7 +124,7 @@ func TestPerShareBlockStoreLocalOnly(t *testing.T) {
 	}
 
 	readBuf := make([]byte, len(testData))
-	n, err := shareObj.BlockStore.ReadAt(ctx, "test-payload", nil, readBuf, 0)
+	n, err := shareObj.BlockStore.ReadAt(ctx, "test-payload", readBuf, 0)
 	if err != nil {
 		t.Fatalf("ReadAt failed: %v", err)
 	}
@@ -194,7 +194,7 @@ func TestLoadSharesResolvesBlockStoreByName(t *testing.T) {
 		t.Fatalf("WriteAt on name-resolved block store failed: %v", err)
 	}
 	buf := make([]byte, len(data))
-	if _, err := shareObj.BlockStore.ReadAt(ctx, "payload", nil, buf, 0); err != nil {
+	if _, err := shareObj.BlockStore.ReadAt(ctx, "payload", buf, 0); err != nil {
 		t.Fatalf("ReadAt on name-resolved block store failed: %v", err)
 	}
 	if string(buf) != string(data) {
@@ -348,7 +348,7 @@ func TestPerShareBlockStoreIsolation(t *testing.T) {
 
 	// Verify share-1 does NOT see share-2's data (different local stores).
 	readBuf1 := make([]byte, len(data2))
-	_, err := s1.BlockStore.ReadAt(ctx, "payload-2", nil, readBuf1, 0)
+	_, err := s1.BlockStore.ReadAt(ctx, "payload-2", readBuf1, 0)
 	// For memory local stores, this should either return zero-filled buffer or
 	// the data won't be found. Since both are memory stores but separate instances,
 	// the data should not be present.
@@ -368,7 +368,7 @@ func TestPerShareBlockStoreIsolation(t *testing.T) {
 
 	// Verify share-2 does NOT see share-1's data.
 	readBuf2 := make([]byte, len(data1))
-	_, err = s2.BlockStore.ReadAt(ctx, "payload-1", nil, readBuf2, 0)
+	_, err = s2.BlockStore.ReadAt(ctx, "payload-1", readBuf2, 0)
 	if err == nil {
 		isZero := true
 		for _, b := range readBuf2 {
@@ -384,7 +384,7 @@ func TestPerShareBlockStoreIsolation(t *testing.T) {
 
 	// Verify each share can read its OWN data.
 	readBuf1Own := make([]byte, len(data1))
-	n, err := s1.BlockStore.ReadAt(ctx, "payload-1", nil, readBuf1Own, 0)
+	n, err := s1.BlockStore.ReadAt(ctx, "payload-1", readBuf1Own, 0)
 	if err != nil {
 		t.Fatalf("share-1 ReadAt own data failed: %v", err)
 	}
@@ -393,7 +393,7 @@ func TestPerShareBlockStoreIsolation(t *testing.T) {
 	}
 
 	readBuf2Own := make([]byte, len(data2))
-	n, err = s2.BlockStore.ReadAt(ctx, "payload-2", nil, readBuf2Own, 0)
+	n, err = s2.BlockStore.ReadAt(ctx, "payload-2", readBuf2Own, 0)
 	if err != nil {
 		t.Fatalf("share-2 ReadAt own data failed: %v", err)
 	}

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -29,7 +29,7 @@ import (
 )
 
 // DefaultShutdownTimeout is the default timeout for graceful shutdown.
-const DefaultShutdownTimeout = 30 * time.Second
+const DefaultShutdownTimeout = lifecycle.DefaultShutdownTimeout
 
 // Type aliases re-exported for backward compatibility.
 type (
@@ -1233,12 +1233,6 @@ func (r *Runtime) GetAdapterProvider(key string) any {
 	defer r.adapterProvidersMu.RUnlock()
 	return r.adapterProviders[key]
 }
-
-// SetNFSClientProvider is deprecated; use SetAdapterProvider("nfs", p).
-func (r *Runtime) SetNFSClientProvider(p any) { r.SetAdapterProvider("nfs", p) }
-
-// NFSClientProvider is deprecated; use GetAdapterProvider("nfs").
-func (r *Runtime) NFSClientProvider() any { return r.GetAdapterProvider("nfs") }
 
 // snapInFlight tracks the per-share orchestration goroutines launched
 // by Runtime.CreateSnapshot. See pkg/controlplane/runtime/snapshot.go

--- a/pkg/controlplane/runtime/shares/coordinator.go
+++ b/pkg/controlplane/runtime/shares/coordinator.go
@@ -93,40 +93,6 @@ func (c *metadataCoordinator) IncrementRefCount(ctx context.Context, hash block.
 	return nil
 }
 
-// DecrementRefCount looks up the FileChunk by hash and decrements its
-// RefCount, returning the new count. ErrFileChunkNotFound on a hash
-// that has no row is tolerated (returns count=0, nil) — a Truncate or
-// Delete on a hash that has already been swept by GC is not a caller
-// error.
-//
-// When the caller has bound an active metadata.Transaction into ctx
-// via metadata.WithTx, both GetByHash and DecrementRefCount route
-// through that tx. Truncate and Delete from the engine path do NOT
-// currently bind a tx (no wrapping WithTransaction), so those callers
-// route through the public store — Truncate/Delete are non-atomic at
-// the cross-store level by design and the refcount audit reconciles
-// drift.
-func (c *metadataCoordinator) DecrementRefCount(ctx context.Context, hash block.ContentHash) (uint32, error) {
-	store := c.resolveStore(ctx)
-	fb, err := store.GetByHash(ctx, hash)
-	if err != nil {
-		return 0, fmt.Errorf("coordinator: GetByHash(%s): %w", hash.String(), err)
-	}
-	if fb == nil {
-		// Already swept / never existed — caller's metadata is stale but
-		// the requested decrement effectively succeeded (count is zero).
-		return 0, nil
-	}
-	count, err := store.DecrementRefCount(ctx, fb.ID)
-	if err != nil {
-		if errors.Is(err, metadata.ErrFileChunkNotFound) {
-			return 0, nil
-		}
-		return 0, fmt.Errorf("coordinator: DecrementRefCount(%s): %w", fb.ID, err)
-	}
-	return count, nil
-}
-
 // DecrementRefCountAndReap decrements the FileChunk row identified by the EXACT
 // ID "{payloadID}/{offset}" and reaps it (row + hash index entry) atomically
 // when the new count reaches 0. The hash then leaves EnumerateFileChunks once no

--- a/pkg/controlplane/runtime/shares/coordinator_test.go
+++ b/pkg/controlplane/runtime/shares/coordinator_test.go
@@ -13,8 +13,8 @@ import (
 
 // TestMetadataCoordinator_RoutesThroughContextTx pins the CR-01 contract:
 // when the caller binds an active metadata.Transaction into ctx via
-// metadata.WithTx, the coordinator's IncrementRefCount / DecrementRefCount
-// MUST run through that tx (so a downstream caller-side failure rolls back
+// metadata.WithTx, the coordinator's IncrementRefCount /
+// DecrementRefCountAndReap MUST run through that tx (so a downstream caller-side failure rolls back
 // every refcount mutation atomically), not through the public
 // MetadataStore surface (which routes per-call to the connection pool).
 //
@@ -58,13 +58,11 @@ func TestMetadataCoordinator_RoutesThroughContextTx(t *testing.T) {
 			t.Errorf("IncrementRefCount routed through tx: got %d calls, want 1", rec.incrementCalls)
 		}
 
-		got, err := coord.DecrementRefCount(txCtx, hash)
-		if err != nil {
+		if _, err := coord.DecrementRefCountAndReap(txCtx, "share", 0); err != nil {
 			return err
 		}
-		_ = got
 		if rec.decrementCalls != 1 {
-			t.Errorf("DecrementRefCount routed through tx: got %d calls, want 1", rec.decrementCalls)
+			t.Errorf("DecrementRefCountAndReap routed through tx: got %d calls, want 1", rec.decrementCalls)
 		}
 		return nil
 	}); err != nil {
@@ -100,12 +98,12 @@ func TestMetadataCoordinator_FallsBackToPublicStoreWithoutTx(t *testing.T) {
 
 	// No WithTx in ctx — coordinator should fall through to the public
 	// store. Decrement once and verify the row was actually mutated.
-	count, err := coord.DecrementRefCount(ctx, hash)
+	count, err := coord.DecrementRefCountAndReap(ctx, "share", 1)
 	if err != nil {
-		t.Fatalf("DecrementRefCount: %v", err)
+		t.Fatalf("DecrementRefCountAndReap: %v", err)
 	}
 	if count != 1 {
-		t.Errorf("DecrementRefCount returned count=%d, want 1", count)
+		t.Errorf("DecrementRefCountAndReap returned count=%d, want 1", count)
 	}
 
 	got, err := store.GetByHash(ctx, hash)
@@ -225,7 +223,7 @@ func (r *recordingTx) IncrementRefCount(ctx context.Context, id string) error {
 	return r.Transaction.IncrementRefCount(ctx, id)
 }
 
-func (r *recordingTx) DecrementRefCount(ctx context.Context, id string) (uint32, error) {
+func (r *recordingTx) DecrementRefCountAndReap(ctx context.Context, id string) (uint32, error) {
 	r.decrementCalls++
-	return r.Transaction.DecrementRefCount(ctx, id)
+	return r.Transaction.DecrementRefCountAndReap(ctx, id)
 }

--- a/pkg/controlplane/runtime/shares/legacy_migrate_test.go
+++ b/pkg/controlplane/runtime/shares/legacy_migrate_test.go
@@ -116,7 +116,7 @@ func readAllLegacyFiles(t *testing.T, bs *engine.Store, when string) {
 	ctx := context.Background()
 	for id, want := range legacyShareFiles {
 		got := make([]byte, len(want))
-		n, err := bs.ReadAt(ctx, id, nil, got, 0)
+		n, err := bs.ReadAt(ctx, id, got, 0)
 		if err != nil {
 			t.Fatalf("ReadAt %s %s: %v", id, when, err)
 		}

--- a/pkg/controlplane/runtime/shares/legacy_verify.go
+++ b/pkg/controlplane/runtime/shares/legacy_verify.go
@@ -91,7 +91,7 @@ var errColdVerifyUnavailable = errors.New("cold verification unavailable")
 func verifyColdSeed(ctx context.Context, bs *engine.Store, report coldSeedReport) error {
 	for _, s := range report.samples {
 		buf := make([]byte, s.length)
-		n, err := bs.ReadAt(ctx, s.payloadID, nil, buf, uint64(s.offset))
+		n, err := bs.ReadAt(ctx, s.payloadID, buf, uint64(s.offset))
 		if err != nil {
 			return fmt.Errorf("%w: read back %s at %d: %w", errColdVerifyUnavailable, s.payloadID, s.offset, err)
 		}

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -2438,7 +2438,7 @@ func (s *Service) XattrStreamReader() metadata.StreamContentReader {
 			return nil, err
 		}
 		buf := make([]byte, int(attr.Size))
-		n, rerr := bs.ReadAt(ctx, string(attr.PayloadID), nil, buf, 0)
+		n, rerr := bs.ReadAt(ctx, string(attr.PayloadID), buf, 0)
 		if rerr != nil && rerr != io.EOF && rerr != io.ErrUnexpectedEOF {
 			return nil, rerr
 		}

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -383,7 +383,6 @@ type SyncerDefaults struct {
 type sharedRemote struct {
 	store    remote.RemoteStore
 	refCount int
-	configID string
 }
 
 // nonClosingRemote wraps a remote.RemoteStore and makes Close() a no-op.
@@ -1569,7 +1568,6 @@ func (s *Service) acquireRemoteStore(ctx context.Context, ref string, provider B
 	s.remoteStores[configID] = &sharedRemote{
 		store:    newStore,
 		refCount: 1,
-		configID: configID,
 	}
 	s.mu.Unlock()
 
@@ -2590,7 +2588,6 @@ func (s *Service) SetShareRemoteForTest(shareName string, rs remote.RemoteStore)
 		s.remoteStores[cid] = &sharedRemote{
 			store:    rs,
 			refCount: 1,
-			configID: cid,
 		}
 	}
 	share.remoteConfigID = cid

--- a/pkg/controlplane/runtime/snapshot_lifecycle_test.go
+++ b/pkg/controlplane/runtime/snapshot_lifecycle_test.go
@@ -192,7 +192,7 @@ func TestSnapshotLifecycleVsGC(t *testing.T) {
 			t.Fatalf("UpdateSnapshotState->ready: %v", err)
 		}
 
-		stats, err := fx.rt.RunBlockGC(ctx, "", false)
+		stats, err := fx.rt.RunBlockGC(ctx, false)
 		if err != nil {
 			t.Fatalf("RunBlockGC: %v", err)
 		}
@@ -232,7 +232,7 @@ func TestSnapshotLifecycleVsGC(t *testing.T) {
 			t.Fatalf("RemoveAll snapshot dir: %v", err)
 		}
 
-		stats, err := fx.rt.RunBlockGC(ctx, "", false)
+		stats, err := fx.rt.RunBlockGC(ctx, false)
 		if err != nil {
 			t.Fatalf("RunBlockGC: %v", err)
 		}

--- a/pkg/metadata/acl/evaluate.go
+++ b/pkg/metadata/acl/evaluate.go
@@ -13,9 +13,7 @@ import (
 const builtinAdministratorsSID = "S-1-5-32-544"
 
 // domainAdminSIDPattern matches the local/domain Administrator account SID
-// (S-1-5-21-{auth1}-{auth2}-{auth3}-500). Mirrors the pattern in
-// pkg/metadata/auth_identity.go::IsAdministratorSID. Kept local to the
-// acl package to avoid a cyclic import from pkg/metadata.
+// (S-1-5-21-{auth1}-{auth2}-{auth3}-500).
 var domainAdminSIDPattern = regexp.MustCompile(`^S-1-5-21-\d+-\d+-\d+-500$`)
 
 // HasTakeOwnershipPrivilege reports whether the given requester SID +
@@ -27,18 +25,20 @@ var domainAdminSIDPattern = regexp.MustCompile(`^S-1-5-21-\d+-\d+-\d+-500$`)
 // the MS-DTYP §2.5.3.2 owner-implicit WRITE_OWNER grant is restricted
 // to admins, matching Samba access_check.c::se_access_check_implicit_owner.
 func HasTakeOwnershipPrivilege(requesterSID string, groupSIDs []string) bool {
-	if isAdminSID(requesterSID) {
+	if IsAdminSID(requesterSID) {
 		return true
 	}
 	for _, g := range groupSIDs {
-		if isAdminSID(g) {
+		if IsAdminSID(g) {
 			return true
 		}
 	}
 	return false
 }
 
-func isAdminSID(sid string) bool {
+// IsAdminSID reports whether the SID is BUILTIN\Administrators or a
+// local/domain Administrator (RID 500) account.
+func IsAdminSID(sid string) bool {
 	if sid == "" {
 		return false
 	}

--- a/pkg/metadata/auth_identity.go
+++ b/pkg/metadata/auth_identity.go
@@ -3,8 +3,9 @@ package metadata
 import (
 	"context"
 	"net"
-	"regexp"
 	"slices"
+
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
 )
 
 // AuthContext contains authentication information for access control checks.
@@ -230,13 +231,6 @@ type IdentityMapping struct {
 	AnonymousSID *string
 }
 
-// Pre-compiled regular expression for Administrator SID validation.
-var (
-	// domainAdminSIDPattern matches domain/local administrator accounts.
-	// Format: S-1-5-21-<domain identifier (3 parts)>-500
-	domainAdminSIDPattern = regexp.MustCompile(`^S-1-5-21-\d+-\d+-\d+-500$`)
-)
-
 // ApplyIdentityMapping applies identity transformation rules.
 //
 // Implements identity mapping (squashing) rules for NFS shares:
@@ -323,16 +317,7 @@ func ApplyIdentityMapping(identity *Identity, mapping *IdentityMapping) *Identit
 //   - Domain/Local Administrator: S-1-5-21-<3 sub-authorities>-500
 //   - Built-in Administrators group: S-1-5-32-544
 func IsAdministratorSID(sid string) bool {
-	if sid == "" {
-		return false
-	}
-
-	// S-1-5-32-544: BUILTIN\Administrators group
-	if sid == "S-1-5-32-544" {
-		return true
-	}
-
-	return domainAdminSIDPattern.MatchString(sid)
+	return acl.IsAdminSID(sid)
 }
 
 // MatchesIPPattern checks if an IP address matches a pattern (CIDR or exact IP).

--- a/pkg/metadata/store/badger/client_recovery.go
+++ b/pkg/metadata/store/badger/client_recovery.go
@@ -149,34 +149,24 @@ func (s *badgerRecoveryStore) RecordReclaimComplete(ctx context.Context, clientI
 // Ensure BadgerMetadataStore implements ClientRecoveryStore.
 var _ lock.ClientRecoveryStore = (*BadgerMetadataStore)(nil)
 
-// getRecoveryStore returns the recovery store, initializing if needed.
-func (s *BadgerMetadataStore) getRecoveryStore() *badgerRecoveryStore {
-	s.recoveryStoreMu.Lock()
-	defer s.recoveryStoreMu.Unlock()
-	if s.recoveryStore == nil {
-		s.recoveryStore = newBadgerRecoveryStore(s.db)
-	}
-	return s.recoveryStore
-}
-
 // PutClientRecovery stores or replaces a client recovery record.
 func (s *BadgerMetadataStore) PutClientRecovery(ctx context.Context, rec *lock.V4ClientRecoveryRecord) error {
-	return s.getRecoveryStore().PutClientRecovery(ctx, rec)
+	return s.recoveryStore.PutClientRecovery(ctx, rec)
 }
 
 // DeleteClientRecovery removes a client recovery record.
 func (s *BadgerMetadataStore) DeleteClientRecovery(ctx context.Context, clientIDString string) error {
-	return s.getRecoveryStore().DeleteClientRecovery(ctx, clientIDString)
+	return s.recoveryStore.DeleteClientRecovery(ctx, clientIDString)
 }
 
 // ListClientRecovery returns all stored client recovery records.
 func (s *BadgerMetadataStore) ListClientRecovery(ctx context.Context) ([]*lock.V4ClientRecoveryRecord, error) {
-	return s.getRecoveryStore().ListClientRecovery(ctx)
+	return s.recoveryStore.ListClientRecovery(ctx)
 }
 
 // RecordReclaimComplete marks a client's recovery record reclaim-complete.
 func (s *BadgerMetadataStore) RecordReclaimComplete(ctx context.Context, clientIDString string) error {
-	return s.getRecoveryStore().RecordReclaimComplete(ctx, clientIDString)
+	return s.recoveryStore.RecordReclaimComplete(ctx, clientIDString)
 }
 
 // ClientRecoveryStore returns this store as a ClientRecoveryStore.

--- a/pkg/metadata/store/badger/clients.go
+++ b/pkg/metadata/store/badger/clients.go
@@ -306,44 +306,34 @@ func (s *badgerClientStore) DeleteClientRegistrationsByMonName(ctx context.Conte
 // Ensure BadgerMetadataStore implements ClientRegistrationStore
 var _ lock.ClientRegistrationStore = (*BadgerMetadataStore)(nil)
 
-// getClientStore returns the client store, initializing if needed.
-func (s *BadgerMetadataStore) getClientStore() *badgerClientStore {
-	s.clientStoreMu.Lock()
-	defer s.clientStoreMu.Unlock()
-	if s.clientStore == nil {
-		s.clientStore = newBadgerClientStore(s.db)
-	}
-	return s.clientStore
-}
-
 // PutClientRegistration stores or updates a client registration.
 func (s *BadgerMetadataStore) PutClientRegistration(ctx context.Context, reg *lock.PersistedClientRegistration) error {
-	return s.getClientStore().PutClientRegistration(ctx, reg)
+	return s.clientStore.PutClientRegistration(ctx, reg)
 }
 
 // GetClientRegistration retrieves a registration by client ID.
 func (s *BadgerMetadataStore) GetClientRegistration(ctx context.Context, clientID string) (*lock.PersistedClientRegistration, error) {
-	return s.getClientStore().GetClientRegistration(ctx, clientID)
+	return s.clientStore.GetClientRegistration(ctx, clientID)
 }
 
 // DeleteClientRegistration removes a registration by client ID.
 func (s *BadgerMetadataStore) DeleteClientRegistration(ctx context.Context, clientID string) error {
-	return s.getClientStore().DeleteClientRegistration(ctx, clientID)
+	return s.clientStore.DeleteClientRegistration(ctx, clientID)
 }
 
 // ListClientRegistrations returns all stored registrations.
 func (s *BadgerMetadataStore) ListClientRegistrations(ctx context.Context) ([]*lock.PersistedClientRegistration, error) {
-	return s.getClientStore().ListClientRegistrations(ctx)
+	return s.clientStore.ListClientRegistrations(ctx)
 }
 
 // DeleteAllClientRegistrations removes all registrations.
 func (s *BadgerMetadataStore) DeleteAllClientRegistrations(ctx context.Context) (int, error) {
-	return s.getClientStore().DeleteAllClientRegistrations(ctx)
+	return s.clientStore.DeleteAllClientRegistrations(ctx)
 }
 
 // DeleteClientRegistrationsByMonName removes all registrations monitoring a specific host.
 func (s *BadgerMetadataStore) DeleteClientRegistrationsByMonName(ctx context.Context, monName string) (int, error) {
-	return s.getClientStore().DeleteClientRegistrationsByMonName(ctx, monName)
+	return s.clientStore.DeleteClientRegistrationsByMonName(ctx, monName)
 }
 
 // ClientRegistrationStore returns this store as a ClientRegistrationStore.

--- a/pkg/metadata/store/badger/durable_handles.go
+++ b/pkg/metadata/store/badger/durable_handles.go
@@ -583,57 +583,48 @@ func (s *badgerDurableStore) DeleteExpiredDurableHandles(ctx context.Context, no
 
 var _ lock.DurableHandleStore = (*BadgerMetadataStore)(nil)
 
-func (s *BadgerMetadataStore) getDurableStore() *badgerDurableStore {
-	s.durableStoreMu.Lock()
-	defer s.durableStoreMu.Unlock()
-	if s.durableStore == nil {
-		s.durableStore = newBadgerDurableStore(s.db)
-	}
-	return s.durableStore
-}
-
 func (s *BadgerMetadataStore) PutDurableHandle(ctx context.Context, handle *lock.PersistedDurableHandle) error {
-	return s.getDurableStore().PutDurableHandle(ctx, handle)
+	return s.durableStore.PutDurableHandle(ctx, handle)
 }
 
 func (s *BadgerMetadataStore) GetDurableHandle(ctx context.Context, id string) (*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().GetDurableHandle(ctx, id)
+	return s.durableStore.GetDurableHandle(ctx, id)
 }
 
 func (s *BadgerMetadataStore) GetDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().GetDurableHandleByFileID(ctx, fileID)
+	return s.durableStore.GetDurableHandleByFileID(ctx, fileID)
 }
 
 func (s *BadgerMetadataStore) GetDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().GetDurableHandleByCreateGuid(ctx, createGuid)
+	return s.durableStore.GetDurableHandleByCreateGuid(ctx, createGuid)
 }
 
 func (s *BadgerMetadataStore) ConsumeDurableHandle(ctx context.Context, id string) (*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().ConsumeDurableHandle(ctx, id)
+	return s.durableStore.ConsumeDurableHandle(ctx, id)
 }
 
 func (s *BadgerMetadataStore) GetDurableHandlesByAppInstanceId(ctx context.Context, appInstanceId [16]byte) ([]*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().GetDurableHandlesByAppInstanceId(ctx, appInstanceId)
+	return s.durableStore.GetDurableHandlesByAppInstanceId(ctx, appInstanceId)
 }
 
 func (s *BadgerMetadataStore) GetDurableHandlesByFileHandle(ctx context.Context, fileHandle []byte) ([]*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().GetDurableHandlesByFileHandle(ctx, fileHandle)
+	return s.durableStore.GetDurableHandlesByFileHandle(ctx, fileHandle)
 }
 
 func (s *BadgerMetadataStore) DeleteDurableHandle(ctx context.Context, id string) error {
-	return s.getDurableStore().DeleteDurableHandle(ctx, id)
+	return s.durableStore.DeleteDurableHandle(ctx, id)
 }
 
 func (s *BadgerMetadataStore) ListDurableHandles(ctx context.Context) ([]*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().ListDurableHandles(ctx)
+	return s.durableStore.ListDurableHandles(ctx)
 }
 
 func (s *BadgerMetadataStore) ListDurableHandlesByShare(ctx context.Context, shareName string) ([]*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().ListDurableHandlesByShare(ctx, shareName)
+	return s.durableStore.ListDurableHandlesByShare(ctx, shareName)
 }
 
 func (s *BadgerMetadataStore) DeleteExpiredDurableHandles(ctx context.Context, now time.Time) (int, error) {
-	return s.getDurableStore().DeleteExpiredDurableHandles(ctx, now)
+	return s.durableStore.DeleteExpiredDurableHandles(ctx, now)
 }
 
 // DurableHandleStore returns this store as a DurableHandleStore.

--- a/pkg/metadata/store/badger/locks.go
+++ b/pkg/metadata/store/badger/locks.go
@@ -533,78 +533,58 @@ func (s *badgerLockStore) ReclaimLease(ctx context.Context, fileHandle lock.File
 // Ensure BadgerMetadataStore implements LockStore
 var _ lock.LockStore = (*BadgerMetadataStore)(nil)
 
-// initLockStore ensures the lock store is initialized.
-func (s *BadgerMetadataStore) initLockStore() {
-	s.lockStoreMu.Lock()
-	defer s.lockStoreMu.Unlock()
-	if s.lockStore == nil {
-		s.lockStore = newBadgerLockStore(s.db)
-	}
-}
-
 // PutLock persists a lock.
 func (s *BadgerMetadataStore) PutLock(ctx context.Context, lk *lock.PersistedLock) error {
-	s.initLockStore()
 	return s.lockStore.PutLock(ctx, lk)
 }
 
 // GetLock retrieves a lock by ID.
 func (s *BadgerMetadataStore) GetLock(ctx context.Context, lockID string) (*lock.PersistedLock, error) {
-	s.initLockStore()
 	return s.lockStore.GetLock(ctx, lockID)
 }
 
 // DeleteLock removes a lock by ID.
 func (s *BadgerMetadataStore) DeleteLock(ctx context.Context, lockID string) error {
-	s.initLockStore()
 	return s.lockStore.DeleteLock(ctx, lockID)
 }
 
 // ListLocks returns locks matching the query.
 func (s *BadgerMetadataStore) ListLocks(ctx context.Context, query lock.LockQuery) ([]*lock.PersistedLock, error) {
-	s.initLockStore()
 	return s.lockStore.ListLocks(ctx, query)
 }
 
 // DeleteLocksByClient removes all locks for a client.
 func (s *BadgerMetadataStore) DeleteLocksByClient(ctx context.Context, clientID string) (int, error) {
-	s.initLockStore()
 	return s.lockStore.DeleteLocksByClient(ctx, clientID)
 }
 
 // DeleteLocksByFile removes all locks for a file.
 func (s *BadgerMetadataStore) DeleteLocksByFile(ctx context.Context, fileID string) (int, error) {
-	s.initLockStore()
 	return s.lockStore.DeleteLocksByFile(ctx, fileID)
 }
 
 // GetServerEpoch returns current server epoch.
 func (s *BadgerMetadataStore) GetServerEpoch(ctx context.Context) (uint64, error) {
-	s.initLockStore()
 	return s.lockStore.GetServerEpoch(ctx)
 }
 
 // IncrementServerEpoch increments and returns new epoch.
 func (s *BadgerMetadataStore) IncrementServerEpoch(ctx context.Context) (uint64, error) {
-	s.initLockStore()
 	return s.lockStore.IncrementServerEpoch(ctx)
 }
 
 // GetCleanShutdown reports whether the previous run shut down gracefully.
 func (s *BadgerMetadataStore) GetCleanShutdown(ctx context.Context) (bool, error) {
-	s.initLockStore()
 	return s.lockStore.GetCleanShutdown(ctx)
 }
 
 // SetCleanShutdown records the clean-shutdown marker durably.
 func (s *BadgerMetadataStore) SetCleanShutdown(ctx context.Context, clean bool) error {
-	s.initLockStore()
 	return s.lockStore.SetCleanShutdown(ctx, clean)
 }
 
 // ReclaimLease reclaims an existing lease during grace period.
 func (s *BadgerMetadataStore) ReclaimLease(ctx context.Context, fileHandle lock.FileHandle, leaseKey [16]byte, clientID string) (*lock.UnifiedLock, error) {
-	s.initLockStore()
 	return s.lockStore.ReclaimLease(ctx, fileHandle, leaseKey, clientID)
 }
 
@@ -619,7 +599,6 @@ func (tx *badgerTransaction) PutLock(ctx context.Context, lk *lock.PersistedLock
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	tx.store.initLockStore()
 	return tx.store.lockStore.putLockTx(tx.txn, lk)
 }
 
@@ -627,7 +606,6 @@ func (tx *badgerTransaction) GetLock(ctx context.Context, lockID string) (*lock.
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	tx.store.initLockStore()
 	return tx.store.lockStore.getLockTx(tx.txn, lockID)
 }
 
@@ -635,7 +613,6 @@ func (tx *badgerTransaction) DeleteLock(ctx context.Context, lockID string) erro
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	tx.store.initLockStore()
 	return tx.store.lockStore.deleteLockTx(tx.txn, lockID)
 }
 
@@ -643,7 +620,6 @@ func (tx *badgerTransaction) ListLocks(ctx context.Context, query lock.LockQuery
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	tx.store.initLockStore()
 	return tx.store.lockStore.listLocksTx(tx.txn, query)
 }
 
@@ -654,7 +630,6 @@ func (tx *badgerTransaction) DeleteLocksByClient(ctx context.Context, clientID s
 	// Operate within the caller's transaction so the deletions are atomic with
 	// the rest of the operation and are discarded if WithTransaction retries on
 	// an OCC conflict (the store-level method would commit out-of-band).
-	tx.store.initLockStore()
 	return tx.store.lockStore.deleteLocksByIndexPrefixTx(tx.txn, []byte(lockIndexPrefix(prefixLockByClient, clientID)))
 }
 
@@ -662,7 +637,6 @@ func (tx *badgerTransaction) DeleteLocksByFile(ctx context.Context, fileID strin
 	if err := ctx.Err(); err != nil {
 		return 0, err
 	}
-	tx.store.initLockStore()
 	return tx.store.lockStore.deleteLocksByIndexPrefixTx(tx.txn, []byte(lockIndexPrefix(prefixLockByFile, fileID)))
 }
 
@@ -670,7 +644,6 @@ func (tx *badgerTransaction) GetServerEpoch(ctx context.Context) (uint64, error)
 	if err := ctx.Err(); err != nil {
 		return 0, err
 	}
-	tx.store.initLockStore()
 	return tx.store.lockStore.getServerEpochTx(tx.txn)
 }
 
@@ -682,7 +655,6 @@ func (tx *badgerTransaction) IncrementServerEpoch(ctx context.Context) (uint64, 
 	// its own db.Update, so on an OCC retry of the outer transaction the epoch
 	// would be bumped once per attempt (double-increment); keeping it in tx.txn
 	// makes the increment exactly-once per committed transaction.
-	tx.store.initLockStore()
 	return tx.store.lockStore.incrementServerEpochTx(tx.txn)
 }
 
@@ -690,7 +662,6 @@ func (tx *badgerTransaction) GetCleanShutdown(ctx context.Context) (bool, error)
 	if err := ctx.Err(); err != nil {
 		return false, err
 	}
-	tx.store.initLockStore()
 	return tx.store.lockStore.GetCleanShutdown(ctx)
 }
 
@@ -701,7 +672,6 @@ func (tx *badgerTransaction) SetCleanShutdown(ctx context.Context, clean bool) e
 	// Write within the caller's transaction so the marker is only durable if
 	// the outer transaction commits (the store-level method commits out-of-band
 	// regardless of the outer transaction's fate).
-	tx.store.initLockStore()
 	return tx.store.lockStore.setCleanShutdownTx(tx.txn, clean)
 }
 
@@ -709,6 +679,5 @@ func (tx *badgerTransaction) ReclaimLease(ctx context.Context, fileHandle lock.F
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	tx.store.initLockStore()
 	return tx.store.lockStore.ReclaimLease(ctx, fileHandle, leaseKey, clientID)
 }

--- a/pkg/metadata/store/badger/locks_tx_atomicity_test.go
+++ b/pkg/metadata/store/badger/locks_tx_atomicity_test.go
@@ -41,7 +41,6 @@ func txLockStore(t *testing.T, tx metadata.Transaction) lock.LockStore {
 func TestTxDeleteLocksByClient_RolledBackWithOuterTx(t *testing.T) {
 	ctx := context.Background()
 	store := newLockTestStore(t)
-	store.initLockStore()
 
 	if err := store.lockStore.PutLock(ctx, &lock.PersistedLock{
 		ID: "lk1", FileID: "f1", OwnerID: "o1", ClientID: "c1",
@@ -81,7 +80,6 @@ func TestTxDeleteLocksByClient_RolledBackWithOuterTx(t *testing.T) {
 func TestTxIncrementServerEpoch_RolledBackWithOuterTx(t *testing.T) {
 	ctx := context.Background()
 	store := newLockTestStore(t)
-	store.initLockStore()
 
 	before, err := store.lockStore.GetServerEpoch(ctx)
 	if err != nil {
@@ -113,7 +111,6 @@ func TestTxIncrementServerEpoch_RolledBackWithOuterTx(t *testing.T) {
 func TestTxIncrementServerEpoch_CommitsOnce(t *testing.T) {
 	ctx := context.Background()
 	store := newLockTestStore(t)
-	store.initLockStore()
 
 	before, err := store.lockStore.GetServerEpoch(ctx)
 	if err != nil {

--- a/pkg/metadata/store/badger/objects.go
+++ b/pkg/metadata/store/badger/objects.go
@@ -56,7 +56,7 @@ func reapBlockTxn(txn *badger.Txn, id string, block *metadata.FileChunk) error {
 	if pid, idx, ok := splitBlockID(id); ok {
 		_ = txn.Delete([]byte(fileChunkFilePrefix + pid + ":" + idx))
 	}
-	if block.IsFinalized() {
+	if block.IsRemote() {
 		_ = txn.Delete([]byte(fileChunkHashPrefix + block.Hash.String()))
 	}
 	return nil
@@ -113,7 +113,7 @@ func (s *BadgerMetadataStore) Put(ctx context.Context, block *metadata.FileChunk
 		}
 
 		// Update hash index for finalized blocks
-		if block.IsFinalized() {
+		if block.IsRemote() {
 			hashKey := []byte(fileChunkHashPrefix + block.Hash.String())
 			return txn.Set(hashKey, []byte(block.ID))
 		}
@@ -980,7 +980,7 @@ func (tx *badgerTransaction) Put(ctx context.Context, block *metadata.FileChunk)
 			return err
 		}
 	}
-	if block.IsFinalized() {
+	if block.IsRemote() {
 		hashKey := []byte(fileChunkHashPrefix + block.Hash.String())
 		return tx.txn.Set(hashKey, []byte(block.ID))
 	}

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -384,8 +384,8 @@ func NewBadgerMetadataStore(ctx context.Context, config BadgerMetadataStoreConfi
 		syncStop:          make(chan struct{}),
 		quota:             quota.NewCache(),
 	}
-	// The substores hold nothing but db, which is never reassigned, so they
-	// are bound once here rather than lazily behind a mutex.
+	// The substores derive only from db, which is never reassigned, so bind
+	// them once here.
 	store.lockStore = newBadgerLockStore(db)
 	store.clientStore = newBadgerClientStore(db)
 	store.durableStore = newBadgerDurableStore(db)

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -130,20 +130,16 @@ type BadgerMetadataStore struct {
 	}
 
 	// lockStore provides lock persistence
-	lockStore   *badgerLockStore
-	lockStoreMu sync.Mutex
+	lockStore *badgerLockStore
 
 	// clientStore provides NSM client registration persistence
-	clientStore   *badgerClientStore
-	clientStoreMu sync.Mutex
+	clientStore *badgerClientStore
 
 	// durableStore provides SMB3 durable handle persistence
-	durableStore   *badgerDurableStore
-	durableStoreMu sync.Mutex
+	durableStore *badgerDurableStore
 
 	// recoveryStore provides NFSv4 client-recovery persistence
-	recoveryStore   *badgerRecoveryStore
-	recoveryStoreMu sync.Mutex
+	recoveryStore *badgerRecoveryStore
 
 	// usedBytes tracks the total logical bytes used by regular files.
 	// Updated atomically on every size-changing operation (create, update, truncate, delete).
@@ -388,6 +384,12 @@ func NewBadgerMetadataStore(ctx context.Context, config BadgerMetadataStoreConfi
 		syncStop:          make(chan struct{}),
 		quota:             quota.NewCache(),
 	}
+	// The substores hold nothing but db, which is never reassigned, so they
+	// are bound once here rather than lazily behind a mutex.
+	store.lockStore = newBadgerLockStore(db)
+	store.clientStore = newBadgerClientStore(db)
+	store.durableStore = newBadgerDurableStore(db)
+	store.recoveryStore = newBadgerRecoveryStore(db)
 
 	// Initialize stats cache with a 5-second TTL for responsive updates
 	// This prevents expensive database scans on every FSSTAT request while

--- a/pkg/metadata/store/memory/objects.go
+++ b/pkg/metadata/store/memory/objects.go
@@ -373,7 +373,7 @@ func (s *MemoryMetadataStore) putFileChunkLocked(_ context.Context, block *metad
 	s.fileChunkData.blocks[block.ID] = &stored
 
 	// Update hash index for finalized blocks
-	if block.IsFinalized() {
+	if block.IsRemote() {
 		s.fileChunkData.hashIndex[block.Hash] = block.ID
 	}
 	return nil
@@ -389,7 +389,7 @@ func (s *MemoryMetadataStore) deleteFileChunkLocked(_ context.Context, id string
 	}
 
 	// Remove from hash index
-	if block.IsFinalized() {
+	if block.IsRemote() {
 		if s.fileChunkData.hashIndex[block.Hash] == id {
 			delete(s.fileChunkData.hashIndex, block.Hash)
 		}

--- a/pkg/metadata/store/memory/objects_test.go
+++ b/pkg/metadata/store/memory/objects_test.go
@@ -163,7 +163,7 @@ func TestFileChunkStore_FindByHash_Found(t *testing.T) {
 		Hash:     hash,
 		DataSize: 2048,
 		RefCount: 1,
-		// IsFinalized() now means State==Remote — only
+		// IsRemote() now means State==Remote — only
 		// Remote rows enter the hash index for dedup lookups.
 		State: metadata.BlockStateRemote,
 	}

--- a/pkg/metadata/store/memory/shares.go
+++ b/pkg/metadata/store/memory/shares.go
@@ -18,7 +18,7 @@ func (store *MemoryMetadataStore) GenerateHandle(ctx context.Context, shareName 
 	}
 
 	// Memory store uses UUID-based handles, path is for compatibility
-	return store.generateFileHandle(shareName, path), nil
+	return store.generateFileHandle(shareName), nil
 }
 
 // GetRootHandle returns the root handle for a share.
@@ -100,7 +100,7 @@ func (store *MemoryMetadataStore) CreateShare(ctx context.Context, share *metada
 	}
 
 	// Generate root handle
-	rootHandle := store.generateFileHandle(share.Name, "/")
+	rootHandle := store.generateFileHandle(share.Name)
 
 	store.shares[share.Name] = &shareData{
 		Share:      *share,
@@ -215,7 +215,7 @@ func (store *MemoryMetadataStore) CreateRootDirectory(
 	if sd, ok := store.shares[shareName]; ok && len(sd.RootHandle) > 0 {
 		rootHandle = sd.RootHandle
 	} else {
-		rootHandle = store.generateFileHandle(shareName, "/")
+		rootHandle = store.generateFileHandle(shareName)
 	}
 	key := handleToKey(rootHandle)
 

--- a/pkg/metadata/store/memory/store.go
+++ b/pkg/metadata/store/memory/store.go
@@ -9,7 +9,6 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/google/uuid"
 	"github.com/oklog/ulid/v2"
 
 	"github.com/marmos91/dittofs/pkg/block"
@@ -106,10 +105,9 @@ type ShareSession struct {
 //
 // Handle Generation:
 //
-// generateFileHandle ignores the path it is given and encodes a fresh UUID
-// against the share name via metadata.EncodeShareHandle, so a handle is
-// independent of the name a file is reachable under and survives renames.
-// The badger backend mints handles the same way.
+// generateFileHandle encodes a fresh UUID against the share name, so a
+// handle is independent of the name a file is reachable under and survives
+// renames. The badger backend mints handles the same way.
 //
 // Consistency Guarantees:
 //
@@ -584,45 +582,16 @@ func (store *MemoryMetadataStore) childNameLocked(
 	return best
 }
 
-// generateFileHandle creates a UUID-based file handle from a share name.
-//
-// Generates a new UUID for each file and encodes it with the
-// share name to create a unique file handle in the format:
-//
-//	Format: "shareName:uuid"
-//	Example: "/export:550e8400-e29b-41d4-a716-446655440000"
-//	Size: share name length + 37 bytes (1 colon + 36 UUID chars)
-//
-// UUID-based handles provide:
-//   - Guaranteed uniqueness (no collisions)
-//   - NFS compatibility (typically under 64 bytes)
-//   - Stable identifiers (UUID doesn't change)
-//   - No path length limitations
-//
-// Note: The fullPath parameter is currently unused but kept for compatibility
-// with existing code. In the future, if path tracking is needed, it should be
-// stored separately in the fileData structure.
-//
-// Parameters:
-//   - shareName: The share name this file belongs to
-//   - fullPath: Reserved for future use (currently ignored)
-//
-// Returns:
-//   - FileHandle: A UUID-based file handle
-func (store *MemoryMetadataStore) generateFileHandle(shareName, fullPath string) metadata.FileHandle {
-	// Generate a new UUID for this file
-	id := uuid.New()
-
-	// Encode the handle using the standard format
-	handle, err := metadata.EncodeShareHandle(shareName, id)
+// generateFileHandle returns a fresh UUID-based handle for a file in the
+// named share, in the standard "shareName:uuid" format. It panics on the
+// only failure metadata.GenerateNewHandle can report — a share name long
+// enough to push the encoded handle past the 64-byte NFS limit — because
+// share names are length-validated before a share is ever registered.
+func (store *MemoryMetadataStore) generateFileHandle(shareName string) metadata.FileHandle {
+	handle, err := metadata.GenerateNewHandle(shareName)
 	if err != nil {
-		// This should never happen for valid share names and UUIDs
-		// If it does, generate a fallback handle
-		// In practice, this error only occurs if the encoded handle exceeds 64 bytes,
-		// which is unlikely for reasonable share names
 		panic(fmt.Sprintf("failed to encode file handle: %v", err))
 	}
-
 	return handle
 }
 

--- a/pkg/metadata/store/memory/store.go
+++ b/pkg/metadata/store/memory/store.go
@@ -584,9 +584,8 @@ func (store *MemoryMetadataStore) childNameLocked(
 
 // generateFileHandle returns a fresh UUID-based handle for a file in the
 // named share, in the standard "shareName:uuid" format. It panics on the
-// only failure metadata.GenerateNewHandle can report — a share name long
-// enough to push the encoded handle past the 64-byte NFS limit — because
-// share names are length-validated before a share is ever registered.
+// only failure GenerateNewHandle can report — a share name long enough to
+// push the encoded handle past 64 bytes — which share creation rejects.
 func (store *MemoryMetadataStore) generateFileHandle(shareName string) metadata.FileHandle {
 	handle, err := metadata.GenerateNewHandle(shareName)
 	if err != nil {

--- a/pkg/metadata/store/memory/transaction.go
+++ b/pkg/metadata/store/memory/transaction.go
@@ -693,7 +693,7 @@ func (tx *memoryTransaction) CreateShare(ctx context.Context, share *metadata.Sh
 		return nil
 	}
 
-	rootHandle := tx.store.generateFileHandle(share.Name, "/")
+	rootHandle := tx.store.generateFileHandle(share.Name)
 	tx.store.shares[share.Name] = &shareData{
 		Share:      *share,
 		RootHandle: rootHandle,
@@ -794,7 +794,7 @@ func (tx *memoryTransaction) CreateRootDirectory(ctx context.Context, shareName 
 	if sd, ok := tx.store.shares[shareName]; ok && len(sd.RootHandle) > 0 {
 		rootHandle = sd.RootHandle
 	} else {
-		rootHandle = tx.store.generateFileHandle(shareName, "/")
+		rootHandle = tx.store.generateFileHandle(shareName)
 	}
 	key := handleToKey(rootHandle)
 

--- a/pkg/metadata/store/postgres/client_recovery.go
+++ b/pkg/metadata/store/postgres/client_recovery.go
@@ -143,34 +143,24 @@ func (s *postgresRecoveryStore) RecordReclaimComplete(ctx context.Context, clien
 // Ensure PostgresMetadataStore implements ClientRecoveryStore.
 var _ lock.ClientRecoveryStore = (*PostgresMetadataStore)(nil)
 
-// getRecoveryStore returns the recovery store, initializing if needed.
-func (s *PostgresMetadataStore) getRecoveryStore() *postgresRecoveryStore {
-	s.recoveryStoreMu.Lock()
-	defer s.recoveryStoreMu.Unlock()
-	if s.recoveryStore == nil {
-		s.recoveryStore = newPostgresRecoveryStore(s)
-	}
-	return s.recoveryStore
-}
-
 // PutClientRecovery stores or replaces a client recovery record.
 func (s *PostgresMetadataStore) PutClientRecovery(ctx context.Context, rec *lock.V4ClientRecoveryRecord) error {
-	return s.getRecoveryStore().PutClientRecovery(ctx, rec)
+	return s.recoveryStore.PutClientRecovery(ctx, rec)
 }
 
 // DeleteClientRecovery removes a client recovery record.
 func (s *PostgresMetadataStore) DeleteClientRecovery(ctx context.Context, clientIDString string) error {
-	return s.getRecoveryStore().DeleteClientRecovery(ctx, clientIDString)
+	return s.recoveryStore.DeleteClientRecovery(ctx, clientIDString)
 }
 
 // ListClientRecovery returns all stored client recovery records.
 func (s *PostgresMetadataStore) ListClientRecovery(ctx context.Context) ([]*lock.V4ClientRecoveryRecord, error) {
-	return s.getRecoveryStore().ListClientRecovery(ctx)
+	return s.recoveryStore.ListClientRecovery(ctx)
 }
 
 // RecordReclaimComplete marks a client's recovery record reclaim-complete.
 func (s *PostgresMetadataStore) RecordReclaimComplete(ctx context.Context, clientIDString string) error {
-	return s.getRecoveryStore().RecordReclaimComplete(ctx, clientIDString)
+	return s.recoveryStore.RecordReclaimComplete(ctx, clientIDString)
 }
 
 // ClientRecoveryStore returns this store as a ClientRecoveryStore.

--- a/pkg/metadata/store/postgres/clients.go
+++ b/pkg/metadata/store/postgres/clients.go
@@ -190,44 +190,34 @@ func (s *postgresClientStore) DeleteClientRegistrationsByMonName(ctx context.Con
 // Ensure PostgresMetadataStore implements ClientRegistrationStore
 var _ lock.ClientRegistrationStore = (*PostgresMetadataStore)(nil)
 
-// getClientStore returns the client store, initializing if needed.
-func (s *PostgresMetadataStore) getClientStore() *postgresClientStore {
-	s.clientStoreMu.Lock()
-	defer s.clientStoreMu.Unlock()
-	if s.clientStore == nil {
-		s.clientStore = newPostgresClientStore(s)
-	}
-	return s.clientStore
-}
-
 // PutClientRegistration stores or updates a client registration.
 func (s *PostgresMetadataStore) PutClientRegistration(ctx context.Context, reg *lock.PersistedClientRegistration) error {
-	return s.getClientStore().PutClientRegistration(ctx, reg)
+	return s.clientStore.PutClientRegistration(ctx, reg)
 }
 
 // GetClientRegistration retrieves a registration by client ID.
 func (s *PostgresMetadataStore) GetClientRegistration(ctx context.Context, clientID string) (*lock.PersistedClientRegistration, error) {
-	return s.getClientStore().GetClientRegistration(ctx, clientID)
+	return s.clientStore.GetClientRegistration(ctx, clientID)
 }
 
 // DeleteClientRegistration removes a registration by client ID.
 func (s *PostgresMetadataStore) DeleteClientRegistration(ctx context.Context, clientID string) error {
-	return s.getClientStore().DeleteClientRegistration(ctx, clientID)
+	return s.clientStore.DeleteClientRegistration(ctx, clientID)
 }
 
 // ListClientRegistrations returns all stored registrations.
 func (s *PostgresMetadataStore) ListClientRegistrations(ctx context.Context) ([]*lock.PersistedClientRegistration, error) {
-	return s.getClientStore().ListClientRegistrations(ctx)
+	return s.clientStore.ListClientRegistrations(ctx)
 }
 
 // DeleteAllClientRegistrations removes all registrations.
 func (s *PostgresMetadataStore) DeleteAllClientRegistrations(ctx context.Context) (int, error) {
-	return s.getClientStore().DeleteAllClientRegistrations(ctx)
+	return s.clientStore.DeleteAllClientRegistrations(ctx)
 }
 
 // DeleteClientRegistrationsByMonName removes all registrations monitoring a specific host.
 func (s *PostgresMetadataStore) DeleteClientRegistrationsByMonName(ctx context.Context, monName string) (int, error) {
-	return s.getClientStore().DeleteClientRegistrationsByMonName(ctx, monName)
+	return s.clientStore.DeleteClientRegistrationsByMonName(ctx, monName)
 }
 
 // ClientRegistrationStore returns this store as a ClientRegistrationStore.

--- a/pkg/metadata/store/postgres/config.go
+++ b/pkg/metadata/store/postgres/config.go
@@ -33,9 +33,8 @@ type PostgresMetadataStoreConfig struct {
 	// DisablePreparedStatements turns off pgx's per-connection prepared-statement
 	// cache, which a pooler in transaction-pooling mode cannot serve. Default
 	// false: statements are prepared and cached.
-	DisablePreparedStatements bool          `mapstructure:"disable_prepared_statements"`
-	AutoMigrate               bool          `mapstructure:"auto_migrate"`    // Default: false (manual control)
-	StatsCacheTTL             time.Duration `mapstructure:"stats_cache_ttl"` // Default: 5s
+	DisablePreparedStatements bool `mapstructure:"disable_prepared_statements"`
+	AutoMigrate               bool `mapstructure:"auto_migrate"` // Default: false (manual control)
 
 	// RelaxedDurability defers commit-time WAL flush for pure-namespace metadata
 	// writes via SET LOCAL synchronous_commit=off, honoring the same
@@ -80,11 +79,6 @@ func (c *PostgresMetadataStoreConfig) ApplyDefaults() {
 	}
 	if c.QueryTimeout == 0 {
 		c.QueryTimeout = 30 * time.Second
-	}
-
-	// Feature defaults
-	if c.StatsCacheTTL == 0 {
-		c.StatsCacheTTL = 5 * time.Second
 	}
 
 	// SSL mode default

--- a/pkg/metadata/store/postgres/durable_handles.go
+++ b/pkg/metadata/store/postgres/durable_handles.go
@@ -367,57 +367,48 @@ func (s *postgresDurableStore) DeleteExpiredDurableHandles(ctx context.Context, 
 
 var _ lock.DurableHandleStore = (*PostgresMetadataStore)(nil)
 
-func (s *PostgresMetadataStore) getDurableStore() *postgresDurableStore {
-	s.durableStoreMu.Lock()
-	defer s.durableStoreMu.Unlock()
-	if s.durableStore == nil {
-		s.durableStore = newPostgresDurableStore(s)
-	}
-	return s.durableStore
-}
-
 func (s *PostgresMetadataStore) PutDurableHandle(ctx context.Context, handle *lock.PersistedDurableHandle) error {
-	return s.getDurableStore().PutDurableHandle(ctx, handle)
+	return s.durableStore.PutDurableHandle(ctx, handle)
 }
 
 func (s *PostgresMetadataStore) GetDurableHandle(ctx context.Context, id string) (*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().GetDurableHandle(ctx, id)
+	return s.durableStore.GetDurableHandle(ctx, id)
 }
 
 func (s *PostgresMetadataStore) GetDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().GetDurableHandleByFileID(ctx, fileID)
+	return s.durableStore.GetDurableHandleByFileID(ctx, fileID)
 }
 
 func (s *PostgresMetadataStore) GetDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().GetDurableHandleByCreateGuid(ctx, createGuid)
+	return s.durableStore.GetDurableHandleByCreateGuid(ctx, createGuid)
 }
 
 func (s *PostgresMetadataStore) ConsumeDurableHandle(ctx context.Context, id string) (*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().ConsumeDurableHandle(ctx, id)
+	return s.durableStore.ConsumeDurableHandle(ctx, id)
 }
 
 func (s *PostgresMetadataStore) GetDurableHandlesByAppInstanceId(ctx context.Context, appInstanceId [16]byte) ([]*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().GetDurableHandlesByAppInstanceId(ctx, appInstanceId)
+	return s.durableStore.GetDurableHandlesByAppInstanceId(ctx, appInstanceId)
 }
 
 func (s *PostgresMetadataStore) GetDurableHandlesByFileHandle(ctx context.Context, fileHandle []byte) ([]*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().GetDurableHandlesByFileHandle(ctx, fileHandle)
+	return s.durableStore.GetDurableHandlesByFileHandle(ctx, fileHandle)
 }
 
 func (s *PostgresMetadataStore) DeleteDurableHandle(ctx context.Context, id string) error {
-	return s.getDurableStore().DeleteDurableHandle(ctx, id)
+	return s.durableStore.DeleteDurableHandle(ctx, id)
 }
 
 func (s *PostgresMetadataStore) ListDurableHandles(ctx context.Context) ([]*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().ListDurableHandles(ctx)
+	return s.durableStore.ListDurableHandles(ctx)
 }
 
 func (s *PostgresMetadataStore) ListDurableHandlesByShare(ctx context.Context, shareName string) ([]*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().ListDurableHandlesByShare(ctx, shareName)
+	return s.durableStore.ListDurableHandlesByShare(ctx, shareName)
 }
 
 func (s *PostgresMetadataStore) DeleteExpiredDurableHandles(ctx context.Context, now time.Time) (int, error) {
-	return s.getDurableStore().DeleteExpiredDurableHandles(ctx, now)
+	return s.durableStore.DeleteExpiredDurableHandles(ctx, now)
 }
 
 // DurableHandleStore returns this store as a DurableHandleStore.

--- a/pkg/metadata/store/postgres/locks.go
+++ b/pkg/metadata/store/postgres/locks.go
@@ -623,78 +623,58 @@ func (s *postgresLockStore) reclaimLeaseTx(ctx context.Context, tx pgx.Tx, fileH
 // Ensure PostgresMetadataStore implements LockStore
 var _ lock.LockStore = (*PostgresMetadataStore)(nil)
 
-// initLockStore ensures the lock store is initialized.
-func (s *PostgresMetadataStore) initLockStore() {
-	s.lockStoreMu.Lock()
-	defer s.lockStoreMu.Unlock()
-	if s.lockStore == nil {
-		s.lockStore = newPostgresLockStore(s.pool)
-	}
-}
-
 // PutLock persists a lock.
 func (s *PostgresMetadataStore) PutLock(ctx context.Context, lk *lock.PersistedLock) error {
-	s.initLockStore()
 	return s.lockStore.PutLock(ctx, lk)
 }
 
 // GetLock retrieves a lock by ID.
 func (s *PostgresMetadataStore) GetLock(ctx context.Context, lockID string) (*lock.PersistedLock, error) {
-	s.initLockStore()
 	return s.lockStore.GetLock(ctx, lockID)
 }
 
 // DeleteLock removes a lock by ID.
 func (s *PostgresMetadataStore) DeleteLock(ctx context.Context, lockID string) error {
-	s.initLockStore()
 	return s.lockStore.DeleteLock(ctx, lockID)
 }
 
 // ListLocks returns locks matching the query.
 func (s *PostgresMetadataStore) ListLocks(ctx context.Context, query lock.LockQuery) ([]*lock.PersistedLock, error) {
-	s.initLockStore()
 	return s.lockStore.ListLocks(ctx, query)
 }
 
 // DeleteLocksByClient removes all locks for a client.
 func (s *PostgresMetadataStore) DeleteLocksByClient(ctx context.Context, clientID string) (int, error) {
-	s.initLockStore()
 	return s.lockStore.DeleteLocksByClient(ctx, clientID)
 }
 
 // DeleteLocksByFile removes all locks for a file.
 func (s *PostgresMetadataStore) DeleteLocksByFile(ctx context.Context, fileID string) (int, error) {
-	s.initLockStore()
 	return s.lockStore.DeleteLocksByFile(ctx, fileID)
 }
 
 // GetServerEpoch returns current server epoch.
 func (s *PostgresMetadataStore) GetServerEpoch(ctx context.Context) (uint64, error) {
-	s.initLockStore()
 	return s.lockStore.GetServerEpoch(ctx)
 }
 
 // IncrementServerEpoch increments and returns new epoch.
 func (s *PostgresMetadataStore) IncrementServerEpoch(ctx context.Context) (uint64, error) {
-	s.initLockStore()
 	return s.lockStore.IncrementServerEpoch(ctx)
 }
 
 // GetCleanShutdown reports whether the previous run shut down gracefully.
 func (s *PostgresMetadataStore) GetCleanShutdown(ctx context.Context) (bool, error) {
-	s.initLockStore()
 	return s.lockStore.GetCleanShutdown(ctx)
 }
 
 // SetCleanShutdown records the clean-shutdown marker durably.
 func (s *PostgresMetadataStore) SetCleanShutdown(ctx context.Context, clean bool) error {
-	s.initLockStore()
 	return s.lockStore.SetCleanShutdown(ctx, clean)
 }
 
 // ReclaimLease reclaims an existing lease during grace period.
 func (s *PostgresMetadataStore) ReclaimLease(ctx context.Context, fileHandle lock.FileHandle, leaseKey [16]byte, clientID string) (*lock.UnifiedLock, error) {
-	s.initLockStore()
 	return s.lockStore.ReclaimLease(ctx, fileHandle, leaseKey, clientID)
 }
 
@@ -706,56 +686,45 @@ func (s *PostgresMetadataStore) ReclaimLease(ctx context.Context, fileHandle loc
 var _ lock.LockStore = (*postgresTransaction)(nil)
 
 func (ptx *postgresTransaction) PutLock(ctx context.Context, lk *lock.PersistedLock) error {
-	ptx.store.initLockStore()
 	return ptx.store.lockStore.putLockTx(ctx, ptx.tx, lk)
 }
 
 func (ptx *postgresTransaction) GetLock(ctx context.Context, lockID string) (*lock.PersistedLock, error) {
-	ptx.store.initLockStore()
 	return ptx.store.lockStore.getLockTx(ctx, ptx.tx, lockID)
 }
 
 func (ptx *postgresTransaction) DeleteLock(ctx context.Context, lockID string) error {
-	ptx.store.initLockStore()
 	return ptx.store.lockStore.deleteLockTx(ctx, ptx.tx, lockID)
 }
 
 func (ptx *postgresTransaction) ListLocks(ctx context.Context, query lock.LockQuery) ([]*lock.PersistedLock, error) {
-	ptx.store.initLockStore()
 	return ptx.store.lockStore.listLocksTx(ctx, ptx.tx, query)
 }
 
 func (ptx *postgresTransaction) DeleteLocksByClient(ctx context.Context, clientID string) (int, error) {
-	ptx.store.initLockStore()
 	return ptx.store.lockStore.deleteLocksByClientTx(ctx, ptx.tx, clientID)
 }
 
 func (ptx *postgresTransaction) DeleteLocksByFile(ctx context.Context, fileID string) (int, error) {
-	ptx.store.initLockStore()
 	return ptx.store.lockStore.deleteLocksByFileTx(ctx, ptx.tx, fileID)
 }
 
 func (ptx *postgresTransaction) GetServerEpoch(ctx context.Context) (uint64, error) {
-	ptx.store.initLockStore()
 	return ptx.store.lockStore.getServerEpochTx(ctx, ptx.tx)
 }
 
 func (ptx *postgresTransaction) IncrementServerEpoch(ctx context.Context) (uint64, error) {
-	ptx.store.initLockStore()
 	return ptx.store.lockStore.incrementServerEpochTx(ctx, ptx.tx)
 }
 
 func (ptx *postgresTransaction) GetCleanShutdown(ctx context.Context) (bool, error) {
-	ptx.store.initLockStore()
 	return ptx.store.lockStore.getCleanShutdownTx(ctx, ptx.tx)
 }
 
 func (ptx *postgresTransaction) SetCleanShutdown(ctx context.Context, clean bool) error {
-	ptx.store.initLockStore()
 	return ptx.store.lockStore.setCleanShutdownTx(ctx, ptx.tx, clean)
 }
 
 func (ptx *postgresTransaction) ReclaimLease(ctx context.Context, fileHandle lock.FileHandle, leaseKey [16]byte, clientID string) (*lock.UnifiedLock, error) {
-	ptx.store.initLockStore()
 	return ptx.store.lockStore.reclaimLeaseTx(ctx, ptx.tx, fileHandle, leaseKey, clientID)
 }

--- a/pkg/metadata/store/postgres/objects.go
+++ b/pkg/metadata/store/postgres/objects.go
@@ -65,7 +65,7 @@ func (s *PostgresMetadataStore) GetFileChunk(ctx context.Context, id string) (*m
 // content hash, regardless of block state. The content hash is derived
 // at rollup time (long before the block reaches the remote) and is the
 // key the engine's CAS read path uses to resolve a chunk. Gating the
-// write on IsFinalized() left every Pending row with a NULL hash; reads
+// write on IsRemote() left every Pending row with a NULL hash; reads
 // then survived only while the bytes stayed in the local append log or
 // RAM cache, and broke the moment local state went cold (restart +
 // cache eviction, or a snapshot restore's ResetLocalState). The memory

--- a/pkg/metadata/store/postgres/pool_helpers.go
+++ b/pkg/metadata/store/postgres/pool_helpers.go
@@ -37,6 +37,26 @@ const poolConnectionAcquireTimeout = 10 * time.Second
 // query body can run on either.
 type rowQuerier func(ctx context.Context, sql string, args ...any) pgx.Row
 
+// acquireConn checks out a pooled connection under the shared acquire timeout.
+// The timeout bounds ONLY the checkout: the returned connection is used with the
+// caller's own context so a lazily-read result set is not cancelled the moment
+// this function returns. A checkout that times out while the caller's context is
+// still live is reported as pool exhaustion; anything else is mapped as a normal
+// query error against op/sql. The caller owns releasing the connection.
+func (s *PostgresMetadataStore) acquireConn(ctx context.Context, op, sql string) (*pgxpool.Conn, error) {
+	acquireCtx, cancel := context.WithTimeout(ctx, poolConnectionAcquireTimeout)
+	defer cancel()
+
+	conn, err := s.pool.Acquire(acquireCtx)
+	if err != nil {
+		if acquireCtx.Err() == context.DeadlineExceeded && ctx.Err() == nil {
+			return nil, fmt.Errorf("connection acquire timeout after %v: pool may be exhausted", poolConnectionAcquireTimeout)
+		}
+		return nil, mapPgError(err, op, sql)
+	}
+	return conn, nil
+}
+
 // queryRow executes a query that returns at most one row with connection acquire timeout.
 // This prevents indefinite blocking when the pool is exhausted.
 func (s *PostgresMetadataStore) queryRow(ctx context.Context, sql string, args ...any) pgx.Row {
@@ -45,24 +65,13 @@ func (s *PostgresMetadataStore) queryRow(ctx context.Context, sql string, args .
 		return &errorRow{err: ctx.Err()}
 	}
 
-	// The acquire timeout bounds ONLY the connection acquisition — it must not
-	// outlive this function via the returned Row. pgx.QueryRow is lazy: the row
-	// data is read from the wire inside the caller's Scan(), bound to whatever
-	// context was passed to QueryRow. If we passed acquireCtx (cancelled by the
-	// defer below the instant this function returns) the caller's Scan would run
-	// against an already-cancelled context and intermittently fail with
-	// "context canceled" depending on whether the row had buffered yet. So scope
-	// acquireCtx to Acquire only, then run the query on the parent ctx — the same
-	// pattern as query()/exec() — and release the connection after Scan.
-	acquireCtx, cancel := context.WithTimeout(ctx, poolConnectionAcquireTimeout)
-	defer cancel()
-
-	conn, err := s.pool.Acquire(acquireCtx)
+	// pgx.QueryRow is lazy: the row is read off the wire inside the caller's
+	// Scan(), bound to the context passed here. Run it on the parent ctx (not the
+	// acquire context, which is cancelled the instant acquireConn returns) and
+	// release the connection after Scan.
+	conn, err := s.acquireConn(ctx, "queryRow", sql)
 	if err != nil {
-		if acquireCtx.Err() == context.DeadlineExceeded && ctx.Err() == nil {
-			return &errorRow{err: fmt.Errorf("connection acquire timeout after %v: pool may be exhausted", poolConnectionAcquireTimeout)}
-		}
-		return &errorRow{err: mapPgError(err, "queryRow", sql)}
+		return &errorRow{err: err}
 	}
 
 	return &poolRow{row: conn.QueryRow(ctx, sql, args...), conn: conn}
@@ -77,18 +86,9 @@ func (s *PostgresMetadataStore) query(ctx context.Context, sql string, args ...a
 		return nil, err
 	}
 
-	// Apply connection acquire timeout
-	acquireCtx, cancel := context.WithTimeout(ctx, poolConnectionAcquireTimeout)
-	defer cancel()
-
-	// Acquire connection from pool
-	conn, err := s.pool.Acquire(acquireCtx)
+	conn, err := s.acquireConn(ctx, "query", sql)
 	if err != nil {
-		if acquireCtx.Err() == context.DeadlineExceeded && ctx.Err() == nil {
-			// Acquire timed out, not the parent context
-			return nil, fmt.Errorf("connection acquire timeout after %v: pool may be exhausted", poolConnectionAcquireTimeout)
-		}
-		return nil, mapPgError(err, "query", sql)
+		return nil, err
 	}
 
 	// Execute query
@@ -111,18 +111,9 @@ func (s *PostgresMetadataStore) exec(ctx context.Context, sql string, args ...an
 		return pgconn.CommandTag{}, err
 	}
 
-	// Apply connection acquire timeout
-	acquireCtx, cancel := context.WithTimeout(ctx, poolConnectionAcquireTimeout)
-	defer cancel()
-
-	// Acquire connection from pool
-	conn, err := s.pool.Acquire(acquireCtx)
+	conn, err := s.acquireConn(ctx, "exec", sql)
 	if err != nil {
-		if acquireCtx.Err() == context.DeadlineExceeded && ctx.Err() == nil {
-			// Acquire timed out, not the parent context
-			return pgconn.CommandTag{}, fmt.Errorf("connection acquire timeout after %v: pool may be exhausted", poolConnectionAcquireTimeout)
-		}
-		return pgconn.CommandTag{}, mapPgError(err, "exec", sql)
+		return pgconn.CommandTag{}, err
 	}
 	defer conn.Release()
 

--- a/pkg/metadata/store/postgres/store.go
+++ b/pkg/metadata/store/postgres/store.go
@@ -147,8 +147,8 @@ func NewPostgresMetadataStore(
 		cancel:       cancel,
 		quota:        quota.NewCache(),
 	}
-	// The substores derive only from pool, which is never reassigned, so they
-	// are bound once here rather than lazily behind a mutex.
+	// The substores derive only from pool, which is never reassigned, so bind
+	// them once here.
 	store.lockStore = newPostgresLockStore(pool)
 	store.clientStore = newPostgresClientStore(store)
 	store.durableStore = newPostgresDurableStore(store)

--- a/pkg/metadata/store/postgres/store.go
+++ b/pkg/metadata/store/postgres/store.go
@@ -51,24 +51,16 @@ type PostgresMetadataStore struct {
 	cancel context.CancelFunc
 
 	// lockStore holds persisted lock data for NLM/SMB lock persistence.
-	// Initialized lazily via initLockStore().
-	lockStore   *postgresLockStore
-	lockStoreMu sync.Mutex
+	lockStore *postgresLockStore
 
 	// clientStore holds NSM client registration persistence.
-	// Initialized lazily via getClientStore().
-	clientStore   *postgresClientStore
-	clientStoreMu sync.Mutex
+	clientStore *postgresClientStore
 
 	// durableStore holds SMB3 durable handle persistence.
-	// Initialized lazily via getDurableStore().
-	durableStore   *postgresDurableStore
-	durableStoreMu sync.Mutex
+	durableStore *postgresDurableStore
 
 	// recoveryStore holds NFSv4 client-recovery persistence.
-	// Initialized lazily via getRecoveryStore().
-	recoveryStore   *postgresRecoveryStore
-	recoveryStoreMu sync.Mutex
+	recoveryStore *postgresRecoveryStore
 
 	// usedBytes tracks the total logical bytes used by regular files.
 	// Updated atomically on every size-changing operation (create, update, truncate, delete).
@@ -155,6 +147,12 @@ func NewPostgresMetadataStore(
 		cancel:       cancel,
 		quota:        quota.NewCache(),
 	}
+	// The substores derive only from pool, which is never reassigned, so they
+	// are bound once here rather than lazily behind a mutex.
+	store.lockStore = newPostgresLockStore(pool)
+	store.clientStore = newPostgresClientStore(store)
+	store.durableStore = newPostgresDurableStore(store)
+	store.recoveryStore = newPostgresRecoveryStore(store)
 
 	// Initialize the usedBytes counter from a SQL SUM query.
 	if err := store.initUsedBytesCounter(ctx); err != nil {
@@ -179,7 +177,6 @@ func NewPostgresMetadataStore(
 		"host", cfg.Host,
 		"database", cfg.Database,
 		"max_conns", cfg.MaxConns,
-		"stats_cache_ttl", cfg.StatsCacheTTL,
 		"prepared_statements", !cfg.DisablePreparedStatements,
 	)
 

--- a/pkg/metadata/store/sqlite/block_record_store.go
+++ b/pkg/metadata/store/sqlite/block_record_store.go
@@ -93,7 +93,7 @@ func (s *SQLiteMetadataStore) WalkBlockRecords(ctx context.Context, fn func(bloc
 	}
 	defer rows.Close()
 	for rows.Next() {
-		rec, _, err := scanBlockRecordRow(rows)
+		rec, _, err := scanBlockRecord(rows)
 		if err != nil {
 			return fmt.Errorf("sqlite block_records walk scan: %w", err)
 		}
@@ -195,7 +195,7 @@ func (tx *sqliteTransaction) WalkBlockRecords(ctx context.Context, fn func(block
 	}
 	defer rows.Close()
 	for rows.Next() {
-		rec, _, err := scanBlockRecordRow(rows)
+		rec, _, err := scanBlockRecord(rows)
 		if err != nil {
 			return fmt.Errorf("sqlite tx block_records walk scan: %w", err)
 		}
@@ -256,34 +256,6 @@ func scanBlockRecord(row scanRow) (block.BlockRecord, bool, error) {
 	}
 	if len(hashRaw) != len(block.ContentHash{}) {
 		return block.BlockRecord{}, false, fmt.Errorf("sqlite scanBlockRecord: malformed block_hash length %d", len(hashRaw))
-	}
-	var h block.ContentHash
-	copy(h[:], hashRaw)
-	return block.BlockRecord{
-		BlockID:        blockID,
-		BlockHash:      h,
-		Length:         length,
-		LiveChunkCount: liveCount,
-		SyncState:      block.BlockState(syncState),
-	}, true, nil
-}
-
-// scanBlockRecordRow scans a streaming Rows cursor (from WalkBlockRecords).
-// The caller drives rows.Next(); this only scans the current row.
-// found is always true here since we are iterating an existing row set.
-func scanBlockRecordRow(rows scanRows) (block.BlockRecord, bool, error) {
-	var (
-		blockID   string
-		hashRaw   []byte
-		length    int64
-		liveCount uint32
-		syncState int
-	)
-	if err := rows.Scan(&blockID, &hashRaw, &length, &liveCount, &syncState); err != nil {
-		return block.BlockRecord{}, false, err
-	}
-	if len(hashRaw) != len(block.ContentHash{}) {
-		return block.BlockRecord{}, false, fmt.Errorf("sqlite scanBlockRecordRow: malformed block_hash length %d", len(hashRaw))
 	}
 	var h block.ContentHash
 	copy(h[:], hashRaw)

--- a/pkg/metadata/store/sqlite/client_recovery.go
+++ b/pkg/metadata/store/sqlite/client_recovery.go
@@ -142,34 +142,24 @@ func (s *sqliteRecoveryStore) RecordReclaimComplete(ctx context.Context, clientI
 // Ensure SQLiteMetadataStore implements ClientRecoveryStore.
 var _ lock.ClientRecoveryStore = (*SQLiteMetadataStore)(nil)
 
-// getRecoveryStore returns the recovery store, initializing if needed.
-func (s *SQLiteMetadataStore) getRecoveryStore() *sqliteRecoveryStore {
-	s.recoveryStoreMu.Lock()
-	defer s.recoveryStoreMu.Unlock()
-	if s.recoveryStore == nil {
-		s.recoveryStore = newSQLiteRecoveryStore(s.conn())
-	}
-	return s.recoveryStore
-}
-
 // PutClientRecovery stores or replaces a client recovery record.
 func (s *SQLiteMetadataStore) PutClientRecovery(ctx context.Context, rec *lock.V4ClientRecoveryRecord) error {
-	return s.getRecoveryStore().PutClientRecovery(ctx, rec)
+	return s.recoveryStore.PutClientRecovery(ctx, rec)
 }
 
 // DeleteClientRecovery removes a client recovery record.
 func (s *SQLiteMetadataStore) DeleteClientRecovery(ctx context.Context, clientIDString string) error {
-	return s.getRecoveryStore().DeleteClientRecovery(ctx, clientIDString)
+	return s.recoveryStore.DeleteClientRecovery(ctx, clientIDString)
 }
 
 // ListClientRecovery returns all stored client recovery records.
 func (s *SQLiteMetadataStore) ListClientRecovery(ctx context.Context) ([]*lock.V4ClientRecoveryRecord, error) {
-	return s.getRecoveryStore().ListClientRecovery(ctx)
+	return s.recoveryStore.ListClientRecovery(ctx)
 }
 
 // RecordReclaimComplete marks a client's recovery record reclaim-complete.
 func (s *SQLiteMetadataStore) RecordReclaimComplete(ctx context.Context, clientIDString string) error {
-	return s.getRecoveryStore().RecordReclaimComplete(ctx, clientIDString)
+	return s.recoveryStore.RecordReclaimComplete(ctx, clientIDString)
 }
 
 // ClientRecoveryStore returns this store as a ClientRecoveryStore.

--- a/pkg/metadata/store/sqlite/clients.go
+++ b/pkg/metadata/store/sqlite/clients.go
@@ -188,44 +188,34 @@ func (s *sqliteClientStore) DeleteClientRegistrationsByMonName(ctx context.Conte
 // Ensure SQLiteMetadataStore implements ClientRegistrationStore
 var _ lock.ClientRegistrationStore = (*SQLiteMetadataStore)(nil)
 
-// getClientStore returns the client store, initializing if needed.
-func (s *SQLiteMetadataStore) getClientStore() *sqliteClientStore {
-	s.clientStoreMu.Lock()
-	defer s.clientStoreMu.Unlock()
-	if s.clientStore == nil {
-		s.clientStore = newSQLiteClientStore(s.conn())
-	}
-	return s.clientStore
-}
-
 // PutClientRegistration stores or updates a client registration.
 func (s *SQLiteMetadataStore) PutClientRegistration(ctx context.Context, reg *lock.PersistedClientRegistration) error {
-	return s.getClientStore().PutClientRegistration(ctx, reg)
+	return s.clientStore.PutClientRegistration(ctx, reg)
 }
 
 // GetClientRegistration retrieves a registration by client ID.
 func (s *SQLiteMetadataStore) GetClientRegistration(ctx context.Context, clientID string) (*lock.PersistedClientRegistration, error) {
-	return s.getClientStore().GetClientRegistration(ctx, clientID)
+	return s.clientStore.GetClientRegistration(ctx, clientID)
 }
 
 // DeleteClientRegistration removes a registration by client ID.
 func (s *SQLiteMetadataStore) DeleteClientRegistration(ctx context.Context, clientID string) error {
-	return s.getClientStore().DeleteClientRegistration(ctx, clientID)
+	return s.clientStore.DeleteClientRegistration(ctx, clientID)
 }
 
 // ListClientRegistrations returns all stored registrations.
 func (s *SQLiteMetadataStore) ListClientRegistrations(ctx context.Context) ([]*lock.PersistedClientRegistration, error) {
-	return s.getClientStore().ListClientRegistrations(ctx)
+	return s.clientStore.ListClientRegistrations(ctx)
 }
 
 // DeleteAllClientRegistrations removes all registrations.
 func (s *SQLiteMetadataStore) DeleteAllClientRegistrations(ctx context.Context) (int, error) {
-	return s.getClientStore().DeleteAllClientRegistrations(ctx)
+	return s.clientStore.DeleteAllClientRegistrations(ctx)
 }
 
 // DeleteClientRegistrationsByMonName removes all registrations monitoring a specific host.
 func (s *SQLiteMetadataStore) DeleteClientRegistrationsByMonName(ctx context.Context, monName string) (int, error) {
-	return s.getClientStore().DeleteClientRegistrationsByMonName(ctx, monName)
+	return s.clientStore.DeleteClientRegistrationsByMonName(ctx, monName)
 }
 
 // ClientRegistrationStore returns this store as a ClientRegistrationStore.

--- a/pkg/metadata/store/sqlite/config.go
+++ b/pkg/metadata/store/sqlite/config.go
@@ -24,19 +24,12 @@ type SQLiteMetadataStoreConfig struct {
 	// AutoMigrate runs embedded migrations on open when true. Default: false
 	// (the factory enables it explicitly, matching the Postgres backend).
 	AutoMigrate bool `mapstructure:"auto_migrate"`
-
-	// StatsCacheTTL is retained for parity with the Postgres config surface.
-	// Default: 5s.
-	StatsCacheTTL time.Duration `mapstructure:"stats_cache_ttl"`
 }
 
 // ApplyDefaults sets default values for unspecified configuration fields.
 func (c *SQLiteMetadataStoreConfig) ApplyDefaults() {
 	if c.BusyTimeout == 0 {
 		c.BusyTimeout = 5 * time.Second
-	}
-	if c.StatsCacheTTL == 0 {
-		c.StatsCacheTTL = 5 * time.Second
 	}
 }
 

--- a/pkg/metadata/store/sqlite/durable_handles.go
+++ b/pkg/metadata/store/sqlite/durable_handles.go
@@ -393,57 +393,48 @@ func (s *sqliteDurableStore) DeleteExpiredDurableHandles(ctx context.Context, no
 
 var _ lock.DurableHandleStore = (*SQLiteMetadataStore)(nil)
 
-func (s *SQLiteMetadataStore) getDurableStore() *sqliteDurableStore {
-	s.durableStoreMu.Lock()
-	defer s.durableStoreMu.Unlock()
-	if s.durableStore == nil {
-		s.durableStore = newSQLiteDurableStore(s.conn())
-	}
-	return s.durableStore
-}
-
 func (s *SQLiteMetadataStore) PutDurableHandle(ctx context.Context, handle *lock.PersistedDurableHandle) error {
-	return s.getDurableStore().PutDurableHandle(ctx, handle)
+	return s.durableStore.PutDurableHandle(ctx, handle)
 }
 
 func (s *SQLiteMetadataStore) GetDurableHandle(ctx context.Context, id string) (*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().GetDurableHandle(ctx, id)
+	return s.durableStore.GetDurableHandle(ctx, id)
 }
 
 func (s *SQLiteMetadataStore) GetDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().GetDurableHandleByFileID(ctx, fileID)
+	return s.durableStore.GetDurableHandleByFileID(ctx, fileID)
 }
 
 func (s *SQLiteMetadataStore) GetDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().GetDurableHandleByCreateGuid(ctx, createGuid)
+	return s.durableStore.GetDurableHandleByCreateGuid(ctx, createGuid)
 }
 
 func (s *SQLiteMetadataStore) ConsumeDurableHandle(ctx context.Context, id string) (*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().ConsumeDurableHandle(ctx, id)
+	return s.durableStore.ConsumeDurableHandle(ctx, id)
 }
 
 func (s *SQLiteMetadataStore) GetDurableHandlesByAppInstanceId(ctx context.Context, appInstanceId [16]byte) ([]*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().GetDurableHandlesByAppInstanceId(ctx, appInstanceId)
+	return s.durableStore.GetDurableHandlesByAppInstanceId(ctx, appInstanceId)
 }
 
 func (s *SQLiteMetadataStore) GetDurableHandlesByFileHandle(ctx context.Context, fileHandle []byte) ([]*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().GetDurableHandlesByFileHandle(ctx, fileHandle)
+	return s.durableStore.GetDurableHandlesByFileHandle(ctx, fileHandle)
 }
 
 func (s *SQLiteMetadataStore) DeleteDurableHandle(ctx context.Context, id string) error {
-	return s.getDurableStore().DeleteDurableHandle(ctx, id)
+	return s.durableStore.DeleteDurableHandle(ctx, id)
 }
 
 func (s *SQLiteMetadataStore) ListDurableHandles(ctx context.Context) ([]*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().ListDurableHandles(ctx)
+	return s.durableStore.ListDurableHandles(ctx)
 }
 
 func (s *SQLiteMetadataStore) ListDurableHandlesByShare(ctx context.Context, shareName string) ([]*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().ListDurableHandlesByShare(ctx, shareName)
+	return s.durableStore.ListDurableHandlesByShare(ctx, shareName)
 }
 
 func (s *SQLiteMetadataStore) DeleteExpiredDurableHandles(ctx context.Context, now time.Time) (int, error) {
-	return s.getDurableStore().DeleteExpiredDurableHandles(ctx, now)
+	return s.durableStore.DeleteExpiredDurableHandles(ctx, now)
 }
 
 // DurableHandleStore returns this store as a DurableHandleStore.

--- a/pkg/metadata/store/sqlite/locks.go
+++ b/pkg/metadata/store/sqlite/locks.go
@@ -612,78 +612,58 @@ func (s *sqliteLockStore) reclaimLeaseTx(ctx context.Context, tx execer, fileHan
 // Ensure SQLiteMetadataStore implements LockStore
 var _ lock.LockStore = (*SQLiteMetadataStore)(nil)
 
-// initLockStore ensures the lock store is initialized.
-func (s *SQLiteMetadataStore) initLockStore() {
-	s.lockStoreMu.Lock()
-	defer s.lockStoreMu.Unlock()
-	if s.lockStore == nil {
-		s.lockStore = newSQLiteLockStore(s.conn())
-	}
-}
-
 // PutLock persists a lock.
 func (s *SQLiteMetadataStore) PutLock(ctx context.Context, lk *lock.PersistedLock) error {
-	s.initLockStore()
 	return s.lockStore.PutLock(ctx, lk)
 }
 
 // GetLock retrieves a lock by ID.
 func (s *SQLiteMetadataStore) GetLock(ctx context.Context, lockID string) (*lock.PersistedLock, error) {
-	s.initLockStore()
 	return s.lockStore.GetLock(ctx, lockID)
 }
 
 // DeleteLock removes a lock by ID.
 func (s *SQLiteMetadataStore) DeleteLock(ctx context.Context, lockID string) error {
-	s.initLockStore()
 	return s.lockStore.DeleteLock(ctx, lockID)
 }
 
 // ListLocks returns locks matching the query.
 func (s *SQLiteMetadataStore) ListLocks(ctx context.Context, query lock.LockQuery) ([]*lock.PersistedLock, error) {
-	s.initLockStore()
 	return s.lockStore.ListLocks(ctx, query)
 }
 
 // DeleteLocksByClient removes all locks for a client.
 func (s *SQLiteMetadataStore) DeleteLocksByClient(ctx context.Context, clientID string) (int, error) {
-	s.initLockStore()
 	return s.lockStore.DeleteLocksByClient(ctx, clientID)
 }
 
 // DeleteLocksByFile removes all locks for a file.
 func (s *SQLiteMetadataStore) DeleteLocksByFile(ctx context.Context, fileID string) (int, error) {
-	s.initLockStore()
 	return s.lockStore.DeleteLocksByFile(ctx, fileID)
 }
 
 // GetServerEpoch returns current server epoch.
 func (s *SQLiteMetadataStore) GetServerEpoch(ctx context.Context) (uint64, error) {
-	s.initLockStore()
 	return s.lockStore.GetServerEpoch(ctx)
 }
 
 // IncrementServerEpoch increments and returns new epoch.
 func (s *SQLiteMetadataStore) IncrementServerEpoch(ctx context.Context) (uint64, error) {
-	s.initLockStore()
 	return s.lockStore.IncrementServerEpoch(ctx)
 }
 
 // GetCleanShutdown reports whether the previous run shut down gracefully.
 func (s *SQLiteMetadataStore) GetCleanShutdown(ctx context.Context) (bool, error) {
-	s.initLockStore()
 	return s.lockStore.GetCleanShutdown(ctx)
 }
 
 // SetCleanShutdown records the clean-shutdown marker durably.
 func (s *SQLiteMetadataStore) SetCleanShutdown(ctx context.Context, clean bool) error {
-	s.initLockStore()
 	return s.lockStore.SetCleanShutdown(ctx, clean)
 }
 
 // ReclaimLease reclaims an existing lease during grace period.
 func (s *SQLiteMetadataStore) ReclaimLease(ctx context.Context, fileHandle lock.FileHandle, leaseKey [16]byte, clientID string) (*lock.UnifiedLock, error) {
-	s.initLockStore()
 	return s.lockStore.ReclaimLease(ctx, fileHandle, leaseKey, clientID)
 }
 
@@ -695,56 +675,45 @@ func (s *SQLiteMetadataStore) ReclaimLease(ctx context.Context, fileHandle lock.
 var _ lock.LockStore = (*sqliteTransaction)(nil)
 
 func (ptx *sqliteTransaction) PutLock(ctx context.Context, lk *lock.PersistedLock) error {
-	ptx.store.initLockStore()
 	return ptx.store.lockStore.putLockTx(ctx, ptx.tx, lk)
 }
 
 func (ptx *sqliteTransaction) GetLock(ctx context.Context, lockID string) (*lock.PersistedLock, error) {
-	ptx.store.initLockStore()
 	return ptx.store.lockStore.getLockTx(ctx, ptx.tx, lockID)
 }
 
 func (ptx *sqliteTransaction) DeleteLock(ctx context.Context, lockID string) error {
-	ptx.store.initLockStore()
 	return ptx.store.lockStore.deleteLockTx(ctx, ptx.tx, lockID)
 }
 
 func (ptx *sqliteTransaction) ListLocks(ctx context.Context, query lock.LockQuery) ([]*lock.PersistedLock, error) {
-	ptx.store.initLockStore()
 	return ptx.store.lockStore.listLocksTx(ctx, ptx.tx, query)
 }
 
 func (ptx *sqliteTransaction) DeleteLocksByClient(ctx context.Context, clientID string) (int, error) {
-	ptx.store.initLockStore()
 	return ptx.store.lockStore.deleteLocksByClientTx(ctx, ptx.tx, clientID)
 }
 
 func (ptx *sqliteTransaction) DeleteLocksByFile(ctx context.Context, fileID string) (int, error) {
-	ptx.store.initLockStore()
 	return ptx.store.lockStore.deleteLocksByFileTx(ctx, ptx.tx, fileID)
 }
 
 func (ptx *sqliteTransaction) GetServerEpoch(ctx context.Context) (uint64, error) {
-	ptx.store.initLockStore()
 	return ptx.store.lockStore.getServerEpochTx(ctx, ptx.tx)
 }
 
 func (ptx *sqliteTransaction) IncrementServerEpoch(ctx context.Context) (uint64, error) {
-	ptx.store.initLockStore()
 	return ptx.store.lockStore.incrementServerEpochTx(ctx, ptx.tx)
 }
 
 func (ptx *sqliteTransaction) GetCleanShutdown(ctx context.Context) (bool, error) {
-	ptx.store.initLockStore()
 	return ptx.store.lockStore.getCleanShutdownTx(ctx, ptx.tx)
 }
 
 func (ptx *sqliteTransaction) SetCleanShutdown(ctx context.Context, clean bool) error {
-	ptx.store.initLockStore()
 	return ptx.store.lockStore.setCleanShutdownTx(ctx, ptx.tx, clean)
 }
 
 func (ptx *sqliteTransaction) ReclaimLease(ctx context.Context, fileHandle lock.FileHandle, leaseKey [16]byte, clientID string) (*lock.UnifiedLock, error) {
-	ptx.store.initLockStore()
 	return ptx.store.lockStore.reclaimLeaseTx(ctx, ptx.tx, fileHandle, leaseKey, clientID)
 }

--- a/pkg/metadata/store/sqlite/objects.go
+++ b/pkg/metadata/store/sqlite/objects.go
@@ -53,7 +53,7 @@ func (s *SQLiteMetadataStore) GetFileChunk(ctx context.Context, id string) (*met
 // content hash, regardless of block state. The content hash is derived
 // at rollup time (long before the block reaches the remote) and is the
 // key the engine's CAS read path uses to resolve a chunk. Gating the
-// write on IsFinalized() left every Pending row with a NULL hash; reads
+// write on IsRemote() left every Pending row with a NULL hash; reads
 // then survived only while the bytes stayed in the local append log or
 // RAM cache, and broke the moment local state went cold (restart +
 // cache eviction, or a snapshot restore's ResetLocalState). The memory

--- a/pkg/metadata/store/sqlite/store.go
+++ b/pkg/metadata/store/sqlite/store.go
@@ -159,8 +159,8 @@ func NewSQLiteMetadataStore(
 		cancel:       cancel,
 		quota:        quota.NewCache(),
 	}
-	// The substores derive only from db, which is never reassigned, so they
-	// are bound once here rather than lazily behind a mutex.
+	// The substores derive only from db, which is never reassigned, so bind
+	// them once here.
 	store.lockStore = newSQLiteLockStore(store.conn())
 	store.clientStore = newSQLiteClientStore(store.conn())
 	store.durableStore = newSQLiteDurableStore(store.conn())

--- a/pkg/metadata/store/sqlite/store.go
+++ b/pkg/metadata/store/sqlite/store.go
@@ -87,19 +87,12 @@ type SQLiteMetadataStore struct {
 	// thereafter. Immutable for the life of the instance.
 	storeID string
 
-	// Lazily-initialized sub-stores for lock / client / durable-handle /
-	// NFSv4-recovery persistence. Each wraps the shared *sql.DB executor.
-	lockStore   *sqliteLockStore
-	lockStoreMu sync.Mutex
-
+	// Sub-stores for lock / client / durable-handle / NFSv4-recovery
+	// persistence. Each wraps the shared *sql.DB executor.
+	lockStore     *sqliteLockStore
 	clientStore   *sqliteClientStore
-	clientStoreMu sync.Mutex
-
-	durableStore   *sqliteDurableStore
-	durableStoreMu sync.Mutex
-
-	recoveryStore   *sqliteRecoveryStore
-	recoveryStoreMu sync.Mutex
+	durableStore  *sqliteDurableStore
+	recoveryStore *sqliteRecoveryStore
 }
 
 // NewSQLiteMetadataStore creates a new SQLite-backed metadata store.
@@ -166,6 +159,12 @@ func NewSQLiteMetadataStore(
 		cancel:       cancel,
 		quota:        quota.NewCache(),
 	}
+	// The substores derive only from db, which is never reassigned, so they
+	// are bound once here rather than lazily behind a mutex.
+	store.lockStore = newSQLiteLockStore(store.conn())
+	store.clientStore = newSQLiteClientStore(store.conn())
+	store.durableStore = newSQLiteDurableStore(store.conn())
+	store.recoveryStore = newSQLiteRecoveryStore(store.conn())
 
 	if err := store.initUsedBytesCounter(ctx); err != nil {
 		_ = db.Close()

--- a/pkg/metadata/types.go
+++ b/pkg/metadata/types.go
@@ -39,11 +39,7 @@ type FileHandle []byte
 // Format: "<shareName>:<uuid>"
 // Example: "/export:550e8400-e29b-41d4-a716-446655440000"
 func EncodeFileHandle(file *File) (FileHandle, error) {
-	encoded := file.ShareName + ":" + file.ID.String()
-	if len(encoded) > 64 {
-		return nil, fmt.Errorf("file handle too long: %d bytes (max 64)", len(encoded))
-	}
-	return FileHandle([]byte(encoded)), nil
+	return EncodeShareHandle(file.ShareName, file.ID)
 }
 
 // EncodeShareHandle encodes a share name and UUID into a FileHandle.


### PR DESCRIPTION
Sweep of the 42 LOW findings classified `bloat` in the data-plane audit: dead fields, dead
parameters, duplicated helpers and redundant plumbing. Every change is behaviour-preserving.
Net **-1029 / +384** across 95 files.

Each deletion below states how it was proved dead. Findings that turned out to be live, or
whose removal is bigger than a sweep, are listed at the bottom rather than acted on.

## pkg/block

- **`FileChunk.IsFinalized`** — byte-identical to `IsRemote` (`State == BlockStateRemote`).
  Repointed its 5 production call sites (memory + badger stores) at `IsRemote`.
- **`GCStats.SharesScanned` / `GCStats.BlocksScanned`** — repo-wide grep finds no writer;
  both were documented as permanently zero. `engine.GCStats` is serialized straight into the
  REST response with no json tags, so these were wire keys — but a client parsing them read
  `0` before and reads absent-therefore-`0` after, so the removal is lossless in both
  directions. The always-zero log field in `runtime/blockgc.go` went with them.
- **`engine.Options.MaxOrphansPerShare`** — declared, never set by any caller, never read.
- **`MetadataCoordinator.DecrementRefCount`** — the engine only ever calls
  `DecrementRefCountAndReap*`; grep of `pkg/block/engine` shows zero production callers of the
  plain variant. Removed from the interface, from the `shares` implementation, and from three
  test fakes. The two `shares/coordinator_test.go` tests that used it as a tx-routing probe were
  retargeted onto `DecrementRefCountAndReap` (with a matching `recordingTx` recorder) so the
  CR-01 contract stays covered.
- **`Store.ReadAt`'s `blocks []ChunkRef` parameter** — `*engine.Store` is the only implementation
  of `block.Reader`, the body ignored the argument (`_ = blocks`), and all ~20 call sites passed
  `nil`. The interface doc promising a "dual-read shim" for empty blocks described behaviour that
  no longer exists.
- **`Syncer.EnsureAvailableAndRead`'s bool return and `dest` buffer** — every `return` was
  `false`, and the function deliberately never wrote to `dest` (the caller re-reads through
  `readLocalByHash`). Renamed to `EnsureAvailable`, since it only hydrates.
- **`Store.LocalForTest`** — byte-identical to `Store.Local`; 4 test call sites repointed.
- **`hasLegacy` bool** threaded through `repackStandaloneChunks` / `migrationChunkBytes` — it
  comes from `legacy, hasLegacy := rbs.(remote.LegacyCASStore)`, where `hasLegacy` is true exactly
  when `legacy != nil` (a failed assertion yields the nil interface).
- **`local/memory.ErrStoreClosed`** — a same-value alias of `block.ErrStoreClosed` used only by
  its own 3 sites in one file; nothing outside referenced it.
- **`_ = srcPayloadID`** in `CopyPayload` — unused parameters compile fine in Go.
- **journal**: `sealSyncedActives` and `reclaimEmptied` carried the same fully-synced-idle-active
  predicate; extracted as `sealableActive`.

## internal/adapter/nfs

- **v3 READ**: the empty-file and offset-past-EOF guards built identical replies.
  `Size == 0` implies `Offset >= Size` for every `uint64` offset, so the pair collapses to
  `PayloadID == "" || Offset >= Size` with one log line.
- **v4 COMMIT/READ/WRITE**: ~41 inline `&types.CompoundResult{Status, OpCode, Data:
  encodeStatusOnly(status)}` literals now route through `commitErr` / `readErr` / `writeErr`,
  matching the `allocErr` / `cloneErr` / `deallocErr` / `seekErr` convention already in the
  package. `encodeCommit4resError` was a byte-identical hand-rolled duplicate of
  `encodeStatusOnly` and became `commitErr`.
- **`bootVerifierBytes` nil guard** — package `init()` unconditionally stores a verifier before
  any handler can run, so the branch was unreachable.

## pkg/metadata

- **Lazy-init substores (badger, postgres, sqlite)** — the lock / client / durable-handle /
  NFSv4-recovery substores were each built on first use behind a `sync.Mutex`, with ~45 guard
  calls between the three backends. Every substore derives only from the db/pool handle, and that
  handle is never reassigned after construction (checked `Reset` and `RestoreSnapshot` on each
  backend), so they are now bound in the constructor. Deleted 12 mutexes and 12 lazy-init
  wrappers. The `memory` backend keeps its lazy pattern — its `Reset` has different semantics.
- **`StatsCacheTTL`** (postgres + sqlite) — parsed via `mapstructure`, defaulted, logged, and
  never read by anything. No YAML sample, doc, fixture or k8s template sets `stats_cache_ttl`,
  and the config loader only warns on unknown keys, so a stray operator setting degrades
  gracefully.
- **sqlite `scanBlockRecordRow`** — a hand-copy of `scanBlockRecord`; `scanRows` satisfies
  `scanRow`, and a rows cursor never returns `sql.ErrNoRows`, so the two are equivalent.
- **memory `generateFileHandle`** — reimplemented `metadata.GenerateNewHandle` and took a
  `fullPath` it explicitly ignored. Now a 4-line wrapper over `GenerateNewHandle` (the panic on
  over-long share names is preserved, so store conformance is unchanged); the dead parameter is
  gone from 6 call sites.
- **`EncodeFileHandle`** now delegates to `EncodeShareHandle` instead of repeating its body.
- **`IsAdministratorSID`** delegates to a now-exported `acl.IsAdminSID` instead of carrying a
  second copy of the RID-500 regex — two copies of a security-relevant predicate is a drift
  hazard. `pkg/metadata` → `pkg/metadata/acl` is not a cycle.
- **postgres `acquireConn`** — `queryRow` / `query` / `exec` each repeated the same
  acquire-timeout-and-classify block.

## pkg/controlplane/runtime

- **`RunBlockGC` / `runBlockGCSweep`'s `sharePrefix`** — warned about and discarded on entry;
  the single production caller passed `""`. Dropped, along with the test case that exercised it.
- **`singleShareReconciler`** — `perRemoteReconciler` with a one-element slice; both
  `GetMetadataStoreForShare` bodies were identical.
- **`SetNFSClientProvider` / `NFSClientProvider`** — deprecated shims that forwarded verbatim to
  `SetAdapterProvider("nfs", …)` / `GetAdapterProvider("nfs")`. All 3 call sites now use the
  generic API.
- **`sharedRemote.configID`** — assigned at two sites, never read (`.configID` has no readers
  anywhere).
- **`runtime.DefaultShutdownTimeout`** now aliases `lifecycle.DefaultShutdownTimeout` instead of
  re-declaring the same literal.

## Findings NOT acted on

Verified and deliberately left:

- **`AuditRefcountsResult.Delta`** — claimed redundant with `DanglingRefs`, but it is live: it
  drives `dfsctl store block audit`'s exit code, two log lines, a `json:"delta"` REST key and the
  persisted `last-inv02.json` summary. Removing it changes both the REST wire and an on-disk
  format.
- **`BlockStoreStats.PendingSyncs` / `PendingUploads`** — the finding claims both are always
  zero. **Refuted**: `stats.go` sets both from `pendingUploads`, and they are read by `dfsctl
  store block stats`, the Prometheus collector and dfsbench.
- **NFSv3 WRITE double overflow check** — the `safeAdd` branch is indeed unreachable
  (`validateWriteRequest` checks overflow pre-clamp, and clamping only shrinks the length), but
  it is a defence-in-depth guard on a network trust boundary. Not worth 5 lines.
- **SMB `ReadRequest.Flags`** — the struct is a faithful mirror of [MS-SMB2] 2.2.19 and the
  decoder is positional; `Padding` / `MinimumCount` / `Channel` / `RemainingBytes` are equally
  "unused". Removing one field breaks the 1:1 mapping and buys nothing.
- **journal `appendTombstone` / `appendTruncateMarker` merge** — real duplication, but it
  rewrites control flow in the on-disk marker writer. Not a sweep-sized change.
- **`pollNFSSettings` / `pollSMBSettings` generic helper** — the two differ in settings type,
  cached fields, log fields and callbacks; the closures a generic version needs cost more lines
  than the duplication.
- **`runtime.dnsResolver`** — a 2-method interface is the cheapest injection point for the DNS
  test fake; the suggested package-level func vars would be global mutable state.
- **`exec.Executor`**, **encryption legacy-CAS file split**, **postgres tx-vs-store
  `WalkBlockRecords`** — pure code motion or an abstraction swap with no net deletion.

### NEEDS-ISSUE

**`pkg/metadata/errors.go`** (the deprecated re-export shim over `pkg/metadata/errors` and
`pkg/metadata/lock`). The finding estimates ~25 call sites; the actual count is **644**
(`metadata.Err*` / `metadata.New*Error` / `metadata.StoreError` / `metadata.ErrorCode`). Deleting
the shim is a repo-wide mechanical rename, not a sweep item. Worth its own issue.

## Verification

`gofmt -l .` empty · `go build ./...` · `go vet ./...` · `go test ./...` · `go test -race` on
`pkg/block`, `pkg/metadata`, `pkg/controlplane`, `internal/adapter` · `golangci-lint run ./...`
— all clean. The `pkg/metadata/storetest` and `pkg/block/blockstoretest` conformance suites pass
for every backend.
