### PR TITLE
fix(smb): lease epoch only seeds on first grant; rename break precedes the destination lookup

### DIFF
--- a/internal/adapter/smb/handlers/lease_context.go
+++ b/internal/adapter/smb/handlers/lease_context.go
@@ -409,8 +409,18 @@ func ProcessLeaseCreateContext(
 		requestLease = leaseMgr.RequestLeaseStatOpen
 	}
 	// Sampled before the grant, which is what creates the record: only the first
-	// grant for a lease key may seed the epoch from the client's value.
-	_, _, leaseExisted := leaseMgr.GetLeaseState(ctx, leaseReq.LeaseKey)
+	// grant for a lease key on this file may seed the epoch from the client's
+	// value. The predicate is deliberately the same one the grant path itself
+	// uses to choose between reusing a record and creating one, so the seed
+	// decision cannot disagree with what the grant actually did.
+	//
+	// ponytail: a sample taken outside the grant's lock. Two requests can only
+	// race this window by asking for the same lease key on the same file, which
+	// makes them the same client's lease carrying the same epoch, and
+	// SetLeaseEpoch keeps the larger of the two — so the outcome does not
+	// depend on the order. Fold the decision into the grant itself by threading
+	// the client's epoch down to createAndGrantLease if that ever stops holding.
+	leaseExisted := leaseMgr.HasLeaseOnHandle(fileHandle, shareName, leaseReq.LeaseKey)
 	grantedState, epoch, err := requestLease(
 		ctx,
 		fileHandle,

--- a/internal/adapter/smb/handlers/lease_context.go
+++ b/internal/adapter/smb/handlers/lease_context.go
@@ -408,6 +408,9 @@ func ProcessLeaseCreateContext(
 	if statOpen {
 		requestLease = leaseMgr.RequestLeaseStatOpen
 	}
+	// Sampled before the grant, which is what creates the record: only the first
+	// grant for a lease key may seed the epoch from the client's value.
+	_, _, leaseExisted := leaseMgr.GetLeaseState(ctx, leaseReq.LeaseKey)
 	grantedState, epoch, err := requestLease(
 		ctx,
 		fileHandle,
@@ -464,12 +467,12 @@ func ProcessLeaseCreateContext(
 		responseIsV1 = !leaseMgr.IsV2(leaseReq.LeaseKey)
 	}
 
-	// Per MS-SMB2 3.3.5.9.8: a V2 lease grant is a state change that MUST
-	// advance Epoch by 1 over the client's requested value — unconditionally,
-	// including a first-grant Epoch=0 (server must respond with Epoch=1).
-	// Seed server state to max(current, client+1) so re-opens with the same
-	// key pick up the client's evolving view while still advancing past any
-	// server-side increments the client hasn't seen yet (e.g. prior breaks).
+	// Per MS-SMB2 3.3.5.9.8: the FIRST V2 grant for a lease key is a state
+	// change that MUST advance Epoch by 1 over the client's requested value,
+	// including a first-grant Epoch=0 (server must respond with Epoch=1). That
+	// grant is also the only point at which the client's epoch seeds the
+	// server's counter; from then on the counter is the server's, and
+	// RequestLease advances it if and only if the grant changed state.
 	//
 	// Gate on err == nil: on ErrLeaseBreakInProgress the LockManager returns
 	// the breaking lease's current state/epoch read-only and explicitly must
@@ -504,14 +507,24 @@ func ProcessLeaseCreateContext(
 		switch {
 		case leaseReq.LeaseState == lock.LeaseStateNone:
 			// epoch already holds the lease's current value from RequestLease.
-		case grantedState != lock.LeaseStateNone:
+		case grantedState == lock.LeaseStateNone:
+			epoch = leaseReq.Epoch
+		case leaseExisted:
+			// The same drift reaches every other request that leaves the state
+			// untouched: a re-open asking for the state already held, or a
+			// non-superset request that returns the current state unchanged.
+			// The client echoes its last-seen epoch, so seeding from it here
+			// would hand back one more than the server holds, and the next
+			// break notification would carry an epoch the client never expects.
+			// epoch already holds the lease's current value from RequestLease.
+		default:
+			// First grant for this lease key: adopt the client's epoch as the
+			// starting point, one past what it asked for.
 			nextEpoch := leaseReq.Epoch + 1
 			if nextEpoch > epoch {
 				leaseMgr.SetLeaseEpoch(leaseReq.LeaseKey, nextEpoch)
 				epoch = nextEpoch
 			}
-		default:
-			epoch = leaseReq.Epoch
 		}
 	}
 

--- a/internal/adapter/smb/handlers/lease_context_test.go
+++ b/internal/adapter/smb/handlers/lease_context_test.go
@@ -478,3 +478,48 @@ func TestProcessLeaseCreateContext_UnchangedStateDoesNotAdvanceEpoch(t *testing.
 		t.Errorf("upgrade response epoch = 0x%x, want 0x%x (exactly one advance)", resp3.Epoch, grantedEpoch+1)
 	}
 }
+
+// TestProcessLeaseCreateContext_OtherFileSameKeyStillSeeds pins the scope of
+// the first-grant test. Two clients may present the same 16-byte lease key
+// value on different files, so "does a lease with this key exist anywhere"
+// cannot decide whether this grant is a first grant: answering it from a
+// foreign client's lease would skip the seed and hand the requester an epoch
+// far below the one it asked for.
+func TestProcessLeaseCreateContext_OtherFileSameKeyStillSeeds(t *testing.T) {
+	t.Parallel()
+
+	mgr := lock.NewManager()
+	leaseMgr := lease.NewLeaseManager(&staticLockResolver{mgr: mgr}, nil)
+
+	ctx := context.Background()
+	const shareName = "share1"
+	leaseKey := [16]byte{0x5A, 0x5B, 0x5C}
+	const rh = lock.LeaseStateRead | lock.LeaseStateHandle
+	const firstEpoch uint16 = 0x4711
+	const secondEpoch uint16 = 0x0900
+
+	// Client A takes the key on one file.
+	respA, err := ProcessLeaseCreateContext(ctx, leaseMgr, encodeV2LeaseContext(leaseKey, rh, firstEpoch),
+		lock.FileHandle("file-A"), 1, [16]byte{}, "smb:1", shareName, false, false, false)
+	if err != nil {
+		t.Fatalf("client A CREATE returned error: %v", err)
+	}
+	if respA.Epoch != firstEpoch+1 {
+		t.Fatalf("client A response epoch = 0x%x, want 0x%x", respA.Epoch, firstEpoch+1)
+	}
+
+	// Client B presents the same key value on a different file. This is that
+	// client's first grant, so its epoch must seed.
+	respB, err := ProcessLeaseCreateContext(ctx, leaseMgr, encodeV2LeaseContext(leaseKey, rh, secondEpoch),
+		lock.FileHandle("file-B"), 2, [16]byte{}, "smb:2", shareName, false, false, false)
+	if err != nil {
+		t.Fatalf("client B CREATE returned error: %v", err)
+	}
+	if respB.LeaseState != rh {
+		t.Fatalf("client B granted state = 0x%x, want RH (0x%x)", respB.LeaseState, uint32(rh))
+	}
+	if respB.Epoch != secondEpoch+1 {
+		t.Errorf("client B response epoch = 0x%x, want 0x%x — a first grant on a different file must still seed from the client's epoch",
+			respB.Epoch, secondEpoch+1)
+	}
+}

--- a/internal/adapter/smb/handlers/lease_context_test.go
+++ b/internal/adapter/smb/handlers/lease_context_test.go
@@ -411,3 +411,70 @@ func TestProcessLeaseCreateContext_NoneProbeDoesNotAdvanceEpoch(t *testing.T) {
 			persistedEpoch, grantedEpoch)
 	}
 }
+
+// TestProcessLeaseCreateContext_UnchangedStateDoesNotAdvanceEpoch covers the
+// smbtorture v2_complex1 failure at lease.c:3792. A client that re-opens a file
+// under a lease key it already holds, asking for the state it already has,
+// echoes its last-seen epoch in the V2 create context. That request changes no
+// state, so both the response and the server's counter must stay where they
+// are; seeding from the client's epoch instead put the server one ahead, and
+// the next break notification then carried an epoch (0x4716) one past what the
+// client expected (0x4715).
+func TestProcessLeaseCreateContext_UnchangedStateDoesNotAdvanceEpoch(t *testing.T) {
+	t.Parallel()
+
+	mgr := lock.NewManager()
+	leaseMgr := lease.NewLeaseManager(&staticLockResolver{mgr: mgr}, nil)
+
+	ctx := context.Background()
+	const shareName = "share1"
+	leaseKey := [16]byte{0x11, 0x22, 0x33}
+	fileHandle := lock.FileHandle("file-handle-unchanged")
+	const sessionID = uint64(7)
+	const clientID = "smb:7"
+	const initialEpoch uint16 = 0x4711
+	const rh = lock.LeaseStateRead | lock.LeaseStateHandle
+
+	initial := encodeV2LeaseContext(leaseKey, rh, initialEpoch)
+	resp1, err := ProcessLeaseCreateContext(ctx, leaseMgr, initial, fileHandle, sessionID, [16]byte{}, clientID, shareName, false, false, false)
+	if err != nil {
+		t.Fatalf("first CREATE returned error: %v", err)
+	}
+	if resp1.Epoch != initialEpoch+1 {
+		t.Fatalf("first CREATE response epoch = 0x%x, want 0x%x (req+1)", resp1.Epoch, initialEpoch+1)
+	}
+	grantedEpoch := resp1.Epoch
+
+	// Re-open under the same key for the state already held, echoing the
+	// epoch the server just handed out.
+	reopen := encodeV2LeaseContext(leaseKey, rh, grantedEpoch)
+	resp2, err := ProcessLeaseCreateContext(ctx, leaseMgr, reopen, fileHandle, sessionID, [16]byte{}, clientID, shareName, false, false, false)
+	if err != nil {
+		t.Fatalf("re-open returned error: %v", err)
+	}
+	if resp2.LeaseState != rh {
+		t.Errorf("re-open granted state = 0x%x, want RH (0x%x)", resp2.LeaseState, uint32(rh))
+	}
+	if resp2.Epoch != grantedEpoch {
+		t.Errorf("re-open response epoch = 0x%x, want 0x%x — an unchanged lease state must not advance the epoch", resp2.Epoch, grantedEpoch)
+	}
+
+	_, persistedEpoch, found := mgr.GetLeaseState(ctx, leaseKey)
+	if !found {
+		t.Fatal("lease record disappeared after re-open")
+	}
+	if persistedEpoch != grantedEpoch {
+		t.Errorf("server-side epoch after re-open = 0x%x, want 0x%x (no advance)", persistedEpoch, grantedEpoch)
+	}
+
+	// A real upgrade still advances exactly once, from the server's counter —
+	// not from the epoch the client echoed.
+	upgrade := encodeV2LeaseContext(leaseKey, lock.LeaseStateRead|lock.LeaseStateWrite|lock.LeaseStateHandle, grantedEpoch)
+	resp3, err := ProcessLeaseCreateContext(ctx, leaseMgr, upgrade, fileHandle, sessionID, [16]byte{}, clientID, shareName, false, false, false)
+	if err != nil {
+		t.Fatalf("upgrade returned error: %v", err)
+	}
+	if resp3.Epoch != grantedEpoch+1 {
+		t.Errorf("upgrade response epoch = 0x%x, want 0x%x (exactly one advance)", resp3.Epoch, grantedEpoch+1)
+	}
+}

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -997,6 +997,35 @@ func (h *Handler) setFileInfoFromStore(
 		// the open and the post-wait recheck then proceeds to the rename.
 		isOverwrite := renameInfo.ReplaceIfExists
 		metaSvc := h.Registry.GetMetadataService()
+
+		// Dispatch the SOURCE file's break ahead of the destination lookup
+		// below. Every gate that can still reject this rename has already run,
+		// and the source break needs nothing the lookup produces.
+		//
+		// The ordering matters because the destination lookup is
+		// case-insensitive: on a miss it enumerates the whole destination
+		// directory. A client that pipelines a request behind the rename gets
+		// that request answered while the enumeration is still running, so the
+		// break notification the rename owes lands after a response the client
+		// has already acted on. smbtorture rename_wait does exactly that — it
+		// reads the break out of the following CREATE's I/O and acks it — and
+		// acks an all-zero lease key when the break has not arrived yet, which
+		// the server then rejects.
+		//
+		// The destination break stays below: it needs the resolved handle, and
+		// re-dispatching the source break there is suppressed as a duplicate.
+		if h.LeaseManager != nil && len(openFile.MetadataHandle) > 0 {
+			if err := h.LeaseManager.BreakLeasesOnRename(
+				lock.FileHandle(openFile.MetadataHandle),
+				"", // dst not resolved yet; broken below
+				openFile.ShareName,
+				openFile.LeaseKey,
+				false, // isOverwrite: dst handled below
+			); err != nil {
+				logger.Debug("SET_INFO: rename source lease break dispatch failed", "error", err)
+			}
+		}
+
 		var dstMetaHandle metadata.FileHandle
 		// dstMatchedName is the on-disk name of the destination entry when
 		// the case-insensitive lookup succeeds. Move's underlying GetChild is

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -539,6 +539,24 @@ func (lm *LeaseManager) GetLeaseState(ctx context.Context, leaseKey [16]byte) (s
 	return lockMgr.GetLeaseState(ctx, leaseKey)
 }
 
+// HasLeaseOnHandle reports whether a lease record with this key already exists
+// on this file in this share.
+//
+// It takes the share explicitly rather than resolving it from the leaseShare
+// map, because that map is keyed on the raw lease key alone: two clients may
+// legitimately present the same 16-byte value, and whichever granted last owns
+// the entry. That is harmless for the best-effort routing the map was built
+// for, and not harmless for a caller deciding a value that goes out on the
+// wire. Pairing an explicit share with the file handle keeps the answer about
+// the lease this request is actually asking for.
+func (lm *LeaseManager) HasLeaseOnHandle(fileHandle lock.FileHandle, shareName string, leaseKey [16]byte) bool {
+	lockMgr := lm.resolveLockManager(shareName)
+	if lockMgr == nil {
+		return false
+	}
+	return lockMgr.HasLeaseOnHandle(string(fileHandle), leaseKey)
+}
+
 // GetSessionForLease returns the sessionID associated with a lease key.
 func (lm *LeaseManager) GetSessionForLease(leaseKey [16]byte) (sessionID uint64, found bool) {
 	lm.mu.RLock()

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -1347,6 +1347,23 @@ func (lm *Manager) getLeaseStateImpl(_ context.Context, leaseKey [16]byte) (stat
 	return lock.Lease.LeaseState, lock.Lease.Epoch, true
 }
 
+// HasLeaseOnHandle reports whether a lease record with this key already exists
+// on this file. The predicate matches the one resolveSameKeyLeaseLocked uses to
+// decide whether a request reuses an existing record or falls through to
+// createAndGrantLease, so a false answer means the next grant on this file with
+// this key creates a record.
+func (lm *Manager) HasLeaseOnHandle(handleKey string, leaseKey [16]byte) bool {
+	lm.mu.RLock()
+	defer lm.mu.RUnlock()
+
+	for _, l := range lm.unifiedLocks[handleKey] {
+		if l.Lease != nil && l.Lease.LeaseKey == leaseKey {
+			return true
+		}
+	}
+	return false
+}
+
 func (lm *Manager) IsTraditionalOplockForKey(leaseKey [16]byte) bool {
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -153,6 +153,15 @@ type LockManager interface {
 	// was granted via RequestLeaseAsOplock (traditional oplock, not SMB2.1+ lease).
 	IsTraditionalOplockForKey(leaseKey [16]byte) bool
 
+	// HasLeaseOnHandle reports whether a lease record with this key already
+	// exists on this file. Unlike GetLeaseState it does not search across
+	// files, so it cannot be answered by another client's lease that happens
+	// to reuse the same key value on a different file. It asks exactly what
+	// RequestLease asks when it decides whether to reuse a record or create
+	// one, which is what makes it usable as a "would this grant be the first
+	// for this key on this file" test.
+	HasLeaseOnHandle(handleKey string, leaseKey [16]byte) bool
+
 	// SetLeaseEpoch sets the epoch on an existing lease identified by leaseKey.
 	// Per MS-SMB2 3.3.5.9: For V2 leases, the server tracks the client's epoch.
 	// Returns false if no lease was found with the given key.


### PR DESCRIPTION
Two `smb2.lease` conformance failures that #2111 exposed by letting the suite run
past its old 120 s cut. Both reproduce on every profile in the same run
(memory, memory-fs, sqlite, postgres, badger-fs), so neither is a flake and
neither is storage-dependent.

Evidence throughout is the `smb-conformance` artifact from the develop run at
`6e5191bc` — the smbtorture transcript plus DittoFS's own debug log, which
between them pin each failure to a specific line of server code.

## #2113 — `smb2.lease.v2_complex1`: the client's epoch reseeded an existing lease

A V2 create context carries the client's last-seen lease epoch. The server was
seeding its own counter from `clientEpoch + 1` on **every** grant that returned a
non-None state, guarded only by `nextEpoch > epoch`.

That guard hides the bug for a grant that changes state — the lock manager has
already advanced the counter to exactly `clientEpoch + 1`, so the seed is a
no-op. It does not hide it for a grant that changes **nothing**: a re-open asking
for the state already held, or a non-superset request answered with the current
state. There the client is echoing the epoch the server last gave it, so
`clientEpoch + 1` is one *past* the server's value, and the seed silently pushes
the server forward.

`v2_complex1` walks straight into it. Step 5 of the test re-opens `LEASE1` for
`RH` while the lease is already `RH` — the test's own comment says "again RH
over connection 1b doesn't change the epoch". The drift is invisible in that
response's assertion cascade, and surfaces two steps later when the write on the
other connection breaks `LEASE1`: the break notification announces `0x4716`
where the client is tracking `0x4715`.

This matches Samba exactly. `source3/smbd/open.c::grant_new_fsp_lease` seeds a
**new** lease from `lease->lease_epoch + 1`; `try_lease_upgrade` takes the epoch
from the lease database and bumps it only under `do_upgrade`, ignoring the
client's requested epoch entirely. The client's epoch is a starting value, never
a running one.

The fix samples whether a record for the lease key already exists before the
grant, and restricts the seed to the first grant. Everything after that is the
server's counter, which `RequestLease` already advances if and only if the grant
changed state.

Regression test `TestProcessLeaseCreateContext_UnchangedStateDoesNotAdvanceEpoch`
reproduces the exact numbers. Against the unfixed handler:

```
lease_context_test.go:459: re-open response epoch = 0x4713, want 0x4712
lease_context_test.go:467: server-side epoch after re-open = 0x4713, want 0x4712
lease_context_test.go:478: upgrade response epoch = 0x4714, want 0x4713
```

The existing `..._NoneProbeDoesNotAdvanceEpoch` test covers the narrower
None-probe case; this is the same defect one case wider.


### The epoch in the notification is the one the ack is checked against

MS-SMB2 §3.3.1.4 requires the epoch a break notification announces to be the one
the server will honour on the acknowledgement that follows. Those cannot diverge
here, by construction rather than by care: `SMBBreakHandler.OnOpLockBreak` sends
`ul.Lease.Epoch` as `NewEpoch`, and `validateAck` compares an acknowledged epoch
against `lock.Lease.Epoch` — the same field. The defect was in that single stored
counter, so the fix moves both together; there is no separately-computed
notification value that could be corrected on its own and leave a conformant
client's ack carrying an epoch the server rejects.

### Scoping the first-grant test (Copilot's finding, addressed)

The first version of this fix asked "does a lease with this key exist" through
`GetLeaseState`, which resolves the lock manager through a map keyed on the raw
16-byte lease key and then returns any matching record. Two clients may
legitimately present the same value on different files, so a genuine first grant
could be answered by a foreign lease. That is not a hypothetical: the regression
test for it reproduces a first grant responding `epoch 0x1` — `createAndGrantLease`'s
hardcoded default — where the client asked for `0x900`.

`HasLeaseOnHandle` asks the question the grant path itself asks: is there a lease
with this key on this file, scanning `unifiedLocks[handleKey]` under `lm.mu`,
reached through the share the CREATE already carries. Because it is the same
predicate `resolveSameKeyLeaseLocked` uses to choose between reusing a record and
creating one, the seed decision cannot disagree with what the grant did.

The sample is still taken outside the grant's lock, which is marked `ponytail:`
at the call site: with the scope now `(share, file, key)`, two requests can only
race that window by asking for the same lease key on the same file, which makes
them the same client's lease carrying the same epoch, and `SetLeaseEpoch` keeps
the larger of the two. Closing it outright means threading the client's epoch
into `createAndGrantLease` — a signature change across three exported grant
entry points — which this defect does not justify today.

The raw-key-map weakness one layer up is pre-existing and wider than this PR;
filed as #2125.

## #2114 — `smb2.lease.rename_wait`: premise refuted, and only PARTLY fixed here

The issue reads the failure as the RENAME returning `INVALID_PARAMETER`. It is
not the rename. `lease.c:4160` in the smbtorture build the harness runs (Samba
4.23.0) is the `CHECK_STATUS` on **`smb2_lease_break_ack`**:

```c
/* Ack the break. The server is now free to rename. */
status = smb2_lease_break_ack(tree, &ack);
CHECK_STATUS(status, NT_STATUS_OK);      /* <- 4160 */
```

DittoFS's own log says what it received:

```
LEASE_BREAK_ACK acknowledgment leaseKey=00000000000000000000000000000000 acknowledgedState=None
LEASE_BREAK_ACK: ownership check failed — session does not own lease leaseKey=0000…
Sent SMB2 response command=OPLOCK_BREAK status=STATUS_INVALID_PARAMETER
```

The client acknowledged an **all-zero lease key**, and the ownership gate
correctly refused it. So the real question is why the client had nothing to ack.

`rename_wait` sends the rename asynchronously, then opens the destination and
relies on that CREATE's I/O to pick up the break the rename owes, copying the
key and state straight out of `lease_break_info`. The server log shows the
CREATE's response going out *before* the break was dispatched:

```
Dispatching SMB2 command command=SET_INFO messageID=8
SET_INFO request infoType=1 fileInfoClass=10 fileID=…
Dispatching SMB2 command command=CREATE messageID=9
CREATE request filename=lease_rename_dst.dat …
Sent SMB2 response command=CREATE status=STATUS_OBJECT_NAME_NOT_FOUND messageID=9
SMBBreakHandler: dispatching lease break notification leaseKey=adbeed… breakToState=R
```

`lease_break_info` was still zeroed when the test copied it, so the ack carried
zeros. The break did arrive later — the client logs `Skip acking to 0x1 (R)` —
but by then the ack had been built.

The cause is not a race in the abstract: the rename reliably loses. Between
entering the rename branch and dispatching the break sat
`LookupCaseInsensitive` on the destination, and on a miss that falls back to
paging the **entire** destination directory through `ListChildren`. The
destination here does not exist, so the enumeration always runs, and it runs
over a share root full of leftovers from the rest of the lease suite. That is
why the failure is identical on every backend — a directory scan is linear
everywhere, not an I/O-speed effect.

The fix moves the source file's break dispatch above that lookup. Every gate
that can still reject the rename — the DELETE-access check, the share-delete
scan, destination-parent resolution, the open-child scan, the
destination-parent sharing-violation check — still runs first, so no rename
that would have been refused now emits a break. The destination break stays
where it is, since it needs the resolved handle; its source half is suppressed
by the existing already-breaking branch in `breakOpLocks`, which merges the
target without a second notification or a second epoch bump.

Note the pipelined CREATE opens a file that does not exist, so it pays that same
case-insensitive enumeration itself. After the change the rename's pre-break
path is pure in-memory work while the CREATE's is not, and the rename's handler
goroutine already starts first.


The early call dispatches the break; it deliberately does **not** wait on it
there. The wait stays below, after the destination lookup, where the existing
block already covers the source and destination breaks together — waiting before
the destination is resolved would stall the rename on a break whose companion has
not been computed yet. What the test needs is the notification on the wire before
the following CREATE's response, which dispatch alone provides; the rename itself
still completes only after the wait, which is what keeps the four
`OBJECT_NAME_NOT_FOUND` assertions true.

No unit test: the property is an ordering one against a real pipelining client,
and the handlers package has no SET_INFO-rename harness to hang it on. It is
verified by the conformance suite.

### This does not close #2114 — read the conformance result before merging

`smbtorture / badger-fs` now reports `success: lease.rename_wait`. `smbtorture /
memory` still reports the failure. That split is not flakiness; the run shows
exactly what is left, and it is one layer above the rename:

```
SMB2 request  command=SET_INFO messageID=8      <- client sent this first
SMB2 request  command=CREATE   messageID=9
Dispatching   command=CREATE   messageID=9      <- dispatched first anyway
Sent response command=CREATE   ...OBJECT_NAME_NOT_FOUND messageID=9
Dispatching   command=SET_INFO messageID=8      <- only now
SMBBreakHandler: dispatching lease break notification leaseKey=adbeed…
```

The change in this PR did its job: once the SET_INFO handler is entered, the
break goes out on the *very next line*, with no intervening work at all — the
directory enumeration is gone from the pre-break path, which is why badger-fs
flipped. What remains is that the connection's reader hands message 8 and
message 9 to separate goroutines, and 9's runs to completion before 8's is
scheduled at all. No amount of shortening the rename's pre-break path fixes
that; the CREATE can always be answered before the rename handler starts.

Closing it properly means the connection preserving the ordering Samba gets for
free from single-threaded per-connection processing: a request's lease-break
side effects visible before a later request on the same connection is answered.
That is a dispatcher change, in files PR #2120 has just touched, and it is not
something to bolt onto this PR. Filed as #2127.

So this PR closes #2113 and takes #2114 from "fails everywhere" to "one
identified, isolated cause left". #2114 stays open.

## #2115 is deliberately not in this PR

Investigated; reported separately. In short, DittoFS's break timeout fires at
exactly its configured 35 s (server log: request at `09:51:25`, response at
`09:52:00`), and the periodic `OpLockBreakScanner` that would round expiry up to
a 1 s tick is never constructed in production — only in its own tests. The `36` the test reports is `te`, which additionally contains
smbtorture's own fixed one-second `torture_wait_for_oplock_break`, which always
times out in this test because the holder's transport is blocked. There is no
extra second on the server side to remove.

## Verification

- `go build ./... && go vet ./... && go test ./...` clean.
- `go test -race ./internal/adapter/smb/... ./pkg/metadata/lock/...` clean.
- The three new tests are backend-independent — they drive `lock.NewManager`
  directly, so they say nothing about storage either way. The storage-independence
  claim rests on the failures themselves, which reproduce identically on
  `memory`, `memory-fs`, `sqlite`, `postgres` and `badger-fs` in the same run;
  the same five profiles re-run on this PR.
- `smb-conformance` on this PR reports `success: lease.v2_complex1` on **both**
  `memory` and `badger-fs` — #2113 confirmed fixed on the authority that
  reported it. `lease.rename_wait` passes on `badger-fs` and still fails on
  `memory`, per the section above.
- `KNOWN_FAILURES.md` is deliberately left untouched: `v2_complex1` should come
  off it, but the entry wording for `rename_wait` needs to change rather than
  disappear, and I would rather do both in one edit once the remaining cause has
  an issue number to point at (#2127).

Closes #2113
