### PR TITLE
perf(journal): carve a file's dirty runs concurrently

### DIFF
--- a/.planning/perf/2026-08-24-1872-carve-drain-convergence-PLAN.md
+++ b/.planning/perf/2026-08-24-1872-carve-drain-convergence-PLAN.md
@@ -1,0 +1,104 @@
+# #1872 carve drain convergence — staged plan (tracking: #2070)
+
+A randomly-written share's drain does not converge: `dfsctl system drain-uploads` times out and
+eviction fails with it. Measured tail on the bench VM was ~2 MiB/30s (~68 KiB/s), network TX
+matching, about 21 serial PUTs/s.
+
+#1875 fixed both contributing defects in one diff and **regressed on hardware** — blocks committed
+continuously while `UnsyncedBytes` stayed flat at 644 MiB, meaning records were never flipped
+synced and the carve re-carved the same ranges forever. That root cause is still unknown. The
+plan below exists to avoid paying that price again.
+
+## The two defects, and why they are separable
+
+`pkg/block/journal/carve.go`, current develop:
+
+| # | Defect | Site | Touches the flip chain? |
+| --- | --- | --- | --- |
+| 1 | Runs upload serially — `carveRun` ends by waiting for its own commits | `carve.go:448` | **no** |
+| 2 | A block is cut at every run boundary, so a 4 KiB run commits its own remote object | `carve.go:424`, tail flush at `:447` | **yes** |
+
+#1875 assumed they were one change, because it fixed both by hoisting the block builder *and* the
+dispatcher to file scope — and a block spanning runs forces `flipUpTo` (`carve.go:574`) to walk the
+whole snapshot with one shared `flipIdx`. That is the part that broke.
+
+Defect 1 alone can be fixed with `flipUpTo` untouched, because each run already carries its own
+dispatcher and its own `flipIdx` over its own slice (`carve.go:273`, `:281`). Defect 1 is also the
+one that makes the drain *converge*, which is the user-visible bug. Defect 2 only makes it faster.
+
+## Step 0 — the regression test that was missing
+
+`pkg/block/journal/carve_scatter_test.go` (new; the same file name exists on the closed
+`perf/1872-carve-pack-across-runs` branch and its two tests are worth salvaging as-is).
+
+Assert that after carving a scattered dirty set, `UnsyncedBytes() == 0`, under a sink that mimics
+the real commit path rather than a fake that always succeeds. #1875's tests asserted block count
+and peak commit concurrency; both passed while the drain looped forever, which is exactly the
+failure this must catch.
+
+Bar: this test fails on `perf/1872-carve-pack-across-runs` and passes on develop. Verify both before
+moving on — a test that passes on the known-bad branch is worth nothing here.
+
+## Step 1 — parallelise runs (no flip changes)
+
+**`carve.go:246`** — the run-splitting loop calls `carveRun` serially. Replace with a bounded
+errgroup over the run slices. Runs are disjoint by construction, and each already owns its
+`flipIdx`, its dispatcher and its `newOffsets`.
+
+**`carve_dispatch.go:60`** — `sem` is built per dispatcher, so N concurrent runs would multiply
+peak carve RAM by N. Hoist it: build one `chan struct{}` in `carveFile` and pass it to
+`newCarveDispatcher`. This *restores* the documented contract — `store.go:67` already says
+`CarveUploadConcurrency` bounds how many of **one file's** blocks are in flight, which per-run
+semantics only accidentally satisfied. Peak RAM stays `cap(sem) x (CarveBlockSize + overhang)`.
+
+Sharp edges, all bounded and none on the flip path:
+
+- **Shared records across adjacent runs.** `extendRunToRowEnd` (`carve.go:264`) can pull two
+  adjacent runs into the same manifest row, and `flipUpTo`'s `recordHasDirtyFragment` check reads
+  fragments of a record another run may be flipping. Both take `sh.mu`; confirm the read-modify-write
+  of the flags byte stays atomic under that lock with two runs in flight, and that
+  `recordHasDirtyFragment` observing a *partially* flipped record is safe (it should be — it skips,
+  and the losing run re-checks on its own flip).
+- **`res *CarveResult`.** `BlocksWritten` / `BytesCarved` are incremented from run goroutines
+  (`carve.go:263` signature). Give each run its own result and merge after the group, rather than
+  adding a mutex to a struct on a hot-ish path.
+- **`ReapSupersededManifest`** (`carve.go:452`) now runs concurrently per run. Runs are disjoint
+  spans and each passes its own `newOffsets`, so a reap cannot delete a sibling's fresh rows — but
+  #1979 and #2049 both landed in this area since #1875 was written, so re-read the row-straddling
+  argument against current code rather than against the PR description.
+- **Error semantics.** Today the first failing run aborts the file (`carve.go:251`). Keep that:
+  collect the first error, let in-flight runs drain, leave the rest dirty.
+
+Verification: full `pkg/block/journal` suite (it covers flip ordering, crash-mid-commit re-carve and
+dedup), `go test -race ./pkg/block/...`, and step 0's test.
+
+## Step 2 — measure on the rig
+
+The probe that motivated #1872: `dittofs-s3-writeback`, `large`, `rand-write-4k` + `seq-read`,
+sampling the store every 30s through the drain. Baseline is develop's progression
+(49 -> 34 -> 45 -> 22 -> 2 -> 2 MiB per 30s).
+
+This settles the question that decides step 3: is the drain **round-trip-bound** (step 1 fixes it)
+or **bandwidth-bound on 4 KiB objects** (only step 3 helps)? 68 KiB/s at ~21 PUTs/s says round-trip,
+but that is one sample on one VM.
+
+Rig discipline: fresh SCW VM, verify `.bench-vm.json` `server_id` is not a coder VM before any
+teardown, heartbeat-monitor the run.
+
+## Step 3 — block packing across runs (conditional)
+
+Only if step 2 shows small-object count still dominating. This is #1875's diff, and its entry price
+is root-causing that stall on hardware first — not re-deriving the watermark-ordering argument,
+which read as correct and was not. Note the obvious theory is already dead: `fileOff` *is* reset per
+run on that branch (line 324), so the watermarks did ascend.
+
+Do not rebase the branch. 19 journal commits have landed on `carve.go` since (#1979, #2049, #1988,
+#2015, #2064); rewrite from the diagnosis.
+
+## What is deliberately not done
+
+No coalescing of runs across gaps (feeding the chunker already-synced resident bytes so a scattered
+neighbourhood becomes one run). It is appealing — it fixes both defects with `flipUpTo` untouched,
+because already-synced intervals flip to a no-op — but its coverage depends on how much of the gap
+is still resident rather than reclaimed or cold, which is unknown and workload-dependent. Revisit
+only if step 2 says step 3 is needed and the flip stall stays unexplained.

--- a/.planning/perf/2026-08-24-1872-carve-drain-convergence-PLAN.md
+++ b/.planning/perf/2026-08-24-1872-carve-drain-convergence-PLAN.md
@@ -1,104 +1,495 @@
-# #1872 carve drain convergence — staged plan (tracking: #2070)
+# Carve drain convergence — implementation plan (#2070, closes #1872)
 
-A randomly-written share's drain does not converge: `dfsctl system drain-uploads` times out and
-eviction fails with it. Measured tail on the bench VM was ~2 MiB/30s (~68 KiB/s), network TX
-matching, about 21 serial PUTs/s.
+> **For agentic workers:** REQUIRED SUB-SKILL: use superpowers:subagent-driven-development (recommended)
+> or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
 
-#1875 fixed both contributing defects in one diff and **regressed on hardware** — blocks committed
-continuously while `UnsyncedBytes` stayed flat at 644 MiB, meaning records were never flipped
-synced and the carve re-carved the same ranges forever. That root cause is still unknown. The
-plan below exists to avoid paying that price again.
+**Goal:** Make a randomly-written share's drain converge, by uploading a file's dirty runs
+concurrently instead of one after another.
 
-## The two defects, and why they are separable
+**Architecture:** `carveFile` currently calls `carveRun` serially, and each `carveRun` ends by
+waiting for its own commits (`carve.go:448`), so a scattered dirty set costs one serial remote
+round-trip per run. Runs become concurrent under a bounded errgroup. Each run keeps its own
+dispatcher, its own `flipIdx` and its own slice, so **`flipUpTo` is not touched** — that is the
+whole point of this shape, and the reason it is not the closed PR #1875. Number of remote objects
+is unchanged; only their serialisation goes away.
 
-`pkg/block/journal/carve.go`, current develop:
+**Tech stack:** Go, `golang.org/x/sync/errgroup` (already a dependency, `go.mod:40`), badger
+metadata store, `pkg/block/journal` + `pkg/block/engine`.
 
-| # | Defect | Site | Touches the flip chain? |
-| --- | --- | --- | --- |
-| 1 | Runs upload serially — `carveRun` ends by waiting for its own commits | `carve.go:448` | **no** |
-| 2 | A block is cut at every run boundary, so a 4 KiB run commits its own remote object | `carve.go:424`, tail flush at `:447` | **yes** |
+**Spec:** GitHub issue #2070. Defect report: #1872. Failed prior attempt: #1875 (closed).
 
-#1875 assumed they were one change, because it fixed both by hoisting the block builder *and* the
-dispatcher to file scope — and a block spanning runs forces `flipUpTo` (`carve.go:574`) to walk the
-whole snapshot with one shared `flipIdx`. That is the part that broke.
+## Global constraints
 
-Defect 1 alone can be fixed with `flipUpTo` untouched, because each run already carries its own
-dispatcher and its own `flipIdx` over its own slice (`carve.go:273`, `:281`). Defect 1 is also the
-one that makes the drain *converge*, which is the user-visible bug. Defect 2 only makes it faster.
+- **`flipUpTo` (`carve.go:574`) must not change in this plan.** It sets the on-disk synced bit;
+  getting it wrong is silent data loss on recovery (#1850). Any task that finds itself editing it
+  has left this plan — stop and re-scope.
+- Peak carve RAM must stay `cap(sem) x (CarveBlockSize + one overhang chunk)`. This bound is the
+  reason `sem` is hoisted rather than duplicated per run.
+- No new config field. Run-level concurrency reuses `CarveUploadConcurrency`.
+- Every task ends with a signed commit (`git commit -S`; if the agent socket fails, use
+  `git -c user.signingkey=$HOME/.ssh/id_rsa.pub commit -S`).
+- `go test -race ./pkg/block/...` green is part of "done" for every task, not just the last.
 
-## Step 0 — the regression test that was missing
+## What is already known and must not be re-derived
 
-`pkg/block/journal/carve_scatter_test.go` (new; the same file name exists on the closed
-`perf/1872-carve-pack-across-runs` branch and its two tests are worth salvaging as-is).
+- **The two defects are separable.** Serial runs (`carve.go:448`) and one-block-per-run
+  (`carve.go:424`) are independent; only the second forces the flip chain to span runs. This plan
+  fixes the first one only.
+- **There is no reproduction of the #1875 stall at any level.** `carve_scatter_test.go` on
+  `perf/1872-carve-pack-across-runs` writes 200 non-contiguous 4 KiB runs and asserts
+  `post-carve unsynced want 0` — verified passing on the branch that stalls on hardware
+  (`ok github.com/marmos91/dittofs/pkg/block/journal 0.905s`). A unit-level scattered carve
+  asserting convergence does **not** reproduce it. Building a reproduction is the entry price for
+  the conditional block-packing work at the end of this plan, not a warm-up for Task 1.
+- **`sh.carveMu` already serialises the whole per-shard carve pass** (`carve.go:177`, `shard.go:54`),
+  and `Carve`'s shard and file loops are both sequential — so at most one `carveFile` is active
+  system-wide. Every race below is between goroutines of a *single* `carveFile` call.
 
-Assert that after carving a scattered dirty set, `UnsyncedBytes() == 0`, under a sink that mimics
-the real commit path rather than a fake that always succeeds. #1875's tests asserted block count
-and peak commit concurrency; both passed while the drain looped forever, which is exactly the
-failure this must catch.
+## File structure
 
-Bar: this test fails on `perf/1872-carve-pack-across-runs` and passes on develop. Verify both before
-moving on — a test that passes on the known-bad branch is worth nothing here.
+| File | Change | Responsibility |
+| --- | --- | --- |
+| `pkg/block/journal/carve.go` | modify `carveFile` (230-258), `carveRun` (263-463) | run-level concurrency; per-run result |
+| `pkg/block/journal/carve_dispatch.go` | modify `newCarveDispatcher` (48-63) | accept a caller-owned `sem` |
+| `pkg/block/journal/store.go` | comment only (67-73) | `CarveUploadConcurrency` now spans a file's runs |
+| `pkg/block/engine/blocksink.go` | modify both `ReapSupersededManifest` (154-161, 195-199) | take the striped commit lock |
+| `pkg/block/engine/blocksink_ssi_test.go` | add one test | reap-vs-commit SSI conflict |
+| `pkg/block/journal/carve_concurrent_test.go` | create | scattered carve converges under concurrent runs |
 
-## Step 1 — parallelise runs (no flip changes)
+---
 
-**`carve.go:246`** — the run-splitting loop calls `carveRun` serially. Replace with a bounded
-errgroup over the run slices. Runs are disjoint by construction, and each already owns its
-`flipIdx`, its dispatcher and its `newOffsets`.
+### Task 1: Give each run its own `CarveResult`
 
-**`carve_dispatch.go:60`** — `sem` is built per dispatcher, so N concurrent runs would multiply
-peak carve RAM by N. Hoist it: build one `chan struct{}` in `carveFile` and pass it to
-`newCarveDispatcher`. This *restores* the documented contract — `store.go:67` already says
-`CarveUploadConcurrency` bounds how many of **one file's** blocks are in flight, which per-run
-semantics only accidentally satisfied. Peak RAM stays `cap(sem) x (CarveBlockSize + overhang)`.
+`res.BytesCarved += int64(boundary)` (`carve.go:416`) and `res.BlocksWritten++`
+(`carve_dispatch.go:145`) run in each run's own goroutine against one shared pointer
+(`carve.go:251`). Within a run the `prev`/`mine` chain orders the dispatcher's writes; across runs
+there is no happens-before at all. **This is a confirmed race, not a hypothetical** — it fires the
+moment Task 4 lands, so it is fixed first, while callers are still serial and nothing can regress.
 
-Sharp edges, all bounded and none on the flip path:
+**Files:**
+- Modify: `pkg/block/journal/carve.go:263` (signature), `:416`, `:432-443` (early return), `:246-255` (caller)
 
-- **Shared records across adjacent runs.** `extendRunToRowEnd` (`carve.go:264`) can pull two
-  adjacent runs into the same manifest row, and `flipUpTo`'s `recordHasDirtyFragment` check reads
-  fragments of a record another run may be flipping. Both take `sh.mu`; confirm the read-modify-write
-  of the flags byte stays atomic under that lock with two runs in flight, and that
-  `recordHasDirtyFragment` observing a *partially* flipped record is safe (it should be — it skips,
-  and the losing run re-checks on its own flip).
-- **`res *CarveResult`.** `BlocksWritten` / `BytesCarved` are incremented from run goroutines
-  (`carve.go:263` signature). Give each run its own result and merge after the group, rather than
-  adding a mutex to a struct on a hot-ish path.
-- **`ReapSupersededManifest`** (`carve.go:452`) now runs concurrently per run. Runs are disjoint
-  spans and each passes its own `newOffsets`, so a reap cannot delete a sibling's fresh rows — but
-  #1979 and #2049 both landed in this area since #1875 was written, so re-read the row-straddling
-  argument against current code rather than against the PR description.
-- **Error semantics.** Today the first failing run aborts the file (`carve.go:251`). Keep that:
-  collect the first error, let in-flight runs drain, leave the rest dirty.
+**Interfaces:**
+- Produces: `func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interval) (CarveResult, error)`
 
-Verification: full `pkg/block/journal` suite (it covers flip ordering, crash-mid-commit re-carve and
-dedup), `go test -race ./pkg/block/...`, and step 0's test.
+- [ ] **Step 1: Change `carveRun` to own its result**
 
-## Step 2 — measure on the rig
+```go
+func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interval) (CarveResult, error) {
+	var res CarveResult
+	// ... unchanged body; pass &res into newCarveDispatcher
+```
 
-The probe that motivated #1872: `dittofs-s3-writeback`, `large`, `rand-write-4k` + `seq-read`,
-sampling the store every 30s through the drain. Baseline is develop's progression
-(49 -> 34 -> 45 -> 22 -> 2 -> 2 MiB per 30s).
+- [ ] **Step 2: Return the partial result on the failure path too**
 
-This settles the question that decides step 3: is the drain **round-trip-bound** (step 1 fixes it)
-or **bandwidth-bound on 4 KiB objects** (only step 3 helps)? 68 KiB/s at ~21 PUTs/s says round-trip,
-but that is one sample on one VM.
+The early return at `carve.go:432-443` must return `(res, err)`, never `(CarveResult{}, err)` —
+blocks that committed before the failure are already durable and today's caller counts them.
 
-Rig discipline: fresh SCW VM, verify `.bench-vm.json` `server_id` is not a coder VM before any
-teardown, heartbeat-monitor the run.
+```go
+	if packErr != nil || disp.aborted() {
+		disp.discard(arenap, arena)
+		if err := disp.wait(); err != nil {
+			return res, err
+		}
+		return res, packErr
+	}
+```
 
-## Step 3 — block packing across runs (conditional)
+- [ ] **Step 3: Sum in `carveFile`**
 
-Only if step 2 shows small-object count still dominating. This is #1875's diff, and its entry price
-is root-causing that stall on hardware first — not re-deriving the watermark-ordering argument,
-which read as correct and was not. Note the obvious theory is already dead: `fileOff` *is* reset per
-run on that branch (line 324), so the watermarks did ascend.
+```go
+		r, err := s.carveRun(ctx, sh, id, snap[start:end])
+		res.BlocksWritten += r.BlocksWritten
+		res.BytesCarved += r.BytesCarved
+		if err != nil {
+			return err
+		}
+```
 
-Do not rebase the branch. 19 journal commits have landed on `carve.go` since (#1979, #2049, #1988,
-#2015, #2064); rewrite from the diagnosis.
+- [ ] **Step 4: Verify no behaviour changed**
 
-## What is deliberately not done
+Run: `go test -race -count=1 ./pkg/block/journal/`
+Expected: PASS. Callers are still serial, and a lone run still gets the full `sem` capacity, so
+`TestCarveRoundTripAndFlip`, `TestCarveCommitStrictlyBeforeFlip`, `TestCarveSinkErrorLeavesDirty`,
+`TestCarveDedupReCarveIsNoOp` and the four `carve_dispatch_test.go` tests must pass unchanged. Any
+failure here is a transcription error in the refactor, not a real finding.
 
-No coalescing of runs across gaps (feeding the chunker already-synced resident bytes so a scattered
-neighbourhood becomes one run). It is appealing — it fixes both defects with `flipUpTo` untouched,
-because already-synced intervals flip to a no-op — but its coverage depends on how much of the gap
-is still resident rather than reclaimed or cold, which is unknown and workload-dependent. Revisit
-only if step 2 says step 3 is needed and the flip stall stays unexplained.
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/block/journal/carve.go
+git commit -S -m "refactor(journal): give each carve run its own CarveResult"
+```
+
+---
+
+### Task 2: Hoist `sem` to the file
+
+`sem` is built inside `newCarveDispatcher` (`carve_dispatch.go:60`), so N concurrent runs would
+multiply peak carve RAM by N. `store.go:67` already documents `CarveUploadConcurrency` as bounding
+**one file's** in-flight blocks — per-run ownership only satisfied that by accident, because runs
+were serial. Hoisting restores the documented contract.
+
+**Files:**
+- Modify: `pkg/block/journal/carve_dispatch.go:48-63`, `pkg/block/journal/carve.go` (`carveFile`, `carveRun`), `pkg/block/journal/store.go:67-73` (comment)
+
+**Interfaces:**
+- Consumes: Task 1's `carveRun` signature.
+- Produces: `func newCarveDispatcher(ctx context.Context, s *Store, sh *shard, id FileID, run []interval, res *CarveResult, flipIdx *int, sem chan struct{}) *carveDispatcher`
+  and `func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interval, sem chan struct{}) (CarveResult, error)`
+
+- [ ] **Step 1: Take the semaphore as a parameter**
+
+```go
+	return &carveDispatcher{
+		ctx: ctx, s: s, sh: sh, id: id, run: run, res: res, flipIdx: flipIdx,
+		sem: sem, prev: prev,
+	}
+```
+
+Nothing else in the dispatcher assumes exclusive ownership: `acquire` (`:71`), `discard` (`:163`),
+the deferred release in `commitAndFlip` (`:113`) and the bare-watermark acquire in `submit` (`:96`)
+are all plain sends/receives on a bounded channel. `prev`/`mine`, `res`, `flipIdx` and `run` stay
+per-dispatcher.
+
+- [ ] **Step 2: Build it once per file**
+
+```go
+	// One semaphore for the whole file: it bounds in-flight blocks (and so peak
+	// carve RAM) across every run, not per run.
+	sem := make(chan struct{}, s.cfg.CarveUploadConcurrency)
+```
+
+- [ ] **Step 3: Update the `CarveUploadConcurrency` comment**
+
+`store.go:67` — say the bound spans a file's carve pass including all its runs. Record the
+trade-off this creates, since it is a deliberate ceiling:
+
+```go
+	// ponytail: with runs concurrent, a file at the limit can leave each run
+	// holding a single slot, so the intra-run block overlap degrades under
+	// multi-run contention; split into a separate CarveRunConcurrency only if
+	// profiling shows the two dimensions need to diverge.
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `go test -race -count=1 ./pkg/block/journal/`
+Expected: PASS, unchanged. Pure plumbing — callers are still serial.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/block/journal/carve.go pkg/block/journal/carve_dispatch.go pkg/block/journal/store.go
+git commit -S -m "refactor(journal): bound in-flight carve blocks per file, not per run"
+```
+
+---
+
+### Task 3: Take the commit lock in `ReapSupersededManifest`
+
+**This is the hazard the first draft of this plan missed, and it is real.** `CommitBlock` routes
+through `commitManifestRows(ctx, s.committer, s.commitLocks, ...)` (`blocksink.go:147`, `:238`),
+which takes a striped per-file mutex. Both `ReapSupersededManifest` impls (`:158`, `:196`) call
+`s.committer.WithTransaction` **directly, with no lock** — verified in current code. Reap ends in
+`ProjectManifestToBlocks` (`pkg/metadata/block_record_store.go:128`), a read-modify-write of the
+same `File.Blocks` row that `carveCommitLocks` exists to serialise; its own doc comment
+(`blocksink.go:26`) names the failure — badger SSI conflict, retry budget exhausted, EDEADLK at the
+client.
+
+Serial runs made this unreachable: a run reaps only after its own `disp.wait()` drained, and no
+other run had started. Concurrent runs break it two ways — reap vs sibling reap, and reap vs a
+**still-in-flight sibling's `CommitBlock`**. Under exactly the workload this plan targets (many
+small runs on one file) that turns "drains slowly" into "churns retries", which is the failure mode
+the plan exists to remove. Land the lock **before** anything calls the path concurrently.
+
+**Files:**
+- Modify: `pkg/block/engine/blocksink.go:154-161` (localBlockSink), `:195-199` (engineBlockSink)
+- Test: `pkg/block/engine/blocksink_ssi_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Model it on `TestLocalBlockSink_ConcurrentSameFileCommit_NoSSIConflict` (`blocksink_ssi_test.go:69`),
+which already provides `newBadgerCommitter(t)` and the `TransactionConflictsForTest()` assertion.
+Drive `CommitBlock` and `ReapSupersededManifest` for the same `payloadID` concurrently from a
+released-together goroutine set:
+
+```go
+func TestLocalBlockSink_ConcurrentReapAndCommit_NoSSIConflict(t *testing.T) {
+	ctx := context.Background()
+	store, pid := newBadgerCommitter(t)
+	sink := localBlockSink{committer: store, commitLocks: &carveCommitLocks{}}
+
+	const n = 8
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			if i%2 == 0 {
+				data := []byte{byte(i), byte(i >> 8), 0xab, 0xcd}
+				errs[i] = sink.CommitBlock(ctx, []journal.CarveChunk{{
+					FileID:     journal.FileID(pid),
+					FileOffset: int64(i) * 4096,
+					Hash:       journal.ChunkHash(blake3.Sum256(data)),
+					Data:       data,
+				}})
+				return
+			}
+			// A disjoint span from every commit above, so a correct
+			// implementation serialises only the shared File-row write.
+			off := int64(i) * 4096
+			errs[i] = sink.ReapSupersededManifest(ctx, journal.FileID(pid), off, off+4096, nil)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoErrorf(t, err, "concurrent carve metadata write %d surfaced an error", i)
+	}
+	require.Zero(t, store.TransactionConflictsForTest(),
+		"a reap racing a sibling run's commit must not conflict on the File row")
+}
+```
+
+- [ ] **Step 2: Run it and confirm it fails for the right reason**
+
+Run: `go test -race -count=1 -run TestLocalBlockSink_ConcurrentReapAndCommit ./pkg/block/engine/`
+Expected: FAIL on the conflict counter, not on an error return — badger retries absorb the
+conflict, so the count is the signal. If it passes first time, do **not** proceed: either the
+contention window is too narrow (raise `n`, tighten the offsets onto one row) or the premise is
+wrong and Task 3 should be dropped. Record which.
+
+- [ ] **Step 3: Take the lock in both impls**
+
+Mirror `commitManifestRows` (`blocksink.go:123-141`) exactly — the nil-receiver `forKey` already
+makes this a no-op for the fixtures that wire no stripes.
+
+```go
+	if mu := s.commitLocks.forKey(string(id)); mu != nil {
+		mu.Lock()
+		defer mu.Unlock()
+	}
+	return s.committer.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return metadata.ReapSupersededManifest(ctx, tx, string(id), runStart, runEnd, newOffsets)
+	})
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `go test -race -count=1 ./pkg/block/engine/`
+Expected: PASS, including the pre-existing `TestLocalBlockSink_ConcurrentSameFileCommit_NoSSIConflict`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/block/engine/blocksink.go pkg/block/engine/blocksink_ssi_test.go
+git commit -S -m "fix(engine): hold the per-file commit lock while reaping superseded manifest rows"
+```
+
+---
+
+### Task 4: Run a file's runs concurrently
+
+**Files:**
+- Modify: `pkg/block/journal/carve.go:230-258`
+- Create: `pkg/block/journal/carve_concurrent_test.go`
+
+**Interfaces:**
+- Consumes: Task 1's `(CarveResult, error)` return, Task 2's `sem` parameter.
+
+- [ ] **Step 1: Write the failing test**
+
+The convergence assertion alone passes even on the stalling branch (see "What is already known"), so
+it is a floor, not the point. What is new here is that it must hold with runs *interleaved*, under
+`-race`, which is what catches the `CarveResult` race if Task 1 was botched and the reap conflict if
+Task 3 was.
+
+```go
+// TestCarveScatteredRunsConvergeConcurrently pins that a scattered dirty set still
+// drains to zero when its runs execute concurrently: every record flips synced, the
+// carved bytes match, and -race sees no shared state across runs.
+func TestCarveScatteredRunsConvergeConcurrently(t *testing.T) {
+	const (
+		runs      = 200
+		runSize   = 4 << 10
+		gap       = 8 << 10 // stride > runSize keeps every run non-contiguous
+		totalSize = runs * runSize
+	)
+	s, _, sink, _ := carveStore(t, Config{CarveBlockSize: 4 << 20, CarveUploadConcurrency: 8})
+	ctx := context.Background()
+
+	want := map[int64][]byte{}
+	for i := 0; i < runs; i++ {
+		off := int64(i) * gap
+		b := randBytes(runSize, int64(i))
+		if err := s.WriteAt(ctx, "f", off, b); err != nil {
+			t.Fatalf("WriteAt %d: %v", i, err)
+		}
+		want[off] = b
+	}
+	if s.UnsyncedBytes() != int64(totalSize) {
+		t.Fatalf("pre-carve unsynced=%d want %d", s.UnsyncedBytes(), totalSize)
+	}
+
+	res, err := s.Carve(ctx, CarveOptions{Force: true})
+	if err != nil {
+		t.Fatalf("Carve: %v", err)
+	}
+	if res.BytesCarved != int64(totalSize) {
+		t.Fatalf("BytesCarved=%d want %d", res.BytesCarved, totalSize)
+	}
+	if s.UnsyncedBytes() != 0 {
+		t.Fatalf("post-carve unsynced=%d want 0", s.UnsyncedBytes())
+	}
+	for off, b := range want {
+		if got := sink.chunkAt(off); got == nil {
+			t.Fatalf("no committed chunk at %d", off)
+		} else if string(got) != string(b) {
+			t.Fatalf("committed bytes at %d differ", off)
+		}
+	}
+	for off := range want {
+		if f := recRawFlags(t, s, "f", off); f&flagSynced == 0 {
+			t.Fatalf("record at %d not flipped synced on disk: flags=%#x", off, f)
+		}
+	}
+}
+```
+
+`sink.chunkAt` does not exist yet — add it next to `fakeSink.carved` (`carve_test.go:99`) as a
+locked read of `s.chunks[off]`. `recRawFlags` already exists (`carve_test.go:151`); the per-offset
+on-disk check is what makes this stronger than counting bytes, because `s.unsynced` is an in-memory
+counter and the durable bit is the thing recovery reads.
+
+- [ ] **Step 2: Run it against the serial implementation**
+
+Run: `go test -race -count=1 -run TestCarveScatteredRunsConvergeConcurrently ./pkg/block/journal/`
+Expected: PASS (runs are still serial at this point). This is deliberate — the test is a
+**regression guard for Step 3**, not a red-then-green driver. Confirming it green here is what makes
+a failure after Step 3 attributable to concurrency.
+
+- [ ] **Step 3: Make the runs concurrent**
+
+Follow the existing precedent at `pkg/block/engine/fetch.go:29-37`.
+
+```go
+	// Runs are disjoint by construction (extendRunToRowEnd stops at any non-warm
+	// interval), so they share no intervals, no records to pack and no result.
+	// Each keeps its own dispatcher and flipIdx: the flip chain stays per-run.
+	sem := make(chan struct{}, s.cfg.CarveUploadConcurrency)
+	g, gctx := errgroup.WithContext(ctx)
+	// ponytail: one knob bounds both goroutines and the per-run
+	// ManifestRowEndAfter transactions; give runs their own limit only if
+	// profiling shows upload and metadata fan-out need to diverge.
+	g.SetLimit(s.cfg.CarveUploadConcurrency)
+
+	results := make([]CarveResult, len(runs))
+	for i, run := range runs {
+		g.Go(func() error {
+			r, err := s.carveRun(gctx, sh, id, run, sem)
+			results[i] = r
+			return err
+		})
+	}
+	err := g.Wait()
+	for _, r := range results {
+		res.BlocksWritten += r.BlocksWritten
+		res.BytesCarved += r.BytesCarved
+	}
+	if err != nil {
+		return err
+	}
+	s.maybeResetDirtyClock(sh, id)
+	return nil
+```
+
+Extract the existing `start`/`end` splitting loop (`carve.go:246-255`) into a `splitRuns(snap)
+[][]interval` helper so the errgroup reads as a fan-out over runs.
+
+Notes on why this is enough, so nobody adds more:
+- Distinct `results[i]` per goroutine plus `g.Wait()`'s barrier is not a race.
+- `errgroup.WithContext` gives first-error-aborts-the-rest for free: `gctx` cancellation trips each
+  run's existing `ctx.Err()` checks (`carve.go:345`, `:351`), and each run drains **itself** through
+  the unchanged `disp.discard` + `disp.wait()` path (`:432-443`). `g.Wait()` returns the first real
+  error, not the `context.Canceled` siblings see — same error as today.
+- `maybeResetDirtyClock` stays single-threaded after `Wait`.
+
+- [ ] **Step 4: Verify under race**
+
+Run: `go test -race -count=1 ./pkg/block/journal/ ./pkg/block/engine/`
+Expected: PASS. Specifically re-check `TestCarveRecordSplitNoPrematureFlip` (`carve_test.go:344`),
+`TestCarveFlipsInWatermarkOrder` and `TestCarveConcurrentCommitErrorStopsWatermark`
+(`carve_dispatch_test.go:229`, `:272`) — the closest existing coverage of the flip chain.
+
+- [ ] **Step 5: Settle the shared-record premise**
+
+`flipUpTo` holds `sh.mu` across its whole body, so "mark fragment synced, check
+`recordHasDirtyFragment`, maybe flip" is atomic no matter which run's goroutine calls it — two runs
+that are fragments of one physical record are safe, and only the run observing zero remaining dirty
+fragments flips. That argument is sound but **nothing currently constructs that shape across runs**.
+
+Try to build it: one large write, then overwrites that leave two non-adjacent dirty fragments of the
+original record with a warm (already-synced) gap between them. If it can be constructed, add it to
+`carve_concurrent_test.go`. **If it cannot be reached through the public API, say so in the commit
+message and on #2070** — an unreachable case is a real finding, and the memory rule is to test the
+premise rather than build on it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pkg/block/journal/carve.go pkg/block/journal/carve_concurrent_test.go pkg/block/journal/carve_test.go
+git commit -S -m "perf(journal): carve a file's dirty runs concurrently"
+```
+
+---
+
+### Task 5: Measure on the rig
+
+Unit tests cannot answer whether this fixed #1872 — the whole defect is remote round-trip latency,
+which every fake sink elides. **This task is part of "done", not a follow-up.**
+
+- [ ] **Step 1: Fresh bench VM.** Verify `.bench-vm.json` `server_id` is not a coder VM before any
+      teardown. Heartbeat-monitor the run; the `--remote` poller hangs on a stall.
+- [ ] **Step 2: Run the probe that motivated #1872** — `dittofs-s3-writeback`, `large`,
+      `rand-write-4k` + `seq-read`, sampling the store every 30s through the drain.
+- [ ] **Step 3: Compare against develop's baseline** — 49 → 34 → 45 → 22 → 2 → 2 MiB per 30s.
+- [ ] **Step 4: Post the numbers on #2070**, whatever they show. The #1875 comment is the standard:
+      report what the rig did, not what the object-count reduction implies.
+
+**This measurement decides the next question and nothing else does:** is the drain round-trip-bound
+(this plan fixes it, close #1872) or bandwidth-bound on 4 KiB objects (it does not, and the packing
+work below becomes necessary)? The 68 KiB/s at ~21 PUTs/s in the #1875 probe says round-trip, but
+that is one sample on one VM.
+
+---
+
+## Gate: block packing across runs (only if Task 5 says so)
+
+Out of scope here. It is #1875's diff, it forces the flip chain to span runs, and its entry price is
+a **reproduction of the #1875 stall**, which does not exist at any level today. The gap between the
+passing unit test and the stalling rig is where to look:
+
+| | unit test | rig |
+| --- | --- | --- |
+| files / shards | one / one | many |
+| record shape | one interval per record | records carrying several fragments |
+| prior state | fresh store | interleaved synced + cold intervals |
+| row straddling | none | `extendRunToRowEnd` in play |
+| dedup oracle | empty fake | real manifest lookups |
+| invocation | one `Carve(Force:true)` | `Force:true` in a drain retry loop |
+| scale | 800 KiB | 644 MiB |
+
+Do not rebase `perf/1872-carve-pack-across-runs` — 19 journal commits have landed on `carve.go`
+since (#1979, #2049, #1988, #2015, #2064). Keep it as the reproduction target; a worktree is at
+`~/dittofs-worktrees/1875-repro`.
+
+Also parked: coalescing runs across gaps by feeding the chunker already-synced resident bytes, so a
+scattered neighbourhood becomes one run. It fixes both defects with `flipUpTo` untouched, because
+already-synced intervals flip to a no-op — but its coverage depends on how much of each gap is still
+resident rather than reclaimed or cold, which is unknown and workload-dependent. Only worth costing
+if the gate opens and the stall stays unexplained.

--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -244,9 +244,16 @@ func (s *Store) carveFile(ctx context.Context, sh *shard, id FileID, res *CarveR
 		return nil
 	}
 
-	// Runs are disjoint by construction (extendRunToRowEnd stops at any non-warm
-	// interval), so they share no intervals, no records to pack and no result.
-	// Each keeps its own dispatcher and flipIdx: the flip chain stays per-run.
+	// Runs cover disjoint ranges (extendRunToRowEnd stops at any non-warm
+	// interval), so no live interval, packing state or result is shared: each run
+	// keeps its own dispatcher, flipIdx and CarveResult.
+	//
+	// Two runs can still reference one physical record, because an overwrite
+	// splits a record into fragments that a later carve can leave on either side
+	// of a warm gap. That stays safe because flipUpTo marks a fragment synced,
+	// checks whether the record has any dirty fragment left, and flips the
+	// on-disk bit all under sh.mu, so whichever run finishes last is the one that
+	// observes zero remaining and flips.
 	//
 	// One semaphore for the whole file: it bounds in-flight block arenas across
 	// all of this file's runs, not just the one currently carving, so that term
@@ -276,7 +283,7 @@ func (s *Store) carveFile(ctx context.Context, sh *shard, id FileID, res *CarveR
 			limit = runs[i+1][0].fileOff
 		}
 		g.Go(func() error {
-			r, err := s.carveRun(gctx, sh, id, run, limit, sem)
+			r, err := s.carveRun(gctx, ctx, sh, id, run, limit, sem)
 			results[i] = r
 			return err
 		})
@@ -313,7 +320,17 @@ func splitRuns(snap []interval) [][]interval {
 // and flips the run's records to synced as the durable frontier advances.
 // limit is the file offset the next run starts at (MaxInt64 for the last run):
 // the run may not extend past it.
-func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interval, limit int64, sem chan struct{}) (CarveResult, error) {
+// ctx bounds the carve work and is cancelled as soon as any sibling run fails,
+// which stops uploads that would be thrown away. reapCtx is the caller's own
+// context and bounds only the end-of-run reap: by the time the reap runs this
+// run's records are committed and already flipped synced, so a sibling's failure
+// must not strand the cleanup of rows nothing will revisit.
+//
+// ponytail: a caller cancelling between the flip and the reap still strands
+// those rows, since nothing retries a reap and the records are no longer dirty;
+// persist a pending-reap intent, or defer the flip until the reap lands, if that
+// window ever shows up in the field.
+func (s *Store) carveRun(ctx, reapCtx context.Context, sh *shard, id FileID, run []interval, limit int64, sem chan struct{}) (CarveResult, error) {
 	var res CarveResult
 	run, err := s.extendRunToRowEnd(ctx, sh, id, run, limit)
 	if err != nil {
@@ -509,7 +526,7 @@ func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interv
 	// batch would delete a sibling batch's fresh rows. Optional: sinks without a
 	// metadata store (test fakes) skip it.
 	if r, ok := s.sink.(supersededReaper); ok {
-		if err := r.ReapSupersededManifest(ctx, id, run[0].fileOff, run[len(run)-1].end(), newOffsets); err != nil {
+		if err := r.ReapSupersededManifest(reapCtx, id, run[0].fileOff, run[len(run)-1].end(), newOffsets); err != nil {
 			return res, err
 		}
 	}

--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -248,7 +248,10 @@ func (s *Store) carveFile(ctx context.Context, sh *shard, id FileID, res *CarveR
 		for end < len(snap) && snap[end].fileOff == snap[end-1].end() {
 			end++
 		}
-		if err := s.carveRun(ctx, sh, id, snap[start:end], res); err != nil {
+		r, err := s.carveRun(ctx, sh, id, snap[start:end])
+		res.BlocksWritten += r.BlocksWritten
+		res.BytesCarved += r.BytesCarved
+		if err != nil {
 			return err
 		}
 		start = end
@@ -260,10 +263,11 @@ func (s *Store) carveFile(ctx context.Context, sh *shard, id FileID, res *CarveR
 // carveRun streams one contiguous dirty run through FastCDC, dedups each chunk,
 // packs novel chunks into blocks (flushed at CarveBlockSize and at the run's end),
 // and flips the run's records to synced as the durable frontier advances.
-func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interval, res *CarveResult) error {
+func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interval) (CarveResult, error) {
+	var res CarveResult
 	run, err := s.extendRunToRowEnd(ctx, sh, id, run)
 	if err != nil {
-		return err
+		return res, err
 	}
 
 	c := chunker.NewChunkerWithParams(s.cfg.ChunkParams)
@@ -278,7 +282,7 @@ func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interv
 	// disp overlaps successive blocks' CommitBlock (upload + commit) while packing
 	// stays sequential. It owns the bounded worker pool, the per-block buffers and
 	// the ordered flip chain; flush hands it a completed block or a bare watermark.
-	disp := newCarveDispatcher(ctx, s, sh, id, run, res, &flipIdx)
+	disp := newCarveDispatcher(ctx, s, sh, id, run, &res, &flipIdx)
 
 	// Each packed block gets its OWN buffer (cap one block plus one overhang chunk)
 	// so its bytes stay live while its CommitBlock runs concurrently with the next
@@ -437,16 +441,16 @@ func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interv
 		// uploads. disp.wait returns the commit error in watermark order.
 		disp.discard(arenap, arena)
 		if err := disp.wait(); err != nil {
-			return err
+			return res, err
 		}
-		return packErr
+		return res, packErr
 	}
 
 	// Tail: commit any remainder and flip through the end of the run (records
 	// covered only by already-durable chunks flip here too, via the bare watermark).
 	flush(run[len(run)-1].end())
 	if err := disp.wait(); err != nil {
-		return err
+		return res, err
 	}
 	// With every row this run produced now committed, reap the manifest rows
 	// the run superseded (stale straddlers / interior chunks the fresh tiling
@@ -456,10 +460,10 @@ func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interv
 	// metadata store (test fakes) skip it.
 	if r, ok := s.sink.(supersededReaper); ok {
 		if err := r.ReapSupersededManifest(ctx, id, run[0].fileOff, run[len(run)-1].end(), newOffsets); err != nil {
-			return err
+			return res, err
 		}
 	}
-	return nil
+	return res, nil
 }
 
 // extendRunToRowEnd grows the run forward to the end of the manifest coverage its

--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -243,12 +243,18 @@ func (s *Store) carveFile(ctx context.Context, sh *shard, id FileID, res *CarveR
 		return nil
 	}
 
+	// One semaphore for the whole file: it bounds in-flight blocks across all of
+	// this file's runs, not just the one currently carving, so peak carve RAM
+	// stays cap(sem) x (CarveBlockSize + one overhang chunk) regardless of how
+	// many runs a file has.
+	sem := make(chan struct{}, s.cfg.CarveUploadConcurrency)
+
 	for start := 0; start < len(snap); {
 		end := start + 1
 		for end < len(snap) && snap[end].fileOff == snap[end-1].end() {
 			end++
 		}
-		r, err := s.carveRun(ctx, sh, id, snap[start:end])
+		r, err := s.carveRun(ctx, sh, id, snap[start:end], sem)
 		res.BlocksWritten += r.BlocksWritten
 		res.BytesCarved += r.BytesCarved
 		if err != nil {
@@ -263,7 +269,7 @@ func (s *Store) carveFile(ctx context.Context, sh *shard, id FileID, res *CarveR
 // carveRun streams one contiguous dirty run through FastCDC, dedups each chunk,
 // packs novel chunks into blocks (flushed at CarveBlockSize and at the run's end),
 // and flips the run's records to synced as the durable frontier advances.
-func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interval) (CarveResult, error) {
+func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interval, sem chan struct{}) (CarveResult, error) {
 	var res CarveResult
 	run, err := s.extendRunToRowEnd(ctx, sh, id, run)
 	if err != nil {
@@ -282,7 +288,7 @@ func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interv
 	// disp overlaps successive blocks' CommitBlock (upload + commit) while packing
 	// stays sequential. It owns the bounded worker pool, the per-block buffers and
 	// the ordered flip chain; flush hands it a completed block or a bare watermark.
-	disp := newCarveDispatcher(ctx, s, sh, id, run, &res, &flipIdx)
+	disp := newCarveDispatcher(ctx, s, sh, id, run, &res, &flipIdx, sem)
 
 	// Each packed block gets its OWN buffer (cap one block plus one overhang chunk)
 	// so its bytes stay live while its CommitBlock runs concurrently with the next

--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"sync"
 
+	"golang.org/x/sync/errgroup"
 	"lukechampine.com/blake3"
 
 	"github.com/marmos91/dittofs/pkg/block/chunker"
@@ -243,27 +244,55 @@ func (s *Store) carveFile(ctx context.Context, sh *shard, id FileID, res *CarveR
 		return nil
 	}
 
+	// Runs are disjoint by construction (extendRunToRowEnd stops at any non-warm
+	// interval), so they share no intervals, no records to pack and no result.
+	// Each keeps its own dispatcher and flipIdx: the flip chain stays per-run.
+	//
 	// One semaphore for the whole file: it bounds in-flight blocks across all of
 	// this file's runs, not just the one currently carving, so peak carve RAM
 	// stays cap(sem) x (CarveBlockSize + one overhang chunk) regardless of how
 	// many runs a file has.
 	sem := make(chan struct{}, s.cfg.CarveUploadConcurrency)
+	g, gctx := errgroup.WithContext(ctx)
+	// ponytail: one knob bounds both goroutines and the per-run
+	// ManifestRowEndAfter transactions; give runs their own limit only if
+	// profiling shows upload and metadata fan-out need to diverge.
+	g.SetLimit(s.cfg.CarveUploadConcurrency)
 
+	runs := splitRuns(snap)
+	results := make([]CarveResult, len(runs))
+	for i, run := range runs {
+		g.Go(func() error {
+			r, err := s.carveRun(gctx, sh, id, run, sem)
+			results[i] = r
+			return err
+		})
+	}
+	err := g.Wait()
+	for _, r := range results {
+		res.BlocksWritten += r.BlocksWritten
+		res.BytesCarved += r.BytesCarved
+	}
+	if err != nil {
+		return err
+	}
+	s.maybeResetDirtyClock(sh, id)
+	return nil
+}
+
+// splitRuns groups an offset-ordered snapshot into maximal contiguous runs; a
+// hole between two intervals starts a new run.
+func splitRuns(snap []interval) [][]interval {
+	var runs [][]interval
 	for start := 0; start < len(snap); {
 		end := start + 1
 		for end < len(snap) && snap[end].fileOff == snap[end-1].end() {
 			end++
 		}
-		r, err := s.carveRun(ctx, sh, id, snap[start:end], sem)
-		res.BlocksWritten += r.BlocksWritten
-		res.BytesCarved += r.BytesCarved
-		if err != nil {
-			return err
-		}
+		runs = append(runs, snap[start:end])
 		start = end
 	}
-	s.maybeResetDirtyClock(sh, id)
-	return nil
+	return runs
 }
 
 // carveRun streams one contiguous dirty run through FastCDC, dedups each chunk,

--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -248,10 +248,17 @@ func (s *Store) carveFile(ctx context.Context, sh *shard, id FileID, res *CarveR
 	// interval), so they share no intervals, no records to pack and no result.
 	// Each keeps its own dispatcher and flipIdx: the flip chain stays per-run.
 	//
-	// One semaphore for the whole file: it bounds in-flight blocks across all of
-	// this file's runs, not just the one currently carving, so peak carve RAM
+	// One semaphore for the whole file: it bounds in-flight block arenas across
+	// all of this file's runs, not just the one currently carving, so that term
 	// stays cap(sem) x (CarveBlockSize + one overhang chunk) regardless of how
-	// many runs a file has.
+	// many runs a file has. It does not bound the chunker scratch buffer, which
+	// each run holds for its whole lifetime, so peak carve RAM per file is that
+	// arena term plus (concurrent runs) x chunker.MaxChunkSize.
+	//
+	// ponytail: the scratch term is sized from the package-wide max chunk rather
+	// than the share's ChunkParams.Max, so a share chunking small still reserves
+	// 16 MiB per concurrent run; size the pooled buffer from ChunkParams.Max if
+	// that headroom ever shows up in a memory profile.
 	sem := make(chan struct{}, s.cfg.CarveUploadConcurrency)
 	g, gctx := errgroup.WithContext(ctx)
 	// ponytail: one knob bounds both goroutines and the per-run
@@ -262,8 +269,14 @@ func (s *Store) carveFile(ctx context.Context, sh *shard, id FileID, res *CarveR
 	runs := splitRuns(snap)
 	results := make([]CarveResult, len(runs))
 	for i, run := range runs {
+		// Bound each run by the next run's start, known here because every run is
+		// materialised before any is dispatched.
+		limit := int64(math.MaxInt64)
+		if i+1 < len(runs) {
+			limit = runs[i+1][0].fileOff
+		}
 		g.Go(func() error {
-			r, err := s.carveRun(gctx, sh, id, run, sem)
+			r, err := s.carveRun(gctx, sh, id, run, limit, sem)
 			results[i] = r
 			return err
 		})
@@ -298,9 +311,11 @@ func splitRuns(snap []interval) [][]interval {
 // carveRun streams one contiguous dirty run through FastCDC, dedups each chunk,
 // packs novel chunks into blocks (flushed at CarveBlockSize and at the run's end),
 // and flips the run's records to synced as the durable frontier advances.
-func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interval, sem chan struct{}) (CarveResult, error) {
+// limit is the file offset the next run starts at (MaxInt64 for the last run):
+// the run may not extend past it.
+func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interval, limit int64, sem chan struct{}) (CarveResult, error) {
 	var res CarveResult
-	run, err := s.extendRunToRowEnd(ctx, sh, id, run)
+	run, err := s.extendRunToRowEnd(ctx, sh, id, run, limit)
 	if err != nil {
 		return res, err
 	}
@@ -511,10 +526,19 @@ func (s *Store) carveRun(ctx context.Context, sh *shard, id FileID, run []interv
 // warm. An evicted range holds no local bytes to re-chunk, and half an extension
 // still ends inside the row.
 //
+// A row reaching past limit, the offset the next run starts at, is refused
+// outright. Runs carve concurrently and flipUpTo marks intervals synced in
+// memory as a run's watermark advances, so a sibling run's already-flipped head
+// is indistinguishable here from pre-existing warm data and warmTail alone would
+// wave such a row through. Refusing on the offset reproduces what a serial carve
+// decides, where that range is still visibly dirty. It has to be a refusal
+// rather than a truncation to limit: the run-end reap deletes whole rows that
+// start inside the run, so tiling only part of a row still drops its tail.
+//
 // ponytail: a row reaching past a later dirty run is left alone, so that run
 // still ends mid-row; covering it means merging the two runs, which is worth
 // building only if that shape shows up in practice.
-func (s *Store) extendRunToRowEnd(ctx context.Context, sh *shard, id FileID, run []interval) ([]interval, error) {
+func (s *Store) extendRunToRowEnd(ctx context.Context, sh *shard, id FileID, run []interval, limit int64) ([]interval, error) {
 	ender, ok := s.sink.(manifestRowEnder)
 	if !ok {
 		return run, nil
@@ -526,6 +550,12 @@ func (s *Store) extendRunToRowEnd(ctx context.Context, sh *shard, id FileID, run
 	rowEnd, err := ender.ManifestRowEndAfter(ctx, id, runEnd)
 	if err != nil {
 		return nil, err
+	}
+	if rowEnd > limit {
+		// The row reaches past a later run: leave this one as snapshotted rather
+		// than half extended, which is what a serial carve does when it finds that
+		// range still dirty.
+		return run, nil
 	}
 	if rowEnd <= runEnd {
 		return run, nil

--- a/pkg/block/journal/carve_concurrent_test.go
+++ b/pkg/block/journal/carve_concurrent_test.go
@@ -205,6 +205,7 @@ type extendingSink struct {
 	gateOff int64
 	waitFor int64
 	rowEnd  int64
+	gated   int
 	timeout error
 }
 
@@ -212,6 +213,9 @@ func (e *extendingSink) ManifestRowEndAfter(_ context.Context, id FileID, off in
 	if off != e.gateOff {
 		return 0, nil
 	}
+	e.mu.Lock()
+	e.gated++
+	e.mu.Unlock()
 	for i := 0; i < 5000; i++ {
 		if syncedAt(e.store, id, e.waitFor) {
 			return e.rowEnd, nil
@@ -289,9 +293,16 @@ func TestCarveRunDoesNotExtendPastNextRun(t *testing.T) {
 	sink.mu.Lock()
 	reaps := append([][2]int64{}, sink.reaps...)
 	timedOut := sink.timeout
+	gated := sink.gated
 	sink.mu.Unlock()
 	if timedOut != nil {
 		t.Fatalf("ordering not reached, test proves nothing: %v", timedOut)
+	}
+	// extendRunToRowEnd short-circuits on warmAt before the sink is consulted, and
+	// the gate is keyed on an exact offset, so drift in either could leave the
+	// ordering unexercised while every assertion below still passes.
+	if gated == 0 {
+		t.Fatalf("the gated lookup was never reached, so the ordering was never exercised and this test proves nothing")
 	}
 	if len(reaps) != len(dirty) {
 		t.Fatalf("got %d reap ranges, want %d: %v", len(reaps), len(dirty), reaps)

--- a/pkg/block/journal/carve_concurrent_test.go
+++ b/pkg/block/journal/carve_concurrent_test.go
@@ -316,3 +316,186 @@ func TestCarveRunDoesNotExtendPastNextRun(t *testing.T) {
 		}
 	}
 }
+
+// TestCarveRunsCommitConcurrently pins the run-level concurrency itself: on a
+// file of several dirty runs, commits from different runs overlap, and the
+// file-wide semaphore caps how many overlap at once. Asserting the drained
+// result alone does not cover this — a serial carveFile produces byte-identical
+// output — so this is what fails if runs are ever serialised again.
+//
+// The commit hook blocks until a second commit joins it rather than sleeping a
+// fixed time, so a concurrent implementation releases immediately and only a
+// serial one pays the timeout, once.
+func TestCarveRunsCommitConcurrently(t *testing.T) {
+	const (
+		runs    = 8
+		runSize = 4 << 10
+		gap     = 8 << 10 // a hole between runs keeps them separate
+		window  = 4
+	)
+	s, _, sink, _ := carveStore(t, Config{CarveBlockSize: 4 << 20, CarveUploadConcurrency: window})
+	ctx := context.Background()
+
+	var (
+		mu         sync.Mutex
+		cur, max   int
+		gaveUp     bool
+		overlapped = make(chan struct{})
+		once       sync.Once
+	)
+	sink.onCommit = func(_ []CarveChunk) {
+		mu.Lock()
+		cur++
+		if cur > max {
+			max = cur
+		}
+		if cur >= 2 {
+			once.Do(func() { close(overlapped) })
+		}
+		skip := gaveUp
+		mu.Unlock()
+
+		if !skip {
+			select {
+			case <-overlapped:
+			case <-time.After(2 * time.Second):
+				// Nothing joined: the carve is serial. Stop waiting so the rest of
+				// the pass does not pay the timeout too.
+				mu.Lock()
+				gaveUp = true
+				mu.Unlock()
+			}
+		}
+		mu.Lock()
+		cur--
+		mu.Unlock()
+	}
+
+	for i := 0; i < runs; i++ {
+		if err := s.WriteAt(ctx, "f", int64(i)*gap, randBytes(runSize, int64(i))); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+	}
+	if _, err := s.Carve(ctx, CarveOptions{Force: true}); err != nil {
+		t.Fatalf("Carve: %v", err)
+	}
+	if s.UnsyncedBytes() != 0 {
+		t.Fatalf("post-carve unsynced=%d want 0", s.UnsyncedBytes())
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if max < 2 {
+		t.Fatalf("max concurrent commits across runs = %d, want > 1: the runs did not overlap", max)
+	}
+	if max > window {
+		t.Fatalf("max concurrent commits across runs = %d, want <= CarveUploadConcurrency (%d)", max, window)
+	}
+}
+
+// reapCtxSink fails the run covering failFrom, but only once the other run has
+// committed, so the surviving run is always past its commits — and therefore has
+// its records flipped synced — when the sibling's failure cancels the carve.
+type reapCtxSink struct {
+	*fakeSink
+	failFrom  int64
+	committed chan struct{}
+	failed    chan struct{}
+	onceC     sync.Once
+	onceF     sync.Once
+
+	mu        sync.Mutex
+	reaps     int
+	cancelled bool
+	stalled   bool
+}
+
+func (r *reapCtxSink) CommitBlock(ctx context.Context, chunks []CarveChunk) error {
+	if len(chunks) > 0 && chunks[0].FileOffset >= r.failFrom {
+		select {
+		case <-r.committed:
+		case <-time.After(5 * time.Second):
+			r.mu.Lock()
+			r.stalled = true
+			r.mu.Unlock()
+			return errors.New("the surviving run never committed")
+		}
+		r.onceF.Do(func() { close(r.failed) })
+		return errors.New("boom")
+	}
+	err := r.fakeSink.CommitBlock(ctx, chunks)
+	if err == nil {
+		r.onceC.Do(func() { close(r.committed) })
+	}
+	return err
+}
+
+func (r *reapCtxSink) ReapSupersededManifest(ctx context.Context, _ FileID, _, _ int64, _ map[int64]struct{}) error {
+	select {
+	case <-r.failed:
+	case <-time.After(5 * time.Second):
+		r.mu.Lock()
+		r.stalled = true
+		r.mu.Unlock()
+		return nil
+	}
+	// The sibling has failed. A reap bounded by the carve's own context is
+	// cancelled from here on; one bounded by the caller's context is not.
+	select {
+	case <-ctx.Done():
+		r.mu.Lock()
+		r.cancelled = true
+		r.mu.Unlock()
+		return ctx.Err()
+	case <-time.After(500 * time.Millisecond):
+	}
+	r.mu.Lock()
+	r.reaps++
+	r.mu.Unlock()
+	return nil
+}
+
+// TestCarveReapSurvivesSiblingFailure pins that a run which finished its commits
+// still reaps the manifest rows it superseded when another run fails.
+//
+// The reap is the last step of a run, after every one of its records is
+// committed and flipped synced. Nothing retries it and a later pass will not
+// revisit those records, so a reap skipped here leaves superseded rows alive
+// forever — and overlap resolution is greatest-start, so a stale row starting
+// later than a fresh one wins and serves old bytes on a cold read.
+func TestCarveReapSurvivesSiblingFailure(t *testing.T) {
+	const (
+		runSize  = 4 << 10
+		failFrom = 64 << 10
+	)
+	s, dd, base, _ := carveStore(t, Config{CarveBlockSize: 4 << 20, CarveUploadConcurrency: 4})
+	sink := &reapCtxSink{
+		fakeSink:  base,
+		failFrom:  failFrom,
+		committed: make(chan struct{}),
+		failed:    make(chan struct{}),
+	}
+	s.SetCarveTargets(dd, sink)
+	ctx := context.Background()
+
+	for _, off := range []int64{0, failFrom} {
+		if err := s.WriteAt(ctx, "f", off, randBytes(runSize, off)); err != nil {
+			t.Fatalf("write %d: %v", off, err)
+		}
+	}
+	if _, err := s.Carve(ctx, CarveOptions{Force: true}); err == nil {
+		t.Fatal("Carve succeeded, want the seeded commit failure")
+	}
+
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	if sink.stalled {
+		t.Fatal("the runs did not interleave as set up, so this test proves nothing")
+	}
+	if sink.cancelled {
+		t.Fatal("the surviving run's reap was cancelled by the sibling's failure, stranding its superseded rows")
+	}
+	if sink.reaps != 1 {
+		t.Fatalf("reaps=%d, want 1 from the surviving run", sink.reaps)
+	}
+}

--- a/pkg/block/journal/carve_concurrent_test.go
+++ b/pkg/block/journal/carve_concurrent_test.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/marmos91/dittofs/pkg/block/chunker"
 )
 
 // TestCarveScatteredRunsConvergeConcurrently pins that a scattered dirty set still
@@ -319,48 +321,73 @@ func TestCarveRunDoesNotExtendPastNextRun(t *testing.T) {
 
 // TestCarveRunsCommitConcurrently pins the run-level concurrency itself: on a
 // file of several dirty runs, commits from different runs overlap, and the
-// file-wide semaphore caps how many overlap at once. Asserting the drained
+// file-scoped semaphore caps how many overlap at once. Asserting the drained
 // result alone does not cover this — a serial carveFile produces byte-identical
 // output — so this is what fails if runs are ever serialised again.
 //
-// The commit hook blocks until a second commit joins it rather than sleeping a
-// fixed time, so a concurrent implementation releases immediately and only a
-// serial one pays the timeout, once.
+// The geometry gives each run several blocks (small chunks, small
+// CarveBlockSize) so the two bounds diverge: the errgroup limit alone would
+// allow window runs x several blocks each in flight, while the one file-scoped
+// semaphore allows window blocks in total. With one block per run the cap
+// assertion could not fail, because the errgroup limit would bound it anyway.
+//
+// The commit hook blocks until more than window commits are in flight rather
+// than sleeping a fixed time, so a carve that breaches the cap releases
+// immediately and is caught; a correct one never breaches it and pays the
+// timeout once, which the gaveUp flag keeps to a single wait for the pass. That
+// wait is also what holds the in-flight set open long enough to see how many
+// distinct runs are committing at the same time.
 func TestCarveRunsCommitConcurrently(t *testing.T) {
 	const (
 		runs    = 8
-		runSize = 4 << 10
-		gap     = 8 << 10 // a hole between runs keeps them separate
+		runSize = 32 << 10
+		gap     = 64 << 10 // a hole between runs keeps them separate
 		window  = 4
 	)
-	s, _, sink, _ := carveStore(t, Config{CarveBlockSize: 4 << 20, CarveUploadConcurrency: window})
+	s, _, sink, _ := carveStore(t, Config{
+		CarveBlockSize:         8 << 10,
+		CarveUploadConcurrency: window,
+		ChunkParams:            chunker.Params{Min: 4 << 10, Avg: 8 << 10, Max: 16 << 10},
+	})
 	ctx := context.Background()
 
 	var (
-		mu         sync.Mutex
-		cur, max   int
-		gaveUp     bool
-		overlapped = make(chan struct{})
-		once       sync.Once
+		mu       sync.Mutex
+		cur, max int
+		commits  int
+		gaveUp   bool
+		exceeded = make(chan struct{})
+		once     sync.Once
+		// Blocks in flight per run, keyed by run index, so the floor counts runs
+		// overlapping rather than one run's own blocks overlapping — a serial
+		// carveFile still reaches window in-flight blocks from a single run.
+		inFlight = map[int64]int{}
+		maxRuns  int
 	)
-	sink.onCommit = func(_ []CarveChunk) {
+	sink.onCommit = func(chunks []CarveChunk) {
+		run := chunks[0].FileOffset / gap
 		mu.Lock()
 		cur++
+		commits++
+		inFlight[run]++
 		if cur > max {
 			max = cur
 		}
-		if cur >= 2 {
-			once.Do(func() { close(overlapped) })
+		if len(inFlight) > maxRuns {
+			maxRuns = len(inFlight)
+		}
+		if cur > window {
+			once.Do(func() { close(exceeded) })
 		}
 		skip := gaveUp
 		mu.Unlock()
 
 		if !skip {
 			select {
-			case <-overlapped:
-			case <-time.After(2 * time.Second):
-				// Nothing joined: the carve is serial. Stop waiting so the rest of
-				// the pass does not pay the timeout too.
+			case <-exceeded:
+			case <-time.After(time.Second):
+				// The cap held. Stop waiting so the rest of the pass does not pay
+				// the timeout too.
 				mu.Lock()
 				gaveUp = true
 				mu.Unlock()
@@ -368,6 +395,9 @@ func TestCarveRunsCommitConcurrently(t *testing.T) {
 		}
 		mu.Lock()
 		cur--
+		if inFlight[run]--; inFlight[run] == 0 {
+			delete(inFlight, run)
+		}
 		mu.Unlock()
 	}
 
@@ -385,11 +415,15 @@ func TestCarveRunsCommitConcurrently(t *testing.T) {
 
 	mu.Lock()
 	defer mu.Unlock()
-	if max < 2 {
-		t.Fatalf("max concurrent commits across runs = %d, want > 1: the runs did not overlap", max)
+	// More blocks than runs is what makes the cap assertion able to fail at all.
+	if commits <= runs {
+		t.Fatalf("%d commits for %d runs: runs are not multi-block, so the cap assertion cannot fail", commits, runs)
+	}
+	if maxRuns < 2 {
+		t.Fatalf("max runs committing at once = %d, want > 1: the runs did not overlap", maxRuns)
 	}
 	if max > window {
-		t.Fatalf("max concurrent commits across runs = %d, want <= CarveUploadConcurrency (%d)", max, window)
+		t.Fatalf("max concurrent commits = %d, want <= CarveUploadConcurrency (%d): the file-scoped bound on in-flight blocks was breached", max, window)
 	}
 }
 

--- a/pkg/block/journal/carve_concurrent_test.go
+++ b/pkg/block/journal/carve_concurrent_test.go
@@ -1,0 +1,165 @@
+package journal
+
+import (
+	"context"
+	"testing"
+)
+
+// TestCarveScatteredRunsConvergeConcurrently pins that a scattered dirty set still
+// drains to zero when its runs execute concurrently: every record flips synced, the
+// carved bytes match, and -race sees no shared state across runs.
+func TestCarveScatteredRunsConvergeConcurrently(t *testing.T) {
+	const (
+		runs      = 200
+		runSize   = 4 << 10
+		gap       = 8 << 10 // stride > runSize keeps every run non-contiguous
+		totalSize = runs * runSize
+	)
+	s, _, sink, _ := carveStore(t, Config{CarveBlockSize: 4 << 20, CarveUploadConcurrency: 8})
+	ctx := context.Background()
+
+	want := map[int64][]byte{}
+	for i := 0; i < runs; i++ {
+		off := int64(i) * gap
+		b := randBytes(runSize, int64(i))
+		if err := s.WriteAt(ctx, "f", off, b); err != nil {
+			t.Fatalf("WriteAt %d: %v", i, err)
+		}
+		want[off] = b
+	}
+	if s.UnsyncedBytes() != int64(totalSize) {
+		t.Fatalf("pre-carve unsynced=%d want %d", s.UnsyncedBytes(), totalSize)
+	}
+
+	res, err := s.Carve(ctx, CarveOptions{Force: true})
+	if err != nil {
+		t.Fatalf("Carve: %v", err)
+	}
+	if res.BytesCarved != int64(totalSize) {
+		t.Fatalf("BytesCarved=%d want %d", res.BytesCarved, totalSize)
+	}
+	if s.UnsyncedBytes() != 0 {
+		t.Fatalf("post-carve unsynced=%d want 0", s.UnsyncedBytes())
+	}
+	for off, b := range want {
+		if got := sink.chunkAt(off); got == nil {
+			t.Fatalf("no committed chunk at %d", off)
+		} else if string(got) != string(b) {
+			t.Fatalf("committed bytes at %d differ", off)
+		}
+	}
+	for off := range want {
+		if f := recRawFlags(t, s, "f", off); f&flagSynced == 0 {
+			t.Fatalf("record at %d not flipped synced on disk: flags=%#x", off, f)
+		}
+	}
+}
+
+// runsSharingARecord reports whether the file's dirty snapshot splits into two
+// or more runs that hold fragments of one physical record — the shape whose
+// safety rests on flipUpTo doing mark-check-flip under the shard lock.
+func runsSharingARecord(s *Store, id FileID) bool {
+	type recKey struct {
+		seg uint64
+		off int64
+	}
+	sh := s.shardFor(id)
+	sh.mu.Lock()
+	fi := sh.index[id]
+	var snap []interval
+	if fi != nil {
+		for _, iv := range fi.ivs {
+			if !iv.synced && !iv.cold {
+				snap = append(snap, iv)
+			}
+		}
+	}
+	sh.mu.Unlock()
+	owner := map[recKey]int{}
+	for ri, run := range splitRuns(snap) {
+		for _, iv := range run {
+			k := recKey{iv.loc.SegmentID, iv.recOff}
+			if prev, ok := owner[k]; ok && prev != ri {
+				return true
+			}
+			owner[k] = ri
+		}
+	}
+	return false
+}
+
+// TestCarveSharedRecordAcrossRuns builds the one shape where concurrent runs are
+// not trivially independent: two runs holding fragments of a single physical
+// record, separated by a synced gap. Only the run that sees no dirty fragment
+// left may flip that record, and flipUpTo holds the shard lock across the whole
+// mark-check-flip, so whichever run finishes last is the one that flips.
+//
+// The shape is built by splitting a record with a small overwrite, carving
+// everything, then clipping each surviving fragment with a later write: the
+// clipped fragments go dirty again while the small record between them stays
+// synced, and that synced gap is what splits the dirty set into two runs.
+func TestCarveSharedRecordAcrossRuns(t *testing.T) {
+	const (
+		size     = 96 << 10
+		midOff   = 40 << 10
+		midEnd   = 48 << 10
+		leftCut  = 32 << 10
+		rightCut = 56 << 10
+	)
+	s, _, sink, _ := carveStore(t, Config{CarveBlockSize: 4 << 20, CarveUploadConcurrency: 4})
+	ctx := context.Background()
+
+	base := randBytes(size, 1)
+	if err := s.WriteAt(ctx, "f", 0, base); err != nil {
+		t.Fatalf("base write: %v", err)
+	}
+	mid := randBytes(midEnd-midOff, 2)
+	if err := s.WriteAt(ctx, "f", midOff, mid); err != nil {
+		t.Fatalf("mid write: %v", err)
+	}
+	if _, err := s.Carve(ctx, CarveOptions{Force: true}); err != nil {
+		t.Fatalf("seed carve: %v", err)
+	}
+	if s.UnsyncedBytes() != 0 {
+		t.Fatalf("seed carve left %d unsynced", s.UnsyncedBytes())
+	}
+
+	// Clip both surviving fragments of the base record; each write re-dirties the
+	// fragment it splits, while the record covering [midOff,midEnd) stays synced.
+	left := randBytes(leftCut, 3)
+	if err := s.WriteAt(ctx, "f", 0, left); err != nil {
+		t.Fatalf("left write: %v", err)
+	}
+	right := randBytes(size-rightCut, 4)
+	if err := s.WriteAt(ctx, "f", rightCut, right); err != nil {
+		t.Fatalf("right write: %v", err)
+	}
+
+	if !runsSharingARecord(s, "f") {
+		t.Fatalf("premise not constructed: no record has fragments in two runs")
+	}
+	if got, want := s.UnsyncedBytes(), int64(midOff+(size-midEnd)); got != want {
+		t.Fatalf("unsynced=%d want %d", got, want)
+	}
+
+	if _, err := s.Carve(ctx, CarveOptions{Force: true}); err != nil {
+		t.Fatalf("Carve: %v", err)
+	}
+	if s.UnsyncedBytes() != 0 {
+		t.Fatalf("post-carve unsynced=%d want 0", s.UnsyncedBytes())
+	}
+
+	wantLeft := append(append([]byte{}, left...), base[leftCut:midOff]...)
+	wantRight := append(append([]byte{}, base[midEnd:rightCut]...), right...)
+	if got := sink.chunkAt(0); string(got) != string(wantLeft) {
+		t.Fatalf("left run committed %d bytes, want %d", len(got), len(wantLeft))
+	}
+	if got := sink.chunkAt(midEnd); string(got) != string(wantRight) {
+		t.Fatalf("right run committed %d bytes, want %d", len(got), len(wantRight))
+	}
+	for _, off := range []int64{0, leftCut, midOff, midEnd, rightCut} {
+		if f := recRawFlags(t, s, "f", off); f&flagSynced == 0 {
+			t.Fatalf("record at %d not flipped synced on disk: flags=%#x", off, f)
+		}
+	}
+}

--- a/pkg/block/journal/carve_concurrent_test.go
+++ b/pkg/block/journal/carve_concurrent_test.go
@@ -2,7 +2,10 @@ package journal
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
+	"time"
 )
 
 // TestCarveScatteredRunsConvergeConcurrently pins that a scattered dirty set still
@@ -90,14 +93,22 @@ func runsSharingARecord(s *Store, id FileID) bool {
 
 // TestCarveSharedRecordAcrossRuns builds the one shape where concurrent runs are
 // not trivially independent: two runs holding fragments of a single physical
-// record, separated by a synced gap. Only the run that sees no dirty fragment
-// left may flip that record, and flipUpTo holds the shard lock across the whole
-// mark-check-flip, so whichever run finishes last is the one that flips.
+// record, separated by a synced gap. It pins that such a file still drains —
+// both runs carve their fragment, the file ends with nothing unsynced, and each
+// run commits exactly its own bytes — with the shard-lock-held mark-check-flip
+// in flipUpTo racing between the two runs under -race.
 //
 // The shape is built by splitting a record with a small overwrite, carving
 // everything, then clipping each surviving fragment with a later write: the
 // clipped fragments go dirty again while the small record between them stays
 // synced, and that synced gap is what splits the dirty set into two runs.
+//
+// Note what this cannot check: a record shared across two runs was necessarily
+// split by a write that had already been carved, so its on-disk synced bit is
+// already set before this carve begins and flipRecordSynced only ORs the bit in.
+// The flag assertions below are therefore live only at offsets 0 and rightCut,
+// whose records are new; UnsyncedBytes reaching zero is what actually pins the
+// in-memory flip for the shared record.
 func TestCarveSharedRecordAcrossRuns(t *testing.T) {
 	const (
 		size     = 96 << 10
@@ -160,6 +171,137 @@ func TestCarveSharedRecordAcrossRuns(t *testing.T) {
 	for _, off := range []int64{0, leftCut, midOff, midEnd, rightCut} {
 		if f := recRawFlags(t, s, "f", off); f&flagSynced == 0 {
 			t.Fatalf("record at %d not flipped synced on disk: flags=%#x", off, f)
+		}
+	}
+}
+
+// syncedAt reports whether the live interval covering off is warm in memory.
+func syncedAt(s *Store, id FileID, off int64) bool {
+	sh := s.shardFor(id)
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	fi := sh.index[id]
+	if fi == nil {
+		return false
+	}
+	for k := range fi.ivs {
+		if fi.ivs[k].fileOff <= off && off < fi.ivs[k].end() {
+			return fi.ivs[k].synced && !fi.ivs[k].cold
+		}
+	}
+	return false
+}
+
+// extendingSink is a fakeSink that also answers the manifest-row lookup and
+// records every run-end reap range. The lookup for gateOff blocks until the
+// interval at waitFor has been flipped synced, which pins the ordering the
+// clamp exists for: the first run asks how far its row reaches only after the
+// second run has already marked its own intervals warm in memory.
+type extendingSink struct {
+	*fakeSink
+	mu      sync.Mutex
+	reaps   [][2]int64
+	store   *Store
+	gateOff int64
+	waitFor int64
+	rowEnd  int64
+	timeout error
+}
+
+func (e *extendingSink) ManifestRowEndAfter(_ context.Context, id FileID, off int64) (int64, error) {
+	if off != e.gateOff {
+		return 0, nil
+	}
+	for i := 0; i < 5000; i++ {
+		if syncedAt(e.store, id, e.waitFor) {
+			return e.rowEnd, nil
+		}
+		time.Sleep(time.Millisecond)
+	}
+	e.mu.Lock()
+	e.timeout = errors.New("timed out waiting for the sibling run to flip")
+	e.mu.Unlock()
+	return 0, nil
+}
+
+func (e *extendingSink) ReapSupersededManifest(_ context.Context, _ FileID, runStart, runEnd int64, _ map[int64]struct{}) error {
+	e.mu.Lock()
+	e.reaps = append(e.reaps, [2]int64{runStart, runEnd})
+	e.mu.Unlock()
+	return nil
+}
+
+// TestCarveRunDoesNotExtendPastNextRun pins that a run's manifest-row extension
+// stops at the next run's start.
+//
+// warmTail cannot tell a sibling run's already-flipped intervals from
+// pre-existing warm data — flipUpTo sets interval.synced in memory as a run's
+// watermark advances — so once runs carve concurrently a run can be offered an
+// extension that reaches straight through a range a sibling is carving. That
+// matters because the run-end reap deletes every manifest row starting inside
+// its range that it did not itself write, so an over-extended run drops the
+// rows the sibling just committed, leaving an uncovered range that cold-reads
+// as zeros with no error anywhere.
+func TestCarveRunDoesNotExtendPastNextRun(t *testing.T) {
+	const rec = 8 << 10
+	s, dd, base, _ := carveStore(t, Config{CarveBlockSize: 4 << 20, CarveUploadConcurrency: 4})
+	sink := &extendingSink{
+		fakeSink: base,
+		store:    s,
+		gateOff:  rec,     // the first run ends here
+		waitFor:  2 * rec, // the second run starts here
+		rowEnd:   4 * rec, // a row reaching past the second run
+	}
+	s.SetCarveTargets(dd, sink)
+	ctx := context.Background()
+
+	// Six records, each written separately so a later full-width overwrite
+	// replaces one outright instead of splitting a larger record (which would
+	// re-dirty its neighbours and merge everything into one run).
+	for i := 0; i < 6; i++ {
+		if err := s.WriteAt(ctx, "f", int64(i)*rec, randBytes(rec, int64(i))); err != nil {
+			t.Fatalf("seed write %d: %v", i, err)
+		}
+	}
+	if _, err := s.Carve(ctx, CarveOptions{Force: true}); err != nil {
+		t.Fatalf("seed carve: %v", err)
+	}
+
+	// Re-dirty records 0 and 2, leaving record 1 warm between the two runs.
+	dirty := []int64{0, 2 * rec}
+	for _, off := range dirty {
+		if err := s.WriteAt(ctx, "f", off, randBytes(rec, off+99)); err != nil {
+			t.Fatalf("dirty write %d: %v", off, err)
+		}
+	}
+
+	sink.mu.Lock()
+	sink.reaps = nil
+	sink.mu.Unlock()
+
+	if _, err := s.Carve(ctx, CarveOptions{Force: true}); err != nil {
+		t.Fatalf("Carve: %v", err)
+	}
+	if s.UnsyncedBytes() != 0 {
+		t.Fatalf("post-carve unsynced=%d want 0", s.UnsyncedBytes())
+	}
+
+	sink.mu.Lock()
+	reaps := append([][2]int64{}, sink.reaps...)
+	timedOut := sink.timeout
+	sink.mu.Unlock()
+	if timedOut != nil {
+		t.Fatalf("ordering not reached, test proves nothing: %v", timedOut)
+	}
+	if len(reaps) != len(dirty) {
+		t.Fatalf("got %d reap ranges, want %d: %v", len(reaps), len(dirty), reaps)
+	}
+	// No run's reap range may reach into a range another run is carving.
+	for _, r := range reaps {
+		for _, start := range dirty {
+			if r[0] < start && start < r[1] {
+				t.Fatalf("reap range [%d,%d) covers the run starting at %d", r[0], r[1], start)
+			}
 		}
 	}
 }

--- a/pkg/block/journal/carve_dispatch.go
+++ b/pkg/block/journal/carve_dispatch.go
@@ -45,7 +45,7 @@ type carveDispatcher struct {
 	abort    atomic.Bool
 }
 
-func newCarveDispatcher(ctx context.Context, s *Store, sh *shard, id FileID, run []interval, res *CarveResult, flipIdx *int) *carveDispatcher {
+func newCarveDispatcher(ctx context.Context, s *Store, sh *shard, id FileID, run []interval, res *CarveResult, flipIdx *int, sem chan struct{}) *carveDispatcher {
 	// A pre-satisfied predecessor so the first block flips as soon as it commits.
 	prev := make(chan bool, 1)
 	prev <- true
@@ -57,7 +57,7 @@ func newCarveDispatcher(ctx context.Context, s *Store, sh *shard, id FileID, run
 		run:     run,
 		res:     res,
 		flipIdx: flipIdx,
-		sem:     make(chan struct{}, s.cfg.CarveUploadConcurrency),
+		sem:     sem,
 		prev:    prev,
 	}
 }

--- a/pkg/block/journal/carve_test.go
+++ b/pkg/block/journal/carve_test.go
@@ -100,6 +100,14 @@ func (s *fakeSink) CommitBlock(_ context.Context, chunks []CarveChunk) error {
 	return nil
 }
 
+// chunkAt returns the plaintext committed at a file offset, or nil if nothing
+// was committed there.
+func (s *fakeSink) chunkAt(off int64) []byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.chunks[off]
+}
+
 // carved reassembles every committed chunk in file-offset order.
 func (s *fakeSink) carved() []byte {
 	s.mu.Lock()

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -69,7 +69,10 @@ type Config struct {
 	// pass — every dirty run it carves shares the one window, not one window
 	// per run. Packing stays sequential; only the block commits overlap, so a
 	// single large file's carve is no longer one PutBlock at a time. Peak carve
-	// RAM scales with this window (window x CarveBlockSize), so keep it modest.
+	// RAM per file is window x (CarveBlockSize + one overhang chunk) for the
+	// block arenas, plus one chunker scratch buffer of chunker.MaxChunkSize for
+	// each run carving concurrently — the window bounds the arenas, not the
+	// scratch buffers — so keep it modest.
 	// Zero falls back to the default via withDefaults.
 	//
 	// ponytail: with runs concurrent, a file at the limit can leave each run

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -65,11 +65,17 @@ type Config struct {
 	MaxLocalBytes int64
 	EvictMaxWait  time.Duration // write-path backpressure budget before ErrLocalStoreFull
 	// CarveUploadConcurrency bounds how many of one file's packed blocks may be
-	// committed (uploaded + committed) at once within a single carve run. Packing
-	// stays sequential; only the block commits overlap, so a single large file's
-	// carve is no longer one PutBlock at a time. Peak carve RAM scales with this
-	// window (window x CarveBlockSize), so keep it modest. Zero falls back to the
-	// default via withDefaults.
+	// committed (uploaded + committed) at once across that file's whole carve
+	// pass — every dirty run it carves shares the one window, not one window
+	// per run. Packing stays sequential; only the block commits overlap, so a
+	// single large file's carve is no longer one PutBlock at a time. Peak carve
+	// RAM scales with this window (window x CarveBlockSize), so keep it modest.
+	// Zero falls back to the default via withDefaults.
+	//
+	// ponytail: with runs concurrent, a file at the limit can leave each run
+	// holding a single slot, so the intra-run block overlap degrades under
+	// multi-run contention; split into a separate CarveRunConcurrency only if
+	// profiling shows the two dimensions need to diverge.
 	CarveUploadConcurrency int
 	// DirtyExpiry bounds how long an appended record may sit unfsynced. A
 	// background loop commits every shard still holding uncovered records once


### PR DESCRIPTION
Carves a file's dirty runs concurrently instead of one at a time. Part of #2070.

## The defect

`carveFile` split a file's live dirty intervals into *runs* — maximal contiguous spans, since a hole resets FastCDC chunking — then carved each run serially, waiting on its own dispatcher before starting the next.

On a scattered file that means each run holds a single block, so the per-run dispatcher has nothing to overlap and effective concurrency pins at **1**. `CarveUploadConcurrency` buys nothing at all, and a drain converges far too slowly.

Measured on a harness of 200 scattered 4 KiB runs (concurrency 8, 2 ms stand-in commit latency):

| | max concurrent commits | wall clock |
| --- | --- | --- |
| before | **1** | 644 / 534 / 559 ms |
| after | **8** | 70 / 91 / 80 ms |

~7x, and the `1` is the defect stated directly.

## What changed

Five commits, smallest first:

1. **`CarveResult` per run** — it was a shared `*CarveResult`, a genuine data race the moment runs overlap.
2. **One semaphore per file, not per run** — a single `sem` bounds in-flight blocks across all of a file's runs, so peak arena memory stays `cap(sem) x (CarveBlockSize + one overhang chunk)` however many runs the file has.
3. **Runs carve concurrently** under an errgroup, with `splitRuns` extracted.
4. **A run's row extension is bounded by the next run's start.** See below — this is the load-bearing correctness commit.
5. **The regression test fails loudly when its ordering gate is skipped.**

`flipUpTo` is untouched in every round. It holds `sh.mu` across its whole body, and that atomicity is the entire safety argument for letting runs flip concurrently.

## The correctness problem concurrency exposed

`extendRunToRowEnd` may extend a run forward to a manifest row boundary. It decides what to absorb using `warmAt`/`warmTail`, which test `iv.synced`.

But `flipUpTo` *sets* `iv.synced` in memory as each run's watermark advances. So once runs overlap, a sibling run that has already flipped its head intervals is indistinguishable from pre-existing warm data, and a run can extend forward over a sibling's territory.

That is corruption, not wasted work. `ReapSupersededManifest` deletes every manifest row whose start falls in `[runStart, runEnd)` and is not in that run's `newOffsets` — and deletes it *whole*. An over-extended run A deletes rows sibling B just committed; B then reaps A's fresh rows; the range ends up covered by nothing and cold-reads as silent zeros. Same class as #1879 / #1956.

Serially this was unreachable, because run *i+1* had not started when run *i* extended, so its intervals were still unsynced and `warmTail` bailed on them. That safety was a property of the schedule, and concurrency removes it.

**The fix is refusal, not truncation.** Each run receives the next run's start as a `limit`, and refuses to extend at all when the row reaches past it:

```go
if rowEnd > limit {
    // The row reaches past a later run: leave this one as snapshotted rather
    // than half extended, which is what a serial carve does when it finds that
    // range still dirty.
    return run, nil
}
```

This is provably serial-equivalent rather than merely safe: `splitRuns` guarantees run *i+1*'s first interval starts exactly at `limit`, so any `rowEnd > limit` forces `warmTail`'s walk through an unsynced interval. Serial refuses iff `rowEnd > limit` — the identical predicate. No geometry where serial extends and this refuses, none where serial refuses and this permits.

Truncating to `limit` instead was tried and rejected: it breaks `TestCarveRunDoesNotExtendIntoDirtyRange` (#2049), whose contract is "left as snapshotted rather than half extended", and it is unsafe on its own terms — since the reap deletes straddling rows whole, a run tiling only to `limit` still deletes the row straddling it, trading one uncovered range for a smaller one without changing the bug's class.

Run reap ranges are now pairwise disjoint and ordered, so one run's reap can never delete a row a sibling just wrote.

## Tests

- `TestCarveScatteredRunsConvergeConcurrently` — 200 scattered runs converge to `UnsyncedBytes() == 0`, per-offset committed bytes and on-disk `synced` flags verified. A `-race` vehicle and regression guard; it does not itself prove concurrency.
- `TestCarveSharedRecordAcrossRuns` — two runs holding fragments of one physical record, separated by a synced gap. The shape was found by fuzzing 300 seeds and delta-debugging to five plain writes; the test asserts via `runsSharingARecord` that the shape was actually constructed *before* carving, so it cannot silently degenerate.
- `TestCarveRunDoesNotExtendPastNextRun` — pins the fix. Gates on *ordering*, not on a return value: the first run's row lookup blocks until the second run's interval is observed `synced`, then returns a row end past it. Reverted, it prints `reap range [0,32768) covers the run starting at 16384`. It also fails loudly if the gate is never reached, rather than passing vacuously.

## Ordering

Depends on #2071 (merged), which puts `ReapSupersededManifest` under the per-file commit stripe lock. Without it, concurrent same-file runs turn badger SSI retry churn into `EDEADLK` at the client under exactly this PR's target workload. Rebased onto it.

## Known and deliberately unchanged

- `ManifestRowEndAfter` remains an unlocked read; the refusal removes the consequence that mattered, but its answer is a snapshot.
- The pre-existing "run ends mid-row, reap deletes the straddling row" behaviour from #2049 is preserved exactly.
- On error, counters are summed across all runs including cancelled siblings, where serially they were the prefix up to the failure. Counters only — every production caller discards `CarveResult`.
- The documented carve-RAM bound now names the per-run `chunker.MaxChunkSize` scratch buffer, which is not under `sem`, with a `ponytail:` marker for the `ChunkParams.Max` upgrade path.
