### PR TITLE
ci(codeql): analyse develop, and close out the #2104 alert triage

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,8 @@ jobs:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     permissions:
-      # Uploading SARIF to the code-scanning API needs this; nothing else here writes.
+      # Uploading SARIF to the code-scanning API needs security-events; the
+      # rest is what init/analyze read to attribute results to a run.
       security-events: write
       contents: read
       actions: read
@@ -37,8 +38,8 @@ jobs:
 
       # Pin the toolchain rather than letting autobuild resolve one: a Go
       # version drift between here and the other workflows changes which
-      # sources CodeQL can resolve, and an unresolved package is silently
-      # analyzed as empty rather than reported as an error.
+      # packages resolve, and an unresolved package is analyzed as empty
+      # rather than reported as an error.
       - name: Set up Go
         if: matrix.language == 'go'
         uses: actions/setup-go@v5
@@ -47,21 +48,18 @@ jobs:
           cache: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-          # The threat model the previous configuration ran under. It treats
-          # authenticated control-plane input as remote, which is what makes
-          # the share-name and snapshot-id paths visible to the path-injection
-          # query at all.
-          config: |
-            threat-models:
-              - remote
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
+      # The category names each language's results in the code-scanning API.
+      # These match the ones the previous configuration used, which is what
+      # keeps existing alerts and their dismissals attached to the same
+      # analysis rather than being raised again as new alerts.
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,67 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
+  schedule:
+    # Weekly, matching the cadence the repository previously ran on.
+    - cron: "27 3 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      # Uploading SARIF to the code-scanning API needs this; nothing else here writes.
+      security-events: write
+      contents: read
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, go, python]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Pin the toolchain rather than letting autobuild resolve one: a Go
+      # version drift between here and the other workflows changes which
+      # sources CodeQL can resolve, and an unresolved package is silently
+      # analyzed as empty rather than reported as an error.
+      - name: Set up Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.x"
+          cache: true
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # The threat model the previous configuration ran under. It treats
+          # authenticated control-plane input as remote, which is what makes
+          # the share-name and snapshot-id paths visible to the path-injection
+          # query at all.
+          config: |
+            threat-models:
+              - remote
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## CodeQL has never analysed the branch we develop on

Triaging the 88 open code-scanning alerts turned up something worth more than any
individual alert: **the alert tab describes a tree we stopped working on 37 commits ago.**

CodeQL ran as GitHub **default setup** — weekly, against the **default branch `main`
only**. Releases flow develop → main, so `main` sat at `6d2a1bb7f` (`chore(release):
v0.30.0`) while `develop` moved on. The last three analyses were all at that same
commit. And because every PR targets `develop` rather than the default branch, **no
CodeQL check has ever run on a pull request** — `gh pr checks 2153` lists 20 checks,
none of them CodeQL.

That explains an otherwise confusing observation: PRs #2116, #2117 and #2118 all merged
to develop and the alert count did not move. 88 − 10 dismissed = 78, unchanged. Those
fixes are real and present on develop; the scanner simply cannot see them, and will not
until a release fast-forwards `main`.

The previous triage pass closed with "leaving this issue open for that per-alert pass
once the three PRs land and CodeQL re-runs against them." That re-run was never going
to happen on its own.

## What this PR does

Replaces default setup with an advanced-setup workflow that analyses **both `develop`
and `main`**, on push and on pull_request.

- **`main` stays covered.** Tags live on main and releases flow through it; dropping it
  would trade one blind spot for another.
- **Categories are unchanged** (`/language:go`, `/language:actions`, `/language:python`),
  so the 48 existing dismissals carry over rather than being raised as new alerts.
- **The `remote` threat model is preserved by not touching it.** It is what makes
  authenticated control-plane input visible to the path-injection query at all, and losing
  it would shrink the alert set and read as a fix. A first draft declared it explicitly;
  that was wrong twice over — `threat-models` takes a scalar rather than a list, and is
  documented as supported only for Java/Kotlin and C#. `remote` is the default model, so
  the correct action is to declare nothing.
- **Not a required check.** A first analysis of a 37-commit-ahead branch will surface
  untriaged findings; making those a merge blocker mid-batch would stop work that is
  currently landing. Verified rather than assumed: ruleset "Protect develop branch" has no
  `required_status_checks` rule, so nothing here can become a merge blocker on its own.
  Gating is a separate decision once the queue is clean.
- **`codeql-action@v4`**, not v3 — v3 is deprecated in December 2026 and already logs a
  warning for workflows that could be running v4.

**This needs one repository-settings change to take effect:** default setup must be
disabled, since the two configurations conflict if both are enabled.

## The triage itself

All 88 alerts were classified. Verdicts:

| Rule | Count | Verdict |
| --- | --- | --- |
| `go/path-injection` | 38 | False positive — **dismissed in this pass**, individually |
| `go/path-injection` | 1 | Real; fixed on develop by #2116, fix verified complete |
| `actions/missing-workflow-permissions` | 24 | Real; fixed on develop by #2117 |
| `go/incorrect-integer-conversion` | 15 | Latent; fixed on develop by #2118 |
| `go/weak-cryptographic-algorithm` + others | 10 | Dismissed in the earlier pass |

The 40 that remain open are all already fixed on develop. They close themselves when a
release advances `main`; that is the honest state, and no code change would move them.

### The 38 dismissals

Each was traced to its taint source individually rather than dismissed as a class — the
earlier pass explicitly declined to bulk-dismiss them, and that caution was right, since
the one alert in the group that had been checked concretely turned out to be a real bug.
Every dismissal carries the specific evidence a future reviewer can re-check:

- **journal `reclaim`/`format`/`segment`/`recovery`/`store`** (22) — `Store.dir` plus a
  constant filename or a `%016d` uint64 segment id. `scanSegmentIDs` is the only place a
  filename comes back off disk, and it never re-joins it: strip `.seg`, `ParseUint`,
  `continue` on error, keep only the integer.
- **`cold.go` / `local/fs/legacy*`** (13) — compile-time constants only. `materialize()`
  resolves a payloadID by **map lookup** — the lookup is the sanitizer — and
  `scanLegacyPayloads` derives the id *from* the `WalkDir` path, never uses one to build a path.
- **`blockstoreprobe/probe.go`** (2) — `Stat` + `CreateTemp` on the admin-supplied dir
  itself, no suffix joined; strictly weaker than the `MkdirAll` the create path already runs.
- **`snapshot.go:1864`** (1) — `os.RemoveAll` on a path containing a client-supplied id,
  the most destructive sink in the set. Guarded at `snapshot.go:1798` by `uuid.Parse`
  before any filesystem touch, with a comment naming this exact traversal.

### Three that could have been real and were not

`scanSegmentIDs` reading filenames off disk; the legacy migration walk re-joining
payload IDs that pre-journal builds derived from client-supplied paths; and the
`RemoveAll` above. Each has a real guard, not an accident of reachability.

### The #2116 fix verified rather than taken on trust

Every seam reaching `deriveLocalStoreDir` was enumerated. Both `AddShare` entry points
(REST `shares.go`, startup `init.go`) funnel through the single chokepoint at
`lifecycle.go:34`, so a hand-edited DB row named `..` fails at boot. `RebindShareBlockStore`
does not validate but is gated on registry membership, which requires surviving `AddShare`.
No rename path exists. The measured escape set of `sanitizeShareName` is exactly
`{"", ".", ".."}` — precisely what `namesShareDirectory` rejects. Pinned by
`share_name_isolation_test.go`, which asserts the derived path rather than just the verdict.

## Stated assumption

`config["path"]` on a block store lets an authenticated admin point the daemon at any
directory it can write, and validation itself `MkdirAll`s it. **Admin-equals-root is the
operative threat model**: the daemon's own filesystem authority is the boundary, not that
string. This is recorded as an assumption rather than written into a dismissal reason,
because it is a policy statement rather than a code fact — and it is the thing to revisit
first if the threat model ever separates admin from root.

Closes #2104

## Known gap this PR does not close — #2167

Review surfaced that the repo has two Go modules and no `go.work`, so autobuild only ever
builds the root module: the operator's 44 Go files have **never** been analysed. That is a
pre-existing blind spot, not a regression — default setup used the same autobuild against
the same tree — so this PR preserves parity and #2167 tracks closing it. Noting it here
because it was invisible in the way that makes this class of problem persist: an unresolved
package is analysed as empty rather than reported as an error.
