### PR TITLE
fix(smb): give buffered notify events to the earliest outstanding request

### DIFF
--- a/internal/adapter/smb/handlers/change_notify.go
+++ b/internal/adapter/smb/handlers/change_notify.go
@@ -249,10 +249,13 @@ type NotifyRegistry struct {
 
 	// inFlightNotify tracks CHANGE_NOTIFY requests that the connection's read
 	// loop has read off the wire but whose handlers have not finished, keyed
-	// by handle. The read loop is sequential, so a lower MessageID here was
-	// necessarily received first even when its goroutine has not run yet.
-	// That is what lets a later request tell it is later. See
-	// HasEarlierInFlightNotify.
+	// by handle. The read loop is sequential and appends here in arrival
+	// order, so element 0 is the earliest-received request still outstanding.
+	//
+	// Order is the slice's, NOT the MessageID's. SMB2 clients may consume
+	// MessageIDs out of order within the credit sequence window, so a numeric
+	// comparison would call 100 "later" than 50 even when 100 arrived first.
+	// See HasEarlierInFlightNotify.
 	//
 	// ponytail: linear scan of a slice. N is one client's CHANGE_NOTIFY
 	// pipelining depth on one handle — 1 or 2 in practice — so a map costs
@@ -1609,22 +1612,22 @@ func (r *NotifyRegistry) MarkNotifyInFlight(fileID [16]byte, messageID uint64) f
 }
 
 // HasEarlierInFlightNotify reports whether another CHANGE_NOTIFY on the same
-// handle was received before messageID and is still unanswered.
+// handle arrived before messageID and is still unanswered.
 //
 // A request that answers yes must not claim buffered events: they belong to the
 // earlier request, which is the one the client is blocked on. Handing them to
 // the later request leaves the earlier one waiting for an event the client will
 // never generate, because the client does not send it until the earlier request
 // returns.
+//
+// "Earlier" means earlier on the wire, which is this slice's append order —
+// never a MessageID comparison. MessageIDs may be consumed out of order within
+// the credit sequence window, so 100 can arrive before 50.
 func (r *NotifyRegistry) HasEarlierInFlightNotify(fileID [16]byte, messageID uint64) bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	for _, id := range r.inFlightNotify[string(fileID[:])] {
-		if id < messageID {
-			return true
-		}
-	}
-	return false
+	ids := r.inFlightNotify[string(fileID[:])]
+	return len(ids) > 0 && ids[0] != messageID
 }
 
 // UnregisterAllForSession unregisters all pending watchers for a session AND

--- a/internal/adapter/smb/handlers/change_notify.go
+++ b/internal/adapter/smb/handlers/change_notify.go
@@ -247,6 +247,19 @@ type NotifyRegistry struct {
 	byMsgKey  map[notifyMsgKey]*PendingNotify
 	byAsyncId map[uint64]*PendingNotify // asyncId -> pending request (for async CANCEL)
 
+	// inFlightNotify tracks CHANGE_NOTIFY requests that the connection's read
+	// loop has read off the wire but whose handlers have not finished, keyed
+	// by handle. The read loop is sequential, so a lower MessageID here was
+	// necessarily received first even when its goroutine has not run yet.
+	// That is what lets a later request tell it is later. See
+	// HasEarlierInFlightNotify.
+	//
+	// ponytail: linear scan of a slice. N is one client's CHANGE_NOTIFY
+	// pipelining depth on one handle — 1 or 2 in practice — so a map costs
+	// more than it saves. Swap for an ordered structure only if a client
+	// appears that pipelines notifies deeply enough to measure.
+	inFlightNotify map[string][]uint64
+
 	// armed tracks directory handles that have at some point issued a
 	// CHANGE_NOTIFY. Mirrors Samba `notify_buffer`: once a watcher has been
 	// "armed" on a handle, subsequent matching filesystem events MUST be
@@ -374,6 +387,7 @@ func NewNotifyRegistry() *NotifyRegistry {
 		byFileID:         make(map[string]*PendingNotify),
 		byMsgKey:         make(map[notifyMsgKey]*PendingNotify),
 		byAsyncId:        make(map[uint64]*PendingNotify),
+		inFlightNotify:   make(map[string][]uint64),
 		armed:            make(map[string]*armedHandle),
 		cancelTombstones: make(map[notifyMsgKey]time.Time),
 		closeTombstones:  make(map[string]time.Time),
@@ -1566,6 +1580,51 @@ func (r *NotifyRegistry) NotifyRmdir(shareName, parentPath, dirName string) {
 
 	// Second: notify parent watchers about the directory removal
 	r.NotifyChange(shareName, parentPath, dirName, FileActionRemoved, FileNotifyChangeDirName)
+}
+
+// MarkNotifyInFlight records that a CHANGE_NOTIFY for fileID has been read off
+// the wire, and returns the function that clears it when the handler is done.
+// Called from the connection read loop, before dispatch, for CHANGE_NOTIFY only
+// — every other command's path is untouched.
+func (r *NotifyRegistry) MarkNotifyInFlight(fileID [16]byte, messageID uint64) func() {
+	key := string(fileID[:])
+	r.mu.Lock()
+	r.inFlightNotify[key] = append(r.inFlightNotify[key], messageID)
+	r.mu.Unlock()
+
+	return func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		ids := r.inFlightNotify[key]
+		for i, id := range ids {
+			if id == messageID {
+				r.inFlightNotify[key] = append(ids[:i], ids[i+1:]...)
+				break
+			}
+		}
+		if len(r.inFlightNotify[key]) == 0 {
+			delete(r.inFlightNotify, key)
+		}
+	}
+}
+
+// HasEarlierInFlightNotify reports whether another CHANGE_NOTIFY on the same
+// handle was received before messageID and is still unanswered.
+//
+// A request that answers yes must not claim buffered events: they belong to the
+// earlier request, which is the one the client is blocked on. Handing them to
+// the later request leaves the earlier one waiting for an event the client will
+// never generate, because the client does not send it until the earlier request
+// returns.
+func (r *NotifyRegistry) HasEarlierInFlightNotify(fileID [16]byte, messageID uint64) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, id := range r.inFlightNotify[string(fileID[:])] {
+		if id < messageID {
+			return true
+		}
+	}
+	return false
 }
 
 // UnregisterAllForSession unregisters all pending watchers for a session AND

--- a/internal/adapter/smb/handlers/change_notify.go
+++ b/internal/adapter/smb/handlers/change_notify.go
@@ -255,13 +255,18 @@ type NotifyRegistry struct {
 	// Order is the slice's, NOT the MessageID's. SMB2 clients may consume
 	// MessageIDs out of order within the credit sequence window, so a numeric
 	// comparison would call 100 "later" than 50 even when 100 arrived first.
-	// See HasEarlierInFlightNotify.
+	//
+	// Entries are (ConnID, MessageID) because MessageID is scoped per TCP
+	// connection. A FileID is valid on every channel of a session, so under
+	// SMB3 multichannel two notifies on one handle can arrive on different
+	// connections carrying the SAME MessageID — and a bare MessageID could
+	// not tell them apart. See HasEarlierInFlightNotify.
 	//
 	// ponytail: linear scan of a slice. N is one client's CHANGE_NOTIFY
 	// pipelining depth on one handle — 1 or 2 in practice — so a map costs
 	// more than it saves. Swap for an ordered structure only if a client
 	// appears that pipelines notifies deeply enough to measure.
-	inFlightNotify map[string][]uint64
+	inFlightNotify map[string][]notifyMsgKey
 
 	// armed tracks directory handles that have at some point issued a
 	// CHANGE_NOTIFY. Mirrors Samba `notify_buffer`: once a watcher has been
@@ -390,7 +395,7 @@ func NewNotifyRegistry() *NotifyRegistry {
 		byFileID:         make(map[string]*PendingNotify),
 		byMsgKey:         make(map[notifyMsgKey]*PendingNotify),
 		byAsyncId:        make(map[uint64]*PendingNotify),
-		inFlightNotify:   make(map[string][]uint64),
+		inFlightNotify:   make(map[string][]notifyMsgKey),
 		armed:            make(map[string]*armedHandle),
 		cancelTombstones: make(map[notifyMsgKey]time.Time),
 		closeTombstones:  make(map[string]time.Time),
@@ -1589,10 +1594,11 @@ func (r *NotifyRegistry) NotifyRmdir(shareName, parentPath, dirName string) {
 // the wire, and returns the function that clears it when the handler is done.
 // Called from the connection read loop, before dispatch, for CHANGE_NOTIFY only
 // — every other command's path is untouched.
-func (r *NotifyRegistry) MarkNotifyInFlight(fileID [16]byte, messageID uint64) func() {
+func (r *NotifyRegistry) MarkNotifyInFlight(fileID [16]byte, connID, messageID uint64) func() {
 	key := string(fileID[:])
+	mk := notifyMsgKey{ConnID: connID, MessageID: messageID}
 	r.mu.Lock()
-	r.inFlightNotify[key] = append(r.inFlightNotify[key], messageID)
+	r.inFlightNotify[key] = append(r.inFlightNotify[key], mk)
 	r.mu.Unlock()
 
 	return func() {
@@ -1604,7 +1610,7 @@ func (r *NotifyRegistry) MarkNotifyInFlight(fileID [16]byte, messageID uint64) f
 		// later comparison. Shift, do not swap.
 		ids := r.inFlightNotify[key]
 		for i, id := range ids {
-			if id == messageID {
+			if id == mk {
 				r.inFlightNotify[key] = append(ids[:i], ids[i+1:]...)
 				break
 			}
@@ -1627,11 +1633,11 @@ func (r *NotifyRegistry) MarkNotifyInFlight(fileID [16]byte, messageID uint64) f
 // "Earlier" means earlier on the wire, which is this slice's append order —
 // never a MessageID comparison. MessageIDs may be consumed out of order within
 // the credit sequence window, so 100 can arrive before 50.
-func (r *NotifyRegistry) HasEarlierInFlightNotify(fileID [16]byte, messageID uint64) bool {
+func (r *NotifyRegistry) HasEarlierInFlightNotify(fileID [16]byte, connID, messageID uint64) bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	ids := r.inFlightNotify[string(fileID[:])]
-	return len(ids) > 0 && ids[0] != messageID
+	return len(ids) > 0 && ids[0] != notifyMsgKey{ConnID: connID, MessageID: messageID}
 }
 
 // UnregisterAllForSession unregisters all pending watchers for a session AND

--- a/internal/adapter/smb/handlers/change_notify.go
+++ b/internal/adapter/smb/handlers/change_notify.go
@@ -1598,6 +1598,10 @@ func (r *NotifyRegistry) MarkNotifyInFlight(fileID [16]byte, messageID uint64) f
 	return func() {
 		r.mu.Lock()
 		defer r.mu.Unlock()
+		// Order-preserving removal is REQUIRED: ids[0] is the earliest
+		// arrival, so a swap-remove (ids[i] = ids[len-1]) would silently
+		// reorder the tail and make HasEarlierInFlightNotify wrong for every
+		// later comparison. Shift, do not swap.
 		ids := r.inFlightNotify[key]
 		for i, id := range ids {
 			if id == messageID {

--- a/internal/adapter/smb/handlers/change_notify.go
+++ b/internal/adapter/smb/handlers/change_notify.go
@@ -249,8 +249,10 @@ type NotifyRegistry struct {
 
 	// inFlightNotify tracks CHANGE_NOTIFY requests that the connection's read
 	// loop has read off the wire but whose handlers have not finished, keyed
-	// by handle. The read loop is sequential and appends here in arrival
-	// order, so element 0 is the earliest-received request still outstanding.
+	// by handle. Each connection's read loop is sequential, and under
+	// multichannel several of them append here under this registry's one
+	// mutex — so the slice records a real arrival order across connections,
+	// and element 0 is the earliest-received request still outstanding.
 	//
 	// Order is the slice's, NOT the MessageID's. SMB2 clients may consume
 	// MessageIDs out of order within the credit sequence window, so a numeric

--- a/internal/adapter/smb/handlers/change_notify_inflight_test.go
+++ b/internal/adapter/smb/handlers/change_notify_inflight_test.go
@@ -1,0 +1,36 @@
+package handlers
+
+import "testing"
+
+// The double-notify hazard: two CHANGE_NOTIFYs read in order 9,10 on one
+// handle, dispatched in order 10,9. Request 10 must decline the buffered
+// events so request 9 — the one the client is blocked on — can take them.
+func TestHasEarlierInFlightNotify(t *testing.T) {
+	r := NewNotifyRegistry()
+	fid := [16]byte{1}
+	other := [16]byte{2}
+
+	// Read loop records both, in wire order, before either is dispatched.
+	done9 := r.MarkNotifyInFlight(fid, 9)
+	done10 := r.MarkNotifyInFlight(fid, 10)
+
+	if !r.HasEarlierInFlightNotify(fid, 10) {
+		t.Error("msgID 10 must see msgID 9 outstanding and decline the events")
+	}
+	if r.HasEarlierInFlightNotify(fid, 9) {
+		t.Error("msgID 9 is the earliest; it must take the events")
+	}
+	if r.HasEarlierInFlightNotify(other, 10) {
+		t.Error("a different handle must not be blocked by this one")
+	}
+
+	// Once 9 is answered, a later notify on the handle is free again.
+	done9()
+	if r.HasEarlierInFlightNotify(fid, 10) {
+		t.Error("msgID 9 is done; msgID 10 must no longer decline")
+	}
+	done10()
+	if len(r.inFlightNotify) != 0 {
+		t.Errorf("tracking leaked: %v", r.inFlightNotify)
+	}
+}

--- a/internal/adapter/smb/handlers/change_notify_inflight_test.go
+++ b/internal/adapter/smb/handlers/change_notify_inflight_test.go
@@ -34,3 +34,25 @@ func TestHasEarlierInFlightNotify(t *testing.T) {
 		t.Errorf("tracking leaked: %v", r.inFlightNotify)
 	}
 }
+
+// MessageIDs may be consumed out of order within the credit sequence window,
+// so 100 can arrive before 50. Arrival order decides, not the number.
+func TestHasEarlierInFlightNotify_OutOfOrderMessageIDs(t *testing.T) {
+	r := NewNotifyRegistry()
+	fid := [16]byte{1}
+
+	done100 := r.MarkNotifyInFlight(fid, 100) // arrived first
+	done50 := r.MarkNotifyInFlight(fid, 50)   // arrived second, lower number
+
+	if r.HasEarlierInFlightNotify(fid, 100) {
+		t.Error("100 arrived first; it must take the events despite the higher number")
+	}
+	if !r.HasEarlierInFlightNotify(fid, 50) {
+		t.Error("50 arrived second; it must decline despite the lower number")
+	}
+	done100()
+	if r.HasEarlierInFlightNotify(fid, 50) {
+		t.Error("50 is now the earliest outstanding; it must take the events")
+	}
+	done50()
+}

--- a/internal/adapter/smb/handlers/change_notify_inflight_test.go
+++ b/internal/adapter/smb/handlers/change_notify_inflight_test.go
@@ -11,22 +11,22 @@ func TestHasEarlierInFlightNotify(t *testing.T) {
 	other := [16]byte{2}
 
 	// Read loop records both, in wire order, before either is dispatched.
-	done9 := r.MarkNotifyInFlight(fid, 9)
-	done10 := r.MarkNotifyInFlight(fid, 10)
+	done9 := r.MarkNotifyInFlight(fid, 1, 9)
+	done10 := r.MarkNotifyInFlight(fid, 1, 10)
 
-	if !r.HasEarlierInFlightNotify(fid, 10) {
+	if !r.HasEarlierInFlightNotify(fid, 1, 10) {
 		t.Error("msgID 10 must see msgID 9 outstanding and decline the events")
 	}
-	if r.HasEarlierInFlightNotify(fid, 9) {
+	if r.HasEarlierInFlightNotify(fid, 1, 9) {
 		t.Error("msgID 9 is the earliest; it must take the events")
 	}
-	if r.HasEarlierInFlightNotify(other, 10) {
+	if r.HasEarlierInFlightNotify(other, 1, 10) {
 		t.Error("a different handle must not be blocked by this one")
 	}
 
 	// Once 9 is answered, a later notify on the handle is free again.
 	done9()
-	if r.HasEarlierInFlightNotify(fid, 10) {
+	if r.HasEarlierInFlightNotify(fid, 1, 10) {
 		t.Error("msgID 9 is done; msgID 10 must no longer decline")
 	}
 	done10()
@@ -41,17 +41,17 @@ func TestHasEarlierInFlightNotify_OutOfOrderMessageIDs(t *testing.T) {
 	r := NewNotifyRegistry()
 	fid := [16]byte{1}
 
-	done100 := r.MarkNotifyInFlight(fid, 100) // arrived first
-	done50 := r.MarkNotifyInFlight(fid, 50)   // arrived second, lower number
+	done100 := r.MarkNotifyInFlight(fid, 1, 100) // arrived first
+	done50 := r.MarkNotifyInFlight(fid, 1, 50)   // arrived second, lower number
 
-	if r.HasEarlierInFlightNotify(fid, 100) {
+	if r.HasEarlierInFlightNotify(fid, 1, 100) {
 		t.Error("100 arrived first; it must take the events despite the higher number")
 	}
-	if !r.HasEarlierInFlightNotify(fid, 50) {
+	if !r.HasEarlierInFlightNotify(fid, 1, 50) {
 		t.Error("50 arrived second; it must decline despite the lower number")
 	}
 	done100()
-	if r.HasEarlierInFlightNotify(fid, 50) {
+	if r.HasEarlierInFlightNotify(fid, 1, 50) {
 		t.Error("50 is now the earliest outstanding; it must take the events")
 	}
 	done50()
@@ -64,21 +64,47 @@ func TestHasEarlierInFlightNotify_FirstReleasePromotesSecond(t *testing.T) {
 	r := NewNotifyRegistry()
 	fid := [16]byte{1}
 
-	doneA := r.MarkNotifyInFlight(fid, 10) // arrived 1st
-	doneB := r.MarkNotifyInFlight(fid, 20) // arrived 2nd
-	doneC := r.MarkNotifyInFlight(fid, 30) // arrived 3rd
+	doneA := r.MarkNotifyInFlight(fid, 1, 10) // arrived 1st
+	doneB := r.MarkNotifyInFlight(fid, 1, 20) // arrived 2nd
+	doneC := r.MarkNotifyInFlight(fid, 1, 30) // arrived 3rd
 
 	doneA() // earliest is answered
 
-	if r.HasEarlierInFlightNotify(fid, 20) {
+	if r.HasEarlierInFlightNotify(fid, 1, 20) {
 		t.Error("20 arrived before 30, so it is now the earliest and must take the events")
 	}
-	if !r.HasEarlierInFlightNotify(fid, 30) {
+	if !r.HasEarlierInFlightNotify(fid, 1, 30) {
 		t.Error("30 is the newest; 20 is still outstanding ahead of it")
 	}
 	doneB()
 	doneC()
 	if len(r.inFlightNotify) != 0 {
 		t.Errorf("tracking leaked: %v", r.inFlightNotify)
+	}
+}
+
+// SMB3 multichannel: one session spans several TCP connections and a FileID is
+// valid on all of them, so two notifies on one handle can arrive on different
+// connections carrying the SAME MessageID. Identity is (ConnID, MessageID).
+func TestHasEarlierInFlightNotify_SameMessageIDDifferentConns(t *testing.T) {
+	r := NewNotifyRegistry()
+	fid := [16]byte{1}
+
+	doneA := r.MarkNotifyInFlight(fid, 1, 10) // conn 1, arrived first
+	doneB := r.MarkNotifyInFlight(fid, 2, 10) // conn 2, same number, arrived second
+
+	if r.HasEarlierInFlightNotify(fid, 1, 10) {
+		t.Error("conn 1's request arrived first; it must take the events")
+	}
+	if !r.HasEarlierInFlightNotify(fid, 2, 10) {
+		t.Error("conn 2's request must decline: conn 1's identically-numbered request is ahead of it")
+	}
+	doneA()
+	if r.HasEarlierInFlightNotify(fid, 2, 10) {
+		t.Error("conn 1 released; conn 2 is now earliest and must take the events")
+	}
+	doneB()
+	if len(r.inFlightNotify) != 0 {
+		t.Errorf("release removed the wrong entry: %v", r.inFlightNotify)
 	}
 }

--- a/internal/adapter/smb/handlers/change_notify_inflight_test.go
+++ b/internal/adapter/smb/handlers/change_notify_inflight_test.go
@@ -56,3 +56,29 @@ func TestHasEarlierInFlightNotify_OutOfOrderMessageIDs(t *testing.T) {
 	}
 	done50()
 }
+
+// Releasing the earliest must promote the SECOND arrival, not the last one.
+// A swap-remove moves the tail element into slot 0, which would make the
+// newest request look like the oldest.
+func TestHasEarlierInFlightNotify_FirstReleasePromotesSecond(t *testing.T) {
+	r := NewNotifyRegistry()
+	fid := [16]byte{1}
+
+	doneA := r.MarkNotifyInFlight(fid, 10) // arrived 1st
+	doneB := r.MarkNotifyInFlight(fid, 20) // arrived 2nd
+	doneC := r.MarkNotifyInFlight(fid, 30) // arrived 3rd
+
+	doneA() // earliest is answered
+
+	if r.HasEarlierInFlightNotify(fid, 20) {
+		t.Error("20 arrived before 30, so it is now the earliest and must take the events")
+	}
+	if !r.HasEarlierInFlightNotify(fid, 30) {
+		t.Error("30 is the newest; 20 is still outstanding ahead of it")
+	}
+	doneB()
+	doneC()
+	if len(r.inFlightNotify) != 0 {
+		t.Errorf("tracking leaked: %v", r.inFlightNotify)
+	}
+}

--- a/internal/adapter/smb/handlers/stub_handlers.go
+++ b/internal/adapter/smb/handlers/stub_handlers.go
@@ -674,7 +674,15 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 	// This runs before the cancel tombstone is consulted in Register. The
 	// tombstone's job is to stop a watch being armed that would wait forever;
 	// it has no say over events that already exist.
-	if changes := h.NotifyRegistry.TakeBufferedEvents(req.FileID, effectiveFilter, watchTree); len(changes) > 0 {
+	// ...but only if this is the earliest CHANGE_NOTIFY still outstanding on
+	// the handle. A client that pipelines two notifies blocks on the first and
+	// does not generate the next event until it returns, so letting the second
+	// take the buffered events strands the first forever.
+	var changes []FileNotifyInformation
+	if !h.NotifyRegistry.HasEarlierInFlightNotify(req.FileID, ctx.MessageID) {
+		changes = h.NotifyRegistry.TakeBufferedEvents(req.FileID, effectiveFilter, watchTree)
+	}
+	if len(changes) > 0 {
 		buffer := EncodeFileNotifyInformation(changes)
 		if uint32(len(buffer)) > effectiveMax {
 			// Too big for the advertised buffer: the client must re-enumerate,

--- a/internal/adapter/smb/handlers/stub_handlers.go
+++ b/internal/adapter/smb/handlers/stub_handlers.go
@@ -679,7 +679,7 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 	// does not generate the next event until it returns, so letting the second
 	// take the buffered events strands the first forever.
 	var changes []FileNotifyInformation
-	if !h.NotifyRegistry.HasEarlierInFlightNotify(req.FileID, ctx.MessageID) {
+	if !h.NotifyRegistry.HasEarlierInFlightNotify(req.FileID, ctx.ConnID, ctx.MessageID) {
 		changes = h.NotifyRegistry.TakeBufferedEvents(req.FileID, effectiveFilter, watchTree)
 	}
 	if len(changes) > 0 {

--- a/pkg/adapter/smb/connection.go
+++ b/pkg/adapter/smb/connection.go
@@ -393,7 +393,7 @@ func (c *Connection) Serve(ctx context.Context) {
 				// CHANGE_NOTIFY pays for this; every other command's path is
 				// unchanged.
 				if hdr.Command == types.CommandChangeNotify {
-					releaseNotify := c.server.handler.NotifyRegistry.MarkNotifyInFlight(fid, hdr.MessageID)
+					releaseNotify := c.server.handler.NotifyRegistry.MarkNotifyInFlight(fid, ci.ConnID, hdr.MessageID)
 					releaseHandleOp = func(prev func()) func() {
 						return func() {
 							releaseNotify()

--- a/pkg/adapter/smb/connection.go
+++ b/pkg/adapter/smb/connection.go
@@ -385,6 +385,22 @@ func (c *Connection) Serve(ctx context.Context) {
 		if len(remainingCompound) == 0 && hdr.Command != types.CommandClose {
 			if fid, ok := smb.ExtractRequestFileID(hdr.Command, body); ok {
 				releaseHandleOp = c.server.handler.BeginHandleOp(fid)
+
+				// Record CHANGE_NOTIFY arrival order before dispatch. This loop
+				// is sequential, so a notify recorded here was demonstrably
+				// received before any later one — which the handler goroutines,
+				// scheduled in any order, cannot otherwise tell. Only
+				// CHANGE_NOTIFY pays for this; every other command's path is
+				// unchanged.
+				if hdr.Command == types.CommandChangeNotify {
+					releaseNotify := c.server.handler.NotifyRegistry.MarkNotifyInFlight(fid, hdr.MessageID)
+					releaseHandleOp = func(prev func()) func() {
+						return func() {
+							releaseNotify()
+							prev()
+						}
+					}(releaseHandleOp)
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes the **hang** #2147 names. `smb2.notify.double` no longer hangs: 5/5 runs
graded in 7-9s.

## It does NOT make `double` pass, and the suite still times out

Stating both first so nobody has to find them later.

**`double` remains order-dependent.** The hang is gone in both dispatch orders,
but the outcome still is not:

| dispatch order | before this PR | after |
| --- | --- | --- |
| earliest request wins | `success` | `success` |
| later request wins | **hang** | graded `failure` in 7-9s |

When the later request wins it now declines the buffered events (correct) and
registers — and then the earlier request registers too, which trips **#2129**:
`Register` holds one watch per FileID, so the second registration evicts the
first and completes it with `STATUS_CANCELLED`. The client fails with

```
Incorrect status NT_STATUS_CANCELLED - should be NT_STATUS_OK
(../../source4/torture/smb2/notify.c:1808)
```

My five local runs all hit the losing order; CI hit the winning one and reports
`smb2.notify.double PASS`. Both are real — that is what order-dependent means.
`double` needs #2129 as well before it passes deterministically. If you run it
locally and see a failure, a pass is equally expected — that is what
order-dependent means, and neither observation is the whole picture.

**#2129 is now reproducible deterministically in the losing order specifically**
— the later request registers, the earlier registers behind it, and `Register`
evicts one. Whoever takes #2129 can rely on that rather than hoping for the
right draw. #2129 has been updated with the evidence.

**`smb2.notify` still times out at 120s**, from this PR's own CI run:

```
smbtorture timed out after 120s on filter: smb2.notify — tests it had not
reached are UNGRADED (inconclusive)
```

A `pass` on the `smbtorture` job means no new failures outside
`KNOWN_FAILURES.md`; it does not mean the suite ran to completion. What this PR
buys is the four tests between `double` and `rmdir` — `file`, `tcp`, `rec`,
`overflow` — which a hang left ungraded and which now grade. Getting the suite
inside its budget needs #2132, which removes `rmdir1`-`rmdir4`'s ~1200s.

## The bug

A client that pipelines two CHANGE_NOTIFYs on one handle blocks on the first and
does not generate the next event until it returns:

```c
req1 = smb2_notify_send(tree1, &(notify.smb2));
req2 = smb2_notify_send(tree1, &(notify.smb2));
status = smb2_notify_recv(req1, torture, &(notify.smb2));   /* blocks here */
CHECK_STATUS(status, NT_STATUS_OK);
smb2_util_mkdir(tree2, BASEDIR_NDOH "\\subdir-name2");      /* not reached */
```

The connection read loop is sequential but hands each request to its own
goroutine, so the second could be dispatched first, take the buffered events,
and strand the first on an event that would never arrive:

```
Dispatching   CHANGE_NOTIFY messageID=10     <- dispatched first
CHANGE_NOTIFY: answered from buffered events without going pending ... messageID=10
Sent SMB2 response CHANGE_NOTIFY status=STATUS_PENDING messageID=9
<nothing>
```

## The fix

The read loop already knows the answer: it reads in wire order, so a notify
recorded there was received before any later one, however the goroutines are
then scheduled. Record CHANGE_NOTIFY arrivals per handle before dispatch, and
have a request decline the buffered events when an earlier one on the same
handle is still unanswered.

**Scoped to CHANGE_NOTIFY on the same handle.** A broader "any earlier request"
test would make a notify decline events because some unrelated operation was in
flight — which is exactly what `smb2.notify.tree` depends on not happening.

**`BeginHandleOp` is untouched.** The new bookkeeping is gated on
`hdr.Command == types.CommandChangeNotify`, so every other command's path
through the read loop is unchanged: no lock, no map, no allocation. Storage is a
slice under the registry's existing mutex, `ponytail:`-marked with the
pipelining depth that would justify an ordered structure.

## Relationship to #2127 — not addressed

Spelled out mechanically so nobody has to infer it:

- changes **which request claims already-buffered events**
- does **not** change the order requests are dispatched in
- does **not** change the order responses are written in
- involves no notification ordering; the dispatcher is unmodified

#2127 is a break notification owed by request N not reaching the wire before
N+1's response. Untouched. It stays open.

## Verification

Ran on the merged tree, `--profile memory`:

| test | runs | result |
| --- | --- | --- |
| `double` | 5 | graded `failure` in 7-9s every time — **no hang** |
| `tree` | 3 | `success` 3/3 — the regression check |
| `mask` | 1 | `success` — synchronous path undisturbed |

`double` × 5 because it is order-dependent and one green run proves nothing —
that is how this regression shipped in the first place. `tree` × 3 because the
scoping condition above is the only thing stopping this fix from trading
`double` for `tree`. `mask` because "an argument that a test cannot be affected"
is not the same object as "the test passed".

Unit test `TestHasEarlierInFlightNotify` encodes the hazard directly: read 9
then 10, assert 10 declines and 9 takes, a different handle is unaffected, and
the tracking does not leak after both release.

Closes #2147
