### PR TITLE
fix(nfs4): release open state when a v4.1 client's lease expires

### DIFF
--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -725,6 +725,43 @@ func (sm *StateManager) RemoveClient(clientID uint64) {
 		"client_id_str", record.ClientIDString)
 }
 
+// removeClientOpenStateLocked drops every open-owner belonging to clientID
+// together with its open states, its lock states, and the locks those hold in
+// the unified lock manager.
+//
+// It scans sm.openOwners by ClientID rather than walking a per-client owner
+// list: V41ClientRecord carries no such list, and the v4.0 ClientRecord one
+// goes stale because freeStateidLocked removes owners from sm.openOwners
+// without removing them there.
+//
+// Caller must hold sm.mu.
+func (sm *StateManager) removeClientOpenStateLocked(clientID uint64) {
+	for key, owner := range sm.openOwners {
+		if owner.ClientID != clientID {
+			continue
+		}
+		for _, openState := range owner.OpenStates {
+			for _, lockState := range openState.LockStates {
+				delete(sm.lockStateByOther, lockState.Stateid.Other)
+				sm.removeOwnerLocksLocked(lockState)
+				if lockState.LockOwner != nil {
+					delete(sm.lockOwners, lockState.LockOwner.Key())
+				}
+			}
+			delete(sm.openStateByOther, openState.Stateid.Other)
+			sm.removeOpenStateFromFileLocked(openState)
+		}
+		delete(sm.openOwners, key)
+	}
+
+	// Drop any retained closed-stateid -> owner replay entries for this client.
+	for other, owner := range sm.closedOwnerByOther {
+		if owner.ClientID == clientID {
+			delete(sm.closedOwnerByOther, other)
+		}
+	}
+}
+
 // onLeaseExpired is the callback invoked when a client's lease timer fires.
 // It cleans up all state for the expired client: open states, open owners,
 // and the client record itself.
@@ -751,36 +788,7 @@ func (sm *StateManager) onLeaseExpired(clientID uint64) {
 	// when no recovery store is wired.
 	sm.deleteClientRecoveryLocked(record.ClientIDString)
 
-	// Remove all open states AND lock states for all owners
-	for _, owner := range record.OpenOwners {
-		for _, openState := range owner.OpenStates {
-			// Clean up lock states associated with this open
-			for _, lockState := range openState.LockStates {
-				// Remove from lockStateByOther map
-				delete(sm.lockStateByOther, lockState.Stateid.Other)
-
-				// Remove actual locks from unified lock manager
-				sm.removeOwnerLocksLocked(lockState)
-
-				// Remove lock-owner from lockOwners map
-				if lockState.LockOwner != nil {
-					delete(sm.lockOwners, lockState.LockOwner.Key())
-				}
-			}
-
-			delete(sm.openStateByOther, openState.Stateid.Other)
-			sm.removeOpenStateFromFileLocked(openState)
-		}
-		// Remove the owner from the openOwners map
-		delete(sm.openOwners, owner.Key())
-	}
-
-	// Drop any retained closed-stateid -> owner replay entries for this client.
-	for other, owner := range sm.closedOwnerByOther {
-		if owner.ClientID == clientID {
-			delete(sm.closedOwnerByOther, other)
-		}
-	}
+	sm.removeClientOpenStateLocked(clientID)
 
 	// Clean up delegations for the expired client
 	for other, deleg := range sm.delegByOther {

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -731,7 +731,7 @@ func (sm *StateManager) RemoveClient(clientID uint64) {
 //
 // It scans sm.openOwners by ClientID rather than walking a per-client owner
 // list: V41ClientRecord carries no such list, and the v4.0 ClientRecord one
-// goes stale because freeStateidLocked removes owners from sm.openOwners
+// goes stale because freeOpenStateidLocked removes owners from sm.openOwners
 // without removing them there.
 //
 // Caller must hold sm.mu.

--- a/internal/adapter/nfs/v4/state/session_test.go
+++ b/internal/adapter/nfs/v4/state/session_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
 // ============================================================================
@@ -1053,13 +1054,30 @@ func TestReaper_ExpiredLeaseReleasesOpenState(t *testing.T) {
 		t.Fatalf("CreateSession error: %v", err)
 	}
 
+	lm := lock.NewManager()
+	sm.SetLockManagerResolver(func(_ []byte) lock.LockManager { return lm })
+
 	fh := []byte("fh-shared")
-	if _, err := sm.OpenFile(clientID, []byte("owner-a"), 1, fh,
+	open, err := sm.OpenFile(clientID, []byte("owner-a"), 1, fh,
 		types.OPEN4_SHARE_ACCESS_BOTH,
 		types.OPEN4_SHARE_DENY_WRITE,
 		types.CLAIM_NULL,
-	); err != nil {
+	)
+	if err != nil {
 		t.Fatalf("OpenFile error: %v", err)
+	}
+
+	// A byte-range lock on top of the open: seqid 0 is the v4.1 bypass, the
+	// slot table provides the replay protection the seqids give v4.0.
+	if _, err := sm.LockNew(context.Background(),
+		clientID, []byte("lock-owner-a"), 0,
+		&open.Stateid, 0,
+		fh, types.WRITE_LT, 0, 100, false,
+	); err != nil {
+		t.Fatalf("LockNew error: %v", err)
+	}
+	if got := len(lm.ListUnifiedLocks(string(fh))); got != 1 {
+		t.Fatalf("unified locks before reap = %d, want 1", got)
 	}
 
 	// Let the lease lapse, then run the sweep the reaper goroutine runs.
@@ -1070,6 +1088,8 @@ func TestReaper_ExpiredLeaseReleasesOpenState(t *testing.T) {
 	_, clientLives := sm.v41ClientsByID[clientID]
 	owners := len(sm.openOwners)
 	opens := len(sm.openStateByOther)
+	lockOwners := len(sm.lockOwners)
+	lockStates := len(sm.lockStateByOther)
 	sm.mu.RUnlock()
 
 	if clientLives {
@@ -1080,6 +1100,17 @@ func TestReaper_ExpiredLeaseReleasesOpenState(t *testing.T) {
 	}
 	if opens != 0 {
 		t.Errorf("openStateByOther = %d, want 0: purged client's open states leaked", opens)
+	}
+	if lockOwners != 0 {
+		t.Errorf("lockOwners = %d, want 0: purged client's lock-owners leaked", lockOwners)
+	}
+	if lockStates != 0 {
+		t.Errorf("lockStateByOther = %d, want 0: purged client's lock states leaked", lockStates)
+	}
+	// The byte range must be free for the next client -- and for SMB, which
+	// shares this manager.
+	if got := len(lm.ListUnifiedLocks(string(fh))); got != 0 {
+		t.Errorf("unified locks after reap = %d, want 0: reaped client's locks still held", got)
 	}
 
 	// The reservation must die with the client: another client opening the same

--- a/internal/adapter/nfs/v4/state/session_test.go
+++ b/internal/adapter/nfs/v4/state/session_test.go
@@ -1034,6 +1034,80 @@ func TestReaper_ActiveLeaseNotCleaned(t *testing.T) {
 	}
 }
 
+// TestReaper_ExpiredLeaseReleasesOpenState checks that reaping a client whose
+// lease lapsed also releases the open state its owners hold. v4.1 OPENs run
+// through the same OpenFile path as v4.0 and land in sm.openOwners, but the
+// V41ClientRecord has no owner list of its own, so a purge that only walked the
+// record left them behind — with their share reservations still denying every
+// other client, and no client record left to ever CLOSE them.
+func TestReaper_ExpiredLeaseReleasesOpenState(t *testing.T) {
+	const lease = 20 * time.Millisecond
+	sm := NewStateManager(lease)
+	defer sm.Shutdown()
+
+	clientID, seqID := registerV41Client(t, sm)
+	if _, _, err := sm.CreateSession(
+		clientID, seqID, 0,
+		defaultForeAttrs(), defaultBackAttrs(), 0, nil,
+	); err != nil {
+		t.Fatalf("CreateSession error: %v", err)
+	}
+
+	fh := []byte("fh-shared")
+	if _, err := sm.OpenFile(clientID, []byte("owner-a"), 1, fh,
+		types.OPEN4_SHARE_ACCESS_BOTH,
+		types.OPEN4_SHARE_DENY_WRITE,
+		types.CLAIM_NULL,
+	); err != nil {
+		t.Fatalf("OpenFile error: %v", err)
+	}
+
+	// Let the lease lapse, then run the sweep the reaper goroutine runs.
+	time.Sleep(3 * lease)
+	sm.reapExpiredSessions()
+
+	sm.mu.RLock()
+	_, clientLives := sm.v41ClientsByID[clientID]
+	owners := len(sm.openOwners)
+	opens := len(sm.openStateByOther)
+	sm.mu.RUnlock()
+
+	if clientLives {
+		t.Fatal("expired v4.1 client still registered after reap")
+	}
+	if owners != 0 {
+		t.Errorf("openOwners = %d, want 0: purged client's open-owners leaked", owners)
+	}
+	if opens != 0 {
+		t.Errorf("openStateByOther = %d, want 0: purged client's open states leaked", opens)
+	}
+
+	// The reservation must die with the client: another client opening the same
+	// file for writing has nothing left to conflict with.
+	var verifier [8]byte
+	copy(verifier[:], "verify02")
+	other, err := sm.ExchangeID([]byte("second-client"), verifier, 0, nil, "10.0.0.2:12345")
+	if err != nil {
+		t.Fatalf("ExchangeID error for second client: %v", err)
+	}
+	if _, _, err := sm.CreateSession(
+		other.ClientID, other.SequenceID, 0,
+		defaultForeAttrs(), defaultBackAttrs(), 0, nil,
+	); err != nil {
+		t.Fatalf("CreateSession error for second client: %v", err)
+	}
+	if _, err := sm.OpenFile(other.ClientID, []byte("owner-b"), 1, fh,
+		types.OPEN4_SHARE_ACCESS_WRITE,
+		types.OPEN4_SHARE_DENY_NONE,
+		types.CLAIM_NULL,
+	); err != nil {
+		if errors.Is(err, ErrShareDenied) {
+			t.Fatal("share reservation of the reaped client still denies other clients")
+		}
+		t.Fatalf("OpenFile error for second client: %v", err)
+	}
+}
+
 func TestReaper_ContextCancellation(t *testing.T) {
 	sm := NewStateManager(DefaultLeaseDuration)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/adapter/nfs/v4/state/v41_client.go
+++ b/internal/adapter/nfs/v4/state/v41_client.go
@@ -302,8 +302,8 @@ func applyImplInfo(record *V41ClientRecord, clientImplId []types.NfsImplId4) {
 	}
 }
 
-// purgeV41Client removes a V41ClientRecord from both lookup maps
-// and destroys all associated sessions.
+// purgeV41Client removes a V41ClientRecord from both lookup maps, releases the
+// open and lock state its owners hold, and destroys all associated sessions.
 // Only deletes from v41ClientsByOwner if the map entry still points to this
 // record (guards against a concurrent createV41Client having already replaced it).
 // Caller must hold sm.mu.
@@ -318,6 +318,8 @@ func (sm *StateManager) purgeV41Client(record *V41ClientRecord) {
 	if record.Lease != nil {
 		record.Lease.Stop()
 	}
+
+	sm.removeClientOpenStateLocked(record.ClientID)
 
 	// Clean up all delegations (file + directory) for this client
 	for other, deleg := range sm.delegByOther {
@@ -464,32 +466,7 @@ func (sm *StateManager) EvictV40Client(clientID uint64) error {
 		record.Lease.Stop()
 	}
 
-	// Remove all open states and lock states for all owners
-	for _, owner := range record.OpenOwners {
-		for _, openState := range owner.OpenStates {
-			for _, lockState := range openState.LockStates {
-				delete(sm.lockStateByOther, lockState.Stateid.Other)
-
-				// Remove actual locks from unified lock manager (matches onLeaseExpired)
-				if lm := sm.lockManagerFor(lockState.FileHandle); lm != nil && lockState.LockOwner != nil {
-					ownerID := lockState.LockOwner.LockManagerOwnerID()
-					handleKey := string(lockState.FileHandle)
-					for _, l := range lm.ListUnifiedLocks(handleKey) {
-						if l.Owner.OwnerID == ownerID {
-							_ = lm.RemoveUnifiedLock(handleKey, l.Owner, l.Offset, l.Length)
-						}
-					}
-				}
-
-				if lockState.LockOwner != nil {
-					delete(sm.lockOwners, lockState.LockOwner.Key())
-				}
-			}
-			delete(sm.openStateByOther, openState.Stateid.Other)
-			sm.removeOpenStateFromFileLocked(openState)
-		}
-		delete(sm.openOwners, owner.Key())
-	}
+	sm.removeClientOpenStateLocked(clientID)
 
 	// Clean up delegations for the evicted client
 	for other, deleg := range sm.delegByOther {


### PR DESCRIPTION


# Description

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)


## Changes Made

Reap open owners, open states and lock states when the lease expires in NFS v4.1, same as in v4.0.

## Testing

<!-- Please describe the tests that you ran to verify your changes: -->

- [X] Unit tests pass (`go test ./...`)
- [ ] Manual testing performed
- [ ] Integration testing performed

## Testing Instructions

<!-- Describe how reviewers can test your changes: -->

Purely theoretical, the following steps should reproduce the issue:
1. One client locks a file using v4.1.
2. Cut off the connection.
3. Try to lock the file with another client from another machine after the lease has expired (in reality, a bit longer).

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published