### PR TITLE
fix(api): bind {scope} on the id-less quota routes

### DIFF
--- a/internal/controlplane/api/handlers/quotas.go
+++ b/internal/controlplane/api/handlers/quotas.go
@@ -77,12 +77,17 @@ func isValidQuotaScope(scope string) bool {
 }
 
 // parseIdentityID resolves the {id} route param into the *uint32 identity used
-// by the store. For the default-user scope identityID is always nil (and any id
-// segment is ignored). For user/group scopes an id is required and must parse as
-// a uint32. Returns ok=false (after writing a problem response) on invalid
-// input.
+// by the store. The default-user scope has one implicit identity, so it takes a
+// nil identityID and rejects an id segment rather than discarding it — a
+// discarded id would silently retarget the write at the share-wide fallback.
+// For user/group scopes an id is required and must parse as a uint32. Returns
+// ok=false (after writing a problem response) on invalid input.
 func parseIdentityID(w http.ResponseWriter, scope, idParam string) (identityID *uint32, ok bool) {
 	if scope == models.QuotaScopeDefaultUser {
+		if idParam != "" {
+			BadRequest(w, "scope "+scope+" takes no identity id")
+			return nil, false
+		}
 		return nil, true
 	}
 	if idParam == "" {

--- a/pkg/apiclient/quotas.go
+++ b/pkg/apiclient/quotas.go
@@ -34,18 +34,16 @@ type UpsertQuotaRequest struct {
 	GraceSeconds int64  `json:"grace_seconds,omitempty"`
 }
 
-// quotaPath builds the REST path for a quota. The default-user scope has no id
-// segment; user/group encode the uid/gid in the path.
+// quotaPath builds the REST path for a quota. Scopes whose identity is
+// implicit (default-user) carry no id segment; user/group encode the uid/gid in
+// the path.
 func quotaPath(share, scope string, id *uint32) string {
-	base := fmt.Sprintf("/api/v1/shares/%s/quotas", url.PathEscape(normalizeShareNameForAPI(share)))
-	if scope == "default-user" {
-		return base + "/default-user"
+	base := fmt.Sprintf("/api/v1/shares/%s/quotas/%s",
+		url.PathEscape(normalizeShareNameForAPI(share)), url.PathEscape(scope))
+	if id == nil {
+		return base
 	}
-	idSeg := ""
-	if id != nil {
-		idSeg = fmt.Sprintf("%d", *id)
-	}
-	return fmt.Sprintf("%s/%s/%s", base, url.PathEscape(scope), idSeg)
+	return fmt.Sprintf("%s/%d", base, *id)
 }
 
 // ListQuotas returns all quotas for a share.

--- a/pkg/apiclient/quotas.go
+++ b/pkg/apiclient/quotas.go
@@ -34,9 +34,10 @@ type UpsertQuotaRequest struct {
 	GraceSeconds int64  `json:"grace_seconds,omitempty"`
 }
 
-// quotaPath builds the REST path for a quota. Scopes whose identity is
-// implicit (default-user) carry no id segment; user/group encode the uid/gid in
-// the path.
+// quotaPath builds the REST path for a quota: a nil id yields no id segment,
+// a non-nil id is appended. Callers must honour the server's rule that
+// default-user takes a nil id and user/group take a non-nil one — the server
+// rejects either mismatch rather than guessing.
 func quotaPath(share, scope string, id *uint32) string {
 	base := fmt.Sprintf("/api/v1/shares/%s/quotas/%s",
 		url.PathEscape(normalizeShareNameForAPI(share)), url.PathEscape(scope))

--- a/pkg/controlplane/api/quota_routes_test.go
+++ b/pkg/controlplane/api/quota_routes_test.go
@@ -1,0 +1,125 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+// doQuota issues an authenticated request against a quota route and returns the
+// recorder.
+func doQuota(t *testing.T, router http.Handler, token, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var r *http.Request
+	if body == "" {
+		r = httptest.NewRequest(method, path, nil)
+	} else {
+		r = httptest.NewRequest(method, path, strings.NewReader(body))
+		r.Header.Set("Content-Type", "application/json")
+	}
+	r.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, r)
+	return rec
+}
+
+// TestQuotaRoutesBindScope exercises set -> get -> list -> remove for every
+// supported scope. The default-user scope has no {id} path segment, so its
+// route must still bind {scope}: a route that hard-codes the literal leaves
+// chi.URLParam(r, "scope") empty and the handler rejects its own scope.
+func TestQuotaRoutesBindScope(t *testing.T) {
+	router, jwtService, _ := newTestRouter(t, false)
+	token := tokenFor(t, jwtService, models.RoleAdmin)
+
+	cases := []struct {
+		scope string
+		path  string
+		id    string
+	}{
+		{models.QuotaScopeUser, "/api/v1/shares/tiered/quotas/user/1000", "1000"},
+		{models.QuotaScopeGroup, "/api/v1/shares/tiered/quotas/group/2000", "2000"},
+		{models.QuotaScopeDefaultUser, "/api/v1/shares/tiered/quotas/default-user", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.scope, func(t *testing.T) {
+			rec := doQuota(t, router, token, http.MethodPut, tc.path, `{"limit_bytes":"1GiB"}`)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("PUT %s = %d, want 200 (body=%q)", tc.path, rec.Code, rec.Body.String())
+			}
+			var got struct {
+				Scope      string  `json:"scope"`
+				IdentityID *uint32 `json:"identity_id"`
+				LimitBytes string  `json:"limit_bytes"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+				t.Fatalf("decode PUT response: %v", err)
+			}
+			if got.Scope != tc.scope {
+				t.Errorf("scope = %q, want %q", got.Scope, tc.scope)
+			}
+			if tc.id == "" {
+				if got.IdentityID != nil {
+					t.Errorf("identity_id = %d, want nil for %s", *got.IdentityID, tc.scope)
+				}
+			} else if got.IdentityID == nil || fmt.Sprint(*got.IdentityID) != tc.id {
+				t.Errorf("identity_id = %v, want %s", got.IdentityID, tc.id)
+			}
+
+			if rec := doQuota(t, router, token, http.MethodGet, tc.path, ""); rec.Code != http.StatusOK {
+				t.Errorf("GET %s = %d, want 200 (body=%q)", tc.path, rec.Code, rec.Body.String())
+			}
+		})
+	}
+
+	// All three land in the listing.
+	rec := doQuota(t, router, token, http.MethodGet, "/api/v1/shares/tiered/quotas", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET quotas = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
+	}
+	for _, tc := range cases {
+		if !strings.Contains(rec.Body.String(), `"scope":"`+tc.scope+`"`) {
+			t.Errorf("listing missing scope %q: %s", tc.scope, rec.Body.String())
+		}
+	}
+
+	for _, tc := range cases {
+		if rec := doQuota(t, router, token, http.MethodDelete, tc.path, ""); rec.Code != http.StatusNoContent {
+			t.Errorf("DELETE %s = %d, want 204 (body=%q)", tc.path, rec.Code, rec.Body.String())
+		}
+	}
+}
+
+// TestQuotaScopedRouteRequiresID verifies that omitting the {id} segment on a
+// user/group quota reports the missing id rather than the scope.
+func TestQuotaScopedRouteRequiresID(t *testing.T) {
+	router, jwtService, _ := newTestRouter(t, false)
+	token := tokenFor(t, jwtService, models.RoleAdmin)
+
+	rec := doQuota(t, router, token, http.MethodPut, "/api/v1/shares/tiered/quotas/user", `{"limit_bytes":"1GiB"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("PUT without id = %d, want 400 (body=%q)", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "identity id is required") {
+		t.Errorf("body = %q, want an identity-id complaint", rec.Body.String())
+	}
+}
+
+// TestQuotaUnknownScopeRejected keeps the scope enum enforced.
+func TestQuotaUnknownScopeRejected(t *testing.T) {
+	router, jwtService, _ := newTestRouter(t, false)
+	token := tokenFor(t, jwtService, models.RoleAdmin)
+
+	rec := doQuota(t, router, token, http.MethodPut, "/api/v1/shares/tiered/quotas/wheel/7", `{"limit_bytes":"1GiB"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("PUT unknown scope = %d, want 400 (body=%q)", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "Invalid scope: wheel") {
+		t.Errorf("body = %q, want the offending scope echoed", rec.Body.String())
+	}
+}

--- a/pkg/controlplane/api/quota_routes_test.go
+++ b/pkg/controlplane/api/quota_routes_test.go
@@ -77,9 +77,19 @@ func TestQuotaRoutesBindScope(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET quotas = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
 	}
+	var listed []struct {
+		Scope string `json:"scope"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode listing: %v (body=%q)", err, rec.Body.String())
+	}
+	seen := make(map[string]bool, len(listed))
+	for _, q := range listed {
+		seen[q.Scope] = true
+	}
 	for _, tc := range cases {
-		if !strings.Contains(rec.Body.String(), `"scope":"`+tc.scope+`"`) {
-			t.Errorf("listing missing scope %q: %s", tc.scope, rec.Body.String())
+		if !seen[tc.scope] {
+			t.Errorf("listing missing scope %q, got %v", tc.scope, seen)
 		}
 	}
 

--- a/pkg/controlplane/api/quota_routes_test.go
+++ b/pkg/controlplane/api/quota_routes_test.go
@@ -15,13 +15,8 @@ import (
 // recorder.
 func doQuota(t *testing.T, router http.Handler, token, method, path, body string) *httptest.ResponseRecorder {
 	t.Helper()
-	var r *http.Request
-	if body == "" {
-		r = httptest.NewRequest(method, path, nil)
-	} else {
-		r = httptest.NewRequest(method, path, strings.NewReader(body))
-		r.Header.Set("Content-Type", "application/json")
-	}
+	r := httptest.NewRequest(method, path, strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
 	r.Header.Set("Authorization", "Bearer "+token)
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, r)
@@ -37,13 +32,13 @@ func TestQuotaRoutesBindScope(t *testing.T) {
 	token := tokenFor(t, jwtService, models.RoleAdmin)
 
 	cases := []struct {
-		scope string
-		path  string
-		id    string
+		scope  string
+		path   string
+		wantID string
 	}{
 		{models.QuotaScopeUser, "/api/v1/shares/tiered/quotas/user/1000", "1000"},
 		{models.QuotaScopeGroup, "/api/v1/shares/tiered/quotas/group/2000", "2000"},
-		{models.QuotaScopeDefaultUser, "/api/v1/shares/tiered/quotas/default-user", ""},
+		{models.QuotaScopeDefaultUser, "/api/v1/shares/tiered/quotas/default-user", "none"},
 	}
 
 	for _, tc := range cases {
@@ -55,7 +50,6 @@ func TestQuotaRoutesBindScope(t *testing.T) {
 			var got struct {
 				Scope      string  `json:"scope"`
 				IdentityID *uint32 `json:"identity_id"`
-				LimitBytes string  `json:"limit_bytes"`
 			}
 			if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 				t.Fatalf("decode PUT response: %v", err)
@@ -63,12 +57,12 @@ func TestQuotaRoutesBindScope(t *testing.T) {
 			if got.Scope != tc.scope {
 				t.Errorf("scope = %q, want %q", got.Scope, tc.scope)
 			}
-			if tc.id == "" {
-				if got.IdentityID != nil {
-					t.Errorf("identity_id = %d, want nil for %s", *got.IdentityID, tc.scope)
-				}
-			} else if got.IdentityID == nil || fmt.Sprint(*got.IdentityID) != tc.id {
-				t.Errorf("identity_id = %v, want %s", got.IdentityID, tc.id)
+			gotID := "none"
+			if got.IdentityID != nil {
+				gotID = fmt.Sprint(*got.IdentityID)
+			}
+			if gotID != tc.wantID {
+				t.Errorf("identity_id = %s, want %s", gotID, tc.wantID)
 			}
 
 			if rec := doQuota(t, router, token, http.MethodGet, tc.path, ""); rec.Code != http.StatusOK {
@@ -95,31 +89,31 @@ func TestQuotaRoutesBindScope(t *testing.T) {
 	}
 }
 
-// TestQuotaScopedRouteRequiresID verifies that omitting the {id} segment on a
-// user/group quota reports the missing id rather than the scope.
-func TestQuotaScopedRouteRequiresID(t *testing.T) {
+// TestQuotaRouteRejectsBadTarget covers the two ways a {scope}[/{id}] path can
+// be wrong: a user/group quota missing its id must complain about the id, and
+// an unrecognised scope must be rejected with the offending value echoed.
+func TestQuotaRouteRejectsBadTarget(t *testing.T) {
 	router, jwtService, _ := newTestRouter(t, false)
 	token := tokenFor(t, jwtService, models.RoleAdmin)
 
-	rec := doQuota(t, router, token, http.MethodPut, "/api/v1/shares/tiered/quotas/user", `{"limit_bytes":"1GiB"}`)
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("PUT without id = %d, want 400 (body=%q)", rec.Code, rec.Body.String())
+	cases := []struct {
+		name     string
+		path     string
+		wantBody string
+	}{
+		{"missing id", "/api/v1/shares/tiered/quotas/user", "identity id is required"},
+		{"unknown scope", "/api/v1/shares/tiered/quotas/wheel/7", "Invalid scope: wheel"},
 	}
-	if !strings.Contains(rec.Body.String(), "identity id is required") {
-		t.Errorf("body = %q, want an identity-id complaint", rec.Body.String())
-	}
-}
 
-// TestQuotaUnknownScopeRejected keeps the scope enum enforced.
-func TestQuotaUnknownScopeRejected(t *testing.T) {
-	router, jwtService, _ := newTestRouter(t, false)
-	token := tokenFor(t, jwtService, models.RoleAdmin)
-
-	rec := doQuota(t, router, token, http.MethodPut, "/api/v1/shares/tiered/quotas/wheel/7", `{"limit_bytes":"1GiB"}`)
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("PUT unknown scope = %d, want 400 (body=%q)", rec.Code, rec.Body.String())
-	}
-	if !strings.Contains(rec.Body.String(), "Invalid scope: wheel") {
-		t.Errorf("body = %q, want the offending scope echoed", rec.Body.String())
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := doQuota(t, router, token, http.MethodPut, tc.path, `{"limit_bytes":"1GiB"}`)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("PUT %s = %d, want 400 (body=%q)", tc.path, rec.Code, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), tc.wantBody) {
+				t.Errorf("body = %q, want it to mention %q", rec.Body.String(), tc.wantBody)
+			}
+		})
 	}
 }

--- a/pkg/controlplane/api/quota_routes_test.go
+++ b/pkg/controlplane/api/quota_routes_test.go
@@ -23,10 +23,11 @@ func doQuota(t *testing.T, router http.Handler, token, method, path, body string
 	return rec
 }
 
-// TestQuotaRoutesBindScope exercises set -> get -> list -> remove for every
-// supported scope. The default-user scope has no {id} path segment, so its
-// route must still bind {scope}: a route that hard-codes the literal leaves
-// chi.URLParam(r, "scope") empty and the handler rejects its own scope.
+// TestQuotaRoutesBindScope sets and reads back a quota for every supported
+// scope, then checks all three appear in the listing and can be removed. The
+// default-user scope has no {id} path segment, so its route must still bind
+// {scope}: a route that hard-codes the literal leaves chi.URLParam(r, "scope")
+// empty and the handler rejects its own scope.
 func TestQuotaRoutesBindScope(t *testing.T) {
 	router, jwtService, _ := newTestRouter(t, false)
 	token := tokenFor(t, jwtService, models.RoleAdmin)
@@ -103,6 +104,7 @@ func TestQuotaRouteRejectsBadTarget(t *testing.T) {
 	}{
 		{"missing id", "/api/v1/shares/tiered/quotas/user", "identity id is required"},
 		{"unknown scope", "/api/v1/shares/tiered/quotas/wheel/7", "Invalid scope: wheel"},
+		{"id on default-user", "/api/v1/shares/tiered/quotas/default-user/5", "takes no identity id"},
 	}
 
 	for _, tc := range cases {

--- a/pkg/controlplane/api/router.go
+++ b/pkg/controlplane/api/router.go
@@ -269,12 +269,13 @@ func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.S
 				// Per-identity (user/group/default-user) quota CRUD.
 				// RequireAdmin is inherited from the parent /shares group.
 				// default-user has no {id} segment (its identity is implicit);
-				// user/group carry the uid/gid in {id}.
+				// user/group carry the uid/gid in {id}. Both shapes bind
+				// {scope} so the handler reads the scope it was routed for.
 				quotaHandler := handlers.NewQuotaHandler(cpStore, rt)
 				r.Get("/{name}/quotas", quotaHandler.List)
-				r.Get("/{name}/quotas/default-user", quotaHandler.Get)
-				r.Put("/{name}/quotas/default-user", quotaHandler.Set)
-				r.Delete("/{name}/quotas/default-user", quotaHandler.Remove)
+				r.Get("/{name}/quotas/{scope}", quotaHandler.Get)
+				r.Put("/{name}/quotas/{scope}", quotaHandler.Set)
+				r.Delete("/{name}/quotas/{scope}", quotaHandler.Remove)
 				r.Get("/{name}/quotas/{scope}/{id}", quotaHandler.Get)
 				r.Put("/{name}/quotas/{scope}/{id}", quotaHandler.Set)
 				r.Delete("/{name}/quotas/{scope}/{id}", quotaHandler.Remove)


### PR DESCRIPTION
Closes #2051.

## What was wrong

Not the CLI. `dfsctl` parses `--scope default-user` fine and sends it; the value is
lost in the REST router.

The quota routes registered the id-less shape with the scope spelled as a **path
literal**:

```go
r.Put("/{name}/quotas/default-user", quotaHandler.Set)   // no {scope} param
r.Put("/{name}/quotas/{scope}/{id}", quotaHandler.Set)   // binds {scope}
```

Every quota handler resolves its target through the shared `parseQuotaTarget`,
which reads the scope back out of the URL params:

```go
scope = chi.URLParam(r, "scope")
if !isValidQuotaScope(scope) {
    BadRequest(w, "Invalid scope: "+scope+" (want user|group|default-user)")
}
```

On the literal route chi binds no `scope` param, so that lookup returns `""`, the
enum check fails, and the handler rejects a request it routed correctly — which is
exactly why the reported message named `default-user` as valid while refusing it,
and why the scope in the message was blank.

Because `parseQuotaTarget` is shared, this hit **GET, PUT and DELETE** on
`default-user`, not just `set`. `dfsctl quota list` was unaffected (`List` never
reads a scope), which is consistent with the report: the default-user row simply
never existed to be listed.

## Reproduction

Added ahead of the fix; it fails on `develop` with the reported string verbatim:

```
=== RUN   TestQuotaRoutesBindScope/default-user
    PUT /api/v1/shares/tiered/quotas/default-user = 400, want 200
      (body="...\"detail\":\"Invalid scope:  (want user|group|default-user)\"}")
    listing missing scope "default-user"
    DELETE /api/v1/shares/tiered/quotas/default-user = 400, want 204
--- FAIL: TestQuotaRoutesBindScope
    --- PASS: TestQuotaRoutesBindScope/user
    --- PASS: TestQuotaRoutesBindScope/group
    --- FAIL: TestQuotaRoutesBindScope/default-user
```

## The fix

Register the id-less shape as `/{name}/quotas/{scope}` so both shapes bind the
param the handler reads. The wire format does not change: `default-user` still has
no id segment, `user`/`group` still carry the uid/gid.

`parseIdentityID` already encoded the same rule — nil identity for `default-user`,
required id otherwise — so nothing in the handlers needed touching, and the enum
stays enforced: an unknown scope now reaches the check with its real value and is
rejected by name (`Invalid scope: wheel`).

One side benefit: `PUT /quotas/user` with no id used to 404 (no route matched that
shape); it now reports `identity id is required for scope user`.

`pkg/apiclient` had the mirror-image special case — a hardcoded `default-user`
branch in `quotaPath`. It keys off a nil identity instead, which is the actual
rule, and is four lines shorter.

## One thing the routing change opened, and closed

Binding `{scope}` on both shapes means `/quotas/default-user/5` now matches the
`{scope}/{id}` route where it previously 404'd — and `parseIdentityID` **discarded**
the id for that scope ("any id segment is ignored", written when the path was
unreachable). That would have silently retargeted a per-user write at the
share-wide fallback quota for any direct API caller. `dfsctl` blocks it client-side
in `resolveID`, so no CLI user could hit it, but it is a real hole on the REST
surface and is rejected now:

```
PUT /api/v1/shares/x/quotas/default-user/5 -> 400 "scope default-user takes no identity id"
```

## Testing

`go build ./...`, `go vet`, `gofmt` clean; full unit suite green. No CLI flags or
command definitions changed, so `go run ./cmd/gendocs` produces no diff.

## Tests

`pkg/controlplane/api/quota_routes_test.go` pins the full set-get-list-remove cycle
for **all three scopes** end to end through the router, plus the missing-id,
unknown-scope and id-on-default-user rejections. There was no test coverage on
these routes before, which is how a literal-vs-param mismatch shipped.
