### PR TITLE
docs(metadata): describe errors.go and lock_exports.go as the package's public API

### DIFF
--- a/pkg/metadata/errors.go
+++ b/pkg/metadata/errors.go
@@ -6,19 +6,34 @@ import (
 )
 
 // ============================================================================
-// Re-exported types from errors package for backward compatibility
+// Public error surface of package metadata
 // ============================================================================
+//
+// The names below are package metadata's error API. Callers across the tree —
+// every protocol adapter, the control-plane API handlers, the block engine and
+// all four metadata store backends — construct, compare and type-switch on
+// them as metadata.StoreError, metadata.ErrNotFound, metadata.IsNotFoundError
+// and the rest.
+//
+// The implementations live in pkg/metadata/errors and pkg/metadata/lock
+// because neither of those packages may import metadata: metadata imports
+// both, so the dependency only runs one way. That lets the store backends and
+// the lock manager raise and inspect the same errors without a cycle — all
+// four backends import pkg/metadata/errors directly — while the aliases here
+// keep the API reachable from the package that owns it.
+//
+// These are aliases, not wrappers, so a value built through either spelling is
+// the identical type and compares equal. Removing or renaming a name here
+// breaks every caller of the metadata package; it is not the cleanup of an
+// unused shim.
 
 // StoreError is re-exported from the errors package.
-// Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/errors directly.
 type StoreError = errors.StoreError
 
 // ErrorCode is re-exported from the errors package.
-// Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/errors directly.
 type ErrorCode = errors.ErrorCode
 
-// Re-exported error codes for backward compatibility.
-// Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/errors directly.
+// The error codes callers compare StoreError.Code against.
 const (
 	ErrNotFound               = errors.ErrNotFound
 	ErrAccessDenied           = errors.ErrAccessDenied
@@ -49,178 +64,150 @@ const (
 )
 
 // ============================================================================
-// Re-exported types from lock package for backward compatibility
+// Lock types, re-exported so lock-aware errors stay reachable here
 // ============================================================================
 
 // LockConflict is re-exported from the lock package.
-// Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type LockConflict = lock.LockConflict
 
 // UnifiedLockConflict is re-exported from the lock package.
-// Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type UnifiedLockConflict = lock.UnifiedLockConflict
 
 // ============================================================================
-// Error Factory Functions (backward compatibility wrappers)
+// Error Factory Functions
 // ============================================================================
 
 // NewNotFoundError creates a StoreError for when a file, directory, or share is not found.
-// Deprecated: Use errors.NewNotFoundError directly.
 func NewNotFoundError(path string, entityType string) *StoreError {
 	return errors.NewNotFoundError(path, entityType)
 }
 
 // NewPermissionDeniedError creates a StoreError for permission denied errors.
-// Deprecated: Use errors.NewPermissionDeniedError directly.
 func NewPermissionDeniedError(path string) *StoreError {
 	return errors.NewPermissionDeniedError(path)
 }
 
 // NewIsDirectoryError creates a StoreError for when a file operation is attempted on a directory.
-// Deprecated: Use errors.NewIsDirectoryError directly.
 func NewIsDirectoryError(path string) *StoreError {
 	return errors.NewIsDirectoryError(path)
 }
 
 // NewNotDirectoryError creates a StoreError for when a directory operation is attempted on a non-directory.
-// Deprecated: Use errors.NewNotDirectoryError directly.
 func NewNotDirectoryError(path string) *StoreError {
 	return errors.NewNotDirectoryError(path)
 }
 
 // NewInvalidHandleError creates a StoreError for malformed file handles.
-// Deprecated: Use errors.NewInvalidHandleError directly.
 func NewInvalidHandleError() *StoreError {
 	return errors.NewInvalidHandleError()
 }
 
 // NewStaleHandleError creates a StoreError for handles that decode but name a
 // share that no longer exists.
-// Deprecated: Use errors.NewStaleHandleError directly.
 func NewStaleHandleError(shareName string) *StoreError {
 	return errors.NewStaleHandleError(shareName)
 }
 
 // NewNotEmptyError creates a StoreError for when a directory is not empty.
-// Deprecated: Use errors.NewNotEmptyError directly.
 func NewNotEmptyError(path string) *StoreError {
 	return errors.NewNotEmptyError(path)
 }
 
 // NewAlreadyExistsError creates a StoreError for when a file/directory already exists.
-// Deprecated: Use errors.NewAlreadyExistsError directly.
 func NewAlreadyExistsError(path string) *StoreError {
 	return errors.NewAlreadyExistsError(path)
 }
 
 // NewConflictError creates a StoreError for ObjectID concurrent-write conflicts.
-// Deprecated: Use errors.NewConflictError directly.
 func NewConflictError(op, message string) *StoreError {
 	return errors.NewConflictError(op, message)
 }
 
 // NewInvalidArgumentError creates a StoreError for invalid arguments.
-// Deprecated: Use errors.NewInvalidArgumentError directly.
 func NewInvalidArgumentError(message string) *StoreError {
 	return errors.NewInvalidArgumentError(message)
 }
 
 // NewAccessDeniedError creates a StoreError for share-level access denial.
-// Deprecated: Use errors.NewAccessDeniedError directly.
 func NewAccessDeniedError(reason string) *StoreError {
 	return errors.NewAccessDeniedError(reason)
 }
 
 // NewLockedError creates a StoreError for lock conflicts.
-// Deprecated: Use lock.NewLockedError directly.
 func NewLockedError(path string, conflict *LockConflict) *StoreError {
 	return lock.NewLockedError(path, conflict)
 }
 
 // NewLockNotFoundError creates a StoreError for unlock operations on non-existent locks.
-// Deprecated: Use lock.NewLockNotFoundError directly.
 func NewLockNotFoundError(path string) *StoreError {
 	return lock.NewLockNotFoundError(path)
 }
 
 // NewQuotaExceededError creates a StoreError for quota exceeded errors.
-// Deprecated: Use errors.NewQuotaExceededError directly.
 func NewQuotaExceededError(path string) *StoreError {
 	return errors.NewQuotaExceededError(path)
 }
 
 // NewPrivilegeRequiredError creates a StoreError for operations requiring root.
-// Deprecated: Use errors.NewPrivilegeRequiredError directly.
 func NewPrivilegeRequiredError(operation string) *StoreError {
 	return errors.NewPrivilegeRequiredError(operation)
 }
 
 // NewNameTooLongError creates a StoreError for paths/names exceeding limits.
-// Deprecated: Use errors.NewNameTooLongError directly.
 func NewNameTooLongError(path string) *StoreError {
 	return errors.NewNameTooLongError(path)
 }
 
 // NewDeadlockError creates a StoreError for deadlock detection.
-// Deprecated: Use lock.NewDeadlockError directly.
 func NewDeadlockError(waiter string, blockedBy []string) *StoreError {
 	return lock.NewDeadlockError(waiter, blockedBy)
 }
 
 // NewGracePeriodError creates a StoreError for grace period blocking.
-// Deprecated: Use lock.NewGracePeriodError directly.
 func NewGracePeriodError(remainingSeconds int) *StoreError {
 	return lock.NewGracePeriodError(remainingSeconds)
 }
 
 // NewLockLimitExceededError creates a StoreError for lock limit violations.
-// Deprecated: Use lock.NewLockLimitExceededError directly.
 func NewLockLimitExceededError(limitType string, current, max int) *StoreError {
 	return lock.NewLockLimitExceededError(limitType, current, max)
 }
 
 // NewLockConflictError creates a StoreError for lock conflicts (upgrade, etc.).
-// Deprecated: Use lock.NewLockConflictError directly.
 func NewLockConflictError(path string, conflict *UnifiedLockConflict) *StoreError {
 	return lock.NewLockConflictError(path, conflict)
 }
 
 // ============================================================================
-// Error Helper Functions (backward compatibility wrappers)
+// Error Helper Functions
 // ============================================================================
 
 // IsNotFoundError checks if an error is a StoreError with ErrNotFound code.
-// Deprecated: Use errors.IsNotFoundError directly.
 func IsNotFoundError(err error) bool {
 	return errors.IsNotFoundError(err)
 }
 
 // IsLockConflictError checks if an error is a StoreError with ErrLockConflict code.
-// Deprecated: Use errors.IsLockConflictError directly.
 func IsLockConflictError(err error) bool {
 	return errors.IsLockConflictError(err)
 }
 
 // IsDeadlockError checks if an error is a StoreError with ErrDeadlock code.
-// Deprecated: Use errors.IsDeadlockError directly.
 func IsDeadlockError(err error) bool {
 	return errors.IsDeadlockError(err)
 }
 
 // IsConflictError checks if an error is a StoreError with ErrConflict code.
-// Deprecated: Use errors.IsConflictError directly.
 func IsConflictError(err error) bool {
 	return errors.IsConflictError(err)
 }
 
 // IsInvalidHandleError checks if an error is a StoreError with ErrInvalidHandle code.
-// Deprecated: Use errors.IsInvalidHandleError directly.
 func IsInvalidHandleError(err error) bool {
 	return errors.IsInvalidHandleError(err)
 }
 
 // IsStaleHandleError checks if an error is a StoreError with ErrStaleHandle code.
-// Deprecated: Use errors.IsStaleHandleError directly.
 func IsStaleHandleError(err error) bool {
 	return errors.IsStaleHandleError(err)
 }

--- a/pkg/metadata/errors.go
+++ b/pkg/metadata/errors.go
@@ -18,14 +18,15 @@ import (
 // The implementations live in pkg/metadata/errors and pkg/metadata/lock
 // because neither of those packages may import metadata: metadata imports
 // both, so the dependency only runs one way. That lets the store backends and
-// the lock manager raise and inspect the same errors without a cycle — all
-// four backends import pkg/metadata/errors directly — while the aliases here
+// the lock manager raise and inspect the same errors without a cycle — the
+// store backends import pkg/metadata/errors directly — while the aliases here
 // keep the API reachable from the package that owns it.
 //
-// These are aliases, not wrappers, so a value built through either spelling is
-// the identical type and compares equal. Removing or renaming a name here
-// breaks every caller of the metadata package; it is not the cleanup of an
-// unused shim.
+// These are aliases, not wrappers: each name here and the name it points at
+// denote one and the same type, so a value can be passed to anything
+// expecting either spelling without conversion. Removing or renaming a name
+// here breaks every caller of the metadata package; it is not the cleanup of
+// an unused shim.
 
 // StoreError is re-exported from the errors package.
 type StoreError = errors.StoreError

--- a/pkg/metadata/lock_exports.go
+++ b/pkg/metadata/lock_exports.go
@@ -1,9 +1,23 @@
 package metadata
 
 // ============================================================================
-// Re-exported lock types from lock package for backward compatibility
+// Public lock surface of package metadata
+// ============================================================================
 //
-// DEPRECATED: Import directly from github.com/marmos91/dittofs/pkg/metadata/lock
+// The names below are package metadata's lock API. The NFS and SMB adapters,
+// the control-plane runtime and the metadata store backends refer to lock
+// state as metadata.FileLock, metadata.PersistedLock, metadata.LockQuery and
+// the rest.
+//
+// The implementations live in pkg/metadata/lock because that package may not
+// import metadata — metadata imports it, so the dependency only runs one way.
+// That lets the lock manager and the backends that persist locks share one set
+// of types without a cycle, while the aliases here keep the API reachable from
+// the package that owns it.
+//
+// These are aliases, not distinct types, so a lock built through either
+// spelling satisfies both. Removing or renaming a name here breaks every
+// caller of the metadata package.
 // ============================================================================
 
 import (
@@ -15,10 +29,9 @@ import (
 // ============================================================================
 
 // LockType is re-exported from the lock package.
-// Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type LockType = lock.LockType
 
-// Lock type constants re-exported for backward compatibility.
+// The lock-type constants callers compare LockType against.
 const (
 	// LockTypeShared is re-exported from the lock package.
 	LockTypeShared = lock.LockTypeShared
@@ -27,10 +40,9 @@ const (
 )
 
 // AccessMode is re-exported from the lock package.
-// Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type AccessMode = lock.AccessMode
 
-// Share reservation constants re-exported for backward compatibility.
+// The share-reservation constants callers compare AccessMode against.
 const (
 	// AccessModeNone is re-exported from the lock package.
 	AccessModeNone = lock.AccessModeNone
@@ -43,15 +55,12 @@ const (
 )
 
 // LockOwner is re-exported from the lock package.
-// Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type LockOwner = lock.LockOwner
 
 // UnifiedLock is re-exported from the lock package.
-// Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type UnifiedLock = lock.UnifiedLock
 
 // FileLock is re-exported from the lock package.
-// Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type FileLock = lock.FileLock
 
 // ============================================================================
@@ -59,11 +68,9 @@ type FileLock = lock.FileLock
 // ============================================================================
 
 // LockManager is re-exported from the lock package as Manager.
-// Deprecated: Import Manager from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type LockManager = lock.Manager
 
 // NewLockManager creates a new lock manager.
-// Deprecated: Use lock.NewManager() directly.
 func NewLockManager() *LockManager {
 	return lock.NewManager()
 }
@@ -73,27 +80,22 @@ func NewLockManager() *LockManager {
 // ============================================================================
 
 // LockConfig is re-exported from the lock package as Config.
-// Deprecated: Import Config from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type LockConfig = lock.Config
 
 // DefaultLockConfig returns default lock configuration.
-// Deprecated: Use lock.DefaultConfig() directly.
 func DefaultLockConfig() LockConfig {
 	return lock.DefaultConfig()
 }
 
 // LockLimits is re-exported from the lock package as Limits.
-// Deprecated: Import Limits from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type LockLimits = lock.Limits
 
 // NewLockLimits creates a new limits tracker.
-// Deprecated: Use lock.NewLimits() directly.
 func NewLockLimits() *LockLimits {
 	return lock.NewLimits()
 }
 
 // LockStats is re-exported from the lock package as Stats.
-// Deprecated: Import Stats from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type LockStats = lock.Stats
 
 // ============================================================================
@@ -101,10 +103,9 @@ type LockStats = lock.Stats
 // ============================================================================
 
 // GraceState is re-exported from the lock package.
-// Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type GraceState = lock.GraceState
 
-// Grace state constants re-exported for backward compatibility.
+// The grace states callers compare GraceState against.
 const (
 	// GraceStateNormal is re-exported from the lock package.
 	GraceStateNormal = lock.GraceStateNormal
@@ -113,11 +114,9 @@ const (
 )
 
 // GracePeriodManager is re-exported from the lock package.
-// Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type GracePeriodManager = lock.GracePeriodManager
 
 // LockOperation is re-exported from the lock package as Operation.
-// Deprecated: Import Operation from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type LockOperation = lock.Operation
 
 // ============================================================================
@@ -125,15 +124,12 @@ type LockOperation = lock.Operation
 // ============================================================================
 
 // ConnectionTracker is re-exported from the lock package.
-// Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type ConnectionTracker = lock.ConnectionTracker
 
 // ConnectionTrackerConfig is re-exported from the lock package.
-// Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type ConnectionTrackerConfig = lock.ConnectionTrackerConfig
 
 // ClientRegistration is re-exported from the lock package.
-// Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type ClientRegistration = lock.ClientRegistration
 
 // ============================================================================
@@ -141,7 +137,6 @@ type ClientRegistration = lock.ClientRegistration
 // ============================================================================
 
 // WaitForGraph is re-exported from the lock package.
-// Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type WaitForGraph = lock.WaitForGraph
 
 // ============================================================================
@@ -149,15 +144,12 @@ type WaitForGraph = lock.WaitForGraph
 // ============================================================================
 
 // LockStore is re-exported from the lock package.
-// Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type LockStore = lock.LockStore
 
 // PersistedLock is re-exported from the lock package.
-// Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type PersistedLock = lock.PersistedLock
 
 // LockQuery is re-exported from the lock package.
-// Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type LockQuery = lock.LockQuery
 
 // ============================================================================
@@ -165,17 +157,13 @@ type LockQuery = lock.LockQuery
 // ============================================================================
 
 // OpLock is re-exported from the lock package.
-// Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type OpLock = lock.OpLock
 
 // OpLockBreakScanner is re-exported from the lock package.
-// Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type OpLockBreakScanner = lock.OpLockBreakScanner
 
 // OpLockBreakCallback is re-exported from the lock package.
-// Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type OpLockBreakCallback = lock.OpLockBreakCallback
 
 // NLMHolderInfo is re-exported from the lock package.
-// Deprecated: Import from github.com/marmos91/dittofs/pkg/metadata/lock directly.
 type NLMHolderInfo = lock.NLMHolderInfo

--- a/pkg/metadata/lock_exports.go
+++ b/pkg/metadata/lock_exports.go
@@ -15,9 +15,10 @@ package metadata
 // of types without a cycle, while the aliases here keep the API reachable from
 // the package that owns it.
 //
-// These are aliases, not distinct types, so a lock built through either
-// spelling satisfies both. Removing or renaming a name here breaks every
-// caller of the metadata package.
+// These are aliases, not distinct types: each name here and the name it
+// points at denote one and the same type, so a value can be passed to a
+// function expecting either spelling without conversion. Removing or
+// renaming a name here breaks every caller of the metadata package.
 // ============================================================================
 
 import (


### PR DESCRIPTION
## The premise behind the audit finding was wrong

The finding proposed deleting `pkg/metadata/errors.go` and
`pkg/metadata/lock_exports.go` — 407 lines described as back-compat shims with
**zero external consumers repo-wide**, existing only so `pkg/metadata`'s own
files can write `ErrNotFound` unqualified.

Measured across the ~90 symbols the two files re-export:

- **491 qualified `metadata.<symbol>` references in 75 files across 18
  packages** — `internal/adapter/smb/handlers` (12 files),
  `internal/adapter/nfs/v4/*`, `internal/adapter/nfs/xdr`,
  `internal/controlplane/api/handlers`, `pkg/adapter/nfs`, `pkg/adapter/smb`,
  `pkg/block/engine`, `pkg/controlplane/runtime` (plus `shares` and `trash`),
  all four backends under `pkg/metadata/store/*`, `pkg/metadata/storetest`, and
  `test/e2e`.
- plus **441 unqualified references in 39 files** inside `pkg/metadata` itself.

Top symbols: `metadata.StoreError` (249 uses), `metadata.IsNotFoundError` (59),
`metadata.ErrNotFound` (50), `metadata.ErrInvalidHandle` (48),
`metadata.FileLock` (31).

So the deletion was never a 407-line removal. It was a ~930-site rename across
~114 files that would *add* an import to each of the 75 external files and
lengthen every call site, since most already import stdlib `errors` and would
need an alias (`metadata.StoreError` → `storeerrors.StoreError`).

**Decision: keep both files.** They are the error and lock API of package
`metadata`, not shims.

## What this PR changes

Comments only. No symbol added, removed or renamed — the non-comment diff is
empty.

- Both file headers now state what the file is: the public error / lock surface
  of package `metadata`, reached by the adapters, API handlers, block engine,
  runtime and every store backend.
- Both explain *why* the implementations sit in `pkg/metadata/errors` and
  `pkg/metadata/lock`: neither sub-package may import `metadata`, because
  `metadata` imports both, so the dependency runs one way only. Verified with
  `go list -deps` — neither sub-package reaches `pkg/metadata`, and all four
  store backends import `pkg/metadata/errors` directly.
- Both say plainly that these are aliases, so a value built through either
  spelling is the identical type, and that removing a name breaks every caller
  of the metadata package rather than cleaning up an unused shim.
- Every `// Deprecated: Import from ... directly.` marker is gone (~30 of them),
  along with the "backward compatibility" section headings. Those markers were
  the load-bearing part of the mistake: they told both tooling and readers that
  the live API was on its way out.

Counts are deliberately kept out of the source comments — they would rot. The
comments make the structural argument instead.

## Evidence

- `go build ./... && go vet ./... && gofmt -l` clean.
- `go test ./...` green.
- `git diff` filtered to non-comment lines is empty, so the compiled API is
  byte-identical.

Closes #1994
