### PR TITLE
feat(kmip): validate the client against PyKMIP in CI and honour the KMIP key state

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,6 +12,7 @@ on:
       - 'go.mod'
       - 'go.sum'
       - 'test/integration/**'
+      - 'test/kmip/**'
       - '.github/workflows/integration-tests.yml'
 
 concurrency:
@@ -77,6 +78,15 @@ jobs:
             sleep 2
           done
 
+      # PyKMIP for the KMIP key-provider interop tests. Without it the
+      # gated tests in pkg/block/encryption/keyprovider skip and the only
+      # KMIP coverage is our own canned TTLV answering our own client.
+      # The script generates certificates, provisions one key per state
+      # the provider reacts to, and exports the DITTOFS_TEST_KMIP_* vars
+      # those tests read.
+      - name: Start PyKMIP
+        run: ./test/kmip/start-pykmip.sh "${{ runner.temp }}/kmip-certs" "$GITHUB_ENV"
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -106,6 +116,10 @@ jobs:
           # Tests RPC client against system rpcbind
           # Skips automatically if rpcbind unavailable or NFS already registered
           go test -tags=portmap_system -v -timeout=2m ./test/integration/portmap/...
+
+      - name: Dump PyKMIP logs on failure
+        if: failure()
+        run: docker logs dittofs-pykmip || true
 
       - name: Upload test logs on failure
         if: failure()

--- a/cmd/dfsctl/commands/store/block/remote/edit.go
+++ b/cmd/dfsctl/commands/store/block/remote/edit.go
@@ -208,10 +208,14 @@ func runEditInteractive(client *apiclient.Client, name string, current *apiclien
 		if newSecretKey != "" {
 			newConfig["secret_access_key"] = newSecretKey
 		}
-		// Carry forward server-side tuning the interactive prompts don't
-		// cover, so an interactive edit doesn't silently reset it.
-		if v, ok := currentConfig["parallel_uploads"]; ok {
-			newConfig["parallel_uploads"] = v
+		// Carry forward server-side settings the interactive prompts don't
+		// cover, so an interactive edit doesn't silently reset them. The
+		// encryption policy in particular has no edit prompt and no edit
+		// flag, so dropping it here would be unrecoverable from the CLI.
+		for _, key := range []string{"parallel_uploads", "encryption", "compression"} {
+			if v, ok := currentConfig[key]; ok {
+				newConfig[key] = v
+			}
 		}
 
 		req.Config = newConfig

--- a/docs/guide/encryption.md
+++ b/docs/guide/encryption.md
@@ -104,11 +104,13 @@ Argon2id parameters (m = 64 MiB, t = 3, p = 4) match the OWASP 2024 password-sto
 
 Read this section before turning encryption on in production.
 
-### Enable encryption at remote-store creation time only
+### Enable encryption at remote-store creation time only, and never remove it
 
 Adding an `encryption` block to a remote store that already contains plaintext blocks will make every existing block **permanently unreadable** through the share — `Get` will return `ErrCiphertextWithoutFrame` because the stored bytes lack the DFENC frame header. The decorator refuses to interpret unframed bytes on an encryption-enabled share; that is intentional (any other behaviour would let a tampered-S3 actor force a plaintext downgrade).
 
 Recommendation: create new remote stores with encryption enabled, migrate data across, then decommission the unencrypted store.
+
+The reverse direction is refused outright: an update that removes the `encryption` block from a store that has one returns `400 Bad Request`. Blocks already written carry a DFENC frame, and an undecorated store would hand that framed ciphertext back to clients as if it were plaintext without erroring anywhere. Changing the encryption policy in place — rotating the key, retiring an old one — stays allowed. To genuinely stop encrypting, create a new store and migrate onto it.
 
 ### Retiring a master key is one-way — you cannot un-retire what you deleted
 
@@ -150,6 +152,24 @@ Two operational notes:
   listing the same file twice, or listing the current key as retired, will
   produce.
 
+### A KMIP key that is not Active stops the share from starting
+
+The KMIP provider reads the object's **State** attribute (via read-only `GetAttributes`) before fetching any key material, and refuses to bring the encrypted store up unless the current `key_uid` is `Active`. `Deactivated`, `Compromised`, `Pre-Active` and `Destroyed` are all rejected, with the state and the uid named in the error. Revoking a key at the HSM is the standardised way of saying "stop using this", so it stops us using it; there is no read-only or degraded mode, and no way to override the check from config.
+
+The practical trap is `Deactivated`, which is the state a key normally enters when it is rotated out at the HSM end. If someone rotates in the HSM without moving `key_uid` on the DittoFS side, the share will not come back after its next restart. Rotate in both places, in that order.
+
+Retired uids are judged by a looser rule, because blocks already written under them have to stay readable:
+
+| State of a `retired_key_uids` entry | Behaviour |
+|---|---|
+| `Active`, `Deactivated`, `Pre-Active` | Loaded normally — `Deactivated` is the expected steady state for a retired key |
+| `Compromised` | Loaded, with a `WARN` recording that data is still being read under a compromised key. Treat that line as the trigger for a re-wrap decision |
+| `Destroyed` | Skipped, naming the state. The HSM has no material to return; blocks under that key are unreadable |
+
+A server that answers `GetAttributes` without a State attribute is treated as an error rather than as `Active` — an unreadable state is not evidence that the key is usable.
+
+Only a share whose store fails this way is affected: the daemon logs the refusal and starts without it, rather than failing the whole start. Note that a share skipped this way is currently visible only in the log — `dfsctl share list` will not flag it.
+
 ### AAD is per-block, not per-share
 
 The associated data bound into the AEAD is the 32-byte BLAKE3 plaintext hash. It binds ciphertext to its CAS address but does **not** bind it to a share identity. Two shares that reference the same remote store config — and therefore share the same master key — could decrypt each other's blocks if an attacker with direct object-store write access moved blocks between share namespaces. This is acceptable for the supported configuration (one remote-store config per workload) but is a hazard if you reuse one master key across security-domain-distinct shares. Do not do that.
@@ -159,4 +179,6 @@ The associated data bound into the AEAD is the 32-byte BLAKE3 plaintext hash. It
 - **Bulk re-wrap** — rotation works (see above), but there is no job that reads blocks under a retired key and rewrites them under the current one, and no way to enumerate which blocks still reference a given key. Both are required before a retired key can ever be safely dropped.
 - **Filename / size / timestamp encryption** — out of scope; metadata stays unencrypted.
 - **Encrypted disk cache tier** — current cache holds plaintext in RAM / disk; use an encrypted filesystem underneath if needed.
+- **Key provisioning over KMIP** — deliberate, not unfinished. The client only ever reads: `Get` and `GetAttributes`. It cannot `Create`, `Register`, `Activate`, `Revoke` or `Destroy`, so the credential DittoFS holds cannot be used to make or destroy key material, and provisioning stays an out-of-band operator responsibility. This mirrors how KMS-backed storage works elsewhere (S3 SSE-KMS calls `GenerateDataKey`/`Decrypt`; it does not create CMKs). Give the DittoFS client a read-only credential.
+- **`Locate` by key name** — resolving a human-readable key name to a uid is read-only and would be an ergonomics win, but is not implemented; configure the uid directly.
 - **FIPS 140-3 mode** — would require swapping Argon2id for PBKDF2-SHA256, pinning AES-only AEADs, and building with the BoringCrypto tag.

--- a/internal/controlplane/api/handlers/block_stores.go
+++ b/internal/controlplane/api/handlers/block_stores.go
@@ -257,7 +257,12 @@ func (h *BlockStoreHandler) Update(w http.ResponseWriter, r *http.Request) {
 		// frame. Dropping the policy does not fail anywhere downstream — the
 		// undecorated store would hand that framed ciphertext back as if it
 		// were plaintext — so the removal is refused here.
-		if hasEncryptionPolicy(previous) && !hasEncryptionPolicy(bs.Config) {
+		hadEncryption, _ := hasEncryptionPolicy(previous)
+		hasEncryption, parsed := hasEncryptionPolicy(bs.Config)
+		// An unparseable incoming blob is left to the config validation
+		// below, which reports the parse error rather than a removal the
+		// request may not have asked for.
+		if parsed && hadEncryption && !hasEncryption {
 			BadRequest(w, "Encryption cannot be removed from a block store once enabled: "+
 				"blocks already written are encrypted and would be served as ciphertext. "+
 				"Change the encryption policy instead, or move the share to a new block store.")

--- a/internal/controlplane/api/handlers/block_stores.go
+++ b/internal/controlplane/api/handlers/block_stores.go
@@ -250,8 +250,19 @@ func (h *BlockStoreHandler) Update(w http.ResponseWriter, r *http.Request) {
 		// Read paths redact secrets to "********"; reconcile any sentinel
 		// the client echoed back so we never overwrite a real credential
 		// with the redaction marker.
+		previous := bs.Config
 		bs.Config = mergeRedactedSecrets(bs.Config, *req.Config)
 		bs.ParsedConfig = nil
+		// Blocks already written to an encrypted store carry an encryption
+		// frame. Dropping the policy does not fail anywhere downstream — the
+		// undecorated store would hand that framed ciphertext back as if it
+		// were plaintext — so the removal is refused here.
+		if hasEncryptionPolicy(previous) && !hasEncryptionPolicy(bs.Config) {
+			BadRequest(w, "Encryption cannot be removed from a block store once enabled: "+
+				"blocks already written are encrypted and would be served as ciphertext. "+
+				"Change the encryption policy instead, or move the share to a new block store.")
+			return
+		}
 	}
 
 	// Re-validate on any type/config change so a no-op PUT does not

--- a/internal/controlplane/api/handlers/block_stores.go
+++ b/internal/controlplane/api/handlers/block_stores.go
@@ -257,6 +257,12 @@ func (h *BlockStoreHandler) Update(w http.ResponseWriter, r *http.Request) {
 		// frame. Dropping the policy does not fail anywhere downstream — the
 		// undecorated store would hand that framed ciphertext back as if it
 		// were plaintext — so the removal is refused here.
+		// The stored blob's parse result is discarded because an
+		// unparseable one cannot have carried a policy that was ever in
+		// effect: building the encrypted store parses the same blob and
+		// fails first, so no block was written under it. Neither write path
+		// can store such a blob either — validation below, and the same
+		// check on create, both parse before persisting.
 		hadEncryption, _ := hasEncryptionPolicy(previous)
 		hasEncryption, parsed := hasEncryptionPolicy(bs.Config)
 		// An unparseable incoming blob is left to the config validation

--- a/internal/controlplane/api/handlers/block_stores_test.go
+++ b/internal/controlplane/api/handlers/block_stores_test.go
@@ -915,7 +915,7 @@ func isValidHealthStatus(s health.Status) bool {
 // ciphertext back as plaintext, so an update that drops the policy is
 // refused. Changing the policy in place stays allowed.
 func TestBlockStoreHandler_Update_EncryptionCannotBeRemoved(t *testing.T) {
-	const encrypted = `{"bucket":"b","region":"us-east-1",` +
+	const encrypted = `{"bucket":"b","region":"us-east-1","access_key_id":"AK","secret_access_key":"SK",` +
 		`"encryption":{"algorithm":"aes-256-gcm","key":{"kind":"local","file":"/k.pem"}}}`
 
 	update := func(t *testing.T, initial, cfg string) *httptest.ResponseRecorder {
@@ -925,7 +925,7 @@ func TestBlockStoreHandler_Update_EncryptionCannotBeRemoved(t *testing.T) {
 			ID: uuid.New().String(), Name: "enc-test", Kind: models.BlockStoreKindRemote,
 			Type: "s3", Config: initial, CreatedAt: time.Now(),
 		}
-		if err := cpStore.CreateBlockStore(context.Background(), bs); err != nil {
+		if _, err := cpStore.CreateBlockStore(context.Background(), bs); err != nil {
 			t.Fatalf("CreateBlockStore: %v", err)
 		}
 		body, _ := json.Marshal(UpdateBlockStoreRequest{Config: &cfg})
@@ -938,14 +938,14 @@ func TestBlockStoreHandler_Update_EncryptionCannotBeRemoved(t *testing.T) {
 	}
 
 	t.Run("removal rejected", func(t *testing.T) {
-		w := update(t, encrypted, `{"bucket":"b","region":"eu-west-1"}`)
+		w := update(t, encrypted, `{"bucket":"b","region":"eu-west-1","access_key_id":"AK","secret_access_key":"SK"}`)
 		if w.Code != http.StatusBadRequest {
 			t.Fatalf("status = %d, want %d, body = %s", w.Code, http.StatusBadRequest, w.Body.String())
 		}
 	})
 
 	t.Run("policy change allowed", func(t *testing.T) {
-		w := update(t, encrypted, `{"bucket":"b","region":"eu-west-1",`+
+		w := update(t, encrypted, `{"bucket":"b","region":"eu-west-1","access_key_id":"AK","secret_access_key":"SK",`+
 			`"encryption":{"algorithm":"aes-256-gcm","key":{"kind":"local","file":"/k2.pem"}}}`)
 		if w.Code != http.StatusOK {
 			t.Fatalf("status = %d, want %d, body = %s", w.Code, http.StatusOK, w.Body.String())
@@ -953,7 +953,7 @@ func TestBlockStoreHandler_Update_EncryptionCannotBeRemoved(t *testing.T) {
 	})
 
 	t.Run("never encrypted stays editable", func(t *testing.T) {
-		w := update(t, `{"bucket":"b","region":"us-east-1"}`, `{"bucket":"b","region":"eu-west-1"}`)
+		w := update(t, `{"bucket":"b","region":"us-east-1","access_key_id":"AK","secret_access_key":"SK"}`, `{"bucket":"b","region":"eu-west-1","access_key_id":"AK","secret_access_key":"SK"}`)
 		if w.Code != http.StatusOK {
 			t.Fatalf("status = %d, want %d, body = %s", w.Code, http.StatusOK, w.Body.String())
 		}

--- a/internal/controlplane/api/handlers/block_stores_test.go
+++ b/internal/controlplane/api/handlers/block_stores_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	stdruntime "runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -956,6 +957,16 @@ func TestBlockStoreHandler_Update_EncryptionCannotBeRemoved(t *testing.T) {
 		w := update(t, encrypted, `{"bucket":"b","region":"eu-west-1","access_key_id":"AK","secret_access_key":"SK","encryption":null}`)
 		if w.Code != http.StatusBadRequest {
 			t.Fatalf("status = %d, want %d, body = %s", w.Code, http.StatusBadRequest, w.Body.String())
+		}
+	})
+
+	t.Run("unparseable config reports the parse error", func(t *testing.T) {
+		w := update(t, encrypted, `not json`)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d, body = %s", w.Code, http.StatusBadRequest, w.Body.String())
+		}
+		if strings.Contains(w.Body.String(), "cannot be removed") {
+			t.Fatalf("invalid JSON reported as an encryption removal: %s", w.Body.String())
 		}
 	})
 

--- a/internal/controlplane/api/handlers/block_stores_test.go
+++ b/internal/controlplane/api/handlers/block_stores_test.go
@@ -952,6 +952,13 @@ func TestBlockStoreHandler_Update_EncryptionCannotBeRemoved(t *testing.T) {
 		}
 	})
 
+	t.Run("nulling the policy is removal", func(t *testing.T) {
+		w := update(t, encrypted, `{"bucket":"b","region":"eu-west-1","access_key_id":"AK","secret_access_key":"SK","encryption":null}`)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d, body = %s", w.Code, http.StatusBadRequest, w.Body.String())
+		}
+	})
+
 	t.Run("never encrypted stays editable", func(t *testing.T) {
 		w := update(t, `{"bucket":"b","region":"us-east-1","access_key_id":"AK","secret_access_key":"SK"}`, `{"bucket":"b","region":"eu-west-1","access_key_id":"AK","secret_access_key":"SK"}`)
 		if w.Code != http.StatusOK {

--- a/internal/controlplane/api/handlers/block_stores_test.go
+++ b/internal/controlplane/api/handlers/block_stores_test.go
@@ -908,3 +908,54 @@ func isValidHealthStatus(s health.Status) bool {
 		return false
 	}
 }
+
+// TestBlockStoreHandler_Update_EncryptionCannotBeRemoved pins the
+// one-way door: blocks already written to an encrypted store carry an
+// encryption frame, and an undecorated store would hand that framed
+// ciphertext back as plaintext, so an update that drops the policy is
+// refused. Changing the policy in place stays allowed.
+func TestBlockStoreHandler_Update_EncryptionCannotBeRemoved(t *testing.T) {
+	const encrypted = `{"bucket":"b","region":"us-east-1",` +
+		`"encryption":{"algorithm":"aes-256-gcm","key":{"kind":"local","file":"/k.pem"}}}`
+
+	update := func(t *testing.T, initial, cfg string) *httptest.ResponseRecorder {
+		t.Helper()
+		cpStore, handler := setupBlockStoreTest(t)
+		bs := &models.BlockStoreConfig{
+			ID: uuid.New().String(), Name: "enc-test", Kind: models.BlockStoreKindRemote,
+			Type: "s3", Config: initial, CreatedAt: time.Now(),
+		}
+		if err := cpStore.CreateBlockStore(context.Background(), bs); err != nil {
+			t.Fatalf("CreateBlockStore: %v", err)
+		}
+		body, _ := json.Marshal(UpdateBlockStoreRequest{Config: &cfg})
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/store/block/remote/enc-test", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req = withBlockStoreKindAndName(req, "remote", "enc-test")
+		w := httptest.NewRecorder()
+		handler.Update(w, req)
+		return w
+	}
+
+	t.Run("removal rejected", func(t *testing.T) {
+		w := update(t, encrypted, `{"bucket":"b","region":"eu-west-1"}`)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d, body = %s", w.Code, http.StatusBadRequest, w.Body.String())
+		}
+	})
+
+	t.Run("policy change allowed", func(t *testing.T) {
+		w := update(t, encrypted, `{"bucket":"b","region":"eu-west-1",`+
+			`"encryption":{"algorithm":"aes-256-gcm","key":{"kind":"local","file":"/k2.pem"}}}`)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d, body = %s", w.Code, http.StatusOK, w.Body.String())
+		}
+	})
+
+	t.Run("never encrypted stays editable", func(t *testing.T) {
+		w := update(t, `{"bucket":"b","region":"us-east-1"}`, `{"bucket":"b","region":"eu-west-1"}`)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d, body = %s", w.Code, http.StatusOK, w.Body.String())
+		}
+	})
+}

--- a/internal/controlplane/api/handlers/helpers.go
+++ b/internal/controlplane/api/handlers/helpers.go
@@ -322,3 +322,15 @@ func HandleStoreError(w http.ResponseWriter, err error) {
 	status, msg := MapStoreError(err)
 	WriteProblem(w, status, http.StatusText(status), msg)
 }
+
+// hasEncryptionPolicy reports whether a block-store config blob carries an
+// "encryption" sub-config. A blob that will not parse reports false: there
+// is no policy to be read out of it either way.
+func hasEncryptionPolicy(blob string) bool {
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(blob), &obj); err != nil {
+		return false
+	}
+	_, ok := obj["encryption"]
+	return ok
+}

--- a/internal/controlplane/api/handlers/helpers.go
+++ b/internal/controlplane/api/handlers/helpers.go
@@ -325,12 +325,13 @@ func HandleStoreError(w http.ResponseWriter, err error) {
 
 // hasEncryptionPolicy reports whether a block-store config blob carries an
 // "encryption" sub-config. A blob that will not parse reports false: there
-// is no policy to be read out of it either way.
+// is no policy to be read out of it either way. A present-but-null value
+// reports false too, so nulling the key counts as removing it rather than
+// as keeping a policy that does not exist.
 func hasEncryptionPolicy(blob string) bool {
 	var obj map[string]any
 	if err := json.Unmarshal([]byte(blob), &obj); err != nil {
 		return false
 	}
-	_, ok := obj["encryption"]
-	return ok
+	return obj["encryption"] != nil
 }

--- a/internal/controlplane/api/handlers/helpers.go
+++ b/internal/controlplane/api/handlers/helpers.go
@@ -324,14 +324,15 @@ func HandleStoreError(w http.ResponseWriter, err error) {
 }
 
 // hasEncryptionPolicy reports whether a block-store config blob carries an
-// "encryption" sub-config. A blob that will not parse reports false: there
-// is no policy to be read out of it either way. A present-but-null value
-// reports false too, so nulling the key counts as removing it rather than
-// as keeping a policy that does not exist.
-func hasEncryptionPolicy(blob string) bool {
+// "encryption" sub-config, and whether the blob parsed at all. A
+// present-but-null value counts as absent, so nulling the key reads as
+// removing it rather than as keeping a policy that does not exist. A blob
+// that will not parse answers (false, false): callers that care about a
+// policy disappearing must not read a parse failure as its removal.
+func hasEncryptionPolicy(blob string) (present, parsed bool) {
 	var obj map[string]any
 	if err := json.Unmarshal([]byte(blob), &obj); err != nil {
-		return false
+		return false, false
 	}
-	return obj["encryption"] != nil
+	return obj["encryption"] != nil, true
 }

--- a/pkg/block/encryption/keyprovider/kmip.go
+++ b/pkg/block/encryption/keyprovider/kmip.go
@@ -16,6 +16,8 @@ import (
 	"github.com/gemalto/kmip-go"
 	"github.com/gemalto/kmip-go/kmip14"
 	"github.com/gemalto/kmip-go/ttlv"
+
+	"github.com/marmos91/dittofs/internal/logger"
 )
 
 // kmipDefaultTimeout bounds a single Get round-trip against the KMIP
@@ -59,13 +61,42 @@ func newKMIPProvider(ctx context.Context, cfg Config) (*kmipProvider, error) {
 	if cfg.TimeoutMS > 0 {
 		timeout = time.Duration(cfg.TimeoutMS) * time.Millisecond
 	}
+	// The state check runs before the Get so that key material the HSM has
+	// disowned is never pulled into this process at all.
+	state, err := fetchKMIPKeyState(ctx, cfg.Endpoint, tlsCfg, cfg.KeyUID, timeout)
+	if err != nil {
+		return nil, err
+	}
+	if state != kmip14.StateActive {
+		return nil, fmt.Errorf("%w: kmip key %q is in state %s at the HSM, not Active; "+
+			"the encrypted remote will not come up until the configured key_uid names an Active key",
+			ErrKeyStateUnusable, cfg.KeyUID, state)
+	}
 	key, err := fetchKMIPKey(ctx, cfg, tlsCfg, cfg.KeyUID, timeout)
 	if err != nil {
 		return nil, err
 	}
 	// A KMIP key is identified by the uid the operator configured, so a
 	// retired uid is its own master key id with nothing to look up.
+	//
+	// A retired key is decrypt-only, so states that would disqualify the
+	// current key do not disqualify it: blocks already written under it
+	// still have to be readable. Only a key whose material the HSM has
+	// destroyed is unusable, and a compromised one is loaded with a loud
+	// warning because it is the input to a re-wrap decision.
 	retired, err := loadRetiredKeys(cfg.KeyUID, cfg.RetiredKeyUIDs, func(uid string) (string, []byte, error) {
+		state, err := fetchKMIPKeyState(ctx, cfg.Endpoint, tlsCfg, uid, timeout)
+		if err != nil {
+			return uid, nil, err
+		}
+		switch state {
+		case kmip14.StateDestroyed, kmip14.StateDestroyedCompromised:
+			return uid, nil, fmt.Errorf("%w: kmip key %q is in state %s at the HSM, so its material is gone",
+				ErrKeyStateUnusable, uid, state)
+		case kmip14.StateCompromised:
+			logger.Warn("retired master key is marked Compromised at the HSM; blocks already written are still being read under it",
+				"key_uid", uid)
+		}
 		k, err := fetchKMIPKey(ctx, cfg, tlsCfg, uid, timeout)
 		return uid, k, err
 	})
@@ -116,10 +147,75 @@ func buildKMIPTLSConfig(cfg Config) (*tls.Config, error) {
 	return tlsCfg, nil
 }
 
-// fetchKMIPSymmetricKey opens a TLS connection to the KMIP server, sends
-// a single Get request for the configured unique identifier, and returns
-// the raw key material bytes. The connection is closed before return.
+// fetchKMIPSymmetricKey asks the KMIP server for the object stored under
+// the configured unique identifier and returns its raw key material.
 func fetchKMIPSymmetricKey(ctx context.Context, endpoint string, tlsCfg *tls.Config, keyUID string, timeout time.Duration) ([]byte, error) {
+	raw, err := kmipRoundTrip(ctx, endpoint, tlsCfg, timeout,
+		kmip14.OperationGet, kmip.GetRequestPayload{UniqueIdentifier: keyUID})
+	if err != nil {
+		return nil, err
+	}
+	var payload kmip.GetResponsePayload
+	if err := ttlv.Unmarshal(raw, &payload); err != nil {
+		return nil, fmt.Errorf("keyprovider: kmip decode Get payload: %w", err)
+	}
+	if payload.ObjectType != kmip14.ObjectTypeSymmetricKey {
+		return nil, fmt.Errorf("keyprovider: kmip key %s is not a symmetric key (got object type %d)", keyUID, payload.ObjectType)
+	}
+	if payload.SymmetricKey == nil {
+		return nil, errors.New("keyprovider: kmip Get response missing SymmetricKey")
+	}
+	return extractSymmetricKeyMaterial(payload.SymmetricKey.KeyBlock.KeyValue)
+}
+
+// kmipGetAttributesRequestPayload and kmipGetAttributesResponsePayload
+// carry the GetAttributes operation, which the KMIP library models no
+// types for. GetAttributes is read-only: it reports on an object and can
+// neither create nor modify one, so the client credential needs no write
+// capability at the HSM.
+type kmipGetAttributesRequestPayload struct {
+	UniqueIdentifier string
+	AttributeName    []string
+}
+
+type kmipGetAttributesResponsePayload struct {
+	UniqueIdentifier string
+	Attribute        []kmip.Attribute
+}
+
+// fetchKMIPKeyState reads the KMIP State attribute of one object. The
+// State is how an HSM says "stop using this" — an operator who revokes a
+// key expects that to reach every consumer of it — so a state that cannot
+// be read is an error rather than an assumed Active.
+func fetchKMIPKeyState(ctx context.Context, endpoint string, tlsCfg *tls.Config, keyUID string, timeout time.Duration) (kmip14.State, error) {
+	stateName := kmip14.TagState.CanonicalName()
+	raw, err := kmipRoundTrip(ctx, endpoint, tlsCfg, timeout,
+		kmip14.OperationGetAttributes,
+		kmipGetAttributesRequestPayload{UniqueIdentifier: keyUID, AttributeName: []string{stateName}})
+	if err != nil {
+		return 0, err
+	}
+	var payload kmipGetAttributesResponsePayload
+	if err := ttlv.Unmarshal(raw, &payload); err != nil {
+		return 0, fmt.Errorf("keyprovider: kmip decode GetAttributes payload: %w", err)
+	}
+	for _, attr := range payload.Attribute {
+		if attr.AttributeName != stateName {
+			continue
+		}
+		value, ok := attr.AttributeValue.(ttlv.EnumValue)
+		if !ok {
+			return 0, fmt.Errorf("keyprovider: kmip key %s State attribute has unexpected go type %T", keyUID, attr.AttributeValue)
+		}
+		return kmip14.State(value), nil
+	}
+	return 0, fmt.Errorf("keyprovider: kmip key %s returned no State attribute", keyUID)
+}
+
+// kmipRoundTrip opens a TLS connection to the KMIP server, sends a
+// single-item batch carrying one operation, and returns that item's
+// response payload. The connection is closed before return.
+func kmipRoundTrip(ctx context.Context, endpoint string, tlsCfg *tls.Config, timeout time.Duration, op kmip14.Operation, reqPayload any) (ttlv.TTLV, error) {
 	dialer := &net.Dialer{Timeout: timeout}
 	conn, err := tls.DialWithDialer(dialer, "tcp", endpoint, tlsCfg)
 	if err != nil {
@@ -140,8 +236,8 @@ func fetchKMIPSymmetricKey(ctx context.Context, endpoint string, tlsCfg *tls.Con
 			BatchCount:      1,
 		},
 		BatchItem: []kmip.RequestBatchItem{{
-			Operation:      kmip14.OperationGet,
-			RequestPayload: kmip.GetRequestPayload{UniqueIdentifier: keyUID},
+			Operation:      op,
+			RequestPayload: reqPayload,
 		}},
 	}
 	reqTTLV, err := ttlv.Marshal(req)
@@ -165,24 +261,14 @@ func fetchKMIPSymmetricKey(ctx context.Context, endpoint string, tlsCfg *tls.Con
 	}
 	item := resp.BatchItem[0]
 	if item.ResultStatus != kmip14.ResultStatusSuccess {
-		return nil, fmt.Errorf("keyprovider: kmip Get failed: status=%d reason=%d message=%q",
-			item.ResultStatus, item.ResultReason, item.ResultMessage)
+		return nil, fmt.Errorf("keyprovider: kmip %v failed: status=%d reason=%d message=%q",
+			op, item.ResultStatus, item.ResultReason, item.ResultMessage)
 	}
-	var payload kmip.GetResponsePayload
 	raw, ok := item.ResponsePayload.(ttlv.TTLV)
 	if !ok {
-		return nil, fmt.Errorf("keyprovider: kmip Get payload is not TTLV (got %T)", item.ResponsePayload)
+		return nil, fmt.Errorf("keyprovider: kmip %v payload is not TTLV (got %T)", op, item.ResponsePayload)
 	}
-	if err := ttlv.Unmarshal(raw, &payload); err != nil {
-		return nil, fmt.Errorf("keyprovider: kmip decode Get payload: %w", err)
-	}
-	if payload.ObjectType != kmip14.ObjectTypeSymmetricKey {
-		return nil, fmt.Errorf("keyprovider: kmip key %s is not a symmetric key (got object type %d)", keyUID, payload.ObjectType)
-	}
-	if payload.SymmetricKey == nil {
-		return nil, errors.New("keyprovider: kmip Get response missing SymmetricKey")
-	}
-	return extractSymmetricKeyMaterial(payload.SymmetricKey.KeyBlock.KeyValue)
+	return raw, nil
 }
 
 // extractSymmetricKeyMaterial pulls the raw byte material out of a KMIP

--- a/pkg/block/encryption/keyprovider/kmip.go
+++ b/pkg/block/encryption/keyprovider/kmip.go
@@ -78,13 +78,28 @@ func newKMIPProvider(ctx context.Context, cfg Config) (*kmipProvider, error) {
 	}
 	// A KMIP key is identified by the uid the operator configured, so a
 	// retired uid is its own master key id with nothing to look up.
-	//
-	// A retired key is decrypt-only, so states that would disqualify the
-	// current key do not disqualify it: blocks already written under it
-	// still have to be readable. Only a key whose material the HSM has
-	// destroyed is unusable, and a compromised one is loaded with a loud
-	// warning because it is the input to a re-wrap decision.
-	retired, err := loadRetiredKeys(cfg.KeyUID, cfg.RetiredKeyUIDs, func(uid string) (string, []byte, error) {
+	retired, err := loadRetiredKeys(cfg.KeyUID, cfg.RetiredKeyUIDs, kmipRetiredKeyLoader(ctx, cfg, tlsCfg, timeout))
+	if err != nil {
+		zeroKey(key)
+		return nil, err
+	}
+	return &kmipProvider{aesGCMKEK: aesGCMKEK{
+		masterKey:   key,
+		masterKeyID: cfg.KeyUID,
+		retired:     retired,
+	}}, nil
+}
+
+// kmipRetiredKeyLoader resolves one retired uid into its key material.
+//
+// A retired key is decrypt-only, so states that disqualify the current key
+// do not disqualify it: blocks already written under it still have to be
+// readable. Only a key whose material the HSM has destroyed is unusable,
+// and it says so in those terms rather than surfacing as a generic fetch
+// failure. A compromised one is loaded with a loud warning, because it is
+// the input to a re-wrap decision.
+func kmipRetiredKeyLoader(ctx context.Context, cfg Config, tlsCfg *tls.Config, timeout time.Duration) retiredKeyLoader {
+	return func(uid string) (string, []byte, error) {
 		state, err := fetchKMIPKeyState(ctx, cfg.Endpoint, tlsCfg, uid, timeout)
 		if err != nil {
 			return uid, nil, err
@@ -99,16 +114,7 @@ func newKMIPProvider(ctx context.Context, cfg Config) (*kmipProvider, error) {
 		}
 		k, err := fetchKMIPKey(ctx, cfg, tlsCfg, uid, timeout)
 		return uid, k, err
-	})
-	if err != nil {
-		zeroKey(key)
-		return nil, err
 	}
-	return &kmipProvider{aesGCMKEK: aesGCMKEK{
-		masterKey:   key,
-		masterKeyID: cfg.KeyUID,
-		retired:     retired,
-	}}, nil
 }
 
 // fetchKMIPKey retrieves one symmetric key from the HSM and enforces the

--- a/pkg/block/encryption/keyprovider/kmip_fake_test.go
+++ b/pkg/block/encryption/keyprovider/kmip_fake_test.go
@@ -215,6 +215,8 @@ func (s *fakeKMIPServer) serve(t *testing.T, conn net.Conn) {
 		if !ok {
 			state = kmip14.StateActive
 		}
+		// State zero is not a KMIP state; the table uses it to ask for a
+		// GetAttributes reply that carries no State attribute at all.
 		_, _ = conn.Write(kmipStateResponse(t, payload.UniqueIdentifier, state))
 		return
 	}
@@ -236,6 +238,10 @@ func (s *fakeKMIPServer) serve(t *testing.T, conn net.Conn) {
 // State enumeration for a uid.
 func kmipStateResponse(t *testing.T, keyUID string, state kmip14.State) ttlv.TTLV {
 	t.Helper()
+	payload := kmipGetAttributesResponsePayload{UniqueIdentifier: keyUID}
+	if state != 0 {
+		payload.Attribute = []kmip.Attribute{kmip.NewAttributeFromTag(kmip14.TagState, 0, state)}
+	}
 	resp := kmip.ResponseMessage{
 		ResponseHeader: kmip.ResponseHeader{
 			ProtocolVersion: kmip.ProtocolVersion{ProtocolVersionMajor: 1, ProtocolVersionMinor: 4},
@@ -243,12 +249,9 @@ func kmipStateResponse(t *testing.T, keyUID string, state kmip14.State) ttlv.TTL
 			BatchCount:      1,
 		},
 		BatchItem: []kmip.ResponseBatchItem{{
-			Operation:    kmip14.OperationGetAttributes,
-			ResultStatus: kmip14.ResultStatusSuccess,
-			ResponsePayload: kmipGetAttributesResponsePayload{
-				UniqueIdentifier: keyUID,
-				Attribute:        []kmip.Attribute{kmip.NewAttributeFromTag(kmip14.TagState, 0, state)},
-			},
+			Operation:       kmip14.OperationGetAttributes,
+			ResultStatus:    kmip14.ResultStatusSuccess,
+			ResponsePayload: payload,
 		}},
 	}
 	raw, err := ttlv.Marshal(resp)
@@ -602,4 +605,99 @@ func TestReadKMIPMessage(t *testing.T) {
 			t.Errorf("frame length = %d, want %d", len(out), len(full))
 		}
 	})
+}
+
+// kmipStateEnv builds a KMIP config plus a fake server whose uid → State
+// table the caller controls, for the states a PyKMIP server cannot be put
+// into.
+func kmipStateEnv(t *testing.T, states map[string]kmip14.State, gets ...ttlv.TTLV) Config {
+	t.Helper()
+	dir := t.TempDir()
+	srvCert, srvKey, srvPEM := genSelfSigned(t, dir, "server")
+	cliCert, cliKey, _ := genSelfSigned(t, dir, "client")
+	caPath := filepath.Join(dir, "ca.pem")
+	if err := os.WriteFile(caPath, srvPEM, 0o600); err != nil {
+		t.Fatalf("write ca: %v", err)
+	}
+	srv := startFakeKMIPStates(t, serverTLSConfig(t, srvCert, srvKey), states, gets...)
+	return Config{
+		Kind:       KindKMIP,
+		Endpoint:   srv.addr(),
+		ClientCert: cliCert,
+		ClientKey:  cliKey,
+		ServerCA:   caPath,
+		TimeoutMS:  5000,
+	}
+}
+
+// TestKMIP_CurrentKeyDestroyedRefused covers the one current-key state a
+// PyKMIP server cannot be put into: its Destroy deletes the object
+// outright, so only the fake can report State Destroyed.
+func TestKMIP_CurrentKeyDestroyedRefused(t *testing.T) {
+	material := bytes.Repeat([]byte{0xE5}, 32)
+	for _, state := range []kmip14.State{kmip14.StateDestroyed, kmip14.StateDestroyedCompromised} {
+		t.Run(state.String(), func(t *testing.T) {
+			cfg := kmipStateEnv(t, map[string]kmip14.State{"uid-1": state},
+				kmipSuccessResponse(t, "uid-1", material))
+			cfg.KeyUID = "uid-1"
+			p, err := newKMIPProvider(context.Background(), cfg)
+			if err == nil {
+				_ = p.Close()
+				t.Fatalf("newKMIPProvider accepted a %s current key", state)
+			}
+			if !errors.Is(err, ErrKeyStateUnusable) {
+				t.Fatalf("error = %v, want ErrKeyStateUnusable", err)
+			}
+		})
+	}
+}
+
+// TestKMIP_RetiredDestroyedKeyDegrades pins the retired-key half: a
+// destroyed uid costs access to the blocks under it rather than the whole
+// provider, and says so in terms of the state.
+func TestKMIP_RetiredDestroyedKeyDegrades(t *testing.T) {
+	material := bytes.Repeat([]byte{0xE6}, 32)
+	cfg := kmipStateEnv(t, map[string]kmip14.State{"uid-old": kmip14.StateDestroyed},
+		kmipSuccessResponse(t, "uid-new", material))
+	cfg.KeyUID = "uid-new"
+	cfg.RetiredKeyUIDs = []string{"uid-old"}
+
+	tlsCfg, err := buildKMIPTLSConfig(cfg)
+	if err != nil {
+		t.Fatalf("buildKMIPTLSConfig: %v", err)
+	}
+	_, _, err = kmipRetiredKeyLoader(context.Background(), cfg, tlsCfg, 5*time.Second)("uid-old")
+	if !errors.Is(err, ErrKeyStateUnusable) {
+		t.Fatalf("retired loader error = %v, want ErrKeyStateUnusable", err)
+	}
+	if !strings.Contains(err.Error(), kmip14.StateDestroyed.String()) {
+		t.Fatalf("error %q should name the Destroyed state", err)
+	}
+
+	p, err := newKMIPProvider(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("newKMIPProvider with a destroyed retired uid: %v, want success", err)
+	}
+	t.Cleanup(func() { _ = p.Close() })
+	if len(p.retired) != 0 {
+		t.Fatalf("retired set holds %d keys, want 0", len(p.retired))
+	}
+}
+
+// TestKMIP_MissingStateAttribute pins the fail-closed rule: a server that
+// answers GetAttributes without a State leaves the provider unable to tell
+// whether the key is usable, and an unknown state is not treated as Active.
+func TestKMIP_MissingStateAttribute(t *testing.T) {
+	material := bytes.Repeat([]byte{0xE7}, 32)
+	cfg := kmipStateEnv(t, map[string]kmip14.State{"uid-1": 0},
+		kmipSuccessResponse(t, "uid-1", material))
+	cfg.KeyUID = "uid-1"
+	p, err := newKMIPProvider(context.Background(), cfg)
+	if err == nil {
+		_ = p.Close()
+		t.Fatal("newKMIPProvider accepted a key whose state could not be read")
+	}
+	if !strings.Contains(err.Error(), "no State attribute") {
+		t.Fatalf("error %q should say the State attribute was missing", err)
+	}
 }

--- a/pkg/block/encryption/keyprovider/kmip_fake_test.go
+++ b/pkg/block/encryption/keyprovider/kmip_fake_test.go
@@ -71,14 +71,17 @@ func genSelfSigned(t *testing.T, dir, name string) (certPath, keyPath string, ce
 	return certPath, keyPath, certPEM
 }
 
-// fakeKMIPServer is a single-shot TLS listener that answers exactly one
-// KMIP Get request with a server-provided ResponseMessage. It speaks the
-// minimal subset of the protocol the provider drives: read one framed TTLV
-// request, write one framed TTLV response.
+// fakeKMIPServer is a TLS listener that answers KMIP requests by
+// operation: GetAttributes is answered from a uid → State table, Get from
+// a queue of canned responses consumed in order. It speaks the minimal
+// subset of the protocol the provider drives — read one framed TTLV
+// request per connection, write one framed TTLV response.
 type fakeKMIPServer struct {
-	ln   net.Listener
-	resp ttlv.TTLV // pre-marshalled response to send back
-	wg   sync.WaitGroup
+	ln     net.Listener
+	states map[string]kmip14.State // uid -> State; absent means Active
+	gets   []ttlv.TTLV             // Get responses, consumed in order
+	mu     sync.Mutex
+	wg     sync.WaitGroup
 }
 
 // kmipSuccessResponse marshals a Get ResponseMessage carrying a symmetric
@@ -141,42 +144,41 @@ func kmipFailureResponse(t *testing.T) ttlv.TTLV {
 	return raw
 }
 
-// startFakeKMIP runs a TLS listener that answers one connection with resp.
+// startFakeKMIP runs a TLS listener that answers one Get with resp.
 func startFakeKMIP(t *testing.T, tlsCfg *tls.Config, resp ttlv.TTLV) *fakeKMIPServer {
 	t.Helper()
 	return startFakeKMIPSeq(t, tlsCfg, resp)
 }
 
-// startFakeKMIPSeq answers one connection per response, in order. Each
-// fetchKMIPSymmetricKey call dials afresh, so a provider that fetches a
-// current key plus N retired uids consumes N+1 responses in the order the
-// uids are configured. Callers that need only one exchange use
-// startFakeKMIP.
+// startFakeKMIPSeq answers each Get with the next queued response, in
+// order. The provider fetches the current key first and then each retired
+// uid, so N retired uids consume N+1 responses. Every uid reports State
+// Active; use startFakeKMIPStates to vary that.
 func startFakeKMIPSeq(t *testing.T, tlsCfg *tls.Config, resps ...ttlv.TTLV) *fakeKMIPServer {
+	t.Helper()
+	return startFakeKMIPStates(t, tlsCfg, nil, resps...)
+}
+
+// startFakeKMIPStates is startFakeKMIPSeq with a uid → State table for the
+// GetAttributes requests the provider issues before each Get. A uid absent
+// from the table reports Active.
+func startFakeKMIPStates(t *testing.T, tlsCfg *tls.Config, states map[string]kmip14.State, resps ...ttlv.TTLV) *fakeKMIPServer {
 	t.Helper()
 	ln, err := tls.Listen("tcp", "127.0.0.1:0", tlsCfg)
 	if err != nil {
 		t.Fatalf("tls.Listen: %v", err)
 	}
-	s := &fakeKMIPServer{ln: ln}
-	if len(resps) > 0 {
-		s.resp = resps[0]
-	}
+	s := &fakeKMIPServer{ln: ln, states: states, gets: resps}
 	s.wg.Add(1)
 	go func() {
 		defer s.wg.Done()
-		for _, resp := range resps {
+		for {
 			conn, err := ln.Accept()
 			if err != nil {
 				return // listener closed
 			}
 			_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
-			// Drain the request: read one framed TTLV so we don't reply
-			// before the client finishes writing (avoids a RST on some
-			// platforms).
-			if _, err := readOneFrame(conn); err == nil {
-				_, _ = conn.Write(resp)
-			}
+			s.serve(t, conn)
 			_ = conn.Close()
 		}
 	}()
@@ -185,6 +187,75 @@ func startFakeKMIPSeq(t *testing.T, tlsCfg *tls.Config, resps ...ttlv.TTLV) *fak
 		s.wg.Wait()
 	})
 	return s
+}
+
+// serve answers one request off conn. Reading the request in full before
+// replying keeps the client from seeing an RST mid-write.
+func (s *fakeKMIPServer) serve(t *testing.T, conn net.Conn) {
+	t.Helper()
+	frame, err := readOneFrame(conn)
+	if err != nil {
+		return
+	}
+	var req kmip.RequestMessage
+	if err := ttlv.Unmarshal(ttlv.TTLV(frame), &req); err != nil || len(req.BatchItem) == 0 {
+		return
+	}
+	item := req.BatchItem[0]
+	if item.Operation == kmip14.OperationGetAttributes {
+		var payload kmipGetAttributesRequestPayload
+		raw, ok := item.RequestPayload.(ttlv.TTLV)
+		if !ok {
+			return
+		}
+		if err := ttlv.Unmarshal(raw, &payload); err != nil {
+			return
+		}
+		state, ok := s.states[payload.UniqueIdentifier]
+		if !ok {
+			state = kmip14.StateActive
+		}
+		_, _ = conn.Write(kmipStateResponse(t, payload.UniqueIdentifier, state))
+		return
+	}
+	// Anything else is a Get: hand back the next queued response, or
+	// nothing at all when the queue is exhausted, which the client sees as
+	// an unreadable key.
+	s.mu.Lock()
+	var resp ttlv.TTLV
+	if len(s.gets) > 0 {
+		resp, s.gets = s.gets[0], s.gets[1:]
+	}
+	s.mu.Unlock()
+	if resp != nil {
+		_, _ = conn.Write(resp)
+	}
+}
+
+// kmipStateResponse marshals a GetAttributes ResponseMessage reporting one
+// State enumeration for a uid.
+func kmipStateResponse(t *testing.T, keyUID string, state kmip14.State) ttlv.TTLV {
+	t.Helper()
+	resp := kmip.ResponseMessage{
+		ResponseHeader: kmip.ResponseHeader{
+			ProtocolVersion: kmip.ProtocolVersion{ProtocolVersionMajor: 1, ProtocolVersionMinor: 4},
+			TimeStamp:       time.Now(),
+			BatchCount:      1,
+		},
+		BatchItem: []kmip.ResponseBatchItem{{
+			Operation:    kmip14.OperationGetAttributes,
+			ResultStatus: kmip14.ResultStatusSuccess,
+			ResponsePayload: kmipGetAttributesResponsePayload{
+				UniqueIdentifier: keyUID,
+				Attribute:        []kmip.Attribute{kmip.NewAttributeFromTag(kmip14.TagState, 0, state)},
+			},
+		}},
+	}
+	raw, err := ttlv.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal kmip state response: %v", err)
+	}
+	return raw
 }
 
 func (s *fakeKMIPServer) addr() string { return s.ln.Addr().String() }

--- a/pkg/block/encryption/keyprovider/kmip_test.go
+++ b/pkg/block/encryption/keyprovider/kmip_test.go
@@ -5,7 +5,10 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strings"
 	"testing"
+
+	"github.com/gemalto/kmip-go/kmip14"
 )
 
 // requireKMIPEnv gates KMIP integration tests behind DITTOFS_TEST_KMIP=1
@@ -53,6 +56,107 @@ func TestKMIP_WrapUnwrapRoundTrip(t *testing.T) {
 	}
 	if !bytes.Equal(got, blockKey) {
 		t.Fatalf("Unwrap returned %x, want %x", got, blockKey)
+	}
+}
+
+// kmipStateUID returns the uid of a key the live server holds in a
+// particular state, or skips when the harness did not provision one. The
+// states come from test/kmip/provision.py.
+func kmipStateUID(t *testing.T, envVar string) string {
+	t.Helper()
+	uid := os.Getenv(envVar)
+	if uid == "" {
+		t.Skipf("%s required", envVar)
+	}
+	return uid
+}
+
+// TestKMIP_RetiredUIDStillUnwrapsLive is the rotation property against a
+// real server: a block wrapped under one uid still unwraps after the
+// current uid has moved on and the first is listed as retired.
+func TestKMIP_RetiredUIDStillUnwrapsLive(t *testing.T) {
+	cfg := requireKMIPEnv(t)
+	newUID := kmipStateUID(t, "DITTOFS_TEST_KMIP_RETIRED_KEY_UID")
+
+	before, err := newKMIPProvider(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("newKMIPProvider(pre-rotation): %v", err)
+	}
+	blockKey := bytes.Repeat([]byte{0x44}, 32)
+	wrapped, oldID, err := before.Wrap(context.Background(), blockKey)
+	if err != nil {
+		t.Fatalf("Wrap: %v", err)
+	}
+	_ = before.Close()
+
+	rotated := cfg
+	rotated.KeyUID = newUID
+	rotated.RetiredKeyUIDs = []string{cfg.KeyUID}
+	after, err := newKMIPProvider(context.Background(), rotated)
+	if err != nil {
+		t.Fatalf("newKMIPProvider(rotated): %v", err)
+	}
+	t.Cleanup(func() { _ = after.Close() })
+
+	if after.CurrentMasterKeyID() != newUID {
+		t.Fatalf("current master key id = %q, want %q", after.CurrentMasterKeyID(), newUID)
+	}
+	got, err := after.Unwrap(context.Background(), wrapped, oldID)
+	if err != nil {
+		t.Fatalf("Unwrap of pre-rotation block: %v", err)
+	}
+	if !bytes.Equal(got, blockKey) {
+		t.Fatalf("Unwrap returned %x, want %x", got, blockKey)
+	}
+}
+
+// TestKMIP_CurrentKeyStateRefusedLive pins the refusal against a real
+// server: a current key the HSM has moved out of Active keeps the
+// encrypted remote from coming up, and the error names both the state and
+// the uid so an operator can act on it.
+func TestKMIP_CurrentKeyStateRefusedLive(t *testing.T) {
+	base := requireKMIPEnv(t)
+	for _, tc := range []struct {
+		envVar string
+		state  kmip14.State
+	}{
+		{"DITTOFS_TEST_KMIP_DEACTIVATED_KEY_UID", kmip14.StateDeactivated},
+		{"DITTOFS_TEST_KMIP_COMPROMISED_KEY_UID", kmip14.StateCompromised},
+		{"DITTOFS_TEST_KMIP_PREACTIVE_KEY_UID", kmip14.StatePreActive},
+	} {
+		t.Run(tc.state.String(), func(t *testing.T) {
+			cfg := base
+			cfg.KeyUID = kmipStateUID(t, tc.envVar)
+			p, err := newKMIPProvider(context.Background(), cfg)
+			if err == nil {
+				_ = p.Close()
+				t.Fatalf("newKMIPProvider accepted a %s current key", tc.state)
+			}
+			if !errors.Is(err, ErrKeyStateUnusable) {
+				t.Fatalf("error = %v, want ErrKeyStateUnusable", err)
+			}
+			if !strings.Contains(err.Error(), tc.state.String()) || !strings.Contains(err.Error(), cfg.KeyUID) {
+				t.Fatalf("error %q should name both the state %q and the uid %q", err, tc.state, cfg.KeyUID)
+			}
+		})
+	}
+}
+
+// TestKMIP_RetiredCompromisedKeyLoadsLive covers the other half of the
+// state policy: a retired key the HSM marks Compromised is still loaded,
+// because the blocks written under it have to stay readable.
+func TestKMIP_RetiredCompromisedKeyLoadsLive(t *testing.T) {
+	cfg := requireKMIPEnv(t)
+	compromised := kmipStateUID(t, "DITTOFS_TEST_KMIP_COMPROMISED_KEY_UID")
+	cfg.RetiredKeyUIDs = []string{compromised}
+
+	p, err := newKMIPProvider(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("newKMIPProvider with a compromised retired uid: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Close() })
+	if _, ok := p.retired[compromised]; !ok {
+		t.Fatalf("retired set does not hold %q; a compromised retired key must stay readable", compromised)
 	}
 }
 

--- a/pkg/block/encryption/keyprovider/provider.go
+++ b/pkg/block/encryption/keyprovider/provider.go
@@ -114,6 +114,12 @@ var (
 	// ErrKeyFileCorrupt indicates a local key file failed to parse — bad
 	// PEM, bad JSON, or out-of-range KDF parameters.
 	ErrKeyFileCorrupt = errors.New("keyprovider: key file corrupt")
+
+	// ErrKeyStateUnusable indicates an external key store reports the key
+	// in a state that forbids the use being made of it: a current master
+	// key that is anything other than Active, or a retired one whose
+	// material the store has destroyed.
+	ErrKeyStateUnusable = errors.New("keyprovider: key state unusable")
 )
 
 // NewProvider constructs a KeyProvider from the parsed Config. Dispatch

--- a/test/kmip/gen-certs.sh
+++ b/test/kmip/gen-certs.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Generates the CA, server and client certificates the PyKMIP container and
+# the Go client authenticate each other with. Output goes to $1 (default
+# ./certs). Everything is throwaway test material with a 2-day lifetime.
+#
+# The keys are ECDSA P-256 rather than RSA on purpose. PyKMIP's "TLS1.2"
+# authentication suite advertises exactly two AEAD cipher suites,
+# ECDHE-ECDSA-AES128-GCM-SHA256 and ECDHE-ECDSA-AES256-GCM-SHA384; every
+# RSA-authenticated entry in that suite is CBC-SHA256, which Go removed
+# from its default TLS 1.2 cipher list. With an RSA server certificate the
+# two sides share no cipher suite and the handshake fails outright.
+set -euo pipefail
+
+OUT="${1:-$(dirname "$0")/certs}"
+mkdir -p "$OUT"
+
+openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 -nodes -days 2 \
+  -keyout "$OUT/ca-key.pem" -out "$OUT/ca-cert.pem" \
+  -subj "/CN=dittofs-kmip-test-ca" >/dev/null 2>&1
+
+gen() {
+  local name="$1" cn="$2" eku="$3" san="$4"
+  openssl req -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 -nodes \
+    -keyout "$OUT/$name-key.pem" -out "$OUT/$name.csr" \
+    -subj "/CN=$cn" >/dev/null 2>&1
+  openssl x509 -req -in "$OUT/$name.csr" -days 2 \
+    -CA "$OUT/ca-cert.pem" -CAkey "$OUT/ca-key.pem" -CAcreateserial \
+    -out "$OUT/$name-cert.pem" \
+    -extfile <(printf 'extendedKeyUsage=%s\nsubjectAltName=%s\n' "$eku" "$san") \
+    >/dev/null 2>&1
+  rm -f "$OUT/$name.csr"
+}
+
+gen server dittofs-kmip-server serverAuth "DNS:localhost,IP:127.0.0.1"
+# PyKMIP derives the client identity from the certificate common name and
+# makes that identity the owner of every object it creates, so the
+# provisioning script and the Go tests have to present this same
+# certificate or the Get is denied by the default access policy.
+gen client dittofs-kmip-client clientAuth "DNS:dittofs-kmip-client"
+
+chmod 0600 "$OUT"/*-key.pem
+echo "$OUT"

--- a/test/kmip/provision.py
+++ b/test/kmip/provision.py
@@ -1,0 +1,53 @@
+"""Provisions the symmetric keys the KMIP interop tests run against.
+
+Creates two AES-256 keys, activates both, and prints their unique
+identifiers as `current=<uid>` / `retired=<uid>` lines. Extra keys in the
+states the provider has to react to (deactivated, compromised, destroyed)
+are created on request via the state names passed on the command line and
+printed as `<state>=<uid>`.
+"""
+
+import sys
+
+from kmip.pie.client import ProxyKmipClient
+from kmip import enums
+
+
+def make_key(client, name):
+    uid = client.create(
+        enums.CryptographicAlgorithm.AES,
+        256,
+        name=name,
+        cryptographic_usage_mask=[
+            enums.CryptographicUsageMask.ENCRYPT,
+            enums.CryptographicUsageMask.DECRYPT,
+        ],
+    )
+    client.activate(uid)
+    return uid
+
+
+def main():
+    with ProxyKmipClient(config_file="/work/pykmip.conf") as client:
+        print("current=%s" % make_key(client, "dittofs-current"))
+        print("retired=%s" % make_key(client, "dittofs-retired"))
+        for state in sys.argv[1:]:
+            uid = make_key(client, "dittofs-%s" % state)
+            if state == "deactivated":
+                client.revoke(
+                    enums.RevocationReasonCode.CESSATION_OF_OPERATION, uid
+                )
+            elif state == "compromised":
+                client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, uid)
+            elif state == "destroyed":
+                client.revoke(
+                    enums.RevocationReasonCode.CESSATION_OF_OPERATION, uid
+                )
+                client.destroy(uid)
+            elif state == "preactive":
+                pass  # created without the activate above; handled below
+            print("%s=%s" % (state, uid))
+
+
+if __name__ == "__main__":
+    main()

--- a/test/kmip/provision.py
+++ b/test/kmip/provision.py
@@ -1,19 +1,20 @@
-"""Provisions the symmetric keys the KMIP interop tests run against.
+"""Provisions the keys the KMIP interop tests run against.
 
-Creates two AES-256 keys, activates both, and prints their unique
-identifiers as `current=<uid>` / `retired=<uid>` lines. Extra keys in the
-states the provider has to react to (deactivated, compromised, destroyed)
-are created on request via the state names passed on the command line and
-printed as `<state>=<uid>`.
+Creates one AES-256 key per state the provider has to react to and prints
+the resulting unique identifiers as `NAME=uid` lines, ready to be fed
+straight into the environment the Go tests read.
+
+Destroyed is deliberately absent: PyKMIP's Destroy removes the object from
+its database outright, so a subsequent GetAttributes reports Item Not
+Found rather than State Destroyed. That state is only reachable against
+the in-process fake server.
 """
-
-import sys
 
 from kmip.pie.client import ProxyKmipClient
 from kmip import enums
 
 
-def make_key(client, name):
+def make_key(client, name, activate=True):
     uid = client.create(
         enums.CryptographicAlgorithm.AES,
         256,
@@ -23,30 +24,32 @@ def make_key(client, name):
             enums.CryptographicUsageMask.DECRYPT,
         ],
     )
-    client.activate(uid)
+    if activate:
+        client.activate(uid)
     return uid
 
 
 def main():
     with ProxyKmipClient(config_file="/work/pykmip.conf") as client:
-        print("current=%s" % make_key(client, "dittofs-current"))
-        print("retired=%s" % make_key(client, "dittofs-retired"))
-        for state in sys.argv[1:]:
-            uid = make_key(client, "dittofs-%s" % state)
-            if state == "deactivated":
-                client.revoke(
-                    enums.RevocationReasonCode.CESSATION_OF_OPERATION, uid
-                )
-            elif state == "compromised":
-                client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, uid)
-            elif state == "destroyed":
-                client.revoke(
-                    enums.RevocationReasonCode.CESSATION_OF_OPERATION, uid
-                )
-                client.destroy(uid)
-            elif state == "preactive":
-                pass  # created without the activate above; handled below
-            print("%s=%s" % (state, uid))
+        current = make_key(client, "dittofs-current")
+        retired = make_key(client, "dittofs-retired")
+
+        deactivated = make_key(client, "dittofs-deactivated")
+        client.revoke(enums.RevocationReasonCode.CESSATION_OF_OPERATION, deactivated)
+
+        compromised = make_key(client, "dittofs-compromised")
+        client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, compromised)
+
+        preactive = make_key(client, "dittofs-preactive", activate=False)
+
+    for name, uid in (
+        ("KEY_UID", current),
+        ("RETIRED_KEY_UID", retired),
+        ("DEACTIVATED_KEY_UID", deactivated),
+        ("COMPROMISED_KEY_UID", compromised),
+        ("PREACTIVE_KEY_UID", preactive),
+    ):
+        print("DITTOFS_TEST_KMIP_%s=%s" % (name, uid))
 
 
 if __name__ == "__main__":

--- a/test/kmip/pykmip.conf
+++ b/test/kmip/pykmip.conf
@@ -1,0 +1,10 @@
+[client]
+host=localhost
+port=5696
+certfile=/certs/client-cert.pem
+keyfile=/certs/client-key.pem
+ca_certs=/certs/ca-cert.pem
+cert_reqs=CERT_REQUIRED
+ssl_version=PROTOCOL_TLSv1_2
+do_handshake_on_connect=True
+suppress_ragged_eofs=True

--- a/test/kmip/server.conf
+++ b/test/kmip/server.conf
@@ -1,0 +1,12 @@
+[server]
+hostname=0.0.0.0
+port=5696
+certificate_path=/certs/server-cert.pem
+key_path=/certs/server-key.pem
+ca_path=/certs/ca-cert.pem
+auth_suite=TLS1.2
+policy_path=/etc/pykmip/policies
+enable_tls_client_auth=True
+tls_cipher_suites=
+logging_level=DEBUG
+database_path=/pykmip.db

--- a/test/kmip/start-pykmip.sh
+++ b/test/kmip/start-pykmip.sh
@@ -14,6 +14,9 @@ CERTS="${1:-$HERE/certs}"
 ENV_FILE="${2:-/dev/stdout}"
 CONTAINER=dittofs-pykmip
 IMAGE=python:3.11-slim
+# Pinned: an unpinned server would let a PyKMIP release change what these
+# tests assert about without any change on this side.
+PYKMIP_VERSION=0.10.0
 
 CERTS="$("$HERE/gen-certs.sh" "$CERTS")"
 CERTS="$(cd "$CERTS" && pwd)"
@@ -32,7 +35,7 @@ docker run -d --name "$CONTAINER" -p 5696:5696 \
   -v "$CERTS:/certs:ro" \
   -v "$HERE:/work:ro" \
   "$IMAGE" \
-  sh -c 'pip install --no-cache-dir pykmip && mkdir -p /etc/pykmip/policies && exec pykmip-server -f /work/server.conf' \
+  sh -c 'pip install --no-cache-dir pykmip=='"$PYKMIP_VERSION"' && mkdir -p /etc/pykmip/policies && exec pykmip-server -f /work/server.conf' \
   >/dev/null
 
 # pip install then server start; the port is the readiness signal.

--- a/test/kmip/start-pykmip.sh
+++ b/test/kmip/start-pykmip.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Brings up a PyKMIP server in Docker, provisions the keys the KMIP
+# interop tests need, and writes the DITTOFS_TEST_KMIP_* environment the
+# gated tests in pkg/block/encryption/keyprovider read.
+#
+#   ./test/kmip/start-pykmip.sh [certs-dir] [env-file]
+#
+# Defaults write certificates to ./test/kmip/certs and the environment to
+# stdout. Tear down afterwards with: docker rm -f dittofs-pykmip
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CERTS="${1:-$HERE/certs}"
+ENV_FILE="${2:-/dev/stdout}"
+CONTAINER=dittofs-pykmip
+IMAGE=python:3.11-slim
+
+CERTS="$("$HERE/gen-certs.sh" "$CERTS")"
+CERTS="$(cd "$CERTS" && pwd)"
+
+docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+
+# Retry the pull: a transient registry hiccup should not fail the job.
+for attempt in 1 2 3 4 5; do
+  if docker pull "$IMAGE"; then break; fi
+  if [ "$attempt" = 5 ]; then echo "docker pull $IMAGE failed after 5 attempts" >&2; exit 1; fi
+  echo "docker pull $IMAGE failed (attempt $attempt), retrying..." >&2
+  sleep $((attempt * 5))
+done
+
+docker run -d --name "$CONTAINER" -p 5696:5696 \
+  -v "$CERTS:/certs:ro" \
+  -v "$HERE:/work:ro" \
+  "$IMAGE" \
+  sh -c 'pip install --no-cache-dir pykmip && mkdir -p /etc/pykmip/policies && exec pykmip-server -f /work/server.conf' \
+  >/dev/null
+
+# pip install then server start; the port is the readiness signal.
+for i in $(seq 1 60); do
+  if docker exec "$CONTAINER" python -c 'import socket,sys; s=socket.socket(); sys.exit(s.connect_ex(("127.0.0.1",5696)))' 2>/dev/null; then
+    break
+  fi
+  if [ "$i" = 60 ]; then
+    echo "PyKMIP did not start in time" >&2
+    docker logs "$CONTAINER" >&2
+    exit 1
+  fi
+  sleep 2
+done
+
+{
+  echo "DITTOFS_TEST_KMIP=1"
+  echo "DITTOFS_TEST_KMIP_ENDPOINT=127.0.0.1:5696"
+  echo "DITTOFS_TEST_KMIP_CERT=$CERTS/client-cert.pem"
+  echo "DITTOFS_TEST_KMIP_KEY=$CERTS/client-key.pem"
+  echo "DITTOFS_TEST_KMIP_CA=$CERTS/ca-cert.pem"
+  docker exec "$CONTAINER" python /work/provision.py
+} >>"$ENV_FILE"


### PR DESCRIPTION
## Summary

Phase 1 and Phase 2 of #1952.

`pkg/block/encryption/keyprovider/kmip.go` has never been run against a KMIP server. The live tests were gated behind six `DITTOFS_TEST_KMIP_*` variables set nowhere in the repo, so `TestKMIP_WrapUnwrapRoundTrip` had never executed; what CI ran was our own client against our own canned TTLV.

This stands up PyKMIP in the integration-tests job, points the gated tests at it, and adds the KMIP State check the issue asks for.

## Phase 1 — PyKMIP in CI

`test/kmip/` holds the harness: `gen-certs.sh`, `server.conf`, `provision.py`, `start-pykmip.sh`. The workflow step runs one script that generates certificates, starts PyKMIP in a container, provisions one key per state the provider has to react to, and writes the six `DITTOFS_TEST_KMIP_*` variables (plus four new per-state uid variables) into `$GITHUB_ENV`. The gating pattern is unchanged — a local `go test ./...` with no variables set still skips cleanly.

**The hardcoded `{Major: 1, Minor: 4}` is fine.** PyKMIP accepts it and answers at 1.4; no negotiation was needed and none was added. `Get` returns the AES-256 material in exactly the structure `extractSymmetricKeyMaterial` expects, and `GetAttributes` works. So the client as shipped does interoperate with the reference server — that is the finding, and it is a positive one.

**One real interop trap, and it is not in our code.** PyKMIP's `TLS1.2` authentication suite advertises exactly two AEAD cipher suites, both ECDSA-authenticated; every RSA-authenticated entry in that suite is CBC-SHA256, which Go dropped from its default TLS 1.2 cipher list. With an RSA server certificate the two sides share no cipher suite and the handshake fails outright with `remote error: tls: handshake failure` — before any KMIP byte is exchanged. `gen-certs.sh` therefore issues ECDSA P-256 keys, with the reason recorded in the script. Worth knowing for anyone debugging a KMIP TLS failure against a conservative appliance; it is a server-side cipher policy question, not a client defect, so nothing in `kmip.go` changed for it.

New live test: `TestKMIP_RetiredUIDStillUnwrapsLive` wraps a block under one uid, then rebuilds the provider with a second uid current and the first in `retired_key_uids`, and unwraps — the #1951 property against a real server rather than a fake.

## Phase 2 — honour the key state

`newKMIPProvider` now issues `GetAttributes` for the State attribute *before* the `Get`, so material for a key the HSM has disowned is never pulled into the process at all. `GetAttributes` is read-only; no write capability was added to the client credential.

Policy as decided on the issue:

- current key not `Active` → refuse to start, naming the state and the uid (`ErrKeyStateUnusable`). No read-only mode.
- retired key in any usable state → load it.
- retired key `Compromised` → load it, `Warn` that data is still being read under a compromised key.
- retired key `Destroyed` / `Destroyed Compromised` → the existing degrade-and-skip path now reports the state specifically instead of a generic fetch failure.
- state unreadable (server answers `GetAttributes` with no State) → **fail closed**. Assuming Active would silently defeat the control this whole phase exists to add.

The transport was folded into one `kmipRoundTrip` helper so `Get` and `GetAttributes` share the dial/deadline/frame/status handling rather than duplicating it.

### States verified against PyKMIP, and the ones that could not be

Verified live: **Active**, **Deactivated**, **Compromised**, **Pre-Active**.

**Not verifiable against PyKMIP: `Destroyed` and `Destroyed Compromised`.** PyKMIP's `Destroy` deletes the object from its database outright rather than transitioning it, so a subsequent `GetAttributes` returns `Item Not Found` — the state is unreachable on that server, not merely awkward to reach. Those two are covered against the in-process fake instead (`TestKMIP_CurrentKeyDestroyedRefused`, `TestKMIP_RetiredDestroyedKeyDegrades`), which is weaker evidence and is called out here rather than left implicit. In practice a `Destroyed` key on PyKMIP degrades through the pre-existing "retired uid the HSM will not serve" path, which is itself covered.

The fake server was reworked to dispatch on the request's operation rather than replaying responses positionally, which is what makes a per-uid State table expressible; existing tests needed no changes.

## Also in here: encryption cannot be silently removed

Chasing what happens when a share's key provider refuses to start turned up an adjacent hole. Boot-time containment is already correct — `LoadSharesFromStore` warn-and-skips a share whose block store will not come up, so one bad key does not take the daemon down — but nothing stopped an operator *removing* the `encryption` block from a block-store config that already had one. Blocks already written are encryption-framed, and an undecorated store hands that framed ciphertext straight back as if it were plaintext. Nothing downstream errors.

Two changes:

- `BlockStoreHandler.Update` refuses a config edit that drops an existing `encryption` policy. Changing the policy in place stays allowed; a store that never had encryption is unaffected.
- `dfsctl store block remote edit` in interactive mode rebuilt the config from prompts alone and silently dropped `encryption` and `compression`, neither of which has a prompt or a flag. It now carries them forward the way `parallel_uploads` already was.

## Known gap, not fixed here

A share skipped at boot is surfaced only as one `WARN` line; `GET /api/v1/shares` reports it as `status: unknown` and `dfsctl share list` drops the status field entirely. So an operator whose HSM key went `Compromised` overnight gets a loud refusal in the log and a share that looks unremarkable in the CLI. That is a separate piece of plumbing and belongs in its own issue rather than growing this one.

## Verification

- `go build ./... && go vet ./...` clean.
- `go test ./pkg/block/encryption/keyprovider/` green with no KMIP env (everything live skips) and green against a live PyKMIP container with the full env set.
- `go test -tags=integration ./internal/controlplane/api/handlers/ -run EncryptionCannotBeRemoved` green.

Closes #1952
