### PR TITLE
ci(smb-compat): gate the Windows 445 bind on the same flag as the assertions

### DIFF
--- a/.github/workflows/smb-client-compat.yml
+++ b/.github/workflows/smb-client-compat.yml
@@ -394,13 +394,26 @@ jobs:
           .\dfsctl.exe share create --name /smbbasic --metadata mem-meta --local mem-payload
           .\dfsctl.exe user create --username test --password 'testpass123'
           .\dfsctl.exe share permission grant /smbbasic --user test --level read-write
-          # Bind DittoFS to 445 — the only port `net use` can reach (445 was
-          # freed above by stopping the in-box SMB server).
-          .\dfsctl.exe adapter enable smb --port 445
+          # Bind DittoFS to 445 — the only port `net use` can reach (445 is
+          # freed above by stopping the in-box SMB server). Gated on the same
+          # measurement that gates the assertions: when the kernel listener
+          # kept 445 the bind cannot succeed, and running it anyway fails the
+          # step and kills the job at bootstrap for the precondition the rest
+          # of this job is written to tolerate. When 445 IS free the bind must
+          # still fail loudly — a bind error there is a real regression.
+          if ($env:SMB445_FREE -eq 'true') {
+            .\dfsctl.exe adapter enable smb --port 445
+            if ($LASTEXITCODE -ne 0) {
+              throw "adapter enable smb --port 445 failed with exit code $LASTEXITCODE"
+            }
 
-          Start-Sleep -Seconds 3
-          Write-Host "DittoFS SMB listener:"
-          (Get-NetTCPConnection -LocalPort 445 -State Listen -ErrorAction SilentlyContinue) | Format-Table -AutoSize
+            Start-Sleep -Seconds 3
+            Write-Host "DittoFS SMB listener:"
+            (Get-NetTCPConnection -LocalPort 445 -State Listen -ErrorAction SilentlyContinue) | Format-Table -AutoSize
+          } else {
+            Write-Host "Skipping the SMB bind: TCP 445 is still owned by the runner's kernel listener (PID 4)."
+            Write-Host "The server stays up so the log and pktmon diagnostics below are still collected."
+          }
 
       - name: Test net use operations
         id: netuse
@@ -522,11 +535,18 @@ jobs:
             )
           } elseif ($env:SMB445_FREE -eq 'false') {
             # Only the measured-and-unmet precondition gets this explanation.
-            $reason = 'TCP 445 stayed owned by the hosted-runner kernel SMB listener (srvnet.sys, PID 4). The Windows redirector always connects to TCP 445 and UNC syntax has no port field, so net use cannot reach DittoFS on any other port. Freeing 445 needs srvnet.sys unloaded, which a hosted runner cannot do without a reboot. Diagnostics were still captured and uploaded.'
-            Write-Host "::notice title=Windows net use tests skipped::$reason"
-            $summary += ":warning: **net use tests skipped** - $reason"
+            # A green check on this job does not mean the redirector path was
+            # exercised, so say what went untested loudly enough that someone
+            # scanning the run sees it: an annotation on the run and a line
+            # here. The bind and the assertions were both skipped.
+            $headline = 'Windows `net use` path NOT tested: TCP 445 held by the runner''s kernel listener'
+            $reason = 'TCP 445 stayed owned by the hosted-runner kernel SMB listener (srvnet.sys, PID 4), so DittoFS was never bound to it. The Windows redirector always connects to TCP 445 and UNC syntax has no port field, so net use cannot reach DittoFS on any other port. Freeing 445 needs srvnet.sys unloaded, which a hosted runner cannot do without a reboot. Diagnostics were still captured and uploaded.'
+            Write-Host "::warning title=Windows net use path not tested::$headline. $reason"
+            $summary += ":warning: **$headline**"
             $summary += ''
-            $summary += 'Run this job on a self-hosted or VM runner where 445 can be claimed to exercise the Windows redirector against DittoFS.'
+            $summary += $reason
+            $summary += ''
+            $summary += 'Nothing was asserted about the Windows redirector in this run. Run this job on a self-hosted or VM runner where 445 can be claimed to exercise it against DittoFS.'
           } else {
             # netuse is also skipped when an earlier step failed or the job was
             # cancelled, which is not the 445 story.

--- a/test/smb-conformance/README.md
+++ b/test/smb-conformance/README.md
@@ -319,6 +319,12 @@ Validates DittoFS SMB adapter against native OS SMB clients on three platforms.
 | macOS (latest) | mount_smbfs | `mount_smbfs //user:pass@localhost:12445/share /tmp/smbtest` |
 | Windows (latest) | net use | `net use Z: \\localhost\share /user:test test123` |
 
+The Windows cell is best-effort. `net use` can only reach TCP 445 (UNC syntax has no port
+field), so DittoFS has to take 445 from the runner's in-box SMB server. When that listener
+cannot be stopped, the job skips the bind and the assertions and says so with a warning
+annotation and a step-summary line — a green Windows job is not by itself proof that the
+redirector path was exercised. Linux and macOS use port 12445 and are unaffected.
+
 ### When It Runs
 
 - **Push to develop** (SMB paths changed)


### PR DESCRIPTION
## What was wrong

The Windows job measures whether TCP 445 actually came free and exports the result:

```powershell
"SMB445_FREE=$($freed.ToString().ToLowerInvariant())" >> $env:GITHUB_ENV
```

That flag gated the `net use` assertions — but not the bind that creates the
precondition. `dfsctl.exe adapter enable smb --port 445` ran unconditionally, so on a
runner where the kernel SMB listener kept 445 the bind failed, the bootstrap step exited
non-zero, and the job died *before* reaching any of the gated logic. The job failed for
exactly the condition the gate was written to tolerate.

## Diagnosis confirmed against real runs

Two jobs from the same afternoon, same workflow, same commit range:

| Job | `SMB445_FREE` | What happened |
|---|---|---|
| [97882736949](https://github.com/marmos91/dittofs/actions/runs/32872532039) (success) | `true` | freed at ~11s, `Adapter 'smb' enabled on port 445`, assertions ran |
| [97873632656](https://github.com/marmos91/dittofs/actions/runs/32869751173) (failure) | `false` | `Error: failed to enable adapter: ... bind: Only one usage of each socket address ...` |

At give-up the failure log shows the port still held by the kernel:

```
TCP 445 freed for DittoFS: False
LocalAddress LocalPort ... State  OwningProcess
::           445       ... Listen 4
```

## Pinning the runner image would not help

The successes are not a runner-image property. Successes and failures come from the
*identical* image build:

```
Image: windows-2025-vs2026   Version: 20260818.207.1   runner 2.336.0
```

That is the image and version for successes 97882736949 (16:32) and 97870183466 (15:54)
**and** for failures 97873632656 (16:04), 97854128923 (15:07), 97952188932 (20:12) — all
on 2026-08-25, interleaved within the same hour. One image build producing both outcomes
rules the image out structurally; no amount of extra samples changes that. So there is no
image to pin, and the gate is the right fix.

What *does* differ is timing. `srvnet` enters `STOP_PENDING` in both cases; in the
success it completes inside the 15 x 2s budget (~11s), in the failure it is still pending
when the loop gives up at ~32s. Whether a longer wait would convert some failures into
real coverage is untested and is not addressed here.

## The change

- **Gate the bind** on `SMB445_FREE`, the same flag that already gates the assertions.
  No second mechanism, no `continue-on-error`.
- **Keep it failing loudly when 445 *is* free.** An explicit `$LASTEXITCODE` check throws,
  so a genuine bind regression on a capable runner still fails the job rather than
  slipping through the new conditional as a silent green.
- **Make the skip visible.** A skipped run is green, so it now emits a `::warning::`
  annotation on the run and a step-summary line that names what went untested:
  *"Windows `net use` path NOT tested: TCP 445 held by the runner's kernel listener"*,
  plus "Nothing was asserted about the Windows redirector in this run."

The server still starts and the pktmon capture, DittoFS log dump, and artifact upload
still run, so #879 diagnostics survive a skipped run.

The Linux (`mount.cifs` + `smbclient`) and macOS (`mount_smbfs`) jobs use port 12445, are
unaffected, and are untouched.

## Verification

All nine `pwsh` steps parse clean, and the changed logic was executed against stubs in
`mcr.microsoft.com/powershell:7.4-ubuntu-22.04` for every branch:

```
===== A: 445 free, bind OK (today happy path) =====
DittoFS SMB listener:
  listener: 445
-> step exit code: 0

===== B: 445 free, bind FAILS (real regression) =====
Error: failed to enable adapter: ... bind: Only one usage ...
STEP FAILED (threw): adapter enable smb --port 445 failed with exit code 1
-> step exit code: 1

===== C: 445 NOT free (the flake) =====
Skipping the SMB bind: TCP 445 is still owned by the runner's kernel listener (PID 4).
-> step exit code: 0
```

Rendered summary for the skip case:

```
::warning title=Windows net use path not tested::Windows `net use` path NOT tested: TCP 445 held by the runner's kernel listener. ...

## SMB Client Compatibility: Windows

:warning: **Windows `net use` path NOT tested: TCP 445 held by the runner's kernel listener**
...
Nothing was asserted about the Windows redirector in this run.
```

Case B is the one that matters for review: the assertions are not weakened, and a bind
failure on a runner that *can* claim 445 still fails the job.

## Verified on real CI, not just locally

`smb-client-compat.yml` does not trigger on pull requests (`push: develop`, `schedule`,
`workflow_dispatch`), so this PR's own checks do not exercise it — a fix to a job's
failure handling that CI never runs would be unverifiable. It was dispatched on this
branch instead. Because the outcome is ~40/60 by runner luck and the concurrency group
cancels in-progress runs on the same ref, dispatches were run serially until both
branches of the gate were observed.

**The skip branch — four dispatches, all of which drew `SMB445_FREE=false`:**

| Run | `SMB445_FREE` | Windows job |
|---|---|---|
| [32898403138](https://github.com/marmos91/dittofs/actions/runs/32898403138) | `false` | success |
| [32898810189](https://github.com/marmos91/dittofs/actions/runs/32898810189) | `false` | success |
| [32899097003](https://github.com/marmos91/dittofs/actions/runs/32899097003) | `false` | success |
| [32899421587](https://github.com/marmos91/dittofs/actions/runs/32899421587) | `false` | success |

Same condition, side by side — this is the whole fix:

```
develop  (job 97873632656): TCP 445 freed for DittoFS: False
                            Error: failed to enable adapter: ... bind: Only one usage ...
                            ##[error]Process completed with exit code 1.

branch   (job 97966250267): TCP 445 freed for DittoFS: False
                            Skipping the SMB bind: TCP 445 is still owned by the
                            runner's kernel listener (PID 4).
                            -> success
```

All four skipped runs surface the annotation in the run's Annotations panel:

```
warning: Windows net use path not tested | Windows `net use` path NOT tested: TCP 445
held by the runner's kernel listener. ...
```

**The bind branch, forced deterministically.** Four dispatches never drew a runner that
frees 445, so rather than keep rolling I forced it: on a throwaway branch I pinned
`$freed = $true` while 445 was still held, which is exactly the "flag says free, bind
fails" case — the silent-green risk this change could have introduced. Run
[32899723787](https://github.com/marmos91/dittofs/actions/runs/32899723787):

```
TCP 445 freed for DittoFS: True
... bind: Only one usage of each socket address ...
adapter enable smb --port 445 failed with exit code 1
##[error]Process completed with exit code 1.
```

The job **failed**, via the new `throw`. A real bind regression on a runner that can claim
445 still fails loudly. The throwaway branch has been deleted.

The one case not observed on live CI is the fully-happy path (445 free *and* bind
succeeds) — no dispatch drew a capable runner. That path's code is unchanged from
`develop` apart from indentation and the added `throw`, it is covered by the local
harness (case A above), and `develop` runs such as job 97882736949 show it working.

Closes #2148
