### PR TITLE
fix(block): seed the local tier for a server-side copy's destination

### DIFF
--- a/internal/adapter/common/clone.go
+++ b/internal/adapter/common/clone.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"time"
 
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/engine"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
@@ -71,6 +73,7 @@ func CloneWholeFile(
 	}
 
 	selfClone := false
+	var copied []block.ChunkRef
 	err := metadataStore.WithTransaction(ctx, func(tx metadata.Transaction) error {
 		// Bind the active txn into the context so the per-share coordinator's
 		// RefCount UPDATEs (driven by engine.CopyPayload) join the same txn as
@@ -106,6 +109,7 @@ func CloneWholeFile(
 			return fmt.Errorf("engine copy payload: %w", err)
 		}
 		dstFile.Blocks = newBlocks
+		copied = newBlocks
 		// Wholesale manifest replacement on the destination — persist refs.
 		dstFile.Size = srcFile.Size
 		dstFile.Mtime = time.Now()
@@ -118,14 +122,49 @@ func CloneWholeFile(
 	if err != nil {
 		return err
 	}
+	// A self-clone left the destination exactly as it was: it inherited no
+	// ranges the local tier has to account for, and its cached entries still
+	// describe the content it holds. Everything below is about a destination
+	// whose content changed.
+	if selfClone {
+		return nil
+	}
+	seedClonedRanges(ctx, blockStore, dstPayloadID, copied)
 
 	// POST-txn: the destination content changed wholesale; drop its cache
 	// entries. Files that still reference the shared CAS hashes via dedup keep
 	// their entries warm (nil removedHashes => key off dstPayloadID only).
-	if cache != nil && !selfClone {
+	if cache != nil {
 		cache.InvalidateFile(dstPayloadID, nil)
 	}
 	return nil
+}
+
+// seedClonedRanges tells the destination's local tier which ranges the copy just
+// gave it. Both reflink helpers in this package call it. The copy moves no
+// bytes, so the destination's ranges land in the
+// manifest and nowhere in the index, and everything that reads residency off the
+// index — the remote-only byte count, the offline-readiness answer — cannot
+// account for them until this runs.
+//
+// It runs after the commit, never before: cold intervals over rows a rolled-back
+// copy never wrote would make a read of the destination's sparse ranges fail
+// closed where it should serve zeros.
+//
+// A failure is logged and the copy still succeeds. The copy is durable and its
+// reads are correct either way — a hole on a remote-backed share hydrates from
+// the manifest exactly as a cold range does — so the only casualty is the
+// accounting, and failing a committed copy to report it would be the worse
+// trade. The next seed of the same ranges picks them up.
+func seedClonedRanges(ctx context.Context, blockStore *engine.Store, dstPayloadID metadata.PayloadID, blocks []block.ChunkRef) {
+	if len(blocks) == 0 {
+		return
+	}
+	if err := blockStore.SeedColdRefs(ctx, string(dstPayloadID), blocks); err != nil {
+		logger.Warn("server-side copy: the destination's ranges are not recorded in the local tier; "+
+			"reads are unaffected, its remote-only bytes are not counted",
+			"payload", dstPayloadID, "error", err)
+	}
 }
 
 // materializeLocalClone is the local-only (no remote store) clone path: it

--- a/internal/adapter/common/clone_test.go
+++ b/internal/adapter/common/clone_test.go
@@ -124,3 +124,73 @@ func TestCloneWholeFile_RollsBackOnIncrementError(t *testing.T) {
 		t.Errorf("InvalidateFile fired %d times after rollback, want 0", len(cache.calls))
 	}
 }
+
+// TestCloneWholeFile_SeedsDestinationRanges pins the wiring the residency
+// accounting depends on: the reflink moves no bytes, so the destination's ranges
+// land in the manifest and would land nowhere in the local tier's index without
+// the post-commit seed. Everything that reports remote-only bytes reads that
+// index, so an unseeded destination is invisible to all of it.
+func TestCloneWholeFile_SeedsDestinationRanges(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	bs, local := newCopyTestEngineWithLocal(t, &fakeCoordinator{}, ms)
+
+	srcBlocks := []block.ChunkRef{
+		{Hash: block.ContentHash{0x11}, Offset: 0, Size: 4096},
+		{Hash: block.ContentHash{0x22}, Offset: 4096, Size: 4096},
+		{Hash: block.ContentHash{0x33}, Offset: 8192, Size: 2048},
+	}
+	const srcSize = 4096 + 4096 + 2048
+	srcHandle := putTestFile(t, ms, "/seed-src.bin", "seed-src-pid", srcBlocks, srcSize)
+	dstHandle := putTestFile(t, ms, "/seed-dst.bin", "seed-dst-pid", nil, 0)
+
+	// Nothing describes the destination before the clone.
+	before, err := local.DataExtents(ctx, "seed-dst-pid", srcSize)
+	if err != nil {
+		t.Fatalf("DataExtents before the clone: %v", err)
+	}
+	if len(before) != 0 {
+		t.Fatalf("the destination already had %d index extents before the clone", len(before))
+	}
+
+	if err := CloneWholeFile(ctx, bs, ms, nil, srcHandle, dstHandle, "seed-dst-pid"); err != nil {
+		t.Fatalf("CloneWholeFile: %v", err)
+	}
+
+	described, err := local.DataExtents(ctx, "seed-dst-pid", srcSize)
+	if err != nil {
+		t.Fatalf("DataExtents after the clone: %v", err)
+	}
+	var describedBytes uint64
+	for _, e := range described {
+		describedBytes += e[1] - e[0]
+	}
+	if describedBytes != srcSize {
+		t.Errorf("the index describes %d bytes of the clone's destination, want %d (extents %v)",
+			describedBytes, srcSize, described)
+	}
+}
+
+// TestCloneWholeFile_SelfCloneSeedsNothing keeps the self-clone no-op whole: the
+// destination is the source, its ranges are already accounted for, and seeding
+// them would describe the source's own bytes as remote-only.
+func TestCloneWholeFile_SelfCloneSeedsNothing(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	bs, local := newCopyTestEngineWithLocal(t, &fakeCoordinator{}, ms)
+
+	srcBlocks := []block.ChunkRef{{Hash: block.ContentHash{0x44}, Offset: 0, Size: 4096}}
+	selfHandle := putTestFile(t, ms, "/seed-self.bin", "seed-self-pid", srcBlocks, 4096)
+
+	if err := CloneWholeFile(ctx, bs, ms, nil, selfHandle, selfHandle, "seed-self-pid"); err != nil {
+		t.Fatalf("CloneWholeFile self-clone: %v", err)
+	}
+
+	described, err := local.DataExtents(ctx, "seed-self-pid", 4096)
+	if err != nil {
+		t.Fatalf("DataExtents: %v", err)
+	}
+	if len(described) != 0 {
+		t.Errorf("the self-clone seeded %v; it copied nothing and must describe nothing", described)
+	}
+}

--- a/internal/adapter/common/copy_payload.go
+++ b/internal/adapter/common/copy_payload.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/engine"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
@@ -62,6 +63,7 @@ func CopyPayload(
 		return fmt.Errorf("CopyPayload: fetch src file attr: %w", err)
 	}
 
+	var copied []block.ChunkRef
 	err = metadataStore.WithTransaction(ctx, func(tx metadata.Transaction) error {
 		// Bind the active txn into the context so the per-share
 		// metadataCoordinator's IncrementRefCount / DecrementRefCount
@@ -84,6 +86,7 @@ func CopyPayload(
 			return fmt.Errorf("fetch dst file attr: %w", err)
 		}
 		dstFile.Blocks = newBlocks
+		copied = newBlocks
 		// Wholesale manifest replacement on the destination — persist refs.
 		dstFile.Size = srcFile.Size
 		dstFile.Mtime = time.Now()
@@ -96,6 +99,7 @@ func CopyPayload(
 	if err != nil {
 		return err
 	}
+	seedClonedRanges(ctx, blockStore, dstPayloadID, copied)
 
 	// POST-txn: conservative invalidation for dst — its content changed
 	// wholesale. Pass nil removedHashes so the cache drops everything

--- a/internal/adapter/common/copy_payload_test.go
+++ b/internal/adapter/common/copy_payload_test.go
@@ -364,6 +364,15 @@ func TestCopyPayload_CtimeUpdated(t *testing.T) {
 // post-txn state via the same store.
 func newCopyTestEngineWithMS(t *testing.T, coord *fakeCoordinator, ms *metadatamemory.MemoryMetadataStore) *engine.Store {
 	t.Helper()
+	bs, _ := newCopyTestEngineWithLocal(t, coord, ms)
+	return bs
+}
+
+// newCopyTestEngineWithLocal is newCopyTestEngineWithMS with the journal-backed
+// local tier handed back too, for the assertions that are about what the index
+// describes rather than what the manifest holds.
+func newCopyTestEngineWithLocal(t *testing.T, coord *fakeCoordinator, ms *metadatamemory.MemoryMetadataStore) (*engine.Store, *fs.FSStore) {
+	t.Helper()
 
 	tmpDir := t.TempDir()
 	localStore, err := fs.NewWithOptions(tmpDir, 100*1024*1024, ms, fs.FSStoreOptions{})
@@ -402,7 +411,7 @@ func newCopyTestEngineWithMS(t *testing.T, coord *fakeCoordinator, ms *metadatam
 	}
 	t.Cleanup(func() { _ = bs.Close() })
 
-	return bs
+	return bs, localStore
 }
 
 // DecrementRefCountAndReapMany loops the single-offset form so this double

--- a/pkg/block/engine/close_gate_test.go
+++ b/pkg/block/engine/close_gate_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"sync"
 	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
 )
 
 // TestStore_CloseDrainsInFlightWriteAt is the area-7 H-A reproducer: a client
@@ -185,6 +187,12 @@ func TestStore_OpAfterCloseReturnsErrStoreClosed(t *testing.T) {
 	t.Run("SeedColdBatch", func(t *testing.T) {
 		if err := bs.SeedColdBatch(ctx, []ColdSeed{{PayloadID: "p", Extents: [][2]int64{{0, 4096}}}}); !errors.Is(err, ErrStoreClosed) {
 			t.Errorf("SeedColdBatch after Close = %v, want ErrStoreClosed; a seed that slips past Close reopens the cold log behind a torn-down store", err)
+		}
+	})
+	t.Run("SeedColdRefs", func(t *testing.T) {
+		refs := []block.ChunkRef{{Hash: block.ContentHash{0x01}, Offset: 0, Size: 4096}}
+		if err := bs.SeedColdRefs(ctx, "p", refs); !errors.Is(err, ErrStoreClosed) {
+			t.Errorf("SeedColdRefs after Close = %v, want ErrStoreClosed; a copy's seed that slips past Close reopens the cold log behind a torn-down store", err)
 		}
 	})
 	t.Run("EvictLocal", func(t *testing.T) {

--- a/pkg/block/engine/flush.go
+++ b/pkg/block/engine/flush.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"math"
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/journal"
@@ -142,6 +143,66 @@ func (bs *Store) SeedColdBatch(ctx context.Context, seeds []ColdSeed) error {
 		js = append(js, journal.ColdSeed{ID: journal.FileID(sd.PayloadID), Extents: sd.Extents})
 	}
 	return cs.SeedColdBatch(ctx, js)
+}
+
+// SeedColdRefs gives the local tier an account of the ranges a payload's chunk
+// refs place, marking each one remote-durable-but-not-local. A server-side copy
+// hands the destination the source's refs without moving a byte, so the
+// destination's ranges exist in the manifest and nowhere in the index; this is
+// what puts them there, and it is the caller's post-commit step — seeding before
+// the manifest lands would describe rows a rolled-back copy never wrote.
+//
+// It changes no read: a hole on a remote-backed share already reconciles against
+// the manifest and hydrates exactly as a cold range does. What it changes is
+// everything that reasons about residency from the index — the remote-only byte
+// count an operator acts on, and OfflineReadiness, which can tell a copy nobody
+// has read back from a range whose interval was lost only once the copy has one.
+//
+// Only the parts of each ref the index does not already describe are seeded, so
+// a copy over a destination that still holds local bytes leaves those alone, and
+// a repeat call costs nothing. Refs with no hash place no bytes (a sparse hole
+// carries no chunk) and are skipped, as are empty ones.
+//
+// One file at a time, under its shard lock, because the destination is live —
+// see journal.Store.SeedCold.
+func (bs *Store) SeedColdRefs(ctx context.Context, payloadID string, refs []block.ChunkRef) error {
+	if err := bs.enter(); err != nil {
+		return err
+	}
+	defer bs.closeMu.RUnlock()
+	// Nothing to record on a share with no remote: a cold range there has
+	// nowhere to hydrate from and fails its reads closed, where the same range
+	// left as a hole reads as the zeros it is. Local-only copies materialize real
+	// bytes into the destination's own journal, which describes them already, so
+	// there is no work here rather than work being refused — the same shape as
+	// the no-remote-hydration case below.
+	if !bs.HasRemoteStore() {
+		return nil
+	}
+	type coldSeeder interface {
+		SeedCold(ctx context.Context, id journal.FileID, extents [][2]int64) error
+	}
+	cs, ok := bs.local.(coldSeeder)
+	if !ok {
+		return nil
+	}
+	extents := make([][2]int64, 0, len(refs))
+	for _, r := range refs {
+		if r.Size == 0 || r.Hash.IsZero() {
+			continue
+		}
+		// The index addresses its ranges in int64, so a ref out past that could
+		// only be described as a negative offset. Skipping it leaves the range a
+		// hole, which still reconciles against the manifest on read.
+		if r.Offset > math.MaxInt64-uint64(r.Size) {
+			continue
+		}
+		extents = append(extents, [2]int64{int64(r.Offset), int64(r.Size)})
+	}
+	if len(extents) == 0 {
+		return nil
+	}
+	return cs.SeedCold(ctx, journal.FileID(payloadID), extents)
 }
 
 // RestoreToVersion rewinds the local journal to a snapshot's version watermark

--- a/pkg/block/engine/offline.go
+++ b/pkg/block/engine/offline.go
@@ -188,12 +188,11 @@ func offlineReadinessOf(ctx context.Context, localTier any, hasRemote bool, shor
 // same set a read can resolve however it picks between covering rows, so two
 // rows over one byte merge into one span instead of counting twice.
 //
-// A lost interval is not the only way to reach a shortfall. A server-side copy
-// writes the destination's manifest rows and no interval for them at all, so a
-// clone nobody has read back yet looks the same from here. That is not a false
-// alarm: those bytes need the remote too, and the index cannot say which of the
-// two it is looking at, which is why the answer is indeterminate rather than a
-// remote-only count.
+// A server-side copy used to be the other way here: it writes the destination's
+// manifest rows and moves no bytes, so a copy nobody had read back looked from
+// here exactly like a range whose interval was lost. The copy now seeds those
+// ranges once its manifest is committed, so it reports as the remote-only count
+// it is and a shortfall is left meaning a genuine loss.
 //
 // ponytail: one ListFileChunks per payload, the same walk warm and the
 // block-count stats take, which is why the caller memoizes the result rather

--- a/pkg/block/engine/offline_manifest_test.go
+++ b/pkg/block/engine/offline_manifest_test.go
@@ -1,6 +1,7 @@
 package engine_test
 
 import (
+	"bytes"
 	"context"
 	"io/fs"
 	"math/rand"
@@ -241,20 +242,21 @@ func TestOfflineReadiness_LostIntervalIsNotSafe(t *testing.T) {
 	}
 }
 
-// TestOfflineReadiness_CloneIsIndeterminate pins the other way a share reaches
-// a shortfall, so nobody reads the refusal as proof of a lost interval.
+// TestOfflineReadiness_CloneIsRemoteOnly puts the readiness answer in front of a
+// server-side copy, which is the other way a share reaches a manifest the index
+// cannot account for.
 //
-// A server-side copy writes the destination's manifest rows and creates no
-// interval for them — the clone's bytes are the source's, already on the
-// remote, and the read path hydrates them on demand. From the index that is
-// indistinguishable from a range whose interval was lost, and the offline
-// answer is the same either way: those bytes need the remote, and the index
-// cannot say which case it is looking at.
+// The copy moves no bytes: the destination inherits the source's chunk refs, so
+// its ranges land in the manifest and, until the copy seeds them, nowhere in the
+// index. From the index alone that is indistinguishable from a range whose
+// interval was lost, and the share can only answer indeterminate — the coarse
+// answer, on any remote-backed share holding a copy nobody has read back.
 //
-// If the copy path ever seeds cold intervals for its destination rows, this
-// test is what says so: the share would then report a remote-only count
-// instead, and the refusal would be left meaning a genuine loss.
-func TestOfflineReadiness_CloneIsIndeterminate(t *testing.T) {
+// The copy path seeds those ranges after its commit, so the share reports them
+// as the remote-only count they are and a shortfall is left meaning a genuine
+// loss. Both halves are asserted here: the unseeded destination is what the
+// clone used to leave behind, and the seeded one is what it leaves now.
+func TestOfflineReadiness_CloneIsRemoteOnly(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
@@ -296,37 +298,68 @@ func TestOfflineReadiness_CloneIsIndeterminate(t *testing.T) {
 	if len(refs) == 0 {
 		t.Fatal("the source carved no placeable rows, so the clone would copy nothing")
 	}
-	if _, err := bs.CopyPayload(ctx, src, dst, refs); err != nil {
+	copied, err := bs.CopyPayload(ctx, src, dst, refs)
+	if err != nil {
 		t.Fatalf("CopyPayload: %v", err)
 	}
 
+	// The copy alone describes nothing: it is a manifest operation, and the seed
+	// below is the separate post-commit step that gives the index its account.
 	described, err := local.DataExtents(ctx, dst, size)
 	if err != nil {
 		t.Fatalf("DataExtents: %v", err)
 	}
 	if len(described) != 0 {
-		t.Fatalf("the copy created %d index extents for the destination; "+
-			"the shortfall this test describes no longer happens", len(described))
+		t.Errorf("the copy created %d index extents on its own; the seed is supposed to be the step that does", len(described))
 	}
 
-	// The memo was filled by the safe answer above, so the store is reopened
-	// over the same journal — same seed marker, same index, empty memo — rather
-	// than replaced, which would refuse for want of a seed instead.
+	if err := bs.SeedColdRefs(ctx, dst, copied); err != nil {
+		t.Fatalf("SeedColdRefs: %v", err)
+	}
+	described, err = local.DataExtents(ctx, dst, size)
+	if err != nil {
+		t.Fatalf("DataExtents after the seed: %v", err)
+	}
+	var describedBytes uint64
+	for _, e := range described {
+		describedBytes += e[1] - e[0]
+	}
+	if describedBytes != size {
+		t.Fatalf("the index describes %d bytes of the destination after the seed, want %d", describedBytes, size)
+	}
+
+	// The memo was filled by the safe answer above, so the store is reopened over
+	// the same journal — same seed marker, same index, empty memo — rather than
+	// replaced, which would refuse for want of a seed instead. The reopen is also
+	// what proves the seed reached the cold log: an in-memory-only marker would
+	// come back a hole and refuse.
 	if err := bs.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
 	bs, local = openOfflineEngine(t, dir, ms, mem)
 	t.Cleanup(func() { _ = bs.Close() })
 	if !local.ColdSeeded() {
-		t.Fatal("the reopened tier lost its seed marker, so the refusal below would not be the shortfall")
+		t.Fatal("the reopened tier lost its seed marker, so the answer below would not be about the clone")
 	}
 
 	got := bs.OfflineReadiness(ctx)
-	if got.Known || got.Safe() {
-		t.Errorf("a share holding an unhydrated clone reported known=%v safe=%v", got.Known, got.Safe())
+	if !got.Known {
+		t.Fatalf("a share holding a seeded clone still cannot answer: %q", got.Reason)
 	}
-	if !strings.Contains(got.Reason, "manifest places") {
-		t.Errorf("refused for some other reason than the shortfall: %q", got.Reason)
+	if got.Safe() {
+		t.Error("a share whose clone needs the remote reported offline-safe")
 	}
-	t.Logf("reason: %s", got.Reason)
+	if got.RemoteOnlyBytes != size {
+		t.Errorf("RemoteOnlyBytes = %d, want %d — the clone's ranges are the only remote-only bytes here", got.RemoteOnlyBytes, size)
+	}
+
+	// The seeded ranges still serve: a cold range and a hole reconcile against
+	// the manifest the same way, so the copy reads back byte-identical.
+	back := make([]byte, size)
+	if _, err := bs.ReadAt(ctx, dst, back, 0); err != nil {
+		t.Fatalf("read the seeded clone back: %v", err)
+	}
+	if !bytes.Equal(back, data) {
+		t.Error("the seeded clone did not read back as the source's bytes")
+	}
 }

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -490,6 +490,13 @@ func (bs *Store) payloadChunkRefs(ctx context.Context, payloadID string) []block
 // per-file rows and the FileAttr.Blocks manifest reference the same hashes and
 // offsets.
 //
+// It creates no local-tier interval for those rows, and cannot: it runs inside
+// the caller's metadata txn, and intervals for rows a rolled-back copy never
+// wrote would make a read of the destination's sparse ranges fail closed. Giving
+// the local tier its account of the destination is the caller's step, after the
+// commit — SeedColdRefs over the returned list. Reads work either way; residency
+// accounting does not.
+//
 // Empty srcBlocks => nil-safe path: copies nothing. CopyPayload no longer
 // copies data at all; adapter call sites that need a data copy drive
 // ReadAt+WriteAt directly. Production callers always supply a snapshot of

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -495,8 +495,82 @@ func staleAfterTruncate(sh *shard, id FileID, notAfter uint64) bool {
 // the remote, which a cold read cannot fetch back. Skipping covered ranges makes
 // the call idempotent and safe to repeat against a store that is only partly
 // missing its markers, at the cost of nothing on a store that has none.
-func (s *Store) SeedCold(ctx context.Context, id FileID, extents [][2]int64) error {
-	return s.SeedColdBatch(ctx, []ColdSeed{{ID: id, Extents: extents}})
+//
+// The whole call runs under the file's shard lock, so a Delete or Truncate of
+// the same file either lands entirely before the seed — and the seed then plans
+// against the index it left — or entirely after, where its version fences the
+// seeded intervals away like any other write. Neither can land in the middle and
+// have the insert undo it, which is what makes this the variant a live file can
+// be seeded through: a server-side copy seeds its destination while other
+// clients are free to unlink it.
+//
+// What the lock does not do is make the caller's extents current. They were
+// chosen before the call, so a truncate that lands first leaves the seed
+// describing a range the file no longer has — a hole is a hole whether it was
+// never written or just clipped away. That range is past the size every reader
+// clamps to, so it serves nothing and only ever inflates the count of bytes the
+// tier calls remote-only. Erring toward "more remote-only than there is" is the
+// safe direction for every caller of that count.
+//
+// ponytail: the cold-log fsync runs under the shard lock, so it stalls that
+// shard for its duration — the same trade Invalidate takes, and for the same
+// reason: one fsync per server-side copy is too rare to show. Take
+// SeedColdBatch's plan/append/insert split instead if a workload ever seeds live
+// files often enough to matter, and pay for the delete watermark it needs.
+func (s *Store) SeedCold(_ context.Context, id FileID, extents [][2]int64) error {
+	if s.closed.Load() {
+		return errClosed
+	}
+	sh := s.shardFor(id)
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	entries := s.planColdSeed(sh, id, extents)
+	if len(entries) == 0 {
+		return nil
+	}
+	if err := s.appendCold(entries); err != nil {
+		return err
+	}
+	fi := sh.indexFor(id)
+	for _, e := range entries {
+		fi.insert(interval{
+			fileOff: e.fileOff,
+			length:  e.length,
+			version: e.version,
+			synced:  true,
+			cold:    true,
+		})
+	}
+	return nil
+}
+
+// planColdSeed turns one file's extents into the cold entries that would cover
+// the parts of them the index does not describe yet. The caller holds the file's
+// shard lock, and the entries carry the versions taken under it.
+func (s *Store) planColdSeed(sh *shard, id FileID, extents [][2]int64) []coldEntry {
+	var entries []coldEntry
+	fi := sh.index[id]
+	for _, e := range extents {
+		if e[1] <= 0 {
+			continue
+		}
+		if fi == nil { // unknown file: the whole extent is a hole
+			entries = append(entries, coldEntry{id: id, fileOff: e[0], length: e[1], version: s.nextVersion()})
+			continue
+		}
+		for _, p := range fi.plan(e[0], e[1]) {
+			if !p.hole {
+				continue
+			}
+			entries = append(entries, coldEntry{
+				id:      id,
+				fileOff: e[0] + p.dstStart,
+				length:  p.dstEnd - p.dstStart,
+				version: s.nextVersion(),
+			})
+		}
+	}
+	return entries
 }
 
 // ColdSeed is one file's worth of work for SeedColdBatch: the file's ID and the
@@ -526,9 +600,10 @@ type ColdSeed struct {
 // it open for the whole batch rather than one fsync. Both callers seed a share
 // that is not serving yet (share add) or one whose local tier was just reset
 // (snapshot restore), so nothing deletes through it today. Closing it means
-// either holding shard locks across the fsync, which is worse, or a per-file
-// delete watermark to revalidate against; build the watermark if a seed ever
-// runs against a live share.
+// either holding shard locks across the fsync or a per-file delete watermark to
+// revalidate against; build the watermark if a batch ever runs against a live
+// share. A caller seeding one live file takes SeedCold instead, which holds the
+// lock across its own fsync and has no gap to close.
 func (s *Store) SeedColdBatch(_ context.Context, seeds []ColdSeed) error {
 	if s.closed.Load() {
 		return errClosed
@@ -537,27 +612,7 @@ func (s *Store) SeedColdBatch(_ context.Context, seeds []ColdSeed) error {
 	for _, sd := range seeds {
 		sh := s.shardFor(sd.ID)
 		sh.mu.Lock()
-		fi := sh.index[sd.ID]
-		for _, e := range sd.Extents {
-			if e[1] <= 0 {
-				continue
-			}
-			if fi == nil { // unknown file: the whole extent is a hole
-				entries = append(entries, coldEntry{id: sd.ID, fileOff: e[0], length: e[1], version: s.nextVersion()})
-				continue
-			}
-			for _, p := range fi.plan(e[0], e[1]) {
-				if !p.hole {
-					continue
-				}
-				entries = append(entries, coldEntry{
-					id:      sd.ID,
-					fileOff: e[0] + p.dstStart,
-					length:  p.dstEnd - p.dstStart,
-					version: s.nextVersion(),
-				})
-			}
-		}
+		entries = append(entries, s.planColdSeed(sh, sd.ID, sd.Extents)...)
 		sh.mu.Unlock()
 	}
 	if len(entries) == 0 {


### PR DESCRIPTION
A server-side copy hands the destination the source's chunk refs and moves no
bytes. `engine.CopyPayload` writes one manifest row per source block for the
destination and creates no interval in the local tier for any of them, so the
destination's ranges exist in the manifest and nowhere in the index.

Reads were never affected — a hole on a remote-backed share reconciles against
the manifest and hydrates exactly as a cold range does (`readAtInternal`:
`st.Cold || (st.Hole && bs.HasRemoteStore())`). What was affected is everything
that reasons about residency from the index: the remote-only byte count an
operator acts on, and `OfflineReadiness`, which since #2121 cross-checks the
index against the manifest and could only report **indeterminate** for a share
holding a copy nobody had read back — indistinguishable there from a range whose
interval was lost.

## Premise

Confirmed on a real engine before any change. On unmodified `develop`,
`TestOfflineReadiness_CloneIsIndeterminate` (added in #2121) passes with:

```
local index does not describe 4194304 bytes in 1 ranges the manifest places,
so whether they are remote-only or lost cannot be determined
```

after cloning 4 MiB: `local.DataExtents(dst, size)` returns zero extents while
the manifest places the full 4 MiB.

## The fix

The copy now seeds cold intervals for the destination's ranges, **after** its
metadata transaction commits.

- `engine.Store.SeedColdRefs` derives the extents a payload's `[]ChunkRef`
  places and hands them to the local tier. It has nothing to do on a share with
  no remote — a cold range there has nowhere to hydrate from and would fail its
  reads closed where the same range left as a hole reads as the zeros it is, and
  a local-only copy materializes real bytes the index already describes.
- `internal/adapter/common` calls it post-commit from both copy helpers
  (`CloneWholeFile`, which NFSv4.2 CLONE drives, and the `CopyPayload` sibling),
  through one shared `seedClonedRanges`.

**The ordering is the whole difficulty, not a detail.** Seeding inside the
transaction — the obvious place, since `engine.CopyPayload` is where both
callers converge — is wrong: a rolled-back copy would leave cold intervals over
rows it never wrote, and a read of the destination's sparse ranges would then
fail closed where it should serve zeros. So the engine primitive stays
interval-free by construction and its doc comment says so; the seed is the
caller's post-commit step. A crash in the window between commit and seed lands
in exactly today's state — the coarse answer, not a wrong one.

A seed failure is logged and the copy still succeeds. The copy is durable and
its reads are correct either way; failing a committed copy to report an
accounting gap would be the worse trade.

## The seed had to become live-file-safe first

`journal.SeedColdBatch` carries a `ponytail:` note naming this exact condition:
it takes an entry's version while planning, drops the shard lock for the fsync,
and inserts after — so a `Delete` landing in that gap sweeps the index above the
pending entry and the insert recreates the range it buried. Its two callers seed
a share that is not serving yet (share add) or one whose local tier was just
reset (snapshot restore). *"Build the watermark if a seed ever runs against a
live share."*

A copy destination is a live file, so this would have been the first such
caller. Rather than build the watermark, `journal.Store.SeedCold` — previously a
one-line delegation to the batch, with no production caller — is now the
single-file variant that holds the shard lock across its own fsync, the same
trade `Invalidate` already takes for the same reason. A concurrent `Delete` or
`Truncate` then lands entirely before the seed (which plans against what it
left) or entirely after (where its version fences the seeded intervals away like
any other write). The batch keeps its split and its note, now scoped to batches.
The planning loop is shared between the two.

## Effect on #2121 / #2110

A copy now reports as a remote-only count, and a manifest shortfall is left
meaning a genuine loss — the discrimination #2110 asked for.
`TestOfflineReadiness_CloneIsIndeterminate` was written to fail when the
destination gains index extents; it is replaced by
`TestOfflineReadiness_CloneIsRemoteOnly`, which pins both halves: the copy alone
still describes nothing (it is a manifest operation), and the seed is what gives
the index its account. The store is closed and reopened over the same journal
before the readiness answer, so the assertion also proves the seed reached the
cold log rather than only memory.

That engine test also reads the destination back and compares bytes, so the
"seeding changes no read" claim is asserted rather than argued.
`TestCloneWholeFile_SeedsDestinationRanges` and
`TestCloneWholeFile_SelfCloneSeedsNothing` pin the same thing at the adapter seam
a protocol CLONE actually goes through; the first fails on `develop` with
`the index describes 0 bytes of the clone's destination, want 10240`.

## Residue

Fix-forward only. Destinations copied before this change keep no intervals and
keep reporting indeterminate until something reads them back or the share is
re-seeded from its manifest; no detection or repair path is added for them.

## Found on the way, not fixed here

A reflink onto a destination that **still holds local bytes** serves the
destination's pre-clone content: the copy replaces the manifest and never
invalidates the destination's journal intervals, and a covered warm range never
reaches the manifest on read. Reproduced on a real engine and filed as **#2160**.

It is pre-existing and untouched by this PR — the seed only fills holes, so it
skips exactly the covered ranges that go stale. The two compose: once the
destination's intervals stop being authoritative, the whole cloned span becomes
a hole and this seed covers all of it.

Closes #2123
