### PR TITLE
fix(carve): keep what a run's first chunk takes over, where the journal says it is owed

### DIFF
--- a/pkg/block/engine/blocksink.go
+++ b/pkg/block/engine/blocksink.go
@@ -142,6 +142,40 @@ func (s localBlockSink) CommitBlock(ctx context.Context, chunks []journal.CarveC
 	return commitManifestRows(ctx, s.committer, s.commitLocks, string(chunks[0].FileID), manifestRows(chunks))
 }
 
+// preserveClobberedRow implements journal's optional clobber guard: before a run
+// whose first fresh chunk lands on an existing row's key replaces that row, keep
+// whatever it still owns past the run's end, over the ranges journal reports as
+// still owed. A nil committer (the clone fixture) has no manifest to keep.
+func preserveClobberedRow(
+	ctx context.Context,
+	committer blockCommitter,
+	locks *carveCommitLocks,
+	payloadID string,
+	runStart, runEnd int64,
+	owed [][2]int64,
+) error {
+	if committer == nil {
+		return nil
+	}
+	// Same File-row serialization as the commit path: this writes manifest rows
+	// and re-projects File.Blocks, so it races the same way under SSI.
+	if mu := locks.forKey(payloadID); mu != nil {
+		mu.Lock()
+		defer mu.Unlock()
+	}
+	return committer.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return metadata.PreserveClobberedRow(ctx, tx, payloadID, runStart, runEnd, owed)
+	})
+}
+
+func (s localBlockSink) PreserveClobberedRow(ctx context.Context, id journal.FileID, runStart, runEnd int64, owed [][2]int64) error {
+	return preserveClobberedRow(ctx, s.committer, s.commitLocks, string(id), runStart, runEnd, owed)
+}
+
+func (s engineBlockSink) PreserveClobberedRow(ctx context.Context, id journal.FileID, runStart, runEnd int64, owed [][2]int64) error {
+	return preserveClobberedRow(ctx, s.committer, s.commitLocks, string(id), runStart, runEnd, owed)
+}
+
 // ReapSupersededManifest implements journal's optional pass-end reap: once a
 // carve pass's rows are all committed, delete the manifest rows they superseded so
 // the per-file manifest tiles [0,size) with no stale straddler or gap (#953). A nil

--- a/pkg/block/engine/blocksink.go
+++ b/pkg/block/engine/blocksink.go
@@ -131,12 +131,7 @@ func commitManifestRows(ctx context.Context, committer blockCommitter, locks *ca
 		defer mu.Unlock()
 	}
 	return committer.WithTransaction(ctx, func(tx metadata.Transaction) error {
-		for _, fc := range rows {
-			if err := tx.Put(ctx, fc); err != nil {
-				return fmt.Errorf("carve: put manifest row %s: %w", fc.ID, err)
-			}
-		}
-		return metadata.ProjectCommittedChunks(ctx, tx, payloadID, rows)
+		return metadata.CommitCarvedChunks(ctx, tx, payloadID, rows)
 	})
 }
 

--- a/pkg/block/engine/cold_read_clobbered_row_test.go
+++ b/pkg/block/engine/cold_read_clobbered_row_test.go
@@ -1,0 +1,164 @@
+package engine_test
+
+import (
+	"bytes"
+	"context"
+	"math/rand"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatabadger "github.com/marmos91/dittofs/pkg/metadata/store/badger"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// overwrite is one [from, to) range to rewrite, chosen from the manifest as it
+// stands when its turn comes so a test can aim at a row an earlier overwrite
+// produced.
+type overwrite func(refs []block.ChunkRef) (from, to uint64)
+
+// clobberFixture carves and syncs an 8 MiB file, then applies each overwrite in
+// turn — evicting before it so the write lands on cold bytes, carving after it,
+// and evicting again — and finally reads the whole file back cold and compares.
+//
+// Evicting before each overwrite is what makes the carve run stop where it does:
+// with the bytes past the write still warm, carve extends the run to the end of
+// the row it lands in, and neither the clobber nor the straddle arises.
+//
+// The read covers the whole file rather than the written range, so a stranded
+// stretch is caught wherever it ends up.
+func clobberFixture(t *testing.T, ms metadata.Store, share string, writes ...overwrite) {
+	t.Helper()
+	ctx := context.Background()
+	bs := newEngineWithRemote(t, ms, remotememory.New())
+	root := createShare(t, ms, share)
+	pid, _ := createRealFile(t, ms, share, share+".bin", root)
+
+	const fileSize = 8 * 1024 * 1024
+	seed := make([]byte, fileSize)
+	rand.New(rand.NewSource(0x2136)).Read(seed) //nolint:gosec // deterministic fixture
+	if _, err := bs.WriteAt(ctx, pid, nil, seed, 0); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	carve(t, bs, ctx, pid)
+
+	want := append([]byte{}, seed...)
+	rng := rand.New(rand.NewSource(0x2136BEEF)) //nolint:gosec // deterministic fixture
+	for n, write := range writes {
+		refs := manifestRefs(t, ms, pid)
+		if len(refs) < 4 {
+			t.Fatalf("overwrite %d: fixture needs at least 4 manifest rows, got %d", n, len(refs))
+		}
+		d0, d1 := write(refs)
+		if _, err := bs.DrainLocalSynced(ctx); err != nil {
+			t.Fatalf("overwrite %d: evict before write: %v", n, err)
+		}
+		ow := make([]byte, d1-d0)
+		rng.Read(ow)
+		copy(want[d0:d1], ow)
+		if _, err := bs.WriteAt(ctx, pid, nil, ow, d0); err != nil {
+			t.Fatalf("overwrite %d: write [%d, %d): %v", n, d0, d1, err)
+		}
+		carve(t, bs, ctx, pid)
+	}
+	if _, err := bs.DrainLocalSynced(ctx); err != nil {
+		t.Fatalf("evict before read: %v", err)
+	}
+
+	got := make([]byte, fileSize)
+	if _, err := bs.ReadAt(ctx, pid, got, 0); err != nil {
+		t.Fatalf("cold read: %v — a range the manifest no longer covers reads as "+
+			"an error rather than as bytes", err)
+	}
+	if bytes.Equal(got, want) {
+		return
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("cold read differs at offset %d: got %#x, want %#x (pre-overwrite byte was %#x)",
+				i, got[i], want[i], seed[i])
+		}
+	}
+}
+
+// atRowStart overwrites the first 8 KiB of the row at index i, so the fresh row
+// takes that row's key and stops far short of its end.
+func atRowStart(i int) overwrite {
+	return func(refs []block.ChunkRef) (uint64, uint64) {
+		return refs[i].Offset, refs[i].Offset + 8192
+	}
+}
+
+// runClobberedRowColdRead drives the defect. The overwrite starts EXACTLY on an
+// old row's offset, so the fresh row takes that row's key, and Put is an upsert
+// — the replaced row is gone before the run-end reap ever lists the manifest,
+// and everything between the fresh row's end and the replaced row's end has no
+// cover at all.
+func runClobberedRowColdRead(t *testing.T, ms metadata.Store) {
+	clobberFixture(t, ms, "clobber", atRowStart(1))
+}
+
+// runClobberedRemnantColdRead drives the same defect a second time at the same
+// place: the first overwrite leaves the replaced row's tail re-keyed to the
+// fresh row's end, and the second overwrite starts exactly THERE, so the row it
+// clobbers is itself a remnant. What survives has to read the original chunk
+// from further in still, which is what says the preserved in-chunk start
+// accumulates rather than being recomputed from the chunk's head.
+func runClobberedRemnantColdRead(t *testing.T, ms metadata.Store) {
+	clobberFixture(t, ms, "remnant",
+		atRowStart(1),
+		// The remnant sits at index 2 once the fresh row has taken index 1's key.
+		atRowStart(2),
+	)
+}
+
+// runLongRunColdRead is a control, and it passes with or without the fix: the
+// run starts on a row's offset but is long enough to tile past that row's end,
+// so nothing of it is left to strand. It is here because it also ends inside a
+// LATER row that starts inside the run, which the reap narrows off its head —
+// the two moves have to compose, and this is what says they do.
+func runLongRunColdRead(t *testing.T, ms metadata.Store) {
+	clobberFixture(t, ms, "longrun", func(refs []block.ChunkRef) (uint64, uint64) {
+		return refs[1].Offset, refs[3].Offset + 8192
+	})
+}
+
+// runInteriorStartColdRead is a control, and it passes with or without the fix:
+// the same overwrite shape but starting INSIDE a row rather than on its offset,
+// so no key is taken over and nothing is clobbered.
+func runInteriorStartColdRead(t *testing.T, ms metadata.Store) {
+	clobberFixture(t, ms, "interiorstart", func(refs []block.ChunkRef) (uint64, uint64) {
+		return refs[1].Offset + 4096, refs[3].Offset + 8192
+	})
+}
+
+func TestMemoryColdRead_ClobberedRow(t *testing.T) { runClobberedRowColdRead(t, memStore()) }
+func TestMemoryColdRead_ClobberedRemnant(t *testing.T) {
+	runClobberedRemnantColdRead(t, memStore())
+}
+func TestMemoryColdRead_LongRun(t *testing.T)       { runLongRunColdRead(t, memStore()) }
+func TestMemoryColdRead_InteriorStart(t *testing.T) { runInteriorStartColdRead(t, memStore()) }
+
+func TestBadgerColdRead_ClobberedRow(t *testing.T) { runClobberedRowColdRead(t, badgerStore(t)) }
+func TestBadgerColdRead_ClobberedRemnant(t *testing.T) {
+	runClobberedRemnantColdRead(t, badgerStore(t))
+}
+func TestBadgerColdRead_LongRun(t *testing.T) { runLongRunColdRead(t, badgerStore(t)) }
+func TestBadgerColdRead_InteriorStart(t *testing.T) {
+	runInteriorStartColdRead(t, badgerStore(t))
+}
+
+func memStore() metadata.Store { return metadatamemory.NewMemoryMetadataStoreWithDefaults() }
+
+func badgerStore(t *testing.T) metadata.Store {
+	t.Helper()
+	ms, err := metadatabadger.NewBadgerMetadataStoreWithDefaults(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("NewBadgerMetadataStoreWithDefaults: %v", err)
+	}
+	// Cleanup (not defer) so the engine's Close joins the syncer workers before
+	// the metadata store closes.
+	t.Cleanup(func() { _ = ms.Close() })
+	return ms
+}

--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -675,6 +675,14 @@ func (s *Store) extendRunToRowEnd(ctx context.Context, sh *shard, id FileID, run
 	if !ok {
 		return run, runEnd, nil
 	}
+	// The manifest lookup is a whole-manifest read, so it is gated on the cheap
+	// in-memory answer first. With nothing durable past the run's end there is
+	// neither anything to extend over nor anything a replaced row could still be
+	// owed — which is every append, the case that would otherwise pay this read
+	// once per run for the life of the file.
+	if !anySyncedFrom(sh, id, runEnd) {
+		return run, runEnd, nil
+	}
 	rowEnd, err := ender.ManifestRowEndAfter(ctx, id, runEnd)
 	if err != nil {
 		return nil, 0, err
@@ -710,6 +718,25 @@ func (s *Store) extendRunToRowEnd(ctx context.Context, sh *shard, id FileID, run
 // re-carved and is served from the local tier until it is. Neither is owed a
 // manifest row, and covering either one with a row that used to span it puts
 // back bytes the file no longer has.
+// anySyncedFrom reports whether any range at or after off is durable on the
+// remote. It is the cheap gate on the whole straddle question: a run with
+// nothing synced past its end can neither be extended nor leave a replaced row
+// owed anything.
+func anySyncedFrom(sh *shard, id FileID, off int64) bool {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	fi := sh.index[id]
+	if fi == nil {
+		return false
+	}
+	for k := range fi.ivs {
+		if fi.ivs[k].synced && fi.ivs[k].end() > off {
+			return true
+		}
+	}
+	return false
+}
+
 func syncedRanges(sh *shard, id FileID, from, to int64) [][2]int64 {
 	if from >= to {
 		return nil

--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"maps"
 	"math"
+	"sort"
 	"sync"
 
 	"lukechampine.com/blake3"
@@ -131,6 +132,33 @@ type supersededReaper interface {
 // against it than against a metadata store.
 type manifestRowEnder interface {
 	ManifestRowEndAfter(ctx context.Context, id FileID, off int64) (int64, error)
+}
+
+// clobberGuard is an optional BlockSink capability, and it exists because a
+// manifest row is keyed by the file offset of its first claimed byte while the
+// commit that writes a row is an upsert. A run starting exactly on an existing
+// row's offset therefore REPLACES that row rather than superseding it: the row
+// is gone before the run-end reap ever lists the manifest, and everything it
+// claimed past the run's end is left with no cover at all.
+//
+// Journal calls PreserveClobberedRow once per run, before the run is packed and
+// so while the row still exists, naming the run's final bounds and the ranges
+// past its end that are still OWED. The sink re-keys whatever the row about to
+// be replaced still owns, restricted to those ranges.
+//
+// owed is what makes this safe, and it is the reason the question is asked here
+// rather than at commit time: the manifest alone cannot tell a range that lost
+// its cover from a range that is SUPPOSED to have none. A punched hole must read
+// as zeros, and re-covering it with the replaced row's pre-punch content is its
+// own corruption — one that a straightforward "keep whatever was there" does
+// commit. Journal answers from the interval index, which distinguishes them:
+// owed carries only ranges durable on the remote (evicted or resident), and
+// excludes both holes and ranges still dirty for a later pass.
+//
+// Sinks without a metadata store (test fakes) don't implement it, and a run then
+// replaces a row exactly as it did before.
+type clobberGuard interface {
+	PreserveClobberedRow(ctx context.Context, id FileID, runStart, runEnd int64, owed [][2]int64) error
 }
 
 // errCarveNotWired is returned by Carve when the dedup/sink collaborators have
@@ -457,12 +485,27 @@ func (s *Store) packRuns(ctx context.Context, sh *shard, id FileID, rs []*runSta
 		if ri+1 < len(rs) {
 			limit = rs[ri+1].start()
 		}
-		ivs, err := s.extendRunToRowEnd(ctx, sh, id, rs[ri].ivs, limit)
+		ivs, rowEnd, err := s.extendRunToRowEnd(ctx, sh, id, rs[ri].ivs, limit)
 		if err != nil {
 			packErr = err
 			break
 		}
 		rs[ri].ivs = ivs
+
+		// The run's first fresh chunk lands on the run's start offset, so if a
+		// manifest row is keyed there it is about to be replaced. Ask the sink to
+		// keep what that row still owns past where this run will stop — but only
+		// over ranges the interval index says are still owed, since the row may
+		// equally be spanning a hole it has no business re-covering.
+		if guard, ok := s.sink.(clobberGuard); ok {
+			runEnd := rs[ri].end()
+			if owed := syncedRanges(sh, id, runEnd, rowEnd); len(owed) > 0 {
+				if err := guard.PreserveClobberedRow(ctx, id, rs[ri].start(), runEnd, owed); err != nil {
+					packErr = err
+					break
+				}
+			}
+		}
 
 		// A fresh chunker and reader per run, and an empty accumulator, so a chunk
 		// never spans the hole between two runs. The block being packed carries
@@ -622,36 +665,82 @@ func (s *Store) packRuns(ctx context.Context, sh *shard, id FileID, rs []*runSta
 // ponytail: a row reaching past a later dirty run is left alone, so that run
 // still ends mid-row; covering it means merging the two runs, which is worth
 // building only if that shape shows up in practice.
-func (s *Store) extendRunToRowEnd(ctx context.Context, sh *shard, id FileID, run []interval, limit int64) ([]interval, error) {
+// It also reports how far the manifest coverage straddling the run's end
+// reaches, so a caller that has to act on the rows the run stops inside does not
+// pay the straddle lookup a second time. That answer is the run's own end
+// whenever the lookup was not needed or the extension consumed the row.
+func (s *Store) extendRunToRowEnd(ctx context.Context, sh *shard, id FileID, run []interval, limit int64) ([]interval, int64, error) {
+	runEnd := run[len(run)-1].end()
 	ender, ok := s.sink.(manifestRowEnder)
 	if !ok {
-		return run, nil
-	}
-	runEnd := run[len(run)-1].end()
-	if !warmAt(sh, id, runEnd) {
-		return run, nil // nothing warm past the run: no extension is possible
+		return run, runEnd, nil
 	}
 	rowEnd, err := ender.ManifestRowEndAfter(ctx, id, runEnd)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
+	}
+	if rowEnd <= runEnd {
+		return run, runEnd, nil
+	}
+	if !warmAt(sh, id, runEnd) {
+		return run, rowEnd, nil // nothing warm past the run: no extension is possible
 	}
 	if rowEnd > limit {
 		// See the doc comment above: redundant while the packer is sequential
 		// and forward, kept for any ordering that carves runs concurrently.
-		return run, nil
-	}
-	if rowEnd <= runEnd {
-		return run, nil
+		return run, rowEnd, nil
 	}
 	tail := warmTail(sh, id, runEnd, rowEnd)
 	if len(tail) == 0 {
-		return run, nil
+		return run, rowEnd, nil
 	}
 	// A fresh slice: run aliases the carve snapshot, whose next entries belong to
 	// the following run.
 	out := make([]interval, 0, len(run)+len(tail))
 	out = append(out, run...)
-	return append(out, tail...), nil
+	return append(out, tail...), rowEnd, nil
+}
+
+// syncedRanges returns the sub-ranges of [from, to) that hold data durable on
+// the remote store — resident or evicted — merged and ascending.
+//
+// It is the discriminator the manifest cannot supply. A range with no interval
+// is a hole: nothing was ever written there, or a punch took it away, and it
+// must read as zeros. A range whose interval is still dirty is about to be
+// re-carved and is served from the local tier until it is. Neither is owed a
+// manifest row, and covering either one with a row that used to span it puts
+// back bytes the file no longer has.
+func syncedRanges(sh *shard, id FileID, from, to int64) [][2]int64 {
+	if from >= to {
+		return nil
+	}
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	fi := sh.index[id]
+	if fi == nil {
+		return nil
+	}
+	spans := make([][2]int64, 0, 4)
+	for k := range fi.ivs {
+		iv := fi.ivs[k]
+		if !iv.synced || iv.end() <= from || iv.fileOff >= to {
+			continue
+		}
+		spans = append(spans, [2]int64{max(iv.fileOff, from), min(iv.end(), to)})
+	}
+	sort.Slice(spans, func(i, j int) bool { return spans[i][0] < spans[j][0] })
+	out := spans[:0]
+	for _, sp := range spans {
+		if n := len(out); n > 0 && sp[0] <= out[n-1][1] {
+			out[n-1][1] = max(out[n-1][1], sp[1])
+			continue
+		}
+		out = append(out, sp)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // warmAt reports whether a warm live interval (durable locally, not evicted, not

--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"maps"
 	"math"
+	"sort"
 	"sync"
 
 	"lukechampine.com/blake3"
@@ -720,8 +721,14 @@ func anySyncedFrom(sh *shard, id FileID, off int64) bool {
 	if fi == nil {
 		return false
 	}
-	for k := range fi.ivs {
-		if fi.ivs[k].synced && fi.ivs[k].end() > off {
+	// Live intervals are held in ascending file order, so everything that could
+	// end past off starts at the first one that does — the same seek findRecord
+	// and hydratable take. Skipping the prefix below off is what keeps this off
+	// the append path's critical section, where off is EOF and the seek lands
+	// past the last interval.
+	k := sort.Search(len(fi.ivs), func(i int) bool { return fi.ivs[i].end() > off })
+	for ; k < len(fi.ivs); k++ {
+		if fi.ivs[k].synced {
 			return true
 		}
 	}

--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"maps"
 	"math"
-	"sort"
 	"sync"
 
 	"lukechampine.com/blake3"
@@ -639,6 +638,11 @@ func (s *Store) packRuns(ctx context.Context, sh *shard, id FileID, rs []*runSta
 // to re-tile the range they share with a superseded row, which is the same price
 // a partial overwrite of a warm interval already pays.
 //
+// It also reports how far the manifest coverage straddling the run's end
+// reaches, so a caller that has to act on the rows the run stops inside does not
+// pay the straddle lookup a second time. That answer is the run's own end
+// whenever the lookup was not needed or the extension consumed the row.
+//
 // The extension is skipped whole unless every byte of it is live, contiguous and
 // warm. An evicted range holds no local bytes to re-chunk, and half an extension
 // still ends inside the row.
@@ -665,10 +669,6 @@ func (s *Store) packRuns(ctx context.Context, sh *shard, id FileID, rs []*runSta
 // ponytail: a row reaching past a later dirty run is left alone, so that run
 // still ends mid-row; covering it means merging the two runs, which is worth
 // building only if that shape shows up in practice.
-// It also reports how far the manifest coverage straddling the run's end
-// reaches, so a caller that has to act on the rows the run stops inside does not
-// pay the straddle lookup a second time. That answer is the run's own end
-// whenever the lookup was not needed or the extension consumed the row.
 func (s *Store) extendRunToRowEnd(ctx context.Context, sh *shard, id FileID, run []interval, limit int64) ([]interval, int64, error) {
 	runEnd := run[len(run)-1].end()
 	ender, ok := s.sink.(manifestRowEnder)
@@ -709,15 +709,6 @@ func (s *Store) extendRunToRowEnd(ctx context.Context, sh *shard, id FileID, run
 	return append(out, tail...), rowEnd, nil
 }
 
-// syncedRanges returns the sub-ranges of [from, to) that hold data durable on
-// the remote store — resident or evicted — merged and ascending.
-//
-// It is the discriminator the manifest cannot supply. A range with no interval
-// is a hole: nothing was ever written there, or a punch took it away, and it
-// must read as zeros. A range whose interval is still dirty is about to be
-// re-carved and is served from the local tier until it is. Neither is owed a
-// manifest row, and covering either one with a row that used to span it puts
-// back bytes the file no longer has.
 // anySyncedFrom reports whether any range at or after off is durable on the
 // remote. It is the cheap gate on the whole straddle question: a run with
 // nothing synced past its end can neither be extended nor leave a replaced row
@@ -737,6 +728,17 @@ func anySyncedFrom(sh *shard, id FileID, off int64) bool {
 	return false
 }
 
+// syncedRanges returns the sub-ranges of [from, to) that hold data durable on
+// the remote store — resident or evicted — coalesced and ascending. Live
+// intervals are held in ascending file order, so one forward walk emits them
+// already ordered and only touching pieces need joining.
+//
+// It is the discriminator the manifest cannot supply. A range with no interval
+// is a hole: nothing was ever written there, or a punch took it away, and it
+// must read as zeros. A range whose interval is still dirty is about to be
+// re-carved and is served from the local tier until it is. Neither is owed a
+// manifest row, and covering either one with a row that used to span it puts
+// back bytes the file no longer has.
 func syncedRanges(sh *shard, id FileID, from, to int64) [][2]int64 {
 	if from >= to {
 		return nil
@@ -747,25 +749,18 @@ func syncedRanges(sh *shard, id FileID, from, to int64) [][2]int64 {
 	if fi == nil {
 		return nil
 	}
-	spans := make([][2]int64, 0, 4)
+	var out [][2]int64
 	for k := range fi.ivs {
 		iv := fi.ivs[k]
 		if !iv.synced || iv.end() <= from || iv.fileOff >= to {
 			continue
 		}
-		spans = append(spans, [2]int64{max(iv.fileOff, from), min(iv.end(), to)})
-	}
-	sort.Slice(spans, func(i, j int) bool { return spans[i][0] < spans[j][0] })
-	out := spans[:0]
-	for _, sp := range spans {
-		if n := len(out); n > 0 && sp[0] <= out[n-1][1] {
-			out[n-1][1] = max(out[n-1][1], sp[1])
+		lo, hi := max(iv.fileOff, from), min(iv.end(), to)
+		if n := len(out); n > 0 && lo <= out[n-1][1] {
+			out[n-1][1] = max(out[n-1][1], hi)
 			continue
 		}
-		out = append(out, sp)
-	}
-	if len(out) == 0 {
-		return nil
+		out = append(out, [2]int64{lo, hi})
 	}
 	return out
 }

--- a/pkg/metadata/block_record_store.go
+++ b/pkg/metadata/block_record_store.go
@@ -337,11 +337,8 @@ func PreserveClobberedRow(ctx context.Context, tx Transaction, payloadID string,
 	if err != nil || old == nil {
 		return err
 	}
-	rowStart, ok := block.ParseChunkOffset(old.ID)
-	if !ok {
-		return nil
-	}
-	rowEnd := int64(rowStart) + int64(old.DataSize)
+	// The row was read by the key runStart builds, so runStart is its start.
+	rowEnd := runStart + int64(old.DataSize)
 	if rowEnd <= runEnd {
 		return nil // the run re-covers everything this row claimed
 	}
@@ -351,7 +348,7 @@ func PreserveClobberedRow(ctx context.Context, tx Transaction, payloadID string,
 		if lo >= hi {
 			continue
 		}
-		piece, ok := narrowOffHead(old, int64(rowStart), lo, hi)
+		piece, ok := narrowOffHead(old, runStart, lo, hi)
 		if !ok {
 			continue // the claim will not fit the row's fields: leave it behind
 		}

--- a/pkg/metadata/block_record_store.go
+++ b/pkg/metadata/block_record_store.go
@@ -289,100 +289,102 @@ func DefaultCommitBlock(
 }
 
 // CommitCarvedChunks writes a carve batch's fresh manifest rows and projects
-// them into File.Blocks, in the caller's txn, preserving whatever an incoming
-// row's key takes over.
+// them into File.Blocks, in the caller's txn.
 //
-// A row is keyed by the file offset of its first claimed byte, and Put is an
-// upsert, so a run that starts exactly on an existing row's offset REPLACES that
-// row rather than superseding it. Where the run's fresh rows stop short of how
-// far the replaced row reached, the stretch beyond loses its only cover: the row
-// that held it no longer exists, and the run-end reap lists a manifest that no
-// longer mentions it, so nothing downstream can put it back. clobberedTail
-// re-keys what the replaced row still owns to the first byte the fresh row does
-// not cover, reading the same chunk from that much further in.
-//
-// Rows are written in the order given, and a preserved tail is written before
-// the row that displaced it, so a later row of the same batch landing on the
-// tail's key sees the tail and preserves what is left of it in turn. A run of
-// any length therefore walks its remnant forward to the run's end, where the
-// reap treats it as a row starting outside the span and leaves it alone.
-//
-// A batch that names no payload (legacy callers passing no rows) writes nothing
-// to project onto and returns early, exactly as the projection alone did.
+// A row is keyed by the file offset of its first claimed byte and Put is an
+// upsert, so a fresh row landing on an offset an existing row already occupies
+// replaces it. Whatever that row still owned past the fresh one is kept by
+// PreserveClobberedRow, which runs before the batch and while the row is still
+// there; by the time a batch reaches here the replacement is the intended
+// outcome.
 func CommitCarvedChunks(ctx context.Context, tx Transaction, payloadID string, rows []*block.FileChunk) error {
-	var preserved []*block.FileChunk
 	for _, fc := range rows {
 		if fc == nil {
 			continue
-		}
-		tail, err := clobberedTail(ctx, tx, fc)
-		if err != nil {
-			return err
-		}
-		if tail != nil {
-			if err := tx.Put(ctx, tail); err != nil {
-				return fmt.Errorf("commit carved chunks: preserve %s: %w", tail.ID, err)
-			}
-			preserved = append(preserved, tail)
 		}
 		if err := tx.Put(ctx, fc); err != nil {
 			return fmt.Errorf("commit carved chunks: put %s: %w", fc.ID, err)
 		}
 	}
-	if len(preserved) == 0 {
-		return ProjectCommittedChunks(ctx, tx, payloadID, rows)
-	}
-	// A preserved tail is a manifest row like any other, so the projection has to
-	// carry it or File.Blocks stops describing the manifest. The full-slice bound
-	// keeps the append off the caller's backing array.
-	return ProjectCommittedChunks(ctx, tx, payloadID, append(rows[:len(rows):len(rows)], preserved...))
+	return ProjectCommittedChunks(ctx, tx, payloadID, rows)
 }
 
-// clobberedTail returns the row that must be written to keep covering what the
-// row at fresh's key still owns past fresh's own end, or nil when nothing does.
+// PreserveClobberedRow keeps what the manifest row keyed at runStart still owns
+// past runEnd, before a carve run's first fresh chunk takes that key over. It is
+// a no-op when no row sits at runStart, or when the row there does not reach
+// past runEnd — the ordinary carve, where a run appends or re-covers at least as
+// much as it replaces.
 //
-// nil covers every ordinary carve: an append writes a key no row holds, and a
-// re-carve that reaches at least as far as the row it replaces leaves nothing
-// behind. The row is read rather than derived from the File.Blocks projection
-// because what survives keeps the original's hash, state, refcount and
-// timestamps, and a projection carries none of those.
+// owed names the ranges past runEnd that are still backed by the remote, and the
+// preserved claim is confined to them. That confinement is the whole point: the
+// replaced row may equally have been spanning a punched hole, whose bytes must
+// read as zeros, and putting its pre-punch content back over that hole is its
+// own silent corruption. The manifest cannot tell the two apart, which is why
+// owed is computed from the journal's interval index and passed in.
 //
-// When another row already sits at the tail's key, it is left alone if it
-// already reaches at least as far — the tail would add no coverage and would
-// cost that row its own. Otherwise the tail is written over it, which never
-// covers less than leaving it. Both need two existing rows overlapping at
-// exactly this offset, so which content the overlap should serve is a question
-// the manifest could not answer before this either.
-func clobberedTail(ctx context.Context, tx Transaction, fresh *block.FileChunk) (*block.FileChunk, error) {
-	off, ok := block.ParseChunkOffset(fresh.ID)
-	if !ok {
-		return nil, nil // an unplaceable key takes over no range
+// One row is written per owed range, each reading the original chunk from
+// however far into it that range begins, so a claim broken up by holes comes
+// back as the pieces that survive rather than as one span across them.
+//
+// A range whose key another row already occupies is left to that row when it
+// reaches at least as far, since the preserved piece would add no coverage and
+// cost that row its own.
+func PreserveClobberedRow(ctx context.Context, tx Transaction, payloadID string, runStart, runEnd int64, owed [][2]int64) error {
+	if payloadID == "" || len(owed) == 0 {
+		return nil
 	}
-	old, err := tx.GetFileChunk(ctx, fresh.ID)
+	old, err := readChunkRow(ctx, tx, fmt.Sprintf("%s/%d", payloadID, runStart))
+	if err != nil || old == nil {
+		return err
+	}
+	rowStart, ok := block.ParseChunkOffset(old.ID)
+	if !ok {
+		return nil
+	}
+	rowEnd := int64(rowStart) + int64(old.DataSize)
+	if rowEnd <= runEnd {
+		return nil // the run re-covers everything this row claimed
+	}
+	var written []*block.FileChunk
+	for _, sp := range owed {
+		lo, hi := max(sp[0], runEnd), min(sp[1], rowEnd)
+		if lo >= hi {
+			continue
+		}
+		piece, ok := narrowOffHead(old, int64(rowStart), lo, hi)
+		if !ok {
+			continue // the claim will not fit the row's fields: leave it behind
+		}
+		occupant, err := readChunkRow(ctx, tx, piece.ID)
+		if err != nil {
+			return err
+		}
+		if occupant != nil && lo+int64(occupant.DataSize) >= hi {
+			continue
+		}
+		if err := tx.Put(ctx, piece); err != nil {
+			return fmt.Errorf("preserve clobbered row %s: put %s: %w", old.ID, piece.ID, err)
+		}
+		written = append(written, piece)
+	}
+	if len(written) == 0 {
+		return nil
+	}
+	return ProjectCommittedChunks(ctx, tx, payloadID, written)
+}
+
+// readChunkRow returns the row stored under id, or (nil, nil) when there is
+// none. Absence is the common answer on this path — a run usually starts where
+// no row does — so it is not an error.
+func readChunkRow(ctx context.Context, tx Transaction, id string) (*block.FileChunk, error) {
+	row, err := tx.GetFileChunk(ctx, id)
 	if err != nil {
 		if errors.Is(err, block.ErrFileChunkNotFound) || IsNotFoundError(err) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("commit carved chunks: read %s: %w", fresh.ID, err)
+		return nil, fmt.Errorf("read manifest row %s: %w", id, err)
 	}
-	if old == nil || old.DataSize <= fresh.DataSize {
-		return nil, nil
-	}
-	rowStart := int64(off)
-	rowEnd := rowStart + int64(old.DataSize)
-	head := rowStart + int64(fresh.DataSize)
-	tail, ok := narrowOffHead(old, rowStart, head, rowEnd)
-	if !ok {
-		return nil, nil // the claim will not fit the row's fields: leave it as it stands
-	}
-	occupant, err := tx.GetFileChunk(ctx, tail.ID)
-	switch {
-	case err != nil && !errors.Is(err, block.ErrFileChunkNotFound) && !IsNotFoundError(err):
-		return nil, fmt.Errorf("commit carved chunks: read %s: %w", tail.ID, err)
-	case err == nil && occupant != nil && head+int64(occupant.DataSize) >= rowEnd:
-		return nil, nil // already covered at least as far as the tail would reach
-	}
-	return tail, nil
+	return row, nil
 }
 
 // ManifestRowEndAfter reports how far the manifest coverage straddling off

--- a/pkg/metadata/block_record_store.go
+++ b/pkg/metadata/block_record_store.go
@@ -333,7 +333,7 @@ func PreserveClobberedRow(ctx context.Context, tx Transaction, payloadID string,
 	if payloadID == "" || len(owed) == 0 {
 		return nil
 	}
-	old, err := readChunkRow(ctx, tx, fmt.Sprintf("%s/%d", payloadID, runStart))
+	old, err := readChunkRow(ctx, tx, chunkRowKey(payloadID, runStart))
 	if err != nil || old == nil {
 		return err
 	}
@@ -348,16 +348,34 @@ func PreserveClobberedRow(ctx context.Context, tx Transaction, payloadID string,
 		if lo >= hi {
 			continue
 		}
-		piece, ok := narrowOffHead(old, runStart, lo, hi)
-		if !ok {
-			continue // the claim will not fit the row's fields: leave it behind
-		}
-		occupant, err := readChunkRow(ctx, tx, piece.ID)
+		// A row already keyed at lo keeps what it claims: it starts where this
+		// piece would, so coverage cannot choose between them, and overwriting it
+		// would swap the bytes a read there already resolves for this row's — a
+		// silent content change with nothing to justify it. Take over only what it
+		// leaves uncovered.
+		occupant, err := readChunkRow(ctx, tx, chunkRowKey(payloadID, lo))
 		if err != nil {
 			return err
 		}
-		if occupant != nil && lo+int64(occupant.DataSize) >= hi {
-			continue
+		if occupant != nil {
+			lo += int64(occupant.DataSize)
+			if lo >= hi {
+				continue
+			}
+			// ponytail: one step past the occupant, so a second row keyed exactly
+			// where the first ends leaves the rest of this range uncovered; walk the
+			// chain if a manifest is ever seen stacking rows that way.
+			next, err := readChunkRow(ctx, tx, chunkRowKey(payloadID, lo))
+			if err != nil {
+				return err
+			}
+			if next != nil {
+				continue
+			}
+		}
+		piece, ok := narrowOffHead(old, runStart, lo, hi)
+		if !ok {
+			continue // the claim will not fit the row's fields: leave it behind
 		}
 		if err := tx.Put(ctx, piece); err != nil {
 			return fmt.Errorf("preserve clobbered row %s: put %s: %w", old.ID, piece.ID, err)
@@ -368,6 +386,12 @@ func PreserveClobberedRow(ctx context.Context, tx Transaction, payloadID string,
 		return nil
 	}
 	return ProjectCommittedChunks(ctx, tx, payloadID, written)
+}
+
+// chunkRowKey renders the manifest key a chunk starting at off within payloadID
+// lives under.
+func chunkRowKey(payloadID string, off int64) string {
+	return fmt.Sprintf("%s/%d", payloadID, off)
 }
 
 // readChunkRow returns the row stored under id, or (nil, nil) when there is

--- a/pkg/metadata/block_record_store.go
+++ b/pkg/metadata/block_record_store.go
@@ -269,17 +269,6 @@ func DefaultCommitBlock(
 		if err := tx.PutBlockRecord(ctx, rec); err != nil {
 			return err
 		}
-		// Per-file manifest rows: the block carver passes one FileChunk per chunk
-		// (ID={FileID}/{FileOffset}, Hash, DataSize, State=Pending); legacy callers
-		// pass nil and write no rows.
-		for _, fc := range fileChunks {
-			if fc == nil {
-				continue
-			}
-			if err := tx.Put(ctx, fc); err != nil {
-				return err
-			}
-		}
 		// Locator overwrite (last-wins), see the function comment. MarkSynced
 		// alone would be first-wins and leave a stale standalone locator in
 		// place; the batched write applies the overwrite for the whole commit
@@ -289,14 +278,111 @@ func DefaultCommitBlock(
 				return err
 			}
 		}
-		// Materialize File.Blocks from the manifest in this same txn so raw-row
-		// readers (snapshot, audit) stay coherent — merging only this batch's
-		// rows, since re-deriving from the whole manifest costs a full list and
-		// sort per committed block object. Skipped for legacy callers that pass
-		// no fileChunks (empty payloadID). Superseded-row reaping happens once
-		// per carve pass (ReapSupersededManifest), not per batch — see below.
-		return ProjectCommittedChunks(ctx, tx, payloadIDFromChunks(fileChunks), fileChunks)
+		// Per-file manifest rows: the block carver passes one FileChunk per chunk
+		// (ID={FileID}/{FileOffset}, Hash, DataSize, State=Pending); legacy callers
+		// pass nil and write no rows. CommitCarvedChunks also re-materializes
+		// File.Blocks in this same txn so raw-row readers (snapshot, audit) stay
+		// coherent. Superseded-row reaping happens once per carve pass
+		// (ReapSupersededManifest), not per batch — see below.
+		return CommitCarvedChunks(ctx, tx, payloadIDFromChunks(fileChunks), fileChunks)
 	})
+}
+
+// CommitCarvedChunks writes a carve batch's fresh manifest rows and projects
+// them into File.Blocks, in the caller's txn, preserving whatever an incoming
+// row's key takes over.
+//
+// A row is keyed by the file offset of its first claimed byte, and Put is an
+// upsert, so a run that starts exactly on an existing row's offset REPLACES that
+// row rather than superseding it. Where the run's fresh rows stop short of how
+// far the replaced row reached, the stretch beyond loses its only cover: the row
+// that held it no longer exists, and the run-end reap lists a manifest that no
+// longer mentions it, so nothing downstream can put it back. clobberedTail
+// re-keys what the replaced row still owns to the first byte the fresh row does
+// not cover, reading the same chunk from that much further in.
+//
+// Rows are written in the order given, and a preserved tail is written before
+// the row that displaced it, so a later row of the same batch landing on the
+// tail's key sees the tail and preserves what is left of it in turn. A run of
+// any length therefore walks its remnant forward to the run's end, where the
+// reap treats it as a row starting outside the span and leaves it alone.
+//
+// A batch that names no payload (legacy callers passing no rows) writes nothing
+// to project onto and returns early, exactly as the projection alone did.
+func CommitCarvedChunks(ctx context.Context, tx Transaction, payloadID string, rows []*block.FileChunk) error {
+	var preserved []*block.FileChunk
+	for _, fc := range rows {
+		if fc == nil {
+			continue
+		}
+		tail, err := clobberedTail(ctx, tx, fc)
+		if err != nil {
+			return err
+		}
+		if tail != nil {
+			if err := tx.Put(ctx, tail); err != nil {
+				return fmt.Errorf("commit carved chunks: preserve %s: %w", tail.ID, err)
+			}
+			preserved = append(preserved, tail)
+		}
+		if err := tx.Put(ctx, fc); err != nil {
+			return fmt.Errorf("commit carved chunks: put %s: %w", fc.ID, err)
+		}
+	}
+	if len(preserved) == 0 {
+		return ProjectCommittedChunks(ctx, tx, payloadID, rows)
+	}
+	// A preserved tail is a manifest row like any other, so the projection has to
+	// carry it or File.Blocks stops describing the manifest. The full-slice bound
+	// keeps the append off the caller's backing array.
+	return ProjectCommittedChunks(ctx, tx, payloadID, append(rows[:len(rows):len(rows)], preserved...))
+}
+
+// clobberedTail returns the row that must be written to keep covering what the
+// row at fresh's key still owns past fresh's own end, or nil when nothing does.
+//
+// nil covers every ordinary carve: an append writes a key no row holds, and a
+// re-carve that reaches at least as far as the row it replaces leaves nothing
+// behind. The row is read rather than derived from the File.Blocks projection
+// because what survives keeps the original's hash, state, refcount and
+// timestamps, and a projection carries none of those.
+//
+// When another row already sits at the tail's key, it is left alone if it
+// already reaches at least as far — the tail would add no coverage and would
+// cost that row its own. Otherwise the tail is written over it, which never
+// covers less than leaving it. Both need two existing rows overlapping at
+// exactly this offset, so which content the overlap should serve is a question
+// the manifest could not answer before this either.
+func clobberedTail(ctx context.Context, tx Transaction, fresh *block.FileChunk) (*block.FileChunk, error) {
+	off, ok := block.ParseChunkOffset(fresh.ID)
+	if !ok {
+		return nil, nil // an unplaceable key takes over no range
+	}
+	old, err := tx.GetFileChunk(ctx, fresh.ID)
+	if err != nil {
+		if errors.Is(err, block.ErrFileChunkNotFound) || IsNotFoundError(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("commit carved chunks: read %s: %w", fresh.ID, err)
+	}
+	if old == nil || old.DataSize <= fresh.DataSize {
+		return nil, nil
+	}
+	rowStart := int64(off)
+	rowEnd := rowStart + int64(old.DataSize)
+	head := rowStart + int64(fresh.DataSize)
+	tail, ok := narrowOffHead(old, rowStart, head, rowEnd)
+	if !ok {
+		return nil, nil // the claim will not fit the row's fields: leave it as it stands
+	}
+	occupant, err := tx.GetFileChunk(ctx, tail.ID)
+	switch {
+	case err != nil && !errors.Is(err, block.ErrFileChunkNotFound) && !IsNotFoundError(err):
+		return nil, fmt.Errorf("commit carved chunks: read %s: %w", tail.ID, err)
+	case err == nil && occupant != nil && head+int64(occupant.DataSize) >= rowEnd:
+		return nil, nil // already covered at least as far as the tail would reach
+	}
+	return tail, nil
 }
 
 // ManifestRowEndAfter reports how far the manifest coverage straddling off

--- a/pkg/metadata/manifest_projection_test.go
+++ b/pkg/metadata/manifest_projection_test.go
@@ -60,6 +60,17 @@ func (t *manifestTx) Delete(_ context.Context, id string) error {
 	return nil
 }
 
+// GetFileChunk hands back a copy, as the real backends do, so a caller that
+// narrows what it reads cannot mutate the stored row in place.
+func (t *manifestTx) GetFileChunk(_ context.Context, id string) (*block.FileChunk, error) {
+	r, ok := t.rows[id]
+	if !ok {
+		return nil, block.ErrFileChunkNotFound
+	}
+	cp := *r
+	return &cp, nil
+}
+
 func (t *manifestTx) ListFileChunks(_ context.Context, payloadID string) ([]*block.FileChunk, error) {
 	t.lists++
 	ids := make([]string, 0, len(t.rows))

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -288,6 +288,14 @@ type Transaction interface {
 	// backend transactions already implement it.
 	ListFileChunks(ctx context.Context, payloadID string) ([]*block.FileChunk, error)
 
+	// GetFileChunk returns the FileChunk row stored under id, read-your-writes
+	// within the tx, or ErrFileChunkNotFound when there is none. Needed so a
+	// carve commit can see what a fresh row's key is about to take over before
+	// the upsert removes it — the whole row, not a projection of it, because what
+	// survives the takeover keeps the original's hash, state and refcount. All
+	// four backend transactions already implement it.
+	GetFileChunk(ctx context.Context, id string) (*block.FileChunk, error)
+
 	// PutSyncedLocators records the synced marker and remote locator of every
 	// chunk, overwriting whatever marker each hash already carries. It is the
 	// batched form of DeleteSynced-then-MarkSynced per chunk and produces the


### PR DESCRIPTION
Closes #2136

## What was wrong

A manifest row is keyed by the file offset of its first claimed byte — the ID is
`"<payloadID>/<fileOffset>"` — and the commit that writes a row is an upsert. So a carve run
starting **exactly** on an existing row's offset REPLACES that row rather than superseding it.
Where the run's fresh rows stop short of how far the replaced row reached, the stretch beyond
loses its only cover: the row that held it no longer exists, and the run-end reap lists a
manifest that no longer mentions it, so nothing downstream can put it back.

```
gen1 row off=1083464 size=1091680 end=2175144
gen2 row off=1083464 size=8192   end=1091656     <- replaced the row above
gen2 row off=2175144 size=1060701 end=3235845    <- next row starts here
```

`[1091656, 2175144)` — 1,083,488 bytes — has no row at all. The cold read fails closed with
`chunk not found`.

## The obvious fix is wrong, and this is the substance of the change

Preserving the replaced row's tail at commit time closes the defect and **fails
`TestManifestSoak_NoLegitimatePathOverlaps`** on seeds 0 and 21. That attempt is on this
branch as `90802e3d5`, replaced by `bc477a75c`; it is kept in history rather than hidden
because the reason it fails is the reason the shipped design looks the way it does.

Instrumented rather than guessed at — seed 21:

```
PRESERVE old=soak21/…/0 [0,11805543) fresh=9897158 tail=…/9897158 start=9897158 size=1908385
manifest OVERLAP — row at 9897158 extends to 11805543, next row starts at 10984315
iter-11 write(off=9896742,len=1174092): cold read mismatch at byte 9897158
```

The range that tail re-covered had been **punched** two iterations earlier —
`punch(off=3946694,len=7852701)`. Those bytes must read as zeros. Preserving resurrected
pre-punch content.

> **A manifest gap is ambiguous.** It is either a punched hole (correct, must read zeros) or a
> stranded range (this defect). Once the row is destroyed nothing distinguishes them — so the
> clobber's destruction is *load-bearing* in the punch case.

The commit path cannot tell them apart, because punches and pending rewrites are recorded in
the journal's interval index, not in the manifest.

## The design

The journal answers the question, because it owns the index that can.

- **`syncedRanges(sh, id, from, to)`** (`pkg/block/journal/carve.go`) returns the sub-ranges
  backed by the remote — resident or evicted — merged and ascending. A range with no interval
  is a hole and is excluded. A range whose interval is still dirty is about to be re-carved and
  is served locally until it is, so it is excluded too.
- **`clobberGuard`**, a new optional `BlockSink` capability, is called once per run **before the
  run is packed** — while the row it is about to replace still exists — naming the run's final
  bounds and the owed ranges past its end.
- **`metadata.PreserveClobberedRow`** re-keys what that row still owns, confined to those
  ranges, writing one row per owed range via `narrowOffHead` so each piece reads the original
  chunk from however far into it that range begins. A claim broken up by holes comes back as
  the pieces that survive rather than as one span across them — representable because #2137
  gave a row an in-chunk start offset.

`extendRunToRowEnd` now also returns the straddling row's end, so the caller that has to act on
it does not pay the straddle lookup twice.

## Evidence

`pkg/block/engine/cold_read_clobbered_row_test.go` — four real-engine tests (real carve, memory
object store, real eviction) on **both** the memory and badger metadata backends, with a
before/after split verified against unmodified `develop`:

| test | on `develop` | with the fix |
| --- | --- | --- |
| `ClobberedRow` — overwrite starting exactly on a row's offset | **fail** | pass |
| `ClobberedRemnant` — the same defect applied twice at the same place, so the row clobbered the second time is itself a remnant and the in-chunk start has to accumulate | **fail** | pass |
| `LongRun` — control: starts on a row's offset but tiles past its end | pass | pass |
| `InteriorStart` — control: same shape, starting *inside* a row | pass | pass |

`LongRun` was written as a third defect case and passes on `develop`, so it is labelled a
control rather than left to read as evidence. It earns its place by exercising the clobber
composing with #2137's head-narrow.

The guard fires exactly once for `ClobberedRow`, and on the range that was being stranded:

```
GUARDFIRED runStart=1088456 runEnd=1096648 owed=[[1096648 2151253]]
```

`TestManifestSoak_NoLegitimatePathOverlaps` passes. `go test ./...` green,
`go test -race ./pkg/block/... ./pkg/metadata/...` green, `golangci-lint run` 0 issues.

## Cost

**Timing on a laptop could not resolve this and I am not going to report a number from it.**
Interleaved A/B on `BenchmarkSequentialWrite8MB` gave −16% to −20% for the *new* side while a
sequential run gave +4%; `BenchmarkRandomWrite4KB` and `BenchmarkMixedRW` sit at ~20µs/op with
42–560% intra-run spread. Those benchmarks cannot see an effect this size, and picking whichever
direction flattered the change would be worthless.

What *is* deterministic is the number of added metadata round-trips, counted by instrumenting
the sink on both sides:

| workload | whole-manifest reads on `develop` | with the fix |
| --- | --- | --- |
| append (`BenchmarkSequentialWrite8MB`, 5 iterations) | 0 | **0** |
| evicted overwrite (`ClobberedRow`) | 0 | **1**, plus 1 guard transaction |

Zero on the append path is not luck: the straddle lookup is a whole-manifest read, so it is
gated behind `anySyncedFrom`, an in-memory interval scan the path was already paying for via
`warmAt`. With nothing durable past the run's end there is neither anything to extend over nor
anything a replaced row could still be owed.

So the cost is **one whole-manifest read and one guard transaction per run whose tail is
synced-but-not-warm** — exactly the case that used to strand data. The guard transaction is one
`GetFileChunk`, plus one `GetFileChunk` and one `Put` per owed piece (one piece in the common
case). An earlier revision of this branch asked the straddle lookup before the in-memory check,
which would have put that read on every run of every append; `5807735f5` fixes that and the
table above is what says it is fixed.

## Residue — fix-forward only

Nothing here detects or repairs files already stranded, and nothing can: the claim is gone from
the manifest *and* from the `File.Blocks` projection re-derived from it, so `manifest_repair`
has no evidence to rebuild from. The systemic audit gap is tracked in #2076.

Worth writing down because it is easy to lose: **the chunk itself survives on the remote**, since
the reap does not decrement CAS refcounts. This strands bytes that still physically exist and
that nothing references.

## One thing left explicitly unverified

While investigating I observed that the reap's "a row starting before its span is safe" rule
rests on fresh rows inside the span outranking the straddler by greatest covering start — and a
**punch** commits a span with no fresh rows at all. At the reap-unit level, seeding one row
`[0, 6000)` and reaping span `[2000, 3000)` with an empty `newOffsets` leaves the row whole, and
offset 2500 resolves to row 0 rather than to nothing.

**I am not claiming this is a live bug.** `TestColdReadAtCarveSeam_PunchedRangeStaysZero` passes
on `develop`, so the engine's punch path evidently handles the common case somewhere else, and
this change does not establish what. All that is established is that the reap rule *alone* does
not protect it, and that this is what the refuted preserve collided with. Confirming or killing
it needs a real-engine probe that has not been run, and it is out of scope here.
