### PR TITLE
fix(shares): report per-share logical usage in share list, not the metadata store's total

### DIFF
--- a/cmd/dfsctl/commands/share/list.go
+++ b/cmd/dfsctl/commands/share/list.go
@@ -21,6 +21,13 @@ storage quota and current usage, the default permission level, the block
 retention policy, and whether the share is currently enabled. Use this command
 to get a quick overview of all shares before running share-specific commands.
 
+USED is the share's logical size: the sum of its file sizes, the same figure
+'du --apparent-size' would report over the mounted share. It is what QUOTA is
+measured against. It is not a count of bytes on disk, and will not match one:
+blocks are deduplicated and compressed, and a share whose blocks have been
+evicted to its remote store occupies almost nothing locally while its USED is
+unchanged. For on-disk figures, use 'dfsctl store block stats'.
+
 Examples:
   # List all shares as a table
   dfsctl share list

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -4125,6 +4125,13 @@ storage quota and current usage, the default permission level, the block
 retention policy, and whether the share is currently enabled. Use this command
 to get a quick overview of all shares before running share-specific commands.
 
+USED is the share's logical size: the sum of its file sizes, the same figure
+'du --apparent-size' would report over the mounted share. It is what QUOTA is
+measured against. It is not a count of bytes on disk, and will not match one:
+blocks are deduplicated and compressed, and a share whose blocks have been
+evicted to its remote store occupies almost nothing locally while its USED is
+unchanged. For on-disk figures, use 'dfsctl store block stats'.
+
 ```
 dfsctl share list
 ```

--- a/internal/controlplane/api/handlers/shares.go
+++ b/internal/controlplane/api/handlers/shares.go
@@ -1623,7 +1623,7 @@ func shareToResponse(s *models.Share) ShareResponse {
 func (h *ShareHandler) shareToResponseWithUsage(ctx context.Context, s *models.Share) ShareResponse {
 	resp := shareToResponse(s)
 	if h.runtime != nil {
-		usedBytes, physicalBytes := h.runtime.GetShareUsage(s.Name)
+		usedBytes, physicalBytes := h.runtime.GetShareUsage(ctx, s.Name)
 		resp.UsedBytes = usedBytes
 		resp.PhysicalBytes = physicalBytes
 		if s.QuotaBytes > 0 {

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -785,7 +785,12 @@ func (r *Runtime) UpdateShareQuota(shareName string, quotaBytes int64) {
 }
 
 // GetShareUsage returns the logical used bytes and physical disk bytes for a share.
-// Returns (0, 0) if the share is not found or has no store.
+//
+// Best-effort: either figure is reported as 0 when it cannot be obtained — an
+// unknown share, a share with no block store, or a failed lookup. Usage feeds a
+// reporting surface, so an unavailable number degrades to zero rather than
+// failing the whole share listing. A 0 therefore means "empty or unknown", and
+// is not a signal to act on.
 //
 // The logical figure is scoped to this share alone. It cannot come from the
 // metadata store's store-wide counter: several shares may name the same

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -786,11 +786,22 @@ func (r *Runtime) UpdateShareQuota(shareName string, quotaBytes int64) {
 
 // GetShareUsage returns the logical used bytes and physical disk bytes for a share.
 // Returns (0, 0) if the share is not found or has no store.
-func (r *Runtime) GetShareUsage(shareName string) (usedBytes int64, physicalBytes int64) {
-	// Get logical used bytes from the metadata store's atomic counter.
+//
+// The logical figure is scoped to this share alone. It cannot come from the
+// metadata store's store-wide counter: several shares may name the same
+// metadata store config and are then served by one store instance, whose
+// counter is their combined total.
+//
+// The physical figure is the block store's on-disk size, which is per block
+// store rather than per share — shares that name the same local store report
+// the same number, and dedup, compression and tiering all move it away from
+// the logical one. Only the logical figure is share-specific.
+func (r *Runtime) GetShareUsage(ctx context.Context, shareName string) (usedBytes int64, physicalBytes int64) {
 	metaStore, err := r.metadataService.GetStoreForShare(shareName)
 	if err == nil {
-		usedBytes = metaStore.GetUsedBytes()
+		if used, usedErr := metaStore.GetUsedBytesForShare(ctx, shareName); usedErr == nil {
+			usedBytes = used
+		}
 	}
 
 	// Get physical bytes from the block store.

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -482,7 +482,27 @@ type Store interface {
 
 	// GetUsedBytes returns the current total logical bytes used by regular files.
 	// This is an O(1) read from an atomic counter.
+	//
+	// The counter is store-wide. A store instance is shared by every share that
+	// names the same metadata store config, so this is NOT a per-share figure —
+	// use GetUsedBytesForShare when reporting usage for one share.
 	GetUsedBytes() int64
+
+	// GetUsedBytesForShare returns the logical bytes used by regular files that
+	// belong to one share: the sum of their sizes, as recorded in metadata.
+	// Directories, symlinks and other non-regular entries contribute nothing,
+	// matching GetUsedBytes semantics.
+	//
+	// This is a metadata figure, not an on-disk one. It is unaffected by block
+	// deduplication, compression, and by whether the share's blocks currently
+	// live in the local tier or only in the remote one.
+	//
+	// An unknown share name returns 0 and a nil error — a share with no files
+	// and a share that does not exist are indistinguishable by usage alone.
+	//
+	// Unlike GetUsedBytes this is not guaranteed O(1): backends that keep only a
+	// store-wide counter compute the per-share figure on demand.
+	GetUsedBytesForShare(ctx context.Context, shareName string) (int64, error)
 
 	// GetQuotaUsage returns the per-identity usage (bytes + file count) for the
 	// given scope (user/group) and identity id (uid or gid). Regular files only,

--- a/pkg/metadata/store/badger/reset.go
+++ b/pkg/metadata/store/badger/reset.go
@@ -51,4 +51,5 @@ func (s *BadgerMetadataStore) invalidateDerivedCaches() {
 	s.statsCache.mu.Lock()
 	s.statsCache.hasStats = false
 	s.statsCache.mu.Unlock()
+	s.invalidateShareUsedCache()
 }

--- a/pkg/metadata/store/badger/share_usage.go
+++ b/pkg/metadata/store/badger/share_usage.go
@@ -36,21 +36,34 @@ func (s *BadgerMetadataStore) GetUsedBytesForShare(ctx context.Context, shareNam
 		return 0, err
 	}
 
-	// The lock is held across the scan so a burst of callers costs one scan
-	// rather than one each.
 	s.shareUsedCache.mu.Lock()
-	defer s.shareUsedCache.mu.Unlock()
+	cached := s.shareUsedCache.byShare
+	fresh := time.Since(s.shareUsedCache.timestamp) < shareUsedCacheTTL
+	gen := s.shareUsedCache.gen
+	s.shareUsedCache.mu.Unlock()
 
-	if s.shareUsedCache.byShare != nil && time.Since(s.shareUsedCache.timestamp) < shareUsedCacheTTL {
-		return s.shareUsedCache.byShare[shareName], nil
+	// A published map is never mutated in place, only replaced, so reading it
+	// outside the lock is safe.
+	if cached != nil && fresh {
+		return cached[shareName], nil
 	}
 
+	// Scanned with the lock released: a committing transaction invalidates this
+	// cache post-commit, and must never queue behind a scan of every record.
+	// Concurrent misses may each scan; that is cheaper than stalling writes.
 	byShare, err := s.scanUsedBytesByShare(ctx)
 	if err != nil {
 		return 0, err
 	}
-	s.shareUsedCache.byShare = byShare
-	s.shareUsedCache.timestamp = time.Now()
+
+	s.shareUsedCache.mu.Lock()
+	// Publish only if nothing invalidated the cache while the scan ran — those
+	// results may already describe a superseded state.
+	if s.shareUsedCache.gen == gen {
+		s.shareUsedCache.byShare = byShare
+		s.shareUsedCache.timestamp = time.Now()
+	}
+	s.shareUsedCache.mu.Unlock()
 
 	return byShare[shareName], nil
 }
@@ -101,12 +114,14 @@ func (s *BadgerMetadataStore) scanUsedBytesByShare(ctx context.Context) (map[str
 	return byShare, nil
 }
 
-// invalidateShareUsedCache drops the cached per-share totals so the next
-// caller rescans. Used where the file records change wholesale (reset,
-// snapshot restore) rather than through the normal mutation path, which the
-// TTL already covers.
+// invalidateShareUsedCache drops the cached per-share totals so the next caller
+// rescans, and bumps the generation so a scan already in flight discards its
+// result instead of publishing a superseded one. Called wherever the file
+// records change: post-commit in withTransaction, on DeleteShare, on Reset, and
+// after a snapshot restore.
 func (s *BadgerMetadataStore) invalidateShareUsedCache() {
 	s.shareUsedCache.mu.Lock()
 	s.shareUsedCache.byShare = nil
+	s.shareUsedCache.gen++
 	s.shareUsedCache.mu.Unlock()
 }

--- a/pkg/metadata/store/badger/share_usage.go
+++ b/pkg/metadata/store/badger/share_usage.go
@@ -10,10 +10,11 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// shareUsedCacheTTL bounds how stale a per-share usage answer may be. It
-// matches the filesystem-statistics cache TTL: both serve reporting surfaces
-// where a few seconds of lag is invisible, and both exist to keep a repeated
-// caller from re-scanning the file records.
+// shareUsedCacheTTL bounds how long a per-share usage answer is reused. Every
+// committed transaction that moves the byte counter already drops the cache,
+// so this is a backstop against a bucket surviving a change that bypassed that
+// path, not the primary freshness mechanism. It matches the
+// filesystem-statistics cache TTL.
 const shareUsedCacheTTL = 5 * time.Second
 
 // GetUsedBytesForShare returns the logical bytes held by one share's regular
@@ -25,11 +26,11 @@ const shareUsedCacheTTL = 5 * time.Second
 // share index, so the per-share split is derived by scanning them.
 //
 // ponytail: O(n) scan over the file records, shared by all shares (one scan
-// fills every bucket) and cached for shareUsedCacheTTL. The store-wide counter
-// is maintained by a transaction delta pipeline that carries no share
-// dimension, so a per-share counter means threading the share name through
-// every mutation site. Do that only if this scan shows up in a profile — it is
-// reached from reporting surfaces, not from the I/O path.
+// fills every bucket) and cached until the next committed size change. The
+// store-wide counter is maintained by a transaction delta pipeline that
+// carries no share dimension, so a per-share counter means threading the share
+// name through every mutation site. Do that only if this scan shows up in a
+// profile — it is reached from reporting surfaces, not from the I/O path.
 func (s *BadgerMetadataStore) GetUsedBytesForShare(ctx context.Context, shareName string) (int64, error) {
 	if err := ctx.Err(); err != nil {
 		return 0, err

--- a/pkg/metadata/store/badger/share_usage.go
+++ b/pkg/metadata/store/badger/share_usage.go
@@ -1,0 +1,111 @@
+package badger
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	badgerdb "github.com/dgraph-io/badger/v4"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// shareUsedCacheTTL bounds how stale a per-share usage answer may be. It
+// matches the filesystem-statistics cache TTL: both serve reporting surfaces
+// where a few seconds of lag is invisible, and both exist to keep a repeated
+// caller from re-scanning the file records.
+const shareUsedCacheTTL = 5 * time.Second
+
+// GetUsedBytesForShare returns the logical bytes held by one share's regular
+// files.
+//
+// The store-wide usedBytes counter cannot answer this: a single store instance
+// backs every share that names the same metadata store config, so the counter
+// is the sum across all of them. The file records are keyed by UUID with no
+// share index, so the per-share split is derived by scanning them.
+//
+// ponytail: O(n) scan over the file records, shared by all shares (one scan
+// fills every bucket) and cached for shareUsedCacheTTL. The store-wide counter
+// is maintained by a transaction delta pipeline that carries no share
+// dimension, so a per-share counter means threading the share name through
+// every mutation site. Do that only if this scan shows up in a profile — it is
+// reached from reporting surfaces, not from the I/O path.
+func (s *BadgerMetadataStore) GetUsedBytesForShare(ctx context.Context, shareName string) (int64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+
+	// The lock is held across the scan so a burst of callers costs one scan
+	// rather than one each.
+	s.shareUsedCache.mu.Lock()
+	defer s.shareUsedCache.mu.Unlock()
+
+	if s.shareUsedCache.byShare != nil && time.Since(s.shareUsedCache.timestamp) < shareUsedCacheTTL {
+		return s.shareUsedCache.byShare[shareName], nil
+	}
+
+	byShare, err := s.scanUsedBytesByShare(ctx)
+	if err != nil {
+		return 0, err
+	}
+	s.shareUsedCache.byShare = byShare
+	s.shareUsedCache.timestamp = time.Now()
+
+	return byShare[shareName], nil
+}
+
+// scanUsedBytesByShare walks every file record and totals the sizes of regular
+// files per share. Corrupted records are skipped rather than failing the scan,
+// matching initUsedBytesCounter: a single undecodable blob must not make usage
+// unreportable for the whole store.
+func (s *BadgerMetadataStore) scanUsedBytesByShare(ctx context.Context) (map[string]int64, error) {
+	byShare := make(map[string]int64)
+
+	err := s.db.View(func(txn *badgerdb.Txn) error {
+		opts := badgerdb.DefaultIteratorOptions
+		opts.Prefix = []byte(prefixFile)
+		opts.PrefetchValues = true
+
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		scanned := 0
+		for it.Rewind(); it.Valid(); it.Next() {
+			if scanned%100 == 0 {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+			}
+			scanned++
+
+			if err := it.Item().Value(func(val []byte) error {
+				file, err := decodeFile(val)
+				if err != nil {
+					return nil
+				}
+				if file.Type == metadata.FileTypeRegular {
+					byShare[file.ShareName] += int64(file.Size)
+				}
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to total per-share used bytes: %w", err)
+	}
+
+	return byShare, nil
+}
+
+// invalidateShareUsedCache drops the cached per-share totals so the next
+// caller rescans. Used where the file records change wholesale (reset,
+// snapshot restore) rather than through the normal mutation path, which the
+// TTL already covers.
+func (s *BadgerMetadataStore) invalidateShareUsedCache() {
+	s.shareUsedCache.mu.Lock()
+	s.shareUsedCache.byShare = nil
+	s.shareUsedCache.mu.Unlock()
+}

--- a/pkg/metadata/store/badger/shares.go
+++ b/pkg/metadata/store/badger/shares.go
@@ -216,6 +216,8 @@ func (s *BadgerMetadataStore) DeleteShare(ctx context.Context, shareName string)
 	if freedBytes > 0 {
 		s.usedBytes.Add(-freedBytes)
 	}
+	// The deleted share's bucket must not outlive it in the per-share cache.
+	s.invalidateShareUsedCache()
 	s.applyQuotaDelta(quotaFreed)
 	return nil
 }

--- a/pkg/metadata/store/badger/snapshot_store.go
+++ b/pkg/metadata/store/badger/snapshot_store.go
@@ -318,6 +318,9 @@ func (s *BadgerMetadataStore) RestoreSnapshot(ctx context.Context, r io.Reader) 
 	if err := s.initUsedBytesAndPayloadIndex(); err != nil {
 		return fmt.Errorf("restore: reinitialize used-bytes counter: %w", err)
 	}
+	// Per-share totals are cached from a scan of the pre-restore rows and would
+	// otherwise survive until the TTL expires.
+	s.invalidateShareUsedCache()
 
 	return nil
 }

--- a/pkg/metadata/store/badger/snapshot_store.go
+++ b/pkg/metadata/store/badger/snapshot_store.go
@@ -318,9 +318,6 @@ func (s *BadgerMetadataStore) RestoreSnapshot(ctx context.Context, r io.Reader) 
 	if err := s.initUsedBytesAndPayloadIndex(); err != nil {
 		return fmt.Errorf("restore: reinitialize used-bytes counter: %w", err)
 	}
-	// Per-share totals are cached from a scan of the pre-restore rows and would
-	// otherwise survive until the TTL expires.
-	s.invalidateShareUsedCache()
 
 	return nil
 }

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -129,6 +129,15 @@ type BadgerMetadataStore struct {
 		mu        sync.RWMutex
 	}
 
+	// shareUsedCache caches the per-share logical byte totals produced by one
+	// scan of the file records (see GetUsedBytesForShare). A nil byShare means
+	// "not computed"; entries older than shareUsedCacheTTL are rescanned.
+	shareUsedCache struct {
+		byShare   map[string]int64
+		timestamp time.Time
+		mu        sync.Mutex
+	}
+
 	// lockStore provides lock persistence
 	lockStore *badgerLockStore
 

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -135,7 +135,10 @@ type BadgerMetadataStore struct {
 	shareUsedCache struct {
 		byShare   map[string]int64
 		timestamp time.Time
-		mu        sync.Mutex
+		// gen is bumped by every invalidation. A scan that started before an
+		// invalidation must not publish its (possibly superseded) result.
+		gen uint64
+		mu  sync.Mutex
 	}
 
 	// lockStore provides lock persistence

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -144,8 +144,11 @@ func (s *BadgerMetadataStore) withTransaction(ctx context.Context, fn func(tx me
 
 		if err == nil {
 			// Apply the accumulated usedBytes delta exactly once, after commit.
+			// The delta carries no share dimension, so the per-share totals are
+			// dropped rather than adjusted: the next reader rescans.
 			if pendingDelta != 0 {
 				s.usedBytes.Add(pendingDelta)
+				s.invalidateShareUsedCache()
 			}
 			// Apply per-identity usage deltas once, after commit.
 			s.applyQuotaDelta(quotaDelta)

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -144,12 +144,14 @@ func (s *BadgerMetadataStore) withTransaction(ctx context.Context, fn func(tx me
 
 		if err == nil {
 			// Apply the accumulated usedBytes delta exactly once, after commit.
-			// The delta carries no share dimension, so the per-share totals are
-			// dropped rather than adjusted: the next reader rescans.
 			if pendingDelta != 0 {
 				s.usedBytes.Add(pendingDelta)
-				s.invalidateShareUsedCache()
 			}
+			// Drop the per-share totals unconditionally. The delta carries no
+			// share dimension, so they cannot be adjusted — and a net-zero
+			// delta does not mean they are unchanged: sizes that cancel across
+			// two shares move both while leaving the store-wide sum alone.
+			s.invalidateShareUsedCache()
 			// Apply per-identity usage deltas once, after commit.
 			s.applyQuotaDelta(quotaDelta)
 			// Apply the staged filesystem-capabilities update once, after commit,

--- a/pkg/metadata/store/memory/store.go
+++ b/pkg/metadata/store/memory/store.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -401,6 +402,31 @@ func NewMemoryMetadataStoreWithDefaults() *MemoryMetadataStore {
 // This is an O(1) atomic read, safe for concurrent access without locks.
 func (store *MemoryMetadataStore) GetUsedBytes() int64 {
 	return store.usedBytes.Load()
+}
+
+// GetUsedBytesForShare sums the sizes of the share's regular files. The
+// store-wide usedBytes counter covers every share held by this store, so it
+// cannot answer a per-share query.
+//
+// ponytail: O(n) walk of the files map under the read lock. The memory backend
+// is a development and test store whose whole state is already an in-process
+// map; a per-share counter is only worth adding if this store ever holds a
+// working set large enough for the walk to matter.
+func (store *MemoryMetadataStore) GetUsedBytesForShare(ctx context.Context, shareName string) (int64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+
+	var total int64
+	for _, fd := range store.files {
+		if fd.ShareName == shareName && fd.Attr.Type == metadata.FileTypeRegular {
+			total += int64(fd.Attr.Size)
+		}
+	}
+	return total, nil
 }
 
 // GetQuotaUsage returns per-identity usage for the given scope and id.

--- a/pkg/metadata/store/postgres/statfs.go
+++ b/pkg/metadata/store/postgres/statfs.go
@@ -29,3 +29,8 @@ func statfsQuery(handle metadata.FileHandle) (sql string, args []any) {
 	return `SELECT COALESCE(SUM(size), 0), COUNT(*) FROM inodes WHERE file_type = $1`,
 		[]any{int(metadata.FileTypeRegular)}
 }
+
+// shareUsedBytesQuery is the per-share logical-bytes aggregate behind
+// GetUsedBytesForShare. It mirrors statfsQuery's share-scoped branch — regular
+// files only — so the two report the same number for the same share.
+const shareUsedBytesQuery = `SELECT COALESCE(SUM(size), 0) FROM inodes WHERE share_name = $1 AND file_type = $2`

--- a/pkg/metadata/store/postgres/store.go
+++ b/pkg/metadata/store/postgres/store.go
@@ -189,6 +189,18 @@ func (s *PostgresMetadataStore) GetUsedBytes() int64 {
 	return s.usedBytes.Load()
 }
 
+// GetUsedBytesForShare sums the sizes of one share's regular files. The
+// store-wide atomic counter covers every share held by this store, so a scoped
+// aggregate is used instead — the same one GetFilesystemStatistics runs, over
+// the idx_inodes_share_name index.
+func (s *PostgresMetadataStore) GetUsedBytesForShare(ctx context.Context, shareName string) (int64, error) {
+	var used int64
+	if err := s.queryRow(ctx, shareUsedBytesQuery, shareName, int(metadata.FileTypeRegular)).Scan(&used); err != nil {
+		return 0, mapPgError(err, "GetUsedBytesForShare", shareName)
+	}
+	return used, nil
+}
+
 // initUsedBytesCounter initializes the store-wide atomic counter from a SQL SUM
 // query and seeds the per-identity usage cache from GROUP BY aggregates. Both
 // are reconstructed from the inodes table (the source

--- a/pkg/metadata/store/sqlite/statfs.go
+++ b/pkg/metadata/store/sqlite/statfs.go
@@ -29,3 +29,8 @@ func statfsQuery(handle metadata.FileHandle) (sql string, args []any) {
 	return `SELECT COALESCE(SUM(size), 0), COUNT(*) FROM inodes WHERE file_type = ?1`,
 		[]any{int(metadata.FileTypeRegular)}
 }
+
+// shareUsedBytesQuery is the per-share logical-bytes aggregate behind
+// GetUsedBytesForShare. It mirrors statfsQuery's share-scoped branch — regular
+// files only — so the two report the same number for the same share.
+const shareUsedBytesQuery = `SELECT COALESCE(SUM(size), 0) FROM inodes WHERE share_name = ?1 AND file_type = ?2`

--- a/pkg/metadata/store/sqlite/store.go
+++ b/pkg/metadata/store/sqlite/store.go
@@ -190,6 +190,18 @@ func (s *SQLiteMetadataStore) GetUsedBytes() int64 {
 	return s.usedBytes.Load()
 }
 
+// GetUsedBytesForShare sums the sizes of one share's regular files. The
+// store-wide atomic counter covers every share held by this store, so a scoped
+// aggregate is used instead — the same one GetFilesystemStatistics runs, over
+// the share_name index.
+func (s *SQLiteMetadataStore) GetUsedBytesForShare(ctx context.Context, shareName string) (int64, error) {
+	var used int64
+	if err := s.queryRow(ctx, shareUsedBytesQuery, shareName, int(metadata.FileTypeRegular)).Scan(&used); err != nil {
+		return 0, mapDBError(err, "GetUsedBytesForShare", shareName)
+	}
+	return used, nil
+}
+
 // initUsedBytesCounter initializes the store-wide atomic counter from a SQL SUM
 // query and seeds the per-identity usage cache from GROUP BY aggregates. Both
 // are reconstructed from the inodes table (the source of truth).

--- a/pkg/metadata/storetest/store_surface.go
+++ b/pkg/metadata/storetest/store_surface.go
@@ -25,6 +25,7 @@ func runStoreSurfaceTests(t *testing.T, factory StoreFactory) {
 	t.Run("DeleteShareViaTransaction", func(t *testing.T) { testDeleteShareViaTransaction(t, factory) })
 	t.Run("DuplicateCreateShare", func(t *testing.T) { testDuplicateCreateShare(t, factory) })
 	t.Run("GetUsedBytes", func(t *testing.T) { testGetUsedBytes(t, factory) })
+	t.Run("GetUsedBytesForShare", func(t *testing.T) { testGetUsedBytesForShare(t, factory) })
 	t.Run("GetQuotaUsage", func(t *testing.T) { testGetQuotaUsage(t, factory) })
 	t.Run("GetQuotaUsageChown", func(t *testing.T) { testGetQuotaUsageChown(t, factory) })
 	t.Run("GetFileByPayloadID", func(t *testing.T) { testGetFileByPayloadID(t, factory) })
@@ -326,6 +327,71 @@ func testGetUsedBytes(t *testing.T, factory StoreFactory) {
 	}
 	if got := store.GetUsedBytes(); got != 0 {
 		t.Fatalf("GetUsedBytes() = %d, want 0 after deleting the only file", got)
+	}
+}
+
+// testGetUsedBytesForShare pins the per-share split of logical usage. Several
+// shares can be served by one store instance (they name the same metadata
+// store config), and the store-wide GetUsedBytes counter then reports their
+// combined total for every one of them. GetUsedBytesForShare must attribute
+// each share only its own bytes.
+func testGetUsedBytesForShare(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+
+	const shareA = "/usage-a"
+	const shareB = "/usage-b"
+	rootA := createTestShare(t, store, shareA)
+	rootB := createTestShare(t, store, shareB)
+
+	assertShareUsed := func(what, shareName string, want int64) {
+		t.Helper()
+		got, err := store.GetUsedBytesForShare(ctx, shareName)
+		if err != nil {
+			t.Fatalf("GetUsedBytesForShare(%q) failed after %s: %v", shareName, what, err)
+		}
+		if got != want {
+			t.Fatalf("GetUsedBytesForShare(%q) = %d, want %d after %s", shareName, got, want, what)
+		}
+	}
+
+	assertShareUsed("share creation", shareA, 0)
+	assertShareUsed("share creation", shareB, 0)
+
+	fileA := createTestFile(t, store, shareA, rootA, "a.bin", 0o644)
+	setFileSize(t, store, fileA, 3000)
+	fileB := createTestFile(t, store, shareB, rootB, "b.bin", 0o644)
+	setFileSize(t, store, fileB, 5000)
+
+	// The store-wide counter is the combined total: that is what made the two
+	// shares indistinguishable when usage was reported from it.
+	if got := store.GetUsedBytes(); got != 8000 {
+		t.Fatalf("GetUsedBytes() = %d, want 8000 (both shares) — test fixture is wrong", got)
+	}
+	assertShareUsed("writes to both shares", shareA, 3000)
+	assertShareUsed("writes to both shares", shareB, 5000)
+
+	// Directories carry no logical bytes, matching GetUsedBytes semantics.
+	createTestDir(t, store, shareA, rootA, "subdir")
+	assertShareUsed("creating a directory", shareA, 3000)
+
+	// A change in one share must not move the other.
+	setFileSize(t, store, fileA, 250)
+	assertShareUsed("truncating a.bin", shareA, 250)
+	assertShareUsed("truncating a.bin", shareB, 5000)
+
+	if err := store.DeleteChild(ctx, rootA, "a.bin"); err != nil {
+		t.Fatalf("DeleteChild() failed: %v", err)
+	}
+	if err := store.DeleteFile(ctx, fileA); err != nil {
+		t.Fatalf("DeleteFile() failed: %v", err)
+	}
+	assertShareUsed("deleting a.bin", shareA, 0)
+	assertShareUsed("deleting a.bin", shareB, 5000)
+
+	// An unknown share reports no usage rather than an error.
+	if got, err := store.GetUsedBytesForShare(ctx, "/no-such-share"); err != nil || got != 0 {
+		t.Fatalf("GetUsedBytesForShare(unknown) = (%d, %v), want (0, nil)", got, err)
 	}
 }
 


### PR DESCRIPTION
## The reported figure was not the block store's on-disk total

The issue's premise is wrong, and it matters: the fix belongs in the metadata
layer, not the block layer.

From the reported run — `/data` holding 167,772,247 bytes of file data,
`/tiered` holding 62,914,560, and both rows reading `220.00MiB`:

```
167,772,247 + 62,914,560 = 230,686,807 bytes = 220.0000MiB   <- what was printed
                          220,228,383 bytes = 210.03MiB      <- size of /data/blocks
```

`ByteSize.String()` renders MiB to two decimals, so the on-disk figure would
have printed as `210.03MiB`. The number on screen is the **sum of the two
shares' logical file bytes** — and the block store's on-disk size never reaches
that column at all: it is carried in a separate `physical_bytes` field that
`share list` does not render.

## Root cause

A `metadata.Store` instance is created per *metadata store config*, not per
share. `shares.prepareShare` resolves it with
`storeProvider.GetMetadataStore(config.MetadataStore)`, which returns the same
instance to every share naming that config, and each of those shares then gets
it registered under its own name by `RegisterStoreForShare`.

`Store.GetUsedBytes()` is a store-wide atomic counter. `Runtime.GetShareUsage`
read it directly, so every share backed by one metadata store was attributed
the combined total of all of them — which is exactly the symptom, two rows
showing the same number equal to their sum.

A deployment with one share per metadata store is unaffected: there, the
store-wide total *is* that share's total, which is why this survived.

## Does the figure feed enforcement?

**Not on the path this PR fixes** — `Runtime.GetShareUsage` has exactly one
caller, `shareToResponseWithUsage`, which fills `used_bytes` / `usage_percent`
in the shares API for `dfsctl share list`. That is display-only.

**But the same store-wide counter is read by two enforcement sites**, which is
a distinct defect and is filed separately as #2057 rather than widened into
this PR:

- `pkg/metadata/io.go` — the share-quota gate in `PrepareWrite` compares a
  per-share quota against `store.GetUsedBytes()`.
- `pkg/metadata/quota_enforce.go` — per-identity quotas compare against
  `store.GetQuotaUsage(scope, id)`, likewise store-wide.

Reproduced deterministically: two shares on one metadata store, `/a` holding
9000 bytes with no quota, `/b` empty with a 4000-byte quota. A 1000-byte write
into the empty `/b` is refused:

```
store-wide GetUsedBytes=9000  perShare(/a)=9000  perShare(/b)=0
Error: NoSpace: share quota exceeded
Messages: share /b is empty with a 4000-byte quota; a 1000-byte write must fit
```

Fixing those changes behaviour (writes that fail today would start succeeding)
and puts a per-share lookup on the write path, which needs its own design —
see #2057, which also lists the other readers: the per-share Prometheus
`LogicalBytes` gauge, `dfsctl quota list`'s per-identity usage, and `df` /
FSSTAT on the badger and memory backends (the SQL backends already scope that
one with a `share_name` predicate).

## Which number this reports, and what it means

**USED is now the share's logical size: the sum of its files' recorded sizes,
regular files only** — what `du --apparent-size` reports over the mounted
share. This is the number `QUOTA` is measured against, so the two columns are
now comparable, and it is what the API field already claimed to be
(`used_bytes`: *"Logical used bytes (sum of file sizes)"*).

It is deliberately **not** a count of bytes on disk, because no per-share
on-disk number exists to report:

- blocks are deduplicated and compressed, so on-disk bytes are smaller than
  logical bytes by an amount no share owns;
- a local block store is shared by every share configured against it, so its
  on-disk size is not divisible by share at all;
- the local tier is a cache — a share whose blocks have been drained to its
  remote store occupies almost nothing locally while still holding every one of
  its files. A usage column that dropped to near zero on eviction would be worse
  than the bug.

The logical figure survives both: it is unchanged by dedup, by compression, and
by which tier the bytes currently sit in. The `share list` help text now says
so, and points at `dfsctl store block stats` for on-disk figures.
No column header change: the column's *documented* meaning did not change, only
its computation, which was wrong.

## The change

`Store.GetUsedBytesForShare(ctx, shareName) (int64, error)` joins the store
contract next to `GetUsedBytes`, with the store-wide caveat now written into
`GetUsedBytes`' own doc comment so the next caller does not repeat this.

- **sqlite / postgres** — a scoped `SUM(size)` over the `share_name` index,
  mirroring the share-scoped branch `statfsQuery` already uses, so
  `GetUsedBytesForShare` and `GetFilesystemStatistics` cannot disagree.
- **memory** — a walk of the files map under the read lock.
- **badger** — file records are keyed by UUID with no share index, so one scan
  buckets every share at once, cached until the next commit. Marked
  `ponytail:` with its ceiling and the upgrade path (thread a share dimension
  through the transaction delta pipeline that maintains `usedBytes`). Three
  details are load-bearing: the scan runs with the cache lock **released**, so a
  committing transaction's post-commit invalidation never queues behind a scan
  of every record; a generation counter makes a scan that raced an invalidation
  discard its result rather than publish a superseded one; and the invalidation
  is unconditional on commit rather than gated on a non-zero byte delta, because
  two size changes that cancel across two shares move both buckets while leaving
  the store-wide sum untouched. The TTL is only a backstop.

`Runtime.GetShareUsage` takes a `ctx` and calls it. Its doc comment now records
that the physical figure it returns alongside is per *block store*, not per
share.

## Verification

- New conformance case `StoreSurface/GetUsedBytesForShare`: two shares in one
  store, 3000 and 5000 bytes. It asserts `GetUsedBytes() == 8000` first, so the
  fixture provably reproduces the reported condition, then asserts each share
  reports only its own bytes across create, mkdir, truncate and delete, and that
  an unknown share reports `(0, nil)`. Green on memory, badger (both durability
  modes) and sqlite locally; postgres runs in CI.
- `go build ./...`, `go vet ./...`, `go test ./...` clean.
- `docs/guide/cli.md` regenerated with `go run ./cmd/gendocs`.

Closes #2052
