### PR TITLE
docs(durability): document relaxed_durability and the namespace loss window

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -976,6 +976,26 @@ These global sizes apply to every BadgerDB metadata store on the node. A single
 store can be overridden via its config-map keys when it is created (see below):
 `--config '{"path":"...","block_cache_mb":2048,"index_cache_mb":1024}'`.
 
+#### `relaxed_durability`
+
+Applies to the `badger` and `postgres` metadata stores. **Defaults to `true`.**
+
+Namespace operations (`create`, `unlink`, `rename`, `mkdir`, `rmdir`,
+attribute-only `setattr`) commit without an inline `fsync`; a background syncer
+makes them durable within 100 ms. Writes paired with file data commit
+synchronously either way, so this is bounded loss, never corruption.
+
+```bash
+# Strict: fsync every namespace commit (roughly a third of the create throughput)
+./dfsctl store metadata add --name badger-strict --type badger \
+  --config '{"path":"/var/lib/dittofs/metadata","relaxed_durability":false}'
+```
+
+Only an event that takes the kernel down — power loss, kernel panic, hypervisor
+reset — can lose that 100 ms window. Killing the `dfs` process (`SIGKILL`,
+OOM-kill, panic) loses nothing at either setting. See
+[Durability → Namespace durability](durability.md#namespace-durability-relaxed_durability).
+
 #### Metadata Store Instances (CLI)
 
 Metadata stores are managed at runtime via `dfsctl` and persisted in the control plane database:

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -981,9 +981,12 @@ store can be overridden via its config-map keys when it is created (see below):
 Applies to the `badger` and `postgres` metadata stores. **Defaults to `true`.**
 
 Namespace operations (`create`, `unlink`, `rename`, `mkdir`, `rmdir`,
-attribute-only `setattr`) commit without an inline `fsync`; a background syncer
-makes them durable within 100 ms. Writes paired with file data commit
-synchronously either way, so this is bounded loss, never corruption.
+attribute-only `setattr`) commit without an inline flush. On `badger` a
+background syncer makes them durable within ~100 ms; on `postgres` the
+transaction runs with `synchronous_commit = off`, so the window is whatever the
+server's `wal_writer_delay` allows (PostgreSQL default 200 ms). Writes paired
+with file data commit synchronously either way, so this is bounded loss, never
+corruption.
 
 ```bash
 # Strict: fsync every namespace commit (roughly a third of the create throughput)
@@ -992,8 +995,9 @@ synchronously either way, so this is bounded loss, never corruption.
 ```
 
 Only an event that takes the kernel down — power loss, kernel panic, hypervisor
-reset — can lose that 100 ms window. Killing the `dfs` process (`SIGKILL`,
-OOM-kill, panic) loses nothing at either setting. See
+reset — can lose that window. Killing the `dfs` process (`SIGKILL`, OOM-kill,
+panic) loses nothing at either setting, because an acknowledged write is already
+in the kernel page cache. See
 [Durability → Namespace durability](durability.md#namespace-durability-relaxed_durability).
 
 #### Metadata Store Instances (CLI)

--- a/docs/guide/durability.md
+++ b/docs/guide/durability.md
@@ -78,22 +78,31 @@ absent these are honored unchanged:
 it** (size, mtime, the block manifest). It does not govern **namespace**
 operations — `create`, `unlink`, `rename`, `mkdir`, `rmdir`, and attribute-only
 `setattr`. Those are controlled separately, by the metadata store's
-`relaxed_durability` setting, which is **enabled by default**:
+`relaxed_durability` setting, which is **enabled by default** on the `badger` and
+`postgres` stores. It is a per-store config key, set when the store is created or
+edited:
 
-```yaml
-metadata:
-  config:
-    relaxed_durability: true    # default
+```bash
+dfsctl store metadata add --name badger-main --type badger \
+  --config '{"path":"/var/lib/dittofs/metadata","relaxed_durability":false}'
 ```
 
-When enabled, a namespace commit does not `fsync` inline. A background syncer
-makes it durable within 100 ms, so at most the last ~100 ms of namespace work is
-at risk. Set `relaxed_durability: false` to restore a synchronous `fsync` on
-every namespace commit, at roughly a third of the create throughput.
+When enabled, a namespace commit does not `fsync` inline. How long it stays at
+risk depends on the backend:
+
+| store | mechanism | window |
+|---|---|---|
+| `badger` | commit skips `fsync`; a background syncer calls `DB.Sync()` on an interval | ~100 ms |
+| `postgres` | `SET LOCAL synchronous_commit = off` on the transaction | set by the server's own `wal_writer_delay` (PostgreSQL default 200 ms) |
+
+Setting `relaxed_durability: false` restores a synchronous flush on every
+namespace commit, at roughly a third of the create throughput.
 
 ### What can actually lose that window
 
-The distinction that matters operationally is **how** the server died:
+The distinction that matters operationally is **how** the server died. The
+numbers below were measured on `badger`; the mechanism (an acknowledged write
+already sitting in the kernel page cache) applies to any backend:
 
 | Failure | Namespace ops at risk |
 |---|---|

--- a/docs/guide/durability.md
+++ b/docs/guide/durability.md
@@ -43,7 +43,7 @@ dfsctl store block local edit <share> --config '{"durability": "remote"}'
 
 | `durability` | Ack after | Survives | ~ops/s (create nj=8) |
 |---|---|---|--:|
-| `local` *(default)* | local journal + metadata `fsync` | process/node crash | ~900 |
+| `local` *(default)* | local journal + metadata `fsync` | process/node crash † | ~900 |
 | `writeback` | local write, metadata `fsync` deferred ~100 ms | crash, ≤ 100 ms metadata loss | ~1680 |
 | `remote` | data durable in S3 | node/disk loss | slow (by design) |
 
@@ -71,6 +71,48 @@ absent these are honored unchanged:
   `durability: remote`); see
   [Configuration → require_durable_commit](configuration.md#require_durable_commit)
   for the full semantics.
+
+## Namespace durability (`relaxed_durability`)
+
+† The `durability` enum above governs **file data and the metadata paired with
+it** (size, mtime, the block manifest). It does not govern **namespace**
+operations — `create`, `unlink`, `rename`, `mkdir`, `rmdir`, and attribute-only
+`setattr`. Those are controlled separately, by the metadata store's
+`relaxed_durability` setting, which is **enabled by default**:
+
+```yaml
+metadata:
+  config:
+    relaxed_durability: true    # default
+```
+
+When enabled, a namespace commit does not `fsync` inline. A background syncer
+makes it durable within 100 ms, so at most the last ~100 ms of namespace work is
+at risk. Set `relaxed_durability: false` to restore a synchronous `fsync` on
+every namespace commit, at roughly a third of the create throughput.
+
+### What can actually lose that window
+
+The distinction that matters operationally is **how** the server died:
+
+| Failure | Namespace ops at risk |
+|---|---|
+| `SIGKILL`, OOM-kill, `dfs` panic, `systemctl kill` | **none** |
+| Power loss, kernel panic, hypervisor reset, disk yank | last ~100 ms |
+
+Killing the process does not lose acknowledged work at any setting. The write-ahead
+log is memory-mapped, so an acknowledged namespace op is already in the kernel's
+page cache, and the page cache outlives the process — the kernel still flushes it.
+Only an event that takes the kernel down with it can lose the un-`fsync`'d tail.
+
+This is bounded loss, never corruption or inconsistency. Data-paired writes stay
+synchronous regardless of this setting, and on restart
+`reconcileMetadataSizeFromJournal` repairs each file's size from the journal's
+durable high-water mark. A lost namespace op leaves a file that was never created,
+not a file that is half-created.
+
+Operators who need every acknowledged `create` to survive power loss — and can
+accept the throughput cost — should set `relaxed_durability: false`.
 
 ## The dirty-age ceiling (`dirty_expire_seconds`)
 


### PR DESCRIPTION
## What was wrong

`relaxed_durability` is documented nowhere. It defaults to `true` on both the
badger and postgres metadata stores (`runtime/init.go:96`), and it defers the
fsync for every namespace operation — `create`, `unlink`, `rename`, `mkdir`,
`rmdir`, attribute-only `setattr` — to a 100 ms background syncer
(`durabilitySyncInterval`).

`docs/guide/durability.md` compounded this: it describes the default `local`
tier as surviving "process/node crash" with no qualification. That is true for
file data and the metadata paired with it, but not for namespace ops, which the
`durability` enum does not govern at all — they are controlled by a separate
metadata-store setting the reader is never told about.

This surfaced from a field evaluation (#1891) asking precisely what the
durability contract is under abrupt termination. We could not point at an
answer.

## Evidence

Measured on a 4 vCPU / 7 GB box, scoring acknowledged creates against an
fsync'd witness log and counting how many survive:

| failure | `relaxed_durability: true` (default) | `false` |
|---|---|---|
| SIGKILL / OOM-kill | 0 lost (0/321, 0/332, 0/331) | 0 lost (0/218, 0/233, 0/226) |
| hard power loss (`sysrq-b`) | 10/804, 6/1463 | 0/913 |

Two things worth stating in the docs came out of that:

- **Killing the process loses nothing at either setting.** Badger's memtable WAL
  is a `z.MmapFile`, so an acknowledged op is already in the page cache, and the
  page cache outlives the process. Only an event that takes the kernel down can
  lose the un-fsync'd tail. Operators conflate these two constantly — the
  evaluation that prompted this did.
- **The loss window is real but bounded**, and the ~100 ms measured matches
  `durabilitySyncInterval` exactly.

## What this changes

Docs only; no behaviour change.

- `durability.md` gains a "Namespace durability" section: what the setting
  covers, the failure-mode table above, why it is bounded loss and never
  corruption, and the opt-out.
- `configuration.md` gains the `relaxed_durability` key in the metadata-store
  reference, where an operator would actually look for it.

Relates to #1891.
