### PR TITLE
fix(carve): keep a row reaching past a reaped run, batch the reap, evict under carveMu

### DIFF
--- a/pkg/block/engine/blocksink.go
+++ b/pkg/block/engine/blocksink.go
@@ -147,15 +147,15 @@ func (s localBlockSink) CommitBlock(ctx context.Context, chunks []journal.CarveC
 	return commitManifestRows(ctx, s.committer, s.commitLocks, string(chunks[0].FileID), manifestRows(chunks))
 }
 
-// ReapSupersededManifest implements journal's optional run-end reap: once a carve
-// run's rows are all committed, delete the manifest rows the run superseded so the
-// per-file manifest tiles [0,size) with no stale straddler or gap (#953). A nil
+// ReapSupersededManifest implements journal's optional pass-end reap: once a
+// carve pass's rows are all committed, delete the manifest rows they superseded so
+// the per-file manifest tiles [0,size) with no stale straddler or gap (#953). A nil
 // committer (the clone fixture) has no manifest to reap.
-func (s localBlockSink) ReapSupersededManifest(ctx context.Context, id journal.FileID, runStart, runEnd int64, newOffsets map[int64]struct{}) error {
+func (s localBlockSink) ReapSupersededManifest(ctx context.Context, id journal.FileID, spans [][2]int64, newOffsets map[int64]struct{}) error {
 	if s.committer == nil {
 		return nil
 	}
-	return reapSupersededManifest(ctx, s.committer, s.commitLocks, string(id), runStart, runEnd, newOffsets)
+	return reapSupersededManifest(ctx, s.committer, s.commitLocks, string(id), spans, newOffsets)
 }
 
 // ManifestRowEndAfter answers journal's run-extension query: how far the manifest
@@ -187,24 +187,24 @@ func manifestRowEndAfter(ctx context.Context, c blockCommitter, payloadID string
 	return end, err
 }
 
-// reapSupersededManifest runs the run-end reap under the same per-file lock
+// reapSupersededManifest runs the pass-end reap under the same per-file lock
 // CommitBlock takes, since both end in a read-modify-write of the file's
 // File.Blocks row and would otherwise abort each other under badger's SSI.
-func reapSupersededManifest(ctx context.Context, c blockCommitter, locks *carveCommitLocks, payloadID string, runStart, runEnd int64, newOffsets map[int64]struct{}) error {
+func reapSupersededManifest(ctx context.Context, c blockCommitter, locks *carveCommitLocks, payloadID string, spans [][2]int64, newOffsets map[int64]struct{}) error {
 	if mu := locks.forKey(payloadID); mu != nil {
 		mu.Lock()
 		defer mu.Unlock()
 	}
 	return c.WithTransaction(ctx, func(tx metadata.Transaction) error {
-		return metadata.ReapSupersededManifest(ctx, tx, payloadID, runStart, runEnd, newOffsets)
+		return metadata.ReapSupersededManifest(ctx, tx, payloadID, spans, newOffsets)
 	})
 }
 
-// ReapSupersededManifest implements journal's optional run-end reap for the
-// remote-backed sink: delete the manifest rows the carve run superseded, atomic
+// ReapSupersededManifest implements journal's optional pass-end reap for the
+// remote-backed sink: delete the manifest rows the carve pass superseded, atomic
 // with a re-projection of File.Blocks (#953).
-func (s engineBlockSink) ReapSupersededManifest(ctx context.Context, id journal.FileID, runStart, runEnd int64, newOffsets map[int64]struct{}) error {
-	return reapSupersededManifest(ctx, s.committer, s.commitLocks, string(id), runStart, runEnd, newOffsets)
+func (s engineBlockSink) ReapSupersededManifest(ctx context.Context, id journal.FileID, spans [][2]int64, newOffsets map[int64]struct{}) error {
+	return reapSupersededManifest(ctx, s.committer, s.commitLocks, string(id), spans, newOffsets)
 }
 
 // engineBlockSink is journal's production BlockSink: it seals each carved chunk,

--- a/pkg/block/engine/blocksink_ssi_test.go
+++ b/pkg/block/engine/blocksink_ssi_test.go
@@ -132,7 +132,7 @@ func TestLocalBlockSink_ConcurrentReapAndCommit_NoSSIConflict(t *testing.T) {
 			// A disjoint span from every commit above, so a correct
 			// implementation serializes only the shared File-row write.
 			off := int64(i) * 4096
-			errs[i] = sink.ReapSupersededManifest(ctx, journal.FileID(pid), off, off+4096, nil)
+			errs[i] = sink.ReapSupersededManifest(ctx, journal.FileID(pid), [][2]int64{{off, off + 4096}}, nil)
 		}(i)
 	}
 	close(start)

--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"math"
 	"sync"
 
@@ -315,9 +316,7 @@ func (s *Store) carveFile(ctx context.Context, sh *shard, id FileID, res *CarveR
 				continue
 			}
 			spans = append(spans, [2]int64{st.start(), st.committedTo})
-			for off := range st.newOffsets {
-				newOffsets[off] = struct{}{}
-			}
+			maps.Copy(newOffsets, st.newOffsets)
 		}
 		if len(spans) > 0 {
 			if rerr := r.ReapSupersededManifest(ctx, id, spans, newOffsets); rerr != nil && err == nil {
@@ -617,8 +616,9 @@ func (s *Store) packRuns(ctx context.Context, sh *shard, id FileID, rs []*runSta
 // were carved concurrently before and would be again — and under any such
 // ordering a sibling's already-flipped head is indistinguishable here from
 // pre-existing warm data. It has to be a refusal rather than a truncation to
-// limit: the run-end reap deletes whole rows that start inside the run, so
-// tiling only part of a row still drops its tail.
+// limit: a run truncated there still ends inside the row, so the reap spares
+// that row whole and its stale cover outlives the fresh tiling anyway — the
+// truncated extension would re-chunk those bytes for nothing.
 //
 // ponytail: a row reaching past a later dirty run is left alone, so that run
 // still ends mid-row; covering it means merging the two runs, which is worth

--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -103,16 +103,18 @@ type BlockSink interface {
 	CommitBlock(ctx context.Context, chunks []CarveChunk) error
 }
 
-// supersededReaper is an optional BlockSink capability. Once a carve run has
-// committed rows, journal calls ReapSupersededManifest so the sink can delete
-// the manifest rows they superseded — keeping the per-file FileChunk manifest a
-// gap-free, overlap-free tiling of [0,size) after a partial overwrite.
-// runStart/runEnd bound the committed part of the re-carved (dirty) range;
-// newOffsets are the chunk offsets this run wrote (so the reap keeps them and
-// deletes only stale straddlers/interior rows). Sinks without a metadata store
+// supersededReaper is an optional BlockSink capability. Once a carve pass has
+// committed a file's rows, journal calls ReapSupersededManifest so the sink can
+// delete the manifest rows they superseded — keeping the per-file FileChunk
+// manifest a gap-free, overlap-free tiling of [0,size) after a partial overwrite.
+// spans are the committed parts of the pass's re-carved (dirty) runs, disjoint
+// and ascending; newOffsets are the chunk offsets the pass wrote (so the reap
+// keeps them and deletes only stale straddlers/interior rows). One call per file
+// rather than one per run: the sink re-reads the whole manifest to answer it, and
+// that read happens under this shard's carve lock. Sinks without a metadata store
 // (test fakes) simply don't implement it and the reap is skipped.
 type supersededReaper interface {
-	ReapSupersededManifest(ctx context.Context, id FileID, runStart, runEnd int64, newOffsets map[int64]struct{}) error
+	ReapSupersededManifest(ctx context.Context, id FileID, spans [][2]int64, newOffsets map[int64]struct{}) error
 }
 
 // manifestRowEnder is an optional BlockSink capability: it reports how far the
@@ -291,23 +293,34 @@ func (s *Store) carveFile(ctx context.Context, sh *shard, id FileID, res *CarveR
 	// greatest-start, so a stale row starting later than a fresh one then wins
 	// and serves old bytes on a cold read.
 	//
-	// For the same reason this runs even when packing failed, and one run's reap
-	// failing does not suppress the others: each run's committed prefix is its
-	// own last chance.
+	// For the same reason this runs even when packing failed: every run that got
+	// anything committed is reaped for, including the ones after a run that
+	// failed mid-way.
 	//
-	// Serial, not concurrent: carveCommitLocks stripes on the payload ID, so every
-	// reap for one file contends on the same mutex anyway.
+	// All of the file's spans go in one call. The sink answers a reap by reading
+	// the file's whole manifest and re-projecting File.Blocks from it, so one call
+	// per run made both costs scale with the run count — a file with tens of
+	// thousands of dirty runs spent minutes of that under this shard's carve lock,
+	// after its records had already flipped synced and its uploads had drained.
 	//
 	// ponytail: a caller cancelling between the flip and the reap still strands
 	// those rows, since nothing retries a reap and the records are no longer
 	// dirty; persist a pending-reap intent, or defer the flip until the reap
 	// lands, if that window ever shows up in the field.
 	if r, ok := s.sink.(supersededReaper); ok {
+		spans := make([][2]int64, 0, len(rs))
+		newOffsets := make(map[int64]struct{})
 		for _, st := range rs {
 			if st.committedTo <= st.start() {
 				continue
 			}
-			if rerr := r.ReapSupersededManifest(ctx, id, st.start(), st.committedTo, st.newOffsets); rerr != nil && err == nil {
+			spans = append(spans, [2]int64{st.start(), st.committedTo})
+			for off := range st.newOffsets {
+				newOffsets[off] = struct{}{}
+			}
+		}
+		if len(spans) > 0 {
+			if rerr := r.ReapSupersededManifest(ctx, id, spans, newOffsets); rerr != nil && err == nil {
 				err = rerr
 			}
 		}

--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -110,19 +110,16 @@ type BlockSink interface {
 // runStart/runEnd bound the committed part of the re-carved (dirty) range;
 // newOffsets are the chunk offsets this run wrote (so the reap keeps them and
 // deletes only stale straddlers/interior rows). Sinks without a metadata store
-// (test fakes) simply don't implement it and the reap is skipped. A sink that
-// implements it is expected to implement manifestRowEnder too: the reap is
-// guarded on that lookup, and both are answered out of the same metadata store.
+// (test fakes) simply don't implement it and the reap is skipped.
 type supersededReaper interface {
 	ReapSupersededManifest(ctx context.Context, id FileID, runStart, runEnd int64, newOffsets map[int64]struct{}) error
 }
 
 // manifestRowEnder is an optional BlockSink capability: it reports how far the
-// manifest coverage straddling an offset reaches. Carve asks it twice: to widen
-// a run to a row boundary before packing it, and to refuse a reap that would end
-// inside a row (see reapEndsOnRowBoundary, which carries the argument). Sinks
-// without a metadata store (test fakes) don't implement it: a run is carved
-// exactly as snapshotted and the reap runs unguarded.
+// manifest coverage straddling an offset reaches. Carve uses it to widen a run to
+// a row boundary before packing it, so the fresh tiling covers every row the
+// run-end reap deletes. Sinks without a metadata store (test fakes) don't
+// implement it: a run is carved exactly as snapshotted.
 //
 // The answer is the greatest end among rows starting strictly before off and
 // reaching past it, or off itself when none does — never a value below off. A
@@ -310,11 +307,7 @@ func (s *Store) carveFile(ctx context.Context, sh *shard, id FileID, res *CarveR
 			if st.committedTo <= st.start() {
 				continue
 			}
-			onBoundary, rerr := s.reapEndsOnRowBoundary(ctx, id, st.committedTo)
-			if rerr == nil && onBoundary {
-				rerr = r.ReapSupersededManifest(ctx, id, st.start(), st.committedTo, st.newOffsets)
-			}
-			if rerr != nil && err == nil {
+			if rerr := r.ReapSupersededManifest(ctx, id, st.start(), st.committedTo, st.newOffsets); rerr != nil && err == nil {
 				err = rerr
 			}
 		}
@@ -324,40 +317,6 @@ func (s *Store) carveFile(ctx context.Context, sh *shard, id FileID, res *CarveR
 	}
 	s.maybeResetDirtyClock(sh, id)
 	return nil
-}
-
-// reapEndsOnRowBoundary reports whether a reap ending at end can delete the rows
-// it covers without stranding any of their bytes.
-//
-// ReapSupersededManifest classifies a row by its start alone: one starting
-// inside the reaped span is deleted whole however far past end it reaches. The
-// stretch from end to that row's end then keeps no cover at all — the next dirty
-// run tiles from its own start, the reap's narrowing branch only ever protects a
-// row starting before the span, and a row claims a prefix of its chunk so none
-// can be made to start mid-chunk and take the stretch over. Nothing revisits it,
-// and once the local bytes are evicted a read of it zero-fills.
-//
-// end is safe exactly when no row starts before it and reaches past it, which is
-// what ManifestRowEndAfter answers. Refusing the whole reap when one does is
-// deliberately blunt: it leaves every stale row of that run alive, so the range
-// keeps overlapping cover and a read there can resolve to the stale row and
-// serve old bytes. That is the recoverable failure of the two — every byte is
-// still addressable and the manifest can be repaired — where a stranded stretch
-// is not.
-//
-// ponytail: a whole-manifest read per reaped run, on top of the reap's own scan
-// of the same rows; fold the check into the reap transaction if a carve profile
-// ever shows the second scan.
-func (s *Store) reapEndsOnRowBoundary(ctx context.Context, id FileID, end int64) (bool, error) {
-	ender, ok := s.sink.(manifestRowEnder)
-	if !ok {
-		return true, nil // only a test fake reaps without the lookup; leave it unguarded
-	}
-	rowEnd, err := ender.ManifestRowEndAfter(ctx, id, end)
-	if err != nil {
-		return false, err
-	}
-	return rowEnd <= end, nil
 }
 
 // splitRuns groups an offset-ordered snapshot into maximal contiguous runs; a
@@ -630,10 +589,10 @@ func (s *Store) packRuns(ctx context.Context, sh *shard, id FileID, rs []*runSta
 // still ends inside the row.
 //
 // Skipping is not free, and every bail below shares the cost: the run then still
-// ends inside a row, so reapEndsOnRowBoundary refuses its reap and every row the
-// run superseded stays alive next to the fresh ones. Extending is what earns the
-// reap; the guard is only what keeps the alternative from being a stranded
-// stretch of file with no manifest cover at all.
+// ends inside a row, and the reap spares that row whole rather than strand the
+// stretch past the run — so the range keeps a stale cover overlapping the fresh
+// tiling instead of being tiled cleanly. Extending is what earns the clean
+// tiling.
 //
 // A row reaching past limit, the offset the next run starts at, is refused
 // outright. It is redundant today: runs are packed in ascending file-offset

--- a/pkg/block/journal/carve_concurrent_test.go
+++ b/pkg/block/journal/carve_concurrent_test.go
@@ -185,12 +185,13 @@ func TestCarveSharedRecordAcrossRuns(t *testing.T) {
 type extendingSink struct {
 	*fakeSink
 	mu      sync.Mutex
-	reaps   [][2]int64
+	reaps   [][2]int64 // every span the sink was asked to reap, in call order
+	calls   int
 	gateOff int64
 	rowEnd  int64
 	gated   int
-	// failFirstReap, when set, is returned by the first reap only, so a test can
-	// see whether one run's reap failure suppresses the runs after it.
+	// failFirstReap, when set, is returned by the first reap call only, so a test
+	// can see a reap failure surface out of Carve.
 	failFirstReap error
 	// straddleEverywhere answers every lookup with a row reaching one byte past
 	// the offset asked about, so no reap span ever ends on a row boundary.
@@ -212,10 +213,11 @@ func (e *extendingSink) ManifestRowEndAfter(_ context.Context, _ FileID, off int
 	return e.rowEnd, nil
 }
 
-func (e *extendingSink) ReapSupersededManifest(_ context.Context, _ FileID, runStart, runEnd int64, _ map[int64]struct{}) error {
+func (e *extendingSink) ReapSupersededManifest(_ context.Context, _ FileID, spans [][2]int64, _ map[int64]struct{}) error {
 	e.mu.Lock()
-	e.reaps = append(e.reaps, [2]int64{runStart, runEnd})
-	first := len(e.reaps) == 1
+	e.reaps = append(e.reaps, spans...)
+	e.calls++
+	first := e.calls == 1
 	e.mu.Unlock()
 	if first {
 		return e.failFirstReap
@@ -474,7 +476,7 @@ func (r *reapCtxSink) CommitBlock(ctx context.Context, chunks []CarveChunk) erro
 	return err
 }
 
-func (r *reapCtxSink) ReapSupersededManifest(_ context.Context, _ FileID, _, _ int64, _ map[int64]struct{}) error {
+func (r *reapCtxSink) ReapSupersededManifest(_ context.Context, _ FileID, spans [][2]int64, _ map[int64]struct{}) error {
 	// Only count a reap that runs after the failure has landed: that is the one
 	// a completed run would lose if the failure suppressed it.
 	select {
@@ -486,7 +488,7 @@ func (r *reapCtxSink) ReapSupersededManifest(_ context.Context, _ FileID, _, _ i
 		return nil
 	}
 	r.mu.Lock()
-	r.reaps++
+	r.reaps += len(spans)
 	r.mu.Unlock()
 	return nil
 }

--- a/pkg/block/journal/carve_concurrent_test.go
+++ b/pkg/block/journal/carve_concurrent_test.go
@@ -194,6 +194,8 @@ type extendingSink struct {
 	failFirstReap error
 	// straddleEverywhere answers every lookup with a row reaching one byte past
 	// the offset asked about, so no reap span ever ends on a row boundary.
+	// Journal reaps over its span either way — sparing the straddling row is the
+	// metadata reap's job, not a reason to skip the whole reap.
 	straddleEverywhere bool
 }
 
@@ -222,13 +224,12 @@ func (e *extendingSink) ReapSupersededManifest(_ context.Context, _ FileID, runS
 }
 
 // TestCarveRunDoesNotExtendPastNextRun pins the end-to-end property: no run's
-// reap range ever reaches into a range another run owns, and a run that could
-// not be widened to a row boundary is not reaped at all. The run-end reap
-// deletes every manifest row starting inside its range that it did not itself
-// write, whole and regardless of how far past the range it reaches, so both a
-// reap range crossing into the next run and a reap ending inside a row would
-// drop cover nothing replaces, leaving an uncovered range that cold-reads as
-// zeros with no error anywhere.
+// reap range ever reaches into a range another run owns, and every run that
+// committed rows is reaped over exactly the range those rows cover — including a
+// run that could not be widened to a row boundary. A reap range crossing into
+// the next run would delete cover that run has not replaced yet; a reap range
+// short of the rows it committed would leave the rows they superseded alive
+// forever, since nothing re-carves an already-flipped range.
 //
 // It does not, on its own, pin the extension refusal in extendRunToRowEnd —
 // warmTail's own all-or-nothing bail on a non-warm interval produces the same
@@ -292,11 +293,11 @@ func TestCarveRunDoesNotExtendPastNextRun(t *testing.T) {
 		t.Fatalf("the gated lookup was never reached, so the extension path this test drives was never exercised and the assertions below prove nothing")
 	}
 	// The first run ends at the gated offset, inside a row reaching to 4*rec, and
-	// the refusal above left it there: its reap is refused rather than allowed to
-	// delete that row and strand the stretch past the run. The second run ends on
-	// a boundary and is reaped as usual.
-	if want := [][2]int64{{2 * rec, 3 * rec}}; !reflect.DeepEqual(reaps, want) {
-		t.Fatalf("reaps=%v, want %v: only the run whose end is a row boundary", reaps, want)
+	// the refusal above left it there — it is still reaped over its own range,
+	// since the straddling row survives that reap whole and nothing is stranded.
+	// The second run ends on a boundary and is reaped as usual.
+	if want := [][2]int64{{0, rec}, {2 * rec, 3 * rec}}; !reflect.DeepEqual(reaps, want) {
+		t.Fatalf("reaps=%v, want %v: each run over exactly the range its rows cover", reaps, want)
 	}
 	// No run's reap range may reach into a range another run is carving.
 	for _, r := range reaps {

--- a/pkg/block/journal/carve_pack_test.go
+++ b/pkg/block/journal/carve_pack_test.go
@@ -174,10 +174,9 @@ func TestCarvePackFlipPlanWatermarks(t *testing.T) {
 // the next pass — reaping into it would delete that cover with no fresh tiling
 // to replace it.
 //
-// The straddled subtest pins that the frontier goes through the same boundary
-// guard as a whole run's end: a row starting inside the prefix and reaching past
-// the frontier would be deleted whole by that reap, so the reap is refused
-// rather than allowed to strand the stretch past it.
+// The straddled subtest pins that a row reaching past the frontier does not
+// suppress the reap: it still runs over exactly the committed prefix, and
+// sparing that one row is the metadata reap's own job.
 func TestCarvePackSpanningBlockFailureReapsTheCommittedPrefix(t *testing.T) {
 	t.Run("boundary", func(t *testing.T) { spanningBlockFailureReap(t, false) })
 	t.Run("straddled", func(t *testing.T) { spanningBlockFailureReap(t, true) })
@@ -234,9 +233,6 @@ func spanningBlockFailureReap(t *testing.T, straddle bool) {
 	}
 
 	want := [][2]int64{{0, frontier}}
-	if straddle {
-		want = nil
-	}
 	sink.mu.Lock()
 	defer sink.mu.Unlock()
 	if !reflect.DeepEqual(sink.reaps, want) {

--- a/pkg/block/journal/carve_pack_test.go
+++ b/pkg/block/journal/carve_pack_test.go
@@ -240,11 +240,11 @@ func spanningBlockFailureReap(t *testing.T, straddle bool) {
 	}
 }
 
-// TestCarvePackReapFailureDoesNotSuppressLaterRuns pins that one run's reap
-// failing still leaves every later complete run reaped. Those runs have already
-// flipped synced, so no later pass revisits them: a reap skipped here never
-// happens at all. The first error still surfaces.
-func TestCarvePackReapFailureDoesNotSuppressLaterRuns(t *testing.T) {
+// TestCarvePackReapCarriesEveryCommittedRun pins that the pass-end reap is asked
+// about every run that committed rows, and that a reap failure surfaces out of
+// Carve. Those runs have already flipped synced, so no later pass revisits them:
+// a run left out of this reap is never reaped at all.
+func TestCarvePackReapCarriesEveryCommittedRun(t *testing.T) {
 	const (
 		runSize = 4 << 10
 		gap     = 64 << 10
@@ -270,7 +270,7 @@ func TestCarvePackReapFailureDoesNotSuppressLaterRuns(t *testing.T) {
 	sink.mu.Lock()
 	defer sink.mu.Unlock()
 	if len(sink.reaps) != runs {
-		t.Fatalf("reaps=%d want %d: a failed reap suppressed the runs after it", len(sink.reaps), runs)
+		t.Fatalf("reaped spans=%d want %d: a committed run was left out of the reap", len(sink.reaps), runs)
 	}
 }
 

--- a/pkg/block/journal/evict_test.go
+++ b/pkg/block/journal/evict_test.go
@@ -531,3 +531,49 @@ func TestInvalidatedRangeSurvivesEviction(t *testing.T) {
 		t.Fatalf("invalidated range must come back cold, not a hole: %+v", st)
 	}
 }
+
+// TestEvictWaitsForCarve pins that eviction holds the shard's carveMu, the way
+// reclaimEmptied and the GC pass already do. A carve flips its records synced as
+// each block commits but reaps the rows they superseded only once it has packed
+// the whole file; a record that flipped in that window is already evictable while
+// stale rows still overlap its range. Coverage resolves to the greatest covering
+// start, so cold-marking there lets a stale row starting later than a fresh one
+// serve old bytes.
+func TestEvictWaitsForCarve(t *testing.T) {
+	s, _ := evictStore(t, Config{})
+	ctx := context.Background()
+
+	fillUntilSealed(t, s, "f", true, 2)
+	sh := s.shardFor("f")
+	if len(sealedSegs(sh)) < 2 {
+		t.Fatal("want >=2 sealed segments to evict from")
+	}
+
+	// Stand in for a carve pass in flight on this shard.
+	sh.carveMu.Lock()
+
+	done := make(chan EvictResult, 1)
+	go func() {
+		res, err := s.Evict(ctx, 0)
+		if err != nil {
+			t.Errorf("Evict: %v", err)
+		}
+		done <- res
+	}()
+
+	select {
+	case res := <-done:
+		t.Fatalf("Evict finished mid-carve (evicted %d segments): it must not cold-mark a segment while a carve holds carveMu", res.SegmentsEvicted)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	sh.carveMu.Unlock()
+	select {
+	case res := <-done:
+		if res.SegmentsEvicted != 1 {
+			t.Fatalf("SegmentsEvicted=%d want 1 once the carve released the lock", res.SegmentsEvicted)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Evict never completed after the carve released carveMu")
+	}
+}

--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -228,7 +228,24 @@ func evictable(seg *segmentMeta) bool {
 // eviction serves. Retrying is safe because the failure leaves the index and the
 // segment untouched; at worst it left markers for bytes that are still local, which
 // the persist-first order already tolerates.
+//
+// carveMu is held for the same reason reclaimEmptied and the GC pass hold it, and
+// the segment-busy claim does not cover: a carve pass flips its records synced as
+// each block commits, but the manifest rows those fresh rows superseded are reaped
+// only once it has packed the whole file. A record that flipped in that window is
+// evictable while stale rows still overlap its range, and coverage resolves to the
+// greatest covering start — so cold-marking it there lets a stale row starting
+// later than a fresh one serve old bytes on the cold read. Holding carveMu also
+// keeps the segment's fd open under carve's unlocked preads, which readRecord
+// already documents as relying on it.
+//
+// ponytail: this waits out the shard's whole carve pass, uploads included, rather
+// than skipping the shard; make it a TryLock that moves on to the next shard's
+// coldest segment if a writer is ever seen stalling behind a live carve.
 func (s *Store) evictSegment(sh *shard, seg *segmentMeta) (freed int64, err error) {
+	sh.carveMu.Lock()
+	defer sh.carveMu.Unlock()
+
 	defer func() {
 		if err != nil {
 			seg.busy.Store(false)

--- a/pkg/metadata/block_record_store.go
+++ b/pkg/metadata/block_record_store.go
@@ -359,8 +359,8 @@ func ManifestRowEndAfter(ctx context.Context, tx Transaction, payloadID string, 
 // no longer tiles [0,size) — a cold read then resolves a stale straddling row
 // (returns old bytes) or hits a gap (zero-fills). That is #953.
 //
-// Reaped set: every existing row for payloadID whose start offset lies in the
-// run's [runStart, runEnd) span and is NOT one of the offsets this run just wrote
+// Reaped set: every existing row for payloadID that lies wholly inside the run's
+// [runStart, runEnd) span and is NOT one of the offsets this run just wrote
 // (newOffsets). Running once at run end — after all of the run's batches have
 // committed their rows — is what makes it correct across a multi-batch run: a
 // straddler spanning a batch seam has no single batch span that contains it, and
@@ -375,11 +375,16 @@ func ManifestRowEndAfter(ctx context.Context, tx Transaction, payloadID string, 
 // and the run's fresh rows take over from there. The chunk keeps every byte on the
 // remote and is still hash-verified over all of them; the row just stops claiming
 // the part the run re-chunked, which is the same shape a truncate's narrow leaves
-// behind. A straddler that ALSO ends past runEnd stays whole: no row can start
-// mid-chunk, so its tail past the run has no other cover and narrowing it would
-// trade the overlap for a gap. Coverage lookups resolve that overlap to the
-// greatest covering start, so the fresh rows win inside the run and the straddler
-// serves only its unre-carved tail.
+// behind.
+//
+// A row that reaches past runEnd stays whole, whichever side it starts on: no row
+// can start mid-chunk, so its tail past the run has no other cover, and both
+// narrowing it (from the head) and deleting it (from inside the run) would trade
+// an overlap for a gap. Coverage lookups resolve that overlap to the greatest
+// covering start, so the fresh rows win inside the run and the surviving row
+// serves only its unre-carved tail. A run whose end sits on a row boundary — what
+// the journal's run extension arranges on the normal path — has no such row, so
+// this only spares anything where a run stops early.
 //
 // ponytail: this fixes read-coherence — the corruption. Decrementing the reaped
 // chunk's CAS refcount to reclaim its remote space is a separate, tracked
@@ -418,6 +423,9 @@ func ReapSupersededManifest(ctx context.Context, tx Transaction, payloadID strin
 		}
 		if _, isNew := newOffsets[int64(off)]; isNew {
 			continue // a row this run just wrote — keep it
+		}
+		if rowEnd > runEnd {
+			continue // reaches past the run: deleting it would strand [runEnd, rowEnd)
 		}
 		if err := tx.Delete(ctx, r.ID); err != nil {
 			return fmt.Errorf("reap superseded: delete %s: %w", r.ID, err)

--- a/pkg/metadata/block_record_store.go
+++ b/pkg/metadata/block_record_store.go
@@ -387,14 +387,35 @@ func ManifestRowEndAfter(ctx context.Context, tx Transaction, payloadID string, 
 // the part the run re-chunked, which is the same shape a truncate's narrow leaves
 // behind.
 //
-// A row that reaches past its span's end stays whole, whichever side it starts on:
-// no row can start mid-chunk, so its tail past the span has no other cover, and
-// both narrowing it (from the head) and deleting it (from inside the span) would
-// trade an overlap for a gap. Coverage lookups resolve that overlap to the
-// greatest covering start, so the fresh rows win inside the span and the surviving
-// row serves only its unre-carved tail. A span ending on a row boundary — what the
-// journal's run extension arranges on the normal path — has no such row, so this
-// only spares anything where a run stopped early.
+// A row that reaches past its span's end stays whole, whichever side it starts
+// on: no row can start mid-chunk, so its tail past the span has no other cover,
+// and deleting it would trade an overlap for a gap. Where it starts decides what
+// that overlap then reads, and the two sides are not alike.
+//
+// Starting BEFORE the span is safe. Coverage resolves an overlap to the greatest
+// covering start, and every fresh row inside the span starts later than a row
+// that began before it, so the fresh rows win across the whole span and the
+// survivor serves only its un-recarved tail.
+//
+// Starting INSIDE the span is not. Over [rowStart, spanEnd) the spared row is
+// itself the greatest start, so it outranks the fresh row covering those bytes
+// and serves the content they held before the carve. Sparing it is the least bad
+// of three wrong answers, not a safe one: deleting it strands [spanEnd, rowEnd)
+// with no cover at all, and it cannot be narrowed off the overlap either, because
+// a row claims a prefix of its chunk and none can be made to start at spanEnd.
+//
+// Nothing here can do better, because the overlap is already decided by the time
+// the reap runs: the fresh rows are committed, and no row that claims a prefix
+// can cover [spanEnd, rowEnd) in the spared row's place. Only carving through to
+// rowEnd avoids it, which is what the journal's run extension arranges whenever
+// the bytes past the span are still warm; a span cuts a row starting inside it
+// only where that extension could not reach — the tail is cold, evicted, holed,
+// or already dirty for a later run.
+//
+// ponytail: over [rowStart, spanEnd) a cold read serves pre-carve bytes, and the
+// manifest records no order to tell the caller so; closing it means carve
+// hydrating the straddler's tail and re-chunking it, or refusing to commit a
+// tiling whose span cuts a row starting inside it (#2124).
 //
 // ponytail: this fixes read-coherence — the corruption. Decrementing the reaped
 // chunk's CAS refcount to reclaim its remote space is a separate, tracked

--- a/pkg/metadata/block_record_store.go
+++ b/pkg/metadata/block_record_store.go
@@ -415,7 +415,7 @@ func ManifestRowEndAfter(ctx context.Context, tx Transaction, payloadID string, 
 // ponytail: over [rowStart, spanEnd) a cold read serves pre-carve bytes, and the
 // manifest records no order to tell the caller so; closing it means carve
 // hydrating the straddler's tail and re-chunking it, or refusing to commit a
-// tiling whose span cuts a row starting inside it (#2124).
+// tiling whose span cuts a row starting inside it (#2128).
 //
 // ponytail: this fixes read-coherence — the corruption. Decrementing the reaped
 // chunk's CAS refcount to reclaim its remote space is a separate, tracked

--- a/pkg/metadata/block_record_store.go
+++ b/pkg/metadata/block_record_store.go
@@ -428,17 +428,17 @@ func ReapSupersededManifest(ctx context.Context, tx Transaction, payloadID strin
 		}
 		rowStart := int64(off)
 		rowEnd := rowStart + int64(r.DataSize)
-		// The first span reaching past the row's start: spans are disjoint and
-		// ascending, so a row overlapping any span overlaps this one — and a row
-		// covering several reaches past its end, which the check below spares.
-		i := sort.Search(len(ordered), func(j int) bool { return ordered[j][1] > rowStart })
-		if i == len(ordered) || ordered[i][0] >= rowEnd {
-			continue // untouched by the pass (incl. cold remainders)
+		// The span this row is acted on: the first one whose end the row does not
+		// reach past. An earlier span the row overlaps is one it outreaches, and
+		// outreaching a span is what spares the row — acting on it there would
+		// strand the stretch beyond, since no row can start mid-chunk to cover it.
+		// A later span the row cannot reach, because acting here leaves it ending
+		// at or before this span's start. Spans ascend, so this is a binary search.
+		i := sort.Search(len(ordered), func(j int) bool { return ordered[j][1] >= rowEnd })
+		if i == len(ordered) || ordered[i][0] >= rowEnd || ordered[i][1] <= rowStart {
+			continue // no span acts on it: untouched (incl. cold remainders)
 		}
-		spanStart, spanEnd := ordered[i][0], ordered[i][1]
-		if rowEnd > spanEnd {
-			continue // reaches past the span: acting on it would strand [spanEnd, rowEnd)
-		}
+		spanStart := ordered[i][0]
 		if rowStart < spanStart {
 			narrowed := *r
 			narrowed.DataSize = uint32(spanStart - rowStart)

--- a/pkg/metadata/block_record_store.go
+++ b/pkg/metadata/block_record_store.go
@@ -352,47 +352,67 @@ func ManifestRowEndAfter(ctx context.Context, tx Transaction, payloadID string, 
 	return end, nil
 }
 
-// ReapSupersededManifest deletes the manifest rows a carve run supersedes and
+// ReapSupersededManifest deletes the manifest rows a carve pass supersedes and
 // re-projects File.Blocks, atomically. A partial overwrite re-chunks the dirty
 // range (plus its warm straddle remainders, re-marked dirty by the journal) into
 // fresh rows; the old rows those supersede must be reaped or the per-file manifest
 // no longer tiles [0,size) — a cold read then resolves a stale straddling row
 // (returns old bytes) or hits a gap (zero-fills). That is #953.
 //
-// Reaped set: every existing row for payloadID that lies wholly inside the run's
-// [runStart, runEnd) span and is NOT one of the offsets this run just wrote
-// (newOffsets). Running once at run end — after all of the run's batches have
-// committed their rows — is what makes it correct across a multi-batch run: a
-// straddler spanning a batch seam has no single batch span that contains it, and
-// reaping per batch by the run span would delete a sibling batch's fresh rows.
-// The run span covers only re-carved (dirty) bytes, so an un-recarved cold
-// remainder falls outside it and is never reaped — no gap. newOffsets excludes
-// this run's own rows so they survive.
+// spans are the committed prefixes of the pass's dirty runs, as [start, end)
+// pairs; they are disjoint, and the holes between them are un-recarved bytes no
+// span may touch. newOffsets holds the offsets of every chunk the pass wrote, so
+// its own fresh rows survive. Reaped set: every existing row that lies wholly
+// inside a span and is not one of those offsets.
 //
-// A row that STARTS before runStart and reaches into the run is not in that set —
-// deleting it would strip [rowStart, runStart) of its only cover — so it is
-// narrowed to the prefix it still owns instead: DataSize becomes runStart-rowStart
-// and the run's fresh rows take over from there. The chunk keeps every byte on the
+// One call per pass, not per run: each span's deletes are decided against the
+// same listing, and File.Blocks is re-projected once at the end. That is what
+// keeps the cost of a file with tens of thousands of dirty runs at one manifest
+// read rather than one per run, all of it under the journal's carve lock. It is
+// also equivalent to reaping the spans one at a time in ascending order, because
+// a row this loop deletes or narrows ends at or before the span it acted on and
+// so cannot reach the spans after it.
+//
+// Running after all of the pass's rows are committed is what makes it correct
+// across a multi-block run: a straddler spanning a block seam has no single
+// block span that contains it, and reaping per block by the run span would
+// delete a sibling block's fresh rows.
+//
+// A row that STARTS before its span and reaches into it is not in the reaped set —
+// deleting it would strip [rowStart, spanStart) of its only cover — so it is
+// narrowed to the prefix it still owns instead: DataSize becomes spanStart-rowStart
+// and the fresh rows take over from there. The chunk keeps every byte on the
 // remote and is still hash-verified over all of them; the row just stops claiming
 // the part the run re-chunked, which is the same shape a truncate's narrow leaves
 // behind.
 //
-// A row that reaches past runEnd stays whole, whichever side it starts on: no row
-// can start mid-chunk, so its tail past the run has no other cover, and both
-// narrowing it (from the head) and deleting it (from inside the run) would trade
-// an overlap for a gap. Coverage lookups resolve that overlap to the greatest
-// covering start, so the fresh rows win inside the run and the surviving row
-// serves only its unre-carved tail. A run whose end sits on a row boundary — what
-// the journal's run extension arranges on the normal path — has no such row, so
-// this only spares anything where a run stops early.
+// A row that reaches past its span's end stays whole, whichever side it starts on:
+// no row can start mid-chunk, so its tail past the span has no other cover, and
+// both narrowing it (from the head) and deleting it (from inside the span) would
+// trade an overlap for a gap. Coverage lookups resolve that overlap to the
+// greatest covering start, so the fresh rows win inside the span and the surviving
+// row serves only its unre-carved tail. A span ending on a row boundary — what the
+// journal's run extension arranges on the normal path — has no such row, so this
+// only spares anything where a run stopped early.
 //
 // ponytail: this fixes read-coherence — the corruption. Decrementing the reaped
 // chunk's CAS refcount to reclaim its remote space is a separate, tracked
 // follow-up (#1715): under-counting only leaks space, it never drops live data.
-func ReapSupersededManifest(ctx context.Context, tx Transaction, payloadID string, runStart, runEnd int64, newOffsets map[int64]struct{}) error {
-	if payloadID == "" || runEnd <= runStart {
+func ReapSupersededManifest(ctx context.Context, tx Transaction, payloadID string, spans [][2]int64, newOffsets map[int64]struct{}) error {
+	if payloadID == "" {
 		return nil
 	}
+	ordered := make([][2]int64, 0, len(spans))
+	for _, sp := range spans {
+		if sp[1] > sp[0] {
+			ordered = append(ordered, sp)
+		}
+	}
+	if len(ordered) == 0 {
+		return nil
+	}
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i][0] < ordered[j][0] })
+
 	rows, err := tx.ListFileChunks(ctx, payloadID)
 	if err != nil {
 		return fmt.Errorf("reap superseded: list manifest for %s: %w", payloadID, err)
@@ -407,25 +427,26 @@ func ReapSupersededManifest(ctx context.Context, tx Transaction, payloadID strin
 		}
 		rowStart := int64(off)
 		rowEnd := rowStart + int64(r.DataSize)
-		if rowStart < runStart {
-			if rowEnd <= runStart || rowEnd > runEnd {
-				continue // no overlap with the run, or narrowing would open a tail gap
-			}
+		// The first span that could overlap the row: spans are disjoint and
+		// ascending, so at most this one does.
+		i := sort.Search(len(ordered), func(i int) bool { return ordered[i][1] > rowStart })
+		if i == len(ordered) || ordered[i][0] >= rowEnd {
+			continue // untouched by the pass (incl. cold remainders)
+		}
+		spanStart, spanEnd := ordered[i][0], ordered[i][1]
+		if rowEnd > spanEnd {
+			continue // reaches past the span: acting on it would strand [spanEnd, rowEnd)
+		}
+		if rowStart < spanStart {
 			narrowed := *r
-			narrowed.DataSize = uint32(runStart - rowStart)
+			narrowed.DataSize = uint32(spanStart - rowStart)
 			if err := tx.Put(ctx, &narrowed); err != nil {
 				return fmt.Errorf("reap superseded: narrow %s: %w", r.ID, err)
 			}
 			continue
 		}
-		if rowStart >= runEnd {
-			continue // outside the re-carved run — untouched (incl. cold remainders)
-		}
-		if _, isNew := newOffsets[int64(off)]; isNew {
-			continue // a row this run just wrote — keep it
-		}
-		if rowEnd > runEnd {
-			continue // reaches past the run: deleting it would strand [runEnd, rowEnd)
+		if _, isNew := newOffsets[rowStart]; isNew {
+			continue // a row this pass just wrote — keep it
 		}
 		if err := tx.Delete(ctx, r.ID); err != nil {
 			return fmt.Errorf("reap superseded: delete %s: %w", r.ID, err)

--- a/pkg/metadata/block_record_store.go
+++ b/pkg/metadata/block_record_store.go
@@ -293,7 +293,7 @@ func DefaultCommitBlock(
 		// rows, since re-deriving from the whole manifest costs a full list and
 		// sort per committed block object. Skipped for legacy callers that pass
 		// no fileChunks (empty payloadID). Superseded-row reaping happens once
-		// per carve run (ReapSupersededManifest), not per batch — see below.
+		// per carve pass (ReapSupersededManifest), not per batch — see below.
 		return ProjectCommittedChunks(ctx, tx, payloadIDFromChunks(fileChunks), fileChunks)
 	})
 }
@@ -306,10 +306,11 @@ func DefaultCommitBlock(
 // single pass would stop one row short.
 //
 // A carve run asks this about its own end. A run that stops inside a row leaves
-// that row half superseded: the run-end reap deletes it, because its start lies
-// in the run, and the part past the run keeps no cover at all — a row claims a
-// prefix of its chunk, so no row can be made to start mid-chunk. Carving through
-// to this offset is what keeps that range covered.
+// that row half superseded, and the reap spares it whole rather than strand the
+// part past the run — a row claims a prefix of its chunk, so no row can be made
+// to start mid-chunk and cover that part instead. The stale row then overlaps
+// the fresh tiling for good. Carving through to this offset is what lets the
+// reap delete it.
 //
 // A payload with no rows yet (the first carve of a file) is not an error: there
 // is nothing to straddle, so the run stands as snapshotted.
@@ -427,9 +428,10 @@ func ReapSupersededManifest(ctx context.Context, tx Transaction, payloadID strin
 		}
 		rowStart := int64(off)
 		rowEnd := rowStart + int64(r.DataSize)
-		// The first span that could overlap the row: spans are disjoint and
-		// ascending, so at most this one does.
-		i := sort.Search(len(ordered), func(i int) bool { return ordered[i][1] > rowStart })
+		// The first span reaching past the row's start: spans are disjoint and
+		// ascending, so a row overlapping any span overlaps this one — and a row
+		// covering several reaches past its end, which the check below spares.
+		i := sort.Search(len(ordered), func(j int) bool { return ordered[j][1] > rowStart })
 		if i == len(ordered) || ordered[i][0] >= rowEnd {
 			continue // untouched by the pass (incl. cold remainders)
 		}

--- a/pkg/metadata/manifest_projection_test.go
+++ b/pkg/metadata/manifest_projection_test.go
@@ -29,6 +29,9 @@ type manifestTx struct {
 	// wroteManifest records whether the last file write went through
 	// SetManifest (manifest rewritten) or UpdateAttrs (attrs only).
 	wroteManifest bool
+	// lists counts ListFileChunks calls: the whole-manifest read is what a reap
+	// costs, so a caller can assert the cost does not scale with its input.
+	lists int
 }
 
 func newManifestTx(payloadID string) *manifestTx {
@@ -58,6 +61,7 @@ func (t *manifestTx) Delete(_ context.Context, id string) error {
 }
 
 func (t *manifestTx) ListFileChunks(_ context.Context, payloadID string) ([]*block.FileChunk, error) {
+	t.lists++
 	ids := make([]string, 0, len(t.rows))
 	for id := range t.rows {
 		if chunkPayloadID(id) == payloadID {

--- a/pkg/metadata/reap_superseded_test.go
+++ b/pkg/metadata/reap_superseded_test.go
@@ -156,6 +156,32 @@ func TestReapSupersededManifest_ManySpans(t *testing.T) {
 	}, tiling(t, tx, pid))
 }
 
+// TestReapSupersededManifest_RowSpanningSeveralSpans pins which span acts on a
+// row long enough to cover more than one: the first whose end it does not reach
+// past. Acting on it at the earlier span would strand the stretch beyond that
+// span, so the row survives there and is narrowed at the later one instead —
+// exactly what reaping the spans one at a time in ascending order does.
+func TestReapSupersededManifest_RowSpanningSeveralSpans(t *testing.T) {
+	const pid = "share/p"
+	ctx := context.Background()
+	tx := newManifestTx(pid)
+
+	// One row [1000, 4500) covers span [2000, 3000), the hole after it, and part
+	// of span [4000, 5000).
+	seedRows(t, tx, pid, [][2]uint64{{0, 1000}, {1000, 3500}, {5000, 1000}})
+	seedRows(t, tx, pid, [][2]uint64{{2000, 1000}, {4000, 1000}})
+	newOffsets := map[int64]struct{}{2000: {}, 4000: {}}
+
+	require.NoError(t, ReapSupersededManifest(ctx, tx, pid, [][2]int64{{2000, 3000}, {4000, 5000}}, newOffsets))
+	require.Equal(t, [][2]int64{
+		{0, 1000},
+		{1000, 4000}, // narrowed at the second span, not the first
+		{2000, 3000},
+		{4000, 5000},
+		{5000, 6000},
+	}, tiling(t, tx, pid))
+}
+
 // TestReapSupersededManifest_CostIsIndependentOfSpanCount pins what makes the
 // pass-end reap one call rather than one per run: it reads the manifest a fixed
 // number of times whatever the run count, so a file with tens of thousands of

--- a/pkg/metadata/reap_superseded_test.go
+++ b/pkg/metadata/reap_superseded_test.go
@@ -34,6 +34,27 @@ func seedRows(t *testing.T, tx *manifestTx, payloadID string, spans [][2]uint64)
 	}
 }
 
+// resolveAt returns the start offset of the row a read at off resolves to — the
+// greatest start among the rows covering off — or -1 when nothing covers it. That
+// is the rule the read path applies (findRowCoveringOffset), and a reap has to be
+// judged by what it makes a read serve rather than by the row list alone: a list
+// that tiles [0, size) can still hand back an older row's bytes wherever a
+// surviving row starts later than the fresh row over the same offsets.
+func resolveAt(t *testing.T, tx *manifestTx, payloadID string, off int64) int64 {
+	t.Helper()
+	rows, err := tx.ListFileChunks(context.Background(), payloadID)
+	require.NoError(t, err)
+	hit := int64(-1)
+	for _, r := range rows {
+		start, ok := block.ParseChunkOffset(r.ID)
+		require.True(t, ok)
+		if off >= int64(start) && off-int64(start) < int64(r.DataSize) && int64(start) > hit {
+			hit = int64(start)
+		}
+	}
+	return hit
+}
+
 // TestReapSupersededManifest_NarrowsStraddler pins the tiling invariant across a
 // carve run that starts in the middle of an existing row. The row starting before
 // the run cannot be deleted — it is the only cover for the bytes before the run —
@@ -84,13 +105,31 @@ func TestReapSupersededManifest_KeepsStraddlerReachingPastRun(t *testing.T) {
 		{1000, 6000}, // kept whole: its tail past 3000 has no other cover
 		{2000, 3000},
 	}, tiling(t, tx, pid))
+
+	// The straddler starts before the run, so the fresh row is the greater start
+	// at every offset inside it: the whole re-carved span reads back fresh bytes.
+	require.Equal(t, int64(2000), resolveAt(t, tx, pid, 2000))
+	require.Equal(t, int64(2000), resolveAt(t, tx, pid, 2999))
+	// Outside the run the straddler is the only cover, which is why it is kept.
+	require.Equal(t, int64(1000), resolveAt(t, tx, pid, 1999))
+	require.Equal(t, int64(1000), resolveAt(t, tx, pid, 3000))
+	require.Equal(t, int64(1000), resolveAt(t, tx, pid, 5999))
+	require.Equal(t, int64(-1), resolveAt(t, tx, pid, 6000))
 }
 
-// TestReapSupersededManifest_KeepsInteriorRowReachingPastRun mirrors the head
-// case at the run's tail: a row that starts inside the run but ends past it must
-// survive whole. Deleting it — which is what its start offset alone would say to
-// do — strands [runEnd, rowEnd) with no cover, and no row can be made to start
-// mid-chunk to take that stretch over, so the bytes read back as zeros.
+// TestReapSupersededManifest_KeepsInteriorRowReachingPastRun pins both what the
+// reap does with a row that starts inside the run and ends past it, and what a
+// read then gets — which are not the same question. The row survives whole:
+// deleting it, which is what its start offset alone would say to do, strands
+// [runEnd, rowEnd) with no cover, and no row can be made to start mid-chunk to
+// take that stretch over, so those bytes would read back as zeros.
+//
+// Surviving is not the same as being right. Coverage resolves to the greatest
+// start, so over [rowStart, runEnd) the spared row outranks the fresh row that
+// also covers those offsets and serves what they held before the carve. The reap
+// has no better move — it cannot narrow a row off its own head — so the
+// assertions below record that stale window instead of claiming there is none.
+// Only carving through to rowEnd removes it.
 func TestReapSupersededManifest_KeepsInteriorRowReachingPastRun(t *testing.T) {
 	const pid = "share/p"
 	ctx := context.Background()
@@ -108,6 +147,19 @@ func TestReapSupersededManifest_KeepsInteriorRowReachingPastRun(t *testing.T) {
 		{2000, 3000}, // the fresh row; the stale [2000, 2500) it replaced is gone
 		{2500, 6000}, // kept whole: its tail past 3000 has no other cover
 	}, tiling(t, tx, pid))
+
+	// Below the spared row's start the fresh row is the greatest start and wins.
+	require.Equal(t, int64(2000), resolveAt(t, tx, pid, 2000))
+	require.Equal(t, int64(2000), resolveAt(t, tx, pid, 2499))
+	// From that start to the run's end the spared row is the greatest start, so it
+	// wins over the fresh row: these offsets were re-carved, yet a read is served
+	// the pre-carve chunk. This is the stale window the reap cannot close.
+	require.Equal(t, int64(2500), resolveAt(t, tx, pid, 2500))
+	require.Equal(t, int64(2500), resolveAt(t, tx, pid, 2999))
+	// Past the run the spared row is the only cover, which is why it is kept.
+	require.Equal(t, int64(2500), resolveAt(t, tx, pid, 3000))
+	require.Equal(t, int64(2500), resolveAt(t, tx, pid, 5999))
+	require.Equal(t, int64(-1), resolveAt(t, tx, pid, 6000))
 }
 
 // TestReapSupersededManifest_LeavesDisjointRowsAlone keeps the reap from

--- a/pkg/metadata/reap_superseded_test.go
+++ b/pkg/metadata/reap_superseded_test.go
@@ -53,7 +53,7 @@ func TestReapSupersededManifest_NarrowsStraddler(t *testing.T) {
 	seedRows(t, tx, pid, [][2]uint64{{2500, 1200}, {3700, 1300}})
 	newOffsets := map[int64]struct{}{2500: {}, 3700: {}}
 
-	require.NoError(t, ReapSupersededManifest(ctx, tx, pid, 2500, 5000, newOffsets))
+	require.NoError(t, ReapSupersededManifest(ctx, tx, pid, [][2]int64{{2500, 5000}}, newOffsets))
 
 	require.Equal(t, [][2]int64{
 		{0, 1000},
@@ -77,7 +77,7 @@ func TestReapSupersededManifest_KeepsStraddlerReachingPastRun(t *testing.T) {
 	seedRows(t, tx, pid, [][2]uint64{{2000, 1000}})
 	newOffsets := map[int64]struct{}{2000: {}}
 
-	require.NoError(t, ReapSupersededManifest(ctx, tx, pid, 2000, 3000, newOffsets))
+	require.NoError(t, ReapSupersededManifest(ctx, tx, pid, [][2]int64{{2000, 3000}}, newOffsets))
 
 	require.Equal(t, [][2]int64{
 		{0, 1000},
@@ -102,7 +102,7 @@ func TestReapSupersededManifest_KeepsInteriorRowReachingPastRun(t *testing.T) {
 	seedRows(t, tx, pid, [][2]uint64{{2000, 1000}})
 	newOffsets := map[int64]struct{}{2000: {}}
 
-	require.NoError(t, ReapSupersededManifest(ctx, tx, pid, 2000, 3000, newOffsets))
+	require.NoError(t, ReapSupersededManifest(ctx, tx, pid, [][2]int64{{2000, 3000}}, newOffsets))
 	require.Equal(t, [][2]int64{
 		{0, 2000},
 		{2000, 3000}, // the fresh row; the stale [2000, 2500) it replaced is gone
@@ -120,9 +120,71 @@ func TestReapSupersededManifest_LeavesDisjointRowsAlone(t *testing.T) {
 	seedRows(t, tx, pid, [][2]uint64{{0, 2000}, {2000, 1000}})
 	newOffsets := map[int64]struct{}{2000: {}}
 
-	require.NoError(t, ReapSupersededManifest(ctx, tx, pid, 2000, 3000, newOffsets))
+	require.NoError(t, ReapSupersededManifest(ctx, tx, pid, [][2]int64{{2000, 3000}}, newOffsets))
 
 	require.Equal(t, [][2]int64{{0, 2000}, {2000, 3000}}, tiling(t, tx, pid))
+}
+
+// TestReapSupersededManifest_ManySpans reaps a whole carve pass in one call: the
+// spans are the committed prefixes of the pass's dirty runs, and the un-recarved
+// bytes in the holes between them keep every row they had.
+func TestReapSupersededManifest_ManySpans(t *testing.T) {
+	const pid = "share/p"
+	ctx := context.Background()
+	tx := newManifestTx(pid)
+
+	// Three 1000-byte rows per 2000-byte span, each span followed by a 1000-byte
+	// hole the pass never re-carved.
+	seedRows(t, tx, pid, [][2]uint64{
+		{0, 1000}, {1000, 1000}, {2000, 1000}, // span [0, 2000) + hole [2000, 3000)
+		{3000, 1000}, {4000, 1000}, {5000, 1000}, // span [3000, 5000) + hole
+		{6000, 1000}, {7000, 1000}, {8000, 1000}, // span [6000, 8000) + hole
+	})
+	// Each span re-tiled by one fresh row.
+	seedRows(t, tx, pid, [][2]uint64{{0, 2000}, {3000, 2000}, {6000, 2000}})
+	newOffsets := map[int64]struct{}{0: {}, 3000: {}, 6000: {}}
+	spans := [][2]int64{{0, 2000}, {3000, 5000}, {6000, 8000}}
+
+	require.NoError(t, ReapSupersededManifest(ctx, tx, pid, spans, newOffsets))
+	require.Equal(t, [][2]int64{
+		{0, 2000},
+		{2000, 3000}, // hole: untouched
+		{3000, 5000},
+		{5000, 6000}, // hole: untouched
+		{6000, 8000},
+		{8000, 9000}, // hole: untouched
+	}, tiling(t, tx, pid))
+}
+
+// TestReapSupersededManifest_CostIsIndependentOfSpanCount pins what makes the
+// pass-end reap one call rather than one per run: it reads the manifest a fixed
+// number of times whatever the run count, so a file with tens of thousands of
+// dirty runs does not hold the journal's carve lock for a scan per run.
+func TestReapSupersededManifest_CostIsIndependentOfSpanCount(t *testing.T) {
+	const pid = "share/p"
+	ctx := context.Background()
+
+	reads := func(spanCount int) int {
+		tx := newManifestTx(pid)
+		var seed [][2]uint64
+		var spans [][2]int64
+		newOffsets := map[int64]struct{}{}
+		for i := 0; i < spanCount; i++ {
+			base := uint64(i) * 3000
+			seed = append(seed, [2]uint64{base, 1000}, [2]uint64{base + 1000, 1000}, [2]uint64{base + 2000, 1000})
+			spans = append(spans, [2]int64{int64(base), int64(base) + 2000})
+			newOffsets[int64(base)] = struct{}{}
+		}
+		seedRows(t, tx, pid, seed)
+		for _, sp := range spans {
+			seedRows(t, tx, pid, [][2]uint64{{uint64(sp[0]), 2000}})
+		}
+		tx.lists = 0
+		require.NoError(t, ReapSupersededManifest(ctx, tx, pid, spans, newOffsets))
+		return tx.lists
+	}
+
+	require.Equal(t, reads(1), reads(16), "manifest reads must not scale with the span count")
 }
 
 // TestManifestRowEndAfter covers the offset a carve run has to reach so the reap

--- a/pkg/metadata/reap_superseded_test.go
+++ b/pkg/metadata/reap_superseded_test.go
@@ -86,6 +86,30 @@ func TestReapSupersededManifest_KeepsStraddlerReachingPastRun(t *testing.T) {
 	}, tiling(t, tx, pid))
 }
 
+// TestReapSupersededManifest_KeepsInteriorRowReachingPastRun mirrors the head
+// case at the run's tail: a row that starts inside the run but ends past it must
+// survive whole. Deleting it — which is what its start offset alone would say to
+// do — strands [runEnd, rowEnd) with no cover, and no row can be made to start
+// mid-chunk to take that stretch over, so the bytes read back as zeros.
+func TestReapSupersededManifest_KeepsInteriorRowReachingPastRun(t *testing.T) {
+	const pid = "share/p"
+	ctx := context.Background()
+	tx := newManifestTx(pid)
+
+	// The run [2000, 3000) stops inside the row at 2500, which reaches 6000.
+	seedRows(t, tx, pid, [][2]uint64{{0, 2000}, {2000, 500}, {2500, 3500}})
+	// Re-carved: one fresh row tiling the run.
+	seedRows(t, tx, pid, [][2]uint64{{2000, 1000}})
+	newOffsets := map[int64]struct{}{2000: {}}
+
+	require.NoError(t, ReapSupersededManifest(ctx, tx, pid, 2000, 3000, newOffsets))
+	require.Equal(t, [][2]int64{
+		{0, 2000},
+		{2000, 3000}, // the fresh row; the stale [2000, 2500) it replaced is gone
+		{2500, 6000}, // kept whole: its tail past 3000 has no other cover
+	}, tiling(t, tx, pid))
+}
+
 // TestReapSupersededManifest_LeavesDisjointRowsAlone keeps the reap from
 // touching a row that merely ends where the run begins.
 func TestReapSupersededManifest_LeavesDisjointRowsAlone(t *testing.T) {


### PR DESCRIPTION
Three issues on the same seam — the carve run-end reap — stacked as six commits, in the order they have to land. They are one PR because each depends on the one before it: #2106 removes the guard whose cost #2108 measures, and #2105's lock is only safe once #2108 has shortened the window it would block on.

Closes #2106
Closes #2108
Closes #2105

---

## 1. `fix(metadata): keep a manifest row that reaches past the reaped run` (#2106)

`ReapSupersededManifest` classified a row by its **start offset alone**. A row starting inside `[runStart, runEnd)` was deleted whole however far past `runEnd` it reached. A manifest row claims a prefix of its chunk, so nothing can be made to start mid-chunk and take `[runEnd, rowEnd)` over — that stretch loses all cover, nothing revisits it, and once the local bytes are evicted a read there zero-fills with no error anywhere.

The head branch already refuses to narrow a row for exactly this reason (`rowEnd > runEnd → continue`). The fix mirrors it at the tail. This is **not** a metadata contract change: keeping a row whole is not the same as narrowing it, and the row goes on meaning exactly what it meant. It leaves an overlap. Where the spared row starts *before* the run, greatest-start resolution makes the run's fresh rows win inside the run and the survivor serves only its un-recarved tail. Where it starts *inside* the run it does not — see the review section at the bottom, which was raised on this PR and is the reason section 5 exists.

Pinned by `TestReapSupersededManifest_KeepsInteriorRowReachingPastRun`, the mirror of the existing head-side `..._KeepsStraddlerReachingPastRun`. Against the unfixed reap it fails with the row `[2500, 6000)` deleted and `[3000, 6000)` stranded.

## 2. `refactor(journal): drop the run-end reap's row-boundary guard` (#2106)

With the predicate fixed, the reap is safe at **any** end by construction, so #2092's journal-side `reapEndsOnRowBoundary` comes back out. That guard refused a run's *whole* reap whenever a row straddled the reap end. It was correct but blunt: it also spared every stale interior row the run superseded, and since nothing re-carves an already-flipped range that overlap was permanent — greatest-start resolution then lets a stale row starting later than a fresh one serve old bytes. It also cost one extra whole-manifest `ListFileChunks` per reaped run, under the shard's carve lock. That is the N → 2N the next commit measures.

`ManifestRowEndAfter` stays: run extension still uses it to widen a run to a row boundary before packing, which is what earns a clean tiling on the normal path.

Two tests pinned the guard and now pin the inverse — that a straddler does **not** suppress the reap, and that each reap range still equals exactly the rows its run committed:
- `TestCarveRunDoesNotExtendPastNextRun` — a run that could not be widened is now reaped over its own range, and neither range reaches into the other run.
- `TestCarvePackSpanningBlockFailureReapsTheCommittedPrefix/straddled` — same committed-prefix range as the `boundary` subtest.

Keeping "the reap range *equals* the committed rows' end" as the assertion (rather than "a reap happened") is deliberate: it is what makes a predicate that silently never fires fail the test.

## 3. `perf(carve): reap a file's superseded rows once per pass, not once per run` (#2108)

The reap ran **once per dirty run**. Each call re-read the file's whole manifest (`ListFileChunks`) and re-projected `File.Blocks` from it — both O(manifest) — serially, on the shard's `carveMu`, *after* the pass's records had already flipped synced and its uploads had drained. For an N-run file that is O(N·M), which is why a drain took 5m41s against a memory remote with no network at all.

The reap now takes every run's committed span in one call: one listing, one re-projection. Equivalent to reaping the spans one at a time in ascending order, because a row this deletes or narrows ends at or before the span it acted on and so cannot reach the spans after it — the argument is written out at the function.

Behaviour deliberately preserved: every run that committed anything is still reaped for, including runs after one that failed mid-way, and a reap failure still surfaces out of `Carve`. What changes is that a store-level failure is now atomic across the file's spans instead of leaving some applied.

- `TestReapSupersededManifest_ManySpans` — the un-recarved holes between spans keep every row they had.
- `TestReapSupersededManifest_CostIsIndependentOfSpanCount` — manifest reads for 16 spans equal those for 1.
- `TestCarvePackReapCarriesEveryCommittedRun` (was `...ReapFailureDoesNotSuppressLaterRuns`) — all three runs' spans reach the reap.

Note for reviewers: `supersededReaper` is an *optional* capability resolved by type assertion, so a stale signature on an implementation fails silently rather than at compile time. Every implementation and test fake was updated.

### 3b. `fix(metadata): act on a row at the first span it does not outreach`

Found while re-deriving the equivalence claim above, before review. The first cut of the batched reap classified each row against the first span it *overlapped*. For a row long enough to cover more than one span, that is always a span the row outreaches — where the row is spared — so it was never narrowed at the later span that does contain its end. Reaping the spans one at a time would have narrowed it there.

Direction of the divergence: more stale overlap survived than intended, never a gap. So this was not a correctness hole, but it broke the property the batched form is justified by, which is worth more than the outcome in this instance.

The span a row is acted on is the first whose end it does not reach past: an earlier overlapping span is one it outreaches, and a later one it can no longer reach, because acting here leaves the row ending at or before this span's start. That also removes the separate outreach check — one `sort.Search` predicate now carries it. `TestReapSupersededManifest_RowSpanningSeveralSpans` pins it and fails against the first cut with the row narrowed to `4500` instead of `4000`.

### 3c. `docs(carve): correct the reap rationale the new predicate invalidated`

`ManifestRowEndAfter` and `extendRunToRowEnd` both justified the run extension by the reap *deleting* a row that starts inside the run — the behaviour commit 1 removes. The extension still earns its keep, for a different reason: without it the run ends inside a row the reap now spares, so the stale cover survives anyway and the overlap is permanent. Comments corrected to the argument that still holds.

## 4. `fix(journal): evict a segment under the shard's carve lock` (#2105)

`flipUpTo` marks a run's records synced as each block commits; the rows those fresh rows superseded are reaped only once the pass has packed the whole file. A record that flipped in that window is already evictable while stale rows still overlap its range — and coverage resolves to the greatest covering start, so an eviction landing there cold-marks the segment and the cold read serves old bytes.

`reclaimEmptied` and the GC pass already take `sh.carveMu` for precisely this class of reason. `evict`/`evictSegment` took only `sh.mu`. Now it takes `carveMu` too.

A second, independent reason the lock belongs there, found while checking the ordering: `readRecord`'s own doc comment states *"Carve is its only caller and holds the shard's carveMu, which GC/eviction also hold before closing a segment, so the fd cannot close under it."* Carve's preads run unlocked and, unlike `readAt`, take no `readGuard` — so that sentence was the only thing standing between a carve pread and `retireSegment` closing the fd, and eviction was not honouring it.

`TestEvictWaitsForCarve` pins it: with the shard's `carveMu` held, `Evict` must not complete; released, it evicts. Against the unfixed build it evicts mid-carve.

The ceiling is marked `ponytail:` at the call site — the eviction now waits out the shard's whole carve pass, uploads included, rather than skipping the shard. The upgrade is a `TryLock` that moves on to the next shard's coldest segment, worth building if a writer is ever seen stalling behind a live carve. Commit 3 is what makes the blocking form acceptable: the pathological wait was the post-drain manifest work, where `unsynced` sits at zero and `ensureSpace`'s backpressure budget stops being refreshed.

---

### Verification

`go build ./...`, `go vet ./...`, `go test -race ./pkg/block/... ./pkg/metadata/...` all green. Each of the three fixes has a regression test that was confirmed to fail against the unfixed code before the fix went in.



---

## 5. Review outcome: the interior-start case reads stale (raised by Copilot)

Copilot flagged the rationale in `ReapSupersededManifest` for claiming "the fresh rows win inside the span" for a spared row **whichever side it starts on**. That clause was false for a row starting inside the span, and the test pinned the row list without ever asking what a read resolves to. Both are now fixed. The reachability question was worked before any edit, because "unreachable" and "reachable" needed opposite diffs.

**Outcome: reachable, and it reads stale — but the same window exists on `develop` today, and nothing at the reap can close it.**

### Reachable, established from the carve code

- Run start is the first dirty interval's offset (`splitRuns` → `runState{ivs: run, committedTo: run[0].fileOff}`) — an arbitrary write offset. Nothing aligns it to a row boundary.
- The span handed to the reap is `[st.start(), st.committedTo)`, and `committedTo` is a fresh FastCDC boundary over new content, unrelated to old row boundaries.
- `extendRunToRowEnd` grows a run **forward only**. There is no backward analogue, and `ManifestRowEndAfter` is asked only about `runEnd`. It bails outright when the bytes past the run end are not warm: `warmAt` is false for a cold or absent interval, and `warmTail` returns nil on any hole, cold, evicted or still-dirty interval; it also refuses when the straddled row reaches past the next dirty run's start.
- So: carve and sync a file, let it be evicted locally, then overwrite a middle range `[d0, d1)` spanning more than one old chunk and ending mid-chunk. Extension cannot reach past `d1`. The span is `[d0, d1)` and the old row `[r0, r1)` with `d0 < r0 < d1 < r1` starts strictly inside it and reaches past it.

Over `[r0, d1)` the spared row is the greatest start, so it outranks the fresh row covering the same offsets and a cold read is served pre-carve bytes.

### Not fixable at the reap, and not a regression

By the time the reap runs the fresh rows are committed. The spared row cannot be narrowed off its own head — a row claims a **prefix** of its chunk (`block.FileChunk` has no in-chunk start offset), so no row can be made to start at `spanEnd` and cover `[spanEnd, rowEnd)` in its place. Deleting it strands that stretch as zeros; keeping it serves stale bytes. Keeping is the less bad of two wrong answers.

It is not introduced here. On `develop`, `reapEndsOnRowBoundary` skipped the **whole** reap in exactly this case, leaving the old rows and the fresh rows side by side — and greatest-start still resolved `[r0, d1)` to the old row. Identical stale window. The per-row predicate is strictly better (it does reap the fully-covered interior rows and narrow the head straddler) but leaves this residual untouched.

Worth stating plainly, since the old comment blurred it: the head straddler is **genuinely** safe, because every fresh row inside the span starts later than it and therefore wins. Only the interior-start case reads stale. The two are not mirror images, and the comment claiming they were is what hid this.

### What changed

- The rationale now states the asymmetry, says sparing is the least bad of three wrong answers rather than a safe one, and carries a `ponytail:` marker naming the ceiling and the upgrade path.
- `TestReapSupersededManifest_KeepsInteriorRowReachingPastRun` now asserts **what a read resolves to** across the overlap, not the row list: `[2000, 2500)` resolves to the fresh row, `[2500, 3000)` resolves to the spared row — the stale window, recorded rather than papered over — and `[3000, 6000)` to the spared row, which is why it is kept.
- The head-straddler test gained the contrasting assertions: the fresh row wins across the **whole** span.
- `resolveAt` applies the read path's rule (greatest covering start); that rule is itself pinned by `TestFindRowCoveringOffset_OverlapResolvesToGreatestStart`.
- Follow-up filed as **#2128** for the carve-time fix — hydrate the straddler's tail and re-chunk through to `rowEnd`, or refuse to commit a tiling whose span cuts a row starting inside it. Truncating the run back to `rowStart` is not a fix on its own: the next pass then starts a run exactly there, its fresh row takes the same offset-keyed ID as the old row and replaces it, stranding `[spanEnd, rowEnd)` — the zero-fill this all started from.
