### PR TITLE
fix(nfs4): bind the client ID to the authenticating principal where the RFCs require it

### DIFF
--- a/internal/adapter/nfs/v4/handlers/client_principal_test.go
+++ b/internal/adapter/nfs/v4/handlers/client_principal_test.go
@@ -9,26 +9,8 @@ import (
 	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
 )
 
-// principalClientID registers a confirmed v4.0 client whose record carries
-// principal, the identity SETCLIENTID_CONFIRM was issued under.
-func principalClientID(t *testing.T, sm *state.StateManager, name, principal, addr string) uint64 {
-	t.Helper()
-
-	result, err := sm.SetClientID(name, [8]byte{1, 2, 3, 4, 5, 6, 7, 8}, state.CallbackInfo{
-		Program: 0x40000000,
-		NetID:   "tcp",
-		Addr:    "127.0.0.1.8.1",
-	}, addr, principal)
-	if err != nil {
-		t.Fatalf("SetClientID(%s): %v", name, err)
-	}
-	if err := sm.ConfirmClientID(result.ClientID, result.ConfirmVerifier); err != nil {
-		t.Fatalf("ConfirmClientID(%s): %v", name, err)
-	}
-	return result.ClientID
-}
-
-func openResult(fx *ioTestFixture, ctx *types.CompoundContext,
+// doOpen drives one OPEN through the handler and returns its raw result.
+func doOpen(fx *ioTestFixture, ctx *types.CompoundContext,
 	seqid uint32, clientID uint64, owner []byte, filename string, openType, shareAccess uint32,
 ) *types.CompoundResult {
 	args := encodeOpenArgs(seqid, shareAccess, types.OPEN4_SHARE_DENY_NONE,
@@ -43,7 +25,7 @@ func openStateid(t *testing.T, fx *ioTestFixture, ctx *types.CompoundContext,
 ) types.Stateid4 {
 	t.Helper()
 
-	result := openResult(fx, ctx, seqid, clientID, owner, filename, openType, shareAccess)
+	result := doOpen(fx, ctx, seqid, clientID, owner, filename, openType, shareAccess)
 	if result.Status != types.NFS4_OK {
 		t.Fatalf("OPEN status = %d, want NFS4_OK", result.Status)
 	}
@@ -80,7 +62,7 @@ func TestOpen_ClientIDSpansPrincipals(t *testing.T) {
 	fx := newIOTestFixture(t, "/export")
 	sm := fx.handler.StateManager
 
-	clientID := principalClientID(t, sm, "shared-client", "uid:1000", "10.0.0.1:1000")
+	clientID := testClientID(t, sm, "shared-client", "uid:1000")
 	owner := []byte("open-owner-1000")
 
 	// uid 1000 establishes the client ID and opens a file it owns.
@@ -92,13 +74,15 @@ func TestOpen_ClientIDSpansPrincipals(t *testing.T) {
 		t.Fatalf("ConfirmOpen: %v", err)
 	}
 
+	// A second user of the same client, under its own credential.
 	other := newRealFSContext(1001, 1001)
-	other.ClientAddr = "10.0.0.9:9999"
 	setCurrentFH(other, fx.rootHandle)
 
 	// The permission check is load-bearing: uid 1001 cannot write the file, and
 	// naming uid 1000's client ID and owner does not get it write access.
-	if status := openResult(fx, other, 3, clientID, owner, "victim.txt",
+	// checkOpenAccess refuses before the state layer sees the request, so seqid
+	// 3 is still unused when the read OPEN below presents it.
+	if status := doOpen(fx, other, 3, clientID, owner, "victim.txt",
 		types.OPEN4_NOCREATE, types.OPEN4_SHARE_ACCESS_BOTH).Status; status != types.NFS4ERR_ACCESS {
 		t.Errorf("OPEN for write by a uid without write permission: status = %d, want NFS4ERR_ACCESS", status)
 	}
@@ -119,7 +103,7 @@ func TestOpen_ClientIDSpansPrincipals(t *testing.T) {
 func TestRenew_PrincipalBinding(t *testing.T) {
 	t.Run("establishing principal is allowed", func(t *testing.T) {
 		fx := newIOTestFixture(t, "/export")
-		clientID := principalClientID(t, fx.handler.StateManager, "c", "uid:1000", "10.0.0.1:1000")
+		clientID := testClientID(t, fx.handler.StateManager, "c", "uid:1000")
 
 		if status := renewStatus(fx, newRealFSContext(1000, 1000), clientID); status != types.NFS4_OK {
 			t.Errorf("RENEW by the establishing principal: status = %d, want NFS4_OK", status)
@@ -128,7 +112,7 @@ func TestRenew_PrincipalBinding(t *testing.T) {
 
 	t.Run("stranger is refused", func(t *testing.T) {
 		fx := newIOTestFixture(t, "/export")
-		clientID := principalClientID(t, fx.handler.StateManager, "c", "uid:1000", "10.0.0.1:1000")
+		clientID := testClientID(t, fx.handler.StateManager, "c", "uid:1000")
 
 		if status := renewStatus(fx, newRealFSContext(1001, 1001), clientID); status != types.NFS4ERR_ACCESS {
 			t.Errorf("RENEW by a stranger: status = %d, want NFS4ERR_ACCESS", status)
@@ -139,7 +123,7 @@ func TestRenew_PrincipalBinding(t *testing.T) {
 		fx := newIOTestFixture(t, "/export")
 		sm := fx.handler.StateManager
 		// The client ID is established by uid 2000, which never opens anything.
-		clientID := principalClientID(t, sm, "c", "uid:2000", "10.0.0.1:1000")
+		clientID := testClientID(t, sm, "c", "uid:2000")
 
 		// uid 1000 is a second user of the same client, with its own owner.
 		// This is the multi-user mount the second algorithm exists for.
@@ -158,7 +142,7 @@ func TestRenew_PrincipalBinding(t *testing.T) {
 
 	t.Run("root is allowed", func(t *testing.T) {
 		fx := newIOTestFixture(t, "/export")
-		clientID := principalClientID(t, fx.handler.StateManager, "c", "uid:1000", "10.0.0.1:1000")
+		clientID := testClientID(t, fx.handler.StateManager, "c", "uid:1000")
 
 		if status := renewStatus(fx, newRealFSContext(0, 0), clientID); status != types.NFS4_OK {
 			t.Errorf("RENEW under the AUTH_SYS machine credential: status = %d, want NFS4_OK", status)
@@ -177,7 +161,7 @@ func TestRenew_PrincipalBinding(t *testing.T) {
 	t.Run("refused renew does not extend the lease", func(t *testing.T) {
 		fx := newIOTestFixture(t, "/export")
 		sm := fx.handler.StateManager
-		clientID := principalClientID(t, sm, "c", "uid:1000", "10.0.0.1:1000")
+		clientID := testClientID(t, sm, "c", "uid:1000")
 
 		before := sm.GetClient(clientID).LastRenewal
 		if status := renewStatus(fx, newRealFSContext(1001, 1001), clientID); status != types.NFS4ERR_ACCESS {
@@ -199,7 +183,7 @@ func TestSetClientID_IdentitylessCallerCannotTakeOver(t *testing.T) {
 	sm := fx.handler.StateManager
 
 	const name = "victim-client"
-	principalClientID(t, sm, name, "uid:1000", "10.0.0.1:1000")
+	testClientID(t, sm, name, "uid:1000")
 
 	cb := state.CallbackInfo{Program: 0x40000000, NetID: "tcp", Addr: "127.0.0.1.8.1"}
 

--- a/internal/adapter/nfs/v4/handlers/client_principal_test.go
+++ b/internal/adapter/nfs/v4/handlers/client_principal_test.go
@@ -28,6 +28,14 @@ func principalClientID(t *testing.T, sm *state.StateManager, name, principal, ad
 	return result.ClientID
 }
 
+func openResult(fx *ioTestFixture, ctx *types.CompoundContext,
+	seqid uint32, clientID uint64, owner []byte, filename string, openType, shareAccess uint32,
+) *types.CompoundResult {
+	args := encodeOpenArgs(seqid, shareAccess, types.OPEN4_SHARE_DENY_NONE,
+		clientID, owner, openType, types.UNCHECKED4, types.CLAIM_NULL, filename)
+	return fx.handler.handleOpen(ctx, bytes.NewReader(args))
+}
+
 // openStateid drives one OPEN through the handler and returns the stateid it
 // produced, failing the test if the OPEN itself was refused.
 func openStateid(t *testing.T, fx *ioTestFixture, ctx *types.CompoundContext,
@@ -35,10 +43,7 @@ func openStateid(t *testing.T, fx *ioTestFixture, ctx *types.CompoundContext,
 ) types.Stateid4 {
 	t.Helper()
 
-	args := encodeOpenArgs(seqid, shareAccess, types.OPEN4_SHARE_DENY_NONE,
-		clientID, owner, openType, types.UNCHECKED4, types.CLAIM_NULL, filename)
-
-	result := fx.handler.handleOpen(ctx, bytes.NewReader(args))
+	result := openResult(fx, ctx, seqid, clientID, owner, filename, openType, shareAccess)
 	if result.Status != types.NFS4_OK {
 		t.Fatalf("OPEN status = %d, want NFS4_OK", result.Status)
 	}
@@ -53,43 +58,158 @@ func openStateid(t *testing.T, fx *ioTestFixture, ctx *types.CompoundContext,
 	return *stateid
 }
 
-// TestOpen_ForeignPrincipalReusesClientOpenOwner reproduces the gap: a caller
-// authenticated as one uid presents another client's clientid and open-owner,
-// is handed that client's open stateid, and CLOSEs it.
-func TestOpen_ForeignPrincipalReusesClientOpenOwner(t *testing.T) {
+// renewStatus drives one RENEW for clientID as the caller ctx authenticates.
+func renewStatus(fx *ioTestFixture, ctx *types.CompoundContext, clientID uint64) uint32 {
+	var args bytes.Buffer
+	_ = xdr.WriteUint64(&args, clientID)
+	return fx.handler.handleRenew(ctx, bytes.NewReader(args.Bytes())).Status
+}
+
+// TestOpen_ClientIDSpansPrincipals records where the boundary actually sits for
+// an OPEN naming another principal's client ID and open-owner.
+//
+// A client ID covers every principal on the client, so the server does not, and
+// must not, refuse an OPEN because the caller is not the principal that
+// established the ID: RFC 7530 Section 3.1 has one connection multiplexing all
+// of a machine's users, Section 9.1.1 gives each of them their own owner under
+// the one ID, and neither Linux nfsd (struct nfs4_stateowner carries no
+// credential) nor nfs-ganesha compares one on OPEN. What stops a caller from
+// reaching a file it has no business in is the per-OPEN permission check, not
+// the state model -- so that check is what this pins.
+func TestOpen_ClientIDSpansPrincipals(t *testing.T) {
 	fx := newIOTestFixture(t, "/export")
 	sm := fx.handler.StateManager
 
-	clientID := principalClientID(t, sm, "victim-client", "uid:1000", "10.0.0.1:1000")
-	owner := []byte("victim-open-owner")
+	clientID := principalClientID(t, sm, "shared-client", "uid:1000", "10.0.0.1:1000")
+	owner := []byte("open-owner-1000")
 
-	// Victim (uid 1000, the principal that established the client ID) opens.
+	// uid 1000 establishes the client ID and opens a file it owns.
 	victim := newRealFSContext(1000, 1000)
 	setCurrentFH(victim, fx.rootHandle)
-	victimStateid := openStateid(t, fx, victim, 1, clientID, owner, "victim.txt", types.OPEN4_CREATE, types.OPEN4_SHARE_ACCESS_BOTH)
-
+	victimStateid := openStateid(t, fx, victim, 1, clientID, owner, "victim.txt",
+		types.OPEN4_CREATE, types.OPEN4_SHARE_ACCESS_BOTH)
 	if _, err := sm.ConfirmOpen(&victimStateid, 2); err != nil {
 		t.Fatalf("ConfirmOpen: %v", err)
 	}
 
-	// Attacker: different uid, different address, same clientid and open-owner.
-	attacker := newRealFSContext(1001, 1001)
-	attacker.ClientAddr = "10.0.0.9:9999"
-	setCurrentFH(attacker, fx.rootHandle)
-	stolen := openStateid(t, fx, attacker, 3, clientID, owner, "victim.txt", types.OPEN4_NOCREATE, types.OPEN4_SHARE_ACCESS_READ)
+	other := newRealFSContext(1001, 1001)
+	other.ClientAddr = "10.0.0.9:9999"
+	setCurrentFH(other, fx.rootHandle)
 
-	if stolen.Other != victimStateid.Other {
-		t.Fatalf("attacker got a distinct open state (%x vs %x); reproduction is not exercising the shared owner",
-			stolen.Other, victimStateid.Other)
+	// The permission check is load-bearing: uid 1001 cannot write the file, and
+	// naming uid 1000's client ID and owner does not get it write access.
+	if status := openResult(fx, other, 3, clientID, owner, "victim.txt",
+		types.OPEN4_NOCREATE, types.OPEN4_SHARE_ACCESS_BOTH).Status; status != types.NFS4ERR_ACCESS {
+		t.Errorf("OPEN for write by a uid without write permission: status = %d, want NFS4ERR_ACCESS", status)
 	}
 
-	// And it can release the victim's state.
-	closeArgs := encodeCloseArgs(4, &stolen)
-	closeResult := fx.handler.handleClose(attacker, bytes.NewReader(closeArgs))
-	if closeResult.Status != types.NFS4_OK {
-		t.Fatalf("CLOSE status = %d, want NFS4_OK", closeResult.Status)
+	// Read access it does have, and there it joins the existing open state --
+	// the documented shape of a shared client ID, not a defect.
+	shared := openStateid(t, fx, other, 3, clientID, owner, "victim.txt",
+		types.OPEN4_NOCREATE, types.OPEN4_SHARE_ACCESS_READ)
+	if shared.Other != victimStateid.Other {
+		t.Errorf("second principal got a distinct open state (%x vs %x)", shared.Other, victimStateid.Other)
 	}
-	if sm.GetOpenState(victimStateid.Other) != nil {
-		t.Fatal("victim open state survived the foreign-principal CLOSE")
+}
+
+// TestRenew_PrincipalBinding covers RFC 7530 Section 16.28.5, which permits a
+// RENEW only from the principal that established the client ID via
+// SETCLIENTID_CONFIRM or from one that currently holds an OPEN under it, and
+// requires NFS4ERR_ACCESS for anyone else.
+func TestRenew_PrincipalBinding(t *testing.T) {
+	t.Run("establishing principal is allowed", func(t *testing.T) {
+		fx := newIOTestFixture(t, "/export")
+		clientID := principalClientID(t, fx.handler.StateManager, "c", "uid:1000", "10.0.0.1:1000")
+
+		if status := renewStatus(fx, newRealFSContext(1000, 1000), clientID); status != types.NFS4_OK {
+			t.Errorf("RENEW by the establishing principal: status = %d, want NFS4_OK", status)
+		}
+	})
+
+	t.Run("stranger is refused", func(t *testing.T) {
+		fx := newIOTestFixture(t, "/export")
+		clientID := principalClientID(t, fx.handler.StateManager, "c", "uid:1000", "10.0.0.1:1000")
+
+		if status := renewStatus(fx, newRealFSContext(1001, 1001), clientID); status != types.NFS4ERR_ACCESS {
+			t.Errorf("RENEW by a stranger: status = %d, want NFS4ERR_ACCESS", status)
+		}
+	})
+
+	t.Run("principal holding an open is allowed", func(t *testing.T) {
+		fx := newIOTestFixture(t, "/export")
+		sm := fx.handler.StateManager
+		// The client ID is established by uid 2000, which never opens anything.
+		clientID := principalClientID(t, sm, "c", "uid:2000", "10.0.0.1:1000")
+
+		// uid 1000 is a second user of the same client, with its own owner.
+		// This is the multi-user mount the second algorithm exists for.
+		user := newRealFSContext(1000, 1000)
+		setCurrentFH(user, fx.rootHandle)
+		stateid := openStateid(t, fx, user, 1, clientID, []byte("open-owner-1000"), "u1000.txt",
+			types.OPEN4_CREATE, types.OPEN4_SHARE_ACCESS_BOTH)
+		if _, err := sm.ConfirmOpen(&stateid, 2); err != nil {
+			t.Fatalf("ConfirmOpen: %v", err)
+		}
+
+		if status := renewStatus(fx, user, clientID); status != types.NFS4_OK {
+			t.Errorf("RENEW by a principal holding an open: status = %d, want NFS4_OK", status)
+		}
+	})
+
+	t.Run("root is allowed", func(t *testing.T) {
+		fx := newIOTestFixture(t, "/export")
+		clientID := principalClientID(t, fx.handler.StateManager, "c", "uid:1000", "10.0.0.1:1000")
+
+		if status := renewStatus(fx, newRealFSContext(0, 0), clientID); status != types.NFS4_OK {
+			t.Errorf("RENEW under the AUTH_SYS machine credential: status = %d, want NFS4_OK", status)
+		}
+	})
+
+	t.Run("record with no principal accepts any caller", func(t *testing.T) {
+		fx := newIOTestFixture(t, "/export")
+		clientID := testClientID(t, fx.handler.StateManager, "no-principal")
+
+		if status := renewStatus(fx, newRealFSContext(1001, 1001), clientID); status != types.NFS4_OK {
+			t.Errorf("RENEW against a record with no stored principal: status = %d, want NFS4_OK", status)
+		}
+	})
+
+	t.Run("refused renew does not extend the lease", func(t *testing.T) {
+		fx := newIOTestFixture(t, "/export")
+		sm := fx.handler.StateManager
+		clientID := principalClientID(t, sm, "c", "uid:1000", "10.0.0.1:1000")
+
+		before := sm.GetClient(clientID).LastRenewal
+		if status := renewStatus(fx, newRealFSContext(1001, 1001), clientID); status != types.NFS4ERR_ACCESS {
+			t.Fatalf("RENEW by a stranger: status = %d, want NFS4ERR_ACCESS", status)
+		}
+		if after := sm.GetClient(clientID).LastRenewal; !after.Equal(before) {
+			t.Errorf("refused RENEW moved LastRenewal %v -> %v", before, after)
+		}
+	})
+}
+
+// TestSetClientID_IdentitylessCallerCannotTakeOver covers the half of RFC 7530
+// Section 9.1.1 / Section 19 that a "both principals non-empty" comparison
+// leaves open: neither SETCLIENTID nor SETCLIENTID_CONFIRM carries a filehandle,
+// so an export's sec= policy never sees them, and a caller that simply omits a
+// credential must not thereby clear the bar.
+func TestSetClientID_IdentitylessCallerCannotTakeOver(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+	sm := fx.handler.StateManager
+
+	const name = "victim-client"
+	principalClientID(t, sm, name, "uid:1000", "10.0.0.1:1000")
+
+	cb := state.CallbackInfo{Program: 0x40000000, NetID: "tcp", Addr: "127.0.0.1.8.1"}
+
+	// A reboot claim (different verifier) under no credential at all.
+	if _, err := sm.SetClientID(name, [8]byte{9, 9, 9, 9, 9, 9, 9, 9}, cb, "10.0.0.9:9999", ""); err != state.ErrClientIDInUse {
+		t.Errorf("SETCLIENTID reboot claim with no principal: got %v, want ErrClientIDInUse", err)
+	}
+
+	// And the same-verifier re-SETCLIENTID path.
+	if _, err := sm.SetClientID(name, [8]byte{1, 2, 3, 4, 5, 6, 7, 8}, cb, "10.0.0.9:9999", ""); err != state.ErrClientIDInUse {
+		t.Errorf("re-SETCLIENTID with no principal: got %v, want ErrClientIDInUse", err)
 	}
 }

--- a/internal/adapter/nfs/v4/handlers/client_principal_test.go
+++ b/internal/adapter/nfs/v4/handlers/client_principal_test.go
@@ -140,12 +140,27 @@ func TestRenew_PrincipalBinding(t *testing.T) {
 		}
 	})
 
-	t.Run("root is allowed", func(t *testing.T) {
+	t.Run("machine credential that established the ID is allowed", func(t *testing.T) {
+		fx := newIOTestFixture(t, "/export")
+		// What a Linux client does: SETCLIENTID_CONFIRM and RENEW both under
+		// the machine credential, which for AUTH_SYS is uid 0.
+		clientID := testClientID(t, fx.handler.StateManager, "c", "uid:0")
+
+		if status := renewStatus(fx, newRealFSContext(0, 0), clientID); status != types.NFS4_OK {
+			t.Errorf("RENEW under the establishing machine credential: status = %d, want NFS4_OK", status)
+		}
+	})
+
+	t.Run("root is refused against another principal's record", func(t *testing.T) {
 		fx := newIOTestFixture(t, "/export")
 		clientID := testClientID(t, fx.handler.StateManager, "c", "uid:1000")
 
-		if status := renewStatus(fx, newRealFSContext(0, 0), clientID); status != types.NFS4_OK {
-			t.Errorf("RENEW under the AUTH_SYS machine credential: status = %d, want NFS4_OK", status)
+		// Principal() cannot tell a verified machine credential from an
+		// AUTH_SYS caller that simply wrote uid 0 into its credential, and
+		// RENEW carries no filehandle for an export's sec= policy to judge, so
+		// uid 0 gets no standing it has not earned on this record.
+		if status := renewStatus(fx, newRealFSContext(0, 0), clientID); status != types.NFS4ERR_ACCESS {
+			t.Errorf("RENEW as uid 0 against a uid:1000 record: status = %d, want NFS4ERR_ACCESS", status)
 		}
 	})
 

--- a/internal/adapter/nfs/v4/handlers/client_principal_test.go
+++ b/internal/adapter/nfs/v4/handlers/client_principal_test.go
@@ -1,0 +1,95 @@
+package handlers
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/state"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+)
+
+// principalClientID registers a confirmed v4.0 client whose record carries
+// principal, the identity SETCLIENTID_CONFIRM was issued under.
+func principalClientID(t *testing.T, sm *state.StateManager, name, principal, addr string) uint64 {
+	t.Helper()
+
+	result, err := sm.SetClientID(name, [8]byte{1, 2, 3, 4, 5, 6, 7, 8}, state.CallbackInfo{
+		Program: 0x40000000,
+		NetID:   "tcp",
+		Addr:    "127.0.0.1.8.1",
+	}, addr, principal)
+	if err != nil {
+		t.Fatalf("SetClientID(%s): %v", name, err)
+	}
+	if err := sm.ConfirmClientID(result.ClientID, result.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID(%s): %v", name, err)
+	}
+	return result.ClientID
+}
+
+// openStateid drives one OPEN through the handler and returns the stateid it
+// produced, failing the test if the OPEN itself was refused.
+func openStateid(t *testing.T, fx *ioTestFixture, ctx *types.CompoundContext,
+	seqid uint32, clientID uint64, owner []byte, filename string, openType, shareAccess uint32,
+) types.Stateid4 {
+	t.Helper()
+
+	args := encodeOpenArgs(seqid, shareAccess, types.OPEN4_SHARE_DENY_NONE,
+		clientID, owner, openType, types.UNCHECKED4, types.CLAIM_NULL, filename)
+
+	result := fx.handler.handleOpen(ctx, bytes.NewReader(args))
+	if result.Status != types.NFS4_OK {
+		t.Fatalf("OPEN status = %d, want NFS4_OK", result.Status)
+	}
+	reader := bytes.NewReader(result.Data)
+	if status, _ := xdr.DecodeUint32(reader); status != types.NFS4_OK {
+		t.Fatalf("encoded OPEN status = %d, want NFS4_OK", status)
+	}
+	stateid, err := types.DecodeStateid4(reader)
+	if err != nil {
+		t.Fatalf("decode stateid: %v", err)
+	}
+	return *stateid
+}
+
+// TestOpen_ForeignPrincipalReusesClientOpenOwner reproduces the gap: a caller
+// authenticated as one uid presents another client's clientid and open-owner,
+// is handed that client's open stateid, and CLOSEs it.
+func TestOpen_ForeignPrincipalReusesClientOpenOwner(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+	sm := fx.handler.StateManager
+
+	clientID := principalClientID(t, sm, "victim-client", "uid:1000", "10.0.0.1:1000")
+	owner := []byte("victim-open-owner")
+
+	// Victim (uid 1000, the principal that established the client ID) opens.
+	victim := newRealFSContext(1000, 1000)
+	setCurrentFH(victim, fx.rootHandle)
+	victimStateid := openStateid(t, fx, victim, 1, clientID, owner, "victim.txt", types.OPEN4_CREATE, types.OPEN4_SHARE_ACCESS_BOTH)
+
+	if _, err := sm.ConfirmOpen(&victimStateid, 2); err != nil {
+		t.Fatalf("ConfirmOpen: %v", err)
+	}
+
+	// Attacker: different uid, different address, same clientid and open-owner.
+	attacker := newRealFSContext(1001, 1001)
+	attacker.ClientAddr = "10.0.0.9:9999"
+	setCurrentFH(attacker, fx.rootHandle)
+	stolen := openStateid(t, fx, attacker, 3, clientID, owner, "victim.txt", types.OPEN4_NOCREATE, types.OPEN4_SHARE_ACCESS_READ)
+
+	if stolen.Other != victimStateid.Other {
+		t.Fatalf("attacker got a distinct open state (%x vs %x); reproduction is not exercising the shared owner",
+			stolen.Other, victimStateid.Other)
+	}
+
+	// And it can release the victim's state.
+	closeArgs := encodeCloseArgs(4, &stolen)
+	closeResult := fx.handler.handleClose(attacker, bytes.NewReader(closeArgs))
+	if closeResult.Status != types.NFS4_OK {
+		t.Fatalf("CLOSE status = %d, want NFS4_OK", closeResult.Status)
+	}
+	if sm.GetOpenState(victimStateid.Other) != nil {
+		t.Fatal("victim open state survived the foreign-principal CLOSE")
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/io_test.go
+++ b/internal/adapter/nfs/v4/handlers/io_test.go
@@ -327,14 +327,17 @@ func encodeCommitArgs(offset uint64, count uint32) []byte {
 // OPEN rejects a clientid that never completed SETCLIENTID /
 // SETCLIENTID_CONFIRM, so tests that drive OPEN must present an established
 // client rather than an arbitrary number. Distinct names give distinct clients.
-func testClientID(t *testing.T, sm *state.StateManager, name string) uint64 {
+//
+// The optional principal is the identity SETCLIENTID_CONFIRM is issued under;
+// omitting it registers a client whose record carries no principal.
+func testClientID(t *testing.T, sm *state.StateManager, name string, principal ...string) uint64 {
 	t.Helper()
 
 	result, err := sm.SetClientID(name, [8]byte{1, 2, 3, 4, 5, 6, 7, 8}, state.CallbackInfo{
 		Program: 0x40000000,
 		NetID:   "tcp",
 		Addr:    "127.0.0.1.8.1",
-	}, "127.0.0.1:1234")
+	}, "127.0.0.1:1234", principal...)
 	if err != nil {
 		t.Fatalf("SetClientID(%s): %v", name, err)
 	}

--- a/internal/adapter/nfs/v4/handlers/open.go
+++ b/internal/adapter/nfs/v4/handlers/open.go
@@ -473,6 +473,7 @@ func (h *Handler) handleOpenClaimNull(
 		[]byte(fileHandle),
 		shareAccess, shareDeny,
 		claimType,
+		ctx.Principal(),
 	)
 	if stateErr != nil {
 		return openError(mapStateError(stateErr))
@@ -573,6 +574,7 @@ func (h *Handler) handleOpenClaimFH(
 		[]byte(fileHandle),
 		shareAccess, shareDeny,
 		claimType,
+		ctx.Principal(),
 	)
 	if stateErr != nil {
 		return openError(mapStateError(stateErr))
@@ -651,6 +653,7 @@ func (h *Handler) handleOpenClaimPrevious(
 		fileHandle,
 		shareAccess, shareDeny,
 		claimType,
+		ctx.Principal(),
 	)
 	if stateErr != nil {
 		nfsStatus := mapStateError(stateErr)
@@ -911,6 +914,7 @@ func (h *Handler) handleOpenClaimDelegateCur(
 		[]byte(fileHandle),
 		shareAccess, shareDeny,
 		types.CLAIM_DELEGATE_CUR,
+		ctx.Principal(),
 	)
 	if stateErr != nil {
 		return openError(mapStateError(stateErr))

--- a/internal/adapter/nfs/v4/handlers/renew.go
+++ b/internal/adapter/nfs/v4/handlers/renew.go
@@ -8,11 +8,11 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// handleRenew implements the RENEW operation (RFC 7530 Section 16.30).
+// handleRenew implements the RENEW operation (RFC 7530 Section 16.28).
 // Renews the lease associated with a client ID to prevent state expiration.
 // Delegates to StateManager.RenewLease for client validation and lease refresh.
 // Extends client lease timer; no file or directory state changes.
-// Errors: NFS4ERR_STALE_CLIENTID, NFS4ERR_EXPIRED, NFS4ERR_BADXDR.
+// Errors: NFS4ERR_STALE_CLIENTID, NFS4ERR_EXPIRED, NFS4ERR_ACCESS, NFS4ERR_BADXDR.
 func (h *Handler) handleRenew(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
 	// Read clientid (uint64)
 	clientID, err := xdr.DecodeUint64(reader)
@@ -25,7 +25,7 @@ func (h *Handler) handleRenew(ctx *types.CompoundContext, reader io.Reader) *typ
 	}
 
 	// Delegate to StateManager for validation and lease renewal
-	if err := h.StateManager.RenewLease(clientID); err != nil {
+	if err := h.StateManager.RenewLease(clientID, ctx.Principal()); err != nil {
 		nfsStatus := mapStateError(err)
 		logger.Info("NFSv4 RENEW failed",
 			"client_id", clientID,

--- a/internal/adapter/nfs/v4/state/client.go
+++ b/internal/adapter/nfs/v4/state/client.go
@@ -25,10 +25,6 @@ var ErrClientIDInUse = errors.New("client ID in use")
 // 16.28.5). Maps to NFS4ERR_ACCESS (13).
 var ErrRenewAccess = errors.New("renew principal not permitted for this client ID")
 
-// rootPrincipal is Principal()'s rendering of AUTH_SYS uid 0, the credential
-// the Linux client uses for client-ID and lease maintenance.
-const rootPrincipal = "uid:0"
-
 // principalHijacks reports whether a request carrying incoming may take over a
 // client record established by stored.
 //

--- a/internal/adapter/nfs/v4/state/client.go
+++ b/internal/adapter/nfs/v4/state/client.go
@@ -20,6 +20,38 @@ var ErrStaleClientID = errors.New("stale client ID")
 // Maps to NFS4ERR_CLID_INUSE (10017).
 var ErrClientIDInUse = errors.New("client ID in use")
 
+// ErrRenewAccess indicates a RENEW arrived under a principal that neither
+// established the client ID nor holds an open under it (RFC 7530 Section
+// 16.28.5). Maps to NFS4ERR_ACCESS (13).
+var ErrRenewAccess = errors.New("renew principal not permitted for this client ID")
+
+// rootPrincipal is Principal()'s rendering of AUTH_SYS uid 0, the credential
+// the Linux client uses for client-ID and lease maintenance.
+const rootPrincipal = "uid:0"
+
+// principalHijacks reports whether a request carrying incoming may take over a
+// client record established by stored.
+//
+// RFC 7530 Section 19 requires the principal on SETCLIENTID and
+// SETCLIENTID_CONFIRM to be "checked against and matched with the previous use
+// of these operations", because those are the operations that release a
+// client's state; Section 9.1.1 states the rule as a MUST NOT on cancelling
+// leased state established by a different principal. RFC 8881 Section 18.35.4
+// case 9 is the same rule for EXCHANGE_ID.
+//
+// A request that carries no identity at all does not match a record that has
+// one. Admitting it would leave the guard reachable only by callers that
+// volunteer a credential: a client ID established under Kerberos would be
+// takeable by an AUTH_NONE caller, and neither SETCLIENTID nor
+// SETCLIENTID_CONFIRM carries a filehandle, so an export's sec= policy never
+// sees the request.
+//
+// A record with no stored principal stays open: it was established without an
+// identity, and there is nothing to check a later request against.
+func principalHijacks(stored, incoming string) bool {
+	return stored != "" && stored != incoming
+}
+
 // ============================================================================
 // Client Record
 // ============================================================================

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -432,11 +432,10 @@ func (sm *StateManager) createNewClient(clientIDStr string, verifier [8]byte, ca
 // unconfirmed record that will replace the confirmed one when confirmed.
 // Caller must hold sm.mu.
 func (sm *StateManager) reuseConfirmedClient(confirmed *ClientRecord, clientIDStr string, verifier [8]byte, callback CallbackInfo, clientAddr, principal string) (*SetClientIDResult, error) {
-	// RFC 7530 Section 9.1.1: if the confirmed record was established by a
-	// principal and this request carries a different non-empty principal,
-	// reject with NFS4ERR_CLID_INUSE. Prevents a third party that knows the
-	// client ID string + verifier from hijacking the client's lease/state.
-	if confirmed.Principal != "" && principal != "" && confirmed.Principal != principal {
+	// Reject a re-SETCLIENTID by anyone but the principal that established the
+	// confirmed record: it would hijack the client's lease and state. See
+	// principalHijacks.
+	if principalHijacks(confirmed.Principal, principal) {
 		return nil, ErrClientIDInUse
 	}
 
@@ -488,11 +487,11 @@ func (sm *StateManager) reuseConfirmedClient(confirmed *ClientRecord, clientIDSt
 // the new one is confirmed in SETCLIENTID_CONFIRM.
 // Caller must hold sm.mu.
 func (sm *StateManager) handleClientReboot(clientIDStr string, verifier [8]byte, callback CallbackInfo, clientAddr, principal string) (*SetClientIDResult, error) {
-	// RFC 7530 Section 9.1.1: a reboot (different verifier) from a different
-	// non-empty principal than the confirmed record is a hijack attempt, not a
-	// real reboot. Reject with NFS4ERR_CLID_INUSE.
+	// A reboot (different verifier) claimed by anyone but the principal that
+	// established the confirmed record is a hijack attempt, not a real reboot.
+	// See principalHijacks.
 	if confirmed := sm.clientsByName[clientIDStr]; confirmed != nil {
-		if confirmed.Principal != "" && principal != "" && confirmed.Principal != principal {
+		if principalHijacks(confirmed.Principal, principal) {
 			return nil, ErrClientIDInUse
 		}
 	}
@@ -1118,6 +1117,7 @@ func (sm *StateManager) OpenFile(
 	fileHandle []byte,
 	shareAccess, shareDeny uint32,
 	claimType uint32,
+	principal ...string,
 ) (result *OpenFileResult, err error) {
 	// Grace period checks (before acquiring sm.mu)
 	switch claimType {
@@ -1171,6 +1171,7 @@ func (sm *StateManager) OpenFile(
 	// Look up or create the open-owner
 	ownerKey := makeOwnerKey(clientID, ownerData)
 	owner, ownerExists := sm.openOwners[ownerKey]
+	princ := firstOrEmpty(principal)
 
 	if ownerExists {
 		// Existing owner: validate seqid
@@ -1201,6 +1202,13 @@ func (sm *StateManager) OpenFile(
 		owner = &OpenOwner{
 			ClientID:  clientID,
 			OwnerData: make([]byte, len(ownerData)),
+			// ponytail: recorded once, at the OPEN that creates the owner,
+			// rather than per open state as FreeBSD's ls_uid is. Every client
+			// that matters keys its open-owners by credential (Linux
+			// nfs4_get_state_owner takes the cred), so one principal per owner
+			// holds; track it per OpenState only if a client turns up that
+			// shares an owner across users.
+			Principal: princ,
 
 			Confirmed:    false,
 			OpenStates:   make([]*OpenState, 0),
@@ -1811,16 +1819,58 @@ func (sm *StateManager) GetOpenState(other [types.NFS4_OTHER_SIZE]byte) *OpenSta
 // Lease Operations (, Task 4)
 // ============================================================================
 
+// renewPrincipalAllowed reports whether principal may renew record's lease.
+//
+// RFC 7530 Section 16.28.5 names exactly two permitted callers: the principal
+// that established the client ID via SETCLIENTID_CONFIRM, and any principal
+// that currently has an OPEN file on the server under that client ID. A RENEW
+// from anyone else "MUST" be rejected with NFS4ERR_ACCESS -- without which any
+// caller that has seen a clientid on the wire can hold a lease, and the state
+// it anchors, open indefinitely.
+//
+// The second caller is what keeps a multi-user mount working: one client ID
+// covers every user on the client, and the RFC expects a lease held on behalf
+// of all of them to be renewable by any of them.
+//
+// Two callers are admitted that the RFC does not name:
+//
+//   - A record with no principal recorded. SETCLIENTID under AUTH_NONE stores
+//     no identity, and there is nothing to compare a later RENEW against.
+//   - uid 0. The Linux client sends SETCLIENTID_CONFIRM and RENEW under a
+//     machine credential, which for AUTH_SYS is uid 0; a client that instead
+//     established the ID as a user and renews as root would otherwise stall.
+//     RFC 7530 speaks of principals and says nothing about AUTH_SYS uids, and
+//     FreeBSD's server carries the same exemption for the same reason.
+//
+// Caller must hold sm.mu.
+func renewPrincipalAllowed(record *ClientRecord, principal string) bool {
+	if record.Principal == "" || principal == record.Principal || principal == rootPrincipal {
+		return true
+	}
+	for _, owner := range record.OpenOwners {
+		if owner.Principal == principal && len(owner.OpenStates) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // RenewLease implements the RENEW operation's state management.
 //
-// Per RFC 7530 Section 16.29:
+// Per RFC 7530 Section 16.28:
 //   - Validates the client ID exists and is confirmed
+//   - Validates the caller may renew this client's lease (Section 16.28.5)
 //   - Resets the lease timer and updates LastRenewal
 //   - Returns ErrStaleClientID if client is unknown or unconfirmed
 //   - Returns NFS4ERR_EXPIRED if the lease has already expired
+//   - Returns NFS4ERR_ACCESS if the caller is not one of the principals
+//     Section 16.28.5 permits
+//
+// The trailing principal is variadic so callers and tests that do not thread an
+// auth principal keep compiling; production passes ctx.Principal().
 //
 // Caller must NOT hold sm.mu.
-func (sm *StateManager) RenewLease(clientID uint64) error {
+func (sm *StateManager) RenewLease(clientID uint64, principal ...string) error {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
@@ -1828,6 +1878,16 @@ func (sm *StateManager) RenewLease(clientID uint64) error {
 	record, exists := sm.clientsByID[clientID]
 	if !exists {
 		return ErrStaleClientID
+	}
+
+	// Checked before the renewal below: a refused RENEW must leave the lease
+	// exactly where it was, or the rejection still hands the caller the effect
+	// it asked for.
+	if !renewPrincipalAllowed(record, firstOrEmpty(principal)) {
+		logger.Info("RenewLease: refusing RENEW from a principal that neither established the client ID nor holds an open",
+			"client_id", clientID,
+			"client_id_str", record.ClientIDString)
+		return ErrRenewAccess
 	}
 
 	if err := renewConfirmedClient(record.Confirmed, record.Lease, &record.LastRenewal); err != nil {

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -1891,9 +1891,6 @@ func (sm *StateManager) RenewLease(clientID uint64, principal ...string) error {
 	// exactly where it was, or the rejection still hands the caller the effect
 	// it asked for.
 	if !renewPrincipalAllowed(record, firstOrEmpty(principal)) {
-		logger.Info("RenewLease: refusing RENEW from a principal that neither established the client ID nor holds an open",
-			"client_id", clientID,
-			"client_id_str", record.ClientIDString)
 		return ErrRenewAccess
 	}
 

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -1823,9 +1823,13 @@ func (sm *StateManager) GetOpenState(other [types.NFS4_OTHER_SIZE]byte) *OpenSta
 // RFC 7530 Section 16.28.5 names exactly two permitted callers: the principal
 // that established the client ID via SETCLIENTID_CONFIRM, and any principal
 // that currently has an OPEN file on the server under that client ID. A RENEW
-// from anyone else "MUST" be rejected with NFS4ERR_ACCESS -- without which any
-// caller that has seen a clientid on the wire can hold a lease, and the state
-// it anchors, open indefinitely.
+// from anyone else MUST be rejected with NFS4ERR_ACCESS.
+//
+// This does not put the lease out of a stranger's reach, and is not meant to.
+// Section 9.5 has DELEGPURGE, LOCK, LOCKT, OPEN and RELEASE_LOCKOWNER renew
+// every lease of the client whose clientid they carry, with no principal
+// restriction -- ValidateAndRenewClient does that on the OPEN path. The
+// restriction is scoped to the one operation whose only effect is the renewal.
 //
 // The second caller is what keeps a multi-user mount working: one client ID
 // covers every user on the client, and the RFC expects a lease held on behalf

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -1171,7 +1171,6 @@ func (sm *StateManager) OpenFile(
 	// Look up or create the open-owner
 	ownerKey := makeOwnerKey(clientID, ownerData)
 	owner, ownerExists := sm.openOwners[ownerKey]
-	princ := firstOrEmpty(principal)
 
 	if ownerExists {
 		// Existing owner: validate seqid
@@ -1208,7 +1207,7 @@ func (sm *StateManager) OpenFile(
 			// nfs4_get_state_owner takes the cred), so one principal per owner
 			// holds; track it per OpenState only if a client turns up that
 			// shares an owner across users.
-			Principal: princ,
+			Principal: firstOrEmpty(principal),
 
 			Confirmed:    false,
 			OpenStates:   make([]*OpenState, 0),

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -1835,19 +1835,23 @@ func (sm *StateManager) GetOpenState(other [types.NFS4_OTHER_SIZE]byte) *OpenSta
 // covers every user on the client, and the RFC expects a lease held on behalf
 // of all of them to be renewable by any of them.
 //
-// Two callers are admitted that the RFC does not name:
+// One caller is admitted that the RFC does not name: a record with no
+// principal recorded. SETCLIENTID under AUTH_NONE stores no identity, and there
+// is nothing to compare a later RENEW against.
 //
-//   - A record with no principal recorded. SETCLIENTID under AUTH_NONE stores
-//     no identity, and there is nothing to compare a later RENEW against.
-//   - uid 0. The Linux client sends SETCLIENTID_CONFIRM and RENEW under a
-//     machine credential, which for AUTH_SYS is uid 0; a client that instead
-//     established the ID as a user and renews as root would otherwise stall.
-//     RFC 7530 speaks of principals and says nothing about AUTH_SYS uids, and
-//     FreeBSD's server carries the same exemption for the same reason.
+// Root gets no exemption. It would have to be an exemption for the string
+// "uid:0" rather than for a verified machine credential, because Principal()
+// renders a GSS-resolved uid and a client-asserted AUTH_SYS uid identically and
+// RENEW carries no filehandle for an export's sec= policy to judge -- so it
+// would hand any AUTH_SYS peer claiming uid 0 the lease of a client established
+// under Kerberos. Nothing needs it: the Linux client renews under the same
+// machine credential it established the client ID with, so the equality above
+// already matches, and a client that falls back to a state owner's credential
+// is covered by the open-holder scan below.
 //
 // Caller must hold sm.mu.
 func renewPrincipalAllowed(record *ClientRecord, principal string) bool {
-	if record.Principal == "" || principal == record.Principal || principal == rootPrincipal {
+	if record.Principal == "" || principal == record.Principal {
 		return true
 	}
 	for _, owner := range record.OpenOwners {

--- a/internal/adapter/nfs/v4/state/openowner.go
+++ b/internal/adapter/nfs/v4/state/openowner.go
@@ -155,6 +155,18 @@ type OpenOwner struct {
 	// OwnerData is the opaque owner identifier from the client.
 	OwnerData []byte
 
+	// Principal is the authenticated identity that opened under this owner, as
+	// CompoundContext.Principal() renders it, or empty when the OPEN carried no
+	// identity.
+	//
+	// It is not an admission check on OPEN: a client ID spans every principal
+	// on the client, and no operation that carries a filehandle binds to one
+	// (RFC 8881 Section 18.35.3 warns clients off enforcing on such operations
+	// for exactly that reason). It exists for RENEW, whose second permitted
+	// principal is "any principal that currently has an OPEN file on the
+	// server" (RFC 7530 Section 16.28.5).
+	Principal string
+
 	// ownerSeq carries this owner's seqid sequence and replay cache.
 	ownerSeq
 

--- a/internal/adapter/nfs/v4/state/stateid_authz_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_authz_test.go
@@ -295,10 +295,12 @@ func TestExchangeID_Case2_PrincipalMismatch(t *testing.T) {
 		t.Fatalf("idempotent EXCHANGE_ID by owning principal: %v", err)
 	}
 
-	// An idempotent call with no principal (e.g. AUTH_NONE) must not clear the
-	// stored principal — otherwise the hijack guard could be reset.
-	if _, err := sm.ExchangeID(ownerID, verifier, 0, nil, "10.0.0.1:12345"); err != nil {
-		t.Fatalf("idempotent EXCHANGE_ID with empty principal: %v", err)
+	// A call carrying no principal at all (AUTH_NONE) is a caller that has not
+	// shown it is alice, so it is refused like any other non-alice caller.
+	// EXCHANGE_ID carries no filehandle, so an export's sec= policy never sees
+	// it and cannot refuse it first.
+	if _, err := sm.ExchangeID(ownerID, verifier, 0, nil, "10.0.0.9:12345"); err != ErrClientIDInUse {
+		t.Errorf("EXCHANGE_ID with empty principal: got %v, want ErrClientIDInUse", err)
 	}
 	sm.mu.RLock()
 	rec = sm.v41ClientsByOwner[string(ownerID)]

--- a/internal/adapter/nfs/v4/state/v41_client.go
+++ b/internal/adapter/nfs/v4/state/v41_client.go
@@ -197,13 +197,13 @@ func (sm *StateManager) ExchangeID(
 
 	case existing.Verifier == verifier:
 		// Case 2: Same owner + same verifier -- idempotent return.
-		// RFC 8881 Section 18.35.4: if the existing record was established by a
-		// principal and this request carries a different non-empty principal,
-		// reject with NFS4ERR_CLID_INUSE (mirrors the v4.0 SETCLIENTID Case 5
-		// guard in reuseConfirmedClient). Without this a third party that knows
-		// a confirmed client's co_ownerid + co_verifier could overwrite the
-		// stored principal and hijack the client's lease/state.
-		if existing.Principal != "" && princ != "" && existing.Principal != princ {
+		// Reject an EXCHANGE_ID by anyone but the principal that established the
+		// existing record (RFC 8881 Section 18.35.4 case 9; mirrors the v4.0
+		// SETCLIENTID guard in reuseConfirmedClient). Without it a third party
+		// that knows a confirmed client's co_ownerid + co_verifier overwrites
+		// the stored principal and hijacks the client's lease and state. See
+		// principalHijacks.
+		if principalHijacks(existing.Principal, princ) {
 			return nil, ErrClientIDInUse
 		}
 		existing.ClientAddr = clientAddr

--- a/internal/adapter/nfs/v4/types/types.go
+++ b/internal/adapter/nfs/v4/types/types.go
@@ -153,10 +153,17 @@ type CompoundContext struct {
 	MinorVersionAccepted bool
 }
 
-// Principal returns a best-effort string identity of the authenticated caller,
-// used as a lease-stealing guard in durable client-recovery records. For
-// AUTH_UNIX it is "uid:N"; otherwise "" (the GSS principal is not threaded onto
-// the compound context today). It is informational, not an authorization input.
+// Principal returns a string identity for the authenticated caller: "uid:N" for
+// AUTH_UNIX and for RPCSEC_GSS, whose principal is resolved to a uid before it
+// reaches here, and "" for AUTH_NONE. The GSS principal itself is not threaded
+// onto the compound context, so two Kerberos principals mapping to one uid are
+// one identity here, and under AUTH_SYS the value is only what the client
+// claimed.
+//
+// It binds a client ID to the identity that established it: the SETCLIENTID and
+// EXCHANGE_ID takeover guards, and the RENEW check of RFC 7530 Section 16.28.5.
+// Those are lease and client-record decisions; per-file access is decided by the
+// AuthContext the operation carries, never by this.
 func (c *CompoundContext) Principal() string {
 	if c.UID != nil {
 		return fmt.Sprintf("uid:%d", *c.UID)

--- a/internal/adapter/nfs/v4/v41/handlers/deps.go
+++ b/internal/adapter/nfs/v4/v41/handlers/deps.go
@@ -35,6 +35,8 @@ func MapStateError(err error) uint32 {
 		return types.NFS4ERR_STALE_CLIENTID
 	case errors.Is(err, state.ErrClientIDInUse):
 		return types.NFS4ERR_CLID_INUSE
+	case errors.Is(err, state.ErrRenewAccess):
+		return types.NFS4ERR_ACCESS
 	default:
 		return types.NFS4ERR_SERVERFAULT
 	}


### PR DESCRIPTION
Closes #2096.

## The issue's premise holds; its proposed fix does not

The symptom is real and reproduces. `TestOpen_ClientIDSpansPrincipals` shows a caller
authenticated as uid 1001 presenting uid 1000's clientid and open-owner and being handed
uid 1000's live open stateid — `StateManager.OpenFile` returns the *existing* `OpenState`
when the owner key already has that filehandle open, bumping only the seqid. From there
CLOSE releases the victim's open state and its share reservations.

The fix the issue proposes — store the principal on `ClientRecord` / `V41ClientRecord`,
compare it in `ValidateAndRenewClient`, return `NFS4ERR_PERM` — is wrong in three separate
ways, and shipping it would have broken every multi-user mount on day one:

**A client ID is per-client, not per-principal.** RFC 7530 §3.1 has one TCP connection
multiplexing every user on a machine; §9.1.1 gives each of them their own open-owner under
the one client ID. RFC 8881 §2.10.8.3 lists "the physical client has multiple users, but
the client implementation has a unique client ID for each user" as one of only three
scenarios for `SP4_MACH_CRED` — i.e. the default assumption is one client ID shared by
many principals. The Linux client is built exactly this way: `nfs4_get_clid_cred()` returns
the machine credential for SETCLIENTID/EXCHANGE_ID, while `nfs4_run_open_task()` and
`_nfs4_do_setlk()` send OPEN and LOCK under `data->owner->so_cred`, and state owners are
looked up *by credential*.

**No production server enforces it on OPEN.** In Linux nfsd, `same_creds()` is called from
exactly six places — `nfsd4_exchange_id`, `nfsd4_create_session`, `replay_matches_cache`,
`nfsd4_setclientid`, and three sites in `nfsd4_setclientid_confirm`. Zero on OPEN or LOCK;
`struct nfs4_stateowner` has no credential field at all. `nfs4_op_open.c` and
`nfs4_op_lock.c` in nfs-ganesha contain no credential comparison either, and illumos'
`creds_ok()` is a literal `return (TRUE);`. RFC 8881 §18.35.3 warns clients off putting
filehandle-carrying operations under principal enforcement, "because the server's access
policies MAY conflict with the client's choice, and thus the client would then be unable
to access a subset of the server's namespace" — OPEN and LOCK carry filehandles.

**`NFS4ERR_PERM` is not the code.** RFC 7530 §13.1.6.2 scopes it to "the requester is not
the owner" of the *file*, and Table 12 lists it as valid only for CREATE, OPEN and SETATTR.
The code for a principal that may not touch a piece of state is `NFS4ERR_WRONG_CRED`
(RFC 8881 §15.1.6.4), which does not exist in NFSv4.0 and is not valid for OPEN in v4.1.

What *does* protect the file in the reproduction is the per-OPEN permission check: the same
foreign caller asking for `SHARE_ACCESS_BOTH` on a file it cannot write is refused with
`NFS4ERR_ACCESS` before any of this. The test pins that, because it is the load-bearing
block and nothing else stands behind it.

## What is actually missing, and is fixed here

Two spec-mandated principal bindings, both absent:

**RENEW had no principal check at all** (`RenewLease`, `manager.go`). RFC 7530 §16.28.5:

> The client that issues RENEW MUST choose the principal, RPC security flavor, and, if
> applicable, GSS-API mechanism and service via one of the following algorithms:
> - The client uses the same principal [...] used when the client ID was established via
>   SETCLIENTID_CONFIRM.
> - The client uses any principal [...] that currently has an OPEN file on the server.
>
> The server MUST reject a RENEW that does not use one of the aforementioned algorithms,
> with the error NFS4ERR_ACCESS.

Both algorithms are implemented — the second is what keeps a multi-user mount working, so
`OpenOwner` now records the principal that created it and `renewPrincipalAllowed` scans
them. One caller the RFC does not name is admitted: a record with no stored principal,
established under AUTH_NONE, where there is nothing to compare against. The check runs
*before* the renewal, so a refused RENEW leaves the lease exactly where it was.

Root gets no exemption. FreeBSD's `nfsrv_notsamecredname()` has one ("allow the same uid or
root", reached only on its non-GSS path), and I copied it before working out that it does not
survive being lifted out of that structure here: `Principal()` renders a GSS-resolved uid and
a client-asserted AUTH_SYS uid identically, and RENEW carries no filehandle for an export's
`sec=` policy to judge — so the exemption handed any AUTH_SYS peer writing `uid=0` into its
credential the lease of a client established under Kerberos, which is precisely the case
where this check has teeth. Nothing needs it: the Linux client renews under the same machine
credential it established the client ID with (`nfs4_get_clid_cred()` and
`nfs4_get_renew_cred()` both return `rpc_machine_cred()`), so plain equality already matches,
and the documented fallback to a state owner's credential is covered by the open-holder scan.
`root_is_refused_against_another_principal's_record` pins it.

**The SETCLIENTID / EXCHANGE_ID takeover guards failed open on an identity-less caller.**
All three sites tested `stored != "" && incoming != "" && stored != incoming`, so a request
carrying no principal matched everything. A client ID established under Kerberos could be
taken over by an AUTH_NONE caller sending SETCLIENTID with a different verifier, which then
evicts the previous confirmed record and every open, lock and delegation hanging off it.
Neither SETCLIENTID nor SETCLIENTID_CONFIRM carries a filehandle, so an export's `sec=`
policy never sees the request and cannot refuse it first. RFC 7530 §19 calls the check on
these two operations "imperative"; §9.1.1 states it as a MUST NOT on cancelling another
principal's leased state; RFC 8881 §18.35.4 case 9 is the same rule for EXCHANGE_ID. The
three sites now share `principalHijacks`, which no longer treats "no credential offered" as
a match. Records with no stored principal stay open — there is nothing to check against.

### The RENEW check does not make a lease unreachable, and is not meant to

RFC 7530 §9.5 grants implicit renewal to five other operations — "Any operation made with a
valid clientid (DELEGPURGE, LOCK, LOCKT, OPEN, RELEASE_LOCKOWNER, or RENEW) [...] informs the
server to renew all of the leases for that client" — none of which carries a principal
restriction, and `ValidateAndRenewClient` implements that on the OPEN path today. So a caller
refused at RENEW can still hold a lease open by sending an OPEN that fails afterwards. That is
the RFC's own design, not a hole this PR leaves: §16.28.5's MUST is scoped to RENEW alone, and
FreeBSD reads it the same way — `nfsrv_notsamecredname()` is reached only via `CLOPS_RENEWOP`,
passed from exactly one place, `nfsrvd_renew()`. The value here is conformance with a MUST that
was simply absent, not a new perimeter.

### What this is and is not worth under AUTH_SYS

`Principal()` is `"uid:N"`, so under AUTH_SYS the identity is whatever the client claimed and
an attacker who knows the victim's uid can still forge it. The binding has real teeth under
`sec=krb5`, where the uid comes from a Kerberos principal the server verified; under AUTH_SYS
it closes the identity-less case and the accidental one, and that is all it can close — which
is also why no AUTH_SYS uid, root included, gets a standing exemption. That is a property of
AUTH_SYS, not of this check — RFC 7530 §19's answer to it is RPCSEC_GSS. The
GSS principal string itself is still not threaded onto `CompoundContext`, so two Kerberos
principals mapping to one uid are one identity here; threading it is a separate change.

## Evidence

Every new assertion was run against a deliberately broken build first:

| Break | Test that went red |
| --- | --- |
| RENEW principal check removed | `stranger_is_refused`, `refused_renew_does_not_extend_the_lease` |
| "any principal holding an OPEN" alternative removed | `principal_holding_an_open_is_allowed` |
| uid 0 exemption re-added | `root_is_refused_against_another_principal's_record` |
| `record.Principal == ""` clause removed | `record_with_no_principal_accepts_any_caller` |
| fail-open on empty incoming principal restored | `TestSetClientID_IdentitylessCallerCannotTakeOver`, `TestExchangeID_Case2_PrincipalMismatch` |
| per-OPEN permission check neutered | `TestOpen_ClientIDSpansPrincipals` |

`TestExchangeID_Case2_PrincipalMismatch` changes: its last assertion pinned the fail-open
(an idempotent EXCHANGE_ID with no principal succeeding). It now asserts the refusal. Its
original point — that such a call must never *clear* the stored principal — is kept.

`go build ./... && go vet ./... && gofmt -l` clean; `go test ./...` green.

## Deliberately not in this PR

- **`SP4_MACH_CRED` / `SP4_SSV`** (RFC 8881 §2.10.8.3) are the spec's actual answer to
  "an attacker forges a client ID and destroys the victim's locking state". They are
  rejected as out of scope at `v41/handlers/exchange_id.go:28`, and implementing them is a
  feature, not a bug fix. nfs-ganesha does not implement them either.
- **The open-owner handoff itself** is left as-is: refusing it is what no other server does
  and what §18.35.3 advises against, and the per-OPEN permission check is what bounds it.
- Auditing the client-ID plumbing turned up a wider unauthenticated surface that is not
  principal-related and belongs in its own issues — `BIND_CONN_TO_SESSION` binds any
  connection to any known sessionid with no check at all (`manager.go` `BindConnToSession`),
  `DESTROY_CLIENTID` fails open for an unidentifiable caller, a v4.1 COMPOUND can reach
  OPEN/LOCK/CLOSE/LOCKU without SEQUENCE when the first op is session-exempt, and
  `types.V4ClientState.ClientID` is read in two places but never written. I have filed
  nothing for these; say the word and I will.

## Relationship to #2146

Nothing here changes a line #2146 changes. #2146 changes which *field* the clientid is read
from in v4.1 (`open.go` around line 103, plus `lock.go`) and adds
`CompoundContext.SessionClientID`; this PR touches `RenewLease`, the SETCLIENTID/EXCHANGE_ID
guards, and the four `OpenFile` call sites further down `open.go`. Branched off
`origin/develop`, not off #2146.

The one file both touch is `handlers/io_test.go`: #2146 appends tests near line 662, this PR
adds a variadic `principal` parameter to `testClientID` near line 327. Whichever lands second
gets a trivial rebase; happy for that to be me.
