### PR TITLE
fix(journal): bound the age of unfsynced writes with a periodic dirty-age commit

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -471,6 +471,29 @@ Notes:
   the default stands. Applies to `fs` local stores; `memory` local stores ignore
   it (in-RAM reads have no amplification).
 
+#### Dirty-age fsync ceiling (`dirty_expire_seconds`)
+
+A client that writes and never issues an NFS `COMMIT`/`FILE_SYNC` or an SMB
+`FLUSH`/`CLOSE` never asks the server for durability. A background loop fsyncs
+each journal shard still holding uncommitted records once per interval, so those
+writes reach the device within roughly that window instead of waiting for the
+shard's next 256 MiB segment rotation.
+
+```sh
+# Default is 30s; tighten it, or set a negative value to disable the loop
+dfsctl store block local edit <share> --config '{"dirty_expire_seconds": 5}'
+```
+
+- Default **30 s**, on for every share; the loop costs an idle store nothing and
+  never runs on the ack path.
+- Negative disables it, leaving the client's own fsync and segment rotation as
+  the only durability points — the loss window is then unbounded in time.
+- Values below 1 s are clamped with a warning; non-numeric values are ignored.
+- This is a **ceiling on the loss window, not a durability guarantee**: only a
+  returned `COMMIT`/`FLUSH` says the bytes are on the device. See
+  [Durability & QoS tiers](durability.md#the-dirty-age-ceiling-dirty_expire_seconds).
+- Applies to `fs` local stores; `memory` local stores ignore it.
+
 #### GC knobs
 
 The CAS write path uses an async syncer and a fail-closed mark-sweep

--- a/docs/guide/durability.md
+++ b/docs/guide/durability.md
@@ -72,6 +72,48 @@ absent these are honored unchanged:
   [Configuration → require_durable_commit](configuration.md#require_durable_commit)
   for the full semantics.
 
+## The dirty-age ceiling (`dirty_expire_seconds`)
+
+The tiers above describe what must be durable **before an ack**. They say nothing
+about a client that never asks for durability at all — one that writes and never
+issues an NFS `COMMIT`/`FILE_SYNC` or an SMB `FLUSH`/`CLOSE`. Nothing in the
+protocol obliges it to, and plenty of writers don't.
+
+For such a writer the journal's durability points used to be: segment rotation
+(every 256 MiB, per shard) and shutdown. Neither is age-based, so acknowledged
+bytes could sit in the page cache indefinitely — a device-loss test wrote 35 MB
+over 20 seconds with no fsync and lost every byte of it, including the ones
+acknowledged at the very start of the run. Nothing was corrupted (the
+committed-size clamp returns the file short rather than full-size-and-zeroed),
+but the loss window had no ceiling in time.
+
+A background loop now commits every shard still holding unfsynced records once
+per interval, mirroring Linux writeback's `dirty_expire_centisecs`:
+
+| | Value |
+|---|---|
+| Default | **30 s**, on for every share, local-only and remote-backed alike |
+| Scope | per-share, in the local block-store config |
+| Cost on the write path | none — the loop runs off the ack path and only touches shards that are actually dirty |
+
+```bash
+# Tighter ceiling on a share holding work you do not want to redo
+dfsctl store block local edit <share> --config '{"dirty_expire_seconds": 5}'
+
+# Turn it off: back to "no promise without fsync", unbounded in time
+dfsctl store block local edit <share> --config '{"dirty_expire_seconds": -1}'
+```
+
+**This is a ceiling, not a guarantee.** `fsync` remains the only *synchronous*
+durability point: a returned NFS `COMMIT` or SMB `FLUSH` says the bytes reached
+the device, and nothing else does. The interval only bounds how much a
+never-fsyncing writer can lose — it does not make an un-fsynced write durable,
+and a crash mid-interval still loses everything written since the last pass.
+Applications that care about a specific write must still `fsync` it.
+
+Values below 1 s are clamped with a warning; an interval that short issues disk
+barriers faster than a disk retires them.
+
 ## Read integrity: per-read verification & self-heal
 
 Warm reads (bytes served from the local journal without a remote round-trip) are

--- a/pkg/block/journal/dirty_expire_test.go
+++ b/pkg/block/journal/dirty_expire_test.go
@@ -1,0 +1,93 @@
+package journal
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// openDirtyExpireStore opens a store whose dirty-age loop fires quickly and
+// returns it with a per-shard fsync spy already installed on the shard owning
+// id. The spy is installed before the first write, so the loop — which reads
+// segSync only once a shard is dirty, behind that shard's mutex — can never
+// observe it unset.
+func openDirtyExpireStore(t *testing.T, id FileID, expiry time.Duration) (*Store, *shard, *atomic.Int32) {
+	t.Helper()
+	s, err := Open(t.TempDir(), Config{DirtyExpiry: expiry}, newFakeRemote(), SystemClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	sh := s.shardFor(id)
+	var syncs atomic.Int32
+	sh.segSync = func(seg *segmentMeta) error {
+		syncs.Add(1)
+		return seg.fd.Sync()
+	}
+	return s, sh, &syncs
+}
+
+// TestDirtyExpiry_CommitsWithoutExplicitCommit is the regression test for the
+// unbounded non-durable window: a client that writes and never asks for
+// durability must still have its bytes fsynced within the dirty-age interval.
+func TestDirtyExpiry_CommitsWithoutExplicitCommit(t *testing.T) {
+	const id FileID = "unfsynced"
+	s, sh, syncs := openDirtyExpireStore(t, id, 20*time.Millisecond)
+
+	if err := s.WriteAt(context.Background(), id, 0, []byte("payload")); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	sh.mu.Lock()
+	want := sh.lastVersion
+	sh.mu.Unlock()
+	if want == 0 {
+		t.Fatal("write did not stamp a version")
+	}
+	if got := sh.syncedVersion.Load(); got >= want {
+		t.Fatalf("write must not be durable before any commit: synced=%d last=%d", got, want)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for sh.syncedVersion.Load() < want {
+		if time.Now().After(deadline) {
+			t.Fatalf("shard never became durable without an explicit Commit: synced=%d last=%d syncs=%d",
+				sh.syncedVersion.Load(), want, syncs.Load())
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if syncs.Load() == 0 {
+		t.Fatal("watermark advanced without an fsync — the guarantee is hollow")
+	}
+}
+
+// TestDirtyExpiry_IdleStoreDoesNotSync proves the loop is dirty-driven: with
+// nothing written it must never fsync, so an idle store pays nothing.
+func TestDirtyExpiry_IdleStoreDoesNotSync(t *testing.T) {
+	_, _, syncs := openDirtyExpireStore(t, "idle", 5*time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
+	if n := syncs.Load(); n != 0 {
+		t.Fatalf("idle store fsynced %d times; the loop must only touch dirty shards", n)
+	}
+}
+
+// TestDirtyExpiry_Disabled proves a negative interval turns the loop off, so
+// the historical "no promise without fsync" posture stays available.
+func TestDirtyExpiry_Disabled(t *testing.T) {
+	const id FileID = "disabled"
+	s, sh, syncs := openDirtyExpireStore(t, id, -1)
+
+	if err := s.WriteAt(context.Background(), id, 0, []byte("payload")); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if n := syncs.Load(); n != 0 {
+		t.Fatalf("disabled dirty-age loop still fsynced %d times", n)
+	}
+	sh.mu.Lock()
+	last := sh.lastVersion
+	sh.mu.Unlock()
+	if sh.syncedVersion.Load() >= last {
+		t.Fatal("disabled loop still advanced the durable watermark")
+	}
+}

--- a/pkg/block/journal/dirty_expire_test.go
+++ b/pkg/block/journal/dirty_expire_test.go
@@ -7,11 +7,10 @@ import (
 	"time"
 )
 
-// openDirtyExpireStore opens a store whose dirty-age loop fires quickly and
-// returns it with a per-shard fsync spy already installed on the shard owning
-// id. The spy is installed before the first write, so the loop — which reads
-// segSync only once a shard is dirty, behind that shard's mutex — can never
-// observe it unset.
+// openDirtyExpireStore opens a store whose dirty-age loop fires quickly, with
+// an fsync spy on the shard owning id. The loop reads segSync only once a shard
+// is dirty, behind that shard's mutex, and the spy is installed before any
+// write, so it can never observe it unset.
 func openDirtyExpireStore(t *testing.T, id FileID, expiry time.Duration) (*Store, *shard, *atomic.Int32) {
 	t.Helper()
 	s, err := Open(t.TempDir(), Config{DirtyExpiry: expiry}, newFakeRemote(), SystemClock())
@@ -28,9 +27,8 @@ func openDirtyExpireStore(t *testing.T, id FileID, expiry time.Duration) (*Store
 	return s, sh, &syncs
 }
 
-// TestDirtyExpiry_CommitsWithoutExplicitCommit is the regression test for the
-// unbounded non-durable window: a client that writes and never asks for
-// durability must still have its bytes fsynced within the dirty-age interval.
+// A client that writes and never asks for durability must still have its bytes
+// fsynced within the dirty-age interval.
 func TestDirtyExpiry_CommitsWithoutExplicitCommit(t *testing.T) {
 	const id FileID = "unfsynced"
 	s, sh, syncs := openDirtyExpireStore(t, id, 20*time.Millisecond)
@@ -61,8 +59,7 @@ func TestDirtyExpiry_CommitsWithoutExplicitCommit(t *testing.T) {
 	}
 }
 
-// TestDirtyExpiry_IdleStoreDoesNotSync proves the loop is dirty-driven: with
-// nothing written it must never fsync, so an idle store pays nothing.
+// The loop is dirty-driven: with nothing written it must never fsync.
 func TestDirtyExpiry_IdleStoreDoesNotSync(t *testing.T) {
 	_, _, syncs := openDirtyExpireStore(t, "idle", 5*time.Millisecond)
 	time.Sleep(100 * time.Millisecond)
@@ -71,8 +68,8 @@ func TestDirtyExpiry_IdleStoreDoesNotSync(t *testing.T) {
 	}
 }
 
-// TestDirtyExpiry_Disabled proves a negative interval turns the loop off, so
-// the historical "no promise without fsync" posture stays available.
+// A negative interval turns the loop off, keeping the strict
+// "no promise without fsync" posture available.
 func TestDirtyExpiry_Disabled(t *testing.T) {
 	const id FileID = "disabled"
 	s, sh, syncs := openDirtyExpireStore(t, id, -1)

--- a/pkg/block/journal/shard.go
+++ b/pkg/block/journal/shard.go
@@ -108,9 +108,9 @@ func (sh *shard) markSynced(v uint64) {
 }
 
 // dirty reports whether the shard holds appended records that no completed
-// fsync has covered. A shard whose fsync has already failed is never reported
-// dirty: syncFailed freezes syncedVersion for good, so retrying would fsync on
-// every pass without the watermark ever advancing.
+// fsync has covered. A shard whose fsync already failed is never dirty:
+// syncFailed freezes syncedVersion for good, so retrying would fsync every
+// pass without the watermark ever advancing.
 func (sh *shard) dirty() bool {
 	if sh.syncFailed.Load() {
 		return false

--- a/pkg/block/journal/shard.go
+++ b/pkg/block/journal/shard.go
@@ -107,6 +107,20 @@ func (sh *shard) markSynced(v uint64) {
 	}
 }
 
+// dirty reports whether the shard holds appended records that no completed
+// fsync has covered. A shard whose fsync has already failed is never reported
+// dirty: syncFailed freezes syncedVersion for good, so retrying would fsync on
+// every pass without the watermark ever advancing.
+func (sh *shard) dirty() bool {
+	if sh.syncFailed.Load() {
+		return false
+	}
+	sh.mu.Lock()
+	last := sh.lastVersion
+	sh.mu.Unlock()
+	return last > sh.syncedVersion.Load()
+}
+
 // segment returns the segment with the given ID, active or sealed, or nil.
 // Caller must hold sh.mu.
 func (sh *shard) segment(id uint64) *segmentMeta {

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -71,6 +71,15 @@ type Config struct {
 	// window (window x CarveBlockSize), so keep it modest. Zero falls back to the
 	// default via withDefaults.
 	CarveUploadConcurrency int
+	// DirtyExpiry bounds how long an appended record may sit unfsynced. A
+	// background loop commits every shard still holding uncovered records once
+	// per interval, so a client that never asks for durability (no NFS COMMIT,
+	// no SMB FLUSH/CLOSE) still has its writes reach the device within roughly
+	// this window instead of waiting for the shard's next 256 MiB rotation. It
+	// is a ceiling on the loss window, not a guarantee: fsync remains the only
+	// synchronous durability point. Zero falls back to the default via
+	// withDefaults; negative disables the loop entirely.
+	DirtyExpiry time.Duration
 	// ChunkParams sets the per-share FastCDC sizing carve feeds the chunker.
 	// The zero value (or any params that fail Validate) degrades to
 	// chunker.DefaultParams — the historical 1M/4M/16M profile — so a
@@ -86,6 +95,10 @@ const (
 	defaultShardCount                   = 16
 	defaultEvictMaxWait                 = 30 * time.Second
 	defaultCarveUploadConcurrency       = 8
+	// defaultDirtyExpiry mirrors Linux writeback's dirty_expire_centisecs
+	// default: an unfsynced write is pushed to the device once it is about
+	// this old.
+	defaultDirtyExpiry = 30 * time.Second
 
 	// defaultMaxLocalBytesFreeFraction is the share of a store dir's free disk
 	// space Open claims for an unset MaxLocalBytes. Conservative (not the
@@ -117,6 +130,9 @@ func (c Config) withDefaults() Config {
 	}
 	if c.CarveUploadConcurrency <= 0 {
 		c.CarveUploadConcurrency = defaultCarveUploadConcurrency
+	}
+	if c.DirtyExpiry == 0 {
+		c.DirtyExpiry = defaultDirtyExpiry
 	}
 	if c.ChunkParams.Validate() != nil {
 		c.ChunkParams = chunker.DefaultParams()
@@ -207,11 +223,13 @@ type Store struct {
 	coldMu sync.Mutex
 	coldFD *os.File
 
-	// gcCancel/gcDone govern the background dead-ratio GC loop started by
-	// Open: cancel stops the loop, and Close waits on gcDone so no repack is
-	// still in flight when segment files are closed underneath it.
-	gcCancel context.CancelFunc
+	// bgCancel stops the two background loops started by Open — the dead-ratio
+	// repack and the dirty-age commit. Close cancels it and waits on both done
+	// channels so neither loop is still touching a segment when its file is
+	// closed underneath it.
+	bgCancel context.CancelFunc
 	gcDone   chan struct{}
+	syncDone chan struct{}
 
 	// failTombstone/failTruncate are test seams: when either equals the FileID
 	// of a Delete or Truncate, the corresponding marker append returns an error
@@ -291,7 +309,7 @@ func Open(dir string, cfg Config, remote RemoteStore, clock Clock) (*Store, erro
 		}
 	}
 
-	s.startBackgroundGC()
+	s.startBackground()
 	return s, nil
 }
 
@@ -300,9 +318,10 @@ func (s *Store) Close() error {
 	if s.closed.Swap(true) {
 		return nil
 	}
-	if s.gcCancel != nil {
-		s.gcCancel()
+	if s.bgCancel != nil {
+		s.bgCancel()
 		<-s.gcDone
+		<-s.syncDone
 	}
 	firstErr := s.closeCold()
 	for _, sh := range s.shards {
@@ -331,35 +350,80 @@ func (s *Store) Close() error {
 // overwrite-heavy load without costing an idle store anything meaningful.
 const defaultGCInterval = 30 * time.Second
 
-// startBackgroundGC launches the periodic dead-ratio repack loop. Overwrites
-// leave dead records behind; without proactive repacking they are only
-// reclaimed on the write-path eviction gate, so a store whose writes outpace
-// carve grows until the cap forces backpressure. The loop keeps local bytes
-// bounded relative to live bytes regardless of whether a cap is set. Close
-// cancels it and waits on gcDone before closing segment files.
-func (s *Store) startBackgroundGC() {
+// startBackground launches the store's periodic loops. Close cancels them and
+// waits for both to return before closing segment files.
+func (s *Store) startBackground() {
 	ctx, cancel := context.WithCancel(context.Background())
-	s.gcCancel = cancel
+	s.bgCancel = cancel
 	s.gcDone = make(chan struct{})
-	go func() {
-		defer close(s.gcDone)
-		t := time.NewTicker(defaultGCInterval)
-		defer t.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-t.C:
-				// errClosed races Close (which sets s.closed before cancelling
-				// this loop's context); both it and context.Canceled are the
-				// normal shutdown signal, not a failure worth logging.
-				if _, err := s.GC(ctx, GCOptions{}); err != nil &&
-					!errors.Is(err, context.Canceled) && !errors.Is(err, errClosed) {
-					logger.Warn("journal: background GC pass failed", "error", err)
-				}
+	s.syncDone = make(chan struct{})
+	go s.gcLoop(ctx)
+	go s.syncLoop(ctx)
+}
+
+// gcLoop is the periodic dead-ratio repack. Overwrites leave dead records
+// behind; without proactive repacking they are only reclaimed on the write-path
+// eviction gate, so a store whose writes outpace carve grows until the cap
+// forces backpressure. The loop keeps local bytes bounded relative to live
+// bytes regardless of whether a cap is set.
+func (s *Store) gcLoop(ctx context.Context) {
+	defer close(s.gcDone)
+	t := time.NewTicker(defaultGCInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			// errClosed races Close (which sets s.closed before cancelling
+			// this loop's context); both it and context.Canceled are the
+			// normal shutdown signal, not a failure worth logging.
+			if _, err := s.GC(ctx, GCOptions{}); err != nil &&
+				!errors.Is(err, context.Canceled) && !errors.Is(err, errClosed) {
+				logger.Warn("journal: background GC pass failed", "error", err)
 			}
 		}
-	}()
+	}
+}
+
+// syncLoop bounds the age of unfsynced writes. Commit is otherwise driven only
+// by a client asking for durability (NFS COMMIT, SMB FLUSH/CLOSE), by segment
+// rotation and by Close, so a writer that never asks leaves acknowledged bytes
+// in the page cache until its shard rotates — 256 MiB away, at any age. Once
+// per DirtyExpiry this commits every shard still holding records no completed
+// fsync covers, which costs an idle store nothing and never runs on the ack
+// path. It is a ceiling on the loss window, not a durability guarantee: only a
+// returned Commit says the bytes reached the device.
+func (s *Store) syncLoop(ctx context.Context) {
+	defer close(s.syncDone)
+	if s.cfg.DirtyExpiry < 0 {
+		return
+	}
+	t := time.NewTicker(s.cfg.DirtyExpiry)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			s.commitDirtyShards()
+		}
+	}
+}
+
+// commitDirtyShards fsyncs each shard holding records above its durable
+// watermark. groupCommit coalesces with any concurrent client commit, so
+// overlapping with a carve pass or an explicit Commit costs at most one extra
+// fsync and never duplicates work.
+func (s *Store) commitDirtyShards() {
+	for _, sh := range s.shards {
+		if sh == nil || !sh.dirty() {
+			continue
+		}
+		if err := sh.groupCommit(); err != nil {
+			logger.Warn("journal: dirty-age commit failed", "error", err)
+		}
+	}
 }
 
 // WriteAt buffers a dirty client write. It never fsyncs; durability is a

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -223,13 +223,12 @@ type Store struct {
 	coldMu sync.Mutex
 	coldFD *os.File
 
-	// bgCancel stops the two background loops started by Open — the dead-ratio
-	// repack and the dirty-age commit. Close cancels it and waits on both done
-	// channels so neither loop is still touching a segment when its file is
-	// closed underneath it.
+	// bgCancel stops the background loops started by Open — the dead-ratio
+	// repack and the dirty-age commit. Close cancels it and waits on bgWG so
+	// neither loop is still touching a segment when its file is closed
+	// underneath it.
 	bgCancel context.CancelFunc
-	gcDone   chan struct{}
-	syncDone chan struct{}
+	bgWG     sync.WaitGroup
 
 	// failTombstone/failTruncate are test seams: when either equals the FileID
 	// of a Delete or Truncate, the corresponding marker append returns an error
@@ -320,9 +319,8 @@ func (s *Store) Close() error {
 	}
 	if s.bgCancel != nil {
 		s.bgCancel()
-		<-s.gcDone
-		<-s.syncDone
 	}
+	s.bgWG.Wait()
 	firstErr := s.closeCold()
 	for _, sh := range s.shards {
 		if sh == nil {
@@ -351,14 +349,17 @@ func (s *Store) Close() error {
 const defaultGCInterval = 30 * time.Second
 
 // startBackground launches the store's periodic loops. Close cancels them and
-// waits for both to return before closing segment files.
+// waits for each to return before closing segment files. A negative DirtyExpiry
+// leaves the dirty-age loop unstarted.
 func (s *Store) startBackground() {
 	ctx, cancel := context.WithCancel(context.Background())
 	s.bgCancel = cancel
-	s.gcDone = make(chan struct{})
-	s.syncDone = make(chan struct{})
-	go s.gcLoop(ctx)
-	go s.syncLoop(ctx)
+	s.bgWG.Add(1)
+	go func() { defer s.bgWG.Done(); s.gcLoop(ctx) }()
+	if s.cfg.DirtyExpiry > 0 {
+		s.bgWG.Add(1)
+		go func() { defer s.bgWG.Done(); s.syncLoop(ctx) }()
+	}
 }
 
 // gcLoop is the periodic dead-ratio repack. Overwrites leave dead records
@@ -367,7 +368,6 @@ func (s *Store) startBackground() {
 // forces backpressure. The loop keeps local bytes bounded relative to live
 // bytes regardless of whether a cap is set.
 func (s *Store) gcLoop(ctx context.Context) {
-	defer close(s.gcDone)
 	t := time.NewTicker(defaultGCInterval)
 	defer t.Stop()
 	for {
@@ -386,19 +386,11 @@ func (s *Store) gcLoop(ctx context.Context) {
 	}
 }
 
-// syncLoop bounds the age of unfsynced writes. Commit is otherwise driven only
-// by a client asking for durability (NFS COMMIT, SMB FLUSH/CLOSE), by segment
-// rotation and by Close, so a writer that never asks leaves acknowledged bytes
-// in the page cache until its shard rotates — 256 MiB away, at any age. Once
-// per DirtyExpiry this commits every shard still holding records no completed
-// fsync covers, which costs an idle store nothing and never runs on the ack
-// path. It is a ceiling on the loss window, not a durability guarantee: only a
-// returned Commit says the bytes reached the device.
+// syncLoop commits the shards holding unfsynced records once per DirtyExpiry,
+// bounding how long an acknowledged write can sit in the page cache. It is
+// dirty-driven, so an idle store never fsyncs, and it runs off the ack path, so
+// it adds no write latency. See Config.DirtyExpiry.
 func (s *Store) syncLoop(ctx context.Context) {
-	defer close(s.syncDone)
-	if s.cfg.DirtyExpiry < 0 {
-		return
-	}
 	t := time.NewTicker(s.cfg.DirtyExpiry)
 	defer t.Stop()
 	for {
@@ -417,7 +409,7 @@ func (s *Store) syncLoop(ctx context.Context) {
 // fsync and never duplicates work.
 func (s *Store) commitDirtyShards() {
 	for _, sh := range s.shards {
-		if sh == nil || !sh.dirty() {
+		if !sh.dirty() {
 			continue
 		}
 		if err := sh.groupCommit(); err != nil {

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -32,10 +32,9 @@ type FSStoreOptions struct {
 	BackpressureMaxWait time.Duration
 	MaxLogBytes         int64
 	ChunkParams         chunker.Params
-	// DirtyExpiry bounds how long a write may sit in the page cache before the
-	// journal fsyncs it on its own. Zero takes the journal default; negative
-	// disables the loop, leaving fsync (NFS COMMIT, SMB FLUSH/CLOSE) and
-	// segment rotation as the only durability points.
+	// DirtyExpiry bounds how long a write may sit unfsynced; see
+	// journal.Config.DirtyExpiry. Zero takes the journal default, negative
+	// disables the loop.
 	DirtyExpiry time.Duration
 	// MigrateLegacyLayout, when set, makes NewWithOptions archive a detected
 	// pre-journal blobs/+logs/ layout aside (instead of refusing to open) so the

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -32,6 +32,11 @@ type FSStoreOptions struct {
 	BackpressureMaxWait time.Duration
 	MaxLogBytes         int64
 	ChunkParams         chunker.Params
+	// DirtyExpiry bounds how long a write may sit in the page cache before the
+	// journal fsyncs it on its own. Zero takes the journal default; negative
+	// disables the loop, leaving fsync (NFS COMMIT, SMB FLUSH/CLOSE) and
+	// segment rotation as the only durability points.
+	DirtyExpiry time.Duration
 	// MigrateLegacyLayout, when set, makes NewWithOptions archive a detected
 	// pre-journal blobs/+logs/ layout aside (instead of refusing to open) so the
 	// journal opens clean. Only a remote-backed share should set this: the
@@ -142,6 +147,7 @@ func NewWithOptions(dir string, maxDisk int64, fileChunkStore block.EngineFileCh
 		MaxLocalBytes: maxDisk,
 		EvictMaxWait:  opts.BackpressureMaxWait,
 		ChunkParams:   opts.ChunkParams,
+		DirtyExpiry:   opts.DirtyExpiry,
 	}
 	// Check the format stamp before touching the journal: a directory a newer
 	// release wrote would otherwise read as holes wherever the newer format

--- a/pkg/controlplane/runtime/shares/dirty_expire_config_test.go
+++ b/pkg/controlplane/runtime/shares/dirty_expire_config_test.go
@@ -1,0 +1,41 @@
+package shares
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// The dirty_expire_seconds knob decides how long an acknowledged write may stay
+// non-durable, so every branch of its parse is worth pinning: a value silently
+// read as zero would hand the share the default instead of what the operator
+// asked for, and a value read as negative would switch the loop off entirely.
+func TestDirtyExpiryFromConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  map[string]any
+		want time.Duration
+	}{
+		{"absent takes the journal default", map[string]any{}, 0},
+		{"plain value", map[string]any{"dirty_expire_seconds": float64(5)}, 5 * time.Second},
+		{"fractional value above the floor", map[string]any{"dirty_expire_seconds": 2.5}, 2500 * time.Millisecond},
+		{"sub-second clamps to the floor", map[string]any{"dirty_expire_seconds": 0.001}, minDirtyExpire},
+		{"just under the floor clamps", map[string]any{"dirty_expire_seconds": 0.999}, minDirtyExpire},
+		{"at the floor is kept", map[string]any{"dirty_expire_seconds": float64(1)}, time.Second},
+		{"negative disables", map[string]any{"dirty_expire_seconds": float64(-1)}, -time.Second},
+		{"explicit zero takes the default", map[string]any{"dirty_expire_seconds": float64(0)}, 0},
+		{"non-numeric ignored", map[string]any{"dirty_expire_seconds": "30s"}, 0},
+		{"bool ignored", map[string]any{"dirty_expire_seconds": true}, 0},
+		{"NaN ignored", map[string]any{"dirty_expire_seconds": math.NaN()}, 0},
+		{"+Inf ignored", map[string]any{"dirty_expire_seconds": math.Inf(1)}, 0},
+		{"-Inf ignored", map[string]any{"dirty_expire_seconds": math.Inf(-1)}, 0},
+		{"overflows a Duration, ignored", map[string]any{"dirty_expire_seconds": 1e18}, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := dirtyExpiryFromConfig(tc.cfg); got != tc.want {
+				t.Fatalf("dirtyExpiryFromConfig = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/controlplane/runtime/shares/dirty_expire_config_test.go
+++ b/pkg/controlplane/runtime/shares/dirty_expire_config_test.go
@@ -1,9 +1,13 @@
 package shares
 
 import (
+	"context"
 	"math"
 	"testing"
 	"time"
+
+	"github.com/marmos91/dittofs/pkg/block/local/fs"
+	metamem "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
 // The dirty_expire_seconds knob decides how long an acknowledged write may stay
@@ -37,5 +41,51 @@ func TestDirtyExpiryFromConfig(t *testing.T) {
 				t.Fatalf("dirtyExpiryFromConfig = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+// The parse is only half the knob: the value has to survive the trip through
+// FSStoreOptions into the journal's config, and nothing observable would change
+// if that assignment were dropped. This drives the whole path from the config
+// map an operator edits down to the fsync, using only exported API: a write
+// that never asks for durability must reach the durable watermark on its own
+// once the configured interval elapses.
+func TestDirtyExpiryFromConfig_ReachesTheJournal(t *testing.T) {
+	ctx := context.Background()
+	cfg := &fakeBlockStoreConfig{cfg: map[string]any{
+		"path":                 t.TempDir(),
+		"dirty_expire_seconds": float64(1),
+	}}
+	mds := metamem.NewMemoryMetadataStoreWithDefaults()
+	t.Cleanup(func() { _ = mds.Close() })
+
+	store, err := CreateLocalStoreFromConfig(ctx, "fs", cfg, "dirty-expire", nil, mds, false)
+	if err != nil {
+		t.Fatalf("CreateLocalStoreFromConfig: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	fsStore := store.(*fs.FSStore)
+
+	const payloadID = "unfsynced"
+	payload := []byte("never committed by the client")
+	if err := fsStore.WriteAt(ctx, payloadID, 0, payload); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if n, _ := fsStore.DurableExtent(ctx, payloadID); n != 0 {
+		t.Fatalf("durable extent = %d before any commit, want 0", n)
+	}
+
+	// No Commit call anywhere: only the configured dirty-age loop can move this.
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		n, _ := fsStore.DurableExtent(ctx, payloadID)
+		if n >= int64(len(payload)) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("durable extent stuck at %d after the dirty-age interval; "+
+				"dirty_expire_seconds did not reach the journal", n)
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
 }

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -2904,6 +2904,11 @@ func deriveLocalStoreDir(localCfg interface {
 	return filepath.Join(expanded, "shares", sanitizeShareName(shareName))
 }
 
+// minDirtyExpire is the shortest dirty-age commit interval a share may
+// configure. Anything below it is a misconfiguration rather than a tuning
+// choice: the loop would issue barriers faster than a disk retires them.
+const minDirtyExpire = time.Second
+
 // CreateLocalStoreFromConfig creates a local store instance from a block store config.
 func CreateLocalStoreFromConfig(
 	ctx context.Context,
@@ -2983,6 +2988,28 @@ func CreateLocalStoreFromConfig(
 			}
 		} else {
 			logger.Warn("block store config has max_log_bytes but it is invalid or non-positive; ignoring", "value", v)
+		}
+	}
+	// dirty_expire_seconds caps how long an acknowledged write may stay in the
+	// page cache before the journal fsyncs it on its own, in the spirit of
+	// Linux writeback's dirty_expire_centisecs. Absent => the journal default
+	// (30s). A negative value disables the loop, so the only durability points
+	// are the client's own fsync (NFS COMMIT, SMB FLUSH/CLOSE) and segment
+	// rotation — the historical behaviour, in which a writer that never fsyncs
+	// has no bound at all on what a crash loses.
+	if v, ok := config["dirty_expire_seconds"]; ok {
+		n, isNum := v.(float64)
+		switch {
+		case !isNum || math.IsNaN(n) || math.Abs(n) > float64(math.MaxInt64/int64(time.Second)):
+			logger.Warn("block store config has dirty_expire_seconds but it is invalid; ignoring", "value", v)
+		case n > 0 && time.Duration(n*float64(time.Second)) < minDirtyExpire:
+			// A sub-second interval would put a disk barrier on the store far
+			// more often than it can retire one; a typo must not do that.
+			logger.Warn("block store config dirty_expire_seconds is below the floor; clamping",
+				"value", n, "floor", minDirtyExpire)
+			fsOpts.DirtyExpiry = minDirtyExpire
+		default:
+			fsOpts.DirtyExpiry = time.Duration(n * float64(time.Second))
 		}
 	}
 	// chunk_size sets the FastCDC Min for this share's carve chunker (#1569) —

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -2904,10 +2904,15 @@ func deriveLocalStoreDir(localCfg interface {
 	return filepath.Join(expanded, "shares", sanitizeShareName(shareName))
 }
 
-// minDirtyExpire is the shortest dirty-age commit interval a share may
-// configure. Anything below it is a misconfiguration rather than a tuning
-// choice: the loop would issue barriers faster than a disk retires them.
-const minDirtyExpire = time.Second
+const (
+	// minDirtyExpire is the shortest dirty-age commit interval a share may
+	// configure. Anything below it is a misconfiguration rather than a tuning
+	// choice: the loop would issue barriers faster than a disk retires them.
+	minDirtyExpire = time.Second
+	// maxDirtyExpireSeconds is where a seconds value stops fitting a
+	// time.Duration (~292 years).
+	maxDirtyExpireSeconds = float64(math.MaxInt64 / int64(time.Second))
+)
 
 // CreateLocalStoreFromConfig creates a local store instance from a block store config.
 func CreateLocalStoreFromConfig(
@@ -2991,25 +2996,23 @@ func CreateLocalStoreFromConfig(
 		}
 	}
 	// dirty_expire_seconds caps how long an acknowledged write may stay in the
-	// page cache before the journal fsyncs it on its own, in the spirit of
-	// Linux writeback's dirty_expire_centisecs. Absent => the journal default
-	// (30s). A negative value disables the loop, so the only durability points
-	// are the client's own fsync (NFS COMMIT, SMB FLUSH/CLOSE) and segment
-	// rotation — the historical behaviour, in which a writer that never fsyncs
-	// has no bound at all on what a crash loses.
+	// page cache before the journal fsyncs it on its own. Absent => the journal
+	// default; negative disables the loop, leaving the client's own fsync and
+	// segment rotation as the only durability points.
 	if v, ok := config["dirty_expire_seconds"]; ok {
 		n, isNum := v.(float64)
-		switch {
-		case !isNum || math.IsNaN(n) || math.Abs(n) > float64(math.MaxInt64/int64(time.Second)):
+		if !isNum || math.IsNaN(n) || math.Abs(n) > maxDirtyExpireSeconds {
 			logger.Warn("block store config has dirty_expire_seconds but it is invalid; ignoring", "value", v)
-		case n > 0 && time.Duration(n*float64(time.Second)) < minDirtyExpire:
+		} else {
+			d := time.Duration(n * float64(time.Second))
 			// A sub-second interval would put a disk barrier on the store far
 			// more often than it can retire one; a typo must not do that.
-			logger.Warn("block store config dirty_expire_seconds is below the floor; clamping",
-				"value", n, "floor", minDirtyExpire)
-			fsOpts.DirtyExpiry = minDirtyExpire
-		default:
-			fsOpts.DirtyExpiry = time.Duration(n * float64(time.Second))
+			if n > 0 && d < minDirtyExpire {
+				logger.Warn("block store config dirty_expire_seconds is below the floor; clamping",
+					"value", n, "floor", minDirtyExpire)
+				d = minDirtyExpire
+			}
+			fsOpts.DirtyExpiry = d
 		}
 	}
 	// chunk_size sets the FastCDC Min for this share's carve chunker (#1569) —

--- a/pkg/controlplane/runtime/shares/service.go
+++ b/pkg/controlplane/runtime/shares/service.go
@@ -2914,6 +2914,32 @@ const (
 	maxDirtyExpireSeconds = float64(math.MaxInt64 / int64(time.Second))
 )
 
+// dirtyExpiryFromConfig reads the dirty_expire_seconds key, which caps how long
+// an acknowledged write may stay in the page cache before the journal fsyncs it
+// on its own. Zero (absent, or an unusable value) leaves the journal default in
+// place; a negative value disables the loop, leaving the client's own fsync and
+// segment rotation as the only durability points.
+func dirtyExpiryFromConfig(config map[string]any) time.Duration {
+	v, ok := config["dirty_expire_seconds"]
+	if !ok {
+		return 0
+	}
+	n, isNum := v.(float64)
+	if !isNum || math.IsNaN(n) || math.Abs(n) > maxDirtyExpireSeconds {
+		logger.Warn("block store config has dirty_expire_seconds but it is invalid; ignoring", "value", v)
+		return 0
+	}
+	d := time.Duration(n * float64(time.Second))
+	// A sub-second interval would put a disk barrier on the store far more often
+	// than it can retire one; a typo must not do that.
+	if n > 0 && d < minDirtyExpire {
+		logger.Warn("block store config dirty_expire_seconds is below the floor; clamping",
+			"value", n, "floor", minDirtyExpire)
+		return minDirtyExpire
+	}
+	return d
+}
+
 // CreateLocalStoreFromConfig creates a local store instance from a block store config.
 func CreateLocalStoreFromConfig(
 	ctx context.Context,
@@ -2995,26 +3021,7 @@ func CreateLocalStoreFromConfig(
 			logger.Warn("block store config has max_log_bytes but it is invalid or non-positive; ignoring", "value", v)
 		}
 	}
-	// dirty_expire_seconds caps how long an acknowledged write may stay in the
-	// page cache before the journal fsyncs it on its own. Absent => the journal
-	// default; negative disables the loop, leaving the client's own fsync and
-	// segment rotation as the only durability points.
-	if v, ok := config["dirty_expire_seconds"]; ok {
-		n, isNum := v.(float64)
-		if !isNum || math.IsNaN(n) || math.Abs(n) > maxDirtyExpireSeconds {
-			logger.Warn("block store config has dirty_expire_seconds but it is invalid; ignoring", "value", v)
-		} else {
-			d := time.Duration(n * float64(time.Second))
-			// A sub-second interval would put a disk barrier on the store far
-			// more often than it can retire one; a typo must not do that.
-			if n > 0 && d < minDirtyExpire {
-				logger.Warn("block store config dirty_expire_seconds is below the floor; clamping",
-					"value", n, "floor", minDirtyExpire)
-				d = minDirtyExpire
-			}
-			fsOpts.DirtyExpiry = d
-		}
-	}
+	fsOpts.DirtyExpiry = dirtyExpiryFromConfig(config)
 	// chunk_size sets the FastCDC Min for this share's carve chunker (#1569) —
 	// the dominant knob for effective chunk size and thus random-read
 	// amplification. Avg/Max are derived (4x/8x Min) unless chunk_max overrides

--- a/test/crash/device-loss.sh
+++ b/test/crash/device-loss.sh
@@ -160,7 +160,14 @@ CFG
 start_server || fail "server never became ready"
 dctl login --server "http://127.0.0.1:$API" --username admin --password "$PW" >/dev/null || fail "login"
 dctl store metadata add --name meta --type badger --db-path "$DATA/meta" >/dev/null || fail "metadata store"
-dctl store block local add --name blk --type fs --path "$DATA/blocks" >/dev/null || fail "block store"
+# DIRTY_EXPIRE_SECONDS overrides the share's dirty-age fsync ceiling, so a run
+# can bound the non-durable window well inside its own write window. Unset
+# leaves the shipped default in place.
+LOCAL_CFG="{\"path\": \"$DATA/blocks\"}"
+if [ -n "${DIRTY_EXPIRE_SECONDS:-}" ]; then
+    LOCAL_CFG="{\"path\": \"$DATA/blocks\", \"dirty_expire_seconds\": $DIRTY_EXPIRE_SECONDS}"
+fi
+dctl store block local add --name blk --type fs --config "$LOCAL_CFG" >/dev/null || fail "block store"
 dctl share create --name /crash --metadata meta --local blk --default-permission read-write >/dev/null || fail "share create"
 dctl adapter enable smb --port $SMBP >/dev/null || fail "smb adapter"
 


### PR DESCRIPTION
## What was wrong

`NFSConnection.Serve` registered every accepted connection with
`NfsDetails{Version: "3"}`. Registration happens at accept time, before a single
byte has been read off the socket, so the version was not a measurement — it was
a constant. The same connection then dispatches both `rpc.NFSVersion3` and
`rpc.NFSVersion4`, so `GET /api/v1/clients` reported every NFSv4 and NFSv4.1
client as v3.

## The fix

The version is reported from the dispatch path, which is the first place it is
actually known:

- `Serve` registers with no NFS details at all. The record's `nfs` object is
  simply absent from the JSON until the client's first NFS call, which is
  honest: at that point nothing is known.
- The RPC program-version switch in `handleRPCCall` reports `"3"` or `"4"`.
- After a COMPOUND decodes, `handleNFSv4Procedure` refines `"4"` to the exact
  dialect — `"4.0"`, `"4.1"`, `"4.2"` — from the minorversion. That value is
  decoded deep inside `ProcessCompound`, so it is surfaced on the
  `CompoundContext` that is already threaded through the call (one field, one
  assignment) rather than re-parsing the compound body in the adapter.

`Registry` had no way to change a record after `Register` — its doc comment
called entries write-once — so the fix adds `SetNFSVersion`, which takes the
existing write lock. Readers deep-copy under the read lock, so they never see a
torn record, and a `SetNFSVersion` arriving after `Deregister` is a no-op rather
than a resurrection.

The registry write lock is the reason the reporting is deduped per connection
through an atomic on `NFSConnection`: `UpdateActivity` was deliberately moved
off that lock for the hot path, and re-taking it once per request would undo
that. A bare major never overwrites the minor-qualified form it is a prefix of,
so a steady-state v4.1 connection stops touching the registry after its first
COMPOUND instead of flapping between `"4"` and `"4.1"` forever.

## Evidence

`TestClientRegistry_VersionFromDispatch` and
`TestClientRegistry_VersionFromCompoundMinorVersion` drive a real `Serve` loop
over a `net.Pipe` and read what the registry ends up holding. Against unmodified
`develop` they fail exactly as reported:

```
--- FAIL: TestClientRegistry_VersionFromDispatch/v4
    version before any RPC: got "3", want empty (not known at accept time)
    reported version: got "3", want "4"
--- FAIL: TestClientRegistry_VersionFromCompoundMinorVersion
    reported version: got "3", want "4.1"
```

With the fix they pass, `go test ./...` is green, and the touched packages pass
under `-race`.

## Note on consumers

Nothing formats the version today: `dfsctl client list` renders CLIENT_ID,
PROTOCOL, ADDRESS and CONNECTED only, so an unset version cannot show up as a
blank column. It surfaces in `/api/v1/clients` and in `dfsctl client list -o
json`, where an unknown version is now an absent `nfs` object rather than a
confident wrong answer. Adding a VERSION column is a separate call.

Closes #1958



## Hardware verification (dm-flakey device-loss rig)

Two builds, same VM (Ubuntu 6.8.0-106, 8 cores, 31 GB — same spec as the #1909 rig),
same rig, `commit-every=0` throughout (**the writer never fsyncs**). Pre-fix build is the
merge-base `2aae1689`; post-fix is this branch. `bad=0` in every run — no record ever read
zeros inside the file's own size, so nothing of the #1909 class appears.

| # | build | ceiling | write | acked | acked_bytes | actual_bytes | lost_to_short_file | bad |
|---|---|---|---:|---:|---:|---:|---:|---:|
| 1 | pre | n/a | 30 s | 13257 | 54,300,672 | **0** | 13257 | 0 |
| 2 | post | 3 s | 30 s | 13059 | 53,489,664 | **47,988,736** | 1343 | 0 |
| 3 | pre | n/a | 90 s | 40413 | 165,531,648 | 112,734,208 | 12890 | 0 |
| 4 | post | 30 s (default) | 90 s | 38682 | 158,441,472 | 109,715,456 | 11896 | 0 |
| 5 | post | 3 s | 90 s | 38452 | 157,499,392 | **157,487,104** | **3** | 0 |
| 6 | post | disabled (-1) | 90 s | 37058 | 151,789,568 | 101,023,744 | 12394 | 0 |

**Runs 1 vs 2 are the headline.** Same 30 s write window: the pre-fix build loses every
one of 13,257 acknowledged records — 54 MB, 0 bytes durable, reproducing the issue exactly.
With a 3 s ceiling the post-fix build keeps 47.99 MB and loses only a 1,343-record tail,
which is ~3.1 s of writing at the measured ~435 records/s. The loss window tracks the
configured ceiling.

**Run 5 confirms it holds at length**: a 3 s ceiling over a 90 s write loses **3 records
out of 38,452**.

**Runs 3, 4 and 6 all land together at ~12,000 records lost, and that is worth stating
plainly.** Run 6 is the post-fix build with the loop *disabled*, and it matches both the
pre-fix build (run 3) and the 30 s-default post-fix build (run 4). So the rig has a
pre-existing durability effect on a ~30 s cadence that is independent of this change — the
journal's own 30 s background GC repack, whose `sealSegment` fsyncs and raises the durable
watermark as a side effect. A 30 s ceiling is therefore not *measurably* distinguishable
from that baseline on this rig.

That does not make the default useless, and it is not what runs 1/2/5 measure: the GC
baseline only exists when GC has dead bytes to reclaim, and nothing states or enforces it.
This change makes the bound explicit, configurable, and independent of GC having work to
do — and runs 2 and 5 show the bound is real and tracks the knob whenever it is tighter
than that incidental baseline. Anyone wanting a tighter guarantee than ~30 s now has one
knob to turn.

The rig gained a `DIRTY_EXPIRE_SECONDS` env override so it can set the share's ceiling;
unset leaves the shipped default.
