### PR TITLE
perf(shares): read only the size the share-start reconcile compares

### DIFF
--- a/pkg/controlplane/runtime/shares/lifecycle.go
+++ b/pkg/controlplane/runtime/shares/lifecycle.go
@@ -6,11 +6,16 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"sync"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/block/local"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
@@ -170,6 +175,106 @@ func (s *Service) durableExtent(shareName string, payloadID metadata.PayloadID) 
 	return bs.DurableExtent(context.Background(), payloadID)
 }
 
+// payloadSizer is the narrow read the size reconcile needs: one file's persisted
+// size, addressed by payload. A store that resolves it directly skips the link
+// count, chunk manifest and derived path GetFileByPayloadID also loads and the
+// reconcile then throws away — per locally-resident file, which is what makes
+// share start on a large store expensive.
+type payloadSizer interface {
+	FileSizeByPayloadID(ctx context.Context, payloadID metadata.PayloadID) (uint64, bool, error)
+}
+
+// payloadSizeLookup returns the cheapest size-by-payload read the store offers,
+// falling back to the full GetFileByPayloadID load for stores that have none.
+func payloadSizeLookup(metadataStore metadata.Store) func(context.Context, metadata.PayloadID) (uint64, bool, error) {
+	if ps, ok := metadataStore.(payloadSizer); ok {
+		return ps.FileSizeByPayloadID
+	}
+	return func(ctx context.Context, payloadID metadata.PayloadID) (uint64, bool, error) {
+		f, err := metadataStore.GetFileByPayloadID(ctx, payloadID)
+		if err != nil {
+			if metadata.IsNotFoundError(err) {
+				return 0, false, nil
+			}
+			return 0, false, err
+		}
+		if f == nil {
+			return 0, false, nil
+		}
+		return f.Size, true, nil
+	}
+}
+
+// staleSize names a file whose persisted metadata size trails the journal's
+// durable high-water mark, and the mark to grow it to.
+type staleSize struct {
+	id          string
+	journalSize int64
+}
+
+// findStaleSizes reports which of the journal's files have a persisted metadata
+// size below their journal high-water mark. It is read-only and order-free, so
+// it splits the file list across workers: one share start compares every
+// locally-resident file, and on a store holding millions of them that
+// comparison is the whole cost of making the share visible.
+//
+// A real store error (I/O, corruption) aborts the scan rather than being
+// swallowed — skipping a file would leave its metadata.Size stale and truncate
+// reads. A file the metadata store does not know is an orphan journal entry and
+// is simply skipped.
+func findStaleSizes(ctx context.Context, metadataStore metadata.Store, localStore local.LocalStore, files []string) ([]staleSize, error) {
+	// The comparisons are point reads against a metadata store that is open but
+	// not yet serving any share, so the only ceiling worth respecting is the
+	// machine's. Workers take contiguous slices rather than one goroutine per
+	// file, which would be millions of spawns to do a handful of reads each.
+	workers := min(runtime.NumCPU(), 8)
+	if len(files) < workers {
+		workers = max(len(files), 1)
+	}
+	chunk := (len(files) + workers - 1) / workers
+
+	sizeOf := payloadSizeLookup(metadataStore)
+	var (
+		mu    sync.Mutex
+		stale []staleSize
+	)
+	g, gctx := errgroup.WithContext(ctx)
+	for start := 0; start < len(files); start += chunk {
+		batch := files[start:min(start+chunk, len(files))]
+		g.Go(func() error {
+			var found []staleSize
+			for _, id := range batch {
+				journalSize, ok := localStore.FileSize(gctx, id)
+				if !ok || journalSize < 0 {
+					continue
+				}
+				size, known, err := sizeOf(gctx, metadata.PayloadID(id))
+				if err != nil {
+					return fmt.Errorf("reconcile size: lookup payload %s: %w", id, err)
+				}
+				// max-only, overflow-safe: size is uint64, journalSize a
+				// non-negative offset; compare in uint64 so a huge size can never
+				// cast negative and shrink.
+				if !known || size >= uint64(journalSize) {
+					continue
+				}
+				found = append(found, staleSize{id: id, journalSize: journalSize})
+			}
+			if len(found) == 0 {
+				return nil
+			}
+			mu.Lock()
+			stale = append(stale, found...)
+			mu.Unlock()
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	return stale, nil
+}
+
 // reconcileMetadataSizeFromJournal grows each file's metadata size up to the
 // local journal's durable high-water mark (#1687 crash-safety net). It is the
 // load-bearing counterpart to the relaxed (deferred-fsync) size commits done on
@@ -191,43 +296,26 @@ func reconcileMetadataSizeFromJournal(ctx context.Context, metadataStore metadat
 	if localStore == nil {
 		return nil
 	}
-	for _, id := range localStore.ListFiles(ctx) {
-		journalSize, ok := localStore.FileSize(ctx, id)
-		if !ok {
-			continue
-		}
-		f, err := metadataStore.GetFileByPayloadID(ctx, metadata.PayloadID(id))
-		if err != nil {
-			if metadata.IsNotFoundError(err) {
-				// Orphan journal entry (no metadata file) — nothing to reconcile.
-				continue
-			}
-			// A real store error (I/O, corruption) must not be silently swallowed —
-			// skipping would leave metadata.Size stale and truncate reads.
-			return fmt.Errorf("reconcile size: lookup payload %s: %w", id, err)
-		}
-		if f == nil {
-			continue
-		}
-		// max-only, overflow-safe: f.Size is uint64, journalSize a non-negative
-		// offset; compare in uint64 so a huge Size can never cast negative and shrink.
-		if journalSize < 0 || f.Size >= uint64(journalSize) {
-			continue
-		}
+	files := localStore.ListFiles(ctx)
+	stale, err := findStaleSizes(ctx, metadataStore, localStore, files)
+	if err != nil {
+		return err
+	}
+	for _, m := range stale {
 		// Grow to the journal high-water mark under a STRICT transaction; re-read
 		// inside the txn so a concurrent legitimate update can't be clobbered.
 		if err := metadataStore.WithTransaction(ctx, func(tx metadata.Transaction) error {
-			cur, err := tx.GetFileByPayloadID(ctx, metadata.PayloadID(id))
+			cur, err := tx.GetFileByPayloadID(ctx, metadata.PayloadID(m.id))
 			if err != nil {
 				return err
 			}
-			if cur == nil || journalSize < 0 || cur.Size >= uint64(journalSize) {
+			if cur == nil || m.journalSize < 0 || cur.Size >= uint64(m.journalSize) {
 				return nil // another writer already caught up; never shrink
 			}
-			cur.Size = uint64(journalSize)
+			cur.Size = uint64(m.journalSize)
 			return tx.UpdateAttrs(ctx, cur)
 		}); err != nil {
-			return fmt.Errorf("reconcile size for payload %s: %w", id, err)
+			return fmt.Errorf("reconcile size for payload %s: %w", m.id, err)
 		}
 	}
 	return nil

--- a/pkg/controlplane/runtime/shares/lifecycle.go
+++ b/pkg/controlplane/runtime/shares/lifecycle.go
@@ -176,10 +176,8 @@ func (s *Service) durableExtent(shareName string, payloadID metadata.PayloadID) 
 }
 
 // payloadSizer is the narrow read the size reconcile needs: one file's persisted
-// size, addressed by payload. A store that resolves it directly skips the link
-// count, chunk manifest and derived path GetFileByPayloadID also loads and the
-// reconcile then throws away — per locally-resident file, which is what makes
-// share start on a large store expensive.
+// size, addressed by payload, without the link count, chunk manifest and derived
+// path GetFileByPayloadID also loads and the reconcile then throws away.
 type payloadSizer interface {
 	FileSizeByPayloadID(ctx context.Context, payloadID metadata.PayloadID) (uint64, bool, error)
 }
@@ -209,28 +207,24 @@ func payloadSizeLookup(metadataStore metadata.Store) func(context.Context, metad
 // durable high-water mark, and the mark to grow it to.
 type staleSize struct {
 	id          string
-	journalSize int64
+	journalSize uint64
 }
 
 // findStaleSizes reports which of the journal's files have a persisted metadata
-// size below their journal high-water mark. It is read-only and order-free, so
-// it splits the file list across workers: one share start compares every
-// locally-resident file, and on a store holding millions of them that
-// comparison is the whole cost of making the share visible.
+// size below their journal high-water mark. The comparison is read-only and
+// order-free, so workers take contiguous slices of the list rather than one
+// goroutine per file: share start compares every locally-resident file, and on a
+// store holding millions of them that is what the share's visibility waits on.
 //
 // A real store error (I/O, corruption) aborts the scan rather than being
 // swallowed — skipping a file would leave its metadata.Size stale and truncate
 // reads. A file the metadata store does not know is an orphan journal entry and
 // is simply skipped.
 func findStaleSizes(ctx context.Context, metadataStore metadata.Store, localStore local.LocalStore, files []string) ([]staleSize, error) {
-	// The comparisons are point reads against a metadata store that is open but
-	// not yet serving any share, so the only ceiling worth respecting is the
-	// machine's. Workers take contiguous slices rather than one goroutine per
-	// file, which would be millions of spawns to do a handful of reads each.
-	workers := min(runtime.NumCPU(), 8)
-	if len(files) < workers {
-		workers = max(len(files), 1)
+	if len(files) == 0 {
+		return nil, nil
 	}
+	workers := min(len(files), runtime.NumCPU(), 8)
 	chunk := (len(files) + workers - 1) / workers
 
 	sizeOf := payloadSizeLookup(metadataStore)
@@ -252,13 +246,12 @@ func findStaleSizes(ctx context.Context, metadataStore metadata.Store, localStor
 				if err != nil {
 					return fmt.Errorf("reconcile size: lookup payload %s: %w", id, err)
 				}
-				// max-only, overflow-safe: size is uint64, journalSize a
-				// non-negative offset; compare in uint64 so a huge size can never
-				// cast negative and shrink.
+				// Grow only, and compare in uint64: a size past the journal mark
+				// must never cast negative and shrink the file.
 				if !known || size >= uint64(journalSize) {
 					continue
 				}
-				found = append(found, staleSize{id: id, journalSize: journalSize})
+				found = append(found, staleSize{id: id, journalSize: uint64(journalSize)})
 			}
 			if len(found) == 0 {
 				return nil
@@ -296,8 +289,7 @@ func reconcileMetadataSizeFromJournal(ctx context.Context, metadataStore metadat
 	if localStore == nil {
 		return nil
 	}
-	files := localStore.ListFiles(ctx)
-	stale, err := findStaleSizes(ctx, metadataStore, localStore, files)
+	stale, err := findStaleSizes(ctx, metadataStore, localStore, localStore.ListFiles(ctx))
 	if err != nil {
 		return err
 	}
@@ -309,10 +301,10 @@ func reconcileMetadataSizeFromJournal(ctx context.Context, metadataStore metadat
 			if err != nil {
 				return err
 			}
-			if cur == nil || m.journalSize < 0 || cur.Size >= uint64(m.journalSize) {
+			if cur == nil || cur.Size >= m.journalSize {
 				return nil // another writer already caught up; never shrink
 			}
-			cur.Size = uint64(m.journalSize)
+			cur.Size = m.journalSize
 			return tx.UpdateAttrs(ctx, cur)
 		}); err != nil {
 			return fmt.Errorf("reconcile size for payload %s: %w", m.id, err)

--- a/pkg/controlplane/runtime/shares/reconcile_size_bench_test.go
+++ b/pkg/controlplane/runtime/shares/reconcile_size_bench_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/marmos91/dittofs/pkg/block/local"
 	"github.com/marmos91/dittofs/pkg/block/local/memory"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	badgerstore "github.com/marmos91/dittofs/pkg/metadata/store/badger"
@@ -93,7 +94,7 @@ func TestFindStaleSizesReportsOnlyLaggingFiles(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, stale, 1)
 	require.Equal(t, ids[2], stale[0].id)
-	require.Equal(t, int64(32), stale[0].journalSize)
+	require.Equal(t, uint64(32), stale[0].journalSize)
 }
 
 // enrichedOnly hides the store's size-only lookup so the scan falls back to the
@@ -102,10 +103,10 @@ type enrichedOnly struct{ metadata.Store }
 
 // scanSerialEnriched reproduces the share-start scan as it ran before this
 // change: one enriched metadata load per locally-resident file, in file order.
-func scanSerialEnriched(ctx context.Context, store metadata.Store, local localSizer, files []string) (int, error) {
+func scanSerialEnriched(ctx context.Context, store metadata.Store, localStore local.LocalStore, files []string) (int, error) {
 	n := 0
 	for _, id := range files {
-		journalSize, ok := local.FileSize(ctx, id)
+		journalSize, ok := localStore.FileSize(ctx, id)
 		if !ok {
 			continue
 		}
@@ -122,10 +123,6 @@ func scanSerialEnriched(ctx context.Context, store metadata.Store, local localSi
 		n++
 	}
 	return n, nil
-}
-
-type localSizer interface {
-	FileSize(ctx context.Context, payloadID string) (int64, bool)
 }
 
 // BenchmarkShareStartSizeScan measures the share-start size scan on a store

--- a/pkg/controlplane/runtime/shares/reconcile_size_bench_test.go
+++ b/pkg/controlplane/runtime/shares/reconcile_size_bench_test.go
@@ -170,3 +170,32 @@ func BenchmarkShareStartSizeScan(b *testing.B) {
 		})
 	}
 }
+
+// TestFindStaleSizesCoversEveryChunk pins that each worker scans its own slice
+// of the file list. The scan hands every worker a batch cut from the same
+// backing array, so a batch shared between them would leave whole stretches of
+// the list unscanned — and an unscanned file whose size needed growing is a
+// read that truncates acknowledged bytes. Growing one file in every chunk,
+// including the first, fails loudly if that ever happens.
+func TestFindStaleSizesCoversEveryChunk(t *testing.T) {
+	const files = 64
+	ctx := context.Background()
+	store, local, ids := buildReconcileFixture(t, files)
+
+	// ids is in creation order, so growing every fourth file spreads the
+	// expected hits across the list however it ends up chunked.
+	want := map[string]uint64{}
+	for i := 0; i < files; i += 4 {
+		require.NoError(t, local.WriteAt(ctx, ids[i], 8, make([]byte, 8)))
+		want[ids[i]] = 16
+	}
+
+	stale, err := findStaleSizes(ctx, store, local, ids)
+	require.NoError(t, err)
+
+	got := map[string]uint64{}
+	for _, s := range stale {
+		got[s.id] = s.journalSize
+	}
+	require.Equal(t, want, got)
+}

--- a/pkg/controlplane/runtime/shares/reconcile_size_bench_test.go
+++ b/pkg/controlplane/runtime/shares/reconcile_size_bench_test.go
@@ -1,0 +1,175 @@
+package shares
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/marmos91/dittofs/pkg/block/local/memory"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	badgerstore "github.com/marmos91/dittofs/pkg/metadata/store/badger"
+)
+
+// buildReconcileFixture creates n regular files nested four directories deep,
+// each with a payload the local store also holds, so the scan sees the shape a
+// warmed share presents at start: every locally-resident file matched by a
+// metadata row whose size is already correct.
+func buildReconcileFixture(tb testing.TB, n int) (*badgerstore.BadgerMetadataStore, *memory.MemoryStore, []string) {
+	tb.Helper()
+	ctx := context.Background()
+
+	store, err := badgerstore.NewBadgerMetadataStoreWithDefaults(ctx, tb.TempDir())
+	require.NoError(tb, err)
+	tb.Cleanup(func() { _ = store.Close() })
+
+	const share = "reconcile"
+	require.NoError(tb, store.CreateShare(ctx, &metadata.Share{Name: share}))
+	rootFile, err := store.CreateRootDirectory(ctx, share, &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o755})
+	require.NoError(tb, err)
+	root, err := metadata.EncodeFileHandle(rootFile)
+	require.NoError(tb, err)
+
+	mkdir := func(parent metadata.FileHandle, path, name string) metadata.FileHandle {
+		h, err := store.GenerateHandle(ctx, share, path)
+		require.NoError(tb, err)
+		_, id, err := metadata.DecodeFileHandle(h)
+		require.NoError(tb, err)
+		f := &metadata.File{ShareName: share, Path: path, FileAttr: metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o755}}
+		f.ID = id
+		require.NoError(tb, store.UpdateAttrs(ctx, f))
+		require.NoError(tb, store.SetParent(ctx, h, parent))
+		require.NoError(tb, store.SetChild(ctx, parent, name, h))
+		return h
+	}
+
+	local := memory.New()
+	ids := make([]string, n)
+	for i := range ids {
+		dir, path := root, ""
+		for d := 0; d < 4; d++ {
+			name := fmt.Sprintf("d%d_%d", d, i%8)
+			path += "/" + name
+			dir = mkdir(dir, path, name)
+		}
+		name := fmt.Sprintf("f%d", i)
+		full := path + "/" + name
+		h, err := store.GenerateHandle(ctx, share, full)
+		require.NoError(tb, err)
+		_, id, err := metadata.DecodeFileHandle(h)
+		require.NoError(tb, err)
+
+		payload := fmt.Sprintf("payload-%08d", i)
+		f := &metadata.File{
+			ShareName: share,
+			Path:      full,
+			FileAttr:  metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o600, PayloadID: metadata.PayloadID(payload), Size: 8},
+		}
+		f.ID = id
+		require.NoError(tb, store.UpdateAttrs(ctx, f))
+		require.NoError(tb, store.SetParent(ctx, h, dir))
+		require.NoError(tb, store.SetChild(ctx, dir, name, h))
+		require.NoError(tb, local.WriteAt(ctx, payload, 0, make([]byte, 8)))
+		ids[i] = payload
+	}
+	return store, local, ids
+}
+
+// TestFindStaleSizesReportsOnlyLaggingFiles pins the scan's answer: a file whose
+// metadata size already covers the journal is left alone, one that trails it is
+// reported with the journal's mark, and a payload with no metadata row (an
+// orphan journal entry) is skipped rather than failing the scan.
+func TestFindStaleSizesReportsOnlyLaggingFiles(t *testing.T) {
+	ctx := context.Background()
+	store, local, ids := buildReconcileFixture(t, 4)
+
+	// Grow one file's journal extent past its recorded metadata size, and add a
+	// payload the metadata store has never heard of.
+	require.NoError(t, local.WriteAt(ctx, ids[2], 8, make([]byte, 24)))
+	require.NoError(t, local.WriteAt(ctx, "payload-orphan", 0, make([]byte, 16)))
+
+	stale, err := findStaleSizes(ctx, store, local, local.ListFiles(ctx))
+	require.NoError(t, err)
+	require.Len(t, stale, 1)
+	require.Equal(t, ids[2], stale[0].id)
+	require.Equal(t, int64(32), stale[0].journalSize)
+}
+
+// enrichedOnly hides the store's size-only lookup so the scan falls back to the
+// enriched GetFileByPayloadID load, which is what share start used to do.
+type enrichedOnly struct{ metadata.Store }
+
+// scanSerialEnriched reproduces the share-start scan as it ran before this
+// change: one enriched metadata load per locally-resident file, in file order.
+func scanSerialEnriched(ctx context.Context, store metadata.Store, local localSizer, files []string) (int, error) {
+	n := 0
+	for _, id := range files {
+		journalSize, ok := local.FileSize(ctx, id)
+		if !ok {
+			continue
+		}
+		f, err := store.GetFileByPayloadID(ctx, metadata.PayloadID(id))
+		if err != nil {
+			if metadata.IsNotFoundError(err) {
+				continue
+			}
+			return 0, err
+		}
+		if f == nil || journalSize < 0 || f.Size >= uint64(journalSize) {
+			continue
+		}
+		n++
+	}
+	return n, nil
+}
+
+type localSizer interface {
+	FileSize(ctx context.Context, payloadID string) (int64, bool)
+}
+
+// BenchmarkShareStartSizeScan measures the share-start size scan on a store
+// where every file is locally resident — the pinned, offline-capable
+// configuration, and the one where the scan costs the most. "enriched" is the
+// per-file load share start used to do; "size-only" reads just the size; both
+// then run across workers.
+func BenchmarkShareStartSizeScan(b *testing.B) {
+	const files = 5000
+	ctx := context.Background()
+	store, local, _ := buildReconcileFixture(b, files)
+	list := local.ListFiles(ctx)
+
+	b.Run("enriched-serial", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := scanSerialEnriched(ctx, store, local, list); err != nil {
+				b.Fatal(err)
+			}
+		}
+		b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*files), "ns/file")
+	})
+
+	for _, tc := range []struct {
+		name  string
+		store metadata.Store
+	}{
+		{"enriched", enrichedOnly{store}},
+		{"size-only", store},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				stale, err := findStaleSizes(ctx, tc.store, local, list)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if len(stale) != 0 {
+					b.Fatalf("unexpected stale sizes: %d", len(stale))
+				}
+			}
+			b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*files), "ns/file")
+		})
+	}
+}

--- a/pkg/metadata/store/badger/files.go
+++ b/pkg/metadata/store/badger/files.go
@@ -475,23 +475,22 @@ func (s *BadgerMetadataStore) PutFilesystemMeta(ctx context.Context, shareName s
 }
 
 // FileSizeByPayloadID returns just the persisted logical size of the file
-// carrying payloadID, without the enrichment GetFileByPayloadID performs.
-// found is false when no file row claims the payload.
+// carrying payloadID. found is false when no file row claims the payload.
 //
-// GetFileByPayloadID resolves the row and then loads the link count, the chunk
-// manifest and the derived path — the last of which walks the parent chain,
-// two point reads per component. A caller that only compares sizes pays all of
-// that per file; share start reconciles one size per locally-resident file, so
-// on a large store the discarded enrichment is the whole cost.
+// GetFileByPayloadID answers the same question but also loads the link count,
+// the chunk manifest and the derived path, the last of which walks the parent
+// chain with two point reads per component. Share start reconciles one size per
+// locally-resident file, so on a large store that discarded enrichment is the
+// whole cost.
 //
 // A payload with no pl: index entry reports not-found rather than falling back
 // to the keyspace scan GetFileByPayloadID uses for rows written before that
-// index existed: the open-time scan indexes every such row before any caller
-// runs, so a miss here means no row holds the payload (an orphan journal
-// entry). Only a stale entry — one resolving to a row that no longer claims
-// the payload — takes the slower path, and it does so through
-// GetFileByPayloadID so the answer stays identical.
-func (s *BadgerMetadataStore) FileSizeByPayloadID(ctx context.Context, payloadID metadata.PayloadID) (size uint64, found bool, err error) {
+// index existed: the open-time backfill indexes every such row before any
+// caller runs, so a miss here means no row holds the payload (an orphan journal
+// entry). An index entry that no longer resolves to a row claiming the payload
+// does fall back, and does so through GetFileByPayloadID itself, so the answer
+// stays identical.
+func (s *BadgerMetadataStore) FileSizeByPayloadID(ctx context.Context, payloadID metadata.PayloadID) (uint64, bool, error) {
 	if err := ctx.Err(); err != nil {
 		return 0, false, err
 	}
@@ -499,8 +498,9 @@ func (s *BadgerMetadataStore) FileSizeByPayloadID(ctx context.Context, payloadID
 		return 0, false, nil
 	}
 
-	var stale bool
-	err = s.db.View(func(txn *badgerdb.Txn) error {
+	var size uint64
+	var found, stale bool
+	err := s.db.View(func(txn *badgerdb.Txn) error {
 		item, err := txn.Get(keyPayloadID(payloadID))
 		if errors.Is(err, badgerdb.ErrKeyNotFound) {
 			return nil
@@ -508,12 +508,8 @@ func (s *BadgerMetadataStore) FileSizeByPayloadID(ctx context.Context, payloadID
 		if err != nil {
 			return err
 		}
-		raw, err := item.ValueCopy(nil)
-		if err != nil {
-			return err
-		}
 		var fileID uuid.UUID
-		if err := fileID.UnmarshalBinary(raw); err != nil {
+		if err := item.Value(func(val []byte) error { return fileID.UnmarshalBinary(val) }); err != nil {
 			stale = true
 			return nil
 		}
@@ -527,11 +523,7 @@ func (s *BadgerMetadataStore) FileSizeByPayloadID(ctx context.Context, payloadID
 		}
 		return row.Value(func(val []byte) error {
 			file, err := decodeFile(val)
-			if err != nil {
-				stale = true
-				return nil
-			}
-			if file.PayloadID != payloadID {
+			if err != nil || file.PayloadID != payloadID {
 				stale = true
 				return nil
 			}

--- a/pkg/metadata/store/badger/files.go
+++ b/pkg/metadata/store/badger/files.go
@@ -473,3 +473,88 @@ func (s *BadgerMetadataStore) PutFilesystemMeta(ctx context.Context, shareName s
 		return tx.PutFilesystemMeta(ctx, shareName, meta)
 	})
 }
+
+// FileSizeByPayloadID returns just the persisted logical size of the file
+// carrying payloadID, without the enrichment GetFileByPayloadID performs.
+// found is false when no file row claims the payload.
+//
+// GetFileByPayloadID resolves the row and then loads the link count, the chunk
+// manifest and the derived path — the last of which walks the parent chain,
+// two point reads per component. A caller that only compares sizes pays all of
+// that per file; share start reconciles one size per locally-resident file, so
+// on a large store the discarded enrichment is the whole cost.
+//
+// A payload with no pl: index entry reports not-found rather than falling back
+// to the keyspace scan GetFileByPayloadID uses for rows written before that
+// index existed: the open-time scan indexes every such row before any caller
+// runs, so a miss here means no row holds the payload (an orphan journal
+// entry). Only a stale entry — one resolving to a row that no longer claims
+// the payload — takes the slower path, and it does so through
+// GetFileByPayloadID so the answer stays identical.
+func (s *BadgerMetadataStore) FileSizeByPayloadID(ctx context.Context, payloadID metadata.PayloadID) (size uint64, found bool, err error) {
+	if err := ctx.Err(); err != nil {
+		return 0, false, err
+	}
+	if payloadID == "" {
+		return 0, false, nil
+	}
+
+	var stale bool
+	err = s.db.View(func(txn *badgerdb.Txn) error {
+		item, err := txn.Get(keyPayloadID(payloadID))
+		if errors.Is(err, badgerdb.ErrKeyNotFound) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		raw, err := item.ValueCopy(nil)
+		if err != nil {
+			return err
+		}
+		var fileID uuid.UUID
+		if err := fileID.UnmarshalBinary(raw); err != nil {
+			stale = true
+			return nil
+		}
+		row, err := txn.Get(keyFile(fileID))
+		if errors.Is(err, badgerdb.ErrKeyNotFound) {
+			stale = true
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		return row.Value(func(val []byte) error {
+			file, err := decodeFile(val)
+			if err != nil {
+				stale = true
+				return nil
+			}
+			if file.PayloadID != payloadID {
+				stale = true
+				return nil
+			}
+			size, found = file.Size, true
+			return nil
+		})
+	})
+	if err != nil {
+		return 0, false, err
+	}
+	if !stale {
+		return size, found, nil
+	}
+
+	file, err := s.GetFileByPayloadID(ctx, payloadID)
+	if err != nil {
+		if metadata.IsNotFoundError(err) {
+			return 0, false, nil
+		}
+		return 0, false, err
+	}
+	if file == nil {
+		return 0, false, nil
+	}
+	return file.Size, true, nil
+}

--- a/pkg/metadata/store/badger/payload_index_test.go
+++ b/pkg/metadata/store/badger/payload_index_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // mkPayloadShare creates a share and returns its root handle.
-func mkPayloadShare(t *testing.T, store *BadgerMetadataStore, shareName string) metadata.FileHandle {
+func mkPayloadShare(t testing.TB, store *BadgerMetadataStore, shareName string) metadata.FileHandle {
 	t.Helper()
 	ctx := context.Background()
 	require.NoError(t, store.CreateShare(ctx, &metadata.Share{Name: shareName}))

--- a/pkg/metadata/store/badger/payload_size_test.go
+++ b/pkg/metadata/store/badger/payload_size_test.go
@@ -157,3 +157,24 @@ func BenchmarkSizeByPayloadID(b *testing.B) {
 		}
 	})
 }
+
+// TestFileSizeByPayloadIDResolvesLegacyRows pins the assumption that lets the
+// fast path treat a pl: index miss as "no row holds this payload" instead of
+// scanning: the open-time backfill indexes rows written before that index
+// existed, so by the time any caller runs there is nothing left to scan for. If
+// that ever stopped holding, share start would skip a file whose size needed
+// growing and reads would truncate at the stale size.
+func TestFileSizeByPayloadIDResolvesLegacyRows(t *testing.T) {
+	dir := t.TempDir()
+	want := seedLegacyFiles(t, dir, "legacy-a", "legacy-b")
+
+	store := openStore(t, dir)
+	defer func() { _ = store.Close() }()
+
+	for _, f := range want {
+		size, found, err := store.FileSizeByPayloadID(context.Background(), f.PayloadID)
+		require.NoError(t, err)
+		require.True(t, found, "payload %q not resolved after open", f.PayloadID)
+		require.Equal(t, f.Size, size)
+	}
+}

--- a/pkg/metadata/store/badger/payload_size_test.go
+++ b/pkg/metadata/store/badger/payload_size_test.go
@@ -1,0 +1,159 @@
+package badger
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	badgerdb "github.com/dgraph-io/badger/v4"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// mkNestedFile creates a regular file at the given depth below the share root,
+// materializing the intervening directories, so the derived path
+// GetFileByPayloadID builds has real parent edges to walk.
+func mkNestedFile(t testing.TB, store *BadgerMetadataStore, shareName string, root metadata.FileHandle, depth, idx int, pid metadata.PayloadID, size uint64) {
+	t.Helper()
+	ctx := context.Background()
+
+	dir, path := root, ""
+	for d := 0; d < depth; d++ {
+		name := fmt.Sprintf("d%d_%d", d, idx%8)
+		path += "/" + name
+		h, err := store.GenerateHandle(ctx, shareName, path)
+		require.NoError(t, err)
+		_, id, err := metadata.DecodeFileHandle(h)
+		require.NoError(t, err)
+		f := &metadata.File{ShareName: shareName, Path: path, FileAttr: metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o755}}
+		f.ID = id
+		require.NoError(t, store.UpdateAttrs(ctx, f))
+		require.NoError(t, store.SetParent(ctx, h, dir))
+		require.NoError(t, store.SetChild(ctx, dir, name, h))
+		dir = h
+	}
+
+	name := fmt.Sprintf("f%d", idx)
+	full := path + "/" + name
+	h, err := store.GenerateHandle(ctx, shareName, full)
+	require.NoError(t, err)
+	_, id, err := metadata.DecodeFileHandle(h)
+	require.NoError(t, err)
+	f := &metadata.File{
+		ShareName: shareName,
+		Path:      full,
+		FileAttr:  metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o600, UID: 1000, GID: 1000, PayloadID: pid, Size: size},
+	}
+	f.ID = id
+	require.NoError(t, store.UpdateAttrs(ctx, f))
+	require.NoError(t, store.SetParent(ctx, h, dir))
+	require.NoError(t, store.SetChild(ctx, dir, name, h))
+}
+
+// mkSizeShare mirrors mkPayloadShare but accepts testing.TB so the benchmark
+// can build the same fixture as the test.
+func mkSizeShare(t testing.TB, store *BadgerMetadataStore, shareName string) metadata.FileHandle {
+	t.Helper()
+	ctx := context.Background()
+	require.NoError(t, store.CreateShare(ctx, &metadata.Share{Name: shareName}))
+	rootFile, err := store.CreateRootDirectory(ctx, shareName, &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o755})
+	require.NoError(t, err)
+	h, err := metadata.EncodeFileHandle(rootFile)
+	require.NoError(t, err)
+	return h
+}
+
+func newSizeTestStore(t testing.TB) *BadgerMetadataStore {
+	t.Helper()
+	store, err := NewBadgerMetadataStoreWithDefaults(context.Background(), t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// TestFileSizeByPayloadIDMatchesGetFileByPayloadID pins the fast size lookup to
+// the answer the enriched load gives, across the cases the reconcile hits: a
+// live row, an unknown payload (orphan journal entry), the empty payload, and a
+// stale pl: entry left behind by a row that no longer claims the payload.
+func TestFileSizeByPayloadIDMatchesGetFileByPayloadID(t *testing.T) {
+	ctx := context.Background()
+	store := newSizeTestStore(t)
+	root := mkSizeShare(t, store, "sizes")
+
+	mkNestedFile(t, store, "sizes", root, 4, 0, "payload-live", 4096)
+
+	t.Run("live row", func(t *testing.T) {
+		size, found, err := store.FileSizeByPayloadID(ctx, "payload-live")
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, uint64(4096), size)
+
+		f, err := store.GetFileByPayloadID(ctx, "payload-live")
+		require.NoError(t, err)
+		require.Equal(t, f.Size, size)
+	})
+
+	t.Run("unknown payload", func(t *testing.T) {
+		_, found, err := store.FileSizeByPayloadID(ctx, "payload-absent")
+		require.NoError(t, err)
+		require.False(t, found)
+	})
+
+	t.Run("empty payload", func(t *testing.T) {
+		_, found, err := store.FileSizeByPayloadID(ctx, "")
+		require.NoError(t, err)
+		require.False(t, found)
+	})
+
+	t.Run("stale index entry falls back", func(t *testing.T) {
+		// Point pl:payload-stale at a file ID that has no row: the fast path
+		// must not report not-found on its own, it must ask the enriched load.
+		require.NoError(t, store.db.Update(func(txn *badgerdb.Txn) error {
+			raw, err := uuid.New().MarshalBinary()
+			if err != nil {
+				return err
+			}
+			return txn.Set(keyPayloadID("payload-stale"), raw)
+		}))
+		_, found, err := store.FileSizeByPayloadID(ctx, "payload-stale")
+		require.NoError(t, err)
+		require.False(t, found)
+	})
+}
+
+// BenchmarkSizeByPayloadID contrasts the two reads share start can use to
+// reconcile one file's size. The gap is the enrichment the reconcile discards:
+// the link count, the chunk manifest, and the derived path, which walks the
+// parent chain with two point reads per component.
+func BenchmarkSizeByPayloadID(b *testing.B) {
+	const files = 2000
+	ctx := context.Background()
+	store := newSizeTestStore(b)
+	root := mkSizeShare(b, store, "bench")
+
+	ids := make([]metadata.PayloadID, files)
+	for i := range ids {
+		ids[i] = metadata.PayloadID(fmt.Sprintf("payload-%06d", i))
+		mkNestedFile(b, store, "bench", root, 4, i, ids[i], uint64(i))
+	}
+
+	b.Run("GetFileByPayloadID", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if _, err := store.GetFileByPayloadID(ctx, ids[i%files]); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("FileSizeByPayloadID", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if _, _, err := store.FileSizeByPayloadID(ctx, ids[i%files]); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/pkg/metadata/store/badger/payload_size_test.go
+++ b/pkg/metadata/store/badger/payload_size_test.go
@@ -52,19 +52,6 @@ func mkNestedFile(t testing.TB, store *BadgerMetadataStore, shareName string, ro
 	require.NoError(t, store.SetChild(ctx, dir, name, h))
 }
 
-// mkSizeShare mirrors mkPayloadShare but accepts testing.TB so the benchmark
-// can build the same fixture as the test.
-func mkSizeShare(t testing.TB, store *BadgerMetadataStore, shareName string) metadata.FileHandle {
-	t.Helper()
-	ctx := context.Background()
-	require.NoError(t, store.CreateShare(ctx, &metadata.Share{Name: shareName}))
-	rootFile, err := store.CreateRootDirectory(ctx, shareName, &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o755})
-	require.NoError(t, err)
-	h, err := metadata.EncodeFileHandle(rootFile)
-	require.NoError(t, err)
-	return h
-}
-
 func newSizeTestStore(t testing.TB) *BadgerMetadataStore {
 	t.Helper()
 	store, err := NewBadgerMetadataStoreWithDefaults(context.Background(), t.TempDir())
@@ -80,7 +67,7 @@ func newSizeTestStore(t testing.TB) *BadgerMetadataStore {
 func TestFileSizeByPayloadIDMatchesGetFileByPayloadID(t *testing.T) {
 	ctx := context.Background()
 	store := newSizeTestStore(t)
-	root := mkSizeShare(t, store, "sizes")
+	root := mkPayloadShare(t, store, "sizes")
 
 	mkNestedFile(t, store, "sizes", root, 4, 0, "payload-live", 4096)
 
@@ -131,7 +118,7 @@ func BenchmarkSizeByPayloadID(b *testing.B) {
 	const files = 2000
 	ctx := context.Background()
 	store := newSizeTestStore(b)
-	root := mkSizeShare(b, store, "bench")
+	root := mkPayloadShare(b, store, "bench")
 
 	ids := make([]metadata.PayloadID, files)
 	for i := range ids {

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -624,13 +624,13 @@ func (s *BadgerMetadataStore) GetUsedBytesForShare(ctx context.Context, shareNam
 // still needs indexing by payload pays one scan at open rather than two — the
 // decode is the expensive part and this is the only place already doing it.
 //
-// ponytail: one serial decode pass over every file row, ~470 ns each (see
-// BenchmarkInitUsedBytesCounter), so a ten-million-file store spends seconds
-// here before the first share opens. Persisting the buckets would remove the
-// pass entirely but has to answer for their consistency after a crash, and
-// badger's Stream would parallelize the decode at the cost of merging partial
-// sums; do either only once this pass, and not the per-share work around it,
-// is what a start is waiting on.
+// ponytail: one serial decode pass over every file row, so a ten-million-file
+// store spends seconds here before the first share opens
+// (BenchmarkInitUsedBytesCounter reports the per-file cost). Persisting the
+// buckets would remove the pass entirely but has to answer for their
+// consistency after a crash, and badger's Stream would parallelize the decode
+// at the cost of merging partial sums; do either only once this pass, and not
+// the per-share work around it, is what a start is waiting on.
 func (s *BadgerMetadataStore) initUsedBytesCounter(indexBatch *badger.WriteBatch) error {
 	byIdentity := make(map[basestore.QuotaKey]*metadata.UsageStat)
 

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -623,6 +623,14 @@ func (s *BadgerMetadataStore) GetUsedBytesForShare(ctx context.Context, shareNam
 // A non-nil indexBatch also stages a pl: index entry per file, so a store that
 // still needs indexing by payload pays one scan at open rather than two — the
 // decode is the expensive part and this is the only place already doing it.
+//
+// ponytail: one serial decode pass over every file row, ~470 ns each (see
+// BenchmarkInitUsedBytesCounter), so a ten-million-file store spends seconds
+// here before the first share opens. Persisting the buckets would remove the
+// pass entirely but has to answer for their consistency after a crash, and
+// badger's Stream would parallelize the decode at the cost of merging partial
+// sums; do either only once this pass, and not the per-share work around it,
+// is what a start is waiting on.
 func (s *BadgerMetadataStore) initUsedBytesCounter(indexBatch *badger.WriteBatch) error {
 	byIdentity := make(map[basestore.QuotaKey]*metadata.UsageStat)
 

--- a/pkg/metadata/store/badger/usedbytes_bench_test.go
+++ b/pkg/metadata/store/badger/usedbytes_bench_test.go
@@ -1,0 +1,48 @@
+package badger
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// BenchmarkInitUsedBytesCounter measures the open-time file scan that seeds the
+// usage cache. It decodes every file row, so it is the second of the two
+// file-count-proportional steps a share start pays before it becomes visible.
+func BenchmarkInitUsedBytesCounter(b *testing.B) {
+	const files = 50000
+	ctx := context.Background()
+	store := newSizeTestStore(b)
+	require.NoError(b, store.CreateShare(ctx, &metadata.Share{Name: "bench"}))
+
+	for i := 0; i < files; i++ {
+		path := fmt.Sprintf("/f%06d", i)
+		h, err := store.GenerateHandle(ctx, "bench", path)
+		require.NoError(b, err)
+		_, id, err := metadata.DecodeFileHandle(h)
+		require.NoError(b, err)
+		f := &metadata.File{
+			ShareName: "bench",
+			Path:      path,
+			FileAttr: metadata.FileAttr{
+				Type: metadata.FileTypeRegular, Mode: 0o600, UID: uint32(i % 32), GID: uint32(i % 8),
+				PayloadID: metadata.PayloadID(fmt.Sprintf("payload-%06d", i)), Size: uint64(i),
+			},
+		}
+		f.ID = id
+		require.NoError(b, store.UpdateAttrs(ctx, f))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := store.initUsedBytesCounter(nil); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*files), "ns/file")
+}


### PR DESCRIPTION
Closes #2075.

## What was actually wrong

Share start reconciles every locally-resident file's metadata size against the
journal's durable high-water mark, before the share becomes visible. The
comparison needs one number — `File.Size` — but it went through
`GetFileByPayloadID`, which returns a fully enriched file: the link count from a
separate key, the chunk manifest from `fm:`, and the derived path, which walks
the parent chain doing **two point reads per component**. A file four
directories deep therefore cost roughly ten Badger reads plus a manifest decode
to answer a size comparison, and every one of those extra reads was thrown away.

That is what made the reconcile the dominant startup term: 26 µs per file
measured on a 4-vCPU VM, about 4.3 minutes before a 10M-file share is visible.

## The fix

- `BadgerMetadataStore.FileSizeByPayloadID` resolves the `pl:` index straight to
  the row and decodes only the size.
- The reconcile takes it through a narrow optional interface, falling back to
  the enriched load for stores that do not offer it (postgres, sqlite, memory —
  behaviour there is unchanged).
- The scan is read-only and order-free, so it is split across workers, with the
  rare size-growing transactions still applied serially afterwards.

## Why the index miss can be treated as "no such row"

The fast path reports not-found on a `pl:` miss instead of falling back to the
legacy keyspace scan. That is safe because the open-time backfill indexes every
row carrying a payload before any caller runs, so a miss means no row holds the
payload — an orphan journal entry, which the old code also skipped, just after
paying for a full scan first. A *stale* entry (one resolving to a row that no
longer claims the payload) still goes through `GetFileByPayloadID`, so the
answer is identical there.

`TestFileSizeByPayloadIDResolvesLegacyRows` pins that assumption directly: it
seeds unindexed rows through a raw Badger handle, opens the store, and asserts
the fast path resolves them. If the backfill ever stopped covering a row, share
start would skip a file whose size needed growing and reads would truncate — so
the assumption is worth a test of its own rather than a comment.

## Evidence

`BenchmarkShareStartSizeScan`, 5000 files four directories deep, M1 Max:

| scan | ns/file | allocs (5000 files) |
| --- | --- | --- |
| enriched, serial (before) | 16731 | 835019 |
| enriched, parallel | 7272 | 825076 |
| size-only, parallel (after) | 2009 | 115678 |

**8.3× on the path that dominates share start**, and 7.2× fewer allocations.
The single lookup alone accounts for most of it — `BenchmarkSizeByPayloadID`
puts `GetFileByPayloadID` at 20477 ns and `FileSizeByPayloadID` at 2442 ns on
the same rows. Scaling the field measurement, a 10M-file share start goes from
~4.3 min to roughly half a minute on the same 4-vCPU hardware.

`TestFlushRelaxed_CrashBeforeMetadataFsync_SizeReconciled` — the crash-safety
test the reconcile exists for — still passes on all four backends, badger
included, so the cheaper read still grows a size the crash left stale.

## What this does not fix

The other file-count-proportional step is still there: the open-time scan that
seeds the usage cache, which decodes every file row. `BenchmarkInitUsedBytesCounter`
now records it (0.5–1.2 µs/file here depending on load; 1.9 µs measured on the
4-vCPU VM, so roughly 19 s at 10M). It is left alone deliberately, with a `ponytail:` marker naming the
ceiling: removing it means either persisting the usage buckets — which then has
to answer for their consistency after a crash — or parallelising the decode and
merging partial sums. Neither is worth doing while it is no longer what a start
waits on, and unlike the reconcile it runs once per metadata store rather than
once per share.
