### PR TITLE
fix(smb): decide the last delete-on-close handle atomically with its departure

### DIFF
--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -396,9 +396,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 		// The election snapshotted the name it decided on, so a rename landing
 		// since cannot make the scan and the unlink disagree about the entry.
 		docName := target.Name
-		deleteParentHandle := target.ParentHandle
 		deleteFileName := target.FileName
-		isBaseFileDelete := target.IsBaseFile
 
 		authCtx, err := BuildAuthContext(ctx)
 		if err != nil {
@@ -421,78 +419,21 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 			}
 			// else: different keys — don't propagate, all dir leases break
 
-			metaSvc := h.Registry.GetMetadataService()
-			// For deferred base-file delete (via stream handle), check the
-			// actual target type — stream handles always have IsDirectory=false.
-			//
-			// Capture the delete target's metadata handle BEFORE removal so
-			// we can route its block-store payload purge afterwards (the
-			// handle encodes share identity and stays valid). The PayloadID
-			// to purge comes from RemoveFile's RETURN value, which is empty
-			// when content must survive (surviving hard link, or recycle to
-			// trash) — purging the open handle's PayloadID instead would
-			// destroy still-referenced content.
-			isDeleteTargetDir := openFile.IsDirectory
-			deleteTargetHandle := openFile.MetadataHandle
-			if isBaseFileDelete {
-				if targetFile, _, lookupErr := metaSvc.LookupCaseInsensitive(authCtx, deleteParentHandle, deleteFileName); lookupErr == nil && targetFile != nil {
-					isDeleteTargetDir = targetFile.Type == metadata.FileTypeDirectory
-					if encoded, encErr := metadata.EncodeFileHandle(targetFile); encErr == nil {
-						deleteTargetHandle = encoded
-					}
-				}
-			}
-			var deleteErr error
-			var removedPayloadID metadata.PayloadID
-			if isDeleteTargetDir {
-				_, deleteErr = metaSvc.RemoveDirectory(authCtx, deleteParentHandle, deleteFileName)
-			} else {
-				var removed *metadata.File
-				removed, _, deleteErr = metaSvc.RemoveFile(authCtx, deleteParentHandle, deleteFileName)
-				if removed != nil {
-					removedPayloadID = removed.PayloadID
-				}
-			}
+			// Remove the elected entry through the shared helper both close
+			// paths use, so the cascade to stream siblings and the payload
+			// purge cannot drift between them. See doc_election.go.
+			isDeleteTargetDir, deleteErr := h.removeElectedTarget(ctx.Context, authCtx, openFile, target, "CLOSE")
 
 			if deleteErr != nil {
-				// Surface the delete-on-close failure (#388) — but only when
-				// no durable-flush failure was already recorded in Step 6. A
+				// Surface the delete-on-close failure — but only when no
+				// durable-flush failure was already recorded in Step 6. A
 				// failed block-store flush is a data-loss signal and takes
 				// precedence: if both fail, the client must see the flush
-				// (data-integrity) status, not the delete error (#1267).
+				// (data-integrity) status, not the delete error.
 				if resp.Status == types.StatusSuccess {
 					resp.Status = common.MapToSMB(deleteErr)
 				}
-				logger.Debug("CLOSE: failed to delete",
-					"path", docName.Path,
-					"isDir", openFile.IsDirectory,
-					"deleteTarget", deleteFileName,
-					"status", resp.Status,
-					"error", deleteErr)
 			} else {
-				logger.Debug("CLOSE: deleted",
-					"path", docName.Path,
-					"deleteTarget", deleteFileName,
-					"isDir", openFile.IsDirectory,
-					"isBaseFileDelete", isBaseFileDelete)
-
-				if !openFile.IsDirectory && !strings.Contains(deleteFileName, ":") {
-					// For base file deletes, cascade ADS streams.
-					// Use a synthetic OpenFile with the base file's info.
-					cascadeOF := openFile
-					if isBaseFileDelete {
-						cascadeOF = (&OpenFile{}).WithName(OpenName{
-							Path:         docName.Path,
-							FileName:     deleteFileName,
-							ParentHandle: deleteParentHandle,
-						})
-					}
-					h.cascadeDeleteADSStreams(authCtx, metaSvc, cascadeOF)
-				}
-
-				h.purgeBlockStorePayload(ctx.Context, deleteTargetHandle, removedPayloadID, docName.Path, "CLOSE")
-				h.restoreParentDirFrozenTimestamps(authCtx, deleteParentHandle)
-
 				// Removing the entry already broke the parent directory's
 				// leases: RemoveFile / RemoveDirectory notify the dir-change
 				// listener, which breaks every parent dir lease (except the
@@ -506,8 +447,8 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 
 				if h.NotifyRegistry != nil {
 					parentPath := GetParentPath(docName.Path)
-					// Use the resolved delete-target type (base file's, not
-					// the stream open's) and the actual deleteFileName.
+					// Use the resolved delete-target type (the base file's, not
+					// the stream open's) and the actual removed name.
 					// NameChangeFilterFor routes ADS names via
 					// FILE_NOTIFY_CHANGE_STREAM_NAME automatically.
 					nameFilter := NameChangeFilterFor(deleteFileName, isDeleteTargetDir)

--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -306,7 +306,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	// (1067-byte files with XSym\n header). On CLOSE, we convert these to
 	// real symlinks in the metadata store for NFS interoperability.
 
-	if !openFile.IsDirectory && payloadID != "" && !openFile.DeletePending && !openFile.InitialDeleteOnClose {
+	if !openFile.IsDirectory && payloadID != "" && !openFile.IsDeletePending() && !openFile.InitialDeleteOnClose {
 		// MFsymlink conversion promotes client-controlled file content to a real
 		// symlink, so it is opt-in per share (default disabled).
 		if tree, treeOK := h.GetTree(ctx.TreeID); treeOK && tree.AllowMFsymlink {

--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -387,249 +387,129 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	// ========================================================================
 	// Step 8: Handle delete-on-close (FileDispositionInformation)
 	// ========================================================================
+	// The last-handle decision and this handle's departure from the set of
+	// handles that could still honour the delete-on-close are one step, taken
+	// inside electDeleteOnClose. Deciding here and removing the handle at step
+	// 10 let two concurrent closers each see the other, each defer, and the
+	// unlink be lost. See doc_election.go.
+	if decision, target := h.electDeleteOnClose(openFile); decision == docDecisionDelete {
+		// The election snapshotted the name it decided on, so a rename landing
+		// since cannot make the scan and the unlink disagree about the entry.
+		docName := target.Name
+		deleteParentHandle := target.ParentHandle
+		deleteFileName := target.FileName
+		isBaseFileDelete := target.IsBaseFile
 
-	// Promote per-handle InitialDeleteOnClose to shared committed DOC at CLOSE
-	// time, mirroring Samba close.c::close_normal_file: if the closing handle
-	// requested initial DOC at CREATE and nobody else has committed a shared
-	// DOC via SET_INFO disposition, set DeletePending so the deletion path
-	// fires (whether this is the last handle or DOC propagates to siblings
-	// via the propagation block below). InitialDeleteOnClose is a per-handle
-	// flag and must NOT block subsequent opens prior to this CLOSE — required
-	// by smbtorture smb2.dirlease.{unlink_same, unlink_different}_initial_and_close.
-	if openFile.InitialDeleteOnClose && !openFile.DeletePending {
-		openFile.DeletePending = true
-	}
-
-	if openFile.DeletePending || openFile.BaseFileDeletePending {
-		// One snapshot of the name: the delete below must not mix the parent
-		// directory from one rename with the file name from another.
-		docName := openFile.Name()
-		// Per MS-FSA 2.1.5.4: delete-on-close only removes the file when the
-		// LAST handle closes. If other handles on the same file exist, propagate
-		// the DOC flag + the original DOC-setter's parent key to remaining handles
-		// so the delete fires on their eventual close.
-		//
-		// For base-file DOC on a non-stream handle, also check for open stream
-		// handles (ADS) on the same base file. Per MS-FSA 2.1.5.9.7 / MS-SMB2
-		// 3.3.5.10, the actual deletion is deferred until all handles — including
-		// stream handles — are closed. The stream handles are marked with
-		// BaseFileDeletePending so the CLOSE of the last stream triggers the
-		// base file removal (smbtorture smb2.streams.delete).
-		isBaseFile := !strings.Contains(docName.FileName, ":")
-		otherHandleExists := false
-		streamHandleExists := false
-
-		if len(openFile.MetadataHandle) > 0 {
-			h.files.Range(func(_, value any) bool {
-				other := value.(*OpenFile)
-				if other.FileID == openFile.FileID {
-					return true // skip self
-				}
-				if bytes.Equal(other.MetadataHandle, openFile.MetadataHandle) {
-					otherHandleExists = true
-					return false
-				}
-				return true
-			})
-		}
-
-		// For base file DOC: also check for open stream handles.
-		if !otherHandleExists && isBaseFile && !openFile.BaseFileDeletePending {
-			basePrefix := docName.FileName + ":"
-			h.rangeStreamsOfBase(openFile.FileID, docName.ParentHandle, basePrefix, func(other *OpenFile) bool {
-				streamHandleExists = true
-				return false
-			})
-		}
-
-		// For stream handle with BaseFileDeletePending: check if other stream
-		// handles with the same base file delete are still open. The actual
-		// base file removal must wait until ALL such handles close.
-		if !otherHandleExists && !streamHandleExists && openFile.BaseFileDeletePending {
-			basePrefix := openFile.BaseFileDeleteFileName + ":"
-			h.rangeStreamsOfBase(openFile.FileID, openFile.BaseFileDeleteParentHandle, basePrefix, func(other *OpenFile) bool {
-				if other.BaseFileDeletePending {
-					otherHandleExists = true
-					return false
-				}
-				return true
-			})
-		}
-
-		if otherHandleExists {
-			// Not the last handle: propagate DOC to remaining handles so the
-			// actual delete fires when they close. The DOC-setter's parent key
-			// is preserved so the closer can compare it for dir-lease
-			// suppression (test_unlink_different_* vs test_unlink_same_*).
-			h.files.Range(func(_, value any) bool {
-				other := value.(*OpenFile)
-				if other.FileID == openFile.FileID {
-					return true
-				}
-				if bytes.Equal(other.MetadataHandle, openFile.MetadataHandle) {
-					// Guard the write: concurrent QUERY_INFO/WRITE goroutines on
-					// the same session may be reading these fields on `other`.
-					// The write lands on the pointer the handle table already
-					// holds, so no re-Store follows: re-Storing would resurrect
-					// a handle whose own CLOSE removed it between this Range and
-					// here, leaving a delete-pending entry nothing ever reaps and
-					// every later CREATE on the path answered DELETE_PENDING.
-					other.mu.Lock()
-					other.DeletePending = true
-					other.DeleteOnCloseParentKey = openFile.DeleteOnCloseParentKey
-					other.HasDeleteOnCloseParentKey = openFile.HasDeleteOnCloseParentKey
-					other.mu.Unlock()
-				}
-				return true
-			})
-			logger.Debug("CLOSE: DOC propagated to other handles (not last)",
-				"path", docName.Path)
-		} else if streamHandleExists {
-			// Base file has DOC but open stream handles remain. Per MS-FSA
-			// 2.1.5.4 / 2.1.5.9.7, defer the actual deletion until all
-			// stream handles close. Mark them with BaseFileDeletePending so
-			// the last stream CLOSE triggers the base file removal.
-			basePrefix := docName.FileName + ":"
-			h.rangeStreamsOfBase(openFile.FileID, docName.ParentHandle, basePrefix, func(other *OpenFile) bool {
-				// Guard the write: concurrent readers on the stream handle
-				// (QUERY_INFO / open path via isFileOrBaseDeletePending) may be
-				// reading these fields on `other`.
-				other.mu.Lock()
-				other.BaseFileDeletePending = true
-				other.BaseFileDeleteParentHandle = docName.ParentHandle
-				other.BaseFileDeleteFileName = docName.FileName
-				other.DeleteOnCloseParentKey = openFile.DeleteOnCloseParentKey
-				other.HasDeleteOnCloseParentKey = openFile.HasDeleteOnCloseParentKey
-				other.mu.Unlock()
-				return true
-			})
-			logger.Debug("CLOSE: base file DOC deferred to stream handles",
-				"path", docName.Path)
+		authCtx, err := BuildAuthContext(ctx)
+		if err != nil {
+			logger.Warn("CLOSE: failed to build auth context for delete", "error", err)
 		} else {
-			// Last handle: perform the actual delete.
+			authCtx.HasDeleteAccess = true
+
+			// Dir-lease parent-key suppression: when the closer's
+			// parent key matches the DOC-setter's parent key, use the closer's
+			// key for suppression (test_unlink_same_*). When they differ, no
+			// suppression — ALL parent dir leases break (test_unlink_different_*).
+			docSetterKeysDiffer := openFile.HasDeleteOnCloseParentKey &&
+				openFile.HasParentLeaseKey &&
+				openFile.DeleteOnCloseParentKey != openFile.ParentLeaseKey
+			if !docSetterKeysDiffer {
+				// Same key (or no DOC key tracking): use closer's parent key
+				PropagateOpenFileParentLeaseKey(authCtx, openFile)
+			}
+			// else: different keys — don't propagate, all dir leases break
+
+			metaSvc := h.Registry.GetMetadataService()
+			// For deferred base-file delete (via stream handle), check the
+			// actual target type — stream handles always have IsDirectory=false.
 			//
-			// If this is a stream handle with BaseFileDeletePending, delete the
-			// base file (not the stream — the stream is a child of the base).
-			deleteParentHandle := docName.ParentHandle
-			deleteFileName := docName.FileName
-			isBaseFileDelete := false
-			if openFile.BaseFileDeletePending {
-				deleteParentHandle = openFile.BaseFileDeleteParentHandle
-				deleteFileName = openFile.BaseFileDeleteFileName
-				isBaseFileDelete = true
+			// Capture the delete target's metadata handle BEFORE removal so
+			// we can route its block-store payload purge afterwards (the
+			// handle encodes share identity and stays valid). The PayloadID
+			// to purge comes from RemoveFile's RETURN value, which is empty
+			// when content must survive (surviving hard link, or recycle to
+			// trash) — purging the open handle's PayloadID instead would
+			// destroy still-referenced content.
+			isDeleteTargetDir := openFile.IsDirectory
+			deleteTargetHandle := openFile.MetadataHandle
+			if isBaseFileDelete {
+				if targetFile, _, lookupErr := metaSvc.LookupCaseInsensitive(authCtx, deleteParentHandle, deleteFileName); lookupErr == nil && targetFile != nil {
+					isDeleteTargetDir = targetFile.Type == metadata.FileTypeDirectory
+					if encoded, encErr := metadata.EncodeFileHandle(targetFile); encErr == nil {
+						deleteTargetHandle = encoded
+					}
+				}
+			}
+			var deleteErr error
+			var removedPayloadID metadata.PayloadID
+			if isDeleteTargetDir {
+				_, deleteErr = metaSvc.RemoveDirectory(authCtx, deleteParentHandle, deleteFileName)
+			} else {
+				var removed *metadata.File
+				removed, _, deleteErr = metaSvc.RemoveFile(authCtx, deleteParentHandle, deleteFileName)
+				if removed != nil {
+					removedPayloadID = removed.PayloadID
+				}
 			}
 
-			authCtx, err := BuildAuthContext(ctx)
-			if err != nil {
-				logger.Warn("CLOSE: failed to build auth context for delete", "error", err)
+			if deleteErr != nil {
+				// Surface the delete-on-close failure (#388) — but only when
+				// no durable-flush failure was already recorded in Step 6. A
+				// failed block-store flush is a data-loss signal and takes
+				// precedence: if both fail, the client must see the flush
+				// (data-integrity) status, not the delete error (#1267).
+				if resp.Status == types.StatusSuccess {
+					resp.Status = common.MapToSMB(deleteErr)
+				}
+				logger.Debug("CLOSE: failed to delete",
+					"path", docName.Path,
+					"isDir", openFile.IsDirectory,
+					"deleteTarget", deleteFileName,
+					"status", resp.Status,
+					"error", deleteErr)
 			} else {
-				authCtx.HasDeleteAccess = true
+				logger.Debug("CLOSE: deleted",
+					"path", docName.Path,
+					"deleteTarget", deleteFileName,
+					"isDir", openFile.IsDirectory,
+					"isBaseFileDelete", isBaseFileDelete)
 
-				// Dir-lease parent-key suppression: when the closer's
-				// parent key matches the DOC-setter's parent key, use the closer's
-				// key for suppression (test_unlink_same_*). When they differ, no
-				// suppression — ALL parent dir leases break (test_unlink_different_*).
-				docSetterKeysDiffer := openFile.HasDeleteOnCloseParentKey &&
-					openFile.HasParentLeaseKey &&
-					openFile.DeleteOnCloseParentKey != openFile.ParentLeaseKey
-				if !docSetterKeysDiffer {
-					// Same key (or no DOC key tracking): use closer's parent key
-					PropagateOpenFileParentLeaseKey(authCtx, openFile)
-				}
-				// else: different keys — don't propagate, all dir leases break
-
-				metaSvc := h.Registry.GetMetadataService()
-				// For deferred base-file delete (via stream handle), check the
-				// actual target type — stream handles always have IsDirectory=false.
-				//
-				// Capture the delete target's metadata handle BEFORE removal so
-				// we can route its block-store payload purge afterwards (the
-				// handle encodes share identity and stays valid). The PayloadID
-				// to purge comes from RemoveFile's RETURN value, which is empty
-				// when content must survive (surviving hard link, or recycle to
-				// trash) — purging the open handle's PayloadID instead would
-				// destroy still-referenced content.
-				isDeleteTargetDir := openFile.IsDirectory
-				deleteTargetHandle := openFile.MetadataHandle
-				if isBaseFileDelete {
-					if targetFile, _, lookupErr := metaSvc.LookupCaseInsensitive(authCtx, deleteParentHandle, deleteFileName); lookupErr == nil && targetFile != nil {
-						isDeleteTargetDir = targetFile.Type == metadata.FileTypeDirectory
-						if encoded, encErr := metadata.EncodeFileHandle(targetFile); encErr == nil {
-							deleteTargetHandle = encoded
-						}
+				if !openFile.IsDirectory && !strings.Contains(deleteFileName, ":") {
+					// For base file deletes, cascade ADS streams.
+					// Use a synthetic OpenFile with the base file's info.
+					cascadeOF := openFile
+					if isBaseFileDelete {
+						cascadeOF = (&OpenFile{}).WithName(OpenName{
+							Path:         docName.Path,
+							FileName:     deleteFileName,
+							ParentHandle: deleteParentHandle,
+						})
 					}
-				}
-				var deleteErr error
-				var removedPayloadID metadata.PayloadID
-				if isDeleteTargetDir {
-					_, deleteErr = metaSvc.RemoveDirectory(authCtx, deleteParentHandle, deleteFileName)
-				} else {
-					var removed *metadata.File
-					removed, _, deleteErr = metaSvc.RemoveFile(authCtx, deleteParentHandle, deleteFileName)
-					if removed != nil {
-						removedPayloadID = removed.PayloadID
-					}
+					h.cascadeDeleteADSStreams(authCtx, metaSvc, cascadeOF)
 				}
 
-				if deleteErr != nil {
-					// Surface the delete-on-close failure (#388) — but only when
-					// no durable-flush failure was already recorded in Step 6. A
-					// failed block-store flush is a data-loss signal and takes
-					// precedence: if both fail, the client must see the flush
-					// (data-integrity) status, not the delete error (#1267).
-					if resp.Status == types.StatusSuccess {
-						resp.Status = common.MapToSMB(deleteErr)
-					}
-					logger.Debug("CLOSE: failed to delete",
-						"path", docName.Path,
-						"isDir", openFile.IsDirectory,
-						"deleteTarget", deleteFileName,
-						"status", resp.Status,
-						"error", deleteErr)
-				} else {
-					logger.Debug("CLOSE: deleted",
-						"path", docName.Path,
-						"deleteTarget", deleteFileName,
-						"isDir", openFile.IsDirectory,
-						"isBaseFileDelete", isBaseFileDelete)
+				h.purgeBlockStorePayload(ctx.Context, deleteTargetHandle, removedPayloadID, docName.Path, "CLOSE")
+				h.restoreParentDirFrozenTimestamps(authCtx, deleteParentHandle)
 
-					if !openFile.IsDirectory && !strings.Contains(deleteFileName, ":") {
-						// For base file deletes, cascade ADS streams.
-						// Use a synthetic OpenFile with the base file's info.
-						cascadeOF := openFile
-						if isBaseFileDelete {
-							cascadeOF = (&OpenFile{}).WithName(OpenName{
-								Path:         docName.Path,
-								FileName:     deleteFileName,
-								ParentHandle: deleteParentHandle,
-							})
-						}
-						h.cascadeDeleteADSStreams(authCtx, metaSvc, cascadeOF)
-					}
+				// Removing the entry already broke the parent directory's
+				// leases: RemoveFile / RemoveDirectory notify the dir-change
+				// listener, which breaks every parent dir lease (except the
+				// originator / suppressed key) to None. The parent-key
+				// suppression was applied via the authCtx propagated above
+				// (closer's key when it matches the DOC-setter's key; none
+				// when they differ, so all dir leases break). Dispatching a
+				// second break here would re-break a lease the client may have
+				// already acked and re-cached in the meantime, sending a
+				// duplicate LEASE_BREAK for one logical change.
 
-					h.purgeBlockStorePayload(ctx.Context, deleteTargetHandle, removedPayloadID, docName.Path, "CLOSE")
-					h.restoreParentDirFrozenTimestamps(authCtx, deleteParentHandle)
-
-					// Removing the entry already broke the parent directory's
-					// leases: RemoveFile / RemoveDirectory notify the dir-change
-					// listener, which breaks every parent dir lease (except the
-					// originator / suppressed key) to None. The parent-key
-					// suppression was applied via the authCtx propagated above
-					// (closer's key when it matches the DOC-setter's key; none
-					// when they differ, so all dir leases break). Dispatching a
-					// second break here would re-break a lease the client may have
-					// already acked and re-cached in the meantime, sending a
-					// duplicate LEASE_BREAK for one logical change.
-
-					if h.NotifyRegistry != nil {
-						parentPath := GetParentPath(docName.Path)
-						// Use the resolved delete-target type (base file's, not
-						// the stream open's) and the actual deleteFileName.
-						// NameChangeFilterFor routes ADS names via
-						// FILE_NOTIFY_CHANGE_STREAM_NAME automatically.
-						nameFilter := NameChangeFilterFor(deleteFileName, isDeleteTargetDir)
-						h.NotifyRegistry.NotifyChange(openFile.ShareName, parentPath, deleteFileName, FileActionRemoved, nameFilter)
-					}
+				if h.NotifyRegistry != nil {
+					parentPath := GetParentPath(docName.Path)
+					// Use the resolved delete-target type (base file's, not
+					// the stream open's) and the actual deleteFileName.
+					// NameChangeFilterFor routes ADS names via
+					// FILE_NOTIFY_CHANGE_STREAM_NAME automatically.
+					nameFilter := NameChangeFilterFor(deleteFileName, isDeleteTargetDir)
+					h.NotifyRegistry.NotifyChange(openFile.ShareName, parentPath, deleteFileName, FileActionRemoved, nameFilter)
 				}
 			}
 		}
@@ -649,12 +529,15 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	// does NOT break (suppressed).
 
 	// SmbWriteTriggered is written under openFile.mu (write) in
-	// armSmbDelayedWrite. Snapshot it under the read lock so we observe a
-	// consistent value against a parallel WRITE on the same handle (#606).
+	// armSmbDelayedWrite, DeletePending under the same lock by a concurrent
+	// closer's delete-on-close election. Snapshot both under the read lock so
+	// we observe consistent values against a parallel WRITE or CLOSE on the
+	// same handle (#606).
 	openFile.mu.RLock()
 	smbWriteTriggered := openFile.SmbWriteTriggered
+	deletePending := openFile.DeletePending
 	openFile.mu.RUnlock()
-	if !openFile.DeletePending && !openFile.IsDirectory && smbWriteTriggered {
+	if !deletePending && !openFile.IsDirectory && smbWriteTriggered {
 		authCtx, authErr := BuildAuthContext(ctx)
 		if authErr != nil {
 			logger.Warn("CLOSE: failed to build auth context for modified-file dir-lease break", "path", closePath, "error", authErr)
@@ -1035,29 +918,6 @@ func (h *Handler) convertToRealSymlink(ctx *SMBHandlerContext, openFile *OpenFil
 		"target", target)
 
 	return nil
-}
-
-// rangeStreamsOfBase iterates over open files that are streams of a base file,
-// filtering out self (by FileID), pipes, handles in a different parent
-// directory, and names that don't start with basePrefix. The caller's fn
-// receives each matching *OpenFile and returns true to continue or false to
-// stop. This consolidates the repeated skip-self/skip-pipe/check-prefix
-// pattern used in the DOC block of Close.
-func (h *Handler) rangeStreamsOfBase(selfFileID [16]byte, parentHandle metadata.FileHandle, basePrefix string, fn func(*OpenFile) bool) {
-	h.files.Range(func(_, value any) bool {
-		other := value.(*OpenFile)
-		if other.FileID == selfFileID || other.IsPipe {
-			return true
-		}
-		otherName := other.Name()
-		if !bytes.Equal(otherName.ParentHandle, parentHandle) {
-			return true
-		}
-		if len(otherName.FileName) <= len(basePrefix) || !strings.EqualFold(otherName.FileName[:len(basePrefix)], basePrefix) {
-			return true
-		}
-		return fn(other)
-	})
 }
 
 // cascadeDeleteADSStreams removes all alternate data streams belonging to a

--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -410,9 +410,11 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 			// parent key matches the DOC-setter's parent key, use the closer's
 			// key for suppression (test_unlink_same_*). When they differ, no
 			// suppression — ALL parent dir leases break (test_unlink_different_*).
-			docSetterKeysDiffer := openFile.HasDeleteOnCloseParentKey &&
+			// The DOC-setter's key comes from the election's snapshot, taken
+			// under the handle lock SET_INFO and the propagation write it under.
+			docSetterKeysDiffer := target.HasDocSetterParentKey &&
 				openFile.HasParentLeaseKey &&
-				openFile.DeleteOnCloseParentKey != openFile.ParentLeaseKey
+				target.DocSetterParentKey != openFile.ParentLeaseKey
 			if !docSetterKeysDiffer {
 				// Same key (or no DOC key tracking): use closer's parent key
 				PropagateOpenFileParentLeaseKey(authCtx, openFile)

--- a/internal/adapter/smb/handlers/close_doc_election_test.go
+++ b/internal/adapter/smb/handlers/close_doc_election_test.go
@@ -247,3 +247,77 @@ func TestElectDeleteOnClose_LastEntrantWins(t *testing.T) {
 		t.Fatalf("closer behind two leaving handles: got %v, want docDecisionDelete", got)
 	}
 }
+
+// TestCloseFilesWithFilter_DurablePersistedSibling_StillUnlink covers the
+// third way a handle leaves the open-file table: the transport-drop path
+// persists a durable handle for later reconnect and drops it from the table
+// exactly as a full close does. A closer that scans while that handle is still
+// listed would defer the unlink to a struct nothing will ever read again, so
+// the persist path has to run the election first like every other departure.
+func TestCloseFilesWithFilter_DurablePersistedSibling_StillUnlink(t *testing.T) {
+	h, smbCtx, _, fileIDA := setupWriteTestShare(t, nil)
+	h.DurableStore = newMockDurableStore()
+
+	rootHandle, err := h.Registry.GetRootHandle(smbCtx.ShareName)
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+
+	// The durable handle carries no delete-on-close of its own, so it is
+	// eligible to be persisted rather than closed.
+	openA, ok := h.GetOpenFile(fileIDA)
+	if !ok {
+		t.Fatalf("seed open file missing")
+	}
+	openA.ShareAccess = 0x07
+	openA.IsDurable = true
+	openA.DurableTimeoutMs = 60000
+
+	// A second session holding the same file with FILE_DELETE_ON_CLOSE.
+	sessB := h.CreateSession("127.0.0.1:12347", false, "test-user", "")
+	uidB, gidB := uint32(0), uint32(0)
+	sessB.User = &models.User{Username: "test-user", UID: &uidB, Groups: []models.Group{{GID: &gidB}}}
+	const treeIDB uint32 = 3
+	h.StoreTree(&TreeConnection{
+		TreeID:     treeIDB,
+		SessionID:  sessB.SessionID,
+		ShareName:  smbCtx.ShareName,
+		Permission: models.PermissionReadWrite,
+	})
+	fileIDB := [16]byte{10}
+	cloneOpenFileForSecondHandle(h, openA, fileIDB, sessB.SessionID, treeIDB)
+
+	h.renameScanMu.Lock()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		h.CloseAllFilesForSession(smbCtx.Context, smbCtx.SessionID, true /* transport disconnect */)
+	}()
+
+	// Let the durable handle be persisted and park on renameScanMu before the
+	// CLOSE below scans for siblings.
+	time.Sleep(settleForDecision)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if _, closeErr := h.Close(&SMBHandlerContext{
+			Context:   smbCtx.Context,
+			SessionID: sessB.SessionID,
+			TreeID:    treeIDB,
+			ShareName: smbCtx.ShareName,
+		}, &CloseRequest{FileID: fileIDB}); closeErr != nil {
+			t.Errorf("Close: %v", closeErr)
+		}
+	}()
+
+	time.Sleep(settleForDecision)
+	h.renameScanMu.Unlock()
+	wg.Wait()
+
+	if fileStillExists(t, h, rootHandle, "data") {
+		t.Fatal("delete-on-close was lost: the closer deferred the unlink to a handle that had been persisted away")
+	}
+}

--- a/internal/adapter/smb/handlers/close_doc_election_test.go
+++ b/internal/adapter/smb/handlers/close_doc_election_test.go
@@ -1,0 +1,249 @@
+// Regression coverage for the last-handle delete-on-close election.
+//
+// Per MS-FSA 2.1.5.4 the unlink fires when the LAST handle on a file closes.
+// Both close paths — the explicit CLOSE handler and the LOGOFF /
+// tree-disconnect / transport-drop teardown — decide "am I the last handle?"
+// by scanning the open-file table for a sibling on the same MetadataHandle,
+// and remove themselves from that table later. When two closers on the same
+// file both scan before either removes itself, each sees the other, each
+// defers the delete to the other, and the file is never unlinked.
+//
+// Both tests below drive that exact interleaving deterministically by holding
+// renameScanMu, which every table removal takes: the closers run their
+// last-handle decision and then park on the mutex, so both decisions provably
+// precede both removals.
+package handlers
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// settleForDecision gives both closers time to run their last-handle decision
+// and park on renameScanMu. Everything they do first is in-memory (metadata
+// and block stores are both the memory backends), so this is generous.
+const settleForDecision = 300 * time.Millisecond
+
+// fileStillExists reports whether name is still present under parent.
+func fileStillExists(t *testing.T, h *Handler, parent metadata.FileHandle, name string) bool {
+	t.Helper()
+	uid, gid := uint32(0), uint32(0)
+	authCtx := &metadata.AuthContext{
+		Context:  context.Background(),
+		Identity: &metadata.Identity{UID: &uid, GID: &gid},
+	}
+	f, _, err := h.Registry.GetMetadataService().LookupCaseInsensitive(authCtx, parent, name)
+	return err == nil && f != nil
+}
+
+// cloneOpenFileForSecondHandle registers a second open on the same metadata
+// file as src, mirroring a second CREATE with FILE_DELETE_ON_CLOSE.
+func cloneOpenFileForSecondHandle(h *Handler, src *OpenFile, fileID [16]byte, sessionID uint64, treeID uint32) *OpenFile {
+	name := src.Name()
+	clone := (&OpenFile{
+		FileID:               fileID,
+		TreeID:               treeID,
+		SessionID:            sessionID,
+		ShareName:            src.ShareName,
+		DesiredAccess:        src.DesiredAccess,
+		GrantedAccess:        src.GrantedAccess,
+		MetadataHandle:       src.MetadataHandle,
+		PayloadID:            src.GetPayloadID(),
+		ShareAccess:          0x07,
+		CreateOptions:        types.FileDeleteOnClose,
+		InitialDeleteOnClose: true,
+	}).WithName(name)
+	h.StoreOpenFile(clone)
+	return clone
+}
+
+// TestClose_ConcurrentLastHandles_StillUnlink drives two concurrent CLOSEs of
+// the only two handles on a file, both carrying FILE_DELETE_ON_CLOSE. Exactly
+// one of them is the last handle, so the file must be gone once both return.
+func TestClose_ConcurrentLastHandles_StillUnlink(t *testing.T) {
+	h, smbCtx, _, fileIDA := setupWriteTestShare(t, nil)
+
+	rootHandle, err := h.Registry.GetRootHandle(smbCtx.ShareName)
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+
+	openA, ok := h.GetOpenFile(fileIDA)
+	if !ok {
+		t.Fatalf("seed open file missing")
+	}
+	openA.ShareAccess = 0x07
+	openA.CreateOptions = types.FileDeleteOnClose
+	openA.InitialDeleteOnClose = true
+
+	fileIDB := [16]byte{8}
+	cloneOpenFileForSecondHandle(h, openA, fileIDB, smbCtx.SessionID, smbCtx.TreeID)
+
+	// Park both closers after their last-handle decision: every removal from
+	// the open-file table takes renameScanMu.
+	h.renameScanMu.Lock()
+
+	var wg sync.WaitGroup
+	statuses := make([]types.Status, 2)
+	for i, fileID := range [][16]byte{fileIDA, fileIDB} {
+		wg.Add(1)
+		go func(slot int, fid [16]byte) {
+			defer wg.Done()
+			resp, closeErr := h.Close(&SMBHandlerContext{
+				Context:   smbCtx.Context,
+				SessionID: smbCtx.SessionID,
+				TreeID:    smbCtx.TreeID,
+				ShareName: smbCtx.ShareName,
+			}, &CloseRequest{FileID: fid})
+			if closeErr != nil {
+				t.Errorf("Close(%x): %v", fid, closeErr)
+				return
+			}
+			statuses[slot] = resp.Status
+		}(i, fileID)
+	}
+
+	time.Sleep(settleForDecision)
+	h.renameScanMu.Unlock()
+	wg.Wait()
+
+	for i, st := range statuses {
+		if st != types.StatusSuccess {
+			t.Errorf("CLOSE %d returned %v, want STATUS_SUCCESS", i, st)
+		}
+	}
+
+	if fileStillExists(t, h, rootHandle, "data") {
+		t.Fatal("delete-on-close was lost: both closers deferred the unlink to each other and the file survived")
+	}
+}
+
+// TestCloseFilesWithFilter_TeardownSiblingLeaving_StillUnlink covers the same
+// defect on the LOGOFF / tree-disconnect / transport-drop path.
+//
+// The symmetric two-teardown interleaving the issue sketches does not actually
+// lose the unlink: closeFilesWithFilter re-reads openFile.DeletePending at its
+// delete gate, after the sibling scan, so whichever teardown propagates second
+// still sees the flag the first one wrote. What it does lose is a delete
+// deferred TO it: a teardown handle carrying no delete-on-close of its own
+// makes its decision in pass 1 and leaves the open-file table only in pass 3,
+// so a concurrent closer that scans in between sees a live sibling, defers,
+// and nobody unlinks.
+//
+// The ordering here is deterministic: the teardown is parked on renameScanMu
+// (already past its own decision) before the explicit CLOSE starts scanning.
+func TestCloseFilesWithFilter_TeardownSiblingLeaving_StillUnlink(t *testing.T) {
+	h, smbCtx, _, fileIDA := setupWriteTestShare(t, nil)
+
+	rootHandle, err := h.Registry.GetRootHandle(smbCtx.ShareName)
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+
+	openA, ok := h.GetOpenFile(fileIDA)
+	if !ok {
+		t.Fatalf("seed open file missing")
+	}
+	openA.ShareAccess = 0x07
+
+	// A second session holding the same file, this one with
+	// FILE_DELETE_ON_CLOSE. It is the handle that must perform the unlink.
+	sessB := h.CreateSession("127.0.0.1:12346", false, "test-user", "")
+	uidB, gidB := uint32(0), uint32(0)
+	sessB.User = &models.User{Username: "test-user", UID: &uidB, Groups: []models.Group{{GID: &gidB}}}
+	const treeIDB uint32 = 2
+	h.StoreTree(&TreeConnection{
+		TreeID:     treeIDB,
+		SessionID:  sessB.SessionID,
+		ShareName:  smbCtx.ShareName,
+		Permission: models.PermissionReadWrite,
+	})
+	fileIDB := [16]byte{9}
+	cloneOpenFileForSecondHandle(h, openA, fileIDB, sessB.SessionID, treeIDB)
+
+	h.renameScanMu.Lock()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		h.CloseAllFilesForSession(smbCtx.Context, smbCtx.SessionID, true /* transport disconnect */)
+	}()
+
+	// Let the teardown finish its own delete-on-close decision and park on
+	// renameScanMu before the CLOSE below scans for siblings.
+	time.Sleep(settleForDecision)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		resp, closeErr := h.Close(&SMBHandlerContext{
+			Context:   smbCtx.Context,
+			SessionID: sessB.SessionID,
+			TreeID:    treeIDB,
+			ShareName: smbCtx.ShareName,
+		}, &CloseRequest{FileID: fileIDB})
+		if closeErr != nil {
+			t.Errorf("Close: %v", closeErr)
+			return
+		}
+		if resp.Status != types.StatusSuccess {
+			t.Errorf("CLOSE returned %v, want STATUS_SUCCESS", resp.Status)
+		}
+	}()
+
+	time.Sleep(settleForDecision)
+	h.renameScanMu.Unlock()
+	wg.Wait()
+
+	if fileStillExists(t, h, rootHandle, "data") {
+		t.Fatal("delete-on-close was lost: the closer deferred the unlink to a handle that had already decided to leave")
+	}
+}
+
+// TestElectDeleteOnClose_LastEntrantWins pins the election contract directly:
+// closers of one file are totally ordered, every closer but the last defers,
+// and the last one deletes — including when it is a handle that carried no
+// delete-on-close of its own until an earlier closer propagated one to it.
+func TestElectDeleteOnClose_LastEntrantWins(t *testing.T) {
+	h := NewHandler()
+	metaHandle := metadata.FileHandle("file-1")
+
+	newOpen := func(id byte, initialDOC bool) *OpenFile {
+		of := (&OpenFile{
+			FileID:               [16]byte{id},
+			MetadataHandle:       metaHandle,
+			InitialDeleteOnClose: initialDOC,
+		}).WithName(OpenName{Path: "f", FileName: "f", ParentHandle: metadata.FileHandle("root")})
+		h.StoreOpenFile(of)
+		return of
+	}
+
+	// Two handles, only the first carrying FILE_DELETE_ON_CLOSE.
+	docHolder := newOpen(1, true)
+	plain := newOpen(2, false)
+
+	if got, _ := h.electDeleteOnClose(docHolder); got != docDecisionDeferred {
+		t.Fatalf("first closer: got %v, want docDecisionDeferred", got)
+	}
+	if !plain.DeletePending {
+		t.Fatal("first closer did not propagate the delete-on-close to the surviving handle")
+	}
+	if got, _ := h.electDeleteOnClose(plain); got != docDecisionDelete {
+		t.Fatalf("last closer: got %v, want docDecisionDelete", got)
+	}
+
+	// Handles still in the table but already past their own election never hold
+	// a delete back: a third closer arriving behind both of them is itself the
+	// last handle.
+	third := newOpen(3, true)
+	if got, _ := h.electDeleteOnClose(third); got != docDecisionDelete {
+		t.Fatalf("closer behind two leaving handles: got %v, want docDecisionDelete", got)
+	}
+}

--- a/internal/adapter/smb/handlers/close_doc_election_test.go
+++ b/internal/adapter/smb/handlers/close_doc_election_test.go
@@ -321,3 +321,71 @@ func TestCloseFilesWithFilter_DurablePersistedSibling_StillUnlink(t *testing.T) 
 		t.Fatal("delete-on-close was lost: the closer deferred the unlink to a handle that had been persisted away")
 	}
 }
+
+// TestCloseFilesWithFilter_BaseFileDeleteCascadesStreams covers the removal
+// side of the election: when the elected target is a base file reached through
+// a stream handle, the base file's stream siblings must go with it. They are
+// ordinary directory entries named `base:stream`, so removing the base entry
+// alone orphans them, and the next enumeration of that name counts them.
+func TestCloseFilesWithFilter_BaseFileDeleteCascadesStreams(t *testing.T) {
+	h, smbCtx, _, fileIDA := setupWriteTestShare(t, nil)
+
+	rootHandle, err := h.Registry.GetRootHandle(smbCtx.ShareName)
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+	uid, gid := uint32(0), uint32(0)
+	authCtx := &metadata.AuthContext{
+		Context:  smbCtx.Context,
+		Identity: &metadata.Identity{UID: &uid, GID: &gid},
+	}
+	metaSvc := h.Registry.GetMetadataService()
+
+	// Two ADS streams on "data", stored as sibling entries.
+	streamNames := []string{"data:one:$DATA", "data:two:$DATA"}
+	for _, sn := range streamNames {
+		if _, _, createErr := metaSvc.CreateFile(authCtx, rootHandle, sn, &metadata.FileAttr{
+			Type: metadata.FileTypeRegular, Mode: 0o644,
+		}); createErr != nil {
+			t.Fatalf("CreateFile(%s): %v", sn, createErr)
+		}
+	}
+
+	// The base handle is gone; the only open left is a stream handle carrying
+	// the deferred base-file delete, which is the state close.go's election
+	// leaves behind when a base-file DOC finds open streams.
+	h.DeleteOpenFile(fileIDA)
+
+	streamFile, _, err := metaSvc.LookupCaseInsensitive(authCtx, rootHandle, streamNames[0])
+	if err != nil {
+		t.Fatalf("lookup stream: %v", err)
+	}
+	streamHandle, err := metadata.EncodeFileHandle(streamFile)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle: %v", err)
+	}
+
+	streamOpen := (&OpenFile{
+		FileID:                     [16]byte{11},
+		TreeID:                     smbCtx.TreeID,
+		SessionID:                  smbCtx.SessionID,
+		ShareName:                  smbCtx.ShareName,
+		MetadataHandle:             streamHandle,
+		ShareAccess:                0x07,
+		BaseFileDeletePending:      true,
+		BaseFileDeleteParentHandle: rootHandle,
+		BaseFileDeleteFileName:     "data",
+	}).WithName(OpenName{Path: streamNames[0], FileName: streamNames[0], ParentHandle: rootHandle})
+	h.StoreOpenFile(streamOpen)
+
+	h.CloseAllFilesForSession(smbCtx.Context, smbCtx.SessionID, false /* explicit logoff */)
+
+	if fileStillExists(t, h, rootHandle, "data") {
+		t.Error("base file survived the deferred delete-on-close")
+	}
+	for _, sn := range streamNames {
+		if fileStillExists(t, h, rootHandle, sn) {
+			t.Errorf("stream %q was orphaned: removing the base entry must cascade to its stream siblings", sn)
+		}
+	}
+}

--- a/internal/adapter/smb/handlers/doc_election.go
+++ b/internal/adapter/smb/handlers/doc_election.go
@@ -43,6 +43,13 @@ type docTarget struct {
 	// IsBaseFile is set when the entry above is the base file behind a stream
 	// handle rather than the closing handle's own name.
 	IsBaseFile bool
+
+	// DocSetterParentKey is the parent lease key recorded by whoever committed
+	// the delete-on-close, snapshotted under the handle lock. The unlink
+	// suppresses the parent dir lease only when it matches the closer's own
+	// parent key; when they differ every parent dir lease breaks.
+	DocSetterParentKey    [16]byte
+	HasDocSetterParentKey bool
 }
 
 // electDeleteOnClose runs the delete-on-close last-handle election for a
@@ -106,6 +113,8 @@ func (h *Handler) electDeleteOnClose(openFile *OpenFile) (docDecision, docTarget
 	baseFileDeletePending := openFile.BaseFileDeletePending
 	baseFileParentHandle := openFile.BaseFileDeleteParentHandle
 	baseFileName := openFile.BaseFileDeleteFileName
+	docSetterKey := openFile.DeleteOnCloseParentKey
+	hasDocSetterKey := openFile.HasDeleteOnCloseParentKey
 	openFile.mu.Unlock()
 
 	if !deletePending && !baseFileDeletePending {
@@ -140,8 +149,8 @@ func (h *Handler) electDeleteOnClose(openFile *OpenFile) (docDecision, docTarget
 			// reaps and every later CREATE on the path answered DELETE_PENDING.
 			other.mu.Lock()
 			other.DeletePending = true
-			other.DeleteOnCloseParentKey = openFile.DeleteOnCloseParentKey
-			other.HasDeleteOnCloseParentKey = openFile.HasDeleteOnCloseParentKey
+			other.DeleteOnCloseParentKey = docSetterKey
+			other.HasDeleteOnCloseParentKey = hasDocSetterKey
 			other.mu.Unlock()
 			return true
 		})
@@ -171,8 +180,8 @@ func (h *Handler) electDeleteOnClose(openFile *OpenFile) (docDecision, docTarget
 			other.BaseFileDeletePending = true
 			other.BaseFileDeleteParentHandle = docName.ParentHandle
 			other.BaseFileDeleteFileName = docName.FileName
-			other.DeleteOnCloseParentKey = openFile.DeleteOnCloseParentKey
-			other.HasDeleteOnCloseParentKey = openFile.HasDeleteOnCloseParentKey
+			other.DeleteOnCloseParentKey = docSetterKey
+			other.HasDeleteOnCloseParentKey = hasDocSetterKey
 			other.mu.Unlock()
 			return true
 		})
@@ -201,7 +210,13 @@ func (h *Handler) electDeleteOnClose(openFile *OpenFile) (docDecision, docTarget
 		}
 	}
 
-	target := docTarget{Name: docName, ParentHandle: docName.ParentHandle, FileName: docName.FileName}
+	target := docTarget{
+		Name:                  docName,
+		ParentHandle:          docName.ParentHandle,
+		FileName:              docName.FileName,
+		DocSetterParentKey:    docSetterKey,
+		HasDocSetterParentKey: hasDocSetterKey,
+	}
 	if baseFileDeletePending {
 		target.ParentHandle = baseFileParentHandle
 		target.FileName = baseFileName

--- a/internal/adapter/smb/handlers/doc_election.go
+++ b/internal/adapter/smb/handlers/doc_election.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"strings"
 
 	"github.com/marmos91/dittofs/internal/logger"
@@ -249,4 +250,101 @@ func (h *Handler) rangeLiveStreamsOfBase(selfFileID [16]byte, parentHandle metad
 		}
 		return fn(other)
 	})
+}
+
+// removeElectedTarget removes the directory entry a delete-on-close election
+// resolved, together with everything that must accompany a removed entry:
+// cascading the base file's ADS streams, purging its block-store payload, and
+// restoring the parent directory's frozen timestamps. It returns the removal
+// error so the caller can surface or log it.
+//
+// Both close paths go through it. They previously removed the entry themselves
+// and drifted: the teardown never cascaded, so once it started removing the
+// resolved target — a base file, for a stream handle carrying a base-file
+// delete — the base entry went and its `name:stream` siblings stayed behind as
+// orphans that the next enumeration of that name counted.
+//
+// Two things stay with the callers because they differ by close path rather
+// than by what was removed:
+//
+//   - Lease breaks. CLOSE relies on the removal's own dir-change notification
+//     to break the parent's leases and deliberately does not dispatch a second
+//     one; the teardown breaks the file's Handle leases before the unlink and
+//     the parent's afterwards, because no SET_INFO disposition preceded it.
+//   - The SMB CHANGE_NOTIFY event. CLOSE emits one; the teardown never has,
+//     and starting to emit one there is a change to the notify registry's
+//     traffic rather than to this removal.
+func (h *Handler) removeElectedTarget(
+	ctx context.Context,
+	authCtx *metadata.AuthContext,
+	openFile *OpenFile,
+	target docTarget,
+	caller string,
+) (removedIsDir bool, err error) {
+	metaSvc := h.Registry.GetMetadataService()
+
+	// For a deferred base-file delete (reached via a stream handle), resolve
+	// the actual target type — stream handles always have IsDirectory=false.
+	//
+	// Capture the delete target's metadata handle BEFORE removal so the
+	// block-store payload purge can be routed afterwards (the handle encodes
+	// share identity and stays valid). The PayloadID to purge comes from
+	// RemoveFile's RETURN value, which is empty when content must survive (a
+	// surviving hard link, or a recycle to trash) — purging the open handle's
+	// PayloadID instead would destroy still-referenced content.
+	isDeleteTargetDir := openFile.IsDirectory
+	deleteTargetHandle := openFile.MetadataHandle
+	if target.IsBaseFile {
+		if targetFile, _, lookupErr := metaSvc.LookupCaseInsensitive(authCtx, target.ParentHandle, target.FileName); lookupErr == nil && targetFile != nil {
+			isDeleteTargetDir = targetFile.Type == metadata.FileTypeDirectory
+			if encoded, encErr := metadata.EncodeFileHandle(targetFile); encErr == nil {
+				deleteTargetHandle = encoded
+			}
+		}
+	}
+
+	var removedPayloadID metadata.PayloadID
+	if isDeleteTargetDir {
+		_, err = metaSvc.RemoveDirectory(authCtx, target.ParentHandle, target.FileName)
+	} else {
+		var removed *metadata.File
+		removed, _, err = metaSvc.RemoveFile(authCtx, target.ParentHandle, target.FileName)
+		if removed != nil {
+			removedPayloadID = removed.PayloadID
+		}
+	}
+	if err != nil {
+		logger.Debug(caller+": failed to delete",
+			"path", target.Name.Path,
+			"deleteTarget", target.FileName,
+			"isDir", isDeleteTargetDir,
+			"error", err)
+		return isDeleteTargetDir, err
+	}
+
+	logger.Debug(caller+": deleted",
+		"path", target.Name.Path,
+		"deleteTarget", target.FileName,
+		"isDir", isDeleteTargetDir,
+		"isBaseFileDelete", target.IsBaseFile)
+
+	// Per MS-FSA 2.1.5.9.7 deleting a file deletes all its streams. The
+	// streams are sibling entries named `base:stream`, so removing the base
+	// entry alone leaves them behind.
+	if !isDeleteTargetDir && !strings.Contains(target.FileName, ":") {
+		cascadeOF := openFile
+		if target.IsBaseFile {
+			cascadeOF = (&OpenFile{}).WithName(OpenName{
+				Path:         target.Name.Path,
+				FileName:     target.FileName,
+				ParentHandle: target.ParentHandle,
+			})
+		}
+		h.cascadeDeleteADSStreams(authCtx, metaSvc, cascadeOF)
+	}
+
+	h.purgeBlockStorePayload(ctx, deleteTargetHandle, removedPayloadID, target.Name.Path, caller)
+	h.restoreParentDirFrozenTimestamps(authCtx, target.ParentHandle)
+
+	return isDeleteTargetDir, nil
 }

--- a/internal/adapter/smb/handlers/doc_election.go
+++ b/internal/adapter/smb/handlers/doc_election.go
@@ -1,0 +1,237 @@
+package handlers
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// docDecision is the outcome of the delete-on-close last-handle election for
+// one closing handle (MS-FSA 2.1.5.4: the unlink happens when the LAST handle
+// on the file closes).
+type docDecision int
+
+const (
+	// docDecisionNone: the closing handle carries no delete-on-close.
+	docDecisionNone docDecision = iota
+
+	// docDecisionDeferred: handles that can still honour the delete-on-close
+	// remain open. They now carry it, and the last of them unlinks.
+	docDecisionDeferred
+
+	// docDecisionDelete: no such handle remains. The caller performs the
+	// unlink.
+	docDecisionDelete
+)
+
+// docTarget names what the electing handle must unlink when the election
+// returns docDecisionDelete. It is snapshotted inside the election so a rename
+// landing afterwards cannot make the scan and the unlink disagree about which
+// entry the delete-on-close was decided for.
+type docTarget struct {
+	// Name is the closing handle's own name at election time.
+	Name OpenName
+
+	// ParentHandle and FileName address the directory entry to remove. For a
+	// stream handle carrying a base-file delete they address the base file,
+	// not the stream — the stream is a child of the base.
+	ParentHandle metadata.FileHandle
+	FileName     string
+
+	// IsBaseFile is set when the entry above is the base file behind a stream
+	// handle rather than the closing handle's own name.
+	IsBaseFile bool
+}
+
+// electDeleteOnClose runs the delete-on-close last-handle election for a
+// closing handle and returns what that handle must do about it.
+//
+// Both close paths — the explicit CLOSE handler and the LOGOFF /
+// tree-disconnect / transport-drop teardown — decide whether they are the last
+// handle on a file well before they remove themselves from the open-file
+// table: CLOSE scans at step 8 and removes at step 10, and the teardown scans
+// in its first pass and removes in its third. Two closers whose scans both land
+// before either removal each see the other as a surviving handle, each defers
+// the unlink to the other, and the file is never deleted — the client is told
+// its delete succeeded and the file survives.
+//
+// Narrowing that span cannot fix it; the decision and the departure have to be
+// one step. They are made so here by an explicit departure mark taken under
+// docElectionMu together with the scan that reads it:
+//
+//   - Every closing handle marks itself as leaving, whether or not it carries a
+//     delete-on-close of its own. A handle that has already run this election
+//     cannot honour a delete-on-close propagated to it afterwards, so it must
+//     stop counting as a surviving handle at exactly that moment.
+//   - The scan ignores handles already marked, so the closers of one file are
+//     totally ordered by the mutex and only the last one in sees no survivor.
+//     Every earlier closer sees a later one and propagates the delete-on-close
+//     to it, which the later closer reads inside its own election.
+//
+// The mark deliberately does NOT remove the handle from h.files. It stays
+// visible to the CREATE delete-pending gate, the share-mode and oplock scans
+// and the rename conflict re-scan until the caller's own removal step, so a
+// CREATE arriving between this election and the unlink still answers
+// STATUS_DELETE_PENDING rather than opening a file that is about to vanish.
+//
+// docElectionMu is a leaf: the election takes only per-OpenFile locks under it
+// and performs no I/O, so it never nests inside renameScanMu, the LockManager,
+// or the lease locks.
+func (h *Handler) electDeleteOnClose(openFile *OpenFile) (docDecision, docTarget) {
+	h.docElectionMu.Lock()
+	defer h.docElectionMu.Unlock()
+
+	openFile.docLeaving = true
+
+	// Promote the per-handle InitialDeleteOnClose from CREATE
+	// FILE_DELETE_ON_CLOSE to the shared committed flag, mirroring Samba
+	// close.c::close_normal_file: if this handle requested initial DOC and
+	// nobody else committed a shared DOC via SET_INFO disposition, set
+	// DeletePending so the deletion fires — either here, or on the handle this
+	// election propagates to. InitialDeleteOnClose must NOT block opens before
+	// this point (smbtorture smb2.dirlease.{unlink_same,unlink_different}
+	// _initial_and_close), which is why the promotion happens at CLOSE and not
+	// at CREATE.
+	//
+	// The read of DeletePending happens inside the election, not before it, so
+	// a closer that was propagated to by an earlier closer observes the flag
+	// and takes its turn as the last handle.
+	openFile.mu.Lock()
+	if openFile.InitialDeleteOnClose && !openFile.DeletePending {
+		openFile.DeletePending = true
+	}
+	deletePending := openFile.DeletePending
+	baseFileDeletePending := openFile.BaseFileDeletePending
+	baseFileParentHandle := openFile.BaseFileDeleteParentHandle
+	baseFileName := openFile.BaseFileDeleteFileName
+	openFile.mu.Unlock()
+
+	if !deletePending && !baseFileDeletePending {
+		return docDecisionNone, docTarget{}
+	}
+
+	// One snapshot of the name: the delete must not mix the parent directory
+	// from one rename with the file name from another.
+	docName := openFile.Name()
+
+	// Opens on the same metadata file that are not themselves leaving. The DOC
+	// is propagated to them in the same pass: not being the last handle means
+	// the actual delete fires when they close. The DOC-setter's parent key is
+	// preserved so the eventual closer can compare it for dir-lease
+	// suppression (test_unlink_different_* vs test_unlink_same_*).
+	otherHandleExists := false
+	if len(openFile.MetadataHandle) > 0 {
+		h.files.Range(func(_, value any) bool {
+			other := value.(*OpenFile)
+			if other.FileID == openFile.FileID || other.docLeaving {
+				return true
+			}
+			if !bytes.Equal(other.MetadataHandle, openFile.MetadataHandle) {
+				return true
+			}
+			otherHandleExists = true
+			// Guard the write: concurrent QUERY_INFO/WRITE goroutines on the
+			// same session may be reading these fields on `other`. The write
+			// lands on the pointer the handle table already holds, so no
+			// re-Store follows: re-Storing would resurrect a handle whose own
+			// CLOSE removed it, leaving a delete-pending entry nothing ever
+			// reaps and every later CREATE on the path answered DELETE_PENDING.
+			other.mu.Lock()
+			other.DeletePending = true
+			other.DeleteOnCloseParentKey = openFile.DeleteOnCloseParentKey
+			other.HasDeleteOnCloseParentKey = openFile.HasDeleteOnCloseParentKey
+			other.mu.Unlock()
+			return true
+		})
+	}
+
+	if otherHandleExists {
+		logger.Debug("CLOSE: DOC propagated to other handles (not last)",
+			"path", docName.Path)
+		return docDecisionDeferred, docTarget{}
+	}
+
+	// For base-file DOC on a non-stream handle, open stream handles (ADS) on
+	// the same base file also hold the deletion back. Per MS-FSA 2.1.5.9.7 /
+	// MS-SMB2 3.3.5.10 the removal is deferred until all handles — including
+	// stream handles — are closed. Marking them with BaseFileDeletePending
+	// makes the CLOSE of the last stream trigger the base file removal
+	// (smbtorture smb2.streams.delete).
+	isBaseFile := !strings.Contains(docName.FileName, ":")
+	if isBaseFile && !baseFileDeletePending {
+		streamHandleExists := false
+		h.rangeLiveStreamsOfBase(openFile.FileID, docName.ParentHandle, docName.FileName+":", func(other *OpenFile) bool {
+			streamHandleExists = true
+			// Guard the write: concurrent readers on the stream handle
+			// (QUERY_INFO / open path via isFileOrBaseDeletePending) may be
+			// reading these fields on `other`.
+			other.mu.Lock()
+			other.BaseFileDeletePending = true
+			other.BaseFileDeleteParentHandle = docName.ParentHandle
+			other.BaseFileDeleteFileName = docName.FileName
+			other.DeleteOnCloseParentKey = openFile.DeleteOnCloseParentKey
+			other.HasDeleteOnCloseParentKey = openFile.HasDeleteOnCloseParentKey
+			other.mu.Unlock()
+			return true
+		})
+		if streamHandleExists {
+			logger.Debug("CLOSE: base file DOC deferred to stream handles",
+				"path", docName.Path)
+			return docDecisionDeferred, docTarget{}
+		}
+	}
+
+	// A stream handle carrying a base-file DOC waits for every other stream
+	// handle carrying the same base-file delete.
+	if baseFileDeletePending {
+		siblingStreamExists := false
+		h.rangeLiveStreamsOfBase(openFile.FileID, baseFileParentHandle, baseFileName+":", func(other *OpenFile) bool {
+			if other.BaseFileDeletePending {
+				siblingStreamExists = true
+				return false
+			}
+			return true
+		})
+		if siblingStreamExists {
+			logger.Debug("CLOSE: base file DOC deferred to remaining stream handles",
+				"path", docName.Path)
+			return docDecisionDeferred, docTarget{}
+		}
+	}
+
+	target := docTarget{Name: docName, ParentHandle: docName.ParentHandle, FileName: docName.FileName}
+	if baseFileDeletePending {
+		target.ParentHandle = baseFileParentHandle
+		target.FileName = baseFileName
+		target.IsBaseFile = true
+	}
+	return docDecisionDelete, target
+}
+
+// rangeLiveStreamsOfBase iterates over the open files that are streams of a
+// base file, filtering out self (by FileID), pipes, handles already leaving
+// via their own election, handles in a different parent directory, and names
+// that don't start with basePrefix. The caller's fn receives each matching
+// *OpenFile and returns true to continue or false to stop.
+//
+// Callers hold docElectionMu: the docLeaving reads below are only meaningful
+// under it, and a stream handle already past its own election can no longer
+// honour a base-file delete marked on it.
+func (h *Handler) rangeLiveStreamsOfBase(selfFileID [16]byte, parentHandle metadata.FileHandle, basePrefix string, fn func(*OpenFile) bool) {
+	h.files.Range(func(_, value any) bool {
+		other := value.(*OpenFile)
+		if other.FileID == selfFileID || other.IsPipe || other.docLeaving {
+			return true
+		}
+		otherName := other.Name()
+		if !bytes.Equal(otherName.ParentHandle, parentHandle) {
+			return true
+		}
+		if len(otherName.FileName) <= len(basePrefix) || !strings.EqualFold(otherName.FileName[:len(basePrefix)], basePrefix) {
+			return true
+		}
+		return fn(other)
+	})
+}

--- a/internal/adapter/smb/handlers/durable_context.go
+++ b/internal/adapter/smb/handlers/durable_context.go
@@ -1101,7 +1101,7 @@ func buildPersistedDurableHandle(
 		DisconnectedAt:  time.Now(),
 		TimeoutMs:       openFile.DurableTimeoutMs,
 		ServerStartTime: serverStartTime,
-		DeletePending:   openFile.DeletePending,
+		DeletePending:   openFile.IsDeletePending(),
 		ParentHandle:    parentHandle,
 		FileName:        name.FileName,
 		IsDirectory:     openFile.IsDirectory,

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -1361,6 +1361,18 @@ func (h *Handler) closeFilesWithFilter(
 			return true
 		}
 
+		// Delete-on-close decision. It runs here, ahead of everything that can
+		// make this handle leave the open-file table — the durable persist
+		// below removes it from h.files just as a full close does — because
+		// the decision and this handle's departure from the set of handles
+		// that can still honour a delete-on-close have to be one step. This
+		// pass decides and the third pass below removes; a concurrent closer
+		// scanning in between must not see a handle already written off, or
+		// it defers the unlink to one that will never perform it. Shared with
+		// close.go step 8; see doc_election.go. The unlink itself runs further
+		// down, after the lock release and the cache flush.
+		decision, docDelete := h.electDeleteOnClose(openFile)
+
 		// Durable handle persistence: when IsDurable is set AND this is a transport
 		// disconnect (not an explicit LOGOFF), persist the handle to the
 		// DurableHandleStore for later reconnection. On explicit LOGOFF the client
@@ -1375,8 +1387,10 @@ func (h *Handler) closeFilesWithFilter(
 		// file persists across the disconnect and a subsequent fresh CREATE sees
 		// the stale content instead of a freshly-created empty file. The matching
 		// delete_on_close2 test stays in KNOWN_FAILURES (same as Samba upstream).
-		hasDeleteOnClose := openFile.CreateOptions&types.FileDeleteOnClose != 0 ||
-			openFile.DeletePending
+		// A non-none decision is exactly "this handle carries a delete-on-close",
+		// read inside the election — so a DOC a concurrent closer propagated
+		// onto this handle a moment ago is honoured rather than persisted away.
+		hasDeleteOnClose := decision != docDecisionNone
 		if openFile.IsDurable && h.DurableStore != nil && isDisconnect && !hasDeleteOnClose {
 			username := ""
 			var sessionKeyHash [32]byte
@@ -1483,23 +1497,12 @@ func (h *Handler) closeFilesWithFilter(
 			h.flushFileCache(ctx, openFile)
 		}
 
-		// Handle delete-on-close (FileDispositionInformation OR per-handle
-		// initial DOC from a CREATE FILE_DELETE_ON_CLOSE that was not promoted
-		// earlier — TDIS / LOGOFF / disconnect skip the explicit CLOSE
-		// handler, so the same promotion applies here).
-		//
-		// Shared with close.go step 8: this pass decides and the third pass
-		// below removes the handle, so the MS-FSA 2.1.5.4 last-handle decision
-		// has to be atomic with that handle's departure from the set of
-		// handles that can still honour the DOC. See doc_election.go.
-		//
-		// Durable handles persisted for reconnect returned above without
-		// reaching this point: they stay logically open, so they neither
-		// elect nor stop counting as survivors.
-		if decision, target := h.electDeleteOnClose(openFile); decision == docDecisionDelete {
-			if len(target.Name.ParentHandle) > 0 && target.Name.FileName != "" {
-				h.handleDeleteOnClose(ctx, sess, openFile, caller)
-			}
+		// Execute the delete-on-close decided above. TDIS / LOGOFF / disconnect
+		// skip the explicit CLOSE handler, so this is where the unlink happens
+		// for them. The target was snapshotted by the election, so a rename
+		// landing since cannot redirect it.
+		if decision == docDecisionDelete && len(docDelete.ParentHandle) > 0 && docDelete.FileName != "" {
+			h.handleDeleteOnClose(ctx, sess, openFile, docDelete, caller)
 		}
 
 		// Queue this handle's per-open lease/oplock record for release in the
@@ -1652,8 +1655,8 @@ func (h *Handler) purgeBlockStorePayload(ctx context.Context, handle metadata.Fi
 // different session/tree on the same transport. Waiting for an ACK here
 // would deadlock — the holder can only ack after the triggering request
 // returns.
-func (h *Handler) handleDeleteOnClose(ctx context.Context, sess *session.Session, openFile *OpenFile, caller string) {
-	name := openFile.Name()
+func (h *Handler) handleDeleteOnClose(ctx context.Context, sess *session.Session, openFile *OpenFile, target docTarget, caller string) {
+	name := target.Name
 	authCtx := h.buildCleanupAuthContext(ctx, sess)
 	// Thread the closing handle's RqLs ParentLeaseKey so notifyDirChange can
 	// apply the MS-SMB2 §3.3.4.20 / Samba `dirlease_should_break` parent-key
@@ -1673,16 +1676,18 @@ func (h *Handler) handleDeleteOnClose(ctx context.Context, sess *session.Session
 		}
 	}
 
+	// Remove what the election resolved, which for a stream handle carrying a
+	// base-file delete is the base file rather than the stream's own name.
 	var deleted bool
 	if openFile.IsDirectory {
-		if _, err := metaSvc.RemoveDirectory(authCtx, name.ParentHandle, name.FileName); err != nil {
+		if _, err := metaSvc.RemoveDirectory(authCtx, target.ParentHandle, target.FileName); err != nil {
 			logger.Debug(caller+": failed to delete directory", "path", name.Path, "error", err)
 		} else {
 			logger.Debug(caller+": directory deleted", "path", name.Path)
 			deleted = true
 		}
 	} else {
-		removed, _, err := metaSvc.RemoveFile(authCtx, name.ParentHandle, name.FileName)
+		removed, _, err := metaSvc.RemoveFile(authCtx, target.ParentHandle, target.FileName)
 		if err != nil {
 			logger.Debug(caller+": failed to delete file", "path", name.Path, "error", err)
 		} else {

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -83,6 +83,17 @@ type Handler struct {
 	// under its own distinct FileID).
 	renameScanMu sync.Mutex
 
+	// docElectionMu serializes the delete-on-close last-handle election
+	// (electDeleteOnClose) across every closing handle: it makes each closer's
+	// "am I the last handle on this file?" scan atomic with its own departure
+	// from the set of handles that can still honour a delete-on-close
+	// (OpenFile.docLeaving). See doc_election.go.
+	//
+	// Lock order: leaf. The election takes only per-OpenFile locks under it and
+	// does no I/O, and no other lock is acquired while it is held — both close
+	// paths have released it well before they take renameScanMu.
+	docElectionMu sync.Mutex
+
 	// Named pipe management (for IPC$ RPC)
 	PipeManager *rpc.PipeManager
 
@@ -536,6 +547,17 @@ type OpenFile struct {
 	// DOC and then immediately open a SECOND handle to it (must succeed).
 	DeletePending        bool // committed shared DOC (visible to other opens)
 	InitialDeleteOnClose bool // per-handle initial DOC from CREATE FILE_DELETE_ON_CLOSE
+
+	// docLeaving marks a handle that has already run its delete-on-close
+	// election (electDeleteOnClose) and can therefore no longer honour a DOC
+	// propagated to it; the election's sibling scans skip such handles.
+	//
+	// Guarded by Handler.docElectionMu — NOT by OpenFile.mu — because it is
+	// only ever read as part of a scan that must be atomic with the writes to
+	// it. The handle stays in Handler.files while marked, so every other scan
+	// (CREATE delete-pending gate, share modes, oplocks, rename conflict) still
+	// sees it until its owner's own removal step.
+	docLeaving bool
 
 	// ShareAccess stores the sharing mode from the CREATE request.
 	// Used for share mode conflict checking during rename and other operations.
@@ -1462,61 +1484,22 @@ func (h *Handler) closeFilesWithFilter(
 		}
 
 		// Handle delete-on-close (FileDispositionInformation OR per-handle
-		// initial DOC from a CREATE FILE_DELETE_ON_CLOSE that was not
-		// promoted earlier — TDIS / LOGOFF / disconnect skip the explicit
-		// CLOSE handler, so the same close.go promotion applies here).
+		// initial DOC from a CREATE FILE_DELETE_ON_CLOSE that was not promoted
+		// earlier — TDIS / LOGOFF / disconnect skip the explicit CLOSE
+		// handler, so the same promotion applies here).
 		//
-		// Promote per-handle InitialDeleteOnClose to shared committed
-		// DeletePending only when no OTHER handle on the same metadata
-		// file remains open: otherwise the unlink in handleDeleteOnClose
-		// would fire before the last sibling closes, violating MS-FSA
-		// 2.1.5.4 (delete-on-close removes the file when the LAST handle
-		// closes, not on the per-handle initial flag). When siblings
-		// remain, propagate the DOC + DOC-setter parent key onto them so
-		// the eventual sibling close in close.go (or this same teardown
-		// for sibling opens in this iteration) fires the delete instead.
-		isInitialDocOnly := openFile.InitialDeleteOnClose && !openFile.DeletePending
-		if isInitialDocOnly && len(openFile.MetadataHandle) > 0 {
-			otherHandleExists := false
-			h.files.Range(func(_, value any) bool {
-				other := value.(*OpenFile)
-				if other.FileID == openFile.FileID {
-					return true
-				}
-				if bytes.Equal(other.MetadataHandle, openFile.MetadataHandle) {
-					otherHandleExists = true
-					return false
-				}
-				return true
-			})
-			if otherHandleExists {
-				// Propagate DOC to remaining handles so their eventual
-				// close triggers the delete. Matches the close.go path
-				// at "DOC propagated to other handles (not last)".
-				h.files.Range(func(_, value any) bool {
-					other := value.(*OpenFile)
-					if other.FileID == openFile.FileID {
-						return true
-					}
-					if bytes.Equal(other.MetadataHandle, openFile.MetadataHandle) {
-						// Guard the write: concurrent QUERY_INFO/WRITE goroutines
-						// on the same session may be reading these fields.
-						other.mu.Lock()
-						other.DeletePending = true
-						other.DeleteOnCloseParentKey = openFile.DeleteOnCloseParentKey
-						other.HasDeleteOnCloseParentKey = openFile.HasDeleteOnCloseParentKey
-						other.mu.Unlock()
-					}
-					return true
-				})
-				logger.Debug(caller+": initial DOC propagated to other handles (not last)",
-					"path", openFile.Name().Path)
-				isInitialDocOnly = false // delete handled by remaining sibling
+		// Shared with close.go step 8: this pass decides and the third pass
+		// below removes the handle, so the MS-FSA 2.1.5.4 last-handle decision
+		// has to be atomic with that handle's departure from the set of
+		// handles that can still honour the DOC. See doc_election.go.
+		//
+		// Durable handles persisted for reconnect returned above without
+		// reaching this point: they stay logically open, so they neither
+		// elect nor stop counting as survivors.
+		if decision, target := h.electDeleteOnClose(openFile); decision == docDecisionDelete {
+			if len(target.Name.ParentHandle) > 0 && target.Name.FileName != "" {
+				h.handleDeleteOnClose(ctx, sess, openFile, caller)
 			}
-		}
-		docName := openFile.Name()
-		if (openFile.DeletePending || isInitialDocOnly) && len(docName.ParentHandle) > 0 && docName.FileName != "" {
-			h.handleDeleteOnClose(ctx, sess, openFile, caller)
 		}
 
 		// Queue this handle's per-open lease/oplock record for release in the

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -1680,8 +1680,6 @@ func (h *Handler) handleDeleteOnClose(ctx context.Context, sess *session.Session
 	if !docSetterKeysDiffer {
 		PropagateOpenFileParentLeaseKey(authCtx, openFile)
 	}
-	metaSvc := h.Registry.GetMetadataService()
-
 	if h.LeaseManager != nil && len(openFile.MetadataHandle) > 0 {
 		lockFileHandle := lock.FileHandle(openFile.MetadataHandle)
 		// Exclude the closing session: its leases on this file are about to
@@ -1694,34 +1692,14 @@ func (h *Handler) handleDeleteOnClose(ctx context.Context, sess *session.Session
 		}
 	}
 
-	// Remove what the election resolved, which for a stream handle carrying a
-	// base-file delete is the base file rather than the stream's own name.
-	var deleted bool
-	if openFile.IsDirectory {
-		if _, err := metaSvc.RemoveDirectory(authCtx, target.ParentHandle, target.FileName); err != nil {
-			logger.Debug(caller+": failed to delete directory", "path", name.Path, "error", err)
-		} else {
-			logger.Debug(caller+": directory deleted", "path", name.Path)
-			deleted = true
-		}
-	} else {
-		removed, _, err := metaSvc.RemoveFile(authCtx, target.ParentHandle, target.FileName)
-		if err != nil {
-			logger.Debug(caller+": failed to delete file", "path", name.Path, "error", err)
-		} else {
-			logger.Debug(caller+": file deleted", "path", name.Path)
-			deleted = true
-			// Purge content via RemoveFile's RETURNED PayloadID — empty when
-			// content must survive (surviving hard link / recycle to trash).
-			var removedPayloadID metadata.PayloadID
-			if removed != nil {
-				removedPayloadID = removed.PayloadID
-			}
-			h.purgeBlockStorePayload(ctx, openFile.MetadataHandle, removedPayloadID, name.Path, caller)
-		}
-	}
+	// Remove what the election resolved — for a stream handle carrying a
+	// base-file delete that is the base file, not the stream's own name —
+	// through the shared helper CLOSE also uses, so the cascade to stream
+	// siblings and the payload purge cannot drift between the two paths.
+	// See doc_election.go.
+	_, err := h.removeElectedTarget(ctx, authCtx, openFile, target, caller)
 
-	if deleted {
+	if err == nil {
 		// No SMBHandlerContext available on the TDIS/LOGOFF/disconnect
 		// teardown path — pass nil so the helper falls back to inline
 		// dispatch (those paths don't ship a triggering response on the

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -1660,8 +1660,16 @@ func (h *Handler) handleDeleteOnClose(ctx context.Context, sess *session.Session
 	authCtx := h.buildCleanupAuthContext(ctx, sess)
 	// Thread the closing handle's RqLs ParentLeaseKey so notifyDirChange can
 	// apply the MS-SMB2 §3.3.4.20 / Samba `dirlease_should_break` parent-key
-	// suppression rule on the parent dir lease.
-	PropagateOpenFileParentLeaseKey(authCtx, openFile)
+	// suppression rule on the parent dir lease. Suppression applies only when
+	// the closer's key matches the key whoever committed the delete-on-close
+	// recorded; when they differ every parent dir lease breaks. Same rule the
+	// explicit CLOSE path applies (close.go step 8).
+	docSetterKeysDiffer := target.HasDocSetterParentKey &&
+		openFile.HasParentLeaseKey &&
+		target.DocSetterParentKey != openFile.ParentLeaseKey
+	if !docSetterKeysDiffer {
+		PropagateOpenFileParentLeaseKey(authCtx, openFile)
+	}
 	metaSvc := h.Registry.GetMetadataService()
 
 	if h.LeaseManager != nil && len(openFile.MetadataHandle) > 0 {

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -926,6 +926,16 @@ func (f *OpenFile) SetPayloadID(id metadata.PayloadID) {
 	f.PayloadID = id
 }
 
+// IsDeletePending returns the committed delete-on-close flag under the read
+// lock. SET_INFO and the CLOSE delete-on-close election write it under the
+// write lock, from goroutines other than the handle's own, so every read
+// outside those critical sections goes through here.
+func (f *OpenFile) IsDeletePending() bool {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.DeletePending
+}
+
 // IsMtimeFrozen returns the MtimeFrozen flag under the read lock.
 func (f *OpenFile) IsMtimeFrozen() bool {
 	f.mu.RLock()
@@ -2607,7 +2617,7 @@ func logRenameConflictHolder(gate string, renamer, holder *OpenFile) {
 		"holderShareAccess", fmt.Sprintf("0x%x", holder.ShareAccess),
 		"holderDesiredAccess", fmt.Sprintf("0x%x", holder.DesiredAccess),
 		"holderIsDurable", holder.IsDurable,
-		"holderDeletePending", holder.DeletePending)
+		"holderDeletePending", holder.IsDeletePending())
 }
 
 // checkParentDirRenameConflict applies the destination-parent share-mode rule

--- a/internal/adapter/smb/handlers/query_info.go
+++ b/internal/adapter/smb/handlers/query_info.go
@@ -685,7 +685,7 @@ func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *me
 		// field — smbtorture `smb2.setinfo` (setinfo.c:228) asserts that
 		// querying STANDARD / ALL_INFORMATION after setting delete disposition
 		// surfaces delete_pending = 1.
-		standardInfo := FileAttrToFileStandardInfo(&file.FileAttr, openFile.DeletePending)
+		standardInfo := FileAttrToFileStandardInfo(&file.FileAttr, openFile.IsDeletePending())
 		standardInfo.AllocationSize = effectiveAllocationSize(standardInfo.EndOfFile, openFile.RequestedAllocSize)
 		return EncodeFileStandardInfo(standardInfo), nil
 
@@ -915,7 +915,7 @@ func (h *Handler) buildFileAllInformationFromStore(authCtx *metadata.AuthContext
 	// One snapshot: this response carries both the path and the file name.
 	name := openFile.Name()
 	basicInfo := FileAttrToFileBasicInfoWithName(attr, basenameForHidden(openFile))
-	standardInfo := FileAttrToFileStandardInfo(&file.FileAttr, openFile.DeletePending)
+	standardInfo := FileAttrToFileStandardInfo(&file.FileAttr, openFile.IsDeletePending())
 	standardInfo.AllocationSize = effectiveAllocationSize(standardInfo.EndOfFile, openFile.RequestedAllocSize)
 	nameBytes := encodeUTF16LE(toSMBPath(name.Path))
 

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -765,8 +765,12 @@ func (h *Handler) setFileInfoFromStore(
 			// Restore mtime/ctime after rename
 			restoreTimestamps()
 
-			// Clear delete-on-close after rename
+			// Clear delete-on-close after rename. Written under the handle
+			// lock: the delete-pending gates and the CLOSE delete-on-close
+			// election read this field under it.
+			openFile.mu.Lock()
 			openFile.DeletePending = false
+			openFile.mu.Unlock()
 
 			// Notify watchers
 			if h.NotifyRegistry != nil {
@@ -1181,8 +1185,11 @@ func (h *Handler) setFileInfoFromStore(
 		// Per MS-FSA 2.1.5.14.10: On successful completion of a rename,
 		// if the file was marked for delete-on-close, clear that disposition.
 		// This prevents the renamed file from being deleted when the handle closes.
-		if openFile.DeletePending {
-			openFile.DeletePending = false
+		openFile.mu.Lock()
+		clearedDOC := openFile.DeletePending
+		openFile.DeletePending = false
+		openFile.mu.Unlock()
+		if clearedDOC {
 			logger.Debug("SET_INFO: cleared delete-on-close after rename",
 				"oldPath", oldPath,
 				"newPath", newPath)
@@ -1273,7 +1280,9 @@ func (h *Handler) setFileInfoFromStore(
 
 		// Capture pre-state to suppress redundant break dispatches when the
 		// disposition is reaffirmed (deletePending stays true).
+		openFile.mu.RLock()
 		wasDeletePending := openFile.DeletePending
+		openFile.mu.RUnlock()
 
 		// Validate we have parent info for deletion
 		if delName := openFile.Name(); deletePending && len(delName.ParentHandle) == 0 {
@@ -1329,12 +1338,16 @@ func (h *Handler) setFileInfoFromStore(
 		}
 
 		// Mark file for deletion on close and record the DOC setter's
-		// parent key for unlink parent-key suppression.
+		// parent key for unlink parent-key suppression. Written under the
+		// handle lock: the delete-pending gates and the CLOSE delete-on-close
+		// election read these fields under it.
+		openFile.mu.Lock()
 		openFile.DeletePending = deletePending
 		if deletePending {
 			openFile.DeleteOnCloseParentKey = openFile.ParentLeaseKey
 			openFile.HasDeleteOnCloseParentKey = openFile.HasParentLeaseKey
 		}
+		openFile.mu.Unlock()
 		h.StoreOpenFile(openFile)
 
 		logger.Debug("SET_INFO: delete disposition set",

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -5,6 +5,16 @@ Last updated: 2026-06-02 (#749 — parked durable CREATE now finalizes the momen
 Tests listed here are expected to fail and will NOT cause CI to report failure.
 Only NEW failures (not in this list) will cause CI to fail.
 
+**Reading a single-`--filter` run:** the names below carry the sub-suite prefix
+(`smb2.durable-open.delete_on_close2`) that `run.sh` adds from its `SUITES`
+"suite:prefix" table. A `run.sh --filter smb2.<suite>` invocation runs the suite
+in one shot without that fixup, so smbtorture reports the bare test name
+(`smb2.delete_on_close2`), it matches nothing here, and a permanently-expected
+failure is graded **new**. Cross-check any "new failure" from a single-filter run
+against this file by test name before treating it as a regression. Single-filter
+mode also skips the per-test `reset_share`, and does not step over the tests the
+full run avoids for client-side crashes (`smb2.dirlease.oplocks`, `scan.scan`).
+
 ## Final Tally (#673 v1.0 conformance gate)
 
 Every remaining entry is justified and falls into exactly one bucket. No


### PR DESCRIPTION
## What this PR contains, and where each part came from

Four things, under one issue number. Only the first is what #2126 asked for; each
of the others is created by the one before it, which is why they are one PR rather
than a stack where the first is knowingly broken.

1. **The atomic last-handle election** — the issue. Though the interleaving the
   issue describes is unreachable and the real defect is a different one; see
   *Premise check*.
2. **The durable-persist ordering** — found in review. It is *created by* (1): the
   deliberate MS-FSA correction to the teardown means a committed delete-on-close
   can now be deferred, and the durable-persist branch left the table without ever
   participating in the election, so a deferral could land on a handle nothing
   would read again.
3. **Locking `DeletePending` and the DOC-setter parent key** — races that (1) makes
   decision-critical, one of which CI's race detector caught.
4. **Converging the two delete paths** — a divergence (1) surfaced and my own fix
   for a Copilot finding then stepped on. It broke `smb2.streams.zero-byte`; the
   mechanism and its arithmetic are below.

## What was wrong

SMB CLOSE decided *"am I the last handle on this file?"* by scanning the open-file
table (step 8, `close.go`) and removed itself from that table roughly three hundred
lines and several I/O-bearing steps later (step 10). The two are not atomic, so two
closers of the same file can both scan before either removes itself: each sees the
other as a surviving handle, each propagates the delete-on-close to the other and
defers, and nobody unlinks. Both clients get `STATUS_SUCCESS` and the file stays on
disk.

`closeFilesWithFilter` — the LOGOFF / tree-disconnect / transport-drop path — has the
same split: it decides in its first pass and removes in its third.

## Premise check

The issue's interleaving table is a code-read argument, so it was tested first.

**Confirmed for `close.go`.** `TestClose_ConcurrentLastHandles_StillUnlink` drives two
concurrent CLOSEs of the only two handles on a file, both carrying
`FILE_DELETE_ON_CLOSE`, and fails deterministically on `develop`: the file survives.
The interleaving is forced rather than raced — both closers park on `renameScanMu`,
which every table removal takes, so both decisions provably precede both removals.

**Refuted as stated for `closeFilesWithFilter`.** The symmetric two-teardown
interleaving the issue sketches does *not* lose the unlink. That path re-reads
`openFile.DeletePending` at its delete gate, *after* the sibling scan, so whichever
teardown propagates second still observes the flag the first one wrote — and the two
orderings that would let both skip are mutually exclusive.

What the teardown path does lose is a delete deferred **to** it. A teardown handle
carrying no delete-on-close of its own makes its decision in pass 1 and leaves the
open-file table only in pass 3; a closer that scans in that window sees it as a live
sibling, hands it the delete-on-close, and it departs without honouring it.
`TestCloseFilesWithFilter_TeardownSiblingLeaving_StillUnlink` covers that, and also
fails deterministically on `develop`.

So the path the issue names is broken, but by a mechanism one step wider than the one
it describes — which is why the fix marks *every* closing handle, not only the ones
carrying a delete-on-close.

## The fix

A shared `electDeleteOnClose` primitive (`doc_election.go`) that both paths route
through. Under one leaf mutex it:

1. marks the closing handle `docLeaving` — unconditionally, whether or not it carries
   a delete-on-close, because a handle past its own election can no longer honour one
   propagated to it;
2. promotes `InitialDeleteOnClose` to the shared `DeletePending`, and **reads**
   `DeletePending` inside the same critical section, so a closer that an earlier
   closer propagated to observes the flag and takes its turn;
3. scans for siblings and ADS stream handles, skipping any already marked;
4. either propagates the delete-on-close to the survivors, or returns
   `docDecisionDelete` to the caller.

Because the mark and the scan share one critical section, the closers of a file are
totally ordered by the mutex and only the last one in sees no survivor. There is no
interleaving in which two closers each see the other, and none in which two both elect
to delete.

Point 1 is what makes this cover the mechanism actually measured rather than only the
one the issue describes. The symmetric case is closed because two closers can no longer
both see the other; the asymmetric one — the case that really loses the unlink — is
closed because a handle with no delete-on-close of its own still marks itself, so
nobody hands it a delete it will not honour. A fix that marked only delete-on-close
handles would close the first and leave the second live, which is exactly the trap in
letting the issue's framing shape the fix.

The mark deliberately does **not** remove the handle from `h.files`. It stays visible
to the CREATE delete-pending gate, the share-mode and oplock scans and the rename
conflict re-scan until the caller's own removal step, so a CREATE arriving between the
election and the unlink still answers `STATUS_DELETE_PENDING` rather than opening a
file that is about to vanish.

`docElectionMu` is a leaf: the election takes only per-`OpenFile` locks under it and
does no I/O. CLOSE has released it before taking `renameScanMu` at step 10, and the
teardown takes it in pass 1, well before `renameScanMu` in pass 3.

## Deliberate behaviour change

`closeFilesWithFilter` previously deleted unconditionally when `DeletePending` was
already committed, with no sibling check at all. It now goes through the same election
and defers to a live sibling, which is what MS-FSA 2.1.5.4 requires and what
`close.go` already did. The per-handle initial-DOC case is unchanged in behaviour —
it already had a sibling check.

## Three ways a handle leaves the table, not two

Review turned up a third departure the first cut missed. The transport-drop path
persists an eligible durable handle for later reconnect and drops it from `h.files`
just as a full close does, but it returned before reaching the election — so a
concurrent closer saw it as a survivor and handed it a delete-on-close that nothing
would ever read again. That hole is *created* by the deliberate change above: on
`develop` a committed `DeletePending` deleted unconditionally, so there was no
deferral to lose.

The election now runs for every non-pipe handle ahead of the persist branch, and that
branch's delete-on-close gate is the election's own decision rather than a separate
unsynchronized read — so a DOC propagated a moment earlier refuses the persist instead
of burying it. `TestCloseFilesWithFilter_DurablePersistedSibling_StillUnlink` covers it
and fails without the reordering.

Review also caught the teardown unlinking the closing handle's own name rather than the
target the election resolved, which for a stream handle carrying a base-file delete
addressed the stream instead of the base file. `handleDeleteOnClose` now takes the
`docTarget`.

## Two delete paths that had already drifted

Threading the elected target into the teardown's unlink — Copilot's finding, and
right in general — silently changed the stream case. For a stream handle carrying
a base-file delete the teardown had been removing the *stream's own* entry; with
the target threaded through it removes the *base file*. Only `close.go` cascaded to
the base file's ADS streams, so the base entry went and its `name:stream` siblings
stayed behind as ordinary directory entries.

That is a real regression, caught by CI and reproduced locally with
`run.sh --filter smb2.streams` on this branch:

```
test: zero-byte
(../../source4/torture/smb2/streams.c:490) Check 0 byte named stream
(../../source4/torture/smb2/streams.c:147) expected 2 streams, got 4
failure: zero-byte [
../../source4/torture/smb2/streams.c:531: Expression `ret == (1)' failed: smb2_create
]
```

The arithmetic: `smb2.streams.delete` runs immediately before `zero-byte` and is the
base-file-DOC-deferred-to-open-stream-handles case. It still passes — it asserts the
base file is gone, and it is. What it leaves behind are its two stream siblings, so
`zero-byte`'s enumeration counts its own 2 plus those 2 orphans — 4. The same run has
13 of 14 passing, `delete` and `basefile-rename-with-open-stream` among them, and
`develop`'s own full conformance run on the same base is green on both profiles, so
the regression is this branch's.

The fix is not a second cascade. Having two call sites is what let the cascade and
the payload purge drift apart in the first place, so both paths now remove the
elected entry through `removeElectedTarget`, which owns the removal and everything
that must accompany it — the ADS cascade, the payload purge, the parent's frozen
timestamps. Two things stay with the callers because they differ by close path
rather than by what was removed: the lease-break policy (CLOSE relies on the
removal's own dir-change notification and deliberately does not dispatch a second
break; the teardown breaks the file's Handle leases before and the parent's after),
and the SMB CHANGE_NOTIFY event, which CLOSE emits and the teardown never has —
starting to emit one there is a change to that registry's traffic, not to this
removal, so it is left alone.

`close.go`'s own behaviour survives the convergence: the delete error still maps to
the CLOSE response status (and still yields to a recorded flush failure), and the
`PostSend`-deferred dir-lease break is untouched — it lives in step 8b, which this
does not go near. The step 8 delete block never dispatched a deferred break at all,
by design.

## Also fixed, on the same field

`SET_INFO` wrote `DeletePending` without holding `OpenFile.mu`, while every reader —
`isFileDeletePending`, `isFileOrBaseDeletePending` — reads it under that lock. The
election's decision now turns on that read, so the three write sites are locked.

## Verification

- All three regression tests fail without the fix and pass with it, deterministically,
  repeated.
- `TestElectDeleteOnClose_LastEntrantWins` pins the ordering contract on the primitive
  itself, and `TestCloseFilesWithFilter_BaseFileDeleteCascadesStreams` pins the
  cascade on the teardown path (it fails without the shared removal).
- `go build ./... && go vet ./...`, full `go test ./...`, and `go test -race` over the
  SMB adapter trees are green.
- smbtorture, memory profile, on the families this touches:
  - `smb2.streams` — 14/14, including `streams.delete` and
    `basefile-rename-with-open-stream`, which exercise the ADS / base-file
    delete-deferral branches the election absorbed.
  - `smb2.durable-open` — 23/24. The one failure is `delete_on_close2`, the documented
    permanent known failure that Samba's own selftest skips; it is reported as "new"
    only because single-filter mode drops the `durable-open.` prefix the
    `KNOWN_FAILURES.md` pattern matches on. `delete_on_close1` passes.
  - `smb2.dirlease` — `v2_request_parent` and `v2_request` pass; `v2_request` is the
    parked-dir-CREATE / CLOSE-ordering case that step 8/10/11 restructuring would break
    first. The rest of the suite is inconclusive: `dirlease.oplocks` SIGSEGVs the
    smbtorture 4.22.6 *client* and aborts the suite, which `KNOWN_FAILURES.md` already
    records as a client bug (the CI job runs dirlease per-subtest and steps over it;
    a single `--filter` invocation does not).

Closes #2126
