### PR TITLE
fix(smb): order response emission per connection so a break is never overtaken

### DIFF
--- a/internal/adapter/smb/compound.go
+++ b/internal/adapter/smb/compound.go
@@ -47,6 +47,12 @@ type compoundResponse struct {
 //   - isEncrypted: whether the compound request was received inside an SMB3 Transform Header
 //   - asyncNotifyCallback: optional callback for CHANGE_NOTIFY async responses (nil = no async)
 func ProcessCompoundRequest(ctx context.Context, firstHeader *header.SMB2Header, firstBody []byte, firstRaw []byte, compoundData []byte, connInfo *ConnInfo, isEncrypted bool, asyncNotifyCallback handlers.AsyncResponseCallback) {
+	// This chain's place in the connection's response order — see RequestOrder
+	// and the single-request path in response.go. Every response below waits
+	// for the responses ahead of it, so a break notification an earlier
+	// request dispatched reaches the wire first.
+	orderToken := OrderTokenFrom(ctx)
+
 	// Per MS-SMB2 3.3.5.2.7.2: the first command in a compound MUST NOT have
 	// the SMB2_FLAGS_RELATED_OPERATIONS flag set. Fail the entire compound.
 	if firstHeader.IsRelated() {
@@ -74,6 +80,7 @@ func ProcessCompoundRequest(ctx context.Context, firstHeader *header.SMB2Header,
 			erh, erb := buildErrorResponseHeaderAndBody(hdr, status, connInfo)
 			errResponses = append(errResponses, compoundResponse{respHeader: erh, body: erb})
 		}
+		orderToken.WaitTurn(ctx)
 		if err := sendCompoundResponses(errResponses, connInfo, isEncrypted); err != nil {
 			logger.Debug("Error sending compound error responses", "error", err)
 		}
@@ -93,6 +100,7 @@ func ProcessCompoundRequest(ctx context.Context, firstHeader *header.SMB2Header,
 				"command", firstHeader.Command.String(),
 				"creditCharge", firstHeader.CreditCharge,
 				"error", err)
+			orderToken.WaitTurn(ctx)
 			failEntireCompound(firstHeader, compoundData, types.StatusInvalidParameter, connInfo, isEncrypted)
 			return
 		}
@@ -105,6 +113,7 @@ func ProcessCompoundRequest(ctx context.Context, firstHeader *header.SMB2Header,
 				"messageID", firstHeader.MessageID,
 				"creditCharge", charge,
 				"exempt", exempt)
+			orderToken.WaitTurn(ctx)
 			failEntireCompound(firstHeader, compoundData, types.StatusInvalidParameter, connInfo, isEncrypted)
 			return
 		}
@@ -135,6 +144,7 @@ func ProcessCompoundRequest(ctx context.Context, firstHeader *header.SMB2Header,
 					"command", hdr.Command.String(),
 					"messageID", hdr.MessageID,
 					"creditCharge", charge)
+				orderToken.WaitTurn(ctx)
 				failEntireCompound(firstHeader, compoundData, types.StatusInvalidParameter, connInfo, isEncrypted)
 				return
 			}
@@ -201,6 +211,7 @@ func ProcessCompoundRequest(ctx context.Context, firstHeader *header.SMB2Header,
 		interimHeader := header.NewResponseHeaderWithCredits(firstHeader, types.StatusPending, interimCredits)
 		interimHeader.Flags |= types.FlagAsync
 		interimHeader.AsyncId = result.AsyncId
+		orderToken.WaitTurn(ctx)
 		if err := SendMessage(interimHeader, MakeErrorBody(), connInfo); err != nil {
 			logger.Debug("Error sending compound async interim response", "error", err)
 		}
@@ -276,6 +287,7 @@ func ProcessCompoundRequest(ctx context.Context, firstHeader *header.SMB2Header,
 	state.processRemaining(ctx, compoundData, connInfo, isEncrypted, asyncNotifyCallback)
 
 	// Send all responses as a single compound response frame.
+	orderToken.WaitTurn(ctx)
 	sendErr := sendCompoundResponses(state.responses, connInfo, isEncrypted)
 	if sendErr != nil {
 		logger.Debug("Error sending compound responses", "error", sendErr)

--- a/internal/adapter/smb/conn_types.go
+++ b/internal/adapter/smb/conn_types.go
@@ -62,6 +62,12 @@ type ConnInfo struct {
 	// WriteMu serializes writes to the connection.
 	WriteMu *LockedWriter
 
+	// RequestOrder keeps responses on this connection going out in the order
+	// the read loop received the requests, so a break notification an earlier
+	// request owes is never overtaken. Nil when a caller dispatches without a
+	// read loop (tests, direct dispatch): ordering is then a no-op.
+	RequestOrder *RequestOrder
+
 	// WriteTimeout for response writes.
 	WriteTimeout time.Duration
 

--- a/internal/adapter/smb/handlers/context.go
+++ b/internal/adapter/smb/handlers/context.go
@@ -199,16 +199,9 @@ type SMBHandlerContext struct {
 	ReleaseAsync func()
 
 	// ReleaseOrder gives up this request's place in the connection's response
-	// order, letting the responses behind it go out ahead of this one.
-	//
-	// A handler MUST call it before blocking on anything only a *later*
-	// request on the same connection can deliver — a lease break
-	// acknowledgement above all. The client cannot send that acknowledgement
-	// until it has seen the responses queued behind this request, so holding
-	// the place across such a wait leaves both sides waiting for each other.
-	//
-	// It is idempotent, and nil when the caller dispatched without a read
-	// loop. Use releaseOrderSlot rather than calling it directly.
+	// order, letting the responses behind it go out ahead of this one. It is
+	// idempotent, and nil when the caller dispatched without a read loop.
+	// Handlers call it through releaseResponseOrder.
 	ReleaseOrder func()
 
 	// RequestAsyncId is the AsyncId from the request header when FlagAsync is set.
@@ -296,18 +289,16 @@ func NewSMBHandlerContext(ctx context.Context, clientAddr string, sessionID uint
 
 // releaseResponseOrder gives up this request's place in the connection's
 // response order, so the responses queued behind it can go out while this
-// handler blocks.
+// handler blocks. Safe on a context dispatched without a read loop.
 //
 // Call it immediately before any wait that only a LATER request on the same
 // connection can satisfy — a lease break acknowledgement, or a holder's CLOSE
 // clearing a share-mode conflict. The client cannot send either until it has
 // received the responses sitting behind this request, so a handler that keeps
 // its place across such a wait and the client end up waiting on each other
-// until the wait's own timeout expires.
-//
-// Safe to call more than once, and on a context dispatched without a read
-// loop. The break notifications such a wait is waiting on have already been
-// written by the time it is reached, which is the ordering that mattered.
+// until the wait's own timeout expires. The break notifications such a wait is
+// waiting on have already been written by the time it is reached, which is the
+// ordering that mattered.
 func releaseResponseOrder(ctx *SMBHandlerContext) {
 	if ctx != nil && ctx.ReleaseOrder != nil {
 		ctx.ReleaseOrder()

--- a/internal/adapter/smb/handlers/context.go
+++ b/internal/adapter/smb/handlers/context.go
@@ -198,6 +198,19 @@ type SMBHandlerContext struct {
 	// handler when registration fails after a successful TryReserveAsync call.
 	ReleaseAsync func()
 
+	// ReleaseOrder gives up this request's place in the connection's response
+	// order, letting the responses behind it go out ahead of this one.
+	//
+	// A handler MUST call it before blocking on anything only a *later*
+	// request on the same connection can deliver — a lease break
+	// acknowledgement above all. The client cannot send that acknowledgement
+	// until it has seen the responses queued behind this request, so holding
+	// the place across such a wait leaves both sides waiting for each other.
+	//
+	// It is idempotent, and nil when the caller dispatched without a read
+	// loop. Use releaseOrderSlot rather than calling it directly.
+	ReleaseOrder func()
+
 	// RequestAsyncId is the AsyncId from the request header when FlagAsync is set.
 	// Used by CANCEL to identify which async operation to cancel.
 	RequestAsyncId uint64
@@ -278,5 +291,25 @@ func NewSMBHandlerContext(ctx context.Context, clientAddr string, sessionID uint
 		SessionID:  sessionID,
 		TreeID:     treeID,
 		MessageID:  messageID,
+	}
+}
+
+// releaseResponseOrder gives up this request's place in the connection's
+// response order, so the responses queued behind it can go out while this
+// handler blocks.
+//
+// Call it immediately before any wait that only a LATER request on the same
+// connection can satisfy — a lease break acknowledgement, or a holder's CLOSE
+// clearing a share-mode conflict. The client cannot send either until it has
+// received the responses sitting behind this request, so a handler that keeps
+// its place across such a wait and the client end up waiting on each other
+// until the wait's own timeout expires.
+//
+// Safe to call more than once, and on a context dispatched without a read
+// loop. The break notifications such a wait is waiting on have already been
+// written by the time it is reached, which is the ordering that mattered.
+func releaseResponseOrder(ctx *SMBHandlerContext) {
+	if ctx != nil && ctx.ReleaseOrder != nil {
+		ctx.ReleaseOrder()
 	}
 }

--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -391,6 +391,9 @@ func (h *Handler) breakAndMaybeParkCreate(ctx *SMBHandlerContext, d *createDraft
 		}
 		// Park failed (no slots / registry full): fall through to sync
 		// wait, then let completeCreateAfterBreak re-evaluate share mode.
+		// The wait ends on an ACK or CLOSE the client has not sent yet, so
+		// step out of the response order before blocking on it.
+		releaseResponseOrder(ctx)
 		waitCtx, cancelWait := context.WithTimeout(d.authCtx.Context, lease.AsyncCreateBreakWaitTimeout)
 		defer cancelWait()
 		if err := h.LeaseManager.WaitForOtherKeyBreaks(waitCtx, lockFileHandle, shareName, waitExceptKey); err != nil {
@@ -461,6 +464,10 @@ func (h *Handler) breakAndMaybeParkCreate(ctx *SMBHandlerContext, d *createDraft
 	// force-completed (otherwise its ACK would fail STATUS_UNSUCCESSFUL). The
 	// non-violation case keeps WaitForOtherKeyBreaks, whose timeout
 	// auto-downgrades other-key leases for a deterministic post-break recheck.
+	//
+	// Both waits below end only on an ACK or a CLOSE the client has not sent
+	// yet, so step out of the response order before blocking on them.
+	releaseResponseOrder(ctx)
 	waitCtx, cancelWait := context.WithTimeout(d.authCtx.Context, breakWaitTimeout)
 	defer cancelWait()
 	if shareConflictWait {

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -900,6 +900,12 @@ func (h *Handler) setFileInfoFromStore(
 						"child", string(child), "error", err)
 				}
 			}
+			// Each wait below ends on an ACK or CLOSE from a lease holder
+			// that may be this very connection, and the client cannot send
+			// either until the responses queued behind this rename reach it.
+			// Step out of the response order first; the break notifications
+			// these waits are waiting on have already been written.
+			releaseResponseOrder(ctx)
 			for _, child := range children {
 				waitCtx, cancelChild := context.WithTimeout(authCtx.Context, lease.AsyncCreateBreakWaitTimeout)
 				if err := h.LeaseManager.WaitForOtherKeyBreaks(
@@ -1095,6 +1101,13 @@ func (h *Handler) setFileInfoFromStore(
 					}
 				}
 			}
+			// The source break was dispatched above; this waits for the
+			// holder to acknowledge it, and the holder may be this very
+			// connection — smbtorture lease.rename_wait holds both leases on
+			// one connection and reads the break out of the CREATE it
+			// pipelined behind this rename. Step out of the response order so
+			// that CREATE can be answered and the ACK can arrive.
+			releaseResponseOrder(ctx)
 			waitCtx, cancelWait := context.WithTimeout(authCtx.Context, lease.AsyncCreateBreakWaitTimeout)
 			if waitErr := h.LeaseManager.WaitForOtherKeyBreaks(
 				waitCtx, srcMetaHandle, openFile.ShareName, openFile.LeaseKey,

--- a/internal/adapter/smb/request_order.go
+++ b/internal/adapter/smb/request_order.go
@@ -92,7 +92,12 @@ func (t *OrderToken) WaitTurn(ctx context.Context) {
 	o := t.order
 
 	o.mu.Lock()
-	if o.low >= t.seq {
+	// A token that already released has given up its place — a handler that
+	// stepped out to wait on a break acknowledgement reaches here afterwards,
+	// on its way to sending its own response. It must not queue for a place it
+	// no longer holds: the order has moved past it, so nothing will ever wake
+	// it and it would sit here until the wait timeout.
+	if t.released || o.low >= t.seq {
 		o.mu.Unlock()
 		return
 	}
@@ -143,7 +148,8 @@ func (t *OrderToken) Release() {
 	}
 	// Only the sequence that just became eligible needs waking: everything
 	// below it was already eligible, and everything above it is still waiting
-	// on this one.
+	// on this one. The loop above can step over several sequences at once, but
+	// only over ones already released, and a released token never waits.
 	if wake, ok := o.waiters[o.low]; ok {
 		delete(o.waiters, o.low)
 		close(wake)

--- a/internal/adapter/smb/request_order.go
+++ b/internal/adapter/smb/request_order.go
@@ -1,0 +1,155 @@
+package smb
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/logger"
+)
+
+// DefaultOrderWaitTimeout bounds how long a response waits for the responses
+// ahead of it. Nothing is expected to reach it: every handler wait that depends
+// on further client traffic releases its slot before blocking. It exists so a
+// handler that blocks unexpectedly delays one connection's responses instead of
+// stalling them forever, and it logs when it fires.
+const DefaultOrderWaitTimeout = 30 * time.Second
+
+// RequestOrder restores, per connection, an ordering a single-threaded server
+// gets for free: a response never reaches the wire ahead of a lease or oplock
+// break notification that an earlier request on the same connection owes.
+//
+// Break notifications are written synchronously by the handler that triggers
+// them, before that handler's own response. So ordering response emission by
+// arrival is enough to order breaks against later responses too.
+//
+// Only the read loop knows arrival order — it reads sequentially, while the
+// handler goroutines it spawns are scheduled in any order. It therefore issues
+// one token per request, in wire order, before spawning. Handlers keep running
+// concurrently; only the moment a response is written is ordered.
+//
+// A handler that must wait for something only a *later* request can deliver —
+// a lease break acknowledgement, say — releases its token before blocking.
+// Without that, the client would be waiting for a response the server is
+// holding behind the very request the client cannot send yet.
+type RequestOrder struct {
+	mu sync.Mutex
+	// wake is closed and replaced on every release, waking all waiters to
+	// re-check. Waiters are one per in-flight request on one connection.
+	wake     chan struct{}
+	next     uint64
+	low      uint64 // every sequence below this has been released
+	released map[uint64]struct{}
+
+	waitTimeout time.Duration
+}
+
+// NewRequestOrder creates the ordering state for one connection.
+func NewRequestOrder() *RequestOrder {
+	return &RequestOrder{
+		wake:        make(chan struct{}),
+		released:    make(map[uint64]struct{}),
+		waitTimeout: DefaultOrderWaitTimeout,
+	}
+}
+
+// OrderToken is one request's place in its connection's response order.
+// A nil token is inert, so paths with no ordering (tests, direct dispatch)
+// need no special casing.
+type OrderToken struct {
+	order    *RequestOrder
+	seq      uint64
+	released atomic.Bool
+}
+
+// Begin claims the next place in the order. Call it from the read loop, in
+// wire order, before the handler goroutine is spawned.
+func (o *RequestOrder) Begin() *OrderToken {
+	if o == nil {
+		return nil
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	seq := o.next
+	o.next++
+	return &OrderToken{order: o, seq: seq}
+}
+
+// WaitTurn blocks until every request that arrived before this one has
+// released its token. Call it immediately before writing a response.
+//
+// It returns early — leaving this response free to overtake — when ctx is
+// cancelled or the wait timeout expires, since a stalled connection is worse
+// than an ordering violation on a connection that is already in trouble.
+func (t *OrderToken) WaitTurn(ctx context.Context) {
+	if t == nil {
+		return
+	}
+	o := t.order
+	deadline := time.NewTimer(o.waitTimeout)
+	defer deadline.Stop()
+
+	for {
+		o.mu.Lock()
+		if o.low >= t.seq {
+			o.mu.Unlock()
+			return
+		}
+		wake := o.wake
+		o.mu.Unlock()
+
+		select {
+		case <-wake:
+		case <-ctx.Done():
+			return
+		case <-deadline.C:
+			logger.Warn("SMB response ordering timed out; response may overtake an earlier request's break notification",
+				"sequence", t.seq,
+				"timeout", o.waitTimeout)
+			return
+		}
+	}
+}
+
+// Release gives up this request's place, letting the responses behind it go
+// out. It is idempotent: the read loop defers it for every request, and a
+// handler may call it earlier when it is about to block on client traffic.
+func (t *OrderToken) Release() {
+	if t == nil || !t.released.CompareAndSwap(false, true) {
+		return
+	}
+	o := t.order
+	o.mu.Lock()
+	o.released[t.seq] = struct{}{}
+	for {
+		if _, ok := o.released[o.low]; !ok {
+			break
+		}
+		delete(o.released, o.low)
+		o.low++
+	}
+	close(o.wake)
+	o.wake = make(chan struct{})
+	o.mu.Unlock()
+}
+
+// orderTokenKey types the context value below.
+type orderTokenKey struct{}
+
+// WithOrderToken attaches a request's ordering token to its context. The token
+// travels with the request rather than through every dispatch signature it
+// crosses, the same way the request's deadline does.
+func WithOrderToken(ctx context.Context, t *OrderToken) context.Context {
+	if t == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, orderTokenKey{}, t)
+}
+
+// OrderTokenFrom returns the request's ordering token, or nil when the caller
+// dispatched without one.
+func OrderTokenFrom(ctx context.Context) *OrderToken {
+	t, _ := ctx.Value(orderTokenKey{}).(*OrderToken)
+	return t
+}

--- a/internal/adapter/smb/request_order.go
+++ b/internal/adapter/smb/request_order.go
@@ -34,13 +34,15 @@ const DefaultOrderWaitTimeout = 30 * time.Second
 // Without that, the client would be waiting for a response the server is
 // holding behind the very request the client cannot send yet.
 type RequestOrder struct {
-	mu sync.Mutex
-	// wake is closed and replaced on every release, waking all waiters to
-	// re-check. Waiters are one per in-flight request on one connection.
-	wake     chan struct{}
+	mu       sync.Mutex
 	next     uint64
 	low      uint64 // every sequence below this has been released
 	released map[uint64]struct{}
+	// waiters holds one channel per response currently waiting for its turn.
+	// A release wakes only the sequence that just became eligible, which then
+	// wakes the next as it releases: a pipelining client costs one handoff per
+	// request rather than one per request per release.
+	waiters map[uint64]chan struct{}
 
 	waitTimeout time.Duration
 }
@@ -48,8 +50,8 @@ type RequestOrder struct {
 // NewRequestOrder creates the ordering state for one connection.
 func NewRequestOrder() *RequestOrder {
 	return &RequestOrder{
-		wake:        make(chan struct{}),
 		released:    make(map[uint64]struct{}),
+		waiters:     make(map[uint64]chan struct{}),
 		waitTimeout: DefaultOrderWaitTimeout,
 	}
 }
@@ -87,28 +89,32 @@ func (t *OrderToken) WaitTurn(ctx context.Context) {
 		return
 	}
 	o := t.order
+
+	o.mu.Lock()
+	if o.low >= t.seq {
+		o.mu.Unlock()
+		return
+	}
+	wake := make(chan struct{})
+	o.waiters[t.seq] = wake
+	o.mu.Unlock()
+
+	defer func() {
+		o.mu.Lock()
+		delete(o.waiters, t.seq)
+		o.mu.Unlock()
+	}()
+
 	deadline := time.NewTimer(o.waitTimeout)
 	defer deadline.Stop()
 
-	for {
-		o.mu.Lock()
-		if o.low >= t.seq {
-			o.mu.Unlock()
-			return
-		}
-		wake := o.wake
-		o.mu.Unlock()
-
-		select {
-		case <-wake:
-		case <-ctx.Done():
-			return
-		case <-deadline.C:
-			logger.Warn("SMB response ordering timed out; response may overtake an earlier request's break notification",
-				"sequence", t.seq,
-				"timeout", o.waitTimeout)
-			return
-		}
+	select {
+	case <-wake:
+	case <-ctx.Done():
+	case <-deadline.C:
+		logger.Warn("SMB response ordering timed out; response may overtake an earlier request's break notification",
+			"sequence", t.seq,
+			"timeout", o.waitTimeout)
 	}
 }
 
@@ -129,8 +135,13 @@ func (t *OrderToken) Release() {
 		delete(o.released, o.low)
 		o.low++
 	}
-	close(o.wake)
-	o.wake = make(chan struct{})
+	// Only the sequence that just became eligible needs waking: everything
+	// below it was already eligible, and everything above it is still waiting
+	// on this one.
+	if wake, ok := o.waiters[o.low]; ok {
+		delete(o.waiters, o.low)
+		close(wake)
+	}
 	o.mu.Unlock()
 }
 

--- a/internal/adapter/smb/request_order.go
+++ b/internal/adapter/smb/request_order.go
@@ -3,18 +3,17 @@ package smb
 import (
 	"context"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// DefaultOrderWaitTimeout bounds how long a response waits for the responses
+// defaultOrderWaitTimeout bounds how long a response waits for the responses
 // ahead of it. Nothing is expected to reach it: every handler wait that depends
 // on further client traffic releases its slot before blocking. It exists so a
 // handler that blocks unexpectedly delays one connection's responses instead of
 // stalling them forever, and it logs when it fires.
-const DefaultOrderWaitTimeout = 30 * time.Second
+const defaultOrderWaitTimeout = 30 * time.Second
 
 // RequestOrder restores, per connection, an ordering a single-threaded server
 // gets for free: a response never reaches the wire ahead of a lease or oplock
@@ -52,7 +51,7 @@ func NewRequestOrder() *RequestOrder {
 	return &RequestOrder{
 		released:    make(map[uint64]struct{}),
 		waiters:     make(map[uint64]chan struct{}),
-		waitTimeout: DefaultOrderWaitTimeout,
+		waitTimeout: defaultOrderWaitTimeout,
 	}
 }
 
@@ -60,9 +59,11 @@ func NewRequestOrder() *RequestOrder {
 // A nil token is inert, so paths with no ordering (tests, direct dispatch)
 // need no special casing.
 type OrderToken struct {
-	order    *RequestOrder
-	seq      uint64
-	released atomic.Bool
+	order *RequestOrder
+	seq   uint64
+	// released is guarded by order.mu, so Release stays exactly-once however
+	// many times it is called.
+	released bool
 }
 
 // Begin claims the next place in the order. Call it from the read loop, in
@@ -122,11 +123,16 @@ func (t *OrderToken) WaitTurn(ctx context.Context) {
 // out. It is idempotent: the read loop defers it for every request, and a
 // handler may call it earlier when it is about to block on client traffic.
 func (t *OrderToken) Release() {
-	if t == nil || !t.released.CompareAndSwap(false, true) {
+	if t == nil {
 		return
 	}
 	o := t.order
 	o.mu.Lock()
+	defer o.mu.Unlock()
+	if t.released {
+		return
+	}
+	t.released = true
 	o.released[t.seq] = struct{}{}
 	for {
 		if _, ok := o.released[o.low]; !ok {
@@ -142,7 +148,6 @@ func (t *OrderToken) Release() {
 		delete(o.waiters, o.low)
 		close(wake)
 	}
-	o.mu.Unlock()
 }
 
 // orderTokenKey types the context value below.

--- a/internal/adapter/smb/request_order_bench_test.go
+++ b/internal/adapter/smb/request_order_bench_test.go
@@ -10,7 +10,9 @@ import (
 	"time"
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/handlers"
+	"github.com/marmos91/dittofs/internal/adapter/smb/header"
 	"github.com/marmos91/dittofs/internal/adapter/smb/session"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 )
 
 // newBenchConnInfo mirrors newTestConnInfo without a *testing.T.
@@ -43,11 +45,11 @@ func benchConn(b *testing.B) (net.Conn, func()) {
 	}
 }
 
-// What ordering costs a pipelining client on the dispatch path, measured on
-// ECHO so the number is the ordering overhead rather than a handler's work.
-// Each iteration dispatches `depth` requests concurrently, as a client with
-// that many credits outstanding would.
-func BenchmarkPipelinedDispatch(b *testing.B) {
+// What ordering costs a client with `depth` requests outstanding, measured
+// against the bare response write it wraps. Handlers are omitted deliberately:
+// the difference between the two arms is the whole cost of ordering, and a
+// handler's own work would only dilute it.
+func BenchmarkOrderedResponseEmission(b *testing.B) {
 	for _, depth := range []int{1, 8, 32} {
 		for _, ordered := range []bool{false, true} {
 			name := "unordered"
@@ -62,6 +64,7 @@ func BenchmarkPipelinedDispatch(b *testing.B) {
 					ci.RequestOrder = NewRequestOrder()
 				}
 				ctx := context.Background()
+				body := MakeErrorBody()
 
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
@@ -72,13 +75,17 @@ func BenchmarkPipelinedDispatch(b *testing.B) {
 						go func(msgID uint64) {
 							defer wg.Done()
 							defer tok.Release()
-							_ = ProcessSingleRequest(WithOrderToken(ctx, tok),
-								echoHeader(msgID), echoBody(), nil, ci, false, nil)
+							tok.WaitTurn(ctx)
+							_ = SendMessage(&header.SMB2Header{
+								StructureSize: header.HeaderSize,
+								Command:       types.SMB2Echo,
+								MessageID:     msgID,
+							}, body, ci)
 						}(uint64(i*depth + j + 1))
 					}
 					wg.Wait()
 				}
-				b.ReportMetric(float64(depth), "requests/iter")
+				b.ReportMetric(float64(depth), "responses/iter")
 			})
 		}
 	}

--- a/internal/adapter/smb/request_order_bench_test.go
+++ b/internal/adapter/smb/request_order_bench_test.go
@@ -1,0 +1,118 @@
+package smb
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/handlers"
+	"github.com/marmos91/dittofs/internal/adapter/smb/session"
+)
+
+// newBenchConnInfo mirrors newTestConnInfo without a *testing.T.
+func newBenchConnInfo(conn net.Conn) *ConnInfo {
+	mgr := session.NewDefaultManager()
+	return &ConnInfo{
+		Conn:           conn,
+		Handler:        handlers.NewHandlerWithSessionManager(mgr),
+		SessionManager: mgr,
+		WriteMu:        &LockedWriter{},
+		WriteTimeout:   2 * time.Second,
+		SequenceWindow: NewSequenceWindowForConnection(mgr),
+	}
+}
+
+// benchConn is a server-side conn whose peer is drained, so a response write
+// costs what it costs on a real socket and nothing more.
+func benchConn(b *testing.B) (net.Conn, func()) {
+	b.Helper()
+	serverConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = io.Copy(io.Discard, clientConn)
+	}()
+	return serverConn, func() {
+		_ = serverConn.Close()
+		_ = clientConn.Close()
+		<-done
+	}
+}
+
+// What ordering costs a pipelining client on the dispatch path, measured on
+// ECHO so the number is the ordering overhead rather than a handler's work.
+// Each iteration dispatches `depth` requests concurrently, as a client with
+// that many credits outstanding would.
+func BenchmarkPipelinedDispatch(b *testing.B) {
+	for _, depth := range []int{1, 8, 32} {
+		for _, ordered := range []bool{false, true} {
+			name := "unordered"
+			if ordered {
+				name = "ordered"
+			}
+			b.Run(fmt.Sprintf("%s/depth=%d", name, depth), func(b *testing.B) {
+				conn, cleanup := benchConn(b)
+				defer cleanup()
+				ci := newBenchConnInfo(conn)
+				if ordered {
+					ci.RequestOrder = NewRequestOrder()
+				}
+				ctx := context.Background()
+
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					var wg sync.WaitGroup
+					for j := range depth {
+						tok := ci.RequestOrder.Begin()
+						wg.Add(1)
+						go func(msgID uint64) {
+							defer wg.Done()
+							defer tok.Release()
+							_ = ProcessSingleRequest(WithOrderToken(ctx, tok),
+								echoHeader(msgID), echoBody(), nil, ci, false, nil)
+						}(uint64(i*depth + j + 1))
+					}
+					wg.Wait()
+				}
+				b.ReportMetric(float64(depth), "requests/iter")
+			})
+		}
+	}
+}
+
+// Handlers must keep running concurrently: only the moment a response is
+// written is ordered. A slow request at the head of the pipeline must not add
+// its latency to each of the requests behind it.
+func TestRequestOrder_KeepsHandlersConcurrent(t *testing.T) {
+	const depth = 32
+	const handlerLatency = 100 * time.Millisecond
+
+	o := NewRequestOrder()
+	tokens := make([]*OrderToken, depth)
+	for i := range tokens {
+		tokens[i] = o.Begin()
+	}
+
+	start := time.Now()
+	var wg sync.WaitGroup
+	for _, tok := range tokens {
+		wg.Add(1)
+		go func(tok *OrderToken) {
+			defer wg.Done()
+			defer tok.Release()
+			time.Sleep(handlerLatency) // the handler's own work
+			tok.WaitTurn(context.Background())
+		}(tok)
+	}
+	wg.Wait()
+
+	// Serialized execution would cost depth*handlerLatency; concurrent
+	// execution with ordered emission costs one handlerLatency plus wakeups.
+	if elapsed := time.Since(start); elapsed > 4*handlerLatency {
+		t.Fatalf("%d concurrent handlers took %v: ordering is serializing execution, not just emission", depth, elapsed)
+	}
+}

--- a/internal/adapter/smb/request_order_test.go
+++ b/internal/adapter/smb/request_order_test.go
@@ -259,3 +259,31 @@ func newRecordingConnPair(t *testing.T) (net.Conn, <-chan types.Command, func())
 	}
 	return serverConn, commands, cleanup
 }
+
+// The two-phase pattern the rename branch uses: a handler releases its place
+// to wait on a break acknowledgement, then reaches its own response and asks
+// for its turn a second time. It must not queue for a place it no longer
+// holds — the order has moved on without it, so nothing would ever wake it and
+// it would sit there until the wait timeout, on exactly the path this ordering
+// exists to protect.
+func TestRequestOrder_ReleasedTokenDoesNotQueueAgain(t *testing.T) {
+	o := NewRequestOrder()
+	o.waitTimeout = time.Hour // a stall here must hang the test, not pass it
+	first := o.Begin()
+	second := o.Begin()
+	_ = first // never releases: the order never reaches second's sequence
+
+	second.Release() // stepped out to wait for a break acknowledgement
+
+	returned := make(chan struct{})
+	go func() {
+		second.WaitTurn(context.Background()) // now sending its own response
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("a released token queued for a place it had given up")
+	}
+}

--- a/internal/adapter/smb/request_order_test.go
+++ b/internal/adapter/smb/request_order_test.go
@@ -1,0 +1,248 @@
+package smb
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/header"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+// A later request's response must not go out while an earlier request on the
+// same connection is still unanswered — that is the window in which the
+// earlier request's lease break notification is overtaken.
+func TestRequestOrder_LaterResponseWaitsForEarlier(t *testing.T) {
+	o := NewRequestOrder()
+	first := o.Begin()
+	second := o.Begin()
+
+	arrived := make(chan struct{})
+	go func() {
+		second.WaitTurn(context.Background())
+		close(arrived)
+	}()
+
+	select {
+	case <-arrived:
+		t.Fatal("second response went out while the first request was still unanswered")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	first.Release()
+
+	select {
+	case <-arrived:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second response never went out after the first released")
+	}
+}
+
+// Releasing out of order must not advance the order past a request that is
+// still holding its place.
+func TestRequestOrder_OutOfOrderRelease(t *testing.T) {
+	o := NewRequestOrder()
+	first, second, third := o.Begin(), o.Begin(), o.Begin()
+
+	arrived := make(chan struct{})
+	go func() {
+		third.WaitTurn(context.Background())
+		close(arrived)
+	}()
+
+	second.Release() // the middle request finishes first
+	select {
+	case <-arrived:
+		t.Fatal("third response went out while the first request was still unanswered")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	first.Release()
+	select {
+	case <-arrived:
+	case <-time.After(2 * time.Second):
+		t.Fatal("third response never went out after every earlier request released")
+	}
+}
+
+// A handler that must wait on client traffic releases early. Its own response
+// then goes out without waiting — it has already given up its place.
+func TestRequestOrder_EarlyReleaseIsIdempotent(t *testing.T) {
+	o := NewRequestOrder()
+	first := o.Begin()
+	second := o.Begin()
+
+	first.Release() // stepped out to wait for a break acknowledgement
+
+	done := make(chan struct{})
+	go func() {
+		second.WaitTurn(context.Background())
+		first.WaitTurn(context.Background()) // the early releaser's own response
+		first.Release()                      // the read loop's deferred release
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("early release did not let the responses behind it through")
+	}
+}
+
+// The wait is bounded so an unexpectedly blocked handler delays one
+// connection's responses instead of stalling them for good.
+func TestRequestOrder_WaitTimesOut(t *testing.T) {
+	o := NewRequestOrder()
+	o.waitTimeout = 20 * time.Millisecond
+	o.Begin() // never released
+	second := o.Begin()
+
+	start := time.Now()
+	second.WaitTurn(context.Background())
+	if elapsed := time.Since(start); elapsed < 20*time.Millisecond {
+		t.Fatalf("returned after %v, before the wait timeout", elapsed)
+	}
+}
+
+// A cancelled request stops waiting for its turn rather than pinning the
+// goroutine to a connection that is going away.
+func TestRequestOrder_WaitStopsOnContextCancel(t *testing.T) {
+	o := NewRequestOrder()
+	o.Begin() // never released
+	second := o.Begin()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		second.WaitTurn(ctx)
+		close(done)
+	}()
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitTurn ignored context cancellation")
+	}
+}
+
+// A nil token is inert, so dispatch paths with no read loop behind them need
+// no special casing.
+func TestRequestOrder_NilTokenIsInert(t *testing.T) {
+	var t0 *OrderToken
+	t0.WaitTurn(context.Background())
+	t0.Release()
+
+	var o *RequestOrder
+	if o.Begin() != nil {
+		t.Fatal("a nil RequestOrder must issue a nil token")
+	}
+	if OrderTokenFrom(context.Background()) != nil {
+		t.Fatal("a context with no token must report none")
+	}
+}
+
+// The defect this ordering exists for, driven through the real dispatch path:
+// a SET_INFO rename (message 1) owes a lease break, and the CREATE the client
+// pipelined behind it (message 2) is handled first. The CREATE's response must
+// not reach the wire before the break, or the client acknowledges a lease key
+// it has never been told.
+func TestProcessSingleRequest_BreakPrecedesLaterResponse(t *testing.T) {
+	serverConn, commands, cleanup := newRecordingConnPair(t)
+	t.Cleanup(cleanup)
+
+	ci := newTestConnInfo(t, serverConn)
+	ci.RequestOrder = NewRequestOrder()
+
+	rename := ci.RequestOrder.Begin() // message 1: read first, dispatched second
+	create := ci.RequestOrder.Begin() // message 2: read second, dispatched first
+
+	echoed := make(chan error, 1)
+	go func() {
+		// Stands in for message 2's handler: it runs to completion long
+		// before message 1's has started.
+		echoed <- ProcessSingleRequest(
+			WithOrderToken(context.Background(), create),
+			echoHeader(2), echoBody(), nil, ci, false, nil,
+		)
+		create.Release()
+	}()
+
+	select {
+	case <-commands:
+		t.Fatal("the later request was answered before the earlier request's break was sent")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Message 1's handler finally runs and dispatches its break notification,
+	// exactly as the lease notifier does — synchronously, before its own
+	// response — then steps out of the order to wait for the acknowledgement.
+	breakHeader := &header.SMB2Header{
+		StructureSize: header.HeaderSize,
+		Command:       types.SMB2OplockBreak,
+		MessageID:     ^uint64(0),
+	}
+	if err := SendMessage(breakHeader, MakeErrorBody(), ci); err != nil {
+		t.Fatalf("sending the break notification failed: %v", err)
+	}
+	rename.Release()
+
+	if err := <-echoed; err != nil {
+		t.Fatalf("ProcessSingleRequest returned %v", err)
+	}
+
+	got := make([]types.Command, 0, 2)
+	for range 2 {
+		select {
+		case cmd := <-commands:
+			got = append(got, cmd)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("only %d frames reached the wire: %v", len(got), got)
+		}
+	}
+	if got[0] != types.SMB2OplockBreak || got[1] != types.SMB2Echo {
+		t.Fatalf("wire order was %v; the break must precede the later request's response", got)
+	}
+}
+
+// newRecordingConnPair returns a server-side conn whose frames are reported,
+// in wire order, as the SMB2 command each one carries.
+func newRecordingConnPair(t *testing.T) (net.Conn, <-chan types.Command, func()) {
+	t.Helper()
+	serverConn, clientConn := net.Pipe()
+	commands := make(chan types.Command, 8)
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		length := make([]byte, 4)
+		for {
+			if _, err := io.ReadFull(clientConn, length); err != nil {
+				return
+			}
+			frame := make([]byte, binary.BigEndian.Uint32(length))
+			if _, err := io.ReadFull(clientConn, frame); err != nil {
+				return
+			}
+			// SMB2 header: ProtocolId(4) StructureSize(2) CreditCharge(2)
+			// Status(4) Command(2) — MS-SMB2 §2.2.1.2.
+			if len(frame) >= 14 {
+				commands <- types.Command(binary.LittleEndian.Uint16(frame[12:14]))
+			}
+		}
+	}()
+
+	var once sync.Once
+	cleanup := func() {
+		once.Do(func() {
+			_ = serverConn.Close()
+			_ = clientConn.Close()
+			<-done
+		})
+	}
+	return serverConn, commands, cleanup
+}

--- a/internal/adapter/smb/request_order_test.go
+++ b/internal/adapter/smb/request_order_test.go
@@ -161,13 +161,26 @@ func TestProcessSingleRequest_BreakPrecedesLaterResponse(t *testing.T) {
 	rename := ci.RequestOrder.Begin() // message 1: read first, dispatched second
 	create := ci.RequestOrder.Begin() // message 2: read second, dispatched first
 
-	echoed := make(chan error, 1)
+	// Message 2 is a CREATE on a session this connection does not have, so it
+	// is answered from the dispatch gate — the point is which response reaches
+	// the wire first, not what it says. ECHO cannot stand in for it: ECHO is
+	// deliberately exempt from the order.
+	createHeader := &header.SMB2Header{
+		StructureSize: header.HeaderSize,
+		Command:       types.SMB2Create,
+		Credits:       1,
+		CreditCharge:  1,
+		MessageID:     2,
+		SessionID:     0x1234,
+	}
+
+	answered := make(chan error, 1)
 	go func() {
 		// Stands in for message 2's handler: it runs to completion long
 		// before message 1's has started.
-		echoed <- ProcessSingleRequest(
+		answered <- ProcessSingleRequest(
 			WithOrderToken(context.Background(), create),
-			echoHeader(2), echoBody(), nil, ci, false, nil,
+			createHeader, nil, nil, ci, false, nil,
 		)
 		create.Release()
 	}()
@@ -191,7 +204,7 @@ func TestProcessSingleRequest_BreakPrecedesLaterResponse(t *testing.T) {
 	}
 	rename.Release()
 
-	if err := <-echoed; err != nil {
+	if err := <-answered; err != nil {
 		t.Fatalf("ProcessSingleRequest returned %v", err)
 	}
 
@@ -204,7 +217,7 @@ func TestProcessSingleRequest_BreakPrecedesLaterResponse(t *testing.T) {
 			t.Fatalf("only %d frames reached the wire: %v", len(got), got)
 		}
 	}
-	if got[0] != types.SMB2OplockBreak || got[1] != types.SMB2Echo {
+	if got[0] != types.SMB2OplockBreak || got[1] != types.SMB2Create {
 		t.Fatalf("wire order was %v; the break must precede the later request's response", got)
 	}
 }

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -92,6 +92,12 @@ func ProcessSingleRequest(
 	default:
 	}
 
+	// This request's place in the connection's response order. Every response
+	// below waits for the responses ahead of it, so a break notification an
+	// earlier request dispatched is on the wire first. Nil (inert) when the
+	// caller dispatched without a read loop. See RequestOrder.
+	orderToken := OrderTokenFrom(ctx)
+
 	// RED metrics: one sample per handled request via a single deferred emit.
 	// metricOp defaults to the request's command name and is refined to the
 	// dispatch-table name once the command resolves; metricErr is flipped on
@@ -139,6 +145,7 @@ func ProcessSingleRequest(
 				"creditCharge", reqHeader.CreditCharge,
 				"error", err)
 			metricErr = true
+			orderToken.WaitTurn(ctx)
 			return SendErrorResponse(reqHeader, types.StatusInvalidParameter, connInfo)
 		}
 	}
@@ -151,6 +158,7 @@ func ProcessSingleRequest(
 				"creditCharge", charge,
 				"exempt", exempt)
 			metricErr = true
+			orderToken.WaitTurn(ctx)
 			return SendErrorResponse(reqHeader, types.StatusInvalidParameter, connInfo)
 		}
 	}
@@ -167,6 +175,7 @@ func ProcessSingleRequest(
 		// cancels the pending op and returns nil (no response), per MS-SMB2
 		// §3.3.5.16.
 		metricErr = true
+		orderToken.WaitTurn(ctx)
 		return sendDispatchError(reqHeader, errStatus, connInfo, isEncrypted)
 	}
 
@@ -188,6 +197,7 @@ func ProcessSingleRequest(
 	// Per MS-SMB2 3.3.5.2.1: enforce encryption requirements.
 	if errStatus := checkEncryptionRequired(reqHeader, connInfo, isEncrypted); errStatus != 0 {
 		metricErr = true
+		orderToken.WaitTurn(ctx)
 		return sendDispatchError(reqHeader, errStatus, connInfo, isEncrypted)
 	}
 
@@ -199,6 +209,7 @@ func ProcessSingleRequest(
 			"command", reqHeader.Command.String(),
 			"messageID", reqHeader.MessageID)
 		metricErr = true
+		orderToken.WaitTurn(ctx)
 		return sendDispatchError(reqHeader, errStatus, connInfo, isEncrypted)
 	}
 
@@ -264,6 +275,7 @@ func ProcessSingleRequest(
 	if err != nil {
 		logger.Debug("Handler error", "command", cmd.Name, "error", err)
 		metricErr = true
+		orderToken.WaitTurn(ctx)
 		return SendErrorResponse(reqHeader, types.StatusInternalError, connInfo)
 	}
 
@@ -309,6 +321,7 @@ func ProcessSingleRequest(
 	// whatever the handler already committed to before replying — a recorded
 	// lease break whose notification never reaches its (possibly unrelated,
 	// still-live) holder. (Same contract as the compound dispatch path.)
+	orderToken.WaitTurn(ctx)
 	sendErr := SendResponseWithHooks(reqHeader, handlerCtx, result, connInfo)
 	if sendErr != nil {
 		runPostSend(handlerCtx)

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -321,7 +321,14 @@ func ProcessSingleRequest(
 	// whatever the handler already committed to before replying — a recorded
 	// lease break whose notification never reaches its (possibly unrelated,
 	// still-live) holder. (Same contract as the compound dispatch path.)
-	orderToken.WaitTurn(ctx)
+	// ECHO is exempt from the response order. A client sends it precisely to
+	// test whether a connection with work outstanding on it is still alive
+	// (MS-SMB2 §3.3.5.13), so queueing its reply behind that work is the one
+	// case where ordering would answer the question wrongly. It carries no
+	// file state, so nothing a break notification protects rides on it.
+	if reqHeader.Command != types.SMB2Echo {
+		orderToken.WaitTurn(ctx)
+	}
 	sendErr := SendResponseWithHooks(reqHeader, handlerCtx, result, connInfo)
 	if sendErr != nil {
 		runPostSend(handlerCtx)

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -424,6 +424,12 @@ func prepareDispatch(ctx context.Context, reqHeader *header.SMB2Header, connInfo
 	// binding (MS-SMB2 §3.3.5.5.2) can key per-channel signing state.
 	handlerCtx.ConnID = connInfo.ConnID
 
+	// Let a handler that must wait on client traffic step out of the
+	// connection's response order first. See SMBHandlerContext.ReleaseOrder.
+	if t := OrderTokenFrom(ctx); t != nil {
+		handlerCtx.ReleaseOrder = t.Release
+	}
+
 	// Thread the connection's transport so completeSessionBind can attach
 	// it to the newly-registered Channel, enabling break notifications
 	// (MS-SMB2 §3.3.4.7) to fan out across bound secondary channels.

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -321,6 +321,7 @@ func ProcessSingleRequest(
 	// whatever the handler already committed to before replying — a recorded
 	// lease break whose notification never reaches its (possibly unrelated,
 	// still-live) holder. (Same contract as the compound dispatch path.)
+	//
 	// ECHO is exempt from the response order. A client sends it precisely to
 	// test whether a connection with work outstanding on it is still alive
 	// (MS-SMB2 §3.3.5.13), so queueing its reply behind that work is the one

--- a/pkg/adapter/smb/connection.go
+++ b/pkg/adapter/smb/connection.go
@@ -346,20 +346,20 @@ func (c *Connection) Serve(ctx context.Context) {
 		copy(rawMessage, hdr.Encode())
 		copy(rawMessage[header.HeaderSize:], body)
 
+		// Claim this request's place in the connection's response order. The
+		// read loop is the only sequential point on the connection, so it is
+		// the only place arrival order can be recorded; the handler goroutines
+		// spawned below are scheduled in any order. A response waits for the
+		// responses ahead of it, which is what keeps a break notification an
+		// earlier request owes from being overtaken. See RequestOrder.
+		orderToken := ci.RequestOrder.Begin()
+		reqCtx := smb.WithOrderToken(ctx, orderToken)
+
 		// LOGOFF must be processed synchronously to guarantee the LoggedOff
 		// flag is set before the next request is read from the connection.
 		// Without this, a concurrent goroutine for the next request could
 		// race with the LOGOFF handler, causing the signing verifier to
 		// return STATUS_ACCESS_DENIED instead of STATUS_USER_SESSION_DELETED.
-		// Claim this request's place in the connection's response order. The
-		// read loop is the only sequential point on the connection, so it is
-		// the only place arrival order can be recorded; the handler goroutines
-		// spawned below are scheduled in any order. A response waits here for
-		// the responses ahead of it, which is what keeps a break notification
-		// an earlier request owes from being overtaken. See RequestOrder.
-		orderToken := ci.RequestOrder.Begin()
-		reqCtx := smb.WithOrderToken(ctx, orderToken)
-
 		if hdr.Command == types.CommandLogoff && len(remainingCompound) == 0 {
 			func() {
 				defer pool.Put(rawMessage)

--- a/pkg/adapter/smb/connection.go
+++ b/pkg/adapter/smb/connection.go
@@ -173,6 +173,7 @@ func (c *Connection) connInfo() *smb.ConnInfo {
 		Handler:        c.server.handler,
 		SessionManager: c.server.sessionManager,
 		WriteMu:        &c.writeMu,
+		RequestOrder:   smb.NewRequestOrder(),
 		WriteTimeout:   c.server.config.Timeouts.Write,
 		SessionTracker: c, // overwritten below
 		CryptoState:    c.CryptoState,
@@ -350,10 +351,20 @@ func (c *Connection) Serve(ctx context.Context) {
 		// Without this, a concurrent goroutine for the next request could
 		// race with the LOGOFF handler, causing the signing verifier to
 		// return STATUS_ACCESS_DENIED instead of STATUS_USER_SESSION_DELETED.
+		// Claim this request's place in the connection's response order. The
+		// read loop is the only sequential point on the connection, so it is
+		// the only place arrival order can be recorded; the handler goroutines
+		// spawned below are scheduled in any order. A response waits here for
+		// the responses ahead of it, which is what keeps a break notification
+		// an earlier request owes from being overtaken. See RequestOrder.
+		orderToken := ci.RequestOrder.Begin()
+		reqCtx := smb.WithOrderToken(ctx, orderToken)
+
 		if hdr.Command == types.CommandLogoff && len(remainingCompound) == 0 {
 			func() {
 				defer pool.Put(rawMessage)
-				if err := smb.ProcessSingleRequest(ctx, hdr, body, rawMessage, ci, isEncrypted, nil); err != nil {
+				defer orderToken.Release()
+				if err := smb.ProcessSingleRequest(reqCtx, hdr, body, rawMessage, ci, isEncrypted, nil); err != nil {
 					logger.Debug("Error processing LOGOFF request", "address", clientAddr, "messageID", hdr.MessageID, "error", err)
 				}
 			}()
@@ -395,20 +406,22 @@ func (c *Connection) Serve(ctx context.Context) {
 
 			go func(reqHeader *header.SMB2Header, reqBody, raw []byte, encrypted bool) {
 				defer pool.Put(raw)
+				defer orderToken.Release()
 				defer c.handleRequestPanic(clientAddr, reqHeader.MessageID)
 				asyncCallback := c.makeAsyncNotifyCallback(ci)
-				smb.ProcessCompoundRequest(ctx, reqHeader, reqBody, raw, compoundData, ci, encrypted, asyncCallback)
+				smb.ProcessCompoundRequest(reqCtx, reqHeader, reqBody, raw, compoundData, ci, encrypted, asyncCallback)
 			}(hdr, body, rawMessage, isEncrypted)
 		} else {
 			go func(reqHeader *header.SMB2Header, reqBody, raw []byte, encrypted bool, release func()) {
 				defer pool.Put(raw)
+				defer orderToken.Release()
 				if release != nil {
 					defer release()
 				}
 				defer c.handleRequestPanic(clientAddr, reqHeader.MessageID)
 
 				asyncCallback := c.makeAsyncNotifyCallback(ci)
-				if err := smb.ProcessSingleRequest(ctx, reqHeader, reqBody, raw, ci, encrypted, asyncCallback); err != nil {
+				if err := smb.ProcessSingleRequest(reqCtx, reqHeader, reqBody, raw, ci, encrypted, asyncCallback); err != nil {
 					logger.Debug("Error processing SMB request", "address", clientAddr, "messageID", reqHeader.MessageID, "error", err)
 				}
 			}(hdr, body, rawMessage, isEncrypted, releaseHandleOp)

--- a/pkg/adapter/smb/connection.go
+++ b/pkg/adapter/smb/connection.go
@@ -360,11 +360,20 @@ func (c *Connection) Serve(ctx context.Context) {
 		// Without this, a concurrent goroutine for the next request could
 		// race with the LOGOFF handler, causing the signing verifier to
 		// return STATUS_ACCESS_DENIED instead of STATUS_USER_SESSION_DELETED.
+		//
+		// It is dispatched WITHOUT its ordering token, so its response never
+		// waits for the responses ahead of it. Waiting happens on this
+		// goroutine, so it would stall the read loop rather than one request:
+		// the next wire message — possibly for a different, live session
+		// multiplexed over this connection — could not even be read until the
+		// earlier request answered. LOGOFF carries no file state, so nothing a
+		// break notification protects rides on it. The token is still released
+		// below, so the requests behind it are not held up.
 		if hdr.Command == types.CommandLogoff && len(remainingCompound) == 0 {
 			func() {
 				defer pool.Put(rawMessage)
 				defer orderToken.Release()
-				if err := smb.ProcessSingleRequest(reqCtx, hdr, body, rawMessage, ci, isEncrypted, nil); err != nil {
+				if err := smb.ProcessSingleRequest(ctx, hdr, body, rawMessage, ci, isEncrypted, nil); err != nil {
 					logger.Debug("Error processing LOGOFF request", "address", clientAddr, "messageID", hdr.MessageID, "error", err)
 				}
 			}()


### PR DESCRIPTION
Restores, per connection, the ordering a single-threaded server gets for free:
a response never reaches the wire ahead of a lease break notification that an
earlier request on the same connection owes.

## The defect

The read loop is sequential, but it hands every request to its own goroutine,
so arrival order is guaranteed and only scheduling is racy — and Go's runnext
slot systematically favours the goroutine spawned *later*. From a `memory` run:

```
SMB2 request  command=SET_INFO messageID=8      <- read first
SMB2 request  command=CREATE   messageID=9      <- read second
Dispatching   command=CREATE   messageID=9      <- dispatched first
Sent response command=CREATE   ...OBJECT_NAME_NOT_FOUND messageID=9
Dispatching   command=SET_INFO messageID=8      <- only now
SMBBreakHandler: dispatching lease break notification leaseKey=adbeed…
```

Message 8 owed a break. The client received a response that logically comes
after that break without the break having been sent.

## Why not serialize dispatch

The issue's second option — serialize per-connection processing to
completion-or-`STATUS_PENDING` — **deadlocks in this codebase**, and that is
worth recording rather than rediscovering.

DittoFS's rename does not go async. `set_info.go`'s rename branch dispatches the
break and then does a bounded *synchronous* `WaitForOtherKeyBreaks`, waiting for
an acknowledgement the client cannot send until it has seen the response to the
request queued behind the rename. Serializing dispatch holds that request back,
so both sides wait until the wait's own timeout expires.

Serializing dispatch is also the wrong shape for the data path: READ has no
async park outside the named-pipe branch, so pipelined cold reads would go from
`max(latency)` to `sum(latency)`.

## What this does instead

Order the *emission* of responses, not their execution.

- The read loop issues one `OrderToken` per request, in wire order, before
  spawning — it is the only sequential point on the connection.
- A response waits until every earlier token is released, then releases its own.
- Handlers keep running fully concurrently. Only the moment a response is
  written is ordered.

Break notifications are already written synchronously by the handler that
triggers them, before that handler's own response (`lease/notifier.go`), so
ordering responses orders breaks against later responses too.

**Release points.** The read loop defers a release for every request. A handler
that must block on something only a *later* request can deliver releases first,
via `releaseResponseOrder` — the break-ACK waits in the rename branch and in
`breakAndMaybeParkCreate`'s sync fallbacks. The break notifications those waits
are waiting on have already been written by then, which is the ordering that
mattered. Without this the rename case deadlocks exactly as dispatch
serialization would.

**Two exemptions.** ECHO is answered without waiting: A client sends it to test whether a connection with work
outstanding on it is still alive (MS-SMB2 §3.3.5.13), so queueing its reply
behind that work answers the question wrongly. It carries no file state.
LOGOFF is dispatched without a token at all, because it is processed on the
read loop — waiting there stalls the next wire message for every session
multiplexed over the connection, not just one request.

## Two defects the review caught

Recorded because both are the kind that hide.

**A released token queued for its place again.** `Release` advances the
low-water mark over every already-released sequence in one step, then wakes the
new frontier. A handler that stepped out for a break ACK and later asked for its
turn had its own sequence stepped over — so its wake was never looked up and it
blocked until the 30s timeout, on precisely the paths `releaseResponseOrder`
exists to protect. Fixed at the root: the mark can only step over sequences
whose token has released, so a released token must not queue at all.
`TestRequestOrder_ReleasedTokenDoesNotQueueAgain` pins it.

The first version of that test passed against the broken code — it raced the
release against the wait, so `WaitTurn` found the order already past it and
never queued. The test now turns on an earlier request that never releases, so
there is nothing to race.

**LOGOFF blocked the read loop.** See the exemption above.

**The wait is bounded** (30s, logged). Nothing is expected to reach it; it
exists so a handler that blocks unexpectedly delays one connection's responses
instead of stalling them for good.

## Throughput cost

`BenchmarkOrderedResponseEmission`, medians of 8, response-write path only so
the number is the cost of ordering rather than a handler's work diluting it:

| pipeline depth | unordered | ordered | per response |
| --- | --- | --- | --- |
| 1 | 3.20 µs | 3.21 µs | none measurable |
| 8 | 18.9 µs | 27.1 µs | +1.03 µs |
| 32 | ~126 µs | ~165 µs | +1.2 µs |

~1 µs of goroutine handoff per response at depth ≥ 8, nothing at depth 1. The
real-world figure is lower: the benchmark has every request finish at once,
whereas a predecessor that did any work is usually already released by the time
its successor reaches the wait.

The first cut cost 3.8× at depth 32 — releases woke every waiter. Releases now
wake only the sequence that just became eligible, which wakes the next as it
releases.

`TestRequestOrder_KeepsHandlersConcurrent` pins the property the numbers rest
on: 32 concurrent 100 ms handlers still finish in ~100 ms, not 3.2 s. Ordering
emission is not serializing execution.

## Relationship to #2151 — no overlap

Spelled out mechanically, mirroring that PR's own four clauses:

- #2151 changes **which request claims already-buffered notify events**; this
  changes **when a response is written**.
- Neither changes the order requests are **dispatched** in.
- #2151's bookkeeping is per handle and gated on `CommandChangeNotify`; this is
  per connection and command-agnostic.
- The two touch `connection.go` in the same loop but not the same statement.

## Verification

`TestProcessSingleRequest_BreakPrecedesLaterResponse` drives the real dispatch
path: a break notification written by the earlier request, a later request whose
handler ran to completion first, and an assertion on wire order. It fails on the
pre-fix behaviour — verified by neutering `WaitTurn` — and passes with it.

The rest of `request_order_test.go` covers the primitive: out-of-order release,
early release, the bounded wait, context cancellation, nil-token inertness.

`go build ./...`, `go vet ./...`, and `go test ./internal/... ./pkg/...` green;
the SMB packages also green under `-race`.

Closes #2127
