### PR TITLE
fix(metadata): narrow the straddling manifest row a carve run supersedes

### DIFF
--- a/pkg/block/engine/cold_read_carve_seam_test.go
+++ b/pkg/block/engine/cold_read_carve_seam_test.go
@@ -47,6 +47,11 @@ func TestColdReadAtCarveSeam_PunchedRangeStaysZero(t *testing.T) {
 	}
 	carve(t, bs, ctx, pid)
 
+	// The run-end reap narrows the row the second run's tiling starts inside, so
+	// the manifest is a clean tiling again rather than an overlap the read path
+	// has to defend against.
+	assertManifestTiles(t, ms, pid, int64(len(seed)), "after-second-carve")
+
 	// Evict the local copy so the read has to come back from the remote store
 	// through the manifest.
 	if _, err := bs.DrainLocalSynced(ctx); err != nil {

--- a/pkg/metadata/block_record_store.go
+++ b/pkg/metadata/block_record_store.go
@@ -315,6 +315,18 @@ func DefaultCommitBlock(
 // remainder falls outside it and is never reaped — no gap. newOffsets excludes
 // this run's own rows so they survive.
 //
+// A row that STARTS before runStart and reaches into the run is not in that set —
+// deleting it would strip [rowStart, runStart) of its only cover — so it is
+// narrowed to the prefix it still owns instead: DataSize becomes runStart-rowStart
+// and the run's fresh rows take over from there. The chunk keeps every byte on the
+// remote and is still hash-verified over all of them; the row just stops claiming
+// the part the run re-chunked, which is the same shape a truncate's narrow leaves
+// behind. A straddler that ALSO ends past runEnd stays whole: no row can start
+// mid-chunk, so its tail past the run has no other cover and narrowing it would
+// trade the overlap for a gap. Coverage lookups resolve that overlap to the
+// greatest covering start, so the fresh rows win inside the run and the straddler
+// serves only its unre-carved tail.
+//
 // ponytail: this fixes read-coherence — the corruption. Decrementing the reaped
 // chunk's CAS refcount to reclaim its remote space is a separate, tracked
 // follow-up (#1715): under-counting only leaks space, it never drops live data.
@@ -334,7 +346,20 @@ func ReapSupersededManifest(ctx context.Context, tx Transaction, payloadID strin
 		if !ok {
 			continue
 		}
-		if int64(off) < runStart || int64(off) >= runEnd {
+		rowStart := int64(off)
+		rowEnd := rowStart + int64(r.DataSize)
+		if rowStart < runStart {
+			if rowEnd <= runStart || rowEnd > runEnd {
+				continue // no overlap with the run, or narrowing would open a tail gap
+			}
+			narrowed := *r
+			narrowed.DataSize = uint32(runStart - rowStart)
+			if err := tx.Put(ctx, &narrowed); err != nil {
+				return fmt.Errorf("reap superseded: narrow %s: %w", r.ID, err)
+			}
+			continue
+		}
+		if rowStart >= runEnd {
 			continue // outside the re-carved run — untouched (incl. cold remainders)
 		}
 		if _, isNew := newOffsets[int64(off)]; isNew {

--- a/pkg/metadata/manifest_projection_test.go
+++ b/pkg/metadata/manifest_projection_test.go
@@ -43,6 +43,17 @@ func (t *manifestTx) Put(_ context.Context, fc *block.FileChunk) error {
 
 func (t *manifestTx) deleteRow(id string) { delete(t.rows, id) }
 
+// Delete follows the FileChunkStore contract: a missing ID is an error, not a
+// silent no-op, so a reap that deletes a row twice or deletes one it never
+// listed shows up here instead of passing.
+func (t *manifestTx) Delete(_ context.Context, id string) error {
+	if _, ok := t.rows[id]; !ok {
+		return block.ErrFileChunkNotFound
+	}
+	t.deleteRow(id)
+	return nil
+}
+
 func (t *manifestTx) ListFileChunks(_ context.Context, payloadID string) ([]*block.FileChunk, error) {
 	ids := make([]string, 0, len(t.rows))
 	for id := range t.rows {

--- a/pkg/metadata/reap_superseded_test.go
+++ b/pkg/metadata/reap_superseded_test.go
@@ -1,0 +1,102 @@
+package metadata
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/marmos91/dittofs/pkg/block"
+)
+
+// tiling renders the manifest as (offset, end) pairs in offset order so a test
+// can state the whole post-reap shape in one assertion.
+func tiling(t *testing.T, tx *manifestTx, payloadID string) [][2]int64 {
+	t.Helper()
+	rows, err := tx.ListFileChunks(context.Background(), payloadID)
+	require.NoError(t, err)
+	out := make([][2]int64, 0, len(rows))
+	for _, r := range rows {
+		off, ok := block.ParseChunkOffset(r.ID)
+		require.True(t, ok)
+		out = append(out, [2]int64{int64(off), int64(off) + int64(r.DataSize)})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i][0] < out[j][0] })
+	return out
+}
+
+// seedRows writes rows tiling the given (offset, size) pairs.
+func seedRows(t *testing.T, tx *manifestTx, payloadID string, spans [][2]uint64) {
+	t.Helper()
+	for i, sp := range spans {
+		require.NoError(t, tx.Put(context.Background(), chunkRow(payloadID, sp[0], i, uint32(sp[1]))))
+	}
+}
+
+// TestReapSupersededManifest_NarrowsStraddler pins the tiling invariant across a
+// carve run that starts in the middle of an existing row. The row starting before
+// the run cannot be deleted — it is the only cover for the bytes before the run —
+// and it cannot be left whole either, or it overlaps the run's fresh rows. It is
+// narrowed to the prefix the run did not re-chunk.
+func TestReapSupersededManifest_NarrowsStraddler(t *testing.T) {
+	const pid = "share/p"
+	ctx := context.Background()
+	tx := newManifestTx(pid)
+
+	// Pre-run manifest tiles [0, 6000): the row at 1000 straddles the run start,
+	// the row at 3000 is interior to the run, the row at 5000 is a cold remainder
+	// past the run.
+	seedRows(t, tx, pid, [][2]uint64{{0, 1000}, {1000, 2000}, {3000, 2000}, {5000, 1000}})
+
+	// The run re-carved [2500, 5000) into two fresh rows.
+	seedRows(t, tx, pid, [][2]uint64{{2500, 1200}, {3700, 1300}})
+	newOffsets := map[int64]struct{}{2500: {}, 3700: {}}
+
+	require.NoError(t, ReapSupersededManifest(ctx, tx, pid, 2500, 5000, newOffsets))
+
+	require.Equal(t, [][2]int64{
+		{0, 1000},
+		{1000, 2500}, // narrowed from end 3000
+		{2500, 3700},
+		{3700, 5000},
+		{5000, 6000}, // cold remainder, untouched
+	}, tiling(t, tx, pid))
+}
+
+// TestReapSupersededManifest_KeepsStraddlerReachingPastRun covers the one
+// straddler that must survive whole: it also ends past the run, and no row can
+// start mid-chunk, so narrowing it would trade the overlap for a gap over
+// [runEnd, rowEnd) — bytes that would then read back as zeros.
+func TestReapSupersededManifest_KeepsStraddlerReachingPastRun(t *testing.T) {
+	const pid = "share/p"
+	ctx := context.Background()
+	tx := newManifestTx(pid)
+
+	seedRows(t, tx, pid, [][2]uint64{{0, 1000}, {1000, 5000}})
+	seedRows(t, tx, pid, [][2]uint64{{2000, 1000}})
+	newOffsets := map[int64]struct{}{2000: {}}
+
+	require.NoError(t, ReapSupersededManifest(ctx, tx, pid, 2000, 3000, newOffsets))
+
+	require.Equal(t, [][2]int64{
+		{0, 1000},
+		{1000, 6000}, // kept whole: its tail past 3000 has no other cover
+		{2000, 3000},
+	}, tiling(t, tx, pid))
+}
+
+// TestReapSupersededManifest_LeavesDisjointRowsAlone keeps the reap from
+// touching a row that merely ends where the run begins.
+func TestReapSupersededManifest_LeavesDisjointRowsAlone(t *testing.T) {
+	const pid = "share/p"
+	ctx := context.Background()
+	tx := newManifestTx(pid)
+
+	seedRows(t, tx, pid, [][2]uint64{{0, 2000}, {2000, 1000}})
+	newOffsets := map[int64]struct{}{2000: {}}
+
+	require.NoError(t, ReapSupersededManifest(ctx, tx, pid, 2000, 3000, newOffsets))
+
+	require.Equal(t, [][2]int64{{0, 2000}, {2000, 3000}}, tiling(t, tx, pid))
+}


### PR DESCRIPTION
## Verdict: CONFIRMED

Reproduced on `develop` (cb3557ea) before touching anything. Driving the reported
punch/punch seam through the real carve path and dumping the manifest after each carve:

```
after-seed   row off=0       size=1060089 end=1060089
             row off=1060089 size=1126673 end=2186762
             ... (clean tiling)
after-punch1 row off=0       size=1060089 end=1060089
             row off=1060089 size=3142268 end=4202357
             row off=4202357 size=1056806 end=5259163
             row off=5259163 size=1032293 end=6291456
after-punch2 row off=0       size=1060089 end=1060089
             row off=1060089 size=3142268 end=4202357
             row off=4189704 size=1229117 end=5418821  <-- OVERLAP (12653 bytes)
             row off=5418821 size=872635  end=6291456
```

The row at 1060089 starts outside the second run's `[4189704, ...)` span, so the reap
never sees it, and it keeps claiming `[4189704, 4202357)` on top of the run's fresh row.
The manifest stops tiling `[0,size)` exactly as reported.

## Root cause

The journal already has a mechanism that stops this on the ordinary overwrite path:
`remarkFragmentsDirty` re-marks the warm surviving fragments of a partially-overwritten
interval dirty, so the next carve run swallows the whole old row and the reap has nothing
to straddle. It keys on *journal interval* boundaries, though, and those are not manifest
row boundaries. A punch whose start lands exactly on an interval boundary that sits
*inside* a manifest row leaves no fragment to re-mark: the run starts mid-row, and
`ReapSupersededManifest`'s `runStart <= rowStart < runEnd` test cannot reach a row that
starts earlier.

## The fix

The straddler is narrowed rather than deleted. `DataSize` becomes `runStart - rowStart`,
so it covers exactly `[rowStart, runStart)` and the run's fresh rows take over from there.
Deleting it was never an option — that range has no other cover, which is the silent-zeros
class this must not create.

Narrowing is not a new shape. `FileChunk.DataSize` is already documented as the row's
*claim* rather than the chunk's length, `Store.narrowChunkRow` already produces prefix-only
rows on truncate, and `hydrateChunk` already clamps a cold fetch to the claim. The chunk on
the remote keeps every byte and is still hash-verified over all of them; the row simply
stops claiming the part the run re-chunked.

One straddler is deliberately left whole: one that also ends *past* `runEnd`. No row can
start mid-chunk, so its tail past the run has no other cover, and trimming it would trade a
tolerated overlap for a gap. Coverage lookups resolve the overlap to the greatest covering
start, so the fresh rows win inside the run and that row serves only its un-re-carved tail.

## Scope

Read-side overlap handling is untouched. Truncate-narrow followed by re-carve produces
legitimate overlap, so the read path has to tolerate it regardless; this only restores the
tiling invariant in the manifest the write path leaves behind.

## Tests

- `TestReapSupersededManifest_NarrowsStraddler` — the tiling across a run that starts
  mid-row. Fails on the pre-fix code (`row 1000..3000` where `1000..2500` is due).
- `TestReapSupersededManifest_KeepsStraddlerReachingPastRun` — pins that the one straddler
  which would open a gap is left alone.
- `TestReapSupersededManifest_LeavesDisjointRowsAlone` — a row abutting the run start is
  not touched.
- `TestColdReadAtCarveSeam_PunchedRangeStaysZero` now also asserts the manifest tiles after
  the second carve, so the reported scenario is pinned end to end through the real carve
  path.

`go test ./...` green (one unrelated flake, `TestSQLite_ConcurrentWritesBackpressureNoEIO`,
"database busy" under CPU contention from a parallel `-race` run; 3/3 green rerun alone).
`go test -race ./pkg/block/engine/ ./pkg/metadata/` green.

## Adjacent, NOT fixed here

While validating I found the mirror-image defect, which is **pre-existing and unchanged by
this PR** (verified: identical manifest with and without the fix). A row that starts
*inside* the run and ends *past* `runEnd` is deleted, and its tail past the run then has no
covering row at all — a GAP, not an overlap:

```
gen3 off=0       size=4189704 end=4189704
     off=4202357 size=1056806 end=5259163   <-- GAP [4189704, 4202357)
     off=5259163 size=1032293 end=6291456
```

Reached by a second punch whose *end* lands on the interval boundary the first punch left
inside a row. The cold read of that range then fails ("still cold after hydrate: chunk not
found") rather than serving bytes. It cannot be fixed in the reap — a suffix claim would
need a row starting mid-chunk, which the row model cannot express — so it needs the carve
run extended forward in the write path. Filed as #2038.

Closes #1992
