### PR TITLE
fix(memory): guard durable handles with the store-wide lock

### DIFF
--- a/pkg/metadata/store/memory/durable_handles.go
+++ b/pkg/metadata/store/memory/durable_handles.go
@@ -3,7 +3,6 @@ package memory
 import (
 	"bytes"
 	"context"
-	"sync"
 	"time"
 
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
@@ -13,12 +12,11 @@ import (
 // Secondary lookups use linear scans, acceptable since durable handle counts
 // are typically low (hundreds at most).
 //
-// Unlike the other memory sub-stores, this one owns its lock: getDurableStore
-// takes the store-wide mutex only long enough to publish the pointer and
-// releases it before the method below runs, so mu here is the sole guard on
-// handles.
+// It carries no lock of its own: every method is reached through a
+// MemoryMetadataStore wrapper that holds the store-wide mutex for the whole
+// call, so handles is guarded by that one lock — the same lock a snapshot
+// holds while it encodes the map.
 type memoryDurableStore struct {
-	mu      sync.RWMutex
 	handles map[string]*lock.PersistedDurableHandle
 }
 
@@ -33,9 +31,6 @@ func (s *memoryDurableStore) PutDurableHandle(ctx context.Context, handle *lock.
 		return err
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	s.handles[handle.ID] = cloneDurableHandle(handle)
 	return nil
 }
@@ -44,9 +39,6 @@ func (s *memoryDurableStore) GetDurableHandle(ctx context.Context, id string) (*
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-
-	s.mu.RLock()
-	defer s.mu.RUnlock()
 
 	handle, exists := s.handles[id]
 	if !exists {
@@ -65,9 +57,6 @@ func (s *memoryDurableStore) GetDurableHandleByFileID(ctx context.Context, fileI
 	if fileID == ([16]byte{}) {
 		return nil, nil
 	}
-
-	s.mu.RLock()
-	defer s.mu.RUnlock()
 
 	handle := s.lowestHandleForFileID(fileID)
 	if handle == nil {
@@ -100,9 +89,6 @@ func (s *memoryDurableStore) GetDurableHandleByCreateGuid(ctx context.Context, c
 		return nil, nil
 	}
 
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	for _, handle := range s.handles {
 		if handle.CreateGuid == createGuid {
 			return cloneDurableHandle(handle), nil
@@ -116,9 +102,6 @@ func (s *memoryDurableStore) ConsumeDurableHandle(ctx context.Context, id string
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	handle, exists := s.handles[id]
 	if !exists {
@@ -138,9 +121,6 @@ func (s *memoryDurableStore) GetDurableHandlesByAppInstanceId(ctx context.Contex
 		return nil, nil
 	}
 
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	var result []*lock.PersistedDurableHandle
 	for _, handle := range s.handles {
 		if handle.AppInstanceId == appInstanceId {
@@ -155,9 +135,6 @@ func (s *memoryDurableStore) GetDurableHandlesByFileHandle(ctx context.Context, 
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-
-	s.mu.RLock()
-	defer s.mu.RUnlock()
 
 	var result []*lock.PersistedDurableHandle
 	for _, handle := range s.handles {
@@ -174,9 +151,6 @@ func (s *memoryDurableStore) DeleteDurableHandle(ctx context.Context, id string)
 		return err
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	delete(s.handles, id)
 	return nil
 }
@@ -185,9 +159,6 @@ func (s *memoryDurableStore) ListDurableHandles(ctx context.Context) ([]*lock.Pe
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-
-	s.mu.RLock()
-	defer s.mu.RUnlock()
 
 	result := make([]*lock.PersistedDurableHandle, 0, len(s.handles))
 	for _, handle := range s.handles {
@@ -201,9 +172,6 @@ func (s *memoryDurableStore) ListDurableHandlesByShare(ctx context.Context, shar
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-
-	s.mu.RLock()
-	defer s.mu.RUnlock()
 
 	var result []*lock.PersistedDurableHandle
 	for _, handle := range s.handles {
@@ -219,9 +187,6 @@ func (s *memoryDurableStore) DeleteExpiredDurableHandles(ctx context.Context, no
 	if err := ctx.Err(); err != nil {
 		return 0, err
 	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	count := 0
 	for id, handle := range s.handles {
@@ -284,58 +249,153 @@ func cloneDurableHandle(h *lock.PersistedDurableHandle) *lock.PersistedDurableHa
 
 var _ lock.DurableHandleStore = (*MemoryMetadataStore)(nil)
 
-// getDurableStore returns the durable store, creating it on first access.
-func (s *MemoryMetadataStore) getDurableStore() *memoryDurableStore {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+// initDurableStore ensures the durable handle store is initialized.
+// Must be called with the store's write lock held.
+func (s *MemoryMetadataStore) initDurableStore() {
 	if s.durableStore == nil {
 		s.durableStore = newMemoryDurableStore()
 	}
-	return s.durableStore
 }
 
+// PutDurableHandle stores or replaces a durable handle.
 func (s *MemoryMetadataStore) PutDurableHandle(ctx context.Context, handle *lock.PersistedDurableHandle) error {
-	return s.getDurableStore().PutDurableHandle(ctx, handle)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.initDurableStore()
+	return s.durableStore.PutDurableHandle(ctx, handle)
 }
 
+// GetDurableHandle retrieves a durable handle by ID.
 func (s *MemoryMetadataStore) GetDurableHandle(ctx context.Context, id string) (*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().GetDurableHandle(ctx, id)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.durableStore == nil {
+		return nil, nil
+	}
+	return s.durableStore.GetDurableHandle(ctx, id)
 }
 
+// GetDurableHandleByFileID retrieves the lowest-ID handle held on a file.
 func (s *MemoryMetadataStore) GetDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().GetDurableHandleByFileID(ctx, fileID)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.durableStore == nil {
+		return nil, nil
+	}
+	return s.durableStore.GetDurableHandleByFileID(ctx, fileID)
 }
 
+// GetDurableHandleByCreateGuid retrieves a V2 durable handle by its create GUID.
 func (s *MemoryMetadataStore) GetDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().GetDurableHandleByCreateGuid(ctx, createGuid)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.durableStore == nil {
+		return nil, nil
+	}
+	return s.durableStore.GetDurableHandleByCreateGuid(ctx, createGuid)
 }
 
+// ConsumeDurableHandle retrieves and removes a durable handle by ID.
 func (s *MemoryMetadataStore) ConsumeDurableHandle(ctx context.Context, id string) (*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().ConsumeDurableHandle(ctx, id)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.durableStore == nil {
+		return nil, nil
+	}
+	return s.durableStore.ConsumeDurableHandle(ctx, id)
 }
 
+// GetDurableHandlesByAppInstanceId returns every handle for an app instance.
 func (s *MemoryMetadataStore) GetDurableHandlesByAppInstanceId(ctx context.Context, appInstanceId [16]byte) ([]*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().GetDurableHandlesByAppInstanceId(ctx, appInstanceId)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.durableStore == nil {
+		return nil, nil
+	}
+	return s.durableStore.GetDurableHandlesByAppInstanceId(ctx, appInstanceId)
 }
 
+// GetDurableHandlesByFileHandle returns every handle on a metadata file handle.
 func (s *MemoryMetadataStore) GetDurableHandlesByFileHandle(ctx context.Context, fileHandle []byte) ([]*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().GetDurableHandlesByFileHandle(ctx, fileHandle)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.durableStore == nil {
+		return nil, nil
+	}
+	return s.durableStore.GetDurableHandlesByFileHandle(ctx, fileHandle)
 }
 
+// DeleteDurableHandle removes a durable handle by ID.
 func (s *MemoryMetadataStore) DeleteDurableHandle(ctx context.Context, id string) error {
-	return s.getDurableStore().DeleteDurableHandle(ctx, id)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.durableStore == nil {
+		return nil
+	}
+	return s.durableStore.DeleteDurableHandle(ctx, id)
 }
 
+// ListDurableHandles returns every stored durable handle.
 func (s *MemoryMetadataStore) ListDurableHandles(ctx context.Context) ([]*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().ListDurableHandles(ctx)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.durableStore == nil {
+		return []*lock.PersistedDurableHandle{}, nil
+	}
+	return s.durableStore.ListDurableHandles(ctx)
 }
 
+// ListDurableHandlesByShare returns every durable handle on a share.
 func (s *MemoryMetadataStore) ListDurableHandlesByShare(ctx context.Context, shareName string) ([]*lock.PersistedDurableHandle, error) {
-	return s.getDurableStore().ListDurableHandlesByShare(ctx, shareName)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.durableStore == nil {
+		return nil, nil
+	}
+	return s.durableStore.ListDurableHandlesByShare(ctx, shareName)
 }
 
+// DeleteExpiredDurableHandles drops every handle whose timeout has elapsed.
 func (s *MemoryMetadataStore) DeleteExpiredDurableHandles(ctx context.Context, now time.Time) (int, error) {
-	return s.getDurableStore().DeleteExpiredDurableHandles(ctx, now)
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.durableStore == nil {
+		return 0, nil
+	}
+	return s.durableStore.DeleteExpiredDurableHandles(ctx, now)
 }
 
 // DurableHandleStore returns this store as a DurableHandleStore.

--- a/pkg/metadata/store/memory/durable_snapshot_race_test.go
+++ b/pkg/metadata/store/memory/durable_snapshot_race_test.go
@@ -15,6 +15,12 @@ import (
 // TestWriteSnapshot_ConcurrentDurableHandles checks that the store-wide read
 // lock WriteSnapshot holds also excludes durable-handle mutators, so encoding
 // the handle map never observes a concurrent write.
+//
+// The regression it guards is a data race, so it only reports reliably under
+// -race, which is how unit-tests.yml and windows-build.yml run the suite.
+// Without that flag a regression surfaces only when the runtime happens to
+// catch the concurrent map access, so a plain `go test` pass proves nothing
+// here.
 func TestWriteSnapshot_ConcurrentDurableHandles(t *testing.T) {
 	store := memory.NewMemoryMetadataStoreWithDefaults()
 	ctx := context.Background()

--- a/pkg/metadata/store/memory/durable_snapshot_race_test.go
+++ b/pkg/metadata/store/memory/durable_snapshot_race_test.go
@@ -1,0 +1,60 @@
+package memory_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// TestWriteSnapshot_ConcurrentDurableHandles checks that the store-wide read
+// lock WriteSnapshot holds also excludes durable-handle mutators, so encoding
+// the handle map never observes a concurrent write.
+func TestWriteSnapshot_ConcurrentDurableHandles(t *testing.T) {
+	store := memory.NewMemoryMetadataStoreWithDefaults()
+	ctx := context.Background()
+
+	for i := range 200 {
+		h := &lock.PersistedDurableHandle{ID: fmt.Sprintf("seed-%d", i), DisconnectedAt: time.Now(), TimeoutMs: 3600000}
+		if err := store.PutDurableHandle(ctx, h); err != nil {
+			t.Fatalf("seed put: %v", err)
+		}
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			h := &lock.PersistedDurableHandle{ID: fmt.Sprintf("live-%d", i), DisconnectedAt: time.Now().Add(-time.Hour), TimeoutMs: 1}
+			if err := store.PutDurableHandle(ctx, h); err != nil {
+				t.Errorf("put: %v", err)
+				return
+			}
+			if _, err := store.DeleteExpiredDurableHandles(ctx, time.Now()); err != nil {
+				t.Errorf("expire: %v", err)
+				return
+			}
+		}
+	}()
+
+	for range 200 {
+		if _, err := store.WriteSnapshot(ctx, io.Discard); err != nil {
+			t.Fatalf("snapshot: %v", err)
+		}
+	}
+	close(stop)
+	wg.Wait()
+}


### PR DESCRIPTION
Closes #2023

## Verdict: CONFIRMED, reproduced under `-race`

The durable-handle wrappers on `MemoryMetadataStore` took `s.mu` only long enough to publish the sub-store pointer (`getDurableStore`, `durable_handles.go:288`) and released it before the method ran, mutating `handles` under a second mutex the sub-store owned. `WriteSnapshot` (`snapshot_store.go:110`) holds `s.mu.RLock()` across gob encoding and hands it the live map (`snapshot_store.go:187`), so its read lock excluded nothing on the writer side.

A temporary test running `WriteSnapshot` against a `PutDurableHandle` / `DeleteExpiredDurableHandles` loop fires the race detector on unmodified develop:

```
WARNING: DATA RACE
Read at ... by goroutine 8:
  encoding/gob.(*Encoder).encodeMap()
  ...MemoryMetadataStore).WriteSnapshot() snapshot_store.go:229
Previous write at ... by goroutine 9:
  ...memoryDurableStore).PutDurableHandle() durable_handles.go:39
```

## Change

- Every durable-handle wrapper now holds `s.mu` (write for the mutators, read for the pure readers) across the whole call, with `initDurableStore()` under the write lock — the shape `clients.go` / `client_recovery.go` already use. Readers no longer lazily create the sub-store; they return the empty result when it is nil.
- `memoryDurableStore.mu` is gone, so all four memory sub-stores are now on one lock and one discipline.
- The reproduction stays as a permanent regression test.

No caller of the wrappers holds `s.mu` — the interface is only reached from outside the package, so no deadlock path.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .` clean. `go test -race ./pkg/metadata/...`, `./pkg/controlplane/runtime/...` and `./internal/adapter/smb/...` all pass; the regression test passes `-count=3`.