### PR TITLE
fix(block): give a manifest row an in-chunk start offset so it can be narrowed off its head

### DIFF
--- a/pkg/block/engine/cold_read_carve_seam_test.go
+++ b/pkg/block/engine/cold_read_carve_seam_test.go
@@ -75,11 +75,10 @@ func TestColdReadAtCarveSeam_PunchedRangeStaysZero(t *testing.T) {
 
 // TestColdReadAtCarveSeam_RunEndInsideRowStaysCovered is the mirror of the test
 // above: instead of a run that STARTS inside an older row, one that ENDS inside
-// it. The reap deletes that row — its start lies in the run — and the part past
-// the run end has no other cover, because a row claims a prefix of its chunk and
-// so cannot start mid-chunk. Carve has to reach the row's end for the manifest
-// to keep tiling, and the whole file has to read back byte-for-byte from the
-// remote tier afterwards.
+// it. That row's start lies in the run, so it may not be spared whole, and the
+// part past the run end has no other cover, so it may not be deleted either —
+// it is narrowed off its head. Either way the manifest has to keep tiling and
+// the whole file has to read back byte-for-byte from the remote tier.
 //
 // The shape is reached by a second punch whose END lands on the journal interval
 // boundary the first punch left inside a manifest row: nothing partially overlaps

--- a/pkg/block/engine/cold_read_interior_straddle_test.go
+++ b/pkg/block/engine/cold_read_interior_straddle_test.go
@@ -1,0 +1,131 @@
+package engine_test
+
+import (
+	"bytes"
+	"context"
+	"math/rand"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatabadger "github.com/marmos91/dittofs/pkg/metadata/store/badger"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// pickInteriorStraddle chooses an overwrite window [d0, d1) over an already
+// carved manifest such that the window starts inside one row, covers at least
+// one row whole, and ends strictly inside a row that starts inside the window:
+// d0 < rowStart < d1 < rowEnd. That is the shape a carve span cannot tile — its
+// end is a fresh chunk boundary unrelated to the old row's end — and the row it
+// cuts starts inside it, so the row cannot be spared without shadowing the fresh
+// tiling and cannot be dropped without stranding its tail.
+func pickInteriorStraddle(t *testing.T, refs []block.ChunkRef) (d0, d1 uint64, straddled block.ChunkRef) {
+	t.Helper()
+	for k := 2; k < len(refs); k++ {
+		r := refs[k]
+		if r.Size < 8192 || refs[k-2].Size < 8192 {
+			continue
+		}
+		d0 = refs[k-2].Offset + 4096
+		d1 = r.Offset + 4096
+		return d0, d1, r
+	}
+	t.Fatalf("manifest has no row shaped for an interior straddle: %d rows", len(refs))
+	return 0, 0, block.ChunkRef{}
+}
+
+// runInteriorStraddleColdRead drives the reachable sequence end to end on a real
+// engine: carve and sync a file, evict it locally, then overwrite a middle range
+// that spans more than one old chunk and ends mid-chunk. The old row the span
+// cuts starts inside the span, so before the head-narrowing reap it survives
+// whole and outranks the fresh rows over [rowStart, spanEnd) — a cold read there
+// is served pre-carve bytes.
+//
+// Three windows are read back, and only one of them is the defect: the head
+// straddler (a row starting BEFORE the span) and the untouched cold tail past
+// the overwrite are correct on both sides of the fix, so a failure confined to
+// the interior straddler is the defect rather than a broken fixture.
+func runInteriorStraddleColdRead(t *testing.T, ms metadata.Store) {
+	ctx := context.Background()
+	bs := newEngineWithRemote(t, ms, remotememory.New())
+	root := createShare(t, ms, "straddle")
+	pid, _ := createRealFile(t, ms, "straddle", "s.bin", root)
+
+	const fileSize = 8 * 1024 * 1024
+	seed := make([]byte, fileSize)
+	rand.New(rand.NewSource(0x2128)).Read(seed) //nolint:gosec // deterministic fixture
+	if _, err := bs.WriteAt(ctx, pid, nil, seed, 0); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	carve(t, bs, ctx, pid)
+
+	d0, d1, straddled := pickInteriorStraddle(t, manifestRefs(t, ms, pid))
+
+	// Evict before the overwrite: with the file local, carve extends the run to
+	// the straddled row's end and the shape never arises. An evicted tail is what
+	// the extension cannot reach.
+	if _, err := bs.DrainLocalSynced(ctx); err != nil {
+		t.Fatalf("evict before overwrite: %v", err)
+	}
+
+	want := append([]byte{}, seed...)
+	ow := make([]byte, d1-d0)
+	rand.New(rand.NewSource(0x2128BEEF)).Read(ow) //nolint:gosec // deterministic fixture
+	copy(want[d0:d1], ow)
+	if _, err := bs.WriteAt(ctx, pid, nil, ow, d0); err != nil {
+		t.Fatalf("overwrite write: %v", err)
+	}
+	carve(t, bs, ctx, pid)
+
+	// Evict again so every read below has to resolve a manifest row and fetch.
+	if _, err := bs.DrainLocalSynced(ctx); err != nil {
+		t.Fatalf("evict before read: %v", err)
+	}
+
+	read := func(off, end uint64) []byte {
+		t.Helper()
+		got := make([]byte, end-off)
+		if _, err := bs.ReadAt(ctx, pid, got, off); err != nil {
+			t.Fatalf("cold read [%d, %d): %v", off, end, err)
+		}
+		return got
+	}
+	diff := func(label string, off, end uint64) {
+		t.Helper()
+		got := read(off, end)
+		if bytes.Equal(got, want[off:end]) {
+			return
+		}
+		for i := range got {
+			if got[i] != want[off+uint64(i)] {
+				at := off + uint64(i)
+				t.Errorf("%s: cold read differs at offset %d: got %#x, want %#x (pre-overwrite byte was %#x)",
+					label, at, got[i], want[at], seed[at])
+				return
+			}
+		}
+	}
+
+	// Control: the row containing d0 starts BEFORE the span and is narrowed off
+	// its tail, which has always worked. It must keep working.
+	diff("head-straddler", d0, straddled.Offset)
+	// The defect: the row starting at straddled.Offset also reaches past d1.
+	diff("interior-straddler", straddled.Offset, d1)
+	// Control: bytes past the span were never re-carved and must still read back
+	// as they were seeded.
+	diff("untouched-tail", d1, min(straddled.Offset+uint64(straddled.Size)+(1<<20), fileSize))
+}
+
+func TestMemoryColdRead_InteriorStraddler(t *testing.T) {
+	runInteriorStraddleColdRead(t, metadatamemory.NewMemoryMetadataStoreWithDefaults())
+}
+
+func TestBadgerColdRead_InteriorStraddler(t *testing.T) {
+	ms, err := metadatabadger.NewBadgerMetadataStoreWithDefaults(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("NewBadgerMetadataStoreWithDefaults: %v", err)
+	}
+	t.Cleanup(func() { _ = ms.Close() })
+	runInteriorStraddleColdRead(t, ms)
+}

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -157,9 +157,10 @@ func (m *Syncer) listFileChunksSnapshot(ctx context.Context, payloadID string) (
 // "<payloadID>/<offset>" (split on the last '/'). A malformed ID is a hard
 // error — an inconsistent manifest, not a benign miss.
 //
-// Only the bytes the row claims are written (see FileChunk.DataSize). A remote
-// read returns the whole chunk, so on a row a shrink narrowed to its surviving
-// prefix, writing the rest would restore bytes past the file's new end, above
+// Only the bytes the row claims are written (see FileChunk.DataSize and
+// FileChunk.StartOffset). A remote read returns the whole chunk, so on a row a
+// narrow cut down to its surviving stretch, writing the rest would restore
+// bytes the row gave up — past the file's new end, above
 // the version of the marker that moved it, and a later re-extend would serve
 // them where a zero hole is due. A row claiming nothing therefore writes
 // nothing: the clamp fails closed, since a claim of zero reaching the local tier

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -172,22 +172,16 @@ func (m *Syncer) listFileChunksSnapshot(ctx context.Context, payloadID string) (
 // window wants.
 func (m *Syncer) hydrateChunk(ctx context.Context, fb *block.FileChunk, data []byte, span hydrateSpan) error {
 	// The claim is [StartOffset, StartOffset+DataSize) of the chunk, and the
-	// row's ID names the file offset of its FIRST claimed byte — so trimming the
-	// head here is what keeps the write-back aligned. A start past the bytes the
-	// remote returned describes a claim the chunk cannot satisfy; write nothing,
-	// the same way a zero claim does, rather than place the wrong bytes.
-	if start := uint64(fb.StartOffset); start > 0 {
-		if start >= uint64(len(data)) {
-			return nil
-		}
-		data = data[start:]
-	}
-	if claimed := uint64(fb.DataSize); claimed < uint64(len(data)) {
-		data = data[:claimed]
-	}
-	if len(data) == 0 {
+	// row's ID names the file offset of its FIRST claimed byte, so the write-back
+	// stays aligned only if the head is trimmed off too. A claim the chunk cannot
+	// satisfy — one starting past the bytes the remote returned, or an empty one —
+	// places nothing rather than the wrong bytes.
+	start := uint64(fb.StartOffset)
+	end := min(start+uint64(fb.DataSize), uint64(len(data)))
+	if start >= end {
 		return nil
 	}
+	data = data[start:end]
 	i := strings.LastIndexByte(fb.ID, '/')
 	off, ok := block.ParseChunkOffset(fb.ID)
 	if i <= 0 || !ok {

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -170,6 +170,17 @@ func (m *Syncer) listFileChunksSnapshot(ctx context.Context, payloadID string) (
 // writes the whole claimed extent, which is what a caller holding a row but no
 // window wants.
 func (m *Syncer) hydrateChunk(ctx context.Context, fb *block.FileChunk, data []byte, span hydrateSpan) error {
+	// The claim is [StartOffset, StartOffset+DataSize) of the chunk, and the
+	// row's ID names the file offset of its FIRST claimed byte — so trimming the
+	// head here is what keeps the write-back aligned. A start past the bytes the
+	// remote returned describes a claim the chunk cannot satisfy; write nothing,
+	// the same way a zero claim does, rather than place the wrong bytes.
+	if start := uint64(fb.StartOffset); start > 0 {
+		if start >= uint64(len(data)) {
+			return nil
+		}
+		data = data[start:]
+	}
 	if claimed := uint64(fb.DataSize); claimed < uint64(len(data)) {
 		data = data[:claimed]
 	}

--- a/pkg/block/engine/manifest_repair.go
+++ b/pkg/block/engine/manifest_repair.go
@@ -44,6 +44,12 @@ type RepairAction struct {
 	Offset uint64 `json:"offset"`
 	Size   uint32 `json:"size"`
 
+	// StartOffset is where inside the chunk the claimed bytes begin, also taken
+	// from the block list. A repair that dropped it would rebuild a row serving
+	// the chunk's head at Offset, which for a head-narrowed claim is the wrong
+	// stretch of the right chunk — bytes that verify and are still wrong.
+	StartOffset uint32 `json:"start_offset,omitempty"`
+
 	// Hash is the content hash the row carries. The remote read path
 	// resolves and verifies a chunk by this hash alone, so a repair that
 	// named the wrong bytes would fail the read rather than serve them.
@@ -73,8 +79,9 @@ func chunkRowID(payloadID string, off uint64) string {
 // refKey groups a claim and a row by the two properties that have to match
 // for one to stand in for the other.
 type refKey struct {
-	hash block.ContentHash
-	size uint32
+	hash  block.ContentHash
+	size  uint32
+	start uint32
 }
 
 // planPayloadRepairs proposes the manifest writes that would make one payload
@@ -114,7 +121,7 @@ func planPayloadRepairs(
 			continue
 		}
 		candidates = append(candidates, ref)
-		perKey[refKey{ref.Hash, ref.Size}]++
+		perKey[refKey{ref.Hash, ref.Size, ref.StartOffset}]++
 	}
 	if len(candidates) == 0 {
 		return nil, nil
@@ -125,20 +132,21 @@ func planPayloadRepairs(
 		if r.Hash.IsZero() {
 			continue // pending row: no committed bytes to place anywhere
 		}
-		k := refKey{r.Hash, r.DataSize}
+		k := refKey{r.Hash, r.DataSize, r.StartOffset}
 		rowsByKey[k] = append(rowsByKey[k], r)
 	}
 
 	out := make([]RepairAction, 0, len(candidates))
 	for _, ref := range candidates {
-		k := refKey{ref.Hash, ref.Size}
+		k := refKey{ref.Hash, ref.Size, ref.StartOffset}
 		action := RepairAction{
-			Path:      path,
-			PayloadID: payloadID,
-			Offset:    ref.Offset,
-			Size:      ref.Size,
-			Hash:      ref.Hash.String(),
-			ToRowID:   chunkRowID(payloadID, ref.Offset),
+			Path:        path,
+			PayloadID:   payloadID,
+			Offset:      ref.Offset,
+			Size:        ref.Size,
+			StartOffset: ref.StartOffset,
+			Hash:        ref.Hash.String(),
+			ToRowID:     chunkRowID(payloadID, ref.Offset),
 		}
 		switch rows := rowsByKey[k]; {
 		case len(rows) == 1 && perKey[k] == 1:
@@ -306,7 +314,7 @@ func indexChunkRows(rows []*block.FileChunk, size uint64) (map[string]*block.Fil
 func claimedOffsets(f *metadata.File) map[refKey]map[uint64]struct{} {
 	claimed := make(map[refKey]map[uint64]struct{}, len(f.Blocks))
 	for _, ref := range f.Blocks {
-		k := refKey{ref.Hash, ref.Size}
+		k := refKey{ref.Hash, ref.Size, ref.StartOffset}
 		if claimed[k] == nil {
 			claimed[k] = make(map[uint64]struct{}, 1)
 		}
@@ -331,7 +339,7 @@ func repairRow(
 	if err != nil {
 		return nil, fmt.Errorf("parse planned hash %q: %w", a.Hash, err)
 	}
-	k := refKey{hash, a.Size}
+	k := refKey{hash, a.Size, a.StartOffset}
 
 	if _, ok := claimed[k][a.Offset]; !ok {
 		a.SkipReason = "the file no longer claims this range"
@@ -356,7 +364,7 @@ func repairRow(
 			a.SkipReason = "the unplaceable row is gone"
 			return nil, nil
 		}
-		if src.Hash != hash || src.DataSize != a.Size {
+		if src.Hash != hash || src.DataSize != a.Size || src.StartOffset != a.StartOffset {
 			a.SkipReason = "the unplaceable row no longer matches the claim"
 			return nil, nil
 		}
@@ -387,11 +395,12 @@ func repairRow(
 	// State and refcount are left where the carve path leaves them, which is
 	// where every other row in the store sits.
 	return &block.FileChunk{
-		ID:         a.ToRowID,
-		Hash:       hash,
-		DataSize:   a.Size,
-		State:      block.BlockStatePending,
-		CreatedAt:  now,
-		LastAccess: now,
+		ID:          a.ToRowID,
+		Hash:        hash,
+		DataSize:    a.Size,
+		StartOffset: a.StartOffset,
+		State:       block.BlockStatePending,
+		CreatedAt:   now,
+		LastAccess:  now,
 	}, nil
 }

--- a/pkg/block/engine/manifest_repair_test.go
+++ b/pkg/block/engine/manifest_repair_test.go
@@ -393,7 +393,7 @@ func TestRepairSkipsWhenEvidenceMoved(t *testing.T) {
 
 			claimed := map[refKey]map[uint64]struct{}{}
 			for _, ref := range f.Blocks {
-				k := refKey{ref.Hash, ref.Size}
+				k := refKey{ref.Hash, ref.Size, ref.StartOffset}
 				if claimed[k] == nil {
 					claimed[k] = map[uint64]struct{}{}
 				}

--- a/pkg/block/engine/offline.go
+++ b/pkg/block/engine/offline.go
@@ -181,10 +181,10 @@ func offlineReadinessOf(ctx context.Context, localTier any, hasRemote bool, shor
 // file and weighed against the ranges the index reports for the same file,
 // which include cold ones — a cold range is described, just not resident.
 //
-// The union is what makes overlap a non-event, and rows do overlap: a row
-// claims a prefix of its chunk, so a row reaching past a later row's whole span
-// is kept rather than cut, and that straddler is what keeps its own tail
-// readable. Coverage here is the set of offsets some row places, which is the
+// The union is what makes overlap a non-event, and rows do overlap: a row that
+// starts before a later row's whole span is kept rather than cut, since the
+// later rows outrank it where they cover and nothing else covers what it holds
+// on either side of them. Coverage here is the set of offsets some row places, which is the
 // same set a read can resolve however it picks between covering rows, so two
 // rows over one byte merge into one span instead of counting twice.
 //

--- a/pkg/block/engine/offline_test.go
+++ b/pkg/block/engine/offline_test.go
@@ -238,9 +238,9 @@ func TestManifestShortfall(t *testing.T) {
 		},
 		{
 			// A row reaching past a later row's whole span is a legitimate
-			// manifest shape, not damage: a row claims a prefix of its chunk, so
-			// nothing can be cut to start mid-chunk and re-cover the tail, and
-			// the straddler is what keeps those bytes readable. Coverage is the
+			// manifest shape, not damage: the straddler starts first, so the
+			// later row outranks it where they meet, and the straddler is what
+			// keeps the bytes on either side of that row readable. Coverage is the
 			// union of what rows claim, so the straddler's tail counts as placed
 			// and the byte the later row also covers is not counted twice.
 			name:      "a straddling row keeps its tail",

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -462,7 +462,7 @@ func (bs *Store) payloadChunkRefs(ctx context.Context, payloadID string) []block
 		if !ok {
 			continue
 		}
-		refs = append(refs, block.ChunkRef{Hash: r.Hash, Offset: off, Size: r.DataSize})
+		refs = append(refs, block.ChunkRef{Hash: r.Hash, Offset: off, Size: r.DataSize, StartOffset: r.StartOffset})
 	}
 	return refs
 }
@@ -594,10 +594,11 @@ func (bs *Store) CopyPayload(ctx context.Context, srcPayloadID, dstPayloadID str
 			return nil, fmt.Errorf("CopyPayload: no transaction or file-block store to persist dst rows for %s", dstPayloadID)
 		}
 		fb := &block.FileChunk{
-			ID:       fmt.Sprintf("%s/%d", dstPayloadID, b.Offset),
-			Hash:     b.Hash,
-			DataSize: b.Size,
-			State:    block.BlockStatePending,
+			ID:          fmt.Sprintf("%s/%d", dstPayloadID, b.Offset),
+			Hash:        b.Hash,
+			DataSize:    b.Size,
+			StartOffset: b.StartOffset,
+			State:       block.BlockStatePending,
 		}
 		if err := putRow(ctx, fb); err != nil {
 			return nil, fmt.Errorf("CopyPayload: FileChunk.Put(%s): %w", fb.ID, err)

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -116,13 +116,14 @@ func (bs *Store) WriteAt(ctx context.Context, payloadID string, currentBlocks []
 // hash. The new []ChunkRef list is returned for the caller to persist
 // via SetManifest. When currentBlocks is empty the legacy path runs and
 // the returned slice is empty (dual-read shim semantics).
-// narrowChunkRow shrinks a manifest row to the surviving prefix of its chunk so
+// narrowChunkRow shrinks a manifest row to the surviving head of its claim so
 // coverage lookups stop resolving it for bytes the file no longer holds and a
-// hydrate writes back only that prefix. The remote chunk is untouched — its hash
-// still addresses the full bytes and the verified read still checks them all —
-// and RefCount is unchanged: the file still references the chunk, just less of
-// it. A row already at or below the surviving size, or already reaped, needs
-// nothing.
+// hydrate writes back only that much. Where in the chunk the claim begins is
+// left alone, so a row already narrowed off its head shrinks from the same place
+// a whole one does. The remote chunk is untouched — its hash still addresses the
+// full bytes and the verified read still checks them all — and RefCount is
+// unchanged: the file still references the chunk, just less of it. A row already
+// at or below the surviving size, or already reaped, needs nothing.
 func (bs *Store) narrowChunkRow(ctx context.Context, payloadID string, b block.ChunkRef) error {
 	if bs.fileChunkStore == nil {
 		return nil

--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -600,11 +600,10 @@ func (s *Store) packRuns(ctx context.Context, sh *shard, id FileID, rs []*runSta
 // warm. An evicted range holds no local bytes to re-chunk, and half an extension
 // still ends inside the row.
 //
-// Skipping is not free, and every bail below shares the cost: the run then still
-// ends inside a row, and the reap spares that row whole rather than strand the
-// stretch past the run — so the range keeps a stale cover overlapping the fresh
-// tiling instead of being tiled cleanly. Extending is what earns the clean
-// tiling.
+// Skipping costs a re-chunk, not correctness: the run then still ends inside a
+// row, and the reap narrows that row off its head so the fresh tiling owns every
+// offset the run covered. Extending buys a tiling whose rows line up with the
+// old boundaries instead of one that leaves a narrowed remnant behind.
 //
 // A row reaching past limit, the offset the next run starts at, is refused
 // outright. It is redundant today: runs are packed in ascending file-offset
@@ -616,9 +615,9 @@ func (s *Store) packRuns(ctx context.Context, sh *shard, id FileID, rs []*runSta
 // were carved concurrently before and would be again — and under any such
 // ordering a sibling's already-flipped head is indistinguishable here from
 // pre-existing warm data. It has to be a refusal rather than a truncation to
-// limit: a run truncated there still ends inside the row, so the reap spares
-// that row whole and its stale cover outlives the fresh tiling anyway — the
-// truncated extension would re-chunk those bytes for nothing.
+// limit: a run truncated there still ends inside the row, so the reap narrows
+// the row off its head just as it would with no extension at all — the truncated
+// extension would re-chunk those bytes for nothing.
 //
 // ponytail: a row reaching past a later dirty run is left alone, so that run
 // still ends mid-row; covering it means merging the two runs, which is worth

--- a/pkg/block/types.go
+++ b/pkg/block/types.go
@@ -153,10 +153,15 @@ func (h *ContentHash) UnmarshalJSON(data []byte) error {
 // >4 GiB; VM workload requirement).
 // Size is the chunk length in bytes (FastCDC min 1 MiB, max 16 MiB
 // uint32 chosen to match FileChunk.DataSize column type).
+// StartOffset is where inside the chunk the referenced bytes begin, mirroring
+// FileChunk.StartOffset; it must travel with the ref because the projection is
+// what a clone and a manifest repair rebuild rows from, and a ref that dropped
+// it would rebuild a row serving the chunk's head at Offset.
 type ChunkRef struct {
-	Hash   ContentHash `json:"hash"`
-	Offset uint64      `json:"offset"`
-	Size   uint32      `json:"size"`
+	Hash        ContentHash `json:"hash"`
+	Offset      uint64      `json:"offset"`
+	Size        uint32      `json:"size"`
+	StartOffset uint32      `json:"start_offset,omitempty"`
 }
 
 // MergeChunkRefsByOffset overlays incoming block refs onto existing ones,
@@ -244,10 +249,26 @@ type FileChunk struct {
 	// DataSize is how many of the chunk's bytes belong to this file at this
 	// row's offset — the row's claim, which is what coverage lookups and a
 	// cold-read hydrate honour. It is the chunk's full length except where a
-	// shrink narrowed the row to the prefix that survived: the chunk on the
+	// narrow cut the row down to the stretch that survived: the chunk on the
 	// remote still holds all of its bytes and is still hash-verified over all of
-	// them, the row just stops claiming the tail.
+	// them, the row just stops claiming what it gave up.
 	DataSize uint32
+
+	// StartOffset is where inside the chunk the claimed bytes begin, so the row
+	// covers file bytes [rowOffset, rowOffset+DataSize) with chunk bytes
+	// [StartOffset, StartOffset+DataSize). Zero for every row a carve writes and
+	// for every row narrowed only off its tail, which is why a row written before
+	// the field existed means exactly what it meant then: the claim starts at the
+	// chunk's first byte.
+	//
+	// A non-zero value comes from narrowing a row off its HEAD, which is what a
+	// carve span ending inside a row that also starts inside it needs: the span
+	// re-chunked that row's head and nothing else, so the row keeps only what
+	// lies past the span. The row's ID moves to the first byte it still claims,
+	// so every coverage and succession lookup goes on reading a row's start
+	// straight off its ID; only the paths that read the chunk's own bytes need
+	// this offset.
+	StartOffset uint32
 
 	// RefCount is the number of files referencing this chunk.
 	RefCount uint32

--- a/pkg/block/types_test.go
+++ b/pkg/block/types_test.go
@@ -495,3 +495,22 @@ func TestPruneChunkRefsToSize(t *testing.T) {
 		})
 	}
 }
+
+// TestFileChunkJSON_StartOffsetAbsentMeansChunkStart pins what a row stored by a
+// build that predates the in-chunk start offset means when a later build reads
+// it. The KV backends persist a FileChunk as JSON, so such a row simply carries
+// no key for the field, and the value it decodes to has to be the one that says
+// "this claim begins at the chunk's first byte".
+func TestFileChunkJSON_StartOffsetAbsentMeansChunkStart(t *testing.T) {
+	const stored = `{"ID":"share/file/4096","DataSize":4096,"RefCount":1,"state":2}`
+	var fc FileChunk
+	if err := json.Unmarshal([]byte(stored), &fc); err != nil {
+		t.Fatalf("unmarshal pre-change row: %v", err)
+	}
+	if fc.StartOffset != 0 {
+		t.Errorf("StartOffset = %d, want 0", fc.StartOffset)
+	}
+	if fc.DataSize != 4096 {
+		t.Errorf("DataSize = %d, want 4096", fc.DataSize)
+	}
+}

--- a/pkg/metadata/block_record_store.go
+++ b/pkg/metadata/block_record_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 
@@ -24,7 +25,7 @@ func ManifestToChunkRefs(rows []*block.FileChunk) []block.ChunkRef {
 		if !ok {
 			continue
 		}
-		refs = append(refs, block.ChunkRef{Hash: r.Hash, Offset: off, Size: r.DataSize})
+		refs = append(refs, block.ChunkRef{Hash: r.Hash, Offset: off, Size: r.DataSize, StartOffset: r.StartOffset})
 	}
 	sort.Slice(refs, func(i, j int) bool { return refs[i].Offset < refs[j].Offset })
 	if len(refs) == 0 {
@@ -54,7 +55,7 @@ func mergeCommittedRefs(refs []block.ChunkRef, payloadID string, rows []*block.F
 		if !ok || chunkPayloadID(r.ID) != payloadID {
 			continue
 		}
-		byOffset[off] = block.ChunkRef{Hash: r.Hash, Offset: off, Size: r.DataSize}
+		byOffset[off] = block.ChunkRef{Hash: r.Hash, Offset: off, Size: r.DataSize, StartOffset: r.StartOffset}
 	}
 	added := make([]block.ChunkRef, 0, len(byOffset))
 	changed := make([]uint64, 0, len(byOffset))
@@ -387,39 +388,67 @@ func ManifestRowEndAfter(ctx context.Context, tx Transaction, payloadID string, 
 // the part the run re-chunked, which is the same shape a truncate's narrow leaves
 // behind.
 //
-// A row that reaches past its span's end stays whole, whichever side it starts
-// on: no row can start mid-chunk, so its tail past the span has no other cover,
-// and deleting it would trade an overlap for a gap. Where it starts decides what
-// that overlap then reads, and the two sides are not alike.
+// A row that STARTS inside its span and reaches past the end is narrowed off its
+// HEAD instead: its ID moves to the span's end, StartOffset advances by what it
+// gave up, and DataSize shrinks to match, so it claims [spanEnd, rowEnd) and
+// nothing more. Sparing it whole would leave it the greatest covering start over
+// [rowStart, spanEnd) — it would outrank the fresh rows there and serve the
+// content those bytes held before the carve — and deleting it would strand
+// [spanEnd, rowEnd) with no cover at all. Narrowing off the head is neither: the
+// chunk on the remote keeps every byte and is still hash-verified over all of
+// them, exactly as it is when a row is narrowed off its tail.
 //
-// Starting BEFORE the span is safe. Coverage resolves an overlap to the greatest
-// covering start, and every fresh row inside the span starts later than a row
-// that began before it, so the fresh rows win across the whole span and the
-// survivor serves only its un-recarved tail.
+// A row that starts before its span and reaches past the end still stays whole,
+// and is safe there: coverage resolves an overlap to the greatest covering
+// start, and every fresh row inside the span starts later than a row that began
+// before it, so the fresh rows win across the whole span and the survivor serves
+// only its un-recarved remainder.
 //
-// Starting INSIDE the span is not. Over [rowStart, spanEnd) the spared row is
-// itself the greatest start, so it outranks the fresh row covering those bytes
-// and serves the content they held before the carve. Sparing it is the least bad
-// of three wrong answers, not a safe one: deleting it strands [spanEnd, rowEnd)
-// with no cover at all, and it cannot be narrowed off the overlap either, because
-// a row claims a prefix of its chunk and none can be made to start at spanEnd.
-//
-// Nothing here can do better, because the overlap is already decided by the time
-// the reap runs: the fresh rows are committed, and no row that claims a prefix
-// can cover [spanEnd, rowEnd) in the spared row's place. Only carving through to
-// rowEnd avoids it, which is what the journal's run extension arranges whenever
-// the bytes past the span are still warm; a span cuts a row starting inside it
-// only where that extension could not reach — the tail is cold, evicted, holed,
-// or already dirty for a later run.
-//
-// ponytail: over [rowStart, spanEnd) a cold read serves pre-carve bytes, and the
-// manifest records no order to tell the caller so; closing it means carve
-// hydrating the straddler's tail and re-chunking it, or refusing to commit a
-// tiling whose span cuts a row starting inside it (#2128).
+// A head narrow moves the row to a new manifest key, and a row already sitting
+// at that key would be overwritten — so the move is taken only when the key is
+// free. ponytail: an occupied key leaves the row spared whole and its stale
+// cover in place; reaching it needs two pre-existing rows overlapping at the
+// span's end, so a resolution rule for that collision is worth building only if
+// one is ever observed.
 //
 // ponytail: this fixes read-coherence — the corruption. Decrementing the reaped
 // chunk's CAS refcount to reclaim its remote space is a separate, tracked
 // follow-up (#1715): under-counting only leaks space, it never drops live data.
+// spanFreeStart returns the first byte of [rowStart, rowEnd) that no span
+// claims, or rowEnd when the spans cover the row outright. Spans are disjoint
+// and ascending, so it is enough to step over the span the row starts in and
+// over any span beginning exactly where that one ended.
+func spanFreeStart(ordered [][2]int64, rowStart, rowEnd int64) int64 {
+	start := rowStart
+	for start < rowEnd {
+		i := sort.Search(len(ordered), func(j int) bool { return ordered[j][1] > start })
+		if i == len(ordered) || ordered[i][0] > start {
+			return start
+		}
+		start = ordered[i][1]
+	}
+	return rowEnd
+}
+
+// narrowOffHead returns a copy of r claiming only [head, rowEnd) of the file,
+// keyed at head and reading the chunk from that many bytes further in. It
+// reports false when the giving-up does not fit the row's 32-bit fields, which
+// no real chunk reaches — a chunk is bounded by the carver's maximum size — so
+// refusing there simply keeps the row as it stands rather than wrapping.
+func narrowOffHead(r *block.FileChunk, rowStart, head, rowEnd int64) (*block.FileChunk, bool) {
+	gave := head - rowStart
+	start := int64(r.StartOffset) + gave
+	size := rowEnd - head
+	if gave <= 0 || start > math.MaxUint32 || size <= 0 || size > math.MaxUint32 {
+		return nil, false
+	}
+	narrowed := *r
+	narrowed.ID = fmt.Sprintf("%s/%d", chunkPayloadID(r.ID), head)
+	narrowed.StartOffset = uint32(start)
+	narrowed.DataSize = uint32(size)
+	return &narrowed, true
+}
+
 func ReapSupersededManifest(ctx context.Context, tx Transaction, payloadID string, spans [][2]int64, newOffsets map[int64]struct{}) error {
 	if payloadID == "" {
 		return nil
@@ -439,6 +468,12 @@ func ReapSupersededManifest(ctx context.Context, tx Transaction, payloadID strin
 	if err != nil {
 		return fmt.Errorf("reap superseded: list manifest for %s: %w", payloadID, err)
 	}
+	occupied := make(map[string]struct{}, len(rows))
+	for _, r := range rows {
+		if r != nil {
+			occupied[r.ID] = struct{}{}
+		}
+	}
 	for _, r := range rows {
 		if r == nil {
 			continue
@@ -449,30 +484,47 @@ func ReapSupersededManifest(ctx context.Context, tx Transaction, payloadID strin
 		}
 		rowStart := int64(off)
 		rowEnd := rowStart + int64(r.DataSize)
-		// The span this row is acted on: the first one whose end the row does not
-		// reach past. An earlier span the row overlaps is one it outreaches, and
-		// outreaching a span is what spares the row — acting on it there would
-		// strand the stretch beyond, since no row can start mid-chunk to cover it.
-		// A later span the row cannot reach, because acting here leaves it ending
-		// at or before this span's start. Spans ascend, so this is a binary search.
+		head := spanFreeStart(ordered, rowStart, rowEnd)
+		if head > rowStart {
+			if _, isNew := newOffsets[rowStart]; isNew {
+				continue // a row this pass just wrote — keep it
+			}
+			if head >= rowEnd {
+				if err := tx.Delete(ctx, r.ID); err != nil {
+					return fmt.Errorf("reap superseded: delete %s: %w", r.ID, err)
+				}
+				continue
+			}
+			narrowed, ok := narrowOffHead(r, rowStart, head, rowEnd)
+			if !ok {
+				continue
+			}
+			if _, taken := occupied[narrowed.ID]; taken {
+				continue // see the head-narrow note above: spared rather than overwritten
+			}
+			if err := tx.Delete(ctx, r.ID); err != nil {
+				return fmt.Errorf("reap superseded: unkey %s: %w", r.ID, err)
+			}
+			if err := tx.Put(ctx, narrowed); err != nil {
+				return fmt.Errorf("reap superseded: narrow %s off its head: %w", r.ID, err)
+			}
+			occupied[narrowed.ID] = struct{}{}
+			continue
+		}
+		// The row starts where no span claims it, so what a span can take is its
+		// tail. The span that acts on it is the first one whose end the row does
+		// not reach past: an earlier span the row outreaches is one that would
+		// strand the stretch beyond if acted on, and a later span the row cannot
+		// reach, because acting here leaves it ending at or before this span's
+		// start. Spans ascend, so this is a binary search.
 		i := sort.Search(len(ordered), func(j int) bool { return ordered[j][1] >= rowEnd })
 		if i == len(ordered) || ordered[i][0] >= rowEnd || ordered[i][1] <= rowStart {
 			continue // no span acts on it: untouched (incl. cold remainders)
 		}
-		spanStart := ordered[i][0]
-		if rowStart < spanStart {
-			narrowed := *r
-			narrowed.DataSize = uint32(spanStart - rowStart)
-			if err := tx.Put(ctx, &narrowed); err != nil {
-				return fmt.Errorf("reap superseded: narrow %s: %w", r.ID, err)
-			}
-			continue
-		}
-		if _, isNew := newOffsets[rowStart]; isNew {
-			continue // a row this pass just wrote — keep it
-		}
-		if err := tx.Delete(ctx, r.ID); err != nil {
-			return fmt.Errorf("reap superseded: delete %s: %w", r.ID, err)
+		narrowed := *r
+		narrowed.DataSize = uint32(ordered[i][0] - rowStart)
+		if err := tx.Put(ctx, &narrowed); err != nil {
+			return fmt.Errorf("reap superseded: narrow %s: %w", r.ID, err)
 		}
 	}
 	return ProjectManifestToBlocks(ctx, tx, payloadID)

--- a/pkg/metadata/block_record_store.go
+++ b/pkg/metadata/block_record_store.go
@@ -354,6 +354,41 @@ func ManifestRowEndAfter(ctx context.Context, tx Transaction, payloadID string, 
 	return end, nil
 }
 
+// spanFreeStart returns the first byte of [rowStart, rowEnd) that no span
+// claims, or rowEnd when the spans cover the row outright. Spans are disjoint
+// and ascending, so the search finds the only span that can cover rowStart, and
+// from there only the next span can begin exactly where the previous one ended.
+func spanFreeStart(ordered [][2]int64, rowStart, rowEnd int64) int64 {
+	start := rowStart
+	i := sort.Search(len(ordered), func(j int) bool { return ordered[j][1] > start })
+	for ; i < len(ordered) && ordered[i][0] <= start; i++ {
+		start = ordered[i][1]
+		if start >= rowEnd {
+			return rowEnd
+		}
+	}
+	return start
+}
+
+// narrowOffHead returns a copy of r claiming only [head, rowEnd) of the file,
+// keyed at head and reading the chunk from that many bytes further in. The
+// caller establishes rowStart < head < rowEnd, so what survives is a non-empty
+// claim smaller than the one it replaces. It reports false when what the row
+// gives up pushes its in-chunk start past what the 32-bit field holds, which no
+// real chunk reaches — a chunk is bounded by the carver's maximum size — so
+// refusing there simply keeps the row as it stands rather than wrapping.
+func narrowOffHead(r *block.FileChunk, rowStart, head, rowEnd int64) (*block.FileChunk, bool) {
+	start := int64(r.StartOffset) + (head - rowStart)
+	if start > math.MaxUint32 {
+		return nil, false
+	}
+	narrowed := *r
+	narrowed.ID = fmt.Sprintf("%s/%d", chunkPayloadID(r.ID), head)
+	narrowed.StartOffset = uint32(start)
+	narrowed.DataSize = uint32(rowEnd - head)
+	return &narrowed, true
+}
+
 // ReapSupersededManifest deletes the manifest rows a carve pass supersedes and
 // re-projects File.Blocks, atomically. A partial overwrite re-chunks the dirty
 // range (plus its warm straddle remainders, re-marked dirty by the journal) into
@@ -414,41 +449,6 @@ func ManifestRowEndAfter(ctx context.Context, tx Transaction, payloadID string, 
 // ponytail: this fixes read-coherence — the corruption. Decrementing the reaped
 // chunk's CAS refcount to reclaim its remote space is a separate, tracked
 // follow-up (#1715): under-counting only leaks space, it never drops live data.
-// spanFreeStart returns the first byte of [rowStart, rowEnd) that no span
-// claims, or rowEnd when the spans cover the row outright. Spans are disjoint
-// and ascending, so it is enough to step over the span the row starts in and
-// over any span beginning exactly where that one ended.
-func spanFreeStart(ordered [][2]int64, rowStart, rowEnd int64) int64 {
-	start := rowStart
-	for start < rowEnd {
-		i := sort.Search(len(ordered), func(j int) bool { return ordered[j][1] > start })
-		if i == len(ordered) || ordered[i][0] > start {
-			return start
-		}
-		start = ordered[i][1]
-	}
-	return rowEnd
-}
-
-// narrowOffHead returns a copy of r claiming only [head, rowEnd) of the file,
-// keyed at head and reading the chunk from that many bytes further in. It
-// reports false when the giving-up does not fit the row's 32-bit fields, which
-// no real chunk reaches — a chunk is bounded by the carver's maximum size — so
-// refusing there simply keeps the row as it stands rather than wrapping.
-func narrowOffHead(r *block.FileChunk, rowStart, head, rowEnd int64) (*block.FileChunk, bool) {
-	gave := head - rowStart
-	start := int64(r.StartOffset) + gave
-	size := rowEnd - head
-	if gave <= 0 || start > math.MaxUint32 || size <= 0 || size > math.MaxUint32 {
-		return nil, false
-	}
-	narrowed := *r
-	narrowed.ID = fmt.Sprintf("%s/%d", chunkPayloadID(r.ID), head)
-	narrowed.StartOffset = uint32(start)
-	narrowed.DataSize = uint32(size)
-	return &narrowed, true
-}
-
 func ReapSupersededManifest(ctx context.Context, tx Transaction, payloadID string, spans [][2]int64, newOffsets map[int64]struct{}) error {
 	if payloadID == "" {
 		return nil
@@ -468,6 +468,8 @@ func ReapSupersededManifest(ctx context.Context, tx Transaction, payloadID strin
 	if err != nil {
 		return fmt.Errorf("reap superseded: list manifest for %s: %w", payloadID, err)
 	}
+	// The keys the manifest already holds, so a head narrow never moves a row
+	// onto one.
 	occupied := make(map[string]struct{}, len(rows))
 	for _, r := range rows {
 		if r != nil {
@@ -485,47 +487,50 @@ func ReapSupersededManifest(ctx context.Context, tx Transaction, payloadID strin
 		rowStart := int64(off)
 		rowEnd := rowStart + int64(r.DataSize)
 		head := spanFreeStart(ordered, rowStart, rowEnd)
-		if head > rowStart {
-			if _, isNew := newOffsets[rowStart]; isNew {
-				continue // a row this pass just wrote — keep it
+		if head == rowStart {
+			// The row starts where no span claims it, so what a span can take is
+			// its tail. The span that acts on it is the first one whose end the row
+			// does not reach past: an earlier span the row outreaches is one that
+			// would strand the stretch beyond if acted on, and a later span the row
+			// cannot reach, because acting here leaves it ending at or before this
+			// span's start. Spans ascend, so this is a binary search.
+			i := sort.Search(len(ordered), func(j int) bool { return ordered[j][1] >= rowEnd })
+			if i == len(ordered) || ordered[i][0] >= rowEnd || ordered[i][1] <= rowStart {
+				continue // no span acts on it: untouched (incl. cold remainders)
 			}
-			if head >= rowEnd {
-				if err := tx.Delete(ctx, r.ID); err != nil {
-					return fmt.Errorf("reap superseded: delete %s: %w", r.ID, err)
-				}
-				continue
+			narrowed := *r
+			narrowed.DataSize = uint32(ordered[i][0] - rowStart)
+			if err := tx.Put(ctx, &narrowed); err != nil {
+				return fmt.Errorf("reap superseded: narrow %s: %w", r.ID, err)
 			}
-			narrowed, ok := narrowOffHead(r, rowStart, head, rowEnd)
-			if !ok {
-				continue
-			}
-			if _, taken := occupied[narrowed.ID]; taken {
-				continue // see the head-narrow note above: spared rather than overwritten
-			}
-			if err := tx.Delete(ctx, r.ID); err != nil {
-				return fmt.Errorf("reap superseded: unkey %s: %w", r.ID, err)
-			}
-			if err := tx.Put(ctx, narrowed); err != nil {
-				return fmt.Errorf("reap superseded: narrow %s off its head: %w", r.ID, err)
-			}
-			occupied[narrowed.ID] = struct{}{}
 			continue
 		}
-		// The row starts where no span claims it, so what a span can take is its
-		// tail. The span that acts on it is the first one whose end the row does
-		// not reach past: an earlier span the row outreaches is one that would
-		// strand the stretch beyond if acted on, and a later span the row cannot
-		// reach, because acting here leaves it ending at or before this span's
-		// start. Spans ascend, so this is a binary search.
-		i := sort.Search(len(ordered), func(j int) bool { return ordered[j][1] >= rowEnd })
-		if i == len(ordered) || ordered[i][0] >= rowEnd || ordered[i][1] <= rowStart {
-			continue // no span acts on it: untouched (incl. cold remainders)
+		// The row starts inside a span, so what the span takes is its head.
+		if _, isNew := newOffsets[rowStart]; isNew {
+			continue // a row this pass just wrote — keep it
 		}
-		narrowed := *r
-		narrowed.DataSize = uint32(ordered[i][0] - rowStart)
-		if err := tx.Put(ctx, &narrowed); err != nil {
-			return fmt.Errorf("reap superseded: narrow %s: %w", r.ID, err)
+		if head >= rowEnd {
+			if err := tx.Delete(ctx, r.ID); err != nil {
+				return fmt.Errorf("reap superseded: delete %s: %w", r.ID, err)
+			}
+			continue
 		}
+		// It reaches past the span too, so it keeps only what lies past it,
+		// re-keyed at the first byte it still claims.
+		narrowed, ok := narrowOffHead(r, rowStart, head, rowEnd)
+		if !ok {
+			continue // the claim will not fit the row's fields: leave it as it stands
+		}
+		if _, taken := occupied[narrowed.ID]; taken {
+			continue // see the head-narrow note above: spared rather than overwritten
+		}
+		if err := tx.Delete(ctx, r.ID); err != nil {
+			return fmt.Errorf("reap superseded: unkey %s: %w", r.ID, err)
+		}
+		if err := tx.Put(ctx, narrowed); err != nil {
+			return fmt.Errorf("reap superseded: narrow %s off its head: %w", r.ID, err)
+		}
+		occupied[narrowed.ID] = struct{}{}
 	}
 	return ProjectManifestToBlocks(ctx, tx, payloadID)
 }

--- a/pkg/metadata/reap_superseded_test.go
+++ b/pkg/metadata/reap_superseded_test.go
@@ -85,10 +85,10 @@ func TestReapSupersededManifest_NarrowsStraddler(t *testing.T) {
 	}, tiling(t, tx, pid))
 }
 
-// TestReapSupersededManifest_KeepsStraddlerReachingPastRun covers the one
-// straddler that must survive whole: it also ends past the run, and no row can
-// start mid-chunk, so narrowing it would trade the overlap for a gap over
-// [runEnd, rowEnd) — bytes that would then read back as zeros.
+// TestReapSupersededManifest_KeepsStraddlerReachingPastRun covers the straddler
+// that must survive whole: it starts before the run AND ends past it, so its
+// bytes on either side have no other cover, and it is safe there because every
+// fresh row inside the run starts later and outranks it across the run.
 func TestReapSupersededManifest_KeepsStraddlerReachingPastRun(t *testing.T) {
 	const pid = "share/p"
 	ctx := context.Background()

--- a/pkg/metadata/reap_superseded_test.go
+++ b/pkg/metadata/reap_superseded_test.go
@@ -117,20 +117,19 @@ func TestReapSupersededManifest_KeepsStraddlerReachingPastRun(t *testing.T) {
 	require.Equal(t, int64(-1), resolveAt(t, tx, pid, 6000))
 }
 
-// TestReapSupersededManifest_KeepsInteriorRowReachingPastRun pins both what the
+// TestReapSupersededManifest_NarrowsInteriorRowOffItsHead pins both what the
 // reap does with a row that starts inside the run and ends past it, and what a
-// read then gets — which are not the same question. The row survives whole:
-// deleting it, which is what its start offset alone would say to do, strands
-// [runEnd, rowEnd) with no cover, and no row can be made to start mid-chunk to
-// take that stretch over, so those bytes would read back as zeros.
+// read then gets — which are not the same question. The row cannot be deleted,
+// which is what its start offset alone would say to do: that strands
+// [runEnd, rowEnd) with no cover. Nor can it be spared whole: coverage resolves
+// to the greatest start, so over [rowStart, runEnd) it would outrank the fresh
+// row covering the same offsets and serve what they held before the carve.
 //
-// Surviving is not the same as being right. Coverage resolves to the greatest
-// start, so over [rowStart, runEnd) the spared row outranks the fresh row that
-// also covers those offsets and serves what they held before the carve. The reap
-// has no better move — it cannot narrow a row off its own head — so the
-// assertions below record that stale window instead of claiming there is none.
-// Only carving through to rowEnd removes it.
-func TestReapSupersededManifest_KeepsInteriorRowReachingPastRun(t *testing.T) {
+// It is narrowed off its HEAD instead. The row moves to the run's end, keeps the
+// stretch only it covers, and gives up the offsets the run re-chunked, so every
+// byte of the run resolves to a fresh row and every byte past it still resolves
+// to the survivor.
+func TestReapSupersededManifest_NarrowsInteriorRowOffItsHead(t *testing.T) {
 	const pid = "share/p"
 	ctx := context.Background()
 	tx := newManifestTx(pid)
@@ -145,21 +144,52 @@ func TestReapSupersededManifest_KeepsInteriorRowReachingPastRun(t *testing.T) {
 	require.Equal(t, [][2]int64{
 		{0, 2000},
 		{2000, 3000}, // the fresh row; the stale [2000, 2500) it replaced is gone
-		{2500, 6000}, // kept whole: its tail past 3000 has no other cover
+		{3000, 6000}, // narrowed off its head: it claimed [2500, 6000)
 	}, tiling(t, tx, pid))
 
-	// Below the spared row's start the fresh row is the greatest start and wins.
+	// The narrowed row reads its chunk from 500 bytes in — what it gave up.
+	rows, err := tx.ListFileChunks(ctx, pid)
+	require.NoError(t, err)
+	for _, r := range rows {
+		if r.ID == pid+"/3000" {
+			require.Equal(t, uint32(500), r.StartOffset)
+		}
+	}
+
+	// The whole run resolves to the fresh row, including the offsets the old row
+	// used to shadow.
 	require.Equal(t, int64(2000), resolveAt(t, tx, pid, 2000))
 	require.Equal(t, int64(2000), resolveAt(t, tx, pid, 2499))
-	// From that start to the run's end the spared row is the greatest start, so it
-	// wins over the fresh row: these offsets were re-carved, yet a read is served
-	// the pre-carve chunk. This is the stale window the reap cannot close.
-	require.Equal(t, int64(2500), resolveAt(t, tx, pid, 2500))
-	require.Equal(t, int64(2500), resolveAt(t, tx, pid, 2999))
-	// Past the run the spared row is the only cover, which is why it is kept.
-	require.Equal(t, int64(2500), resolveAt(t, tx, pid, 3000))
-	require.Equal(t, int64(2500), resolveAt(t, tx, pid, 5999))
+	require.Equal(t, int64(2000), resolveAt(t, tx, pid, 2500))
+	require.Equal(t, int64(2000), resolveAt(t, tx, pid, 2999))
+	// Past the run the narrowed row is the only cover, and it still reaches 6000.
+	require.Equal(t, int64(3000), resolveAt(t, tx, pid, 3000))
+	require.Equal(t, int64(3000), resolveAt(t, tx, pid, 5999))
 	require.Equal(t, int64(-1), resolveAt(t, tx, pid, 6000))
+}
+
+// TestReapSupersededManifest_SparesInteriorRowWhenItsNewKeyIsTaken pins the one
+// case the head narrow declines: another row already sits at the run's end, so
+// moving this one there would overwrite it and strand whatever it covers past
+// the mover's own end. The row is spared whole instead, which leaves its stale
+// cover in place — the outcome every interior straddler used to get.
+func TestReapSupersededManifest_SparesInteriorRowWhenItsNewKeyIsTaken(t *testing.T) {
+	const pid = "share/p"
+	ctx := context.Background()
+	tx := newManifestTx(pid)
+
+	// Two overlapping pre-run rows: [2500, 6000) and [3000, 4000).
+	seedRows(t, tx, pid, [][2]uint64{{0, 2000}, {2000, 500}, {2500, 3500}, {3000, 1000}})
+	seedRows(t, tx, pid, [][2]uint64{{2000, 1000}})
+	newOffsets := map[int64]struct{}{2000: {}}
+
+	require.NoError(t, ReapSupersededManifest(ctx, tx, pid, [][2]int64{{2000, 3000}}, newOffsets))
+	require.Equal(t, [][2]int64{
+		{0, 2000},
+		{2000, 3000},
+		{2500, 6000}, // spared: 3000 is taken, so it cannot move there
+		{3000, 4000},
+	}, tiling(t, tx, pid))
 }
 
 // TestReapSupersededManifest_LeavesDisjointRowsAlone keeps the reap from

--- a/pkg/metadata/store/internal/sqlcodec/sqlcodec.go
+++ b/pkg/metadata/store/internal/sqlcodec/sqlcodec.go
@@ -250,8 +250,8 @@ func FileRowToFileWithNlinkAndBlocks(r Row, withBlocks bool) (*metadata.File, er
 // validation as loadFileChunkRefs (a malformed hash is surfaced as an error,
 // never coerced to a half-decoded ref).
 func decodeChunkRefsJSON(raw []byte) ([]block.ChunkRef, error) {
-	// Element shape: [offset(int64), size(int32), hash_hex(string)].
-	var rows [][3]json.RawMessage
+	// Element shape: [offset(int64), size(int32), hash_hex(string), start(int32)].
+	var rows [][4]json.RawMessage
 	if err := json.Unmarshal(raw, &rows); err != nil {
 		return nil, fmt.Errorf("decode folded block refs: %w", err)
 	}
@@ -264,6 +264,7 @@ func decodeChunkRefsJSON(raw []byte) ([]block.ChunkRef, error) {
 			off     int64
 			sz      int32
 			hashHex string
+			start   int32
 		)
 		if err := json.Unmarshal(r[0], &off); err != nil {
 			return nil, fmt.Errorf("decode folded block ref offset: %w", err)
@@ -273,6 +274,9 @@ func decodeChunkRefsJSON(raw []byte) ([]block.ChunkRef, error) {
 		}
 		if err := json.Unmarshal(r[2], &hashHex); err != nil {
 			return nil, fmt.Errorf("decode folded block ref hash: %w", err)
+		}
+		if err := json.Unmarshal(r[3], &start); err != nil {
+			return nil, fmt.Errorf("decode folded block ref start offset: %w", err)
 		}
 		rawHash, err := hex.DecodeString(hashHex)
 		if err != nil {
@@ -288,6 +292,7 @@ func decodeChunkRefsJSON(raw []byte) ([]block.ChunkRef, error) {
 		copy(br.Hash[:], rawHash)
 		br.Offset = uint64(off)
 		br.Size = uint32(sz)
+		br.StartOffset = uint32(start)
 		out = append(out, br)
 	}
 	return out, nil

--- a/pkg/metadata/store/postgres/encoding.go
+++ b/pkg/metadata/store/postgres/encoding.go
@@ -24,12 +24,12 @@ func encodeFileHandle(shareName string, idStr string) (metadata.FileHandle, erro
 // a SELECT whose inode row is aliased `f` (it references f.id) and decode the
 // result with sqlcodec.FileRowToFileWithNlinkAndBlocks(row, true).
 //
-// Each element is [offset, size, hash_hex]; hash is encode(...,'hex') so the
+// Each element is [offset, size, hash_hex, start_offset]; hash is encode(...,'hex') so the
 // BYTEA round-trips byte-for-byte. An inode with no refs yields SQL NULL, which
 // decodes to a nil slice (parity with loadFileChunkRefs on an empty set).
 const blockRefsAggExpr = `(
 	SELECT json_agg(
-		json_build_array(fbr."offset", fbr.size, encode(fbr.hash, 'hex'))
+		json_build_array(fbr."offset", fbr.size, encode(fbr.hash, 'hex'), fbr.start_offset)
 		ORDER BY fbr."offset" ASC
 	)
 	FROM file_block_refs fbr

--- a/pkg/metadata/store/postgres/file_block_refs.go
+++ b/pkg/metadata/store/postgres/file_block_refs.go
@@ -67,9 +67,9 @@ func putFileChunkRefs(ctx context.Context, tx pgx.Tx, fileID uuid.UUID, blocks [
 	}
 	for _, b := range upserts {
 		batch.Queue(
-			`INSERT INTO file_block_refs (file_id, "offset", size, hash) VALUES ($1, $2, $3, $4)
-			 ON CONFLICT (file_id, "offset") DO UPDATE SET size = excluded.size, hash = excluded.hash`,
-			fileID, int64(b.Offset), int32(b.Size), b.Hash[:],
+			`INSERT INTO file_block_refs (file_id, "offset", size, hash, start_offset) VALUES ($1, $2, $3, $4, $5)
+			 ON CONFLICT (file_id, "offset") DO UPDATE SET size = excluded.size, hash = excluded.hash, start_offset = excluded.start_offset`,
+			fileID, int64(b.Offset), int32(b.Size), b.Hash[:], int32(b.StartOffset),
 		)
 	}
 
@@ -89,8 +89,9 @@ func putFileChunkRefs(ctx context.Context, tx pgx.Tx, fileID uuid.UUID, blocks [
 
 // storedChunkRef is a stored file_block_refs row minus its offset (the map key).
 type storedChunkRef struct {
-	size int32
-	hash []byte
+	size  int32
+	start int32
+	hash  []byte
 }
 
 // fileChunkRefsDelta diffs blocks against the rows currently stored for fileID
@@ -117,7 +118,7 @@ func fileChunkRefsDelta(ctx context.Context, tx pgx.Tx, fileID uuid.UUID, blocks
 
 	stored := make(map[int64]storedChunkRef)
 	if hasPriorRefs && (inScope == nil || len(inScope) > 0) {
-		query := `SELECT "offset", size, hash FROM file_block_refs WHERE file_id = $1`
+		query := `SELECT "offset", size, hash, start_offset FROM file_block_refs WHERE file_id = $1`
 		args := []any{fileID}
 		if inScope != nil {
 			query += ` AND "offset" = ANY($2)`
@@ -134,14 +135,14 @@ func fileChunkRefsDelta(ctx context.Context, tx pgx.Tx, fileID uuid.UUID, blocks
 		defer rows.Close()
 		for rows.Next() {
 			var off int64
-			var sz int32
+			var sz, start int32
 			var raw []byte
-			if err := rows.Scan(&off, &sz, &raw); err != nil {
+			if err := rows.Scan(&off, &sz, &raw, &start); err != nil {
 				return nil, nil, len(stored), fmt.Errorf("scan file_block_ref: %w", err)
 			}
 			h := make([]byte, len(raw))
 			copy(h, raw)
-			stored[off] = storedChunkRef{size: sz, hash: h}
+			stored[off] = storedChunkRef{size: sz, start: start, hash: h}
 		}
 		if err := rows.Err(); err != nil {
 			return nil, nil, len(stored), fmt.Errorf("iterate file_block_refs: %w", err)
@@ -158,7 +159,7 @@ func fileChunkRefsDelta(ctx context.Context, tx pgx.Tx, fileID uuid.UUID, blocks
 			}
 		}
 		incoming[off] = struct{}{}
-		if s, ok := stored[off]; ok && s.size == int32(b.Size) && bytes.Equal(s.hash, b.Hash[:]) {
+		if s, ok := stored[off]; ok && s.size == int32(b.Size) && s.start == int32(b.StartOffset) && bytes.Equal(s.hash, b.Hash[:]) {
 			continue // identical row already stored — no write
 		}
 		upserts = append(upserts, b)
@@ -209,7 +210,7 @@ func deleteFileChunkRefs(ctx context.Context, tx pgx.Tx, fileID uuid.UUID) error
 // rows into its metadata read via blockRefsAggExpr (#1176).
 func (s *PostgresMetadataStore) loadFileChunkRefs(ctx context.Context, fileID uuid.UUID) ([]block.ChunkRef, error) {
 	rows, err := s.query(ctx,
-		`SELECT "offset", size, hash FROM file_block_refs WHERE file_id = $1 ORDER BY "offset" ASC`,
+		`SELECT "offset", size, hash, start_offset FROM file_block_refs WHERE file_id = $1 ORDER BY "offset" ASC`,
 		fileID,
 	)
 	if err != nil {
@@ -220,9 +221,9 @@ func (s *PostgresMetadataStore) loadFileChunkRefs(ctx context.Context, fileID uu
 	var out []block.ChunkRef
 	for rows.Next() {
 		var off int64
-		var sz int32
+		var sz, start int32
 		var raw []byte
-		if err := rows.Scan(&off, &sz, &raw); err != nil {
+		if err := rows.Scan(&off, &sz, &raw, &start); err != nil {
 			return nil, fmt.Errorf("scan file_block_ref: %w", err)
 		}
 		if len(raw) != block.HashSize {
@@ -235,6 +236,7 @@ func (s *PostgresMetadataStore) loadFileChunkRefs(ctx context.Context, fileID uu
 		copy(br.Hash[:], raw)
 		br.Offset = uint64(off)
 		br.Size = uint32(sz)
+		br.StartOffset = uint32(start)
 		out = append(out, br)
 	}
 	if err := rows.Err(); err != nil {

--- a/pkg/metadata/store/postgres/migrations/000045_file_blocks_start_offset.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000045_file_blocks_start_offset.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE file_block_refs DROP COLUMN IF EXISTS start_offset;
+ALTER TABLE file_blocks DROP COLUMN IF EXISTS start_offset;

--- a/pkg/metadata/store/postgres/migrations/000045_file_blocks_start_offset.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000045_file_blocks_start_offset.up.sql
@@ -1,0 +1,15 @@
+-- A manifest row claims [rowOffset, rowOffset+data_size) of the file, served by
+-- the chunk's bytes starting at start_offset. Zero means the claim begins at the
+-- chunk's first byte, which is what every existing row means and what every row
+-- a carve writes still means, so the default backfills the whole table
+-- correctly and no rewrite is needed.
+--
+-- A non-zero value comes from narrowing a row off its head, which a carve span
+-- ending inside a row that also starts inside it needs: the row keeps only what
+-- lies past the span, and its id moves to the first byte it still claims.
+ALTER TABLE file_blocks ADD COLUMN IF NOT EXISTS start_offset INTEGER NOT NULL DEFAULT 0;
+
+-- Same offset on the FileAttr.Blocks projection: a clone and a manifest repair
+-- rebuild rows from it, so a ref that dropped the offset would rebuild a row
+-- serving the chunk's head at the ref's offset.
+ALTER TABLE file_block_refs ADD COLUMN IF NOT EXISTS start_offset INTEGER NOT NULL DEFAULT 0;

--- a/pkg/metadata/store/postgres/objects.go
+++ b/pkg/metadata/store/postgres/objects.go
@@ -43,7 +43,7 @@ var _ block.FileChunkStore = (*PostgresMetadataStore)(nil)
 // FileChunkStore interface; kept as a backend
 // method for engine-internal callers.
 func (s *PostgresMetadataStore) GetFileChunk(ctx context.Context, id string) (*metadata.FileChunk, error) {
-	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
+	query := `SELECT id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at
 		FROM file_blocks WHERE id = $1`
 	row := s.queryRow(ctx, query, id)
 
@@ -93,16 +93,17 @@ func (s *PostgresMetadataStore) Put(ctx context.Context, block *metadata.FileChu
 	// Increment/Decrement. hash uses COALESCE so a zero-hash Put never NULLs
 	// a previously-persisted good hash.
 	query := `
-		INSERT INTO file_blocks (id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		INSERT INTO file_blocks (id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		ON CONFLICT (id) DO UPDATE SET
 			hash = COALESCE(EXCLUDED.hash, file_blocks.hash),
 			data_size = EXCLUDED.data_size,
+			start_offset = EXCLUDED.start_offset,
 			last_access = EXCLUDED.last_access,
 			state = EXCLUDED.state,
 			last_sync_attempt_at = EXCLUDED.last_sync_attempt_at`
 	_, err := s.exec(ctx, query,
-		block.ID, hashStr, block.DataSize,
+		block.ID, hashStr, block.DataSize, block.StartOffset,
 		block.RefCount, block.LastAccess, block.CreatedAt, block.State, lastSyncAttemptAt)
 	if err != nil {
 		return fmt.Errorf("put file chunk: %w", err)
@@ -249,7 +250,7 @@ func (s *PostgresMetadataStore) AddRef(ctx context.Context, hash block.ContentHa
 // (state=2) blocks — Pending or Syncing rows have not been confirmed on
 // the remote and are unsafe dedup targets.
 func (s *PostgresMetadataStore) GetByHash(ctx context.Context, hash metadata.ContentHash) (*metadata.FileChunk, error) {
-	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
+	query := `SELECT id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at
 		FROM file_blocks WHERE hash = $1 AND state = 2 /* Remote */`
 	row := s.queryRow(ctx, query, hash.String())
 
@@ -270,7 +271,7 @@ func (s *PostgresMetadataStore) GetByHash(ctx context.Context, hash metadata.Con
 // default: the bounds only bracket the prefix under byte ordering, and a
 // byte-ordered id column lets the primary-key index seek the range instead of
 // filtering the whole table.
-const listFileChunksQuery = `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
+const listFileChunksQuery = `SELECT id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at
 	FROM file_blocks
 	WHERE id >= $1 COLLATE "C" AND id < $2 COLLATE "C"
 	ORDER BY id COLLATE "C" ASC`
@@ -450,7 +451,7 @@ func scanFileChunk(row pgx.Row) (*metadata.FileChunk, error) {
 		hashStr           sql.NullString
 		lastSyncAttemptAt sql.NullTime
 	)
-	if err := row.Scan(&block.ID, &hashStr, &block.DataSize,
+	if err := row.Scan(&block.ID, &hashStr, &block.DataSize, &block.StartOffset,
 		&block.RefCount, &block.LastAccess, &block.CreatedAt, &block.State, &lastSyncAttemptAt); err != nil {
 		return nil, err
 	}
@@ -503,7 +504,7 @@ func (tx *postgresTransaction) GetFileChunk(ctx context.Context, id string) (*me
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
+	query := `SELECT id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at
 		FROM file_blocks WHERE id = $1`
 	row := tx.tx.QueryRow(ctx, query, id)
 	block, err := scanFileChunk(row)
@@ -534,16 +535,17 @@ func (tx *postgresTransaction) Put(ctx context.Context, block *metadata.FileChun
 	// Put). RefCount mutates only via Increment/Decrement. hash uses COALESCE
 	// so a zero-hash Put never NULLs a previously-persisted good hash.
 	query := `
-		INSERT INTO file_blocks (id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		INSERT INTO file_blocks (id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		ON CONFLICT (id) DO UPDATE SET
 			hash = COALESCE(EXCLUDED.hash, file_blocks.hash),
 			data_size = EXCLUDED.data_size,
+			start_offset = EXCLUDED.start_offset,
 			last_access = EXCLUDED.last_access,
 			state = EXCLUDED.state,
 			last_sync_attempt_at = EXCLUDED.last_sync_attempt_at`
 	_, err := tx.tx.Exec(ctx, query,
-		block.ID, hashStr, block.DataSize,
+		block.ID, hashStr, block.DataSize, block.StartOffset,
 		block.RefCount, block.LastAccess, block.CreatedAt, block.State, lastSyncAttemptAt)
 	if err != nil {
 		return fmt.Errorf("put file chunk: %w", err)
@@ -640,7 +642,7 @@ func (tx *postgresTransaction) GetByHash(ctx context.Context, hash metadata.Cont
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	query := `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
+	query := `SELECT id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at
 		FROM file_blocks WHERE hash = $1 AND state = 2 /* Remote */`
 	row := tx.tx.QueryRow(ctx, query, hash.String())
 	block, err := scanFileChunk(row)
@@ -716,10 +718,10 @@ func (tx *postgresTransaction) EnumerateFileChunks(ctx context.Context, fn func(
 func (s *PostgresMetadataStore) InjectCorruptHashRow(ctx context.Context, blockID string, badHash string) error {
 	now := time.Now()
 	_, err := s.exec(ctx, `
-		INSERT INTO file_blocks (id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		INSERT INTO file_blocks (id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		ON CONFLICT (id) DO UPDATE SET hash = EXCLUDED.hash`,
-		blockID, badHash, uint32(64), uint32(1), now, now, int(block.BlockStateRemote), nil,
+		blockID, badHash, uint32(64), uint32(0), uint32(1), now, now, int(block.BlockStateRemote), nil,
 	)
 	if err != nil {
 		return fmt.Errorf("inject corrupt hash row: %w", err)

--- a/pkg/metadata/store/postgres/objects.go
+++ b/pkg/metadata/store/postgres/objects.go
@@ -39,13 +39,39 @@ var _ block.FileChunkStore = (*PostgresMetadataStore)(nil)
 // FileChunk Operations
 // ============================================================================
 
+// fileChunkColumns is the file_blocks column list every chunk read and write
+// names, in the order scanFileChunk reads them. Naming it once is what keeps a
+// column added to one query from being missed by the others, or by the scan.
+const fileChunkColumns = `id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at`
+
+const (
+	selectFileChunkByID   = `SELECT ` + fileChunkColumns + ` FROM file_blocks WHERE id = $1`
+	selectFileChunkByHash = `SELECT ` + fileChunkColumns + ` FROM file_blocks WHERE hash = $1 AND state = 2 /* Remote */`
+	insertFileChunk       = `INSERT INTO file_blocks (` + fileChunkColumns + `) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`
+)
+
+// putFileChunkQuery omits ref_count from the ON CONFLICT UPDATE list so
+// concurrent IncrementRefCount / DecrementRefCount (which run as atomic SQL
+// `+1` / `-1` UPDATEs) cannot be silently overwritten by a stale
+// Put-with-in-memory-RefCount. RefCount on the INSERT path is still set
+// verbatim from the caller's *FileChunk (matches the contract for new rows).
+// For existing rows, RefCount mutates exclusively through Increment/Decrement.
+// hash uses COALESCE so a zero-hash Put never NULLs a previously-persisted good
+// hash.
+const putFileChunkQuery = insertFileChunk + `
+	ON CONFLICT (id) DO UPDATE SET
+		hash = COALESCE(EXCLUDED.hash, file_blocks.hash),
+		data_size = EXCLUDED.data_size,
+		start_offset = EXCLUDED.start_offset,
+		last_access = EXCLUDED.last_access,
+		state = EXCLUDED.state,
+		last_sync_attempt_at = EXCLUDED.last_sync_attempt_at`
+
 // GetFileChunk retrieves a file chunk by its ID. Not on the narrowed
 // FileChunkStore interface; kept as a backend
 // method for engine-internal callers.
 func (s *PostgresMetadataStore) GetFileChunk(ctx context.Context, id string) (*metadata.FileChunk, error) {
-	query := `SELECT id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at
-		FROM file_blocks WHERE id = $1`
-	row := s.queryRow(ctx, query, id)
+	row := s.queryRow(ctx, selectFileChunkByID, id)
 
 	block, err := scanFileChunk(row)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -84,25 +110,7 @@ func (s *PostgresMetadataStore) Put(ctx context.Context, block *metadata.FileChu
 		lastSyncAttemptAt = &t
 	}
 
-	// Omit ref_count from the ON CONFLICT UPDATE list so concurrent
-	// IncrementRefCount / DecrementRefCount (which run as atomic SQL `+1` /
-	// `-1` UPDATEs) cannot be silently overwritten by a stale
-	// Put-with-in-memory-RefCount. RefCount on the INSERT path is still set
-	// verbatim from the caller's *FileChunk (matches the contract for new
-	// rows). For existing rows, RefCount mutates exclusively through
-	// Increment/Decrement. hash uses COALESCE so a zero-hash Put never NULLs
-	// a previously-persisted good hash.
-	query := `
-		INSERT INTO file_blocks (id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-		ON CONFLICT (id) DO UPDATE SET
-			hash = COALESCE(EXCLUDED.hash, file_blocks.hash),
-			data_size = EXCLUDED.data_size,
-			start_offset = EXCLUDED.start_offset,
-			last_access = EXCLUDED.last_access,
-			state = EXCLUDED.state,
-			last_sync_attempt_at = EXCLUDED.last_sync_attempt_at`
-	_, err := s.exec(ctx, query,
+	_, err := s.exec(ctx, putFileChunkQuery,
 		block.ID, hashStr, block.DataSize, block.StartOffset,
 		block.RefCount, block.LastAccess, block.CreatedAt, block.State, lastSyncAttemptAt)
 	if err != nil {
@@ -250,9 +258,7 @@ func (s *PostgresMetadataStore) AddRef(ctx context.Context, hash block.ContentHa
 // (state=2) blocks — Pending or Syncing rows have not been confirmed on
 // the remote and are unsafe dedup targets.
 func (s *PostgresMetadataStore) GetByHash(ctx context.Context, hash metadata.ContentHash) (*metadata.FileChunk, error) {
-	query := `SELECT id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at
-		FROM file_blocks WHERE hash = $1 AND state = 2 /* Remote */`
-	row := s.queryRow(ctx, query, hash.String())
+	row := s.queryRow(ctx, selectFileChunkByHash, hash.String())
 
 	block, err := scanFileChunk(row)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -271,7 +277,7 @@ func (s *PostgresMetadataStore) GetByHash(ctx context.Context, hash metadata.Con
 // default: the bounds only bracket the prefix under byte ordering, and a
 // byte-ordered id column lets the primary-key index seek the range instead of
 // filtering the whole table.
-const listFileChunksQuery = `SELECT id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at
+const listFileChunksQuery = `SELECT ` + fileChunkColumns + `
 	FROM file_blocks
 	WHERE id >= $1 COLLATE "C" AND id < $2 COLLATE "C"
 	ORDER BY id COLLATE "C" ASC`
@@ -504,9 +510,7 @@ func (tx *postgresTransaction) GetFileChunk(ctx context.Context, id string) (*me
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	query := `SELECT id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at
-		FROM file_blocks WHERE id = $1`
-	row := tx.tx.QueryRow(ctx, query, id)
+	row := tx.tx.QueryRow(ctx, selectFileChunkByID, id)
 	block, err := scanFileChunk(row)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, metadata.ErrFileChunkNotFound
@@ -531,20 +535,7 @@ func (tx *postgresTransaction) Put(ctx context.Context, block *metadata.FileChun
 		t := block.LastSyncAttemptAt
 		lastSyncAttemptAt = &t
 	}
-	// Omit ref_count from the ON CONFLICT update list (matches the pool-path
-	// Put). RefCount mutates only via Increment/Decrement. hash uses COALESCE
-	// so a zero-hash Put never NULLs a previously-persisted good hash.
-	query := `
-		INSERT INTO file_blocks (id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-		ON CONFLICT (id) DO UPDATE SET
-			hash = COALESCE(EXCLUDED.hash, file_blocks.hash),
-			data_size = EXCLUDED.data_size,
-			start_offset = EXCLUDED.start_offset,
-			last_access = EXCLUDED.last_access,
-			state = EXCLUDED.state,
-			last_sync_attempt_at = EXCLUDED.last_sync_attempt_at`
-	_, err := tx.tx.Exec(ctx, query,
+	_, err := tx.tx.Exec(ctx, putFileChunkQuery,
 		block.ID, hashStr, block.DataSize, block.StartOffset,
 		block.RefCount, block.LastAccess, block.CreatedAt, block.State, lastSyncAttemptAt)
 	if err != nil {
@@ -642,9 +633,7 @@ func (tx *postgresTransaction) GetByHash(ctx context.Context, hash metadata.Cont
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	query := `SELECT id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at
-		FROM file_blocks WHERE hash = $1 AND state = 2 /* Remote */`
-	row := tx.tx.QueryRow(ctx, query, hash.String())
+	row := tx.tx.QueryRow(ctx, selectFileChunkByHash, hash.String())
 	block, err := scanFileChunk(row)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
@@ -717,10 +706,7 @@ func (tx *postgresTransaction) EnumerateFileChunks(ctx context.Context, fn func(
 // Put contract that always serializes a valid ContentHash.String().
 func (s *PostgresMetadataStore) InjectCorruptHashRow(ctx context.Context, blockID string, badHash string) error {
 	now := time.Now()
-	_, err := s.exec(ctx, `
-		INSERT INTO file_blocks (id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-		ON CONFLICT (id) DO UPDATE SET hash = EXCLUDED.hash`,
+	_, err := s.exec(ctx, insertFileChunk+` ON CONFLICT (id) DO UPDATE SET hash = EXCLUDED.hash`,
 		blockID, badHash, uint32(64), uint32(0), uint32(1), now, now, int(block.BlockStateRemote), nil,
 	)
 	if err != nil {

--- a/pkg/metadata/store/postgres/snapshot_store.go
+++ b/pkg/metadata/store/postgres/snapshot_store.go
@@ -45,7 +45,13 @@ const (
 	// file_blocks is in backupTables, so the dumped row shape changes one column.
 	// v9 drops the dead pending_writes table (migration 000042), lowering the
 	// backup table count by one.
-	postgresSchemaVersion = uint32(9)
+	// v10 adds the start_offset column to file_blocks AND file_block_refs
+	// (migration 000045); both are in backupTables, so two dumped row shapes gain
+	// a column. The COPY here names no column list, so a restore matches columns
+	// by position and an older stream would run out of values partway through the
+	// row rather than default the new column — the version gate is what turns
+	// that into a legible refusal.
+	postgresSchemaVersion = uint32(10)
 )
 
 // backupTables lists every metadata table in FK-safe dependency order

--- a/pkg/metadata/store/sqlite/encoding.go
+++ b/pkg/metadata/store/sqlite/encoding.go
@@ -24,7 +24,7 @@ func encodeFileHandle(shareName string, idStr string) (metadata.FileHandle, erro
 // a SELECT whose inode row is aliased `f` (it references f.id) and decode the
 // result with sqlcodec.FileRowToFileWithNlinkAndBlocks(row, true).
 //
-// Each element is [offset, size, hash_hex]; hash is lower(hex(...)) so the
+// Each element is [offset, size, hash_hex, start_offset]; hash is lower(hex(...)) so the
 // BLOB round-trips byte-for-byte. An inode with no refs yields a JSON empty
 // array '[]', which decodes to a nil slice (parity with loadFileChunkRefs on an
 // empty set).
@@ -32,9 +32,9 @@ func encodeFileHandle(shareName string, idStr string) (metadata.FileHandle, erro
 // SQLite's json_group_array does not accept an inner ORDER BY, so the rows are
 // ordered by "offset" ASC in a derived subquery before aggregation.
 const blockRefsAggExpr = `(
-	SELECT json_group_array(json_array(fbr."offset", fbr.size, lower(hex(fbr.hash))))
+	SELECT json_group_array(json_array(fbr."offset", fbr.size, lower(hex(fbr.hash)), fbr.start_offset))
 	FROM (
-		SELECT "offset", size, hash
+		SELECT "offset", size, hash, start_offset
 		FROM file_block_refs
 		WHERE file_id = f.id
 		ORDER BY "offset" ASC

--- a/pkg/metadata/store/sqlite/file_block_refs.go
+++ b/pkg/metadata/store/sqlite/file_block_refs.go
@@ -68,12 +68,13 @@ func putFileChunkRefs(ctx context.Context, tx execer, fileID uuid.UUID, blocks [
 
 // storedChunkRef is a stored file_block_refs row minus its offset (the map key).
 type storedChunkRef struct {
-	size int32
-	hash []byte
+	size  int32
+	start int32
+	hash  []byte
 }
 
 // fileChunkRefsDelta diffs blocks against the rows currently stored for fileID
-// and returns the refs to UPSERT (new offset, or changed size/hash) and the
+// and returns the refs to UPSERT (new offset, or changed size/start/hash) and the
 // stored offsets to DELETE (absent from blocks). When hasPriorRefs is false the
 // stored set is known-empty, so the query is skipped and every ref is an
 // upsert. Offsets are unique under the (file_id, "offset") PK, so keying the
@@ -111,7 +112,7 @@ func fileChunkRefsDelta(ctx context.Context, tx execer, fileID uuid.UUID, blocks
 			}
 		}
 		incoming[off] = struct{}{}
-		if s, ok := stored[off]; ok && s.size == int32(b.Size) && bytes.Equal(s.hash, b.Hash[:]) {
+		if s, ok := stored[off]; ok && s.size == int32(b.Size) && s.start == int32(b.StartOffset) && bytes.Equal(s.hash, b.Hash[:]) {
 			continue // identical row already stored — no write
 		}
 		upserts = append(upserts, b)
@@ -130,7 +131,7 @@ func fileChunkRefsDelta(ctx context.Context, tx execer, fileID uuid.UUID, blocks
 // batches capped the same way as the write helpers so the bound-parameter count
 // stays under SQLite's default limit.
 func scanStoredChunkRefs(ctx context.Context, tx execer, fileID uuid.UUID, inScope map[int64]struct{}, out map[int64]storedChunkRef) error {
-	const selectRefs = `SELECT "offset", size, hash FROM file_block_refs WHERE file_id = ?`
+	const selectRefs = `SELECT "offset", size, start_offset, hash FROM file_block_refs WHERE file_id = ?`
 	if inScope == nil {
 		return scanChunkRefBatch(ctx, tx, fileID, selectRefs, []any{fileID}, out)
 	}
@@ -170,14 +171,14 @@ func scanChunkRefBatch(ctx context.Context, tx execer, fileID uuid.UUID, query s
 	defer rows.Close()
 	for rows.Next() {
 		var off int64
-		var sz int32
+		var sz, start int32
 		var raw []byte
-		if err := rows.Scan(&off, &sz, &raw); err != nil {
+		if err := rows.Scan(&off, &sz, &start, &raw); err != nil {
 			return fmt.Errorf("scan file_block_ref: %w", err)
 		}
 		h := make([]byte, len(raw))
 		copy(h, raw)
-		out[off] = storedChunkRef{size: sz, hash: h}
+		out[off] = storedChunkRef{size: sz, start: start, hash: h}
 	}
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("iterate file_block_refs: %w", err)
@@ -217,11 +218,11 @@ func deleteChunkRefOffsets(ctx context.Context, tx execer, fileID uuid.UUID, off
 
 // upsertChunkRefs inserts-or-updates the given refs for fileID with a multi-row
 // INSERT ... ON CONFLICT per batch instead of one Exec per ref. Batches are
-// capped so the bound-parameter count stays under SQLite's default limit; 4
-// columns per row → 200 rows = 800 params. Incoming offsets are unique under
+// capped so the bound-parameter count stays under SQLite's default limit; 5
+// columns per row → 200 rows = 1000 params. Incoming offsets are unique under
 // the (file_id, "offset") PK, so no batch upserts the same row twice.
 func upsertChunkRefs(ctx context.Context, tx execer, fileID uuid.UUID, refs []block.ChunkRef) error {
-	const colsPerRow = 4
+	const colsPerRow = 5
 	const rowsPerBatch = 200
 	for start := 0; start < len(refs); start += rowsPerBatch {
 		end := start + rowsPerBatch
@@ -230,16 +231,16 @@ func upsertChunkRefs(ctx context.Context, tx execer, fileID uuid.UUID, refs []bl
 		}
 		batch := refs[start:end]
 		var sb strings.Builder
-		sb.WriteString(`INSERT INTO file_block_refs (file_id, "offset", size, hash) VALUES `)
+		sb.WriteString(`INSERT INTO file_block_refs (file_id, "offset", size, start_offset, hash) VALUES `)
 		args := make([]any, 0, len(batch)*colsPerRow)
 		for i, b := range batch {
 			if i > 0 {
 				sb.WriteByte(',')
 			}
-			sb.WriteString("(?, ?, ?, ?)")
-			args = append(args, fileID, int64(b.Offset), int32(b.Size), b.Hash[:])
+			sb.WriteString("(?, ?, ?, ?, ?)")
+			args = append(args, fileID, int64(b.Offset), int32(b.Size), int32(b.StartOffset), b.Hash[:])
 		}
-		sb.WriteString(` ON CONFLICT (file_id, "offset") DO UPDATE SET size = excluded.size, hash = excluded.hash`)
+		sb.WriteString(` ON CONFLICT (file_id, "offset") DO UPDATE SET size = excluded.size, start_offset = excluded.start_offset, hash = excluded.hash`)
 		if _, err := tx.Exec(ctx, sb.String(), args...); err != nil {
 			return fmt.Errorf("upsert file_block_refs batch: %w", err)
 		}

--- a/pkg/metadata/store/sqlite/file_block_refs.go
+++ b/pkg/metadata/store/sqlite/file_block_refs.go
@@ -66,6 +66,11 @@ func putFileChunkRefs(ctx context.Context, tx execer, fileID uuid.UUID, blocks [
 	return true, scanned, nil
 }
 
+// maxBoundParams is the ceiling a multi-row statement's batch size is derived
+// from: SQLite's default SQLITE_MAX_VARIABLE_NUMBER is 999, and the margin leaves
+// room for a statement that binds a value outside its per-row group.
+const maxBoundParams = 900
+
 // storedChunkRef is a stored file_block_refs row minus its offset (the map key).
 type storedChunkRef struct {
 	size  int32
@@ -218,12 +223,15 @@ func deleteChunkRefOffsets(ctx context.Context, tx execer, fileID uuid.UUID, off
 
 // upsertChunkRefs inserts-or-updates the given refs for fileID with a multi-row
 // INSERT ... ON CONFLICT per batch instead of one Exec per ref. Batches are
-// capped so the bound-parameter count stays under SQLite's default limit; 5
-// columns per row → 200 rows = 1000 params. Incoming offsets are unique under
-// the (file_id, "offset") PK, so no batch upserts the same row twice.
+// capped so the bound-parameter count stays under SQLite's default limit of 999,
+// which is why the row count is DERIVED from the column count rather than fixed:
+// a column added to the statement shrinks the batch instead of pushing it over
+// the cap, where the whole Exec would fail with "too many SQL variables".
+// Incoming offsets are unique under the (file_id, "offset") PK, so no batch
+// upserts the same row twice.
 func upsertChunkRefs(ctx context.Context, tx execer, fileID uuid.UUID, refs []block.ChunkRef) error {
 	const colsPerRow = 5
-	const rowsPerBatch = 200
+	const rowsPerBatch = maxBoundParams / colsPerRow
 	for start := 0; start < len(refs); start += rowsPerBatch {
 		end := start + rowsPerBatch
 		if end > len(refs) {

--- a/pkg/metadata/store/sqlite/migrations/000009_file_blocks_start_offset.down.sql
+++ b/pkg/metadata/store/sqlite/migrations/000009_file_blocks_start_offset.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE file_block_refs DROP COLUMN start_offset;
+ALTER TABLE file_blocks DROP COLUMN start_offset;

--- a/pkg/metadata/store/sqlite/migrations/000009_file_blocks_start_offset.up.sql
+++ b/pkg/metadata/store/sqlite/migrations/000009_file_blocks_start_offset.up.sql
@@ -1,0 +1,15 @@
+-- A manifest row claims [rowOffset, rowOffset+data_size) of the file, served by
+-- the chunk's bytes starting at start_offset. Zero means the claim begins at the
+-- chunk's first byte, which is what every existing row means and what every row
+-- a carve writes still means, so the default backfills the whole table
+-- correctly and no rewrite is needed.
+--
+-- A non-zero value comes from narrowing a row off its head, which a carve span
+-- ending inside a row that also starts inside it needs: the row keeps only what
+-- lies past the span, and its id moves to the first byte it still claims.
+ALTER TABLE file_blocks ADD COLUMN start_offset INTEGER NOT NULL DEFAULT 0;
+
+-- Same offset on the FileAttr.Blocks projection: a clone and a manifest repair
+-- rebuild rows from it, so a ref that dropped the offset would rebuild a row
+-- serving the chunk's head at the ref's offset.
+ALTER TABLE file_block_refs ADD COLUMN start_offset INTEGER NOT NULL DEFAULT 0;

--- a/pkg/metadata/store/sqlite/objects.go
+++ b/pkg/metadata/store/sqlite/objects.go
@@ -100,11 +100,19 @@ func (s *SQLiteMetadataStore) DecrementRefCountAndReap(ctx context.Context, id s
 // the transaction path run them over their own executor, so the two surfaces
 // cannot drift apart.
 
+// fileChunkColumns is the file_blocks column list every chunk read and write
+// names, in the order scanFileChunk reads them. Naming it once is what keeps a
+// column added to one query from being missed by the others, or by the scan.
+const fileChunkColumns = `id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at`
+
+// insertFileChunk is the INSERT the row writers share; each appends its own
+// ON CONFLICT clause.
+const insertFileChunk = `INSERT INTO file_blocks (` + fileChunkColumns + `) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)`
+
 // getFileChunkTx reads one chunk row by ID, mapping a missing row to
 // ErrFileChunkNotFound.
 func getFileChunkTx(ctx context.Context, x execer, id string) (*metadata.FileChunk, error) {
-	row := x.QueryRow(ctx, `SELECT id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at
-		FROM file_blocks WHERE id = ?1`, id)
+	row := x.QueryRow(ctx, `SELECT `+fileChunkColumns+` FROM file_blocks WHERE id = ?1`, id)
 	chunk, err := scanFileChunk(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, metadata.ErrFileChunkNotFound
@@ -135,9 +143,7 @@ func putFileChunkTx(ctx context.Context, x execer, chunk *metadata.FileChunk) er
 		t := chunk.LastSyncAttemptAt
 		lastSyncAttemptAt = &t
 	}
-	_, err := x.Exec(ctx, `
-		INSERT INTO file_blocks (id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at)
-		VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+	_, err := x.Exec(ctx, insertFileChunk+`
 		ON CONFLICT (id) DO UPDATE SET
 			hash = COALESCE(EXCLUDED.hash, file_blocks.hash),
 			data_size = EXCLUDED.data_size,
@@ -212,8 +218,7 @@ func addRefTx(ctx context.Context, x execer, hash block.ContentHash) error {
 // getByHashTx resolves a Remote chunk by content hash, returning (nil, nil)
 // when none matches.
 func getByHashTx(ctx context.Context, x execer, hash metadata.ContentHash) (*metadata.FileChunk, error) {
-	row := x.QueryRow(ctx, `SELECT id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at
-		FROM file_blocks WHERE hash = ?1 AND state = 2 /* Remote */`, hash.String())
+	row := x.QueryRow(ctx, `SELECT `+fileChunkColumns+` FROM file_blocks WHERE hash = ?1 AND state = 2 /* Remote */`, hash.String())
 	chunk, err := scanFileChunk(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
@@ -303,7 +308,7 @@ func (s *SQLiteMetadataStore) GetByHash(ctx context.Context, hash metadata.Conte
 // default: the bounds only bracket the prefix under byte ordering, and a
 // byte-ordered id column lets the primary-key index seek the range instead of
 // filtering the whole table.
-const listFileChunksQuery = `SELECT id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at
+const listFileChunksQuery = `SELECT ` + fileChunkColumns + `
 	FROM file_blocks
 	WHERE id >= ?1 COLLATE BINARY AND id < ?2 COLLATE BINARY
 	ORDER BY id COLLATE BINARY ASC`
@@ -640,10 +645,7 @@ func (tx *sqliteTransaction) EnumerateFileChunks(ctx context.Context, fn func(bl
 // Put contract that always serializes a valid ContentHash.String().
 func (s *SQLiteMetadataStore) InjectCorruptHashRow(ctx context.Context, blockID string, badHash string) error {
 	now := time.Now()
-	_, err := s.exec(ctx, `
-		INSERT INTO file_blocks (id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at)
-		VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
-		ON CONFLICT (id) DO UPDATE SET hash = EXCLUDED.hash`,
+	_, err := s.exec(ctx, insertFileChunk+` ON CONFLICT (id) DO UPDATE SET hash = EXCLUDED.hash`,
 		blockID, badHash, uint32(64), uint32(0), uint32(1), now, now, int(block.BlockStateRemote), nil,
 	)
 	if err != nil {

--- a/pkg/metadata/store/sqlite/objects.go
+++ b/pkg/metadata/store/sqlite/objects.go
@@ -103,7 +103,7 @@ func (s *SQLiteMetadataStore) DecrementRefCountAndReap(ctx context.Context, id s
 // getFileChunkTx reads one chunk row by ID, mapping a missing row to
 // ErrFileChunkNotFound.
 func getFileChunkTx(ctx context.Context, x execer, id string) (*metadata.FileChunk, error) {
-	row := x.QueryRow(ctx, `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
+	row := x.QueryRow(ctx, `SELECT id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at
 		FROM file_blocks WHERE id = ?1`, id)
 	chunk, err := scanFileChunk(row)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -136,15 +136,16 @@ func putFileChunkTx(ctx context.Context, x execer, chunk *metadata.FileChunk) er
 		lastSyncAttemptAt = &t
 	}
 	_, err := x.Exec(ctx, `
-		INSERT INTO file_blocks (id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at)
-		VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+		INSERT INTO file_blocks (id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at)
+		VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
 		ON CONFLICT (id) DO UPDATE SET
 			hash = COALESCE(EXCLUDED.hash, file_blocks.hash),
 			data_size = EXCLUDED.data_size,
+			start_offset = EXCLUDED.start_offset,
 			last_access = EXCLUDED.last_access,
 			state = EXCLUDED.state,
 			last_sync_attempt_at = EXCLUDED.last_sync_attempt_at`,
-		chunk.ID, hashStr, chunk.DataSize,
+		chunk.ID, hashStr, chunk.DataSize, chunk.StartOffset,
 		chunk.RefCount, chunk.LastAccess, chunk.CreatedAt, chunk.State, lastSyncAttemptAt)
 	if err != nil {
 		return fmt.Errorf("put file chunk: %w", err)
@@ -211,7 +212,7 @@ func addRefTx(ctx context.Context, x execer, hash block.ContentHash) error {
 // getByHashTx resolves a Remote chunk by content hash, returning (nil, nil)
 // when none matches.
 func getByHashTx(ctx context.Context, x execer, hash metadata.ContentHash) (*metadata.FileChunk, error) {
-	row := x.QueryRow(ctx, `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
+	row := x.QueryRow(ctx, `SELECT id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at
 		FROM file_blocks WHERE hash = ?1 AND state = 2 /* Remote */`, hash.String())
 	chunk, err := scanFileChunk(row)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -302,7 +303,7 @@ func (s *SQLiteMetadataStore) GetByHash(ctx context.Context, hash metadata.Conte
 // default: the bounds only bracket the prefix under byte ordering, and a
 // byte-ordered id column lets the primary-key index seek the range instead of
 // filtering the whole table.
-const listFileChunksQuery = `SELECT id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at
+const listFileChunksQuery = `SELECT id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at
 	FROM file_blocks
 	WHERE id >= ?1 COLLATE BINARY AND id < ?2 COLLATE BINARY
 	ORDER BY id COLLATE BINARY ASC`
@@ -484,7 +485,7 @@ func scanFileChunk(row scanRow) (*metadata.FileChunk, error) {
 		hashStr           sql.NullString
 		lastSyncAttemptAt sql.NullTime
 	)
-	if err := row.Scan(&block.ID, &hashStr, &block.DataSize,
+	if err := row.Scan(&block.ID, &hashStr, &block.DataSize, &block.StartOffset,
 		&block.RefCount, &block.LastAccess, &block.CreatedAt, &block.State, &lastSyncAttemptAt); err != nil {
 		return nil, err
 	}
@@ -640,10 +641,10 @@ func (tx *sqliteTransaction) EnumerateFileChunks(ctx context.Context, fn func(bl
 func (s *SQLiteMetadataStore) InjectCorruptHashRow(ctx context.Context, blockID string, badHash string) error {
 	now := time.Now()
 	_, err := s.exec(ctx, `
-		INSERT INTO file_blocks (id, hash, data_size, ref_count, last_access, created_at, state, last_sync_attempt_at)
-		VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+		INSERT INTO file_blocks (id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at)
+		VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
 		ON CONFLICT (id) DO UPDATE SET hash = EXCLUDED.hash`,
-		blockID, badHash, uint32(64), uint32(1), now, now, int(block.BlockStateRemote), nil,
+		blockID, badHash, uint32(64), uint32(0), uint32(1), now, now, int(block.BlockStateRemote), nil,
 	)
 	if err != nil {
 		return fmt.Errorf("inject corrupt hash row: %w", err)

--- a/pkg/metadata/store/sqlite/snapshot_store.go
+++ b/pkg/metadata/store/sqlite/snapshot_store.go
@@ -29,6 +29,13 @@ const sqliteEngineTag = "sqlite"
 // file_blocks IS in backupTables, so the dumped row shape changes one column.
 // v5 adds the block_records section, matching what the postgres backend has
 // always dumped; RestoreSnapshot rejects the older streams that lack it.
+//
+// Adding a column to a dumped table does not bump this, which is why the
+// start_offset column on file_blocks and file_block_refs did not. The stream
+// carries its own column names and restore inserts only the columns it names,
+// so a stream written before the column existed still restores and the column
+// takes its default — the direction a column DROP does not survive, which is
+// what v3 and v4 are.
 const sqliteSchemaVersion uint32 = 5
 
 // backupTables lists every table dumped by WriteSnapshot and reloaded by RestoreSnapshot, in a

--- a/pkg/metadata/store/sqlite/start_offset_migration_test.go
+++ b/pkg/metadata/store/sqlite/start_offset_migration_test.go
@@ -1,0 +1,88 @@
+package sqlite_test
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata/store/sqlite"
+)
+
+// TestStartOffsetMigration_PreExistingRowClaimsChunkStart reads a row written
+// before the manifest carried an in-chunk start offset and pins what it means
+// afterwards: the claim still begins at the chunk's first byte.
+//
+// The database is rewound to the schema that predates the column — the two
+// columns dropped, the recorded version rolled back — and the row is written
+// through raw SQL in the shape that schema allowed. Reopening runs the migration
+// over it, so what the store reads back is a genuinely pre-change row rather
+// than a fresh one with the field left unset.
+func TestStartOffsetMigration_PreExistingRowClaimsChunkStart(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "startoff.db")
+
+	cfg := &sqlite.SQLiteMetadataStoreConfig{Path: dbPath, AutoMigrate: true}
+	store, err := sqlite.NewSQLiteMetadataStore(ctx, cfg, sqliteTestCapabilities())
+	if err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close after first open: %v", err)
+	}
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite directly: %v", err)
+	}
+	fileID := "00000000-0000-0000-0000-0000000002a1"
+	now := time.Now().UTC()
+	for _, stmt := range []struct {
+		q    string
+		args []any
+	}{
+		{q: `ALTER TABLE file_blocks DROP COLUMN start_offset`},
+		{q: `ALTER TABLE file_block_refs DROP COLUMN start_offset`},
+		{q: `DELETE FROM schema_migrations WHERE version >= 9`},
+		{
+			q: `INSERT INTO file_blocks (id, hash, data_size, ref_count, last_access, created_at, state)
+			    VALUES (?1, ?2, ?3, 1, ?4, ?4, 2)`,
+			args: []any{"legacy-payload/4096", "0000000000000000000000000000000000000000000000000000000000000001", int32(4096), now},
+		},
+		{
+			q:    `INSERT INTO file_block_refs (file_id, "offset", size, hash) VALUES (?1, ?2, ?3, ?4)`,
+			args: []any{fileID, int64(4096), int32(4096), make([]byte, block.HashSize)},
+		},
+	} {
+		if _, err := db.Exec(stmt.q, stmt.args...); err != nil {
+			t.Fatalf("rewind step %q: %v", stmt.q, err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close direct handle: %v", err)
+	}
+
+	store, err = sqlite.NewSQLiteMetadataStore(ctx, cfg, sqliteTestCapabilities())
+	if err != nil {
+		t.Fatalf("reopen and migrate: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	rows, err := store.ListFileChunks(ctx, "legacy-payload")
+	if err != nil {
+		t.Fatalf("ListFileChunks: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("ListFileChunks returned %d rows, want 1", len(rows))
+	}
+	if rows[0].StartOffset != 0 {
+		t.Errorf("pre-change row: StartOffset = %d, want 0 — it claimed its chunk "+
+			"from the first byte before the column existed and must go on doing so",
+			rows[0].StartOffset)
+	}
+	if rows[0].DataSize != 4096 {
+		t.Errorf("pre-change row: DataSize = %d, want 4096", rows[0].DataSize)
+	}
+}

--- a/pkg/metadata/storetest/file_block_ops.go
+++ b/pkg/metadata/storetest/file_block_ops.go
@@ -61,6 +61,21 @@ func runFileChunkOpsTests(t *testing.T, factory StoreFactory) {
 		testListFileChunksForeignRows(t, factory)
 	})
 
+	// StartOffset says where inside the chunk a row's claimed bytes begin. A
+	// backend that drops it serves a head-narrowed row the chunk's head, which
+	// verifies against the chunk hash and is still the wrong stretch of the file.
+	t.Run("PutGet_StartOffsetRoundTrips", func(t *testing.T) {
+		testPutGet_StartOffsetRoundTrips(t, factory)
+	})
+
+	// A row stored before StartOffset existed carries no value for it, and must
+	// keep meaning what it meant then: the claim starts at the chunk's first
+	// byte. Zero is that meaning, so a row put without the field reads back with
+	// it zero rather than absent or defaulted to something else.
+	t.Run("PutGet_StartOffsetDefaultsToChunkStart", func(t *testing.T) {
+		testPutGet_StartOffsetDefaultsToChunkStart(t, factory)
+	})
+
 	// GetFileChunkAtOffset is the read-path fast path: it resolves the single
 	// chunk covering a byte offset without enumerating the manifest. The
 	// covering guard (off < chunkOffset+DataSize) must return nil for a hole /
@@ -1198,6 +1213,92 @@ func testPut_TwoIDsSameHash(t *testing.T, factory StoreFactory) {
 // Both per-file read accessors (ListFileChunks and GetFileChunk) must
 // surface the hash for a Pending row, because the engine CAS read path
 // resolves chunks through that index, not just through finalized rows.
+// testPutGet_StartOffsetRoundTrips: a non-zero StartOffset survives Put and
+// comes back from every read path a resolver uses — the point lookup, the
+// per-payload list, and the indexed covering lookup where the backend has one.
+func testPutGet_StartOffsetRoundTrips(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+
+	const pid = "file-startoff"
+	fb := &block.FileChunk{
+		ID:          pid + "/3000",
+		Hash:        hashOfSeed("start-offset-roundtrip"),
+		State:       block.BlockStateRemote,
+		DataSize:    3000,
+		StartOffset: 500,
+		RefCount:    1,
+		LastAccess:  time.Now(),
+		CreatedAt:   time.Now(),
+	}
+	if err := store.Put(ctx, fb); err != nil {
+		t.Fatalf("Put failed: %v", err)
+	}
+
+	legacy := asLegacy(t, store)
+	got, err := legacy.GetFileChunk(ctx, fb.ID)
+	if err != nil {
+		t.Fatalf("GetFileChunk failed: %v", err)
+	}
+	if got.StartOffset != 500 {
+		t.Errorf("GetFileChunk: StartOffset = %d, want 500", got.StartOffset)
+	}
+
+	rows, err := legacy.ListFileChunks(ctx, pid)
+	if err != nil {
+		t.Fatalf("ListFileChunks failed: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("ListFileChunks returned %d rows, want 1", len(rows))
+	}
+	if rows[0].StartOffset != 500 {
+		t.Errorf("ListFileChunks: StartOffset = %d, want 500", rows[0].StartOffset)
+	}
+
+	if idx, ok := store.(interface {
+		GetFileChunkAtOffset(context.Context, string, uint64) (*block.FileChunk, error)
+	}); ok {
+		covering, err := idx.GetFileChunkAtOffset(ctx, pid, 4000)
+		if err != nil {
+			t.Fatalf("GetFileChunkAtOffset failed: %v", err)
+		}
+		if covering == nil {
+			t.Fatalf("GetFileChunkAtOffset(4000) = nil, want the row covering [3000, 6000)")
+		}
+		if covering.StartOffset != 500 {
+			t.Errorf("GetFileChunkAtOffset: StartOffset = %d, want 500", covering.StartOffset)
+		}
+	}
+}
+
+// testPutGet_StartOffsetDefaultsToChunkStart: a row written with no StartOffset
+// reads back claiming the chunk from its first byte.
+func testPutGet_StartOffsetDefaultsToChunkStart(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+
+	fb := &block.FileChunk{
+		ID:         "file-nostartoff/0",
+		Hash:       hashOfSeed("start-offset-default"),
+		State:      block.BlockStateRemote,
+		DataSize:   4096,
+		RefCount:   1,
+		LastAccess: time.Now(),
+		CreatedAt:  time.Now(),
+	}
+	if err := store.Put(ctx, fb); err != nil {
+		t.Fatalf("Put failed: %v", err)
+	}
+	got, err := asLegacy(t, store).GetFileChunk(ctx, fb.ID)
+	if err != nil {
+		t.Fatalf("GetFileChunk failed: %v", err)
+	}
+	if got.StartOffset != 0 {
+		t.Errorf("GetFileChunk: StartOffset = %d, want 0 — a row that names no "+
+			"in-chunk start claims the chunk from its first byte", got.StartOffset)
+	}
+}
+
 func testPutGet_PendingHashRoundTrips(t *testing.T, factory StoreFactory) {
 	store := factory(t)
 	ctx := t.Context()

--- a/pkg/metadata/storetest/file_block_ops.go
+++ b/pkg/metadata/storetest/file_block_ops.go
@@ -1210,9 +1210,6 @@ func testPut_TwoIDsSameHash(t *testing.T, factory StoreFactory) {
 
 // testPutGet_PendingHashRoundTrips pins the contract that a FileChunk's
 // content hash survives a Put/Get round-trip regardless of block state.
-// Both per-file read accessors (ListFileChunks and GetFileChunk) must
-// surface the hash for a Pending row, because the engine CAS read path
-// resolves chunks through that index, not just through finalized rows.
 // testPutGet_StartOffsetRoundTrips: a non-zero StartOffset survives Put and
 // comes back from every read path a resolver uses — the point lookup, the
 // per-payload list, and the indexed covering lookup where the backend has one.
@@ -1299,6 +1296,9 @@ func testPutGet_StartOffsetDefaultsToChunkStart(t *testing.T, factory StoreFacto
 	}
 }
 
+// Both per-file read accessors (ListFileChunks and GetFileChunk) must
+// surface the hash for a Pending row, because the engine CAS read path
+// resolves chunks through that index, not just through finalized rows.
 func testPutGet_PendingHashRoundTrips(t *testing.T, factory StoreFactory) {
 	store := factory(t)
 	ctx := t.Context()


### PR DESCRIPTION
Closes #2128

## What was wrong

A manifest row claimed a **prefix** of its chunk: it covered file bytes
`[idOffset, idOffset+DataSize)`, served by chunk bytes `[0, DataSize)`.

That left one carve outcome with no correct action available. When a carve span
`[d0, d1)` ends strictly inside an old row `[r0, r1)` that also *starts* inside the
span — `d0 < r0 < d1 < r1` — the reap could do neither of the two things a row
supports:

- **delete it** → `[d1, r1)` loses its only cover, because no row could be made to
  start at `d1` and take that stretch over;
- **spare it** → coverage resolves an overlap to the greatest covering start, so over
  `[r0, d1)` the old row outranks the fresh rows covering the same offsets, and a cold
  read is served the bytes those offsets held **before** the carve.

Sparing shipped, as the less bad of two wrong answers. `extendRunToRowEnd` avoids the
shape when the bytes past the span are warm; when they are cold, evicted, holed, or
already dirty for a later run, the extension bails and the shape stands.

## What this does

`block.FileChunk` and `block.ChunkRef` gain **`StartOffset uint32`**: where inside the
chunk the claimed bytes begin. A row now covers file `[idOffset, idOffset+DataSize)`
served by chunk bytes `[StartOffset, StartOffset+DataSize)`.

The row's ID still names its **first claimed byte**. That is the load-bearing choice:
every coverage lookup, every succession lookup, and both backends' offset indexes go on
reading a row's start straight off its ID, so none of them changed. Only paths that read
the chunk's own bytes consume `StartOffset`, and there is exactly one — `hydrateChunk`.

`ReapSupersededManifest` now narrows such a row off its **head**: the ID moves to the
span's end, `StartOffset` advances by what the row gave up, `DataSize` shrinks to match.
Symmetric with the tail narrow that already worked, and the chunk stays hash-verified
over all of its bytes either way — the row simply stops claiming part of it.

**This closes the case where the old row starts _strictly inside_ the span. It does not
close the adjacent case where the old row starts _exactly at_ the span** — there the fresh
row's `Put` upserts over it and destroys it before the reap ever runs. That is #2136, filed
from this work; see §3 below. A reader who sees "rows can now be narrowed off the head"
should not read it as the whole overwrite family being closed.

Neither of the two fixes the issue proposed is here. Hydrating the straddler's tail puts
a remote read on the write path; refusing the tiling leaves a file that can stall
un-carved. Removing the limitation costs neither.

## Evidence

`pkg/block/engine/cold_read_interior_straddle_test.go` drives the reachable sequence on a
**real engine** — real carve, real remote (memory object store), real eviction — against
both the memory and badger metadata backends. It carves and syncs an 8 MiB file, evicts
it, then overwrites a middle range that spans more than one old chunk and ends mid-chunk,
choosing `d0`/`d1` from the actual post-carve manifest so the straddle shape is
guaranteed rather than hoped for. It evicts again and reads back.

Before (unmodified base):

```
--- FAIL: TestMemoryColdRead_InteriorStraddler
    interior-straddler: cold read differs at offset 2307143:
        got 0x61, want 0x7b (pre-overwrite byte was 0x61)
--- FAIL: TestBadgerColdRead_InteriorStraddler
    interior-straddler: cold read differs at offset 2307143:
        got 0x61, want 0x7b (pre-overwrite byte was 0x61)
```

`got` is the pre-overwrite byte exactly — pre-carve bytes, served silently.

After: both pass.

Two controls in the same test, asserted on both sides of the fix so a failure confined to
the straddler means the defect and not a broken fixture:

- **head-straddler** — the row containing `d0` starts *before* the span and is narrowed
  off its tail. Genuinely safe today; passes before and after.
- **untouched-tail** — bytes past the span were never re-carved; passes before and after.

Unit level: `pkg/metadata/reap_superseded_test.go` asserts the post-reap tiling *and* what
a resolved read gets at each offset. `TestReapSupersededManifest_KeepsInteriorRowReaching
PastRun`, which pinned the stale window, becomes
`TestReapSupersededManifest_NarrowsInteriorRowOffItsHead` and pins its absence.

`go test ./...` green, `go test -race ./pkg/block/... ./pkg/metadata/...` green,
`golangci-lint run` 0 issues.

## 1. Migration

`StartOffset == 0` means "the claim starts at the chunk's first byte" — exactly what
every row means today and what every row a carve writes still means. So existing rows are
correct unchanged and **nothing is rewritten**.

- **badger / memory** — rows are JSON. A stored row carries no key for the field and
  decodes to zero. Pinned by `TestFileChunkJSON_StartOffsetAbsentMeansChunkStart` in
  `pkg/block/types_test.go`.
- **sqlite / postgres** — one `ALTER TABLE ... ADD COLUMN start_offset INTEGER NOT NULL
  DEFAULT 0` per table, on `file_blocks` (the rows) and `file_block_refs` (the
  `FileAttr.Blocks` projection). The default backfills; both migrations are reversible.

Pinned end to end by `TestStartOffsetMigration_PreExistingRowClaimsChunkStart`
(`pkg/metadata/store/sqlite/`): it rewinds a migrated database to the schema that predates
the column — dropping both columns and rolling the recorded version back — writes a row in
the shape that schema allowed, then reopens so the migration runs over it, and asserts the
row reads back claiming its chunk from byte 0. That is a genuinely pre-change row, not a
fresh one with the field left unset.

`ChunkRef` carries the offset too, deliberately: `File.Blocks` is what `CopyPayload`
(server-side clone) and `manifest_repair` rebuild rows from, and a ref that dropped it
would rebuild a row serving the chunk's **head** at the ref's offset — the wrong stretch
of the right chunk, bytes that pass the BLAKE3 verify and are still wrong.

One user-visible consequence: the postgres backup dumps `file_blocks` and
`file_block_refs` through a `COPY` that names no column list, so a restore matches
columns by **position**. A stream written before the column existed would run out of
values partway through each row, so `postgresSchemaVersion` goes to 10 and the version
gate refuses it legibly instead. The sqlite backup carries its own column names and
inserts only what a stream names, so an added column defaults there and its version
stays put — the direction a column *drop* does not survive, which is what its v3 and v4
bumps were. Both comments now say so.

`pkg/metadata/storetest/` gains two conformance cases every backend must pass:
`PutGet_StartOffsetRoundTrips` (non-zero value survives Put and comes back from the point
lookup, the per-payload list, and the indexed covering lookup where a backend has one) and
`PutGet_StartOffsetDefaultsToChunkStart`.

## 2. Greatest-covering-start, and #1974

**The rule stays. It is still load-bearing, and this change does not close #1974.**

#1974 was already closed, on 2026-08-18 by #1991, and by a different mechanism: the fetch
walk bounds a resolved row's claim at the start of the next row that begins inside it
(`chunkWindowResolver.covering`), so a stale straddler can no longer be consumed across a
newer row's head. That clamp and greatest-start are both untouched here. I checked the
issue rather than inferring it.

Overlaps are still generated after this change, by sources this change does not touch:

- A row that starts **before** its span and reaches past it is still spared whole, and
  that is correct — its bytes on either side of the span have no other cover, and every
  fresh row inside the span starts later, so the fresh rows win across the span.
  Pinned by `TestReapSupersededManifest_KeepsStraddlerReachingPastRun`.
- A row spanning several spans is narrowed to the *last* acting span's start, so it still
  overlaps the earlier spans' fresh rows. Pinned by
  `TestReapSupersededManifest_RowSpanningSeveralSpans`.
- A truncate narrows a straddling row to the new size and a later write re-carves from an
  earlier chunk boundary, leaving the narrowed row claiming bytes the new row also covers
  — the case `findRowCoveringOffset`'s own comment names, and nothing here changes it.
- The new head narrow declines when its target key is already occupied (see below).

So removing greatest-start on the strength of this change would be wrong, and I have not.

## 3. Where the class still exists

**Two places, one small and one filed.**

**a) The head narrow declines an occupied key.** Moving a row to the span's end would
overwrite a row already sitting there and strand whatever that row covers past the mover's
own end. When the key is taken the row is spared whole instead — today's outcome, stale
cover included. Reaching it needs two *pre-existing* overlapping rows meeting at the span's
end, so it is marked `ponytail:` with the upgrade path (a resolution rule for the
collision) rather than built speculatively. Pinned by
`TestReapSupersededManifest_SparesInteriorRowWhenItsNewKeyIsTaken`.

**b) A fresh row destroying a longer old row at the same offset — filed as #2136.**
When a run starts *exactly* on an old row's offset, the fresh row takes the same
offset-keyed ID and `tx.Put` upserts, so the old row is gone before the reap ever lists
the manifest. If the fresh row is shorter, everything between the two ends loses its only
cover. Probed on a real engine and **reproduced on unmodified `develop` (`7f1b811d`)**, so
it predates this change and is not caused by it:

```
gen1 row off=1083464 size=1091680 end=2175144
gen2 row off=1083464 size=8192   end=1091656     <- replaced the row above
gen2 row off=2175144 size=1060701 end=3235845    <- next row starts here
```

`[1091656, 2175144)` — 1,083,488 bytes — has no row at all, and the cold read fails closed
with `chunk not found`. #2128's body names this mechanism in passing, as a reason not to
fix #2128 by truncating the run; it needs no truncation to be reached.

The two are adjacent and neither closes the other. #2128 is the row that starts *strictly
inside* the span, survives the commit, and could not be narrowed off its head — closed
here. #2136 is the row that starts *exactly at* the span and never reaches the reap at all
— untouched here. A severity qualifier worth stating: the chunk itself survives on the
remote, because the reap does not decrement CAS refcounts, so #2136 strands bytes that
still physically exist and that nothing references.

#2136's fix is not representable without the field this PR adds — the remnant row it needs
to write is `[freshEnd, oldEnd)` with the start advanced into the chunk, which is exactly
`StartOffset` — so it stacks on this branch rather than racing it.

## Not changed, and why

`extendRunToRowEnd` stays. It is no longer a correctness requirement — the reap can handle
a run that ends mid-row — but it still buys a tiling whose rows line up with the old
boundaries instead of one that leaves a narrowed remnant. Removing it is a behaviour and
performance change with its own risk, and it does not belong in this diff. Its comments
now say that.
