### PR TITLE
test: make the two wall-clock-budget flakes deterministic

### DIFF
--- a/pkg/metadata/lock/directory.go
+++ b/pkg/metadata/lock/directory.go
@@ -84,6 +84,9 @@ type recentlyBrokenCache struct {
 	mu      sync.RWMutex
 	entries map[string]time.Time
 	ttl     time.Duration
+	// nowFn reads the current time. Tests override it to step the clock across
+	// the TTL boundary instead of sleeping.
+	nowFn func() time.Time
 }
 
 // newRecentlyBrokenCache creates a new recently-broken cache with the given TTL.
@@ -91,6 +94,7 @@ func newRecentlyBrokenCache(ttl time.Duration) *recentlyBrokenCache {
 	return &recentlyBrokenCache{
 		entries: make(map[string]time.Time),
 		ttl:     ttl,
+		nowFn:   time.Now,
 	}
 }
 
@@ -104,7 +108,7 @@ func (c *recentlyBrokenCache) IsRecentlyBroken(handleKey string) bool {
 	if !ok {
 		return false
 	}
-	if time.Since(ts) > c.ttl {
+	if c.nowFn().Sub(ts) > c.ttl {
 		delete(c.entries, handleKey)
 		return false
 	}
@@ -116,7 +120,7 @@ func (c *recentlyBrokenCache) Mark(handleKey string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.entries[handleKey] = time.Now()
+	c.entries[handleKey] = c.nowFn()
 
 	// Lazy cleanup: remove expired entries when we add new ones
 	c.cleanupLocked()
@@ -124,7 +128,7 @@ func (c *recentlyBrokenCache) Mark(handleKey string) {
 
 // cleanupLocked removes expired entries. Must be called with mu held for write.
 func (c *recentlyBrokenCache) cleanupLocked() {
-	now := time.Now()
+	now := c.nowFn()
 	for key, ts := range c.entries {
 		if now.Sub(ts) > c.ttl {
 			delete(c.entries, key)

--- a/pkg/metadata/lock/directory_test.go
+++ b/pkg/metadata/lock/directory_test.go
@@ -414,14 +414,23 @@ func TestRecentlyBrokenCache_IsRecentlyBroken(t *testing.T) {
 func TestRecentlyBrokenCache_Expiry(t *testing.T) {
 	t.Parallel()
 
-	// Use very short TTL for testing
-	cache := newRecentlyBrokenCache(10 * time.Millisecond)
+	// Drive the cache off a stepped clock rather than real elapsed time: the
+	// expiry transition is what matters, and asserting it against a wall-clock
+	// interval makes the verdict a function of scheduling and timer granularity.
+	const ttl = time.Second
+	now := time.Now()
+	cache := newRecentlyBrokenCache(ttl)
+	cache.nowFn = func() time.Time { return now }
 
 	cache.Mark("dir1")
 	assert.True(t, cache.IsRecentlyBroken("dir1"))
 
-	// Wait for expiry
-	time.Sleep(20 * time.Millisecond)
+	// Still inside the TTL.
+	now = now.Add(ttl)
+	assert.True(t, cache.IsRecentlyBroken("dir1"), "should survive up to the TTL")
+
+	// Past it.
+	now = now.Add(time.Nanosecond)
 	assert.False(t, cache.IsRecentlyBroken("dir1"), "should expire after TTL")
 }
 

--- a/pkg/metadata/store/sqlite/backpressure_test.go
+++ b/pkg/metadata/store/sqlite/backpressure_test.go
@@ -5,50 +5,40 @@ import (
 	"errors"
 	"path/filepath"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/marmos91/dittofs/pkg/metadata"
-	"github.com/marmos91/dittofs/pkg/metadata/store/internal/txretry"
 	"github.com/marmos91/dittofs/pkg/metadata/store/sqlite"
 )
 
-const (
-	// fixedAttemptCeiling is the total wait of the fixed 3-attempt (10/20/30ms)
-	// retry loop this test guards against: a transaction that blocks longer than
-	// this is one that loop would have given up on and returned EIO for.
-	fixedAttemptCeiling = 60 * time.Millisecond
-
-	// callLimit bounds a single transaction against the budget it retries
-	// within, not against elapsed test time: WithTransaction returns once that
-	// budget elapses, so no call can legitimately run far past it however slow
-	// the machine is. The multiple is slack for scheduling and one final attempt
-	// — large enough that reaching it means the call stopped terminating on its
-	// own, not that the disk was slow.
-	callLimit = 4 * txretry.Budget
-)
+// fixedAttemptCount is the attempt count of the fixed 3-attempt (10/20/30ms)
+// retry loop this test guards against. The contending writer must still be
+// retrying after this many attempts — that is what backpressure means here, and
+// what the old loop could not do. The count is asserted rather than the elapsed
+// time it happens to take: how long those attempts occupy is a property of the
+// machine, the attempt count is a property of the loop.
+const fixedAttemptCount = 3
 
 // TestSQLite_ConcurrentWritesBackpressureNoEIO is the #1769 regression guard.
 //
-// Under concurrent writers contending on a single hot row (the shared parent
-// directory inode), the metadata store must backpressure — block and retry
-// until the transaction succeeds — never surface metadata.ErrIOError (which
-// maps to NFS3ErrIO / EIO) to the caller. Before the fix, WithTransaction gave
-// up after 3 attempts (10/20/30ms) and returned ErrIOError.
+// When a writer collides with the sqlite write lock, the metadata store must
+// backpressure — block and retry until the lock frees — never surface
+// metadata.ErrIOError (which maps to NFS3ErrIO / EIO) to the caller. Before the
+// fix, WithTransaction gave up after 3 attempts (10/20/30ms) and returned
+// ErrIOError.
 //
 // A single sqlite store pins MaxOpenConns(1), so writers through one store
 // already serialize at the Go pool and never collide. Real SQLITE_BUSY
-// contention needs multiple connections to the same file, so this test opens
-// several store handles against one on-disk database and hammers the same
-// directory row across all of them with a tiny busy_timeout. All mutations
-// must succeed.
+// contention needs multiple connections to the same file, so this test opens two
+// store handles against one on-disk database: one holds a write transaction open
+// on the shared root inode while the other tries to write the same row.
+//
+// The holder releases when the contender has made more attempts than the old
+// loop ever would — not after a wall-clock interval — so the verdict is a
+// property of the retry loop rather than a race against a budget on a machine of
+// unknown speed.
 func TestSQLite_ConcurrentWritesBackpressureNoEIO(t *testing.T) {
-	// No test-wide deadline: each transaction is bounded by the store's own
-	// retry budget instead. A ctx deadline would decide the verdict itself —
-	// WithTransaction tightens its retry budget to an earlier ctx deadline, so
-	// the budget shrinks to nothing as the run approaches it, and the deadline
-	// aborts whatever statement is in flight when it fires.
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "backpressure.db")
 
@@ -57,17 +47,11 @@ func TestSQLite_ConcurrentWritesBackpressureNoEIO(t *testing.T) {
 		cfg := &sqlite.SQLiteMetadataStoreConfig{
 			Path:        dbPath,
 			AutoMigrate: autoMigrate,
-			// busy_timeout bounds how long the driver waits for the single write
-			// lock before returning SQLITE_BUSY up to WithTransaction's retry loop.
-			// It is kept small so sustained cross-connection contention still
-			// surfaces SQLITE_BUSY and exercises that retry/backpressure path — but
-			// not so small that every brief collision is handed to the retry loop,
-			// which under heavy contention can exhaust the loop's per-call time
-			// budget and turn a transient conflict into EIO. At this value the
-			// driver absorbs sub-threshold collisions while only sustained
-			// contention reaches the retry loop, so colliding writers backpressure
-			// (run slow) rather than error.
-			BusyTimeout: 50 * time.Millisecond,
+			// busy_timeout bounds how long the driver waits for the write lock
+			// before returning SQLITE_BUSY up to WithTransaction's retry loop.
+			// Small, so the contender reaches that loop promptly instead of
+			// sitting in the driver.
+			BusyTimeout: 20 * time.Millisecond,
 		}
 		store, err := sqlite.NewSQLiteMetadataStore(ctx, cfg, sqliteTestCapabilities())
 		if err != nil {
@@ -79,90 +63,94 @@ func TestSQLite_ConcurrentWritesBackpressureNoEIO(t *testing.T) {
 
 	// First handle owns migration + creates the shared share/root row.
 	const share = "/hot"
-	primary := newStore(true)
-	if _, err := primary.CreateRootDirectory(ctx, share, &metadata.FileAttr{Mode: 0o755}); err != nil {
+	holder := newStore(true)
+	if _, err := holder.CreateRootDirectory(ctx, share, &metadata.FileAttr{Mode: 0o755}); err != nil {
 		t.Fatalf("CreateRootDirectory(%q): %v", share, err)
 	}
+	// Second connection to the SAME file, so the two genuinely collide on the
+	// sqlite write lock rather than queueing behind one pool.
+	contender := newStore(false)
 
-	// Several independent connections (one per store handle) to the SAME file so
-	// concurrent writers genuinely collide on the sqlite write lock.
-	const (
-		stores          = 4
-		writersPerStore = 4
-		iters           = 60
+	// Resolved before either transaction opens: each store pins MaxOpenConns(1),
+	// so a store call made from inside its own transaction would wait forever for
+	// the connection that transaction is holding.
+	root, err := holder.GetRootHandle(ctx, share)
+	if err != nil {
+		t.Fatalf("GetRootHandle(%q): %v", share, err)
+	}
+
+	touchRoot := func(tx metadata.Transaction) error {
+		f, err := tx.GetFile(ctx, root)
+		if err != nil {
+			return err
+		}
+		f.Mtime = time.Now()
+		return tx.UpdateAttrs(ctx, f)
+	}
+
+	var (
+		locked      = make(chan struct{}) // holder owns the write lock
+		release     = make(chan struct{}) // holder may commit
+		lockedOnce  sync.Once
+		releaseOnce sync.Once
+		attempts    int // contender goroutine only; read after wg.Wait
+		blocked     time.Duration
+		holderErr   error
+		contendErr  error
+		wg          sync.WaitGroup
 	)
-	handles := []metadata.Store{primary}
-	for i := 1; i < stores; i++ {
-		handles = append(handles, newStore(false))
-	}
+	doRelease := func() { releaseOnce.Do(func() { close(release) }) }
 
-	var wg sync.WaitGroup
-	var backpressured atomic.Int64
-	errCh := make(chan error, stores*writersPerStore*iters)
-	start := make(chan struct{})
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		holderErr = holder.WithTransaction(ctx, func(tx metadata.Transaction) error {
+			if err := touchRoot(tx); err != nil {
+				return err
+			}
+			lockedOnce.Do(func() { close(locked) })
+			<-release
+			return nil
+		})
+	}()
 
-	for _, store := range handles {
-		for w := 0; w < writersPerStore; w++ {
-			wg.Add(1)
-			go func(store metadata.Store) {
-				defer wg.Done()
-				rootHandle, err := store.GetRootHandle(ctx, share)
-				if err != nil {
-					errCh <- err
-					return
-				}
-				<-start // release all writers together to maximize contention
-				for i := 0; i < iters; i++ {
-					// Bound the single call, so a regression to an unbounded wait
-					// fails here instead of hanging until the package timeout.
-					// Later than the budget, so it never becomes the budget.
-					callCtx, cancel := context.WithTimeout(ctx, callLimit)
-					began := time.Now()
-					err := store.WithTransaction(callCtx, func(tx metadata.Transaction) error {
-						// Read + rewrite the SAME parent-directory inode: a genuine
-						// hot-row write conflict across all connections.
-						f, err := tx.GetFile(callCtx, rootHandle)
-						if err != nil {
-							return err
-						}
-						f.Mtime = time.Now()
-						return tx.UpdateAttrs(callCtx, f)
-					})
-					cancel()
-					blocked := time.Since(began)
-					if err != nil {
-						if blocked >= callLimit {
-							t.Errorf("WithTransaction blocked %v without returning, past the %v budget it retries within (limit %v)", blocked, txretry.Budget, callLimit)
-							return
-						}
-						errCh <- err
-						return
-					}
-					if blocked > fixedAttemptCeiling {
-						backpressured.Add(1)
-					}
-				}
-			}(store)
-		}
-	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// However the contender ends — retried enough, or gave up — the holder
+		// must not be left blocked.
+		defer doRelease()
+		<-locked
+		began := time.Now()
+		contendErr = contender.WithTransaction(ctx, func(tx metadata.Transaction) error {
+			attempts++
+			// Past the old ceiling the loop has already proven it backpressures;
+			// free the lock so this run terminates on the retry loop's own
+			// behaviour rather than on a timer.
+			if attempts > fixedAttemptCount {
+				doRelease()
+			}
+			return touchRoot(tx)
+		})
+		blocked = time.Since(began)
+	}()
 
-	close(start)
 	wg.Wait()
-	close(errCh)
 
-	for err := range errCh {
-		var se *metadata.StoreError
-		if errors.As(err, &se) && se.Code == metadata.ErrIOError {
-			t.Fatalf("write returned EIO under contention (should backpressure, #1769): %v", err)
-		}
-		t.Fatalf("unexpected error under contention: %v", err)
+	if holderErr != nil {
+		t.Fatalf("holder transaction failed: %v", holderErr)
 	}
-
-	// How much of the retry path this run actually reached. Reported rather than
-	// asserted on: the count is how often the driver's busy_timeout was fully
-	// exhausted, which on fast idle hardware happens only a handful of times in
-	// the whole run (measured across 200 runs: min 1, median 5), so any floor
-	// would be a coin toss there. A slow or loaded machine — the one that
-	// mattered for this guard — reaches it far more often.
-	t.Logf("%d/%d transactions blocked past %v and still succeeded", backpressured.Load(), stores*writersPerStore*iters, fixedAttemptCeiling)
+	if contendErr != nil {
+		var se *metadata.StoreError
+		if errors.As(contendErr, &se) && se.Code == metadata.ErrIOError {
+			t.Fatalf("write returned EIO after %d attempts in %v under contention (should backpressure, #1769): %v",
+				attempts, blocked, contendErr)
+		}
+		t.Fatalf("unexpected error under contention: %v", contendErr)
+	}
+	if attempts <= fixedAttemptCount {
+		t.Fatalf("contending write took %d attempts, never exercised the retry path past the fixed %d-attempt ceiling",
+			attempts, fixedAttemptCount)
+	}
+	t.Logf("contending write succeeded after %d attempts blocked for %v", attempts, blocked)
 }

--- a/pkg/metadata/store/sqlite/backpressure_test.go
+++ b/pkg/metadata/store/sqlite/backpressure_test.go
@@ -14,10 +14,10 @@ import (
 
 // fixedAttemptCount is the attempt count of the fixed 3-attempt (10/20/30ms)
 // retry loop this test guards against. The contending writer must still be
-// retrying after this many attempts — that is what backpressure means here, and
-// what the old loop could not do. The count is asserted rather than the elapsed
-// time it happens to take: how long those attempts occupy is a property of the
-// machine, the attempt count is a property of the loop.
+// retrying past it — that is what backpressure means here, and what the old loop
+// could not do. The count is asserted rather than the time those attempts happen
+// to take: the count is a property of the loop, the duration a property of the
+// machine.
 const fixedAttemptCount = 3
 
 // TestSQLite_ConcurrentWritesBackpressureNoEIO is the #1769 regression guard.
@@ -31,13 +31,11 @@ const fixedAttemptCount = 3
 // A single sqlite store pins MaxOpenConns(1), so writers through one store
 // already serialize at the Go pool and never collide. Real SQLITE_BUSY
 // contention needs multiple connections to the same file, so this test opens two
-// store handles against one on-disk database: one holds a write transaction open
-// on the shared root inode while the other tries to write the same row.
-//
-// The holder releases when the contender has made more attempts than the old
-// loop ever would — not after a wall-clock interval — so the verdict is a
-// property of the retry loop rather than a race against a budget on a machine of
-// unknown speed.
+// store handles against one on-disk database: the holder keeps a write
+// transaction open on the shared root inode while the contender writes the same
+// row. The holder releases once the contender has out-retried the old loop, so
+// the verdict rests on the retry loop's behaviour rather than on a wall-clock
+// budget measured on a machine of unknown speed.
 func TestSQLite_ConcurrentWritesBackpressureNoEIO(t *testing.T) {
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "backpressure.db")
@@ -89,53 +87,52 @@ func TestSQLite_ConcurrentWritesBackpressureNoEIO(t *testing.T) {
 	}
 
 	var (
-		locked      = make(chan struct{}) // holder owns the write lock
-		release     = make(chan struct{}) // holder may commit
-		lockedOnce  sync.Once
-		releaseOnce sync.Once
-		attempts    int // contender goroutine only; read after wg.Wait
-		blocked     time.Duration
-		holderErr   error
-		contendErr  error
-		wg          sync.WaitGroup
+		locked    = make(chan struct{}) // holder owns the write lock
+		release   = make(chan struct{}) // holder may commit
+		done      = make(chan struct{}) // holder returned; holderErr readable
+		holderErr error
 	)
+	// Both callbacks re-run on every retry, and the holder retries too if its own
+	// commit collides, so each close happens at most once.
+	var lockedOnce, releaseOnce sync.Once
+	signalLocked := func() { lockedOnce.Do(func() { close(locked) }) }
 	doRelease := func() { releaseOnce.Do(func() { close(release) }) }
 
-	wg.Add(1)
 	go func() {
-		defer wg.Done()
+		defer close(done)
 		holderErr = holder.WithTransaction(ctx, func(tx metadata.Transaction) error {
 			if err := touchRoot(tx); err != nil {
 				return err
 			}
-			lockedOnce.Do(func() { close(locked) })
+			signalLocked()
 			<-release
 			return nil
 		})
 	}()
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		// However the contender ends — retried enough, or gave up — the holder
-		// must not be left blocked.
-		defer doRelease()
-		<-locked
-		began := time.Now()
-		contendErr = contender.WithTransaction(ctx, func(tx metadata.Transaction) error {
-			attempts++
-			// Past the old ceiling the loop has already proven it backpressures;
-			// free the lock so this run terminates on the retry loop's own
-			// behaviour rather than on a timer.
-			if attempts > fixedAttemptCount {
-				doRelease()
-			}
-			return touchRoot(tx)
-		})
-		blocked = time.Since(began)
-	}()
+	select {
+	case <-locked:
+	case <-done:
+		t.Fatalf("holder never took the write lock: %v", holderErr)
+	}
 
-	wg.Wait()
+	attempts := 0
+	began := time.Now()
+	contendErr := contender.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		attempts++
+		// Past the old ceiling the loop has already proven it backpressures; free
+		// the lock so this run terminates on the retry loop's own behaviour rather
+		// than on a timer.
+		if attempts > fixedAttemptCount {
+			doRelease()
+		}
+		return touchRoot(tx)
+	})
+	blocked := time.Since(began)
+	// However the contender ended — retried enough, or gave up — the holder must
+	// not be left blocked.
+	doRelease()
+	<-done
 
 	if holderErr != nil {
 		t.Fatalf("holder transaction failed: %v", holderErr)


### PR DESCRIPTION
Two flaky tests with one shape: an absolute wall-clock budget asserted against
shared, variable-speed hardware. Different packages, no code overlap — grouped
because the fix philosophy is the same. Both take the deterministic option
rather than widening a threshold, which only moves where the flake lands.

Neither failure was caused by the PR it surfaced on: #2112 appeared on #2103 and
#2100 on #2092, both of which touch `pkg/block/journal` only and cannot reach
either package.

## `TestRecentlyBrokenCache_Expiry` (#2112)

The test built the cache with a 10ms TTL and asserted `IsRecentlyBroken` on the
statement immediately after `Mark`. Windows' default system timer granularity is
~15.6ms — larger than the whole TTL — so a scheduling gap between two adjacent
statements routinely expires the entry, and the test failed at the assertion
*before* the one it exists to test.

`recentlyBrokenCache` now reads the clock through a `nowFn func() time.Time`
field defaulting to `time.Now` (the pattern already used by
`pkg/block/remote/memory`), and the test steps that clock across the TTL
boundary instead of sleeping. Both assertions are now exact, and the boundary
itself is pinned: at exactly `ttl` the entry is still present (the check is
`>`), one nanosecond later it is gone. Production behaviour is unchanged.

## `TestSQLite_ConcurrentWritesBackpressureNoEIO` (#2100)

The property worth guarding is #1769: the retry loop backpressures under write
contention rather than giving up after a fixed 3-attempt (10/20/30ms) ceiling
and returning EIO. The test measured that with 16 writers × 60 iterations on one
hot row and failed if *any* call exhausted `txretry.Budget` — so the verdict was
a function of how loaded the runner was. #1777 already raised `BusyTimeout`
1ms→50ms for the same failure; that bought headroom without removing the
dependence on machine speed, and a contended Linux runner reached the budget
anyway.

The race is replaced by a scheduled collision. Two store handles open the same
database file (real cross-connection SQLITE_BUSY contention — a single store
pins `MaxOpenConns(1)` and never collides with itself). One holds a write
transaction open on the shared root inode; the other writes the same row and
backpressures. The holder releases **when the contender has retried past the
fixed 3-attempt ceiling**, not after a wall-clock interval, so nothing waits on
a timer and the test terminates on the retry loop's own behaviour.

What is asserted is the attempt count — a property of the loop — plus "no EIO".
Elapsed time is logged, not asserted: it belongs to the machine. That is also
why the old `blocked > 60ms` check is gone; in WAL mode a contending write
frequently returns `SQLITE_BUSY_SNAPSHOT` well inside `busy_timeout`, so four
genuine retries can complete in 30ms on an idle laptop.

The guard still bites. Forcing `txretry.Backoff` to give up after 3 attempts
(simulating the #1769 regression) fails the test as intended:

```
--- FAIL: TestSQLite_ConcurrentWritesBackpressureNoEIO (0.03s)
    backpressure_test.go:148: write returned EIO after 3 attempts in 7.082708ms under contention (should backpressure, #1769): IOError: tx: database busy, retry
```

`txretry.Budget` is untouched.

## Verification

```
$ go test -race -count=50 ./pkg/metadata/lock/
ok  	github.com/marmos91/dittofs/pkg/metadata/lock	176.552s

$ go test -race -count=50 -run TestSQLite_ConcurrentWritesBackpressureNoEIO ./pkg/metadata/store/sqlite/
ok  	github.com/marmos91/dittofs/pkg/metadata/store/sqlite	102.060s

$ go test -race -count=10 ./pkg/metadata/store/sqlite/
ok  	github.com/marmos91/dittofs/pkg/metadata/store/sqlite	456.170s
```

That sqlite run was deliberately made to compete for the machine with a
concurrent 50-iteration run of the whole package — it took 8x longer than the
same command on an idle laptop (12.9s) and returned the same verdict, which is
the property the rewrite was for.

The rewritten backpressure test is also an order of magnitude cheaper than the
one it replaces, which took 29s for a single run on the CI job that failed.

Closes #2112
Closes #2100
