### PR TITLE
ci: stop the integration job hanging in the rpcbind install

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,6 +23,9 @@ jobs:
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-latest
+    # Without a cap this job inherits the six-hour default, so a hang holds a
+    # required check for the rest of the day instead of failing and retrying.
+    timeout-minutes: 45
 
     strategy:
       matrix:
@@ -106,6 +109,12 @@ jobs:
         run: go test -tags=integration -v -timeout=20m -p 1 ./...
 
       - name: Install and start rpcbind
+        env:
+          # apt and needrestart both prompt on a tty-less runner if left to
+          # their defaults, and a prompt here blocks with no output until the
+          # job's wall clock runs out.
+          DEBIAN_FRONTEND: noninteractive
+          NEEDRESTART_MODE: a
         run: |
           sudo apt-get update
           sudo apt-get install -y rpcbind


### PR DESCRIPTION
## What was wrong

Eight PRs sat un-mergeable for most of a day on a single required check,
`Integration Tests (1.25.x)`. The runs were not queued — they were hung, some
for four to five hours.

The hang is in one step. From a stuck job's step list:

```
completed  success  Run all integration tests
in_progress   -     Install and start rpcbind      <-- 3h30m, zero output
pending       -     Run portmap system integration tests
```

The tests themselves had already passed. The step is:

```yaml
sudo apt-get update
sudo apt-get install -y rpcbind
sudo systemctl start rpcbind || sudo rpcbind
```

`apt-get` runs with no `DEBIAN_FRONTEND`, and the runner image ships
`needrestart`, which prompts after installing a package that pulls in a
service. On a tty-less runner a prompt blocks forever and emits nothing, which
is exactly the observed signature: last log line at the end of the previous
step, then silence.

Two things then combine to make it maximally expensive:

- The job has no `timeout-minutes`, so it inherits GitHub's six-hour default.
  A hang holds a required check for the rest of the working day rather than
  failing and being retried. Every other slow workflow here is capped —
  `smb-conformance.yml` at 30/45, the POSIX jobs at 60 — which is why those
  failed visibly while this one silently stalled.
- It is intermittent (it depends on whether a restart is deemed necessary), so
  it reads as flaky infrastructure rather than a fixable defect.

## The change

Set `DEBIAN_FRONTEND=noninteractive` and `NEEDRESTART_MODE=a` on that step, and
cap the job at 45 minutes. A healthy run of this job completes well inside that.

## Evidence

The prompt itself is not visible in the API log for an in-progress step, so the
interactive-prompt mechanism is the leading explanation rather than a captured
one. What is directly established: the step is the one hung, it produced no
output for hours, the tests before it passed, the same job succeeds on other
branches, and the job had no time cap. The `timeout-minutes` half of this fix
stands on its own regardless — a hang should cost one CI cycle, not six hours.
