### PR TITLE
test(journal): bound backpressure termination by EvictMaxWait, not wall clock

### DIFF
--- a/pkg/block/journal/evict_test.go
+++ b/pkg/block/journal/evict_test.go
@@ -424,17 +424,20 @@ func TestBackpressureWaitsForSyncer(t *testing.T) {
 // draining, the unsynced bytes pinning the cap never fall, so the write path must
 // still fail with ErrLocalStoreFull within a bounded budget rather than hang.
 func TestBackpressureTerminalWhenNoSyncer(t *testing.T) {
-	s, _ := evictStore(t, Config{MaxLocalBytes: 2 << 20, EvictMaxWait: 50 * time.Millisecond})
+	const maxWait = 50 * time.Millisecond
+	s, _ := evictStore(t, Config{MaxLocalBytes: 2 << 20, EvictMaxWait: maxWait})
 	ctx := context.Background()
 
 	buf := bytes.Repeat([]byte{0xCD}, chunk256)
 	var off int64
 	var gotFull bool
-	start := time.Now()
+	var blocked time.Duration
 	for i := 0; i < 64; i++ {
+		attempt := time.Now()
 		err := s.WriteAt(ctx, "f", off, buf)
 		if errors.Is(err, ErrLocalStoreFull) {
 			gotFull = true
+			blocked = time.Since(attempt)
 			break
 		}
 		if err != nil {
@@ -445,8 +448,14 @@ func TestBackpressureTerminalWhenNoSyncer(t *testing.T) {
 	if !gotFull {
 		t.Fatalf("expected ErrLocalStoreFull with no syncer to drain the cap")
 	}
-	if elapsed := time.Since(start); elapsed > 5*time.Second {
-		t.Fatalf("backpressure must be bounded, not hang: took %v", elapsed)
+	// Bound only the rejected write, and off EvictMaxWait rather than a constant.
+	// The writes that fill the cap are fsync-bound and cost whatever the disk
+	// costs; the rejected one appends nothing and finds nothing to evict, so all
+	// it does is poll out the eviction budget. Its duration therefore tracks
+	// EvictMaxWait, and the multiple is slack for timer granularity and
+	// scheduling on a loaded machine, not room for disk latency.
+	if limit := 20 * maxWait; blocked > limit {
+		t.Fatalf("backpressure must terminate on its own budget, not hang: blocked %v with EvictMaxWait %v (limit %v)", blocked, maxWait, limit)
 	}
 }
 

--- a/pkg/block/journal/evict_test.go
+++ b/pkg/block/journal/evict_test.go
@@ -423,40 +423,35 @@ func TestBackpressureWaitsForSyncer(t *testing.T) {
 // TestBackpressureTerminalWhenNoSyncer is the BUG 2 negative case: with no syncer
 // draining, the unsynced bytes pinning the cap never fall, so the write path must
 // still fail with ErrLocalStoreFull within a bounded budget rather than hang.
+//
+// Only the rejected write is timed, and against EvictMaxWait rather than a
+// constant: the writes that fill the cap are fsync-bound and cost whatever the
+// disk costs, while the rejected one appends nothing and finds nothing to evict,
+// so all it does is poll out the eviction budget. The multiple is slack for timer
+// granularity and scheduling, not room for disk latency.
 func TestBackpressureTerminalWhenNoSyncer(t *testing.T) {
 	const maxWait = 50 * time.Millisecond
+	const limit = 20 * maxWait
 	s, _ := evictStore(t, Config{MaxLocalBytes: 2 << 20, EvictMaxWait: maxWait})
 	ctx := context.Background()
 
 	buf := bytes.Repeat([]byte{0xCD}, chunk256)
 	var off int64
-	var gotFull bool
-	var blocked time.Duration
 	for i := 0; i < 64; i++ {
 		attempt := time.Now()
 		err := s.WriteAt(ctx, "f", off, buf)
 		if errors.Is(err, ErrLocalStoreFull) {
-			gotFull = true
-			blocked = time.Since(attempt)
-			break
+			if blocked := time.Since(attempt); blocked > limit {
+				t.Fatalf("backpressure must terminate on its own budget, not hang: blocked %v with EvictMaxWait %v (limit %v)", blocked, maxWait, limit)
+			}
+			return
 		}
 		if err != nil {
 			t.Fatalf("WriteAt: %v", err)
 		}
 		off += chunk256
 	}
-	if !gotFull {
-		t.Fatalf("expected ErrLocalStoreFull with no syncer to drain the cap")
-	}
-	// Bound only the rejected write, and off EvictMaxWait rather than a constant.
-	// The writes that fill the cap are fsync-bound and cost whatever the disk
-	// costs; the rejected one appends nothing and finds nothing to evict, so all
-	// it does is poll out the eviction budget. Its duration therefore tracks
-	// EvictMaxWait, and the multiple is slack for timer granularity and
-	// scheduling on a loaded machine, not room for disk latency.
-	if limit := 20 * maxWait; blocked > limit {
-		t.Fatalf("backpressure must terminate on its own budget, not hang: blocked %v with EvictMaxWait %v (limit %v)", blocked, maxWait, limit)
-	}
+	t.Fatalf("expected ErrLocalStoreFull with no syncer to drain the cap")
 }
 
 func TestConcurrentWriteEvictRace(t *testing.T) {


### PR DESCRIPTION
## Verdict on the filed diagnosis: PARTIAL

The issue is right that this is a wall-clock-assertion flake and not a product gap, and right that the product behaved correctly (the run reached `ErrLocalStoreFull`; only the timing assertion failed). But the mechanism it names is wrong, and every fix it suggests would either do nothing or make the flake worse.

**Refuted.** The issue claims the loop "can burn `EvictMaxWait` on each of 64 blocked attempts, so the worst-case wait budget is `64 x 50ms = 3.2s`". It cannot. The loop `break`s on the first `ErrLocalStoreFull`, and once the cap is pinned by unsynced bytes with no syncer, `ensureSpace` can never recover — nothing is evictable and `unsynced` never falls, so the first blocked call is also the last. Exactly **one** attempt ever pays the budget.

Instrumented on `develop`:

```
iter=0 elapsed=1.44ms   err=<nil>              disk=262242   unsynced=262144
iter=1 elapsed=17.24ms  err=<nil>              disk=524420   unsynced=524288
iter=2 elapsed=268µs    err=<nil>              disk=786598   unsynced=786432
iter=3 elapsed=31.27ms  err=<nil>              disk=1048840  unsynced=1048576
iter=4 elapsed=110µs    err=<nil>              disk=1311018  unsynced=1310720
iter=5 elapsed=85µs     err=<nil>              disk=1573196  unsynced=1572864
iter=6 elapsed=16.83ms  err=<nil>              disk=1835438  unsynced=1835008
iter=7 elapsed=55.74ms  err=local store full   disk=1835438  unsynced=1835008
TOTAL 124.8ms
```

Seven writes fill the 2 MiB cap, the eighth is rejected. Split across three runs:

```
open=25.19ms  fill(7 writes)=44.79ms  blockedCall=55.34ms
open=5.07ms   fill(7 writes)=38.55ms  blockedCall=55.08ms
open=13.36ms  fill(7 writes)=46.60ms  blockedCall=55.14ms
```

The sleep budget is ~55ms — about **1%** of the 5s bound, not 64%. The cost that actually varies by machine is the other term: `Open` plus seven fsync-bound 256 KiB appends, several of which cross a segment seal (`sealInPlace` fsyncs). That is what turns ~125ms here into 9.61s on the Windows runner, and no constant can bound it.

This also means the issue's three suggested remedies are all wrong:

- *Lower the iteration ceiling* — no effect. The loop already exits at 8 of 64; the ceiling is never reached.
- *Lower `EvictMaxWait`* — removes at most 50ms of a 9.61s failure.
- *Scale the bound off `EvictMaxWait x iterations`* — that yields `64 x 50ms = 3.2s`, **tighter** than the 5s it replaces. It would flake harder.

## The actual fix

The assertion's intent — "backpressure terminates rather than hangs" — is worth keeping, so it is kept, and made to measure that intent instead of the disk.

Time only the write that is rejected, and derive the ceiling from the configured `EvictMaxWait` rather than a constant:

```go
const maxWait = 50 * time.Millisecond
const limit = 20 * maxWait
...
attempt := time.Now()
err := s.WriteAt(ctx, "f", off, buf)
if errors.Is(err, ErrLocalStoreFull) {
    if blocked := time.Since(attempt); blocked > limit {
        t.Fatalf("backpressure must terminate on its own budget, not hang: ...")
    }
    return
}
```

That call is the right thing to measure because it does no file I/O at all: `appendRecord` (`segment.go:285`) calls `ensureSpace` before touching any fd and returns its error immediately, and `ensureSpace` drives `evict(ctx, overage, false)` — with `allowActiveSeal=false` and nothing evictable, `evict` only scans the sealed set under a shard lock and returns. So the rejected write's entire cost is the `EvictMaxWait` deadline polled at `evictBackoff` (10ms) granularity. It tracks a config knob, not the storage.

Deriving the limit from `maxWait` also fixes the second-order problem: the old 5s was silently wrong if anyone changed `EvictMaxWait` or the record size. The new bound follows the knob.

## Why this holds on a 3x-slower runner

The change removes disk latency from the assertion entirely rather than budgeting for it, so runner disk speed no longer enters the calculation at any multiplier. What remains is timer granularity and goroutine scheduling. Nominal cost is `EvictMaxWait` rounded up to the next poll round plus one round to observe the deadline: 50 + ~20 = ~70ms. On Windows with 15.6ms timer ticks the poll rounds coarsen to `ceil(50/15.6) = 4` rounds plus one, ~78ms; at 3x scheduling slowdown, ~240ms. The 1s limit leaves roughly 4x headroom over that and ~14x over nominal.

Evidence rather than assertion:

**Slow-disk reproduction.** Injecting a 1.5s sleep into `appendRecord` after `ensureSpace` succeeds — slow fills, unchanged rejection path, exactly the Windows shape — reproduces the reported failure and shows the fix clearing it. Same simulation, both versions:

```
OLD:  evict_test.go:449: backpressure must be bounded, not hang: took 10.609087375s
      --- FAIL: TestBackpressureTerminalWhenNoSyncer (10.64s)

NEW:  --- PASS: TestBackpressureTerminalWhenNoSyncer (10.66s)
```

10.6s wall clock, bracketing the 9.61s observed on CI. The old bound fails; the new one passes because the rejected call still cost ~55ms.

**Starved-scheduler stress.** The Windows job runs `go test -short -race -v ./...`, so the race detector is in play there. Under `GOMAXPROCS=1`, `-race`, and 8 competing CPU hogs, 10 consecutive runs all pass, at ~475ms per run for the *whole* test including `Open` and the seven writes — well under the 1s ceiling that applies to the blocked call alone.

**Negative control — the guard still bites.** Changing `ensureSpace`'s deadline to `EvictMaxWait * 40` (a product regression that fails to bound its wait) is caught:

```
evict_test.go:458: backpressure must terminate on its own budget, not hang: blocked 2.00700575s with EvictMaxWait 50ms (limit 1s)
--- FAIL: TestBackpressureTerminalWhenNoSyncer (2.06s)
```

The old 5s bound would have **passed** that regression. The new assertion is strictly stronger at detecting the failure it exists to detect, while being immune to the one it was firing on.

## Sibling tests

Checked, as the same latent shape would be worth fixing in one pass. `evict_test.go:448` was the only wall-clock assertion in `pkg/block/journal` — the other three backpressure tests (`TestPressureBackpressureDirtyPinned`, `TestEnsureSpaceEvictsSyncedUnderPressure`, `TestBackpressureWaitsForSyncer`) set `EvictMaxWait` but assert logical outcomes only, with no timing bound to blow.

The one other `> 5*time.Second` in the tree, `keyprovider/kmip_fake_test.go:472`, is already the correct shape: it times a single dial against a configured 200ms timeout and does no disk I/O. That is the in-repo precedent this change follows.

## Relationship to #1777

Same family (test aggression measured on a slow runner, not a product gap), same remedy in spirit: keep the regression integrity, drop the pathological timing. #1777 removed the aggression from the setup; here the setup is fine and the aggression is in what the assertion spans, so the span is what narrows.

## Verification

- `go build ./...`, `go vet ./pkg/block/...`, `gofmt -l` clean
- `go test ./pkg/block/journal/ -count=1` and `go test -race ./pkg/block/journal/ -count=1` pass
- backpressure/pressure/ensure-space tests `-count=5` pass

Test-only change; no product code touched.

Closes #2047
