### PR TITLE
fix(smb): gate rename on the destination parent's write sharing, not delete sharing

### DIFF
--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -2598,26 +2598,34 @@ func logRenameConflictHolder(gate string, renamer, holder *OpenFile) {
 		"holderDeletePending", holder.DeletePending)
 }
 
-// checkParentDirRenameConflict applies the destination-parent share-mode
-// rule from MS-FSA 2.1.5.14.11.3 / Samba smbd_smb2_setinfo_rename_dst_parent_check.
-// Rename takes an implicit DELETE-bearing access on the destination parent
-// without granting share-delete; only the DELETE vs FILE_SHARE_DELETE pair
-// matters for the conflict (the ADD_FILE bit doesn't interact with the
-// share-mode word, so we don't probe write/share-write). An existing
-// destination-parent open conflicts when it (a) lacks FILE_SHARE_DELETE —
-// denying the rename's DELETE access — or (b) already holds DELETE access —
-// incompatible with the rename's ShareAccess=0. The renamer's own handle
-// is excluded by FileID. Caller passes the destination parent handle (same
-// as source parent for same-directory rename). Returns true on conflict.
-func (h *Handler) checkParentDirRenameConflict(renamerFileID [16]byte, dstParent metadata.FileHandle) bool {
-	const fileShareDelete = uint32(0x04) // FILE_SHARE_DELETE
+// checkParentDirRenameConflict applies the destination-parent share-mode rule
+// from MS-FSA 2.1.5.15.12 step 8.1: a rename from a remote client opens the
+// destination directory with DesiredAccess FILE_ADD_FILE|SYNCHRONIZE (or
+// FILE_ADD_SUBDIRECTORY for a directory source) and ShareAccess
+// FILE_SHARE_READ|FILE_SHARE_WRITE — no DELETE is requested and share-delete
+// is not granted. Linking a new name into a directory is therefore a WRITE
+// against that directory, not a delete of it, and two pairings decide the
+// conflict: the implicit open's write access against the holder's
+// FILE_SHARE_WRITE, and the implicit open's withheld share-delete against a
+// holder that already has DELETE access. A holder that merely lacks
+// FILE_SHARE_DELETE does not conflict — nothing in the rename asks to delete
+// the destination parent.
+//
+// The renamer's own handle is excluded by FileID; every other open counts,
+// including one on the renamer's own session, because the implicit open is a
+// fresh open evaluated against the whole open list.
+//
+// Caller passes the destination parent handle (same as source parent for a
+// same-directory rename). Returns true on conflict.
+func (h *Handler) checkParentDirRenameConflict(renamer *OpenFile, dstParent metadata.FileHandle) bool {
+	const fileShareWrite = uint32(0x02) // FILE_SHARE_WRITE
 	if len(dstParent) == 0 {
 		return false
 	}
 	var culprit *OpenFile
 	h.files.Range(func(_, value any) bool {
 		other := value.(*OpenFile)
-		if other.FileID == renamerFileID {
+		if other.FileID == renamer.FileID {
 			return true
 		}
 		if len(other.MetadataHandle) == 0 {
@@ -2635,17 +2643,14 @@ func (h *Handler) checkParentDirRenameConflict(renamerFileID [16]byte, dstParent
 		if isStatOnlyOpen(other.DesiredAccess) {
 			return true
 		}
-		if other.ShareAccess&fileShareDelete == 0 || hasDeleteAccess(other.DesiredAccess) {
+		if other.ShareAccess&fileShareWrite == 0 || hasDeleteAccess(other.DesiredAccess) {
 			culprit = other
 			return false
 		}
 		return true
 	})
 	if culprit != nil {
-		// #1652: dump the dst-parent holder that tripped the gate. renamerFileID
-		// is only an ID here, so pass a minimal renamer view for the log.
-		logRenameConflictHolder("dst-parent share-mode gate",
-			&OpenFile{FileID: renamerFileID}, culprit)
+		logRenameConflictHolder("dst-parent share-mode gate", renamer, culprit)
 		return true
 	}
 	return false

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -2599,26 +2599,22 @@ func logRenameConflictHolder(gate string, renamer, holder *OpenFile) {
 }
 
 // checkParentDirRenameConflict applies the destination-parent share-mode rule
-// from MS-FSA 2.1.5.15.12 step 8.1: a rename from a remote client opens the
-// destination directory with DesiredAccess FILE_ADD_FILE|SYNCHRONIZE (or
-// FILE_ADD_SUBDIRECTORY for a directory source) and ShareAccess
-// FILE_SHARE_READ|FILE_SHARE_WRITE — no DELETE is requested and share-delete
-// is not granted. Linking a new name into a directory is therefore a WRITE
-// against that directory, not a delete of it, and two pairings decide the
-// conflict: the implicit open's write access against the holder's
-// FILE_SHARE_WRITE, and the implicit open's withheld share-delete against a
-// holder that already has DELETE access. A holder that merely lacks
-// FILE_SHARE_DELETE does not conflict — nothing in the rename asks to delete
-// the destination parent.
+// from MS-FSA 2.1.5.15.12 step 8.1: the rename opens the destination directory
+// with DesiredAccess FILE_ADD_FILE|SYNCHRONIZE and ShareAccess
+// FILE_SHARE_READ|FILE_SHARE_WRITE. Linking a new name into a directory is
+// therefore a WRITE against that directory, not a delete of it, so an existing
+// open conflicts only when it denies write sharing, or already holds DELETE
+// access — which the rename's withheld share-delete is incompatible with. A
+// holder that merely lacks FILE_SHARE_DELETE does not conflict; nothing in the
+// rename asks to delete the destination parent.
 //
-// The renamer's own handle is excluded by FileID; every other open counts,
-// including one on the renamer's own session, because the implicit open is a
-// fresh open evaluated against the whole open list.
+// Only the renamer's own handle is excluded, by FileID. Another open on the
+// renamer's own session still counts, because the implicit open is a fresh
+// open evaluated against the whole open list.
 //
 // Caller passes the destination parent handle (same as source parent for a
 // same-directory rename). Returns true on conflict.
 func (h *Handler) checkParentDirRenameConflict(renamer *OpenFile, dstParent metadata.FileHandle) bool {
-	const fileShareWrite = uint32(0x02) // FILE_SHARE_WRITE
 	if len(dstParent) == 0 {
 		return false
 	}
@@ -2638,12 +2634,12 @@ func (h *Handler) checkParentDirRenameConflict(renamer *OpenFile, dstParent meta
 		// READ_CONTROL only) impose no share-mode constraint per MS-SMB2
 		// §3.3.5.9.8 + Samba `is_lease_stat_open`. smbtorture rename.msword
 		// opens the parent dir stat-only with ShareAccess=0 and expects the
-		// rename to succeed; without this filter the lack of FILE_SHARE_DELETE
+		// rename to succeed; without this filter its lack of FILE_SHARE_WRITE
 		// would falsely trip the conflict.
 		if isStatOnlyOpen(other.DesiredAccess) {
 			return true
 		}
-		if other.ShareAccess&fileShareWrite == 0 || hasDeleteAccess(other.DesiredAccess) {
+		if other.ShareAccess&smbShareWrite == 0 || hasDeleteAccess(other.DesiredAccess) {
 			culprit = other
 			return false
 		}

--- a/internal/adapter/smb/handlers/rename_dst_parent_gate_test.go
+++ b/internal/adapter/smb/handlers/rename_dst_parent_gate_test.go
@@ -1,0 +1,153 @@
+// Destination-parent share-mode gate for SET_INFO rename.
+//
+// MS-FSA 2.1.5.15.12 step 8.1 opens the destination directory with
+// DesiredAccess FILE_ADD_FILE|SYNCHRONIZE and ShareAccess
+// FILE_SHARE_READ|FILE_SHARE_WRITE. The cases below pin both directions of
+// that pairing: a write-sharing holder must not block the rename, and a
+// DELETE-access holder must still block it.
+
+package handlers
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+const (
+	shareRead   = uint32(0x01)
+	shareWrite  = uint32(0x02)
+	shareDelete = uint32(0x04)
+
+	secFileAll   = uint32(0x000001FF) // every file-specific right, no DELETE
+	deleteAccess = uint32(0x00010000)
+	readAttrs    = uint32(0x00000080)
+)
+
+// storeDstParentHolder registers an open handle on dstParent and returns it.
+func storeDstParentHolder(h *Handler, dstParent metadata.FileHandle, desired, share uint32) *OpenFile {
+	of := (&OpenFile{
+		FileID:         h.GenerateFileID(),
+		MetadataHandle: dstParent,
+		DesiredAccess:  desired,
+		ShareAccess:    share,
+		ShareName:      "share",
+		SessionID:      25,
+		TreeID:         25,
+	}).WithName(OpenName{Path: "watched-dir"})
+	h.StoreOpenFile(of)
+	return of
+}
+
+// storeRenamer registers the source-file handle that the rename runs on.
+func storeRenamer(h *Handler, dstParent metadata.FileHandle) *OpenFile {
+	of := (&OpenFile{
+		FileID:         h.GenerateFileID(),
+		MetadataHandle: metadata.FileHandle{0x51, 0x52},
+		DesiredAccess:  secFileAll | deleteAccess,
+		ShareAccess:    shareRead | shareWrite | shareDelete,
+		ShareName:      "share",
+		SessionID:      7,
+		TreeID:         7,
+	}).WithName(OpenName{Path: "watched-dir/subdir/file", ParentHandle: metadata.FileHandle{0x99}})
+	h.StoreOpenFile(of)
+	return of
+}
+
+func TestParentDirRenameConflict(t *testing.T) {
+	dstParent := metadata.FileHandle{0xDE, 0xAD, 0xBE, 0xEF}
+
+	tests := []struct {
+		name          string
+		holderDesired uint32
+		holderShare   uint32
+		wantConflict  bool
+	}{
+		{
+			// A CHANGE_NOTIFY watcher on the destination directory:
+			// SEC_FILE_ALL with FILE_SHARE_READ|FILE_SHARE_WRITE. It permits
+			// write sharing and holds no DELETE, so linking a new name into
+			// the directory does not conflict with it.
+			name:          "write-sharing watcher does not block the rename",
+			holderDesired: secFileAll,
+			holderShare:   shareRead | shareWrite,
+			wantConflict:  false,
+		},
+		{
+			// The rename's implicit open withholds share-delete, so a holder
+			// that already has DELETE access on the destination parent is
+			// incompatible and must still be refused.
+			name:          "delete-access holder still blocks the rename",
+			holderDesired: deleteAccess,
+			holderShare:   shareRead | shareWrite | shareDelete,
+			wantConflict:  true,
+		},
+		{
+			// The implicit open requests FILE_ADD_FILE, a write against the
+			// directory, so a holder denying write sharing must be refused.
+			name:          "holder denying write sharing still blocks the rename",
+			holderDesired: secFileAll,
+			holderShare:   shareRead | shareDelete,
+			wantConflict:  true,
+		},
+		{
+			// Stat-only opens impose no share-mode constraint at all.
+			name:          "stat-only holder does not block the rename",
+			holderDesired: readAttrs,
+			holderShare:   0,
+			wantConflict:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := NewHandler()
+			renamer := storeRenamer(h, dstParent)
+			storeDstParentHolder(h, dstParent, tc.holderDesired, tc.holderShare)
+
+			if got := h.checkParentDirRenameConflict(renamer, dstParent); got != tc.wantConflict {
+				t.Fatalf("conflict = %v, want %v", got, tc.wantConflict)
+			}
+		})
+	}
+}
+
+// The renamer's own handle must never be its own conflict. Exercised by
+// pointing the renamer's handle at the destination parent itself, the only
+// shape in which the scan can reach it.
+func TestParentDirRenameConflict_ExcludesRenamerOwnHandle(t *testing.T) {
+	dstParent := metadata.FileHandle{0xDE, 0xAD, 0xBE, 0xEF}
+	h := NewHandler()
+
+	renamer := (&OpenFile{
+		FileID:         h.GenerateFileID(),
+		MetadataHandle: dstParent,
+		DesiredAccess:  deleteAccess, // would trip the gate as any other holder
+		ShareAccess:    0,
+		ShareName:      "share",
+		SessionID:      7,
+		TreeID:         7,
+	}).WithName(OpenName{Path: "watched-dir"})
+	h.StoreOpenFile(renamer)
+
+	if h.checkParentDirRenameConflict(renamer, dstParent) {
+		t.Fatal("renamer blocked by its own open handle on the destination parent")
+	}
+}
+
+// A second handle held by the renamer's own session is not excluded: the
+// implicit destination-parent open is evaluated against the whole open list,
+// so a same-session DELETE-access holder still refuses the rename.
+func TestParentDirRenameConflict_SameSessionHolderStillConflicts(t *testing.T) {
+	dstParent := metadata.FileHandle{0xDE, 0xAD, 0xBE, 0xEF}
+	h := NewHandler()
+
+	renamer := storeRenamer(h, dstParent)
+	holder := storeDstParentHolder(h, dstParent, deleteAccess, shareRead|shareWrite|shareDelete)
+	holder.SessionID = renamer.SessionID
+	holder.TreeID = renamer.TreeID
+
+	if !h.checkParentDirRenameConflict(renamer, dstParent) {
+		t.Fatal("same-session DELETE-access holder did not refuse the rename")
+	}
+}

--- a/internal/adapter/smb/handlers/rename_dst_parent_gate_test.go
+++ b/internal/adapter/smb/handlers/rename_dst_parent_gate_test.go
@@ -11,17 +11,14 @@ package handlers
 import (
 	"testing"
 
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
 const (
-	shareRead   = uint32(0x01)
-	shareWrite  = uint32(0x02)
-	shareDelete = uint32(0x04)
-
 	secFileAll   = uint32(0x000001FF) // every file-specific right, no DELETE
-	deleteAccess = uint32(0x00010000)
-	readAttrs    = uint32(0x00000080)
+	deleteAccess = uint32(types.Delete)
+	readAttrs    = uint32(types.FileReadAttributes)
 )
 
 // storeDstParentHolder registers an open handle on dstParent and returns it.
@@ -40,12 +37,12 @@ func storeDstParentHolder(h *Handler, dstParent metadata.FileHandle, desired, sh
 }
 
 // storeRenamer registers the source-file handle that the rename runs on.
-func storeRenamer(h *Handler, dstParent metadata.FileHandle) *OpenFile {
+func storeRenamer(h *Handler) *OpenFile {
 	of := (&OpenFile{
 		FileID:         h.GenerateFileID(),
 		MetadataHandle: metadata.FileHandle{0x51, 0x52},
 		DesiredAccess:  secFileAll | deleteAccess,
-		ShareAccess:    shareRead | shareWrite | shareDelete,
+		ShareAccess:    smbShareRead | smbShareWrite | smbShareDelete,
 		ShareName:      "share",
 		SessionID:      7,
 		TreeID:         7,
@@ -70,7 +67,7 @@ func TestParentDirRenameConflict(t *testing.T) {
 			// the directory does not conflict with it.
 			name:          "write-sharing watcher does not block the rename",
 			holderDesired: secFileAll,
-			holderShare:   shareRead | shareWrite,
+			holderShare:   smbShareRead | smbShareWrite,
 			wantConflict:  false,
 		},
 		{
@@ -79,7 +76,7 @@ func TestParentDirRenameConflict(t *testing.T) {
 			// incompatible and must still be refused.
 			name:          "delete-access holder still blocks the rename",
 			holderDesired: deleteAccess,
-			holderShare:   shareRead | shareWrite | shareDelete,
+			holderShare:   smbShareRead | smbShareWrite | smbShareDelete,
 			wantConflict:  true,
 		},
 		{
@@ -87,7 +84,7 @@ func TestParentDirRenameConflict(t *testing.T) {
 			// directory, so a holder denying write sharing must be refused.
 			name:          "holder denying write sharing still blocks the rename",
 			holderDesired: secFileAll,
-			holderShare:   shareRead | shareDelete,
+			holderShare:   smbShareRead | smbShareDelete,
 			wantConflict:  true,
 		},
 		{
@@ -102,7 +99,7 @@ func TestParentDirRenameConflict(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			h := NewHandler()
-			renamer := storeRenamer(h, dstParent)
+			renamer := storeRenamer(h)
 			storeDstParentHolder(h, dstParent, tc.holderDesired, tc.holderShare)
 
 			if got := h.checkParentDirRenameConflict(renamer, dstParent); got != tc.wantConflict {
@@ -142,8 +139,8 @@ func TestParentDirRenameConflict_SameSessionHolderStillConflicts(t *testing.T) {
 	dstParent := metadata.FileHandle{0xDE, 0xAD, 0xBE, 0xEF}
 	h := NewHandler()
 
-	renamer := storeRenamer(h, dstParent)
-	holder := storeDstParentHolder(h, dstParent, deleteAccess, shareRead|shareWrite|shareDelete)
+	renamer := storeRenamer(h)
+	holder := storeDstParentHolder(h, dstParent, deleteAccess, smbShareRead|smbShareWrite|smbShareDelete)
 	holder.SessionID = renamer.SessionID
 	holder.TreeID = renamer.TreeID
 

--- a/internal/adapter/smb/handlers/rename_scan_close_race_test.go
+++ b/internal/adapter/smb/handlers/rename_scan_close_race_test.go
@@ -104,7 +104,7 @@ func TestRenameScan_vs_Close_Serialized_NoRace(t *testing.T) {
 				observedTorn.Store(true)
 			}
 			_ = h.checkShareDeleteConflict(of)
-			_ = h.checkParentDirRenameConflict(of.FileID, of.MetadataHandle)
+			_ = h.checkParentDirRenameConflict(of, of.MetadataHandle)
 			_ = h.anyOpenChild(of.MetadataHandle)
 			if torn.Load() {
 				observedTorn.Store(true)
@@ -172,7 +172,7 @@ func TestRenameScan_vs_Close_NegativeControl(t *testing.T) {
 				observedTorn.Store(true)
 			}
 			_ = h.checkShareDeleteConflict(of)
-			_ = h.checkParentDirRenameConflict(of.FileID, of.MetadataHandle)
+			_ = h.checkParentDirRenameConflict(of, of.MetadataHandle)
 			_ = h.anyOpenChild(of.MetadataHandle)
 			if torn.Load() {
 				observedTorn.Store(true)

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -950,7 +950,7 @@ func (h *Handler) setFileInfoFromStore(
 		// that a concurrent CLOSE is mid-removing is observed atomically — no
 		// spurious SHARING_VIOLATION.
 		h.renameScanMu.Lock()
-		conflict := h.checkParentDirRenameConflict(openFile.FileID, toDir)
+		conflict := h.checkParentDirRenameConflict(openFile, toDir)
 		h.renameScanMu.Unlock()
 		if conflict && !bytes.Equal(toDir, openFile.Name().ParentHandle) {
 			h.breakDstParentDirHandleLeasesForRename(authCtx, toDir, openFile)
@@ -962,7 +962,7 @@ func (h *Handler) setFileInfoFromStore(
 			// upgrades the lease and the second setinfo runs). Authoritative
 			// under the mutex.
 			h.renameScanMu.Lock()
-			conflict = h.checkParentDirRenameConflict(openFile.FileID, toDir)
+			conflict = h.checkParentDirRenameConflict(openFile, toDir)
 			h.renameScanMu.Unlock()
 		}
 		if conflict {

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -918,16 +918,17 @@ func (h *Handler) setFileInfoFromStore(
 			}
 		}
 
-		// Per MS-FSA 2.1.5.14.11.3 / Samba smbd_smb2_setinfo_rename_dst_parent_check:
-		// rename takes an implicit open on the destination parent directory
-		// with DELETE+FILE_ADD_FILE and ShareAccess=0. Any existing open of
-		// that directory that lacks FILE_SHARE_DELETE or holds DELETE access
+		// Per MS-FSA 2.1.5.15.12 step 8.1: rename takes an implicit open on
+		// the destination parent directory with FILE_ADD_FILE|SYNCHRONIZE
+		// (FILE_ADD_SUBDIRECTORY for a directory source) and ShareAccess
+		// FILE_SHARE_READ|FILE_SHARE_WRITE. Any existing open of that
+		// directory that denies write sharing or already holds DELETE access
 		// conflicts. Stream renames don't traverse the directory layer and
 		// returned earlier above; we're past that branch here.
 		//
 		// Conflict-gated dst-parent dir-lease pre-break (smbtorture
 		// smb2.dirlease.rename_dst_parent, lease.c:7331): when an existing
-		// holder on dst-parent denies the implicit destructive open with
+		// holder on dst-parent denies the implicit open with
 		// SHARING_VIOLATION, the dst-parent's RH dir-lease holder must observe
 		// an RH→R strip-Handle break first; the break may give the holder a
 		// chance to close its conflicting handle. After the break drains we
@@ -2177,12 +2178,11 @@ func (h *Handler) breakParentDirLeasesForContentChangeOn(ctx *SMBHandlerContext,
 
 // breakDstParentDirHandleLeasesForRename strips the Handle bit only (RH -> R)
 // on dst-parent dir leases held by holders that conflict with the rename's
-// implicit DELETE+FILE_ADD_FILE open. Called BEFORE the dst-parent share-mode
+// implicit FILE_ADD_FILE open. Called BEFORE the dst-parent share-mode
 // conflict check so the break notification is observed even when the conflict
-// surfaces STATUS_SHARING_VIOLATION (smbtorture smb2.dirlease.rename_dst_parent
-// stage 1, lease.c:7331). Read caching is preserved (RH -> R) — the rename
-// hasn't mutated directory contents yet, only the dst-parent's Handle caching
-// is invalidated by the implicit destructive open intent.
+// surfaces STATUS_SHARING_VIOLATION. Read caching is preserved (RH -> R) — the
+// rename hasn't mutated directory contents yet, only the dst-parent's Handle
+// caching is invalidated by the pending new name.
 //
 // Honors ParentLeaseKey suppression from C2 only — no ClientID exclusion,
 // same-client dir leases break when the key doesn't match.


### PR DESCRIPTION
## What was wrong

A SET_INFO `FileRenameInformation` was refused with `STATUS_SHARING_VIOLATION`
whenever *any* open handle on the **destination parent directory** lacked
`FILE_SHARE_DELETE`. An ordinary open directory handle — a CHANGE_NOTIFY
watcher, say — was enough to make every rename into that directory fail:

```
SET_INFO rename conflict holder gate=dst-parent share-mode gate
  holderPath=test_notify_REC holderShareAccess=0x3 holderDesiredAccess=0x1ff
SET_INFO: rename blocked by destination-parent sharing violation
  path=test_notify_REC/subdir-name/subname2
```

`0x3` is `FILE_SHARE_READ|FILE_SHARE_WRITE`; `0x1ff` is `SEC_FILE_ALL`, which
does not contain `DELETE`.

## Why the old gate was the wrong shape

`checkParentDirRenameConflict` modelled the rename as taking a *DELETE-bearing*
implicit open on the destination parent, and its doc comment said the
`FILE_ADD_FILE` bit "doesn't interact with the share-mode word". Both halves of
that are the wrong way round.

MS-FSA 2.1.5.15.12 step 8.1 specifies the implicit open exactly:

- **DesiredAccess** = `FILE_ADD_FILE|SYNCHRONIZE` (or `FILE_ADD_SUBDIRECTORY`
  when the source is a directory)
- **ShareAccess** = `FILE_SHARE_READ|FILE_SHARE_WRITE|FILE_SHARE_DELETE`, with
  Appendix A note `<185>` recording that Windows 11 / Server 2022 and earlier
  actually use `FILE_SHARE_READ|FILE_SHARE_WRITE`, and that consequently *"if
  there is a pre-existing handle with DELETE access on the destination
  directory this will result in the operation failing with
  STATUS_SHARING_VIOLATION"*.

`DELETE` is never requested. Linking a new name into a directory is a **write**
against that directory, not a delete of it. So the two pairings that decide the
conflict are:

| implicit open | holder | verdict |
| --- | --- | --- |
| requests `FILE_ADD_FILE` (write) | lacks `FILE_SHARE_WRITE` | conflict |
| withholds share-delete | has `DELETE` access | conflict |
| — | merely lacks `FILE_SHARE_DELETE` | **no conflict** |

The third row is the bug. The gate now tests `FILE_SHARE_WRITE` where it used
to test `FILE_SHARE_DELETE`; the `DELETE`-access leg is untouched.

## The gate still refuses

`smb2.dirlease.rename_dst_parent` (which passes today and must keep passing) is
unaffected by design, and its wire shape is the proof that the surviving leg is
the load-bearing one. That test opens the destination parent with
`smb2_util_share_access("RWD")` — it *does* grant `FILE_SHARE_DELETE` — and
`desired_access = DELETE_ACCESS`. It never went through the leg being removed;
it trips the `DELETE`-access leg, which is exactly Appendix A `<185>`.

`TestParentDirRenameConflict` pins all four outcomes, and the two behavioural
rows each fail if the condition is reverted to the old constant:

```
--- FAIL: TestParentDirRenameConflict/write-sharing_watcher_does_not_block_the_rename
        conflict = true, want false
--- FAIL: TestParentDirRenameConflict/holder_denying_write_sharing_still_blocks_the_rename
        conflict = false, want true
```

## The renamer-identity half

The issue reports `renamerPath=` empty and `renamerSession=0 renamerTree=0` in
the conflict log and reads that as a check unable to tell "me" from "someone
else". The premise does not survive contact with the code: those fields are
empty because `logRenameConflictHolder` was handed a synthesised
`&OpenFile{FileID: renamerFileID}` stub — the scan itself always had the FileID
and always excluded the renamer's own handle by it. This is a **diagnostics**
defect, not a gate defect, and it is what made the report misattribute the
cause. Fixed by threading the real `*OpenFile` through instead of a bare
`[16]byte`, so the log now names the renamer.

Worth stating explicitly, because the obvious "fix" here would be wrong: the
scan must **not** exclude the renamer's session or tree. The implicit
destination-parent open is a fresh open evaluated against the whole open list,
and `smb2.dirlease.rename_dst_parent` proves the point on the wire — it holds
the conflicting destination-parent handle on the *same tree* that issues the
rename, and still expects `STATUS_SHARING_VIOLATION`. Broadening the exclusion
from handle to session would break it. `TestParentDirRenameConflict_SameSessionHolderStillConflicts`
pins that.

## The two-symptoms framing

Confirmed, at least up to the assertion that fails. `smb2.notify.rec:609` and
`smb2.notify.mask-change:813` are the same statement in two tests: a
`smb2_setinfo_file` with `RAW_SFILEINFO_RENAME_INFORMATION` moving
`BASEDIR\subdir-name\subname2` to `BASEDIR\subname2-r` on `tree2`, while
`tree1` holds `BASEDIR` open with `desired_access = SEC_FILE_ALL` and
`share_access = READ|WRITE`. That is the `0x1ff` / `0x3` in the log, exactly.

`mask-change` is **not** expected to start passing, and its `KNOWN_FAILURES.md`
row is deliberately left alone. Its documented rationale (completion-filter
mask stickiness, `notify.c:771-772`) has not been refuted — it has merely been
*unreachable*, because the test now dies at line 813 before ever reaching the
mask assertion at 833-845. This change should move the failure point from 813
back to the documented one rather than clear it. The row should be re-checked
against a conformance run, not edited on this reasoning.

`smb2.notify.rec` has no such downstream assertion in its path and is the test
this is expected to fix.

## Scope check

`checkShareDeleteConflict` — the **source-file** gate — is correct and
unchanged: a rename does remove the source link, so all other opens on the
source genuinely must permit delete sharing. No hardlink
(`FileLinkInformation`) destination-parent share gate exists in the tree, so
there is no sibling caller carrying the same mistake.

## Verification

- `go build ./...`, `go vet ./...`, `golangci-lint run` — clean
- `go test ./...` — green
- `go test -race ./internal/adapter/smb/handlers/` — green
- New tests fail against the pre-fix condition (output above)

Not run: `test/smb-conformance/run.sh` (suite lock held elsewhere). The wire
confirmation for `notify.rec` and the re-check of the `mask-change` row are
outstanding.

Closes #2130
