### PR TITLE
feat(dfsctl): repair the recoverable manifest damage store check reports

### DIFF
--- a/cmd/dfsctl/commands/store/check.go
+++ b/cmd/dfsctl/commands/store/check.go
@@ -141,8 +141,11 @@ func runStoreCheck(_ *cobra.Command, args []string) error {
 			if format == output.FormatTable {
 				printRepairOutcome(results)
 			}
-		} else if applied, err = confirmAndRepair(client, shareNames, format, results); err != nil {
-			return err
+		} else {
+			applied, err = confirmAndRepair(client, shareNames, format, results)
+			if err != nil {
+				return err
+			}
 		}
 		if applied {
 			// Re-scan read-only so the verdict below describes the store as
@@ -295,18 +298,18 @@ func printCheckTables(results []*engine.ManifestCheckResult) error {
 // findings joined into a single cell so a wide store still reads as a table.
 func printCheckDetail(r *engine.ManifestCheckResult) error {
 	table := output.NewTableData("PATH", "SIZE", "FINDINGS")
-	var listed int
+	var listed bool
 	for i := range r.Findings {
 		f := &r.Findings[i]
 		notes := checkFindingNotes(f)
 		if len(notes) == 0 {
 			continue
 		}
-		listed++
+		listed = true
 		table.AddRow(f.Path, fmt.Sprintf("%d", f.Size), strings.Join(notes, "; "))
 	}
 
-	if listed == 0 {
+	if !listed {
 		if r.UncoveredRanges > r.ClaimedUncoveredRanges && !checkIncludeHoles {
 			fmt.Println()
 			fmt.Println("No damage found. Uncovered ranges no file claims were not listed; pass --include-holes to see them.")
@@ -365,7 +368,7 @@ func checkFindingNotes(f *engine.PayloadFinding) []string {
 // printRepairPlan lists the writes a repair run would make for one share, so
 // the operator sees every row before answering the prompt.
 func printRepairPlan(r *engine.ManifestCheckResult) error {
-	if len(r.Repairs) == 0 || r.RepairsApplied+r.RepairsSkipped > 0 {
+	if len(r.Repairs) == 0 || repairRunWrote(r) {
 		// Nothing planned, or the run already wrote — printRepairOutcome
 		// reports what a run that wrote actually did.
 		return nil
@@ -391,11 +394,18 @@ func printRepairPlan(r *engine.ManifestCheckResult) error {
 // repairSummary renders one share's repair counters, reading as a plan before
 // the writes and as an outcome after them.
 func repairSummary(r *engine.ManifestCheckResult) string {
-	if r.RepairsApplied+r.RepairsSkipped == 0 {
+	if !repairRunWrote(r) {
 		return fmt.Sprintf("%d planned", r.RepairsPlanned)
 	}
 	return fmt.Sprintf("%d planned, %d applied, %d skipped",
 		r.RepairsPlanned, r.RepairsApplied, r.RepairsSkipped)
+}
+
+// repairRunWrote reports whether this result came from a pass that wrote,
+// as opposed to one that only planned. Every action of a pass that wrote is
+// either applied or skipped, so the two counters are zero only before it ran.
+func repairRunWrote(r *engine.ManifestCheckResult) bool {
+	return r.RepairsApplied+r.RepairsSkipped > 0
 }
 
 // repairActionLabel names a repair kind in the words the help text uses.

--- a/cmd/dfsctl/commands/store/check.go
+++ b/cmd/dfsctl/commands/store/check.go
@@ -218,16 +218,19 @@ func confirmAndRepair(
 	for _, r := range planned {
 		total += r.RepairsPlanned
 	}
+	if format != output.FormatTable {
+		// Neither a prompt nor a note may land in the middle of the
+		// machine-readable document the caller just received.
+		if total == 0 {
+			return false, nil
+		}
+		return false, fmt.Errorf("nothing written: %d repair(s) planned, re-run with --yes to apply them", total)
+	}
+
 	if total == 0 {
 		fmt.Println()
 		fmt.Println("Nothing to repair: no finding carries the evidence needed to put a row back.")
 		return false, nil
-	}
-
-	if format != output.FormatTable {
-		// The prompt would land in the middle of the machine-readable
-		// document the caller just received.
-		return false, fmt.Errorf("nothing written: %d repair(s) planned, re-run with --yes to apply them", total)
 	}
 
 	prompt := fmt.Sprintf("Apply %d manifest repair(s)? This writes to the metadata store.", total)

--- a/cmd/dfsctl/commands/store/check.go
+++ b/cmd/dfsctl/commands/store/check.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/marmos91/dittofs/cmd/dfsctl/cmdutil"
 	"github.com/marmos91/dittofs/internal/cli/output"
+	"github.com/marmos91/dittofs/pkg/apiclient"
 	"github.com/marmos91/dittofs/pkg/block/engine"
 )
 
@@ -16,6 +17,13 @@ import (
 // table. They are always counted in the summary; they are off by default in
 // the detail because a sparse file legitimately has them.
 var checkIncludeHoles bool
+
+// checkRepair turns the scan into a repair run, and checkRepairYes skips the
+// confirmation. Without --yes the run is a dry run that ends at the prompt.
+var (
+	checkRepair    bool
+	checkRepairYes bool
+)
 
 var checkCmd = &cobra.Command{
 	Use:   "check [share]",
@@ -45,6 +53,25 @@ manifest, so it is counted separately and never fails the command. Pass
 The unknown-hash check is skipped on a share with no remote store: nothing is
 ever marked synced there, so every row would be reported.
 
+--repair adds a second half: for every finding, work out whether the store
+holds enough evidence to put the manifest back, list what that would take, and
+apply it once you confirm. Nothing is written before the prompt, so --repair on
+its own is a dry run; --yes answers the prompt for scripted use. Only two kinds
+of finding are repairable, and both restore a row the file already claims:
+
+  * a row with no parseable offset whose hash and length match exactly one
+    range the file claims and no row covers — the row is moved to that offset,
+    keeping everything else about it
+  * a range the file claims that no row covers, whose hash the synced-hash
+    store resolves — a row is written for it, and the remote already holds the
+    bytes it names
+
+A repair only ever adds coverage the file already asked for. It never drops a
+row, never widens or narrows a claim, and never marks a hash synced. Findings
+it cannot pair with that evidence — a row matching no claim, a claim whose hash
+nothing resolves, a hash the synced-hash store does not know — are reported and
+left alone: those need the bytes re-synced, not the metadata rewritten.
+
 With no argument every share is scanned. The command exits non-zero when
 damage is found, so it can be scripted (` + "`dfsctl store check || alert`" + `).
 
@@ -52,7 +79,9 @@ Examples:
   dfsctl store check
   dfsctl store check myshare
   dfsctl store check myshare --include-holes
-  dfsctl store check myshare -o json`,
+  dfsctl store check myshare -o json
+  dfsctl store check myshare --repair
+  dfsctl store check myshare --repair --yes`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runStoreCheck,
 }
@@ -60,6 +89,10 @@ Examples:
 func init() {
 	checkCmd.Flags().BoolVar(&checkIncludeHoles, "include-holes", false,
 		"list uncovered ranges that no file claims (legitimate for sparse files)")
+	checkCmd.Flags().BoolVar(&checkRepair, "repair", false,
+		"list the findings the store can put back, and apply them once confirmed")
+	checkCmd.Flags().BoolVar(&checkRepairYes, "yes", false,
+		"Skip confirmation prompt")
 }
 
 func runStoreCheck(_ *cobra.Command, args []string) error {
@@ -82,32 +115,49 @@ func runStoreCheck(_ *cobra.Command, args []string) error {
 		}
 	}
 
-	results := make([]*engine.ManifestCheckResult, 0, len(shareNames))
-	for _, name := range shareNames {
-		res, err := client.BlockStoreCheckManifests(name)
-		if err != nil {
-			return fmt.Errorf("failed to check share %q: %w", name, err)
-		}
-		if res == nil || res.Result == nil {
-			return fmt.Errorf("store check for share %q returned no result", name)
-		}
-		results = append(results, res.Result)
-	}
-
 	format, err := cmdutil.GetOutputFormatParsed()
 	if err != nil {
 		return err
 	}
-	switch format {
-	case output.FormatJSON:
-		err = output.PrintJSON(os.Stdout, results)
-	case output.FormatYAML:
-		err = output.PrintYAML(os.Stdout, results)
-	default:
-		err = printCheckTables(results)
+
+	// With --yes there is nothing to confirm, so the first pass is already
+	// the repair pass. Without it the first pass only plans, and the prompt
+	// decides whether a second one writes.
+	opts := apiclient.BlockStoreManifestCheckOptions{
+		PlanRepairs:  checkRepair,
+		ApplyRepairs: checkRepair && checkRepairYes,
 	}
+	results, err := scanShares(client, shareNames, opts)
 	if err != nil {
 		return err
+	}
+	if err := printCheckResults(results, format); err != nil {
+		return err
+	}
+
+	if checkRepair {
+		applied := opts.ApplyRepairs
+		if applied {
+			if format == output.FormatTable {
+				printRepairOutcome(results)
+			}
+		} else if applied, err = confirmAndRepair(client, shareNames, format, results); err != nil {
+			return err
+		}
+		if applied {
+			// Re-scan read-only so the verdict below describes the store as
+			// it stands now, not as the repair pass found it.
+			if results, err = scanShares(client, shareNames, apiclient.BlockStoreManifestCheckOptions{}); err != nil {
+				return err
+			}
+			if format == output.FormatTable {
+				fmt.Println()
+				fmt.Println("Store as it stands after the repair:")
+			}
+			if err := printCheckResults(results, format); err != nil {
+				return err
+			}
+		}
 	}
 
 	var damaged int
@@ -120,6 +170,82 @@ func runStoreCheck(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("manifest damage found on %d of %d share(s)", damaged, len(results))
 	}
 	return nil
+}
+
+// scanShares runs one scan per share with the same options.
+func scanShares(
+	client *apiclient.Client,
+	shareNames []string,
+	opts apiclient.BlockStoreManifestCheckOptions,
+) ([]*engine.ManifestCheckResult, error) {
+	results := make([]*engine.ManifestCheckResult, 0, len(shareNames))
+	for _, name := range shareNames {
+		res, err := client.BlockStoreCheckManifests(name, opts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check share %q: %w", name, err)
+		}
+		if res == nil || res.Result == nil {
+			return nil, fmt.Errorf("store check for share %q returned no result", name)
+		}
+		results = append(results, res.Result)
+	}
+	return results, nil
+}
+
+func printCheckResults(results []*engine.ManifestCheckResult, format output.Format) error {
+	switch format {
+	case output.FormatJSON:
+		return output.PrintJSON(os.Stdout, results)
+	case output.FormatYAML:
+		return output.PrintYAML(os.Stdout, results)
+	default:
+		return printCheckTables(results)
+	}
+}
+
+// confirmAndRepair prompts for the plan the dry run just printed and, on a
+// yes, runs the scan again with the writes enabled. Reports whether it wrote.
+func confirmAndRepair(
+	client *apiclient.Client,
+	shareNames []string,
+	format output.Format,
+	planned []*engine.ManifestCheckResult,
+) (bool, error) {
+	var total uint64
+	for _, r := range planned {
+		total += r.RepairsPlanned
+	}
+	if total == 0 {
+		fmt.Println()
+		fmt.Println("Nothing to repair: no finding carries the evidence needed to put a row back.")
+		return false, nil
+	}
+
+	if format != output.FormatTable {
+		// The prompt would land in the middle of the machine-readable
+		// document the caller just received.
+		return false, fmt.Errorf("nothing written: %d repair(s) planned, re-run with --yes to apply them", total)
+	}
+
+	prompt := fmt.Sprintf("Apply %d manifest repair(s)? This writes to the metadata store.", total)
+	ok, err := cmdutil.ConfirmDestructive(prompt, false)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		fmt.Println("Aborted. Nothing was written.")
+		return false, nil
+	}
+
+	applied, err := scanShares(client, shareNames, apiclient.BlockStoreManifestCheckOptions{
+		PlanRepairs:  true,
+		ApplyRepairs: true,
+	})
+	if err != nil {
+		return false, err
+	}
+	printRepairOutcome(applied)
+	return true, nil
 }
 
 // printCheckTables renders a summary per share followed by the per-payload
@@ -149,10 +275,16 @@ func printCheckTables(results []*engine.ManifestCheckResult) error {
 			{"Unplaceable rows", fmt.Sprintf("%d", r.UnplaceableRows)},
 			{"Rows with unknown hash", unknown},
 		}
+		if r.RepairsPlanned > 0 {
+			pairs = append(pairs, [2]string{"Repairs", repairSummary(r)})
+		}
 		if err := output.SimpleTable(os.Stdout, pairs); err != nil {
 			return err
 		}
 		if err := printCheckDetail(r); err != nil {
+			return err
+		}
+		if err := printRepairPlan(r); err != nil {
 			return err
 		}
 	}
@@ -228,4 +360,86 @@ func checkFindingNotes(f *engine.PayloadFinding) []string {
 		notes = append(notes, "damaged; detail truncated")
 	}
 	return notes
+}
+
+// printRepairPlan lists the writes a repair run would make for one share, so
+// the operator sees every row before answering the prompt.
+func printRepairPlan(r *engine.ManifestCheckResult) error {
+	if len(r.Repairs) == 0 || r.RepairsApplied+r.RepairsSkipped > 0 {
+		// Nothing planned, or the run already wrote — printRepairOutcome
+		// reports what a run that wrote actually did.
+		return nil
+	}
+	table := output.NewTableData("PATH", "ACTION", "RANGE", "ROW")
+	for i := range r.Repairs {
+		a := &r.Repairs[i]
+		table.AddRow(a.Path, repairActionLabel(a.Kind),
+			fmt.Sprintf("[%d,%d)", a.Offset, a.Offset+uint64(a.Size)),
+			repairRowNote(a))
+	}
+	fmt.Println()
+	if err := output.PrintTable(os.Stdout, table); err != nil {
+		return err
+	}
+	if r.RepairsTruncated {
+		fmt.Println()
+		fmt.Println("Repair plan truncated; re-run after applying these to see the rest.")
+	}
+	return nil
+}
+
+// repairSummary renders one share's repair counters, reading as a plan before
+// the writes and as an outcome after them.
+func repairSummary(r *engine.ManifestCheckResult) string {
+	if r.RepairsApplied+r.RepairsSkipped == 0 {
+		return fmt.Sprintf("%d planned", r.RepairsPlanned)
+	}
+	return fmt.Sprintf("%d planned, %d applied, %d skipped",
+		r.RepairsPlanned, r.RepairsApplied, r.RepairsSkipped)
+}
+
+// repairActionLabel names a repair kind in the words the help text uses.
+func repairActionLabel(k engine.RepairKind) string {
+	switch k {
+	case engine.RepairReplaceRow:
+		return "move row to offset"
+	case engine.RepairRecreateRow:
+		return "write row for claim"
+	default:
+		return string(k)
+	}
+}
+
+// repairRowNote renders the manifest keys one action touches.
+func repairRowNote(a *engine.RepairAction) string {
+	if a.FromRowID != "" {
+		return a.FromRowID + " -> " + a.ToRowID
+	}
+	return a.ToRowID
+}
+
+// printRepairOutcome reports what a repair pass wrote, naming every action it
+// declined so a skipped repair is never mistaken for a done one.
+func printRepairOutcome(results []*engine.ManifestCheckResult) {
+	var applied, skipped uint64
+	for _, r := range results {
+		applied += r.RepairsApplied
+		skipped += r.RepairsSkipped
+	}
+	fmt.Println()
+	fmt.Printf("Applied %d repair(s), skipped %d.\n", applied, skipped)
+	if skipped == 0 {
+		return
+	}
+	fmt.Println("A skipped repair is one whose evidence changed between the scan and the write;")
+	fmt.Println("the store moved under it and nothing was forced. Re-run to pick it up again.")
+	for _, r := range results {
+		for i := range r.Repairs {
+			a := &r.Repairs[i]
+			if a.Applied || a.SkipReason == "" {
+				continue
+			}
+			fmt.Printf("  %s [%d,%d): %s\n", a.Path, a.Offset, a.Offset+uint64(a.Size), a.SkipReason)
+		}
+	}
 }

--- a/cmd/dfsctl/commands/store/check_test.go
+++ b/cmd/dfsctl/commands/store/check_test.go
@@ -458,6 +458,33 @@ func TestCheckCmd_RepairRefusesToPromptIntoMachineOutput(t *testing.T) {
 	}
 }
 
+// TestCheckCmd_RepairKeepsMachineOutputClean asserts that with a
+// machine-readable format nothing human-readable is printed after the
+// document, including the note for a run with nothing to repair.
+func TestCheckCmd_RepairKeepsMachineOutputClean(t *testing.T) {
+	s := newCheckServer(t)
+	s.results["myshare"] = damagedResult()
+	withCheckTestServer(t, s.URL)
+	cmdutil.Flags.Output = "json"
+	checkRepair = true
+
+	var runErr error
+	out := captureStdoutCheck(t, func() {
+		runErr = runStoreCheck(checkCmd, []string{"myshare"})
+	})
+
+	if runErr == nil {
+		t.Fatal("unrepaired damage must still exit non-zero")
+	}
+	if strings.Contains(out, "Nothing to repair") {
+		t.Errorf("human text landed in the JSON document: %q", out)
+	}
+	var decoded []*engine.ManifestCheckResult
+	if err := json.Unmarshal([]byte(out), &decoded); err != nil {
+		t.Fatalf("stdout is not a JSON document: %v (got %q)", err, out)
+	}
+}
+
 // TestCheckCmd_RepairWithNothingToRepair asserts damage the command cannot
 // prove repairable stops before the prompt and still exits non-zero.
 func TestCheckCmd_RepairWithNothingToRepair(t *testing.T) {

--- a/cmd/dfsctl/commands/store/check_test.go
+++ b/cmd/dfsctl/commands/store/check_test.go
@@ -19,9 +19,15 @@ import (
 // exercised.
 type checkServer struct {
 	*httptest.Server
-	paths   []string
-	shares  []apiclient.Share
+	paths  []string
+	shares []apiclient.Share
+	// opts records the repair switches of every scan request in order, so a
+	// test can assert what the command asked the server to do.
+	opts    []apiclient.BlockStoreManifestCheckOptions
 	results map[string]*engine.ManifestCheckResult
+	// respond overrides results when set, so a test can answer the plan, the
+	// apply and the re-scan differently within one run.
+	respond func(name string, opts apiclient.BlockStoreManifestCheckOptions) *engine.ManifestCheckResult
 }
 
 func newCheckServer(t *testing.T) *checkServer {
@@ -36,7 +42,17 @@ func newCheckServer(t *testing.T) *checkServer {
 			return
 		}
 		name := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v1/shares/"), "/audit/manifest")
-		res, ok := s.results[name]
+		var opts apiclient.BlockStoreManifestCheckOptions
+		_ = json.NewDecoder(r.Body).Decode(&opts)
+		s.opts = append(s.opts, opts)
+		var res *engine.ManifestCheckResult
+		ok := false
+		if s.respond != nil {
+			res = s.respond(name, opts)
+			ok = res != nil
+		} else {
+			res, ok = s.results[name]
+		}
 		if r.Method != http.MethodPost || !ok {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -50,7 +66,7 @@ func newCheckServer(t *testing.T) *checkServer {
 func withCheckTestServer(t *testing.T, url string) {
 	t.Helper()
 	origServer, origToken, origOutput := cmdutil.Flags.ServerURL, cmdutil.Flags.Token, cmdutil.Flags.Output
-	origHoles := checkIncludeHoles
+	origHoles, origRepair, origYes := checkIncludeHoles, checkRepair, checkRepairYes
 	cmdutil.Flags.ServerURL = url
 	cmdutil.Flags.Token = "test-token"
 	cmdutil.Flags.Output = "table"
@@ -58,7 +74,7 @@ func withCheckTestServer(t *testing.T, url string) {
 		cmdutil.Flags.ServerURL = origServer
 		cmdutil.Flags.Token = origToken
 		cmdutil.Flags.Output = origOutput
-		checkIncludeHoles = origHoles
+		checkIncludeHoles, checkRepair, checkRepairYes = origHoles, origRepair, origYes
 	})
 }
 
@@ -275,5 +291,193 @@ func TestCheckCmd_SkipReasonDistinguishesCases(t *testing.T) {
 		if !strings.Contains(out, "not checked ("+reason+")") {
 			t.Errorf("output must name the skip reason %q; got %q", reason, out)
 		}
+	}
+}
+
+// repairPlanResult is the damaged share with one repairable finding: a claimed
+// range whose hash the remote resolves.
+func repairPlanResult() *engine.ManifestCheckResult {
+	r := damagedResult()
+	r.RepairsPlanned = 1
+	r.Repairs = []engine.RepairAction{{
+		Kind:      engine.RepairRecreateRow,
+		Path:      "/docs/report.pdf",
+		PayloadID: "payload-1",
+		Offset:    0,
+		Size:      4096,
+		ToRowID:   "payload-1/0",
+	}}
+	return r
+}
+
+// repairStages answers a whole --repair run: the plan, then the apply, then the
+// read-only re-scan that reports the store as it now stands.
+func repairStages() func(string, apiclient.BlockStoreManifestCheckOptions) *engine.ManifestCheckResult {
+	return func(_ string, opts apiclient.BlockStoreManifestCheckOptions) *engine.ManifestCheckResult {
+		switch {
+		case opts.ApplyRepairs:
+			r := repairPlanResult()
+			r.RepairsApplied = 1
+			r.Repairs[0].Applied = true
+			return r
+		case opts.PlanRepairs:
+			return repairPlanResult()
+		default:
+			return &engine.ManifestCheckResult{Share: "myshare", FilesScanned: 42, SyncedHashesChecked: true}
+		}
+	}
+}
+
+// withConfirmAnswer feeds the confirmation prompt and keeps its output out of
+// the captured stdout the assertions read.
+func withConfirmAnswer(t *testing.T, answer string) {
+	t.Helper()
+	origIn, origOut := cmdutil.ConfirmInput, cmdutil.ConfirmOutput
+	cmdutil.ConfirmInput = strings.NewReader(answer + "\n")
+	cmdutil.ConfirmOutput = io.Discard
+	t.Cleanup(func() {
+		cmdutil.ConfirmInput = origIn
+		cmdutil.ConfirmOutput = origOut
+	})
+}
+
+// TestCheckCmd_RepairIsDryRunUntilConfirmed pins the safety property of the
+// flag: --repair on its own asks the server to plan and nothing else, and a
+// refused prompt leaves the store untouched.
+func TestCheckCmd_RepairIsDryRunUntilConfirmed(t *testing.T) {
+	s := newCheckServer(t)
+	s.respond = repairStages()
+	withCheckTestServer(t, s.URL)
+	withConfirmAnswer(t, "n")
+	checkRepair = true
+
+	var runErr error
+	out := captureStdoutCheck(t, func() {
+		runErr = runStoreCheck(checkCmd, []string{"myshare"})
+	})
+
+	if len(s.opts) != 1 {
+		t.Fatalf("want a single scan, got %d: %+v", len(s.opts), s.opts)
+	}
+	if s.opts[0].ApplyRepairs || !s.opts[0].PlanRepairs {
+		t.Fatalf("dry run asked the server to write: %+v", s.opts[0])
+	}
+	if runErr == nil {
+		t.Fatal("unrepaired damage must still exit non-zero")
+	}
+	for _, frag := range []string{"write row for claim", "payload-1/0", "Aborted"} {
+		if !strings.Contains(out, frag) {
+			t.Errorf("stdout missing %q, got %q", frag, out)
+		}
+	}
+}
+
+// TestCheckCmd_RepairAppliesOnConfirm asserts a confirmed run writes once and
+// then re-reads the store, so the verdict it prints and the exit code it
+// returns describe the store after the repair rather than before it.
+func TestCheckCmd_RepairAppliesOnConfirm(t *testing.T) {
+	s := newCheckServer(t)
+	s.respond = repairStages()
+	withCheckTestServer(t, s.URL)
+	withConfirmAnswer(t, "y")
+	checkRepair = true
+
+	var runErr error
+	out := captureStdoutCheck(t, func() {
+		runErr = runStoreCheck(checkCmd, []string{"myshare"})
+	})
+
+	if len(s.opts) != 3 {
+		t.Fatalf("want plan, apply and re-scan, got %+v", s.opts)
+	}
+	if s.opts[0].ApplyRepairs {
+		t.Fatalf("the planning scan wrote: %+v", s.opts[0])
+	}
+	if !s.opts[1].ApplyRepairs {
+		t.Fatalf("the confirmed scan did not write: %+v", s.opts[1])
+	}
+	if s.opts[2].PlanRepairs || s.opts[2].ApplyRepairs {
+		t.Fatalf("the verifying re-scan was not read-only: %+v", s.opts[2])
+	}
+	if runErr != nil {
+		t.Fatalf("a fully repaired store must exit zero, got %v", runErr)
+	}
+	for _, frag := range []string{"Applied 1 repair(s), skipped 0", "Store as it stands after the repair"} {
+		if !strings.Contains(out, frag) {
+			t.Errorf("stdout missing %q, got %q", frag, out)
+		}
+	}
+}
+
+// TestCheckCmd_RepairYesSkipsThePrompt asserts --yes writes on the first scan
+// without reading the prompt at all.
+func TestCheckCmd_RepairYesSkipsThePrompt(t *testing.T) {
+	s := newCheckServer(t)
+	s.respond = repairStages()
+	withCheckTestServer(t, s.URL)
+	// Any read of the prompt would block on an empty reader.
+	withConfirmAnswer(t, "")
+	checkRepair, checkRepairYes = true, true
+
+	var runErr error
+	out := captureStdoutCheck(t, func() {
+		runErr = runStoreCheck(checkCmd, []string{"myshare"})
+	})
+
+	if len(s.opts) != 2 || !s.opts[0].ApplyRepairs {
+		t.Fatalf("want an immediate apply then a re-scan, got %+v", s.opts)
+	}
+	if runErr != nil {
+		t.Fatalf("a fully repaired store must exit zero, got %v", runErr)
+	}
+	if !strings.Contains(out, "Applied 1 repair(s)") {
+		t.Errorf("stdout missing the outcome, got %q", out)
+	}
+}
+
+// TestCheckCmd_RepairRefusesToPromptIntoMachineOutput asserts that with a
+// machine-readable format the run stops at the plan rather than printing a
+// prompt into the middle of the document.
+func TestCheckCmd_RepairRefusesToPromptIntoMachineOutput(t *testing.T) {
+	s := newCheckServer(t)
+	s.respond = repairStages()
+	withCheckTestServer(t, s.URL)
+	cmdutil.Flags.Output = "json"
+	checkRepair = true
+
+	var runErr error
+	captureStdoutCheck(t, func() {
+		runErr = runStoreCheck(checkCmd, []string{"myshare"})
+	})
+
+	if len(s.opts) != 1 || s.opts[0].ApplyRepairs {
+		t.Fatalf("machine output must not write, got %+v", s.opts)
+	}
+	if runErr == nil || !strings.Contains(runErr.Error(), "--yes") {
+		t.Fatalf("error = %v, want one naming --yes", runErr)
+	}
+}
+
+// TestCheckCmd_RepairWithNothingToRepair asserts damage the command cannot
+// prove repairable stops before the prompt and still exits non-zero.
+func TestCheckCmd_RepairWithNothingToRepair(t *testing.T) {
+	s := newCheckServer(t)
+	s.results["myshare"] = damagedResult()
+	withCheckTestServer(t, s.URL)
+	checkRepair = true
+
+	var runErr error
+	out := captureStdoutCheck(t, func() {
+		runErr = runStoreCheck(checkCmd, []string{"myshare"})
+	})
+
+	if len(s.opts) != 1 {
+		t.Fatalf("want a single scan, got %+v", s.opts)
+	}
+	if runErr == nil {
+		t.Fatal("unrepairable damage must still exit non-zero")
+	}
+	if !strings.Contains(out, "Nothing to repair") {
+		t.Errorf("stdout missing the nothing-to-repair note, got %q", out)
 	}
 }

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -6443,6 +6443,27 @@ manifest, so it is counted separately and never fails the command. Pass
 The unknown-hash check is skipped on a share with no remote store: nothing is
 ever marked synced there, so every row would be reported.
 
+--repair adds a second half: for every finding, work out whether the store
+holds enough evidence to put the manifest back, list what that would take, and
+apply it once you confirm. Nothing is written before the prompt, so --repair on
+its own is a dry run; --yes answers the prompt for scripted use. Only two kinds
+of finding are repairable, and both restore a row the file already claims:
+
+```
+* a row with no parseable offset whose hash and length match exactly one
+  range the file claims and no row covers — the row is moved to that offset,
+  keeping everything else about it
+* a range the file claims that no row covers, whose hash the synced-hash
+  store resolves — a row is written for it, and the remote already holds the
+  bytes it names
+```
+
+A repair only ever adds coverage the file already asked for. It never drops a
+row, never widens or narrows a claim, and never marks a hash synced. Findings
+it cannot pair with that evidence — a row matching no claim, a claim whose hash
+nothing resolves, a hash the synced-hash store does not know — are reported and
+left alone: those need the bytes re-synced, not the metadata rewritten.
+
 With no argument every share is scanned. The command exits non-zero when
 damage is found, so it can be scripted (`dfsctl store check || alert`).
 
@@ -6457,12 +6478,16 @@ dfsctl store check
 dfsctl store check myshare
 dfsctl store check myshare --include-holes
 dfsctl store check myshare -o json
+dfsctl store check myshare --repair
+dfsctl store check myshare --repair --yes
 ```
 
 Flags:
 
 ```
       --include-holes   list uncovered ranges that no file claims (legitimate for sparse files)
+      --repair          list the findings the store can put back, and apply them once confirmed
+      --yes             Skip confirmation prompt
 ```
 
 Global flags:

--- a/internal/controlplane/api/handlers/blockstore_manifest_check.go
+++ b/internal/controlplane/api/handlers/blockstore_manifest_check.go
@@ -2,7 +2,9 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -16,9 +18,9 @@ import (
 // BlockStoreManifestCheckHandler, defined here so the handler can be unit
 // tested against a fake rather than a whole *runtime.Runtime.
 type ManifestCheckRuntime interface {
-	// CheckManifests runs the metadata-only manifest-coverage scan for the
-	// named share.
-	CheckManifests(ctx context.Context, shareName string) (*engine.ManifestCheckResult, error)
+	// CheckManifests runs the manifest-coverage scan for the named share,
+	// planning and applying repairs as opts asks.
+	CheckManifests(ctx context.Context, shareName string, opts engine.ManifestCheckOptions) (*engine.ManifestCheckResult, error)
 }
 
 // BlockStoreManifestCheckHandler exposes the on-demand manifest-coverage scan.
@@ -37,6 +39,18 @@ func NewBlockStoreManifestCheckHandler(rt ManifestCheckRuntime) *BlockStoreManif
 // output. Returned by POST /api/v1/shares/{name}/audit/manifest.
 type BlockStoreManifestCheckResponse struct {
 	Result *engine.ManifestCheckResult `json:"result"`
+}
+
+// BlockStoreManifestCheckRequest is the optional body of
+// POST /api/v1/shares/{name}/audit/manifest. An absent or empty body keeps the
+// scan read-only, so a caller written before repairs existed cannot start one.
+type BlockStoreManifestCheckRequest struct {
+	// PlanRepairs reports which findings the scan has evidence to repair,
+	// writing nothing.
+	PlanRepairs bool `json:"plan_repairs,omitempty"`
+
+	// ApplyRepairs writes those repairs. It implies PlanRepairs.
+	ApplyRepairs bool `json:"apply_repairs,omitempty"`
 }
 
 // RunManifestCheck handles POST /api/v1/shares/{name}/audit/manifest.
@@ -62,7 +76,16 @@ func (h *BlockStoreManifestCheckHandler) RunManifestCheck(w http.ResponseWriter,
 		return
 	}
 
-	res, err := h.runtime.CheckManifests(r.Context(), name)
+	var req BlockStoreManifestCheckRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		BadRequest(w, "invalid request body")
+		return
+	}
+
+	res, err := h.runtime.CheckManifests(r.Context(), name, engine.ManifestCheckOptions{
+		PlanRepairs:  req.PlanRepairs || req.ApplyRepairs,
+		ApplyRepairs: req.ApplyRepairs,
+	})
 	if err != nil {
 		if errors.Is(err, shares.ErrShareNotFound) {
 			NotFound(w, "share not found: "+name)
@@ -82,6 +105,9 @@ func (h *BlockStoreManifestCheckHandler) RunManifestCheck(w http.ResponseWriter,
 		"claimed_uncovered_bytes", res.ClaimedUncoveredBytes,
 		"unplaceable_rows", res.UnplaceableRows,
 		"unknown_hash_rows", res.UnknownHashRows,
+		"repairs_planned", res.RepairsPlanned,
+		"repairs_applied", res.RepairsApplied,
+		"repairs_skipped", res.RepairsSkipped,
 		"duration_ms", res.DurationMS,
 	)
 

--- a/internal/controlplane/api/handlers/blockstore_manifest_check.go
+++ b/internal/controlplane/api/handlers/blockstore_manifest_check.go
@@ -76,8 +76,19 @@ func (h *BlockStoreManifestCheckHandler) RunManifestCheck(w http.ResponseWriter,
 		return
 	}
 
+	// Decoded here rather than through decodeJSONBody because an absent body
+	// is not an error on this endpoint: it is what a caller asking for a plain
+	// read-only scan sends. The size cap is the same one every other body gets.
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	var req BlockStoreManifestCheckRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			WriteProblem(w, http.StatusRequestEntityTooLarge,
+				"Request Entity Too Large",
+				"request body exceeds the 1 MiB limit")
+			return
+		}
 		BadRequest(w, "invalid request body")
 		return
 	}

--- a/internal/controlplane/api/handlers/blockstore_manifest_check_test.go
+++ b/internal/controlplane/api/handlers/blockstore_manifest_check_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -18,10 +19,16 @@ type fakeManifestCheckRuntime struct {
 	res   *engine.ManifestCheckResult
 	err   error
 	calls []string
+	opts  []engine.ManifestCheckOptions
 }
 
-func (f *fakeManifestCheckRuntime) CheckManifests(_ context.Context, shareName string) (*engine.ManifestCheckResult, error) {
+func (f *fakeManifestCheckRuntime) CheckManifests(
+	_ context.Context,
+	shareName string,
+	opts engine.ManifestCheckOptions,
+) (*engine.ManifestCheckResult, error) {
 	f.calls = append(f.calls, shareName)
+	f.opts = append(f.opts, opts)
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -33,6 +40,70 @@ func runManifestCheck(rt ManifestCheckRuntime, share string) *httptest.ResponseR
 	w := httptest.NewRecorder()
 	NewBlockStoreManifestCheckHandler(rt).RunManifestCheck(w, req)
 	return w
+}
+
+// runManifestCheckBody posts an explicit request body.
+func runManifestCheckBody(rt ManifestCheckRuntime, share, body string) *httptest.ResponseRecorder {
+	req := newAuditRequest(http.MethodPost, "/api/v1/shares/"+share+"/audit/manifest", share)
+	req.Body = io.NopCloser(strings.NewReader(body))
+	w := httptest.NewRecorder()
+	NewBlockStoreManifestCheckHandler(rt).RunManifestCheck(w, req)
+	return w
+}
+
+// TestManifestCheckHandler_RepairOptions pins the two properties the repair
+// switches have to hold at the boundary: a caller that sends no body — every
+// caller written before repairs existed — gets a read-only scan, and asking to
+// apply also asks to plan, so a repair is never applied unreported.
+func TestManifestCheckHandler_RepairOptions(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want engine.ManifestCheckOptions
+	}{
+		{name: "no body", body: "", want: engine.ManifestCheckOptions{}},
+		{name: "empty object", body: "{}", want: engine.ManifestCheckOptions{}},
+		{
+			name: "plan only",
+			body: `{"plan_repairs":true}`,
+			want: engine.ManifestCheckOptions{PlanRepairs: true},
+		},
+		{
+			name: "apply implies plan",
+			body: `{"apply_repairs":true}`,
+			want: engine.ManifestCheckOptions{PlanRepairs: true, ApplyRepairs: true},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &fakeManifestCheckRuntime{res: &engine.ManifestCheckResult{Share: "/myshare"}}
+			var w *httptest.ResponseRecorder
+			if tc.body == "" {
+				w = runManifestCheck(fake, "myshare")
+			} else {
+				w = runManifestCheckBody(fake, "myshare", tc.body)
+			}
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d (body=%q)", w.Code, w.Body.String())
+			}
+			if len(fake.opts) != 1 || fake.opts[0] != tc.want {
+				t.Fatalf("options = %+v, want %+v", fake.opts, tc.want)
+			}
+		})
+	}
+}
+
+// TestManifestCheckHandler_BadBody asserts a malformed body is refused rather
+// than silently read as a read-only scan.
+func TestManifestCheckHandler_BadBody(t *testing.T) {
+	fake := &fakeManifestCheckRuntime{res: &engine.ManifestCheckResult{}}
+	w := runManifestCheckBody(fake, "myshare", "{not json")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d (body=%q)", w.Code, w.Body.String())
+	}
+	if len(fake.calls) != 0 {
+		t.Fatalf("runtime was called for a malformed body: %+v", fake.calls)
+	}
 }
 
 // TestManifestCheckHandler_Success asserts the handler normalizes the share

--- a/internal/controlplane/api/handlers/blockstore_manifest_check_test.go
+++ b/internal/controlplane/api/handlers/blockstore_manifest_check_test.go
@@ -188,3 +188,18 @@ func TestManifestCheckHandler_RuntimeError(t *testing.T) {
 		t.Errorf("response body leaks the underlying error path: %q", w.Body.String())
 	}
 }
+
+// TestManifestCheckHandler_OversizedBody asserts the endpoint caps the body it
+// reads. The switches it carries are two booleans, so anything approaching the
+// limit is a caller the handler should refuse rather than read.
+func TestManifestCheckHandler_OversizedBody(t *testing.T) {
+	fake := &fakeManifestCheckRuntime{res: &engine.ManifestCheckResult{}}
+	body := `{"plan_repairs":true,"pad":"` + strings.Repeat("x", 2<<20) + `"}`
+	w := runManifestCheckBody(fake, "myshare", body)
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d (body=%q)", w.Code, w.Body.String())
+	}
+	if len(fake.calls) != 0 {
+		t.Fatalf("runtime was called for an oversized body: %+v", fake.calls)
+	}
+}

--- a/pkg/apiclient/blockstore.go
+++ b/pkg/apiclient/blockstore.go
@@ -262,10 +262,26 @@ type BlockStoreManifestCheckResult struct {
 //
 // No block is fetched and no remote object is touched, so the call costs a
 // metadata walk regardless of how much data the share holds.
-func (c *Client) BlockStoreCheckManifests(shareName string) (*BlockStoreManifestCheckResult, error) {
+//
+// opts asks the server to also work out which of those findings it has the
+// evidence to repair, and to write them. The zero value keeps the scan
+// read-only.
+func (c *Client) BlockStoreCheckManifests(shareName string, opts BlockStoreManifestCheckOptions) (*BlockStoreManifestCheckResult, error) {
 	return createResource[BlockStoreManifestCheckResult](
 		c,
 		fmt.Sprintf("/api/v1/shares/%s/audit/manifest", url.PathEscape(normalizeShareNameForAPI(shareName))),
-		struct{}{},
+		opts,
 	)
+}
+
+// BlockStoreManifestCheckOptions is the request body for
+// POST /api/v1/shares/{name}/audit/manifest. Mirrors the server-side
+// handlers.BlockStoreManifestCheckRequest shape.
+type BlockStoreManifestCheckOptions struct {
+	// PlanRepairs reports which findings the server has evidence to repair,
+	// writing nothing.
+	PlanRepairs bool `json:"plan_repairs,omitempty"`
+
+	// ApplyRepairs writes those repairs. It implies PlanRepairs.
+	ApplyRepairs bool `json:"apply_repairs,omitempty"`
 }

--- a/pkg/block/engine/manifest_check.go
+++ b/pkg/block/engine/manifest_check.go
@@ -395,6 +395,15 @@ func repairPayload(
 	}
 	res.RepairsPlanned += uint64(len(actions))
 
+	// Trim to what the report can still carry, so the actions a run writes and
+	// the actions it lists are always the same set — an applied repair the
+	// operator cannot see is worse than one deferred to the next run. The
+	// planned counter above stays exact past the trim.
+	if room := maxManifestCheckFindings - len(res.Repairs); len(actions) > room {
+		actions = actions[:room]
+		res.RepairsTruncated = true
+	}
+
 	if opts.ApplyRepairs {
 		if err := applyPayloadRepairs(ctx, store, f, actions); err != nil {
 			return false, fmt.Errorf("repair payload %q: %w", payloadID, err)

--- a/pkg/block/engine/manifest_check.go
+++ b/pkg/block/engine/manifest_check.go
@@ -136,6 +136,25 @@ type ManifestCheckResult struct {
 	// SyncedHashesChecked is false.
 	UnknownHashRows uint64 `json:"unknown_hash_rows"`
 
+	// RepairsPlanned is the number of manifest writes the scan found
+	// evidence for. Zero unless repairs were asked for.
+	RepairsPlanned uint64 `json:"repairs_planned,omitempty"`
+
+	// RepairsApplied is the number of those writes that landed, and
+	// RepairsSkipped the number whose evidence had moved by the time the
+	// write transaction ran. Both are zero on a scan that only planned.
+	RepairsApplied uint64 `json:"repairs_applied,omitempty"`
+	RepairsSkipped uint64 `json:"repairs_skipped,omitempty"`
+
+	// Repairs is the per-action detail, capped at maxManifestCheckFindings
+	// entries. The cap bounds a report, not the work: a scan stops planning
+	// once it is full, so a store past the cap is repaired by running the
+	// command again rather than in one pass.
+	Repairs []RepairAction `json:"repairs,omitempty"`
+
+	// RepairsTruncated reports that the plan stopped at the cap.
+	RepairsTruncated bool `json:"repairs_truncated,omitempty"`
+
 	// Findings is the per-payload detail, capped at
 	// maxManifestCheckFindings entries.
 	Findings []PayloadFinding `json:"findings,omitempty"`
@@ -149,6 +168,24 @@ type ManifestCheckResult struct {
 // that no file claims do not count — see ByteRange.Claimed.
 func (r *ManifestCheckResult) Damaged() bool {
 	return r.ClaimedUncoveredRanges > 0 || r.UnplaceableRows > 0 || r.UnknownHashRows > 0
+}
+
+// ManifestCheckOptions selects which of the scan's checks run and whether it
+// is allowed to write.
+type ManifestCheckOptions struct {
+	// CheckSynced runs the unknown-hash check, which needs a share whose
+	// hashes are marked synced at all — see CheckManifests.
+	CheckSynced bool
+
+	// PlanRepairs works out which findings the scan has enough evidence to
+	// repair and reports them, writing nothing. It is what an operator sees
+	// before deciding.
+	PlanRepairs bool
+
+	// ApplyRepairs writes the planned repairs, one transaction per payload,
+	// re-establishing each precondition inside that transaction. It implies
+	// PlanRepairs.
+	ApplyRepairs bool
 }
 
 // CheckManifests walks every regular file in a share and compares the byte
@@ -173,9 +210,15 @@ func (r *ManifestCheckResult) Damaged() bool {
 // no claim from the file's own block list, and the report keeps claimed and
 // unclaimed spans apart for that reason.
 //
-// checkSynced gates the third check. A share with no remote store never marks
-// a hash synced, so running it there would report every row in the share.
-func CheckManifests(ctx context.Context, share string, store metadata.Store, checkSynced bool) (*ManifestCheckResult, error) {
+// opts.CheckSynced gates the third check. A share with no remote store never
+// marks a hash synced, so running it there would report every row in the share.
+//
+// opts.PlanRepairs and opts.ApplyRepairs turn the scan from a read into a
+// write. Planning stays read-only and costs the same walk; applying writes only
+// the rows the plan found evidence for, one transaction per payload. With
+// neither set the scan touches nothing, which is what every existing caller
+// gets.
+func CheckManifests(ctx context.Context, share string, store metadata.Store, opts ManifestCheckOptions) (*ManifestCheckResult, error) {
 	if store == nil {
 		return nil, errors.New("store check: metadata store is nil")
 	}
@@ -186,7 +229,7 @@ func CheckManifests(ctx context.Context, share string, store metadata.Store, che
 	result := &ManifestCheckResult{
 		Share:               share,
 		StartedAt:           time.Now().UTC(),
-		SyncedHashesChecked: checkSynced,
+		SyncedHashesChecked: opts.CheckSynced,
 	}
 
 	rootHandle, err := store.GetRootHandle(ctx, share)
@@ -195,7 +238,7 @@ func CheckManifests(ctx context.Context, share string, store metadata.Store, che
 	}
 	if err := walkAuditShareFiles(ctx, store, rootHandle, "", func(path string, f *metadata.File) error {
 		result.FilesScanned++
-		return checkFileManifest(ctx, store, path, f, checkSynced, result)
+		return checkFileManifest(ctx, store, path, f, opts, result)
 	}); err != nil {
 		return nil, fmt.Errorf("store check: walk share %q: %w", share, err)
 	}
@@ -231,7 +274,7 @@ func checkFileManifest(
 	store metadata.Store,
 	path string,
 	f *metadata.File,
-	checkSynced bool,
+	opts ManifestCheckOptions,
 	res *ManifestCheckResult,
 ) error {
 	payloadID := string(f.PayloadID)
@@ -246,16 +289,20 @@ func checkFileManifest(
 
 	finding := &PayloadFinding{Path: path, PayloadID: payloadID, Size: f.Size}
 	covered := make([][2]uint64, 0, len(rows))
+	rowIDs := make(map[string]struct{}, len(rows))
+	var unplaceable []*block.FileChunk
 	var found bool
 
 	for _, row := range rows {
 		if row == nil {
 			continue
 		}
+		rowIDs[row.ID] = struct{}{}
 		off, placeable := block.ParseChunkOffset(row.ID)
 		if !placeable {
 			res.UnplaceableRows++
 			finding.Damaged, found = true, true
+			unplaceable = append(unplaceable, row)
 			appendCapped(&finding.UnplaceableRows, row.ID, &finding.Truncated)
 		}
 		if row.Hash.IsZero() {
@@ -264,7 +311,7 @@ func checkFileManifest(
 		// The hash is put to the synced-hash store even for a row that
 		// cannot be placed. Where its bytes belong is unknown, but whether
 		// the remote holds them is still answerable and still worth saying.
-		if checkSynced {
+		if opts.CheckSynced {
 			synced, serr := store.IsSynced(ctx, row.Hash)
 			if serr != nil {
 				return fmt.Errorf("is synced %s: %w", row.Hash, serr)
@@ -291,7 +338,8 @@ func checkFileManifest(
 	}
 
 	claimed = coalesceExtents(claimed)
-	for _, hole := range uncoveredRanges(coalesceExtents(covered), f.Size) {
+	coveredExtents := coalesceExtents(covered)
+	for _, hole := range uncoveredRanges(coveredExtents, f.Size) {
 		for _, piece := range splitByClaim(hole, claimed) {
 			found = true
 			res.UncoveredRanges++
@@ -305,11 +353,62 @@ func checkFileManifest(
 		}
 	}
 
+	if opts.PlanRepairs || opts.ApplyRepairs {
+		repaired, rerr := repairPayload(ctx, store, path, payloadID, f, rowIDs, unplaceable, coveredExtents, opts, res)
+		if rerr != nil {
+			return rerr
+		}
+		found = found || repaired
+	}
+
 	if !found {
 		return nil
 	}
 	res.record(finding)
 	return nil
+}
+
+// repairPayload plans, optionally applies, and records one payload's repairs.
+// It reports whether anything was proposed, so a payload whose only story is a
+// repair still shows up in the per-payload detail.
+func repairPayload(
+	ctx context.Context,
+	store metadata.Store,
+	path, payloadID string,
+	f *metadata.File,
+	rowIDs map[string]struct{},
+	unplaceable []*block.FileChunk,
+	covered [][2]uint64,
+	opts ManifestCheckOptions,
+	res *ManifestCheckResult,
+) (bool, error) {
+	if uint64(len(res.Repairs)) >= maxManifestCheckFindings {
+		res.RepairsTruncated = true
+		return false, nil
+	}
+	actions, err := planPayloadRepairs(ctx, store, path, payloadID, f, rowIDs, unplaceable, covered, opts.CheckSynced)
+	if err != nil {
+		return false, err
+	}
+	if len(actions) == 0 {
+		return false, nil
+	}
+	res.RepairsPlanned += uint64(len(actions))
+
+	if opts.ApplyRepairs {
+		if err := applyPayloadRepairs(ctx, store, f, actions); err != nil {
+			return false, fmt.Errorf("repair payload %q: %w", payloadID, err)
+		}
+		for i := range actions {
+			if actions[i].Applied {
+				res.RepairsApplied++
+			} else {
+				res.RepairsSkipped++
+			}
+		}
+	}
+	res.Repairs = append(res.Repairs, actions...)
+	return true, nil
 }
 
 // appendCapped appends to a per-payload detail list until it reaches

--- a/pkg/block/engine/manifest_check.go
+++ b/pkg/block/engine/manifest_check.go
@@ -382,7 +382,7 @@ func repairPayload(
 	opts ManifestCheckOptions,
 	res *ManifestCheckResult,
 ) (bool, error) {
-	if uint64(len(res.Repairs)) >= maxManifestCheckFindings {
+	if len(res.Repairs) >= maxManifestCheckFindings {
 		res.RepairsTruncated = true
 		return false, nil
 	}

--- a/pkg/block/engine/manifest_check_test.go
+++ b/pkg/block/engine/manifest_check_test.go
@@ -207,7 +207,7 @@ func TestCheckManifests_HolesAndUnknownHashes(t *testing.T) {
 				}
 			}
 
-			res, err := CheckManifests(ctx, share, store, true)
+			res, err := CheckManifests(ctx, share, store, ManifestCheckOptions{CheckSynced: true})
 			if err != nil {
 				t.Fatalf("CheckManifests: %v", err)
 			}
@@ -277,7 +277,7 @@ func TestCheckManifests_LocalOnlySkipsSyncedCheck(t *testing.T) {
 	seedCheckFile(t, store, share, root, "f", 4096,
 		[]seedRow{{"0", 4096, 1}}, []seedRef{{0, 4096, 1}})
 
-	res, err := CheckManifests(ctx, share, store, false)
+	res, err := CheckManifests(ctx, share, store, ManifestCheckOptions{})
 	if err != nil {
 		t.Fatalf("CheckManifests: %v", err)
 	}
@@ -316,7 +316,7 @@ func TestCheckManifests_UnplaceableRow(t *testing.T) {
 		t.Fatalf("MarkSynced: %v", err)
 	}
 
-	res, err := CheckManifests(ctx, share, store, true)
+	res, err := CheckManifests(ctx, share, store, ManifestCheckOptions{CheckSynced: true})
 	if err != nil {
 		t.Fatalf("CheckManifests: %v", err)
 	}
@@ -357,7 +357,7 @@ func TestCheckManifests_PendingRowHoldsNoBytes(t *testing.T) {
 	payloadID := seedCheckFile(t, store, share, root, "f", 4096,
 		[]seedRow{{"0", 4096, 0}}, nil)
 
-	res, err := CheckManifests(ctx, share, store, true)
+	res, err := CheckManifests(ctx, share, store, ManifestCheckOptions{CheckSynced: true})
 	if err != nil {
 		t.Fatalf("CheckManifests: %v", err)
 	}
@@ -431,7 +431,7 @@ func TestCheckManifests_CapDoesNotHideDamage(t *testing.T) {
 	refs = append(refs, seedRef{damagedOff, 4096, 2})
 	payloadID := seedCheckFile(t, store, share, root, "f", damagedOff+4096, rows, refs)
 
-	res, err := CheckManifests(ctx, share, store, false)
+	res, err := CheckManifests(ctx, share, store, ManifestCheckOptions{})
 	if err != nil {
 		t.Fatalf("CheckManifests: %v", err)
 	}

--- a/pkg/block/engine/manifest_repair.go
+++ b/pkg/block/engine/manifest_repair.go
@@ -1,0 +1,386 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// RepairKind names what one repair entry does to the manifest.
+type RepairKind string
+
+const (
+	// RepairReplaceRow moves a row that carries no parseable chunk offset to
+	// the offset the file's own block list gives its hash. Everything else
+	// about the row — hash, size, refcount, state, timestamps — is carried
+	// over; only the ID changes. Two defects go away at once: the row becomes
+	// placeable and the range it belongs to becomes covered.
+	RepairReplaceRow RepairKind = "replace_row"
+
+	// RepairRecreateRow adds a manifest row for a range the file claims and
+	// no row covers, taking the hash and length from the claim itself. It is
+	// only ever proposed for a hash the synced-hash store resolves, so the
+	// bytes are fetchable from the remote by that hash alone.
+	RepairRecreateRow RepairKind = "recreate_row"
+)
+
+// RepairAction is one proposed manifest write. A scan that plans repairs fills
+// Kind through ToRowID; a scan that applies them also fills Applied or
+// SkipReason, so the same value describes both what was intended and what
+// happened.
+type RepairAction struct {
+	// Kind is the action taken on the manifest.
+	Kind RepairKind `json:"kind"`
+
+	// Path and PayloadID identify the file the row belongs to.
+	Path      string `json:"path"`
+	PayloadID string `json:"payload_id"`
+
+	// Offset and Size are the byte range the repaired row will claim, taken
+	// from the file's own block list.
+	Offset uint64 `json:"offset"`
+	Size   uint32 `json:"size"`
+
+	// Hash is the content hash the row carries. The remote read path
+	// resolves and verifies a chunk by this hash alone, so a repair that
+	// named the wrong bytes would fail the read rather than serve them.
+	Hash string `json:"hash"`
+
+	// FromRowID is the unplaceable row being moved, empty for a recreate.
+	FromRowID string `json:"from_row_id,omitempty"`
+
+	// ToRowID is the manifest key the row will live under.
+	ToRowID string `json:"to_row_id"`
+
+	// Applied reports that the write went through.
+	Applied bool `json:"applied,omitempty"`
+
+	// SkipReason names why the action was not applied. An action is skipped
+	// when a precondition that held during the scan no longer holds inside
+	// the write transaction — the store is live and may have moved.
+	SkipReason string `json:"skip_reason,omitempty"`
+}
+
+// chunkRowID renders the manifest key a chunk at off within payloadID lives
+// under. It is the inverse of block.ParseChunkOffset.
+func chunkRowID(payloadID string, off uint64) string {
+	return fmt.Sprintf("%s/%d", payloadID, off)
+}
+
+// refKey groups a claim and a row by the two properties that have to match
+// for one to stand in for the other.
+type refKey struct {
+	hash block.ContentHash
+	size uint32
+}
+
+// planPayloadRepairs proposes the manifest writes that would make one payload
+// readable again. It proposes a write only where the evidence names both the
+// bytes and where they belong:
+//
+//   - the file's own block list gives a hash, an offset and a length for the
+//     range, and no placeable row covers that range, so writing a row there
+//     takes nothing away from any reader; and
+//   - either an unplaceable row carries exactly that hash and length — its
+//     bytes are the claim's bytes, only its offset was lost — or the
+//     synced-hash store resolves the hash, so the remote holds the bytes.
+//
+// Everything else is left alone. A claim whose hash nothing can resolve gets
+// no row: a row pointing at bytes no store holds turns an uncovered range into
+// a failing read without recovering anything. An unplaceable row that matches
+// no claim gets no offset: there is nothing that says where it belongs.
+//
+// Ambiguity is refused rather than guessed. Where a hash and length pair names
+// more than one uncovered claim, or more than one unplaceable row, the two
+// cannot be paired one-to-one and the rows are left for the operator; those
+// claims fall through to the synced-hash branch, which needs no pairing.
+func planPayloadRepairs(
+	ctx context.Context,
+	store metadata.Store,
+	path, payloadID string,
+	f *metadata.File,
+	rowIDs map[string]struct{},
+	unplaceable []*block.FileChunk,
+	covered [][2]uint64,
+	checkSynced bool,
+) ([]RepairAction, error) {
+	candidates := make([]block.ChunkRef, 0, 4)
+	perKey := make(map[refKey]int)
+	for _, ref := range f.Blocks {
+		if !repairableClaim(ref, f.Size, rowIDs, payloadID, covered) {
+			continue
+		}
+		candidates = append(candidates, ref)
+		perKey[refKey{ref.Hash, ref.Size}]++
+	}
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	rowsByKey := make(map[refKey][]*block.FileChunk, len(unplaceable))
+	for _, r := range unplaceable {
+		if r.Hash.IsZero() {
+			continue // pending row: no committed bytes to place anywhere
+		}
+		k := refKey{r.Hash, r.DataSize}
+		rowsByKey[k] = append(rowsByKey[k], r)
+	}
+
+	out := make([]RepairAction, 0, len(candidates))
+	for _, ref := range candidates {
+		k := refKey{ref.Hash, ref.Size}
+		action := RepairAction{
+			Path:      path,
+			PayloadID: payloadID,
+			Offset:    ref.Offset,
+			Size:      ref.Size,
+			Hash:      ref.Hash.String(),
+			ToRowID:   chunkRowID(payloadID, ref.Offset),
+		}
+		switch rows := rowsByKey[k]; {
+		case len(rows) == 1 && perKey[k] == 1:
+			action.Kind = RepairReplaceRow
+			action.FromRowID = rows[0].ID
+		case checkSynced:
+			synced, err := store.IsSynced(ctx, ref.Hash)
+			if err != nil {
+				return nil, fmt.Errorf("is synced %s: %w", ref.Hash, err)
+			}
+			if !synced {
+				continue
+			}
+			action.Kind = RepairRecreateRow
+		default:
+			continue
+		}
+		out = append(out, action)
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
+// repairableClaim reports whether one entry of a file's block list names a
+// range a repair may write a row for: it has to carry committed bytes, sit
+// wholly inside the file, be covered by no placeable row, and have nothing
+// already occupying its manifest key.
+func repairableClaim(
+	ref block.ChunkRef,
+	size uint64,
+	rowIDs map[string]struct{},
+	payloadID string,
+	covered [][2]uint64,
+) bool {
+	if ref.Size == 0 || ref.Hash.IsZero() {
+		return false
+	}
+	end := ref.Offset + uint64(ref.Size)
+	if end < ref.Offset || end > size {
+		// A claim reaching past the recorded size is a disagreement the scan
+		// cannot settle: writing a row for it would commit to one side of it.
+		return false
+	}
+	if overlapsCovered(covered, ref.Offset, end) {
+		return false
+	}
+	// A row already at that key holds no committed bytes yet — a pending
+	// rollup owns the offset, and overwriting it would drop the write it is
+	// about to commit.
+	_, taken := rowIDs[chunkRowID(payloadID, ref.Offset)]
+	return !taken
+}
+
+// overlapsCovered reports whether [start, end) touches any covered extent.
+// covered must be sorted and non-overlapping.
+//
+// ponytail: linear over the payload's extents, and it only runs for a payload
+// that already has a claimed-uncovered range; make it a binary search if a
+// store ever shows up whose damaged files are also its most fragmented.
+func overlapsCovered(covered [][2]uint64, start, end uint64) bool {
+	for _, c := range covered {
+		if c[0] < end && start < c[1] {
+			return true
+		}
+	}
+	return false
+}
+
+// applyPayloadRepairs writes one payload's planned actions in a single
+// transaction and records, on each action, whether it landed.
+//
+// Every precondition the plan relied on is re-established against the rows and
+// the file the transaction sees, because the plan was computed outside it and
+// the share stays live throughout: a concurrent carve may have written the row
+// the plan wanted to add, and a concurrent truncate may have dropped the claim
+// it was derived from. An action whose evidence no longer holds is skipped with
+// a reason, never forced.
+func applyPayloadRepairs(ctx context.Context, store metadata.Store, f *metadata.File, actions []RepairAction) error {
+	handle, err := metadata.EncodeFileHandle(f)
+	if err != nil {
+		return fmt.Errorf("encode handle for payload %q: %w", f.PayloadID, err)
+	}
+	payloadID := string(f.PayloadID)
+
+	return store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		cur, err := tx.GetFile(ctx, handle)
+		if metadata.IsNotFoundError(err) {
+			// Unlinked between the scan and the write. There is nothing left
+			// to repair, and it is not a reason to abandon the other payloads.
+			for i := range actions {
+				actions[i].SkipReason = "the file is gone"
+			}
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("re-read file for payload %q: %w", payloadID, err)
+		}
+		rows, err := tx.ListFileChunks(ctx, payloadID)
+		if err != nil {
+			return fmt.Errorf("re-list chunks for payload %q: %w", payloadID, err)
+		}
+
+		byID := make(map[string]*block.FileChunk, len(rows))
+		covered := make([][2]uint64, 0, len(rows))
+		for _, row := range rows {
+			if row == nil {
+				continue
+			}
+			byID[row.ID] = row
+			off, placeable := block.ParseChunkOffset(row.ID)
+			if !placeable || row.Hash.IsZero() {
+				continue
+			}
+			if e, ok := clipRange(off, uint64(row.DataSize), cur.Size); ok {
+				covered = append(covered, e)
+			}
+		}
+		covered = coalesceExtents(covered)
+
+		claimed := make(map[refKey]map[uint64]struct{}, len(cur.Blocks))
+		for _, ref := range cur.Blocks {
+			k := refKey{ref.Hash, ref.Size}
+			if claimed[k] == nil {
+				claimed[k] = make(map[uint64]struct{}, 1)
+			}
+			claimed[k][ref.Offset] = struct{}{}
+		}
+
+		now := time.Now().UTC()
+		for i := range actions {
+			a := &actions[i]
+			row, err := repairRow(ctx, tx, a, cur, byID, claimed, covered, now)
+			if err != nil {
+				return err
+			}
+			if row == nil {
+				continue // a.SkipReason says why
+			}
+			if a.Kind == RepairReplaceRow {
+				// The delete and the put share this transaction, so the row
+				// is never absent from the manifest between the two.
+				if err := tx.Delete(ctx, a.FromRowID); err != nil {
+					return fmt.Errorf("delete unplaceable row %q: %w", a.FromRowID, err)
+				}
+			}
+			if err := tx.Put(ctx, row); err != nil {
+				return fmt.Errorf("put repaired row %q: %w", a.ToRowID, err)
+			}
+			// Fold the write into the view the remaining actions are checked
+			// against, so a second action for the same offset — two block-list
+			// entries claiming one range — is skipped as occupied rather than
+			// silently overwriting the first.
+			byID[row.ID] = row
+			delete(byID, a.FromRowID)
+			covered = coalesceExtents(append(covered, [2]uint64{a.Offset, a.Offset + uint64(a.Size)}))
+			// The file's block list already carries this claim — it is where
+			// the repair came from — so its projection needs no rewrite.
+			a.Applied = true
+		}
+		return nil
+	})
+}
+
+// repairRow re-checks one action against the transaction's view and returns
+// the row to write, or nil with a.SkipReason set when the evidence has moved.
+func repairRow(
+	ctx context.Context,
+	tx metadata.Transaction,
+	a *RepairAction,
+	cur *metadata.File,
+	byID map[string]*block.FileChunk,
+	claimed map[refKey]map[uint64]struct{},
+	covered [][2]uint64,
+	now time.Time,
+) (*block.FileChunk, error) {
+	hash, err := block.ParseContentHash(a.Hash)
+	if err != nil {
+		return nil, fmt.Errorf("parse planned hash %q: %w", a.Hash, err)
+	}
+	k := refKey{hash, a.Size}
+
+	if _, ok := claimed[k][a.Offset]; !ok {
+		a.SkipReason = "the file no longer claims this range"
+		return nil, nil
+	}
+	if end := a.Offset + uint64(a.Size); end > cur.Size {
+		a.SkipReason = "the file is now shorter than the range"
+		return nil, nil
+	}
+	if _, taken := byID[a.ToRowID]; taken {
+		a.SkipReason = "a manifest row now occupies the target offset"
+		return nil, nil
+	}
+	if overlapsCovered(covered, a.Offset, a.Offset+uint64(a.Size)) {
+		a.SkipReason = "another row now covers the range"
+		return nil, nil
+	}
+
+	if a.Kind == RepairReplaceRow {
+		src, ok := byID[a.FromRowID]
+		if !ok {
+			a.SkipReason = "the unplaceable row is gone"
+			return nil, nil
+		}
+		if src.Hash != hash || src.DataSize != a.Size {
+			a.SkipReason = "the unplaceable row no longer matches the claim"
+			return nil, nil
+		}
+		moved := *src
+		moved.ID = a.ToRowID
+		return &moved, nil
+	}
+
+	// The synced marker is the whole of a recreate's evidence, so it is read
+	// again here rather than trusted from the plan. It can be dropped between
+	// the two — the refcount cascade clears the marker of a hash nothing
+	// references any more, and a hash whose row went missing is exactly that.
+	synced, err := tx.IsSynced(ctx, hash)
+	if err != nil {
+		return nil, fmt.Errorf("re-check synced %s: %w", hash, err)
+	}
+	if !synced {
+		a.SkipReason = "the claim's hash is no longer marked synced"
+		return nil, nil
+	}
+
+	// A recreated row states what the evidence supports and no more: the
+	// claim's hash and its length, under the manifest key its offset gives.
+	// Those three are what a read needs — it resolves the bytes by hash
+	// through the synced-hash store and verifies their BLAKE3 on arrival, so
+	// a row naming a chunk the remote does not hold fails the read rather
+	// than serving it, and one naming the wrong chunk fails the verify.
+	// State and refcount are left where the carve path leaves them, which is
+	// where every other row in the store sits.
+	return &block.FileChunk{
+		ID:         a.ToRowID,
+		Hash:       hash,
+		DataSize:   a.Size,
+		State:      block.BlockStatePending,
+		CreatedAt:  now,
+		LastAccess: now,
+	}, nil
+}

--- a/pkg/block/engine/manifest_repair.go
+++ b/pkg/block/engine/manifest_repair.go
@@ -158,9 +158,6 @@ func planPayloadRepairs(
 		}
 		out = append(out, action)
 	}
-	if len(out) == 0 {
-		return nil, nil
-	}
 	return out, nil
 }
 
@@ -243,31 +240,8 @@ func applyPayloadRepairs(ctx context.Context, store metadata.Store, f *metadata.
 			return fmt.Errorf("re-list chunks for payload %q: %w", payloadID, err)
 		}
 
-		byID := make(map[string]*block.FileChunk, len(rows))
-		covered := make([][2]uint64, 0, len(rows))
-		for _, row := range rows {
-			if row == nil {
-				continue
-			}
-			byID[row.ID] = row
-			off, placeable := block.ParseChunkOffset(row.ID)
-			if !placeable || row.Hash.IsZero() {
-				continue
-			}
-			if e, ok := clipRange(off, uint64(row.DataSize), cur.Size); ok {
-				covered = append(covered, e)
-			}
-		}
-		covered = coalesceExtents(covered)
-
-		claimed := make(map[refKey]map[uint64]struct{}, len(cur.Blocks))
-		for _, ref := range cur.Blocks {
-			k := refKey{ref.Hash, ref.Size}
-			if claimed[k] == nil {
-				claimed[k] = make(map[uint64]struct{}, 1)
-			}
-			claimed[k][ref.Offset] = struct{}{}
-		}
+		byID, covered := indexChunkRows(rows, cur.Size)
+		claimed := claimedOffsets(cur)
 
 		now := time.Now().UTC()
 		for i := range actions {
@@ -302,6 +276,43 @@ func applyPayloadRepairs(ctx context.Context, store metadata.Store, f *metadata.
 		}
 		return nil
 	})
+}
+
+// indexChunkRows indexes a payload's manifest rows by ID and returns the
+// coalesced extents the placeable rows with committed bytes cover — the view
+// an action is re-checked against.
+func indexChunkRows(rows []*block.FileChunk, size uint64) (map[string]*block.FileChunk, [][2]uint64) {
+	byID := make(map[string]*block.FileChunk, len(rows))
+	covered := make([][2]uint64, 0, len(rows))
+	for _, row := range rows {
+		if row == nil {
+			continue
+		}
+		byID[row.ID] = row
+		off, placeable := block.ParseChunkOffset(row.ID)
+		if !placeable || row.Hash.IsZero() {
+			continue
+		}
+		if e, ok := clipRange(off, uint64(row.DataSize), size); ok {
+			covered = append(covered, e)
+		}
+	}
+	return byID, coalesceExtents(covered)
+}
+
+// claimedOffsets indexes a file's own block list as the set of offsets it
+// claims for each hash and length, so one action's claim can be looked up
+// without walking the list again.
+func claimedOffsets(f *metadata.File) map[refKey]map[uint64]struct{} {
+	claimed := make(map[refKey]map[uint64]struct{}, len(f.Blocks))
+	for _, ref := range f.Blocks {
+		k := refKey{ref.Hash, ref.Size}
+		if claimed[k] == nil {
+			claimed[k] = make(map[uint64]struct{}, 1)
+		}
+		claimed[k][ref.Offset] = struct{}{}
+	}
+	return claimed
 }
 
 // repairRow re-checks one action against the transaction's view and returns

--- a/pkg/block/engine/manifest_repair_test.go
+++ b/pkg/block/engine/manifest_repair_test.go
@@ -524,3 +524,41 @@ func TestRepairDoesNotOverwriteItsOwnWrite(t *testing.T) {
 		})
 	}
 }
+
+// TestRepairPlanHonoursTheReportCap pins that a run never writes more repairs
+// than it lists. An applied repair the operator cannot see in the report is
+// worse than one deferred to the next run, so the cap trims both together.
+func TestRepairPlanHonoursTheReportCap(t *testing.T) {
+	ctx := t.Context()
+	share := "/repair"
+	store, root := newCheckStore(t, "memory", share)
+
+	// One payload whose claims outnumber the report cap on their own.
+	const claims = maxManifestCheckFindings + 5
+	refs := make([]seedRef, 0, claims)
+	for i := range claims {
+		refs = append(refs, seedRef{off: uint64(i) * 4096, size: 4096, hash: byte(1 + i%200)})
+	}
+	seedCheckFile(t, store, share, root, "wide", uint64(claims)*4096, nil, refs)
+	for h := 1; h <= 200; h++ {
+		if err := store.MarkSynced(ctx, seedHash(byte(h)), block.ChunkLocator{}); err != nil {
+			t.Fatalf("MarkSynced: %v", err)
+		}
+	}
+
+	res := runRepair(t, store, share, ManifestCheckOptions{
+		CheckSynced: true, PlanRepairs: true, ApplyRepairs: true,
+	})
+	if len(res.Repairs) > maxManifestCheckFindings {
+		t.Fatalf("report carries %d repairs, over the cap of %d", len(res.Repairs), maxManifestCheckFindings)
+	}
+	if !res.RepairsTruncated {
+		t.Fatal("plan was trimmed without saying so")
+	}
+	if res.RepairsPlanned != claims {
+		t.Fatalf("RepairsPlanned = %d, want the exact %d found", res.RepairsPlanned, claims)
+	}
+	if got := res.RepairsApplied + res.RepairsSkipped; got != uint64(len(res.Repairs)) {
+		t.Fatalf("wrote %d repairs but listed %d", got, len(res.Repairs))
+	}
+}

--- a/pkg/block/engine/manifest_repair_test.go
+++ b/pkg/block/engine/manifest_repair_test.go
@@ -1,0 +1,526 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// repairBackends runs a repair scenario on every metadata backend the check
+// suite covers, so a repair proved on the in-memory store is also proved on a
+// store that has to serialise the transaction.
+var repairBackends = []string{"memory", "sqlite"}
+
+// sqlOnlyBackends is for scenarios built around an unplaceable row. The
+// in-memory store drops a row whose ID suffix is not numeric before returning
+// it from ListFileChunks, so no caller there can see one — the same reason the
+// scan's own unplaceable-row test is SQL-only.
+var sqlOnlyBackends = []string{"sqlite"}
+
+// resolveAt answers the question a read asks of the manifest: which row covers
+// this offset? It is the read path's own resolver, so a test asserting on it
+// asserts on what a reader would get rather than on a re-derived opinion.
+func resolveAt(t *testing.T, store metadata.Store, payloadID string, off uint64) (*block.FileChunk, error) {
+	t.Helper()
+	rows, err := store.ListFileChunks(context.Background(), payloadID)
+	if err != nil && !errors.Is(err, block.ErrFileChunkNotFound) {
+		t.Fatalf("ListFileChunks: %v", err)
+	}
+	hit, err := findRowCoveringOffset(rows, off)
+	if err != nil {
+		return nil, err
+	}
+	if hit == nil {
+		return nil, nil
+	}
+	return hit.fb, nil
+}
+
+// manifestSnapshot captures every row of a payload so a test can assert what a
+// repair left behind as well as what it added.
+func manifestSnapshot(t *testing.T, store metadata.Store, payloadID string) map[string]block.FileChunk {
+	t.Helper()
+	rows, err := store.ListFileChunks(context.Background(), payloadID)
+	if err != nil && !errors.Is(err, block.ErrFileChunkNotFound) {
+		t.Fatalf("ListFileChunks: %v", err)
+	}
+	out := make(map[string]block.FileChunk, len(rows))
+	for _, r := range rows {
+		if r != nil {
+			out[r.ID] = *r
+		}
+	}
+	return out
+}
+
+// assertNoBytesLost pins the property every repair has to hold: each hash that
+// covered a byte range before the repair still covers a range after it. A
+// repair adds coverage the file already asked for and moves a row that covered
+// nothing; it must never drop one.
+func assertNoBytesLost(t *testing.T, before, after map[string]block.FileChunk) {
+	t.Helper()
+	live := make(map[block.ContentHash]uint32, len(after))
+	for _, r := range after {
+		if r.DataSize > live[r.Hash] {
+			live[r.Hash] = r.DataSize
+		}
+	}
+	for id, r := range before {
+		if r.Hash.IsZero() {
+			continue
+		}
+		if live[r.Hash] < r.DataSize {
+			t.Fatalf("repair lost coverage for row %s: hash %s claimed %d bytes before, %d after",
+				id, r.Hash, r.DataSize, live[r.Hash])
+		}
+	}
+}
+
+func runRepair(t *testing.T, store metadata.Store, share string, opts ManifestCheckOptions) *ManifestCheckResult {
+	t.Helper()
+	res, err := CheckManifests(t.Context(), share, store, opts)
+	if err != nil {
+		t.Fatalf("CheckManifests: %v", err)
+	}
+	return res
+}
+
+// TestRepairReplacesUnplaceableRow covers the one case where the store knows
+// both the bytes and where they belong: a row whose offset was lost, and a
+// claim naming exactly its hash and length. Before the repair the read path
+// refuses the whole payload; after it, the row resolves.
+func TestRepairReplacesUnplaceableRow(t *testing.T) {
+	for _, backend := range sqlOnlyBackends {
+		t.Run(backend, func(t *testing.T) {
+			share := "/repair"
+			store, root := newCheckStore(t, backend, share)
+			payloadID := seedCheckFile(t, store, share, root, "moved", 4096,
+				[]seedRow{{suffix: "not-an-offset", size: 4096, hash: 1}},
+				[]seedRef{{off: 0, size: 4096, hash: 1}},
+			)
+
+			if _, err := resolveAt(t, store, payloadID, 0); !errors.Is(err, block.ErrManifestInconsistent) {
+				t.Fatalf("read path should refuse before the repair, got %v", err)
+			}
+			before := manifestSnapshot(t, store, payloadID)
+
+			plan := runRepair(t, store, share, ManifestCheckOptions{PlanRepairs: true})
+			if plan.RepairsPlanned != 1 || len(plan.Repairs) != 1 {
+				t.Fatalf("want 1 planned repair, got %d: %+v", plan.RepairsPlanned, plan.Repairs)
+			}
+			if got := plan.Repairs[0].Kind; got != RepairReplaceRow {
+				t.Fatalf("want %s, got %s", RepairReplaceRow, got)
+			}
+			if snap := manifestSnapshot(t, store, payloadID); len(snap) != len(before) {
+				t.Fatalf("planning wrote to the store: %d rows before, %d after", len(before), len(snap))
+			}
+
+			applied := runRepair(t, store, share, ManifestCheckOptions{ApplyRepairs: true, PlanRepairs: true})
+			if applied.RepairsApplied != 1 || applied.RepairsSkipped != 0 {
+				t.Fatalf("want 1 applied 0 skipped, got %d/%d", applied.RepairsApplied, applied.RepairsSkipped)
+			}
+
+			row, err := resolveAt(t, store, payloadID, 0)
+			if err != nil {
+				t.Fatalf("read path still refuses after the repair: %v", err)
+			}
+			if row == nil {
+				t.Fatal("no row covers offset 0 after the repair")
+			}
+			if row.ID != payloadID+"/0" {
+				t.Fatalf("row ID = %q, want %q", row.ID, payloadID+"/0")
+			}
+			if row.Hash != seedHash(1) || row.DataSize != 4096 {
+				t.Fatalf("repaired row carries hash %s size %d, want the claim's", row.Hash, row.DataSize)
+			}
+			assertNoBytesLost(t, before, manifestSnapshot(t, store, payloadID))
+
+			after := runRepair(t, store, share, ManifestCheckOptions{})
+			if after.Damaged() {
+				t.Fatalf("payload still reports damage after the repair: %+v", after)
+			}
+		})
+	}
+}
+
+// TestRepairRecreatesRowForSyncedClaim covers the case the store can answer
+// without any surviving row: the file claims a range, no row covers it, and the
+// synced-hash store resolves the claim's hash, so the remote holds the bytes.
+func TestRepairRecreatesRowForSyncedClaim(t *testing.T) {
+	for _, backend := range repairBackends {
+		t.Run(backend, func(t *testing.T) {
+			ctx := t.Context()
+			share := "/repair"
+			store, root := newCheckStore(t, backend, share)
+			payloadID := seedCheckFile(t, store, share, root, "dropped", 8192,
+				[]seedRow{{suffix: "4096", size: 4096, hash: 2}},
+				[]seedRef{{off: 0, size: 4096, hash: 1}, {off: 4096, size: 4096, hash: 2}},
+			)
+			if err := store.MarkSynced(ctx, seedHash(1), block.ChunkLocator{}); err != nil {
+				t.Fatalf("MarkSynced: %v", err)
+			}
+			if err := store.MarkSynced(ctx, seedHash(2), block.ChunkLocator{}); err != nil {
+				t.Fatalf("MarkSynced: %v", err)
+			}
+
+			if row, err := resolveAt(t, store, payloadID, 0); err != nil || row != nil {
+				t.Fatalf("offset 0 should read as a hole before the repair, got row=%v err=%v", row, err)
+			}
+			before := manifestSnapshot(t, store, payloadID)
+
+			applied := runRepair(t, store, share, ManifestCheckOptions{
+				CheckSynced: true, PlanRepairs: true, ApplyRepairs: true,
+			})
+			if applied.RepairsApplied != 1 {
+				t.Fatalf("want 1 applied repair, got %d: %+v", applied.RepairsApplied, applied.Repairs)
+			}
+			if got := applied.Repairs[0].Kind; got != RepairRecreateRow {
+				t.Fatalf("want %s, got %s", RepairRecreateRow, got)
+			}
+
+			row, err := resolveAt(t, store, payloadID, 0)
+			if err != nil || row == nil {
+				t.Fatalf("offset 0 unresolved after the repair: row=%v err=%v", row, err)
+			}
+			if row.Hash != seedHash(1) || row.DataSize != 4096 {
+				t.Fatalf("recreated row carries hash %s size %d, want the claim's", row.Hash, row.DataSize)
+			}
+			assertNoBytesLost(t, before, manifestSnapshot(t, store, payloadID))
+
+			after := runRepair(t, store, share, ManifestCheckOptions{CheckSynced: true})
+			if after.Damaged() {
+				t.Fatalf("payload still reports damage after the repair: %+v", after)
+			}
+		})
+	}
+}
+
+// TestRepairLeavesUnprovableCasesAlone pins the half of the report the command
+// must not act on. Each case is damage the scan reports and the repair has no
+// evidence for, so the store has to come back untouched.
+func TestRepairLeavesUnprovableCasesAlone(t *testing.T) {
+	cases := []struct {
+		name string
+		size uint64
+		rows []seedRow
+		refs []seedRef
+		// synced names the hash seeds the synced-hash store knows.
+		synced []byte
+		// backends narrows the case to the stores that can host it.
+		backends []string
+	}{{
+		// The claim's hash is not on the remote and no row carries it, so
+		// nothing can serve those bytes. A row here would turn an uncovered
+		// range into a failing read and recover nothing.
+		name: "claim whose hash nothing resolves",
+		size: 4096,
+		refs: []seedRef{{off: 0, size: 4096, hash: 1}},
+	}, {
+		// The row's bytes exist but nothing says where they belong.
+		name:     "unplaceable row matching no claim",
+		size:     4096,
+		rows:     []seedRow{{suffix: "not-an-offset", size: 4096, hash: 9}},
+		refs:     []seedRef{{off: 0, size: 4096, hash: 1}},
+		backends: sqlOnlyBackends,
+	}, {
+		// Two rows and two claims share a hash and length, so no pairing is
+		// better founded than any other and neither hash is on the remote.
+		name: "ambiguous one-to-many match",
+		size: 8192,
+		rows: []seedRow{
+			{suffix: "not-an-offset-a", size: 4096, hash: 1},
+			{suffix: "not-an-offset-b", size: 4096, hash: 1},
+		},
+		refs:     []seedRef{{off: 0, size: 4096, hash: 1}, {off: 4096, size: 4096, hash: 1}},
+		backends: sqlOnlyBackends,
+	}, {
+		// A pending row already owns the offset. Writing there would drop the
+		// bytes the rollup that created it is about to commit.
+		name: "pending row already at the offset",
+		size: 4096,
+		rows: []seedRow{{suffix: "0", size: 4096, hash: 0}},
+		refs: []seedRef{{off: 0, size: 4096, hash: 1}},
+		// The hash is on the remote, so only the occupied offset holds
+		// this case back.
+		synced: []byte{1},
+	}, {
+		// A placeable row whose hash the synced-hash store does not know is
+		// reported, but its bytes are what is missing, not its metadata.
+		name: "row with an unknown hash",
+		size: 4096,
+		rows: []seedRow{{suffix: "0", size: 4096, hash: 3}},
+		refs: []seedRef{{off: 0, size: 4096, hash: 3}},
+	}}
+
+	for _, tc := range cases {
+		backends := tc.backends
+		if backends == nil {
+			backends = repairBackends
+		}
+		for _, backend := range backends {
+			t.Run(tc.name+"/"+backend, func(t *testing.T) {
+				ctx := t.Context()
+				share := "/repair"
+				store, root := newCheckStore(t, backend, share)
+				payloadID := seedCheckFile(t, store, share, root, "f", tc.size, tc.rows, tc.refs)
+				for _, h := range tc.synced {
+					if err := store.MarkSynced(ctx, seedHash(h), block.ChunkLocator{}); err != nil {
+						t.Fatalf("MarkSynced: %v", err)
+					}
+				}
+				before := manifestSnapshot(t, store, payloadID)
+
+				res := runRepair(t, store, share, ManifestCheckOptions{
+					CheckSynced: true, PlanRepairs: true, ApplyRepairs: true,
+				})
+				if res.RepairsPlanned != 0 || len(res.Repairs) != 0 {
+					t.Fatalf("planned %d repair(s) with no evidence: %+v", res.RepairsPlanned, res.Repairs)
+				}
+				if !res.Damaged() {
+					t.Fatal("scan stopped reporting damage it cannot repair")
+				}
+
+				after := manifestSnapshot(t, store, payloadID)
+				if len(after) != len(before) {
+					t.Fatalf("manifest changed: %d rows before, %d after", len(before), len(after))
+				}
+				for id, row := range before {
+					got, ok := after[id]
+					if !ok {
+						t.Fatalf("row %s was removed", id)
+					}
+					if got.Hash != row.Hash || got.DataSize != row.DataSize {
+						t.Fatalf("row %s was rewritten: %+v -> %+v", id, row, got)
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestRepairSkipsWhenEvidenceMoved covers the write transaction re-establishing
+// what the plan relied on. The plan is computed outside the transaction against
+// a live store, so each precondition has to be able to fail there — and fail as
+// a skip carrying a reason, never as a forced write.
+func TestRepairSkipsWhenEvidenceMoved(t *testing.T) {
+	const payloadID = "payload-f"
+	hash := seedHash(1)
+
+	base := func() (*metadata.File, map[string]*block.FileChunk) {
+		return &metadata.File{
+				FileAttr: metadata.FileAttr{
+					Size:      4096,
+					PayloadID: metadata.PayloadID(payloadID),
+					Blocks:    []block.ChunkRef{{Hash: hash, Offset: 0, Size: 4096}},
+				},
+			}, map[string]*block.FileChunk{
+				payloadID + "/x": {ID: payloadID + "/x", Hash: hash, DataSize: 4096},
+			}
+	}
+
+	cases := []struct {
+		name   string
+		mutate func(f *metadata.File, rows map[string]*block.FileChunk, covered *[][2]uint64)
+		reason string
+		// kind defaults to RepairReplaceRow; the recreate branch rests on
+		// the synced marker instead of a source row.
+		kind RepairKind
+		// synced marks the claim's hash in the synced-hash store.
+		synced  bool
+		applies bool
+	}{{
+		name:    "evidence intact",
+		mutate:  func(*metadata.File, map[string]*block.FileChunk, *[][2]uint64) {},
+		applies: true,
+	}, {
+		name:   "claim withdrawn",
+		mutate: func(f *metadata.File, _ map[string]*block.FileChunk, _ *[][2]uint64) { f.Blocks = nil },
+		reason: "the file no longer claims this range",
+	}, {
+		name:   "file truncated",
+		mutate: func(f *metadata.File, _ map[string]*block.FileChunk, _ *[][2]uint64) { f.Size = 2048 },
+		reason: "the file is now shorter than the range",
+	}, {
+		name: "offset taken",
+		mutate: func(_ *metadata.File, rows map[string]*block.FileChunk, _ *[][2]uint64) {
+			rows[payloadID+"/0"] = &block.FileChunk{ID: payloadID + "/0"}
+		},
+		reason: "a manifest row now occupies the target offset",
+	}, {
+		name: "range covered",
+		mutate: func(_ *metadata.File, _ map[string]*block.FileChunk, covered *[][2]uint64) {
+			*covered = [][2]uint64{{0, 4096}}
+		},
+		reason: "another row now covers the range",
+	}, {
+		name: "source row gone",
+		mutate: func(_ *metadata.File, rows map[string]*block.FileChunk, _ *[][2]uint64) {
+			delete(rows, payloadID+"/x")
+		},
+		reason: "the unplaceable row is gone",
+	}, {
+		name: "source row rewritten",
+		mutate: func(_ *metadata.File, rows map[string]*block.FileChunk, _ *[][2]uint64) {
+			rows[payloadID+"/x"].DataSize = 1024
+		},
+		reason: "the unplaceable row no longer matches the claim",
+	}, {
+		name:    "recreate with the marker intact",
+		kind:    RepairRecreateRow,
+		synced:  true,
+		mutate:  func(*metadata.File, map[string]*block.FileChunk, *[][2]uint64) {},
+		applies: true,
+	}, {
+		// The refcount cascade clears the marker of a hash nothing references,
+		// and a hash whose row went missing is exactly that — so the one piece
+		// of evidence a recreate rests on can disappear under the plan.
+		name:   "recreate after the marker was cleared",
+		kind:   RepairRecreateRow,
+		mutate: func(*metadata.File, map[string]*block.FileChunk, *[][2]uint64) {},
+		reason: "the claim's hash is no longer marked synced",
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f, rows := base()
+			var covered [][2]uint64
+			tc.mutate(f, rows, &covered)
+
+			claimed := map[refKey]map[uint64]struct{}{}
+			for _, ref := range f.Blocks {
+				k := refKey{ref.Hash, ref.Size}
+				if claimed[k] == nil {
+					claimed[k] = map[uint64]struct{}{}
+				}
+				claimed[k][ref.Offset] = struct{}{}
+			}
+
+			kind := tc.kind
+			if kind == "" {
+				kind = RepairReplaceRow
+			}
+			action := RepairAction{
+				Kind:      kind,
+				PayloadID: payloadID,
+				Offset:    0,
+				Size:      4096,
+				Hash:      hash.String(),
+				ToRowID:   payloadID + "/0",
+			}
+			if kind == RepairReplaceRow {
+				action.FromRowID = payloadID + "/x"
+			}
+
+			store, _ := newCheckStore(t, "memory", "/repair")
+			if tc.synced {
+				if err := store.MarkSynced(t.Context(), hash, block.ChunkLocator{}); err != nil {
+					t.Fatalf("MarkSynced: %v", err)
+				}
+			}
+			var row *block.FileChunk
+			err := store.WithTransaction(t.Context(), func(tx metadata.Transaction) error {
+				var terr error
+				row, terr = repairRow(t.Context(), tx, &action, f, rows, claimed, covered, f.Mtime)
+				return terr
+			})
+			if err != nil {
+				t.Fatalf("repairRow: %v", err)
+			}
+			if tc.applies {
+				if row == nil {
+					t.Fatalf("intact evidence was skipped: %q", action.SkipReason)
+				}
+				if row.ID != action.ToRowID || row.Hash != hash || row.DataSize != 4096 {
+					t.Fatalf("repaired row = %+v, want the claim under the new ID", row)
+				}
+				return
+			}
+			if row != nil {
+				t.Fatal("wrote a row whose evidence had moved")
+			}
+			if action.SkipReason != tc.reason {
+				t.Fatalf("skip reason = %q, want %q", action.SkipReason, tc.reason)
+			}
+		})
+	}
+}
+
+// TestRepairToleratesAVanishedFile pins that a file unlinked between the scan
+// and the write costs its own repairs and nothing else. Aborting the whole run
+// there would let one unlink during a long scan strand every other payload's
+// repair.
+func TestRepairToleratesAVanishedFile(t *testing.T) {
+	share := "/repair"
+	store, _ := newCheckStore(t, "memory", share)
+
+	gone := &metadata.File{
+		ID:        uuid.New(),
+		ShareName: share,
+		FileAttr: metadata.FileAttr{
+			Size:      4096,
+			PayloadID: "payload-gone",
+			Blocks:    []block.ChunkRef{{Hash: seedHash(1), Offset: 0, Size: 4096}},
+		},
+	}
+	actions := []RepairAction{{
+		Kind:      RepairRecreateRow,
+		PayloadID: "payload-gone",
+		Size:      4096,
+		Hash:      seedHash(1).String(),
+		ToRowID:   "payload-gone/0",
+	}}
+
+	if err := applyPayloadRepairs(t.Context(), store, gone, actions); err != nil {
+		t.Fatalf("a vanished file must not fail the run: %v", err)
+	}
+	if actions[0].Applied {
+		t.Fatal("wrote a row for a file that no longer exists")
+	}
+	if actions[0].SkipReason != "the file is gone" {
+		t.Fatalf("skip reason = %q", actions[0].SkipReason)
+	}
+	if rows := manifestSnapshot(t, store, "payload-gone"); len(rows) != 0 {
+		t.Fatalf("manifest gained %d row(s) for a deleted file", len(rows))
+	}
+}
+
+// TestRepairDoesNotOverwriteItsOwnWrite pins that actions within one
+// transaction are checked against each other's writes. Two block-list entries
+// claiming the same range would otherwise both target one manifest key, and the
+// second put would silently replace the first.
+//
+// Only the in-memory store can host it: the SQL backends key a file's block
+// list by offset, so the duplicate entry never survives the write that seeds it.
+func TestRepairDoesNotOverwriteItsOwnWrite(t *testing.T) {
+	for _, backend := range []string{"memory"} {
+		t.Run(backend, func(t *testing.T) {
+			ctx := t.Context()
+			share := "/repair"
+			store, root := newCheckStore(t, backend, share)
+			payloadID := seedCheckFile(t, store, share, root, "twice", 4096, nil,
+				[]seedRef{{off: 0, size: 4096, hash: 1}, {off: 0, size: 4096, hash: 2}},
+			)
+			for _, h := range []byte{1, 2} {
+				if err := store.MarkSynced(ctx, seedHash(h), block.ChunkLocator{}); err != nil {
+					t.Fatalf("MarkSynced: %v", err)
+				}
+			}
+
+			res := runRepair(t, store, share, ManifestCheckOptions{
+				CheckSynced: true, PlanRepairs: true, ApplyRepairs: true,
+			})
+			if res.RepairsApplied != 1 || res.RepairsSkipped != 1 {
+				t.Fatalf("want 1 applied 1 skipped, got %d/%d: %+v",
+					res.RepairsApplied, res.RepairsSkipped, res.Repairs)
+			}
+			if rows := manifestSnapshot(t, store, payloadID); len(rows) != 1 {
+				t.Fatalf("want a single row at the offset, got %d", len(rows))
+			}
+		})
+	}
+}

--- a/pkg/controlplane/runtime/manifestcheck.go
+++ b/pkg/controlplane/runtime/manifestcheck.go
@@ -22,17 +22,17 @@ import (
 // resolved is treated as local-only — the conservative direction, since it
 // suppresses a check rather than inventing findings.
 //
+// opts carries the repair switches through unchanged. With neither set the
+// call writes nothing, which is what a plain check does.
+//
 // Returns ErrShareNotFound (wrapped) when the share is unknown.
-func (r *Runtime) CheckManifests(ctx context.Context, shareName string) (*engine.ManifestCheckResult, error) {
+func (r *Runtime) CheckManifests(ctx context.Context, shareName string, opts engine.ManifestCheckOptions) (*engine.ManifestCheckResult, error) {
 	mds, err := r.GetMetadataStoreForShare(shareName)
 	if err != nil {
 		return nil, err
 	}
 
-	var (
-		checkSynced bool
-		skipped     string
-	)
+	var skipped string
 	bs, bsErr := r.sharesSvc.GetBlockStoreForShare(shareName)
 	switch {
 	case bsErr != nil || bs == nil:
@@ -42,10 +42,10 @@ func (r *Runtime) CheckManifests(ctx context.Context, shareName string) (*engine
 	case !bs.HasRemoteStore():
 		skipped = "share has no remote store"
 	default:
-		checkSynced = true
+		opts.CheckSynced = true
 	}
 
-	res, err := engine.CheckManifests(ctx, shareName, mds, checkSynced)
+	res, err := engine.CheckManifests(ctx, shareName, mds, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -57,6 +57,9 @@ func (r *Runtime) CheckManifests(ctx context.Context, shareName string) (*engine
 		"claimed_uncovered_bytes", res.ClaimedUncoveredBytes,
 		"unplaceable_rows", res.UnplaceableRows,
 		"unknown_hash_rows", res.UnknownHashRows,
+		"repairs_planned", res.RepairsPlanned,
+		"repairs_applied", res.RepairsApplied,
+		"repairs_skipped", res.RepairsSkipped,
 		"duration_ms", res.DurationMS,
 	)
 	return res, nil


### PR DESCRIPTION
`store check` reported three kinds of manifest damage and gave the operator no
way to act on any of them. This adds `--repair`, which acts on the subset the
store holds proof for and says so explicitly about the rest.

## Which cases are repairable

The scan reports three defects. Only two shapes carry enough evidence to write
a row for, and both restore coverage the file itself already claims.

| Reported case | Repairable | Why |
| --- | --- | --- |
| Unplaceable row whose hash and length match exactly one uncovered claim | **yes** — move the row | The claim names the offset, and the hash names the bytes. The row keeps every other field; only its ID changes. |
| Claimed-but-uncovered range whose hash `IsSynced` resolves | **yes** — write the row | The remote holds the bytes under that hash, and the read path resolves a remote chunk by hash alone. |
| Claimed-but-uncovered range whose hash nothing resolves | no | Nothing can serve those bytes. A row would turn an uncovered range into a failing read and recover nothing. |
| Unplaceable row matching no claim | no | Nothing says where it belongs. Guessing an offset is how a manifest starts serving the wrong bytes. |
| Ambiguous match — one hash and length naming several rows or several claims | no | No pairing is better founded than any other. |
| Row whose hash the synced-hash store does not know | no | What is missing is the upload, not the metadata. Marking such a hash synced would let eviction drop the last copy — a data-loss bug, not a repair. |
| Uncovered range no file claims | not damage | Indistinguishable from a sparse hole or from bytes not yet rolled up. |

The repair only ever **adds** coverage the file already asked for. It never
deletes a claim, never widens or narrows one, and never marks a hash synced.
The one delete it performs — the old ID of a moved row — shares a transaction
with the put that replaces it, so the row is never absent from the manifest.

Two properties make the write safe rather than merely plausible. Remote chunks
are resolved by content hash and BLAKE3-verified on arrival, so a repair naming
a chunk the remote does not hold fails the read closed rather than serving
zeros — the pre-repair state, an uncovered range, is the one that zero-fills
silently. And every precondition the plan relies on, the synced marker
included, is re-established inside the write transaction, so a plan built
against a store that has since moved is skipped with a reason rather than
forced.

## Interface

`store check --repair` lists the writes it would make and stops at a
confirmation prompt — nothing is written before an answer. `--yes` answers it,
matching `share snapshot restore`. With `-o json`/`-o yaml` the run stops at
the plan rather than printing a prompt into the middle of the document, and
names `--yes` in the error.

A confirmed run writes, then re-scans read-only, so the summary it prints and
the exit code it returns describe the store as it stands afterwards. Without
`--repair` the command behaves exactly as before: no writes, no prompt, no
change for existing users. The API keeps that property at the boundary — the
scan endpoint's new request body is optional, and a caller that sends none gets
a read-only scan.

## Tests

Each repair path is proved through the read path's own resolver
(`findRowCoveringOffset`), not a re-derived opinion: the offset refuses or
reads as a hole before the repair and resolves the right chunk after it, on both
the in-memory and the SQL backend. Alongside that:

- every unprovable case leaves the manifest byte-identical, and the scan keeps
  reporting it as damage
- planning writes nothing
- a repair never drops coverage a hash held before it
- every precondition re-checked inside the write transaction is driven to its
  skip, with its reason asserted, including a hash whose synced marker was
  cleared between the plan and the write
- a file unlinked mid-run costs its own repairs and nothing else
- two claims colliding on one offset yield one write and one skip, never a
  silent overwrite
- the CLI dry run asks the server only to plan; a refused prompt writes nothing

Closes #2012
