### PR TITLE
refactor(journal): decompose recover() into named phases

### DIFF
--- a/pkg/block/journal/recovery.go
+++ b/pkg/block/journal/recovery.go
@@ -53,337 +53,47 @@ func scanSegmentIDs(dir string) ([]uint64, error) {
 // its torn tail truncated. All valid records feed a fresh interval index — order
 // does not matter because insert resolves overlaps by Version — and the global
 // LSN resumes at max(observed Version)+1.
+//
+// The phases run in the order below; each is a method on recoveryState, which
+// carries the tables being rebuilt between them.
 func (s *Store) recover() error {
-	segIDs, err := scanSegmentIDs(s.dir)
-	if err != nil {
-		return err
-	}
-	// Deterministic, ascending replay. Version still decides newest-wins, but a
-	// stable order keeps recovery reproducible and eases debugging.
-	sort.Slice(segIDs, func(i, j int) bool { return segIDs[i] < segIDs[j] })
+	r := newRecoveryState(s)
 
-	n := s.cfg.ShardCount
-	actives := make([]*segmentMeta, n) // data-bearing unsealed segment per shard
-	sealedByShard := make([]map[uint64]*segmentMeta, n)
-	indexByShard := make([]map[FileID]*fileIndex, n)
-	for i := 0; i < n; i++ {
-		sealedByShard[i] = make(map[uint64]*segmentMeta)
-		indexByShard[i] = make(map[FileID]*fileIndex)
-	}
-
-	var (
-		emptyPool   []*segmentMeta // empty unsealed segments, reusable as any shard's active
-		orphans     []uint64       // unattachable segment ids, candidates for the age-gated sweep
-		maxSegID    uint64
-		maxVersion  uint64
-		unsynced    int64
-		missingIdx  int
-		opened      []*segmentMeta           // every fd we opened, closed on error
-		tombstones  = map[FileID]uint64{}    // deleted file -> highest tombstone version
-		truncations = map[FileID]truncMark{} // truncated file -> highest truncate marker
-		ok          bool
-	)
+	ok := false
 	defer func() {
 		if !ok {
-			for _, m := range opened {
-				_ = m.close()
-			}
+			r.closeOpened()
 		}
 	}()
 
-	for _, id := range segIDs {
-		if id > maxSegID {
-			maxSegID = id
-		}
-		path := s.segPath(id)
-		fd, err := os.OpenFile(path, os.O_RDWR, 0o644)
-		if err != nil {
-			return fmt.Errorf("journal: open segment %q: %w", path, err)
-		}
-		var hdr [segHeaderSize]byte
-		if _, rerr := fd.ReadAt(hdr[:], 0); rerr != nil {
-			// A header that will not even read back is a torn create; sweep it.
-			_ = fd.Close()
-			orphans = append(orphans, id)
-			continue
-		}
-		hdrID, createdAt, flags, hdrOK := decodeSegHeader(hdr[:])
-		if !hdrOK || hdrID != id {
-			_ = fd.Close()
-			orphans = append(orphans, id)
-			continue
-		}
-		sealed := flags&segFlagSealed != 0
-
-		// SegmentSize is the ceiling for a single record's PayloadLen (the append
-		// path enforces it), so it doubles as the sanity ceiling that stops a
-		// CRC-coincidence torn header from making the scanner trust a bogus length.
-		recs, validUpTo := scanValidRecords(fd, s.cfg.SegmentSize, s.cfg.SegmentSize)
-
-		if sealed && len(recs) == 0 {
-			// No write path can produce this: sealing fsyncs the records before it
-			// sets the sealed bit, and every seal is gated on the segment already
-			// holding a record. A sealed header over a record stream that scans
-			// empty therefore means the bytes under it were damaged after the fact.
-			// Skip the segment — no record names its shard, so there is nothing to
-			// attach it to — but leave the file on disk rather than sweeping it:
-			// nothing in the rebuilt index points into it, so unlinking it would
-			// destroy the only remaining copy of whatever payload is still down
-			// there.
-			_ = fd.Close()
-			logger.Warn("journal: sealed segment scans as zero valid records (damaged first record), skipping it; left in place for inspection",
-				"segment_path", path)
-			continue
-		}
-
-		m := &segmentMeta{id: id, createdAt: createdAt, fd: fd}
-		m.tail.Store(validUpTo)
-		if sealed {
-			m.sealed.Store(true)
-		}
-		opened = append(opened, m)
-
-		if !sealed && len(recs) == 0 {
-			// Empty active segment: no records name its shard. Hold it as a reuse
-			// pool entry rather than a data-bearing active.
-			emptyPool = append(emptyPool, m)
-			continue
-		}
-		if !sealed && validUpTo < fileSize(fd) {
-			// Drop the torn tail and make the truncation durable before it is read.
-			if terr := fd.Truncate(validUpTo); terr != nil {
-				return fmt.Errorf("journal: truncate torn tail %q: %w", path, terr)
-			}
-			if serr := fd.Sync(); serr != nil {
-				return fmt.Errorf("journal: fsync truncated segment %q: %w", path, serr)
-			}
-		}
-
-		// Every record in a segment belongs to files that hash to one shard, so
-		// the first record names the segment's shard.
-		sh := s.shardIndex(FileID(recs[0].fileID))
-
-		if !sealed {
-			m.idxFD, _ = os.OpenFile(s.idxPath(id), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
-			if actives[sh] == nil {
-				actives[sh] = m
-			} else {
-				// Defensive: two data-bearing unsealed segments for one shard should
-				// never happen (one active per shard). Keep the higher id active and
-				// demote the other to a sealed, still-readable segment.
-				if id > actives[sh].id {
-					actives[sh], m = m, actives[sh]
-				}
-				m.sealed.Store(true)
-				if m.idxFD != nil {
-					_ = m.idxFD.Close()
-					m.idxFD = nil
-				}
-				sealedByShard[sh][m.id] = m
-			}
-		} else {
-			sealedByShard[sh][id] = m
-		}
-
-		if s.idxMissing(id) {
-			if rerr := s.rebuildIdx(id, recs); rerr != nil {
-				return rerr
-			}
-			missingIdx++
-		}
-
-		idxMap := indexByShard[sh]
-		for _, rec := range recs {
-			if rec.header.Version > maxVersion {
-				maxVersion = rec.header.Version
-			}
-			// Reconstruct the segment's pin watermark: minVersion is the lowest
-			// record Version it holds, so a live snapshot keeps it off GC.
-			m.noteMinVersion(rec.header.Version)
-			if rec.header.Flags&flagTombstone != 0 {
-				fid := FileID(rec.fileID)
-				if rec.header.Version > tombstones[fid] {
-					tombstones[fid] = rec.header.Version
-				}
-				continue
-			}
-			if rec.header.Flags&flagTruncate != 0 {
-				fid := FileID(rec.fileID)
-				if cur, ok := truncations[fid]; !ok || rec.header.Version > cur.version {
-					truncations[fid] = truncMark{version: rec.header.Version, newSize: int64(rec.header.FileOffset)}
-				}
-				continue
-			}
-			payloadOff := rec.segOff + recordHeaderSize + int64(len(rec.fileID))
-			fid := FileID(rec.fileID)
-			fi := idxMap[fid]
-			if fi == nil {
-				fi = &fileIndex{}
-				idxMap[fid] = fi
-			}
-			synced := rec.header.Flags&flagSynced != 0
-			fi.insert(interval{
-				fileOff: int64(rec.header.FileOffset),
-				length:  int64(rec.header.PayloadLen),
-				version: rec.header.Version,
-				recOff:  rec.segOff,
-				synced:  synced,
-				loc: SegmentLocation{
-					SegmentID: id,
-					Offset:    payloadOff,
-					Length:    int64(rec.header.PayloadLen),
-				},
-			})
-			// Coarse byte accounting: liveBytes ignores same-segment supersession
-			// (GC recomputes deadBytes on repack). unsynced feeds write backpressure.
-			m.liveBytes.Add(int64(rec.header.PayloadLen))
-			m.records.Add(1)
-			if synced {
-				m.syncedRecords.Add(1)
-			} else if fi.firstDirtyNanos == 0 {
-				// A recovered dirty file gets a fresh dirty-age stamp so the carve
-				// age gate fires after a restart (approximate — the original write
-				// time is not persisted; it is only a batching heuristic).
-				fi.firstDirtyNanos = s.clock.Now().UnixNano()
-			}
-		}
+	if err := r.scanSegments(); err != nil {
+		return err
 	}
-
-	if missingIdx > 0 {
+	if r.missingIdx > 0 {
 		logger.Warn("journal: segments missing .idx sidecar, rebuilding from segment scan (recovery slower)",
-			"segments", missingIdx)
+			"segments", r.missingIdx)
+	}
+	if err := r.applyColdLog(); err != nil {
+		return err
 	}
 
-	// Replay the cold log (cold.go). A cold interval owns no record — eviction
-	// unlinked the segment that held its bytes, or the range was seeded cold from
-	// a surviving manifest — so this side-log is the only thing that keeps the
-	// range from coming back as a POSIX hole that reads as zeros. Inserted with
-	// each entry's original Version, so a later warm write shadows it and the
-	// tombstone/truncate passes below clip it exactly like a warm interval.
-	coldLoaded, err := loadCold(s.dir)
+	s.nextSeg.Store(r.maxSegID + 1)
+	// nextVersion increments-then-returns, so storing maxVersion makes the next
+	// issued LSN exactly max(observed)+1 — strictly past every replayed record.
+	s.version.Store(r.maxVersion)
+
+	applyTombstones(r.indexByShard, r.tombstones)
+	applyTruncations(r.indexByShard, r.truncations)
+
+	r.compactColdLog()
+	s.unsynced.Store(r.reconcileByteCounters())
+
+	shards, err := r.assignActiveSegments()
 	if err != nil {
 		return err
 	}
-	for _, e := range coldLoaded {
-		if e.length <= 0 {
-			continue
-		}
-		if e.version > maxVersion {
-			maxVersion = e.version
-		}
-		idxMap := indexByShard[s.shardIndex(e.id)]
-		fi := idxMap[e.id]
-		if fi == nil {
-			fi = &fileIndex{}
-			idxMap[e.id] = fi
-		}
-		fi.insert(interval{
-			fileOff: e.fileOff,
-			length:  e.length,
-			version: e.version,
-			synced:  true,
-			cold:    true,
-		})
-	}
 
-	s.nextSeg.Store(maxSegID + 1)
-	// nextVersion increments-then-returns, so storing maxVersion makes the next
-	// issued LSN exactly max(observed)+1 — strictly past every replayed record.
-	s.version.Store(maxVersion)
-
-	applyTombstones(indexByShard, tombstones)
-	applyTruncations(indexByShard, truncations)
-
-	// Compact the cold log once the live set has drifted well below what the log
-	// holds: entries superseded by a later hydrate, buried by a tombstone or
-	// clipped by a truncate are dead weight the next recovery would replay again.
-	// Recovery is the only place the surviving set is known, and rewriting is
-	// atomic (temp + rename), so a crash here keeps the previous log.
-	// ponytail: compaction only at open — the log grows within one uptime only as
-	// fast as eviction marks new ranges cold, which is bounded by the local cap.
-	if live := liveColdEntries(indexByShard); len(coldLoaded) > 2*len(live)+coldCompactFloor {
-		if werr := s.rewriteCold(live); werr != nil {
-			// Non-fatal: a stale-but-valid log costs redundant replay, not
-			// correctness, and refusing to open would strand the whole share.
-			logger.Warn("journal: cold log compaction failed, keeping the existing log", "err", werr)
-		}
-	}
-
-	// Recompute unsynced from the final live coverage rather than the raw
-	// per-record sum: insert resolves overlaps, so a superseded record's bytes are
-	// dead and must not count toward the backpressure signal. In the same pass,
-	// reconstruct each segment's deadBytes from the authoritative live coverage
-	// (occupied liveBytes − currently-live): replay charges only physical records,
-	// so tombstones, same-segment overlaps, and truncate clips leave dead payload
-	// that never touched the counter. Without this, pickVictim's deadBytes<=0 gate
-	// skips every recovered segment and GC can never reclaim pre-restart dead space.
-	// Skip cold intervals exactly as pickVictim does so the live totals agree.
-	for i, idxMap := range indexByShard {
-		live := make(map[uint64]int64)
-		for _, fi := range idxMap {
-			for k := range fi.ivs {
-				if fi.ivs[k].cold {
-					continue
-				}
-				if !fi.ivs[k].synced {
-					unsynced += fi.ivs[k].length
-				}
-				live[fi.ivs[k].loc.SegmentID] += fi.ivs[k].length
-			}
-		}
-		for id, seg := range sealedByShard[i] {
-			if dead := seg.liveBytes.Load() - live[id]; dead > 0 {
-				seg.deadBytes.Store(dead)
-			}
-		}
-		if a := actives[i]; a != nil {
-			if dead := a.liveBytes.Load() - live[a.id]; dead > 0 {
-				a.deadBytes.Store(dead)
-			}
-		}
-	}
-	s.unsynced.Store(unsynced)
-
-	// Give every shard an active segment: reuse a pooled empty one, else mint a
-	// fresh one (nextSeg is now set past every recovered id). Build into a local
-	// slice and publish it only on success so a mid-build error path never leaves
-	// half-open fds double-closed by both the defer and the caller's Close.
-	poolPos := 0
-	shards := make([]*shard, n)
-	for i := 0; i < n; i++ {
-		active := actives[i]
-		if active == nil {
-			if poolPos < len(emptyPool) {
-				active = emptyPool[poolPos]
-				poolPos++
-				active.idxFD, _ = os.OpenFile(s.idxPath(active.id), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
-			} else {
-				seg, cerr := s.createSegment()
-				if cerr != nil {
-					return cerr
-				}
-				opened = append(opened, seg)
-				active = seg
-			}
-		}
-		sh := newShard(active)
-		sh.sealed = sealedByShard[i]
-		sh.index = indexByShard[i]
-		// Everything the index holds now was read back off the device and passed
-		// its CRCs, so it survived the crash by definition: the durable watermark
-		// starts at the highest replayed Version rather than at zero.
-		sh.lastVersion = maxVersion
-		sh.syncedVersion.Store(maxVersion)
-		shards[i] = sh
-	}
-
-	// Any pooled empty segment we did not adopt is an orphan.
-	for ; poolPos < len(emptyPool); poolPos++ {
-		orphans = append(orphans, emptyPool[poolPos].id)
-		_ = emptyPool[poolPos].close()
-	}
-
-	s.sweepOrphans(orphans)
+	s.sweepOrphans(r.orphans)
 	s.shards = shards
 	// Reconcile the disk-byte counter with what recovery actually opened: each
 	// segment's tail is its on-disk size (header + intact records). createSegment
@@ -400,6 +110,381 @@ func (s *Store) recover() error {
 	s.diskBytes.Store(disk)
 	ok = true
 	return nil
+}
+
+// recoveryState carries the tables recover() rebuilds across its phases: the
+// per-shard segment and interval maps, the segments opened so far (all closed
+// again if a later phase fails), and the tombstone/truncate markers whose
+// clipping is deferred until every record has been replayed.
+type recoveryState struct {
+	s *Store
+
+	actives       []*segmentMeta // data-bearing unsealed segment per shard
+	sealedByShard []map[uint64]*segmentMeta
+	indexByShard  []map[FileID]*fileIndex
+
+	emptyPool []*segmentMeta // empty unsealed segments, reusable as any shard's active
+	orphans   []uint64       // unattachable segment ids, candidates for the age-gated sweep
+	opened    []*segmentMeta // every fd we opened, closed on error
+
+	maxSegID   uint64
+	maxVersion uint64
+	missingIdx int
+	coldLoaded int // cold-log entries read back, for the compaction ratio
+
+	tombstones  map[FileID]uint64    // deleted file -> highest tombstone version
+	truncations map[FileID]truncMark // truncated file -> highest truncate marker
+}
+
+func newRecoveryState(s *Store) *recoveryState {
+	n := s.cfg.ShardCount
+	r := &recoveryState{
+		s:             s,
+		actives:       make([]*segmentMeta, n),
+		sealedByShard: make([]map[uint64]*segmentMeta, n),
+		indexByShard:  make([]map[FileID]*fileIndex, n),
+		tombstones:    map[FileID]uint64{},
+		truncations:   map[FileID]truncMark{},
+	}
+	for i := 0; i < n; i++ {
+		r.sealedByShard[i] = make(map[uint64]*segmentMeta)
+		r.indexByShard[i] = make(map[FileID]*fileIndex)
+	}
+	return r
+}
+
+func (r *recoveryState) closeOpened() {
+	for _, m := range r.opened {
+		_ = m.close()
+	}
+}
+
+// scanSegments opens every <id>.seg in the store directory in ascending id
+// order and folds it into the recovery tables.
+func (r *recoveryState) scanSegments() error {
+	segIDs, err := scanSegmentIDs(r.s.dir)
+	if err != nil {
+		return err
+	}
+	// Deterministic, ascending replay. Version still decides newest-wins, but a
+	// stable order keeps recovery reproducible and eases debugging.
+	sort.Slice(segIDs, func(i, j int) bool { return segIDs[i] < segIDs[j] })
+
+	for _, id := range segIDs {
+		if id > r.maxSegID {
+			r.maxSegID = id
+		}
+		if err := r.loadSegment(id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// loadSegment reads one segment's header and record stream, classifies it as
+// active / sealed / empty / orphan, truncates an active segment's torn tail,
+// and replays its records into the shard's interval index.
+func (r *recoveryState) loadSegment(id uint64) error {
+	s := r.s
+	path := s.segPath(id)
+	fd, err := os.OpenFile(path, os.O_RDWR, 0o644)
+	if err != nil {
+		return fmt.Errorf("journal: open segment %q: %w", path, err)
+	}
+	var hdr [segHeaderSize]byte
+	if _, rerr := fd.ReadAt(hdr[:], 0); rerr != nil {
+		// A header that will not even read back is a torn create; sweep it.
+		_ = fd.Close()
+		r.orphans = append(r.orphans, id)
+		return nil
+	}
+	hdrID, createdAt, flags, hdrOK := decodeSegHeader(hdr[:])
+	if !hdrOK || hdrID != id {
+		_ = fd.Close()
+		r.orphans = append(r.orphans, id)
+		return nil
+	}
+	sealed := flags&segFlagSealed != 0
+
+	// SegmentSize is the ceiling for a single record's PayloadLen (the append
+	// path enforces it), so it doubles as the sanity ceiling that stops a
+	// CRC-coincidence torn header from making the scanner trust a bogus length.
+	recs, validUpTo := scanValidRecords(fd, s.cfg.SegmentSize, s.cfg.SegmentSize)
+
+	if sealed && len(recs) == 0 {
+		// No write path can produce this: sealing fsyncs the records before it
+		// sets the sealed bit, and every seal is gated on the segment already
+		// holding a record. A sealed header over a record stream that scans
+		// empty therefore means the bytes under it were damaged after the fact.
+		// Skip the segment — no record names its shard, so there is nothing to
+		// attach it to — but leave the file on disk rather than sweeping it:
+		// nothing in the rebuilt index points into it, so unlinking it would
+		// destroy the only remaining copy of whatever payload is still down
+		// there.
+		_ = fd.Close()
+		logger.Warn("journal: sealed segment scans as zero valid records (damaged first record), skipping it; left in place for inspection",
+			"segment_path", path)
+		return nil
+	}
+
+	m := &segmentMeta{id: id, createdAt: createdAt, fd: fd}
+	m.tail.Store(validUpTo)
+	if sealed {
+		m.sealed.Store(true)
+	}
+	r.opened = append(r.opened, m)
+
+	if !sealed && len(recs) == 0 {
+		// Empty active segment: no records name its shard. Hold it as a reuse
+		// pool entry rather than a data-bearing active.
+		r.emptyPool = append(r.emptyPool, m)
+		return nil
+	}
+	if !sealed && validUpTo < fileSize(fd) {
+		// Drop the torn tail and make the truncation durable before it is read.
+		if terr := fd.Truncate(validUpTo); terr != nil {
+			return fmt.Errorf("journal: truncate torn tail %q: %w", path, terr)
+		}
+		if serr := fd.Sync(); serr != nil {
+			return fmt.Errorf("journal: fsync truncated segment %q: %w", path, serr)
+		}
+	}
+
+	// Every record in a segment belongs to files that hash to one shard, so
+	// the first record names the segment's shard.
+	sh := s.shardIndex(FileID(recs[0].fileID))
+
+	if !sealed {
+		m.idxFD, _ = os.OpenFile(s.idxPath(id), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
+		if r.actives[sh] == nil {
+			r.actives[sh] = m
+		} else {
+			// Defensive: two data-bearing unsealed segments for one shard should
+			// never happen (one active per shard). Keep the higher id active and
+			// demote the other to a sealed, still-readable segment.
+			if id > r.actives[sh].id {
+				r.actives[sh], m = m, r.actives[sh]
+			}
+			m.sealed.Store(true)
+			if m.idxFD != nil {
+				_ = m.idxFD.Close()
+				m.idxFD = nil
+			}
+			r.sealedByShard[sh][m.id] = m
+		}
+	} else {
+		r.sealedByShard[sh][id] = m
+	}
+
+	if s.idxMissing(id) {
+		if rerr := s.rebuildIdx(id, recs); rerr != nil {
+			return rerr
+		}
+		r.missingIdx++
+	}
+
+	r.replayRecords(m, sh, id, recs)
+	return nil
+}
+
+// replayRecords folds one segment's valid records into the shard's interval
+// index: tombstone and truncate markers are collected for the deferred clipping
+// passes, every other record becomes an interval and feeds the segment's byte
+// and record counters.
+func (r *recoveryState) replayRecords(m *segmentMeta, sh, id uint64, recs []record) {
+	idxMap := r.indexByShard[sh]
+	for _, rec := range recs {
+		if rec.header.Version > r.maxVersion {
+			r.maxVersion = rec.header.Version
+		}
+		// Reconstruct the segment's pin watermark: minVersion is the lowest
+		// record Version it holds, so a live snapshot keeps it off GC.
+		m.noteMinVersion(rec.header.Version)
+		if rec.header.Flags&flagTombstone != 0 {
+			fid := FileID(rec.fileID)
+			if rec.header.Version > r.tombstones[fid] {
+				r.tombstones[fid] = rec.header.Version
+			}
+			continue
+		}
+		if rec.header.Flags&flagTruncate != 0 {
+			fid := FileID(rec.fileID)
+			if cur, ok := r.truncations[fid]; !ok || rec.header.Version > cur.version {
+				r.truncations[fid] = truncMark{version: rec.header.Version, newSize: int64(rec.header.FileOffset)}
+			}
+			continue
+		}
+		payloadOff := rec.segOff + recordHeaderSize + int64(len(rec.fileID))
+		fid := FileID(rec.fileID)
+		fi := idxMap[fid]
+		if fi == nil {
+			fi = &fileIndex{}
+			idxMap[fid] = fi
+		}
+		synced := rec.header.Flags&flagSynced != 0
+		fi.insert(interval{
+			fileOff: int64(rec.header.FileOffset),
+			length:  int64(rec.header.PayloadLen),
+			version: rec.header.Version,
+			recOff:  rec.segOff,
+			synced:  synced,
+			loc: SegmentLocation{
+				SegmentID: id,
+				Offset:    payloadOff,
+				Length:    int64(rec.header.PayloadLen),
+			},
+		})
+		// Coarse byte accounting: liveBytes ignores same-segment supersession
+		// (GC recomputes deadBytes on repack). unsynced feeds write backpressure.
+		m.liveBytes.Add(int64(rec.header.PayloadLen))
+		m.records.Add(1)
+		if synced {
+			m.syncedRecords.Add(1)
+		} else if fi.firstDirtyNanos == 0 {
+			// A recovered dirty file gets a fresh dirty-age stamp so the carve
+			// age gate fires after a restart (approximate — the original write
+			// time is not persisted; it is only a batching heuristic).
+			fi.firstDirtyNanos = r.s.clock.Now().UnixNano()
+		}
+	}
+}
+
+// applyColdLog replays the cold log (cold.go). A cold interval owns no record —
+// eviction unlinked the segment that held its bytes, or the range was seeded
+// cold from a surviving manifest — so this side-log is the only thing that keeps
+// the range from coming back as a POSIX hole that reads as zeros. Inserted with
+// each entry's original Version, so a later warm write shadows it and the
+// tombstone/truncate passes clip it exactly like a warm interval.
+func (r *recoveryState) applyColdLog() error {
+	coldLoaded, err := loadCold(r.s.dir)
+	if err != nil {
+		return err
+	}
+	r.coldLoaded = len(coldLoaded)
+	for _, e := range coldLoaded {
+		if e.length <= 0 {
+			continue
+		}
+		if e.version > r.maxVersion {
+			r.maxVersion = e.version
+		}
+		idxMap := r.indexByShard[r.s.shardIndex(e.id)]
+		fi := idxMap[e.id]
+		if fi == nil {
+			fi = &fileIndex{}
+			idxMap[e.id] = fi
+		}
+		fi.insert(interval{
+			fileOff: e.fileOff,
+			length:  e.length,
+			version: e.version,
+			synced:  true,
+			cold:    true,
+		})
+	}
+	return nil
+}
+
+// compactColdLog rewrites the cold log once the live set has drifted well below
+// what the log holds: entries superseded by a later hydrate, buried by a
+// tombstone or clipped by a truncate are dead weight the next recovery would
+// replay again. Recovery is the only place the surviving set is known, and
+// rewriting is atomic (temp + rename), so a crash here keeps the previous log.
+// ponytail: compaction only at open — the log grows within one uptime only as
+// fast as eviction marks new ranges cold, which is bounded by the local cap.
+func (r *recoveryState) compactColdLog() {
+	live := liveColdEntries(r.indexByShard)
+	if r.coldLoaded <= 2*len(live)+coldCompactFloor {
+		return
+	}
+	if werr := r.s.rewriteCold(live); werr != nil {
+		// Non-fatal: a stale-but-valid log costs redundant replay, not
+		// correctness, and refusing to open would strand the whole share.
+		logger.Warn("journal: cold log compaction failed, keeping the existing log", "err", werr)
+	}
+}
+
+// reconcileByteCounters recomputes unsynced from the final live coverage rather
+// than the raw per-record sum: insert resolves overlaps, so a superseded
+// record's bytes are dead and must not count toward the backpressure signal. In
+// the same pass it reconstructs each segment's deadBytes from the authoritative
+// live coverage (occupied liveBytes − currently-live): replay charges only
+// physical records, so tombstones, same-segment overlaps, and truncate clips
+// leave dead payload that never touched the counter. Without this, pickVictim's
+// deadBytes<=0 gate skips every recovered segment and GC can never reclaim
+// pre-restart dead space. Cold intervals are skipped exactly as pickVictim skips
+// them so the live totals agree.
+func (r *recoveryState) reconcileByteCounters() int64 {
+	var unsynced int64
+	for i, idxMap := range r.indexByShard {
+		live := make(map[uint64]int64)
+		for _, fi := range idxMap {
+			for k := range fi.ivs {
+				if fi.ivs[k].cold {
+					continue
+				}
+				if !fi.ivs[k].synced {
+					unsynced += fi.ivs[k].length
+				}
+				live[fi.ivs[k].loc.SegmentID] += fi.ivs[k].length
+			}
+		}
+		for id, seg := range r.sealedByShard[i] {
+			if dead := seg.liveBytes.Load() - live[id]; dead > 0 {
+				seg.deadBytes.Store(dead)
+			}
+		}
+		if a := r.actives[i]; a != nil {
+			if dead := a.liveBytes.Load() - live[a.id]; dead > 0 {
+				a.deadBytes.Store(dead)
+			}
+		}
+	}
+	return unsynced
+}
+
+// assignActiveSegments gives every shard an active segment: reuse a pooled empty
+// one, else mint a fresh one (nextSeg is set past every recovered id by the time
+// this runs). The shards are built into a local slice and published by the
+// caller only on success, so a mid-build error path never leaves half-open fds
+// double-closed by both the recovery defer and the caller's Close. Any pooled
+// empty segment left unadopted joins the orphan sweep.
+func (r *recoveryState) assignActiveSegments() ([]*shard, error) {
+	n := r.s.cfg.ShardCount
+	poolPos := 0
+	shards := make([]*shard, n)
+	for i := 0; i < n; i++ {
+		active := r.actives[i]
+		if active == nil {
+			if poolPos < len(r.emptyPool) {
+				active = r.emptyPool[poolPos]
+				poolPos++
+				active.idxFD, _ = os.OpenFile(r.s.idxPath(active.id), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
+			} else {
+				seg, cerr := r.s.createSegment()
+				if cerr != nil {
+					return nil, cerr
+				}
+				r.opened = append(r.opened, seg)
+				active = seg
+			}
+		}
+		sh := newShard(active)
+		sh.sealed = r.sealedByShard[i]
+		sh.index = r.indexByShard[i]
+		// Everything the index holds now was read back off the device and passed
+		// its CRCs, so it survived the crash by definition: the durable watermark
+		// starts at the highest replayed Version rather than at zero.
+		sh.lastVersion = r.maxVersion
+		sh.syncedVersion.Store(r.maxVersion)
+		shards[i] = sh
+	}
+
+	for ; poolPos < len(r.emptyPool); poolPos++ {
+		r.orphans = append(r.orphans, r.emptyPool[poolPos].id)
+		_ = r.emptyPool[poolPos].close()
+	}
+	return shards, nil
 }
 
 // applyTombstones drops each deleted file's intervals older than its tombstone.


### PR DESCRIPTION
One of the god-function findings from the 2026-08-05 data-plane audit.
Pure structural refactor: no behaviour change.

## What was wrong

`Store.recover()` was a ~350-line single body threading a dozen mutable locals
(`actives`, `sealedByShard`, `indexByShard`, `emptyPool`, `orphans`, `tombstones`,
`truncations`, `unsynced`, `missingIdx`, `opened`, `maxSegID`, `maxVersion`) across eight
unrelated concerns:

1. segment directory scan and header classification (active / sealed / empty / orphan),
2. torn-tail truncate + fsync,
3. `.idx` sidecar rebuild,
4. record replay into the interval index, including tombstone/truncate marker collection,
5. cold-log replay,
6. cold-log compaction,
7. byte-counter reconciliation (`unsynced`, per-segment `deadBytes`),
8. active-segment assignment and the orphan sweep.

This is the replay-correctness path — the one that decides whether a range comes back as
data or as a hole reading zeros — and none of those phases could be exercised on its own.

## What changed

The working set moves into a `recoveryState` struct, and each phase becomes a method:

| method | phase |
| --- | --- |
| `scanSegments` / `loadSegment` | 1-3 |
| `replayRecords` | 4 |
| `applyColdLog` | 5 |
| `compactColdLog` | 6 |
| `reconcileByteCounters` | 7 |
| `assignActiveSegments` | 8 |

`recover()` is now a 55-line orchestrator calling them in exactly the order the inline body
ran. `recoveryState.opened` keeps the existing all-or-nothing fd cleanup: the same
`ok`-guarded defer closes every segment opened by any phase if a later phase fails.

Mechanical notes:

- the per-segment `continue`s in the scan loop became `return nil` from `loadSegment`,
- `unsynced` is now `reconcileByteCounters`'s return value instead of a shared local,
- `liveColdEntries` was already evaluated unconditionally (it was the `if` statement's init
  clause), so hoisting it into `compactColdLog` changes nothing.

No logic, ordering, or error path was altered.

## Evidence

```
go build ./... && go vet ./pkg/block/journal/          # clean
go test -race ./pkg/block/journal/                     # ok (84s)
```

The journal package has the crash/replay suites; they are the check that matters here and
they pass unchanged under `-race`.

Refs #1967
