### PR TITLE
perf(seed): batch the manifest cold seed into one durable append

### DIFF
--- a/pkg/block/engine/close_gate_test.go
+++ b/pkg/block/engine/close_gate_test.go
@@ -182,6 +182,11 @@ func TestStore_OpAfterCloseReturnsErrStoreClosed(t *testing.T) {
 			t.Fatalf("want ErrStoreClosed, got %v", err)
 		}
 	})
+	t.Run("SeedColdBatch", func(t *testing.T) {
+		if err := bs.SeedColdBatch(ctx, []ColdSeed{{PayloadID: "p", Extents: [][2]int64{{0, 4096}}}}); !errors.Is(err, ErrStoreClosed) {
+			t.Errorf("SeedColdBatch after Close = %v, want ErrStoreClosed; a seed that slips past Close reopens the cold log behind a torn-down store", err)
+		}
+	})
 	t.Run("EvictLocal", func(t *testing.T) {
 		if err := bs.EvictLocal(ctx, "p"); !errors.Is(err, ErrStoreClosed) {
 			t.Fatalf("want ErrStoreClosed, got %v", err)

--- a/pkg/block/engine/flush.go
+++ b/pkg/block/engine/flush.go
@@ -118,9 +118,18 @@ type ColdSeed struct {
 // of a manifest seed's wall clock on a share with many small files. Every entry
 // is held in memory until that write, so callers bound their own batches.
 //
+// The batch is one lifecycle-gated op, so a Close waits out the append in flight
+// and the seeds after it fail fast rather than reopening the cold log behind a
+// torn-down store. Seeding in batches rather than one call for a whole manifest
+// is what keeps that wait short.
+//
 // No-op when the local store has no remote-hydration support (e.g. the in-memory
 // test store), which the caller only hits on non-remote paths anyway.
 func (bs *Store) SeedColdBatch(ctx context.Context, seeds []ColdSeed) error {
+	if err := bs.enter(); err != nil {
+		return err
+	}
+	defer bs.closeMu.RUnlock()
 	type coldSeeder interface {
 		SeedColdBatch(ctx context.Context, seeds []journal.ColdSeed) error
 	}

--- a/pkg/block/engine/flush.go
+++ b/pkg/block/engine/flush.go
@@ -101,24 +101,38 @@ func (bs *Store) DrainRollups(ctx context.Context) error {
 	return err
 }
 
-// SeedCold marks payloadID's extents — each an {offset, length} pair — as
-// remote-durable-but-not-local so a subsequent read faults them in from the
-// remote store rather than zero-filling. Callers pass a whole file's extents at
-// once: the local tier persists the markers, and one durable write per file beats
-// one per extent when a caller is seeding an entire manifest. Snapshot restore
-// and the pre-journal upgrade both use it (remote-backed shares only) to arm cold
-// reads over a local tier that holds none of the bytes. No-op when the local store
-// has no remote-hydration support (e.g. the in-memory test store), which the
-// caller only hits on non-remote paths anyway.
-func (bs *Store) SeedCold(ctx context.Context, payloadID string, extents [][2]int64) error {
+// ColdSeed is one payload's worth of work for SeedColdBatch: the payload ID and
+// the {offset, length} extents of it to mark cold.
+type ColdSeed struct {
+	PayloadID string
+	Extents   [][2]int64
+}
+
+// SeedColdBatch marks the seeds' extents as remote-durable-but-not-local so a
+// subsequent read faults them in from the remote store rather than zero-filling.
+// Snapshot restore and the pre-journal upgrade both use it (remote-backed shares
+// only) to arm cold reads over a local tier that holds none of the bytes.
+//
+// Callers pass many payloads at once because the local tier makes the markers
+// durable once per call, not once per payload — an fsync per file is nearly all
+// of a manifest seed's wall clock on a share with many small files. Every entry
+// is held in memory until that write, so callers bound their own batches.
+//
+// No-op when the local store has no remote-hydration support (e.g. the in-memory
+// test store), which the caller only hits on non-remote paths anyway.
+func (bs *Store) SeedColdBatch(ctx context.Context, seeds []ColdSeed) error {
 	type coldSeeder interface {
-		SeedCold(ctx context.Context, id journal.FileID, extents [][2]int64) error
+		SeedColdBatch(ctx context.Context, seeds []journal.ColdSeed) error
 	}
 	cs, ok := bs.local.(coldSeeder)
 	if !ok {
 		return nil
 	}
-	return cs.SeedCold(ctx, journal.FileID(payloadID), extents)
+	js := make([]journal.ColdSeed, 0, len(seeds))
+	for _, sd := range seeds {
+		js = append(js, journal.ColdSeed{ID: journal.FileID(sd.PayloadID), Extents: sd.Extents})
+	}
+	return cs.SeedColdBatch(ctx, js)
 }
 
 // RestoreToVersion rewinds the local journal to a snapshot's version watermark

--- a/pkg/block/journal/cold.go
+++ b/pkg/block/journal/cold.go
@@ -115,9 +115,17 @@ func decodeColdEntry(buf []byte) (coldEntry, int, error) {
 }
 
 // appendCold durably records entries so a restart still knows the ranges are
-// remote-resident rather than holes. It fsyncs before returning: the caller
-// (eviction) is about to unlink the only local copy of those bytes, and a lost
-// entry means silent zeros, not a slow read.
+// remote-resident rather than holes.
+//
+// It fsyncs before returning because of the eviction caller: that caller is about
+// to unlink the only local copy of these bytes, and a lost entry means silent
+// zeros rather than a slow read. The seed caller is idempotent — an interrupted
+// seed leaves no ColdSeeded marker and repeats — so its appends may be batched.
+// Batching both loses the eviction caller's only durable record of a copy it is
+// about to unlink.
+//
+// Entries are already a batch: a caller that may batch does so by accumulating
+// entries and calling this once, never by relaxing what this does with them.
 func (s *Store) appendCold(entries []coldEntry) error {
 	if len(entries) == 0 {
 		return nil

--- a/pkg/block/journal/cold_test.go
+++ b/pkg/block/journal/cold_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -309,5 +310,119 @@ func TestColdSeededMarkerSurvivesReopen(t *testing.T) {
 	defer func() { _ = s2.Close() }()
 	if !s2.ColdSeeded() {
 		t.Error("the marker did not survive a reopen, so every start rescans the manifest")
+	}
+}
+
+// TestEvictAppendsColdEntriesBeforeReturning pins the half of appendCold's
+// contract that cannot be relaxed. Eviction unlinks the only local copy of the
+// bytes it just described, so its entries have to be on disk by the time Evict
+// returns; a restart that finds them missing reads those ranges as holes and
+// serves zeros. The seed path is allowed to batch its appends because it takes
+// nothing away, and this test is what fails if that batching is ever extended to
+// eviction as a symmetry cleanup.
+//
+// It reads the log back from the filesystem rather than from the store's index,
+// so a deferred or buffered append fails it. It cannot observe the fsync itself:
+// a write without Sync still reads back out of page cache, so no in-process test
+// can tell the two apart — losing the Sync alone is caught by the device-loss
+// rig, not here.
+func TestEvictAppendsColdEntriesBeforeReturning(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfg := Config{ShardCount: 1, SegmentSize: minSegmentSize}
+
+	s, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	// Hydrated records are born synced, so the whole shard qualifies for eviction.
+	fillUntilSealed(t, s, "f", true, 2)
+	res, err := s.Evict(ctx, 1<<30)
+	if err != nil {
+		t.Fatalf("Evict: %v", err)
+	}
+	if res.SegmentsEvicted == 0 {
+		t.Fatal("Evict freed nothing, so the durability this test is about was never exercised")
+	}
+
+	// Deliberately no Close and no Sync from the test: whatever is on disk here,
+	// the eviction put there before it returned.
+	entries, err := loadCold(dir)
+	if err != nil {
+		t.Fatalf("loadCold: %v", err)
+	}
+	var covered int64
+	for _, e := range entries {
+		if e.id == "f" {
+			covered += e.length
+		}
+	}
+	if covered == 0 {
+		t.Fatalf("Evict unlinked %d bytes of the only local copy but left no cold entry on disk (%d entries): "+
+			"a restart takes those ranges for holes and serves zeros instead of fetching them", res.BytesFreed, len(entries))
+	}
+}
+
+// TestSeedColdBatchIsDurableAndMatchesPerFileSeeding is the seed side of the same
+// contract. Batching is allowed to make the append rarer; it is not allowed to
+// make it optional, and it must not change what lands. The batch is compared
+// against the same files seeded one at a time: a fresh store hands out versions
+// in the same order either way, so the two logs are byte-for-byte identical.
+func TestSeedColdBatchIsDurableAndMatchesPerFileSeeding(t *testing.T) {
+	ctx := context.Background()
+	seeds := []ColdSeed{
+		{ID: "a", Extents: [][2]int64{{0, 4096}, {4096, 4096}}},
+		{ID: "b", Extents: [][2]int64{{0, 8192}}},
+		{ID: "c", Extents: [][2]int64{{4096, 4096}}},
+	}
+	cfg := Config{ShardCount: 4, SegmentSize: minSegmentSize}
+
+	batchDir := t.TempDir()
+	batched, err := Open(batchDir, cfg, newFakeRemote(), newFakeClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = batched.Close() }()
+	if err := batched.SeedColdBatch(ctx, seeds); err != nil {
+		t.Fatalf("SeedColdBatch: %v", err)
+	}
+
+	// Again no Close: a batch that only becomes durable on shutdown is the bug.
+	got, err := loadCold(batchDir)
+	if err != nil {
+		t.Fatalf("loadCold after batch: %v", err)
+	}
+	for _, sd := range seeds {
+		found := false
+		for _, e := range got {
+			if e.id == sd.ID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("SeedColdBatch returned with no on-disk entry for %q; a restart reads its ranges as holes", sd.ID)
+		}
+	}
+
+	oneDir := t.TempDir()
+	oneAtATime, err := Open(oneDir, cfg, newFakeRemote(), newFakeClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = oneAtATime.Close() }()
+	for _, sd := range seeds {
+		if err := oneAtATime.SeedCold(ctx, sd.ID, sd.Extents); err != nil {
+			t.Fatalf("SeedCold %q: %v", sd.ID, err)
+		}
+	}
+	want, err := loadCold(oneDir)
+	if err != nil {
+		t.Fatalf("loadCold after per-file seeding: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("batched seed recorded %v, seeding the same files one at a time recorded %v", got, want)
 	}
 }

--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -258,6 +258,8 @@ func (s *Store) evictSegment(sh *shard, seg *segmentMeta) (freed int64, err erro
 		backed[e.id] = struct{}{}
 	}
 
+	// This append's fsync is load-bearing and must stay per call: the bytes it
+	// describes are unlinked below, so the log is about to be their only record.
 	if err = s.appendCold(entries); err != nil {
 		// Without a durable marker the range would come back from a restart as a
 		// hole, so keep the segment (and its bytes) instead of evicting blind.

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -492,7 +492,8 @@ func staleAfterTruncate(sh *shard, id FileID, notAfter uint64) bool {
 // The markers are persisted before they are indexed: an in-memory-only seed would
 // be lost on the next restart, turning the ranges back into holes that read as
 // zeros with no fetch. Extents are taken a whole file at a time so seeding a
-// manifest costs one fsync per file rather than one per extent.
+// manifest costs one fsync per file rather than one per extent; SeedColdBatch
+// takes many files at a time and costs one for the batch.
 //
 // Only the parts of each extent the file index does not already cover are
 // seeded. A cold interval carries a fresh version, so seeding over a range the
@@ -500,35 +501,60 @@ func staleAfterTruncate(sh *shard, id FileID, notAfter uint64) bool {
 // the remote, which a cold read cannot fetch back. Skipping covered ranges makes
 // the call idempotent and safe to repeat against a store that is only partly
 // missing its markers, at the cost of nothing on a store that has none.
-func (s *Store) SeedCold(_ context.Context, id FileID, extents [][2]int64) error {
+func (s *Store) SeedCold(ctx context.Context, id FileID, extents [][2]int64) error {
+	return s.SeedColdBatch(ctx, []ColdSeed{{ID: id, Extents: extents}})
+}
+
+// ColdSeed is one file's worth of work for SeedColdBatch: the file's ID and the
+// {offset, length} extents to mark cold, exactly as SeedCold takes them.
+type ColdSeed struct {
+	ID      FileID
+	Extents [][2]int64
+}
+
+// SeedColdBatch is SeedCold over many files, with one durable append for the
+// whole batch instead of one per file. Seeding a manifest is otherwise an fsync
+// per file, which is nearly all of its wall clock on a share with many small
+// files.
+//
+// Batching is safe here and only here: seeding takes nothing away, so an
+// interrupted batch leaves the store where it started — the ranges stay holes,
+// no ColdSeeded marker is written, and the next start seeds them again. Eviction
+// cannot borrow this, because it unlinks the bytes its entries describe.
+//
+// Callers bound their own batches: every entry is held in memory until the
+// append, so a whole manifest at once trades the fsyncs for a proportional heap.
+func (s *Store) SeedColdBatch(_ context.Context, seeds []ColdSeed) error {
 	if s.closed.Load() {
 		return errClosed
 	}
-	sh := s.shardFor(id)
-	sh.mu.Lock()
-	fi := sh.index[id]
-	entries := make([]coldEntry, 0, len(extents))
-	for _, e := range extents {
-		if e[1] <= 0 {
-			continue
-		}
-		if fi == nil { // unknown file: the whole extent is a hole
-			entries = append(entries, coldEntry{id: id, fileOff: e[0], length: e[1], version: s.nextVersion()})
-			continue
-		}
-		for _, p := range fi.plan(e[0], e[1]) {
-			if !p.hole {
+	var entries []coldEntry
+	for _, sd := range seeds {
+		sh := s.shardFor(sd.ID)
+		sh.mu.Lock()
+		fi := sh.index[sd.ID]
+		for _, e := range sd.Extents {
+			if e[1] <= 0 {
 				continue
 			}
-			entries = append(entries, coldEntry{
-				id:      id,
-				fileOff: e[0] + p.dstStart,
-				length:  p.dstEnd - p.dstStart,
-				version: s.nextVersion(),
-			})
+			if fi == nil { // unknown file: the whole extent is a hole
+				entries = append(entries, coldEntry{id: sd.ID, fileOff: e[0], length: e[1], version: s.nextVersion()})
+				continue
+			}
+			for _, p := range fi.plan(e[0], e[1]) {
+				if !p.hole {
+					continue
+				}
+				entries = append(entries, coldEntry{
+					id:      sd.ID,
+					fileOff: e[0] + p.dstStart,
+					length:  p.dstEnd - p.dstStart,
+					version: s.nextVersion(),
+				})
+			}
 		}
+		sh.mu.Unlock()
 	}
-	sh.mu.Unlock()
 	if len(entries) == 0 {
 		return nil
 	}
@@ -539,17 +565,17 @@ func (s *Store) SeedCold(_ context.Context, id FileID, extents [][2]int64) error
 	if err := s.appendCold(entries); err != nil {
 		return err
 	}
-	sh.mu.Lock()
-	defer sh.mu.Unlock()
-	fi = sh.indexFor(id)
 	for _, e := range entries {
-		fi.insert(interval{
+		sh := s.shardFor(e.id)
+		sh.mu.Lock()
+		sh.indexFor(e.id).insert(interval{
 			fileOff: e.fileOff,
 			length:  e.length,
 			version: e.version,
 			synced:  true,
 			cold:    true,
 		})
+		sh.mu.Unlock()
 	}
 	return nil
 }

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -532,6 +532,10 @@ func (s *Store) SeedCold(_ context.Context, id FileID, extents [][2]int64) error
 	if len(entries) == 0 {
 		return nil
 	}
+	// Unlike eviction's append, this one may be batched across files: no local
+	// copy is being unlinked, and an interrupted seed leaves no ColdSeeded marker
+	// so it simply repeats. That batching belongs on this side of the call, by
+	// accumulating entries before it — never inside appendCold.
 	if err := s.appendCold(entries); err != nil {
 		return err
 	}

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -524,6 +524,17 @@ type ColdSeed struct {
 //
 // Callers bound their own batches: every entry is held in memory until the
 // append, so a whole manifest at once trades the fsyncs for a proportional heap.
+//
+// ponytail: an entry's version is taken while planning and the shard lock is
+// dropped for the append, so a Delete landing in that gap sweeps the index at a
+// version above the pending entry and the insert below recreates the range it
+// buried. The gap is not new — a single-file seed has it too — but a batch holds
+// it open for the whole batch rather than one fsync. Both callers seed a share
+// that is not serving yet (share add) or one whose local tier was just reset
+// (snapshot restore), so nothing deletes through it today. Closing it means
+// either holding shard locks across the fsync, which is worse, or a per-file
+// delete watermark to revalidate against; build the watermark if a seed ever
+// runs against a live share.
 func (s *Store) SeedColdBatch(_ context.Context, seeds []ColdSeed) error {
 	if s.closed.Load() {
 		return errClosed

--- a/pkg/controlplane/runtime/shares/legacy_verify.go
+++ b/pkg/controlplane/runtime/shares/legacy_verify.go
@@ -40,6 +40,12 @@ const coldVerifySamples = 8
 // nothing extra, short enough that a large one never looks wedged.
 const migrationProgressInterval = 5 * time.Second
 
+// coldSeedBatchExtents is how many extents SeedColdFromManifest buffers before
+// making them durable. Each flush is one fsync, so a bigger batch is strictly
+// faster and strictly more heap; 64Ki extents is a few MiB of entries and takes
+// the measured 56k-chunk manifest in a single write.
+const coldSeedBatchExtents = 64 << 10
+
 // coldSample is one manifest extent the migration will read back and hash.
 type coldSample struct {
 	payloadID string

--- a/pkg/controlplane/runtime/shares/lifecycle.go
+++ b/pkg/controlplane/runtime/shares/lifecycle.go
@@ -537,6 +537,11 @@ func SeedColdFromManifest(ctx context.Context, bs *engine.Store, metaStore metad
 	// bound is on extents rather than payloads because that is what the buffer
 	// actually holds: a share of huge files would otherwise buffer the whole
 	// manifest before it hit any payload count worth flushing at.
+	//
+	// It bounds what the buffering adds, not the peak: a payload whose own extents
+	// exceed the bound goes in whole and flushes on the next check. Splitting one
+	// would buy nothing — ListFileChunks has already materialized that payload's
+	// rows in full before this sees them, so the slice is live either way.
 	batch := make([]engine.ColdSeed, 0, 256)
 	buffered := 0
 	flush := func() error {

--- a/pkg/controlplane/runtime/shares/lifecycle.go
+++ b/pkg/controlplane/runtime/shares/lifecycle.go
@@ -517,9 +517,9 @@ func (s *Service) StopRollups(ctx context.Context) {
 // copy of the data — after a snapshot restore wiped the local tier, or after a
 // pre-journal upgrade archived the legacy local layout aside. Remote-backed
 // shares only (the caller gates on that); the cold fetch it arms is
-// BLAKE3-verified. One ListFileChunks and one SeedCold per payload — O(chunks),
-// acceptable for a rare control-plane / startup path, and seeding a whole file at
-// once keeps the local tier's durable write to one per file.
+// BLAKE3-verified. One ListFileChunks per payload — O(chunks), acceptable for a
+// rare control-plane / startup path — and the seeds themselves are batched, so
+// the local tier's durable write costs one per batch rather than one per file.
 //
 // The report it returns is what the seed observed on the way through: how much
 // it covered, how much of it the manifest does not yet call remote, and a few
@@ -533,6 +533,22 @@ func SeedColdFromManifest(ctx context.Context, bs *engine.Store, metaStore metad
 	started := time.Now()
 	lastLog := started
 	logger.Info("seeding cold intervals from the metadata manifest")
+	// Extents are buffered across payloads and flushed as one durable write. The
+	// bound is on extents rather than payloads because that is what the buffer
+	// actually holds: a share of huge files would otherwise buffer the whole
+	// manifest before it hit any payload count worth flushing at.
+	batch := make([]engine.ColdSeed, 0, 256)
+	buffered := 0
+	flush := func() error {
+		if len(batch) == 0 {
+			return nil
+		}
+		if err := bs.SeedColdBatch(ctx, batch); err != nil {
+			return fmt.Errorf("seed cold %s (+%d more): %w", batch[0].PayloadID, len(batch)-1, err)
+		}
+		batch, buffered = batch[:0], 0
+		return nil
+	}
 	err := metaStore.EnumeratePayloads(ctx, func(payloadID string) error {
 		rows, err := metaStore.ListFileChunks(ctx, payloadID)
 		if err != nil {
@@ -581,8 +597,14 @@ func SeedColdFromManifest(ctx context.Context, bs *engine.Store, metaStore metad
 				})
 			}
 		}
-		if err := bs.SeedCold(ctx, payloadID, extents); err != nil {
-			return fmt.Errorf("seed cold %s: %w", payloadID, err)
+		if len(extents) > 0 {
+			batch = append(batch, engine.ColdSeed{PayloadID: payloadID, Extents: extents})
+			buffered += len(extents)
+		}
+		if buffered >= coldSeedBatchExtents {
+			if err := flush(); err != nil {
+				return err
+			}
 		}
 		report.payloads++
 		if time.Since(lastLog) >= migrationProgressInterval {
@@ -593,5 +615,8 @@ func SeedColdFromManifest(ctx context.Context, bs *engine.Store, metaStore metad
 		}
 		return nil
 	})
-	return report, err
+	if err != nil {
+		return report, err
+	}
+	return report, flush()
 }

--- a/pkg/controlplane/runtime/shares/lifecycle.go
+++ b/pkg/controlplane/runtime/shares/lifecycle.go
@@ -544,7 +544,7 @@ func SeedColdFromManifest(ctx context.Context, bs *engine.Store, metaStore metad
 			return nil
 		}
 		if err := bs.SeedColdBatch(ctx, batch); err != nil {
-			return fmt.Errorf("seed cold %s (+%d more): %w", batch[0].PayloadID, len(batch)-1, err)
+			return fmt.Errorf("seed cold %d payloads from %s: %w", len(batch), batch[0].PayloadID, err)
 		}
 		batch, buffered = batch[:0], 0
 		return nil


### PR DESCRIPTION
## Problem

`SeedColdFromManifest` called `engine.SeedCold` once per payload, and every one of
those calls fsynced the cold log. That fsync — not the metadata lookups — is where
the seed spends its time:

| backend | share of seed wall clock |
| --- | --- |
| memory | ~97% |
| badger | ~98% |
| sqlite | ~87% |
| postgres | 29.3% |

The knob is **file count, not chunk count**: `SeedCold` fsyncs per payload while
`IsSynced` runs per chunk. The same 56,000 chunks spread over 100 large files
instead of 3,500 small ones takes badger's seed from 18.7s to 0.879s. A 3,500-file
share pays ~20-25s of pure fsync, which is a large part of why a big migration
"looks like a hang" (#1843).

## Fix

`appendCold` already takes a `[]coldEntry`. It was batched at the entry level and
merely *called* once per payload, so batching across payloads needs no API change
and — critically — no change to `appendCold` itself.

- `journal.SeedColdBatch` takes many files and makes one durable append for the
  batch. `SeedCold` is now a one-element call into it.
- `engine.SeedCold` becomes `engine.SeedColdBatch`.
- `SeedColdFromManifest` buffers seeds across payloads and flushes every 64Ki
  extents, plus once at the end.

**`appendCold` is unchanged except for its comment**, so eviction's per-call fsync
cannot have been affected by this diff.

`engine.Store.SeedCold` is removed rather than kept as a wrapper: it had one
caller and no behaviour of its own. `journal.Store.SeedCold` stays, as a
one-element call into `SeedColdBatch`.

## Why only the seed may batch

`appendCold` has two callers with opposite requirements, and its comment read like
a general contract while having been written for only one of them:

- **eviction** (`reclaim.go`) is about to unlink the only local copy of the bytes
  its entries describe. A lost entry there is silent zeros on the next start. Its
  per-call fsync is load-bearing.
- **seed** (`store.go`) takes nothing away. An interrupted seed leaves no
  `ColdSeeded` marker and simply repeats on the next start, so a crash mid-seed
  costs a repeat, not data.

The first commit is comment-only and says exactly this at the definition and at
both call sites, so the distinction is visible where the decision gets made rather
than only in issue text. This project has lost data twice on this confusion
(#1850, #1879); the expensive part both times was diagnosis.

## Also fixed here

`engine.Store.SeedCold` never took the store's `closeMu` lifecycle gate, though
every other public data op on `Store` does. A seed racing `Close` could pass the
journal's own `closed` check and then have `appendCold` reopen `cold.log` behind a
torn-down store, leaking the fd. Pre-existing, but batching lengthens the call, so
it is gated here and added to `TestStore_OpAfterCloseReturnsErrStoreClosed`, which
enumerates the gated ops. Batching in bounded chunks rather than one call for the
whole manifest is also what keeps a concurrent `Close`'s wait short.

## Tests

Two guards in `cold_test.go`, both verified by mutation (the stated regression was
introduced, the test failed, the mutation was reverted):

- `TestEvictAppendsColdEntriesBeforeReturning` — the important one. Reads the cold
  log back from the filesystem, not from the store's index, right after `Evict`
  returns. Fails if eviction's append is ever deferred or batched as a "symmetry
  cleanup". It cannot see the fsync itself: a write without `Sync` still reads back
  out of page cache, so no in-process test distinguishes them — losing the `Sync`
  alone stays the device-loss rig's job, and the test comment says so.
- `TestSeedColdBatchIsDurableAndMatchesPerFileSeeding` — the batch must be on disk
  when it returns, and must write byte-for-byte what per-file seeding wrote.

The controlplane's final flush is already covered end-to-end by
`TestSnapshotByteVerify_RemoteColdSeed_Matrix`, whose manifests are small enough to
live entirely in the tail batch.

Closes #2083
