### PR TITLE
perf(sql): seek file_blocks by ID range instead of scanning with LIKE

### DIFF
--- a/pkg/block/ids.go
+++ b/pkg/block/ids.go
@@ -65,6 +65,27 @@ func ChunkOffsetFor(id, payloadID string) (uint64, bool) {
 	return v, true
 }
 
+// PayloadPrefixRange returns the half-open ID range [lo, hi) holding every
+// FileChunk row of payloadID, for backends that locate a file's chunks by
+// seeking an ordered index of row IDs.
+//
+// Row IDs are "<payloadID>/<chunkOffset>", so the range runs from the
+// separator to the byte after it: '/' is 0x2F, '0' is 0x30, and nothing sorts
+// between them, so [payloadID+"/", payloadID+"0") is exactly the set of IDs
+// carrying the prefix.
+//
+// That equality holds only when the range is compared in BYTE order. A
+// linguistic collation may treat punctuation as ignorable, which sorts
+// "<payloadID>/1" after "<payloadID>0" and drops the row out of the range;
+// callers must pin a byte-ordered comparison rather than take the database
+// default.
+//
+// The range locates rows, it does not decide membership: it still spans
+// payloads nested beneath this one, and ChunksForPayload settles what belongs.
+func PayloadPrefixRange(payloadID string) (lo, hi string) {
+	return payloadID + "/", payloadID + "0"
+}
+
 // ChunksForPayload keeps the rows that belong to payloadID and orders them by
 // chunk offset. The returned slice is never nil.
 //

--- a/pkg/block/ids.go
+++ b/pkg/block/ids.go
@@ -74,11 +74,10 @@ func ChunkOffsetFor(id, payloadID string) (uint64, bool) {
 // between them, so [payloadID+"/", payloadID+"0") is exactly the set of IDs
 // carrying the prefix.
 //
-// That equality holds only when the range is compared in BYTE order. A
-// linguistic collation may treat punctuation as ignorable, which sorts
-// "<payloadID>/1" after "<payloadID>0" and drops the row out of the range;
+// That equality holds only when the range is compared in BYTE order, so
 // callers must pin a byte-ordered comparison rather than take the database
-// default.
+// default: a linguistic collation may treat punctuation as ignorable and sort
+// a row out of the range.
 //
 // The range locates rows, it does not decide membership: it still spans
 // payloads nested beneath this one, and ChunksForPayload settles what belongs.

--- a/pkg/metadata/store/postgres/migrations/000044_file_blocks_id_c_collation.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000044_file_blocks_id_c_collation.down.sql
@@ -1,0 +1,5 @@
+-- Return file_blocks.id to the database's default collation. ListFileChunks
+-- still returns the right rows afterwards — it pins COLLATE "C" on the
+-- comparison — but the primary-key btree can no longer serve the range, so the
+-- per-payload lookup goes back to scanning the whole table.
+ALTER TABLE file_blocks ALTER COLUMN id TYPE VARCHAR(255) COLLATE pg_catalog."default";

--- a/pkg/metadata/store/postgres/migrations/000044_file_blocks_id_c_collation.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000044_file_blocks_id_c_collation.up.sql
@@ -7,9 +7,8 @@
 -- the set of IDs carrying the payloadID prefix.
 --
 -- "Exactly" only holds under byte ordering. On a linguistic collation such as
--- en_US.utf8 — the default of the stock postgres image — punctuation is
--- ignorable at the primary comparison level, so 'p/1048576' sorts AFTER 'p0'
--- and falls outside the range. The queries therefore pin COLLATE "C" on the
+-- en_US.utf8, punctuation is ignorable at the primary comparison level, so
+-- 'p/1048576' sorts AFTER 'p0' and falls outside the range. The queries therefore pin COLLATE "C" on the
 -- comparison itself and stay correct whether or not this migration has run;
 -- what this migration adds is an index whose stored order MATCHES that
 -- comparison, which is what lets the planner seek instead of scanning every

--- a/pkg/metadata/store/postgres/migrations/000044_file_blocks_id_c_collation.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000044_file_blocks_id_c_collation.up.sql
@@ -1,0 +1,20 @@
+-- Give file_blocks.id byte ordering so the primary-key btree can answer the
+-- per-payload prefix range scan in ListFileChunks.
+--
+-- FileChunk row IDs have the form {payloadID}/{chunkOffset}, and locating one
+-- file's chunks is a scan of the half-open range [payloadID || '/',
+-- payloadID || '0') — '/' is 0x2F and '0' is 0x30, so that range is exactly
+-- the set of IDs carrying the payloadID prefix.
+--
+-- "Exactly" only holds under byte ordering. On a linguistic collation such as
+-- en_US.utf8 — the default of the stock postgres image — punctuation is
+-- ignorable at the primary comparison level, so 'p/1048576' sorts AFTER 'p0'
+-- and falls outside the range. The queries therefore pin COLLATE "C" on the
+-- comparison itself and stay correct whether or not this migration has run;
+-- what this migration adds is an index whose stored order MATCHES that
+-- comparison, which is what lets the planner seek instead of scanning every
+-- row and discarding the ones that miss.
+--
+-- Rewrites the table and rebuilds its indexes. No new index is created, so
+-- there is no added per-insert cost on the chunk write path.
+ALTER TABLE file_blocks ALTER COLUMN id TYPE VARCHAR(255) COLLATE "C";

--- a/pkg/metadata/store/postgres/objects.go
+++ b/pkg/metadata/store/postgres/objects.go
@@ -263,23 +263,24 @@ func (s *PostgresMetadataStore) GetByHash(ctx context.Context, hash metadata.Con
 	return block, nil
 }
 
-// ListFileChunks returns all blocks belonging to a file, ordered by block index.
-// The ID range is a prefilter; block.ChunksForPayload decides membership
-// and order.
+// listFileChunksQuery takes the bounds of block.PayloadPrefixRange and is a
+// prefilter; block.ChunksForPayload decides membership and order.
 //
 // The range is compared and ordered in byte collation, not the database
-// default: block.PayloadPrefixRange's bounds only bracket the prefix under
-// byte ordering, and a byte-ordered id column lets the primary-key index seek
-// the range instead of filtering the whole table.
+// default: the bounds only bracket the prefix under byte ordering, and a
+// byte-ordered id column lets the primary-key index seek the range instead of
+// filtering the whole table.
+const listFileChunksQuery = `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
+	FROM file_blocks
+	WHERE id >= $1 COLLATE "C" AND id < $2 COLLATE "C"
+	ORDER BY id COLLATE "C" ASC`
+
+// ListFileChunks returns all blocks belonging to a file, ordered by block index.
 // Not on the narrowed FileChunkStore interface;
 // kept as a backend method for engine-internal callers.
 func (s *PostgresMetadataStore) ListFileChunks(ctx context.Context, payloadID string) ([]*metadata.FileChunk, error) {
-	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
-		FROM file_blocks
-		WHERE id >= $1 COLLATE "C" AND id < $2 COLLATE "C"
-		ORDER BY id COLLATE "C" ASC`
 	lo, hi := block.PayloadPrefixRange(payloadID)
-	rows, err := s.query(ctx, query, lo, hi)
+	rows, err := s.query(ctx, listFileChunksQuery, lo, hi)
 	if err != nil {
 		return nil, fmt.Errorf("list file chunks: %w", err)
 	}
@@ -659,12 +660,8 @@ func (tx *postgresTransaction) GetByHash(ctx context.Context, hash metadata.Cont
 // (read-after-write violation; the SQL is otherwise identical to the
 // store-level methods).
 func (tx *postgresTransaction) ListFileChunks(ctx context.Context, payloadID string) ([]*metadata.FileChunk, error) {
-	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
-		FROM file_blocks
-		WHERE id >= $1 COLLATE "C" AND id < $2 COLLATE "C"
-		ORDER BY id COLLATE "C" ASC`
 	lo, hi := block.PayloadPrefixRange(payloadID)
-	rows, err := tx.tx.Query(ctx, query, lo, hi)
+	rows, err := tx.tx.Query(ctx, listFileChunksQuery, lo, hi)
 	if err != nil {
 		return nil, fmt.Errorf("list file chunks: %w", err)
 	}

--- a/pkg/metadata/store/postgres/objects.go
+++ b/pkg/metadata/store/postgres/objects.go
@@ -264,16 +264,22 @@ func (s *PostgresMetadataStore) GetByHash(ctx context.Context, hash metadata.Con
 }
 
 // ListFileChunks returns all blocks belonging to a file, ordered by block index.
-// The LIKE query is a prefilter; block.ChunksForPayload decides membership
+// The ID range is a prefilter; block.ChunksForPayload decides membership
 // and order.
+//
+// The range is compared and ordered in byte collation, not the database
+// default: block.PayloadPrefixRange's bounds only bracket the prefix under
+// byte ordering, and a byte-ordered id column lets the primary-key index seek
+// the range instead of filtering the whole table.
 // Not on the narrowed FileChunkStore interface;
 // kept as a backend method for engine-internal callers.
 func (s *PostgresMetadataStore) ListFileChunks(ctx context.Context, payloadID string) ([]*metadata.FileChunk, error) {
 	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
 		FROM file_blocks
-		WHERE id LIKE $1
-		ORDER BY id ASC`
-	rows, err := s.query(ctx, query, payloadID+"/%")
+		WHERE id >= $1 COLLATE "C" AND id < $2 COLLATE "C"
+		ORDER BY id COLLATE "C" ASC`
+	lo, hi := block.PayloadPrefixRange(payloadID)
+	rows, err := s.query(ctx, query, lo, hi)
 	if err != nil {
 		return nil, fmt.Errorf("list file chunks: %w", err)
 	}
@@ -655,9 +661,10 @@ func (tx *postgresTransaction) GetByHash(ctx context.Context, hash metadata.Cont
 func (tx *postgresTransaction) ListFileChunks(ctx context.Context, payloadID string) ([]*metadata.FileChunk, error) {
 	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
 		FROM file_blocks
-		WHERE id LIKE $1
-		ORDER BY id ASC`
-	rows, err := tx.tx.Query(ctx, query, payloadID+"/%")
+		WHERE id >= $1 COLLATE "C" AND id < $2 COLLATE "C"
+		ORDER BY id COLLATE "C" ASC`
+	lo, hi := block.PayloadPrefixRange(payloadID)
+	rows, err := tx.tx.Query(ctx, query, lo, hi)
 	if err != nil {
 		return nil, fmt.Errorf("list file chunks: %w", err)
 	}

--- a/pkg/metadata/store/sqlite/objects.go
+++ b/pkg/metadata/store/sqlite/objects.go
@@ -296,16 +296,22 @@ func (s *SQLiteMetadataStore) GetByHash(ctx context.Context, hash metadata.Conte
 }
 
 // ListFileChunks returns all blocks belonging to a file, ordered by block index.
-// The LIKE query is a prefilter; block.ChunksForPayload decides membership
+// The ID range is a prefilter; block.ChunksForPayload decides membership
 // and order.
+//
+// The range is compared and ordered in byte collation, not the database
+// default: block.PayloadPrefixRange's bounds only bracket the prefix under
+// byte ordering, and a byte-ordered id column lets the primary-key index seek
+// the range instead of filtering the whole table.
 // Not on the narrowed FileChunkStore interface;
 // kept as a backend method for engine-internal callers.
 func (s *SQLiteMetadataStore) ListFileChunks(ctx context.Context, payloadID string) ([]*metadata.FileChunk, error) {
 	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
 		FROM file_blocks
-		WHERE id LIKE ?1
-		ORDER BY id ASC`
-	rows, err := s.query(ctx, query, payloadID+"/%")
+		WHERE id >= ?1 COLLATE BINARY AND id < ?2 COLLATE BINARY
+		ORDER BY id COLLATE BINARY ASC`
+	lo, hi := block.PayloadPrefixRange(payloadID)
+	rows, err := s.query(ctx, query, lo, hi)
 	if err != nil {
 		return nil, fmt.Errorf("list file chunks: %w", err)
 	}
@@ -579,9 +585,10 @@ func (tx *sqliteTransaction) GetByHash(ctx context.Context, hash metadata.Conten
 func (tx *sqliteTransaction) ListFileChunks(ctx context.Context, payloadID string) ([]*metadata.FileChunk, error) {
 	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
 		FROM file_blocks
-		WHERE id LIKE ?1
-		ORDER BY id ASC`
-	rows, err := tx.tx.Query(ctx, query, payloadID+"/%")
+		WHERE id >= ?1 COLLATE BINARY AND id < ?2 COLLATE BINARY
+		ORDER BY id COLLATE BINARY ASC`
+	lo, hi := block.PayloadPrefixRange(payloadID)
+	rows, err := tx.tx.Query(ctx, query, lo, hi)
 	if err != nil {
 		return nil, fmt.Errorf("list file chunks: %w", err)
 	}

--- a/pkg/metadata/store/sqlite/objects.go
+++ b/pkg/metadata/store/sqlite/objects.go
@@ -295,23 +295,24 @@ func (s *SQLiteMetadataStore) GetByHash(ctx context.Context, hash metadata.Conte
 	return getByHashTx(ctx, s.conn(), hash)
 }
 
-// ListFileChunks returns all blocks belonging to a file, ordered by block index.
-// The ID range is a prefilter; block.ChunksForPayload decides membership
-// and order.
+// listFileChunksQuery takes the bounds of block.PayloadPrefixRange and is a
+// prefilter; block.ChunksForPayload decides membership and order.
 //
 // The range is compared and ordered in byte collation, not the database
-// default: block.PayloadPrefixRange's bounds only bracket the prefix under
-// byte ordering, and a byte-ordered id column lets the primary-key index seek
-// the range instead of filtering the whole table.
+// default: the bounds only bracket the prefix under byte ordering, and a
+// byte-ordered id column lets the primary-key index seek the range instead of
+// filtering the whole table.
+const listFileChunksQuery = `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
+	FROM file_blocks
+	WHERE id >= ?1 COLLATE BINARY AND id < ?2 COLLATE BINARY
+	ORDER BY id COLLATE BINARY ASC`
+
+// ListFileChunks returns all blocks belonging to a file, ordered by block index.
 // Not on the narrowed FileChunkStore interface;
 // kept as a backend method for engine-internal callers.
 func (s *SQLiteMetadataStore) ListFileChunks(ctx context.Context, payloadID string) ([]*metadata.FileChunk, error) {
-	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
-		FROM file_blocks
-		WHERE id >= ?1 COLLATE BINARY AND id < ?2 COLLATE BINARY
-		ORDER BY id COLLATE BINARY ASC`
 	lo, hi := block.PayloadPrefixRange(payloadID)
-	rows, err := s.query(ctx, query, lo, hi)
+	rows, err := s.query(ctx, listFileChunksQuery, lo, hi)
 	if err != nil {
 		return nil, fmt.Errorf("list file chunks: %w", err)
 	}
@@ -583,12 +584,8 @@ func (tx *sqliteTransaction) GetByHash(ctx context.Context, hash metadata.Conten
 // store-level methods).
 
 func (tx *sqliteTransaction) ListFileChunks(ctx context.Context, payloadID string) ([]*metadata.FileChunk, error) {
-	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
-		FROM file_blocks
-		WHERE id >= ?1 COLLATE BINARY AND id < ?2 COLLATE BINARY
-		ORDER BY id COLLATE BINARY ASC`
 	lo, hi := block.PayloadPrefixRange(payloadID)
-	rows, err := tx.tx.Query(ctx, query, lo, hi)
+	rows, err := tx.tx.Query(ctx, listFileChunksQuery, lo, hi)
 	if err != nil {
 		return nil, fmt.Errorf("list file chunks: %w", err)
 	}

--- a/pkg/metadata/storetest/file_block_ops.go
+++ b/pkg/metadata/storetest/file_block_ops.go
@@ -2174,6 +2174,15 @@ func testListFileChunksForeignRows(t *testing.T, factory StoreFactory) {
 		mk("share/dxr/0", 500),
 		// Sibling reachable only through a LIKE "%" wildcard.
 		mk("share/dir-other/0", 600),
+
+		// Siblings straddling the '/' separator in byte order. A backend that
+		// seeks a range rather than matching a prefix bounds it by the bytes
+		// either side of '/' (0x2F), so these two names sit hard against that
+		// bound: '.' is 0x2E and '0' is 0x30. "share/dir0" is also a payloadID
+		// that "share/dir" is a strict prefix of, which is what an inclusive
+		// upper bound would wrongly swallow.
+		mk("share/dir./0", 700),
+		mk("share/dir0/0", 800),
 	}
 	for _, b := range rows {
 		if err := store.Put(ctx, b); err != nil {
@@ -2204,6 +2213,19 @@ func testListFileChunksForeignRows(t *testing.T, factory StoreFactory) {
 	}
 	if !slices.IsSorted(offsets) {
 		t.Errorf("ListFileChunks(share/dir) offsets %v not ascending", offsets)
+	}
+
+	// Each boundary sibling must still be listable in its own right, and a
+	// multi-digit offset must survive: it is the row a range compared in a
+	// collation that ignores punctuation sorts past the upper bound and drops.
+	for _, pid := range []string{"share/dir.", "share/dir0"} {
+		res, lerr := asLegacy(t, store).ListFileChunks(ctx, pid)
+		if lerr != nil {
+			t.Fatalf("ListFileChunks(%s) error: %v", pid, lerr)
+		}
+		if len(res) != 1 || res[0].ID != pid+"/0" {
+			t.Errorf("ListFileChunks(%s) = %v, want [%s/0]", pid, res, pid)
+		}
 	}
 
 	// The nested payload must still be listable in its own right.

--- a/pkg/metadata/storetest/file_block_ops.go
+++ b/pkg/metadata/storetest/file_block_ops.go
@@ -2158,6 +2158,8 @@ func testListFileChunksForeignRows(t *testing.T, factory StoreFactory) {
 	// to it.
 	rows := []*block.FileChunk{
 		mk("share/dir/0", 100),
+		// Multi-digit offset: the row a backend seeking a range in a collation
+		// that ignores punctuation sorts past the upper bound and drops.
 		mk("share/dir/4096", 200),
 		// Belongs to share/dir but carries no placeable offset. This is the
 		// damaged-row class that manifest scans exist to report, so it must
@@ -2215,9 +2217,8 @@ func testListFileChunksForeignRows(t *testing.T, factory StoreFactory) {
 		t.Errorf("ListFileChunks(share/dir) offsets %v not ascending", offsets)
 	}
 
-	// Each boundary sibling must still be listable in its own right, and a
-	// multi-digit offset must survive: it is the row a range compared in a
-	// collation that ignores punctuation sorts past the upper bound and drops.
+	// Each boundary sibling must still be listable in its own right, and must
+	// return only its own row.
 	for _, pid := range []string{"share/dir.", "share/dir0"} {
 		res, lerr := asLegacy(t, store).ListFileChunks(ctx, pid)
 		if lerr != nil {


### PR DESCRIPTION
## What was wrong

`ListFileChunks` located a file's chunks with `WHERE id LIKE '<payloadID>/%'`. Neither SQL backend can serve that from an index:

- **postgres** cannot use a default-collation btree for a prefix `LIKE`, so every call sequentially scanned the whole `file_blocks` table;
- **sqlite** does not apply its `LIKE` optimisation to the case-insensitive default operator, so it fell back to a full scan of the primary-key index.

The query appears four times — the store and transaction variants on each backend — and all four are fixed. The transaction variants matter: they are the path taken inside `WithTransaction`, so fixing only the store methods would have looked complete under any benchmark that never opens a transaction while leaving the scan fully reachable in production.

## The premise that did not survive

The issue proposes a range predicate `id >= $1 AND id < $1 || '0'` on the grounds that it needs no migration and that a default-collation btree can serve it.

**It cannot — not correctly.** A default-collation btree serves that range syntactically, but on a linguistic collation the range no longer *means* "has this prefix". `en_US.utf8` — the default of the stock `postgres:16` image this project tests and ships against — treats punctuation as ignorable at the primary comparison level, so `'p/1048576'` sorts *after* `'p0'` and falls outside the range:

```
postgres=# SELECT (SELECT count(*) FROM fb2 WHERE id LIKE 'p/%')                       AS like_n,
                  (SELECT count(*) FROM fb2 WHERE id >= 'p/' AND id < 'p0')            AS range_n;
 like_n | range_n
--------+---------
      3 |       1
```

Built as prescribed, the existing conformance suite catches it immediately — a manifest silently losing two thirds of its chunks:

```
file_block_ops.go:821:  ListFileChunks(file-A) returned 1 blocks, want 3
file_block_ops.go:881:  ListFileChunks(file-sort) returned 1 blocks, want 5
file_block_ops.go:922:  ListFileChunks(file-mix) returned 1 blocks, want 4
file_block_ops.go:2205: ListFileChunks(share/dir) = [share/dir/0], want exactly
                        [share/dir/0 share/dir/4096 share/dir/block-0]
```

That is the silent-zeros class, so the shape had to change. The boundary character itself checks out — row IDs are `<payloadID>/<decimalOffset>`, `'/'` is `0x2F`, `'0'` is `0x30`, nothing sorts between them — but only under **byte** ordering.

## The fix

Two halves, and they are independent on purpose:

1. **The comparison is pinned to byte collation** (`COLLATE "C"` on postgres, `COLLATE BINARY` on sqlite) at all four sites. This is what makes the range mean "has this prefix", and it holds whatever the database's own collation is. `block.PayloadPrefixRange` is the single place the `0x2F`/`0x30` bound is derived, next to the other functions that already know the ID shape.

2. **A migration gives `file_blocks.id` byte ordering**, so the primary-key index's stored order matches that comparison and the planner can seek instead of scanning.

Splitting it this way means the migration is a pure performance enabler. If it has not run, or is rolled back, the query is **slower, never wrong** — it still returned all 16 rows against an unmigrated column in testing. There is no window in which a half-applied deployment loses chunks.

No new index is created, so there is no added per-insert cost on the chunk write path.

## Evidence

Before, on an unmigrated schema at 56,000 rows — reproduces the plan in the issue:

```
Sort  (cost=1629.88..1631.29 rows=566) (actual time=3.943..3.944 rows=16 loops=1)
  Buffers: shared hit=904
  ->  Seq Scan on file_blocks  (actual time=1.384..3.919 rows=16 loops=1)
        Filter: ((id)::text ~~ 'bench/file-001234/%'::text)
        Rows Removed by Filter: 55984
Execution Time: 3.954 ms
```

After, same data, migrated schema:

```
Index Scan using file_blocks_pkey on file_blocks  (actual time=0.003..0.005 rows=16 loops=1)
  Index Cond: (((id)::text >= 'bench/file-001234/'::text COLLATE "C")
           AND ((id)::text <  'bench/file-0012340'::text COLLATE "C"))
  Buffers: shared hit=4
Execution Time: 0.010 ms
```

Seq Scan → Index Scan, 904 → 4 buffers, 3.954 ms → 0.010 ms, with no sort node. sqlite moves from `SCAN ... USING COVERING INDEX` to `SEARCH ... (id>? AND id<?)`.

Worth recording: once the column is byte-ordered, postgres derives the same index bounds from the *old* `LIKE` on its own, so the migration alone would have fixed postgres. The query change is what fixes sqlite, what keeps the result correct on an unmigrated column, and what drops the `%`/`_` wildcard over-match that `ChunksForPayload` previously had to filter back out.

The migration rewrites the table. Timed at 2,000,000 rows / 492 MB with all five secondary indexes present: **2.1 s**, so it is milliseconds at the scale this was reported from and seconds at the largest scale measured in the field. Across the rewrite, row count, a content checksum over every `(id, hash)` pair, and all six indexes are unchanged, and every index comes back valid. The upgrade was also driven through the real migration runner against a populated database already at version 43, which moved to 44 and flipped the column collation as expected.

## Tests

`ListFileChunks_ForeignRows` gains two siblings sitting hard against the range bound — `share/dir.` (`0x2E`) and `share/dir0` (`0x30`), the latter a payloadID that `share/dir` is a strict prefix of, which is what a careless inclusive upper bound swallows. Each must still list its own row.

The suite runs on both backends. Verified green on sqlite, and on postgres against a live `postgres:16` (`en_US.utf8`) both migrated from scratch and end-to-end; verified failing with the un-pinned predicate, as quoted above.

Closes #2085
