### PR TITLE
fix(smb): relate base files and streams by resolved identity, not path text

### DIFF
--- a/internal/adapter/smb/handlers/create.go
+++ b/internal/adapter/smb/handlers/create.go
@@ -1421,7 +1421,9 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	}
 	// Even when the file does not exist in the metadata store (already
 	// removed by the unlink), a deferred base-file delete may still be
-	// pending on an open stream handle. Check by path.
+	// pending on an open stream handle. Match those handles by the parent
+	// directory and the name within it, there being no metadata handle left
+	// to compare against.
 	if !fileExists {
 		if h.isFileOrBaseDeletePending(nil, parentHandle, baseName) {
 			return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusDeletePending}}, nil

--- a/internal/adapter/smb/handlers/create.go
+++ b/internal/adapter/smb/handlers/create.go
@@ -1391,7 +1391,7 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 
 	// Cross-stream share-mode check for new files (no lease break needed).
 	if !fileExists {
-		if shareConflict := h.checkShareModeConflict(nil, req.DesiredAccess, req.ShareAccess, filename); shareConflict {
+		if shareConflict := h.checkShareModeConflict(nil, req.DesiredAccess, req.ShareAccess, parentHandle, baseName); shareConflict {
 			logger.Debug("CREATE: sharing violation on new file",
 				"path", filename,
 				"desiredAccess", fmt.Sprintf("0x%x", req.DesiredAccess),
@@ -1414,7 +1414,7 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	// (smbtorture smb2.streams.delete).
 	if fileExists {
 		if existingHandle, encErr := metadata.EncodeFileHandle(existingFile); encErr == nil {
-			if h.isFileOrBaseDeletePending(existingHandle, filename) {
+			if h.isFileOrBaseDeletePending(existingHandle, parentHandle, baseName) {
 				return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusDeletePending}}, nil
 			}
 		}
@@ -1423,7 +1423,7 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	// removed by the unlink), a deferred base-file delete may still be
 	// pending on an open stream handle. Check by path.
 	if !fileExists {
-		if h.isFileOrBaseDeletePending(nil, filename) {
+		if h.isFileOrBaseDeletePending(nil, parentHandle, baseName) {
 			return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusDeletePending}}, nil
 		}
 	}

--- a/internal/adapter/smb/handlers/create_path_spelling_test.go
+++ b/internal/adapter/smb/handlers/create_path_spelling_test.go
@@ -1,0 +1,214 @@
+package handlers
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+// Share-mode and delete-pending conflict scans relate a base file to its
+// alternate data streams. That relation cannot come from the metadata handle —
+// a stream is a separate metadata entry from its base — so it has to be derived
+// from the name. The name a handle carries must therefore identify the object,
+// not echo the spelling the client happened to use: SMB CREATE accepts any
+// syntactically legal spelling of a path, and two spellings of one path must
+// reach the same conflict decision.
+//
+// These tests pin both halves: that CREATE records a spelling-independent
+// identity for the handle, and that both conflict scans key off it.
+
+const (
+	testAccessRead   = uint32(0x00000001) // FILE_READ_DATA
+	testAccessDelete = uint32(0x00010000) // DELETE
+	testShareRead    = uint32(0x01)
+	testShareWrite   = uint32(0x02)
+	testShareDelete  = uint32(0x04)
+)
+
+// spellingCreateRequest builds a CREATE for fname with explicit access and
+// sharing masks, so a test can set up a share-mode conflict.
+func spellingCreateRequest(
+	fname string,
+	access, share uint32,
+	disp types.CreateDisposition,
+	opts types.CreateOptions,
+) *CreateRequest {
+	return &CreateRequest{
+		FileName:          fname,
+		DesiredAccess:     access,
+		FileAttributes:    types.FileAttributeNormal,
+		ShareAccess:       share,
+		CreateDisposition: disp,
+		CreateOptions:     opts,
+	}
+}
+
+// mustCreate drives a CREATE through the real handler and fails on any status
+// other than the one expected.
+func mustCreate(t *testing.T, h *Handler, ctx *SMBHandlerContext, req *CreateRequest) *CreateResponse {
+	t.Helper()
+	resp, err := h.Create(ctx, req)
+	if err != nil {
+		t.Fatalf("Create(%q): %v", req.FileName, err)
+	}
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("Create(%q): status = 0x%08x, want STATUS_SUCCESS", req.FileName, uint32(resp.Status))
+	}
+	return resp
+}
+
+// TestCreate_NameIdentityIsSpellingIndependent drives two legal spellings of one
+// path through the real CREATE handler and compares the name each open records.
+// Every component of both spellings exists, and both resolve to the same object.
+//
+// The stored Path reproduces whatever the client sent; the (ParentHandle,
+// FileName) pair is resolved state and agrees across spellings. Any conflict
+// decision that reads Path therefore inherits the client's spelling, while one
+// that reads the pair does not.
+func TestCreate_NameIdentityIsSpellingIndependent(t *testing.T) {
+	h, smbCtx, _ := setupStreamsDisabledShare(t, false)
+
+	mustCreate(t, h, smbCtx, spellingCreateRequest(
+		"d", testAccessRead, 0x07, types.FileCreate, types.FileDirectoryFile))
+	mustCreate(t, h, smbCtx, spellingCreateRequest(
+		"d\\sub", testAccessRead, 0x07, types.FileCreate, types.FileDirectoryFile))
+	mustCreate(t, h, smbCtx, spellingCreateRequest(
+		"d\\f", testAccessRead, 0x07, types.FileCreate, 0))
+
+	// Two spellings of "d/f": the direct one, and one routing through an
+	// existing subdirectory and back out.
+	direct := mustCreate(t, h, smbCtx, spellingCreateRequest(
+		"d\\f", testAccessRead, 0x07, types.FileOpen, 0))
+	viaDotDot := mustCreate(t, h, smbCtx, spellingCreateRequest(
+		"d\\sub\\..\\f", testAccessRead, 0x07, types.FileOpen, 0))
+
+	a, ok := h.GetOpenFile(direct.FileID)
+	if !ok {
+		t.Fatal("open handle for direct spelling not found")
+	}
+	b, ok := h.GetOpenFile(viaDotDot.FileID)
+	if !ok {
+		t.Fatal("open handle for ..-spelling not found")
+	}
+
+	// Both spellings must have landed on the same object, or the rest of the
+	// comparison means nothing.
+	if !bytes.Equal(a.MetadataHandle, b.MetadataHandle) {
+		t.Fatalf("spellings resolved to different objects: %x vs %x",
+			a.MetadataHandle, b.MetadataHandle)
+	}
+
+	nameA, nameB := a.Name(), b.Name()
+
+	// Resolved identity agrees across spellings.
+	if !bytes.Equal(nameA.ParentHandle, nameB.ParentHandle) {
+		t.Errorf("ParentHandle differs across spellings: %x vs %x",
+			nameA.ParentHandle, nameB.ParentHandle)
+	}
+	if nameA.FileName != nameB.FileName {
+		t.Errorf("FileName differs across spellings: %q vs %q", nameA.FileName, nameB.FileName)
+	}
+
+	// The recorded Path does not: it is the client's own spelling. This is
+	// deliberate — diagnostics echo what the client asked for — and is exactly
+	// why conflict decisions must not be derived from it.
+	if nameA.Path == nameB.Path {
+		t.Errorf("Path unexpectedly equal across spellings (%q); "+
+			"this test's premise no longer holds", nameA.Path)
+	}
+}
+
+// TestCheckShareModeConflict_SpellingIndependent holds a stream open that
+// refuses delete sharing, then opens the base file for DELETE under two
+// spellings. Per MS-FSA 2.1.5.1.2 the base-vs-stream pair is delete-share
+// checked, so both opens must be refused with STATUS_SHARING_VIOLATION.
+//
+// The two spellings differ only in text and name the same object, so a
+// difference in outcome is a conflict the server failed to detect.
+func TestCheckShareModeConflict_SpellingIndependent(t *testing.T) {
+	for _, spelling := range []string{"d\\f", "d\\sub\\..\\f", "d\\\\f", "d\\.\\f"} {
+		t.Run(spelling, func(t *testing.T) {
+			h, smbCtx, _ := setupStreamsDisabledShare(t, false)
+
+			mustCreate(t, h, smbCtx, spellingCreateRequest(
+				"d", testAccessRead, 0x07, types.FileCreate, types.FileDirectoryFile))
+			mustCreate(t, h, smbCtx, spellingCreateRequest(
+				"d\\sub", testAccessRead, 0x07, types.FileCreate, types.FileDirectoryFile))
+			mustCreate(t, h, smbCtx, spellingCreateRequest(
+				"d\\f", testAccessRead, 0x07, types.FileCreate, 0))
+
+			// Stream handle holds DELETE and denies delete sharing.
+			mustCreate(t, h, smbCtx, spellingCreateRequest(
+				"d\\f:s1", testAccessRead|testAccessDelete,
+				testShareRead|testShareWrite, types.FileOpenIf, 0))
+
+			// Opening the base for DELETE conflicts: the stream's ShareAccess
+			// omits FILE_SHARE_DELETE.
+			resp, err := h.Create(smbCtx, spellingCreateRequest(
+				spelling, testAccessDelete,
+				testShareRead|testShareWrite|testShareDelete, types.FileOpen, 0))
+			if err != nil {
+				t.Fatalf("Create(%q): %v", spelling, err)
+			}
+			if resp.Status != types.StatusSharingViolation {
+				t.Errorf("Create(%q): status = 0x%08x, want STATUS_SHARING_VIOLATION (0x%08x)",
+					spelling, uint32(resp.Status), uint32(types.StatusSharingViolation))
+			}
+		})
+	}
+}
+
+// TestIsFileOrBaseDeletePending_SpellingIndependent covers the delete-pending
+// arm of the same relation. A stream handle carrying BaseFileDeletePending must
+// block a subsequent open of its base file however that open spells the path.
+//
+// The stream handle is built with the name triple CREATE records for
+// "d/f:s1" — a client-spelled Path alongside the resolved parent handle and
+// parent-relative name.
+func TestIsFileOrBaseDeletePending_SpellingIndependent(t *testing.T) {
+	parent := []byte{0xAA, 0xBB}
+	baseHandle := []byte{0x01}
+	streamHandle := []byte{0x02}
+
+	for _, storedPath := range []string{"d/f:s1", "d/sub/../f:s1", "d//f:s1", "d/./f:s1"} {
+		t.Run(storedPath, func(t *testing.T) {
+			h := NewHandler()
+
+			stream := (&OpenFile{
+				FileID:         h.GenerateFileID(),
+				MetadataHandle: streamHandle,
+			}).WithName(OpenName{
+				Path:         storedPath,
+				FileName:     "f:s1",
+				ParentHandle: parent,
+			})
+			stream.BaseFileDeletePending = true
+			h.StoreOpenFile(stream)
+
+			if !h.isFileOrBaseDeletePending(baseHandle, "f") {
+				t.Errorf("stored path %q: base open not refused, "+
+					"want DELETE_PENDING from the stream handle", storedPath)
+			}
+		})
+	}
+
+	// A same-named file in a different directory must not be dragged in.
+	t.Run("different parent", func(t *testing.T) {
+		h := NewHandler()
+		stream := (&OpenFile{
+			FileID:         h.GenerateFileID(),
+			MetadataHandle: streamHandle,
+		}).WithName(OpenName{
+			Path:         "other/f:s1",
+			FileName:     "f:s1",
+			ParentHandle: []byte{0xCC, 0xDD},
+		})
+		stream.BaseFileDeletePending = true
+		h.StoreOpenFile(stream)
+
+		if h.isFileOrBaseDeletePending(baseHandle, "f") {
+			t.Error("a stream in a different directory must not make this base delete-pending")
+		}
+	})
+}

--- a/internal/adapter/smb/handlers/create_path_spelling_test.go
+++ b/internal/adapter/smb/handlers/create_path_spelling_test.go
@@ -186,7 +186,7 @@ func TestIsFileOrBaseDeletePending_SpellingIndependent(t *testing.T) {
 			stream.BaseFileDeletePending = true
 			h.StoreOpenFile(stream)
 
-			if !h.isFileOrBaseDeletePending(baseHandle, "f") {
+			if !h.isFileOrBaseDeletePending(baseHandle, parent, "f") {
 				t.Errorf("stored path %q: base open not refused, "+
 					"want DELETE_PENDING from the stream handle", storedPath)
 			}
@@ -207,7 +207,7 @@ func TestIsFileOrBaseDeletePending_SpellingIndependent(t *testing.T) {
 		stream.BaseFileDeletePending = true
 		h.StoreOpenFile(stream)
 
-		if h.isFileOrBaseDeletePending(baseHandle, "f") {
+		if h.isFileOrBaseDeletePending(baseHandle, parent, "f") {
 			t.Error("a stream in a different directory must not make this base delete-pending")
 		}
 	})

--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -292,7 +292,7 @@ func (h *Handler) breakAndMaybeParkCreate(ctx *SMBHandlerContext, d *createDraft
 	case d.req.CreateOptions&types.FileDeleteOnClose != 0:
 		reason = lock.BreakReasonSharingViolation
 	default:
-		initialConflict = h.checkShareModeConflict(d.existingHandle, d.req.DesiredAccess, d.req.ShareAccess, d.filename)
+		initialConflict = h.checkShareModeConflict(d.existingHandle, d.req.DesiredAccess, d.req.ShareAccess, d.parentHandle, d.baseName)
 		conflictComputed = true
 		if initialConflict {
 			reason = lock.BreakReasonSharingViolation
@@ -477,7 +477,7 @@ func (h *Handler) breakAndMaybeParkCreate(ctx *SMBHandlerContext, d *createDraft
 				return initialConflict
 			}
 			return d.existingHandle != nil &&
-				h.checkShareModeConflict(d.existingHandle, effectiveAccess, d.req.ShareAccess, d.filename)
+				h.checkShareModeConflict(d.existingHandle, effectiveAccess, d.req.ShareAccess, d.parentHandle, d.baseName)
 		}
 		if err := h.LeaseManager.WaitForShareConflictClear(waitCtx, lockFileHandle, shareName, conflictPresent); err != nil {
 			logger.Debug("CREATE: sync share-conflict wait completed", "error", err)
@@ -526,7 +526,7 @@ func (h *Handler) recheckExistingFileGates(d *createDraft, effectiveAccess uint3
 	// holder, returning STATUS_SHARING_VIOLATION. Covers
 	// smb2.acls.OVERWRITE_READ_ONLY_FILE sharing_tcases arm (#575).
 	if fileExists && d.existingHandle != nil {
-		if shareConflict := h.checkShareModeConflict(d.existingHandle, effectiveAccess, req.ShareAccess, filename); shareConflict {
+		if shareConflict := h.checkShareModeConflict(d.existingHandle, effectiveAccess, req.ShareAccess, d.parentHandle, d.baseName); shareConflict {
 			logger.Debug("CREATE: sharing violation",
 				"path", filename,
 				"desiredAccess", fmt.Sprintf("0x%x", req.DesiredAccess),
@@ -1595,7 +1595,7 @@ func (h *Handler) parkCreateOnLeaseBreak(
 			effectiveAccess := effectiveAccessForOpen(d.req.DesiredAccess, d.req.CreateDisposition)
 			conflictPresent := func() bool {
 				return d.existingHandle != nil &&
-					h.checkShareModeConflict(d.existingHandle, effectiveAccess, d.req.ShareAccess, d.filename)
+					h.checkShareModeConflict(d.existingHandle, effectiveAccess, d.req.ShareAccess, d.parentHandle, d.baseName)
 			}
 			if err := h.LeaseManager.WaitForShareConflictClear(waitCtx, lockFileHandle, shareName, conflictPresent); err != nil {
 				logger.Debug("CREATE async: share-conflict wait completed",

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -2311,8 +2311,16 @@ func (h *Handler) isFileDeletePending(fileHandle metadata.FileHandle) bool {
 //   - Opening a stream:   reject if any handle on the base file or sibling
 //     stream carries BaseFileDeletePending.
 //
-// filePath is the normalized path being opened (e.g., "file" or "file:Stream One").
-func (h *Handler) isFileOrBaseDeletePending(fileHandle metadata.FileHandle, filePath string) bool {
+// The open is identified by its resolved parent directory handle and its
+// parent-relative name (e.g. "file" or "file:Stream One"), not by its full
+// path. A base file and its streams are siblings in one directory, so that
+// pair relates them by identity; the full path cannot, because it reproduces
+// whatever spelling the client sent.
+func (h *Handler) isFileOrBaseDeletePending(
+	fileHandle metadata.FileHandle,
+	parentHandle metadata.FileHandle,
+	fileName string,
+) bool {
 	// Fast path: direct metadata-handle match against an existing handle
 	// whose own DeletePending is set. Covers the same-file re-open case
 	// (smbtorture smb2.oplock.doc, smb2.streams.delete).
@@ -2320,7 +2328,7 @@ func (h *Handler) isFileOrBaseDeletePending(fileHandle metadata.FileHandle, file
 		return true
 	}
 
-	openBase := adsBasePath(filePath) // non-empty if filePath is a stream
+	openBase := adsBaseName(fileName) // non-empty if fileName is a stream
 	pending := false
 	h.files.Range(func(_, value any) bool {
 		existing := value.(*OpenFile)
@@ -2335,19 +2343,22 @@ func (h *Handler) isFileOrBaseDeletePending(fileHandle metadata.FileHandle, file
 		if !bdp {
 			return true
 		}
-		existingPath := existing.Name().Path
-		existingBase := adsBasePath(existingPath)
+		existingName := existing.Name()
+		if !bytes.Equal(existingName.ParentHandle, parentHandle) {
+			return true
+		}
+		existingBase := adsBaseName(existingName.FileName)
 		if openBase == "" {
 			// Opening a base file: match against any stream of this base.
-			if strings.EqualFold(existingBase, filePath) {
+			if strings.EqualFold(existingBase, fileName) {
 				pending = true
 				return false
 			}
 		} else {
 			// Opening a stream: match against a sibling stream sharing the
-			// same base path, or against a base-file handle of that base.
+			// same base name, or against a base-file handle of that base.
 			if strings.EqualFold(existingBase, openBase) ||
-				strings.EqualFold(existingPath, openBase) {
+				strings.EqualFold(existingName.FileName, openBase) {
 				pending = true
 				return false
 			}
@@ -2365,7 +2376,14 @@ func (h *Handler) isFileOrBaseDeletePending(fileHandle metadata.FileHandle, file
 //   - Stream A vs Stream B (different streams, same base) → NOT checked
 //
 // Returns true if a conflict exists (CREATE should fail with STATUS_SHARING_VIOLATION).
-func (h *Handler) checkShareModeConflict(fileHandle metadata.FileHandle, newDesiredAccess, newShareAccess uint32, filePath string) bool {
+// The open is identified by its resolved parent directory handle and its
+// parent-relative name, for the reason given on isFileOrBaseDeletePending.
+func (h *Handler) checkShareModeConflict(
+	fileHandle metadata.FileHandle,
+	newDesiredAccess, newShareAccess uint32,
+	parentHandle metadata.FileHandle,
+	fileName string,
+) bool {
 	const (
 		fileShareRead   = uint32(0x01)
 		fileShareWrite  = uint32(0x02)
@@ -2415,7 +2433,7 @@ func (h *Handler) checkShareModeConflict(fileHandle metadata.FileHandle, newDesi
 		return access&(deleteAccess|genericAll|maxAllowed) != 0
 	}
 
-	newBase := adsBasePath(filePath)
+	newBase := adsBaseName(fileName)
 
 	conflict := false
 	h.files.Range(func(key, value any) bool {
@@ -2433,13 +2451,18 @@ func (h *Handler) checkShareModeConflict(fileHandle metadata.FileHandle, newDesi
 		sameFile := bytes.Equal(existing.MetadataHandle, fileHandle)
 		crossStream := false
 		if !sameFile {
-			existingPath := existing.Name().Path
-			existingBase := adsBasePath(existingPath)
+			existingName := existing.Name()
+			// A base file and its streams live in one directory; a handle
+			// anywhere else cannot be related to this open.
+			if !bytes.Equal(existingName.ParentHandle, parentHandle) {
+				return true
+			}
+			existingBase := adsBaseName(existingName.FileName)
 			baseVsStream := false
 			if newBase == "" && existingBase != "" {
-				baseVsStream = strings.EqualFold(existingBase, filePath)
+				baseVsStream = strings.EqualFold(existingBase, fileName)
 			} else if newBase != "" && existingBase == "" {
-				baseVsStream = strings.EqualFold(newBase, existingPath)
+				baseVsStream = strings.EqualFold(newBase, existingName.FileName)
 			}
 			if !baseVsStream {
 				return true
@@ -2513,23 +2536,16 @@ func (h *Handler) lookupCaseInsensitive(
 	return metaSvc.LookupCaseInsensitive(authCtx, parentHandle, name)
 }
 
-// adsBasePath extracts the base file path from a potentially ADS-qualified path.
-// For "dir/file.txt:stream" returns "dir/file.txt".
-// For "dir/file.txt" (no stream) returns "" (not an ADS).
-func adsBasePath(filePath string) string {
-	lastSep := strings.LastIndex(filePath, "/")
-	var fileName string
-	if lastSep >= 0 {
-		fileName = filePath[lastSep+1:]
-	} else {
-		fileName = filePath
-	}
+// adsBaseName extracts the base file name from a potentially ADS-qualified
+// parent-relative name. For "file.txt:stream" it returns "file.txt"; for
+// "file.txt" (not a stream) it returns "".
+//
+// Stream names cannot contain a path separator (rejected at CREATE), so this
+// operates on a single name component, never a path.
+func adsBaseName(fileName string) string {
 	colonIdx := strings.Index(fileName, ":")
 	if colonIdx <= 0 {
 		return ""
-	}
-	if lastSep >= 0 {
-		return filePath[:lastSep+1] + fileName[:colonIdx]
 	}
 	return fileName[:colonIdx]
 }

--- a/internal/adapter/smb/handlers/handler_test.go
+++ b/internal/adapter/smb/handlers/handler_test.go
@@ -691,6 +691,9 @@ func TestSession(t *testing.T) {
 // =============================================================================
 
 func TestCheckShareModeConflict_ADSCrossStream(t *testing.T) {
+	// Every handle in these cases is a sibling in one directory.
+	adsParent := []byte{0xF0}
+
 	const (
 		fileReadData   = uint32(0x00000001)
 		fileWriteData  = uint32(0x00000002)
@@ -710,12 +713,13 @@ func TestCheckShareModeConflict_ADSCrossStream(t *testing.T) {
 			DesiredAccess:  fileReadData,
 			ShareAccess:    fileShareRead, // no FILE_SHARE_DELETE
 			MetadataHandle: []byte{0x01},
-		}).WithName(OpenName{Path: "file.txt:stream1"}))
+		}).WithName(OpenName{Path: "file.txt:stream1", FileName: "file.txt:stream1", ParentHandle: adsParent}))
 
 		conflict := h.checkShareModeConflict(
 			[]byte{0x02},
 			deleteAccess,
 			fileShareRead|fileShareWrite,
+			adsParent,
 			"file.txt",
 		)
 		if !conflict {
@@ -731,12 +735,13 @@ func TestCheckShareModeConflict_ADSCrossStream(t *testing.T) {
 			DesiredAccess:  fileReadData,
 			ShareAccess:    fileShareRead, // no write sharing
 			MetadataHandle: []byte{0x01},
-		}).WithName(OpenName{Path: "file.txt:stream1"}))
+		}).WithName(OpenName{Path: "file.txt:stream1", FileName: "file.txt:stream1", ParentHandle: adsParent}))
 
 		conflict := h.checkShareModeConflict(
 			[]byte{0x02},
 			fileWriteData,
 			fileShareRead|fileShareWrite,
+			adsParent,
 			"file.txt",
 		)
 		if conflict {
@@ -752,12 +757,13 @@ func TestCheckShareModeConflict_ADSCrossStream(t *testing.T) {
 			DesiredAccess:  fileReadData,
 			ShareAccess:    fileShareRead,
 			MetadataHandle: []byte{0x01},
-		}).WithName(OpenName{Path: "file.txt:stream1"}))
+		}).WithName(OpenName{Path: "file.txt:stream1", FileName: "file.txt:stream1", ParentHandle: adsParent}))
 
 		conflict := h.checkShareModeConflict(
 			[]byte{0x02},
 			fileWriteData,
 			fileShareRead|fileShareWrite,
+			adsParent,
 			"file.txt:stream2",
 		)
 		if conflict {
@@ -773,12 +779,13 @@ func TestCheckShareModeConflict_ADSCrossStream(t *testing.T) {
 			DesiredAccess:  fileReadData,
 			ShareAccess:    fileShareRead,
 			MetadataHandle: []byte{0x01},
-		}).WithName(OpenName{Path: "file.txt:stream1"}))
+		}).WithName(OpenName{Path: "file.txt:stream1", FileName: "file.txt:stream1", ParentHandle: adsParent}))
 
 		conflict := h.checkShareModeConflict(
 			[]byte{0x01},
 			fileWriteData,
 			fileShareRead|fileShareWrite,
+			adsParent,
 			"file.txt:stream1",
 		)
 		if !conflict {
@@ -794,12 +801,13 @@ func TestCheckShareModeConflict_ADSCrossStream(t *testing.T) {
 			DesiredAccess:  fileReadData | fileWriteData,
 			ShareAccess:    0,
 			MetadataHandle: []byte{0x01},
-		}).WithName(OpenName{Path: "file1.txt"}))
+		}).WithName(OpenName{Path: "file1.txt", FileName: "file1.txt", ParentHandle: adsParent}))
 
 		conflict := h.checkShareModeConflict(
 			[]byte{0x02},
 			fileReadData|fileWriteData,
 			0,
+			adsParent,
 			"file2.txt:stream",
 		)
 		if conflict {
@@ -816,12 +824,13 @@ func TestCheckShareModeConflict_ADSCrossStream(t *testing.T) {
 			DesiredAccess:  fileReadAttributes,
 			ShareAccess:    0,
 			MetadataHandle: []byte{0x01},
-		}).WithName(OpenName{Path: "file.txt"}))
+		}).WithName(OpenName{Path: "file.txt", FileName: "file.txt", ParentHandle: adsParent}))
 
 		conflict := h.checkShareModeConflict(
 			[]byte{0x01},
 			fileReadData|fileWriteData,
 			fileShareRead|fileShareWrite,
+			adsParent,
 			"file.txt",
 		)
 		if conflict {
@@ -837,8 +846,8 @@ func TestCheckShareModeConflict_ADSCrossStream(t *testing.T) {
 			DesiredAccess:  writeDac,
 			ShareAccess:    0,
 			MetadataHandle: []byte{0x01},
-		}).WithName(OpenName{Path: "file.txt"}))
-		if h.checkShareModeConflict([]byte{0x01}, fileReadData|fileWriteData, fileShareRead|fileShareWrite, "file.txt") {
+		}).WithName(OpenName{Path: "file.txt", FileName: "file.txt", ParentHandle: adsParent}))
+		if h.checkShareModeConflict([]byte{0x01}, fileReadData|fileWriteData, fileShareRead|fileShareWrite, adsParent, "file.txt") {
 			t.Error("Expected no conflict: WRITE_DAC-only existing open must not impose share-mode constraint")
 		}
 	})
@@ -851,12 +860,13 @@ func TestCheckShareModeConflict_ADSCrossStream(t *testing.T) {
 			DesiredAccess: fileReadData | fileWriteData,
 			ShareAccess:   0,
 			IsPipe:        true,
-		}).WithName(OpenName{Path: "srvsvc"}))
+		}).WithName(OpenName{Path: "srvsvc", FileName: "srvsvc", ParentHandle: adsParent}))
 
 		conflict := h.checkShareModeConflict(
 			[]byte{0x01},
 			fileReadData,
 			fileShareRead,
+			adsParent,
 			"srvsvc",
 		)
 		if conflict {
@@ -874,6 +884,9 @@ func TestCheckShareModeConflict_ADSCrossStream(t *testing.T) {
 // MAXIMUM_ALLOWED opener was treated as read-only and bypassed SHARE_WRITE /
 // SHARE_DELETE enforcement in both directions.
 func TestCheckShareModeConflict_MaximumAllowed(t *testing.T) {
+	// Every handle in these cases is a sibling in one directory.
+	adsParent := []byte{0xF0}
+
 	const (
 		fileReadData    = uint32(0x00000001)
 		fileWriteData   = uint32(0x00000002)
@@ -891,10 +904,10 @@ func TestCheckShareModeConflict_MaximumAllowed(t *testing.T) {
 			DesiredAccess:  maximumAllowed,
 			ShareAccess:    fileShareRead, // no FILE_SHARE_WRITE
 			MetadataHandle: []byte{0x01},
-		}).WithName(OpenName{Path: "file.txt"}))
+		}).WithName(OpenName{Path: "file.txt", FileName: "file.txt", ParentHandle: adsParent}))
 		// New writer with full sharing must conflict: the existing
 		// MAXIMUM_ALLOWED handle holds write and does not share it.
-		if !h.checkShareModeConflict([]byte{0x01}, fileWriteData, fileShareRead|fileShareWrite|fileShareDelete, "file.txt") {
+		if !h.checkShareModeConflict([]byte{0x01}, fileWriteData, fileShareRead|fileShareWrite|fileShareDelete, adsParent, "file.txt") {
 			t.Error("Expected conflict: existing MAXIMUM_ALLOWED holds write but does not share it")
 		}
 	})
@@ -907,8 +920,8 @@ func TestCheckShareModeConflict_MaximumAllowed(t *testing.T) {
 			DesiredAccess:  maximumAllowed,
 			ShareAccess:    fileShareRead | fileShareWrite, // no FILE_SHARE_DELETE
 			MetadataHandle: []byte{0x01},
-		}).WithName(OpenName{Path: "file.txt"}))
-		if !h.checkShareModeConflict([]byte{0x01}, deleteAccess, fileShareRead|fileShareWrite|fileShareDelete, "file.txt") {
+		}).WithName(OpenName{Path: "file.txt", FileName: "file.txt", ParentHandle: adsParent}))
+		if !h.checkShareModeConflict([]byte{0x01}, deleteAccess, fileShareRead|fileShareWrite|fileShareDelete, adsParent, "file.txt") {
 			t.Error("Expected conflict: existing MAXIMUM_ALLOWED holds delete but does not share it")
 		}
 	})
@@ -921,10 +934,10 @@ func TestCheckShareModeConflict_MaximumAllowed(t *testing.T) {
 			DesiredAccess:  fileReadData,
 			ShareAccess:    fileShareRead, // no FILE_SHARE_WRITE
 			MetadataHandle: []byte{0x01},
-		}).WithName(OpenName{Path: "file.txt"}))
+		}).WithName(OpenName{Path: "file.txt", FileName: "file.txt", ParentHandle: adsParent}))
 		// New MAXIMUM_ALLOWED opener implies write; the existing handle does
 		// not share write, so this must conflict.
-		if !h.checkShareModeConflict([]byte{0x01}, maximumAllowed, fileShareRead|fileShareWrite|fileShareDelete, "file.txt") {
+		if !h.checkShareModeConflict([]byte{0x01}, maximumAllowed, fileShareRead|fileShareWrite|fileShareDelete, adsParent, "file.txt") {
 			t.Error("Expected conflict: new MAXIMUM_ALLOWED implies write, existing handle does not share write")
 		}
 	})
@@ -936,8 +949,8 @@ func TestCheckShareModeConflict_MaximumAllowed(t *testing.T) {
 			DesiredAccess:  fileReadData,
 			ShareAccess:    fileShareRead | fileShareWrite, // no FILE_SHARE_DELETE
 			MetadataHandle: []byte{0x01},
-		}).WithName(OpenName{Path: "file.txt"}))
-		if !h.checkShareModeConflict([]byte{0x01}, maximumAllowed, fileShareRead|fileShareWrite|fileShareDelete, "file.txt") {
+		}).WithName(OpenName{Path: "file.txt", FileName: "file.txt", ParentHandle: adsParent}))
+		if !h.checkShareModeConflict([]byte{0x01}, maximumAllowed, fileShareRead|fileShareWrite|fileShareDelete, adsParent, "file.txt") {
 			t.Error("Expected conflict: new MAXIMUM_ALLOWED implies delete, existing handle does not share delete")
 		}
 	})
@@ -1025,26 +1038,25 @@ func TestOpenFile(t *testing.T) {
 }
 
 // =============================================================================
-// adsBasePath Tests
+// adsBaseName Tests
 // =============================================================================
 
-func TestAdsBasePath(t *testing.T) {
+func TestAdsBaseName(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
 		expected string
 	}{
-		{"StreamWithDir", "dir/file.txt:stream", "dir/file.txt"},
-		{"StreamWithoutDir", "file.txt:stream", "file.txt"},
+		{"Stream", "file.txt:stream", "file.txt"},
 		{"NotADS_PlainFile", "file.txt", ""},
 		{"NotADS_Empty", "", ""},
-		{"NotADS_DirAndFile", "dir/file.txt", ""},
+		{"LeadingColon_NotADS", ":stream", ""},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := adsBasePath(tc.input)
+			got := adsBaseName(tc.input)
 			if got != tc.expected {
-				t.Errorf("adsBasePath(%q) = %q, want %q", tc.input, got, tc.expected)
+				t.Errorf("adsBaseName(%q) = %q, want %q", tc.input, got, tc.expected)
 			}
 		})
 	}


### PR DESCRIPTION
## The premise holds, and it is reachable

#2134 was filed as a prediction from a code read, explicitly not a demonstrated
failure. It is real. A client can open one file under two legal spellings and
get two different share-mode answers.

Driven through the real `h.Create` handler, with every path component existing:

```
--- FAIL: TestCheckShareModeConflict_SpellingIndependent
    --- FAIL: .../d\sub\..\f    status = 0x00000000, want STATUS_SHARING_VIOLATION (0xc0000043)
    --- FAIL: .../d\\f          status = 0x00000000, want STATUS_SHARING_VIOLATION (0xc0000043)
    --- FAIL: .../d\.\f         status = 0x00000000, want STATUS_SHARING_VIOLATION (0xc0000043)
```

The `d\f` spelling of the same open passes: the conflict is raised correctly.
A stream handle on `d\f:s1` holds DELETE and denies delete sharing, so opening
the base file for DELETE must be refused per MS-FSA 2.1.5.1.2. Spell the base
file any other way and the server hands out the handle.

## What was actually wrong

The conflict scans have to relate a base file to its alternate data streams. A
stream is a **separate metadata entry** from its base — a sibling in the same
directory — so `bytes.Equal(existing.MetadataHandle, fileHandle)` cannot settle
that pair. It settles the same-object case and nothing else.

For the base↔stream pair the code fell back to comparing `OpenFile.Name().Path`,
which holds the client's raw spelling. `normalizeCreatePath` only maps `\`→`/`
and trims leading separators; it does not `path.Clean`. Meanwhile resolution
*does* clean, because `path.Dir` cleans and `path.Base` takes the last
component. So `d\sub\..\f`, `d\\f`, `d\.\f` and `d\f` all resolve to one object
while recording four different strings.

The decision degraded from identity to string equality at exactly the case
identity could not cover, and the spelling assumption became load-bearing
without anyone choosing it.

Note the issue's cited `create.go:1810` is the **named-pipe** open. Pipes are
skipped by both scans (`if existing.IsPipe`), so that line is not the defect.
The real writer is `create_post_break.go:1301`, which records
`OpenName{Path: filename, FileName: baseName, ParentHandle: parentHandle}`.

## The fix: derive the relation from state, not text

Both scans now identify an open by its **resolved parent directory handle** plus
its **parent-relative name** — the pair `OpenName` already carries, and the pair
`rangeStreamsOfBase` in `close.go` has always used for exactly this relation.
A base file and its streams are siblings in one directory, so that pair relates
them by identity.

```go
existingName := existing.Name()
if !bytes.Equal(existingName.ParentHandle, parentHandle) {
    return true
}
existingBase := adsBaseName(existingName.FileName)
```

`adsBasePath` (which split a full path) becomes `adsBaseName` (which splits a
single name component). Stream names cannot contain a separator — CREATE rejects
that — so the path-splitting half was only ever there to serve the text
comparison being removed.

**Nothing is normalised, and `OpenName.Path` is unchanged.** It still holds the
client's own spelling, which is correct for the diagnostics that consume it. The
issue proposed storing `cleaned` instead; that fix is not needed, because the
comparisons stop reading the field entirely. This also leaves the notify-local
`path.Clean` in #2133 as the single normalisation point in the tree rather than
adding a second one.

### Two behaviours improved as a side effect

- **Case-folding of the directory component is now the store's**, via
  `lookupCaseInsensitive` during path walk, rather than `strings.EqualFold` over
  raw bytes.
- **Cross-share false conflicts are gone.** Two shares can each hold `d/f`; the
  old full-path compare matched them and raised a conflict between unrelated
  files. File handles encode share identity, so the parent-handle compare does
  not. A regression test covers the different-parent case.

## Audit of the other `Name().Path` consumers

The issue asked for these to be classified. Every one is a **diagnostic** — the
value reaches nothing but a log field, where echoing the client's own spelling
is the correct behaviour:

| Site | Verdict |
| --- | --- |
| `write.go:193` | diagnostic — log fields only |
| `ioctl_sparse.go:60,150,379` | diagnostic — log fields only |
| `read.go:180,493`, `flush.go:209`, `close.go:215`, `handler.go:1978` | diagnostic |
| `ioctl_copychunk.go:250,361` | diagnostic |
| `set_info.go:1221` (`GetParentPath`) | derivation, not comparison — builds the new stored path on a handle-relative rename |
| `handler.go:2338`, `handler.go:2436` | **comparisons — fixed here** |

`disconnectedShareDeniesNewOpen` was checked too: it keys off the metadata
handle and access masks, never path text, so it is unaffected.

## Verification

- `go build ./... && go vet ./... && gofmt -l` clean
- `go test ./...` and `go test -race ./internal/adapter/smb/handlers/` pass
- Three new tests, all failing before this change:
  - `TestCreate_NameIdentityIsSpellingIndependent` — pins the premise itself:
    two spellings through real CREATE land on one `MetadataHandle` with equal
    `(ParentHandle, FileName)` and different `Path`. If normalisation is ever
    added at CREATE this test says so out loud rather than silently passing.
  - `TestCheckShareModeConflict_SpellingIndependent` — four spellings, all must
    yield STATUS_SHARING_VIOLATION.
  - `TestIsFileOrBaseDeletePending_SpellingIndependent` — the delete-pending arm,
    plus a different-parent case so the new parent-handle guard is shown to
    actually refuse something rather than being silently inert.

Closes #2134
