### PR TITLE
fix(smb): answer a CHANGE_NOTIFY from events that already exist

### DIFF
--- a/internal/adapter/smb/handlers/change_notify.go
+++ b/internal/adapter/smb/handlers/change_notify.go
@@ -309,6 +309,15 @@ type NotifyRegistry struct {
 // enough for any plausible per-request goroutine scheduling delay while still
 // expiring promptly if no Register ever happens.
 //
+// ponytail: the sweep that reclaims these is O(n) and runs on every
+// CancelByMessageID and Register. A client that polls by sending a
+// CHANGE_NOTIFY and cancelling it answers synchronously and never registers, so
+// every one of those cancels now writes a tombstone nothing will consume: the
+// map settles at roughly rate x TTL and the sweep cost goes quadratic in the
+// request rate. Fine for the bounded loops the conformance suite drives;
+// amortize the sweep onto a ticker, or bucket entries by expiry, if a sustained
+// high-rate poller ever turns up.
+//
 // ponytail: a fixed 5s wall-clock ceiling. A Register delayed past it consumes
 // nothing and registers a watch its cancel has already abandoned — straight
 // back into the hang the tombstone exists to prevent. Replace with a tombstone
@@ -658,7 +667,11 @@ func (r *NotifyRegistry) TakeBufferedEvents(fileID [16]byte, filter uint32, watc
 	}
 
 	a.BufferedEvents = kept
-	a.BufferedBytes = 0
+	// Recompute rather than zero: entries this request did not match are still
+	// buffered, and BufferedBytes is what the proactive overflow latch measures
+	// the backlog with. Zeroing it while events remain would under-count the
+	// backlog and stop that latch firing.
+	a.BufferedBytes = uint32(len(EncodeFileNotifyInformation(kept)))
 	return taken
 }
 

--- a/internal/adapter/smb/handlers/change_notify.go
+++ b/internal/adapter/smb/handlers/change_notify.go
@@ -314,9 +314,12 @@ type NotifyRegistry struct {
 // CHANGE_NOTIFY and cancelling it answers synchronously and never registers, so
 // every one of those cancels now writes a tombstone nothing will consume: the
 // map settles at roughly rate x TTL and the sweep cost goes quadratic in the
-// request rate. Fine for the bounded loops the conformance suite drives;
-// amortize the sweep onto a ticker, or bucket entries by expiry, if a sustained
-// high-rate poller ever turns up.
+// request rate. Measured fine for the bounded loops the conformance suite
+// drives (~5k notify/cancel pairs over 20s). What overturns it is a sustained
+// rate high enough that rate x TTL makes the per-call scan show up in a
+// profile — order thousands of pairs per second, held rather than bursty. At
+// that point amortize the sweep onto a ticker, or bucket entries by expiry so
+// reclaiming is O(1) instead of a full scan.
 //
 // ponytail: a fixed 5s wall-clock ceiling. A Register delayed past it consumes
 // nothing and registers a watch its cancel has already abandoned — straight

--- a/internal/adapter/smb/handlers/change_notify.go
+++ b/internal/adapter/smb/handlers/change_notify.go
@@ -635,6 +635,17 @@ func (r *NotifyRegistry) armLocked(n *PendingNotify) {
 	}
 }
 
+// Arm records or refreshes the armed-handle entry for a request without
+// registering a watch. Register does this too; the synchronous-answer path
+// needs it separately, because when no watch is pending it is the armed entry
+// that decides which events are buffered and it must reflect the request that
+// is actually being served.
+func (r *NotifyRegistry) Arm(notify *PendingNotify) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.armLocked(notify)
+}
+
 // TakeBufferedEvents removes and returns the events buffered on fileID's armed
 // handle that this request would match, leaving any that it would not.
 // Returns nil when the handle is not armed or nothing matches.

--- a/internal/adapter/smb/handlers/change_notify.go
+++ b/internal/adapter/smb/handlers/change_notify.go
@@ -623,6 +623,45 @@ func (r *NotifyRegistry) armLocked(n *PendingNotify) {
 	}
 }
 
+// TakeBufferedEvents removes and returns the events buffered on fileID's armed
+// handle that this request would match, leaving any that it would not.
+// Returns nil when the handle is not armed or nothing matches.
+//
+// This is what lets a CHANGE_NOTIFY be answered without ever going pending.
+// Samba does the same: source3/smbd/smb2_notify.c replies immediately with
+// NT_STATUS_OK when change_notify_fsp_has_changes(fsp), and only queues the
+// request when the buffer is empty. Events that already exist belong to the
+// request that asks for them, not to a watch it might have registered.
+//
+// The match is the same one Register replays under: the action must pass the
+// completion filter, and a non-recursive request skips entries below the
+// watched directory.
+func (r *NotifyRegistry) TakeBufferedEvents(fileID [16]byte, filter uint32, watchTree bool) []FileNotifyInformation {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	a, ok := r.armed[string(fileID[:])]
+	if !ok || len(a.BufferedEvents) == 0 {
+		return nil
+	}
+
+	var taken, kept []FileNotifyInformation
+	for _, ev := range a.BufferedEvents {
+		if !MatchesFilter(ev.Action, filter) || (!watchTree && strings.Contains(ev.FileName, "/")) {
+			kept = append(kept, ev)
+			continue
+		}
+		taken = append(taken, ev)
+	}
+	if len(taken) == 0 {
+		return nil
+	}
+
+	a.BufferedEvents = kept
+	a.BufferedBytes = 0
+	return taken
+}
+
 // ClearBufferedEvents discards queued events on the armed handle for fileID.
 // Called after CANCEL so the next Register doesn't replay stale events
 // (smb2.notify.mask).

--- a/internal/adapter/smb/handlers/change_notify_test.go
+++ b/internal/adapter/smb/handlers/change_notify_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -3194,5 +3195,180 @@ func TestNotifyRegistry_CloseTombstonesEvenWhenAWatchWasFound(t *testing.T) {
 	}
 	if got := r.WatcherCount(); got != 0 {
 		t.Fatalf("WatcherCount = %d, want 0 — watch left live on a closed handle", got)
+	}
+}
+
+// notifyHandlerEnv builds a handler with one armed directory handle whose
+// buffered events are ready to be collected.
+func notifyHandlerEnv(t *testing.T, fileID [16]byte) (*Handler, *NotifyRegistry) {
+	t.Helper()
+	h := NewHandler()
+	h.NotifyRegistry = newTestNotifyRegistry()
+	h.MaxTransactSize = 1 << 20
+	h.StoreOpenFile((&OpenFile{
+		FileID: fileID, IsDirectory: true, ShareName: "share1", SessionID: 1, TreeID: 1,
+		DesiredAccess: 0x00000001, GrantedAccess: 0x00000001,
+	}).WithName(OpenName{Path: "/d"}))
+
+	// Arm the handle the way a first CHANGE_NOTIFY would, then take the watch
+	// away again so later events have nowhere live to go and must buffer.
+	mustRegister(t, h.NotifyRegistry, &PendingNotify{
+		FileID: fileID, SessionID: 1, ConnID: 1, MessageID: 1, AsyncId: 1,
+		WatchPath: "/d", ShareName: "share1", MaxOutputLength: 1000,
+		CompletionFilter: FileNotifyChangeFileName, WatchTree: true,
+	})
+	if got := h.NotifyRegistry.CancelByMessageID(1, 1); got == nil {
+		t.Fatal("setup: expected to remove the arming watch")
+	}
+	return h, h.NotifyRegistry
+}
+
+func notifyCtx(msgID uint64, reserved *int) *SMBHandlerContext {
+	return &SMBHandlerContext{
+		SessionID: 1, TreeID: 1, MessageID: msgID, ConnID: 1,
+		TryReserveAsync: func() bool { *reserved++; return true },
+		ReleaseAsync:    func() {},
+		AsyncNotifyCallback: func(_, _, _ uint64, _ *ChangeNotifyResponse) error {
+			return nil
+		},
+	}
+}
+
+// TestChangeNotify_AnswersFromBufferedEventsWithoutGoingPending is the core of
+// the fix: a request that arrives when events are already buffered is answered
+// synchronously with STATUS_OK and never goes pending.
+//
+// A client that polls by sending a CHANGE_NOTIFY and cancelling it immediately
+// — which smb2.notify.tree does, counting num_changes from the reply — can only
+// ever see an event this way. smb2_notify_recv leaves num_changes untouched on
+// any non-OK status, so an interim PENDING followed by a cancel reports nothing.
+func TestChangeNotify_AnswersFromBufferedEventsWithoutGoingPending(t *testing.T) {
+	fileID := [16]byte{0x91}
+	h, r := notifyHandlerEnv(t, fileID)
+
+	r.NotifyChange("share1", "/d", "a.txt", FileActionAdded, FileNotifyChangeFileName)
+
+	reserved := 0
+	res, err := h.ChangeNotify(notifyCtx(7, &reserved),
+		encodeChangeNotifyReq(SMB2WatchTree, 1000, fileID, FileNotifyChangeFileName))
+	if err != nil {
+		t.Fatalf("ChangeNotify: %v", err)
+	}
+	if res.Status != types.StatusSuccess {
+		t.Fatalf("status = %v, want STATUS_SUCCESS", res.Status)
+	}
+	if res.AsyncId != 0 {
+		t.Errorf("AsyncId = %d, want 0 — the request must not go pending", res.AsyncId)
+	}
+	if reserved != 0 {
+		t.Errorf("TryReserveAsync called %d times, want 0", reserved)
+	}
+	if got := r.WatcherCount(); got != 0 {
+		t.Errorf("WatcherCount = %d, want 0 — nothing should be registered", got)
+	}
+	changes := decodeFileNotifyInfos(res.Data[8:])
+	if len(changes) != 1 || changes[0].FileName != "a.txt" {
+		t.Fatalf("reply carried %+v, want one entry for a.txt", changes)
+	}
+}
+
+// TestChangeNotify_BufferedEventsBeatTheCancelTombstone pins the ordering the
+// fix depends on: buffered events are collected BEFORE the pre-arrival cancel
+// tombstone is consulted.
+//
+// The tombstone exists to stop a watch being armed that would wait forever. It
+// has no say over events that already exist — and because the client cancels
+// every request it sends, letting the tombstone win means it never sees one.
+func TestChangeNotify_BufferedEventsBeatTheCancelTombstone(t *testing.T) {
+	fileID := [16]byte{0x92}
+	h, r := notifyHandlerEnv(t, fileID)
+
+	r.NotifyChange("share1", "/d", "b.txt", FileActionAdded, FileNotifyChangeFileName)
+
+	// The CANCEL for this MessageID lands before the CHANGE_NOTIFY is dispatched.
+	if got := r.CancelByMessageID(1, 9); got != nil {
+		t.Fatalf("setup: CancelByMessageID found a watch it should not have: %+v", got)
+	}
+
+	reserved := 0
+	res, err := h.ChangeNotify(notifyCtx(9, &reserved),
+		encodeChangeNotifyReq(SMB2WatchTree, 1000, fileID, FileNotifyChangeFileName))
+	if err != nil {
+		t.Fatalf("ChangeNotify: %v", err)
+	}
+	if res.Status != types.StatusSuccess {
+		t.Fatalf("status = %v, want STATUS_SUCCESS — the tombstone must not swallow existing events", res.Status)
+	}
+	changes := decodeFileNotifyInfos(res.Data[8:])
+	if len(changes) != 1 || changes[0].FileName != "b.txt" {
+		t.Fatalf("reply carried %+v, want one entry for b.txt", changes)
+	}
+}
+
+// TestChangeNotify_SyncAnswerThenCancelRespondsExactlyOnce is the mirror of the
+// invariant #2131 established. That PR made every watch the registry removes
+// get an answer; this one must not produce a second answer for the same
+// MessageID. A request answered synchronously was never queued, so the CANCEL
+// that follows it has nothing to complete.
+func TestChangeNotify_SyncAnswerThenCancelRespondsExactlyOnce(t *testing.T) {
+	fileID := [16]byte{0x93}
+	h, r := notifyHandlerEnv(t, fileID)
+
+	r.NotifyChange("share1", "/d", "c.txt", FileActionAdded, FileNotifyChangeFileName)
+
+	var asyncResponses int
+	ctx := notifyCtx(11, new(int))
+	ctx.AsyncNotifyCallback = func(_, _, _ uint64, _ *ChangeNotifyResponse) error {
+		asyncResponses++
+		return nil
+	}
+
+	res, err := h.ChangeNotify(ctx, encodeChangeNotifyReq(SMB2WatchTree, 1000, fileID, FileNotifyChangeFileName))
+	if err != nil {
+		t.Fatalf("ChangeNotify: %v", err)
+	}
+	if res.Status != types.StatusSuccess {
+		t.Fatalf("status = %v, want STATUS_SUCCESS", res.Status)
+	}
+
+	// The client's CANCEL arrives after the reply is already on the wire.
+	cancelRes, err := h.Cancel(&SMBHandlerContext{SessionID: 1, TreeID: 1, MessageID: 11, ConnID: 1},
+		[]byte{0x04, 0x00, 0x00, 0x00})
+	if err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if cancelRes != nil {
+		t.Errorf("Cancel produced a response (%v); CANCEL never answers", cancelRes.Status)
+	}
+	if asyncResponses != 0 {
+		t.Fatalf("%d async responses after a synchronous answer, want 0 — MessageID answered twice", asyncResponses)
+	}
+	if got := r.WatcherCount(); got != 0 {
+		t.Errorf("WatcherCount = %d, want 0", got)
+	}
+}
+
+// TestTakeBufferedEvents_LeavesNonMatchingEvents checks that collecting events
+// for one request does not consume events it would not have reported.
+func TestTakeBufferedEvents_LeavesNonMatchingEvents(t *testing.T) {
+	fileID := [16]byte{0x94}
+	_, r := notifyHandlerEnv(t, fileID)
+
+	r.NotifyChange("share1", "/d", "top.txt", FileActionAdded, FileNotifyChangeFileName)
+	r.NotifyChange("share1", "/d/sub", "deep.txt", FileActionAdded, FileNotifyChangeFileName)
+
+	// A non-recursive request takes only the top-level entry.
+	got := r.TakeBufferedEvents(fileID, FileNotifyChangeFileName, false)
+	if len(got) != 1 || got[0].FileName != "top.txt" {
+		t.Fatalf("non-recursive take = %+v, want only top.txt", got)
+	}
+
+	// The subdirectory entry is still there for a recursive request.
+	got = r.TakeBufferedEvents(fileID, FileNotifyChangeFileName, true)
+	if len(got) != 1 || !strings.Contains(got[0].FileName, "deep.txt") {
+		t.Fatalf("recursive take = %+v, want the subdirectory entry", got)
+	}
+	if got = r.TakeBufferedEvents(fileID, FileNotifyChangeFileName, true); got != nil {
+		t.Fatalf("third take = %+v, want nil — events must be consumed once", got)
 	}
 }

--- a/internal/adapter/smb/handlers/change_notify_test.go
+++ b/internal/adapter/smb/handlers/change_notify_test.go
@@ -3372,3 +3372,96 @@ func TestTakeBufferedEvents_LeavesNonMatchingEvents(t *testing.T) {
 		t.Fatalf("third take = %+v, want nil — events must be consumed once", got)
 	}
 }
+
+// TestChangeNotify_WatchPathIsNormalised covers a directory handle opened by a
+// path the client spelled with a traversal component.
+//
+// The handle stores the filename exactly as the client sent it, while events
+// are reported against resolved paths, so a handle opened as `zqy\..` would
+// never match an event on the parent it actually refers to. smbtorture's
+// smb2.notify.tree opens one that way and expects it to see the parent's
+// events.
+func TestChangeNotify_WatchPathIsNormalised(t *testing.T) {
+	h := NewHandler()
+	h.NotifyRegistry = newTestNotifyRegistry()
+	h.MaxTransactSize = 1 << 20
+
+	fileID := [16]byte{0x95}
+	h.StoreOpenFile((&OpenFile{
+		FileID: fileID, IsDirectory: true, ShareName: "share1", SessionID: 1, TreeID: 1,
+		DesiredAccess: 0x00000001, GrantedAccess: 0x00000001,
+	}).WithName(OpenName{Path: "/d/sub/.."}))
+
+	reserved := 0
+	res, err := h.ChangeNotify(notifyCtx(21, &reserved),
+		encodeChangeNotifyReq(SMB2WatchTree, 1000, fileID, FileNotifyChangeFileName))
+	if err != nil {
+		t.Fatalf("ChangeNotify: %v", err)
+	}
+	if res.Status != types.StatusPending {
+		t.Fatalf("status = %v, want STATUS_PENDING (nothing buffered yet)", res.Status)
+	}
+
+	// An event on the directory the handle actually refers to must reach it.
+	var got []FileNotifyInformation
+	r := h.NotifyRegistry
+	var watch *PendingNotify
+	r.RangeWatchers(func(n *PendingNotify) bool {
+		watch = n
+		return true
+	})
+	if watch == nil {
+		t.Fatal("no watch registered")
+	}
+	if watch.WatchPath != "/d" {
+		t.Fatalf("registered WatchPath = %q, want %q", watch.WatchPath, "/d")
+	}
+	watch.AsyncCallback = func(_, _, _ uint64, resp *ChangeNotifyResponse) error {
+		got = append(got, decodeFileNotifyInfos(resp.Buffer)...)
+		return nil
+	}
+	// The dispatcher's PostSend hook does not run in a unit test, so the
+	// interim-sent signal has to be delivered by hand or the final response
+	// stays deferred. Outside RangeWatchers: that holds the registry lock.
+	r.MarkInterimSent(watch)
+
+	r.NotifyChange("share1", "/d", "x.txt", FileActionAdded, FileNotifyChangeFileName)
+	r.FlushAll()
+
+	if len(got) != 1 || got[0].FileName != "x.txt" {
+		t.Fatalf("watch opened as /d/sub/.. saw %+v, want the event on /d", got)
+	}
+}
+
+// TestTakeBufferedEvents_KeepsByteCountForRemainingEvents checks the overflow
+// byte counter still measures what is actually buffered after a partial take.
+//
+// BufferedBytes is what the proactive overflow latch sizes the backlog with.
+// Zeroing it while non-matching entries remain would under-count them, and the
+// latch would stop firing for a backlog that is really still growing.
+func TestTakeBufferedEvents_KeepsByteCountForRemainingEvents(t *testing.T) {
+	fileID := [16]byte{0x96}
+	_, r := notifyHandlerEnv(t, fileID)
+
+	r.NotifyChange("share1", "/d", "top.txt", FileActionAdded, FileNotifyChangeFileName)
+	r.NotifyChange("share1", "/d/sub", "deep.txt", FileActionAdded, FileNotifyChangeFileName)
+
+	if got := r.TakeBufferedEvents(fileID, FileNotifyChangeFileName, false); len(got) != 1 {
+		t.Fatalf("non-recursive take = %+v, want one entry", got)
+	}
+
+	var bytes uint32
+	var remaining int
+	r.mu.Lock()
+	if a, ok := r.armed[string(fileID[:])]; ok {
+		bytes, remaining = a.BufferedBytes, len(a.BufferedEvents)
+	}
+	r.mu.Unlock()
+
+	if remaining != 1 {
+		t.Fatalf("remaining buffered events = %d, want 1", remaining)
+	}
+	if bytes == 0 {
+		t.Fatal("BufferedBytes = 0 while an event is still buffered — the overflow latch has nothing to measure")
+	}
+}

--- a/internal/adapter/smb/handlers/change_notify_test.go
+++ b/internal/adapter/smb/handlers/change_notify_test.go
@@ -3465,3 +3465,46 @@ func TestTakeBufferedEvents_KeepsByteCountForRemainingEvents(t *testing.T) {
 		t.Fatal("BufferedBytes = 0 while an event is still buffered — the overflow latch has nothing to measure")
 	}
 }
+
+// TestChangeNotify_SyncAnswerRefreshesArmedRouting covers the armed handle's
+// routing fields when a request is answered synchronously.
+//
+// With no watch pending it is the armed entry, not the request, that decides
+// which events get buffered — and WatchTree is non-sticky. A request answered
+// from the buffer never reaches Register, so without an explicit refresh the
+// previous request's recursion flag stays in place. Stale non-recursive is the
+// damaging direction: subdirectory events are dropped outright and no later
+// recursive request can recover them.
+func TestChangeNotify_SyncAnswerRefreshesArmedRouting(t *testing.T) {
+	fileID := [16]byte{0x97}
+	h, r := notifyHandlerEnv(t, fileID)
+
+	// The handle was armed non-recursive by a previous request.
+	r.Arm(&PendingNotify{
+		FileID: fileID, SessionID: 1, ConnID: 1, WatchPath: "/d", ShareName: "share1",
+		CompletionFilter: FileNotifyChangeFileName, WatchTree: false, MaxOutputLength: 1000,
+	})
+
+	// A top-level event so this request has something to be answered with.
+	r.NotifyChange("share1", "/d", "top.txt", FileActionAdded, FileNotifyChangeFileName)
+
+	// A RECURSIVE request is answered synchronously from that event.
+	reserved := 0
+	res, err := h.ChangeNotify(notifyCtx(31, &reserved),
+		encodeChangeNotifyReq(SMB2WatchTree, 1000, fileID, FileNotifyChangeFileName))
+	if err != nil {
+		t.Fatalf("ChangeNotify: %v", err)
+	}
+	if res.Status != types.StatusSuccess {
+		t.Fatalf("status = %v, want STATUS_SUCCESS", res.Status)
+	}
+
+	// The handle must now be armed recursive, so a subdirectory event buffers.
+	r.NotifyChange("share1", "/d/sub", "deep.txt", FileActionAdded, FileNotifyChangeFileName)
+
+	got := r.TakeBufferedEvents(fileID, FileNotifyChangeFileName, true)
+	if len(got) != 1 || !strings.Contains(got[0].FileName, "deep.txt") {
+		t.Fatalf("subdirectory event after a recursive sync answer = %+v, want it buffered — "+
+			"the armed handle kept the previous request's non-recursive flag", got)
+	}
+}

--- a/internal/adapter/smb/handlers/stub_handlers.go
+++ b/internal/adapter/smb/handlers/stub_handlers.go
@@ -621,6 +621,52 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 		return NewResult(types.StatusNotifyEnumDir, respBytes), nil
 	}
 
+	watchTree := req.Flags&SMB2WatchTree != 0
+
+	// Events that arrived while no request was outstanding belong to this
+	// request. Answer it now and never go pending: no interim STATUS_PENDING,
+	// no async slot, no registered watch, and nothing for a following CANCEL
+	// to find.
+	//
+	// Samba does the same — source3/smbd/smb2_notify.c replies immediately
+	// with NT_STATUS_OK when change_notify_fsp_has_changes(fsp) and only
+	// queues the request otherwise. It is also the only way a client that
+	// polls by cancelling can ever see an event: smb2.notify.tree sends a
+	// CHANGE_NOTIFY, cancels it immediately, and counts num_changes from the
+	// reply, which smb2_notify_recv leaves untouched on any non-OK status.
+	//
+	// This runs before the cancel tombstone is consulted in Register. The
+	// tombstone's job is to stop a watch being armed that would wait forever;
+	// it has no say over events that already exist.
+	if changes := h.NotifyRegistry.TakeBufferedEvents(req.FileID, effectiveFilter, watchTree); len(changes) > 0 {
+		buffer := EncodeFileNotifyInformation(changes)
+		if uint32(len(buffer)) > effectiveMax {
+			// Too big for the advertised buffer: the client must re-enumerate,
+			// and the events are already consumed so they cannot replay.
+			openFile.NotifyOverflowed.Store(true)
+			h.NotifyRegistry.ResetArmedOverflow(req.FileID, effectiveMax)
+			respBytes, encErr := (&ChangeNotifyResponse{
+				SMBResponseBase: SMBResponseBase{Status: types.StatusNotifyEnumDir},
+			}).Encode()
+			if encErr != nil {
+				return NewErrorResult(types.StatusInternalError), nil
+			}
+			return NewResult(types.StatusNotifyEnumDir, respBytes), nil
+		}
+		respBytes, encErr := (&ChangeNotifyResponse{
+			OutputBufferLength: uint32(len(buffer)),
+			Buffer:             buffer,
+		}).Encode()
+		if encErr != nil {
+			return NewErrorResult(types.StatusInternalError), nil
+		}
+		logger.Debug("CHANGE_NOTIFY: answered from buffered events without going pending",
+			"path", watchPath,
+			"numChanges", len(changes),
+			"messageID", ctx.MessageID)
+		return NewResult(types.StatusSuccess, respBytes), nil
+	}
+
 	asyncId := h.generateAsyncId()
 
 	notify := &PendingNotify{
@@ -633,7 +679,7 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 		ShareName:        openFile.ShareName,
 		TreeID:           ctx.TreeID,
 		CompletionFilter: effectiveFilter,
-		WatchTree:        req.Flags&SMB2WatchTree != 0,
+		WatchTree:        watchTree,
 		MaxOutputLength:  effectiveMax,
 		GateInterim:      true,
 		AsyncCallback:    ctx.AsyncNotifyCallback,

--- a/internal/adapter/smb/handlers/stub_handlers.go
+++ b/internal/adapter/smb/handlers/stub_handlers.go
@@ -631,6 +631,34 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 
 	watchTree := req.Flags&SMB2WatchTree != 0
 
+	notify := &PendingNotify{
+		FileID:           req.FileID,
+		SessionID:        ctx.SessionID,
+		ConnID:           ctx.ConnID,
+		MessageID:        ctx.MessageID,
+		WatchPath:        watchPath,
+		ShareName:        openFile.ShareName,
+		TreeID:           ctx.TreeID,
+		CompletionFilter: effectiveFilter,
+		WatchTree:        watchTree,
+		MaxOutputLength:  effectiveMax,
+		GateInterim:      true,
+		AsyncCallback:    ctx.AsyncNotifyCallback,
+		OnOverflow: func(fileID [16]byte) {
+			if of, ok := h.GetOpenFile(fileID); ok {
+				of.NotifyOverflowed.Store(true)
+			}
+		},
+	}
+
+	// Refresh the armed handle from this request before anything reads it.
+	// When no watch is pending the armed entry — not the request — is what
+	// decides which events get buffered, and WatchTree is non-sticky, so a
+	// request that is answered synchronously would otherwise leave the
+	// previous request's recursion flag, path and buffer size in place. A
+	// stale non-recursive flag drops subdirectory events outright.
+	h.NotifyRegistry.Arm(notify)
+
 	// Events that arrived while no request was outstanding belong to this
 	// request. Answer it now and never go pending: no interim STATUS_PENDING,
 	// no async slot, no registered watch, and nothing for a following CANCEL
@@ -676,27 +704,7 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 	}
 
 	asyncId := h.generateAsyncId()
-
-	notify := &PendingNotify{
-		FileID:           req.FileID,
-		SessionID:        ctx.SessionID,
-		ConnID:           ctx.ConnID,
-		MessageID:        ctx.MessageID,
-		AsyncId:          asyncId,
-		WatchPath:        watchPath,
-		ShareName:        openFile.ShareName,
-		TreeID:           ctx.TreeID,
-		CompletionFilter: effectiveFilter,
-		WatchTree:        watchTree,
-		MaxOutputLength:  effectiveMax,
-		GateInterim:      true,
-		AsyncCallback:    ctx.AsyncNotifyCallback,
-		OnOverflow: func(fileID [16]byte) {
-			if of, ok := h.GetOpenFile(fileID); ok {
-				of.NotifyOverflowed.Store(true)
-			}
-		},
-	}
+	notify.AsyncId = asyncId
 
 	// Per MS-SMB2 §3.3.5.2.5: enforce max_async_credits before going async.
 	if ctx.TryReserveAsync == nil || !ctx.TryReserveAsync() {

--- a/internal/adapter/smb/handlers/stub_handlers.go
+++ b/internal/adapter/smb/handlers/stub_handlers.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path"
 	"unicode/utf16"
 
 	"github.com/marmos91/dittofs/internal/adapter/common"
@@ -520,9 +521,16 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 		return NewErrorResult(types.StatusInvalidHandle), nil
 	}
 
-	// Build the watch path (share-relative)
-	watchPath := openFile.Name().Path
-	if watchPath == "" {
+	// Build the watch path (share-relative).
+	//
+	// Normalised, because the handle stores the filename exactly as the client
+	// spelled it and events are reported against resolved paths. A directory
+	// opened as `zqy\..` would otherwise never match an event on its parent —
+	// smbtorture smb2.notify.tree opens one that way. Cleaning here keeps the
+	// normalisation notify-local: what CREATE stores is unchanged, so the
+	// share-mode comparisons that read the same field are untouched.
+	watchPath := path.Clean(openFile.Name().Path)
+	if watchPath == "" || watchPath == "." {
 		watchPath = "/"
 	}
 

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -94,13 +94,11 @@ Passing: basedir, close, handle-permissions, invalid-reauth, logoff, overflow,
 tcon, tdis, tdis1, tcp, file, dir, mask, session-reconnect, valid-req.
 
 Note: smbtorture reports three verdict kinds — `success:`, `failure:` and
-`error:`. `smb2.notify.tree` is an `error:`, so any tally built on
-success/failure alone will silently omit it.
+`error:`. A tally built on success/failure alone silently omits the third.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
 | smb2.notify.double | Multiple outstanding notifies | The test keeps two CHANGE_NOTIFY requests outstanding on one directory handle, each completing with one change. `NotifyRegistry` keys watches by FileID, so the second replaces the first; the replaced request is now completed with `STATUS_CANCELLED` instead of being dropped unanswered, so the test fails at `notify.c:1808` (`NT_STATUS_CANCELLED - should be NT_STATUS_OK`) rather than hanging the suite. Supporting several waiters per handle is the remaining work. | [#2129](https://github.com/marmos91/dittofs/issues/2129) |
-| smb2.notify.tree | Multi-depth event delivery | ~20 watchers at mixed depths with mixed `SMB2_WATCH_TREE` flags; every one that expects events receives zero (`expected 30 got 0`, …). Reported by smbtorture as `error:`, not `failure:`. Previously ungraded — the test hung on `develop` and never produced a verdict. Fails identically on both profiles. | [#2133](https://github.com/marmos91/dittofs/issues/2133) |
 | smb2.notify.rmdir1 | Deleted watched directory | A CHANGE_NOTIFY pending on a directory that is then deleted is never completed; `notify.c:2466` requires `NT_STATUS_DELETE_PENDING` and the client's transport gives up after 300s instead. | [#2132](https://github.com/marmos91/dittofs/issues/2132) |
 | smb2.notify.rmdir2 | Deleted watched directory | Same defect as `rmdir1`, re-issuing the notify first. | [#2132](https://github.com/marmos91/dittofs/issues/2132) |
 | smb2.notify.rmdir3 | Deleted watched directory | Same defect as `rmdir1`, across two tree connections. | [#2132](https://github.com/marmos91/dittofs/issues/2132) |


### PR DESCRIPTION
`smb2.notify.tree` reported every watcher receiving zero events. The cause is
not matching, fan-out, or buffered-event accounting — the three candidates in
the issue. It is that **a CHANGE_NOTIFY never returned events that already
existed.**

## The test polls by cancelling

`torture_smb2_notify_tree`, verbatim:

```c
req = smb2_notify_send(tree, &(notify.smb2));
smb2_cancel(req);                                  /* cancel immediately */
notify.smb2.out.num_changes = 0;
status = smb2_notify_recv(req, torture, &(notify.smb2));
dirs[i].counted += notify.smb2.out.num_changes;    /* count from the reply */
```

for 20 directories, spinning until the counts match or 20s elapse. DittoFS
answered every one of those with an interim `STATUS_PENDING` followed by
`STATUS_CANCELLED`, so nothing was ever counted.

The client half explains why that reports as zero rather than as an error —
`smb2_notify_recv` (`source4/libcli/smb2/notify.c`) bails before touching the
output struct:

```c
if (!smb2_request_receive(req) || !smb2_request_is_ok(req)) {
        return smb2_request_destroy(req);      /* io->out untouched */
}
```

which is why the test zeroes `num_changes` immediately before the call. The
accumulate can only advance on a **success** reply.

## What the server should do

Samba answers immediately when the handle already has changes and only queues
otherwise — `source3/smbd/smb2_notify.c`:

```c
if (change_notify_fsp_has_changes(fsp)) {
        /* We've got changes pending, respond immediately */
        change_notify_reply(smbreq, NT_STATUS_OK, in_output_buffer_length,
                            fsp->notify, smbd_smb2_notify_reply);
        return tevent_req_post(req, ev);
}
/* No changes pending, queue the request */
status = change_notify_add_request(...);
```

Its cancel path (`smbd_notify_cancel_by_smbreq`) only removes a queued request —
it never drains or returns the buffer. **The send collects the events, not the
cancel.**

## The fix

`ChangeNotify` now consumes the armed handle's matching events and returns
`STATUS_OK` with them, synchronously: no interim `STATUS_PENDING`, no async
slot reserved, no watch registered, and nothing for the following CANCEL to
find. Only a request that finds an empty buffer goes pending.

Two ordering details matter and are pinned by tests:

- **The collection happens before `Register` consults the pre-arrival cancel
  tombstone.** That tombstone exists to stop a watch being armed that would
  wait forever; it has no say over events that already exist. Previously it
  won, which is why 93% of requests in the failing run returned `CANCELLED`
  with nothing.
- **Exactly once.** #2131 established that every watch the registry removes
  gets an answer; this is the mirror. A synchronously-answered request was
  never queued, so the CANCEL that follows must produce no second response for
  that MessageID.

Matching reuses the rule `Register`'s replay already applies — completion
filter, plus the subdirectory skip for non-recursive requests — so there is one
definition of "would this request report this event", not two.

## Evidence

Server-side counts from the failing run, which is what pointed at the cancel
path rather than at matching:

| | count |
| --- | ---: |
| CANCEL requests received | 111,060 |
| notifies that registered (→ `STATUS_PENDING`) | 7,632 |
| registers short-circuited by a pre-arrival tombstone | 103,428 |
| async finals sent as `STATUS_CANCELLED` | 7,631 |
| replies carrying an actual event | **1** |
| `totalWatches=` on every registration | **1** |

7,632 + 103,428 = 111,060 exactly — every notify sent was cancelled. That the
failure is indifferent to nesting, depth and `WatchTree` is what rules out a
matching or fan-out explanation: a plain non-recursive watch on `atsy` failed
the same way as the recursive one on `abc`.

Each new test fails on the pre-fix code with the diagnostic that names the
defect, not merely absent:

- `AnswersFromBufferedEventsWithoutGoingPending` → `status = STATUS_PENDING, want STATUS_SUCCESS`
- `BufferedEventsBeatTheCancelTombstone` → `status = STATUS_CANCELLED, want STATUS_SUCCESS`
- `SyncAnswerThenCancelRespondsExactlyOnce` → asserts no second response
- `TakeBufferedEvents_LeavesNonMatchingEvents` → non-matching events survive; a third take returns nil
- `TakeBufferedEvents_KeepsByteCountForRemainingEvents` → `BufferedBytes = 0 while an event is still buffered — the overflow latch has nothing to measure`
- `ChangeNotify_WatchPathIsNormalised` → `watch opened as /d/sub/.. saw [], want the event on /d`

The byte-count one came out of review of this PR, not of develop: the first
version of `TakeBufferedEvents` zeroed `BufferedBytes` whenever it took
anything, even where non-matching events stayed buffered. That counter is what
the proactive overflow latch measures the backlog with, so under-counting it
stops the latch firing for a backlog that is still growing. It was reachable
through `TakeBufferedEvents_LeavesNonMatchingEvents` — a test this PR added —
which exercised the partial-drain case without checking the counter. Now
recomputed from what remains.

## Result

`memory` profile, targeted filters, against the real server:

| filter | before | after |
| --- | --- | --- |
| `smb2.notify.tree` | `error` — 17 watchers receiving zero events | **`success`** (44s) |
| `smb2.notify.mask` | `success` | **`success`** (88s) |
| `smb2.notify.double` | `failure` — `notify.c:1808` | **`success`** (31s) |

`mask` was run to *assert* that this change cannot break it rather than to rely
on the argument that it cannot: the argument and the evidence are different
things and only one of them is evidence.

The fix landed in two parts, and the second was predicted before it was
measured. The synchronous-answer path took `tree` from 17 zero-event watchers
to **one** — `i=12`, watching `test_notify_TREE\zqy\..`. That survivor is a
different defect: the handle stores the filename exactly as the client spelled
it, while events are reported against resolved paths, so that watch never
matched its own parent. Normalising the path where the watch derives it takes
it to zero.

That normalisation is deliberately **notify-local**. What CREATE stores is
unchanged, so the share-mode and delete-pending comparisons that read the same
field are untouched — those are a decision path, tracked separately as #2134,
and they are not something to change from inside a notify fix.

## `smb2.notify.double` now passes — and that does **not** fix #2129

`double` passes after this change without `Register`'s one-watch-per-FileID
replacement being touched. Under the immediate-reply path the test never needs
two outstanding watches: it does the mkdir first, so whichever request is
dispatched first is answered synchronously and never queues, and the other
queues and collects the second mkdir. The assertion is symmetric, so it holds
either dispatch order — which matters, because the two are dispatched
concurrently.

**#2129 stays open, and nothing here closes it.** `double` passing does not mean
the limitation was fixed; it means `double` stopped demonstrating it. `Register`
still replaces a second watch on the same FileID — that code is byte-identical
to develop. MS-SMB2 permits multiple outstanding CHANGE_NOTIFYs per handle and
real Windows clients issue them, so the gap is live; it is now merely
**unpinned**, which is worse for whoever has to find it later, not better.
Recorded on #2129 in those terms. Removing the limitation needs its own change
with its own coverage.

## The armed handle has to be refreshed even when nothing registers

Found in review of this PR, and it is the subtlest thing here.

When no watch is pending it is the **armed entry**, not the request, that
decides which events get buffered — `chargeArmedBuffer` gates on
`a.WatchTree` and `a.CompletionFilter` (`change_notify.go:1118`, `:1122`), the
rename paths on the same (`:1174-1179`, `:1231-1238`), and the proactive
overflow latch on `a.MaxOutputLength` (`:1256`). `Register` refreshes all of
those through `armLocked` on every re-arm. A request answered synchronously
never reaches `Register`, so it refreshed none of them, and `WatchTree` is
explicitly non-sticky — it comes fresh from each request.

**The two directions are not equally bad, and the asymmetry is the real
severity:**

- **Stale non-recursive** while the current request is recursive: matching
  subdirectory events are never buffered at all. They are *lost* — no later
  recursive request can recover them, because nothing ever wrote them down.
- **Stale recursive** while the current request is non-recursive: extra events
  are buffered, but `TakeBufferedEvents` filters them out and leaves them in
  place. They linger rather than mis-deliver.

Both are wrong; only one destroys data. The regression test drives the losing
direction specifically — arm non-recursive, answer a *recursive* request
synchronously, then fire a subdirectory event — and reports, against the
previous commit:

```
subdirectory event after a recursive sync answer = [], want it buffered —
the armed handle kept the previous request's non-recursive flag
```

The fix reuses the refresh `Register` already performs (`NotifyRegistry.Arm`
wrapping `armLocked`) rather than writing a second copy of the arming rule.
Two copies of "what is this handle watching" is how the next drift bug gets
written.

## Deliberately undecided

Two behaviours this PR does not settle, stated so nobody has to infer whether
they were derived:

**Completion-filter interaction with the immediate reply.** Samba leaves a
`TODO: write a torture test to check the filtering behaviour here` directly
above the code being mirrored, so upstream is itself unsure. This PR matches
only what `smb2.notify.tree` and `smb2.notify.mask` actually pin and invents
nothing beyond that.

**Overflow on the synchronous path.** When the encoded reply exceeds the
advertised buffer, this latches the sticky-overflow flag and returns
`STATUS_NOTIFY_ENUM_DIR`. **I made it latch, to match `deliverChanges` on the
async path, and no test pins it either way.** It was chosen for consistency,
not derived from a requirement — so it can be changed later without wondering
what depended on it.

## Scope

`Register`'s one-watch-per-FileID replacement is **not** touched. If
`smb2.notify.double` passes as a result of this change, that limitation stops
being pinned by any test, which makes altering it a change with no coverage
either way — not something that should ride along inside this PR.

`smb2.notify.tree`'s `KNOWN_FAILURES.md` row is removed here. #2131 added it
against this issue on its own measurement; it comes out on this one.

Closes #2133
