### PR TITLE
fix(nfs4): key v4.1 open- and lock-owners by the session's client

### DIFF
--- a/internal/adapter/nfs/v4/handlers/compound.go
+++ b/internal/adapter/nfs/v4/handlers/compound.go
@@ -479,6 +479,9 @@ func (h *Handler) dispatchV41(compCtx *types.CompoundContext, tag []byte, numOps
 
 	// SEQUENCE succeeded -- set v4.1 bypass for per-owner seqid
 	compCtx.SkipOwnerSeqid = true
+	if sess != nil {
+		compCtx.SessionClientID = sess.ClientID
+	}
 
 	// Ensure slot is released and response is cached via defer
 	var responseBytes []byte

--- a/internal/adapter/nfs/v4/handlers/compound_test.go
+++ b/internal/adapter/nfs/v4/handlers/compound_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/pseudofs"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
 // buildCompoundArgs encodes a COMPOUND4args structure for testing.
@@ -794,6 +796,147 @@ func TestCompound_V41_EmptyCompound(t *testing.T) {
 	if string(decoded.Tag) != "v41-empty" {
 		t.Errorf("tag = %q, want %q", string(decoded.Tag), "v41-empty")
 	}
+}
+
+// TestCompoundV41_SessionClientIDKeysOwners drives OPEN, LOCK and LOCKT through
+// real v4.1 COMPOUNDs whose open_owner4 and lock_owner4 carry a clientid the
+// server must ignore (RFC 8881 Sections 18.16.3 and 18.10.3), to cover the
+// dispatch step that puts the session's client on the compound context. The
+// handler-level tests set that field themselves, so nothing there would notice
+// if SEQUENCE stopped supplying it.
+//
+// The owner opaque is one string throughout, so all three operations name the
+// same open- and lock-owner as long as each is keyed by the session's client.
+// The LOCKT then reports the lock as free -- a lock never conflicts with its own
+// owner -- whereas an owner split across two client identities makes it a
+// conflict and answers NFS4ERR_DENIED.
+func TestCompoundV41_SessionClientIDKeysOwners(t *testing.T) {
+	const (
+		filename  = "v41-owner-keying.txt"
+		lockStart = 0
+		lockLen   = 128
+	)
+	owner := []byte("session-keyed-owner")
+
+	fx := newIOTestFixture(t, "/export")
+	// Byte-range conflicts are only detected when a lock manager is present;
+	// without one LOCKT reports every range as free and proves nothing.
+	fx.handler.StateManager.SetLockManager(lock.NewManager())
+	sessionID := createSessionOn(t, fx.handler, "v41-owner-keying-client")
+
+	// SEQUENCE + OPEN, with open_owner4.clientid = 0 -- the value a conforming
+	// v4.1 client is free to send.
+	openArgs := encodeOpenArgs(
+		0, types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE,
+		0, owner,
+		types.OPEN4_CREATE, types.UNCHECKED4, types.CLAIM_NULL, filename,
+	)
+	resp := processV41Compound(t, fx.handler, "open", fx.rootHandle, []compoundOp{
+		{opCode: types.OP_SEQUENCE, data: encodeSequenceArgs(sessionID, 0, 1, 0, false)},
+		{opCode: types.OP_OPEN, data: openArgs},
+	})
+	reader := skipToLastResult(t, resp, 2, types.OP_OPEN)
+	openStateid, err := types.DecodeStateid4(reader)
+	if err != nil {
+		t.Fatalf("decode OPEN stateid: %v", err)
+	}
+
+	file, err := fx.metaSvc.Lookup(newTestAuthCtx(0, 0), fx.rootHandle, filename)
+	if err != nil {
+		t.Fatalf("lookup %s: %v", filename, err)
+	}
+	fileHandle, err := metadata.EncodeFileHandle(file)
+	if err != nil {
+		t.Fatalf("encode handle: %v", err)
+	}
+
+	// SEQUENCE + LOCK, lock_owner4.clientid = 0 as well. Both seqids are zero
+	// because v4.1 ignores them.
+	lockArgs := encodeNewLockOwnerArgs(types.WRITE_LT, lockStart, lockLen, 0, openStateid, 0, 0, owner)
+
+	resp = processV41Compound(t, fx.handler, "lock", fileHandle, []compoundOp{
+		{opCode: types.OP_SEQUENCE, data: encodeSequenceArgs(sessionID, 0, 2, 0, false)},
+		{opCode: types.OP_LOCK, data: lockArgs},
+	})
+	skipToLastResult(t, resp, 2, types.OP_LOCK)
+
+	// SEQUENCE + LOCKT for the same range and owner, this time with a stale
+	// non-zero clientid on the wire.
+	locktArgs := encodeLocktArgs(types.WRITE_LT, lockStart, lockLen, 0xDEADBEEF, owner)
+
+	resp = processV41Compound(t, fx.handler, "lockt", fileHandle, []compoundOp{
+		{opCode: types.OP_SEQUENCE, data: encodeSequenceArgs(sessionID, 0, 3, 0, false)},
+		{opCode: types.OP_LOCKT, data: locktArgs},
+	})
+	skipToLastResult(t, resp, 2, types.OP_LOCKT)
+}
+
+// processV41Compound runs a v4.1 COMPOUND against currentFH and fails the test
+// unless the overall status is NFS4_OK, which for a SEQUENCE-led compound means
+// every operation in it succeeded. The filehandle is seeded rather than reached
+// by a PUTFH op because the fixture's share is registered disabled, which PUTFH
+// answers with NFS4ERR_STALE.
+func processV41Compound(t *testing.T, h *Handler, tag string, currentFH metadata.FileHandle, ops []compoundOp) []byte {
+	t.Helper()
+
+	ctx := newTestCompoundContext()
+	ctx.CurrentFH = make([]byte, len(currentFH))
+	copy(ctx.CurrentFH, currentFH)
+
+	resp, err := h.ProcessCompound(ctx, buildCompoundArgsWithOps([]byte(tag), 1, ops))
+	if err != nil {
+		t.Fatalf("%s COMPOUND error: %v", tag, err)
+	}
+	if status, _ := xdr.DecodeUint32(bytes.NewReader(resp)); status != types.NFS4_OK {
+		t.Fatalf("%s COMPOUND status = %d, want NFS4_OK", tag, status)
+	}
+	return resp
+}
+
+// skipToLastResult walks a COMPOUND response past its leading SEQUENCE and
+// PUTFH results and returns a reader positioned just after the last result's
+// status, ready for that operation's own reply body.
+func skipToLastResult(t *testing.T, resp []byte, numOps int, lastOp uint32) *bytes.Reader {
+	t.Helper()
+
+	reader := bytes.NewReader(resp)
+	_, _ = xdr.DecodeUint32(reader) // overall status
+	_, _ = xdr.DecodeOpaque(reader) // tag
+	numResults, _ := xdr.DecodeUint32(reader)
+	if int(numResults) != numOps {
+		t.Fatalf("numResults = %d, want %d", numResults, numOps)
+	}
+
+	for i := 0; i < numOps; i++ {
+		opCode, _ := xdr.DecodeUint32(reader)
+
+		if i == numOps-1 {
+			if opCode != lastOp {
+				t.Fatalf("last result op = %s, want %s", types.OpName(opCode), types.OpName(lastOp))
+			}
+			if status, _ := xdr.DecodeUint32(reader); status != types.NFS4_OK {
+				t.Fatalf("%s status = %d, want NFS4_OK", types.OpName(opCode), status)
+			}
+			return reader
+		}
+
+		// SEQUENCE carries a reply body after its status; every other leading
+		// operation here (PUTFH) is status-only.
+		if opCode == types.OP_SEQUENCE {
+			var seqRes types.SequenceRes
+			if err := seqRes.Decode(reader); err != nil {
+				t.Fatalf("decode SequenceRes: %v", err)
+			}
+			if seqRes.Status != types.NFS4_OK {
+				t.Fatalf("SEQUENCE status = %d, want NFS4_OK", seqRes.Status)
+			}
+			continue
+		}
+		if status, _ := xdr.DecodeUint32(reader); status != types.NFS4_OK {
+			t.Fatalf("%s status = %d, want NFS4_OK", types.OpName(opCode), status)
+		}
+	}
+	return reader
 }
 
 // ============================================================================

--- a/internal/adapter/nfs/v4/handlers/io_test.go
+++ b/internal/adapter/nfs/v4/handlers/io_test.go
@@ -665,6 +665,82 @@ func TestOpen_UnknownClientID_ReturnsStaleClientID(t *testing.T) {
 	}
 }
 
+// openOther runs one OPEN of filename with the given wire clientid and returns
+// the "other" field of the stateid it produced. Two OPENs by the same
+// open-owner on the same file share one open state, so an unchanged "other"
+// across two calls means both were keyed under the same client.
+func openOther(t *testing.T, fx *ioTestFixture, ctx *types.CompoundContext, wireClientID uint64, filename string) [12]byte {
+	t.Helper()
+
+	setCurrentFH(ctx, fx.rootHandle)
+
+	args := encodeOpenArgs(
+		0,
+		types.OPEN4_SHARE_ACCESS_BOTH,
+		types.OPEN4_SHARE_DENY_NONE,
+		wireClientID,
+		[]byte("shared-owner"),
+		types.OPEN4_CREATE,
+		types.UNCHECKED4,
+		types.CLAIM_NULL,
+		filename,
+	)
+
+	result := fx.handler.handleOpen(ctx, bytes.NewReader(args))
+	if result.Status != types.NFS4_OK {
+		t.Fatalf("OPEN status = %d, want NFS4_OK", result.Status)
+	}
+
+	reader := bytes.NewReader(result.Data)
+	if status, _ := xdr.DecodeUint32(reader); status != types.NFS4_OK {
+		t.Fatalf("encoded OPEN status = %d, want NFS4_OK", status)
+	}
+	stateid, err := types.DecodeStateid4(reader)
+	if err != nil {
+		t.Fatalf("decode stateid: %v", err)
+	}
+	return stateid.Other
+}
+
+// TestOpen_SessionClientIDOutranksWireClientID checks that a v4.1 OPEN keys its
+// open-owner by the session's client rather than by open_owner4.clientid, which
+// RFC 8881 Section 18.16.3 declares ignored for v4.1 and which a conforming
+// client may therefore send as zero or stale.
+func TestOpen_SessionClientIDOutranksWireClientID(t *testing.T) {
+	t.Run("v41_session_client_wins", func(t *testing.T) {
+		fx := newIOTestFixture(t, "/export")
+
+		ctx := newRealFSContext(0, 0)
+		ctx.SkipOwnerSeqid = true // as the v4.1 dispatch path sets after SEQUENCE
+		ctx.SessionClientID = testClientID(t, fx.handler.StateManager, "v41-session-client")
+
+		// Same owner, same file, two unrelated wire clientids: the zero a
+		// conforming client is free to send, and a stale non-zero one.
+		first := openOther(t, fx, ctx, 0, "v41.txt")
+		second := openOther(t, fx, ctx, 0xDEADBEEF, "v41.txt")
+
+		if first != second {
+			t.Errorf("stateid other changed between OPENs (%x -> %x): the wire "+
+				"clientid split one client's state across two open-owners",
+				first, second)
+		}
+	})
+
+	t.Run("v40_wire_client_still_used", func(t *testing.T) {
+		fx := newIOTestFixture(t, "/export")
+
+		ctx := newRealFSContext(0, 0)
+		ctx.SkipOwnerSeqid = true // keep seqid out of it; v4.0 leaves SessionClientID zero
+
+		first := openOther(t, fx, ctx, testClientID(t, fx.handler.StateManager, "v40-client-a"), "v40.txt")
+		second := openOther(t, fx, ctx, testClientID(t, fx.handler.StateManager, "v40-client-b"), "v40.txt")
+
+		if first == second {
+			t.Error("distinct v4.0 clientids collapsed onto one open-owner")
+		}
+	})
+}
+
 // ============================================================================
 // OPEN_CONFIRM Tests
 // ============================================================================

--- a/internal/adapter/nfs/v4/handlers/lock.go
+++ b/internal/adapter/nfs/v4/handlers/lock.go
@@ -131,6 +131,7 @@ func (h *Handler) handleLock(ctx *types.CompoundContext, reader io.Reader) *type
 				Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
 			}
 		}
+		lockOwnerClientID = ctx.EffectiveClientID(lockOwnerClientID)
 
 		lockOwnerData, decErr := xdr.DecodeOpaque(reader)
 		if decErr != nil {
@@ -312,6 +313,7 @@ func (h *Handler) handleLockT(ctx *types.CompoundContext, reader io.Reader) *typ
 			Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
 		}
 	}
+	clientID = ctx.EffectiveClientID(clientID)
 
 	ownerData, err := xdr.DecodeOpaque(reader)
 	if err != nil {

--- a/internal/adapter/nfs/v4/handlers/lock_test.go
+++ b/internal/adapter/nfs/v4/handlers/lock_test.go
@@ -13,6 +13,49 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
+// encodeNewLockOwnerArgs encodes LOCK4args for the new_lock_owner = true case,
+// where the lock-owner is established from an open stateid
+// (open_to_lock_owner4). The seqids are ignored under v4.1.
+func encodeNewLockOwnerArgs(
+	lockType uint32,
+	offset, length uint64,
+	openSeqid uint32,
+	openStateid *types.Stateid4,
+	lockSeqid uint32,
+	clientID uint64,
+	owner []byte,
+) []byte {
+	var buf bytes.Buffer
+
+	_ = xdr.WriteUint32(&buf, lockType)
+	_ = xdr.WriteUint32(&buf, 0) // reclaim = false
+	_ = xdr.WriteUint64(&buf, offset)
+	_ = xdr.WriteUint64(&buf, length)
+	_ = xdr.WriteUint32(&buf, 1) // new_lock_owner = true
+	// open_to_lock_owner4: open_seqid + open_stateid + lock_seqid + lock_owner4
+	_ = xdr.WriteUint32(&buf, openSeqid)
+	types.EncodeStateid4(&buf, openStateid)
+	_ = xdr.WriteUint32(&buf, lockSeqid)
+	_ = xdr.WriteUint64(&buf, clientID)
+	_ = xdr.WriteXDROpaque(&buf, owner)
+
+	return buf.Bytes()
+}
+
+// encodeLocktArgs encodes LOCKT4args.
+func encodeLocktArgs(lockType uint32, offset, length uint64, clientID uint64, owner []byte) []byte {
+	var buf bytes.Buffer
+
+	_ = xdr.WriteUint32(&buf, lockType)
+	_ = xdr.WriteUint64(&buf, offset)
+	_ = xdr.WriteUint64(&buf, length)
+	// lock_owner4: clientid + owner
+	_ = xdr.WriteUint64(&buf, clientID)
+	_ = xdr.WriteXDROpaque(&buf, owner)
+
+	return buf.Bytes()
+}
+
 // ============================================================================
 // LOCK Handler Tests
 // ============================================================================

--- a/internal/adapter/nfs/v4/handlers/open.go
+++ b/internal/adapter/nfs/v4/handlers/open.go
@@ -100,6 +100,7 @@ func (h *Handler) handleOpen(ctx *types.CompoundContext, reader io.Reader) *type
 	if err != nil {
 		return openError(types.NFS4ERR_BADXDR)
 	}
+	clientID = ctx.EffectiveClientID(clientID)
 	ownerData, err := xdr.DecodeOpaque(reader)
 	if err != nil {
 		return openError(types.NFS4ERR_BADXDR)

--- a/internal/adapter/nfs/v4/handlers/sequence_handler_test.go
+++ b/internal/adapter/nfs/v4/handlers/sequence_handler_test.go
@@ -29,7 +29,15 @@ func encodeSequenceArgs(sessionID types.SessionId4, slotID, seqID, highestSlotID
 func createTestSession(t *testing.T) (*Handler, types.SessionId4) {
 	t.Helper()
 	h := newTestHandler()
-	clientID, seqID := registerExchangeID(t, h, "seq-test-client")
+	return h, createSessionOn(t, h, "seq-test-client")
+}
+
+// createSessionOn performs EXCHANGE_ID + CREATE_SESSION on an existing handler,
+// for tests whose handler is built around a real share rather than by
+// newTestHandler.
+func createSessionOn(t *testing.T, h *Handler, ownerID string) types.SessionId4 {
+	t.Helper()
+	clientID, seqID := registerExchangeID(t, h, ownerID)
 
 	ctx := newTestCompoundContext()
 	secParms := []types.CallbackSecParms4{{CbSecFlavor: 0}} // AUTH_NONE
@@ -59,7 +67,7 @@ func createTestSession(t *testing.T) (*Handler, types.SessionId4) {
 		t.Fatalf("CREATE_SESSION status = %d, want NFS4_OK", csRes.Status)
 	}
 
-	return h, csRes.SessionID
+	return csRes.SessionID
 }
 
 // decodeSequenceRes decodes SEQUENCE4res from a COMPOUND response that has

--- a/internal/adapter/nfs/v4/types/types.go
+++ b/internal/adapter/nfs/v4/types/types.go
@@ -125,6 +125,11 @@ type CompoundContext struct {
 	// making per-owner seqid redundant.
 	SkipOwnerSeqid bool
 
+	// SessionClientID is the client ID owning the session a v4.1 COMPOUND ran
+	// SEQUENCE on. Zero in v4.0 compounds and before SEQUENCE succeeds.
+	// EffectiveClientID reads it; see there for why it outranks the wire value.
+	SessionClientID uint64
+
 	// ConnectionID is the unique identifier for the TCP connection, assigned
 	// at accept() time and threaded through dispatch. Used by
 	// BIND_CONN_TO_SESSION and connection draining checks.
@@ -151,6 +156,23 @@ type CompoundContext struct {
 	// NFS4ERR_MINOR_VERS_MISMATCH -- that last case returns a well-formed reply
 	// and a nil error, so the error alone cannot be used to tell them apart.
 	MinorVersionAccepted bool
+}
+
+// EffectiveClientID returns the client ID an open-owner or lock-owner should be
+// keyed under, given the clientid decoded from the owner's wire representation.
+//
+// In v4.1 the session identifies the client, and the clientid field of
+// open_owner4 and lock_owner4 is ignored (RFC 8881 Sections 18.16.3 and
+// 18.10.3): a conforming client may send zero or a stale value there. Keying
+// owners by it would scatter one client's state across identities that no
+// client record covers and no lease reaps. The session's client is authoritative
+// whenever there is one; in v4.0 the wire value is the only identity a request
+// carries.
+func (c *CompoundContext) EffectiveClientID(wireClientID uint64) uint64 {
+	if c.SessionClientID != 0 {
+		return c.SessionClientID
+	}
+	return wireClientID
 }
 
 // Principal returns a string identity for the authenticated caller: "uid:N" for


### PR DESCRIPTION
# Description

## Type of change

Fixes: https://github.com/marmos91/dittofs/issues/2095

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)


## Changes Made

Use the session's client ID in NFS v4.1.

## Testing

- [X] Unit tests pass (`go test ./...`)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published