### PR TITLE
refactor(acl): collapse the duplicated DACL walk and EvaluateContext builders

### DIFF
--- a/pkg/metadata/acl/evaluate.go
+++ b/pkg/metadata/acl/evaluate.go
@@ -176,6 +176,8 @@ const takeOwnershipImplicitRight = ACE4_WRITE_OWNER
 //     holds SeTakeOwnershipPrivilege (evalCtx.RequesterHasTakeOwnership).
 //     Explicit DENY in the DACL still wins per-bit.
 //  7. Return true if and only if ALL requested bits are in allowedBits.
+//
+// Steps 1-6 live in walkDACL, shared with EvaluateGranted.
 func Evaluate(a *ACL, evalCtx *EvaluateContext, requestedMask uint32) bool {
 	if requestedMask == 0 {
 		return true
@@ -184,7 +186,7 @@ func Evaluate(a *ACL, evalCtx *EvaluateContext, requestedMask uint32) bool {
 	// An empty DACL (len(a.ACEs) == 0) is the MS-DTYP §2.5.3 "deny all"
 	// case but §2.5.3.2 still grants the file owner READ_CONTROL|
 	// WRITE_DAC|WRITE_OWNER, so we must fall through to the owner-implicit
-	// pass below rather than short-circuiting here.
+	// pass in walkDACL rather than short-circuiting here.
 	if a == nil {
 		return false
 	}
@@ -194,6 +196,44 @@ func Evaluate(a *ACL, evalCtx *EvaluateContext, requestedMask uint32) bool {
 		return true
 	}
 
+	return walkDACL(a, evalCtx, requestedMask)&requestedMask == requestedMask
+}
+
+// EvaluateGranted computes, in a SINGLE pass over the DACL, the subset of
+// probeMask that the requester is granted. It is the multi-bit analog of
+// Evaluate: where Evaluate answers "are ALL bits in mask allowed?" (and must
+// be called once per probed bit to discover a granted subset), EvaluateGranted
+// answers "which of these bits are allowed?" and walks the ACE list only once.
+//
+// The result is bit-identical to probing each set bit of probeMask through
+// Evaluate individually and OR-ing the ones that return true. This holds
+// because walkDACL's allow/deny accumulation is per-bit-independent —
+// first-match-wins applies separately to each bit position via
+// `ace.AccessMask &^ (allowedBits | deniedBits)` — and the OWNER_RIGHTS
+// pre-scan and MS-DTYP §2.5.3.2 owner-implicit grant likewise act per-bit.
+// Early termination only short-circuits once a decision is reached and never
+// alters the final allow/deny outcome for any bit.
+//
+// Returns 0 immediately for an empty probeMask or a nil ACL (matching
+// Evaluate's "nil ACL grants nothing" contract). NullDACL grants every probed
+// bit.
+func EvaluateGranted(a *ACL, evalCtx *EvaluateContext, probeMask uint32) uint32 {
+	// Empty probe or nil ACL grants nothing (matches Evaluate's nil-ACL contract).
+	if probeMask == 0 || a == nil {
+		return 0
+	}
+	if a.NullDACL {
+		return probeMask
+	}
+
+	return walkDACL(a, evalCtx, probeMask) & probeMask
+}
+
+// walkDACL runs steps 1-6 of the evaluation algorithm over a non-nil, non-null
+// DACL and returns the accumulated allowed bits. decisionMask names the bits
+// the caller cares about; it only drives early termination, never the outcome
+// for any individual bit. Callers apply their own final test to the result.
+func walkDACL(a *ACL, evalCtx *EvaluateContext, decisionMask uint32) uint32 {
 	// First pass: does this DACL contain any effective OWNER_RIGHTS ACE
 	// that affects access decisions? The override only matters when the
 	// requester is the file owner, so non-owners skip the scan entirely.
@@ -252,8 +292,8 @@ func Evaluate(a *ACL, evalCtx *EvaluateContext, requestedMask uint32) bool {
 			continue
 		}
 
-		// Early termination: all requested bits have been decided.
-		if (allowedBits|deniedBits)&requestedMask == requestedMask {
+		// Early termination: every bit of interest has been decided.
+		if (allowedBits|deniedBits)&decisionMask == decisionMask {
 			break
 		}
 	}
@@ -276,97 +316,7 @@ func Evaluate(a *ACL, evalCtx *EvaluateContext, requestedMask uint32) bool {
 		}
 	}
 
-	// Access is granted only if ALL requested bits are in allowedBits.
-	return (allowedBits & requestedMask) == requestedMask
-}
-
-// EvaluateGranted computes, in a SINGLE pass over the DACL, the subset of
-// probeMask that the requester is granted. It is the multi-bit analog of
-// Evaluate: where Evaluate answers "are ALL bits in mask allowed?" (and must
-// be called once per probed bit to discover a granted subset), EvaluateGranted
-// answers "which of these bits are allowed?" and walks the ACE list only once.
-//
-// The result is bit-identical to probing each set bit of probeMask through
-// Evaluate individually and OR-ing the ones that return true. This holds
-// because Evaluate's allow/deny accumulation is per-bit-independent —
-// first-match-wins applies separately to each bit position via
-// `ace.AccessMask &^ (allowedBits | deniedBits)` — and the OWNER_RIGHTS
-// pre-scan and MS-DTYP §2.5.3.2 owner-implicit grant likewise act per-bit.
-// Early termination in Evaluate only short-circuits once a decision is reached
-// and never alters the final allow/deny outcome for any bit.
-//
-// Returns 0 immediately for an empty probeMask or a nil ACL (matching
-// Evaluate's "nil ACL grants nothing" contract). NullDACL grants every probed
-// bit.
-func EvaluateGranted(a *ACL, evalCtx *EvaluateContext, probeMask uint32) uint32 {
-	// Empty probe or nil ACL grants nothing (matches Evaluate's nil-ACL contract).
-	if probeMask == 0 || a == nil {
-		return 0
-	}
-	if a.NullDACL {
-		return probeMask
-	}
-
-	requesterIsOwner := evalCtx.UID == evalCtx.FileOwnerUID
-	var ownerRightsPresent bool
-	if requesterIsOwner {
-		for i := range a.ACEs {
-			ace := &a.ACEs[i]
-			if ace.IsInheritOnly() {
-				continue
-			}
-			if ace.Who != SpecialOwnerRights {
-				continue
-			}
-			if ace.Type != ACE4_ACCESS_ALLOWED_ACE_TYPE &&
-				ace.Type != ACE4_ACCESS_DENIED_ACE_TYPE {
-				continue
-			}
-			ownerRightsPresent = true
-			break
-		}
-	}
-
-	var allowedBits uint32
-	var deniedBits uint32
-
-	for i := range a.ACEs {
-		ace := &a.ACEs[i]
-
-		if ace.IsInheritOnly() {
-			continue
-		}
-		if !aceMatchesWhoWithOwnerRights(ace, evalCtx, ownerRightsPresent) {
-			continue
-		}
-
-		switch ace.Type {
-		case ACE4_ACCESS_ALLOWED_ACE_TYPE:
-			newBits := ace.AccessMask &^ (allowedBits | deniedBits)
-			allowedBits |= newBits
-
-		case ACE4_ACCESS_DENIED_ACE_TYPE:
-			newBits := ace.AccessMask &^ (allowedBits | deniedBits)
-			deniedBits |= newBits
-
-		case ACE4_SYSTEM_AUDIT_ACE_TYPE, ACE4_SYSTEM_ALARM_ACE_TYPE:
-			continue
-		}
-
-		// Early termination: every probed bit has been decided either way.
-		if (allowedBits|deniedBits)&probeMask == probeMask {
-			break
-		}
-	}
-
-	if requesterIsOwner && !ownerRightsPresent {
-		allowedBits |= ownerImplicitRights &^ deniedBits
-		if evalCtx.RequesterHasTakeOwnership {
-			allowedBits |= takeOwnershipImplicitRight &^ deniedBits
-		}
-	}
-
-	return allowedBits & probeMask
+	return allowedBits
 }
 
 // aceMatchesWhoWithOwnerRights checks if an ACE applies to the given

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -407,21 +407,9 @@ func evaluateACLPermissions(
 	shareOpts *ShareOptions,
 	requested Permission,
 ) Permission {
-	// Handle anonymous/no identity
+	// Anonymous/no identity: no root bypass applies, so evaluate straight away.
 	if identity == nil || identity.UID == nil {
-		// Anonymous: suppress OWNER@ matching and the MS-DTYP §2.5.3.2
-		// owner-implicit RC|WRITE_DAC pass by forcing FileOwnerUID to
-		// the AnonymousFileOwnerUID sentinel — without it the requester's
-		// zero-valued UID would collapse onto a root-owned file's owner.
-		// Anonymous additionally confines matching to EVERYONE@, so the
-		// zero-valued UID/GID cannot pick up GROUP@ on a root-group-owned
-		// file or an explicit "0@localdomain" ACE.
-		evalCtx := &acl.EvaluateContext{
-			Anonymous:    true,
-			FileOwnerUID: acl.AnonymousFileOwnerUID,
-			FileOwnerGID: file.GID,
-		}
-		return evaluateWithACL(file.ACL, evalCtx, requested, shareOpts)
+		return evaluateWithACL(file.ACL, buildEvalContext(file.UID, file.GID, identity), requested, shareOpts)
 	}
 
 	uid := *identity.UID
@@ -434,32 +422,7 @@ func evaluateACLPermissions(
 		return requested
 	}
 
-	// Build evaluation context
-	evalCtx := &acl.EvaluateContext{
-		UID:          uid,
-		GIDs:         identity.GIDs,
-		FileOwnerUID: file.UID,
-		FileOwnerGID: file.GID,
-	}
-	if identity.GID != nil {
-		evalCtx.GID = *identity.GID
-	}
-
-	// Set Who to "username@domain" if available for named principal matching
-	switch {
-	case identity.Username != "" && identity.Domain != "":
-		evalCtx.Who = identity.Username + "@" + identity.Domain
-	case identity.Username != "":
-		evalCtx.Who = identity.Username
-	}
-
-	if identity.SID != nil {
-		evalCtx.SID = *identity.SID
-	}
-	evalCtx.GroupSIDs = identity.GroupSIDs
-	// MS-DTYP §2.5.3.2: owner-implicit WRITE_OWNER requires
-	// SeTakeOwnershipPrivilege (admins only). See acl.Evaluate.
-	evalCtx.RequesterHasTakeOwnership = acl.HasTakeOwnershipPrivilege(evalCtx.SID, evalCtx.GroupSIDs)
+	evalCtx := buildEvalContext(file.UID, file.GID, identity)
 
 	return evaluateWithACL(file.ACL, evalCtx, requested, shareOpts)
 }
@@ -1156,35 +1119,47 @@ func (s *Service) ComputeMaximalAccess(file *File, authCtx *AuthContext) uint32 
 	return access
 }
 
-// buildFileAccessEvalContext mirrors evaluateACLPermissions's EvaluateContext
-// construction so per-bit ACL evaluation in CheckFileAccess produces the same
-// allow/deny decisions a downstream read/write permission check would later
-// produce against the same file. Kept private to the metadata package.
+// buildFileAccessEvalContext builds the EvaluateContext used for per-bit ACL
+// evaluation in CheckFileAccess, taking the file owner from the File row.
 func buildFileAccessEvalContext(file *File, authCtx *AuthContext) *acl.EvaluateContext {
-	if authCtx == nil || authCtx.Identity == nil || authCtx.Identity.UID == nil {
-		// FileOwnerUID is forced to the AnonymousFileOwnerUID sentinel so
-		// the anonymous requester's zero-valued UID cannot collapse onto a
-		// root-owned file's owner and pick up OWNER@ ACEs plus the
-		// MS-DTYP §2.5.3.2 owner-implicit RC|WRITE_DAC grant. Anonymous
-		// confines the DACL walk to EVERYONE@.
+	var identity *Identity
+	if authCtx != nil {
+		identity = authCtx.Identity
+	}
+	return buildEvalContext(file.UID, file.GID, identity)
+}
+
+// buildEvalContext builds the acl.EvaluateContext for a requester against a
+// file owned by ownerUID/ownerGID. It is the single construction shared by the
+// ACL access checks in this package, so the NFS, SMB and access-based
+// enumeration paths cannot drift apart.
+//
+// A nil identity (or one with no UID) is anonymous: FileOwnerUID is forced to
+// the acl.AnonymousFileOwnerUID sentinel so the requester's zero-valued UID
+// cannot collapse onto a root-owned file's owner and pick up OWNER@ ACEs plus
+// the MS-DTYP §2.5.3.2 owner-implicit RC|WRITE_DAC grant, and Anonymous
+// confines matching to EVERYONE@ so a zero-valued UID/GID cannot pick up
+// GROUP@ on a root-group-owned file or an explicit "0@localdomain" ACE.
+func buildEvalContext(ownerUID, ownerGID uint32, identity *Identity) *acl.EvaluateContext {
+	if identity == nil || identity.UID == nil {
 		return &acl.EvaluateContext{
 			Anonymous:    true,
 			FileOwnerUID: acl.AnonymousFileOwnerUID,
-			FileOwnerGID: file.GID,
+			FileOwnerGID: ownerGID,
 		}
 	}
 
-	identity := authCtx.Identity
 	evalCtx := &acl.EvaluateContext{
 		UID:          *identity.UID,
 		GIDs:         identity.GIDs,
-		FileOwnerUID: file.UID,
-		FileOwnerGID: file.GID,
+		FileOwnerUID: ownerUID,
+		FileOwnerGID: ownerGID,
 	}
 	if identity.GID != nil {
 		evalCtx.GID = *identity.GID
 	}
 
+	// Who is "username@domain" when both are available, for named principal matching.
 	switch {
 	case identity.Username != "" && identity.Domain != "":
 		evalCtx.Who = identity.Username + "@" + identity.Domain

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -1130,9 +1130,11 @@ func buildFileAccessEvalContext(file *File, authCtx *AuthContext) *acl.EvaluateC
 }
 
 // buildEvalContext builds the acl.EvaluateContext for a requester against a
-// file owned by ownerUID/ownerGID. It is the single construction shared by the
-// ACL access checks in this package, so the NFS, SMB and access-based
-// enumeration paths cannot drift apart.
+// file owned by ownerUID/ownerGID. It is the shared construction behind
+// evaluateACLPermissions and buildFileAccessEvalContext, so the NFS and SMB
+// permission paths cannot drift apart. buildAttrEvalContext
+// (file_access_checker.go) still carries its own copy for the access-based
+// enumeration path.
 //
 // A nil identity (or one with no UID) is anonymous: FileOwnerUID is forced to
 // the acl.AnonymousFileOwnerUID sentinel so the requester's zero-valued UID


### PR DESCRIPTION
Two of the duplicated-algorithm findings from the 2026-08-05 data-plane audit.
Pure structural refactor: no behaviour change.

## 1. `acl.Evaluate` / `acl.EvaluateGranted` duplicated the entire DACL walk

`evaluate.go` carried the security-critical access-check algorithm twice, byte-identical
modulo the final test:

- the owner-rights pre-scan (does an effective `OWNER_RIGHTS` ACE exist?),
- the first-match-wins ACE accumulation (`ace.AccessMask &^ (allowedBits | deniedBits)`),
- the MS-DTYP §2.5.3.2 owner-implicit tail including `RequesterHasTakeOwnership`.

Nothing kept the two copies in sync. They now share one private
`walkDACL(a, evalCtx, decisionMask) uint32` that returns the accumulated allowed bits;
`decisionMask` only drives early termination, which (as `EvaluateGranted`'s own godoc
already argued) never alters the outcome for any individual bit. The two entry points
keep their own nil/`NullDACL`/empty-mask contracts and differ only in what they do with
the result:

```go
Evaluate:         walkDACL(a, evalCtx, requestedMask)&requestedMask == requestedMask
EvaluateGranted:  walkDACL(a, evalCtx, probeMask) & probeMask
```

## 2. `acl.EvaluateContext` construction built from scratch in two places

`evaluateACLPermissions` (inline) and `buildFileAccessEvalContext` each built the same
~25-line context — anonymous `AnonymousFileOwnerUID` sentinel branch, then
UID/GIDs/GID/Who switch/SID/GroupSIDs/`RequesterHasTakeOwnership`. The second one's
godoc literally said it "mirrors evaluateACLPermissions". Both now call one
`buildEvalContext(ownerUID, ownerGID uint32, identity *Identity)`.

The inline copy's anonymous branch also moved ahead of the root bypass, which is where it
already effectively sat: an anonymous requester has no UID, so the `uid == 0` bypass was
unreachable for it.

### Known remaining copy

`file_access_checker.go:buildAttrEvalContext` is a third copy of the same construction
(same body, `*FileAttr` instead of `*File`). It is not touched here because that file is
owned by a concurrent branch; collapsing it is a one-line delegation to `buildEvalContext`
once that lands.

## Evidence

Behaviour-preserving by construction; the evidence is the existing suites, which cover
this code heavily (`evaluate_test.go` 36 KB, `evaluate_granted_test.go`, plus the
metadata permission suites).

```
go build ./... && go vet ./pkg/metadata/...   # clean
go test -race ./pkg/metadata/... ./internal/adapter/...   # all pass
```

Net: 148 lines removed, 73 added.

Refs #1967
