### PR TITLE
fix(smb): scope lease ack, reclaim and break staging to the lease's own file

### DIFF
--- a/internal/adapter/smb/handlers/lease_ack_identity_test.go
+++ b/internal/adapter/smb/handlers/lease_ack_identity_test.go
@@ -1,0 +1,68 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/lease"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// TestLeaseAck_DoesNotDowngradeAnotherClientsLease drives two V2 lease clients
+// through the real grant, break and acknowledge path.
+//
+// Two clients may present the same 16-byte lease key value on different files
+// of one share: the cross-file uniqueness rule is per (client, file), so the
+// value alone is not an identity. A LEASE_BREAK_ACK is one client's statement
+// about its own lease. It must not resolve, complete, or rewrite the state of a
+// lease another client holds under the same key value on another file.
+func TestLeaseAck_DoesNotDowngradeAnotherClientsLease(t *testing.T) {
+	t.Parallel()
+
+	mgr := lock.NewManager()
+	notifier := &capturingNotifier{}
+	leaseMgr := lease.NewLeaseManager(&staticLockResolver{mgr: mgr}, notifier)
+	mgr.RegisterBreakCallbacks(lease.NewSMBBreakHandler(leaseMgr, notifier))
+
+	ctx := context.Background()
+	const shareName = "share1"
+	leaseKey := [16]byte{0xC0, 0xFF, 0xEE}
+	const rwh = lock.LeaseStateRead | lock.LeaseStateWrite | lock.LeaseStateHandle
+	guidA := [16]byte{0xA1}
+	guidB := [16]byte{0xB2}
+
+	respA, err := ProcessLeaseCreateContext(ctx, leaseMgr, encodeV2LeaseContext(leaseKey, rwh, 0x0100),
+		lock.FileHandle("file-A"), 1, guidA, "smb:1", shareName, false, false, false)
+	if err != nil || respA.LeaseState != rwh {
+		t.Fatalf("client A CREATE: state=0x%x err=%v", respA.LeaseState, err)
+	}
+	respB, err := ProcessLeaseCreateContext(ctx, leaseMgr, encodeV2LeaseContext(leaseKey, rwh, 0x0200),
+		lock.FileHandle("file-B"), 2, guidB, "smb:2", shareName, false, false, false)
+	if err != nil || respB.LeaseState != rwh {
+		t.Fatalf("client B CREATE: state=0x%x err=%v", respB.LeaseState, err)
+	}
+
+	// Break B's lease and leave it unacknowledged.
+	if err := mgr.BreakLeasesOnOpenConflict("file-B", &lock.LockOwner{ClientID: "smb:9"}, lock.BreakReasonDestructive); err != nil {
+		t.Fatalf("break client B's lease: %v", err)
+	}
+	stateBAfterBreak, _, _ := leaseMgr.GetLeaseState(ctx, lock.FileHandle("file-B"), shareName, leaseKey)
+
+	// Break A's lease, then let A acknowledge it.
+	if err := mgr.BreakLeasesOnOpenConflict("file-A", &lock.LockOwner{ClientID: "smb:9"}, lock.BreakReasonDestructive); err != nil {
+		t.Fatalf("break client A's lease: %v", err)
+	}
+	ackState := uint32(lock.LeaseStateNone)
+	if err := leaseMgr.AcknowledgeLeaseBreak(ctx, leaseKey, 1, guidA, ackState, 0); err != nil {
+		t.Fatalf("client A ack: %v", err)
+	}
+
+	stateB, _, foundB := leaseMgr.GetLeaseState(ctx, lock.FileHandle("file-B"), shareName, leaseKey)
+	if !foundB {
+		t.Fatalf("client B's lease record disappeared after client A acknowledged its own break")
+	}
+	if stateB != stateBAfterBreak {
+		t.Errorf("client B lease state = 0x%x, want 0x%x (unchanged) — client A's LEASE_BREAK_ACK rewrote a lease B holds on another file under the same key value",
+			stateB, stateBAfterBreak)
+	}
+}

--- a/internal/adapter/smb/lease/identity_test.go
+++ b/internal/adapter/smb/lease/identity_test.go
@@ -229,7 +229,7 @@ func TestResolveAckBinding_SameSessionTwoSharesIsDeterministic(t *testing.T) {
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()
 	for i := 0; i < 200; i++ {
-		ck, found := lm.resolveAckBindingLocked(leaseKey, 1, [16]byte{})
+		ck, _, found := lm.resolveAckBindingLocked(leaseKey, 1, [16]byte{})
 		if !found {
 			t.Fatalf("iteration %d: no binding resolved", i)
 		}

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -506,7 +506,6 @@ func (lm *LeaseManager) resolveAckBindingLocked(leaseKey [16]byte, sessionID uin
 	// one of two candidates leaves the other lease Breaking until it times out
 	// and downgrades a lease nobody acknowledged.
 	var sessionKey, guidKey leaseClientKey
-	var sessionBinding, guidBinding leaseBinding
 	var sessionFound, guidFound bool
 	for ck, b := range lm.bindings {
 		if ck.Key != leaseKey {
@@ -514,7 +513,7 @@ func (lm *LeaseManager) resolveAckBindingLocked(leaseKey [16]byte, sessionID uin
 		}
 		if b.SessionID == sessionID {
 			if !sessionFound || ck.Share < sessionKey.Share {
-				sessionKey, sessionBinding, sessionFound = ck, b, true
+				sessionKey, sessionFound = ck, true
 			}
 			continue
 		}
@@ -522,13 +521,13 @@ func (lm *LeaseManager) resolveAckBindingLocked(leaseKey [16]byte, sessionID uin
 			continue
 		}
 		if !guidFound || ck.Share < guidKey.Share {
-			guidKey, guidBinding, guidFound = ck, b, true
+			guidKey, guidFound = ck, true
 		}
 	}
 	if sessionFound {
-		return sessionKey, sessionBinding, true
+		return sessionKey, lm.bindings[sessionKey], true
 	}
-	return guidKey, guidBinding, guidFound
+	return guidKey, lm.bindings[guidKey], guidFound
 }
 
 // ReleaseLeaseForHandle releases lease records only under a specific handleKey

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -444,7 +444,7 @@ func (lm *LeaseManager) AcknowledgeLeaseBreak(
 	epoch uint16,
 ) error {
 	lm.mu.RLock()
-	ck, found := lm.resolveAckBindingLocked(leaseKey, sessionID, connGUID)
+	ck, binding, found := lm.resolveAckBindingLocked(leaseKey, sessionID, connGUID)
 	lm.mu.RUnlock()
 	if !found {
 		logger.Debug("AcknowledgeLeaseBreak: no lease bound to this client (CLOSE-beat-ack), treating as success",
@@ -461,7 +461,7 @@ func (lm *LeaseManager) AcknowledgeLeaseBreak(
 		return nil
 	}
 
-	err := lockMgr.AcknowledgeLeaseBreak(ctx, leaseKey, acknowledgedState, epoch)
+	err := lockMgr.AcknowledgeLeaseBreak(ctx, binding.HandleKey, leaseKey, acknowledgedState, epoch)
 	if err != nil {
 		if errors.Is(err, lock.ErrLeaseAckNotFound) {
 			logger.Debug("AcknowledgeLeaseBreak: lease record absent (CLOSE-beat-ack), treating as success",
@@ -497,7 +497,7 @@ func (lm *LeaseManager) AcknowledgeLeaseBreak(
 // per client — single digits in practice, and only acks that are not from the
 // owning session walk past the first match. Add a by-key index if a profile
 // ever shows this scan.
-func (lm *LeaseManager) resolveAckBindingLocked(leaseKey [16]byte, sessionID uint64, connGUID [16]byte) (leaseClientKey, bool) {
+func (lm *LeaseManager) resolveAckBindingLocked(leaseKey [16]byte, sessionID uint64, connGUID [16]byte) (leaseClientKey, leaseBinding, bool) {
 	// A client holding one key in two shares makes the ack ambiguous —
 	// MS-SMB2 §3.3.5.9.8 binds a lease to (ClientGuid, LeaseKey) and does not
 	// contemplate it, and a single session can hold tree connects to both. Map
@@ -506,6 +506,7 @@ func (lm *LeaseManager) resolveAckBindingLocked(leaseKey [16]byte, sessionID uin
 	// one of two candidates leaves the other lease Breaking until it times out
 	// and downgrades a lease nobody acknowledged.
 	var sessionKey, guidKey leaseClientKey
+	var sessionBinding, guidBinding leaseBinding
 	var sessionFound, guidFound bool
 	for ck, b := range lm.bindings {
 		if ck.Key != leaseKey {
@@ -513,7 +514,7 @@ func (lm *LeaseManager) resolveAckBindingLocked(leaseKey [16]byte, sessionID uin
 		}
 		if b.SessionID == sessionID {
 			if !sessionFound || ck.Share < sessionKey.Share {
-				sessionKey, sessionFound = ck, true
+				sessionKey, sessionBinding, sessionFound = ck, b, true
 			}
 			continue
 		}
@@ -521,13 +522,13 @@ func (lm *LeaseManager) resolveAckBindingLocked(leaseKey [16]byte, sessionID uin
 			continue
 		}
 		if !guidFound || ck.Share < guidKey.Share {
-			guidKey, guidFound = ck, true
+			guidKey, guidBinding, guidFound = ck, b, true
 		}
 	}
 	if sessionFound {
-		return sessionKey, true
+		return sessionKey, sessionBinding, true
 	}
-	return guidKey, guidFound
+	return guidKey, guidBinding, guidFound
 }
 
 // ReleaseLeaseForHandle releases lease records only under a specific handleKey
@@ -692,7 +693,7 @@ func (lm *LeaseManager) GetSessionForLease(clientID, shareName string, leaseKey 
 func (lm *LeaseManager) VerifyLeaseAckOwnership(leaseKey [16]byte, sessionID uint64, connGUID [16]byte) bool {
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()
-	_, found := lm.resolveAckBindingLocked(leaseKey, sessionID, connGUID)
+	_, _, found := lm.resolveAckBindingLocked(leaseKey, sessionID, connGUID)
 	return found
 }
 

--- a/pkg/metadata/lock/byte_range_lock_wait_test.go
+++ b/pkg/metadata/lock/byte_range_lock_wait_test.go
@@ -59,7 +59,7 @@ func TestByteRangeLock_WaitForBreakBeforeGrant_ACK(t *testing.T) {
 		// correctness does not depend on it (the wait re-checks state on entry),
 		// but it exercises the channel-signal path.
 		time.Sleep(10 * time.Millisecond)
-		_ = lm.AcknowledgeLeaseBreak(context.Background(), smbLease, LeaseStateNone, 0)
+		_ = lm.AcknowledgeLeaseBreak(context.Background(), fileID, smbLease, LeaseStateNone, 0)
 	}()
 
 	// The adapter fix: wait for the break to drain before retrying the insert.

--- a/pkg/metadata/lock/dirlease_dedup_break_test.go
+++ b/pkg/metadata/lock/dirlease_dedup_break_test.go
@@ -282,7 +282,7 @@ func TestOnDirChange_SerializesMultipleDirLeaseBreaks(t *testing.T) {
 	}
 
 	// Acknowledging the first break delivers the deferred second break.
-	if err := lm.AcknowledgeLeaseBreak(context.Background(), first, LeaseStateNone, 0); err != nil {
+	if err := lm.AcknowledgeLeaseBreak(context.Background(), handleKey, first, LeaseStateNone, 0); err != nil {
 		t.Fatalf("AcknowledgeLeaseBreak: %v", err)
 	}
 
@@ -319,7 +319,7 @@ func TestAcknowledgeLeaseBreak_ClearsMirroredSiblings(t *testing.T) {
 	lm.OnDirChange(FileHandle(handleKey), DirChangeRemoveEntry, "smb:3", [16]byte{}, false)
 
 	// The client sends exactly ONE acknowledge for the shared lease key.
-	if err := lm.AcknowledgeLeaseBreak(context.Background(), dlease2Key, LeaseStateNone, 0); err != nil {
+	if err := lm.AcknowledgeLeaseBreak(context.Background(), handleKey, dlease2Key, LeaseStateNone, 0); err != nil {
 		t.Fatalf("AcknowledgeLeaseBreak: %v", err)
 	}
 

--- a/pkg/metadata/lock/lease_interface_test.go
+++ b/pkg/metadata/lock/lease_interface_test.go
@@ -174,7 +174,7 @@ func TestLockManager_HasLeaseOperations(t *testing.T) {
 	_ = err
 
 	// AcknowledgeLeaseBreak should exist
-	err = lm.AcknowledgeLeaseBreak(ctx, leaseKey, LeaseStateNone, 0)
+	err = lm.AcknowledgeLeaseBreak(ctx, "file1", leaseKey, LeaseStateNone, 0)
 	_ = err
 
 	// ReleaseLease should exist

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -956,12 +956,11 @@ func (lm *Manager) acknowledgeLeaseBreakImpl(_ context.Context, handleKey string
 	lm.mu.Lock()
 	defer lm.unlock()
 
-	// The file comes from the caller rather than from the key. An ack is one
-	// client's statement about its own lease, and a lease key is not an
-	// identity: the cross-file uniqueness rule is per (client, file), so
-	// resolving by key alone can land the ack on a lease another client holds
-	// under the same value on another file — completing a break that client
-	// never acknowledged and overwriting its state.
+	// An ack is one client's statement about its own lease, so it resolves on
+	// the file the acknowledging connection named. A key-only lookup could
+	// land it on a lease another client holds under the same key value on
+	// another file (see leaseRecordsOnHandleLocked), completing a break that
+	// client never acknowledged and overwriting its state.
 	records := lm.leaseRecordsOnHandleLocked(handleKey, leaseKey)
 	if len(records) == 0 {
 		return ErrLeaseAckNotFound
@@ -977,7 +976,7 @@ func (lm *Manager) acknowledgeLeaseBreakImpl(_ context.Context, handleKey string
 	}
 
 	if acknowledgedState == LeaseStateNone {
-		lm.completeAckToNoneLocked(handleKey, leaseKey, lock)
+		lm.completeAckToNoneLocked(handleKey, lock)
 		return nil
 	}
 
@@ -1098,7 +1097,7 @@ func validateAck(lock *UnifiedLock, acknowledgedState uint32, epoch uint16) erro
 // STATUS_UNSUCCESSFUL, smbtorture breaking2/breaking5) from a CLOSE-beat-ack
 // race (record gone → ErrLeaseAckNotFound → silent success, WPTS
 // BVT_DirectoryLeasing_ReadWriteHandleCaching). Must hold lm.mu.
-func (lm *Manager) completeAckToNoneLocked(handleKey string, leaseKey [16]byte, lock *UnifiedLock) {
+func (lm *Manager) completeAckToNoneLocked(handleKey string, lock *UnifiedLock) {
 	lock.Lease.LeaseState = LeaseStateNone
 	lock.Lease.Breaking = false
 	lock.Lease.BreakToState = 0
@@ -1110,7 +1109,7 @@ func (lm *Manager) completeAckToNoneLocked(handleKey string, leaseKey [16]byte, 
 	lm.clearBreakingSiblingsLocked(handleKey, lock)
 
 	logger.Debug("AcknowledgeLeaseBreak: lease released to None (record kept until CLOSE)",
-		"leaseKey", fmt.Sprintf("%x", leaseKey))
+		"leaseKey", fmt.Sprintf("%x", lock.Lease.LeaseKey))
 	lm.signalBreakWaitLocked(handleKey)
 	// Deliver the next directory RH-lease break on this directory that was
 	// deferred behind this one, so multi-lease dir breaks serialize.
@@ -1181,20 +1180,20 @@ func (lm *Manager) dispatchNextBreakStageLocked(handleKey string, leaseKey [16]b
 
 // clearBreakingSiblingsLocked syncs the other records of primary's lease to its
 // post-acknowledge state. Opens on one file sharing a lease key are one logical
-// lease: breakOpLocks puts such sibling records into Breaking=true via
-// mirrorBreakStageLocked without ever sending a wire notification (only one
-// break is dispatched for the shared key). A client's single acknowledge
-// resolves to one record, so without this sync the mirrored siblings stay
-// Breaking=true forever and any WaitForBreakCompletion on that handleKey blocks
-// until the force-complete timeout — a per-operation stall under directory
-// churn. Progressive multi-stage breaks (partial acks) are file-lease only and
-// never mirror across a shared key, so they are unaffected.
+// lease: OnDirChange and breakOpLocks put such sibling records into
+// Breaking=true via mirrorBreakStageLocked without ever sending a wire
+// notification (only one break is dispatched for the shared key). A client's
+// single acknowledge resolves to one record, so without this sync the mirrored
+// siblings stay Breaking=true forever and any WaitForBreakCompletion on that
+// handleKey blocks until the force-complete timeout — a per-operation stall
+// under directory churn. Progressive multi-stage breaks (partial acks) are
+// file-lease only and never mirror across a shared key, so they are unaffected.
 //
-// The sweep stops at primary's own file. mirrorBreakStageLocked only ever runs
-// over one handleKey bucket, so every sibling it creates is on that file; and
-// the cross-file uniqueness rule means a key on another file belongs to another
-// client. Reaching those would clear a Breaking flag and overwrite a LeaseState
-// on a lease whose holder acknowledged nothing. Must hold lm.mu.
+// The sweep stops at primary's own file. Both mirroring paths iterate a single
+// handleKey bucket, so every sibling they create is on that file, and a record
+// holding the key on another file belongs to another client. Reaching those
+// would clear a Breaking flag and overwrite a LeaseState on a lease whose
+// holder acknowledged nothing. Must hold lm.mu.
 func (lm *Manager) clearBreakingSiblingsLocked(handleKey string, primary *UnifiedLock) {
 	cleared := false
 	for _, lock := range lm.leaseRecordsOnHandleLocked(handleKey, primary.Lease.LeaseKey) {

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -128,10 +128,11 @@ func advanceEpoch(lease *OpLock) {
 // index is reconciled from the live slice on every mutation; if a bucket entry
 // is ever stale the in-bucket scan simply finds no match there and moves on.
 //
-// Because which holder comes back is unspecified, this must not decide a value
-// that goes out on the wire. Its callers are the LEASE_BREAK_ACK and reclaim
-// routing, which are handed only a lease key; the paths that read or write a
-// lease's state and epoch take the file as a parameter and resolve through
+// Because which holder comes back is unspecified, this must not decide anything
+// a client can observe. One caller remains: the no-lockStore reclaim branch,
+// which has no persisted record and so no file handle to scope to. Every path
+// that resolves a lease a client acts on — its state, its epoch, its break
+// acknowledgment, its reclaim — takes the file as a parameter and goes through
 // leaseRecordsOnHandleLocked instead.
 func (lm *Manager) findLeaseByKey(leaseKey [16]byte) (string, *UnifiedLock, int) {
 	buckets := lm.leaseKeyIndex[leaseKey]
@@ -1163,11 +1164,16 @@ func (lm *Manager) dispatchNextBreakStageLocked(handleKey string, leaseKey [16]b
 	// lease during the dispatch window. The `lock` pointer may now reference an
 	// orphaned UnifiedLock — read fields off the re-found record (or signal
 	// waiters and return when gone).
-	_, currentLock, _ := lm.findLeaseByKey(leaseKey)
-	if currentLock == nil {
+	//
+	// Scoped to this lease's own file: resolving by key alone would fall back to
+	// another client's lease under the same key value once this one is gone, and
+	// decide from ITS state whether this file's waiters may proceed.
+	current := lm.leaseRecordsOnHandleLocked(handleKey, leaseKey)
+	if len(current) == 0 {
 		lm.signalBreakWaitLocked(handleKey)
 		return
 	}
+	currentLock := current[0]
 
 	// Signal waiters only when the break has fully drained: either the inline
 	// fire-and-forget path already updated LeaseState to nextTarget (no further

--- a/pkg/metadata/lock/leases.go
+++ b/pkg/metadata/lock/leases.go
@@ -950,16 +950,23 @@ func lockTypeForLeaseState(state uint32) LockType {
 // The client must acknowledge with a state <= breakToState. If acknowledgedState
 // is LeaseStateNone, the lease is downgraded to None but the record is kept
 // alive until the holding handle CLOSEs (see ack-to-None block below).
-func (lm *Manager) acknowledgeLeaseBreakImpl(_ context.Context, leaseKey [16]byte,
-	acknowledgedState uint32, epoch uint16) error {
+func (lm *Manager) acknowledgeLeaseBreakImpl(_ context.Context, handleKey string,
+	leaseKey [16]byte, acknowledgedState uint32, epoch uint16) error {
 
 	lm.mu.Lock()
 	defer lm.unlock()
 
-	handleKey, lock, _ := lm.findLeaseByKey(leaseKey)
-	if lock == nil {
+	// The file comes from the caller rather than from the key. An ack is one
+	// client's statement about its own lease, and a lease key is not an
+	// identity: the cross-file uniqueness rule is per (client, file), so
+	// resolving by key alone can land the ack on a lease another client holds
+	// under the same value on another file — completing a break that client
+	// never acknowledged and overwriting its state.
+	records := lm.leaseRecordsOnHandleLocked(handleKey, leaseKey)
+	if len(records) == 0 {
 		return ErrLeaseAckNotFound
 	}
+	lock := records[0]
 
 	if !lock.Lease.Breaking {
 		return classifyLateAck(lock, leaseKey, acknowledgedState)
@@ -1000,7 +1007,7 @@ func (lm *Manager) acknowledgeLeaseBreakImpl(_ context.Context, leaseKey [16]byt
 
 	// Persist updated state
 	lm.persistUnifiedLockLocked(lock)
-	lm.clearBreakingSiblingsLocked(leaseKey, lock)
+	lm.clearBreakingSiblingsLocked(handleKey, lock)
 
 	logger.Debug("AcknowledgeLeaseBreak: break acknowledged",
 		"leaseKey", fmt.Sprintf("%x", leaseKey),
@@ -1100,7 +1107,7 @@ func (lm *Manager) completeAckToNoneLocked(handleKey string, leaseKey [16]byte, 
 	lock.Type = lockTypeForLeaseState(LeaseStateNone)
 
 	lm.persistUnifiedLockLocked(lock)
-	lm.clearBreakingSiblingsLocked(leaseKey, lock)
+	lm.clearBreakingSiblingsLocked(handleKey, lock)
 
 	logger.Debug("AcknowledgeLeaseBreak: lease released to None (record kept until CLOSE)",
 		"leaseKey", fmt.Sprintf("%x", leaseKey))
@@ -1172,36 +1179,39 @@ func (lm *Manager) dispatchNextBreakStageLocked(handleKey string, leaseKey [16]b
 	}
 }
 
-// clearBreakingSiblingsLocked syncs every other lease record sharing leaseKey to
-// primary's post-acknowledge state. Opens sharing a lease key are one logical
-// lease: OnDirChange and breakOpLocks put such sibling records into Breaking=true
-// via mirrorBreakStageLocked without ever sending a wire notification (only one
-// break is dispatched for the shared key). A client's single acknowledge resolves
-// through findLeaseByKey to exactly one record, so without this sync the mirrored
-// siblings stay Breaking=true forever and any WaitForBreakCompletion on their
-// handleKey blocks until the force-complete timeout — a per-operation stall under
-// directory churn. Progressive multi-stage breaks (partial acks) are file-lease
-// only and never mirror across a shared key, so they are unaffected. Must hold lm.mu.
-func (lm *Manager) clearBreakingSiblingsLocked(leaseKey [16]byte, primary *UnifiedLock) {
-	for handleKey := range lm.leaseKeyIndex[leaseKey] {
-		cleared := false
-		for _, lock := range lm.unifiedLocks[handleKey] {
-			if lock == primary || lock.Lease == nil ||
-				lock.Lease.LeaseKey != leaseKey || !lock.Lease.Breaking {
-				continue
-			}
-			lock.Lease.LeaseState = primary.Lease.LeaseState
-			lock.Lease.Breaking = false
-			lock.Lease.BreakToState = 0
-			lock.Lease.BreakingToRequired = primary.Lease.BreakingToRequired
-			lock.Lease.BreakStarted = time.Time{}
-			lock.Type = lockTypeForLeaseState(primary.Lease.LeaseState)
-			lm.persistUnifiedLockLocked(lock)
-			cleared = true
+// clearBreakingSiblingsLocked syncs the other records of primary's lease to its
+// post-acknowledge state. Opens on one file sharing a lease key are one logical
+// lease: breakOpLocks puts such sibling records into Breaking=true via
+// mirrorBreakStageLocked without ever sending a wire notification (only one
+// break is dispatched for the shared key). A client's single acknowledge
+// resolves to one record, so without this sync the mirrored siblings stay
+// Breaking=true forever and any WaitForBreakCompletion on that handleKey blocks
+// until the force-complete timeout — a per-operation stall under directory
+// churn. Progressive multi-stage breaks (partial acks) are file-lease only and
+// never mirror across a shared key, so they are unaffected.
+//
+// The sweep stops at primary's own file. mirrorBreakStageLocked only ever runs
+// over one handleKey bucket, so every sibling it creates is on that file; and
+// the cross-file uniqueness rule means a key on another file belongs to another
+// client. Reaching those would clear a Breaking flag and overwrite a LeaseState
+// on a lease whose holder acknowledged nothing. Must hold lm.mu.
+func (lm *Manager) clearBreakingSiblingsLocked(handleKey string, primary *UnifiedLock) {
+	cleared := false
+	for _, lock := range lm.leaseRecordsOnHandleLocked(handleKey, primary.Lease.LeaseKey) {
+		if lock == primary || !lock.Lease.Breaking {
+			continue
 		}
-		if cleared {
-			lm.signalBreakWaitLocked(handleKey)
-		}
+		lock.Lease.LeaseState = primary.Lease.LeaseState
+		lock.Lease.Breaking = false
+		lock.Lease.BreakToState = 0
+		lock.Lease.BreakingToRequired = primary.Lease.BreakingToRequired
+		lock.Lease.BreakStarted = time.Time{}
+		lock.Type = lockTypeForLeaseState(primary.Lease.LeaseState)
+		lm.persistUnifiedLockLocked(lock)
+		cleared = true
+	}
+	if cleared {
+		lm.signalBreakWaitLocked(handleKey)
 	}
 }
 
@@ -1475,9 +1485,9 @@ func (lm *Manager) RequestLeaseStatOpen(ctx context.Context, fileHandle FileHand
 }
 
 // AcknowledgeLeaseBreak processes a client's lease break acknowledgment.
-func (lm *Manager) AcknowledgeLeaseBreak(ctx context.Context, leaseKey [16]byte,
-	acknowledgedState uint32, epoch uint16) error {
-	return lm.acknowledgeLeaseBreakImpl(ctx, leaseKey, acknowledgedState, epoch)
+func (lm *Manager) AcknowledgeLeaseBreak(ctx context.Context, handleKey string,
+	leaseKey [16]byte, acknowledgedState uint32, epoch uint16) error {
+	return lm.acknowledgeLeaseBreakImpl(ctx, handleKey, leaseKey, acknowledgedState, epoch)
 }
 
 // ReleaseLease releases all lease state for the given lease key.

--- a/pkg/metadata/lock/leases_test.go
+++ b/pkg/metadata/lock/leases_test.go
@@ -225,7 +225,7 @@ func TestRequestLease_CrossKeyConflict(t *testing.T) {
 			epoch := lock.Lease.Epoch
 			// Simulate client acknowledging break to R (strip W)
 			go func() {
-				_ = mgr.AcknowledgeLeaseBreak(ctx, key, breakToState, epoch)
+				_ = mgr.AcknowledgeLeaseBreak(ctx, handleKey, key, breakToState, epoch)
 			}()
 		},
 	})
@@ -463,7 +463,7 @@ func TestRequestLease_PostAckCrossKeyDoesNotRedispatch(t *testing.T) {
 	require.EqualValues(t, 1, breakCount.Load(), "pre-RqLs break must dispatch exactly once")
 
 	// Step 3: Client 2 ACKs RWH→RH.
-	require.NoError(t, mgr.AcknowledgeLeaseBreak(ctx, key2, LeaseStateRead|LeaseStateHandle, 0))
+	require.NoError(t, mgr.AcknowledgeLeaseBreak(ctx, "file1", key2, LeaseStateRead|LeaseStateHandle, 0))
 
 	// Verify LEASE2 is now at RH, not Breaking.
 	curState, _, ok := mgr.GetLeaseState(ctx, "file1", key2)
@@ -964,7 +964,7 @@ func TestAcknowledgeLeaseBreak_CompletesBreak(t *testing.T) {
 			epoch := lock.Lease.Epoch
 			// Acknowledge break to None (fully relinquish) asynchronously
 			go func() {
-				_ = mgr.AcknowledgeLeaseBreak(ctx, key, LeaseStateNone, epoch)
+				_ = mgr.AcknowledgeLeaseBreak(ctx, handleKey, key, LeaseStateNone, epoch)
 			}()
 		},
 	})
@@ -1023,7 +1023,7 @@ func TestAcknowledgeLeaseBreak_ToReadState(t *testing.T) {
 	mgr.mu.Unlock()
 
 	// Acknowledge to Read
-	err = mgr.AcknowledgeLeaseBreak(ctx, key1, LeaseStateRead, 0)
+	err = mgr.AcknowledgeLeaseBreak(ctx, "file1", key1, LeaseStateRead, 0)
 	require.NoError(t, err)
 
 	// Verify state was updated
@@ -1045,7 +1045,7 @@ func TestAcknowledgeLeaseBreak_NoActiveBreak(t *testing.T) {
 	require.NoError(t, err)
 
 	// Try to acknowledge a break that doesn't exist
-	err = mgr.AcknowledgeLeaseBreak(ctx, leaseKey, LeaseStateNone, 0)
+	err = mgr.AcknowledgeLeaseBreak(ctx, "file1", leaseKey, LeaseStateNone, 0)
 	assert.Error(t, err, "should error when no break in progress")
 }
 
@@ -1076,7 +1076,7 @@ func TestAcknowledgeLeaseBreak_AckToNone_KeepsRecordAtNone(t *testing.T) {
 	mgr.mu.Unlock()
 
 	// Acknowledge to None (fully release)
-	err = mgr.AcknowledgeLeaseBreak(ctx, key1, LeaseStateNone, 0)
+	err = mgr.AcknowledgeLeaseBreak(ctx, "file1", key1, LeaseStateNone, 0)
 	require.NoError(t, err)
 
 	// Per MS-SMB2 3.3.5.22.2 + smbtorture breaking2/breaking5: the lease
@@ -1087,7 +1087,7 @@ func TestAcknowledgeLeaseBreak_AckToNone_KeepsRecordAtNone(t *testing.T) {
 	assert.Equal(t, LeaseStateNone, state, "lease state should be None")
 
 	// Duplicate ack on the released record → ErrLeaseAckNotBreaking.
-	err = mgr.AcknowledgeLeaseBreak(ctx, key1, LeaseStateNone, 0)
+	err = mgr.AcknowledgeLeaseBreak(ctx, "file1", key1, LeaseStateNone, 0)
 	assert.ErrorIs(t, err, ErrLeaseAckNotBreaking, "duplicate ack must surface ErrLeaseAckNotBreaking")
 
 	// CLOSE removes the record fully.
@@ -1142,7 +1142,7 @@ func TestAcknowledgeLeaseBreak_LateAckNonNoneAfterTimeout_Succeeds(t *testing.T)
 
 	// Holder ACKs late with RW (its handle-strip break-to, a non-None state).
 	// Must succeed — the break the server already completed is benignly ack'd.
-	err = mgr.AcknowledgeLeaseBreak(ctx, key1, LeaseStateRead|LeaseStateWrite, 0)
+	err = mgr.AcknowledgeLeaseBreak(ctx, "file1", key1, LeaseStateRead|LeaseStateWrite, 0)
 	require.NoError(t, err, "late non-None ACK after timeout force-complete must succeed (ack-sane)")
 
 	// The ACK must not resurrect bits: the forced None stands.
@@ -1183,7 +1183,7 @@ func TestAcknowledgeLeaseBreak_LateAckAfterLeaseConflictTimeout_Unsuccessful(t *
 	require.Equal(t, LeaseStateNone, state, "force-complete revoked to None")
 
 	// The deadbeat holder's late ACK must fail with STATUS_UNSUCCESSFUL.
-	err = mgr.AcknowledgeLeaseBreak(ctx, key1, LeaseStateRead|LeaseStateHandle, 0)
+	err = mgr.AcknowledgeLeaseBreak(ctx, "file1", key1, LeaseStateRead|LeaseStateHandle, 0)
 	require.ErrorIs(t, err, ErrLeaseAckNotBreaking,
 		"late ACK after open-conflict force-complete must be UNSUCCESSFUL (smb2.lease.timeout)")
 }
@@ -1527,7 +1527,7 @@ func TestEpoch_BreakPlusAck_SingleIncrement(t *testing.T) {
 		"break initiation must advance epoch to grant + 1")
 
 	// ACK. Epoch must stay at 2: the state change was already counted.
-	require.NoError(t, mgr.AcknowledgeLeaseBreak(ctx, key, LeaseStateRead|LeaseStateHandle, 2))
+	require.NoError(t, mgr.AcknowledgeLeaseBreak(ctx, "file1", key, LeaseStateRead|LeaseStateHandle, 2))
 	assert.Equal(t, uint16(2), epochForLease(t, mgr, key),
 		"ACK must not advance epoch — would drift one past the client (#417)")
 }
@@ -1548,12 +1548,12 @@ func TestEpoch_TwoBreakCycles_TwoIncrements(t *testing.T) {
 
 	// Cycle 1: break RWH → RH, ACK.
 	setBreaking(t, mgr, key, LeaseStateRead|LeaseStateHandle)
-	require.NoError(t, mgr.AcknowledgeLeaseBreak(ctx, key, LeaseStateRead|LeaseStateHandle, 2))
+	require.NoError(t, mgr.AcknowledgeLeaseBreak(ctx, "file2", key, LeaseStateRead|LeaseStateHandle, 2))
 	require.Equal(t, uint16(2), epochForLease(t, mgr, key))
 
 	// Cycle 2: break RH → R, ACK. One more increment expected.
 	setBreaking(t, mgr, key, LeaseStateRead)
-	require.NoError(t, mgr.AcknowledgeLeaseBreak(ctx, key, LeaseStateRead, 3))
+	require.NoError(t, mgr.AcknowledgeLeaseBreak(ctx, "file2", key, LeaseStateRead, 3))
 	assert.Equal(t, uint16(3), epochForLease(t, mgr, key),
 		"two break/ack cycles must yield exactly two increments total")
 }
@@ -1961,7 +1961,7 @@ func TestProgressiveLeaseBreak_RWH_AndMerge_ToNone(t *testing.T) {
 
 	// Stage 3: client ACKs RWH→RH. Re-eval finds acked state has H bit ⇒
 	// next target = required(0) | R = R. Dispatch RH→R.
-	require.NoError(t, mgr.AcknowledgeLeaseBreak(ctx,
+	require.NoError(t, mgr.AcknowledgeLeaseBreak(ctx, handleKey,
 		key1, LeaseStateRead|LeaseStateHandle, 0))
 
 	got = snapshotBreaks(breakMu, breaks)
@@ -1981,7 +1981,7 @@ func TestProgressiveLeaseBreak_RWH_AndMerge_ToNone(t *testing.T) {
 	// H ⇒ next target = required(0) = 0. Dispatch R→"" (fire-and-forget,
 	// inline downgrade). Record persists at LeaseState=None (handle-bound
 	// lifetime — only CLOSE removes it).
-	require.NoError(t, mgr.AcknowledgeLeaseBreak(ctx, key1, LeaseStateRead, 0))
+	require.NoError(t, mgr.AcknowledgeLeaseBreak(ctx, handleKey, key1, LeaseStateRead, 0))
 
 	got = snapshotBreaks(breakMu, breaks)
 	require.Len(t, got, 3, "stage 4: ACK RH→R triggers R→\"\" notification")
@@ -2018,7 +2018,7 @@ func TestProgressiveLeaseBreak_NoSpuriousAfterReachingRequired(t *testing.T) {
 
 	// Client ACKs to the offered state. No concurrent break has tightened
 	// BreakingToRequired ⇒ no second stage dispatched.
-	require.NoError(t, mgr.AcknowledgeLeaseBreak(ctx,
+	require.NoError(t, mgr.AcknowledgeLeaseBreak(ctx, handleKey,
 		key1, LeaseStateRead|LeaseStateHandle, 0))
 
 	assert.Len(t, snapshotBreaks(breakMu, breaks), 1,

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -121,9 +121,15 @@ type LockManager interface {
 		parentLeaseKey [16]byte, ownerID string, clientID string, shareName string,
 		requestedState uint32, isDirectory bool) (grantedState uint32, epoch uint16, err error)
 
-	// AcknowledgeLeaseBreak processes a client's lease break acknowledgment.
-	// acknowledgedState is the state the client accepts (must be <= breakToState).
-	AcknowledgeLeaseBreak(ctx context.Context, leaseKey [16]byte,
+	// AcknowledgeLeaseBreak processes a client's lease break acknowledgment on
+	// one file. acknowledgedState is the state the client accepts (must be <=
+	// breakToState).
+	//
+	// The file is a parameter because the wire gives only a lease key, which is
+	// not an identity: another client may hold the same value on another file
+	// of this share. The acknowledging connection supplies the rest, exactly as
+	// MS-SMB2 §3.3.5.22.2 step 1 requires.
+	AcknowledgeLeaseBreak(ctx context.Context, handleKey string, leaseKey [16]byte,
 		acknowledgedState uint32, epoch uint16) error
 
 	// ReleaseLease releases ALL lease state for the given lease key across

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -125,10 +125,9 @@ type LockManager interface {
 	// one file. acknowledgedState is the state the client accepts (must be <=
 	// breakToState).
 	//
-	// The file is a parameter because the wire gives only a lease key, which is
-	// not an identity: another client may hold the same value on another file
-	// of this share. The acknowledging connection supplies the rest, exactly as
-	// MS-SMB2 §3.3.5.22.2 step 1 requires.
+	// handleKey scopes the ack to the acknowledging client's own lease: the
+	// wire carries only a lease key, and another client may hold the same key
+	// value on another file of this share.
 	AcknowledgeLeaseBreak(ctx context.Context, handleKey string, leaseKey [16]byte,
 		acknowledgedState uint32, epoch uint16) error
 

--- a/pkg/metadata/lock/reclaim.go
+++ b/pkg/metadata/lock/reclaim.go
@@ -151,7 +151,12 @@ func (lm *Manager) reclaimLeaseImpl(ctx context.Context, leaseKey [16]byte,
 
 			lm.mu.Lock()
 			handleKey := string(lock.FileHandle)
-			if _, existing, _ := lm.findLeaseByKey(leaseKey); existing != nil {
+			// Scoped to this record's own file: resolving by key alone would
+			// find a lease another client holds under the same key value on
+			// another file, then mutate and return THAT record — leaving this
+			// client's own lease unrestored.
+			if existing := lm.leaseRecordsOnHandleLocked(handleKey, leaseKey); len(existing) > 0 {
+				existing := existing[0]
 				// Already reclaimed - update state and return existing
 				existing.Lease.LeaseState = requestedState
 				existing.Type = lockTypeForLeaseState(requestedState)

--- a/pkg/metadata/lock/reclaim.go
+++ b/pkg/metadata/lock/reclaim.go
@@ -182,7 +182,10 @@ func (lm *Manager) reclaimLeaseImpl(ctx context.Context, leaseKey [16]byte,
 		return nil, fmt.Errorf("no persisted lease found with key %x", leaseKey)
 	}
 
-	// No lockStore: try to find in memory (for testing without persistence)
+	// No lockStore: try to find in memory (for testing without persistence).
+	// This is the one lease lookup left resolving by key alone — with no
+	// persisted record there is no file handle to scope it to. Configure a
+	// lockStore for any path where two clients may share a key value.
 	lm.mu.Lock()
 	defer lm.unlock()
 

--- a/pkg/metadata/lock/reclaim.go
+++ b/pkg/metadata/lock/reclaim.go
@@ -155,9 +155,10 @@ func (lm *Manager) reclaimLeaseImpl(ctx context.Context, leaseKey [16]byte,
 			// find a lease another client holds under the same key value on
 			// another file, then mutate and return THAT record — leaving this
 			// client's own lease unrestored.
-			if existing := lm.leaseRecordsOnHandleLocked(handleKey, leaseKey); len(existing) > 0 {
-				existing := existing[0]
+			records := lm.leaseRecordsOnHandleLocked(handleKey, leaseKey)
+			if len(records) > 0 {
 				// Already reclaimed - update state and return existing
+				existing := records[0]
 				existing.Lease.LeaseState = requestedState
 				existing.Type = lockTypeForLeaseState(requestedState)
 				existing.Reclaim = true

--- a/pkg/metadata/lock/reclaim_identity_test.go
+++ b/pkg/metadata/lock/reclaim_identity_test.go
@@ -1,0 +1,63 @@
+package lock
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestReclaimLease_ReturnsTheReclaimingClientsOwnLease drives a real
+// restart-into-grace and inspects which record the reclaim comes back with.
+//
+// Two clients may hold the same 16-byte lease key value on different files of
+// one share: the cross-file uniqueness rule is per (client, file), so the value
+// alone is not an identity. The persisted-record lookup is correctly scoped by
+// clientID, but the in-memory short-circuit that follows it is not — so once
+// one client's record is back in memory, the other's reclaim can resolve to it.
+func TestReclaimLease_ReturnsTheReclaimingClientsOwnLease(t *testing.T) {
+	ctx := context.Background()
+	store := newMockLockStore()
+
+	leaseKey := [16]byte{0x5E, 0xED}
+	const rh = LeaseStateRead | LeaseStateHandle
+
+	// Two clients take the same key value on different files, and both leases
+	// are persisted.
+	mgr := NewManager()
+	mgr.SetLockStore(store)
+	mgr.SetShareName("share-a")
+
+	_, _, err := mgr.RequestLease(ctx, FileHandle("share-a:file-X"), leaseKey, [16]byte{},
+		"owner-A", "clientA", "share-a", rh, false)
+	require.NoError(t, err)
+	_, _, err = mgr.RequestLease(ctx, FileHandle("share-a:file-Y"), leaseKey, [16]byte{},
+		"owner-B", "clientB", "share-a", rh, false)
+	require.NoError(t, err)
+
+	persisted, err := store.ListLocks(ctx, LockQuery{ShareName: "share-a"})
+	require.NoError(t, err)
+	require.Len(t, persisted, 2, "both clients' leases should be persisted")
+
+	// Restart: fresh manager over the same store, inside the grace window.
+	fresh := NewManagerWithGracePeriod(NewGracePeriodManager(2*time.Minute, func() {}))
+	fresh.SetLockStore(store)
+	fresh.SetShareName("share-a")
+	fresh.EnterGracePeriod([]string{"clientA", "clientB"})
+	require.True(t, fresh.IsInGracePeriod())
+
+	// Client B reclaims first, putting its record back in memory.
+	lockB, err := fresh.ReclaimLease(ctx, leaseKey, rh, false, "clientB")
+	require.NoError(t, err)
+	require.Equal(t, FileHandle("share-a:file-Y"), lockB.FileHandle,
+		"client B must reclaim its own lease on file-Y")
+
+	// Client A now reclaims. It must get its own lease on file-X.
+	lockA, err := fresh.ReclaimLease(ctx, leaseKey, rh, false, "clientA")
+	require.NoError(t, err)
+	require.Equal(t, FileHandle("share-a:file-X"), lockA.FileHandle,
+		"client A reclaimed a lease on the wrong file — the in-memory short-circuit resolved by lease key alone and handed back client B's record")
+	require.Equal(t, "clientA", lockA.Owner.ClientID,
+		"client A reclaimed a record owned by another client")
+}

--- a/pkg/metadata/lock/wait_share_conflict_test.go
+++ b/pkg/metadata/lock/wait_share_conflict_test.go
@@ -90,7 +90,7 @@ func TestWaitForShareConflictClear_ReturnsWhenBreakDrainsButConflictPersists(t *
 	// Holder ACKs the break to RW (Handle stripped), keeping its open. This
 	// clears Breaking; the wait must then exit on the no-breaking-lease branch.
 	time.Sleep(150 * time.Millisecond)
-	require.NoError(t, lm.AcknowledgeLeaseBreak(ctx, holderKey, LeaseStateRead|LeaseStateWrite, 0))
+	require.NoError(t, lm.AcknowledgeLeaseBreak(ctx, "file2", holderKey, LeaseStateRead|LeaseStateWrite, 0))
 
 	select {
 	case err := <-done:
@@ -137,6 +137,6 @@ func TestWaitForShareConflictClear_TimeoutDoesNotForceComplete(t *testing.T) {
 	// The lease must NOT be a timeout tombstone — it is still breaking, so a
 	// late ACK succeeds (contrast WaitForBreakCompletion, which would have
 	// force-revoked it to None and made the ACK fail STATUS_UNSUCCESSFUL).
-	require.NoError(t, lm.AcknowledgeLeaseBreak(ctx, holderKey, LeaseStateRead|LeaseStateWrite, 0),
+	require.NoError(t, lm.AcknowledgeLeaseBreak(ctx, "file3", holderKey, LeaseStateRead|LeaseStateWrite, 0),
 		"holder ACK after the deferred-open timeout must still succeed (lease not tombstoned)")
 }


### PR DESCRIPTION
## Both paths reproduce. Neither was refuted.

#2150 filed its own reachability as *predicted from a code read only*. Both are
now demonstrated, and the ack one is materially worse than the epoch defect
#2149 fixed.

### A client's lease is silently revoked by another client's acknowledgment

`internal/adapter/smb/handlers/lease_ack_identity_test.go` grants two V2 leases
under the same 16-byte key value on different files of one share, breaks B's
lease and leaves it unacknowledged, then breaks and acknowledges **A's**.
Against the pre-fix tree:

```
client B lease state = 0x0, want 0x7 (unchanged) — client A's LEASE_BREAK_ACK
rewrote a lease B holds on another file under the same key value
```

Client B's lease goes `RWH` → `None`. Fully revoked. B never acknowledged
anything and receives no notification, so B's client still believes it holds
write and handle caching and keeps caching writes for a lease the server has
destroyed.

The test drives the real path — `ProcessLeaseCreateContext` for the grants,
`BreakLeasesOnOpenConflict` for the breaks, and the SMB-layer
`AcknowledgeLeaseBreak` that resolves the binding from session + ClientGUID. It
does not call the impl and assert it touched the wrong bucket.

### A reclaim returns another client's lease

`pkg/metadata/lock/reclaim_identity_test.go` does a real restart into the grace
window over a real lock store:

```
expected: "share-a:file-X"
actual  : "share-a:file-Y"
```

Client A's reclaim comes back with **B's** record, on a file A never asked
about, and A's own lease on file-X is never restored.

## The spec says this is structurally impossible, not merely undesirable

MS-SMB2 §3.3.5.22.2 (Processing a Lease Acknowledgment), verbatim:

> the server MUST locate the Lease Table by performing a lookup in
> **GlobalLeaseTableList** using **Connection.ClientGuid** as the lookup key. […]
> The server MUST locate the lease on which the client is acknowledging a lease
> break by performing a lookup in **LeaseTable.LeaseList** using the **LeaseKey**
> of the request as the lookup key.

The lookup is **two-level**: ClientGuid selects a lease table, and only then does
LeaseKey select a lease *within that client's table*. §3.3.4.7 uses the identical
shape for break dispatch (`ClientGuid` → LeaseTable, `ClientLeaseId` → Lease). A
lease key only ever names an entry inside one client's namespace, so an ack
reaching another client's lease cannot happen in the spec's data model at all.

DittoFS keeps one flat map keyed by the raw value, which is exactly the
mismatch. This change restores the spec's own structure rather than bolting a
guard onto a flat lookup.

## Root cause

#2139 split lease identity from the key value in the SMB adapter; #2149 carried
that split into the epoch and state axis of `lock.Manager`. The ack and reclaim
paths were left, and are the same defect one level down.

## The fix

| | before | after |
| --- | --- | --- |
| `AcknowledgeLeaseBreak` | `(ctx, leaseKey, state, epoch)` | `(ctx, handleKey, leaseKey, state, epoch)` |
| `clearBreakingSiblingsLocked` | every bucket holding the key | the primary's own bucket |
| `reclaimLeaseImpl` step 7 | `findLeaseByKey(leaseKey)` | the `handleKey` it already computed |
| `dispatchNextBreakStageLocked` | `findLeaseByKey(leaseKey)` | the `handleKey` already in scope |

That last row was not in the issue. Review caught it, and it belongs here rather
than in a follow-up: it is reached **from `acknowledgeLeaseBreakImpl` itself** on
the progressive multi-stage break path, so it is the same defect in the same call
chain as the ack this PR fixes. It re-resolves after releasing `lm.mu` for the
dispatch, and if this lease is gone by then it would fall back to another
client's record under the same key and read ITS `LeaseState` to decide whether
this file's waiters may proceed. Patching only the sites the issue named would
have left a sibling on the same path broken.

After this change `findLeaseByKey` has exactly **one** production caller left —
the no-lockStore reclaim branch, which has no persisted record and therefore no
file handle to scope to. Its doc and that call site now say so.

The SMB layer already resolved `(client, share, key)` in `resolveAckBindingLocked`
to pick the right share's lock manager; it now also returns the `leaseBinding`,
whose `HandleKey` was recorded at grant, so the file reaches the lock layer. One
production caller.

### Why narrowing the sibling sweep is safe

The sweep is load-bearing and is NOT removed. Its own commit documents why it
exists: `breakOpLocks` and `OnDirChange` mirror a break stage onto same-key
siblings without sending a second wire notification, so a client's single
acknowledgment must clear them or they stay `Breaking=true` forever and every
later `WaitForBreakCompletion` on that handle stalls until the force-complete
timeout.

What changed is only its scope, and the load-bearing set is unaffected:

- Both mirroring paths iterate **one** `handleKey` bucket — `break.go:765`
  inside `breakOpLocks`, and `directory.go:225` inside `OnDirChange`, which
  takes `handleKey := string(parentHandle)` and reads `lm.unifiedLocks[handleKey]`.
  Every sibling either path can create is therefore on the primary's own file.
- The cross-file uniqueness rule means a record for the key on a *different*
  file belongs to a *different client* — never a legitimate sibling.
- `TestAcknowledgeLeaseBreak_ClearsMirroredSiblings`, which pins the stall this
  sweep prevents, uses one `handleKey` with two same-key records and passes
  unchanged.

## Scope: the issue was slightly wrong, in DittoFS's favour

#2150 said `reclaimLeaseImpl` resolves by key across all buckets. The
**persisted** lookup is in fact correctly clientID-scoped, with a
defence-in-depth assert against an over-permissive store backend. Only the
in-memory short-circuit that follows it is key-only — and it computes
`handleKey` one line above and then does not use it. Narrower than filed.

The no-lockStore branch of `reclaimLeaseImpl` still resolves by key. It has no
file handle to scope to, and is the documented "testing without persistence"
path; left as is.

## Verification

- Two regression tests, each failing before and passing after.
- `go build ./... && go vet ./... && go test ./...` green.
- `go test -race` green on `pkg/metadata/lock/...` and `internal/adapter/smb/...`.
- Every binding writer sets or preserves `HandleKey`: the grant path assigns
  `binding.HandleKey = string(fileHandle)`, and `UpdateSessionForLease` (durable
  reconnect) mutates only `SessionID` on an existing binding and returns early
  when there is none. So routing the ack by `binding.HandleKey` cannot resolve
  to an empty handle.
- `break_twice`, `breaking*`, `v2_breaking3` and the `dhv2` replay family run in
  CI's smbtorture jobs on this PR.

22 ack call sites across 6 test files were updated to name the file each test
granted on. No assertion was weakened, deleted, or changed.

Closes #2150
