### PR TITLE
test(smbtorture): fail on an ungraded tail nobody signed off on, drop aio_delay

### DIFF
--- a/test/smb-conformance/README.md
+++ b/test/smb-conformance/README.md
@@ -144,11 +144,11 @@ cd smbtorture
 
 ### Available Sub-Suites
 
-**Standalone tests** (run individually with 60s timeout each):
+**Standalone tests** (run individually, 300s budget each):
 
 `smb2.connect`, `smb2.setinfo`, `smb2.stream-inherit-perms`, `smb2.set-sparse-ioctl`, `smb2.zero-data-ioctl`, `smb2.ioctl-on-stream`, `smb2.dosmode`, `smb2.async_dosmode`, `smb2.maxfid`, `smb2.check-sharemode`, `smb2.openattr`, `smb2.winattr`, `smb2.winattr2`, `smb2.sdread`, `smb2.secleak`, `smb2.session-id`, `smb2.tcon`, `smb2.mkdir`
 
-**Full sub-suites** (120s each, except the few `run.sh` grants more; `smb2.aio_delay` and `smb2.bench` are deliberately not run — see the comments beside them in `run.sh`):
+**Full sub-suites** (300s budget each, except `smb2.notify` at 120s; `smb2.aio_delay` and `smb2.bench` are deliberately not run — see the comments beside them in `run.sh`):
 
 `smb2.acls`, `smb2.acls_non_canonical`, `smb2.change_notify_disabled`, `smb2.compound`, `smb2.create`, `smb2.credits`, `smb2.delete-on-close`, `smb2.dir`, `smb2.durable-open`, `smb2.durable-v2-open`, `smb2.getinfo`, `smb2.ioctl`, `smb2.kernel-oplocks`, `smb2.lease`, `smb2.lock`, `smb2.notify`, `smb2.oplock`, `smb2.read`, `smb2.rename`, `smb2.replay`, `smb2.scan`, `smb2.session`, `smb2.streams`, `smb2.timestamps`, `smb2.twrp`, `smb2.write`
 

--- a/test/smb-conformance/README.md
+++ b/test/smb-conformance/README.md
@@ -148,9 +148,9 @@ cd smbtorture
 
 `smb2.connect`, `smb2.setinfo`, `smb2.stream-inherit-perms`, `smb2.set-sparse-ioctl`, `smb2.zero-data-ioctl`, `smb2.ioctl-on-stream`, `smb2.dosmode`, `smb2.async_dosmode`, `smb2.maxfid`, `smb2.check-sharemode`, `smb2.openattr`, `smb2.winattr`, `smb2.winattr2`, `smb2.sdread`, `smb2.secleak`, `smb2.session-id`, `smb2.tcon`, `smb2.mkdir`
 
-**Full sub-suites** (run with 120s timeout each):
+**Full sub-suites** (120s each, except the few `run.sh` grants more; `smb2.aio_delay` and `smb2.bench` are deliberately not run — see the comments beside them in `run.sh`):
 
-`smb2.acls`, `smb2.acls_non_canonical`, `smb2.aio_delay`, `smb2.bench`, `smb2.change_notify_disabled`, `smb2.compound`, `smb2.create`, `smb2.credits`, `smb2.delete-on-close`, `smb2.dir`, `smb2.durable-open`, `smb2.durable-v2-open`, `smb2.getinfo`, `smb2.ioctl`, `smb2.kernel-oplocks`, `smb2.lease`, `smb2.lock`, `smb2.notify`, `smb2.oplock`, `smb2.read`, `smb2.rename`, `smb2.replay`, `smb2.scan`, `smb2.session`, `smb2.streams`, `smb2.timestamps`, `smb2.twrp`, `smb2.write`
+`smb2.acls`, `smb2.acls_non_canonical`, `smb2.change_notify_disabled`, `smb2.compound`, `smb2.create`, `smb2.credits`, `smb2.delete-on-close`, `smb2.dir`, `smb2.durable-open`, `smb2.durable-v2-open`, `smb2.getinfo`, `smb2.ioctl`, `smb2.kernel-oplocks`, `smb2.lease`, `smb2.lock`, `smb2.notify`, `smb2.oplock`, `smb2.read`, `smb2.rename`, `smb2.replay`, `smb2.scan`, `smb2.session`, `smb2.streams`, `smb2.timestamps`, `smb2.twrp`, `smb2.write`
 
 ### Known Failures
 

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -405,6 +405,52 @@ not — Go keeps function names in `pclntab` for tracebacks — but that had to 
 measured rather than reasoned about. A wrong kill is quieter than a wrong
 confirmation: nobody investigates a door that is already closed.
 
+### 2026-08-26 — a suite cut short now fails the job, and the budget is one number
+
+Until now a suite that ran out of budget was reported and then ignored by the
+verdict. That is the wrong default. A cut suite emits no result lines past the
+cut point, so its remaining tests are *missing*, not passing — and the job still
+printed `0 new failures`. `smb2.replay` sat truncated for three months with a
+real DH2Q defect in its tail (#2086/#1322) while every run reported clean.
+
+`run.sh` now records, alongside each truncation, the reason it is allowed to
+happen; `parse-results.sh` fails the job on any truncation that carries no
+reason. One suite is on that list: `smb2.notify`, which hangs on a cancelled
+CHANGE_NOTIFY that never receives a final response (#2109) — no budget fixes an
+unbounded client wait. Verified by emptying the sign-off on a throwaway branch
+and confirming the job goes red on exactly that suite (run 32937937648); before
+the change, the same truncation was green.
+
+**The per-suite budgets are gone.** They were sized per suite and did not survive
+contact with the other profiles: `smb2.dir` runs 22.8s on `memory` and 111.7s on
+`sqlite` against the same 120s wall, and `smb2.maxfid` — 18.2s on `badger-fs` —
+ran into its 60s wall on one `postgres` draw and lost its only test. Any figure
+tight enough to mean something on one backend is a coin flip on another. The
+budget exists to bound a hang, not to grade speed, so there is now one: **300s**
+for every suite and standalone test, with `smb2.notify` held at 120s because
+burning five minutes on a known hang buys nothing.
+
+Slowest legitimate suite measured across all five profiles is
+`smb2.compound_find` at 193s (sqlite), then `lease` 187s, `replay` 165s,
+`oplock` 146s, `multichannel` 132s. 300s clears the slowest by ~1.6x.
+
+`smb2.compound_find` was the last uncharacterised truncation and is **not** a
+defect: `compound_find_close` creates 5000 files one synchronous CREATE+CLOSE at
+a time before the FIND it actually tests, and the count is hard-coded in the
+test, so unlike `maxfid` there is no knob to bound it. Every persistent metadata
+backend overran 120s; with budget it passes on all of them (sqlite 182/193s,
+postgres 134/160s, memory 43s).
+
+`smb2.aio_delay` is **dropped** from the suite list. Its single test,
+`aio_cancel`, loops on `req->cancel.can_cancel` with no bound, and that flag is
+set in exactly one place in the smbtorture client — on receipt of an interim
+`NT_STATUS_PENDING`. Samba only ever runs this suite against a share carrying its
+`vfs_delay_inject` module, whose purpose is to make reads artificially slow so
+smbd defers them. DittoFS has no such module and the harness targets
+`/smbbasic`, so a 1-byte read completes immediately, no interim is sent, and the
+suite burned 120s per profile per run having graded 0 of 1. It is a Samba VFS
+harness, not a conformance case, and it can never produce a verdict here.
+
 ### 2026-08-25 — per-suite budgets: 3 pre-existing failures surfaced out of the ungraded tails
 
 `smb2.lease`, `smb2.multichannel` and `smb2.oplock` were being cut short at 120s

--- a/test/smb-conformance/smbtorture/parse-results.sh
+++ b/test/smb-conformance/smbtorture/parse-results.sh
@@ -353,11 +353,13 @@ for name in "${NOW_PASSING_LIST[@]+"${NOW_PASSING_LIST[@]}"}"; do
 done
 NOW_PASSING_LIST=("${_now_passing[@]+"${_now_passing[@]}"}")
 
-# Suites the harness gave up on, recorded by run.sh as "filter<TAB>seconds".
-# Everything those suites had not reached is missing from the results above.
+# Suites the harness gave up on, recorded by run.sh as
+# "filter<TAB>seconds<TAB>reason". Everything those suites had not reached is
+# missing from the results above.
 #
-# The third field is the reason that truncation is expected, written by run.sh's
-# expected_truncation(). Empty means nobody signed off on it: the tests the
+# The reason is written by run.sh's expected_truncation() and says why no budget
+# would help. Empty — including a two-field row from before the column existed —
+# means nobody signed off on it: the tests the
 # suite never reached are missing from the results, and a run that quietly loses
 # coverage must not report as clean, so it fails the job.
 declare -a TIMED_OUT_SUITES=()

--- a/test/smb-conformance/smbtorture/parse-results.sh
+++ b/test/smb-conformance/smbtorture/parse-results.sh
@@ -8,8 +8,9 @@
 #   - SKIP:  Test was skipped (dim)
 #
 # Exit codes:
-#   0  All failures are known (or no failures)
-#   >0 Number of new unexpected failures
+#   0  All failures are known (or no failures) and no suite was cut short
+#      without a recorded reason
+#   >0 Number of new unexpected failures, plus suites cut short with no sign-off
 #   1  Missing output file or no results
 #
 # Usage:
@@ -354,11 +355,22 @@ NOW_PASSING_LIST=("${_now_passing[@]+"${_now_passing[@]}"}")
 
 # Suites the harness gave up on, recorded by run.sh as "filter<TAB>seconds".
 # Everything those suites had not reached is missing from the results above.
+#
+# The third field is the reason that truncation is expected, written by run.sh's
+# expected_truncation(). Empty means nobody signed off on it: the tests the
+# suite never reached are missing from the results, and a run that quietly loses
+# coverage must not report as clean, so it fails the job.
 declare -a TIMED_OUT_SUITES=()
+declare -a UNEXPECTED_TRUNCATIONS=()
 if [[ -n "$RESULTS_DIR" ]] && [[ -f "${RESULTS_DIR}/timeouts.txt" ]]; then
-    while IFS=$'\t' read -r to_filter to_secs; do
+    while IFS=$'\t' read -r to_filter to_secs to_reason; do
         [[ -z "$to_filter" ]] && continue
-        TIMED_OUT_SUITES+=("${to_filter} (gave up after ${to_secs:-?}s)")
+        if [[ -n "$to_reason" ]]; then
+            TIMED_OUT_SUITES+=("${to_filter} (gave up after ${to_secs:-?}s) — expected: ${to_reason}")
+        else
+            TIMED_OUT_SUITES+=("${to_filter} (gave up after ${to_secs:-?}s)")
+            UNEXPECTED_TRUNCATIONS+=("${to_filter} (gave up after ${to_secs:-?}s)")
+        fi
     done < "${RESULTS_DIR}/timeouts.txt"
 fi
 
@@ -597,9 +609,12 @@ report_body() {
     echo "| Skipped | ${SKIP_COUNT} |"
     echo "| Inconclusive | ${#INCOMPLETE_LIST[@]} |"
     echo "| Suites cut short | ${#TIMED_OUT_SUITES[@]} |"
+    echo "| Cut short unexpectedly | ${#UNEXPECTED_TRUNCATIONS[@]} |"
 
     report_list "New failures — not in KNOWN_FAILURES.md, these fail the job" \
         "${NEW_FAILURE_LIST[@]+"${NEW_FAILURE_LIST[@]}"}"
+    report_list "Suites cut short with no sign-off — lost coverage, these fail the job" \
+        "${UNEXPECTED_TRUNCATIONS[@]+"${UNEXPECTED_TRUNCATIONS[@]}"}"
     report_list "Suites cut short by timeout — everything they did not reach is ungraded" \
         "${TIMED_OUT_SUITES[@]+"${TIMED_OUT_SUITES[@]}"}"
     report_list "Tests with no verdict — killed mid-test, neither pass nor fail" \
@@ -619,18 +634,34 @@ echo ""
 # --------------------------------------------------------------------------
 # Verdict
 #
-# The job fails on exactly one thing: failures that are not on the
-# KNOWN_FAILURES.md blacklist. Timeouts and no-verdict tests are reported
-# above but do not move the verdict in either direction — a suite the harness
-# abandoned is evidence of nothing, and failing on it would trade one flake
-# for another.
+# The job fails on two things: failures that are not on the KNOWN_FAILURES.md
+# blacklist, and suites the harness gave up on without a recorded reason.
+#
+# The second is not a failed test — it is a missing one. Tests past the cut
+# point emit no result lines at all, so they are neither passed nor failed, and
+# a run that grades only what it reached would report clean while silently
+# shrinking its own coverage. A truncation that someone has signed off on
+# (run.sh's expected_truncation) is still reported, but does not move the
+# verdict; anything else does.
 # --------------------------------------------------------------------------
-if [[ "$NEW_FAILURES" -gt 0 ]]; then
-    echo -e "${RED}${BOLD}RESULT: ${NEW_FAILURES} new failure(s) detected!${NC}"
-    echo ""
-    echo "To add as known failures, append to KNOWN_FAILURES.md:"
-    echo "  | <test-name> | <category> | <reason> | - |"
-    echo ""
+BAD=$((NEW_FAILURES + ${#UNEXPECTED_TRUNCATIONS[@]}))
+
+if [[ "$BAD" -gt 0 ]]; then
+    if [[ "$NEW_FAILURES" -gt 0 ]]; then
+        echo -e "${RED}${BOLD}RESULT: ${NEW_FAILURES} new failure(s) detected!${NC}"
+        echo ""
+        echo "To add as known failures, append to KNOWN_FAILURES.md:"
+        echo "  | <test-name> | <category> | <reason> | - |"
+        echo ""
+    fi
+    if [[ ${#UNEXPECTED_TRUNCATIONS[@]} -gt 0 ]]; then
+        echo -e "${RED}${BOLD}RESULT: ${#UNEXPECTED_TRUNCATIONS[@]} suite(s) cut short with no sign-off!${NC}"
+        echo ""
+        echo "Those suites lost every test they had not reached. Either give them"
+        echo "enough budget to finish, or record why no budget can help them in"
+        echo "run.sh's expected_truncation()."
+        echo ""
+    fi
 else
     echo -e "${GREEN}${BOLD}RESULT: All failures are known. CI green.${NC}"
     if [[ ${#INCOMPLETE_LIST[@]} -gt 0 || ${#TIMED_OUT_SUITES[@]} -gt 0 ]]; then
@@ -639,5 +670,5 @@ else
     echo ""
 fi
 
-# Exit with count of new failures (0 = success)
-exit "$NEW_FAILURES"
+# Exit with the count of things that fail the job (0 = success)
+exit "$BAD"

--- a/test/smb-conformance/smbtorture/parse-results.sh
+++ b/test/smb-conformance/smbtorture/parse-results.sh
@@ -365,11 +365,12 @@ declare -a UNEXPECTED_TRUNCATIONS=()
 if [[ -n "$RESULTS_DIR" ]] && [[ -f "${RESULTS_DIR}/timeouts.txt" ]]; then
     while IFS=$'\t' read -r to_filter to_secs to_reason; do
         [[ -z "$to_filter" ]] && continue
+        cut_short="${to_filter} (gave up after ${to_secs:-?}s)"
         if [[ -n "$to_reason" ]]; then
-            TIMED_OUT_SUITES+=("${to_filter} (gave up after ${to_secs:-?}s) — expected: ${to_reason}")
+            TIMED_OUT_SUITES+=("${cut_short} — expected: ${to_reason}")
         else
-            TIMED_OUT_SUITES+=("${to_filter} (gave up after ${to_secs:-?}s)")
-            UNEXPECTED_TRUNCATIONS+=("${to_filter} (gave up after ${to_secs:-?}s)")
+            TIMED_OUT_SUITES+=("$cut_short")
+            UNEXPECTED_TRUNCATIONS+=("$cut_short")
         fi
     done < "${RESULTS_DIR}/timeouts.txt"
 fi

--- a/test/smb-conformance/smbtorture/parse-results_test.sh
+++ b/test/smb-conformance/smbtorture/parse-results_test.sh
@@ -116,7 +116,7 @@ assert_output "unfinished test named" "- smb2.notify.mask"
 assert_output "unfinished test is not a pass" "| Passed | 1 |"
 
 # -- A timeout must not hide a new failure the suite did produce. --
-printf 'smb2.notify\t120\n' > "${WORK}/timeouts.txt"
+printf 'smb2.notify\t120\tno budget helps\n' > "${WORK}/timeouts.txt"
 run_case "new failure inside a timed-out suite still fails" 1 <<'EOF'
 test: smb2.notify.dir
 failure: smb2.notify.dir [ regression ]
@@ -126,14 +126,47 @@ assert_output "timed-out suite reported" "- smb2.notify (gave up after 120s)"
 assert_output "new failure inside timed-out suite named" "- smb2.notify.dir"
 rm -f "${WORK}/timeouts.txt"
 
-# -- A timeout on its own is reported but leaves the job green. --
-printf 'smb2.notify\t120\n' > "${WORK}/timeouts.txt"
-run_case "timeout alone stays green" 0 <<'EOF'
+# -- A truncation someone signed off on is reported but stays green. --
+printf 'smb2.notify\t120\tno budget helps\n' > "${WORK}/timeouts.txt"
+run_case "signed-off timeout stays green" 0 <<'EOF'
 test: smb2.connect.connect1
 success: smb2.connect.connect1
 test: smb2.notify.mask
 EOF
 assert_output "timeout counted" "| Suites cut short | 1 |"
+assert_output "signed-off timeout not counted against" "| Cut short unexpectedly | 0 |"
+assert_output "sign-off reason shown" "expected: no budget helps"
+rm -f "${WORK}/timeouts.txt"
+
+# -- A truncation nobody signed off on reds the job on its own: the tests past
+# -- the cut point are missing, not passing. This is the whole point of the
+# -- third column, so it is pinned from both directions. --
+printf 'smb2.compound_find\t120\t\n' > "${WORK}/timeouts.txt"
+run_case "unexplained timeout fails the job" 1 <<'EOF'
+test: smb2.connect.connect1
+success: smb2.connect.connect1
+test: smb2.compound_find.compound_find_close
+EOF
+assert_output "unexplained timeout counted" "| Cut short unexpectedly | 1 |"
+assert_output "unexplained timeout named" "- smb2.compound_find (gave up after 120s)"
+assert_output "unexplained timeout explains itself" "cut short with no sign-off"
+rm -f "${WORK}/timeouts.txt"
+
+# -- A two-field row (no third column at all) is unexplained too, not a parse
+# -- error: the file gains a column, and an old row must not read as signed off. --
+printf 'smb2.compound_find\t120\n' > "${WORK}/timeouts.txt"
+run_case "two-field timeout row fails the job" 1 <<'EOF'
+test: smb2.connect.connect1
+success: smb2.connect.connect1
+EOF
+rm -f "${WORK}/timeouts.txt"
+
+# -- Failures and unexplained truncations both count toward the exit code. --
+printf 'smb2.compound_find\t120\t\n' > "${WORK}/timeouts.txt"
+run_case "failure plus unexplained timeout counts both" 2 <<'EOF'
+test: smb2.rename.rename1
+failure: smb2.rename.rename1 [ regression ]
+EOF
 rm -f "${WORK}/timeouts.txt"
 
 # -- A blacklisted test that passes is surfaced as a removal candidate. --

--- a/test/smb-conformance/smbtorture/run.sh
+++ b/test/smb-conformance/smbtorture/run.sh
@@ -550,7 +550,17 @@ else
     SUITES=(
         "smb2.acls:acls"
         "smb2.acls_non_canonical:acls_non_canonical:smbnoncanon"
-        "smb2.aio_delay:aio_delay"
+        # smb2.aio_delay is intentionally NOT run: its single test, aio_cancel,
+        # sends a 1-byte READ and then loops on `req->cancel.can_cancel` with no
+        # bound. That flag is set in exactly one place in the smbtorture client
+        # — on receipt of an interim NT_STATUS_PENDING — so the test cannot
+        # proceed at all unless the server defers the read. Samba only ever runs
+        # this suite against a share carrying its `vfs_delay_inject` module,
+        # whose whole purpose is to make reads artificially slow. DittoFS has no
+        # such module and the harness targets /smbbasic, so the read completes
+        # immediately, no interim is ever sent, and the suite burns its entire
+        # budget having graded 0 of 1. That is not a tight budget and not a
+        # server gap: the suite can never produce a verdict here.
         # smb2.bench is intentionally NOT run: it is a throughput benchmark
         # family (echo, oplock1, path-contention-shared, read, session-setup),
         # not a conformance suite. The tests measure round-trip timing and
@@ -689,12 +699,18 @@ else
         # smb2.notify is deliberately NOT raised. It hangs on a cancelled
         # CHANGE_NOTIFY that never receives a final response, so a bigger budget
         # only burns more of it while leaving the same tail ungraded.
-        # smb2.aio_delay and smb2.compound_find stay at 120s too: still
-        # uncharacterised, and sizing a budget for an unknown is how an ungraded
-        # tail gets established in the first place.
+        #
+        # smb2.compound_find is a volume case, the same shape as maxfid was:
+        # compound_find_close creates 5000 files one synchronous CREATE+CLOSE
+        # round trip at a time before the FIND it actually tests, and the count
+        # is hard-coded in the test, so there is no knob to bound it with. The
+        # memory profiles finish it in ~43s; every persistent metadata backend
+        # pays more per CREATE and overruns 120s. Probe value, to be replaced by
+        # the measurement it produces.
         case "$suite" in
             smb2.replay|smb2.durable-*|smb2.lease|smb2.multichannel|smb2.oplock)
                 suite_timeout=300 ;;
+            smb2.compound_find) suite_timeout=600 ;;
             *) suite_timeout=120 ;;
         esac
         run_smbtorture "$suite" "$suite_timeout" "$prefix" "${share:-}" || record_rc $?

--- a/test/smb-conformance/smbtorture/run.sh
+++ b/test/smb-conformance/smbtorture/run.sh
@@ -468,10 +468,9 @@ run_smbtorture() {
     if [[ $rc -ge 129 ]]; then
         log_warn "smbtorture client crashed (exit code $rc, signal $((rc - 128))) for filter: $filter — client-side bug, not failing the job on this alone"
     elif [[ $rc -eq 124 ]]; then
-        local reason
-        reason="$(expected_truncation "$filter")"
         log_warn "smbtorture timed out after ${per_timeout}s on filter: $filter — tests it had not reached are UNGRADED (inconclusive)"
-        printf '%s\t%s\t%s\n' "$filter" "$per_timeout" "$reason" >> "${RESULTS_DIR}/timeouts.txt"
+        printf '%s\t%s\t%s\n' "$filter" "$per_timeout" "$(expected_truncation "$filter")" \
+            >> "${RESULTS_DIR}/timeouts.txt"
     elif [[ $rc -ge 125 ]]; then
         log_warn "smbtorture infrastructure failure (exit code $rc) for filter: $filter"
     fi

--- a/test/smb-conformance/smbtorture/run.sh
+++ b/test/smb-conformance/smbtorture/run.sh
@@ -401,6 +401,23 @@ fi
 # whereas the default smb2.acls suite requires Windows-default canonicalization.
 SMBTORTURE_DEFAULT_SHARE="${SMBTORTURE_DEFAULT_SHARE:-smbbasic}"
 
+# expected_truncation SUITE
+# Prints why SUITE is allowed to be cut short by its budget, or nothing when it
+# is not. A suite that runs out of budget loses every test it had not reached,
+# and those tests report as neither passed nor failed — so by default that is a
+# job failure, the same as a new red test. This list is the only escape hatch,
+# and each entry needs a reason a bigger budget cannot address.
+expected_truncation() {
+    case "$1" in
+        smb2.notify)
+            # A cancelled CHANGE_NOTIFY never receives its final response, so
+            # the client blocks until the harness kills the suite. More budget
+            # only burns more of it and leaves the same tail ungraded. Tracked
+            # in #2109.
+            echo "cancelled CHANGE_NOTIFY never completed (#2109)" ;;
+    esac
+}
+
 # run_smbtorture FILTER [PER_TEST_TIMEOUT] [SUITE_PREFIX] [SHARE]
 # Runs smbtorture with the given filter, appending output to results file.
 # When SUITE_PREFIX is set, test/success/failure/error lines in the output
@@ -433,9 +450,11 @@ run_smbtorture() {
     #   124            -> the per-suite timeout fired: the harness gave up on this
     #                     filter. Whatever the suite had not reached yet produced
     #                     NO result lines at all, so those tests are ungraded —
-    #                     inconclusive, not passing. Recorded in timeouts.txt so
-    #                     parse-results.sh can report the lost coverage instead of
-    #                     letting it read as a clean run.
+    #                     inconclusive, not passing. Recorded in timeouts.txt
+    #                     along with the reason it is allowed to happen, if any,
+    #                     so parse-results.sh can red the job on lost coverage
+    #                     nobody signed off on instead of letting it read as a
+    #                     clean run.
     #   125            -> docker run/daemon error (image pull 502, OOM-killed
     #                     container, etc.) — a real infrastructure failure
     #   128+N (>=129)  -> the smbtorture CLIENT process was killed by signal N
@@ -449,8 +468,10 @@ run_smbtorture() {
     if [[ $rc -ge 129 ]]; then
         log_warn "smbtorture client crashed (exit code $rc, signal $((rc - 128))) for filter: $filter — client-side bug, not failing the job on this alone"
     elif [[ $rc -eq 124 ]]; then
+        local reason
+        reason="$(expected_truncation "$filter")"
         log_warn "smbtorture timed out after ${per_timeout}s on filter: $filter — tests it had not reached are UNGRADED (inconclusive)"
-        printf '%s\t%s\n' "$filter" "$per_timeout" >> "${RESULTS_DIR}/timeouts.txt"
+        printf '%s\t%s\t%s\n' "$filter" "$per_timeout" "$reason" >> "${RESULTS_DIR}/timeouts.txt"
     elif [[ $rc -ge 125 ]]; then
         log_warn "smbtorture infrastructure failure (exit code $rc) for filter: $filter"
     fi
@@ -496,8 +517,9 @@ reset_share() {
 #                     by signal) — those are upstream client bugs and must not
 #                     red the job; parse-results.sh grades the actual protocol
 #                     outcomes from whatever output was produced. A per-suite
-#                     timeout (124) is also left non-fatal, matching the prior
-#                     behaviour (partial output is still graded).
+#                     timeout (124) is not fatal here either — partial output is
+#                     still graded, and parse-results.sh is what fails the job
+#                     over a truncation that is not on the expected list.
 _smbtorture_exit=0
 _smbtorture_infra=0
 
@@ -696,9 +718,7 @@ else
         # variance needs; the two profiles land within 4s of each other, so the
         # figure is not backend-sensitive.
         #
-        # smb2.notify is deliberately NOT raised. It hangs on a cancelled
-        # CHANGE_NOTIFY that never receives a final response, so a bigger budget
-        # only burns more of it while leaving the same tail ungraded.
+        # smb2.notify is deliberately NOT raised — see expected_truncation().
         #
         # smb2.compound_find is a volume case, the same shape as maxfid was:
         # compound_find_close creates 5000 files one synchronous CREATE+CLOSE

--- a/test/smb-conformance/smbtorture/run.sh
+++ b/test/smb-conformance/smbtorture/run.sh
@@ -559,7 +559,13 @@ else
         # opens/leases) can't fail a previously-passing test. Refs #568.
         reset_share "$SMBTORTURE_DEFAULT_SHARE"
         log_info "  Running: ${test}"
-        run_smbtorture "$test" 60 || record_rc $?
+        # Same budget as the sub-suites, and for the same reason. The 60s these
+        # used to get was not slack: smb2.maxfid opens 2000 handles one at a
+        # time, which is 18s on badger-fs but 52s on postgres, and one postgres
+        # draw ran into the wall at 60s and lost the test entirely. Every other
+        # standalone finishes inside 20s, so the larger figure costs nothing
+        # unless something actually hangs.
+        run_smbtorture "$test" 300 || record_rc $?
     done
 
     # Sub-suites with prefix for test name fixup.
@@ -697,41 +703,27 @@ else
         else
             log_info "  Running: ${suite}"
         fi
-        # Durable-handle and replay suites drive many durable open/disconnect/
-        # reconnect cycles, and the replay-vs-pending-break arms each spend ~6s
-        # parked on a lease break the test deliberately acks late. At 120s even
-        # the memory profile reports "smb2.replay (gave up after 120s)" and
-        # leaves the tail of the suite ungraded; badger-fs is slower still,
-        # since each cycle persists/consumes a durable handle with a
-        # synchronous, non-coalescing fsync. Give those suites more head room
-        # on every profile; every other suite keeps 120s.
+        # One budget for every suite. It is there to bound a hang, not to
+        # grade speed: a suite that legitimately runs for three minutes is not
+        # a problem, a suite that never returns is. Per-suite numbers were
+        # tried and do not hold -- the same suite spans 22s on memory and 112s
+        # on sqlite, so any figure tight enough to be meaningful on one profile
+        # is a coin flip on another, and losing that flip silently drops every
+        # test past the cut point.
         #
-        # smb2.lease, smb2.multichannel and smb2.oplock overrun 120s the same
-        # way, on every profile — the cut is not a storage-speed effect.
-        # smb2.oplock is the clearest case: batch22b deliberately waits out an
-        # oplock break timeout (smbtorture's own `oplocktimeout`, default 35s)
-        # with the holder's transport blocked so no ack can arrive.
+        # Slowest legitimate suite measured across all five profiles is
+        # smb2.compound_find at 193s (sqlite); smb2.lease, smb2.replay,
+        # smb2.oplock and smb2.multichannel follow at 187/165/146/132s. 300s
+        # clears the slowest by ~1.6x, which is the margin the runner's own
+        # variance has been observed to need, and still caps a wedged suite at
+        # five minutes.
         #
-        # Measured end-to-end, with enough budget to finish (memory/badger-fs):
-        # lease 182/186s, oplock 145/145s, multichannel 132/132s, replay 163s.
-        # 300s is ~1.6x the slowest of those, which is the headroom the runner's
-        # variance needs; the two profiles land within 4s of each other, so the
-        # figure is not backend-sensitive.
-        #
-        # smb2.notify is deliberately NOT raised — see expected_truncation().
-        #
-        # smb2.compound_find is a volume case, the same shape as maxfid was:
-        # compound_find_close creates 5000 files one synchronous CREATE+CLOSE
-        # round trip at a time before the FIND it actually tests, and the count
-        # is hard-coded in the test, so there is no knob to bound it with. The
-        # memory profiles finish it in ~43s; every persistent metadata backend
-        # pays more per CREATE and overruns 120s. Probe value, to be replaced by
-        # the measurement it produces.
+        # smb2.notify is the one exception, in the other direction: it is a
+        # known hang (see expected_truncation), so letting it burn the full
+        # budget buys nothing but CI time.
         case "$suite" in
-            smb2.replay|smb2.durable-*|smb2.lease|smb2.multichannel|smb2.oplock)
-                suite_timeout=300 ;;
-            smb2.compound_find) suite_timeout=600 ;;
-            *) suite_timeout=120 ;;
+            smb2.notify) suite_timeout=120 ;;
+            *) suite_timeout=300 ;;
         esac
         run_smbtorture "$suite" "$suite_timeout" "$prefix" "${share:-}" || record_rc $?
     done


### PR DESCRIPTION
## The defect

smbtorture has three verdicts — `success:`, `failure:` and `error:` — and the job
fails on exactly one thing: a `failure:`/`error:` that is not on
`KNOWN_FAILURES.md`. A suite killed by its `timeout(1)` budget emits **none of the
three** for anything past the cut point. Those tests are not passing and not
failing; they are *missing*. The run reported `0 new failures` and went green.

That is not theoretical. `smb2.replay` was cut at 120s for three months while a
real DH2Q replay defect sat in its ungraded tail, across two issues (#2086,
#1322), on runs that all reported clean.

#2097 and #2111 fixed the truncations they could measure. This closes the hole
itself: **a suite cut short now fails the job unless someone has recorded why no
budget can help it.**

## Three changes, in dependency order

### 1. `smb2.aio_delay` is dropped — it is a Samba VFS harness, not a conformance suite

Its single test, `aio_cancel` (`source4/torture/smb2/read.c:459`), writes 64K,
reopens the file, sends a **1-byte** READ, then spins:

```c
req = smb2_read_send(tree, &r);
while (!req->cancel.can_cancel) {
        rc = tevent_loop_once(tctx->ev);
        ...
}
```

with no bound. `req->cancel.can_cancel` is set in exactly one place in the
client — on receipt of an interim `NT_STATUS_PENDING`. So the test cannot start
until the server defers the read. Samba's own header on that suite says it
plainly: *"aio testing against share with VFS module 'delay_inject'"*. That
module exists to make reads artificially slow so smbd defers them.

DittoFS has no equivalent and the harness targets `/smbbasic`, so the 1-byte read
completes immediately, no interim is ever sent, and the suite burns its whole
budget having graded **0 of 1**. Confirmed in the server log for the truncated
run: CREATE → WRITE 64K → CLOSE → CREATE → `READ ... requested=1 actual=1`
answered `STATUS_SUCCESS`, then nothing at all for 120s.

That is coverage of one fewer suite, and it is the right trade: the suite has
never produced a verdict on any profile, and leaving it in poisons the exact
signal this PR makes load-bearing.

### 2. One budget, because per-suite figures do not survive the other profiles

`smb2.compound_find` was the last uncharacterised truncation, and it is not a
defect either: `compound_find_close` creates **5000 files**, one synchronous
CREATE+CLOSE round trip at a time, before the FIND it actually tests. The count
is hard-coded in the test, so unlike `maxfid` there is no `--option` to bound it
with. Every persistent metadata backend overran 120s. Given room it passes
everywhere — badger-fs 157.6s, postgres 134-160s, sqlite 182-193s, memory 43.6s.

Sizing it per-suite is where this stopped being a tuning exercise. Measuring the
wall time of every suite on every profile shows the hand-tuned walls were already
one bad draw from firing:

| suite | memory | badger-fs | postgres | sqlite | old wall |
|---|---:|---:|---:|---:|---:|
| `compound_find` | 43.6s | 157.6s | 133.8 / 159.5s | 182.2 / 193.2s | 120s |
| `dir` | 22.8s | 60.4s | 101.4s | **111.7s** | 120s |
| `maxfid` | ~5s | 18.2s | 52.3s / **60.3s (cut)** | 31.4 / 32.1s | 60s |

`smb2.dir` at 93% of its wall on sqlite, and `smb2.maxfid` actually running into
its wall on one of two postgres draws and losing its only test — silently, green.
A wall tight enough to mean something on `memory` is a coin flip on `sqlite`.

So the budget is now **one number: 300s**, for every suite and every standalone
test. It is there to bound a hang, not to grade speed. The slowest legitimate
suite measured across all five profiles is `compound_find` at 193s, then `lease`
187s, `replay` 165s, `oplock` 146s, `multichannel` 132s — 300s clears the slowest
by ~1.6x, the same factor #2111 used, and still caps a wedged suite at five
minutes. This *deletes* the per-suite `case` arms rather than adding to them.

`smb2.notify` is the one exception in the other direction, held at 120s: it is a
known hang (#2109), so letting it burn five minutes buys nothing.

### 3. The verdict change

`run.sh` gains `expected_truncation()`, a single lookup both the full-suite loop
and the single-`--filter` path go through. It prints why a suite is allowed to be
cut short, or nothing. That reason becomes a third tab-separated field in
`timeouts.txt`; `parse-results.sh` reds the job on any row with an empty third
field, and reports the signed-off ones without moving the verdict.

One suite is on the list — `smb2.notify` (#2109). An old two-field row reads as
unsigned-off, not as a parse error, which is the safe direction.

## Verification

**The guard was made to refuse something.** A guard that has never fired is
unverified, so the sign-off was emptied on a throwaway branch and the real
suite run on CI: run
[32937937648](https://github.com/marmos91/dittofs/actions/runs/32937937648) went
**red** on `smbtorture / memory`, on exactly the right suite —

```
| Suites cut short | 1 |
| Cut short unexpectedly | 1 |
### Suites cut short with no sign-off — lost coverage, these fail the job (1)
- smb2.notify (gave up after 120s)
RESULT: 1 suite(s) cut short with no sign-off!
```

That same truncation is green on every run of `develop` today. Branch deleted.

**The new grading tests were run against the pre-change parser** and 8 assertions
fail there, including the two that matter (`unexplained timeout fails the job:
exit 0, want 1`), so they are not self-satisfying. They cover: signed-off
truncation stays green, unsigned-off reds, a legacy two-field row reds, and a
failure plus a truncation counts both.

**Sample sizes**, since single draws are not measurements: `compound_find` and
`maxfid` were each measured on 2 independent sqlite runs and 2 independent
postgres runs (4 dispatched probe runs); the cross-profile wall-time table is
from the 5-profile `develop` run 32901765186 plus those probes. The `maxfid`
60s cut is 1 of 2 postgres draws — which is the point, not a caveat.

## What this does not do

No `KNOWN_FAILURES.md` rows are added. An ungraded test is not a known failure,
it is an untested one — and after this, an untested one reds the job.

## Final CI state

Both presubmit profiles green with the guard live, and the sign-off doing exactly
what it should:

```
smbtorture / memory      | New Failures | 0 |  | Suites cut short | 1 |  | Cut short unexpectedly | 0 |
smbtorture / badger-fs   | New Failures | 0 |  | Suites cut short | 1 |  | Cut short unexpectedly | 0 |
- smb2.notify (gave up after 120s) — expected: cancelled CHANGE_NOTIFY never completed (#2109)
```

Closes #2098
