### PR TITLE
fix(smb): key per-lease state on the lease's identity, not on the lease key alone

### DIFF
--- a/internal/adapter/smb/handlers/create.go
+++ b/internal/adapter/smb/handlers/create.go
@@ -947,7 +947,7 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 						// subsequent break notifications carry the correct
 						// NewEpoch rather than the re-registration's reset value.
 						if reportedLeaseEpoch != epoch {
-							h.LeaseManager.SetLeaseEpoch(restored.LeaseKey, reportedLeaseEpoch)
+							h.LeaseManager.SetLeaseEpoch(tree.ShareName, restored.LeaseKey, reportedLeaseEpoch)
 						}
 						// Build lease response context
 						if leaseCtx := FindCreateContext(req.CreateContexts, LeaseContextTagRequest); leaseCtx != nil {
@@ -981,12 +981,12 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 						// version recorded by the original grant; an absent
 						// mark (e.g. cleared by intervening release) is set to
 						// V2 here.
-						h.LeaseManager.MarkLeaseVersionIfUnset(restored.LeaseKey, true)
+						h.LeaseManager.MarkLeaseVersionIfUnset(lockFileHandle, tree.ShareName, restored.LeaseKey, true)
 						restored.OplockLevel = OplockLevelLease
 					}
 
 					// Update session mapping for break notification routing
-					h.LeaseManager.UpdateSessionForLease(restored.LeaseKey, ctx.SessionID)
+					h.LeaseManager.UpdateSessionForLease(clientID, tree.ShareName, restored.LeaseKey, ctx.SessionID)
 				} else if restored.OplockLevel != OplockLevelNone && restored.OplockLevel != OplockLevelLease {
 					// Traditional oplock: re-request via synthetic lease key
 					var requestedState uint32
@@ -1701,7 +1701,7 @@ func (h *Handler) refreshReplayLease(ctx *SMBHandlerContext, req *CreateRequest,
 	if h.LeaseManager == nil {
 		return types.StatusSuccess
 	}
-	state, epoch, found := h.LeaseManager.GetLeaseState(ctx.Context, open.LeaseKey)
+	state, epoch, found := h.LeaseManager.GetLeaseState(ctx.Context, open.ShareName, open.LeaseKey)
 	if !found {
 		return types.StatusSuccess
 	}

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -1370,7 +1370,7 @@ func (h *Handler) closeFilesWithFilter(
 			var leaseState uint32
 			var leaseEpoch uint16
 			if h.LeaseManager != nil && openFile.LeaseKey != ([16]byte{}) {
-				if state, epoch, found := h.LeaseManager.GetLeaseState(ctx, openFile.LeaseKey); found {
+				if state, epoch, found := h.LeaseManager.GetLeaseState(ctx, openFile.ShareName, openFile.LeaseKey); found {
 					leaseState = state
 					leaseEpoch = epoch
 				}

--- a/internal/adapter/smb/handlers/lease_context.go
+++ b/internal/adapter/smb/handlers/lease_context.go
@@ -296,7 +296,7 @@ func (r *LeaseResponseContext) Encode() []byte {
 // carries `ctx`, or the zero value when no CryptoState is wired (test
 // contexts and some legacy paths). The lease layer treats a zero GUID as
 // "ClientGUID-based break routing disabled for this lease" and falls back
-// to the per-lease sessionMap, so passing zero is always safe.
+// to the session that registered the lease, so passing zero is always safe.
 func connClientGUID(ctx *SMBHandlerContext) [16]byte {
 	if ctx == nil || ctx.ConnCryptoState == nil {
 		return [16]byte{}
@@ -331,8 +331,8 @@ func FindCreateContext(contexts []CreateContext, name string) *CreateContext {
 //     Used by LeaseManager to bind the lease at MS-SMB2 §3.3.5.9.8 granularity
 //     and route break notifications to the client's primary session
 //     (smbtorture v2_complex1). Tests that don't exercise multi-session
-//     routing pass a zero value, which falls back to per-lease sessionMap
-//     dispatch.
+//     routing pass a zero value, which falls back to dispatching on the
+//     session that registered the lease.
 //   - clientID: The connection tracker client ID
 //   - shareName: The share name
 //   - isDirectory: Whether the target is a directory

--- a/internal/adapter/smb/handlers/lease_context.go
+++ b/internal/adapter/smb/handlers/lease_context.go
@@ -464,7 +464,7 @@ func ProcessLeaseCreateContext(
 	// v2_epoch2 (V2 grant + V1 reopen → V2 response with running epoch) and
 	// v2_epoch3 (V1 grant + V2 upgrade → V1 response throughout).
 	if err == nil && grantedState != lock.LeaseStateNone {
-		leaseMgr.MarkLeaseVersionIfUnset(leaseReq.LeaseKey, !requestIsV1)
+		leaseMgr.MarkLeaseVersionIfUnset(fileHandle, shareName, leaseReq.LeaseKey, !requestIsV1)
 	}
 
 	// Resolve the response version from the lease's recorded version. Fall
@@ -473,8 +473,8 @@ func ProcessLeaseCreateContext(
 	// ErrLeaseBreakInProgress (referencing a lease already marked at its
 	// original grant; the !IsLeaseVersionKnown branch is defensive).
 	responseIsV1 := requestIsV1
-	if leaseMgr.IsLeaseVersionKnown(leaseReq.LeaseKey) {
-		responseIsV1 = !leaseMgr.IsV2(leaseReq.LeaseKey)
+	if leaseMgr.IsLeaseVersionKnown(fileHandle, shareName, leaseReq.LeaseKey) {
+		responseIsV1 = !leaseMgr.IsV2(fileHandle, shareName, leaseReq.LeaseKey)
 	}
 
 	// Per MS-SMB2 3.3.5.9.8: the FIRST V2 grant for a lease key is a state
@@ -532,7 +532,7 @@ func ProcessLeaseCreateContext(
 			// starting point, one past what it asked for.
 			nextEpoch := leaseReq.Epoch + 1
 			if nextEpoch > epoch {
-				leaseMgr.SetLeaseEpoch(leaseReq.LeaseKey, nextEpoch)
+				leaseMgr.SetLeaseEpoch(shareName, leaseReq.LeaseKey, nextEpoch)
 				epoch = nextEpoch
 			}
 		}

--- a/internal/adapter/smb/handlers/lease_context_test.go
+++ b/internal/adapter/smb/handlers/lease_context_test.go
@@ -523,3 +523,50 @@ func TestProcessLeaseCreateContext_OtherFileSameKeyStillSeeds(t *testing.T) {
 			respB.Epoch, secondEpoch+1)
 	}
 }
+
+// TestProcessLeaseCreateContext_OtherClientSameKeyKeepsOwnVersion pins the
+// scope of the recorded lease version. The version decides the shape of the
+// RqLs response context on the wire: a V1 lease answers with the 32-byte
+// context that has no epoch field, a V2 lease with the 52-byte one that does.
+// Two clients may present the same 16-byte lease key value on different files,
+// so the version of one client's lease must not decide the response format of
+// the other's.
+func TestProcessLeaseCreateContext_OtherClientSameKeyKeepsOwnVersion(t *testing.T) {
+	t.Parallel()
+
+	mgr := lock.NewManager()
+	leaseMgr := lease.NewLeaseManager(&staticLockResolver{mgr: mgr}, nil)
+
+	ctx := context.Background()
+	const shareName = "share1"
+	leaseKey := [16]byte{0x7A, 0x7B, 0x7C}
+	const rh = lock.LeaseStateRead | lock.LeaseStateHandle
+	const clientEpoch uint16 = 0x0900
+
+	// Client A establishes the key with a V1 create context on one file.
+	v1 := make([]byte, LeaseV1ContextSize)
+	copy(v1[0:16], leaseKey[:])
+	binary.LittleEndian.PutUint32(v1[16:20], rh)
+	respA, err := ProcessLeaseCreateContext(ctx, leaseMgr, v1,
+		lock.FileHandle("file-A"), 1, [16]byte{0xA1}, "smb:1", shareName, false, false, false)
+	if err != nil {
+		t.Fatalf("client A CREATE returned error: %v", err)
+	}
+	if !respA.IsV1 {
+		t.Fatalf("client A response is V2, want V1")
+	}
+
+	// Client B presents the same key value on a different file, in a V2
+	// create context. It is a different lease and must be answered as V2.
+	respB, err := ProcessLeaseCreateContext(ctx, leaseMgr, encodeV2LeaseContext(leaseKey, rh, clientEpoch),
+		lock.FileHandle("file-B"), 2, [16]byte{0xB2}, "smb:2", shareName, false, false, false)
+	if err != nil {
+		t.Fatalf("client B CREATE returned error: %v", err)
+	}
+	if respB.IsV1 {
+		t.Errorf("client B response context is V1 (32 bytes, no epoch field), want V2 — another client's lease under the same key value decided this client's response format")
+	}
+	if respB.Epoch != clientEpoch+1 {
+		t.Errorf("client B response epoch = 0x%x, want 0x%x", respB.Epoch, clientEpoch+1)
+	}
+}

--- a/internal/adapter/smb/handlers/reopen2_e2e_test.go
+++ b/internal/adapter/smb/handlers/reopen2_e2e_test.go
@@ -382,7 +382,7 @@ func TestReopen2_V2Lease_RestoresRWH(t *testing.T) {
 		t.Fatal("initial open: missing DH2Q grant blob")
 	}
 	// Confirm the lease really sits at RWH in the LeaseManager before disconnect.
-	if state, _, found := e.h.LeaseManager.GetLeaseState(context.Background(), leaseKey); !found ||
+	if state, _, found := e.h.LeaseManager.GetLeaseState(context.Background(), e.tree.ShareName, leaseKey); !found ||
 		state != uint32(lock.LeaseStateRead|lock.LeaseStateWrite|lock.LeaseStateHandle) {
 		t.Fatalf("initial open: LeaseManager state = 0x%x found=%v, want RWH", state, found)
 	}

--- a/internal/adapter/smb/handlers/replay_dhv2_test.go
+++ b/internal/adapter/smb/handlers/replay_dhv2_test.go
@@ -250,6 +250,7 @@ func grantRWHLease(t *testing.T, leaseMgr *lease.LeaseManager, leaseKey [16]byte
 	}
 	return &OpenFile{
 		SessionID:   sessionID,
+		ShareName:   "share1",
 		OplockLevel: OplockLevelLease,
 		LeaseKey:    leaseKey,
 	}

--- a/internal/adapter/smb/handlers/stub_handlers.go
+++ b/internal/adapter/smb/handlers/stub_handlers.go
@@ -841,7 +841,7 @@ func (h *Handler) handleLeaseBreakAck(ctx *SMBHandlerContext, body []byte) (*Han
 		return NewErrorResult(types.StatusInvalidParameter), nil
 	}
 
-	if err := h.LeaseManager.AcknowledgeLeaseBreak(ctx.Context, ack.LeaseKey, ack.LeaseState, 0); err != nil {
+	if err := h.LeaseManager.AcknowledgeLeaseBreak(ctx.Context, ack.LeaseKey, ctx.SessionID, connClientGUID(ctx), ack.LeaseState, 0); err != nil {
 		logger.Warn("LEASE_BREAK_ACK: acknowledgment failed",
 			"leaseKey", fmt.Sprintf("%x", ack.LeaseKey),
 			"error", err)
@@ -899,7 +899,7 @@ func (h *Handler) handleOplockBreakAck(ctx *SMBHandlerContext, body []byte) (*Ha
 	// Map acknowledged oplock level to lease state
 	newState := oplockLevelToLeaseState(ack.OplockLevel)
 
-	if err := h.LeaseManager.AcknowledgeLeaseBreak(ctx.Context, openFile.LeaseKey, newState, 0); err != nil {
+	if err := h.LeaseManager.AcknowledgeLeaseBreak(ctx.Context, openFile.LeaseKey, ctx.SessionID, connClientGUID(ctx), newState, 0); err != nil {
 		logger.Warn("OPLOCK_BREAK_ACK: acknowledgment failed",
 			"fileID", fmt.Sprintf("%x", ack.FileID),
 			"error", err)

--- a/internal/adapter/smb/lease/identity_test.go
+++ b/internal/adapter/smb/lease/identity_test.go
@@ -60,3 +60,152 @@ func TestReleaseSessionLeases_OtherClientSameKeyKeepsItsLease(t *testing.T) {
 		t.Errorf("client A's lease on file-A survived its own logoff")
 	}
 }
+
+// TestGetLeaseState_OtherShareSameKeyAnswersItsOwn asserts that a lease-state
+// read answers about the share it was asked about. The same 16-byte key value
+// can be live in two shares at once — each share has its own lock manager, so
+// the cross-file uniqueness rule does not span them. The state and epoch read
+// here go back out on the wire: they are what a durable disconnect persists
+// and what a replayed CREATE rewrites its RqLs response context with.
+func TestGetLeaseState_OtherShareSameKeyAnswersItsOwn(t *testing.T) {
+	t.Parallel()
+
+	mgr1, mgr2 := lock.NewManager(), lock.NewManager()
+	lm := NewLeaseManager(&shareResolver{mgrs: map[string]lock.LockManager{
+		"share1": mgr1,
+		"share2": mgr2,
+	}}, nil)
+	ctx := context.Background()
+	leaseKey := [16]byte{0x44, 0x55}
+
+	if _, _, err := lm.RequestLease(ctx, lock.FileHandle("file-A"), leaseKey, [16]byte{},
+		1, [16]byte{0xA1}, "smb:lease:A", "smb:1", "share1", testRH, false); err != nil {
+		t.Fatalf("client A RequestLease: %v", err)
+	}
+	if _, _, err := lm.RequestLease(ctx, lock.FileHandle("file-B"), leaseKey, [16]byte{},
+		2, [16]byte{0xB2}, "smb:lease:B", "smb:2", "share2", lock.LeaseStateRead, false); err != nil {
+		t.Fatalf("client B RequestLease: %v", err)
+	}
+
+	if state, _, found := lm.GetLeaseState(ctx, "share1", leaseKey); !found || state != testRH {
+		t.Errorf("GetLeaseState(share1) = 0x%x found=%v, want RH (0x%x) — answered from the other share's lease",
+			state, found, uint32(testRH))
+	}
+	if state, _, found := lm.GetLeaseState(ctx, "share2", leaseKey); !found || state != lock.LeaseStateRead {
+		t.Errorf("GetLeaseState(share2) = 0x%x found=%v, want R (0x%x)",
+			state, found, uint32(lock.LeaseStateRead))
+	}
+}
+
+// TestAcknowledgeLeaseBreak_ResolvesTheAckingClientsLease asserts that a
+// LEASE_BREAK_ACK is applied to the acking client's own lease. The wire gives
+// only a lease key, so the acking connection supplies the rest of the identity;
+// resolving the share from the key alone sends the ack to whichever client
+// registered the key value last, which both fails the acking client's request
+// and leaves its lease stuck in Breaking until the server force-downgrades it.
+func TestAcknowledgeLeaseBreak_ResolvesTheAckingClientsLease(t *testing.T) {
+	t.Parallel()
+
+	mgr1, mgr2 := lock.NewManager(), lock.NewManager()
+	lm := NewLeaseManager(&shareResolver{mgrs: map[string]lock.LockManager{
+		"share1": mgr1,
+		"share2": mgr2,
+	}}, nil)
+	ctx := context.Background()
+	leaseKey := [16]byte{0x66, 0x77}
+	guidA := [16]byte{0xA1}
+
+	if _, _, err := lm.RequestLease(ctx, lock.FileHandle("file-A"), leaseKey, [16]byte{},
+		1, guidA, "smb:lease:A", "smb:1", "share1", testRH, false); err != nil {
+		t.Fatalf("client A RequestLease: %v", err)
+	}
+	// Client B takes the same key value in the other share, after A. On a
+	// per-key share map this is the entry A's ack would resolve through.
+	if _, _, err := lm.RequestLease(ctx, lock.FileHandle("file-B"), leaseKey, [16]byte{},
+		2, [16]byte{0xB2}, "smb:lease:B", "smb:2", "share2", lock.LeaseStateRead, false); err != nil {
+		t.Fatalf("client B RequestLease: %v", err)
+	}
+
+	// A conflicting open breaks client A's lease.
+	if err := mgr1.BreakLeasesOnOpenConflict("file-A", &lock.LockOwner{ClientID: "smb:9"}, lock.BreakReasonDestructive); err != nil {
+		t.Fatalf("break A's lease: %v", err)
+	}
+	if !mgr1.HasOtherBreakingLeases("file-A", [16]byte{}) {
+		t.Fatal("client A's lease is not breaking after the conflicting open")
+	}
+
+	if err := lm.AcknowledgeLeaseBreak(ctx, leaseKey, 1, guidA, lock.LeaseStateNone, 0); err != nil {
+		t.Fatalf("client A's ack rejected: %v", err)
+	}
+	if mgr1.HasOtherBreakingLeases("file-A", [16]byte{}) {
+		t.Errorf("client A's lease is still breaking after its own ack — the ack was routed to another client's lease")
+	}
+	if state, _, _ := mgr2.GetLeaseState(ctx, leaseKey); state != lock.LeaseStateRead {
+		t.Errorf("client B's lease state = 0x%x, want R (0x%x) — A's ack downgraded B's lease",
+			state, uint32(lock.LeaseStateRead))
+	}
+}
+
+// TestVerifyLeaseAckOwnership_RejectsForeignClientSameKey asserts the ack
+// ownership gate is decided by the binding the ack will actually act on. A
+// session holding the same key value on another file must not be able to
+// acknowledge — and thereby downgrade — a lease it does not own.
+func TestVerifyLeaseAckOwnership_RejectsForeignClientSameKey(t *testing.T) {
+	t.Parallel()
+
+	mgr := lock.NewManager()
+	lm := NewLeaseManager(&shareResolver{mgrs: map[string]lock.LockManager{"share1": mgr}}, nil)
+	ctx := context.Background()
+	leaseKey := [16]byte{0x88}
+	guidA, guidB := [16]byte{0xA1}, [16]byte{0xB2}
+
+	if _, _, err := lm.RequestLease(ctx, lock.FileHandle("file-A"), leaseKey, [16]byte{},
+		1, guidA, "smb:lease:A", "smb:1", "share1", testRH, false); err != nil {
+		t.Fatalf("client A RequestLease: %v", err)
+	}
+	if _, _, err := lm.RequestLease(ctx, lock.FileHandle("file-B"), leaseKey, [16]byte{},
+		2, guidB, "smb:lease:B", "smb:2", "share1", testRH, false); err != nil {
+		t.Fatalf("client B RequestLease: %v", err)
+	}
+
+	if !lm.VerifyLeaseAckOwnership(leaseKey, 1, guidA) {
+		t.Error("client A's ack for its own lease was rejected")
+	}
+	if !lm.VerifyLeaseAckOwnership(leaseKey, 2, guidB) {
+		t.Error("client B's ack for its own lease was rejected")
+	}
+	if lm.VerifyLeaseAckOwnership(leaseKey, 3, [16]byte{0xCC}) {
+		t.Error("a third client's ack for a key it never bound was accepted")
+	}
+}
+
+// TestGetSessionForBreak_ZeroGUIDSameKeyRoutesToOwner covers the break-routing
+// fallback taken when no ClientGUID was recorded (callers without a
+// CryptoState: older durable-reconnect paths and tests). The ClientGUID path
+// above it is already client-scoped, so this fallback is where a per-key
+// session mapping mis-routes: the break for one client's lease is delivered on
+// whichever session registered the key value last.
+func TestGetSessionForBreak_ZeroGUIDSameKeyRoutesToOwner(t *testing.T) {
+	t.Parallel()
+
+	mgr := lock.NewManager()
+	lm := NewLeaseManager(&shareResolver{mgrs: map[string]lock.LockManager{"share1": mgr}}, nil)
+	ctx := context.Background()
+	leaseKey := [16]byte{0x99}
+
+	if _, _, err := lm.RequestLease(ctx, lock.FileHandle("file-A"), leaseKey, [16]byte{},
+		1, [16]byte{}, "smb:lease:A", "smb:1", "share1", testRH, false); err != nil {
+		t.Fatalf("client A RequestLease: %v", err)
+	}
+	if _, _, err := lm.RequestLease(ctx, lock.FileHandle("file-B"), leaseKey, [16]byte{},
+		2, [16]byte{}, "smb:lease:B", "smb:2", "share1", testRH, false); err != nil {
+		t.Fatalf("client B RequestLease: %v", err)
+	}
+
+	if sid, ok := lm.GetSessionForBreak("smb:1", "share1", leaseKey); !ok || sid != 1 {
+		t.Errorf("break for client A's lease routes to session %d (ok=%v), want 1", sid, ok)
+	}
+	if sid, ok := lm.GetSessionForBreak("smb:2", "share1", leaseKey); !ok || sid != 2 {
+		t.Errorf("break for client B's lease routes to session %d (ok=%v), want 2", sid, ok)
+	}
+}

--- a/internal/adapter/smb/lease/identity_test.go
+++ b/internal/adapter/smb/lease/identity_test.go
@@ -209,3 +209,33 @@ func TestGetSessionForBreak_ZeroGUIDSameKeyRoutesToOwner(t *testing.T) {
 		t.Errorf("break for client B's lease routes to session %d (ok=%v), want 2", sid, ok)
 	}
 }
+
+// TestResolveAckBinding_SameSessionTwoSharesIsDeterministic pins the tie-break
+// for the case MS-SMB2 does not contemplate: one session holding tree connects
+// to two shares and presenting the same lease key value in both. Map iteration
+// order is randomized, so resolving to whichever candidate came out of the map
+// first would send an ack to an arbitrary one of the two — leaving the other
+// lease Breaking until it times out, and downgrading a lease nobody acked.
+func TestResolveAckBinding_SameSessionTwoSharesIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	lm := NewLeaseManager(nil, nil)
+	leaseKey := [16]byte{0xAB, 0xCD}
+	lm.bindings[leaseClientKey{ClientID: "smb:1", Share: "share-b", Key: leaseKey}] =
+		leaseBinding{SessionID: 1, HandleKey: "file-b"}
+	lm.bindings[leaseClientKey{ClientID: "smb:1", Share: "share-a", Key: leaseKey}] =
+		leaseBinding{SessionID: 1, HandleKey: "file-a"}
+
+	lm.mu.RLock()
+	defer lm.mu.RUnlock()
+	for i := 0; i < 200; i++ {
+		ck, found := lm.resolveAckBindingLocked(leaseKey, 1, [16]byte{})
+		if !found {
+			t.Fatalf("iteration %d: no binding resolved", i)
+		}
+		if ck.Share != "share-a" {
+			t.Fatalf("iteration %d: ack resolved to share %q, want the deterministic pick %q",
+				i, ck.Share, "share-a")
+		}
+	}
+}

--- a/internal/adapter/smb/lease/identity_test.go
+++ b/internal/adapter/smb/lease/identity_test.go
@@ -239,3 +239,45 @@ func TestResolveAckBinding_SameSessionTwoSharesIsDeterministic(t *testing.T) {
 		}
 	}
 }
+
+// TestReleaseLeaseForHandle_DropsOnlyTheClosedHandlesBinding asserts that a
+// CLOSE takes the closing client's binding with it, and leaves alone a lease
+// another client holds under the same key value on a different file.
+//
+// A binding that outlives its own lease record still answers the ack ownership
+// gate, and the lock manager's own ack is by key: a client that has closed
+// could then acknowledge — and so downgrade — a break on the lease that
+// outlived it.
+func TestReleaseLeaseForHandle_DropsOnlyTheClosedHandlesBinding(t *testing.T) {
+	t.Parallel()
+
+	mgr := lock.NewManager()
+	lm := NewLeaseManager(&shareResolver{mgrs: map[string]lock.LockManager{"share1": mgr}}, nil)
+	ctx := context.Background()
+	leaseKey := [16]byte{0x33, 0x44}
+	guidA, guidB := [16]byte{0xA1}, [16]byte{0xB2}
+
+	if _, _, err := lm.RequestLease(ctx, lock.FileHandle("file-A"), leaseKey, [16]byte{},
+		1, guidA, "smb:lease:A", "smb:1", "share1", testRH, false); err != nil {
+		t.Fatalf("client A RequestLease: %v", err)
+	}
+	if _, _, err := lm.RequestLease(ctx, lock.FileHandle("file-B"), leaseKey, [16]byte{},
+		2, guidB, "smb:lease:B", "smb:2", "share1", testRH, false); err != nil {
+		t.Fatalf("client B RequestLease: %v", err)
+	}
+
+	// Client A closes its handle. Client B keeps its lease on the other file.
+	if err := lm.ReleaseLeaseForHandle(ctx, lock.FileHandle("file-A"), leaseKey, "share1"); err != nil {
+		t.Fatalf("ReleaseLeaseForHandle(file-A): %v", err)
+	}
+
+	if lm.VerifyLeaseAckOwnership(leaseKey, 1, guidA) {
+		t.Error("client A can still acknowledge a break after closing its only handle — its binding outlived its lease")
+	}
+	if !lm.VerifyLeaseAckOwnership(leaseKey, 2, guidB) {
+		t.Error("client B lost its ack ownership when client A closed a different file")
+	}
+	if sid, ok := lm.GetSessionForBreak("smb:2", "share1", leaseKey); !ok || sid != 2 {
+		t.Errorf("client B break routing after A's close = %d (ok=%v), want 2", sid, ok)
+	}
+}

--- a/internal/adapter/smb/lease/identity_test.go
+++ b/internal/adapter/smb/lease/identity_test.go
@@ -1,0 +1,62 @@
+package lease
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// shareResolver routes each share name to its own lock.Manager, mirroring the
+// per-share LockManager layout the runtime builds.
+type shareResolver struct {
+	mgrs map[string]lock.LockManager
+}
+
+func (r *shareResolver) GetLockManagerForShare(shareName string) lock.LockManager {
+	return r.mgrs[shareName]
+}
+
+const testRH = lock.LeaseStateRead | lock.LeaseStateHandle
+
+// TestReleaseSessionLeases_OtherClientSameKeyKeepsItsLease asserts that a
+// logoff releases only the leases the departing session actually holds. Two
+// clients may present the same 16-byte lease key value on different files, so
+// a per-key session mapping records only whichever of them registered last:
+// the survivor's lease is torn down and the loser's is never released at all.
+func TestReleaseSessionLeases_OtherClientSameKeyKeepsItsLease(t *testing.T) {
+	t.Parallel()
+
+	mgr := lock.NewManager()
+	lm := NewLeaseManager(&shareResolver{mgrs: map[string]lock.LockManager{"share1": mgr}}, nil)
+	ctx := context.Background()
+	leaseKey := [16]byte{0x11, 0x22, 0x33}
+
+	if _, _, err := lm.RequestLease(ctx, lock.FileHandle("file-A"), leaseKey, [16]byte{},
+		1, [16]byte{0xA1}, "smb:lease:A", "smb:1", "share1", testRH, false); err != nil {
+		t.Fatalf("client A RequestLease: %v", err)
+	}
+	if _, _, err := lm.RequestLease(ctx, lock.FileHandle("file-B"), leaseKey, [16]byte{},
+		2, [16]byte{0xB2}, "smb:lease:B", "smb:2", "share1", testRH, false); err != nil {
+		t.Fatalf("client B RequestLease: %v", err)
+	}
+
+	// Client B logs off. Only its lease on file-B may go.
+	if err := lm.ReleaseSessionLeases(ctx, 2); err != nil {
+		t.Fatalf("ReleaseSessionLeases(2): %v", err)
+	}
+	if !mgr.HasLeaseOnHandle("file-A", leaseKey) {
+		t.Errorf("client A's lease on file-A was released by client B's logoff")
+	}
+	if mgr.HasLeaseOnHandle("file-B", leaseKey) {
+		t.Errorf("client B's lease on file-B survived its own logoff")
+	}
+
+	// Client A logs off. Its lease must go now.
+	if err := lm.ReleaseSessionLeases(ctx, 1); err != nil {
+		t.Fatalf("ReleaseSessionLeases(1): %v", err)
+	}
+	if mgr.HasLeaseOnHandle("file-A", leaseKey) {
+		t.Errorf("client A's lease on file-A survived its own logoff")
+	}
+}

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -498,25 +498,34 @@ func (lm *LeaseManager) AcknowledgeLeaseBreak(
 // owning session walk past the first match. Add a by-key index if a profile
 // ever shows this scan.
 func (lm *LeaseManager) resolveAckBindingLocked(leaseKey [16]byte, sessionID uint64, connGUID [16]byte) (leaseClientKey, bool) {
-	var guidKey leaseClientKey
-	var guidFound bool
+	// A client holding one key in two shares makes the ack ambiguous —
+	// MS-SMB2 §3.3.5.9.8 binds a lease to (ClientGuid, LeaseKey) and does not
+	// contemplate it, and a single session can hold tree connects to both. Map
+	// iteration order is randomized, so both branches below take the lowest
+	// share name rather than the first hit: an ack that lands on an arbitrary
+	// one of two candidates leaves the other lease Breaking until it times out
+	// and downgrades a lease nobody acknowledged.
+	var sessionKey, guidKey leaseClientKey
+	var sessionFound, guidFound bool
 	for ck, b := range lm.bindings {
 		if ck.Key != leaseKey {
 			continue
 		}
 		if b.SessionID == sessionID {
-			return ck, true
+			if !sessionFound || ck.Share < sessionKey.Share {
+				sessionKey, sessionFound = ck, true
+			}
+			continue
 		}
 		if connGUID == ([16]byte{}) || !b.HasGUID || b.ClientGUID != connGUID {
 			continue
 		}
-		// A client holding one key in two shares makes the ack ambiguous —
-		// MS-SMB2 §3.3.5.9.8 binds a lease to (ClientGuid, LeaseKey) and does
-		// not contemplate it. Break the tie on share name so the choice is at
-		// least deterministic across runs.
 		if !guidFound || ck.Share < guidKey.Share {
 			guidKey, guidFound = ck, true
 		}
+	}
+	if sessionFound {
+		return sessionKey, true
 	}
 	return guidKey, guidFound
 }

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -57,20 +57,83 @@ const handleLeaseBreakWaitTimeout = 5 * time.Second
 // (timeout-disconnect, breaking3, etc.) rely on the shorter bound.
 const TraditionalOplockBreakWaitTimeout = 35 * time.Second
 
-// clientLeaseKey scopes lease-key bindings by (Owner.ClientID, lease key)
-// because lock.Manager allows two distinct clients to each hold a record
-// under the same numeric LeaseKey on different files (per round-3
-// `lease_match` scoping). Without this composite key, client B's lease
-// would overwrite client A's break-routing binding in `leaseClientGUID`,
-// or — sticky-on-first — route B's breaks to A's primary session.
+// leaseRecordKey identifies the lease RECORD the lock manager holds: one
+// share's lock manager, one file, one lease key. The lock manager matches a
+// request against an existing record on exactly (handleKey, leaseKey) within
+// one share's manager, so a property of the record — its protocol version —
+// belongs to that triple and not to the lease key alone.
 //
-// Key holds the raw 16-byte lease key (not a hex string): it is the map key
-// for every hot-path lease lookup, so using the array directly keeps those
-// paths allocation-free. Hex is computed only for logging.
-type clientLeaseKey struct {
+// Two distinct clients may present the same numeric lease key on different
+// files; keying a per-record property on the key alone lets whichever of them
+// wrote last decide the other's value.
+//
+// HandleKey and Key hold the raw handle string and the raw 16-byte key (not a
+// hex string): this is a map key on the lease hot path, so using them directly
+// keeps those paths allocation-free. Hex is computed only for logging.
+type leaseRecordKey struct {
+	Share     string
+	HandleKey string
+	Key       [16]byte
+}
+
+// leaseClientKey identifies one client's BINDING to a lease key: (client,
+// share, key). Per MS-SMB2 §3.3.5.9.8 a lease is bound to a
+// (ClientGUID, LeaseKey) pair, and lock.Manager enforces that binding by
+// refusing a key already held by the same Owner.ClientID on another file
+// within the share (`hasLeaseKeyOnOtherFile`, Samba `lease_match`). That rule
+// makes this triple resolve to at most one file at a time, so the binding can
+// carry the file it is on rather than key on it.
+//
+// The share is part of the identity because the uniqueness rule is enforced
+// per share — each share has its own lock manager — so one client can hold the
+// same key on files in two different shares.
+type leaseClientKey struct {
 	ClientID string
+	Share    string
 	Key      [16]byte
 }
+
+// leaseBinding is what a client's hold on a lease key resolves to: the file
+// the lease is on, the session that registered it, and the ClientGUID it is
+// bound to.
+type leaseBinding struct {
+	// HandleKey is the file the lease was granted on. Recorded rather than
+	// keyed on because (client, share, key) already determines it, and the
+	// LEASE_BREAK_ACK path is given only a lease key on the wire.
+	HandleKey string
+
+	// SessionID is the session that most recently registered this binding.
+	// Break notifications fall back to it when no ClientGUID was recorded.
+	SessionID uint64
+
+	// ClientGUID is the GUID recorded on the FIRST grant for this binding
+	// and is sticky: a same-(client, share, key) reopen does not change it.
+	// Per MS-SMB2 §3.3.5.9.8 break notifications are routed at the client
+	// level (Samba `smbXsrv_pending_break_submit` in
+	// source3/smbd/smb2_server.c picks the FIRST connection of
+	// `client->connections` regardless of which session holds the open).
+	//
+	// Required by smbtorture smb2.lease.v2_complex1 — two sessions of the
+	// same ClientGUID open with different lease keys, and breaks for either
+	// lease must arrive on the FIRST session's primary transport.
+	ClientGUID [16]byte
+
+	// HasGUID distinguishes "bound to the zero GUID" from "never bound".
+	// Callers without a CryptoState (older durable-reconnect paths, tests)
+	// pass a zero GUID and get no ClientGUID-based routing.
+	HasGUID bool
+}
+
+// leaseVersion is the create-context version a lease was established with.
+// The zero value means the version is not yet known, which the response
+// encoder distinguishes from V1 (a single bool cannot carry the third state).
+type leaseVersion uint8
+
+const (
+	leaseVersionUnknown leaseVersion = iota
+	leaseVersionV1
+	leaseVersionV2
+)
 
 // LockManagerResolver resolves the LockManager for a given share name.
 // This allows the LeaseManager to work across multiple shares without
@@ -87,46 +150,34 @@ type LockManagerResolver interface {
 //
 // Thread-safe: all mutable state is protected by mu.
 type LeaseManager struct {
-	resolver   LockManagerResolver
-	notifier   LeaseBreakNotifier
-	sessionMap map[[16]byte]uint64 // leaseKey -> sessionID
-	leaseShare map[[16]byte]string // leaseKey -> shareName (for resolution)
-	// leaseV2 records whether each lease was granted from an
-	// SMB2_CREATE_REQUEST_LEASE_V2 context. Per MS-SMB2 §2.2.23.2 the
-	// NewEpoch field of a break notification MUST be zero for V1 leases;
-	// for V2 leases it carries the incremented lease epoch. Sending a
-	// non-zero NewEpoch on a V1 break trips the client (#417 root cause
-	// for smb2.multichannel.leases.test1-3).
-	//
-	// Sticky version semantics: per smbtorture v2_epoch2 / v2_epoch3, the
-	// lease's protocol version is set on the FIRST grant for a given key
-	// and does not change across reopens — even when a subsequent request
-	// uses the other version's create-context format. To distinguish
-	// V1-established (mark exists, value false) from
-	// version-not-yet-known (mark absent), we track BOTH versions
-	// explicitly via parallel maps; a single bool can't carry the third
-	// state. leaseV1 is true iff first grant was V1.
-	leaseV2 map[[16]byte]bool // leaseKey -> true iff V2-established
-	leaseV1 map[[16]byte]bool // leaseKey -> true iff V1-established
+	resolver LockManagerResolver
+	notifier LeaseBreakNotifier
 
-	// leaseClientGUID records the ClientGUID that first granted each
-	// (clientID, leaseKey) pair. Per MS-SMB2 §3.3.5.9.8 a lease is bound to
-	// a (ClientGUID, LeaseKey) pair and break notifications are routed at
-	// the client level (Samba `smbXsrv_pending_break_submit` in
-	// source3/smbd/smb2_server.c picks the FIRST connection of
-	// `client->connections` regardless of which session holds the open).
-	// Sticky on FIRST grant: a same-(clientID,key) reopen does NOT change
-	// the recorded GUID.
+	// bindings records, per (client, share, lease key), which file the lease
+	// is on, which session registered it, and which ClientGUID it is bound
+	// to. Break routing, share resolution and session teardown all read it.
+	bindings map[leaseClientKey]leaseBinding
+
+	// versions records the create-context version each lease RECORD was
+	// established with. Per MS-SMB2 §2.2.23.2 the NewEpoch field of a break
+	// notification MUST be zero for V1 leases and carries the incremented
+	// lease epoch for V2 ones; the same distinction selects the 32-byte or
+	// 52-byte RqLs response context on CREATE. Sending a non-zero NewEpoch
+	// on a V1 break trips the client (#417 root cause for
+	// smb2.multichannel.leases.test1-3).
 	//
-	// Composite-keyed by (clientID, leaseKey) because lock.Manager scopes
-	// lease-key uniqueness per Owner.ClientID — two distinct clients may
-	// each hold a record under the same numeric LeaseKey on different
-	// files, and break routing must not collide between them.
+	// Sticky version semantics: per smbtorture v2_epoch2 / v2_epoch3 the
+	// version is set on the FIRST grant for a record and does not change
+	// across reopens, even when a later request uses the other version's
+	// create-context format.
 	//
-	// Required by smbtorture smb2.lease.v2_complex1 — two sessions of the
-	// same ClientGUID open with different lease keys, and breaks for either
-	// lease must arrive on the FIRST session's primary transport.
-	leaseClientGUID map[clientLeaseKey][16]byte
+	// Keyed per record rather than per client because lock.Manager keeps ONE
+	// lease record per (handleKey, leaseKey) and hands it to every requester
+	// of that key on that file — including a second session of the same
+	// client. The version has to follow the record it describes, or a reopen
+	// on another session would answer in a different format than the break
+	// notification for the same record.
+	versions map[leaseRecordKey]leaseVersion
 
 	// clientPrimarySession records the FIRST sessionID seen for each
 	// ClientGUID (first-write wins). When a lease must be broken, its
@@ -151,11 +202,8 @@ func NewLeaseManager(resolver LockManagerResolver, notifier LeaseBreakNotifier) 
 	return &LeaseManager{
 		resolver:             resolver,
 		notifier:             notifier,
-		sessionMap:           make(map[[16]byte]uint64),
-		leaseShare:           make(map[[16]byte]string),
-		leaseV2:              make(map[[16]byte]bool),
-		leaseV1:              make(map[[16]byte]bool),
-		leaseClientGUID:      make(map[clientLeaseKey][16]byte),
+		bindings:             make(map[leaseClientKey]leaseBinding),
+		versions:             make(map[leaseRecordKey]leaseVersion),
 		clientPrimarySession: make(map[[16]byte]uint64),
 	}
 }
@@ -273,29 +321,31 @@ func (lm *LeaseManager) requestLeaseInternal(
 		return lock.LeaseStateNone, 0, fmt.Errorf("no lock manager for share %q", shareName)
 	}
 
-	// Pre-register the session mapping BEFORE creating the lease in the
-	// LockManager. The LockManager's RequestLease may trigger cross-key
-	// conflict breaks, which dispatch through breakOpLocks → SMBBreakHandler.
-	// If the session mapping isn't set yet, the break notification can't be
-	// routed to the correct SMB client. Similarly, another goroutine's
-	// BreakHandleLeasesOnOpenAsync may fire between the LockManager grant
-	// and the session map update, causing a "no session" miss.
+	// Pre-register the binding BEFORE creating the lease in the LockManager.
+	// The LockManager's RequestLease may trigger cross-key conflict breaks,
+	// which dispatch through breakOpLocks → SMBBreakHandler. If the binding
+	// isn't set yet, the break notification can't be routed to the correct
+	// SMB client. Similarly, another goroutine's BreakHandleLeasesOnOpenAsync
+	// may fire between the LockManager grant and the binding update, causing
+	// a "no session" miss.
 	//
-	// Pre-registering is safe: if the grant fails or returns None, we
-	// remove the entry below.
+	// Pre-registering is safe: if the grant fails or returns None, the
+	// previous binding is put back below.
+	ck := leaseClientKey{ClientID: clientID, Share: shareName, Key: leaseKey}
 	lm.mu.Lock()
-	lm.sessionMap[leaseKey] = sessionID
-	lm.leaseShare[leaseKey] = shareName
-	// Bind the lease to a ClientGUID on FIRST grant (sticky). Cross-client
-	// key reuse is rejected upstream by lease_match (ErrLeaseKeyInUse), so
-	// the only paths that re-enter here on the same key are same-client
-	// reopens / upgrades — those must NOT rebind the GUID. Zero ClientGUID
+	prev, hadPrev := lm.bindings[ck]
+	binding := prev
+	binding.HandleKey = string(fileHandle)
+	binding.SessionID = sessionID
+	// Bind the lease to a ClientGUID on FIRST grant (sticky). The only paths
+	// that re-enter here on the same (client, share, key) are same-client
+	// reopens and upgrades — those must NOT rebind the GUID. Zero ClientGUID
 	// callers (legacy paths) leave the binding unset and fall back to the
-	// per-lease sessionMap for break dispatch.
+	// binding's session for break dispatch.
 	if clientGUID != ([16]byte{}) {
-		clk := clientLeaseKey{ClientID: clientID, Key: leaseKey}
-		if _, bound := lm.leaseClientGUID[clk]; !bound {
-			lm.leaseClientGUID[clk] = clientGUID
+		if !binding.HasGUID {
+			binding.ClientGUID = clientGUID
+			binding.HasGUID = true
 		}
 		// Register this session as the primary for the ClientGUID iff no
 		// session is currently registered (first-write wins). Mirrors the
@@ -308,7 +358,23 @@ func (lm *LeaseManager) requestLeaseInternal(
 			lm.clientPrimarySession[clientGUID] = sessionID
 		}
 	}
+	lm.bindings[ck] = binding
 	lm.mu.Unlock()
+
+	// restorePreRegistration undoes the pre-registration above when the grant
+	// produced no record. A rejected grant must not leave this client's
+	// binding pointing at the file it was refused — the client may still hold
+	// the key on the file it bound earlier, which is exactly why the grant
+	// was refused.
+	restorePreRegistration := func() {
+		lm.mu.Lock()
+		if hadPrev {
+			lm.bindings[ck] = prev
+		} else {
+			delete(lm.bindings, ck)
+		}
+		lm.mu.Unlock()
+	}
 
 	// Dispatch to the appropriate Manager method so the new record's
 	// IsTraditionalOplock tag and stat-open break-suppression are set
@@ -339,20 +405,22 @@ func (lm *LeaseManager) requestLeaseInternal(
 		)
 	}
 	if err != nil && !errors.Is(err, lock.ErrLeaseBreakInProgress) {
-		lm.removeLeaseMapping(leaseKey)
+		restorePreRegistration()
 		return 0, 0, err
 	}
 
-	// Remove pre-registered mapping only if the LockManager has no record
-	// for this key. grantedState == None can mean either:
+	// Undo the pre-registration only if the LockManager has no record for
+	// this key on this file. grantedState == None can mean either:
 	//   - rejected request (no record created) — must reap pre-registration
 	//   - successful None probe / existing released-to-None record — keep
-	//     the mapping so a later unsolicited or duplicate ack still resolves
+	//     the binding so a later unsolicited or duplicate ack still resolves
 	//     and surfaces ErrLeaseAckNotBreaking (smbtorture breaking5).
-	if grantedState == lock.LeaseStateNone {
-		if _, _, found := lockMgr.GetLeaseState(ctx, leaseKey); !found {
-			lm.removeLeaseMapping(leaseKey)
-		}
+	//
+	// The check is scoped to this file: a record under the same key on a
+	// DIFFERENT file belongs to another client's lease and says nothing about
+	// whether this grant created anything.
+	if grantedState == lock.LeaseStateNone && !lm.HasLeaseOnHandle(fileHandle, shareName, leaseKey) {
+		restorePreRegistration()
 	}
 
 	return grantedState, epoch, err
@@ -377,17 +445,26 @@ func (lm *LeaseManager) requestLeaseInternal(
 func (lm *LeaseManager) AcknowledgeLeaseBreak(
 	ctx context.Context,
 	leaseKey [16]byte,
+	sessionID uint64,
+	connGUID [16]byte,
 	acknowledgedState uint32,
 	epoch uint16,
 ) error {
 	lm.mu.RLock()
-	shareName := lm.leaseShare[leaseKey]
+	ck, _, found := lm.resolveAckBindingLocked(leaseKey, sessionID, connGUID)
 	lm.mu.RUnlock()
+	if !found {
+		logger.Debug("AcknowledgeLeaseBreak: no lease bound to this client (CLOSE-beat-ack), treating as success",
+			"leaseKey", fmt.Sprintf("%x", leaseKey),
+			"sessionID", sessionID)
+		return nil
+	}
 
-	lockMgr := lm.resolveLockManager(shareName)
+	lockMgr := lm.resolveLockManager(ck.Share)
 	if lockMgr == nil {
 		logger.Debug("AcknowledgeLeaseBreak: no lock manager for lease (CLOSE-beat-ack), treating as success",
-			"leaseKey", fmt.Sprintf("%x", leaseKey))
+			"leaseKey", fmt.Sprintf("%x", leaseKey),
+			"share", ck.Share)
 		return nil
 	}
 
@@ -396,63 +473,122 @@ func (lm *LeaseManager) AcknowledgeLeaseBreak(
 		if errors.Is(err, lock.ErrLeaseAckNotFound) {
 			logger.Debug("AcknowledgeLeaseBreak: lease record absent (CLOSE-beat-ack), treating as success",
 				"leaseKey", fmt.Sprintf("%x", leaseKey))
-			lm.removeLeaseMapping(leaseKey)
+			lm.mu.Lock()
+			delete(lm.bindings, ck)
+			lm.mu.Unlock()
 			return nil
 		}
 		return err
 	}
 
-	// Do NOT reap leaseShare on ack-to-None: the lock manager keeps the
+	// Do NOT reap the binding on ack-to-None: the lock manager keeps the
 	// record alive at state=None until CLOSE, so a duplicate ack on the same
 	// key must continue to find the lockMgr and surface
-	// ErrLeaseAckNotBreaking. ReleaseLeaseForHandle clears the mapping when
-	// no records remain (see GetLeaseState-found check there).
+	// ErrLeaseAckNotBreaking. ReleaseLeaseForHandle clears the binding when
+	// no records remain (see the GetLeaseState-found check there).
 	return nil
 }
 
-// ReleaseLease delegates to the shared LockManager and removes the session mapping.
-func (lm *LeaseManager) ReleaseLease(ctx context.Context, leaseKey [16]byte) error {
-	// Resolve the LockManager for this lease's share
-	lm.mu.RLock()
-	shareName := lm.leaseShare[leaseKey]
-	lm.mu.RUnlock()
+// resolveAckBindingLocked finds the lease binding a LEASE_BREAK_ACK refers to.
+// The wire gives only a lease key, so the acknowledging connection supplies
+// the rest of the identity, exactly as MS-SMB2 §3.3.5.22.2 step 1 requires
+// ("locate the lease ... whose LeaseKey matches ... and ClientGuid matches
+// Connection.ClientGuid").
+//
+// The owning session is preferred; a ClientGUID match covers multichannel and
+// durable reconnect on a different session of the same client. A zero connGUID
+// never matches a recorded GUID, so a stray ack cannot probe another client's
+// lease. Must hold lm.mu (read or write).
+//
+// ponytail: linear over the bindings map, which holds one entry per open lease
+// per client — single digits in practice, and only acks that are not from the
+// owning session walk past the first match. Add a by-key index if a profile
+// ever shows this scan.
+func (lm *LeaseManager) resolveAckBindingLocked(leaseKey [16]byte, sessionID uint64, connGUID [16]byte) (leaseClientKey, leaseBinding, bool) {
+	var guidKey leaseClientKey
+	var guidBinding leaseBinding
+	var guidFound bool
+	for ck, b := range lm.bindings {
+		if ck.Key != leaseKey {
+			continue
+		}
+		if b.SessionID == sessionID {
+			return ck, b, true
+		}
+		if connGUID == ([16]byte{}) || !b.HasGUID || b.ClientGUID != connGUID {
+			continue
+		}
+		// A client holding one key in two shares makes the ack ambiguous —
+		// MS-SMB2 §3.3.5.9.8 binds a lease to (ClientGuid, LeaseKey) and does
+		// not contemplate it. Break the tie on share name so the choice is at
+		// least deterministic across runs.
+		if !guidFound || ck.Share < guidKey.Share {
+			guidKey, guidBinding, guidFound = ck, b, true
+		}
+	}
+	return guidKey, guidBinding, guidFound
+}
+
+// ReleaseLease releases every record for a lease key in one share and drops
+// the client's binding to it.
+func (lm *LeaseManager) ReleaseLease(ctx context.Context, clientID, shareName string, leaseKey [16]byte) error {
+	ck := leaseClientKey{ClientID: clientID, Share: shareName, Key: leaseKey}
 
 	lockMgr := lm.resolveLockManager(shareName)
 	if lockMgr == nil {
 		// Already released or no manager
-		lm.removeLeaseMapping(leaseKey)
+		lm.mu.Lock()
+		delete(lm.bindings, ck)
+		lm.mu.Unlock()
 		return nil
 	}
 
-	err := lockMgr.ReleaseLease(ctx, leaseKey)
-	if err != nil {
+	if err := lockMgr.ReleaseLease(ctx, leaseKey); err != nil {
 		return err
 	}
 
-	lm.removeLeaseMapping(leaseKey)
+	lm.mu.Lock()
+	delete(lm.bindings, ck)
+	lm.mu.Unlock()
 	return nil
 }
 
 // ReleaseLeaseForHandle releases lease records only under a specific handleKey
 // bucket. Used by CLOSE so that opens on OTHER files sharing the same
 // LeaseKey constant (typical in smbtorture, which reuses fixed LEASE1/LEASE2
-// macros across tests) retain their records. The session/share mappings are
-// only torn down when the last record for the key is gone.
+// macros across tests) retain their records. The bindings are only torn down
+// when the last record for the key is gone.
 func (lm *LeaseManager) ReleaseLeaseForHandle(ctx context.Context, fileHandle lock.FileHandle, leaseKey [16]byte, shareName string) error {
 	lockMgr := lm.resolveLockManager(shareName)
 	if lockMgr == nil {
 		return nil
 	}
 
-	if err := lockMgr.ReleaseLeaseForHandle(ctx, string(fileHandle), leaseKey); err != nil {
+	handleKey := string(fileHandle)
+	if err := lockMgr.ReleaseLeaseForHandle(ctx, handleKey, leaseKey); err != nil {
 		return err
 	}
 
-	// Only drop session/share mappings if no lease records remain anywhere for
-	// this key — otherwise a concurrent open on a different file would lose
-	// break-dispatch routing.
+	// The recorded version describes the record on THIS file, so it goes as
+	// soon as that record does — a surviving record under the same key on
+	// another file is a different lease with its own version.
+	if !lockMgr.HasLeaseOnHandle(handleKey, leaseKey) {
+		lm.mu.Lock()
+		delete(lm.versions, leaseRecordKey{Share: shareName, HandleKey: handleKey, Key: leaseKey})
+		lm.mu.Unlock()
+	}
+
+	// Only drop bindings if no lease records remain anywhere in this share
+	// for this key — otherwise a concurrent open on a different file would
+	// lose break-dispatch routing.
 	if _, _, found := lockMgr.GetLeaseState(ctx, leaseKey); !found {
-		lm.removeLeaseMapping(leaseKey)
+		lm.mu.Lock()
+		for ck := range lm.bindings {
+			if ck.Share == shareName && ck.Key == leaseKey {
+				delete(lm.bindings, ck)
+			}
+		}
+		lm.mu.Unlock()
 	}
 	return nil
 }
@@ -461,56 +597,57 @@ func (lm *LeaseManager) ReleaseLeaseForHandle(ctx context.Context, fileHandle lo
 // This is called during session cleanup (LOGOFF / connection close).
 func (lm *LeaseManager) ReleaseSessionLeases(ctx context.Context, sessionID uint64) error {
 	lm.mu.RLock()
-	// Collect all lease keys for this session
-	var keysToRelease [][16]byte
-	for key, sid := range lm.sessionMap {
-		if sid == sessionID {
-			keysToRelease = append(keysToRelease, key)
+	// Collect the bindings this session registered. Each carries the file its
+	// lease is on, so the release is scoped to that file: another client
+	// holding the same key value on a different file keeps its lease.
+	type sessionLease struct {
+		key     leaseClientKey
+		binding leaseBinding
+	}
+	var toRelease []sessionLease
+	for ck, b := range lm.bindings {
+		if b.SessionID == sessionID {
+			toRelease = append(toRelease, sessionLease{key: ck, binding: b})
 		}
 	}
 	lm.mu.RUnlock()
 
-	// Release each lease
-	for _, key := range keysToRelease {
-		if err := lm.ReleaseLease(ctx, key); err != nil {
+	for _, sl := range toRelease {
+		if err := lm.ReleaseLeaseForHandle(ctx, lock.FileHandle(sl.binding.HandleKey), sl.key.Key, sl.key.Share); err != nil {
 			logger.Warn("LeaseManager: failed to release session lease",
 				"sessionID", sessionID,
-				"leaseKey", fmt.Sprintf("%x", key),
+				"leaseKey", fmt.Sprintf("%x", sl.key.Key),
 				"error", err)
 			// Continue releasing other leases
 		}
+		lm.mu.Lock()
+		delete(lm.bindings, sl.key)
+		lm.mu.Unlock()
 	}
 
 	// Reap any clientPrimarySession entries that pointed at the gone
 	// session AND re-elect a successor where surviving leases of the same
 	// ClientGUID still exist. Without re-election, breaks for those leases
-	// would fall back to the per-lease sessionMap (last-write-wins),
-	// deviating from the "first live connection" semantics this map exists
-	// to enforce — Samba's `client->connections` always rehomes to the
-	// next-oldest connection of the client, not to whichever session most
-	// recently touched the lease. We approximate "oldest surviving
-	// session" by picking the smallest sessionID still associated with
-	// any (clientID, leaseKey) bound to that ClientGUID; sessionIDs are
-	// monotonically allocated, so smallest = earliest.
+	// would fall back to the binding's own session, deviating from the
+	// "first live connection" semantics this map exists to enforce — Samba's
+	// `client->connections` always rehomes to the next-oldest connection of
+	// the client, not to whichever session most recently touched the lease.
+	// We approximate "oldest surviving session" by picking the smallest
+	// sessionID still bound to that ClientGUID; sessionIDs are monotonically
+	// allocated, so smallest = earliest.
 	lm.mu.Lock()
 	for guid, sid := range lm.clientPrimarySession {
 		if sid != sessionID {
 			continue
 		}
-		// Election: scan leaseClientGUID for entries bound to this guid,
-		// look up their sessionMap entry, take min.
 		var minSID uint64
 		var found bool
-		for clk, boundGUID := range lm.leaseClientGUID {
-			if boundGUID != guid {
+		for _, b := range lm.bindings {
+			if !b.HasGUID || b.ClientGUID != guid || b.SessionID == sessionID {
 				continue
 			}
-			candidateSID, ok := lm.sessionMap[clk.Key]
-			if !ok || candidateSID == sessionID {
-				continue // skip the released session
-			}
-			if !found || candidateSID < minSID {
-				minSID = candidateSID
+			if !found || b.SessionID < minSID {
+				minSID = b.SessionID
 				found = true
 			}
 		}
@@ -525,12 +662,15 @@ func (lm *LeaseManager) ReleaseSessionLeases(ctx context.Context, sessionID uint
 	return nil
 }
 
-// GetLeaseState delegates to the shared LockManager.
-func (lm *LeaseManager) GetLeaseState(ctx context.Context, leaseKey [16]byte) (state uint32, epoch uint16, found bool) {
-	lm.mu.RLock()
-	shareName := lm.leaseShare[leaseKey]
-	lm.mu.RUnlock()
-
+// GetLeaseState returns the state and epoch of a lease key in one share.
+//
+// The share is a parameter rather than something this layer resolves from the
+// key, because the key alone does not identify a lease: two clients may
+// present the same 16-byte value on files in different shares, and answering
+// from the wrong share's lock manager reports a foreign lease's state and
+// epoch — values that go straight back out on the wire on a durable reconnect
+// or a replayed CREATE.
+func (lm *LeaseManager) GetLeaseState(ctx context.Context, shareName string, leaseKey [16]byte) (state uint32, epoch uint16, found bool) {
 	lockMgr := lm.resolveLockManager(shareName)
 	if lockMgr == nil {
 		return lock.LeaseStateNone, 0, false
@@ -541,14 +681,6 @@ func (lm *LeaseManager) GetLeaseState(ctx context.Context, leaseKey [16]byte) (s
 
 // HasLeaseOnHandle reports whether a lease record with this key already exists
 // on this file in this share.
-//
-// It takes the share explicitly rather than resolving it from the leaseShare
-// map, because that map is keyed on the raw lease key alone: two clients may
-// legitimately present the same 16-byte value, and whichever granted last owns
-// the entry. That is harmless for the best-effort routing the map was built
-// for, and not harmless for a caller deciding a value that goes out on the
-// wire. Pairing an explicit share with the file handle keeps the answer about
-// the lease this request is actually asking for.
 func (lm *LeaseManager) HasLeaseOnHandle(fileHandle lock.FileHandle, shareName string, leaseKey [16]byte) bool {
 	lockMgr := lm.resolveLockManager(shareName)
 	if lockMgr == nil {
@@ -557,12 +689,13 @@ func (lm *LeaseManager) HasLeaseOnHandle(fileHandle lock.FileHandle, shareName s
 	return lockMgr.HasLeaseOnHandle(string(fileHandle), leaseKey)
 }
 
-// GetSessionForLease returns the sessionID associated with a lease key.
-func (lm *LeaseManager) GetSessionForLease(leaseKey [16]byte) (sessionID uint64, found bool) {
+// GetSessionForLease returns the sessionID bound to a lease by one client in
+// one share.
+func (lm *LeaseManager) GetSessionForLease(clientID, shareName string, leaseKey [16]byte) (sessionID uint64, found bool) {
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()
-	sid, ok := lm.sessionMap[leaseKey]
-	return sid, ok
+	b, ok := lm.bindings[leaseClientKey{ClientID: clientID, Share: shareName, Key: leaseKey}]
+	return b.SessionID, ok
 }
 
 // VerifyLeaseAckOwnership reports whether a session presenting a
@@ -573,50 +706,24 @@ func (lm *LeaseManager) GetSessionForLease(leaseKey [16]byte) (sessionID uint64,
 // when it arrives from the owning client.
 //
 // Authorization rule:
-//   - The lease must exist (sessionMap is the authoritative leaseKey registry).
-//   - The ack is authorized if the acking sessionID is the lease's registering
-//     session (the common case), OR the ack's connection ClientGUID matches the
-//     lease's recorded (ClientGuid, LeaseKey) binding (multichannel / durable
-//     reconnect on a different session of the same client).
+//   - A lease bound to this key must exist.
+//   - The ack is authorized if the acking sessionID registered the binding
+//     (the common case), OR the ack's connection ClientGUID matches the
+//     binding's recorded GUID (multichannel / durable reconnect on a
+//     different session of the same client).
 //
-// Returns false when the lease is unknown so a stray ack for a non-existent
-// lease key cannot be used to probe state. A zero connGUID never matches a
-// recorded non-zero GUID, so an attacker who cannot reproduce the victim's
-// ClientGUID is rejected.
+// Returns false when no such binding exists so a stray ack for a
+// non-existent lease key cannot be used to probe state. A zero connGUID never
+// matches a recorded non-zero GUID, so an attacker who cannot reproduce the
+// victim's ClientGUID is rejected.
 //
-// Cost: O(1) for the legitimate-owner ack (the only ack a well-behaved client
-// sends) via the sessionMap fast path below. The ClientGUID scan runs only for
-// acks whose sessionID does NOT already own the lease — and is bounded by the
-// number of distinct clients holding this EXACT leaseKey (effectively 1 for
-// real clients, which use random 16-byte keys), not the total lease count.
+// This resolves the same binding AcknowledgeLeaseBreak then acts on, so the
+// authorization and the action cannot disagree about which lease is meant.
 func (lm *LeaseManager) VerifyLeaseAckOwnership(leaseKey [16]byte, sessionID uint64, connGUID [16]byte) bool {
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()
-
-	// Lease must exist (sessionMap is the authoritative leaseKey registry).
-	sid, known := lm.sessionMap[leaseKey]
-	if !known {
-		return false
-	}
-
-	// Fast path: the registering session is acking its own lease. O(1).
-	if sid == sessionID {
-		return true
-	}
-
-	// Otherwise the ack may still be legitimate via the ClientGUID binding
-	// (multichannel / durable reconnect on a different session of the same
-	// client). Match the ack's connection GUID against the lease's recorded
-	// binding. A zero connGUID never matches a recorded non-zero GUID.
-	if connGUID != ([16]byte{}) {
-		for clk, guid := range lm.leaseClientGUID {
-			if clk.Key == leaseKey && guid == connGUID {
-				return true
-			}
-		}
-	}
-	// Neither the owning session nor a matching ClientGUID binding -> reject.
-	return false
+	_, _, found := lm.resolveAckBindingLocked(leaseKey, sessionID, connGUID)
+	return found
 }
 
 // GetSessionForBreak returns the sessionID that should receive a break
@@ -624,42 +731,50 @@ func (lm *LeaseManager) VerifyLeaseAckOwnership(leaseKey [16]byte, sessionID uin
 // `smbXsrv_pending_break_submit` (source3/smbd/smb2_server.c) the break is
 // delivered to the FIRST connection of `client->connections` — i.e. the
 // oldest live connection of the lease's ClientGUID — irrespective of which
-// session opened the file. When the lease has a recorded ClientGUID and a
+// session opened the file. When the binding has a recorded ClientGUID and a
 // primary session is registered for that GUID, this method returns that
-// session. Otherwise it falls back to the lease's per-record sessionMap
-// entry (legacy callers without ClientGUID; durable-reconnect tests that
-// don't thread a CryptoState).
+// session. Otherwise it falls back to the binding's own session (legacy
+// callers without a ClientGUID; durable-reconnect tests that don't thread a
+// CryptoState).
 //
 // Required by smbtorture smb2.lease.v2_complex1, which opens two sessions
 // of the same ClientGUID and asserts every lease break (including breaks
 // for leases held only by the second session) arrives on the first
 // session's transport.
-// `clientID` scopes the GUID lookup; pass `ul.Owner.ClientID` from the
-// breaking record so two clients holding the same numeric leaseKey on
-// different files don't cross-route their breaks. Empty clientID skips
-// the GUID-based path and falls back to the per-key sessionMap (legacy
-// callers without an Owner).
-func (lm *LeaseManager) GetSessionForBreak(leaseKey [16]byte, clientID string) (sessionID uint64, found bool) {
+//
+// clientID and shareName scope the lookup: pass `ul.Owner.ClientID` and
+// `ul.Owner.ShareName` from the breaking record so two clients holding the
+// same numeric leaseKey on different files don't cross-route their breaks,
+// and so the fallback session is the one that registered THIS lease rather
+// than whichever client registered the key value last.
+func (lm *LeaseManager) GetSessionForBreak(clientID, shareName string, leaseKey [16]byte) (sessionID uint64, found bool) {
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()
-	if clientID != "" {
-		if guid, ok := lm.leaseClientGUID[clientLeaseKey{ClientID: clientID, Key: leaseKey}]; ok {
-			if sid, ok := lm.clientPrimarySession[guid]; ok {
-				return sid, true
-			}
+	b, ok := lm.bindings[leaseClientKey{ClientID: clientID, Share: shareName, Key: leaseKey}]
+	if !ok {
+		return 0, false
+	}
+	if b.HasGUID {
+		if sid, ok := lm.clientPrimarySession[b.ClientGUID]; ok {
+			return sid, true
 		}
 	}
-	sid, ok := lm.sessionMap[leaseKey]
-	return sid, ok
+	return b.SessionID, true
 }
 
-// UpdateSessionForLease updates the session ID associated with a lease key.
-// Used during durable handle reconnect to associate the existing lease with
-// the new session for break notification routing.
-func (lm *LeaseManager) UpdateSessionForLease(leaseKey [16]byte, sessionID uint64) {
+// UpdateSessionForLease updates the session ID bound to a lease by one client
+// in one share. Used during durable handle reconnect to associate the existing
+// lease with the new session for break notification routing.
+func (lm *LeaseManager) UpdateSessionForLease(clientID, shareName string, leaseKey [16]byte, sessionID uint64) {
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
-	lm.sessionMap[leaseKey] = sessionID
+	ck := leaseClientKey{ClientID: clientID, Share: shareName, Key: leaseKey}
+	b, ok := lm.bindings[ck]
+	if !ok {
+		return
+	}
+	b.SessionID = sessionID
+	lm.bindings[ck] = b
 }
 
 // SetNotifier sets the lease break notifier for sending break notifications.
@@ -1232,14 +1347,14 @@ func (lm *LeaseManager) BreakParentReadLeasesOnModify(
 	return lockMgr.WaitForBreakCompletion(waitCtx, handleKey)
 }
 
-// SetLeaseEpoch sets the epoch on an existing lease identified by leaseKey.
-// Per MS-SMB2 3.3.5.9: For V2 leases, the server should track the client's
-// epoch from the RqLs create context.
-func (lm *LeaseManager) SetLeaseEpoch(leaseKey [16]byte, epoch uint16) {
-	lm.mu.RLock()
-	shareName := lm.leaseShare[leaseKey]
-	lm.mu.RUnlock()
-
+// SetLeaseEpoch sets the epoch on an existing lease identified by leaseKey in
+// one share. Per MS-SMB2 3.3.5.9: for V2 leases, the server should track the
+// client's epoch from the RqLs create context.
+//
+// The share is a parameter for the same reason it is one on GetLeaseState: the
+// key alone does not identify a lease, and the epoch written here is the
+// NewEpoch of the next break notification for whatever lease it lands on.
+func (lm *LeaseManager) SetLeaseEpoch(shareName string, leaseKey [16]byte, epoch uint16) {
 	lockMgr := lm.resolveLockManager(shareName)
 	if lockMgr == nil {
 		return
@@ -1291,95 +1406,74 @@ func (lm *LeaseManager) BreakReadLeasesOnWrite(
 	return lockMgr.CheckAndBreakOpLocksForWrite(handleKey, exclude)
 }
 
-// LeaseCount returns the number of active leases tracked by this manager.
-// Used for state debugging instrumentation.
+// LeaseCount returns the number of active lease bindings tracked by this
+// manager. Used for state debugging instrumentation.
 func (lm *LeaseManager) LeaseCount() int {
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()
-	return len(lm.sessionMap)
+	return len(lm.bindings)
 }
 
-// RangeLeases iterates over all tracked leases, calling fn for each.
+// RangeLeases iterates over all tracked lease bindings, calling fn for each.
 // The callback receives (leaseKey, sessionID, shareName); callers that need a
 // hex string for logging format it themselves (fmt.Sprintf("%x", leaseKey)).
 // Return false to stop iteration. Used for state debugging instrumentation.
 func (lm *LeaseManager) RangeLeases(fn func(leaseKey [16]byte, sessionID uint64, shareName string) bool) {
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()
-	for key, sid := range lm.sessionMap {
-		shareName := lm.leaseShare[key]
-		if !fn(key, sid, shareName) {
+	for ck, b := range lm.bindings {
+		if !fn(ck.Key, b.SessionID, ck.Share) {
 			return
 		}
 	}
 }
 
-// removeLeaseMapping removes a lease key from the session and share maps.
-// Must be called without lm.mu held.
-//
-// clientPrimarySession is intentionally NOT cleared here: it is keyed by
-// ClientGUID, not by lease key, and other leases of the same client may
-// still need it for break routing. The map is reaped by ReleaseSessionLeases
-// when the corresponding session disappears.
-func (lm *LeaseManager) removeLeaseMapping(leaseKey [16]byte) {
-	lm.mu.Lock()
-	delete(lm.sessionMap, leaseKey)
-	delete(lm.leaseShare, leaseKey)
-	delete(lm.leaseV2, leaseKey)
-	delete(lm.leaseV1, leaseKey)
-	// leaseClientGUID is composite-keyed by (clientID, leaseKey). The caller
-	// of removeLeaseMapping is the cleanup path of RequestLease for a
-	// failed grant; for a bound entry, the matching clientID is whichever
-	// client first bound it. Sweep all entries with this leaseKey —
-	// safe because at most one (clientID, leaseKey) is ever bound here per
-	// client (round-3 same-client cross-file rejection).
-	for clk := range lm.leaseClientGUID {
-		if clk.Key == leaseKey {
-			delete(lm.leaseClientGUID, clk)
-		}
-	}
-	lm.mu.Unlock()
-}
-
-// MarkLeaseVersionIfUnset records the lease's protocol version on FIRST grant
-// for the given key. Subsequent calls on the same key are no-ops — per
+// MarkLeaseVersionIfUnset records the lease's protocol version on the FIRST
+// grant for a record. Subsequent calls for the same record are no-ops — per
 // smbtorture v2_epoch2 / v2_epoch3 the version is sticky from the originating
 // grant: a V2-established lease keeps responding V2 even to V1 reopens, and
 // a V1-established lease keeps responding V1 even when a V2 upgrade comes in.
 //
+// Scoped to (share, file, key) because that is the identity of the record the
+// version describes. Keying it on the lease key alone lets a lease held by
+// another client under the same key value decide this lease's response format.
+//
 // Callers must invoke this after a successful RequestLease whenever the
 // grantedState is non-None, passing isV2 derived from the request's
 // create-context size (V2 = 52 bytes, V1 = 32 bytes).
-func (lm *LeaseManager) MarkLeaseVersionIfUnset(leaseKey [16]byte, isV2 bool) {
+func (lm *LeaseManager) MarkLeaseVersionIfUnset(fileHandle lock.FileHandle, shareName string, leaseKey [16]byte, isV2 bool) {
+	rk := leaseRecordKey{Share: shareName, HandleKey: string(fileHandle), Key: leaseKey}
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
-	if lm.leaseV1[leaseKey] || lm.leaseV2[leaseKey] {
+	if lm.versions[rk] != leaseVersionUnknown {
 		return
 	}
 	if isV2 {
-		lm.leaseV2[leaseKey] = true
+		lm.versions[rk] = leaseVersionV2
 	} else {
-		lm.leaseV1[leaseKey] = true
+		lm.versions[rk] = leaseVersionV1
 	}
 }
 
 // IsV2 reports whether the lease was first granted from a V2 create context.
-// Returns false for V1-established leases AND for unknown keys (safe default:
-// treat as V1 and send NewEpoch = 0 rather than leak a non-zero epoch).
-func (lm *LeaseManager) IsV2(leaseKey [16]byte) bool {
+// Returns false for V1-established leases AND for unknown records (safe
+// default: treat as V1 and send NewEpoch = 0 rather than leak a non-zero
+// epoch).
+func (lm *LeaseManager) IsV2(fileHandle lock.FileHandle, shareName string, leaseKey [16]byte) bool {
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()
-	return lm.leaseV2[leaseKey]
+	return lm.versions[leaseRecordKey{Share: shareName, HandleKey: string(fileHandle), Key: leaseKey}] == leaseVersionV2
 }
 
-// IsLeaseVersionKnown reports whether the lease's version has been recorded
-// (i.e. a successful grant has occurred for this key and MarkLeaseVersionIfUnset
-// fired). Used by the response-encoding path to decide whether to use the
-// established version or fall back to the current request's format.
-func (lm *LeaseManager) IsLeaseVersionKnown(leaseKey [16]byte) bool {
+// IsLeaseVersionKnown reports whether the record's version has been recorded
+// (i.e. a successful grant has occurred for this key on this file and
+// MarkLeaseVersionIfUnset fired). Used by the response-encoding path to decide
+// whether to use the established version or fall back to the current request's
+// format.
+func (lm *LeaseManager) IsLeaseVersionKnown(fileHandle lock.FileHandle, shareName string, leaseKey [16]byte) bool {
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()
-	return lm.leaseV1[leaseKey] || lm.leaseV2[leaseKey]
+	return lm.versions[leaseRecordKey{Share: shareName, HandleKey: string(fileHandle), Key: leaseKey}] != leaseVersionUnknown
 }
 
 // resolveLockManager resolves the LockManager for a share name.

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -546,27 +546,32 @@ func (lm *LeaseManager) ReleaseLeaseForHandle(ctx context.Context, fileHandle lo
 		return err
 	}
 
-	// The recorded version describes the record on THIS file, so it goes as
-	// soon as that record does — a surviving record under the same key on
-	// another file is a different lease with its own version.
-	if !lockMgr.HasLeaseOnHandle(handleKey, leaseKey) {
-		lm.mu.Lock()
-		delete(lm.versions, leaseRecordKey{Share: shareName, HandleKey: handleKey, Key: leaseKey})
-		lm.mu.Unlock()
+	// Both the recorded version and the bindings describe the record on THIS
+	// file, so they go as soon as that record does. A surviving record under
+	// the same key on another file belongs to a different lease that keeps its
+	// own version and its own break-dispatch routing.
+	//
+	// The check is handle-scoped rather than share-wide: asking whether ANY
+	// record for the key survives in the share keeps a binding alive whose
+	// own record is gone, and a stale binding still answers the ack ownership
+	// gate — letting a client that has closed acknowledge, and so downgrade,
+	// a break on the lease that outlived it.
+	//
+	// A holder that acked to None still has a record here (the lock manager
+	// keeps it at state=None until CLOSE), so a duplicate ack on the same key
+	// keeps resolving and keeps surfacing ErrLeaseAckNotBreaking.
+	if lockMgr.HasLeaseOnHandle(handleKey, leaseKey) {
+		return nil
 	}
 
-	// Only drop bindings if no lease records remain anywhere in this share
-	// for this key — otherwise a concurrent open on a different file would
-	// lose break-dispatch routing.
-	if _, _, found := lockMgr.GetLeaseState(ctx, leaseKey); !found {
-		lm.mu.Lock()
-		for ck := range lm.bindings {
-			if ck.Share == shareName && ck.Key == leaseKey {
-				delete(lm.bindings, ck)
-			}
+	lm.mu.Lock()
+	delete(lm.versions, leaseRecordKey{Share: shareName, HandleKey: handleKey, Key: leaseKey})
+	for ck, b := range lm.bindings {
+		if ck.Share == shareName && ck.Key == leaseKey && b.HandleKey == handleKey {
+			delete(lm.bindings, ck)
 		}
-		lm.mu.Unlock()
 	}
+	lm.mu.Unlock()
 	return nil
 }
 

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -521,30 +521,6 @@ func (lm *LeaseManager) resolveAckBindingLocked(leaseKey [16]byte, sessionID uin
 	return guidKey, guidFound
 }
 
-// ReleaseLease releases every record for a lease key in one share and drops
-// the client's binding to it.
-func (lm *LeaseManager) ReleaseLease(ctx context.Context, clientID, shareName string, leaseKey [16]byte) error {
-	ck := leaseClientKey{ClientID: clientID, Share: shareName, Key: leaseKey}
-
-	lockMgr := lm.resolveLockManager(shareName)
-	if lockMgr == nil {
-		// Already released or no manager
-		lm.mu.Lock()
-		delete(lm.bindings, ck)
-		lm.mu.Unlock()
-		return nil
-	}
-
-	if err := lockMgr.ReleaseLease(ctx, leaseKey); err != nil {
-		return err
-	}
-
-	lm.mu.Lock()
-	delete(lm.bindings, ck)
-	lm.mu.Unlock()
-	return nil
-}
-
 // ReleaseLeaseForHandle releases lease records only under a specific handleKey
 // bucket. Used by CLOSE so that opens on OTHER files sharing the same
 // LeaseKey constant (typical in smbtorture, which reuses fixed LEASE1/LEASE2

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -61,11 +61,9 @@ const TraditionalOplockBreakWaitTimeout = 35 * time.Second
 // share's lock manager, one file, one lease key. The lock manager matches a
 // request against an existing record on exactly (handleKey, leaseKey) within
 // one share's manager, so a property of the record — its protocol version —
-// belongs to that triple and not to the lease key alone.
-//
-// Two distinct clients may present the same numeric lease key on different
-// files; keying a per-record property on the key alone lets whichever of them
-// wrote last decide the other's value.
+// belongs to that triple and not to the lease key alone: two distinct clients
+// may present the same numeric key on different files, and keying on the key
+// alone lets whichever wrote last decide the other's value.
 //
 // HandleKey and Key hold the raw handle string and the raw 16-byte key (not a
 // hex string): this is a map key on the lease hot path, so using them directly
@@ -162,21 +160,16 @@ type LeaseManager struct {
 	// established with. Per MS-SMB2 §2.2.23.2 the NewEpoch field of a break
 	// notification MUST be zero for V1 leases and carries the incremented
 	// lease epoch for V2 ones; the same distinction selects the 32-byte or
-	// 52-byte RqLs response context on CREATE. Sending a non-zero NewEpoch
-	// on a V1 break trips the client (#417 root cause for
-	// smb2.multichannel.leases.test1-3).
-	//
-	// Sticky version semantics: per smbtorture v2_epoch2 / v2_epoch3 the
-	// version is set on the FIRST grant for a record and does not change
-	// across reopens, even when a later request uses the other version's
-	// create-context format.
+	// 52-byte RqLs response context on CREATE. Sending a non-zero NewEpoch on
+	// a V1 break trips the client (smb2.multichannel.leases.test1-3).
 	//
 	// Keyed per record rather than per client because lock.Manager keeps ONE
 	// lease record per (handleKey, leaseKey) and hands it to every requester
 	// of that key on that file — including a second session of the same
 	// client. The version has to follow the record it describes, or a reopen
 	// on another session would answer in a different format than the break
-	// notification for the same record.
+	// notification for the same record. MarkLeaseVersionIfUnset documents the
+	// sticky-on-first-grant semantics.
 	versions map[leaseRecordKey]leaseVersion
 
 	// clientPrimarySession records the FIRST sessionID seen for each
@@ -221,8 +214,8 @@ func NewLeaseManager(resolver LockManagerResolver, notifier LeaseBreakNotifier) 
 //     (NEGOTIATE). Used to bind the lease to its client at MS-SMB2 §3.3.5.9.8
 //     granularity and to route break notifications to the client's primary
 //     session (Samba `client->connections` head). Zero is accepted (no
-//     ClientGUID-based routing for that lease — falls back to per-lease
-//     sessionMap), which keeps callers that don't have a CryptoState wired
+//     ClientGUID-based routing for that lease — falls back to the binding's
+//     own session), which keeps callers that don't have a CryptoState wired
 //     (older durable-reconnect paths, tests) working.
 //   - ownerID: The lock owner identifier
 //   - clientID: The connection tracker client ID
@@ -451,7 +444,7 @@ func (lm *LeaseManager) AcknowledgeLeaseBreak(
 	epoch uint16,
 ) error {
 	lm.mu.RLock()
-	ck, _, found := lm.resolveAckBindingLocked(leaseKey, sessionID, connGUID)
+	ck, found := lm.resolveAckBindingLocked(leaseKey, sessionID, connGUID)
 	lm.mu.RUnlock()
 	if !found {
 		logger.Debug("AcknowledgeLeaseBreak: no lease bound to this client (CLOSE-beat-ack), treating as success",
@@ -504,16 +497,15 @@ func (lm *LeaseManager) AcknowledgeLeaseBreak(
 // per client — single digits in practice, and only acks that are not from the
 // owning session walk past the first match. Add a by-key index if a profile
 // ever shows this scan.
-func (lm *LeaseManager) resolveAckBindingLocked(leaseKey [16]byte, sessionID uint64, connGUID [16]byte) (leaseClientKey, leaseBinding, bool) {
+func (lm *LeaseManager) resolveAckBindingLocked(leaseKey [16]byte, sessionID uint64, connGUID [16]byte) (leaseClientKey, bool) {
 	var guidKey leaseClientKey
-	var guidBinding leaseBinding
 	var guidFound bool
 	for ck, b := range lm.bindings {
 		if ck.Key != leaseKey {
 			continue
 		}
 		if b.SessionID == sessionID {
-			return ck, b, true
+			return ck, true
 		}
 		if connGUID == ([16]byte{}) || !b.HasGUID || b.ClientGUID != connGUID {
 			continue
@@ -523,10 +515,10 @@ func (lm *LeaseManager) resolveAckBindingLocked(leaseKey [16]byte, sessionID uin
 		// not contemplate it. Break the tie on share name so the choice is at
 		// least deterministic across runs.
 		if !guidFound || ck.Share < guidKey.Share {
-			guidKey, guidBinding, guidFound = ck, b, true
+			guidKey, guidFound = ck, true
 		}
 	}
-	return guidKey, guidBinding, guidFound
+	return guidKey, guidFound
 }
 
 // ReleaseLease releases every record for a lease key in one share and drops
@@ -664,12 +656,11 @@ func (lm *LeaseManager) ReleaseSessionLeases(ctx context.Context, sessionID uint
 
 // GetLeaseState returns the state and epoch of a lease key in one share.
 //
-// The share is a parameter rather than something this layer resolves from the
-// key, because the key alone does not identify a lease: two clients may
-// present the same 16-byte value on files in different shares, and answering
-// from the wrong share's lock manager reports a foreign lease's state and
-// epoch — values that go straight back out on the wire on a durable reconnect
-// or a replayed CREATE.
+// The share is a parameter rather than resolved from the key because the key
+// alone does not identify a lease: two clients may present the same 16-byte
+// value in different shares, and the wrong share's lock manager reports a
+// foreign lease's state and epoch — values that go straight back out on the
+// wire on a durable reconnect or a replayed CREATE.
 func (lm *LeaseManager) GetLeaseState(ctx context.Context, shareName string, leaseKey [16]byte) (state uint32, epoch uint16, found bool) {
 	lockMgr := lm.resolveLockManager(shareName)
 	if lockMgr == nil {
@@ -699,30 +690,18 @@ func (lm *LeaseManager) GetSessionForLease(clientID, shareName string, leaseKey 
 }
 
 // VerifyLeaseAckOwnership reports whether a session presenting a
-// LEASE_BREAK_ACK for leaseKey is entitled to acknowledge it, per MS-SMB2
-// §3.3.5.22.2 step 1 ("the server MUST locate the lease ... whose LeaseKey
-// matches ... and whose ClientGuid matches the Connection.ClientGuid"). A
-// lease is bound to a (ClientGuid, LeaseKey) pair, so an ack is valid only
-// when it arrives from the owning client.
+// LEASE_BREAK_ACK for leaseKey is entitled to acknowledge it: a lease is bound
+// to a (ClientGuid, LeaseKey) pair, so an ack is valid only when it arrives
+// from the owning client. Returns false when the ack resolves to no binding,
+// so a stray ack for a key the sender never held cannot probe state.
 //
-// Authorization rule:
-//   - A lease bound to this key must exist.
-//   - The ack is authorized if the acking sessionID registered the binding
-//     (the common case), OR the ack's connection ClientGUID matches the
-//     binding's recorded GUID (multichannel / durable reconnect on a
-//     different session of the same client).
-//
-// Returns false when no such binding exists so a stray ack for a
-// non-existent lease key cannot be used to probe state. A zero connGUID never
-// matches a recorded non-zero GUID, so an attacker who cannot reproduce the
-// victim's ClientGUID is rejected.
-//
-// This resolves the same binding AcknowledgeLeaseBreak then acts on, so the
-// authorization and the action cannot disagree about which lease is meant.
+// This resolves the same binding AcknowledgeLeaseBreak then acts on (see
+// resolveAckBindingLocked for the matching rule), so the authorization and the
+// action cannot disagree about which lease is meant.
 func (lm *LeaseManager) VerifyLeaseAckOwnership(leaseKey [16]byte, sessionID uint64, connGUID [16]byte) bool {
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()
-	_, _, found := lm.resolveAckBindingLocked(leaseKey, sessionID, connGUID)
+	_, found := lm.resolveAckBindingLocked(leaseKey, sessionID, connGUID)
 	return found
 }
 
@@ -1434,9 +1413,8 @@ func (lm *LeaseManager) RangeLeases(fn func(leaseKey [16]byte, sessionID uint64,
 // grant: a V2-established lease keeps responding V2 even to V1 reopens, and
 // a V1-established lease keeps responding V1 even when a V2 upgrade comes in.
 //
-// Scoped to (share, file, key) because that is the identity of the record the
-// version describes. Keying it on the lease key alone lets a lease held by
-// another client under the same key value decide this lease's response format.
+// Scoped to (share, file, key) — the identity of the record the version
+// describes, see leaseRecordKey.
 //
 // Callers must invoke this after a successful RequestLease whenever the
 // grantedState is non-None, passing isV2 derived from the request's

--- a/internal/adapter/smb/lease/manager_test.go
+++ b/internal/adapter/smb/lease/manager_test.go
@@ -97,17 +97,18 @@ func TestMarkLeaseVersionIfUnset_StickyV2(t *testing.T) {
 
 	lm := NewLeaseManager(nil, nil)
 	key := [16]byte{0xAA}
+	fh := lock.FileHandle("file-1")
 
-	lm.MarkLeaseVersionIfUnset(key, true) // first grant: V2
-	if !lm.IsV2(key) {
+	lm.MarkLeaseVersionIfUnset(fh, "share1", key, true) // first grant: V2
+	if !lm.IsV2(fh, "share1", key) {
 		t.Fatalf("expected IsV2=true after V2 first grant")
 	}
-	if !lm.IsLeaseVersionKnown(key) {
+	if !lm.IsLeaseVersionKnown(fh, "share1", key) {
 		t.Fatalf("expected version known after first grant")
 	}
 
-	lm.MarkLeaseVersionIfUnset(key, false) // V1 reopen — must NOT downgrade
-	if !lm.IsV2(key) {
+	lm.MarkLeaseVersionIfUnset(fh, "share1", key, false) // V1 reopen — must NOT downgrade
+	if !lm.IsV2(fh, "share1", key) {
 		t.Errorf("V1 reopen wrongly cleared V2 mark")
 	}
 }
@@ -119,17 +120,18 @@ func TestMarkLeaseVersionIfUnset_StickyV1(t *testing.T) {
 
 	lm := NewLeaseManager(nil, nil)
 	key := [16]byte{0xBB}
+	fh := lock.FileHandle("file-1")
 
-	lm.MarkLeaseVersionIfUnset(key, false) // first grant: V1
-	if lm.IsV2(key) {
+	lm.MarkLeaseVersionIfUnset(fh, "share1", key, false) // first grant: V1
+	if lm.IsV2(fh, "share1", key) {
 		t.Fatalf("V1 first grant wrongly set V2 mark")
 	}
-	if !lm.IsLeaseVersionKnown(key) {
+	if !lm.IsLeaseVersionKnown(fh, "share1", key) {
 		t.Fatalf("expected version known after first grant")
 	}
 
-	lm.MarkLeaseVersionIfUnset(key, true) // V2 upgrade — must NOT promote
-	if lm.IsV2(key) {
+	lm.MarkLeaseVersionIfUnset(fh, "share1", key, true) // V2 upgrade — must NOT promote
+	if lm.IsV2(fh, "share1", key) {
 		t.Errorf("V2 upgrade wrongly upgraded V1 lease to V2")
 	}
 }
@@ -183,10 +185,10 @@ func TestGetSessionForBreak_RoutesByClientGUIDPrimary(t *testing.T) {
 	// of the shared ClientGUID — not to whichever session opened the lease.
 	// LEASE2's per-lease sessionMap entry initially points at session2, so
 	// this assertion specifically pins the ClientGUID-aware override.
-	if sid, ok := lm.GetSessionForBreak(lease1, "client-1"); !ok || sid != session1 {
+	if sid, ok := lm.GetSessionForBreak("client-1", "share1", lease1); !ok || sid != session1 {
 		t.Errorf("LEASE1 break session = %d (ok=%v), want %d", sid, ok, session1)
 	}
-	if sid, ok := lm.GetSessionForBreak(lease2, "client-2"); !ok || sid != session1 {
+	if sid, ok := lm.GetSessionForBreak("client-2", "share1", lease2); !ok || sid != session1 {
 		t.Errorf("LEASE2 break session = %d (ok=%v), want %d (ClientGUID primary, NOT per-lease sessionMap session2=%d)",
 			sid, ok, session1, session2)
 	}
@@ -195,7 +197,7 @@ func TestGetSessionForBreak_RoutesByClientGUIDPrimary(t *testing.T) {
 	// (used by other paths that genuinely want the registering session;
 	// none currently fault on this distinction but the API contract is
 	// preserved for callers that do).
-	if sid, _ := lm.GetSessionForLease(lease2); sid != session2 {
+	if sid, _ := lm.GetSessionForLease("client-2", "share1", lease2); sid != session2 {
 		t.Errorf("GetSessionForLease(LEASE2) = %d, want %d (per-lease sessionMap unchanged)",
 			sid, session2)
 	}
@@ -223,7 +225,7 @@ func TestGetSessionForBreak_FallsBackToSessionMap(t *testing.T) {
 		t.Fatalf("RequestLease: %v", err)
 	}
 
-	if sid, ok := lm.GetSessionForBreak(leaseKey, "client-1"); !ok || sid != session1 {
+	if sid, ok := lm.GetSessionForBreak("client-1", "share1", leaseKey); !ok || sid != session1 {
 		t.Errorf("GetSessionForBreak(zero GUID) = %d (ok=%v), want %d (sessionMap fallback)",
 			sid, ok, session1)
 	}
@@ -396,10 +398,10 @@ func TestGetSessionForBreak_CrossClientSameLeaseKey_IsolatesByClientID(t *testin
 	}
 
 	// Each client's break must route to its own primary session.
-	if sid, ok := lm.GetSessionForBreak(leaseKey, "client-A"); !ok || sid != sessionA {
+	if sid, ok := lm.GetSessionForBreak("client-A", "share1", leaseKey); !ok || sid != sessionA {
 		t.Errorf("client A break = %d (ok=%v), want %d", sid, ok, sessionA)
 	}
-	if sid, ok := lm.GetSessionForBreak(leaseKey, "client-B"); !ok || sid != sessionB {
+	if sid, ok := lm.GetSessionForBreak("client-B", "share1", leaseKey); !ok || sid != sessionB {
 		t.Errorf("client B break = %d (ok=%v), want %d", sid, ok, sessionB)
 	}
 }
@@ -467,10 +469,11 @@ func TestMarkLeaseVersionIfUnset_UnknownByDefault(t *testing.T) {
 
 	lm := NewLeaseManager(nil, nil)
 	key := [16]byte{0xCC}
-	if lm.IsLeaseVersionKnown(key) {
+	fh := lock.FileHandle("file-1")
+	if lm.IsLeaseVersionKnown(fh, "share1", key) {
 		t.Errorf("fresh key should not be marked known")
 	}
-	if lm.IsV2(key) {
+	if lm.IsV2(fh, "share1", key) {
 		t.Errorf("fresh key should default to !IsV2")
 	}
 }
@@ -1028,6 +1031,8 @@ func TestLeaseKeyRawMapRoundTrip(t *testing.T) {
 
 	keyA := [16]byte{0x01, 0x02, 0x03}
 	keyB := [16]byte{0x01, 0x02, 0x04} // differs only in last byte
+	fhA := lock.FileHandle("fA")
+	fhB := lock.FileHandle("fB")
 	const sessA uint64 = 5
 	const sessB uint64 = 6
 
@@ -1035,25 +1040,25 @@ func TestLeaseKeyRawMapRoundTrip(t *testing.T) {
 		sessA, [16]byte{}, "oA", "cA", "share1", lock.LeaseStateRead, false); err != nil {
 		t.Fatalf("RequestLease A: %v", err)
 	}
-	lm.MarkLeaseVersionIfUnset(keyA, true)
+	lm.MarkLeaseVersionIfUnset(fhA, "share1", keyA, true)
 
 	if _, _, err := lm.RequestLease(ctx, lock.FileHandle("fB"), keyB, [16]byte{},
 		sessB, [16]byte{}, "oB", "cB", "share1", lock.LeaseStateRead, false); err != nil {
 		t.Fatalf("RequestLease B: %v", err)
 	}
-	lm.MarkLeaseVersionIfUnset(keyB, false)
+	lm.MarkLeaseVersionIfUnset(fhB, "share1", keyB, false)
 
 	// Distinct keys must not collide across any map.
-	if sid, ok := lm.GetSessionForLease(keyA); !ok || sid != sessA {
+	if sid, ok := lm.GetSessionForLease("cA", "share1", keyA); !ok || sid != sessA {
 		t.Errorf("session(keyA) = %d ok=%v, want %d", sid, ok, sessA)
 	}
-	if sid, ok := lm.GetSessionForLease(keyB); !ok || sid != sessB {
+	if sid, ok := lm.GetSessionForLease("cB", "share1", keyB); !ok || sid != sessB {
 		t.Errorf("session(keyB) = %d ok=%v, want %d", sid, ok, sessB)
 	}
-	if !lm.IsV2(keyA) {
+	if !lm.IsV2(fhA, "share1", keyA) {
 		t.Errorf("keyA should be V2")
 	}
-	if lm.IsV2(keyB) {
+	if lm.IsV2(fhB, "share1", keyB) {
 		t.Errorf("keyB should be V1")
 	}
 
@@ -1071,16 +1076,16 @@ func TestLeaseKeyRawMapRoundTrip(t *testing.T) {
 	}
 
 	// Release A; B must remain intact (no cross-key wipe).
-	if err := lm.ReleaseLease(ctx, keyA); err != nil {
+	if err := lm.ReleaseLease(ctx, "cA", "share1", keyA); err != nil {
 		t.Fatalf("ReleaseLease A: %v", err)
 	}
-	if _, ok := lm.GetSessionForLease(keyA); ok {
+	if _, ok := lm.GetSessionForLease("cA", "share1", keyA); ok {
 		t.Errorf("keyA session mapping should be gone after release")
 	}
-	if sid, ok := lm.GetSessionForLease(keyB); !ok || sid != sessB {
+	if sid, ok := lm.GetSessionForLease("cB", "share1", keyB); !ok || sid != sessB {
 		t.Errorf("keyB session mapping must survive A's release: %d ok=%v", sid, ok)
 	}
-	if !lm.IsLeaseVersionKnown(keyB) {
+	if !lm.IsLeaseVersionKnown(fhB, "share1", keyB) {
 		t.Errorf("keyB version mark must survive A's release")
 	}
 }

--- a/internal/adapter/smb/lease/manager_test.go
+++ b/internal/adapter/smb/lease/manager_test.go
@@ -183,7 +183,7 @@ func TestGetSessionForBreak_RoutesByClientGUIDPrimary(t *testing.T) {
 
 	// Both leases must route their breaks to session1 — the FIRST session
 	// of the shared ClientGUID — not to whichever session opened the lease.
-	// LEASE2's per-lease sessionMap entry initially points at session2, so
+	// LEASE2's binding initially records session2, so
 	// this assertion specifically pins the ClientGUID-aware override.
 	if sid, ok := lm.GetSessionForBreak("client-1", "share1", lease1); !ok || sid != session1 {
 		t.Errorf("LEASE1 break session = %d (ok=%v), want %d", sid, ok, session1)
@@ -193,22 +193,22 @@ func TestGetSessionForBreak_RoutesByClientGUIDPrimary(t *testing.T) {
 			sid, ok, session1, session2)
 	}
 
-	// The legacy GetSessionForLease still returns the per-lease sessionMap
-	// (used by other paths that genuinely want the registering session;
+	// The legacy GetSessionForLease still returns the registering session
+	// (used by other paths that genuinely want it;
 	// none currently fault on this distinction but the API contract is
 	// preserved for callers that do).
 	if sid, _ := lm.GetSessionForLease("client-2", "share1", lease2); sid != session2 {
-		t.Errorf("GetSessionForLease(LEASE2) = %d, want %d (per-lease sessionMap unchanged)",
+		t.Errorf("GetSessionForLease(LEASE2) = %d, want %d (binding session unchanged)",
 			sid, session2)
 	}
 }
 
-// TestGetSessionForBreak_FallsBackToSessionMap covers the legacy /
+// TestGetSessionForBreak_FallsBackToBindingSession covers the legacy /
 // test-context path where ClientGUID is unknown (zero) — typical for unit
 // tests that don't wire a CryptoState. Break dispatch must continue to
-// route via the per-lease sessionMap so we don't regress any existing
-// single-session lease test.
-func TestGetSessionForBreak_FallsBackToSessionMap(t *testing.T) {
+// route via the session that registered the binding so we don't regress any
+// existing single-session lease test.
+func TestGetSessionForBreak_FallsBackToBindingSession(t *testing.T) {
 	t.Parallel()
 
 	mgr := lock.NewManager()
@@ -226,7 +226,7 @@ func TestGetSessionForBreak_FallsBackToSessionMap(t *testing.T) {
 	}
 
 	if sid, ok := lm.GetSessionForBreak("client-1", "share1", leaseKey); !ok || sid != session1 {
-		t.Errorf("GetSessionForBreak(zero GUID) = %d (ok=%v), want %d (sessionMap fallback)",
+		t.Errorf("GetSessionForBreak(zero GUID) = %d (ok=%v), want %d (binding-session fallback)",
 			sid, ok, session1)
 	}
 }
@@ -363,8 +363,8 @@ func TestReleaseSessionLeases_ReapsClientPrimary(t *testing.T) {
 // the per-client uniqueness of lease keys: lock.Manager scopes lease-key
 // reuse by Owner.ClientID (round-3 lease_match), so two distinct SMB
 // clients may each hold a record under the same numeric LeaseKey on
-// different files. The composite-keyed leaseClientGUID map must keep
-// their break-routing bindings isolated — client B's break must NOT route
+// different files. The composite-keyed bindings map must keep their
+// break-routing entries isolated — client B's break must NOT route
 // to client A's primary session even when their leaseKeys collide.
 func TestGetSessionForBreak_CrossClientSameLeaseKey_IsolatesByClientID(t *testing.T) {
 	t.Parallel()
@@ -411,7 +411,7 @@ func TestGetSessionForBreak_CrossClientSameLeaseKey_IsolatesByClientID(t *testin
 // primary session of a ClientGUID is released, the next-oldest surviving
 // session of the same ClientGUID must be elected as the new primary so
 // future breaks continue to route at the client level rather than falling
-// through to the per-lease sessionMap (last-write-wins).
+// through to each binding's own session.
 func TestReleaseSessionLeases_ReElectsPrimaryFromSurvivors(t *testing.T) {
 	t.Parallel()
 

--- a/internal/adapter/smb/lease/manager_test.go
+++ b/internal/adapter/smb/lease/manager_test.go
@@ -1076,8 +1076,8 @@ func TestLeaseKeyRawMapRoundTrip(t *testing.T) {
 	}
 
 	// Release A; B must remain intact (no cross-key wipe).
-	if err := lm.ReleaseLease(ctx, "cA", "share1", keyA); err != nil {
-		t.Fatalf("ReleaseLease A: %v", err)
+	if err := lm.ReleaseLeaseForHandle(ctx, fhA, keyA, "share1"); err != nil {
+		t.Fatalf("ReleaseLeaseForHandle A: %v", err)
 	}
 	if _, ok := lm.GetSessionForLease("cA", "share1", keyA); ok {
 		t.Errorf("keyA session mapping should be gone after release")

--- a/internal/adapter/smb/lease/notifier.go
+++ b/internal/adapter/smb/lease/notifier.go
@@ -65,8 +65,9 @@ func (h *SMBBreakHandler) OnOpLockBreak(handleKey string, ul *lock.UnifiedLock, 
 	// on the session that opened the lease. GetSessionForBreak resolves
 	// via the recorded ClientGUID → primary session map; legacy callers
 	// without a CryptoState (zero ClientGUID at grant time) fall through
-	// to the per-lease sessionMap, preserving prior single-session test
-	// behavior. Required by smbtorture smb2.lease.v2_complex1.
+	// to the session that registered the binding, preserving prior
+	// single-session test behavior. Required by smbtorture
+	// smb2.lease.v2_complex1.
 	sessionID, found := h.leaseManager.GetSessionForBreak(ul.Owner.ClientID, ul.Owner.ShareName, ul.Lease.LeaseKey)
 	if !found {
 		logger.Debug("SMBBreakHandler: no session for lease, skipping break notification",

--- a/internal/adapter/smb/lease/notifier.go
+++ b/internal/adapter/smb/lease/notifier.go
@@ -67,7 +67,7 @@ func (h *SMBBreakHandler) OnOpLockBreak(handleKey string, ul *lock.UnifiedLock, 
 	// without a CryptoState (zero ClientGUID at grant time) fall through
 	// to the per-lease sessionMap, preserving prior single-session test
 	// behavior. Required by smbtorture smb2.lease.v2_complex1.
-	sessionID, found := h.leaseManager.GetSessionForBreak(ul.Lease.LeaseKey, ul.Owner.ClientID)
+	sessionID, found := h.leaseManager.GetSessionForBreak(ul.Owner.ClientID, ul.Owner.ShareName, ul.Lease.LeaseKey)
 	if !found {
 		logger.Debug("SMBBreakHandler: no session for lease, skipping break notification",
 			"leaseKey", fmt.Sprintf("%x", ul.Lease.LeaseKey),
@@ -91,7 +91,7 @@ func (h *SMBBreakHandler) OnOpLockBreak(handleKey string, ul *lock.UnifiedLock, 
 	// granted from a V2 create context. Unknown keys default to V1 (safe:
 	// zero is always valid and avoids leaking stale epochs to V1 clients).
 	var newEpoch uint16
-	if h.leaseManager.IsV2(ul.Lease.LeaseKey) {
+	if h.leaseManager.IsV2(lock.FileHandle(handleKey), ul.Owner.ShareName, ul.Lease.LeaseKey) {
 		// LockManager already advanced the epoch when initiating the break.
 		newEpoch = ul.Lease.Epoch
 	}

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -1012,7 +1012,7 @@ Fix (signed):
 
 Confirmed via three new unit tests in `manager_test.go`:
 `TestGetSessionForBreak_RoutesByClientGUIDPrimary`,
-`TestGetSessionForBreak_FallsBackToSessionMap`,
+`TestGetSessionForBreak_FallsBackToBindingSession`,
 `TestReleaseSessionLeases_ReapsClientPrimary`.
 
 **#429 lease cluster:** `v2_complex1` now expected to PASS.


### PR DESCRIPTION
The SMB `LeaseManager` kept four maps keyed on the raw 16-byte lease key. Two
clients may legitimately present the same key value on different files —
MS-SMB2 binds a lease to a *(ClientGuid, LeaseKey)* pair, not to the key alone,
and `lock.Manager` enforces cross-file uniqueness only per `Owner.ClientID`
within a single share (`hasLeaseKeyOnOtherFile`, Samba's `lease_match`). So a
lookup by key alone returns an arbitrary matching record, and every write is an
unconditional overwrite.

This is the layer beneath #2113 / #2124. There the fix was to stop asking "does
a lease with this key exist" and ask "does one exist on *this file*"; here the
maps that answer such questions get the same treatment.

## What the key alone was deciding

The issue reports four raw-keyed maps and says two of them decide wire-visible
values. The count of maps is right. The severity split is not: **three of the
four** put a wrong value on the wire, and the fourth causes a cross-client lease
teardown that is not about the wire at all.

### `leaseV1` / `leaseV2` — the RqLs response shape and `NewEpoch`. LIVE.

`IsLeaseVersionKnown` / `IsV2` select between the 32-byte V1 create-context
response (no epoch field at all) and the 52-byte V2 one, and in the break
notifier they decide whether `NewEpoch` carries the lease epoch or the zero
MS-SMB2 §2.2.23.2 requires for a V1 lease. The stickiness is deliberate —
smbtorture `v2_epoch2` / `v2_epoch3` require a lease to keep answering in the
version it was established with — but keying it on the raw value made it sticky
across *unrelated clients*. One client establishing key `K` as V1 forced every
other client presenting `K` to be answered as V1, epoch field and all.

Reachable in a single share, no special configuration.

### `leaseShare` — which share's lock manager answers. LIVE.

Each share owns its own `lock.Manager`, so the cross-file uniqueness rule does
not span shares: the same key value can be live in two of them at once, and the
map holds whichever registered last. Three consequences, all wire-facing:

- `GetLeaseState` returns a foreign lease's state and epoch. That is the value
  a durable disconnect persists (`handler.go`) and the value a replayed CREATE
  rewrites its RqLs response context with (`create.go`).
- `SetLeaseEpoch` writes the client's seeded epoch into the wrong share.
- `AcknowledgeLeaseBreak` applies a `LEASE_BREAK_ACK` against the wrong share's
  manager. The acking client gets `STATUS_UNSUCCESSFUL` and — worse — its lease
  stays `Breaking` until the server force-downgrades it on timeout.

The ack case is the sharpest: `VerifyLeaseAckOwnership` authorized the ack
through the ClientGUID binding (composite-keyed, correct), and then
`AcknowledgeLeaseBreak` resolved the share from the raw key. The gate and the
action were answering about different leases.

### `sessionMap` — break routing, and lease teardown at LOGOFF.

Two separate consequences with different reachability:

- **Break routing: LATENT for any client that sent a ClientGUID.**
  `GetSessionForBreak` tries `leaseClientGUID` first, which is already
  composite-keyed, and only falls back to `sessionMap[key]` when no GUID was
  recorded. That fallback exists for callers without a `CryptoState` (older
  durable-reconnect paths, tests). On it, one client's break notification is
  delivered on whichever session registered the key value last. Reported as
  latent rather than live, and pinned by a test at the manager level.

- **Teardown at LOGOFF: LIVE, unconditionally.** `ReleaseSessionLeases` scans
  `sessionMap` for entries matching the departing session. With two clients on
  one key, the map holds only the later one — so the *earlier* client's lease is
  never released on its own logoff, and the *later* client's logoff resolves
  `leaseShare[key]` and calls `lock.Manager.ReleaseLease`, which is share-wide
  by key and destroys **both**. A client silently loses its lease: it gets no
  break notification, and no subsequent open breaks against it.

  This one is not in the issue and is the most severe of the set.

## The fix

Two maps replace the five, each keyed on the identity that actually
distinguishes what it describes:

```go
bindings map[leaseClientKey]leaseBinding   // (ClientID, ShareName, LeaseKey)
versions map[leaseRecordKey]leaseVersion   // (ShareName, HandleKey, LeaseKey)
```

`leaseBinding` carries the file the lease is on, the session that registered
it, and the sticky ClientGUID — subsuming `sessionMap`, `leaseShare` and
`leaseClientGUID`. `clientPrimarySession` is unchanged; it is keyed on
ClientGUID and was never part of the defect.

**Why two maps and not the single one the issue suggests.** The version is a
property of the lease *record*, not of a client. `lock.Manager` keeps one record
per `(handleKey, leaseKey)` and hands it to every requester of that key on that
file — `resolveSameKeyLeaseLocked` matches on the lease key within the handle
bucket and does not look at the client. A second session of the same
multichannel client reopening the file gets that same record. Keying the version
per client would have split one record's version across two sessions and let the
CREATE response and the break notification for the same record disagree about
their format. The split is drawn where the underlying object's identity
actually changes.

The file is recorded on the binding rather than keyed on, because
`(client, share, key)` already determines it — that is exactly what
`hasLeaseKeyOnOtherFile` enforces — and because a `LEASE_BREAK_ACK` arrives
carrying only a lease key. That ack now resolves through
`resolveAckBindingLocked`, the same predicate `VerifyLeaseAckOwnership` uses, so
authorization and action can no longer name different leases.

`resolveAckBindingLocked` takes the lowest share name on **both** branches, not
just the ClientGUID one. A single session can hold tree connects to two shares
and present the same key in both; map iteration order is randomized, so
returning the first session match would send an ack to an arbitrary one of the
two candidates — leaving the other lease `Breaking` until it times out, and
downgrading a lease nobody acknowledged.

Three smaller corrections fall out of the re-keying:

- `ReleaseSessionLeases` now releases through `ReleaseLeaseForHandle` using the
  file recorded on each binding, instead of the share-wide `ReleaseLease`.
- `ReleaseLeaseForHandle` drops a binding when *its own* record goes, not when
  the share's last record for the key goes. The share-wide guard made sense
  while the maps were raw-keyed — dropping the entry would have destroyed the
  other file's routing as well — but with per-client bindings it left a binding
  alive whose lease was gone, and a stale binding still answers the ack
  ownership gate. Since `lock.Manager` acknowledges by key, a client that had
  closed could then downgrade the break on the lease that outlived it.
  (Copilot's finding; `TestReleaseLeaseForHandle_DropsOnlyTheClosedHandlesBinding`
  fails without it.)
- The failed-grant rollback in `requestLeaseInternal` restores the client's
  previous binding instead of deleting the key's entries outright, and its
  "did this grant create anything" check is scoped to the file rather than the
  share — a record under the same key on a different file belongs to someone
  else and says nothing about this grant.

## Signatures changed, and every call site

A widened key that callers populate wrongly is worse than a narrow one, so each
of these was checked against the grant it has to agree with.

| Method | Was | Now | Call sites |
| --- | --- | --- | --- |
| `GetLeaseState` | `(ctx, key)` | `(ctx, share, key)` | `handler.go` durable-persist → `openFile.ShareName`; `create.go` CREATE-replay → `open.ShareName` |
| `SetLeaseEpoch` | `(key, epoch)` | `(share, key, epoch)` | `lease_context.go` first-grant seed → the handler's own `shareName`; `create.go` durable restore → `tree.ShareName` |
| `MarkLeaseVersionIfUnset` | `(key, isV2)` | `(fileHandle, share, key, isV2)` | `lease_context.go` → own `fileHandle`/`shareName`; `create.go` → `lockFileHandle`/`tree.ShareName` |
| `IsV2`, `IsLeaseVersionKnown` | `(key)` | `(fileHandle, share, key)` | `lease_context.go` response encoding; `notifier.go` → `handleKey` / `ul.Owner.ShareName` |
| `GetSessionForBreak` | `(key, clientID)` | `(clientID, share, key)` | `notifier.go` → `ul.Owner.ClientID` / `ul.Owner.ShareName` |
| `UpdateSessionForLease` | `(key, sessionID)` | `(clientID, share, key, sessionID)` | `create.go` durable reconnect → the same `clientID` and share as the `RequestLease` above it |
| `AcknowledgeLeaseBreak` | `(ctx, key, state, epoch)` | `(ctx, key, sessionID, connGUID, state, epoch)` | `stub_handlers.go` lease ack and oplock ack → `ctx.SessionID` / `connClientGUID(ctx)` |
| `GetSessionForLease` | `(key)` | `(clientID, share, key)` | tests only |

`LeaseManager.ReleaseLease` is deleted rather than re-keyed: it had no
production caller (releases go through `ReleaseLeaseForHandle`, whose signature
is unchanged), and widening a dead API is the worst of both outcomes.

In `lease_context.go` the share and file handle threaded through are the
function's own parameters — the same values handed to `RequestLease` a few lines
below — so the version mark, the version read and the epoch seed all name the
lease the CREATE actually granted. In `create.go`'s durable-reconnect block they
are the exact values passed to the `RequestLease` immediately above. In
`notifier.go` they come off the breaking record itself; `Owner.ShareName` is set
by `createAndGrantLease` from the grant's share for every lease record.

`OpenFile.ShareName` is populated from `tree.ShareName` at every production
construction site that can carry a lease. No caller was silently passing the
wrong identity. One *test fixture* built an `OpenFile` without a share and
started failing — the widened key catching an under-specified fixture, not a
production path.

`close.go` and `change_notify.go` are untouched; `handler.go` changes on one
line.

## Evidence

Five of the six new tests fail on unmodified `develop` at `7f1b811d`. Run there
(with the two signature-dependent assertions expressed against the old API):

```
    lease_context_test.go:567: client B response context is V1 (32 bytes, no epoch field), want V2 — another client's lease under the same key value decided this client's response format
    lease_context_test.go:570: client B response epoch = 0x1, want 0x901
--- FAIL: TestProcessLeaseCreateContext_OtherClientSameKeyKeepsOwnVersion

    before_test.go:49: client A's lease on file-A was released by client B's logoff
--- FAIL: TestReleaseSessionLeases_OtherClientSameKeyKeepsItsLease

    before_test.go:91: GetLeaseState(share1) = 0x1 found=true, want RH (0x3) — answered from the other share's lease
--- FAIL: TestGetLeaseState_OtherShareSameKeyAnswersItsOwn

    before_test.go:138: client A's ack rejected: lease not in breaking state
--- FAIL: TestAcknowledgeLeaseBreak_ResolvesTheAckingClientsLease

    before_test.go:206: break for client A's lease routes to session 2 (ok=true), want 1
--- FAIL: TestGetSessionForBreak_ZeroGUIDSameKeyRoutesToOwner

--- PASS: TestVerifyLeaseAckOwnership_RejectsForeignClientSameKey
```

Two later tests — the deterministic ack tie-break and the handle-scoped binding
drop — pin defects introduced or left standing by earlier commits on this
branch rather than by `develop`; each fails on the commit before its fix.

The `VerifyLeaseAckOwnership` test passes before and after: the ownership *gate* was already
composite-keyed. It is a pin on the new resolver, not a reproduction — kept so
that folding the gate and the ack onto one predicate cannot loosen it.

All pass on this branch. `go test ./...` and `go test -race` over
`internal/adapter/smb/...` and `pkg/metadata/lock/...` are green, including the
multichannel routing tests (`v2_complex1`'s `GetSessionForBreak` primary-session
election) and the version-stickiness tests (`v2_epoch2` / `v2_epoch3`) that the
narrowed scoping had to preserve.

## What this does not fix

`lock.Manager` is still raw-key internally: `findLeaseByKey`,
`releaseLeaseImpl`, `acknowledgeLeaseBreakImpl` and `SetLeaseEpoch` all match on
the lease key alone within a share. `SetLeaseEpoch` is the clearest one — it
deliberately converges *every* record matching the key across handle buckets to
`max(requested, existing)`, which is required so a lease's own sibling records
agree, but it does not stop at a client boundary. So with two V2 clients holding
the same key on different files in one share, one client's first-grant epoch
seed still pushes the other's epoch forward.

This PR removes the SMB-side mis-resolution — the wrong share, the wrong
client's binding, the wrong record's version — but it does not re-key the lock
manager, so a same-key collision can still cross a client boundary at that
layer. Worth a follow-up issue.

Closes #2125
