### PR TITLE
fix(journal): a hydrate fills the local tier, it does not overwrite it

### DIFF
--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -53,11 +53,10 @@ type coveringChunk struct {
 // row's head, and the local tier keeps whichever landed last rather than
 // whichever row coverage prefers. A zero To means the row's whole extent.
 //
-// At is the local store's WriteVersion as it stood before the manifest rows
-// were resolved. It bounds the write-back in time as well as in space: the
-// local tier drops it when the range changed since, so a fetch stalled in the
-// remote read while a write, truncate or punch lands cannot put the
-// pre-mutation bytes back over the newer ones. Zero leaves that gate off.
+// At is the local store's WriteVersion as it stood before the manifest rows were
+// resolved. The local tier drops the write-back where the range changed since,
+// so a fetch stalled in the remote read while a write, truncate or punch lands
+// cannot put the pre-mutation bytes back. Zero leaves that gate off.
 type hydrateSpan struct {
 	From uint64
 	To   uint64

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -52,9 +52,16 @@ type coveringChunk struct {
 // start; hydrating its full extent would put the older bytes over the newer
 // row's head, and the local tier keeps whichever landed last rather than
 // whichever row coverage prefers. A zero To means the row's whole extent.
+//
+// At is the local store's WriteVersion as it stood before the manifest rows
+// were resolved. It bounds the write-back in time as well as in space: the
+// local tier drops it when the range changed since, so a fetch stalled in the
+// remote read while a write, truncate or punch lands cannot put the
+// pre-mutation bytes back over the newer ones. Zero leaves that gate off.
 type hydrateSpan struct {
 	From uint64
 	To   uint64
+	At   uint64
 }
 
 // collectCoveringChunks returns every manifest row covering [start, end), in
@@ -92,6 +99,9 @@ func (m *Syncer) collectCoveringChunks(ctx context.Context, payloadID string, st
 	// index every lookup falls back to a full per-payload manifest scan, and the
 	// resolver's snapshot turns K of those into one.
 	res := newChunkWindowResolver(m.fileChunkStore, payloadID)
+	// Sampled before the first row is read: every span this walk produces may
+	// only write back over bytes that already existed when it started looking.
+	at := m.local.WriteVersion()
 	if fb, absOff, err := res.coveringRow(ctx, start); err == nil && fb != nil && absOff < start {
 		start = absOff
 	}
@@ -118,7 +128,7 @@ func (m *Syncer) collectCoveringChunks(ctx context.Context, payloadID string, st
 		out = append(out, coveringChunk{
 			blockIdx: absOff / uint64(BlockSize),
 			fb:       fb,
-			span:     hydrateSpan{From: cur, To: claimEnd},
+			span:     hydrateSpan{From: cur, To: claimEnd, At: at},
 		})
 		cur = claimEnd
 	}
@@ -183,7 +193,7 @@ func (m *Syncer) hydrateChunk(ctx context.Context, fb *block.FileChunk, data []b
 		}
 		off, data = off+lo, data[lo:hi]
 	}
-	return m.local.Hydrate(ctx, fb.ID[:i], int64(off), data)
+	return m.local.Hydrate(ctx, fb.ID[:i], int64(off), data, span.At)
 }
 
 // clampSpan converts an absolute hydrate span into offsets within a chunk's

--- a/pkg/block/engine/fetch_test.go
+++ b/pkg/block/engine/fetch_test.go
@@ -46,7 +46,7 @@ func newFailingPutLocal() *failingPutLocal {
 // for the test to close `release` (with a safety timeout so a buggy test does
 // not wedge the suite), then returns the sentinel error. The cold-fetch path
 // persists via journal Hydrate (payloadID+offset), not the old hash-keyed Put.
-func (f *failingPutLocal) Hydrate(_ context.Context, _ string, _ int64, _ []byte) error {
+func (f *failingPutLocal) Hydrate(_ context.Context, _ string, _ int64, _ []byte, _ uint64) error {
 	f.puts.Add(1)
 	f.once.Do(func() { close(f.entered) })
 	select {

--- a/pkg/block/engine/hydrate_after_mutation_test.go
+++ b/pkg/block/engine/hydrate_after_mutation_test.go
@@ -126,3 +126,41 @@ func TestHydrateDoesNotResurrectOverMutation(t *testing.T) {
 		}
 	}
 }
+
+// TestColdWindowFetchDoesNotOverwritePunchedBytes pins that a cold read whose
+// window also spans freshly punched bytes does not put the pre-punch content
+// back over them. The window resolves every covering row, including the row the
+// punch superseded, so its write-back has to leave the punched range alone.
+func TestColdWindowFetchDoesNotOverwritePunchedBytes(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	bs := newEngineWithRemote(t, ms, remotememory.New())
+
+	rootHandle := createShare(t, ms, "coldwindow")
+	pid, _ := createRealFile(t, ms, "coldwindow", "f.bin", rootHandle)
+
+	const fileSize = 6 * 1024 * 1024
+	const punchLen = 1024 * 1024
+	orig := bytes.Repeat([]byte{0xCD}, fileSize)
+	if _, err := bs.WriteAt(ctx, pid, nil, orig, 0); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	carve(t, bs, ctx, pid)
+	if _, err := bs.DrainLocalSynced(ctx); err != nil {
+		t.Fatalf("DrainLocalSynced: %v", err)
+	}
+
+	// The punched bytes are live and local; everything past them is cold, so the
+	// read below has to fetch and still must not disturb them.
+	if _, err := bs.PunchHole(ctx, pid, manifestRefs(t, ms, pid), 0, punchLen); err != nil {
+		t.Fatalf("PunchHole: %v", err)
+	}
+
+	got := make([]byte, fileSize)
+	if _, err := bs.ReadAt(ctx, pid, got, 0); err != nil {
+		t.Fatalf("ReadAt: %v", err)
+	}
+	if n := punchLen - bytes.Count(got[:punchLen], []byte{0}); n != 0 {
+		t.Fatalf("punched range resurrected: %d nonzero of %d (first byte %#x)", n, punchLen, got[0])
+	}
+}

--- a/pkg/block/engine/hydrate_after_mutation_test.go
+++ b/pkg/block/engine/hydrate_after_mutation_test.go
@@ -1,0 +1,128 @@
+package engine_test
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/block/local/fs"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// gatedRemote stalls the first chunk read until release is closed, so a fetch
+// that resolved its manifest rows before a mutation writes its bytes back after
+// that mutation has been carved.
+type gatedRemote struct {
+	*remotememory.Store
+	release chan struct{}
+	entered chan struct{}
+	once    sync.Once
+}
+
+func (g *gatedRemote) ReadChunk(ctx context.Context, blockID string, offset, length int64, hash block.ContentHash) ([]byte, error) {
+	g.once.Do(func() { close(g.entered) })
+	select {
+	case <-g.release:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	return g.Store.ReadChunk(ctx, blockID, offset, length, hash)
+}
+
+func newEngineWithGatedRemote(t *testing.T, ms metadata.Store, rem *gatedRemote) *engine.Store {
+	t.Helper()
+	syncedHashStore, ok := ms.(metadata.SyncedHashStore)
+	if !ok {
+		t.Fatalf("metadata store %T does not implement metadata.SyncedHashStore", ms)
+	}
+	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{
+		MaxLogBytes: 128 * 1024 * 1024,
+	})
+	if err != nil {
+		t.Fatalf("fs.NewWithOptions: %v", err)
+	}
+	syncer := engine.NewSyncer(localStore, rem, ms, engine.DefaultConfig())
+	syncer.SetSyncedHashStore(syncedHashStore)
+	syncer.SetRemoteBlockStore(rem)
+	bs, err := engine.New(engine.BlockStoreConfig{
+		Local:           localStore,
+		Syncer:          syncer,
+		FileChunkStore:  ms,
+		Coordinator:     &testCoordinator{store: ms},
+		SyncedHashStore: syncedHashStore,
+		ReadBufferBytes: 64 * 1024 * 1024,
+	})
+	if err != nil {
+		t.Fatalf("engine.New: %v", err)
+	}
+	if err := bs.Start(context.Background()); err != nil {
+		t.Fatalf("engine.Start: %v", err)
+	}
+	t.Cleanup(func() { _ = bs.Close() })
+	return bs
+}
+
+// TestHydrateDoesNotResurrectOverMutation pins that a remote fetch in flight
+// across a mutation cannot put the pre-mutation bytes back. The fetch resolves
+// its covering rows, stalls in the remote read, and only writes back after the
+// punch has been carved and made durable locally. The punched range must still
+// read as zeros.
+func TestHydrateDoesNotResurrectOverMutation(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	rem := &gatedRemote{Store: remotememory.New(), release: make(chan struct{}), entered: make(chan struct{})}
+	bs := newEngineWithGatedRemote(t, ms, rem)
+
+	rootHandle := createShare(t, ms, "hydraterace")
+	pid, _ := createRealFile(t, ms, "hydraterace", "f.bin", rootHandle)
+
+	const fileSize = 6 * 1024 * 1024
+	const punchLen = 4 * 1024 * 1024
+	orig := bytes.Repeat([]byte{0xAB}, fileSize)
+	if _, err := bs.WriteAt(ctx, pid, nil, orig, 0); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	carve(t, bs, ctx, pid)
+	if _, err := bs.DrainLocalSynced(ctx); err != nil {
+		t.Fatalf("DrainLocalSynced: %v", err)
+	}
+
+	// A cold read that resolves the pre-punch manifest and then stalls.
+	readDone := make(chan struct{})
+	go func() {
+		defer close(readDone)
+		one := make([]byte, 1)
+		_, _ = bs.ReadAt(ctx, pid, one, 0)
+	}()
+	select {
+	case <-rem.entered:
+	case <-time.After(30 * time.Second):
+		t.Fatal("remote read never started")
+	}
+
+	// The mutation lands and is made durable while that fetch is stalled.
+	if _, err := bs.PunchHole(ctx, pid, manifestRefs(t, ms, pid), 0, punchLen); err != nil {
+		t.Fatalf("PunchHole: %v", err)
+	}
+	carve(t, bs, ctx, pid)
+
+	close(rem.release)
+	<-readDone
+
+	got := make([]byte, punchLen)
+	if _, err := bs.ReadAt(ctx, pid, got, 0); err != nil {
+		t.Fatalf("ReadAt after punch: %v", err)
+	}
+	for i, b := range got {
+		if b != 0 {
+			t.Fatalf("punched range resurrected: byte %d = %#x (want 0); %d nonzero of %d",
+				i, b, punchLen-bytes.Count(got, []byte{0}), punchLen)
+		}
+	}
+}

--- a/pkg/block/engine/manifest_soak_test.go
+++ b/pkg/block/engine/manifest_soak_test.go
@@ -1,0 +1,181 @@
+package engine_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"sort"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// assertNoOverlap fails when two manifest rows claim the same byte. Unlike
+// assertManifestTiles it tolerates gaps, which are legitimate for a sparse file,
+// and checks only the half the covering lookup cannot resolve on its own.
+func overlappedOffset(t *testing.T, ms metadata.Store, pid string) (uint64, bool) {
+	t.Helper()
+	refs := manifestRefs(t, ms, pid)
+	sort.Slice(refs, func(i, j int) bool { return refs[i].Offset < refs[j].Offset })
+	var prevEnd uint64
+	var prevOff uint64
+	for i, r := range refs {
+		if i > 0 && r.Offset < prevEnd {
+			t.Logf("manifest OVERLAP — row at %d extends to %d, next row starts at %d", prevOff, prevEnd, r.Offset)
+			return r.Offset, true
+		}
+		prevOff, prevEnd = r.Offset, r.Offset+uint64(r.Size)
+	}
+	return 0, false
+}
+
+// soakModel mirrors the byte content the engine should hold.
+type soakModel struct{ b []byte }
+
+func (m *soakModel) write(off uint64, data []byte) {
+	if need := int(off) + len(data); need > len(m.b) {
+		m.b = append(m.b, make([]byte, need-len(m.b))...)
+	}
+	copy(m.b[off:], data)
+}
+
+func (m *soakModel) truncate(size uint64) {
+	if int(size) <= len(m.b) {
+		m.b = m.b[:size]
+		return
+	}
+	m.b = append(m.b, make([]byte, int(size)-len(m.b))...)
+}
+
+func (m *soakModel) punch(off, length uint64) {
+	end := off + length
+	if end > uint64(len(m.b)) {
+		end = uint64(len(m.b))
+	}
+	for i := off; i < end; i++ {
+		m.b[i] = 0
+	}
+}
+
+// TestManifestSoak_NoLegitimatePathOverlaps drives the real mutation paths
+// through randomized sequences and, after every carve, asserts that no two
+// manifest rows cover the same offset and that a cold read of the whole file
+// still matches the model. The covering lookup reports overlapping rows as an
+// inconsistency rather than resolving them, so a legitimate path that produced
+// overlap would turn readable files into read errors.
+func TestManifestSoak_NoLegitimatePathOverlaps(t *testing.T) {
+	if testing.Short() {
+		t.Skip("soak")
+	}
+	for seed := range 24 {
+		t.Run(fmt.Sprintf("seed-%d", seed), func(t *testing.T) {
+			t.Parallel()
+			runManifestSoak(t, metadatamemory.NewMemoryMetadataStoreWithDefaults(), 60, int64(seed))
+		})
+	}
+}
+
+func runManifestSoak(t *testing.T, ms metadata.Store, iterations int, seedN int64) {
+	t.Helper()
+	ctx := context.Background()
+	bs := newEngineWithRemote(t, ms, remotememory.New())
+	share := fmt.Sprintf("soak%d", seedN)
+	rootHandle := createShare(t, ms, share)
+	pid, _ := createRealFile(t, ms, share, "soak.bin", rootHandle)
+
+	const maxSize = 12 * 1024 * 1024
+	rng := rand.New(rand.NewSource(0x50AC + seedN)) //nolint:gosec // deterministic fixture
+	model := &soakModel{}
+
+	seed := make([]byte, 6*1024*1024)
+	rng.Read(seed)
+	if _, err := bs.WriteAt(ctx, pid, nil, seed, 0); err != nil {
+		t.Fatalf("seed WriteAt: %v", err)
+	}
+	model.write(0, seed)
+	carve(t, bs, ctx, pid)
+
+	for i := range iterations {
+		label := fmt.Sprintf("iter-%d", i)
+		_ = label
+		switch rng.Intn(3) {
+		case 0: // overwrite or extend
+			off := uint64(rng.Intn(maxSize))
+			length := 1 + rng.Intn(3*1024*1024)
+			if int(off)+length > maxSize {
+				length = maxSize - int(off)
+			}
+			data := make([]byte, length)
+			rng.Read(data)
+			if _, err := bs.WriteAt(ctx, pid, nil, data, off); err != nil {
+				t.Fatalf("%s WriteAt(%d, %d): %v", label, off, length, err)
+			}
+			model.write(off, data)
+			label = fmt.Sprintf("%s write(off=%d,len=%d)", label, off, length)
+		case 1: // grow or shrink
+			size := uint64(rng.Intn(maxSize))
+			if _, err := bs.Truncate(ctx, pid, manifestRefs(t, ms, pid), size); err != nil {
+				t.Fatalf("%s Truncate(%d): %v", label, size, err)
+			}
+			model.truncate(size)
+			label = fmt.Sprintf("%s truncate(%d)", label, size)
+		case 2: // punch
+			if len(model.b) == 0 {
+				continue
+			}
+			off := uint64(rng.Intn(len(model.b)))
+			length := uint64(1 + rng.Intn(len(model.b)-int(off)))
+			if _, err := bs.PunchHole(ctx, pid, manifestRefs(t, ms, pid), off, length); err != nil {
+				t.Fatalf("%s PunchHole(%d, %d): %v", label, off, length, err)
+			}
+			model.punch(off, length)
+			label = fmt.Sprintf("%s punch(off=%d,len=%d)", label, off, length)
+		}
+
+		carve(t, bs, ctx, pid)
+		ovOff, overlapped := overlappedOffset(t, ms, pid)
+
+		// Force the file cold so the read resolves covering rows from the manifest
+		// rather than serving warm local bytes. EvictLocal is a no-op.
+		if _, err := bs.DrainLocalSynced(ctx); err != nil {
+			t.Fatalf("%s DrainLocalSynced: %v", label, err)
+		}
+		if overlapped && ovOff < uint64(len(model.b)) {
+			one := make([]byte, 1)
+			_, perr := bs.ReadAt(ctx, pid, one, ovOff)
+			switch {
+			case perr != nil && errors.Is(perr, block.ErrManifestInconsistent):
+				t.Fatalf("%s: READ BROKEN at double-covered offset %d: %v", label, ovOff, perr)
+			case perr != nil:
+				t.Fatalf("%s: read at double-covered offset %d: %v", label, ovOff, perr)
+			case one[0] != model.b[ovOff]:
+				t.Fatalf("%s: WRONG BYTE at double-covered offset %d", label, ovOff)
+			default:
+				t.Logf("%s: double-covered offset %d read fine", label, ovOff)
+			}
+		}
+		if len(model.b) == 0 {
+			continue
+		}
+		got := make([]byte, len(model.b))
+		if _, err := bs.ReadAt(ctx, pid, got, 0); err != nil {
+			if errors.Is(err, block.ErrManifestInconsistent) {
+				t.Fatalf("%s: cold read reported ErrManifestInconsistent: %v", label, err)
+			}
+			t.Fatalf("%s cold ReadAt: %v", label, err)
+		}
+		t.Logf("%s ok (size=%d)", label, len(model.b))
+		if !bytes.Equal(got, model.b) {
+			first := 0
+			for first < len(got) && got[first] == model.b[first] {
+				first++
+			}
+			t.Fatalf("%s: cold read mismatch at byte %d (size %d)", label, first, len(model.b))
+		}
+	}
+}

--- a/pkg/block/engine/read_internal.go
+++ b/pkg/block/engine/read_internal.go
@@ -99,17 +99,31 @@ func (bs *Store) healCorruptWarmRead(ctx context.Context, payloadID string, data
 // cold, so a genuinely sparse file still reads as zeros; a zero-length window
 // never reaches here (readAtInternal returns early), and would report cold=false
 // regardless, so the guard has nothing to fail open on.
+//
+// One retry sits before that refusal. A fetch that overlapped a write, truncate
+// or punch has its write-back dropped, because those bytes predate the mutation
+// (see hydrateSpan); when the mutated range was then carved and evicted it
+// reports cold again, and failing there would turn a read racing a write into
+// an I/O error. The retry resolves against the post-mutation manifest and
+// samples a fresh bound, so it fetches the bytes that now cover the window.
+// Bounded at one — a window that is still cold after a fetch that raced nothing
+// is the real "could not bring it back" case this refuses.
 func (bs *Store) ensureAndReadFromLocal(ctx context.Context, payloadID string, dest []byte, offset uint64) error {
-	if err := bs.syncer.EnsureAvailable(ctx, payloadID, offset, uint32(len(dest))); err != nil {
-		return fmt.Errorf("manifest reconcile for %s at offset %d failed: %w", payloadID, offset, err)
-	}
-	_, st, err := bs.local.ReadAt(ctx, payloadID, int64(offset), dest)
-	if err != nil {
-		return fmt.Errorf("read after hydrate failed: %w", err)
-	}
-	if st.Cold {
-		return fmt.Errorf("window for %s at offset %d (%d bytes) is still cold after hydrate: %w",
-			payloadID, offset, len(dest), block.ErrChunkNotFound)
+	for attempt := range 2 {
+		if err := bs.syncer.EnsureAvailable(ctx, payloadID, offset, uint32(len(dest))); err != nil {
+			return fmt.Errorf("manifest reconcile for %s at offset %d failed: %w", payloadID, offset, err)
+		}
+		_, st, err := bs.local.ReadAt(ctx, payloadID, int64(offset), dest)
+		if err != nil {
+			return fmt.Errorf("read after hydrate failed: %w", err)
+		}
+		if !st.Cold {
+			return nil
+		}
+		if attempt == 1 {
+			return fmt.Errorf("window for %s at offset %d (%d bytes) is still cold after hydrate: %w",
+				payloadID, offset, len(dest), block.ErrChunkNotFound)
+		}
 	}
 	return nil
 }

--- a/pkg/block/engine/read_internal.go
+++ b/pkg/block/engine/read_internal.go
@@ -49,7 +49,7 @@ func (bs *Store) readAtInternal(ctx context.Context, payloadID string, data []by
 			// A durable-tier warm read detected on-disk corruption. The local bytes
 			// are untrustworthy, so never return them: heal from the remote or fail
 			// closed.
-			return bs.healCorruptWarmRead(ctx, payloadID, data, offset)
+			return bs.healCorruptWarmRead(ctx, payloadID, data, offset, corrupt)
 		}
 		return 0, fmt.Errorf("local read failed: %w", err)
 	}
@@ -66,15 +66,22 @@ func (bs *Store) readAtInternal(ctx context.Context, payloadID string, data []by
 
 // healCorruptWarmRead recovers from on-disk corruption that a durable-tier warm
 // read detected (journal returned *CorruptRangeError). With a remote store it
-// re-fetches the covering chunks through the standard hydrate path — the fetch
-// is BLAKE3-verified and the fresh Hydrate supersedes the corrupt local interval
-// by version — then re-reads the now-healed bytes. Without a remote there is no
-// good copy to heal from, so it fails closed with ErrIntegrityCheckFailed (maps
-// to NFS3ERR_IO) rather than returning corrupt or zero-filled bytes.
-func (bs *Store) healCorruptWarmRead(ctx context.Context, payloadID string, data []byte, offset uint64) (int, error) {
+// demotes the bad range to remote-only and re-fetches the covering chunks
+// through the standard hydrate path — the fetch is BLAKE3-verified — then
+// re-reads the now-healed bytes. Without a remote there is no good copy to heal
+// from, so it fails closed with ErrIntegrityCheckFailed (maps to NFS3ERR_IO)
+// rather than returning corrupt or zero-filled bytes.
+//
+// The demotion is what makes the re-fetch land: a hydrate fills rather than
+// overwrites, so while the store still claims to hold these bytes the fresh
+// copy has nowhere to go and the re-read finds the same bad record.
+func (bs *Store) healCorruptWarmRead(ctx context.Context, payloadID string, data []byte, offset uint64, corrupt *journal.CorruptRangeError) (int, error) {
 	if !bs.HasRemoteStore() {
 		return 0, fmt.Errorf("warm read integrity failure for %s at offset %d (local-only, no remote to heal from): %w",
 			payloadID, offset, block.ErrIntegrityCheckFailed)
+	}
+	if err := bs.local.Invalidate(ctx, payloadID, corrupt.Offset, corrupt.Len); err != nil {
+		return 0, fmt.Errorf("demote corrupt range for %s at offset %d: %w", payloadID, offset, err)
 	}
 	if err := bs.ensureAndReadFromLocal(ctx, payloadID, data, offset); err != nil {
 		return 0, fmt.Errorf("heal corrupt warm read for %s at offset %d: %w", payloadID, offset, err)
@@ -100,16 +107,15 @@ func (bs *Store) healCorruptWarmRead(ctx context.Context, payloadID string, data
 // never reaches here (readAtInternal returns early), and would report cold=false
 // regardless, so the guard has nothing to fail open on.
 //
-// One retry sits before that refusal. A fetch that overlapped a write, truncate
-// or punch has its write-back dropped, because those bytes predate the mutation
-// (see hydrateSpan); when the mutated range was then carved and evicted it
-// reports cold again, and failing there would turn a read racing a write into
-// an I/O error. The retry resolves against the post-mutation manifest and
-// samples a fresh bound, so it fetches the bytes that now cover the window.
-// Bounded at one — a window that is still cold after a fetch that raced nothing
-// is the real "could not bring it back" case this refuses.
+// One retry sits before that refusal. A fetch that raced a write, truncate or
+// punch has its write-back dropped (see hydrateSpan), so a mutated range that
+// was then carved and evicted reports cold again — failing there would turn a
+// read racing a write into an I/O error. The retry resolves against the
+// post-mutation manifest with a fresh bound. Bounded at one: a window still cold
+// after a fetch that raced nothing is the real "could not bring it back" case
+// this refuses.
 func (bs *Store) ensureAndReadFromLocal(ctx context.Context, payloadID string, dest []byte, offset uint64) error {
-	for attempt := range 2 {
+	for range 2 {
 		if err := bs.syncer.EnsureAvailable(ctx, payloadID, offset, uint32(len(dest))); err != nil {
 			return fmt.Errorf("manifest reconcile for %s at offset %d failed: %w", payloadID, offset, err)
 		}
@@ -120,12 +126,9 @@ func (bs *Store) ensureAndReadFromLocal(ctx context.Context, payloadID string, d
 		if !st.Cold {
 			return nil
 		}
-		if attempt == 1 {
-			return fmt.Errorf("window for %s at offset %d (%d bytes) is still cold after hydrate: %w",
-				payloadID, offset, len(dest), block.ErrChunkNotFound)
-		}
 	}
-	return nil
+	return fmt.Errorf("window for %s at offset %d (%d bytes) is still cold after hydrate: %w",
+		payloadID, offset, len(dest), block.ErrChunkNotFound)
 }
 
 // rowWithOffset bundles a FileChunk row with the absolute payload

--- a/pkg/block/engine/warm.go
+++ b/pkg/block/engine/warm.go
@@ -89,6 +89,9 @@ func (m *Syncer) WarmAll(ctx context.Context, progress func(done, total int64)) 
 		if err := ctx.Err(); err != nil {
 			return WarmResult{}, err
 		}
+		// Sampled before this payload's rows are read, so a warm fetch cannot
+		// write back over bytes written while it was running (see hydrateSpan).
+		at := m.local.WriteVersion()
 		rows, err := m.listFileChunksSnapshot(ctx, payloadID)
 		if err != nil {
 			return WarmResult{}, fmt.Errorf("warm: list blocks for %s: %w", payloadID, err)
@@ -122,7 +125,7 @@ func (m *Syncer) WarmAll(ctx context.Context, progress func(done, total int64)) 
 			// it is left for the demand read to fetch — one row here means one
 			// range, and filling the gap with the older bytes is the outcome
 			// this clamp exists to prevent.
-			span := hydrateSpan{From: absOff, To: absOff + uint64(fb.DataSize)}
+			span := hydrateSpan{From: absOff, To: absOff + uint64(fb.DataSize), At: at}
 			if i := sort.Search(len(starts), func(i int) bool { return starts[i] > absOff }); i < len(starts) && starts[i] < span.To {
 				span.To = starts[i]
 			}

--- a/pkg/block/journal/disk_bytes_test.go
+++ b/pkg/block/journal/disk_bytes_test.go
@@ -59,7 +59,7 @@ func TestDiskBytesSeededOverCapConvergesDown(t *testing.T) {
 	// reopen without a carve pass.
 	buf := bytes.Repeat([]byte{0xCD}, chunk256)
 	for i := range 24 {
-		if err := first.Hydrate(ctx, "f", int64(i)*chunk256, buf); err != nil {
+		if err := first.Hydrate(ctx, "f", int64(i)*chunk256, buf, 0); err != nil {
 			t.Fatalf("Hydrate: %v", err)
 		}
 	}
@@ -87,7 +87,7 @@ func TestDiskBytesSeededOverCapConvergesDown(t *testing.T) {
 
 	// The write-path gate now sees the real footprint and reclaims down to the
 	// cap instead of concluding there is headroom.
-	if err := s.Hydrate(ctx, "f", 64<<20, buf); err != nil {
+	if err := s.Hydrate(ctx, "f", 64<<20, buf, 0); err != nil {
 		t.Fatalf("write over seeded cap: %v", err)
 	}
 	// Eviction is whole-segment and admission does not reserve, so the cap is a

--- a/pkg/block/journal/evict_test.go
+++ b/pkg/block/journal/evict_test.go
@@ -51,7 +51,7 @@ func fillUntilSealed(t *testing.T, s *Store, id FileID, synced bool, wantSealed 
 		}
 		var err error
 		if synced {
-			err = s.Hydrate(ctx, id, off, buf)
+			err = s.Hydrate(ctx, id, off, buf, 0)
 		} else {
 			err = s.WriteAt(ctx, id, off, buf)
 		}
@@ -215,7 +215,7 @@ func TestEvictedRangeReadsCold(t *testing.T) {
 	ctx := context.Background()
 
 	target := bytes.Repeat([]byte{0x5A}, chunk256)
-	if err := s.Hydrate(ctx, "f", 0, target); err != nil {
+	if err := s.Hydrate(ctx, "f", 0, target, 0); err != nil {
 		t.Fatalf("Hydrate target: %v", err)
 	}
 	fillUntilSealed(t, s, "f", true, 2) // seal the segment holding the target
@@ -287,7 +287,7 @@ func TestEnsureSpaceEvictsSyncedUnderPressure(t *testing.T) {
 	buf := bytes.Repeat([]byte{0x11}, chunk256)
 	var off int64
 	for i := 0; i < 40; i++ { // ~10 MiB through a 2 MiB cap
-		if err := s.Hydrate(ctx, "f", off, buf); err != nil {
+		if err := s.Hydrate(ctx, "f", off, buf, 0); err != nil {
 			t.Fatalf("Hydrate under pressure: %v", err)
 		}
 		off += chunk256
@@ -308,10 +308,10 @@ func TestEvictForceSealsSyncedActive(t *testing.T) {
 	// Two synced 256 KiB records (512 KiB total) stay in the active segment: well
 	// under the 1 MiB roll threshold, so nothing seals on its own.
 	buf := bytes.Repeat([]byte{0x3C}, chunk256)
-	if err := s.Hydrate(ctx, "f", 0, buf); err != nil {
+	if err := s.Hydrate(ctx, "f", 0, buf, 0); err != nil {
 		t.Fatalf("Hydrate: %v", err)
 	}
-	if err := s.Hydrate(ctx, "f", chunk256, buf); err != nil {
+	if err := s.Hydrate(ctx, "f", chunk256, buf, 0); err != nil {
 		t.Fatalf("Hydrate: %v", err)
 	}
 	if segs := sealedSegs(s.shardFor("f")); len(segs) != 0 {
@@ -468,7 +468,7 @@ func TestConcurrentWriteEvictRace(t *testing.T) {
 			defer wg.Done()
 			var off int64
 			for i := 0; i < 16; i++ {
-				if err := s.Hydrate(ctx, id, off, buf); err != nil {
+				if err := s.Hydrate(ctx, id, off, buf, 0); err != nil {
 					t.Errorf("Hydrate: %v", err)
 					return
 				}

--- a/pkg/block/journal/gc_test.go
+++ b/pkg/block/journal/gc_test.go
@@ -96,7 +96,7 @@ func seedRepackable(t *testing.T, s *Store) []byte {
 	rand.New(rand.NewSource(1)).Read(keep)
 	rand.New(rand.NewSource(2)).Read(gone)
 
-	if err := s.Hydrate(ctx, "keep", 0, keep); err != nil { // synced=true
+	if err := s.Hydrate(ctx, "keep", 0, keep, 0); err != nil { // synced=true
 		t.Fatal(err)
 	}
 	if err := s.WriteAt(ctx, "gone", 0, gone); err != nil { // synced=false

--- a/pkg/block/journal/hydrate_gate_test.go
+++ b/pkg/block/journal/hydrate_gate_test.go
@@ -6,54 +6,25 @@ import (
 	"testing"
 )
 
-// TestHydrateGate covers the WriteVersion bound on a hydrate's write-back: a
-// mark taken before the range was written keeps the fetched bytes out, a mark
-// taken after lets them in, and an unmarked hydrate is ungated.
-func TestHydrateGate(t *testing.T) {
+// TestHydrateFillsWithoutOverwriting covers what a hydrate is allowed to write
+// back: live local bytes are never replaced whatever the mark, a cold range is
+// filled only when it predates the mark, and a range the file does not hold is
+// always filled.
+func TestHydrateFillsWithoutOverwriting(t *testing.T) {
 	ctx := context.Background()
 	stale := bytes.Repeat([]byte{0xAB}, 4096)
 	fresh := bytes.Repeat([]byte{0x00}, 4096)
 
-	t.Run("mark predating the write drops it", func(t *testing.T) {
-		s, _ := evictStore(t, Config{})
-		if err := s.WriteAt(ctx, "f", 0, stale); err != nil {
-			t.Fatalf("WriteAt: %v", err)
-		}
-		mark := s.WriteVersion() // a fetch resolves here
-		if err := s.WriteAt(ctx, "f", 0, fresh); err != nil {
-			t.Fatalf("WriteAt: %v", err)
-		}
-		if err := s.Hydrate(ctx, "f", 0, stale, mark); err != nil {
-			t.Fatalf("Hydrate: %v", err)
-		}
-		got := make([]byte, len(fresh))
+	read := func(t *testing.T, s *Store, n int) []byte {
+		t.Helper()
+		got := make([]byte, n)
 		if _, _, err := s.ReadAt(ctx, "f", 0, got); err != nil {
 			t.Fatalf("ReadAt: %v", err)
 		}
-		if !bytes.Equal(got, fresh) {
-			t.Fatalf("stale hydrate won over a newer write")
-		}
-	})
+		return got
+	}
 
-	t.Run("mark after the write lets it through", func(t *testing.T) {
-		s, _ := evictStore(t, Config{})
-		if err := s.WriteAt(ctx, "f", 0, fresh); err != nil {
-			t.Fatalf("WriteAt: %v", err)
-		}
-		mark := s.WriteVersion()
-		if err := s.Hydrate(ctx, "f", 0, stale, mark); err != nil {
-			t.Fatalf("Hydrate: %v", err)
-		}
-		got := make([]byte, len(stale))
-		if _, _, err := s.ReadAt(ctx, "f", 0, got); err != nil {
-			t.Fatalf("ReadAt: %v", err)
-		}
-		if !bytes.Equal(got, stale) {
-			t.Fatalf("hydrate marked after the write was dropped")
-		}
-	})
-
-	t.Run("zero mark is ungated", func(t *testing.T) {
+	t.Run("live bytes survive an unmarked hydrate", func(t *testing.T) {
 		s, _ := evictStore(t, Config{})
 		if err := s.WriteAt(ctx, "f", 0, fresh); err != nil {
 			t.Fatalf("WriteAt: %v", err)
@@ -61,12 +32,85 @@ func TestHydrateGate(t *testing.T) {
 		if err := s.Hydrate(ctx, "f", 0, stale, 0); err != nil {
 			t.Fatalf("Hydrate: %v", err)
 		}
-		got := make([]byte, len(stale))
-		if _, _, err := s.ReadAt(ctx, "f", 0, got); err != nil {
-			t.Fatalf("ReadAt: %v", err)
+		if !bytes.Equal(read(t, s, len(fresh)), fresh) {
+			t.Fatal("hydrate overwrote live local bytes")
 		}
-		if !bytes.Equal(got, stale) {
-			t.Fatalf("ungated hydrate was dropped")
+	})
+
+	t.Run("live bytes survive a hydrate marked after them", func(t *testing.T) {
+		s, _ := evictStore(t, Config{})
+		if err := s.WriteAt(ctx, "f", 0, fresh); err != nil {
+			t.Fatalf("WriteAt: %v", err)
+		}
+		if err := s.Hydrate(ctx, "f", 0, stale, s.WriteVersion()); err != nil {
+			t.Fatalf("Hydrate: %v", err)
+		}
+		if !bytes.Equal(read(t, s, len(fresh)), fresh) {
+			t.Fatal("hydrate overwrote live local bytes")
+		}
+	})
+
+	t.Run("a hole is filled", func(t *testing.T) {
+		s, _ := evictStore(t, Config{})
+		if err := s.Hydrate(ctx, "f", 0, stale, s.WriteVersion()); err != nil {
+			t.Fatalf("Hydrate: %v", err)
+		}
+		if !bytes.Equal(read(t, s, len(stale)), stale) {
+			t.Fatal("hydrate of a hole was dropped")
+		}
+	})
+
+	t.Run("a cold range is filled only when it predates the mark", func(t *testing.T) {
+		s, _ := evictStore(t, Config{})
+		// An unrelated record first, so the mark taken before "f" is written is
+		// still non-zero — a zero mark means "no bound", not "the beginning".
+		if err := s.WriteAt(ctx, "g", 0, fresh); err != nil {
+			t.Fatalf("WriteAt: %v", err)
+		}
+		markBefore := s.WriteVersion()
+		if err := s.WriteAt(ctx, "f", 0, fresh); err != nil {
+			t.Fatalf("WriteAt: %v", err)
+		}
+		markAfter := s.WriteVersion()
+		sh := s.shardFor("f")
+		sh.mu.Lock()
+		for i := range sh.index["f"].ivs {
+			sh.index["f"].ivs[i].cold = true
+		}
+		sh.mu.Unlock()
+
+		if err := s.Hydrate(ctx, "f", 0, stale, markBefore); err != nil {
+			t.Fatalf("Hydrate: %v", err)
+		}
+		if _, st, err := s.ReadAt(ctx, "f", 0, make([]byte, len(stale))); err != nil {
+			t.Fatalf("ReadAt: %v", err)
+		} else if !st.Cold {
+			t.Fatal("hydrate marked before the cold range was recorded was not dropped")
+		}
+
+		if err := s.Hydrate(ctx, "f", 0, stale, markAfter); err != nil {
+			t.Fatalf("Hydrate: %v", err)
+		}
+		if !bytes.Equal(read(t, s, len(stale)), stale) {
+			t.Fatal("hydrate of a cold range predating the mark was dropped")
+		}
+	})
+
+	t.Run("only the cold part of a straddling range is filled", func(t *testing.T) {
+		s, _ := evictStore(t, Config{})
+		if err := s.WriteAt(ctx, "f", 0, fresh); err != nil { // [0, 4096) stays live
+			t.Fatalf("WriteAt: %v", err)
+		}
+		both := append(append([]byte{}, stale...), stale...)
+		if err := s.Hydrate(ctx, "f", 0, both, s.WriteVersion()); err != nil {
+			t.Fatalf("Hydrate: %v", err)
+		}
+		got := read(t, s, len(both))
+		if !bytes.Equal(got[:len(fresh)], fresh) {
+			t.Fatal("hydrate overwrote the live head")
+		}
+		if !bytes.Equal(got[len(fresh):], stale) {
+			t.Fatal("hydrate did not fill the hole past the live head")
 		}
 	})
 }

--- a/pkg/block/journal/hydrate_gate_test.go
+++ b/pkg/block/journal/hydrate_gate_test.go
@@ -1,0 +1,72 @@
+package journal
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+// TestHydrateGate covers the WriteVersion bound on a hydrate's write-back: a
+// mark taken before the range was written keeps the fetched bytes out, a mark
+// taken after lets them in, and an unmarked hydrate is ungated.
+func TestHydrateGate(t *testing.T) {
+	ctx := context.Background()
+	stale := bytes.Repeat([]byte{0xAB}, 4096)
+	fresh := bytes.Repeat([]byte{0x00}, 4096)
+
+	t.Run("mark predating the write drops it", func(t *testing.T) {
+		s, _ := evictStore(t, Config{})
+		if err := s.WriteAt(ctx, "f", 0, stale); err != nil {
+			t.Fatalf("WriteAt: %v", err)
+		}
+		mark := s.WriteVersion() // a fetch resolves here
+		if err := s.WriteAt(ctx, "f", 0, fresh); err != nil {
+			t.Fatalf("WriteAt: %v", err)
+		}
+		if err := s.Hydrate(ctx, "f", 0, stale, mark); err != nil {
+			t.Fatalf("Hydrate: %v", err)
+		}
+		got := make([]byte, len(fresh))
+		if _, _, err := s.ReadAt(ctx, "f", 0, got); err != nil {
+			t.Fatalf("ReadAt: %v", err)
+		}
+		if !bytes.Equal(got, fresh) {
+			t.Fatalf("stale hydrate won over a newer write")
+		}
+	})
+
+	t.Run("mark after the write lets it through", func(t *testing.T) {
+		s, _ := evictStore(t, Config{})
+		if err := s.WriteAt(ctx, "f", 0, fresh); err != nil {
+			t.Fatalf("WriteAt: %v", err)
+		}
+		mark := s.WriteVersion()
+		if err := s.Hydrate(ctx, "f", 0, stale, mark); err != nil {
+			t.Fatalf("Hydrate: %v", err)
+		}
+		got := make([]byte, len(stale))
+		if _, _, err := s.ReadAt(ctx, "f", 0, got); err != nil {
+			t.Fatalf("ReadAt: %v", err)
+		}
+		if !bytes.Equal(got, stale) {
+			t.Fatalf("hydrate marked after the write was dropped")
+		}
+	})
+
+	t.Run("zero mark is ungated", func(t *testing.T) {
+		s, _ := evictStore(t, Config{})
+		if err := s.WriteAt(ctx, "f", 0, fresh); err != nil {
+			t.Fatalf("WriteAt: %v", err)
+		}
+		if err := s.Hydrate(ctx, "f", 0, stale, 0); err != nil {
+			t.Fatalf("Hydrate: %v", err)
+		}
+		got := make([]byte, len(stale))
+		if _, _, err := s.ReadAt(ctx, "f", 0, got); err != nil {
+			t.Fatalf("ReadAt: %v", err)
+		}
+		if !bytes.Equal(got, stale) {
+			t.Fatalf("ungated hydrate was dropped")
+		}
+	})
+}

--- a/pkg/block/journal/hydrate_gate_test.go
+++ b/pkg/block/journal/hydrate_gate_test.go
@@ -114,3 +114,29 @@ func TestHydrateFillsWithoutOverwriting(t *testing.T) {
 		}
 	})
 }
+
+// TestHydrateAfterTruncateIsDropped pins the one mutation that leaves no
+// interval behind: a truncate empties the range instead of recording over it,
+// so a hydrate whose bound predates the truncate is refused outright.
+func TestHydrateAfterTruncateIsDropped(t *testing.T) {
+	ctx := context.Background()
+	s, _ := evictStore(t, Config{})
+	data := bytes.Repeat([]byte{0xAB}, 4096)
+	if err := s.WriteAt(ctx, "f", 0, data); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	mark := s.WriteVersion() // a fetch resolves the pre-truncate manifest here
+	if err := s.Truncate(ctx, "f", 0); err != nil {
+		t.Fatalf("Truncate: %v", err)
+	}
+	if err := s.Hydrate(ctx, "f", 0, data, mark); err != nil {
+		t.Fatalf("Hydrate: %v", err)
+	}
+	got := make([]byte, len(data))
+	if _, _, err := s.ReadAt(ctx, "f", 0, got); err != nil {
+		t.Fatalf("ReadAt: %v", err)
+	}
+	if !bytes.Equal(got, make([]byte, len(data))) {
+		t.Fatal("hydrate resurrected bytes a truncate removed")
+	}
+}

--- a/pkg/block/journal/index.go
+++ b/pkg/block/journal/index.go
@@ -498,20 +498,57 @@ func (e idxEntry) encode() []byte {
 	return buf
 }
 
-// recordedSince reports whether any live interval overlapping [off, off+n) was
-// recorded after mark. It answers "did this range change while I was away" for
-// a hydrate that sampled the store's WriteVersion before deciding what to
-// fetch; a nil index (unknown file) has nothing newer.
-func (fi *fileIndex) recordedSince(off, n int64, mark uint64) bool {
-	if fi == nil || n <= 0 {
-		return false
+// hydratable returns the sub-ranges of [off, off+n) that a hydrate may fill:
+// those no live interval holds, and those a cold interval holds that was
+// recorded no later than mark. Ranges are ascending, disjoint and coalesced,
+// and are offsets in the file, not in the caller's buffer.
+//
+// Live warm or dirty bytes are never overwritten. They are the newer copy by
+// construction — the remote holds what a carve uploaded, the journal holds that
+// plus anything written since — so a fetch that resolved the manifest rows
+// covering them is offering the older content back.
+//
+// mark bounds the cold case in time: a cold range recorded after the caller
+// sampled it postdates the fetch, so those bytes were superseded and evicted
+// while it was running. A mark of 0 bounds nothing.
+func (fi *fileIndex) hydratable(off, n int64, mark uint64) [][2]int64 {
+	if n <= 0 {
+		return nil
 	}
 	end := off + n
-	k := sort.Search(len(fi.ivs), func(i int) bool { return fi.ivs[i].end() > off })
-	for ; k < len(fi.ivs) && fi.ivs[k].fileOff < end; k++ {
-		if fi.ivs[k].version > mark {
-			return true
-		}
+	if fi == nil {
+		return [][2]int64{{off, end}}
 	}
-	return false
+	var out [][2]int64
+	add := func(lo, hi int64) {
+		if lo >= hi {
+			return
+		}
+		if k := len(out) - 1; k >= 0 && out[k][1] == lo {
+			out[k][1] = hi
+			return
+		}
+		out = append(out, [2]int64{lo, hi})
+	}
+	cur := off
+	k := sort.Search(len(fi.ivs), func(i int) bool { return fi.ivs[i].end() > off })
+	for ; k < len(fi.ivs) && fi.ivs[k].fileOff < end && cur < end; k++ {
+		iv := fi.ivs[k]
+		if iv.fileOff > cur {
+			add(cur, min(iv.fileOff, end)) // no interval holds this: a hole
+			cur = min(iv.fileOff, end)
+		}
+		stop := min(iv.end(), end)
+		if iv.cold && (mark == 0 || iv.version <= mark) {
+			add(cur, stop)
+		}
+		cur = max(cur, stop)
+	}
+	add(cur, end)
+	return out
+}
+
+// coversWhole reports whether ranges is exactly the single span [off, off+n).
+func coversWhole(ranges [][2]int64, off, n int64) bool {
+	return len(ranges) == 1 && ranges[0][0] == off && ranges[0][1] == off+n
 }

--- a/pkg/block/journal/index.go
+++ b/pkg/block/journal/index.go
@@ -499,18 +499,13 @@ func (e idxEntry) encode() []byte {
 }
 
 // hydratable returns the sub-ranges of [off, off+n) that a hydrate may fill:
-// those no live interval holds, and those a cold interval holds that was
-// recorded no later than mark. Ranges are ascending, disjoint and coalesced,
-// and are offsets in the file, not in the caller's buffer.
+// those no live interval holds, plus those a cold interval holds that was
+// recorded no later than mark (0 bounds nothing). Ranges are ascending, disjoint
+// and coalesced, and are offsets in the file, not in the caller's buffer.
 //
-// Live warm or dirty bytes are never overwritten. They are the newer copy by
-// construction — the remote holds what a carve uploaded, the journal holds that
-// plus anything written since — so a fetch that resolved the manifest rows
-// covering them is offering the older content back.
-//
-// mark bounds the cold case in time: a cold range recorded after the caller
-// sampled it postdates the fetch, so those bytes were superseded and evicted
-// while it was running. A mark of 0 bounds nothing.
+// Live warm or dirty bytes are never included — they are the newer copy — and
+// neither is a cold interval recorded after mark, which postdates the fetch.
+// See Store.Hydrate.
 func (fi *fileIndex) hydratable(off, n int64, mark uint64) [][2]int64 {
 	if n <= 0 {
 		return nil

--- a/pkg/block/journal/index.go
+++ b/pkg/block/journal/index.go
@@ -497,3 +497,21 @@ func (e idxEntry) encode() []byte {
 	buf[36] = e.Flags
 	return buf
 }
+
+// recordedSince reports whether any live interval overlapping [off, off+n) was
+// recorded after mark. It answers "did this range change while I was away" for
+// a hydrate that sampled the store's WriteVersion before deciding what to
+// fetch; a nil index (unknown file) has nothing newer.
+func (fi *fileIndex) recordedSince(off, n int64, mark uint64) bool {
+	if fi == nil || n <= 0 {
+		return false
+	}
+	end := off + n
+	k := sort.Search(len(fi.ivs), func(i int) bool { return fi.ivs[i].end() > off })
+	for ; k < len(fi.ivs) && fi.ivs[k].fileOff < end; k++ {
+		if fi.ivs[k].version > mark {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/block/journal/segment.go
+++ b/pkg/block/journal/segment.go
@@ -265,6 +265,8 @@ func (s *Store) sealSegment(sh *shard) error {
 // crash. Dropping the lock therefore needs the watermark replaced by an in-flight
 // version set (ceiling = lowest in-flight Version minus one) first; build that
 // only if append contention on a shard actually shows up in a profile.
+// A synced record is a hydrate, and is gated: see hydratable. notAfter is the
+// caller's sampled WriteVersion, or 0 for no bound in time.
 func (s *Store) appendRecord(ctx context.Context, id FileID, offset int64, data []byte, synced bool, notAfter uint64) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -301,9 +303,13 @@ func (s *Store) appendRecord(ctx context.Context, id FileID, offset int64, data 
 	sh.mu.Lock()
 	defer sh.mu.Unlock()
 
-	// The gate is tested under the same lock that stamps the version, so a
-	// mutation cannot slip between the test and the append and still lose.
-	if notAfter > 0 && sh.index[id].recordedSince(offset, int64(len(data)), notAfter) {
+	// A hydrate fills; it never overwrites. The range is re-tested here, under
+	// the same lock that stamps the version, so a write landing between the
+	// caller's split and this append cannot end up beneath older bytes. Anything
+	// short of the whole range is dropped rather than trimmed — the caller
+	// already split on the same predicate, so a short answer means the range
+	// changed underneath and the fetched bytes are the wrong ones.
+	if synced && !coversWhole(sh.index[id].hydratable(offset, int64(len(data)), notAfter), offset, int64(len(data))) {
 		return nil
 	}
 

--- a/pkg/block/journal/segment.go
+++ b/pkg/block/journal/segment.go
@@ -265,8 +265,9 @@ func (s *Store) sealSegment(sh *shard) error {
 // crash. Dropping the lock therefore needs the watermark replaced by an in-flight
 // version set (ceiling = lowest in-flight Version minus one) first; build that
 // only if append contention on a shard actually shows up in a profile.
-// A synced record is a hydrate, and is gated: see hydratable. notAfter is the
-// caller's sampled WriteVersion, or 0 for no bound in time.
+//
+// synced marks a hydrate, whose range is gated below; notAfter is its caller's
+// sampled WriteVersion, or 0 for no bound. See Store.Hydrate.
 func (s *Store) appendRecord(ctx context.Context, id FileID, offset int64, data []byte, synced bool, notAfter uint64) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -306,12 +307,14 @@ func (s *Store) appendRecord(ctx context.Context, id FileID, offset int64, data 
 	// A hydrate fills; it never overwrites. The range is re-tested here, under
 	// the same lock that stamps the version, so a write landing between the
 	// caller's split and this append cannot end up beneath older bytes. Anything
-	// short of the whole range is dropped rather than trimmed — the caller
-	// already split on the same predicate, so a short answer means the range
-	// changed underneath and the fetched bytes are the wrong ones.
-	if synced && (s.staleAfterTruncate(notAfter) ||
-		!coversWhole(sh.index[id].hydratable(offset, int64(len(data)), notAfter), offset, int64(len(data)))) {
-		return nil
+	// short of the whole range is dropped rather than trimmed — the caller split
+	// on the same predicate, so a short answer means the range changed underneath
+	// and the fetched bytes are the wrong ones.
+	if synced {
+		n := int64(len(data))
+		if s.staleAfterTruncate(notAfter) || !coversWhole(sh.index[id].hydratable(offset, n, notAfter), offset, n) {
+			return nil
+		}
 	}
 
 	if sh.active.tail.Load()+recLen > s.cfg.SegmentSize {

--- a/pkg/block/journal/segment.go
+++ b/pkg/block/journal/segment.go
@@ -309,7 +309,8 @@ func (s *Store) appendRecord(ctx context.Context, id FileID, offset int64, data 
 	// short of the whole range is dropped rather than trimmed — the caller
 	// already split on the same predicate, so a short answer means the range
 	// changed underneath and the fetched bytes are the wrong ones.
-	if synced && !coversWhole(sh.index[id].hydratable(offset, int64(len(data)), notAfter), offset, int64(len(data))) {
+	if synced && (s.staleAfterTruncate(notAfter) ||
+		!coversWhole(sh.index[id].hydratable(offset, int64(len(data)), notAfter), offset, int64(len(data)))) {
 		return nil
 	}
 

--- a/pkg/block/journal/segment.go
+++ b/pkg/block/journal/segment.go
@@ -312,7 +312,7 @@ func (s *Store) appendRecord(ctx context.Context, id FileID, offset int64, data 
 	// and the fetched bytes are the wrong ones.
 	if synced {
 		n := int64(len(data))
-		if s.staleAfterTruncate(notAfter) || !coversWhole(sh.index[id].hydratable(offset, n, notAfter), offset, n) {
+		if staleAfterTruncate(sh, id, notAfter) || !coversWhole(sh.index[id].hydratable(offset, n, notAfter), offset, n) {
 			return nil
 		}
 	}

--- a/pkg/block/journal/segment.go
+++ b/pkg/block/journal/segment.go
@@ -265,7 +265,7 @@ func (s *Store) sealSegment(sh *shard) error {
 // crash. Dropping the lock therefore needs the watermark replaced by an in-flight
 // version set (ceiling = lowest in-flight Version minus one) first; build that
 // only if append contention on a shard actually shows up in a profile.
-func (s *Store) appendRecord(ctx context.Context, id FileID, offset int64, data []byte, synced bool) error {
+func (s *Store) appendRecord(ctx context.Context, id FileID, offset int64, data []byte, synced bool, notAfter uint64) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -300,6 +300,12 @@ func (s *Store) appendRecord(ctx context.Context, id FileID, offset int64, data 
 	sh := s.shardFor(id)
 	sh.mu.Lock()
 	defer sh.mu.Unlock()
+
+	// The gate is tested under the same lock that stamps the version, so a
+	// mutation cannot slip between the test and the append and still lose.
+	if notAfter > 0 && sh.index[id].recordedSince(offset, int64(len(data)), notAfter) {
+		return nil
+	}
 
 	if sh.active.tail.Load()+recLen > s.cfg.SegmentSize {
 		if err := s.sealSegment(sh); err != nil {

--- a/pkg/block/journal/shard.go
+++ b/pkg/block/journal/shard.go
@@ -32,6 +32,12 @@ type shard struct {
 	active *segmentMeta
 	sealed map[uint64]*segmentMeta
 	index  map[FileID]*fileIndex
+	// truncVer is, per file, the store LSN as it stood when that file's most
+	// recent truncate began. A hydrate whose caller sampled its bound at or
+	// below it is refused: truncate clips intervals away rather than recording
+	// one, so a range it emptied leaves nothing for hydratable to weigh a stale
+	// write-back against. Entries die with the file's index on delete.
+	truncVer map[FileID]uint64
 	// lastVersion is the highest record Version appended to this shard, stamped
 	// under mu once the record's write() returned. syncedVersion is the highest
 	// Version a completed fsync has covered — records above it exist only in the
@@ -83,10 +89,11 @@ type shard struct {
 
 func newShard(active *segmentMeta) *shard {
 	sh := &shard{
-		active:  active,
-		sealed:  make(map[uint64]*segmentMeta),
-		index:   make(map[FileID]*fileIndex),
-		segSync: func(seg *segmentMeta) error { return seg.fd.Sync() },
+		active:   active,
+		sealed:   make(map[uint64]*segmentMeta),
+		index:    make(map[FileID]*fileIndex),
+		truncVer: make(map[FileID]uint64),
+		segSync:  func(seg *segmentMeta) error { return seg.fd.Sync() },
 	}
 	sh.commitCond = sync.NewCond(&sh.commitMu)
 	return sh

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -421,15 +421,29 @@ func (s *Store) commitDirtyShards() {
 // WriteAt buffers a dirty client write. It never fsyncs; durability is a
 // separate Commit.
 func (s *Store) WriteAt(ctx context.Context, id FileID, offset int64, data []byte) error {
-	return s.appendRecord(ctx, id, offset, data, false)
+	return s.appendRecord(ctx, id, offset, data, false, 0)
 }
 
 // Hydrate writes bytes fetched from the remote store during a cold read. Same
 // append primitive as WriteAt, but the record is born clean (already durable
 // remotely) so it is immediately evictable.
-func (s *Store) Hydrate(ctx context.Context, id FileID, offset int64, data []byte) error {
-	return s.appendRecord(ctx, id, offset, data, true)
+//
+// notAfter is the WriteVersion the caller observed before it resolved which
+// remote bytes to fetch. The write-back is dropped when any live interval
+// overlapping the range was recorded after that, because those bytes postdate
+// the fetch: a fetch stalled in the remote read while a write, truncate or
+// punch lands would otherwise append at a fresh version and win, putting the
+// pre-mutation bytes back over durable newer ones. Dropping costs at most a
+// re-fetch on the next read — the fetched bytes still serve this one. A zero
+// notAfter disables the gate, for a caller that holds no such observation.
+func (s *Store) Hydrate(ctx context.Context, id FileID, offset int64, data []byte, notAfter uint64) error {
+	return s.appendRecord(ctx, id, offset, data, true, notAfter)
 }
+
+// WriteVersion reports the store's current global LSN. Sampled before a caller
+// resolves what to fetch, it bounds what that fetch is allowed to write back
+// (see Hydrate).
+func (s *Store) WriteVersion() uint64 { return s.version.Load() }
 
 // SeedCold registers a byte range as remote-durable-but-not-local: a read of it
 // reports cold so the engine hydrates it from the remote store instead of

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -190,10 +190,9 @@ type Store struct {
 	nextSeg atomic.Uint64 // global segment-ID allocator
 	version atomic.Uint64 // global monotonic LSN
 	// lastTruncVer is the LSN as it stood when the most recent truncate began.
-	// A bound at or below it was sampled no later than that point.
-	// A hydrate whose caller sampled its bound before that is dropped: truncate
-	// clips intervals away rather than recording one, so a range it emptied
-	// leaves nothing behind for hydratable to weigh a stale write-back against.
+	// A hydrate whose bound is at or below it is dropped: truncate clips
+	// intervals away rather than recording one, so a range it emptied leaves
+	// nothing behind for hydratable to weigh the stale write-back against.
 	//
 	// ponytail: one watermark for the whole store, so a truncate of any file
 	// briefly refuses in-flight hydrates of every other file. A refused hydrate
@@ -440,21 +439,20 @@ func (s *Store) WriteAt(ctx context.Context, id FileID, offset int64, data []byt
 // remotely) so it is immediately evictable.
 //
 // It fills rather than overwrites: only the parts of the range no live interval
-// holds, plus the parts a cold interval holds, are written. A read window
-// resolves every manifest row covering it once any byte of it is cold, so a
-// fetch routinely offers bytes for ranges the journal already holds — and those
-// are the newer copy, since the remote holds what a carve uploaded and the
-// journal holds that plus everything written since. Writing them back would put
-// a client's just-written data underneath the content it replaced.
+// holds, plus the parts a cold interval holds no later than notAfter, are
+// written. A read window resolves every manifest row covering it once any byte
+// of it is cold, so a fetch routinely offers bytes the journal already holds —
+// and the journal's are the newer copy, since the remote holds what a carve
+// uploaded and the journal holds that plus everything written since. Writing
+// them back would put a client's just-written data underneath the content it
+// replaced.
 //
-// notAfter bounds the cold case in time. It is the WriteVersion the caller
-// sampled before it resolved which remote bytes to fetch; a cold range recorded
-// after that was superseded and evicted while the fetch was running, so those
-// bytes are stale too. Zero applies no bound.
+// notAfter is the WriteVersion the caller sampled before it resolved which
+// remote bytes to fetch; a cold range recorded after it was superseded and
+// evicted while the fetch ran, so it is stale too. Zero applies no bound.
 //
 // Dropping is always safe: the write-back is a cache fill, never a read's
-// answer. The fetched bytes still serve the read that triggered them, and the
-// cost of dropping is at most a re-fetch next time.
+// answer, and costs at most a re-fetch.
 func (s *Store) Hydrate(ctx context.Context, id FileID, offset int64, data []byte, notAfter uint64) error {
 	if s.staleAfterTruncate(notAfter) {
 		return nil
@@ -1129,6 +1127,44 @@ func (s *Store) RestoreToVersion(ctx context.Context, v uint64) error {
 		if err := s.Delete(ctx, id); err != nil {
 			return fmt.Errorf("journal: restore: tombstone post-V file %q: %w", id, err)
 		}
+	}
+	return nil
+}
+
+// Invalidate marks the live synced intervals overlapping [off, off+length) cold:
+// their local bytes are unusable, but the range is still durable remotely, so a
+// read of it fetches instead of serving what is there. A whole interval is
+// demoted even when the range covers only part of it, because the record it
+// points into is the unit that failed.
+//
+// A dirty interval is left alone. Nothing has uploaded it, so there is no copy
+// to fetch back, and demoting it would turn unwritten-back data into zeros; a
+// read of it fails closed instead.
+//
+// This is what lets a hydrate stay a fill rather than an overwrite: a caller
+// that has proven the local bytes bad demotes them first, and the re-fetch then
+// lands in a range the journal no longer claims to hold.
+func (s *Store) Invalidate(_ context.Context, id FileID, off, length int64) error {
+	if s.closed.Load() {
+		return errClosed
+	}
+	if length <= 0 {
+		return nil
+	}
+	end := off + length
+	sh := s.shardFor(id)
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	fi := sh.index[id]
+	if fi == nil {
+		return nil
+	}
+	for k := range fi.ivs {
+		iv := &fi.ivs[k]
+		if iv.end() <= off || iv.fileOff >= end || iv.cold || !iv.synced {
+			continue
+		}
+		iv.cold = true
 	}
 	return nil
 }

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -428,16 +428,33 @@ func (s *Store) WriteAt(ctx context.Context, id FileID, offset int64, data []byt
 // append primitive as WriteAt, but the record is born clean (already durable
 // remotely) so it is immediately evictable.
 //
-// notAfter is the WriteVersion the caller observed before it resolved which
-// remote bytes to fetch. The write-back is dropped when any live interval
-// overlapping the range was recorded after that, because those bytes postdate
-// the fetch: a fetch stalled in the remote read while a write, truncate or
-// punch lands would otherwise append at a fresh version and win, putting the
-// pre-mutation bytes back over durable newer ones. Dropping costs at most a
-// re-fetch on the next read — the fetched bytes still serve this one. A zero
-// notAfter disables the gate, for a caller that holds no such observation.
+// It fills rather than overwrites: only the parts of the range no live interval
+// holds, plus the parts a cold interval holds, are written. A read window
+// resolves every manifest row covering it once any byte of it is cold, so a
+// fetch routinely offers bytes for ranges the journal already holds — and those
+// are the newer copy, since the remote holds what a carve uploaded and the
+// journal holds that plus everything written since. Writing them back would put
+// a client's just-written data underneath the content it replaced.
+//
+// notAfter bounds the cold case in time. It is the WriteVersion the caller
+// sampled before it resolved which remote bytes to fetch; a cold range recorded
+// after that was superseded and evicted while the fetch was running, so those
+// bytes are stale too. Zero applies no bound.
+//
+// Dropping is always safe: the write-back is a cache fill, never a read's
+// answer. The fetched bytes still serve the read that triggered them, and the
+// cost of dropping is at most a re-fetch next time.
 func (s *Store) Hydrate(ctx context.Context, id FileID, offset int64, data []byte, notAfter uint64) error {
-	return s.appendRecord(ctx, id, offset, data, true, notAfter)
+	sh := s.shardFor(id)
+	sh.mu.Lock()
+	ranges := sh.index[id].hydratable(offset, int64(len(data)), notAfter)
+	sh.mu.Unlock()
+	for _, r := range ranges {
+		if err := s.appendRecord(ctx, id, r[0], data[r[0]-offset:r[1]-offset], true, notAfter); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // WriteVersion reports the store's current global LSN. Sampled before a caller

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -189,16 +189,6 @@ type Store struct {
 
 	nextSeg atomic.Uint64 // global segment-ID allocator
 	version atomic.Uint64 // global monotonic LSN
-	// lastTruncVer is the LSN as it stood when the most recent truncate began.
-	// A hydrate whose bound is at or below it is dropped: truncate clips
-	// intervals away rather than recording one, so a range it emptied leaves
-	// nothing behind for hydratable to weigh the stale write-back against.
-	//
-	// ponytail: one watermark for the whole store, so a truncate of any file
-	// briefly refuses in-flight hydrates of every other file. A refused hydrate
-	// costs a re-fetch, and the read path retries, so the price is bounded;
-	// make it per-file if truncate ever runs often enough to matter.
-	lastTruncVer atomic.Uint64
 	// pinVersion is the highest snapshot watermark still held by a live snapshot
 	// (0 = none). A segment whose minVersion is at or below it is kept off the
 	// eviction/GC path so a local-only snapshot's bytes — the only durable copy —
@@ -454,12 +444,12 @@ func (s *Store) WriteAt(ctx context.Context, id FileID, offset int64, data []byt
 // Dropping is always safe: the write-back is a cache fill, never a read's
 // answer, and costs at most a re-fetch.
 func (s *Store) Hydrate(ctx context.Context, id FileID, offset int64, data []byte, notAfter uint64) error {
-	if s.staleAfterTruncate(notAfter) {
-		return nil
-	}
 	sh := s.shardFor(id)
 	sh.mu.Lock()
-	ranges := sh.index[id].hydratable(offset, int64(len(data)), notAfter)
+	var ranges [][2]int64
+	if !staleAfterTruncate(sh, id, notAfter) {
+		ranges = sh.index[id].hydratable(offset, int64(len(data)), notAfter)
+	}
 	sh.mu.Unlock()
 	for _, r := range ranges {
 		if err := s.appendRecord(ctx, id, r[0], data[r[0]-offset:r[1]-offset], true, notAfter); err != nil {
@@ -474,10 +464,11 @@ func (s *Store) Hydrate(ctx context.Context, id FileID, offset int64, data []byt
 // (see Hydrate).
 func (s *Store) WriteVersion() uint64 { return s.version.Load() }
 
-// staleAfterTruncate reports whether a bound predates the most recent truncate,
-// which is the one mutation that leaves no interval behind to compare against.
-func (s *Store) staleAfterTruncate(notAfter uint64) bool {
-	return notAfter > 0 && notAfter <= s.lastTruncVer.Load()
+// staleAfterTruncate reports whether a hydrate's bound predates the file's most
+// recent truncate, which is the one mutation that leaves no interval behind to
+// compare against. Callers hold sh.mu.
+func staleAfterTruncate(sh *shard, id FileID, notAfter uint64) bool {
+	return notAfter > 0 && notAfter <= sh.truncVer[id]
 }
 
 // SeedCold registers a byte range as remote-durable-but-not-local: a read of it
@@ -713,6 +704,8 @@ func (s *Store) Delete(ctx context.Context, id FileID) error {
 			fi.ivs = kept
 		}
 	}
+	// The file is gone, so its truncate bound has nothing left to guard.
+	delete(sh.truncVer, id)
 	sh.mu.Unlock()
 	if dirty != 0 {
 		s.unsynced.Add(-dirty)
@@ -870,14 +863,15 @@ func (s *Store) Truncate(ctx context.Context, id FileID, newSize int64) error {
 			}
 		}
 	}
+	if past {
+		// Published before the marker is stamped, so a hydrate that samples its
+		// bound after this point is never mistaken for one that predates the clip.
+		sh.truncVer[id] = s.version.Load()
+	}
 	sh.mu.Unlock()
 	if !past {
 		return nil
 	}
-
-	// Published before the marker is stamped, so a hydrate that samples its
-	// bound after this point is never mistaken for one that predates the clip.
-	s.lastTruncVer.Store(s.version.Load())
 
 	// Durability first: the marker must be on disk before the index is clipped.
 	truncVer, err := s.appendTruncateMarker(ctx, id, newSize)

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -189,6 +189,17 @@ type Store struct {
 
 	nextSeg atomic.Uint64 // global segment-ID allocator
 	version atomic.Uint64 // global monotonic LSN
+	// lastTruncVer is the LSN as it stood when the most recent truncate began.
+	// A bound at or below it was sampled no later than that point.
+	// A hydrate whose caller sampled its bound before that is dropped: truncate
+	// clips intervals away rather than recording one, so a range it emptied
+	// leaves nothing behind for hydratable to weigh a stale write-back against.
+	//
+	// ponytail: one watermark for the whole store, so a truncate of any file
+	// briefly refuses in-flight hydrates of every other file. A refused hydrate
+	// costs a re-fetch, and the read path retries, so the price is bounded;
+	// make it per-file if truncate ever runs often enough to matter.
+	lastTruncVer atomic.Uint64
 	// pinVersion is the highest snapshot watermark still held by a live snapshot
 	// (0 = none). A segment whose minVersion is at or below it is kept off the
 	// eviction/GC path so a local-only snapshot's bytes — the only durable copy —
@@ -445,6 +456,9 @@ func (s *Store) WriteAt(ctx context.Context, id FileID, offset int64, data []byt
 // answer. The fetched bytes still serve the read that triggered them, and the
 // cost of dropping is at most a re-fetch next time.
 func (s *Store) Hydrate(ctx context.Context, id FileID, offset int64, data []byte, notAfter uint64) error {
+	if s.staleAfterTruncate(notAfter) {
+		return nil
+	}
 	sh := s.shardFor(id)
 	sh.mu.Lock()
 	ranges := sh.index[id].hydratable(offset, int64(len(data)), notAfter)
@@ -461,6 +475,12 @@ func (s *Store) Hydrate(ctx context.Context, id FileID, offset int64, data []byt
 // resolves what to fetch, it bounds what that fetch is allowed to write back
 // (see Hydrate).
 func (s *Store) WriteVersion() uint64 { return s.version.Load() }
+
+// staleAfterTruncate reports whether a bound predates the most recent truncate,
+// which is the one mutation that leaves no interval behind to compare against.
+func (s *Store) staleAfterTruncate(notAfter uint64) bool {
+	return notAfter > 0 && notAfter <= s.lastTruncVer.Load()
+}
 
 // SeedCold registers a byte range as remote-durable-but-not-local: a read of it
 // reports cold so the engine hydrates it from the remote store instead of
@@ -856,6 +876,10 @@ func (s *Store) Truncate(ctx context.Context, id FileID, newSize int64) error {
 	if !past {
 		return nil
 	}
+
+	// Published before the marker is stamped, so a hydrate that samples its
+	// bound after this point is never mistaken for one that predates the clip.
+	s.lastTruncVer.Store(s.version.Load())
 
 	// Durability first: the marker must be on disk before the index is clipped.
 	truncVer, err := s.appendTruncateMarker(ctx, id, newSize)

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -212,8 +212,8 @@ func (s *FSStore) ReadAt(ctx context.Context, payloadID string, offset int64, ds
 	return s.Store.ReadAt(ctx, journal.FileID(payloadID), offset, dst)
 }
 
-func (s *FSStore) Hydrate(ctx context.Context, payloadID string, offset int64, data []byte) error {
-	return s.Store.Hydrate(ctx, journal.FileID(payloadID), offset, data)
+func (s *FSStore) Hydrate(ctx context.Context, payloadID string, offset int64, data []byte, notAfter uint64) error {
+	return s.Store.Hydrate(ctx, journal.FileID(payloadID), offset, data, notAfter)
 }
 
 func (s *FSStore) Commit(ctx context.Context, payloadID string) error {

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -216,6 +216,10 @@ func (s *FSStore) Hydrate(ctx context.Context, payloadID string, offset int64, d
 	return s.Store.Hydrate(ctx, journal.FileID(payloadID), offset, data, notAfter)
 }
 
+func (s *FSStore) Invalidate(ctx context.Context, payloadID string, offset, length int64) error {
+	return s.Store.Invalidate(ctx, journal.FileID(payloadID), offset, length)
+}
+
 func (s *FSStore) Commit(ctx context.Context, payloadID string) error {
 	return s.Store.Commit(ctx, journal.FileID(payloadID))
 }

--- a/pkg/block/local/local.go
+++ b/pkg/block/local/local.go
@@ -48,7 +48,16 @@ type LocalStore interface {
 	// Hydrate writes bytes fetched from the remote store during a cold read.
 	// Same append primitive as WriteAt, but the record is born clean (already
 	// durable remotely) so it is immediately evictable.
-	Hydrate(ctx context.Context, payloadID string, offset int64, data []byte) error
+	//
+	// notAfter is the WriteVersion sampled before the caller resolved which
+	// remote bytes to fetch. The write-back is dropped when the range changed
+	// since, so a fetch stalled across a write, truncate or punch cannot put
+	// the pre-mutation bytes back. Zero disables the gate.
+	Hydrate(ctx context.Context, payloadID string, offset int64, data []byte, notAfter uint64) error
+
+	// WriteVersion reports a monotonic marker of the store's write history,
+	// sampled before resolving a fetch to bound what it may write back.
+	WriteVersion() uint64
 
 	// Commit fsyncs the file's buffered writes so they become durable. NFS
 	// COMMIT / SMB Flush land here. Backends without a durable substrate (the

--- a/pkg/block/local/local.go
+++ b/pkg/block/local/local.go
@@ -59,6 +59,12 @@ type LocalStore interface {
 	// sampled before resolving a fetch to bound what it may write back.
 	WriteVersion() uint64
 
+	// Invalidate demotes the durable bytes covering [offset, offset+length) to
+	// remote-only, so a read of the range fetches rather than serving them. A
+	// caller that has proven the local copy unusable calls it before re-fetching,
+	// since Hydrate fills and will not write over a range the store still claims.
+	Invalidate(ctx context.Context, payloadID string, offset, length int64) error
+
 	// Commit fsyncs the file's buffered writes so they become durable. NFS
 	// COMMIT / SMB Flush land here. Backends without a durable substrate (the
 	// in-memory store) implement it as a no-op returning nil.

--- a/pkg/block/local/memory/memory.go
+++ b/pkg/block/local/memory/memory.go
@@ -82,7 +82,12 @@ func (s *MemoryStore) WriteAt(_ context.Context, payloadID string, offset int64,
 }
 
 // Hydrate writes remote-fetched bytes; born clean, so no unsynced charge.
-func (s *MemoryStore) Hydrate(_ context.Context, payloadID string, offset int64, data []byte) error {
+//
+// ponytail: notAfter is accepted and ignored — the flat per-file buffer records
+// no per-range version to compare it against, and this store never evicts, so
+// the cold read that carries a meaningful mark does not arise here. Give the
+// buffer an interval index if a memory-local share ever needs the gate.
+func (s *MemoryStore) Hydrate(_ context.Context, payloadID string, offset int64, data []byte, _ uint64) error {
 	if offset < 0 {
 		return block.ErrInvalidOffset
 	}
@@ -316,3 +321,8 @@ func (s *MemoryStore) Durable() bool { return s.durable.Load() }
 
 // SetDurable overrides the durability report.
 func (s *MemoryStore) SetDurable(v bool) { s.durable.Store(v) }
+
+// WriteVersion reports a monotonic marker of the store's write history. The
+// memory store keeps no such history, so it reports zero, which reads as "no
+// observation" and leaves Hydrate's gate disabled.
+func (s *MemoryStore) WriteVersion() uint64 { return 0 }

--- a/pkg/block/local/memory/memory.go
+++ b/pkg/block/local/memory/memory.go
@@ -322,7 +322,10 @@ func (s *MemoryStore) Durable() bool { return s.durable.Load() }
 // SetDurable overrides the durability report.
 func (s *MemoryStore) SetDurable(v bool) { s.durable.Store(v) }
 
-// WriteVersion reports a monotonic marker of the store's write history. The
-// memory store keeps no such history, so it reports zero, which reads as "no
-// observation" and leaves Hydrate's gate disabled.
+// WriteVersion reports zero: this store keeps no write history, so Hydrate's
+// gate stays disabled.
 func (s *MemoryStore) WriteVersion() uint64 { return 0 }
+
+// Invalidate is a no-op: the memory store has no durable tier to demote and no
+// remote copy to fall back to, so there is nothing a read could fetch instead.
+func (s *MemoryStore) Invalidate(_ context.Context, _ string, _, _ int64) error { return nil }


### PR DESCRIPTION
## A cold read still returns pre-punch bytes, by a mechanism nothing here has covered yet

Two things came out of re-opening this.

**The residual the issue was held open for no longer reproduces.** After #1979 the
24-seed mutation soak still failed 1/24 under `-race`, attributed to the carve-seam
shadowing filed as #1974. That seam has since been closed from three directions —
#1991 on the read/hydrate side, #2039 narrowing the straddler at a run's start, #2049
carving through the row a run's end lands inside. Re-measured with the soak from this
issue's body:

| tree | mode | failed seeds |
| --- | --- | --- |
| develop pre-#1979 (historic) | plain / `-race` | 5/24 · 8/24 |
| develop post-#1979 (historic) | `-race` | 1/24 |
| **develop 70dc7778** | plain | **0/24** |
| **develop 70dc7778** | `-race` | **0/24 x 13 runs — 0 in 312 seeds** |
| 336743ca (#1979 merge, control) | `-race` | 2 in 48 seeds |
| **this branch** | `-race` | **0 in 192 seeds** (8 runs x 24) |

The fix's 192 seeds are 3 runs on the tree as first written, 3 after the per-file
truncate bound below, and 2 on the rebased tree; runs killed mid-flight are counted as
void rather than as passes.

The control run matters: at `336743ca`, where the 1/24 was originally measured, the
same ported harness still fails — 2 seeds in 48, both `iter-0 punch(...)` cold-read
mismatches. So the harness detects what it was written for, and `develop`'s 0-in-312 is
a real change rather than a broken port.

The soak lands here as a regression test.

**But the punch bug itself is still there,** and it does not need a race, a seam, or a
soak to hit. It reproduces single-threaded, first try.

## What is actually wrong

A remote fetch resolves the manifest rows covering a read window, downloads each
chunk, and writes the bytes back into the local journal so a later read serves them
warm. The journal is an append log whose index resolves overlap by version, highest
wins — and `Hydrate` stamped a **fresh** version at append time, *after* the download.
So a write-back always won, whatever else the range had acquired in the meantime.

That is wrong in two different ways, and both produce this issue's symptom.

**1. A window that is only partly cold fetches rows it must not write back.**
`EnsureAvailable` resolves *every* row covering the window as soon as any byte of it
is cold, on the documented assumption that "Hydrate is idempotent for any already-warm
sub-range". After a punch it is not: the punch's zeros are live local bytes the
manifest does not describe yet, and the row the punch superseded is still what the
window resolves. Hydrating it puts the pre-punch content straight back over them.

No concurrency at all. `TestColdWindowFetchDoesNotOverwritePunchedBytes` — write
6 MiB, carve, evict, punch 1 MiB, read the file — on `develop`:

```
punched range resurrected: 1048576 nonzero of 1048576 (first byte 0xcd)
```

**2. A fetch in flight across a mutation writes back the pre-mutation bytes.**
Same append, different window: the fetch resolved its rows before the mutation and
lands after it, at a higher version, so it wins over bytes that are already durable.
The window is one remote GET wide — tens to hundreds of milliseconds against a real
object store — and nothing the client does opens it: `Store.ReadAt` fires
`scheduleReadahead` on **every** read, so a sequential reader leaves prefetch workers
in flight behind it, and `WarmAll` does the same in bulk.

`TestHydrateDoesNotResurrectOverMutation` — seed 6 MiB, carve, evict, start a cold
read that stalls inside the remote read, punch `[0, 4 MiB)`, carve it durable, release
the fetch — on `develop`:

```
punched range resurrected: byte 0 = 0xab (want 0); 4194304 nonzero of 4194304
```

Both fail on unmodified `origin/develop`; both pass here.

## The fix

**A hydrate fills; it never overwrites.** `journal.Store.Hydrate` writes back only the
sub-ranges no live interval holds, plus the sub-ranges a cold interval holds — the two
cases where the journal has nothing of its own to lose. Live warm or dirty bytes are
the newer copy by construction: the remote holds what a carve uploaded, the journal
holds that plus everything written since. Splitting rather than dropping matters,
because a chunk routinely straddles warm and cold, and the cold half still needs
filling.

**The cold case is bounded in time too.** `WriteVersion()` exposes the store's global
LSN; the engine samples it *before* it resolves the first manifest row — at the top of
`collectCoveringChunks`, and per payload in `WarmAll` — and carries it in the existing
`hydrateSpan`, which already threads to `hydrateChunk`, so no new parameter crosses the
fetch path. A cold range recorded after that bound was superseded and evicted while the
fetch was running, so those bytes are stale as well. The bound stays out of the
in-flight dedup key, so concurrent fetchers still share one GET; whichever wins the slot
hydrates under its own bound and a piggybacker never writes back at all.

Both tests run under the same shard lock that stamps the version, so a mutation cannot
slip between the test and the append and still lose.

**Truncate is the one mutation that leaves nothing to compare against** — it clips
intervals away rather than recording one, so a range it emptied looks like a plain hole.
A hydrate whose bound predates that file's most recent truncate is refused outright,
against a per-file bound on the shard (`shard.truncVer`), published under `sh.mu` when
the truncate is found to have something past the new size and dropped with the file's
index on delete. Per-file rather than store-wide on purpose: the bound is the one drop
reason that can refuse a *hole*, and a hole that stays a hole reads as zeros rather than
as an error. Scoped to the truncated file, the only reads it can affect are of a file
that was just truncated — where the rows past the new size have been reaped, nothing
resolves over the range, and zeros are the right answer.

Dropping a write-back is always safe. It is a cache fill, never a read's answer — the
fetched bytes still serve the read that triggered them, and the cost is at most a
re-fetch next time.

**One bounded retry** was added to `ensureAndReadFromLocal` before its "still cold after
hydrate" refusal. A read that raced a write it then lost the write-back for would
otherwise turn into an I/O error; the retry resolves against the post-mutation manifest
under a fresh bound. Ordinary cold reads never reach it — eviction flips an interval to
cold *in place*, keeping its version, so it never trips the bound.

`local/memory` accepts the bound and ignores it: a flat per-file buffer records no
per-range version, and that store never evicts, so the cold read that carries a
meaningful bound does not arise there. Marked `ponytail:` with the upgrade path.

## Verification

- `TestColdWindowFetchDoesNotOverwritePunchedBytes` and
  `TestHydrateDoesNotResurrectOverMutation` — both fail on unmodified `origin/develop`
  with the output above, both pass here.
- `TestHydrateFillsWithoutOverwriting` (five cases) and `TestHydrateAfterTruncateIsDropped`
  pin the gate at the journal layer.
- The mutation soak from this issue lands as `TestManifestSoak_NoLegitimatePathOverlaps`.
- `go build ./...`, `go vet ./...`, `gofmt` clean; `go test ./...` green.

Closes #1956
