### PR TITLE
fix(smb): scope a lease's epoch and state to its own file, not the lease key

### DIFF
--- a/internal/adapter/smb/handlers/create.go
+++ b/internal/adapter/smb/handlers/create.go
@@ -947,7 +947,7 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 						// subsequent break notifications carry the correct
 						// NewEpoch rather than the re-registration's reset value.
 						if reportedLeaseEpoch != epoch {
-							h.LeaseManager.SetLeaseEpoch(tree.ShareName, restored.LeaseKey, reportedLeaseEpoch)
+							h.LeaseManager.SetLeaseEpoch(lockFileHandle, tree.ShareName, restored.LeaseKey, reportedLeaseEpoch)
 						}
 						// Build lease response context
 						if leaseCtx := FindCreateContext(req.CreateContexts, LeaseContextTagRequest); leaseCtx != nil {
@@ -1703,7 +1703,7 @@ func (h *Handler) refreshReplayLease(ctx *SMBHandlerContext, req *CreateRequest,
 	if h.LeaseManager == nil {
 		return types.StatusSuccess
 	}
-	state, epoch, found := h.LeaseManager.GetLeaseState(ctx.Context, open.ShareName, open.LeaseKey)
+	state, epoch, found := h.LeaseManager.GetLeaseState(ctx.Context, lock.FileHandle(open.MetadataHandle), open.ShareName, open.LeaseKey)
 	if !found {
 		return types.StatusSuccess
 	}

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -1416,7 +1416,7 @@ func (h *Handler) closeFilesWithFilter(
 			var leaseState uint32
 			var leaseEpoch uint16
 			if h.LeaseManager != nil && openFile.LeaseKey != ([16]byte{}) {
-				if state, epoch, found := h.LeaseManager.GetLeaseState(ctx, openFile.ShareName, openFile.LeaseKey); found {
+				if state, epoch, found := h.LeaseManager.GetLeaseState(ctx, lock.FileHandle(openFile.MetadataHandle), openFile.ShareName, openFile.LeaseKey); found {
 					leaseState = state
 					leaseEpoch = epoch
 				}

--- a/internal/adapter/smb/handlers/lease_context.go
+++ b/internal/adapter/smb/handlers/lease_context.go
@@ -532,7 +532,7 @@ func ProcessLeaseCreateContext(
 			// starting point, one past what it asked for.
 			nextEpoch := leaseReq.Epoch + 1
 			if nextEpoch > epoch {
-				leaseMgr.SetLeaseEpoch(shareName, leaseReq.LeaseKey, nextEpoch)
+				leaseMgr.SetLeaseEpoch(fileHandle, shareName, leaseReq.LeaseKey, nextEpoch)
 				epoch = nextEpoch
 			}
 		}

--- a/internal/adapter/smb/handlers/lease_context_test.go
+++ b/internal/adapter/smb/handlers/lease_context_test.go
@@ -402,7 +402,7 @@ func TestProcessLeaseCreateContext_NoneProbeDoesNotAdvanceEpoch(t *testing.T) {
 	}
 
 	// Server-side tracking should also remain unchanged.
-	_, persistedEpoch, found := mgr.GetLeaseState(ctx, leaseKey)
+	_, persistedEpoch, found := mgr.GetLeaseState(ctx, string(fileHandle), leaseKey)
 	if !found {
 		t.Fatal("lease record disappeared after None-probe")
 	}
@@ -459,7 +459,7 @@ func TestProcessLeaseCreateContext_UnchangedStateDoesNotAdvanceEpoch(t *testing.
 		t.Errorf("re-open response epoch = 0x%x, want 0x%x — an unchanged lease state must not advance the epoch", resp2.Epoch, grantedEpoch)
 	}
 
-	_, persistedEpoch, found := mgr.GetLeaseState(ctx, leaseKey)
+	_, persistedEpoch, found := mgr.GetLeaseState(ctx, string(fileHandle), leaseKey)
 	if !found {
 		t.Fatal("lease record disappeared after re-open")
 	}

--- a/internal/adapter/smb/handlers/lease_epoch_identity_test.go
+++ b/internal/adapter/smb/handlers/lease_epoch_identity_test.go
@@ -1,0 +1,123 @@
+package handlers
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/lease"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// capturingNotifier records the LEASE_BREAK_NOTIFICATION values the break
+// dispatch path hands to the transport, including the NewEpoch that goes on
+// the wire.
+type capturingNotifier struct {
+	mu     sync.Mutex
+	breaks []capturedBreak
+}
+
+type capturedBreak struct {
+	SessionID    uint64
+	LeaseKey     [16]byte
+	CurrentState uint32
+	NewState     uint32
+	Epoch        uint16
+}
+
+func (n *capturingNotifier) SendLeaseBreak(sessionID uint64, leaseKey [16]byte, currentState, newState uint32, epoch uint16) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.breaks = append(n.breaks, capturedBreak{
+		SessionID:    sessionID,
+		LeaseKey:     leaseKey,
+		CurrentState: currentState,
+		NewState:     newState,
+		Epoch:        epoch,
+	})
+	return nil
+}
+
+func (n *capturingNotifier) forSession(sessionID uint64) []capturedBreak {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	var out []capturedBreak
+	for _, b := range n.breaks {
+		if b.SessionID == sessionID {
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+// TestLeaseBreakNewEpoch_OtherClientSameKeyDoesNotSeedIt drives two V2 lease
+// clients through the real grant path and reads the NewEpoch the break
+// notification for the first one actually carries.
+//
+// Two clients may present the same 16-byte lease key value on different files
+// of one share: the uniqueness rule is per-(client, file), so the value alone
+// is not an identity. Each grant seeds the server's epoch counter from the
+// epoch that client asked for. A client's break notification must therefore
+// carry an epoch that follows from its own grants — a NewEpoch derived from
+// another client's counter is one the receiving client can trace to no request
+// of its own.
+func TestLeaseBreakNewEpoch_OtherClientSameKeyDoesNotSeedIt(t *testing.T) {
+	t.Parallel()
+
+	mgr := lock.NewManager()
+	notifier := &capturingNotifier{}
+	leaseMgr := lease.NewLeaseManager(&staticLockResolver{mgr: mgr}, notifier)
+	mgr.RegisterBreakCallbacks(lease.NewSMBBreakHandler(leaseMgr, notifier))
+
+	ctx := context.Background()
+	const shareName = "share1"
+	leaseKey := [16]byte{0xDE, 0xAD, 0xBE, 0xEF}
+	const rh = lock.LeaseStateRead | lock.LeaseStateHandle
+	const epochA uint16 = 0x0100
+	const epochB uint16 = 0x7000
+
+	respA, err := ProcessLeaseCreateContext(ctx, leaseMgr, encodeV2LeaseContext(leaseKey, rh, epochA),
+		lock.FileHandle("file-A"), 1, [16]byte{0xA1}, "smb:1", shareName, false, false, false)
+	if err != nil {
+		t.Fatalf("client A CREATE: %v", err)
+	}
+	if respA.Epoch != epochA+1 {
+		t.Fatalf("client A response epoch = 0x%x, want 0x%x", respA.Epoch, epochA+1)
+	}
+
+	// Client B's first grant on a different file seeds its own counter well
+	// above A's.
+	respB, err := ProcessLeaseCreateContext(ctx, leaseMgr, encodeV2LeaseContext(leaseKey, rh, epochB),
+		lock.FileHandle("file-B"), 2, [16]byte{0xB2}, "smb:2", shareName, false, false, false)
+	if err != nil {
+		t.Fatalf("client B CREATE: %v", err)
+	}
+	if respB.Epoch != epochB+1 {
+		t.Fatalf("client B response epoch = 0x%x, want 0x%x", respB.Epoch, epochB+1)
+	}
+
+	// A conflicting open on A's file breaks A's lease.
+	if err := mgr.BreakLeasesOnOpenConflict("file-A", &lock.LockOwner{ClientID: "smb:9"}, lock.BreakReasonDestructive); err != nil {
+		t.Fatalf("break client A's lease: %v", err)
+	}
+
+	sent := notifier.forSession(1)
+	if len(sent) != 1 {
+		t.Fatalf("client A received %d break notifications, want 1", len(sent))
+	}
+	// Per MS-SMB2 §3.3.4.7 the server sets NewEpoch = Epoch + 1 when it
+	// dispatches the break, where Epoch is the value this client last saw in
+	// its own RqLs response.
+	if want := respA.Epoch + 1; sent[0].Epoch != want {
+		t.Errorf("client A break NewEpoch = 0x%x, want 0x%x — the epoch came from client B's counter (B was granted 0x%x on another file under the same key value)",
+			sent[0].Epoch, want, respB.Epoch)
+	}
+
+	// Client B's lease is untouched by a break on another file.
+	if got := notifier.forSession(2); len(got) != 0 {
+		t.Errorf("client B received %d break notifications for a break on another client's file", len(got))
+	}
+	if _, epoch, found := leaseMgr.GetLeaseState(ctx, shareName, leaseKey); !found || epoch < respB.Epoch {
+		t.Errorf("client B lease epoch = 0x%x found=%v, want >= 0x%x", epoch, found, respB.Epoch)
+	}
+}

--- a/internal/adapter/smb/handlers/lease_epoch_identity_test.go
+++ b/internal/adapter/smb/handlers/lease_epoch_identity_test.go
@@ -74,7 +74,7 @@ func TestLeaseBreakNewEpoch_OtherClientSameKeyDoesNotSeedIt(t *testing.T) {
 	leaseKey := [16]byte{0xDE, 0xAD, 0xBE, 0xEF}
 	const rh = lock.LeaseStateRead | lock.LeaseStateHandle
 	const epochA uint16 = 0x0100
-	const epochB uint16 = 0x7000
+	const epochB uint16 = 0xF000
 
 	respA, err := ProcessLeaseCreateContext(ctx, leaseMgr, encodeV2LeaseContext(leaseKey, rh, epochA),
 		lock.FileHandle("file-A"), 1, [16]byte{0xA1}, "smb:1", shareName, false, false, false)
@@ -85,8 +85,12 @@ func TestLeaseBreakNewEpoch_OtherClientSameKeyDoesNotSeedIt(t *testing.T) {
 		t.Fatalf("client A response epoch = 0x%x, want 0x%x", respA.Epoch, epochA+1)
 	}
 
-	// Client B's first grant on a different file seeds its own counter well
-	// above A's.
+	// Client B's first grant on a different file seeds its own counter far
+	// above A's — far enough that folding it into A's lease would push A's
+	// NewEpoch more than 32767 past the epoch A last saw. Per MS-SMB2
+	// §3.2.5.19.2 step 7 a client adopts a break's new lease state only when
+	// the epoch gap is at most 32767, so beyond that it keeps caching under a
+	// lease the server has already broken.
 	respB, err := ProcessLeaseCreateContext(ctx, leaseMgr, encodeV2LeaseContext(leaseKey, rh, epochB),
 		lock.FileHandle("file-B"), 2, [16]byte{0xB2}, "smb:2", shareName, false, false, false)
 	if err != nil {

--- a/internal/adapter/smb/handlers/lease_epoch_identity_test.go
+++ b/internal/adapter/smb/handlers/lease_epoch_identity_test.go
@@ -117,7 +117,7 @@ func TestLeaseBreakNewEpoch_OtherClientSameKeyDoesNotSeedIt(t *testing.T) {
 	if got := notifier.forSession(2); len(got) != 0 {
 		t.Errorf("client B received %d break notifications for a break on another client's file", len(got))
 	}
-	if _, epoch, found := leaseMgr.GetLeaseState(ctx, shareName, leaseKey); !found || epoch < respB.Epoch {
+	if _, epoch, found := leaseMgr.GetLeaseState(ctx, lock.FileHandle("file-B"), shareName, leaseKey); !found || epoch < respB.Epoch {
 		t.Errorf("client B lease epoch = 0x%x found=%v, want >= 0x%x", epoch, found, respB.Epoch)
 	}
 }

--- a/internal/adapter/smb/handlers/reopen2_e2e_test.go
+++ b/internal/adapter/smb/handlers/reopen2_e2e_test.go
@@ -382,7 +382,7 @@ func TestReopen2_V2Lease_RestoresRWH(t *testing.T) {
 		t.Fatal("initial open: missing DH2Q grant blob")
 	}
 	// Confirm the lease really sits at RWH in the LeaseManager before disconnect.
-	if state, _, found := e.h.LeaseManager.GetLeaseState(context.Background(), e.tree.ShareName, leaseKey); !found ||
+	if state, _, found := e.h.LeaseManager.GetLeaseState(context.Background(), lock.FileHandle(of.MetadataHandle), e.tree.ShareName, leaseKey); !found ||
 		state != uint32(lock.LeaseStateRead|lock.LeaseStateWrite|lock.LeaseStateHandle) {
 		t.Fatalf("initial open: LeaseManager state = 0x%x found=%v, want RWH", state, found)
 	}

--- a/internal/adapter/smb/handlers/replay_dhv2_test.go
+++ b/internal/adapter/smb/handlers/replay_dhv2_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/lease"
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
@@ -249,10 +250,11 @@ func grantRWHLease(t *testing.T, leaseMgr *lease.LeaseManager, leaseKey [16]byte
 		t.Fatalf("granted lease state 0x%x, want RWH (0x7)", resp.LeaseState)
 	}
 	return &OpenFile{
-		SessionID:   sessionID,
-		ShareName:   "share1",
-		OplockLevel: OplockLevelLease,
-		LeaseKey:    leaseKey,
+		SessionID:      sessionID,
+		ShareName:      "share1",
+		MetadataHandle: metadata.FileHandle(fh),
+		OplockLevel:    OplockLevelLease,
+		LeaseKey:       leaseKey,
 	}
 }
 

--- a/internal/adapter/smb/handlers/session_teardown_lease_leak_test.go
+++ b/internal/adapter/smb/handlers/session_teardown_lease_leak_test.go
@@ -226,7 +226,7 @@ func TestSessionTeardown_ReleasesTraditionalOplockRegistry(t *testing.T) {
 	if e.mgr.HasActiveLeaseRecord(string(fh), [16]byte{}) {
 		t.Error("LEAK: lock-manager oplock record survived session teardown")
 	}
-	if _, _, found := e.mgr.GetLeaseState(context.Background(), of.LeaseKey); found {
+	if _, _, found := e.mgr.GetLeaseState(context.Background(), string(fh), of.LeaseKey); found {
 		t.Error("LEAK: oplock lease state survived session teardown")
 	}
 	if e.notifier.count() != 0 {

--- a/internal/adapter/smb/lease/identity_test.go
+++ b/internal/adapter/smb/lease/identity_test.go
@@ -87,11 +87,11 @@ func TestGetLeaseState_OtherShareSameKeyAnswersItsOwn(t *testing.T) {
 		t.Fatalf("client B RequestLease: %v", err)
 	}
 
-	if state, _, found := lm.GetLeaseState(ctx, "share1", leaseKey); !found || state != testRH {
+	if state, _, found := lm.GetLeaseState(ctx, lock.FileHandle("file-A"), "share1", leaseKey); !found || state != testRH {
 		t.Errorf("GetLeaseState(share1) = 0x%x found=%v, want RH (0x%x) — answered from the other share's lease",
 			state, found, uint32(testRH))
 	}
-	if state, _, found := lm.GetLeaseState(ctx, "share2", leaseKey); !found || state != lock.LeaseStateRead {
+	if state, _, found := lm.GetLeaseState(ctx, lock.FileHandle("file-B"), "share2", leaseKey); !found || state != lock.LeaseStateRead {
 		t.Errorf("GetLeaseState(share2) = 0x%x found=%v, want R (0x%x)",
 			state, found, uint32(lock.LeaseStateRead))
 	}
@@ -140,7 +140,7 @@ func TestAcknowledgeLeaseBreak_ResolvesTheAckingClientsLease(t *testing.T) {
 	if mgr1.HasOtherBreakingLeases("file-A", [16]byte{}) {
 		t.Errorf("client A's lease is still breaking after its own ack — the ack was routed to another client's lease")
 	}
-	if state, _, _ := mgr2.GetLeaseState(ctx, leaseKey); state != lock.LeaseStateRead {
+	if state, _, _ := mgr2.GetLeaseState(ctx, "file-B", leaseKey); state != lock.LeaseStateRead {
 		t.Errorf("client B's lease state = 0x%x, want R (0x%x) — A's ack downgraded B's lease",
 			state, uint32(lock.LeaseStateRead))
 	}

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -644,20 +644,21 @@ func (lm *LeaseManager) ReleaseSessionLeases(ctx context.Context, sessionID uint
 	return nil
 }
 
-// GetLeaseState returns the state and epoch of a lease key in one share.
+// GetLeaseState returns the state and epoch of the lease this key holds on one
+// file of one share.
 //
-// The share is a parameter rather than resolved from the key because the key
-// alone does not identify a lease: two clients may present the same 16-byte
-// value in different shares, and the wrong share's lock manager reports a
-// foreign lease's state and epoch — values that go straight back out on the
-// wire on a durable reconnect or a replayed CREATE.
-func (lm *LeaseManager) GetLeaseState(ctx context.Context, shareName string, leaseKey [16]byte) (state uint32, epoch uint16, found bool) {
+// The file and the share are parameters rather than resolved from the key
+// because the key alone does not identify a lease: two clients may present the
+// same 16-byte value on different files, or in different shares, and the wrong
+// record reports a foreign lease's state and epoch — values that go straight
+// back out on the wire on a durable reconnect or a replayed CREATE.
+func (lm *LeaseManager) GetLeaseState(ctx context.Context, fileHandle lock.FileHandle, shareName string, leaseKey [16]byte) (state uint32, epoch uint16, found bool) {
 	lockMgr := lm.resolveLockManager(shareName)
 	if lockMgr == nil {
 		return lock.LeaseStateNone, 0, false
 	}
 
-	return lockMgr.GetLeaseState(ctx, leaseKey)
+	return lockMgr.GetLeaseState(ctx, string(fileHandle), leaseKey)
 }
 
 // HasLeaseOnHandle reports whether a lease record with this key already exists
@@ -840,8 +841,8 @@ func (lm *LeaseManager) BreakLeasesOnByteRangeLock(
 		eo := excludeOwner[0]
 		if eo.ExcludeLeaseKey != ([16]byte{}) {
 			ctx := context.Background()
-			state, _, found := lockMgr.GetLeaseState(ctx, eo.ExcludeLeaseKey)
-			isTraditional := lockMgr.IsTraditionalOplockForKey(eo.ExcludeLeaseKey)
+			state, _, found := lockMgr.GetLeaseState(ctx, handleKey, eo.ExcludeLeaseKey)
+			isTraditional := lockMgr.IsTraditionalOplockForKey(handleKey, eo.ExcludeLeaseKey)
 			if found && (!isTraditional || state&lock.LeaseStateWrite != 0) {
 				exclude = eo
 			}
@@ -1316,20 +1317,22 @@ func (lm *LeaseManager) BreakParentReadLeasesOnModify(
 	return lockMgr.WaitForBreakCompletion(waitCtx, handleKey)
 }
 
-// SetLeaseEpoch sets the epoch on an existing lease identified by leaseKey in
-// one share. Per MS-SMB2 3.3.5.9: for V2 leases, the server should track the
+// SetLeaseEpoch sets the epoch on the lease this key holds on one file of one
+// share. Per MS-SMB2 3.3.5.9: for V2 leases, the server should track the
 // client's epoch from the RqLs create context.
 //
-// The share is a parameter for the same reason it is one on GetLeaseState: the
-// key alone does not identify a lease, and the epoch written here is the
-// NewEpoch of the next break notification for whatever lease it lands on.
-func (lm *LeaseManager) SetLeaseEpoch(shareName string, leaseKey [16]byte, epoch uint16) {
+// The file and the share are parameters for the same reason they are on
+// GetLeaseState: the key alone does not identify a lease, and the epoch written
+// here is the NewEpoch of the next break notification for whatever lease it
+// lands on. Seeding this client's epoch onto another client's lease hands that
+// client a NewEpoch no grant of its own produced.
+func (lm *LeaseManager) SetLeaseEpoch(fileHandle lock.FileHandle, shareName string, leaseKey [16]byte, epoch uint16) {
 	lockMgr := lm.resolveLockManager(shareName)
 	if lockMgr == nil {
 		return
 	}
 
-	lockMgr.SetLeaseEpoch(leaseKey, epoch)
+	lockMgr.SetLeaseEpoch(string(fileHandle), leaseKey, epoch)
 }
 
 // BreakReadLeasesOnWrite breaks Read (Level II) oplocks/leases held by other
@@ -1361,8 +1364,8 @@ func (lm *LeaseManager) BreakReadLeasesOnWrite(
 	var exclude *lock.LockOwner
 	if excludeLeaseKey != ([16]byte{}) {
 		ctx := context.Background()
-		state, _, found := lockMgr.GetLeaseState(ctx, excludeLeaseKey)
-		isTraditional := lockMgr.IsTraditionalOplockForKey(excludeLeaseKey)
+		state, _, found := lockMgr.GetLeaseState(ctx, handleKey, excludeLeaseKey)
+		isTraditional := lockMgr.IsTraditionalOplockForKey(handleKey, excludeLeaseKey)
 		// Leases: always exclude the writer's own key (nobreakself per MS-SMB2 §3.3.5.9).
 		// Traditional oplocks: exclude only when the writer has Write caching.
 		// A Level II oplock holder must self-break on write per Samba

--- a/pkg/metadata/lock/indexes_test.go
+++ b/pkg/metadata/lock/indexes_test.go
@@ -119,7 +119,7 @@ func TestIndex_ReleaseLeaseForHandleKeepsOtherFileBinding(t *testing.T) {
 	require.NoError(t, mgr.ReleaseLeaseForHandle(ctx, "fileA", key))
 	assertIndexesConsistent(t, mgr)
 
-	_, _, found := mgr.GetLeaseState(ctx, key)
+	_, _, found := mgr.GetLeaseState(ctx, "fileB", key)
 	assert.True(t, found, "fileB lease record must survive fileA release")
 }
 
@@ -153,7 +153,7 @@ func TestIndex_ReleaseBoundBucketKeepsOtherFileResolvable(t *testing.T) {
 	assert.Equal(t, "fileA", hk, "fileA must still resolve after releasing fileB")
 	require.NotNil(t, lk, "fileA lease record must remain resolvable")
 
-	_, _, found := mgr.GetLeaseState(ctx, key)
+	_, _, found := mgr.GetLeaseState(ctx, "fileA", key)
 	assert.True(t, found, "fileA lease record must survive fileB release")
 }
 
@@ -175,9 +175,9 @@ func TestIndex_RemoveClientLocksTouchesOnlyClientBuckets(t *testing.T) {
 	assertIndexesConsistent(t, mgr)
 
 	// client1's leases gone, client2's intact.
-	_, _, f1 := mgr.GetLeaseState(ctx, [16]byte{1})
-	_, _, f2 := mgr.GetLeaseState(ctx, [16]byte{2})
-	_, _, f3 := mgr.GetLeaseState(ctx, [16]byte{3})
+	_, _, f1 := mgr.GetLeaseState(ctx, "f1", [16]byte{1})
+	_, _, f2 := mgr.GetLeaseState(ctx, "f2", [16]byte{2})
+	_, _, f3 := mgr.GetLeaseState(ctx, "f3", [16]byte{3})
 	assert.False(t, f1, "client1 f1 lease should be removed")
 	assert.False(t, f2, "client1 f2 lease should be removed")
 	assert.True(t, f3, "client2 f3 lease must remain")
@@ -292,12 +292,16 @@ func TestIndex_ReclaimAddsToIndex(t *testing.T) {
 // Index lookup vs full scan equivalence
 // ============================================================================
 
-// scanLeaseKeyMatches is the reference implementation SetLeaseEpoch used before
-// it consulted leaseKeyIndex: a full sweep of every handleKey bucket collecting
-// every record bound to leaseKey.
-func scanLeaseKeyMatches(lm *Manager, leaseKey [16]byte) map[string]bool {
+// scanLeaseKeyMatches is a reference implementation of the record selection
+// SetLeaseEpoch performs: a full sweep of every handleKey bucket, collecting the
+// records bound to leaseKey ON handleKey and no others. A record for the same
+// key on a different file belongs to a different lease.
+func scanLeaseKeyMatches(lm *Manager, handleKey string, leaseKey [16]byte) map[string]bool {
 	out := make(map[string]bool)
-	for _, locks := range lm.unifiedLocks {
+	for hk, locks := range lm.unifiedLocks {
+		if hk != handleKey {
+			continue
+		}
 		for _, l := range locks {
 			if l.Lease != nil && l.Lease.LeaseKey == leaseKey {
 				out[l.ID] = true
@@ -377,35 +381,53 @@ func buildMixedLockSet(t *testing.T, mgr *Manager) (keys [][16]byte, handleKeys 
 		[]string{"file1", "file2", "file3", "file4", "dir1", "absent"}
 }
 
-// TestSetLeaseEpoch_IndexMatchesFullScan proves the leaseKeyIndex-driven record
-// selection in SetLeaseEpoch reaches the same records a full unifiedLocks sweep
-// would, and converges every one of them.
-func TestSetLeaseEpoch_IndexMatchesFullScan(t *testing.T) {
+// TestSetLeaseEpoch_MatchesFullScan proves the record selection in
+// SetLeaseEpoch reaches the same records a full unifiedLocks sweep scoped to the
+// same file would, converges every one of them, and leaves records for the same
+// key on other files where they were. Runs over every (key, file) pair the
+// fixture can produce, including pairs that hold no lease.
+func TestSetLeaseEpoch_MatchesFullScan(t *testing.T) {
 	t.Parallel()
 	mgr := NewManager()
-	keys, _ := buildMixedLockSet(t, mgr)
+	keys, handleKeys := buildMixedLockSet(t, mgr)
 	assertIndexesConsistent(t, mgr)
 
+	const target = uint16(7)
 	for _, key := range keys {
-		mgr.mu.RLock()
-		want := scanLeaseKeyMatches(mgr, key)
-		mgr.mu.RUnlock()
-
-		// SetLeaseEpoch reports found iff the scan found records, and lifts
-		// every matching record to the same epoch.
-		ok := mgr.SetLeaseEpoch(key, 7)
-		assert.Equal(t, len(want) > 0, ok, "SetLeaseEpoch found-flag must match the scan for key %x", key)
-
-		mgr.mu.RLock()
-		for _, locks := range mgr.unifiedLocks {
-			for _, l := range locks {
-				if l.Lease != nil && l.Lease.LeaseKey == key {
-					assert.Equal(t, uint16(7), l.Lease.Epoch,
-						"every record for key %x must converge to the target epoch", key)
+		for _, handleKey := range handleKeys {
+			mgr.mu.RLock()
+			want := scanLeaseKeyMatches(mgr, handleKey, key)
+			// Snapshot every other record bound to this key so the assertion
+			// below can show none of them moved.
+			untouched := make(map[*UnifiedLock]uint16)
+			for hk, locks := range mgr.unifiedLocks {
+				for _, l := range locks {
+					if l.Lease != nil && l.Lease.LeaseKey == key && hk != handleKey {
+						untouched[l] = l.Lease.Epoch
+					}
 				}
 			}
+			mgr.mu.RUnlock()
+
+			// SetLeaseEpoch reports found iff the scoped scan found records,
+			// and lifts every one of them to the same epoch.
+			ok := mgr.SetLeaseEpoch(handleKey, key, target)
+			assert.Equal(t, len(want) > 0, ok,
+				"SetLeaseEpoch found-flag must match the scan for key %x on %s", key, handleKey)
+
+			mgr.mu.RLock()
+			for _, l := range mgr.unifiedLocks[handleKey] {
+				if l.Lease != nil && l.Lease.LeaseKey == key {
+					assert.GreaterOrEqual(t, l.Lease.Epoch, target,
+						"every record for key %x on %s must converge to at least the target epoch", key, handleKey)
+				}
+			}
+			for l, epoch := range untouched {
+				assert.Equal(t, epoch, l.Lease.Epoch,
+					"a record for key %x on another file is a different lease and must not move", key)
+			}
+			mgr.mu.RUnlock()
 		}
-		mgr.mu.RUnlock()
 	}
 }
 

--- a/pkg/metadata/lock/lease_interface_test.go
+++ b/pkg/metadata/lock/lease_interface_test.go
@@ -186,7 +186,7 @@ func TestLockManager_HasLeaseOperations(t *testing.T) {
 	_ = err
 
 	// GetLeaseState should exist
-	state, epoch, found := lm.GetLeaseState(ctx, leaseKey)
+	state, epoch, found := lm.GetLeaseState(ctx, "file1", leaseKey)
 	_ = state
 	_ = epoch
 	_ = found

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -1334,17 +1334,37 @@ func (lm *Manager) releaseLeaseRecords(ctx context.Context, handleKey string, le
 	}
 }
 
-// GetLeaseState returns the current state and epoch for a lease key.
-func (lm *Manager) getLeaseStateImpl(_ context.Context, leaseKey [16]byte) (state uint32, epoch uint16, found bool) {
+// leaseRecordsOnHandleLocked returns the records for leaseKey on handleKey.
+//
+// (handleKey, leaseKey) is the identity of a lease record within one share's
+// manager: it is what resolveSameKeyLeaseLocked matches a request against when
+// it decides to reuse a record rather than create one. The lease key alone is
+// not that identity — two clients may present the same 16-byte value on
+// different files of one share, which the cross-file uniqueness rule permits
+// because it is scoped per (client, file).
+//
+// Must be called with lm.mu held (read or write).
+func (lm *Manager) leaseRecordsOnHandleLocked(handleKey string, leaseKey [16]byte) []*UnifiedLock {
+	var out []*UnifiedLock
+	for _, l := range lm.unifiedLocks[handleKey] {
+		if l.Lease != nil && l.Lease.LeaseKey == leaseKey {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+// GetLeaseState returns the current state and epoch of the lease on handleKey.
+func (lm *Manager) getLeaseStateImpl(_ context.Context, handleKey string, leaseKey [16]byte) (state uint32, epoch uint16, found bool) {
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()
 
-	_, lock, _ := lm.findLeaseByKey(leaseKey)
-	if lock == nil || lock.Lease == nil {
+	records := lm.leaseRecordsOnHandleLocked(handleKey, leaseKey)
+	if len(records) == 0 {
 		return 0, 0, false
 	}
 
-	return lock.Lease.LeaseState, lock.Lease.Epoch, true
+	return records[0].Lease.LeaseState, records[0].Lease.Epoch, true
 }
 
 // HasLeaseOnHandle reports whether a lease record with this key already exists
@@ -1364,11 +1384,11 @@ func (lm *Manager) HasLeaseOnHandle(handleKey string, leaseKey [16]byte) bool {
 	return false
 }
 
-func (lm *Manager) IsTraditionalOplockForKey(leaseKey [16]byte) bool {
+func (lm *Manager) IsTraditionalOplockForKey(handleKey string, leaseKey [16]byte) bool {
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()
-	_, lock, _ := lm.findLeaseByKey(leaseKey)
-	return lock != nil && lock.Lease != nil && lock.Lease.IsTraditionalOplock
+	records := lm.leaseRecordsOnHandleLocked(handleKey, leaseKey)
+	return len(records) > 0 && records[0].Lease.IsTraditionalOplock
 }
 
 // ============================================================================
@@ -1484,55 +1504,52 @@ func (lm *Manager) ReleaseLeaseForHandle(ctx context.Context, handleKey string, 
 	return lm.releaseLeaseForHandleImpl(ctx, handleKey, leaseKey)
 }
 
-// GetLeaseState returns the current state and epoch for a lease key.
-func (lm *Manager) GetLeaseState(ctx context.Context, leaseKey [16]byte) (state uint32, epoch uint16, found bool) {
-	return lm.getLeaseStateImpl(ctx, leaseKey)
+// GetLeaseState returns the current state and epoch of the lease on handleKey.
+func (lm *Manager) GetLeaseState(ctx context.Context, handleKey string, leaseKey [16]byte) (state uint32, epoch uint16, found bool) {
+	return lm.getLeaseStateImpl(ctx, handleKey, leaseKey)
 }
 
-// SetLeaseEpoch sets the epoch on an existing lease identified by leaseKey.
+// SetLeaseEpoch sets the epoch on the lease (handleKey, leaseKey) holds.
 // Per MS-SMB2 3.3.5.9: For V2 leases, the server should track the client's
 // epoch from the RqLs create context. SetLeaseEpoch is called after RequestLease
 // to initialize the epoch to the client's requested value.
-// Returns false if no lease was found with the given key.
-func (lm *Manager) SetLeaseEpoch(leaseKey [16]byte, epoch uint16) bool {
+// Returns false if no lease was found on that file with the given key.
+func (lm *Manager) SetLeaseEpoch(handleKey string, leaseKey [16]byte, epoch uint16) bool {
 	lm.mu.Lock()
 	defer lm.unlock()
 
-	// Update every lease record matching leaseKey, not just the first found.
-	// Stale records from prior tests (same LEASE1 constant across smbtorture
-	// tests) or from multiple opens by different clients can coexist in
-	// lm.unifiedLocks under different handleKey buckets. findLeaseByKey's
-	// map-iteration order is non-deterministic, so scoping to the first
-	// match can miss the lease that RequestLease just granted — leaving it
-	// at Epoch=1 (createAndGrantLease default) while the response to the
-	// client carries the higher requested epoch. Subsequent break
-	// notifications then dispatch with Epoch=2 instead of requestedEpoch+2,
-	// regressing smbtorture V2 tests (break_twice, breaking*, v2_breaking3).
-	// Two passes so all matching records converge to the SAME epoch. A
-	// per-record `if epoch >= lock.Lease.Epoch` guard lets sibling records that
-	// start at different epochs diverge (e.g. one at 5 stays 5 while another at
-	// 1 moves to 4), and GetLeaseState / break dispatch then read whichever
-	// map-order surfaces first — a non-deterministic NewEpoch in break
-	// notifications (the break_twice / v2_breaking3 regression class). Compute
-	// the max of the requested epoch and every matching record's current epoch,
-	// then assign that single max to all of them so the lease has one epoch.
+	// Update every record of THIS lease, not just the first found. Reopens and
+	// reclaims can leave more than one record for a key on one file, so scoping
+	// to the first match can miss the one RequestLease just granted — leaving
+	// it at Epoch=1 (createAndGrantLease default) while the response to the
+	// client carries the higher requested epoch. Subsequent break notifications
+	// then dispatch with Epoch=2 instead of requestedEpoch+2, regressing
+	// smbtorture V2 tests (break_twice, breaking*, v2_breaking3).
 	//
-	// Probes only the buckets leaseKeyIndex names for leaseKey; the ones it
-	// omits hold no record for the key and could never have matched.
+	// Two passes so all of this lease's records converge to the SAME epoch. A
+	// per-record `if epoch >= lock.Lease.Epoch` guard lets siblings that start
+	// at different epochs diverge (e.g. one at 5 stays 5 while another at 1
+	// moves to 4), and a read of the lease then answers from whichever the
+	// slice surfaces first. Compute the max of the requested epoch and every
+	// record's current epoch, then assign that single max to all of them so the
+	// lease has one epoch.
+	//
+	// The convergence stops at this file. A lease key is not an identity: the
+	// cross-file uniqueness rule is per (client, file), so another client may
+	// hold the same 16-byte value on a different file of this share. Folding
+	// that client's records into the max hands it an epoch no grant of its own
+	// produced, and the gap is what a client acts on — per MS-SMB2 §3.2.5.19.2
+	// a NewEpoch more than 1 past the one it last saw forces a cache purge, and
+	// one more than 32767 past it makes the client discard the break's new
+	// lease state outright.
+	records := lm.leaseRecordsOnHandleLocked(handleKey, leaseKey)
 	target := epoch
-	var matches []*UnifiedLock
-	for handleKey := range lm.leaseKeyIndex[leaseKey] {
-		for _, lock := range lm.unifiedLocks[handleKey] {
-			if lock.Lease == nil || lock.Lease.LeaseKey != leaseKey {
-				continue
-			}
-			if lock.Lease.Epoch > target {
-				target = lock.Lease.Epoch
-			}
-			matches = append(matches, lock)
+	for _, lock := range records {
+		if lock.Lease.Epoch > target {
+			target = lock.Lease.Epoch
 		}
 	}
-	for _, lock := range matches {
+	for _, lock := range records {
 		lock.Lease.Epoch = target
 		// Persist the new epoch like every other lease state-change path.
 		// Without this, RestoreLocks rebuilds the lease at the stale grant-time
@@ -1541,5 +1558,5 @@ func (lm *Manager) SetLeaseEpoch(leaseKey [16]byte, epoch uint16) bool {
 		// §3.3.4.7 epoch monotonicity.
 		lm.persistUnifiedLockLocked(lock)
 	}
-	return len(matches) > 0
+	return len(records) > 0
 }

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -1380,7 +1380,15 @@ func (lm *Manager) HasLeaseOnHandle(handleKey string, leaseKey [16]byte) bool {
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()
 
-	return len(lm.leaseRecordsOnHandleLocked(handleKey, leaseKey)) > 0
+	// Scans rather than reusing leaseRecordsOnHandleLocked: this answers a
+	// boolean on the CREATE path, and building a slice to do it costs an
+	// allocation per call that an early return does not.
+	for _, l := range lm.unifiedLocks[handleKey] {
+		if l.Lease != nil && l.Lease.LeaseKey == leaseKey {
+			return true
+		}
+	}
+	return false
 }
 
 func (lm *Manager) IsTraditionalOplockForKey(handleKey string, leaseKey [16]byte) bool {

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -127,6 +127,12 @@ func advanceEpoch(lease *OpLock) {
 // not) track because slice positions shift on every filtered rebuild. The
 // index is reconciled from the live slice on every mutation; if a bucket entry
 // is ever stale the in-bucket scan simply finds no match there and moves on.
+//
+// Because which holder comes back is unspecified, this must not decide a value
+// that goes out on the wire, and no longer does: the paths that read or write a
+// lease's state and epoch take the file as a parameter and resolve through
+// leaseRecordsOnHandleLocked. What remains here is the LEASE_BREAK_ACK and
+// reclaim routing, which are given only a lease key.
 func (lm *Manager) findLeaseByKey(leaseKey [16]byte) (string, *UnifiedLock, int) {
 	buckets := lm.leaseKeyIndex[leaseKey]
 	if buckets == nil {

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -1517,13 +1517,14 @@ func (lm *Manager) SetLeaseEpoch(handleKey string, leaseKey [16]byte, epoch uint
 	lm.mu.Lock()
 	defer lm.unlock()
 
-	// Update every record of THIS lease, not just the first found. Reopens and
-	// reclaims can leave more than one record for a key on one file, so scoping
-	// to the first match can miss the one RequestLease just granted — leaving
-	// it at Epoch=1 (createAndGrantLease default) while the response to the
-	// client carries the higher requested epoch. Subsequent break notifications
-	// then dispatch with Epoch=2 instead of requestedEpoch+2, regressing
-	// smbtorture V2 tests (break_twice, breaking*, v2_breaking3).
+	// Update every record of THIS lease, not just the first found. A grant
+	// cannot add a second record for a key already on the file
+	// (resolveSameKeyLeaseLocked reuses it) but RestoreLocks appends persisted
+	// rows without that guard, so more than one can exist here. Scoping to the
+	// first match would then risk missing the one RequestLease just granted,
+	// leaving it at Epoch=1 (createAndGrantLease default) while the response to
+	// the client carries the higher requested epoch, and the next break
+	// notification dispatching Epoch=2 instead of requestedEpoch+2.
 	//
 	// Two passes so all of this lease's records converge to the SAME epoch. A
 	// per-record `if epoch >= lock.Lease.Epoch` guard lets siblings that start

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -1374,20 +1374,13 @@ func (lm *Manager) getLeaseStateImpl(_ context.Context, handleKey string, leaseK
 }
 
 // HasLeaseOnHandle reports whether a lease record with this key already exists
-// on this file. The predicate matches the one resolveSameKeyLeaseLocked uses to
-// decide whether a request reuses an existing record or falls through to
-// createAndGrantLease, so a false answer means the next grant on this file with
-// this key creates a record.
+// on this file, so a false answer means the next grant on this file with this
+// key creates a record.
 func (lm *Manager) HasLeaseOnHandle(handleKey string, leaseKey [16]byte) bool {
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()
 
-	for _, l := range lm.unifiedLocks[handleKey] {
-		if l.Lease != nil && l.Lease.LeaseKey == leaseKey {
-			return true
-		}
-	}
-	return false
+	return len(lm.leaseRecordsOnHandleLocked(handleKey, leaseKey)) > 0
 }
 
 func (lm *Manager) IsTraditionalOplockForKey(handleKey string, leaseKey [16]byte) bool {
@@ -1540,14 +1533,13 @@ func (lm *Manager) SetLeaseEpoch(handleKey string, leaseKey [16]byte, epoch uint
 	// record's current epoch, then assign that single max to all of them so the
 	// lease has one epoch.
 	//
-	// The convergence stops at this file. A lease key is not an identity: the
-	// cross-file uniqueness rule is per (client, file), so another client may
-	// hold the same 16-byte value on a different file of this share. Folding
-	// that client's records into the max hands it an epoch no grant of its own
-	// produced, and the gap is what a client acts on — per MS-SMB2 §3.2.5.19.2
-	// a NewEpoch more than 1 past the one it last saw forces a cache purge, and
-	// one more than 32767 past it makes the client discard the break's new
-	// lease state outright.
+	// The convergence stops at this file, because leaseRecordsOnHandleLocked
+	// resolves by (handleKey, leaseKey). Folding in a same-key lease on another
+	// file — another client's, per the identity rule described there — hands
+	// that client an epoch no grant of its own produced, and the gap is what it
+	// acts on: per MS-SMB2 §3.2.5.19.2 a NewEpoch more than 1 past the one it
+	// last saw forces a cache purge, and one more than 32767 past it makes the
+	// client discard the break's new lease state outright.
 	records := lm.leaseRecordsOnHandleLocked(handleKey, leaseKey)
 	target := epoch
 	for _, lock := range records {

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -1537,10 +1537,16 @@ func (lm *Manager) SetLeaseEpoch(handleKey string, leaseKey [16]byte, epoch uint
 	// The convergence stops at this file, because leaseRecordsOnHandleLocked
 	// resolves by (handleKey, leaseKey). Folding in a same-key lease on another
 	// file — another client's, per the identity rule described there — hands
-	// that client an epoch no grant of its own produced, and the gap is what it
-	// acts on: per MS-SMB2 §3.2.5.19.2 a NewEpoch more than 1 past the one it
-	// last saw forces a cache purge, and one more than 32767 past it makes the
-	// client discard the break's new lease state outright.
+	// that client an epoch no grant of its own produced, and the SIZE of that
+	// jump is what it acts on.
+	//
+	// The epoch is a wrapping sequence number, not a counter: MS-SMB2
+	// §3.2.5.7.5 compares it modulo 2^16, treating the server's value as newer
+	// only when it is at most 32767 ahead. Raising an epoch is therefore not
+	// inherently safe — past that half-space boundary the value reads as OLDER,
+	// and §3.2.5.19.2 step 7 then leaves the client on its old lease state while
+	// the server believes the lease broken. A gap above 1 also forces a cache
+	// purge.
 	records := lm.leaseRecordsOnHandleLocked(handleKey, leaseKey)
 	target := epoch
 	for _, lock := range records {

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -129,10 +129,10 @@ func advanceEpoch(lease *OpLock) {
 // is ever stale the in-bucket scan simply finds no match there and moves on.
 //
 // Because which holder comes back is unspecified, this must not decide a value
-// that goes out on the wire, and no longer does: the paths that read or write a
+// that goes out on the wire. Its callers are the LEASE_BREAK_ACK and reclaim
+// routing, which are handed only a lease key; the paths that read or write a
 // lease's state and epoch take the file as a parameter and resolve through
-// leaseRecordsOnHandleLocked. What remains here is the LEASE_BREAK_ACK and
-// reclaim routing, which are given only a lease key.
+// leaseRecordsOnHandleLocked instead.
 func (lm *Manager) findLeaseByKey(leaseKey [16]byte) (string, *UnifiedLock, int) {
 	buckets := lm.leaseKeyIndex[leaseKey]
 	if buckets == nil {

--- a/pkg/metadata/lock/leases_test.go
+++ b/pkg/metadata/lock/leases_test.go
@@ -280,7 +280,7 @@ func TestRequestLeaseStatOpen_NoBreakOnCrossKeyConflict(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, LeaseStateRead|LeaseStateWrite|LeaseStateHandle, state)
 
-	_, holderEpoch, ok := mgr.GetLeaseState(ctx, key1)
+	_, holderEpoch, ok := mgr.GetLeaseState(ctx, "file1", key1)
 	require.True(t, ok)
 
 	// A stat-open requester asks for RH on the same file with a different key.
@@ -295,7 +295,7 @@ func TestRequestLeaseStatOpen_NoBreakOnCrossKeyConflict(t *testing.T) {
 		"stat-open requester must NOT break the existing holder (#751)")
 
 	// The holder is untouched: state and epoch unchanged, not Breaking.
-	holderState, postEpoch, ok := mgr.GetLeaseState(ctx, key1)
+	holderState, postEpoch, ok := mgr.GetLeaseState(ctx, "file1", key1)
 	require.True(t, ok)
 	assert.Equal(t, LeaseStateRead|LeaseStateWrite|LeaseStateHandle, holderState,
 		"holder lease state must be unchanged")
@@ -391,7 +391,7 @@ func TestRequestLease_CrossKeyConflictOnAlreadyBreakingLease(t *testing.T) {
 
 	// Snapshot the post-break epoch so we can prove the cross-key conflict
 	// branch does NOT bump it again.
-	_, breakingEpoch, ok := mgr.GetLeaseState(ctx, key1)
+	_, breakingEpoch, ok := mgr.GetLeaseState(ctx, "file1", key1)
 	require.True(t, ok)
 
 	// Client 2 now requests RWH on the same file with a different key. The
@@ -410,7 +410,7 @@ func TestRequestLease_CrossKeyConflictOnAlreadyBreakingLease(t *testing.T) {
 	assert.EqualValues(t, 1, breakCount.Load(),
 		"cross-key conflict on already-breaking lease must NOT redispatch break")
 
-	_, postEpoch, ok := mgr.GetLeaseState(ctx, key1)
+	_, postEpoch, ok := mgr.GetLeaseState(ctx, "file1", key1)
 	require.True(t, ok)
 	assert.Equal(t, breakingEpoch, postEpoch,
 		"cross-key conflict on already-breaking lease must NOT bump epoch")
@@ -466,7 +466,7 @@ func TestRequestLease_PostAckCrossKeyDoesNotRedispatch(t *testing.T) {
 	require.NoError(t, mgr.AcknowledgeLeaseBreak(ctx, key2, LeaseStateRead|LeaseStateHandle, 0))
 
 	// Verify LEASE2 is now at RH, not Breaking.
-	curState, _, ok := mgr.GetLeaseState(ctx, key2)
+	curState, _, ok := mgr.GetLeaseState(ctx, "file1", key2)
 	require.True(t, ok)
 	require.Equal(t, LeaseStateRead|LeaseStateHandle, curState)
 
@@ -991,7 +991,7 @@ func TestAcknowledgeLeaseBreak_CompletesBreak(t *testing.T) {
 	// state-None record must surface ErrLeaseAckNotBreaking →
 	// STATUS_UNSUCCESSFUL per smbtorture breaking2/breaking5.
 	assert.Eventually(t, func() bool {
-		state, _, found := mgr.GetLeaseState(ctx, key1)
+		state, _, found := mgr.GetLeaseState(ctx, "file1", key1)
 		return found && state == LeaseStateNone
 	}, 3*time.Second, 10*time.Millisecond, "key1 lease should drop to LeaseState=None after ack")
 }
@@ -1027,7 +1027,7 @@ func TestAcknowledgeLeaseBreak_ToReadState(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify state was updated
-	state, _, found := mgr.GetLeaseState(ctx, key1)
+	state, _, found := mgr.GetLeaseState(ctx, "file1", key1)
 	assert.True(t, found)
 	assert.Equal(t, LeaseStateRead, state)
 }
@@ -1082,7 +1082,7 @@ func TestAcknowledgeLeaseBreak_AckToNone_KeepsRecordAtNone(t *testing.T) {
 	// Per MS-SMB2 3.3.5.22.2 + smbtorture breaking2/breaking5: the lease
 	// record persists at LeaseState=None until CLOSE so a duplicate ack
 	// can be distinguished from CLOSE-beat-ack.
-	state, _, found := mgr.GetLeaseState(ctx, key1)
+	state, _, found := mgr.GetLeaseState(ctx, "file1", key1)
 	assert.True(t, found, "lease record should persist after ack-to-None")
 	assert.Equal(t, LeaseStateNone, state, "lease state should be None")
 
@@ -1093,7 +1093,7 @@ func TestAcknowledgeLeaseBreak_AckToNone_KeepsRecordAtNone(t *testing.T) {
 	// CLOSE removes the record fully.
 	err = mgr.ReleaseLeaseForHandle(ctx, "file1", key1)
 	require.NoError(t, err)
-	_, _, found = mgr.GetLeaseState(ctx, key1)
+	_, _, found = mgr.GetLeaseState(ctx, "file1", key1)
 	assert.False(t, found, "lease should be gone after CLOSE")
 }
 
@@ -1136,7 +1136,7 @@ func TestAcknowledgeLeaseBreak_LateAckNonNoneAfterTimeout_Succeeds(t *testing.T)
 	// The parked CREATE's break-wait timer fires first (CI jitter): force-complete
 	// tombstones the lease to None and tags BrokenViaTimeout.
 	mgr.forceCompleteBreaks("file1")
-	state, _, found := mgr.GetLeaseState(ctx, key1)
+	state, _, found := mgr.GetLeaseState(ctx, "file1", key1)
 	require.True(t, found, "force-completed record persists at None")
 	require.Equal(t, LeaseStateNone, state, "force-complete revoked to None")
 
@@ -1146,7 +1146,7 @@ func TestAcknowledgeLeaseBreak_LateAckNonNoneAfterTimeout_Succeeds(t *testing.T)
 	require.NoError(t, err, "late non-None ACK after timeout force-complete must succeed (ack-sane)")
 
 	// The ACK must not resurrect bits: the forced None stands.
-	state, _, found = mgr.GetLeaseState(ctx, key1)
+	state, _, found = mgr.GetLeaseState(ctx, "file1", key1)
 	assert.True(t, found, "record still present after late ACK")
 	assert.Equal(t, LeaseStateNone, state, "late ACK must not resurrect lease bits")
 }
@@ -1178,7 +1178,7 @@ func TestAcknowledgeLeaseBreak_LateAckAfterLeaseConflictTimeout_Unsuccessful(t *
 	// Holder ignores the break; the parked CREATE's wait fires force-complete,
 	// which must preserve BreakReason on the tombstone.
 	mgr.forceCompleteBreaks("file1")
-	state, _, found := mgr.GetLeaseState(ctx, key1)
+	state, _, found := mgr.GetLeaseState(ctx, "file1", key1)
 	require.True(t, found, "force-completed record persists at None")
 	require.Equal(t, LeaseStateNone, state, "force-complete revoked to None")
 
@@ -1230,7 +1230,7 @@ func TestReleaseLease_RemovesLease(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify it exists
-	_, _, found := mgr.GetLeaseState(ctx, leaseKey)
+	_, _, found := mgr.GetLeaseState(ctx, "file1", leaseKey)
 	assert.True(t, found)
 
 	// Release
@@ -1238,7 +1238,7 @@ func TestReleaseLease_RemovesLease(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify it's gone
-	_, _, found = mgr.GetLeaseState(ctx, leaseKey)
+	_, _, found = mgr.GetLeaseState(ctx, "file1", leaseKey)
 	assert.False(t, found)
 }
 
@@ -1392,7 +1392,7 @@ func TestGetLeaseState_Found(t *testing.T) {
 	require.NoError(t, err)
 
 	// Get state
-	state, epoch, found := mgr.GetLeaseState(ctx, leaseKey)
+	state, epoch, found := mgr.GetLeaseState(ctx, "file1", leaseKey)
 	assert.True(t, found)
 	assert.Equal(t, LeaseStateRead|LeaseStateHandle, state)
 	assert.Equal(t, uint16(1), epoch)
@@ -1405,7 +1405,7 @@ func TestGetLeaseState_NotFound(t *testing.T) {
 	ctx := context.Background()
 	leaseKey := [16]byte{99, 99, 99}
 
-	state, epoch, found := mgr.GetLeaseState(ctx, leaseKey)
+	state, epoch, found := mgr.GetLeaseState(ctx, "file1", leaseKey)
 	assert.False(t, found)
 	assert.Equal(t, uint32(0), state)
 	assert.Equal(t, uint16(0), epoch)
@@ -1987,7 +1987,7 @@ func TestProgressiveLeaseBreak_RWH_AndMerge_ToNone(t *testing.T) {
 	require.Len(t, got, 3, "stage 4: ACK RH→R triggers R→\"\" notification")
 	assert.Equal(t, LeaseStateNone, got[2], "stage 4: target = None")
 
-	state, _, found := mgr.GetLeaseState(ctx, key1)
+	state, _, found := mgr.GetLeaseState(ctx, handleKey, key1)
 	assert.True(t, found, "stage 4: record persists after R→None auto-downgrade")
 	assert.Equal(t, LeaseStateNone, state, "stage 4: state drained to None")
 }
@@ -2068,7 +2068,7 @@ func TestForceCompleteBreaks_DrainsToNone_AndMerged(t *testing.T) {
 	// LeaseState=None (handle-bound lifetime).
 	mgr.forceCompleteBreaks(handleKey)
 
-	state, _, found := mgr.GetLeaseState(ctx, key1)
+	state, _, found := mgr.GetLeaseState(ctx, handleKey, key1)
 	require.True(t, found, "force-complete keeps the record alive until CLOSE")
 	assert.Equal(t, LeaseStateNone, state,
 		"force-complete must revoke to None per Samba lease_timeout_handler")
@@ -2118,7 +2118,7 @@ func TestForceCompleteBreaks_DrainsToNone_SingleBreak(t *testing.T) {
 	// Client doesn't ACK; the wait times out → force-complete fires.
 	mgr.forceCompleteBreaks(handleKey)
 
-	state, _, found := mgr.GetLeaseState(ctx, key1)
+	state, _, found := mgr.GetLeaseState(ctx, handleKey, key1)
 	require.True(t, found, "force-complete keeps the record alive until CLOSE")
 	assert.Equal(t, LeaseStateNone, state,
 		"force-complete on timeout revokes to None per Samba lease_timeout_handler — "+

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -145,13 +145,22 @@ type LockManager interface {
 	ReclaimLease(ctx context.Context, leaseKey [16]byte,
 		requestedState uint32, isDirectory bool, clientID string) (*UnifiedLock, error)
 
-	// GetLeaseState returns the current state and epoch for a lease key.
-	// found=false if no lease exists with that key.
-	GetLeaseState(ctx context.Context, leaseKey [16]byte) (state uint32, epoch uint16, found bool)
+	// GetLeaseState returns the current state and epoch of the lease that
+	// leaseKey holds on handleKey. found=false if that file holds no lease
+	// under that key.
+	//
+	// The file is a parameter rather than resolved from the key because the
+	// key alone does not identify a lease: the cross-file uniqueness rule is
+	// scoped per (client, file), so another client may hold the same 16-byte
+	// value on a different file of this share. The state and epoch returned
+	// here go back out on the wire on a durable disconnect and on a replayed
+	// CREATE.
+	GetLeaseState(ctx context.Context, handleKey string, leaseKey [16]byte) (state uint32, epoch uint16, found bool)
 
-	// IsTraditionalOplockForKey returns true if the lease record for this key
-	// was granted via RequestLeaseAsOplock (traditional oplock, not SMB2.1+ lease).
-	IsTraditionalOplockForKey(leaseKey [16]byte) bool
+	// IsTraditionalOplockForKey returns true if the lease record this key holds
+	// on handleKey was granted via RequestLeaseAsOplock (traditional oplock,
+	// not SMB2.1+ lease).
+	IsTraditionalOplockForKey(handleKey string, leaseKey [16]byte) bool
 
 	// HasLeaseOnHandle reports whether a lease record with this key already
 	// exists on this file. Unlike GetLeaseState it does not search across
@@ -162,10 +171,10 @@ type LockManager interface {
 	// for this key on this file" test.
 	HasLeaseOnHandle(handleKey string, leaseKey [16]byte) bool
 
-	// SetLeaseEpoch sets the epoch on an existing lease identified by leaseKey.
-	// Per MS-SMB2 3.3.5.9: For V2 leases, the server tracks the client's epoch.
-	// Returns false if no lease was found with the given key.
-	SetLeaseEpoch(leaseKey [16]byte, epoch uint16) bool
+	// SetLeaseEpoch sets the epoch on the lease that leaseKey holds on
+	// handleKey. Per MS-SMB2 3.3.5.9: For V2 leases, the server tracks the
+	// client's epoch. Returns false if that file holds no lease under that key.
+	SetLeaseEpoch(handleKey string, leaseKey [16]byte, epoch uint16) bool
 
 	// ========================================================================
 	// Delegation Operations

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -163,12 +163,10 @@ type LockManager interface {
 	IsTraditionalOplockForKey(handleKey string, leaseKey [16]byte) bool
 
 	// HasLeaseOnHandle reports whether a lease record with this key already
-	// exists on this file. Unlike GetLeaseState it does not search across
-	// files, so it cannot be answered by another client's lease that happens
-	// to reuse the same key value on a different file. It asks exactly what
-	// RequestLease asks when it decides whether to reuse a record or create
-	// one, which is what makes it usable as a "would this grant be the first
-	// for this key on this file" test.
+	// exists on this file. It asks exactly what RequestLease asks when it
+	// decides whether to reuse a record or create one, which is what makes it
+	// usable as a "would this grant be the first for this key on this file"
+	// test.
 	HasLeaseOnHandle(handleKey string, leaseKey [16]byte) bool
 
 	// SetLeaseEpoch sets the epoch on the lease that leaseKey holds on

--- a/pkg/metadata/lock/manager_test.go
+++ b/pkg/metadata/lock/manager_test.go
@@ -1222,46 +1222,76 @@ func TestMergeLocks_DifferentOwners(t *testing.T) {
 	}
 }
 
-// TestSetLeaseEpoch_UpdatesAllMatchingRecords covers the broadened behavior
-// added with the #429 lease work: the same LeaseKey can appear under
-// different handleKey buckets (smbtorture reuses fixed LEASE1/LEASE2 macros),
-// and SetLeaseEpoch must update every record so subsequent break
-// notifications dispatch with the right NewEpoch regardless of which record
-// findLeaseByKey happens to return.
-func TestSetLeaseEpoch_UpdatesAllMatchingRecords(t *testing.T) {
+// TestSetLeaseEpoch_UpdatesEveryRecordOfTheLease asserts the epoch lands on
+// every record of the lease it names, not just the first found: reopens and
+// reclaims can leave more than one record for a key on one file, and missing
+// the one RequestLease just granted leaves it at the createAndGrantLease
+// default while the client's response carries the higher requested epoch.
+func TestSetLeaseEpoch_UpdatesEveryRecordOfTheLease(t *testing.T) {
 	t.Parallel()
 
 	lm := NewManager()
 	leaseKey := [16]byte{0xaa, 0xbb, 0xcc}
 
 	// Seeding unifiedLocks directly skips the mutation paths that maintain the
-	// reverse indexes, so reconcile each bucket the way those paths do —
-	// lease-key lookups resolve through leaseKeyIndex.
+	// reverse indexes, so reconcile the bucket the way those paths do.
 	lm.mu.Lock()
 	lm.unifiedLocks["/share:fileA"] = []*UnifiedLock{
 		{Owner: LockOwner{OwnerID: "oA"}, Lease: &OpLock{LeaseKey: leaseKey, LeaseState: LeaseStateRead, Epoch: 1}},
+		{Owner: LockOwner{OwnerID: "oA2"}, Lease: &OpLock{LeaseKey: leaseKey, LeaseState: LeaseStateRead, Epoch: 1}},
 	}
 	lm.reindexHandleLocked("/share:fileA", nil)
-	lm.unifiedLocks["/share:fileB"] = []*UnifiedLock{
-		{Owner: LockOwner{OwnerID: "oB"}, Lease: &OpLock{LeaseKey: leaseKey, LeaseState: LeaseStateRead, Epoch: 1}},
-	}
-	lm.reindexHandleLocked("/share:fileB", nil)
 	lm.unlock()
 
-	if !lm.SetLeaseEpoch(leaseKey, 7) {
+	if !lm.SetLeaseEpoch("/share:fileA", leaseKey, 7) {
 		t.Fatalf("SetLeaseEpoch returned false, expected true when records exist")
 	}
 
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()
-	for _, handle := range []string{"/share:fileA", "/share:fileB"} {
-		locks := lm.unifiedLocks[handle]
-		if len(locks) != 1 {
-			t.Fatalf("%s: expected 1 record, got %d", handle, len(locks))
+	for i, l := range lm.unifiedLocks["/share:fileA"] {
+		if got := l.Lease.Epoch; got != 7 {
+			t.Errorf("record %d: Epoch = %d, want 7", i, got)
 		}
-		if got := locks[0].Lease.Epoch; got != 7 {
-			t.Errorf("%s: Epoch = %d, want 7", handle, got)
-		}
+	}
+}
+
+// TestSetLeaseEpoch_LeavesOtherFilesSameKeyAlone asserts the epoch stops at the
+// lease it was asked about. A 16-byte lease key is not an identity: the
+// cross-file uniqueness rule is scoped per (client, file), so another client
+// may hold the same value on another file of this share. Folding that client's
+// record into the convergence hands it a NewEpoch no grant of its own produced
+// — and per MS-SMB2 §3.2.5.19.2 a client acts on the SIZE of the jump, purging
+// its cache when the gap exceeds 1 and discarding the break's new lease state
+// outright when it exceeds 32767.
+func TestSetLeaseEpoch_LeavesOtherFilesSameKeyAlone(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	leaseKey := [16]byte{0x11, 0x22, 0x33}
+
+	lm.mu.Lock()
+	lm.unifiedLocks["/share:fileA"] = []*UnifiedLock{
+		{Owner: LockOwner{OwnerID: "oA", ClientID: "clientA"}, Lease: &OpLock{LeaseKey: leaseKey, LeaseState: LeaseStateRead, Epoch: 0x0101}},
+	}
+	lm.reindexHandleLocked("/share:fileA", nil)
+	lm.unifiedLocks["/share:fileB"] = []*UnifiedLock{
+		{Owner: LockOwner{OwnerID: "oB", ClientID: "clientB"}, Lease: &OpLock{LeaseKey: leaseKey, LeaseState: LeaseStateRead, Epoch: 0xF001}},
+	}
+	lm.reindexHandleLocked("/share:fileB", nil)
+	lm.unlock()
+
+	if !lm.SetLeaseEpoch("/share:fileB", leaseKey, 0xF001) {
+		t.Fatalf("SetLeaseEpoch returned false, expected true when records exist")
+	}
+
+	lm.mu.RLock()
+	defer lm.mu.RUnlock()
+	if got := lm.unifiedLocks["/share:fileA"][0].Lease.Epoch; got != 0x0101 {
+		t.Errorf("client A's lease on fileA: Epoch = 0x%x, want 0x0101 — client B's epoch was folded into another client's lease", got)
+	}
+	if got := lm.unifiedLocks["/share:fileB"][0].Lease.Epoch; got != 0xF001 {
+		t.Errorf("client B's lease on fileB: Epoch = 0x%x, want 0xF001", got)
 	}
 }
 
@@ -1269,17 +1299,17 @@ func TestSetLeaseEpoch_ReturnsFalseForUnknownKey(t *testing.T) {
 	t.Parallel()
 
 	lm := NewManager()
-	if lm.SetLeaseEpoch([16]byte{0xff, 0xee}, 5) {
+	if lm.SetLeaseEpoch("/share:fileA", [16]byte{0xff, 0xee}, 5) {
 		t.Fatalf("SetLeaseEpoch returned true for unknown key")
 	}
 }
 
-// TestSetLeaseEpoch_ConvergesDivergentRecords asserts that sibling records
-// sharing a lease key but starting at DIFFERENT epochs all converge to a
-// single epoch — the max of the requested epoch and every record's current
-// epoch. A per-record `if requested >= current` guard would leave the higher
-// record untouched while raising the lower one, so break dispatch could read a
-// non-deterministic NewEpoch depending on map-iteration order.
+// TestSetLeaseEpoch_ConvergesDivergentRecords asserts that sibling records of
+// ONE lease starting at DIFFERENT epochs all converge to a single epoch — the
+// max of the requested epoch and every record's current epoch. A per-record
+// `if requested >= current` guard would leave the higher record untouched while
+// raising the lower one, so a read of the lease, and the break dispatch that
+// follows it, could answer from whichever the slice surfaces first.
 func TestSetLeaseEpoch_ConvergesDivergentRecords(t *testing.T) {
 	t.Parallel()
 
@@ -1289,25 +1319,22 @@ func TestSetLeaseEpoch_ConvergesDivergentRecords(t *testing.T) {
 	lm.mu.Lock()
 	lm.unifiedLocks["/share:fileA"] = []*UnifiedLock{
 		{Owner: LockOwner{OwnerID: "oA"}, Lease: &OpLock{LeaseKey: leaseKey, LeaseState: LeaseStateRead, Epoch: 5}},
+		{Owner: LockOwner{OwnerID: "oA2"}, Lease: &OpLock{LeaseKey: leaseKey, LeaseState: LeaseStateRead, Epoch: 1}},
 	}
 	lm.reindexHandleLocked("/share:fileA", nil)
-	lm.unifiedLocks["/share:fileB"] = []*UnifiedLock{
-		{Owner: LockOwner{OwnerID: "oB"}, Lease: &OpLock{LeaseKey: leaseKey, LeaseState: LeaseStateRead, Epoch: 1}},
-	}
-	lm.reindexHandleLocked("/share:fileB", nil)
 	lm.unlock()
 
 	// Request a lower epoch (4) than the highest existing record (5). All
 	// records must converge to 5 (the max), not split into 5 and 4.
-	if !lm.SetLeaseEpoch(leaseKey, 4) {
+	if !lm.SetLeaseEpoch("/share:fileA", leaseKey, 4) {
 		t.Fatalf("SetLeaseEpoch returned false, expected true when records exist")
 	}
 
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()
-	for _, handle := range []string{"/share:fileA", "/share:fileB"} {
-		if got := lm.unifiedLocks[handle][0].Lease.Epoch; got != 5 {
-			t.Errorf("%s: Epoch = %d, want 5 (all records converge to the max)", handle, got)
+	for i, l := range lm.unifiedLocks["/share:fileA"] {
+		if got := l.Lease.Epoch; got != 5 {
+			t.Errorf("record %d: Epoch = %d, want 5 (all records of one lease converge to the max)", i, got)
 		}
 	}
 }
@@ -1330,7 +1357,7 @@ func TestSetLeaseEpoch_Persists(t *testing.T) {
 	lm.reindexHandleLocked("/share:fileA", nil)
 	lm.unlock()
 
-	if !lm.SetLeaseEpoch(leaseKey, 9) {
+	if !lm.SetLeaseEpoch("/share:fileA", leaseKey, 9) {
 		t.Fatalf("SetLeaseEpoch returned false, expected true")
 	}
 

--- a/pkg/metadata/lock/manager_test.go
+++ b/pkg/metadata/lock/manager_test.go
@@ -1223,10 +1223,12 @@ func TestMergeLocks_DifferentOwners(t *testing.T) {
 }
 
 // TestSetLeaseEpoch_UpdatesEveryRecordOfTheLease asserts the epoch lands on
-// every record of the lease it names, not just the first found: reopens and
-// reclaims can leave more than one record for a key on one file, and missing
-// the one RequestLease just granted leaves it at the createAndGrantLease
-// default while the client's response carries the higher requested epoch.
+// every record of the lease it names, not just the first found. A grant cannot
+// add a second record for a key already on the file and neither can a reclaim;
+// RestoreLocks appends persisted rows without that guard, so more than one can
+// exist. Missing the one RequestLease just granted would leave it at the
+// createAndGrantLease default while the client's response carries the higher
+// requested epoch.
 func TestSetLeaseEpoch_UpdatesEveryRecordOfTheLease(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/metadata/lock/wait_share_conflict_test.go
+++ b/pkg/metadata/lock/wait_share_conflict_test.go
@@ -101,7 +101,7 @@ func TestWaitForShareConflictClear_ReturnsWhenBreakDrainsButConflictPersists(t *
 
 	// The holder's lease must NOT have been force-completed to None: the ACK
 	// already moved it to RW and the wait left it intact.
-	state, _, found := lm.GetLeaseState(ctx, holderKey)
+	state, _, found := lm.GetLeaseState(ctx, "file2", holderKey)
 	require.True(t, found, "holder lease must still exist (not tombstoned)")
 	assert.Equal(t, LeaseStateRead|LeaseStateWrite, state, "ACKed RW must survive — the wait must not force-complete it")
 }


### PR DESCRIPTION
## The premise held, and it is worse than the issue predicted

#2145 filed its own reachability claim as *predicted from a code read, not
demonstrated*, and argued two reasons it might not matter: the convergence only
ever raises an epoch so it cannot break MS-SMB2 monotonicity, and real clients
pick random lease keys.

The first of those is wrong. Monotonicity is not what a client checks.

### What a client actually receives

`internal/adapter/smb/handlers/lease_epoch_identity_test.go` drives two V2 lease
clients through the real grant path (`ProcessLeaseCreateContext`), breaks the
first one's lease with a conflicting open, and reads the `NewEpoch` that the
break dispatch hands the transport notifier. Against the pre-fix scope:

```
client A break NewEpoch = 0xf002, want 0x102 — the epoch came from client B's
counter (B was granted 0xf001 on another file under the same key value)
```

Client A asked for epoch `0x0100` and was granted `0x0101`. Client B's first
grant, on a *different file* under the same 16-byte key value, seeded `0xF001`.
The two-pass max in `SetLeaseEpoch` folded B's counter into A's record, so the
break notification for A's lease carried `0xF002` — 61185 past the last epoch A
ever saw.

That path is not circular: it runs the real grant, the real break dispatch,
`SMBBreakHandler.OnOpLockBreak`, and the notifier that encodes the wire
notification. It is not a unit test asserting that `SetLeaseEpoch` moved a
number.

### The epoch is not a counter. It is a wrapping sequence number.

This is the part worth getting right, because the obvious reading of the code
produces a false sense of safety.

MS-SMB2 §3.2.5.7.5 defines the comparison the client actually performs:

> Δepoch is a **16-bit signed integer** indicating if the Epoch value sent by the
> server is newer than the current Epoch value held by the client. It is
> evaluated as follows:
> 1. If the Epoch value sent by the server is equal to `File.LeaseEpoch`, then
>    Δepoch is 0.
> 2. If the Epoch value sent by the server is not equal to `File.LeaseEpoch` and
>    Epoch minus `File.LeaseEpoch` is **less than or equal to 32767**, then
>    Δepoch is **greater than 0**.

So the epoch is compared **modulo 2^16**, and 32767 is the half-space boundary
between "newer" and "not newer". §3.2.5.19.2 applies the same test to break
notifications: **step 7** copies the new LeaseState into `File.LeaseState` only
when the gap is ≤ 32767, and **step 6** forces a cache purge when the gap
exceeds 1. Step 8's plain-copy fallback covers dialect 2.1 only, so on SMB 3.x
there is no safety net.

**This is what kills the "it only ever raises the epoch, so monotonicity holds"
argument.** That argument presumes there is a monotonic direction to be safe in.
In mod-2^16 comparison there isn't: every value is simultaneously ahead of and
behind every other, and which one the client sees is decided entirely by the
half-space test. "Up" is not a weak guarantee here — it is not defined.

A gap of 61185 does not read to the client as *much newer*. It reads as
**older**. The client does not adopt the break's new lease state, and keeps
caching under a lease the server has already broken.

#### A second surface, stated narrowly

The §3.2.5.7.5 table governs the CREATE response too, not only break
notifications — but the relevant part is one cell, not a row, so here it is
verbatim (rows = state the client currently holds, columns = `LeaseState`
returned in the response):

```
| RWH | Invalid | Invalid | Δepoch=0 : No change<br><br>Δepoch!= 0 : Invalid |  |
```

The claim is only about the **RWH → RWH** cell: a client already holding RWH
that re-opens for the state it already has gets `No change` when Δepoch is 0,
and **Invalid** when it is not. An inflated server epoch makes Δepoch non-zero
on exactly that no-change reopen.

Two things this is *not*, because the row is easy to over-read:

- The `R` and `RH` columns of that row are `Invalid` **regardless of Δepoch** —
  they are downgrades, and the epoch is not what disqualifies them.
- The pattern is not uniform down the table. In the `R` row it is the other way
  round: `R`→`RH` reads `Δepoch=1: Upgrade / Δepoch>1: Upgrade & purge cache. /
  Δepoch=0: Invalid.`, so there `Δepoch = 0` is the invalid one.

Worth noting but not leaning on: the repro in this PR uses **RH**, and the
`RH`→`RH` cell lists only `Δepoch=0` and `Δepoch>0` — it defines no behaviour for
a Δepoch that reads as older. So for the state this PR actually exercises, the
CREATE surface is undefined rather than specified-bad.

**None of this is load-bearing.** The epoch argument rests on §3.2.5.19.2 step 7,
which is quoted above and applies directly to the demonstrated break path. This
paragraph is an additional surface, and it is deliberately scoped to the one
cell that can be checked against the quoted text.

The second reason in the issue stands: real clients pick random keys, so this is
adversarial- and test-shaped rather than something a Windows fleet hits by
accident. That bounds the urgency, not the correctness.

## Root cause

#2139 split lease identity from the lease key value in the SMB adapter, keying
`LeaseManager` on `(ClientID, ShareName, LeaseKey)` and
`(ShareName, HandleKey, LeaseKey)`. It stopped at that boundary. Underneath,
`lock.Manager` still treated the key as the identity.

While the key *was* the identity, "every record matching the key" and "this
lease's records" named the same set, and converging across the whole set was
correct by construction. After the split they are different sets, and the code
still treated them as one.

## The fix: narrow the scope, keep the convergence

The two-pass max stays. It is load-bearing — a per-record
`if epoch >= lock.Lease.Epoch` guard lets sibling records of one lease diverge,
and a read of the lease then answers from whichever the slice surfaces first.
Only its *scope* changes: from every record matching the key, to the records of
the lease on one file. That is the same split #2139 drew one layer up.

### Why narrowing cannot regress `break_twice` / `breaking*` / `v2_breaking3`

Those cases are the reason the multi-record iteration exists, so it is worth
being structural rather than hopeful about it. The smbtorture KNOWN_FAILURES log
records why it was added (#429, "Leases" section):

> The orphaned records accumulated across tests. By the time `break_twice` ran,
> three `LEASE1` records sat in **the same file's bucket** (two from prior tests
> where cleanup was skipped, one freshly granted).

The siblings that broke `break_twice` were **co-located on one file**, and the
companion fix in that same change — `ReleaseLeaseForHandle`, which scopes
cleanup to one bucket — removed the accumulation cause. The cross-*file* reach
was incidental over-scope, never what those tests needed. The narrowed
convergence still covers every within-file sibling, which is the entire set
those cases exercise.

None of `break_twice`, `breaking*` or `v2_breaking3` is listed in
KNOWN_FAILURES, so they are expected-pass and CI's smbtorture job is a live
guard on this, not a formality.

Three `lock.Manager` methods now take the file:

| | before | after |
| --- | --- | --- |
| `GetLeaseState` | `(ctx, leaseKey)` | `(ctx, handleKey, leaseKey)` |
| `SetLeaseEpoch` | `(leaseKey, epoch)` | `(handleKey, leaseKey, epoch)` |
| `IsTraditionalOplockForKey` | `(leaseKey)` | `(handleKey, leaseKey)` |

They resolve through a new `leaseRecordsOnHandleLocked` instead of
`findLeaseByKey`, whose own doc has always said which holder it returns is
unspecified.

**Narrowing the write alone would have been a half-fix.** `getLeaseStateImpl`
read through the same ambiguous `findLeaseByKey`; the convergence was masking
that by making every candidate's epoch equal. Scoping the write without the read
would have traded a wrong-but-deterministic epoch for a non-deterministic one at
`create.go`'s replay path and `handler.go`'s durable-disconnect persist — both of
which put that epoch back on the wire. The read and the write of one field had to
move together.

Every call site already had the file in hand (`rootHandle`, `lockFileHandle`,
`openFile.MetadataHandle`), so no new plumbing was needed.

### The invariant this rests on

The whole change is only correct if **the handle used at grant time equals the
handle used at read/write time on every path** — a mismatch returns
`found=false` silently and drops a lease's persisted epoch rather than erroring,
which no test would catch. Traced on all six paths:

| path | grant | read/write |
| --- | --- | --- |
| share root | `create.go:1910` `lock.FileHandle(rootHandle)` | `:1937` `MetadataHandle: rootHandle` |
| normal open | `create_post_break.go:980/1010` `lock.FileHandle(fileHandle)` | `:1282` `MetadataHandle: fileHandle` |
| durable reconnect | `create.go:875` `lock.FileHandle(restored.MetadataHandle)` | `:950` `SetLeaseEpoch(lockFileHandle, …)` |
| replay cache | original grant's `OpenFile` | `create.go:1706` `open.MetadataHandle` |
| durable disconnect | original grant's `OpenFile` | `handler.go:1419` `openFile.MetadataHandle` |
| write / BR-lock self-exclude | — | `lease/manager.go:844,1367`, `handleKey` from the same `fileHandle` the break targets |

## Scope turned out narrower than the issue's list

The issue named five key-only sites. Only the epoch/state axis decided a
wire-visible value. What remains key-only, deliberately, and is **not** shown to
be defective here:

Both of the remaining lease-key-only paths are now filed as **#2150**, with the
observation that would settle each and an explicit note that neither is
demonstrated.

- `acknowledgeLeaseBreakImpl` and `clearBreakingSiblingsLocked` — the
  LEASE_BREAK_ACK path is given only a lease key on the wire. #2139's
  `resolveAckBinding` already resolves `(client, share, key) → HandleKey` one
  layer up and could push it down. Worth flagging honestly: reading
  `clearBreakingSiblingsLocked` (leases.go:1185), it walks every bucket in
  `leaseKeyIndex[leaseKey]` and copies the acking record's `LeaseState` onto any
  *Breaking* record with the same key value — including another client's, on
  another file. That is structurally the same defect on a different axis. It is
  **predicted from a code read only**; nothing here demonstrates it, and fixing
  it means changing ack routing, which is heavily exercised by smbtorture. It
  belongs in its own change, not smuggled into this one.
- `reclaimLeaseImpl` — grace-period reclaim, same shape.
- `releaseLeaseImpl` — scans every bucket **by design**; release must scrub the
  key everywhere.

## Verification

- New handler-level regression test, failing before and passing after, driven
  through grant → break dispatch → notifier.
- `go build ./... && go vet ./... && go test ./...` green.
- `go test -race ./pkg/metadata/lock/... ./internal/adapter/smb/...` green.
- The convergence guards the issue named — `break_twice`, `breaking*`,
  `v2_breaking3` — run in CI's smbtorture job on this PR.

Two `pkg/metadata/lock` unit tests asserted the cross-file convergence directly
(`TestSetLeaseEpoch_UpdatesAllMatchingRecords`,
`TestSetLeaseEpoch_ConvergesDivergentRecords`). They were pinning the pre-split
assumption, so they are rewritten to pin the same convergence at the correct
scope, plus a new `TestSetLeaseEpoch_LeavesOtherFilesSameKeyAlone` for the
boundary.

One test fixture (`grantRWHLease` in `replay_dhv2_test.go`) granted its lease on
`file-1` but returned an `OpenFile` with no `MetadataHandle`. That was invisible
while lookup was by key alone. Setting the field is a fixture correction, not a
weakened assertion — production sets it at both construction sites.

### One claim walked back

An earlier draft of the `SetLeaseEpoch` comment said "reopens and reclaims can
leave more than one record for a key on one file". Review could not find a path
for either, and it was right: `resolveSameKeyLeaseLocked` makes a same-key grant
reuse the existing record, and `reclaimLeaseImpl` guards on `findLeaseByKey`
before appending. The one path that genuinely appends without a same-key guard is
`RestoreLocks` (`manager.go:1362`). The comment now names that instead of a
mechanism that does not exist. The multi-record loop stays either way — it is
what makes the convergence a convergence — but the comment should not assert
reachability nobody has shown.

The stale `sessionMap` comment rider in the issue is deliberately untouched;
those files are held by concurrent work on #2132.

Closes #2145
