### PR TITLE
ci(smb): make the Windows client-compat job skip honestly instead of failing on an unmeetable precondition

### DIFF
--- a/.github/workflows/smb-client-compat.yml
+++ b/.github/workflows/smb-client-compat.yml
@@ -343,13 +343,17 @@ jobs:
           }
           Write-Host "TCP 445 freed for DittoFS: $freed (false => hosted-runner kernel listener; net use cannot reach DittoFS without a reboot)"
           (Get-NetTCPConnection -LocalPort 445 -State Listen -ErrorAction SilentlyContinue) | Format-Table -AutoSize
+          # The net use assertions below are gated on this: the redirector can
+          # only reach DittoFS when DittoFS owns 445. Asserting anyway turns an
+          # unmeetable precondition into a permanent job failure.
+          "SMB445_FREE=$($freed.ToString().ToLowerInvariant())" >> $env:GITHUB_ENV
           # sc.exe returns nonzero when a service is already stopped, which pwsh
           # would otherwise propagate as a step failure. This step is
           # best-effort — clear the residual exit code so the job proceeds to
           # the bootstrap (which binds DittoFS to 445 if it is now free).
           $global:LASTEXITCODE = 0
 
-      - name: Start packet capture (pktmon, #879 diagnosis)
+      - name: "Start packet capture (pktmon, #879 diagnosis)"
         shell: pwsh
         run: |
           # Capture the loopback SMB handshake at the byte level so any
@@ -396,6 +400,11 @@ jobs:
           (Get-NetTCPConnection -LocalPort 445 -State Listen -ErrorAction SilentlyContinue) | Format-Table -AutoSize
 
       - name: Test net use operations
+        id: netuse
+        # Skipped when the kernel SMB listener kept 445: `net use` would reach
+        # the in-box Windows SMB server, not DittoFS. On a runner where 445 is
+        # claimable this runs and a genuine regression still fails the job.
+        if: env.SMB445_FREE == 'true'
         shell: pwsh
         run: |
           # Mount SMB share
@@ -465,7 +474,7 @@ jobs:
           Write-Host "===== dfs-stderr.log ====="
           Get-Content dfs-stderr.log -ErrorAction SilentlyContinue | Select-Object -Last 40
 
-      - name: Upload #879 diagnosis artifacts
+      - name: "Upload #879 diagnosis artifacts"
         if: always()
         uses: actions/upload-artifact@v4
         with:
@@ -493,22 +502,39 @@ jobs:
         if: always()
         shell: pwsh
         run: |
-          @"
-          ## SMB Client Compatibility: Windows
-
-          | Test | Status |
-          |------|--------|
-          | net use mount | :white_check_mark: |
-          | File create/read | :white_check_mark: |
-          | Directory create | :white_check_mark: |
-          | Directory listing | :white_check_mark: |
-          | Delete | :white_check_mark: |
-          "@ >> $env:GITHUB_STEP_SUMMARY
+          # Report what actually happened. A fixed all-green table would claim
+          # passes for a run whose assertions never executed, or failed.
+          $outcome = '${{ steps.netuse.outcome }}'
+          $mark = if ($outcome -eq 'success') { ':white_check_mark:' } else { ':x:' }
+          $summary = @('## SMB Client Compatibility: Windows', '')
+          if ($outcome -eq 'skipped') {
+            $reason = 'TCP 445 stayed owned by the hosted-runner kernel SMB listener (srvnet.sys, PID 4). The Windows redirector always connects to TCP 445 and UNC syntax has no port field, so net use cannot reach DittoFS on any other port. Freeing 445 needs srvnet.sys unloaded, which a hosted runner cannot do without a reboot. Diagnostics were still captured and uploaded.'
+            Write-Host "::notice title=Windows net use tests skipped::$reason"
+            $summary += ":warning: **net use tests skipped** - $reason"
+            $summary += ''
+            $summary += 'Run this job on a self-hosted or VM runner where 445 can be claimed to exercise the Windows redirector against DittoFS.'
+          } else {
+            $summary += @(
+              '| Test | Status |'
+              '|------|--------|'
+              "| net use mount | $mark |"
+              "| File create/read | $mark |"
+              "| Directory create | $mark |"
+              "| Directory listing | $mark |"
+              "| Delete | $mark |"
+            )
+          }
+          $summary | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
       - name: Cleanup
         if: always()
         shell: pwsh
         run: |
           net use Z: /delete /yes 2>$null
-          $pid = $env:DFS_PID
-          if ($pid) { Stop-Process -Id $pid -Force -ErrorAction SilentlyContinue }
+          # $pid is a read-only automatic variable; assigning to it throws and
+          # leaves the server process running.
+          $dfsPid = $env:DFS_PID
+          if ($dfsPid) { Stop-Process -Id $dfsPid -Force -ErrorAction SilentlyContinue }
+          # net use exits nonzero when Z: was never mapped; pwsh would otherwise
+          # propagate that as a cleanup failure.
+          $global:LASTEXITCODE = 0

--- a/.github/workflows/smb-client-compat.yml
+++ b/.github/workflows/smb-client-compat.yml
@@ -505,15 +505,9 @@ jobs:
           # Report what actually happened. A fixed all-green table would claim
           # passes for a run whose assertions never executed, or failed.
           $outcome = '${{ steps.netuse.outcome }}'
-          $mark = if ($outcome -eq 'success') { ':white_check_mark:' } else { ':x:' }
           $summary = @('## SMB Client Compatibility: Windows', '')
-          if ($outcome -eq 'skipped') {
-            $reason = 'TCP 445 stayed owned by the hosted-runner kernel SMB listener (srvnet.sys, PID 4). The Windows redirector always connects to TCP 445 and UNC syntax has no port field, so net use cannot reach DittoFS on any other port. Freeing 445 needs srvnet.sys unloaded, which a hosted runner cannot do without a reboot. Diagnostics were still captured and uploaded.'
-            Write-Host "::notice title=Windows net use tests skipped::$reason"
-            $summary += ":warning: **net use tests skipped** - $reason"
-            $summary += ''
-            $summary += 'Run this job on a self-hosted or VM runner where 445 can be claimed to exercise the Windows redirector against DittoFS.'
-          } else {
+          if ($outcome -eq 'success' -or $outcome -eq 'failure') {
+            $mark = if ($outcome -eq 'success') { ':white_check_mark:' } else { ':x:' }
             $summary += @(
               '| Test | Status |'
               '|------|--------|'
@@ -523,6 +517,17 @@ jobs:
               "| Directory listing | $mark |"
               "| Delete | $mark |"
             )
+          } elseif ($env:SMB445_FREE -eq 'false') {
+            # Only the measured-and-unmet precondition gets this explanation.
+            $reason = 'TCP 445 stayed owned by the hosted-runner kernel SMB listener (srvnet.sys, PID 4). The Windows redirector always connects to TCP 445 and UNC syntax has no port field, so net use cannot reach DittoFS on any other port. Freeing 445 needs srvnet.sys unloaded, which a hosted runner cannot do without a reboot. Diagnostics were still captured and uploaded.'
+            Write-Host "::notice title=Windows net use tests skipped::$reason"
+            $summary += ":warning: **net use tests skipped** - $reason"
+            $summary += ''
+            $summary += 'Run this job on a self-hosted or VM runner where 445 can be claimed to exercise the Windows redirector against DittoFS.'
+          } else {
+            # netuse is also skipped when an earlier step failed or the job was
+            # cancelled, which is not the 445 story.
+            $summary += ":x: **net use tests did not run** - an earlier step in the job failed or the job was cancelled."
           }
           $summary | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 


### PR DESCRIPTION
Closes #1995

## What was wrong

`SMB Client Compatibility` has failed on every `develop` run for weeks. macOS and Linux pass; the **Windows (net use)** job fails, and could not pass on a hosted runner as written. Two independent harness defects, neither in DittoFS.

### 1. The job asserted a precondition it had just measured as unmet

The Windows redirector always connects to TCP 445 — UNC syntax has no port field — so `net use` can only reach DittoFS if DittoFS owns 445. Freeing 445 means unloading the kernel SMB listener (`srvnet.sys`, PID 4), which a hosted runner cannot do without a reboot. The "Free TCP 445 (best-effort)" step knows this, tries anyway, and logs the result:

```
TCP 445 freed for DittoFS: False (false => hosted-runner kernel listener; net use cannot reach DittoFS without a reboot)
```

The next step then ran `net use` regardless and hard-failed:

```
System error 64 has occurred.
net use failed with exit code 2
```

`$freed` is now exported as `SMB445_FREE` and gates the assertion step. When 445 is kernel-owned the step is genuinely skipped (GitHub shows it as skipped), a `::notice` explains why, and the step summary carries the same reason. Diagnostics (pktmon capture, `dittofs.log`, stdout/stderr) still run and still upload. On a self-hosted or VM runner where 445 is claimable the step runs exactly as before, so a real Windows-redirector regression still fails the job.

The step summary was also a fixed all-green table emitted under `if: always()` — it printed five checkmarks on every one of those failing runs. It now reports the actual `steps.netuse.outcome`: pass table, fail table, or the skip explanation.

### 2. Cleanup assigned to `$pid`

```powershell
$pid = $env:DFS_PID
```

`$pid` is a PowerShell read-only automatic variable (the current process ID), so this threw:

```
Cannot overwrite variable PID because it is read-only or constant.
##[error]Process completed with exit code 1.
```

Cleanup failed independently of (1) and never killed `dfs`. Renamed to `$dfsPid`. The step also needed `$global:LASTEXITCODE = 0` at the end for the same reason the "Free TCP 445" step does: `net use Z: /delete` exits nonzero when `Z:` was never mapped, and pwsh propagates that as a step failure.

### Incidental

Two step names contained an unescaped `#` after whitespace, so YAML parsed the rest as a comment and the run log showed "Start packet capture (pktmon," and "Upload". Quoted.

## Verification

Manual `workflow_dispatch` on this branch (the workflow excludes PRs by design: `on: push: branches: [develop]` + schedule + dispatch, so it never appears in the PR checks list). All three jobs green, with the Windows `net use` step reported as skipped-with-reason rather than passed.

## Not done here

Moving the Windows job to a self-hosted/VM runner where 445 can actually be claimed is the only way to get real `net use` coverage. That is a separate decision; this PR makes the workflow tell the truth about what it did and did not exercise.
