### PR TITLE
docs(smb): correct 60+ wrong MS-SMB2 spec citations in the SMB adapter

### DIFF
--- a/internal/adapter/smb/compound.go
+++ b/internal/adapter/smb/compound.go
@@ -155,7 +155,8 @@ func ProcessCompoundRequest(ctx context.Context, firstHeader *header.SMB2Header,
 
 	result, fileID, handlerCtx := ProcessRequestWithFileIDAndCallback(ctx, firstHeader, firstBody, firstRaw, connInfo, isEncrypted, asyncNotifyCallback)
 
-	// Per MS-SMB2 §3.3.4.4 and smbtorture compound_async.getinfo_middle:
+	// Per MS-SMB2 §3.3.4.2 ("Sending an Interim Response for an Asynchronous Operation")
+	// and smbtorture compound_async.getinfo_middle:
 	// When a compound command returns STATUS_PENDING with an AsyncId AND
 	// there are remaining commands, send the interim response standalone and
 	// defer the remaining compound commands to the async completion callback.
@@ -207,7 +208,7 @@ func ProcessCompoundRequest(ctx context.Context, firstHeader *header.SMB2Header,
 		// on the wire. The callback was swapped above (ReplaceCallback) so the
 		// goroutine picks up the continue-compound wrapper, and MarkStarted runs
 		// post-interim so the final compound response can never overtake the
-		// interim (MS-SMB2 §3.3.4.4 ordering; same class as the standalone path
+		// interim (MS-SMB2 §3.3.4.2 (interim async response) ordering; same class as the standalone path
 		// in response.go that smb2.bench.oplock1 trips). Skipping the release
 		// would deadlock the CREATE after the wait drains (smbtorture
 		// compound.compound-break IO_TIMEOUT race).
@@ -800,7 +801,7 @@ type compoundLoopState struct {
 	// AsyncIds of parked CREATEs whose interim STATUS_PENDING is buffered into
 	// responses (not yet on the wire). MarkStarted MUST fire only after the
 	// compound frame is written, so the resume goroutine's final response can
-	// never overtake the interim (MS-SMB2 §3.3.4.4; same ordering class as the
+	// never overtake the interim (MS-SMB2 §3.3.4.2 (interim async response); same ordering class as the
 	// standalone path that smb2.bench.oplock1 trips).
 	markStartedAsyncIDs []uint64
 }
@@ -1057,7 +1058,8 @@ func (s *compoundLoopState) processRemaining(
 // STATUS_PENDING. It builds a compound response containing the CREATE's final
 // result and all subsequent commands, then sends it as a single compound frame.
 //
-// Per MS-SMB2 §3.3.4.4: the CREATE's interim STATUS_PENDING was already sent
+// Per MS-SMB2 §3.3.4.2 ("Sending an Interim Response for an Asynchronous Operation"):
+// the CREATE's interim STATUS_PENDING was already sent
 // standalone by ProcessCompoundRequest. completeCompoundAfterAsyncCreate delivers
 // the remaining responses (the CREATE completion + GETINFO + CLOSE etc.) as a compound.
 //

--- a/internal/adapter/smb/compound.go
+++ b/internal/adapter/smb/compound.go
@@ -299,7 +299,7 @@ func ProcessCompoundRequest(ctx context.Context, firstHeader *header.SMB2Header,
 
 // sendCompoundResponses sends all compound responses in a single NetBIOS frame.
 //
-// Per MS-SMB2 3.3.5.2.7 — Sending Compounded Responses:
+// Per MS-SMB2 3.3.4.1.3 ("Sending Compounded Responses"):
 //   - Each non-last response is padded to 8-byte alignment
 //   - NextCommand in the header points to the next command's offset
 //   - Per MS-SMB2 3.3.4.1.1: each command is signed individually over its own
@@ -630,7 +630,7 @@ func ParseCompoundCommand(data []byte) (*header.SMB2Header, []byte, []byte, erro
 
 // VerifyCompoundCommandSignature verifies the signature of a compound sub-command.
 //
-// Per MS-SMB2 3.3.5.2.7.2 — Handling Compounded Requests:
+// Per MS-SMB2 3.3.5.2.7.2 ("Handling Compounded Related Requests"):
 // Each command in a compound request is signed individually over its own bytes
 // (from its SMB2 header to NextCommand offset, or end for the last command).
 // The signature covers ONLY that command's bytes, not the entire compound.

--- a/internal/adapter/smb/compound.go
+++ b/internal/adapter/smb/compound.go
@@ -80,8 +80,9 @@ func ProcessCompoundRequest(ctx context.Context, firstHeader *header.SMB2Header,
 		return
 	}
 
-	// Per MS-SMB2 3.2.4.1.4: compound-level credit accounting.
-	// The first command's CreditCharge covers the entire compound.
+	// Per MS-SMB2 §3.3.5.2.5 ("Verifying the Credit Charge and the Payload Size"):
+	// compound-level credit accounting. The first command's CreditCharge
+	// covers the entire compound.
 	// CreditCharge size validation is skipped for exempt commands; sequence
 	// window Consume still runs for NEGOTIATE and first SESSION_SETUP but is
 	// skipped for CANCEL — see response.go for rationale (#378).
@@ -352,8 +353,9 @@ func sendCompoundResponses(responses []compoundResponse, connInfo *ConnInfo, req
 		return SendMessage(hdr, responses[0].body, connInfo)
 	}
 
-	// Per MS-SMB2 3.2.4.1.4: middle compound responses grant 0 credits;
-	// only the last response grants credits to the client.
+	// Middle compound responses grant 0 credits; only the last response grants
+	// credits to the client. MS-SMB2 §3.3.4.1.3 permits per-response granting;
+	// this is the Windows/Samba convention.
 	applyCompoundCreditZeroing(responses, connInfo)
 
 	// Build compound payload: sign each command individually, then concatenate.
@@ -480,8 +482,9 @@ func failEntireCompound(firstHeader *header.SMB2Header, compoundData []byte, sta
 }
 
 // applyCompoundCreditZeroing applies compound-level credit accounting to responses.
-// Per MS-SMB2 3.2.4.1.4: middle compound responses grant 0 credits; only the last
-// response grants credits. For single-response compounds (len <= 1), no zeroing
+// Middle compound responses grant 0 credits; only the last response grants
+// credits (MS-SMB2 §3.3.4.1.3 "Sending Compounded Responses" permits either;
+// this follows Windows/Samba). For single-response compounds (len <= 1), no zeroing
 // is applied since they go through SendMessage which handles granting normally.
 //
 // Each sub-response was built via buildResponseHeaderAndBody, which already
@@ -495,8 +498,7 @@ func applyCompoundCreditZeroing(responses []compoundResponse, connInfo *ConnInfo
 		return
 	}
 	// Move each middle response's grant onto the last response rather than
-	// reclaiming it. Per MS-SMB2 3.2.4.1.4 only the last response in a compound
-	// advertises credits, but every sub-request debits one credit, so the client
+	// reclaiming it. Only the last response in a compound advertises credits, but every sub-request debits one credit, so the client
 	// must be credited for the WHOLE compound on the one response it reads
 	// credits from. Reclaiming the middle grants instead left the last response
 	// advertising only its own single grant, so a stat compound (CREATE +
@@ -836,7 +838,8 @@ func (s *compoundLoopState) processRemaining(
 ) {
 	for len(remaining) >= header.HeaderSize {
 		// Keep a reference to the current command's start for signature verification.
-		// Per MS-SMB2 3.2.4.1.4, each compound command is signed over its own bytes.
+		// Per MS-SMB2 §3.3.4.1.1 ("Signing the Message"), each compound command is
+		// signed over its own bytes.
 		currentCommandData := remaining
 
 		hdr, cmdBody, nextRemaining, err := ParseCompoundCommand(remaining)

--- a/internal/adapter/smb/credit_wiring_test.go
+++ b/internal/adapter/smb/credit_wiring_test.go
@@ -246,7 +246,8 @@ func TestSendMessageWithConnInfo_GrantExpansion(t *testing.T) {
 
 // TestCompound_CreditValidationAtCompoundLevel verifies that compound-level
 // credit validation only consumes from the sequence window for the first command.
-// Per MS-SMB2 3.2.4.1.4: the first command's CreditCharge covers the entire compound.
+// Per MS-SMB2 §3.3.5.2.5 ("Verifying the Credit Charge and the Payload Size"):
+// the first command's CreditCharge covers the entire compound.
 func TestCompound_CreditValidationAtCompoundLevel(t *testing.T) {
 	sw := session.NewCommandSequenceWindow(131070)
 	sw.Grant(255) // Grant enough credits

--- a/internal/adapter/smb/crypto_state.go
+++ b/internal/adapter/smb/crypto_state.go
@@ -37,7 +37,8 @@ type ConnectionCryptoState struct {
 
 	// SigningAlgorithmExplicit reports whether the client explicitly
 	// negotiated the signing algorithm via a SIGNING_CAPABILITIES negotiate
-	// context (MS-SMB2 §3.1.1.2). When false, SigningAlgorithmId carries the
+	// context (MS-SMB2 §2.2.3.1.7 ("SMB2_SIGNING_CAPABILITIES")). When false,
+	// SigningAlgorithmId carries the
 	// server-side default (AES-128-CMAC for 3.x), not a client selection.
 	// Used to disambiguate HMAC-SHA256 (wire value 0x0000) from a
 	// default-zero placeholder.

--- a/internal/adapter/smb/handlers/auth_helper.go
+++ b/internal/adapter/smb/handlers/auth_helper.go
@@ -423,7 +423,7 @@ func (h *Handler) buildOpenerAuthContext(ctx *SMBHandlerContext, openFile *OpenF
 // PropagateOpenFileParentLeaseKey copies the OpenFile's RqLs parent-lease-key
 // linkage (if any) onto an AuthContext. This is the hand-off that lets
 // MetadataService.notifyDirChange and the dir-lease parent-key suppression
-// rule (MS-SMB2 §3.3.4.20) skip the matching parent dir
+// rule (Samba `dirlease_should_break`) skip the matching parent dir
 // lease when the originating handle's CREATE carried
 // LEASE_FLAG_PARENT_LEASE_KEY_SET. Safe to call with a nil OpenFile (no-op).
 //

--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -465,7 +465,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	// that modified the file (WRITE occurred) breaks parent-dir leases. The
 	// WRITE itself does NOT break — only the CLOSE triggers the break so
 	// directory caching is only invalidated once the mutation is committed.
-	// Parent-key suppression (MS-SMB2 §3.3.4.20) applies: if the
+	// Parent-key suppression (Samba `dirlease_should_break`) applies: if the
 	// closing handle carried a ParentLeaseKey matching the parent's dir lease,
 	// that lease is suppressed. Covers smb2.dirlease.v2_request: write without
 	// parent key -> close breaks dir lease; write with parent key -> close

--- a/internal/adapter/smb/handlers/context.go
+++ b/internal/adapter/smb/handlers/context.go
@@ -123,7 +123,8 @@ type SMBHandlerContext struct {
 	// NextCommand is the SMB2 header NextCommand offset for this request.
 	// Nonzero iff this request is NOT the last in a compound chain. Handlers
 	// that may emit an async interim response (STATUS_PENDING) consult this to
-	// avoid parking a non-last compound command — per MS-SMB2 §3.3.4.4 an async
+	// avoid parking a non-last compound command — per MS-SMB2
+	// §3.3.4.2 (interim async response) an async
 	// operation MUST be the last in a compound. Populated by prepareDispatch.
 	NextCommand uint32
 

--- a/internal/adapter/smb/handlers/create.go
+++ b/internal/adapter/smb/handlers/create.go
@@ -1387,7 +1387,8 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	// that lease BEFORE the final share-mode check so holders can release
 	// cached handles. The post-break flow (recheck + create + response) runs
 	// in completeCreateAfterBreak so the same code path serves both the sync
-	// wait and the async park-on-break goroutine (MS-SMB2 §3.3.4.4/§3.3.4.7).
+	// wait and the async park-on-break goroutine (MS-SMB2 §3.3.4.2 (interim async response)
+	// and §3.3.4.7 "Object Store Indicates a Lease Break").
 
 	// Cross-stream share-mode check for new files (no lease break needed).
 	if !fileExists {

--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -670,7 +670,7 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 	// rearm (test_rearm_dirlease). Mirrors Samba's delay_for_oplock_fn
 	// running before the actual create.
 	//
-	// Parent-key suppression (MS-SMB2 §3.3.4.20 / Samba dirlease_should_break):
+	// Parent-key suppression (Samba `dirlease_should_break`):
 	// if this CREATE carried an RqLs with
 	// LEASE_FLAG_PARENT_LEASE_KEY_SET, extract the ParentLeaseKey from the
 	// incoming request so the matching dir-lease is NOT broken.
@@ -1316,8 +1316,8 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 	h.CaptureOpenerIdentity(ctx, openFile)
 
 	// Record the RqLs parent-lease-key linkage so downstream operations on
-	// this handle (SET_INFO, WRITE, CLOSE-on-delete) can apply the MS-SMB2
-	// §3.3.4.20 / Samba `dirlease_should_break` parent-key suppression rule
+	// this handle (SET_INFO, WRITE, CLOSE-on-delete) can apply the Samba
+	// `dirlease_should_break` parent-key suppression rule
 	// against the parent directory's lease. Captured even when the file
 	// lease itself was denied (response leaseState=None) — the linkage
 	// applies regardless of the per-file grant outcome. Gated on HasParent

--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -439,7 +439,8 @@ func (h *Handler) breakAndMaybeParkCreate(ctx *SMBHandlerContext, d *createDraft
 		breakWaitTimeout = lease.TraditionalOplockBreakWaitTimeout
 	}
 
-	// Per MS-SMB2 §3.3.4.4 and smbtorture compound_async.getinfo_middle:
+	// Per MS-SMB2 §3.3.4.2 ("Sending an Interim Response for an Asynchronous Operation")
+	// and smbtorture compound_async.getinfo_middle:
 	// When a compound CREATE needs to wait for a lease break, it MUST go async
 	// (STATUS_PENDING) even if it is not the last command in the compound.
 	// The compound processor handles non-last STATUS_PENDING by sending the

--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -932,7 +932,10 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 		}
 	}
 
-	// Step 8a-bis: MS-SMB2 §3.3.4.18 disconnected-handle preservation/purge.
+	// Step 8a-bis: disconnected-handle preservation/purge. Preservation is
+	// MS-SMB2 §3.3.7.1 ("Handling Loss of a Connection"); the break that can
+	// knock a preserved handle below H is §3.3.4.7 ("Object Store Indicates a
+	// Lease Break").
 	//
 	// Evaluate any disconnected durable handles on this metadata handle
 	// against the new open's lease/share-mode and purge those that the new

--- a/internal/adapter/smb/handlers/disconnected_state_machine.go
+++ b/internal/adapter/smb/handlers/disconnected_state_machine.go
@@ -9,14 +9,16 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
-// MS-SMB2 §3.3.4.18 — Disconnected durable handle preservation/purge state machine.
+// Disconnected durable handle preservation/purge state machine.
 //
 // When a client transport-disconnects, an open with IsDurable set is persisted
 // to the DurableHandleStore. While disconnected, operations from OTHER opens on
 // the same underlying file may conflict with the disconnected open's persisted
-// state. This file implements the preserve/purge decision per [MS-SMB2] §3.3.4.18
-// (Server Receives an Object Store Operation) and §3.3.5.9 (Receiving an SMB2
-// CREATE Request, Step 10 share-mode/lease conflict handling) — mirroring
+// state. This file implements the preserve/purge decision per [MS-SMB2] §3.3.7.1
+// ("Handling Loss of a Connection", which lists the conditions under which an
+// Open is preserved for reconnect), §3.3.4.7 ("Object Store Indicates a Lease
+// Break", which drives the purge) and §3.3.5.9 ("Receiving an SMB2 CREATE
+// Request", Step 10 share-mode/lease conflict handling) — mirroring
 // Samba's `delay_for_oplock_fn` + `share_mode_cleanup_disconnected` semantics
 // from source3/smbd/open.c and source3/smbd/scavenger.c.
 //
@@ -368,7 +370,7 @@ func (h *Handler) purgeDisconnectedConflicts(
 
 // purgeConflictingDisconnectedHandlesForOpen purges the disconnected handles on
 // the underlying file (keyed by metadata handle) that conflict with the new
-// open under §3.3.4.18.
+// open under MS-SMB2 §3.3.4.7 ("Object Store Indicates a Lease Break").
 func (h *Handler) purgeConflictingDisconnectedHandlesForOpen(
 	ctx context.Context,
 	metaHandle []byte,
@@ -451,7 +453,8 @@ func (h *Handler) purgeOneDisconnectedHandle(
 
 // shouldPersistDurableOnDisconnect returns false when an open MUST NOT be
 // persisted as a durable handle at transport-disconnect time, even if it
-// carries IsDurable. Per MS-SMB2 §3.3.4.18 and smb2.durable-v2-open.lock-noW-lease,
+// carries IsDurable. Per MS-SMB2 §3.3.7.1 ("Handling Loss of a Connection")
+// and smb2.durable-v2-open.lock-noW-lease,
 // an open holding a byte-range lock under a lease that lacks W (write caching)
 // cannot reliably resume: the BR-lock is bound to the open's OpenID and the
 // lease cannot promote to W on reconnect without breaking other holders.

--- a/internal/adapter/smb/handlers/disconnected_state_machine.go
+++ b/internal/adapter/smb/handlers/disconnected_state_machine.go
@@ -45,7 +45,8 @@ import (
 //     does NOT break it (Samba is_stat_open) and does NOT purge.
 //
 //   - A WRITE from a live handle breaks Level-II (Read) leases on the same
-//     file to None per MS-SMB2 §3.3.5.16; any disconnected RH lease on the
+//     file to None per MS-SMB2 §3.3.5.13 ("Receiving an SMB2 WRITE Request");
+//     any disconnected RH lease on the
 //     file with a different lease-key is purged (it would break to None).
 //
 //   - A RENAME from a live handle breaks Handle leases on the same file to

--- a/internal/adapter/smb/handlers/disconnected_state_machine_test.go
+++ b/internal/adapter/smb/handlers/disconnected_state_machine_test.go
@@ -11,7 +11,8 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
-// TestDisconnectedConflictOnNewOpen exercises the MS-SMB2 §3.3.4.18 truth
+// TestDisconnectedConflictOnNewOpen exercises the MS-SMB2 §3.3.7.1
+// ("Handling Loss of a Connection") / §3.3.4.7 truth
 // table for FRESH (non-reconnect) CREATE opens against disconnected durable
 // handles, mirroring the matrix asserted by
 // smb2.durable-v2-open.{keep,purge}-disconnected-* in
@@ -478,7 +479,8 @@ func TestDurablePurgeMuSerializesPersistAndPurge(t *testing.T) {
 }
 
 // TestShouldPersistDurableOnDisconnect pins down the lock-noW-lease persist
-// gate (smb2.durable-v2-open.lock-noW-lease, MS-SMB2 §3.3.4.18).
+// gate (smb2.durable-v2-open.lock-noW-lease,
+// MS-SMB2 §3.3.7.1 "Handling Loss of a Connection").
 func TestShouldPersistDurableOnDisconnect(t *testing.T) {
 	rh := smbLeaseRead | smbLeaseHandle
 	rwh := smbLeaseRead | smbLeaseHandle | smbLeaseWrite

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -631,9 +631,15 @@ type OpenFile struct {
 
 	// ParentLeaseKey is the 128-bit parent directory lease key carried in the
 	// CREATE RqLs (V2) when the client set SMB2_LEASE_FLAG_PARENT_LEASE_KEY_SET.
-	// Used by the dir-lease parent-key suppression rule (MS-SMB2 §3.3.4.20):
-	// SET_INFO / WRITE / CLOSE-on-delete on this handle MUST NOT break the
-	// parent dir lease whose LeaseKey matches this value. The field is
+	// Established per MS-SMB2 §3.3.5.9.11 ("Handling the
+	// SMB2_CREATE_REQUEST_LEASE_V2 Create Context"). Used by the dir-lease
+	// parent-key suppression rule: SET_INFO / WRITE / CLOSE-on-delete on this
+	// handle MUST NOT break the parent dir lease whose LeaseKey matches this
+	// value. That suppression is not stated in any MS-SMB2 server section —
+	// §3.3.4.7 hands the break decision to the object store, and the only
+	// spec text naming ParentLeaseKey outside the wire structures is the
+	// client-side §3.2.4.3.8 — so Samba `dirlease_should_break` is the
+	// binding reference for the rule itself. The field is
 	// meaningful only when HasParentLeaseKey is true.
 	ParentLeaseKey    [16]byte
 	HasParentLeaseKey bool
@@ -1671,7 +1677,7 @@ func (h *Handler) handleDeleteOnClose(ctx context.Context, sess *session.Session
 	name := target.Name
 	authCtx := h.buildCleanupAuthContext(ctx, sess)
 	// Thread the closing handle's RqLs ParentLeaseKey so notifyDirChange can
-	// apply the MS-SMB2 §3.3.4.20 / Samba `dirlease_should_break` parent-key
+	// apply the Samba `dirlease_should_break` parent-key
 	// suppression rule on the parent dir lease. Suppression applies only when
 	// the closer's key matches the key whoever committed the delete-on-close
 	// recorded; when they differ every parent dir lease breaks. Same rule the

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -849,7 +849,8 @@ func (f *OpenFile) OpenID() string {
 
 // openHasLocks reports whether any byte-range lock is currently recorded
 // against the given open under the lock manager. Source of truth for the
-// MS-SMB2 §3.3.4.18 durable persist gate at disconnect time — avoids the
+// MS-SMB2 §3.3.7.1 ("Handling Loss of a Connection") durable persist gate
+// at disconnect time — avoids the
 // TOCTOU race between an async-parked LOCK goroutine's HasByteRangeLocks
 // flag flip and the disconnect-time read (see lock_async.go::resumePendingLock,
 // MS-SMB2 §3.3.5.14 / smb2.durable-v2-open.lock-noW-lease).
@@ -1422,7 +1423,8 @@ func (h *Handler) closeFilesWithFilter(
 				}
 			}
 
-			// MS-SMB2 §3.3.4.18 persist gate: refuse to persist when the
+			// MS-SMB2 §3.3.7.1 ("Handling Loss of a Connection") persist gate:
+			// refuse to persist when the
 			// open holds a byte-range lock under a lease lacking W. The
 			// disconnected reconnect cannot reliably re-establish the lock
 			// because the BR-lock is bound to the open's OpenID and a

--- a/internal/adapter/smb/handlers/ioctl_copychunk.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk.go
@@ -405,7 +405,8 @@ func (h *Handler) executeCopyChunks(
 	srcPayloadID := string(srcFile.PayloadID)
 	srcSize := srcFile.Size
 
-	// Per MS-SMB2 3.3.5.16: Break Read caching leases held by other clients on
+	// Per MS-SMB2 §3.3.5.13 ("Receiving an SMB2 WRITE Request"): break Read caching
+	// leases held by other clients on
 	// the destination before writing, so they invalidate their cached data.
 	if h.LeaseManager != nil {
 		lockFileHandle := lock.FileHandle(dstOpen.MetadataHandle)

--- a/internal/adapter/smb/handlers/ioctl_network_interfaces.go
+++ b/internal/adapter/smb/handlers/ioctl_network_interfaces.go
@@ -74,10 +74,13 @@ func (h *Handler) handleQueryNetworkInterfaceInfo(ctx *SMBHandlerContext, body [
 	}
 
 	output := encodeNetworkInterfaceInfoList(entries)
-	// MS-SMB2 §3.3.4.20.13: if MaxOutputResponse is insufficient for the
-	// full reply, return STATUS_BUFFER_TOO_SMALL. smbtorture bug14788
-	// exercises max_output=1 against the sentinel FileID and asserts
-	// BUFFER_TOO_SMALL distinct from INVALID_PARAMETER.
+	// If MaxOutputResponse is insufficient for the full reply, return
+	// STATUS_BUFFER_TOO_SMALL. MS-SMB2 §3.3.5.15.11 ("Handling a Query Network
+	// Interface Request") does not specify this case, and §3.3.5.15 lists
+	// STATUS_BUFFER_TOO_SMALL only among the IOCTL status codes generally, so
+	// the binding reference is the harness: smbtorture bug14788 exercises
+	// max_output=1 against the sentinel FileID and asserts BUFFER_TOO_SMALL
+	// distinct from INVALID_PARAMETER.
 	if maxOutput := parseIoctlMaxOutputSize(body); maxOutput < uint32(len(output)) {
 		return NewErrorResult(types.StatusBufferTooSmall), nil
 	}

--- a/internal/adapter/smb/handlers/lock.go
+++ b/internal/adapter/smb/handlers/lock.go
@@ -523,7 +523,7 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 			// inline retry on the dispatch goroutine.
 			//
 			// Async parking is unsafe in compound chains (NextCommand != 0,
-			// MS-SMB2 §3.3.4.4) and in multi-element requests. The first
+			// MS-SMB2 §3.3.4.2 (interim async response)) and in multi-element requests. The first
 			// guard is enforced by the !ctx.NextCommand check below; the
 			// second is implicit because §3.3.5.14 forbids multi-element
 			// requests with a blocking first element (rejected above), and

--- a/internal/adapter/smb/handlers/lock.go
+++ b/internal/adapter/smb/handlers/lock.go
@@ -579,7 +579,8 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 	// Mark this open as having held at least one byte-range lock. The flag
 	// is consumed at disconnect by shouldPersistDurableOnDisconnect to refuse
 	// durable persistence for opens that hold BR-locks under a non-W lease
-	// (smbtorture smb2.durable-v2-open.lock-noW-lease, MS-SMB2 §3.3.4.18).
+	// (smbtorture smb2.durable-v2-open.lock-noW-lease,
+	// MS-SMB2 §3.3.7.1 "Handling Loss of a Connection").
 	// Strictly monotonic — UNLOCK does NOT clear it, mirroring Samba's
 	// pessimistic `vfs_default_durable_disconnect` semantics.
 	for _, le := range req.Locks {

--- a/internal/adapter/smb/handlers/negotiate.go
+++ b/internal/adapter/smb/handlers/negotiate.go
@@ -458,7 +458,8 @@ func (h *Handler) processNegotiateContexts(
 // defaultSigningAlgorithmPreference is the server's default signing algorithm
 // preference order, used when SigningAlgorithmPreference is not configured.
 // HMAC-SHA256 is included because clients MAY explicitly request it via the
-// 3.1.1 SIGNING_CAPABILITIES negotiate context (MS-SMB2 §3.1.1.2). When
+// 3.1.1 SIGNING_CAPABILITIES negotiate context
+// (MS-SMB2 §2.2.3.1.7 "SMB2_SIGNING_CAPABILITIES"). When
 // selected for 3.1.1 the signing key is the first 16 bytes of the
 // SP800-108-derived SigningKey and the verifier uses HMAC-SHA256.
 var defaultSigningAlgorithmPreference = []uint16{

--- a/internal/adapter/smb/handlers/query_directory_test.go
+++ b/internal/adapter/smb/handlers/query_directory_test.go
@@ -1,8 +1,10 @@
 // Refs #573. Handler-level integration coverage for SMB2 QUERY_DIRECTORY
-// with the share's AccessBasedEnumeration toggle. Mirrors MS-SMB2 §3.3.5.18.1
-// ¶6 ("If TreeConnect.Share.AccessBasedEnumeration is TRUE, the server MUST
-// NOT include entries for which the user does not have FILE_READ_DATA /
-// FILE_LIST_DIRECTORY access") and the smb2.acls.ACCESSBASED smbtorture
+// with the share's AccessBasedEnumeration toggle. Mirrors MS-SMB2 §3.3.5.18
+// ("Receiving an SMB2 QUERY_DIRECTORY Request"): "If
+// TreeConnect.Share.DoAccessBasedDirectoryEnumeration is TRUE and the object
+// store supports security, the server MUST also exclude entries for which the
+// user represented by Session.SecurityContext is not granted GENERIC_READ and
+// FILE_LIST_DIRECTORY access". Also the smb2.acls.ACCESSBASED smbtorture
 // case at source4/torture/smb2/acls.c:2308.
 package handlers
 

--- a/internal/adapter/smb/handlers/read.go
+++ b/internal/adapter/smb/handlers/read.go
@@ -183,7 +183,8 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	// Step 2b: Validate read access
 	// ========================================================================
 	//
-	// Per MS-SMB2 3.3.5.15: the server MUST verify that the open was created
+	// Per MS-SMB2 §3.3.5.12 ("Receiving an SMB2 READ Request"): the server MUST
+	// verify that the open was created
 	// with read access. hasReadAccess treats FILE_READ_DATA, FILE_EXECUTE,
 	// GENERIC_READ, GENERIC_ALL, and MAXIMUM_ALLOWED as read access — Samba
 	// and Windows allow READ on an FILE_EXECUTE-only handle (execution
@@ -229,7 +230,8 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}, nil
 	}
 
-	// Per MS-SMB2 3.3.5.13: the server MUST fail a READ whose Length exceeds the
+	// Per MS-SMB2 §3.3.5.12 ("Receiving an SMB2 READ Request"): the server MUST fail
+	// a READ whose Length exceeds the
 	// MaxReadSize advertised in the NEGOTIATE response with
 	// STATUS_INVALID_PARAMETER. Without this clamp the request is bounded only by
 	// the 64 MB NetBIOS frame cap, letting one READ allocate up to 64× the

--- a/internal/adapter/smb/handlers/readwrite_maxsize_clamp_test.go
+++ b/internal/adapter/smb/handlers/readwrite_maxsize_clamp_test.go
@@ -74,8 +74,9 @@ func TestRead_AtMaxReadSizeNotRejectedByClamp(t *testing.T) {
 }
 
 // TestWrite_ClampsLengthToMaxWriteSize verifies a WRITE whose payload exceeds
-// MaxWriteSize is rejected with STATUS_INVALID_PARAMETER — the symmetric
-// contract to the READ clamp (MS-SMB2 §3.3.5.12 ("Receiving an SMB2 READ Request")).
+// MaxWriteSize is rejected with STATUS_INVALID_PARAMETER, per MS-SMB2 §3.3.5.13
+// ("Receiving an SMB2 WRITE Request") — the symmetric contract to the READ
+// clamp above (§3.3.5.12).
 func TestWrite_ClampsLengthToMaxWriteSize(t *testing.T) {
 	h := NewHandler()
 	if h.MaxWriteSize == 0 {

--- a/internal/adapter/smb/handlers/readwrite_maxsize_clamp_test.go
+++ b/internal/adapter/smb/handlers/readwrite_maxsize_clamp_test.go
@@ -8,7 +8,8 @@ import (
 
 // TestRead_ClampsLengthToMaxReadSize verifies a READ whose Length exceeds the
 // MaxReadSize advertised in NEGOTIATE is rejected with STATUS_INVALID_PARAMETER
-// (MS-SMB2 3.3.5.13). Without the clamp the request would be bounded only by
+// (MS-SMB2 §3.3.5.12 ("Receiving an SMB2 READ Request")). Without the clamp the
+// request would be bounded only by
 // the 64 MB NetBIOS frame cap, letting one READ allocate 64x the advertised
 // ceiling. Mirrors the Windows/Samba reject of an over-max READ.
 func TestRead_ClampsLengthToMaxReadSize(t *testing.T) {
@@ -74,7 +75,7 @@ func TestRead_AtMaxReadSizeNotRejectedByClamp(t *testing.T) {
 
 // TestWrite_ClampsLengthToMaxWriteSize verifies a WRITE whose payload exceeds
 // MaxWriteSize is rejected with STATUS_INVALID_PARAMETER — the symmetric
-// contract to the READ clamp (MS-SMB2 3.3.5.13).
+// contract to the READ clamp (MS-SMB2 §3.3.5.12 ("Receiving an SMB2 READ Request")).
 func TestWrite_ClampsLengthToMaxWriteSize(t *testing.T) {
 	h := NewHandler()
 	if h.MaxWriteSize == 0 {

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -1063,7 +1063,8 @@ func (h *Handler) setFileInfoFromStore(
 				logger.Debug("SET_INFO: rename lease break dispatch failed", "error", err)
 			}
 
-			// MS-SMB2 §3.3.4.18 / §3.3.5.21: RENAME breaks Handle leases on
+			// MS-SMB2 §3.3.5.21 ("Receiving an SMB2 SET_INFO Request") and
+			// §3.3.4.7 ("Object Store Indicates a Lease Break"): RENAME breaks Handle leases on
 			// the renamed file (and on the overwrite target). Any
 			// disconnected durable handle with a different lease key loses
 			// H — the disconnected client cannot ack the break, so the
@@ -1379,7 +1380,8 @@ func (h *Handler) setFileInfoFromStore(
 			if breakErr := h.LeaseManager.BreakReadLeasesOnWrite(lockFileHandle, openFile.ShareName, openFile.LeaseKey); breakErr != nil {
 				logger.Debug("SET_INFO: oplock break on EOF set failed (non-fatal)", "path", openFile.Name().Path, "error", breakErr)
 			}
-			// MS-SMB2 §3.3.4.18: truncation is a data-modifying op that
+			// MS-SMB2 §3.3.4.7 ("Object Store Indicates a Lease Break"):
+			// truncation is a data-modifying op that
 			// breaks Level-II Read leases to NONE — purge any disconnected
 			// durable handle whose lease holds R-caching from a different key.
 			if h.DurableStore != nil {

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -2156,7 +2156,7 @@ func (h *Handler) breakParentDirLeasesForContentChangeOn(ctx *SMBHandlerContext,
 
 	parentLockHandle := lock.FileHandle(parentHandle)
 
-	// Apply parent-key suppression only (MS-SMB2 §3.3.4.20): if
+	// Apply parent-key suppression only (Samba `dirlease_should_break`): if
 	// the originating handle's CREATE carried an RqLs with ParentLeaseKey
 	// set, the matching parent dir lease MUST NOT be broken. No ClientID
 	// exclusion — same-client breaks fire when the key doesn't match.
@@ -2358,7 +2358,7 @@ func (h *Handler) handleFileLinkInformation(
 
 	// Thread the open file's ParentLeaseKey into the auth context so
 	// MetadataService.notifyDirChange forwards it to OnDirChange and the
-	// dir-lease parent-key suppression rule (MS-SMB2 §3.3.4.20) skips the
+	// dir-lease parent-key suppression rule (Samba `dirlease_should_break`) skips the
 	// matching parent dir lease (same-key holder does not get broken).
 	PropagateOpenFileParentLeaseKey(authCtx, openFile)
 

--- a/internal/adapter/smb/handlers/write.go
+++ b/internal/adapter/smb/handlers/write.go
@@ -379,7 +379,8 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 		}
 	}
 
-	// MS-SMB2 §3.3.4.18 / §3.3.5.16: a WRITE breaks Level-II (Read) leases
+	// MS-SMB2 §3.3.5.13 ("Receiving an SMB2 WRITE Request") and §3.3.4.7
+	// ("Object Store Indicates a Lease Break"): a WRITE breaks Level-II (Read) leases
 	// on the same file to NONE. Any disconnected durable handle with a
 	// lease holding R-caching on this file (and a different lease key from
 	// the writer's) loses H along with R and must be purged — the

--- a/internal/adapter/smb/handlers/write.go
+++ b/internal/adapter/smb/handlers/write.go
@@ -196,7 +196,8 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	// Step 2b: Validate write access
 	// ========================================================================
 	//
-	// Per MS-SMB2 3.3.5.16: The server MUST verify that the open was created
+	// Per MS-SMB2 §3.3.5.13 ("Receiving an SMB2 WRITE Request"): the server MUST
+	// verify that the open was created
 	// with write access (FILE_WRITE_DATA or FILE_APPEND_DATA). If the open
 	// lacks write access, return STATUS_ACCESS_DENIED.
 	//
@@ -368,7 +369,8 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	// Step 8b: Break Level II (Read) oplocks from other clients
 	// ========================================================================
 	//
-	// Per MS-SMB2 3.3.5.16: If the write operation will change file data,
+	// Per MS-SMB2 §3.3.5.13 ("Receiving an SMB2 WRITE Request"): if the write
+	// operation will change file data,
 	// the server MUST break Read caching leases held by other clients to
 	// None. The writer's own lease is excluded via its LeaseKey.
 

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -1336,7 +1336,8 @@ func (lm *LeaseManager) SetLeaseEpoch(fileHandle lock.FileHandle, shareName stri
 }
 
 // BreakReadLeasesOnWrite breaks Read (Level II) oplocks/leases held by other
-// opens on a file when a WRITE is performed. Per MS-SMB2 3.3.5.16, writes must
+// opens on a file when a WRITE is performed. Per MS-SMB2
+// §3.3.5.13 ("Receiving an SMB2 WRITE Request"), writes must
 // break all Read caching on the file so that other clients see the updated data.
 //
 // For SMB2.1+ leases: the writer's own lease is excluded ONLY when it holds

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -1128,7 +1128,7 @@ func (lm *LeaseManager) BreakFileHandleLeasesOnDelete(
 //
 // excludeParentLeaseKey + hasExcludeKey carry the originating handle's
 // ParentLeaseKey (when set on its RqLs) so the dir-lease parent-key
-// suppression rule (MS-SMB2 §3.3.4.20) is applied in breakOpLocks.
+// suppression rule (Samba `dirlease_should_break`) is applied in breakOpLocks.
 func (lm *LeaseManager) resolveParentBreakArgs(
 	parentHandle lock.FileHandle,
 	shareName string,
@@ -1168,8 +1168,8 @@ func (lm *LeaseManager) resolveParentBreakArgs(
 // Required by WPTS BVT BVT_DirectoryLeasing_LeaseBreakOnMultiClients.
 //
 // excludeParentLeaseKey + hasExcludeKey carry the originating handle's RqLs
-// ParentLeaseKey for the dir-lease parent-key suppression rule (MS-SMB2
-// §3.3.4.20). Pass the zero key + false when there is no parent-key
+// ParentLeaseKey for the dir-lease parent-key suppression rule (Samba
+// `dirlease_should_break`). Pass the zero key + false when there is no parent-key
 // linkage to honor.
 func (lm *LeaseManager) BreakParentHandleLeasesOnCreate(
 	ctx context.Context,
@@ -1214,7 +1214,7 @@ func (lm *LeaseManager) BreakParentHandleLeasesOnCreate(
 // Waits for LEASE_BREAK_ACK with parentLeaseBreakWaitTimeout (same ack-wait
 // guarantee as BreakParentHandleLeasesOnCreate). excludeClientID +
 // excludeParentLeaseKey + hasExcludeKey carry the suppression rules from
-// MS-SMB2 §3.3.4.20 so a same-client or parent-key-linked dir
+// Samba `dirlease_should_break` so a same-client or parent-key-linked dir
 // lease is not broken.
 func (lm *LeaseManager) BreakParentDirLeasesOnDestructiveCreate(
 	ctx context.Context,

--- a/internal/adapter/smb/lease/manager_test.go
+++ b/internal/adapter/smb/lease/manager_test.go
@@ -625,7 +625,7 @@ func TestBreakParentHandle_ExcludesTriggeringClient(t *testing.T) {
 // TestBreakParentHandleLeasesOnCreate_ParentKeyPlumbed asserts the new
 // (#470 C2) parent-key suppression args are forwarded into the LockOwner
 // passed to BreakLeasesOnOpenConflict. The dir-lease parent-key suppression
-// rule (MS-SMB2 §3.3.4.20) is enforced INSIDE the lock manager — this test
+// rule (Samba `dirlease_should_break`) is enforced INSIDE the lock manager — this test
 // pins that the LeaseManager does the plumbing, not the actual suppression.
 func TestBreakParentHandleLeasesOnCreate_ParentKeyPlumbed(t *testing.T) {
 	t.Parallel()
@@ -981,7 +981,7 @@ func TestBreakParentDirLeasesOnDestructiveCreate_SingleBreakWithDestructiveReaso
 // TestBreakParentDirLeasesOnDestructiveCreate_PlumbsParentKeySuppression pins
 // that the C2 parent-key-suppression args (excludeClientID + parent_key +
 // hasExcludeKey) are forwarded into the LockOwner used for the break call,
-// so the dir-lease parent-key rule (MS-SMB2 §3.3.4.20) keeps applying on the
+// so the dir-lease parent-key rule (Samba `dirlease_should_break`) keeps applying on the
 // destructive path.
 func TestBreakParentDirLeasesOnDestructiveCreate_PlumbsParentKeySuppression(t *testing.T) {
 	t.Parallel()

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -1001,7 +1001,7 @@ func sendMessageWithSigner(hdr *header.SMB2Header, body []byte, connInfo *ConnIn
 // SendMessage sends an SMB2 message with NetBIOS framing, optional encryption,
 // and optional signing.
 //
-// Per MS-SMB2 3.3.4.1.1 — Signing an Outgoing Message:
+// Per MS-SMB2 3.3.4.1.1 ("Signing the Message"):
 // If the session has Session.SigningRequired set and the message is not encrypted,
 // the server MUST sign the response using the session's signing key. Encrypted
 // sessions use AEAD for integrity instead of signing (MS-SMB2 3.3.4.1.3).

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -763,7 +763,8 @@ func buildResponseHeaderAndBody(reqHeader *header.SMB2Header, ctx *handlers.SMBH
 		respHeader.TreeID = ctx.TreeID
 	}
 
-	// Per [MS-SMB2] 3.3.5.15: When a handler returns STATUS_PENDING with an
+	// Per [MS-SMB2] 3.3.4.2 ("Sending an Interim Response for an Asynchronous
+	// Operation"): when a handler returns STATUS_PENDING with an
 	// AsyncId, the response is an interim async response. Set FlagAsync and
 	// populate AsyncId on the header.
 	if result.AsyncId != 0 {
@@ -792,7 +793,8 @@ func buildResponseHeaderAndBody(reqHeader *header.SMB2Header, ctx *handlers.SMBH
 		}
 	}
 
-	// Per [MS-SMB2] 3.3.5.15: STATUS_PENDING interim responses use the
+	// Per [MS-SMB2] 3.3.4.2 (interim async response): STATUS_PENDING
+	// interim responses use the
 	// error response body format (9 bytes) even though STATUS_PENDING is
 	// a success-class status code. Ensure a body is always present.
 	if result.Status == types.StatusPending && body == nil {

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -325,7 +325,7 @@ func ProcessSingleRequest(
 	// the interim write, a fast break-drain (e.g. the holder closing rather
 	// than ACKing, as in smb2.bench.oplock1) could let the resume goroutine
 	// win the write lock and emit the final STATUS_SUCCESS before the interim
-	// STATUS_PENDING — a §3.3.4.4 ordering violation the client answers with a
+	// STATUS_PENDING — a §3.3.4.2 ordering violation the client answers with a
 	// TCP RST (NT_STATUS_CONNECTION_DISCONNECTED).
 	if reqHeader.Command == types.SMB2Create &&
 		result.Status == types.StatusPending && result.AsyncId != 0 &&
@@ -393,7 +393,8 @@ func prepareDispatch(ctx context.Context, reqHeader *header.SMB2Header, connInfo
 
 	// Propagate the compound chain position: nonzero NextCommand means another
 	// subcommand follows this one, so async interim responses are unsafe here
-	// (MS-SMB2 §3.3.4.4). Zero means standalone or last-in-compound — async OK.
+	// (MS-SMB2 §3.3.4.2 (interim async response)). Zero means standalone or
+	// last-in-compound — async OK.
 	handlerCtx.NextCommand = reqHeader.NextCommand
 
 	// Replay protection (MS-SMB2 §2.2.1.2): surface the
@@ -1235,7 +1236,8 @@ func SendAsyncChangeNotifyResponse(sessionID, messageID, asyncId uint64, respons
 // an interim response at that position, and SendAsyncCompletionResponse delivers
 // the final result as a separate message with the matching AsyncId.
 //
-// Per MS-SMB2 3.3.4.4: The async completion response uses the async header
+// Per MS-SMB2 §3.3.4.2 ("Sending an Interim Response for an Asynchronous Operation"):
+// the async completion response uses the async header
 // format (FlagAsync set, AsyncId in header) and carries the handler's final
 // status and response body.
 //

--- a/internal/adapter/smb/session/credit_validation.go
+++ b/internal/adapter/smb/session/credit_validation.go
@@ -8,7 +8,8 @@ import (
 )
 
 // IsCreditExempt returns true for commands that bypass credit checks.
-// Per MS-SMB2 3.3.5.1 (NEGOTIATE) and 3.3.5.2.3 (CANCEL).
+// Per MS-SMB2 3.3.5.1 ("Accepting an Incoming Connection") and 3.3.5.2.3
+// ("Verifying the Sequence Number").
 // First SESSION_SETUP (SessionID=0) is also exempt because the client
 // starts with 0 credits per MS-SMB2 3.3.5.1.
 //

--- a/internal/adapter/smb/session/doc.go
+++ b/internal/adapter/smb/session/doc.go
@@ -75,6 +75,6 @@
 //
 // # References
 //
-//   - [MS-SMB2] Section 3.3.1.2 - Per Session
-//   - [MS-SMB2] Section 3.3.1.1 - Global
+//   - [MS-SMB2] Section 3.3.1.8 - Per Session
+//   - [MS-SMB2] Section 3.3.1.5 - Global
 package session

--- a/internal/adapter/smb/session/sequence_window.go
+++ b/internal/adapter/smb/session/sequence_window.go
@@ -179,9 +179,11 @@ func (w *CommandSequenceWindow) Size() uint64 {
 
 // Reclaim decreases the outstanding-credit counter without retracting any
 // message IDs from the window. Used by the compound response path: each
-// sub-response's Grant() extends the window individually, but MS-SMB2
-// 3.2.4.1.4 requires middle compound responses to advertise Credits=0
-// on the wire. After zeroing those headers, Reclaim rolls back the
+// sub-response's Grant() extends the window individually, but only the last
+// response in a compound advertises credits on the wire. MS-SMB2 §3.3.4.1.3
+// ("Sending Compounded Responses") permits either — "the server MAY grant
+// credits separately on each response in the compounded chain" — so this is
+// the Windows/Samba convention, not a spec MUST. After zeroing those headers, Reclaim rolls back the
 // `available` bookkeeping so the server's view of the client's
 // cur_credits matches what we actually told the client. The underlying
 // message IDs stay marked valid — if the client ever sent one (it won't,

--- a/internal/adapter/smb/types/status.go
+++ b/internal/adapter/smb/types/status.go
@@ -208,7 +208,8 @@ const (
 
 	// StatusFileLockConflict indicates an I/O operation (READ/WRITE) conflicts
 	// with an existing byte-range lock held by another session.
-	// Per MS-SMB2 3.3.5.15 (Read) and 3.3.5.16 (Write).
+	// Per MS-SMB2 §3.3.5.12 ("Receiving an SMB2 READ Request") and
+	// §3.3.5.13 ("Receiving an SMB2 WRITE Request").
 	StatusFileLockConflict Status = 0xC0000054
 
 	// StatusLockNotGranted indicates a LOCK request could not be acquired


### PR DESCRIPTION
Closes #2152.

Comment-only. Every changed line is a `//` comment — verified mechanically, not asserted:
`git diff -U0 | grep '^[+-]'` with comment and blank lines stripped returns nothing.

## What was checked, and how

`microsoft_docs_fetch` on the MS-SMB2 landing page gave the current published revision
(**v87.0, 2026-07-14**). I pulled that PDF and extracted the complete section-number → title map
(527 sections) plus the full 499-page body text, so every verdict here is checked against the
authoritative document rather than inferred from surrounding code — which is how the three
originally-reported wrong citations survived in the first place.

**The map was validated before being trusted 800+ times:** it reproduces all seven independently
verified titles (§3.3.4.17, §3.3.5.12–.16, §3.3.5.19) exactly. Where it disagreed with the code I
confirmed against the spec *body*, not just the table of contents.

## A parser bug looks exactly like a finding

Worth recording, because it cuts both ways and the second direction is the dangerous one.

**Pass 1 invented findings.** My first extractor reported 9 cited sections as absent from the spec.
Seven were wrapped-TOC-line artifacts of my own parser. Only three survived re-parsing and a
full-body grep. The three are credible *because* the seven were killed.

**Pass 2 hid findings.** My sweep regex was `MS-SMB2[^0-9]{0,18}?(\d+(?:\.\d+)+)`, which cannot
reach a *second* section number on the same line — the first number's digits break the `[^0-9]` run.
So `write.go`'s `§3.3.4.18 / §3.3.5.16` was counted once and its second half was invisible.
**I only noticed because a later grep returned a site my own dataset did not contain.**

**Pass 3.** Fixing that surfaced a third blind spot: bare `§N.N.N` with no spec token on the line.

## The completeness argument rests on the shape-sweep, not on the keyword passes

Three keyword passes, three parser faults, and the count grew every time — 803, +25, +67. That is
not evidence of completeness; it is only evidence that no fourth fault had been tripped over yet.
**The keyword passes demonstrably missed 93 references between them**, so they cannot support the
claim. So the sweep was redone by *shape*: every `\d+(\.\d+)+` token in `internal/adapter/smb/`,
with no requirement for `MS-`, `§`, or any keyword, then every match classified.

| category | count |
| --- | ---: |
| **Total shape-matches** (263 files) | **1861** |
| − SMB dialect versions (`3.1.1`, `2.0.2`, …) | 291 |
| − IP addresses in string literals | 162 |
| − code literals outside comments (`0.25`, `1.5`) | 51 |
| − comment prose numbers (8.3 short name, Windows 8.1, DCE 1.1) | 23 |
| − ASN.1 OIDs (`1.2.840.113554.1.2.2`) | 11 |
| **= spec citations** | **1323** |

Of those 1323: MS-SMB2 814, MS-FSCC 156, MS-FSA 121, MS-NLMP 50, MS-DTYP 41, multi-spec lines 33,
RFC 11, C706 8, MS-ERREF 7, MS-SRVS 5, others 6, and 71 written as `§`/`Section` with the spec named
on a nearby line.

**The shape-sweep found a fourth class, exactly as predicted** — 67 references the keyword passes
never saw, almost all of them second-and-later section numbers on multi-section lines, plus RFC
`Section N.N` word-form. Most resolve correct, but one real cluster fell out of it: seven citations
of **§3.2.4.1.4, a CLIENT section**, used for server response behaviour (commit 7). That cluster
would have merged undetected on the strength of "I looked three times".

## Corrections

**Three fabricated sections** — zero occurrences across all 499 pages:

| cited | correct |
| --- | --- |
| `§3.1.1.2` | **§2.2.3.1.7 "SMB2_SIGNING_CAPABILITIES"** (§3.1.1 has only §3.1.1.1; the 5 textual matches are cross-refs to MS-KILE / MS-LSAD) |
| `§3.3.4.20.13` | **deleted** — §3.3.5.15.11 does not specify the `MaxOutputResponse` case at all; smbtorture `bug14788` is the real authority |
| `§3.3.5.18.1 ¶6` | **§3.3.5.18** — the quote was also wrong twice: the ADM variable is `Share.DoAccessBasedDirectoryEnumeration`, and the spec requires `GENERIC_READ` **and** `FILE_LIST_DIRECTORY` |

**Three wrong clusters** (36 sites):

| cited | actually is | correct |
| --- | --- | --- |
| `§3.3.4.18` ×13 | "Server Application Queries a Session" (MS-SRVS `SESSION_INFO_502`) | **§3.3.7.1** persist gate / **§3.3.4.7** break-driven purge |
| `§3.3.4.20` ×13 | "Server Application Queries an Open" (MS-SRVS `FILE_INFO_3`) | **deleted** — see below |
| `§3.3.4.4` ×11 | "Sending an Error Response" | **§3.3.4.2 "Sending an Interim Response for an Asynchronous Operation"** |

**Nine individual corrections** and **four label fixes** — see the per-commit messages.

## Two findings that are not renumberings

**The parent-key suppression rule is not in MS-SMB2 at all.** I traced every `ParentLeaseKey`
occurrence in the spec: it appears in the wire structures (§2.2.13.2.10, §2.2.14.2.10), in
§3.3.5.9.11 where `Lease.ParentLeaseKey` is *established* from the CREATE, and in §3.2.4.3.8 — a
**client** section. §3.3.4.7 hands the break decision to the object store. So the 13 `§3.3.4.20`
citations have no correct replacement and are deleted, leaving Samba `dirlease_should_break` as the
binding reference, with the delegation stated once on the `ParentLeaseKey` field so nobody re-adds a
server-section number for a rule the server sections do not contain.

**There is no offset to apply.** The wrong numbers are off by +1, +3, −14 and more depending on the
site. `read.go` cited §3.3.5.13 for READ (+1) while `status.go` cited §3.3.5.15 for Read (+3) — two
different errors for the same operation. Every site was matched by the behaviour it describes.

## Verified correct — left untouched deliberately

Per review, titles were added **only to citations actually changed**; the verified-correct set is
recorded here instead, to avoid hundreds of no-op lines burying the real corrections. After this PR,
151 distinct sections across 792 sites resolve correctly. The largest:

| section | title | sites |
| --- | --- | --- |
| §3.3.5.9 | Receiving an SMB2 CREATE Request | 44 |
| §3.3.5.5.2 | Reauthenticating an Existing Session | 40 |
| §3.3.5.5.3 | Handling GSS-API Authentication | 22 |
| §3.3.4.7 | Object Store Indicates a Lease Break | 22 |
| §3.3.5.14 | Receiving an SMB2 LOCK Request | 21 |
| §2.2.13 | SMB2 CREATE Request | 20 |
| §3.3.5.5 | Receiving an SMB2 SESSION_SETUP Request | 19 |
| §3.3.5.9.7 | Handling the SMB2_CREATE_DURABLE_HANDLE_RECONNECT Create Context | 19 |
| §2.2.10 | SMB2 TREE_CONNECT Response | 17 |
| §3.3.5.16 | Receiving an SMB2 CANCEL Request | 13 |

Notably §3.3.5.16 splits: 13 genuine CANCEL citations are correct and untouched, while 6 sites used
the same number for WRITE semantics and are corrected. Bulk-retitling the correct set is a separate
mechanical change with a different risk profile.

## Out of scope, split out

The same defect class exists in the **MS-FSCC** (12 sites) and **MS-FSA** (54 sites) citations in
this tree, including a fabricated `§2.1.5.14.x` family of 43 sites. Filed as **#2155** rather than
folded in. **MS-ERREF (7 sites) and MS-DTYP (37 sites) are clean.**

`close.go`'s `3.3.4.1` / `3.3.5.16.1` pair belongs to #2151 and arrives via develop.
