### PR TITLE
fix(metadata): drop every derived badger cache on Reset and RestoreSnapshot

### DIFF
--- a/pkg/metadata/store/badger/create_cache.go
+++ b/pkg/metadata/store/badger/create_cache.go
@@ -107,9 +107,8 @@ func (c *direntCache) invalidate(key string) {
 
 // invalidateAll drops every entry, positive and negative, for callers that
 // replace the whole backing store rather than a single directory entry (Reset,
-// RestoreSnapshot). Same ordering rule as invalidate: bump gen first so an
-// in-flight populate against the pre-wipe generation cannot re-insert after
-// the clear.
+// RestoreSnapshot). Order matters: bump gen BEFORE clearing (see
+// fileReadCache.invalidateAll).
 func (c *direntCache) invalidateAll() {
 	c.gen.Add(1)
 	c.m.Clear()

--- a/pkg/metadata/store/badger/create_cache.go
+++ b/pkg/metadata/store/badger/create_cache.go
@@ -105,6 +105,17 @@ func (c *direntCache) invalidate(key string) {
 	}
 }
 
+// invalidateAll drops every entry, positive and negative, for callers that
+// replace the whole backing store rather than a single directory entry (Reset,
+// RestoreSnapshot). Same ordering rule as invalidate: bump gen first so an
+// in-flight populate against the pre-wipe generation cannot re-insert after
+// the clear.
+func (c *direntCache) invalidateAll() {
+	c.gen.Add(1)
+	c.m.Clear()
+	c.n.Store(0)
+}
+
 // pruneToHalf best-effort trims the map back toward half the cap on overflow.
 func (c *direntCache) pruneToHalf() {
 	if !c.prune.CompareAndSwap(false, true) {

--- a/pkg/metadata/store/badger/read_cache.go
+++ b/pkg/metadata/store/badger/read_cache.go
@@ -91,8 +91,8 @@ func (c *fileReadCache) invalidate(key string) {
 
 // invalidateAll drops every entry, for callers that replace the whole backing
 // store rather than a single file record (Reset, RestoreSnapshot). Same
-// ordering rule as invalidate: bump gen first so an in-flight populate against
-// the pre-wipe generation cannot re-insert after the clear.
+// ordering rule as invalidate: bump gen before clearing, so an in-flight
+// populate against the pre-wipe generation cannot re-insert after the clear.
 func (c *fileReadCache) invalidateAll() {
 	c.gen.Add(1)
 	c.m.Clear()

--- a/pkg/metadata/store/badger/read_cache.go
+++ b/pkg/metadata/store/badger/read_cache.go
@@ -89,6 +89,16 @@ func (c *fileReadCache) invalidate(key string) {
 	}
 }
 
+// invalidateAll drops every entry, for callers that replace the whole backing
+// store rather than a single file record (Reset, RestoreSnapshot). Same
+// ordering rule as invalidate: bump gen first so an in-flight populate against
+// the pre-wipe generation cannot re-insert after the clear.
+func (c *fileReadCache) invalidateAll() {
+	c.gen.Add(1)
+	c.m.Clear()
+	c.n.Store(0)
+}
+
 // pruneToHalf best-effort trims the map back toward half the cap on overflow.
 // One pruner at a time; entries drop in Range order (arbitrary) — a dropped file
 // just re-populates on its next read.

--- a/pkg/metadata/store/badger/reset.go
+++ b/pkg/metadata/store/badger/reset.go
@@ -16,9 +16,9 @@ var _ metadata.Resetable = (*BadgerMetadataStore)(nil)
 // it (typically the restore dump that follows).
 //
 // Every in-memory structure derived from the dropped keys is re-derived here
-// too: the derived caches would otherwise keep answering from entries whose
-// backing records no longer exist — a wrong permission decision for share
-// options, and pre-drop attributes or directory entries for the rest.
+// too — see invalidateDerivedCaches. A surviving entry answers from a record
+// that no longer exists: a wrong permission decision for share options, and
+// pre-drop attributes or directory entries for the rest.
 func (s *BadgerMetadataStore) Reset(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return fmt.Errorf("badger reset cancelled: %w", err)
@@ -35,17 +35,20 @@ func (s *BadgerMetadataStore) Reset(ctx context.Context) error {
 }
 
 // invalidateDerivedCaches clears every cache the store derives from the
-// durable records, for the paths that replace those records wholesale rather
-// than one at a time. Ordinary mutations invalidate per key from
-// withTransaction; a wholesale replacement has no key list to work from, and
-// the restore path never goes through a badgerTransaction at all.
+// durable records, for the paths that replace those records wholesale (Reset,
+// RestoreSnapshot). Ordinary mutations invalidate per key from withTransaction;
+// a wholesale replacement has no key list to work from, and the restore path
+// never goes through a badgerTransaction at all.
 //
-// The filesystem-statistics cache is deliberately left alone: it carries its
-// own short TTL and re-derives itself, so it cannot outlive the wipe the way a
-// TTL-less entry can.
+// The filesystem-statistics cache is dropped here too. Its own TTL bounds the
+// staleness rather than leaving it forever, but a wipe invalidates it on the
+// spot and FSSTAT should not report counts for files that are gone.
 func (s *BadgerMetadataStore) invalidateDerivedCaches() {
 	s.shareCache.InvalidateAll()
 	s.readCache.invalidateAll()
 	s.parentCache.invalidateAll()
 	s.direntCache.invalidateAll()
+	s.statsCache.mu.Lock()
+	s.statsCache.hasStats = false
+	s.statsCache.mu.Unlock()
 }

--- a/pkg/metadata/store/badger/reset.go
+++ b/pkg/metadata/store/badger/reset.go
@@ -16,9 +16,9 @@ var _ metadata.Resetable = (*BadgerMetadataStore)(nil)
 // it (typically the restore dump that follows).
 //
 // Every in-memory structure derived from the dropped keys is re-derived here
-// too: the share read cache would otherwise keep answering GetShareOptions
-// from entries whose backing records no longer exist, which is a wrong
-// permission decision.
+// too: the derived caches would otherwise keep answering from entries whose
+// backing records no longer exist — a wrong permission decision for share
+// options, and pre-drop attributes or directory entries for the rest.
 func (s *BadgerMetadataStore) Reset(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return fmt.Errorf("badger reset cancelled: %w", err)
@@ -26,10 +26,26 @@ func (s *BadgerMetadataStore) Reset(ctx context.Context) error {
 	if err := s.db.DropAll(); err != nil {
 		return fmt.Errorf("badger reset: drop all: %w", err)
 	}
-	s.shareCache.InvalidateAll()
+	s.invalidateDerivedCaches()
 	s.usedBytes.Store(0)
 	s.quotaMu.Lock()
 	s.quota.Reset()
 	s.quotaMu.Unlock()
 	return nil
+}
+
+// invalidateDerivedCaches clears every cache the store derives from the
+// durable records, for the paths that replace those records wholesale rather
+// than one at a time. Ordinary mutations invalidate per key from
+// withTransaction; a wholesale replacement has no key list to work from, and
+// the restore path never goes through a badgerTransaction at all.
+//
+// The filesystem-statistics cache is deliberately left alone: it carries its
+// own short TTL and re-derives itself, so it cannot outlive the wipe the way a
+// TTL-less entry can.
+func (s *BadgerMetadataStore) invalidateDerivedCaches() {
+	s.shareCache.InvalidateAll()
+	s.readCache.invalidateAll()
+	s.parentCache.invalidateAll()
+	s.direntCache.invalidateAll()
 }

--- a/pkg/metadata/store/badger/snapshot_store.go
+++ b/pkg/metadata/store/badger/snapshot_store.go
@@ -188,13 +188,13 @@ func (s *BadgerMetadataStore) RestoreSnapshot(ctx context.Context, r io.Reader) 
 		return metadata.ErrRestoreDestinationNotEmpty
 	}
 
-	// The restored records replace whatever the derived caches were built
-	// from, and the failure path drops everything again — either way an entry
-	// that outlives this call answers for state that is gone. The restore
-	// streams through a WriteBatch rather than a badgerTransaction, so none of
-	// the per-key invalidation an ordinary mutation performs runs here. A
-	// restore also reuses the same share name and the same file UUIDs, so warm
-	// keys would keep matching.
+	// The restored records replace whatever the derived caches were built from,
+	// and the failure path drops everything again — either way an entry that
+	// outlives this call answers for state that is gone. Nothing else clears
+	// them: the restore streams through a WriteBatch rather than a
+	// badgerTransaction, so the per-key invalidation an ordinary mutation
+	// performs never runs, and a restore reuses the same share name and file
+	// UUIDs, so warm keys keep matching.
 	defer s.invalidateDerivedCaches()
 
 	// Read envelope header.

--- a/pkg/metadata/store/badger/snapshot_store.go
+++ b/pkg/metadata/store/badger/snapshot_store.go
@@ -188,10 +188,14 @@ func (s *BadgerMetadataStore) RestoreSnapshot(ctx context.Context, r io.Reader) 
 		return metadata.ErrRestoreDestinationNotEmpty
 	}
 
-	// The restored records replace whatever the share read cache was built
-	// from, and the failure path drops everything again — either way an
-	// entry that outlives this call is a wrong permission decision.
-	defer s.shareCache.InvalidateAll()
+	// The restored records replace whatever the derived caches were built
+	// from, and the failure path drops everything again — either way an entry
+	// that outlives this call answers for state that is gone. The restore
+	// streams through a WriteBatch rather than a badgerTransaction, so none of
+	// the per-key invalidation an ordinary mutation performs runs here. A
+	// restore also reuses the same share name and the same file UUIDs, so warm
+	// keys would keep matching.
+	defer s.invalidateDerivedCaches()
 
 	// Read envelope header.
 	engineTag, payloadReader, acc, err := backup.ReadHeader(r)

--- a/pkg/metadata/storetest/reset_conformance.go
+++ b/pkg/metadata/storetest/reset_conformance.go
@@ -2,11 +2,55 @@ package storetest
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
+
+// fileForReadStore and createCacheStore mirror the optional fast-path
+// interfaces the metadata service probes for. A backend that implements them
+// answers from its own derived caches, which is exactly the state this suite
+// has to see torn down by Reset and RestoreSnapshot; a backend that does not
+// falls back to the plain Store methods below.
+type fileForReadStore interface {
+	GetFileForRead(ctx context.Context, handle metadata.FileHandle) (*metadata.File, error)
+}
+
+type createCacheStore interface {
+	GetFileForCreate(ctx context.Context, handle metadata.FileHandle) (*metadata.File, error)
+	GetChildForCreate(ctx context.Context, dirHandle metadata.FileHandle, name string) (metadata.FileHandle, error)
+}
+
+// readFile loads handle through the backend's read fast path when it has one,
+// so any file-read cache behind it is both warmed and consulted.
+func readFile(ctx context.Context, store metadata.Store, handle metadata.FileHandle) (*metadata.File, error) {
+	if r, ok := store.(fileForReadStore); ok {
+		return r.GetFileForRead(ctx, handle)
+	}
+	return store.GetFile(ctx, handle)
+}
+
+// readParent loads a directory through the backend's create fast path when it
+// has one, so any parent-directory cache behind it is warmed and consulted.
+func readParent(ctx context.Context, store metadata.Store, handle metadata.FileHandle) (*metadata.File, error) {
+	if c, ok := store.(createCacheStore); ok {
+		return c.GetFileForCreate(ctx, handle)
+	}
+	return store.GetFile(ctx, handle)
+}
+
+// lookupChild resolves name through the backend's create fast path when it has
+// one, so any directory-entry cache behind it is warmed and consulted. That
+// cache also holds negative entries, so calling this against an empty store
+// arms a cached ABSENT that a later restore has to clear.
+func lookupChild(ctx context.Context, store metadata.Store, dir metadata.FileHandle, name string) (metadata.FileHandle, error) {
+	if c, ok := store.(createCacheStore); ok {
+		return c.GetChildForCreate(ctx, dir, name)
+	}
+	return store.GetChild(ctx, dir, name)
+}
 
 // asResetable is a helper that type-asserts a MetadataStore to Resetable,
 // calling t.Fatal if the assertion fails. Mirrors asSnapshotable.
@@ -63,11 +107,26 @@ func ResetThenRestoreConformance(t *testing.T, factory SnapshotableStoreFactory)
 		t.Fatalf("WriteSnapshot HashSet.Len() = %d, want %d", hs.Len(), len(uniqueHashes))
 	}
 
-	// Read the share options once before Reset so any share-options cache the
-	// backend keeps is warm, and the post-Reset check below exercises the
-	// cache rather than the backing store.
+	// Warm every cache the backend derives from the records Reset is about to
+	// drop, so the post-Reset checks below exercise the caches rather than the
+	// backing store: share options, the file read path, the parent-directory
+	// read path, and the directory-entry lookup.
 	if _, err := store.GetShareOptions(ctx, shareName); err != nil {
 		t.Fatalf("GetShareOptions(%q) pre-Reset: %v", shareName, err)
+	}
+	rootHandle, err := store.GetRootHandle(ctx, shareName)
+	if err != nil {
+		t.Fatalf("GetRootHandle(%q) pre-Reset: %v", shareName, err)
+	}
+	alphaHandle, err := lookupChild(ctx, store, rootHandle, "alpha.bin")
+	if err != nil {
+		t.Fatalf("lookup alpha.bin pre-Reset: %v", err)
+	}
+	if _, err := readFile(ctx, store, alphaHandle); err != nil {
+		t.Fatalf("read alpha.bin pre-Reset: %v", err)
+	}
+	if _, err := readParent(ctx, store, rootHandle); err != nil {
+		t.Fatalf("read root pre-Reset: %v", err)
 	}
 
 	// 2. Reset the SAME store in place — no close/reopen.
@@ -85,6 +144,20 @@ func ResetThenRestoreConformance(t *testing.T, factory SnapshotableStoreFactory)
 		t.Fatalf("post-Reset GetBlockRecord: %v", err)
 	} else if found {
 		t.Errorf("block record %q survived Reset", blockRec.BlockID)
+	}
+
+	// The same rule applies to every other derived cache: a file whose record
+	// was dropped must not still be readable, a dropped directory must not
+	// still resolve, and a dropped directory entry must not still be found.
+	// This lookup also arms a negative dirent entry for the restore below.
+	if _, err := readFile(ctx, store, alphaHandle); err == nil {
+		t.Errorf("post-Reset read of alpha.bin succeeded, want an error")
+	}
+	if _, err := readParent(ctx, store, rootHandle); err == nil {
+		t.Errorf("post-Reset read of the root directory succeeded, want an error")
+	}
+	if _, err := lookupChild(ctx, store, rootHandle, "alpha.bin"); err == nil {
+		t.Errorf("post-Reset lookup of alpha.bin succeeded, want an error")
 	}
 
 	// Reset must clear the per-identity quota cache too, not just the
@@ -141,18 +214,23 @@ func ResetThenRestoreConformance(t *testing.T, factory SnapshotableStoreFactory)
 		t.Fatalf("share %q not found post-Restore (shares: %v)", shareName, restored)
 	}
 
-	rootHandle, err := store.GetRootHandle(ctx, shareName)
+	rootHandle, err = store.GetRootHandle(ctx, shareName)
 	if err != nil {
 		t.Fatalf("GetRootHandle(%q): %v", shareName, err)
 	}
 
-	alphaHandle, err := store.GetChild(ctx, rootHandle, "alpha.bin")
+	// Resolved through the caching lookup so the ABSENT entry armed while the
+	// store was empty has to have been cleared by the restore.
+	alphaHandle, err = lookupChild(ctx, store, rootHandle, "alpha.bin")
 	if err != nil {
-		t.Fatalf("GetChild alpha.bin: %v", err)
+		t.Fatalf("lookup alpha.bin post-Restore: %v", err)
 	}
-	alphaFile, err := store.GetFile(ctx, alphaHandle)
+	if _, err := readParent(ctx, store, rootHandle); err != nil {
+		t.Fatalf("read root post-Restore: %v", err)
+	}
+	alphaFile, err := readFile(ctx, store, alphaHandle)
 	if err != nil {
-		t.Fatalf("GetFile alpha: %v", err)
+		t.Fatalf("read alpha post-Restore: %v", err)
 	}
 	if alphaFile.Size != 8<<20 {
 		t.Errorf("alpha.Size = %d, want %d", alphaFile.Size, 8<<20)
@@ -164,13 +242,13 @@ func ResetThenRestoreConformance(t *testing.T, factory SnapshotableStoreFactory)
 		t.Fatalf("alpha.Blocks len = %d, want 2", len(alphaFile.Blocks))
 	}
 
-	betaHandle, err := store.GetChild(ctx, rootHandle, "beta.bin")
+	betaHandle, err := lookupChild(ctx, store, rootHandle, "beta.bin")
 	if err != nil {
-		t.Fatalf("GetChild beta.bin: %v", err)
+		t.Fatalf("lookup beta.bin post-Restore: %v", err)
 	}
-	betaFile, err := store.GetFile(ctx, betaHandle)
+	betaFile, err := readFile(ctx, store, betaHandle)
 	if err != nil {
-		t.Fatalf("GetFile beta: %v", err)
+		t.Fatalf("read beta post-Restore: %v", err)
 	}
 	if betaFile.Size != 6<<20 {
 		t.Errorf("beta.Size = %d, want %d", betaFile.Size, 6<<20)

--- a/pkg/metadata/storetest/reset_conformance.go
+++ b/pkg/metadata/storetest/reset_conformance.go
@@ -9,19 +9,21 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// fileForReadStore and createCacheStore mirror the optional fast-path
-// interfaces the metadata service probes for. A backend that implements them
-// answers from its own derived caches, which is exactly the state this suite
-// has to see torn down by Reset and RestoreSnapshot; a backend that does not
-// falls back to the plain Store methods below.
-type fileForReadStore interface {
-	GetFileForRead(ctx context.Context, handle metadata.FileHandle) (*metadata.File, error)
-}
+// fileForReadStore and createCacheStore are the read-side subset of the
+// optional fast-path interfaces the metadata service probes for. A backend that
+// implements them answers from its own derived caches, which is exactly the
+// state this suite has to see torn down by Reset and RestoreSnapshot; a backend
+// that does not falls back to the plain Store methods below.
+type (
+	fileForReadStore interface {
+		GetFileForRead(ctx context.Context, handle metadata.FileHandle) (*metadata.File, error)
+	}
 
-type createCacheStore interface {
-	GetFileForCreate(ctx context.Context, handle metadata.FileHandle) (*metadata.File, error)
-	GetChildForCreate(ctx context.Context, dirHandle metadata.FileHandle, name string) (metadata.FileHandle, error)
-}
+	createCacheStore interface {
+		GetFileForCreate(ctx context.Context, handle metadata.FileHandle) (*metadata.File, error)
+		GetChildForCreate(ctx context.Context, dirHandle metadata.FileHandle, name string) (metadata.FileHandle, error)
+	}
+)
 
 // readFile loads handle through the backend's read fast path when it has one,
 // so any file-read cache behind it is both warmed and consulted.


### PR DESCRIPTION
## What was wrong

`BadgerMetadataStore.Reset` (`db.DropAll`) and `RestoreSnapshot` replace every durable record wholesale, but only the share cache was invalidated. The store keeps three more caches derived from those records, and neither entry point touched them:

- `readCache` — decoded `File` records for the handle-addressed read hot path (`GetFileForRead`)
- `parentCache` — decoded parent-directory `File` records with derived paths (`GetFileForCreate`)
- `direntCache` — `(parentID,name) -> childHandle|ABSENT` (`GetChildForCreate`)

Two things make this bite rather than self-heal:

- `RestoreSnapshot` streams the dump through a badger `WriteBatch`, never through a `badgerTransaction`, so none of the per-key `dirtyFiles`/`dirtyDirents` invalidation an ordinary mutation performs runs on the restore path at all.
- Neither cache has a TTL. Entries die only on a keyed `invalidate()` or the 8192-entry prune, and a restore reuses the same share name and the same file UUIDs — so every warm key keeps matching after the wipe.

The result is warm keys answering with pre-restore attributes, and pre-restore directory entries (positive *and* negative), against post-restore data.

**Reachability, verified structurally rather than assumed:** `Runtime.RestoreSnapshot` calls `resetable.Reset` and `snapshotable.RestoreSnapshot` on the store returned by `GetMetadataStoreForShare` — the live instance that was serving the share. `DisableShare`/`EnableShare` only flip a flag on the share row and registry and notify adapters; they do not tear down or rebuild the metadata store, so the quiesce around the restore does not clear anything. The caches survive the whole cycle in-process.

## The fix

`fileReadCache` and `direntCache` get an `invalidateAll()` that mirrors `sharecache.Cache.InvalidateAll` exactly — bump the generation first, then clear — so an in-flight generation-guarded populate against the pre-wipe generation cannot re-insert after the clear. A single `invalidateDerivedCaches()` on the store flushes all four, and both entry points call it (`RestoreSnapshot` via the existing `defer`, so the failure paths that leave the store empty are covered too).

The filesystem-statistics cache is dropped alongside them. Its 5s TTL already bounded the staleness, but there is no reason for FSSTAT to report counts for files that are gone. No other in-memory map in the badger package is derived from durable records (`usedBytes`, the quota cache and the payload index are already re-derived by `Reset`/`initUsedBytesAndPayloadIndex`).

## Evidence

`ResetThenRestoreConformance` already warmed and re-checked the share cache; it now also warms and re-checks a file read, a parent-directory read and a dirent lookup, going through the backend's optional fast-path interfaces when it has them and falling back to the plain `Store` methods when it does not. The post-Reset lookup deliberately arms a negative dirent entry that the restore then has to clear.

A conformance extension that passes before the fix proves nothing, so that was checked explicitly. Against the pre-fix badger build all three new post-Reset assertions fail:

```
--- FAIL: TestResetThenRestoreConformance (0.08s)
    badger_conformance_test.go:52: post-Reset read of alpha.bin succeeded, want an error
    badger_conformance_test.go:52: post-Reset read of the root directory succeeded, want an error
    badger_conformance_test.go:52: post-Reset lookup of alpha.bin succeeded, want an error
FAIL
```

With the fix, every backend wired to the suite passes:

```
ok  github.com/marmos91/dittofs/pkg/metadata/store/badger    0.760s
ok  github.com/marmos91/dittofs/pkg/metadata/store/memory    0.282s
ok  github.com/marmos91/dittofs/pkg/metadata/store/sqlite    0.926s
ok  github.com/marmos91/dittofs/pkg/metadata/store/postgres  3.035s   (-tags integration, against a live postgres)
```

`go test ./pkg/metadata/... ./pkg/controlplane/...` green, `go test -race ./pkg/metadata/store/badger/ ./pkg/metadata/storetest/` green, `golangci-lint run ./pkg/metadata/...` clean.

Closes #1961.
