### PR TITLE
refactor: validate the LOW duplication tranche; thread ctx into DiscoveryName

### DIFF
--- a/.planning/audits/2026-08-05-dataplane/report.md
+++ b/.planning/audits/2026-08-05-dataplane/report.md
@@ -1023,10 +1023,12 @@ Every finding passed three gates: confirmed from source, reachable from a non-te
 
 ### [LOW] CompoundResult error-literal repeated ~9x per file instead of using sibling's helper pattern
 - **Where:** `internal/adapter/nfs/v4/handlers/read.go:24` · `structure`
+> STATUS: FIXED in #2000 — readErr (read.go:204), writeErr (write.go:231) and commitErr (commit.go:128) now mirror readPlusErr; no inline CompoundResult status literal remains in the three handlers.
 - **Fix:** Add `readErr(status)`, `writeErr(status)`, `commitErr(status)` (or one generic `opErr(op, status uint32) *types.CompoundResult`) per handler mirroring readPlusErr; replace all inline literals.
 
 ### [LOW] nil-Registry guard + block-store resolve boilerplate duplicated across all 4 handlers
 - **Where:** `internal/adapter/nfs/v4/handlers/read.go:174` · `structure`
+> STATUS: FIXED in #1999 — h.resolveBlockStore (helpers.go:250) is the single resolve path; read.go:128 and the sibling handlers call it.
 - **Fix:** Add one `h.resolveBlockStore(ctx, fh, forWrite bool)` helper in this package that read/write/commit call (read_plus keeps its error-return shape). Do NOT push into common.ResolveFor* — the in-code comment deliberately keeps the NFSv4 concern out of common.
 
 ### [LOW] READ_PLUS response buffer not pre-sized, unlike sibling READ handler
@@ -1431,6 +1433,7 @@ Every finding passed three gates: confirmed from source, reachable from a non-te
 
 ### [LOW] FileAccessChecker: single-implementation capability interface declared in the producer package
 - **Where:** `pkg/metadata/file_access_checker.go:32` · `structure` · *re-confirmed*
+> STATUS: FIXED in #2020 — the interface and its `var _` assertion are gone; `rg FileAccessChecker` over the tree is empty, so there was no test fake keeping it alive either.
 - **Fix:** Delete the FileAccessChecker interface and the var _ assertion; have filterByAccess/canEnumerateEntry in query_directory.go take *metadata.Service directly, or declare a small local interface in the smb/handlers package (consumer-side) if a test double is genuinely needed there.
 
 ### [LOW] CreateRootDirectory's UID/GID reconciliation on an existing root writes the file record without invalidating readCache/parentCache
@@ -1595,6 +1598,7 @@ Every finding passed three gates: confirmed from source, reachable from a non-te
 
 ### [LOW] Package-level mutable global cache-size config instead of threading through store config
 - **Where:** `pkg/metadata/store/badger/cache.go:69` · `structure`
+> STATUS: WONTFIX — claim is accurate but the suggested fix is a net loss. The store-open path is the package-level runtime.CreateMetadataStoreFromConfig (init.go:55), whose second caller is the HTTP handler internal/controlplane/api/handlers/metadata_stores.go:87 — a runtime-added store, with no access to cfg.Metadata.Badger. Threading the operator defaults there means either a new parameter on an exported bootstrap function that the API handler cannot fill, or parking the two values on Runtime — the same re-introduce-state-on-Runtime move rejected for the netgroups.go finding. The global is written once in start.go before any store opens and read at open time, which is exactly what a process-wide operator default needs; the mutex and getter are the price.
 - **Fix:** Resolve operator config once in cmd/dfs/commands/start.go and pass it through BadgerMetadataStoreConfig / the runtime/stores/service.go store-open path; drops the mutex, the getter, and the test reset boilerplate.
 
 ### [LOW] block_record_store.go: tx-level and store-level methods duplicate the same txn body instead of sharing a free function
@@ -1656,6 +1660,8 @@ Every finding passed three gates: confirmed from source, reachable from a non-te
 
 ### [LOW] Store-level read CRUD methods duplicate transaction-level methods body-for-body instead of sharing a *Locked helper
 - **Where:** `pkg/metadata/store/memory/files.go:123` · `structure`
+> STATUS: FIXED in #2018 — getFileLocked / getChildLocked / getParentLocked / getLinkCountLocked / listChildrenLocked now hold the single body; the store methods take RLock and the transaction methods (transaction.go:242/402/451/459/477) call the same helpers.
+> DRIFT (found on re-check, closed silently by that collapse): the pair was NOT byte-identical. Diffing the two copies at 47449ef3^ shows GetFile/GetChild/GetParent/GetLinkCount differing only in receiver and lock acquisition, but the transaction-level ListChildren omitted the link-count reconciliation the store-level copy performed (`if nlink, ok := store.linkCounts[childKey]` / dir→2 / file→1), so a listing taken inside a transaction reported the raw stored Nlink and lost the multi-link signal. #2018 collapsed onto the store-level copy, which is the correct one, so the drift is gone — but nothing pinned it: the existing conformance case HardLinkListChildrenShowsNlinkGT1 only drives the store-level surface, and the tx surface had no production caller (only storetest/ea_ops.go), which is why it went unnoticed. Added HardLinkTxListChildrenShowsNlinkGT1 to pkg/metadata/storetest so a future re-split cannot regress it; verified it fails when the reconciliation is removed, and passes on memory/badger/sqlite as shipped.
 - **Fix:** Factor each duplicated pair into a *Locked helper (getFileLocked, getChildLocked, getParentLocked, ...) called from both the store method (under RLock) and the tx method (lock already held), matching the FileChunkStore *Locked precedent in objects.go.
 
 ### [LOW] Three near-identical lazy sub-stores double-lock with a dead inner mutex; a fourth uses the opposite (correct) discipline
@@ -1760,6 +1766,7 @@ Every finding passed three gates: confirmed from source, reachable from a non-te
 
 ### [LOW] read.go re-implements CompoundResult error boilerplate 14x instead of package-convention xxxErr helper
 - **Where:** `internal/adapter/nfs/v4/handlers/read.go:24` · `bloat`
+> STATUS: FIXED in #2000 — same change as the `structure` duplicate of this finding above.
 - **Fix:** Add `func readErr(status uint32) *types.CompoundResult { return &types.CompoundResult{Status: status, OpCode: types.OP_READ, Data: encodeStatusOnly(status)} }` and replace all 14 inline literals with `return readErr(...)`.
 
 ### [LOW] Package doc contradicts actual segmentation logic — describes fallback path as the primary one
@@ -1810,6 +1817,7 @@ Every finding passed three gates: confirmed from source, reachable from a non-te
 
 ### [LOW] DiscoveryName takes no ctx and calls context.Background() for its store I/O
 - **Where:** `pkg/controlplane/runtime/discovery.go:20` · `structure`
+> STATUS: FIXED — DiscoveryName(ctx) threads the caller's context into GetSetting. The call sites had no context to pass, so auxsvc.Group.Reconcile now hands its already-stored base context (the adapter's Serve context) to the sidecar builder, and the NFS/SMB discoveryName helpers take it from there.
 - **Fix:** Add a ctx context.Context parameter to DiscoveryName and thread it through to GetSetting; update the (presumably few) call sites.
 
 ### [LOW] MetricsSnapshot N+1 DB query: ListSnapshots called per-share every scrape
@@ -1853,6 +1861,7 @@ Every finding passed three gates: confirmed from source, reachable from a non-te
 
 ### [LOW] Long parameter list / positional dependency injection across three methods
 - **Where:** `pkg/controlplane/runtime/lifecycle/service.go:232` · `structure`
+> STATUS: FIXED in #2021 — Serve now takes a named lifecycle.Deps struct (service.go:229-256) carrying the six shutdown collaborators.
 - **Fix:** Collect the six shutdown collaborators into a single `Deps`/`Config` struct passed once to `New()` or `Serve()`, e.g. `type Deps struct { Settings SettingsInitializer; Adapters AdapterLoader; ... }`. Removes positional-arg fragility and makes future additions additive instead of signature-breaking.
 
 ### [LOW] First-boot machine-SID persist failure is silently swallowed, breaking the documented restart-stability invariant

--- a/pkg/adapter/auxsvc/auxsvc.go
+++ b/pkg/adapter/auxsvc/auxsvc.go
@@ -118,19 +118,26 @@ func (g *Group) Start(s Service) error {
 // settings-apply that runs before Serve is a no-op — the initial start is done
 // by Serve itself.
 func (g *Group) Ready() bool {
+	return g.baseContext() != nil
+}
+
+// baseContext returns the stored base context, or nil before SetBaseContext.
+func (g *Group) baseContext() context.Context {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	return g.baseCtx != nil
+	return g.baseCtx
 }
 
 // Reconcile starts or stops the named service so its running state matches want,
 // letting a live settings change toggle it. It is a no-op until Ready (before
 // Serve has seeded the base context), so the initial start — performed by Serve
-// itself — is never raced. build is invoked only when a start is needed. Returns
-// the Start error, if any; a stop error is swallowed (StopAll/StopOne already
-// debug-log it).
-func (g *Group) Reconcile(name string, want bool, build func() Service) error {
-	if !g.Ready() {
+// itself — is never raced. build is invoked only when a start is needed, and
+// receives the base context so a builder that reads control-plane state does not
+// have to invent one. Returns the Start error, if any; a stop error is swallowed
+// (StopAll/StopOne already debug-log it).
+func (g *Group) Reconcile(name string, want bool, build func(context.Context) Service) error {
+	baseCtx := g.baseContext()
+	if baseCtx == nil {
 		return nil
 	}
 	switch running := g.IsRunning(name); {
@@ -139,7 +146,7 @@ func (g *Group) Reconcile(name string, want bool, build func() Service) error {
 		// accept-loop apply and the settings-watcher poll); the loser gets
 		// ErrAlreadyRunning, which is benign here — the single-instance invariant
 		// still holds — so it is not surfaced as a start failure.
-		if err := g.Start(build()); err != nil && !errors.Is(err, ErrAlreadyRunning) {
+		if err := g.Start(build(baseCtx)); err != nil && !errors.Is(err, ErrAlreadyRunning) {
 			return err
 		}
 	case !want && running:

--- a/pkg/adapter/auxsvc/auxsvc_test.go
+++ b/pkg/adapter/auxsvc/auxsvc_test.go
@@ -196,13 +196,13 @@ func TestGroup_ReconcileStartsAndStops(t *testing.T) {
 	g.SetBaseContext(context.Background())
 	svc := &fakeService{name: "mdns"}
 
-	if err := g.Reconcile("mdns", true, func() Service { return svc }); err != nil {
+	if err := g.Reconcile("mdns", true, func(context.Context) Service { return svc }); err != nil {
 		t.Fatalf("Reconcile(start): %v", err)
 	}
 	if !g.IsRunning("mdns") {
 		t.Fatal("Reconcile(want=true) should have started the service")
 	}
-	if err := g.Reconcile("mdns", false, func() Service { return svc }); err != nil {
+	if err := g.Reconcile("mdns", false, func(context.Context) Service { return svc }); err != nil {
 		t.Fatalf("Reconcile(stop): %v", err)
 	}
 	if g.IsRunning("mdns") {
@@ -210,10 +210,29 @@ func TestGroup_ReconcileStartsAndStops(t *testing.T) {
 	}
 }
 
+func TestGroup_ReconcilePassesBaseContextToBuilder(t *testing.T) {
+	type key struct{}
+	base := context.WithValue(context.Background(), key{}, "seeded")
+
+	g := NewGroup()
+	g.SetBaseContext(base)
+
+	var got context.Context
+	if err := g.Reconcile("mdns", true, func(ctx context.Context) Service {
+		got = ctx
+		return &fakeService{name: "mdns"}
+	}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if got == nil || got.Value(key{}) != "seeded" {
+		t.Fatal("Reconcile must hand the builder the base context, not a fresh one")
+	}
+}
+
 func TestGroup_ReconcileNoOpBeforeReady(t *testing.T) {
 	g := NewGroup() // no SetBaseContext
 	built := false
-	if err := g.Reconcile("mdns", true, func() Service { built = true; return &fakeService{name: "mdns"} }); err != nil {
+	if err := g.Reconcile("mdns", true, func(context.Context) Service { built = true; return &fakeService{name: "mdns"} }); err != nil {
 		t.Fatalf("Reconcile before Ready should be a no-op, got %v", err)
 	}
 	if built || g.IsRunning("mdns") {
@@ -235,7 +254,7 @@ func TestGroup_StopAllClearsBaseContextSoLateReconcileNoOps(t *testing.T) {
 	// A live reconcile racing shutdown must not start a service the now-stopped
 	// group would never tear down.
 	built := false
-	if err := g.Reconcile("b", true, func() Service { built = true; return &fakeService{name: "b"} }); err != nil {
+	if err := g.Reconcile("b", true, func(context.Context) Service { built = true; return &fakeService{name: "b"} }); err != nil {
 		t.Fatalf("post-StopAll Reconcile: %v", err)
 	}
 	if built || g.IsRunning("b") {

--- a/pkg/adapter/nfs/auxservices.go
+++ b/pkg/adapter/nfs/auxservices.go
@@ -56,9 +56,9 @@ func (s *NFSAdapter) startEnabledAuxServices(ctx context.Context) {
 // discoveryName is the instance-wide name to advertise, resolved from the
 // control plane (the `discovery.name` setting, defaulting to
 // "DittoFS-<hostname>"). NFS advertises only over mDNS, which uses it verbatim.
-func (s *NFSAdapter) discoveryName() string {
+func (s *NFSAdapter) discoveryName(ctx context.Context) string {
 	if s.Registry != nil {
-		if n := s.Registry.DiscoveryName(); n != "" {
+		if n := s.Registry.DiscoveryName(ctx); n != "" {
 			return n
 		}
 	}
@@ -84,9 +84,9 @@ func (s *NFSAdapter) mdnsEnabled() bool {
 // advertiser starts and is not rebuilt when shares change, so renaming/removing
 // that export leaves a stale path hint until the adapter or advertiser restarts;
 // re-advertising on share changes is a follow-up.
-func (s *NFSAdapter) newMDNSSidecar() auxsvc.Service {
+func (s *NFSAdapter) newMDNSSidecar(ctx context.Context) auxsvc.Service {
 	rec := mdns.ServiceRecord{
-		Instance: s.discoveryName(),
+		Instance: s.discoveryName(ctx),
 		Service:  "_nfs._tcp",
 		Port:     uint16(s.Port()),
 	}
@@ -146,7 +146,7 @@ func (s *NFSAdapter) reconcileSysreg() {
 	go func() {
 		defer s.sysregReconciling.Store(false)
 		err := s.sidecars.Reconcile(sysregSidecarName, want,
-			func() auxsvc.Service { return sysregSidecar{s} })
+			func(context.Context) auxsvc.Service { return sysregSidecar{s} })
 		if err != nil {
 			logger.Debug("System rpcbind registration sidecar failed to start", "error", err)
 		}

--- a/pkg/adapter/smb/discovery.go
+++ b/pkg/adapter/smb/discovery.go
@@ -60,9 +60,9 @@ func (s *Adapter) wsDiscoveryEnabled() bool {
 // control plane (the `discovery.name` setting, defaulting to
 // "DittoFS-<hostname>"). mDNS uses it verbatim; WS-Discovery folds it to a
 // NetBIOS-legal computer name (see newWSDSidecar).
-func (s *Adapter) discoveryName() string {
+func (s *Adapter) discoveryName(ctx context.Context) string {
 	if s.Registry != nil {
-		if n := s.Registry.DiscoveryName(); n != "" {
+		if n := s.Registry.DiscoveryName(ctx); n != "" {
 			return n
 		}
 	}
@@ -72,8 +72,8 @@ func (s *Adapter) discoveryName() string {
 // newMDNSSidecar builds the SMB mDNS advertiser: an _smb._tcp instance on the
 // adapter's real port, plus a _device-info._tcp record whose model= TXT makes
 // Finder show a server icon rather than a generic one.
-func (s *Adapter) newMDNSSidecar() auxsvc.Service {
-	name := s.discoveryName()
+func (s *Adapter) newMDNSSidecar(ctx context.Context) auxsvc.Service {
+	name := s.discoveryName(ctx)
 	port := uint16(s.Port())
 	return mdns.NewSidecar([]mdns.ServiceRecord{
 		{Instance: name, Service: "_smb._tcp", Port: port},
@@ -85,7 +85,7 @@ func (s *Adapter) newMDNSSidecar() auxsvc.Service {
 // name under its NetBIOS domain (or WORKGROUP when standalone). A fresh
 // AppSequence InstanceId (process start time) makes Windows treat a restart as a
 // new instance.
-func (s *Adapter) newWSDSidecar() auxsvc.Service {
+func (s *Adapter) newWSDSidecar(ctx context.Context) auxsvc.Service {
 	workgroup := ""
 	if s.handler != nil {
 		workgroup = s.handler.NetBIOSDomain
@@ -96,7 +96,7 @@ func (s *Adapter) newWSDSidecar() auxsvc.Service {
 	// WS-Discovery renders the value as a Windows computer name, so fold it to a
 	// NetBIOS-legal form (the raw instance name may contain characters or a
 	// length Explorer rejects). mDNS keeps the raw name.
-	name := hostinfo.NetBIOSSafe(s.discoveryName())
+	name := hostinfo.NetBIOSSafe(s.discoveryName(ctx))
 	// Distinct, strictly-increasing InstanceId per responder build (see the
 	// wsdInstanceID field) so a live toggle never rewinds the AppSequence.
 	return wsd.NewResponder(name, workgroup, isDomain, s.wsdInstanceID.Add(1))

--- a/pkg/controlplane/runtime/discovery.go
+++ b/pkg/controlplane/runtime/discovery.go
@@ -17,9 +17,9 @@ const DiscoveryNameKey = "discovery.name"
 // ("DittoFS-<hostname>") when unset. It is a single server identity; each
 // adapter formats it for its own protocol (WS-Discovery folds it to a
 // NetBIOS-legal computer name via hostinfo.NetBIOSSafe, mDNS uses it verbatim).
-func (r *Runtime) DiscoveryName() string {
+func (r *Runtime) DiscoveryName(ctx context.Context) string {
 	if r.store != nil {
-		if v, err := r.store.GetSetting(context.Background(), DiscoveryNameKey); err == nil {
+		if v, err := r.store.GetSetting(ctx, DiscoveryNameKey); err == nil {
 			if v = strings.TrimSpace(v); v != "" {
 				return v
 			}

--- a/pkg/controlplane/runtime/discovery_integration_test.go
+++ b/pkg/controlplane/runtime/discovery_integration_test.go
@@ -15,14 +15,14 @@ import (
 func TestDiscoveryName_OverrideFromSetting(t *testing.T) {
 	rt, cpStore := newRuntimeForChecks(t)
 
-	if got, want := rt.DiscoveryName(), hostinfo.DefaultDiscoveryName(); got != want {
+	if got, want := rt.DiscoveryName(t.Context()), hostinfo.DefaultDiscoveryName(); got != want {
 		t.Fatalf("unset DiscoveryName = %q, want default %q", got, want)
 	}
 
 	if err := cpStore.SetSetting(context.Background(), DiscoveryNameKey, "  My Filer  "); err != nil {
 		t.Fatalf("SetSetting: %v", err)
 	}
-	if got, want := rt.DiscoveryName(), "My Filer"; got != want {
+	if got, want := rt.DiscoveryName(t.Context()), "My Filer"; got != want {
 		t.Fatalf("override DiscoveryName = %q, want trimmed %q", got, want)
 	}
 }

--- a/pkg/controlplane/runtime/discovery_test.go
+++ b/pkg/controlplane/runtime/discovery_test.go
@@ -10,7 +10,7 @@ import (
 // no store is wired (and thus no override can be read).
 func TestDiscoveryName_DefaultWithoutStore(t *testing.T) {
 	rt := &Runtime{}
-	if got, want := rt.DiscoveryName(), hostinfo.DefaultDiscoveryName(); got != want {
+	if got, want := rt.DiscoveryName(t.Context()), hostinfo.DefaultDiscoveryName(); got != want {
 		t.Fatalf("DiscoveryName without store = %q, want default %q", got, want)
 	}
 }

--- a/pkg/metadata/storetest/file_ops.go
+++ b/pkg/metadata/storetest/file_ops.go
@@ -23,6 +23,9 @@ func runFileOpsTests(t *testing.T, factory StoreFactory) {
 		testHardLinkMoveOneNameAcrossDirectoriesPreservesOther(t, factory)
 	})
 	t.Run("HardLinkListChildrenShowsNlinkGT1", func(t *testing.T) { testHardLinkListChildrenShowsNlinkGT1(t, factory) })
+	t.Run("HardLinkTxListChildrenShowsNlinkGT1", func(t *testing.T) {
+		testHardLinkTxListChildrenShowsNlinkGT1(t, factory)
+	})
 	t.Run("HardLinkGetParentIsValid", func(t *testing.T) { testHardLinkGetParentIsValid(t, factory) })
 	t.Run("DerivedPathReflectsParentRename", func(t *testing.T) { testDerivedPathReflectsParentRename(t, factory) })
 	t.Run("SetFileAttributes", func(t *testing.T) { testSetFileAttributes(t, factory) })
@@ -706,6 +709,58 @@ func testHardLinkListChildrenShowsNlinkGT1(t *testing.T, factory StoreFactory) {
 	// Both names point at the inode, so it must appear twice in the listing.
 	if seen != 2 {
 		t.Errorf("hard-linked inode appeared %d times in listing, want 2", seen)
+	}
+}
+
+// testHardLinkTxListChildrenShowsNlinkGT1 is testHardLinkListChildrenShowsNlinkGT1
+// against the transaction-level ListChildren. The two surfaces are separate
+// implementations in every backend, so the store-level assertion does not cover
+// this one: a transaction listing that skips the link-count reconciliation
+// reports the raw stored Nlink and silently loses the multi-link signal.
+func testHardLinkTxListChildrenShowsNlinkGT1(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	rootHandle := createTestShare(t, store, "/test")
+	ctx := t.Context()
+
+	handle := createTestFile(t, store, "/test", rootHandle, "A", 0644)
+	if err := store.SetChild(ctx, rootHandle, "B", handle); err != nil {
+		t.Fatalf("SetChild(B) failed: %v", err)
+	}
+	if err := store.SetLinkCount(ctx, handle, 2); err != nil {
+		t.Fatalf("SetLinkCount(2) failed: %v", err)
+	}
+
+	var entries []metadata.DirEntry
+	if err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		var err error
+		entries, _, err = tx.ListChildren(ctx, rootHandle, "", 0)
+		return err
+	}); err != nil {
+		t.Fatalf("WithTransaction(ListChildren) failed: %v", err)
+	}
+
+	var seen int
+	for _, e := range entries {
+		if string(e.Handle) != string(handle) {
+			continue
+		}
+		seen++
+		var nlink uint32
+		if e.Attr != nil {
+			nlink = e.Attr.Nlink
+		} else {
+			f, err := store.GetFile(ctx, e.Handle)
+			if err != nil {
+				t.Fatalf("GetFile(%q) failed: %v", e.Name, err)
+			}
+			nlink = f.Nlink
+		}
+		if nlink < 2 {
+			t.Errorf("tx entry %q nlink = %d, want >= 2 for a hard-linked inode", e.Name, nlink)
+		}
+	}
+	if seen != 2 {
+		t.Errorf("hard-linked inode appeared %d times in tx listing, want 2", seen)
 	}
 }
 


### PR DESCRIPTION
Part of #1994 — the "God objects and duplication" duplication claims.

Every claim was validated before touching anything: the two copies were extracted
and literally diffed, at the parent of whichever PR later collapsed them.

## Verdicts

| Finding | Verdict |
| --- | --- |
| `memory/files.go:123` GetFile/GetChild/GetParent | **CONFIRMED-BUT-DRIFTED** — collapsed by #2018, drift closed silently, now pinned by a test |
| `nfs/v4/handlers/read.go:24` 14x `encodeStatusOnly` | CONFIRMED-IDENTICAL — already collapsed by #2000 |
| `nfs/v4/handlers/read.go:174` block-store resolve | CONFIRMED-IDENTICAL — already collapsed by #1999 |
| `file_access_checker.go:32` single-impl interface | CONFIRMED — already removed by #2020, no test fake existed |
| `lifecycle/service.go:232` positional DI | CONFIRMED — already fixed by #2021 (`lifecycle.Deps`) |
| `runtime/discovery.go:20` `context.Background()` | CONFIRMED — **fixed here** |
| `badger/cache.go:69` package-level cache config | CONFIRMED-BUT-WONTFIX — the suggested fix is a net loss, see report |

Four of the seven were already fixed by sibling PRs in the same tranche; those get
a `> STATUS:` marker in the audit report rather than a code change.

## The drift

`memory/files.go` GetFile/GetChild/GetParent/GetLinkCount really were byte-identical
between the pool path and the transaction path — but `ListChildren`, collapsed in the
same change, was **not**. The transaction-level copy omitted the link-count
reconciliation the store-level copy performed, so a listing taken inside a transaction
reported the raw stored `Nlink` and lost the multi-link signal entirely.

#2018 collapsed onto the store-level copy, which is the correct one, so the bug is
already gone on develop — but nothing pinned it. The existing conformance case
`HardLinkListChildrenShowsNlinkGT1` only drives the store-level surface, and the tx
surface has no production caller, which is why it went unnoticed for as long as it did.

This PR adds `HardLinkTxListChildrenShowsNlinkGT1` to the store conformance suite so a
future re-split cannot reintroduce it. Verified it fails when the reconciliation is
removed, and passes on memory/badger/sqlite as shipped.

## The one code fix

`DiscoveryName` now takes a context instead of calling `context.Background()` for its
settings read. The call sites had no context to pass, so `auxsvc.Group.Reconcile` hands
the sidecar builder the base context it already stores (the adapter's Serve context),
and the NFS/SMB `discoveryName` helpers take it from there.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .` clean.
`go test -race` green on `auxsvc`, `controlplane/runtime`, `adapter/smb`, `adapter/nfs`,
`metadata/storetest`, and the memory/badger/sqlite backends.