### PR TITLE
fix(snapshot): recover the orchestration error from the row when the goroutine finishes first

### DIFF
--- a/pkg/controlplane/models/snapshot.go
+++ b/pkg/controlplane/models/snapshot.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"errors"
+	"fmt"
 	"path/filepath"
 	"time"
 )
@@ -35,10 +37,66 @@ type Snapshot struct {
 	// Scheduled marks snapshots created by the background snapshot scheduler.
 	// Only scheduled snapshots are eligible for automatic retention pruning;
 	// manually-created snapshots are never auto-pruned.
-	Scheduled bool      `gorm:"not null;default:false" json:"scheduled"`
-	Error     string    `gorm:"size:1024" json:"error,omitempty"`
-	CreatedAt time.Time `gorm:"autoCreateTime" json:"created_at"`
-	UpdatedAt time.Time `gorm:"autoUpdateTime" json:"updated_at"`
+	Scheduled bool   `gorm:"not null;default:false" json:"scheduled"`
+	Error     string `gorm:"size:1024" json:"error,omitempty"`
+	// FailureKind records which sentinel produced Error. It lets a caller
+	// that arrives after the orchestration goroutine has exited rebuild a
+	// typed error from the row instead of matching the message text. Empty
+	// on rows that never failed and on rows written before the kind was
+	// recorded.
+	FailureKind string    `gorm:"size:32" json:"failure_kind,omitempty"`
+	CreatedAt   time.Time `gorm:"autoCreateTime" json:"created_at"`
+	UpdatedAt   time.Time `gorm:"autoUpdateTime" json:"updated_at"`
+}
+
+// Snapshot failure kinds, as persisted on the row's FailureKind column.
+// These tokens are part of the stored format: renaming one strands the rows
+// already written with the old spelling.
+const (
+	FailureKindBackup       string = "backup"
+	FailureKindVerify       string = "verify"
+	FailureKindDrainTimeout string = "drain_timeout"
+)
+
+// snapshotFailureSentinels pairs each failure kind with the sentinel it
+// records, in classification order.
+var snapshotFailureSentinels = []struct {
+	kind     string
+	sentinel error
+}{
+	{FailureKindDrainTimeout, ErrSnapshotDrainTimeout},
+	{FailureKindVerify, ErrSnapshotVerifyFailed},
+	{FailureKindBackup, ErrSnapshotBackupFailed},
+}
+
+// SnapshotFailureKind classifies cause into the token stored on the row.
+// Returns "" when cause wraps no known snapshot failure sentinel.
+func SnapshotFailureKind(cause error) string {
+	for _, m := range snapshotFailureSentinels {
+		if errors.Is(cause, m.sentinel) {
+			return m.kind
+		}
+	}
+	return ""
+}
+
+// SnapshotFailureError rebuilds a caller-facing error from a terminal
+// state='failed' row. It carries the persisted message and, when the row
+// records a known failure kind, wraps the matching sentinel so errors.Is
+// classifies it exactly as the in-memory error would have. Rows with an empty
+// or unrecognised kind yield a plain error — non-nil either way, so a failed
+// snapshot is never mistaken for a successful one.
+func SnapshotFailureError(s *Snapshot) error {
+	msg := s.Error
+	if msg == "" {
+		msg = "snapshot failed"
+	}
+	for _, m := range snapshotFailureSentinels {
+		if m.kind == s.FailureKind {
+			return fmt.Errorf("%s: %w", msg, m.sentinel)
+		}
+	}
+	return errors.New(msg)
 }
 
 func (Snapshot) TableName() string {

--- a/pkg/controlplane/models/snapshot.go
+++ b/pkg/controlplane/models/snapshot.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"errors"
-	"fmt"
 	"path/filepath"
 	"time"
 )
@@ -80,9 +79,22 @@ func SnapshotFailureKind(cause error) string {
 	return ""
 }
 
+// snapshotFailure is a rebuilt failure: it prints the message persisted on the
+// row and unwraps to the sentinel the row's kind names. The persisted message
+// is the original error's own Error() output, which already contains the
+// sentinel's text, so printing it verbatim rather than re-wrapping keeps the
+// rebuilt error's string identical to the one an in-memory waiter sees.
+type snapshotFailure struct {
+	msg      string
+	sentinel error
+}
+
+func (e *snapshotFailure) Error() string { return e.msg }
+func (e *snapshotFailure) Unwrap() error { return e.sentinel }
+
 // SnapshotFailureError rebuilds a caller-facing error from a terminal
 // state='failed' row. It carries the persisted message and, when the row
-// records a known failure kind, wraps the matching sentinel so errors.Is
+// records a known failure kind, unwraps to the matching sentinel so errors.Is
 // classifies it exactly as the in-memory error would have. Rows with an empty
 // or unrecognised kind yield a plain error — non-nil either way, so a failed
 // snapshot is never mistaken for a successful one.
@@ -93,7 +105,7 @@ func SnapshotFailureError(s *Snapshot) error {
 	}
 	for _, m := range snapshotFailureSentinels {
 		if m.kind == s.FailureKind {
-			return fmt.Errorf("%s: %w", msg, m.sentinel)
+			return &snapshotFailure{msg: msg, sentinel: m.sentinel}
 		}
 	}
 	return errors.New(msg)

--- a/pkg/controlplane/models/snapshot_test.go
+++ b/pkg/controlplane/models/snapshot_test.go
@@ -171,3 +171,23 @@ func TestSnapshotFailureKind(t *testing.T) {
 		t.Fatalf("SnapshotFailureKind(nil) = %q, want \"\"", got)
 	}
 }
+
+// TestSnapshotFailureError_MessageMatchesInMemory pins the rebuilt error's
+// string to the in-memory one. The row's message is the original error's own
+// Error() output, so it already ends in the sentinel's text; re-wrapping it
+// around the sentinel would print that text twice and make the message depend
+// on whether the waiter observed the orchestration error or rebuilt it.
+func TestSnapshotFailureError_MessageMatchesInMemory(t *testing.T) {
+	t.Parallel()
+
+	inMemory := fmt.Errorf("manifest hash mismatch: %w", ErrSnapshotVerifyFailed)
+	row := Snapshot{Error: inMemory.Error(), FailureKind: SnapshotFailureKind(inMemory)}
+
+	rebuilt := SnapshotFailureError(&row)
+	if rebuilt.Error() != inMemory.Error() {
+		t.Fatalf("rebuilt = %q, want %q", rebuilt.Error(), inMemory.Error())
+	}
+	if !errors.Is(rebuilt, ErrSnapshotVerifyFailed) {
+		t.Fatalf("rebuilt = %v, want errors.Is(ErrSnapshotVerifyFailed)", rebuilt)
+	}
+}

--- a/pkg/controlplane/models/snapshot_test.go
+++ b/pkg/controlplane/models/snapshot_test.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -111,5 +113,61 @@ func TestSnapshot_FieldSet(t *testing.T) {
 		if !strings.Contains(src, needle) {
 			t.Errorf("snapshot.go missing required field %q", name)
 		}
+	}
+}
+
+// TestSnapshotFailureError covers rebuilding a caller-facing error from a
+// terminal row: a recorded kind restores the sentinel identity, and a row
+// without one (written before the kind was persisted, or classified from a
+// cause matching no sentinel) still yields a non-nil error so a failed
+// snapshot can never read as a success.
+func TestSnapshotFailureError(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		row  Snapshot
+		want error // nil = any non-nil error, matching no sentinel
+	}{
+		{"verify", Snapshot{Error: "boom", FailureKind: FailureKindVerify}, ErrSnapshotVerifyFailed},
+		{"backup", Snapshot{Error: "boom", FailureKind: FailureKindBackup}, ErrSnapshotBackupFailed},
+		{"drain timeout", Snapshot{Error: "boom", FailureKind: FailureKindDrainTimeout}, ErrSnapshotDrainTimeout},
+		{"kind not recorded", Snapshot{Error: "boom"}, nil},
+		{"unknown kind", Snapshot{Error: "boom", FailureKind: "martian"}, nil},
+		{"no message either", Snapshot{}, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := SnapshotFailureError(&tc.row)
+			if got == nil {
+				t.Fatal("SnapshotFailureError = nil, want non-nil for a failed row")
+			}
+			if tc.want != nil && !errors.Is(got, tc.want) {
+				t.Fatalf("SnapshotFailureError = %v, want errors.Is(%v)", got, tc.want)
+			}
+			if tc.want == nil && SnapshotFailureKind(got) != "" {
+				t.Fatalf("SnapshotFailureError = %v, want no sentinel", got)
+			}
+		})
+	}
+}
+
+// TestSnapshotFailureKind pins that the kind persisted by the orchestration
+// round-trips back to the sentinel the caller matches on.
+func TestSnapshotFailureKind(t *testing.T) {
+	t.Parallel()
+
+	for _, sentinel := range []error{ErrSnapshotVerifyFailed, ErrSnapshotBackupFailed, ErrSnapshotDrainTimeout} {
+		cause := fmt.Errorf("snapshot create abc: step failed: %w: %v", sentinel, errors.New("cause"))
+		row := Snapshot{Error: cause.Error(), FailureKind: SnapshotFailureKind(cause)}
+		if !errors.Is(SnapshotFailureError(&row), sentinel) {
+			t.Fatalf("round-trip lost sentinel %v (kind %q)", sentinel, row.FailureKind)
+		}
+	}
+	if got := SnapshotFailureKind(errors.New("unclassified")); got != "" {
+		t.Fatalf("SnapshotFailureKind(unclassified) = %q, want \"\"", got)
+	}
+	if got := SnapshotFailureKind(nil); got != "" {
+		t.Fatalf("SnapshotFailureKind(nil) = %q, want \"\"", got)
 	}
 }

--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -250,8 +250,10 @@ func (r *Runtime) CreateSnapshot(ctx context.Context, shareName string, opts Cre
 //     callers can errors.Is against the typed sentinels (e.g.
 //     models.ErrSnapshotVerifyFailed).
 //   - Already-complete snapshot (chan drained or removed from registry):
-//     no chan present → falls through to GetSnapshot immediately with
-//     nil orchestration error. The row state carries the outcome.
+//     no chan is present, so the row is the only outcome available. A
+//     state=failed row is rebuilt into the same wrapped sentinel via
+//     models.SnapshotFailureError, so the caller sees the failure whether
+//     or not it won the race against the goroutine's teardown.
 //   - ctx cancel during wait: returns nil, ctx.Err() without consulting
 //     GetSnapshot.
 //   - Unknown snapshot id: GetSnapshot returns
@@ -259,12 +261,10 @@ func (r *Runtime) CreateSnapshot(ctx context.Context, shareName string, opts Cre
 //
 // Concurrency: the per-snap chan is buffered with cap 1 and closed after
 // the single send (see runSnapshotOrchestration's deferred cleanup), so
-// reads after the close yield the zero-value snapResult{} — the first
-// reader observes the orchestration error and subsequent readers see the
-// row state (which already reflects failure as state=failed). This
-// single-broadcast behavior is acceptable for the current single-caller
-// pattern; a multi-subscriber event-stream upgrade (sync.Cond) is a
-// possible future enhancement.
+// reads after the close yield the zero-value snapResult{}. That drained
+// read and a missing registry entry are the same case, and both recover
+// the error from the row instead of reporting success — the outcome does
+// not depend on which of the caller and the goroutine ran first.
 func (r *Runtime) WaitForSnapshot(ctx context.Context, shareName, snapID string) (*models.Snapshot, error) {
 	if r == nil || r.store == nil {
 		return nil, errors.New("runtime: nil store")
@@ -293,8 +293,8 @@ func (r *Runtime) WaitForSnapshot(ctx context.Context, shareName, snapID string)
 		case res := <-doneCh:
 			// nil err on success or the wrapped sentinel on failure.
 			// Closed-then-drained chans yield the zero-value
-			// snapResult{} → orchErr stays nil and the row state is the
-			// authoritative outcome for late subscribers.
+			// snapResult{}, leaving orchErr nil; the row check below
+			// recovers the failure for those late subscribers.
 			orchErr = res.err
 		case <-ctx.Done():
 			return nil, ctx.Err()
@@ -306,6 +306,14 @@ func (r *Runtime) WaitForSnapshot(ctx context.Context, shareName, snapID string)
 		// ErrSnapshotNotFound propagates as-is (errors.Is works through
 		// the underlying wrap).
 		return nil, gerr
+	}
+	if orchErr == nil && snap.State == models.StateFailed {
+		// The goroutine's error was never observed: it finished and tore
+		// down its chan before this call looked, another waiter drained
+		// the single-send chan, or the orchestration ran in an earlier
+		// process. The row is authoritative, so rebuild the error from it
+		// rather than returning a failed snapshot with nil error.
+		orchErr = models.SnapshotFailureError(snap)
 	}
 	return snap, orchErr
 }
@@ -787,8 +795,10 @@ func drainSentinel(err error) error {
 }
 
 // failSnap flips the snapshot row to state='failed' and persists cause's
-// message onto the row's Error column so show/list surface the reason
-// instead of "(no error message)". Best-effort: if the row update itself
+// message and sentinel kind onto the row's Error and FailureKind columns, so
+// show/list surface the reason instead of "(no error message)" and a caller
+// that waits after the orchestration goroutine has exited can rebuild the
+// same typed error from the row. Best-effort: if the row update itself
 // fails (e.g., DB unavailable), we log but do not double-fail the
 // orchestration error — the wrapped sentinel posted to doneCh is still the
 // authoritative signal for callers, and the startup-recovery scan will
@@ -802,7 +812,8 @@ func (r *Runtime) failSnap(shareName, snapID string, cause error) {
 	if cause != nil {
 		msg = cause.Error()
 	}
-	if err := r.store.MarkSnapshotFailed(context.Background(), shareName, snapID, msg); err != nil {
+	kind := models.SnapshotFailureKind(cause)
+	if err := r.store.MarkSnapshotFailed(context.Background(), shareName, snapID, msg, kind); err != nil {
 		logger.Error("snapshot create: failed to flip state=failed (will reconcile on next restart)",
 			"snapshot_id", snapID,
 			"share", shareName,
@@ -982,7 +993,8 @@ func (r *Runtime) recoverOrphanedSnapshots(ctx context.Context) error {
 				continue
 			}
 			if uerr := r.store.MarkSnapshotFailed(ctx, shareName, snap.ID,
-				"abandoned: server restarted while snapshot was still creating"); uerr != nil {
+				"abandoned: server restarted while snapshot was still creating",
+				models.FailureKindBackup); uerr != nil {
 				logger.Error("snapshot recovery: flip to failed",
 					"snapshot_id", snap.ID,
 					"share", shareName,

--- a/pkg/controlplane/runtime/snapshot_waitrace_test.go
+++ b/pkg/controlplane/runtime/snapshot_waitrace_test.go
@@ -1,0 +1,61 @@
+package runtime
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+// TestWaitForSnapshot_ErrorSurvivesOrchestrationFinishingFirst pins the
+// contract that WaitForSnapshot reports a failed snapshot as a failure even
+// when the caller arrives after orchestration has already finished and torn
+// down its in-memory result channel. The row is the authoritative outcome, so
+// a terminal state=failed row must yield the typed sentinel regardless of who
+// won the race.
+func TestWaitForSnapshot_ErrorSurvivesOrchestrationFinishingFirst(t *testing.T) {
+	t.Parallel()
+	fx := newRestoreFixture(t, restoreFixtureOpts{})
+	defer fx.close()
+
+	ctx := fx.ctx()
+	files := fx.populateFiles(ctx, []string{"waitrace.bin"})
+
+	// Same C3 inconsistency used by the empty-manifest test: the snapshot
+	// fails verify deterministically.
+	if err := fx.meta.DeleteFile(ctx, files[0].handle); err != nil {
+		t.Fatalf("DeleteFile: %v", err)
+	}
+
+	snapID, err := fx.rt.CreateSnapshot(ctx, fx.shareName, CreateSnapshotOpts{})
+	if err != nil {
+		t.Fatalf("CreateSnapshot (sync part): %v", err)
+	}
+
+	// Let orchestration settle before waiting — this is what a loaded machine
+	// does by accident.
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		row, gerr := fx.rt.GetSnapshot(ctx, fx.shareName, snapID)
+		if gerr != nil {
+			t.Fatalf("GetSnapshot: %v", gerr)
+		}
+		if row.State != models.StateCreating {
+			t.Logf("orchestration settled: state=%s", row.State)
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("snapshot never left state=creating")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	snap, werr := fx.rt.WaitForSnapshot(ctx, fx.shareName, snapID)
+	if snap == nil || snap.State != models.StateFailed {
+		t.Fatalf("snapshot state = %v, want failed", snap)
+	}
+	if !errors.Is(werr, models.ErrSnapshotVerifyFailed) {
+		t.Fatalf("WaitForSnapshot err = %v, want errors.Is(ErrSnapshotVerifyFailed) for a state=failed row", werr)
+	}
+}

--- a/pkg/controlplane/store/interface.go
+++ b/pkg/controlplane/store/interface.go
@@ -586,12 +586,15 @@ type SnapshotStore interface {
 	UpdateSnapshotState(ctx context.Context, shareName, id, state string) error
 
 	// MarkSnapshotFailed flips a snapshot to state='failed' and persists
-	// errMsg onto its Error column in a single UPDATE so show/list can
-	// surface the failure reason. Not gated on prior state (the
-	// orchestration goroutine may call it from any pipeline step). errMsg
-	// is truncated to fit the column. Returns models.ErrSnapshotNotFound
-	// if no row matches (shareName, id).
-	MarkSnapshotFailed(ctx context.Context, shareName, id, errMsg string) error
+	// errMsg plus failureKind onto its Error and FailureKind columns in a
+	// single UPDATE, so show/list can surface the failure reason and a
+	// caller waiting after the orchestration goroutine has exited can
+	// rebuild the typed error. Not gated on prior state (the orchestration
+	// goroutine may call it from any pipeline step). errMsg is truncated to
+	// fit the column; failureKind may be "" when the cause matches no known
+	// sentinel. Returns models.ErrSnapshotNotFound if no row matches
+	// (shareName, id).
+	MarkSnapshotFailed(ctx context.Context, shareName, id, errMsg, failureKind string) error
 
 	// UpdateSnapshotDurable flips the RemoteDurable bit on the snapshot
 	// row matching (shareName, id). Called by the orchestration goroutine

--- a/pkg/controlplane/store/snapshots.go
+++ b/pkg/controlplane/store/snapshots.go
@@ -132,15 +132,17 @@ func (s *GORMStore) UpdateSnapshotState(ctx context.Context, shareName, id, stat
 }
 
 // MarkSnapshotFailed flips a snapshot to state='failed' and persists errMsg
-// onto the row's Error column in a single UPDATE, so show/list surface the
-// failure reason instead of "(no error message)". Unlike UpdateSnapshotState
-// it does not gate on the prior state: the orchestration goroutine calls this
-// from any pipeline step (still 'creating', or a retry that already flipped
-// back to 'creating'), and the recovery scan must be able to record a reason
-// regardless. errMsg is truncated to fit the column.
+// and failureKind onto the row's Error and FailureKind columns in a single
+// UPDATE, so show/list surface the failure reason instead of "(no error
+// message)" and a later waiter can rebuild the typed error from the row.
+// Unlike UpdateSnapshotState it does not gate on the prior state: the
+// orchestration goroutine calls this from any pipeline step (still
+// 'creating', or a retry that already flipped back to 'creating'), and the
+// recovery scan must be able to record a reason regardless. errMsg is
+// truncated to fit the column.
 //
 // Returns models.ErrSnapshotNotFound if no row matches (shareName, id).
-func (s *GORMStore) MarkSnapshotFailed(ctx context.Context, shareName, id, errMsg string) error {
+func (s *GORMStore) MarkSnapshotFailed(ctx context.Context, shareName, id, errMsg, failureKind string) error {
 	const maxErrLen = 1024
 	if len(errMsg) > maxErrLen {
 		errMsg = errMsg[:maxErrLen]
@@ -149,9 +151,10 @@ func (s *GORMStore) MarkSnapshotFailed(ctx context.Context, shareName, id, errMs
 	res := db.Model(&models.Snapshot{}).
 		Where("share_name = ? AND id = ?", shareName, id).
 		Updates(map[string]any{
-			"state":      models.StateFailed,
-			"error":      errMsg,
-			"updated_at": time.Now(),
+			"state":        models.StateFailed,
+			"error":        errMsg,
+			"failure_kind": failureKind,
+			"updated_at":   time.Now(),
 		})
 	if res.Error != nil {
 		return res.Error


### PR DESCRIPTION
Closes #1866.

## Verdict: confirmed, deterministic

`WaitForSnapshot` returned the orchestration error only while a live per-snap
result channel was in the registry, but `runSnapshotOrchestration`'s deferred
cleanup deletes that entry the moment it completes. A caller arriving after
teardown found `hasCh == false`, skipped the receive entirely, left `orchErr`
at its nil zero value, and returned the **failed** snapshot row with a **nil**
error. Whether a failed snapshot reported failure depended on which side won a
race — which is why this looked like a flaky test rather than a bug.

The same hole exists on a second path the original report did not name: the
channel is buffered cap 1, sent once and closed, so a *second* waiter drains
the zero value and loses the error even when the registry entry is still live.
Both are fixed by the same change.

Reproduced on clean `develop` in 0.04s with no simulation — just waiting for
the row to leave `creating` before calling `WaitForSnapshot`, which is what a
loaded runner does by accident:

```
snapshot_waitrace_test.go:45: orchestration settled: state=failed
snapshot_waitrace_test.go:59: WaitForSnapshot err = <nil>, want errors.Is(ErrSnapshotVerifyFailed) for a state=failed row
```

## Blast radius, corrected

The audit's note that the REST wait endpoint reports success for a failed
snapshot does not hold on the current tree: `WaitForSnapshot` is declared on
the handler's `SnapshotRuntime` interface but no route calls it, and `dfsctl`
waits by polling the row state through `apiclient`. The only production caller
is `RestoreSnapshot`'s safety-snapshot wait, and that one is already shielded
by an explicit `safetySnap.State != StateReady` check immediately after. So the
defect is real but currently contained to the runtime API and its tests — worth
fixing before a caller trusts the error, not a live outage.

## Change

The row is authoritative, but it only stored the message string, so the
sentinel identity was unrecoverable. Rather than match sentinels back out of
message text:

- `models.Snapshot` gains a `FailureKind` column recording which sentinel
  produced `Error` (`backup` / `verify` / `drain_timeout`).
- `MarkSnapshotFailed` persists the kind alongside the message in the same
  UPDATE; `failSnap` classifies the cause via `models.SnapshotFailureKind`.
- `WaitForSnapshot` rebuilds the wrapped error from a terminal `state=failed`
  row whenever no orchestration error was observed.

Making the reconstruction faithful is what keeps the fix deterministic: the
caller now gets the *same* typed sentinel regardless of who won the race.
Returning a bare untyped error on the registry-miss path would have removed the
false success but left the error's identity depending on machine speed.

Rows with no recorded kind — written before this change, or from a cause
matching no sentinel — still yield a non-nil error, so a failed snapshot can
never read as a success. The column is added by AutoMigrate.

## Tests

- `TestWaitForSnapshot_ErrorSurvivesOrchestrationFinishingFirst` — the
  regression test above; fails on `develop`, passes here.
- `TestSnapshotFailureError` / `TestSnapshotFailureKind` — sentinel round-trip
  plus the empty/unknown-kind fallbacks.

`go build ./... && go vet ./... && gofmt -l .` clean.
`go test -race` green across `./pkg/controlplane/...` and
`./internal/controlplane/...`. The originally-red
`TestSnapshot_EncryptionInteraction` passes 10/10 under `-race`.