### PR TITLE
ci(smb-compat): the 30s wait for TCP 445 is measured — srvnet is wedged, not slow

### DIFF
--- a/.github/workflows/smb-client-compat.yml
+++ b/.github/workflows/smb-client-compat.yml
@@ -343,6 +343,14 @@ jobs:
             sc.exe stop $svc 2>&1 | Out-String | Write-Host
           }
           $freed = $false
+          # 15 x 2s is deliberate and measured, not a guess anyone should raise.
+          # A runner that can release 445 does it in about 11s, comfortably
+          # inside this window. A runner that cannot is not merely slow: watched
+          # for a further 62s past the give-up, across three runs, 445 stayed
+          # held and srvnet stayed in STOP_PENDING without advancing a single
+          # state -- three times this budget bought nothing. The wait is not the
+          # variable in either population, so a longer one would only make the
+          # skip path slower to reach.
           for ($i = 0; $i -lt 15; $i++) {
             if (-not (Get-NetTCPConnection -LocalPort 445 -State Listen -ErrorAction SilentlyContinue)) { $freed = $true; break }
             sc.exe stop srv2 2>&1 | Out-Null


### PR DESCRIPTION
## The answer, from the numbers

#2154 asked for the srvnet stop to be measured before anyone decided whether the
30s wait for TCP 445 is too short. #2158 added the instrumentation. This is the
reading, and it says **do not raise the budget**.

The issue set the decision rule itself:

> If the give-up cases cluster just past 30s, a larger budget is justified by
> data. If they are flat at the ceiling with `srvnet` never advancing past
> `STOP_PENDING`, the wait is not the variable and the budget should stay where
> it is.

They are flat at the ceiling.

## What the instrumentation had recorded

Six give-ups carry the `srvnet-stop-timing` line. Every one of them:

| run | event | line |
|---|---|---|
| [32937043788](https://github.com/marmos91/dittofs/actions/runs/32937043788) | push develop | `freed=False elapsed_ms=32267 failed_polls=15 srvnet_state='STATE : 3 STOP_PENDING'` |
| [32936084276](https://github.com/marmos91/dittofs/actions/runs/32936084276) | push develop | `freed=False elapsed_ms=32123 failed_polls=15 srvnet_state='STATE : 3 STOP_PENDING'` |
| [32904946454](https://github.com/marmos91/dittofs/actions/runs/32904946454) | dispatch | `freed=False elapsed_ms=32480 failed_polls=15 srvnet_state='STATE : 3 STOP_PENDING'` |
| [32938264982](https://github.com/marmos91/dittofs/actions/runs/32938264982) | dispatch | `freed=False elapsed_ms=32265 failed_polls=15 srvnet_state='STATE : 3 STOP_PENDING'` |
| [32938261697](https://github.com/marmos91/dittofs/actions/runs/32938261697) | dispatch | `freed=False elapsed_ms=31556 failed_polls=15 srvnet_state='STATE : 3 STOP_PENDING'` |
| [32938256223](https://github.com/marmos91/dittofs/actions/runs/32938256223) | dispatch | `freed=False elapsed_ms=32347 failed_polls=15 srvnet_state='STATE : 3 STOP_PENDING'` |

Six give-ups, zero successes since instrumentation landed. (A seventh line in the
logs, `elapsed_ms=912 poll_iters=0`, came from the throwaway branch #2158 used to
force the success path with a faked port probe. It measures nothing.)

## Why counting those six is not enough, and what settles it

`elapsed_ms` is **right-censored on a give-up**. The loop stops at its own
deadline, so every give-up reports the deadline back — ~32s, always, however long
the stop would really have taken. A population of censored readings can never
show whether they were about to finish. Accumulating more of them, as the issue
proposed in step 2, would have produced more identical rows and no more
information.

So the reading came from watching the same stop past the point where the verdict
was already written, with nothing riding on the answer. Three runs, temporarily
instrumented on this branch:

```
srvnet-post-giveup freed_late=False extra_ms=61999 srvnet_state='STATE : 3 STOP_PENDING'
srvnet-post-giveup freed_late=False extra_ms=61324 srvnet_state='STATE : 3 STOP_PENDING'
srvnet-post-giveup freed_late=False extra_ms=62081 srvnet_state='STATE : 3 STOP_PENDING'
```

**~94 seconds total — over three times the current budget — and `srvnet` had not
advanced one state.** Not slow. Wedged, exactly as the issue's case 2 predicted.

Against that, the one known success in the record (job 97882736949, quoted in
#2154) released 445 in **~11s**, comfortably inside the existing 30s. So the two
populations are:

- **can stop** → finishes in ~11s, already well inside the budget;
- **cannot stop** → still `STOP_PENDING` at 94s, and no budget reaches it.

The wait is not the variable in either. Raising it would only make the skip path
slower to reach.

## What this PR contains

The temporary post-give-up watch was the instrument, not the product — keeping it
would burn a minute per give-up run forever to re-confirm a settled answer, which
is precisely the pattern #2154 was written to avoid. It is not in this diff.

What ships is the finding, recorded where the next person will hit it: a comment
on the loop saying the 15 x 2s is measured, with the numbers that measured it, so
"just make the flaky thing wait longer" does not get proposed again in three
months. Eight lines, no behaviour change.

`srvnet-stop-timing` from #2158 stays: it costs nothing and it is the ongoing
evidence of how often the skip path is taken.

## Sample sizes, stated plainly

- 6 instrumented give-ups (2 push-to-develop, 4 dispatch), all `STOP_PENDING` at ~32s.
- 3 post-give-up observations, all still `STOP_PENDING` at ~94s.
- 1 historical success at ~11s, from before instrumentation (#2154's own table).
- 0 successes observed since instrumentation landed.

All on `windows-2025-vs2026`.

## Scope, unchanged

This does not touch the gate from #2153. Some runners genuinely cannot release
445 without a reboot — which is now the measured explanation rather than a
suspicion — so the bind stays gated and the skip stays visible.

Closes #2154
