### PR TITLE
fix(shares): reject share names that cannot address their own directory

### DIFF
--- a/pkg/controlplane/runtime/shares/share_name_isolation_test.go
+++ b/pkg/controlplane/runtime/shares/share_name_isolation_test.go
@@ -1,0 +1,52 @@
+package shares
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// TestAcceptedShareNamesStayInsideSharesTree pins the property that makes the
+// per-share data directory an isolation boundary: every share name that
+// ValidateShareName accepts must derive a directory strictly beneath
+// <base>/shares/.
+//
+// deriveLocalStoreDir builds that path as Join(base, "shares", sanitized), and
+// sanitizeShareName escapes '/' but not '.'. So the guarantee rests on the two
+// functions agreeing, and they live in different packages — a later change to
+// either one alone would silently reopen a name like ".." resolving the share's
+// directory to base. Asserting the derived path here, rather than only the
+// validator's verdict, is what catches that.
+func TestAcceptedShareNamesStayInsideSharesTree(t *testing.T) {
+	t.Parallel()
+
+	const base = "/var/lib/dittofs"
+	cfg := &fakeBlockStoreConfig{cfg: map[string]any{"path": base}}
+	sharesRoot := filepath.Join(base, "shares")
+
+	names := []string{
+		"data", "/data", "/my.share.v2", "/share.", "/...", "/a/b",
+		".", "/.", "..", "/..", "//..", "/../..", "/a/../..",
+		"", "/", strings.Repeat("a", 300),
+	}
+
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if err := metadata.ValidateShareName(name); err != nil {
+				t.Skipf("rejected before any directory is derived: %v", err)
+			}
+
+			got := deriveLocalStoreDir(cfg, name)
+			if got == "" {
+				t.Fatalf("deriveLocalStoreDir(%q) = %q, want a path", name, got)
+			}
+			if got == sharesRoot || !strings.HasPrefix(got, sharesRoot+string(filepath.Separator)) {
+				t.Fatalf("share %q derives %q, which escapes %q", name, got, sharesRoot)
+			}
+		})
+	}
+}

--- a/pkg/controlplane/runtime/shares/share_name_isolation_test.go
+++ b/pkg/controlplane/runtime/shares/share_name_isolation_test.go
@@ -36,7 +36,13 @@ func TestAcceptedShareNamesStayInsideSharesTree(t *testing.T) {
 	}
 
 	for _, name := range names {
-		t.Run(name, func(t *testing.T) {
+		// t.Run renders an empty name as "#00", which says nothing about which
+		// case it was; label it so a failure names the input.
+		label := name
+		if label == "" {
+			label = "<empty>"
+		}
+		t.Run(label, func(t *testing.T) {
 			t.Parallel()
 
 			if err := metadata.ValidateShareName(name); err != nil {

--- a/pkg/controlplane/runtime/shares/share_name_isolation_test.go
+++ b/pkg/controlplane/runtime/shares/share_name_isolation_test.go
@@ -22,7 +22,10 @@ import (
 func TestAcceptedShareNamesStayInsideSharesTree(t *testing.T) {
 	t.Parallel()
 
-	const base = "/var/lib/dittofs"
+	// deriveLocalStoreDir requires an absolute base, and what counts as
+	// absolute is platform-specific, so take one from the test environment
+	// rather than hardcoding a POSIX path.
+	base := t.TempDir()
 	cfg := &fakeBlockStoreConfig{cfg: map[string]any{"path": base}}
 	sharesRoot := filepath.Join(base, "shares")
 

--- a/pkg/metadata/validation.go
+++ b/pkg/metadata/validation.go
@@ -131,6 +131,10 @@ const (
 // recoverable once a share exists: a name containing ':' yields handles whose
 // UUID component fails to parse, and a name longer than MaxShareNameLen yields
 // no handle at all, so every file operation on the share fails at handle mint.
+//
+// It also rejects names that cannot address a directory of their own beneath
+// the per-share storage tree; see namesShareDirectory.
+//
 // Call this at every seam that creates a share, before any state is persisted.
 func ValidateShareName(name string) error {
 	switch {
@@ -143,8 +147,36 @@ func ValidateShareName(name string) error {
 			"share name %q is %d bytes, exceeding the %d-byte maximum "+
 				`(a %d-byte file handle holds "<share>:<uuid>")`,
 			name, len(name), MaxShareNameLen, MaxFileHandleSize))
+	case !namesShareDirectory(name):
+		return NewInvalidArgumentError(fmt.Sprintf(
+			`share name %q must name a directory inside the shares tree, `+
+				`not "", "." or ".."`, name))
 	}
 	return nil
+}
+
+// namesShareDirectory reports whether name still names a directory that can sit
+// inside the per-share tree once the leading slashes callers prepend are gone.
+//
+// The per-share data directory is built as Join(base, "shares", <name>), and
+// the sanitizer that produces that last component escapes '/' but leaves '.'
+// untouched. So ".." reaches Join intact and resolves the share's directory to
+// base, outside the tree that keeps shares isolated from one another, while "."
+// and the empty string collapse onto the tree itself — a directory every such
+// share would then share. None of the three names a directory of its own.
+//
+// Callers normalize a name to exactly one leading slash before validating, and
+// that normalization turns an empty request into "/", so the spellings that
+// arrive here are "/", "/." and "/..". The sanitizer strips only a single
+// leading slash, which leaves "//.." inert on its own, but TrimLeft folds every
+// spelling in: a share addressing the tree or its parent is meaningless however
+// it is written.
+func namesShareDirectory(name string) bool {
+	switch strings.TrimLeft(name, "/") {
+	case "", ".", "..":
+		return false
+	}
+	return true
 }
 
 // ValidateName validates a filename for creation/move operations.

--- a/pkg/metadata/validation.go
+++ b/pkg/metadata/validation.go
@@ -149,8 +149,9 @@ func ValidateShareName(name string) error {
 			name, len(name), MaxShareNameLen, MaxFileHandleSize))
 	case !namesShareDirectory(name):
 		return NewInvalidArgumentError(fmt.Sprintf(
-			`share name %q must name a directory inside the shares tree, `+
-				`not "", "." or ".."`, name))
+			`share name %q must name a directory inside the shares tree: `+
+				`with its leading slashes removed it is "", "." or "..", `+
+				`none of which is a directory of its own`, name))
 	}
 	return nil
 }
@@ -158,9 +159,9 @@ func ValidateShareName(name string) error {
 // namesShareDirectory reports whether name still names a directory that can sit
 // inside the per-share tree once the leading slashes callers prepend are gone.
 //
-// The per-share data directory is built as Join(base, "shares", <name>), and
-// the sanitizer that produces that last component escapes '/' but leaves '.'
-// untouched. So ".." reaches Join intact and resolves the share's directory to
+// The per-share data directory is built as Join(base, "shares", <sanitized>),
+// where the sanitizer that produces that last component escapes '/' but leaves
+// '.' untouched. So ".." reaches Join intact and resolves the share's directory to
 // base, outside the tree that keeps shares isolated from one another, while "."
 // and the empty string collapse onto the tree itself — a directory every such
 // share would then share. None of the three names a directory of its own.

--- a/pkg/metadata/validation_test.go
+++ b/pkg/metadata/validation_test.go
@@ -610,3 +610,59 @@ func TestPointerHelpers(t *testing.T) {
 		assert.True(t, *ptr)
 	})
 }
+
+// ============================================================================
+// ValidateShareName Tests
+// ============================================================================
+
+func TestValidateShareName(t *testing.T) {
+	t.Parallel()
+
+	longName := strings.Repeat("a", MaxShareNameLen+1)
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"plain name", "data", false},
+		{"leading slash", "/data", false},
+		{"dots inside the name", "/my.share.v2", false},
+		{"name ending in a dot", "/share.", false},
+		{"three dots", "/...", false},
+		{"embedded slash", "/a/b", false},
+
+		{"empty", "", true},
+		{"contains colon", "/da:ta", true},
+		{"too long", longName, true},
+
+		// A name whose path form is "", "." or ".." does not name a directory
+		// inside the per-share tree; see namesShareDirectory.
+		{"dot", ".", true},
+		{"dot with leading slash", "/.", true},
+		{"parent", "..", true},
+		{"parent with leading slash", "/..", true},
+		{"parent with repeated slashes", "//..", true},
+
+		// normalizeShareName turns an empty or all-slash request into "/",
+		// which names the shares tree itself rather than a share inside it.
+		{"root", "/", true},
+		{"repeated slashes only", "///", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateShareName(tt.input)
+			if tt.wantErr {
+				require.Error(t, err, "expected %q to be rejected", tt.input)
+				var se *StoreError
+				require.ErrorAs(t, err, &se)
+				assert.Equal(t, ErrInvalidArgument, se.Code)
+				return
+			}
+			assert.NoError(t, err, "expected %q to be accepted", tt.input)
+		})
+	}
+}


### PR DESCRIPTION
Fixes the one real bug from the #2104 CodeQL triage (`go/path-injection`).

## The bug

A share's local data directory is built in `deriveLocalStoreDir`:

```go
return filepath.Join(expanded, "shares", sanitizeShareName(shareName))
```

and the sanitizer is:

```go
func sanitizeShareName(name string) string {
	name = strings.TrimPrefix(name, "/")
	return url.PathEscape(name)
}
```

`url.PathEscape` escapes `/`, but **`.` is unreserved and passes through
untouched**. So `".."` survives the sanitizer intact and `filepath.Join` then
resolves the share's directory to `base` — outside the `shares/` tree that keeps
shares isolated from one another. Verified by running the sanitizer verbatim:

```
name="normal"  sanitized="normal"      join=".../shares/normal"    ESCAPES=false
name=".."      sanitized=".."          join="/var/lib/dittofs"     ESCAPES=true
name="/.."     sanitized=".."          join="/var/lib/dittofs"     ESCAPES=true
name="../.."   sanitized="..%2F.."     join=".../shares/..%2F.."   ESCAPES=false
```

Traversal is capped at one level, because the sanitizer *does* escape `/`.

Nothing upstream rejected it: `ValidateShareName` checked only for empty, a `:`,
and the length budget. The contrast is right next door — `ValidateName`, for
filenames, has always rejected `"."`, `".."`, `/` and NUL, and its doc comment
explains why that guard is centralized. Share names never got the same guard.

## A second case, found by the test rather than by reading

Writing the property test surfaced one I had missed: **`"/"`**.

`normalizeShareName` trims all leading slashes and re-adds one, returning `"/"`
for an empty or all-slash input — and the REST handler normalizes *before* it
validates. So `POST /shares {"name": ""}` produced a share named `"/"`, which
sanitizes to `""` and derives `<base>/shares` — the shares tree **itself**, the
container for every other share.

That is why the fix rejects `""`, `"."` and `".."` rather than just the dots.

## The fix

Three cases added to `ValidateShareName`, the function whose doc already says
"call this at every seam that creates a share". Both such seams — the REST
create handler and `AddShare` — already call it, and I confirmed every path that
reaches `deriveLocalStoreDir` / `deriveGCStateRoot` funnels through share
creation, so there is no bypass to patch separately.

## Impact and safety

Creating a share is an authenticated control-plane operation, so this is an
isolation bug rather than an unauthenticated exploit — a privileged caller could
put a share's blocks outside its own directory, or make two shares collide.

For an existing deployment carrying such a share, `init.go` treats a failed
`AddShare` as **warn-and-skip**, not a boot abort (only `ErrFutureFormat` /
`ErrLegacyLocalFormat` stop the daemon), so this cannot brick a running install.
I also checked no legitimate share is named `"/"`: the only hits are `"/" + name`
constructions in tests.

## Tests

- `TestValidateShareName` — there was no test for this function at all. Table
  covers the new rejections plus the pre-existing rules, and names that merely
  *contain* dots (`/my.share.v2`, `/share.`, `/...`) which must still be accepted.
- `TestAcceptedShareNamesStayInsideSharesTree` — asserts the **derived path**,
  not the validator's verdict. The validator and the sanitizer live in different
  packages, so a later change to either one alone would silently reopen this; a
  validator-only test would not catch it. This is the test that found the `"/"`
  case.

Both verified to fail against the pre-fix tree — 5 subtests fail there, 0 after.
Notably `"//.."` passes both ways, confirming it was already inert because the
sanitizer strips only one leading slash and escapes the rest.

`go test ./...` 134 packages green, `go vet` and `golangci-lint` clean.