### PR TITLE
fix(smb): decide content-change dir-lease breaks at change time, not at dispatch time

### DIFF
--- a/internal/adapter/smb/compound.go
+++ b/internal/adapter/smb/compound.go
@@ -284,14 +284,15 @@ func ProcessCompoundRequest(ctx context.Context, firstHeader *header.SMB2Header,
 	state.releaseStartedGates(connInfo.Handler.PendingCreateRegistry)
 
 	// Per MS-SMB2 3.3.4.1: run deferred post-send hooks (e.g.
-	// STATUS_NOTIFY_CLEANUP after CLOSE) only after the compound response
-	// has been written. Skip them if the compound write failed — the
-	// connection is likely dead and the hooks would just log spurious
-	// SendMessage errors on a torn-down session.
-	if sendErr == nil {
-		for _, hook := range state.postSendHooks {
-			hook()
-		}
+	// STATUS_NOTIFY_CLEANUP after CLOSE) after the compound response has been
+	// written. They run even when the write failed: a hook is deferred only to
+	// order its delivery after this response, and a response that never reached
+	// the wire imposes no such ordering. Dropping it would strand whatever a
+	// handler already committed to before replying — a recorded lease break
+	// whose notification never reaches its (possibly unrelated, still-live)
+	// holder.
+	for _, hook := range state.postSendHooks {
+		hook()
 	}
 }
 
@@ -1120,9 +1121,7 @@ func completeCompoundAfterAsyncCreate(
 	// into this completion frame, only after it is on the wire.
 	state.releaseStartedGates(connInfo.Handler.PendingCreateRegistry)
 
-	if sendErr == nil {
-		for _, hook := range state.postSendHooks {
-			hook()
-		}
+	for _, hook := range state.postSendHooks {
+		hook()
 	}
 }

--- a/internal/adapter/smb/handlers/close_dirlease_break_order_test.go
+++ b/internal/adapter/smb/handlers/close_dirlease_break_order_test.go
@@ -102,15 +102,13 @@ func TestClose_DirLeaseRelease_AfterOpenFileRemoval(t *testing.T) {
 	// signal branch (gated on lock.Lease.Breaking) is inert. Use the async
 	// (no-ACK, no-wait) dispatch so the lease lands in Breaking=true without
 	// blocking the test on a holder ack that never arrives.
-	if err := h.LeaseManager.BreakParentDirLeasesOnContentChangeAsync(
+	h.LeaseManager.PrepareParentDirLeaseBreakOnContentChange(
 		lock.FileHandle(dirMetaHandle),
 		shareName,
 		"",
 		[16]byte{},
 		false,
-	); err != nil {
-		t.Fatalf("BreakParentDirLeasesOnContentChangeAsync: %v", err)
-	}
+	)()
 
 	// Register the holder's OpenFile (the conflicting dst-parent dir handle).
 	openFile := (&OpenFile{

--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -704,9 +704,7 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 		// EDEADLK. The break notification is still sent (same
 		// BreakLeasesOnOpenConflict dispatch); the holder acks on its own
 		// schedule. Mirrors Samba contend_dirleases → send_break_to_none.
-		if breakErr := h.LeaseManager.BreakParentDirLeasesOnContentChangeAsync(parentLockHandle, tree.ShareName, "", excludeParentKey, hasExcludeKey); breakErr != nil {
-			logger.Debug("CREATE: parent directory lease break failed", "error", breakErr)
-		}
+		h.LeaseManager.PrepareParentDirLeaseBreakOnContentChange(parentLockHandle, tree.ShareName, "", excludeParentKey, hasExcludeKey)()
 	}
 
 	// Step 7: Perform create/open.

--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -701,9 +701,9 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 		// waiting here would block the CREATE reply on an ACK the creating client
 		// can only send over the same credit-limited connection — under sustained
 		// fio create load the SMB credit window collapses and Linux cifs.ko returns
-		// EDEADLK. The break notification is still sent (same
-		// BreakLeasesOnOpenConflict dispatch); the holder acks on its own
-		// schedule. Mirrors Samba contend_dirleases → send_break_to_none.
+		// EDEADLK. The break notification is still sent (the returned dispatch
+		// runs inline here); the holder acks on its own schedule. Mirrors Samba
+		// contend_dirleases → send_break_to_none.
 		h.LeaseManager.PrepareParentDirLeaseBreakOnContentChange(parentLockHandle, tree.ShareName, "", excludeParentKey, hasExcludeKey)()
 	}
 

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -2124,7 +2124,6 @@ func (h *Handler) breakParentDirLeasesForContentChangeOn(ctx *SMBHandlerContext,
 	logger.Debug("SET_INFO: parent directory lease break-to-None recorded", "path", path, "parent", parentDbg)
 	dispatch := h.LeaseManager.PrepareParentDirLeaseBreakOnContentChange(
 		parentLockHandle, shareName, "", excludeParentKey, hasExcludeKey)
-	dispatch = func(send func()) func() { return func() { time.Sleep(80 * time.Millisecond); send() } }(dispatch) // TEMP REPRO WIDENER
 
 	// Defer dispatch until after the triggering request's response is on the
 	// wire when an SMB ctx is available. Mirrors Samba `send_break_to_none`

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -2121,14 +2121,10 @@ func (h *Handler) breakParentDirLeasesForContentChangeOn(ctx *SMBHandlerContext,
 	parentDbg := fmt.Sprintf("%x", parentHandle)
 	shareName := openFile.ShareName
 
-	dispatch := func() {
-		if breakErr := h.LeaseManager.BreakParentDirLeasesOnContentChangeAsync(
-			parentLockHandle, shareName, "",
-			excludeParentKey, hasExcludeKey,
-		); breakErr != nil {
-			logger.Debug("SET_INFO: parent directory lease break-to-None failed", "path", path, "parent", parentDbg, "error", breakErr)
-		}
-	}
+	logger.Debug("SET_INFO: parent directory lease break-to-None recorded", "path", path, "parent", parentDbg)
+	dispatch := h.LeaseManager.PrepareParentDirLeaseBreakOnContentChange(
+		parentLockHandle, shareName, "", excludeParentKey, hasExcludeKey)
+	dispatch = func(send func()) func() { return func() { time.Sleep(80 * time.Millisecond); send() } }(dispatch) // TEMP REPRO WIDENER
 
 	// Defer dispatch until after the triggering request's response is on the
 	// wire when an SMB ctx is available. Mirrors Samba `send_break_to_none`
@@ -2345,15 +2341,9 @@ func (h *Handler) handleFileLinkInformation(
 		hasExcludeKey := openFile.HasParentLeaseKey
 		shareName := openFile.ShareName
 		dstDbg := newPath
-		dispatch := func() {
-			if breakErr := h.LeaseManager.BreakParentDirLeasesOnContentChangeAsync(
-				dstParentLock, shareName,
-				"", excludeParentKey, hasExcludeKey,
-			); breakErr != nil {
-				logger.Debug("SET_INFO: hardlink dst-parent dir lease break-to-None failed",
-					"dst", dstDbg, "error", breakErr)
-			}
-		}
+		logger.Debug("SET_INFO: hardlink dst-parent dir lease break-to-None recorded", "dst", dstDbg)
+		dispatch := h.LeaseManager.PrepareParentDirLeaseBreakOnContentChange(
+			dstParentLock, shareName, "", excludeParentKey, hasExcludeKey)
 		// Defer until after the SET_INFO response is on the wire so the
 		// client's lease handler runs in the next tevent cycle with
 		// lease_skip_ack=true (see breakParentDirLeasesForContentChangeOn

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -2335,14 +2335,10 @@ func (h *Handler) handleFileLinkInformation(
 	// force-complete the lease on timeout and the replay would hit
 	// STATUS_UNSUCCESSFUL.
 	if h.LeaseManager != nil {
-		dstParentLock := lock.FileHandle(dstDir)
-		excludeParentKey := openFile.ParentLeaseKey
-		hasExcludeKey := openFile.HasParentLeaseKey
-		shareName := openFile.ShareName
-		dstDbg := newPath
-		logger.Debug("SET_INFO: hardlink dst-parent dir lease break-to-None recorded", "dst", dstDbg)
+		logger.Debug("SET_INFO: hardlink dst-parent dir lease break-to-None recorded", "dst", newPath)
 		dispatch := h.LeaseManager.PrepareParentDirLeaseBreakOnContentChange(
-			dstParentLock, shareName, "", excludeParentKey, hasExcludeKey)
+			lock.FileHandle(dstDir), openFile.ShareName, "",
+			openFile.ParentLeaseKey, openFile.HasParentLeaseKey)
 		// Defer until after the SET_INFO response is on the wire so the
 		// client's lease handler runs in the next tevent cycle with
 		// lease_skip_ack=true (see breakParentDirLeasesForContentChangeOn

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -1139,8 +1139,8 @@ func (lm *LeaseManager) BreakParentDirLeasesOnDestructiveCreate(
 	return lockMgr.WaitForBreakCompletion(waitCtx, handleKey)
 }
 
-// BreakParentDirLeasesOnContentChangeAsync dispatches the same single
-// break-to-None notification per holder as BreakParentDirLeasesOnDestructiveCreate
+// PrepareParentDirLeaseBreakOnContentChange records the same single
+// break-to-None per holder as BreakParentDirLeasesOnDestructiveCreate
 // but WITHOUT waiting for the LEASE_BREAK_ACK. Used by content-change paths
 // (SET_INFO rename / hardlink / disposition, CLOSE-on-delete, WRITE-mark)
 // where the triggering request must complete on its own transport: waiting for
@@ -1156,19 +1156,30 @@ func (lm *LeaseManager) BreakParentDirLeasesOnDestructiveCreate(
 // unlink_different_set_and_close, unlink_*_initial_and_close} which all set
 // lease_skip_ack=true before the triggering op and replay the captured ACK
 // after the response returns.
-func (lm *LeaseManager) BreakParentDirLeasesOnContentChangeAsync(
+//
+// The break is RECORDED on the leases that exist when this is called and the
+// returned function only puts the notifications on the wire. Callers that
+// defer that function past their own response therefore break exactly the
+// leases the change contended with: a dir lease granted in the meantime is
+// not caught by a change that predates it. Evaluating the holder set at
+// dispatch time instead let a write-close's deferred break revoke a dir lease
+// granted by the very next CREATE, which the client counted as a second
+// LEASE_BREAK for one change.
+//
+// The returned function is always non-nil and is a no-op when nothing broke.
+func (lm *LeaseManager) PrepareParentDirLeaseBreakOnContentChange(
 	parentHandle lock.FileHandle,
 	shareName string,
 	excludeClientID string,
 	excludeParentLeaseKey [16]byte,
 	hasExcludeKey bool,
-) error {
+) func() {
 	lockMgr, handleKey, excludeOwner := lm.resolveParentBreakArgs(
 		parentHandle, shareName, excludeClientID, excludeParentLeaseKey, hasExcludeKey)
 	if lockMgr == nil {
-		return nil
+		return func() {}
 	}
-	return lockMgr.BreakLeasesOnOpenConflict(handleKey, excludeOwner, lock.BreakReasonDestructive)
+	return lockMgr.PrepareBreakLeasesOnOpenConflict(handleKey, excludeOwner, lock.BreakReasonDestructive)
 }
 
 // BreakParentReadLeasesOnModify breaks Read leases on a parent directory

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -302,13 +302,17 @@ func ProcessSingleRequest(
 	// Track session lifecycle for connection cleanup
 	TrackSessionLifecycle(reqHeader.Command, reqHeader.SessionID, handlerCtx.SessionID, result.Status, result.IsBinding, connInfo.SessionTracker)
 
-	// Send response and run after-hooks with the response bytes. If the
-	// write fails, return early — any registered PostSend hook is
-	// intentionally dropped because the connection is likely dead and the
-	// hook would just log spurious SendMessage errors on a torn-down
-	// session. (Same contract as the compound dispatch path.)
-	if err := SendResponseWithHooks(reqHeader, handlerCtx, result, connInfo); err != nil {
-		return err
+	// Send the response and run the after-hooks with the response bytes. A
+	// PostSend hook still runs when the write fails: the hook is deferred only
+	// to order its delivery after this response, and a response that never
+	// reached the wire imposes no such ordering. Dropping it would strand
+	// whatever the handler already committed to before replying — a recorded
+	// lease break whose notification never reaches its (possibly unrelated,
+	// still-live) holder. (Same contract as the compound dispatch path.)
+	sendErr := SendResponseWithHooks(reqHeader, handlerCtx, result, connInfo)
+	if sendErr != nil {
+		runPostSend(handlerCtx)
+		return sendErr
 	}
 
 	// Release any parked-CREATE resume goroutine now that the interim
@@ -335,9 +339,7 @@ func ProcessSingleRequest(
 	// now, with writeMu released, so the hook's own SendMessage re-acquires
 	// the lock cleanly and the cleanup notification is unambiguously ordered
 	// after the CLOSE response.
-	if handlerCtx != nil && handlerCtx.PostSend != nil {
-		handlerCtx.PostSend()
-	}
+	runPostSend(handlerCtx)
 
 	// NOTE: We intentionally do NOT delete the session here. The session is
 	// kept alive with LoggedOff=true so that in-flight request goroutines
@@ -1441,4 +1443,11 @@ var errorBody = []byte{9, 0, 0, 0, 0, 0, 0, 0, 0}
 // must only read or copy the returned bytes, never mutate them in place.
 func MakeErrorBody() []byte {
 	return errorBody
+}
+
+// runPostSend invokes ctx's deferred post-send hook, if it registered one.
+func runPostSend(ctx *handlers.SMBHandlerContext) {
+	if ctx != nil && ctx.PostSend != nil {
+		ctx.PostSend()
+	}
 }

--- a/pkg/metadata/lock/break.go
+++ b/pkg/metadata/lock/break.go
@@ -101,9 +101,8 @@ func (lm *Manager) BreakLeasesForByteRangeLock(handleKey string, excludeOwner *L
 // computed via ComputeLeaseBreakTo(state, reason); a lease is broken only
 // when the computed target differs from its current state.
 func (lm *Manager) BreakLeasesOnOpenConflict(handleKey string, excludeOwner *LockOwner, reason BreakReason) error {
-	return lm.breakOpLocks(handleKey, excludeOwner, breakSentinelForReason(reason), reason, func(lease *OpLock) bool {
-		return ComputeLeaseBreakTo(lease.LeaseState, reason) != lease.LeaseState
-	})
+	lm.PrepareBreakLeasesOnOpenConflict(handleKey, excludeOwner, reason)()
+	return nil
 }
 
 // PrepareBreakLeasesOnOpenConflict records the same breaks as
@@ -659,19 +658,8 @@ func (lm *Manager) signalBreakWaitLocked(handleKey string) {
 	}
 }
 
-// breakOpLocks marks matching oplocks as breaking and dispatches break
-// notifications. Releases mutex before dispatching to avoid deadlock.
-//
-// breakToState is the target state for the break. Pass BreakToStripWrite
-// to compute the per-lease break-to state by stripping the Write bit from
-// each lease's current state (preserving Read and Handle).
-//
-// Concurrent-break behavior: when a lease is already Breaking, the new
-// target is AND-merged into BreakingToRequired (cumulative final target)
-// without dispatching a new notification or advancing the epoch. This
-// mirrors Samba `process_oplock_break_message` lines 956-965; the next
-// progressive stage is dispatched from acknowledgeLeaseBreakImpl after the
-// in-flight ACK arrives.
+// breakOpLocks marks matching oplocks as breaking and dispatches their break
+// notifications immediately. See markOpLockBreaks for the marking rules.
 func (lm *Manager) breakOpLocks(
 	handleKey string,
 	excludeOwner *LockOwner,
@@ -686,7 +674,19 @@ func (lm *Manager) breakOpLocks(
 // markOpLockBreaks records the break on every matching lease under handleKey
 // and returns the function that puts the still-unsent notifications on the
 // wire. The victim set is decided here, under lm.mu, so a lease granted after
-// this returns is never caught by a change that predates it.
+// this returns is never caught by a change that predates it. The mutex is
+// released before the returned function dispatches, to avoid deadlock.
+//
+// breakToState is the target state for the break. Pass BreakToStripWrite
+// to compute the per-lease break-to state by stripping the Write bit from
+// each lease's current state (preserving Read and Handle).
+//
+// Concurrent-break behavior: when a lease is already Breaking, the new
+// target is AND-merged into BreakingToRequired (cumulative final target)
+// without dispatching a new notification or advancing the epoch. This
+// mirrors Samba `process_oplock_break_message` lines 956-965; the next
+// progressive stage is dispatched from acknowledgeLeaseBreakImpl after the
+// in-flight ACK arrives.
 func (lm *Manager) markOpLockBreaks(
 	handleKey string,
 	excludeOwner *LockOwner,

--- a/pkg/metadata/lock/break.go
+++ b/pkg/metadata/lock/break.go
@@ -106,6 +106,17 @@ func (lm *Manager) BreakLeasesOnOpenConflict(handleKey string, excludeOwner *Loc
 	})
 }
 
+// PrepareBreakLeasesOnOpenConflict records the same breaks as
+// BreakLeasesOnOpenConflict but leaves the wire notifications unsent,
+// returning the function that sends them. Splitting the two lets a caller
+// order the notification after its own response while the set of leases the
+// change breaks is still decided at the moment of the change.
+func (lm *Manager) PrepareBreakLeasesOnOpenConflict(handleKey string, excludeOwner *LockOwner, reason BreakReason) func() {
+	return lm.markOpLockBreaks(handleKey, excludeOwner, breakSentinelForReason(reason), reason, func(lease *OpLock) bool {
+		return ComputeLeaseBreakTo(lease.LeaseState, reason) != lease.LeaseState
+	})
+}
+
 // BreakReadLeasesForParentDir breaks Read leases on a parent directory when
 // a child file is modified (SET_INFO, WRITE, DELETE). Per MS-FSA 2.1.5.14:
 // changes to directory contents or child metadata invalidate Read caching,
@@ -668,6 +679,21 @@ func (lm *Manager) breakOpLocks(
 	reason BreakReason,
 	shouldBreak func(lease *OpLock) bool,
 ) error {
+	lm.markOpLockBreaks(handleKey, excludeOwner, breakToState, reason, shouldBreak)()
+	return nil
+}
+
+// markOpLockBreaks records the break on every matching lease under handleKey
+// and returns the function that puts the still-unsent notifications on the
+// wire. The victim set is decided here, under lm.mu, so a lease granted after
+// this returns is never caught by a change that predates it.
+func (lm *Manager) markOpLockBreaks(
+	handleKey string,
+	excludeOwner *LockOwner,
+	breakToState uint32,
+	reason BreakReason,
+	shouldBreak func(lease *OpLock) bool,
+) func() {
 	lm.mu.Lock()
 	locks := lm.unifiedLocks[handleKey]
 
@@ -799,11 +825,11 @@ func (lm *Manager) breakOpLocks(
 	}
 	lm.unlock()
 
-	for _, entry := range toBreak {
-		lm.dispatchOpLockBreak(handleKey, entry.lock, entry.breakToState)
+	return func() {
+		for _, entry := range toBreak {
+			lm.dispatchOpLockBreak(handleKey, entry.lock, entry.breakToState)
+		}
 	}
-
-	return nil
 }
 
 // computeFreshTarget resolves a breakOpLocks sentinel against the current

--- a/pkg/metadata/lock/dirlease_prepare_break_test.go
+++ b/pkg/metadata/lock/dirlease_prepare_break_test.go
@@ -1,0 +1,103 @@
+package lock
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+// dlease1Key is the DLEASE1 lease-key constant smbtorture reuses across the
+// dirlease subtests (source4/torture/smb2/lease.c).
+var dlease1Key = [16]byte{0x01, 0, 0, 0, 0, 0, 0, 0, 0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+
+// TestPrepareBreakLeasesOnOpenConflictIgnoresLaterGrant pins the rule that a
+// content change breaks the leases that existed when it happened, not the ones
+// present when its notification is finally sent.
+//
+// The SMB CLOSE of a written file records a break-to-None on its parent
+// directory's leases and defers the notification until after the CLOSE
+// response, so a client that skips the ACK still sees the break. Each SMB2
+// request runs on its own goroutine, so the client's next CREATE can be granted
+// a fresh directory lease before that deferred notification runs. Re-reading
+// the lease table at send time revoked that new lease, and the client counted
+// two LEASE_BREAKs for one change.
+func TestPrepareBreakLeasesOnOpenConflictIgnoresLaterGrant(t *testing.T) {
+	lm := NewManager()
+	const handleKey = "/share:test_unlink"
+
+	var mu sync.Mutex
+	var broken [][16]byte
+	lm.RegisterBreakCallbacks(&testBreakCallbacks{
+		onOpLockBreak: func(_ string, l *UnifiedLock, _ uint32) {
+			mu.Lock()
+			broken = append(broken, l.Lease.LeaseKey)
+			mu.Unlock()
+		},
+	})
+
+	// The directory carries no lease when the change happens.
+	send := lm.PrepareBreakLeasesOnOpenConflict(handleKey, &LockOwner{}, BreakReasonDestructive)
+
+	// A later CREATE takes an RH directory lease on the same directory.
+	if _, _, err := lm.RequestLease(context.Background(), FileHandle(handleKey), dlease1Key,
+		[16]byte{}, "owner-1", "smb:1", "share",
+		LeaseStateRead|LeaseStateHandle, true); err != nil {
+		t.Fatalf("RequestLease: %v", err)
+	}
+
+	send()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(broken) != 0 {
+		t.Fatalf("deferred notification broke %d lease(s) (%x); a lease granted after the "+
+			"change must not be broken by it", len(broken), broken)
+	}
+	if _, rec, _ := lm.findLeaseByKey(dlease1Key); rec != nil && rec.Lease.Breaking {
+		t.Fatal("lease granted after the change was marked Breaking by it")
+	}
+}
+
+// TestPrepareBreakLeasesOnOpenConflictBreaksExistingLease is the positive half:
+// a lease held when the change happens is still broken once the notification is
+// sent, and it is marked Breaking as soon as the change is recorded.
+func TestPrepareBreakLeasesOnOpenConflictBreaksExistingLease(t *testing.T) {
+	lm := NewManager()
+	const handleKey = "/share:test_unlink"
+
+	var mu sync.Mutex
+	var broken [][16]byte
+	lm.RegisterBreakCallbacks(&testBreakCallbacks{
+		onOpLockBreak: func(_ string, l *UnifiedLock, _ uint32) {
+			mu.Lock()
+			broken = append(broken, l.Lease.LeaseKey)
+			mu.Unlock()
+		},
+	})
+
+	if _, _, err := lm.RequestLease(context.Background(), FileHandle(handleKey), dlease1Key,
+		[16]byte{}, "owner-1", "smb:1", "share",
+		LeaseStateRead|LeaseStateHandle, true); err != nil {
+		t.Fatalf("RequestLease: %v", err)
+	}
+
+	send := lm.PrepareBreakLeasesOnOpenConflict(handleKey, &LockOwner{}, BreakReasonDestructive)
+
+	if _, rec, _ := lm.findLeaseByKey(dlease1Key); rec == nil || !rec.Lease.Breaking {
+		t.Fatal("lease held at change time must be marked Breaking when the change is recorded")
+	}
+	mu.Lock()
+	sentEarly := len(broken)
+	mu.Unlock()
+	if sentEarly != 0 {
+		t.Fatalf("notification sent before send(): %d", sentEarly)
+	}
+
+	send()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(broken) != 1 || broken[0] != dlease1Key {
+		t.Fatalf("want one break on DLEASE1, got %x", broken)
+	}
+}

--- a/pkg/metadata/lock/dirlease_prepare_break_test.go
+++ b/pkg/metadata/lock/dirlease_prepare_break_test.go
@@ -10,6 +10,18 @@ import (
 // dirlease subtests (source4/torture/smb2/lease.c).
 var dlease1Key = [16]byte{0x01, 0, 0, 0, 0, 0, 0, 0, 0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
 
+// leaseBreakingState reports whether a lease with the given key exists and
+// whether it is mid-break. findLeaseByKey requires lm.mu, so take it here.
+func leaseBreakingState(lm *Manager, leaseKey [16]byte) (found, breaking bool) {
+	lm.mu.Lock()
+	defer lm.unlock()
+	_, rec, _ := lm.findLeaseByKey(leaseKey)
+	if rec == nil || rec.Lease == nil {
+		return false, false
+	}
+	return true, rec.Lease.Breaking
+}
+
 // TestPrepareBreakLeasesOnOpenConflictIgnoresLaterGrant pins the rule that a
 // content change breaks the leases that existed when it happened, not the ones
 // present when its notification is finally sent.
@@ -53,7 +65,7 @@ func TestPrepareBreakLeasesOnOpenConflictIgnoresLaterGrant(t *testing.T) {
 		t.Fatalf("deferred notification broke %d lease(s) (%x); a lease granted after the "+
 			"change must not be broken by it", len(broken), broken)
 	}
-	if _, rec, _ := lm.findLeaseByKey(dlease1Key); rec != nil && rec.Lease.Breaking {
+	if found, breaking := leaseBreakingState(lm, dlease1Key); found && breaking {
 		t.Fatal("lease granted after the change was marked Breaking by it")
 	}
 }
@@ -83,7 +95,7 @@ func TestPrepareBreakLeasesOnOpenConflictBreaksExistingLease(t *testing.T) {
 
 	send := lm.PrepareBreakLeasesOnOpenConflict(handleKey, &LockOwner{}, BreakReasonDestructive)
 
-	if _, rec, _ := lm.findLeaseByKey(dlease1Key); rec == nil || !rec.Lease.Breaking {
+	if found, breaking := leaseBreakingState(lm, dlease1Key); !found || !breaking {
 		t.Fatal("lease held at change time must be marked Breaking when the change is recorded")
 	}
 	mu.Lock()

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -223,6 +223,12 @@ type LockManager interface {
 	// Per-lease target state is computed via ComputeLeaseBreakTo(state, reason).
 	BreakLeasesOnOpenConflict(handleKey string, excludeOwner *LockOwner, reason BreakReason) error
 
+	// PrepareBreakLeasesOnOpenConflict records the same breaks but returns the
+	// function that sends their notifications, so a caller can order the wire
+	// notification after its own response without letting a lease granted in
+	// between be broken by a change that predates it.
+	PrepareBreakLeasesOnOpenConflict(handleKey string, excludeOwner *LockOwner, reason BreakReason) func()
+
 	// BreakReadLeasesForParentDir breaks Read leases on a parent directory
 	// when directory content changes (CREATE, RENAME, DELETE on close).
 	// Per MS-FSA 2.1.5.14: changes to directory listing invalidate Read


### PR DESCRIPTION
## What was actually wrong

A directory-content change picks which parent directory leases to break **when its
notification is put on the wire**, not when the change happens. Those two moments are not
the same, and the gap is a race the client observes as a duplicate `LEASE_BREAK`.

`breakParentDirLeasesForContentChangeOn` (`set_info.go`) does not dispatch the break
inline. It hands a closure to `AppendPostSend` so the notification lands *after* the
triggering request's response — required for Samba `send_break_to_none` parity, because
the dirlease tests set `lease_skip_ack=true` after the triggering op and replay the ACK
themselves. That deferral is correct. What was wrong is that the closure called
`BreakParentDirLeasesOnContentChangeAsync`, which reads `lm.unifiedLocks[parent]` **at
dispatch time**.

Every SMB2 request runs on its own goroutine (`pkg/adapter/smb/connection.go`, the read
loop `go func`s each request and moves on). So the sequence below is legal and, under
load, common:

```
msg 16  CLOSE test_unlink/test_unlink.dat   (written file → dir-lease break registered
                                             via PostSend, no ParentLeaseKey exclusion)
        response written  ────────────────► client
                                            client sends msg 17
msg 17  CREATE test_unlink  → RequestLease grants DLEASE1 = RH, epoch 1
        ... msg 16's PostSend hook finally runs, re-reads the lease table,
            finds DLEASE1 and revokes it ...
```

`smb2.dirlease.unlink_*_and_close` then sees two breaks for one logical change — the stale
one on DLEASE1 plus the legitimate one on DLEASE2 at `close(h1)` — and fails
`lease_break_info.count got 0x2 - should be 0x1`.

This matches the field evidence recorded on the issue exactly: the surplus break lands on
directory handle 1 **immediately after its grant**, carries `breakToState=None epoch=2`,
and has **no `OnDirChange` line** — because it never came from `OnDirChange`, it came from
`breakOpLocks` via a stale PostSend hook.

## Confirming the premise

The issue was reopened after #1806 with two competing readings: real defect, or base flake
in the harness. It is a real defect, and the harness is innocent — CI runs every
`smb2.dirlease.*` subtest in its own smbtorture process against a freshly reset share, so
there is no cross-test state to blame.

Reproduced deterministically by widening the existing race window with an 80 ms sleep in
front of the PostSend dispatch (nothing else changed):

```
WARNING!: (lease.c:7653): wrong value for lease_break_info.count got 0x2 - should be 0x1
WARNING!: (lease.c:7653): wrong value for ...current_lease.lease_key.data[0] got 0x1 - should be 0x2
failure: unlink_same_initial_and_close
```

Byte-identical to the CI fingerprint, including the wrong lease key being DLEASE1. With
the fix applied and **the 80 ms widener still in place**, all four `unlink_*` subtests
pass — the outcome no longer depends on the window at all.

## The fix

Record the break when the change happens; defer only the notification.

`breakOpLocks` already collected its victims under `lm.mu` and dispatched after
unlocking. That seam is now exposed: `markOpLockBreaks` marks the leases and returns the
function that sends their notifications, and `PrepareBreakLeasesOnOpenConflict` is the
twin of `BreakLeasesOnOpenConflict` that stops at the marking. The SMB lease manager's
`BreakParentDirLeasesOnContentChangeAsync` becomes
`PrepareParentDirLeaseBreakOnContentChange`, returning that send function; the two
`AppendPostSend` sites defer the send instead of the whole decision, and the inline
CREATE-time site calls it straight through.

A lease granted after the change is therefore not in the set and is never broken by it.
As a bonus the holder is marked `Breaking` as soon as the change is recorded, so a
concurrent open in the window takes the existing already-breaking merge path rather than
dispatching a second fresh break.

## One consequence worth calling out

Marking at change time means the lease is `Breaking` before the triggering response is
written — so if that write fails, the `PostSend` hook that would have sent the
notification used to be discarded, stranding a recorded break on a holder that may be a
different, still-live client until the 35 s `OpLockBreakScanner` force-revoked it.

The hooks are no longer discarded on a failed write (`response.go`, `compound.go`). A hook
is deferred only to order its delivery *after* the triggering response; a response that
never reached the wire imposes no such ordering, so there is nothing left to order against
and every reason to still deliver. The only hook that previously relied on the skip is the
CLOSE→`STATUS_NOTIFY_CLEANUP` delivery, which now logs one warning on a dead connection
instead of silently vanishing; `QueueFinalAfterInterim` does not block.

## Tests

`pkg/metadata/lock/dirlease_prepare_break_test.go` pins both halves: a lease granted
between `Prepare` and `send` is untouched, and a lease held at change time is still
marked `Breaking` immediately and broken when `send` runs. The first test fails against
the old dispatch-time behaviour with the same DLEASE1 key from the report.

- `go build ./... && go vet ./... && gofmt -l` clean
- `go test ./...` and `go test -race ./pkg/metadata/lock/... ./internal/adapter/smb/...` pass
- `test/smb-conformance/smbtorture`, memory profile, share reset between every subtest:
  - `unlink_{same,different}_{initial,set}_and_close`: 56/56 green before the change (the
    race does not reproduce on an idle laptop), 60/60 green after, and 12/12 green with
    the 80 ms widener that reproduced the failure 1/1 beforehand.
  - the whole `smb2.dirlease.*` suite bar the known `oplocks` client SIGSEGV — which also
    covers `rename`, `rename_dst_parent`, `hardlink` and the `set*` subtests that share
    the same helper: 17/17 green.

## Not touched

`BreakParentDirLeasesOnDestructiveCreate` has no production caller (only tests). Left
alone — unrelated to this defect.

Closes #1701
