### PR TITLE
fix(metadata): make ListFileChunks membership agree across backends

### DIFF
--- a/pkg/block/engine/audit_state.go
+++ b/pkg/block/engine/audit_state.go
@@ -33,8 +33,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
-	"strings"
 	"time"
 
 	// justification: AuditRefcounts is the cross-file metadata-walk
@@ -43,6 +41,7 @@ import (
 	// directory tree (GetRootHandle, GetFile, ListChildren) and to read
 	// the backing FileChunk rows (ListFileChunks). Lifting these helpers
 	// into pkg/block would create a circular import.
+	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
@@ -174,16 +173,14 @@ func auditFileManifest(ctx context.Context, store metadata.Store, f *metadata.Fi
 	// FileChunk ID after "{payloadID}/") to the row's content hash. A row
 	// with a zero hash does not back a manifest ref — treat it as absent.
 	byOffset := make(map[uint64]metadata.ContentHash, len(rows))
-	prefix := payloadID + "/"
 	for _, row := range rows {
 		if row == nil || row.Hash.IsZero() {
 			continue
 		}
-		suffix := strings.TrimPrefix(row.ID, prefix)
-		off, convErr := strconv.ParseUint(suffix, 10, 64)
-		if convErr != nil {
-			// Non-numeric suffix: not an offset-keyed CAS row. Skip it
-			// rather than crediting it to an offset.
+		off, ok := block.ChunkOffsetFor(row.ID, payloadID)
+		if !ok {
+			// Not an offset-keyed CAS row of this payload. Skip it rather
+			// than crediting it to an offset.
 			continue
 		}
 		byOffset[off] = row.Hash

--- a/pkg/block/engine/manifest_check_test.go
+++ b/pkg/block/engine/manifest_check_test.go
@@ -297,13 +297,22 @@ func TestCheckManifests_LocalOnlySkipsSyncedCheck(t *testing.T) {
 // chunk offset — the row class that read paths refuse with
 // ErrManifestInconsistent and that cold seeding cannot place at all.
 //
-// Only the SQL backends can host this case: memory's ListFileChunks drops a
-// non-numeric ID suffix before returning, so the row is invisible to any
-// caller there and the range surfaces as an uncovered span instead.
+// It runs on every backend the check harness can build: the row belongs to the payload and is merely
+// damaged, so ListFileChunks must hand it to the scan rather than filter it
+// out. A backend that dropped it would make this damage class invisible to
+// the scan, which is the whole thing the scan exists to report.
 func TestCheckManifests_UnplaceableRow(t *testing.T) {
+	for _, backend := range []string{"memory", "sqlite"} {
+		t.Run(backend, func(t *testing.T) {
+			checkManifestsUnplaceableRow(t, backend)
+		})
+	}
+}
+
+func checkManifestsUnplaceableRow(t *testing.T, backend string) {
 	ctx := t.Context()
 	const share = "unplaceable"
-	store, root := newCheckStore(t, "sqlite", share)
+	store, root := newCheckStore(t, backend, share)
 
 	payloadID := seedCheckFile(t, store, share, root, "f", 8192,
 		[]seedRow{{"block-0", 4096, 1}, {"4096", 4096, 2}},

--- a/pkg/block/engine/manifest_check_test.go
+++ b/pkg/block/engine/manifest_check_test.go
@@ -297,10 +297,11 @@ func TestCheckManifests_LocalOnlySkipsSyncedCheck(t *testing.T) {
 // chunk offset — the row class that read paths refuse with
 // ErrManifestInconsistent and that cold seeding cannot place at all.
 //
-// It runs on every backend the check harness can build: the row belongs to the payload and is merely
-// damaged, so ListFileChunks must hand it to the scan rather than filter it
-// out. A backend that dropped it would make this damage class invisible to
-// the scan, which is the whole thing the scan exists to report.
+// It runs on every backend the check harness can build: the row belongs to the
+// payload and is merely damaged, so ListFileChunks must hand it to the scan
+// rather than filter it out. A backend that dropped it would make this damage
+// class invisible to the scan, which is the whole thing the scan exists to
+// report.
 func TestCheckManifests_UnplaceableRow(t *testing.T) {
 	for _, backend := range []string{"memory", "sqlite"} {
 		t.Run(backend, func(t *testing.T) {

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -511,13 +511,13 @@ func (m *Syncer) GetFileSize(ctx context.Context, payloadID string) (uint64, err
 	// the trailing ID component is the chunk's absolute byte
 	// Offset (FastCDC), not a synthetic blockIdx — do NOT multiply by
 	// BlockSize.
-	prefix := payloadID + "/"
 	for i := len(blocks) - 1; i >= 0; i-- {
 		fb := blocks[i]
 		if fb == nil || fb.Hash.IsZero() {
 			continue
 		}
-		if len(fb.ID) <= len(prefix) || fb.ID[:len(prefix)] != prefix {
+		chunkOffset, ok := block.ChunkOffsetFor(fb.ID, payloadID)
+		if !ok {
 			continue
 		}
 		synced, err := hashStore.IsSynced(ctx, fb.Hash)
@@ -525,10 +525,6 @@ func (m *Syncer) GetFileSize(ctx context.Context, payloadID string) (uint64, err
 			return 0, fmt.Errorf("is synced %s: %w", fb.Hash, err)
 		}
 		if !synced {
-			continue
-		}
-		chunkOffset, ok := block.ParseChunkOffset(fb.ID)
-		if !ok {
 			continue
 		}
 		return chunkOffset + uint64(fb.DataSize), nil

--- a/pkg/block/ids.go
+++ b/pkg/block/ids.go
@@ -22,18 +22,34 @@ func ParseChunkOffset(id string) (uint64, bool) {
 	return v, true
 }
 
-// ChunkOffsetFor extracts the chunk offset from a FileChunk ID that belongs to
+// ChunkSuffixFor returns the trailing component of a FileChunk ID that belongs
+// to payloadID, i.e. the single path component after "<payloadID>/", and
+// reports whether the ID belongs to payloadID at all.
+//
+// Membership is decided by the component boundary alone, not by the component
+// being a number. A row whose trailing component is not a decimal offset is
+// still this payload's row — it is a damaged one, and hiding it from callers
+// hides the damage. Conversely, payloadIDs are built from a share name and a
+// file path and so contain slashes, so "<payloadID>/<more>/<offset>" names a
+// chunk of a payload nested beneath this one and does not belong here.
+func ChunkSuffixFor(id, payloadID string) (string, bool) {
+	rest, ok := strings.CutPrefix(id, payloadID+"/")
+	if !ok || rest == "" || strings.IndexByte(rest, '/') >= 0 {
+		return "", false
+	}
+	return rest, true
+}
+
+// ChunkOffsetFor extracts the chunk offset from a FileChunk ID belonging to
 // payloadID, i.e. an ID of the exact form "<payloadID>/<chunkOffset>".
 //
 // It is stricter than ParseChunkOffset, which splits on the last slash and so
-// cannot tell a chunk of payloadID from a chunk of a payload nested beneath it.
-// PayloadIDs are built from share name and file path and therefore contain
-// slashes, so "<payloadID>/<more>/<chunkOffset>" is the ID of a different
-// file's chunk; it returns (0, false) here, as does any ID that is not
-// prefixed by payloadID or whose trailing component is not a decimal offset.
+// cannot tell a chunk of payloadID from a chunk of a payload nested beneath
+// it. It returns (0, false) for an ID that belongs to another payload and for
+// one that belongs to this payload but carries no placeable offset.
 func ChunkOffsetFor(id, payloadID string) (uint64, bool) {
-	rest, ok := strings.CutPrefix(id, payloadID+"/")
-	if !ok || strings.IndexByte(rest, '/') >= 0 {
+	rest, ok := ChunkSuffixFor(id, payloadID)
+	if !ok {
 		return 0, false
 	}
 	v, err := strconv.ParseUint(rest, 10, 64)

--- a/pkg/block/ids.go
+++ b/pkg/block/ids.go
@@ -21,3 +21,24 @@ func ParseChunkOffset(id string) (uint64, bool) {
 	}
 	return v, true
 }
+
+// ChunkOffsetFor extracts the chunk offset from a FileChunk ID that belongs to
+// payloadID, i.e. an ID of the exact form "<payloadID>/<chunkOffset>".
+//
+// It is stricter than ParseChunkOffset, which splits on the last slash and so
+// cannot tell a chunk of payloadID from a chunk of a payload nested beneath it.
+// PayloadIDs are built from share name and file path and therefore contain
+// slashes, so "<payloadID>/<more>/<chunkOffset>" is the ID of a different
+// file's chunk; it returns (0, false) here, as does any ID that is not
+// prefixed by payloadID or whose trailing component is not a decimal offset.
+func ChunkOffsetFor(id, payloadID string) (uint64, bool) {
+	rest, ok := strings.CutPrefix(id, payloadID+"/")
+	if !ok || strings.IndexByte(rest, '/') >= 0 {
+		return 0, false
+	}
+	v, err := strconv.ParseUint(rest, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}

--- a/pkg/block/ids.go
+++ b/pkg/block/ids.go
@@ -34,8 +34,13 @@ func ParseChunkOffset(id string) (uint64, bool) {
 // file path and so contain slashes, so "<payloadID>/<more>/<offset>" names a
 // chunk of a payload nested beneath this one and does not belong here.
 func chunkSuffixFor(id, payloadID string) (string, bool) {
-	rest, ok := strings.CutPrefix(id, payloadID+"/")
-	if !ok || rest == "" || strings.IndexByte(rest, '/') >= 0 {
+	// Compared in place rather than against payloadID+"/": this runs per row
+	// and per sort comparison, and building the prefix would allocate on each.
+	if len(id) <= len(payloadID)+1 || id[:len(payloadID)] != payloadID || id[len(payloadID)] != '/' {
+		return "", false
+	}
+	rest := id[len(payloadID)+1:]
+	if strings.IndexByte(rest, '/') >= 0 {
 		return "", false
 	}
 	return rest, true
@@ -76,16 +81,27 @@ func ChunkOffsetFor(id, payloadID string) (uint64, bool) {
 // kept: it is this file's row and it is damaged, and dropping it would hide
 // the damage from the callers whose job is to report it. It sorts as offset 0.
 func ChunksForPayload(rows []*FileChunk, payloadID string) []*FileChunk {
-	out := make([]*FileChunk, 0, len(rows))
-	for _, r := range rows {
-		if _, ok := chunkSuffixFor(r.ID, payloadID); ok {
-			out = append(out, r)
-		}
+	// Offsets are parsed once and sorted alongside their row rather than
+	// re-parsed inside the comparator, which would repeat the work O(n log n)
+	// times. A row of this payload with no placeable offset keys as 0.
+	type keyed struct {
+		row *FileChunk
+		off uint64
 	}
-	sort.SliceStable(out, func(i, j int) bool {
-		a, _ := ChunkOffsetFor(out[i].ID, payloadID)
-		b, _ := ChunkOffsetFor(out[j].ID, payloadID)
-		return a < b
-	})
+	keys := make([]keyed, 0, len(rows))
+	for _, r := range rows {
+		suffix, ok := chunkSuffixFor(r.ID, payloadID)
+		if !ok {
+			continue
+		}
+		off, _ := strconv.ParseUint(suffix, 10, 64)
+		keys = append(keys, keyed{row: r, off: off})
+	}
+	sort.SliceStable(keys, func(i, j int) bool { return keys[i].off < keys[j].off })
+
+	out := make([]*FileChunk, len(keys))
+	for i, k := range keys {
+		out[i] = k.row
+	}
 	return out
 }

--- a/pkg/block/ids.go
+++ b/pkg/block/ids.go
@@ -1,6 +1,7 @@
 package block
 
 import (
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -22,7 +23,7 @@ func ParseChunkOffset(id string) (uint64, bool) {
 	return v, true
 }
 
-// ChunkSuffixFor returns the trailing component of a FileChunk ID that belongs
+// chunkSuffixFor returns the trailing component of a FileChunk ID that belongs
 // to payloadID, i.e. the single path component after "<payloadID>/", and
 // reports whether the ID belongs to payloadID at all.
 //
@@ -32,7 +33,7 @@ func ParseChunkOffset(id string) (uint64, bool) {
 // hides the damage. Conversely, payloadIDs are built from a share name and a
 // file path and so contain slashes, so "<payloadID>/<more>/<offset>" names a
 // chunk of a payload nested beneath this one and does not belong here.
-func ChunkSuffixFor(id, payloadID string) (string, bool) {
+func chunkSuffixFor(id, payloadID string) (string, bool) {
 	rest, ok := strings.CutPrefix(id, payloadID+"/")
 	if !ok || rest == "" || strings.IndexByte(rest, '/') >= 0 {
 		return "", false
@@ -48,7 +49,7 @@ func ChunkSuffixFor(id, payloadID string) (string, bool) {
 // it. It returns (0, false) for an ID that belongs to another payload and for
 // one that belongs to this payload but carries no placeable offset.
 func ChunkOffsetFor(id, payloadID string) (uint64, bool) {
-	rest, ok := ChunkSuffixFor(id, payloadID)
+	rest, ok := chunkSuffixFor(id, payloadID)
 	if !ok {
 		return 0, false
 	}
@@ -57,4 +58,34 @@ func ChunkOffsetFor(id, payloadID string) (uint64, bool) {
 		return 0, false
 	}
 	return v, true
+}
+
+// ChunksForPayload keeps the rows that belong to payloadID and orders them by
+// chunk offset. The returned slice is never nil.
+//
+// Metadata backends locate a file's chunks with a coarse prefix scan — a SQL
+// LIKE on the ID, a map walk — and hand the result here; this is the
+// membership test, the scan is not. A prefix over-matches two ways: SQL LIKE
+// reads "_" and "%" inside the payloadID as wildcards, and a plain prefix also
+// spans payloads nested beneath this one, since payloadIDs are built from a
+// share name and a file path and so contain slashes. Consumers read a row's
+// trailing component as its offset, so an unfiltered foreign row is credited
+// to this file at that offset.
+//
+// A row of this payload whose trailing component is not a decimal offset is
+// kept: it is this file's row and it is damaged, and dropping it would hide
+// the damage from the callers whose job is to report it. It sorts as offset 0.
+func ChunksForPayload(rows []*FileChunk, payloadID string) []*FileChunk {
+	out := make([]*FileChunk, 0, len(rows))
+	for _, r := range rows {
+		if _, ok := chunkSuffixFor(r.ID, payloadID); ok {
+			out = append(out, r)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		a, _ := ChunkOffsetFor(out[i].ID, payloadID)
+		b, _ := ChunkOffsetFor(out[j].ID, payloadID)
+		return a < b
+	})
+	return out
 }

--- a/pkg/metadata/store/memory/objects.go
+++ b/pkg/metadata/store/memory/objects.go
@@ -3,7 +3,6 @@ package memory
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/marmos91/dittofs/pkg/block"
@@ -499,24 +498,16 @@ func (s *MemoryMetadataStore) listFileChunksLocked(_ context.Context, payloadID 
 	if s.fileChunkData == nil {
 		return []*metadata.FileChunk{}, nil
 	}
-	result := make([]*metadata.FileChunk, 0, len(s.fileChunkData.blocks))
+	// Prefix scan, the map-backed counterpart of the SQL backends' LIKE
+	// prefilter; block.ChunksForPayload decides membership and order.
+	var candidates []*metadata.FileChunk
 	for id, fc := range s.fileChunkData.blocks {
-		if _, ok := block.ChunkSuffixFor(id, payloadID); !ok {
-			continue
+		if strings.HasPrefix(id, payloadID+"/") {
+			c := *fc
+			candidates = append(candidates, &c)
 		}
-		b := *fc
-		result = append(result, &b)
 	}
-
-	// Order by chunk offset. A row of this payload carrying no placeable
-	// offset is damaged, not foreign: it stays in the result and sorts as 0.
-	sort.SliceStable(result, func(i, j int) bool {
-		a, _ := block.ChunkOffsetFor(result[i].ID, payloadID)
-		b, _ := block.ChunkOffsetFor(result[j].ID, payloadID)
-		return a < b
-	})
-
-	return result, nil
+	return block.ChunksForPayload(candidates, payloadID), nil
 }
 
 // InjectRefCountLeak is a test-only capability hook implementing the

--- a/pkg/metadata/store/memory/objects.go
+++ b/pkg/metadata/store/memory/objects.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/marmos91/dittofs/pkg/block"
@@ -500,31 +499,23 @@ func (s *MemoryMetadataStore) listFileChunksLocked(_ context.Context, payloadID 
 	if s.fileChunkData == nil {
 		return []*metadata.FileChunk{}, nil
 	}
-	prefix := payloadID + "/"
-	type indexedBlock struct {
-		block *metadata.FileChunk
-		idx   int
-	}
-	var candidates []indexedBlock
-	for id, block := range s.fileChunkData.blocks {
-		if strings.HasPrefix(id, prefix) {
-			suffix := id[len(prefix):]
-			blockIdx, err := strconv.Atoi(suffix)
-			if err != nil {
-				continue // Skip entries with non-numeric suffix
-			}
-			b := *block
-			candidates = append(candidates, indexedBlock{block: &b, idx: blockIdx})
+	result := make([]*metadata.FileChunk, 0, len(s.fileChunkData.blocks))
+	for id, fc := range s.fileChunkData.blocks {
+		if _, ok := block.ChunkSuffixFor(id, payloadID); !ok {
+			continue
 		}
+		b := *fc
+		result = append(result, &b)
 	}
-	// Sort by block index ascending
-	sort.Slice(candidates, func(i, j int) bool {
-		return candidates[i].idx < candidates[j].idx
+
+	// Order by chunk offset. A row of this payload carrying no placeable
+	// offset is damaged, not foreign: it stays in the result and sorts as 0.
+	sort.SliceStable(result, func(i, j int) bool {
+		a, _ := block.ChunkOffsetFor(result[i].ID, payloadID)
+		b, _ := block.ChunkOffsetFor(result[j].ID, payloadID)
+		return a < b
 	})
-	result := make([]*metadata.FileChunk, len(candidates))
-	for i, c := range candidates {
-		result[i] = c.block
-	}
+
 	return result, nil
 }
 

--- a/pkg/metadata/store/postgres/objects.go
+++ b/pkg/metadata/store/postgres/objects.go
@@ -273,14 +273,18 @@ func (s *PostgresMetadataStore) GetByHash(ctx context.Context, hash metadata.Con
 // since payloadIDs are built from a share name and a file path and so contain
 // slashes. Consumers read a row's trailing component as its offset, so an
 // unfiltered foreign row is credited to this file at that offset.
+//
+// A row of this payload whose trailing component is not a decimal offset is
+// kept: it is this file's row and it is damaged, and dropping it would hide
+// the damage from the callers whose job is to report it. It sorts as offset 0.
 func pgChunksForPayload(rows []*metadata.FileChunk, payloadID string) []*metadata.FileChunk {
 	out := make([]*metadata.FileChunk, 0, len(rows))
 	for _, r := range rows {
-		if _, ok := block.ChunkOffsetFor(r.ID, payloadID); ok {
+		if _, ok := block.ChunkSuffixFor(r.ID, payloadID); ok {
 			out = append(out, r)
 		}
 	}
-	sort.Slice(out, func(i, j int) bool {
+	sort.SliceStable(out, func(i, j int) bool {
 		a, _ := block.ChunkOffsetFor(out[i].ID, payloadID)
 		b, _ := block.ChunkOffsetFor(out[j].ID, payloadID)
 		return a < b

--- a/pkg/metadata/store/postgres/objects.go
+++ b/pkg/metadata/store/postgres/objects.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -265,6 +264,30 @@ func (s *PostgresMetadataStore) GetByHash(ctx context.Context, hash metadata.Con
 	return block, nil
 }
 
+// pgChunksForPayload keeps the rows that actually belong to payloadID and orders
+// them by chunk offset.
+//
+// The LIKE prefilter is a coarse index scan, not the membership test. It
+// over-matches two ways: SQL LIKE reads "_" and "%" inside the payloadID as
+// wildcards, and a plain prefix also spans payloads nested beneath this one,
+// since payloadIDs are built from a share name and a file path and so contain
+// slashes. Consumers read a row's trailing component as its offset, so an
+// unfiltered foreign row is credited to this file at that offset.
+func pgChunksForPayload(rows []*metadata.FileChunk, payloadID string) []*metadata.FileChunk {
+	out := make([]*metadata.FileChunk, 0, len(rows))
+	for _, r := range rows {
+		if _, ok := block.ChunkOffsetFor(r.ID, payloadID); ok {
+			out = append(out, r)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		a, _ := block.ChunkOffsetFor(out[i].ID, payloadID)
+		b, _ := block.ChunkOffsetFor(out[j].ID, payloadID)
+		return a < b
+	})
+	return out
+}
+
 // ListFileChunks returns all blocks belonging to a file, ordered by block index.
 // Uses LIKE query on block ID prefix, then sorts in Go for correct numeric ordering.
 // Not on the narrowed FileChunkStore interface;
@@ -283,15 +306,7 @@ func (s *PostgresMetadataStore) ListFileChunks(ctx context.Context, payloadID st
 	if err != nil {
 		return nil, err
 	}
-	// SQL ORDER BY id ASC gives lexicographic order which is wrong for multi-digit
-	// block indices (e.g., "10" < "2"). Sort by parsed numeric index.
-	sort.Slice(result, func(i, j int) bool {
-		return pgParseBlockIdx(result[i].ID) < pgParseBlockIdx(result[j].ID)
-	})
-	if result == nil {
-		return []*metadata.FileChunk{}, nil
-	}
-	return result, nil
+	return pgChunksForPayload(result, payloadID), nil
 }
 
 // enumerateHashesQuery is the GC mark live-set query. It UNIONs the CAS index
@@ -439,16 +454,6 @@ func (s *PostgresMetadataStore) EnumerateFileChunks(ctx context.Context, fn func
 		return fmt.Errorf("enumerate file chunks: rows: %w", err)
 	}
 	return nil
-}
-
-// pgParseBlockIdx returns the numeric suffix of a block ID ("{payloadID}/{n}"), used as a sort key; 0 if absent.
-func pgParseBlockIdx(id string) int {
-	if idx := strings.LastIndex(id, "/"); idx >= 0 {
-		if v, err := strconv.Atoi(id[idx+1:]); err == nil {
-			return v
-		}
-	}
-	return 0
 }
 
 // ============================================================================
@@ -685,15 +690,7 @@ func (tx *postgresTransaction) ListFileChunks(ctx context.Context, payloadID str
 	if err != nil {
 		return nil, err
 	}
-	// Lexicographic SQL order mis-sorts multi-digit indices ("10" < "2");
-	// sort by parsed numeric index, matching the store-level method.
-	sort.Slice(result, func(i, j int) bool {
-		return pgParseBlockIdx(result[i].ID) < pgParseBlockIdx(result[j].ID)
-	})
-	if result == nil {
-		return []*metadata.FileChunk{}, nil
-	}
-	return result, nil
+	return pgChunksForPayload(result, payloadID), nil
 }
 
 func (tx *postgresTransaction) EnumerateFileChunks(ctx context.Context, fn func(block.ContentHash) error) error {

--- a/pkg/metadata/store/postgres/objects.go
+++ b/pkg/metadata/store/postgres/objects.go
@@ -293,7 +293,7 @@ func pgChunksForPayload(rows []*metadata.FileChunk, payloadID string) []*metadat
 }
 
 // ListFileChunks returns all blocks belonging to a file, ordered by block index.
-// Uses LIKE query on block ID prefix, then sorts in Go for correct numeric ordering.
+// The LIKE query is a prefilter; pgChunksForPayload decides membership and order.
 // Not on the narrowed FileChunkStore interface;
 // kept as a backend method for engine-internal callers.
 func (s *PostgresMetadataStore) ListFileChunks(ctx context.Context, payloadID string) ([]*metadata.FileChunk, error) {

--- a/pkg/metadata/store/postgres/objects.go
+++ b/pkg/metadata/store/postgres/objects.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -264,36 +263,9 @@ func (s *PostgresMetadataStore) GetByHash(ctx context.Context, hash metadata.Con
 	return block, nil
 }
 
-// pgChunksForPayload keeps the rows that actually belong to payloadID and orders
-// them by chunk offset.
-//
-// The LIKE prefilter is a coarse index scan, not the membership test. It
-// over-matches two ways: SQL LIKE reads "_" and "%" inside the payloadID as
-// wildcards, and a plain prefix also spans payloads nested beneath this one,
-// since payloadIDs are built from a share name and a file path and so contain
-// slashes. Consumers read a row's trailing component as its offset, so an
-// unfiltered foreign row is credited to this file at that offset.
-//
-// A row of this payload whose trailing component is not a decimal offset is
-// kept: it is this file's row and it is damaged, and dropping it would hide
-// the damage from the callers whose job is to report it. It sorts as offset 0.
-func pgChunksForPayload(rows []*metadata.FileChunk, payloadID string) []*metadata.FileChunk {
-	out := make([]*metadata.FileChunk, 0, len(rows))
-	for _, r := range rows {
-		if _, ok := block.ChunkSuffixFor(r.ID, payloadID); ok {
-			out = append(out, r)
-		}
-	}
-	sort.SliceStable(out, func(i, j int) bool {
-		a, _ := block.ChunkOffsetFor(out[i].ID, payloadID)
-		b, _ := block.ChunkOffsetFor(out[j].ID, payloadID)
-		return a < b
-	})
-	return out
-}
-
 // ListFileChunks returns all blocks belonging to a file, ordered by block index.
-// The LIKE query is a prefilter; pgChunksForPayload decides membership and order.
+// The LIKE query is a prefilter; block.ChunksForPayload decides membership
+// and order.
 // Not on the narrowed FileChunkStore interface;
 // kept as a backend method for engine-internal callers.
 func (s *PostgresMetadataStore) ListFileChunks(ctx context.Context, payloadID string) ([]*metadata.FileChunk, error) {
@@ -310,7 +282,7 @@ func (s *PostgresMetadataStore) ListFileChunks(ctx context.Context, payloadID st
 	if err != nil {
 		return nil, err
 	}
-	return pgChunksForPayload(result, payloadID), nil
+	return block.ChunksForPayload(result, payloadID), nil
 }
 
 // enumerateHashesQuery is the GC mark live-set query. It UNIONs the CAS index
@@ -694,7 +666,7 @@ func (tx *postgresTransaction) ListFileChunks(ctx context.Context, payloadID str
 	if err != nil {
 		return nil, err
 	}
-	return pgChunksForPayload(result, payloadID), nil
+	return block.ChunksForPayload(result, payloadID), nil
 }
 
 func (tx *postgresTransaction) EnumerateFileChunks(ctx context.Context, fn func(block.ContentHash) error) error {

--- a/pkg/metadata/store/sqlite/objects.go
+++ b/pkg/metadata/store/sqlite/objects.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -297,6 +296,30 @@ func (s *SQLiteMetadataStore) GetByHash(ctx context.Context, hash metadata.Conte
 	return getByHashTx(ctx, s.conn(), hash)
 }
 
+// chunksForPayload keeps the rows that actually belong to payloadID and orders
+// them by chunk offset.
+//
+// The LIKE prefilter is a coarse index scan, not the membership test. It
+// over-matches two ways: SQL LIKE reads "_" and "%" inside the payloadID as
+// wildcards, and a plain prefix also spans payloads nested beneath this one,
+// since payloadIDs are built from a share name and a file path and so contain
+// slashes. Consumers read a row's trailing component as its offset, so an
+// unfiltered foreign row is credited to this file at that offset.
+func chunksForPayload(rows []*metadata.FileChunk, payloadID string) []*metadata.FileChunk {
+	out := make([]*metadata.FileChunk, 0, len(rows))
+	for _, r := range rows {
+		if _, ok := block.ChunkOffsetFor(r.ID, payloadID); ok {
+			out = append(out, r)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		a, _ := block.ChunkOffsetFor(out[i].ID, payloadID)
+		b, _ := block.ChunkOffsetFor(out[j].ID, payloadID)
+		return a < b
+	})
+	return out
+}
+
 // ListFileChunks returns all blocks belonging to a file, ordered by block index.
 // Uses LIKE query on block ID prefix, then sorts in Go for correct numeric ordering.
 // Not on the narrowed FileChunkStore interface;
@@ -315,15 +338,7 @@ func (s *SQLiteMetadataStore) ListFileChunks(ctx context.Context, payloadID stri
 	if err != nil {
 		return nil, err
 	}
-	// SQL ORDER BY id ASC gives lexicographic order which is wrong for multi-digit
-	// block indices (e.g., "10" < "2"). Sort by parsed numeric index.
-	sort.Slice(result, func(i, j int) bool {
-		return parseBlockIdx(result[i].ID) < parseBlockIdx(result[j].ID)
-	})
-	if result == nil {
-		return []*metadata.FileChunk{}, nil
-	}
-	return result, nil
+	return chunksForPayload(result, payloadID), nil
 }
 
 // enumerateHashesQuery is the GC mark live-set query. It UNIONs the CAS index
@@ -475,16 +490,6 @@ func (s *SQLiteMetadataStore) EnumerateFileChunks(ctx context.Context, fn func(b
 	return nil
 }
 
-// parseBlockIdx returns the numeric suffix of a block ID ("{payloadID}/{n}"), used as a sort key; 0 if absent.
-func parseBlockIdx(id string) int {
-	if idx := strings.LastIndex(id, "/"); idx >= 0 {
-		if v, err := strconv.Atoi(id[idx+1:]); err == nil {
-			return v
-		}
-	}
-	return 0
-}
-
 // ============================================================================
 // Scan Helpers
 // ============================================================================
@@ -609,15 +614,7 @@ func (tx *sqliteTransaction) ListFileChunks(ctx context.Context, payloadID strin
 	if err != nil {
 		return nil, err
 	}
-	// Lexicographic SQL order mis-sorts multi-digit indices ("10" < "2");
-	// sort by parsed numeric index, matching the store-level method.
-	sort.Slice(result, func(i, j int) bool {
-		return parseBlockIdx(result[i].ID) < parseBlockIdx(result[j].ID)
-	})
-	if result == nil {
-		return []*metadata.FileChunk{}, nil
-	}
-	return result, nil
+	return chunksForPayload(result, payloadID), nil
 }
 
 func (tx *sqliteTransaction) EnumerateFileChunks(ctx context.Context, fn func(block.ContentHash) error) error {

--- a/pkg/metadata/store/sqlite/objects.go
+++ b/pkg/metadata/store/sqlite/objects.go
@@ -325,7 +325,7 @@ func chunksForPayload(rows []*metadata.FileChunk, payloadID string) []*metadata.
 }
 
 // ListFileChunks returns all blocks belonging to a file, ordered by block index.
-// Uses LIKE query on block ID prefix, then sorts in Go for correct numeric ordering.
+// The LIKE query is a prefilter; chunksForPayload decides membership and order.
 // Not on the narrowed FileChunkStore interface;
 // kept as a backend method for engine-internal callers.
 func (s *SQLiteMetadataStore) ListFileChunks(ctx context.Context, payloadID string) ([]*metadata.FileChunk, error) {

--- a/pkg/metadata/store/sqlite/objects.go
+++ b/pkg/metadata/store/sqlite/objects.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -296,36 +295,9 @@ func (s *SQLiteMetadataStore) GetByHash(ctx context.Context, hash metadata.Conte
 	return getByHashTx(ctx, s.conn(), hash)
 }
 
-// chunksForPayload keeps the rows that actually belong to payloadID and orders
-// them by chunk offset.
-//
-// The LIKE prefilter is a coarse index scan, not the membership test. It
-// over-matches two ways: SQL LIKE reads "_" and "%" inside the payloadID as
-// wildcards, and a plain prefix also spans payloads nested beneath this one,
-// since payloadIDs are built from a share name and a file path and so contain
-// slashes. Consumers read a row's trailing component as its offset, so an
-// unfiltered foreign row is credited to this file at that offset.
-//
-// A row of this payload whose trailing component is not a decimal offset is
-// kept: it is this file's row and it is damaged, and dropping it would hide
-// the damage from the callers whose job is to report it. It sorts as offset 0.
-func chunksForPayload(rows []*metadata.FileChunk, payloadID string) []*metadata.FileChunk {
-	out := make([]*metadata.FileChunk, 0, len(rows))
-	for _, r := range rows {
-		if _, ok := block.ChunkSuffixFor(r.ID, payloadID); ok {
-			out = append(out, r)
-		}
-	}
-	sort.SliceStable(out, func(i, j int) bool {
-		a, _ := block.ChunkOffsetFor(out[i].ID, payloadID)
-		b, _ := block.ChunkOffsetFor(out[j].ID, payloadID)
-		return a < b
-	})
-	return out
-}
-
 // ListFileChunks returns all blocks belonging to a file, ordered by block index.
-// The LIKE query is a prefilter; chunksForPayload decides membership and order.
+// The LIKE query is a prefilter; block.ChunksForPayload decides membership
+// and order.
 // Not on the narrowed FileChunkStore interface;
 // kept as a backend method for engine-internal callers.
 func (s *SQLiteMetadataStore) ListFileChunks(ctx context.Context, payloadID string) ([]*metadata.FileChunk, error) {
@@ -342,7 +314,7 @@ func (s *SQLiteMetadataStore) ListFileChunks(ctx context.Context, payloadID stri
 	if err != nil {
 		return nil, err
 	}
-	return chunksForPayload(result, payloadID), nil
+	return block.ChunksForPayload(result, payloadID), nil
 }
 
 // enumerateHashesQuery is the GC mark live-set query. It UNIONs the CAS index
@@ -618,7 +590,7 @@ func (tx *sqliteTransaction) ListFileChunks(ctx context.Context, payloadID strin
 	if err != nil {
 		return nil, err
 	}
-	return chunksForPayload(result, payloadID), nil
+	return block.ChunksForPayload(result, payloadID), nil
 }
 
 func (tx *sqliteTransaction) EnumerateFileChunks(ctx context.Context, fn func(block.ContentHash) error) error {

--- a/pkg/metadata/store/sqlite/objects.go
+++ b/pkg/metadata/store/sqlite/objects.go
@@ -305,14 +305,18 @@ func (s *SQLiteMetadataStore) GetByHash(ctx context.Context, hash metadata.Conte
 // since payloadIDs are built from a share name and a file path and so contain
 // slashes. Consumers read a row's trailing component as its offset, so an
 // unfiltered foreign row is credited to this file at that offset.
+//
+// A row of this payload whose trailing component is not a decimal offset is
+// kept: it is this file's row and it is damaged, and dropping it would hide
+// the damage from the callers whose job is to report it. It sorts as offset 0.
 func chunksForPayload(rows []*metadata.FileChunk, payloadID string) []*metadata.FileChunk {
 	out := make([]*metadata.FileChunk, 0, len(rows))
 	for _, r := range rows {
-		if _, ok := block.ChunkOffsetFor(r.ID, payloadID); ok {
+		if _, ok := block.ChunkSuffixFor(r.ID, payloadID); ok {
 			out = append(out, r)
 		}
 	}
-	sort.Slice(out, func(i, j int) bool {
+	sort.SliceStable(out, func(i, j int) bool {
 		a, _ := block.ChunkOffsetFor(out[i].ID, payloadID)
 		b, _ := block.ChunkOffsetFor(out[j].ID, payloadID)
 		return a < b

--- a/pkg/metadata/storetest/file_block_ops.go
+++ b/pkg/metadata/storetest/file_block_ops.go
@@ -2186,17 +2186,14 @@ func testListFileChunksForeignRows(t *testing.T, factory StoreFactory) {
 	if err != nil {
 		t.Fatalf("ListFileChunks(share/dir) error: %v", err)
 	}
-	// The unplaceable row has no offset to sort on and sorts as 0.
-	want := []string{"share/dir/block-0", "share/dir/0", "share/dir/4096"}
 	gotIDs := make([]string, len(got))
 	for i, b := range got {
 		gotIDs[i] = b.ID
 	}
-	sortedWant := slices.Clone(want)
-	slices.Sort(sortedWant)
-	sortedGot := slices.Clone(gotIDs)
-	slices.Sort(sortedGot)
-	if !slices.Equal(sortedGot, sortedWant) {
+	// The unplaceable row also sorts as offset 0, so its position relative to
+	// "share/dir/0" is not pinned; compare the rows as a set, order below.
+	want := []string{"share/dir/0", "share/dir/4096", "share/dir/block-0"}
+	if !slices.Equal(slices.Sorted(slices.Values(gotIDs)), want) {
 		t.Errorf("ListFileChunks(share/dir) = %v, want exactly %v", gotIDs, want)
 	}
 	// Placeable rows must still come back in ascending offset order.

--- a/pkg/metadata/storetest/file_block_ops.go
+++ b/pkg/metadata/storetest/file_block_ops.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -54,6 +55,10 @@ func runFileChunkOpsTests(t *testing.T, factory StoreFactory) {
 
 	t.Run("ListFileChunks_EmptyStore", func(t *testing.T) {
 		testListFileChunksEmptyStore(t, factory)
+	})
+
+	t.Run("ListFileChunks_ForeignRows", func(t *testing.T) {
+		testListFileChunksForeignRows(t, factory)
 	})
 
 	// GetFileChunkAtOffset is the read-path fast path: it resolves the single
@@ -2118,4 +2123,86 @@ func livePayloadContains(t *testing.T, store metadata.Store, payloadID string) b
 		t.Fatalf("EnumerateLivePayloadIDs: %v", err)
 	}
 	return found
+}
+
+// testListFileChunksForeignRows pins the exact membership predicate of
+// ListFileChunks: a row belongs to payloadID only when its ID has the form
+// "{payloadID}/{decimal offset}".
+//
+// PayloadIDs are built from a share name and a file path, so they contain
+// slashes and one payloadID can be a path-prefix of another. A backend that
+// answers with a plain string-prefix match returns the nested payload's rows
+// too, and every consumer then reads the trailing component as an offset —
+// crediting another file's chunk to this file at that offset.
+//
+// The same over-match reaches backends that translate the prefix into a SQL
+// LIKE pattern, where "_" matches any single character and "%" matches any
+// sequence, so a payloadID containing either slurps in unrelated siblings.
+func testListFileChunksForeignRows(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+
+	mk := func(id string, size uint32) *block.FileChunk {
+		return &block.FileChunk{
+			ID: id, State: block.BlockStatePending, DataSize: size,
+			RefCount: 1, LastAccess: time.Now(), CreatedAt: time.Now(),
+		}
+	}
+
+	// "share/dir" owns two chunks. Every other row below is a chunk of some
+	// other file that a loose prefix or LIKE match would wrongly attribute
+	// to it.
+	rows := []*block.FileChunk{
+		mk("share/dir/0", 100),
+		mk("share/dir/4096", 200),
+
+		// Nested payload: a file inside a directory of the same name.
+		mk("share/dir/nested/0", 300),
+		// Nested payload whose own name is numeric, so the joined ID reads
+		// like a plausible offset chain.
+		mk("share/dir/7/0", 400),
+
+		// Sibling reachable only through a LIKE "_" wildcard.
+		mk("share/dxr/0", 500),
+		// Sibling reachable only through a LIKE "%" wildcard.
+		mk("share/dir-other/0", 600),
+	}
+	for _, b := range rows {
+		if err := store.Put(ctx, b); err != nil {
+			t.Fatalf("Put(%s) failed: %v", b.ID, err)
+		}
+	}
+
+	got, err := asLegacy(t, store).ListFileChunks(ctx, "share/dir")
+	if err != nil {
+		t.Fatalf("ListFileChunks(share/dir) error: %v", err)
+	}
+	want := []string{"share/dir/0", "share/dir/4096"}
+	gotIDs := make([]string, len(got))
+	for i, b := range got {
+		gotIDs[i] = b.ID
+	}
+	if !slices.Equal(gotIDs, want) {
+		t.Errorf("ListFileChunks(share/dir) = %v, want %v", gotIDs, want)
+	}
+
+	// The nested payload must still be listable in its own right.
+	nested, err := asLegacy(t, store).ListFileChunks(ctx, "share/dir/nested")
+	if err != nil {
+		t.Fatalf("ListFileChunks(share/dir/nested) error: %v", err)
+	}
+	if len(nested) != 1 || nested[0].ID != "share/dir/nested/0" {
+		t.Errorf("ListFileChunks(share/dir/nested) = %v, want [share/dir/nested/0]", nested)
+	}
+
+	// A payloadID carrying LIKE metacharacters matches only itself.
+	for _, pid := range []string{"share/d_r", "share/d%"} {
+		res, lerr := asLegacy(t, store).ListFileChunks(ctx, pid)
+		if lerr != nil {
+			t.Fatalf("ListFileChunks(%s) error: %v", pid, lerr)
+		}
+		if len(res) != 0 {
+			t.Errorf("ListFileChunks(%s) returned %d rows, want 0", pid, len(res))
+		}
+	}
 }

--- a/pkg/metadata/storetest/file_block_ops.go
+++ b/pkg/metadata/storetest/file_block_ops.go
@@ -2138,6 +2138,11 @@ func livePayloadContains(t *testing.T, store metadata.Store, payloadID string) b
 // The same over-match reaches backends that translate the prefix into a SQL
 // LIKE pattern, where "_" matches any single character and "%" matches any
 // sequence, so a payloadID containing either slurps in unrelated siblings.
+//
+// The predicate is the component boundary, not the component being numeric.
+// A backend that additionally requires a decimal suffix under-returns instead:
+// it drops this payload's own damaged rows, making the damage class that
+// manifest scans report structurally invisible on that backend.
 func testListFileChunksForeignRows(t *testing.T, factory StoreFactory) {
 	store := factory(t)
 	ctx := t.Context()
@@ -2155,6 +2160,10 @@ func testListFileChunksForeignRows(t *testing.T, factory StoreFactory) {
 	rows := []*block.FileChunk{
 		mk("share/dir/0", 100),
 		mk("share/dir/4096", 200),
+		// Belongs to share/dir but carries no placeable offset. This is the
+		// damaged-row class that manifest scans exist to report, so it must
+		// be returned, not filtered out as if it were foreign.
+		mk("share/dir/block-0", 250),
 
 		// Nested payload: a file inside a directory of the same name.
 		mk("share/dir/nested/0", 300),
@@ -2177,13 +2186,28 @@ func testListFileChunksForeignRows(t *testing.T, factory StoreFactory) {
 	if err != nil {
 		t.Fatalf("ListFileChunks(share/dir) error: %v", err)
 	}
-	want := []string{"share/dir/0", "share/dir/4096"}
+	// The unplaceable row has no offset to sort on and sorts as 0.
+	want := []string{"share/dir/block-0", "share/dir/0", "share/dir/4096"}
 	gotIDs := make([]string, len(got))
 	for i, b := range got {
 		gotIDs[i] = b.ID
 	}
-	if !slices.Equal(gotIDs, want) {
-		t.Errorf("ListFileChunks(share/dir) = %v, want %v", gotIDs, want)
+	sortedWant := slices.Clone(want)
+	slices.Sort(sortedWant)
+	sortedGot := slices.Clone(gotIDs)
+	slices.Sort(sortedGot)
+	if !slices.Equal(sortedGot, sortedWant) {
+		t.Errorf("ListFileChunks(share/dir) = %v, want exactly %v", gotIDs, want)
+	}
+	// Placeable rows must still come back in ascending offset order.
+	var offsets []uint64
+	for _, b := range got {
+		if off, ok := block.ChunkOffsetFor(b.ID, "share/dir"); ok {
+			offsets = append(offsets, off)
+		}
+	}
+	if !slices.IsSorted(offsets) {
+		t.Errorf("ListFileChunks(share/dir) offsets %v not ascending", offsets)
 	}
 
 	// The nested payload must still be listable in its own right.

--- a/pkg/metadata/storetest/file_block_ops.go
+++ b/pkg/metadata/storetest/file_block_ops.go
@@ -2126,8 +2126,9 @@ func livePayloadContains(t *testing.T, store metadata.Store, payloadID string) b
 }
 
 // testListFileChunksForeignRows pins the exact membership predicate of
-// ListFileChunks: a row belongs to payloadID only when its ID has the form
-// "{payloadID}/{decimal offset}".
+// ListFileChunks: a row belongs to payloadID when its ID is payloadID plus
+// exactly one more path component. Whether that component parses as a decimal
+// offset decides only whether the row is placeable, never whether it belongs.
 //
 // PayloadIDs are built from a share name and a file path, so they contain
 // slashes and one payloadID can be a path-prefix of another. A backend that


### PR DESCRIPTION
## The issue's premise was half right, and the half it got wrong pointed the fix the other way

#2013 reports that memory's `ListFileChunks` silently drops rows whose ID suffix is not a plain
integer, that the SQL backends return those rows, and that the fix is to make memory match SQL.

Two of those three are wrong. Measured on `develop` with a new conformance case, the three
backends implement three different membership predicates, and **the SQL pair is the one that is
badly wrong**:

| backend | predicate | verdict |
| --- | --- | --- |
| badger | `fb-file:{payloadID}:{suffix}` secondary index — exact payloadID, any suffix | correct |
| memory | `strings.HasPrefix` + `strconv.Atoi(suffix)` | under-returns |
| sqlite / postgres | `WHERE id LIKE '{payloadID}/%'` | over-returns |

`ListFileChunks` answers "which rows belong to this file". Row IDs are `{payloadID}/{offset}`, and
payloadIDs contain slashes, so the predicate has to be *"payloadID plus exactly one more path
component"* — which is precisely what badger's colon-delimited index enforces, and what neither
other backend implements.

### What sqlite and postgres get wrong: they return other files' rows

`LIKE '{payloadID}/%'` over-matches two independent ways.

1. **Nested payloads.** Asked for `share/dir`, it also returns `share/dir/nested/0` — a chunk of a
   *different file*.
2. **LIKE metacharacters.** SQL `LIKE` reads `_` as "any one character" and `%` as "any sequence",
   and the payloadID is interpolated unescaped. Asked for `share/d_r`, it returns rows belonging to
   `share/dxr`.

This is not a cosmetic ordering wart. Every consumer of these rows reads the trailing ID component
as the chunk's byte offset via `block.ParseChunkOffset`, which splits on the **last** slash. So a
foreign row `share/dir/nested/0` is credited to `share/dir` as a chunk at offset 0 — another file's
bytes, placed in this file's manifest. The new conformance case caught exactly that on sqlite:

```
ListFileChunks(share/dir) = [share/dir/0 share/dir/7/0 share/dir/nested/0 share/dir/4096],
                       want [share/dir/0 share/dir/4096]
ListFileChunks(share/d_r) returned 5 rows, want 0
ListFileChunks(share/d%)  returned 6 rows, want 0
```

Three rows claiming offset 0, two of them from other files.

The worst consumer is GC. `reapStrandedRows` (`pkg/controlplane/runtime/blockgc_reconcile.go`)
lists the chunks of a payload it has decided is stranded and passes each row straight to
`DecrementRefCountAndReap(fb.ID)`. Under the over-match, reaping a dead `export/a` also enumerates
and reaps the rows of a **live** `export/a/f` — so this is a path to deleting a live file's chunks,
not merely to misreading them.

`SeedColdFromManifest` (`pkg/controlplane/runtime/shares/lifecycle.go`) is the second consumer:
a nested payload's rows folded into the outer payload's cold-seed extents seed the wrong extents
for that file.

### What memory gets wrong: it hides the damage class the scan exists to report

The `Atoi` filter does correctly reject nested rows, which is why this never produced a false-clean
result. But it rejects them for the wrong reason, and the reason over-fires: a row
`{payloadID}/block-0` has a single trailing component and genuinely **belongs** to this payload. It
is simply damaged — it carries no placeable offset. That is the `ErrManifestInconsistent` class that
#1881 and `dfsctl store check` exist to surface, and memory made it structurally invisible.

So the issue is right that memory drops rows it should return; it is wrong that SQL is the reference
to copy. Widening memory's parser to match SQL would have imported the cross-file bleed.

### Reachability: latent on current-format data, live on legacy stores

Stated plainly because it decides how alarming this is. Since #1166, production payloadIDs are
`share/<inode-uuid>` (`pkg/metadata/file_helpers.go`) — one slash, no nesting possible, and a UUID
contains neither `_` nor `%`. So on a store created by current code the over-match has no input.

It is reachable on:

- **Legacy path-based `content_id`s**, which the code contractually still supports and never
  recomputes (`PayloadID` is stored at create time and survives rename untouched). There, filenames
  with underscores are ordinary, and a rename-then-recreate leaves a live `export/a` payload
  alongside a live `export/a/f`.
- **Rows that outlive their file.** `RemoveFile` deletes no chunk rows; NFSv4's remove handler
  discards the returned payload entirely, so rows persist until the GC reconcile pass, which itself
  skips rows inside the grace window.

Verdict: **PARTIAL** — the divergence and the SQL over-match are real and reproduced; the blast
radius on current-format data is nil. Fixed anyway because it is cheap, it deletes code, and the
conformance gap is the part that will otherwise recur.

## The fix

One predicate, in `pkg/block/ids.go`, replacing three hand-rolled copies:

- `ChunkSuffixFor(id, payloadID)` — membership: payloadID plus exactly one component. Numeric or
  not is not membership's business.
- `ChunkOffsetFor(id, payloadID)` — membership *and* a placeable decimal offset, for callers that
  need to position bytes.

memory, sqlite and postgres now filter on `ChunkSuffixFor` and order on `ChunkOffsetFor`, matching
badger. Damaged rows are returned and sort as offset 0, the order the SQL backends already used.
`parseBlockIdx` and `pgParseBlockIdx` existed only to serve these four call sites and are deleted.

The LIKE prefilter stays as a coarse index scan — it only ever over-matches, and membership is now
decided in Go, so escaping it would buy nothing but a wider diff.

Two engine sites hand-rolled the same predicate as a prefix check followed by `ParseChunkOffset`
(`syncer.go`, `audit_state.go`); both now call the shared helper, which is a net deletion and
removes the pattern that caused the drift.

## Coverage

The conformance suite is the part #2013 correctly identified as mattering most — it is supposed to
stop backends diverging and it had no case for this. `ListFileChunks_ForeignRows` in
`pkg/metadata/storetest/` now pins the whole predicate: nested payloads excluded, LIKE
metacharacters excluded, the nested payload still listable in its own right, and the owned-but-
unplaceable row **returned**. It fails on unfixed sqlite and passes on all backends after.

`TestCheckManifests_UnplaceableRow` was pinned to sqlite with a comment saying memory could not host
the case. It now runs on memory and sqlite both — the direct demonstration that the divergence is
closed.

## Verification

- `go build ./... && go vet ./... && gofmt -l` clean
- `go test ./...` green
- `go test -race ./pkg/block/... ./pkg/metadata/...` green
- New conformance case fails on `develop`'s sqlite, passes on all three backends after

Postgres has no local instance here, so its conformance run is CI's; the change is line-for-line the
same as sqlite's.

Closes #2013
