### PR TITLE
refactor(metadata): split PutFile into UpdateAttrs and SetManifest

### DIFF
--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -1371,7 +1371,7 @@ Production call chain (per-write, on quiesce):
             └─ persistFileChunksAfterFlush
                 └─ ComputeObjectID(blocks)
                 └─ coordinator.PersistFileChunks(blocks, objectID)
-                    └─ runtime coordinator: WithTransaction(GetFileByPayloadID + PutFile)
+                    └─ runtime coordinator: WithTransaction(GetFileByPayloadID + SetManifest)
                         // FileAttr.Blocks AND FileAttr.ObjectID
                         // written in one metadata txn
 ```

--- a/internal/adapter/common/clone.go
+++ b/internal/adapter/common/clone.go
@@ -25,7 +25,7 @@ import (
 // Everything is atomic in one metadata transaction:
 //   - engine.CopyPayload's per-hash IncrementRefCount UPDATEs are bound to the
 //     txn (via metadata.WithTx) so they commit/roll back together with the
-//     destination PutFile. On any error nothing is committed — no partial
+//     destination UpdateAttrs. On any error nothing is committed — no partial
 //     dstFileAttr, no leaked RefCount bumps.
 //   - cache.InvalidateFile (if cache != nil) runs POST-txn, after the commit.
 //
@@ -74,7 +74,7 @@ func CloneWholeFile(
 	err := metadataStore.WithTransaction(ctx, func(tx metadata.Transaction) error {
 		// Bind the active txn into the context so the per-share coordinator's
 		// RefCount UPDATEs (driven by engine.CopyPayload) join the same txn as
-		// the destination PutFile and commit/roll back together.
+		// the destination UpdateAttrs and commit/roll back together.
 		txCtx := metadata.WithTx(ctx, tx)
 
 		// Re-read the source INSIDE the txn, AFTER the drain, so the copy uses the
@@ -107,11 +107,10 @@ func CloneWholeFile(
 		}
 		dstFile.Blocks = newBlocks
 		// Wholesale manifest replacement on the destination — persist refs.
-		dstFile.BlocksDirty = true
 		dstFile.Size = srcFile.Size
 		dstFile.Mtime = time.Now()
 		dstFile.Ctime = dstFile.Mtime // content change is also a metadata change
-		if err := tx.PutFile(ctx, dstFile); err != nil {
+		if err := tx.SetManifest(ctx, dstFile); err != nil {
 			return fmt.Errorf("persist dst file: %w", err)
 		}
 		return nil
@@ -221,7 +220,7 @@ func materializeLocalClone(
 		dstFile.Size = srcFile.Size
 		dstFile.Mtime = time.Now()
 		dstFile.Ctime = dstFile.Mtime // content change is also a metadata change
-		if err := tx.PutFile(ctx, dstFile); err != nil {
+		if err := tx.UpdateAttrs(ctx, dstFile); err != nil {
 			return fmt.Errorf("persist dst file: %w", err)
 		}
 		return nil

--- a/internal/adapter/common/clone_test.go
+++ b/internal/adapter/common/clone_test.go
@@ -89,7 +89,7 @@ func TestCloneWholeFile_SelfCloneNoOp(t *testing.T) {
 }
 
 // TestCloneWholeFile_RollsBackOnIncrementError pins the atomicity contract: a
-// mid-loop IncrementRefCount failure rolls back the destination PutFile and all
+// mid-loop IncrementRefCount failure rolls back the destination UpdateAttrs and all
 // RefCount bumps, and skips the POST-txn cache invalidation.
 func TestCloneWholeFile_RollsBackOnIncrementError(t *testing.T) {
 	ctx := context.Background()

--- a/internal/adapter/common/copy_payload.go
+++ b/internal/adapter/common/copy_payload.go
@@ -19,8 +19,8 @@ import (
 //   - Inside the txn, engine.CopyPayload invokes
 //     coordinator.IncrementRefCount for each unique src hash; the
 //     coordinator's RefCount UPDATEs share the same txn, so they
-//     commit/roll back atomically with PutFile(dst).
-//   - On any error (Increment failure, PutFile failure, ctx cancel), the
+//     commit/roll back atomically with UpdateAttrs(dst).
+//   - On any error (Increment failure, UpdateAttrs failure, ctx cancel), the
 //     txn rolls back ALL writes — no partial dstFileAttr, no partial
 //     RefCount bumps committed.
 //   - cache.InvalidateFile runs ONLY on success, AFTER the commit.
@@ -36,7 +36,7 @@ import (
 // its RefCount UPDATEs to whatever txn is currently active for the
 // caller's context — see pkg/block/engine/coordinator.go for the
 // contract. The metadata.Transaction passed to fn here is the canonical
-// place where dst's PutFile lands; engine increments piggyback on the
+// place where dst's UpdateAttrs lands; engine increments piggyback on the
 // same txn through the coordinator's per-impl mechanism.
 func CopyPayload(
 	ctx context.Context,
@@ -67,7 +67,7 @@ func CopyPayload(
 		// metadataCoordinator's IncrementRefCount / DecrementRefCount
 		// calls route through it instead of the connection pool. Without
 		// this, every successful Increment commits on its own connection
-		// and survives a downstream PutFile rollback — silent leak.
+		// and survives a downstream UpdateAttrs rollback — silent leak.
 		// See pkg/metadata/tx_context.go for the carrier API.
 		txCtx := metadata.WithTx(ctx, tx)
 
@@ -85,11 +85,10 @@ func CopyPayload(
 		}
 		dstFile.Blocks = newBlocks
 		// Wholesale manifest replacement on the destination — persist refs.
-		dstFile.BlocksDirty = true
 		dstFile.Size = srcFile.Size
 		dstFile.Mtime = time.Now()
 		dstFile.Ctime = dstFile.Mtime // content change is also a metadata change
-		if err := tx.PutFile(ctx, dstFile); err != nil {
+		if err := tx.SetManifest(ctx, dstFile); err != nil {
 			return fmt.Errorf("persist dst file attr: %w", err)
 		}
 		return nil

--- a/internal/adapter/common/copy_payload_test.go
+++ b/internal/adapter/common/copy_payload_test.go
@@ -110,12 +110,12 @@ func putTestFile(t *testing.T, ms metadata.Store, path string, payloadID metadat
 		},
 	}
 
-	if err := ms.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile(%s) failed: %v", path, err)
+	if err := ms.UpdateAttrs(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs(%s) failed: %v", path, err)
 	}
 
 	// Memory store derives the handle via EncodeShareHandle(ShareName, ID).
-	// The same encoding is used in tx.PutFile, so a re-encoded handle here
+	// The same encoding is used in tx.UpdateAttrs, so a re-encoded handle here
 	// matches the key the file was stored under.
 	handle, err := metadata.EncodeShareHandle(file.ShareName, file.ID)
 	if err != nil {
@@ -128,7 +128,7 @@ func putTestFile(t *testing.T, ms metadata.Store, path string, payloadID metadat
 // asserts:
 //   - dst's FileAttr.Blocks matches src's ChunkRefs
 //   - each unique hash got exactly one IncrementRefCount call
-//   - PutFile(dst) was invoked through the metadataStore (visible via
+//   - UpdateAttrs(dst) was invoked through the metadataStore (visible via
 //     a GetFile call after the helper returns)
 //   - cache.InvalidateFile fired POST-txn with payloadID = dstPayloadID
 func TestCopyPayload_AtomicSuccess(t *testing.T) {
@@ -198,7 +198,7 @@ func TestCopyPayload_AtomicSuccess(t *testing.T) {
 }
 
 // TestCopyPayload_RollsBackOnIncrementError pins the rollback contract:
-// mid-loop IncrementRefCount failure rolls back ALL writes (no PutFile(dst),
+// mid-loop IncrementRefCount failure rolls back ALL writes (no UpdateAttrs(dst),
 // no partial dstFileAttr persisted, no InvalidateFile call).
 func TestCopyPayload_RollsBackOnIncrementError(t *testing.T) {
 	ctx := context.Background()
@@ -324,15 +324,15 @@ func TestCopyPayload_CtimeUpdated(t *testing.T) {
 	// Seed dst with a known old Ctime so we can detect it did not change.
 	oldTime := time.Now().Add(-1 * time.Hour)
 	dstHandle := putTestFile(t, ms, "/ctime-dst.bin", "ctime-dst-pid", nil, 0)
-	// Overwrite Ctime to a known-old value via a direct PutFile before the copy.
+	// Overwrite Ctime to a known-old value via a direct UpdateAttrs before the copy.
 	dstFilePre, err := ms.GetFile(ctx, dstHandle)
 	if err != nil {
 		t.Fatalf("GetFile(dst) pre-copy: %v", err)
 	}
 	dstFilePre.Ctime = oldTime
 	dstFilePre.Mtime = oldTime
-	if err := ms.PutFile(ctx, dstFilePre); err != nil {
-		t.Fatalf("PutFile(dst) seed old Ctime: %v", err)
+	if err := ms.UpdateAttrs(ctx, dstFilePre); err != nil {
+		t.Fatalf("UpdateAttrs(dst) seed old Ctime: %v", err)
 	}
 
 	preCopy := time.Now()

--- a/internal/adapter/nfs/v4/handlers/io_test.go
+++ b/internal/adapter/nfs/v4/handlers/io_test.go
@@ -207,7 +207,7 @@ func (fx *ioTestFixture) createDirectory(t *testing.T, parentHandle metadata.Fil
 	}
 
 	ctx := context.Background()
-	if err := fx.store.PutFile(ctx, file); err != nil {
+	if err := fx.store.UpdateAttrs(ctx, file); err != nil {
 		t.Fatalf("put dir: %v", err)
 	}
 	if err := fx.store.SetChild(ctx, parentHandle, name, fileHandle); err != nil {

--- a/internal/adapter/nfs/v4/handlers/realfs_test.go
+++ b/internal/adapter/nfs/v4/handlers/realfs_test.go
@@ -80,7 +80,7 @@ func newRealFSTestFixture(t *testing.T, shareName string) *realFSTestFixture {
 			Ctime: time.Now(),
 		},
 	}
-	if err := store.PutFile(context.Background(), rootFile); err != nil {
+	if err := store.UpdateAttrs(context.Background(), rootFile); err != nil {
 		t.Fatalf("put root file: %v", err)
 	}
 	if err := store.SetLinkCount(context.Background(), rootHandle, 2); err != nil {
@@ -137,7 +137,7 @@ func (f *realFSTestFixture) createTestFile(t *testing.T, parentHandle metadata.F
 	}
 
 	ctx := context.Background()
-	if err := f.store.PutFile(ctx, file); err != nil {
+	if err := f.store.UpdateAttrs(ctx, file); err != nil {
 		t.Fatalf("put file: %v", err)
 	}
 	if err := f.store.SetChild(ctx, parentHandle, name, fileHandle); err != nil {

--- a/pkg/block/engine/api_blockref_test.go
+++ b/pkg/block/engine/api_blockref_test.go
@@ -381,7 +381,7 @@ func TestTruncate_EmptyBlocksLegacyPath(t *testing.T) {
 
 // TestWriteAt_ReturnsCurrentBlocks asserts the contract: until
 // wires the FastCDC re-chunking, WriteAt returns
-// currentBlocks unchanged so the caller's UpdateAttrs sees a stable list.
+// currentBlocks unchanged so the caller's SetManifest sees a stable list.
 func TestWriteAt_ReturnsCurrentBlocks(t *testing.T) {
 	bs := newTestEngine(t, 0, 0)
 	ctx := context.Background()

--- a/pkg/block/engine/api_blockref_test.go
+++ b/pkg/block/engine/api_blockref_test.go
@@ -381,7 +381,7 @@ func TestTruncate_EmptyBlocksLegacyPath(t *testing.T) {
 
 // TestWriteAt_ReturnsCurrentBlocks asserts the contract: until
 // wires the FastCDC re-chunking, WriteAt returns
-// currentBlocks unchanged so the caller's PutFile sees a stable list.
+// currentBlocks unchanged so the caller's UpdateAttrs sees a stable list.
 func TestWriteAt_ReturnsCurrentBlocks(t *testing.T) {
 	bs := newTestEngine(t, 0, 0)
 	ctx := context.Background()

--- a/pkg/block/engine/audit_state_test.go
+++ b/pkg/block/engine/audit_state_test.go
@@ -102,8 +102,8 @@ func seedAuditTestStore(t *testing.T) (store *metadatamemory.MemoryMetadataStore
 				Blocks:    refs,
 			},
 		}
-		if err := store.PutFile(ctx, file); err != nil {
-			t.Fatalf("PutFile: %v", err)
+		if err := store.UpdateAttrs(ctx, file); err != nil {
+			t.Fatalf("UpdateAttrs: %v", err)
 		}
 		if err := store.SetParent(ctx, handle, rootHandle); err != nil {
 			t.Fatalf("SetParent: %v", err)

--- a/pkg/block/engine/blocksink.go
+++ b/pkg/block/engine/blocksink.go
@@ -26,7 +26,7 @@ const _ = uint(-(numCarveCommitStripes & (numCarveCommitStripes - 1)))
 
 // carveCommitLocks serializes a payloadID's metadata commit so the within-file
 // carve dispatcher's concurrent CommitBlock calls do not read-modify-write the
-// same File row at once. Each commit re-projects File.Blocks (a PutFile), so two
+// same File row at once. Each commit re-projects File.Blocks (a UpdateAttrs), so two
 // overlapping commits for one file abort under badger's SSI as a transaction
 // conflict; enough contention exhausts the retry budget and surfaces to the
 // carver (the SMB/NFS client sees EDEADLK). The block upload runs OUTSIDE this

--- a/pkg/block/engine/blocksink.go
+++ b/pkg/block/engine/blocksink.go
@@ -26,7 +26,7 @@ const _ = uint(-(numCarveCommitStripes & (numCarveCommitStripes - 1)))
 
 // carveCommitLocks serializes a payloadID's metadata commit so the within-file
 // carve dispatcher's concurrent CommitBlock calls do not read-modify-write the
-// same File row at once. Each commit re-projects File.Blocks (a UpdateAttrs), so two
+// same File row at once. Each commit re-projects File.Blocks (a SetManifest), so two
 // overlapping commits for one file abort under badger's SSI as a transaction
 // conflict; enough contention exhausts the retry budget and surfaces to the
 // carver (the SMB/NFS client sees EDEADLK). The block upload runs OUTSIDE this

--- a/pkg/block/engine/blocksink_ssi_test.go
+++ b/pkg/block/engine/blocksink_ssi_test.go
@@ -50,7 +50,7 @@ func newBadgerCommitter(t *testing.T) (*metadatabadger.BadgerMetadataStore, meta
 		},
 	}
 	file.ID = id
-	require.NoError(t, store.PutFile(ctx, file))
+	require.NoError(t, store.UpdateAttrs(ctx, file))
 	require.NoError(t, store.SetParent(ctx, handle, dir))
 	require.NoError(t, store.SetChild(ctx, dir, "f.bin", handle))
 	return store, pid
@@ -59,7 +59,7 @@ func newBadgerCommitter(t *testing.T) (*metadatabadger.BadgerMetadataStore, meta
 // TestLocalBlockSink_ConcurrentSameFileCommit_NoSSIConflict reproduces the carve
 // SSI wall: the within-file carve dispatcher (CarveUploadConcurrency) fires
 // several CommitBlock calls for one file concurrently, and each re-projects
-// File.Blocks (PutFile) on the SAME File row. Under badger's SSI that read-write
+// File.Blocks (UpdateAttrs) on the SAME File row. Under badger's SSI that read-write
 // on a shared row aborts as ErrConflict; enough contention exhausts the retry
 // budget and surfaces the conflict to the carver (the client sees EDEADLK).
 //

--- a/pkg/block/engine/blocksink_ssi_test.go
+++ b/pkg/block/engine/blocksink_ssi_test.go
@@ -59,7 +59,7 @@ func newBadgerCommitter(t *testing.T) (*metadatabadger.BadgerMetadataStore, meta
 // TestLocalBlockSink_ConcurrentSameFileCommit_NoSSIConflict reproduces the carve
 // SSI wall: the within-file carve dispatcher (CarveUploadConcurrency) fires
 // several CommitBlock calls for one file concurrently, and each re-projects
-// File.Blocks (UpdateAttrs) on the SAME File row. Under badger's SSI that read-write
+// File.Blocks (SetManifest) on the SAME File row. Under badger's SSI that read-write
 // on a shared row aborts as ErrConflict; enough contention exhausts the retry
 // budget and surfaces the conflict to the carver (the client sees EDEADLK).
 //

--- a/pkg/block/engine/clone_localonly_test.go
+++ b/pkg/block/engine/clone_localonly_test.go
@@ -99,8 +99,8 @@ func TestCloneWholeFile_LocalOnly_MaterializesContent(t *testing.T) {
 		t.Fatalf("GetFile src: %v", err)
 	}
 	srcFile.Size = size
-	if err := ms.PutFile(ctx, srcFile); err != nil {
-		t.Fatalf("PutFile src size: %v", err)
+	if err := ms.UpdateAttrs(ctx, srcFile); err != nil {
+		t.Fatalf("UpdateAttrs src size: %v", err)
 	}
 
 	// CLONE over a local-only share.

--- a/pkg/block/engine/coordinator.go
+++ b/pkg/block/engine/coordinator.go
@@ -85,7 +85,7 @@ type MetadataCoordinator interface {
 	// PersistFileChunks updates FileAttr.Blocks AND FileAttr.ObjectID
 	// for a given file in a single metadata txn. It is invoked by the
 	// runtime coordinator wrapper (which resolves payloadID → fileHandle
-	// and runs PutFile in one txn) after a Flush persists a file's chunk
+	// and runs UpdateAttrs in one txn) after a Flush persists a file's chunk
 	// manifest — the engine itself no longer drives it from a local-store
 	// chunk-lifecycle hook, of which none remain.
 	//

--- a/pkg/block/engine/coordinator.go
+++ b/pkg/block/engine/coordinator.go
@@ -85,7 +85,7 @@ type MetadataCoordinator interface {
 	// PersistFileChunks updates FileAttr.Blocks AND FileAttr.ObjectID
 	// for a given file in a single metadata txn. It is invoked by the
 	// runtime coordinator wrapper (which resolves payloadID → fileHandle
-	// and runs UpdateAttrs in one txn) after a Flush persists a file's chunk
+	// and runs SetManifest in one txn) after a Flush persists a file's chunk
 	// manifest — the engine itself no longer drives it from a local-store
 	// chunk-lifecycle hook, of which none remain.
 	//

--- a/pkg/block/engine/drain_persist_test.go
+++ b/pkg/block/engine/drain_persist_test.go
@@ -19,7 +19,7 @@ import (
 // coordinator.go) — that package may not be imported here per the
 // strict-grep boundary. It drives PersistFileChunks the exact way the
 // production wrapper does: resolve payloadID -> existing file row via
-// GetFileByPayloadID, mutate Blocks + ObjectID, UpdateAttrs under the existing
+// GetFileByPayloadID, mutate Blocks + ObjectID, SetManifest under the existing
 // id, all in one metadata transaction, wrapping a backend object_id
 // uniqueness conflict into engine.ErrObjectIDConflict.
 type testCoordinator struct {
@@ -63,7 +63,7 @@ func (c *testCoordinator) PersistFileChunks(ctx context.Context, payloadID strin
 		}
 		file.Blocks = blocks
 		file.ObjectID = objectID
-		if perr := tx.UpdateAttrs(ctx, file); perr != nil {
+		if perr := tx.SetManifest(ctx, file); perr != nil {
 			return mapObjectIDConflict(perr)
 		}
 		return nil

--- a/pkg/block/engine/drain_persist_test.go
+++ b/pkg/block/engine/drain_persist_test.go
@@ -19,7 +19,7 @@ import (
 // coordinator.go) — that package may not be imported here per the
 // strict-grep boundary. It drives PersistFileChunks the exact way the
 // production wrapper does: resolve payloadID -> existing file row via
-// GetFileByPayloadID, mutate Blocks + ObjectID, PutFile under the existing
+// GetFileByPayloadID, mutate Blocks + ObjectID, UpdateAttrs under the existing
 // id, all in one metadata transaction, wrapping a backend object_id
 // uniqueness conflict into engine.ErrObjectIDConflict.
 type testCoordinator struct {
@@ -63,7 +63,7 @@ func (c *testCoordinator) PersistFileChunks(ctx context.Context, payloadID strin
 		}
 		file.Blocks = blocks
 		file.ObjectID = objectID
-		if perr := tx.PutFile(ctx, file); perr != nil {
+		if perr := tx.UpdateAttrs(ctx, file); perr != nil {
 			return mapObjectIDConflict(perr)
 		}
 		return nil
@@ -197,8 +197,8 @@ func createRealFile(t *testing.T, store metadata.Store, shareName, name string, 
 			PayloadID: metadata.PayloadID(payloadID),
 		},
 	}
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile %q: %v", name, err)
+	if err := store.UpdateAttrs(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs %q: %v", name, err)
 	}
 	if err := store.SetParent(ctx, handle, rootHandle); err != nil {
 		t.Fatalf("SetParent %q: %v", name, err)

--- a/pkg/block/engine/manifest_check_test.go
+++ b/pkg/block/engine/manifest_check_test.go
@@ -133,19 +133,18 @@ func seedCheckFile(
 		ID:        fileID,
 		ShareName: share,
 		FileAttr: metadata.FileAttr{
-			Type:        metadata.FileTypeRegular,
-			Mode:        0o644,
-			Size:        size,
-			Mtime:       now,
-			Ctime:       now,
-			Atime:       now,
-			PayloadID:   metadata.PayloadID(payloadID),
-			Blocks:      blocks,
-			BlocksDirty: true,
+			Type:      metadata.FileTypeRegular,
+			Mode:      0o644,
+			Size:      size,
+			Mtime:     now,
+			Ctime:     now,
+			Atime:     now,
+			PayloadID: metadata.PayloadID(payloadID),
+			Blocks:    blocks,
 		},
 	}
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile(%s): %v", name, err)
+	if err := store.SetManifest(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs(%s): %v", name, err)
 	}
 	if err := store.SetParent(ctx, handle, root); err != nil {
 		t.Fatalf("SetParent(%s): %v", name, err)

--- a/pkg/block/engine/range.go
+++ b/pkg/block/engine/range.go
@@ -21,7 +21,7 @@ import (
 //
 // Caller invariant (caller-snapshot-wins): blocks MUST be sorted
 // by Offset. The metadata-store conformance suite verifies
-// that PutFile/GetFile preserve sort order.
+// that UpdateAttrs/GetFile preserve sort order.
 func findBlocksForRange(blocks []block.ChunkRef, offset, size uint64) (start, end int) {
 	if len(blocks) == 0 || size == 0 {
 		return 0, 0

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -114,7 +114,7 @@ func (bs *Store) WriteAt(ctx context.Context, payloadID string, currentBlocks []
 // when currentBlocks is non-empty, blocks strictly past newSize
 // are dropped and the coordinator decrements RefCount for each dropped
 // hash. The new []ChunkRef list is returned for the caller to persist
-// via PutFile. When currentBlocks is empty the legacy path runs and
+// via UpdateAttrs. When currentBlocks is empty the legacy path runs and
 // the returned slice is empty (dual-read shim semantics).
 // narrowChunkRow shrinks a manifest row to the surviving prefix of its chunk so
 // coverage lookups stop resolving it for bytes the file no longer holds and a
@@ -177,7 +177,7 @@ func (bs *Store) Truncate(ctx context.Context, payloadID string, currentBlocks [
 	//
 	// CAS-path ChunkRef pruning + coordinator DecrementRefCount per
 	// dropped hash. Empty input (legacy/dual-read path) skips the
-	// coordinator and returns nil so the caller's PutFile keeps
+	// coordinator and returns nil so the caller's UpdateAttrs keeps
 	// FileAttr.Blocks untouched.
 	var kept []block.ChunkRef
 	if len(currentBlocks) > 0 {
@@ -563,7 +563,7 @@ func (bs *Store) CopyPayload(ctx context.Context, srcPayloadID, dstPayloadID str
 	// store mutex for the life of fn; the store-level fileChunkStore.Put would
 	// re-acquire that same (non-reentrant) mutex and self-deadlock. The
 	// tx-bound Put writes under the already-held lock and commits/rolls back
-	// atomically with the caller's dst FileAttr.Blocks PutFile — so the per-file
+	// atomically with the caller's dst FileAttr.Blocks UpdateAttrs — so the per-file
 	// rows and the FileAttr.Blocks manifest stay consistent. With no bound txn
 	// (e.g. unit tests wiring the engine directly) fall back to the store-level
 	// Put, matching the rollup ObjectIDPersister which runs outside any txn.

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -114,7 +114,7 @@ func (bs *Store) WriteAt(ctx context.Context, payloadID string, currentBlocks []
 // when currentBlocks is non-empty, blocks strictly past newSize
 // are dropped and the coordinator decrements RefCount for each dropped
 // hash. The new []ChunkRef list is returned for the caller to persist
-// via UpdateAttrs. When currentBlocks is empty the legacy path runs and
+// via SetManifest. When currentBlocks is empty the legacy path runs and
 // the returned slice is empty (dual-read shim semantics).
 // narrowChunkRow shrinks a manifest row to the surviving prefix of its chunk so
 // coverage lookups stop resolving it for bytes the file no longer holds and a

--- a/pkg/block/filechunk.go
+++ b/pkg/block/filechunk.go
@@ -180,14 +180,14 @@ type Reader interface {
 //
 // write operations thread a caller-supplied
 // []ChunkRef snapshot of the file's FileAttr.Blocks. WriteAt returns the
-// new []ChunkRef (caller persists via UpdateAttrs in the same metadata txn).
+// new []ChunkRef (caller persists via SetManifest in the same metadata txn).
 // Truncate / Delete invoke the MetadataCoordinator to decrement RefCount
 // for hashes the operation drops; CopyPayload becomes O(1) — increments
 // RefCount per unique source hash, no data copy.
 type Writer interface {
 	// WriteAt writes data to storage at the given offset and returns
 	// the file's new ChunkRef list (sorted, sparse-hole-preserving).
-	// Caller persists via UpdateAttrs in the same metadata txn.
+	// Caller persists via SetManifest in the same metadata txn.
 	WriteAt(ctx context.Context, payloadID string, currentBlocks []ChunkRef, data []byte, offset uint64) ([]ChunkRef, error)
 
 	// Truncate changes the size of a payload. Returns the new ChunkRef

--- a/pkg/block/filechunk.go
+++ b/pkg/block/filechunk.go
@@ -180,14 +180,14 @@ type Reader interface {
 //
 // write operations thread a caller-supplied
 // []ChunkRef snapshot of the file's FileAttr.Blocks. WriteAt returns the
-// new []ChunkRef (caller persists via PutFile in the same metadata txn).
+// new []ChunkRef (caller persists via UpdateAttrs in the same metadata txn).
 // Truncate / Delete invoke the MetadataCoordinator to decrement RefCount
 // for hashes the operation drops; CopyPayload becomes O(1) — increments
 // RefCount per unique source hash, no data copy.
 type Writer interface {
 	// WriteAt writes data to storage at the given offset and returns
 	// the file's new ChunkRef list (sorted, sparse-hole-preserving).
-	// Caller persists via PutFile in the same metadata txn.
+	// Caller persists via UpdateAttrs in the same metadata txn.
 	WriteAt(ctx context.Context, payloadID string, currentBlocks []ChunkRef, data []byte, offset uint64) ([]ChunkRef, error)
 
 	// Truncate changes the size of a payload. Returns the new ChunkRef

--- a/pkg/controlplane/runtime/blockgc_reconcile_test.go
+++ b/pkg/controlplane/runtime/blockgc_reconcile_test.go
@@ -48,7 +48,7 @@ func TestReapStrandedRows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DecodeFileHandle: %v", err)
 	}
-	if err := store.PutFile(ctx, &metadata.File{
+	if err := store.UpdateAttrs(ctx, &metadata.File{
 		ID:        id,
 		ShareName: "share",
 		Path:      "/live.bin",
@@ -58,7 +58,7 @@ func TestReapStrandedRows(t *testing.T) {
 			PayloadID: metadata.PayloadID(livePID),
 		},
 	}); err != nil {
-		t.Fatalf("PutFile: %v", err)
+		t.Fatalf("UpdateAttrs: %v", err)
 	}
 
 	seedReconcileFB(t, ctx, store, livePID, 2, old)        // live, must survive

--- a/pkg/controlplane/runtime/blocks_flip_test.go
+++ b/pkg/controlplane/runtime/blocks_flip_test.go
@@ -49,8 +49,8 @@ func createFileForPayload(t *testing.T, ctx context.Context, meta metadata.Store
 			PayloadID: payloadID,
 		},
 	}
-	if err := meta.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile %q: %v", name, err)
+	if err := meta.UpdateAttrs(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs %q: %v", name, err)
 	}
 	if err := meta.SetParent(ctx, handle, root); err != nil {
 		t.Fatalf("SetParent %q: %v", name, err)

--- a/pkg/controlplane/runtime/openhandle_hold_test.go
+++ b/pkg/controlplane/runtime/openhandle_hold_test.go
@@ -60,7 +60,7 @@ func openHoldPutFile(t *testing.T, store metadata.Store, shareName, path string,
 	require.NoError(t, err)
 	_, id, err := metadata.DecodeFileHandle(h)
 	require.NoError(t, err)
-	require.NoError(t, store.PutFile(ctx, &metadata.File{
+	require.NoError(t, store.UpdateAttrs(ctx, &metadata.File{
 		ID:        id,
 		ShareName: shareName,
 		Path:      path,

--- a/pkg/controlplane/runtime/shares/coordinator.go
+++ b/pkg/controlplane/runtime/shares/coordinator.go
@@ -76,7 +76,7 @@ func (c *metadataCoordinator) resolveStore(ctx context.Context) block.FileChunkS
 // When the caller has bound an active metadata.Transaction into ctx
 // via metadata.WithTx, both GetByHash and IncrementRefCount route
 // through that tx — keeping the per-row UPDATE inside the caller's
-// txn so a downstream PutFile failure rolls back BOTH the file attrs
+// txn so a downstream UpdateAttrs failure rolls back BOTH the file attrs
 // AND every increment.
 func (c *metadataCoordinator) IncrementRefCount(ctx context.Context, hash block.ContentHash) error {
 	store := c.resolveStore(ctx)
@@ -169,7 +169,7 @@ func (c *metadataCoordinator) ReprojectBlocks(ctx context.Context, payloadID str
 // FileAttr.ObjectID for the file identified by payloadID in a single
 // metadata transaction. The runtime wrapper resolves
 // payloadID → fileHandle → file via tx.GetFileByPayloadID and persists
-// the updated FileAttr via tx.PutFile.
+// the updated FileAttr via tx.UpdateAttrs.
 //
 // This is the post-Flush seam — the syncer invokes this after every
 // successful Flush so the canonical FileAttr.Blocks list reflects every
@@ -178,7 +178,7 @@ func (c *metadataCoordinator) ReprojectBlocks(ctx context.Context, payloadID str
 // The syncer computes the BLAKE3 Merkle-root ObjectID over `blocks`
 // (via block.ComputeObjectID) and threads it through this hook so
 // the metadata write atomically updates both Blocks AND ObjectID in the
-// same PutFile transaction.
+// same UpdateAttrs transaction.
 //
 // Conflict mapping: a Postgres unique-violation on files_object_id_idx
 // (first-committer-wins) — or the equivalent mderrors.ErrConflict from
@@ -198,10 +198,9 @@ func (c *metadataCoordinator) PersistFileChunks(ctx context.Context, payloadID s
 		// FileAttr is embedded on metadata.File (not a pointer).
 		file.Blocks = blocks
 		// Post-Flush manifest write — must persist file_block_refs.
-		file.BlocksDirty = true
 		// Same-txn write of Blocks AND ObjectID.
 		file.ObjectID = objectID
-		if err := tx.PutFile(ctx, file); err != nil {
+		if err := tx.SetManifest(ctx, file); err != nil {
 			return mapObjectIDConflict(err)
 		}
 		return nil

--- a/pkg/controlplane/runtime/shares/coordinator.go
+++ b/pkg/controlplane/runtime/shares/coordinator.go
@@ -169,7 +169,7 @@ func (c *metadataCoordinator) ReprojectBlocks(ctx context.Context, payloadID str
 // FileAttr.ObjectID for the file identified by payloadID in a single
 // metadata transaction. The runtime wrapper resolves
 // payloadID → fileHandle → file via tx.GetFileByPayloadID and persists
-// the updated FileAttr via tx.UpdateAttrs.
+// the updated FileAttr via tx.SetManifest.
 //
 // This is the post-Flush seam — the syncer invokes this after every
 // successful Flush so the canonical FileAttr.Blocks list reflects every
@@ -178,7 +178,7 @@ func (c *metadataCoordinator) ReprojectBlocks(ctx context.Context, payloadID str
 // The syncer computes the BLAKE3 Merkle-root ObjectID over `blocks`
 // (via block.ComputeObjectID) and threads it through this hook so
 // the metadata write atomically updates both Blocks AND ObjectID in the
-// same UpdateAttrs transaction.
+// same SetManifest transaction.
 //
 // Conflict mapping: a Postgres unique-violation on files_object_id_idx
 // (first-committer-wins) — or the equivalent mderrors.ErrConflict from

--- a/pkg/controlplane/runtime/shares/coordinator_test.go
+++ b/pkg/controlplane/runtime/shares/coordinator_test.go
@@ -118,7 +118,7 @@ func TestMetadataCoordinator_FallsBackToPublicStoreWithoutTx(t *testing.T) {
 // TestMetadataCoordinator_RollsBackOnDownstreamPutFileFailure pins the
 // CR-01 atomicity contract end-to-end: when the caller binds an active
 // metadata.Transaction into ctx via metadata.WithTx and a downstream
-// PutFile fails AFTER successful IncrementRefCount calls, the wrapping
+// UpdateAttrs fails AFTER successful IncrementRefCount calls, the wrapping
 // WithTransaction MUST roll back EVERY refcount mutation.
 //
 // Memory backend prior to CR-01 was technically correct (single mutex
@@ -158,7 +158,7 @@ func TestMetadataCoordinator_RollsBackOnDownstreamPutFileFailure(t *testing.T) {
 
 	// Simulate the exact wiring common.CopyPayload uses: open a real
 	// txn, bump refcount on every hash through the coordinator (via
-	// WithTx-bound ctx), then trigger a synthetic PutFile failure.
+	// WithTx-bound ctx), then trigger a synthetic UpdateAttrs failure.
 	// WithTransaction MUST roll back; refcounts MUST be unchanged.
 	injected := errors.New("synthetic put failure")
 	err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
@@ -168,7 +168,7 @@ func TestMetadataCoordinator_RollsBackOnDownstreamPutFileFailure(t *testing.T) {
 				return err
 			}
 		}
-		// Synthetic downstream failure (would be tx.PutFile in production).
+		// Synthetic downstream failure (would be tx.UpdateAttrs in production).
 		return injected
 	})
 	if !errors.Is(err, injected) {

--- a/pkg/controlplane/runtime/shares/lifecycle.go
+++ b/pkg/controlplane/runtime/shares/lifecycle.go
@@ -189,7 +189,7 @@ func (s *Service) durableExtent(shareName string, payloadID metadata.PayloadID) 
 //
 // bs.Local.ListFiles/FileSize are served from the journal's in-memory index
 // (populated by recover() at open), so the common no-mismatch case is cheap: a
-// point read of metadata per file, and a strict PutFile only on an actual gap.
+// point read of metadata per file, and a strict UpdateAttrs only on an actual gap.
 func reconcileMetadataSizeFromJournal(ctx context.Context, metadataStore metadata.Store, bs *engine.Store) error {
 	if bs == nil {
 		return nil
@@ -232,7 +232,7 @@ func reconcileMetadataSizeFromJournal(ctx context.Context, metadataStore metadat
 				return nil // another writer already caught up; never shrink
 			}
 			cur.Size = uint64(journalSize)
-			return tx.PutFile(ctx, cur)
+			return tx.UpdateAttrs(ctx, cur)
 		}); err != nil {
 			return fmt.Errorf("reconcile size for payload %s: %w", id, err)
 		}

--- a/pkg/controlplane/runtime/snapshot_byteverify_test.go
+++ b/pkg/controlplane/runtime/snapshot_byteverify_test.go
@@ -279,8 +279,8 @@ func (f *byteVerifyFixture) createEmptyFile(ctx context.Context, name string) me
 			PayloadID: payloadID,
 		},
 	}
-	if err := f.meta.PutFile(ctx, file); err != nil {
-		f.t.Fatalf("PutFile %q: %v", name, err)
+	if err := f.meta.UpdateAttrs(ctx, file); err != nil {
+		f.t.Fatalf("UpdateAttrs %q: %v", name, err)
 	}
 	if err := f.meta.SetParent(ctx, handle, root); err != nil {
 		f.t.Fatalf("SetParent %q: %v", name, err)

--- a/pkg/controlplane/runtime/snapshot_consistency_test.go
+++ b/pkg/controlplane/runtime/snapshot_consistency_test.go
@@ -396,7 +396,7 @@ func (f *realBackupFixture) tryPutMultiChunkFile(ctx context.Context, name strin
 		},
 	}
 	file.ID = id
-	if err := f.mem.PutFile(ctx, file); err != nil {
+	if err := f.mem.UpdateAttrs(ctx, file); err != nil {
 		return fmt.Errorf("put file: %w", err)
 	}
 	if isNew {

--- a/pkg/controlplane/runtime/snapshot_restore_test.go
+++ b/pkg/controlplane/runtime/snapshot_restore_test.go
@@ -715,8 +715,8 @@ func (f *restoreFixture) populateFiles(ctx context.Context, names []string) []fi
 				Blocks: []block.ChunkRef{{Hash: hash, Offset: 0, Size: 4096}},
 			},
 		}
-		if err := f.meta.PutFile(ctx, file); err != nil {
-			f.t.Fatalf("PutFile %q: %v", name, err)
+		if err := f.meta.UpdateAttrs(ctx, file); err != nil {
+			f.t.Fatalf("UpdateAttrs %q: %v", name, err)
 		}
 		if err := f.meta.SetParent(ctx, handle, f.rootHandle); err != nil {
 			f.t.Fatalf("SetParent %q: %v", name, err)

--- a/pkg/controlplane/runtime/trash/reaper_test.go
+++ b/pkg/controlplane/runtime/trash/reaper_test.go
@@ -14,7 +14,7 @@ import (
 //
 // CreateFile cannot set Size: ApplyCreateDefaults zeroes it for regular files
 // (no data-plane write runs in these unit tests). So we stamp Size directly
-// through the store's GetFile/PutFile — the same direct-store technique the
+// through the store's GetFile/UpdateAttrs — the same direct-store technique the
 // service uses in clearStamp for fields SetFileAttributes does not expose. The
 // recycle move preserves the attr, so Entry.Size is non-zero and the max-size
 // eviction test can assert on it deterministically.
@@ -30,7 +30,7 @@ func (tt *trashTest) recycleSized(name string, size uint64) {
 	file, err := store.GetFile(tt.ctx.Context, handle)
 	require.NoError(tt.t, err)
 	file.Size = size
-	require.NoError(tt.t, store.PutFile(tt.ctx.Context, file))
+	require.NoError(tt.t, store.UpdateAttrs(tt.ctx.Context, file))
 
 	_, _, err = tt.deps.svc.RemoveFile(tt.ctx, tt.deps.rootHandle, name)
 	require.NoError(tt.t, err)

--- a/pkg/controlplane/runtime/trash/service.go
+++ b/pkg/controlplane/runtime/trash/service.go
@@ -351,7 +351,7 @@ func clearStamp(ctx *metadata.AuthContext, svc *metadata.Service, shareName stri
 	file.DeletedAt = nil
 	file.OriginalPath = ""
 	file.DeletedBy = ""
-	return store.PutFile(ctx.Context, file)
+	return store.UpdateAttrs(ctx.Context, file)
 }
 
 // Empty permanently removes every recycled root from the share's bin, freeing

--- a/pkg/controlplane/runtime/trash/service_test.go
+++ b/pkg/controlplane/runtime/trash/service_test.go
@@ -317,7 +317,7 @@ func TestEmptyThreadsBlocksToFreeBlocks(t *testing.T) {
 		{Offset: 0, Size: 4096},
 		{Offset: 4096, Size: 4096},
 	}
-	require.NoError(t, store.PutFile(tt.ctx.Context, file))
+	require.NoError(t, store.UpdateAttrs(tt.ctx.Context, file))
 
 	// Recycle it, then empty the bin.
 	_, _, err = tt.deps.svc.RemoveFile(tt.ctx, tt.deps.rootHandle, "withblocks.txt")

--- a/pkg/metadata/block_record_store.go
+++ b/pkg/metadata/block_record_store.go
@@ -168,13 +168,12 @@ func putProjection(ctx context.Context, tx Transaction, file *File, refs []block
 	// A projection from the manifest IS a manifest write — persist it. This
 	// funnels carve/rollup commit (DefaultCommitBlock), the reap+re-carve
 	// (ReapSupersededManifest), and coordinator.ReprojectBlocks.
-	file.BlocksDirty = true
-	file.BlocksDirtyOffsets = changed
-	err := tx.PutFile(ctx, file)
+	file.ManifestDirtyOffsets = changed
+	err := tx.SetManifest(ctx, file)
 	// The scope describes this write only — clearing it stops a caller that
 	// reuses the struct for a wider manifest mutation from inheriting a promise
 	// that no longer holds.
-	file.BlocksDirtyOffsets = nil
+	file.ManifestDirtyOffsets = nil
 	return err
 }
 

--- a/pkg/metadata/copy_file_attr_test.go
+++ b/pkg/metadata/copy_file_attr_test.go
@@ -18,29 +18,28 @@ import (
 func TestCopyFileAttr_CopiesEveryField(t *testing.T) {
 	deletedAt := time.Unix(1700000000, 0).UTC()
 	src := &FileAttr{
-		Type:               FileTypeRegular,
-		Mode:               0o644,
-		UID:                1000,
-		GID:                1000,
-		Nlink:              3,
-		Size:               4096,
-		Atime:              time.Unix(1, 0).UTC(),
-		Mtime:              time.Unix(2, 0).UTC(),
-		Ctime:              time.Unix(3, 0).UTC(),
-		CreationTime:       time.Unix(4, 0).UTC(),
-		PayloadID:          "payload-1",
-		LinkTarget:         "/target",
-		Rdev:               42,
-		Hidden:             true,
-		EAs:                map[string][]byte{"user.k": []byte("v")},
-		IdempotencyToken:   99,
-		Blocks:             []block.ChunkRef{{Offset: 0}},
-		BlocksDirty:        true,
-		BlocksDirtyOffsets: []uint64{0, 8192},
-		NewInode:           true,
-		DeletedAt:          &deletedAt,
-		OriginalPath:       "/was/here",
-		DeletedBy:          "someone",
+		Type:                 FileTypeRegular,
+		Mode:                 0o644,
+		UID:                  1000,
+		GID:                  1000,
+		Nlink:                3,
+		Size:                 4096,
+		Atime:                time.Unix(1, 0).UTC(),
+		Mtime:                time.Unix(2, 0).UTC(),
+		Ctime:                time.Unix(3, 0).UTC(),
+		CreationTime:         time.Unix(4, 0).UTC(),
+		PayloadID:            "payload-1",
+		LinkTarget:           "/target",
+		Rdev:                 42,
+		Hidden:               true,
+		EAs:                  map[string][]byte{"user.k": []byte("v")},
+		IdempotencyToken:     99,
+		Blocks:               []block.ChunkRef{{Offset: 0}},
+		ManifestDirtyOffsets: []uint64{0, 8192},
+		NewInode:             true,
+		DeletedAt:            &deletedAt,
+		OriginalPath:         "/was/here",
+		DeletedBy:            "someone",
 		ACL: &acl.ACL{
 			ACEs:          []acl.ACE{{}},
 			Protected:     true,
@@ -65,11 +64,11 @@ func TestCopyFileAttr_CopiesEveryField(t *testing.T) {
 func TestCopyFileAttr_IsDeep(t *testing.T) {
 	deletedAt := time.Unix(1700000000, 0).UTC()
 	src := &FileAttr{
-		EAs:                map[string][]byte{"user.k": []byte("v")},
-		Blocks:             []block.ChunkRef{{Offset: 0}},
-		BlocksDirtyOffsets: []uint64{1},
-		DeletedAt:          &deletedAt,
-		ACL:                &acl.ACL{ACEs: []acl.ACE{{}}, NullDACL: true},
+		EAs:                  map[string][]byte{"user.k": []byte("v")},
+		Blocks:               []block.ChunkRef{{Offset: 0}},
+		ManifestDirtyOffsets: []uint64{1},
+		DeletedAt:            &deletedAt,
+		ACL:                  &acl.ACL{ACEs: []acl.ACE{{}}, NullDACL: true},
 	}
 
 	got := CopyFileAttr(src)
@@ -77,7 +76,7 @@ func TestCopyFileAttr_IsDeep(t *testing.T) {
 	got.EAs["user.k"][0] = 'X'
 	got.EAs["added"] = []byte("new")
 	got.Blocks[0].Offset = 777
-	got.BlocksDirtyOffsets[0] = 777
+	got.ManifestDirtyOffsets[0] = 777
 	*got.DeletedAt = time.Unix(0, 0).UTC()
 	got.ACL.NullDACL = false
 	got.ACL.ACEs = append(got.ACL.ACEs, acl.ACE{})
@@ -85,7 +84,7 @@ func TestCopyFileAttr_IsDeep(t *testing.T) {
 	require.Equal(t, byte('v'), src.EAs["user.k"][0])
 	require.NotContains(t, src.EAs, "added")
 	require.Equal(t, uint64(0), src.Blocks[0].Offset)
-	require.Equal(t, uint64(1), src.BlocksDirtyOffsets[0])
+	require.Equal(t, uint64(1), src.ManifestDirtyOffsets[0])
 	require.Equal(t, deletedAt, *src.DeletedAt)
 	require.True(t, src.ACL.NullDACL, "mutating the copy must not clear the source's null-DACL flag")
 	require.Len(t, src.ACL.ACEs, 1)

--- a/pkg/metadata/create_readcache_test.go
+++ b/pkg/metadata/create_readcache_test.go
@@ -18,7 +18,7 @@ import (
 // still hits the real badger txn and joins Badger's SSI conflict read-set. So N
 // concurrent creates of the SAME (parent,name) must resolve to exactly ONE
 // winner, the rest AlreadyExists, and — critically — NO orphaned inode (a
-// double-create would PutFile a second inode whose dirent lost, inflating the
+// double-create would UpdateAttrs a second inode whose dirent lost, inflating the
 // file count).
 //
 // If the dirent cache ever served the in-txn recheck, both racers would see

--- a/pkg/metadata/data_write.go
+++ b/pkg/metadata/data_write.go
@@ -9,10 +9,10 @@ import (
 // transaction implements it to collapse the read-modify-write a WRITE performs
 // — grow size to max(old, new), stamp mtime/ctime, optionally clear setuid/setgid
 // — into a single narrow statement, instead of GetFile (full-row read) plus
-// PutFile (full-row rewrite). It returns the resulting size so the caller can
+// UpdateAttrs (full-row rewrite). It returns the resulting size so the caller can
 // synthesize post-op attrs without reading the row back.
 //
-// Optional: transactions that do not implement it fall back to GetFile+PutFile.
+// Optional: transactions that do not implement it fall back to GetFile+UpdateAttrs.
 // Only regular files are affected: a missing target returns ErrNotFound, and a
 // target that exists but is not a regular file returns ErrIsDirectory and is
 // left untouched.

--- a/pkg/metadata/deferred_flush_applier_test.go
+++ b/pkg/metadata/deferred_flush_applier_test.go
@@ -13,7 +13,7 @@ import (
 
 // newApplierFixture builds a Service over a sqlite store. sqlite implements
 // DataWriteApplier, so the deferred pending-write flush takes the narrow
-// single-statement path rather than the GetFile+PutFile fallback. The memory
+// single-statement path rather than the GetFile+UpdateAttrs fallback. The memory
 // store used by the other service tests does not implement it, so this is the
 // only place the fast path is exercised end to end through the Service.
 func newApplierFixture(t *testing.T) (*metadata.Service, metadata.Store, metadata.FileHandle, string) {
@@ -47,7 +47,7 @@ func newApplierFixture(t *testing.T) (*metadata.Service, metadata.Store, metadat
 // TestDeferredFlushAppliesNarrowWrite covers the default write path: deferred
 // commits are on by default, so a WRITE buffers into the pending-write tracker
 // and only the flush touches the store. It asserts the flush persists what the
-// GetFile+PutFile fallback would have persisted — size grown, times stamped,
+// GetFile+UpdateAttrs fallback would have persisted — size grown, times stamped,
 // and no shrink when a later write lands at a lower offset.
 func TestDeferredFlushAppliesNarrowWrite(t *testing.T) {
 	svc, store, rootHandle, _ := newApplierFixture(t)

--- a/pkg/metadata/errors/errors.go
+++ b/pkg/metadata/errors/errors.go
@@ -278,8 +278,8 @@ func NewAlreadyExistsError(path string) *StoreError {
 }
 
 // NewConflictError creates a Conflict error.
-// op is the calling operation name (e.g., "memory PutFile",
-// "badger PutFile"); message is the specific reason (e.g.,
+// op is the calling operation name (e.g., "memory UpdateAttrs",
+// "badger UpdateAttrs"); message is the specific reason (e.g.,
 // "object_id already mapped to file <other-id>").
 func NewConflictError(op, message string) *StoreError {
 	return &StoreError{

--- a/pkg/metadata/errors/errors_test.go
+++ b/pkg/metadata/errors/errors_test.go
@@ -98,7 +98,7 @@ func TestFactoryFunctions(t *testing.T) {
 		{"StaleHandle", NewStaleHandleError("myshare"), ErrStaleHandle, "", `no store configured for share "myshare"`},
 		{"NotEmpty", NewNotEmptyError("/x"), ErrNotEmpty, "/x", "directory not empty"},
 		{"AlreadyExists", NewAlreadyExistsError("/x"), ErrAlreadyExists, "/x", "already exists"},
-		{"Conflict", NewConflictError("memory PutFile", "dup"), ErrConflict, "", "memory PutFile: dup"},
+		{"Conflict", NewConflictError("memory UpdateAttrs", "dup"), ErrConflict, "", "memory UpdateAttrs: dup"},
 		{"InvalidArgument", NewInvalidArgumentError("nope"), ErrInvalidArgument, "", "nope"},
 		{"AccessDenied", NewAccessDeniedError("no read bit"), ErrAccessDenied, "", "no read bit"},
 		{"QuotaExceeded", NewQuotaExceededError("/x"), ErrQuotaExceeded, "/x", "disk quota exceeded"},
@@ -199,7 +199,7 @@ func TestClassifiersNonStoreError(t *testing.T) {
 
 // errors.As must be able to extract a *StoreError from the concrete type.
 func TestErrorsAsExtraction(t *testing.T) {
-	orig := NewConflictError("badger PutFile", "object_id already mapped")
+	orig := NewConflictError("badger UpdateAttrs", "object_id already mapped")
 	var got *StoreError
 	if !goerrors.As(orig, &got) {
 		t.Fatal("errors.As failed to extract *StoreError")

--- a/pkg/metadata/file_create.go
+++ b/pkg/metadata/file_create.go
@@ -190,14 +190,14 @@ func (s *Service) CreateHardLink(ctx *AuthContext, dirHandle FileHandle, name st
 		// Update timestamps
 		now := time.Now()
 		target.Ctime = now
-		if err := tx.PutFile(ctx.Context, target); err != nil {
+		if err := tx.UpdateAttrs(ctx.Context, target); err != nil {
 			return err
 		}
 
 		dir.Mtime = now
 		dir.Ctime = now
 		wcc.After = CopyFileAttr(&dir.FileAttr)
-		return tx.PutFile(ctx.Context, dir)
+		return tx.UpdateAttrs(ctx.Context, dir)
 	})
 	unlockCreateName()
 	if err != nil {
@@ -453,7 +453,7 @@ func (s *Service) createEntry(
 		newFile.NewInode = true
 
 		// Store the entry
-		if err := tx.PutFile(ctx.Context, newFile); err != nil {
+		if err := tx.UpdateAttrs(ctx.Context, newFile); err != nil {
 			return err
 		}
 

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -320,6 +320,9 @@ func (s *Service) SetFileAttributes(ctx *AuthContext, handle FileHandle, attrs *
 
 	now := time.Now()
 	modified := false
+	// Set when a size-down truncate prunes the block list, so the commit
+	// below rewrites the stored manifest instead of only the attrs.
+	blocksPruned := false
 
 	// Apply requested changes
 	if attrs.Mode != nil {
@@ -442,9 +445,9 @@ func (s *Service) SetFileAttributes(ctx *AuthContext, handle FileHandle, attrs *
 		// without inline decrements.
 		if *attrs.Size < file.Size && len(file.Blocks) > 0 {
 			file.Blocks = block.PruneChunkRefsToSize(file.Blocks, *attrs.Size)
-			// The manifest actually changed (tail pruned) — the SQL backends
-			// must persist the shortened file_block_refs list.
-			file.BlocksDirty = true
+			// The manifest actually changed (tail pruned), so the write below
+			// must persist the shortened block list, not just the attrs.
+			blocksPruned = true
 			// Keep ObjectID (the Merkle root over Blocks) consistent with the
 			// trimmed list, or zero it when no blocks remain so the file reads
 			// as "never quiesced" instead of carrying a stale dedup pointer.
@@ -543,7 +546,7 @@ func (s *Service) SetFileAttributes(ctx *AuthContext, handle FileHandle, attrs *
 		// EOF returns stale-tail / silent-truncation bytes (#588). Persist it
 		// through a fully-durable transaction so relaxed-durability mode still
 		// fsyncs it. Pure-attribute changes (mode/owner/times/xattr/ACL) are not
-		// data-paired, so they take the relaxed path — note store.PutFile would
+		// data-paired, so they take the relaxed path — note store.UpdateAttrs would
 		// force an inline fsync (it wraps the durable WithTransaction), so it is
 		// deliberately bypassed here in favor of withRelaxedTransaction to
 		// actually defer the write (#1573 Wall 1).
@@ -556,7 +559,10 @@ func (s *Service) SetFileAttributes(ctx *AuthContext, handle FileHandle, attrs *
 			mu := s.pendingWrites.GetFlushLock(handle)
 			mu.Lock()
 			err := store.WithTransaction(ctx.Context, func(tx Transaction) error {
-				return tx.PutFile(ctx.Context, file)
+				if blocksPruned {
+					return tx.SetManifest(ctx.Context, file)
+				}
+				return tx.UpdateAttrs(ctx.Context, file)
 			})
 			if err == nil {
 				// Discard, don't flush: a buffered MaxSize would resurrect the
@@ -569,7 +575,7 @@ func (s *Service) SetFileAttributes(ctx *AuthContext, handle FileHandle, attrs *
 			}
 		} else {
 			if err := withRelaxedTransaction(store, ctx.Context, func(tx Transaction) error {
-				return tx.PutFile(ctx.Context, file)
+				return tx.UpdateAttrs(ctx.Context, file)
 			}); err != nil {
 				return nil, err
 			}
@@ -878,7 +884,7 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 				}
 				// Update ctime on the file being unlinked (affects remaining hard links)
 				dstFile.Ctime = now
-				if err := tx.PutFile(ctx.Context, dstFile); err != nil {
+				if err := tx.UpdateAttrs(ctx.Context, dstFile); err != nil {
 					return err
 				}
 			}
@@ -940,10 +946,10 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 		// parent_child_map / parent edges (#1166), so a rename just moves the
 		// edge and the new path is reconstructed fresh on the next GetFile.
 		// This is what makes hard links correct: renaming one name can never
-		// stale another name's path. PutFile is tx-critical: a failed ctime
+		// stale another name's path. UpdateAttrs is tx-critical: a failed ctime
 		// write must roll the whole rename back.
 		srcFile.Ctime = now
-		if err := tx.PutFile(ctx.Context, srcFile); err != nil {
+		if err := tx.UpdateAttrs(ctx.Context, srcFile); err != nil {
 			return err
 		}
 
@@ -1008,5 +1014,5 @@ func (s *Service) MarkFileAsOrphaned(ctx *AuthContext, handle FileHandle) error 
 	now := time.Now()
 	file.Nlink = 0
 	file.Ctime = now
-	return store.PutFile(ctx.Context, file)
+	return store.UpdateAttrs(ctx.Context, file)
 }

--- a/pkg/metadata/file_recycle.go
+++ b/pkg/metadata/file_recycle.go
@@ -175,7 +175,7 @@ func (s *Service) stampRecycled(ctx *AuthContext, handle FileHandle, deletedAt t
 	file.DeletedAt = &at
 	file.OriginalPath = origRel
 	file.DeletedBy = deletedBy
-	return store.PutFile(ctx.Context, file)
+	return store.UpdateAttrs(ctx.Context, file)
 }
 
 // clearRecycleStamp reverts the three trash fields on a node, used to roll back
@@ -192,7 +192,7 @@ func (s *Service) clearRecycleStamp(ctx *AuthContext, handle FileHandle) error {
 	file.DeletedAt = nil
 	file.OriginalPath = ""
 	file.DeletedBy = ""
-	return store.PutFile(ctx.Context, file)
+	return store.UpdateAttrs(ctx.Context, file)
 }
 
 // maxBinNameAttempts bounds the collision-resolution loop in freeBinName. A

--- a/pkg/metadata/file_remove.go
+++ b/pkg/metadata/file_remove.go
@@ -191,7 +191,7 @@ func (s *Service) RemoveFile(ctx *AuthContext, parentHandle FileHandle, name str
 
 			// Update file's ctime
 			file.Ctime = now
-			if err := tx.PutFile(ctx.Context, file); err != nil {
+			if err := tx.UpdateAttrs(ctx.Context, file); err != nil {
 				return err
 			}
 		} else {
@@ -208,7 +208,7 @@ func (s *Service) RemoveFile(ctx *AuthContext, parentHandle FileHandle, name str
 			// Update file's ctime and nlink
 			file.Ctime = now
 			file.Nlink = 0
-			if err := tx.PutFile(ctx.Context, file); err != nil {
+			if err := tx.UpdateAttrs(ctx.Context, file); err != nil {
 				return err
 			}
 		}

--- a/pkg/metadata/file_types.go
+++ b/pkg/metadata/file_types.go
@@ -103,22 +103,10 @@ type FileAttr struct {
 	// Memory: typed slice held directly.
 	Blocks []block.ChunkRef `json:"blocks,omitempty"`
 
-	// BlocksDirty is a transient, request-scoped signal that this PutFile
-	// legitimately mutated the block manifest (Blocks was assigned/pruned),
-	// so the SQL backends must persist file_block_refs. It is NOT persisted:
-	// json:"-" keeps it out of the Badger f: blob, and Postgres/SQLite write
-	// explicit column lists so a struct field never reaches a row. It
-	// defaults to false, so attr-only writes (chmod/utimes/close/rename/
-	// xattr/…) skip the DELETE+INSERT manifest rewrite entirely on the SQL
-	// backends — the write-amplification fix (#1715 #8). Only the sites that
-	// actually change Blocks set it true; Memory/Badger ignore it and always
-	// hold Blocks inline.
-	BlocksDirty bool `json:"-"`
-
-	// BlocksDirtyOffsets narrows BlocksDirty to the offsets that can possibly
-	// differ from what the SQL backends already store, so their manifest diff
-	// costs the changed range rather than the whole file. Transient and
-	// request-scoped like BlocksDirty, and never persisted.
+	// ManifestDirtyOffsets narrows a SetManifest write to the offsets that can
+	// possibly differ from what the SQL backends already store, so their
+	// manifest diff costs the changed range rather than the whole file.
+	// Transient, request-scoped and never persisted; UpdateAttrs ignores it.
 	//
 	// nil means "unknown": the backend must diff the entire stored manifest.
 	// Non-nil (empty included) is a promise that every offset outside the set
@@ -126,7 +114,7 @@ type FileAttr struct {
 	// upsert and delete only within the set. Only a caller that folded a known
 	// row set into an already-coherent Blocks projection can make that promise;
 	// a caller that re-derived Blocks from scratch must leave this nil.
-	BlocksDirtyOffsets []uint64 `json:"-"`
+	ManifestDirtyOffsets []uint64 `json:"-"`
 
 	// NewInode marks a File the caller has just constructed and knows has no
 	// row yet, so a store that would otherwise probe for one can insert
@@ -197,7 +185,7 @@ func CopyFileAttr(attr *FileAttr) *FileAttr {
 	}
 
 	c.Blocks = slices.Clone(attr.Blocks)
-	c.BlocksDirtyOffsets = slices.Clone(attr.BlocksDirtyOffsets)
+	c.ManifestDirtyOffsets = slices.Clone(attr.ManifestDirtyOffsets)
 
 	if attr.DeletedAt != nil {
 		deletedAt := *attr.DeletedAt

--- a/pkg/metadata/io.go
+++ b/pkg/metadata/io.go
@@ -250,7 +250,7 @@ func (s *Service) deferredCommitWrite(ctx *AuthContext, intent *WriteOperation) 
 				}
 				file.Mode &= ^uint32(0o6000)
 				file.Ctime = intent.NewMtime
-				return tx.PutFile(ctx.Context, file)
+				return tx.UpdateAttrs(ctx.Context, file)
 			})
 			if txErr != nil {
 				logger.Error("deferredCommitWrite: SUID clearing transaction failed",
@@ -315,7 +315,7 @@ func (s *Service) immediateCommitWrite(ctx *AuthContext, intent *WriteOperation)
 	var resultFile *File
 	err = store.WithTransaction(ctx.Context, func(tx Transaction) error {
 		// Fast path: a single narrow UPDATE (grow size, stamp times, clear suid)
-		// instead of GetFile (aggregate block-refs read) + PutFile (full-row
+		// instead of GetFile (aggregate block-refs read) + UpdateAttrs (full-row
 		// rewrite), for backends that implement it. Post-op attrs are synthesized
 		// from the pre-write attrs plus the authoritative final size — the same
 		// no-read-back trick the deferred-commit path uses.
@@ -359,7 +359,7 @@ func (s *Service) immediateCommitWrite(ctx *AuthContext, intent *WriteOperation)
 		if clearSUID {
 			file.Mode &= ^uint32(0o6000)
 		}
-		if err := tx.PutFile(ctx.Context, file); err != nil {
+		if err := tx.UpdateAttrs(ctx.Context, file); err != nil {
 			return err
 		}
 		resultFile = file
@@ -512,7 +512,7 @@ func (s *Service) flushPendingWrite(ctx *AuthContext, handle FileHandle, state *
 			file.Mode &= ^uint32(0o6000)
 		}
 
-		return tx.PutFile(ctx.Context, file)
+		return tx.UpdateAttrs(ctx.Context, file)
 	}
 
 	if durable {

--- a/pkg/metadata/manifest_projection_test.go
+++ b/pkg/metadata/manifest_projection_test.go
@@ -26,6 +26,9 @@ type manifestTx struct {
 	rows    map[string]*block.FileChunk
 	file    *File
 	records map[string]struct{}
+	// wroteManifest records whether the last file write went through
+	// SetManifest (manifest rewritten) or UpdateAttrs (attrs only).
+	wroteManifest bool
 }
 
 func newManifestTx(payloadID string) *manifestTx {
@@ -78,8 +81,15 @@ func (t *manifestTx) GetFileByPayloadID(_ context.Context, pid PayloadID) (*File
 	return copyFileRow(t.file), nil
 }
 
-func (t *manifestTx) PutFile(_ context.Context, f *File) error {
+func (t *manifestTx) UpdateAttrs(_ context.Context, f *File) error {
 	t.file = copyFileRow(f)
+	t.wroteManifest = false
+	return nil
+}
+
+func (t *manifestTx) SetManifest(_ context.Context, f *File) error {
+	t.file = copyFileRow(f)
+	t.wroteManifest = true
 	return nil
 }
 
@@ -180,7 +190,7 @@ func TestCommitBlockProjectionMatchesFullReprojection(t *testing.T) {
 
 		want := tx.fullProjection(t, payloadID)
 		require.Equal(t, want, tx.file.Blocks, "projection after batch %d", batchNo)
-		require.True(t, tx.file.BlocksDirty, "batch %d must mark the block list dirty", batchNo)
+		require.True(t, tx.wroteManifest, "batch %d must persist the block list via SetManifest", batchNo)
 
 		// Re-committing the same block object is a no-op, projection included.
 		require.NoError(t, DefaultCommitBlock(ctx, tx, rec, nil, rows))

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -1085,7 +1085,7 @@ func (s *Service) flushDirTimes(ctx context.Context, dirHandle FileHandle) {
 		if !applyDirTimes(&dir.FileAttr, mtime, ctime, atime) {
 			return nil
 		}
-		return tx.PutFile(ctx, dir)
+		return tx.UpdateAttrs(ctx, dir)
 	})
 	if err != nil {
 		return // leave pending in place; a later bump/flush will retry

--- a/pkg/metadata/service_quota_test.go
+++ b/pkg/metadata/service_quota_test.go
@@ -95,7 +95,7 @@ func (f *quotaFixture) createFileWithSize(name string, size uint64) metadata.Fil
 			storedFile.Size = size
 			storedFile.Mtime = time.Now()
 			storedFile.Ctime = time.Now()
-			return tx.PutFile(storeCtx, storedFile)
+			return tx.UpdateAttrs(storeCtx, storedFile)
 		})
 		require.NoError(f.t, err)
 	}

--- a/pkg/metadata/sparse.go
+++ b/pkg/metadata/sparse.go
@@ -53,7 +53,7 @@ func (s *Service) PunchHole(ctx *AuthContext, handle FileHandle, offset, length 
 
 	// Commit any pending write metadata first so file.Blocks/Size reflect the
 	// latest state before we mutate the block list. Durable: this flush precedes a
-	// strict manifest-mutating PutFile, and DEALLOCATE/ALLOCATE are rare (not the
+	// strict manifest-mutating UpdateAttrs, and DEALLOCATE/ALLOCATE are rare (not the
 	// hot WRITE path), so keep the metadata fsync inline.
 	if _, err := s.FlushPendingWriteForFile(ctx, handle, true); err != nil {
 		return nil, err
@@ -84,7 +84,6 @@ func (s *Service) PunchHole(ctx *AuthContext, handle FileHandle, offset, length 
 	newBlocks := block.PunchHole(file.Blocks, offset, length)
 	file.Blocks = newBlocks
 	// PunchHole rewrote the manifest — persist the new file_block_refs list.
-	file.BlocksDirty = true
 	if !file.ObjectID.IsZero() {
 		if len(newBlocks) == 0 {
 			file.ObjectID = block.ObjectID{}
@@ -97,7 +96,7 @@ func (s *Service) PunchHole(ctx *AuthContext, handle FileHandle, offset, length 
 	file.Mtime = now
 	file.Ctime = now
 
-	if err := store.PutFile(ctx.Context, file); err != nil {
+	if err := store.SetManifest(ctx.Context, file); err != nil {
 		return nil, err
 	}
 
@@ -127,7 +126,7 @@ func (s *Service) Allocate(ctx *AuthContext, handle FileHandle, offset, length u
 		return nil, err
 	}
 
-	// Durable flush (see PunchHole): precedes a strict PutFile, rare op.
+	// Durable flush (see PunchHole): precedes a strict UpdateAttrs, rare op.
 	if _, err := s.FlushPendingWriteForFile(ctx, handle, true); err != nil {
 		return nil, err
 	}
@@ -161,7 +160,7 @@ func (s *Service) Allocate(ctx *AuthContext, handle FileHandle, offset, length u
 	file.Mtime = now
 	file.Ctime = now
 
-	if err := store.PutFile(ctx.Context, file); err != nil {
+	if err := store.UpdateAttrs(ctx.Context, file); err != nil {
 		return nil, err
 	}
 

--- a/pkg/metadata/sparse_test.go
+++ b/pkg/metadata/sparse_test.go
@@ -24,7 +24,7 @@ func makeSparseFile(t *testing.T, fx *testFixture, name string, size uint64, blo
 	stored.Size = size
 	stored.Blocks = blocks
 	stored.PayloadID = metadata.PayloadID("payload-" + name)
-	require.NoError(t, fx.store.PutFile(fx.rootContext().Context, stored))
+	require.NoError(t, fx.store.UpdateAttrs(fx.rootContext().Context, stored))
 	return handle
 }
 

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -34,10 +34,26 @@ type Files interface {
 	// NO permission checking - caller is responsible.
 	GetFile(ctx context.Context, handle FileHandle) (*File, error)
 
-	// PutFile stores or updates file metadata.
+	// UpdateAttrs stores or updates file metadata, leaving whatever block
+	// manifest the store already holds for the file untouched.
 	// Creates the file if it doesn't exist, updates if it does.
 	// NO validation - caller is responsible for data integrity.
-	PutFile(ctx context.Context, file *File) error
+	//
+	// This is the attr-only write behind chmod/utimes/close/rename/xattr and
+	// every other mutation that does not change file.Blocks. Skipping the
+	// manifest rewrite is what keeps those writes cheap on the SQL backends,
+	// where the manifest lives in a separate file_block_refs table.
+	UpdateAttrs(ctx context.Context, file *File) error
+
+	// SetManifest stores or updates file metadata AND replaces the stored
+	// block manifest with file.Blocks. Only callers that actually mutated the
+	// block list may use it: carve/rollup commit, truncate, punch-hole,
+	// clone, copy-payload and manifest reprojection.
+	//
+	// Backends that keep the block list inline in the file record (badger,
+	// memory) treat it as UpdateAttrs; the SQL backends rewrite
+	// file_block_refs, scoped by File.ManifestDirtyOffsets when it is non-nil.
+	SetManifest(ctx context.Context, file *File) error
 
 	// DeleteFile removes file metadata by handle.
 	// Returns ErrNotFound if handle doesn't exist.
@@ -314,7 +330,7 @@ type Transaction interface {
 //
 //	    // Modify file...
 //
-//	    return tx.PutFile(ctx, file)  // Success = commit, error = rollback
+//	    return tx.UpdateAttrs(ctx, file)  // Success = commit, error = rollback
 //	})
 type Transactor interface {
 	// WithTransaction executes fn within a transaction.

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -50,9 +50,11 @@ type Files interface {
 	// block list may use it: carve/rollup commit, truncate, punch-hole,
 	// clone, copy-payload and manifest reprojection.
 	//
-	// Backends that keep the block list inline in the file record (badger,
-	// memory) treat it as UpdateAttrs; the SQL backends rewrite
-	// file_block_refs, scoped by File.ManifestDirtyOffsets when it is non-nil.
+	// Where the manifest is stored separately from the attrs — the SQL
+	// backends' file_block_refs table, badger's fm:<uuid> key — this is the
+	// only method that rewrites it, scoped by File.ManifestDirtyOffsets when
+	// that is non-nil. The memory backend keeps the block list inline on the
+	// stored FileAttr and so treats it exactly as UpdateAttrs.
 	SetManifest(ctx context.Context, file *File) error
 
 	// DeleteFile removes file metadata by handle.

--- a/pkg/metadata/store/badger/badger_conformance_test.go
+++ b/pkg/metadata/store/badger/badger_conformance_test.go
@@ -152,7 +152,7 @@ func TestBadgerStore_DerivePathReverseIndex(t *testing.T) {
 		if dir {
 			typ = metadata.FileTypeDirectory
 		}
-		require.NoError(t, store.PutFile(ctx, &metadata.File{
+		require.NoError(t, store.UpdateAttrs(ctx, &metadata.File{
 			ID: id, ShareName: shareName,
 			FileAttr: metadata.FileAttr{
 				Type: typ, Mode: 0o644,
@@ -262,7 +262,7 @@ func TestBadgerStore_PutGetFile_BlocksRoundTrip(t *testing.T) {
 			Blocks:       want,
 		},
 	}
-	require.NoError(t, store.PutFile(ctx, file))
+	require.NoError(t, store.UpdateAttrs(ctx, file))
 	require.NoError(t, store.SetParent(ctx, handle, rootHandle))
 	require.NoError(t, store.SetChild(ctx, rootHandle, "blocks.bin", handle))
 
@@ -292,7 +292,7 @@ func TestBadgerStore_PutGetFile_BlocksRoundTrip(t *testing.T) {
 			// Blocks left nil.
 		},
 	}
-	require.NoError(t, store.PutFile(ctx, nilFile))
+	require.NoError(t, store.UpdateAttrs(ctx, nilFile))
 	gotNil, err := store.GetFile(ctx, nilHandle)
 	require.NoError(t, err)
 	assert.Nil(t, gotNil.Blocks)

--- a/pkg/metadata/store/badger/badger_integration_test.go
+++ b/pkg/metadata/store/badger/badger_integration_test.go
@@ -176,7 +176,7 @@ func TestBadgerMetadataStore_CRUD(t *testing.T) {
 		t.Fatalf("Failed to encode root file handle: %v", err)
 	}
 
-	t.Run("PutFile", func(t *testing.T) {
+	t.Run("UpdateAttrs", func(t *testing.T) {
 		handle, err := store.GenerateHandle(ctx, shareName, "/testfile.txt")
 		if err != nil {
 			t.Fatalf("Failed to generate handle: %v", err)
@@ -199,7 +199,7 @@ func TestBadgerMetadataStore_CRUD(t *testing.T) {
 			},
 		}
 
-		err = store.PutFile(ctx, file)
+		err = store.UpdateAttrs(ctx, file)
 		if err != nil {
 			t.Fatalf("Failed to put file: %v", err)
 		}
@@ -239,7 +239,7 @@ func TestBadgerMetadataStore_CRUD(t *testing.T) {
 			},
 		}
 
-		err = store.PutFile(ctx, childFile)
+		err = store.UpdateAttrs(ctx, childFile)
 		if err != nil {
 			t.Fatalf("Failed to put child file: %v", err)
 		}

--- a/pkg/metadata/store/badger/create_cache_test.go
+++ b/pkg/metadata/store/badger/create_cache_test.go
@@ -50,7 +50,7 @@ func putDir(t *testing.T, s *BadgerMetadataStore, share string, parent metadata.
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.PutFile(ctx, &metadata.File{
+	if err := s.UpdateAttrs(ctx, &metadata.File{
 		ID: id, ShareName: share,
 		FileAttr: metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o755},
 	}); err != nil {
@@ -77,7 +77,7 @@ func TestWarmFileReadCache_HitAndPathless(t *testing.T) {
 	f.ShareName = "/s"
 	f.Path = "/dir/created.txt"
 	f.Mode = 0o644
-	if err := s.PutFile(ctx, f); err != nil { // persist so a real read would succeed
+	if err := s.UpdateAttrs(ctx, f); err != nil { // persist so a real read would succeed
 		t.Fatal(err)
 	}
 	handle, err := metadata.EncodeShareHandle("/s", f.ID)
@@ -189,7 +189,7 @@ func TestGetFileForCreate_PathFreshAfterRename(t *testing.T) {
 		t.Fatalf("initial parent read: path=%q err=%v", got.Path, err)
 	}
 
-	// Rename /dirA -> /dirB exactly as Move does: repoint the edges AND PutFile
+	// Rename /dirA -> /dirB exactly as Move does: repoint the edges AND UpdateAttrs
 	// the moved directory (its ctime changes), which drives the cache invalidation.
 	if err := s.DeleteChild(ctx, root, "dirA"); err != nil {
 		t.Fatal(err)
@@ -201,7 +201,7 @@ func TestGetFileForCreate_PathFreshAfterRename(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.PutFile(ctx, moved); err != nil { // ctime bump -> dirtyFiles -> invalidate
+	if err := s.UpdateAttrs(ctx, moved); err != nil { // ctime bump -> dirtyFiles -> invalidate
 		t.Fatal(err)
 	}
 

--- a/pkg/metadata/store/badger/encoding.go
+++ b/pkg/metadata/store/badger/encoding.go
@@ -239,7 +239,7 @@ const (
 	fOrigPath   = 23 // string
 	fDeletedBy  = 24 // string
 	// Path (File.Path) is intentionally NOT encoded: it is derived from parent
-	// edges on read (#1166). BlocksDirty is transient (json:"-"), also not stored.
+	// edges on read (#1166). ManifestDirtyOffsets is transient, also not stored.
 )
 
 func putField(dst []byte, id uint64, val []byte) []byte {

--- a/pkg/metadata/store/badger/encoding_test.go
+++ b/pkg/metadata/store/badger/encoding_test.go
@@ -154,8 +154,8 @@ func TestBadgerEncodeFile_NilBlocksOmitted(t *testing.T) {
 
 // TestEncodeDecodeFile_AllFields exercises every persisted FileAttr field
 // (including ACL, EAs, ObjectID, DeletedAt, unicode names, empty/nil maps and a
-// zero-length EA value) through encode -> binary decode. Path and BlocksDirty
-// are intentionally not persisted.
+// zero-length EA value) through encode -> binary decode. Path and the transient
+// request-scoped fields are intentionally not persisted.
 func TestEncodeDecodeFile_AllFields(t *testing.T) {
 	var oid block.ContentHash
 	for i := range oid {

--- a/pkg/metadata/store/badger/files.go
+++ b/pkg/metadata/store/badger/files.go
@@ -135,10 +135,18 @@ func (tx *badgerTransaction) putManifest(id uuid.UUID, blocks []block.ChunkRef) 
 	return tx.txn.Set(keyFileManifest(id), data)
 }
 
-// PutFile stores or updates file metadata.
-func (s *BadgerMetadataStore) PutFile(ctx context.Context, file *metadata.File) error {
+// UpdateAttrs stores or updates file metadata.
+func (s *BadgerMetadataStore) UpdateAttrs(ctx context.Context, file *metadata.File) error {
 	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
-		return tx.PutFile(ctx, file)
+		return tx.UpdateAttrs(ctx, file)
+	})
+}
+
+// SetManifest stores or updates file metadata and rewrites the stored block
+// manifest from file.Blocks.
+func (s *BadgerMetadataStore) SetManifest(ctx context.Context, file *metadata.File) error {
+	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return tx.SetManifest(ctx, file)
 	})
 }
 

--- a/pkg/metadata/store/badger/manifest_split_test.go
+++ b/pkg/metadata/store/badger/manifest_split_test.go
@@ -37,7 +37,7 @@ func readManifest(t *testing.T, s *BadgerMetadataStore, id uuid.UUID) (version u
 }
 
 // mkChunkedFile creates a regular file carrying nChunks 1 MiB blocks and returns
-// its handle. The manifest is marked dirty so PutFile persists it to fm:.
+// its handle. The manifest is marked dirty so UpdateAttrs persists it to fm:.
 func mkChunkedFile(t *testing.T, store *BadgerMetadataStore, share string, dir metadata.FileHandle, name, path string, nChunks int) metadata.FileHandle {
 	t.Helper()
 	ctx := context.Background()
@@ -58,14 +58,13 @@ func mkChunkedFile(t *testing.T, store *BadgerMetadataStore, share string, dir m
 		Path:      path,
 		FileAttr: metadata.FileAttr{
 			Type: metadata.FileTypeRegular, Mode: 0o600, UID: 1000, GID: 1000,
-			Size:        uint64(nChunks) << 20,
-			PayloadID:   metadata.PayloadID(path),
-			Blocks:      blocks,
-			BlocksDirty: true,
+			Size:      uint64(nChunks) << 20,
+			PayloadID: metadata.PayloadID(path),
+			Blocks:    blocks,
 		},
 	}
 	file.ID = id
-	require.NoError(t, store.PutFile(ctx, file))
+	require.NoError(t, store.SetManifest(ctx, file))
 	require.NoError(t, store.SetParent(ctx, handle, dir))
 	require.NoError(t, store.SetChild(ctx, dir, name, handle))
 	return handle
@@ -95,9 +94,9 @@ func TestManifestSplit_AttrOnlyWriteLeavesManifestUntouched(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, blocks0, got.Blocks, "manifest must round-trip through the split")
 
-	// chmod: attr-only mutation, BlocksDirty stays false.
+	// chmod: attr-only mutation, so it goes through UpdateAttrs.
 	got.Mode = 0o644
-	require.NoError(t, store.PutFile(ctx, got))
+	require.NoError(t, store.UpdateAttrs(ctx, got))
 
 	v1, blocks1, ok := readManifest(t, store, id)
 	require.True(t, ok)
@@ -108,7 +107,7 @@ func TestManifestSplit_AttrOnlyWriteLeavesManifestUntouched(t *testing.T) {
 	got2, err := store.GetFile(ctx, handle)
 	require.NoError(t, err)
 	got2.Mtime = got2.Mtime.Add(1)
-	require.NoError(t, store.PutFile(ctx, got2))
+	require.NoError(t, store.UpdateAttrs(ctx, got2))
 
 	v2, _, ok := readManifest(t, store, id)
 	require.True(t, ok)
@@ -134,7 +133,7 @@ func TestManifestSplit_GetByPayloadIDReturnsManifest(t *testing.T) {
 }
 
 // TestManifestSplit_CarveWritesManifest confirms the gate still persists a
-// genuinely changed manifest (a re-carve marks BlocksDirty).
+// genuinely changed manifest (a re-carve calls SetManifest).
 func TestManifestSplit_CarveWritesManifest(t *testing.T) {
 	ctx := context.Background()
 	store, err := NewBadgerMetadataStoreWithDefaults(ctx, t.TempDir())
@@ -155,8 +154,7 @@ func TestManifestSplit_CarveWritesManifest(t *testing.T) {
 	h[0] = 0xEE
 	got.Blocks = append(got.Blocks, block.ChunkRef{Hash: h, Offset: 8 << 20, Size: 1 << 20})
 	got.Size = 9 << 20
-	got.BlocksDirty = true
-	require.NoError(t, store.PutFile(ctx, got))
+	require.NoError(t, store.SetManifest(ctx, got))
 
 	v1, blocks1, ok := readManifest(t, store, id)
 	require.True(t, ok)
@@ -186,8 +184,7 @@ func TestManifestSplit_TruncatePrunes(t *testing.T) {
 	require.NoError(t, err)
 	got.Blocks = block.PruneChunkRefsToSize(got.Blocks, 4<<20)
 	got.Size = 4 << 20
-	got.BlocksDirty = true
-	require.NoError(t, store.PutFile(ctx, got))
+	require.NoError(t, store.SetManifest(ctx, got))
 
 	_, blocks, ok := readManifest(t, store, id)
 	require.True(t, ok)
@@ -198,8 +195,7 @@ func TestManifestSplit_TruncatePrunes(t *testing.T) {
 	require.NoError(t, err)
 	got.Blocks = block.PruneChunkRefsToSize(got.Blocks, 0)
 	got.Size = 0
-	got.BlocksDirty = true
-	require.NoError(t, store.PutFile(ctx, got))
+	require.NoError(t, store.SetManifest(ctx, got))
 
 	_, _, ok = readManifest(t, store, id)
 	require.False(t, ok, "truncate-to-zero must delete the fm: key")

--- a/pkg/metadata/store/badger/objects.go
+++ b/pkg/metadata/store/badger/objects.go
@@ -935,7 +935,7 @@ var _ blockpkg.FileChunkStore = (*badgerTransaction)(nil)
 // *badger.Txn so a rollback (returning an error from WithTransaction's fn)
 // discards the RefCount mutation. Calling tx.store.X(...) instead would open
 // its own db.Update and defeat rollback for any caller that bumps RefCount
-// inside WithTransaction and then hits a downstream PutFile failure.
+// inside WithTransaction and then hits a downstream UpdateAttrs failure.
 
 func (tx *badgerTransaction) GetFileChunk(ctx context.Context, id string) (*metadata.FileChunk, error) {
 	if err := ctx.Err(); err != nil {

--- a/pkg/metadata/store/badger/payload_index_test.go
+++ b/pkg/metadata/store/badger/payload_index_test.go
@@ -43,7 +43,7 @@ func mkPayloadFile(t *testing.T, store *BadgerMetadataStore, shareName string, d
 		},
 	}
 	file.ID = id
-	require.NoError(t, store.PutFile(ctx, file))
+	require.NoError(t, store.UpdateAttrs(ctx, file))
 	require.NoError(t, store.SetParent(ctx, handle, dir))
 	require.NoError(t, store.SetChild(ctx, dir, name, handle))
 	return handle
@@ -78,7 +78,7 @@ func payloadIndexValue(t *testing.T, s *BadgerMetadataStore, pid metadata.Payloa
 }
 
 // TestPayloadIndex_PointLookupAndTeardown covers the #1435 secondary index: it
-// is written on PutFile, resolves GetFileByPayloadID, still works via the legacy
+// is written on UpdateAttrs, resolves GetFileByPayloadID, still works via the legacy
 // scan fallback when the entry is absent, and is torn down on DeleteFile.
 func TestPayloadIndex_PointLookupAndTeardown(t *testing.T) {
 	ctx := context.Background()
@@ -96,7 +96,7 @@ func TestPayloadIndex_PointLookupAndTeardown(t *testing.T) {
 
 	// Index written and points at the file.
 	idxID, ok := payloadIndexValue(t, store, pid)
-	require.True(t, ok, "pl: index entry must exist after PutFile")
+	require.True(t, ok, "pl: index entry must exist after UpdateAttrs")
 	require.Equal(t, fileID, idxID)
 
 	// Lookup resolves (via the index fast path).
@@ -145,7 +145,7 @@ func TestPayloadIndex_MovesOnPayloadIDChange(t *testing.T) {
 	require.NoError(t, err)
 	newPID := metadata.PayloadID(shareName + "/" + uuid.NewString())
 	file.PayloadID = newPID
-	require.NoError(t, store.PutFile(ctx, file))
+	require.NoError(t, store.UpdateAttrs(ctx, file))
 
 	// Old entry gone, new entry points at the same file.
 	if _, ok := payloadIndexValue(t, store, oldPID); ok {

--- a/pkg/metadata/store/badger/permission_integration_test.go
+++ b/pkg/metadata/store/badger/permission_integration_test.go
@@ -207,7 +207,7 @@ func TestBadgerStore_FileWithDifferentOwners(t *testing.T) {
 				},
 			}
 
-			err = store.PutFile(ctx, file)
+			err = store.UpdateAttrs(ctx, file)
 			if err != nil {
 				t.Fatalf("Failed to put file: %v", err)
 			}

--- a/pkg/metadata/store/badger/read_cache.go
+++ b/pkg/metadata/store/badger/read_cache.go
@@ -78,7 +78,7 @@ func (c *fileReadCache) store(key string, file *metadata.File, genAtRead uint64)
 // rejected the instant gen moves; deleting first would leave a window in which
 // that reader's store() (still seeing the old gen) re-inserts the stale entry
 // after the delete. The get() path is intentionally ungated by gen: a read that
-// is ordered-after this write (the writer's PutFile returns only once invalidate
+// is ordered-after this write (the writer's UpdateAttrs returns only once invalidate
 // finishes, within withTransaction) always sees the delete and misses; a read
 // merely concurrent with the still-uncommitted write has no ordering guarantee,
 // so serving either value is correct.

--- a/pkg/metadata/store/badger/read_cache_test.go
+++ b/pkg/metadata/store/badger/read_cache_test.go
@@ -23,7 +23,7 @@ func putFileForTest(t testing.TB, s *BadgerMetadataStore, share, path string, mo
 	f.ShareName = share
 	f.Path = path
 	f.Mode = mode
-	if err := s.PutFile(ctx, f); err != nil {
+	if err := s.UpdateAttrs(ctx, f); err != nil {
 		t.Fatal(err)
 	}
 	return handle
@@ -49,11 +49,11 @@ func TestReadCache_NoStaleReadAfterMutation(t *testing.T) {
 		t.Fatalf("first read: mode=%o, want 644", got.Mode)
 	}
 
-	// Mutate via PutFile — must invalidate the cache.
+	// Mutate via UpdateAttrs — must invalidate the cache.
 	_, id, _ := metadata.DecodeFileHandle(handle)
 	f := bigFile(4)
 	f.ID, f.ShareName, f.Path, f.Mode = id, "/s", "/f", 0o600
-	if err := s.PutFile(ctx, f); err != nil {
+	if err := s.UpdateAttrs(ctx, f); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/metadata/store/badger/relaxed_durability_bench_test.go
+++ b/pkg/metadata/store/badger/relaxed_durability_bench_test.go
@@ -14,7 +14,7 @@ import (
 
 // BenchmarkNamespaceCommit measures serial single-thread namespace-commit
 // throughput — the create/remove/rename hot path (#1573 Wall 1). Both sub-benchmarks
-// run the SAME code a create runs (WithTransactionRelaxed committing a PutFile);
+// run the SAME code a create runs (WithTransactionRelaxed committing a UpdateAttrs);
 // only the store's durability config differs, so the delta is purely the
 // per-commit fsync the strict store still pays and the relaxed store defers.
 //
@@ -52,7 +52,7 @@ func BenchmarkNamespaceCommit(b *testing.B) {
 				// Same call the create path uses: relaxed in relaxed mode,
 				// fsync-per-commit in strict mode (SyncWrites=true).
 				if err := store.WithTransactionRelaxed(ctx, func(tx metadata.Transaction) error {
-					return tx.PutFile(ctx, f)
+					return tx.UpdateAttrs(ctx, f)
 				}); err != nil {
 					b.Fatal(err)
 				}

--- a/pkg/metadata/store/badger/restart_persistence_test.go
+++ b/pkg/metadata/store/badger/restart_persistence_test.go
@@ -127,7 +127,7 @@ func mkFile(t *testing.T, store metadata.Store, shareName string, dirHandle meta
 	file.ID = id
 	mutate(&file.FileAttr)
 
-	require.NoError(t, store.PutFile(ctx, file))
+	require.NoError(t, store.UpdateAttrs(ctx, file))
 	require.NoError(t, store.SetParent(ctx, handle, dirHandle))
 	require.NoError(t, store.SetChild(ctx, dirHandle, name, handle))
 	return handle

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -361,7 +361,19 @@ func (tx *badgerTransaction) childNameByScan(parentID, child uuid.UUID) string {
 	return tx.anyOtherChildName(parentID, child, "")
 }
 
-func (tx *badgerTransaction) PutFile(ctx context.Context, file *metadata.File) error {
+// UpdateAttrs persists the file's attributes and leaves the stored fm:<uuid>
+// manifest untouched.
+func (tx *badgerTransaction) UpdateAttrs(ctx context.Context, file *metadata.File) error {
+	return tx.putFile(ctx, file, false)
+}
+
+// SetManifest persists the file's attributes and rewrites the stored
+// fm:<uuid> manifest from file.Blocks.
+func (tx *badgerTransaction) SetManifest(ctx context.Context, file *metadata.File) error {
+	return tx.putFile(ctx, file, true)
+}
+
+func (tx *badgerTransaction) putFile(ctx context.Context, file *metadata.File, writeManifest bool) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -418,14 +430,13 @@ func (tx *badgerTransaction) PutFile(ctx context.Context, file *metadata.File) e
 	}
 	tx.dirtyFiles = append(tx.dirtyFiles, file.ID.String())
 
-	// Persist the chunk manifest to fm:<uuid> only when it changed. BlocksDirty
-	// is set by the sites that mutate the manifest (carve/truncate/punch); an
-	// attr-only write leaves it false and skips the rewrite — the write-
-	// amplification fix. When the flag is unset but the file carries blocks with
-	// no manifest key yet, the manifest is still written: this covers a fresh
-	// create and migrates a legacy f: blob off its embedded manifest (the new f:
-	// encoding no longer carries it) without rewriting an already-materialized one.
-	writeManifest := file.BlocksDirty
+	// Persist the chunk manifest to fm:<uuid> only when it changed: the sites
+	// that mutate it (carve/truncate/punch) come through SetManifest, while an
+	// attr-only UpdateAttrs skips the rewrite. When the caller asked for an
+	// attr-only write but the file carries blocks with no manifest key yet, the
+	// manifest is still written: this covers a fresh create and migrates a
+	// legacy f: blob off its embedded manifest (the new f: encoding no longer
+	// carries it) without rewriting an already-materialized one.
 	if !writeManifest && len(file.Blocks) > 0 {
 		if _, err := tx.txn.Get(keyFileManifest(file.ID)); goerrors.Is(err, badgerdb.ErrKeyNotFound) {
 			writeManifest = true
@@ -445,7 +456,7 @@ func (tx *badgerTransaction) PutFile(ctx context.Context, file *metadata.File) e
 	// Step 1: drop stale secondary entry if the ObjectID changed.
 	if !oldObjectID.IsZero() && oldObjectID != file.ObjectID {
 		if err := tx.txn.Delete(keyObjectID(oldObjectID)); err != nil && !goerrors.Is(err, badgerdb.ErrKeyNotFound) {
-			return fmt.Errorf("badger PutFile: delete stale obj index: %w", err)
+			return fmt.Errorf("badger UpdateAttrs: delete stale obj index: %w", err)
 		}
 	}
 
@@ -458,20 +469,20 @@ func (tx *badgerTransaction) PutFile(ctx context.Context, file *metadata.File) e
 				var existingID uuid.UUID
 				if uerr := existingID.UnmarshalBinary(raw); uerr == nil && existingID != file.ID {
 					return mderrors.NewConflictError(
-						"badger PutFile",
+						"badger UpdateAttrs",
 						fmt.Sprintf("object_id already mapped to file %s", existingID),
 					)
 				}
 			}
 		} else if !goerrors.Is(gerr, badgerdb.ErrKeyNotFound) {
-			return fmt.Errorf("badger PutFile: probe obj index: %w", gerr)
+			return fmt.Errorf("badger UpdateAttrs: probe obj index: %w", gerr)
 		}
 		idBin, merr := file.ID.MarshalBinary()
 		if merr != nil {
-			return fmt.Errorf("badger PutFile: marshal file ID: %w", merr)
+			return fmt.Errorf("badger UpdateAttrs: marshal file ID: %w", merr)
 		}
 		if err := tx.txn.Set(keyObjectID(file.ObjectID), idBin); err != nil {
-			return fmt.Errorf("badger PutFile: set obj index: %w", err)
+			return fmt.Errorf("badger UpdateAttrs: set obj index: %w", err)
 		}
 	}
 
@@ -481,16 +492,16 @@ func (tx *badgerTransaction) PutFile(ctx context.Context, file *metadata.File) e
 	// changed, then point the (possibly new) PayloadID at this file.
 	if oldPayloadID != "" && oldPayloadID != file.PayloadID {
 		if err := tx.txn.Delete(keyPayloadID(oldPayloadID)); err != nil && !goerrors.Is(err, badgerdb.ErrKeyNotFound) {
-			return fmt.Errorf("badger PutFile: delete stale payload index: %w", err)
+			return fmt.Errorf("badger UpdateAttrs: delete stale payload index: %w", err)
 		}
 	}
 	if file.PayloadID != "" {
 		idBin, merr := file.ID.MarshalBinary()
 		if merr != nil {
-			return fmt.Errorf("badger PutFile: marshal file ID: %w", merr)
+			return fmt.Errorf("badger UpdateAttrs: marshal file ID: %w", merr)
 		}
 		if err := tx.txn.Set(keyPayloadID(file.PayloadID), idBin); err != nil {
-			return fmt.Errorf("badger PutFile: set payload index: %w", err)
+			return fmt.Errorf("badger UpdateAttrs: set payload index: %w", err)
 		}
 	}
 

--- a/pkg/metadata/store/badger/tx_usedbytes_integration_test.go
+++ b/pkg/metadata/store/badger/tx_usedbytes_integration_test.go
@@ -56,8 +56,8 @@ func TestBadger_UsedBytes_RetryNoDoubleCount(t *testing.T) {
 			},
 		}
 	}
-	if err := store.PutFile(ctx, mkFile(0)); err != nil {
-		t.Fatalf("initial PutFile: %v", err)
+	if err := store.UpdateAttrs(ctx, mkFile(0)); err != nil {
+		t.Fatalf("initial UpdateAttrs: %v", err)
 	}
 	rootHandle, err := metadata.EncodeShareHandle(shareName, rootFile.ID)
 	if err != nil {
@@ -79,7 +79,7 @@ func TestBadger_UsedBytes_RetryNoDoubleCount(t *testing.T) {
 			defer wg.Done()
 			for i := 0; i < itersPerWorker; i++ {
 				size := base*1000 + uint64(i)*7
-				_ = store.PutFile(ctx, mkFile(size))
+				_ = store.UpdateAttrs(ctx, mkFile(size))
 			}
 		}(uint64(w + 1))
 	}
@@ -134,14 +134,14 @@ func TestBadger_Restore_ReinitsUsedBytes(t *testing.T) {
 		t.Fatalf("DecodeFileHandle: %v", err)
 	}
 	now := time.Now()
-	if err := src.PutFile(ctx, &metadata.File{
+	if err := src.UpdateAttrs(ctx, &metadata.File{
 		ID: fileID, ShareName: shareName, Path: "/data.bin",
 		FileAttr: metadata.FileAttr{
 			Type: metadata.FileTypeRegular, Mode: 0o644, Size: wantSize,
 			Atime: now, Mtime: now, Ctime: now,
 		},
 	}); err != nil {
-		t.Fatalf("PutFile: %v", err)
+		t.Fatalf("UpdateAttrs: %v", err)
 	}
 	if err := src.SetChild(ctx, rootHandle, "data.bin", fileHandle); err != nil {
 		t.Fatalf("SetChild: %v", err)
@@ -217,14 +217,14 @@ func TestBadger_GetFilesystemStatistics_IgnoresNonRegular(t *testing.T) {
 		t.Fatalf("DecodeFileHandle: %v", err)
 	}
 	now := time.Now()
-	if err := store.PutFile(ctx, &metadata.File{
+	if err := store.UpdateAttrs(ctx, &metadata.File{
 		ID: fileID, ShareName: shareName, Path: "/f.bin",
 		FileAttr: metadata.FileAttr{
 			Type: metadata.FileTypeRegular, Mode: 0o644, Size: regularSize,
 			Atime: now, Mtime: now, Ctime: now,
 		},
 	}); err != nil {
-		t.Fatalf("PutFile: %v", err)
+		t.Fatalf("UpdateAttrs: %v", err)
 	}
 	if err := store.SetChild(ctx, rootHandle, "f.bin", fileHandle); err != nil {
 		t.Fatalf("SetChild: %v", err)

--- a/pkg/metadata/store/memory/counter_test.go
+++ b/pkg/metadata/store/memory/counter_test.go
@@ -67,7 +67,7 @@ func createFile(t *testing.T, store *memory.MemoryMetadataStore, name string, si
 				Ctime: now,
 			},
 		}
-		if err := tx.PutFile(ctx, file); err != nil {
+		if err := tx.UpdateAttrs(ctx, file); err != nil {
 			return err
 		}
 		return tx.SetChild(ctx, rootHandle, name, h)
@@ -120,7 +120,7 @@ func TestCounter_RolledBackTxDoesNotDrift(t *testing.T) {
 			return err
 		}
 		now := time.Now()
-		if err := tx.PutFile(ctx, &metadata.File{
+		if err := tx.UpdateAttrs(ctx, &metadata.File{
 			ID:        id,
 			ShareName: "/test",
 			Path:      "/ghost.txt",
@@ -152,7 +152,7 @@ func TestCounter_RolledBackTxDoesNotDrift(t *testing.T) {
 	}
 }
 
-// TestCounter_UpdateFileSize verifies usedBytes adjusts on size change (PutFile update).
+// TestCounter_UpdateFileSize verifies usedBytes adjusts on size change (UpdateAttrs update).
 func TestCounter_UpdateFileSize(t *testing.T) {
 	t.Parallel()
 	store := newTestStore(t)
@@ -170,7 +170,7 @@ func TestCounter_UpdateFileSize(t *testing.T) {
 			return err
 		}
 		now := time.Now()
-		return tx.PutFile(ctx, &metadata.File{
+		return tx.UpdateAttrs(ctx, &metadata.File{
 			ID:        id,
 			ShareName: "/test",
 			Path:      "/file1.txt",
@@ -193,7 +193,7 @@ func TestCounter_UpdateFileSize(t *testing.T) {
 	}
 }
 
-// TestCounter_Truncate verifies usedBytes decreases when file is truncated (PutFile with smaller size).
+// TestCounter_Truncate verifies usedBytes decreases when file is truncated (UpdateAttrs with smaller size).
 func TestCounter_Truncate(t *testing.T) {
 	t.Parallel()
 	store := newTestStore(t)
@@ -207,7 +207,7 @@ func TestCounter_Truncate(t *testing.T) {
 			return err
 		}
 		now := time.Now()
-		return tx.PutFile(ctx, &metadata.File{
+		return tx.UpdateAttrs(ctx, &metadata.File{
 			ID:        id,
 			ShareName: "/test",
 			Path:      "/file1.txt",
@@ -289,7 +289,7 @@ func TestCounter_DirectoryIgnored(t *testing.T) {
 				Ctime: now,
 			},
 		}
-		if err := tx.PutFile(ctx, dir); err != nil {
+		if err := tx.UpdateAttrs(ctx, dir); err != nil {
 			return err
 		}
 		return tx.SetChild(ctx, rootHandle, "subdir", h)

--- a/pkg/metadata/store/memory/files.go
+++ b/pkg/metadata/store/memory/files.go
@@ -13,7 +13,7 @@ import (
 // value type (Hash is a [32]byte array, Offset and Size are scalars), so a
 // flat element-wise copy is sufficient — there are no shared pointer fields.
 //
-// Used by PutFile/GetFile in the Memory backend to prevent slice aliasing
+// Used by UpdateAttrs/GetFile in the Memory backend to prevent slice aliasing
 // between the caller's view and the stored view (T-12-09).
 //
 // Returns nil if the input is nil or empty so the round-trip preserves
@@ -28,7 +28,7 @@ func cloneBlocks(in []block.ChunkRef) []block.ChunkRef {
 // Who), so an element-wise slice copy fully detaches the clone — no nested
 // pointers remain.
 //
-// Used by PutFile/GetFile/ListChildren in the Memory backend to prevent ACL
+// Used by UpdateAttrs/GetFile/ListChildren in the Memory backend to prevent ACL
 // aliasing between the caller's view and the stored view. Without this, an
 // in-place edit of an ACE by either side silently corrupts the other (the
 // Badger backend round-trips through JSON and never aliases, so this restores
@@ -147,11 +147,19 @@ func (store *MemoryMetadataStore) getFileLocked(handle metadata.FileHandle) (*me
 	return store.buildFileWithNlink(handle, fileData)
 }
 
-// PutFile stores or updates file metadata.
+// UpdateAttrs stores or updates file metadata.
 // Creates the entry if it doesn't exist.
-func (store *MemoryMetadataStore) PutFile(ctx context.Context, file *metadata.File) error {
+func (store *MemoryMetadataStore) UpdateAttrs(ctx context.Context, file *metadata.File) error {
 	return store.WithTransaction(ctx, func(tx metadata.Transaction) error {
-		return tx.PutFile(ctx, file)
+		return tx.UpdateAttrs(ctx, file)
+	})
+}
+
+// SetManifest stores or updates file metadata and rewrites the stored block
+// manifest from file.Blocks.
+func (store *MemoryMetadataStore) SetManifest(ctx context.Context, file *metadata.File) error {
+	return store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return tx.SetManifest(ctx, file)
 	})
 }
 

--- a/pkg/metadata/store/memory/files_blocks_test.go
+++ b/pkg/metadata/store/memory/files_blocks_test.go
@@ -59,7 +59,7 @@ func putFileForBlocksTest(
 			Blocks:       blocks,
 		},
 	}
-	require.NoError(t, store.PutFile(ctx, file))
+	require.NoError(t, store.UpdateAttrs(ctx, file))
 	require.NoError(t, store.SetParent(ctx, handle, rootHandle))
 	require.NoError(t, store.SetChild(ctx, rootHandle, name, handle))
 	return handle, file
@@ -77,7 +77,7 @@ func makeBlock(seed byte, idx int) block.ChunkRef {
 	}
 }
 
-// TestMemoryStore_PutFile_BlocksDeepCopy verifies that PutFile deep-copies
+// TestMemoryStore_PutFile_BlocksDeepCopy verifies that UpdateAttrs deep-copies
 // the caller's []ChunkRef so a subsequent caller-side mutation cannot
 // observably mutate the stored view (T-12-09 mitigation).
 func TestMemoryStore_PutFile_BlocksDeepCopy(t *testing.T) {
@@ -91,7 +91,7 @@ func TestMemoryStore_PutFile_BlocksDeepCopy(t *testing.T) {
 	}
 	handle, _ := putFileForBlocksTest(t, store, "/put-deep", "put.bin", original)
 
-	// Mutate the caller-side slice AFTER PutFile returned.
+	// Mutate the caller-side slice AFTER UpdateAttrs returned.
 	mutated := original
 	mutated[0].Hash[0] = 0xFF
 	mutated[1].Offset = 999
@@ -103,11 +103,11 @@ func TestMemoryStore_PutFile_BlocksDeepCopy(t *testing.T) {
 	require.Len(t, got.Blocks, 3)
 
 	assert.Equal(t, byte(0xAA), got.Blocks[0].Hash[0],
-		"PutFile must deep-copy: caller-side hash mutation leaked into stored state")
+		"UpdateAttrs must deep-copy: caller-side hash mutation leaked into stored state")
 	assert.Equal(t, uint64(4*1024*1024), got.Blocks[1].Offset,
-		"PutFile must deep-copy: caller-side offset mutation leaked into stored state")
+		"UpdateAttrs must deep-copy: caller-side offset mutation leaked into stored state")
 	assert.Equal(t, uint32(4*1024*1024), got.Blocks[2].Size,
-		"PutFile must deep-copy: caller-side size mutation leaked into stored state")
+		"UpdateAttrs must deep-copy: caller-side size mutation leaked into stored state")
 }
 
 // TestMemoryStore_GetFile_BlocksDeepCopy verifies that GetFile returns a

--- a/pkg/metadata/store/memory/files_sacl_test.go
+++ b/pkg/metadata/store/memory/files_sacl_test.go
@@ -39,7 +39,7 @@ func putFileWithACL(t *testing.T, store *MemoryMetadataStore, shareName, name st
 			ACL: a,
 		},
 	}
-	require.NoError(t, store.PutFile(ctx, file))
+	require.NoError(t, store.UpdateAttrs(ctx, file))
 	require.NoError(t, store.SetParent(ctx, handle, rootHandle))
 	require.NoError(t, store.SetChild(ctx, rootHandle, name, handle))
 	return handle, file
@@ -71,7 +71,7 @@ func TestMemoryStore_SACL_RoundTrip(t *testing.T) {
 }
 
 // TestMemoryStore_SACL_DeepCopy verifies cloneACL deep-copies the SACL slice so
-// a caller-side mutation after PutFile does not leak into stored state.
+// a caller-side mutation after UpdateAttrs does not leak into stored state.
 func TestMemoryStore_SACL_DeepCopy(t *testing.T) {
 	store := NewMemoryMetadataStoreWithDefaults()
 	ctx := context.Background()
@@ -81,7 +81,7 @@ func TestMemoryStore_SACL_DeepCopy(t *testing.T) {
 	}
 	handle, file := putFileWithACL(t, store, "share-sacl-copy", "f", in)
 
-	// Mutate the caller-side SACL after PutFile returned.
+	// Mutate the caller-side SACL after UpdateAttrs returned.
 	file.ACL.SACL[0].AccessMask = acl.ACE4_READ_DATA
 
 	got, err := store.GetFile(ctx, handle)
@@ -89,5 +89,5 @@ func TestMemoryStore_SACL_DeepCopy(t *testing.T) {
 	require.NotNil(t, got.ACL)
 	require.Len(t, got.ACL.SACL, 1)
 	require.Equal(t, uint32(acl.ACE4_WRITE_DATA), got.ACL.SACL[0].AccessMask,
-		"PutFile must deep-copy SACL: caller-side mutation leaked into stored state")
+		"UpdateAttrs must deep-copy SACL: caller-side mutation leaked into stored state")
 }

--- a/pkg/metadata/store/memory/reset_test.go
+++ b/pkg/metadata/store/memory/reset_test.go
@@ -70,8 +70,8 @@ func TestReset_PopulatedStore(t *testing.T) {
 				Mode: 0o644,
 			},
 		}
-		if err := store.PutFile(ctx, f); err != nil {
-			t.Fatalf("PutFile %s: %v", name, err)
+		if err := store.UpdateAttrs(ctx, f); err != nil {
+			t.Fatalf("UpdateAttrs %s: %v", name, err)
 		}
 		if err := store.SetParent(ctx, handle, rootHandle); err != nil {
 			t.Fatalf("SetParent %s: %v", name, err)

--- a/pkg/metadata/store/memory/store.go
+++ b/pkg/metadata/store/memory/store.go
@@ -248,7 +248,7 @@ type MemoryMetadataStore struct {
 	// lookup. Populated only for non-zero ObjectIDs
 	// (post-quiesce); zero entries skipped.
 	//
-	// Maintained inside PutFile/DeleteFile under the same store-level lock
+	// Maintained inside UpdateAttrs/DeleteFile under the same store-level lock
 	// (mu) that guards `files`, mirroring the fileChunkData.hashIndex
 	// discipline (objects.go).
 	//

--- a/pkg/metadata/store/memory/transaction.go
+++ b/pkg/metadata/store/memory/transaction.go
@@ -242,7 +242,14 @@ func (tx *memoryTransaction) GetFile(ctx context.Context, handle metadata.FileHa
 	return tx.store.getFileLocked(handle)
 }
 
-func (tx *memoryTransaction) PutFile(ctx context.Context, file *metadata.File) error {
+// SetManifest is UpdateAttrs on this backend: the block list rides the stored
+// FileAttr, so there is no separate manifest to rewrite.
+func (tx *memoryTransaction) SetManifest(ctx context.Context, file *metadata.File) error {
+	return tx.UpdateAttrs(ctx, file)
+}
+
+// UpdateAttrs stores or updates file metadata, block list included.
+func (tx *memoryTransaction) UpdateAttrs(ctx context.Context, file *metadata.File) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -308,7 +315,7 @@ func (tx *memoryTransaction) PutFile(ctx context.Context, file *metadata.File) e
 	// first and then returned ErrConflict on the race check, the file row would
 	// still hold the old ObjectID but the index would no longer map it — a
 	// subsequent FindByObjectID(oldObjectID) would return nil even though the
-	// file persists with that ObjectID. Reorder so a failed PutFile leaves
+	// file persists with that ObjectID. Reorder so a failed UpdateAttrs leaves
 	// every map untouched.
 	//
 	// Step 1: race detection (first-committer-wins). If someone
@@ -317,7 +324,7 @@ func (tx *memoryTransaction) PutFile(ctx context.Context, file *metadata.File) e
 	if !attrCopy.ObjectID.IsZero() {
 		if otherKey, claimed := tx.store.objectIndex[attrCopy.ObjectID]; claimed && otherKey != key {
 			return mderrors.NewConflictError(
-				"memory PutFile",
+				"memory UpdateAttrs",
 				fmt.Sprintf("object_id already mapped to file key %s", otherKey),
 			)
 		}

--- a/pkg/metadata/store/metabench/write_compare_bench_test.go
+++ b/pkg/metadata/store/metabench/write_compare_bench_test.go
@@ -58,7 +58,7 @@ func backends() []backend {
 }
 
 // BenchmarkWriteCompare drives the identical data-write metadata op — the RMW a
-// 4k WRITE triggers: GetFile (SELECT) then PutFile (row UPDATE) in one txn —
+// 4k WRITE triggers: GetFile (SELECT) then UpdateAttrs (row UPDATE) in one txn —
 // against each backend, scattered over a populated file set, and reports IOPS.
 // Run one backend at a time with its own profile to compare flamegraphs:
 //
@@ -99,8 +99,8 @@ func BenchmarkWriteCompare(b *testing.B) {
 					ShareName: share, Path: fp, ID: id,
 					FileAttr: metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644, UID: 1000, GID: 1000},
 				}
-				if err := store.PutFile(ctx, f); err != nil {
-					b.Fatalf("PutFile seed: %v", err)
+				if err := store.UpdateAttrs(ctx, f); err != nil {
+					b.Fatalf("UpdateAttrs seed: %v", err)
 				}
 				if err := store.SetParent(ctx, h, rootHandle); err != nil {
 					b.Fatalf("SetParent: %v", err)
@@ -123,7 +123,7 @@ func BenchmarkWriteCompare(b *testing.B) {
 							return err
 						}
 						f.Mtime = time.Now()
-						return tx.PutFile(ctx, f)
+						return tx.UpdateAttrs(ctx, f)
 					}); err != nil {
 						b.Fatalf("write txn: %v", err)
 					}

--- a/pkg/metadata/store/postgres/data_write.go
+++ b/pkg/metadata/store/postgres/data_write.go
@@ -13,7 +13,7 @@ import (
 
 // ApplyDataWrite implements metadata.DataWriteApplier: the hot-path metadata
 // update for a data WRITE, done as a single statement instead of GetFile
-// (aggregate block-refs read) + PutFile (20-column rewrite). Postgres RETURNING
+// (aggregate block-refs read) + UpdateAttrs (20-column rewrite). Postgres RETURNING
 // can reference the pre-update CTE, so the read of the old size/owner and the
 // in-place update collapse into one round-trip.
 //
@@ -21,7 +21,7 @@ import (
 // shrinks the file — mtime/ctime are stamped to now, and setuid/setgid clear
 // when clearSUID is set. Only regular files are affected. The usedBytes and
 // per-identity quota deltas are accumulated on the tx and applied once after a
-// successful commit, exactly like PutFile.
+// successful commit, exactly like UpdateAttrs.
 func (tx *postgresTransaction) ApplyDataWrite(
 	ctx context.Context, handle metadata.FileHandle, newSize uint64, now time.Time, clearSUID bool,
 ) (uint64, error) {

--- a/pkg/metadata/store/postgres/data_write_test.go
+++ b/pkg/metadata/store/postgres/data_write_test.go
@@ -50,7 +50,7 @@ func uniqueShare(prefix string) string {
 
 // TestApplyDataWrite_Sound_Postgres is the Postgres twin of the sqlite
 // soundness test: it drives the DataWriteApplier fast path through a real
-// transaction and asserts the row ends in the state the GetFile+PutFile
+// transaction and asserts the row ends in the state the GetFile+UpdateAttrs
 // fallback would have produced.
 func TestApplyDataWrite_Sound_Postgres(t *testing.T) {
 	if os.Getenv("DITTOFS_TEST_POSTGRES_DSN") == "" {
@@ -93,7 +93,7 @@ func TestApplyDataWrite_Sound_Postgres(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := store.PutFile(ctx, &metadata.File{ShareName: share, Path: fp, ID: id,
+		if err := store.UpdateAttrs(ctx, &metadata.File{ShareName: share, Path: fp, ID: id,
 			FileAttr: metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: mode, UID: 1000, GID: 1000, Size: size}}); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/metadata/store/postgres/file_block_refs.go
+++ b/pkg/metadata/store/postgres/file_block_refs.go
@@ -18,7 +18,7 @@ import (
 // we use a separate table (not JSONB on files) to avoid TOAST write
 // amplification on the VM-primary workload.
 //
-// All helpers operate against a pgx.Tx so that PutFile's ChunkRef replace
+// All helpers operate against a pgx.Tx so that UpdateAttrs's ChunkRef replace
 // happens atomically with the files row UPDATE.
 //
 // Schema lives in migrations/000012_file_block_refs.up.sql.
@@ -172,7 +172,7 @@ func fileChunkRefsDelta(ctx context.Context, tx pgx.Tx, fileID uuid.UUID, blocks
 	return upserts, deletes, len(stored), nil
 }
 
-// PutFileChunkRefsCallCount returns how many times PutFile actually wrote
+// PutFileChunkRefsCallCount returns how many times UpdateAttrs actually wrote
 // file_block_refs rows — the delta upserted or deleted at least one row —
 // since store open. Test-only — proves attr-only writes and no-op
 // re-projections of an unchanged manifest perform ZERO manifest writes.
@@ -181,7 +181,7 @@ func (s *PostgresMetadataStore) PutFileChunkRefsCallCount() int64 {
 }
 
 // PutFileChunkRefsManifestRowsScanned returns how many stored file_block_refs
-// rows PutFile's manifest diff has read since store open. Test-only — proves a
+// rows UpdateAttrs's manifest diff has read since store open. Test-only — proves a
 // scoped commit's read cost tracks the changed offsets, not the file's total
 // chunk count.
 func (s *PostgresMetadataStore) PutFileChunkRefsManifestRowsScanned() int64 {

--- a/pkg/metadata/store/postgres/files.go
+++ b/pkg/metadata/store/postgres/files.go
@@ -66,11 +66,19 @@ func (s *PostgresMetadataStore) GetFile(ctx context.Context, handle metadata.Fil
 	return file, nil
 }
 
-// PutFile stores or updates file metadata.
+// UpdateAttrs stores or updates file metadata.
 // Creates the entry if it doesn't exist.
-func (s *PostgresMetadataStore) PutFile(ctx context.Context, file *metadata.File) error {
+func (s *PostgresMetadataStore) UpdateAttrs(ctx context.Context, file *metadata.File) error {
 	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
-		return tx.PutFile(ctx, file)
+		return tx.UpdateAttrs(ctx, file)
+	})
+}
+
+// SetManifest stores or updates file metadata and rewrites the stored block
+// manifest from file.Blocks.
+func (s *PostgresMetadataStore) SetManifest(ctx context.Context, file *metadata.File) error {
+	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return tx.SetManifest(ctx, file)
 	})
 }
 

--- a/pkg/metadata/store/postgres/high_findings_test.go
+++ b/pkg/metadata/store/postgres/high_findings_test.go
@@ -52,8 +52,8 @@ func putSizedFile(t *testing.T, store metadata.Store, shareName, rootName string
 			Size: size,
 		},
 	}
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile: %v", err)
+	if err := store.UpdateAttrs(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs: %v", err)
 	}
 	if err := store.SetParent(ctx, handle, rootHandle); err != nil {
 		t.Fatalf("SetParent: %v", err)
@@ -67,7 +67,7 @@ func putSizedFile(t *testing.T, store metadata.Store, shareName, rootName string
 	return handle
 }
 
-// setFileSize updates the size of an existing file (GetFile -> mutate -> PutFile).
+// setFileSize updates the size of an existing file (GetFile -> mutate -> UpdateAttrs).
 func setFileSize(t *testing.T, store metadata.Store, handle metadata.FileHandle, size uint64) {
 	t.Helper()
 	ctx := t.Context()
@@ -76,8 +76,8 @@ func setFileSize(t *testing.T, store metadata.Store, handle metadata.FileHandle,
 		t.Fatalf("GetFile: %v", err)
 	}
 	f.FileAttr.Size = size
-	if err := store.PutFile(ctx, f); err != nil {
-		t.Fatalf("PutFile (resize): %v", err)
+	if err := store.UpdateAttrs(ctx, f); err != nil {
+		t.Fatalf("UpdateAttrs (resize): %v", err)
 	}
 }
 
@@ -229,7 +229,7 @@ func TestPostgres_WithTransaction_RetriesOnSerializationFailure(t *testing.T) {
 			}
 			close(ready) // let the racing tx proceed
 			f.FileAttr.Size = 1000
-			return tx.PutFile(ctx, f)
+			return tx.UpdateAttrs(ctx, f)
 		})
 	}()
 
@@ -240,7 +240,7 @@ func TestPostgres_WithTransaction_RetriesOnSerializationFailure(t *testing.T) {
 			return err
 		}
 		f.FileAttr.Size = 2000
-		return tx.PutFile(ctx, f)
+		return tx.UpdateAttrs(ctx, f)
 	}); err != nil {
 		t.Fatalf("racing tx failed (retry not transparent?): %v", err)
 	}

--- a/pkg/metadata/store/postgres/high_findings_unit_test.go
+++ b/pkg/metadata/store/postgres/high_findings_unit_test.go
@@ -37,7 +37,7 @@ func TestStoreError_Unwrap_IsRetryable(t *testing.T) {
 
 // TestStoreError_Unwrap_DeadlockRetryable mirrors the above for deadlocks.
 func TestStoreError_Unwrap_DeadlockRetryable(t *testing.T) {
-	se := mapPgError(&pgconn.PgError{Code: "40P01"}, "PutFile", "")
+	se := mapPgError(&pgconn.PgError{Code: "40P01"}, "UpdateAttrs", "")
 	if !isRetryableError(se) {
 		t.Fatalf("isRetryableError(mapped 40P01) = false, want true (err=%v)", se)
 	}

--- a/pkg/metadata/store/postgres/objectid_conflict_test.go
+++ b/pkg/metadata/store/postgres/objectid_conflict_test.go
@@ -108,8 +108,8 @@ func conflictTestFile(t *testing.T, store *postgres.PostgresMetadataStore, share
 			PayloadID: metadata.PayloadID(strings.TrimPrefix(shareName, "/") + "/" + name),
 		},
 	}
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile %q: %v", name, err)
+	if err := store.UpdateAttrs(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs %q: %v", name, err)
 	}
 	if err := store.SetLinkCount(ctx, handle, 1); err != nil {
 		t.Fatalf("SetLinkCount %q: %v", name, err)
@@ -144,8 +144,8 @@ func TestPostgresPutFile_ObjectIDConflictMapsToErrConflict(t *testing.T) {
 	}
 	fA.ObjectID = contested
 	fA.Blocks = []block.ChunkRef{{Hash: block.ContentHash{1, 2, 3, 4}, Offset: 0, Size: 4096}}
-	if err := store.PutFile(ctx, fA); err != nil {
-		t.Fatalf("PutFile A (first claimant): %v", err)
+	if err := store.UpdateAttrs(ctx, fA); err != nil {
+		t.Fatalf("UpdateAttrs A (first claimant): %v", err)
 	}
 
 	// Second claimant must lose with ErrConflict (NOT ErrAlreadyExists).
@@ -155,9 +155,9 @@ func TestPostgresPutFile_ObjectIDConflictMapsToErrConflict(t *testing.T) {
 	}
 	fB.ObjectID = contested
 	fB.Blocks = []block.ChunkRef{{Hash: block.ContentHash{1, 2, 3, 4}, Offset: 0, Size: 4096}}
-	err = store.PutFile(ctx, fB)
+	err = store.UpdateAttrs(ctx, fB)
 	if err == nil {
-		t.Fatal("PutFile B should have failed with object_id conflict")
+		t.Fatal("UpdateAttrs B should have failed with object_id conflict")
 	}
 	if !mderrors.IsConflictError(err) {
 		t.Fatalf("object_id conflict must map to ErrConflict, got %v", err)
@@ -174,7 +174,7 @@ func TestPostgresPutFile_ObjectIDConflictMapsToErrConflict(t *testing.T) {
 // active rows sharing a path_hash — pjdfstest rename/23, #1160). Namespace
 // uniqueness — no two entries with the same name in a directory — is enforced
 // by parent_child_map UNIQUE(parent_id, child_name), NOT files.path_hash, so a
-// raw PutFile of a DIFFERENT id at the SAME (share, path) with nlink>0 must now
+// raw UpdateAttrs of a DIFFERENT id at the SAME (share, path) with nlink>0 must now
 // succeed instead of failing with ErrAlreadyExists. This guards against the
 // index being reintroduced (which would re-break hard-link rename on postgres).
 func TestPostgresPutFile_DuplicatePathAllowed(t *testing.T) {
@@ -197,7 +197,7 @@ func TestPostgresPutFile_DuplicatePathAllowed(t *testing.T) {
 			Mode: 0o644,
 		},
 	}
-	if perr := store.PutFile(ctx, dupFile); perr != nil {
-		t.Fatalf("duplicate-path PutFile should now succeed (path_hash uniqueness dropped in #1165), got %v", perr)
+	if perr := store.UpdateAttrs(ctx, dupFile); perr != nil {
+		t.Fatalf("duplicate-path UpdateAttrs should now succeed (path_hash uniqueness dropped in #1165), got %v", perr)
 	}
 }

--- a/pkg/metadata/store/postgres/objects.go
+++ b/pkg/metadata/store/postgres/objects.go
@@ -488,7 +488,7 @@ var _ block.FileChunkStore = (*postgresTransaction)(nil)
 // public store's connection-pool helpers. Previously every method just
 // called `tx.store.X(...)` which routed through the pool — defeating
 // rollback for any caller that bumped RefCount inside WithTransaction
-// then encountered a downstream PutFile failure (silent
+// then encountered a downstream UpdateAttrs failure (silent
 // leak). All proxies below are now tx-bound; non-mutating
 // helpers keep the pool path because no caller mutates state through them.
 

--- a/pkg/metadata/store/postgres/postgres_blockref_test.go
+++ b/pkg/metadata/store/postgres/postgres_blockref_test.go
@@ -109,8 +109,8 @@ func createShareAndFile(t *testing.T, store metadata.Store, shareName, fileName 
 			GID:  1000,
 		},
 	}
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile: %v", err)
+	if err := store.UpdateAttrs(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs: %v", err)
 	}
 	if err := store.SetParent(ctx, handle, rootHandle); err != nil {
 		t.Fatalf("SetParent: %v", err)
@@ -124,7 +124,7 @@ func createShareAndFile(t *testing.T, store metadata.Store, shareName, fileName 
 	return handle
 }
 
-// TestPostgres_FileChunkRefs_BlocksRoundTrip asserts that PutFile with a
+// TestPostgres_FileChunkRefs_BlocksRoundTrip asserts that UpdateAttrs with a
 // non-empty Blocks list, followed by GetFile, returns identical Blocks
 // (sorted by Offset, byte-equal Hash, equal Offset, equal Size).
 func TestPostgres_FileChunkRefs_BlocksRoundTrip(t *testing.T) {
@@ -144,9 +144,8 @@ func TestPostgres_FileChunkRefs_BlocksRoundTrip(t *testing.T) {
 		t.Fatalf("GetFile (initial): %v", err)
 	}
 	file.FileAttr.Blocks = want
-	file.BlocksDirty = true // manifest write — gate persists file_block_refs
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile with Blocks: %v", err)
+	if err := store.SetManifest(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs with Blocks: %v", err)
 	}
 
 	got, err := store.GetFile(ctx, handle)
@@ -170,7 +169,7 @@ func TestPostgres_FileChunkRefs_BlocksRoundTrip(t *testing.T) {
 	}
 }
 
-// TestPostgres_FileChunkRefs_ReplaceFully asserts that a second PutFile
+// TestPostgres_FileChunkRefs_ReplaceFully asserts that a second UpdateAttrs
 // with a different Blocks list fully replaces the first (no leftover rows).
 func TestPostgres_FileChunkRefs_ReplaceFully(t *testing.T) {
 	store := newTestStore(t)
@@ -188,9 +187,8 @@ func TestPostgres_FileChunkRefs_ReplaceFully(t *testing.T) {
 		t.Fatalf("GetFile (1): %v", err)
 	}
 	file.FileAttr.Blocks = first
-	file.BlocksDirty = true // manifest write — gate persists file_block_refs
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile (first): %v", err)
+	if err := store.SetManifest(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs (first): %v", err)
 	}
 
 	// Second write with a different (and shorter) list.
@@ -203,9 +201,8 @@ func TestPostgres_FileChunkRefs_ReplaceFully(t *testing.T) {
 		t.Fatalf("GetFile (2): %v", err)
 	}
 	file.FileAttr.Blocks = second
-	file.BlocksDirty = true // manifest write — gate persists file_block_refs
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile (second): %v", err)
+	if err := store.SetManifest(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs (second): %v", err)
 	}
 
 	got, err := store.GetFile(ctx, handle)
@@ -242,9 +239,8 @@ func TestPostgres_FileChunkRefs_CascadeDelete(t *testing.T) {
 		t.Fatalf("GetFile: %v", err)
 	}
 	file.FileAttr.Blocks = blocks
-	file.BlocksDirty = true // manifest write — gate persists file_block_refs
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile: %v", err)
+	if err := store.SetManifest(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs: %v", err)
 	}
 
 	// Capture file ID for direct SQL count.
@@ -294,7 +290,7 @@ func mustParentHandle(t *testing.T, store metadata.Store, handle metadata.FileHa
 }
 
 // TestPostgres_FileChunkRefs_ConcurrentPutFile asserts that two concurrent
-// PutFile calls on the same file_id do not produce duplicate or interleaved
+// UpdateAttrs calls on the same file_id do not produce duplicate or interleaved
 // rows. The PK (file_id, offset) means duplicates would error; the test
 // asserts no error AND a final state matching one of the two writers.
 func TestPostgres_FileChunkRefs_ConcurrentPutFile(t *testing.T) {
@@ -325,15 +321,14 @@ func TestPostgres_FileChunkRefs_ConcurrentPutFile(t *testing.T) {
 				return
 			}
 			file.FileAttr.Blocks = blocks
-			file.BlocksDirty = true // manifest write — gate persists file_block_refs
-			errs[idx] = store.PutFile(ctx, file)
+			errs[idx] = store.SetManifest(ctx, file)
 		}(i, blocks)
 	}
 	wg.Wait()
 
 	for i, err := range errs {
 		if err != nil {
-			t.Fatalf("PutFile goroutine %d: %v", i, err)
+			t.Fatalf("UpdateAttrs goroutine %d: %v", i, err)
 		}
 	}
 
@@ -391,9 +386,8 @@ func TestPostgres_Restore_ReconcilesNullHashFileChunks(t *testing.T) {
 	file.Blocks = []block.ChunkRef{
 		{Hash: want, Offset: 0, Size: 4 << 20},
 	}
-	file.BlocksDirty = true // manifest write — gate persists file_block_refs
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile with Blocks: %v", err)
+	if err := store.SetManifest(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs with Blocks: %v", err)
 	}
 
 	// The file_blocks read-index row ID is "{content_id}/{offset}".

--- a/pkg/metadata/store/postgres/store.go
+++ b/pkg/metadata/store/postgres/store.go
@@ -31,8 +31,8 @@ type PostgresMetadataStore struct {
 	// logger for structured logging
 	logger *slog.Logger
 
-	// manifestWrites counts how many times PutFile actually persisted the
-	// file_block_refs manifest (i.e. ran past the BlocksDirty gate). Test-only
+	// manifestWrites counts how many times a write actually persisted the
+	// file_block_refs manifest (i.e. came in through SetManifest). Test-only
 	// observability: it lets the conformance suite prove an attr-only write
 	// performed ZERO manifest writes (row-count alone cannot — a DELETE+INSERT
 	// of the same M rows leaves the same count). Never read in production.
@@ -40,7 +40,7 @@ type PostgresMetadataStore struct {
 
 	// manifestRowsScanned counts the stored file_block_refs rows the manifest
 	// diff has had to read since open. Test-only observability: it is what
-	// BlocksDirtyOffsets bounds, so a test can prove a scoped commit reads the
+	// ManifestDirtyOffsets bounds, so a test can prove a scoped commit reads the
 	// changed offsets rather than the whole file. Never read in production.
 	manifestRowsScanned atomic.Int64
 

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -251,7 +251,19 @@ func (tx *postgresTransaction) GetFile(ctx context.Context, handle metadata.File
 	return file, nil
 }
 
-func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File) error {
+// UpdateAttrs persists the file's attributes and leaves the stored
+// file_block_refs manifest untouched.
+func (tx *postgresTransaction) UpdateAttrs(ctx context.Context, file *metadata.File) error {
+	return tx.putFile(ctx, file, false)
+}
+
+// SetManifest persists the file's attributes and rewrites the stored
+// file_block_refs manifest from file.Blocks.
+func (tx *postgresTransaction) SetManifest(ctx context.Context, file *metadata.File) error {
+	return tx.putFile(ctx, file, true)
+}
+
+func (tx *postgresTransaction) putFile(ctx context.Context, file *metadata.File, writeManifest bool) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -331,7 +343,7 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 		var marshalErr error
 		aclJSON, marshalErr = json.Marshal(file.ACL)
 		if marshalErr != nil {
-			return mapPgError(marshalErr, "PutFile", "marshal ACL")
+			return mapPgError(marshalErr, "UpdateAttrs", "marshal ACL")
 		}
 	}
 
@@ -342,7 +354,7 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 		var marshalErr error
 		easJSON, marshalErr = json.Marshal(file.EAs)
 		if marshalErr != nil {
-			return mapPgError(marshalErr, "PutFile", "marshal EAs")
+			return mapPgError(marshalErr, "UpdateAttrs", "marshal EAs")
 		}
 	}
 
@@ -394,7 +406,7 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 		case errors.Is(scanErr, pgx.ErrNoRows):
 			updated = false
 		default:
-			return mapPgError(scanErr, "PutFile", "")
+			return mapPgError(scanErr, "UpdateAttrs", "")
 		}
 	}
 
@@ -448,7 +460,7 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 			file.Hidden, aclJSON, easJSON, objectIDArg,
 			deletedAtArg, file.OriginalPath, file.DeletedBy,
 		); err != nil {
-			return mapPgError(err, "PutFile", "")
+			return mapPgError(err, "UpdateAttrs", "")
 		}
 
 		// Track new regular file size.
@@ -462,7 +474,7 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 		// Debug logging for new file inserts, gated so the id formatting and
 		// variadic boxing are skipped when Debug is off.
 		if tx.store.logger.Enabled(ctx, slog.LevelDebug) {
-			tx.store.logger.Debug("PutFile inserted",
+			tx.store.logger.Debug("UpdateAttrs inserted",
 				"id", file.ID.String(),
 				"share", file.ShareName,
 				"path", file.Path,
@@ -471,23 +483,22 @@ func (tx *postgresTransaction) PutFile(ctx context.Context, file *metadata.File)
 		}
 	}
 
-	// persist FileAttr.Blocks into file_block_refs — but ONLY when the caller
-	// signalled the manifest legitimately changed (BlocksDirty). Attr-only
-	// writes (chmod/utimes/close/rename/xattr/…) leave BlocksDirty false, so
-	// they skip the DELETE+INSERT entirely instead of rewriting the whole
-	// chunk list on every write (#1715 #8 write-amplification fix). Only
-	// regular files carry ChunkRef payloads; empty/nil Blocks under a dirty
-	// flag performs a DELETE-only pass so no stale rows survive a drop.
-	if file.Type == metadata.FileTypeRegular && file.BlocksDirty {
+	// persist FileAttr.Blocks into file_block_refs — but ONLY on the
+	// SetManifest path. Attr-only writes (chmod/utimes/close/rename/xattr/…)
+	// come through UpdateAttrs and skip the DELETE+INSERT entirely instead of
+	// rewriting the whole chunk list on every write. Only regular files carry
+	// ChunkRef payloads; empty/nil Blocks on a SetManifest performs a
+	// DELETE-only pass so no stale rows survive a drop.
+	if file.Type == metadata.FileTypeRegular && writeManifest {
 		// Apply only the rows that actually changed. An in-place overwrite that
 		// reuses the same chunk boundaries frequently projects an identical
 		// manifest, so putFileChunkRefs writes nothing and reports wrote=false.
 		// Freshly-inserted rows (!updated) have no prior refs, so every ref is
 		// a plain insert. The counter tracks manifests that truly changed.
-		wrote, scanned, err := putFileChunkRefs(ctx, tx.tx, file.ID, file.Blocks, updated, file.BlocksDirtyOffsets)
+		wrote, scanned, err := putFileChunkRefs(ctx, tx.tx, file.ID, file.Blocks, updated, file.ManifestDirtyOffsets)
 		tx.store.manifestRowsScanned.Add(int64(scanned))
 		if err != nil {
-			return mapPgError(err, "PutFile", "blocks")
+			return mapPgError(err, "SetManifest", "blocks")
 		}
 		if wrote {
 			tx.store.manifestWrites.Add(1)

--- a/pkg/metadata/store/postgres/write_path_bench_test.go
+++ b/pkg/metadata/store/postgres/write_path_bench_test.go
@@ -43,9 +43,9 @@ func benchSeed(b *testing.B, store metadata.Store, n int) (string, []metadata.Fi
 		if err != nil {
 			b.Fatalf("DecodeFileHandle: %v", err)
 		}
-		if err := store.PutFile(ctx, &metadata.File{ShareName: share, Path: fp, ID: id,
+		if err := store.UpdateAttrs(ctx, &metadata.File{ShareName: share, Path: fp, ID: id,
 			FileAttr: metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644, UID: 1000, GID: 1000}}); err != nil {
-			b.Fatalf("PutFile seed: %v", err)
+			b.Fatalf("UpdateAttrs seed: %v", err)
 		}
 		if err := store.SetParent(ctx, h, rootHandle); err != nil {
 			b.Fatalf("SetParent: %v", err)
@@ -62,7 +62,7 @@ func benchSeed(b *testing.B, store metadata.Store, n int) (string, []metadata.Fi
 // against a scattered file set, in the two shapes the runtime can take:
 //
 //	getfile_putfile — the fallback: GetFile (row + aggregate block-refs read)
-//	                  then PutFile (full-row UPDATE), two statements per op
+//	                  then UpdateAttrs (full-row UPDATE), two statements per op
 //	applydatawrite  — the DataWriteApplier fast path: one CTE statement that
 //	                  reads the old size/owner and updates size/mtime/ctime in
 //	                  a single round-trip
@@ -111,7 +111,7 @@ func BenchmarkPostgresWritePath(b *testing.B) {
 			f.Size = 4096
 			f.Mtime = time.Now()
 			f.Ctime = f.Mtime
-			return tx.PutFile(ctx, f)
+			return tx.UpdateAttrs(ctx, f)
 		})
 	})
 

--- a/pkg/metadata/store/sqlite/backpressure_test.go
+++ b/pkg/metadata/store/sqlite/backpressure_test.go
@@ -101,7 +101,7 @@ func TestSQLite_ConcurrentWritesBackpressureNoEIO(t *testing.T) {
 							return err
 						}
 						f.Mtime = time.Now()
-						return tx.PutFile(ctx, f)
+						return tx.UpdateAttrs(ctx, f)
 					})
 					if err != nil {
 						errCh <- err

--- a/pkg/metadata/store/sqlite/data_write.go
+++ b/pkg/metadata/store/sqlite/data_write.go
@@ -12,13 +12,13 @@ import (
 
 // ApplyDataWrite implements metadata.DataWriteApplier: the hot-path metadata
 // update for a data WRITE, done as a narrow SELECT-then-UPDATE instead of the
-// GetFile (aggregate block-refs read) + PutFile (20-column rewrite) pair.
+// GetFile (aggregate block-refs read) + UpdateAttrs (20-column rewrite) pair.
 //
 // It grows size to max(old, new) — so an out-of-order write at a lower offset
 // never shrinks the file — stamps mtime/ctime to now, and clears setuid/setgid
 // when clearSUID is set. Only regular files are affected; the usedBytes and
 // per-identity quota deltas are accumulated on the tx and applied once after a
-// successful commit, exactly like PutFile, so a retry never double-counts.
+// successful commit, exactly like UpdateAttrs, so a retry never double-counts.
 func (tx *sqliteTransaction) ApplyDataWrite(
 	ctx context.Context, handle metadata.FileHandle, newSize uint64, now time.Time, clearSUID bool,
 ) (uint64, error) {

--- a/pkg/metadata/store/sqlite/data_write_test.go
+++ b/pkg/metadata/store/sqlite/data_write_test.go
@@ -51,7 +51,7 @@ func TestApplyDataWrite_Sound(t *testing.T) {
 			t.Fatal(err)
 		}
 		_, id, _ := metadata.DecodeFileHandle(h)
-		if err := store.PutFile(ctx, &metadata.File{ShareName: share, Path: "/s/" + name, ID: id,
+		if err := store.UpdateAttrs(ctx, &metadata.File{ShareName: share, Path: "/s/" + name, ID: id,
 			FileAttr: metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: mode, UID: 1000, GID: 1000, Size: size}}); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/metadata/store/sqlite/file_block_refs.go
+++ b/pkg/metadata/store/sqlite/file_block_refs.go
@@ -18,7 +18,7 @@ import (
 // we use a separate table (not JSONB on files) to avoid TOAST write
 // amplification on the VM-primary workload.
 //
-// All helpers operate against a pgx.Tx so that PutFile's ChunkRef replace
+// All helpers operate against a pgx.Tx so that UpdateAttrs's ChunkRef replace
 // happens atomically with the files row UPDATE.
 //
 // Schema lives in migrations/000012_file_block_refs.up.sql.
@@ -247,7 +247,7 @@ func upsertChunkRefs(ctx context.Context, tx execer, fileID uuid.UUID, refs []bl
 	return nil
 }
 
-// PutFileChunkRefsCallCount returns how many times PutFile actually wrote
+// PutFileChunkRefsCallCount returns how many times UpdateAttrs actually wrote
 // file_block_refs rows — the delta upserted or deleted at least one row —
 // since store open. Test-only — proves attr-only writes and no-op
 // re-projections of an unchanged manifest perform ZERO manifest writes.
@@ -256,7 +256,7 @@ func (s *SQLiteMetadataStore) PutFileChunkRefsCallCount() int64 {
 }
 
 // PutFileChunkRefsManifestRowsScanned returns how many stored file_block_refs
-// rows PutFile's manifest diff has read since store open. Test-only — proves a
+// rows UpdateAttrs's manifest diff has read since store open. Test-only — proves a
 // scoped commit's read cost tracks the changed offsets, not the file's total
 // chunk count.
 func (s *SQLiteMetadataStore) PutFileChunkRefsManifestRowsScanned() int64 {

--- a/pkg/metadata/store/sqlite/files.go
+++ b/pkg/metadata/store/sqlite/files.go
@@ -65,11 +65,19 @@ func (s *SQLiteMetadataStore) GetFile(ctx context.Context, handle metadata.FileH
 	return file, nil
 }
 
-// PutFile stores or updates file metadata.
+// UpdateAttrs stores or updates file metadata.
 // Creates the entry if it doesn't exist.
-func (s *SQLiteMetadataStore) PutFile(ctx context.Context, file *metadata.File) error {
+func (s *SQLiteMetadataStore) UpdateAttrs(ctx context.Context, file *metadata.File) error {
 	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
-		return tx.PutFile(ctx, file)
+		return tx.UpdateAttrs(ctx, file)
+	})
+}
+
+// SetManifest stores or updates file metadata and rewrites the stored block
+// manifest from file.Blocks.
+func (s *SQLiteMetadataStore) SetManifest(ctx context.Context, file *metadata.File) error {
+	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return tx.SetManifest(ctx, file)
 	})
 }
 

--- a/pkg/metadata/store/sqlite/manifest_delta_scope_test.go
+++ b/pkg/metadata/store/sqlite/manifest_delta_scope_test.go
@@ -68,20 +68,19 @@ func scopedCommitRowsScanned(t *testing.T, chunks int) int64 {
 
 	// Seed the manifest in one unscoped write — the state a large file reaches
 	// before the commit under test.
-	if err := store.PutFile(ctx, &metadata.File{
+	if err := store.SetManifest(ctx, &metadata.File{
 		ShareName: share,
 		Path:      "/f",
 		ID:        id,
 		FileAttr: metadata.FileAttr{
-			Type:        metadata.FileTypeRegular,
-			Mode:        0o644,
-			Size:        uint64(chunks) * chunkSize,
-			PayloadID:   metadata.PayloadID(payloadID),
-			Blocks:      refs,
-			BlocksDirty: true,
+			Type:      metadata.FileTypeRegular,
+			Mode:      0o644,
+			Size:      uint64(chunks) * chunkSize,
+			PayloadID: metadata.PayloadID(payloadID),
+			Blocks:    refs,
 		},
 	}); err != nil {
-		t.Fatalf("PutFile (seed %d chunks): %v", chunks, err)
+		t.Fatalf("SetManifest (seed %d chunks): %v", chunks, err)
 	}
 
 	// Commit a single replacement chunk in the middle of the file, the way a

--- a/pkg/metadata/store/sqlite/narrow_write_bench_test.go
+++ b/pkg/metadata/store/sqlite/narrow_write_bench_test.go
@@ -45,8 +45,8 @@ func seedFiles(b *testing.B, store metadata.Store, share string, n int) []string
 		}
 		f := &metadata.File{ShareName: share, Path: fp, ID: id,
 			FileAttr: metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644, UID: 1000, GID: 1000}}
-		if err := store.PutFile(ctx, f); err != nil {
-			b.Fatalf("PutFile seed: %v", err)
+		if err := store.UpdateAttrs(ctx, f); err != nil {
+			b.Fatalf("UpdateAttrs seed: %v", err)
 		}
 		if err := store.SetParent(ctx, h, rootHandle); err != nil {
 			b.Fatalf("SetParent: %v", err)
@@ -84,9 +84,9 @@ func seedHandles(b *testing.B, store metadata.Store, share string, n int) []meta
 		if err != nil {
 			b.Fatalf("DecodeFileHandle: %v", err)
 		}
-		if err := store.PutFile(ctx, &metadata.File{ShareName: share, Path: fp, ID: id,
+		if err := store.UpdateAttrs(ctx, &metadata.File{ShareName: share, Path: fp, ID: id,
 			FileAttr: metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644, UID: 1000, GID: 1000}}); err != nil {
-			b.Fatalf("PutFile seed: %v", err)
+			b.Fatalf("UpdateAttrs seed: %v", err)
 		}
 		if err := store.SetParent(ctx, h, rootHandle); err != nil {
 			b.Fatalf("SetParent: %v", err)
@@ -100,7 +100,7 @@ func seedHandles(b *testing.B, store metadata.Store, share string, n int) []meta
 }
 
 // BenchmarkNarrowWrite isolates the two SQL write-path levers against the same
-// populated table the GetFile+PutFile path runs at ~5k IOPS:
+// populated table the GetFile+UpdateAttrs path runs at ~5k IOPS:
 //
 //	raw      — narrow single UPDATE, re-parsed each op (isolates: drop SELECT +
 //	           20-col rewrite + explicit txn, but keep per-op SQL compilation)

--- a/pkg/metadata/store/sqlite/narrow_write_verify_test.go
+++ b/pkg/metadata/store/sqlite/narrow_write_verify_test.go
@@ -32,7 +32,7 @@ func TestNarrowUpdateAffectsRow(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := store.PutFile(ctx, &metadata.File{ShareName: share, Path: "/hot/f", ID: id,
+	if err := store.UpdateAttrs(ctx, &metadata.File{ShareName: share, Path: "/hot/f", ID: id,
 		FileAttr: metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644, UID: 1000, GID: 1000}}); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/metadata/store/sqlite/objects.go
+++ b/pkg/metadata/store/sqlite/objects.go
@@ -521,7 +521,7 @@ var _ block.FileChunkStore = (*sqliteTransaction)(nil)
 // never the store's pool helpers: a pool connection cannot see the
 // transaction's uncommitted writes and would survive its rollback, so a caller
 // that bumped RefCount inside WithTransaction and then hit a downstream
-// PutFile failure would leak the bump.
+// UpdateAttrs failure would leak the bump.
 
 func (tx *sqliteTransaction) GetFileChunk(ctx context.Context, id string) (*metadata.FileChunk, error) {
 	return getFileChunkTx(ctx, tx.tx, id)

--- a/pkg/metadata/store/sqlite/store.go
+++ b/pkg/metadata/store/sqlite/store.go
@@ -57,8 +57,8 @@ type SQLiteMetadataStore struct {
 	// query on startup.
 	usedBytes atomic.Int64
 
-	// manifestWrites counts how many times PutFile actually persisted the
-	// file_block_refs manifest (i.e. ran past the BlocksDirty gate). Test-only
+	// manifestWrites counts how many times a write actually persisted the
+	// file_block_refs manifest (i.e. came in through SetManifest). Test-only
 	// observability: it lets the conformance suite prove an attr-only write
 	// performed ZERO manifest writes (row-count alone cannot — a DELETE+INSERT
 	// of the same M rows leaves the same count). Never read in production.
@@ -66,7 +66,7 @@ type SQLiteMetadataStore struct {
 
 	// manifestRowsScanned counts the stored file_block_refs rows the manifest
 	// diff has had to read since open. Test-only observability: it is what
-	// BlocksDirtyOffsets bounds, so a test can prove a scoped commit reads the
+	// ManifestDirtyOffsets bounds, so a test can prove a scoped commit reads the
 	// changed offsets rather than the whole file. Never read in production.
 	manifestRowsScanned atomic.Int64
 

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -196,7 +196,19 @@ func (tx *sqliteTransaction) GetFile(ctx context.Context, handle metadata.FileHa
 	return file, nil
 }
 
-func (tx *sqliteTransaction) PutFile(ctx context.Context, file *metadata.File) error {
+// UpdateAttrs persists the file's attributes and leaves the stored
+// file_block_refs manifest untouched.
+func (tx *sqliteTransaction) UpdateAttrs(ctx context.Context, file *metadata.File) error {
+	return tx.putFile(ctx, file, false)
+}
+
+// SetManifest persists the file's attributes and rewrites the stored
+// file_block_refs manifest from file.Blocks.
+func (tx *sqliteTransaction) SetManifest(ctx context.Context, file *metadata.File) error {
+	return tx.putFile(ctx, file, true)
+}
+
+func (tx *sqliteTransaction) putFile(ctx context.Context, file *metadata.File, writeManifest bool) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -271,7 +283,7 @@ func (tx *sqliteTransaction) PutFile(ctx context.Context, file *metadata.File) e
 		var marshalErr error
 		aclJSON, marshalErr = json.Marshal(file.ACL)
 		if marshalErr != nil {
-			return mapDBError(marshalErr, "PutFile", "marshal ACL")
+			return mapDBError(marshalErr, "UpdateAttrs", "marshal ACL")
 		}
 	}
 
@@ -282,7 +294,7 @@ func (tx *sqliteTransaction) PutFile(ctx context.Context, file *metadata.File) e
 		var marshalErr error
 		easJSON, marshalErr = json.Marshal(file.EAs)
 		if marshalErr != nil {
-			return mapDBError(marshalErr, "PutFile", "marshal EAs")
+			return mapDBError(marshalErr, "UpdateAttrs", "marshal EAs")
 		}
 	}
 
@@ -332,12 +344,12 @@ func (tx *sqliteTransaction) PutFile(ctx context.Context, file *metadata.File) e
 				deletedAtArg, file.OriginalPath, file.DeletedBy,
 				file.ID, file.ShareName,
 			); err != nil {
-				return mapDBError(err, "PutFile", "")
+				return mapDBError(err, "UpdateAttrs", "")
 			}
 		case errors.Is(scanErr, sql.ErrNoRows):
 			updated = false
 		default:
-			return mapDBError(scanErr, "PutFile", "")
+			return mapDBError(scanErr, "UpdateAttrs", "")
 		}
 	}
 
@@ -391,7 +403,7 @@ func (tx *sqliteTransaction) PutFile(ctx context.Context, file *metadata.File) e
 			file.Hidden, aclJSON, easJSON, objectIDArg,
 			deletedAtArg, file.OriginalPath, file.DeletedBy,
 		); err != nil {
-			return mapDBError(err, "PutFile", "")
+			return mapDBError(err, "UpdateAttrs", "")
 		}
 
 		// Track new regular file size.
@@ -405,7 +417,7 @@ func (tx *sqliteTransaction) PutFile(ctx context.Context, file *metadata.File) e
 		// Debug logging for new file inserts, gated so the id formatting is
 		// skipped when Debug is off.
 		if tx.store.logger.Enabled(ctx, slog.LevelDebug) {
-			tx.store.logger.Debug("PutFile inserted",
+			tx.store.logger.Debug("UpdateAttrs inserted",
 				"id", file.ID.String(),
 				"share", file.ShareName,
 				"path", file.Path,
@@ -414,23 +426,22 @@ func (tx *sqliteTransaction) PutFile(ctx context.Context, file *metadata.File) e
 		}
 	}
 
-	// persist FileAttr.Blocks into file_block_refs — but ONLY when the caller
-	// signalled the manifest legitimately changed (BlocksDirty). Attr-only
-	// writes (chmod/utimes/close/rename/xattr/…) leave BlocksDirty false, so
-	// they skip the DELETE+INSERT entirely instead of rewriting the whole
-	// chunk list on every write (#1715 #8 write-amplification fix). Only
-	// regular files carry ChunkRef payloads; empty/nil Blocks under a dirty
-	// flag performs a DELETE-only pass so no stale rows survive a drop.
-	if file.Type == metadata.FileTypeRegular && file.BlocksDirty {
+	// persist FileAttr.Blocks into file_block_refs — but ONLY on the
+	// SetManifest path. Attr-only writes (chmod/utimes/close/rename/xattr/…)
+	// come through UpdateAttrs and skip the DELETE+INSERT entirely instead of
+	// rewriting the whole chunk list on every write. Only regular files carry
+	// ChunkRef payloads; empty/nil Blocks on a SetManifest performs a
+	// DELETE-only pass so no stale rows survive a drop.
+	if file.Type == metadata.FileTypeRegular && writeManifest {
 		// Apply only the rows that actually changed. An in-place overwrite that
 		// reuses the same chunk boundaries frequently projects an identical
 		// manifest, so putFileChunkRefs writes nothing and reports wrote=false.
 		// Freshly-inserted rows (!updated) have no prior refs, so every ref is
 		// a plain insert. The counter tracks manifests that truly changed.
-		wrote, scanned, err := putFileChunkRefs(ctx, tx.tx, file.ID, file.Blocks, updated, file.BlocksDirtyOffsets)
+		wrote, scanned, err := putFileChunkRefs(ctx, tx.tx, file.ID, file.Blocks, updated, file.ManifestDirtyOffsets)
 		tx.store.manifestRowsScanned.Add(int64(scanned))
 		if err != nil {
-			return mapDBError(err, "PutFile", "blocks")
+			return mapDBError(err, "SetManifest", "blocks")
 		}
 		if wrote {
 			tx.store.manifestWrites.Add(1)

--- a/pkg/metadata/store/sqlite/write_throughput_bench_test.go
+++ b/pkg/metadata/store/sqlite/write_throughput_bench_test.go
@@ -18,7 +18,7 @@ import (
 // a 4k random write: ONE SQLiteMetadataStore (MaxOpenConns(1)) driven by many
 // concurrent protocol writers. Each op is the metadata cost the runtime pays
 // per data write — a read-modify-write of the inode row: GetFile (SELECT) then
-// PutFile (full-row UPDATE), inside one WithTransaction (BeginTx + Commit, a WAL
+// UpdateAttrs (full-row UPDATE), inside one WithTransaction (BeginTx + Commit, a WAL
 // frame, no fsync under WAL+synchronous=NORMAL).
 //
 // With a single connection the concurrent writers do not collide at the SQLite
@@ -53,7 +53,7 @@ func BenchmarkWriteThroughput(b *testing.B) {
 					return err
 				}
 				f.Mtime = time.Now()
-				return tx.PutFile(ctx, f)
+				return tx.UpdateAttrs(ctx, f)
 			}); err != nil {
 				b.Fatalf("write txn: %v", err)
 			}
@@ -101,7 +101,7 @@ func BenchmarkWriteThroughputBatched(b *testing.B) {
 							return err
 						}
 						f.Mtime = time.Now()
-						if err := tx.PutFile(ctx, f); err != nil {
+						if err := tx.UpdateAttrs(ctx, f); err != nil {
 							return err
 						}
 					}
@@ -165,8 +165,8 @@ func BenchmarkWriteThroughputScattered(b *testing.B) {
 			ShareName: share, Path: fullPath, ID: id,
 			FileAttr: metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644, UID: 1000, GID: 1000},
 		}
-		if err := store.PutFile(ctx, f); err != nil {
-			b.Fatalf("PutFile seed: %v", err)
+		if err := store.UpdateAttrs(ctx, f); err != nil {
+			b.Fatalf("UpdateAttrs seed: %v", err)
 		}
 		if err := store.SetParent(ctx, h, rootHandle); err != nil {
 			b.Fatalf("SetParent: %v", err)
@@ -189,7 +189,7 @@ func BenchmarkWriteThroughputScattered(b *testing.B) {
 					return err
 				}
 				f.Mtime = time.Now()
-				return tx.PutFile(ctx, f)
+				return tx.UpdateAttrs(ctx, f)
 			}); err != nil {
 				b.Fatalf("write txn: %v", err)
 			}

--- a/pkg/metadata/storetest/acl_aliasing.go
+++ b/pkg/metadata/storetest/acl_aliasing.go
@@ -8,7 +8,7 @@ import (
 )
 
 // runACLAliasingTests asserts that backends deep-copy FileAttr.ACL on both the
-// store-from-caller (PutFile) and return-to-caller (GetFile) paths, so neither
+// store-from-caller (UpdateAttrs) and return-to-caller (GetFile) paths, so neither
 // side can corrupt the other's view by mutating an ACE in place.
 //
 // This pins the cross-backend parity gap the area-6 audit found: the memory
@@ -23,7 +23,7 @@ func runACLAliasingTests(t *testing.T, factory StoreFactory) {
 
 // putFileWithACL creates a regular file carrying the supplied ACL and returns
 // its handle. The caller retains ownership of acl (it is set on the File passed
-// to PutFile) so tests can mutate it afterwards to probe for aliasing.
+// to UpdateAttrs) so tests can mutate it afterwards to probe for aliasing.
 func putFileWithACL(t *testing.T, store metadata.Store, handle metadata.FileHandle, a *acl.ACL) {
 	t.Helper()
 
@@ -33,8 +33,8 @@ func putFileWithACL(t *testing.T, store metadata.Store, handle metadata.FileHand
 		t.Fatalf("GetFile: %v", err)
 	}
 	file.ACL = a
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile with ACL: %v", err)
+	if err := store.UpdateAttrs(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs with ACL: %v", err)
 	}
 }
 
@@ -51,7 +51,7 @@ func newTestACL() *acl.ACL {
 	}
 }
 
-// testPutDoesNotAliasCallerACL: PutFile a file with a non-empty ACL, then mutate
+// testPutDoesNotAliasCallerACL: UpdateAttrs a file with a non-empty ACL, then mutate
 // the caller's ACE slice in place; re-GetFile must return the ORIGINAL ACL.
 // If the store aliased the caller's slice, the in-place edit would leak into
 // the stored row.
@@ -73,7 +73,7 @@ func testPutDoesNotAliasCallerACL(t *testing.T, factory StoreFactory) {
 		t.Fatalf("GetFile: %v", err)
 	}
 	if got.ACL == nil {
-		t.Fatalf("stored ACL is nil after PutFile")
+		t.Fatalf("stored ACL is nil after UpdateAttrs")
 	}
 	if len(got.ACL.ACEs) != 1 {
 		t.Fatalf("expected 1 stored ACE, got %d", len(got.ACL.ACEs))

--- a/pkg/metadata/storetest/blockref_roundtrip.go
+++ b/pkg/metadata/storetest/blockref_roundtrip.go
@@ -32,7 +32,7 @@ type FileChunkRefsAccessor interface {
 // automatically runs them against Memory, Badger, and Postgres.
 //
 // Every metadata backend MUST round-trip FileAttr.Blocks across
-// PutFile/GetFile (including replace and nil semantics). Postgres
+// UpdateAttrs/GetFile (including replace and nil semantics). Postgres
 // additionally exercises the FK ON DELETE CASCADE behavior.
 func runChunkRefOpsTests(t *testing.T, factory StoreFactory) {
 	t.Helper()
@@ -59,7 +59,7 @@ func runChunkRefOpsTests(t *testing.T, factory StoreFactory) {
 }
 
 // testChunkRef_MultiPassMerge guards the store-layer contract that a file's
-// complete block list survives successive PutFile calls — both an append
+// complete block list survives successive UpdateAttrs calls — both an append
 // (A then A+B) and an in-place overlay of an existing offset (A'). GetFile
 // and WriteSnapshot must return the full, correct set after each pass; no earlier
 // offset may be dropped.
@@ -68,7 +68,7 @@ func runChunkRefOpsTests(t *testing.T, factory StoreFactory) {
 // across several passes. A regression that persisted only the latest pass's
 // refs (REPLACE-by-partial-list) instead of the complete merged list would
 // silently drop earlier offsets — exactly the data-loss class this asserts
-// against. The contract is: whatever complete list the caller hands PutFile,
+// against. The contract is: whatever complete list the caller hands UpdateAttrs,
 // GetFile/WriteSnapshot return it intact and ordered by offset.
 func testChunkRef_MultiPassMerge(t *testing.T, factory StoreFactory) {
 	store := factory(t)
@@ -124,9 +124,8 @@ func putBlocks(t *testing.T, store metadata.Store, fileHandle metadata.FileHandl
 		t.Fatalf("GetFile (pre-put): %v", err)
 	}
 	file.Blocks = blocks
-	file.BlocksDirty = true
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile (%d blocks): %v", len(blocks), err)
+	if err := store.SetManifest(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs (%d blocks): %v", len(blocks), err)
 	}
 }
 
@@ -183,7 +182,7 @@ func assertSnapshotContains(t *testing.T, store metadata.Store, want []block.Chu
 }
 
 // testChunkRef_RoundTripBasic asserts that a file with three sorted-by-offset
-// ChunkRefs survives a PutFile/GetFile round-trip with deep equality on every
+// ChunkRefs survives a UpdateAttrs/GetFile round-trip with deep equality on every
 // field of every ChunkRef. Catches encoding drift between backends.
 func testChunkRef_RoundTripBasic(t *testing.T, factory StoreFactory) {
 	store := factory(t)
@@ -203,9 +202,8 @@ func testChunkRef_RoundTripBasic(t *testing.T, factory StoreFactory) {
 		t.Fatalf("GetFile (pre-put): %v", err)
 	}
 	file.Blocks = blocks
-	file.BlocksDirty = true
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile: %v", err)
+	if err := store.SetManifest(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs: %v", err)
 	}
 
 	got, err := store.GetFile(ctx, fileHandle)
@@ -250,12 +248,11 @@ func testChunkRef_NilBlocks(t *testing.T, factory StoreFactory) {
 		t.Errorf("Blocks len: got %d, want 0 (nil-Blocks file)", len(got.Blocks))
 	}
 
-	// Now explicitly set Blocks to nil and PutFile; round-trip should
+	// Now explicitly set Blocks to nil and UpdateAttrs; round-trip should
 	// remain empty.
 	got.Blocks = nil
-	got.BlocksDirty = true // drop to nil must run the manifest DELETE
-	if err := store.PutFile(ctx, got); err != nil {
-		t.Fatalf("PutFile (nil Blocks): %v", err)
+	if err := store.SetManifest(ctx, got); err != nil {
+		t.Fatalf("UpdateAttrs (nil Blocks): %v", err)
 	}
 
 	got2, err := store.GetFile(ctx, fileHandle)
@@ -263,12 +260,12 @@ func testChunkRef_NilBlocks(t *testing.T, factory StoreFactory) {
 		t.Fatalf("GetFile (post-nil-put): %v", err)
 	}
 	if len(got2.Blocks) != 0 {
-		t.Errorf("Blocks len after nil PutFile: got %d, want 0", len(got2.Blocks))
+		t.Errorf("Blocks len after nil UpdateAttrs: got %d, want 0", len(got2.Blocks))
 	}
 }
 
-// testChunkRef_ReplaceBlocks asserts that PutFile fully replaces the
-// previous ChunkRefs list — no leftover rows from prior PutFile calls.
+// testChunkRef_ReplaceBlocks asserts that UpdateAttrs fully replaces the
+// previous ChunkRefs list — no leftover rows from prior UpdateAttrs calls.
 // The Postgres backend implements this via DELETE+INSERT in the same tx;
 // Memory and Badger replace the slice trivially (single-blob encoding).
 func testChunkRef_ReplaceBlocks(t *testing.T, factory StoreFactory) {
@@ -278,7 +275,7 @@ func testChunkRef_ReplaceBlocks(t *testing.T, factory StoreFactory) {
 	rootHandle := createTestShare(t, store, "blockref-replace")
 	fileHandle := createTestFile(t, store, "blockref-replace", rootHandle, "replace.bin", 0o644)
 
-	// Initial PutFile with 5 blocks.
+	// Initial UpdateAttrs with 5 blocks.
 	five := []block.ChunkRef{
 		{Hash: hashOfSeed("rep-0"), Offset: 0, Size: 1 << 20},
 		{Hash: hashOfSeed("rep-1"), Offset: 1 << 20, Size: 1 << 20},
@@ -291,9 +288,8 @@ func testChunkRef_ReplaceBlocks(t *testing.T, factory StoreFactory) {
 		t.Fatalf("GetFile (pre 5): %v", err)
 	}
 	file.Blocks = five
-	file.BlocksDirty = true
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile (5 blocks): %v", err)
+	if err := store.SetManifest(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs (5 blocks): %v", err)
 	}
 
 	got5, err := store.GetFile(ctx, fileHandle)
@@ -305,16 +301,15 @@ func testChunkRef_ReplaceBlocks(t *testing.T, factory StoreFactory) {
 	}
 
 	// Replace with 2 different blocks at different offsets. After the
-	// second PutFile the GetFile must return exactly the new 2 — no
+	// second UpdateAttrs the GetFile must return exactly the new 2 — no
 	// leftover rows from the prior list.
 	two := []block.ChunkRef{
 		{Hash: hashOfSeed("rep-X"), Offset: 0, Size: 2 << 20},
 		{Hash: hashOfSeed("rep-Y"), Offset: 2 << 20, Size: 2 << 20},
 	}
 	got5.Blocks = two
-	got5.BlocksDirty = true
-	if err := store.PutFile(ctx, got5); err != nil {
-		t.Fatalf("PutFile (2 blocks replace): %v", err)
+	if err := store.SetManifest(ctx, got5); err != nil {
+		t.Fatalf("UpdateAttrs (2 blocks replace): %v", err)
 	}
 
 	got2, err := store.GetFile(ctx, fileHandle)
@@ -360,9 +355,8 @@ func testChunkRef_CascadeDeleteOnFileDelete(t *testing.T, factory StoreFactory) 
 		t.Fatalf("GetFile: %v", err)
 	}
 	file.Blocks = blocks
-	file.BlocksDirty = true
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile: %v", err)
+	if err := store.SetManifest(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs: %v", err)
 	}
 
 	// Capture the underlying file ID from the handle for direct row counting.

--- a/pkg/metadata/storetest/dir_ops.go
+++ b/pkg/metadata/storetest/dir_ops.go
@@ -130,8 +130,8 @@ func testListDirectoryHydratesACL(t *testing.T, factory StoreFactory) {
 			},
 		},
 	}
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile with ACL: %v", err)
+	if err := store.UpdateAttrs(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs with ACL: %v", err)
 	}
 
 	entries, _, err := store.ListChildren(ctx, rootHandle, "", 100)
@@ -342,8 +342,8 @@ func testLinkCountAgreesWithGetFile(t *testing.T, factory StoreFactory) {
 				},
 			}
 			entry.ID = id
-			if err := store.PutFile(ctx, entry); err != nil {
-				t.Fatalf("PutFile() failed: %v", err)
+			if err := store.UpdateAttrs(ctx, entry); err != nil {
+				t.Fatalf("UpdateAttrs() failed: %v", err)
 			}
 			// Both namespace edges, so the only thing left unset is the link
 			// count. Backends that derive File.Path from parent edges otherwise

--- a/pkg/metadata/storetest/ea_ops.go
+++ b/pkg/metadata/storetest/ea_ops.go
@@ -7,7 +7,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// runEAOpsTests asserts cross-backend parity for FileAttr.EAs: PutFile/GetFile
+// runEAOpsTests asserts cross-backend parity for FileAttr.EAs: UpdateAttrs/GetFile
 // round-trip of an EA map, case-insensitive name resolution with set-case
 // preservation, zero-length values, deletion, persistence across reads, and
 // deep-copy (aliasing) discipline on both the store-from-caller and
@@ -80,8 +80,8 @@ func putFileWithEAs(t *testing.T, store metadata.Store, handle metadata.FileHand
 		t.Fatalf("GetFile: %v", err)
 	}
 	file.EAs = eas
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile with EAs: %v", err)
+	if err := store.UpdateAttrs(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs with EAs: %v", err)
 	}
 }
 
@@ -258,8 +258,8 @@ func testEAPersistsAcrossReads(t *testing.T, factory StoreFactory) {
 		t.Fatalf("GetFile: %v", err)
 	}
 	file.Size = 4096
-	if err := store.PutFile(t.Context(), file); err != nil {
-		t.Fatalf("PutFile: %v", err)
+	if err := store.UpdateAttrs(t.Context(), file); err != nil {
+		t.Fatalf("UpdateAttrs: %v", err)
 	}
 
 	got := getEAs(t, store, handle)

--- a/pkg/metadata/storetest/file_block_ops.go
+++ b/pkg/metadata/storetest/file_block_ops.go
@@ -1915,8 +1915,8 @@ func testEnumerateLivePayloadIDs(t *testing.T, factory StoreFactory) {
 		t.Fatalf("GetFile: %v", err)
 	}
 	f.PayloadID = metadata.PayloadID(livePID)
-	if err := store.PutFile(ctx, f); err != nil {
-		t.Fatalf("PutFile (set payload): %v", err)
+	if err := store.UpdateAttrs(ctx, f); err != nil {
+		t.Fatalf("UpdateAttrs (set payload): %v", err)
 	}
 	seedStrandedBlocks(t, ctx, store, livePID, 2)
 
@@ -1994,10 +1994,9 @@ func testEnumerateFileChunks_UnlinkedFileExcludesManifest(t *testing.T, factory 
 		t.Fatalf("GetFile: %v", err)
 	}
 	f.Blocks = []block.ChunkRef{{Hash: want, Offset: 0, Size: 4 << 20}}
-	f.BlocksDirty = true
 	f.Size = 4 << 20
-	if err := store.PutFile(ctx, f); err != nil {
-		t.Fatalf("PutFile (linked): %v", err)
+	if err := store.SetManifest(ctx, f); err != nil {
+		t.Fatalf("UpdateAttrs (linked): %v", err)
 	}
 	if !enumerateContains(t, store, want) {
 		t.Fatalf("baseline: hash %s absent from live set while nlink>0", want)
@@ -2007,7 +2006,7 @@ func testEnumerateFileChunks_UnlinkedFileExcludesManifest(t *testing.T, factory 
 	// link). The embedded File.Nlink is not the authoritative link count (#1166):
 	// SetLinkCount is the only API that updates the source of truth (SQL
 	// inodes.nlink, badger l: key, memory linkCounts), so it is the faithful
-	// simulation — mutating File.Nlink + PutFile would not move it.
+	// simulation — mutating File.Nlink + UpdateAttrs would not move it.
 	if err := store.DeleteChild(ctx, root, "dead.bin"); err != nil {
 		t.Fatalf("DeleteChild: %v", err)
 	}
@@ -2036,10 +2035,9 @@ func testEnumerateFileChunks_HardLinkSurvivesOneRemoval(t *testing.T, factory St
 		t.Fatalf("GetFile: %v", err)
 	}
 	f.Blocks = []block.ChunkRef{{Hash: want, Offset: 0, Size: 4 << 20}}
-	f.BlocksDirty = true
 	f.Size = 4 << 20
-	if err := store.PutFile(ctx, f); err != nil {
-		t.Fatalf("PutFile: %v", err)
+	if err := store.SetManifest(ctx, f); err != nil {
+		t.Fatalf("UpdateAttrs: %v", err)
 	}
 	// Two hard links.
 	if err := store.SetLinkCount(ctx, h, 2); err != nil {
@@ -2075,8 +2073,8 @@ func testEnumerateLivePayloadIDs_ExcludesNlinkZero(t *testing.T, factory StoreFa
 		t.Fatalf("GetFile: %v", err)
 	}
 	f.PayloadID = payloadID
-	if err := store.PutFile(ctx, f); err != nil {
-		t.Fatalf("PutFile (linked): %v", err)
+	if err := store.UpdateAttrs(ctx, f); err != nil {
+		t.Fatalf("UpdateAttrs (linked): %v", err)
 	}
 	if !livePayloadContains(t, store, payloadID) {
 		t.Fatalf("baseline: payload %s absent from live payloads while nlink>0", payloadID)

--- a/pkg/metadata/storetest/file_ops.go
+++ b/pkg/metadata/storetest/file_ops.go
@@ -37,7 +37,7 @@ func runFileOpsTests(t *testing.T, factory StoreFactory) {
 }
 
 // testTimestampPrecision verifies file timestamps round-trip with full
-// nanosecond (sub-microsecond) fidelity through PutFile/GetFile on every
+// nanosecond (sub-microsecond) fidelity through UpdateAttrs/GetFile on every
 // backend. SMB FILETIME carries 100ns granularity; a backend that truncates to
 // microseconds (the postgres TIMESTAMPTZ default) returns a different FILETIME
 // on QUERY than was set, failing WPTS BVT_SMB2Basic_QueryAndSet_FileInfo
@@ -67,8 +67,8 @@ func testTimestampPrecision(t *testing.T, factory StoreFactory) {
 	file.Ctime = ctime
 	file.CreationTime = creation
 
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile() failed: %v", err)
+	if err := store.UpdateAttrs(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs() failed: %v", err)
 	}
 
 	got, err := store.GetFile(ctx, handle)
@@ -89,7 +89,7 @@ func testTimestampPrecision(t *testing.T, factory StoreFactory) {
 }
 
 // testHighModeBits verifies a file mode carrying high bits above the POSIX
-// permission range round-trips through PutFile/GetFile on every backend. The
+// permission range round-trips through UpdateAttrs/GetFile on every backend. The
 // SMB adapter stores DOS attributes (e.g. modeDOSExplicit = 0x10000) in high
 // mode bits; a backend that range-checks mode to <= 0o7777 rejects a SET_INFO
 // FILE_BASIC_INFORMATION with attributes as STATUS_INVALID_PARAMETER, failing
@@ -109,8 +109,8 @@ func testHighModeBits(t *testing.T, factory StoreFactory) {
 	// SMBModeFromAttrs produces for a SET_INFO with FileAttributes.
 	const highMode = uint32(0x10000 | 0o644)
 	file.Mode = highMode
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile() with high mode bits 0x%X failed: %v", highMode, err)
+	if err := store.UpdateAttrs(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs() with high mode bits 0x%X failed: %v", highMode, err)
 	}
 
 	got, err := store.GetFile(ctx, handle)
@@ -427,8 +427,8 @@ func testContentIdStableAcrossRename(t *testing.T, factory StoreFactory) {
 	}
 	const payloadID = metadata.PayloadID("test/blob-content-id")
 	file.PayloadID = payloadID
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile() with PayloadID failed: %v", err)
+	if err := store.UpdateAttrs(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs() with PayloadID failed: %v", err)
 	}
 
 	// Rename across directories: drop the old edge, add a new one under root.
@@ -497,8 +497,8 @@ func testHardLinkUnlinkFirstNameKeepsInode(t *testing.T, factory StoreFactory) {
 		t.Fatalf("GetFile() failed: %v", err)
 	}
 	file.Size = 4096
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile() failed: %v", err)
+	if err := store.UpdateAttrs(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs() failed: %v", err)
 	}
 
 	// Unlink A: drop its edge and decrement nlink to 1.
@@ -818,8 +818,8 @@ func testSetFileAttributes(t *testing.T, factory StoreFactory) {
 	file.UID = 2000
 	file.Size = 1024
 
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile() with updated attrs failed: %v", err)
+	if err := store.UpdateAttrs(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs() with updated attrs failed: %v", err)
 	}
 
 	// Verify changes

--- a/pkg/metadata/storetest/inv02_durable_regression_test.go
+++ b/pkg/metadata/storetest/inv02_durable_regression_test.go
@@ -83,8 +83,8 @@ func TestReconcileINV02_DuplicateHashRowsVisible(t *testing.T) {
 			PayloadID: metadata.PayloadID(payloadID),
 		},
 	}
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile: %v", err)
+	if err := store.UpdateAttrs(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs: %v", err)
 	}
 	if err := store.SetParent(ctx, handle, rootHandle); err != nil {
 		t.Fatalf("SetParent: %v", err)

--- a/pkg/metadata/storetest/inv02_fuzz.go
+++ b/pkg/metadata/storetest/inv02_fuzz.go
@@ -297,20 +297,19 @@ func fuzzCreateFile(ctx context.Context, store metadata.Store, shareName string,
 		ShareName: shareName,
 		Path:      "/" + name,
 		FileAttr: metadata.FileAttr{
-			Type:        metadata.FileTypeRegular,
-			Mode:        0o644,
-			UID:         1000,
-			GID:         1000,
-			Mtime:       now,
-			Ctime:       now,
-			Atime:       now,
-			Blocks:      refs,
-			BlocksDirty: true,
-			PayloadID:   metadata.PayloadID(payloadID),
+			Type:      metadata.FileTypeRegular,
+			Mode:      0o644,
+			UID:       1000,
+			GID:       1000,
+			Mtime:     now,
+			Ctime:     now,
+			Atime:     now,
+			Blocks:    refs,
+			PayloadID: metadata.PayloadID(payloadID),
 		},
 	}
-	if err := store.PutFile(ctx, file); err != nil {
-		return fmt.Errorf("PutFile: %w", err)
+	if err := store.SetManifest(ctx, file); err != nil {
+		return fmt.Errorf("UpdateAttrs: %w", err)
 	}
 	if err := store.SetParent(ctx, handle, rootHandle); err != nil {
 		return fmt.Errorf("SetParent: %w", err)
@@ -410,20 +409,19 @@ func fuzzCopyFile(ctx context.Context, store metadata.Store, shareName string, r
 		ShareName: shareName,
 		Path:      "/" + name,
 		FileAttr: metadata.FileAttr{
-			Type:        metadata.FileTypeRegular,
-			Mode:        0o644,
-			UID:         1000,
-			GID:         1000,
-			Mtime:       now,
-			Ctime:       now,
-			Atime:       now,
-			Blocks:      srcBlocks,
-			BlocksDirty: true,
-			PayloadID:   metadata.PayloadID(src.payloadID),
+			Type:      metadata.FileTypeRegular,
+			Mode:      0o644,
+			UID:       1000,
+			GID:       1000,
+			Mtime:     now,
+			Ctime:     now,
+			Atime:     now,
+			Blocks:    srcBlocks,
+			PayloadID: metadata.PayloadID(src.payloadID),
 		},
 	}
-	if err := store.PutFile(ctx, dst); err != nil {
-		return fmt.Errorf("PutFile copy: %w", err)
+	if err := store.SetManifest(ctx, dst); err != nil {
+		return fmt.Errorf("UpdateAttrs copy: %w", err)
 	}
 	if err := store.SetParent(ctx, handle, rootHandle); err != nil {
 		return fmt.Errorf("SetParent copy: %w", err)
@@ -444,7 +442,7 @@ func fuzzCopyFile(ctx context.Context, store metadata.Store, shareName string, r
 }
 
 // fuzzMutateObjectID picks a random file owned by this worker, recomputes
-// its ObjectID from the current Blocks slice, and PutFile-s the result so
+// its ObjectID from the current Blocks slice, and UpdateAttrs-s the result so
 // the secondary index gets refreshed. Mirrors the engine's post-Flush
 // coordinator hook at the storetest level — independent of any
 // engine wiring, but exercising the SAME index discipline.
@@ -474,20 +472,20 @@ func fuzzMutateObjectID(ctx context.Context, store metadata.Store, rng *rand.Ran
 	}
 
 	f.ObjectID = block.ComputeObjectID(f.Blocks)
-	if err := store.PutFile(ctx, f); err != nil {
+	if err := store.UpdateAttrs(ctx, f); err != nil {
 		// first-committer-wins: another worker may have claimed
 		// the same ObjectID (improbable for distinct seed-derived
 		// hashes, but legal). Treat as non-fatal.
 		if isConcurrentQuiesceConflict(err) {
 			return nil
 		}
-		return fmt.Errorf("PutFile: %w", err)
+		return fmt.Errorf("UpdateAttrs: %w", err)
 	}
 	return nil
 }
 
 // isConcurrentQuiesceConflict returns true for the per-backend conflict
-// signals surfaced by first-committer-wins on PutFile. Mirrors the
+// signals surfaced by first-committer-wins on UpdateAttrs. Mirrors the
 // concurrentRaceErrIsConflict helper in objectid_roundtrip.go.
 func isConcurrentQuiesceConflict(err error) bool {
 	if err == nil {

--- a/pkg/metadata/storetest/objectid_lookup.go
+++ b/pkg/metadata/storetest/objectid_lookup.go
@@ -34,7 +34,7 @@ func testObjectID_FindByObjectID(t *testing.T, factory StoreFactory) {
 		t.Fatalf("fixture broken: distinct block fixtures produced equal ObjectID %s", oidA.String())
 	}
 
-	// PutFile A + B with their respective ObjectIDs.
+	// UpdateAttrs A + B with their respective ObjectIDs.
 	for _, pair := range []struct {
 		handle metadata.FileHandle
 		blocks []block.ChunkRef
@@ -49,10 +49,9 @@ func testObjectID_FindByObjectID(t *testing.T, factory StoreFactory) {
 			t.Fatalf("GetFile %s: %v", pair.label, err)
 		}
 		f.Blocks = pair.blocks
-		f.BlocksDirty = true
 		f.ObjectID = pair.oid
-		if err := store.PutFile(ctx, f); err != nil {
-			t.Fatalf("PutFile %s: %v", pair.label, err)
+		if err := store.SetManifest(ctx, f); err != nil {
+			t.Fatalf("UpdateAttrs %s: %v", pair.label, err)
 		}
 	}
 
@@ -100,7 +99,7 @@ func testObjectID_FindByObjectID(t *testing.T, factory StoreFactory) {
 //
 // The factory contract creates a fresh store per call (suite.go), so we
 // cannot literally close+reopen the same backing path here; the
-// recompute-after-PutFile-GetFile cycle is the closest equivalent that
+// recompute-after-UpdateAttrs-GetFile cycle is the closest equivalent that
 // runs uniformly across all three backends. Conformance harnesses that
 // specifically exercise close+reopen live in the per-backend integration
 // tests.
@@ -123,10 +122,9 @@ func testObjectID_RestartStability(t *testing.T, factory StoreFactory) {
 		t.Fatalf("GetFile (pre-put): %v", err)
 	}
 	file.Blocks = blocks
-	file.BlocksDirty = true
 	file.ObjectID = wantOID
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile: %v", err)
+	if err := store.SetManifest(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs: %v", err)
 	}
 
 	got, err := store.GetFile(ctx, fileHandle)
@@ -143,7 +141,7 @@ func testObjectID_RestartStability(t *testing.T, factory StoreFactory) {
 			recomputed.String(), wantOID.String())
 	}
 
-	// FindByObjectID resolves the same Blocks that PutFile stored.
+	// FindByObjectID resolves the same Blocks that UpdateAttrs stored.
 	refs, err := store.FindByObjectID(ctx, wantOID)
 	if err != nil {
 		t.Fatalf("FindByObjectID: %v", err)
@@ -159,7 +157,7 @@ func testObjectID_RestartStability(t *testing.T, factory StoreFactory) {
 }
 
 // testObjectID_ConcurrentQuiesceRace asserts first-committer-wins
-// semantics: two PutFile calls racing to claim the SAME ObjectID for
+// semantics: two UpdateAttrs calls racing to claim the SAME ObjectID for
 // DIFFERENT files settle so exactly one survives in the secondary index.
 //
 // Detection is per-backend (Memory/Badger surface ErrConflict; Postgres
@@ -184,7 +182,7 @@ func testObjectID_ConcurrentQuiesceRace(t *testing.T, factory StoreFactory) {
 	})
 
 	// Pre-load each file with its current state from the store and stage
-	// the contested ObjectID. Use distinct Blocks so each file's PutFile
+	// the contested ObjectID. Use distinct Blocks so each file's UpdateAttrs
 	// updates a unique row but both attempt to claim `contested`.
 	loadAndStage := func(handle metadata.FileHandle, seed string) *metadata.File {
 		f, err := store.GetFile(ctx, handle)
@@ -194,7 +192,6 @@ func testObjectID_ConcurrentQuiesceRace(t *testing.T, factory StoreFactory) {
 		f.Blocks = []block.ChunkRef{
 			{Hash: hashOfSeed(seed), Offset: 0, Size: 4096},
 		}
-		f.BlocksDirty = true
 		f.ObjectID = contested
 		return f
 	}
@@ -274,7 +271,7 @@ func testObjectID_CrossShareDedupScope(t *testing.T, factory StoreFactory) {
 		t.Fatalf("fixture broken: distinct block fixtures produced equal ObjectID %s", oidA.String())
 	}
 
-	// PutFile each share's file with its respective ObjectID.
+	// UpdateAttrs each share's file with its respective ObjectID.
 	for _, pair := range []struct {
 		handle metadata.FileHandle
 		blocks []block.ChunkRef
@@ -289,10 +286,9 @@ func testObjectID_CrossShareDedupScope(t *testing.T, factory StoreFactory) {
 			t.Fatalf("GetFile %s: %v", pair.label, err)
 		}
 		f.Blocks = pair.blocks
-		f.BlocksDirty = true
 		f.ObjectID = pair.oid
-		if err := store.PutFile(ctx, f); err != nil {
-			t.Fatalf("PutFile %s: %v", pair.label, err)
+		if err := store.SetManifest(ctx, f); err != nil {
+			t.Fatalf("UpdateAttrs %s: %v", pair.label, err)
 		}
 	}
 

--- a/pkg/metadata/storetest/objectid_roundtrip.go
+++ b/pkg/metadata/storetest/objectid_roundtrip.go
@@ -51,7 +51,7 @@ func runObjectIDOpsTests(t *testing.T, factory StoreFactory) {
 }
 
 // testObjectID_RoundTripBasic asserts that a non-zero ObjectID computed over
-// three sorted-by-offset ChunkRefs survives a PutFile/GetFile round-trip
+// three sorted-by-offset ChunkRefs survives a UpdateAttrs/GetFile round-trip
 // with byte-equal payload. Catches encoding drift between backends.
 func testObjectID_RoundTripBasic(t *testing.T, factory StoreFactory) {
 	store := factory(t)
@@ -75,10 +75,9 @@ func testObjectID_RoundTripBasic(t *testing.T, factory StoreFactory) {
 		t.Fatalf("GetFile (pre-put): %v", err)
 	}
 	file.Blocks = blocks
-	file.BlocksDirty = true
 	file.ObjectID = wantOID
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile: %v", err)
+	if err := store.SetManifest(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs: %v", err)
 	}
 
 	got, err := store.GetFile(ctx, fileHandle)
@@ -92,7 +91,7 @@ func testObjectID_RoundTripBasic(t *testing.T, factory StoreFactory) {
 }
 
 // testObjectID_ZeroSentinel asserts that the all-zero ObjectID sentinel is
-// accepted on PutFile and read back as zero, and that FindByObjectID with
+// accepted on UpdateAttrs and read back as zero, and that FindByObjectID with
 // a zero argument short-circuits to (nil, nil) without backend access
 // (partial/skip-zero discipline).
 func testObjectID_ZeroSentinel(t *testing.T, factory StoreFactory) {
@@ -113,19 +112,18 @@ func testObjectID_ZeroSentinel(t *testing.T, factory StoreFactory) {
 			got.ObjectID.String())
 	}
 
-	// Explicit PutFile with the zero sentinel.
+	// Explicit UpdateAttrs with the zero sentinel.
 	got.Blocks = nil
-	got.BlocksDirty = true // zero-case: persist the emptied manifest
 	got.ObjectID = block.ObjectID{}
-	if err := store.PutFile(ctx, got); err != nil {
-		t.Fatalf("PutFile (zero ObjectID): %v", err)
+	if err := store.SetManifest(ctx, got); err != nil {
+		t.Fatalf("UpdateAttrs (zero ObjectID): %v", err)
 	}
 	got2, err := store.GetFile(ctx, fileHandle)
 	if err != nil {
 		t.Fatalf("GetFile (post-zero-put): %v", err)
 	}
 	if !got2.ObjectID.IsZero() {
-		t.Errorf("ObjectID after zero PutFile: got %s, want zero",
+		t.Errorf("ObjectID after zero UpdateAttrs: got %s, want zero",
 			got2.ObjectID.String())
 	}
 
@@ -161,10 +159,9 @@ func testObjectID_MutationLifecycle(t *testing.T, factory StoreFactory) {
 		t.Fatalf("GetFile: %v", err)
 	}
 	file.Blocks = blocks
-	file.BlocksDirty = true
 	file.ObjectID = wantOID
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile (quiesced): %v", err)
+	if err := store.SetManifest(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs (quiesced): %v", err)
 	}
 
 	// Pre-mutation: index lookup hits.
@@ -183,8 +180,8 @@ func testObjectID_MutationLifecycle(t *testing.T, factory StoreFactory) {
 		t.Fatalf("GetFile (pre-mutate): %v", err)
 	}
 	mutated.ObjectID = block.ObjectID{}
-	if err := store.PutFile(ctx, mutated); err != nil {
-		t.Fatalf("PutFile (mutation): %v", err)
+	if err := store.UpdateAttrs(ctx, mutated); err != nil {
+		t.Fatalf("UpdateAttrs (mutation): %v", err)
 	}
 
 	// Post-mutation: index lookup MUST miss.
@@ -209,7 +206,7 @@ func testObjectID_MutationLifecycle(t *testing.T, factory StoreFactory) {
 
 // testObjectID_SortStability asserts ComputeObjectID determinism (two
 // independent calls over the same sorted ChunkRef list yield byte-equal
-// ObjectIDs) and survives a PutFile/GetFile/recompute cycle.
+// ObjectIDs) and survives a UpdateAttrs/GetFile/recompute cycle.
 func testObjectID_SortStability(t *testing.T, factory StoreFactory) {
 	store := factory(t)
 	ctx := t.Context()
@@ -240,10 +237,9 @@ func testObjectID_SortStability(t *testing.T, factory StoreFactory) {
 		t.Fatalf("GetFile: %v", err)
 	}
 	file.Blocks = blocks
-	file.BlocksDirty = true
 	file.ObjectID = a
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile: %v", err)
+	if err := store.SetManifest(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs: %v", err)
 	}
 
 	got, err := store.GetFile(ctx, fileHandle)
@@ -280,7 +276,7 @@ func concurrentRaceErrIsConflict(err error) bool {
 	return false
 }
 
-// raceWorkerResult captures one goroutine's PutFile outcome for the
+// raceWorkerResult captures one goroutine's UpdateAttrs outcome for the
 // ConcurrentQuiesceRace scenario. Used by both objectid_roundtrip.go and
 // objectid_lookup.go via the shared runner below.
 type raceWorkerResult struct {
@@ -288,7 +284,7 @@ type raceWorkerResult struct {
 	err error
 }
 
-// runConcurrentQuiesceRace launches two goroutines that each PutFile a
+// runConcurrentQuiesceRace launches two goroutines that each SetManifest a
 // distinct file but with the same target ObjectID. Returns both worker
 // outcomes once both goroutines complete. The barrier (`start`) ensures
 // they race rather than serialize.
@@ -305,7 +301,7 @@ func runConcurrentQuiesceRace(
 		go func(idx int) {
 			defer wg.Done()
 			<-start
-			results[idx].err = store.PutFile(ctx, files[idx])
+			results[idx].err = store.SetManifest(ctx, files[idx])
 		}(i)
 	}
 	close(start)

--- a/pkg/metadata/storetest/permissions.go
+++ b/pkg/metadata/storetest/permissions.go
@@ -82,8 +82,8 @@ func testDirectoryPermissionAttributes(t *testing.T, factory StoreFactory) {
 	}
 	dir.ID = id
 
-	if err := store.PutFile(ctx, dir); err != nil {
-		t.Fatalf("PutFile() failed: %v", err)
+	if err := store.UpdateAttrs(ctx, dir); err != nil {
+		t.Fatalf("UpdateAttrs() failed: %v", err)
 	}
 	if err := store.SetParent(ctx, handle, rootHandle); err != nil {
 		t.Fatalf("SetParent() failed: %v", err)

--- a/pkg/metadata/storetest/snapshot_conformance.go
+++ b/pkg/metadata/storetest/snapshot_conformance.go
@@ -129,7 +129,7 @@ func testSnapshot_UsageCountersAfterRestore(t *testing.T, factory SnapshotableSt
 // this change: the GC mark live set (EnumerateFileChunks) MUST be a SUPERSET of
 // the snapshot Snapshot HashSet (built from File.Blocks / file_block_refs). Before
 // EnumerateFileChunks unioned the manifest, a hash present only in the manifest
-// (the common case — populateTestData writes hashes via PutFile, never to the
+// (the common case — populateTestData writes hashes via UpdateAttrs, never to the
 // CAS index) was MISSED by the mark phase and the sweep would reap the still-
 // live remote chunk once a snapshot hold lapsed (data loss). After the union the
 // two sets are equal here; the assertion is the weaker superset to stay robust
@@ -192,10 +192,9 @@ func testSnapshot_LiveSetUnionsManifestNegativeControl(t *testing.T, factory Sna
 	// Manifest carries the hash; NO FileChunkStore.Put is issued, so the CAS
 	// index (file_blocks / fb: / fileChunkData.blocks) has no row for it.
 	f.Blocks = []block.ChunkRef{{Hash: manifestOnly, Offset: 0, Size: 4 << 20}}
-	f.BlocksDirty = true
 	f.Size = 4 << 20
-	if err := store.PutFile(ctx, f); err != nil {
-		t.Fatalf("PutFile: %v", err)
+	if err := store.SetManifest(ctx, f); err != nil {
+		t.Fatalf("UpdateAttrs: %v", err)
 	}
 
 	found := false
@@ -231,10 +230,9 @@ func testSnapshot_ExcludesUnlinkedFileChunks(t *testing.T, factory SnapshotableS
 		t.Fatalf("GetFile: %v", err)
 	}
 	f.Blocks = []block.ChunkRef{{Hash: dead, Offset: 0, Size: 4 << 20}}
-	f.BlocksDirty = true
 	f.Size = 4 << 20
-	if err := store.PutFile(ctx, f); err != nil {
-		t.Fatalf("PutFile: %v", err)
+	if err := store.SetManifest(ctx, f); err != nil {
+		t.Fatalf("UpdateAttrs: %v", err)
 	}
 
 	// Baseline: a live file's block IS in the manifest.
@@ -300,10 +298,9 @@ func populateTestData(t *testing.T, store metadata.Store, sharePrefix string) (s
 		{Hash: hashA0, Offset: 0, Size: 4 << 20},
 		{Hash: hashA1, Offset: 4 << 20, Size: 4 << 20},
 	}
-	fA.BlocksDirty = true
 	fA.Size = 8 << 20
-	if err := store.PutFile(ctx, fA); err != nil {
-		t.Fatalf("PutFile alpha: %v", err)
+	if err := store.SetManifest(ctx, fA); err != nil {
+		t.Fatalf("UpdateAttrs alpha: %v", err)
 	}
 
 	// File B: one unique hash + one shared with file A (hashA0 for dedup).
@@ -317,10 +314,9 @@ func populateTestData(t *testing.T, store metadata.Store, sharePrefix string) (s
 		{Hash: hashB0, Offset: 0, Size: 2 << 20},
 		{Hash: hashA0, Offset: 2 << 20, Size: 4 << 20}, // shared with alpha
 	}
-	fB.BlocksDirty = true
 	fB.Size = 6 << 20
-	if err := store.PutFile(ctx, fB); err != nil {
-		t.Fatalf("PutFile beta: %v", err)
+	if err := store.SetManifest(ctx, fB); err != nil {
+		t.Fatalf("UpdateAttrs beta: %v", err)
 	}
 
 	// Unique hashes: hashA0, hashA1, hashB0 (3 unique despite 4 block refs).
@@ -530,11 +526,10 @@ func testSnapshot_ConcurrentWriter(t *testing.T, factory SnapshotableStoreFactor
 				Blocks: []block.ChunkRef{
 					{Hash: concurrentHash, Offset: 0, Size: 1 << 20},
 				},
-				BlocksDirty: true,
 			},
 		}
 		f.ID = id
-		if err := store.PutFile(ctx, f); err != nil {
+		if err := store.SetManifest(ctx, f); err != nil {
 			concurrentErr = err
 			return
 		}
@@ -792,9 +787,8 @@ func testSnapshot_HashSet_ExactMatch(t *testing.T, factory SnapshotableStoreFact
 		{Hash: hashes[0], Offset: 0, Size: 1 << 20},
 		{Hash: hashes[1], Offset: 1 << 20, Size: 1 << 20},
 	}
-	f1.BlocksDirty = true
-	if err := store.PutFile(ctx, f1); err != nil {
-		t.Fatalf("PutFile f1: %v", err)
+	if err := store.SetManifest(ctx, f1); err != nil {
+		t.Fatalf("UpdateAttrs f1: %v", err)
 	}
 
 	// File 2: hashes[2], hashes[3]
@@ -807,9 +801,8 @@ func testSnapshot_HashSet_ExactMatch(t *testing.T, factory SnapshotableStoreFact
 		{Hash: hashes[2], Offset: 0, Size: 1 << 20},
 		{Hash: hashes[3], Offset: 1 << 20, Size: 1 << 20},
 	}
-	f2.BlocksDirty = true
-	if err := store.PutFile(ctx, f2); err != nil {
-		t.Fatalf("PutFile f2: %v", err)
+	if err := store.SetManifest(ctx, f2); err != nil {
+		t.Fatalf("UpdateAttrs f2: %v", err)
 	}
 
 	// File 3: hashes[4]
@@ -821,9 +814,8 @@ func testSnapshot_HashSet_ExactMatch(t *testing.T, factory SnapshotableStoreFact
 	f3.Blocks = []block.ChunkRef{
 		{Hash: hashes[4], Offset: 0, Size: 1 << 20},
 	}
-	f3.BlocksDirty = true
-	if err := store.PutFile(ctx, f3); err != nil {
-		t.Fatalf("PutFile f3: %v", err)
+	if err := store.SetManifest(ctx, f3); err != nil {
+		t.Fatalf("UpdateAttrs f3: %v", err)
 	}
 
 	// Snapshot and collect HashSet.
@@ -867,9 +859,8 @@ func testSnapshot_HashSet_Dedup(t *testing.T, factory SnapshotableStoreFactory) 
 	fA.Blocks = []block.ChunkRef{
 		{Hash: sharedHash, Offset: 0, Size: 4 << 20},
 	}
-	fA.BlocksDirty = true
-	if err := store.PutFile(ctx, fA); err != nil {
-		t.Fatalf("PutFile dup-a: %v", err)
+	if err := store.SetManifest(ctx, fA); err != nil {
+		t.Fatalf("UpdateAttrs dup-a: %v", err)
 	}
 
 	// File B: single block with the SAME shared hash.
@@ -881,9 +872,8 @@ func testSnapshot_HashSet_Dedup(t *testing.T, factory SnapshotableStoreFactory) 
 	fB.Blocks = []block.ChunkRef{
 		{Hash: sharedHash, Offset: 0, Size: 4 << 20},
 	}
-	fB.BlocksDirty = true
-	if err := store.PutFile(ctx, fB); err != nil {
-		t.Fatalf("PutFile dup-b: %v", err)
+	if err := store.SetManifest(ctx, fB); err != nil {
+		t.Fatalf("UpdateAttrs dup-b: %v", err)
 	}
 
 	// Snapshot and collect HashSet.

--- a/pkg/metadata/storetest/store_surface.go
+++ b/pkg/metadata/storetest/store_surface.go
@@ -53,8 +53,8 @@ func testDeleteSharePurgesCounters(t *testing.T, factory StoreFactory) {
 	for i := range file.ObjectID {
 		file.ObjectID[i] = byte(i + 1)
 	}
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile with ObjectID: %v", err)
+	if err := store.UpdateAttrs(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs with ObjectID: %v", err)
 	}
 
 	if got := store.GetUsedBytes(); got != 8192 {
@@ -81,8 +81,8 @@ func testDeleteSharePurgesCounters(t *testing.T, factory StoreFactory) {
 	for i := range file2.ObjectID {
 		file2.ObjectID[i] = byte(i + 1) // same ObjectID as before
 	}
-	if err := store.PutFile(ctx, file2); err != nil {
-		t.Fatalf("PutFile same ObjectID after DeleteShare: got ErrConflict or unexpected error: %v — objectIndex was not purged by DeleteShare", err)
+	if err := store.UpdateAttrs(ctx, file2); err != nil {
+		t.Fatalf("UpdateAttrs same ObjectID after DeleteShare: got ErrConflict or unexpected error: %v — objectIndex was not purged by DeleteShare", err)
 	}
 }
 
@@ -149,7 +149,7 @@ func namesOf(entries []metadata.DirEntry) []string {
 }
 
 // setFileSize reads a file, sets its logical Size, and writes it back. Used to
-// drive the per-backend usedBytes counter (it tracks size deltas on PutFile).
+// drive the per-backend usedBytes counter (it tracks size deltas on UpdateAttrs).
 func setFileSize(t *testing.T, store metadata.Store, handle metadata.FileHandle, size uint64) {
 	t.Helper()
 	ctx := t.Context()
@@ -159,8 +159,8 @@ func setFileSize(t *testing.T, store metadata.Store, handle metadata.FileHandle,
 		t.Fatalf("GetFile() failed: %v", err)
 	}
 	file.Size = size
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile() failed: %v", err)
+	if err := store.UpdateAttrs(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs() failed: %v", err)
 	}
 }
 
@@ -357,8 +357,8 @@ func createTestFileOwned(t *testing.T, store metadata.Store, shareName string, d
 			Size: size,
 		},
 	}
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile() failed: %v", err)
+	if err := store.UpdateAttrs(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs() failed: %v", err)
 	}
 	if err := store.SetParent(ctx, handle, dirHandle); err != nil {
 		t.Fatalf("SetParent() failed: %v", err)
@@ -442,7 +442,7 @@ func testGetQuotaUsage(t *testing.T, factory StoreFactory) {
 }
 
 // testGetQuotaUsageChown verifies that changing a regular file's UID/GID via
-// PutFile moves its bytes+count from the old identity to the new — the
+// UpdateAttrs moves its bytes+count from the old identity to the new — the
 // easy-to-miss accounting event called out by #1151.
 func testGetQuotaUsageChown(t *testing.T, factory StoreFactory) {
 	store := factory(t)
@@ -464,8 +464,8 @@ func testGetQuotaUsageChown(t *testing.T, factory StoreFactory) {
 	}
 	file.UID = 1001
 	file.GID = 2001
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile() chown failed: %v", err)
+	if err := store.UpdateAttrs(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs() chown failed: %v", err)
 	}
 	wantUsage(t, store, metadata.QuotaScopeUser, 1000, 0, 0)
 	wantUsage(t, store, metadata.QuotaScopeGroup, 2000, 0, 0)
@@ -478,8 +478,8 @@ func testGetQuotaUsageChown(t *testing.T, factory StoreFactory) {
 		t.Fatalf("GetFile() failed: %v", err)
 	}
 	file.GID = 2002
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile() gid-only chown failed: %v", err)
+	if err := store.UpdateAttrs(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs() gid-only chown failed: %v", err)
 	}
 	wantUsage(t, store, metadata.QuotaScopeUser, 1001, 400, 1)
 	wantUsage(t, store, metadata.QuotaScopeGroup, 2001, 0, 0)
@@ -507,9 +507,8 @@ func testGetFileByPayloadID(t *testing.T, factory StoreFactory) {
 		{Hash: hashOfSeed("pid-b0"), Offset: 0, Size: 4096},
 		{Hash: hashOfSeed("pid-b1"), Offset: 4096, Size: 2048},
 	}
-	file.BlocksDirty = true
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile() with PayloadID failed: %v", err)
+	if err := store.SetManifest(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs() with PayloadID failed: %v", err)
 	}
 
 	got, err := store.GetFileByPayloadID(ctx, payloadID)

--- a/pkg/metadata/storetest/suite.go
+++ b/pkg/metadata/storetest/suite.go
@@ -78,7 +78,7 @@ func RunConformanceSuite(t *testing.T, factory StoreFactory) {
 	})
 
 	// ACLAliasing asserts both directions of FileAttr.ACL deep-copy
-	// discipline: PutFile must not alias the caller's ACE slice, and
+	// discipline: UpdateAttrs must not alias the caller's ACE slice, and
 	// GetFile must not hand back the store's backing slice. Pins the
 	// cross-backend parity gap the area-6 audit found in the memory backend.
 	t.Run("ACLAliasing", func(t *testing.T) {
@@ -86,7 +86,7 @@ func RunConformanceSuite(t *testing.T, factory StoreFactory) {
 	})
 
 	// EAOps covers FileAttr.EAs (SMB extended attributes, MS-FSCC §2.4.15):
-	// PutFile/GetFile round-trip, zero-length values, deletion, case-
+	// UpdateAttrs/GetFile round-trip, zero-length values, deletion, case-
 	// insensitive name resolution with set-case preservation, deep-copy
 	// (aliasing) discipline, and persistence across unrelated writes. Pins
 	// cross-backend parity the same way ACLAliasing does for ACLs.
@@ -111,7 +111,7 @@ func RunConformanceSuite(t *testing.T, factory StoreFactory) {
 	})
 
 	// ChunkRefOps conformance for FileAttr.Blocks []ChunkRef
-	// round-trip across PutFile/GetFile, replace semantics, and the
+	// round-trip across UpdateAttrs/GetFile, replace semantics, and the
 	// Postgres-only FK-cascade behavior. Memory and Badger skip the
 	// cascade scenario via FileChunkRefsAccessor type-assertion
 	// failure.
@@ -271,8 +271,8 @@ func createTestFile(t *testing.T, store metadata.Store, shareName string, dirHan
 	file.ID = id
 
 	// Put file
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile() failed: %v", err)
+	if err := store.UpdateAttrs(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs() failed: %v", err)
 	}
 
 	// Set parent
@@ -328,8 +328,8 @@ func createTestDir(t *testing.T, store metadata.Store, shareName string, parentH
 	dir.ID = id
 
 	// Put directory
-	if err := store.PutFile(ctx, dir); err != nil {
-		t.Fatalf("PutFile() failed: %v", err)
+	if err := store.UpdateAttrs(ctx, dir); err != nil {
+		t.Fatalf("UpdateAttrs() failed: %v", err)
 	}
 
 	// Set parent

--- a/pkg/metadata/storetest/truncate_block_refs.go
+++ b/pkg/metadata/storetest/truncate_block_refs.go
@@ -24,8 +24,8 @@ func runTruncateChunkRefTests(t *testing.T, factory StoreFactory) {
 }
 
 // manifestWriteCounter is an optional, test-only capability the SQL backends
-// implement to expose how many times PutFile actually persisted the
-// file_block_refs manifest (i.e. ran past the BlocksDirty gate). It is what
+// implement to expose how many times UpdateAttrs actually persisted the
+// file_block_refs manifest (i.e. came in through SetManifest). It is what
 // lets ChmodDoesNotRewriteRefs prove ZERO manifest writes — a row-count check
 // alone cannot, because a DELETE+INSERT of the same M rows leaves the same
 // count. Memory/Badger do not implement it (they hold Blocks inline and have
@@ -64,9 +64,8 @@ func testChunkRef_ChmodDoesNotRewriteRefs(t *testing.T, factory StoreFactory) {
 		file.Blocks[i] = block.ChunkRef{Hash: h, Offset: uint64(i) * mib, Size: uint32(mib)}
 	}
 	file.ObjectID = block.ComputeObjectID(file.Blocks)
-	file.BlocksDirty = true // seeding the manifest IS a manifest write
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile() seeding %d blocks failed: %v", nBlocks, err)
+	if err := store.SetManifest(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs() seeding %d blocks failed: %v", nBlocks, err)
 	}
 
 	// Baseline the manifest-write counter AFTER seeding, so we measure only
@@ -175,10 +174,9 @@ func testTruncateDownPrunesChunkRefs(t *testing.T, factory StoreFactory) {
 	// truncate must keep it consistent with the trimmed list, not leave it stale.
 	file.ObjectID = block.ComputeObjectID(file.Blocks)
 	// Seeding the manifest is a manifest-changing write — the SQL backends
-	// gate file_block_refs persistence on BlocksDirty.
-	file.BlocksDirty = true
-	if err := store.PutFile(ctx, file); err != nil {
-		t.Fatalf("PutFile() with 4 MiB block list failed: %v", err)
+	// gate file_block_refs persistence on the SetManifest entry point.
+	if err := store.SetManifest(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs() with 4 MiB block list failed: %v", err)
 	}
 
 	// Truncate down to 1 MiB through the service's SetFileAttributes path.

--- a/pkg/metadata/storetest/xattr_ops.go
+++ b/pkg/metadata/storetest/xattr_ops.go
@@ -64,8 +64,8 @@ func createStreamChild(t *testing.T, store metadata.Store, shareName string, par
 	}
 	file.Size = size
 	file.PayloadID = metadata.PayloadID(metadata.BuildPayloadID(shareName, file.Path))
-	if err := store.PutFile(t.Context(), file); err != nil {
-		t.Fatalf("PutFile(stream child): %v", err)
+	if err := store.UpdateAttrs(t.Context(), file); err != nil {
+		t.Fatalf("UpdateAttrs(stream child): %v", err)
 	}
 	return handle
 }

--- a/pkg/metadata/tx_integrity_test.go
+++ b/pkg/metadata/tx_integrity_test.go
@@ -110,16 +110,16 @@ func TestRemoveFile_ConcurrentCreateHardLink(t *testing.T) {
 // Move atomicity (full rollback on a mid-rename failure)
 // ============================================================================
 
-// errPutFileInjected is returned by the fault-injecting tx when PutFile is
+// errPutFileInjected is returned by the fault-injecting tx when UpdateAttrs is
 // called for the targeted file ID.
-var errPutFileInjected = errors.New("injected PutFile failure")
+var errPutFileInjected = errors.New("injected UpdateAttrs failure")
 
 // errLinkCountInjected is returned by the fault-injecting tx when GetLinkCount
 // is called for the targeted file ID.
 var errLinkCountInjected = errors.New("injected GetLinkCount failure")
 
 // faultyStore wraps a MetadataStore and, inside WithTransaction, injects
-// targeted failures into tx.PutFile, tx.GetLinkCount and tx.GetChild — each
+// targeted failures into tx.UpdateAttrs, tx.GetLinkCount and tx.GetChild — each
 // keyed by its own field, so a test arms only the one it needs. Everything
 // else delegates to the real store, so the operation under test runs normally
 // up to the injected failure. The faults key on the inode ID rather than
@@ -127,7 +127,7 @@ var errLinkCountInjected = errors.New("injected GetLinkCount failure")
 // discriminator at call time.
 type faultyStore struct {
 	metadata.Store
-	failID uuid.UUID // file ID whose PutFile should fail
+	failID uuid.UUID // file ID whose UpdateAttrs should fail
 	// failLinkCountID is the file ID whose in-transaction GetLinkCount fails.
 	failLinkCountID uuid.UUID
 	// getChild, when set, intercepts in-transaction GetChild lookups by name.
@@ -156,11 +156,11 @@ type faultyTx struct {
 	getChild        func(name string) (metadata.FileHandle, error, bool)
 }
 
-func (t *faultyTx) PutFile(ctx context.Context, file *metadata.File) error {
+func (t *faultyTx) UpdateAttrs(ctx context.Context, file *metadata.File) error {
 	if file.ID == t.failID {
 		return errPutFileInjected
 	}
-	return t.Transaction.PutFile(ctx, file)
+	return t.Transaction.UpdateAttrs(ctx, file)
 }
 
 func (t *faultyTx) GetLinkCount(ctx context.Context, handle metadata.FileHandle) (uint32, error) {
@@ -210,7 +210,7 @@ func newFaultyFixture(t *testing.T) *faultyFixture {
 }
 
 // TestMove_RollsBackOnPutFileFailure asserts the rename is atomic: when the
-// PutFile(srcFile) ctime write fails mid-transaction, the whole Move rolls
+// UpdateAttrs(srcFile) ctime write fails mid-transaction, the whole Move rolls
 // back — the source stays at its original name and the destination name is not
 // created. Previously Move discarded these errors with `_ =` and committed a
 // partial rename (entry relinked but the inode write lost).
@@ -231,14 +231,14 @@ func TestMove_RollsBackOnPutFileFailure(t *testing.T) {
 	_, srcID, err := metadata.DecodeFileHandle(srcHandle)
 	require.NoError(t, err)
 
-	// Arm the fault on the moved inode's ctime PutFile. It is keyed on the
+	// Arm the fault on the moved inode's ctime UpdateAttrs. It is keyed on the
 	// inode ID (stable across the rename) rather than File.Path, which Move no
 	// longer mutates/persists (#1166).
 	fx.faulty.failID = srcID
 
 	// The move must fail with the injected error.
 	_, err = fx.svc.Move(fx.ctx, fx.root, "myfile.txt", destHandle, "moved.txt")
-	require.ErrorIs(t, err, errPutFileInjected, "Move must surface the injected PutFile failure, not swallow it")
+	require.ErrorIs(t, err, errPutFileInjected, "Move must surface the injected UpdateAttrs failure, not swallow it")
 
 	// Full rollback: source still at its original name/path...
 	stillThere, err := fx.store.GetChild(ctx, fx.root, "myfile.txt")

--- a/pkg/metadata/xattr.go
+++ b/pkg/metadata/xattr.go
@@ -222,7 +222,7 @@ func ResolveSetXattr(ctx context.Context, files Files, handle FileHandle, name s
 		return err
 	}
 	file.ApplyEAMutations([]EAMutation{{Name: name, Value: value}})
-	return files.PutFile(ctx, file)
+	return files.UpdateAttrs(ctx, file)
 }
 
 // ResolveRemoveXattr removes an xattr from the inline backing. Removing a name
@@ -240,7 +240,7 @@ func ResolveRemoveXattr(ctx context.Context, files Files, handle FileHandle, nam
 		return &StoreError{Code: metaerrors.ErrNotFound, Message: "xattr not found"}
 	}
 	file.ApplyEAMutations([]EAMutation{{Name: name, Delete: true}})
-	return files.PutFile(ctx, file)
+	return files.UpdateAttrs(ctx, file)
 }
 
 // ResolveListXattr returns every xattr name on the file, merged from both

--- a/pkg/snapshot/backup_bench_test.go
+++ b/pkg/snapshot/backup_bench_test.go
@@ -208,7 +208,7 @@ type SeedOpts struct {
 // opts.BlocksPerFile ChunkRefs. Returns the store, the number of unique
 // block hashes seeded, and a cleanup func.
 //
-// Files are attached directly under the share root via PutFile + SetParent
+// Files are attached directly under the share root via UpdateAttrs + SetParent
 // + SetChild — the same surface the metadata conformance suite uses — so
 // the seed exercises the real Backup hash-extraction path (File.Blocks on
 // the f: prefix) without routing through CreateFile permission checks.
@@ -318,7 +318,7 @@ func seed(ctx context.Context, store metadata.Store, opts SeedOpts) (int, error)
 			},
 		}
 		f.ID = id
-		if err := store.PutFile(ctx, f); err != nil {
+		if err := store.UpdateAttrs(ctx, f); err != nil {
 			return 0, fmt.Errorf("snapshots bench: put file: %w", err)
 		}
 		if err := store.SetParent(ctx, handle, rootHandle); err != nil {


### PR DESCRIPTION
## What

Splits the single `Files.PutFile(ctx, file)` method into two:

```go
UpdateAttrs(ctx, file)   // attrs only; stored manifest untouched
SetManifest(ctx, file)   // attrs + replace the stored block manifest from file.Blocks
```

and deletes the transient `File.BlocksDirty` flag that used to carry that choice
as data. `File.BlocksDirtyOffsets` is renamed `File.ManifestDirtyOffsets`, since
the field it qualified no longer exists; its semantics are unchanged.

This is the interface half of #1715 Wave 3. The *data* half already shipped as
the `BlocksDirty` gate in #1820/#1841 — this only moves the signal from a struct
field to the method the caller picks.

## Why now

#1828 stage 1 of 7. The later `store/sql` merge (stages 2-3) collapses the sqlite
and postgres query bodies into one copy. Doing the reshape first means that merge
inherits an already-clean shape instead of porting the `BlocksDirty` convention
into the new package and reshaping it afterwards — a smaller total diff.

Independently, a flag on a struct is the wrong place for "which write is this".
It is set at one call site and read at another, four packages away, and nothing
in the type system stops a caller from forgetting it — the exact failure mode
that produces a silently-stale `file_block_refs` table. The method name cannot be
forgotten.

## Behaviour

No change, by construction. Each backend keeps one body and gains two entry
points:

```go
func (tx *sqliteTransaction) UpdateAttrs(ctx, file) error { return tx.putFile(ctx, file, false) }
func (tx *sqliteTransaction) SetManifest(ctx, file) error { return tx.putFile(ctx, file, true) }
```

and the gate that read `file.BlocksDirty` now reads the `writeManifest`
parameter. Same for postgres and badger. `memory` keeps the block list inline in
the stored `FileAttr`, so its `SetManifest` is `UpdateAttrs` — it already ignored
`BlocksDirty`.

Badger's extra fallback is preserved verbatim: an attr-only write on a file that
carries blocks but has no `fm:<uuid>` key yet still writes the manifest, which is
what migrates a legacy `f:` blob off its embedded manifest.

## Call sites converted to `SetManifest`

Every site that previously set `BlocksDirty = true`, and only those:

- `metadata/block_record_store.go` `putProjection` — carve/rollup commit, reap+re-carve, `ReprojectBlocks`
- `metadata/file_modify.go` — size-down truncate that prunes the block list
- `metadata/sparse.go` — punch-hole
- `adapter/common/clone.go`, `adapter/common/copy_payload.go` — wholesale manifest replacement on the destination
- `controlplane/runtime/shares/coordinator.go` — post-quiesce ObjectID write

In `file_modify.go` the flag was set inside the truncate branch and read at an
unconditional commit further down, so it becomes a `blocksPruned` local that
selects the method at the commit. Everything else was adjacent enough to convert
in place.

## Verification

- `go build ./...`, `go vet ./...` clean
- `go test ./pkg/metadata/... ./pkg/block/engine/... ./pkg/controlplane/... ./internal/adapter/common/...` — 26/26 packages pass
- `pkg/metadata/storetest/` conformance passes for all four backends; the manifest-gate
  assertions there (`truncate_block_refs.go`, `blockref_roundtrip.go`,
  `objectid_*.go`, `snapshot_conformance.go`) now exercise the two entry points
  rather than the flag, so the write-amplification guarantee is still under test.
- `manifest_projection_test.go`'s fake transaction asserts the projection path
  goes through `SetManifest`, replacing the old `BlocksDirty` assertion.

No on-disk format change: `BlocksDirty` was `json:"-"` and the SQL backends write
explicit column lists, so it never reached a row.

Refs #1828
