### PR TITLE
fix(metadata): reject an undecodable handle in statfs on every backend

### DIFF
--- a/pkg/metadata/service_test.go
+++ b/pkg/metadata/service_test.go
@@ -205,11 +205,9 @@ func TestMetadataService_HandleRouting_TypedErrors(t *testing.T) {
 	})
 }
 
-// TestMetadataService_FSStat_RejectsUndecodableHandle pins the guarantee the
-// backends rely on: FSSTAT decodes the handle and fails before a store is ever
-// selected, so no backend's GetFilesystemStatistics can be reached with a
-// handle that does not decode. Backends reject one too, but only this check
-// keeps the protocol-visible answer BADHANDLE rather than some share's usage.
+// TestMetadataService_FSStat_RejectsUndecodableHandle pins the protocol-visible
+// answer: FSSTAT decodes the handle and fails before a store is selected, so an
+// undecodable handle reads back as BADHANDLE rather than as some share's usage.
 func TestMetadataService_FSStat_RejectsUndecodableHandle(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/metadata/service_test.go
+++ b/pkg/metadata/service_test.go
@@ -205,6 +205,22 @@ func TestMetadataService_HandleRouting_TypedErrors(t *testing.T) {
 	})
 }
 
+// TestMetadataService_FSStat_RejectsUndecodableHandle pins the guarantee the
+// backends rely on: FSSTAT decodes the handle and fails before a store is ever
+// selected, so no backend's GetFilesystemStatistics can be reached with a
+// handle that does not decode. Backends reject one too, but only this check
+// keeps the protocol-visible answer BADHANDLE rather than some share's usage.
+func TestMetadataService_FSStat_RejectsUndecodableHandle(t *testing.T) {
+	t.Parallel()
+
+	fx := newTestFixture(t)
+
+	_, err := fx.service.GetFilesystemStatisticsForIdentity(context.Background(), metadata.FileHandle("garbage-no-colon"), nil)
+
+	require.Error(t, err)
+	assert.True(t, metadata.IsInvalidHandleError(err), "want ErrInvalidHandle, got %v", err)
+}
+
 // ============================================================================
 // CreateFile Tests
 // ============================================================================

--- a/pkg/metadata/store/badger/server.go
+++ b/pkg/metadata/store/badger/server.go
@@ -7,7 +7,6 @@ import (
 	badgerdb "github.com/dgraph-io/badger/v4"
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/metadata"
-	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 )
 
 // ============================================================================
@@ -153,13 +152,21 @@ func (s *BadgerMetadataStore) storeCapabilities(capabilities metadata.Filesystem
 // Both figures are O(1) reads of the per-share usage bucket. Only regular files
 // contribute, matching the SQL backends' scoped aggregate: directories carry no
 // logical bytes and the share root would otherwise inflate UsedFiles.
+//
+// A handle that does not decode names no share and is rejected, matching the
+// other backends.
 func (s *BadgerMetadataStore) GetFilesystemStatistics(ctx context.Context, handle metadata.FileHandle) (*metadata.FilesystemStatistics, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 
+	shareName, _, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		return nil, err
+	}
+
 	s.quotaMu.Lock()
-	usage := s.quota.Share(basestore.ShareOfHandle(handle))
+	usage := s.quota.Share(shareName)
 	s.quotaMu.Unlock()
 
 	usedSize := uint64(max(usage.Bytes, 0))

--- a/pkg/metadata/store/badger/server.go
+++ b/pkg/metadata/store/badger/server.go
@@ -153,8 +153,7 @@ func (s *BadgerMetadataStore) storeCapabilities(capabilities metadata.Filesystem
 // contribute, matching the SQL backends' scoped aggregate: directories carry no
 // logical bytes and the share root would otherwise inflate UsedFiles.
 //
-// A handle that does not decode names no share and is rejected, matching the
-// other backends.
+// A handle that does not decode names no share and is rejected.
 func (s *BadgerMetadataStore) GetFilesystemStatistics(ctx context.Context, handle metadata.FileHandle) (*metadata.FilesystemStatistics, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -1404,7 +1404,10 @@ func (tx *badgerTransaction) GetFilesystemStatistics(ctx context.Context, handle
 		return nil, err
 	}
 
-	shareName := basestore.ShareOfHandle(handle)
+	shareName, _, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		return nil, err
+	}
 
 	// Read through the open transaction rather than the post-commit usage
 	// cache, so a statfs issued inside a transaction sees that transaction's

--- a/pkg/metadata/store/basestore/handle.go
+++ b/pkg/metadata/store/basestore/handle.go
@@ -18,27 +18,3 @@ func GenerateHandle(ctx context.Context, shareName string) (metadata.FileHandle,
 	}
 	return metadata.GenerateNewHandle(shareName)
 }
-
-// ShareOfHandle returns the share a handle belongs to, or the empty string when
-// the handle does not decode.
-//
-// Usage and statistics are per-share, so every backend needs the handle's share
-// to answer statfs. An undecodable handle is not an error there, but what the
-// empty string means is the CALLER's policy, not this function's — the two in
-// tree differ:
-//
-//   - The KV backends treat it as a share name that matches nothing, so usage
-//     reads back zero. A share with no files and a share that does not exist are
-//     indistinguishable by usage anyway.
-//   - The SQL backends' statfsQuery treats it as a sentinel for "no share
-//     predicate" and falls back to the store-wide aggregate, which keeps a
-//     single-share deployment reporting the same numbers it always has.
-//
-// Decide which you want at the call site rather than assuming empty means zero.
-func ShareOfHandle(handle metadata.FileHandle) string {
-	shareName, _, err := metadata.DecodeFileHandle(handle)
-	if err != nil {
-		return ""
-	}
-	return shareName
-}

--- a/pkg/metadata/store/memory/server.go
+++ b/pkg/metadata/store/memory/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/marmos91/dittofs/pkg/metadata"
-	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 )
 
 // ============================================================================
@@ -108,12 +107,9 @@ func (store *MemoryMetadataStore) GetFilesystemStatistics(ctx context.Context, h
 		return nil, err
 	}
 
-	// Validate handle
-	if len(handle) == 0 {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrInvalidHandle,
-			Message: "file handle cannot be empty",
-		}
+	shareName, _, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		return nil, err
 	}
 
 	store.mu.RLock()
@@ -128,7 +124,7 @@ func (store *MemoryMetadataStore) GetFilesystemStatistics(ctx context.Context, h
 		}
 	}
 
-	stats := store.computeStatistics(basestore.ShareOfHandle(handle))
+	stats := store.computeStatistics(shareName)
 	return &stats, nil
 }
 

--- a/pkg/metadata/store/memory/transaction.go
+++ b/pkg/metadata/store/memory/transaction.go
@@ -804,6 +804,11 @@ func (tx *memoryTransaction) GetFilesystemStatistics(ctx context.Context, handle
 		return nil, err
 	}
 
-	stats := tx.store.computeStatistics(basestore.ShareOfHandle(handle))
+	shareName, _, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		return nil, err
+	}
+
+	stats := tx.store.computeStatistics(shareName)
 	return &stats, nil
 }

--- a/pkg/metadata/store/postgres/server.go
+++ b/pkg/metadata/store/postgres/server.go
@@ -86,10 +86,13 @@ func (s *PostgresMetadataStore) SetFilesystemCapabilities(capabilities metadata.
 // GetFilesystemStatistics returns filesystem statistics scoped to the share
 // encoded in the handle. The store-wide atomic usedBytes counter cannot answer
 // a per-share query, so a scoped SQL aggregate (statfsQuery) is used instead.
-// An undecodable handle falls back to the store-wide totals (single-share
-// compatible).
+// A handle that does not decode names no share and is rejected.
 func (s *PostgresMetadataStore) GetFilesystemStatistics(ctx context.Context, handle metadata.FileHandle) (*metadata.FilesystemStatistics, error) {
-	sql, args := statfsQuery(handle)
+	shareName, _, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		return nil, err
+	}
+	sql, args := statfsQuery(shareName)
 	var bytesUsed, filesUsed int64
 	if err := s.queryRow(ctx, sql, args...).Scan(&bytesUsed, &filesUsed); err != nil {
 		return nil, mapPgError(err, "GetFilesystemStatistics", "")

--- a/pkg/metadata/store/postgres/statfs.go
+++ b/pkg/metadata/store/postgres/statfs.go
@@ -5,15 +5,13 @@ import (
 )
 
 // statfsQuery builds the aggregate query (and its args) behind
-// GetFilesystemStatistics, scoped to one share.
+// GetFilesystemStatistics, for the pool and the transaction path alike. The
+// share predicate is not optional: without it every share reports the
+// store-wide total.
 //
-// The aggregate counts only regular files, matching the semantics of the
-// store-wide usedBytes counter it replaces: directories, symlinks and other
-// non-regular entries carry no logical bytes and must not inflate UsedFiles
-// (the share root directory would otherwise be counted).
-//
-// Both the pool and the transaction implementations share this, so the scoping
-// rule lives in exactly one place.
+// Only regular files are counted, matching the store-wide usedBytes counter:
+// directories, symlinks and other non-regular entries carry no logical bytes
+// and would otherwise inflate UsedFiles by the share root.
 func statfsQuery(shareName string) (sql string, args []any) {
 	return `SELECT COALESCE(SUM(size), 0), COUNT(*) FROM inodes WHERE share_name = $1 AND file_type = $2`,
 		[]any{shareName, int(metadata.FileTypeRegular)}

--- a/pkg/metadata/store/postgres/statfs.go
+++ b/pkg/metadata/store/postgres/statfs.go
@@ -2,28 +2,19 @@ package postgres
 
 import (
 	"github.com/marmos91/dittofs/pkg/metadata"
-	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 )
 
-// statfsQuery builds the aggregate query (and its args) for
-// GetFilesystemStatistics. When the handle decodes to a share name the
-// aggregate is scoped to that share with a WHERE predicate; otherwise it falls
-// back to the store-wide aggregate (single-share compatible). An undecodable
-// handle is treated as the store-wide case rather than an error.
+// statfsQuery builds the aggregate query (and its args) behind
+// GetFilesystemStatistics, scoped to one share.
 //
 // The aggregate counts only regular files, matching the semantics of the
-// store-wide usedBytes counter (initUsedBytesCounter) it replaces: directories,
-// symlinks and other non-regular entries carry no logical bytes and must not
-// inflate UsedFiles (the share root directory would otherwise be counted).
+// store-wide usedBytes counter it replaces: directories, symlinks and other
+// non-regular entries carry no logical bytes and must not inflate UsedFiles
+// (the share root directory would otherwise be counted).
 //
-// Both the pool and transaction implementations share this so the scoping rule
-// lives in exactly one place.
-func statfsQuery(handle metadata.FileHandle) (sql string, args []any) {
-	shareName := basestore.ShareOfHandle(handle)
-	if shareName != "" {
-		return `SELECT COALESCE(SUM(size), 0), COUNT(*) FROM inodes WHERE share_name = $1 AND file_type = $2`,
-			[]any{shareName, int(metadata.FileTypeRegular)}
-	}
-	return `SELECT COALESCE(SUM(size), 0), COUNT(*) FROM inodes WHERE file_type = $1`,
-		[]any{int(metadata.FileTypeRegular)}
+// Both the pool and the transaction implementations share this, so the scoping
+// rule lives in exactly one place.
+func statfsQuery(shareName string) (sql string, args []any) {
+	return `SELECT COALESCE(SUM(size), 0), COUNT(*) FROM inodes WHERE share_name = $1 AND file_type = $2`,
+		[]any{shareName, int(metadata.FileTypeRegular)}
 }

--- a/pkg/metadata/store/postgres/statfs_test.go
+++ b/pkg/metadata/store/postgres/statfs_test.go
@@ -4,55 +4,28 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/uuid"
-
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// TestStatfsQuery_ScopedVsStoreWide asserts the share-scoping rule lives in one
-// place: a handle that decodes to a share name yields the share-scoped query
-// (share name + regular-file-type predicate). The aggregate counts only regular
+// TestStatfsQuery_ShareScoped asserts the share-scoping rule lives in one place:
+// the aggregate always carries a share predicate, so no caller can accidentally
+// report the store-wide total for one share. The aggregate counts only regular
 // files so the share root directory does not inflate UsedFiles.
-func TestStatfsQuery_ScopedVsStoreWide(t *testing.T) {
-	handle, err := encodeFileHandle("/myshare", uuid.New().String())
-	if err != nil {
-		t.Fatalf("encodeFileHandle: %v", err)
-	}
-
-	sql, args := statfsQuery(handle)
+func TestStatfsQuery_ShareScoped(t *testing.T) {
+	sql, args := statfsQuery("/myshare")
 	if !strings.Contains(sql, "share_name = $1") {
-		t.Errorf("scoped query missing share predicate: %q", sql)
+		t.Errorf("query missing share predicate: %q", sql)
 	}
 	if !strings.Contains(sql, "file_type = $2") {
-		t.Errorf("scoped query missing regular-file predicate: %q", sql)
+		t.Errorf("query missing regular-file predicate: %q", sql)
 	}
 	if len(args) != 2 {
-		t.Fatalf("scoped query args = %v, want share name + file type", args)
+		t.Fatalf("query args = %v, want share name + file type", args)
 	}
 	if got, ok := args[0].(string); !ok || got != "/myshare" {
-		t.Errorf("scoped query arg[0] = %v, want \"/myshare\"", args[0])
+		t.Errorf("query arg[0] = %v, want \"/myshare\"", args[0])
 	}
 	if got, ok := args[1].(int); !ok || got != int(metadata.FileTypeRegular) {
-		t.Errorf("scoped query arg[1] = %v, want FileTypeRegular", args[1])
-	}
-}
-
-// TestStatfsQuery_InvalidHandleFallsBackStoreWide ensures an undecodable handle
-// does not error or scope to a garbage share — it falls back to the store-wide
-// aggregate (single-share compatible). The aggregate still restricts to regular
-// files (matching the store-wide usedBytes counter) so directories are excluded.
-func TestStatfsQuery_InvalidHandleFallsBackStoreWide(t *testing.T) {
-	sql, args := statfsQuery([]byte{0x01, 0x02, 0x03}) // not a valid encoded handle
-	if strings.Contains(sql, "share_name") {
-		t.Errorf("invalid handle produced a share-scoped query: %q", sql)
-	}
-	if !strings.Contains(sql, "file_type = $1") {
-		t.Errorf("store-wide query missing regular-file predicate: %q", sql)
-	}
-	if len(args) != 1 {
-		t.Fatalf("store-wide query args = %v, want just the file type", args)
-	}
-	if got, ok := args[0].(int); !ok || got != int(metadata.FileTypeRegular) {
-		t.Errorf("store-wide query arg[0] = %v, want FileTypeRegular", args[0])
+		t.Errorf("query arg[1] = %v, want FileTypeRegular", args[1])
 	}
 }

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -1356,9 +1356,6 @@ func (tx *postgresTransaction) GetFilesystemStatistics(ctx context.Context, hand
 		return nil, err
 	}
 
-	// Scope the aggregate to the share encoded in the handle (statfsQuery).
-	// Without the WHERE predicate every share reports the store-wide total, so
-	// a handle that does not decode names no share and is rejected.
 	shareName, _, err := metadata.DecodeFileHandle(handle)
 	if err != nil {
 		return nil, err

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -1357,10 +1357,13 @@ func (tx *postgresTransaction) GetFilesystemStatistics(ctx context.Context, hand
 	}
 
 	// Scope the aggregate to the share encoded in the handle (statfsQuery).
-	// Without the WHERE predicate every share reports the store-wide total. An
-	// invalid handle falls back to the store-wide aggregate (single-share
-	// compatible).
-	sql, args := statfsQuery(handle)
+	// Without the WHERE predicate every share reports the store-wide total, so
+	// a handle that does not decode names no share and is rejected.
+	shareName, _, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		return nil, err
+	}
+	sql, args := statfsQuery(shareName)
 	var bytesUsed, filesUsed int64
 	if err := tx.tx.QueryRow(ctx, sql, args...).Scan(&bytesUsed, &filesUsed); err != nil {
 		return nil, mapPgError(err, "GetFilesystemStatistics", "")

--- a/pkg/metadata/store/sqlite/server.go
+++ b/pkg/metadata/store/sqlite/server.go
@@ -98,10 +98,13 @@ func (s *SQLiteMetadataStore) SetFilesystemCapabilities(capabilities metadata.Fi
 // GetFilesystemStatistics returns filesystem statistics scoped to the share
 // encoded in the handle. The store-wide atomic usedBytes counter cannot answer
 // a per-share query, so a scoped SQL aggregate (statfsQuery) is used instead.
-// An undecodable handle falls back to the store-wide totals (single-share
-// compatible).
+// A handle that does not decode names no share and is rejected.
 func (s *SQLiteMetadataStore) GetFilesystemStatistics(ctx context.Context, handle metadata.FileHandle) (*metadata.FilesystemStatistics, error) {
-	sql, args := statfsQuery(handle)
+	shareName, _, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		return nil, err
+	}
+	sql, args := statfsQuery(shareName)
 	var bytesUsed, filesUsed int64
 	if err := s.queryRow(ctx, sql, args...).Scan(&bytesUsed, &filesUsed); err != nil {
 		return nil, mapDBError(err, "GetFilesystemStatistics", "")

--- a/pkg/metadata/store/sqlite/statfs.go
+++ b/pkg/metadata/store/sqlite/statfs.go
@@ -2,28 +2,19 @@ package sqlite
 
 import (
 	"github.com/marmos91/dittofs/pkg/metadata"
-	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 )
 
-// statfsQuery builds the aggregate query (and its args) for
-// GetFilesystemStatistics. When the handle decodes to a share name the
-// aggregate is scoped to that share with a WHERE predicate; otherwise it falls
-// back to the store-wide aggregate (single-share compatible). An undecodable
-// handle is treated as the store-wide case rather than an error.
+// statfsQuery builds the aggregate query (and its args) behind
+// GetFilesystemStatistics, scoped to one share.
 //
 // The aggregate counts only regular files, matching the semantics of the
-// store-wide usedBytes counter (initUsedBytesCounter) it replaces: directories,
-// symlinks and other non-regular entries carry no logical bytes and must not
-// inflate UsedFiles (the share root directory would otherwise be counted).
+// store-wide usedBytes counter it replaces: directories, symlinks and other
+// non-regular entries carry no logical bytes and must not inflate UsedFiles
+// (the share root directory would otherwise be counted).
 //
-// Both the pool and transaction implementations share this so the scoping rule
-// lives in exactly one place.
-func statfsQuery(handle metadata.FileHandle) (sql string, args []any) {
-	shareName := basestore.ShareOfHandle(handle)
-	if shareName != "" {
-		return `SELECT COALESCE(SUM(size), 0), COUNT(*) FROM inodes WHERE share_name = ?1 AND file_type = ?2`,
-			[]any{shareName, int(metadata.FileTypeRegular)}
-	}
-	return `SELECT COALESCE(SUM(size), 0), COUNT(*) FROM inodes WHERE file_type = ?1`,
-		[]any{int(metadata.FileTypeRegular)}
+// Both the pool and the transaction implementations share this, so the scoping
+// rule lives in exactly one place.
+func statfsQuery(shareName string) (sql string, args []any) {
+	return `SELECT COALESCE(SUM(size), 0), COUNT(*) FROM inodes WHERE share_name = ?1 AND file_type = ?2`,
+		[]any{shareName, int(metadata.FileTypeRegular)}
 }

--- a/pkg/metadata/store/sqlite/statfs.go
+++ b/pkg/metadata/store/sqlite/statfs.go
@@ -5,15 +5,13 @@ import (
 )
 
 // statfsQuery builds the aggregate query (and its args) behind
-// GetFilesystemStatistics, scoped to one share.
+// GetFilesystemStatistics, for the pool and the transaction path alike. The
+// share predicate is not optional: without it every share reports the
+// store-wide total.
 //
-// The aggregate counts only regular files, matching the semantics of the
-// store-wide usedBytes counter it replaces: directories, symlinks and other
-// non-regular entries carry no logical bytes and must not inflate UsedFiles
-// (the share root directory would otherwise be counted).
-//
-// Both the pool and the transaction implementations share this, so the scoping
-// rule lives in exactly one place.
+// Only regular files are counted, matching the store-wide usedBytes counter:
+// directories, symlinks and other non-regular entries carry no logical bytes
+// and would otherwise inflate UsedFiles by the share root.
 func statfsQuery(shareName string) (sql string, args []any) {
 	return `SELECT COALESCE(SUM(size), 0), COUNT(*) FROM inodes WHERE share_name = ?1 AND file_type = ?2`,
 		[]any{shareName, int(metadata.FileTypeRegular)}

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -1299,10 +1299,13 @@ func (tx *sqliteTransaction) GetFilesystemStatistics(ctx context.Context, handle
 	}
 
 	// Scope the aggregate to the share encoded in the handle (statfsQuery).
-	// Without the WHERE predicate every share reports the store-wide total. An
-	// invalid handle falls back to the store-wide aggregate (single-share
-	// compatible).
-	sql, args := statfsQuery(handle)
+	// Without the WHERE predicate every share reports the store-wide total, so
+	// a handle that does not decode names no share and is rejected.
+	shareName, _, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		return nil, err
+	}
+	sql, args := statfsQuery(shareName)
 	var bytesUsed, filesUsed int64
 	if err := tx.tx.QueryRow(ctx, sql, args...).Scan(&bytesUsed, &filesUsed); err != nil {
 		return nil, mapDBError(err, "GetFilesystemStatistics", "")

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -1298,9 +1298,6 @@ func (tx *sqliteTransaction) GetFilesystemStatistics(ctx context.Context, handle
 		return nil, err
 	}
 
-	// Scope the aggregate to the share encoded in the handle (statfsQuery).
-	// Without the WHERE predicate every share reports the store-wide total, so
-	// a handle that does not decode names no share and is rejected.
 	shareName, _, err := metadata.DecodeFileHandle(handle)
 	if err != nil {
 		return nil, err

--- a/pkg/metadata/storetest/store_surface.go
+++ b/pkg/metadata/storetest/store_surface.go
@@ -643,6 +643,17 @@ func testFilesystemMetaStatsCaps(t *testing.T, factory StoreFactory) {
 		t.Errorf("GetFilesystemStatistics() UsedBytes = %d, want 1234", stats.UsedBytes)
 	}
 
+	// A handle that does not decode names no share, so it has no usage to
+	// report. Backends must reject it rather than substituting a reading of
+	// their own — zero, or the store-wide aggregate across every share the
+	// store holds. The store instance is shared by every share naming the same
+	// config, so a store-wide fallback would report another share's bytes.
+	if _, err := store.GetFilesystemStatistics(ctx, metadata.FileHandle("not-a-handle")); err == nil {
+		t.Error("GetFilesystemStatistics() on an undecodable handle returned no error, want ErrInvalidHandle")
+	} else if !metadata.IsInvalidHandleError(err) {
+		t.Errorf("GetFilesystemStatistics() on an undecodable handle error = %v, want ErrInvalidHandle", err)
+	}
+
 	// SetFilesystemCapabilities must be observable through
 	// GetFilesystemCapabilities (resolved against the root handle).
 	caps, err := store.GetFilesystemCapabilities(ctx, rootHandle)


### PR DESCRIPTION
`basestore.ShareOfHandle` turned a decode failure into the empty string and left
its meaning to the caller. Each of the three store families then picked a
different meaning, and statfs answered a corrupt handle three different ways.

Closes #2067.

## The premise was understated: three behaviours, not two

The issue described two. There are three — the memory backend's store-level and
transaction-level paths do not agree with each other. Adding the conformance
assertion to unmodified `develop` and running it against each backend:

```
badger   store_surface.go:652: GetFilesystemStatistics() on an undecodable handle
                               returned no error, want ErrInvalidHandle
sqlite   store_surface.go:652: GetFilesystemStatistics() on an undecodable handle
                               returned no error, want ErrInvalidHandle
memory   store_surface.go:654: GetFilesystemStatistics() on an undecodable handle
                               error = NotFound: file not found, want ErrInvalidHandle
```

- **badger** — reads the per-share usage bucket for share `""`, which matches
  nothing, and reports zero usage with no error.
- **memory** — the *store* path happens to reject, but by accident and with the
  wrong code: its handle-exists check fires `ErrNotFound`. Its *transaction*
  path has no such check and returns zeros like badger.
- **sqlite / postgres** — `statfsQuery` drops the `WHERE share_name = ?`
  predicate entirely and reports the aggregate across every share the store
  instance holds. One store instance backs every share naming the same metadata
  store config, so this is another share's bytes, not a harmless total.

## The fix

Delete `ShareOfHandle`. It existed only to discard `DecodeFileHandle`'s error,
and that discard is the whole defect — six call sites each had to re-invent a
policy for a value that means "this failed". The call sites now decode directly
and propagate the typed `ErrInvalidHandle`, so all four backends agree.

`statfsQuery` takes a share name instead of a handle and has no fallback branch,
which removes the "no share predicate" case from the SQL backends structurally
rather than by convention.

Net −19 lines.

## This changes no production behaviour, and here is why

An undecodable handle cannot reach a backend's `GetFilesystemStatistics` on a
live server. The only production caller is
`Service.GetFilesystemStatisticsForIdentity`, which decodes *first* and returns
before a store is selected (`pkg/metadata/service.go:635`):

```go
shareName, _, err := DecodeFileHandle(handle)
if err != nil {
    return nil, err
}
store, err := s.GetStoreForShare(shareName)
```

The evidence that this is the only route is structural, not statistical:

- An exhaustive grep for `\.GetFilesystemStatistics(` finds three non-test call
  sites — `pkg/metadata/service.go`, the SMB handler, and the conformance suite
  — and the SMB one goes through the Service with a handle taken from an already
  open file.
- Every struct embedding `metadata.Store` or `metadata.Transaction` (which could
  forward the method by promotion) is a test file or the conformance harness;
  there is no production wrapper.
- `DecodeFileHandle` rejects an empty share name outright
  (`pkg/metadata/types.go:89`), so a handle that decodes *never* yields the empty
  string. `ShareOfHandle` returned "" only on error.

So the divergence was reachable only from a direct store-level caller — which
today means tests and any future backend author reading the contract. That is
still worth fixing: `storetest/` is a published contract, and its old doc comment
actively told a new backend author that the meaning was theirs to choose.

Of the three options the issue laid out, this is **reject** — chosen because the
Service already does exactly that one layer up, so it is the only option that
makes the backends agree with the behaviour the server already has.

## Verification

- Conformance assertion added to `storetest/store_surface.go`, so a new backend
  cannot diverge again. It fails on unmodified `develop` for badger, sqlite and
  memory (output above) and passes here.
- `TestMetadataService_FSStat_RejectsUndecodableHandle` pins the Service-level
  guarantee the backends rely on, so the protocol-visible answer stays BADHANDLE.
- `go build ./...`, `go vet ./...`, `gofmt -l`, `go test ./...` all clean.

## Left alone deliberately

The memory backend's store-level statfs still verifies the handle exists and
returns `ErrNotFound` for a well-formed handle naming a deleted file, where the
other backends return statistics. That is a real divergence but a different one
— decodable handle, not undecodable — and unifying it would change what a live
server reports. Not folded into this PR.
