### PR TITLE
fix(dfsbench): judge the cold-barrier drain residue by the segments it pins

### DIFF
--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -580,9 +580,14 @@ const dittofsEvictSegmentBytes int64 = 256 << 20
 // has to assume the finest spread it can plausibly see — the carver's minimum
 // chunk (chunker.MinChunkSize).
 //
-// ponytail: an estimate standing in for a count the store already tracks; report
-// unsynced records (or pinned segments) from `dfsctl store block stats` and the
-// estimate collapses into reading that field.
+// ponytail: an estimate standing in for a count the store already tracks, and a
+// deliberately pessimistic one — several stragglers sharing a segment (one file's
+// un-carved tail) are counted as if each held a segment of its own, so a residue
+// can be refused that eviction would in fact have freed. That direction is the
+// cheap one to be wrong in: a refused drain is loud, while a tolerated pin is a
+// warm number labelled cold. Report unsynced records (or pinned segments) from
+// `dfsctl store block stats` and both the estimate and its pessimism collapse
+// into reading that field.
 const dittofsDrainStragglerBytes int64 = 1 << 20
 
 // dittofsDrainResidueOK reports whether a drain residue is small enough to leave

--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -561,25 +561,81 @@ func dittofsWaitSettled(ctx context.Context) error {
 	}
 }
 
-// dittofsDrainDriftFloorBytes is the residual unsynced size the drain loop
-// tolerates as "done". A freshly-written file's final bytes sit in the append log
-// until the next rollup boundary, so a few chunks stay un-carved/un-synced
-// indefinitely without another write — requiring EXACTLY 0 loops forever. A few
-// MiB out of a multi-GiB file is <0.1% and does not meaningfully warm the cold
-// pass (the post-evict ≥80%-drop check is the real cold gate).
-const dittofsDrainDriftFloorBytes = 32 << 20 // 32 MiB
+// dittofsEvictSegmentBytes is the granularity at which eviction actually frees
+// local disk. The journal reclaims whole segments and refuses any segment still
+// holding an unsynced record, so one straggler keeps its entire segment resident.
+// pkg/block/local/fs leaves Config.SegmentSize unset, so the bench share runs on
+// the journal's own default.
+const dittofsEvictSegmentBytes int64 = 256 << 20
 
-// dittofsDrainUntilSynced loops `dfsctl system drain-uploads` until the store's
-// unsynced bytes fall to the drift floor, stable across two polls. A single drain
-// is not enough: rollup is async and carveFlush is snapshot-at-claim, so one pass
-// misses chunks that roll up mid-drain — leaving them locally resident and
-// un-evictable, so the "cold" pass silently reads them from local disk (the
-// confound that made several cold-read A/Bs meaningless). The short settle between
-// rounds lets the async rollup produce the next batch of CAS chunks for the
-// following drain to upload.
+// dittofsDrainStragglerBytes is the smallest residue assumed able to pin a
+// segment of its own. Unsynced bytes are spread over an unknown number of
+// records, and only that count decides how many segments they pin, so the drain
+// has to assume the finest spread it can plausibly see — the carver's minimum
+// chunk.
+//
+// ponytail: an estimate standing in for a count the store already tracks; report
+// unsynced records (or pinned segments) from `dfsctl store block stats` and the
+// estimate collapses into reading that field.
+const dittofsDrainStragglerBytes int64 = 1 << 20
+
+// dittofsDrainResidueOK reports whether a drain residue is small enough to leave
+// behind. Its size alone does not answer that: eviction frees segments, not
+// bytes, so what a residue costs is the segments it pins. 32 MiB sitting in one
+// segment pins 256 MiB; the same 32 MiB spread one straggler at a time pins 32
+// segments — 8 GiB — and the barrier that follows then fails on bytes the drain
+// deliberately left behind. A residue is harmless only when even the worst
+// spread still leaves the local tier able to shed the ≥80% the cold barrier goes
+// on to demand. Below the barrier's own floor that drop is never verified, so no
+// residue there can invalidate a measurement that was never going to be checked.
+func dittofsDrainResidueOK(unsyncedBytes, localResidentBytes int64) bool {
+	if unsyncedBytes <= 0 || localResidentBytes <= dittofsColdBarrierFloorBytes {
+		return true
+	}
+	pinned := dittofsWorstCasePinnedBytes(unsyncedBytes)
+	if pinned > localResidentBytes {
+		pinned = localResidentBytes
+	}
+	return pinned <= localResidentBytes/5
+}
+
+// dittofsWorstCasePinnedBytes is the local disk an unsynced residue can hold down
+// when every straggler in it sits alone in its own segment.
+func dittofsWorstCasePinnedBytes(unsyncedBytes int64) int64 {
+	if unsyncedBytes <= 0 {
+		return 0
+	}
+	segments := (unsyncedBytes + dittofsDrainStragglerBytes - 1) / dittofsDrainStragglerBytes
+	return segments * dittofsEvictSegmentBytes
+}
+
+// dittofsDrainResidueErr reports a residue the drain could not get below,
+// spelling out the segment arithmetic that makes it fatal — the number is
+// otherwise unreadable, since the residue is small and what fails is the local
+// disk it pins.
+func dittofsDrainResidueErr(st dittofsBlockTotals, rounds int) error {
+	pinned := dittofsWorstCasePinnedBytes(st.UnsyncedBytes)
+	return fmt.Errorf("drain-uploads left %dMiB unsynced after %d rounds (local=%dMiB pending_uploads=%d) — eviction frees whole %dMiB segments and skips any holding an unsynced record, so that residue can pin up to %dMiB locally, against the %dMiB the cold barrier lets survive",
+		st.UnsyncedBytes>>20, rounds, st.LocalDiskUsed>>20, st.PendingUploads,
+		dittofsEvictSegmentBytes>>20, pinned>>20, (st.LocalDiskUsed/5)>>20)
+}
+
+// dittofsDrainUntilSynced loops `dfsctl system drain-uploads` until the residue
+// left unsynced can no longer pin enough segments to warm the cold pass, stable
+// across two polls. A single drain is not enough: rollup is async and carveFlush
+// is snapshot-at-claim, so one pass misses chunks that roll up mid-drain —
+// leaving them locally resident and un-evictable, so the "cold" pass silently
+// reads them from local disk (the confound that made several cold-read A/Bs
+// meaningless). The short settle between rounds lets the async rollup produce the
+// next batch of CAS chunks for the following drain to upload.
 func dittofsDrainUntilSynced(ctx context.Context) error {
 	const maxRounds = 60
-	stable := 0
+	// Rounds an intolerable residue may sit unchanged before the loop gives up.
+	// Each round costs a full drain-uploads timeout, so riding out every round on
+	// a residue that is not moving turns a failed barrier into a many-hour one.
+	const maxFlatRounds = 3
+	stable, flat := 0, 0
+	prevUnsynced := int64(-1)
 	for i := 0; i < maxRounds; i++ {
 		// Bound each drain explicitly (issue #1668): a cold-evict drain of a large
 		// working set can exceed the client's 6m default, and the failure surfaces
@@ -594,13 +650,21 @@ func dittofsDrainUntilSynced(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		if st.UnsyncedBytes <= dittofsDrainDriftFloorBytes {
+		switch {
+		case dittofsDrainResidueOK(st.UnsyncedBytes, st.LocalDiskUsed):
+			flat = 0
 			if stable++; stable >= 2 {
 				return nil
 			}
-		} else {
+		case st.UnsyncedBytes == prevUnsynced:
 			stable = 0
+			if flat++; flat >= maxFlatRounds {
+				return dittofsDrainResidueErr(st, i+1)
+			}
+		default:
+			stable, flat = 0, 0
 		}
+		prevUnsynced = st.UnsyncedBytes
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -608,8 +672,7 @@ func dittofsDrainUntilSynced(ctx context.Context) error {
 		}
 	}
 	st, _ := dittofsBlockStats(ctx)
-	return fmt.Errorf("drain-uploads never fell below %dMiB unsynced after %d rounds (unsynced=%dMiB pending_uploads=%d) — cannot force a cold read",
-		dittofsDrainDriftFloorBytes>>20, maxRounds, st.UnsyncedBytes>>20, st.PendingUploads)
+	return dittofsDrainResidueErr(st, maxRounds)
 }
 
 // dittofsReportDrainProgress samples the store's unsynced size every

--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/marmos91/dittofs/internal/dfsbench/exec"
+	"github.com/marmos91/dittofs/pkg/block/chunker"
 )
 
 // benchDataMount is the isolated data volume `dfsbench setup --data-volume-gb`
@@ -578,7 +579,7 @@ const dittofsEvictSegmentBytes int64 = 256 << 20
 // segment of its own. Unsynced bytes are spread over an unknown number of
 // records, and only that count decides how many segments they pin, so the drain
 // has to assume the finest spread it can plausibly see — the carver's minimum
-// chunk (chunker.MinChunkSize).
+// chunk.
 //
 // ponytail: an estimate standing in for a count the store already tracks, and a
 // deliberately pessimistic one — several stragglers sharing a segment (one file's
@@ -588,7 +589,7 @@ const dittofsEvictSegmentBytes int64 = 256 << 20
 // warm number labelled cold. Report unsynced records (or pinned segments) from
 // `dfsctl store block stats` and both the estimate and its pessimism collapse
 // into reading that field.
-const dittofsDrainStragglerBytes int64 = 1 << 20
+const dittofsDrainStragglerBytes int64 = chunker.MinChunkSize
 
 // dittofsDrainResidueOK reports whether a drain residue is small enough to leave
 // behind. Its size alone does not answer that: eviction frees segments, not
@@ -633,12 +634,16 @@ func dittofsDrainResidueErr(st dittofsBlockTotals, rounds int) error {
 // next batch of CAS chunks for the following drain to upload.
 func dittofsDrainUntilSynced(ctx context.Context) error {
 	const maxRounds = 60
-	// Rounds an intolerable residue may sit unchanged before the loop gives up.
-	// Each round costs a full drain-uploads timeout, so riding out every round on
-	// a residue that is not moving turns a failed barrier into a many-hour one.
-	const maxFlatRounds = 3
-	stable, flat := 0, 0
-	prevUnsynced := int64(-1)
+	// Consecutive rounds an intolerable residue may fail to reach a new low before
+	// the loop gives up. Each round costs a full drain-uploads timeout, so riding
+	// out every round on a residue that is going nowhere turns a failed barrier
+	// into a many-hour one. Progress is measured against the lowest residue seen
+	// rather than against the previous round, so neither a byte of jitter nor a
+	// transient rise while the store digests reads as a stall — only a run of
+	// rounds that all fail to beat the best does.
+	const maxStalledRounds = 3
+	stalled, stable := 0, 0
+	bestUnsynced := int64(-1)
 	for i := 0; i < maxRounds; i++ {
 		// Bound each drain explicitly (issue #1668): a cold-evict drain of a large
 		// working set can exceed the client's 6m default, and the failure surfaces
@@ -655,19 +660,21 @@ func dittofsDrainUntilSynced(ctx context.Context) error {
 		}
 		switch {
 		case dittofsDrainResidueOK(st.UnsyncedBytes, st.LocalDiskUsed):
-			flat = 0
+			stalled = 0
 			if stable++; stable >= 2 {
 				return nil
 			}
-		case prevUnsynced >= 0 && st.UnsyncedBytes >= prevUnsynced:
+		case bestUnsynced >= 0 && st.UnsyncedBytes >= bestUnsynced:
 			stable = 0
-			if flat++; flat >= maxFlatRounds {
+			if stalled++; stalled >= maxStalledRounds {
 				return dittofsDrainResidueErr(st, i+1)
 			}
 		default:
-			stable, flat = 0, 0
+			stable, stalled = 0, 0
 		}
-		prevUnsynced = st.UnsyncedBytes
+		if bestUnsynced < 0 || st.UnsyncedBytes < bestUnsynced {
+			bestUnsynced = st.UnsyncedBytes
+		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()

--- a/internal/dfsbench/backend/dittofs.go
+++ b/internal/dfsbench/backend/dittofs.go
@@ -470,6 +470,12 @@ func dittofsMount(ctx context.Context, proto Protocol) (string, error) {
 // datasets and metadata slack shouldn't fail the check.
 const dittofsColdBarrierFloorBytes = 64 << 20 // 64 MiB
 
+// dittofsColdBarrierBudgetBytes is the most local disk that may still be resident
+// after the evict for the pass that follows to count as cold: the ≥80% drop the
+// barrier verifies. The drain ahead of it has to leave a residue this same budget
+// can absorb, so both derive the number here rather than each spelling it out.
+func dittofsColdBarrierBudgetBytes(residentBytes int64) int64 { return residentBytes / 5 }
+
 // dittofsBlockTotals is the subset of `dfsctl store block stats -o json` the
 // cold barrier needs: how much is resident locally, and how much is not yet
 // durable on the remote (so DrainLocalSynced can't drop it).
@@ -572,7 +578,7 @@ const dittofsEvictSegmentBytes int64 = 256 << 20
 // segment of its own. Unsynced bytes are spread over an unknown number of
 // records, and only that count decides how many segments they pin, so the drain
 // has to assume the finest spread it can plausibly see — the carver's minimum
-// chunk.
+// chunk (chunker.MinChunkSize).
 //
 // ponytail: an estimate standing in for a count the store already tracks; report
 // unsynced records (or pinned segments) from `dfsctl store block stats` and the
@@ -581,22 +587,16 @@ const dittofsDrainStragglerBytes int64 = 1 << 20
 
 // dittofsDrainResidueOK reports whether a drain residue is small enough to leave
 // behind. Its size alone does not answer that: eviction frees segments, not
-// bytes, so what a residue costs is the segments it pins. 32 MiB sitting in one
-// segment pins 256 MiB; the same 32 MiB spread one straggler at a time pins 32
-// segments — 8 GiB — and the barrier that follows then fails on bytes the drain
-// deliberately left behind. A residue is harmless only when even the worst
-// spread still leaves the local tier able to shed the ≥80% the cold barrier goes
-// on to demand. Below the barrier's own floor that drop is never verified, so no
-// residue there can invalidate a measurement that was never going to be checked.
+// bytes, so what a residue costs is the segments it pins, and a residue is
+// harmless only when even the worst spread — every straggler alone in its own
+// segment — still fits the budget the cold barrier allows to survive. Below the
+// barrier's own floor that drop is never verified, so no residue there can
+// invalidate a measurement that was never going to be checked.
 func dittofsDrainResidueOK(unsyncedBytes, localResidentBytes int64) bool {
 	if unsyncedBytes <= 0 || localResidentBytes <= dittofsColdBarrierFloorBytes {
 		return true
 	}
-	pinned := dittofsWorstCasePinnedBytes(unsyncedBytes)
-	if pinned > localResidentBytes {
-		pinned = localResidentBytes
-	}
-	return pinned <= localResidentBytes/5
+	return dittofsWorstCasePinnedBytes(unsyncedBytes) <= dittofsColdBarrierBudgetBytes(localResidentBytes)
 }
 
 // dittofsWorstCasePinnedBytes is the local disk an unsynced residue can hold down
@@ -610,14 +610,12 @@ func dittofsWorstCasePinnedBytes(unsyncedBytes int64) int64 {
 }
 
 // dittofsDrainResidueErr reports a residue the drain could not get below,
-// spelling out the segment arithmetic that makes it fatal — the number is
-// otherwise unreadable, since the residue is small and what fails is the local
-// disk it pins.
+// spelling out the segment arithmetic that makes it fatal.
 func dittofsDrainResidueErr(st dittofsBlockTotals, rounds int) error {
 	pinned := dittofsWorstCasePinnedBytes(st.UnsyncedBytes)
 	return fmt.Errorf("drain-uploads left %dMiB unsynced after %d rounds (local=%dMiB pending_uploads=%d) — eviction frees whole %dMiB segments and skips any holding an unsynced record, so that residue can pin up to %dMiB locally, against the %dMiB the cold barrier lets survive",
 		st.UnsyncedBytes>>20, rounds, st.LocalDiskUsed>>20, st.PendingUploads,
-		dittofsEvictSegmentBytes>>20, pinned>>20, (st.LocalDiskUsed/5)>>20)
+		dittofsEvictSegmentBytes>>20, pinned>>20, dittofsColdBarrierBudgetBytes(st.LocalDiskUsed)>>20)
 }
 
 // dittofsDrainUntilSynced loops `dfsctl system drain-uploads` until the residue
@@ -656,7 +654,7 @@ func dittofsDrainUntilSynced(ctx context.Context) error {
 			if stable++; stable >= 2 {
 				return nil
 			}
-		case st.UnsyncedBytes == prevUnsynced:
+		case prevUnsynced >= 0 && st.UnsyncedBytes >= prevUnsynced:
 			stable = 0
 			if flat++; flat >= maxFlatRounds {
 				return dittofsDrainResidueErr(st, i+1)
@@ -952,7 +950,7 @@ func dittofsColdBarrier(ctx context.Context, diag *dittofsBarrierDiag) error {
 			before.LocalDiskUsed>>20, after.LocalDiskUsed>>20, dittofsColdBarrierFloorBytes>>20)
 		return nil
 	}
-	if after.LocalDiskUsed > before.LocalDiskUsed/5 {
+	if after.LocalDiskUsed > dittofsColdBarrierBudgetBytes(before.LocalDiskUsed) {
 		return fmt.Errorf("cold barrier failed: local disk only fell %dMiB→%dMiB (want ≥80%% drop); the cold pass would measure locally-served reads, not S3",
 			before.LocalDiskUsed>>20, after.LocalDiskUsed>>20)
 	}

--- a/internal/dfsbench/backend/dittofs_test.go
+++ b/internal/dfsbench/backend/dittofs_test.go
@@ -255,3 +255,33 @@ func TestDittofsResidentFilesReportsAPartialScan(t *testing.T) {
 		t.Errorf("got %q, want the partial scan flagged", got)
 	}
 }
+
+// A drain residue is judged by the segments it can pin, not by its size: the
+// pathological shape is a handful of MiB scattered one straggler per segment,
+// which frees nothing while looking negligible in bytes.
+func TestDittofsDrainResidueOK(t *testing.T) {
+	const gib = int64(1) << 30
+	tests := []struct {
+		name          string
+		unsynced      int64
+		localResident int64
+		want          bool
+	}{
+		{"fully synced", 0, 8 * gib, true},
+		{"one straggler pins one segment out of a large tier", 1 << 20, 8 * gib, true},
+		// <0.1% of a multi-GiB file by bytes, but spread thinly it pins ~32
+		// segments (8 GiB) and the barrier's 80%-drop check then fails.
+		{"small residue spread across many segments", 32 << 20, 8 * gib, false},
+		{"same residue against a tier big enough to absorb the pin", 32 << 20, 128 * gib, true},
+		{"whole tier pinnable", 4 << 20, gib, false},
+		{"under the barrier floor the drop is never verified", 32 << 20, 32 << 20, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := dittofsDrainResidueOK(tc.unsynced, tc.localResident); got != tc.want {
+				t.Errorf("dittofsDrainResidueOK(%d, %d) = %v, want %v",
+					tc.unsynced, tc.localResident, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What was wrong

`dittofsDrainUntilSynced` stopped draining once the store reported `unsynced_bytes <= 32 MiB`,
on the reasoning that a few MiB out of a multi-GiB file is <0.1% and cannot meaningfully warm
the cold pass. That reasoning is denominated in **bytes**. Eviction is denominated in
**segments**, and the two do not convert.

Verified against the tree, not assumed:

- `journal.Config.SegmentSize` defaults to `256 << 20` and `ShardCount` to `16`
  (`pkg/block/journal/store.go:100,104`).
- `pkg/block/local/fs/fs.go:152` builds its `journal.Config` with only `MaxLocalBytes`,
  `EvictMaxWait`, `ChunkParams` and `DirtyExpiry` — both defaults hold for the bench share.
- `evictable` (`pkg/block/journal/reclaim.go:207`) requires `syncedRecords == records`, and
  `sealableActive` the same for a force-seal during `DrainLocalSynced`. One unsynced record
  therefore pins its entire 256 MiB segment.
- `unsynced_bytes` in `dfsctl store block stats` is the journal's own dirty-record counter
  (`engine/stats.go` → `syncer.UnsyncedBytes()` → `journal.Store.UnsyncedBytes`), so the
  residue the harness tolerates is exactly the residue that pins segments.

So the tolerated residue's cost is not its size but the segments it lands in: 32 MiB sitting
in one segment costs 256 MiB of pinned local disk, while the same 32 MiB spread one straggler
at a time costs 32 segments — 8 GiB. The cold barrier that runs immediately after then fails
its ≥80%-drop check on bytes the drain deliberately left behind, and it does so intermittently
in exactly the way that depends on *where* the residue landed rather than how much of it there is.

## The fix

Re-denominate the tolerance. `dittofsDrainResidueOK(unsyncedBytes, localResidentBytes)` accepts
a residue only when its worst case — every straggler alone in its own segment — still leaves the
local tier able to shed the ≥80% the barrier goes on to demand. Below
`dittofsColdBarrierFloorBytes` the barrier never verifies the drop, so nothing a residue does
there can invalidate a measurement that was never going to be checked, and it is accepted.

A tolerance survives, as intended — it just scales with what eviction can free instead of
being a flat number:

| local tier | old floor | new tolerance |
| --- | --- | --- |
| 1 GiB | 32 MiB | 0 (256 MiB clears no 20% budget this small) |
| 4 GiB | 32 MiB | 3 MiB |
| 8 GiB | 32 MiB | 6 MiB |
| 64 GiB | 32 MiB | 51 MiB |

A genuine append-log trickle still passes; 32 MiB against a multi-GiB tier no longer does. Note
that the case it now refuses is one the old code did not really pass either — 32 MiB spread over
four shards' tails pins 1 GiB, so a 4 GiB tier failed the barrier a moment later, with a message
about local disk rather than about the residue that caused it.

The drain and the barrier now take their budget from one `dittofsColdBarrierBudgetBytes` helper,
so the tolerance cannot drift away from the assertion it exists to satisfy.

Two secondary changes:

- The straggler floor is an estimate (1 MiB, the carver's minimum chunk) because the store does
  not report how many records or segments the residue occupies. It is marked `ponytail:` with the
  upgrade path — report unsynced records or pinned segments from `dfsctl store block stats` and
  the whole derivation collapses into reading that field. The estimate is deliberately on the
  pessimistic side: a false drain failure is loud, whereas a tolerated pin produces a warm number
  labelled "cold". The known ceiling is named in the marker: several stragglers sharing one
  segment — one file's un-carved tail — are counted as if each held a segment, so a residue can
  be refused that eviction would have freed.
- An intolerable residue that sits unchanged for 3 rounds now fails immediately instead of
  riding out all 60. Each round costs a 15m `drain-uploads` timeout, so the tighter tolerance
  could otherwise have turned a failed barrier into a many-hour one. A residue that is still
  shrinking keeps draining as before.

The failure message now spells out the segment arithmetic, since the residue is small and what
actually fails is the local disk it pins.

## Scope

This is a harness fix on its own merits — the arithmetic was wrong in a unit that eviction
cannot honour. It is **not** a diagnosis: refusing to drop a segment holding an unsynced record
is correct journal behaviour, and no reproduction ties this to any observed barrier failure.
Nothing in `pkg/block/` changes.

## Verification

```
go build ./... && go vet ./...
go test -race ./internal/dfsbench/...
```

`TestDittofsDrainResidueOK` pins the pathological shape rather than the benign one: 32 MiB
against an 8 GiB tier must be rejected (the old flat floor accepted it), 1 MiB against the same
tier accepted, and 32 MiB against a 128 GiB tier accepted because that tier can absorb the pin.
Reverting the tolerance to a byte floor fails the third case.

Closes #2078
Refs #1877
