### PR TITLE
fix(smb): release the DH2Q replay reservation before the parked CREATE's final response

### DIFF
--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -1578,8 +1578,11 @@ func (h *Handler) parkCreateOnLeaseBreak(
 
 	go func() {
 		defer cancel()
-		// Backstop for the exits that deliver no response of their own — the
-		// entry was preempted, and whoever preempted it released already.
+		// Unconditional backstop, so the reservation is cleared on every exit of
+		// this goroutine — including the early return below, taken when a CANCEL
+		// or session teardown preempted the entry and delivers the response
+		// itself. The exits that DO send from here release explicitly first;
+		// releaseReplay's once-per-entry cap is what makes that overlap safe.
 		defer pending.releaseReplay()
 
 		if shareConflictWait {

--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -1567,13 +1567,29 @@ func (h *Handler) parkCreateOnLeaseBreak(
 	// parked path) per CREATE attempt. A zero CreateGuid is a no-op in Release.
 	replayGuid := dh2qCreateGuid(d.req)
 
+	// The reservation must be gone BEFORE the parked CREATE's terminal status
+	// reaches the wire. A client that reads that status may put its replay on
+	// the connection immediately, and the server can dispatch it while the
+	// resume goroutine is still unwinding; with the reservation still held,
+	// resolveCreateReplay answers STATUS_FILE_NOT_AVAILABLE for a CREATE that
+	// has already resolved — the replay must instead observe the terminal
+	// outcome (cached open on success, a re-evaluated share-mode contest that
+	// yields the same STATUS_SHARING_VIOLATION on failure). So every path that
+	// sends a final response releases first; the deferred call below is the
+	// backstop for the exits that send nothing (CANCEL / teardown preemption).
+	//
+	// Releasing any earlier would be wrong: while the CREATE is still resolving
+	// a replay has no outcome to observe and must keep failing fast rather than
+	// starting a second, concurrent CREATE for the same CreateGuid.
+	releaseReplayReservation := func() {
+		if h.CreateReplayCache != nil {
+			h.CreateReplayCache.Release(ctx.SessionID, replayGuid)
+		}
+	}
+
 	go func() {
 		defer cancel()
-		defer func() {
-			if h.CreateReplayCache != nil {
-				h.CreateReplayCache.Release(ctx.SessionID, replayGuid)
-			}
-		}()
+		defer releaseReplayReservation()
 
 		if shareConflictWait {
 			// Deferred-open resume: wait for the live share-mode conflict to
@@ -1628,6 +1644,7 @@ func (h *Handler) parkCreateOnLeaseBreak(
 				"messageID", messageID,
 				"asyncId", asyncId,
 				"treeID", ctx.TreeID)
+			releaseReplayReservation()
 			if err := pending.Callback(pending.SessionID, messageID, asyncId, types.StatusNetworkNameDeleted, nil); err != nil {
 				logger.Debug("CREATE async: failed to send tree-deleted response", "error", err)
 			}
@@ -1646,6 +1663,8 @@ func (h *Handler) parkCreateOnLeaseBreak(
 				body = encoded
 			}
 		}
+
+		releaseReplayReservation()
 
 		if err := pending.Callback(pending.SessionID, messageID, asyncId, status, body); err != nil {
 			logger.Warn("CREATE async: failed to send final response",

--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -1527,6 +1527,16 @@ func (h *Handler) parkCreateOnLeaseBreak(
 	// auto-downgrades other-key leases and lets the CREATE proceed.
 	waitCtx, cancel := context.WithTimeout(context.Background(), breakWaitTimeout)
 
+	// The DH2Q CreateGuid was already Reserved by the caller (Create, before the
+	// breakAndMaybeParkCreate dispatch) so a replayed CREATE fails fast with
+	// STATUS_FILE_NOT_AVAILABLE instead of blocking on the same break (smbtorture
+	// replay-dhv2-pending* / *-vs-{oplock,lease}). Since this CREATE is parking
+	// async, ownership of the matching Release transfers to the entry below: the
+	// caller returns STATUS_PENDING immediately and does NOT release. This keeps
+	// exactly one Reserve (in Create) and one Release per CREATE attempt. A zero
+	// CreateGuid is a no-op in Release.
+	replayGuid := dh2qCreateGuid(d.req)
+
 	pending := &PendingCreate{
 		ConnID:    ctx.ConnID,
 		SessionID: ctx.SessionID,
@@ -1534,6 +1544,15 @@ func (h *Handler) parkCreateOnLeaseBreak(
 		AsyncId:   asyncId,
 		Cancel:    cancel,
 		Callback:  ctx.AsyncCreateCompleteCallback,
+		// releaseReplay is invoked by every path that delivers this CREATE's
+		// final response, immediately before the response goes out — the resume
+		// goroutine below, and the CANCEL / session-teardown paths that preempt
+		// it. See PendingCreate.releaseReplay for why the ordering matters.
+		replayReleaser: func() {
+			if h.CreateReplayCache != nil {
+				h.CreateReplayCache.Release(ctx.SessionID, replayGuid)
+			}
+		},
 		// started is closed by the dispatcher (response.go single-cmd path
 		// or compound.go after ReplaceCallback) once the Callback has been
 		// finalized. The resume goroutine waits on it before invoking
@@ -1557,39 +1576,11 @@ func (h *Handler) parkCreateOnLeaseBreak(
 	shareName := d.tree.ShareName
 	messageID := ctx.MessageID
 
-	// The DH2Q CreateGuid was already Reserved by the caller (Create, before the
-	// breakAndMaybeParkCreate dispatch) so a replayed CREATE fails fast with
-	// STATUS_FILE_NOT_AVAILABLE instead of blocking on the same break (smbtorture
-	// replay-dhv2-pending* / *-vs-{oplock,lease}). Since this CREATE is parking
-	// async, ownership of the matching Release transfers to the resume goroutine
-	// below: the caller returns STATUS_PENDING immediately and does NOT release.
-	// This keeps exactly one Reserve (in Create) and one Release (here for the
-	// parked path) per CREATE attempt. A zero CreateGuid is a no-op in Release.
-	replayGuid := dh2qCreateGuid(d.req)
-
-	// The reservation must be gone BEFORE the parked CREATE's terminal status
-	// reaches the wire. A client that reads that status may put its replay on
-	// the connection immediately, and the server can dispatch it while the
-	// resume goroutine is still unwinding; with the reservation still held,
-	// resolveCreateReplay answers STATUS_FILE_NOT_AVAILABLE for a CREATE that
-	// has already resolved — the replay must instead observe the terminal
-	// outcome (cached open on success, a re-evaluated share-mode contest that
-	// yields the same STATUS_SHARING_VIOLATION on failure). So every path that
-	// sends a final response releases first; the deferred call below is the
-	// backstop for the exits that send nothing (CANCEL / teardown preemption).
-	//
-	// Releasing any earlier would be wrong: while the CREATE is still resolving
-	// a replay has no outcome to observe and must keep failing fast rather than
-	// starting a second, concurrent CREATE for the same CreateGuid.
-	releaseReplayReservation := func() {
-		if h.CreateReplayCache != nil {
-			h.CreateReplayCache.Release(ctx.SessionID, replayGuid)
-		}
-	}
-
 	go func() {
 		defer cancel()
-		defer releaseReplayReservation()
+		// Backstop for the exits that deliver no response of their own — the
+		// entry was preempted, and whoever preempted it released already.
+		defer pending.releaseReplay()
 
 		if shareConflictWait {
 			// Deferred-open resume: wait for the live share-mode conflict to
@@ -1644,7 +1635,7 @@ func (h *Handler) parkCreateOnLeaseBreak(
 				"messageID", messageID,
 				"asyncId", asyncId,
 				"treeID", ctx.TreeID)
-			releaseReplayReservation()
+			pending.releaseReplay()
 			if err := pending.Callback(pending.SessionID, messageID, asyncId, types.StatusNetworkNameDeleted, nil); err != nil {
 				logger.Debug("CREATE async: failed to send tree-deleted response", "error", err)
 			}
@@ -1664,7 +1655,7 @@ func (h *Handler) parkCreateOnLeaseBreak(
 			}
 		}
 
-		releaseReplayReservation()
+		pending.releaseReplay()
 
 		if err := pending.Callback(pending.SessionID, messageID, asyncId, status, body); err != nil {
 			logger.Warn("CREATE async: failed to send final response",

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -1896,6 +1896,7 @@ func (h *Handler) cancelAsyncOpsForSession(sessionID uint64) {
 		for _, parked := range h.PendingCreateRegistry.UnregisterAllForSession(sessionID) {
 			if parked.Callback != nil {
 				go func(p *PendingCreate) {
+					p.releaseReplay()
 					if err := p.Callback(p.SessionID, p.MessageID, p.AsyncId, types.StatusCancelled, nil); err != nil {
 						logger.Debug("session cleanup: failed to cancel pending CREATE",
 							"asyncId", p.AsyncId, "messageID", p.MessageID, "error", err)

--- a/internal/adapter/smb/handlers/pending_create_registry.go
+++ b/internal/adapter/smb/handlers/pending_create_registry.go
@@ -44,9 +44,19 @@ type PendingCreate struct {
 	// already reached a terminal status. Invoking it any earlier would be wrong
 	// — while the CREATE is still resolving a replay has no outcome to observe
 	// and must keep failing fast rather than starting a second, concurrent
-	// CREATE for the same CreateGuid. Idempotent, and nil for CREATEs that
-	// carry no CreateGuid. Call it through releaseReplay, which tolerates nil.
+	// CREATE for the same CreateGuid.
+	//
+	// Nil for CREATEs that carry no CreateGuid. Always call it through
+	// releaseReplay, which tolerates nil and runs the hook AT MOST ONCE per
+	// parked CREATE. That cap is load-bearing, not hygiene: the reservation is
+	// keyed by CreateGuid alone, not by CREATE instance, so releasing is not
+	// idempotent in any useful sense. A terminal STATUS_SHARING_VIOLATION is
+	// exactly what a client retries with the SAME CreateGuid, and if that retry
+	// parks and re-reserves the key first, a second release from this
+	// already-finished entry would clear the NEW CREATE's reservation and let a
+	// replay start a second concurrent CREATE for that guid.
 	replayReleaser func()
+	replayOnce     sync.Once
 
 	// started is closed by MarkStarted once the dispatch layer has finalized
 	// the Callback assignment for this entry. The resume goroutine MUST wait
@@ -80,12 +90,18 @@ const (
 	createBucketSession = iota
 )
 
-// releaseReplay clears the parked CREATE's replay reservation, if it has one.
-// Safe on an entry that carries no hook.
+// releaseReplay clears this parked CREATE's replay reservation. Safe on an
+// entry that carries no hook, and safe to call from several delivery paths —
+// the resume goroutine's deferred backstop deliberately overlaps the explicit
+// release on the paths that send a response, so the hook runs at most once per
+// entry. See PendingCreate.replayReleaser for why once-per-entry (rather than
+// merely "delete is idempotent") is what keeps a finished CREATE from clearing
+// a newer CREATE's reservation for the same CreateGuid.
 func (p *PendingCreate) releaseReplay() {
-	if p.replayReleaser != nil {
-		p.replayReleaser()
+	if p.replayReleaser == nil {
+		return
 	}
+	p.replayOnce.Do(p.replayReleaser)
 }
 
 // MaxPendingCreates caps concurrent parked CREATEs per server to protect the

--- a/internal/adapter/smb/handlers/pending_create_registry.go
+++ b/internal/adapter/smb/handlers/pending_create_registry.go
@@ -46,9 +46,13 @@ type PendingCreate struct {
 	// and must keep failing fast rather than starting a second, concurrent
 	// CREATE for the same CreateGuid.
 	//
-	// Nil for CREATEs that carry no CreateGuid. Always call it through
-	// releaseReplay, which tolerates nil and runs the hook AT MOST ONCE per
-	// parked CREATE. That cap is load-bearing, not hygiene: the reservation is
+	// parkCreateOnLeaseBreak wires this on every parked CREATE, so it is non-nil
+	// there whether or not the request carried a CreateGuid — a CREATE without
+	// one releases the zero guid, which Release ignores. It is nil only on
+	// entries built outside that path, which is why releaseReplay tolerates nil.
+	//
+	// Always go through releaseReplay: it runs the hook AT MOST ONCE per parked
+	// CREATE. That cap is load-bearing, not hygiene: the reservation is
 	// keyed by CreateGuid alone, not by CREATE instance, so releasing is not
 	// idempotent in any useful sense. A terminal STATUS_SHARING_VIOLATION is
 	// exactly what a client retries with the SAME CreateGuid, and if that retry

--- a/internal/adapter/smb/handlers/pending_create_registry.go
+++ b/internal/adapter/smb/handlers/pending_create_registry.go
@@ -35,6 +35,19 @@ type PendingCreate struct {
 	// StatusCancelled + nil body). Releases the async slot as part of its work.
 	Callback AsyncCreateCompleteCallback
 
+	// releaseReplay clears the DH2Q CreateGuid reservation this CREATE holds
+	// while it is parked. Every path that delivers the CREATE's final response
+	// MUST invoke it immediately BEFORE sending: a client learns the CREATE is
+	// finished from exactly that response and may put its replay on the
+	// connection at once, so a reservation that outlives the send makes
+	// resolveCreateReplay answer STATUS_FILE_NOT_AVAILABLE for a CREATE that has
+	// already reached a terminal status. Invoking it any earlier would be wrong
+	// — while the CREATE is still resolving a replay has no outcome to observe
+	// and must keep failing fast rather than starting a second, concurrent
+	// CREATE for the same CreateGuid. Idempotent, and nil for CREATEs that
+	// carry no CreateGuid. Call it through releaseReplay, which tolerates nil.
+	replayReleaser func()
+
 	// started is closed by MarkStarted once the dispatch layer has finalized
 	// the Callback assignment for this entry. The resume goroutine MUST wait
 	// on it before invoking Callback. Without this gate, a fast localhost
@@ -66,6 +79,14 @@ const (
 const (
 	createBucketSession = iota
 )
+
+// releaseReplay clears the parked CREATE's replay reservation, if it has one.
+// Safe on an entry that carries no hook.
+func (p *PendingCreate) releaseReplay() {
+	if p.replayReleaser != nil {
+		p.replayReleaser()
+	}
+}
 
 // MaxPendingCreates caps concurrent parked CREATEs per server to protect the
 // process from runaway clients. Picked to match MaxPendingWatches.

--- a/internal/adapter/smb/handlers/replay_pending_violation_test.go
+++ b/internal/adapter/smb/handlers/replay_pending_violation_test.go
@@ -343,3 +343,44 @@ func TestParkedCreate_ReplayReservationClearedOnSessionCancel(t *testing.T) {
 	h.cancelAsyncOpsForSession(sessionID)
 	awaitFinalResponse(t, sent, types.StatusCancelled)
 }
+
+// TestParkedCreate_StaleBackstopCannotClearANewerReservation pins why the
+// release hook is capped at once per entry rather than merely "idempotent".
+//
+// The reservation is keyed by CreateGuid alone, so releasing it is not a
+// self-cancelling operation — it clears whatever reservation currently stands
+// under that key, no matter which CREATE put it there. The resume goroutine's
+// deferred backstop deliberately overlaps the explicit release on the paths
+// that send a response, so it fires again after the terminal status is already
+// on the wire. STATUS_SHARING_VIOLATION is exactly the status a client retries
+// with the same CreateGuid; if that retry parks and re-reserves first, an
+// uncapped backstop would delete the NEW CREATE's reservation, and a replay
+// would stop failing fast and could start a second concurrent CREATE.
+func TestParkedCreate_StaleBackstopCannotClearANewerReservation(t *testing.T) {
+	cache := NewCreateReplayCache()
+	const sessionID = uint64(7)
+	guid := [16]byte{0x2a, 0x1}
+
+	// A parked CREATE holding the reservation, wired as parkCreateOnLeaseBreak
+	// wires one.
+	parked := &PendingCreate{replayReleaser: func() { cache.Release(sessionID, guid) }}
+	cache.Reserve(sessionID, guid)
+
+	// It resolves and delivers its terminal status, releasing first.
+	parked.releaseReplay()
+	if cache.IsReserved(sessionID, guid) {
+		t.Fatal("release did not clear the parked CREATE's own reservation")
+	}
+
+	// The client retries the failed CREATE with the SAME CreateGuid; it parks
+	// again and takes a fresh reservation.
+	cache.Reserve(sessionID, guid)
+
+	// The finished entry's deferred backstop now fires.
+	parked.releaseReplay()
+
+	if !cache.IsReserved(sessionID, guid) {
+		t.Fatal("a finished CREATE's backstop cleared a newer CREATE's reservation for the same " +
+			"CreateGuid: a replay would stop failing fast and could start a second concurrent CREATE")
+	}
+}

--- a/internal/adapter/smb/handlers/replay_pending_violation_test.go
+++ b/internal/adapter/smb/handlers/replay_pending_violation_test.go
@@ -1,9 +1,14 @@
 package handlers
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/marmos91/dittofs/internal/adapter/smb/lease"
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
 // These tests pin the replay-decision state machine for the #749
@@ -185,5 +190,120 @@ func TestReplayPendingViolation_CrossSessionIsolation(t *testing.T) {
 	const otherSession = uint64(99)
 	if resp, handled := h.resolveCreateReplay(newReplayCtx(otherSession, true), req); handled {
 		t.Fatalf("foreign-session replay must not see another session's reservation, got %s", resp.GetStatus())
+	}
+}
+
+// TestParkedCreate_ReplayReservationClearedBeforeFinalResponse pins the
+// ORDERING the state-machine tests above cannot see: the CreateGuid
+// reservation must already be gone at the instant the parked CREATE's
+// terminal status is handed to the wire.
+//
+// The park resolves, the server writes STATUS_SHARING_VIOLATION for the
+// original CREATE, and the client — which learns the CREATE is finished from
+// exactly that response — puts its replay on the connection straight away. If
+// the reservation outlives the send by even a scheduling quantum, the server
+// dispatches that replay against a reservation for a CREATE that has already
+// resolved and answers STATUS_FILE_NOT_AVAILABLE where the terminal
+// STATUS_SHARING_VIOLATION is required (smbtorture
+// smb2.replay.dhv2-pending1n-vs-violation-lease-ack-sane, replay.c io23).
+//
+// The wait resolves immediately here (no lock manager → the share-conflict
+// wait returns at once, as it does when the holder ACKs its break and keeps
+// its open), so the whole test is deterministic: it asserts what the callback
+// observes, not how fast anything runs.
+func TestParkedCreate_ReplayReservationClearedBeforeFinalResponse(t *testing.T) {
+	h, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
+	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
+	h.StoreTree(tree)
+	// A nil lock manager makes WaitForShareConflictClear return immediately,
+	// standing in for the holder's break having drained with its open intact.
+	h.LeaseManager = lease.NewLeaseManager(&staticLockResolver{}, nil)
+
+	const fileName = "parked.dat"
+	existingFile, _, err := rt.GetMetadataService().CreateFile(rootAuth, rootHandle, fileName,
+		&metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o777})
+	if err != nil {
+		t.Fatalf("CreateFile: %v", err)
+	}
+	metaHandle, err := metadata.EncodeFileHandle(existingFile)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle: %v", err)
+	}
+
+	// The holder: reading the file while denying every share mode, so the
+	// parked CREATE below still loses the share-mode contest on recheck.
+	h.StoreOpenFile((&OpenFile{
+		FileID:         [16]byte{0xAA},
+		SessionID:      violationSessionID + 1,
+		ShareName:      smbCtx.ShareName,
+		DesiredAccess:  0x00000001, // FILE_READ_DATA
+		ShareAccess:    0,          // deny read/write/delete
+		MetadataHandle: metaHandle,
+	}).WithName(OpenName{Path: fileName, FileName: fileName}))
+
+	guid := [16]byte{0x21, 0x9}
+	req := dh2qCreateReq(guid, nil)
+	req.FileName = fileName
+	req.DesiredAccess = 0x00000001
+	req.ShareAccess = 0
+	req.CreateDisposition = types.FileOpen
+
+	draft := &createDraft{
+		req:            req,
+		tree:           tree,
+		authCtx:        rootAuth,
+		filename:       fileName,
+		baseName:       fileName,
+		parentHandle:   rootHandle,
+		existingFile:   existingFile,
+		existingHandle: metaHandle,
+		fileExists:     true,
+		createAction:   types.FileOpened,
+	}
+
+	// Create() reserves the guid before dispatching the break; the parked
+	// resume goroutine owns the matching release.
+	h.CreateReplayCache.Reserve(smbCtx.SessionID, guid)
+
+	type finalResponse struct {
+		status         types.Status
+		reservedAtSend bool
+	}
+	sent := make(chan finalResponse, 1)
+
+	parkCtx := &SMBHandlerContext{
+		Context:         context.Background(),
+		SessionID:       smbCtx.SessionID,
+		TreeID:          smbCtx.TreeID,
+		ShareName:       smbCtx.ShareName,
+		MessageID:       5,
+		TryReserveAsync: func() bool { return true },
+		ReleaseAsync:    func() {},
+		AsyncCreateCompleteCallback: func(_, _, _ uint64, status types.Status, _ []byte) error {
+			sent <- finalResponse{status, h.CreateReplayCache.IsReserved(smbCtx.SessionID, guid)}
+			return nil
+		},
+	}
+
+	asyncId := h.parkCreateOnLeaseBreak(parkCtx, draft, lock.FileHandle(metaHandle),
+		[16]byte{}, 2*time.Second, true)
+	if asyncId == 0 {
+		t.Fatal("parkCreateOnLeaseBreak refused to park")
+	}
+	if !h.PendingCreateRegistry.MarkStarted(asyncId) {
+		t.Fatal("MarkStarted: pending CREATE not registered")
+	}
+
+	select {
+	case got := <-sent:
+		if got.status != types.StatusSharingViolation {
+			t.Fatalf("parked CREATE final status = %s, want SHARING_VIOLATION", got.status)
+		}
+		if got.reservedAtSend {
+			t.Fatal("CreateGuid still reserved when the parked CREATE's final response was sent: " +
+				"a replay racing that response resolves to FILE_NOT_AVAILABLE instead of the terminal status")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("parked CREATE never delivered a final response")
 	}
 }

--- a/internal/adapter/smb/handlers/replay_pending_violation_test.go
+++ b/internal/adapter/smb/handlers/replay_pending_violation_test.go
@@ -211,7 +211,21 @@ func TestReplayPendingViolation_CrossSessionIsolation(t *testing.T) {
 // wait returns at once, as it does when the holder ACKs its break and keeps
 // its open), so the whole test is deterministic: it asserts what the callback
 // observes, not how fast anything runs.
-func TestParkedCreate_ReplayReservationClearedBeforeFinalResponse(t *testing.T) {
+// parkedFinalResponse records what a parked CREATE's completion callback saw:
+// the status being sent, and whether the DH2Q replay reservation was still held
+// at that instant. The second field is the invariant under test.
+type parkedFinalResponse struct {
+	status         types.Status
+	reservedAtSend bool
+}
+
+// parkedViolationCreate stands up a CREATE parked behind a share-mode conflict
+// it can never win, and returns the handler, the reserved CreateGuid, the async
+// id of the parked entry, and a channel that reports what the final-response
+// callback saw. The share-conflict wait resolves immediately (no lock manager),
+// standing in for the holder having ACKed its break while keeping its open.
+func parkedViolationCreate(t *testing.T) (*Handler, uint64, uint64, <-chan parkedFinalResponse) {
+	t.Helper()
 	h, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
 	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
 	h.StoreTree(tree)
@@ -265,11 +279,7 @@ func TestParkedCreate_ReplayReservationClearedBeforeFinalResponse(t *testing.T) 
 	// resume goroutine owns the matching release.
 	h.CreateReplayCache.Reserve(smbCtx.SessionID, guid)
 
-	type finalResponse struct {
-		status         types.Status
-		reservedAtSend bool
-	}
-	sent := make(chan finalResponse, 1)
+	sent := make(chan parkedFinalResponse, 1)
 
 	parkCtx := &SMBHandlerContext{
 		Context:         context.Background(),
@@ -280,7 +290,7 @@ func TestParkedCreate_ReplayReservationClearedBeforeFinalResponse(t *testing.T) 
 		TryReserveAsync: func() bool { return true },
 		ReleaseAsync:    func() {},
 		AsyncCreateCompleteCallback: func(_, _, _ uint64, status types.Status, _ []byte) error {
-			sent <- finalResponse{status, h.CreateReplayCache.IsReserved(smbCtx.SessionID, guid)}
+			sent <- parkedFinalResponse{status, h.CreateReplayCache.IsReserved(smbCtx.SessionID, guid)}
 			return nil
 		},
 	}
@@ -290,14 +300,18 @@ func TestParkedCreate_ReplayReservationClearedBeforeFinalResponse(t *testing.T) 
 	if asyncId == 0 {
 		t.Fatal("parkCreateOnLeaseBreak refused to park")
 	}
-	if !h.PendingCreateRegistry.MarkStarted(asyncId) {
-		t.Fatal("MarkStarted: pending CREATE not registered")
-	}
+	return h, smbCtx.SessionID, asyncId, sent
+}
 
+// awaitFinalResponse fails the test unless the parked CREATE delivered a final
+// response whose status matches want AND the replay reservation was already
+// cleared at the instant that response was handed to the wire.
+func awaitFinalResponse(t *testing.T, sent <-chan parkedFinalResponse, want types.Status) {
+	t.Helper()
 	select {
 	case got := <-sent:
-		if got.status != types.StatusSharingViolation {
-			t.Fatalf("parked CREATE final status = %s, want SHARING_VIOLATION", got.status)
+		if got.status != want {
+			t.Fatalf("parked CREATE final status = %s, want %s", got.status, want)
 		}
 		if got.reservedAtSend {
 			t.Fatal("CreateGuid still reserved when the parked CREATE's final response was sent: " +
@@ -306,4 +320,26 @@ func TestParkedCreate_ReplayReservationClearedBeforeFinalResponse(t *testing.T) 
 	case <-time.After(10 * time.Second):
 		t.Fatal("parked CREATE never delivered a final response")
 	}
+}
+
+// TestParkedCreate_ReplayReservationClearedBeforeFinalResponse covers the
+// resume goroutine's own delivery: the park resolves, the CREATE loses the
+// share-mode contest, and STATUS_SHARING_VIOLATION goes out.
+func TestParkedCreate_ReplayReservationClearedBeforeFinalResponse(t *testing.T) {
+	h, _, asyncId, sent := parkedViolationCreate(t)
+	if !h.PendingCreateRegistry.MarkStarted(asyncId) {
+		t.Fatal("MarkStarted: pending CREATE not registered")
+	}
+	awaitFinalResponse(t, sent, types.StatusSharingViolation)
+}
+
+// TestParkedCreate_ReplayReservationClearedOnSessionCancel covers the other
+// delivery path: session teardown preempts the parked CREATE and sends
+// STATUS_CANCELLED itself. That response is just as terminal, so it carries the
+// same ordering obligation — the resume goroutine's deferred release is a
+// backstop, not the thing that orders this send.
+func TestParkedCreate_ReplayReservationClearedOnSessionCancel(t *testing.T) {
+	h, sessionID, _, sent := parkedViolationCreate(t)
+	h.cancelAsyncOpsForSession(sessionID)
+	awaitFinalResponse(t, sent, types.StatusCancelled)
 }

--- a/internal/adapter/smb/handlers/stub_handlers.go
+++ b/internal/adapter/smb/handlers/stub_handlers.go
@@ -397,6 +397,7 @@ func (h *Handler) Cancel(ctx *SMBHandlerContext, body []byte) (*HandlerResult, e
 				"messageID", parked.MessageID)
 			if parked.Callback != nil {
 				go func(p *PendingCreate) {
+					p.releaseReplay()
 					if err := p.Callback(p.SessionID, p.MessageID, p.AsyncId, types.StatusCancelled, nil); err != nil {
 						logger.Warn("CANCEL: failed to send STATUS_CANCELLED for CREATE",
 							"messageID", p.MessageID,

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -349,8 +349,14 @@ written to the connection. The client learns the CREATE is finished from exactly
 that response and sends its replay immediately, and the server could dispatch it
 while the reservation still stood — answering `STATUS_FILE_NOT_AVAILABLE` for a
 CREATE that had already resolved. Every path that delivers a final response now
-releases first; the `defer` remains only as the backstop for the CANCEL/teardown
-exits that send nothing.
+releases first — the resume goroutine, the tree-gone exit, and the CANCEL /
+session-teardown paths, which send `STATUS_CANCELLED` themselves. The `defer`
+remains as an unconditional backstop covering the resume goroutine's own early
+return, taken when one of those preempted the entry so nothing is sent from
+there. Releasing is capped at once per parked CREATE, because the reservation is
+keyed by CreateGuid alone: `STATUS_SHARING_VIOLATION` is exactly what a client
+retries with the same guid, and an uncapped backstop from the finished entry
+would clear the retry's reservation.
 
 The `smb2.replay` and `smb2.durable-*` suites also now get the 300 s per-suite
 budget on **every** profile. The memory profile was reporting

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -333,6 +333,30 @@ These entries remain in CI's known-failure set (so they don't break the build) b
 
 ## Changelog
 
+### 2026-08-24 — `dhv2-pending1n-vs-violation-lease-ack-sane`: replay reservation outlived the parked CREATE's response
+
+The intermittent failure of this expected-pass row was **not** the "5 s
+break-wait timer race" the #749 entry below describes — that entry is still
+accurate about what #749 fixed, but it stopped being the live defect the moment
+the deferred-open retry landed. In the captured failure the holder's
+`LEASE_BREAK_ACK` returns `STATUS_SUCCESS` (the lease is never force-completed)
+and the parked CREATE resolves correctly to `STATUS_SHARING_VIOLATION`; the
+assertion that fails is the *next* one, the replay at `replay.c:1731` (io23).
+
+The parked CREATE's resume goroutine released its DH2Q CreateGuid reservation in
+a `defer`, so the release ran only after the terminal response had already been
+written to the connection. The client learns the CREATE is finished from exactly
+that response and sends its replay immediately, and the server could dispatch it
+while the reservation still stood — answering `STATUS_FILE_NOT_AVAILABLE` for a
+CREATE that had already resolved. Every path that delivers a final response now
+releases first; the `defer` remains only as the backstop for the CANCEL/teardown
+exits that send nothing.
+
+The `smb2.replay` and `smb2.durable-*` suites also now get the 300 s per-suite
+budget on **every** profile. The memory profile was reporting
+`smb2.replay (gave up after 120s)`, leaving the tail of the suite ungraded —
+which is why the defect surfaced as an occasional row rather than a standing one.
+
 ### 2026-08-18 — #1923 `channel-sequence`: excuse the self-contradictory random CSN draw
 
 `smb2.replay.channel-sequence` flipped the badger-fs verdict between two runs of

--- a/test/smb-conformance/smbtorture/run.sh
+++ b/test/smb-conformance/smbtorture/run.sh
@@ -643,21 +643,17 @@ else
         else
             log_info "  Running: ${suite}"
         fi
-        # Durable-handle and replay suites drive many durable open/
-        # disconnect/reconnect cycles, and the replay-vs-pending-break arms
-        # each spend ~6s parked on a lease break the test deliberately acks
-        # late. That alone overruns the default per-suite budget on every
-        # profile — the memory profile reports "smb2.replay (gave up after
-        # 120s)" and leaves the tail of the suite ungraded, which is how a
-        # real defect in those arms stayed intermittent instead of being
-        # reported every run. badger-fs is slower still (each cycle
-        # persists/consumes a durable handle with a synchronous,
-        # non-coalescing fsync, on top of the emulated CI runner's inflated
-        # per-fsync latency). Give these suites the same head room on every
-        # profile; every other suite keeps 120s.
-        suite_timeout=120
+        # Durable-handle and replay suites drive many durable open/disconnect/
+        # reconnect cycles, and the replay-vs-pending-break arms each spend ~6s
+        # parked on a lease break the test deliberately acks late. At 120s even
+        # the memory profile reports "smb2.replay (gave up after 120s)" and
+        # leaves the tail of the suite ungraded; badger-fs is slower still,
+        # since each cycle persists/consumes a durable handle with a
+        # synchronous, non-coalescing fsync. Give those suites more head room
+        # on every profile; every other suite keeps 120s.
         case "$suite" in
             smb2.replay|smb2.durable-*) suite_timeout=300 ;;
+            *) suite_timeout=120 ;;
         esac
         run_smbtorture "$suite" "$suite_timeout" "$prefix" "${share:-}" || record_rc $?
     done

--- a/test/smb-conformance/smbtorture/run.sh
+++ b/test/smb-conformance/smbtorture/run.sh
@@ -644,19 +644,21 @@ else
             log_info "  Running: ${suite}"
         fi
         # Durable-handle and replay suites drive many durable open/
-        # disconnect/reconnect cycles. On the badger-fs profile each of
-        # those persists/consumes a durable handle with a synchronous,
-        # non-coalescing fsync, so the cycles run far slower than on the
-        # memory backend and the default per-suite budget is too tight
-        # under the emulated CI runner (inflated per-fsync latency),
-        # timing the suite out mid-run. Give just those suites more head
-        # room on badger-fs; every other suite/profile keeps 120s.
+        # disconnect/reconnect cycles, and the replay-vs-pending-break arms
+        # each spend ~6s parked on a lease break the test deliberately acks
+        # late. That alone overruns the default per-suite budget on every
+        # profile — the memory profile reports "smb2.replay (gave up after
+        # 120s)" and leaves the tail of the suite ungraded, which is how a
+        # real defect in those arms stayed intermittent instead of being
+        # reported every run. badger-fs is slower still (each cycle
+        # persists/consumes a durable handle with a synchronous,
+        # non-coalescing fsync, on top of the emulated CI runner's inflated
+        # per-fsync latency). Give these suites the same head room on every
+        # profile; every other suite keeps 120s.
         suite_timeout=120
-        if [[ "$PROFILE" == "badger-fs" ]]; then
-            case "$suite" in
-                smb2.replay|smb2.durable-*) suite_timeout=300 ;;
-            esac
-        fi
+        case "$suite" in
+            smb2.replay|smb2.durable-*) suite_timeout=300 ;;
+        esac
         run_smbtorture "$suite" "$suite_timeout" "$prefix" "${share:-}" || record_rc $?
     done
 


### PR DESCRIPTION
`smb2.replay.dhv2-pending1n-vs-violation-lease-ack-sane` is an expected-pass row
that has failed intermittently on the `smbtorture / memory` job since June.
#1322 and #2086 are the same failure filed three months apart, so this closes
both.

## The issue's premise was wrong, and that matters

#1322 names the cause as a "~5 s break-wait timer race": the parked
share-violation CREATE force-completing the holder's lease on its break-wait
timeout, racing the holder's ~5 s release. That description is inherited from the
#749 `KNOWN_FAILURES.md` entry and it is stale — #749's deferred-open
`WaitForShareConflictClear` removed the force-complete, and the captured failure
shows it working exactly as intended.

Server log from the failing run (32119886932, `smbtorture / memory`,
`smbtorture-memory` artifact, 09:26:40):

```
LEASE_BREAK_ACK acknowledgment                leaseKey=01391b40… acknowledgedState=RW
Sent SMB2 response  command=OPLOCK_BREAK      status=STATUS_SUCCESS      messageID=9
CREATE: sharing violation  path=…lease_ack_sane_TJLmr8tu.dat  shareAccess=0x0
Sending async completion response  command=CREATE status=STATUS_SHARING_VIOLATION messageID=5 asyncId=5795
Sent SMB2 response  command=CREATE           status=STATUS_SHARING_VIOLATION  messageID=5
SMB2 request        command=CREATE           messageID=7  flags=0x20000018     ← REPLAY_OPERATION
Sent SMB2 response  command=CREATE           status=STATUS_FILE_NOT_AVAILABLE messageID=7
```

The holder's `LEASE_BREAK_ACK` returns `STATUS_SUCCESS`, so the lease was never
force-completed. The parked CREATE resolves correctly to
`STATUS_SHARING_VIOLATION`, and smbtorture's `Checking req21 expecting
NT_STATUS_SHARING_VIOLATION` passes. The assertion that fails is the *next* one —
the replay at `replay.c:1731` (io23):

```
../../source4/torture/smb2/replay.c:1731: Incorrect status
  NT_STATUS_FILE_NOT_AVAILABLE - should be NT_STATUS_SHARING_VIOLATION
```

(#1322's follow-up comment transcribed this the other way round — "got
SHARING_VIOLATION, expected FILE_NOT_AVAILABLE". The raw assertion in both runs'
artifacts reads got `FILE_NOT_AVAILABLE`, expected `SHARING_VIOLATION`, which is
also what `replay.c:1731` requires for the `-ack-sane` parameterisation. The two
issues are one failure, not two.)

## Actual root cause

`parkCreateOnLeaseBreak`'s resume goroutine released the DH2Q CreateGuid replay
reservation in a `defer`:

```go
go func() {
    defer cancel()
    defer func() { h.CreateReplayCache.Release(ctx.SessionID, replayGuid) }()
    ...
    pending.Callback(..., status, body)   // ← terminal response goes on the wire here
}()                                       // ← reservation released only now
```

`pending.Callback` is a synchronous send (`SendAsyncCompletionResponse`), so the
parked CREATE's terminal status reaches the client *before* the reservation is
cleared. The client learns the CREATE is finished from exactly that response and
puts its replay on the connection immediately; the connection's read loop is a
different goroutine, so the server can dispatch that replay while the resume
goroutine is still unwinding. `resolveCreateReplay` then finds no cached entry
(failures are not cached, by design) but a live reservation, and short-circuits
to `STATUS_FILE_NOT_AVAILABLE` for a CREATE that has already resolved.

The window is the goroutine's return-to-defer gap, which is why it presented as
a rare flake rather than a hard failure. The failing run and its green re-run on
the same commit are otherwise identical — 558 total, the same 7 suites cut short,
487 vs 488 passed — differing only in this one row.

It is not a regression from either PR it appeared on — #1315 is control-plane
only and #2082 is offline-read observability; neither has SMB surface. The defect
has been present since the parked path was introduced.

## Fix

The release now hangs off the `PendingCreate` entry itself, and every path that
delivers this CREATE's terminal status calls it immediately before sending. That
is three paths, not one: the resume goroutine's own delivery, the tree-gone
`STATUS_NETWORK_NAME_DELETED` exit, and — found in review — the CANCEL
(`stub_handlers.go`) and session-teardown (`cancelAsyncOpsForSession`) paths,
which preempt the parked entry and send `STATUS_CANCELLED` from a different
goroutine entirely. Those two had the identical defect: they relied on the resume
goroutine's `defer` firing at some unrelated later moment. The `defer` remains
only as the backstop for exits that send nothing at all.

The release is capped at **once per parked entry** (a `sync.Once` on the
`PendingCreate`), which is load-bearing rather than hygiene. The backstop
deliberately overlaps the explicit release on every path that sends a response,
and `Release` deletes by `{SessionID, CreateGuid}` — the key, not the CREATE
instance. `STATUS_SHARING_VIOLATION` is exactly the status a client retries with
the *same* CreateGuid, so if that retry parks and re-reserves first, an uncapped
backstop from the finished entry would delete the **new** CREATE's reservation:
`resolveCreateReplay` would stop failing fast and could start a second
concurrent CREATE for one guid. Per-entry (rather than a guard inside `Release`)
is what makes that structurally impossible — `Release` cannot tell the two
CREATEs apart. The hook's doc comment previously claimed "Idempotent", which is
true of `delete` in isolation and false at the level that matters; it now states
the guarantee that actually holds.

Ordering is now deterministic rather than dependent on scheduling:

- Releasing any **earlier** would be wrong. While `completeCreateAfterBreak` is
  still running the CREATE genuinely is in progress, and a replay must keep
  failing fast rather than starting a second concurrent CREATE for the same
  CreateGuid.
- Releasing before the send is safe on the success path because
  `completeCreateAfterBreak` calls `CreateReplayCache.Store` before it returns,
  and `resolveCreateReplay` checks `LookupEntry` before `IsReserved` — a replay
  in that window finds the cached open.
- On the failure path there is nothing to cache, so the replay falls through to
  the normal CREATE path and re-loses the same share-mode contest, yielding the
  same `STATUS_SHARING_VIOLATION`. That is the status the test requires.

## Harness

`smb2.replay` / `smb2.durable-*` now get the 300 s per-suite budget on **every**
profile, not just `badger-fs`. The memory profile's `timeouts.txt` reads
`smb2.replay 120` and its `summary.txt` reads `smb2.replay (gave up after 120s)`
— the suite was being cut short and the tail left ungraded, which is part of why
this defect surfaced as an occasional row instead of a standing one. The
replay-vs-pending-break arms each park ~6 s on a lease break the test
deliberately acks late, so 120 s does not fit the suite on any backend.

The row is **not** added to `KNOWN_FAILURES.md`: it passes on `badger-fs`, so it
is not known-unsupported behaviour. Unlike the `-windows` variants of this family
(architecturally known-failing per #1832), the `-sane` variants are the
conformant target and a failure there is real signal.

## Verification

Two regression tests drive `parkCreateOnLeaseBreak` end to end and assert, from
inside the completion callback, that the reservation is already gone at the
instant the terminal response is handed to the wire — one per delivery path
(`…ClearedBeforeFinalResponse` for the resume goroutine,
`…ClearedOnSessionCancel` for the teardown preemption). Both are deterministic:
they inspect what the callback observes, not how fast anything runs. A third,
`…StaleBackstopCannotClearANewerReservation`, pins the once-per-entry cap by
releasing, re-reserving the same key, then firing the finished entry's backstop
and asserting the newer reservation survives. Each was confirmed to fail without
its own half of the fix (5/5, 3/3 and 3/3 respectively):

```
# before the fix
--- FAIL: TestParkedCreate_ReplayReservationClearedBeforeFinalResponse (0.00s)
    CreateGuid still reserved when the parked CREATE's final response was sent:
    a replay racing that response resolves to FILE_NOT_AVAILABLE instead of the
    terminal status
FAIL   (5/5 runs)

# after
ok  github.com/marmos91/dittofs/internal/adapter/smb/handlers
```

`go test ./internal/adapter/smb/...` and `go test -race ./internal/adapter/smb/...`
are green.

Closes #2086
Closes #1322
