### PR TITLE
ci(smb): stop the Windows compat job failing on a precondition it measures as unmet

### DIFF
--- a/.github/workflows/smb-client-compat.yml
+++ b/.github/workflows/smb-client-compat.yml
@@ -308,6 +308,7 @@ jobs:
           go build -o dfsctl.exe cmd/dfsctl/main.go
 
       - name: Free TCP 445 for DittoFS (best-effort)
+        id: free445
         shell: pwsh
         run: |
           # #879 ROOT CAUSE: the Windows redirector (`net use \\host\share`)
@@ -342,6 +343,10 @@ jobs:
             Start-Sleep -Seconds 2
           }
           Write-Host "TCP 445 freed for DittoFS: $freed (false => hosted-runner kernel listener; net use cannot reach DittoFS without a reboot)"
+          # Publish the result so the net use assertions can skip honestly
+          # instead of failing on a precondition this step just measured as
+          # unmet. Without the gate the job can never pass on a hosted runner.
+          "freed=$($freed.ToString().ToLower())" >> $env:GITHUB_OUTPUT
           (Get-NetTCPConnection -LocalPort 445 -State Listen -ErrorAction SilentlyContinue) | Format-Table -AutoSize
           # sc.exe returns nonzero when a service is already stopped, which pwsh
           # would otherwise propagate as a step failure. This step is
@@ -396,6 +401,7 @@ jobs:
           (Get-NetTCPConnection -LocalPort 445 -State Listen -ErrorAction SilentlyContinue) | Format-Table -AutoSize
 
       - name: Test net use operations
+        if: steps.free445.outputs.freed == 'true'
         shell: pwsh
         run: |
           # Mount SMB share
@@ -431,6 +437,15 @@ jobs:
 
           # Disconnect
           net use Z: /delete /yes
+
+      - name: Report skipped net use assertions
+        if: steps.free445.outputs.freed != 'true'
+        shell: pwsh
+        run: |
+          Write-Host "SKIPPED: the runner's kernel SMB listener (srvnet.sys, PID 4) still owns TCP 445."
+          Write-Host "The Windows redirector has no port field in UNC syntax, so net use cannot reach"
+          Write-Host "DittoFS on 12445. Freeing 445 needs a reboot, which a hosted runner cannot do."
+          Write-Host "The macOS and Linux jobs still exercise the same SMB server end to end."
 
       - name: Stop packet capture (#879 diagnosis)
         if: always()
@@ -493,16 +508,23 @@ jobs:
         if: always()
         shell: pwsh
         run: |
+          $ran = "${{ steps.free445.outputs.freed }}" -eq "true"
+          $status = if ($ran) { ":white_check_mark:" } else { ":fast_forward: skipped" }
+          $note = if ($ran) { "" } else {
+            "Skipped: the runner's kernel SMB listener owns TCP 445, so ``net use`` cannot reach DittoFS. See the ""Free TCP 445"" step."
+          }
           @"
           ## SMB Client Compatibility: Windows
 
           | Test | Status |
           |------|--------|
-          | net use mount | :white_check_mark: |
-          | File create/read | :white_check_mark: |
-          | Directory create | :white_check_mark: |
-          | Directory listing | :white_check_mark: |
-          | Delete | :white_check_mark: |
+          | net use mount | $status |
+          | File create/read | $status |
+          | Directory create | $status |
+          | Directory listing | $status |
+          | Delete | $status |
+
+          $note
           "@ >> $env:GITHUB_STEP_SUMMARY
 
       - name: Cleanup
@@ -510,5 +532,7 @@ jobs:
         shell: pwsh
         run: |
           net use Z: /delete /yes 2>$null
-          $pid = $env:DFS_PID
-          if ($pid) { Stop-Process -Id $pid -Force -ErrorAction SilentlyContinue }
+          # $pid is a read-only automatic variable (the current process id);
+          # assigning to it throws and fails the step before the cleanup runs.
+          $dfsPid = $env:DFS_PID
+          if ($dfsPid) { Stop-Process -Id $dfsPid -Force -ErrorAction SilentlyContinue }


### PR DESCRIPTION
Closes #1995.

`SMB Client Compatibility` has been red on develop since at least 2026-08-05. macOS and Linux pass; the Windows job cannot pass as written. Two independent defects, both in the harness — DittoFS itself is fine, and the workflow's own comments already argue that (macOS `mount_smbfs` and Samba `smbclient` 4.19 both authenticate against the same server, negotiating identically to the Windows redirector).

### 1. The job asserted a precondition it had already measured as unmet

The "Free TCP 445" step is explicitly best-effort. The Windows redirector always connects to TCP 445 and UNC syntax has no port field, so reaching DittoFS on 12445 means owning 445 — which means unloading the kernel SMB listener (`srvnet.sys`, PID 4). A hosted runner cannot do that without a reboot. The step says so:

```
TCP 445 freed for DittoFS: False (false => hosted-runner kernel listener; net use cannot reach DittoFS without a reboot)
```

The next step then ran `net use` regardless and threw:

```
System error 64 has occurred.
net use failed with exit code 2
```

Now the probe publishes `freed` as a step output and the assertions gate on it. When 445 is kernel-owned the job skips them and prints why; when a runner *can* free 445 the assertions run exactly as before. A new "Report skipped net use assertions" step makes the skip visible in the log rather than silent, and the step summary renders `:fast_forward: skipped` instead of five green ticks for tests that never ran — the old summary claimed five passes on a job that had just failed.

### 2. Cleanup assigned to `$pid`

```powershell
$pid = $env:DFS_PID
```

`$pid` is a PowerShell **read-only automatic variable** (the current process id). Assigning to it throws:

```
Cannot overwrite variable PID because it is read-only or constant.
```

So the step failed on its own, and the `dfs` process was never stopped. Renamed to `$dfsPid`.

### Notes

This does not paper over a product failure. It stops the job asserting something the environment makes impossible, so a genuine regression in the macOS or Linux jobs — which do exercise the server end to end — becomes visible again instead of drowning in a permanently red check.

If you'd rather actually exercise `net use`, that needs a self-hosted or VM runner where 445 can be claimed; worth a follow-up if Windows redirector coverage matters. I've left the pktmon capture and log-dump diagnostics running unconditionally so that path stays debuggable.

Verified the YAML parses; the PowerShell changes are inspection-only since there is no Windows runner locally — the CI run on this PR is the real check.