### PR TITLE
fix(gc): propagate remote-tier error detail into the server-wide sweep total

### DIFF
--- a/pkg/controlplane/runtime/blockgc.go
+++ b/pkg/controlplane/runtime/blockgc.go
@@ -137,7 +137,7 @@ func (r *Runtime) runBlockGCSweep(ctx context.Context, dryRun bool, progress fun
 			rec := &perRemoteReconciler{rt: r, shares: entry.Shares}
 
 			stats := collectGarbageFn(ctx, rec, opts)
-			s := accumulateGCStats(total, stats, false)
+			s := accumulateGCStats(total, stats)
 			logger.Info("RunBlockGC: complete",
 				"configID", entry.ConfigID,
 				"hashesMarked", s.HashesMarked,
@@ -226,7 +226,7 @@ func (r *Runtime) runLocalGC(ctx context.Context, shareFilter string, dryRun boo
 
 		rec := &perRemoteReconciler{rt: r, shares: []string{entry.ShareName}}
 		stats := collectGarbageLocalFn(ctx, entry.Store, rec, opts)
-		s := accumulateGCStats(total, stats, true)
+		s := accumulateGCStats(total, stats)
 		logger.Info("local GC: complete",
 			"tier", "local",
 			"share", entry.ShareName,
@@ -341,7 +341,7 @@ func (r *Runtime) runBlockGCForShare(ctx context.Context, name string, dryRun bo
 
 			rec := &perRemoteReconciler{rt: r, shares: entry.Shares}
 			stats := collectGarbageFn(ctx, rec, opts)
-			s := accumulateGCStats(total, stats, true)
+			s := accumulateGCStats(total, stats)
 			logger.Info("RunBlockGCForShare: complete",
 				"share", name,
 				"configID", entry.ConfigID,
@@ -399,9 +399,12 @@ var collectGarbageFn = engine.CollectGarbage
 // accumulateGCStats folds a per-remote stats result into total and returns
 // the per-remote snapshot for logging. Returns a zero value when stats is
 // nil — CollectGarbage always returns non-nil but the defensive copy keeps
-// callers panic-free if that ever changes. When includeDryRunMeta is true,
-// also propagates DryRun, DryRunCandidates, and FirstErrors.
-func accumulateGCStats(total, stats *engine.GCStats, includeDryRunMeta bool) engine.GCStats {
+// callers panic-free if that ever changes.
+//
+// DryRun, DryRunCandidates and FirstErrors propagate like every other field.
+// FirstErrors in particular is the only cause detail an operator gets for a
+// failed sweep — ErrorCount alone renders as a count with no explanation.
+func accumulateGCStats(total, stats *engine.GCStats) engine.GCStats {
 	if stats == nil {
 		return engine.GCStats{}
 	}
@@ -416,13 +419,11 @@ func accumulateGCStats(total, stats *engine.GCStats, includeDryRunMeta bool) eng
 	total.OrphanBlocks += s.OrphanBlocks
 	total.BytesReclaimed += s.BytesReclaimed
 	total.Errors += s.Errors
-	if includeDryRunMeta {
-		if s.DryRun {
-			total.DryRun = true
-		}
-		total.DryRunCandidates = append(total.DryRunCandidates, s.DryRunCandidates...)
-		total.FirstErrors = append(total.FirstErrors, s.FirstErrors...)
+	if s.DryRun {
+		total.DryRun = true
 	}
+	total.DryRunCandidates = append(total.DryRunCandidates, s.DryRunCandidates...)
+	total.FirstErrors = append(total.FirstErrors, s.FirstErrors...)
 	return s
 }
 

--- a/pkg/controlplane/runtime/blockgc_reconcile.go
+++ b/pkg/controlplane/runtime/blockgc_reconcile.go
@@ -79,7 +79,7 @@ func (r *Runtime) runBlockGCReconcile(ctx context.Context, dryRun bool, progress
 	if err != nil {
 		return total, err
 	}
-	accumulateGCStats(total, sweep, true)
+	accumulateGCStats(total, sweep)
 	logger.Info("RunBlockGCReconcile: complete",
 		"dryRun", dryRun,
 		"strandedRowsReaped", total.StrandedRowsReaped,

--- a/pkg/controlplane/runtime/blockgc_test.go
+++ b/pkg/controlplane/runtime/blockgc_test.go
@@ -441,3 +441,40 @@ func TestPurgeLegacyCAS_ConfiguredShareNotRegistered(t *testing.T) {
 		t.Fatalf("purged %d cas objects, want %d", rs.deleted, len(rs.objects))
 	}
 }
+
+// TestRunBlockGC_PropagatesRemoteTierErrorDetail asserts the server-wide sweep
+// carries a remote sweep's FirstErrors and dry-run candidates into the
+// aggregate it returns, not just the ErrorCount. FirstErrors is the only cause
+// detail dfsctl renders for a failed GC run, so dropping it leaves an operator
+// with a bare "errors: N".
+func TestRunBlockGC_PropagatesRemoteTierErrorDetail(t *testing.T) {
+	orig := collectGarbageFn
+	collectGarbageFn = func(_ context.Context, _ engine.MetadataReconciler, _ *engine.Options) *engine.GCStats {
+		return &engine.GCStats{
+			ErrorCount:       2,
+			FirstErrors:      []string{"s3: connection refused", "s3: access denied"},
+			DryRun:           true,
+			DryRunCandidates: []string{"blocks/abc"},
+		}
+	}
+	t.Cleanup(func() { collectGarbageFn = orig })
+
+	rt := newRuntimeForGC(t, map[string]remote.RemoteStore{"/share-a": &fakeRemoteStore{name: "s3"}})
+
+	stats, err := rt.RunBlockGC(context.Background(), true)
+	if err != nil {
+		t.Fatalf("RunBlockGC: %v", err)
+	}
+	if stats.ErrorCount != 2 {
+		t.Errorf("ErrorCount = %d, want 2", stats.ErrorCount)
+	}
+	if len(stats.FirstErrors) != 2 {
+		t.Fatalf("FirstErrors = %v, want the remote sweep's 2 entries", stats.FirstErrors)
+	}
+	if !stats.DryRun {
+		t.Error("DryRun not propagated from the remote sweep")
+	}
+	if len(stats.DryRunCandidates) != 1 {
+		t.Errorf("DryRunCandidates = %v, want 1 entry", stats.DryRunCandidates)
+	}
+}


### PR DESCRIPTION
Part of the #1994 LOW structure tail. Found by diffing a finding phrased as duplication.

## The finding, and why it was not cosmetic

The audit filed `singleShareReconciler duplicates perRemoteReconciler for the single-share case`. That premise is wrong — no `singleShareReconciler` type exists, and `perRemoteReconciler` is not duplicated. But the two bodies that genuinely are near-duplicates, `runBlockGCSweep` (server-wide) and `runBlockGCForShare` (share-scoped), turned out to disagree.

```go
// blockgc.go:140  runBlockGCSweep   — remote tier
s := accumulateGCStats(total, stats, false)
// blockgc.go:229  runBlockGCSweep   — local tier, same function
s := accumulateGCStats(total, stats, true)
// blockgc.go:344  runBlockGCForShare — remote tier
s := accumulateGCStats(total, stats, true)
```

One function mixed both conventions. The flag gated `DryRun`, `DryRunCandidates` and `FirstErrors`.

`FirstErrors` is not dry-run metadata. It is the curated, class-diversified sample of GC error messages built in `engine/gc.go:737-780`, and it is the only cause detail `dfsctl store block gc` and `dfsctl store block gc status` render. `ErrorCount` still incremented, so on every server-wide run — the GC scheduler, and `store block gc --reconcile` — an operator got:

```
errors: 3
```

with the three causes discarded one stack level below. `runBlockGCReconcile` then folded the sweep result with `true`, clearly expecting detail that had already been dropped.

On `--reconcile --dry-run` the same gate meant `DryRunCandidates` held only local-tier candidates, under-reporting what a real remote sweep would delete.

## Change

Propagate the three fields unconditionally and delete the `includeDryRunMeta` parameter — after the fix it carried one value at all four call sites. The dead flexibility is what let the two copies disagree in the first place, so removing it is the part that stops this recurring.

## Test

`TestRunBlockGC_PropagatesRemoteTierErrorDetail` drives the sweep through the `collectGarbageFn` seam with a stats result carrying `FirstErrors` and dry-run candidates, and asserts they reach the returned aggregate. Verified to fail on the pre-fix code (`FirstErrors = []`) and pass after.
