### PR TITLE
refactor(metadata): extract store/basestore from internal/{quota,sqlstat}

### DIFF
--- a/pkg/metadata/store/badger/shares.go
+++ b/pkg/metadata/store/badger/shares.go
@@ -19,10 +19,7 @@ import (
 
 // GenerateHandle creates a new unique file handle for a path in a share.
 func (s *BadgerMetadataStore) GenerateHandle(ctx context.Context, shareName string, path string) (metadata.FileHandle, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-	return metadata.GenerateNewHandle(shareName)
+	return basestore.GenerateHandle(ctx, shareName)
 }
 
 // ============================================================================

--- a/pkg/metadata/store/badger/shares.go
+++ b/pkg/metadata/store/badger/shares.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/metadata"
-	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
+	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sharecache"
 )
 
@@ -191,7 +191,7 @@ func (s *BadgerMetadataStore) DeleteShare(ctx context.Context, shareName string)
 	}
 
 	var freedBytes int64
-	var quotaFreed map[quota.Key]metadata.UsageStat
+	var quotaFreed map[basestore.QuotaKey]metadata.UsageStat
 	err := s.updateWithConflictRetry(ctx, func(txn *badgerdb.Txn) error {
 		_, err := txn.Get(keyShare(shareName))
 		if err != nil {
@@ -223,7 +223,7 @@ func (s *BadgerMetadataStore) DeleteShare(ctx context.Context, shareName string)
 // applyQuotaDelta folds a per-identity usage delta into the in-memory usage
 // cache. Called post-commit (matching usedBytes). Buckets that drop to zero or
 // below are removed.
-func (s *BadgerMetadataStore) applyQuotaDelta(delta map[quota.Key]metadata.UsageStat) {
+func (s *BadgerMetadataStore) applyQuotaDelta(delta map[basestore.QuotaKey]metadata.UsageStat) {
 	if len(delta) == 0 {
 		return
 	}
@@ -247,7 +247,7 @@ func (s *BadgerMetadataStore) applyQuotaDelta(delta map[quota.Key]metadata.Usage
 // pendingDelta and the pool-path applies it only once updateWithConflictRetry
 // returns nil — so a conflict retry that re-runs the enclosing Update never
 // double-counts. The counter is statfs-only, not quota-enforcing.
-func (s *BadgerMetadataStore) deleteShareFiles(txn *badgerdb.Txn, shareName string) (freedBytes int64, quotaFreed map[quota.Key]metadata.UsageStat, err error) {
+func (s *BadgerMetadataStore) deleteShareFiles(txn *badgerdb.Txn, shareName string) (freedBytes int64, quotaFreed map[basestore.QuotaKey]metadata.UsageStat, err error) {
 	type doomed struct {
 		id        uuid.UUID
 		objectID  metadata.ContentHash
@@ -293,7 +293,7 @@ func (s *BadgerMetadataStore) deleteShareFiles(txn *badgerdb.Txn, shareName stri
 	}
 	it.Close()
 
-	quotaFreed = make(map[quota.Key]metadata.UsageStat)
+	quotaFreed = make(map[basestore.QuotaKey]metadata.UsageStat)
 	for _, v := range victims {
 		if delErr := deleteFileKeys(txn, v.id, v.objectID, v.payloadID); delErr != nil {
 			return 0, nil, delErr
@@ -309,12 +309,12 @@ func (s *BadgerMetadataStore) deleteShareFiles(txn *badgerdb.Txn, shareName stri
 			if v.size > 0 {
 				freedBytes += int64(v.size)
 			}
-			uk := quota.Key{Scope: metadata.QuotaScopeUser, ID: v.uid}
+			uk := basestore.QuotaKey{Scope: metadata.QuotaScopeUser, ID: v.uid}
 			us := quotaFreed[uk]
 			us.Bytes -= int64(v.size)
 			us.Files--
 			quotaFreed[uk] = us
-			gk := quota.Key{Scope: metadata.QuotaScopeGroup, ID: v.gid}
+			gk := basestore.QuotaKey{Scope: metadata.QuotaScopeGroup, ID: v.gid}
 			gs := quotaFreed[gk]
 			gs.Bytes -= int64(v.size)
 			gs.Files--

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -736,33 +736,8 @@ func NewBadgerMetadataStoreWithDefaultsAndCaches(ctx context.Context, dbPath str
 // and limits) for the given path, with cache sizes left at 0 (auto-sized).
 func defaultStoreConfig(dbPath string) BadgerMetadataStoreConfig {
 	return BadgerMetadataStoreConfig{
-		DBPath: dbPath,
-		Capabilities: metadata.FilesystemCapabilities{
-			// Transfer Sizes
-			MaxReadSize:        1048576, // 1MB
-			PreferredReadSize:  1048576, // 1MB — matches Linux knfsd default; reduces NFS round-trips per block
-			MaxWriteSize:       1048576, // 1MB
-			PreferredWriteSize: 1048576, // 1MB
-
-			// Limits
-			MaxFileSize:      9223372036854775807, // 2^63-1 (practically unlimited)
-			MaxFilenameLen:   255,                 // Standard Unix limit
-			MaxPathLen:       4096,                // Standard Unix limit
-			MaxHardLinkCount: 32767,               // Similar to ext4
-
-			// Features
-			SupportsHardLinks:     true,  // We track link counts
-			SupportsSymlinks:      true,  // We store symlink targets
-			CaseSensitive:         true,  // Keys are case-sensitive
-			CasePreserving:        true,  // We store exact filenames
-			ChownRestricted:       false, // Allow chown
-			SupportsACLs:          false, // No ACL support yet
-			SupportsExtendedAttrs: true,  // EAs persist in the FileAttr JSON blob
-			TruncatesLongNames:    true,  // Reject with error
-
-			// Time Resolution
-			TimestampResolution: 1, // 1 nanosecond (Go time.Time precision)
-		},
+		DBPath:          dbPath,
+		Capabilities:    basestore.DefaultCapabilities(),
 		MaxStorageBytes: 0, // Unlimited (reported as available disk space)
 		MaxFiles:        0, // Unlimited (reported as 1 million)
 	}

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
-	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
+	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sharecache"
 )
 
@@ -153,7 +153,7 @@ type BadgerMetadataStore struct {
 	// transaction's pending per-identity deltas exactly once on successful
 	// commit. Guarded by quotaMu.
 	quotaMu sync.Mutex
-	quota   *quota.Cache
+	quota   *basestore.QuotaCache
 
 	// storeID is the engine-persistent identifier for this store instance,
 	// backed by the cfg:store_id key in BadgerDB. Created on first open of
@@ -382,7 +382,7 @@ func NewBadgerMetadataStore(ctx context.Context, config BadgerMetadataStoreConfi
 		storeID:           sid,
 		relaxedDurability: config.RelaxedDurability,
 		syncStop:          make(chan struct{}),
-		quota:             quota.NewCache(),
+		quota:             basestore.NewQuotaCache(),
 	}
 	// The substores derive only from db, which is never reassigned, so bind
 	// them once here.

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -957,11 +957,7 @@ func (tx *badgerTransaction) PutFilesystemMeta(ctx context.Context, shareName st
 }
 
 func (tx *badgerTransaction) GenerateHandle(ctx context.Context, shareName string, path string) (metadata.FileHandle, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	return metadata.GenerateNewHandle(shareName)
+	return basestore.GenerateHandle(ctx, shareName)
 }
 
 // ============================================================================

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -13,7 +13,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	mderrors "github.com/marmos91/dittofs/pkg/metadata/errors"
-	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
+	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 )
 
 // ============================================================================
@@ -40,7 +40,7 @@ type badgerTransaction struct {
 	// (scope, id). Captured per attempt and applied to the store's quota cache
 	// exactly once after a successful commit, identical to pendingDelta (so a
 	// conflict-retry cannot double-count).
-	quota quota.Delta
+	quota basestore.QuotaDelta
 	// dirtyShares collects share names whose stored share record this
 	// transaction mutated. Captured per attempt and, after a successful commit,
 	// used to invalidate the share read cache (see withTransaction). Reset per
@@ -123,7 +123,7 @@ func (s *BadgerMetadataStore) withTransaction(ctx context.Context, fn func(tx me
 		// successful commit and reset per attempt (a retried attempt starts
 		// from zero, so a conflict-retry cannot double-count usedBytes).
 		var pendingDelta int64
-		var quotaDelta map[quota.Key]metadata.UsageStat
+		var quotaDelta map[basestore.QuotaKey]metadata.UsageStat
 		var dirtyFiles []string
 		var dirtyShares []string
 		var dirtyDirents []string

--- a/pkg/metadata/store/basestore/capabilities.go
+++ b/pkg/metadata/store/basestore/capabilities.go
@@ -1,0 +1,40 @@
+package basestore
+
+import "github.com/marmos91/dittofs/pkg/metadata"
+
+// DefaultCapabilities returns the filesystem capabilities a backend reports
+// when the operator has not configured any: 1 MiB transfers, POSIX-shaped
+// name and path limits, and no hard file-size ceiling.
+//
+// The 1 MiB preferred read/write matches the Linux knfsd default and keeps NFS
+// round-trips per block down. Capabilities are advertised to clients, not
+// enforced here, so a backend that genuinely cannot do something (ACLs today)
+// must say so rather than inherit a true from this set.
+func DefaultCapabilities() metadata.FilesystemCapabilities {
+	return metadata.FilesystemCapabilities{
+		// Transfer sizes.
+		MaxReadSize:        1048576,
+		PreferredReadSize:  1048576,
+		MaxWriteSize:       1048576,
+		PreferredWriteSize: 1048576,
+
+		// Limits.
+		MaxFileSize:      9223372036854775807, // 2^63-1, practically unlimited
+		MaxFilenameLen:   255,                 // standard Unix limit
+		MaxPathLen:       4096,                // standard Unix limit
+		MaxHardLinkCount: 32767,               // similar to ext4
+
+		// Features.
+		SupportsHardLinks:     true,  // link counts are tracked
+		SupportsSymlinks:      true,  // symlink targets are stored
+		CaseSensitive:         true,  // keys are case-sensitive
+		CasePreserving:        true,  // exact filenames are stored
+		ChownRestricted:       false, // chown is allowed
+		SupportsACLs:          false, // no ACL support yet
+		SupportsExtendedAttrs: true,  // EAs persist on FileAttr.EAs
+		TruncatesLongNames:    true,  // reject with an error, do not truncate
+
+		// Time resolution.
+		TimestampResolution: 1, // 1ns, Go time.Time precision
+	}
+}

--- a/pkg/metadata/store/basestore/handle.go
+++ b/pkg/metadata/store/basestore/handle.go
@@ -1,0 +1,20 @@
+package basestore
+
+import (
+	"context"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// GenerateHandle mints a fresh UUID-based file handle for the named share.
+//
+// The path a caller passes to the store-level GenerateHandle is ignored: every
+// backend addresses files by UUID, and the path is carried in the file record.
+// Returns an error rather than panicking when the encoded handle would exceed
+// the 64-byte limit.
+func GenerateHandle(ctx context.Context, shareName string) (metadata.FileHandle, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return metadata.GenerateNewHandle(shareName)
+}

--- a/pkg/metadata/store/basestore/quota.go
+++ b/pkg/metadata/store/basestore/quota.go
@@ -1,54 +1,62 @@
-// Package quota holds the shared per-identity usage accounting used by every
-// metadata store backend. Each backend keeps a Cache of per-user/per-group
-// byte and file counts (for statfs and quota enforcement) and accumulates
-// changes made inside a transaction in a Delta, folding the Delta into the
-// Cache exactly once after the transaction commits so a conflict-retry never
+// Package basestore holds the pieces every metadata store backend shares:
+// per-identity usage accounting, the statfs assembly used by the SQL
+// backends, the default filesystem capabilities, and file-handle minting.
+//
+// It deliberately holds no retry policy. The SQL family retries on
+// busy/serialization errors through internal/txretry; the KV family retries
+// on Badger's SSI conflicts inside its own loop. Those budgets must never be
+// shared.
+//
+// Quota accounting: each backend keeps a QuotaCache of per-user/per-group byte
+// and file counts (for statfs and quota enforcement) and accumulates changes
+// made inside a transaction in a QuotaDelta, folding the delta into the cache
+// exactly once after the transaction commits so a conflict-retry never
 // double-counts.
 //
-// Cache performs no locking of its own; callers guard it with their existing
-// mutex.
-package quota
+// QuotaCache performs no locking of its own; callers guard it with their
+// existing mutex.
+package basestore
 
 import "github.com/marmos91/dittofs/pkg/metadata"
 
-// Key identifies a per-identity usage bucket: an owner id within a scope
+// QuotaKey identifies a per-identity usage bucket: an owner id within a scope
 // (user or group).
-type Key struct {
+type QuotaKey struct {
 	Scope metadata.QuotaScope
 	ID    uint32
 }
 
-// Cache holds per-identity usage split into user and group scopes. It does no
+// QuotaCache holds per-identity usage split into user and group scopes. It does no
 // locking; callers hold their own mutex across Get/Apply/Seed/Reset.
-type Cache struct {
+type QuotaCache struct {
 	user  map[uint32]*metadata.UsageStat
 	group map[uint32]*metadata.UsageStat
 }
 
-// NewCache returns an empty, ready-to-use Cache.
-func NewCache() *Cache {
-	return &Cache{
+// NewQuotaCache returns an empty, ready-to-use QuotaCache.
+func NewQuotaCache() *QuotaCache {
+	return &QuotaCache{
 		user:  make(map[uint32]*metadata.UsageStat),
 		group: make(map[uint32]*metadata.UsageStat),
 	}
 }
 
 // Reset empties the cache.
-func (c *Cache) Reset() {
+func (c *QuotaCache) Reset() {
 	c.user = make(map[uint32]*metadata.UsageStat)
 	c.group = make(map[uint32]*metadata.UsageStat)
 }
 
 // Seed replaces the cache contents with per-identity usage pre-aggregated from
 // durable rows at startup. The maps are adopted as-is.
-func (c *Cache) Seed(user, group map[uint32]*metadata.UsageStat) {
+func (c *QuotaCache) Seed(user, group map[uint32]*metadata.UsageStat) {
 	c.user = user
 	c.group = group
 }
 
 // Get returns the usage for one identity. A missing key returns a zero
 // UsageStat.
-func (c *Cache) Get(scope metadata.QuotaScope, id uint32) metadata.UsageStat {
+func (c *QuotaCache) Get(scope metadata.QuotaScope, id uint32) metadata.UsageStat {
 	m := c.user
 	if scope == metadata.QuotaScopeGroup {
 		m = c.group
@@ -62,7 +70,7 @@ func (c *Cache) Get(scope metadata.QuotaScope, id uint32) metadata.UsageStat {
 // Apply folds a per-identity usage delta into the cache. Buckets that drop to
 // zero or below are removed; a negative accumulation is clamped to zero so a
 // quota enforcer never reads a too-permissive total.
-func (c *Cache) Apply(delta map[Key]metadata.UsageStat) {
+func (c *QuotaCache) Apply(delta map[QuotaKey]metadata.UsageStat) {
 	for k, d := range delta {
 		m := c.user
 		if k.Scope == metadata.QuotaScopeGroup {
@@ -87,41 +95,41 @@ func (c *Cache) Apply(delta map[Key]metadata.UsageStat) {
 	}
 }
 
-// Delta accumulates per-identity usage changes made inside a single
-// transaction, keyed by owner identity. It is folded into a Cache exactly once
+// QuotaDelta accumulates per-identity usage changes made inside a single
+// transaction, keyed by owner identity. It is folded into a QuotaCache exactly once
 // after the transaction commits. The zero value is ready to use.
-type Delta struct {
-	m map[Key]metadata.UsageStat
+type QuotaDelta struct {
+	m map[QuotaKey]metadata.UsageStat
 }
 
 // Add records a usage change for a file's owner identity across both the user
 // and group scopes. bytes is the size delta; files is the inode delta (+1 on
 // create, -1 on delete, 0 for an in-place resize). A no-op change is dropped.
-func (d *Delta) Add(uid, gid uint32, bytes, files int64) {
+func (d *QuotaDelta) Add(uid, gid uint32, bytes, files int64) {
 	if bytes == 0 && files == 0 {
 		return
 	}
 	if d.m == nil {
-		d.m = make(map[Key]metadata.UsageStat)
+		d.m = make(map[QuotaKey]metadata.UsageStat)
 	}
-	u := d.m[Key{metadata.QuotaScopeUser, uid}]
+	u := d.m[QuotaKey{metadata.QuotaScopeUser, uid}]
 	u.Bytes += bytes
 	u.Files += files
-	d.m[Key{metadata.QuotaScopeUser, uid}] = u
-	g := d.m[Key{metadata.QuotaScopeGroup, gid}]
+	d.m[QuotaKey{metadata.QuotaScopeUser, uid}] = u
+	g := d.m[QuotaKey{metadata.QuotaScopeGroup, gid}]
 	g.Bytes += bytes
 	g.Files += files
-	d.m[Key{metadata.QuotaScopeGroup, gid}] = g
+	d.m[QuotaKey{metadata.QuotaScopeGroup, gid}] = g
 }
 
 // AddKeyed merges a single pre-keyed usage change (used when folding the
 // per-identity totals freed by a share delete). A no-op change is dropped.
-func (d *Delta) AddKeyed(k Key, s metadata.UsageStat) {
+func (d *QuotaDelta) AddKeyed(k QuotaKey, s metadata.UsageStat) {
 	if s.Bytes == 0 && s.Files == 0 {
 		return
 	}
 	if d.m == nil {
-		d.m = make(map[Key]metadata.UsageStat)
+		d.m = make(map[QuotaKey]metadata.UsageStat)
 	}
 	cur := d.m[k]
 	cur.Bytes += s.Bytes
@@ -129,8 +137,8 @@ func (d *Delta) AddKeyed(k Key, s metadata.UsageStat) {
 	d.m[k] = cur
 }
 
-// Map returns the accumulated per-identity deltas for folding into a Cache.
+// Map returns the accumulated per-identity deltas for folding into a QuotaCache.
 // It may be nil when nothing was accumulated.
-func (d *Delta) Map() map[Key]metadata.UsageStat {
+func (d *QuotaDelta) Map() map[QuotaKey]metadata.UsageStat {
 	return d.m
 }

--- a/pkg/metadata/store/basestore/quota_test.go
+++ b/pkg/metadata/store/basestore/quota_test.go
@@ -1,4 +1,4 @@
-package quota
+package basestore
 
 import (
 	"testing"
@@ -7,11 +7,11 @@ import (
 )
 
 // TestDeltaApplyAndGet exercises the accumulate → apply → read round-trip that
-// every store shares: a Delta records owner changes across user and group
-// scopes, the Cache folds them, and Get reports the result.
+// every store shares: a QuotaDelta records owner changes across user and group
+// scopes, the QuotaCache folds them, and Get reports the result.
 func TestDeltaApplyAndGet(t *testing.T) {
-	c := NewCache()
-	var d Delta
+	c := NewQuotaCache()
+	var d QuotaDelta
 
 	// Create a 1000-byte file owned by uid 7 / gid 3.
 	d.Add(7, 3, 1000, 1)
@@ -33,14 +33,14 @@ func TestDeltaApplyAndGet(t *testing.T) {
 // logic: removing the file empties the bucket, and an over-decrement never
 // leaves a negative total.
 func TestApplyDeletesAtZero(t *testing.T) {
-	c := NewCache()
+	c := NewQuotaCache()
 
-	var create Delta
+	var create QuotaDelta
 	create.Add(7, 3, 1000, 1)
 	c.Apply(create.Map())
 
 	// Delete the file: bucket reaches zero and is removed.
-	var del Delta
+	var del QuotaDelta
 	del.Add(7, 3, -1000, -1)
 	c.Apply(del.Map())
 
@@ -50,7 +50,7 @@ func TestApplyDeletesAtZero(t *testing.T) {
 
 	// Over-decrement (accounting drift) clamps to zero rather than going
 	// negative.
-	c.Apply(map[Key]metadata.UsageStat{
+	c.Apply(map[QuotaKey]metadata.UsageStat{
 		{metadata.QuotaScopeUser, 7}: {Bytes: -500, Files: -1},
 	})
 	if got := c.Get(metadata.QuotaScopeUser, 7); got.Bytes < 0 || got.Files < 0 {

--- a/pkg/metadata/store/basestore/statfs.go
+++ b/pkg/metadata/store/basestore/statfs.go
@@ -1,8 +1,9 @@
-// Package sqlstat holds the statfs assembly shared by the SQL metadata store
+// statfs.go holds the statfs assembly shared by the SQL metadata store
 // backends. Each backend runs its own aggregate query (the placeholder syntax
 // differs between drivers) and hands the scanned used-bytes / used-files counts
 // here to build the reported FilesystemStatistics.
-package sqlstat
+
+package basestore
 
 import "github.com/marmos91/dittofs/pkg/metadata"
 
@@ -13,10 +14,10 @@ const (
 	TotalFiles uint64 = 1 << 32 // 4 billion files
 )
 
-// Build assembles a FilesystemStatistics from the scanned aggregate counts,
+// BuildStatistics assembles a FilesystemStatistics from the scanned aggregate counts,
 // clamping available space to zero if usage somehow exceeds the (effectively
 // unlimited) ceilings.
-func Build(bytesUsed, filesUsed int64) *metadata.FilesystemStatistics {
+func BuildStatistics(bytesUsed, filesUsed int64) *metadata.FilesystemStatistics {
 	used := uint64(bytesUsed)
 	usedFiles := uint64(filesUsed)
 

--- a/pkg/metadata/store/basestore/statfs_test.go
+++ b/pkg/metadata/store/basestore/statfs_test.go
@@ -1,11 +1,11 @@
-package sqlstat
+package basestore
 
 import "testing"
 
 // TestBuild verifies the shared assembler computes used / available from the
 // scanned aggregate and reports the unlimited ceilings.
-func TestBuild(t *testing.T) {
-	stats := Build(4096, 3)
+func TestBuildStatistics(t *testing.T) {
+	stats := BuildStatistics(4096, 3)
 
 	if stats.UsedBytes != 4096 {
 		t.Errorf("UsedBytes = %d, want 4096", stats.UsedBytes)
@@ -30,7 +30,7 @@ func TestBuild(t *testing.T) {
 // TestBuild_ZeroUsage covers the empty-share case: zero usage yields the full
 // ceiling as available.
 func TestBuild_ZeroUsage(t *testing.T) {
-	stats := Build(0, 0)
+	stats := BuildStatistics(0, 0)
 	if stats.AvailableBytes != TotalBytes {
 		t.Errorf("AvailableBytes = %d, want full ceiling %d", stats.AvailableBytes, TotalBytes)
 	}

--- a/pkg/metadata/store/memory/snapshot_store.go
+++ b/pkg/metadata/store/memory/snapshot_store.go
@@ -14,7 +14,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/backup"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
-	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
+	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 )
 
 const (
@@ -414,7 +414,7 @@ func (s *MemoryMetadataStore) RestoreSnapshot(ctx context.Context, r io.Reader) 
 	// A cache left at its pre-restore contents reports usage for files that
 	// no longer exist.
 	var totalBytes int64
-	var usage quota.Delta
+	var usage basestore.QuotaDelta
 	for _, fd := range s.files {
 		if fd.Attr != nil && fd.Attr.Type == metadata.FileTypeRegular {
 			totalBytes += int64(fd.Attr.Size)

--- a/pkg/metadata/store/memory/store.go
+++ b/pkg/metadata/store/memory/store.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
-	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
+	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 )
 
 // shareData holds the internal representation of a share configuration.
@@ -214,7 +214,7 @@ type MemoryMetadataStore struct {
 	// transaction's pending per-identity deltas exactly once on successful
 	// commit, identical to the usedBytes discipline.
 	quotaMu sync.Mutex
-	quota   *quota.Cache
+	quota   *basestore.QuotaCache
 
 	// storeID is the engine-persistent identifier for this store instance.
 	// Assigned on construction with a fresh ULID and immutable for the life
@@ -326,7 +326,7 @@ func NewMemoryMetadataStore(config MemoryMetadataStoreConfig) *MemoryMetadataSto
 		// ObjectID -> handle-key secondary index.
 		objectIndex: make(map[block.ContentHash]string),
 		// per-identity quota usage counters.
-		quota: quota.NewCache(),
+		quota: basestore.NewQuotaCache(),
 		// Block packing record store.
 		blockRecords: make(map[string]*block.BlockRecord),
 	}

--- a/pkg/metadata/store/memory/store.go
+++ b/pkg/metadata/store/memory/store.go
@@ -366,32 +366,7 @@ func NewMemoryMetadataStore(config MemoryMetadataStoreConfig) *MemoryMetadataSto
 //   - *MemoryMetadataStore: A new store instance with default configuration
 func NewMemoryMetadataStoreWithDefaults() *MemoryMetadataStore {
 	return NewMemoryMetadataStore(MemoryMetadataStoreConfig{
-		Capabilities: metadata.FilesystemCapabilities{
-			// Transfer Sizes
-			MaxReadSize:        1048576, // 1MB
-			PreferredReadSize:  1048576, // 1MB — matches Linux knfsd default; reduces NFS round-trips per block
-			MaxWriteSize:       1048576, // 1MB
-			PreferredWriteSize: 1048576, // 1MB
-
-			// Limits
-			MaxFileSize:      9223372036854775807, // 2^63-1 (practically unlimited)
-			MaxFilenameLen:   255,                 // Standard Unix limit
-			MaxPathLen:       4096,                // Standard Unix limit
-			MaxHardLinkCount: 32767,               // Similar to ext4
-
-			// Features
-			SupportsHardLinks:     true, // We track link counts
-			SupportsSymlinks:      true, // We store symlink targets
-			CaseSensitive:         true, // Go map keys are case-sensitive
-			CasePreserving:        true, // We store exact filenames
-			ChownRestricted:       false,
-			SupportsACLs:          false,
-			SupportsExtendedAttrs: true, // EAs persist on FileAttr.EAs (set/query via SMB FileFullEaInformation)
-			TruncatesLongNames:    true, // Reject with error, don't truncate
-
-			// Time Resolution
-			TimestampResolution: 1, // 1 nanosecond (Go time.Time precision)
-		},
+		Capabilities:    basestore.DefaultCapabilities(),
 		MaxStorageBytes: 0, // Unlimited (reported as 1TB)
 		MaxFiles:        0, // Unlimited (reported as 1 million)
 	})

--- a/pkg/metadata/store/memory/transaction.go
+++ b/pkg/metadata/store/memory/transaction.go
@@ -9,7 +9,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	mderrors "github.com/marmos91/dittofs/pkg/metadata/errors"
-	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
+	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 )
 
 // ============================================================================
@@ -31,7 +31,7 @@ type memoryTransaction struct {
 	// quota accumulates per-identity usage changes (bytes + file count) keyed by
 	// (scope, id). Applied to the store's quota cache exactly once after a
 	// successful commit, identical to pendingDelta.
-	quota quota.Delta
+	quota basestore.QuotaDelta
 	// syncedOps buffers SyncedHashStore mutations made inside the closure.
 	// The synced maps live under their own mutex (syncedMu), NOT store.mu, so
 	// they cannot participate in the snapshot/restore rollback: instead the

--- a/pkg/metadata/store/memory/transaction.go
+++ b/pkg/metadata/store/memory/transaction.go
@@ -510,11 +510,7 @@ func (tx *memoryTransaction) PutFilesystemMeta(ctx context.Context, shareName st
 }
 
 func (tx *memoryTransaction) GenerateHandle(ctx context.Context, shareName string, path string) (metadata.FileHandle, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	return metadata.GenerateNewHandle(shareName)
+	return basestore.GenerateHandle(ctx, shareName)
 }
 
 func (tx *memoryTransaction) GetFileByPayloadID(ctx context.Context, payloadID metadata.PayloadID) (*metadata.File, error) {

--- a/pkg/metadata/store/postgres/server.go
+++ b/pkg/metadata/store/postgres/server.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/marmos91/dittofs/pkg/metadata"
-	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlstat"
+	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 )
 
 // ============================================================================
@@ -94,5 +94,5 @@ func (s *PostgresMetadataStore) GetFilesystemStatistics(ctx context.Context, han
 	if err := s.queryRow(ctx, sql, args...).Scan(&bytesUsed, &filesUsed); err != nil {
 		return nil, mapPgError(err, "GetFilesystemStatistics", "")
 	}
-	return sqlstat.Build(bytesUsed, filesUsed), nil
+	return basestore.BuildStatistics(bytesUsed, filesUsed), nil
 }

--- a/pkg/metadata/store/postgres/shares.go
+++ b/pkg/metadata/store/postgres/shares.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sharecache"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlcodec"
 )
@@ -20,12 +21,7 @@ import (
 
 // GenerateHandle creates a new unique file handle for a path in a share.
 func (s *PostgresMetadataStore) GenerateHandle(ctx context.Context, shareName string, path string) (metadata.FileHandle, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	// PostgreSQL uses UUID-based handles, path is stored in File struct
-	return metadata.GenerateNewHandle(shareName)
+	return basestore.GenerateHandle(ctx, shareName)
 }
 
 // GetRootHandle returns the root handle for a share.

--- a/pkg/metadata/store/postgres/store.go
+++ b/pkg/metadata/store/postgres/store.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/metadata"
-	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
+	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sharecache"
 )
 
@@ -73,7 +73,7 @@ type PostgresMetadataStore struct {
 	// it is always reconstructed correctly). Updated from a transaction's pending
 	// per-identity deltas exactly once on successful commit. Guarded by quotaMu.
 	quotaMu sync.Mutex
-	quota   *quota.Cache
+	quota   *basestore.QuotaCache
 
 	// shareCache caches decoded ShareOptions so the permission funnel every
 	// read/write/create/setattr traverses does not re-run the options SELECT
@@ -145,7 +145,7 @@ func NewPostgresMetadataStore(
 		logger:       log,
 		ctx:          storeCtx,
 		cancel:       cancel,
-		quota:        quota.NewCache(),
+		quota:        basestore.NewQuotaCache(),
 	}
 	// The substores derive only from pool, which is never reassigned, so bind
 	// them once here.
@@ -257,7 +257,7 @@ func (s *PostgresMetadataStore) GetQuotaUsage(scope metadata.QuotaScope, id uint
 // applyQuotaDelta folds a per-identity usage delta into the in-memory usage
 // cache. Called post-commit (matching usedBytes). Buckets that drop to zero or
 // below are removed.
-func (s *PostgresMetadataStore) applyQuotaDelta(delta map[quota.Key]metadata.UsageStat) {
+func (s *PostgresMetadataStore) applyQuotaDelta(delta map[basestore.QuotaKey]metadata.UsageStat) {
 	if len(delta) == 0 {
 		return
 	}

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -15,9 +15,8 @@ import (
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/acl"
-	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
+	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlcodec"
-	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlstat"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/txretry"
 )
 
@@ -47,7 +46,7 @@ type postgresTransaction struct {
 	// (scope, id). Applied to the store's quota cache exactly once after a
 	// successful commit, identical to pendingDelta (so a serialization/deadlock
 	// retry never double-counts).
-	quota quota.Delta
+	quota basestore.QuotaDelta
 	// sharesDirty records that this transaction wrote a share record, so the
 	// store's ShareOptions cache is dropped after the commit. A stale entry is
 	// a wrong permission decision, and shares are few enough that clearing the
@@ -1116,7 +1115,7 @@ func (tx *postgresTransaction) collectShareQuotaFreed(ctx context.Context, share
 		if err := rows.Scan(&id, &bytes, &files); err != nil {
 			return mapPgError(err, "DeleteShare", shareName)
 		}
-		tx.quota.AddKeyed(quota.Key{Scope: scope, ID: uint32(id)}, metadata.UsageStat{Bytes: -bytes, Files: -files})
+		tx.quota.AddKeyed(basestore.QuotaKey{Scope: scope, ID: uint32(id)}, metadata.UsageStat{Bytes: -bytes, Files: -files})
 	}
 	if err := rows.Err(); err != nil {
 		return mapPgError(err, "DeleteShare", shareName)
@@ -1381,7 +1380,7 @@ func (tx *postgresTransaction) GetFilesystemStatistics(ctx context.Context, hand
 		return nil, mapPgError(err, "GetFilesystemStatistics", "")
 	}
 
-	return sqlstat.Build(bytesUsed, filesUsed), nil
+	return basestore.BuildStatistics(bytesUsed, filesUsed), nil
 }
 
 // ============================================================================

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -932,12 +932,7 @@ func (tx *postgresTransaction) PutFilesystemMeta(ctx context.Context, shareName 
 }
 
 func (tx *postgresTransaction) GenerateHandle(ctx context.Context, shareName string, path string) (metadata.FileHandle, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	// PostgreSQL uses UUID-based handles, path is stored in File struct
-	return metadata.GenerateNewHandle(shareName)
+	return basestore.GenerateHandle(ctx, shareName)
 }
 
 // ============================================================================

--- a/pkg/metadata/store/sqlite/server.go
+++ b/pkg/metadata/store/sqlite/server.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 
 	"github.com/marmos91/dittofs/pkg/metadata"
-	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlstat"
+	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 )
 
 // ============================================================================
@@ -106,5 +106,5 @@ func (s *SQLiteMetadataStore) GetFilesystemStatistics(ctx context.Context, handl
 	if err := s.queryRow(ctx, sql, args...).Scan(&bytesUsed, &filesUsed); err != nil {
 		return nil, mapDBError(err, "GetFilesystemStatistics", "")
 	}
-	return sqlstat.Build(bytesUsed, filesUsed), nil
+	return basestore.BuildStatistics(bytesUsed, filesUsed), nil
 }

--- a/pkg/metadata/store/sqlite/shares.go
+++ b/pkg/metadata/store/sqlite/shares.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sharecache"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlcodec"
 )
@@ -20,12 +21,7 @@ import (
 
 // GenerateHandle creates a new unique file handle for a path in a share.
 func (s *SQLiteMetadataStore) GenerateHandle(ctx context.Context, shareName string, path string) (metadata.FileHandle, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	// Handles are UUID-based; the path is stored in the File struct.
-	return metadata.GenerateNewHandle(shareName)
+	return basestore.GenerateHandle(ctx, shareName)
 }
 
 // GetRootHandle returns the root handle for a share.

--- a/pkg/metadata/store/sqlite/store.go
+++ b/pkg/metadata/store/sqlite/store.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/metadata"
-	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
+	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sharecache"
 )
 
@@ -74,7 +74,7 @@ type SQLiteMetadataStore struct {
 	// keyed by owner uid / gid. Seeded from a GROUP BY query on startup and
 	// updated from each committed transaction's deltas. Guarded by quotaMu.
 	quotaMu sync.Mutex
-	quota   *quota.Cache
+	quota   *basestore.QuotaCache
 
 	// shareCache caches decoded ShareOptions so the permission funnel every
 	// read/write/create/setattr traverses does not re-run the options SELECT
@@ -157,7 +157,7 @@ func NewSQLiteMetadataStore(
 		logger:       log,
 		ctx:          storeCtx,
 		cancel:       cancel,
-		quota:        quota.NewCache(),
+		quota:        basestore.NewQuotaCache(),
 	}
 	// The substores derive only from db, which is never reassigned, so bind
 	// them once here.
@@ -252,7 +252,7 @@ func (s *SQLiteMetadataStore) GetQuotaUsage(scope metadata.QuotaScope, id uint32
 
 // applyQuotaDelta folds a per-identity usage delta into the in-memory usage
 // cache. Called post-commit (matching usedBytes).
-func (s *SQLiteMetadataStore) applyQuotaDelta(delta map[quota.Key]metadata.UsageStat) {
+func (s *SQLiteMetadataStore) applyQuotaDelta(delta map[basestore.QuotaKey]metadata.UsageStat) {
 	if len(delta) == 0 {
 		return
 	}

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -13,9 +13,8 @@ import (
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/acl"
-	"github.com/marmos91/dittofs/pkg/metadata/store/internal/quota"
+	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlcodec"
-	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlstat"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/txretry"
 )
 
@@ -48,7 +47,7 @@ type sqliteTransaction struct {
 	// (scope, id). Applied to the store's quota cache exactly once after a
 	// successful commit, identical to pendingDelta (so a serialization/deadlock
 	// retry never double-counts).
-	quota quota.Delta
+	quota basestore.QuotaDelta
 	// sharesDirty records that this transaction wrote a share record, so the
 	// store's ShareOptions cache is dropped after the commit. A stale entry is
 	// a wrong permission decision, and shares are few enough that clearing the
@@ -1058,7 +1057,7 @@ func (tx *sqliteTransaction) collectShareQuotaFreed(ctx context.Context, shareNa
 		if err := rows.Scan(&id, &bytes, &files); err != nil {
 			return mapDBError(err, "DeleteShare", shareName)
 		}
-		tx.quota.AddKeyed(quota.Key{Scope: scope, ID: uint32(id)}, metadata.UsageStat{Bytes: -bytes, Files: -files})
+		tx.quota.AddKeyed(basestore.QuotaKey{Scope: scope, ID: uint32(id)}, metadata.UsageStat{Bytes: -bytes, Files: -files})
 	}
 	if err := rows.Err(); err != nil {
 		return mapDBError(err, "DeleteShare", shareName)
@@ -1337,7 +1336,7 @@ func (tx *sqliteTransaction) GetFilesystemStatistics(ctx context.Context, handle
 		return nil, mapDBError(err, "GetFilesystemStatistics", "")
 	}
 
-	return sqlstat.Build(bytesUsed, filesUsed), nil
+	return basestore.BuildStatistics(bytesUsed, filesUsed), nil
 }
 
 // ============================================================================

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -874,12 +874,7 @@ func (tx *sqliteTransaction) PutFilesystemMeta(ctx context.Context, shareName st
 }
 
 func (tx *sqliteTransaction) GenerateHandle(ctx context.Context, shareName string, path string) (metadata.FileHandle, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	// Handles are UUID-based; the path is stored in the File struct.
-	return metadata.GenerateNewHandle(shareName)
+	return basestore.GenerateHandle(ctx, shareName)
 }
 
 // ============================================================================


### PR DESCRIPTION
## What

Creates `pkg/metadata/store/basestore/` — the package every metadata backend
shares — and moves the two existing shared helpers into it:

- `internal/quota` → `basestore/quota.go`
- `internal/sqlstat` → `basestore/statfs.go`

Plus two small top-ups that delete real duplication across the four backends:

- `basestore.DefaultCapabilities()` replaces two byte-identical 25-line
  `metadata.FilesystemCapabilities{…}` literals in `badger/store.go` and
  `memory/store.go`.
- `basestore.GenerateHandle(ctx, shareName)` replaces **seven** copies of the
  same three-line body — `shares.go` in badger/sqlite/postgres and
  `transaction.go` in badger/sqlite/postgres/memory.

Net −12 lines as git counts it with rename detection (+171/−183); the duplication actually deleted is larger — two 25-line capability literals and seven 3-line handle bodies — partly offset by the new basestore/capabilities.go and handle.go. Nothing else changes: no logic, no queries, no schema.

## Why one package rather than two subpackages

Merging the two into a single `basestore` means the identifiers have to carry
their own namespace, so they were renamed on the way in:

| was | now |
|---|---|
| `quota.Key` | `basestore.QuotaKey` |
| `quota.Cache` / `quota.NewCache` | `basestore.QuotaCache` / `basestore.NewQuotaCache` |
| `quota.Delta` | `basestore.QuotaDelta` |
| `sqlstat.Build` | `basestore.BuildStatistics` |

`basestore.NewCache()` in a package that also holds capabilities and statfs
would be ambiguous; `basestore.Build()` more so. The receiver fields named
`quota` (`tx.quota.Add(…)`, `s.quota.Apply(…)`) are untouched — only package
selectors were rewritten.

## Retry policy stays where it is

`internal/txretry` is **not** moved and `basestore` contains no retry logic.
The SQL family retries on busy/serialization errors (`SQLITE_BUSY`, postgres
40001/40P01) through `txretry`; the KV family retries on Badger's SSI conflicts
inside its own loop. Those two budgets must never be shared — folding them is
the single highest risk in the #1828 program, and this PR is where the
separation starts being load-bearing. The package doc says so explicitly.

## Two things found while doing this, neither fixed here

**1. `memory` panics on a share name longer than 27 characters — filed as #2060.**

The plan asked whether `memory`'s local `generateFileHandle` was intentional or
latent drift. It is not a different algorithm: it calls the same
`metadata.GenerateNewHandle` as the other three backends. What diverges is the
error handling — it panics where the others return an error:

```go
handle, err := metadata.GenerateNewHandle(shareName)
if err != nil {
	panic(fmt.Sprintf("failed to encode file handle: %v", err))
}
```

Its doc comment justifies the panic on the grounds that "share creation rejects"
names long enough to overflow the 64-byte handle. It does not — `AddShare`
checks only for an empty name and for `':'`. A share name of 28+ characters is
accepted and then panics the server on first handle mint. Reproduced:

```
PANIC observed: failed to encode file handle: file handle too long: 78 bytes (max 64)
```

`memory` is a selectable production metadata store, so this is reachable from
the share-create API. Left untouched here so the fix lands as its own change
with the missing `AddShare` length check — see #2060. Consequently
`memory/shares.go` `GenerateHandle` is the one of the eight call sites NOT routed
through `basestore.GenerateHandle`.

**2. Three different "default" capability sets exist, and only two of them are
actually the same.**

`DefaultCapabilities()` intentionally covers only the two that are byte-identical
(badger and memory). It does not touch:

- `runtime/init.go`, which carries the *production* sqlite and postgres
  defaults as two more line-for-line identical literals — different values
  again (64 KiB preferred transfer, 100 GB max file size).
- the sqlite/postgres conformance-test helpers, which use a third set that
  omits `SupportsExtendedAttrs` and `TruncatesLongNames` even though both SQL
  backends do support EAs.

The plan expected all of these to collapse into one helper. They cannot without
changing advertised capabilities, which is a behaviour change and does not belong
in a move-only PR. Flagging rather than folding.

## Verification

- `go build ./...` clean
- `go test ./pkg/metadata/... ./pkg/controlplane/... ./internal/adapter/common/...` passes
- `pkg/metadata/storetest/` conformance passes for all four backends
- `pkg/block/blockstoretest/` untouched and green

Refs #1828

