### PR TITLE
feat(integrity): run the structural manifest scan on a schedule

### DIFF
--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -310,6 +310,18 @@ func runStart(cmd *cobra.Command, args []string) error {
 		logger.Info("auto-GC disabled by config (gc.auto_enabled=false)")
 	}
 
+	// Background structural manifest scan: verifies that each share's
+	// manifest still covers what its files claim to hold. Metadata-only, so
+	// it fetches no block and touches no remote object. The damage it looks
+	// for is invisible at read time — an uncovered range a file still claims
+	// is indistinguishable from a sparse hole, so the read returns zeros and
+	// reports success — which is why nothing else can report it.
+	if cfg.Integrity.AutoScanEnabled() {
+		rt.StartScheduledIntegrityScan(ctx, cfg.Integrity.AutoInterval)
+	} else {
+		logger.Info("integrity scan disabled by config (integrity.auto_enabled=false)")
+	}
+
 	// Configure runtime
 	rt.SetShutdownTimeout(cfg.ShutdownTimeout)
 	// Seed an operator-pinned machine SID (if configured) BEFORE Serve so the

--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -310,12 +310,10 @@ func runStart(cmd *cobra.Command, args []string) error {
 		logger.Info("auto-GC disabled by config (gc.auto_enabled=false)")
 	}
 
-	// Background structural manifest scan: verifies that each share's
-	// manifest still covers what its files claim to hold. Metadata-only, so
-	// it fetches no block and touches no remote object. The damage it looks
-	// for is invisible at read time — an uncovered range a file still claims
-	// is indistinguishable from a sparse hole, so the read returns zeros and
-	// reports success — which is why nothing else can report it.
+	// Background structural manifest scan: periodically checks that each
+	// share's manifest still covers what its files claim to hold — damage the
+	// read path cannot report, because an uncovered range reads back as a
+	// sparse hole. Enabled by default; bound to ctx so it stops on shutdown.
 	if cfg.Integrity.AutoScanEnabled() {
 		rt.StartScheduledIntegrityScan(ctx, cfg.Integrity.AutoInterval)
 	} else {

--- a/cmd/dfsctl/commands/share/list.go
+++ b/cmd/dfsctl/commands/share/list.go
@@ -175,7 +175,7 @@ func runList(cmd *cobra.Command, args []string) error {
 
 // shareStatusString renders the server's status, or empty when the server sent
 // none, so an absent status is never shown as a status of "".
-func shareStatusString(r *health.Report) string {
+func shareStatusString(r *health.ShareStatus) string {
 	if r == nil {
 		return ""
 	}

--- a/cmd/dfsctl/commands/share/show.go
+++ b/cmd/dfsctl/commands/share/show.go
@@ -206,15 +206,15 @@ func integrityRows(in *health.IntegrityStatus) [][]string {
 	if in == nil {
 		return [][]string{{"Integrity Scan", "not yet run"}}
 	}
+	at := in.LastRunAt.Local().Format("2006-01-02 15:04:05")
 	if in.Error != "" {
 		return [][]string{
-			{"Integrity Scan", "failed " + in.LastRunAt.Local().Format("2006-01-02 15:04:05")},
+			{"Integrity Scan", "failed " + at},
 			{"Integrity Error", in.Error},
 		}
 	}
 	rows := [][]string{
-		{"Integrity Scan", fmt.Sprintf("%s (%d files, %dms)",
-			in.LastRunAt.Local().Format("2006-01-02 15:04:05"), in.FilesScanned, in.DurationMS)},
+		{"Integrity Scan", fmt.Sprintf("%s (%d files, %dms)", at, in.FilesScanned, in.DurationMS)},
 		{"Integrity Findings", fmt.Sprintf("%d payloads (%d damaged)",
 			in.PayloadsWithFindings, in.DamagedPayloads)},
 	}

--- a/cmd/dfsctl/commands/share/show.go
+++ b/cmd/dfsctl/commands/share/show.go
@@ -9,6 +9,7 @@ import (
 	"github.com/marmos91/dittofs/internal/bytesize"
 	"github.com/marmos91/dittofs/internal/cli/output"
 	"github.com/marmos91/dittofs/pkg/apiclient"
+	"github.com/marmos91/dittofs/pkg/health"
 	"github.com/spf13/cobra"
 )
 
@@ -101,6 +102,7 @@ func (sd ShareDetail) Rows() [][]string {
 		if s.Status.Message != "" {
 			rows = append(rows, []string{"Status Detail", s.Status.Message})
 		}
+		rows = append(rows, integrityRows(s.Status.Integrity)...)
 	}
 
 	// Only show Retention TTL when a TTL is set
@@ -194,4 +196,34 @@ func shareOwnerString(uid, gid *uint32) string {
 		group = *gid
 	}
 	return fmt.Sprintf("%d:%d", *uid, group)
+}
+
+// integrityRows renders the last structural manifest scan for the detail
+// table. A share the server has not scanned yet says so rather than showing
+// a row of zeros, which would read as a clean bill of health the server has
+// not actually given.
+func integrityRows(in *health.IntegrityStatus) [][]string {
+	if in == nil {
+		return [][]string{{"Integrity Scan", "not yet run"}}
+	}
+	if in.Error != "" {
+		return [][]string{
+			{"Integrity Scan", "failed " + in.LastRunAt.Local().Format("2006-01-02 15:04:05")},
+			{"Integrity Error", in.Error},
+		}
+	}
+	rows := [][]string{
+		{"Integrity Scan", fmt.Sprintf("%s (%d files, %dms)",
+			in.LastRunAt.Local().Format("2006-01-02 15:04:05"), in.FilesScanned, in.DurationMS)},
+		{"Integrity Findings", fmt.Sprintf("%d payloads (%d damaged)",
+			in.PayloadsWithFindings, in.DamagedPayloads)},
+	}
+	// The per-kind breakdown is noise on a clean share; show it only when
+	// there is something to break down.
+	if in.PayloadsWithFindings > 0 {
+		rows = append(rows, []string{"Integrity Detail", fmt.Sprintf(
+			"%d claimed-uncovered ranges, %d unplaceable rows, %d unknown hashes",
+			in.ClaimedUncoveredRanges, in.UnplaceableRows, in.UnknownHashRows)})
+	}
+	return rows
 }

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -2251,6 +2251,9 @@ spec:
 | ⭐ `dittofs_snapshot_operations_total{op,result}` | Snapshot operations by `op` (create/delete/restore) and `result` (ok/error). |
 | `dittofs_snapshot_duration_seconds{op}` | Snapshot operation latency histogram, by `op` (create/delete/restore). |
 | ⭐ `dittofs_snapshot_last_success_timestamp_seconds{share}` | Unix time of the last successful snapshot create (backup-freshness signal). |
+| ⭐ `dittofs_integrity_findings{share,kind}` | Findings from the last structural manifest scan, by `kind`: `payloads_with_findings`, `damaged_payloads`, `claimed_uncovered_ranges`, `unplaceable_rows`, `unknown_hash_rows`. |
+| ⭐ `dittofs_integrity_last_scan_timestamp_seconds{share}` | Unix time the structural manifest scan last completed (0 = never scanned since process start). |
+| `dittofs_integrity_last_scan_duration_seconds{share}` / `dittofs_integrity_files_scanned{share}` | Cost and reach of the last structural manifest scan. |
 
 ### Example alert expressions
 
@@ -2270,6 +2273,26 @@ groups:
         labels: { severity: warning }
         annotations:
           summary: "DittoFS has had no successful snapshot create in >24h"
+
+      # A share holding manifest damage. The read path cannot report this
+      # class: an uncovered range a file still claims reads back as a sparse
+      # hole, so reads return zeros and succeed. Only the scan sees it.
+      - alert: DittoFSManifestDamage
+        expr: dittofs_integrity_findings{kind="damaged_payloads"} > 0
+        for: 15m
+        labels: { severity: critical }
+        annotations:
+          summary: "DittoFS share {{ $labels.share }} has damaged payloads; run dfsctl store check"
+
+      # The integrity scan has not completed in 48h. A last-scan value of 0
+      # means never scanned since process start, which this expression catches
+      # because time() - 0 is far past the threshold.
+      - alert: DittoFSIntegrityScanStale
+        expr: (time() - dittofs_integrity_last_scan_timestamp_seconds) > 172800
+        for: 1h
+        labels: { severity: warning }
+        annotations:
+          summary: "DittoFS share {{ $labels.share }} has not been integrity-scanned in >48h"
 
       # Remote block store unreachable.
       - alert: DittoFSRemoteDown

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -592,6 +592,57 @@ See [ARCHITECTURE.md](../internals/architecture.md#garbage-collection-mark-sweep
 for the full mark-sweep design and [CLI.md](cli.md) for the on-demand
 `dfsctl store block gc` command.
 
+#### Background integrity scan
+
+A share's manifest can end up disagreeing with its own files' block lists:
+a file claims bytes in a range that no manifest row covers. At read time
+that is indistinguishable from a legitimate sparse hole — absent rows are
+how sparse files are represented — so the read returns zeros and reports
+success. Nothing on the data path can report it. The background scan is
+what finds it.
+
+```yaml
+integrity:
+  auto_enabled: true          # Run the structural manifest scan
+                              # automatically. Default true. Set false to
+                              # require manual `dfsctl store check`.
+  auto_interval: 24h          # Period between scans. Default 24h. Values
+                              # in (0, 5m) are REJECTED — a scan is a full
+                              # metadata walk of every share. Ignored when
+                              # auto_enabled is false.
+```
+
+The scan is **metadata-only**: it fetches no block and touches no remote
+object, so it costs a metadata walk regardless of how much data a share
+holds and generates **no S3 egress**. It writes nothing — it neither plans
+nor applies repairs. Shares are scanned one at a time.
+
+Findings surface in three places:
+
+- `dfsctl share show <name>` reports when the share was last scanned and
+  what was found. A share with damaged payloads reads as `degraded` even
+  when every subsystem probe is healthy.
+- Prometheus: `dittofs_integrity_last_scan_timestamp_seconds`,
+  `dittofs_integrity_last_scan_duration_seconds`,
+  `dittofs_integrity_files_scanned`, and
+  `dittofs_integrity_findings{kind="..."}` broken out by
+  `payloads_with_findings`, `damaged_payloads`,
+  `claimed_uncovered_ranges`, `unplaceable_rows` and `unknown_hash_rows`.
+  A share never scanned reports a last-scan timestamp of 0, so an alert on
+  scan age fires for it.
+- The server log, at `WARN`, for any share with damaged payloads.
+
+Run `dfsctl store check <share>` for the per-file detail behind a finding,
+and `--repair` to act on it.
+
+The schedule restarts from zero on server start, so a box restarted more
+often than `auto_interval` never completes a scan. Lower the interval on a
+host that reboots frequently.
+
+Env-var mapping:
+`DITTOFS_INTEGRITY_AUTO_ENABLED`,
+`DITTOFS_INTEGRITY_AUTO_INTERVAL`.
+
 #### Local cache size limit & write backpressure
 
 When a share has a **remote** block store configured (S3 or filesystem

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -623,13 +623,20 @@ Findings surface in three places:
   what was found. A share with damaged payloads reads as `degraded` even
   when every subsystem probe is healthy.
 - Prometheus: `dittofs_integrity_last_scan_timestamp_seconds`,
+  `dittofs_integrity_last_scan_failed`,
   `dittofs_integrity_last_scan_duration_seconds`,
   `dittofs_integrity_files_scanned`, and
   `dittofs_integrity_findings{kind="..."}` broken out by
   `payloads_with_findings`, `damaged_payloads`,
   `claimed_uncovered_ranges`, `unplaceable_rows` and `unknown_hash_rows`.
-  A share never scanned reports a last-scan timestamp of 0, so an alert on
-  scan age fires for it.
+
+  The last-scan timestamp is 0 both for a share never scanned and for one
+  whose last scan failed — a failed scan completes nothing, so it has no
+  time to report. `dittofs_integrity_last_scan_failed` is what separates
+  them: `0` with a zero timestamp means the scan has not run yet, `1` means
+  it is running and erroring. Without that second series a scanner failing
+  on every tick would look exactly like one that was never switched on, and
+  stay that way indefinitely.
 - The server log, at `WARN`, for any share with damaged payloads.
 
 Run `dfsctl store check <share>` for the per-file detail behind a finding,
@@ -2252,7 +2259,8 @@ spec:
 | `dittofs_snapshot_duration_seconds{op}` | Snapshot operation latency histogram, by `op` (create/delete/restore). |
 | ⭐ `dittofs_snapshot_last_success_timestamp_seconds{share}` | Unix time of the last successful snapshot create (backup-freshness signal). |
 | ⭐ `dittofs_integrity_findings{share,kind}` | Findings from the last structural manifest scan, by `kind`: `payloads_with_findings`, `damaged_payloads`, `claimed_uncovered_ranges`, `unplaceable_rows`, `unknown_hash_rows`. |
-| ⭐ `dittofs_integrity_last_scan_timestamp_seconds{share}` | Unix time the structural manifest scan last completed (0 = never scanned since process start). |
+| ⭐ `dittofs_integrity_last_scan_timestamp_seconds{share}` | Unix time the structural manifest scan last completed. 0 means it has never run since process start **or** its last attempt failed. |
+| ⭐ `dittofs_integrity_last_scan_failed{share}` | `1` when the most recent structural manifest scan failed, `0` when it completed or has never run. Pairs with the timestamp above to tell "never scanned" from "scans are erroring". |
 | `dittofs_integrity_last_scan_duration_seconds{share}` / `dittofs_integrity_files_scanned{share}` | Cost and reach of the last structural manifest scan. |
 
 ### Example alert expressions
@@ -2293,6 +2301,16 @@ groups:
         labels: { severity: warning }
         annotations:
           summary: "DittoFS share {{ $labels.share }} has not been integrity-scanned in >48h"
+
+      # The scan is running but failing. Without this the share looks
+      # identical to one whose scanner was never enabled: both report a
+      # last-scan timestamp of 0, forever.
+      - alert: DittoFSIntegrityScanFailing
+        expr: dittofs_integrity_last_scan_failed == 1
+        for: 1h
+        labels: { severity: warning }
+        annotations:
+          summary: "DittoFS integrity scan for {{ $labels.share }} is failing; the share is not being verified"
 
       # Remote block store unreachable.
       - alert: DittoFSRemoteDown

--- a/internal/controlplane/api/handlers/shares.go
+++ b/internal/controlplane/api/handlers/shares.go
@@ -264,10 +264,11 @@ type ShareResponse struct {
 	UpdatedAt            time.Time `json:"updated_at"`
 
 	// Status is the worst-of health report derived from the share's
-	// metadata store and block store engine. Non-omitempty so
-	// clients can render "unknown" explicitly when the runtime has
-	// not loaded the share yet.
-	Status health.Report `json:"status"`
+	// metadata store and block store engine, plus the structural
+	// counters recorded alongside it. Non-omitempty so clients can
+	// render "unknown" explicitly when the runtime has not loaded the
+	// share yet.
+	Status health.ShareStatus `json:"status"`
 
 	// Warnings carries non-fatal operator-facing messages about the request
 	// that just completed — e.g. a block-store binding change that only takes
@@ -1648,18 +1649,18 @@ func (h *ShareHandler) shareToResponseWithUsage(ctx context.Context, s *models.S
 	return resp
 }
 
-// unknownRuntimeReport builds a [health.StatusUnknown] report used
+// unknownRuntimeReport builds a [health.StatusUnknown] status used
 // when a handler is wired without a runtime. Kept in one place so
 // shares.go's nil-guard branches stay consistent.
-func unknownRuntimeReport() health.Report {
-	return health.Report{
+func unknownRuntimeReport() health.ShareStatus {
+	return health.ShareStatus{Report: health.Report{
 		Status:    health.StatusUnknown,
 		Message:   "runtime not initialized",
 		CheckedAt: time.Now().UTC(),
-	}
+	}}
 }
 
-// shareStatus returns a [health.Report] for the named share via the
+// shareStatus returns a [health.ShareStatus] for the named share via the
 // runtime's cached checker layer. Callers MUST ensure h.runtime is
 // non-nil; this helper intentionally does not guard so the panic
 // surface stays visible in tests. Analogous to the statusFor helpers
@@ -1668,12 +1669,12 @@ func unknownRuntimeReport() health.Report {
 // /status handlers wrap once at the handler level, and list handlers
 // wrap once before the populate loop so all entities share a single
 // 5s budget instead of compounding to N*5s worst case.
-func (h *ShareHandler) shareStatus(ctx context.Context, name string) health.Report {
-	return h.runtime.ShareChecker(name).Healthcheck(ctx)
+func (h *ShareHandler) shareStatus(ctx context.Context, name string) health.ShareStatus {
+	return h.runtime.ShareStatus(ctx, name)
 }
 
 // Status handles GET /api/v1/shares/{name}/status. Returns 404 when
-// the share config does not exist and 200 with a [health.Report]
+// the share config does not exist and 200 with a [health.ShareStatus]
 // JSON body otherwise.
 func (h *ShareHandler) Status(w http.ResponseWriter, r *http.Request) {
 	name := normalizeShareName(chi.URLParam(r, "name"))

--- a/pkg/apiclient/shares.go
+++ b/pkg/apiclient/shares.go
@@ -84,7 +84,7 @@ type Share struct {
 	// Omitted when empty: a server that sends no status must not be rendered
 	// as one reporting a zero-value report, which would carry an empty Status
 	// and a year-zero CheckedAt that no server ever produced.
-	Status *health.Report `json:"status,omitempty"`
+	Status *health.ShareStatus `json:"status,omitempty"`
 }
 
 // CreateShareRequest is the request to create a share.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -226,15 +226,10 @@ func (c *GCConfig) Validate() error {
 	return nil
 }
 
-// IntegrityConfig configures the background structural manifest scan.
-// The scan walks each share's metadata and compares the byte ranges its
-// manifest rows cover against every file's recorded size, reporting spans
-// a file claims to hold but no row covers, rows carrying no placeable
-// chunk offset, and rows whose hash was never confirmed mirrored.
-//
-// It is metadata-only: no block is fetched and no remote object is
-// touched, so its cost is a metadata walk regardless of how much data a
-// share holds. The same scan is runnable on demand via `dfsctl store check`.
+// IntegrityConfig configures the background structural manifest scan, which
+// compares the byte ranges each share's manifest rows cover against its
+// files' recorded sizes. Knobs cover only the schedule. The scan is
+// metadata-only and is also runnable on demand (`dfsctl store check`).
 type IntegrityConfig struct {
 	// AutoEnabled turns on the background scan. Defaults to true. Set
 	// false to require an operator to run `dfsctl store check` by hand.
@@ -252,8 +247,8 @@ func (c *IntegrityConfig) ApplyDefaults() {
 		on := true
 		c.AutoEnabled = &on
 	}
-	// Only fill the unset (zero) case. A negative value is a user mistake
-	// and must survive to Validate rather than be rewritten silently.
+	// Only fill the unset (zero) case. A negative value is a user mistake and
+	// must survive to Validate, not be silently rewritten to the default.
 	if c.AutoInterval == 0 {
 		c.AutoInterval = 24 * time.Hour
 	}
@@ -267,10 +262,9 @@ func (c *IntegrityConfig) AutoScanEnabled() bool {
 
 // Validate returns an error if the IntegrityConfig has invalid values.
 //
-// The floor is 5m rather than GC's 1m because a scan is a full metadata
-// walk of every share: on a store of any size a sub-5m cadence leaves the
-// scan running continuously, which is a scheduling mistake rather than an
-// aggressive setting.
+// AutoInterval's floor is 5m rather than GC's 1m: a scan is a full metadata
+// walk of every share, so on a store of any size a sub-5m cadence leaves it
+// running continuously.
 func (c *IntegrityConfig) Validate() error {
 	if c.AutoInterval < 0 {
 		return fmt.Errorf("integrity.auto_interval must be >= 0 (got %v)", c.AutoInterval)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -80,6 +80,11 @@ type Config struct {
 	// These knobs apply globally to every block-store GC invocation.
 	GC GCConfig `mapstructure:"gc" yaml:"gc"`
 
+	// Integrity configures the background structural manifest scan, which
+	// periodically verifies that every share's manifest still agrees with
+	// its files' own block lists.
+	Integrity IntegrityConfig `mapstructure:"integrity" yaml:"integrity"`
+
 	// Snapshot configures the snapshot create orchestration. Knobs apply
 	// to every Runtime.CreateSnapshot invocation.
 	Snapshot SnapshotConfig `mapstructure:"snapshot" yaml:"snapshot"`
@@ -217,6 +222,61 @@ func (c *GCConfig) Validate() error {
 	}
 	if c.CompactionLiveRatio < 0 || c.CompactionLiveRatio > 1 {
 		return fmt.Errorf("gc.compaction_live_ratio must be in [0, 1] (got %v); 0 disables compaction", c.CompactionLiveRatio)
+	}
+	return nil
+}
+
+// IntegrityConfig configures the background structural manifest scan.
+// The scan walks each share's metadata and compares the byte ranges its
+// manifest rows cover against every file's recorded size, reporting spans
+// a file claims to hold but no row covers, rows carrying no placeable
+// chunk offset, and rows whose hash was never confirmed mirrored.
+//
+// It is metadata-only: no block is fetched and no remote object is
+// touched, so its cost is a metadata walk regardless of how much data a
+// share holds. The same scan is runnable on demand via `dfsctl store check`.
+type IntegrityConfig struct {
+	// AutoEnabled turns on the background scan. Defaults to true. Set
+	// false to require an operator to run `dfsctl store check` by hand.
+	AutoEnabled *bool `mapstructure:"auto_enabled" yaml:"auto_enabled"`
+
+	// AutoInterval is the period between scans. Defaults to 24h. Values
+	// in (0, 5m) are rejected at config load. Ignored when AutoEnabled is
+	// false.
+	AutoInterval time.Duration `mapstructure:"auto_interval" yaml:"auto_interval"`
+}
+
+// ApplyDefaults fills any zero-valued field with the defaults.
+func (c *IntegrityConfig) ApplyDefaults() {
+	if c.AutoEnabled == nil {
+		on := true
+		c.AutoEnabled = &on
+	}
+	// Only fill the unset (zero) case. A negative value is a user mistake
+	// and must survive to Validate rather than be rewritten silently.
+	if c.AutoInterval == 0 {
+		c.AutoInterval = 24 * time.Hour
+	}
+}
+
+// AutoScanEnabled reports whether the background scan is on (default true
+// when unset).
+func (c *IntegrityConfig) AutoScanEnabled() bool {
+	return c.AutoEnabled == nil || *c.AutoEnabled
+}
+
+// Validate returns an error if the IntegrityConfig has invalid values.
+//
+// The floor is 5m rather than GC's 1m because a scan is a full metadata
+// walk of every share: on a store of any size a sub-5m cadence leaves the
+// scan running continuously, which is a scheduling mistake rather than an
+// aggressive setting.
+func (c *IntegrityConfig) Validate() error {
+	if c.AutoInterval < 0 {
+		return fmt.Errorf("integrity.auto_interval must be >= 0 (got %v)", c.AutoInterval)
+	}
+	if c.AutoInterval > 0 && c.AutoInterval < 5*time.Minute {
+		return fmt.Errorf("integrity.auto_interval must be >= 5m; the scan is a full metadata walk per share (got %v); set 0 to use the 24h default", c.AutoInterval)
 	}
 	return nil
 }

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -24,6 +24,7 @@ func ApplyDefaults(cfg *Config) {
 	applyAdminDefaults(&cfg.Admin)
 	applyKerberosDefaults(&cfg.Kerberos)
 	cfg.GC.ApplyDefaults()
+	cfg.Integrity.ApplyDefaults()
 	cfg.Snapshot.ApplyDefaults()
 	cfg.Blockstore.ApplyDefaults()
 	cfg.Metadata.ApplyDefaults()

--- a/pkg/config/integrity_test.go
+++ b/pkg/config/integrity_test.go
@@ -46,3 +46,30 @@ func TestIntegrityConfig_Validate(t *testing.T) {
 		})
 	}
 }
+
+// TestLoad_IntegrityAutoEnv_RoundTrip proves the *bool and Duration scan knobs
+// decode from env through Load, the way the auto-GC pair does.
+func TestLoad_IntegrityAutoEnv_RoundTrip(t *testing.T) {
+	content := `
+database:
+  type: sqlite
+controlplane:
+  jwt:
+    secret: "test-secret-key-for-testing-minimum-32-chars"
+`
+	path := writeConfigFile(t, content)
+
+	t.Setenv("DITTOFS_INTEGRITY_AUTO_ENABLED", "false")
+	t.Setenv("DITTOFS_INTEGRITY_AUTO_INTERVAL", "6h")
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Integrity.AutoScanEnabled() {
+		t.Errorf("integrity.auto_enabled: env override dropped, got true want false")
+	}
+	if cfg.Integrity.AutoInterval != 6*time.Hour {
+		t.Errorf("integrity.auto_interval: env override dropped, got %v want 6h", cfg.Integrity.AutoInterval)
+	}
+}

--- a/pkg/config/integrity_test.go
+++ b/pkg/config/integrity_test.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIntegrityConfig_Defaults(t *testing.T) {
+	var c IntegrityConfig
+	c.ApplyDefaults()
+	if !c.AutoScanEnabled() {
+		t.Error("AutoScanEnabled() = false after defaults, want true (scan on by default)")
+	}
+	if c.AutoInterval != 24*time.Hour {
+		t.Errorf("AutoInterval = %v, want 24h", c.AutoInterval)
+	}
+}
+
+func TestIntegrityConfig_ExplicitOff(t *testing.T) {
+	off := false
+	c := IntegrityConfig{AutoEnabled: &off}
+	c.ApplyDefaults()
+	if c.AutoScanEnabled() {
+		t.Error("AutoScanEnabled() = true, want false when explicitly disabled")
+	}
+}
+
+func TestIntegrityConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name     string
+		interval time.Duration
+		wantErr  bool
+	}{
+		{"unset uses default", 0, false},
+		{"negative rejected", -time.Second, true},
+		{"below floor rejected", time.Minute, true},
+		{"at floor accepted", 5 * time.Minute, false},
+		{"daily accepted", 24 * time.Hour, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := IntegrityConfig{AutoInterval: tc.interval}
+			if err := c.Validate(); (err != nil) != tc.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -46,6 +46,7 @@ func Validate(cfg *Config) error {
 	if err := cfg.Integrity.Validate(); err != nil {
 		return err
 	}
+
 	if err := cfg.Snapshot.Validate(); err != nil {
 		return err
 	}

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -43,6 +43,9 @@ func Validate(cfg *Config) error {
 		return err
 	}
 
+	if err := cfg.Integrity.Validate(); err != nil {
+		return err
+	}
 	if err := cfg.Snapshot.Validate(); err != nil {
 		return err
 	}

--- a/pkg/controlplane/runtime/integrity_scheduler.go
+++ b/pkg/controlplane/runtime/integrity_scheduler.go
@@ -143,15 +143,20 @@ func (r *Runtime) ShareIntegrity(share string) *health.IntegrityStatus {
 // A worse status from a subsystem probe always wins; the scan can only
 // downgrade a healthy share, never upgrade an unhealthy one.
 func (r *Runtime) ShareStatus(ctx context.Context, share string) health.ShareStatus {
-	out := health.ShareStatus{
-		Report:    r.ShareChecker(share).Healthcheck(ctx),
-		Integrity: r.ShareIntegrity(share),
+	return withIntegrity(r.ShareChecker(share).Healthcheck(ctx), r.ShareIntegrity(share))
+}
+
+// withIntegrity joins a subsystem health report to a recorded scan outcome,
+// downgrading a healthy share to degraded when the scan found damage. Pure
+// function — no I/O — so the downgrade rule can be tested on its own.
+func withIntegrity(rep health.Report, in *health.IntegrityStatus) health.ShareStatus {
+	out := health.ShareStatus{Report: rep, Integrity: in}
+	if in == nil || in.DamagedPayloads == 0 || rep.Status != health.StatusHealthy {
+		return out
 	}
-	if out.Integrity != nil && out.Integrity.DamagedPayloads > 0 && out.Status == health.StatusHealthy {
-		out.Status = health.StatusDegraded
-		out.Message = fmt.Sprintf(
-			"integrity: %d damaged payloads of %d with findings; run `dfsctl store check` for detail",
-			out.Integrity.DamagedPayloads, out.Integrity.PayloadsWithFindings)
-	}
+	out.Status = health.StatusDegraded
+	out.Message = fmt.Sprintf(
+		"integrity: %d damaged payloads of %d with findings; run `dfsctl store check` for detail",
+		in.DamagedPayloads, in.PayloadsWithFindings)
 	return out
 }

--- a/pkg/controlplane/runtime/integrity_scheduler.go
+++ b/pkg/controlplane/runtime/integrity_scheduler.go
@@ -2,11 +2,13 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime/shares"
 	"github.com/marmos91/dittofs/pkg/health"
 )
 
@@ -74,6 +76,12 @@ func (r *Runtime) scanShareIntegrity(ctx context.Context, share string) {
 		// Context cancellation is shutdown, not a finding: recording it
 		// would leave every share reporting a failed scan across a restart.
 		if ctx.Err() != nil {
+			return
+		}
+		// The share list is sampled once per tick, so a share removed since
+		// then fails here. Recording that would put an entry back for a name
+		// the removal just cleared, and describe a share that is gone.
+		if errors.Is(err, shares.ErrShareNotFound) {
 			return
 		}
 		logger.Error("integrity scan: share scan failed", logger.KeyShare, share, "error", err)

--- a/pkg/controlplane/runtime/integrity_scheduler.go
+++ b/pkg/controlplane/runtime/integrity_scheduler.go
@@ -17,17 +17,16 @@ import (
 //
 // Each tick scans the shares one at a time and synchronously, so runs never
 // overlap and the walk never competes with itself for the metadata store. A
-// long run simply delays the next tick. The scan writes nothing — it plans
-// no repairs and applies none — so a tick skipped by shutdown or an error
-// costs only freshness, and the next tick catches up.
+// long run simply delays the next tick. The scan writes nothing, so a tick
+// skipped by shutdown or an error costs only freshness; the next tick
+// catches up.
 //
-// ponytail: a ticker, so the schedule restarts from zero on every server
-// start and a box restarted more often than the interval never scans. The
-// fix is to persist the last-run time per share and scan at startup when it
-// is older than the interval; do that once operators actually report boxes
-// that never complete a scan, because scanning at every boot puts a full
-// metadata walk on the startup path, which is the cost this scheduler exists
-// to keep off it.
+// ponytail: a plain ticker, so the schedule restarts from zero on every
+// server start and a box restarted more often than the interval never
+// completes a scan. Upgrade to a persisted per-share last-run time, scanning
+// at startup when it is older than the interval, once operators report such
+// boxes — it puts a full metadata walk on the startup path, which is the
+// cost this scheduler exists to keep off it.
 func (r *Runtime) StartScheduledIntegrityScan(ctx context.Context, interval time.Duration) {
 	if interval <= 0 {
 		interval = 24 * time.Hour
@@ -85,7 +84,7 @@ func (r *Runtime) scanShareIntegrity(ctx context.Context, share string) {
 		return
 	}
 
-	status := &health.IntegrityStatus{
+	r.setShareIntegrity(share, &health.IntegrityStatus{
 		LastRunAt:              res.CompletedAt,
 		DurationMS:             res.DurationMS,
 		FilesScanned:           res.FilesScanned,
@@ -94,8 +93,7 @@ func (r *Runtime) scanShareIntegrity(ctx context.Context, share string) {
 		ClaimedUncoveredRanges: res.ClaimedUncoveredRanges,
 		UnplaceableRows:        res.UnplaceableRows,
 		UnknownHashRows:        res.UnknownHashRows,
-	}
-	r.setShareIntegrity(share, status)
+	})
 
 	if res.DamagedPayloads > 0 {
 		logger.Warn("integrity scan: share has damaged payloads",
@@ -120,12 +118,12 @@ func (r *Runtime) setShareIntegrity(share string, status *health.IntegrityStatus
 
 // ShareIntegrity returns the named share's most recent scan outcome, or nil
 // when no scan has run for it in this process. The returned value is a copy,
-// safe to hand to a caller that outlives the next scan.
+// so a caller never holds a pointer into state the next scan replaces.
 func (r *Runtime) ShareIntegrity(share string) *health.IntegrityStatus {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	status, ok := r.shareIntegrity[share]
-	if !ok || status == nil {
+	status := r.shareIntegrity[share]
+	if status == nil {
 		return nil
 	}
 	cp := *status
@@ -133,12 +131,9 @@ func (r *Runtime) ShareIntegrity(share string) *health.IntegrityStatus {
 }
 
 // ShareStatus returns the named share's health report together with the
-// structural counters recorded alongside it. It is what a client asking
-// "is this share alright" should be given: a share whose manifest scan
-// found damaged payloads is reported degraded even though every subsystem
-// probe comes back healthy, because that damage is invisible to the probes
-// — an uncovered range a file still claims reads back as zeros and reports
-// success.
+// structural counters recorded alongside it. A share whose manifest scan
+// found damaged payloads reads as degraded even when every subsystem probe
+// comes back healthy, because that damage is invisible to the probes.
 //
 // A worse status from a subsystem probe always wins; the scan can only
 // downgrade a healthy share, never upgrade an unhealthy one.

--- a/pkg/controlplane/runtime/integrity_scheduler.go
+++ b/pkg/controlplane/runtime/integrity_scheduler.go
@@ -69,7 +69,23 @@ func (r *Runtime) runIntegrityScanOnce(ctx context.Context) {
 	}
 }
 
-// scanShareIntegrity runs one read-only manifest scan and records the result.
+// recordShareIntegrity stores a completed scan's outcome as the share's current
+// integrity status. Called by every scan, scheduled or operator-run.
+func (r *Runtime) recordShareIntegrity(share string, res *engine.ManifestCheckResult) {
+	r.setShareIntegrity(share, &health.IntegrityStatus{
+		LastRunAt:              res.CompletedAt,
+		DurationMS:             res.DurationMS,
+		FilesScanned:           res.FilesScanned,
+		PayloadsWithFindings:   res.PayloadsWithFindings,
+		DamagedPayloads:        res.DamagedPayloads,
+		ClaimedUncoveredRanges: res.ClaimedUncoveredRanges,
+		UnplaceableRows:        res.UnplaceableRows,
+		UnknownHashRows:        res.UnknownHashRows,
+	})
+}
+
+// scanShareIntegrity runs one read-only manifest scan. CheckManifests records
+// the outcome; this adds the failure case and the operator-facing warning.
 func (r *Runtime) scanShareIntegrity(ctx context.Context, share string) {
 	res, err := r.CheckManifests(ctx, share, engine.ManifestCheckOptions{})
 	if err != nil {
@@ -91,17 +107,6 @@ func (r *Runtime) scanShareIntegrity(ctx context.Context, share string) {
 		})
 		return
 	}
-
-	r.setShareIntegrity(share, &health.IntegrityStatus{
-		LastRunAt:              res.CompletedAt,
-		DurationMS:             res.DurationMS,
-		FilesScanned:           res.FilesScanned,
-		PayloadsWithFindings:   res.PayloadsWithFindings,
-		DamagedPayloads:        res.DamagedPayloads,
-		ClaimedUncoveredRanges: res.ClaimedUncoveredRanges,
-		UnplaceableRows:        res.UnplaceableRows,
-		UnknownHashRows:        res.UnknownHashRows,
-	})
 
 	if res.DamagedPayloads > 0 {
 		logger.Warn("integrity scan: share has damaged payloads",

--- a/pkg/controlplane/runtime/integrity_scheduler.go
+++ b/pkg/controlplane/runtime/integrity_scheduler.go
@@ -1,0 +1,157 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/health"
+)
+
+// StartScheduledIntegrityScan runs the structural manifest scan over every
+// share on the given interval until ctx is cancelled. It returns
+// immediately; the loop runs in its own goroutine and exits when ctx is
+// done (server shutdown).
+//
+// Each tick scans the shares one at a time and synchronously, so runs never
+// overlap and the walk never competes with itself for the metadata store. A
+// long run simply delays the next tick. The scan writes nothing — it plans
+// no repairs and applies none — so a tick skipped by shutdown or an error
+// costs only freshness, and the next tick catches up.
+//
+// ponytail: a ticker, so the schedule restarts from zero on every server
+// start and a box restarted more often than the interval never scans. The
+// fix is to persist the last-run time per share and scan at startup when it
+// is older than the interval; do that once operators actually report boxes
+// that never complete a scan, because scanning at every boot puts a full
+// metadata walk on the startup path, which is the cost this scheduler exists
+// to keep off it.
+func (r *Runtime) StartScheduledIntegrityScan(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = 24 * time.Hour
+	}
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		logger.Info("integrity scan: scheduler started", "interval", interval)
+		for {
+			select {
+			case <-ctx.Done():
+				logger.Info("integrity scan: scheduler stopped")
+				return
+			case <-ticker.C:
+				// A tick and ctx.Done() can be ready at the same time and
+				// select picks at random. Re-check so shutdown never
+				// triggers one last walk.
+				if ctx.Err() != nil {
+					logger.Info("integrity scan: scheduler stopped")
+					return
+				}
+				r.runIntegrityScanOnce(ctx)
+			}
+		}
+	}()
+}
+
+// runIntegrityScanOnce scans every registered share once, recording each
+// outcome for the share's status report. Errors are logged and recorded,
+// never fatal — one unscannable share must not stop the others or the
+// scheduler.
+func (r *Runtime) runIntegrityScanOnce(ctx context.Context) {
+	for _, name := range r.ListShares() {
+		if ctx.Err() != nil {
+			return
+		}
+		r.scanShareIntegrity(ctx, name)
+	}
+}
+
+// scanShareIntegrity runs one read-only manifest scan and records the result.
+func (r *Runtime) scanShareIntegrity(ctx context.Context, share string) {
+	res, err := r.CheckManifests(ctx, share, engine.ManifestCheckOptions{})
+	if err != nil {
+		// Context cancellation is shutdown, not a finding: recording it
+		// would leave every share reporting a failed scan across a restart.
+		if ctx.Err() != nil {
+			return
+		}
+		logger.Error("integrity scan: share scan failed", logger.KeyShare, share, "error", err)
+		r.setShareIntegrity(share, &health.IntegrityStatus{
+			LastRunAt: time.Now().UTC(),
+			Error:     err.Error(),
+		})
+		return
+	}
+
+	status := &health.IntegrityStatus{
+		LastRunAt:              res.CompletedAt,
+		DurationMS:             res.DurationMS,
+		FilesScanned:           res.FilesScanned,
+		PayloadsWithFindings:   res.PayloadsWithFindings,
+		DamagedPayloads:        res.DamagedPayloads,
+		ClaimedUncoveredRanges: res.ClaimedUncoveredRanges,
+		UnplaceableRows:        res.UnplaceableRows,
+		UnknownHashRows:        res.UnknownHashRows,
+	}
+	r.setShareIntegrity(share, status)
+
+	if res.DamagedPayloads > 0 {
+		logger.Warn("integrity scan: share has damaged payloads",
+			logger.KeyShare, share,
+			"damaged_payloads", res.DamagedPayloads,
+			"claimed_uncovered_ranges", res.ClaimedUncoveredRanges,
+			"unplaceable_rows", res.UnplaceableRows,
+			"unknown_hash_rows", res.UnknownHashRows,
+		)
+	}
+}
+
+// setShareIntegrity records a share's latest scan outcome.
+func (r *Runtime) setShareIntegrity(share string, status *health.IntegrityStatus) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.shareIntegrity == nil {
+		r.shareIntegrity = make(map[string]*health.IntegrityStatus)
+	}
+	r.shareIntegrity[share] = status
+}
+
+// ShareIntegrity returns the named share's most recent scan outcome, or nil
+// when no scan has run for it in this process. The returned value is a copy,
+// safe to hand to a caller that outlives the next scan.
+func (r *Runtime) ShareIntegrity(share string) *health.IntegrityStatus {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	status, ok := r.shareIntegrity[share]
+	if !ok || status == nil {
+		return nil
+	}
+	cp := *status
+	return &cp
+}
+
+// ShareStatus returns the named share's health report together with the
+// structural counters recorded alongside it. It is what a client asking
+// "is this share alright" should be given: a share whose manifest scan
+// found damaged payloads is reported degraded even though every subsystem
+// probe comes back healthy, because that damage is invisible to the probes
+// — an uncovered range a file still claims reads back as zeros and reports
+// success.
+//
+// A worse status from a subsystem probe always wins; the scan can only
+// downgrade a healthy share, never upgrade an unhealthy one.
+func (r *Runtime) ShareStatus(ctx context.Context, share string) health.ShareStatus {
+	out := health.ShareStatus{
+		Report:    r.ShareChecker(share).Healthcheck(ctx),
+		Integrity: r.ShareIntegrity(share),
+	}
+	if out.Integrity != nil && out.Integrity.DamagedPayloads > 0 && out.Status == health.StatusHealthy {
+		out.Status = health.StatusDegraded
+		out.Message = fmt.Sprintf(
+			"integrity: %d damaged payloads of %d with findings; run `dfsctl store check` for detail",
+			out.Integrity.DamagedPayloads, out.Integrity.PayloadsWithFindings)
+	}
+	return out
+}

--- a/pkg/controlplane/runtime/integrity_scheduler_test.go
+++ b/pkg/controlplane/runtime/integrity_scheduler_test.go
@@ -1,0 +1,90 @@
+package runtime
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block/remote"
+	"github.com/marmos91/dittofs/pkg/health"
+)
+
+// TestStartScheduledIntegrityScan_TicksAndStops verifies the scheduler walks
+// every registered share on its interval, records the outcome where the
+// status report can find it, and exits when its context is cancelled. The
+// scan itself is real — a genuine metadata walk over an (empty) share — so a
+// break anywhere between the ticker and the recorded status fails here.
+func TestStartScheduledIntegrityScan_TicksAndStops(t *testing.T) {
+	rt := newRuntimeForGC(t, map[string]remote.RemoteStore{"/share-a": &fakeRemoteStore{name: "s3"}})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	rt.StartScheduledIntegrityScan(ctx, 10*time.Millisecond)
+
+	deadline := time.Now().Add(2 * time.Second)
+	var got *health.IntegrityStatus
+	for time.Now().Before(deadline) {
+		if got = rt.ShareIntegrity("/share-a"); got != nil {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got == nil {
+		t.Fatal("no integrity status recorded for /share-a after 2s")
+	}
+	if got.Error != "" {
+		t.Fatalf("scan reported an error: %s", got.Error)
+	}
+	if got.LastRunAt.IsZero() {
+		t.Error("LastRunAt is zero; the status was recorded without a run time")
+	}
+	if got.DamagedPayloads != 0 {
+		t.Errorf("DamagedPayloads = %d on an empty share, want 0", got.DamagedPayloads)
+	}
+
+	cancel()
+	time.Sleep(30 * time.Millisecond)
+	stopped := rt.ShareIntegrity("/share-a").LastRunAt
+	time.Sleep(60 * time.Millisecond)
+	if after := rt.ShareIntegrity("/share-a").LastRunAt; !after.Equal(stopped) {
+		t.Errorf("scheduler kept running after cancel: %v -> %v", stopped, after)
+	}
+}
+
+// TestWithIntegrity_DowngradeRule pins the one piece of judgement in the
+// status join: damage degrades a healthy share, and never touches a share
+// that is already worse off.
+func TestWithIntegrity_DowngradeRule(t *testing.T) {
+	healthy := health.Report{Status: health.StatusHealthy}
+	unhealthy := health.Report{Status: health.StatusUnhealthy, Message: "block: remote unreachable"}
+
+	tests := []struct {
+		name       string
+		rep        health.Report
+		in         *health.IntegrityStatus
+		wantStatus health.Status
+		wantMsg    string
+	}{
+		{"no scan yet", healthy, nil, health.StatusHealthy, ""},
+		{"clean scan", healthy, &health.IntegrityStatus{FilesScanned: 10}, health.StatusHealthy, ""},
+		{"damage degrades", healthy, &health.IntegrityStatus{DamagedPayloads: 3, PayloadsWithFindings: 5}, health.StatusDegraded, "3 damaged payloads of 5"},
+		{"never upgrades", unhealthy, &health.IntegrityStatus{DamagedPayloads: 3}, health.StatusUnhealthy, "block: remote unreachable"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := withIntegrity(tc.rep, tc.in)
+			if got.Status != tc.wantStatus {
+				t.Errorf("Status = %q, want %q", got.Status, tc.wantStatus)
+			}
+			if tc.wantMsg != "" && !strings.Contains(got.Message, tc.wantMsg) {
+				t.Errorf("Message = %q, want it to contain %q", got.Message, tc.wantMsg)
+			}
+			if tc.wantMsg == "" && got.Message != "" {
+				t.Errorf("Message = %q, want empty", got.Message)
+			}
+			if got.Integrity != tc.in {
+				t.Error("Integrity was not carried through to the status")
+			}
+		})
+	}
+}

--- a/pkg/controlplane/runtime/integrity_scheduler_test.go
+++ b/pkg/controlplane/runtime/integrity_scheduler_test.go
@@ -88,3 +88,41 @@ func TestWithIntegrity_DowngradeRule(t *testing.T) {
 		})
 	}
 }
+
+// TestIntegritySnapshot_FailedScanIsNotNeverScanned pins the distinction the
+// metrics surface has to keep: a scan that fails publishes no counts and no
+// completion time, exactly like a share never scanned, so the failure has to
+// be flagged separately or a permanently-erroring scanner reads as a disabled
+// one forever.
+func TestIntegritySnapshot_FailedScanIsNotNeverScanned(t *testing.T) {
+	never := integritySnapshot(nil)
+	if never.LastScanUnix != 0 || never.LastScanFailed {
+		t.Errorf("never scanned = %+v, want zero timestamp and failed=false", never)
+	}
+
+	failed := integritySnapshot(&health.IntegrityStatus{
+		LastRunAt: time.Now().UTC(),
+		Error:     "metadata store unavailable",
+	})
+	if !failed.LastScanFailed {
+		t.Error("a failed scan did not set LastScanFailed")
+	}
+	if failed.LastScanUnix != 0 {
+		t.Errorf("LastScanUnix = %d after a failed scan, want 0 (nothing completed)", failed.LastScanUnix)
+	}
+	if failed.FilesScanned != 0 || failed.DamagedPayloads != 0 {
+		t.Errorf("failed scan published counts: %+v", failed)
+	}
+
+	ok := integritySnapshot(&health.IntegrityStatus{
+		LastRunAt:       time.Unix(1700000000, 0).UTC(),
+		FilesScanned:    42,
+		DamagedPayloads: 1,
+	})
+	if ok.LastScanFailed {
+		t.Error("a completed scan was flagged as failed")
+	}
+	if ok.LastScanUnix != 1700000000 || ok.FilesScanned != 42 || ok.DamagedPayloads != 1 {
+		t.Errorf("completed scan = %+v, want the recorded values", ok)
+	}
+}

--- a/pkg/controlplane/runtime/manifestcheck.go
+++ b/pkg/controlplane/runtime/manifestcheck.go
@@ -50,6 +50,11 @@ func (r *Runtime) CheckManifests(ctx context.Context, shareName string, opts eng
 		return nil, err
 	}
 	res.SyncedCheckSkipped = skipped
+	// Every scan of a share refreshes what its status reports, whoever asked
+	// for it. An operator who has just run a repair by hand would otherwise
+	// keep seeing the findings it fixed until the next scheduled tick, and
+	// read that as the repair having failed.
+	r.recordShareIntegrity(shareName, res)
 	logger.Info("store check: complete",
 		logger.KeyShare, shareName,
 		"files_scanned", res.FilesScanned,

--- a/pkg/controlplane/runtime/metrics.go
+++ b/pkg/controlplane/runtime/metrics.go
@@ -111,9 +111,15 @@ func quotaPrincipalLabel(id uint32) string {
 // surface. A share never scanned in this process, or whose last scan failed,
 // reports zeros: a zero last-scan timestamp is what an alert on scan age is
 // meant to fire on, and a failed scan produced no counts worth publishing.
+// The failed case is flagged rather than left to look like the never-scanned
+// one, so a scanner erroring every tick does not read as one that was never
+// switched on.
 func integritySnapshot(s *health.IntegrityStatus) metrics.IntegrityScanSnapshot {
-	if s == nil || s.Error != "" {
+	if s == nil {
 		return metrics.IntegrityScanSnapshot{}
+	}
+	if s.Error != "" {
+		return metrics.IntegrityScanSnapshot{LastScanFailed: true}
 	}
 	return metrics.IntegrityScanSnapshot{
 		LastScanUnix:           s.LastRunAt.Unix(),

--- a/pkg/controlplane/runtime/metrics.go
+++ b/pkg/controlplane/runtime/metrics.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/health"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metrics"
 )
@@ -45,6 +46,7 @@ func (r *Runtime) MetricsSnapshot(ctx context.Context) metrics.Snapshot {
 			FileCount:           int64(st.FileCount),
 			SnapshotsHeld:       held,
 			LastSnapshotUnix:    lastUnix,
+			Integrity:           integritySnapshot(r.ShareIntegrity(ps.ShareName)),
 		})
 	}
 
@@ -103,4 +105,24 @@ func quotaPrincipalLabel(id uint32) string {
 		return "default"
 	}
 	return strconv.FormatUint(uint64(id), 10)
+}
+
+// integritySnapshot renders a recorded manifest-scan outcome for the metrics
+// surface. A share never scanned in this process, or whose last scan failed,
+// reports zeros: a zero last-scan timestamp is what an alert on scan age is
+// meant to fire on, and a failed scan produced no counts worth publishing.
+func integritySnapshot(s *health.IntegrityStatus) metrics.IntegrityScanSnapshot {
+	if s == nil || s.Error != "" {
+		return metrics.IntegrityScanSnapshot{}
+	}
+	return metrics.IntegrityScanSnapshot{
+		LastScanUnix:           s.LastRunAt.Unix(),
+		DurationSeconds:        float64(s.DurationMS) / 1000,
+		FilesScanned:           int64(s.FilesScanned),
+		PayloadsWithFindings:   int64(s.PayloadsWithFindings),
+		DamagedPayloads:        int64(s.DamagedPayloads),
+		ClaimedUncoveredRanges: int64(s.ClaimedUncoveredRanges),
+		UnplaceableRows:        int64(s.UnplaceableRows),
+		UnknownHashRows:        int64(s.UnknownHashRows),
+	}
 }

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -119,6 +119,13 @@ type Runtime struct {
 	// is successfully added or removed. Guarded by mu.
 	skippedShares map[string]string
 
+	// shareIntegrity maps a share name to the outcome of the most recent
+	// structural manifest scan for it. Empty until the scheduled scan has
+	// run, and process-local: a restart clears it, which reads honestly as
+	// "not verified since this process started" rather than as a stale
+	// clean bill of health. Guarded by mu.
+	shareIntegrity map[string]*health.IntegrityStatus
+
 	// metrics is the Prometheus metrics handle, set at startup. It is the
 	// carrier for inline adapter instruments (RED, connection, auth counters):
 	// adapters reach it via Runtime so no per-adapter plumbing is needed. May

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -476,12 +476,16 @@ func (r *Runtime) shareSkipReason(name string) (string, bool) {
 	return reason, ok
 }
 
-// clearShareSkipped drops any recorded skip reason for a share, so a name that
-// is successfully added or removed stops reporting a stale boot-time failure.
-func (r *Runtime) clearShareSkipped(name string) {
+// clearShareState drops the per-name state the runtime records about a share
+// outside the share registry: the reason it was refused, and the outcome of the
+// last integrity scan over it. Called when a name is successfully added or
+// removed, so neither a stale boot-time failure nor a scan result describing a
+// share that no longer exists resurfaces under a reused name.
+func (r *Runtime) clearShareState(name string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	delete(r.skippedShares, name)
+	delete(r.shareIntegrity, name)
 }
 
 // HealthcheckShare returns the named share's overall health, computed
@@ -575,7 +579,7 @@ func (r *Runtime) AddShare(ctx context.Context, config *ShareConfig) error {
 		return err
 	}
 	// The share is serving now, so any earlier refusal no longer describes it.
-	r.clearShareSkipped(config.Name)
+	r.clearShareState(config.Name)
 	// Wire quota into the metadata service (0 = unlimited).
 	// Always set explicitly to ensure consistency after restarts when a
 	// quota was removed (set to 0) via the API.
@@ -668,7 +672,7 @@ func (r *Runtime) RemoveShare(name string) error {
 	rmErr := r.sharesSvc.RemoveShare(name)
 	// The share is gone, so a recorded refusal would outlive its subject and
 	// resurface if a new share reused the name.
-	r.clearShareSkipped(name)
+	r.clearShareState(name)
 	// Deregister the share's per-share store / lock manager / unified view /
 	// notifier / quota from the metadata service, mirroring the AddShare
 	// registration above. Without this the service maps grow unbounded across

--- a/pkg/controlplane/runtime/share_skip_status_test.go
+++ b/pkg/controlplane/runtime/share_skip_status_test.go
@@ -52,7 +52,7 @@ func TestHealthcheckShare_SkipReasonClearedOnAddAndRemove(t *testing.T) {
 		t.Fatal("expected the skip reason to be recorded")
 	}
 
-	rt.clearShareSkipped("/s")
+	rt.clearShareState("/s")
 	if _, skipped := rt.shareSkipReason("/s"); skipped {
 		t.Error("expected the skip reason to be cleared")
 	}
@@ -69,7 +69,7 @@ func TestShareSkipReason_IsPerShare(t *testing.T) {
 	rt := newRuntimeForSkipStatus()
 
 	rt.markShareSkipped("/a", "reason a")
-	rt.clearShareSkipped("/b")
+	rt.clearShareState("/b")
 
 	if reason, skipped := rt.shareSkipReason("/a"); !skipped || reason != "reason a" {
 		t.Errorf("shareSkipReason(/a) = (%q, %v), want (\"reason a\", true)", reason, skipped)

--- a/pkg/health/share.go
+++ b/pkg/health/share.go
@@ -8,9 +8,8 @@ import "time"
 // every existing consumer of the report fields is unaffected.
 //
 // Counters live here rather than in [Report.Message] because they are
-// numbers an operator charts and alerts on, and because a share can have
-// several independent things worth reporting at once — prose collapses
-// them into one string that nothing can parse back apart.
+// numbers an operator charts and alerts on, and a share can have several
+// worth reporting at once.
 type ShareStatus struct {
 	Report
 
@@ -28,8 +27,8 @@ type ShareStatus struct {
 // list: a claimed-but-uncovered span, a row carrying no placeable chunk
 // offset, or a row whose hash the synced-hash store does not know. The
 // first of those is invisible at read time — an absent row is how sparse
-// holes are represented, so the read path returns zeros and reports
-// success — which is why the scan exists.
+// holes are represented, so the read returns zeros and reports success —
+// which is why the scan exists.
 type IntegrityStatus struct {
 	// LastRunAt is when the scan completed (UTC).
 	LastRunAt time.Time `json:"last_run_at"`

--- a/pkg/health/share.go
+++ b/pkg/health/share.go
@@ -1,0 +1,60 @@
+package health
+
+import "time"
+
+// ShareStatus is a share's health report plus the structured per-share
+// counters that belong next to it. The [Report] is embedded, so the JSON
+// form is a plain report with optional extra objects hanging off it and
+// every existing consumer of the report fields is unaffected.
+//
+// Counters live here rather than in [Report.Message] because they are
+// numbers an operator charts and alerts on, and because a share can have
+// several independent things worth reporting at once — prose collapses
+// them into one string that nothing can parse back apart.
+type ShareStatus struct {
+	Report
+
+	// Integrity is the outcome of the most recent structural manifest
+	// scan for this share. Nil when no scan has run yet.
+	Integrity *IntegrityStatus `json:"integrity,omitempty"`
+}
+
+// IntegrityStatus summarises one structural manifest scan: what it looked
+// at, when, and what it found. It is metadata-only — no block is fetched
+// and no remote object is touched to produce it.
+//
+// DamagedPayloads is the field that matters. A payload is damaged when the
+// scan found evidence the manifest disagrees with the file's own block
+// list: a claimed-but-uncovered span, a row carrying no placeable chunk
+// offset, or a row whose hash the synced-hash store does not know. The
+// first of those is invisible at read time — an absent row is how sparse
+// holes are represented, so the read path returns zeros and reports
+// success — which is why the scan exists.
+type IntegrityStatus struct {
+	// LastRunAt is when the scan completed (UTC).
+	LastRunAt time.Time `json:"last_run_at"`
+
+	// DurationMS is the scan's wall-clock cost in milliseconds.
+	DurationMS int64 `json:"duration_ms"`
+
+	// FilesScanned is the number of regular files walked.
+	FilesScanned uint64 `json:"files_scanned"`
+
+	// PayloadsWithFindings is the number of payloads the scan had
+	// something to say about, damage or not.
+	PayloadsWithFindings uint64 `json:"payloads_with_findings"`
+
+	// DamagedPayloads is the subset of those holding evidence of damage.
+	DamagedPayloads uint64 `json:"damaged_payloads"`
+
+	// Findings by kind, so an operator can tell which defect is present
+	// without re-running the scan by hand.
+	ClaimedUncoveredRanges uint64 `json:"claimed_uncovered_ranges"`
+	UnplaceableRows        uint64 `json:"unplaceable_rows"`
+	UnknownHashRows        uint64 `json:"unknown_hash_rows"`
+
+	// Error names why the scan did not complete, empty when it did. A
+	// failed scan keeps the previous run's counters out of the report
+	// rather than presenting stale numbers as current.
+	Error string `json:"error,omitempty"`
+}

--- a/pkg/metrics/collectors.go
+++ b/pkg/metrics/collectors.go
@@ -42,6 +42,7 @@ type runtimeCollector struct {
 
 	// Per-share structural integrity scan.
 	integrityLastScan     *prometheus.Desc
+	integrityScanFailed   *prometheus.Desc
 	integrityScanDuration *prometheus.Desc
 	integrityFilesScanned *prometheus.Desc
 	integrityFindings     *prometheus.Desc
@@ -87,7 +88,8 @@ func newRuntimeCollector(p Provider) *runtimeCollector {
 		snapshotsActive:  d(fqdn("snapshot", "active"), "Number of ready (held) snapshots.", share),
 		snapshotLastTime: d(fqdn("snapshot", "last_success_timestamp_seconds"), "Unix time of the most recent ready snapshot (0 = none).", share),
 
-		integrityLastScan:     d(fqdn("integrity", "last_scan_timestamp_seconds"), "Unix time the structural manifest scan last completed for this share (0 = never scanned since process start).", share),
+		integrityLastScan:     d(fqdn("integrity", "last_scan_timestamp_seconds"), "Unix time the structural manifest scan last completed for this share. 0 means it has either never run since process start or its last attempt failed; dittofs_integrity_last_scan_failed tells those apart.", share),
+		integrityScanFailed:   d(fqdn("integrity", "last_scan_failed"), "Whether the most recent structural manifest scan for this share failed (1) or completed (0). 0 on a share never scanned.", share),
 		integrityScanDuration: d(fqdn("integrity", "last_scan_duration_seconds"), "Wall-clock duration of the last structural manifest scan.", share),
 		integrityFilesScanned: d(fqdn("integrity", "files_scanned"), "Regular files walked by the last structural manifest scan.", share),
 		integrityFindings:     d(fqdn("integrity", "findings"), "Findings from the last structural manifest scan, by kind: payloads_with_findings, damaged_payloads, claimed_uncovered_ranges, unplaceable_rows, unknown_hash_rows.", finding),
@@ -116,7 +118,7 @@ func (c *runtimeCollector) allDescs() []*prometheus.Desc {
 		c.remoteUp, c.remoteOutage, c.remoteReadsBlocked,
 		c.logicalBytes, c.storeFiles,
 		c.snapshotsActive, c.snapshotLastTime,
-		c.integrityLastScan, c.integrityScanDuration, c.integrityFilesScanned, c.integrityFindings,
+		c.integrityLastScan, c.integrityScanFailed, c.integrityScanDuration, c.integrityFilesScanned, c.integrityFindings,
 		c.quotaUsedBytes, c.quotaLimitBytes, c.quotaUsedInodes, c.quotaLimitInodes,
 		c.clientsActive,
 	}
@@ -148,6 +150,7 @@ func (c *runtimeCollector) Collect(ch chan<- prometheus.Metric) {
 
 		in := s.Integrity
 		gauge(c.integrityLastScan, float64(in.LastScanUnix), s.Name)
+		gauge(c.integrityScanFailed, boolToFloat(in.LastScanFailed), s.Name)
 		gauge(c.integrityScanDuration, in.DurationSeconds, s.Name)
 		gauge(c.integrityFilesScanned, float64(in.FilesScanned), s.Name)
 		gauge(c.integrityFindings, float64(in.PayloadsWithFindings), s.Name, "payloads_with_findings")

--- a/pkg/metrics/collectors.go
+++ b/pkg/metrics/collectors.go
@@ -40,6 +40,12 @@ type runtimeCollector struct {
 	snapshotsActive  *prometheus.Desc
 	snapshotLastTime *prometheus.Desc
 
+	// Per-share structural integrity scan.
+	integrityLastScan     *prometheus.Desc
+	integrityScanDuration *prometheus.Desc
+	integrityFilesScanned *prometheus.Desc
+	integrityFindings     *prometheus.Desc
+
 	// Per-principal quotas.
 	quotaUsedBytes   *prometheus.Desc
 	quotaLimitBytes  *prometheus.Desc
@@ -53,6 +59,7 @@ type runtimeCollector struct {
 func newRuntimeCollector(p Provider) *runtimeCollector {
 	share := []string{"share"}
 	quota := []string{"scope", "principal", "share"}
+	finding := []string{"share", "kind"}
 	fqdn := func(sub, name string) string { return prometheus.BuildFQName(Namespace, sub, name) }
 	d := func(fq, help string, labels []string) *prometheus.Desc {
 		return prometheus.NewDesc(fq, help, labels, nil)
@@ -80,6 +87,11 @@ func newRuntimeCollector(p Provider) *runtimeCollector {
 		snapshotsActive:  d(fqdn("snapshot", "active"), "Number of ready (held) snapshots.", share),
 		snapshotLastTime: d(fqdn("snapshot", "last_success_timestamp_seconds"), "Unix time of the most recent ready snapshot (0 = none).", share),
 
+		integrityLastScan:     d(fqdn("integrity", "last_scan_timestamp_seconds"), "Unix time the structural manifest scan last completed for this share (0 = never scanned since process start).", share),
+		integrityScanDuration: d(fqdn("integrity", "last_scan_duration_seconds"), "Wall-clock duration of the last structural manifest scan.", share),
+		integrityFilesScanned: d(fqdn("integrity", "files_scanned"), "Regular files walked by the last structural manifest scan.", share),
+		integrityFindings:     d(fqdn("integrity", "findings"), "Findings from the last structural manifest scan, by kind: payloads_with_findings, damaged_payloads, claimed_uncovered_ranges, unplaceable_rows, unknown_hash_rows.", finding),
+
 		quotaUsedBytes:   d(fqdn("quota", "used_bytes"), "Bytes used by a quota principal.", quota),
 		quotaLimitBytes:  d(fqdn("quota", "limit_bytes"), "Hard byte limit for a quota principal (0 = unlimited).", quota),
 		quotaUsedInodes:  d(fqdn("quota", "used_inodes"), "Inodes used by a quota principal.", quota),
@@ -104,6 +116,7 @@ func (c *runtimeCollector) allDescs() []*prometheus.Desc {
 		c.remoteUp, c.remoteOutage, c.remoteReadsBlocked,
 		c.logicalBytes, c.storeFiles,
 		c.snapshotsActive, c.snapshotLastTime,
+		c.integrityLastScan, c.integrityScanDuration, c.integrityFilesScanned, c.integrityFindings,
 		c.quotaUsedBytes, c.quotaLimitBytes, c.quotaUsedInodes, c.quotaLimitInodes,
 		c.clientsActive,
 	}
@@ -132,6 +145,16 @@ func (c *runtimeCollector) Collect(ch chan<- prometheus.Metric) {
 		gauge(c.storeFiles, float64(s.FileCount), s.Name)
 		gauge(c.snapshotsActive, float64(s.SnapshotsHeld), s.Name)
 		gauge(c.snapshotLastTime, float64(s.LastSnapshotUnix), s.Name)
+
+		in := s.Integrity
+		gauge(c.integrityLastScan, float64(in.LastScanUnix), s.Name)
+		gauge(c.integrityScanDuration, in.DurationSeconds, s.Name)
+		gauge(c.integrityFilesScanned, float64(in.FilesScanned), s.Name)
+		gauge(c.integrityFindings, float64(in.PayloadsWithFindings), s.Name, "payloads_with_findings")
+		gauge(c.integrityFindings, float64(in.DamagedPayloads), s.Name, "damaged_payloads")
+		gauge(c.integrityFindings, float64(in.ClaimedUncoveredRanges), s.Name, "claimed_uncovered_ranges")
+		gauge(c.integrityFindings, float64(in.UnplaceableRows), s.Name, "unplaceable_rows")
+		gauge(c.integrityFindings, float64(in.UnknownHashRows), s.Name, "unknown_hash_rows")
 
 		// Sync/remote series only make sense for shares with a remote backend.
 		if s.HasRemote {

--- a/pkg/metrics/snapshot.go
+++ b/pkg/metrics/snapshot.go
@@ -67,8 +67,8 @@ type ShareSnapshot struct {
 
 	// Integrity is the last structural manifest scan's outcome, zero-valued
 	// when no scan has run for this share in this process. A zero
-	// LastScanUnix is emitted rather than suppressed so an alert on scan
-	// age fires for a share that has never been verified.
+	// LastScanUnix is emitted rather than suppressed so an alert on scan age
+	// fires for a share that has never been verified.
 	Integrity IntegrityScanSnapshot
 }
 

--- a/pkg/metrics/snapshot.go
+++ b/pkg/metrics/snapshot.go
@@ -65,10 +65,12 @@ type ShareSnapshot struct {
 	SnapshotsHeld    int64
 	LastSnapshotUnix int64 // 0 = none held
 
-	// Integrity is the last structural manifest scan's outcome, zero-valued
-	// when no scan has run for this share in this process. A zero
-	// LastScanUnix is emitted rather than suppressed so an alert on scan age
-	// fires for a share that has never been verified.
+	// Integrity is the last structural manifest scan's outcome. Its counters
+	// are zero both when no scan has run for this share in this process and
+	// when the last one failed, since a failed scan produced nothing worth
+	// publishing; LastScanFailed separates those. A zero LastScanUnix is
+	// emitted rather than suppressed so an alert on scan age fires for a
+	// share that has never been verified.
 	Integrity IntegrityScanSnapshot
 }
 

--- a/pkg/metrics/snapshot.go
+++ b/pkg/metrics/snapshot.go
@@ -75,7 +75,15 @@ type ShareSnapshot struct {
 // IntegrityScanSnapshot is one share's structural manifest scan result: how
 // much was walked, when, and what was found, split by defect kind.
 type IntegrityScanSnapshot struct {
-	LastScanUnix         int64 // 0 = never scanned in this process
+	// LastScanUnix is when the last scan completed. It is 0 both for a share
+	// never scanned in this process and for one whose last scan failed, since
+	// a failed scan completed nothing — LastScanFailed is what tells those
+	// two apart. Without it a scanner erroring on every tick would be
+	// indistinguishable from a scanner that was never switched on, which is
+	// the silent-failure shape this scan exists to remove, not reproduce.
+	LastScanUnix   int64
+	LastScanFailed bool
+
 	DurationSeconds      float64
 	FilesScanned         int64
 	PayloadsWithFindings int64

--- a/pkg/metrics/snapshot.go
+++ b/pkg/metrics/snapshot.go
@@ -64,6 +64,28 @@ type ShareSnapshot struct {
 	// Snapshots.
 	SnapshotsHeld    int64
 	LastSnapshotUnix int64 // 0 = none held
+
+	// Integrity is the last structural manifest scan's outcome, zero-valued
+	// when no scan has run for this share in this process. A zero
+	// LastScanUnix is emitted rather than suppressed so an alert on scan
+	// age fires for a share that has never been verified.
+	Integrity IntegrityScanSnapshot
+}
+
+// IntegrityScanSnapshot is one share's structural manifest scan result: how
+// much was walked, when, and what was found, split by defect kind.
+type IntegrityScanSnapshot struct {
+	LastScanUnix         int64 // 0 = never scanned in this process
+	DurationSeconds      float64
+	FilesScanned         int64
+	PayloadsWithFindings int64
+
+	// Findings by kind. DamagedPayloads is the per-payload verdict; the
+	// three below are the per-row/per-range evidence behind it.
+	DamagedPayloads        int64
+	ClaimedUncoveredRanges int64
+	UnplaceableRows        int64
+	UnknownHashRows        int64
 }
 
 // QuotaSnapshot is one configured quota principal's usage and limits. Limits of


### PR DESCRIPTION
## What was wrong

The detection layer for structural manifest damage has been complete for a
while: `CheckManifests` walks a share's manifest against every file's own
block list, `dfsctl store check` runs it, and `manifest_repair.go` can put
the missing rows back. Nothing ever ran any of it. There was no scheduler,
no config key, no default cadence — the CLI help even suggested wiring
`|| alert` into cron, i.e. the product shipped the detection and left the
schedule to the operator.

That matters for exactly one damage shape, and it is the worst one. A range
with no manifest row that the file's block list still claims is, at read
time, indistinguishable from a legitimate sparse hole. Absent rows are how
sparse files are represented, so the read path has no honest basis to
refuse: it returns zeros and reports success. The unplaceable-row case is
loud and the unknown-hash case is loud; this one is silent by design, and
the audit was the only thing that could see it — the thing nothing
scheduled.

## What this adds

A per-share scheduled structural scan, shaped after the existing auto-GC
loop in `blockgc_scheduler.go`:

- **`integrity.auto_enabled` / `integrity.auto_interval`** — on by default,
  24h, with an explicit off switch. The interval floor is 5m rather than
  GC's 1m because a scan is a full metadata walk of every share; below that
  it never stops running.
- **The loop** (`pkg/controlplane/runtime/integrity_scheduler.go`) scans
  shares one at a time, synchronously, so runs never overlap and the walk
  never competes with itself for the metadata store. It calls the existing
  `Runtime.CheckManifests` with no repair options set, so it writes nothing.
  Metadata-only — no block is fetched, no remote object touched, no S3
  egress.
- **Metrics**: `dittofs_integrity_last_scan_timestamp_seconds`,
  `_last_scan_duration_seconds`, `_files_scanned`, and
  `dittofs_integrity_findings{kind}` split by `payloads_with_findings`,
  `damaged_payloads`, `claimed_uncovered_ranges`, `unplaceable_rows`,
  `unknown_hash_rows`. A share never scanned emits a last-scan timestamp of
  0 rather than nothing, so an alert on scan age fires for it instead of
  silently having no series to evaluate.
- **A health signal**: `dfsctl share show` reports when the share was last
  scanned and what was found, and a share with damaged payloads reads as
  `degraded` even though every subsystem probe is healthy — which is the
  point, since the probes cannot see this damage.

## The status shape

`ShareResponse.Status` and `GET /api/v1/shares/{name}/status` change type
from `health.Report` to a new `health.ShareStatus`, which **embeds**
`health.Report`. The JSON is a strict superset: the same top-level
`status` / `message` / `checked_at` / `latency_ms` keys, plus an optional
`integrity` object. Nothing that reads the old fields is affected.

The struct is deliberately shaped to take more than one section. The
offline-safety counter in #1848 is the next one, and it wants the same
thing this does — a per-share number an operator charts, sitting next to
the health verdict. Folding numbers into `Report.Message` would have worked
for one of them and collapsed as soon as there were two, since a share can
have several independent things worth reporting at once and prose cannot
be parsed back apart.

Note the downgrade rule only ever worsens a report: damage degrades a
healthy share and leaves an already-degraded or unhealthy one alone.

## Known ceiling

The schedule is a plain ticker, so it restarts from zero on every server
start and a box restarted more often than the interval never completes a
scan. The fix is to persist the last-run time per share and scan at startup
when it is stale — but scanning at every boot puts a full metadata walk on
the startup path, which is the cost this scheduler exists to keep off it.
Marked with a `ponytail:` comment naming the trigger, and called out in the
docs.

## Verification

- `go build ./... && go vet ./... && go test ./...` green.
- `TestStartScheduledIntegrityScan_TicksAndStops` runs the real scan against
  a real memory metadata store — no fake sink — and asserts the recorded
  status appears where the status report reads it, and that the loop stops
  on cancel.
- `TestWithIntegrity_DowngradeRule` pins the four cases of the downgrade
  join, including "never upgrades".
- `TestLoad_IntegrityAutoEnv_RoundTrip` proves the `*bool` and `Duration`
  knobs decode from `DITTOFS_INTEGRITY_*` through `Load`.

Closes #2076
