### PR TITLE
fix(journal): carve through the manifest row a run's end lands inside

### DIFF
--- a/pkg/block/engine/blocksink.go
+++ b/pkg/block/engine/blocksink.go
@@ -160,6 +160,35 @@ func (s localBlockSink) ReapSupersededManifest(ctx context.Context, id journal.F
 	})
 }
 
+// ManifestRowEndAfter answers journal's run-extension query: how far the manifest
+// coverage straddling off reaches, so a carve run does not stop inside a row it
+// is about to supersede. A nil committer (the clone fixture) has no manifest, so
+// the run stands as snapshotted.
+func (s localBlockSink) ManifestRowEndAfter(ctx context.Context, id journal.FileID, off int64) (int64, error) {
+	if s.committer == nil {
+		return off, nil
+	}
+	return manifestRowEndAfter(ctx, s.committer, string(id), off)
+}
+
+// ManifestRowEndAfter answers journal's run-extension query for the
+// remote-backed sink.
+func (s engineBlockSink) ManifestRowEndAfter(ctx context.Context, id journal.FileID, off int64) (int64, error) {
+	return manifestRowEndAfter(ctx, s.committer, string(id), off)
+}
+
+// manifestRowEndAfter runs the straddle lookup in a transaction, so it reads the
+// same manifest the reap will mutate.
+func manifestRowEndAfter(ctx context.Context, c blockCommitter, payloadID string, off int64) (int64, error) {
+	end := off
+	err := c.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		var err error
+		end, err = metadata.ManifestRowEndAfter(ctx, tx, payloadID, off)
+		return err
+	})
+	return end, err
+}
+
 // ReapSupersededManifest implements journal's optional run-end reap for the
 // remote-backed sink: delete the manifest rows the carve run superseded, atomic
 // with a re-projection of File.Blocks (#953).

--- a/pkg/block/engine/cold_read_carve_seam_test.go
+++ b/pkg/block/engine/cold_read_carve_seam_test.go
@@ -72,3 +72,61 @@ func TestColdReadAtCarveSeam_PunchedRangeStaysZero(t *testing.T) {
 		}
 	}
 }
+
+// TestColdReadAtCarveSeam_RunEndInsideRowStaysCovered is the mirror of the test
+// above: instead of a run that STARTS inside an older row, one that ENDS inside
+// it. The reap deletes that row — its start lies in the run — and the part past
+// the run end has no other cover, because a row claims a prefix of its chunk and
+// so cannot start mid-chunk. Carve has to reach the row's end for the manifest
+// to keep tiling, and the whole file has to read back byte-for-byte from the
+// remote tier afterwards.
+//
+// The shape is reached by a second punch whose END lands on the journal interval
+// boundary the first punch left inside a manifest row: nothing partially overlaps
+// a warm interval there, so the run stops exactly at the boundary, mid-row.
+func TestColdReadAtCarveSeam_RunEndInsideRowStaysCovered(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	bs := newEngineWithRemote(t, ms, remotememory.New())
+	root := createShare(t, ms, "runend")
+	pid, _ := createRealFile(t, ms, "runend", "r.bin", root)
+
+	rng := rand.New(rand.NewSource(0x50AC + 22)) //nolint:gosec // deterministic fixture
+	seed := make([]byte, 6*1024*1024)
+	rng.Read(seed)
+	if _, err := bs.WriteAt(ctx, pid, nil, seed, 0); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	carve(t, bs, ctx, pid)
+
+	const firstOff, firstLen = 2092552, 2 << 20 // ends at 4189704
+	if _, err := bs.PunchHole(ctx, pid, manifestRefs(t, ms, pid), firstOff, firstLen); err != nil {
+		t.Fatalf("first punch: %v", err)
+	}
+	carve(t, bs, ctx, pid)
+
+	const secondOff = 1_000_000
+	if _, err := bs.PunchHole(ctx, pid, manifestRefs(t, ms, pid), secondOff, firstOff+firstLen-secondOff); err != nil {
+		t.Fatalf("second punch: %v", err)
+	}
+	carve(t, bs, ctx, pid)
+
+	assertManifestTiles(t, ms, pid, int64(len(seed)), "after-second-carve")
+
+	if _, err := bs.DrainLocalSynced(ctx); err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	want := append([]byte{}, seed...)
+	for i := secondOff; i < firstOff+firstLen; i++ {
+		want[i] = 0
+	}
+	got := make([]byte, len(seed))
+	if _, err := bs.ReadAt(ctx, pid, got, 0); err != nil {
+		t.Fatalf("cold read: %v", err)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("cold read differs at offset %d: got %#x, want %#x", i, got[i], want[i])
+		}
+	}
+}

--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -106,6 +106,18 @@ type supersededReaper interface {
 	ReapSupersededManifest(ctx context.Context, id FileID, runStart, runEnd int64, newOffsets map[int64]struct{}) error
 }
 
+// manifestRowEnder is an optional BlockSink capability: it reports how far the
+// manifest coverage straddling an offset reaches. A run that stops inside a row
+// leaves that row half superseded — the run-end reap deletes it, because its
+// start lies in the run, and the part past the run keeps no cover at all, since
+// a row claims a prefix of its chunk and so cannot be made to start mid-chunk.
+// Carving through to the reported offset is what keeps that range covered. Sinks
+// without a metadata store (test fakes) don't implement it and a run is carved
+// exactly as snapshotted.
+type manifestRowEnder interface {
+	ManifestRowEndAfter(ctx context.Context, id FileID, off int64) (int64, error)
+}
+
 // errCarveNotWired is returned by Carve when the dedup/sink collaborators have
 // not been injected via SetCarveTargets.
 var errCarveNotWired = errors.New("journal: carve targets not wired (SetCarveTargets)")
@@ -249,6 +261,11 @@ func (s *Store) carveFile(ctx context.Context, sh *shard, id FileID, res *CarveR
 // packs novel chunks into blocks (flushed at CarveBlockSize and at the run's end),
 // and flips the run's records to synced as the durable frontier advances.
 func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interval, res *CarveResult) error {
+	run, err := s.extendRunToRowEnd(ctx, sh, id, run)
+	if err != nil {
+		return err
+	}
+
 	c := chunker.NewChunkerWithParams(s.cfg.ChunkParams)
 	rr := &runReader{s: s, sh: sh, id: id, ivs: run}
 
@@ -440,6 +457,98 @@ func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interv
 	if r, ok := s.sink.(supersededReaper); ok {
 		if err := r.ReapSupersededManifest(ctx, id, run[0].fileOff, run[len(run)-1].end(), newOffsets); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+// extendRunToRowEnd grows the run forward to the end of the manifest coverage its
+// end lands inside, so the fresh tiling covers every row the run-end reap is
+// about to delete. The added bytes are already durable; they are re-chunked only
+// to re-tile the range they share with a superseded row, which is the same price
+// a partial overwrite of a warm interval already pays.
+//
+// The extension is skipped whole unless every byte of it is live, contiguous and
+// warm. An evicted range holds no local bytes to re-chunk, and half an extension
+// still ends inside the row.
+//
+// ponytail: a row reaching past a later dirty run is left alone, so that run
+// still ends mid-row; covering it means merging the two runs, which is worth
+// building only if that shape shows up in practice.
+func (s *Store) extendRunToRowEnd(ctx context.Context, sh *shard, id FileID, run []interval) ([]interval, error) {
+	ender, ok := s.sink.(manifestRowEnder)
+	if !ok {
+		return run, nil
+	}
+	runEnd := run[len(run)-1].end()
+	if !warmAt(sh, id, runEnd) {
+		return run, nil // nothing warm past the run: no extension is possible
+	}
+	rowEnd, err := ender.ManifestRowEndAfter(ctx, id, runEnd)
+	if err != nil {
+		return nil, err
+	}
+	if rowEnd <= runEnd {
+		return run, nil
+	}
+	tail := warmTail(sh, id, runEnd, rowEnd)
+	if len(tail) == 0 {
+		return run, nil
+	}
+	// A fresh slice: run aliases the carve snapshot, whose next entries belong to
+	// the following run.
+	out := make([]interval, 0, len(run)+len(tail))
+	out = append(out, run...)
+	return append(out, tail...), nil
+}
+
+// warmAt reports whether a warm live interval (durable locally, not evicted, not
+// dirty) starts exactly at off. A run with nothing warm past its end cannot be
+// extended whatever the manifest says, so this keeps the manifest lookup off the
+// common path: a carve of freshly appended bytes ends at the file's end, where
+// nothing lives at all.
+func warmAt(sh *shard, id FileID, off int64) bool {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	fi := sh.index[id]
+	if fi == nil {
+		return false
+	}
+	for k := range fi.ivs {
+		if fi.ivs[k].fileOff == off {
+			return fi.ivs[k].synced && !fi.ivs[k].cold
+		}
+	}
+	return false
+}
+
+// warmTail returns the live intervals covering [from, to), clipped to that range,
+// when every one of them is present, contiguous and warm (durable locally, not
+// evicted, not still dirty). Anything else yields nil: a hole or an evicted range
+// has no local bytes to re-chunk, and a dirty range belongs to a later run that
+// would then carve it twice.
+func warmTail(sh *shard, id FileID, from, to int64) []interval {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	fi := sh.index[id]
+	if fi == nil {
+		return nil
+	}
+	var out []interval
+	cur := from
+	for k := range fi.ivs {
+		iv := fi.ivs[k]
+		if iv.end() <= cur {
+			continue
+		}
+		if iv.fileOff > cur || iv.cold || !iv.synced {
+			return nil
+		}
+		stop := min(iv.end(), to)
+		out = append(out, iv.clamp(cur, stop))
+		cur = stop
+		if cur >= to {
+			return out
 		}
 	}
 	return nil

--- a/pkg/block/journal/carve_runextend_test.go
+++ b/pkg/block/journal/carve_runextend_test.go
@@ -1,0 +1,148 @@
+package journal
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+// rowEnderSink is a fakeSink that also answers the run-extension query, standing
+// in for the production sink's manifest lookup.
+type rowEnderSink struct {
+	*fakeSink
+	mu     sync.Mutex
+	rowEnd int64
+	asked  []int64
+}
+
+func (s *rowEnderSink) ManifestRowEndAfter(_ context.Context, _ FileID, off int64) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.asked = append(s.asked, off)
+	if s.rowEnd > off {
+		return s.rowEnd, nil
+	}
+	return off, nil
+}
+
+// carvedRange returns the range the sink's committed chunks span, so a test can
+// see how far a run reached.
+func carvedRange(s *fakeSink) (lo, hi int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	first := true
+	for off, data := range s.chunks {
+		if first || off < lo {
+			lo = off
+		}
+		if end := off + int64(len(data)); first || end > hi {
+			hi = end
+		}
+		first = false
+	}
+	return lo, hi
+}
+
+// carvedBytesIn counts how many bytes of [from, to) the sink's committed chunks
+// cover. Chunk boundaries are content-defined, so a run's reach has to be read
+// off the bytes it covered rather than off any particular chunk offset.
+func carvedBytesIn(s *fakeSink, from, to int64) int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var n int64
+	for off, data := range s.chunks {
+		lo, hi := max(off, from), min(off+int64(len(data)), to)
+		if hi > lo {
+			n += hi - lo
+		}
+	}
+	return n
+}
+
+// carveWithRowEnder wires a sink that reports rowEnd as the end of the manifest
+// coverage straddling any earlier offset.
+func carveWithRowEnder(t *testing.T) (*Store, *rowEnderSink) {
+	t.Helper()
+	s, dd, sink, _ := carveStore(t, Config{CarveBlockSize: 1 << 20})
+	re := &rowEnderSink{fakeSink: sink}
+	s.SetCarveTargets(dd, re)
+	return s, re
+}
+
+// splitIntervals lays down interval boundaries at 8Ki, 16Ki, 24Ki and 32Ki. A
+// write that partially overlaps a warm interval re-dirties its survivors, so the
+// only way to leave a warm neighbour standing is to overwrite a whole interval —
+// which first has to exist.
+func splitIntervals(t *testing.T, ctx context.Context, s *Store) {
+	t.Helper()
+	if err := s.WriteAt(ctx, "f", 0, randBytes(64<<10, 7)); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	for _, w := range [][2]int64{{8 << 10, 8 << 10}, {24 << 10, 8 << 10}} {
+		if _, err := s.Carve(ctx, CarveOptions{Force: true}); err != nil {
+			t.Fatalf("Carve: %v", err)
+		}
+		if err := s.WriteAt(ctx, "f", w[0], randBytes(int(w[1]), w[0])); err != nil {
+			t.Fatalf("WriteAt %d: %v", w[0], err)
+		}
+	}
+	if _, err := s.Carve(ctx, CarveOptions{Force: true}); err != nil {
+		t.Fatalf("Carve: %v", err)
+	}
+}
+
+// TestCarveRunExtendsToStraddledRowEnd pins the extension: a run whose end lands
+// inside a manifest row carves on to that row's end, so the run-end reap does not
+// delete a row whose tail nothing else covers.
+func TestCarveRunExtendsToStraddledRowEnd(t *testing.T) {
+	ctx := context.Background()
+	s, sink := carveWithRowEnder(t)
+	splitIntervals(t, ctx, s)
+
+	// An exact-range overwrite of one interval leaves its neighbours warm, so the
+	// dirty run stops at 16Ki — inside a row reaching to 20Ki.
+	if err := s.WriteAt(ctx, "f", 8<<10, randBytes(8<<10, 11)); err != nil {
+		t.Fatalf("overwrite: %v", err)
+	}
+	sink.chunks = map[int64][]byte{}
+	sink.rowEnd = 20 << 10
+
+	if _, err := s.Carve(ctx, CarveOptions{Force: true}); err != nil {
+		t.Fatalf("Carve: %v", err)
+	}
+	lo, hi := carvedRange(sink.fakeSink)
+	if lo != 8<<10 || hi != 20<<10 {
+		t.Fatalf("carve covered [%d, %d), want [%d, %d)", lo, hi, 8<<10, 20<<10)
+	}
+}
+
+// TestCarveRunDoesNotExtendIntoDirtyRange pins the refusal: the bytes past the
+// run end belong to a later dirty run, so extending would carve them twice. The
+// run is left as snapshotted rather than half extended.
+func TestCarveRunDoesNotExtendIntoDirtyRange(t *testing.T) {
+	ctx := context.Background()
+	s, sink := carveWithRowEnder(t)
+	splitIntervals(t, ctx, s)
+
+	// Two dirty runs with a warm interval between them.
+	if err := s.WriteAt(ctx, "f", 8<<10, randBytes(8<<10, 11)); err != nil {
+		t.Fatalf("overwrite head: %v", err)
+	}
+	if err := s.WriteAt(ctx, "f", 24<<10, randBytes(8<<10, 12)); err != nil {
+		t.Fatalf("overwrite tail: %v", err)
+	}
+	sink.chunks = map[int64][]byte{}
+	sink.rowEnd = 28 << 10 // past the first run, into the second one
+
+	if _, err := s.Carve(ctx, CarveOptions{Force: true}); err != nil {
+		t.Fatalf("Carve: %v", err)
+	}
+	if n := carvedBytesIn(sink.fakeSink, 16<<10, 24<<10); n != 0 {
+		t.Fatalf("the first run was extended into the warm gap: %d bytes of [16Ki, 24Ki) carved", n)
+	}
+	for _, r := range [][2]int64{{8 << 10, 16 << 10}, {24 << 10, 32 << 10}} {
+		if n := carvedBytesIn(sink.fakeSink, r[0], r[1]); n != r[1]-r[0] {
+			t.Fatalf("run [%d, %d) carved %d bytes, want %d", r[0], r[1], n, r[1]-r[0])
+		}
+	}
+}

--- a/pkg/metadata/block_record_store.go
+++ b/pkg/metadata/block_record_store.go
@@ -2,6 +2,7 @@ package metadata
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -296,6 +297,60 @@ func DefaultCommitBlock(
 		// per carve run (ReapSupersededManifest), not per batch — see below.
 		return ProjectCommittedChunks(ctx, tx, payloadIDFromChunks(fileChunks), fileChunks)
 	})
+}
+
+// ManifestRowEndAfter reports how far the manifest coverage straddling off
+// reaches: the greatest end among the rows that start strictly before off and
+// extend past it, or off when none does. Rows starting in the range that opens up
+// are folded in too, so the answer is a point past which no straddling row is
+// left — with overlapping rows (a truncate-narrow plus a re-carve leaves some) a
+// single pass would stop one row short.
+//
+// A carve run asks this about its own end. A run that stops inside a row leaves
+// that row half superseded: the run-end reap deletes it, because its start lies
+// in the run, and the part past the run keeps no cover at all — a row claims a
+// prefix of its chunk, so no row can be made to start mid-chunk. Carving through
+// to this offset is what keeps that range covered.
+//
+// A payload with no rows yet (the first carve of a file) is not an error: there
+// is nothing to straddle, so the run stands as snapshotted.
+//
+// ponytail: O(n log n) over the whole manifest per carve run, on top of the reap's
+// own scan; a straddle index would pay off only once profiling at real chunk
+// counts says these two scans matter.
+func ManifestRowEndAfter(ctx context.Context, tx Transaction, payloadID string, off int64) (int64, error) {
+	if payloadID == "" {
+		return off, nil
+	}
+	rows, err := tx.ListFileChunks(ctx, payloadID)
+	if err != nil {
+		if errors.Is(err, block.ErrFileChunkNotFound) {
+			return off, nil
+		}
+		return 0, fmt.Errorf("manifest row end after %d for %s: %w", off, payloadID, err)
+	}
+	spans := make([][2]int64, 0, len(rows))
+	for _, r := range rows {
+		if r == nil {
+			continue
+		}
+		rowOff, ok := block.ParseChunkOffset(r.ID)
+		if !ok {
+			continue
+		}
+		spans = append(spans, [2]int64{int64(rowOff), int64(rowOff) + int64(r.DataSize)})
+	}
+	sort.Slice(spans, func(i, j int) bool { return spans[i][0] < spans[j][0] })
+	end := off
+	for _, sp := range spans {
+		if sp[0] >= end {
+			break // rows are sorted by start: nothing later can straddle end either
+		}
+		if sp[1] > end {
+			end = sp[1]
+		}
+	}
+	return end, nil
 }
 
 // ReapSupersededManifest deletes the manifest rows a carve run supersedes and

--- a/pkg/metadata/reap_superseded_test.go
+++ b/pkg/metadata/reap_superseded_test.go
@@ -100,3 +100,42 @@ func TestReapSupersededManifest_LeavesDisjointRowsAlone(t *testing.T) {
 
 	require.Equal(t, [][2]int64{{0, 2000}, {2000, 3000}}, tiling(t, tx, pid))
 }
+
+// TestManifestRowEndAfter covers the offset a carve run has to reach so the reap
+// never deletes a row whose tail the run leaves uncovered.
+func TestManifestRowEndAfter(t *testing.T) {
+	const pid = "share/p"
+	ctx := context.Background()
+
+	t.Run("no rows", func(t *testing.T) {
+		end, err := ManifestRowEndAfter(ctx, newManifestTx(pid), pid, 2000)
+		require.NoError(t, err)
+		require.Equal(t, int64(2000), end)
+	})
+
+	t.Run("row boundary", func(t *testing.T) {
+		tx := newManifestTx(pid)
+		seedRows(t, tx, pid, [][2]uint64{{0, 2000}, {2000, 1000}})
+		end, err := ManifestRowEndAfter(ctx, tx, pid, 2000)
+		require.NoError(t, err)
+		require.Equal(t, int64(2000), end, "a row starting at the offset does not straddle it")
+	})
+
+	t.Run("straddler", func(t *testing.T) {
+		tx := newManifestTx(pid)
+		seedRows(t, tx, pid, [][2]uint64{{0, 1000}, {1000, 2000}, {3000, 1000}})
+		end, err := ManifestRowEndAfter(ctx, tx, pid, 2500)
+		require.NoError(t, err)
+		require.Equal(t, int64(3000), end)
+	})
+
+	t.Run("overlapping chain", func(t *testing.T) {
+		// The row at 2800 starts past the probe but inside the straddler, so a
+		// single pass would stop at 3000 and still leave 2800..4000 half covered.
+		tx := newManifestTx(pid)
+		seedRows(t, tx, pid, [][2]uint64{{0, 1000}, {1000, 2000}, {2800, 1200}, {4000, 500}})
+		end, err := ManifestRowEndAfter(ctx, tx, pid, 2500)
+		require.NoError(t, err)
+		require.Equal(t, int64(4000), end)
+	})
+}


### PR DESCRIPTION
## Verdict: CONFIRMED, and the leading hypothesis holds

Re-derived on develop `fadd83f0` — with #1992's narrowing already in — before touching
anything. The manifest after the third carve is unchanged from what was reported:

```
gen3 off=0       size=4189704 end=4189704
     off=4202357 size=1056806 end=5259163   <-- GAP [4189704, 4202357), 12653 bytes
     off=5259163 size=1032293 end=6291456
```

and the cold read of the file fails outright:

```
window for <pid> at offset 0 (6291456 bytes) is still cold after hydrate: chunk not found
```

#1992's narrowing does not touch this shape and does not change it: narrowing only applies
to a row starting **before** `runStart`, and the row here starts at 1060089, inside the run
`[0, 4189704)`. The two are independent, as originally verified.

The conclusion that it cannot be fixed in the reap also still holds, for the reason that
made #1992's guard necessary: covering `[runEnd, rowEnd)` needs a row that starts
mid-chunk, and a row claims a *prefix* of its chunk (`FileChunk.DataSize`) — there is no
intra-chunk offset to key one on. Keeping the row instead of deleting it is not an option
either: inside the run it can win the greatest-covering-start lookup at offsets the fresh
rows also cover, and would serve pre-overwrite bytes. So the run has to reach the row's
end, in the write path.

## Root cause

The journal already has the mechanism for this, and it is the same one behind #1992:
`remarkFragmentsDirty` re-dirties the warm surviving fragments of a partially overwritten
interval so the next carve run swallows the old row whole. It keys on **journal interval**
boundaries, and those are not manifest row boundaries. A write whose *end* lands exactly on
an interval boundary that sits inside a row partially overlaps nothing, so no survivor is
re-marked and the run stops mid-row. (#1992 was the same failure at the run's *start*.)

## The fix

`carveRun` asks the sink how far the manifest coverage straddling the run's end reaches
(`ManifestRowEndAfter`) and appends the warm live intervals up to that offset to the run, so
the fresh tiling covers every row the reap is about to delete. The added bytes are already
durable; they are re-chunked only to re-tile the range they share with a superseded row —
the same price the survivor path already pays.

`ManifestRowEndAfter` folds in rows that start inside the range it opens up, because
overlapping rows are legitimate (a truncate-narrow plus a re-carve leaves some) and a single
pass would stop one row short and re-open the gap one row along.

Two deliberate refusals, both fail-closed:

- **The extension is skipped whole** unless every byte of it is live, contiguous and warm.
  An evicted range holds no local bytes to re-chunk, and half an extension still ends inside
  the row. A range that is dirty belongs to a later run, which would then carve it twice.
- **A cheap local probe first**: if nothing warm starts at the run's end, no extension is
  possible whatever the manifest says, so the metadata lookup is skipped. That is every
  carve of freshly appended bytes, where the run ends at the file's end — this keeps a
  manifest scan off the common write path.

Nothing is zero-filled and no error is made quieter. Where the extension is refused, the
behaviour is exactly today's — the loud `chunk not found` — which is the correct fallback
for a data-availability bug.

## Coherence with #1992

#1992's guard leaves one straddler whole: the row that starts before `runStart` **and** ends
past `runEnd`, because narrowing it would have traded a tolerated overlap for a gap. That
guard is untouched and still needed — it is what protects the case where the run cannot be
extended. Where the run *can* be extended, `ManifestRowEndAfter` now reports that row's end
too, the run reaches it, and #1992's narrowing resolves the overlap instead of tolerating
it. The two compose: extend when the bytes are there, tolerate when they are not.

## Tests

- `TestColdReadAtCarveSeam_RunEndInsideRowStaysCovered` — the reported scenario end to end
  through the real carve path: the manifest tiles after the third carve and the whole file
  reads back byte-for-byte from the remote tier after `DrainLocalSynced`. Fails on the
  pre-fix code with the gap above.
- `TestCarveRunExtendsToStraddledRowEnd` — the run reaches the reported row end. Fails
  pre-fix (`carve covered [8192, 16384), want [8192, 20480)`).
- `TestCarveRunDoesNotExtendIntoDirtyRange` — pins the refusal, so a later dirty run is
  never carved twice.
- `TestManifestRowEndAfter` — no rows, a row boundary (a row starting *at* the offset does
  not straddle it), a straddler, and an overlapping chain where a single pass stops short.

`go test ./...` green. `go test -race ./pkg/block/journal/ ./pkg/block/engine/ ./pkg/metadata/`
green.

## Adjacent

#1956 and #1974 untouched. No interaction found: this only changes how far a carve run
reaches, not what a committed block or a deduped chunk's row contains.

Residual, marked `ponytail:` in the code rather than fixed: a row reaching past a *later*
dirty run is left alone, so that run still ends mid-row. Covering it means merging the two
runs, which is worth building only if that shape shows up in practice.

Closes #2038
