### PR TITLE
refactor(metadata): drop the memory store's dead lock sub-store and its shadow mutexes

### DIFF
--- a/pkg/metadata/store/memory/client_recovery.go
+++ b/pkg/metadata/store/memory/client_recovery.go
@@ -2,7 +2,6 @@ package memory
 
 import (
 	"context"
-	"sync"
 
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
@@ -15,11 +14,10 @@ import (
 // storage. Records are server-global, keyed by ClientIDString.
 //
 // Thread Safety:
-// All operations are protected by a read-write mutex. Returned records are
-// deep copies so callers can never alias or mutate the stored record.
+// It carries no lock of its own: every field is read and written by
+// MemoryMetadataStore under the store-wide mutex. Returned records are deep
+// copies so callers can never alias or mutate the stored record.
 type memoryRecoveryStore struct {
-	mu sync.RWMutex
-
 	// records maps ClientIDString to its recovery record.
 	records map[string]*lock.V4ClientRecoveryRecord
 }
@@ -48,9 +46,6 @@ func (s *memoryRecoveryStore) PutClientRecovery(ctx context.Context, rec *lock.V
 		return err
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	// Store a clone so a later mutation of the caller's record does not
 	// leak into the store.
 	s.records[rec.ClientIDString] = cloneRecoveryRecord(rec)
@@ -63,9 +58,6 @@ func (s *memoryRecoveryStore) DeleteClientRecovery(ctx context.Context, clientID
 		return err
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	delete(s.records, clientIDString)
 	return nil
 }
@@ -75,9 +67,6 @@ func (s *memoryRecoveryStore) ListClientRecovery(ctx context.Context) ([]*lock.V
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-
-	s.mu.RLock()
-	defer s.mu.RUnlock()
 
 	result := make([]*lock.V4ClientRecoveryRecord, 0, len(s.records))
 	for _, rec := range s.records {
@@ -91,9 +80,6 @@ func (s *memoryRecoveryStore) RecordReclaimComplete(ctx context.Context, clientI
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	if rec, ok := s.records[clientIDString]; ok {
 		rec.ReclaimComplete = true

--- a/pkg/metadata/store/memory/clients.go
+++ b/pkg/metadata/store/memory/clients.go
@@ -2,7 +2,6 @@ package memory
 
 import (
 	"context"
-	"sync"
 
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
@@ -18,11 +17,9 @@ import (
 //   - Ephemeral deployments where client registration persistence is not required
 //
 // Thread Safety:
-// All operations are protected by a read-write mutex, making the store
-// safe for concurrent access from multiple goroutines.
+// It carries no lock of its own: every field is read and written by
+// MemoryMetadataStore under the store-wide mutex.
 type memoryClientStore struct {
-	mu sync.RWMutex
-
 	// registrations maps client ID to PersistedClientRegistration
 	registrations map[string]*lock.PersistedClientRegistration
 }
@@ -40,9 +37,6 @@ func (s *memoryClientStore) PutClientRegistration(ctx context.Context, reg *lock
 		return err
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	// Clone the registration to prevent external modifications
 	s.registrations[reg.ClientID] = cloneClientRegistration(reg)
 	return nil
@@ -53,9 +47,6 @@ func (s *memoryClientStore) GetClientRegistration(ctx context.Context, clientID 
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-
-	s.mu.RLock()
-	defer s.mu.RUnlock()
 
 	reg, exists := s.registrations[clientID]
 	if !exists {
@@ -72,9 +63,6 @@ func (s *memoryClientStore) DeleteClientRegistration(ctx context.Context, client
 		return err
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	delete(s.registrations, clientID)
 	return nil
 }
@@ -84,9 +72,6 @@ func (s *memoryClientStore) ListClientRegistrations(ctx context.Context) ([]*loc
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-
-	s.mu.RLock()
-	defer s.mu.RUnlock()
 
 	result := make([]*lock.PersistedClientRegistration, 0, len(s.registrations))
 	for _, reg := range s.registrations {
@@ -101,9 +86,6 @@ func (s *memoryClientStore) DeleteAllClientRegistrations(ctx context.Context) (i
 		return 0, err
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	count := len(s.registrations)
 	s.registrations = make(map[string]*lock.PersistedClientRegistration)
 	return count, nil
@@ -114,9 +96,6 @@ func (s *memoryClientStore) DeleteClientRegistrationsByMonName(ctx context.Conte
 	if err := ctx.Err(); err != nil {
 		return 0, err
 	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	count := 0
 	for id, reg := range s.registrations {

--- a/pkg/metadata/store/memory/durable_handles.go
+++ b/pkg/metadata/store/memory/durable_handles.go
@@ -12,6 +12,11 @@ import (
 // memoryDurableStore implements lock.DurableHandleStore using in-memory storage.
 // Secondary lookups use linear scans, acceptable since durable handle counts
 // are typically low (hundreds at most).
+//
+// Unlike the other memory sub-stores, this one owns its lock: getDurableStore
+// takes the store-wide mutex only long enough to publish the pointer and
+// releases it before the method below runs, so mu here is the sole guard on
+// handles.
 type memoryDurableStore struct {
 	mu      sync.RWMutex
 	handles map[string]*lock.PersistedDurableHandle

--- a/pkg/metadata/store/memory/files.go
+++ b/pkg/metadata/store/memory/files.go
@@ -129,6 +129,12 @@ func (store *MemoryMetadataStore) GetFile(ctx context.Context, handle metadata.F
 	store.mu.RLock()
 	defer store.mu.RUnlock()
 
+	return store.getFileLocked(handle)
+}
+
+// getFileLocked is the shared body of GetFile and the transaction-level
+// GetFile. Must be called with store.mu held (read or write).
+func (store *MemoryMetadataStore) getFileLocked(handle metadata.FileHandle) (*metadata.File, error) {
 	key := handleToKey(handle)
 	fileData, exists := store.files[key]
 	if !exists {
@@ -168,6 +174,12 @@ func (store *MemoryMetadataStore) GetChild(ctx context.Context, dirHandle metada
 	store.mu.RLock()
 	defer store.mu.RUnlock()
 
+	return store.getChildLocked(dirHandle, name)
+}
+
+// getChildLocked is the shared body of GetChild and the transaction-level
+// GetChild. Must be called with store.mu held (read or write).
+func (store *MemoryMetadataStore) getChildLocked(dirHandle metadata.FileHandle, name string) (metadata.FileHandle, error) {
 	dirKey := handleToKey(dirHandle)
 	childrenMap, exists := store.children[dirKey]
 	if !exists {
@@ -214,6 +226,12 @@ func (store *MemoryMetadataStore) GetParent(ctx context.Context, handle metadata
 	store.mu.RLock()
 	defer store.mu.RUnlock()
 
+	return store.getParentLocked(handle)
+}
+
+// getParentLocked is the shared body of GetParent and the transaction-level
+// GetParent. Must be called with store.mu held (read or write).
+func (store *MemoryMetadataStore) getParentLocked(handle metadata.FileHandle) (metadata.FileHandle, error) {
 	key := handleToKey(handle)
 	parentHandle, exists := store.parents[key]
 	if !exists {
@@ -244,13 +262,14 @@ func (store *MemoryMetadataStore) GetLinkCount(ctx context.Context, handle metad
 	store.mu.RLock()
 	defer store.mu.RUnlock()
 
-	key := handleToKey(handle)
-	count, exists := store.linkCounts[key]
-	if !exists {
-		return 0, nil
-	}
+	return store.getLinkCountLocked(handle), nil
+}
 
-	return count, nil
+// getLinkCountLocked is the shared body of GetLinkCount and the
+// transaction-level GetLinkCount. Must be called with store.mu held.
+// A handle with no recorded count reports zero.
+func (store *MemoryMetadataStore) getLinkCountLocked(handle metadata.FileHandle) uint32 {
+	return store.linkCounts[handleToKey(handle)]
 }
 
 // SetLinkCount sets the hard link count for a file.
@@ -271,6 +290,12 @@ func (store *MemoryMetadataStore) ListChildren(ctx context.Context, dirHandle me
 	store.mu.RLock()
 	defer store.mu.RUnlock()
 
+	return store.listChildrenLocked(dirHandle, cursor, limit)
+}
+
+// listChildrenLocked is the shared body of ListChildren and the
+// transaction-level ListChildren. Must be called with store.mu held.
+func (store *MemoryMetadataStore) listChildrenLocked(dirHandle metadata.FileHandle, cursor string, limit int) ([]metadata.DirEntry, string, error) {
 	dirKey := handleToKey(dirHandle)
 	childrenMap, exists := store.children[dirKey]
 	if !exists {

--- a/pkg/metadata/store/memory/locks.go
+++ b/pkg/metadata/store/memory/locks.go
@@ -2,7 +2,6 @@ package memory
 
 import (
 	"context"
-	"sync"
 
 	"github.com/marmos91/dittofs/pkg/metadata/errors"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
@@ -12,18 +11,13 @@ import (
 // Memory LockStore Implementation
 // ============================================================================
 
-// memoryLockStore implements lock.LockStore using in-memory storage.
+// memoryLockStore holds the in-memory lock state backing
+// MemoryMetadataStore's lock.LockStore implementation.
 //
-// This implementation is suitable for:
-//   - Testing and development environments
-//   - Ephemeral deployments where lock persistence is not required
-//
-// Thread Safety:
-// All operations are protected by a read-write mutex, making the store
-// safe for concurrent access from multiple goroutines.
+// It carries no lock of its own: every field is read and written by
+// MemoryMetadataStore under the store-wide mutex, held for the whole
+// operation, so a second mutex here would guard nothing.
 type memoryLockStore struct {
-	mu sync.RWMutex
-
 	// locks maps lock ID to PersistedLock
 	locks map[string]*lock.PersistedLock
 
@@ -45,173 +39,6 @@ func newMemoryLockStore() *memoryLockStore {
 		locks:       make(map[string]*lock.PersistedLock),
 		serverEpoch: 0,
 	}
-}
-
-// PutLock persists a lock. Overwrites if lock with same ID exists.
-func (s *memoryLockStore) PutLock(ctx context.Context, lk *lock.PersistedLock) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	// Clone the lock to prevent external modifications
-	s.locks[lk.ID] = cloneLock(lk)
-	return nil
-}
-
-// GetLock retrieves a lock by ID.
-func (s *memoryLockStore) GetLock(ctx context.Context, lockID string) (*lock.PersistedLock, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	lock, exists := s.locks[lockID]
-	if !exists {
-		return nil, &errors.StoreError{
-			Code:    errors.ErrLockNotFound,
-			Message: "lock not found",
-			Path:    lockID,
-		}
-	}
-
-	// Return a clone to prevent external modifications
-	return cloneLock(lock), nil
-}
-
-// DeleteLock removes a lock by ID.
-func (s *memoryLockStore) DeleteLock(ctx context.Context, lockID string) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if _, exists := s.locks[lockID]; !exists {
-		return &errors.StoreError{
-			Code:    errors.ErrLockNotFound,
-			Message: "lock not found",
-			Path:    lockID,
-		}
-	}
-
-	delete(s.locks, lockID)
-	return nil
-}
-
-// ListLocks returns locks matching the query.
-func (s *memoryLockStore) ListLocks(ctx context.Context, query lock.LockQuery) ([]*lock.PersistedLock, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	var result []*lock.PersistedLock
-
-	for _, lk := range s.locks {
-		if query.MatchesLock(lk) {
-			result = append(result, cloneLock(lk))
-		}
-	}
-
-	return result, nil
-}
-
-// DeleteLocksByClient removes all locks for a client.
-func (s *memoryLockStore) DeleteLocksByClient(ctx context.Context, clientID string) (int, error) {
-	if err := ctx.Err(); err != nil {
-		return 0, err
-	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	count := 0
-	for id, lk := range s.locks {
-		if lk.ClientID == clientID {
-			delete(s.locks, id)
-			count++
-		}
-	}
-
-	return count, nil
-}
-
-// DeleteLocksByFile removes all locks for a file.
-func (s *memoryLockStore) DeleteLocksByFile(ctx context.Context, fileID string) (int, error) {
-	if err := ctx.Err(); err != nil {
-		return 0, err
-	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	count := 0
-	for id, lk := range s.locks {
-		if lk.FileID == fileID {
-			delete(s.locks, id)
-			count++
-		}
-	}
-
-	return count, nil
-}
-
-// GetServerEpoch returns current server epoch.
-func (s *memoryLockStore) GetServerEpoch(ctx context.Context) (uint64, error) {
-	if err := ctx.Err(); err != nil {
-		return 0, err
-	}
-
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	return s.serverEpoch, nil
-}
-
-// IncrementServerEpoch increments and returns new epoch.
-func (s *memoryLockStore) IncrementServerEpoch(ctx context.Context) (uint64, error) {
-	if err := ctx.Err(); err != nil {
-		return 0, err
-	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.serverEpoch++
-	return s.serverEpoch, nil
-}
-
-// GetCleanShutdown reports whether the previous run shut down gracefully.
-func (s *memoryLockStore) GetCleanShutdown(ctx context.Context) (bool, error) {
-	if err := ctx.Err(); err != nil {
-		return false, err
-	}
-
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	return s.cleanShutdown, nil
-}
-
-// SetCleanShutdown records the clean-shutdown marker.
-func (s *memoryLockStore) SetCleanShutdown(ctx context.Context, clean bool) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.cleanShutdown = clean
-	return nil
 }
 
 // ============================================================================

--- a/pkg/metadata/store/memory/transaction.go
+++ b/pkg/metadata/store/memory/transaction.go
@@ -239,16 +239,7 @@ func (tx *memoryTransaction) GetFile(ctx context.Context, handle metadata.FileHa
 		return nil, err
 	}
 
-	key := handleToKey(handle)
-	fileData, exists := tx.store.files[key]
-	if !exists {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrNotFound,
-			Message: "file not found",
-		}
-	}
-
-	return tx.store.buildFileWithNlink(handle, fileData)
+	return tx.store.getFileLocked(handle)
 }
 
 func (tx *memoryTransaction) PutFile(ctx context.Context, file *metadata.File) error {
@@ -408,24 +399,7 @@ func (tx *memoryTransaction) GetChild(ctx context.Context, dirHandle metadata.Fi
 		return nil, err
 	}
 
-	dirKey := handleToKey(dirHandle)
-	childrenMap, exists := tx.store.children[dirKey]
-	if !exists {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrNotFound,
-			Message: "child not found",
-		}
-	}
-
-	childHandle, exists := childrenMap[name]
-	if !exists {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrNotFound,
-			Message: "child not found",
-		}
-	}
-
-	return childHandle, nil
+	return tx.store.getChildLocked(dirHandle, name)
 }
 
 func (tx *memoryTransaction) SetChild(ctx context.Context, dirHandle metadata.FileHandle, name string, childHandle metadata.FileHandle) error {
@@ -474,55 +448,7 @@ func (tx *memoryTransaction) ListChildren(ctx context.Context, dirHandle metadat
 		return nil, "", err
 	}
 
-	dirKey := handleToKey(dirHandle)
-	childrenMap, exists := tx.store.children[dirKey]
-	if !exists {
-		// Empty directory
-		return []metadata.DirEntry{}, "", nil
-	}
-
-	// Get sorted entries
-	sortedNames := sortedChildNames(childrenMap)
-
-	// Find start position based on cursor.
-	startIdx := childPageStart(sortedNames, cursor)
-
-	if limit <= 0 {
-		limit = 1000 // Default limit
-	}
-
-	// Collect entries
-	var entries []metadata.DirEntry
-	for i := startIdx; i < len(sortedNames) && len(entries) < limit; i++ {
-		name := sortedNames[i]
-		childHandle := childrenMap[name]
-
-		entry := metadata.DirEntry{
-			ID:     metadata.HandleToINode(childHandle),
-			Name:   name,
-			Handle: childHandle,
-		}
-
-		// Try to get attributes (deep-copy reference-bearing fields).
-		childKey := handleToKey(childHandle)
-		if fileData, exists := tx.store.files[childKey]; exists {
-			attr := *fileData.Attr
-			attr.Blocks = cloneBlocks(fileData.Attr.Blocks)
-			attr.ACL = cloneACL(fileData.Attr.ACL)
-			attr.EAs = cloneEAs(fileData.Attr.EAs)
-			entry.Attr = &attr
-		}
-
-		entries = append(entries, entry)
-	}
-
-	// Determine next cursor
-	nextCursor := ""
-	if startIdx+len(entries) < len(sortedNames) {
-		nextCursor = entries[len(entries)-1].Name
-	}
-
-	return entries, nextCursor, nil
+	return tx.store.listChildrenLocked(dirHandle, cursor, limit)
 }
 
 func (tx *memoryTransaction) GetParent(ctx context.Context, handle metadata.FileHandle) (metadata.FileHandle, error) {
@@ -530,16 +456,7 @@ func (tx *memoryTransaction) GetParent(ctx context.Context, handle metadata.File
 		return nil, err
 	}
 
-	key := handleToKey(handle)
-	parentHandle, exists := tx.store.parents[key]
-	if !exists {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrNotFound,
-			Message: "parent not found",
-		}
-	}
-
-	return parentHandle, nil
+	return tx.store.getParentLocked(handle)
 }
 
 func (tx *memoryTransaction) SetParent(ctx context.Context, handle metadata.FileHandle, parentHandle metadata.FileHandle) error {
@@ -557,13 +474,7 @@ func (tx *memoryTransaction) GetLinkCount(ctx context.Context, handle metadata.F
 		return 0, err
 	}
 
-	key := handleToKey(handle)
-	count, exists := tx.store.linkCounts[key]
-	if !exists {
-		return 0, nil
-	}
-
-	return count, nil
+	return tx.store.getLinkCountLocked(handle), nil
 }
 
 func (tx *memoryTransaction) SetLinkCount(ctx context.Context, handle metadata.FileHandle, count uint32) error {

--- a/pkg/metadata/store/memory/transaction.go
+++ b/pkg/metadata/store/memory/transaction.go
@@ -170,9 +170,9 @@ func (store *MemoryMetadataStore) restoreLocked(snap *txSnapshot) {
 // backend.
 //
 // Scope: the snapshot covers the file/directory/share/fileblock metadata maps.
-// The separately-mutexed lock store (memoryLockStore, area-5) is NOT snapshotted
-// — lock persistence runs in its own transactions and is not mixed with
-// file-metadata mutations in a single WithTransaction.
+// Lock state (memoryLockStore) is NOT snapshotted — lock persistence runs in its
+// own transactions and is not mixed with file-metadata mutations in a single
+// WithTransaction. It is guarded by the same store-wide mutex taken here.
 func (store *MemoryMetadataStore) WithTransaction(ctx context.Context, fn func(tx metadata.Transaction) error) error {
 	if err := ctx.Err(); err != nil {
 		return err


### PR DESCRIPTION
## What was wrong

`pkg/metadata/store/memory/locks.go` declared a full ten-method `lock.LockStore`
implementation on `memoryLockStore` — `PutLock`, `GetLock`, `DeleteLock`,
`ListLocks`, `DeleteLocksByClient`, `DeleteLocksByFile`, `GetServerEpoch`,
`IncrementServerEpoch`, `GetCleanShutdown`, `SetCleanShutdown`. Nothing calls any
of them.

The naive grep is misleading, because `MemoryMetadataStore` declares ten methods
with exactly the same names. Those are the ones that run: they reach into
`s.lockStore.<field>` directly under the store-wide mutex, via the `*Locked`
helpers, and they are what `RunLockPersistenceSuite` exercises through
`memory_conformance_test.go`. The sub-store's own `sync.RWMutex` was therefore
guarding fields that only ever change under a different lock — a trap for the
next person to read the file, not a guard.

The same shadow mutex sat on `memoryClientStore` and `memoryRecoveryStore`.
Every method on those two is reached only from a `MemoryMetadataStore` wrapper
that holds `store.mu` for the whole call, so the inner lock was a second,
uncontended acquisition every time.

`memoryDurableStore` looks identical but is not, and keeps its lock:
`getDurableStore()` takes `store.mu` only long enough to publish the pointer and
releases it (via `defer`) before the sub-store method runs, so the inner mutex is
the sole guard on `handles` — with SMB3 durable-handle traffic from several
connections plus the periodic `DeleteExpiredDurableHandles` scavenger hitting
that map concurrently. The struct now says so, so the next reader does not
"tidy" it away.

That asymmetry is itself a pre-existing bug — `WriteSnapshot` holds only
`store.mu` while gob-encodes the live `handles` map, so it does not exclude a
concurrent durable-handle mutator holding the other lock. Filed as #2023 rather
than folded in here, since fixing it means changing how the durable wrappers
lock, which is a behaviour change this PR deliberately does not make.

## Drift found while removing the duplication

The store-level and transaction-level read paths (`GetFile`, `GetChild`,
`GetParent`, `GetLinkCount`, `ListChildren`) were copies of each other. Four of
the five were still byte-identical; `ListChildren` had already drifted:

- store-level derived each entry's `Nlink` from `linkCounts` (falling back to 2
  for directories, 1 otherwise),
- transaction-level returned the raw stored `Attr` value.

They now share one `listChildrenLocked`, so the transaction path reports the same
derived link count. No production caller of the transaction variant reads
`Attr.Nlink` today (the stream-name scans in `pkg/metadata/xattr.go` use only
`Name`), so this closes a latent divergence rather than a live bug.

## Evidence

- `go build ./... && go vet ./...` clean.
- `go test -race ./pkg/metadata/store/memory/...` green, including the
  lock-persistence conformance suite that covers all ten lock methods.
- `go test ./...` green.

Refs #1994
