### PR TITLE
feat(offline): report per-share remote-only bytes and offline read safety

### DIFF
--- a/cmd/dfsctl/commands/share/show.go
+++ b/cmd/dfsctl/commands/share/show.go
@@ -103,6 +103,7 @@ func (sd ShareDetail) Rows() [][]string {
 			rows = append(rows, []string{"Status Detail", s.Status.Message})
 		}
 		rows = append(rows, integrityRows(s.Status.Integrity)...)
+		rows = append(rows, offlineRows(s.Status.Offline)...)
 	}
 
 	// Only show Retention TTL when a TTL is set
@@ -226,4 +227,21 @@ func integrityRows(in *health.IntegrityStatus) [][]string {
 			in.ClaimedUncoveredRanges, in.UnplaceableRows, in.UnknownHashRows)})
 	}
 	return rows
+}
+
+// offlineRows renders whether the share would keep serving reads with its
+// remote unreachable. A share whose residency the server could not determine
+// says so rather than claiming either answer.
+func offlineRows(o *health.OfflineStatus) [][]string {
+	if o == nil {
+		return nil
+	}
+	if o.Unknown != "" {
+		return [][]string{{"Offline Safe", "unknown (" + o.Unknown + ")"}}
+	}
+	if o.Safe {
+		return [][]string{{"Offline Safe", "yes"}}
+	}
+	return [][]string{{"Offline Safe", fmt.Sprintf("no (%s remote-only across %d ranges)",
+		bytesize.ByteSize(o.RemoteOnlyBytes), o.RemoteOnlyRanges)}}
 }

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -642,6 +642,53 @@ Findings surface in three places:
 Run `dfsctl store check <share>` for the per-file detail behind a finding,
 and `--repair` to act on it.
 
+#### Offline read safety
+
+A remote-backed share's local tier is a cache: once a range is mirrored to the
+remote it becomes evictable, and an evicted range is served by fetching it
+back. Reads of such a range fail while the remote is unreachable. Whether a
+box would keep serving through an outage therefore depends on how much of its
+data is currently remote-only, and that number moves with every eviction and
+every warm.
+
+The server reports it per share:
+
+- `dfsctl share show <name>` prints `Offline Safe: yes`, or
+  `no (12.4 GiB remote-only across 431 ranges)`.
+- Prometheus: `dittofs_offline_safe{share}` (1/0),
+  `dittofs_offline_remote_only_bytes{share}` and
+  `dittofs_offline_remote_only_ranges{share}`.
+
+Zero remote-only bytes is a provably offline-safe share. To get there, warm
+the share and stop it evicting again:
+
+```bash
+dfsctl share warm /archive
+dfsctl share edit /archive --retention pin
+```
+
+The measurement never guesses. Three cases report **unknown** rather than a
+number, because a zero would read as "provably safe" for exactly the shares
+whose data is most likely to be remote-only:
+
+- the share's local tier does not track residency (the in-memory backend),
+- the local tier has not been seeded from the manifest yet — it holds no
+  record of ranges that live only on the remote, so they would count as
+  absent rather than remote-only,
+- the block store is closed.
+
+An unknown share reports `dittofs_offline_safe = 0` but publishes no byte
+counts, so a dashboard cannot mistake it for a clean fully-local share.
+
+The figure is **bytes, not blocks**. The local tier tracks byte ranges, which
+split and merge independently of manifest chunk rows; a block count would
+need a metadata walk to produce and would not answer "how much would break
+offline" any more precisely.
+
+Note this is read availability only. Offline **writes** already work — writes
+are stored locally and drain when the remote returns.
+
+
 The schedule restarts from zero on server start, so a box restarted more
 often than `auto_interval` never completes a scan. Lower the interval on a
 host that reboots frequently.
@@ -2262,6 +2309,8 @@ spec:
 | ⭐ `dittofs_integrity_last_scan_timestamp_seconds{share}` | Unix time the structural manifest scan last completed. 0 means it has never run since process start **or** its last attempt failed. |
 | ⭐ `dittofs_integrity_last_scan_failed{share}` | `1` when the most recent structural manifest scan failed, `0` when it completed or has never run. Pairs with the timestamp above to tell "never scanned" from "scans are erroring". |
 | `dittofs_integrity_last_scan_duration_seconds{share}` / `dittofs_integrity_files_scanned{share}` | Cost and reach of the last structural manifest scan. |
+| ⭐ `dittofs_offline_safe{share}` | `1` when every byte the share holds can be served with the remote unreachable, else `0`. A share whose residency cannot be determined reports `0` and publishes no byte counts. |
+| `dittofs_offline_remote_only_bytes{share}` / `dittofs_offline_remote_only_ranges{share}` | Data the local tier no longer holds and would have to fetch from the remote to serve, and how many ranges it spans. |
 
 ### Example alert expressions
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -675,7 +675,8 @@ whose data is most likely to be remote-only:
 - the local tier has not been seeded from the manifest yet — it holds no
   record of ranges that live only on the remote, so they would count as
   absent rather than remote-only,
-- the block store is closed.
+- the block store is closed,
+- the residency scan did not finish inside the request's deadline.
 
 An unknown share reports `dittofs_offline_safe = 0` but publishes no byte
 counts, so a dashboard cannot mistake it for a clean fully-local share.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -680,6 +680,14 @@ whose data is most likely to be remote-only:
 An unknown share reports `dittofs_offline_safe = 0` but publishes no byte
 counts, so a dashboard cannot mistake it for a clean fully-local share.
 
+A share with **no remote at all** is normally safe by construction — nothing
+evicts it, so everything it holds is local. The exception is a share whose
+remote was unbound after it had already evicted: the evicted ranges stay
+recorded in the local tier and are replayed from its cold log on the next
+open, but there is no longer anything to fetch them from, so they never
+serve. Those shares report a non-zero remote-only figure rather than being
+waved through as local-only.
+
 The figure is **bytes, not blocks**. The local tier tracks byte ranges, which
 split and merge independently of manifest chunk rows; a block count would
 need a metadata walk to produce and would not answer "how much would break

--- a/internal/controlplane/api/handlers/shares.go
+++ b/internal/controlplane/api/handlers/shares.go
@@ -1644,20 +1644,22 @@ func (h *ShareHandler) shareToResponseWithUsage(ctx context.Context, s *models.S
 		}
 		resp.Status = h.shareStatus(ctx, s.Name)
 	} else {
-		resp.Status = unknownRuntimeReport()
+		resp.Status = unknownRuntimeStatus()
 	}
 	return resp
 }
 
-// unknownRuntimeReport builds a [health.StatusUnknown] status used
+// unknownRuntimeStatus builds a [health.StatusUnknown] status used
 // when a handler is wired without a runtime. Kept in one place so
 // shares.go's nil-guard branches stay consistent.
-func unknownRuntimeReport() health.ShareStatus {
-	return health.ShareStatus{Report: health.Report{
-		Status:    health.StatusUnknown,
-		Message:   "runtime not initialized",
-		CheckedAt: time.Now().UTC(),
-	}}
+func unknownRuntimeStatus() health.ShareStatus {
+	return health.ShareStatus{
+		Report: health.Report{
+			Status:    health.StatusUnknown,
+			Message:   "runtime not initialized",
+			CheckedAt: time.Now().UTC(),
+		},
+	}
 }
 
 // shareStatus returns a [health.ShareStatus] for the named share via the
@@ -1693,7 +1695,7 @@ func (h *ShareHandler) Status(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if h.runtime == nil {
-		WriteJSONOK(w, unknownRuntimeReport())
+		WriteJSONOK(w, unknownRuntimeStatus())
 		return
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), HealthCheckTimeout)

--- a/pkg/block/engine/offline.go
+++ b/pkg/block/engine/offline.go
@@ -1,0 +1,77 @@
+package engine
+
+// OfflineReadiness reports whether a share could keep serving reads with its
+// remote store unreachable, and by how much it falls short.
+//
+// The question has one honest answer per share: every byte the share holds is
+// either resident in the local tier or it is not. A range that is not — one
+// written, mirrored to the remote and since evicted locally — needs the remote
+// to serve, so a share with any such range would fail reads during an outage.
+// Zero remote-only bytes is a provable offline-safe share.
+type OfflineReadiness struct {
+	// RemoteOnlyBytes is the total size of ranges the local tier no longer
+	// holds and would have to fetch from the remote to serve.
+	RemoteOnlyBytes int64 `json:"remote_only_bytes"`
+
+	// RemoteOnlyRanges is how many separate ranges those bytes span.
+	RemoteOnlyRanges int64 `json:"remote_only_ranges"`
+
+	// Known reports whether the counts above mean anything. When it is false
+	// the share's residency cannot be determined and Reason says why —
+	// reporting zero in that case would read as "offline safe" for exactly
+	// the shares whose data is most likely to be remote-only.
+	Known bool `json:"known"`
+
+	// Reason names why Known is false, empty when it is true.
+	Reason string `json:"reason,omitempty"`
+}
+
+// Safe reports whether the share can serve every byte it holds without the
+// remote. An indeterminate readiness is never safe.
+func (o OfflineReadiness) Safe() bool { return o.Known && o.RemoteOnlyBytes == 0 }
+
+// coldRangeReporter is the local-tier capability this needs: which of its
+// ranges are remote-only, and whether it has been told what the manifest holds
+// yet. The journal-backed tier satisfies it; the in-memory tier does not, and
+// asserting for it here keeps that from becoming another method every fake has
+// to implement.
+type coldRangeReporter interface {
+	ColdExtents() (bytes int64, extents int64)
+	ColdSeeded() bool
+}
+
+// OfflineReadiness measures how much of this share's data is remote-only.
+//
+// ponytail: an O(live ranges) in-memory scan of the local tier's index on
+// every call, holding one shard's lock at a time. Keeping a running counter
+// instead would make it O(1), but the cold flag is set and cleared across
+// insert, split, clamp, evict, hydrate and repack, and a counter that drifts
+// on any one of those reports a share offline-safe when it is not. Take the
+// scan until a metrics scrape actually shows up in a latency profile.
+func (bs *Store) OfflineReadiness() OfflineReadiness {
+	bs.closeMu.RLock()
+	defer bs.closeMu.RUnlock()
+	if bs.closed {
+		return OfflineReadiness{Reason: "block store is closed"}
+	}
+
+	// A share with no remote has nothing to be cut off from: every byte it
+	// holds is local by construction.
+	if !bs.HasRemoteStore() {
+		return OfflineReadiness{Known: true}
+	}
+
+	reporter, ok := bs.local.(coldRangeReporter)
+	if !ok {
+		return OfflineReadiness{Reason: "local tier does not track remote-only ranges"}
+	}
+	// An unseeded tier holds no interval for ranges that live only on the
+	// remote, so its index would report them as absent rather than cold and
+	// the count would come back zero on the worst case it exists to catch.
+	if !reporter.ColdSeeded() {
+		return OfflineReadiness{Reason: "local tier has not been seeded from the manifest"}
+	}
+
+	bytes, ranges := reporter.ColdExtents()
+	return OfflineReadiness{RemoteOnlyBytes: bytes, RemoteOnlyRanges: ranges, Known: true}
+}

--- a/pkg/block/engine/offline.go
+++ b/pkg/block/engine/offline.go
@@ -63,23 +63,34 @@ func (bs *Store) OfflineReadiness() OfflineReadiness {
 // would say that about exactly the shares whose data is most likely to be
 // remote-only.
 func offlineReadinessOf(localTier any, hasRemote bool) OfflineReadiness {
-	// A share with no remote has nothing to be cut off from: every byte it
-	// holds is local by construction.
-	if !hasRemote {
-		return OfflineReadiness{Known: true}
-	}
-
 	reporter, ok := localTier.(coldRangeReporter)
 	if !ok {
+		// A tier that cannot report residency and has no remote also has
+		// nothing to evict to, so everything it holds is local. With a remote
+		// it could hold evicted ranges it cannot tell us about.
+		if !hasRemote {
+			return OfflineReadiness{Known: true}
+		}
 		return OfflineReadiness{Reason: "local tier does not track remote-only ranges"}
 	}
+
 	// An unseeded tier holds no interval for ranges that live only on the
-	// remote, so its index would report them as absent rather than cold and
-	// the count would come back zero on the worst case it exists to catch.
-	if !reporter.ColdSeeded() {
+	// remote, so its index would report them as absent rather than cold and the
+	// count would come back zero on the worst case this exists to catch.
+	// Seeding only ever runs for a remote-backed share, so an unseeded tier is
+	// a blind spot only when there is a remote it might not have caught up with.
+	if hasRemote && !reporter.ColdSeeded() {
 		return OfflineReadiness{Reason: "local tier has not been seeded from the manifest"}
 	}
 
+	// Ask the tier even with no remote configured. A share can hold cold ranges
+	// and have no remote at once — unbinding a remote from a share that had
+	// already evicted leaves the cold intervals in place, and the journal
+	// replays them from its cold log on the next open. Those ranges are worse
+	// than unsafe: reads reconcile on the cold flag whether or not a remote
+	// exists, so there is nothing to fetch them from and they never serve. A
+	// non-zero count is the honest report; treating "no remote" as "all local"
+	// would call that share provably offline-safe.
 	bytes, ranges := reporter.ColdExtents()
 	return OfflineReadiness{RemoteOnlyBytes: bytes, RemoteOnlyRanges: ranges, Known: true}
 }

--- a/pkg/block/engine/offline.go
+++ b/pkg/block/engine/offline.go
@@ -54,14 +54,22 @@ func (bs *Store) OfflineReadiness() OfflineReadiness {
 	if bs.closed {
 		return OfflineReadiness{Reason: "block store is closed"}
 	}
+	return offlineReadinessOf(bs.local, bs.HasRemoteStore())
+}
 
+// offlineReadinessOf holds the gating rules, separated from the store lookup so
+// they can be exercised directly. Each of them refuses to answer rather than
+// answering zero, because a zero here reads as "provably offline safe" and
+// would say that about exactly the shares whose data is most likely to be
+// remote-only.
+func offlineReadinessOf(localTier any, hasRemote bool) OfflineReadiness {
 	// A share with no remote has nothing to be cut off from: every byte it
 	// holds is local by construction.
-	if !bs.HasRemoteStore() {
+	if !hasRemote {
 		return OfflineReadiness{Known: true}
 	}
 
-	reporter, ok := bs.local.(coldRangeReporter)
+	reporter, ok := localTier.(coldRangeReporter)
 	if !ok {
 		return OfflineReadiness{Reason: "local tier does not track remote-only ranges"}
 	}

--- a/pkg/block/engine/offline.go
+++ b/pkg/block/engine/offline.go
@@ -1,5 +1,7 @@
 package engine
 
+import "context"
+
 // OfflineReadiness reports whether a share could keep serving reads with its
 // remote store unreachable, and by how much it falls short.
 //
@@ -36,7 +38,7 @@ func (o OfflineReadiness) Safe() bool { return o.Known && o.RemoteOnlyBytes == 0
 // asserting for it here keeps that from becoming another method every fake has
 // to implement.
 type coldRangeReporter interface {
-	ColdExtents() (bytes int64, extents int64)
+	ColdExtents(ctx context.Context) (bytes int64, extents int64, err error)
 	ColdSeeded() bool
 }
 
@@ -48,13 +50,13 @@ type coldRangeReporter interface {
 // insert, split, clamp, evict, hydrate and repack, and a counter that drifts
 // on any one of those reports a share offline-safe when it is not. Take the
 // scan until a metrics scrape actually shows up in a latency profile.
-func (bs *Store) OfflineReadiness() OfflineReadiness {
+func (bs *Store) OfflineReadiness(ctx context.Context) OfflineReadiness {
 	bs.closeMu.RLock()
 	defer bs.closeMu.RUnlock()
 	if bs.closed {
 		return OfflineReadiness{Reason: "block store is closed"}
 	}
-	return offlineReadinessOf(bs.local, bs.HasRemoteStore())
+	return offlineReadinessOf(ctx, bs.local, bs.HasRemoteStore())
 }
 
 // offlineReadinessOf holds the gating rules, separated from the store lookup so
@@ -62,7 +64,7 @@ func (bs *Store) OfflineReadiness() OfflineReadiness {
 // answering zero, because a zero here reads as "provably offline safe" and
 // would say that about exactly the shares whose data is most likely to be
 // remote-only.
-func offlineReadinessOf(localTier any, hasRemote bool) OfflineReadiness {
+func offlineReadinessOf(ctx context.Context, localTier any, hasRemote bool) OfflineReadiness {
 	reporter, ok := localTier.(coldRangeReporter)
 	if !ok {
 		// A tier that cannot report residency and has no remote also has
@@ -91,6 +93,9 @@ func offlineReadinessOf(localTier any, hasRemote bool) OfflineReadiness {
 	// exists, so there is nothing to fetch them from and they never serve. A
 	// non-zero count is the honest report; treating "no remote" as "all local"
 	// would call that share provably offline-safe.
-	bytes, ranges := reporter.ColdExtents()
+	bytes, ranges, err := reporter.ColdExtents(ctx)
+	if err != nil {
+		return OfflineReadiness{Reason: "residency scan did not finish: " + err.Error()}
+	}
 	return OfflineReadiness{RemoteOnlyBytes: bytes, RemoteOnlyRanges: ranges, Known: true}
 }

--- a/pkg/block/engine/offline_test.go
+++ b/pkg/block/engine/offline_test.go
@@ -48,11 +48,18 @@ func TestOfflineReadinessOf_Gating(t *testing.T) {
 		wantKnown bool
 		wantBytes int64
 	}{
-		{"no remote is local by construction", &fakeColdReporter{}, false, true, 0},
+		{"no remote, tier confirms nothing evicted", &fakeColdReporter{}, false, true, 0},
 		{"tier that cannot report residency", struct{}{}, true, false, 0},
+		{"no remote and no residency tracking", struct{}{}, false, true, 0},
 		{"unseeded tier cannot see remote-only ranges", &fakeColdReporter{seeded: false, bytes: 0}, true, false, 0},
 		{"seeded and fully local", &fakeColdReporter{seeded: true}, true, true, 0},
 		{"seeded with evicted ranges", &fakeColdReporter{seeded: true, bytes: 4096, extents: 2}, true, true, 4096},
+		// Unbinding a remote from a share that had already evicted leaves the
+		// cold intervals behind, and the journal replays them from its cold log
+		// on the next open. Reads reconcile on the cold flag whether or not a
+		// remote exists, so those ranges never serve — reporting this share
+		// safe would be the worst answer the measurement can give.
+		{"no remote but cold ranges remain", &fakeColdReporter{seeded: false, bytes: 8192, extents: 3}, false, true, 8192},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -68,6 +75,9 @@ func TestOfflineReadinessOf_Gating(t *testing.T) {
 			}
 			if got.Known && got.Reason != "" {
 				t.Errorf("answered but still gave a reason: %q", got.Reason)
+			}
+			if got.Safe() && got.RemoteOnlyBytes != 0 {
+				t.Errorf("reported safe with %d remote-only bytes", got.RemoteOnlyBytes)
 			}
 		})
 	}

--- a/pkg/block/engine/offline_test.go
+++ b/pkg/block/engine/offline_test.go
@@ -1,6 +1,10 @@
 package engine
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"testing"
+)
 
 // fakeColdReporter stands in for the local tier's residency surface so the
 // gating rules can be checked without building a journal.
@@ -8,10 +12,16 @@ type fakeColdReporter struct {
 	seeded  bool
 	bytes   int64
 	extents int64
+	err     error
 }
 
-func (f *fakeColdReporter) ColdExtents() (int64, int64) { return f.bytes, f.extents }
-func (f *fakeColdReporter) ColdSeeded() bool            { return f.seeded }
+func (f *fakeColdReporter) ColdExtents(ctx context.Context) (int64, int64, error) {
+	if f.err != nil {
+		return 0, 0, f.err
+	}
+	return f.bytes, f.extents, ctx.Err()
+}
+func (f *fakeColdReporter) ColdSeeded() bool { return f.seeded }
 
 // TestOfflineReadiness_Safe pins the two ways a readiness answer can be wrong
 // in the dangerous direction: reporting zero remote-only bytes for a share
@@ -63,7 +73,7 @@ func TestOfflineReadinessOf_Gating(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := offlineReadinessOf(tc.localTier, tc.hasRemote)
+			got := offlineReadinessOf(context.Background(), tc.localTier, tc.hasRemote)
 			if got.Known != tc.wantKnown {
 				t.Errorf("Known = %v, want %v (reason %q)", got.Known, tc.wantKnown, got.Reason)
 			}
@@ -80,5 +90,35 @@ func TestOfflineReadinessOf_Gating(t *testing.T) {
 				t.Errorf("reported safe with %d remote-only bytes", got.RemoteOnlyBytes)
 			}
 		})
+	}
+}
+
+// TestOfflineReadinessOf_CancelledScanIsUnknown asserts a walk that ran out of
+// time reports unknown rather than the partial total it had reached. A status
+// request and a metrics scrape both carry a deadline, and a truncated count
+// would read as a share holding less remote-only data than it does.
+func TestOfflineReadinessOf_CancelledScanIsUnknown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	got := offlineReadinessOf(ctx, &fakeColdReporter{seeded: true, bytes: 4096, extents: 2}, true)
+	if got.Known {
+		t.Error("a cancelled scan reported a known answer")
+	}
+	if got.Safe() {
+		t.Error("a cancelled scan reported the share offline-safe")
+	}
+	if got.RemoteOnlyBytes != 0 {
+		t.Errorf("RemoteOnlyBytes = %d after cancellation, want 0 (no partial totals)", got.RemoteOnlyBytes)
+	}
+	if got.Reason == "" {
+		t.Error("refused to answer without saying why")
+	}
+
+	// A scan that fails for its own reasons is the same kind of non-answer.
+	failed := offlineReadinessOf(context.Background(),
+		&fakeColdReporter{seeded: true, err: errors.New("store is closed")}, true)
+	if failed.Known || failed.Safe() {
+		t.Errorf("a failed scan reported known=%v safe=%v", failed.Known, failed.Safe())
 	}
 }

--- a/pkg/block/engine/offline_test.go
+++ b/pkg/block/engine/offline_test.go
@@ -1,0 +1,74 @@
+package engine
+
+import "testing"
+
+// fakeColdReporter stands in for the local tier's residency surface so the
+// gating rules can be checked without building a journal.
+type fakeColdReporter struct {
+	seeded  bool
+	bytes   int64
+	extents int64
+}
+
+func (f *fakeColdReporter) ColdExtents() (int64, int64) { return f.bytes, f.extents }
+func (f *fakeColdReporter) ColdSeeded() bool            { return f.seeded }
+
+// TestOfflineReadiness_Safe pins the two ways a readiness answer can be wrong
+// in the dangerous direction: reporting zero remote-only bytes for a share
+// whose residency is not actually known reads as "provably offline safe" for
+// exactly the shares most likely not to be.
+func TestOfflineReadiness_Safe(t *testing.T) {
+	tests := []struct {
+		name     string
+		r        OfflineReadiness
+		wantSafe bool
+	}{
+		{"known and fully local", OfflineReadiness{Known: true}, true},
+		{"known with remote-only bytes", OfflineReadiness{Known: true, RemoteOnlyBytes: 1}, false},
+		{"unknown reads as unsafe", OfflineReadiness{Reason: "local tier has not been seeded from the manifest"}, false},
+		{"unknown is never safe even at zero", OfflineReadiness{Reason: "block store is closed", RemoteOnlyBytes: 0}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.r.Safe(); got != tc.wantSafe {
+				t.Errorf("Safe() = %v, want %v", got, tc.wantSafe)
+			}
+		})
+	}
+}
+
+// TestOfflineReadinessOf_Gating pins when the measurement refuses to answer.
+// Each refusal replaces a zero that would have read as "provably offline
+// safe", which is the wrong answer in the dangerous direction.
+func TestOfflineReadinessOf_Gating(t *testing.T) {
+	tests := []struct {
+		name      string
+		localTier any
+		hasRemote bool
+		wantKnown bool
+		wantBytes int64
+	}{
+		{"no remote is local by construction", &fakeColdReporter{}, false, true, 0},
+		{"tier that cannot report residency", struct{}{}, true, false, 0},
+		{"unseeded tier cannot see remote-only ranges", &fakeColdReporter{seeded: false, bytes: 0}, true, false, 0},
+		{"seeded and fully local", &fakeColdReporter{seeded: true}, true, true, 0},
+		{"seeded with evicted ranges", &fakeColdReporter{seeded: true, bytes: 4096, extents: 2}, true, true, 4096},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := offlineReadinessOf(tc.localTier, tc.hasRemote)
+			if got.Known != tc.wantKnown {
+				t.Errorf("Known = %v, want %v (reason %q)", got.Known, tc.wantKnown, got.Reason)
+			}
+			if got.RemoteOnlyBytes != tc.wantBytes {
+				t.Errorf("RemoteOnlyBytes = %d, want %d", got.RemoteOnlyBytes, tc.wantBytes)
+			}
+			if !got.Known && got.Reason == "" {
+				t.Error("refused to answer without saying why")
+			}
+			if got.Known && got.Reason != "" {
+				t.Errorf("answered but still gave a reason: %q", got.Reason)
+			}
+		})
+	}
+}

--- a/pkg/block/journal/coldstats.go
+++ b/pkg/block/journal/coldstats.go
@@ -1,5 +1,7 @@
 package journal
 
+import "context"
+
 // ColdExtents reports the ranges this store knows about whose bytes are
 // durable on the remote store but no longer resident locally. Reading one
 // requires the remote, so a store with no cold extent can serve every byte it
@@ -16,14 +18,25 @@ package journal
 // offline" directly and costs an in-memory scan.
 //
 // The scan holds each shard's lock only for that shard's slice of the index,
-// so it never blocks the whole store at once. It is O(live intervals), which
-// is why callers should treat it as a periodic gauge rather than something to
-// call per request.
-func (s *Store) ColdExtents() (bytes int64, extents int64) {
+// so it never blocks the whole store at once, and it gives up between shards
+// when ctx is done — a status request or a metrics scrape carries a deadline,
+// and a large share must not be able to run one past it. A cancelled walk
+// reports no counts rather than a partial total, which would read as a share
+// with less remote-only data than it has.
+//
+// It is O(live intervals), so callers should treat it as a periodic gauge
+// rather than something to call per request.
+func (s *Store) ColdExtents(ctx context.Context) (bytes int64, extents int64, err error) {
 	if s.closed.Load() {
-		return 0, 0
+		return 0, 0, errClosed
 	}
 	for _, sh := range s.shards {
+		// Checked between shards rather than inside the inner loop: a caller
+		// with a deadline gets out after at most one shard's slice of the
+		// index, and the check never lands while a shard lock is held.
+		if err := ctx.Err(); err != nil {
+			return 0, 0, err
+		}
 		sh.mu.Lock()
 		for _, fi := range sh.index {
 			for _, iv := range fi.ivs {
@@ -36,5 +49,5 @@ func (s *Store) ColdExtents() (bytes int64, extents int64) {
 		}
 		sh.mu.Unlock()
 	}
-	return bytes, extents
+	return bytes, extents, nil
 }

--- a/pkg/block/journal/coldstats.go
+++ b/pkg/block/journal/coldstats.go
@@ -1,0 +1,40 @@
+package journal
+
+// ColdExtents reports the ranges this store knows about whose bytes are
+// durable on the remote store but no longer resident locally. Reading one
+// requires the remote, so a store with no cold extent can serve every byte it
+// holds with the remote unreachable.
+//
+// A cold range is distinct from an absent one: an absent range is a true hole
+// and reads as zeros by definition, while a cold range is served by fetching.
+// Only cold ranges are counted, so a sparse file contributes nothing.
+//
+// The tally is bytes and ranges, not blocks. A journal interval is a byte
+// range, split by partial overwrite and clamped by hydrate, so it does not
+// stand in one-to-one for a manifest chunk row. Counting chunk rows instead
+// would mean a metadata walk; the byte figure answers "how much would break
+// offline" directly and costs an in-memory scan.
+//
+// The scan holds each shard's lock only for that shard's slice of the index,
+// so it never blocks the whole store at once. It is O(live intervals), which
+// is why callers should treat it as a periodic gauge rather than something to
+// call per request.
+func (s *Store) ColdExtents() (bytes int64, extents int64) {
+	if s.closed.Load() {
+		return 0, 0
+	}
+	for _, sh := range s.shards {
+		sh.mu.Lock()
+		for _, fi := range sh.index {
+			for _, iv := range fi.ivs {
+				if !iv.cold {
+					continue
+				}
+				bytes += iv.length
+				extents++
+			}
+		}
+		sh.mu.Unlock()
+	}
+	return bytes, extents
+}

--- a/pkg/block/journal/coldstats_test.go
+++ b/pkg/block/journal/coldstats_test.go
@@ -15,7 +15,7 @@ func TestColdExtents_CountsEvictedRangesOnly(t *testing.T) {
 
 	fillUntilSealed(t, s, "f", true, 2)
 
-	if bytes, extents := s.ColdExtents(); bytes != 0 || extents != 0 {
+	if bytes, extents, err := s.ColdExtents(ctx); err != nil || bytes != 0 || extents != 0 {
 		t.Fatalf("before eviction: ColdExtents() = (%d, %d), want (0, 0) — nothing has been evicted", bytes, extents)
 	}
 
@@ -27,7 +27,10 @@ func TestColdExtents_CountsEvictedRangesOnly(t *testing.T) {
 		t.Fatalf("Evict evicted %d segments, want 1", res.SegmentsEvicted)
 	}
 
-	bytes, extents := s.ColdExtents()
+	bytes, extents, err := s.ColdExtents(ctx)
+	if err != nil {
+		t.Fatalf("ColdExtents: %v", err)
+	}
 	if bytes <= 0 || extents <= 0 {
 		t.Fatalf("after eviction: ColdExtents() = (%d, %d), want both positive", bytes, extents)
 	}
@@ -49,7 +52,7 @@ func TestColdExtents_HydrateClearsIt(t *testing.T) {
 	if _, err := s.Evict(ctx, 0); err != nil {
 		t.Fatalf("Evict: %v", err)
 	}
-	coldBefore, extentsBefore := s.ColdExtents()
+	coldBefore, extentsBefore, _ := s.ColdExtents(ctx)
 	if coldBefore == 0 {
 		t.Fatal("eviction produced no cold bytes; the rest of this test proves nothing")
 	}
@@ -62,7 +65,7 @@ func TestColdExtents_HydrateClearsIt(t *testing.T) {
 		}
 	}
 
-	if bytes, extents := s.ColdExtents(); bytes != 0 || extents != 0 {
+	if bytes, extents, _ := s.ColdExtents(ctx); bytes != 0 || extents != 0 {
 		t.Fatalf("after re-hydrating everything: ColdExtents() = (%d, %d) (was %d, %d), want (0, 0)",
 			bytes, extents, coldBefore, extentsBefore)
 	}
@@ -83,4 +86,24 @@ func coldIntervals(s *Store) []interval {
 		sh.mu.Unlock()
 	}
 	return out
+}
+
+// TestColdExtents_HonoursContext asserts a walk with a cancelled context gives
+// up instead of running a status request or a metrics scrape past its deadline.
+func TestColdExtents_HonoursContext(t *testing.T) {
+	s, _ := evictStore(t, Config{})
+	fillUntilSealed(t, s, "f", true, 2)
+	if _, err := s.Evict(context.Background(), 0); err != nil {
+		t.Fatalf("Evict: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	bytes, extents, err := s.ColdExtents(ctx)
+	if err == nil {
+		t.Fatal("ColdExtents ignored a cancelled context")
+	}
+	if bytes != 0 || extents != 0 {
+		t.Errorf("cancelled walk returned partial counts (%d, %d), want zeros", bytes, extents)
+	}
 }

--- a/pkg/block/journal/coldstats_test.go
+++ b/pkg/block/journal/coldstats_test.go
@@ -1,0 +1,86 @@
+package journal
+
+import (
+	"context"
+	"testing"
+)
+
+// TestColdExtents_CountsEvictedRangesOnly drives the real evict path and
+// asserts the tally moves with it: a store holding only resident data reports
+// nothing remote-only, and evicting a segment turns exactly those bytes into
+// the figure an operator reads as "this would not serve offline".
+func TestColdExtents_CountsEvictedRangesOnly(t *testing.T) {
+	s, _ := evictStore(t, Config{})
+	ctx := context.Background()
+
+	fillUntilSealed(t, s, "f", true, 2)
+
+	if bytes, extents := s.ColdExtents(); bytes != 0 || extents != 0 {
+		t.Fatalf("before eviction: ColdExtents() = (%d, %d), want (0, 0) — nothing has been evicted", bytes, extents)
+	}
+
+	res, err := s.Evict(ctx, 0)
+	if err != nil {
+		t.Fatalf("Evict: %v", err)
+	}
+	if res.SegmentsEvicted != 1 {
+		t.Fatalf("Evict evicted %d segments, want 1", res.SegmentsEvicted)
+	}
+
+	bytes, extents := s.ColdExtents()
+	if bytes <= 0 || extents <= 0 {
+		t.Fatalf("after eviction: ColdExtents() = (%d, %d), want both positive", bytes, extents)
+	}
+	// The tally counts payload ranges, so it must not exceed the segment's
+	// on-disk footprint, which also carries record framing.
+	if bytes > res.BytesFreed {
+		t.Errorf("cold bytes %d exceed the %d bytes the eviction freed on disk", bytes, res.BytesFreed)
+	}
+}
+
+// TestColdExtents_HydrateClearsIt asserts pulling an evicted range back local
+// removes it from the tally, so an operator running a warm can watch the
+// number fall to zero rather than watching a figure that only ever grows.
+func TestColdExtents_HydrateClearsIt(t *testing.T) {
+	s, _ := evictStore(t, Config{})
+	ctx := context.Background()
+
+	fillUntilSealed(t, s, "f", true, 2)
+	if _, err := s.Evict(ctx, 0); err != nil {
+		t.Fatalf("Evict: %v", err)
+	}
+	coldBefore, extentsBefore := s.ColdExtents()
+	if coldBefore == 0 {
+		t.Fatal("eviction produced no cold bytes; the rest of this test proves nothing")
+	}
+
+	// Re-hydrate every cold range, which is what a warm does.
+	for _, iv := range coldIntervals(s) {
+		buf := make([]byte, iv.length)
+		if err := s.Hydrate(ctx, "f", iv.fileOff, buf, 0); err != nil {
+			t.Fatalf("Hydrate(%d, %d): %v", iv.fileOff, iv.length, err)
+		}
+	}
+
+	if bytes, extents := s.ColdExtents(); bytes != 0 || extents != 0 {
+		t.Fatalf("after re-hydrating everything: ColdExtents() = (%d, %d) (was %d, %d), want (0, 0)",
+			bytes, extents, coldBefore, extentsBefore)
+	}
+}
+
+// coldIntervals snapshots the store's cold ranges so a test can act on them.
+func coldIntervals(s *Store) []interval {
+	var out []interval
+	for _, sh := range s.shards {
+		sh.mu.Lock()
+		for _, fi := range sh.index {
+			for _, iv := range fi.ivs {
+				if iv.cold {
+					out = append(out, iv)
+				}
+			}
+		}
+		sh.mu.Unlock()
+	}
+	return out
+}

--- a/pkg/controlplane/runtime/integrity_scheduler.go
+++ b/pkg/controlplane/runtime/integrity_scheduler.go
@@ -151,7 +151,9 @@ func (r *Runtime) ShareIntegrity(share string) *health.IntegrityStatus {
 // A worse status from a subsystem probe always wins; the scan can only
 // downgrade a healthy share, never upgrade an unhealthy one.
 func (r *Runtime) ShareStatus(ctx context.Context, share string) health.ShareStatus {
-	return withIntegrity(r.ShareChecker(share).Healthcheck(ctx), r.ShareIntegrity(share))
+	out := withIntegrity(r.ShareChecker(share).Healthcheck(ctx), r.ShareIntegrity(share))
+	out.Offline = r.ShareOffline(share)
+	return out
 }
 
 // withIntegrity joins a subsystem health report to a recorded scan outcome,

--- a/pkg/controlplane/runtime/integrity_scheduler.go
+++ b/pkg/controlplane/runtime/integrity_scheduler.go
@@ -152,7 +152,7 @@ func (r *Runtime) ShareIntegrity(share string) *health.IntegrityStatus {
 // downgrade a healthy share, never upgrade an unhealthy one.
 func (r *Runtime) ShareStatus(ctx context.Context, share string) health.ShareStatus {
 	out := withIntegrity(r.ShareChecker(share).Healthcheck(ctx), r.ShareIntegrity(share))
-	out.Offline = r.ShareOffline(share)
+	out.Offline = r.ShareOffline(ctx, share)
 	return out
 }
 

--- a/pkg/controlplane/runtime/metrics.go
+++ b/pkg/controlplane/runtime/metrics.go
@@ -47,7 +47,7 @@ func (r *Runtime) MetricsSnapshot(ctx context.Context) metrics.Snapshot {
 			SnapshotsHeld:       held,
 			LastSnapshotUnix:    lastUnix,
 			Integrity:           integritySnapshot(r.ShareIntegrity(ps.ShareName)),
-			Offline:             offlineSnapshot(r.ShareOffline(ps.ShareName)),
+			Offline:             offlineSnapshot(r.ShareOffline(ctx, ps.ShareName)),
 		})
 	}
 

--- a/pkg/controlplane/runtime/metrics.go
+++ b/pkg/controlplane/runtime/metrics.go
@@ -47,6 +47,7 @@ func (r *Runtime) MetricsSnapshot(ctx context.Context) metrics.Snapshot {
 			SnapshotsHeld:       held,
 			LastSnapshotUnix:    lastUnix,
 			Integrity:           integritySnapshot(r.ShareIntegrity(ps.ShareName)),
+			Offline:             offlineSnapshot(r.ShareOffline(ps.ShareName)),
 		})
 	}
 
@@ -130,5 +131,20 @@ func integritySnapshot(s *health.IntegrityStatus) metrics.IntegrityScanSnapshot 
 		ClaimedUncoveredRanges: int64(s.ClaimedUncoveredRanges),
 		UnplaceableRows:        int64(s.UnplaceableRows),
 		UnknownHashRows:        int64(s.UnknownHashRows),
+	}
+}
+
+// offlineSnapshot renders a share's offline read readiness for the metrics
+// surface. A share with no block store to ask reports unknown rather than
+// safe.
+func offlineSnapshot(o *health.OfflineStatus) metrics.OfflineSnapshot {
+	if o == nil {
+		return metrics.OfflineSnapshot{}
+	}
+	return metrics.OfflineSnapshot{
+		Safe:             o.Safe,
+		Known:            o.Unknown == "",
+		RemoteOnlyBytes:  o.RemoteOnlyBytes,
+		RemoteOnlyRanges: o.RemoteOnlyRanges,
 	}
 }

--- a/pkg/controlplane/runtime/offline.go
+++ b/pkg/controlplane/runtime/offline.go
@@ -1,0 +1,27 @@
+package runtime
+
+import (
+	"github.com/marmos91/dittofs/pkg/health"
+)
+
+// ShareOffline reports whether the named share could keep serving reads with
+// its remote store unreachable. Returns nil when the share has no block store
+// to ask — a metadata-only share, or one that is not currently served.
+//
+// The measurement is taken live rather than recorded by a scheduled pass: the
+// answer changes with every eviction and every warm, and an operator running
+// `dfsctl share warm` wants to watch the number fall, not learn about it
+// tomorrow.
+func (r *Runtime) ShareOffline(share string) *health.OfflineStatus {
+	bs, err := r.sharesSvc.GetBlockStoreForShare(share)
+	if err != nil || bs == nil {
+		return nil
+	}
+	rd := bs.OfflineReadiness()
+	return &health.OfflineStatus{
+		Safe:             rd.Safe(),
+		RemoteOnlyBytes:  rd.RemoteOnlyBytes,
+		RemoteOnlyRanges: rd.RemoteOnlyRanges,
+		Unknown:          rd.Reason,
+	}
+}

--- a/pkg/controlplane/runtime/offline.go
+++ b/pkg/controlplane/runtime/offline.go
@@ -1,6 +1,8 @@
 package runtime
 
 import (
+	"context"
+
 	"github.com/marmos91/dittofs/pkg/health"
 )
 
@@ -12,12 +14,12 @@ import (
 // answer changes with every eviction and every warm, and an operator running
 // `dfsctl share warm` wants to watch the number fall, not learn about it
 // tomorrow.
-func (r *Runtime) ShareOffline(share string) *health.OfflineStatus {
+func (r *Runtime) ShareOffline(ctx context.Context, share string) *health.OfflineStatus {
 	bs, err := r.sharesSvc.GetBlockStoreForShare(share)
 	if err != nil || bs == nil {
 		return nil
 	}
-	rd := bs.OfflineReadiness()
+	rd := bs.OfflineReadiness(ctx)
 	return &health.OfflineStatus{
 		Safe:             rd.Safe(),
 		RemoteOnlyBytes:  rd.RemoteOnlyBytes,

--- a/pkg/health/share.go
+++ b/pkg/health/share.go
@@ -16,6 +16,40 @@ type ShareStatus struct {
 	// Integrity is the outcome of the most recent structural manifest
 	// scan for this share. Nil when no scan has run yet.
 	Integrity *IntegrityStatus `json:"integrity,omitempty"`
+
+	// Offline reports whether the share could keep serving reads with its
+	// remote store unreachable. Nil when the share has no block store.
+	Offline *OfflineStatus `json:"offline,omitempty"`
+}
+
+// OfflineStatus answers "would this share keep serving if the remote were
+// unreachable", and by how much it falls short.
+//
+// It deliberately does not affect the share's health status. A share that is
+// not offline-safe is not unwell — most shares are not, by design, because a
+// remote-backed local tier evicts what it has mirrored. Whether that matters
+// is the operator's call, so this reports the number and leaves the verdict
+// alone.
+type OfflineStatus struct {
+	// Safe is true when every byte the share holds can be served without the
+	// remote. False when some cannot, or when residency is indeterminate.
+	Safe bool `json:"safe"`
+
+	// RemoteOnlyBytes is how much data the local tier no longer holds and
+	// would have to fetch from the remote to serve, across RemoteOnlyRanges
+	// separate ranges. Both are zero on a safe share.
+	//
+	// The figure is bytes, not blocks: the local tier tracks byte ranges,
+	// which split and merge independently of manifest chunk rows, so a block
+	// count would need a metadata walk to produce and would not be any more
+	// accurate an answer to "how much would break offline".
+	RemoteOnlyBytes  int64 `json:"remote_only_bytes"`
+	RemoteOnlyRanges int64 `json:"remote_only_ranges"`
+
+	// Unknown names why residency could not be determined, empty when it
+	// could. A share reporting this is not safe and not known to be unsafe;
+	// the counts above are meaningless for it.
+	Unknown string `json:"unknown,omitempty"`
 }
 
 // IntegrityStatus summarises one structural manifest scan: what it looked

--- a/pkg/metrics/collectors.go
+++ b/pkg/metrics/collectors.go
@@ -47,6 +47,11 @@ type runtimeCollector struct {
 	integrityFilesScanned *prometheus.Desc
 	integrityFindings     *prometheus.Desc
 
+	// Per-share offline read readiness.
+	offlineSafe         *prometheus.Desc
+	offlineRemoteBytes  *prometheus.Desc
+	offlineRemoteRanges *prometheus.Desc
+
 	// Per-principal quotas.
 	quotaUsedBytes   *prometheus.Desc
 	quotaLimitBytes  *prometheus.Desc
@@ -94,6 +99,10 @@ func newRuntimeCollector(p Provider) *runtimeCollector {
 		integrityFilesScanned: d(fqdn("integrity", "files_scanned"), "Regular files walked by the last structural manifest scan.", share),
 		integrityFindings:     d(fqdn("integrity", "findings"), "Findings from the last structural manifest scan, by kind: payloads_with_findings, damaged_payloads, claimed_uncovered_ranges, unplaceable_rows, unknown_hash_rows.", finding),
 
+		offlineSafe:         d(fqdn("offline", "safe"), "Whether every byte the share holds can be served with the remote unreachable (1) or not (0). A share whose residency cannot be determined reports 0.", share),
+		offlineRemoteBytes:  d(fqdn("offline", "remote_only_bytes"), "Bytes the local tier no longer holds and would have to fetch from the remote to serve.", share),
+		offlineRemoteRanges: d(fqdn("offline", "remote_only_ranges"), "Number of separate ranges those remote-only bytes span.", share),
+
 		quotaUsedBytes:   d(fqdn("quota", "used_bytes"), "Bytes used by a quota principal.", quota),
 		quotaLimitBytes:  d(fqdn("quota", "limit_bytes"), "Hard byte limit for a quota principal (0 = unlimited).", quota),
 		quotaUsedInodes:  d(fqdn("quota", "used_inodes"), "Inodes used by a quota principal.", quota),
@@ -119,6 +128,7 @@ func (c *runtimeCollector) allDescs() []*prometheus.Desc {
 		c.logicalBytes, c.storeFiles,
 		c.snapshotsActive, c.snapshotLastTime,
 		c.integrityLastScan, c.integrityScanFailed, c.integrityScanDuration, c.integrityFilesScanned, c.integrityFindings,
+		c.offlineSafe, c.offlineRemoteBytes, c.offlineRemoteRanges,
 		c.quotaUsedBytes, c.quotaLimitBytes, c.quotaUsedInodes, c.quotaLimitInodes,
 		c.clientsActive,
 	}
@@ -158,6 +168,15 @@ func (c *runtimeCollector) Collect(ch chan<- prometheus.Metric) {
 		gauge(c.integrityFindings, float64(in.ClaimedUncoveredRanges), s.Name, "claimed_uncovered_ranges")
 		gauge(c.integrityFindings, float64(in.UnplaceableRows), s.Name, "unplaceable_rows")
 		gauge(c.integrityFindings, float64(in.UnknownHashRows), s.Name, "unknown_hash_rows")
+
+		// A share whose residency cannot be determined emits the safety gauge
+		// as 0 but no byte counts: publishing zeros there would read as a
+		// clean, fully-local share.
+		gauge(c.offlineSafe, boolToFloat(s.Offline.Safe), s.Name)
+		if s.Offline.Known {
+			gauge(c.offlineRemoteBytes, float64(s.Offline.RemoteOnlyBytes), s.Name)
+			gauge(c.offlineRemoteRanges, float64(s.Offline.RemoteOnlyRanges), s.Name)
+		}
 
 		// Sync/remote series only make sense for shares with a remote backend.
 		if s.HasRemote {

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -158,3 +158,49 @@ func TestWithAuth(t *testing.T) {
 		t.Fatalf("good-token: want 200, got %d", rec.Code)
 	}
 }
+
+// A share whose residency could not be determined must still report a safety
+// gauge, but must NOT publish byte counts: zeros there are indistinguishable
+// from a clean, fully-local share, which is the one wrong answer this signal
+// cannot afford to give.
+func TestRuntimeCollector_UnknownOfflineShareOmitsByteGauges(t *testing.T) {
+	m := newTestMetrics(t, Snapshot{Shares: []ShareSnapshot{{
+		Name: "unknowable", HasRemote: true,
+		Offline: OfflineSnapshot{Safe: false, Known: false},
+	}}})
+	if got := testutil.CollectAndCount(m.Registry(), "dittofs_offline_remote_only_bytes"); got != 0 {
+		t.Errorf("unknown share published remote_only_bytes (%d series), want none", got)
+	}
+	if got := testutil.CollectAndCount(m.Registry(), "dittofs_offline_remote_only_ranges"); got != 0 {
+		t.Errorf("unknown share published remote_only_ranges (%d series), want none", got)
+	}
+	if got := testutil.CollectAndCount(m.Registry(), "dittofs_offline_safe"); got != 1 {
+		t.Fatalf("expected one offline_safe series, got %d", got)
+	}
+	if err := testutil.CollectAndCompare(m.Registry(), strings.NewReader(`
+# HELP dittofs_offline_safe Whether every byte the share holds can be served with the remote unreachable (1) or not (0). A share whose residency cannot be determined reports 0.
+# TYPE dittofs_offline_safe gauge
+dittofs_offline_safe{share="unknowable"} 0
+`), "dittofs_offline_safe"); err != nil {
+		t.Fatalf("unexpected offline_safe value: %v", err)
+	}
+}
+
+// A share whose residency IS known publishes both byte gauges alongside the
+// safety verdict, so an operator can see how far from safe it is.
+func TestRuntimeCollector_KnownOfflineShareEmitsByteGauges(t *testing.T) {
+	m := newTestMetrics(t, Snapshot{Shares: []ShareSnapshot{{
+		Name: "known", HasRemote: true,
+		Offline: OfflineSnapshot{Safe: false, Known: true, RemoteOnlyBytes: 4096, RemoteOnlyRanges: 2},
+	}}})
+	if err := testutil.CollectAndCompare(m.Registry(), strings.NewReader(`
+# HELP dittofs_offline_remote_only_bytes Bytes the local tier no longer holds and would have to fetch from the remote to serve.
+# TYPE dittofs_offline_remote_only_bytes gauge
+dittofs_offline_remote_only_bytes{share="known"} 4096
+# HELP dittofs_offline_remote_only_ranges Number of separate ranges those remote-only bytes span.
+# TYPE dittofs_offline_remote_only_ranges gauge
+dittofs_offline_remote_only_ranges{share="known"} 2
+`), "dittofs_offline_remote_only_bytes", "dittofs_offline_remote_only_ranges"); err != nil {
+		t.Fatalf("unexpected byte gauges: %v", err)
+	}
+}

--- a/pkg/metrics/snapshot.go
+++ b/pkg/metrics/snapshot.go
@@ -72,6 +72,19 @@ type ShareSnapshot struct {
 	// emitted rather than suppressed so an alert on scan age fires for a
 	// share that has never been verified.
 	Integrity IntegrityScanSnapshot
+
+	// Offline reports whether the share could serve reads with its remote
+	// unreachable.
+	Offline OfflineSnapshot
+}
+
+// OfflineSnapshot is one share's offline read readiness: how much of its data
+// the local tier no longer holds, and whether that figure is knowable at all.
+type OfflineSnapshot struct {
+	Safe             bool
+	Known            bool
+	RemoteOnlyBytes  int64
+	RemoteOnlyRanges int64
 }
 
 // IntegrityScanSnapshot is one share's structural manifest scan result: how


### PR DESCRIPTION
Stacked on #2080 — review that first; this branch reuses the status shape it
introduces.

## What was missing

The warm+pin half of this issue was already done: `dfsctl share warm` pulls a
share fully local and the `pin` retention policy never evicts what is local,
so `warm` + `pin` already gives full offline read availability today. What
was missing was any way to *see* it. A repo-wide grep for remote-only /
cold-bytes residency returned nothing: no counter, no metric, no share-status
field. An operator could assemble the guarantee by hand and had no way to
confirm it held, or to notice when eviction quietly broke it again.

## Where the answer already lived

The residency bit exists and is exact — it just was not exported.
`journal.interval.cold` marks a range that was written, is durable on the
remote, and whose local bytes have been evicted. That is definitionally
"remote-only": a read of it fetches, and would fail with the remote
unreachable. Everything else in the local index is resident.

Nothing else in the tree answers this, and it is worth saying why, because
each near-miss looks usable:

- `BlockStoreStats.BlocksLocal` / `BlocksCached` are **dead fields, never
  incremented**. `classifyBlocks` (pkg/block/engine/stats.go) classifies by
  *sync state* only, so every non-dirty row lands in `BlocksRemote` — a fully
  warm share reports 100% `BlocksRemote`.
- `FileChunk.State` is upload lifecycle, not residency. `BlockStateRemote`
  means "carved and uploaded", and eviction never writes back to metadata.
  So **metadata alone cannot answer this at any cost**, and adding a
  residency column would put a DB write on every evict and every hydrate.
- `DataExtents` deliberately reports cold ranges as data (it exists to make
  SEEK correct), so it cannot distinguish them.
- `share warm` does not compute a remote-only set either — it re-fetches
  every row on purpose, for the same reason.

## What this adds

- `journal.Store.ColdExtents()` — an in-memory walk of the interval index,
  one shard lock at a time, tallying cold bytes and ranges. No metadata, no
  disk, no S3. It reuses the traversal shape `Stats()` and `liveColdEntries`
  already use.
- `engine.Store.OfflineReadiness()` — the gating, plus `Safe()`.
- `dfsctl share show`: `Offline Safe: yes` / `no (12.4 GiB remote-only across
  431 ranges)`.
- `dittofs_offline_safe{share}`, `dittofs_offline_remote_only_bytes{share}`,
  `dittofs_offline_remote_only_ranges{share}`.

## It refuses to answer rather than answer zero

The whole thing turns on one asymmetry: reporting zero remote-only bytes for
a share whose residency is not actually known reads as *provably offline
safe*, and would say that about exactly the shares whose data is most likely
to be remote-only. So three cases report unknown instead:

- the local tier does not track residency (in-memory backend),
- **the local tier has not been seeded from the manifest** — an unseeded tier
  holds no interval at all for ranges living only on the remote, so its index
  reports them absent rather than cold and the raw count comes back zero on
  the worst case the measurement exists to catch,
- the block store is closed.

An unknown share reports `dittofs_offline_safe = 0` and publishes no byte
counts, so a dashboard cannot mistake it for a clean fully-local one.

## Two deliberate calls

**Bytes, not blocks.** The issue asks for a block count. Journal intervals are
byte ranges that split on partial overwrite and clamp on hydrate, so they do
not stand in one-to-one for manifest chunk rows. A true block count means
joining cold extents against `ListFileChunks`, which drags a metadata walk
back in — for a number that answers "how much would break offline" less
directly than the bytes do. Reporting extents alongside the bytes gives the
fragmentation picture without the lie.

**This does not degrade the share's health.** A share that is not offline-safe
is not unwell — most remote-backed shares are not, by design, because the
local tier evicts what it has mirrored. That is the reason the status shape
#2080 introduces carries structured counters rather than prose: #2076's
finding *should* downgrade a share and this one should not, and a single
`Report.Message` string cannot express both at once.

## Known ceiling

`ColdExtents` is O(live intervals) per call, on the metrics scrape path and
the share-status path. A running counter would be O(1), but `cold` is set and
cleared across insert, split, clamp, evict, hydrate and repack, and a counter
that drifts on any one of those reports a share offline-safe when it is not.
Marked with a `ponytail:` comment naming the trigger: take the scan until a
scrape actually shows up in a latency profile.

## Verification

- `go build ./... && go vet ./... && go test ./...` green.
- `TestColdExtents_CountsEvictedRangesOnly` drives the **real** evict path —
  no fake — and asserts the tally is zero before eviction, positive after,
  and never exceeds the bytes the eviction actually freed on disk.
- `TestColdExtents_HydrateClearsIt` re-hydrates every cold range and asserts
  the figure returns to zero, so the number an operator watches during a warm
  actually falls.
- `TestOfflineReadinessOf_Gating` pins each refusal, including that a refusal
  always carries a reason and an answer never does.

Closes #1848
