### PR TITLE
refactor(metadata): collapse the third EvaluateContext copy onto the shared builder

### DIFF
--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -1131,10 +1131,8 @@ func buildFileAccessEvalContext(file *File, authCtx *AuthContext) *acl.EvaluateC
 
 // buildEvalContext builds the acl.EvaluateContext for a requester against a
 // file owned by ownerUID/ownerGID. It is the shared construction behind
-// evaluateACLPermissions and buildFileAccessEvalContext, so the NFS and SMB
-// permission paths cannot drift apart. buildAttrEvalContext
-// (file_access_checker.go) still carries its own copy for the access-based
-// enumeration path.
+// evaluateACLPermissions, buildFileAccessEvalContext and buildAttrEvalContext,
+// so the NFS, SMB and access-based enumeration paths cannot drift apart.
 //
 // A nil identity (or one with no UID) is anonymous: FileOwnerUID is forced to
 // the acl.AnonymousFileOwnerUID sentinel so the requester's zero-valued UID

--- a/pkg/metadata/file_access_checker.go
+++ b/pkg/metadata/file_access_checker.go
@@ -61,49 +61,16 @@ func (s *Service) CheckAttrReadAccess(attr *FileAttr, authCtx *AuthContext, requ
 }
 
 // buildAttrEvalContext constructs an acl.EvaluateContext from a FileAttr +
-// AuthContext pair. It mirrors buildFileAccessEvalContext but takes the bare
-// FileAttr (no enclosing File / handle), which is all an access-based
-// enumeration decision has in scope.
+// AuthContext pair, taking the file owner from the attr rather than an
+// enclosing File row: a bare FileAttr is all an access-based enumeration
+// decision has in scope. The construction itself is buildEvalContext's, so the
+// enumeration path cannot drift from the NFS and SMB permission paths.
 func buildAttrEvalContext(attr *FileAttr, authCtx *AuthContext) *acl.EvaluateContext {
-	if authCtx == nil || authCtx.Identity == nil || authCtx.Identity.UID == nil {
-		// Anonymous: force FileOwnerUID to the AnonymousFileOwnerUID sentinel so
-		// the requester's zero-valued UID cannot collapse onto a root-owned
-		// entry's owner and pick up OWNER@ ACEs plus the MS-DTYP §2.5.3.2
-		// owner-implicit grant. Anonymous confines the DACL walk to EVERYONE@.
-		return &acl.EvaluateContext{
-			Anonymous:    true,
-			FileOwnerUID: acl.AnonymousFileOwnerUID,
-			FileOwnerGID: attr.GID,
-		}
+	var identity *Identity
+	if authCtx != nil {
+		identity = authCtx.Identity
 	}
-
-	identity := authCtx.Identity
-	evalCtx := &acl.EvaluateContext{
-		UID:          *identity.UID,
-		GIDs:         identity.GIDs,
-		FileOwnerUID: attr.UID,
-		FileOwnerGID: attr.GID,
-	}
-	if identity.GID != nil {
-		evalCtx.GID = *identity.GID
-	}
-
-	switch {
-	case identity.Username != "" && identity.Domain != "":
-		evalCtx.Who = identity.Username + "@" + identity.Domain
-	case identity.Username != "":
-		evalCtx.Who = identity.Username
-	}
-
-	if identity.SID != nil {
-		evalCtx.SID = *identity.SID
-	}
-	evalCtx.GroupSIDs = identity.GroupSIDs
-	// MS-DTYP §2.5.3.2: owner-implicit WRITE_OWNER requires
-	// SeTakeOwnershipPrivilege (admins only). See acl.Evaluate.
-	evalCtx.RequesterHasTakeOwnership = acl.HasTakeOwnershipPrivilege(evalCtx.SID, evalCtx.GroupSIDs)
-
-	return evalCtx
+	return buildEvalContext(attr.UID, attr.GID, identity)
 }
 
 // attrPosixCanRead implements the read-bit selection used when an entry has no


### PR DESCRIPTION
## What was wrong

The data-plane audit filed the `acl.EvaluateContext` construction as triplicated, and #2014 closed two of the three: `buildFileAccessEvalContext` became a delegation and the inline copy went away. The third, `buildAttrEvalContext` in `file_access_checker.go`, was left alone on purpose because `file_access_checker.go` was being rewritten concurrently by #2020. #2020 has since merged, so this is the promised follow-up.

`buildAttrEvalContext` duplicated `buildEvalContext` line for line: same anonymous guard, same `AnonymousFileOwnerUID` sentinel, same `Who` composition from username and domain, same SID and GroupSIDs copy, same `RequesterHasTakeOwnership` probe. The only difference was taking the file owner from a `FileAttr` rather than from a `File`.

That is the drift risk the audit finding named. The access-based enumeration path decides whether a directory entry is visible; if its context construction ever diverges from the path that decides whether the same file is readable, a name becomes visible that its own DACL denies, or vice versa.

## The change

`buildAttrEvalContext` now extracts the identity from the `AuthContext` (nil safe, exactly as `buildFileAccessEvalContext` does) and delegates to `buildEvalContext(attr.UID, attr.GID, identity)`. Net 35 lines gone, no behaviour change: the two bodies were equivalent, so the delegation produces an identical context for every input.

`buildEvalContext`'s godoc no longer has to carve out an exception for the copy that outlived #2014.

## Testing

- `go test -race ./pkg/metadata/ ./internal/adapter/smb/handlers/` green, which covers the cross-protocol permission conformance suite and the SMB access-based enumeration tests that exercise this builder.
- `go build ./...`, `gofmt` clean.

Refs #1967