### PR TITLE
test(smbtorture): raise the budgets the truncation reporting has been pointing at, bound maxfid

### DIFF
--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -105,6 +105,15 @@ DittoFS's userspace virtual filesystem. They are listed in the
 [Permanently Unimplementable](#permanently-unimplementable-out-of-scope)
 appendix.
 
+One residual remains. `smb2.oplock` used to be cut short at 120s having graded
+28 of 42 tests, and `batch22b` was the test in flight when the axe fell — so its
+final elapsed value was never observed. With budget to finish, it fails by one
+second. Identical on both profiles.
+
+| Test Name | Category | Reason | Issue |
+|-----------|----------|--------|-------|
+| smb2.oplock.batch22b | Break timeout | The test blocks the holder's transport so no ack can arrive and requires the second open to complete within smbtorture's `oplocktimeout` (35s). DittoFS takes 36s: `oplock.c:2715` reports `te got 36 - should be between 0 and 35`. The wait itself is by design; overshooting the ceiling is not. Pre-existing, and unobservable while the suite was truncated. | [#2115](https://github.com/marmos91/dittofs/issues/2115) |
+
 ### Directory Leases (Partial Implementation)
 
 Directory leases (dirlease) are a separate feature from file leases.
@@ -199,8 +208,16 @@ outstanding known failures in this category.
 Lease V2 is implemented but many smbtorture lease tests still fail due to
 incomplete break notification delivery and multi-client coordination.
 
+The two rows below were not newly broken — they sit past the point where
+`smb2.lease` used to be cut short at 120s (it graded 25 of 45 tests), so they
+were being silently left ungraded rather than reported. Raising the budget made
+them visible; both fail identically on `memory` and `badger-fs`, so neither is a
+flake or a storage-backend artifact.
+
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
+| smb2.lease.v2_complex1 | Lease epoch | Break notification carries an over-incremented epoch: `lease.c:3792` wants `new_epoch 0x4715`, DittoFS sends `0x4716`. Pre-existing; surfaced when the suite was allowed to run past its old 120s cut. | [#2113](https://github.com/marmos91/dittofs/issues/2113) |
+| smb2.lease.rename_wait | Rename vs pending break | RENAME issued while a lease break is outstanding returns `NT_STATUS_INVALID_PARAMETER`; `lease.c:4160` requires `NT_STATUS_OK`. Pre-existing; same cause of invisibility. | [#2114](https://github.com/marmos91/dittofs/issues/2114) |
 
 ### Sessions (Remaining)
 
@@ -300,7 +317,6 @@ These entries remain in CI's known-failure set (so they don't break the build) b
 | smb2.timestamp_resolution.resolution1 | Timing-dependent (upstream-skipped) | Test source documents `~15ms` Windows timestamp resolution and warns of a `1/15` false-fail rate even on a low-latency reference SMB connection. Explicitly skipped by Samba's own selftest (`selftest/skip:69-70`: `^samba3.smb2.timestamp_resolution` / `^samba4.smb2.timestamp_resolution`) "preserved here for future SMB2 timestamps behaviour archaeologists". DittoFS classifies the same way upstream does. |
 | smb2.create.gentest | Generative impersonation matrix (upstream-skipped) | Brute-forces hundreds of `(create_disposition × create_options × ImpersonationLevel × attribute)` combinations expecting Windows-exact status codes. Explicitly listed in Samba's own selftest knownfail (`selftest/knownfail`: `^samba3.smb2.create.gentest`) — fails on Samba file-backed shares. The status-code surface mirrors Windows-internal IRP_MJ_CREATE behaviour, not MS-FSA. |
 | smb2.durable-open.delete_on_close2 | Durable DOC (upstream-skipped) | Reopens a durable handle that was opened with FILE_DELETE_ON_CLOSE, then asserts the post-reconnect delete-on-close + truncate-on-overwrite interaction matches Windows verbatim. Explicitly listed in Samba's own selftest knownfail (`selftest/knownfail`: `^samba3.smb2.durable-open.delete_on_close2`) — fails against Samba's own file-backed share, not just DittoFS. The disconnect path intentionally does NOT persist a durable handle carrying delete-on-close (the open is fully closed instead, so the stored content is not resurrected on reconnect); reproducing the exact Windows ordering of DOC-survives-reconnect has no MS-SMB2 spec mapping and is upstream-skipped. |
-| smb2.maxfid | smbtorture wall-clock budget | Test issues up to 65520 sequential synchronous CREATEs (Samba `source4/torture/smb2/maxfid.c:100`, controlled by `torture:maxopenfiles`). Total RTT-bound runtime exceeds the 60s per-test wall set by `run.sh` (STANDALONE_TESTS). DittoFS keeps CREATE succeeding throughout (no protocol-level handle-table cap), so the suite is killed mid-loop before reaching the cleanup phase. Raising the per-test wall to accommodate one stress test inflates full-suite runtime substantially without exercising a protocol gap. |
 | smb2.notify.mask-change | Samba notify-mask quirk | Asserts that, once a CHANGE_NOTIFY completion-filter mask has been armed on a directory handle, re-issuing CHANGE_NOTIFY with a different mask MUST observe the original mask only until the handle is closed (test source: `source4/torture/smb2/notify.c:771-772` — "Now try and change the mask to include other events. This should not work - once the mask is set on a directory h1 it seems to be fixed until the fnum is closed"). MS-SMB2 §3.3.5.19 does not specify mask-coalescing across separate CHANGE_NOTIFY requests on the same handle, and the test has a long-standing "never passed individually" history against DittoFS independent of test order. Surrounding scenarios (cross-tree dir/file rename plumbing, recursion-flag-mixed reqs on the same FID) are also Samba implementation conventions. |
 | smb2.dirlease.oplocks | smbtorture client crash | Bucket 11. smbtorture 4.22.6 **client** SIGSEGVs in this dirlease subtest and aborts the rest of the dirlease suite. `run.sh` runs `smb2.dirlease` per-subtest and skips `oplocks` (same workaround shape as `scan.scan`, #633). DittoFS is pure Go and not in the backtrace — not a server gap. |
 | smb2.replay.dhv2-pending1n-vs-violation-lease-close-windows | Windows replay ordering | Bucket 10. Windows-specific replayed-CREATE-vs-pending-break ordering; Samba's own source does not reproduce the `-windows` arm (fails on Samba too). The `-sane` arm (the conformant target) now passes (#749). |
@@ -332,6 +348,41 @@ These entries remain in CI's known-failure set (so they don't break the build) b
 `KNOWN_FAILURES_KERBEROS.md` now carries a single row (`smb2.reauth5`, an upstream Samba selftest knownfail) after the #686 Kerberos sweep harvested the stale multi-channel rows. It is loaded only when smbtorture runs with `--use-kerberos`, which the non-Kerberos v1.0 CI job (`.github/workflows/smb-conformance.yml`, running `./run.sh` without `--kerberos`) does not pass, so it does not gate v1.0.
 
 ## Changelog
+
+### 2026-08-25 — per-suite budgets: 3 pre-existing failures surfaced out of the ungraded tails
+
+`smb2.lease`, `smb2.multichannel` and `smb2.oplock` were being cut short at 120s
+on every profile, and `smb2.maxfid` never graded its single test at all.
+Measured end to end with enough budget to finish, they take 182/186s, 132s and
+145s (memory/badger-fs); `maxfid` opens handles until the server refuses, and
+smbtorture defaults that to 65520, so it is now bounded to 2000 and completes in
+5s/15s. The three suites move to the same 300s tier `smb2.replay` already had.
+
+Letting them finish is what made the following visible. **None is a regression** —
+each sits past the old cut point, so it was being left ungraded (inconclusive,
+not failed) and the job still reported `0 new failures`. All three fail
+identically on `memory` and `badger-fs`, so none is a flake or backend artifact.
+Each is listed above against an owning issue:
+
+- `smb2.lease.v2_complex1` — over-incremented break epoch (#2113). `lease` graded 25 of 45 before.
+- `smb2.lease.rename_wait` — RENAME during a pending break returns INVALID_PARAMETER (#2114).
+- `smb2.oplock.batch22b` — break completes at 36s against a 35s ceiling (#2115). `oplock` graded 28 of 42 before.
+
+`smb2.maxfid` is **dropped** from the Permanently Unimplementable appendix: it
+now passes. That entry had already identified `torture:maxopenfiles` as the knob
+and correctly refused to raise the wall for one stress test — bounding the test
+is the step it stopped short of. Note the pass is a bounded one: 2000 handles,
+not the server's ceiling, as the comment in `run.sh` says.
+
+Two other rows (`smb2.charset.Testing`, `smb2.kernel-oplocks.kernel_oplocks4`)
+also report as now-passing, but they do so on unmodified `develop` as well, so
+they are pre-existing and left alone rather than swept up here.
+
+`smb2.notify` is deliberately left at 120s: it hangs on a cancelled CHANGE_NOTIFY
+that never receives a final response (#2109), which no budget fixes.
+`smb2.aio_delay` and `smb2.compound_find` are left cut short as well — still
+uncharacterised, and sizing a budget for an unknown is what established the
+ungraded tail to begin with.
 
 ### 2026-08-24 — `dhv2-pending1n-vs-violation-lease-ack-sane`: replay reservation outlived the parked CREATE's response
 

--- a/test/smb-conformance/smbtorture/run.sh
+++ b/test/smb-conformance/smbtorture/run.sh
@@ -359,6 +359,8 @@ if $KERBEROS; then
         # subdirectories still exercises the many-open path far past any real
         # client, at a thirtieth of the work. A passing smb2.maxfid therefore
         # means "2000 handles are fine", NOT "the server's ceiling was found".
+        # Bounded it finishes in 5s (memory) / 15s (badger-fs), so it needs no
+        # extra budget — it keeps the standard 60s standalone-test allowance.
         "--option=torture:maxopenfiles=2000"
         # Reserved server-side ACL xattr name surfaced to smbtorture
         # smb2.ea.acl_xattr. The server rejects EA writes targeting this name
@@ -383,6 +385,8 @@ else
         # subdirectories still exercises the many-open path far past any real
         # client, at a thirtieth of the work. A passing smb2.maxfid therefore
         # means "2000 handles are fine", NOT "the server's ceiling was found".
+        # Bounded it finishes in 5s (memory) / 15s (badger-fs), so it needs no
+        # extra budget — it keeps the standard 60s standalone-test allowance.
         "--option=torture:maxopenfiles=2000"
         # Reserved server-side ACL xattr name surfaced to smbtorture
         # smb2.ea.acl_xattr. The server rejects EA writes targeting this name
@@ -670,19 +674,27 @@ else
         # synchronous, non-coalescing fsync. Give those suites more head room
         # on every profile; every other suite keeps 120s.
         #
-        # smb2.lease, smb2.multichannel and smb2.oplock also overrun 120s, on
-        # every profile — the cut is not a storage-speed effect. smb2.oplock is
-        # the clearest: batch22b deliberately waits out an oplock break timeout
-        # (smbtorture's own `oplocktimeout`, default 35s) with the holder's
-        # transport blocked so no ack can arrive, and it does not start until
-        # ~88s into the suite. 120s cannot fit it.
+        # smb2.lease, smb2.multichannel and smb2.oplock overrun 120s the same
+        # way, on every profile — the cut is not a storage-speed effect.
+        # smb2.oplock is the clearest case: batch22b deliberately waits out an
+        # oplock break timeout (smbtorture's own `oplocktimeout`, default 35s)
+        # with the holder's transport blocked so no ack can arrive.
+        #
+        # Measured end-to-end, with enough budget to finish (memory/badger-fs):
+        # lease 182/186s, oplock 145/145s, multichannel 132/132s, replay 163s.
+        # 300s is ~1.6x the slowest of those, which is the headroom the runner's
+        # variance needs; the two profiles land within 4s of each other, so the
+        # figure is not backend-sensitive.
         #
         # smb2.notify is deliberately NOT raised. It hangs on a cancelled
         # CHANGE_NOTIFY that never receives a final response, so a bigger budget
         # only burns more of it while leaving the same tail ungraded.
+        # smb2.aio_delay and smb2.compound_find stay at 120s too: still
+        # uncharacterised, and sizing a budget for an unknown is how an ungraded
+        # tail gets established in the first place.
         case "$suite" in
-            smb2.replay|smb2.durable-*) suite_timeout=300 ;;
-            smb2.lease|smb2.multichannel|smb2.oplock) suite_timeout=600 ;;
+            smb2.replay|smb2.durable-*|smb2.lease|smb2.multichannel|smb2.oplock)
+                suite_timeout=300 ;;
             *) suite_timeout=120 ;;
         esac
         run_smbtorture "$suite" "$suite_timeout" "$prefix" "${share:-}" || record_rc $?

--- a/test/smb-conformance/smbtorture/run.sh
+++ b/test/smb-conformance/smbtorture/run.sh
@@ -351,6 +351,15 @@ if $KERBEROS; then
         "--option=client min protocol=SMB2_02"
         "--option=client max protocol=SMB3"
         "--option=torture:smbd=false"
+        # smb2.maxfid opens handles until the server refuses, defaulting to
+        # 65520 — a number smbtorture picked to stay under socket_wrapper's
+        # socket limit, not because the behaviour needs that many. Unbounded
+        # it cannot finish in any per-suite budget we would want to grant, so
+        # it is deliberately capped: 2000 concurrent handles across 2
+        # subdirectories still exercises the many-open path far past any real
+        # client, at a thirtieth of the work. A passing smb2.maxfid therefore
+        # means "2000 handles are fine", NOT "the server's ceiling was found".
+        "--option=torture:maxopenfiles=2000"
         # Reserved server-side ACL xattr name surfaced to smbtorture
         # smb2.ea.acl_xattr. The server rejects EA writes targeting this name
         # with STATUS_ACCESS_DENIED (set_info.go::reservedACLXattrName).
@@ -366,6 +375,15 @@ else
         "--option=client min protocol=SMB2_02"
         "--option=client max protocol=SMB3"
         "--option=torture:smbd=false"
+        # smb2.maxfid opens handles until the server refuses, defaulting to
+        # 65520 — a number smbtorture picked to stay under socket_wrapper's
+        # socket limit, not because the behaviour needs that many. Unbounded
+        # it cannot finish in any per-suite budget we would want to grant, so
+        # it is deliberately capped: 2000 concurrent handles across 2
+        # subdirectories still exercises the many-open path far past any real
+        # client, at a thirtieth of the work. A passing smb2.maxfid therefore
+        # means "2000 handles are fine", NOT "the server's ceiling was found".
+        "--option=torture:maxopenfiles=2000"
         # Reserved server-side ACL xattr name surfaced to smbtorture
         # smb2.ea.acl_xattr. The server rejects EA writes targeting this name
         # with STATUS_ACCESS_DENIED (set_info.go::reservedACLXattrName).
@@ -651,8 +669,20 @@ else
         # since each cycle persists/consumes a durable handle with a
         # synchronous, non-coalescing fsync. Give those suites more head room
         # on every profile; every other suite keeps 120s.
+        #
+        # smb2.lease, smb2.multichannel and smb2.oplock also overrun 120s, on
+        # every profile — the cut is not a storage-speed effect. smb2.oplock is
+        # the clearest: batch22b deliberately waits out an oplock break timeout
+        # (smbtorture's own `oplocktimeout`, default 35s) with the holder's
+        # transport blocked so no ack can arrive, and it does not start until
+        # ~88s into the suite. 120s cannot fit it.
+        #
+        # smb2.notify is deliberately NOT raised. It hangs on a cancelled
+        # CHANGE_NOTIFY that never receives a final response, so a bigger budget
+        # only burns more of it while leaving the same tail ungraded.
         case "$suite" in
             smb2.replay|smb2.durable-*) suite_timeout=300 ;;
+            smb2.lease|smb2.multichannel|smb2.oplock) suite_timeout=600 ;;
             *) suite_timeout=120 ;;
         esac
         run_smbtorture "$suite" "$suite_timeout" "$prefix" "${share:-}" || record_rc $?


### PR DESCRIPTION
Acts on the truncation reporting #1919 already added: `run.sh:430` logs the
UNGRADED warning and `:431` records to `timeouts.txt`, but nothing uses it. This
raises the budgets that reporting has been pointing at, and bounds the one suite
no budget can fix.

**Scope note:** this PR does *not* make exit 124 fatal. That is deliberate and
sequenced — see the end.

## The issue assumed six tight budgets. Measurement says otherwise

Per-suite analysis of run 32119886932 (both profiles, same commit): for each
cut-short suite, which test was in flight when the budget fired, how long it had
been running, and the median of its already-graded siblings.

| suite | budget | graded/started | in flight when cut | started | burned | sibling median |
| --- | ---: | ---: | --- | ---: | ---: | ---: |
| `maxfid` | 60s | **0 / 1** | `maxfid` | 0.0s in | ~60s | 0.00s |
| `aio_delay` | 120s | **0 / 1** | `aio_cancel` | 0.0s in | ~120s | 0.00s |
| `notify` | 120s | **2 / 3** | `dir` | 0.1s in | ~120s | 0.08s |
| `oplock` | 120s | 28 / 29 | `batch22b` | 88.0s in | ~32s | 2.03s |
| `lease` | 120s | 25 / 26 | `v2_epoch2` | 118.6s in | ~1.4s | 3.01s |
| `multichannel` | 120s | 7 / 8 | `leases.test2` | 118.5s in | ~1.5s | 6.06s |

`memory` and `badger-fs` agree to within 0.5s on all of them, so none of this is
storage speed. They do not want the same fix:

**`oplock.batch22b` is by design.** `source4/torture/smb2/oplock.c:2644` sets
`oplocktimeout` to 35s, blocks the holder's transport so no ACK can arrive, and
requires the second open to succeed once the server's break fires
(`CHECK_RANGE(te, 0, timeout)`). The ~32s is the designed wait. It starts ~88s
in, so `smb2.oplock` needs >123s — this *raises* the budget rather than excusing
it.

**`maxfid` is a stress test, not a hang.** `maxfid.c:47` defaults
`maxopenfiles` to 65520, then opens that many handles. 0/1 in 60s is 65520
CREATEs that cannot finish, not a stall. A bigger budget buys a slow suite
instead of a working one, so this PR **bounds the test** to 2000 handles
instead. Rationale in the code comment: 2000 concurrent handles across 2
subdirectories exercises the many-open path far past any real client at a
thirtieth of the work. Stated plainly there, because a passing `smb2.maxfid` now
means "2000 handles are fine", **not** "the server's ceiling was found".

**`notify` is a real defect and is deliberately left at 120s** — see #2109:
a cancelled CHANGE_NOTIFY never receives a final response, confirmed from the
server's own DEBUG log. No budget fixes an unbounded client wait.

**`aio_delay.aio_cancel` and `compound_find`** (the latter cut on `badger-fs`
only) are not yet characterised and are untouched here.

## Measured budgets

The counts above only ever established a lower bound — "at least 26" tests in
`lease`, "at least 8" in `multichannel`. So this PR first pushed a deliberately
generous 600s probe to let CI report real completion times, measured in CI
rather than locally because the budget has to fit the emulated runner and a
laptop figure would not transfer. Run 32788936356:

| suite | memory | badger-fs | graded before → after | budget set |
| --- | ---: | ---: | ---: | ---: |
| `lease` | 182.4s | 186.4s | 25 → **45** | 300s |
| `oplock` | 144.8s | 144.7s | 28 → **42** | 300s |
| `multichannel` | 131.6s | 131.6s | 7 → **11** | 300s |
| `maxfid` | 5.4s | 14.9s | 0 → **1** | unchanged (60s) |

The three land in `smb2.replay`'s existing 300s tier — ~1.6x the slowest — so
the case arm is one line rather than three bespoke numbers. The two profiles
agree to within 4s, confirming the cut was never storage-dependent.

`maxfid` needs **no** budget change once bounded: 2000 handles finish in 5s/15s
against the standard 60s standalone allowance. It now passes, so its
Permanently Unimplementable row is dropped — that entry had already named
`torture:maxopenfiles` as the knob and correctly refused to raise the wall for
one stress test; bounding is the step it stopped short of.

Cut-short suites: **6 → 2** (memory), **7 → 3** (badger-fs).

## Three pre-existing failures came out of the ungraded tails

Letting the suites finish is what made these visible. **None is a regression.**
Each sits past the old cut point, so it was being left ungraded — inconclusive,
not failed — while the job reported `0 new failures`. All three fail
*identically* on `memory` and `badger-fs`, so none is a flake or a backend
artifact. Added to `KNOWN_FAILURES.md` against owning issues:

| test | assertion | issue |
| --- | --- | --- |
| `lease.v2_complex1` | `lease.c:3792`: `new_epoch got 0x4716 - should be 0x4715` | #2113 |
| `lease.rename_wait` | `lease.c:4160`: `NT_STATUS_INVALID_PARAMETER - should be NT_STATUS_OK` | #2114 |
| `oplock.batch22b` | `oplock.c:2715`: `te got 36 - should be between 0 and 35` | #2115 |

`batch22b` also corrects my earlier reading. I had called the ~32s wait "by
design" — the `oplocktimeout` part is, but the suite was cut *before* the test
finished, so 32s was never the final value. Given room to complete it lands at
**36s**, one second past the ceiling the test asserts. The wait is by design;
overshooting it is not.

Verified with the real grader: `parse-results.sh` against both profiles'
artifacts reports **0 new failures**, and `parse-results_test.sh` passes. Two
rows report as now-passing (`charset.Testing`, `kernel-oplocks4`) but do so on
unmodified `develop` as well, so they are pre-existing and left alone.

## Precedent that this works

#2097 gave `smb2.replay` the 300s budget on every profile. It is now absent from
both profiles' cut-short lists, and the memory profile went from **558 to 575
tests graded, 487 to 497 passed**. Seventeen previously-unadjudicated tests. It
also found a real product defect that had been sitting in that ungraded tail for
three months across two issues (#2086, #1322).

## Sequencing

Making exit 124 fatal is PR 2, not this one, and it must not go up while
`aio_cancel` or `compound_find` are uncharacterised: flipping it with an unknown
outstanding reds the profile on something nobody understands, and the reflex fix
is to raise that suite's budget — which is exactly how the ungraded tail got
established.

Refs #2098
