### PR TITLE
docs: document the ponytail: deliberate-simplification marker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,27 @@ composition layer over six sub-services: `adapters/`, `stores/`, `shares/`, `mou
   numbers, no CI/runner/OS names, no phase/plan/decision IDs. Those belong in
   commit messages, PR descriptions, or `.planning/`, not in source.
 
+### `ponytail:` markers
+
+A `ponytail:` comment marks a **knowingly-simple implementation**, naming its ceiling and
+the upgrade path that would justify replacing it:
+
+```go
+// ponytail: O(n) keys-only scan per candidate, and only an overlap yields more
+// than one candidate; upgrade to a big-endian fb-off index for a true O(log n)
+// reverse-seek only if profiling at real N still shows it.
+func (s *BadgerMetadataStore) GetFileChunkAtOffset(...)
+```
+
+They are a **debt ledger, not TODOs**: each one records a decision that was correct at the
+time along with the evidence that would overturn it. There are 19 of them, mostly in
+`pkg/block/engine`, `pkg/block/journal` and `pkg/metadata/store`.
+
+This is the one sanctioned exception to the "no external references" rule above — the
+prefix is what makes the set harvestable as a group. Keep the marker when editing nearby
+code; drop it only when the shortcut is actually replaced, not when the comment is merely
+reworded.
+
 ## Commits & PRs
 
 - Never mention Claude Code, AI tools, or add `Co-Authored-By` lines for AI.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,8 +116,8 @@ func (s *BadgerMetadataStore) GetFileChunkAtOffset(...)
 ```
 
 They are a **debt ledger, not TODOs**: each one records a decision that was correct at the
-time along with the evidence that would overturn it. There are 19 of them, mostly in
-`pkg/block/engine`, `pkg/block/journal` and `pkg/metadata/store`.
+time along with the evidence that would overturn it. They appear throughout the codebase,
+mostly in `pkg/block/engine`, `pkg/block/journal` and `pkg/metadata/store`.
 
 This is the one sanctioned exception to the "no external references" rule above — the
 prefix is what makes the set harvestable as a group. Keep the marker when editing nearby


### PR DESCRIPTION
There are 19 `ponytail:` comments in production source and the convention is documented nowhere — not in `CLAUDE.md`, not in `contributing.md`. A contributor without the tooling installed reads them as noise, which is exactly what happened to me while sweeping the data-plane audit's comment findings: I flagged them as a stray label to strip.

They are not. Each records a knowingly-simple implementation together with its ceiling and the evidence that would justify replacing it — e.g. `GetFileChunkAtOffset`'s O(n) keys-only scan, which names the big-endian `fb-off` index as the upgrade and "only if profiling at real N still shows it" as the trigger. That is a real engineering note, and stripping the prefix would have kept the prose while destroying the set's harvestability.

This adds a short subsection under **Code comments** explaining what the marker means, that the markers form a debt ledger rather than a TODO list, and that this is the deliberate exception to the "never reference things external to the code" rule immediately above it — since without saying so, the two rules read as contradictory and the next person to sweep comments will delete them.

Docs only, no code change.