### PR TITLE
fix(block): bound parsed chunk offsets to int64 at the parse

### DIFF
--- a/pkg/block/ids.go
+++ b/pkg/block/ids.go
@@ -1,6 +1,7 @@
 package block
 
 import (
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -10,14 +11,21 @@ import (
 // ID of the form "<payloadID>/<chunkOffset>" and returns
 // (chunkOffset, true) on success. Returns (0, false) for malformed IDs
 // (no slash, trailing slash, non-digit characters after the slash, or an
-// offset that does not fit in a uint64).
+// offset that does not fit in an int64).
+//
+// The int64 ceiling, rather than the uint64 one the parse itself permits, is
+// what callers need: every one of them converts the result to int64 to compare
+// it against a file offset or a run boundary, and a value above MaxInt64 would
+// arrive there negative and order before every real offset. Rejecting it here
+// keeps that conversion total for all callers instead of asking each to guard
+// its own.
 func ParseChunkOffset(id string) (uint64, bool) {
 	slash := strings.LastIndexByte(id, '/')
 	if slash < 0 || slash == len(id)-1 {
 		return 0, false
 	}
 	v, err := strconv.ParseUint(id[slash+1:], 10, 64)
-	if err != nil {
+	if err != nil || v > math.MaxInt64 {
 		return 0, false
 	}
 	return v, true
@@ -59,7 +67,7 @@ func ChunkOffsetFor(id, payloadID string) (uint64, bool) {
 		return 0, false
 	}
 	v, err := strconv.ParseUint(rest, 10, 64)
-	if err != nil {
+	if err != nil || v > math.MaxInt64 {
 		return 0, false
 	}
 	return v, true

--- a/pkg/block/ids_test.go
+++ b/pkg/block/ids_test.go
@@ -11,7 +11,7 @@ func TestParseChunkOffset(t *testing.T) {
 	}{
 		{"simple", "share/file/0", 0, true},
 		{"non-zero", "share/file/12345", 12345, true},
-		{"max-digits", "p/18446744073709551615", 18446744073709551615, true},
+		{"max-int64", "p/9223372036854775807", 9223372036854775807, true},
 		{"nested-slashes", "a/b/c/42", 42, true},
 
 		{"no-slash", "noslash", 0, false},
@@ -23,10 +23,55 @@ func TestParseChunkOffset(t *testing.T) {
 		{"plus-sign", "p/+1", 0, false},
 		{"hex", "p/0x10", 0, false},
 		{"only-slash", "/", 0, false},
+
+		// Callers convert the result to int64 to compare against file offsets,
+		// so a value the uint64 parse accepts but int64 cannot hold is rejected
+		// here rather than arriving negative at the comparison.
+		{"above-int64-max", "p/9223372036854775808", 0, false},
+		{"max-uint64", "p/18446744073709551615", 0, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			gotV, gotOK := ParseChunkOffset(tc.id)
+			if gotOK != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", gotOK, tc.wantOK)
+			}
+			if gotV != tc.wantV {
+				t.Fatalf("v = %d, want %d", gotV, tc.wantV)
+			}
+		})
+	}
+}
+
+func TestChunkOffsetFor(t *testing.T) {
+	cases := []struct {
+		name      string
+		id        string
+		payloadID string
+		wantV     uint64
+		wantOK    bool
+	}{
+		{"simple", "p/0", "p", 0, true},
+		{"non-zero", "p/12345", "p", 12345, true},
+		{"max-int64", "p/9223372036854775807", "p", 9223372036854775807, true},
+
+		// Stricter than ParseChunkOffset: the component must belong to this
+		// payload, not to one nested beneath it.
+		{"nested-payload", "p/q/42", "p", 0, false},
+		{"other-payload", "q/42", "p", 0, false},
+		{"prefix-not-boundary", "pp/42", "p", 0, false},
+
+		{"trailing-slash", "p/", "p", 0, false},
+		{"non-digit", "p/12a", "p", 0, false},
+		{"negative-sign", "p/-1", "p", 0, false},
+
+		// Same int64 ceiling as ParseChunkOffset: callers narrow the result.
+		{"above-int64-max", "p/9223372036854775808", "p", 0, false},
+		{"max-uint64", "p/18446744073709551615", "p", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotV, gotOK := ChunkOffsetFor(tc.id, tc.payloadID)
 			if gotOK != tc.wantOK {
 				t.Fatalf("ok = %v, want %v", gotOK, tc.wantOK)
 			}

--- a/pkg/metadata/store/badger/chunk_index_highbit_test.go
+++ b/pkg/metadata/store/badger/chunk_index_highbit_test.go
@@ -1,0 +1,73 @@
+package badger_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	blockpkg "github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/badger"
+)
+
+// 2^63: one above MaxInt64, so it parses as a uint64 but not as an offset.
+const highBitOffset = "9223372036854775808"
+
+func newChunkIndexStore(t *testing.T) *badger.BadgerMetadataStore {
+	t.Helper()
+	store, err := badger.NewBadgerMetadataStoreWithDefaults(context.Background(), filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("NewBadgerMetadataStoreWithDefaults: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// A row whose ID suffix exceeds MaxInt64 sits at an offset the covering guard
+// cannot resolve, so the indexed lookup must refuse rather than answer "no chunk
+// here" — the reader zero-fills a hole, which would serve zeros over a row whose
+// range is merely unknown.
+func TestGetFileChunkAtOffsetRefusesHighBitRow(t *testing.T) {
+	ctx := context.Background()
+	store := newChunkIndexStore(t)
+
+	const payload = "p"
+	if err := store.Put(ctx, &metadata.FileChunk{ID: payload + "/" + highBitOffset, DataSize: 4096}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	got, err := store.GetFileChunkAtOffset(ctx, payload, 100)
+	if err == nil {
+		t.Fatalf("got (%v, nil), want ErrManifestInconsistent: an unplaceable row was reported as a hole", got != nil)
+	}
+	if !errors.Is(err, blockpkg.ErrManifestInconsistent) {
+		t.Fatalf("err = %v, want ErrManifestInconsistent", err)
+	}
+}
+
+// One unreadable row must not make the whole payload unreadable: when another
+// row covers the offset, that row still answers the read.
+func TestGetFileChunkAtOffsetServesCoveredOffsetDespiteHighBitRow(t *testing.T) {
+	ctx := context.Background()
+	store := newChunkIndexStore(t)
+
+	const payload = "p"
+	covering := &metadata.FileChunk{ID: payload + "/0", DataSize: 4096}
+	for _, row := range []*metadata.FileChunk{
+		covering,
+		{ID: payload + "/" + highBitOffset, DataSize: 4096},
+	} {
+		if err := store.Put(ctx, row); err != nil {
+			t.Fatalf("Put(%s): %v", row.ID, err)
+		}
+	}
+
+	got, err := store.GetFileChunkAtOffset(ctx, payload, 100)
+	if err != nil {
+		t.Fatalf("GetFileChunkAtOffset: %v", err)
+	}
+	if got == nil || got.ID != covering.ID {
+		t.Fatalf("got %v, want the covering row %q", got, covering.ID)
+	}
+}

--- a/pkg/metadata/store/badger/objects.go
+++ b/pkg/metadata/store/badger/objects.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -457,6 +458,11 @@ func loadFileChunkAtIndexOffset(txn *badger.Txn, payloadID string, off uint64) (
 // as one. Such a suffix is a row ID's suffix verbatim, so the row sits at an
 // unknown offset and its caller must refuse rather than report a hole the reader
 // would zero-fill.
+//
+// A suffix above MaxInt64 counts as not parsing here, matching the ceiling
+// block.ParseChunkOffset applies to the row's own ID. Were it kept instead, this
+// scan would place a row the covering guard then refuses, and the offset would
+// be reported as a hole rather than as the unreadable row it is.
 func scanChunkIndexOffsets(txn *badger.Txn, payloadID string, keep func(cand, best uint64, have bool) bool) (bestOff uint64, found bool, unplaceable string) {
 	prefix := []byte(fileChunkFilePrefix + payloadID + ":")
 	opts := badger.DefaultIteratorOptions
@@ -468,7 +474,7 @@ func scanChunkIndexOffsets(txn *badger.Txn, payloadID string, keep func(cand, be
 	for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
 		suffix := string(it.Item().Key()[len(prefix):])
 		cand, perr := strconv.ParseUint(suffix, 10, 64)
-		if perr != nil {
+		if perr != nil || cand > math.MaxInt64 {
 			if unplaceable == "" {
 				unplaceable = suffix
 			}


### PR DESCRIPTION
Addresses the 15 `go/incorrect-integer-conversion` alerts from #2104.

## The defect

`ParseChunkOffset` (and its stricter sibling `ChunkOffsetFor`) parse a chunk
ID's trailing component with `strconv.ParseUint(..., 10, 64)` and return it
unchecked. Every one of the ~24 call sites then converts to `int64` to compare
against a file offset or a run boundary — so a value above `MaxInt64` arrives
there **negative**, ordering before every real offset rather than after them.

CodeQL flags the conversion sites, including six in
`sqlite/postgres/file_block_refs.go` that contain no parse of their own — it is
tracing those `uint64`s back through dataflow to this parse. That is why the
guard belongs here: it sits on every path, so one barrier covers all fifteen
rather than two dozen call sites each guarding themselves.

## Reachability — latent, not exploitable

The parsed component comes from chunk IDs **we generate** (`<payloadID>/<offset>`),
where the offset is a file offset and cannot exceed `int64`. So nothing we
produce is newly rejected, and a negative offset would be a corrupted-metadata
symptom rather than an attack. This is a robustness fix.

## A pinned test I had to change

`TestParseChunkOffset` carried `{"max-digits", "p/18446744073709551615", ..., true}`
— asserting that max-uint64 is *accepted*. My change makes it fail, so the
question is whether that pin is load-bearing.

It is not: it asserts the range of `ParseUint` itself, not a property any caller
relies on. Every caller narrows to `int64`, and an 8-exabyte file offset is not
representable in Go's file APIs regardless. The case is now the boundary pair —
`max-int64` accepted, `above-int64-max` and `max-uint64` rejected.

## Scope

- `ChunkOffsetFor` gets the same bound. Fixing only one of two functions with
  identical shape would leave the fix half-applied.
- `ChunkOffsetFor` had **no test coverage at all**; it gains one covering the
  bound plus its documented payload-boundary strictness (`p/q/42`, `pp/42`).
- The third `ParseUint` in the file keys a sort in `uint64` space and never
  narrows, so it is correct as-is and left alone.

## Testing

`go test ./...` 134 packages green, `go vet` and `golangci-lint` clean.

One caveat worth stating: CodeQL runs as GitHub's default setup, so I cannot
confirm locally that all 15 alerts clear. The code is correct either way; if any
survive, they will show a path I have not accounted for and I will follow up.

---

## Added after review: the index scan shares the ceiling

Copilot flagged that `scanChunkIndexOffsets` (badger) still parsed its `fb-file`
key suffixes unbounded, so index and parser now disagreed about what is
placeable: the scan would keep a high-bit suffix as a candidate offset, then the
covering guard would refuse the row and the offset would fall through as a
**sparse hole the reader zero-fills** — the outcome that function's contract
exists to prevent.

The seam is real and is now fixed: both parses share one ceiling, so the index
places exactly the rows the guard can resolve, and such a row is reported
unplaceable so `GetFileChunkAtOffset` refuses through the existing
`errUnplaceableRow` path.

**The hole is not a regression from this PR**, which I measured rather than
inferred — storing a row `p/9223372036854775808` and reading offset 100:

| tree | `ParseChunkOffset` | result |
| --- | --- | --- |
| develop (unbounded) | `ok=true` | `(nil, nil)` — sparse hole |
| this PR, before the scan fix | `ok=false` | `(nil, nil)` — sparse hole |
| this PR, after the scan fix | `ok=false` | `ErrManifestInconsistent` |

Unbounded, the parse produced an offset so large the covering guard's
`off >= abs` failed anyway, reaching the same fall-through. The bound changed
which line rejects the row, not the outcome. So this closes a standing gap
rather than one the offset bound introduced.

Two regression tests against the real badger path: one pins the refusal (fails
on develop), one pins that a payload with a covering row still reads normally,
since one unreadable row must not make a whole payload unreadable.
