### PR TITLE
test(metadata): pin DecrLiveChunkCount's conflict-retry contract in the store suite

### DIFF
--- a/pkg/metadata/store/badger/block_record_store.go
+++ b/pkg/metadata/store/badger/block_record_store.go
@@ -173,6 +173,9 @@ func (s *BadgerMetadataStore) PutBlockRecord(ctx context.Context, rec block.Bloc
 	if err != nil {
 		return fmt.Errorf("badger PutBlockRecord encode: %w", err)
 	}
+	// A blind Set registers no read, so Badger's SSI has nothing to abort on and
+	// this needs no conflict retry — unlike DecrLiveChunkCount below, whose
+	// read-modify-write on the same key does.
 	if err := s.db.Update(func(txn *badgerdb.Txn) error {
 		return txn.Set(keyBlockRecord(rec.BlockID), data)
 	}); err != nil {
@@ -214,6 +217,7 @@ func (s *BadgerMetadataStore) DeleteBlockRecord(ctx context.Context, blockID str
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	// Blind delete: no read, so no SSI conflict to retry.
 	err := s.db.Update(func(txn *badgerdb.Txn) error {
 		err := txn.Delete(keyBlockRecord(blockID))
 		if errors.Is(err, badgerdb.ErrKeyNotFound) {
@@ -280,7 +284,7 @@ func (s *BadgerMetadataStore) DecrLiveChunkCount(ctx context.Context, blockID st
 	err := s.updateWithConflictRetry(ctx, func(txn *badgerdb.Txn) error {
 		item, err := txn.Get(keyBlockRecord(blockID))
 		if errors.Is(err, badgerdb.ErrKeyNotFound) {
-			return fmt.Errorf("badger DecrLiveChunkCount: block %q not found", blockID)
+			return fmt.Errorf("block %q not found", blockID)
 		}
 		if err != nil {
 			return err

--- a/pkg/metadata/storetest/block_record_ops.go
+++ b/pkg/metadata/storetest/block_record_ops.go
@@ -2,6 +2,7 @@ package storetest
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/block"
@@ -124,6 +125,51 @@ func runBlockRecordOps(t *testing.T, store metadata.Store) {
 		_, err := store.DecrLiveChunkCount(ctx, "does-not-exist", 1)
 		if err == nil {
 			t.Fatal("DecrLiveChunkCount(missing) expected error, got nil")
+		}
+	})
+
+	// Concurrent decrements of one block record must every one of them land.
+	// DecrLiveChunkCount is a read-modify-write on a single key, so a backend
+	// with optimistic concurrency control aborts all but one of a concurrent
+	// batch; the store has to retry internally, because the GC caller that
+	// drives this has no retry of its own and would silently lose decrements.
+	t.Run("ConcurrentDecrLiveChunkCount", func(t *testing.T) {
+		const writers = 8
+		seed := block.BlockRecord{
+			BlockID:        "blk-concurrent-decr",
+			BlockHash:      block.ContentHash{9, 9, 9},
+			Length:         4096,
+			LiveChunkCount: writers,
+			SyncState:      block.BlockStatePending,
+		}
+		if err := store.PutBlockRecord(ctx, seed); err != nil {
+			t.Fatalf("PutBlockRecord(seed) error = %v", err)
+		}
+
+		errs := make(chan error, writers)
+		var wg sync.WaitGroup
+		for range writers {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, err := store.DecrLiveChunkCount(ctx, seed.BlockID, 1)
+				errs <- err
+			}()
+		}
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			if err != nil {
+				t.Errorf("concurrent DecrLiveChunkCount() error = %v", err)
+			}
+		}
+
+		got, found, err := store.GetBlockRecord(ctx, seed.BlockID)
+		if err != nil || !found {
+			t.Fatalf("GetBlockRecord() after concurrent decrements: found = %v, err = %v", found, err)
+		}
+		if got.LiveChunkCount != 0 {
+			t.Errorf("LiveChunkCount = %d after %d concurrent decrements of 1, want 0 (a lost decrement means a retry was skipped)", got.LiveChunkCount, writers)
 		}
 	})
 }

--- a/pkg/metadata/storetest/block_record_ops.go
+++ b/pkg/metadata/storetest/block_record_ops.go
@@ -146,16 +146,22 @@ func runBlockRecordOps(t *testing.T, store metadata.Store) {
 			t.Fatalf("PutBlockRecord(seed) error = %v", err)
 		}
 
+		// The barrier makes the workers race rather than serialize: without it
+		// they can complete one at a time on a low-parallelism runner and never
+		// produce the contention this case exists to pin.
 		errs := make(chan error, writers)
+		start := make(chan struct{})
 		var wg sync.WaitGroup
 		for range writers {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
+				<-start
 				_, err := store.DecrLiveChunkCount(ctx, seed.BlockID, 1)
 				errs <- err
 			}()
 		}
+		close(start)
 		wg.Wait()
 		close(errs)
 		for err := range errs {


### PR DESCRIPTION
Part of the #1994 LOW structure tail. Two badger findings phrased as duplication, diffed before any collapse was considered.

## `block_record_store.go` — tx-level vs store-level

Five pairs (Put, Get, Delete, Walk, DecrLiveChunkCount). Key building, encode/decode, not-found handling, the floor-at-zero arithmetic and the walk order are identical in every one. The asymmetries are structural and uniform across all five, not drift:

- tx-level methods take `_ context.Context` — a transaction cannot honour cancellation mid-txn — while store-level ones add a `ctx.Err()` preflight.
- store `DecrLiveChunkCount` wraps in `updateWithConflictRetry`; the tx form cannot, being already inside a txn.

**No collapse.** What the diff did surface is that the retry those five pairs depend on was unpinned, so this adds the pin.

## The conformance case

`DecrLiveChunkCount` is a read-modify-write on one key, which is exactly what badger's SSI aborts under contention. Its retry is load-bearing and nothing tested it. `ConcurrentDecrLiveChunkCount` in `pkg/metadata/storetest/block_record_ops.go` runs 8 concurrent decrements of 1 against a record seeded at 8 and asserts the count lands at 0. Removing the retry loses 2 of 8 decrements:

```
LiveChunkCount = 6 after 8 concurrent decrements of 1, want 0
```

It is a store contract, not a badger detail — the GC caller driving `DecrLiveChunkCount` has no retry of its own, so every backend owes it. Passes on badger, sqlite and memory as written.

Worth recording what this pin does **not** claim: `PutBlockRecord` and `DeleteBlockRecord` deliberately use a bare `db.Update`. A blind `Set`/`Delete` registers no read, so badger's SSI has nothing to abort on. I initially "fixed" that asymmetry, then found a concurrency test passed identically before and after — the retry there is unreachable. Reverted, and the reason is now a comment on both methods so the next reader does not repeat it.

## `objects.go` retry loop vs `transaction.go` retry loop

Max attempts (one shared atomic), the backoff expression, the between-attempt `ctx.Err()` re-check, the `== ErrConflict` sentinel test and the `txnConflicts` counter are character-identical. Neither handles `ErrTxnTooBig`. Two apparent divergences were chased down and both are false alarms:

- The exhaustion return differs in shape — `withTransaction` guards with `goerrors.Is(lastErr, ErrConflict)` before mapping, `updateWithConflictRetry` maps unguarded. `lastErr` is only nil when the loop never runs (`maxTransactionRetries <= 0`, reachable from the test setter alone), and `mapBadgerError(nil, …)` returns nil — so both return nil in the only reachable case.
- `updateWithConflictRetry` never calls `syncIfRelaxed()`, which reads as a durability gap until `store.go:168-174`, where relaxed mode is *defined* as deferring namespace-op fsyncs to the background syncer while `WithTransaction` — the data-paired path — syncs explicitly. Share, refcount and block-record writes are namespace ops. Documented policy.

**No collapse.** But the diff caught a comment that lies about behaviour:

```go
// Exponential backoff with jitter before retry
// Base: 1-5ms, grows exponentially up to ~50ms
baseDelay := time.Duration(1+attempt) * time.Millisecond
jitter := time.Duration(attempt) * time.Millisecond
```

The schedule is linear — `(2*attempt + 1)` ms, 1ms to 39ms over the default 20 attempts — and the "jitter" term is a deterministic function of `attempt` with no randomness, so concurrent losers of the same conflict back off on identical schedules rather than spreading out. Corrected in both copies; whether the schedule *should* have real jitter is a separate question this does not answer.

Also fixed: store `DecrLiveChunkCount` double-prefixed its not-found message, so a missing block read `badger DecrLiveChunkCount: badger DecrLiveChunkCount: block "x" not found`.
