### PR TITLE
fix(nfs): report the real NFS version for a connected client

### DIFF
--- a/internal/adapter/nfs/v4/handlers/compound.go
+++ b/internal/adapter/nfs/v4/handlers/compound.go
@@ -330,6 +330,7 @@ func (h *Handler) ProcessCompound(compCtx *types.CompoundContext, data []byte) (
 	if err != nil {
 		return nil, fmt.Errorf("decode COMPOUND minorversion: %w", err)
 	}
+	compCtx.MinorVersion = minorVersion
 
 	// Decode number of operations
 	numOps, err := xdr.DecodeUint32(reader)

--- a/internal/adapter/nfs/v4/handlers/compound.go
+++ b/internal/adapter/nfs/v4/handlers/compound.go
@@ -330,7 +330,6 @@ func (h *Handler) ProcessCompound(compCtx *types.CompoundContext, data []byte) (
 	if err != nil {
 		return nil, fmt.Errorf("decode COMPOUND minorversion: %w", err)
 	}
-	compCtx.MinorVersion = minorVersion
 
 	// Decode number of operations
 	numOps, err := xdr.DecodeUint32(reader)
@@ -353,6 +352,7 @@ func (h *Handler) ProcessCompound(compCtx *types.CompoundContext, data []byte) (
 			"client", compCtx.ClientAddr)
 		return encodeCompoundResponse(types.NFS4ERR_MINOR_VERS_MISMATCH, tag, nil)
 	}
+	compCtx.MinorVersion, compCtx.MinorVersionAccepted = minorVersion, true
 
 	switch minorVersion {
 	case types.NFS4_MINOR_VERSION_0:

--- a/internal/adapter/nfs/v4/handlers/compound_test.go
+++ b/internal/adapter/nfs/v4/handlers/compound_test.go
@@ -2665,8 +2665,39 @@ func TestProcessCompound_RecordsMinorVersion(t *testing.T) {
 			t.Fatalf("minorversion %d: ProcessCompound error: %v", minorVersion, err)
 		}
 
+		if !ctx.MinorVersionAccepted {
+			t.Errorf("minorversion %d: MinorVersionAccepted = false, want true", minorVersion)
+		}
 		if ctx.MinorVersion != minorVersion {
 			t.Errorf("ctx.MinorVersion = %d, want %d", ctx.MinorVersion, minorVersion)
 		}
+	}
+}
+
+// TestProcessCompound_RefusedMinorVersionNotRecorded verifies that a
+// minorversion outside the accepted range is not left on the context. The
+// refusal is answered with NFS4ERR_MINOR_VERS_MISMATCH and a nil error, so a
+// caller that read MinorVersion on a nil error alone would treat a dialect the
+// server never served as the client's version.
+func TestProcessCompound_RefusedMinorVersionNotRecorded(t *testing.T) {
+	h := newTestHandler()
+	ctx := newTestCompoundContext()
+
+	data := buildCompoundArgs(nil, 99, []uint32{types.OP_PUTROOTFH})
+	resp, err := h.ProcessCompound(ctx, data)
+	if err != nil {
+		t.Fatalf("ProcessCompound error: %v", err)
+	}
+
+	decoded, err := decodeCompoundResponse(resp)
+	if err != nil {
+		t.Fatalf("decode response error: %v", err)
+	}
+	if decoded.Status != types.NFS4ERR_MINOR_VERS_MISMATCH {
+		t.Fatalf("status = %d, want NFS4ERR_MINOR_VERS_MISMATCH (%d)", decoded.Status, types.NFS4ERR_MINOR_VERS_MISMATCH)
+	}
+
+	if ctx.MinorVersionAccepted {
+		t.Error("MinorVersionAccepted = true for a refused minorversion, want false")
 	}
 }

--- a/internal/adapter/nfs/v4/handlers/compound_test.go
+++ b/internal/adapter/nfs/v4/handlers/compound_test.go
@@ -2650,3 +2650,23 @@ func TestIsOperationBlocked_CacheHit(t *testing.T) {
 		t.Errorf("OP_DELEGPURGE should be cleared after empty SetBlockedOps")
 	}
 }
+
+// TestProcessCompound_RecordsMinorVersion verifies that the decoded
+// minorversion is left on the compound context. The NFS adapter reads it there
+// to report the client's exact dialect ("4.0" / "4.1" / "4.2") rather than the
+// bare major version the RPC header carries.
+func TestProcessCompound_RecordsMinorVersion(t *testing.T) {
+	for _, minorVersion := range []uint32{0, 1, 2} {
+		h := newTestHandler()
+		ctx := newTestCompoundContext()
+
+		data := buildCompoundArgs(nil, minorVersion, []uint32{types.OP_PUTROOTFH})
+		if _, err := h.ProcessCompound(ctx, data); err != nil {
+			t.Fatalf("minorversion %d: ProcessCompound error: %v", minorVersion, err)
+		}
+
+		if ctx.MinorVersion != minorVersion {
+			t.Errorf("ctx.MinorVersion = %d, want %d", ctx.MinorVersion, minorVersion)
+		}
+	}
+}

--- a/internal/adapter/nfs/v4/types/types.go
+++ b/internal/adapter/nfs/v4/types/types.go
@@ -137,12 +137,20 @@ type CompoundContext struct {
 	RequestDigest []byte
 
 	// MinorVersion is the minorversion field decoded from the COMPOUND
-	// arguments (0 for NFSv4.0, 1 for NFSv4.1, 2 for NFSv4.2). Set by
-	// ProcessCompound as soon as it is decoded, before the accepted-range
-	// check, so it always reflects what the client asked for. Zero until
-	// then, which is indistinguishable from a genuine v4.0 request -- read it
-	// only after ProcessCompound has returned without error.
+	// arguments (0 for NFSv4.0, 1 for NFSv4.1, 2 for NFSv4.2). ProcessCompound
+	// sets it only once the value has passed the accepted-range check, so it
+	// never holds a dialect the server refused to serve.
+	//
+	// Zero is both "NFSv4.0" and "not set yet", so read it only when
+	// MinorVersionAccepted is true.
 	MinorVersion uint32
+
+	// MinorVersionAccepted reports whether MinorVersion holds a minorversion
+	// the server accepted. False when ProcessCompound has not run, when it
+	// failed before the range check, or when it answered
+	// NFS4ERR_MINOR_VERS_MISMATCH -- that last case returns a well-formed reply
+	// and a nil error, so the error alone cannot be used to tell them apart.
+	MinorVersionAccepted bool
 }
 
 // Principal returns a best-effort string identity of the authenticated caller,

--- a/internal/adapter/nfs/v4/types/types.go
+++ b/internal/adapter/nfs/v4/types/types.go
@@ -135,6 +135,14 @@ type CompoundContext struct {
 	// slot request fingerprint to detect false retries (RFC 8881
 	// Section 2.10.6.1.3 -- a slot+seqid reused for a different request).
 	RequestDigest []byte
+
+	// MinorVersion is the minorversion field decoded from the COMPOUND
+	// arguments (0 for NFSv4.0, 1 for NFSv4.1, 2 for NFSv4.2). Set by
+	// ProcessCompound as soon as it is decoded, before the accepted-range
+	// check, so it always reflects what the client asked for. Zero until
+	// then, which is indistinguishable from a genuine v4.0 request -- read it
+	// only after ProcessCompound has returned without error.
+	MinorVersion uint32
 }
 
 // Principal returns a best-effort string identity of the authenticated caller,

--- a/pkg/adapter/nfs/client_version_test.go
+++ b/pkg/adapter/nfs/client_version_test.go
@@ -1,0 +1,262 @@
+package nfs
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc"
+	v4handlers "github.com/marmos91/dittofs/internal/adapter/nfs/v4/handlers"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/pseudofs"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime/clients"
+)
+
+// encodeCall builds a complete RPC-over-TCP call record (RFC 5531): a
+// record-marking header followed by an AUTH_NULL call header and the procedure
+// arguments.
+func encodeCall(xid, program, version, procedure uint32, args []byte) []byte {
+	var body []byte
+	for _, v := range []uint32{
+		xid,
+		0, // msg_type: CALL
+		2, // rpcvers
+		program,
+		version,
+		procedure,
+		0, 0, // cred: AUTH_NULL, zero-length body
+		0, 0, // verf: AUTH_NULL, zero-length body
+	} {
+		body = binary.BigEndian.AppendUint32(body, v)
+	}
+	body = append(body, args...)
+	return append(binary.BigEndian.AppendUint32(nil, uint32(len(body))|0x80000000), body...)
+}
+
+// readReply consumes a single RPC-over-TCP reply frame.
+func readReply(t *testing.T, conn net.Conn) {
+	t.Helper()
+
+	header := make([]byte, 4)
+	if _, err := io.ReadFull(conn, header); err != nil {
+		t.Fatalf("reading fragment header: %v", err)
+	}
+	bodyLen := binary.BigEndian.Uint32(header) &^ 0x80000000
+	if _, err := io.ReadFull(conn, make([]byte, bodyLen)); err != nil {
+		t.Fatalf("reading reply body: %v", err)
+	}
+}
+
+// reportedVersion returns the NFS version the registry holds for the client, or
+// "" when no NFS details have been recorded.
+func reportedVersion(t *testing.T, rt *runtime.Runtime, clientID string) string {
+	t.Helper()
+
+	record := rt.Clients().Get(clientID)
+	if record == nil {
+		t.Fatalf("client %q is not registered", clientID)
+	}
+	if record.NFS == nil {
+		return ""
+	}
+	return record.NFS.Version
+}
+
+// waitForClient blocks until the connection has registered itself, so the
+// assertions do not race the Serve goroutine's first statements.
+func waitForClient(t *testing.T, rt *runtime.Runtime, clientID string) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if rt.Clients().Get(clientID) != nil {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("client %q never registered", clientID)
+}
+
+// TestClientRegistry_VersionFromDispatch drives a served connection with a
+// single NFS call and checks the version the registry ends up reporting.
+//
+// The version used to be hardcoded to "3" when the connection was accepted,
+// before anything had been read off the wire, so an NFSv4 client was reported
+// as v3 by /api/v1/clients. It is now unset at accept time and filled in from
+// the dispatched call.
+func TestClientRegistry_VersionFromDispatch(t *testing.T) {
+	const clientID = "nfs-1"
+	const unknownProc = uint32(99) // absent from the dispatch tables: cheap reply
+
+	tests := []struct {
+		name    string
+		version uint32
+		want    string
+	}{
+		{name: "v3", version: rpc.NFSVersion3, want: "3"},
+		{name: "v4", version: rpc.NFSVersion4, want: "4"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			adapter := New(NFSConfig{Enabled: true, Port: 12049})
+			rt := runtime.New(nil)
+			adapter.Registry = rt
+
+			client, server := net.Pipe()
+			t.Cleanup(func() { _ = client.Close(); _ = server.Close() })
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			served := make(chan struct{})
+			go func() {
+				defer close(served)
+				NewNFSConnection(adapter, server, 1).Serve(ctx)
+			}()
+
+			waitForClient(t, rt, clientID)
+			if got := reportedVersion(t, rt, clientID); got != "" {
+				t.Errorf("version before any RPC: got %q, want empty (not known at accept time)", got)
+			}
+
+			if _, err := client.Write(encodeCall(0xCAFEF00D, rpc.ProgramNFS, tc.version, unknownProc, nil)); err != nil {
+				t.Fatalf("writing call: %v", err)
+			}
+			// The reply is written after dispatch, so by the time it lands the
+			// version has been reported.
+			readReply(t, client)
+
+			if got := reportedVersion(t, rt, clientID); got != tc.want {
+				t.Errorf("reported version: got %q, want %q", got, tc.want)
+			}
+
+			_ = client.Close()
+			select {
+			case <-served:
+			case <-time.After(2 * time.Second):
+				t.Fatal("Serve did not return after the client closed")
+			}
+		})
+	}
+}
+
+// newRegisteredConnection wires a connection to a live registry and registers it
+// the way Serve does, without running the read loop.
+func newRegisteredConnection(t *testing.T) (*NFSConnection, *runtime.Runtime) {
+	t.Helper()
+
+	adapter := New(NFSConfig{Enabled: true, Port: 12049})
+	rt := runtime.New(nil)
+	adapter.Registry = rt
+
+	client, server := net.Pipe()
+	t.Cleanup(func() { _ = client.Close(); _ = server.Close() })
+
+	conn := NewNFSConnection(adapter, server, 1)
+	conn.clientID = "nfs-1"
+	rt.Clients().Register(&clients.ClientRecord{
+		ClientID: conn.clientID,
+		Protocol: "nfs",
+		Address:  "127.0.0.1:12345",
+	})
+	return conn, rt
+}
+
+// TestNoteNFSVersion_MinorVersionRefinement verifies that the minor version
+// decoded from a COMPOUND replaces the bare major learned from the RPC program
+// version, and that a later bare major does not undo it — otherwise every v4
+// COMPOUND would flap the record between "4" and "4.1", taking the registry
+// write lock twice per request.
+func TestNoteNFSVersion_MinorVersionRefinement(t *testing.T) {
+	conn, rt := newRegisteredConnection(t)
+
+	conn.noteNFSVersion("4")
+	if got := reportedVersion(t, rt, conn.clientID); got != "4" {
+		t.Fatalf("after program version: got %q, want %q", got, "4")
+	}
+
+	conn.noteNFSVersion("4.1")
+	if got := reportedVersion(t, rt, conn.clientID); got != "4.1" {
+		t.Fatalf("after COMPOUND minorversion: got %q, want %q", got, "4.1")
+	}
+
+	conn.noteNFSVersion("4")
+	if got := reportedVersion(t, rt, conn.clientID); got != "4.1" {
+		t.Errorf("after a further v4 call: got %q, want %q (minor version must not be dropped)", got, "4.1")
+	}
+}
+
+// TestNoteNFSVersion_UnregisteredClient verifies the version report is a no-op
+// once the client has gone away, rather than resurrecting a deregistered record.
+func TestNoteNFSVersion_UnregisteredClient(t *testing.T) {
+	conn, rt := newRegisteredConnection(t)
+
+	rt.Clients().Deregister(conn.clientID)
+	conn.noteNFSVersion("4.1")
+
+	if record := rt.Clients().Get(conn.clientID); record != nil {
+		t.Errorf("deregistered client was recreated: %+v", record)
+	}
+}
+
+// encodeCompoundArgs builds COMPOUND4args: an empty tag, the minorversion, and
+// a single PUTROOTFH operation.
+func encodeCompoundArgs(minorVersion uint32) []byte {
+	var args []byte
+	for _, v := range []uint32{
+		0, // tag: zero-length opaque
+		minorVersion,
+		1,  // numops
+		24, // OP_PUTROOTFH
+	} {
+		args = binary.BigEndian.AppendUint32(args, v)
+	}
+	return args
+}
+
+// TestClientRegistry_VersionFromCompoundMinorVersion verifies that the dialect
+// reported for a v4.1 client is "4.1" and not the bare "4" the RPC program
+// version carries: the minorversion only appears inside the COMPOUND body.
+func TestClientRegistry_VersionFromCompoundMinorVersion(t *testing.T) {
+	const clientID = "nfs-1"
+
+	adapter := New(NFSConfig{Enabled: true, Port: 12049})
+	rt := runtime.New(nil)
+	adapter.Registry = rt
+	adapter.v4Handler = v4handlers.NewHandler(rt, pseudofs.New())
+
+	client, server := net.Pipe()
+	t.Cleanup(func() { _ = client.Close(); _ = server.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	served := make(chan struct{})
+	go func() {
+		defer close(served)
+		NewNFSConnection(adapter, server, 1).Serve(ctx)
+	}()
+
+	waitForClient(t, rt, clientID)
+
+	call := encodeCall(0xCAFEF00D, rpc.ProgramNFS, rpc.NFSVersion4, 1 /* COMPOUND */, encodeCompoundArgs(1))
+	if _, err := client.Write(call); err != nil {
+		t.Fatalf("writing COMPOUND: %v", err)
+	}
+	readReply(t, client)
+
+	if got := reportedVersion(t, rt, clientID); got != "4.1" {
+		t.Errorf("reported version: got %q, want %q", got, "4.1")
+	}
+
+	_ = client.Close()
+	select {
+	case <-served:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve did not return after the client closed")
+	}
+}

--- a/pkg/adapter/nfs/client_version_test.go
+++ b/pkg/adapter/nfs/client_version_test.go
@@ -260,3 +260,63 @@ func TestClientRegistry_VersionFromCompoundMinorVersion(t *testing.T) {
 		t.Fatal("Serve did not return after the client closed")
 	}
 }
+
+// TestClientRegistry_RefusedMinorVersionNotReported verifies that a minorversion
+// the server refuses is never written to the registry. NFS4ERR_MINOR_VERS_MISMATCH
+// is answered with a well-formed reply and a nil error, so the error alone
+// cannot be used to tell a refusal from a served COMPOUND, and a client can put
+// any uint32 in that field. The connection stays on the "4" the RPC header
+// carried.
+func TestClientRegistry_RefusedMinorVersionNotReported(t *testing.T) {
+	const clientID = "nfs-1"
+
+	adapter := New(NFSConfig{Enabled: true, Port: 12049})
+	rt := runtime.New(nil)
+	adapter.Registry = rt
+	adapter.v4Handler = v4handlers.NewHandler(rt, pseudofs.New())
+
+	client, server := net.Pipe()
+	t.Cleanup(func() { _ = client.Close(); _ = server.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	served := make(chan struct{})
+	go func() {
+		defer close(served)
+		NewNFSConnection(adapter, server, 1).Serve(ctx)
+	}()
+
+	waitForClient(t, rt, clientID)
+
+	call := encodeCall(0xCAFEF00D, rpc.ProgramNFS, rpc.NFSVersion4, 1 /* COMPOUND */, encodeCompoundArgs(99))
+	if _, err := client.Write(call); err != nil {
+		t.Fatalf("writing COMPOUND: %v", err)
+	}
+	readReply(t, client)
+
+	if got := reportedVersion(t, rt, clientID); got != "4" {
+		t.Errorf("reported version: got %q, want %q (a refused minorversion must not be reported)", got, "4")
+	}
+
+	_ = client.Close()
+	select {
+	case <-served:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve did not return after the client closed")
+	}
+}
+
+// TestNoteNFSVersion_MinorVersionIsNotAPrefixMatch verifies that a two-digit
+// minor version on record does not swallow a later single-digit one. Only the
+// bare major is allowed to be superseded, so "4.1" still replaces "4.10".
+func TestNoteNFSVersion_MinorVersionIsNotAPrefixMatch(t *testing.T) {
+	conn, rt := newRegisteredConnection(t)
+
+	conn.noteNFSVersion("4.10")
+	conn.noteNFSVersion("4.1")
+
+	if got := reportedVersion(t, rt, conn.clientID); got != "4.1" {
+		t.Errorf("reported version: got %q, want %q", got, "4.1")
+	}
+}

--- a/pkg/adapter/nfs/connection.go
+++ b/pkg/adapter/nfs/connection.go
@@ -279,16 +279,22 @@ func (c *NFSConnection) dispatchRequest(ctx context.Context, clientAddr string, 
 // the dispatch path reports it: the program version gives "3" or "4", and the
 // COMPOUND minorversion refines "4" to "4.0"/"4.1"/"4.2" once decoded.
 //
-// Nothing is published while the version already on record starts with the one
-// being reported, which covers both an unchanged version and a bare major
-// arriving after the minor-qualified form it is a prefix of. A steady-state
-// connection therefore stops taking the registry write lock after its first
-// calls.
+// Nothing is published while the version on record already says as much or
+// more: an unchanged version, or the bare major that every RPC header carries
+// arriving after a COMPOUND refined it to "4.1". Matching on version+"." rather
+// than on the bare prefix keeps "4.1" from reading as a refinement of "4.10".
+// A steady-state connection therefore stops taking the registry write lock
+// after its first calls.
 func (c *NFSConnection) noteNFSVersion(version string) {
-	if cur, _ := c.nfsVersion.Load().(string); strings.HasPrefix(cur, version) {
+	cur, _ := c.nfsVersion.Load().(string)
+	if cur == version || strings.HasPrefix(cur, version+".") {
 		return
 	}
 	if rt := c.server.Registry; rt != nil && c.clientID != "" {
+		// ponytail: last writer wins. Two dispatch goroutines can both pass the
+		// check above, so a v4.1 connection can briefly report "4" until its
+		// next COMPOUND corrects it. Needs a compare-and-swap plus ordered
+		// stores only if this field ever gates behaviour instead of reporting.
 		c.nfsVersion.Store(version)
 		rt.Clients().SetNFSVersion(c.clientID, version)
 	}

--- a/pkg/adapter/nfs/connection.go
+++ b/pkg/adapter/nfs/connection.go
@@ -8,7 +8,9 @@ import (
 	"io"
 	"net"
 	"runtime/debug"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	nfs_internal "github.com/marmos91/dittofs/internal/adapter/nfs"
@@ -57,6 +59,11 @@ type NFSConnection struct {
 	// nil unless the connection is bound for back-channel.
 	pendingCBReplies *state.PendingCBReplies
 
+	// nfsVersion holds the NFS version string last published to the client
+	// registry for this connection. Read and written from the concurrent
+	// dispatch goroutines, so it is atomic.
+	nfsVersion atomic.Value // string
+
 	// tlsUpgraded records whether this connection has completed an RFC 9289
 	// STARTTLS upgrade. Once true, c.conn is a *tls.Conn and all traffic is
 	// encrypted. Only touched from the single Serve read loop (the upgrade is
@@ -99,14 +106,16 @@ func (c *NFSConnection) Serve(ctx context.Context) {
 	clientAddr := c.conn.RemoteAddr().String()
 	logger.Debug("New connection", "address", clientAddr)
 
-	// Register with the client registry for operational visibility.
+	// Register with the client registry for operational visibility. The NFS
+	// version is left unset: nothing has been read off the wire yet, and this
+	// connection can carry v3 and v4 calls alike. noteNFSVersion fills it in
+	// from the dispatched calls.
 	c.clientID = fmt.Sprintf("nfs-%d", c.connectionID)
 	if rt := c.server.Registry; rt != nil {
 		rt.Clients().Register(&clients.ClientRecord{
 			ClientID: c.clientID,
 			Protocol: "nfs",
 			Address:  clientAddr,
-			NFS:      &clients.NfsDetails{Version: "3"},
 		})
 	}
 
@@ -263,6 +272,25 @@ func (c *NFSConnection) dispatchRequest(ctx context.Context, clientAddr string, 
 				"error", err)
 		}
 	}(call, rawMessage)
+}
+
+// noteNFSVersion publishes the NFS version seen on this connection to the
+// client registry. The version is not known when the connection is accepted, so
+// the dispatch path reports it: the program version gives "3" or "4", and the
+// COMPOUND minorversion refines "4" to "4.0"/"4.1"/"4.2" once decoded.
+//
+// The registry write lock is only taken when the value actually changes, and a
+// bare major never overwrites the minor-qualified form it is a prefix of, so a
+// steady-state connection stops touching the registry after its first calls.
+func (c *NFSConnection) noteNFSVersion(version string) {
+	cur, _ := c.nfsVersion.Load().(string)
+	if cur == version || strings.HasPrefix(cur, version) {
+		return
+	}
+	if rt := c.server.Registry; rt != nil && c.clientID != "" {
+		c.nfsVersion.Store(version)
+		rt.Clients().SetNFSVersion(c.clientID, version)
+	}
 }
 
 // resetIdleTimeout resets the connection deadline if an idle timeout is configured.

--- a/pkg/adapter/nfs/connection.go
+++ b/pkg/adapter/nfs/connection.go
@@ -279,12 +279,13 @@ func (c *NFSConnection) dispatchRequest(ctx context.Context, clientAddr string, 
 // the dispatch path reports it: the program version gives "3" or "4", and the
 // COMPOUND minorversion refines "4" to "4.0"/"4.1"/"4.2" once decoded.
 //
-// The registry write lock is only taken when the value actually changes, and a
-// bare major never overwrites the minor-qualified form it is a prefix of, so a
-// steady-state connection stops touching the registry after its first calls.
+// Nothing is published while the version already on record starts with the one
+// being reported, which covers both an unchanged version and a bare major
+// arriving after the minor-qualified form it is a prefix of. A steady-state
+// connection therefore stops taking the registry write lock after its first
+// calls.
 func (c *NFSConnection) noteNFSVersion(version string) {
-	cur, _ := c.nfsVersion.Load().(string)
-	if cur == version || strings.HasPrefix(cur, version) {
+	if cur, _ := c.nfsVersion.Load().(string); strings.HasPrefix(cur, version) {
 		return
 	}
 	if rt := c.server.Registry; rt != nil && c.clientID != "" {

--- a/pkg/adapter/nfs/dispatch.go
+++ b/pkg/adapter/nfs/dispatch.go
@@ -173,11 +173,15 @@ func (c *NFSConnection) handleRPCCall(ctx context.Context, call *rpc.RPCCallMess
 
 	switch call.Program {
 	case rpc.ProgramNFS:
-		// Route based on NFS version: v3 and v4 are both supported
+		// Route based on NFS version: v3 and v4 are both supported. The RPC
+		// program version is the first point at which the client's NFS version
+		// is known, so it is reported to the client registry here.
 		switch call.Version {
 		case rpc.NFSVersion3:
+			c.noteNFSVersion("3")
 			replyData, err = c.handleNFSProcedure(ctx, call, procedureData, clientAddr)
 		case rpc.NFSVersion4:
+			c.noteNFSVersion("4")
 			replyData, err = c.handleNFSv4Procedure(ctx, call, procedureData, clientAddr)
 		default:
 			return c.handleUnsupportedVersion(call, rpc.NFSVersion3, rpc.NFSVersion4, "NFS", clientAddr)

--- a/pkg/adapter/nfs/handlers.go
+++ b/pkg/adapter/nfs/handlers.go
@@ -436,9 +436,10 @@ func (c *NFSConnection) handleNFSv4Procedure(ctx context.Context, call *rpc.RPCC
 		c.recordOp("COMPOUND", start, err == nil)
 
 		// The COMPOUND carries the minorversion, so the registry's "4" can now
-		// be refined to the exact dialect. Only meaningful once the compound
-		// has decoded; on a wire error the field is still zero.
-		if err == nil {
+		// be refined to the exact dialect. A refused minorversion is not
+		// reported: it is answered with NFS4ERR_MINOR_VERS_MISMATCH and a nil
+		// error, and the server never served that dialect.
+		if err == nil && compCtx.MinorVersionAccepted {
 			c.noteNFSVersion("4." + strconv.FormatUint(uint64(compCtx.MinorVersion), 10))
 		}
 

--- a/pkg/adapter/nfs/handlers.go
+++ b/pkg/adapter/nfs/handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
+	"strconv"
 	"time"
 
 	nfs "github.com/marmos91/dittofs/internal/adapter/nfs"
@@ -433,6 +434,13 @@ func (c *NFSConnection) handleNFSv4Procedure(ctx context.Context, call *rpc.RPCC
 		start := time.Now()
 		result, err := c.server.v4Handler.ProcessCompound(compCtx, data)
 		c.recordOp("COMPOUND", start, err == nil)
+
+		// The COMPOUND carries the minorversion, so the registry's "4" can now
+		// be refined to the exact dialect. Only meaningful once the compound
+		// decoded; on a wire error the field is still zero.
+		if err == nil {
+			c.noteNFSVersion("4." + strconv.FormatUint(uint64(compCtx.MinorVersion), 10))
+		}
 
 		// After COMPOUND completes, check if this connection was bound for
 		// back-channel. If so, register a ConnWriter and PendingCBReplies

--- a/pkg/adapter/nfs/handlers.go
+++ b/pkg/adapter/nfs/handlers.go
@@ -437,7 +437,7 @@ func (c *NFSConnection) handleNFSv4Procedure(ctx context.Context, call *rpc.RPCC
 
 		// The COMPOUND carries the minorversion, so the registry's "4" can now
 		// be refined to the exact dialect. Only meaningful once the compound
-		// decoded; on a wire error the field is still zero.
+		// has decoded; on a wire error the field is still zero.
 		if err == nil {
 			c.noteNFSVersion("4." + strconv.FormatUint(uint64(compCtx.MinorVersion), 10))
 		}

--- a/pkg/controlplane/runtime/clients/service.go
+++ b/pkg/controlplane/runtime/clients/service.go
@@ -26,7 +26,11 @@ type ClientRecord struct {
 
 // NfsDetails holds NFS-specific client information.
 type NfsDetails struct {
-	Version string `json:"version"` // "3", "4.0", "4.1"
+	// Version is the NFS protocol version observed on the connection: "3",
+	// "4", or a minor-qualified "4.0"/"4.1"/"4.2". It is empty until the
+	// client's first NFS call, because a connection is registered when it is
+	// accepted and the version is not on the wire until then.
+	Version string `json:"version"`
 }
 
 // SmbDetails holds SMB-specific client information.
@@ -45,8 +49,9 @@ type clientEntry struct {
 // Registry provides thread-safe client tracking with TTL-based stale cleanup.
 // It follows the same sub-service pattern as mounts.Tracker.
 //
-// mu guards the map structure; an entry's remaining fields are set at Register
-// and never mutated again.
+// mu guards the map structure and an entry's non-atomic fields. Those fields
+// are set at Register and only ever changed again by SetNFSVersion, which takes
+// the write lock, so readers under the read lock always see a consistent record.
 // The per-request activity bump (UpdateActivity) takes only a shared read lock
 // for map safety and stores into the entry's atomic timestamp, so the
 // highest-fan-in call in the system no longer serializes on the write lock.
@@ -87,6 +92,20 @@ func (r *Registry) Register(record *ClientRecord) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.clients[record.ClientID] = e
+}
+
+// SetNFSVersion records the NFS protocol version observed for a client. The
+// version cannot be supplied at Register time: a connection is registered when
+// it is accepted, before any RPC has arrived, and the same connection can carry
+// both v3 and v4 calls. The adapter therefore fills it in from the dispatched
+// calls, only when the value changes. No-op if the client is not registered.
+func (r *Registry) SetNFSVersion(clientID, version string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if e, ok := r.clients[clientID]; ok {
+		e.NFS = &NfsDetails{Version: version}
+	}
 }
 
 // Deregister removes and returns a client record. Returns nil if not found.


### PR DESCRIPTION
## What was wrong

`NFSConnection.Serve` registered every accepted connection with
`NfsDetails{Version: "3"}`. Registration happens at accept time, before a single
byte has been read off the socket, so the version was not a measurement — it was
a constant. The same connection then dispatches both `rpc.NFSVersion3` and
`rpc.NFSVersion4`, so `GET /api/v1/clients` reported every NFSv4 and NFSv4.1
client as v3.

## The fix

The version is reported from the dispatch path, which is the first place it is
actually known:

- `Serve` registers with no NFS details at all. The record's `nfs` object is
  simply absent from the JSON until the client's first NFS call, which is
  honest: at that point nothing is known.
- The RPC program-version switch in `handleRPCCall` reports `"3"` or `"4"`.
- After a COMPOUND decodes, `handleNFSv4Procedure` refines `"4"` to the exact
  dialect — `"4.0"`, `"4.1"`, `"4.2"` — from the minorversion. That value is
  decoded deep inside `ProcessCompound`, so it is surfaced on the
  `CompoundContext` that is already threaded through the call (one field, one
  assignment) rather than re-parsing the compound body in the adapter.

`Registry` had no way to change a record after `Register` — its doc comment
called entries write-once — so the fix adds `SetNFSVersion`, which takes the
existing write lock. Readers deep-copy under the read lock, so they never see a
torn record, and a `SetNFSVersion` arriving after `Deregister` is a no-op rather
than a resurrection.

The registry write lock is the reason the reporting is deduped per connection
through an atomic on `NFSConnection`: `UpdateActivity` was deliberately moved
off that lock for the hot path, and re-taking it once per request would undo
that. A bare major never overwrites the minor-qualified form it is a prefix of,
so a steady-state v4.1 connection stops touching the registry after its first
COMPOUND instead of flapping between `"4"` and `"4.1"` forever.

## Evidence

`TestClientRegistry_VersionFromDispatch` and
`TestClientRegistry_VersionFromCompoundMinorVersion` drive a real `Serve` loop
over a `net.Pipe` and read what the registry ends up holding. Against unmodified
`develop` they fail exactly as reported:

```
--- FAIL: TestClientRegistry_VersionFromDispatch/v4
    version before any RPC: got "3", want empty (not known at accept time)
    reported version: got "3", want "4"
--- FAIL: TestClientRegistry_VersionFromCompoundMinorVersion
    reported version: got "3", want "4.1"
```

With the fix they pass, `go test ./...` is green, and the touched packages pass
under `-race`.

## What review changed

Two defects came out of review, both in the minorversion half:

- `NFS4ERR_MINOR_VERS_MISMATCH` is answered with a well-formed COMPOUND reply
  and a *nil* Go error, so gating the report on `err == nil` did not tell a
  refusal from a served compound — a client sending minorversion 99 wrote
  `"4.99"` into an operator-facing API. `ProcessCompound` now records the
  minorversion only after it passes the configured accepted range, and flags
  that it did. Deciding it there rather than allowlisting 0/1/2 in the adapter
  keeps it correct when an admin narrows `v4_max_minor_version`.
- The dedupe compared bare prefixes, so `strings.HasPrefix("4.10", "4.1")`
  meant a two-digit minor version on record permanently swallowed a later
  single-digit one. It now matches on `version + "."`, so only a bare major can
  be superseded.

The remaining sharp edge is marked rather than fixed: two dispatch goroutines
can both pass the dedupe check, so a v4.1 connection can briefly report `"4"`
until its next COMPOUND corrects it. A `ponytail:` comment at the store site
names the ceiling and the upgrade path. A compare-and-swap is more machinery
than a reporting field earns.

The SMB sibling registration site (`pkg/adapter/smb/connection.go:93`) does not
have this defect: it registers a real `SessionID`, not a constant.

## Note on consumers

Nothing formats the version today: `dfsctl client list` renders CLIENT_ID,
PROTOCOL, ADDRESS and CONNECTED only, so an unset version cannot show up as a
blank column. It surfaces in `/api/v1/clients` and in `dfsctl client list -o
json`, where an unknown version is now an absent `nfs` object rather than a
confident wrong answer. Adding a VERSION column is a separate call.

Closes #1962
