### PR TITLE
test(dfsbench): capture the evidence a failed cold barrier needs

### DIFF
--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -662,15 +662,29 @@ const dittofsBarrierLogTailBytes = 256 << 10
 
 // dittofsBarrierDiag collects what the bare "local disk only fell X→Y" error
 // throws away: the full block-store stats JSON at each step, what the evict
-// reported freeing, and the server log written while the barrier ran. Fields
-// left empty mark steps the barrier never reached, which is itself part of the
-// answer.
+// reported freeing, and the server log written while the barrier ran. A step
+// left empty is one the barrier never reached, which is itself part of the
+// answer — a step that was reached but whose capture failed carries the note
+// dittofsCapture built for it, so the two never read alike.
 type dittofsBarrierDiag struct {
 	logOffset int64  // server-log size when the barrier started
-	entry     []byte // stats before the drain — the "before" the ratio is measured against
-	postDrain []byte // stats after the drain loop, i.e. immediately before the evict
-	evictOut  []byte // `store block evict -o json`: files evicted, bytes freed
-	postEvict []byte // stats after the evict — the "after" of the ratio
+	entry     string // stats before the drain — the "before" the ratio is measured against
+	postDrain string // stats after the drain loop, i.e. immediately before the evict
+	evictOut  string // `store block evict -o json`: files evicted, bytes freed
+	postEvict string // stats after the evict — the "after" of the ratio
+}
+
+// dittofsCapture renders one captured command output for the dump: the output
+// itself, or a note naming the error when the capture failed. An empty string is
+// reserved for a step the barrier never reached.
+func dittofsCapture(out []byte, err error) string {
+	if err != nil {
+		return fmt.Sprintf("(capture failed: %v)", err)
+	}
+	if s := strings.TrimSpace(string(out)); s != "" {
+		return s
+	}
+	return "(command produced no output)"
 }
 
 // dump prints the collected evidence to the run log, which is pulled back off
@@ -679,19 +693,18 @@ func (d *dittofsBarrierDiag) dump(cause error) {
 	_, _ = fmt.Fprintf(exec.CmdOut, "cold barrier diagnostics — %v\n", cause)
 	for _, step := range []struct {
 		label string
-		raw   []byte
+		text  string
 	}{
 		{"block stats at barrier entry", d.entry},
 		{"block stats after drain (pre-evict)", d.postDrain},
 		{"evict result", d.evictOut},
 		{"block stats after evict", d.postEvict},
 	} {
-		raw := strings.TrimSpace(string(step.raw))
-		if raw == "" {
-			_, _ = fmt.Fprintf(exec.CmdOut, "  %s: not reached\n", step.label)
-			continue
+		text := step.text
+		if text == "" {
+			text = "not reached"
 		}
-		_, _ = fmt.Fprintf(exec.CmdOut, "  %s: %s\n", step.label, raw)
+		_, _ = fmt.Fprintf(exec.CmdOut, "  %s: %s\n", step.label, text)
 	}
 	_, _ = fmt.Fprintf(exec.CmdOut, "  surviving local tier: %s\n", dittofsResidentFiles(dittofsDataDir+"/blocks"))
 	_, _ = fmt.Fprintf(exec.CmdOut, "  server log (%s) since barrier entry:\n%s\n",
@@ -721,13 +734,21 @@ func dittofsResidentFiles(dir string) string {
 	}
 	var files []entry
 	var total int64
-	// The callback swallows every error, so the walk itself cannot fail.
+	unreadable := 0
+	// The callback swallows every error so one bad subtree costs a line of the
+	// sample rather than the whole dump, but it counts them: a partial scan that
+	// printed as a complete one would misdescribe the tier the barrier left behind.
 	_ = filepath.WalkDir(dir, func(path string, e os.DirEntry, err error) error {
-		if err != nil || e.IsDir() {
-			return nil //nolint:nilerr // an unreadable subtree costs one line of the sample, not the dump
+		if err != nil {
+			unreadable++
+			return nil //nolint:nilerr // counted above and reported below, not silently dropped
+		}
+		if e.IsDir() {
+			return nil
 		}
 		info, err := e.Info()
 		if err != nil {
+			unreadable++
 			return nil //nolint:nilerr // ditto
 		}
 		files = append(files, entry{strings.TrimPrefix(path, dir+"/"), info.Size()})
@@ -735,6 +756,9 @@ func dittofsResidentFiles(dir string) string {
 		return nil
 	})
 	if len(files) == 0 {
+		if unreadable > 0 {
+			return fmt.Sprintf("(unreadable: %d entries under %s could not be scanned)", unreadable, dir)
+		}
 		return fmt.Sprintf("%s is empty", dir)
 	}
 	sort.Slice(files, func(i, j int) bool { return files[i].size > files[j].size })
@@ -745,6 +769,9 @@ func dittofsResidentFiles(dir string) string {
 	}
 	if len(files) > dittofsResidentSampleFiles {
 		fmt.Fprintf(&b, " (+%d more)", len(files)-dittofsResidentSampleFiles)
+	}
+	if unreadable > 0 {
+		fmt.Fprintf(&b, "; %d entries unreadable, so the totals are a floor", unreadable)
 	}
 	return b.String()
 }
@@ -781,7 +808,9 @@ func dittofsLogSince(path string, off int64) string {
 	if _, err := f.Seek(start, io.SeekStart); err != nil {
 		return fmt.Sprintf("(unreadable: %v)", err)
 	}
-	b, err := io.ReadAll(f)
+	// Cap the read itself, not just the seek: the file can grow between the Stat
+	// above and this read, and a busy server would otherwise flood the run log.
+	b, err := io.ReadAll(io.LimitReader(f, dittofsBarrierLogTailBytes))
 	if len(b) == 0 && err != nil {
 		return fmt.Sprintf("(unreadable: %v)", err)
 	}
@@ -817,7 +846,7 @@ func dittofsColdBarrier(ctx context.Context, diag *dittofsBarrierDiag) error {
 	// DiskWr/NetRx meter exposed: cold pulled only ~15-33 MB/s from S3 while the
 	// data sat on the block volume).
 	raw, before, err := dittofsBlockStatsRaw(ctx)
-	diag.entry = raw
+	diag.entry = dittofsCapture(raw, err)
 	if err != nil {
 		return err
 	}
@@ -827,7 +856,8 @@ func dittofsColdBarrier(ctx context.Context, diag *dittofsBarrierDiag) error {
 	// Sample between the drain and the evict: this separates "the drain left bytes
 	// the evict was right to refuse" from "the evict declined bytes the drain had
 	// already made durable" — which the before/after pair alone cannot tell apart.
-	diag.postDrain, _, err = dittofsBlockStatsRaw(ctx)
+	raw, _, err = dittofsBlockStatsRaw(ctx)
+	diag.postDrain = dittofsCapture(raw, err)
 	if err != nil {
 		return err
 	}
@@ -836,12 +866,12 @@ func dittofsColdBarrier(ctx context.Context, diag *dittofsBarrierDiag) error {
 	// result rather than the success line: bytes_freed says directly whether the
 	// evict declined to drop anything or dropped bytes that came back.
 	evictOut, err := exec.Out(ctx, "dfsctl", "store", "block", "evict", "-o", "json")
-	diag.evictOut = evictOut
+	diag.evictOut = dittofsCapture(evictOut, err)
 	if err != nil {
 		return fmt.Errorf("dfsctl store block evict: %w", err)
 	}
 	raw, after, err := dittofsBlockStatsRaw(ctx)
-	diag.postEvict = raw
+	diag.postEvict = dittofsCapture(raw, err)
 	if err != nil {
 		return err
 	}

--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -1,7 +1,6 @@
 package backend
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -485,12 +484,11 @@ func dittofsBlockStats(ctx context.Context) (dittofsBlockTotals, error) {
 	return totals, err
 }
 
-// dittofsBlockStatsRaw returns the parsed totals alongside the untouched JSON
-// the server produced. dittofsBlockTotals keeps three fields; the response also
-// carries eviction_suspended, remote_healthy, failed_syncs, outage_duration_secs
-// and the per-state block counts — the fields that say WHY an evict declined to
-// drop anything. The cold barrier keeps the raw bytes so a failure can print
-// them instead of the three numbers that only restate the symptom.
+// dittofsBlockStatsRaw returns the parsed totals alongside the untouched JSON.
+// dittofsBlockTotals keeps three fields; the response also carries
+// eviction_suspended, remote_healthy, failed_syncs and the per-state block
+// counts — the fields that say WHY an evict declined to drop anything. The cold
+// barrier keeps the raw bytes so a failure can print those too.
 func dittofsBlockStatsRaw(ctx context.Context) ([]byte, dittofsBlockTotals, error) {
 	out, err := exec.Out(ctx, "dfsctl", "store", "block", "stats", "-o", "json")
 	if err != nil {
@@ -662,11 +660,11 @@ func dittofsReportDrainProgress(ctx context.Context, round int) func() {
 // first bytes after the barrier started.
 const dittofsBarrierLogTailBytes = 256 << 10
 
-// dittofsBarrierDiag collects what a cold-barrier failure needs and what the
-// bare "local disk only fell X→Y" error throws away: the full block-store stats
-// JSON at each step, what the evict itself reported freeing, and the server log
-// written while the barrier ran. Fields left empty mark steps the barrier never
-// reached, which is itself part of the answer.
+// dittofsBarrierDiag collects what the bare "local disk only fell X→Y" error
+// throws away: the full block-store stats JSON at each step, what the evict
+// reported freeing, and the server log written while the barrier ran. Fields
+// left empty mark steps the barrier never reached, which is itself part of the
+// answer.
 type dittofsBarrierDiag struct {
 	logOffset int64  // server-log size when the barrier started
 	entry     []byte // stats before the drain — the "before" the ratio is measured against
@@ -688,8 +686,8 @@ func (d *dittofsBarrierDiag) dump(cause error) {
 		{"evict result", d.evictOut},
 		{"block stats after evict", d.postEvict},
 	} {
-		raw := bytes.TrimSpace(step.raw)
-		if len(raw) == 0 {
+		raw := strings.TrimSpace(string(step.raw))
+		if raw == "" {
 			_, _ = fmt.Fprintf(exec.CmdOut, "  %s: not reached\n", step.label)
 			continue
 		}
@@ -709,9 +707,8 @@ const dittofsResidentSampleFiles = 20
 // stats JSON reports only an aggregate byte count, which cannot distinguish a
 // remainder made of whole journal segments (eviction's unit is a segment, so one
 // unsynced record keeps its entire segment resident) from one spread thinly
-// across many files. The shape of the surviving set is what tells those apart.
-// Best-effort: it explains a barrier that already failed and never adds a second
-// failure, so every error becomes a parenthesised note.
+// across many files. Best-effort: it explains a barrier that already failed and
+// must never add a second one, so every error becomes a parenthesised note.
 func dittofsResidentFiles(dir string) string {
 	type entry struct {
 		name string
@@ -724,7 +721,8 @@ func dittofsResidentFiles(dir string) string {
 	}
 	var files []entry
 	var total int64
-	err := filepath.WalkDir(dir, func(path string, e os.DirEntry, err error) error {
+	// The callback swallows every error, so the walk itself cannot fail.
+	_ = filepath.WalkDir(dir, func(path string, e os.DirEntry, err error) error {
 		if err != nil || e.IsDir() {
 			return nil //nolint:nilerr // an unreadable subtree costs one line of the sample, not the dump
 		}
@@ -732,17 +730,10 @@ func dittofsResidentFiles(dir string) string {
 		if err != nil {
 			return nil //nolint:nilerr // ditto
 		}
-		rel, relErr := filepath.Rel(dir, path)
-		if relErr != nil {
-			rel = path
-		}
-		files = append(files, entry{rel, info.Size()})
+		files = append(files, entry{strings.TrimPrefix(path, dir+"/"), info.Size()})
 		total += info.Size()
 		return nil
 	})
-	if err != nil {
-		return fmt.Sprintf("(unreadable: %v)", err)
-	}
 	if len(files) == 0 {
 		return fmt.Sprintf("%s is empty", dir)
 	}
@@ -786,10 +777,7 @@ func dittofsLogSince(path string, off int64) string {
 	if st.Size() <= off {
 		return "(the server logged nothing while the barrier ran)"
 	}
-	start := off
-	if tail := st.Size() - dittofsBarrierLogTailBytes; tail > start {
-		start = tail
-	}
+	start := max(off, st.Size()-dittofsBarrierLogTailBytes)
 	if _, err := f.Seek(start, io.SeekStart); err != nil {
 		return fmt.Sprintf("(unreadable: %v)", err)
 	}
@@ -801,9 +789,8 @@ func dittofsLogSince(path string, off int64) string {
 }
 
 // dittofsEvict drops locally-cached blocks so the next read is cold-from-S3, and
-// on any failure prints the evidence needed to explain it. The barrier has fired
-// once in the field with nothing recorded beyond the two byte counts in its own
-// error message, which say the local tier did not empty but not why.
+// on any failure prints the evidence explaining it. The barrier's own error
+// carries two byte counts, which say the local tier did not empty but not why.
 func dittofsEvict(ctx context.Context) error {
 	diag := dittofsBarrierDiag{logOffset: dittofsLogSize(dittofsServerLog)}
 	err := dittofsColdBarrier(ctx, &diag)
@@ -837,18 +824,17 @@ func dittofsColdBarrier(ctx context.Context, diag *dittofsBarrierDiag) error {
 	if err := dittofsDrainUntilSynced(ctx); err != nil {
 		return err
 	}
-	// Sample again between the drain and the evict. This is the sample that
-	// separates "the drain left bytes the evict was right to refuse" from "the
-	// evict declined bytes the drain had already made durable" — the two
-	// explanations the post-hoc pair of byte counts cannot tell apart.
+	// Sample between the drain and the evict: this separates "the drain left bytes
+	// the evict was right to refuse" from "the evict declined bytes the drain had
+	// already made durable" — which the before/after pair alone cannot tell apart.
 	diag.postDrain, _, err = dittofsBlockStatsRaw(ctx)
 	if err != nil {
 		return err
 	}
 	// Evict local blocks + read buffer. DrainLocalSynced drops only synced blocks;
 	// now that everything is synced it can drop the whole file. Take the JSON
-	// result rather than the success line: bytes_freed is the direct answer to
-	// whether the evict declined to drop anything or dropped bytes that came back.
+	// result rather than the success line: bytes_freed says directly whether the
+	// evict declined to drop anything or dropped bytes that came back.
 	evictOut, err := exec.Out(ctx, "dfsctl", "store", "block", "evict", "-o", "json")
 	diag.evictOut = evictOut
 	if err != nil {

--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -751,7 +751,7 @@ func dittofsResidentFiles(dir string) string {
 			unreadable++
 			return nil //nolint:nilerr // ditto
 		}
-		files = append(files, entry{strings.TrimPrefix(path, dir+"/"), info.Size()})
+		files = append(files, entry{strings.TrimPrefix(path, dir+string(os.PathSeparator)), info.Size()})
 		total += info.Size()
 		return nil
 	})

--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -717,6 +717,11 @@ func dittofsResidentFiles(dir string) string {
 		name string
 		size int64
 	}
+	if _, err := os.Stat(dir); err != nil {
+		// Distinguish "the tier emptied" from "the directory is not there" — the
+		// dump is read by someone deciding whether the evict worked.
+		return fmt.Sprintf("(unreadable: %v)", err)
+	}
 	var files []entry
 	var total int64
 	err := filepath.WalkDir(dir, func(path string, e os.DirEntry, err error) error {

--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -1,9 +1,11 @@
 package backend
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -96,6 +98,11 @@ const (
 // cache (/blocks). It lives on the isolated data volume when one is mounted,
 // else the legacy root-disk path.
 var dittofsDataDir = benchPath("/var/lib/bench-dittofs", "dittofs")
+
+// dittofsServerLog is where dittofsSetup redirects the benched server's stdout
+// and stderr. The cold barrier reads back the window it wrote while running, so
+// a barrier failure carries the server's own account of it.
+const dittofsServerLog = "/var/log/bench-dittofs.log"
 
 // dittofsMetaKind selects the metadata-store engine. The block store (fs local
 // cache + S3 remote) is identical across all three, so a badger/sqlite/postgres
@@ -333,7 +340,7 @@ func dittofsSetup(ctx context.Context, env BackendEnv, kind dittofsMetaKind, dur
 	// regardless of the binary's default, so log volume is uniform across A/B runs
 	// (belt-and-suspenders alongside #1738 demoting per-op logs to Debug).
 	start := fmt.Sprintf("DITTOFS_LOGGING_LEVEL=WARN DITTOFS_CONTROLPLANE_SECRET=%s DITTOFS_ADMIN_INITIAL_PASSWORD=%s "+
-		"dfs start >/var/log/bench-dittofs.log 2>&1 &", dittofsSecret, dittofsAdminPass)
+		"dfs start >"+dittofsServerLog+" 2>&1 &", dittofsSecret, dittofsAdminPass)
 	if err := exec.Sh(ctx, "sh", "-c", start); err != nil {
 		return err
 	}
@@ -458,14 +465,6 @@ func dittofsMount(ctx context.Context, proto Protocol) (string, error) {
 	return "", err
 }
 
-// dittofsEvict drops locally-cached blocks so the next read is cold-from-S3.
-// #1595's DrainLocalSynced is what makes `store block evict` actually force it.
-//
-// Drain queued uploads FIRST: `store block evict` (DrainLocalSynced) only drops
-// blocks already synced to S3. A block whose upload is still in flight is left
-// on local disk, so the "cold" read serves it from cache — the pass reads warm,
-// S3MB stays 0, and cold≈warm. Draining first makes every block synced and
-// therefore evictable, so the next read genuinely comes from S3.
 // dittofsColdBarrierFloorBytes is the resident-bytes threshold below which the
 // cold-barrier verification stops caring about an exact drop ratio — small
 // datasets and metadata slack shouldn't fail the check.
@@ -481,17 +480,28 @@ type dittofsBlockTotals struct {
 }
 
 func dittofsBlockStats(ctx context.Context) (dittofsBlockTotals, error) {
+	_, totals, err := dittofsBlockStatsRaw(ctx)
+	return totals, err
+}
+
+// dittofsBlockStatsRaw returns the parsed totals alongside the untouched JSON
+// the server produced. dittofsBlockTotals keeps three fields; the response also
+// carries eviction_suspended, remote_healthy, failed_syncs, outage_duration_secs
+// and the per-state block counts — the fields that say WHY an evict declined to
+// drop anything. The cold barrier keeps the raw bytes so a failure can print
+// them instead of the three numbers that only restate the symptom.
+func dittofsBlockStatsRaw(ctx context.Context) ([]byte, dittofsBlockTotals, error) {
 	out, err := exec.Out(ctx, "dfsctl", "store", "block", "stats", "-o", "json")
 	if err != nil {
-		return dittofsBlockTotals{}, fmt.Errorf("dfsctl store block stats: %w", err)
+		return nil, dittofsBlockTotals{}, fmt.Errorf("dfsctl store block stats: %w", err)
 	}
 	var resp struct {
 		Totals dittofsBlockTotals `json:"totals"`
 	}
 	if err := json.Unmarshal(out, &resp); err != nil {
-		return dittofsBlockTotals{}, fmt.Errorf("parse block stats json: %w\n%s", err, out)
+		return out, dittofsBlockTotals{}, fmt.Errorf("parse block stats json: %w\n%s", err, out)
 	}
-	return resp.Totals, nil
+	return out, resp.Totals, nil
 }
 
 // dittofsSettleTimeout bounds how long the warm-read settle waits for the block
@@ -645,25 +655,147 @@ func dittofsReportDrainProgress(ctx context.Context, round int) func() {
 	}
 }
 
+// dittofsBarrierLogTailBytes caps how much server log a failed cold barrier
+// reproduces. The barrier can run for minutes across many drain rounds, so it
+// keeps the most recent output — the window around the failure — rather than the
+// first bytes after the barrier started.
+const dittofsBarrierLogTailBytes = 256 << 10
+
+// dittofsBarrierDiag collects what a cold-barrier failure needs and what the
+// bare "local disk only fell X→Y" error throws away: the full block-store stats
+// JSON at each step, what the evict itself reported freeing, and the server log
+// written while the barrier ran. Fields left empty mark steps the barrier never
+// reached, which is itself part of the answer.
+type dittofsBarrierDiag struct {
+	logOffset int64  // server-log size when the barrier started
+	entry     []byte // stats before the drain — the "before" the ratio is measured against
+	postDrain []byte // stats after the drain loop, i.e. immediately before the evict
+	evictOut  []byte // `store block evict -o json`: files evicted, bytes freed
+	postEvict []byte // stats after the evict — the "after" of the ratio
+}
+
+// dump prints the collected evidence to the run log, which is pulled back off
+// the bench VM with the results. cause is the failure being explained.
+func (d *dittofsBarrierDiag) dump(cause error) {
+	_, _ = fmt.Fprintf(exec.CmdOut, "cold barrier diagnostics — %v\n", cause)
+	for _, step := range []struct {
+		label string
+		raw   []byte
+	}{
+		{"block stats at barrier entry", d.entry},
+		{"block stats after drain (pre-evict)", d.postDrain},
+		{"evict result", d.evictOut},
+		{"block stats after evict", d.postEvict},
+	} {
+		raw := bytes.TrimSpace(step.raw)
+		if len(raw) == 0 {
+			_, _ = fmt.Fprintf(exec.CmdOut, "  %s: not reached\n", step.label)
+			continue
+		}
+		_, _ = fmt.Fprintf(exec.CmdOut, "  %s: %s\n", step.label, raw)
+	}
+	_, _ = fmt.Fprintf(exec.CmdOut, "  server log (%s) since barrier entry:\n%s\n",
+		dittofsServerLog, dittofsLogSince(dittofsServerLog, d.logOffset))
+}
+
+// dittofsLogSize reports the current size of path, or 0 when it cannot be
+// stat'd. A wrong offset only widens the window the failure dump prints, so this
+// never fails the barrier.
+func dittofsLogSize(path string) int64 {
+	st, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	return st.Size()
+}
+
+// dittofsLogSince returns the bytes of path written after offset off, keeping at
+// most dittofsBarrierLogTailBytes of the most recent output. It returns a
+// parenthesised note rather than an error for every failure: this runs only to
+// explain a barrier that already failed, and must never become a second failure.
+func dittofsLogSince(path string, off int64) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Sprintf("(unreadable: %v)", err)
+	}
+	defer func() { _ = f.Close() }()
+	st, err := f.Stat()
+	if err != nil {
+		return fmt.Sprintf("(unreadable: %v)", err)
+	}
+	if st.Size() <= off {
+		return "(the server logged nothing while the barrier ran)"
+	}
+	start := off
+	if tail := st.Size() - dittofsBarrierLogTailBytes; tail > start {
+		start = tail
+	}
+	if _, err := f.Seek(start, io.SeekStart); err != nil {
+		return fmt.Sprintf("(unreadable: %v)", err)
+	}
+	b, err := io.ReadAll(f)
+	if len(b) == 0 && err != nil {
+		return fmt.Sprintf("(unreadable: %v)", err)
+	}
+	return string(b)
+}
+
+// dittofsEvict drops locally-cached blocks so the next read is cold-from-S3, and
+// on any failure prints the evidence needed to explain it. The barrier has fired
+// once in the field with nothing recorded beyond the two byte counts in its own
+// error message, which say the local tier did not empty but not why.
 func dittofsEvict(ctx context.Context) error {
+	diag := dittofsBarrierDiag{logOffset: dittofsLogSize(dittofsServerLog)}
+	err := dittofsColdBarrier(ctx, &diag)
+	if err != nil {
+		diag.dump(err)
+	}
+	return err
+}
+
+// dittofsColdBarrier drains, evicts and then verifies that the local tier
+// actually emptied.
+//
+// The drain comes FIRST: `store block evict` drops only blocks already synced to
+// S3. A block whose upload is still in flight is left on local disk, so the
+// "cold" read serves it from cache — the pass reads warm, S3MB stays 0, and
+// cold≈warm. Draining first makes every block synced and therefore evictable, so
+// the next read genuinely comes from S3.
+//
+// diag accumulates the evidence for the failure dump as each step completes.
+func dittofsColdBarrier(ctx context.Context, diag *dittofsBarrierDiag) error {
 	// Cold-read barrier. Force the whole warm-written file durable on S3, evict the
 	// local tier, then VERIFY it actually emptied — otherwise the cold pass reads
 	// locally-resident bytes and silently measures a warm read (the confound the
 	// DiskWr/NetRx meter exposed: cold pulled only ~15-33 MB/s from S3 while the
 	// data sat on the block volume).
-	before, err := dittofsBlockStats(ctx)
+	raw, before, err := dittofsBlockStatsRaw(ctx)
+	diag.entry = raw
 	if err != nil {
 		return err
 	}
 	if err := dittofsDrainUntilSynced(ctx); err != nil {
 		return err
 	}
+	// Sample again between the drain and the evict. This is the sample that
+	// separates "the drain left bytes the evict was right to refuse" from "the
+	// evict declined bytes the drain had already made durable" — the two
+	// explanations the post-hoc pair of byte counts cannot tell apart.
+	diag.postDrain, _, err = dittofsBlockStatsRaw(ctx)
+	if err != nil {
+		return err
+	}
 	// Evict local blocks + read buffer. DrainLocalSynced drops only synced blocks;
-	// now that everything is synced it can drop the whole file.
-	if err := exec.Sh(ctx, "dfsctl", "store", "block", "evict"); err != nil {
+	// now that everything is synced it can drop the whole file. Take the JSON
+	// result rather than the success line: bytes_freed is the direct answer to
+	// whether the evict declined to drop anything or dropped bytes that came back.
+	evictOut, err := exec.Out(ctx, "dfsctl", "store", "block", "evict", "-o", "json")
+	diag.evictOut = evictOut
+	if err != nil {
 		return fmt.Errorf("dfsctl store block evict: %w", err)
 	}
-	after, err := dittofsBlockStats(ctx)
+	raw, after, err := dittofsBlockStatsRaw(ctx)
+	diag.postEvict = raw
 	if err != nil {
 		return err
 	}

--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -694,8 +695,62 @@ func (d *dittofsBarrierDiag) dump(cause error) {
 		}
 		_, _ = fmt.Fprintf(exec.CmdOut, "  %s: %s\n", step.label, raw)
 	}
+	_, _ = fmt.Fprintf(exec.CmdOut, "  surviving local tier: %s\n", dittofsResidentFiles(dittofsDataDir+"/blocks"))
 	_, _ = fmt.Fprintf(exec.CmdOut, "  server log (%s) since barrier entry:\n%s\n",
 		dittofsServerLog, dittofsLogSince(dittofsServerLog, d.logOffset))
+}
+
+// dittofsResidentSampleFiles is how many of the largest surviving files the
+// failure dump names.
+const dittofsResidentSampleFiles = 20
+
+// dittofsResidentFiles summarises what is still on the local tier under dir: the
+// file count, their total size, and the largest few by name and size. The block
+// stats JSON reports only an aggregate byte count, which cannot distinguish a
+// remainder made of whole journal segments (eviction's unit is a segment, so one
+// unsynced record keeps its entire segment resident) from one spread thinly
+// across many files. The shape of the surviving set is what tells those apart.
+// Best-effort: it explains a barrier that already failed and never adds a second
+// failure, so every error becomes a parenthesised note.
+func dittofsResidentFiles(dir string) string {
+	type entry struct {
+		name string
+		size int64
+	}
+	var files []entry
+	var total int64
+	err := filepath.WalkDir(dir, func(path string, e os.DirEntry, err error) error {
+		if err != nil || e.IsDir() {
+			return nil //nolint:nilerr // an unreadable subtree costs one line of the sample, not the dump
+		}
+		info, err := e.Info()
+		if err != nil {
+			return nil //nolint:nilerr // ditto
+		}
+		rel, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			rel = path
+		}
+		files = append(files, entry{rel, info.Size()})
+		total += info.Size()
+		return nil
+	})
+	if err != nil {
+		return fmt.Sprintf("(unreadable: %v)", err)
+	}
+	if len(files) == 0 {
+		return fmt.Sprintf("%s is empty", dir)
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].size > files[j].size })
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d files, %dMiB total; largest:", len(files), total>>20)
+	for _, f := range files[:min(len(files), dittofsResidentSampleFiles)] {
+		fmt.Fprintf(&b, " %s=%dMiB", f.name, f.size>>20)
+	}
+	if len(files) > dittofsResidentSampleFiles {
+		fmt.Fprintf(&b, " (+%d more)", len(files)-dittofsResidentSampleFiles)
+	}
+	return b.String()
 }
 
 // dittofsLogSize reports the current size of path, or 0 when it cannot be

--- a/internal/dfsbench/backend/dittofs_test.go
+++ b/internal/dfsbench/backend/dittofs_test.go
@@ -169,4 +169,11 @@ exit 0
 			t.Errorf("dump missing %q:\n%s", want, out)
 		}
 	}
+	// The label alone proves nothing: dump prints every label, and an unpopulated
+	// step prints the same label followed by "not reached". This barrier reached
+	// all four steps, so any "not reached" here means a capture was never wired
+	// to the step it labels.
+	if strings.Contains(out, "not reached") {
+		t.Errorf("a step the barrier reached captured nothing:\n%s", out)
+	}
 }

--- a/internal/dfsbench/backend/dittofs_test.go
+++ b/internal/dfsbench/backend/dittofs_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -20,6 +21,21 @@ func captureCmdOut(t *testing.T) *bytes.Buffer {
 	exec.CmdOut = &buf
 	t.Cleanup(func() { exec.CmdOut = prev })
 	return &buf
+}
+
+// writeStubDfsctl puts a fake dfsctl at the front of PATH for the test. The
+// stub is a POSIX shell script, and the harness only ever runs on the Linux
+// bench VM, so the tests that drive the barrier through it are Linux-only.
+func writeStubDfsctl(t *testing.T, script string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the stub dfsctl is a POSIX shell script; the harness runs on the bench VM")
+	}
+	bin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bin, "dfsctl"), []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
 // writeLog writes n bytes of filler followed by tail and returns the path.
@@ -136,19 +152,13 @@ func TestDittofsBarrierDiagDumpMarksUnreachedSteps(t *testing.T) {
 // reported, and that a missing server log degrades to a note rather than a
 // second failure.
 func TestDittofsEvictDumpsDiagnosticsOnFailure(t *testing.T) {
-	bin := t.TempDir()
-	stub := filepath.Join(bin, "dfsctl")
-	script := `#!/bin/sh
+	writeStubDfsctl(t, `#!/bin/sh
 case "$*" in
   *"block stats"*) echo '{"totals":{"local_disk_used":5717934080,"unsynced_bytes":0,"pending_uploads":0,"eviction_suspended":true,"failed_syncs":7}}' ;;
   *"block evict"*) echo '{"local_files_evicted":0,"bytes_freed":0}' ;;
 esac
 exit 0
-`
-	if err := os.WriteFile(stub, []byte(script), 0o700); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+`)
 	buf := captureCmdOut(t)
 
 	err := dittofsEvict(context.Background())
@@ -194,18 +204,13 @@ func TestDittofsCaptureDistinguishesFailureFromUnattempted(t *testing.T) {
 }
 
 func TestDittofsEvictMarksAFailedCaptureAsFailed(t *testing.T) {
-	bin := t.TempDir()
-	script := `#!/bin/sh
+	writeStubDfsctl(t, `#!/bin/sh
 case "$*" in
   *"block stats"*) echo '{"totals":{"local_disk_used":5717934080,"unsynced_bytes":0}}' ;;
   *"block evict"*) echo 'boom' >&2; exit 1 ;;
 esac
 exit 0
-`
-	if err := os.WriteFile(filepath.Join(bin, "dfsctl"), []byte(script), 0o700); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+`)
 	buf := captureCmdOut(t)
 
 	if err := dittofsEvict(context.Background()); err == nil {
@@ -222,6 +227,12 @@ exit 0
 }
 
 func TestDittofsResidentFilesReportsAPartialScan(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mode 000 does not deny directory reads on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root reads the directory regardless of its mode")
+	}
 	dir := t.TempDir()
 	sub := filepath.Join(dir, "locked")
 	if err := os.MkdirAll(sub, 0o755); err != nil {
@@ -240,9 +251,6 @@ func TestDittofsResidentFilesReportsAPartialScan(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chmod(sub, 0o755) })
 
-	if os.Geteuid() == 0 {
-		t.Skip("root reads the directory regardless of its mode")
-	}
 	if got := dittofsResidentFiles(dir); !strings.Contains(got, "unreadable") {
 		t.Errorf("got %q, want the partial scan flagged", got)
 	}

--- a/internal/dfsbench/backend/dittofs_test.go
+++ b/internal/dfsbench/backend/dittofs_test.go
@@ -1,0 +1,90 @@
+package backend
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/dfsbench/exec"
+)
+
+// writeLog writes n bytes of filler followed by tail and returns the path.
+func writeLog(t *testing.T, filler int, tail string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "server.log")
+	if err := os.WriteFile(path, append(bytes.Repeat([]byte("x"), filler), tail...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestDittofsLogSince(t *testing.T) {
+	t.Run("returns only what was written after the offset", func(t *testing.T) {
+		path := writeLog(t, 0, "before\nafter\n")
+		got := dittofsLogSince(path, int64(len("before\n")))
+		if got != "after\n" {
+			t.Fatalf("got %q, want %q", got, "after\n")
+		}
+	})
+
+	t.Run("says so when the server logged nothing", func(t *testing.T) {
+		path := writeLog(t, 0, "before\n")
+		got := dittofsLogSince(path, int64(len("before\n")))
+		if !strings.Contains(got, "logged nothing") {
+			t.Fatalf("got %q, want a nothing-logged note", got)
+		}
+	})
+
+	t.Run("keeps the tail when the window exceeds the cap", func(t *testing.T) {
+		// The window is everything after offset 0, which is far larger than the
+		// cap; the bytes nearest the failure must survive, not the earliest ones.
+		path := writeLog(t, dittofsBarrierLogTailBytes*2, "FAILURE WINDOW\n")
+		got := dittofsLogSince(path, 0)
+		if len(got) > dittofsBarrierLogTailBytes {
+			t.Fatalf("window %d bytes exceeds the %d cap", len(got), dittofsBarrierLogTailBytes)
+		}
+		if !strings.HasSuffix(got, "FAILURE WINDOW\n") {
+			t.Fatal("capped window dropped the most recent output")
+		}
+	})
+
+	t.Run("never fails on a missing log", func(t *testing.T) {
+		if got := dittofsLogSince(filepath.Join(t.TempDir(), "absent"), 0); !strings.Contains(got, "unreadable") {
+			t.Fatalf("got %q, want an unreadable note", got)
+		}
+	})
+}
+
+func TestDittofsLogSizeMissingFileIsZero(t *testing.T) {
+	if got := dittofsLogSize(filepath.Join(t.TempDir(), "absent")); got != 0 {
+		t.Fatalf("got %d, want 0", got)
+	}
+}
+
+func TestDittofsBarrierDiagDumpMarksUnreachedSteps(t *testing.T) {
+	var buf bytes.Buffer
+	prev := exec.CmdOut
+	exec.CmdOut = &buf
+	defer func() { exec.CmdOut = prev }()
+
+	// A barrier that failed inside the drain reaches only the entry sample; the
+	// dump must say which evidence is missing rather than print empty sections.
+	d := dittofsBarrierDiag{entry: []byte(`{"totals":{"local_disk_used":1}}`)}
+	d.dump(errors.New("drain-uploads never fell below the floor"))
+
+	out := buf.String()
+	for _, want := range []string{
+		"drain-uploads never fell below the floor",
+		`{"totals":{"local_disk_used":1}}`,
+		"block stats after drain (pre-evict): not reached",
+		"evict result: not reached",
+		"block stats after evict: not reached",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("dump missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/internal/dfsbench/backend/dittofs_test.go
+++ b/internal/dfsbench/backend/dittofs_test.go
@@ -64,6 +64,35 @@ func TestDittofsLogSizeMissingFileIsZero(t *testing.T) {
 	}
 }
 
+func TestDittofsResidentFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "share"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, size := range map[string]int{
+		"share/000001.seg": 3 << 20,
+		"share/000002.seg": 1 << 20,
+		"small":            0,
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), make([]byte, size), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got := dittofsResidentFiles(dir)
+	// Largest first, so the shape of the surviving set is legible at a glance.
+	if !strings.Contains(got, "3 files, 4MiB total") {
+		t.Errorf("missing totals: %s", got)
+	}
+	if i, j := strings.Index(got, "000001.seg"), strings.Index(got, "000002.seg"); i < 0 || j < 0 || i > j {
+		t.Errorf("files not ordered largest-first: %s", got)
+	}
+
+	if got := dittofsResidentFiles(filepath.Join(dir, "absent")); !strings.Contains(got, "empty") {
+		t.Errorf("got %q, want an empty-dir note", got)
+	}
+}
+
 func TestDittofsBarrierDiagDumpMarksUnreachedSteps(t *testing.T) {
 	var buf bytes.Buffer
 	prev := exec.CmdOut

--- a/internal/dfsbench/backend/dittofs_test.go
+++ b/internal/dfsbench/backend/dittofs_test.go
@@ -112,7 +112,7 @@ func TestDittofsBarrierDiagDumpMarksUnreachedSteps(t *testing.T) {
 
 	// A barrier that failed inside the drain reaches only the entry sample; the
 	// dump must say which evidence is missing rather than print empty sections.
-	d := dittofsBarrierDiag{entry: []byte(`{"totals":{"local_disk_used":1}}`)}
+	d := dittofsBarrierDiag{entry: `{"totals":{"local_disk_used":1}}`}
 	d.dump(errors.New("drain-uploads never fell below the floor"))
 
 	out := buf.String()
@@ -175,5 +175,75 @@ exit 0
 	// to the step it labels.
 	if strings.Contains(out, "not reached") {
 		t.Errorf("a step the barrier reached captured nothing:\n%s", out)
+	}
+}
+
+func TestDittofsCaptureDistinguishesFailureFromUnattempted(t *testing.T) {
+	// An empty string is the dump's marker for a step the barrier never reached,
+	// so a step that WAS attempted must never render as one — the two lead to
+	// opposite conclusions about where the barrier stopped.
+	if got := dittofsCapture(nil, errors.New("exit 1")); !strings.Contains(got, "capture failed: exit 1") {
+		t.Errorf("got %q, want a capture-failed note", got)
+	}
+	if got := dittofsCapture(nil, nil); got == "" {
+		t.Error("a successful command with empty output must not render as unattempted")
+	}
+	if got := dittofsCapture([]byte("  {}\n"), nil); got != "{}" {
+		t.Errorf("got %q, want the trimmed output", got)
+	}
+}
+
+func TestDittofsEvictMarksAFailedCaptureAsFailed(t *testing.T) {
+	bin := t.TempDir()
+	script := `#!/bin/sh
+case "$*" in
+  *"block stats"*) echo '{"totals":{"local_disk_used":5717934080,"unsynced_bytes":0}}' ;;
+  *"block evict"*) echo 'boom' >&2; exit 1 ;;
+esac
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(bin, "dfsctl"), []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	buf := captureCmdOut(t)
+
+	if err := dittofsEvict(context.Background()); err == nil {
+		t.Fatal("want an error when the evict command fails")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "evict result: (capture failed:") {
+		t.Errorf("a failed evict must be reported as failed, not unattempted:\n%s", out)
+	}
+	// The steps after the failure genuinely were not reached, and must still say so.
+	if !strings.Contains(out, "block stats after evict: not reached") {
+		t.Errorf("dump lost the not-reached marker:\n%s", out)
+	}
+}
+
+func TestDittofsResidentFilesReportsAPartialScan(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "locked")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "a.seg"), make([]byte, 1<<20), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b.seg"), make([]byte, 2<<20), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// An unreadable subtree must not shrink the sample silently — the count would
+	// then describe a tier that is emptier than the real one.
+	if err := os.Chmod(sub, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(sub, 0o755) })
+
+	if os.Geteuid() == 0 {
+		t.Skip("root reads the directory regardless of its mode")
+	}
+	if got := dittofsResidentFiles(dir); !strings.Contains(got, "unreadable") {
+		t.Errorf("got %q, want the partial scan flagged", got)
 	}
 }

--- a/internal/dfsbench/backend/dittofs_test.go
+++ b/internal/dfsbench/backend/dittofs_test.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -88,7 +89,10 @@ func TestDittofsResidentFiles(t *testing.T) {
 		t.Errorf("files not ordered largest-first: %s", got)
 	}
 
-	if got := dittofsResidentFiles(filepath.Join(dir, "absent")); !strings.Contains(got, "empty") {
+	if got := dittofsResidentFiles(filepath.Join(dir, "absent")); !strings.Contains(got, "unreadable") {
+		t.Errorf("got %q, want an unreadable note", got)
+	}
+	if got := dittofsResidentFiles(t.TempDir()); !strings.Contains(got, "is empty") {
 		t.Errorf("got %q, want an empty-dir note", got)
 	}
 }
@@ -111,6 +115,52 @@ func TestDittofsBarrierDiagDumpMarksUnreachedSteps(t *testing.T) {
 		"block stats after drain (pre-evict): not reached",
 		"evict result: not reached",
 		"block stats after evict: not reached",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("dump missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestDittofsEvictDumpsDiagnosticsOnFailure drives the whole barrier against a
+// stub dfsctl that reports a local tier which never shrinks — the field failure
+// this dump exists for. It pins the wiring: that a failed barrier prints the raw
+// stats (including the fields the parsed totals drop), what the evict itself
+// reported, and that a missing server log degrades to a note rather than a
+// second failure.
+func TestDittofsEvictDumpsDiagnosticsOnFailure(t *testing.T) {
+	bin := t.TempDir()
+	stub := filepath.Join(bin, "dfsctl")
+	script := `#!/bin/sh
+case "$*" in
+  *"block stats"*) echo '{"totals":{"local_disk_used":5717934080,"unsynced_bytes":0,"pending_uploads":0,"eviction_suspended":true,"failed_syncs":7}}' ;;
+  *"block evict"*) echo '{"local_files_evicted":0,"bytes_freed":0}' ;;
+esac
+exit 0
+`
+	if err := os.WriteFile(stub, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	var buf bytes.Buffer
+	prev := exec.CmdOut
+	exec.CmdOut = &buf
+	defer func() { exec.CmdOut = prev }()
+
+	err := dittofsEvict(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "cold barrier failed") {
+		t.Fatalf("got %v, want a cold-barrier failure", err)
+	}
+
+	out := buf.String()
+	for _, want := range []string{
+		"cold barrier diagnostics",
+		`"eviction_suspended":true`, // dropped by dittofsBlockTotals; kept by the raw capture
+		`"failed_syncs":7`,
+		"block stats after drain (pre-evict)",
+		`"bytes_freed":0`,
+		"server log",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("dump missing %q:\n%s", want, out)

--- a/internal/dfsbench/backend/dittofs_test.go
+++ b/internal/dfsbench/backend/dittofs_test.go
@@ -12,6 +12,16 @@ import (
 	"github.com/marmos91/dittofs/internal/dfsbench/exec"
 )
 
+// captureCmdOut redirects command output into a buffer for the test's duration.
+func captureCmdOut(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := exec.CmdOut
+	exec.CmdOut = &buf
+	t.Cleanup(func() { exec.CmdOut = prev })
+	return &buf
+}
+
 // writeLog writes n bytes of filler followed by tail and returns the path.
 func writeLog(t *testing.T, filler int, tail string) string {
 	t.Helper()
@@ -98,10 +108,7 @@ func TestDittofsResidentFiles(t *testing.T) {
 }
 
 func TestDittofsBarrierDiagDumpMarksUnreachedSteps(t *testing.T) {
-	var buf bytes.Buffer
-	prev := exec.CmdOut
-	exec.CmdOut = &buf
-	defer func() { exec.CmdOut = prev }()
+	buf := captureCmdOut(t)
 
 	// A barrier that failed inside the drain reaches only the entry sample; the
 	// dump must say which evidence is missing rather than print empty sections.
@@ -142,11 +149,7 @@ exit 0
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
-
-	var buf bytes.Buffer
-	prev := exec.CmdOut
-	exec.CmdOut = &buf
-	defer func() { exec.CmdOut = prev }()
+	buf := captureCmdOut(t)
 
 	err := dittofsEvict(context.Background())
 	if err == nil || !strings.Contains(err.Error(), "cold barrier failed") {


### PR DESCRIPTION
## What this is

Diagnostics, not a fix. The cold barrier fired once during the 292-cell QoS matrix
run and left behind nothing but the two byte counts in its own error message:

```
FAIL dittofs-sqlite-s3-nfs3: evict: cold barrier failed: local disk only fell
5453MiB→4665MiB (want ≥80% drop)
```

Those two numbers restate the symptom and cannot distinguish any of the
mechanisms that produce it. It has not reproduced — immediate reruns of the same
tier passed cleanly (`4096MiB→0MiB`, `4399MiB→42MiB`) and the other four DittoFS
tiers cleared the identical barrier in the same run — so this PR does not chase a
cause. It makes the next occurrence diagnosable instead of lost.

The issue names the evidence that was missing: `dfsctl store block stats -o json`
before the evict, plus the server log for that window. That is what gets captured.

## What is captured

On **any** error out of the barrier (the drain half included, not just the evict
half), `dittofsEvict` now prints to the run log — which `--remote` pulls back into
`bench-results/run.log`:

| Evidence | Why it is the discriminator |
| --- | --- |
| Raw stats JSON at barrier entry | `dittofsBlockTotals` keeps 3 of ~25 fields. The dropped ones are the interesting ones: `eviction_suspended`, `remote_healthy`, `outage_duration_secs`, `failed_syncs`, and the per-state block counts. |
| Raw stats JSON **after the drain, before the evict** | Separates "the drain left bytes the evict was right to refuse" from "the evict declined bytes the drain had already made durable". The post-hoc pair of counts cannot tell those apart. |
| `store block evict -o json` (`bytes_freed`, `local_files_evicted`) | Says directly whether the evict declined to drop anything, or dropped bytes that came back. The barrier previously threw this output away. |
| Summary of files still resident on the local tier | Eviction's unit is a whole journal segment, so the *shape* of the surviving set (N files of ~256 MiB vs bytes spread thinly) is information the aggregate byte count cannot carry. |
| Server log window written while the barrier ran | Tail-capped at 256 KiB so a long multi-round drain cannot flood the run log. |

Every capture path degrades to a parenthesised note rather than an error: this
runs only to explain a barrier that already failed and must never become a second
failure. Steps the barrier never reached print `not reached`, which is itself part
of the answer.

The pass/fail rule, the 64 MiB floor, the drift floor and the drain loop are all
unchanged.

Sample of the dump, from the end-to-end test:

```
cold barrier diagnostics — cold barrier failed: local disk only fell 5453MiB→5453MiB (want ≥80% drop); ...
  block stats at barrier entry: {"totals":{"local_disk_used":5717934080,"unsynced_bytes":0,...,"eviction_suspended":true,"failed_syncs":7}}
  block stats after drain (pre-evict): {"totals":{...}}
  evict result: {"local_files_evicted":0,"bytes_freed":0}
  block stats after evict: {"totals":{...}}
  surviving local tier: 19 files, 4665MiB total; largest: 000031.seg=256MiB ...
  server log (/var/log/bench-dittofs.log) since barrier entry:
  ...
```

## A hypothesis the capture will confirm or kill — NOT a diagnosis

Reading the evict path while wiring this up turned up an arithmetic fit worth
recording, from a code read only, with no reproduction behind it:

- The journal evicts **whole segments**. `SegmentSize` defaults to 256 MiB and
  `ShardCount` to 16, and `pkg/block/local/fs` sets neither, so both defaults hold
  for every bench share.
- A segment is evictable only when **every** record in it is synced —
  `claimColdestEvictable` for sealed segments, `sealableActive` for the actives.
  One straggler unsynced record therefore pins its entire 256 MiB segment.
- The harness's `dittofsDrainUntilSynced` deliberately stops at ≤32 MiB unsynced
  (`dittofsDrainDriftFloorBytes`), on the reasoning that "a few MiB out of a
  multi-GiB file is <0.1% and does not meaningfully warm the cold pass". That
  reasoning is byte-denominated; eviction is segment-denominated. 32 MiB scattered
  one straggler at a time across 18 segments pins 4608 MiB.

4665 MiB is ~18.2 segments, and the mechanism is intermittent in exactly the way
the report is: it turns on where the drain's residue happens to land, not on how
big it is. That said — it is a fit, not evidence, and the
alternatives (a health blip suspending eviction, failed syncs, a snapshot pinning
segments) fit the same two numbers just as well. The whole point of this PR is
that the next occurrence will say which. The post-drain `unsynced_bytes` plus the
surviving-file shape settle it in one line of log.

Filed as #2078 rather than widening this PR into a fix.

## Verification

- `go build ./... && go vet ./internal/... && go test ./internal/...` green.
- New tests cover the offset/cap math of the log window, the "not reached" marking,
  the resident-file summary, and an end-to-end run of the whole barrier against a
  stub `dfsctl` that reports a local tier which never shrinks.
- Mutation-checked: inverting the tail-cap comparison in `dittofsLogSince` fails
  two of the new subtests.
- Not run on a bench VM — the change is confined to the harness's failure path and
  a live matrix run costs hours of VM time to exercise one `if err != nil`.

Refs #1877 — deliberately NOT `Closes`. This PR instruments the failure; it does not explain it.
#1877 stays open until the next occurrence, when the new capture makes it decisive.
The candidate mechanism is filed separately as #2078.

