### PR TITLE
feat: report why a share is not being served

### DIFF
--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"os"
 	"os/signal"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -261,9 +263,17 @@ func runStart(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// A skipped share only shrinks the share count, which reads as normal to
+	// anyone who does not already know how many shares to expect. Name them
+	// here, where an operator is looking at the moment it happens.
+	skipped := rt.SkippedShares()
 	logger.Info("Runtime initialized",
 		"metadata_stores", rt.CountMetadataStores(),
-		"shares", rt.CountShares())
+		"shares", rt.CountShares(),
+		"shares_not_served", len(skipped))
+	for _, name := range slices.Sorted(maps.Keys(skipped)) {
+		logger.Warn("Share is NOT being served", "share", name, "reason", skipped[name])
+	}
 	logger.Info("Per-share BlockStores created during share loading")
 
 	// One-time stranded-row reconcile migration (#1433): reaps file_blocks

--- a/cmd/dfsctl/commands/share/list.go
+++ b/cmd/dfsctl/commands/share/list.go
@@ -68,9 +68,9 @@ func (sl ShareList) Rows() [][]string {
 		if s.Enabled {
 			enabled = "yes"
 		}
-		status := s.Status
-		if status == "" {
-			status = "-"
+		status := "-"
+		if s.Status != "" {
+			status = s.Status
 		}
 		rows = append(rows, []string{s.Name, s.MetadataStore, s.LocalBlockStore, s.RemoteBlockStore, s.Quota, s.Used, s.DefaultPermission, s.Retention, enabled, status})
 	}

--- a/cmd/dfsctl/commands/share/list.go
+++ b/cmd/dfsctl/commands/share/list.go
@@ -7,6 +7,7 @@ import (
 	"github.com/marmos91/dittofs/cmd/dfsctl/cmdutil"
 	"github.com/marmos91/dittofs/internal/bytesize"
 	"github.com/marmos91/dittofs/pkg/apiclient"
+	"github.com/marmos91/dittofs/pkg/health"
 	"github.com/spf13/cobra"
 )
 
@@ -48,8 +49,9 @@ type shareRow struct {
 	Enabled           bool   `json:"enabled"`
 	// Status is the server-reported health of the share. It is what
 	// distinguishes a share that is being served from one the server started
-	// but refused to serve; the reason is shown by 'share show'.
-	Status string `json:"status"`
+	// but refused to serve; the reason is shown by 'share show'. Omitted when
+	// the server sent none, rather than reported as an empty status.
+	Status string `json:"status,omitempty"`
 }
 
 // ShareList is a list of shares for table rendering.
@@ -157,9 +159,18 @@ func runList(cmd *cobra.Command, args []string) error {
 			DefaultPermission: s.DefaultPermission,
 			Retention:         retention,
 			Enabled:           s.Enabled,
-			Status:            string(s.Status.Status),
+			Status:            shareStatusString(s.Status),
 		})
 	}
 
 	return cmdutil.PrintOutput(os.Stdout, rows, len(rows) == 0, "No shares found.", rows)
+}
+
+// shareStatusString renders the server's status, or empty when the server sent
+// none, so an absent status is never shown as a status of "".
+func shareStatusString(r *health.Report) string {
+	if r == nil {
+		return ""
+	}
+	return string(r.Status)
 }

--- a/cmd/dfsctl/commands/share/list.go
+++ b/cmd/dfsctl/commands/share/list.go
@@ -46,6 +46,10 @@ type shareRow struct {
 	DefaultPermission string `json:"default_permission"`
 	Retention         string `json:"retention"`
 	Enabled           bool   `json:"enabled"`
+	// Status is the server-reported health of the share. It is what
+	// distinguishes a share that is being served from one the server started
+	// but refused to serve; the reason is shown by 'share show'.
+	Status string `json:"status"`
 }
 
 // ShareList is a list of shares for table rendering.
@@ -53,7 +57,7 @@ type ShareList []shareRow
 
 // Headers implements TableRenderer.
 func (sl ShareList) Headers() []string {
-	return []string{"NAME", "METADATA STORE", "LOCAL STORE", "REMOTE STORE", "QUOTA", "USED", "DEFAULT PERMISSION", "RETENTION", "ENABLED"}
+	return []string{"NAME", "METADATA STORE", "LOCAL STORE", "REMOTE STORE", "QUOTA", "USED", "DEFAULT PERMISSION", "RETENTION", "ENABLED", "STATUS"}
 }
 
 // Rows implements TableRenderer.
@@ -64,7 +68,11 @@ func (sl ShareList) Rows() [][]string {
 		if s.Enabled {
 			enabled = "yes"
 		}
-		rows = append(rows, []string{s.Name, s.MetadataStore, s.LocalBlockStore, s.RemoteBlockStore, s.Quota, s.Used, s.DefaultPermission, s.Retention, enabled})
+		status := s.Status
+		if status == "" {
+			status = "-"
+		}
+		rows = append(rows, []string{s.Name, s.MetadataStore, s.LocalBlockStore, s.RemoteBlockStore, s.Quota, s.Used, s.DefaultPermission, s.Retention, enabled, status})
 	}
 	return rows
 }
@@ -149,6 +157,7 @@ func runList(cmd *cobra.Command, args []string) error {
 			DefaultPermission: s.DefaultPermission,
 			Retention:         retention,
 			Enabled:           s.Enabled,
+			Status:            string(s.Status.Status),
 		})
 	}
 

--- a/cmd/dfsctl/commands/share/list_test.go
+++ b/cmd/dfsctl/commands/share/list_test.go
@@ -36,9 +36,9 @@ func TestShareList_Row_RendersEnabledYes(t *testing.T) {
 	if len(rows) != 1 {
 		t.Fatalf("expected 1 row, got %d", len(rows))
 	}
-	last := rows[0][len(rows[0])-1]
-	if last != "yes" {
-		t.Errorf("last column = %q, want \"yes\"", last)
+	got := rows[0][columnIndex(t, sl.Headers(), "ENABLED")]
+	if got != "yes" {
+		t.Errorf("ENABLED column = %q, want \"yes\"", got)
 	}
 }
 
@@ -49,9 +49,9 @@ func TestShareList_Row_RendersEnabledDash(t *testing.T) {
 		{Name: "/archive", Enabled: false},
 	}
 	rows := sl.Rows()
-	last := rows[0][len(rows[0])-1]
-	if last != "-" {
-		t.Errorf("last column = %q, want \"-\"", last)
+	got := rows[0][columnIndex(t, sl.Headers(), "ENABLED")]
+	if got != "-" {
+		t.Errorf("ENABLED column = %q, want \"-\"", got)
 	}
 }
 
@@ -89,5 +89,36 @@ func TestShareList_JSON_IncludesEnabledField(t *testing.T) {
 	got := string(b)
 	if !strings.Contains(got, `"enabled":true`) {
 		t.Errorf("json output missing \"enabled\":true, got %s", got)
+	}
+}
+
+// columnIndex returns the position of the named column, so assertions survive
+// new columns being appended to the table.
+func columnIndex(t *testing.T, headers []string, name string) int {
+	t.Helper()
+	for i, h := range headers {
+		if h == name {
+			return i
+		}
+	}
+	t.Fatalf("column %q missing from headers: %v", name, headers)
+	return -1
+}
+
+// A share the server refused to serve must be visible in the table, and a
+// share whose status the server did not report must not render an empty cell.
+func TestShareList_Row_RendersStatus(t *testing.T) {
+	sl := ShareList{
+		{Name: "/refused", Enabled: true, Status: "unhealthy"},
+		{Name: "/nostatus", Enabled: true},
+	}
+	rows := sl.Rows()
+	idx := columnIndex(t, sl.Headers(), "STATUS")
+
+	if got := rows[0][idx]; got != "unhealthy" {
+		t.Errorf("STATUS column = %q, want \"unhealthy\"", got)
+	}
+	if got := rows[1][idx]; got != "-" {
+		t.Errorf("absent status rendered as %q, want \"-\"", got)
 	}
 }

--- a/cmd/dfsctl/commands/share/show.go
+++ b/cmd/dfsctl/commands/share/show.go
@@ -93,6 +93,16 @@ func (sd ShareDetail) Rows() [][]string {
 		{"Retention", retPolicy},
 	}
 
+	// Status, and the reason behind it when the server has one. A share the
+	// server refused to serve is otherwise indistinguishable here from a
+	// healthy one.
+	if s.Status.Status != "" {
+		rows = append(rows, []string{"Status", string(s.Status.Status)})
+		if s.Status.Message != "" {
+			rows = append(rows, []string{"Status Detail", s.Status.Message})
+		}
+	}
+
 	// Only show Retention TTL when a TTL is set
 	if s.RetentionTTL != "" {
 		rows = append(rows, []string{"Retention TTL", s.RetentionTTL})

--- a/cmd/dfsctl/commands/share/show.go
+++ b/cmd/dfsctl/commands/share/show.go
@@ -96,7 +96,7 @@ func (sd ShareDetail) Rows() [][]string {
 	// Status, and the reason behind it when the server has one. A share the
 	// server refused to serve is otherwise indistinguishable here from a
 	// healthy one.
-	if s.Status.Status != "" {
+	if s.Status != nil && s.Status.Status != "" {
 		rows = append(rows, []string{"Status", string(s.Status.Status)})
 		if s.Status.Message != "" {
 			rows = append(rows, []string{"Status Detail", s.Status.Message})

--- a/pkg/apiclient/shares.go
+++ b/pkg/apiclient/shares.go
@@ -80,7 +80,11 @@ type Share struct {
 	// Status is the server's health report for the share. A share the server
 	// refused to serve reports unhealthy with the reason in Message, which is
 	// the only place that refusal is visible outside the server log.
-	Status health.Report `json:"status"`
+	//
+	// Omitted when empty: a server that sends no status must not be rendered
+	// as one reporting a zero-value report, which would carry an empty Status
+	// and a year-zero CheckedAt that no server ever produced.
+	Status *health.Report `json:"status,omitempty"`
 }
 
 // CreateShareRequest is the request to create a share.

--- a/pkg/apiclient/shares.go
+++ b/pkg/apiclient/shares.go
@@ -5,6 +5,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/marmos91/dittofs/pkg/health"
 )
 
 // normalizeShareNameForAPI strips all leading slashes from share names for API URLs.
@@ -74,6 +76,11 @@ type Share struct {
 	OwnerGID  *uint32   `json:"owner_gid,omitempty"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
+
+	// Status is the server's health report for the share. A share the server
+	// refused to serve reports unhealthy with the reason in Message, which is
+	// the only place that refusal is visible outside the server log.
+	Status health.Report `json:"status"`
 }
 
 // CreateShareRequest is the request to create a share.

--- a/pkg/controlplane/runtime/init.go
+++ b/pkg/controlplane/runtime/init.go
@@ -263,6 +263,7 @@ func LoadSharesFromStore(ctx context.Context, rt *Runtime, s store.Store) error 
 		}
 		if shareConfig == nil {
 			// Share references an unknown metadata store; already logged.
+			rt.MarkShareSkipped(share.Name, "metadata store "+share.MetadataStoreID+" is not configured")
 			continue
 		}
 
@@ -279,6 +280,7 @@ func LoadSharesFromStore(ctx context.Context, rt *Runtime, s store.Store) error 
 			logger.Warn("Failed to add share to runtime",
 				"share", share.Name,
 				"error", err)
+			rt.MarkShareSkipped(share.Name, err.Error())
 			continue
 		}
 

--- a/pkg/controlplane/runtime/init.go
+++ b/pkg/controlplane/runtime/init.go
@@ -263,7 +263,7 @@ func LoadSharesFromStore(ctx context.Context, rt *Runtime, s store.Store) error 
 		}
 		if shareConfig == nil {
 			// Share references an unknown metadata store; already logged.
-			rt.MarkShareSkipped(share.Name, "metadata store "+share.MetadataStoreID+" is not configured")
+			rt.markShareSkipped(share.Name, "metadata store "+share.MetadataStoreID+" is not configured")
 			continue
 		}
 
@@ -280,7 +280,7 @@ func LoadSharesFromStore(ctx context.Context, rt *Runtime, s store.Store) error 
 			logger.Warn("Failed to add share to runtime",
 				"share", share.Name,
 				"error", err)
-			rt.MarkShareSkipped(share.Name, err.Error())
+			rt.markShareSkipped(share.Name, err.Error())
 			continue
 		}
 

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -108,6 +108,16 @@ type Runtime struct {
 	mountTracker   *MountTracker
 	clientRegistry *ClientRegistry
 
+	// skippedShares maps a share name to the reason it is not being served.
+	// A share that exists in the control-plane store but whose runtime setup
+	// failed is absent from sharesSvc entirely, so a status probe would find
+	// nothing and report "share not found" as StatusUnknown — indistinguishable
+	// from a share the runtime simply has not reached yet. Recording the reason
+	// here lets HealthcheckShare report StatusUnhealthy with the cause instead.
+	// Entries are added when a share is skipped and cleared once the same name
+	// is successfully added or removed. Guarded by mu.
+	skippedShares map[string]string
+
 	// metrics is the Prometheus metrics handle, set at startup. It is the
 	// carrier for inline adapter instruments (RED, connection, auth counters):
 	// adapters reach it via Runtime so no per-adapter plumbing is needed. May
@@ -447,6 +457,36 @@ func (r *Runtime) LocalStoreDir(shareName string) (string, error) {
 //     follow-up phase can sharpen this once the store registry can
 //     report "configured but not currently loaded" vs "never
 //     registered".
+//
+// MarkShareSkipped records that a share exists in the control-plane store but
+// is not being served, along with the reason. The reason is surfaced verbatim
+// by HealthcheckShare, so it should read as an operator-facing explanation.
+func (r *Runtime) MarkShareSkipped(name, reason string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.skippedShares == nil {
+		r.skippedShares = make(map[string]string)
+	}
+	r.skippedShares[name] = reason
+}
+
+// ShareSkipReason returns the reason the named share is not being served, and
+// whether such a reason was recorded.
+func (r *Runtime) ShareSkipReason(name string) (string, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	reason, ok := r.skippedShares[name]
+	return reason, ok
+}
+
+// clearShareSkipped drops any recorded skip reason for a share, so a name that
+// is successfully added or removed stops reporting a stale boot-time failure.
+func (r *Runtime) clearShareSkipped(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.skippedShares, name)
+}
+
 func (r *Runtime) HealthcheckShare(ctx context.Context, shareName string) health.Report {
 	// Capture start so every early-return path populates LatencyMs,
 	// matching what Share.Healthcheck does. A flat zero on
@@ -474,6 +514,13 @@ func (r *Runtime) HealthcheckShare(ctx context.Context, shareName string) health
 
 	share, err := r.sharesSvc.GetShare(shareName)
 	if err != nil {
+		// A share the runtime deliberately refused to serve is absent from the
+		// registry exactly like one that was never configured. Report the
+		// recorded reason as unhealthy so the refusal is visible, rather than
+		// letting it read as an indeterminate probe.
+		if reason, skipped := r.ShareSkipReason(shareName); skipped {
+			return earlyReturn(health.StatusUnhealthy, "share not served: "+reason)
+		}
 		return earlyReturn(health.StatusUnknown, "share not found: "+err.Error())
 	}
 
@@ -507,6 +554,8 @@ func (r *Runtime) AddShare(ctx context.Context, config *ShareConfig) error {
 	if err := r.sharesSvc.AddShare(ctx, config, r.storesSvc, r.metadataService, r.store, localDefaults, syncDefaults); err != nil {
 		return err
 	}
+	// The share is serving now, so any earlier refusal no longer describes it.
+	r.clearShareSkipped(config.Name)
 	// Wire quota into the metadata service (0 = unlimited).
 	// Always set explicitly to ensure consistency after restarts when a
 	// quota was removed (set to 0) via the API.
@@ -597,6 +646,9 @@ func (r *Runtime) RemoveShare(name string) error {
 	// service-map growth #897/#907 fixed, and it has to run even when the
 	// block-store Close or snapshot-dir wipe failed. Aggregate instead.
 	rmErr := r.sharesSvc.RemoveShare(name)
+	// The share is gone, so a recorded refusal would outlive its subject and
+	// resurface if a new share reused the name.
+	r.clearShareSkipped(name)
 	// Deregister the share's per-share store / lock manager / unified view /
 	// notifier / quota from the metadata service, mirroring the AddShare
 	// registration above. Without this the service maps grow unbounded across

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -439,10 +440,10 @@ func (r *Runtime) LocalStoreDir(shareName string) (string, error) {
 	return r.sharesSvc.LocalStoreDir(shareName)
 }
 
-// MarkShareSkipped records that a share exists in the control-plane store but
+// markShareSkipped records that a share exists in the control-plane store but
 // is not being served, along with the reason. The reason is surfaced verbatim
 // by HealthcheckShare, so it should read as an operator-facing explanation.
-func (r *Runtime) MarkShareSkipped(name, reason string) {
+func (r *Runtime) markShareSkipped(name, reason string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.skippedShares == nil {
@@ -456,19 +457,12 @@ func (r *Runtime) MarkShareSkipped(name, reason string) {
 func (r *Runtime) SkippedShares() map[string]string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	if len(r.skippedShares) == 0 {
-		return nil
-	}
-	out := make(map[string]string, len(r.skippedShares))
-	for name, reason := range r.skippedShares {
-		out[name] = reason
-	}
-	return out
+	return maps.Clone(r.skippedShares)
 }
 
-// ShareSkipReason returns the reason the named share is not being served, and
+// shareSkipReason returns the reason the named share is not being served, and
 // whether such a reason was recorded.
-func (r *Runtime) ShareSkipReason(name string) (string, bool) {
+func (r *Runtime) shareSkipReason(name string) (string, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	reason, ok := r.skippedShares[name]
@@ -537,7 +531,7 @@ func (r *Runtime) HealthcheckShare(ctx context.Context, shareName string) health
 		// registry exactly like one that was never configured. Report the
 		// recorded reason as unhealthy so the refusal is visible, rather than
 		// letting it read as an indeterminate probe.
-		if reason, skipped := r.ShareSkipReason(shareName); skipped {
+		if reason, skipped := r.shareSkipReason(shareName); skipped {
 			return earlyReturn(health.StatusUnhealthy, "share not served: "+reason)
 		}
 		return earlyReturn(health.StatusUnknown, "share not found: "+err.Error())

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -439,25 +439,6 @@ func (r *Runtime) LocalStoreDir(shareName string) (string, error) {
 	return r.sharesSvc.LocalStoreDir(shareName)
 }
 
-// HealthcheckShare returns the named share's overall health, computed
-// as the worst-of its block store engine and metadata store. The
-// runtime owns both registries, so this is the natural place to wire
-// the lookup before delegating to [Share.Healthcheck].
-//
-// Lookup-failure semantics:
-//
-//   - "share not found" → [health.StatusUnknown]. The runtime can't
-//     say anything definitive about a share it doesn't know about.
-//   - "metadata store not loaded" → [health.StatusUnknown] as well.
-//     The store may have been registered earlier but evicted, or
-//     never registered (a startup misconfiguration). Without
-//     a way to distinguish those cases — the registry doesn't expose
-//     the difference — the conservative answer is StatusUnknown:
-//     the probe is indeterminate, not the share itself broken. A
-//     follow-up phase can sharpen this once the store registry can
-//     report "configured but not currently loaded" vs "never
-//     registered".
-//
 // MarkShareSkipped records that a share exists in the control-plane store but
 // is not being served, along with the reason. The reason is surfaced verbatim
 // by HealthcheckShare, so it should read as an operator-facing explanation.
@@ -502,6 +483,29 @@ func (r *Runtime) clearShareSkipped(name string) {
 	delete(r.skippedShares, name)
 }
 
+// HealthcheckShare returns the named share's overall health, computed
+// as the worst-of its block store engine and metadata store. The
+// runtime owns both registries, so this is the natural place to wire
+// the lookup before delegating to [Share.Healthcheck].
+//
+// Lookup-failure semantics:
+//
+//   - "share not found", with a recorded skip reason →
+//     [health.StatusUnhealthy]. The runtime refused to serve this
+//     share and knows why, so the refusal is reported rather than
+//     hidden behind an indeterminate probe.
+//   - "share not found", with no skip reason → [health.StatusUnknown].
+//     The runtime can't say anything definitive about a share it
+//     doesn't know about.
+//   - "metadata store not loaded" → [health.StatusUnknown] as well.
+//     The store may have been registered earlier but evicted, or
+//     never registered (a startup misconfiguration). Without
+//     a way to distinguish those cases — the registry doesn't expose
+//     the difference — the conservative answer is StatusUnknown:
+//     the probe is indeterminate, not the share itself broken. A
+//     follow-up phase can sharpen this once the store registry can
+//     report "configured but not currently loaded" vs "never
+//     registered".
 func (r *Runtime) HealthcheckShare(ctx context.Context, shareName string) health.Report {
 	// Capture start so every early-return path populates LatencyMs,
 	// matching what Share.Healthcheck does. A flat zero on

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -470,6 +470,21 @@ func (r *Runtime) MarkShareSkipped(name, reason string) {
 	r.skippedShares[name] = reason
 }
 
+// SkippedShares returns a copy of the recorded skip reasons, keyed by share
+// name. Empty when every configured share is being served.
+func (r *Runtime) SkippedShares() map[string]string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if len(r.skippedShares) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(r.skippedShares))
+	for name, reason := range r.skippedShares {
+		out[name] = reason
+	}
+	return out
+}
+
 // ShareSkipReason returns the reason the named share is not being served, and
 // whether such a reason was recorded.
 func (r *Runtime) ShareSkipReason(name string) (string, bool) {

--- a/pkg/controlplane/runtime/share_skip_status_test.go
+++ b/pkg/controlplane/runtime/share_skip_status_test.go
@@ -31,7 +31,7 @@ func TestHealthcheckShare_SkippedReportsUnhealthyWithReason(t *testing.T) {
 	}
 
 	const reason = "master key is Deactivated at the HSM"
-	rt.MarkShareSkipped("/refused", reason)
+	rt.markShareSkipped("/refused", reason)
 
 	rep = rt.HealthcheckShare(context.Background(), "/refused")
 	if rep.Status != health.StatusUnhealthy {
@@ -47,13 +47,13 @@ func TestHealthcheckShare_SkippedReportsUnhealthyWithReason(t *testing.T) {
 func TestHealthcheckShare_SkipReasonClearedOnAddAndRemove(t *testing.T) {
 	rt := newRuntimeForSkipStatus()
 
-	rt.MarkShareSkipped("/s", "remote endpoint unreachable")
-	if _, skipped := rt.ShareSkipReason("/s"); !skipped {
+	rt.markShareSkipped("/s", "remote endpoint unreachable")
+	if _, skipped := rt.shareSkipReason("/s"); !skipped {
 		t.Fatal("expected the skip reason to be recorded")
 	}
 
 	rt.clearShareSkipped("/s")
-	if _, skipped := rt.ShareSkipReason("/s"); skipped {
+	if _, skipped := rt.shareSkipReason("/s"); skipped {
 		t.Error("expected the skip reason to be cleared")
 	}
 
@@ -68,13 +68,13 @@ func TestHealthcheckShare_SkipReasonClearedOnAddAndRemove(t *testing.T) {
 func TestShareSkipReason_IsPerShare(t *testing.T) {
 	rt := newRuntimeForSkipStatus()
 
-	rt.MarkShareSkipped("/a", "reason a")
+	rt.markShareSkipped("/a", "reason a")
 	rt.clearShareSkipped("/b")
 
-	if reason, skipped := rt.ShareSkipReason("/a"); !skipped || reason != "reason a" {
-		t.Errorf("ShareSkipReason(/a) = (%q, %v), want (\"reason a\", true)", reason, skipped)
+	if reason, skipped := rt.shareSkipReason("/a"); !skipped || reason != "reason a" {
+		t.Errorf("shareSkipReason(/a) = (%q, %v), want (\"reason a\", true)", reason, skipped)
 	}
-	if _, skipped := rt.ShareSkipReason("/b"); skipped {
-		t.Error("ShareSkipReason(/b) reported a reason that was never recorded")
+	if _, skipped := rt.shareSkipReason("/b"); skipped {
+		t.Error("shareSkipReason(/b) reported a reason that was never recorded")
 	}
 }

--- a/pkg/controlplane/runtime/share_skip_status_test.go
+++ b/pkg/controlplane/runtime/share_skip_status_test.go
@@ -1,0 +1,80 @@
+package runtime
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime/shares"
+	"github.com/marmos91/dittofs/pkg/health"
+)
+
+// newRuntimeForSkipStatus builds the smallest Runtime that can answer a share
+// status probe: HealthcheckShare only reaches the shares registry before it
+// decides, so no stores, metadata service or block stores are needed.
+func newRuntimeForSkipStatus() *Runtime {
+	return &Runtime{sharesSvc: shares.New()}
+}
+
+// A share the runtime refused to serve is absent from the shares registry
+// exactly like a share that was never configured. Without a recorded reason
+// both report StatusUnknown "share not found", which is what made a boot-time
+// refusal invisible to an operator reading the API or the CLI.
+func TestHealthcheckShare_SkippedReportsUnhealthyWithReason(t *testing.T) {
+	rt := newRuntimeForSkipStatus()
+
+	// Baseline: an unknown share is indeterminate, not unhealthy. This is the
+	// contract the skip reason has to stay distinguishable from.
+	rep := rt.HealthcheckShare(context.Background(), "/never-configured")
+	if rep.Status != health.StatusUnknown {
+		t.Errorf("unconfigured share status = %s, want unknown", rep.Status)
+	}
+
+	const reason = "master key is Deactivated at the HSM"
+	rt.MarkShareSkipped("/refused", reason)
+
+	rep = rt.HealthcheckShare(context.Background(), "/refused")
+	if rep.Status != health.StatusUnhealthy {
+		t.Errorf("skipped share status = %s, want unhealthy", rep.Status)
+	}
+	if !strings.Contains(rep.Message, reason) {
+		t.Errorf("message = %q, want it to carry %q", rep.Message, reason)
+	}
+}
+
+// A recorded refusal must not outlive its subject: once the same name is
+// serving, or is gone, the stale boot-time reason has to stop being reported.
+func TestHealthcheckShare_SkipReasonClearedOnAddAndRemove(t *testing.T) {
+	rt := newRuntimeForSkipStatus()
+
+	rt.MarkShareSkipped("/s", "remote endpoint unreachable")
+	if _, skipped := rt.ShareSkipReason("/s"); !skipped {
+		t.Fatal("expected the skip reason to be recorded")
+	}
+
+	rt.clearShareSkipped("/s")
+	if _, skipped := rt.ShareSkipReason("/s"); skipped {
+		t.Error("expected the skip reason to be cleared")
+	}
+
+	rep := rt.HealthcheckShare(context.Background(), "/s")
+	if rep.Status != health.StatusUnknown {
+		t.Errorf("cleared share status = %s, want unknown", rep.Status)
+	}
+}
+
+// Clearing a name that was never skipped must not disturb other entries, and
+// reading an absent name must not report a reason.
+func TestShareSkipReason_IsPerShare(t *testing.T) {
+	rt := newRuntimeForSkipStatus()
+
+	rt.MarkShareSkipped("/a", "reason a")
+	rt.clearShareSkipped("/b")
+
+	if reason, skipped := rt.ShareSkipReason("/a"); !skipped || reason != "reason a" {
+		t.Errorf("ShareSkipReason(/a) = (%q, %v), want (\"reason a\", true)", reason, skipped)
+	}
+	if _, skipped := rt.ShareSkipReason("/b"); skipped {
+		t.Error("ShareSkipReason(/b) reported a reason that was never recorded")
+	}
+}


### PR DESCRIPTION
Closes #2010.

## What was wrong

A share whose runtime setup fails at boot is warn-and-skipped by `LoadSharesFromStore` and never enters the shares registry. `HealthcheckShare` resolves a share by asking that registry, so for a skipped share it took the lookup-failure path and returned:

```
status = unknown, message = "share not found: share not found: \"/refused\""
```

which is exactly what a share that was **never configured** returns. The two states were indistinguishable, so the refusal existed only as one WARN line in the log.

`dfsctl share list` was worse than "unknown": `pkg/apiclient/Share` had no `Status` field at all, so the client silently discarded the status the server was already sending.

## The fix

The runtime records *why* a share is not being served, and `HealthcheckShare` reports it as `StatusUnhealthy` with the reason instead of an indeterminate probe result.

This sits at the single seam both endpoints already route through, so `GET /api/v1/shares` and `GET /api/v1/shares/{name}/status` are both covered without touching either handler.

No new status type: `health.Report` already carries `Status` + `Message`, and its own doc says *"Prefer explicit StatusDegraded or StatusUnhealthy when the failure mode is known."* A skipped share is a known failure mode.

- `runtime.go` — `skippedShares map[string]string` guarded by the existing `mu`. Cleared in `AddShare` on success and in `RemoveShare` regardless of teardown error, so a reason cannot outlive its subject or be inherited by a same-name re-create. The map is per-`Runtime` and in-memory, so nothing survives a restart to go stale.
- `init.go` — both warn-and-skip sites record a reason (failed `AddShare`, and a share referencing an unconfigured metadata store).
- `apiclient/shares.go` — `Status health.Report`, matching the server's existing `ShareResponse.Status` shape.
- `share list` — STATUS column; `share show` — status plus the reason behind it.
- `dfs start` — logs `shares_not_served` and names each one. The issue asked whether this belonged here; a skipped share otherwise just shrinks the share count, which reads as normal to anyone who does not already know what to expect.

## Evidence

The regression test fails without the fix and passes with it. Removing only the new branch in `HealthcheckShare`:

```
--- FAIL: TestHealthcheckShare_SkippedReportsUnhealthyWithReason
    share_skip_status_test.go:38: skipped share status = unknown, want unhealthy
    share_skip_status_test.go:41: message = "share not found: share not found: \"/refused\"",
        want it to carry "master key is Deactivated at the HSM"
```

That message is the reported symptom reproduced exactly. Restored, the suite is green: `go build`, `go vet`, `gofmt`, and `go test ./...` (134 packages, exit 0).

The tests also pin the baseline they must stay distinguishable from: an unconfigured share still reports `unknown`, not `unhealthy`.

## Not KMIP-specific

Rebased onto #2009. A revoked KMIP key is now one reason a share reports unhealthy, but every other boot-skip reason — unreachable remote endpoint, missing local directory, permissions, unconfigured metadata store — goes through the same path.

## Two notes for the reviewer

- **Two existing tests changed.** `TestShareList_Row_RendersEnabledYes/Dash` asserted on `rows[0][len(rows[0])-1]`, which the new STATUS column displaced. They now look the ENABLED column up by name, so appending a column cannot break them again.
- **`docs/guide/cli.md` is regenerated and carries an unrelated 4-line change.** It had drifted: `dfsctl client list --share` was removed from the command tree earlier but the generated doc was never refreshed. `go run ./cmd/gendocs` picked it up. Not part of this change, but the file is generated and hand-editing it is forbidden, so it comes along.
