### PR TITLE
fix(engine): cross-check offline readiness against the manifest

### DIFF
--- a/pkg/block/engine/engine.go
+++ b/pkg/block/engine/engine.go
@@ -87,6 +87,10 @@ type Store struct {
 	// FileChunkStore surface).
 	fileChunkStore block.EngineFileChunkStore // optional: for block count stats
 
+	// offlineShortfall memoizes the manifest cross-check OfflineReadiness
+	// runs against the local tier's interval index.
+	offlineShortfall shortfallMemo
+
 	// coordinator handles all metadata-store operations the engine
 	// needs (RefCount mutations, ChunkRef-list persistence). May be nil
 	// in tests; production wiring (pkg/controlplane/runtime/shares/

--- a/pkg/block/engine/offline.go
+++ b/pkg/block/engine/offline.go
@@ -181,6 +181,13 @@ func offlineReadinessOf(ctx context.Context, localTier any, hasRemote bool, shor
 // file and weighed against the ranges the index reports for the same file,
 // which include cold ones — a cold range is described, just not resident.
 //
+// The union is what makes overlap a non-event, and rows do overlap: a row
+// claims a prefix of its chunk, so a row reaching past a later row's whole span
+// is kept rather than cut, and that straddler is what keeps its own tail
+// readable. Coverage here is the set of offsets some row places, which is the
+// same set a read can resolve however it picks between covering rows, so two
+// rows over one byte merge into one span instead of counting twice.
+//
 // A lost interval is not the only way to reach a shortfall. A server-side copy
 // writes the destination's manifest rows and no interval for them at all, so a
 // clone nobody has read back yet looks the same from here. That is not a false

--- a/pkg/block/engine/offline.go
+++ b/pkg/block/engine/offline.go
@@ -95,12 +95,12 @@ func (bs *Store) OfflineReadiness(ctx context.Context) OfflineReadiness {
 	if bs.closed {
 		return OfflineReadiness{Reason: "block store is closed"}
 	}
-	return offlineReadinessOf(ctx, bs.local, bs.HasRemoteStore(), bs.manifestShortfall)
+	return offlineReadinessOf(ctx, bs.local, bs.HasRemoteStore(), bs.memoizedShortfall)
 }
 
-// manifestShortfall is the store's cross-check, memoized. See shortfallMemo for
+// memoizedShortfall is the store's cross-check, memoized. See shortfallMemo for
 // why the result is reused rather than recomputed on every call.
-func (bs *Store) manifestShortfall(ctx context.Context, index coldRangeReporter) (int64, int64, error) {
+func (bs *Store) memoizedShortfall(ctx context.Context, index coldRangeReporter) (int64, int64, error) {
 	if bs.fileChunkStore == nil {
 		return 0, 0, errNoManifest
 	}
@@ -148,12 +148,8 @@ func offlineReadinessOf(ctx context.Context, localTier any, hasRemote bool, shor
 
 	// That count is the index's account of itself, so it cannot see a range the
 	// index has forgotten: no interval means no contribution, which is exactly
-	// what an absent range looks like. The manifest is written by a different
-	// subsystem and outlives a lost interval, so it is the only thing here that
-	// can tell those two apart.
-	if shortfall == nil {
-		return OfflineReadiness{Reason: "manifest cross-check did not run: " + errNoManifest.Error()}
-	}
+	// what an absent range looks like. The manifest outlives a lost interval, so
+	// it is the only thing here that can tell those two apart.
 	missing, missingRanges, err := shortfall(ctx, reporter)
 	if err != nil {
 		return OfflineReadiness{Reason: "manifest cross-check did not run: " + err.Error()}
@@ -161,7 +157,7 @@ func offlineReadinessOf(ctx context.Context, localTier any, hasRemote bool, shor
 	if missing > 0 {
 		return OfflineReadiness{Reason: fmt.Sprintf(
 			"local index does not describe %d bytes in %d ranges the manifest places, "+
-				"so how much of this share is resident cannot be determined",
+				"so whether they are remote-only or lost cannot be determined",
 			missing, missingRanges)}
 	}
 	return OfflineReadiness{RemoteOnlyBytes: bytes, RemoteOnlyRanges: ranges, Known: true}
@@ -183,6 +179,13 @@ func offlineReadinessOf(ctx context.Context, localTier any, hasRemote bool, shor
 // and reporting them is CheckManifests' job. Everything else is unioned per
 // file and weighed against the ranges the index reports for the same file,
 // which include cold ones — a cold range is described, just not resident.
+//
+// A lost interval is not the only way to reach a shortfall. A server-side copy
+// writes the destination's manifest rows and no interval for them at all, so a
+// clone nobody has read back yet looks the same from here. That is not a false
+// alarm: those bytes need the remote too, and the index cannot say which of the
+// two it is looking at, which is why the answer is indeterminate rather than a
+// remote-only count.
 //
 // ponytail: one ListFileChunks per payload, the same walk warm and the
 // block-count stats take, which is why the caller memoizes the result rather
@@ -251,23 +254,25 @@ func placedRanges(rows []*block.FileChunk) ([][2]uint64, int64) {
 // subtractExtents returns the parts of a that no extent of b covers. Both must
 // be sorted and non-overlapping, as coalesceExtents and DataExtents return
 // them; the result is too.
+//
+// ponytail: rescans b from the front for every span of a. Both lists are one
+// file's coalesced coverage, so a is usually a single span; carry a cursor
+// across spans only if a profile ever shows this walk.
 func subtractExtents(a, b [][2]uint64) [][2]uint64 {
 	var out [][2]uint64
-	j := 0
 	for _, span := range a {
 		cur := span[0]
-		// a is sorted and cur never moves backwards, so extents of b already
-		// behind it stay behind it for every later span.
-		for j < len(b) && b[j][1] <= cur {
-			j++
-		}
-		for k := j; k < len(b) && b[k][0] < span[1] && cur < span[1]; k++ {
-			if b[k][0] > cur {
-				out = append(out, [2]uint64{cur, b[k][0]})
+		for _, cover := range b {
+			if cover[1] <= cur {
+				continue // already behind the part of span still uncovered
 			}
-			if b[k][1] > cur {
-				cur = b[k][1]
+			if cover[0] >= span[1] {
+				break // b is sorted, so nothing later reaches back into span
 			}
+			if cover[0] > cur {
+				out = append(out, [2]uint64{cur, cover[0]})
+			}
+			cur = cover[1]
 		}
 		if cur < span[1] {
 			out = append(out, [2]uint64{cur, span[1]})
@@ -302,7 +307,8 @@ type shortfallMemo struct {
 func (m *shortfallMemo) get(ctx context.Context, index coldRangeReporter, chunks manifestLister) (int64, int64, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if !m.at.IsZero() && time.Since(m.at) < shortfallInterval {
+	// A zero at is older than any interval, so an empty memo falls through.
+	if time.Since(m.at) < shortfallInterval {
 		return m.bytes, m.ranges, nil
 	}
 	bytes, ranges, err := manifestShortfall(ctx, index, chunks)

--- a/pkg/block/engine/offline.go
+++ b/pkg/block/engine/offline.go
@@ -306,16 +306,18 @@ func placedRanges(rows []*block.FileChunk) ([][2]uint64, int64) {
 			continue
 		}
 		// A parsed offset is bounded to int64 and DataSize is 32 bits, so the
-		// sum cannot wrap, but it can sit past int64 — and the clamp below is
-		// handed to DataExtents as an int64.
-		rowEnd := off + uint64(row.DataSize)
+		// sum cannot wrap, but it can sit past int64 — and the index reports
+		// its side of the comparison over an int64 span, so it can never
+		// describe a byte out there. Clamping the row rather than only the
+		// span keeps that unreachable tail from reading as a missing range.
+		rowEnd := min(off+uint64(row.DataSize), math.MaxInt64)
+		if rowEnd <= off {
+			continue
+		}
 		placed = append(placed, [2]uint64{off, rowEnd})
 		if rowEnd > end {
 			end = rowEnd
 		}
-	}
-	if end > math.MaxInt64 {
-		end = math.MaxInt64
 	}
 	return coalesceExtents(placed), int64(end)
 }

--- a/pkg/block/engine/offline.go
+++ b/pkg/block/engine/offline.go
@@ -1,15 +1,33 @@
 package engine
 
-import "context"
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+)
 
 // OfflineReadiness reports whether a share could keep serving reads with its
 // remote store unreachable, and by how much it falls short.
 //
-// The question has one honest answer per share: every byte the share holds is
-// either resident in the local tier or it is not. A range that is not — one
-// written, mirrored to the remote and since evicted locally — needs the remote
-// to serve, so a share with any such range would fail reads during an outage.
-// Zero remote-only bytes is a provable offline-safe share.
+// Every byte the share holds is either resident in the local tier or it is
+// not. A range that is not — one written, mirrored to the remote and since
+// evicted locally — needs the remote to serve, so a share with any such range
+// would fail reads during an outage.
+//
+// The local tier's interval index is what reports those ranges, and it can only
+// speak for ranges it still describes. An interval lost rather than evicted
+// leaves nothing behind: it adds nothing to the tally, and a range the index has
+// forgotten is indistinguishable there from one that was never written. So the
+// tally alone proves nothing, and the measurement weighs the index against the
+// share's manifest — an independent record of what the share holds — before it
+// calls anything safe. Zero remote-only bytes AND no range the manifest places
+// that the index cannot account for is a provably offline-safe share; a
+// shortfall against the manifest makes the answer indeterminate rather than
+// safe.
 type OfflineReadiness struct {
 	// RemoteOnlyBytes is the total size of ranges the local tier no longer
 	// holds and would have to fetch from the remote to serve.
@@ -33,16 +51,37 @@ type OfflineReadiness struct {
 func (o OfflineReadiness) Safe() bool { return o.Known && o.RemoteOnlyBytes == 0 }
 
 // coldRangeReporter is the local-tier capability this needs: which of its
-// ranges are remote-only, and whether it has been told what the manifest holds
-// yet. The journal-backed tier satisfies it; the in-memory tier does not, and
-// asserting for it here keeps that from becoming another method every fake has
-// to implement.
+// ranges are remote-only, which ranges it describes for one file, and whether
+// it has been told what the manifest holds yet. The journal-backed tier
+// satisfies it; the in-memory tier does not, and asserting for it here keeps
+// that from becoming another method every fake has to implement.
 type coldRangeReporter interface {
 	ColdExtents(ctx context.Context) (bytes int64, extents int64, err error)
 	ColdSeeded() bool
+	DataExtents(ctx context.Context, payloadID string, size int64) ([][2]uint64, error)
 }
 
-// OfflineReadiness measures how much of this share's data is remote-only.
+// manifestLister is the manifest surface the cross-check reads: which files the
+// share has, and which ranges each one's rows place. block.EngineFileChunkStore
+// satisfies it.
+type manifestLister interface {
+	EnumeratePayloads(ctx context.Context, fn func(payloadID string) error) error
+	ListFileChunks(ctx context.Context, payloadID string) ([]*block.FileChunk, error)
+}
+
+// shortfallFunc reports how many bytes, in how many ranges, the share's
+// manifest places that the local tier's index does not describe at all. It is
+// passed into the gating rules rather than reached for, so those rules can be
+// exercised without a metadata store and so the store can memoize the walk.
+type shortfallFunc func(ctx context.Context, index coldRangeReporter) (bytes int64, ranges int64, err error)
+
+// errNoManifest is what the cross-check reports when the share has no manifest
+// to weigh its index against. It is a non-answer, not a clean bill of health:
+// the index alone cannot report a range it has forgotten.
+var errNoManifest = errors.New("share has no manifest to check the local index against")
+
+// OfflineReadiness measures how much of this share's data is remote-only, and
+// whether the local index can account for everything the manifest places.
 //
 // ponytail: an O(live ranges) in-memory scan of the local tier's index on
 // every call, holding one shard's lock at a time. Keeping a running counter
@@ -56,7 +95,16 @@ func (bs *Store) OfflineReadiness(ctx context.Context) OfflineReadiness {
 	if bs.closed {
 		return OfflineReadiness{Reason: "block store is closed"}
 	}
-	return offlineReadinessOf(ctx, bs.local, bs.HasRemoteStore())
+	return offlineReadinessOf(ctx, bs.local, bs.HasRemoteStore(), bs.manifestShortfall)
+}
+
+// manifestShortfall is the store's cross-check, memoized. See shortfallMemo for
+// why the result is reused rather than recomputed on every call.
+func (bs *Store) manifestShortfall(ctx context.Context, index coldRangeReporter) (int64, int64, error) {
+	if bs.fileChunkStore == nil {
+		return 0, 0, errNoManifest
+	}
+	return bs.offlineShortfall.get(ctx, index, bs.fileChunkStore)
 }
 
 // offlineReadinessOf holds the gating rules, separated from the store lookup so
@@ -64,7 +112,7 @@ func (bs *Store) OfflineReadiness(ctx context.Context) OfflineReadiness {
 // answering zero, because a zero here reads as "provably offline safe" and
 // would say that about exactly the shares whose data is most likely to be
 // remote-only.
-func offlineReadinessOf(ctx context.Context, localTier any, hasRemote bool) OfflineReadiness {
+func offlineReadinessOf(ctx context.Context, localTier any, hasRemote bool, shortfall shortfallFunc) OfflineReadiness {
 	reporter, ok := localTier.(coldRangeReporter)
 	if !ok {
 		// A tier that cannot report residency and has no remote also has
@@ -97,5 +145,173 @@ func offlineReadinessOf(ctx context.Context, localTier any, hasRemote bool) Offl
 	if err != nil {
 		return OfflineReadiness{Reason: "residency scan did not finish: " + err.Error()}
 	}
+
+	// That count is the index's account of itself, so it cannot see a range the
+	// index has forgotten: no interval means no contribution, which is exactly
+	// what an absent range looks like. The manifest is written by a different
+	// subsystem and outlives a lost interval, so it is the only thing here that
+	// can tell those two apart.
+	if shortfall == nil {
+		return OfflineReadiness{Reason: "manifest cross-check did not run: " + errNoManifest.Error()}
+	}
+	missing, missingRanges, err := shortfall(ctx, reporter)
+	if err != nil {
+		return OfflineReadiness{Reason: "manifest cross-check did not run: " + err.Error()}
+	}
+	if missing > 0 {
+		return OfflineReadiness{Reason: fmt.Sprintf(
+			"local index does not describe %d bytes in %d ranges the manifest places, "+
+				"so how much of this share is resident cannot be determined",
+			missing, missingRanges)}
+	}
 	return OfflineReadiness{RemoteOnlyBytes: bytes, RemoteOnlyRanges: ranges, Known: true}
+}
+
+// manifestShortfall reports how much of what the share's manifest places the
+// local tier's index does not describe at all.
+//
+// It is the outside opinion the readiness answer needs. The index is the thing
+// being doubted, so its own tally cannot say whether it is complete; manifest
+// rows are written by a different subsystem and survive a lost interval, so a
+// row whose range no interval covers is evidence the index has forgotten
+// something. Those bytes serve neither locally nor from the remote — nothing
+// left knows where to fetch them from — which is why a shortfall is reported as
+// indeterminate rather than folded into the remote-only count.
+//
+// Rows holding no committed bytes yet place nothing, and neither do rows whose
+// ID carries no chunk offset: where those bytes belong is unknowable from here,
+// and reporting them is CheckManifests' job. Everything else is unioned per
+// file and weighed against the ranges the index reports for the same file,
+// which include cold ones — a cold range is described, just not resident.
+//
+// ponytail: one ListFileChunks per payload, the same walk warm and the
+// block-count stats take, which is why the caller memoizes the result rather
+// than paying for it on every scrape.
+func manifestShortfall(ctx context.Context, index coldRangeReporter, chunks manifestLister) (bytes int64, ranges int64, err error) {
+	var payloads []string
+	if err := chunks.EnumeratePayloads(ctx, func(id string) error {
+		payloads = append(payloads, id)
+		return nil
+	}); err != nil {
+		return 0, 0, err
+	}
+	for _, id := range payloads {
+		if err := ctx.Err(); err != nil {
+			return 0, 0, err
+		}
+		rows, err := chunks.ListFileChunks(ctx, id)
+		if err != nil {
+			return 0, 0, err
+		}
+		placed, end := placedRanges(rows)
+		if len(placed) == 0 {
+			continue
+		}
+		described, err := index.DataExtents(ctx, id, end)
+		if err != nil {
+			return 0, 0, err
+		}
+		for _, gap := range subtractExtents(placed, described) {
+			ranges++
+			bytes += int64(gap[1] - gap[0])
+		}
+	}
+	return bytes, ranges, nil
+}
+
+// placedRanges returns one payload's manifest coverage in canonical form, plus
+// the offset its last placed byte ends at — the clamp DataExtents needs to
+// report the index's view of the same span.
+func placedRanges(rows []*block.FileChunk) ([][2]uint64, int64) {
+	placed := make([][2]uint64, 0, len(rows))
+	var end uint64
+	for _, row := range rows {
+		if row == nil || row.DataSize == 0 || row.Hash.IsZero() {
+			continue
+		}
+		off, ok := block.ParseChunkOffset(row.ID)
+		if !ok {
+			continue
+		}
+		rowEnd := off + uint64(row.DataSize)
+		if rowEnd <= off {
+			continue // an end that wrapped describes no range
+		}
+		placed = append(placed, [2]uint64{off, rowEnd})
+		if rowEnd > end {
+			end = rowEnd
+		}
+	}
+	if end > 1<<62 {
+		end = 1 << 62 // keep a corrupt row from overflowing the int64 clamp
+	}
+	return coalesceExtents(placed), int64(end)
+}
+
+// subtractExtents returns the parts of a that no extent of b covers. Both must
+// be sorted and non-overlapping, as coalesceExtents and DataExtents return
+// them; the result is too.
+func subtractExtents(a, b [][2]uint64) [][2]uint64 {
+	var out [][2]uint64
+	j := 0
+	for _, span := range a {
+		cur := span[0]
+		// a is sorted and cur never moves backwards, so extents of b already
+		// behind it stay behind it for every later span.
+		for j < len(b) && b[j][1] <= cur {
+			j++
+		}
+		for k := j; k < len(b) && b[k][0] < span[1] && cur < span[1]; k++ {
+			if b[k][0] > cur {
+				out = append(out, [2]uint64{cur, b[k][0]})
+			}
+			if b[k][1] > cur {
+				cur = b[k][1]
+			}
+		}
+		if cur < span[1] {
+			out = append(out, [2]uint64{cur, span[1]})
+		}
+	}
+	return out
+}
+
+// shortfallInterval is how long a cross-check result stands before the walk is
+// paid for again.
+const shortfallInterval = time.Minute
+
+// shortfallMemo caches the last manifest cross-check.
+//
+// The walk costs one metadata round-trip per file, and OfflineReadiness sits on
+// the metrics scrape path, which is deliberately free of per-file DB walks (see
+// MetricsBlockStats). Recomputing it per scrape would put that walk back.
+//
+// ponytail: a plain time window rather than invalidation. A shortfall is a
+// durable structural condition — a range the index has forgotten stays
+// forgotten until something repairs it — so a verdict a minute old is still the
+// right verdict, and a fresh process starts with an empty memo. Wire it to an
+// invalidation signal only if a caller ever needs the answer to move faster
+// than that.
+type shortfallMemo struct {
+	mu     sync.Mutex
+	at     time.Time
+	bytes  int64
+	ranges int64
+}
+
+func (m *shortfallMemo) get(ctx context.Context, index coldRangeReporter, chunks manifestLister) (int64, int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !m.at.IsZero() && time.Since(m.at) < shortfallInterval {
+		return m.bytes, m.ranges, nil
+	}
+	bytes, ranges, err := manifestShortfall(ctx, index, chunks)
+	if err != nil {
+		// A walk that ran out of its caller's deadline says nothing about the
+		// share, so there is nothing worth remembering: the next call gets to
+		// try again on its own budget rather than inheriting this one's.
+		return 0, 0, err
+	}
+	m.at, m.bytes, m.ranges = time.Now(), bytes, ranges
+	return bytes, ranges, nil
 }

--- a/pkg/block/engine/offline.go
+++ b/pkg/block/engine/offline.go
@@ -215,12 +215,73 @@ func manifestShortfall(ctx context.Context, index coldRangeReporter, chunks mani
 		if err != nil {
 			return 0, 0, err
 		}
-		for _, gap := range subtractExtents(placed, described) {
+		if len(subtractExtents(placed, described)) == 0 {
+			continue
+		}
+		confirmed, err := confirmShortfall(ctx, chunks, id, placed, described)
+		if err != nil {
+			return 0, 0, err
+		}
+		for _, gap := range confirmed {
 			ranges++
 			bytes += int64(gap[1] - gap[0])
 		}
 	}
 	return bytes, ranges, nil
+}
+
+// confirmShortfall re-reads one payload's manifest and keeps only the gaps its
+// rows still place, so a file being deleted or truncated while the walk runs is
+// not reported as a loss.
+//
+// The two records narrow in opposite orders, and neither operation is atomic
+// with the other. Truncate reaps the manifest before it clips the index, so an
+// index already narrow means the manifest narrowed first and this second read
+// sees it. Delete empties the index first and reaps the rows a round-trip
+// later, so the first read can catch rows whose bytes are already gone; the
+// re-read is issued after that round-trip has had a chance to land.
+//
+// Intersecting rather than replacing is what keeps a concurrent write out of
+// the count: a row the re-read added is a range whose interval was created
+// before the row, so the index would have described it had the walk looked
+// again — reporting it would be an alarm about work in progress.
+//
+// ponytail: one extra manifest read per payload that looked short, and only
+// then. A file mid-delete whose reap has not landed by the re-read is still
+// counted; make the two records narrow in the same order if that ever shows up
+// as a recurring false alarm.
+func confirmShortfall(
+	ctx context.Context,
+	chunks manifestLister,
+	payloadID string,
+	placed, described [][2]uint64,
+) ([][2]uint64, error) {
+	rows, err := chunks.ListFileChunks(ctx, payloadID)
+	if err != nil {
+		return nil, err
+	}
+	stillPlaced, _ := placedRanges(rows)
+	return subtractExtents(intersectExtents(placed, stillPlaced), described), nil
+}
+
+// intersectExtents returns the ranges covered by both a and b. Both must be
+// sorted and non-overlapping; the result is too.
+func intersectExtents(a, b [][2]uint64) [][2]uint64 {
+	var out [][2]uint64
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		start := max(a[i][0], b[j][0])
+		end := min(a[i][1], b[j][1])
+		if start < end {
+			out = append(out, [2]uint64{start, end})
+		}
+		if a[i][1] < b[j][1] {
+			i++
+		} else {
+			j++
+		}
+	}
+	return out
 }
 
 // placedRanges returns one payload's manifest coverage in canonical form, plus

--- a/pkg/block/engine/offline.go
+++ b/pkg/block/engine/offline.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -236,17 +237,17 @@ func placedRanges(rows []*block.FileChunk) ([][2]uint64, int64) {
 		if !ok {
 			continue
 		}
+		// A parsed offset is bounded to int64 and DataSize is 32 bits, so the
+		// sum cannot wrap, but it can sit past int64 — and the clamp below is
+		// handed to DataExtents as an int64.
 		rowEnd := off + uint64(row.DataSize)
-		if rowEnd <= off {
-			continue // an end that wrapped describes no range
-		}
 		placed = append(placed, [2]uint64{off, rowEnd})
 		if rowEnd > end {
 			end = rowEnd
 		}
 	}
-	if end > 1<<62 {
-		end = 1 << 62 // keep a corrupt row from overflowing the int64 clamp
+	if end > math.MaxInt64 {
+		end = math.MaxInt64
 	}
 	return coalesceExtents(placed), int64(end)
 }

--- a/pkg/block/engine/offline_manifest_test.go
+++ b/pkg/block/engine/offline_manifest_test.go
@@ -6,8 +6,10 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/engine"
 	localfs "github.com/marmos91/dittofs/pkg/block/local/fs"
 	"github.com/marmos91/dittofs/pkg/block/remote"
@@ -224,8 +226,8 @@ func TestOfflineReadiness_LostIntervalIsNotSafe(t *testing.T) {
 					t.Errorf("the pre-cross-check answer was already unsafe (%d remote-only bytes), "+
 						"so this case proves nothing about the new check", coldBytes)
 				}
-				if got.Reason == "" {
-					t.Error("refused to answer without saying why")
+				if !strings.Contains(got.Reason, "manifest places") {
+					t.Errorf("refused for some other reason than the shortfall: %q", got.Reason)
 				}
 			case "evicted":
 				// A cold range is described, just not resident: the cross-check
@@ -237,4 +239,94 @@ func TestOfflineReadiness_LostIntervalIsNotSafe(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestOfflineReadiness_CloneIsIndeterminate pins the other way a share reaches
+// a shortfall, so nobody reads the refusal as proof of a lost interval.
+//
+// A server-side copy writes the destination's manifest rows and creates no
+// interval for them — the clone's bytes are the source's, already on the
+// remote, and the read path hydrates them on demand. From the index that is
+// indistinguishable from a range whose interval was lost, and the offline
+// answer is the same either way: those bytes need the remote, and the index
+// cannot say which case it is looking at.
+//
+// If the copy path ever seeds cold intervals for its destination rows, this
+// test is what says so: the share would then report a remote-only count
+// instead, and the refusal would be left meaning a genuine loss.
+func TestOfflineReadiness_CloneIsIndeterminate(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	mem := remotememory.New()
+	bs, local := openOfflineEngine(t, dir, ms, mem)
+
+	root := createShare(t, ms, "clone")
+	src, _ := createRealFile(t, ms, "clone", "src.bin", root)
+	dst, _ := createRealFile(t, ms, "clone", "dst.bin", root)
+
+	const size = 4 * 1024 * 1024
+	data := make([]byte, size)
+	rand.New(rand.NewSource(7)).Read(data) //nolint:gosec // deterministic fixture
+	if _, err := bs.WriteAt(ctx, src, nil, data, 0); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	carve(t, bs, ctx, src)
+	if err := local.MarkColdSeeded(); err != nil {
+		t.Fatalf("MarkColdSeeded: %v", err)
+	}
+
+	// The source alone is resident and accounted for.
+	if got := bs.OfflineReadiness(ctx); !got.Safe() {
+		t.Fatalf("before the clone: Safe() = false, want true (reason %q)", got.Reason)
+	}
+
+	srcRows, err := ms.ListFileChunks(ctx, src)
+	if err != nil {
+		t.Fatalf("ListFileChunks: %v", err)
+	}
+	var refs []block.ChunkRef
+	for _, r := range srcRows {
+		off, ok := block.ParseChunkOffset(r.ID)
+		if !ok || r.Hash.IsZero() {
+			continue
+		}
+		refs = append(refs, block.ChunkRef{Hash: r.Hash, Offset: off, Size: r.DataSize})
+	}
+	if len(refs) == 0 {
+		t.Fatal("the source carved no placeable rows, so the clone would copy nothing")
+	}
+	if _, err := bs.CopyPayload(ctx, src, dst, refs); err != nil {
+		t.Fatalf("CopyPayload: %v", err)
+	}
+
+	described, err := local.DataExtents(ctx, dst, size)
+	if err != nil {
+		t.Fatalf("DataExtents: %v", err)
+	}
+	if len(described) != 0 {
+		t.Fatalf("the copy created %d index extents for the destination; "+
+			"the shortfall this test describes no longer happens", len(described))
+	}
+
+	// The memo was filled by the safe answer above, so the store is reopened
+	// over the same journal — same seed marker, same index, empty memo — rather
+	// than replaced, which would refuse for want of a seed instead.
+	if err := bs.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	bs, local = openOfflineEngine(t, dir, ms, mem)
+	t.Cleanup(func() { _ = bs.Close() })
+	if !local.ColdSeeded() {
+		t.Fatal("the reopened tier lost its seed marker, so the refusal below would not be the shortfall")
+	}
+
+	got := bs.OfflineReadiness(ctx)
+	if got.Known || got.Safe() {
+		t.Errorf("a share holding an unhydrated clone reported known=%v safe=%v", got.Known, got.Safe())
+	}
+	if !strings.Contains(got.Reason, "manifest places") {
+		t.Errorf("refused for some other reason than the shortfall: %q", got.Reason)
+	}
+	t.Logf("reason: %s", got.Reason)
 }

--- a/pkg/block/engine/offline_manifest_test.go
+++ b/pkg/block/engine/offline_manifest_test.go
@@ -1,0 +1,240 @@
+package engine_test
+
+import (
+	"context"
+	"io/fs"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block/engine"
+	localfs "github.com/marmos91/dittofs/pkg/block/local/fs"
+	"github.com/marmos91/dittofs/pkg/block/remote"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// keepOpenRemote hands the engine a remote it will not tear down, so the same
+// uploaded blocks are still there after the store is closed and reopened over
+// the same journal directory.
+type keepOpenRemote struct{ *remotememory.Store }
+
+func (keepOpenRemote) Close() error { return nil }
+
+var _ remote.RemoteStore = keepOpenRemote{}
+
+// openOfflineEngine builds a journal-backed engine over dir. Called twice per
+// case with the same dir and metadata store, so the second call is a restart.
+func openOfflineEngine(t *testing.T, dir string, ms metadata.Store, mem *remotememory.Store) (*engine.Store, *localfs.FSStore) {
+	t.Helper()
+	shs, ok := ms.(metadata.SyncedHashStore)
+	if !ok {
+		t.Fatalf("metadata store %T does not implement metadata.SyncedHashStore", ms)
+	}
+	local, err := localfs.NewWithOptions(dir, 100*1024*1024, ms, localfs.FSStoreOptions{
+		MaxLogBytes: 128 * 1024 * 1024,
+	})
+	if err != nil {
+		t.Fatalf("fs.NewWithOptions: %v", err)
+	}
+	syncer := engine.NewSyncer(local, mem, ms, engine.DefaultConfig())
+	syncer.SetSyncedHashStore(shs)
+	syncer.SetRemoteBlockStore(mem)
+	bs, err := engine.New(engine.BlockStoreConfig{
+		Local:           local,
+		Remote:          keepOpenRemote{mem},
+		Syncer:          syncer,
+		FileChunkStore:  ms,
+		Coordinator:     &testCoordinator{store: ms},
+		SyncedHashStore: shs,
+		ReadBufferBytes: 16 * 1024 * 1024,
+	})
+	if err != nil {
+		t.Fatalf("engine.New: %v", err)
+	}
+	if err := bs.Start(context.Background()); err != nil {
+		t.Fatalf("engine.Start: %v", err)
+	}
+	return bs, local
+}
+
+// findColdLog returns the journal's cold.log path under dir. It fails the test
+// when there is none, so a rig that silently stopped producing cold markers
+// cannot pass by removing nothing.
+func findColdLog(t *testing.T, dir string) string {
+	t.Helper()
+	var found []string
+	if err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && d.Name() == "cold.log" {
+			found = append(found, path)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walk %s: %v", dir, err)
+	}
+	if len(found) != 1 {
+		t.Fatalf("found %d cold.log files under %s, want exactly 1: %v", len(found), dir, found)
+	}
+	return found[0]
+}
+
+// TestOfflineReadiness_LostIntervalIsNotSafe puts the readiness answer in front
+// of the three states it has to tell apart, all reached the same way — write,
+// carve, restart — so the only thing that varies is what the journal still
+// knows on the way back up.
+//
+//   - resident: nothing evicted. Every byte serves locally, and the share is
+//     safe. This is the control: the cross-check must not refuse a healthy
+//     share.
+//   - evicted: the local bytes are gone but the cold markers replayed, so the
+//     index still describes the ranges. Not safe, and the existing count says
+//     by how much. This is what the cross-check must not confuse with a loss.
+//   - lost: the same eviction, but the cold log did not survive the restart —
+//     #2084's shape, where a marker never reached the log before the segment
+//     holding the only copy was unlinked. The index describes nothing, so the
+//     remote-only count is zero and the pre-cross-check answer was a confident
+//     "provably offline safe" for a share that can no longer serve those bytes
+//     at all.
+func TestOfflineReadiness_LostIntervalIsNotSafe(t *testing.T) {
+	const fileSize = 8 * 1024 * 1024
+
+	for _, tc := range []struct {
+		name        string
+		evict       bool
+		loseColdLog bool
+		wantKnown   bool
+		wantSafe    bool
+		wantBytes   int64
+	}{
+		{name: "resident", wantKnown: true, wantSafe: true},
+		{name: "evicted", evict: true, wantKnown: true, wantBytes: fileSize},
+		{name: "lost", evict: true, loseColdLog: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			dir := t.TempDir()
+			ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+			mem := remotememory.New()
+
+			bs, local := openOfflineEngine(t, dir, ms, mem)
+			root := createShare(t, ms, "offline")
+			pid, _ := createRealFile(t, ms, "offline", "data.bin", root)
+
+			data := make([]byte, fileSize)
+			rand.New(rand.NewSource(0x0FF11E)).Read(data) //nolint:gosec // deterministic fixture
+			if _, err := bs.WriteAt(ctx, pid, nil, data, 0); err != nil {
+				t.Fatalf("WriteAt: %v", err)
+			}
+			carve(t, bs, ctx, pid)
+			if tc.evict {
+				if _, err := bs.DrainLocalSynced(ctx); err != nil {
+					t.Fatalf("DrainLocalSynced: %v", err)
+				}
+			}
+			// The seed marker is what the readiness gate checks before it
+			// trusts the index at all; without it every case below would
+			// refuse for the wrong reason.
+			if err := local.MarkColdSeeded(); err != nil {
+				t.Fatalf("MarkColdSeeded: %v", err)
+			}
+
+			// The manifest is the denominator the cross-check works against.
+			// Assert it is non-empty before the restart, so a rig whose carve
+			// stopped writing rows fails here instead of passing everything.
+			rows, err := ms.ListFileChunks(ctx, pid)
+			if err != nil {
+				t.Fatalf("ListFileChunks: %v", err)
+			}
+			var placed int64
+			for _, row := range rows {
+				if row != nil && !row.Hash.IsZero() {
+					placed += int64(row.DataSize)
+				}
+			}
+			if placed != fileSize {
+				t.Fatalf("manifest places %d bytes across %d rows, want %d", placed, len(rows), fileSize)
+			}
+
+			coldLog := ""
+			if tc.evict {
+				coldLog = findColdLog(t, dir)
+			}
+			if err := bs.Close(); err != nil {
+				t.Fatalf("Close: %v", err)
+			}
+			if tc.loseColdLog {
+				if err := os.Remove(coldLog); err != nil {
+					t.Fatalf("remove %s: %v", coldLog, err)
+				}
+			}
+
+			bs, local = openOfflineEngine(t, dir, ms, mem)
+			t.Cleanup(func() { _ = bs.Close() })
+
+			// The whole input the pre-cross-check answer was built from. Read
+			// it here rather than assuming it, so the "was safe before" half of
+			// this test is an observation.
+			coldBytes, coldRanges, err := local.ColdExtents(ctx)
+			if err != nil {
+				t.Fatalf("ColdExtents: %v", err)
+			}
+			described, err := local.DataExtents(ctx, pid, fileSize)
+			if err != nil {
+				t.Fatalf("DataExtents: %v", err)
+			}
+			var describedBytes int64
+			for _, e := range described {
+				describedBytes += int64(e[1] - e[0])
+			}
+			priorAnswer := engine.OfflineReadiness{
+				RemoteOnlyBytes:  coldBytes,
+				RemoteOnlyRanges: coldRanges,
+				Known:            true,
+			}
+			t.Logf("manifest places %d bytes in %d rows; index describes %d bytes in %d extents "+
+				"(%d of them cold in %d ranges); answer without the cross-check: safe=%v",
+				placed, len(rows), describedBytes, len(described), coldBytes, coldRanges, priorAnswer.Safe())
+
+			got := bs.OfflineReadiness(ctx)
+			if got.Known != tc.wantKnown {
+				t.Errorf("Known = %v, want %v (reason %q)", got.Known, tc.wantKnown, got.Reason)
+			}
+			if got.Safe() != tc.wantSafe {
+				t.Errorf("Safe() = %v, want %v (reason %q)", got.Safe(), tc.wantSafe, got.Reason)
+			}
+			if got.RemoteOnlyBytes != tc.wantBytes {
+				t.Errorf("RemoteOnlyBytes = %d, want %d", got.RemoteOnlyBytes, tc.wantBytes)
+			}
+
+			switch tc.name {
+			case "lost":
+				// Both halves of the discrimination, on the same run: the index
+				// has nothing to say about a range the manifest still places,
+				// and that silence used to read as proof of safety.
+				if describedBytes != 0 {
+					t.Errorf("index still describes %d bytes after the cold log was lost; "+
+						"the rig did not reproduce a lost interval", describedBytes)
+				}
+				if !priorAnswer.Safe() {
+					t.Errorf("the pre-cross-check answer was already unsafe (%d remote-only bytes), "+
+						"so this case proves nothing about the new check", coldBytes)
+				}
+				if got.Reason == "" {
+					t.Error("refused to answer without saying why")
+				}
+			case "evicted":
+				// A cold range is described, just not resident: the cross-check
+				// must count it as covered, or it would refuse for every share
+				// that has ever evicted and never discriminate at all.
+				if describedBytes != fileSize {
+					t.Errorf("index describes %d bytes of the evicted file, want %d", describedBytes, fileSize)
+				}
+			}
+		})
+	}
+}

--- a/pkg/block/engine/offline_test.go
+++ b/pkg/block/engine/offline_test.go
@@ -23,6 +23,14 @@ func (f *fakeColdReporter) ColdExtents(ctx context.Context) (int64, int64, error
 }
 func (f *fakeColdReporter) ColdSeeded() bool { return f.seeded }
 
+func (f *fakeColdReporter) DataExtents(context.Context, string, int64) ([][2]uint64, error) {
+	return nil, nil
+}
+
+// noShortfall stands in for a manifest that accounts for every range the index
+// describes, so the gating rules below are exercised on their own.
+func noShortfall(context.Context, coldRangeReporter) (int64, int64, error) { return 0, 0, nil }
+
 // TestOfflineReadiness_Safe pins the two ways a readiness answer can be wrong
 // in the dangerous direction: reporting zero remote-only bytes for a share
 // whose residency is not actually known reads as "provably offline safe" for
@@ -55,25 +63,34 @@ func TestOfflineReadinessOf_Gating(t *testing.T) {
 		name      string
 		localTier any
 		hasRemote bool
+		shortfall shortfallFunc
 		wantKnown bool
 		wantBytes int64
 	}{
-		{"no remote, tier confirms nothing evicted", &fakeColdReporter{}, false, true, 0},
-		{"tier that cannot report residency", struct{}{}, true, false, 0},
-		{"no remote and no residency tracking", struct{}{}, false, true, 0},
-		{"unseeded tier cannot see remote-only ranges", &fakeColdReporter{seeded: false, bytes: 0}, true, false, 0},
-		{"seeded and fully local", &fakeColdReporter{seeded: true}, true, true, 0},
-		{"seeded with evicted ranges", &fakeColdReporter{seeded: true, bytes: 4096, extents: 2}, true, true, 4096},
+		{"no remote, tier confirms nothing evicted", &fakeColdReporter{}, false, noShortfall, true, 0},
+		{"tier that cannot report residency", struct{}{}, true, noShortfall, false, 0},
+		{"no remote and no residency tracking", struct{}{}, false, noShortfall, true, 0},
+		{"unseeded tier cannot see remote-only ranges", &fakeColdReporter{seeded: false, bytes: 0}, true, noShortfall, false, 0},
+		{"seeded and fully local", &fakeColdReporter{seeded: true}, true, noShortfall, true, 0},
+		{"seeded with evicted ranges", &fakeColdReporter{seeded: true, bytes: 4096, extents: 2}, true, noShortfall, true, 4096},
 		// Unbinding a remote from a share that had already evicted leaves the
 		// cold intervals behind, and the journal replays them from its cold log
 		// on the next open. Reads reconcile on the cold flag whether or not a
 		// remote exists, so those ranges never serve — reporting this share
 		// safe would be the worst answer the measurement can give.
-		{"no remote but cold ranges remain", &fakeColdReporter{seeded: false, bytes: 8192, extents: 3}, false, true, 8192},
+		{"no remote but cold ranges remain", &fakeColdReporter{seeded: false, bytes: 8192, extents: 3}, false, noShortfall, true, 8192},
+		// A range the manifest places that no interval describes was lost, not
+		// evicted: it adds nothing to the cold tally, so without this the
+		// answer below would be a confident zero.
+		{"manifest places bytes the index has forgotten", &fakeColdReporter{seeded: true}, true,
+			func(context.Context, coldRangeReporter) (int64, int64, error) { return 4096, 1, nil }, false, 0},
+		{"cross-check could not run", &fakeColdReporter{seeded: true}, true,
+			func(context.Context, coldRangeReporter) (int64, int64, error) { return 0, 0, errNoManifest }, false, 0},
+		{"no manifest to cross-check against", &fakeColdReporter{seeded: true}, true, nil, false, 0},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := offlineReadinessOf(context.Background(), tc.localTier, tc.hasRemote)
+			got := offlineReadinessOf(context.Background(), tc.localTier, tc.hasRemote, tc.shortfall)
 			if got.Known != tc.wantKnown {
 				t.Errorf("Known = %v, want %v (reason %q)", got.Known, tc.wantKnown, got.Reason)
 			}
@@ -101,7 +118,7 @@ func TestOfflineReadinessOf_CancelledScanIsUnknown(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	got := offlineReadinessOf(ctx, &fakeColdReporter{seeded: true, bytes: 4096, extents: 2}, true)
+	got := offlineReadinessOf(ctx, &fakeColdReporter{seeded: true, bytes: 4096, extents: 2}, true, noShortfall)
 	if got.Known {
 		t.Error("a cancelled scan reported a known answer")
 	}
@@ -117,7 +134,7 @@ func TestOfflineReadinessOf_CancelledScanIsUnknown(t *testing.T) {
 
 	// A scan that fails for its own reasons is the same kind of non-answer.
 	failed := offlineReadinessOf(context.Background(),
-		&fakeColdReporter{seeded: true, err: errors.New("store is closed")}, true)
+		&fakeColdReporter{seeded: true, err: errors.New("store is closed")}, true, noShortfall)
 	if failed.Known || failed.Safe() {
 		t.Errorf("a failed scan reported known=%v safe=%v", failed.Known, failed.Safe())
 	}

--- a/pkg/block/engine/offline_test.go
+++ b/pkg/block/engine/offline_test.go
@@ -3,7 +3,10 @@ package engine
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
 )
 
 // fakeColdReporter stands in for the local tier's residency surface so the
@@ -138,4 +141,203 @@ func TestOfflineReadinessOf_CancelledScanIsUnknown(t *testing.T) {
 	if failed.Known || failed.Safe() {
 		t.Errorf("a failed scan reported known=%v safe=%v", failed.Known, failed.Safe())
 	}
+}
+
+// stubIndex reports a canned set of described ranges per file, standing in for
+// the local tier's interval index.
+type stubIndex struct {
+	described map[string][][2]uint64
+	seeded    bool
+}
+
+func (s *stubIndex) ColdExtents(context.Context) (int64, int64, error) { return 0, 0, nil }
+func (s *stubIndex) ColdSeeded() bool                                  { return s.seeded }
+func (s *stubIndex) DataExtents(_ context.Context, id string, size int64) ([][2]uint64, error) {
+	var out [][2]uint64
+	for _, e := range s.described[id] {
+		if e[0] >= uint64(size) {
+			continue
+		}
+		if e[1] > uint64(size) {
+			e[1] = uint64(size)
+		}
+		out = append(out, e)
+	}
+	return out, nil
+}
+
+// chunkRow builds one manifest row placing [off, off+size). A non-zero hash is
+// what makes a row committed; zeroHash rows hold no bytes yet.
+func chunkRow(payloadID string, off uint64, size uint32, committed bool) *block.FileChunk {
+	row := &block.FileChunk{ID: fmt.Sprintf("%s/%d", payloadID, off), DataSize: size}
+	if committed {
+		row.Hash = block.ContentHash{1}
+	}
+	return row
+}
+
+// stubManifest is a fixed set of manifest rows per payload.
+type stubManifest map[string][]*block.FileChunk
+
+func (m stubManifest) EnumeratePayloads(_ context.Context, fn func(string) error) error {
+	for id := range m {
+		if err := fn(id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m stubManifest) ListFileChunks(_ context.Context, id string) ([]*block.FileChunk, error) {
+	return m[id], nil
+}
+
+// TestManifestShortfall pins what the cross-check counts as a range the index
+// has forgotten. The dangerous direction is under-reporting — a shortfall read
+// as zero is what lets a lost range pass as offline-safe — but a check that
+// fires on a healthy share is just as useless, so both are asserted.
+func TestManifestShortfall(t *testing.T) {
+	tests := []struct {
+		name       string
+		rows       []*block.FileChunk
+		described  [][2]uint64
+		wantBytes  int64
+		wantRanges int64
+	}{
+		{
+			name:      "index describes everything the manifest places",
+			rows:      []*block.FileChunk{chunkRow("p", 0, 1024, true), chunkRow("p", 1024, 1024, true)},
+			described: [][2]uint64{{0, 2048}},
+		},
+		{
+			name:       "index describes nothing at all",
+			rows:       []*block.FileChunk{chunkRow("p", 0, 1024, true)},
+			wantBytes:  1024,
+			wantRanges: 1,
+		},
+		{
+			name:       "a hole in the middle of what the index describes",
+			rows:       []*block.FileChunk{chunkRow("p", 0, 3072, true)},
+			described:  [][2]uint64{{0, 1024}, {2048, 3072}},
+			wantBytes:  1024,
+			wantRanges: 1,
+		},
+		{
+			name:       "holes at both ends",
+			rows:       []*block.FileChunk{chunkRow("p", 0, 4096, true)},
+			described:  [][2]uint64{{1024, 3072}},
+			wantBytes:  2048,
+			wantRanges: 2,
+		},
+		{
+			name:      "overlapping rows are one span, not two claims",
+			rows:      []*block.FileChunk{chunkRow("p", 0, 2048, true), chunkRow("p", 1024, 1024, true)},
+			described: [][2]uint64{{0, 2048}},
+		},
+		{
+			// A row with no committed bytes has nothing on the remote to place,
+			// so the index having no interval for it is not a loss.
+			name:      "a pending row places nothing",
+			rows:      []*block.FileChunk{chunkRow("p", 0, 1024, false)},
+			described: nil,
+		},
+		{
+			// Where an unplaceable row's bytes belong is unknowable here, so it
+			// is CheckManifests' finding, not this one's.
+			name:      "an unplaceable row places nothing",
+			rows:      []*block.FileChunk{{ID: "p/not-an-offset", DataSize: 1024, Hash: block.ContentHash{1}}},
+			described: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			index := &stubIndex{described: map[string][][2]uint64{"p": tc.described}, seeded: true}
+			bytes, ranges, err := manifestShortfall(context.Background(), index, stubManifest{"p": tc.rows})
+			if err != nil {
+				t.Fatalf("manifestShortfall: %v", err)
+			}
+			if bytes != tc.wantBytes || ranges != tc.wantRanges {
+				t.Errorf("shortfall = %d bytes in %d ranges, want %d in %d",
+					bytes, ranges, tc.wantBytes, tc.wantRanges)
+			}
+		})
+	}
+}
+
+// TestSubtractExtents covers the arithmetic the shortfall is measured with,
+// including the case that matters most: an empty b, where every byte of a is
+// missing rather than none of it.
+func TestSubtractExtents(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b [][2]uint64
+		want [][2]uint64
+	}{
+		{name: "nothing covers anything", a: [][2]uint64{{0, 10}}, want: [][2]uint64{{0, 10}}},
+		{name: "fully covered", a: [][2]uint64{{0, 10}}, b: [][2]uint64{{0, 10}}},
+		{name: "covered by a wider span", a: [][2]uint64{{2, 8}}, b: [][2]uint64{{0, 10}}},
+		{name: "gap in the middle", a: [][2]uint64{{0, 10}}, b: [][2]uint64{{0, 3}, {7, 10}}, want: [][2]uint64{{3, 7}}},
+		{name: "b entirely before a", a: [][2]uint64{{10, 20}}, b: [][2]uint64{{0, 5}}, want: [][2]uint64{{10, 20}}},
+		{name: "b entirely after a", a: [][2]uint64{{0, 5}}, b: [][2]uint64{{10, 20}}, want: [][2]uint64{{0, 5}}},
+		{
+			name: "several spans share one covering list",
+			a:    [][2]uint64{{0, 10}, {20, 30}},
+			b:    [][2]uint64{{5, 25}},
+			want: [][2]uint64{{0, 5}, {25, 30}},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := subtractExtents(tc.a, tc.b)
+			if len(got) != len(tc.want) {
+				t.Fatalf("subtractExtents = %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("subtractExtents = %v, want %v", got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+// TestShortfallMemoReusesTheWalk asserts the metrics scrape path does not pay
+// for a manifest walk on every call, and that a walk which failed is not
+// remembered as a verdict.
+func TestShortfallMemoReusesTheWalk(t *testing.T) {
+	var walks int
+	manifest := &countingManifest{stubManifest{"p": {chunkRow("p", 0, 1024, true)}}, &walks}
+	index := &stubIndex{described: map[string][][2]uint64{"p": {{0, 1024}}}, seeded: true}
+
+	var memo shortfallMemo
+	for i := 0; i < 3; i++ {
+		if _, _, err := memo.get(context.Background(), index, manifest); err != nil {
+			t.Fatalf("get: %v", err)
+		}
+	}
+	if walks != 1 {
+		t.Errorf("walked the manifest %d times over 3 calls, want 1", walks)
+	}
+
+	// A cancelled walk is a non-answer, so the next caller must get its own
+	// attempt rather than inherit this one's failure.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var fresh shortfallMemo
+	if _, _, err := fresh.get(ctx, index, manifest); err == nil {
+		t.Fatal("a cancelled walk reported a verdict")
+	}
+	if !fresh.at.IsZero() {
+		t.Error("a failed walk was remembered as a verdict")
+	}
+}
+
+type countingManifest struct {
+	stubManifest
+	walks *int
+}
+
+func (c *countingManifest) EnumeratePayloads(ctx context.Context, fn func(string) error) error {
+	*c.walks++
+	return c.stubManifest.EnumeratePayloads(ctx, fn)
 }

--- a/pkg/block/engine/offline_test.go
+++ b/pkg/block/engine/offline_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/block"
@@ -273,6 +274,18 @@ func TestManifestShortfall(t *testing.T) {
 			name:      "an unplaceable row places nothing",
 			rows:      []*block.FileChunk{{ID: "p/not-an-offset", DataSize: 1024, Hash: block.ContentHash{1}}},
 			described: nil,
+		},
+		{
+			// A parsed offset is bounded to int64, so a row near the top of the
+			// range can name an end the index has no way to express: it reports
+			// its side over an int64 span. Counting that unreachable tail would
+			// be a shortfall invented by the arithmetic rather than found in the
+			// data — the one thing this check must never do.
+			name: "a row reaching past int64 is clamped, not counted",
+			rows: []*block.FileChunk{
+				chunkRow("p", math.MaxInt64-1024, 4096, true),
+			},
+			described: [][2]uint64{{math.MaxInt64 - 1024, math.MaxInt64}},
 		},
 	}
 	for _, tc := range tests {

--- a/pkg/block/engine/offline_test.go
+++ b/pkg/block/engine/offline_test.go
@@ -87,9 +87,10 @@ func TestOfflineReadinessOf_Gating(t *testing.T) {
 		// answer below would be a confident zero.
 		{"manifest places bytes the index has forgotten", &fakeColdReporter{seeded: true}, true,
 			func(context.Context, coldRangeReporter) (int64, int64, error) { return 4096, 1, nil }, false, 0},
+		// A share with no manifest reaches this the same way: the store's
+		// cross-check reports errNoManifest rather than a zero shortfall.
 		{"cross-check could not run", &fakeColdReporter{seeded: true}, true,
 			func(context.Context, coldRangeReporter) (int64, int64, error) { return 0, 0, errNoManifest }, false, 0},
-		{"no manifest to cross-check against", &fakeColdReporter{seeded: true}, true, nil, false, 0},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/block/engine/offline_test.go
+++ b/pkg/block/engine/offline_test.go
@@ -236,6 +236,31 @@ func TestManifestShortfall(t *testing.T) {
 			described: [][2]uint64{{0, 2048}},
 		},
 		{
+			// A row reaching past a later row's whole span is a legitimate
+			// manifest shape, not damage: a row claims a prefix of its chunk, so
+			// nothing can be cut to start mid-chunk and re-cover the tail, and
+			// the straddler is what keeps those bytes readable. Coverage is the
+			// union of what rows claim, so the straddler's tail counts as placed
+			// and the byte the later row also covers is not counted twice.
+			name:      "a straddling row keeps its tail",
+			rows:      []*block.FileChunk{chunkRow("p", 0, 3072, true), chunkRow("p", 1024, 1024, true)},
+			described: [][2]uint64{{0, 3072}},
+		},
+		{
+			name:       "a straddling row's tail is missed like any other range",
+			rows:       []*block.FileChunk{chunkRow("p", 0, 3072, true), chunkRow("p", 1024, 1024, true)},
+			described:  [][2]uint64{{0, 2048}},
+			wantBytes:  1024,
+			wantRanges: 1,
+		},
+		{
+			// Rows arrive in whatever order the backend returns them, and an
+			// out-of-order pair must union the same way a sorted one does.
+			name:      "rows out of offset order still union",
+			rows:      []*block.FileChunk{chunkRow("p", 2048, 1024, true), chunkRow("p", 0, 2048, true)},
+			described: [][2]uint64{{0, 3072}},
+		},
+		{
 			// A row with no committed bytes has nothing on the remote to place,
 			// so the index having no interval for it is not a loss.
 			name:      "a pending row places nothing",

--- a/pkg/block/engine/offline_test.go
+++ b/pkg/block/engine/offline_test.go
@@ -342,3 +342,123 @@ func (c *countingManifest) EnumeratePayloads(ctx context.Context, fn func(string
 	*c.walks++
 	return c.stubManifest.EnumeratePayloads(ctx, fn)
 }
+
+// vanishingManifest serves one set of rows to the first read of a payload and
+// another to every read after it, standing in for a delete or truncate that
+// lands between the walk's two looks at the same file.
+type vanishingManifest struct {
+	first, then []*block.FileChunk
+	reads       int
+}
+
+func (m *vanishingManifest) EnumeratePayloads(_ context.Context, fn func(string) error) error {
+	return fn("p")
+}
+
+func (m *vanishingManifest) ListFileChunks(context.Context, string) ([]*block.FileChunk, error) {
+	m.reads++
+	if m.reads == 1 {
+		return m.first, nil
+	}
+	return m.then, nil
+}
+
+// TestManifestShortfallConfirmsBeforeReporting pins the re-read. The index and
+// the manifest narrow in opposite orders and neither operation is atomic with
+// the other, so a walk that looked once would call a file being deleted a lost
+// range and hold that verdict for the life of the memo.
+//
+// The second case is the half that makes the first mean something: a manifest
+// that still places the bytes on the re-read is a real shortfall and must
+// survive the confirmation.
+func TestManifestShortfallConfirmsBeforeReporting(t *testing.T) {
+	wide := []*block.FileChunk{chunkRow("p", 0, 4096, true)}
+	// The index describes nothing, which is what a payload whose local entry
+	// has already been emptied looks like.
+	index := &stubIndex{described: map[string][][2]uint64{}, seeded: true}
+
+	tests := []struct {
+		name       string
+		manifest   *vanishingManifest
+		wantBytes  int64
+		wantRanges int64
+		wantReads  int
+	}{
+		{
+			name:      "rows reaped between the two reads",
+			manifest:  &vanishingManifest{first: wide},
+			wantReads: 2,
+		},
+		{
+			name:       "rows still place the bytes on the re-read",
+			manifest:   &vanishingManifest{first: wide, then: wide},
+			wantBytes:  4096,
+			wantRanges: 1,
+			wantReads:  2,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bytes, ranges, err := manifestShortfall(context.Background(), index, tc.manifest)
+			if err != nil {
+				t.Fatalf("manifestShortfall: %v", err)
+			}
+			if bytes != tc.wantBytes || ranges != tc.wantRanges {
+				t.Errorf("shortfall = %d bytes in %d ranges, want %d in %d",
+					bytes, ranges, tc.wantBytes, tc.wantRanges)
+			}
+			if tc.manifest.reads != tc.wantReads {
+				t.Errorf("read the manifest %d times, want %d", tc.manifest.reads, tc.wantReads)
+			}
+		})
+	}
+
+	// A payload that never looked short is not re-read at all.
+	covered := &vanishingManifest{first: wide, then: wide}
+	full := &stubIndex{described: map[string][][2]uint64{"p": {{0, 4096}}}, seeded: true}
+	if _, _, err := manifestShortfall(context.Background(), full, covered); err != nil {
+		t.Fatalf("manifestShortfall: %v", err)
+	}
+	if covered.reads != 1 {
+		t.Errorf("read the manifest %d times for a fully described payload, want 1", covered.reads)
+	}
+}
+
+// TestIntersectExtents covers the arithmetic the confirmation narrows with.
+func TestIntersectExtents(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b [][2]uint64
+		want [][2]uint64
+	}{
+		{name: "one side empty", a: [][2]uint64{{0, 10}}},
+		{name: "identical", a: [][2]uint64{{0, 10}}, b: [][2]uint64{{0, 10}}, want: [][2]uint64{{0, 10}}},
+		{name: "partial overlap", a: [][2]uint64{{0, 10}}, b: [][2]uint64{{5, 20}}, want: [][2]uint64{{5, 10}}},
+		{name: "disjoint", a: [][2]uint64{{0, 5}}, b: [][2]uint64{{5, 10}}},
+		{
+			name: "one span against several",
+			a:    [][2]uint64{{0, 30}},
+			b:    [][2]uint64{{2, 4}, {10, 12}, {40, 50}},
+			want: [][2]uint64{{2, 4}, {10, 12}},
+		},
+		{
+			name: "several against several",
+			a:    [][2]uint64{{0, 10}, {20, 30}},
+			b:    [][2]uint64{{5, 25}},
+			want: [][2]uint64{{5, 10}, {20, 25}},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := intersectExtents(tc.a, tc.b)
+			if len(got) != len(tc.want) {
+				t.Fatalf("intersectExtents = %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("intersectExtents = %v, want %v", got, tc.want)
+				}
+			}
+		})
+	}
+}

--- a/pkg/health/share.go
+++ b/pkg/health/share.go
@@ -32,7 +32,10 @@ type ShareStatus struct {
 // alone.
 type OfflineStatus struct {
 	// Safe is true when every byte the share holds can be served without the
-	// remote. False when some cannot, or when residency is indeterminate.
+	// remote. False when some cannot, or when residency is indeterminate —
+	// which includes a local tier whose index cannot account for a range the
+	// share's manifest places, since a range the index has forgotten looks
+	// exactly like one that was never written.
 	Safe bool `json:"safe"`
 
 	// RemoteOnlyBytes is how much data the local tier no longer holds and


### PR DESCRIPTION
`OfflineReadiness` answered "could this share serve every byte with the remote
unreachable" from the local journal tier's cold-interval tally alone. That tally
is the index's account of itself, so it cannot see a range the index has
forgotten: a lost interval leaves no entry, adds nothing to the count, and is
indistinguishable there from a range that was never written. `RemoteOnlyBytes`
stayed 0, `Known` stayed true, and `Safe()` returned true — green-lighting a
detach that could not serve those bytes.

#2103 closed the loss vector that exposed this. The detection gap is structural
and stays: a guard built on markers cannot see a missing marker.

## The change

`Store.OfflineReadiness` now weighs the index against the share's `FileChunk`
manifest before it calls anything safe. For every payload, the ranges its rows
place (union, placeable and committed rows only) are subtracted from the ranges
the local index describes for the same file — `DataExtents`, which includes cold
ranges, so an evicted range is *described* even though it is not resident. Any
shortfall makes the answer indeterminate (`Known == false`, `Safe() == false`)
rather than zero.

The honest answer has to come from outside the interval index, because the index
is the thing being doubted. The manifest is written by a different subsystem and
outlives a lost interval, which is what makes it usable as the denominator.

The docstring claimed "Zero remote-only bytes is a provable offline-safe share",
which the mechanism did not deliver. It now says what it actually checks.

## Verification

`TestOfflineReadiness_LostIntervalIsNotSafe` reaches three states the same way —
write 8 MiB, carve, restart — so the only thing that varies is what the journal
knows on the way back up:

| case | index describes | cold tally | answer without the cross-check | with it |
| --- | --- | --- | --- | --- |
| `resident` (control) | 8388608 | 0 | safe | **safe** |
| `evicted` (control) | 8388608 | 8388608 | not safe | **not safe, 8 MiB remote-only** |
| `lost` | **0** | 0 | **safe** | **indeterminate** |

The `lost` case removes `cold.log` between the close and the reopen, so recovery
replays nothing — the state #2084 produced when a marker never reached the log
before the segment holding the only copy was unlinked. The pre-cross-check
verdict is not asserted from memory: the test reads `ColdExtents` on the live
store and evaluates the old formula on it, and fails if that verdict was not
`Safe() == true`. It also fails if the rig did not actually strand the range
(`describedBytes != 0`) or if the manifest did not place the full 8 MiB, so a
rig that quietly stopped reproducing anything cannot pass.

Both halves matter. With the cross-check stubbed out, only `lost` fails —
`resident` and `evicted` still pass, so the guard discriminates rather than
refusing everything:

```
--- FAIL: TestOfflineReadiness_LostIntervalIsNotSafe/lost
    manifest places 8388608 bytes in 8 rows; index describes 0 bytes in 0 extents
    (0 of them cold in 0 ranges); answer without the cross-check: safe=true
    Known = true, want false
    Safe() = true, want false
```

`TestManifestShortfall` and `TestSubtractExtents` cover the arithmetic (holes at
either end, holes in the middle, overlapping rows, pending rows, unplaceable
rows, an index that describes nothing).

## A clone reaches the same state, and that is worth knowing before merge

`CopyPayload` — NFSv4.2 CLONE and SMB server-side copy — writes the
destination's manifest rows and creates **no journal interval** for them. From
this seam a clone nobody has read back is indistinguishable from a lost
interval, so a share holding one now reports indeterminate rather than safe.
Verified, not inferred: `TestOfflineReadiness_CloneIsIndeterminate` clones 4 MiB
and asserts the destination has zero index extents.

That verdict is not wrong — those bytes need the remote too, and the index
genuinely cannot say which of the two cases it is looking at, which is why the
refusal names both. But it does mean the gauge reads "unknown" on any
remote-backed share with an unhydrated clone. The clean follow-up is to have
`CopyPayload` seed cold intervals for its destination rows: the clone would then
report as a remote-only count (accurate, and actionable with `dfsctl share
warm`), and a shortfall would be left meaning a genuine loss. That touches the
clone path and its transaction ordering, so it is not in this PR — filed as
#2123, and the test above is written to fail when it lands.

## Overlap is not a defect here

Manifest rows overlap legitimately — a row claims a prefix of its chunk, so a
row reaching past a later row's whole span is kept rather than cut, and that
straddler is what keeps its own tail readable. Coverage is therefore the
**union** of what rows place, never a sum of row lengths and never an assumed
tiling of `[0, size)`. Two rows over one byte merge into one span; a straddler's
tail counts once. That union is the same set of offsets a read can resolve
whichever covering row it picks, which is what makes it the right denominator
for "could this be served".

Pinned by `TestManifestShortfall`: overlapping rows, a straddling row keeping
its tail, a straddler whose tail the index genuinely does not describe, and rows
returned out of offset order. This also means a change that keeps *more* rows
moves manifest coverage the same way or wider, and never turns a healthy file
into a shortfall.

## Two records that narrow in opposite orders

The walk reads the manifest and the index with no snapshot between them, and the
two data-path operations that shrink a file disagree about which to shrink
first. `Truncate` reaps the manifest before it clips the index — the safe
order. `Delete` empties the local index and reaps the rows a full metadata
round-trip later, so a walk landing in that window reads rows whose bytes are
already gone and would call a file being deleted a lost range, memoized for a
minute.

So a shortfall is confirmed against a second read of that payload's manifest,
and only the gaps its rows still place are counted. Intersecting rather than
replacing is what keeps a concurrent write out of the count: a row the re-read
added has an interval older than itself, so it was never missing. The re-read
costs one extra `ListFileChunks`, and only for a payload that already looked
short — `TestManifestShortfallConfirmsBeforeReporting` asserts the fully
described case is read exactly once, that a reaped payload reports nothing, and
that a payload whose rows survive the re-read still reports its shortfall.

This narrows the delete window rather than closing it: a reap still in flight at
the re-read is counted. Making both records narrow in the same order would close
it, and that is a change to the delete path, not to this seam.

## Cost

The cross-check is one `ListFileChunks` per payload, and `OfflineReadiness` sits
on the metrics scrape path, which deliberately avoids per-file DB walks
(`MetricsBlockStats` uses the lite stats path for exactly that reason). The
result is memoized for a minute — a shortfall is a durable structural condition,
so a verdict that old is still the right verdict, and a fresh process starts with
an empty memo. A walk that failed or ran out of its caller's deadline is not
remembered as a verdict.

Not included: #2076's manifest-audit wiring. This cross-check is its own walk.

Closes #2110
