### PR TITLE
fix(lock): derive a lease record's lock type, and take the store round-trip out from under the share mutex

### DIFF
--- a/pkg/metadata/lock/break.go
+++ b/pkg/metadata/lock/break.go
@@ -156,7 +156,7 @@ func (lm *Manager) WaitForBreakCompletionExceptKey(ctx context.Context, handleKe
 			}
 		}
 		if !hasOther {
-			lm.mu.Unlock()
+			lm.unlock()
 			return nil
 		}
 
@@ -165,7 +165,7 @@ func (lm *Manager) WaitForBreakCompletionExceptKey(ctx context.Context, handleKe
 			ch = make(chan struct{})
 			lm.breakWaitChans[handleKey] = ch
 		}
-		lm.mu.Unlock()
+		lm.unlock()
 
 		select {
 		case <-ctx.Done():
@@ -205,7 +205,7 @@ func (lm *Manager) WaitForByteRangeLeaseBreak(ctx context.Context, handleKey str
 			}
 		}
 		if !hasBreakingLease {
-			lm.mu.Unlock()
+			lm.unlock()
 			return nil
 		}
 
@@ -214,7 +214,7 @@ func (lm *Manager) WaitForByteRangeLeaseBreak(ctx context.Context, handleKey str
 			ch = make(chan struct{})
 			lm.breakWaitChans[handleKey] = ch
 		}
-		lm.mu.Unlock()
+		lm.unlock()
 
 		select {
 		case <-ctx.Done():
@@ -450,7 +450,7 @@ func (lm *Manager) WaitForBreakCompletion(ctx context.Context, handleKey string)
 		}
 
 		if !hasBreaking {
-			lm.mu.Unlock()
+			lm.unlock()
 			return nil
 		}
 
@@ -461,7 +461,7 @@ func (lm *Manager) WaitForBreakCompletion(ctx context.Context, handleKey string)
 			ch = make(chan struct{})
 			lm.breakWaitChans[handleKey] = ch
 		}
-		lm.mu.Unlock()
+		lm.unlock()
 
 		select {
 		case <-ctx.Done():
@@ -521,7 +521,7 @@ func (lm *Manager) WaitForShareConflictClear(ctx context.Context, handleKey stri
 		// final recheck yields SHARING_VIOLATION promptly instead of stalling
 		// until the deadline (smbtorture dhv2-pending1n-vs-violation-lease-ack-sane).
 		if !lm.hasBreakingLeaseLocked(handleKey) {
-			lm.mu.Unlock()
+			lm.unlock()
 			return nil
 		}
 		ch, ok := lm.breakWaitChans[handleKey]
@@ -529,7 +529,7 @@ func (lm *Manager) WaitForShareConflictClear(ctx context.Context, handleKey stri
 			ch = make(chan struct{})
 			lm.breakWaitChans[handleKey] = ch
 		}
-		lm.mu.Unlock()
+		lm.unlock()
 
 		// Re-check after subscribing so a signal racing between the predicate
 		// evaluation above and channel registration is not missed.
@@ -584,7 +584,7 @@ func (lm *Manager) forceCompleteBreaks(handleKey string) {
 // spurious break notifications on subsequent IO.
 func (lm *Manager) forceCompleteBreaksExceptKey(handleKey string, exceptKey [16]byte) {
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 
 	modified := false
 	for _, l := range lm.unifiedLocks[handleKey] {
@@ -629,7 +629,7 @@ func (lm *Manager) forceCompleteBreaksExceptKey(handleKey string, exceptKey [16]
 func (lm *Manager) signalBreakWait(handleKey string) {
 	lm.mu.Lock()
 	lm.signalBreakWaitLocked(handleKey)
-	lm.mu.Unlock()
+	lm.unlock()
 }
 
 // SignalParkedCreates is the LockManager-interface entry point for
@@ -797,7 +797,7 @@ func (lm *Manager) breakOpLocks(
 		canonicalByKey[lock.Lease.LeaseKey] = lock.Lease
 		toBreak = append(toBreak, breakEntry{lock: snapshot, breakToState: targetState})
 	}
-	lm.mu.Unlock()
+	lm.unlock()
 
 	for _, entry := range toBreak {
 		lm.dispatchOpLockBreak(handleKey, entry.lock, entry.breakToState)
@@ -905,6 +905,6 @@ func (lm *Manager) mirrorBreakStageLocked(sibling *UnifiedLock, canonical *OpLoc
 // Callbacks are invoked in registration order during break operations.
 func (lm *Manager) RegisterBreakCallbacks(callbacks BreakCallbacks) {
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 	lm.breakCallbacks = append(lm.breakCallbacks, callbacks)
 }

--- a/pkg/metadata/lock/byte_range_lock_break_test.go
+++ b/pkg/metadata/lock/byte_range_lock_break_test.go
@@ -148,7 +148,7 @@ func TestBreakLeasesForByteRangeLock_TightensInFlightBreakToNone(t *testing.T) {
 
 	// Verify BreakingToRequired tightened to None.
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 	_, ul, _ := lm.findLeaseByKey(leaseOther)
 	require.NotNil(t, ul)
 	assert.Equal(t, uint32(0), ul.Lease.BreakingToRequired,

--- a/pkg/metadata/lock/byte_range_lock_wait_test.go
+++ b/pkg/metadata/lock/byte_range_lock_wait_test.go
@@ -151,7 +151,7 @@ func TestWaitForByteRangeLeaseBreak_IgnoresBreakingDelegation(t *testing.T) {
 
 	// The delegation is left untouched — only DELEGRETURN may clear it.
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 	require.Len(t, lm.unifiedLocks[fileID], 1)
 	assert.True(t, lm.unifiedLocks[fileID][0].Delegation.Breaking,
 		"the wait must not force-complete or remove the delegation")
@@ -184,7 +184,7 @@ func TestWaitForByteRangeLeaseBreak_CancelDoesNotForceBreak(t *testing.T) {
 	// The lease must NOT have been force-downgraded: it is still Breaking with
 	// its Write bit intact, awaiting the holder's own ACK.
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 	_, ul, _ := lm.findLeaseByKey(smbLease)
 	require.NotNil(t, ul)
 	assert.True(t, ul.Lease.Breaking, "cancellation must not resolve the break")

--- a/pkg/metadata/lock/byterange.go
+++ b/pkg/metadata/lock/byterange.go
@@ -309,9 +309,9 @@ func (lm *Manager) UpgradeLock(handleKey string, owner LockOwner, offset, length
 	// Step 3: Atomically upgrade the lock
 	unifiedLocks[ownLockIndex].Type = LockTypeExclusive
 
-	// Persist the upgraded type under lm.mu so the change survives a restart.
-	// Without this the in-memory lock reverted to shared on restart and a
-	// reader could be wrongly granted against an intended-exclusive lock (R3-3).
+	// Persist the upgraded type so the change survives a restart. Without this
+	// the in-memory lock reverted to shared on restart and a reader could be
+	// wrongly granted against an intended-exclusive lock (R3-3).
 	lm.persistUnifiedLockLocked(unifiedLocks[ownLockIndex])
 
 	return unifiedLocks[ownLockIndex].Clone(), nil
@@ -437,8 +437,9 @@ func (lm *Manager) RemoveUnifiedLock(handleKey string, owner LockOwner, offset, 
 		}
 
 		// Overlaps - split the lock. Delete the original record, then persist
-		// each fragment (each carries a fresh UUID from SplitLock). Done under
-		// lm.mu so the store sees delete-then-puts in mutation order.
+		// each fragment (each carries a fresh UUID from SplitLock). All land on
+		// the same persist lane, so the store sees delete-then-puts in mutation
+		// order.
 		found = true
 		lm.deleteUnifiedLockLocked(lock)
 		splitResult := SplitLock(lock, offset, length)

--- a/pkg/metadata/lock/byterange.go
+++ b/pkg/metadata/lock/byterange.go
@@ -260,7 +260,7 @@ func mergeTwoLocks(a, b *UnifiedLock) *UnifiedLock {
 // invariant is enforced by TestUpgradeLock_WholeLockOnly.
 func (lm *Manager) UpgradeLock(handleKey string, owner LockOwner, offset, length uint64) (*UnifiedLock, error) {
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 
 	unifiedLocks := lm.getUnifiedLocksLocked(handleKey)
 
@@ -328,7 +328,7 @@ func (lm *Manager) getUnifiedLocksLocked(handleKey string) []*UnifiedLock {
 // conflict cases: access modes, oplock-oplock, oplock-byterange, byterange-byterange.
 func (lm *Manager) AddUnifiedLock(handleKey string, lock *UnifiedLock) error {
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 
 	existing := lm.unifiedLocks[handleKey]
 
@@ -412,7 +412,7 @@ func (lm *Manager) TestUnifiedLock(handleKey string, want *UnifiedLock) *Unified
 // RemoveUnifiedLock removes a unified lock using POSIX splitting semantics.
 func (lm *Manager) RemoveUnifiedLock(handleKey string, owner LockOwner, offset, length uint64) error {
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 
 	existing := lm.unifiedLocks[handleKey]
 	if len(existing) == 0 {
@@ -489,7 +489,7 @@ func (lm *Manager) RemoveFileUnifiedLocks(handleKey string) {
 	delete(lm.unifiedLocks, handleKey)
 	lm.reindexHandleLocked(handleKey, old)
 	delete(lm.breakWaitChans, handleKey)
-	lm.mu.Unlock()
+	lm.unlock()
 }
 
 // GetUnifiedLock retrieves a specific unified lock by owner and range.

--- a/pkg/metadata/lock/connection.go
+++ b/pkg/metadata/lock/connection.go
@@ -482,9 +482,9 @@ func (lm *Manager) RemoveClientLocks(clientID string) {
 // or other NLM clients. The trailing ":" in the caller-supplied prefix prevents
 // "nlm:client1:" from matching "nlm:client10:".
 //
-// The persisted bulk-delete runs synchronously under lm.mu for the same
-// ordering reason as RemoveClientLocks. Calling with a prefix that matches no
-// locks is safe and returns 0.
+// Each matched record is deleted individually on its own file's persist lane,
+// for the same ordering reason as RemoveClientLocks. Calling with a prefix that
+// matches no locks is safe and returns 0.
 //
 // Unlike RemoveClientLocks, this intentionally keeps the full unifiedLocks
 // scan: the predicate is a prefix match on Owner.OwnerID, and there is no

--- a/pkg/metadata/lock/connection.go
+++ b/pkg/metadata/lock/connection.go
@@ -395,10 +395,11 @@ func (ct *ConnectionTracker) Close() {
 
 // RemoveAllLocks removes all locks (legacy, unified, and delegations) for a file.
 //
-// The persisted bulk-delete runs synchronously under lm.mu (handleKey is the
-// FileID used when persisting): keeping it ordered with single-record PutLock/
-// DeleteLock prevents a concurrent acquire on the same file from racing this
-// delete to the store and leaving an orphaned record behind (R3-1 class).
+// The persisted bulk-delete goes on handleKey's persist lane (handleKey is the
+// FileID used when persisting): keeping it ordered with the single-record
+// PutLock/DeleteLock for the same file prevents a concurrent acquire from
+// racing this delete to the store and leaving an orphaned record behind
+// (R3-1 class).
 func (lm *Manager) RemoveAllLocks(handleKey string) {
 	lm.mu.Lock()
 	defer lm.unlock()
@@ -421,8 +422,8 @@ func (lm *Manager) RemoveAllLocks(handleKey string) {
 }
 
 // RemoveClientLocks removes all unified locks held by a specific client. The
-// persisted bulk-delete runs synchronously under lm.mu for the same ordering
-// reason as RemoveAllLocks.
+// persisted bulk-delete spans files, so it goes on every persist lane and acts
+// as a barrier, for the same ordering reason as RemoveAllLocks.
 //
 // clientHandleIndex (clientID -> set of handleKeys, see indexes.go) bounds the
 // work to the buckets the client actually appears in instead of scanning every

--- a/pkg/metadata/lock/connection.go
+++ b/pkg/metadata/lock/connection.go
@@ -401,7 +401,7 @@ func (ct *ConnectionTracker) Close() {
 // delete to the store and leaving an orphaned record behind (R3-1 class).
 func (lm *Manager) RemoveAllLocks(handleKey string) {
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 	delete(lm.locks, handleKey)
 	old := lm.unifiedLocks[handleKey]
 	delete(lm.unifiedLocks, handleKey)
@@ -409,11 +409,14 @@ func (lm *Manager) RemoveAllLocks(handleKey string) {
 	delete(lm.breakWaitChans, handleKey)
 
 	if lm.lockStore != nil {
-		ctx, cancel := withPersistTimeout()
-		defer cancel()
-		if _, err := lm.lockStore.DeleteLocksByFile(ctx, handleKey); err != nil {
-			logger.Error("RemoveAllLocks: failed to delete persisted locks", "handleKey", handleKey, "error", err)
-		}
+		store := lm.lockStore
+		lm.enqueuePersistLocked(handleKey, func() {
+			ctx, cancel := withPersistTimeout()
+			defer cancel()
+			if _, err := store.DeleteLocksByFile(ctx, handleKey); err != nil {
+				logger.Error("RemoveAllLocks: failed to delete persisted locks", "handleKey", handleKey, "error", err)
+			}
+		})
 	}
 }
 
@@ -426,7 +429,7 @@ func (lm *Manager) RemoveAllLocks(handleKey string) {
 // entry in unifiedLocks under the global mutex.
 func (lm *Manager) RemoveClientLocks(clientID string) {
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 
 	// Snapshot the affected handleKeys before mutating: reindexHandleLocked
 	// updates clientHandleIndex underneath us, so iterating the map directly
@@ -453,11 +456,17 @@ func (lm *Manager) RemoveClientLocks(clientID string) {
 	}
 
 	if lm.lockStore != nil {
-		ctx, cancel := withPersistTimeout()
-		defer cancel()
-		if _, err := lm.lockStore.DeleteLocksByClient(ctx, clientID); err != nil {
-			logger.Error("RemoveClientLocks: failed to delete persisted locks", "clientID", clientID, "error", err)
-		}
+		store := lm.lockStore
+		// A client-wide delete spans files, so it takes every lane: nothing
+		// this critical section ordered before it may land after it, and
+		// nothing after it may land before.
+		lm.enqueuePersistBarrierLocked(func() {
+			ctx, cancel := withPersistTimeout()
+			defer cancel()
+			if _, err := store.DeleteLocksByClient(ctx, clientID); err != nil {
+				logger.Error("RemoveClientLocks: failed to delete persisted locks", "clientID", clientID, "error", err)
+			}
+		})
 	}
 }
 
@@ -486,7 +495,7 @@ func (lm *Manager) RemoveClientLocks(clientID string) {
 // leaseKeyIndex consistent for the records this removes.
 func (lm *Manager) ReleaseByOwnerPrefix(prefix string) int {
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 
 	released := 0
 	for handleKey, locks := range lm.unifiedLocks {

--- a/pkg/metadata/lock/delegation.go
+++ b/pkg/metadata/lock/delegation.go
@@ -285,7 +285,7 @@ func (lm *Manager) revokeTimedOutLease(handleKey string, leaseKey [16]byte) {
 // removeMatchingLocksAndSignal removes every UnifiedLock on handleKey for which
 // match returns true, then wakes any WaitForBreakCompletion / parked-CREATE
 // waiters. When deletePersisted is true, each removed lock's persisted record is
-// deleted (best-effort) under lm.mu. Returns true if at least one lock matched.
+// deleted (best-effort). Returns true if at least one lock matched.
 //
 // Shared by RevokeDelegation and revokeTimedOutLease: same mutex discipline,
 // same post-unlock signalBreakWait so parked CREATEs unblock immediately rather

--- a/pkg/metadata/lock/delegation.go
+++ b/pkg/metadata/lock/delegation.go
@@ -164,7 +164,7 @@ func DelegationConflictsWithLease(deleg *Delegation, lease *OpLock) bool {
 // was recently broken.
 func (lm *Manager) GrantDelegation(handleKey string, delegation *Delegation) error {
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 
 	// Check anti-storm cache inside the lock to be atomic with lease conflict check.
 	if lm.recentlyBroken != nil && lm.recentlyBroken.IsRecentlyBroken(handleKey) {
@@ -306,7 +306,7 @@ func (lm *Manager) removeMatchingLocksAndSignal(handleKey string, deletePersiste
 		remaining = append(remaining, l)
 	}
 	if !found {
-		lm.mu.Unlock()
+		lm.unlock()
 		return false
 	}
 	if len(remaining) == 0 {
@@ -315,7 +315,7 @@ func (lm *Manager) removeMatchingLocksAndSignal(handleKey string, deletePersiste
 		lm.unifiedLocks[handleKey] = remaining
 	}
 	lm.reindexHandleLocked(handleKey, old)
-	lm.mu.Unlock()
+	lm.unlock()
 
 	lm.signalBreakWait(handleKey)
 	return true
@@ -341,7 +341,7 @@ func (lm *Manager) ReturnDelegation(handleKey string, delegationID string) error
 		lm.unifiedLocks[handleKey] = remaining
 	}
 	lm.reindexHandleLocked(handleKey, locks)
-	lm.mu.Unlock()
+	lm.unlock()
 
 	lm.signalBreakWait(handleKey)
 	return nil
@@ -440,7 +440,7 @@ func (lm *Manager) breakDelegations(
 			toBreak = append(toBreak, lock.Clone())
 		}
 	}
-	lm.mu.Unlock()
+	lm.unlock()
 
 	if len(toBreak) > 0 && lm.recentlyBroken != nil {
 		lm.recentlyBroken.Mark(handleKey)

--- a/pkg/metadata/lock/directory.go
+++ b/pkg/metadata/lock/directory.go
@@ -250,7 +250,7 @@ func (lm *Manager) OnDirChange(parentHandle FileHandle, changeType DirChangeType
 	for i := range delegsToBreak {
 		delegsToBreak[i] = delegsToBreak[i].Clone()
 	}
-	lm.mu.Unlock()
+	lm.unlock()
 
 	totalBreaks := len(leasesToBreak) + len(delegsToBreak)
 	if totalBreaks == 0 {
@@ -302,7 +302,7 @@ func (lm *Manager) dispatchNextDeferredDirBreakLocked(handleKey string) {
 	}
 	snapshot := next.Clone()
 	func() {
-		lm.mu.Unlock()
+		lm.unlock()
 		defer lm.mu.Lock()
 		lm.dispatchOpLockBreak(handleKey, snapshot, LeaseStateNone)
 	}()

--- a/pkg/metadata/lock/dirlease_dedup_break_test.go
+++ b/pkg/metadata/lock/dirlease_dedup_break_test.go
@@ -47,7 +47,7 @@ func twoSameKeyDirLeases(t *testing.T, lm *Manager, handleKey string, key [16]by
 	// AcknowledgeLeaseBreak) can resolve these directly-injected records, as it
 	// would for records added through the normal grant path.
 	lm.reindexHandleLocked(handleKey, nil)
-	lm.mu.Unlock()
+	lm.unlock()
 
 	return mu, breaksByKey, records
 }
@@ -63,7 +63,7 @@ func assertBothSiblingsBreaking(t *testing.T, lm *Manager, records []*UnifiedLoc
 	t.Helper()
 
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 
 	first := records[0].Lease
 	for i, rec := range records {
@@ -179,7 +179,7 @@ func oneDirLease(t *testing.T, lm *Manager, handleKey, ownerClient string, key [
 		Lease: &OpLock{LeaseKey: key, LeaseState: LeaseStateRead | LeaseStateHandle, Epoch: 1, IsDirectory: true},
 	}}
 	lm.reindexHandleLocked(handleKey, nil)
-	lm.mu.Unlock()
+	lm.unlock()
 	return mu, breaks
 }
 
@@ -264,7 +264,7 @@ func TestOnDirChange_SerializesMultipleDirLeaseBreaks(t *testing.T) {
 			Lease: &OpLock{LeaseKey: key2, LeaseState: LeaseStateRead | LeaseStateHandle, Epoch: 1, IsDirectory: true}},
 	}
 	lm.reindexHandleLocked(handleKey, nil)
-	lm.mu.Unlock()
+	lm.unlock()
 
 	// A change with no parent key breaks both dir leases.
 	lm.OnDirChange(FileHandle(handleKey), DirChangeRemoveEntry, "smb:other", [16]byte{}, false)
@@ -328,18 +328,18 @@ func TestAcknowledgeLeaseBreak_ClearsMirroredSiblings(t *testing.T) {
 	lm.mu.Lock()
 	for i, rec := range records {
 		if rec.Lease.Breaking {
-			lm.mu.Unlock()
+			lm.unlock()
 			t.Fatalf("record %d (%s): Breaking=true after a single acknowledge; the "+
 				"mirrored sibling was never cleared (WaitForBreakCompletion stalls until "+
 				"the force-complete timeout)", i, rec.Owner.OwnerID)
 		}
 		if rec.Lease.LeaseState != LeaseStateNone {
-			lm.mu.Unlock()
+			lm.unlock()
 			t.Fatalf("record %d (%s): LeaseState=%#x after ack-to-None; want None",
 				i, rec.Owner.OwnerID, rec.Lease.LeaseState)
 		}
 	}
-	lm.mu.Unlock()
+	lm.unlock()
 
 	// With no record left Breaking, WaitForBreakCompletion returns at once rather
 	// than blocking until the timeout.

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -353,7 +353,7 @@ func (lm *Manager) requestLeaseImpl(ctx context.Context, req leaseRequest) (gran
 	// the original handleKey still count as bindings here (handle-bound
 	// lifetime, PR #452).
 	if lm.hasLeaseKeyOnOtherFile(req.leaseKey, req.handleKey, req.clientID) {
-		lm.mu.Unlock()
+		lm.unlock()
 		logger.Debug("RequestLease: lease key already bound to another file for this client",
 			"leaseKey", fmt.Sprintf("%x", req.leaseKey),
 			"fileHandle", req.handleKey,
@@ -365,7 +365,7 @@ func (lm *Manager) requestLeaseImpl(ctx context.Context, req leaseRequest) (gran
 	locks := lm.unifiedLocks[req.handleKey]
 
 	if deleg := conflictingDelegation(locks, req.state); deleg != nil {
-		lm.mu.Unlock()
+		lm.unlock()
 		logger.Debug("RequestLease: delegation conflict, denying lease",
 			"fileHandle", req.handleKey,
 			"delegationType", deleg.DelegType.String(),
@@ -375,7 +375,7 @@ func (lm *Manager) requestLeaseImpl(ctx context.Context, req leaseRequest) (gran
 	}
 
 	if handled, state, ep, serr := lm.resolveSameKeyLeaseLocked(req, locks); handled {
-		lm.mu.Unlock()
+		lm.unlock()
 		return state, ep, serr
 	}
 
@@ -389,7 +389,7 @@ func (lm *Manager) requestLeaseImpl(ctx context.Context, req leaseRequest) (gran
 	// states: strip Write, then strip Handle, then Read only, then None.
 	grantState := bestGrantableState(locks, req.leaseKey, req.state, req.isDirectory, req.isTraditionalOplock)
 	if grantState == LeaseStateNone {
-		lm.mu.Unlock()
+		lm.unlock()
 		logger.Debug("RequestLease: no compatible state after conflict resolution",
 			"fileHandle", req.handleKey,
 			"requestedState", LeaseStateToString(req.state))
@@ -397,7 +397,7 @@ func (lm *Manager) requestLeaseImpl(ctx context.Context, req leaseRequest) (gran
 	}
 
 	granted, grantedEpoch := lm.createAndGrantLease(ctx, req, grantState)
-	lm.mu.Unlock()
+	lm.unlock()
 
 	logger.Debug("RequestLease: granted lease",
 		"fileHandle", req.handleKey,
@@ -427,7 +427,7 @@ func (lm *Manager) probeLeaseState(req leaseRequest) (uint32, uint16, error) {
 		currentState := lock.Lease.LeaseState
 		epoch := lock.Lease.Epoch
 		breaking := lock.Lease.Breaking
-		lm.mu.Unlock()
+		lm.unlock()
 		if breaking {
 			logger.Debug("RequestLease: None-probe on breaking same-key lease, surfacing break-in-progress",
 				"fileHandle", req.handleKey,
@@ -437,7 +437,7 @@ func (lm *Manager) probeLeaseState(req leaseRequest) (uint32, uint16, error) {
 		}
 		return currentState, epoch, nil
 	}
-	lm.mu.Unlock()
+	lm.unlock()
 	return LeaseStateNone, 0, nil
 }
 
@@ -723,7 +723,7 @@ func (lm *Manager) breakConflictingLeasesLocked(req leaseRequest, locks []*Unifi
 		// SMBBreakHandler.OnOpLockBreak which calls SendLeaseBreak inline).
 		// Per MS-SMB2 3.3.4.7 the notification ordering requirement is
 		// therefore satisfied without further synchronization.
-		lm.mu.Unlock()
+		lm.unlock()
 		lm.dispatchOpLockBreak(req.handleKey, lockSnapshot, breakTo)
 
 		// Do NOT wait for the LEASE_BREAK_ACK before returning to the
@@ -948,7 +948,7 @@ func (lm *Manager) acknowledgeLeaseBreakImpl(_ context.Context, leaseKey [16]byt
 	acknowledgedState uint32, epoch uint16) error {
 
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 
 	handleKey, lock, _ := lm.findLeaseByKey(leaseKey)
 	if lock == nil {
@@ -1138,11 +1138,11 @@ func (lm *Manager) dispatchNextBreakStageLocked(handleKey string, leaseKey [16]b
 
 	// Release lm.mu before dispatching to avoid deadlock with the SMB transport
 	// callback (mirrors breakOpLocks pattern). The deferred re-Lock keeps the
-	// caller's `defer lm.mu.Unlock()` correct even if dispatchOpLockBreak panics
+	// caller's `defer lm.unlock()` correct even if dispatchOpLockBreak panics
 	// — without it the unwind would run through an unlocked mutex and the outer
 	// defer would double-unlock.
 	func() {
-		lm.mu.Unlock()
+		lm.unlock()
 		defer lm.mu.Lock()
 		lm.dispatchOpLockBreak(handleKey, snapshot, nextTarget)
 	}()
@@ -1202,7 +1202,7 @@ func (lm *Manager) clearBreakingSiblingsLocked(leaseKey [16]byte, primary *Unifi
 // ReleaseLease releases all lease state for the given lease key.
 func (lm *Manager) releaseLeaseImpl(ctx context.Context, leaseKey [16]byte) error {
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 
 	// Find and remove all locks with matching lease key. The same lease key
 	// constant can be bound on multiple files (distinct handleKey buckets), and
@@ -1246,7 +1246,7 @@ func (lm *Manager) releaseLeaseImpl(ctx context.Context, leaseKey [16]byte) erro
 // on the surviving file and break ACK lookup / break-to matching.
 func (lm *Manager) releaseLeaseForHandleImpl(ctx context.Context, handleKey string, leaseKey [16]byte) error {
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 
 	locks := lm.unifiedLocks[handleKey]
 	if len(locks) == 0 {
@@ -1280,6 +1280,14 @@ func (lm *Manager) releaseLeaseForHandleImpl(ctx context.Context, handleKey stri
 	var remaining []*UnifiedLock
 	var deleteErrs []error
 	hadBreaking := false
+
+	// The deletes below run inline rather than through the persist queue,
+	// because their error is reported to the caller. Empty this file's lane
+	// first so they still land after everything lm.mu ordered ahead of them.
+	if lm.lockStore != nil {
+		lm.drainPersistLaneLocked(handleKey)
+	}
+
 	for _, lock := range locks {
 		if lock.Lease != nil && lock.Lease.LeaseKey == leaseKey {
 			if lock.Lease.Breaking {
@@ -1467,7 +1475,7 @@ func (lm *Manager) GetLeaseState(ctx context.Context, leaseKey [16]byte) (state 
 // Returns false if no lease was found with the given key.
 func (lm *Manager) SetLeaseEpoch(leaseKey [16]byte, epoch uint16) bool {
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 
 	// Update every lease record matching leaseKey, not just the first found.
 	// Stale records from prior tests (same LEASE1 constant across smbtorture

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -1245,12 +1245,25 @@ func (lm *Manager) releaseLeaseImpl(ctx context.Context, leaseKey [16]byte) erro
 // record for a concurrent open on file B; otherwise stale records accumulate
 // on the surviving file and break ACK lookup / break-to matching.
 func (lm *Manager) releaseLeaseForHandleImpl(ctx context.Context, handleKey string, leaseKey [16]byte) error {
+	// The deletes are queued on the file's persist lane like every other
+	// mutation, and they run before releaseLeaseRecords returns, so their
+	// errors are complete by the time they are read here.
+	var deleteErrs []error
+	lm.releaseLeaseRecords(ctx, handleKey, leaseKey, &deleteErrs)
+
+	if len(deleteErrs) > 0 {
+		return fmt.Errorf("release lease for handle %q: %w", handleKey, errors.Join(deleteErrs...))
+	}
+	return nil
+}
+
+func (lm *Manager) releaseLeaseRecords(ctx context.Context, handleKey string, leaseKey [16]byte, deleteErrs *[]error) {
 	lm.mu.Lock()
 	defer lm.unlock()
 
 	locks := lm.unifiedLocks[handleKey]
 	if len(locks) == 0 {
-		return nil
+		return
 	}
 
 	// hadBreaking records whether any lease we remove here was in the Breaking
@@ -1278,15 +1291,7 @@ func (lm *Manager) releaseLeaseForHandleImpl(ctx context.Context, handleKey stri
 	// smb2.kernel-oplocks.kernel_oplocks7: that test explicitly accepts BOTH the
 	// re-open-first (EXCLUSIVE) and parked-create-first (NONE) orderings.
 	var remaining []*UnifiedLock
-	var deleteErrs []error
 	hadBreaking := false
-
-	// The deletes below run inline rather than through the persist queue,
-	// because their error is reported to the caller. Empty this file's lane
-	// first so they still land after everything lm.mu ordered ahead of them.
-	if lm.lockStore != nil {
-		lm.drainPersistLaneLocked(handleKey)
-	}
 
 	for _, lock := range locks {
 		if lock.Lease != nil && lock.Lease.LeaseKey == leaseKey {
@@ -1294,19 +1299,23 @@ func (lm *Manager) releaseLeaseForHandleImpl(ctx context.Context, handleKey stri
 				hadBreaking = true
 			}
 			if lm.lockStore != nil {
-				if err := lm.lockStore.DeleteLock(ctx, lock.ID); err != nil && !storeerrors.IsNotFoundError(err) {
-					// In-memory removal proceeds regardless: the persisted
-					// record will be reaped by the next client-disconnect or
-					// file-deletion sweep. Surface the error so observability
-					// catches a misbehaving store rather than the lease leak
-					// going silent (round-3 follow-up).
-					logger.Error("ReleaseLeaseForHandle: persistent DeleteLock failed",
-						"handleKey", handleKey,
-						"lockID", lock.ID,
-						"leaseKey", fmt.Sprintf("%x", leaseKey),
-						"error", err)
-					deleteErrs = append(deleteErrs, err)
-				}
+				store := lm.lockStore
+				lockID := lock.ID
+				lm.enqueuePersistLocked(handleKey, func() {
+					if err := store.DeleteLock(ctx, lockID); err != nil && !storeerrors.IsNotFoundError(err) {
+						// In-memory removal proceeds regardless: the persisted
+						// record will be reaped by the next client-disconnect or
+						// file-deletion sweep. Surface the error so observability
+						// catches a misbehaving store rather than the lease leak
+						// going silent.
+						logger.Error("ReleaseLeaseForHandle: persistent DeleteLock failed",
+							"handleKey", handleKey,
+							"lockID", lockID,
+							"leaseKey", fmt.Sprintf("%x", leaseKey),
+							"error", err)
+						*deleteErrs = append(*deleteErrs, err)
+					}
+				})
 			}
 			continue
 		}
@@ -1323,11 +1332,6 @@ func (lm *Manager) releaseLeaseForHandleImpl(ctx context.Context, handleKey stri
 	if hadBreaking {
 		lm.signalBreakWaitLocked(handleKey)
 	}
-
-	if len(deleteErrs) > 0 {
-		return fmt.Errorf("release lease for handle %q: %w", handleKey, errors.Join(deleteErrs...))
-	}
-	return nil
 }
 
 // GetLeaseState returns the current state and epoch for a lease key.

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -1221,6 +1221,15 @@ func (lm *Manager) deleteFileLockLocked(fl *FileLock) {
 // override is skipped when lm.shareName is empty so a directly-constructed
 // manager preserves a producer-set Owner.ShareName.
 func (lm *Manager) persistUnifiedLockLocked(ul *UnifiedLock) {
+	// For a lease record Type is a projection of LeaseState, not an independent
+	// field: re-derive it here so a mutation that changes LeaseState without
+	// touching Type cannot write out a record whose Type contradicts the lease
+	// it carries. Byte-range and delegation records own their Type outright and
+	// are left alone.
+	if ul.Lease != nil {
+		ul.Type = lockTypeForLeaseState(ul.Lease.LeaseState)
+	}
+
 	if lm.lockStore == nil {
 		return
 	}

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -807,10 +807,12 @@ func (lm *Manager) notifyByteRangeReleased(handleKey string) {
 //
 // Returns nil on success, or ErrLocked if a conflict exists.
 //
-// Persistence is synchronous under lm.mu: the in-memory mutation and the
-// PutLock run while the mutex is held so the store sees mutations in the same
-// order the mutex serializes them. Two concurrent ops on the same persistID can
-// no longer reach the store out of order (the reorder/resurrection bug class).
+// Persistence is synchronous with respect to the caller: the in-memory
+// mutation happens under lm.mu, the PutLock is queued on the file's persist
+// lane and runs once lm.mu is released, and this call does not return until it
+// has run. Per file the store still sees mutations in the order the mutex
+// serialized them, so two concurrent ops on the same persistID cannot reach the
+// store out of order (the reorder/resurrection bug class).
 func (lm *Manager) Lock(handleKey string, lock FileLock) error {
 	lm.mu.Lock()
 	defer lm.unlock()
@@ -1172,9 +1174,9 @@ func (lm *Manager) assignPersistIDLocked(fl *FileLock) {
 }
 
 // withPersistTimeout returns a context bounded by persistTimeout so a hung
-// backend can never wedge the lock manager: the store call runs synchronously
-// under lm.mu (mutex order == store order), but the timeout caps how long it
-// can block the critical section.
+// backend can never wedge the lock manager: the store call holds its file's
+// persist lane and blocks the operation that queued it, and the timeout caps
+// how long either can last.
 func withPersistTimeout() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), persistTimeout)
 }
@@ -1221,7 +1223,7 @@ func (lm *Manager) deleteFileLockLocked(handleKey string, fl *FileLock) {
 	lm.deletePersistedLocked(handleKey, fl.persistID)
 }
 
-// persistUnifiedLockLocked synchronously persists a unified lock. No-op if
+// persistUnifiedLockLocked queues a unified lock for persistence. No-op if
 // persistence is disabled. Caller must hold lm.mu.
 //
 // The share name is stamped from lm.shareName rather than trusting the
@@ -1253,8 +1255,8 @@ func (lm *Manager) persistUnifiedLockLocked(ul *UnifiedLock) {
 	lm.putLockLocked(pl)
 }
 
-// deleteUnifiedLockLocked synchronously removes a persisted unified lock. No-op
-// if persistence is disabled. Caller must hold lm.mu.
+// deleteUnifiedLockLocked queues removal of a persisted unified lock. No-op if
+// persistence is disabled. Caller must hold lm.mu.
 func (lm *Manager) deleteUnifiedLockLocked(ul *UnifiedLock) {
 	if lm.lockStore == nil {
 		return

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -720,6 +720,14 @@ type Manager struct {
 	// drain, mirroring the NLM-side onUnlock callback. May be nil. Fired
 	// outside lm.mu so the subscriber can call back into the Manager.
 	onByteRangeRelease func(handleKey string)
+
+	// persistLanes orders lock-store writes per file, and pendingPersist holds
+	// the writes the current critical section has queued but not yet run. See
+	// persistqueue.go: mutations take a lane ticket under lm.mu and make their
+	// store call after lm.mu is released, so per file the store still observes
+	// them in mutex order while different files' round-trips overlap.
+	persistLanes   [persistLaneCount]persistLane
+	pendingPersist []persistOp
 }
 
 // DefaultDelegationRecallTimeout is the default delegation recall timeout.
@@ -735,7 +743,7 @@ const persistTimeout = 3 * time.Second
 // newBaseManager creates a Manager with all common fields initialized.
 // Callers customize the returned Manager before use.
 func newBaseManager(recentlyBrokenTTL time.Duration) *Manager {
-	return &Manager{
+	m := &Manager{
 		locks:                   make(map[string][]FileLock),
 		unifiedLocks:            make(map[string][]*UnifiedLock),
 		leaseKeyIndex:           make(map[[16]byte]map[string]int),
@@ -744,6 +752,10 @@ func newBaseManager(recentlyBrokenTTL time.Duration) *Manager {
 		breakWaitChans:          make(map[string]chan struct{}),
 		delegationRecallTimeout: DefaultDelegationRecallTimeout,
 	}
+	for i := range m.persistLanes {
+		m.persistLanes[i].cond = sync.NewCond(&m.persistLanes[i].mu)
+	}
+	return m
 }
 
 // NewManager creates a new lock manager.
@@ -771,7 +783,7 @@ func NewManagerWithGracePeriod(gracePeriod *GracePeriodManager) *Manager {
 func (lm *Manager) SetByteRangeReleaseCallback(fn func(handleKey string)) {
 	lm.mu.Lock()
 	lm.onByteRangeRelease = fn
-	lm.mu.Unlock()
+	lm.unlock()
 }
 
 // notifyByteRangeReleased fires the release callback (if registered) for
@@ -800,7 +812,7 @@ func (lm *Manager) notifyByteRangeReleased(handleKey string) {
 // no longer reach the store out of order (the reorder/resurrection bug class).
 func (lm *Manager) Lock(handleKey string, lock FileLock) error {
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 
 	existing := lm.locks[handleKey]
 
@@ -872,7 +884,7 @@ func (lm *Manager) Unlock(handleKey string, openID string, sessionID uint64, off
 
 func (lm *Manager) doUnlock(handleKey string, openID string, sessionID uint64, offset, length uint64) (bool, error) {
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 
 	existing := lm.locks[handleKey]
 	if len(existing) == 0 {
@@ -887,7 +899,7 @@ func (lm *Manager) doUnlock(handleKey string, openID string, sessionID uint64, o
 		if lockOwnerID(&existing[i]) == owner &&
 			existing[i].Offset == offset &&
 			existing[i].Length == length {
-			lm.deleteFileLockLocked(&existing[i])
+			lm.deleteFileLockLocked(handleKey, &existing[i])
 			// Remove this lock
 			lm.locks[handleKey] = append(existing[:i], existing[i+1:]...)
 
@@ -919,7 +931,7 @@ func (lm *Manager) UnlockAllForOpen(handleKey string, openID string) int {
 
 func (lm *Manager) doUnlockAllForOpen(handleKey string, openID string) int {
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 
 	existing := lm.locks[handleKey]
 	if len(existing) == 0 {
@@ -931,7 +943,7 @@ func (lm *Manager) doUnlockAllForOpen(handleKey string, openID string) int {
 	removed := 0
 	for i := range existing {
 		if existing[i].OpenID == openID {
-			lm.deleteFileLockLocked(&existing[i])
+			lm.deleteFileLockLocked(handleKey, &existing[i])
 			removed++
 		} else {
 			remaining = append(remaining, existing[i])
@@ -962,7 +974,7 @@ func (lm *Manager) UnlockAllForSession(handleKey string, sessionID uint64) int {
 
 func (lm *Manager) doUnlockAllForSession(handleKey string, sessionID uint64) int {
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 
 	existing := lm.locks[handleKey]
 	if len(existing) == 0 {
@@ -974,7 +986,7 @@ func (lm *Manager) doUnlockAllForSession(handleKey string, sessionID uint64) int
 	removed := 0
 	for i := range existing {
 		if existing[i].SessionID == sessionID {
-			lm.deleteFileLockLocked(&existing[i])
+			lm.deleteFileLockLocked(handleKey, &existing[i])
 			removed++
 		} else {
 			remaining = append(remaining, existing[i])
@@ -1084,14 +1096,14 @@ func (lm *Manager) ListLocks(handleKey string) []FileLock {
 // Called when a file is deleted to clean up any stale lock entries.
 func (lm *Manager) RemoveFileLocks(handleKey string) {
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 	delete(lm.locks, handleKey)
 }
 
 // SetDelegationRecallTimeout sets the delegation recall timeout (thread-safe).
 func (lm *Manager) SetDelegationRecallTimeout(d time.Duration) {
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 	lm.delegationRecallTimeout = d
 }
 
@@ -1105,14 +1117,14 @@ func (lm *Manager) DelegationRecallTimeout() time.Duration {
 // SetHandleChecker sets the handle checker used for lease reclaim validation.
 func (lm *Manager) SetHandleChecker(hc HandleChecker) {
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 	lm.handleChecker = hc
 }
 
 // SetLockStore sets the persistent lock store for lease persistence.
 func (lm *Manager) SetLockStore(store LockStore) {
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 	lm.lockStore = store
 }
 
@@ -1121,14 +1133,14 @@ func (lm *Manager) SetLockStore(store LockStore) {
 // NFSv4 principal check is skipped (SMB-only deployments).
 func (lm *Manager) SetClientRecoveryStore(store ClientRecoveryStore) {
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 	lm.clientRecoveryStore = store
 }
 
 // SetEpoch records the current server epoch stamped on persisted locks.
 func (lm *Manager) SetEpoch(epoch uint64) {
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 	lm.epoch = epoch
 }
 
@@ -1137,7 +1149,7 @@ func (lm *Manager) SetEpoch(epoch uint64) {
 // per-share ListLocks query at startup.
 func (lm *Manager) SetShareName(shareName string) {
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 	lm.shareName = shareName
 }
 
@@ -1189,7 +1201,7 @@ func (lm *Manager) fileLockToPersisted(handleKey string, fl *FileLock) *Persiste
 	}
 }
 
-// persistFileLockLocked synchronously persists a byte-range lock. No-op if
+// persistFileLockLocked queues a byte-range lock for persistence. No-op if
 // persistence is disabled. Caller must hold lm.mu.
 func (lm *Manager) persistFileLockLocked(handleKey string, fl *FileLock) {
 	if lm.lockStore == nil {
@@ -1198,14 +1210,14 @@ func (lm *Manager) persistFileLockLocked(handleKey string, fl *FileLock) {
 	lm.putLockLocked(lm.fileLockToPersisted(handleKey, fl))
 }
 
-// deleteFileLockLocked synchronously removes a persisted byte-range lock. No-op
-// if persistence is disabled or the lock was never persisted. Caller must hold
+// deleteFileLockLocked queues removal of a persisted byte-range lock. No-op if
+// persistence is disabled or the lock was never persisted. Caller must hold
 // lm.mu.
-func (lm *Manager) deleteFileLockLocked(fl *FileLock) {
+func (lm *Manager) deleteFileLockLocked(handleKey string, fl *FileLock) {
 	if lm.lockStore == nil || fl.persistID == "" {
 		return
 	}
-	lm.deletePersistedLocked(fl.persistID)
+	lm.deletePersistedLocked(handleKey, fl.persistID)
 }
 
 // persistUnifiedLockLocked synchronously persists a unified lock. No-op if
@@ -1246,13 +1258,15 @@ func (lm *Manager) deleteUnifiedLockLocked(ul *UnifiedLock) {
 	if lm.lockStore == nil {
 		return
 	}
-	lm.deletePersistedLocked(ul.ID)
+	lm.deletePersistedLocked(string(ul.FileHandle), ul.ID)
 }
 
-// putLockLocked persists one record synchronously under lm.mu, bounded by
-// persistTimeout. Caller must hold lm.mu and must have already applied the
-// in-memory mutation, so the store observes mutations in mutex order — this is
-// what eliminates the reorder/resurrection bug class (R3-1).
+// putLockLocked queues one record for persistence on its file's lane, bounded
+// by persistTimeout when it runs. Caller must hold lm.mu and must have already
+// applied the in-memory mutation, so the store observes mutations in mutex
+// order — this is what eliminates the reorder/resurrection bug class (R3-1).
+// The call itself is made after lm.mu is released and before the acquiring
+// operation returns to its client (see persistqueue.go).
 //
 // Persistence is BEST-EFFORT. The in-memory lock map is authoritative for the
 // running server, so a failed PutLock must NOT fail the lock op — the client is
@@ -1262,33 +1276,41 @@ func (lm *Manager) deleteUnifiedLockLocked(ul *UnifiedLock) {
 // could be granted. The operator MUST treat these ERROR logs as a durability
 // alarm. Errors are logged with file/owner context so they are observable.
 func (lm *Manager) putLockLocked(pl *PersistedLock) {
-	ctx, cancel := withPersistTimeout()
-	defer cancel()
-	if err := lm.lockStore.PutLock(ctx, pl); err != nil {
-		logger.Error("lock persistence failed: lock held in memory but NOT durable across restart",
-			"lockID", pl.ID,
-			"share", pl.ShareName,
-			"fileID", pl.FileID,
-			"ownerID", pl.OwnerID,
-			"error", err)
-	}
+	store := lm.lockStore
+	lm.enqueuePersistLocked(pl.FileID, func() {
+		ctx, cancel := withPersistTimeout()
+		defer cancel()
+		if err := store.PutLock(ctx, pl); err != nil {
+			logger.Error("lock persistence failed: lock held in memory but NOT durable across restart",
+				"lockID", pl.ID,
+				"share", pl.ShareName,
+				"fileID", pl.FileID,
+				"ownerID", pl.OwnerID,
+				"error", err)
+		}
+	})
 }
 
-// deletePersistedLocked removes one record by ID synchronously under lm.mu,
-// bounded by persistTimeout. Caller must hold lm.mu and must have already
-// applied the in-memory removal (mutex order == store order).
+// deletePersistedLocked queues removal of one record by ID on fileKey's lane,
+// bounded by persistTimeout when it runs. Caller must hold lm.mu and must have
+// already applied the in-memory removal (mutex order == store order). fileKey
+// must be the same key the record was persisted under, so the delete stays
+// ordered behind its own put.
 //
 // Best-effort with the same contract as putLockLocked: a failed DeleteLock
 // means a released lock may resurrect on restart until the next successful
 // overwrite/cleanup. ErrLockNotFound is ignored — the record is already gone.
-func (lm *Manager) deletePersistedLocked(id string) {
-	ctx, cancel := withPersistTimeout()
-	defer cancel()
-	if err := lm.lockStore.DeleteLock(ctx, id); err != nil && !isLockNotFound(err) {
-		logger.Error("lock-delete persistence failed: released lock may resurrect on restart",
-			"lockID", id,
-			"error", err)
-	}
+func (lm *Manager) deletePersistedLocked(fileKey, id string) {
+	store := lm.lockStore
+	lm.enqueuePersistLocked(fileKey, func() {
+		ctx, cancel := withPersistTimeout()
+		defer cancel()
+		if err := store.DeleteLock(ctx, id); err != nil && !isLockNotFound(err) {
+			logger.Error("lock-delete persistence failed: released lock may resurrect on restart",
+				"lockID", id,
+				"error", err)
+		}
+	})
 }
 
 // RestoreLocks loads previously-persisted locks back into the in-memory lock
@@ -1300,7 +1322,7 @@ func (lm *Manager) deletePersistedLocked(id string) {
 // locks are by definition conflict-free with each other.
 func (lm *Manager) RestoreLocks(persisted []*PersistedLock) error {
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 
 	for _, pl := range persisted {
 		// pl.FileID is the handle key used when persisting (see persist helpers).

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -734,10 +734,11 @@ type Manager struct {
 // NFS uses a longer timeout than SMB leases (90s vs 35s).
 const DefaultDelegationRecallTimeout = 90 * time.Second
 
-// persistTimeout bounds every synchronous lock-store call made under lm.mu.
-// Persistence runs inline (mutex order == store order, see putLockLocked) so a
-// hung backend would otherwise wedge the lock manager indefinitely; the timeout
-// turns that into a bounded best-effort failure that logs and proceeds.
+// persistTimeout bounds every lock-store call the manager makes. The call runs
+// before the operation that queued it returns, and it holds its file's persist
+// lane while it runs, so a hung backend would otherwise wedge that file (and
+// its caller) indefinitely; the timeout turns that into a bounded best-effort
+// failure that logs and proceeds.
 const persistTimeout = 3 * time.Second
 
 // newBaseManager creates a Manager with all common fields initialized.

--- a/pkg/metadata/lock/manager_test.go
+++ b/pkg/metadata/lock/manager_test.go
@@ -1246,7 +1246,7 @@ func TestSetLeaseEpoch_UpdatesAllMatchingRecords(t *testing.T) {
 		{Owner: LockOwner{OwnerID: "oB"}, Lease: &OpLock{LeaseKey: leaseKey, LeaseState: LeaseStateRead, Epoch: 1}},
 	}
 	lm.reindexHandleLocked("/share:fileB", nil)
-	lm.mu.Unlock()
+	lm.unlock()
 
 	if !lm.SetLeaseEpoch(leaseKey, 7) {
 		t.Fatalf("SetLeaseEpoch returned false, expected true when records exist")
@@ -1295,7 +1295,7 @@ func TestSetLeaseEpoch_ConvergesDivergentRecords(t *testing.T) {
 		{Owner: LockOwner{OwnerID: "oB"}, Lease: &OpLock{LeaseKey: leaseKey, LeaseState: LeaseStateRead, Epoch: 1}},
 	}
 	lm.reindexHandleLocked("/share:fileB", nil)
-	lm.mu.Unlock()
+	lm.unlock()
 
 	// Request a lower epoch (4) than the highest existing record (5). All
 	// records must converge to 5 (the max), not split into 5 and 4.
@@ -1328,7 +1328,7 @@ func TestSetLeaseEpoch_Persists(t *testing.T) {
 		{ID: "lease-1", Owner: LockOwner{OwnerID: "oA"}, Lease: &OpLock{LeaseKey: leaseKey, LeaseState: LeaseStateRead, Epoch: 1}},
 	}
 	lm.reindexHandleLocked("/share:fileA", nil)
-	lm.mu.Unlock()
+	lm.unlock()
 
 	if !lm.SetLeaseEpoch(leaseKey, 9) {
 		t.Fatalf("SetLeaseEpoch returned false, expected true")

--- a/pkg/metadata/lock/oplock_break_test.go
+++ b/pkg/metadata/lock/oplock_break_test.go
@@ -576,7 +576,7 @@ func TestOpLockBreakScanner_RevokeUnblocksWaitForBreakCompletion(t *testing.T) {
 	// Insert directly into in-memory map to bypass conflict-check path.
 	lm.mu.Lock()
 	lm.unifiedLocks["file-wait"] = append(lm.unifiedLocks["file-wait"], breakingLock)
-	lm.mu.Unlock()
+	lm.unlock()
 
 	// Persist it so the scanner can find it.
 	pl := ToPersistedLock(breakingLock, 1)

--- a/pkg/metadata/lock/persist_test.go
+++ b/pkg/metadata/lock/persist_test.go
@@ -868,3 +868,42 @@ func TestRestoreLocks_ByteRangeEnforcedAfterRestart(t *testing.T) {
 	ioConflict := fresh.CheckForIO(handleKey, "open-2", 8, 50, 20, true)
 	require.NotNil(t, ioConflict, "restored byte-range lock must be enforced by CheckForIO")
 }
+
+// TestRequestLease_UpgradePersistsDerivedLockType verifies that a same-key
+// R -> RW lease upgrade writes out a record whose LockType tracks the upgraded
+// lease state. The upgrade arm changes LeaseState and the epoch only, so the
+// derivation has to happen on the way to the store; without it the record says
+// "shared" while the lease it carries holds the Write bit.
+func TestRequestLease_UpgradePersistsDerivedLockType(t *testing.T) {
+	ctx := context.Background()
+	store := newMockLockStore()
+
+	mgr := NewManager()
+	mgr.SetLockStore(store)
+	mgr.SetShareName("share-a")
+
+	fh := FileHandle("file-1")
+	leaseKey := [16]byte{1}
+
+	granted, _, err := mgr.RequestLease(ctx, fh, leaseKey, [16]byte{},
+		"owner-1", "client-1", "share-a", LeaseStateRead, false)
+	require.NoError(t, err)
+	require.Equal(t, LeaseStateRead, granted)
+
+	granted, _, err = mgr.RequestLease(ctx, fh, leaseKey, [16]byte{},
+		"owner-1", "client-1", "share-a", LeaseStateRead|LeaseStateWrite, false)
+	require.NoError(t, err)
+	require.Equal(t, LeaseStateRead|LeaseStateWrite, granted)
+
+	persisted, err := store.ListLocks(ctx, LockQuery{ShareName: "share-a"})
+	require.NoError(t, err)
+	require.Len(t, persisted, 1)
+	require.Equal(t, LeaseStateRead|LeaseStateWrite, persisted[0].LeaseState)
+	require.Equal(t, int(LockTypeExclusive), persisted[0].LockType,
+		"upgraded lease must persist an exclusive lock type")
+
+	// A record already on disk with a stale type comes back consistent.
+	stale := persisted[0]
+	stale.LockType = int(LockTypeShared)
+	require.Equal(t, LockTypeExclusive, FromPersistedLock(stale).Type)
+}

--- a/pkg/metadata/lock/persistqueue.go
+++ b/pkg/metadata/lock/persistqueue.go
@@ -1,0 +1,168 @@
+package lock
+
+import "sync"
+
+// Lock-store writes are ordered by ticket, not by lm.mu.
+//
+// Every mutation the Manager persists used to make its store call while still
+// holding lm.mu. That is what made "mutex order == store order" true, and that
+// ordering is the whole reason the reorder/resurrection class does not exist:
+// the store can never observe a lock's PutLock after the DeleteLock that
+// released it, nor an acquire that lm.mu already ordered behind a bulk delete.
+//
+// It also meant one store round-trip serialized the entire share. With a
+// remote-backed lock store the manager ran at one lock operation per round-trip
+// regardless of how many clients or cores were pushing it, because the lock
+// operations queued on lm.mu behind somebody else's network call.
+//
+// So the store call moves out of the critical section, and the ordering moves
+// onto tickets. A mutation still applies to the in-memory maps under lm.mu, but
+// instead of calling the store it takes a ticket on the lane its file hashes to
+// and records the call as a pending op. The op runs after lm.mu is released, in
+// its lane's ticket order, and the caller does not return until its own ops have
+// run — so persistence is still synchronous with respect to the client, and per
+// file the store still sees mutations in exactly the order lm.mu applied them.
+// What changes is that two different files' round-trips now overlap.
+//
+// Operations that are not scoped to one file (a client-wide bulk delete) take a
+// ticket on every lane and so act as a barrier: nothing crosses them in either
+// direction.
+//
+// Deadlock-freedom: tickets are issued under lm.mu, so if critical section A
+// precedes critical section B then A's ticket precedes B's on every lane they
+// share. An op only ever waits on a strictly earlier ticket, and "earlier" is
+// the total order lm.mu already imposed, so the wait-for graph cannot cycle.
+
+// persistLaneCount is the number of independent store-ordering lanes. Files hash to
+// a lane; the count bounds how many store round-trips can be in flight for one
+// share, and 16 is well past the point where the lock store rather than the
+// manager is the limit.
+const persistLaneCount = 16
+
+// persistLane is a ticket lock. Tickets are handed out under lm.mu (next) and
+// retired by the goroutine that ran the op (done); an op holds its lane for the
+// whole store call, which is what keeps a lane's writes ordered and serialized.
+type persistLane struct {
+	mu   sync.Mutex
+	cond *sync.Cond
+	next uint64
+	done uint64
+}
+
+func (l *persistLane) acquire(seq uint64) {
+	l.mu.Lock()
+	for l.done != seq {
+		l.cond.Wait()
+	}
+	l.mu.Unlock()
+}
+
+func (l *persistLane) release() {
+	l.mu.Lock()
+	l.done++
+	l.cond.Broadcast()
+	l.mu.Unlock()
+}
+
+// persistOp is one store call together with the lane tickets it must hold to
+// run. A file-scoped op holds one; a barrier holds all of them.
+type persistOp struct {
+	lanes []*persistLane
+	seqs  []uint64
+	run   func()
+}
+
+func (op persistOp) exec() {
+	for i, lane := range op.lanes {
+		lane.acquire(op.seqs[i])
+	}
+	op.run()
+	for _, lane := range op.lanes {
+		lane.release()
+	}
+}
+
+// laneFor maps a file key to its lane. FNV-1a over the key, inlined to avoid
+// allocating a hash per persisted mutation.
+func (lm *Manager) laneFor(fileKey string) *persistLane {
+	h := uint32(2166136261)
+	for i := 0; i < len(fileKey); i++ {
+		h ^= uint32(fileKey[i])
+		h *= 16777619
+	}
+	return &lm.persistLanes[h%persistLaneCount]
+}
+
+// enqueuePersistLocked records a store call scoped to one file, to run once
+// lm.mu is released. Caller must hold lm.mu and must have already applied the
+// in-memory mutation.
+func (lm *Manager) enqueuePersistLocked(fileKey string, run func()) {
+	lane := lm.laneFor(fileKey)
+	lm.pendingPersist = append(lm.pendingPersist, persistOp{
+		lanes: []*persistLane{lane},
+		seqs:  []uint64{lane.next},
+		run:   run,
+	})
+	lane.next++
+}
+
+// enqueuePersistBarrierLocked records a store call that is not scoped to a
+// single file. It takes a ticket on every lane, so it runs after everything
+// lm.mu ordered before it and before everything lm.mu ordered after it, across
+// all files. Caller must hold lm.mu.
+func (lm *Manager) enqueuePersistBarrierLocked(run func()) {
+	op := persistOp{
+		lanes: make([]*persistLane, persistLaneCount),
+		seqs:  make([]uint64, persistLaneCount),
+		run:   run,
+	}
+	for i := range lm.persistLanes {
+		lane := &lm.persistLanes[i]
+		op.lanes[i] = lane
+		op.seqs[i] = lane.next
+		lane.next++
+	}
+	lm.pendingPersist = append(lm.pendingPersist, op)
+}
+
+// unlock releases lm.mu and then runs the store calls this critical section
+// queued, in ticket order. Every site that acquires lm.mu for writing must
+// release it through here rather than calling lm.mu.Unlock directly, otherwise
+// its persists sit in the queue until some unrelated goroutine happens to
+// unlock and the caller returns before its own write reached the store.
+func (lm *Manager) unlock() {
+	ops := lm.pendingPersist
+	lm.pendingPersist = nil
+	lm.unlock()
+
+	for _, op := range ops {
+		op.exec()
+	}
+}
+
+// drainPersistLaneLocked empties fileKey's lane so the caller can make a store
+// call for that file inline and still have it land in mutex order. It runs this
+// critical section's own queued calls first (they may sit on the same lane, and
+// nothing else will run them while lm.mu is held), then waits for every ticket
+// issued on the lane to retire. Caller must hold lm.mu.
+//
+// It exists for the one path that must call the store inline because it returns
+// the store's error to its caller. Everything else should queue.
+//
+// Draining terminates: new tickets are only issued under lm.mu, which this
+// caller holds, and the goroutines retiring the outstanding ones do not need
+// lm.mu to make progress.
+func (lm *Manager) drainPersistLaneLocked(fileKey string) {
+	ops := lm.pendingPersist
+	lm.pendingPersist = nil
+	for _, op := range ops {
+		op.exec()
+	}
+
+	lane := lm.laneFor(fileKey)
+	lane.mu.Lock()
+	for lane.done != lane.next {
+		lane.cond.Wait()
+	}
+	lane.mu.Unlock()
+}

--- a/pkg/metadata/lock/persistqueue.go
+++ b/pkg/metadata/lock/persistqueue.go
@@ -133,7 +133,7 @@ func (lm *Manager) enqueuePersistBarrierLocked(run func()) {
 func (lm *Manager) unlock() {
 	ops := lm.pendingPersist
 	lm.pendingPersist = nil
-	lm.unlock()
+	lm.mu.Unlock()
 
 	for _, op := range ops {
 		op.exec()

--- a/pkg/metadata/lock/persistqueue.go
+++ b/pkg/metadata/lock/persistqueue.go
@@ -33,10 +33,10 @@ import "sync"
 // share. An op only ever waits on a strictly earlier ticket, and "earlier" is
 // the total order lm.mu already imposed, so the wait-for graph cannot cycle.
 
-// persistLaneCount is the number of independent store-ordering lanes. Files hash to
-// a lane; the count bounds how many store round-trips can be in flight for one
-// share, and 16 is well past the point where the lock store rather than the
-// manager is the limit.
+// ponytail: fixed 16 lanes, hashed by file. The count bounds how many store
+// round-trips can be in flight for one share; make it configurable, or scale it
+// off GOMAXPROCS, only if a profile shows lane collisions rather than the lock
+// store itself as the limit.
 const persistLaneCount = 16
 
 // persistLane is a ticket lock. Tickets are handed out under lm.mu (next) and
@@ -142,31 +142,4 @@ func (lm *Manager) unlock() {
 	for _, op := range ops {
 		op.exec()
 	}
-}
-
-// drainPersistLaneLocked empties fileKey's lane so the caller can make a store
-// call for that file inline and still have it land in mutex order. It runs this
-// critical section's own queued calls first (they may sit on the same lane, and
-// nothing else will run them while lm.mu is held), then waits for every ticket
-// issued on the lane to retire. Caller must hold lm.mu.
-//
-// It exists for the one path that must call the store inline because it returns
-// the store's error to its caller. Everything else should queue.
-//
-// Draining terminates: new tickets are only issued under lm.mu, which this
-// caller holds, and the goroutines retiring the outstanding ones do not need
-// lm.mu to make progress.
-func (lm *Manager) drainPersistLaneLocked(fileKey string) {
-	ops := lm.pendingPersist
-	lm.pendingPersist = nil
-	for _, op := range ops {
-		op.exec()
-	}
-
-	lane := lm.laneFor(fileKey)
-	lane.mu.Lock()
-	for lane.done != lane.next {
-		lane.cond.Wait()
-	}
-	lane.mu.Unlock()
 }

--- a/pkg/metadata/lock/persistqueue.go
+++ b/pkg/metadata/lock/persistqueue.go
@@ -76,10 +76,14 @@ func (op persistOp) exec() {
 	for i, lane := range op.lanes {
 		lane.acquire(op.seqs[i])
 	}
+	// Retire on the way out even if the store panics: a ticket that is never
+	// retired wedges its lane, and every later write to those files with it.
+	defer func() {
+		for _, lane := range op.lanes {
+			lane.release()
+		}
+	}()
 	op.run()
-	for _, lane := range op.lanes {
-		lane.release()
-	}
 }
 
 // laneFor maps a file key to its lane. FNV-1a over the key, inlined to avoid

--- a/pkg/metadata/lock/persistqueue_test.go
+++ b/pkg/metadata/lock/persistqueue_test.go
@@ -1,0 +1,183 @@
+package lock
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// slowLockStore adds a fixed per-call delay to the mock store, standing in for
+// a lock store whose writes cross a network.
+type slowLockStore struct {
+	*mockLockStore
+	putDelay time.Duration
+	delDelay time.Duration
+}
+
+func (s *slowLockStore) PutLock(ctx context.Context, lock *PersistedLock) error {
+	time.Sleep(s.putDelay)
+	return s.mockLockStore.PutLock(ctx, lock)
+}
+
+func (s *slowLockStore) DeleteLock(ctx context.Context, lockID string) error {
+	time.Sleep(s.delDelay)
+	return s.mockLockStore.DeleteLock(ctx, lockID)
+}
+
+func newSlowLockStore(put, del time.Duration) *slowLockStore {
+	return &slowLockStore{mockLockStore: newMockLockStore(), putDelay: put, delDelay: del}
+}
+
+func benchFileLock(id, session uint64, openID string) FileLock {
+	return FileLock{
+		ID:        id,
+		SessionID: session,
+		OpenID:    openID,
+		Offset:    0,
+		Length:    16,
+		Exclusive: true,
+	}
+}
+
+// TestPersistQueue_WriteIsDurableBeforeReturn pins the contract that moving the
+// store call out of lm.mu must not make persistence asynchronous: by the time
+// Lock returns, the record is in the store, and by the time Unlock returns it
+// is gone.
+func TestPersistQueue_WriteIsDurableBeforeReturn(t *testing.T) {
+	ctx := context.Background()
+	store := newSlowLockStore(20*time.Millisecond, 20*time.Millisecond)
+
+	mgr := NewManager()
+	mgr.SetLockStore(store)
+	mgr.SetShareName("share-a")
+
+	const handleKey = "share-a:file-1"
+	fl := benchFileLock(1, 7, "open-1")
+
+	require.NoError(t, mgr.Lock(handleKey, fl))
+	persisted, err := store.ListLocks(ctx, LockQuery{ShareName: "share-a"})
+	require.NoError(t, err)
+	require.Len(t, persisted, 1, "Lock must not return before its record reached the store")
+
+	require.NoError(t, mgr.Unlock(handleKey, fl.OpenID, fl.SessionID, fl.Offset, fl.Length))
+	persisted, err = store.ListLocks(ctx, LockQuery{ShareName: "share-a"})
+	require.NoError(t, err)
+	require.Empty(t, persisted, "Unlock must not return before its delete reached the store")
+}
+
+// TestPersistQueue_DeleteNeverOvertakesPut hammers one file — so every write
+// lands on the same lane — with a store whose PutLock is far slower than its
+// DeleteLock. An unordered flush lets a release's DeleteLock run before the
+// acquire's PutLock it is meant to undo, which resurrects the record; the lane
+// ticket is what forbids that. The store must end empty.
+func TestPersistQueue_DeleteNeverOvertakesPut(t *testing.T) {
+	ctx := context.Background()
+	store := newSlowLockStore(5*time.Millisecond, 0)
+
+	mgr := NewManager()
+	mgr.SetLockStore(store)
+	mgr.SetShareName("share-a")
+
+	const handleKey = "share-a:file-1"
+	const workers = 8
+	const rounds = 10
+
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			// Non-overlapping ranges so the workers never conflict with each
+			// other and every attempt actually reaches the store.
+			offset := uint64(w) * 16
+			fl := FileLock{
+				ID:        uint64(w),
+				SessionID: uint64(w),
+				OpenID:    fmt.Sprintf("open-%d", w),
+				Offset:    offset,
+				Length:    16,
+				Exclusive: true,
+			}
+			for r := 0; r < rounds; r++ {
+				require.NoError(t, mgr.Lock(handleKey, fl))
+				require.NoError(t, mgr.Unlock(handleKey, fl.OpenID, fl.SessionID, fl.Offset, fl.Length))
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	require.Empty(t, mgr.ListLocks(handleKey))
+
+	persisted, err := store.ListLocks(ctx, LockQuery{ShareName: "share-a"})
+	require.NoError(t, err)
+	require.Empty(t, persisted, "a delete must never land before the put it undoes")
+}
+
+// TestPersistQueue_ClientBulkDeleteIsABarrier checks that the client-wide bulk
+// delete, which is not scoped to one file, still orders against per-file writes
+// on every file: locks acquired before it are gone afterwards even though they
+// live on different lanes.
+func TestPersistQueue_ClientBulkDeleteIsABarrier(t *testing.T) {
+	ctx := context.Background()
+	store := newSlowLockStore(2*time.Millisecond, 0)
+
+	mgr := NewManager()
+	mgr.SetLockStore(store)
+	mgr.SetShareName("share-a")
+
+	for i := 0; i < 32; i++ {
+		handleKey := fmt.Sprintf("share-a:file-%d", i)
+		lock := NewUnifiedLock(
+			LockOwner{OwnerID: fmt.Sprintf("owner-%d", i), ClientID: "client-1", ShareName: "share-a"},
+			FileHandle(handleKey), 0, 16, LockTypeExclusive)
+		require.NoError(t, mgr.AddUnifiedLock(handleKey, lock))
+	}
+
+	persisted, err := store.ListLocks(ctx, LockQuery{ShareName: "share-a"})
+	require.NoError(t, err)
+	require.Len(t, persisted, 32)
+
+	mgr.RemoveClientLocks("client-1")
+
+	persisted, err = store.ListLocks(ctx, LockQuery{ShareName: "share-a"})
+	require.NoError(t, err)
+	require.Empty(t, persisted, "client bulk delete must order after every per-file write")
+}
+
+// BenchmarkLockUnlock_StoreLatency measures byte-range lock+unlock on distinct
+// files — zero logical conflict — against lock stores of increasing round-trip
+// cost. It is the shape that showed the share-wide mutex serializing every
+// store round-trip: with the call inside lm.mu the result was flat across
+// GOMAXPROCS at roughly two round-trips per operation no matter how many
+// goroutines were pushing.
+func BenchmarkLockUnlock_StoreLatency(b *testing.B) {
+	for _, delay := range []time.Duration{0, 100 * time.Microsecond, time.Millisecond} {
+		b.Run(delay.String(), func(b *testing.B) {
+			store := newSlowLockStore(delay, delay)
+			mgr := NewManager()
+			mgr.SetLockStore(store)
+			mgr.SetShareName("bench")
+
+			var next atomic.Uint64
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				id := next.Add(1)
+				handleKey := fmt.Sprintf("bench:file-%d", id)
+				fl := benchFileLock(id, id, fmt.Sprintf("open-%d", id))
+				for pb.Next() {
+					if err := mgr.Lock(handleKey, fl); err != nil {
+						b.Fatal(err)
+					}
+					if err := mgr.Unlock(handleKey, fl.OpenID, fl.SessionID, fl.Offset, fl.Length); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		})
+	}
+}

--- a/pkg/metadata/lock/reclaim.go
+++ b/pkg/metadata/lock/reclaim.go
@@ -156,14 +156,14 @@ func (lm *Manager) reclaimLeaseImpl(ctx context.Context, leaseKey [16]byte,
 				existing.Lease.LeaseState = requestedState
 				existing.Type = lockTypeForLeaseState(requestedState)
 				existing.Reclaim = true
-				lm.mu.Unlock()
+				lm.unlock()
 				logger.Debug("ReclaimLease: lease already in memory, updated",
 					"leaseKey", fmt.Sprintf("%x", leaseKey))
 				return existing.Clone(), nil
 			}
 			lm.unifiedLocks[handleKey] = append(lm.unifiedLocks[handleKey], lock)
 			lm.indexAddLockLocked(handleKey, lock)
-			lm.mu.Unlock()
+			lm.unlock()
 
 			logger.Debug("ReclaimLease: lease reclaimed",
 				"leaseKey", fmt.Sprintf("%x", leaseKey),
@@ -178,7 +178,7 @@ func (lm *Manager) reclaimLeaseImpl(ctx context.Context, leaseKey [16]byte,
 
 	// No lockStore: try to find in memory (for testing without persistence)
 	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	defer lm.unlock()
 
 	_, existingLock, _ := lm.findLeaseByKey(leaseKey)
 	if existingLock != nil {

--- a/pkg/metadata/lock/reclaim.go
+++ b/pkg/metadata/lock/reclaim.go
@@ -146,6 +146,7 @@ func (lm *Manager) reclaimLeaseImpl(ctx context.Context, leaseKey [16]byte,
 			// Step 7: Restore in memory (idempotent: skip if already reclaimed)
 			lock := FromPersistedLock(pl)
 			lock.Lease.LeaseState = requestedState
+			lock.Type = lockTypeForLeaseState(requestedState)
 			lock.Reclaim = true
 
 			lm.mu.Lock()
@@ -153,6 +154,7 @@ func (lm *Manager) reclaimLeaseImpl(ctx context.Context, leaseKey [16]byte,
 			if _, existing, _ := lm.findLeaseByKey(leaseKey); existing != nil {
 				// Already reclaimed - update state and return existing
 				existing.Lease.LeaseState = requestedState
+				existing.Type = lockTypeForLeaseState(requestedState)
 				existing.Reclaim = true
 				lm.mu.Unlock()
 				logger.Debug("ReclaimLease: lease already in memory, updated",

--- a/pkg/metadata/lock/store.go
+++ b/pkg/metadata/lock/store.go
@@ -468,6 +468,12 @@ func FromPersistedLock(pl *PersistedLock) *UnifiedLock {
 			el.Lease.BreakToState &^= LeaseStateWrite
 			el.Lease.BreakingToRequired &^= LeaseStateWrite
 		}
+
+		// Type is a projection of LeaseState for a lease record. Derive it from
+		// the (possibly clamped) restored state rather than trusting the stored
+		// column, so a record written by a binary that left Type behind on a
+		// lease upgrade comes back consistent.
+		el.Type = lockTypeForLeaseState(el.Lease.LeaseState)
 	}
 
 	// Restore delegation fields if this is a delegation (DelegationID present)


### PR DESCRIPTION
Two defects in `pkg/metadata/lock/`, both validated against `develop` before any code was written.

## 1. A lease record persisted a lock type that contradicted its lease state

**Verdict: CONFIRMED, and worse than reported — three sites drift, not one.**

`UnifiedLock.Type` is meant to be a projection of `Lease.LeaseState` for a lease-bearing record: `createAndGrantLease`, the ack path and the break paths all re-derive it via `lockTypeForLeaseState`. Three sites changed `LeaseState` and did not:

- `leases.go` same-key upgrade arm (the one in the report) — an `R -> RW` or `RH -> RWH` upgrade advanced the epoch and the state, then persisted a record whose `Type` still said `LockTypeShared` while the lease carried the Write bit.
- `reclaim.go`, both narrowing sites — a reclaim at a state narrower than the persisted one left `Type` reporting the wider one.

`FromPersistedLock` restores `LockType` verbatim, so the stale value survives a restart. It also strips the Write bit from a directory lease on ingestion without touching `Type`, which manufactures the same inconsistency from a legacy record.

**Reachability: inert today, and the report's two open questions both resolve.** Nothing reads `Type` on a lease-bearing record. Lease-to-lease conflict goes through `OpLocksConflict` on the `Lease` (`types.go:315`); the lease-vs-byte-range arm reads `IsExclusive()` on the *byte-range* side only; and every byte-range consumer guards with `IsLease()`/`IsDelegation()` first (`fileLockConflictsWithUnified`, `unifiedLockBlocksIO`, `CheckNLMLocksForLeaseConflict`). The one unguarded reader is `UpgradeLock` (`byterange.go:271`), which has no production callers. So this is a silent inconsistency in persisted metadata rather than a live bug — which is what the report claimed.

**Fix.** Derive rather than keep call sites in sync, as the report suggested. `persistUnifiedLockLocked` re-derives `Type` for a lease record on the way to the store, so no mutation can write out a contradictory record; `FromPersistedLock` derives it again after the directory clamp, so records written by an older binary come back consistent. The two reclaim sites set it directly because they do not persist. Byte-range and delegation records keep owning their `Type`.

`TestRequestLease_UpgradePersistsDerivedLockType` fails on `develop` (`LockType 0`, expected `1`) and passes here.

## 2. The lock store round-trip ran inside the share-wide mutex

**Verdict: CONFIRMED and measured.** This is the `pkg/metadata/lock/manager.go` half of the structure finding. Byte-range lock+unlock on **distinct** files — zero logical conflict, so any flattening is pure mutex — against stores of increasing round-trip cost, Apple M1 Max, `benchtime=300x`:

| store latency | before, 1 core | before, 8 cores | after, 1 core | after, 8 cores |
|---|---|---|---|---|
| 0 | 1514 ns | 1725 ns | 1476 ns | 2131 ns |
| 100 µs | 262 µs | 281 µs | 252 µs | **32.8 µs** |
| 1 ms | 2.322 ms | 2.364 ms | 2.311 ms | **294 µs** |

Before, the line is flat: eight goroutines on eight different files went no faster than one, because each was queued on `lm.mu` behind somebody else's network call. That is ~430 lock operations per second **share-wide**, independent of client count and core count, and it covers the SMB open path (`createAndGrantLease`, the break stages, ack and release) as well as explicit locking. All four backends implement `lock.LockStore`, so this is on for every real share.

**Fix: the ordering moves from the mutex onto tickets.** `putLockLocked` used to be documented as "mutex order == store order", and that ordering is load-bearing — it is what stops a `DeleteLock` from overtaking the `PutLock` it undoes and resurrecting a released lock. It is preserved, not dropped:

- Under `lm.mu`, a mutation applies to the in-memory maps as before, then takes a ticket on one of 16 lanes (files hash to a lane) and queues its store call as a closure. Ticket issue is under `lm.mu`, so per lane the tickets are in mutex order.
- `Manager.unlock()` releases `lm.mu` and then runs that critical section's queued calls, on the caller's goroutine, each waiting for its lane's predecessor to retire. So per file the store still observes mutations in exactly the order `lm.mu` applied them, and **the caller does not return until its own writes reached the store** — persistence stays synchronous with respect to the client. What changes is only that two different files' round-trips overlap.
- A client-wide bulk delete is not scoped to one file, so it takes a ticket on every lane and acts as a barrier in both directions.
- `releaseLeaseForHandleImpl` reports its delete error to its caller, which it can still do without an inline store call: the locked work moves into its own function, so the queued deletes run inside that function's deferred unlock, on the same goroutine, and the collected errors are complete by the time the wrapper reads them. Nothing calls the store under `lm.mu` any more.

Deadlock-freedom: tickets are issued under `lm.mu`, so if critical section A precedes B then A's ticket precedes B's on every lane they share. An op only ever waits on a strictly earlier ticket, and "earlier" is the total order `lm.mu` already imposed, so the wait-for graph cannot cycle.

Mechanically, every `lm.mu.Unlock()` on a write acquisition becomes `lm.unlock()`; read acquisitions never enqueue and are untouched.

Three tests pin the contract that the benchmark cannot: a write is in the store before the acquiring call returns; a delete never lands before the put it undoes (same file, `PutLock` far slower than `DeleteLock`, so an unordered flush leaves an orphan); and the client-wide delete orders against per-file writes across lanes.

`go test -race ./pkg/metadata/... ./internal/adapter/... ./pkg/adapter/...` is green, as is `go test ./...`.

## What is deliberately not in this PR

The other half of #2029 — `pkg/metadata/service.go` as a god object — was measured and is not a problem worth a diff. 128 `Service` receivers exist but only ~20 touch `s.mu`, the hot path serves from a lock-free `storeCache`, and the one genuine `s.mu` read on the write path benchmarks at 77.1 ns against a 44.6 ns `sync.Map` control — under 0.1% of an operation that costs tens of microseconds. Splitting it would have to move `removeGen`, `lockManagers` and `graceCoordinator` across the same seam, which is the lock-ownership redesign the audit deferred. Left alone.

Striping `lm.mu` itself is also still open: the 7 remaining cross-bucket traversals need atomicity across N handle buckets plus the two reverse indexes. This PR takes the store round-trip out from under the mutex, which is where the measured cost was; the in-memory map contention was never the problem (sub-microsecond, ~1.3M lock ops/s at 8 cores).

Closes #2024
