### PR TITLE
fix(journal): persist Invalidate's cold demotion before marking the interval

### DIFF
--- a/pkg/block/journal/evict_test.go
+++ b/pkg/block/journal/evict_test.go
@@ -489,11 +489,10 @@ func TestConcurrentWriteEvictRace(t *testing.T) {
 	wg.Wait()
 }
 
-// TestInvalidatedRangeSurvivesEviction pins the durability of a demotion.
-// Invalidate is the one path that marks an interval cold while its record is
-// still live in a segment on disk, and every reclaim path treats a cold interval
-// as owning nothing there — so without a durable marker the reclaim unlinks the
-// only copy and the range comes back from a restart as a hole that reads zeros.
+// TestInvalidatedRangeSurvivesEviction pins the durability of a demotion: the
+// segment still holding the demoted range is evicted, so only a cold-log marker
+// can carry it across the restart. Without one the range comes back a hole that
+// reads zeros.
 func TestInvalidatedRangeSurvivesEviction(t *testing.T) {
 	dir := t.TempDir()
 	cfg := Config{ShardCount: 1, SegmentSize: minSegmentSize}

--- a/pkg/block/journal/evict_test.go
+++ b/pkg/block/journal/evict_test.go
@@ -488,3 +488,47 @@ func TestConcurrentWriteEvictRace(t *testing.T) {
 	}()
 	wg.Wait()
 }
+
+// TestInvalidatedRangeSurvivesEviction pins the durability of a demotion.
+// Invalidate is the one path that marks an interval cold while its record is
+// still live in a segment on disk, and every reclaim path treats a cold interval
+// as owning nothing there — so without a durable marker the reclaim unlinks the
+// only copy and the range comes back from a restart as a hole that reads zeros.
+func TestInvalidatedRangeSurvivesEviction(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{ShardCount: 1, SegmentSize: minSegmentSize}
+	ctx := context.Background()
+
+	s, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := s.Hydrate(ctx, "f", 0, bytes.Repeat([]byte{0x5A}, chunk256), 0); err != nil {
+		t.Fatalf("Hydrate: %v", err)
+	}
+	fillUntilSealed(t, s, "f", true, 2) // seal the segment holding the target
+
+	if err := s.Invalidate(ctx, "f", 0, chunk256); err != nil {
+		t.Fatalf("Invalidate: %v", err)
+	}
+	if _, err := s.Evict(ctx, 1<<30); err != nil {
+		t.Fatalf("Evict: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	s2, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	t.Cleanup(func() { _ = s2.Close() })
+
+	_, st, err := s2.ReadAt(ctx, "f", 0, make([]byte, chunk256))
+	if err != nil {
+		t.Fatalf("ReadAt after restart: %v", err)
+	}
+	if st.Hole || !st.Cold {
+		t.Fatalf("invalidated range must come back cold, not a hole: %+v", st)
+	}
+}

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -1182,6 +1182,18 @@ func (s *Store) RestoreToVersion(ctx context.Context, v uint64) error {
 // This is what lets a hydrate stay a fill rather than an overwrite: a caller
 // that has proven the local bytes bad demotes them first, and the re-fetch then
 // lands in a range the journal no longer claims to hold.
+//
+// The markers are persisted to the cold log FIRST, for the same reason eviction
+// persists them first: this is the one path that marks an interval cold while
+// its record is still live in a segment on disk, and every path that reclaims a
+// segment — eviction, the emptied-segment sweep, GC repack — treats a cold
+// interval as owning nothing there. Without a durable marker the reclaim unlinks
+// the only copy and a restart finds neither a record nor a marker, so the range
+// comes back a hole and reads zeros. Persisting first can at worst leave a
+// marker for bytes that are still local, which costs a needless remote fetch.
+//
+// A failed append leaves the interval warm and returns the error, so the caller's
+// read fails closed rather than proceeding on a demotion the store cannot keep.
 func (s *Store) Invalidate(_ context.Context, id FileID, off, length int64) error {
 	if s.closed.Load() {
 		return errClosed
@@ -1191,11 +1203,34 @@ func (s *Store) Invalidate(_ context.Context, id FileID, off, length int64) erro
 	}
 	end := off + length
 	sh := s.shardFor(id)
+	// ponytail: the cold-log fsync runs under the shard lock, so it stalls the
+	// shard for its duration. This path only fires on a record that failed its
+	// checksum, so the contention is bounded by how often the local tier rots;
+	// split it into scan/append/flip like evictSegment if that stops being rare.
 	sh.mu.Lock()
 	defer sh.mu.Unlock()
 	fi := sh.index[id]
 	if fi == nil {
 		return nil
+	}
+	var entries []coldEntry
+	for k := range fi.ivs {
+		iv := &fi.ivs[k]
+		if iv.end() <= off || iv.fileOff >= end || iv.cold || !iv.synced {
+			continue
+		}
+		entries = append(entries, coldEntry{
+			id:      id,
+			fileOff: iv.fileOff,
+			length:  iv.length,
+			version: iv.version,
+		})
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+	if err := s.appendCold(entries); err != nil {
+		return err
 	}
 	for k := range fi.ivs {
 		iv := &fi.ivs[k]

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -1183,14 +1183,13 @@ func (s *Store) RestoreToVersion(ctx context.Context, v uint64) error {
 // that has proven the local bytes bad demotes them first, and the re-fetch then
 // lands in a range the journal no longer claims to hold.
 //
-// The markers are persisted to the cold log FIRST, for the same reason eviction
-// persists them first: this is the one path that marks an interval cold while
-// its record is still live in a segment on disk, and every path that reclaims a
-// segment — eviction, the emptied-segment sweep, GC repack — treats a cold
-// interval as owning nothing there. Without a durable marker the reclaim unlinks
-// the only copy and a restart finds neither a record nor a marker, so the range
-// comes back a hole and reads zeros. Persisting first can at worst leave a
-// marker for bytes that are still local, which costs a needless remote fetch.
+// The markers are persisted to the cold log before the flip. This is the one
+// path that marks an interval cold while its record is still live in a segment,
+// and every path that reclaims a segment — eviction, the emptied-segment sweep,
+// GC repack — treats a cold interval as owning nothing there, so without a
+// durable marker the reclaim unlinks the only copy and a restart finds the range
+// a hole that reads zeros. Persisting first can at worst leave a marker for
+// bytes that are still local, which costs a needless remote fetch.
 //
 // A failed append leaves the interval warm and returns the error, so the caller's
 // read fails closed rather than proceeding on a demotion the store cannot keep.
@@ -1213,12 +1212,16 @@ func (s *Store) Invalidate(_ context.Context, id FileID, off, length int64) erro
 	if fi == nil {
 		return nil
 	}
-	var entries []coldEntry
+	var (
+		entries []coldEntry
+		hits    []int
+	)
 	for k := range fi.ivs {
 		iv := &fi.ivs[k]
 		if iv.end() <= off || iv.fileOff >= end || iv.cold || !iv.synced {
 			continue
 		}
+		hits = append(hits, k)
 		entries = append(entries, coldEntry{
 			id:      id,
 			fileOff: iv.fileOff,
@@ -1232,12 +1235,8 @@ func (s *Store) Invalidate(_ context.Context, id FileID, off, length int64) erro
 	if err := s.appendCold(entries); err != nil {
 		return err
 	}
-	for k := range fi.ivs {
-		iv := &fi.ivs[k]
-		if iv.end() <= off || iv.fileOff >= end || iv.cold || !iv.synced {
-			continue
-		}
-		iv.cold = true
+	for _, k := range hits {
+		fi.ivs[k].cold = true
 	}
 	return nil
 }

--- a/test/crash/invalidate-cold-loss.sh
+++ b/test/crash/invalidate-cold-loss.sh
@@ -254,6 +254,13 @@ log "evicted"
 # journal directory with no remote, and it is what separates the two states:
 # a range that kept its marker reads cold and FAILS CLOSED, while a range that
 # lost it reads as a hole and is zero-filled with no error at any layer.
+# Bring the remote back up first. It only had to be down at the heal, and the
+# detach drains uploads through it — against a stopped remote that drain times
+# out, the rebind fails, and the read failures below would then be as easily
+# blamed on a broken rebind as on a lost marker. With it up the detach is clean,
+# and the probes fail only because the share has no remote tier at all.
+start_minio || fail "minio did not come back before the detach"
+
 TOKEN=$(python3 -c "
 import json
 d = json.load(open('$WORK/cfg/dfsctl/config.json'))

--- a/test/crash/invalidate-cold-loss.sh
+++ b/test/crash/invalidate-cold-loss.sh
@@ -166,10 +166,13 @@ mount_smb || fail "cifs mount"
 cat > "$WORK/records.py" <<'PY'
 import hashlib, os, sys
 
-def body(i, record):
+def marker(i):
     head = ("REC%08d" % i).encode()
-    b = head + hashlib.sha256(head).digest()
-    return b + b"\xa5" * (record - len(b))
+    return head + hashlib.sha256(head).digest()
+
+def body(i, record):
+    m = marker(i)
+    return m + b"\xa5" * (record - len(m))
 
 if sys.argv[1] == "write":
     path, record, count = sys.argv[2], int(sys.argv[3]), int(sys.argv[4])
@@ -177,48 +180,29 @@ if sys.argv[1] == "write":
         for i in range(count):
             f.write(body(i, record))
         os.fsync(f.fileno())
-elif sys.argv[1] == "verify":
-    path, record, count = sys.argv[2], int(sys.argv[3]), int(sys.argv[4])
-    data = open(path, "rb").read()
-    zeros = garbage = short = 0
-    for i in range(count):
-        got = data[i * record:(i + 1) * record]
-        if len(got) < record:
-            short += 1
-        elif got == body(i, record):
-            pass
-        elif got == b"\x00" * len(got):
-            zeros += 1
-        else:
-            garbage += 1
-    print("bytes=%d want=%d zeros=%d garbage=%d short=%d"
-          % (len(data), record * count, zeros, garbage, short))
-    print("VERDICT=%s" % ("PASS" if (zeros or garbage or short) == 0 else "FAIL"))
 elif sys.argv[1] == "corrupt":
-    # Flip a byte inside the target record's payload as it sits in a segment.
-    # The record's body CRC covers the payload, so the next warm read of it
-    # fails verification with the interval already live in the index — which is
-    # the only way to reach the demotion this rig tests.
-    segdir, record = sys.argv[2], int(sys.argv[3])
-    marker = ("REC%08d" % int(sys.argv[4])).encode() + \
-             hashlib.sha256(("REC%08d" % int(sys.argv[4])).encode()).digest()
+    # Flip a byte of the target record's filler as it sits in a segment. The
+    # record's body CRC covers the payload, so the next warm read of it fails
+    # verification with the interval already live in the index — which is the
+    # only way to reach the demotion this rig tests.
+    segdir, m = sys.argv[2], marker(int(sys.argv[3]))
     segs = []
     for root, _, names in os.walk(segdir):
         segs += [os.path.join(root, n) for n in names if n.endswith(".seg")]
     for p in sorted(segs):
         with open(p, "r+b") as f:
             blob = f.read()
-            at = blob.find(marker)
+            at = blob.find(m)
             if at < 0:
                 continue
-            spot = at + 64
+            spot = at + len(m)
             f.seek(spot)
             f.write(bytes([blob[spot] ^ 0xFF]))
             f.flush()
             os.fsync(f.fileno())
         print("corrupted %s at %d" % (p, spot))
         sys.exit(0)
-    sys.exit("marker for record %s not found in any segment" % sys.argv[4])
+    sys.exit("marker for record %s not found in any segment" % sys.argv[3])
 PY
 
 python3 "$WORK/records.py" write "$WORK/smb/cold.bin" "$RECORD" "$RECORDS" || fail "write"
@@ -242,7 +226,7 @@ start_server || fail "server did not come back"
 mount_smb || fail "cifs remount"
 
 # --- corrupt one record in place, with the server running -------------------
-python3 "$WORK/records.py" corrupt "$DATA/blocks" "$RECORD" "$TARGET_REC" \
+python3 "$WORK/records.py" corrupt "$DATA/blocks" "$TARGET_REC" \
   || fail "could not corrupt the target record"
 
 # --- take the remote away, so the heal's re-fetch fails ---------------------

--- a/test/crash/invalidate-cold-loss.sh
+++ b/test/crash/invalidate-cold-loss.sh
@@ -1,0 +1,331 @@
+#!/usr/bin/env bash
+# Cold-marker durability rig: does a range demoted by a failed corrupt-read heal
+# survive the eviction of the segment that still holds it?
+#
+# The journal demotes a range to cold when a warm read finds its on-disk record
+# corrupt, then re-fetches it from the remote store. When that re-fetch fails
+# (remote unreachable) the range stays cold in memory while its record is still
+# live in a segment on disk. Eviction retires that segment. If the demotion was
+# never written to cold.log, a restart finds neither a record nor a marker and
+# the range reads back as zeros — right size, no error at any layer.
+#
+# The rig drives that exact sequence against a real server over SMB:
+#
+#   1. write self-identifying 4096-byte records, let carve upload them
+#   2. restart clean, so every record is warm on disk and no cache is holding it
+#   3. corrupt one record's payload in place while the server runs, so the next
+#      read of it fails its body CRC with the interval already in the index
+#   4. stop the remote, so the heal's re-fetch fails and the range stays cold
+#   5. read it — the read must fail loudly; that is the demotion firing
+#   6. evict, retiring the segment that held the only copy
+#   7. detach the remote tier, restart, and probe the demoted range
+#
+# Step 7 is what makes the loss observable. While a remote store is attached,
+# the engine reconciles a hole against the FileChunk manifest and the bytes come
+# back either way — the lost marker costs only a needless fetch. Detached, a
+# range that kept its marker fails closed and a range that lost it reads zeros.
+#
+# Verdict: the demoted range must refuse the read, exactly as the neighbouring
+# range that kept its marker does. The demoted range reading back as zeros while
+# its neighbour refuses is the bug.
+#
+# Requires: root, Linux, cifs-utils, python3, a minio binary.
+#
+# sudo ./invalidate-cold-loss.sh /path/to/dfs /path/to/dfsctl [/path/to/minio]
+
+set -u
+
+DFS="${1:?path to dfs binary required}"
+DFSCTL="${2:?path to dfsctl binary required}"
+MINIO="${3:-/root/minio}"
+
+export PATH="/usr/sbin:/sbin:/usr/bin:/bin:$PATH"
+
+WORK=/var/tmp/dfs-invalidate
+DATA=$WORK/data
+BUCKET=dfs
+API=18098
+SMBP=12456
+S3PORT=19000
+RECORD=4096
+RECORDS=1024          # 4 MiB
+TARGET_REC=200        # the record whose on-disk payload gets corrupted
+
+rand() { head -c "$1" /dev/urandom | base64 | tr -dc 'A-Za-z0-9' | head -c "$1"; }
+PW=$(rand 24); SECRET=$(rand 48)
+S3KEY=minioadmin; S3SECRET=minioadmin
+
+log() { echo "[$(date +%H:%M:%S)] $*"; }
+fail() { log "FAIL: $*"; exit 1; }
+
+kill_pidfile() {
+  local f=$1 pid
+  pid=$(cat "$f" 2>/dev/null) || return 0
+  [ -n "$pid" ] || return 0
+  kill -9 "$pid" 2>/dev/null
+  for _ in {1..100}; do kill -0 "$pid" 2>/dev/null || return 0; sleep 0.1; done
+  return 1
+}
+
+# The server is killed before its mount is torn down, so the unmount is lazy:
+# a plain umount would block on a reply that is never coming.
+umount_smb() { umount -l "$WORK/smb" 2>/dev/null; }
+
+start_minio() {
+  mkdir -p "$WORK/minio/$BUCKET"
+  MINIO_ROOT_USER=$S3KEY MINIO_ROOT_PASSWORD=$S3SECRET \
+    setsid "$MINIO" server --address "127.0.0.1:$S3PORT" "$WORK/minio" \
+    >"$WORK/minio.log" 2>&1 &
+  echo $! > "$WORK/minio.pid"
+  for _ in {1..100}; do
+    curl -sf "http://127.0.0.1:$S3PORT/minio/health/live" >/dev/null 2>&1 && return 0
+    sleep 0.2
+  done
+  return 1
+}
+stop_minio() { kill_pidfile "$WORK/minio.pid"; }
+
+start_server() {
+  DITTOFS_ADMIN_INITIAL_PASSWORD=$PW setsid "$DFS" start --foreground \
+    --config "$WORK/config.yaml" --pid-file "$WORK/dfs.pid" \
+    --log-file "$WORK/dfs.log" >>"$WORK/dfs.out" 2>&1 &
+  for _ in {1..150}; do
+    curl -sf "http://127.0.0.1:$API/health" >/dev/null 2>&1 && return 0
+    sleep 0.3
+  done
+  return 1
+}
+# Graceful stop, so shutdown flushes whatever it flushes; the bug under test is
+# a lost durable marker, not a lost write, so a clean stop is the honest one.
+stop_server() {
+  local pid
+  pid=$(cat "$WORK/dfs.pid" 2>/dev/null) || return 0
+  [ -n "$pid" ] || return 0
+  kill -TERM "$pid" 2>/dev/null
+  for _ in {1..150}; do kill -0 "$pid" 2>/dev/null || return 0; sleep 0.2; done
+  kill -9 "$pid" 2>/dev/null
+  return 0
+}
+
+mount_smb() {
+  for _ in {1..40}; do
+    mount -t cifs "//127.0.0.1/cold" "$WORK/smb" \
+      -o "port=$SMBP,username=admin,password=$PW,vers=3.1.1,cache=none" 2>/dev/null && return 0
+    sleep 0.5
+  done
+  return 1
+}
+
+dctl() { XDG_CONFIG_HOME="$WORK/cfg" "$DFSCTL" "$@"; }
+
+cleanup() {
+  umount_smb
+  stop_server
+  kill_pidfile "$WORK/dfs.pid"
+  stop_minio
+}
+trap cleanup EXIT INT TERM
+
+# --- setup -----------------------------------------------------------------
+cleanup
+rm -rf "$WORK"; mkdir -p "$WORK/cfg" "$DATA/meta" "$DATA/blocks" "$WORK/smb"
+
+start_minio || fail "minio never became ready"
+
+cat > "$WORK/config.yaml" <<CFG
+logging: {level: INFO, format: text, output: $WORK/dfs.log}
+controlplane:
+  host: 127.0.0.1
+  port: $API
+  jwt: {secret: "$SECRET"}
+database: {type: sqlite, sqlite: {path: "$WORK/controlplane.db"}}
+CFG
+
+start_server || fail "server never became ready"
+dctl login --server "http://127.0.0.1:$API" --username admin --password "$PW" >/dev/null \
+  || fail "login"
+dctl store metadata add --name meta --type badger --db-path "$DATA/meta" >/dev/null \
+  || fail "metadata store"
+
+# dirty_expire_seconds forces carve to run promptly, so the records are synced to
+# the remote (and their segments evictable) without waiting on the default age.
+dctl store block local add --name local --type fs \
+  --config "{\"path\": \"$DATA/blocks\", \"dirty_expire_seconds\": 2}" >/dev/null \
+  || fail "local block store"
+
+dctl store block remote add --name s3 --type s3 \
+  --config "{\"bucket\": \"$BUCKET\", \"region\": \"us-east-1\", \"endpoint\": \"http://127.0.0.1:$S3PORT\", \"access_key_id\": \"$S3KEY\", \"secret_access_key\": \"$S3SECRET\", \"allow_private_endpoint\": true}" >/dev/null \
+  || fail "remote block store"
+
+dctl share create --name /cold --metadata meta --local local \
+  --remote s3 --default-permission read-write >/dev/null || fail "share"
+dctl adapter enable smb --port $SMBP >/dev/null || fail "smb adapter"
+mount_smb || fail "cifs mount"
+
+# --- write -----------------------------------------------------------------
+cat > "$WORK/records.py" <<'PY'
+import hashlib, os, sys
+
+def body(i, record):
+    head = ("REC%08d" % i).encode()
+    b = head + hashlib.sha256(head).digest()
+    return b + b"\xa5" * (record - len(b))
+
+if sys.argv[1] == "write":
+    path, record, count = sys.argv[2], int(sys.argv[3]), int(sys.argv[4])
+    with open(path, "wb", buffering=0) as f:
+        for i in range(count):
+            f.write(body(i, record))
+        os.fsync(f.fileno())
+elif sys.argv[1] == "verify":
+    path, record, count = sys.argv[2], int(sys.argv[3]), int(sys.argv[4])
+    data = open(path, "rb").read()
+    zeros = garbage = short = 0
+    for i in range(count):
+        got = data[i * record:(i + 1) * record]
+        if len(got) < record:
+            short += 1
+        elif got == body(i, record):
+            pass
+        elif got == b"\x00" * len(got):
+            zeros += 1
+        else:
+            garbage += 1
+    print("bytes=%d want=%d zeros=%d garbage=%d short=%d"
+          % (len(data), record * count, zeros, garbage, short))
+    print("VERDICT=%s" % ("PASS" if (zeros or garbage or short) == 0 else "FAIL"))
+elif sys.argv[1] == "corrupt":
+    # Flip a byte inside the target record's payload as it sits in a segment.
+    # The record's body CRC covers the payload, so the next warm read of it
+    # fails verification with the interval already live in the index — which is
+    # the only way to reach the demotion this rig tests.
+    segdir, record = sys.argv[2], int(sys.argv[3])
+    marker = ("REC%08d" % int(sys.argv[4])).encode() + \
+             hashlib.sha256(("REC%08d" % int(sys.argv[4])).encode()).digest()
+    segs = []
+    for root, _, names in os.walk(segdir):
+        segs += [os.path.join(root, n) for n in names if n.endswith(".seg")]
+    for p in sorted(segs):
+        with open(p, "r+b") as f:
+            blob = f.read()
+            at = blob.find(marker)
+            if at < 0:
+                continue
+            spot = at + 64
+            f.seek(spot)
+            f.write(bytes([blob[spot] ^ 0xFF]))
+            f.flush()
+            os.fsync(f.fileno())
+        print("corrupted %s at %d" % (p, spot))
+        sys.exit(0)
+    sys.exit("marker for record %s not found in any segment" % sys.argv[4])
+PY
+
+python3 "$WORK/records.py" write "$WORK/smb/cold.bin" "$RECORD" "$RECORDS" || fail "write"
+log "wrote $((RECORD * RECORDS)) bytes"
+
+# Wait for carve to push every byte to the remote: the demotion under test only
+# fires on a SYNCED interval, and only a fully-synced segment is evictable.
+for _ in {1..120}; do
+  up=$(find "$WORK/minio/$BUCKET" -type f 2>/dev/null | wc -l)
+  [ "$up" -gt 0 ] && break
+  sleep 1
+done
+[ "$up" -gt 0 ] || fail "carve never uploaded anything to the remote"
+sleep 8
+log "remote holds $(find "$WORK/minio/$BUCKET" -type f | wc -l) objects"
+
+# --- restart clean, so every read below goes to disk ------------------------
+umount_smb
+stop_server
+start_server || fail "server did not come back"
+mount_smb || fail "cifs remount"
+
+# --- corrupt one record in place, with the server running -------------------
+python3 "$WORK/records.py" corrupt "$DATA/blocks" "$RECORD" "$TARGET_REC" \
+  || fail "could not corrupt the target record"
+
+# --- take the remote away, so the heal's re-fetch fails ---------------------
+stop_minio
+log "remote stopped"
+
+# The read must fail: the local bytes failed their CRC and there is nothing to
+# heal from. That failure IS the demotion firing — it is what leaves the range
+# marked cold while its record is still live in a segment on disk.
+if dd if="$WORK/smb/cold.bin" of=/dev/null bs=$RECORD skip=$TARGET_REC count=1 2>"$WORK/read.err"; then
+  log "WARNING: the corrupt read succeeded; the demotion window may not have opened"
+else
+  log "corrupt read failed as expected: $(tail -1 "$WORK/read.err")"
+fi
+
+# --- evict, retiring the segment that holds the only copy -------------------
+dctl store block evict --share /cold --local-only 2>&1 | tail -3
+log "evicted"
+
+# --- detach the remote tier from the share ----------------------------------
+# A lost cold marker degrades the range to a POSIX hole, and readAtInternal
+# reconciles a hole against the FileChunk manifest whenever a remote store is
+# configured — which hides the loss for as long as one is. Detaching the remote
+# is a supported control-plane edit that rebuilds the engine over the SAME
+# journal directory with no remote, and it is what separates the two states:
+# a range that kept its marker reads cold and FAILS CLOSED, while a range that
+# lost it reads as a hole and is zero-filled with no error at any layer.
+TOKEN=$(python3 -c "
+import json
+d = json.load(open('$WORK/cfg/dfsctl/config.json'))
+print(d['contexts'][d['current_context']]['access_token'])
+")
+# The hot-reload half of this edit runs a drain against the stopped remote and
+# times out; the binding is still cleared, and the server says a restart is
+# required — which is the next thing the rig does. So the edit is judged by
+# whether the binding actually went away, not by the request's exit status.
+curl -s -X PUT "http://127.0.0.1:$API/api/v1/shares/cold" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"remote_block_store_id": ""}' --max-time 180 >/dev/null
+
+umount_smb
+stop_server
+start_server || fail "server did not come back after detach"
+grep -q "mode=remote-backed" <(tail -40 "$WORK/dfs.log") \
+  && fail "share still has a remote tier after the detach"
+log "remote tier detached from the share"
+mount_smb || fail "cifs remount after detach"
+
+# --- verify -----------------------------------------------------------------
+# Every range in the file is remote-only now, so a correct store refuses every
+# one of them. NEIGHBOUR is the control: it kept its marker either way, so it
+# must fail on both builds — that is what makes the target's result specific to
+# the demotion rather than to the detach.
+NEIGHBOUR=$((TARGET_REC + 1))
+probe() {
+  local rec=$1 out
+  out=$WORK/probe.$rec
+  if dd if="$WORK/smb/cold.bin" of="$out" bs=$RECORD skip="$rec" count=1 2>/dev/null; then
+    if [ ! -s "$out" ]; then
+      echo "empty"
+    elif python3 -c "import sys; sys.exit(0 if open('$out','rb').read().strip(b'\\x00') == b'' else 1)"; then
+      echo "ZEROS"
+    else
+      echo "data"
+    fi
+  else
+    echo "refused"
+  fi
+}
+
+target=$(probe "$TARGET_REC")
+neighbour=$(probe "$NEIGHBOUR")
+{
+  echo "target_record=$TARGET_REC read=$target"
+  echo "neighbour_record=$NEIGHBOUR read=$neighbour"
+  # The neighbour proves the store still refuses remote-only ranges at all; the
+  # target reading as zeros while it does is the marker that was lost.
+  if [ "$neighbour" != "refused" ]; then
+    echo "VERDICT=INCONCLUSIVE (control record did not fail closed)"
+  elif [ "$target" = "refused" ]; then
+    echo "VERDICT=PASS"
+  else
+    echo "VERDICT=FAIL"
+  fi
+} | tee "$WORK/result.txt"
+grep -q "VERDICT=PASS" "$WORK/result.txt"

--- a/test/crash/invalidate-cold-loss.sh
+++ b/test/crash/invalidate-cold-loss.sh
@@ -243,7 +243,14 @@ else
 fi
 
 # --- evict, retiring the segment that holds the only copy -------------------
-dctl store block evict --share /cold --local-only 2>&1 | tail -3
+# The verdict rests on this actually retiring the segment, so its exit status is
+# checked rather than piped away: an eviction that quietly failed would leave the
+# record on disk and the rig would then grade a run in which nothing was lost.
+if ! dctl store block evict --share /cold --local-only >"$WORK/evict.out" 2>&1; then
+  cat "$WORK/evict.out"
+  fail "evict"
+fi
+tail -3 "$WORK/evict.out"
 log "evicted"
 
 # --- detach the remote tier from the share ----------------------------------


### PR DESCRIPTION
`Invalidate` marked an interval cold in memory and returned, without appending to
`cold.log`. It is the **only** path that sets `cold` on an interval whose record is
still live in a segment on disk — and every path that reclaims a segment treats a
cold interval as owning nothing there:

| reclaim path | the cold check | effect on an Invalidate-demoted interval |
| --- | --- | --- |
| `evictSegment` scan | `!fi.ivs[k].cold` builds the cold-log entries | skips it, so no entry is written |
| `reclaimEmptied` | `if !iv.cold { liveSegs[...] }` | segment counts as dead, retired outright |
| `repackSegment` | `if iv.cold \|\| ... { continue }` | record is not relocated, source unlinked |
| `dropVictim` | `if !iv.cold && ...` | segment judged unreferenced, retired |

So the segment holding the only copy was unlinked, `applyColdLog` had nothing to
replay, and the range came back from a restart as a POSIX hole.

`evictSegment`'s own comment states the invariant this violated:

> The markers are persisted to the cold log FIRST, while the segment is still on
> disk: they are the only remaining record that those ranges hold data, so a crash
> between marking and unlinking must not be able to lose them.

## The fix

Append the cold entries before setting the bits, matching that persist-first
ordering. A failed append leaves the interval warm and returns the error, so the
read fails closed rather than proceeding on a demotion the store cannot keep.

This is the narrower of the issue's two suggestions, and the reclaim table above is
why it is also the more complete one: fixing the eviction scan would have left the
other three paths losing the same interval. One place, four callers.

## Verification

The issue was filed as a code-read finding with its load-bearing claim unreproduced,
so it was reproduced first, on a Debian VM against a real server over SMB, with two
builds of the same tree differing only in this commit. `test/crash/invalidate-cold-loss.sh`
drives: write and carve → restart clean → corrupt one record's payload in place while
the server runs → stop the remote so the heal's re-fetch fails → read (fails loudly,
which is the demotion firing) → evict, retiring the segment → restore the remote →
detach the remote tier → restart → probe two records.

```
                       pre-fix            post-fix
target record 200      read=ZEROS         read=refused
control record 201     read=refused       read=refused
cold.log              73656 B = 1023      73728 B = 1024 entries
VERDICT               FAIL               PASS
```

The file holds 1024 intervals. Pre-fix, exactly one of them — the range `Invalidate`
demoted — got no durable marker, and it is the one that reads back as 4096 bytes of
`0x00` with `dd` exiting 0. Record 201 is the control: it kept its marker, so it fails
closed on both builds, which is what makes the target's result specific to the demotion
rather than to the detach.

**The pre-fix failure is silent, not loud.** The server log is where this is decided,
because the two runs' rig output differs by one word but their server logs differ by one
line. Post-detach `still cold after hydrate` failures, by offset (record 200 = 819200,
record 201 = 823296):

```
pre-fix    at offset 823296                      <- control only
post-fix   at offset 819200, at offset 823296    <- control AND target
```

Pre-fix there is **no logged error at all** for the target's read: correct size, clean
zeros, `dd` exit 0, nothing at any layer. That is the silent failure the issue predicted
and the reason it belongs with #1850 / #1879 / #1888. The loud `chunk not found` at
819200 appears only on the fixed build — it is the fix working, the range failing closed
because the marker survived.

An earlier pass of the rig detached the remote while it was still stopped. The drain
inside `RebindShareBlockStore` then timed out (`context deadline exceeded`), the
hot-reload failed, and the server asked for the restart the rig performs anyway — so the
verdicts were unaffected, but a reviewer could reasonably have attributed the read
failures to the broken rebind rather than to a lost marker. The rig now restores the
remote before the detach; the rebind is clean (`rebind: failed` count: 0 in both runs)
and both verdicts are unchanged.

The same loss is pinned at the journal layer by `TestInvalidatedRangeSurvivesEviction`,
which reports `{Cold:false Hole:true}` before the fix and cold after, over a real on-disk
store closed and reopened.

## One correction to the issue

The issue's step 3 — "restart → range is gone → reads return zeros" — is not true on
its own. `readAtInternal` computes `reconcile := st.Cold || (st.Hole && bs.HasRemoteStore())`,
so while a remote store is attached the hole is reconciled against the `FileChunk`
manifest and the bytes come back; the lost marker costs only a needless fetch. An
initial run of the rig passed on the unfixed build for exactly that reason.

`HasRemoteStore()` is not an invariant, though. Clearing a share's remote tier
(`PUT /api/v1/shares/{name}` with an empty `remote_block_store_id`) rebuilds the engine
over the *same* journal directory with no remote, and from there the two states diverge
exactly as the issue described: a range that kept its marker reads cold and fails closed
with `ErrChunkNotFound`; a range that lost it reads as a hole and is zero-filled with no
error. **Cold is an error, a hole is silent zeros** — that is the delta this creates, and
it is what the rig now measures.

Two things make that worse rather than academic:

- The operator's own pre-detach safety check cannot see it. `OfflineReadiness` is built
  from `ColdExtents`, which iterates the intervals and skips `!iv.cold`. A lost marker
  leaves no interval at all, so it contributes zero — the check reports
  `RemoteOnlyBytes: 0` and `Safe() == true`, green-lighting the very detach that loses
  the bytes.
- It never self-heals. `seedColdIfNeeded` returns early once the share has no remote, and
  again on the one-shot `ColdSeeded` marker that was already set while the share *was*
  remote-backed. No restart re-seeds the hole.

The manifest is also not an unconditional backstop, which is worth saying because the
paragraph above leans on it. Probing that assumption while verifying this issue turned up
a separate carve-seam gap: a warm, synced, non-cold interval can end up with no
`FileChunk` row at all, when `extendRunToRowEnd` declines to extend a run past a later
dirty run while `ReapSupersededManifest` deletes the straddling row anyway. Not filed
here and out of scope for this PR — noted because it means the range this fix protects
can be one the manifest cannot recover either, which is the population where losing the
marker is worst.

## Notes

- The cold-log fsync now runs under the shard lock. This path fires only on a record that
  failed its checksum, so the contention is bounded by how often the local tier rots; a
  `ponytail:` marker names the scan/append/flip split as the upgrade if that stops being
  rare.
- `sh.mu → coldMu` is the same order `evictSegment` already takes, and nothing in the
  package takes `coldMu → sh.mu`.
- A duplicate entry (once here, once from a later `evictSegment`) is harmless: replay
  inserts by version and recovery compacts the log through `liveColdEntries`.

Closes #2084
