### PR TITLE
ci(smb-compat): record how long srvnet actually takes to release TCP 445

### DIFF
--- a/.github/workflows/smb-client-compat.yml
+++ b/.github/workflows/smb-client-compat.yml
@@ -357,9 +357,15 @@ jobs:
           # well as the ones that ran out of budget; a give-up otherwise
           # records only the verdict. srvnet_state distinguishes a driver
           # still pending at the deadline from one that reached STOPPED.
+          # failed_polls is the loop counter at exit, which is the number of
+          # polls that still saw 445 held -- 0 when the first poll found it
+          # free, 15 when the budget ran out. It is deliberately not the number
+          # of polls performed: that is failed_polls+1 after an early break but
+          # only 15 after exhaustion, so it would not mean the same thing on
+          # both paths.
           $srvnetState = (sc.exe query srvnet 2>&1 | Select-String -Pattern 'STATE' | ForEach-Object { ($_.Line -replace '\s+', ' ').Trim() }) -join ' '
           if (-not $srvnetState) { $srvnetState = 'unknown' }
-          Write-Host "srvnet-stop-timing freed=$freed elapsed_ms=$([int]$stopWatch.Elapsed.TotalMilliseconds) poll_iters=$i srvnet_state='$srvnetState'"
+          Write-Host "srvnet-stop-timing freed=$freed elapsed_ms=$([int]$stopWatch.Elapsed.TotalMilliseconds) failed_polls=$i srvnet_state='$srvnetState'"
           (Get-NetTCPConnection -LocalPort 445 -State Listen -ErrorAction SilentlyContinue) | Format-Table -AutoSize
           # The net use assertions below are gated on this: the redirector can
           # only reach DittoFS when DittoFS owns 445. Asserting anyway turns an

--- a/.github/workflows/smb-client-compat.yml
+++ b/.github/workflows/smb-client-compat.yml
@@ -334,6 +334,11 @@ jobs:
           sc.exe config LanmanServer start= disabled | Out-Null
           sc.exe config srv2 start= disabled | Out-Null
           sc.exe config srvnet start= disabled | Out-Null
+          # Timing only: the stopwatch and the log line below do not change
+          # whether or when the loop gives up. It starts here so the measured
+          # span matches what the log shows -- from the first stop request to
+          # the moment 445 is observed free, or to the give-up.
+          $stopWatch = [Diagnostics.Stopwatch]::StartNew()
           foreach ($svc in 'LanmanServer','srv2','srvnet') {
             sc.exe stop $svc 2>&1 | Out-String | Write-Host
           }
@@ -344,7 +349,17 @@ jobs:
             sc.exe stop srvnet 2>&1 | Out-Null
             Start-Sleep -Seconds 2
           }
+          $stopWatch.Stop()
           Write-Host "TCP 445 freed for DittoFS: $freed (false => hosted-runner kernel listener; net use cannot reach DittoFS without a reboot)"
+          # Emitted on every run, not only on give-ups. srvnet enters
+          # STOP_PENDING either way, so telling "slow to stop" apart from
+          # "never stops" needs the durations of the runs that freed 445 as
+          # well as the ones that ran out of budget; a give-up otherwise
+          # records only the verdict. srvnet_state distinguishes a driver
+          # still pending at the deadline from one that reached STOPPED.
+          $srvnetState = (sc.exe query srvnet 2>&1 | Select-String -Pattern 'STATE' | ForEach-Object { ($_.Line -replace '\s+', ' ').Trim() }) -join ' '
+          if (-not $srvnetState) { $srvnetState = 'unknown' }
+          Write-Host "srvnet-stop-timing freed=$freed elapsed_ms=$([int]$stopWatch.Elapsed.TotalMilliseconds) poll_iters=$i srvnet_state='$srvnetState'"
           (Get-NetTCPConnection -LocalPort 445 -State Listen -ErrorAction SilentlyContinue) | Format-Table -AutoSize
           # The net use assertions below are gated on this: the redirector can
           # only reach DittoFS when DittoFS owns 445. Asserting anyway turns an


### PR DESCRIPTION
## What this is

The measurement step for #2154, not the decision. **This PR does not close that issue**
and deliberately does not touch the timeout.

## Why the timeout is not being raised

The wait loop in the Windows job gives up after 15 x 2s and reports `SMB445_FREE=false`.
Evidence from #2148 showed `srvnet` sitting in `STOP_PENDING` in *both* outcomes — it
completed at ~11s on job 97882736949 and was still pending at the ~32s give-up on job
97873632656. Two readings cannot tell "slow to stop" apart from "never stops", and those
two worlds call for opposite fixes.

Raising the number is a one-line change with plenty of headroom (30s inside a 15-minute
job that finishes in 4-6 minutes), which is exactly why it is the wrong move first. If
the longer wait turns out to be silently useless, nothing fails and nothing is logged —
the change accrues confidence in proportion to how long it has been doing nothing. So:
measure, then decide.

## The change

The loop reported only its verdict. Now it also reports how long the verdict took.

- A stopwatch spanning the first `sc.exe stop` request to the loop's exit — the same
  span the two data points above were read from, so new numbers are comparable to them.
- One greppable line, emitted **unconditionally**:

```
srvnet-stop-timing freed=<bool> elapsed_ms=<int> failed_polls=<int> srvnet_state='<STATE line>'
```

Logging only give-ups would produce a censored sample: the `~11s` figure came from a run
that *passed*, and the comparison that matters is between the two populations. So the
success path is instrumented too.

`srvnet_state` comes from `sc.exe query srvnet` after the loop, and is the field that
actually discriminates: a give-up at `STOP_PENDING` is consistent with a budget that is
too short, whereas a give-up with srvnet never advancing points at a wedged driver, where
no budget helps.

## Control flow is unchanged

The diff is **purely additive — 15 insertions, 0 deletions**, so no existing line was
modified. The iteration count, the poll condition, the per-iteration `sc.exe stop` calls,
the `break`, and the give-up behaviour are byte-identical. This observes the existing
behaviour rather than a new one.

The added `sc.exe query srvnet` sits before the step's existing `$global:LASTEXITCODE = 0`
reset, so it introduces no exit-code leak.

## Verification

All nine `pwsh` steps parse clean. The step was executed against stubs for three cases,
since the whole point is that the line must appear on every path:

```
===== A: 445 free on first poll =====
srvnet-stop-timing freed=True  elapsed_ms=11 failed_polls=0  srvnet_state='STATE : 1 STOPPED'
GITHUB_ENV -> SMB445_FREE=true      final LASTEXITCODE: 0

===== B: 445 free on 5th poll =====
srvnet-stop-timing freed=True  elapsed_ms=10 failed_polls=4  srvnet_state='STATE : 1 STOPPED'
GITHUB_ENV -> SMB445_FREE=true      final LASTEXITCODE: 0

===== C: never frees (give-up) =====
srvnet-stop-timing freed=False elapsed_ms=17 failed_polls=15 srvnet_state='STATE : 3 STOP_PENDING'
GITHUB_ENV -> SMB445_FREE=false     final LASTEXITCODE: 0
```

`SMB445_FREE` is still written correctly on every path and none leaks a non-zero exit
code. (`elapsed_ms` is tiny here only because `Start-Sleep` is stubbed.)

### On real CI, both branches

`smb-client-compat.yml` does not trigger on pull requests, so this PR's own checks do not
exercise it. Dispatched on the branch instead:

**Give-up branch** — [32904946454](https://github.com/marmos91/dittofs/actions/runs/32904946454),
Windows job success:

```
srvnet-stop-timing freed=False elapsed_ms=32480 failed_polls=15 srvnet_state='STATE : 3 STOP_PENDING'
```

That is already a real data point, and it matches the ~32s give-up seen on job
97873632656 in #2148.

**Loop-success branch** — a dispatch never draws a runner that frees 445, so rather than
roll for it I forced it on a throwaway branch by pointing the poll at an unused port, so
the loop breaks on its first poll:

```
srvnet-stop-timing freed=True elapsed_ms=912 failed_polls=0 srvnet_state='STATE : 3 STOP_PENDING'
```

This was the case worth forcing, because the harness stubbed `sc.exe query srvnet` and
the real binary's output had never been parsed. It came back as a single clean `STATE`
line, not multiline noise and not empty. (`STOP_PENDING` is correct there — only the port
probe was faked, srvnet genuinely had not stopped.) That run also failed at the bind via
the guard from #2153, which is the expected behaviour on a forced-true flag. Throwaway
branch deleted.

## What this does not do, and what would close #2154

#2154 stays open, but as waiting-on-data rather than waiting-on-someone-to-look. What
closes it: let these lines accumulate across the weekly and push-triggered runs, then read
the distribution. If give-ups cluster just past the current budget, a larger budget is
justified by data. If they sit flat at the ceiling with srvnet never advancing past
`STOP_PENDING`, the wait is not the variable and the budget should stay as it is. Only
that reading justifies changing the number.

This also does not affect the gate shipped in #2153 — some runners genuinely cannot
release 445 without a reboot, so the bind stays gated and the skip stays visible however
the budget is eventually tuned.

Refs #2154
