### PR TITLE
refactor(runtime): pass lifecycle collaborators as a named Deps struct

### DIFF
--- a/pkg/controlplane/runtime/lifecycle/service.go
+++ b/pkg/controlplane/runtime/lifecycle/service.go
@@ -255,8 +255,14 @@ type Deps struct {
 	RollupStopper RollupStopper
 }
 
-// Serve starts all components and blocks until shutdown.
+// Serve starts all components and blocks until shutdown. It fails fast when
+// Deps.AdapterLoader is missing, which both startup and shutdown dereference
+// unconditionally.
 func (s *Service) Serve(ctx context.Context, deps Deps) error {
+	if deps.AdapterLoader == nil {
+		return fmt.Errorf("lifecycle: Deps.AdapterLoader is required")
+	}
+
 	var err error
 
 	s.serveOnce.Do(func() {

--- a/pkg/controlplane/runtime/lifecycle/service.go
+++ b/pkg/controlplane/runtime/lifecycle/service.go
@@ -224,63 +224,66 @@ func (s *Service) SetAPIServer(server AuxiliaryServer) {
 	}
 }
 
+// Deps are the collaborators Serve drives through startup and shutdown. Every
+// field except AdapterLoader is optional; a nil field skips the step it owns.
+type Deps struct {
+	// Settings loads adapter settings once and then polls for changes.
+	Settings SettingsInitializer
+
+	// AdapterLoader starts the configured adapters and stops them on shutdown.
+	// Required.
+	AdapterLoader AdapterLoader
+
+	// MetadataFlusher drains pending metadata writes during shutdown.
+	MetadataFlusher MetadataFlusher
+
+	// StoreCloser closes the metadata stores, last of the data-plane steps.
+	StoreCloser StoreCloser
+
+	// MachineSIDStore loads or generates the machine SID used for Windows
+	// identity mapping. Nil yields an ephemeral SID (testing).
+	MachineSIDStore MachineSIDStore
+
+	// SnapshotDrainer is invoked as the FIRST shutdown step so in-flight
+	// snapshot orchestration goroutines are cancelled and drained BEFORE
+	// StopAllAdapters + CloseMetadataStores — otherwise those goroutines would
+	// race a closing metadata store / control-plane DB.
+	SnapshotDrainer SnapshotDrainer
+
+	// RollupStopper fences the per-share rollup workers before the metadata
+	// stores close.
+	RollupStopper RollupStopper
+}
+
 // Serve starts all components and blocks until shutdown.
-//
-// The machineSIDStore parameter is used to load or generate the machine SID
-// for Windows identity mapping. Pass nil to use an ephemeral SID (testing).
-//
-// The snapshotDrainer parameter is invoked as the FIRST shutdown step so
-// in-flight snapshot orchestration goroutines are cancelled and drained
-// BEFORE StopAllAdapters + CloseMetadataStores — otherwise those
-// goroutines would race a closing metadata store / control-plane DB.
-// Pass nil to skip snapshot draining (tests that do not exercise the
-// snapshot pipeline).
-func (s *Service) Serve(
-	ctx context.Context,
-	settings SettingsInitializer,
-	adapterLoader AdapterLoader,
-	metadataFlusher MetadataFlusher,
-	storeCloser StoreCloser,
-	machineSIDStore MachineSIDStore,
-	snapshotDrainer SnapshotDrainer,
-	rollupStopper RollupStopper,
-) error {
+func (s *Service) Serve(ctx context.Context, deps Deps) error {
 	var err error
 
 	s.serveOnce.Do(func() {
 		s.served = true
-		err = s.serve(ctx, settings, adapterLoader, metadataFlusher, storeCloser, machineSIDStore, snapshotDrainer, rollupStopper)
+		err = s.serve(ctx, deps)
 	})
 
 	return err
 }
 
-func (s *Service) serve(
-	ctx context.Context,
-	settings SettingsInitializer,
-	adapterLoader AdapterLoader,
-	metadataFlusher MetadataFlusher,
-	storeCloser StoreCloser,
-	machineSIDStore MachineSIDStore,
-	snapshotDrainer SnapshotDrainer,
-	rollupStopper RollupStopper,
-) error {
+func (s *Service) serve(ctx context.Context, deps Deps) error {
 	logger.Info("Starting DittoFS runtime")
 
 	// Initialize machine SID BEFORE any adapters start.
 	// This ensures consistent identity mapping for all connections.
-	if err := s.initMachineSID(ctx, machineSIDStore); err != nil {
+	if err := s.initMachineSID(ctx, deps.MachineSIDStore); err != nil {
 		return fmt.Errorf("failed to initialize machine SID: %w", err)
 	}
 
-	if settings != nil {
-		if err := settings.LoadInitial(ctx); err != nil {
+	if deps.Settings != nil {
+		if err := deps.Settings.LoadInitial(ctx); err != nil {
 			logger.Warn("Failed to load initial adapter settings", "error", err)
 		}
-		settings.Start(ctx)
+		deps.Settings.Start(ctx)
 	}
 
-	if err := adapterLoader.LoadAdaptersFromStore(ctx); err != nil {
+	if err := deps.AdapterLoader.LoadAdaptersFromStore(ctx); err != nil {
 		return fmt.Errorf("failed to load adapters: %w", err)
 	}
 
@@ -304,22 +307,15 @@ func (s *Service) serve(
 		shutdownErr = fmt.Errorf("API server error: %w", err)
 	}
 
-	s.shutdown(settings, adapterLoader, metadataFlusher, storeCloser, snapshotDrainer, rollupStopper)
+	s.shutdown(deps)
 
 	logger.Info("DittoFS runtime stopped")
 	return shutdownErr
 }
 
-func (s *Service) shutdown(
-	settings SettingsInitializer,
-	adapterLoader AdapterLoader,
-	metadataFlusher MetadataFlusher,
-	storeCloser StoreCloser,
-	snapshotDrainer SnapshotDrainer,
-	rollupStopper RollupStopper,
-) {
-	if settings != nil {
-		settings.Stop()
+func (s *Service) shutdown(deps Deps) {
+	if deps.Settings != nil {
+		deps.Settings.Stop()
 	}
 
 	// Drain in-flight snapshot orchestration goroutines BEFORE stopping
@@ -329,19 +325,19 @@ func (s *Service) shutdown(
 	// timeout. Orphans after the timeout will still exit on their own
 	// since runtimeCtx is already cancelled; we just may proceed before
 	// every wg.Done fires.
-	if snapshotDrainer != nil {
+	if deps.SnapshotDrainer != nil {
 		drainCtx, cancel := context.WithTimeout(context.Background(), s.shutdownTimeout)
-		snapshotDrainer.ShutdownSnapshots(drainCtx)
+		deps.SnapshotDrainer.ShutdownSnapshots(drainCtx)
 		cancel()
 	}
 
 	logger.Info("Stopping all adapters")
-	if err := adapterLoader.StopAllAdapters(); err != nil {
+	if err := deps.AdapterLoader.StopAllAdapters(); err != nil {
 		logger.Warn("Error stopping adapters", "error", err)
 	}
 
-	if metadataFlusher != nil {
-		flushed, err := metadataFlusher.FlushAllPendingWritesForShutdown(s.shutdownTimeout)
+	if deps.MetadataFlusher != nil {
+		flushed, err := deps.MetadataFlusher.FlushAllPendingWritesForShutdown(s.shutdownTimeout)
 		if err != nil {
 			logger.Warn("Error flushing pending writes", "error", err, "flushed", flushed)
 		} else if flushed > 0 {
@@ -354,14 +350,14 @@ func (s *Service) shutdown(
 	// through the metadata store, so an in-flight rollup must be drained while
 	// the DB is still open or it races the close ("sql: database is closed").
 	// Runs after StopAllAdapters (no new writes create fresh rollup work).
-	if rollupStopper != nil {
+	if deps.RollupStopper != nil {
 		rollupCtx, cancel := context.WithTimeout(context.Background(), s.shutdownTimeout)
-		rollupStopper.StopRollups(rollupCtx)
+		deps.RollupStopper.StopRollups(rollupCtx)
 		cancel()
 	}
 
-	if storeCloser != nil {
-		storeCloser.CloseMetadataStores()
+	if deps.StoreCloser != nil {
+		deps.StoreCloser.CloseMetadataStores()
 	}
 
 	if s.apiServer != nil {

--- a/pkg/controlplane/runtime/lifecycle/service_test.go
+++ b/pkg/controlplane/runtime/lifecycle/service_test.go
@@ -148,7 +148,7 @@ func TestSetAPIServerPanicsAfterServe(t *testing.T) {
 	s := New(time.Second)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Serve returns immediately on cancelled ctx
-	_ = s.Serve(ctx, nil, &fakeAdapters{}, nil, nil, nil, nil, nil)
+	_ = s.Serve(ctx, Deps{AdapterLoader: &fakeAdapters{}})
 
 	defer func() {
 		if recover() == nil {
@@ -172,7 +172,14 @@ func TestServeGracefulShutdownOnCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := s.Serve(ctx, settings, adapters, flusher, closer, nil, drainer, rollups)
+	err := s.Serve(ctx, Deps{
+		Settings:        settings,
+		AdapterLoader:   adapters,
+		MetadataFlusher: flusher,
+		StoreCloser:     closer,
+		SnapshotDrainer: drainer,
+		RollupStopper:   rollups,
+	})
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("err = %v, want context.Canceled", err)
 	}
@@ -213,7 +220,7 @@ func TestServeAdapterLoadFailure(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	err := s.Serve(ctx, nil, adapters, nil, closer, nil, nil, nil)
+	err := s.Serve(ctx, Deps{AdapterLoader: adapters, StoreCloser: closer})
 	if err == nil {
 		t.Fatal("expected error from adapter load failure")
 	}
@@ -235,7 +242,7 @@ func TestServeAPIServerFailureTriggersShutdown(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	err := s.Serve(ctx, nil, &fakeAdapters{}, nil, closer, nil, nil, nil)
+	err := s.Serve(ctx, Deps{AdapterLoader: &fakeAdapters{}, StoreCloser: closer})
 	if err == nil || !errors.Is(err, api.startErr) {
 		t.Errorf("err = %v, want wrapped %v", err, api.startErr)
 	}
@@ -253,10 +260,10 @@ func TestServeOnlyRunsOnce(t *testing.T) {
 	adapters := &fakeAdapters{}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	_ = s.Serve(ctx, nil, adapters, nil, nil, nil, nil, nil)
+	_ = s.Serve(ctx, Deps{AdapterLoader: adapters})
 
 	second := &fakeAdapters{}
-	if err := s.Serve(ctx, nil, second, nil, nil, nil, nil, nil); err != nil {
+	if err := s.Serve(ctx, Deps{AdapterLoader: second}); err != nil {
 		t.Errorf("second Serve = %v, want nil", err)
 	}
 	if second.loaded {

--- a/pkg/controlplane/runtime/lifecycle/service_test.go
+++ b/pkg/controlplane/runtime/lifecycle/service_test.go
@@ -254,6 +254,16 @@ func TestServeAPIServerFailureTriggersShutdown(t *testing.T) {
 	}
 }
 
+// A Deps without an AdapterLoader is a programming error: both startup and
+// shutdown dereference it unconditionally, so Serve rejects it instead of
+// panicking.
+func TestServeRequiresAdapterLoader(t *testing.T) {
+	s := New(time.Second)
+	if err := s.Serve(context.Background(), Deps{}); err == nil {
+		t.Fatal("expected error for Deps without an AdapterLoader")
+	}
+}
+
 // Serve uses sync.Once: a second call is a no-op and returns nil.
 func TestServeOnlyRunsOnce(t *testing.T) {
 	s := New(time.Second)

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -817,7 +817,15 @@ func (r *Runtime) Serve(ctx context.Context) error {
 		logger.Error("restore recovery returned error (continuing startup)", "error", err)
 	}
 
-	return r.lifecycleSvc.Serve(ctx, r.settingsWatcher, r.adaptersSvc, r.metadataService, r.storesSvc, r.store, r, r)
+	return r.lifecycleSvc.Serve(ctx, lifecycle.Deps{
+		Settings:        r.settingsWatcher,
+		AdapterLoader:   r.adaptersSvc,
+		MetadataFlusher: r.metadataService,
+		StoreCloser:     r.storesSvc,
+		MachineSIDStore: r.store,
+		SnapshotDrainer: r,
+		RollupStopper:   r,
+	})
 }
 
 // StopRollups stops + drains every share's block-store rollup worker pool.


### PR DESCRIPTION
## What was wrong

`lifecycle.Service.Serve`, its inner `serve`, and `shutdown` each threaded the
same six collaborators positionally. The one production call site read:

```go
r.lifecycleSvc.Serve(ctx, r.settingsWatcher, r.adaptersSvc, r.metadataService,
    r.storesSvc, r.store, r, r)
```

The trailing `r, r` are the snapshot drainer and the rollup stopper. Both are
satisfied by `*Runtime`, so transposing them compiles and silently reorders
shutdown — and the ordering is load-bearing: snapshot draining must run first,
and rollups must be fenced before the metadata stores close or an in-flight
rollup races the DB close.

## Change

One `Deps` struct with named fields, passed to `Serve` and forwarded to `serve`
and `shutdown`. Every nil-check is preserved; `AdapterLoader` stays the only
required field. A future collaborator becomes an additive field rather than a
signature break at three call sites.

## Evidence

- `go build ./... && go vet ./...` clean.
- `go test ./...` green, including the lifecycle shutdown-ordering tests that
  assert `StopRollups` runs before `CloseMetadataStores`.

Refs #1994

---

## Verdict ledger for the rest of #1994

This is the last of four PRs off #1994. The issue's remaining items were worked
through and land as follows; #1994 stays open for the one blocked item below.

### Applied (other PRs)

- `pkg/metadata/store/memory/locks.go` — dead ten-method lock sub-store and the
  three shadow mutexes deleted; the five duplicated read paths now share
  `*Locked` helpers, closing a `ListChildren` `Nlink` drift.
- `pkg/controlplane/runtime/stores/service.go` + `postgres/schema_ops.go` — the
  never-built restore-orchestrator scaffold deleted.
- `pkg/metadata/file_access_checker.go` — single-implementation
  `FileAccessChecker` replaced by a one-method consumer-side interface.

### Already fixed on develop

- `internal/adapter/nfs/v4/handlers/read.go:24` — the 14 inline
  `CompoundResult` error literals are gone; `readErr` exists at `read.go:204`,
  alongside `writeErr`, `commitErr` and `readPlusErr`. Nothing left to do.
- `pkg/block/engine/syncer.go:702` — the dead `UploadInterval` computation was
  removed in the meantime.

### WONTFIX — the issue's own reading is right

- **`pkg/block/journal/segment.go:279`** — releasing `sh.mu` across the writes
  lets `groupCommit` ack a version as durable while its bytes are still in
  flight. That is the silent-zeros class. The lock is the ordering guarantee,
  not incidental.
- **`pkg/block/journal/reclaim.go:131`** — real, but latency, not correctness.
  The cited `evictSegment` / `repackSegment` precedent does not transfer: those
  can snapshot-then-unlock because their victim is sealed *and* busy-claimed,
  and an active segment has no such claim.
- **`pkg/controlplane/runtime/netgroups.go:24`** — would re-introduce state the
  file's own comment records as deliberately moved off `Runtime`.
- **`pkg/controlplane/runtime/runtime.go:575`** — would bind share teardown to
  the HTTP request context, letting a client disconnect abort cleanup. The
  detached context is correct.

### WONTFIX — net addition, not deletion

- **`pkg/block/engine/syncer.go:34`** (god object). The proposed fix extracts the
  carve wiring into a collaborator *with its own lock*. `carveActive` is derived
  from `remoteBlockStore`, `blockCommitter` and `hasRemote` together, so that
  split puts a lock-ordering obligation on the carve path — whose failure mode is
  silent zeros — to buy legibility on a struct whose fields already document
  their own locking discipline section by section. Not worth the risk without a
  hardware rig to prove it.
- **`pkg/block/local/fs/fs.go:56`** (`journal.Store` embed). Converting the embed
  to a named field means writing explicit pass-throughs for everything the tree
  actually calls through it — `SeedCold`, `JournalVersion`, `SetPinVersion`,
  `PinVersion`, `RestoreToVersion`, `SetVerifyReads`, `FileCount`,
  `SetEvictionEnabled`, `SetCarveTargets`, `UnsyncedBytes`, `Close` — used from
  `snapshot.go`, `shares/service.go` and the `local.LocalStore` interface. That
  is ~16 forwarding methods added to gate a hazard the audit itself found
  unreachable.
- **`pkg/block/local/local.go:33`** (18-method interface). The issue says the ROI
  is poor and it is already sectioned by comment. Agreed.
- **`pkg/metadata/store/badger/cache.go:69`** (package-level cache config). The
  global is written exactly once, in `cmd/dfs/commands/start.go`, before any
  store opens, and read as a fallback under `resolveCacheSizesMB`. It is a
  genuinely different operator knob from the per-store `block_cache_mb` override
  (config.yaml vs the control-plane store config), so it cannot simply be folded
  into the per-store config. Threading it explicitly means widening
  `runtime.InitializeFromStore` down to the engine switch to carry two int64s
  that never change after startup — more surface, not less.
- **`pkg/controlplane/runtime/discovery.go:20`** (`context.Background()`). Adding
  a `ctx` parameter means widening the `Registry` interface in both
  `pkg/adapter/nfs` and `pkg/adapter/smb`, whose `discoveryName()` callers have
  no context to pass. The ctx-free shape is also the house pattern for
  live-settings accessors on `Runtime` (`GetNFSSettings`, `GetSMBSettings`), and
  the read already degrades safely to `hostinfo.DefaultDiscoveryName()`.

### Premises checked

- `pkg/block/engine/stats.go:74` — as the issue says, partly wrong; one
  `context.Background()`, not several.
- The sqlite `transaction.go` size complaint — soft, as the issue says: sqlite
  1354, postgres 1401, badger 1677. House pattern, not an outlier.

### BLOCKED, needs a decision — `errors.go` + `lock_exports.go`

The issue states these 407 lines have "**zero** external consumers repo-wide" and
exist only so `pkg/metadata`'s own files can write `ErrNotFound` unqualified
(~436 in-package sites). **That premise is wrong.** Measured on this tree, across
the 90 symbols the two files re-export:

- **491 qualified `metadata.<symbol>` references in 75 files across 18 packages**
  — `internal/adapter/smb/handlers`, `internal/adapter/nfs/v4/*`,
  `internal/controlplane/api/handlers`, `pkg/adapter/nfs`, `pkg/adapter/smb`,
  `pkg/block/engine`, `pkg/controlplane/runtime` (+ `shares`, `trash`), all four
  store backends under `pkg/metadata/store/*`, `pkg/metadata/storetest`, and
  `test/e2e`.
- plus **441 unqualified references in 39 files** inside `pkg/metadata` itself.

The top symbols are the ones that make the package usable from outside:
`metadata.StoreError` (249 uses), `metadata.IsNotFoundError` (59),
`metadata.ErrNotFound` (50), `metadata.ErrInvalidHandle` (48),
`metadata.FileLock` (31).

So this is not a 407-line deletion. It is a ~930-site rename across ~114 files
that adds an import to every one of those 75 external files and lengthens every
call site (`metadata.StoreError` → `storeerrors.StoreError`, since most of these
files already import stdlib `errors` and need an alias). It also touches
`pkg/controlplane/runtime/shares/`, which is owned by concurrent work, and it
would conflict with essentially every other in-flight change to `pkg/metadata`.

Left undone pending a call on whether that trade is wanted.

Refs #1994
