### PR TITLE
fix(api): gate the drain-uploads stall trip on there being something to upload

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -176,10 +176,12 @@ controlplane:
   read_timeout: 10s          # Max time to read request
   write_timeout: 10s         # Max time to write response
   idle_timeout: 60s          # Max idle time for keep-alive
-  drain_stall_timeout: 5m    # Abort POST /system/drain-uploads only if no
-                             # upload completes within this window (inactivity
-                             # timeout, NOT a total cap — a large flush may run
-                             # for as long as it keeps making progress)
+  drain_stall_timeout: 5m    # Abort POST /api/v1/system/drain-uploads only if
+                             # no upload completes within this window WHILE
+                             # bytes are still unsynced (inactivity timeout,
+                             # NOT a total cap — a large flush may run for as
+                             # long as it keeps making progress, and a drain
+                             # with nothing left to upload is never aborted)
 
   # Force the bootstrap "admin" user to set a new password on first login.
   # Default true (secure by default). Set to false for automated/test
@@ -225,7 +227,7 @@ controlplane:
 | `read_timeout` | `10s` | Maximum duration to read request |
 | `write_timeout` | `10s` | Maximum duration to write response |
 | `idle_timeout` | `60s` | Maximum idle time for keep-alive |
-| `drain_stall_timeout` | `5m` | Inactivity bound for `POST /system/drain-uploads`. The drain has **no total time cap** — a multi-GiB flush runs as long as it keeps making progress — and is aborted (504) only if no upload completes within this window (the remote stalled). Mirrors rclone's `--timeout` |
+| `drain_stall_timeout` | `5m` | Inactivity bound for `POST /api/v1/system/drain-uploads`. The drain has **no total time cap** — a multi-GiB flush runs as long as it keeps making progress — and is aborted (504) only if no upload completes within this window while bytes are still unsynced (the remote stalled). A drain with nothing left to upload is never aborted: no attempt can conclude, so a flat counter says nothing about liveness. Mirrors rclone's `--timeout` |
 | `require_initial_password_change` | `true` | Force the bootstrap `admin` user to change its password on first login. Set to `false` to opt out (automated/test deployments). Also skipped when `DITTOFS_ADMIN_INITIAL_PASSWORD` is set |
 | `pprof` | `false` | Expose Go `/debug/pprof/*` profiling endpoints |
 | `pprof_mutex_rate` | `100` (when `pprof: true`; else `0`) | Mutex contention sampling, 1 per N events. Applied only when `pprof: true`; unset/`0` then falls back to `100`. Without it `/debug/pprof/mutex` is header-only. Disable profiling via `pprof: false`, not by zeroing this |

--- a/internal/controlplane/api/handlers/system.go
+++ b/internal/controlplane/api/handlers/system.go
@@ -31,6 +31,10 @@ type drainRuntime interface {
 	// UploadProgress returns a monotonic count of concluded mirror attempts.
 	// Used purely as a liveness signal by the idle watchdog.
 	UploadProgress() int64
+	// UnsyncedBytes returns the bytes still awaiting a remote. Zero means no
+	// upload attempt can conclude, so a flat UploadProgress says nothing about
+	// whether the drain is alive.
+	UnsyncedBytes() int64
 }
 
 // SystemHandler handles system-level endpoints.
@@ -79,11 +83,17 @@ func NewSystemHandler(rt *runtime.Runtime, drainStallTimeout time.Duration) *Sys
 //     only on a genuine stall. CAS chunks are at most a few MiB, so even on a
 //     slow link a single chunk finishes well inside any sane idle window.
 //
-// What a trip actually means is narrower than "the remote is wedged": the
-// watchdog observes only that no upload attempt concluded during the window. A
-// stuck carve, a stuck remote, and a drain that never had anything to do are
-// indistinguishable from here, so the 504 reports the observation and how much
-// landed before it, and leaves the diagnosis to the reader.
+//     The counter alone cannot carry that judgement, because it moves only when
+//     an upload attempt concludes, and a drain also spends time in phases that
+//     conclude none. So the trip is gated on there still being something
+//     unsynced: with nothing left, the flat counter is the expected reading
+//     rather than evidence of a stall, and the drain is left to return.
+//
+// What a trip actually means is still narrower than "the remote is wedged": the
+// watchdog observes that no upload attempt concluded during the window while
+// bytes were still waiting for one. A stuck carve and a stuck remote read the
+// same from here, so the 504 reports the observation and how much landed before
+// it, and leaves the diagnosis to the reader.
 //
 // A genuine client disconnect (request context Canceled, as opposed to the
 // deadline-exceeded fired by middleware.Timeout) still aborts the drain.
@@ -180,10 +190,25 @@ func (h *SystemHandler) runWithIdleWatchdog(ctx context.Context, cancel context.
 				continue
 			}
 			idleFor += interval
-			if idleFor >= h.drainStallTimeout {
-				cancel()
-				return <-drainDone, true // wait for the drain to unwind on ctx cancel
+			if idleFor < h.drainStallTimeout {
+				continue
 			}
+			// A flat attempt count only means the remote has stalled while there
+			// is still something to upload. With nothing unsynced left there is
+			// no attempt left to conclude, so the counter is flat by definition
+			// and the drain is finishing work the counter cannot see — the carve
+			// pass it serializes behind still has manifest rows to reap, and a
+			// local-only store never moves the counter at all. Cancelling here
+			// aborts a live drain and reports it as a stalled remote. Keep
+			// waiting instead; the caller's own request deadline still bounds it.
+			if h.runtime.UnsyncedBytes() == 0 {
+				logger.Warn("Drain uploads: no upload concluded for the idle window, but nothing is left unsynced; still waiting for the drain to return",
+					"idle_window", h.drainStallTimeout)
+				idleFor = 0
+				continue
+			}
+			cancel()
+			return <-drainDone, true // wait for the drain to unwind on ctx cancel
 		}
 	}
 }

--- a/internal/controlplane/api/handlers/system_test.go
+++ b/internal/controlplane/api/handlers/system_test.go
@@ -15,11 +15,13 @@ import (
 )
 
 // fakeDrainRuntime is a minimal drainRuntime test double. drainFn overrides
-// DrainAllUploads; uploadProgressFn overrides UploadProgress. The zero value
-// drains instantly with no error and reports no progress.
+// DrainAllUploads; uploadProgressFn overrides UploadProgress; unsyncedBytesFn
+// overrides UnsyncedBytes. The zero value drains instantly with no error,
+// reports no progress, and reports a non-empty backlog.
 type fakeDrainRuntime struct {
 	drainFn          func(ctx context.Context) error
 	uploadProgressFn func() int64
+	unsyncedBytesFn  func() int64
 }
 
 func (f *fakeDrainRuntime) DrainAllUploads(ctx context.Context) error {
@@ -34,6 +36,15 @@ func (f *fakeDrainRuntime) UploadProgress() int64 {
 		return f.uploadProgressFn()
 	}
 	return 0
+}
+
+func (f *fakeDrainRuntime) UnsyncedBytes() int64 {
+	if f.unsyncedBytesFn != nil {
+		return f.unsyncedBytesFn()
+	}
+	// Default to a backlog so the zero value keeps the watchdog armed: tests
+	// that assert a stall trips do not have to opt in.
+	return 1
 }
 
 // newSystemRouterWithGlobalTimeout mirrors the production router's short global
@@ -173,6 +184,60 @@ func TestSystemHandler_DrainUploads_StallReturns504(t *testing.T) {
 	}
 	if rr.Code != http.StatusGatewayTimeout {
 		t.Fatalf("status = %d, want 504 for a stalled drain: body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestSystemHandler_DrainUploads_NoBacklogIsNotAStall covers the tail of a
+// drain: the upload counter goes flat as soon as the last block lands, but the
+// drain runs on past that — the carve pass it waits behind still has manifest rows to
+// reap, and none of that concludes an upload attempt. Judging that window by
+// the counter alone cancels a live drain and reports the remote as stalled. So
+// once nothing is left unsynced the watchdog must keep waiting, and the drain
+// must be allowed to return its own 200.
+func TestSystemHandler_DrainUploads_NoBacklogIsNotAStall(t *testing.T) {
+	release := make(chan struct{})
+	var cancelled atomic.Bool
+	fake := &fakeDrainRuntime{
+		// Nothing left to upload: no attempt can conclude, so the counter is
+		// flat by definition rather than because the remote wedged.
+		unsyncedBytesFn: func() int64 { return 0 },
+		drainFn: func(ctx context.Context) error {
+			select {
+			case <-release:
+				return nil
+			case <-ctx.Done():
+				cancelled.Store(true)
+				return ctx.Err()
+			}
+		},
+	}
+	h := &SystemHandler{runtime: fake, drainStallTimeout: 20 * time.Millisecond}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/drain-uploads", nil)
+	rr := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		h.DrainUploads(rr, req)
+		close(done)
+	}()
+
+	// Outlast several stall windows before letting the drain finish.
+	time.Sleep(150 * time.Millisecond)
+	if cancelled.Load() {
+		t.Fatal("watchdog cancelled a drain with nothing left unsynced")
+	}
+	close(release)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("drain did not return")
+	}
+	if cancelled.Load() {
+		t.Fatal("watchdog cancelled a drain with nothing left unsynced")
+	}
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: body=%s", rr.Code, rr.Body.String())
 	}
 }
 

--- a/internal/controlplane/api/handlers/system_writedeadline_test.go
+++ b/internal/controlplane/api/handlers/system_writedeadline_test.go
@@ -29,6 +29,10 @@ func (s *slowDrainRuntime) DrainAllUploads(ctx context.Context) error {
 
 func (s *slowDrainRuntime) UploadProgress() int64 { return s.progress.Load() }
 
+// A backlog the whole time: this test is about the write deadline, not the
+// idle watchdog, so the drain must stay under the watchdog's arm.
+func (s *slowDrainRuntime) UnsyncedBytes() int64 { return 1 }
+
 // TestDrainUploads_SurvivesServerWriteTimeout guards the cold-read benchmark
 // blocker: a drain legitimately runs longer than http.Server.WriteTimeout, so
 // the handler must clear this connection's write deadline. Without the clear the

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -1094,6 +1094,13 @@ func (r *Runtime) UploadProgress() int64 {
 	return r.sharesSvc.UploadProgress()
 }
 
+// UnsyncedBytes returns the local bytes not yet mirrored to a remote across all
+// per-share BlockStores. The drain-uploads handler reads it to distinguish a
+// drain with nothing left to upload from one whose remote has stalled.
+func (r *Runtime) UnsyncedBytes() int64 {
+	return r.sharesSvc.UnsyncedBytes()
+}
+
 // GetBlockStoreStats returns block store statistics, optionally filtered by share name.
 func (r *Runtime) GetBlockStoreStats(shareName string) (*shares.BlockStoreStatsResponse, error) {
 	return r.sharesSvc.GetBlockStoreStats(shareName)

--- a/pkg/controlplane/runtime/shares/blockstore_ops.go
+++ b/pkg/controlplane/runtime/shares/blockstore_ops.go
@@ -188,6 +188,28 @@ func (s *Service) UploadProgress() int64 {
 	return total
 }
 
+// UnsyncedBytes returns the local bytes not yet mirrored to a remote, summed
+// across every share's block store.
+//
+// The drain-uploads watchdog reads it to tell a stalled drain from one whose
+// uploads are simply finished: with nothing unsynced left, no upload attempt
+// CAN conclude, so a flat UploadProgress is the expected reading rather than
+// evidence the remote has wedged. Uses the lite stats — the per-block-state
+// walk the full snapshot performs is a whole-manifest scan, far too expensive
+// for a supervisor.
+func (s *Service) UnsyncedBytes() int64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var total int64
+	for _, share := range s.registry {
+		if share.BlockStore != nil {
+			total += share.BlockStore.GetStatsLite().UnsyncedBytes
+		}
+	}
+	return total
+}
+
 // ShareBlockStoreStats holds block store statistics for a single share.
 type ShareBlockStoreStats struct {
 	ShareName string                 `json:"share_name"`


### PR DESCRIPTION
## What was wrong

`POST /api/v1/system/drain-uploads` is bounded by inactivity, not wall-clock: an idle
watchdog samples `UploadProgress()` — a monotonic count of concluded mirror attempts —
and cancels the drain when that count stays flat for `drainStallTimeout` (5m default).

That counter only moves when an upload attempt concludes. A drain also spends time in
phases that conclude none, and those read identically to a wedged remote from the
watchdog's seat. So a drain that has already made everything durable gets cancelled
while it is still alive, and the client is told the remote stalled.

The issue guessed an empty wait set — a zero-work drain blocking on a condition nothing
signals. That is not what happens. **A zero-work drain returns immediately** (measured:
0s on develop). The drain in the report was not waiting on a signal; it was waiting for
a lock.

## What the drain was actually doing

Reproduced on `origin/develop` at the engine level — no S3, memory remote, default
chunk params, so this is neither S3-specific nor specific to the packing branch it was
observed on. Workload: 256 MiB sequential write, drain, then scattered 4 KiB random
overwrites (the `rand-write-4k` shape), then drain again. That second drain takes
**5m41s against an in-memory remote** — so the time is not upload time. Goroutine dump
from the same harness while that drain sat blocked:

```
goroutine 41097 [sync.Mutex.Lock]:                      <- the explicit drain
  journal.(*Store).Carve            carve.go:178        <- sh.carveMu.Lock()
  engine.(*Store).DrainAllUploads   flush.go:65

goroutine 54739 [chan send]:                            <- holds that shard's carveMu
  errgroup.(*Group).Go
  journal.(*Store).carveFile        carve.go:285
  journal.(*Store).Carve            carve.go:184
  engine.(*Syncer).carvePass.func2  carve_dispatch.go:120

goroutine 2732263 [sync.Mutex.Lock]:                    <- and its runs, x8
  engine.reapSupersededManifest     blocksink.go:195    <- the per-payload stripe lock
  journal.(*Store).carveRun         carve.go:529

goroutine 2706005 [runnable]:                           <- the one actually working
  badger.listFileChunksTxn          objects.go:748
```

The background carve dispatcher is mid-pass on the same shard, holding `sh.carveMu`.
Its runs each end in `ReapSupersededManifest`, which serializes on one per-payload
stripe mutex and costs a whole-manifest `ListFileChunks` plus a full `File.Blocks`
re-projection — both already marked `ponytail:` as O(n)-per-run. On a file re-chunked
by scattered 4 KiB writes there are thousands of such runs against a manifest of
hundreds of thousands of rows. None of it concludes an upload attempt, and `carveMu`
is a plain mutex, so the explicit drain simply waits.

`flipUpTo` marks records synced as each block commits, and the reaps run *after* the
flips, inside the same `carveMu`-held pass. So `unsynced_bytes` reaches zero on the
last flip while the pass — and therefore the drain waiting behind it — still has
minutes of manifest work left. That is the reported state, and the rig's own stats
timeline shows it directly:

```
19:29:20  unsynced=34MiB   completed_syncs=1416  blocks_remote=210725
19:29:38  unsynced=0MiB    completed_syncs=1420  blocks_remote=212438
19:29:56  unsynced=0MiB    completed_syncs=1420  blocks_remote=212438
   ... every sample identical for five minutes ...
19:34:11  unsynced=0MiB    completed_syncs=1420  blocks_remote=212438
19:34:25  [ERROR] Drain uploads failed error=context canceled duration=6m42s stalled=true
          upload_attempts_concluded=546
```

Scope of each piece of evidence, stated plainly: the local reproduction pins the
blocking mechanism and shows a single drain legitimately running for many minutes with
no network involved; the rig timeline supplies the end state (`unsynced_bytes: 0`, a
live upload counter frozen for five minutes). I did not reproduce the two together
locally — that needs the rig's manifest scale.

Two corrections to the report while we are here. "One server log line across six
minutes" is not evidence of a wedge: that server ran at WARN level (its log has 300
ERROR and 32 WARN lines and **zero** INFO), so a busy metadata phase is silent by
construction. And "the work finished" is only half true — the *upload* work finished at
19:29:38; the carve had not.

## The fix

Gate the stall trip on there still being something an upload could conclude. With
nothing unsynced left the counter is flat by definition, so it carries no information
about whether the drain is alive — keep waiting instead of cancelling.

`Runtime.UnsyncedBytes()` sums `GetStatsLite().UnsyncedBytes` across shares (lite: the
full snapshot's per-block-state walk is a whole-manifest scan, far too expensive for a
supervisor). The genuine-stall 504 is unchanged: unsynced bytes outstanding and nothing
concluding still means the remote has wedged.

This also covers the local-only case the handler's own comment already flagged —
`SyncCounts` returns `(0, 0)` with no remote, so such a store presents a permanently
flat counter and could never have drained through this endpoint without tripping.

Not fixed with a timeout, per the issue. Not fixed by making the drain preempt the
background carve either: that serialization on `carveMu` is deliberate, and breaking it
would let both passes pack the same chunks.

Residual risk, stated plainly: a drain that genuinely deadlocks with nothing unsynced
now waits instead of returning 504. The caller's own request deadline still aborts it
(a client disconnect cancels the drain), and each idle window now logs a WARN naming
the state, so it is visible rather than silent.

## Not fixed here

The reap cost that makes this window minutes long — `ReapSupersededManifest` and
`ManifestRowEndAfter` each doing a full manifest scan per carve run, all serialized on
one stripe lock — is a separate, real defect. Both already carry `ponytail:` markers
naming that ceiling, and the area is being reworked. This PR does not touch it.

## Verification

- `go build ./... && go vet ./... && gofmt -l` clean.
- New regression test `TestSystemHandler_DrainUploads_NoBacklogIsNotAStall`: a drain that
  outlasts several idle windows with nothing unsynced must not be cancelled and must
  return its own 200. Fails before this change with the reported signature
  (`Drain uploads failed error=context canceled ... stalled=true`), passes after.
- `TestSystemHandler_DrainUploads_StallReturns504` still passes — the real-stall path is
  untouched (the test double now reports a backlog, which is what makes it a stall).

Closes #2090.
