### PR TITLE
fix(engine): hold the per-file commit lock while reaping superseded manifest rows

### DIFF
--- a/pkg/block/engine/blocksink.go
+++ b/pkg/block/engine/blocksink.go
@@ -155,6 +155,10 @@ func (s localBlockSink) ReapSupersededManifest(ctx context.Context, id journal.F
 	if s.committer == nil {
 		return nil
 	}
+	if mu := s.commitLocks.forKey(string(id)); mu != nil {
+		mu.Lock()
+		defer mu.Unlock()
+	}
 	return s.committer.WithTransaction(ctx, func(tx metadata.Transaction) error {
 		return metadata.ReapSupersededManifest(ctx, tx, string(id), runStart, runEnd, newOffsets)
 	})
@@ -193,6 +197,10 @@ func manifestRowEndAfter(ctx context.Context, c blockCommitter, payloadID string
 // remote-backed sink: delete the manifest rows the carve run superseded, atomic
 // with a re-projection of File.Blocks (#953).
 func (s engineBlockSink) ReapSupersededManifest(ctx context.Context, id journal.FileID, runStart, runEnd int64, newOffsets map[int64]struct{}) error {
+	if mu := s.commitLocks.forKey(string(id)); mu != nil {
+		mu.Lock()
+		defer mu.Unlock()
+	}
 	return s.committer.WithTransaction(ctx, func(tx metadata.Transaction) error {
 		return metadata.ReapSupersededManifest(ctx, tx, string(id), runStart, runEnd, newOffsets)
 	})

--- a/pkg/block/engine/blocksink.go
+++ b/pkg/block/engine/blocksink.go
@@ -155,13 +155,7 @@ func (s localBlockSink) ReapSupersededManifest(ctx context.Context, id journal.F
 	if s.committer == nil {
 		return nil
 	}
-	if mu := s.commitLocks.forKey(string(id)); mu != nil {
-		mu.Lock()
-		defer mu.Unlock()
-	}
-	return s.committer.WithTransaction(ctx, func(tx metadata.Transaction) error {
-		return metadata.ReapSupersededManifest(ctx, tx, string(id), runStart, runEnd, newOffsets)
-	})
+	return reapSupersededManifest(ctx, s.committer, s.commitLocks, string(id), runStart, runEnd, newOffsets)
 }
 
 // ManifestRowEndAfter answers journal's run-extension query: how far the manifest
@@ -193,17 +187,24 @@ func manifestRowEndAfter(ctx context.Context, c blockCommitter, payloadID string
 	return end, err
 }
 
+// reapSupersededManifest runs the run-end reap under the same per-file lock
+// CommitBlock takes, since both end in a read-modify-write of the file's
+// File.Blocks row and would otherwise abort each other under badger's SSI.
+func reapSupersededManifest(ctx context.Context, c blockCommitter, locks *carveCommitLocks, payloadID string, runStart, runEnd int64, newOffsets map[int64]struct{}) error {
+	if mu := locks.forKey(payloadID); mu != nil {
+		mu.Lock()
+		defer mu.Unlock()
+	}
+	return c.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return metadata.ReapSupersededManifest(ctx, tx, payloadID, runStart, runEnd, newOffsets)
+	})
+}
+
 // ReapSupersededManifest implements journal's optional run-end reap for the
 // remote-backed sink: delete the manifest rows the carve run superseded, atomic
 // with a re-projection of File.Blocks (#953).
 func (s engineBlockSink) ReapSupersededManifest(ctx context.Context, id journal.FileID, runStart, runEnd int64, newOffsets map[int64]struct{}) error {
-	if mu := s.commitLocks.forKey(string(id)); mu != nil {
-		mu.Lock()
-		defer mu.Unlock()
-	}
-	return s.committer.WithTransaction(ctx, func(tx metadata.Transaction) error {
-		return metadata.ReapSupersededManifest(ctx, tx, string(id), runStart, runEnd, newOffsets)
-	})
+	return reapSupersededManifest(ctx, s.committer, s.commitLocks, string(id), runStart, runEnd, newOffsets)
 }
 
 // engineBlockSink is journal's production BlockSink: it seals each carved chunk,

--- a/pkg/block/engine/blocksink_ssi_test.go
+++ b/pkg/block/engine/blocksink_ssi_test.go
@@ -99,3 +99,48 @@ func TestLocalBlockSink_ConcurrentSameFileCommit_NoSSIConflict(t *testing.T) {
 	require.Zero(t, store.TransactionConflictsForTest(),
 		"concurrent same-file carve commits must not serialize on the File row (SSI conflict)")
 }
+
+// TestLocalBlockSink_ConcurrentReapAndCommit_NoSSIConflict reproduces the same
+// File-row hazard as above, but between a run's own commits and a sibling
+// run's end-of-run reap: ReapSupersededManifest ends in a read-modify-write of
+// the same File.Blocks row that CommitBlock projects onto, so the two must
+// serialize on that row rather than race it.
+func TestLocalBlockSink_ConcurrentReapAndCommit_NoSSIConflict(t *testing.T) {
+	ctx := context.Background()
+	store, pid := newBadgerCommitter(t)
+	sink := localBlockSink{committer: store, commitLocks: &carveCommitLocks{}}
+
+	const n = 8
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			if i%2 == 0 {
+				data := []byte{byte(i), byte(i >> 8), 0xab, 0xcd}
+				errs[i] = sink.CommitBlock(ctx, []journal.CarveChunk{{
+					FileID:     journal.FileID(pid),
+					FileOffset: int64(i) * 4096,
+					Hash:       journal.ChunkHash(blake3.Sum256(data)),
+					Data:       data,
+				}})
+				return
+			}
+			// A disjoint span from every commit above, so a correct
+			// implementation serializes only the shared File-row write.
+			off := int64(i) * 4096
+			errs[i] = sink.ReapSupersededManifest(ctx, journal.FileID(pid), off, off+4096, nil)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoErrorf(t, err, "concurrent carve metadata write %d surfaced an error", i)
+	}
+	require.Zero(t, store.TransactionConflictsForTest(),
+		"a reap racing a sibling run's commit must not conflict on the File row")
+}


### PR DESCRIPTION
Part of #2070 (which stages the fix for #1872). Self-contained — it does not depend on the carve-concurrency work and can land on its own.

## The defect

`CommitBlock` takes a striped per-file mutex (`carveCommitLocks.forKey`) before writing manifest rows, because that write ends in `ProjectManifestToBlocks` — a read-modify-write of the file's `File.Blocks` row — and badger's SSI aborts concurrent writers to the same row. That lock is what keeps a file's concurrent carve commits off each other; without it the retry budget drains and the conflict surfaces as EDEADLK.

Both `ReapSupersededManifest` implementations performed the same `File.Blocks` write **without** taking that lock.

It was unreachable while carve runs were serial: a run reaps only after its own `disp.wait()` has drained every commit for that run, and no sibling run has started. Making runs concurrent (the next change in #2070) exposes it two ways — reap racing a sibling reap, and reap racing a sibling run's still-in-flight `CommitBlock`.

## Measured

The new test drives 8 goroutines at one file, alternating `CommitBlock` and `ReapSupersededManifest`. Every reap genuinely re-projects the row: `metadata.ReapSupersededManifest` calls `ProjectManifestToBlocks` on any non-empty span whether or not a row matched.

```
before the fix:  TransactionConflictsForTest() = 9
after the fix:   TransactionConflictsForTest() = 0
```

The failure is on the conflict counter rather than an error return — badger's retry loop absorbs the conflict, which is exactly why this would have degraded quietly under the workload the concurrency change targets.

## The change

Both sinks call one `reapSupersededManifest` helper that takes the stripe and holds it across the whole transaction, mirroring `commitManifestRows`. Badger's retry loop runs inside that single `WithTransaction` call, so every attempt is covered. `localBlockSink`'s nil-committer no-op is checked before the lock; `forKey`'s nil-receiver path keeps fixtures that wire no stripes working.

Not touched: `ManifestRowEndAfter`, the run-extension straddle lookup, is a read outside the lock. It is not a conflict source, but concurrent runs will each call it — tracked on #2070 rather than widened into this PR.

## Verified

`go test -race -count=1 ./pkg/block/engine/` green, including the pre-existing `TestLocalBlockSink_ConcurrentSameFileCommit_NoSSIConflict`. `go build ./...` and `go vet` clean.