### PR TITLE
ci: declare the GITHUB_TOKEN scopes each workflow needs

### DIFF
--- a/.github/workflows/ad-dc.yml
+++ b/.github/workflows/ad-dc.yml
@@ -28,6 +28,9 @@ on:
     - cron: '0 4 * * *'  # Nightly 4 AM UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ad-dc-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -34,6 +34,9 @@ on:
     - cron: '0 4 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,6 +15,9 @@ on:
       - 'test/kmip/**'
       - '.github/workflows/integration-tests.yml'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [develop, main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/nfs-kerberos.yml
+++ b/.github/workflows/nfs-kerberos.yml
@@ -40,6 +40,9 @@ on:
     - cron: '0 4 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   nfs-kerberos:
     name: NFS sec=krb5 mount test

--- a/.github/workflows/operator-tests.yml
+++ b/.github/workflows/operator-tests.yml
@@ -14,6 +14,9 @@ on:
       - 'k8s/dittofs-operator/**'
       - '.github/workflows/operator-tests.yml'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/posix-tests.yml
+++ b/.github/workflows/posix-tests.yml
@@ -43,6 +43,9 @@ on:
     - cron: '0 4 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [develop, main]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/smb-client-compat.yml
+++ b/.github/workflows/smb-client-compat.yml
@@ -21,6 +21,9 @@ on:
     - cron: '0 4 * * 1'  # Weekly Monday 4 AM UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: smb-client-compat-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/smb-conformance.yml
+++ b/.github/workflows/smb-conformance.yml
@@ -53,6 +53,9 @@ on:
           - sqlite
           - postgres
 
+permissions:
+  contents: read
+
 concurrency:
   group: smb-conformance-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,6 +13,9 @@ on:
       - 'go.sum'
       - '.github/workflows/unit-tests.yml'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -13,6 +13,9 @@ on:
       - 'go.sum'
       - '.github/workflows/windows-build.yml'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Closes the 24 `actions/missing-workflow-permissions` alerts from #2104 — the
largest single class on the code-scanning tab.

Twelve workflows had no `permissions:` block, so their token scopes came from
the repository-wide default and nothing in the file recorded what they were
allowed to do.

## Why this is behaviour-preserving

The repository default is already read-only:

```
$ gh api repos/marmos91/dittofs/actions/permissions/workflow
{"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}
```

So `contents: read` grants exactly what these jobs already had. What does change
is that a declared block narrows every *unlisted* scope from `read` to `none`,
so I checked what else could be in use rather than assuming:

- **Only two workflows touch `GITHUB_TOKEN` at all** — `secret-scan.yml` (gitleaks)
  and `smb-conformance.yml` (baseline refresh). Every other one just checks out
  code.
- **`secret-scan`** therefore also keeps `pull-requests: read`, since the gitleaks
  action reads PR data through the token. Without it that scope would drop to
  `none`, which is a real narrowing rather than a no-op.
- **`smb-conformance`'s `smbtorture-baseline-refresh`** is the only job that
  writes. It already declares `contents: write` for itself, and a job-level block
  still overrides the top-level one — verified both are present after the change.
- **Both `download-artifact` steps** (`posix-tests.yml`) read artifacts from their
  own run — no `run-id`, no `github-token` — so no job needs the `actions` scope.

## Files

`ad-dc`, `e2e-tests`, `integration-tests`, `lint`, `nfs-kerberos`,
`operator-tests`, `posix-tests`, `secret-scan`, `smb-client-compat`,
`smb-conformance`, `unit-tests`, `windows-build`.

`close-linked-issues.yml` and `nix-update-hash.yml` were already clean — they
declare permissions at job level, which is why CodeQL never flagged them.

All twelve files re-parsed as valid YAML after the edit. The real check is CI on
this PR: it exercises every one of these workflows under the new scopes.