### PR TITLE
refactor(metadata): replace the single-impl FileAccessChecker with a consumer-side probe

### DIFF
--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -454,10 +454,10 @@ type OpenFile struct {
 	// at acls.c:440).
 	//
 	// Per-op gates are INTENTIONALLY frozen to this snapshot, not re-evaluated
-	// through the central FileAccessChecker on each request:
+	// through the central metadata permission core on each request:
 	//
 	//   - The single access check happens once, at CREATE, through the central
-	//     metadata.FileAccessChecker (CheckFileAccess / CheckFileAccessWithParent).
+	//     metadata.Service (CheckFileAccess / CheckFileAccessWithParent).
 	//     Subsequent READ / WRITE / DELETE / SET_INFO / IOCTL (sparse, copychunk,
 	//     fsctl) handlers gate against this frozen GrantedAccess rather than
 	//     re-running the checker. This is the MS-SMB2 / MS-FSA handle model

--- a/internal/adapter/smb/handlers/query_directory.go
+++ b/internal/adapter/smb/handlers/query_directory.go
@@ -1145,7 +1145,7 @@ const abeReadMask = acl.ACE4_READ_DATA |
 // filterByAccess returns the subset of entries the requester may read,
 // implementing MS-SRVS SHI1005_FLAGS_ACCESS_BASED_DIRECTORY_ENUM semantics.
 // The per-entry read decision is delegated to the central permission checker
-// (metadata.FileAccessChecker.CheckAttrReadAccess), so ABE visibility honors
+// (metadata.Service.CheckAttrReadAccess), so ABE visibility honors
 // the same ACL / DENY-ACE / SID evaluation — over one EvaluateContext — that
 // CREATE-time access checks use. The handler does protocol only: it picks the
 // entries and the read mask; the metadata layer owns the decision.
@@ -1155,7 +1155,16 @@ const abeReadMask = acl.ACE4_READ_DATA |
 //     still returns nil the entry is hidden (fail-closed).
 //   - If hydrate is nil the entry is hidden directly. Returning true here
 //     would leak entries that ABE is supposed to suppress.
-func filterByAccess(checker metadata.FileAccessChecker, entries []metadata.DirEntry, authCtx *metadata.AuthContext, hydrate attrHydrator) []metadata.DirEntry {
+//
+// attrReadChecker is the slice of the metadata permission core that
+// access-based enumeration needs: the attr-only read probe. *metadata.Service
+// is the production implementation; declaring the contract here keeps the
+// dependency pointed at what this handler actually calls.
+type attrReadChecker interface {
+	CheckAttrReadAccess(attr *metadata.FileAttr, authCtx *metadata.AuthContext, requestedMask uint32) bool
+}
+
+func filterByAccess(checker attrReadChecker, entries []metadata.DirEntry, authCtx *metadata.AuthContext, hydrate attrHydrator) []metadata.DirEntry {
 	if len(entries) == 0 {
 		return entries
 	}
@@ -1182,7 +1191,7 @@ func filterByAccess(checker metadata.FileAccessChecker, entries []metadata.DirEn
 // access-based enumeration. See filterByAccess for the policy contract. The
 // actual read evaluation (ACL when present, POSIX mode-bit fallback, root and
 // anonymous handling) lives in the central checker.
-func canEnumerateEntry(checker metadata.FileAccessChecker, entry *metadata.DirEntry, authCtx *metadata.AuthContext, hydrate attrHydrator) bool {
+func canEnumerateEntry(checker attrReadChecker, entry *metadata.DirEntry, authCtx *metadata.AuthContext, hydrate attrHydrator) bool {
 	attr := entry.Attr
 	if attr == nil {
 		// Attr is documented optional on DirEntry (pkg/metadata/validation.go).

--- a/internal/adapter/smb/handlers/query_directory_abe_test.go
+++ b/internal/adapter/smb/handlers/query_directory_abe_test.go
@@ -13,11 +13,11 @@ import (
 
 func uint32Ptr(v uint32) *uint32 { return &v }
 
-// abeChecker returns a metadata.FileAccessChecker for the access-based
+// abeChecker returns the metadata permission core used by the access-based
 // enumeration filter under test. CheckAttrReadAccess evaluates purely from the
 // passed FileAttr + AuthContext and touches no store, so a bare service
 // instance is sufficient.
-func abeChecker() metadata.FileAccessChecker { return metadata.New() }
+func abeChecker() *metadata.Service { return metadata.New() }
 
 // authForUID builds an AuthContext for the given UID with a single primary GID.
 // Context is wired to context.Background() so future hydrators that dereference

--- a/pkg/metadata/file_access_checker.go
+++ b/pkg/metadata/file_access_checker.go
@@ -2,12 +2,12 @@ package metadata
 
 import "github.com/marmos91/dittofs/pkg/metadata/acl"
 
-// FileAccessChecker is the single protocol-agnostic entry point every protocol
-// adapter (NFSv3 / NFSv4.0 / NFSv4.1 / SMB2 / SMB3) funnels permission
-// decisions through. Consolidating the checks behind one interface keeps the
-// "handlers do protocol only" invariant: adapters translate their wire access
-// bits to and from the canonical vocabularies below and never evaluate ACLs,
-// DENY ACEs, or SID-based grants themselves.
+// Service's permission-check methods are the single protocol-agnostic entry
+// point every protocol adapter (NFSv3 / NFSv4.0 / NFSv4.1 / SMB2 / SMB3)
+// funnels permission decisions through. Consolidating the checks in one place keeps the "handlers do
+// protocol only" invariant: adapters translate their wire access bits to and
+// from the canonical vocabularies below and never evaluate ACLs, DENY ACEs, or
+// SID-based grants themselves.
 //
 // Two request vocabularies are supported because the two protocol families
 // arrive with different access-bit models, but both resolve to the same
@@ -25,34 +25,6 @@ import "github.com/marmos91/dittofs/pkg/metadata/acl"
 // enumeration, where only a directory entry's FileAttr (not a full File with a
 // handle) is in scope. It centralizes the ACL+POSIX read evaluation the SMB
 // query_directory handler previously inlined via a direct acl.Evaluate call.
-//
-// *Service is the production implementation; the interface exists so the
-// permission core has one named contract and so the cross-protocol conformance
-// matrix can assert every protocol's translation lands on identical decisions.
-type FileAccessChecker interface {
-	// CheckPermissions evaluates a generic-flag request against a file handle
-	// and returns the granted subset (NFS path).
-	CheckPermissions(ctx *AuthContext, handle FileHandle, requested Permission) (Permission, error)
-
-	// CheckFileAccess evaluates an MS-DTYP DesiredAccess mask against a file's
-	// stored DACL and returns the granted mask (SMB CREATE path). Returns
-	// ErrAccessDenied as a *StoreError when a non-MAXIMUM_ALLOWED bit is denied.
-	CheckFileAccess(file *File, authCtx *AuthContext, desiredAccess uint32) (uint32, error)
-
-	// CheckFileAccessWithParent extends CheckFileAccess with the MS-FSA
-	// delete-via-parent override (FILE_DELETE_CHILD on the parent grants DELETE
-	// on the child even when the child's own DACL denies it).
-	CheckFileAccessWithParent(file *File, parent *File, authCtx *AuthContext, desiredAccess uint32) (uint32, error)
-
-	// CheckAttrReadAccess reports whether the requester may read the entry
-	// described by attr. Used by SMB access-based enumeration. requestedMask is
-	// the set of MS-DTYP / NFSv4 read rights the caller requires (these bit
-	// positions are shared between the two models per RFC 7530 §6.2.1).
-	CheckAttrReadAccess(attr *FileAttr, authCtx *AuthContext, requestedMask uint32) bool
-}
-
-// Static assertion that *Service satisfies the consolidated checker contract.
-var _ FileAccessChecker = (*Service)(nil)
 
 // CheckAttrReadAccess reports whether authCtx may read the entry described by
 // attr, evaluating its ACL when present and falling back to POSIX mode bits

--- a/pkg/metadata/storetest/cross_protocol_permissions.go
+++ b/pkg/metadata/storetest/cross_protocol_permissions.go
@@ -18,10 +18,10 @@ import (
 // differently. The original NFSv4 ACCESS handler reimplemented a Unix-mode-only
 // check that ignored ACLs, DENY ACEs, and SID-based grants, so the same file
 // produced a different answer on NFSv4 than on NFSv3/SMB. This suite pins the
-// fix: every protocol "lane" below drives the SAME central
-// metadata.Service entry point its production adapter uses, and the
-// suite asserts every lane agrees with every other lane and with the expected
-// decision — including DENY ACEs and SID-only grants (the bug class).
+// fix: every protocol "lane" below drives the SAME central metadata.Service
+// entry point that its production adapter uses, and the suite asserts every
+// lane agrees with every other lane and with the expected decision — including
+// DENY ACEs and SID-only grants (the bug class).
 //
 // Run it from each backend's conformance test (memory / badger / postgres) so
 // the matrix is (memory|badger|postgres) x (NFSv3|NFSv4.0|NFSv4.1|SMB).

--- a/pkg/metadata/storetest/cross_protocol_permissions.go
+++ b/pkg/metadata/storetest/cross_protocol_permissions.go
@@ -19,7 +19,7 @@ import (
 // check that ignored ACLs, DENY ACEs, and SID-based grants, so the same file
 // produced a different answer on NFSv4 than on NFSv3/SMB. This suite pins the
 // fix: every protocol "lane" below drives the SAME central
-// metadata.FileAccessChecker entry point its production adapter uses, and the
+// metadata.Service entry point its production adapter uses, and the
 // suite asserts every lane agrees with every other lane and with the expected
 // decision — including DENY ACEs and SID-only grants (the bug class).
 //


### PR DESCRIPTION
## What was wrong

`metadata.FileAccessChecker` declared four methods in the producer package with
exactly one implementation, `*metadata.Service`, and a `var _` assertion pinning
it. Three of the four were never called through the interface — every caller
holds a concrete `*Service`. The single consumer that took the interface as a
parameter, SMB access-based enumeration, uses one method of the four:
`CheckAttrReadAccess`.

## Change

`filterByAccess` / `canEnumerateEntry` in
`internal/adapter/smb/handlers/query_directory.go` now declare the one-method
contract they actually call, consumer-side. The interface and its assertion are
gone from `pkg/metadata`.

The narrative the interface's doc comment carried — that these methods are the
single protocol-agnostic entry point every adapter funnels permission decisions
through, and why there are two request vocabularies — is kept, on the methods it
describes.

## Evidence

- `go build ./... && go vet ./...` clean.
- `go test ./...` green, including the ABE tests in
  `internal/adapter/smb/handlers/query_directory_abe_test.go` and the
  cross-protocol permission conformance matrix.

Refs #1994
