### PR TITLE
fix(adapters): report the real bind outcome from adapter enable

### DIFF
--- a/cmd/dfsctl/commands/adapter/list.go
+++ b/cmd/dfsctl/commands/adapter/list.go
@@ -14,7 +14,7 @@ var listCmd = &cobra.Command{
 	Short: "List protocol adapters",
 	Long: `List all protocol adapters configured on the DittoFS server.
 
-Each row shows the adapter type (nfs or smb), the port it listens on, and whether it is currently enabled. Use this command to quickly confirm which protocols are active before connecting clients.
+Each row shows the adapter type (nfs or smb), the port it listens on, whether it is enabled, and whether its listener is actually running. RUNNING is the one to check before connecting clients: an adapter can be enabled yet not running when its port could not be claimed.
 
 Examples:
   # List adapters as a table
@@ -30,14 +30,19 @@ type AdapterList []apiclient.Adapter
 
 // Headers implements TableRenderer.
 func (al AdapterList) Headers() []string {
-	return []string{"TYPE", "PORT", "ENABLED"}
+	return []string{"TYPE", "PORT", "ENABLED", "RUNNING"}
 }
 
 // Rows implements TableRenderer.
 func (al AdapterList) Rows() [][]string {
 	rows := make([][]string, 0, len(al))
 	for _, a := range al {
-		rows = append(rows, []string{a.Type, fmt.Sprintf("%d", a.Port), cmdutil.BoolToYesNo(a.Enabled)})
+		rows = append(rows, []string{
+			a.Type,
+			fmt.Sprintf("%d", a.Port),
+			cmdutil.BoolToYesNo(a.Enabled),
+			cmdutil.BoolToYesNo(a.Running),
+		})
 	}
 	return rows
 }

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -950,7 +950,7 @@ List protocol adapters
 
 List all protocol adapters configured on the DittoFS server.
 
-Each row shows the adapter type (nfs or smb), the port it listens on, and whether it is currently enabled. Use this command to quickly confirm which protocols are active before connecting clients.
+Each row shows the adapter type (nfs or smb), the port it listens on, whether it is enabled, and whether its listener is actually running. RUNNING is the one to check before connecting clients: an adapter can be enabled yet not running when its port could not be claimed.
 
 ```
 dfsctl adapter list

--- a/internal/controlplane/api/handlers/adapters.go
+++ b/internal/controlplane/api/handlers/adapters.go
@@ -98,9 +98,8 @@ func (h *AdapterHandler) Create(w http.ResponseWriter, r *http.Request) {
 			Conflict(w, "Adapter already exists")
 			return
 		}
-		// Carry the cause: the common failure is a listener that could not
-		// bind, and the port or address that refused it is the whole of what
-		// the operator needs to fix it.
+		// Carry the cause: the usual failure is a listener that could not bind,
+		// and the port that refused it is what the operator needs to fix it.
 		InternalServerError(w, fmt.Sprintf("Failed to create adapter: %v", err))
 		return
 	}

--- a/internal/controlplane/api/handlers/adapters.go
+++ b/internal/controlplane/api/handlers/adapters.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -97,7 +98,10 @@ func (h *AdapterHandler) Create(w http.ResponseWriter, r *http.Request) {
 			Conflict(w, "Adapter already exists")
 			return
 		}
-		InternalServerError(w, "Failed to create adapter")
+		// Carry the cause: the common failure is a listener that could not
+		// bind, and the port or address that refused it is the whole of what
+		// the operator needs to fix it.
+		InternalServerError(w, fmt.Sprintf("Failed to create adapter: %v", err))
 		return
 	}
 
@@ -273,7 +277,7 @@ func (h *AdapterHandler) Update(w http.ResponseWriter, r *http.Request) {
 
 	// UpdateAdapter updates store AND restarts the adapter
 	if err := h.runtime.UpdateAdapter(r.Context(), adapter); err != nil {
-		InternalServerError(w, "Failed to update adapter")
+		InternalServerError(w, fmt.Sprintf("Failed to update adapter: %v", err))
 		return
 	}
 

--- a/internal/controlplane/api/handlers/health_test.go
+++ b/internal/controlplane/api/handlers/health_test.go
@@ -19,9 +19,15 @@ import (
 type mockAdapter struct {
 	protocol string
 	port     int
+	ready    chan struct{}
+}
+
+func newMockAdapter(protocol string, port int) *mockAdapter {
+	return &mockAdapter{protocol: protocol, port: port, ready: make(chan struct{})}
 }
 
 func (m *mockAdapter) Serve(ctx context.Context) error {
+	close(m.ready)
 	<-ctx.Done()
 	return ctx.Err()
 }
@@ -36,6 +42,12 @@ func (m *mockAdapter) Protocol() string {
 
 func (m *mockAdapter) Port() int {
 	return m.port
+}
+
+// ListenerReady reports the mock as bound as soon as Serve runs: it has no
+// real socket, so there is nothing to wait for beyond the goroutine starting.
+func (m *mockAdapter) ListenerReady() <-chan struct{} {
+	return m.ready
 }
 
 // Healthcheck satisfies the [adapters.ProtocolAdapter] interface (the
@@ -298,7 +310,7 @@ func TestReadiness_WithSharesAndAdapters_ReturnsOK(t *testing.T) {
 	}
 
 	// Add a mock adapter
-	adapter := &mockAdapter{protocol: "test", port: 12345}
+	adapter := newMockAdapter("test", 12345)
 	if err := reg.AddAdapter(adapter); err != nil {
 		t.Fatalf("Failed to add adapter: %v", err)
 	}

--- a/internal/controlplane/api/handlers/health_test.go
+++ b/internal/controlplane/api/handlers/health_test.go
@@ -50,10 +50,9 @@ func (m *mockAdapter) ListenerReady() <-chan struct{} {
 	return m.ready
 }
 
-// Healthcheck satisfies the [adapters.ProtocolAdapter] interface (the
-// new method added in phase U-C). The mock has no real lifecycle
-// state, so it always reports healthy with the current timestamp;
-// tests that need richer behaviour should use a dedicated fake.
+// Healthcheck satisfies the [adapters.ProtocolAdapter] interface. The mock has
+// no real lifecycle state, so it always reports healthy with the current
+// timestamp; tests that need richer behaviour should use a dedicated fake.
 func (m *mockAdapter) Healthcheck(_ context.Context) health.Report {
 	return health.Report{
 		Status:    health.StatusHealthy,

--- a/pkg/adapter/base.go
+++ b/pkg/adapter/base.go
@@ -118,9 +118,9 @@ type BaseAdapter struct {
 	// Uses sync.Map for concurrent-safe access optimized for high churn scenarios.
 	ActiveConnections sync.Map
 
-	// ListenerReady is closed when the listener is ready to accept connections.
-	// Used by tests to synchronize with server startup.
-	ListenerReady chan struct{}
+	// listenerReady is closed once the listener is bound and ready to accept
+	// connections. Read it through [BaseAdapter.ListenerReady].
+	listenerReady chan struct{}
 
 	// started flips to true once ServeWithFactory has bound the listener
 	// successfully. Used by [BaseAdapter.Healthcheck] to distinguish a
@@ -158,7 +158,7 @@ func NewBaseAdapter(config BaseConfig, protocol string) *BaseAdapter {
 		connSemaphore:  connSemaphore,
 		ShutdownCtx:    shutdownCtx,
 		CancelRequests: cancelRequests,
-		ListenerReady:  make(chan struct{}),
+		listenerReady:  make(chan struct{}),
 	}
 }
 
@@ -208,8 +208,8 @@ func (b *BaseAdapter) ServeWithFactory(
 	// Store listener with mutex protection and signal readiness.
 	//
 	// Ordering invariant: started must be flipped BEFORE closing
-	// ListenerReady. Tests (and the API layer's /status routes) treat
-	// "ListenerReady has fired" as proof that the listener is bound,
+	// listenerReady. Tests (and the API layer's /status routes) treat
+	// "listenerReady has fired" as proof that the listener is bound,
 	// so any concurrent Healthcheck observing a ready listener must
 	// also see started=true. Inverting these two lines would create a
 	// window where a probe sees a ready listener but reports
@@ -218,7 +218,7 @@ func (b *BaseAdapter) ServeWithFactory(
 	b.listener = listener
 	b.listenerMu.Unlock()
 	b.started.Store(true)
-	close(b.ListenerReady)
+	close(b.listenerReady)
 
 	logger.Info(b.protocolName+" server listening", "port", b.Config.Port)
 
@@ -500,7 +500,7 @@ func (b *BaseAdapter) Stop(ctx context.Context) error {
 // GetListenerAddr returns the address the server is listening on.
 // Blocks until the listener is ready, making it safe for tests.
 func (b *BaseAdapter) GetListenerAddr() string {
-	<-b.ListenerReady
+	<-b.listenerReady
 
 	b.listenerMu.RLock()
 	defer b.listenerMu.RUnlock()
@@ -509,6 +509,14 @@ func (b *BaseAdapter) GetListenerAddr() string {
 		return ""
 	}
 	return b.listener.Addr().String()
+}
+
+// ListenerReady returns a channel that is closed once the adapter has bound
+// its listening socket. It stays open when the bind fails, so a caller that
+// races it against the result of Serve learns whether the socket actually
+// came up instead of assuming it did.
+func (b *BaseAdapter) ListenerReady() <-chan struct{} {
+	return b.listenerReady
 }
 
 // Port returns the configured TCP port.

--- a/pkg/adapter/base.go
+++ b/pkg/adapter/base.go
@@ -511,10 +511,9 @@ func (b *BaseAdapter) GetListenerAddr() string {
 	return b.listener.Addr().String()
 }
 
-// ListenerReady returns a channel that is closed once the adapter has bound
-// its listening socket. It stays open when the bind fails, so a caller that
-// races it against the result of Serve learns whether the socket actually
-// came up instead of assuming it did.
+// ListenerReady returns a channel closed once the adapter has bound its
+// listening socket. It stays open when the bind fails, so a caller racing it
+// against the result of Serve learns whether the socket came up.
 func (b *BaseAdapter) ListenerReady() <-chan struct{} {
 	return b.listenerReady
 }

--- a/pkg/adapter/base_stop_test.go
+++ b/pkg/adapter/base_stop_test.go
@@ -61,7 +61,7 @@ func TestBaseAdapter_Stop_ClosesListener(t *testing.T) {
 	b.listener = ln
 	b.listenerMu.Unlock()
 	b.started.Store(true)
-	close(b.ListenerReady)
+	close(b.listenerReady)
 
 	// Sanity: the listener accepts before Stop.
 	c, err := net.DialTimeout("tcp", addr, time.Second)

--- a/pkg/apiclient/adapters.go
+++ b/pkg/apiclient/adapters.go
@@ -7,9 +7,12 @@ import (
 
 // Adapter represents a protocol adapter configuration.
 type Adapter struct {
-	Type      string          `json:"type"`
-	Port      int             `json:"port"`
-	Enabled   bool            `json:"enabled"`
+	Type    string `json:"type"`
+	Port    int    `json:"port"`
+	Enabled bool   `json:"enabled"`
+	// Running reports whether the adapter's listener is actually bound, which
+	// can differ from Enabled when a start failed to claim its port.
+	Running   bool            `json:"running"`
 	Config    json.RawMessage `json:"config,omitempty"`
 	CreatedAt time.Time       `json:"created_at"`
 }

--- a/pkg/controlplane/runtime/adapters/service.go
+++ b/pkg/controlplane/runtime/adapters/service.go
@@ -78,6 +78,13 @@ type adapterEntry struct {
 	cancelled bool
 }
 
+// serving reports whether the entry describes an adapter that confirmed its
+// listener and has not since been abandoned. A cancelled entry has not: it
+// holds the type so nothing else claims it, but either a start gave up waiting
+// for the bind or a teardown gave up waiting for the exit, so nothing about it
+// is known to be listening. Caller must hold mu.
+func (e *adapterEntry) serving() bool { return !e.cancelled }
+
 // Service manages protocol adapter lifecycle.
 type Service struct {
 	mu      sync.RWMutex
@@ -342,11 +349,34 @@ func (s *Service) awaitListener(adapterType string, entry *adapterEntry) error {
 	case <-time.After(s.startTimeout):
 		// The adapter is still running and may yet bind, so the entry stays to
 		// keep holding the type, marked the same way a timed-out stop marks it.
+		// Its context is cancelled, so it will exit; reap it then, or the type
+		// stays claimed by an adapter no caller can reach — a failed start rolls
+		// the store row back, and a later stop looks that row up before it would
+		// ever reach this entry.
 		entry.cancel()
 		s.mu.Lock()
 		entry.cancelled = true
 		s.mu.Unlock()
+		go s.reapWhenServed(adapterType, entry)
 		return fmt.Errorf("adapter %s listener not ready after %s", adapterType, s.startTimeout)
+	}
+}
+
+// reapWhenServed drops the entry once its serve goroutine has returned, freeing
+// the type for a later start. It is the cleanup for an entry that was abandoned
+// mid-flight: the context is already cancelled, so the wait ends as soon as the
+// adapter unwinds. The entry is dropped only while the map still holds it, so a
+// teardown that got there first cannot have its replacement removed. An adapter
+// that never returns keeps its entry, which is the honest answer — it may still
+// hold the socket.
+func (s *Service) reapWhenServed(adapterType string, entry *adapterEntry) {
+	<-entry.served
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.entries[adapterType] == entry {
+		delete(s.entries, adapterType)
+		logger.Info("Abandoned adapter released its socket", "type", adapterType)
 	}
 }
 
@@ -392,6 +422,7 @@ func (s *Service) stopAdapter(adapterType string) error {
 		entry.stopping = false
 		entry.cancelled = true
 		s.mu.Unlock()
+		go s.reapWhenServed(adapterType, entry)
 		logger.Warn("Adapter stop timed out", "type", adapterType)
 		return fmt.Errorf("adapter %s stop timed out", adapterType)
 	}
@@ -444,27 +475,29 @@ func (s *Service) LoadAdaptersFromStore(ctx context.Context) error {
 	return nil
 }
 
+// ListRunningAdapters names the adapters that are serving. It answers the same
+// question as [Service.IsAdapterRunning] and must agree with it — readiness
+// reports this list, so an abandoned entry counted here would advertise a
+// listener that may not exist.
 func (s *Service) ListRunningAdapters() []string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	types := make([]string, 0, len(s.entries))
-	for t := range s.entries {
-		types = append(types, t)
+	for t, e := range s.entries {
+		if e.serving() {
+			types = append(types, t)
+		}
 	}
 	return types
 }
 
-// IsAdapterRunning reports whether an adapter of the given type is serving. A
-// cancelled entry is not: it holds the type so nothing else claims it, but its
-// adapter never confirmed the listener — either a start gave up waiting for the
-// bind, or a teardown gave up waiting for the exit. Reporting those as running
-// would advertise a listener that may not exist.
+// IsAdapterRunning reports whether an adapter of the given type is serving.
 func (s *Service) IsAdapterRunning(adapterType string) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	e, exists := s.entries[adapterType]
-	return exists && !e.cancelled
+	return exists && e.serving()
 }
 
 // GetAdapter returns the running adapter for the given type, or nil if

--- a/pkg/controlplane/runtime/adapters/service.go
+++ b/pkg/controlplane/runtime/adapters/service.go
@@ -16,6 +16,12 @@ import (
 // DefaultShutdownTimeout is the default timeout for graceful adapter shutdown.
 const DefaultShutdownTimeout = 30 * time.Second
 
+// defaultStartTimeout bounds how long a start waits for the adapter to bind.
+// Binding is a syscall, so the wait is normally sub-millisecond; the bound
+// exists only so setup that runs before the bind and wedges cannot hang the
+// caller forever.
+const defaultStartTimeout = 15 * time.Second
+
 // ProtocolAdapter is the interface for protocol adapters (NFS, SMB).
 //
 // It mirrors a strict subset of [adapter.Adapter]: the methods this
@@ -30,6 +36,12 @@ type ProtocolAdapter interface {
 	Protocol() string
 	Port() int
 	Healthcheck(ctx context.Context) health.Report
+
+	// ListenerReady is closed once Serve has bound the listening socket. It
+	// stays open when the bind fails, which is what lets a start distinguish
+	// "serving" from "about to fail" instead of reporting success for a
+	// listener that never came up.
+	ListenerReady() <-chan struct{}
 }
 
 // RuntimeSetter is implemented by adapters that need runtime access.
@@ -66,6 +78,7 @@ type Service struct {
 
 	store           store.AdapterStore
 	shutdownTimeout time.Duration
+	startTimeout    time.Duration
 	runtime         any // injected into adapters implementing RuntimeSetter
 }
 
@@ -78,6 +91,7 @@ func New(adapterStore store.AdapterStore, shutdownTimeout time.Duration) *Servic
 		entries:         make(map[string]*adapterEntry),
 		store:           adapterStore,
 		shutdownTimeout: shutdownTimeout,
+		startTimeout:    defaultStartTimeout,
 	}
 }
 
@@ -259,25 +273,74 @@ func (s *Service) DisableAdapter(ctx context.Context, adapterType string) error 
 	return nil
 }
 
+// startAdapter creates the adapter, runs it, and returns only once its
+// listener is bound. The entry is registered before the wait so a competing
+// start of the same type is refused while this one is still binding, and it is
+// dropped again if the bind fails.
 func (s *Service) startAdapter(cfg *models.AdapterConfig) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	if err := s.typeClaimedLocked(cfg.Type); err != nil {
+		s.mu.Unlock()
 		return err
 	}
 
 	if s.factory == nil {
+		s.mu.Unlock()
 		return fmt.Errorf("adapter factory not set")
 	}
 
 	adp, err := s.factory(cfg)
 	if err != nil {
+		s.mu.Unlock()
 		return fmt.Errorf("failed to create adapter: %w", err)
 	}
 
-	s.registerAndRunAdapterLocked(adp, cfg)
-	return nil
+	entry := s.registerAndRunAdapterLocked(adp, cfg)
+	s.mu.Unlock()
+
+	return s.awaitListener(cfg.Type, entry)
+}
+
+// awaitListener blocks until the adapter has bound its listening socket, its
+// serve goroutine has returned, or the start deadline passes. Binding happens
+// inside Serve, so this is the only point at which a bind failure — an
+// occupied port, an unavailable address, insufficient privilege — becomes
+// observable; returning before it makes every start report the intent to serve
+// rather than the outcome.
+//
+// A serve goroutine that returned has released the socket, so its entry is
+// dropped and the type freed for a retry. A start that merely timed out has
+// not: the adapter is still running and may yet bind, so the entry stays to
+// keep holding the type, marked the same way a timed-out stop marks it.
+func (s *Service) awaitListener(adapterType string, entry *adapterEntry) error {
+	var err error
+
+	select {
+	case serveErr := <-entry.errCh:
+		err = serveErr
+		if err == nil {
+			err = fmt.Errorf("adapter %s stopped before its listener was ready", adapterType)
+		}
+		entry.cancel()
+		s.mu.Lock()
+		delete(s.entries, adapterType)
+		s.mu.Unlock()
+
+	case <-entry.adapter.ListenerReady():
+		logger.Info("Adapter started", "type", adapterType, "port", entry.adapter.Port())
+		return nil
+
+	case <-time.After(s.startTimeout):
+		err = fmt.Errorf("adapter %s listener not ready after %s", adapterType, s.startTimeout)
+		entry.cancel()
+		s.mu.Lock()
+		entry.cancelled = true
+		s.mu.Unlock()
+	}
+
+	logger.Error("Adapter failed to start", "type", adapterType, "error", err)
+	return err
 }
 
 // stopAdapter tears down the running adapter of the given type. Its entry stays
@@ -403,15 +466,17 @@ func (s *Service) AddAdapter(adapter ProtocolAdapter) error {
 	adapterType := adapter.Protocol()
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	if err := s.typeClaimedLocked(adapterType); err != nil {
+		s.mu.Unlock()
 		return err
 	}
 
 	cfg := &models.AdapterConfig{Type: adapterType, Port: adapter.Port(), Enabled: true}
-	s.registerAndRunAdapterLocked(adapter, cfg)
-	return nil
+	entry := s.registerAndRunAdapterLocked(adapter, cfg)
+	s.mu.Unlock()
+
+	return s.awaitListener(adapterType, entry)
 }
 
 // clientDisconnecter allows force-closing a specific client connection.
@@ -454,8 +519,10 @@ func (s *Service) typeClaimedLocked(adapterType string) error {
 	}
 }
 
-// registerAndRunAdapterLocked starts the adapter in a goroutine. Caller must hold mu.
-func (s *Service) registerAndRunAdapterLocked(adp ProtocolAdapter, cfg *models.AdapterConfig) {
+// registerAndRunAdapterLocked runs the adapter in a goroutine and returns its
+// entry. The adapter has not bound its listener yet at this point; callers wait
+// for that with [Service.awaitListener]. Caller must hold mu.
+func (s *Service) registerAndRunAdapterLocked(adp ProtocolAdapter, cfg *models.AdapterConfig) *adapterEntry {
 	if setter, ok := adp.(RuntimeSetter); ok && s.runtime != nil {
 		setter.SetRuntime(s.runtime)
 	}
@@ -472,12 +539,13 @@ func (s *Service) registerAndRunAdapterLocked(adp ProtocolAdapter, cfg *models.A
 		errCh <- err
 	}()
 
-	s.entries[cfg.Type] = &adapterEntry{
+	entry := &adapterEntry{
 		adapter: adp,
 		config:  cfg,
 		cancel:  cancel,
 		errCh:   errCh,
 	}
+	s.entries[cfg.Type] = entry
 
-	logger.Info("Adapter started", "type", cfg.Type, "port", cfg.Port)
+	return entry
 }

--- a/pkg/controlplane/runtime/adapters/service.go
+++ b/pkg/controlplane/runtime/adapters/service.go
@@ -339,7 +339,6 @@ func (s *Service) awaitListener(adapterType string, entry *adapterEntry) error {
 		s.mu.Unlock()
 	}
 
-	logger.Error("Adapter failed to start", "type", adapterType, "error", err)
 	return err
 }
 

--- a/pkg/controlplane/runtime/adapters/service.go
+++ b/pkg/controlplane/runtime/adapters/service.go
@@ -37,10 +37,9 @@ type ProtocolAdapter interface {
 	Port() int
 	Healthcheck(ctx context.Context) health.Report
 
-	// ListenerReady is closed once Serve has bound the listening socket. It
-	// stays open when the bind fails, which is what lets a start distinguish
-	// "serving" from "about to fail" instead of reporting success for a
-	// listener that never came up.
+	// ListenerReady is closed once Serve has bound the listening socket, and
+	// stays open when the bind fails. Racing it against Serve returning is what
+	// lets a start report the outcome of the bind rather than the intent.
 	ListenerReady() <-chan struct{}
 }
 
@@ -308,38 +307,33 @@ func (s *Service) startAdapter(cfg *models.AdapterConfig) error {
 // occupied port, an unavailable address, insufficient privilege — becomes
 // observable; returning before it makes every start report the intent to serve
 // rather than the outcome.
-//
-// A serve goroutine that returned has released the socket, so its entry is
-// dropped and the type freed for a retry. A start that merely timed out has
-// not: the adapter is still running and may yet bind, so the entry stays to
-// keep holding the type, marked the same way a timed-out stop marks it.
 func (s *Service) awaitListener(adapterType string, entry *adapterEntry) error {
-	var err error
-
 	select {
-	case serveErr := <-entry.errCh:
-		err = serveErr
-		if err == nil {
-			err = fmt.Errorf("adapter %s stopped before its listener was ready", adapterType)
-		}
-		entry.cancel()
-		s.mu.Lock()
-		delete(s.entries, adapterType)
-		s.mu.Unlock()
-
 	case <-entry.adapter.ListenerReady():
 		logger.Info("Adapter started", "type", adapterType, "port", entry.adapter.Port())
 		return nil
 
+	case err := <-entry.errCh:
+		// The serve goroutine returned, so it has released the socket: drop the
+		// entry and free the type for a retry.
+		entry.cancel()
+		s.mu.Lock()
+		delete(s.entries, adapterType)
+		s.mu.Unlock()
+		if err == nil {
+			return fmt.Errorf("adapter %s stopped before its listener was ready", adapterType)
+		}
+		return err
+
 	case <-time.After(s.startTimeout):
-		err = fmt.Errorf("adapter %s listener not ready after %s", adapterType, s.startTimeout)
+		// The adapter is still running and may yet bind, so the entry stays to
+		// keep holding the type, marked the same way a timed-out stop marks it.
 		entry.cancel()
 		s.mu.Lock()
 		entry.cancelled = true
 		s.mu.Unlock()
+		return fmt.Errorf("adapter %s listener not ready after %s", adapterType, s.startTimeout)
 	}
-
-	return err
 }
 
 // stopAdapter tears down the running adapter of the given type. Its entry stays

--- a/pkg/controlplane/runtime/adapters/service.go
+++ b/pkg/controlplane/runtime/adapters/service.go
@@ -315,10 +315,15 @@ func (s *Service) awaitListener(adapterType string, entry *adapterEntry) error {
 
 	case err := <-entry.errCh:
 		// The serve goroutine returned, so it has released the socket: drop the
-		// entry and free the type for a retry.
+		// entry and free the type for a retry. Drop it only while the map still
+		// holds this entry — a teardown that overtook this start has already
+		// removed it, and whatever registered the type afterwards belongs to a
+		// later start that is still serving.
 		entry.cancel()
 		s.mu.Lock()
-		delete(s.entries, adapterType)
+		if s.entries[adapterType] == entry {
+			delete(s.entries, adapterType)
+		}
 		s.mu.Unlock()
 		if err == nil {
 			return fmt.Errorf("adapter %s stopped before its listener was ready", adapterType)

--- a/pkg/controlplane/runtime/adapters/service.go
+++ b/pkg/controlplane/runtime/adapters/service.go
@@ -407,6 +407,14 @@ func (s *Service) StopAllAdapters() error {
 }
 
 // LoadAdaptersFromStore loads enabled adapters from store and starts them.
+//
+// An adapter that cannot start is logged and skipped rather than failing the
+// load. A persisted port can become unusable between one boot and the next —
+// another process claimed it, or the host lost the address — and taking the
+// whole server down with it would also take down the control-plane API, which
+// is the only way left to correct the port without console access. The adapter
+// stays enabled in the store: that is the requested state, retried on the next
+// start or when the operator re-enables it.
 func (s *Service) LoadAdaptersFromStore(ctx context.Context) error {
 	adapters, err := s.store.ListAdapters(ctx)
 	if err != nil {
@@ -420,7 +428,8 @@ func (s *Service) LoadAdaptersFromStore(ctx context.Context) error {
 		}
 
 		if err := s.startAdapter(cfg); err != nil {
-			return fmt.Errorf("failed to start adapter %s: %w", cfg.Type, err)
+			logger.Error("Adapter failed to start; continuing without it",
+				"type", cfg.Type, "port", cfg.Port, "error", err)
 		}
 	}
 

--- a/pkg/controlplane/runtime/adapters/service.go
+++ b/pkg/controlplane/runtime/adapters/service.go
@@ -55,7 +55,16 @@ type adapterEntry struct {
 	adapter ProtocolAdapter
 	config  *models.AdapterConfig
 	cancel  context.CancelFunc
-	errCh   chan error
+
+	// served is closed once the serve goroutine has returned, with serveErr
+	// holding its result. A start and a teardown can both be waiting on the
+	// same adapter to exit, so this is a broadcast rather than a single
+	// delivered value: a value sent once would wake only whichever of them
+	// happened to receive it, leaving the other to sit out its own timeout and
+	// then report that instead of the real outcome. serveErr is written before
+	// the close and read only after it.
+	served   chan struct{}
+	serveErr error
 
 	// stopping marks a teardown in progress: the entry is still in the map,
 	// but the adapter is on its way out. Guarded by Service.mu.
@@ -313,7 +322,7 @@ func (s *Service) awaitListener(adapterType string, entry *adapterEntry) error {
 		logger.Info("Adapter started", "type", adapterType, "port", entry.adapter.Port())
 		return nil
 
-	case err := <-entry.errCh:
+	case <-entry.served:
 		// The serve goroutine returned, so it has released the socket: drop the
 		// entry and free the type for a retry. Drop it only while the map still
 		// holds this entry — a teardown that overtook this start has already
@@ -325,10 +334,10 @@ func (s *Service) awaitListener(adapterType string, entry *adapterEntry) error {
 			delete(s.entries, adapterType)
 		}
 		s.mu.Unlock()
-		if err == nil {
+		if entry.serveErr == nil {
 			return fmt.Errorf("adapter %s stopped before its listener was ready", adapterType)
 		}
-		return err
+		return entry.serveErr
 
 	case <-time.After(s.startTimeout):
 		// The adapter is still running and may yet bind, so the entry stays to
@@ -372,7 +381,7 @@ func (s *Service) stopAdapter(adapterType string) error {
 
 	entry.cancel()
 	select {
-	case <-entry.errCh:
+	case <-entry.served:
 		s.mu.Lock()
 		delete(s.entries, adapterType)
 		s.mu.Unlock()
@@ -446,11 +455,16 @@ func (s *Service) ListRunningAdapters() []string {
 	return types
 }
 
+// IsAdapterRunning reports whether an adapter of the given type is serving. A
+// cancelled entry is not: it holds the type so nothing else claims it, but its
+// adapter never confirmed the listener — either a start gave up waiting for the
+// bind, or a teardown gave up waiting for the exit. Reporting those as running
+// would advertise a listener that may not exist.
 func (s *Service) IsAdapterRunning(adapterType string) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	_, exists := s.entries[adapterType]
-	return exists
+	e, exists := s.entries[adapterType]
+	return exists && !e.cancelled
 }
 
 // GetAdapter returns the running adapter for the given type, or nil if
@@ -535,7 +549,14 @@ func (s *Service) registerAndRunAdapterLocked(adp ProtocolAdapter, cfg *models.A
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	errCh := make(chan error, 1)
+
+	entry := &adapterEntry{
+		adapter: adp,
+		config:  cfg,
+		cancel:  cancel,
+		served:  make(chan struct{}),
+	}
+	s.entries[cfg.Type] = entry
 
 	go func() {
 		logger.Info("Starting adapter", "protocol", adp.Protocol(), "port", adp.Port())
@@ -543,16 +564,9 @@ func (s *Service) registerAndRunAdapterLocked(adp ProtocolAdapter, cfg *models.A
 		if err != nil && !errors.Is(err, context.Canceled) && ctx.Err() == nil {
 			logger.Error("Adapter failed", "protocol", adp.Protocol(), "error", err)
 		}
-		errCh <- err
+		entry.serveErr = err
+		close(entry.served)
 	}()
-
-	entry := &adapterEntry{
-		adapter: adp,
-		config:  cfg,
-		cancel:  cancel,
-		errCh:   errCh,
-	}
-	s.entries[cfg.Type] = entry
 
 	return entry
 }

--- a/pkg/controlplane/runtime/adapters/service_test.go
+++ b/pkg/controlplane/runtime/adapters/service_test.go
@@ -3,7 +3,9 @@ package adapters
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -468,4 +470,145 @@ func TestEnableAdapter_RollsBackEnabledOnStartFailure(t *testing.T) {
 	if stored.Enabled {
 		t.Fatal("persisted config still claims the adapter is enabled after a failed start")
 	}
+}
+
+// squattedPortAdapter fails to bind because something else already holds its
+// port, the same way a real adapter fails when the kernel SMB listener or
+// another process owns the port an operator asked for.
+type squattedPortAdapter struct {
+	protocol string
+	port     int
+	ready    chan struct{}
+}
+
+func newSquattedPortAdapter(protocol string, port int) *squattedPortAdapter {
+	return &squattedPortAdapter{protocol: protocol, port: port, ready: make(chan struct{})}
+}
+
+func (a *squattedPortAdapter) Serve(context.Context) error {
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", a.port))
+	if err != nil {
+		return err
+	}
+	close(a.ready)
+	defer func() { _ = ln.Close() }()
+	return nil
+}
+
+func (a *squattedPortAdapter) Stop(context.Context) error                { return nil }
+func (a *squattedPortAdapter) Protocol() string                          { return a.protocol }
+func (a *squattedPortAdapter) Port() int                                 { return a.port }
+func (a *squattedPortAdapter) Healthcheck(context.Context) health.Report { return health.Report{} }
+func (a *squattedPortAdapter) ListenerReady() <-chan struct{}            { return a.ready }
+
+// squatPort binds a loopback port and keeps it for the test, returning the
+// port number nothing else can claim while the test runs.
+func squatPort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("squat listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+// TestStartAdapter_ReportsBindFailure proves a start reports the outcome of the
+// bind rather than the intent to serve. Binding happens inside Serve, which
+// runs in its own goroutine, so a start that returns early hands back success
+// for a listener that never came up — the caller then advertises an adapter
+// that is not serving, and clients reaching the port find whatever else owns
+// it. The seam is shared by every adapter type, so both are checked.
+func TestStartAdapter_ReportsBindFailure(t *testing.T) {
+	for _, adapterType := range []string{"smb", "nfs"} {
+		t.Run(adapterType, func(t *testing.T) {
+			port := squatPort(t)
+
+			st := newFakeAdapterStore()
+			svc := New(st, time.Second)
+			svc.SetAdapterFactory(func(cfg *models.AdapterConfig) (ProtocolAdapter, error) {
+				return newSquattedPortAdapter(cfg.Type, cfg.Port), nil
+			})
+
+			cfg := &models.AdapterConfig{Type: adapterType, Port: port, Enabled: false}
+			if _, err := st.CreateAdapter(context.Background(), cfg); err != nil {
+				t.Fatalf("seed adapter: %v", err)
+			}
+
+			err := svc.EnableAdapter(context.Background(), adapterType)
+			if err == nil {
+				t.Fatal("EnableAdapter reported success for an adapter that never bound its port")
+			}
+			if !strings.Contains(err.Error(), "address already in use") {
+				t.Fatalf("error does not name the bind failure: %v", err)
+			}
+
+			if svc.IsAdapterRunning(adapterType) {
+				t.Error("adapter left registered as running after a failed bind")
+			}
+
+			stored, err := st.GetAdapter(context.Background(), adapterType)
+			if err != nil {
+				t.Fatalf("GetAdapter: %v", err)
+			}
+			if stored.Enabled {
+				t.Error("store still advertises the adapter as enabled after a failed bind")
+			}
+		})
+	}
+}
+
+// wedgedAdapter never binds and never returns from Serve, standing in for setup
+// that hangs before the listener is created.
+type wedgedAdapter struct {
+	protocol string
+	port     int
+	release  chan struct{}
+	ready    chan struct{}
+}
+
+func newWedgedAdapter(protocol string, port int) *wedgedAdapter {
+	return &wedgedAdapter{
+		protocol: protocol,
+		port:     port,
+		release:  make(chan struct{}),
+		ready:    make(chan struct{}),
+	}
+}
+
+func (a *wedgedAdapter) Serve(context.Context) error {
+	<-a.release
+	return nil
+}
+
+func (a *wedgedAdapter) Stop(context.Context) error                { return nil }
+func (a *wedgedAdapter) Protocol() string                          { return a.protocol }
+func (a *wedgedAdapter) Port() int                                 { return a.port }
+func (a *wedgedAdapter) Healthcheck(context.Context) health.Report { return health.Report{} }
+func (a *wedgedAdapter) ListenerReady() <-chan struct{}            { return a.ready }
+
+// TestStartAdapter_TimesOutWhenListenerNeverBinds proves the wait is bounded:
+// an adapter that wedges before binding fails the start instead of blocking the
+// caller forever. Its entry stays behind because the adapter is still alive and
+// may yet claim the socket.
+func TestStartAdapter_TimesOutWhenListenerNeverBinds(t *testing.T) {
+	svc := New(newFakeAdapterStore(), time.Second)
+	svc.startTimeout = 50 * time.Millisecond
+
+	wedged := newWedgedAdapter("nfs", 12049)
+	svc.SetAdapterFactory(func(cfg *models.AdapterConfig) (ProtocolAdapter, error) {
+		return wedged, nil
+	})
+
+	err := svc.CreateAdapter(context.Background(), &models.AdapterConfig{
+		Type: "nfs", Port: 12049, Enabled: true,
+	})
+	if err == nil {
+		t.Fatal("CreateAdapter reported success for an adapter that never bound")
+	}
+	if !strings.Contains(err.Error(), "listener not ready") {
+		t.Fatalf("error does not name the wait: %v", err)
+	}
+
+	close(wedged.release)
 }

--- a/pkg/controlplane/runtime/adapters/service_test.go
+++ b/pkg/controlplane/runtime/adapters/service_test.go
@@ -553,8 +553,16 @@ func TestStartAdapter_ReportsBindFailure(t *testing.T) {
 			if err == nil {
 				t.Fatal("EnableAdapter reported success for an adapter that never bound its port")
 			}
-			if !strings.Contains(err.Error(), "address already in use") {
-				t.Fatalf("error does not name the bind failure: %v", err)
+			// Assert on the parts every platform words the same way. The
+			// operating systems disagree on the wording of the errno itself
+			// ("address already in use" against "Only one usage of each socket
+			// address..."), but the caller needs the same two facts either way:
+			// that a bind is what failed, and which port refused it.
+			if !strings.Contains(err.Error(), "bind:") {
+				t.Errorf("error does not identify a bind failure: %v", err)
+			}
+			if !strings.Contains(err.Error(), fmt.Sprintf("%d", port)) {
+				t.Errorf("error does not name the port that refused: %v", err)
 			}
 
 			if svc.IsAdapterRunning(adapterType) {

--- a/pkg/controlplane/runtime/adapters/service_test.go
+++ b/pkg/controlplane/runtime/adapters/service_test.go
@@ -617,6 +617,13 @@ func TestStartAdapter_TimesOutWhenListenerNeverBinds(t *testing.T) {
 	if !strings.Contains(err.Error(), "listener not ready") {
 		t.Fatalf("error does not name the wait: %v", err)
 	}
+
+	// The entry stays behind to hold the type, but nothing about it confirmed a
+	// listener, so it must not be advertised as running — that is the same
+	// false success in a different coat.
+	if svc.IsAdapterRunning("nfs") {
+		t.Error("adapter reported as running after its start timed out waiting for the bind")
+	}
 }
 
 // TestLoadAdaptersFromStore_SkipsUnbindableAdapter proves a boot survives a

--- a/pkg/controlplane/runtime/adapters/service_test.go
+++ b/pkg/controlplane/runtime/adapters/service_test.go
@@ -498,14 +498,15 @@ func newSquattedPortAdapter(protocol string, port int) *squattedPortAdapter {
 	return &squattedPortAdapter{protocol: protocol, port: port, ready: make(chan struct{})}
 }
 
-func (a *squattedPortAdapter) Serve(context.Context) error {
+func (a *squattedPortAdapter) Serve(ctx context.Context) error {
 	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", a.port))
 	if err != nil {
 		return err
 	}
-	close(a.ready)
 	defer func() { _ = ln.Close() }()
-	return nil
+	close(a.ready)
+	<-ctx.Done()
+	return ctx.Err()
 }
 
 func (a *squattedPortAdapter) Stop(context.Context) error                { return nil }
@@ -571,27 +572,22 @@ func TestStartAdapter_ReportsBindFailure(t *testing.T) {
 	}
 }
 
-// wedgedAdapter never binds and never returns from Serve, standing in for setup
-// that hangs before the listener is created.
+// wedgedAdapter never binds, standing in for setup that hangs before the
+// listener is created. Serve returns only once the start gives up and cancels
+// it, so the adapter is still running for the whole of the wait.
 type wedgedAdapter struct {
 	protocol string
 	port     int
-	release  chan struct{}
 	ready    chan struct{}
 }
 
 func newWedgedAdapter(protocol string, port int) *wedgedAdapter {
-	return &wedgedAdapter{
-		protocol: protocol,
-		port:     port,
-		release:  make(chan struct{}),
-		ready:    make(chan struct{}),
-	}
+	return &wedgedAdapter{protocol: protocol, port: port, ready: make(chan struct{})}
 }
 
-func (a *wedgedAdapter) Serve(context.Context) error {
-	<-a.release
-	return nil
+func (a *wedgedAdapter) Serve(ctx context.Context) error {
+	<-ctx.Done()
+	return ctx.Err()
 }
 
 func (a *wedgedAdapter) Stop(context.Context) error                { return nil }
@@ -608,9 +604,8 @@ func TestStartAdapter_TimesOutWhenListenerNeverBinds(t *testing.T) {
 	svc := New(newFakeAdapterStore(), time.Second)
 	svc.startTimeout = 50 * time.Millisecond
 
-	wedged := newWedgedAdapter("nfs", 12049)
 	svc.SetAdapterFactory(func(cfg *models.AdapterConfig) (ProtocolAdapter, error) {
-		return wedged, nil
+		return newWedgedAdapter(cfg.Type, cfg.Port), nil
 	})
 
 	err := svc.CreateAdapter(context.Background(), &models.AdapterConfig{
@@ -622,8 +617,6 @@ func TestStartAdapter_TimesOutWhenListenerNeverBinds(t *testing.T) {
 	if !strings.Contains(err.Error(), "listener not ready") {
 		t.Fatalf("error does not name the wait: %v", err)
 	}
-
-	close(wedged.release)
 }
 
 // TestLoadAdaptersFromStore_SkipsUnbindableAdapter proves a boot survives a

--- a/pkg/controlplane/runtime/adapters/service_test.go
+++ b/pkg/controlplane/runtime/adapters/service_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -54,6 +55,18 @@ func (f *fakeAdapterStore) GetAdapter(_ context.Context, t string) (*models.Adap
 	}
 	cp := *a
 	return &cp, nil
+}
+
+func (f *fakeAdapterStore) ListAdapters(_ context.Context) ([]*models.AdapterConfig, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]*models.AdapterConfig, 0, len(f.byType))
+	for _, a := range f.byType {
+		cp := *a
+		out = append(out, &cp)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Type < out[j].Type })
+	return out, nil
 }
 
 func (f *fakeAdapterStore) DeleteAdapter(_ context.Context, t string) error {
@@ -611,4 +624,39 @@ func TestStartAdapter_TimesOutWhenListenerNeverBinds(t *testing.T) {
 	}
 
 	close(wedged.release)
+}
+
+// TestLoadAdaptersFromStore_SkipsUnbindableAdapter proves a boot survives a
+// persisted port that can no longer be claimed: the failing adapter is skipped
+// and the rest still start, so the control-plane API stays reachable and the
+// port can be corrected without console access.
+func TestLoadAdaptersFromStore_SkipsUnbindableAdapter(t *testing.T) {
+	port := squatPort(t)
+
+	st := newFakeAdapterStore()
+	ctx := context.Background()
+	if _, err := st.CreateAdapter(ctx, &models.AdapterConfig{Type: "smb", Port: port, Enabled: true}); err != nil {
+		t.Fatalf("seed smb: %v", err)
+	}
+	if _, err := st.CreateAdapter(ctx, &models.AdapterConfig{Type: "nfs", Port: 12049, Enabled: true}); err != nil {
+		t.Fatalf("seed nfs: %v", err)
+	}
+
+	svc := New(st, time.Second)
+	svc.SetAdapterFactory(func(cfg *models.AdapterConfig) (ProtocolAdapter, error) {
+		if cfg.Type == "smb" {
+			return newSquattedPortAdapter(cfg.Type, cfg.Port), nil
+		}
+		return newFakeListenerAdapter(cfg.Type, cfg.Port), nil
+	})
+
+	if err := svc.LoadAdaptersFromStore(ctx); err != nil {
+		t.Fatalf("a single unbindable adapter failed the whole load: %v", err)
+	}
+	if svc.IsAdapterRunning("smb") {
+		t.Error("unbindable adapter registered as running")
+	}
+	if !svc.IsAdapterRunning("nfs") {
+		t.Error("bindable adapter was not started")
+	}
 }

--- a/pkg/controlplane/runtime/adapters/service_test.go
+++ b/pkg/controlplane/runtime/adapters/service_test.go
@@ -104,6 +104,7 @@ func (a *fakeListenerAdapter) Stop(context.Context) error {
 func (a *fakeListenerAdapter) Protocol() string                          { return a.protocol }
 func (a *fakeListenerAdapter) Port() int                                 { return a.port }
 func (a *fakeListenerAdapter) Healthcheck(context.Context) health.Report { return health.Report{} }
+func (a *fakeListenerAdapter) ListenerReady() <-chan struct{}            { return a.ready }
 
 func (a *fakeListenerAdapter) listener() net.Listener {
 	a.mu.Lock()
@@ -286,6 +287,7 @@ type slowStopAdapter struct {
 	stopOnce   sync.Once
 	stopCalled chan struct{}
 	release    chan struct{}
+	ready      chan struct{}
 }
 
 func newSlowStopAdapter(protocol string, port int) *slowStopAdapter {
@@ -294,10 +296,12 @@ func newSlowStopAdapter(protocol string, port int) *slowStopAdapter {
 		port:       port,
 		stopCalled: make(chan struct{}),
 		release:    make(chan struct{}),
+		ready:      make(chan struct{}),
 	}
 }
 
 func (a *slowStopAdapter) Serve(ctx context.Context) error {
+	close(a.ready)
 	<-ctx.Done()
 	<-a.release
 	return ctx.Err()
@@ -311,6 +315,7 @@ func (a *slowStopAdapter) Stop(context.Context) error {
 func (a *slowStopAdapter) Protocol() string                          { return a.protocol }
 func (a *slowStopAdapter) Port() int                                 { return a.port }
 func (a *slowStopAdapter) Healthcheck(context.Context) health.Report { return health.Report{} }
+func (a *slowStopAdapter) ListenerReady() <-chan struct{}            { return a.ready }
 
 // TestStopAdapter_HoldsEntryUntilAdapterConfirmsStopped proves the registry
 // keeps describing an adapter that is still alive: a start of the same type

--- a/pkg/controlplane/runtime/checkers_test.go
+++ b/pkg/controlplane/runtime/checkers_test.go
@@ -66,21 +66,29 @@ type fakeAdapter struct {
 	calls    int64
 	status   health.Status
 	stopped  chan struct{}
+	ready    chan struct{}
 }
 
 func newFakeAdapter(protocol string, status health.Status) *fakeAdapter {
-	return &fakeAdapter{protocol: protocol, status: status, stopped: make(chan struct{})}
+	return &fakeAdapter{
+		protocol: protocol,
+		status:   status,
+		stopped:  make(chan struct{}),
+		ready:    make(chan struct{}),
+	}
 }
 
 func (a *fakeAdapter) Serve(ctx context.Context) error {
+	close(a.ready)
 	<-ctx.Done()
 	close(a.stopped)
 	return ctx.Err()
 }
 
-func (a *fakeAdapter) Stop(_ context.Context) error { return nil }
-func (a *fakeAdapter) Protocol() string             { return a.protocol }
-func (a *fakeAdapter) Port() int                    { return 0 }
+func (a *fakeAdapter) Stop(_ context.Context) error   { return nil }
+func (a *fakeAdapter) ListenerReady() <-chan struct{} { return a.ready }
+func (a *fakeAdapter) Protocol() string               { return a.protocol }
+func (a *fakeAdapter) Port() int                      { return 0 }
 func (a *fakeAdapter) Healthcheck(_ context.Context) health.Report {
 	atomic.AddInt64(&a.calls, 1)
 	return health.Report{Status: a.status, CheckedAt: time.Now().UTC()}
@@ -240,23 +248,30 @@ type mutableFakeAdapter struct {
 	calls    int64
 	status   atomic.Value // health.Status
 	stopped  chan struct{}
+	ready    chan struct{}
 }
 
 func newMutableFakeAdapter(protocol string, initial health.Status) *mutableFakeAdapter {
-	a := &mutableFakeAdapter{protocol: protocol, stopped: make(chan struct{})}
+	a := &mutableFakeAdapter{
+		protocol: protocol,
+		stopped:  make(chan struct{}),
+		ready:    make(chan struct{}),
+	}
 	a.status.Store(initial)
 	return a
 }
 
 func (a *mutableFakeAdapter) Serve(ctx context.Context) error {
+	close(a.ready)
 	<-ctx.Done()
 	close(a.stopped)
 	return ctx.Err()
 }
 
-func (a *mutableFakeAdapter) Stop(_ context.Context) error { return nil }
-func (a *mutableFakeAdapter) Protocol() string             { return a.protocol }
-func (a *mutableFakeAdapter) Port() int                    { return 0 }
+func (a *mutableFakeAdapter) Stop(_ context.Context) error   { return nil }
+func (a *mutableFakeAdapter) ListenerReady() <-chan struct{} { return a.ready }
+func (a *mutableFakeAdapter) Protocol() string               { return a.protocol }
+func (a *mutableFakeAdapter) Port() int                      { return 0 }
 func (a *mutableFakeAdapter) Healthcheck(_ context.Context) health.Report {
 	atomic.AddInt64(&a.calls, 1)
 	return health.Report{Status: a.status.Load().(health.Status), CheckedAt: time.Now().UTC()}


### PR DESCRIPTION
## The premise held: CONFIRMED, and it is not SMB-specific

Reproduced on `develop` (cb3557ea) with the real binaries before touching any code.
A squatter process holds a port; DittoFS is then asked to serve on it:

```
$ dfsctl adapter enable smb --port 15445
Adapter 'smb' enabled on port 15445
$ echo $?
0
$ dfsctl adapter list
TYPE  PORT   ENABLED
smb   15445  yes
$ lsof -nP -iTCP:15445 -sTCP:LISTEN
python3.1 53364 ... TCP *:15445 (LISTEN)      <- the squatter, and nothing else
```

The server log shows the ordering that explains it:

```
[INFO]  Adapter started type=smb port=15445
[INFO]  API request completed method=PUT path=/api/v1/adapters/smb status=200
[INFO]  Starting adapter protocol=SMB port=15445
[ERROR] Adapter failed protocol=SMB error=failed to create SMB listener on port 15445: listen tcp :15445: bind: address already in use
```

"Adapter started" and the HTTP 200 are both emitted *before* the goroutine that
does the binding has even run.

## Root cause

`net.Listen` happens inside `Serve`, and `adapters.Service.registerAndRunAdapterLocked`
launched `Serve` in a goroutine and returned immediately. The bind error went into
`entry.errCh`, which nothing reads until teardown. So `startAdapter` — and therefore
`CreateAdapter`, `EnableAdapter`, `UpdateAdapter`, `AddAdapter` and
`LoadAdaptersFromStore`, every caller — reported the *intent* to serve rather than
the outcome.

The issue asked whether this was SMB-specific. It is not: NFS takes the identical
path. The guard therefore goes in the one shared seam rather than per caller, and
the regression test runs over both types.

## The fix

`BaseAdapter` already had a `listenerReady` channel that `ServeWithFactory` closes
immediately after a successful `net.Listen` — it was only being used by tests and
`GetListenerAddr`. It is now exposed as `ListenerReady() <-chan struct{}` on the
`ProtocolAdapter` interface, and `startAdapter` waits on it.

`awaitListener` selects over three outcomes:

- the serve goroutine returned — the bind failed and the socket is gone, so the
  entry is dropped, the type freed, and the error returned;
- the listener bound — the start succeeded, and this is where "Adapter started"
  is now logged;
- the start deadline passed — the adapter is still alive and may yet claim the
  socket, so the entry stays and is marked the same way a timed-out stop marks it.

The entry is registered while the lock is held and the wait happens after it is
released, so a competing start of the same type is still refused while this one
is binding, without holding the service lock across the bind.

Putting the method on the interface rather than type-asserting follows the
reasoning already written on `ProtocolAdapter` for `Healthcheck`.

## Two consequences that had to be handled

**Boot must not die on a stale port.** `LoadAdaptersFromStore` already propagated
a start failure, and `dfs start` already treated that as fatal — the path was
simply unreachable while starts never failed. Making starts honest made it
reachable, and a persisted port that another process has since claimed would take
the whole server down, *including the control-plane API*, which is the only remote
way to correct the port. It now logs the failure loudly and continues without that
adapter. Verified: the server stays healthy and serves NFS while SMB's port is held.

**The error had to survive the API.** Both adapter handlers replaced the cause with
`"Failed to update adapter"`. The port that refused the bind is the whole of what an
operator needs, so the cause is now carried through, matching the existing style in
`netlogon.go`.

## Making the divergence visible

The API already returned `running` per adapter; `dfsctl adapter list` dropped it.
It is now a column, so "configured" and "actually serving" can no longer look
identical:

```
TYPE  PORT   ENABLED  RUNNING
nfs   12049  yes      yes
smb   15445  yes      no
```

`docs/guide/cli.md` regenerated with `go run ./cmd/gendocs`.

## After the fix

```
$ dfsctl adapter enable smb --port 15445
Error: failed to enable adapter: Failed to update adapter: failed to restart adapter
after update: failed to create SMB listener on port 15445: listen tcp :15445:
bind: address already in use
$ echo $?
1
```

and a free port still works unchanged (`enable smb --port 15446` → exit 0, listener present).

## Two more holes review found on the new path

Both are cases of the same bug wearing a different coat, so they are fixed here
rather than deferred.

**A cancelled entry was still reported as running.** When a start gives up waiting
for the bind it keeps the entry so nothing else claims the type, marked
`cancelled`. `IsAdapterRunning` only checked map presence, so it answered `true` —
and that call is exactly what feeds the new `RUNNING` column. An adapter whose
start explicitly failed would have displayed `ENABLED=no, RUNNING=yes`. It now
treats a cancelled entry as not running. The regression test fails without the fix.

**One serve result, two waiters.** `startAdapter` releases the lock before waiting,
so a teardown can be waiting on the same adapter to exit at the same time as a
start. The result was delivered as a single value on a buffered channel, so
whichever waiter received it won and the other sat out its own timeout and then
reported *that* instead of the real outcome — a start would report "listener not
ready after 15s" in place of the `EADDRINUSE` this change exists to surface. The
serve result is now a broadcast: the error is stored and a `served` channel closed,
so both waiters observe the same real outcome.

## Tests

- `TestStartAdapter_ReportsBindFailure` — over both `smb` and `nfs`: a genuine
  `EADDRINUSE` (the test squats a real loopback port) must fail the enable, must not
  leave the adapter registered as running, and must roll the persisted `enabled`
  flag back.
- `TestStartAdapter_TimesOutWhenListenerNeverBinds` — an adapter that wedges before
  binding fails the start instead of hanging the caller, and is not reported as
  running afterwards.
- `TestLoadAdaptersFromStore_SkipsUnbindableAdapter` — one unbindable adapter does
  not stop the others, so the API stays reachable.

The adapter fakes across three packages now carry a real readiness signal closed
inside `Serve`, rather than reporting ready before `Serve` runs — a fake that
signalled readiness at construction would hide exactly this bug.

`go build ./...`, `go vet ./...`, `go test ./...` and `-race` on the touched
packages are green. The one full-suite failure,
`TestSQLite_ConcurrentWritesBackpressureNoEIO`, is the known sqlite contention flake
under parallel load and is unrelated — it passes 3/3 in isolation on this branch and
this change touches no metadata store.

Closes #2006
