### PR TITLE
fix(smb): arm the session-cleanup barrier before draining a dying connection

### DIFF
--- a/internal/adapter/smb/handlers/cleanup_barrier.go
+++ b/internal/adapter/smb/handlers/cleanup_barrier.go
@@ -1,6 +1,10 @@
 package handlers
 
-import "sync"
+import (
+	"sync"
+
+	"github.com/marmos91/dittofs/internal/logger"
+)
 
 // alreadyIdle is the channel a barrier with nothing outstanding hands out.
 var alreadyIdle = func() chan struct{} {
@@ -43,10 +47,16 @@ func (b *cleanupBarrier) Add(count int) {
 }
 
 // Done retires one in-progress cleanup, releasing waiters when it was the last.
+//
+// A Done with nothing outstanding is an accounting bug in the close path — it
+// would have opened the barrier early, which is the very thing the barrier
+// exists to prevent — so it is logged rather than swallowed. It is not applied:
+// going negative would close an already-closed channel on the next Done.
 func (b *cleanupBarrier) Done() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.n == 0 {
+		logger.Error("cleanup barrier: Done with no cleanup outstanding")
 		return
 	}
 	b.n--

--- a/internal/adapter/smb/handlers/cleanup_barrier.go
+++ b/internal/adapter/smb/handlers/cleanup_barrier.go
@@ -1,0 +1,66 @@
+package handlers
+
+import "sync"
+
+// alreadyIdle is the channel a barrier with nothing outstanding hands out.
+var alreadyIdle = func() chan struct{} {
+	c := make(chan struct{})
+	close(c)
+	return c
+}()
+
+// cleanupBarrier counts in-progress session cleanups and lets waiters block
+// until the count is back to zero. The zero value is ready to use.
+//
+// A sync.WaitGroup cannot serve here: arming happens on whichever connection
+// goroutine just lost its socket, while the waiter is a SESSION_SETUP on an
+// unrelated connection, so Add routinely runs from zero with a Wait already in
+// flight. That is the one WaitGroup usage the race detector rejects, and the
+// reason it rejects it is exactly the failure that matters — a Wait that has
+// already sampled the counter as zero returns even though the Add happened
+// first, letting the new session through before the old one's handles are gone.
+//
+// The idle channel carries the state instead: it is open while cleanups are
+// outstanding and closed while there are none, so a waiter that reads it after
+// an Add is guaranteed to see the open channel.
+type cleanupBarrier struct {
+	mu   sync.Mutex
+	n    int
+	idle chan struct{}
+}
+
+// Add registers count more in-progress cleanups.
+func (b *cleanupBarrier) Add(count int) {
+	if count <= 0 {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.n == 0 {
+		b.idle = make(chan struct{})
+	}
+	b.n += count
+}
+
+// Done retires one in-progress cleanup, releasing waiters when it was the last.
+func (b *cleanupBarrier) Done() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.n == 0 {
+		return
+	}
+	b.n--
+	if b.n == 0 {
+		close(b.idle)
+	}
+}
+
+// Idle returns a channel that is closed once no cleanup is outstanding.
+func (b *cleanupBarrier) Idle() <-chan struct{} {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.idle == nil {
+		return alreadyIdle
+	}
+	return b.idle
+}

--- a/internal/adapter/smb/handlers/cleanup_barrier_test.go
+++ b/internal/adapter/smb/handlers/cleanup_barrier_test.go
@@ -1,0 +1,78 @@
+package handlers
+
+import (
+	"sync"
+	"testing"
+)
+
+func isIdle(b *cleanupBarrier) bool {
+	select {
+	case <-b.Idle():
+		return true
+	default:
+		return false
+	}
+}
+
+func TestCleanupBarrier(t *testing.T) {
+	var b cleanupBarrier
+
+	if !isIdle(&b) {
+		t.Fatal("zero-value barrier should be idle")
+	}
+	if b.Add(0); !isIdle(&b) {
+		t.Fatal("Add(0) should leave the barrier idle")
+	}
+
+	// A waiter that took the channel before the last Done must still be woken.
+	b.Add(2)
+	held := b.Idle()
+	b.Add(1)
+	if isIdle(&b) {
+		t.Fatal("barrier reported idle with cleanups outstanding")
+	}
+	for i := 0; i < 3; i++ {
+		b.Done()
+	}
+	select {
+	case <-held:
+	default:
+		t.Fatal("channel captured before the last Done was not closed")
+	}
+	if !isIdle(&b) {
+		t.Fatal("barrier should be idle once every cleanup is retired")
+	}
+
+	// Re-arming after going idle hands out a fresh, open channel.
+	b.Add(1)
+	if isIdle(&b) {
+		t.Fatal("re-armed barrier reported idle")
+	}
+	b.Done()
+
+	// An unbalanced Done must not double-close the idle channel.
+	b.Done()
+	if !isIdle(&b) {
+		t.Fatal("barrier should stay idle after an unbalanced Done")
+	}
+}
+
+func TestCleanupBarrierConcurrentAddDone(t *testing.T) {
+	var b cleanupBarrier
+	var wg sync.WaitGroup
+
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			b.Add(1)
+			_ = isIdle(&b)
+			b.Done()
+		}()
+	}
+	wg.Wait()
+
+	if !isIdle(&b) {
+		t.Fatal("barrier should be idle after every Add was matched by a Done")
+	}
+}

--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -469,12 +469,16 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 				if bytes.Equal(other.MetadataHandle, openFile.MetadataHandle) {
 					// Guard the write: concurrent QUERY_INFO/WRITE goroutines on
 					// the same session may be reading these fields on `other`.
+					// The write lands on the pointer the handle table already
+					// holds, so no re-Store follows: re-Storing would resurrect
+					// a handle whose own CLOSE removed it between this Range and
+					// here, leaving a delete-pending entry nothing ever reaps and
+					// every later CREATE on the path answered DELETE_PENDING.
 					other.mu.Lock()
 					other.DeletePending = true
 					other.DeleteOnCloseParentKey = openFile.DeleteOnCloseParentKey
 					other.HasDeleteOnCloseParentKey = openFile.HasDeleteOnCloseParentKey
 					other.mu.Unlock()
-					h.StoreOpenFile(other)
 				}
 				return true
 			})
@@ -497,7 +501,6 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 				other.DeleteOnCloseParentKey = openFile.DeleteOnCloseParentKey
 				other.HasDeleteOnCloseParentKey = openFile.HasDeleteOnCloseParentKey
 				other.mu.Unlock()
-				h.StoreOpenFile(other)
 				return true
 			})
 			logger.Debug("CLOSE: base file DOC deferred to stream handles",

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -1760,14 +1760,9 @@ func (h *Handler) WaitForCleanup() {
 // SignalPendingCleanup registers count in-progress cleanups on the barrier.
 // It MUST be called before any cleanup work begins — including draining the
 // dying connection's in-flight requests — so WaitForCleanup() in a new
-// session's SESSION_SETUP blocks until that cleanup is done.
-//
-// The race: when a connection drops, cleanup runs on the old connection's
-// goroutine. The accept loop can spawn a new connection goroutine before the
-// old one gets that far. Every step arming happens after is a window in which
-// WaitForCleanup sees an idle barrier while the old session's open files are
-// still in the handle table, and a CREATE on one of their paths can be refused
-// with STATUS_DELETE_PENDING or STATUS_SHARING_VIOLATION.
+// session's SESSION_SETUP blocks until that cleanup is done. Every step
+// arming happens after is a window in which WaitForCleanup sees an idle
+// barrier while the old session's open files are still in the handle table.
 func (h *Handler) SignalPendingCleanup(count int) {
 	h.cleanup.Add(count)
 }

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -1496,7 +1496,6 @@ func (h *Handler) closeFilesWithFilter(
 						other.DeleteOnCloseParentKey = openFile.DeleteOnCloseParentKey
 						other.HasDeleteOnCloseParentKey = openFile.HasDeleteOnCloseParentKey
 						other.mu.Unlock()
-						h.StoreOpenFile(other)
 					}
 					return true
 				})

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -301,12 +301,12 @@ type Handler struct {
 	// Defaults to 60000 (60 seconds). Configurable via SMBAdapterSettings.
 	DurableTimeoutMs uint32
 
-	// cleanupWg tracks in-progress session cleanups. New SESSION_SETUP
-	// requests wait for this to reach zero before proceeding, ensuring
+	// cleanup counts in-progress session cleanups. New SESSION_SETUP
+	// requests wait for it to reach zero before proceeding, ensuring
 	// that stale state from a disconnected session (open files, leases,
 	// change-notify watchers) is fully removed before a new session's
 	// operations can observe the shared Handler maps.
-	cleanupWg sync.WaitGroup
+	cleanup cleanupBarrier
 
 	// resumeKeys maps opaque 24-byte resume keys to FileIDs for FSCTL_SRV_COPYCHUNK.
 	// Keys are issued via FSCTL_SRV_REQUEST_RESUME_KEY and revoked on file close.
@@ -1751,39 +1751,34 @@ func (h *Handler) DeleteAllTreesForSession(sessionID uint64) int {
 // The timeout prevents indefinite blocking when cleanup is slow (e.g., flushing
 // many open files), which would cause smbtorture connection timeouts.
 func (h *Handler) WaitForCleanup() {
-	done := make(chan struct{})
-	go func() {
-		h.cleanupWg.Wait()
-		close(done)
-	}()
 	select {
-	case <-done:
+	case <-h.cleanup.Idle():
 	case <-time.After(3 * time.Second):
 		logger.Warn("WaitForCleanup: timed out after 3s, proceeding with session setup")
 	}
 }
 
-// SignalPendingCleanup increments the cleanup WaitGroup by count.
-// This MUST be called before any async cleanup work begins, to ensure
-// that WaitForCleanup() in a new session's SESSION_SETUP will block
-// until the cleanup is done.
+// SignalPendingCleanup registers count in-progress cleanups on the barrier.
+// It MUST be called before any cleanup work begins — including draining the
+// dying connection's in-flight requests — so WaitForCleanup() in a new
+// session's SESSION_SETUP blocks until that cleanup is done.
 //
-// The race: When a connection drops, cleanup runs in the old connection's
-// goroutine. The accept loop can spawn a new connection goroutine before
-// the old goroutine enters CleanupSession. If Add(1) is inside
-// CleanupSession, there is a window where WaitForCleanup returns 0
-// (no pending cleanup) even though cleanup has not started yet.
-// By calling SignalPendingCleanup before the cleanup loop, the WaitGroup
-// is guaranteed to be non-zero when the new session checks it.
+// The race: when a connection drops, cleanup runs on the old connection's
+// goroutine. The accept loop can spawn a new connection goroutine before the
+// old one gets that far. Every step arming happens after is a window in which
+// WaitForCleanup sees an idle barrier while the old session's open files are
+// still in the handle table, and a CREATE on one of their paths can be refused
+// with STATUS_DELETE_PENDING or STATUS_SHARING_VIOLATION.
 func (h *Handler) SignalPendingCleanup(count int) {
-	h.cleanupWg.Add(count)
+	h.cleanup.Add(count)
 }
 
-// SignalCleanupDone decrements the cleanup WaitGroup by one.
-// Used by panic recovery in the cleanup loop to release remaining slots
-// when CleanupSession cannot be called (because it would call Done itself).
+// SignalCleanupDone retires one in-progress cleanup on the barrier. Used by
+// the connection close path and by panic recovery in the cleanup loop, to
+// release remaining slots when CleanupSession cannot be called (because it
+// would call Done itself).
 func (h *Handler) SignalCleanupDone() {
-	h.cleanupWg.Done()
+	h.cleanup.Done()
 }
 
 // ExpireSessionNotifies completes any pending CHANGE_NOTIFY requests for a
@@ -1930,9 +1925,9 @@ func (h *Handler) cancelAsyncOpsForSession(sessionID uint64) {
 //
 // IMPORTANT: The caller must call SignalPendingCleanup(1) before calling
 // CleanupSession to ensure the cleanup barrier is visible to new sessions.
-// The WaitGroup decrement (Done) happens via defer.
+// The matching Done happens via defer.
 func (h *Handler) CleanupSession(ctx context.Context, sessionID uint64, isDisconnect bool) {
-	defer h.cleanupWg.Done()
+	defer h.cleanup.Done()
 
 	logger.Debug("CleanupSession: starting cleanup", "sessionID", sessionID, "isDisconnect", isDisconnect)
 

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -1917,9 +1917,10 @@ func (h *Handler) cancelAsyncOpsForSession(sessionID uint64) {
 // When isDisconnect is true (transport drop), durable handles are preserved.
 // When false (explicit LOGOFF), all handles are fully closed.
 //
-// IMPORTANT: The caller must call SignalPendingCleanup(1) before calling
-// CleanupSession to ensure the cleanup barrier is visible to new sessions.
-// The matching Done happens via defer.
+// IMPORTANT: this consumes one cleanup-barrier count, retired from a defer so
+// it is released on a panicking unwind too. The caller must have armed that
+// count with SignalPendingCleanup before the call — one per session it is about
+// to clean up — so the barrier is visible to new sessions for the whole span.
 func (h *Handler) CleanupSession(ctx context.Context, sessionID uint64, isDisconnect bool) {
 	defer h.cleanup.Done()
 

--- a/internal/adapter/smb/handlers/reopen2_e2e_test.go
+++ b/internal/adapter/smb/handlers/reopen2_e2e_test.go
@@ -166,7 +166,7 @@ func (e *reopen2Env) initialLeaseDurableOpen(
 // state via GetLeaseState and writes the durable handle) and the real lease
 // release (releaseSessionLeasesAndNotifies, which clears the LeaseManager). These
 // are exactly steps 1 and 2 of Handler.CleanupSession; calling CleanupSession
-// directly would trip its cleanupWg.Done without a matching Add (that bookkeeping
+// directly would retire a cleanup-barrier count without a matching Add (that bookkeeping
 // is owned by the dispatch-layer scheduler, not the cleanup work itself).
 func (e *reopen2Env) disconnect(sessionID uint64) {
 	ctx := context.Background()

--- a/internal/adapter/smb/handlers/session_teardown_lease_leak_test.go
+++ b/internal/adapter/smb/handlers/session_teardown_lease_leak_test.go
@@ -193,8 +193,8 @@ func (e *teardownLeakEnv) create(
 }
 
 // disconnect runs the persist + lease-release halves of CleanupSession for a
-// transport drop (steps 1+2). Calling CleanupSession directly would trip its
-// cleanupWg.Done without a matching Add (owned by the dispatch scheduler).
+// transport drop (steps 1+2). Calling CleanupSession directly would retire a
+// cleanup-barrier count without a matching Add (owned by the dispatch scheduler).
 func (e *teardownLeakEnv) disconnect(sessionID uint64) {
 	ctx := context.Background()
 	e.h.CloseAllFilesForSession(ctx, sessionID, true)

--- a/pkg/adapter/smb/cleanup_barrier_test.go
+++ b/pkg/adapter/smb/cleanup_barrier_test.go
@@ -53,7 +53,7 @@ func TestConnectionClose_BarrierCoversRequestDrain(t *testing.T) {
 	// barrier before doing so; if it only arms inside cleanupSessions, that
 	// never happens while the drain is held and this loop runs out.
 	armed := false
-	for deadline := time.Now().Add(2 * time.Second); time.Now().Before(deadline); {
+	for deadline := time.Now().Add(2 * time.Second); time.Now().Before(deadline); time.Sleep(10 * time.Millisecond) {
 		if !cleanupBarrierOpen(c, 50*time.Millisecond) {
 			armed = true
 			break

--- a/pkg/adapter/smb/cleanup_barrier_test.go
+++ b/pkg/adapter/smb/cleanup_barrier_test.go
@@ -1,0 +1,79 @@
+package smb
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// cleanupBarrierOpen reports whether a SESSION_SETUP-style barrier wait gets
+// through within d. False means the barrier is holding new sessions back.
+func cleanupBarrierOpen(c *Connection, d time.Duration) bool {
+	done := make(chan struct{})
+	go func() {
+		c.server.handler.WaitForCleanup()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(d):
+		return false
+	}
+}
+
+// TestConnectionClose_BarrierCoversRequestDrain pins the ordering that keeps a
+// reconnecting client from seeing the previous connection's open files.
+//
+// The close path drains in-flight request goroutines (c.wg.Wait()) before it
+// reaches cleanupSessions, which is where the per-session cleanup counts are
+// added. If the barrier is only armed there, a new connection's SESSION_SETUP
+// that lands during the drain passes straight through while the dying
+// connection's handles are still in the handle table — long enough for a CREATE
+// to be refused with STATUS_DELETE_PENDING by a leftover delete-on-close
+// handle. The barrier must therefore be armed before the drain, not after.
+func TestConnectionClose_BarrierCoversRequestDrain(t *testing.T) {
+	server, client := net.Pipe()
+	defer func() { _ = server.Close() }()
+	defer func() { _ = client.Close() }()
+
+	c := newTestConnection(server)
+
+	// Model a request goroutine that has not finished yet: the read loop has
+	// exited (handleConnectionClose runs) but the drain cannot complete.
+	c.wg.Add(1)
+
+	closed := make(chan struct{})
+	go func() {
+		c.handleConnectionClose()
+		close(closed)
+	}()
+
+	// The close path parks in c.wg.Wait() and stays there. It must arm the
+	// barrier before doing so; if it only arms inside cleanupSessions, that
+	// never happens while the drain is held and this loop runs out.
+	armed := false
+	for deadline := time.Now().Add(2 * time.Second); time.Now().Before(deadline); {
+		if !cleanupBarrierOpen(c, 50*time.Millisecond) {
+			armed = true
+			break
+		}
+	}
+	if !armed {
+		t.Fatal("cleanup barrier stayed open while the closing connection was draining in-flight requests")
+	}
+
+	c.wg.Done()
+
+	select {
+	case <-closed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleConnectionClose did not finish after the drain completed")
+	}
+
+	// Once the close path is done the barrier must open again, or every later
+	// SESSION_SETUP eats the 3s WaitForCleanup timeout.
+	if !cleanupBarrierOpen(c, 2*time.Second) {
+		t.Fatal("cleanup barrier still closed after connection close completed")
+	}
+}

--- a/pkg/adapter/smb/connection.go
+++ b/pkg/adapter/smb/connection.go
@@ -438,6 +438,22 @@ func (c *Connection) handleConnectionClose() {
 		logger.Error("Panic in SMB connection handler", "address", clientAddr, "error", r)
 	}
 
+	// Arm the cleanup barrier here, before anything else on the close path.
+	// A new connection's SESSION_SETUP waits on this barrier (WaitForCleanup)
+	// so it never observes handles belonging to a connection that is going
+	// away. cleanupSessions arms it too, but only once it is reached — which
+	// is after c.wg.Wait() has drained every in-flight request goroutine.
+	// A client that closes one socket and immediately opens another can be
+	// served inside that drain window, and then sees the dead connection's
+	// open files: a CREATE on a path whose leftover handle carries
+	// delete-on-close returns STATUS_DELETE_PENDING, and one whose leftover
+	// handle conflicts on share mode returns STATUS_SHARING_VIOLATION.
+	// Holding one count across the whole close path covers the drain too;
+	// the counts cleanupSessions adds for its own per-session teardown nest
+	// inside it.
+	c.server.handler.SignalPendingCleanup(1)
+	defer c.server.handler.SignalCleanupDone()
+
 	start := time.Now()
 	c.wg.Wait()
 	waitDur := time.Since(start)

--- a/pkg/adapter/smb/connection.go
+++ b/pkg/adapter/smb/connection.go
@@ -438,19 +438,17 @@ func (c *Connection) handleConnectionClose() {
 		logger.Error("Panic in SMB connection handler", "address", clientAddr, "error", r)
 	}
 
-	// Arm the cleanup barrier here, before anything else on the close path.
-	// A new connection's SESSION_SETUP waits on this barrier (WaitForCleanup)
-	// so it never observes handles belonging to a connection that is going
-	// away. cleanupSessions arms it too, but only once it is reached — which
-	// is after c.wg.Wait() has drained every in-flight request goroutine.
-	// A client that closes one socket and immediately opens another can be
-	// served inside that drain window, and then sees the dead connection's
-	// open files: a CREATE on a path whose leftover handle carries
-	// delete-on-close returns STATUS_DELETE_PENDING, and one whose leftover
-	// handle conflicts on share mode returns STATUS_SHARING_VIOLATION.
-	// Holding one count across the whole close path covers the drain too;
-	// the counts cleanupSessions adds for its own per-session teardown nest
-	// inside it.
+	// Arm the cleanup barrier before the drain below. A new connection's
+	// SESSION_SETUP waits on this barrier (WaitForCleanup) so it never
+	// observes handles belonging to a connection that is going away.
+	// cleanupSessions arms it too, but only once it is reached — after
+	// c.wg.Wait() has drained every in-flight request goroutine. A client
+	// that closes one socket and immediately opens another can be served
+	// inside that drain window and see the dead connection's open files: a
+	// CREATE on a path whose leftover handle carries delete-on-close is
+	// refused with STATUS_DELETE_PENDING, and one that conflicts on share
+	// mode with STATUS_SHARING_VIOLATION. This one count spans the whole
+	// close path; the per-session counts cleanupSessions adds nest inside it.
 	c.server.handler.SignalPendingCleanup(1)
 	defer c.server.handler.SignalCleanupDone()
 
@@ -526,19 +524,18 @@ func (c *Connection) cleanupSessions() {
 	// State leak detection: log state before cleanup starts
 	c.server.handler.LogStateSnapshot("Connection close: state before session cleanup", 0)
 
-	// Signal the cleanup barrier BEFORE starting any cleanup work.
-	// This ensures that WaitForCleanup() in a new connection's SESSION_SETUP
-	// will block even if the new goroutine reaches SESSION_SETUP before we
-	// enter CleanupSession. Without this pre-increment, there is a race window
-	// where cleanupWg is 0 (Add hasn't been called yet) and WaitForCleanup
-	// returns immediately, allowing the new session to access stale state.
+	// Count the sessions about to be torn down before any cleanup work starts:
+	// CleanupSession retires one count each, so WaitForCleanup() in a new
+	// connection's SESSION_SETUP keeps blocking until the last of them
+	// returns. These counts nest inside the one handleConnectionClose holds
+	// across the whole close path.
 	c.server.handler.SignalPendingCleanup(len(dying))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	// Guard the cleanup loop against panics. If CleanupSession panics,
-	// call Done() for remaining sessions so cleanupWg doesn't get stuck,
+	// call Done() for remaining sessions so the barrier doesn't get stuck,
 	// then re-panic to preserve the original failure signal.
 	cleaned := 0
 	defer func() {

--- a/pkg/adapter/smb/connection.go
+++ b/pkg/adapter/smb/connection.go
@@ -534,14 +534,20 @@ func (c *Connection) cleanupSessions() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	// Guard the cleanup loop against panics. If CleanupSession panics,
-	// call Done() for remaining sessions so the barrier doesn't get stuck,
-	// then re-panic to preserve the original failure signal.
-	cleaned := 0
+	// Guard the cleanup loop against panics. If CleanupSession panics, retire
+	// the counts of the sessions it never reached so the barrier doesn't get
+	// stuck, then re-panic to preserve the original failure signal.
+	//
+	// retired counts sessions whose count is already gone, so it is bumped
+	// BEFORE the call, not after: CleanupSession retires its own count from a
+	// defer, which runs on the panicking unwind too. Counting only the
+	// completed ones would release the panicking session's count a second
+	// time and open the barrier while a session that was never touched still
+	// has open files in the handle table.
+	retired := 0
 	defer func() {
 		if r := recover(); r != nil {
-			remaining := len(dying) - cleaned
-			for i := 0; i < remaining; i++ {
+			for i := retired; i < len(dying); i++ {
 				c.server.handler.SignalCleanupDone()
 			}
 			panic(r)
@@ -549,8 +555,8 @@ func (c *Connection) cleanupSessions() {
 	}()
 
 	for _, sessionID := range dying {
+		retired++
 		c.server.handler.CleanupSession(ctx, sessionID, true /* transport disconnect */)
-		cleaned++
 	}
 
 	// State leak detection: log final state after all session cleanups


### PR DESCRIPTION
Closes #2107.

## The premise held, and the failure has an exact mechanism

`smb2.ioctl.trim_simple` failed with its setup CREATE rejected `NT_STATUS_DELETE_PENDING`. The
issue is right that this has nothing to do with trim (the test's normal outcome is SKIP at
`ioctl.c:5734`, and the run never reached that line) and right that PR #2092 cannot have caused
it — re-verified here in two lines: `journal.Open` still has exactly one caller,
`pkg/block/local/fs/fs.go:165`, and every smbtorture profile in `bootstrap.sh` configures
`store block local add --type memory`, so no journal store is ever constructed in that process.

What the issue could not establish, and this PR does, is why the CREATE was refused. It is not a
statistical argument.

**`STATUS_DELETE_PENDING` has exactly two sources on the CREATE path**, both in
`internal/adapter/smb/handlers/create.go` (`:1418`, `:1427`), and both are the same gate:
`isFileOrBaseDeletePending`, which returns true only when an entry in the handler's open-file
table carries `DeletePending` or `BaseFileDeletePending`. So the failing CREATE necessarily saw a
handle in that table.

**It was not the test's own handle.** In Samba 4.22.6, `test_setup_create_fill` (`ioctl.c:331`)
is `smb2_util_unlink(tree, fname)` — a CREATE with `FILE_DELETE_ON_CLOSE` followed by a CLOSE —
and then `test_setup_open` (the CREATE that failed, at `ioctl.c:325`). Those are serialized on one
connection, and `close.go` removes the handle from the table at step 10, before the CLOSE response
is written. By the time the client sends the next CREATE, its own unlink handle is gone.

**It was the previous test's handle.** `test_ioctl_sparse_qar_overflow`, registered immediately
before `trim_simple` (`ioctl.c:7716`), returns without ever closing `fh` — it leaks an open handle
on `FNAME`. `torture_suite_add_1smb2_test` gives each test a fresh connection and tears the
previous one down with `talloc_free`, i.e. a bare socket close with no LOGOFF or TDIS. So the
leaked handle goes away only when the server finishes tearing down the dead connection, and that
teardown is asynchronous with respect to the next test's traffic. If it has not finished:

1. `smb2_util_unlink`'s CREATE succeeds (share access is `DELETE|READ|WRITE` on both opens).
2. Its CLOSE promotes delete-on-close, finds the leaked handle as another open on the same file,
   and per MS-FSA 2.1.5.4 propagates `DeletePending` to it instead of unlinking.
3. `test_setup_open`'s CREATE finds the file still present with a delete-pending handle on it →
   `STATUS_DELETE_PENDING`.

It then heals itself as soon as the teardown lands, which is why a rerun is green and why the
occurrence count stayed at 1.

## The actual defect: the barrier that should have prevented this is armed one step too late

DittoFS already has the mechanism for this. `SessionSetup` calls `WaitForCleanup()` precisely so
a reconnecting client never observes a dying connection's shared state. The bug is where it gets
armed.

`handleConnectionClose` (`pkg/adapter/smb/connection.go`) runs `c.wg.Wait()` — draining every
in-flight request goroutine on the dead connection — and only then calls `cleanupSessions()`,
which is where `SignalPendingCleanup` lived. A new connection's SESSION_SETUP that lands during
that drain sees an idle barrier and sails through, while the dead connection's open files are all
still in the table. Under a loaded runner (that run had seven suites cut short by timeout, i.e.
#2098 in the wild) the drain is exactly where the scheduling delay accumulates.

The barrier is now armed at the top of the close path, before the drain, with one count held
across the whole thing; the per-session counts `cleanupSessions` adds nest inside it. This closes
the window down to the goroutine wake on the socket EOF itself, which is on the same goroutine as
the arming and so has no further gap to give away.

## The barrier could also fail to hold when it *was* armed

The barrier was a `sync.WaitGroup`. Arming happens on whichever connection goroutine just lost its
socket; the waiter is a SESSION_SETUP on an unrelated connection. That means `Add` routinely runs
from a zero counter with a `Wait` already in flight — the one usage `sync.WaitGroup` documents as
invalid, and which the Go race detector rejects. It is not academic: a `Wait` that has already
sampled the counter as zero returns even though the `Add` happened first. The first version of the
regression test below tripped the detector on it.

`cleanupBarrier` (new, `internal/adapter/smb/handlers/cleanup_barrier.go`) replaces it with a
mutex-guarded counter plus an `idle` channel that is open while cleanups are outstanding. A waiter
that reads the channel after an `Add` is guaranteed to see it open. `WaitForCleanup` now selects
on that channel and its existing 3s timeout, which also drops the goroutine it used to spawn per
call.

## Second finding on the same seam: a re-Store that resurrects a closed handle

The delete-on-close propagation blocks (`close.go` twice, `handler.go` once) write `DeletePending`
onto sibling handles found by ranging the open-file table, and then called
`h.StoreOpenFile(other)`. `other` is the pointer the table already holds, so the write is visible
without it — the Store was redundant. Worse, when a sibling's own CLOSE removed it between the
`Range` and the Store, the Store put it back with `DeletePending` set and nothing left to reap it,
so *every* later CREATE on that path answered `DELETE_PENDING` for the life of the process.

This is not what #2107 observed — it would cascade rather than heal — so it is reported here as an
adjacent latent defect found while tracing the same gate, not as the cause. The fix is deleting
three redundant calls.

## Third finding, from review: the cleanup panic path released one count too many

`cleanupSessions`' panic guard retired a barrier count for every session the loop had not
*completed*. But `CleanupSession` retires its own count from a `defer`, which runs on the panicking
unwind as well — so the panicking session's count was released twice, and the barrier could reach
zero while a session the loop never reached still had its open files in the handle table. That is
the same early-open this PR exists to prevent, arriving by the panic path instead. The guard now
counts sessions whose count is already gone.

The `sync.WaitGroup` used to make that imbalance loud (it panics on a negative counter);
`cleanupBarrier.Done` cannot go negative without double-closing its channel, so an unbalanced Done
is logged at error instead of silently swallowed.

## The shape, and where else it appears

All three fixes above are one defect shape: **sample state, then act on the sample across a step or
lock boundary that lets the state change in between.** The barrier count was added after the drain
rather than before it; the panic guard counted completions rather than releases; the propagation
re-Stored an entry it had sampled by `Range` and that a concurrent CLOSE could have removed.

Two more instances in the same teardown path, checked while here:

- `removeChannelsAndPartition` samples `sess.ChannelCount()` and then tears the session down. A
  SESSION_SETUP binding a channel in between would destroy a session under a live channel. Arming
  the barrier at the top of the close path closes this one too, since the binder now waits — worth
  recording, because it was open for the same reason and is fixed by the same line.
- `close.go` decides "am I the last handle on this file?" at step 8 and removes itself from the
  table at step 10. Two concurrent last-handle closes can each see the other and each defer the
  delete, so the unlink is lost. `renameScanMu` covers steps 10–11 only; the step 8 scan is
  outside it. Filed as #2126 rather than folded in — it is a different failure (a lost delete, not
  an early-opened barrier), it predates this PR, and it wants its own reproduction.

## Verification

`internal/adapter/smb/handlers/cleanup_barrier_test.go` covers the barrier primitive itself
(zero value, a waiter that captured the channel before the last Done, re-arming, an unbalanced
Done, and concurrent Add/Done under `-race`).

`pkg/adapter/smb/cleanup_barrier_test.go` reproduces the window deterministically: hold the
connection's request drain, then check whether the cleanup barrier lets a SESSION_SETUP-style wait
through.

Without the arming change (fix reverted, everything else in place):

```
--- FAIL: TestConnectionClose_BarrierCoversRequestDrain (2.00s)
    cleanup_barrier_test.go:63: cleanup barrier stayed open while the closing connection was draining in-flight requests
FAIL
```

With it, `-race -count=5`:

```
ok  	github.com/marmos91/dittofs/pkg/adapter/smb	2.904s
```

`go build ./...`, `go vet ./...`, `gofmt`, `go test ./...` and `go test -race` over
`./internal/adapter/smb/... ./pkg/adapter/smb/...` are clean.

## What this does not claim

The residual window is smaller, not zero: the server still learns the connection is gone only when
its read loop wakes on EOF, and nothing can arm a barrier before that. Samba has the same
asynchrony (a forked child releasing share modes as it exits), so a sufficiently starved runner can
still land a CREATE inside it. The leaked handle in `test_ioctl_sparse_qar_overflow` is an upstream
test artifact and is not fixed here.

The sub-millisecond adjacency between `sparse_qar_overflow` completing and trim's create failing
was never re-readable (attempt 1's logs stopped being served once the job was superseded) and is
not relied on anywhere above; the argument is structural throughout.
