### PR TITLE
feat(dfsctl): add store check, a metadata-only manifest coverage scan

### DIFF
--- a/cmd/dfsctl/commands/store/check.go
+++ b/cmd/dfsctl/commands/store/check.go
@@ -1,0 +1,220 @@
+package store
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/marmos91/dittofs/cmd/dfsctl/cmdutil"
+	"github.com/marmos91/dittofs/internal/cli/output"
+	"github.com/marmos91/dittofs/pkg/block/engine"
+)
+
+// checkIncludeHoles adds the uncovered ranges no file claims to the detail
+// table. They are always counted in the summary; they are off by default in
+// the detail because a sparse file legitimately has them.
+var checkIncludeHoles bool
+
+var checkCmd = &cobra.Command{
+	Use:   "check [share]",
+	Short: "Scan manifests for ranges no chunk covers",
+	Long: `Scan the store for files whose manifest does not describe the whole file.
+
+Per payload the scan compares the byte ranges the manifest rows cover against
+the file's recorded size and reports three structural defects:
+
+  * ranges no manifest row covers
+  * rows that exist but carry no parseable chunk offset, so no reader can place
+    them — a read of such a range refuses rather than serving bytes
+  * rows whose content hash the synced-hash store has no record of
+
+The scan is metadata-only. No block is fetched, no file data is read and no
+remote object is touched, so it costs a metadata walk regardless of how much
+data the store holds and incurs no egress. It answers "how many files are
+affected" without reading every file. It does NOT verify block contents —
+remote fetches are already hash-verified on the read path.
+
+An uncovered range is only reported as damage when the file's own block list
+claims data lives there. A range nothing claims cannot be told apart from a
+legitimate sparse hole or from bytes written but not yet rolled up into the
+manifest, so it is counted separately and never fails the command. Pass
+--include-holes to list those ranges too.
+
+The unknown-hash check is skipped on a share with no remote store: nothing is
+ever marked synced there, so every row would be reported.
+
+With no argument every share is scanned. The command exits non-zero when
+damage is found, so it can be scripted (` + "`dfsctl store check || alert`" + `).
+
+Examples:
+  dfsctl store check
+  dfsctl store check myshare
+  dfsctl store check myshare --include-holes
+  dfsctl store check myshare -o json`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runStoreCheck,
+}
+
+func init() {
+	checkCmd.Flags().BoolVar(&checkIncludeHoles, "include-holes", false,
+		"list uncovered ranges that no file claims (legitimate for sparse files)")
+}
+
+func runStoreCheck(_ *cobra.Command, args []string) error {
+	client, err := cmdutil.GetAuthenticatedClient()
+	if err != nil {
+		return err
+	}
+
+	shareNames := args
+	if len(shareNames) == 0 {
+		shares, err := client.ListShares()
+		if err != nil {
+			return fmt.Errorf("failed to list shares: %w", err)
+		}
+		for _, s := range shares {
+			shareNames = append(shareNames, s.Name)
+		}
+		if len(shareNames) == 0 {
+			return fmt.Errorf("no shares configured")
+		}
+	}
+
+	results := make([]*engine.ManifestCheckResult, 0, len(shareNames))
+	for _, name := range shareNames {
+		res, err := client.BlockStoreCheckManifests(name)
+		if err != nil {
+			return fmt.Errorf("failed to check share %q: %w", name, err)
+		}
+		if res == nil || res.Result == nil {
+			return fmt.Errorf("store check for share %q returned no result", name)
+		}
+		results = append(results, res.Result)
+	}
+
+	format, err := cmdutil.GetOutputFormatParsed()
+	if err != nil {
+		return err
+	}
+	switch format {
+	case output.FormatJSON:
+		err = output.PrintJSON(os.Stdout, results)
+	case output.FormatYAML:
+		err = output.PrintYAML(os.Stdout, results)
+	default:
+		err = printCheckTables(results)
+	}
+	if err != nil {
+		return err
+	}
+
+	var damaged int
+	for _, r := range results {
+		if r.Damaged() {
+			damaged++
+		}
+	}
+	if damaged > 0 {
+		return fmt.Errorf("manifest damage found on %d of %d share(s)", damaged, len(results))
+	}
+	return nil
+}
+
+// printCheckTables renders a summary per share followed by the per-payload
+// detail, mirroring printAuditTable's key/value shape for the summary half.
+func printCheckTables(results []*engine.ManifestCheckResult) error {
+	for i, r := range results {
+		if i > 0 {
+			fmt.Println()
+		}
+		unknown := fmt.Sprintf("%d", r.UnknownHashRows)
+		if !r.SyncedHashesChecked {
+			unknown = "not checked (share has no remote store)"
+		}
+		pairs := [][2]string{
+			{"Share", r.Share},
+			{"Duration", fmt.Sprintf("%dms", r.DurationMS)},
+			{"Files scanned", fmt.Sprintf("%d", r.FilesScanned)},
+			{"Damaged payloads", fmt.Sprintf("%d", r.DamagedPayloads)},
+			{"Uncovered, claimed", fmt.Sprintf("%d range(s), %d bytes", r.ClaimedUncoveredRanges, r.ClaimedUncoveredBytes)},
+			{"Uncovered, unclaimed", fmt.Sprintf("%d range(s), %d bytes", r.UncoveredRanges-r.ClaimedUncoveredRanges, r.UncoveredBytes-r.ClaimedUncoveredBytes)},
+			{"Unplaceable rows", fmt.Sprintf("%d", r.UnplaceableRows)},
+			{"Rows with unknown hash", unknown},
+		}
+		if err := output.SimpleTable(os.Stdout, pairs); err != nil {
+			return err
+		}
+		if err := printCheckDetail(r); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// printCheckDetail lists the affected payloads, one row per payload, with the
+// findings joined into a single cell so a wide store still reads as a table.
+func printCheckDetail(r *engine.ManifestCheckResult) error {
+	table := output.NewTableData("PATH", "SIZE", "FINDINGS")
+	var listed int
+	for i := range r.Findings {
+		f := &r.Findings[i]
+		notes := checkFindingNotes(f)
+		if len(notes) == 0 {
+			continue
+		}
+		listed++
+		table.AddRow(f.Path, fmt.Sprintf("%d", f.Size), strings.Join(notes, "; "))
+	}
+
+	if listed == 0 {
+		if r.UncoveredRanges > r.ClaimedUncoveredRanges && !checkIncludeHoles {
+			fmt.Println()
+			fmt.Println("No damage found. Uncovered ranges no file claims were not listed; pass --include-holes to see them.")
+		}
+		return nil
+	}
+
+	fmt.Println()
+	if err := output.PrintTable(os.Stdout, table); err != nil {
+		return err
+	}
+	if r.FindingsTruncated {
+		fmt.Println()
+		fmt.Println("Detail list truncated; the counts above are complete.")
+	}
+	fmt.Println()
+	fmt.Println("An uncovered range marked \"claimed\" is damage: the file's own block list says data")
+	fmt.Println("lives there and no manifest row covers it. An unclaimed range cannot be told apart")
+	fmt.Println("from a sparse hole or from bytes not yet rolled up, so it is reported, not judged.")
+	return nil
+}
+
+// checkFindingNotes renders one payload's findings as short human-readable
+// phrases. Returns nil when the payload has nothing worth listing, which is
+// the case for a payload holding only unclaimed holes unless --include-holes
+// is set.
+func checkFindingNotes(f *engine.PayloadFinding) []string {
+	var notes []string
+	for _, rng := range f.Uncovered {
+		if !rng.Claimed && !checkIncludeHoles {
+			continue
+		}
+		kind := "hole, unclaimed"
+		if rng.Claimed {
+			kind = "uncovered, claimed"
+		}
+		notes = append(notes, fmt.Sprintf("[%d,%d) %s", rng.Start, rng.End, kind))
+	}
+	for _, id := range f.UnplaceableRows {
+		notes = append(notes, "unplaceable row "+id)
+	}
+	for _, id := range f.UnknownHashRows {
+		notes = append(notes, "hash unknown to the synced-hash store: row "+id)
+	}
+	if len(notes) > 0 && f.Truncated {
+		notes = append(notes, "(more, truncated)")
+	}
+	return notes
+}

--- a/cmd/dfsctl/commands/store/check.go
+++ b/cmd/dfsctl/commands/store/check.go
@@ -131,7 +131,13 @@ func printCheckTables(results []*engine.ManifestCheckResult) error {
 		}
 		unknown := fmt.Sprintf("%d", r.UnknownHashRows)
 		if !r.SyncedHashesChecked {
-			unknown = "not checked (no remote store resolved for this share)"
+			// Say which of the two suppressing conditions applied: nothing
+			// to check, or a check that could not be run.
+			reason := r.SyncedCheckSkipped
+			if reason == "" {
+				reason = "reason not recorded"
+			}
+			unknown = "not checked (" + reason + ")"
 		}
 		pairs := [][2]string{
 			{"Share", r.Share},

--- a/cmd/dfsctl/commands/store/check.go
+++ b/cmd/dfsctl/commands/store/check.go
@@ -131,7 +131,7 @@ func printCheckTables(results []*engine.ManifestCheckResult) error {
 		}
 		unknown := fmt.Sprintf("%d", r.UnknownHashRows)
 		if !r.SyncedHashesChecked {
-			unknown = "not checked (share has no remote store)"
+			unknown = "not checked (no remote store resolved for this share)"
 		}
 		pairs := [][2]string{
 			{"Share", r.Share},

--- a/cmd/dfsctl/commands/store/check.go
+++ b/cmd/dfsctl/commands/store/check.go
@@ -213,8 +213,13 @@ func checkFindingNotes(f *engine.PayloadFinding) []string {
 	for _, id := range f.UnknownHashRows {
 		notes = append(notes, "hash unknown to the synced-hash store: row "+id)
 	}
-	if len(notes) > 0 && f.Truncated {
+	if f.Truncated {
 		notes = append(notes, "(more, truncated)")
+	}
+	if len(notes) == 0 && f.Damaged {
+		// The payload is damaged but every listed range is an unclaimed
+		// hole that --include-holes would suppress. Never drop it.
+		notes = append(notes, "damaged; detail truncated")
 	}
 	return notes
 }

--- a/cmd/dfsctl/commands/store/check_test.go
+++ b/cmd/dfsctl/commands/store/check_test.go
@@ -190,7 +190,7 @@ func TestCheckCmd_UnclaimedHoleIsNotDamage(t *testing.T) {
 	if !strings.Contains(out, "--include-holes") {
 		t.Errorf("output must point at --include-holes when holes were suppressed; got %q", out)
 	}
-	if !strings.Contains(out, "not checked (share has no remote store)") {
+	if !strings.Contains(out, "not checked (no remote store resolved") {
 		t.Errorf("a skipped synced-hash check must say so rather than print 0; got %q", out)
 	}
 

--- a/cmd/dfsctl/commands/store/check_test.go
+++ b/cmd/dfsctl/commands/store/check_test.go
@@ -161,6 +161,7 @@ func TestCheckCmd_UnclaimedHoleIsNotDamage(t *testing.T) {
 		return &engine.ManifestCheckResult{
 			Share:                "myshare",
 			FilesScanned:         1,
+			SyncedCheckSkipped:   "share has no remote store",
 			PayloadsWithFindings: 1,
 			UncoveredRanges:      1,
 			UncoveredBytes:       4096,
@@ -190,7 +191,7 @@ func TestCheckCmd_UnclaimedHoleIsNotDamage(t *testing.T) {
 	if !strings.Contains(out, "--include-holes") {
 		t.Errorf("output must point at --include-holes when holes were suppressed; got %q", out)
 	}
-	if !strings.Contains(out, "not checked (no remote store resolved") {
+	if !strings.Contains(out, "not checked (share has no remote store") {
 		t.Errorf("a skipped synced-hash check must say so rather than print 0; got %q", out)
 	}
 
@@ -246,4 +247,33 @@ func TestCheckCmd_Registered(t *testing.T) {
 		}
 	}
 	t.Fatal("checkCmd not registered on store.Cmd")
+}
+
+// TestCheckCmd_SkipReasonDistinguishesCases pins that the two conditions
+// suppressing the unknown-hash check are reported apart. A share with no
+// remote store has nothing that check could find; a share whose block store
+// could not be resolved has a check that could not be run, and telling the
+// second operator the first thing sends them away from a real fault.
+func TestCheckCmd_SkipReasonDistinguishesCases(t *testing.T) {
+	for _, reason := range []string{
+		"share has no remote store",
+		"block store could not be resolved for this share",
+	} {
+		s := newCheckServer(t)
+		s.results["myshare"] = &engine.ManifestCheckResult{
+			Share:              "myshare",
+			FilesScanned:       1,
+			SyncedCheckSkipped: reason,
+		}
+		withCheckTestServer(t, s.URL)
+
+		out := captureStdoutCheck(t, func() {
+			if err := runStoreCheck(checkCmd, []string{"myshare"}); err != nil {
+				t.Fatalf("runStoreCheck: %v", err)
+			}
+		})
+		if !strings.Contains(out, "not checked ("+reason+")") {
+			t.Errorf("output must name the skip reason %q; got %q", reason, out)
+		}
+	}
 }

--- a/cmd/dfsctl/commands/store/check_test.go
+++ b/cmd/dfsctl/commands/store/check_test.go
@@ -1,0 +1,249 @@
+package store
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/marmos91/dittofs/cmd/dfsctl/cmdutil"
+	"github.com/marmos91/dittofs/pkg/apiclient"
+	"github.com/marmos91/dittofs/pkg/block/engine"
+)
+
+// checkServer is a recording stub for the manifest-check endpoint. It also
+// answers the share listing so the no-argument (whole-store) path can be
+// exercised.
+type checkServer struct {
+	*httptest.Server
+	paths   []string
+	shares  []apiclient.Share
+	results map[string]*engine.ManifestCheckResult
+}
+
+func newCheckServer(t *testing.T) *checkServer {
+	t.Helper()
+	s := &checkServer{results: map[string]*engine.ManifestCheckResult{}}
+	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.paths = append(s.paths, r.Method+" "+r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.Method == http.MethodGet && r.URL.Path == "/api/v1/shares" {
+			_ = json.NewEncoder(w).Encode(s.shares)
+			return
+		}
+		name := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v1/shares/"), "/audit/manifest")
+		res, ok := s.results[name]
+		if r.Method != http.MethodPost || !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(apiclient.BlockStoreManifestCheckResult{Result: res})
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+func withCheckTestServer(t *testing.T, url string) {
+	t.Helper()
+	origServer, origToken, origOutput := cmdutil.Flags.ServerURL, cmdutil.Flags.Token, cmdutil.Flags.Output
+	origHoles := checkIncludeHoles
+	cmdutil.Flags.ServerURL = url
+	cmdutil.Flags.Token = "test-token"
+	cmdutil.Flags.Output = "table"
+	t.Cleanup(func() {
+		cmdutil.Flags.ServerURL = origServer
+		cmdutil.Flags.Token = origToken
+		cmdutil.Flags.Output = origOutput
+		checkIncludeHoles = origHoles
+	})
+}
+
+func captureStdoutCheck(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+	fn()
+	_ = w.Close()
+	os.Stdout = orig
+	return <-done
+}
+
+// damagedResult is a share holding one payload with a claimed-but-uncovered
+// leading page — the shape of the field report this command exists to answer.
+func damagedResult() *engine.ManifestCheckResult {
+	return &engine.ManifestCheckResult{
+		Share:                  "myshare",
+		FilesScanned:           42,
+		SyncedHashesChecked:    true,
+		PayloadsWithFindings:   1,
+		DamagedPayloads:        1,
+		UncoveredRanges:        1,
+		UncoveredBytes:         4096,
+		ClaimedUncoveredRanges: 1,
+		ClaimedUncoveredBytes:  4096,
+		Findings: []engine.PayloadFinding{{
+			Path:      "/docs/report.pdf",
+			PayloadID: "payload-1",
+			Size:      1048576,
+			Uncovered: []engine.ByteRange{{Start: 0, End: 4096, Claimed: true}},
+		}},
+	}
+}
+
+// TestCheckCmd_DamageExitsNonZero asserts the command hits the per-share
+// endpoint, renders the affected path, and returns an error so the scan can
+// gate a script.
+func TestCheckCmd_DamageExitsNonZero(t *testing.T) {
+	s := newCheckServer(t)
+	s.results["myshare"] = damagedResult()
+	withCheckTestServer(t, s.URL)
+
+	var runErr error
+	out := captureStdoutCheck(t, func() {
+		runErr = runStoreCheck(checkCmd, []string{"myshare"})
+	})
+
+	if want := "POST /api/v1/shares/myshare/audit/manifest"; len(s.paths) != 1 || s.paths[0] != want {
+		t.Fatalf("requests = %v, want [%s]", s.paths, want)
+	}
+	if runErr == nil {
+		t.Fatal("damage must return a non-nil error (non-zero exit)")
+	}
+	for _, frag := range []string{"Files scanned", "42", "Damaged payloads", "/docs/report.pdf", "[0,4096) uncovered, claimed"} {
+		if !strings.Contains(out, frag) {
+			t.Errorf("stdout missing %q, got %q", frag, out)
+		}
+	}
+}
+
+// TestCheckCmd_DamageExitsNonZeroAcrossFormats pins that -o json/yaml still
+// exits non-zero — a machine consumer must not read exit 0 on corruption.
+func TestCheckCmd_DamageExitsNonZeroAcrossFormats(t *testing.T) {
+	for _, format := range []string{"json", "yaml"} {
+		t.Run(format, func(t *testing.T) {
+			s := newCheckServer(t)
+			s.results["myshare"] = damagedResult()
+			withCheckTestServer(t, s.URL)
+			cmdutil.Flags.Output = format
+
+			var runErr error
+			out := captureStdoutCheck(t, func() {
+				runErr = runStoreCheck(checkCmd, []string{"myshare"})
+			})
+			if runErr == nil {
+				t.Fatalf("%s: damage must return a non-nil error", format)
+			}
+			if !strings.Contains(out, "report.pdf") {
+				t.Errorf("%s: result body must still be emitted; got %q", format, out)
+			}
+		})
+	}
+}
+
+// TestCheckCmd_UnclaimedHoleIsNotDamage is the false-positive guard: a sparse
+// file's hole must neither fail the command nor clutter the default detail
+// table, but must still be counted and reachable with --include-holes.
+func TestCheckCmd_UnclaimedHoleIsNotDamage(t *testing.T) {
+	sparse := func() *engine.ManifestCheckResult {
+		return &engine.ManifestCheckResult{
+			Share:                "myshare",
+			FilesScanned:         1,
+			PayloadsWithFindings: 1,
+			UncoveredRanges:      1,
+			UncoveredBytes:       4096,
+			Findings: []engine.PayloadFinding{{
+				Path:      "/sparse.img",
+				PayloadID: "payload-1",
+				Size:      8192,
+				Uncovered: []engine.ByteRange{{Start: 0, End: 4096}},
+			}},
+		}
+	}
+
+	s := newCheckServer(t)
+	s.results["myshare"] = sparse()
+	withCheckTestServer(t, s.URL)
+
+	var runErr error
+	out := captureStdoutCheck(t, func() {
+		runErr = runStoreCheck(checkCmd, []string{"myshare"})
+	})
+	if runErr != nil {
+		t.Fatalf("an unclaimed hole must not fail the command: %v", runErr)
+	}
+	if strings.Contains(out, "/sparse.img") {
+		t.Errorf("unclaimed hole must stay out of the default detail; got %q", out)
+	}
+	if !strings.Contains(out, "--include-holes") {
+		t.Errorf("output must point at --include-holes when holes were suppressed; got %q", out)
+	}
+	if !strings.Contains(out, "not checked (share has no remote store)") {
+		t.Errorf("a skipped synced-hash check must say so rather than print 0; got %q", out)
+	}
+
+	checkIncludeHoles = true
+	out = captureStdoutCheck(t, func() {
+		runErr = runStoreCheck(checkCmd, []string{"myshare"})
+	})
+	if runErr != nil {
+		t.Fatalf("--include-holes must not turn a hole into a failure: %v", runErr)
+	}
+	if !strings.Contains(out, "/sparse.img") || !strings.Contains(out, "hole, unclaimed") {
+		t.Errorf("--include-holes must list the hole; got %q", out)
+	}
+}
+
+// TestCheckCmd_NoArgScansEveryShare covers the whole-store path: list the
+// shares, scan each, and fail if any one of them is damaged.
+func TestCheckCmd_NoArgScansEveryShare(t *testing.T) {
+	s := newCheckServer(t)
+	s.shares = []apiclient.Share{{Name: "clean"}, {Name: "myshare"}}
+	s.results["clean"] = &engine.ManifestCheckResult{Share: "clean", FilesScanned: 7}
+	s.results["myshare"] = damagedResult()
+	withCheckTestServer(t, s.URL)
+
+	var runErr error
+	captureStdoutCheck(t, func() {
+		runErr = runStoreCheck(checkCmd, nil)
+	})
+	if runErr == nil || !strings.Contains(runErr.Error(), "1 of 2 share(s)") {
+		t.Fatalf("want a failure naming 1 of 2 shares, got %v", runErr)
+	}
+	want := []string{
+		"GET /api/v1/shares",
+		"POST /api/v1/shares/clean/audit/manifest",
+		"POST /api/v1/shares/myshare/audit/manifest",
+	}
+	if len(s.paths) != len(want) {
+		t.Fatalf("requests = %v, want %v", s.paths, want)
+	}
+	for i := range want {
+		if s.paths[i] != want[i] {
+			t.Fatalf("requests = %v, want %v", s.paths, want)
+		}
+	}
+}
+
+// TestCheckCmd_Registered guards against a refactor dropping the AddCommand
+// call, which would silently remove the command from `dfsctl store --help`.
+func TestCheckCmd_Registered(t *testing.T) {
+	for _, sub := range Cmd.Commands() {
+		if sub == checkCmd {
+			return
+		}
+	}
+	t.Fatal("checkCmd not registered on store.Cmd")
+}

--- a/cmd/dfsctl/commands/store/store.go
+++ b/cmd/dfsctl/commands/store/store.go
@@ -39,4 +39,5 @@ Examples:
 func init() {
 	Cmd.AddCommand(metadata.Cmd)
 	Cmd.AddCommand(block.Cmd)
+	Cmd.AddCommand(checkCmd)
 }

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -718,6 +718,7 @@ Global flags:
         - [`dfsctl store block remote list`](#dfsctl-store-block-remote-list) — List remote block stores
         - [`dfsctl store block remote remove`](#dfsctl-store-block-remote-remove) — Remove a remote block store
       - [`dfsctl store block stats`](#dfsctl-store-block-stats) — Show block store statistics
+    - [`dfsctl store check`](#dfsctl-store-check) — Scan manifests for ranges no chunk covers
     - [`dfsctl store metadata`](#dfsctl-store-metadata) — Manage metadata stores
       - [`dfsctl store metadata add`](#dfsctl-store-metadata-add) — Add a metadata store
       - [`dfsctl store metadata edit`](#dfsctl-store-metadata-edit) — Edit a metadata store
@@ -1400,7 +1401,7 @@ Manage connected clients
 
 Manage connected NFS and SMB clients on the DittoFS server.
 
-Use these commands to inspect which clients are currently connected, filter by protocol or share, and forcefully disconnect misbehaving sessions. All operations require admin privileges.
+Use these commands to inspect which clients are currently connected, filter by protocol, and forcefully disconnect misbehaving sessions. All operations require admin privileges.
 
 **Examples:**
 
@@ -1410,9 +1411,6 @@ dfsctl client list
 
 # Show only NFS clients
 dfsctl client list --protocol nfs
-
-# Show clients connected to a specific share
-dfsctl client list --share myshare
 
 # Disconnect a specific client by its ID
 dfsctl client disconnect nfs-42 --force
@@ -6398,6 +6396,73 @@ Flags:
 
 ```
       --share string   Show stats for a specific share only
+```
+
+Global flags:
+
+```
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
+```
+
+### `dfsctl store check`
+
+Scan manifests for ranges no chunk covers
+
+Scan the store for files whose manifest does not describe the whole file.
+
+Per payload the scan compares the byte ranges the manifest rows cover against
+the file's recorded size and reports three structural defects:
+
+```
+* ranges no manifest row covers
+* rows that exist but carry no parseable chunk offset, so no reader can place
+  them — a read of such a range refuses rather than serving bytes
+* rows whose content hash the synced-hash store has no record of
+```
+
+The scan is metadata-only. No block is fetched, no file data is read and no
+remote object is touched, so it costs a metadata walk regardless of how much
+data the store holds and incurs no egress. It answers "how many files are
+affected" without reading every file. It does NOT verify block contents —
+remote fetches are already hash-verified on the read path.
+
+An uncovered range is only reported as damage when the file's own block list
+claims data lives there. A range nothing claims cannot be told apart from a
+legitimate sparse hole or from bytes written but not yet rolled up into the
+manifest, so it is counted separately and never fails the command. Pass
+--include-holes to list those ranges too.
+
+The unknown-hash check is skipped on a share with no remote store: nothing is
+ever marked synced there, so every row would be reported.
+
+With no argument every share is scanned. The command exits non-zero when
+damage is found, so it can be scripted (`dfsctl store check || alert`).
+
+```
+dfsctl store check [share] [flags]
+```
+
+**Examples:**
+
+```bash
+dfsctl store check
+dfsctl store check myshare
+dfsctl store check myshare --include-holes
+dfsctl store check myshare -o json
+```
+
+Flags:
+
+```
+      --include-holes   list uncovered ranges that no file claims (legitimate for sparse files)
 ```
 
 Global flags:

--- a/internal/controlplane/api/handlers/blockstore_manifest_check.go
+++ b/internal/controlplane/api/handlers/blockstore_manifest_check.go
@@ -68,7 +68,7 @@ func (h *BlockStoreManifestCheckHandler) RunManifestCheck(w http.ResponseWriter,
 			NotFound(w, "share not found: "+name)
 			return
 		}
-		logger.Debug("Store check error", "share", name, "error", err)
+		logger.Debug("Store check error", logger.KeyShare, name, "error", err)
 		// The underlying error can carry filesystem paths; it is logged at
 		// Debug above rather than returned in the body.
 		InternalServerError(w, "store check failed")
@@ -76,7 +76,7 @@ func (h *BlockStoreManifestCheckHandler) RunManifestCheck(w http.ResponseWriter,
 	}
 
 	logger.Info("Store check complete",
-		"share", name,
+		logger.KeyShare, name,
 		"files_scanned", res.FilesScanned,
 		"damaged_payloads", res.DamagedPayloads,
 		"claimed_uncovered_bytes", res.ClaimedUncoveredBytes,

--- a/internal/controlplane/api/handlers/blockstore_manifest_check.go
+++ b/internal/controlplane/api/handlers/blockstore_manifest_check.go
@@ -1,0 +1,89 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime/shares"
+)
+
+// ManifestCheckRuntime is the narrow Runtime surface needed by
+// BlockStoreManifestCheckHandler, defined here so the handler can be unit
+// tested against a fake rather than a whole *runtime.Runtime.
+type ManifestCheckRuntime interface {
+	// CheckManifests runs the metadata-only manifest-coverage scan for the
+	// named share.
+	CheckManifests(ctx context.Context, shareName string) (*engine.ManifestCheckResult, error)
+}
+
+// BlockStoreManifestCheckHandler exposes the on-demand manifest-coverage scan.
+type BlockStoreManifestCheckHandler struct {
+	runtime ManifestCheckRuntime
+}
+
+// NewBlockStoreManifestCheckHandler constructs a handler bound to the given
+// Runtime surface. A nil runtime makes the handler refuse requests rather than
+// panic, so the server still boots in degraded modes.
+func NewBlockStoreManifestCheckHandler(rt ManifestCheckRuntime) *BlockStoreManifestCheckHandler {
+	return &BlockStoreManifestCheckHandler{runtime: rt}
+}
+
+// BlockStoreManifestCheckResponse wraps engine.ManifestCheckResult for JSON
+// output. Returned by POST /api/v1/shares/{name}/audit/manifest.
+type BlockStoreManifestCheckResponse struct {
+	Result *engine.ManifestCheckResult `json:"result"`
+}
+
+// RunManifestCheck handles POST /api/v1/shares/{name}/audit/manifest.
+//
+// The scan walks the share's metadata store and, per payload, compares the
+// ranges its manifest rows cover against the file's recorded size. It reads no
+// block data and touches no remote store.
+//
+// Status codes:
+//   - 200 OK with BlockStoreManifestCheckResponse on success
+//   - 400 Bad Request when {name} is empty
+//   - 404 Not Found when {name} is not a registered share
+//   - 500 Internal Server Error on unexpected runtime errors
+func (h *BlockStoreManifestCheckHandler) RunManifestCheck(w http.ResponseWriter, r *http.Request) {
+	if h.runtime == nil {
+		InternalServerError(w, "runtime not initialized")
+		return
+	}
+
+	name := normalizeShareName(chi.URLParam(r, "name"))
+	if name == "/" {
+		BadRequest(w, "share name is required")
+		return
+	}
+
+	res, err := h.runtime.CheckManifests(r.Context(), name)
+	if err != nil {
+		if errors.Is(err, shares.ErrShareNotFound) {
+			NotFound(w, "share not found: "+name)
+			return
+		}
+		logger.Debug("Store check error", "share", name, "error", err)
+		// The underlying error can carry filesystem paths; it is logged at
+		// Debug above rather than returned in the body.
+		InternalServerError(w, "store check failed")
+		return
+	}
+
+	logger.Info("Store check complete",
+		"share", name,
+		"files_scanned", res.FilesScanned,
+		"damaged_payloads", res.DamagedPayloads,
+		"claimed_uncovered_bytes", res.ClaimedUncoveredBytes,
+		"unplaceable_rows", res.UnplaceableRows,
+		"unknown_hash_rows", res.UnknownHashRows,
+		"duration_ms", res.DurationMS,
+	)
+
+	WriteJSONOK(w, BlockStoreManifestCheckResponse{Result: res})
+}

--- a/internal/controlplane/api/handlers/blockstore_manifest_check_test.go
+++ b/internal/controlplane/api/handlers/blockstore_manifest_check_test.go
@@ -1,0 +1,119 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime/shares"
+)
+
+// fakeManifestCheckRuntime is a recording stand-in for ManifestCheckRuntime.
+type fakeManifestCheckRuntime struct {
+	res   *engine.ManifestCheckResult
+	err   error
+	calls []string
+}
+
+func (f *fakeManifestCheckRuntime) CheckManifests(_ context.Context, shareName string) (*engine.ManifestCheckResult, error) {
+	f.calls = append(f.calls, shareName)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.res, nil
+}
+
+func runManifestCheck(rt ManifestCheckRuntime, share string) *httptest.ResponseRecorder {
+	req := newAuditRequest(http.MethodPost, "/api/v1/shares/"+share+"/audit/manifest", share)
+	w := httptest.NewRecorder()
+	NewBlockStoreManifestCheckHandler(rt).RunManifestCheck(w, req)
+	return w
+}
+
+// TestManifestCheckHandler_Success asserts the handler normalizes the share
+// name, invokes the runtime once, and round-trips the findings as JSON.
+func TestManifestCheckHandler_Success(t *testing.T) {
+	fake := &fakeManifestCheckRuntime{res: &engine.ManifestCheckResult{
+		Share:                  "/myshare",
+		FilesScanned:           3,
+		DamagedPayloads:        1,
+		UncoveredRanges:        2,
+		UncoveredBytes:         8192,
+		ClaimedUncoveredRanges: 1,
+		ClaimedUncoveredBytes:  4096,
+		Findings: []engine.PayloadFinding{{
+			Path:      "/docs/report.pdf",
+			PayloadID: "payload-1",
+			Size:      1048576,
+			Damaged:   true,
+			Uncovered: []engine.ByteRange{{Start: 0, End: 4096, Claimed: true}},
+		}},
+	}}
+
+	w := runManifestCheck(fake, "myshare")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body=%q)", w.Code, w.Body.String())
+	}
+	if len(fake.calls) != 1 || fake.calls[0] != "/myshare" {
+		t.Fatalf("expected a single call for /myshare, got %+v", fake.calls)
+	}
+
+	var resp BlockStoreManifestCheckResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Result == nil || resp.Result.DamagedPayloads != 1 || resp.Result.ClaimedUncoveredBytes != 4096 {
+		t.Fatalf("unexpected result: %+v", resp.Result)
+	}
+	if len(resp.Result.Findings) != 1 || !resp.Result.Findings[0].Damaged {
+		t.Fatalf("per-payload detail lost in transit: %+v", resp.Result.Findings)
+	}
+	if got := resp.Result.Findings[0].Uncovered; len(got) != 1 || !got[0].Claimed {
+		t.Fatalf("claimed flag lost in transit: %+v", got)
+	}
+}
+
+// TestManifestCheckHandler_ShareNotFound maps the share sentinel to 404.
+func TestManifestCheckHandler_ShareNotFound(t *testing.T) {
+	fake := &fakeManifestCheckRuntime{err: fmt.Errorf("%w: %q", shares.ErrShareNotFound, "ghost")}
+	if w := runManifestCheck(fake, "ghost"); w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d (body=%q)", w.Code, w.Body.String())
+	}
+}
+
+// TestManifestCheckHandler_EmptyShareName rejects an empty URL parameter
+// without reaching the runtime.
+func TestManifestCheckHandler_EmptyShareName(t *testing.T) {
+	fake := &fakeManifestCheckRuntime{}
+	if w := runManifestCheck(fake, ""); w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if len(fake.calls) != 0 {
+		t.Fatal("runtime must not be invoked on an empty share name")
+	}
+}
+
+// TestManifestCheckHandler_NilRuntime fails closed rather than panicking.
+func TestManifestCheckHandler_NilRuntime(t *testing.T) {
+	if w := runManifestCheck(nil, "myshare"); w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 on nil runtime, got %d", w.Code)
+	}
+}
+
+// TestManifestCheckHandler_RuntimeError surfaces an unexpected error as 500
+// with the underlying message stripped — it can carry filesystem paths.
+func TestManifestCheckHandler_RuntimeError(t *testing.T) {
+	fake := &fakeManifestCheckRuntime{err: fmt.Errorf("walk failed: %s", "/secret/path")}
+	w := runManifestCheck(fake, "myshare")
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	if strings.Contains(w.Body.String(), "/secret/path") {
+		t.Errorf("response body leaks the underlying error path: %q", w.Body.String())
+	}
+}

--- a/pkg/apiclient/blockstore.go
+++ b/pkg/apiclient/blockstore.go
@@ -246,3 +246,26 @@ func (c *Client) BlockStoreAuditRefcounts(shareName string) (*BlockStoreAuditRes
 		struct{}{},
 	)
 }
+
+// BlockStoreManifestCheckResult is the response body for
+// POST /api/v1/shares/{name}/audit/manifest. Mirrors the server-side
+// handlers.BlockStoreManifestCheckResponse shape.
+type BlockStoreManifestCheckResult struct {
+	Result *engine.ManifestCheckResult `json:"result"`
+}
+
+// BlockStoreCheckManifests runs the metadata-only manifest-coverage scan for
+// the named share. Per payload the server compares the byte ranges the
+// manifest rows cover against the file's recorded size and reports uncovered
+// ranges, rows carrying no parseable chunk offset, and rows whose hash the
+// synced-hash store does not know.
+//
+// No block is fetched and no remote object is touched, so the call costs a
+// metadata walk regardless of how much data the share holds.
+func (c *Client) BlockStoreCheckManifests(shareName string) (*BlockStoreManifestCheckResult, error) {
+	return createResource[BlockStoreManifestCheckResult](
+		c,
+		fmt.Sprintf("/api/v1/shares/%s/audit/manifest", url.PathEscape(normalizeShareNameForAPI(shareName))),
+		struct{}{},
+	)
+}

--- a/pkg/block/engine/audit_state.go
+++ b/pkg/block/engine/audit_state.go
@@ -122,7 +122,7 @@ func AuditRefcounts(ctx context.Context, share string, store metadata.Store, loc
 	if err != nil {
 		return nil, fmt.Errorf("audit-refcounts: get root handle for %q: %w", share, err)
 	}
-	if err := walkAuditShareFiles(ctx, store, rootHandle, func(f *metadata.File) error {
+	if err := walkAuditShareFiles(ctx, store, rootHandle, "", func(_ string, f *metadata.File) error {
 		result.TotalFiles++
 		backed, dangling, err := auditFileManifest(ctx, store, f)
 		if err != nil {
@@ -203,11 +203,17 @@ func auditFileManifest(ctx context.Context, store metadata.Store, f *metadata.Fi
 }
 
 // walkAuditShareFiles recursively walks the share rooted at dirHandle
-// invoking fn for every regular file. Pagination is via the existing
-// ListChildren cursor; depth is unbounded but bounded by the share's
-// directory tree depth. Pure-traversal — no mutation, safe for concurrent
-// reads against the live metadata store.
-func walkAuditShareFiles(ctx context.Context, store metadata.Store, dirHandle metadata.FileHandle, fn func(*metadata.File) error) error {
+// invoking fn for every regular file, with the file's slash-separated path
+// below dir. Pagination is via the existing ListChildren cursor; depth is
+// unbounded but bounded by the share's directory tree depth. Pure-traversal —
+// no mutation, safe for concurrent reads against the live metadata store.
+func walkAuditShareFiles(
+	ctx context.Context,
+	store metadata.Store,
+	dirHandle metadata.FileHandle,
+	dir string,
+	fn func(path string, f *metadata.File) error,
+) error {
 	cursor := ""
 	for {
 		entries, next, err := store.ListChildren(ctx, dirHandle, cursor, 0)
@@ -226,13 +232,14 @@ func walkAuditShareFiles(ctx context.Context, store metadata.Store, dirHandle me
 			if err != nil {
 				return fmt.Errorf("get file %q: %w", e.Name, err)
 			}
+			path := dir + "/" + e.Name
 			switch child.Type {
 			case metadata.FileTypeDirectory:
-				if err := walkAuditShareFiles(ctx, store, e.Handle, fn); err != nil {
+				if err := walkAuditShareFiles(ctx, store, e.Handle, path, fn); err != nil {
 					return err
 				}
 			case metadata.FileTypeRegular:
-				if err := fn(child); err != nil {
+				if err := fn(path, child); err != nil {
 					return err
 				}
 			}

--- a/pkg/block/engine/manifest_check.go
+++ b/pkg/block/engine/manifest_check.go
@@ -293,8 +293,9 @@ func checkFileManifest(
 		}
 	}
 
+	claimed = coalesceExtents(claimed)
 	for _, hole := range uncoveredRanges(coalesceExtents(covered), f.Size) {
-		for _, piece := range splitByClaim(hole, coalesceExtents(claimed)) {
+		for _, piece := range splitByClaim(hole, claimed) {
 			appendCapped(&finding.Uncovered, piece, &finding.Truncated)
 		}
 	}

--- a/pkg/block/engine/manifest_check.go
+++ b/pkg/block/engine/manifest_check.go
@@ -18,7 +18,8 @@ const maxManifestCheckFindings = 1000
 
 // maxManifestCheckRangesPerPayload bounds the per-payload range and row lists
 // for the same reason: one heavily fragmented file must not be able to fill the
-// whole report on its own.
+// whole report on its own. The counters and the payload's damaged verdict are
+// taken before an entry is dropped, so the cap never hides damage.
 const maxManifestCheckRangesPerPayload = 32
 
 // ByteRange is a half-open [Start, End) span of a payload that no manifest row
@@ -64,26 +65,22 @@ type PayloadFinding struct {
 	UnknownHashRows []string `json:"unknown_hash_rows,omitempty"`
 
 	// Truncated reports that at least one of the lists above stopped short
-	// of the payload's full set.
+	// of the payload's full set. The counts on the enclosing
+	// ManifestCheckResult, and Damaged below, stay exact past that point.
 	Truncated bool `json:"truncated,omitempty"`
-}
 
-// Damaged reports whether this payload holds evidence of manifest damage, as
-// opposed to holes the scan cannot tell apart from sparseness.
-func (p *PayloadFinding) Damaged() bool {
-	if len(p.UnplaceableRows) > 0 || len(p.UnknownHashRows) > 0 {
-		return true
-	}
-	for _, r := range p.Uncovered {
-		if r.Claimed {
-			return true
-		}
-	}
-	return false
+	// Damaged reports whether this payload holds evidence of manifest
+	// damage — a claimed-but-uncovered span, an unplaceable row or an
+	// unknown hash — as opposed to holes the scan cannot tell apart from
+	// sparseness. It is decided as the payload is scanned, so a payload
+	// whose lists were truncated still reports damage found past the cap.
+	Damaged bool `json:"damaged,omitempty"`
 }
 
 // ManifestCheckResult is the outcome of a manifest-coverage scan over one
-// share. Every count is exact; only the Findings list is capped.
+// share. Every count is exact — the per-payload detail lists and the Findings
+// list are capped, but the totals are taken as each defect is found, before
+// anything is dropped for display.
 type ManifestCheckResult struct {
 	// Share is the share whose metadata store was scanned.
 	Share string `json:"share"`
@@ -191,15 +188,7 @@ func CheckManifests(ctx context.Context, share string, store metadata.Store, che
 	}
 	if err := walkAuditShareFiles(ctx, store, rootHandle, "", func(path string, f *metadata.File) error {
 		result.FilesScanned++
-		finding, err := checkFileManifest(ctx, store, path, f, checkSynced)
-		if err != nil {
-			return err
-		}
-		if finding == nil {
-			return nil
-		}
-		result.accumulate(finding)
-		return nil
+		return checkFileManifest(ctx, store, path, f, checkSynced, result)
 	}); err != nil {
 		return nil, fmt.Errorf("store check: walk share %q: %w", share, err)
 	}
@@ -209,24 +198,14 @@ func CheckManifests(ctx context.Context, share string, store metadata.Store, che
 	return result, nil
 }
 
-// accumulate folds one payload's finding into the running totals and appends
-// it to the capped detail list.
-func (r *ManifestCheckResult) accumulate(f *PayloadFinding) {
+// record appends one payload's finding to the capped detail list. The totals
+// are already in place by the time it runs — they are taken as each defect is
+// found, so a defect dropped from a display list still counts.
+func (r *ManifestCheckResult) record(f *PayloadFinding) {
 	r.PayloadsWithFindings++
-	if f.Damaged() {
+	if f.Damaged {
 		r.DamagedPayloads++
 	}
-	for _, rng := range f.Uncovered {
-		r.UncoveredRanges++
-		r.UncoveredBytes += rng.End - rng.Start
-		if rng.Claimed {
-			r.ClaimedUncoveredRanges++
-			r.ClaimedUncoveredBytes += rng.End - rng.Start
-		}
-	}
-	r.UnplaceableRows += uint64(len(f.UnplaceableRows))
-	r.UnknownHashRows += uint64(len(f.UnknownHashRows))
-
 	if len(r.Findings) >= maxManifestCheckFindings {
 		r.FindingsTruncated = true
 		return
@@ -246,19 +225,21 @@ func checkFileManifest(
 	path string,
 	f *metadata.File,
 	checkSynced bool,
-) (*PayloadFinding, error) {
+	res *ManifestCheckResult,
+) error {
 	payloadID := string(f.PayloadID)
 	if payloadID == "" {
-		return nil, nil
+		return nil
 	}
 
 	rows, err := store.ListFileChunks(ctx, payloadID)
 	if err != nil && !errors.Is(err, block.ErrFileChunkNotFound) {
-		return nil, fmt.Errorf("list file chunks for payload %q: %w", payloadID, err)
+		return fmt.Errorf("list file chunks for payload %q: %w", payloadID, err)
 	}
 
 	finding := &PayloadFinding{Path: path, PayloadID: payloadID, Size: f.Size}
 	covered := make([][2]uint64, 0, len(rows))
+	var found bool
 
 	for _, row := range rows {
 		if row == nil {
@@ -266,6 +247,8 @@ func checkFileManifest(
 		}
 		off, ok := block.ParseChunkOffset(row.ID)
 		if !ok {
+			res.UnplaceableRows++
+			finding.Damaged, found = true, true
 			appendCapped(&finding.UnplaceableRows, row.ID, &finding.Truncated)
 			continue
 		}
@@ -275,9 +258,11 @@ func checkFileManifest(
 		if checkSynced {
 			synced, serr := store.IsSynced(ctx, row.Hash)
 			if serr != nil {
-				return nil, fmt.Errorf("is synced %s: %w", row.Hash, serr)
+				return fmt.Errorf("is synced %s: %w", row.Hash, serr)
 			}
 			if !synced {
+				res.UnknownHashRows++
+				finding.Damaged, found = true, true
 				appendCapped(&finding.UnknownHashRows, row.ID, &finding.Truncated)
 			}
 		}
@@ -296,18 +281,29 @@ func checkFileManifest(
 	claimed = coalesceExtents(claimed)
 	for _, hole := range uncoveredRanges(coalesceExtents(covered), f.Size) {
 		for _, piece := range splitByClaim(hole, claimed) {
+			found = true
+			res.UncoveredRanges++
+			res.UncoveredBytes += piece.End - piece.Start
+			if piece.Claimed {
+				res.ClaimedUncoveredRanges++
+				res.ClaimedUncoveredBytes += piece.End - piece.Start
+				finding.Damaged = true
+			}
 			appendCapped(&finding.Uncovered, piece, &finding.Truncated)
 		}
 	}
 
-	if len(finding.Uncovered) == 0 && len(finding.UnplaceableRows) == 0 && len(finding.UnknownHashRows) == 0 {
-		return nil, nil
+	if !found {
+		return nil
 	}
-	return finding, nil
+	res.record(finding)
+	return nil
 }
 
 // appendCapped appends to a per-payload detail list until it reaches
-// maxManifestCheckRangesPerPayload, flagging truncation once it stops.
+// maxManifestCheckRangesPerPayload, flagging truncation once it stops. It
+// bounds only what is shown: the totals and the damaged verdict are taken
+// before it runs, so dropping an entry here never changes the result.
 func appendCapped[T any](dst *[]T, v T, truncated *bool) {
 	if len(*dst) >= maxManifestCheckRangesPerPayload {
 		*truncated = true

--- a/pkg/block/engine/manifest_check.go
+++ b/pkg/block/engine/manifest_check.go
@@ -97,10 +97,17 @@ type ManifestCheckResult struct {
 	// FilesScanned is the number of regular files walked.
 	FilesScanned uint64 `json:"files_scanned"`
 
-	// SyncedHashesChecked reports whether the unknown-hash check ran. It is
-	// skipped on a share with no remote store, where nothing is ever marked
-	// synced and every row would otherwise be reported.
+	// SyncedHashesChecked reports whether the unknown-hash check ran.
 	SyncedHashesChecked bool `json:"synced_hashes_checked"`
+
+	// SyncedCheckSkipped names why the unknown-hash check did not run, and
+	// is empty when it ran. Two conditions suppress it and they mean
+	// opposite things to an operator: a share with no remote store has
+	// nothing that check could find, while a share whose block store could
+	// not be resolved has a check that could not be performed — reporting
+	// the second as the first tells someone with a broken block store that
+	// there was nothing to look for.
+	SyncedCheckSkipped string `json:"synced_check_skipped,omitempty"`
 
 	// PayloadsWithFindings is the number of payloads the scan had something
 	// to report about, damage or not.

--- a/pkg/block/engine/manifest_check.go
+++ b/pkg/block/engine/manifest_check.go
@@ -245,16 +245,18 @@ func checkFileManifest(
 		if row == nil {
 			continue
 		}
-		off, ok := block.ParseChunkOffset(row.ID)
-		if !ok {
+		off, placeable := block.ParseChunkOffset(row.ID)
+		if !placeable {
 			res.UnplaceableRows++
 			finding.Damaged, found = true, true
 			appendCapped(&finding.UnplaceableRows, row.ID, &finding.Truncated)
-			continue
 		}
 		if row.Hash.IsZero() {
-			continue
+			continue // pending row: no committed bytes and no hash to look up
 		}
+		// The hash is put to the synced-hash store even for a row that
+		// cannot be placed. Where its bytes belong is unknown, but whether
+		// the remote holds them is still answerable and still worth saying.
 		if checkSynced {
 			synced, serr := store.IsSynced(ctx, row.Hash)
 			if serr != nil {
@@ -265,6 +267,9 @@ func checkFileManifest(
 				finding.Damaged, found = true, true
 				appendCapped(&finding.UnknownHashRows, row.ID, &finding.Truncated)
 			}
+		}
+		if !placeable {
+			continue // sits at no offset, so it can cover nothing
 		}
 		if e, ok := clipRange(off, uint64(row.DataSize), f.Size); ok {
 			covered = append(covered, e)

--- a/pkg/block/engine/manifest_check.go
+++ b/pkg/block/engine/manifest_check.go
@@ -1,0 +1,383 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// maxManifestCheckFindings bounds how many damaged payloads are reported in
+// detail. The aggregate counters stay exact past the cap; only the per-payload
+// list stops growing, so a store where every file is damaged still produces a
+// bounded response.
+const maxManifestCheckFindings = 1000
+
+// maxManifestCheckRangesPerPayload bounds the per-payload range and row lists
+// for the same reason: one heavily fragmented file must not be able to fill the
+// whole report on its own.
+const maxManifestCheckRangesPerPayload = 32
+
+// ByteRange is a half-open [Start, End) span of a payload that no manifest row
+// covers.
+type ByteRange struct {
+	Start uint64 `json:"start"`
+	End   uint64 `json:"end"`
+
+	// Claimed reports whether the file's own block list (FileAttr.Blocks)
+	// says data lives in this span. A claimed span with no covering row is
+	// damage: the file names a chunk the manifest cannot place. An unclaimed
+	// span is indistinguishable from a legitimate sparse hole or from bytes
+	// written but not yet rolled up into the manifest, so it is reported and
+	// not counted as damage.
+	Claimed bool `json:"claimed"`
+}
+
+// PayloadFinding is the per-payload detail for one file the scan found
+// something to say about.
+type PayloadFinding struct {
+	// Path is the file's path within the share, for operators who need to
+	// act on the result rather than only count it.
+	Path string `json:"path"`
+
+	// PayloadID is the content identifier whose manifest was scanned.
+	PayloadID string `json:"payload_id"`
+
+	// Size is the file's recorded size — the extent the manifest is
+	// expected to cover.
+	Size uint64 `json:"size"`
+
+	// Uncovered lists the spans of [0, Size) that no placeable manifest row
+	// with committed bytes covers.
+	Uncovered []ByteRange `json:"uncovered,omitempty"`
+
+	// UnplaceableRows lists the IDs of manifest rows that exist but carry no
+	// parseable chunk offset, so no reader can say which bytes they hold.
+	UnplaceableRows []string `json:"unplaceable_rows,omitempty"`
+
+	// UnknownHashRows lists the IDs of manifest rows whose content hash the
+	// synced-hash store has no record of, i.e. rows claiming bytes that were
+	// never confirmed mirrored to the remote.
+	UnknownHashRows []string `json:"unknown_hash_rows,omitempty"`
+
+	// Truncated reports that at least one of the lists above stopped short
+	// of the payload's full set.
+	Truncated bool `json:"truncated,omitempty"`
+}
+
+// Damaged reports whether this payload holds evidence of manifest damage, as
+// opposed to holes the scan cannot tell apart from sparseness.
+func (p *PayloadFinding) Damaged() bool {
+	if len(p.UnplaceableRows) > 0 || len(p.UnknownHashRows) > 0 {
+		return true
+	}
+	for _, r := range p.Uncovered {
+		if r.Claimed {
+			return true
+		}
+	}
+	return false
+}
+
+// ManifestCheckResult is the outcome of a manifest-coverage scan over one
+// share. Every count is exact; only the Findings list is capped.
+type ManifestCheckResult struct {
+	// Share is the share whose metadata store was scanned.
+	Share string `json:"share"`
+
+	// StartedAt is when the scan began (UTC).
+	StartedAt time.Time `json:"started_at"`
+
+	// CompletedAt is when the scan finished (UTC).
+	CompletedAt time.Time `json:"completed_at"`
+
+	// DurationMS is the wall-clock cost in milliseconds.
+	DurationMS int64 `json:"duration_ms"`
+
+	// FilesScanned is the number of regular files walked.
+	FilesScanned uint64 `json:"files_scanned"`
+
+	// SyncedHashesChecked reports whether the unknown-hash check ran. It is
+	// skipped on a share with no remote store, where nothing is ever marked
+	// synced and every row would otherwise be reported.
+	SyncedHashesChecked bool `json:"synced_hashes_checked"`
+
+	// PayloadsWithFindings is the number of payloads the scan had something
+	// to report about, damage or not.
+	PayloadsWithFindings uint64 `json:"payloads_with_findings"`
+
+	// DamagedPayloads is the number of payloads holding evidence of damage:
+	// a claimed-but-uncovered span, an unplaceable row, or an unknown hash.
+	DamagedPayloads uint64 `json:"damaged_payloads"`
+
+	// UncoveredRanges and UncoveredBytes total every uncovered span,
+	// claimed or not.
+	UncoveredRanges uint64 `json:"uncovered_ranges"`
+	UncoveredBytes  uint64 `json:"uncovered_bytes"`
+
+	// ClaimedUncoveredRanges and ClaimedUncoveredBytes total the subset the
+	// files' own block lists claim to hold data — the damaged subset.
+	ClaimedUncoveredRanges uint64 `json:"claimed_uncovered_ranges"`
+	ClaimedUncoveredBytes  uint64 `json:"claimed_uncovered_bytes"`
+
+	// UnplaceableRows is the total count of manifest rows with no parseable
+	// chunk offset.
+	UnplaceableRows uint64 `json:"unplaceable_rows"`
+
+	// UnknownHashRows is the total count of manifest rows whose hash the
+	// synced-hash store does not know. Always zero when
+	// SyncedHashesChecked is false.
+	UnknownHashRows uint64 `json:"unknown_hash_rows"`
+
+	// Findings is the per-payload detail, capped at
+	// maxManifestCheckFindings entries.
+	Findings []PayloadFinding `json:"findings,omitempty"`
+
+	// FindingsTruncated reports that more payloads had findings than the
+	// list holds.
+	FindingsTruncated bool `json:"findings_truncated,omitempty"`
+}
+
+// Damaged reports whether the scan found evidence of manifest damage. Holes
+// that no file claims do not count — see ByteRange.Claimed.
+func (r *ManifestCheckResult) Damaged() bool {
+	return r.ClaimedUncoveredRanges > 0 || r.UnplaceableRows > 0 || r.UnknownHashRows > 0
+}
+
+// CheckManifests walks every regular file in a share and compares the byte
+// ranges its manifest rows cover against the file's recorded size, reporting
+// three structural defects:
+//
+//  1. spans of the file no manifest row covers,
+//  2. rows that exist but carry no parseable chunk offset, so no reader can
+//     place them (block.ErrManifestInconsistent at read time),
+//  3. rows whose content hash the synced-hash store has no record of.
+//
+// It is metadata-only. No block is fetched, no local data is read and no
+// remote object is touched, so the cost is a metadata walk regardless of how
+// much data the share holds — cheap enough to answer "how many files are
+// affected" store-wide.
+//
+// The coverage view is the manifest's alone, which is deliberately narrower
+// than DataExtents: that unions the local journal tier as well, so it reports
+// data for bytes written but not yet rolled up. Counting those as covered here
+// would hide exactly the manifest gap this scan exists to find, at the cost of
+// reporting a not-yet-rolled-up range as an uncovered span. Such a span carries
+// no claim from the file's own block list, and the report keeps claimed and
+// unclaimed spans apart for that reason.
+//
+// checkSynced gates the third check. A share with no remote store never marks
+// a hash synced, so running it there would report every row in the share.
+func CheckManifests(ctx context.Context, share string, store metadata.Store, checkSynced bool) (*ManifestCheckResult, error) {
+	if store == nil {
+		return nil, errors.New("store check: metadata store is nil")
+	}
+	if share == "" {
+		return nil, errors.New("store check: share is empty")
+	}
+
+	result := &ManifestCheckResult{
+		Share:               share,
+		StartedAt:           time.Now().UTC(),
+		SyncedHashesChecked: checkSynced,
+	}
+
+	rootHandle, err := store.GetRootHandle(ctx, share)
+	if err != nil {
+		return nil, fmt.Errorf("store check: get root handle for %q: %w", share, err)
+	}
+	if err := walkAuditShareFiles(ctx, store, rootHandle, "", func(path string, f *metadata.File) error {
+		result.FilesScanned++
+		finding, err := checkFileManifest(ctx, store, path, f, checkSynced)
+		if err != nil {
+			return err
+		}
+		if finding == nil {
+			return nil
+		}
+		result.accumulate(finding)
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("store check: walk share %q: %w", share, err)
+	}
+
+	result.CompletedAt = time.Now().UTC()
+	result.DurationMS = result.CompletedAt.Sub(result.StartedAt).Milliseconds()
+	return result, nil
+}
+
+// accumulate folds one payload's finding into the running totals and appends
+// it to the capped detail list.
+func (r *ManifestCheckResult) accumulate(f *PayloadFinding) {
+	r.PayloadsWithFindings++
+	if f.Damaged() {
+		r.DamagedPayloads++
+	}
+	for _, rng := range f.Uncovered {
+		r.UncoveredRanges++
+		r.UncoveredBytes += rng.End - rng.Start
+		if rng.Claimed {
+			r.ClaimedUncoveredRanges++
+			r.ClaimedUncoveredBytes += rng.End - rng.Start
+		}
+	}
+	r.UnplaceableRows += uint64(len(f.UnplaceableRows))
+	r.UnknownHashRows += uint64(len(f.UnknownHashRows))
+
+	if len(r.Findings) >= maxManifestCheckFindings {
+		r.FindingsTruncated = true
+		return
+	}
+	r.Findings = append(r.Findings, *f)
+}
+
+// checkFileManifest scans one file's manifest rows. Returns nil when the file
+// has nothing to report.
+//
+// A row with a zero hash holds no committed bytes yet, so it contributes no
+// coverage and is not put to the synced-hash store — the same reading
+// DataExtents takes of a pending row.
+func checkFileManifest(
+	ctx context.Context,
+	store metadata.Store,
+	path string,
+	f *metadata.File,
+	checkSynced bool,
+) (*PayloadFinding, error) {
+	payloadID := string(f.PayloadID)
+	if payloadID == "" {
+		return nil, nil
+	}
+
+	rows, err := store.ListFileChunks(ctx, payloadID)
+	if err != nil && !errors.Is(err, block.ErrFileChunkNotFound) {
+		return nil, fmt.Errorf("list file chunks for payload %q: %w", payloadID, err)
+	}
+
+	finding := &PayloadFinding{Path: path, PayloadID: payloadID, Size: f.Size}
+	covered := make([][2]uint64, 0, len(rows))
+
+	for _, row := range rows {
+		if row == nil {
+			continue
+		}
+		off, ok := block.ParseChunkOffset(row.ID)
+		if !ok {
+			appendCapped(&finding.UnplaceableRows, row.ID, &finding.Truncated)
+			continue
+		}
+		if row.Hash.IsZero() {
+			continue
+		}
+		if checkSynced {
+			synced, serr := store.IsSynced(ctx, row.Hash)
+			if serr != nil {
+				return nil, fmt.Errorf("is synced %s: %w", row.Hash, serr)
+			}
+			if !synced {
+				appendCapped(&finding.UnknownHashRows, row.ID, &finding.Truncated)
+			}
+		}
+		if e, ok := clipRange(off, uint64(row.DataSize), f.Size); ok {
+			covered = append(covered, e)
+		}
+	}
+
+	claimed := make([][2]uint64, 0, len(f.Blocks))
+	for _, ref := range f.Blocks {
+		if e, ok := clipRange(ref.Offset, uint64(ref.Size), f.Size); ok {
+			claimed = append(claimed, e)
+		}
+	}
+
+	for _, hole := range uncoveredRanges(coalesceExtents(covered), f.Size) {
+		for _, piece := range splitByClaim(hole, coalesceExtents(claimed)) {
+			appendCapped(&finding.Uncovered, piece, &finding.Truncated)
+		}
+	}
+
+	if len(finding.Uncovered) == 0 && len(finding.UnplaceableRows) == 0 && len(finding.UnknownHashRows) == 0 {
+		return nil, nil
+	}
+	return finding, nil
+}
+
+// appendCapped appends to a per-payload detail list until it reaches
+// maxManifestCheckRangesPerPayload, flagging truncation once it stops.
+func appendCapped[T any](dst *[]T, v T, truncated *bool) {
+	if len(*dst) >= maxManifestCheckRangesPerPayload {
+		*truncated = true
+		return
+	}
+	*dst = append(*dst, v)
+}
+
+// clipRange returns [off, off+length) clipped to [0, size), and whether
+// anything survived the clip. An overflowing end is clamped to size.
+func clipRange(off, length, size uint64) ([2]uint64, bool) {
+	if length == 0 || off >= size {
+		return [2]uint64{}, false
+	}
+	end := off + length
+	if end < off || end > size {
+		end = size
+	}
+	return [2]uint64{off, end}, true
+}
+
+// uncoveredRanges returns [0, size) minus covered, which must already be
+// sorted and non-overlapping (coalesceExtents output).
+func uncoveredRanges(covered [][2]uint64, size uint64) [][2]uint64 {
+	var (
+		out [][2]uint64
+		cur uint64
+	)
+	for _, c := range covered {
+		if c[0] > cur {
+			out = append(out, [2]uint64{cur, c[0]})
+		}
+		if c[1] > cur {
+			cur = c[1]
+		}
+	}
+	if cur < size {
+		out = append(out, [2]uint64{cur, size})
+	}
+	return out
+}
+
+// splitByClaim cuts one uncovered span against the file's own block list,
+// tagging each piece with whether the file claims data there. claimed must be
+// sorted and non-overlapping.
+func splitByClaim(hole [2]uint64, claimed [][2]uint64) []ByteRange {
+	var out []ByteRange
+	cur := hole[0]
+	for _, c := range claimed {
+		if c[1] <= cur {
+			continue
+		}
+		if c[0] >= hole[1] {
+			break
+		}
+		start := c[0]
+		if start < cur {
+			start = cur
+		}
+		end := c[1]
+		if end > hole[1] {
+			end = hole[1]
+		}
+		if start > cur {
+			out = append(out, ByteRange{Start: cur, End: start})
+		}
+		out = append(out, ByteRange{Start: start, End: end, Claimed: true})
+		cur = end
+	}
+	if cur < hole[1] {
+		out = append(out, ByteRange{Start: cur, End: hole[1]})
+	}
+	return out
+}

--- a/pkg/block/engine/manifest_check_test.go
+++ b/pkg/block/engine/manifest_check_test.go
@@ -309,19 +309,33 @@ func TestCheckManifests_UnplaceableRow(t *testing.T) {
 		[]seedRow{{"block-0", 4096, 1}, {"4096", 4096, 2}},
 		[]seedRef{{0, 4096, 1}, {4096, 4096, 2}})
 
-	res, err := CheckManifests(ctx, share, store, false)
+	// Only the placeable row's hash is known to the synced-hash store, so
+	// the unplaceable row must still be put to it: where its bytes belong is
+	// unknown, but whether the remote holds them is still answerable.
+	if err := store.MarkSynced(ctx, seedHash(2), block.ChunkLocator{}); err != nil {
+		t.Fatalf("MarkSynced: %v", err)
+	}
+
+	res, err := CheckManifests(ctx, share, store, true)
 	if err != nil {
 		t.Fatalf("CheckManifests: %v", err)
 	}
 	if res.UnplaceableRows != 1 {
 		t.Fatalf("UnplaceableRows = %d, want 1", res.UnplaceableRows)
 	}
+	if res.UnknownHashRows != 1 {
+		t.Fatalf("UnknownHashRows = %d, want 1 (the unplaceable row's hash)", res.UnknownHashRows)
+	}
 	f := findingFor(t, res, payloadID)
 	if f == nil {
 		t.Fatal("no finding for the payload holding an unplaceable row")
 	}
-	if want := payloadID + "/block-0"; len(f.UnplaceableRows) != 1 || f.UnplaceableRows[0] != want {
+	want := payloadID + "/block-0"
+	if len(f.UnplaceableRows) != 1 || f.UnplaceableRows[0] != want {
 		t.Fatalf("UnplaceableRows = %v, want [%s]", f.UnplaceableRows, want)
+	}
+	if len(f.UnknownHashRows) != 1 || f.UnknownHashRows[0] != want {
+		t.Fatalf("UnknownHashRows = %v, want [%s]", f.UnknownHashRows, want)
 	}
 	// The unplaceable row contributes no coverage, so the range it should
 	// have held is also reported as claimed-but-uncovered.

--- a/pkg/block/engine/manifest_check_test.go
+++ b/pkg/block/engine/manifest_check_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -237,7 +238,7 @@ func TestCheckManifests_HolesAndUnknownHashes(t *testing.T) {
 			if len(df.Uncovered) != 1 || df.Uncovered[0] != (ByteRange{Start: 0, End: 4096, Claimed: true}) {
 				t.Fatalf("damaged payload: Uncovered = %v, want one claimed [0,4096)", df.Uncovered)
 			}
-			if !df.Damaged() {
+			if !df.Damaged {
 				t.Fatal("damaged payload: Damaged() = false")
 			}
 
@@ -248,7 +249,7 @@ func TestCheckManifests_HolesAndUnknownHashes(t *testing.T) {
 			if len(sf.Uncovered) != 1 || sf.Uncovered[0] != (ByteRange{Start: 0, End: 4096, Claimed: false}) {
 				t.Fatalf("sparse payload: Uncovered = %v, want one unclaimed [0,4096)", sf.Uncovered)
 			}
-			if sf.Damaged() {
+			if sf.Damaged {
 				t.Fatal("sparse payload: Damaged() = true, want false — an unclaimed hole is not damage")
 			}
 
@@ -386,5 +387,56 @@ func TestUncoveredRanges(t *testing.T) {
 	// A row overhanging the recorded size still covers everything below it.
 	if n := len(uncoveredRanges([][2]uint64{{0, 100}}, 40)); n != 0 {
 		t.Fatalf("overhanging coverage reported %d uncovered ranges", n)
+	}
+}
+
+// TestCheckManifests_CapDoesNotHideDamage pins that the per-payload display
+// cap bounds only what is listed. A file fragmented past the cap by holes
+// nothing claims must still report the claimed range that follows them —
+// dropping it would make the scan exit clean on a damaged store, the exact
+// silence this command exists to end.
+func TestCheckManifests_CapDoesNotHideDamage(t *testing.T) {
+	ctx := t.Context()
+	const share = "fragmented"
+	store, root := newCheckStore(t, "memory", share)
+
+	// Alternate covered and uncovered 4 KiB pages so the file opens with
+	// more unclaimed holes than the per-payload list can hold, then claim a
+	// final page that no row covers.
+	const holes = maxManifestCheckRangesPerPayload + 4
+	var (
+		rows []seedRow
+		refs []seedRef
+	)
+	for i := 0; i < holes; i++ {
+		off := uint64(i)*8192 + 4096
+		rows = append(rows, seedRow{strconv.FormatUint(off, 10), 4096, 1})
+		refs = append(refs, seedRef{off, 4096, 1})
+	}
+	damagedOff := uint64(holes) * 8192
+	refs = append(refs, seedRef{damagedOff, 4096, 2})
+	payloadID := seedCheckFile(t, store, share, root, "f", damagedOff+4096, rows, refs)
+
+	res, err := CheckManifests(ctx, share, store, false)
+	if err != nil {
+		t.Fatalf("CheckManifests: %v", err)
+	}
+	if res.ClaimedUncoveredRanges != 1 || res.ClaimedUncoveredBytes != 4096 {
+		t.Fatalf("ClaimedUncoveredRanges=%d ClaimedUncoveredBytes=%d, want 1 and 4096",
+			res.ClaimedUncoveredRanges, res.ClaimedUncoveredBytes)
+	}
+	if res.UncoveredRanges != holes+1 {
+		t.Fatalf("UncoveredRanges = %d, want %d", res.UncoveredRanges, holes+1)
+	}
+	if res.DamagedPayloads != 1 || !res.Damaged() {
+		t.Fatalf("DamagedPayloads=%d Damaged=%v, want 1 and true", res.DamagedPayloads, res.Damaged())
+	}
+	f := findingFor(t, res, payloadID)
+	if f == nil || !f.Damaged {
+		t.Fatalf("finding = %+v, want Damaged", f)
+	}
+	if !f.Truncated || len(f.Uncovered) != maxManifestCheckRangesPerPayload {
+		t.Fatalf("Truncated=%v len(Uncovered)=%d, want true and %d",
+			f.Truncated, len(f.Uncovered), maxManifestCheckRangesPerPayload)
 	}
 }

--- a/pkg/block/engine/manifest_check_test.go
+++ b/pkg/block/engine/manifest_check_test.go
@@ -1,0 +1,390 @@
+package engine
+
+import (
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+	metadatasqlite "github.com/marmos91/dittofs/pkg/metadata/store/sqlite"
+)
+
+// seedRow describes one FileChunk row to plant: the suffix appended after
+// "{payloadID}/", the row's DataSize, and a hash seed (0 means the zero hash,
+// i.e. a pending row that holds no committed bytes).
+type seedRow struct {
+	suffix string
+	size   uint32
+	hash   byte
+}
+
+// seedRef describes one entry of the file's own block list.
+type seedRef struct {
+	off  uint64
+	size uint32
+	hash byte
+}
+
+func seedHash(b byte) block.ContentHash {
+	var h block.ContentHash
+	if b == 0 {
+		return h
+	}
+	for i := range h {
+		h[i] = b
+	}
+	return h
+}
+
+// newCheckStore builds an empty share on the named backend and returns the
+// store plus its root handle.
+func newCheckStore(t *testing.T, backend, share string) (metadata.Store, metadata.FileHandle) {
+	t.Helper()
+	ctx := t.Context()
+
+	var store metadata.Store
+	switch backend {
+	case "memory":
+		store = metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	case "sqlite":
+		s, err := metadatasqlite.NewSQLiteMetadataStore(ctx, &metadatasqlite.SQLiteMetadataStoreConfig{
+			Path:        t.TempDir() + "/m.db",
+			AutoMigrate: true,
+		}, metadata.FilesystemCapabilities{
+			MaxFileSize:         1 << 40,
+			MaxFilenameLen:      255,
+			MaxPathLen:          4096,
+			MaxHardLinkCount:    32767,
+			CaseSensitive:       true,
+			CasePreserving:      true,
+			TimestampResolution: 1,
+		})
+		if err != nil {
+			t.Fatalf("NewSQLiteMetadataStore: %v", err)
+		}
+		t.Cleanup(func() { _ = s.Close() })
+		store = s
+	default:
+		t.Fatalf("unknown backend %q", backend)
+	}
+
+	if err := store.CreateShare(ctx, &metadata.Share{Name: share}); err != nil {
+		t.Fatalf("CreateShare: %v", err)
+	}
+	if _, err := store.CreateRootDirectory(ctx, share, &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory, Mode: 0o755,
+	}); err != nil {
+		t.Fatalf("CreateRootDirectory: %v", err)
+	}
+	root, err := store.GetRootHandle(ctx, share)
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+	return store, root
+}
+
+// seedCheckFile plants one regular file under root with the given recorded
+// size, FileChunk rows and block list, and returns its payloadID.
+func seedCheckFile(
+	t *testing.T,
+	store metadata.Store,
+	share string,
+	root metadata.FileHandle,
+	name string,
+	size uint64,
+	rows []seedRow,
+	refs []seedRef,
+) string {
+	t.Helper()
+	ctx := t.Context()
+	now := time.Now().UTC()
+
+	handle, err := store.GenerateHandle(ctx, share, "/"+name)
+	if err != nil {
+		t.Fatalf("GenerateHandle(%s): %v", name, err)
+	}
+	_, fileID, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		t.Fatalf("DecodeFileHandle(%s): %v", name, err)
+	}
+
+	payloadID := "payload-" + name
+	for _, r := range rows {
+		if err := store.Put(ctx, &block.FileChunk{
+			ID:         payloadID + "/" + r.suffix,
+			Hash:       seedHash(r.hash),
+			State:      block.BlockStatePending,
+			DataSize:   r.size,
+			LastAccess: now,
+			CreatedAt:  now,
+		}); err != nil {
+			t.Fatalf("Put chunk %s/%s: %v", payloadID, r.suffix, err)
+		}
+	}
+
+	blocks := make([]block.ChunkRef, 0, len(refs))
+	for _, r := range refs {
+		blocks = append(blocks, block.ChunkRef{Hash: seedHash(r.hash), Offset: r.off, Size: r.size})
+	}
+
+	file := &metadata.File{
+		ID:        fileID,
+		ShareName: share,
+		FileAttr: metadata.FileAttr{
+			Type:        metadata.FileTypeRegular,
+			Mode:        0o644,
+			Size:        size,
+			Mtime:       now,
+			Ctime:       now,
+			Atime:       now,
+			PayloadID:   metadata.PayloadID(payloadID),
+			Blocks:      blocks,
+			BlocksDirty: true,
+		},
+	}
+	if err := store.PutFile(ctx, file); err != nil {
+		t.Fatalf("PutFile(%s): %v", name, err)
+	}
+	if err := store.SetParent(ctx, handle, root); err != nil {
+		t.Fatalf("SetParent(%s): %v", name, err)
+	}
+	if err := store.SetChild(ctx, root, name, handle); err != nil {
+		t.Fatalf("SetChild(%s): %v", name, err)
+	}
+	if err := store.SetLinkCount(ctx, handle, 1); err != nil {
+		t.Fatalf("SetLinkCount(%s): %v", name, err)
+	}
+	return payloadID
+}
+
+func findingFor(t *testing.T, res *ManifestCheckResult, payloadID string) *PayloadFinding {
+	t.Helper()
+	for i := range res.Findings {
+		if res.Findings[i].PayloadID == payloadID {
+			return &res.Findings[i]
+		}
+	}
+	return nil
+}
+
+// TestCheckManifests_HolesAndUnknownHashes exercises the three reportable
+// conditions that every metadata backend surfaces identically: a range no row
+// covers that the file's own block list claims (damage), a range nothing
+// claims (indistinguishable from sparseness), and a row whose hash the
+// synced-hash store does not know. A healthy file must produce no finding at
+// all — a scan that reports nothing everywhere proves nothing.
+func TestCheckManifests_HolesAndUnknownHashes(t *testing.T) {
+	for _, backend := range []string{"memory", "sqlite"} {
+		t.Run(backend, func(t *testing.T) {
+			ctx := t.Context()
+			const share = "checkshare"
+			store, root := newCheckStore(t, backend, share)
+
+			// Healthy: two rows covering [0,8192), both claimed and both synced.
+			healthy := seedCheckFile(t, store, share, root, "healthy", 8192,
+				[]seedRow{{"0", 4096, 1}, {"4096", 4096, 2}},
+				[]seedRef{{0, 4096, 1}, {4096, 4096, 2}})
+
+			// Damaged: the file claims data at [0,4096) but only the second
+			// row survives, so nothing covers the leading page — the #1879
+			// shape.
+			damaged := seedCheckFile(t, store, share, root, "damaged", 8192,
+				[]seedRow{{"4096", 4096, 3}},
+				[]seedRef{{0, 4096, 4}, {4096, 4096, 3}})
+
+			// Sparse: a real hole at [0,4096) that the file does not claim.
+			sparse := seedCheckFile(t, store, share, root, "sparse", 8192,
+				[]seedRow{{"4096", 4096, 5}},
+				[]seedRef{{4096, 4096, 5}})
+
+			// Every hash above is marked synced except hash 2, which stays
+			// unknown to the synced-hash store.
+			for _, h := range []byte{1, 3, 5} {
+				if err := store.MarkSynced(ctx, seedHash(h), block.ChunkLocator{}); err != nil {
+					t.Fatalf("MarkSynced(%d): %v", h, err)
+				}
+			}
+
+			res, err := CheckManifests(ctx, share, store, true)
+			if err != nil {
+				t.Fatalf("CheckManifests: %v", err)
+			}
+			if res.FilesScanned != 3 {
+				t.Fatalf("FilesScanned = %d, want 3", res.FilesScanned)
+			}
+			if !res.Damaged() {
+				t.Fatal("Damaged() = false, want true")
+			}
+
+			// The healthy file's only finding is its unknown hash; it has no
+			// uncovered range.
+			hf := findingFor(t, res, healthy)
+			if hf == nil {
+				t.Fatal("healthy payload: want a finding for the unknown hash")
+			}
+			if len(hf.Uncovered) != 0 {
+				t.Fatalf("healthy payload: Uncovered = %v, want none", hf.Uncovered)
+			}
+			if want := []string{healthy + "/4096"}; len(hf.UnknownHashRows) != 1 || hf.UnknownHashRows[0] != want[0] {
+				t.Fatalf("healthy payload: UnknownHashRows = %v, want %v", hf.UnknownHashRows, want)
+			}
+
+			df := findingFor(t, res, damaged)
+			if df == nil {
+				t.Fatal("damaged payload: no finding")
+			}
+			if len(df.Uncovered) != 1 || df.Uncovered[0] != (ByteRange{Start: 0, End: 4096, Claimed: true}) {
+				t.Fatalf("damaged payload: Uncovered = %v, want one claimed [0,4096)", df.Uncovered)
+			}
+			if !df.Damaged() {
+				t.Fatal("damaged payload: Damaged() = false")
+			}
+
+			sf := findingFor(t, res, sparse)
+			if sf == nil {
+				t.Fatal("sparse payload: no finding")
+			}
+			if len(sf.Uncovered) != 1 || sf.Uncovered[0] != (ByteRange{Start: 0, End: 4096, Claimed: false}) {
+				t.Fatalf("sparse payload: Uncovered = %v, want one unclaimed [0,4096)", sf.Uncovered)
+			}
+			if sf.Damaged() {
+				t.Fatal("sparse payload: Damaged() = true, want false — an unclaimed hole is not damage")
+			}
+
+			if res.ClaimedUncoveredBytes != 4096 || res.UncoveredBytes != 8192 {
+				t.Fatalf("ClaimedUncoveredBytes=%d UncoveredBytes=%d, want 4096 and 8192",
+					res.ClaimedUncoveredBytes, res.UncoveredBytes)
+			}
+			if res.UnknownHashRows != 1 {
+				t.Fatalf("UnknownHashRows = %d, want 1", res.UnknownHashRows)
+			}
+			if res.DamagedPayloads != 2 {
+				t.Fatalf("DamagedPayloads = %d, want 2 (damaged + the unknown-hash file)", res.DamagedPayloads)
+			}
+		})
+	}
+}
+
+// TestCheckManifests_LocalOnlySkipsSyncedCheck pins the gate that keeps a
+// share with no remote store from reporting every one of its rows: nothing is
+// ever marked synced there, so the unknown-hash check must not run.
+func TestCheckManifests_LocalOnlySkipsSyncedCheck(t *testing.T) {
+	ctx := t.Context()
+	const share = "localonly"
+	store, root := newCheckStore(t, "memory", share)
+	seedCheckFile(t, store, share, root, "f", 4096,
+		[]seedRow{{"0", 4096, 1}}, []seedRef{{0, 4096, 1}})
+
+	res, err := CheckManifests(ctx, share, store, false)
+	if err != nil {
+		t.Fatalf("CheckManifests: %v", err)
+	}
+	if res.SyncedHashesChecked {
+		t.Fatal("SyncedHashesChecked = true, want false")
+	}
+	if res.UnknownHashRows != 0 || len(res.Findings) != 0 {
+		t.Fatalf("local-only scan reported %d unknown-hash rows and %d findings, want none",
+			res.UnknownHashRows, len(res.Findings))
+	}
+	if res.Damaged() {
+		t.Fatal("Damaged() = true on a healthy local-only share")
+	}
+}
+
+// TestCheckManifests_UnplaceableRow plants a row whose ID carries no parseable
+// chunk offset — the row class that read paths refuse with
+// ErrManifestInconsistent and that cold seeding cannot place at all.
+//
+// Only the SQL backends can host this case: memory's ListFileChunks drops a
+// non-numeric ID suffix before returning, so the row is invisible to any
+// caller there and the range surfaces as an uncovered span instead.
+func TestCheckManifests_UnplaceableRow(t *testing.T) {
+	ctx := t.Context()
+	const share = "unplaceable"
+	store, root := newCheckStore(t, "sqlite", share)
+
+	payloadID := seedCheckFile(t, store, share, root, "f", 8192,
+		[]seedRow{{"block-0", 4096, 1}, {"4096", 4096, 2}},
+		[]seedRef{{0, 4096, 1}, {4096, 4096, 2}})
+
+	res, err := CheckManifests(ctx, share, store, false)
+	if err != nil {
+		t.Fatalf("CheckManifests: %v", err)
+	}
+	if res.UnplaceableRows != 1 {
+		t.Fatalf("UnplaceableRows = %d, want 1", res.UnplaceableRows)
+	}
+	f := findingFor(t, res, payloadID)
+	if f == nil {
+		t.Fatal("no finding for the payload holding an unplaceable row")
+	}
+	if want := payloadID + "/block-0"; len(f.UnplaceableRows) != 1 || f.UnplaceableRows[0] != want {
+		t.Fatalf("UnplaceableRows = %v, want [%s]", f.UnplaceableRows, want)
+	}
+	// The unplaceable row contributes no coverage, so the range it should
+	// have held is also reported as claimed-but-uncovered.
+	if len(f.Uncovered) != 1 || !f.Uncovered[0].Claimed || f.Uncovered[0] != (ByteRange{0, 4096, true}) {
+		t.Fatalf("Uncovered = %v, want one claimed [0,4096)", f.Uncovered)
+	}
+	if !res.Damaged() {
+		t.Fatal("Damaged() = false with an unplaceable row present")
+	}
+}
+
+// TestCheckManifests_PendingRowHoldsNoBytes pins that a zero-hash row
+// contributes no coverage — it holds no committed bytes, the same reading
+// DataExtents takes — and is not put to the synced-hash store.
+func TestCheckManifests_PendingRowHoldsNoBytes(t *testing.T) {
+	ctx := t.Context()
+	const share = "pending"
+	store, root := newCheckStore(t, "memory", share)
+	payloadID := seedCheckFile(t, store, share, root, "f", 4096,
+		[]seedRow{{"0", 4096, 0}}, nil)
+
+	res, err := CheckManifests(ctx, share, store, true)
+	if err != nil {
+		t.Fatalf("CheckManifests: %v", err)
+	}
+	f := findingFor(t, res, payloadID)
+	if f == nil || len(f.Uncovered) != 1 || f.Uncovered[0].Claimed {
+		t.Fatalf("Findings = %+v, want one unclaimed uncovered range", res.Findings)
+	}
+	if res.UnknownHashRows != 0 {
+		t.Fatalf("UnknownHashRows = %d, want 0 — a pending row has no hash to look up", res.UnknownHashRows)
+	}
+}
+
+func TestSplitByClaim(t *testing.T) {
+	claimed := [][2]uint64{{100, 200}, {300, 400}}
+	got := splitByClaim([2]uint64{50, 350}, claimed)
+	want := []ByteRange{
+		{50, 100, false},
+		{100, 200, true},
+		{200, 300, false},
+		{300, 350, true},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("splitByClaim = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("splitByClaim[%d] = %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestUncoveredRanges(t *testing.T) {
+	got := uncoveredRanges([][2]uint64{{0, 10}, {20, 30}}, 40)
+	want := [][2]uint64{{10, 20}, {30, 40}}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("uncoveredRanges = %v, want %v", got, want)
+	}
+	if n := len(uncoveredRanges([][2]uint64{{0, 40}}, 40)); n != 0 {
+		t.Fatalf("fully covered payload reported %d uncovered ranges", n)
+	}
+	// A row overhanging the recorded size still covers everything below it.
+	if n := len(uncoveredRanges([][2]uint64{{0, 100}}, 40)); n != 0 {
+		t.Fatalf("overhanging coverage reported %d uncovered ranges", n)
+	}
+}

--- a/pkg/controlplane/api/router.go
+++ b/pkg/controlplane/api/router.go
@@ -199,6 +199,7 @@ func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.S
 			blockStoreHandler := handlers.NewBlockStoreStatsHandler(rt)
 			blockGCHandler := handlers.NewBlockStoreGCHandler(rt)
 			blockAuditHandler := handlers.NewBlockStoreAuditHandler(rt)
+			manifestCheckHandler := handlers.NewBlockStoreManifestCheckHandler(rt)
 			mountHandler := handlers.NewMountHandler(rt)
 
 			// Share management (admin only)
@@ -308,6 +309,10 @@ func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.S
 				// inherited admin middleware); persists last-inv02.json
 				// under the share's audit-state directory.
 				r.Post("/{name}/audit/refcounts", blockAuditHandler.RunAudit)
+
+				// Per-share manifest-coverage scan. Metadata-only: it
+				// reads no block data and touches no remote store.
+				r.Post("/{name}/audit/manifest", manifestCheckHandler.RunManifestCheck)
 			})
 
 			// Cross-share snapshot policy listing (admin only). Per-share

--- a/pkg/controlplane/runtime/manifestcheck.go
+++ b/pkg/controlplane/runtime/manifestcheck.go
@@ -51,7 +51,7 @@ func (r *Runtime) CheckManifests(ctx context.Context, shareName string) (*engine
 	}
 	res.SyncedCheckSkipped = skipped
 	logger.Info("store check: complete",
-		"share", shareName,
+		logger.KeyShare, shareName,
 		"files_scanned", res.FilesScanned,
 		"damaged_payloads", res.DamagedPayloads,
 		"claimed_uncovered_bytes", res.ClaimedUncoveredBytes,

--- a/pkg/controlplane/runtime/manifestcheck.go
+++ b/pkg/controlplane/runtime/manifestcheck.go
@@ -1,0 +1,54 @@
+package runtime
+
+import (
+	"context"
+
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/block/engine"
+)
+
+// CheckManifests runs the metadata-only manifest-coverage scan for the named
+// share: per payload it compares the byte ranges the manifest rows cover
+// against the file's recorded size and reports uncovered ranges, rows that
+// carry no parseable chunk offset, and rows whose hash the synced-hash store
+// does not know.
+//
+// The scan fetches no block and reads no file data, so its cost is a metadata
+// walk regardless of how much data the share holds.
+//
+// The unknown-hash check runs only when the share has a remote store. A
+// local-only share never marks a hash synced, so running it there would report
+// every row in the share as unknown. A share whose block store cannot be
+// resolved is treated as local-only — the conservative direction, since it
+// suppresses a check rather than inventing findings.
+//
+// Returns ErrShareNotFound (wrapped) when the share is unknown.
+func (r *Runtime) CheckManifests(ctx context.Context, shareName string) (*engine.ManifestCheckResult, error) {
+	mds, err := r.GetMetadataStoreForShare(shareName)
+	if err != nil {
+		return nil, err
+	}
+
+	checkSynced := false
+	if bs, bsErr := r.sharesSvc.GetBlockStoreForShare(shareName); bsErr != nil {
+		logger.Debug("store check: block store lookup failed, skipping the synced-hash check",
+			"share", shareName, "error", bsErr)
+	} else if bs != nil {
+		checkSynced = bs.HasRemoteStore()
+	}
+
+	res, err := engine.CheckManifests(ctx, shareName, mds, checkSynced)
+	if err != nil {
+		return nil, err
+	}
+	logger.Info("store check: complete",
+		"share", shareName,
+		"filesScanned", res.FilesScanned,
+		"damagedPayloads", res.DamagedPayloads,
+		"claimedUncoveredBytes", res.ClaimedUncoveredBytes,
+		"unplaceableRows", res.UnplaceableRows,
+		"unknownHashRows", res.UnknownHashRows,
+		"durationMs", res.DurationMS,
+	)
+	return res, nil
+}

--- a/pkg/controlplane/runtime/manifestcheck.go
+++ b/pkg/controlplane/runtime/manifestcheck.go
@@ -29,18 +29,27 @@ func (r *Runtime) CheckManifests(ctx context.Context, shareName string) (*engine
 		return nil, err
 	}
 
-	checkSynced := false
-	if bs, bsErr := r.sharesSvc.GetBlockStoreForShare(shareName); bsErr != nil {
-		logger.Debug("store check: block store lookup failed, skipping the synced-hash check",
-			"share", shareName, "error", bsErr)
-	} else if bs != nil {
-		checkSynced = bs.HasRemoteStore()
+	var (
+		checkSynced bool
+		skipped     string
+	)
+	bs, bsErr := r.sharesSvc.GetBlockStoreForShare(shareName)
+	switch {
+	case bsErr != nil || bs == nil:
+		skipped = "block store could not be resolved for this share"
+		logger.Warn("store check: block store lookup failed, cannot run the synced-hash check",
+			logger.KeyShare, shareName, "error", bsErr)
+	case !bs.HasRemoteStore():
+		skipped = "share has no remote store"
+	default:
+		checkSynced = true
 	}
 
 	res, err := engine.CheckManifests(ctx, shareName, mds, checkSynced)
 	if err != nil {
 		return nil, err
 	}
+	res.SyncedCheckSkipped = skipped
 	logger.Info("store check: complete",
 		"share", shareName,
 		"files_scanned", res.FilesScanned,

--- a/pkg/controlplane/runtime/manifestcheck.go
+++ b/pkg/controlplane/runtime/manifestcheck.go
@@ -43,12 +43,12 @@ func (r *Runtime) CheckManifests(ctx context.Context, shareName string) (*engine
 	}
 	logger.Info("store check: complete",
 		"share", shareName,
-		"filesScanned", res.FilesScanned,
-		"damagedPayloads", res.DamagedPayloads,
-		"claimedUncoveredBytes", res.ClaimedUncoveredBytes,
-		"unplaceableRows", res.UnplaceableRows,
-		"unknownHashRows", res.UnknownHashRows,
-		"durationMs", res.DurationMS,
+		"files_scanned", res.FilesScanned,
+		"damaged_payloads", res.DamagedPayloads,
+		"claimed_uncovered_bytes", res.ClaimedUncoveredBytes,
+		"unplaceable_rows", res.UnplaceableRows,
+		"unknown_hash_rows", res.UnknownHashRows,
+		"duration_ms", res.DurationMS,
 	)
 	return res, nil
 }


### PR DESCRIPTION
Closes #1882.

#1879's reporter asked a question the store could not answer: *"is there any way to know how many objects are affected without reading every file?"* This adds `dfsctl store check`, which answers it from metadata alone.

## What it does

Per payload, the scan compares the byte ranges the manifest rows cover against the file's recorded size and reports three structural defects:

1. **Ranges no row covers.** Split into two classes, because that distinction is what makes the output usable:
   - *claimed* — the file's own block list (`FileAttr.Blocks`) says data lives there and no manifest row covers it. This is damage, and it is the #1879 shape.
   - *unclaimed* — nothing claims the range. A sparse file legitimately has these, and so does data written but not yet rolled up into the manifest. **The scan cannot tell those apart**, so it counts them separately, says so in the output, and never fails on them. They are also kept out of the detail table unless `--include-holes` is passed.
2. **Rows whose ID carries no parseable chunk offset** — the `ErrManifestInconsistent` class from #1881. Such a row exists but sits at no offset any reader can place, so it contributes no coverage and the range it should have held also surfaces as claimed-but-uncovered.
3. **Rows whose hash the synced-hash store does not know.**

## Cost

The scan is **metadata-only**. It walks the metadata store (`ListChildren` / `GetFile` / `ListFileChunks` / `IsSynced`) and never calls into a block store, never reads local file data, and never touches a remote object — so there is no S3 egress and the cost is a metadata walk regardless of how much data the store holds. That is the actual requirement in #1882, and it is why re-hashing (#1490) could not have answered #1879: the damaged range had **no block to hash**.

## Coverage semantics

The manifest's own view is used, deliberately narrower than `engine.DataExtents`. `DataExtents` unions the local journal tier as well, so it reports data for bytes written but not yet rolled up; counting those as covered here would hide exactly the manifest gap the scan exists to find. The cost is that a not-yet-rolled-up range shows as an uncovered span — which is precisely why claimed and unclaimed spans are kept apart.

A zero-hash (pending) row contributes no coverage and is not put to the synced-hash store, matching the reading `DataExtents` already takes of a pending row.

## Two false-positive gates

- **Local-only shares skip the unknown-hash check.** `FileChunk.State` is not authoritative for sync — the carve path never transitions a row to `BlockStateRemote`, `SyncedHashStore` is the oracle — so a share with no remote store has nothing marked synced and every row would otherwise be reported. `Runtime.CheckManifests` gates on `GetBlockStoreForShare(...).HasRemoteStore()`, and the output prints `not checked (share has no remote store)` rather than a misleading `0`.
- **Unclaimed holes never fail the command**, per above.

## Surface

- `dfsctl store check [share]` — with no argument every share is scanned. Exits non-zero when damage is found, in **every** output format, so it can gate a script (`dfsctl store check || alert`).
- `POST /api/v1/shares/{name}/audit/manifest` (admin), mirroring the existing `/audit/refcounts` endpoint shape.
- `engine.CheckManifests(ctx, share, metadata.Store, checkSynced)`.

No new store-side interface: `metadata.Store` already embeds both the `FileChunk` surface and `SyncedHashStore`, so the scan needs nothing that every backend does not already implement. The existing `walkAuditShareFiles` is reused, extended to carry the file's path so the report names the affected file rather than only counting it.

## Backend divergence found while testing

`ListFileChunks` on the **memory** backend drops a row whose ID suffix is not a plain integer before returning it (`objects.go`, `strconv.Atoi` → `continue`), so an unplaceable row is invisible to every caller there. The SQL backends (`WHERE id LIKE '{payload}/%'`) return it. The test suite is therefore run over both memory and sqlite for the shared cases, with the unplaceable-row case pinned on sqlite and the divergence documented in the test. On memory the same damage still surfaces — as a claimed-but-uncovered range instead of an unplaceable row — so the scan does not fail open there.

## Tests

- `pkg/block/engine/manifest_check_test.go` — memory + sqlite: a claimed hole (damage), an unclaimed hole (not damage), an unknown hash, a pending row, a healthy file that must produce **no** finding, the local-only gate, and the unplaceable row on sqlite.
- `cmd/dfsctl/commands/store/check_test.go` — endpoint/method, exit code non-zero on damage across table/json/yaml, unclaimed holes neither failing nor cluttering the default detail, `--include-holes`, and the whole-store (no-argument) path.

## Deliberately left out

- **Full read-and-verify pass behind a flag.** Not a thin addition: it needs the per-share `*engine.Store`, streams every file, and pays remote egress — a different cost class and a different code path from a metadata walk. #1490 already tracks content scrubbing (re-hashing blocks / bit rot), which is the right home for it.
- **A repair path.** Out of scope here; worth a follow-up, since #1881's analysis says the bytes are usually still on the remote in the hole case.
