### PR TITLE
docs(smb): correct ~243 wrong MS-FSCC and MS-FSA spec citations in the SMB adapter

### DIFF
--- a/internal/adapter/smb/handlers/change_notify.go
+++ b/internal/adapter/smb/handlers/change_notify.go
@@ -116,7 +116,8 @@ type ChangeNotifyResponse struct {
 	Buffer             []byte // Serialized FileNotifyInformation array
 }
 
-// FileNotifyInformation represents a single change notification [MS-FSCC] 2.4.42.
+// FileNotifyInformation represents a single change notification
+// [MS-FSCC] 2.7.1 (FILE_NOTIFY_INFORMATION).
 type FileNotifyInformation struct {
 	Action   uint32
 	FileName string // Relative path within watched directory

--- a/internal/adapter/smb/handlers/change_notify.go
+++ b/internal/adapter/smb/handlers/change_notify.go
@@ -1385,7 +1385,7 @@ func (r *NotifyRegistry) chargeArmedBuffer(
 }
 
 // encodedNotifyEntrySize returns the wire size of a single
-// FILE_NOTIFY_INFORMATION entry whose FileName is name (MS-FSCC §2.4.42):
+// FILE_NOTIFY_INFORMATION entry whose FileName is name (MS-FSCC §2.7.1 (FILE_NOTIFY_INFORMATION)):
 // 12-byte fixed header (NextEntryOffset | Action | FileNameLength) plus the
 // UTF-16LE filename bytes, aligned up to 4 bytes. Empty names are charged
 // the minNotifyEntryBytes floor to avoid undercounting a sentinel-encoded

--- a/internal/adapter/smb/handlers/change_notify.go
+++ b/internal/adapter/smb/handlers/change_notify.go
@@ -962,7 +962,8 @@ const (
 // NameChangeFilterFor returns the appropriate FileNotifyChange* mask for a
 // file-name-change event on a target with the given baseName and directory
 // flag. ADS streams (name contains ':') route via FILE_NOTIFY_CHANGE_STREAM_NAME
-// per MS-FSCC §2.6 — applies to create / delete / rename of stream entries so
+// per MS-SMB2 §2.2.35 ("SMB2 CHANGE_NOTIFY Request"), which defines the
+// CompletionFilter bits — applies to create / delete / rename of stream entries so
 // stream-name watchers see them.
 func NameChangeFilterFor(baseName string, isDirectory bool) uint32 {
 	if strings.Contains(baseName, ":") {

--- a/internal/adapter/smb/handlers/change_notify_test.go
+++ b/internal/adapter/smb/handlers/change_notify_test.go
@@ -2424,7 +2424,7 @@ func TestNameChangeFilterFor(t *testing.T) {
 	}
 }
 
-// decodeFileNotifyInfos walks a FILE_NOTIFY_INFORMATION list (MS-FSCC §2.4.42).
+// decodeFileNotifyInfos walks a FILE_NOTIFY_INFORMATION list (MS-FSCC §2.7.1 (FILE_NOTIFY_INFORMATION)).
 // Test helper only — production decode happens client-side.
 func decodeFileNotifyInfos(buf []byte) []FileNotifyInformation {
 	var out []FileNotifyInformation

--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -866,7 +866,7 @@ func (h *Handler) convertToRealSymlink(ctx *SMBHandlerContext, openFile *OpenFil
 // cascadeDeleteADSStreams removes all alternate data streams belonging to a
 // base file that was just deleted. ADS streams are stored as sibling entries
 // in the parent directory with names like "baseFile:streamName:$DATA".
-// Per MS-FSA 2.1.5.9.7, deleting a file deletes all its streams.
+// Per MS-FSA 2.1.5.1.2.1 ("Algorithm to Check Access to an Existing File"), deleting a file deletes all its streams.
 func (h *Handler) cascadeDeleteADSStreams(authCtx *metadata.AuthContext, metaSvc *metadata.Service, openFile *OpenFile) {
 	name := openFile.Name()
 	prefix := name.FileName + ":"

--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -137,7 +137,7 @@ func (resp *CloseResponse) Encode() ([]byte, error) {
 // so a failed block-store (or pending-metadata) flush is mapped to a non-success
 // status rather than silently acknowledged — otherwise the client treats data
 // that never persisted as committed (#1267). Delete-on-close unlink failures are
-// likewise surfaced per MS-SMB2 3.3.5.10 / MS-FSA 2.1.5.4 (#388) — the client
+// likewise surfaced per MS-SMB2 3.3.5.10 / MS-FSA 2.1.5.5 ("Server Requests Closing of an Open") (#388) — the client
 // must know the file was not removed. The handle itself is always released
 // regardless of any flush/delete failure, to prevent resource leaks.
 func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseResponse, error) {

--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -290,7 +290,7 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 				}
 			}
 
-			// Per MS-FSA 2.1.5.14.2: After flushing pending writes (which may overwrite
+			// Per MS-FSA §2.1.5.15.2 ("FileBasicInformation"): After flushing pending writes (which may overwrite
 			// frozen timestamps), restore any timestamps that were frozen via SET_INFO -1.
 			// The deferred commit flush sets Mtime/Ctime to the WRITE time, but if the
 			// handle has frozen timestamps, those must be preserved.

--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -137,7 +137,7 @@ func (resp *CloseResponse) Encode() ([]byte, error) {
 // so a failed block-store (or pending-metadata) flush is mapped to a non-success
 // status rather than silently acknowledged — otherwise the client treats data
 // that never persisted as committed (#1267). Delete-on-close unlink failures are
-// likewise surfaced per MS-SMB2 3.3.5.10 / MS-FSA 2.1.5.5 ("Server Requests Closing of an Open") (#388) — the client
+// likewise surfaced per MS-SMB2 3.3.5.10 / MS-FSA 2.1.5.5 ("Server Requests Closing an Open") (#388) — the client
 // must know the file was not removed. The handle itself is always released
 // regardless of any flush/delete failure, to prevent resource leaks.
 func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseResponse, error) {

--- a/internal/adapter/smb/handlers/close_doc_election_test.go
+++ b/internal/adapter/smb/handlers/close_doc_election_test.go
@@ -1,6 +1,6 @@
 // Regression coverage for the last-handle delete-on-close election.
 //
-// Per MS-FSA 2.1.5.4 the unlink fires when the LAST handle on a file closes.
+// Per MS-FSA 2.1.5.5 ("Server Requests Closing of an Open") the unlink fires when the LAST handle on a file closes.
 // Both close paths — the explicit CLOSE handler and the LOGOFF /
 // tree-disconnect / transport-drop teardown — decide "am I the last handle?"
 // by scanning the open-file table for a sibling on the same MetadataHandle,

--- a/internal/adapter/smb/handlers/close_doc_election_test.go
+++ b/internal/adapter/smb/handlers/close_doc_election_test.go
@@ -1,6 +1,6 @@
 // Regression coverage for the last-handle delete-on-close election.
 //
-// Per MS-FSA 2.1.5.5 ("Server Requests Closing of an Open") the unlink fires when the LAST handle on a file closes.
+// Per MS-FSA 2.1.5.5 ("Server Requests Closing an Open") the unlink fires when the LAST handle on a file closes.
 // Both close paths — the explicit CLOSE handler and the LOGOFF /
 // tree-disconnect / transport-drop teardown — decide "am I the last handle?"
 // by scanning the open-file table for a sibling on the same MetadataHandle,

--- a/internal/adapter/smb/handlers/converters.go
+++ b/internal/adapter/smb/handlers/converters.go
@@ -289,7 +289,7 @@ func FileAttrToFileBasicInfoWithName(attr *metadata.FileAttr, name string) *File
 }
 
 // FileAttrToFileStandardInfo converts metadata FileAttr to SMB FILE_STANDARD_INFORMATION
-// [MS-FSCC] 2.4.41. Computes AllocationSize (cluster-aligned) and EndOfFile from the
+// [MS-FSCC] 2.4.47 (FileStandardInformation). Computes AllocationSize (cluster-aligned) and EndOfFile from the
 // file size, and reports link count, delete-pending, and directory flags. For symlinks,
 // the EndOfFile reflects the MFsymlink size (1067 bytes) rather than the target path length.
 func FileAttrToFileStandardInfo(attr *metadata.FileAttr, isDeletePending bool) *FileStandardInfo {

--- a/internal/adapter/smb/handlers/converters.go
+++ b/internal/adapter/smb/handlers/converters.go
@@ -299,7 +299,7 @@ func FileAttrToFileStandardInfo(attr *metadata.FileAttr, isDeletePending bool) *
 	allocationSize := calculateAllocationSize(size)
 
 	// NumberOfLinks reflects the open's delete-on-close disposition. Per Windows
-	// / MS-FSA §2.1.5.11.6, once a handle marks the file for deletion the file is
+	// / MS-FSA §2.1.5.12.27 ("FileStandardInformation"), once a handle marks the file for deletion the file is
 	// on its way out and FILE_STANDARD_INFORMATION reports NumberOfLinks = 0;
 	// clearing the disposition restores it to the real link count (>= 1).
 	// smbtorture smb2.setinfo (setinfo.c:229) asserts nlink == 0 with

--- a/internal/adapter/smb/handlers/converters.go
+++ b/internal/adapter/smb/handlers/converters.go
@@ -66,12 +66,12 @@ const (
 	modeDOSSparse = uint32(0x200000)
 
 	// filetimeFreeze is the FILETIME sentinel value -1 (0xFFFFFFFFFFFFFFFF).
-	// Per MS-FSA 2.1.5.14.2: The object store MUST NOT change this attribute
+	// Per MS-FSA §2.1.5.15.2 ("FileBasicInformation"): The object store MUST NOT change this attribute
 	// for this or subsequent operations on this handle.
 	filetimeFreeze = uint64(0xFFFFFFFFFFFFFFFF)
 
 	// filetimeUnfreeze is the FILETIME sentinel value -2 (0xFFFFFFFFFFFFFFFE).
-	// Per MS-FSA 2.1.5.14.2: Re-enable auto-update for subsequent operations.
+	// Per MS-FSA §2.1.5.15.2 ("FileBasicInformation"): Re-enable auto-update for subsequent operations.
 	filetimeUnfreeze = uint64(0xFFFFFFFFFFFFFFFE)
 )
 
@@ -373,7 +373,7 @@ func DirEntryToDirectoryEntry(entry *metadata.DirEntry, fileIndex uint64) *Direc
 
 // DecodeBasicInfoToSetAttrs decodes FILE_BASIC_INFORMATION from a raw buffer
 // directly into SetAttrs, properly handling all FILETIME sentinel values per
-// [MS-FSCC] 2.4.7 and [MS-FSA] 2.1.5.14.2:
+// [MS-FSCC] 2.4.7 and [MS-FSA] §2.1.5.15.2 ("FileBasicInformation"):
 //   - 0: don't change this timestamp
 //   - 0xFFFFFFFFFFFFFFFF (-1): don't change this timestamp; disable auto-update
 //   - 0xFFFFFFFFFFFFFFFE (-2): don't change this timestamp; enable auto-update
@@ -404,7 +404,7 @@ func DecodeBasicInfoToSetAttrs(buffer []byte) *metadata.SetAttrs {
 }
 
 // processFiletimeForSet interprets a FILETIME value for SET_INFO operations.
-// Per [MS-FSA] 2.1.5.14.2:
+// Per [MS-FSA] §2.1.5.15.2 ("FileBasicInformation"):
 //   - 0: don't change (server MUST NOT change this attribute)
 //   - -1: don't change; disable auto-update for subsequent operations
 //   - -2: don't change; re-enable auto-update for subsequent operations

--- a/internal/adapter/smb/handlers/converters.go
+++ b/internal/adapter/smb/handlers/converters.go
@@ -319,7 +319,7 @@ func FileAttrToFileStandardInfo(attr *metadata.FileAttr, isDeletePending bool) *
 }
 
 // FileAttrToFileNetworkOpenInfoWithName converts metadata FileAttr to SMB
-// FILE_NETWORK_OPEN_INFORMATION [MS-FSCC] 2.4.27. Combines timestamps, allocation
+// FILE_NETWORK_OPEN_INFORMATION [MS-FSCC] 2.4.34 (FileNetworkOpenInformation). Combines timestamps, allocation
 // size, end of file, and attributes into a single structure. It applies
 // IsHiddenFile so dot-prefixed entries surface FILE_ATTRIBUTE_HIDDEN.
 func FileAttrToFileNetworkOpenInfoWithName(attr *metadata.FileAttr, name string) *FileNetworkOpenInfo {

--- a/internal/adapter/smb/handlers/converters_test.go
+++ b/internal/adapter/smb/handlers/converters_test.go
@@ -208,7 +208,7 @@ func TestFileAttrToSMBAttributesWithName_HiddenByDotPrefix(t *testing.T) {
 }
 
 // TestSMBModeFromAttrs_OverwriteForcesArchive locks down the contract that
-// overwriteFile relies on: per MS-FSA 2.1.5.1.2.1, OVERWRITE/SUPERSEDE always
+// overwriteFile relies on: per MS-FSA 2.1.5.1.2 ("Open of an Existing File"), OVERWRITE/SUPERSEDE always
 // sets FILE_ATTRIBUTE_ARCHIVE on the post-overwrite metadata, so the mode
 // produced from the request attrs OR'd with ARCHIVE must round-trip to a
 // FileAttr whose SMB attrs include ARCHIVE — even when the client only sent

--- a/internal/adapter/smb/handlers/create.go
+++ b/internal/adapter/smb/handlers/create.go
@@ -2221,7 +2221,7 @@ func (h *Handler) updateBaseObjectTimestampsForADSWrite(
 	// If only one timestamp is frozen, metadata's SetFileAttributes will
 	// auto-bump Ctime to NOW because modified=true and attrs.Ctime==nil
 	// (file_modify.go: `if modified { if attrs.Ctime == nil { file.Ctime = now }}`).
-	// Per MS-FSA 2.1.5.14.2, the freeze sentinel applies to the underlying
+	// Per MS-FSA §2.1.5.15.2 ("FileBasicInformation"), the freeze sentinel applies to the underlying
 	// object, so an ADS write must not bump the base's frozen ChangeTime
 	// (WPTS FileInfo_Set_FileBasicInformation_Timestamp_MinusOne_Dir_ChangeTime).
 	// Pin Ctime to the base's current value when the ADS handle has Ctime frozen.

--- a/internal/adapter/smb/handlers/create.go
+++ b/internal/adapter/smb/handlers/create.go
@@ -600,7 +600,8 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 		return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusInvalidParameter}}, nil
 	}
 
-	// Per MS-SMB2 §2.2.13 + MS-FSCC §2.6, three CreateOptions bits are defined
+	// Per MS-SMB2 §2.2.13 ("SMB2 CREATE Request"), which is where CreateOptions
+	// is defined, three CreateOptions bits are defined
 	// in Samba but unimplemented in DittoFS and MUST return STATUS_NOT_SUPPORTED
 	// rather than silently succeed. Samba sets `not_supported_mask = 0x00102080`
 	// for these probes (smbtorture smb2.create.gentest):
@@ -751,8 +752,10 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 		return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusObjectNameInvalid}}, nil
 	}
 
-	// Per MS-FSA 2.1.5.1, wildcard characters are invalid in path
-	// components. Note: wildcards ARE valid inside stream names (e.g.,
+	// Wildcard characters are invalid in path components: MS-FSA 2.1.5.1 Phase 1
+	// defers name validity to MS-FSCC 2.1.5 ("Pathname"), and MS-FSA 2.1.4.3
+	// ("Algorithm for Determining If a Character Is a Wildcard") names the five
+	// characters tested here. Note: wildcards ARE valid inside stream names (e.g.,
 	// "file:?Stream*" is legal), so this check applies only to the base
 	// file path (stream suffix already stripped above).
 	if strings.ContainsAny(filename, "*?<>\"") {
@@ -1175,8 +1178,10 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 
 	// Pre-disposition parent-DACL gate: any non-pure-OPEN disposition mutates
 	// the parent directory's contents (creating, overwriting, or superseding a
-	// child). MS-FSA 2.1.5.1.1 + MS-SMB2 §3.3.5.9 require parent-create
-	// permission to be evaluated before failing on disposition collisions, so
+	// child). MS-FSA orders these the other way round — 2.1.5.1.2 fails
+	// FILE_CREATE with OBJECT_NAME_COLLISION before any parent-DACL check — so
+	// this follows Samba's open_file_ntcreate, which evaluates parent-create
+	// permission first so
 	// a deny ACE on the parent surfaces as ACCESS_DENIED rather than
 	// OBJECT_NAME_COLLISION / DELETE_PENDING. FILE_OPEN is the only pure-open
 	// disposition; everything else (CREATE, CREATE_IF, OVERWRITE,
@@ -1264,7 +1269,7 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	// Step 6: Handle create disposition
 	// ========================================================================
 	//
-	// Per MS-FSA 2.1.5.1.1: Disposition check (e.g., FILE_CREATE failing with
+	// Per MS-FSA 2.1.5.1 Phase 7 ("Type of stream to open"): Disposition check (e.g., FILE_CREATE failing with
 	// OBJECT_NAME_COLLISION when the name exists) takes priority over type
 	// constraint checks (NOT_A_DIRECTORY / FILE_IS_A_DIRECTORY).
 	// For ADS, this also takes priority over base-file share mode checks:
@@ -1334,7 +1339,7 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 		}
 	}
 
-	// Per MS-FSA 2.1.5.1.2.1: Overwrite/supersede attribute mismatch rules.
+	// Per MS-FSA 2.1.5.1.2 ("Open of an Existing File"): Overwrite/supersede attribute mismatch rules.
 	// READONLY on the existing file denies the overwrite entirely.
 	// HIDDEN and SYSTEM must be present in the request if set on the existing file.
 	if fileExists && existingFile.Type != metadata.FileTypeDirectory {
@@ -1346,7 +1351,7 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 					"action", createAction)
 				return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusAccessDenied}}, nil
 			}
-			// Per MS-FSA 2.1.5.1.2.2: Hidden and System flags must be preserved.
+			// Per MS-FSA 2.1.5.1.2 ("Open of an Existing File"): Hidden and System flags must be preserved.
 			if existingAttrs&types.FileAttributeHidden != 0 && req.FileAttributes&types.FileAttributeHidden == 0 {
 				logger.Debug("CREATE: attribute mismatch — existing hidden, request not hidden",
 					"path", filename)
@@ -1403,7 +1408,7 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 
 	// Step 6c-pre: Check delete-pending state before oplock break dispatch.
 	//
-	// Per MS-FSA 2.1.5.1.2 and MS-SMB2 3.3.5.9: if an existing open on the
+	// Per MS-FSA 2.1.5.1 Phase 6 ("Location of file") and MS-SMB2 3.3.5.9: if an existing open on the
 	// file has set disposition delete-on-close, subsequent opens MUST fail
 	// with STATUS_DELETE_PENDING without triggering an oplock break. The
 	// check runs BEFORE breakAndMaybeParkCreate so the holder's oplock
@@ -2126,7 +2131,7 @@ func (h *Handler) overwriteFile(
 		Size: &zeroSize,
 	}
 
-	// Per MS-FSA 2.1.5.1.2.1: OVERWRITE/SUPERSEDE forces FILE_ATTRIBUTE_ARCHIVE
+	// Per MS-FSA 2.1.5.1.2 ("Open of an Existing File"): OVERWRITE/SUPERSEDE forces FILE_ATTRIBUTE_ARCHIVE
 	// on the post-overwrite metadata regardless of what the client sent — the
 	// data is "needs backup" again. Apply the requested attributes plus ARCHIVE,
 	// and preserve modeDOSCompressed (controlled only via FSCTL_SET_COMPRESSION).

--- a/internal/adapter/smb/handlers/create.go
+++ b/internal/adapter/smb/handlers/create.go
@@ -1408,9 +1408,11 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 
 	// Step 6c-pre: Check delete-pending state before oplock break dispatch.
 	//
-	// Per MS-FSA 2.1.5.1 Phase 6 ("Location of file") and MS-SMB2 3.3.5.9: if an existing open on the
-	// file has set disposition delete-on-close, subsequent opens MUST fail
-	// with STATUS_DELETE_PENDING without triggering an oplock break. The
+	// If an existing open on the file has set disposition delete-on-close,
+	// subsequent opens MUST fail with STATUS_DELETE_PENDING without triggering an
+	// oplock break. MS-FSA 2.1.5.1 Phase 6 ("Location of file") states this for
+	// intermediate path components; for the final component it follows
+	// MS-SMB2 3.3.5.9 and Samba. The
 	// check runs BEFORE breakAndMaybeParkCreate so the holder's oplock
 	// remains intact. Required by smbtorture smb2.oplock.doc.
 	//

--- a/internal/adapter/smb/handlers/create.go
+++ b/internal/adapter/smb/handlers/create.go
@@ -32,7 +32,7 @@ const CreateContextTagAllocationSize = "AlSi"
 
 // CreateContextTagExtendedAttributes is the SMB2_CREATE_EA_BUFFER create
 // context tag ("ExtA") [MS-SMB2] 2.2.13.2.1. Its Data is a
-// FILE_FULL_EA_INFORMATION chain (MS-FSCC §2.4.15) of extended attributes the
+// FILE_FULL_EA_INFORMATION chain (MS-FSCC §2.4.16 ("FileFullEaInformation")) of extended attributes the
 // client wants attached to the file at creation time.
 const CreateContextTagExtendedAttributes = "ExtA"
 

--- a/internal/adapter/smb/handlers/create_dacl_enforcement_test.go
+++ b/internal/adapter/smb/handlers/create_dacl_enforcement_test.go
@@ -455,7 +455,7 @@ func TestCreate_MaxAllowedPlusExplicitDeniedBit_ReturnsAccessDenied(t *testing.T
 // STATUS_ACCESS_DENIED because OVERWRITE implicitly requires FILE_WRITE_DATA
 // to truncate the existing file, which the DACL does not grant.
 //
-// Per MS-FSA §2.1.5.1.2.1 and Samba open_file_ntcreate
+// Per MS-FSA §2.1.5.1.2 ("Open of an Existing File") and Samba open_file_ntcreate
 // (`open_access_mask |= FILE_WRITE_DATA` when O_TRUNC).
 func TestCreate_OverwriteRestrictedFile_ReturnsAccessDenied(t *testing.T) {
 	h, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
@@ -491,7 +491,7 @@ func TestCreate_OverwriteRestrictedFile_ReturnsAccessDenied(t *testing.T) {
 // smb2.acls.OVERWRITE_READ_ONLY_FILE (issue #565) — SUPERSEDE arm at
 // source4/torture/smb2/acls.c:3104. Mirrors the OVERWRITE test above but with
 // FILE_SUPERSEDE disposition: SUPERSEDE replaces the existing file content,
-// which inherently requires FILE_WRITE_DATA per MS-FSA §2.1.5.1.2.1 and must
+// which inherently requires FILE_WRITE_DATA per MS-FSA §2.1.5.1.2 ("Open of an Existing File") and must
 // be denied when the DACL grants only READ_DATA.
 func TestCreate_SupersedeRestrictedFile_ReturnsAccessDenied(t *testing.T) {
 	h, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)

--- a/internal/adapter/smb/handlers/create_doc_perms_test.go
+++ b/internal/adapter/smb/handlers/create_doc_perms_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
-// Handler-level regression coverage for the MS-FSA §2.1.5.18 delete-on-close
+// Handler-level regression coverage for the MS-FSA §2.1.5.1.1 ("Creation of a New File") delete-on-close
 // permission semantics exercised by smbtorture
 // smb2.delete-on-close-perms.{CREATE,CREATE_IF,OVERWRITE_IF,READONLY}.
 //
@@ -118,7 +118,7 @@ func makeDocDraft(
 }
 
 // TestCreate_DeleteOnClose_ReadOnlyFile_ReturnsCannotDelete locks down the
-// MS-FSA §2.1.5.18 gate exercised by smb2.delete-on-close-perms.READONLY
+// MS-FSA §2.1.5.1.2.1 ("Algorithm to Check Access to an Existing File") gate exercised by smb2.delete-on-close-perms.READONLY
 // step 6: OPEN-ing an existing file with FILE_ATTRIBUTE_READONLY and the
 // FILE_DELETE_ON_CLOSE create option MUST return STATUS_CANNOT_DELETE,
 // regardless of whether the caller holds DELETE on the file's DACL.
@@ -152,7 +152,7 @@ func TestCreate_DeleteOnClose_ReadOnlyFile_ReturnsCannotDelete(t *testing.T) {
 
 	// OPEN existing READONLY file with DELETE_ON_CLOSE. DesiredAccess carries
 	// SEC_STD_DELETE | SEC_RIGHTS_FILE_READ so hasDeleteAccess is satisfied —
-	// the MS-FSA §2.1.5.18 readonly veto must still fire.
+	// the MS-FSA §2.1.5.1.2.1 ("Algorithm to Check Access to an Existing File") readonly veto must still fire.
 	const desiredAccess uint32 = 0x00130089 // SEC_RIGHTS_FILE_READ | SEC_STD_DELETE
 	draft := makeDocDraft(t, tree, rootAuth, rootHandle, readonlyFile,
 		"ro.txt", types.FileOpen, types.FileOpened, desiredAccess, 0)
@@ -167,7 +167,7 @@ func TestCreate_DeleteOnClose_ReadOnlyFile_ReturnsCannotDelete(t *testing.T) {
 // TestCreate_DeleteOnClose_NewFileWithReadOnlyAttr_ReturnsCannotDelete covers
 // smb2.delete-on-close-perms.READONLY step 1: a CREATE that asks to mark a
 // new file READONLY *and* DELETE_ON_CLOSE simultaneously is an immediate
-// MS-FSA §2.1.5.18 contradiction. completeCreateAfterBreak must reject the
+// MS-FSA §2.1.5.1.1 ("Creation of a New File") contradiction. completeCreateAfterBreak must reject the
 // open with STATUS_CANNOT_DELETE before the file is materialized in the
 // metadata store.
 func TestCreate_DeleteOnClose_NewFileWithReadOnlyAttr_ReturnsCannotDelete(t *testing.T) {
@@ -188,7 +188,7 @@ func TestCreate_DeleteOnClose_NewFileWithReadOnlyAttr_ReturnsCannotDelete(t *tes
 }
 
 // TestCreate_DeleteOnClose_WithoutDeleteAccess_ReturnsAccessDenied locks down
-// the MS-FSA §2.1.5.18 gate that the DOC option requires DELETE in
+// the MS-FSA §2.1.5.1 Phase 1 ("Parameter Validation") gate that the DOC option requires DELETE in
 // DesiredAccess (Samba: smbd_set_initial_delete_on_close). This is the
 // "hasDeleteAccess" leg of step 6d and is the first guard the DOC-perms
 // suite relies on for new-file scenarios.

--- a/internal/adapter/smb/handlers/create_filecreated_grant_test.go
+++ b/internal/adapter/smb/handlers/create_filecreated_grant_test.go
@@ -20,7 +20,7 @@ import (
 // SEC_RIGHTS_FILE_ALL — not the narrowed subset that the inherited DACL
 // would imply.
 //
-// Per MS-FSA §2.1.5.1.2 CreateFile and Samba
+// Per MS-FSA §2.1.5.1.1 ("Creation of a New File") CreateFile and Samba
 // source3/smbd/open.c::open_file_ntcreate, when a new file is created the
 // server grants the creator the resolved DesiredAccess as-is. The parent
 // DACL gates the create operation (already enforced upstream via

--- a/internal/adapter/smb/handlers/create_path_spelling_test.go
+++ b/internal/adapter/smb/handlers/create_path_spelling_test.go
@@ -121,7 +121,7 @@ func TestCreate_NameIdentityIsSpellingIndependent(t *testing.T) {
 
 // TestCheckShareModeConflict_SpellingIndependent holds a stream open that
 // refuses delete sharing, then opens the base file for DELETE under two
-// spellings. Per MS-FSA 2.1.5.1.2 the base-vs-stream pair is delete-share
+// spellings. Per MS-FSA 2.1.5.1.2.1 ("Algorithm to Check Access to an Existing File") the base-vs-stream pair is delete-share
 // checked, so both opens must be refused with STATUS_SHARING_VIOLATION.
 //
 // The two spellings differ only in text and name the same object, so a

--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -911,7 +911,7 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 		grantedAccess = resolveAccessFlags(req.DesiredAccess)
 	}
 
-	// Step 7a: Restore frozen timestamps on parent directory (MS-FSA 2.1.5.14.2).
+	// Step 7a: Restore frozen timestamps on parent directory (MS-FSA §2.1.5.15.2 ("FileBasicInformation")).
 	if createAction == types.FileCreated || createAction == types.FileOverwritten || createAction == types.FileSuperseded {
 		h.restoreParentDirFrozenTimestamps(authCtx, parentHandle)
 	}

--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -850,7 +850,7 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 
 	// Apply extended attributes from an SMB2_CREATE_EA_BUFFER ("ExtA") create
 	// context. MS-SMB2 §2.2.13.2.1: the client may attach a
-	// FILE_FULL_EA_INFORMATION chain (MS-FSCC §2.4.15) at CREATE so the file is
+	// FILE_FULL_EA_INFORMATION chain (MS-FSCC §2.4.16 ("FileFullEaInformation")) at CREATE so the file is
 	// born with EAs (smbtorture smb2.setinfo opens its test file this way, then
 	// asserts the pre-existing EAs survive a later SET_INFO). Only applied on a
 	// freshly created file; reopening an existing file does not re-seed EAs.

--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -99,7 +99,7 @@ func isDestructiveDisposition(d types.CreateDisposition) bool {
 //	    open_access_mask |= FILE_WRITE_DATA; /* This will cause oplock breaks. */
 //	}
 //
-// Per MS-FSA §2.1.5.1.2.1, OVERWRITE / OVERWRITE_IF / SUPERSEDE on an existing
+// Per MS-FSA §2.1.5.1.2 ("Open of an Existing File"), OVERWRITE / OVERWRITE_IF / SUPERSEDE on an existing
 // file inherently truncate it and so require FILE_WRITE_DATA regardless of
 // what the client put in DesiredAccess. Samba uses `open_access_mask` for
 // BOTH the DACL access-rights check (smbd_check_access_rights_fsp) AND the
@@ -608,7 +608,7 @@ func (h *Handler) recheckExistingFileGates(d *createDraft, effectiveAccess uint3
 				return 0, false, &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusCannotDelete}}
 			}
 		}
-		// READONLY+DOC is forbidden per MS-FSA 2.1.5.1.2.1: the resulting file
+		// READONLY+DOC is forbidden per MS-FSA 2.1.5.1.1 ("Creation of a New File"): the resulting file
 		// would be marked DOC and READONLY simultaneously, but READONLY blocks
 		// the eventual unlink. Only fires when req.FileAttributes actually
 		// propagates to the resulting file — dispositions that create or
@@ -727,9 +727,10 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 			// Concurrent-create race: another opener won between our
 			// pre-create lookup and the metadata-store transaction. For
 			// dispositions that accept an existing target (OPEN_IF,
-			// OVERWRITE_IF, SUPERSEDE), MS-FSA §2.1.5.1.1 requires falling
-			// back to the existing-file branch — not surfacing the race as
-			// OBJECT_NAME_COLLISION. Required by smbtorture
+			// OVERWRITE_IF, SUPERSEDE), fall back to the existing-file branch
+			// rather than surfacing the race as OBJECT_NAME_COLLISION. MS-FSA
+			// has no concurrency model and does not specify this; it is
+			// required by smbtorture
 			// smb2.create.mkdir-dup (two parallel OPEN_IF on the same
 			// directory name MUST yield 1 CREATED + 1 EXISTED). Strict-CREATE
 			// (FILE_CREATE / FILE_OVERWRITE) still surfaces the collision per
@@ -893,7 +894,7 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 	// inherited DACL. The inherited DACL governs subsequent opens by other
 	// principals — it does not narrow the creator's handle. This matches
 	// Samba `source3/smbd/open.c::open_file_ntcreate`, which only runs the
-	// DACL check on existing-file paths, and MS-FSA §2.1.5.1.2 CreateFile
+	// DACL check on existing-file paths, and MS-FSA §2.1.5.1.1 ("Creation of a New File") CreateFile
 	// (the DesiredAccess check is gated by the parent DACL, not the new
 	// child's inherited DACL). Re-checking would surface the smbtorture
 	// failure in smb2.acls.INHERITANCE/INHERITFLAGS/SDFLAGSVSCHOWN, where

--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -554,7 +554,7 @@ func (h *Handler) recheckExistingFileGates(d *createDraft, effectiveAccess uint3
 	// the QUERY_INFO open-level access gate (MS-SMB2 §3.3.5.20.1).
 	if fileExists && existingFile != nil {
 		// Fetch parent so CheckFileAccessWithParent can apply the
-		// FILE_DELETE_CHILD override per MS-FSA §2.1.4.13 (Samba
+		// FILE_DELETE_CHILD override per MS-FSA §2.1.5.1.2.1 ("Algorithm to Check Access to an Existing File") (Samba
 		// parent_override_delete). Best-effort: a parent-lookup failure
 		// falls back to file-only DACL evaluation (nil parent is safe).
 		var parentFile *metadata.File

--- a/internal/adapter/smb/handlers/create_race_recovery_gates_test.go
+++ b/internal/adapter/smb/handlers/create_race_recovery_gates_test.go
@@ -355,7 +355,7 @@ func TestCreate_RaceRecovery_OpenIfNonRootInheritedACLSucceeds(t *testing.T) {
 		},
 		// Mirror real SMB sessions, which set this so a parent DACL lacking
 		// FILE_TRAVERSE does not block resolution of a child the requester may
-		// open (MS-FSA §2.1.5.1.1; handler.go sets it on every SMB AuthContext).
+		// open (MS-FSA §2.1.5.1 Phase 6 ("Location of file"); handler.go sets it on every SMB AuthContext).
 		BypassTraverseChecking: true,
 	}
 

--- a/internal/adapter/smb/handlers/disconnected_state_machine.go
+++ b/internal/adapter/smb/handlers/disconnected_state_machine.go
@@ -31,7 +31,7 @@ import (
 //     after timeout; we collapse the two steps).
 //
 //   - A new open with FILE_SHARE_NONE on a file with a disconnected handle
-//     purges the disconnected handle (share-mode conflict, MS-FSA 2.1.5.1.2).
+//     purges the disconnected handle (share-mode conflict, MS-FSA 2.1.5.1.2.2 ("Algorithm to Check Sharing Access to an Existing Stream or Directory")).
 //
 //   - A new data-access open whose access the disconnected handle's OWN deny
 //     mode excludes (e.g. D opened FILE_SHARE_NONE, new open wants read/write)
@@ -192,7 +192,7 @@ const (
 // Decision rules (see file-level comment for spec mapping):
 //
 //   - newShareAccess excludes all of {READ, WRITE, DELETE} (SHARE_NONE) →
-//     purge (MS-FSA 2.1.5.1.2 share-mode conflict on the NEW open's deny mode).
+//     purge (MS-FSA 2.1.5.1.2.2 ("Algorithm to Check Sharing Access to an Existing Stream or Directory") share-mode conflict on the NEW open's deny mode).
 //   - D was opened with a deny mode that excludes the new open's access
 //     (D.ShareAccess denies new.DesiredAccess) → purge. This is the V1
 //     durable_open.open2-lease case: D held an RH lease with FILE_SHARE_NONE,

--- a/internal/adapter/smb/handlers/doc_election.go
+++ b/internal/adapter/smb/handlers/doc_election.go
@@ -11,7 +11,7 @@ import (
 )
 
 // docDecision is the outcome of the delete-on-close last-handle election for
-// one closing handle (MS-FSA 2.1.5.5 ("Server Requests Closing of an Open"): the unlink happens when the LAST handle
+// one closing handle (MS-FSA 2.1.5.5 ("Server Requests Closing an Open"): the unlink happens when the LAST handle
 // on the file closes).
 type docDecision int
 
@@ -165,7 +165,7 @@ func (h *Handler) electDeleteOnClose(openFile *OpenFile) (docDecision, docTarget
 	}
 
 	// For base-file DOC on a non-stream handle, open stream handles (ADS) on
-	// the same base file also hold the deletion back. Per MS-FSA 2.1.5.5 ("Server Requests Closing of an Open") /
+	// the same base file also hold the deletion back. Per MS-FSA 2.1.5.5 ("Server Requests Closing an Open") /
 	// MS-SMB2 3.3.5.10 the removal is deferred until all handles — including
 	// stream handles — are closed. Marking them with BaseFileDeletePending
 	// makes the CLOSE of the last stream trigger the base file removal

--- a/internal/adapter/smb/handlers/doc_election.go
+++ b/internal/adapter/smb/handlers/doc_election.go
@@ -165,7 +165,7 @@ func (h *Handler) electDeleteOnClose(openFile *OpenFile) (docDecision, docTarget
 	}
 
 	// For base-file DOC on a non-stream handle, open stream handles (ADS) on
-	// the same base file also hold the deletion back. Per MS-FSA 2.1.5.9.7 /
+	// the same base file also hold the deletion back. Per MS-FSA 2.1.5.5 ("Server Requests Closing of an Open") /
 	// MS-SMB2 3.3.5.10 the removal is deferred until all handles — including
 	// stream handles — are closed. Marking them with BaseFileDeletePending
 	// makes the CLOSE of the last stream trigger the base file removal
@@ -346,7 +346,7 @@ func (h *Handler) removeElectedTarget(
 		"isDir", isDeleteTargetDir,
 		"isBaseFileDelete", target.IsBaseFile)
 
-	// Per MS-FSA 2.1.5.9.7 deleting a file deletes all its streams. The
+	// Per MS-FSA 2.1.5.1.2.1 ("Algorithm to Check Access to an Existing File") deleting a file deletes all its streams. The
 	// streams are sibling entries named `base:stream`, so removing the base
 	// entry alone leaves them behind.
 	if !isDeleteTargetDir && !strings.Contains(target.FileName, ":") {

--- a/internal/adapter/smb/handlers/doc_election.go
+++ b/internal/adapter/smb/handlers/doc_election.go
@@ -11,7 +11,7 @@ import (
 )
 
 // docDecision is the outcome of the delete-on-close last-handle election for
-// one closing handle (MS-FSA 2.1.5.4: the unlink happens when the LAST handle
+// one closing handle (MS-FSA 2.1.5.5 ("Server Requests Closing of an Open"): the unlink happens when the LAST handle
 // on the file closes).
 type docDecision int
 

--- a/internal/adapter/smb/handlers/ea.go
+++ b/internal/adapter/smb/handlers/ea.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ============================================================================
-// FILE_FULL_EA_INFORMATION wire codec (MS-FSCC §2.4.15)
+// FILE_FULL_EA_INFORMATION wire codec (MS-FSCC §2.4.16 ("FileFullEaInformation"))
 // ============================================================================
 //
 // A FILE_FULL_EA_INFORMATION chain encodes a file's extended attributes as a
@@ -54,7 +54,7 @@ func decodeFullEaEntries(buffer []byte) ([]eaEntry, error) {
 		valueLen := int(uint16(buffer[offset+6]) | uint16(buffer[offset+7])<<8)
 		nameStart := offset + 8
 		nameEnd := nameStart + nameLen
-		// +1 for the trailing NUL byte mandated by MS-FSCC §2.4.15.
+		// +1 for the trailing NUL byte mandated by MS-FSCC §2.4.16 ("FileFullEaInformation").
 		if nameEnd+1 > len(buffer) {
 			return nil, fmt.Errorf("FILE_FULL_EA_INFORMATION: name at offset %d truncated", offset)
 		}
@@ -84,7 +84,7 @@ func decodeFullEaEntries(buffer []byte) ([]eaEntry, error) {
 }
 
 // eaMutationsFromEntries converts decoded SET_INFO EA entries into store
-// EAMutations. Per MS-FSCC §2.4.15 and Samba (smbd ea set): an entry with a
+// EAMutations. Per MS-FSCC §2.4.16 ("FileFullEaInformation") and Samba (smbd ea set): an entry with a
 // zero-length value DELETES the named EA; a non-empty value upserts it. The
 // reserved ACL-xattr name is filtered by the caller before this runs.
 func eaMutationsFromEntries(entries []eaEntry) []metadata.EAMutation {
@@ -100,7 +100,7 @@ func eaMutationsFromEntries(entries []eaEntry) []metadata.EAMutation {
 }
 
 // encodeFullEaInformation serialises a file's extended attributes into a
-// FILE_FULL_EA_INFORMATION chain (MS-FSCC §2.4.15). EAs are emitted in a
+// FILE_FULL_EA_INFORMATION chain (MS-FSCC §2.4.16 ("FileFullEaInformation")). EAs are emitted in a
 // stable, case-insensitive name order so the wire output is deterministic.
 // The reserved ACL-xattr slot (security.NTACL) is never enumerated — it is
 // the server's private NT-ACL store, mirroring Samba's vfs_acl_xattr.
@@ -114,7 +114,7 @@ func encodeFullEaInformation(eas map[string][]byte) []byte {
 			continue
 		}
 		// EaNameLength is a uint8 and EaValueLength a uint16 on the wire
-		// (MS-FSCC §2.4.15). Skip any entry that cannot be represented rather
+		// (MS-FSCC §2.4.16 ("FileFullEaInformation")). Skip any entry that cannot be represented rather
 		// than emit a length field that wraps and corrupts the chain. EAs
 		// arriving via SMB are already bounded by these field widths; this only
 		// guards values written through a non-SMB metadata path. Filtering here
@@ -169,7 +169,7 @@ func encodeFullEaInformation(eas map[string][]byte) []byte {
 }
 
 // fullEaInformationSize returns the number of bytes the EA chain for these EAs
-// occupies on the wire (MS-FSCC §2.4.15), used to populate the EaSize field of
+// occupies on the wire (MS-FSCC §2.4.16 ("FileFullEaInformation")), used to populate the EaSize field of
 // FILE_ALL_INFORMATION / FILE_EA_INFORMATION. Matches encodeFullEaInformation's
 // layout exactly (including inter-entry 4-byte padding).
 func fullEaInformationSize(eas map[string][]byte) uint32 {

--- a/internal/adapter/smb/handlers/fileid_test.go
+++ b/internal/adapter/smb/handlers/fileid_test.go
@@ -18,7 +18,7 @@ import (
 // observe it on a single file:
 //
 //  1. QFid create context response (DiskFileId, first 8 bytes)
-//  2. FileInternalInformation [MS-FSCC §2.4.20]
+//  2. FileInternalInformation [MS-FSCC §2.4.27 (FileInternalInformation)]
 //  3. FileAllInformation embedded InternalInformation field [MS-FSCC §2.4.2]
 //  4. FileIdBothDirectoryInformation FileId field via QUERY_DIRECTORY
 //
@@ -223,7 +223,7 @@ func TestFileID_UniqueAcrossSiblings(t *testing.T) {
 // readFirstNamedEntryFileID drives QueryDirectory with FileIdBothDirectoryInformation
 // and an exact-name pattern, returning the FileId field of the matched entry.
 // The wire format for FILE_ID_BOTH_DIR_INFORMATION places FileId at offset 96
-// within each entry [MS-FSCC §2.4.18].
+// within each entry [MS-FSCC §2.4.22 (FileIdBothDirectoryInformation)].
 func readFirstNamedEntryFileID(
 	t *testing.T,
 	h *Handler,

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -2543,7 +2543,7 @@ func adsBaseName(fileName string) string {
 }
 
 // checkShareDeleteConflict checks if any other open handle on the same file
-// lacks FILE_SHARE_DELETE in its ShareAccess. Per MS-FSA 2.1.5.14.10, a rename
+// lacks FILE_SHARE_DELETE in its ShareAccess. Per MS-FSA 2.1.5.1.2.1 ("Algorithm to Check Access to an Existing File"), a rename
 // requires all other opens to permit delete sharing. Returns true if a conflict
 // exists (rename should be blocked with STATUS_SHARING_VIOLATION).
 func (h *Handler) checkShareDeleteConflict(renameFile *OpenFile) bool {
@@ -2702,7 +2702,7 @@ func (h *Handler) anyOpenChild(dirHandle metadata.FileHandle) bool {
 
 // hasOpenHandleOnFile reports whether any open file handle (other than the
 // renamer's own handle) currently references targetMeta. Used by the
-// SET_INFO FileRenameInformation handler to enforce MS-FSA §2.1.5.14.10
+// SET_INFO FileRenameInformation handler to enforce MS-FSA §2.1.5.15.12 ("FileRenameInformation")
 // "rename overwrite onto an open file" — once any H-lease on the destination
 // has been broken to RW, the destination's open handle still blocks the
 // overwrite and must surface as STATUS_ACCESS_DENIED.

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -2609,7 +2609,7 @@ func logRenameConflictHolder(gate string, renamer, holder *OpenFile) {
 }
 
 // checkParentDirRenameConflict applies the destination-parent share-mode rule
-// from MS-FSA 2.1.5.15.12 step 8.1: the rename opens the destination directory
+// from MS-FSA 2.1.5.15.12 ("FileRenameInformation"): the rename opens the destination directory
 // with DesiredAccess FILE_ADD_FILE|SYNCHRONIZE and ShareAccess
 // FILE_SHARE_READ|FILE_SHARE_WRITE. Linking a new name into a directory is
 // therefore a WRITE against that directory, not a delete of it, so an existing

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -472,8 +472,10 @@ type OpenFile struct {
 	//     Subsequent READ / WRITE / DELETE / SET_INFO / IOCTL (sparse, copychunk,
 	//     fsctl) handlers gate against this frozen GrantedAccess rather than
 	//     re-running the checker. This is the MS-SMB2 / MS-FSA handle model
-	//     (MS-FSA §2.1.5.2/§2.1.5.3 operate on Open.GrantedAccess; §2.1.5.4
-	//     delete-on-close honors the authorization frozen at open), and it is
+	//     (MS-SMB2 §3.3.5.12/§3.3.5.13 gate READ and WRITE on Open.GrantedAccess
+	//     — MS-FSA's own read and write algorithms never consult it — and MS-FSA
+	//     §2.1.5.5 Phase 1 delete-on-close honors the authorization frozen at
+	//     open), and it is
 	//     deliberately spec-correct: an open's rights do NOT shrink or grow if
 	//     the DACL changes after the handle is granted. Re-evaluating per-op
 	//     would be a protocol bug, not a fix — a Windows client holding a valid
@@ -525,7 +527,7 @@ type OpenFile struct {
 	// Delete on close support (FileDispositionInformation).
 	//
 	// DeletePending tracks the SHARED, committed delete-on-close state per
-	// MS-FSA 2.1.5.1.2.1 and Samba `is_delete_on_close_set` (locking.tdb).
+	// MS-FSA 2.1.5.15.3 ("FileDispositionInformation") and Samba `is_delete_on_close_set` (locking.tdb).
 	// It is set ONLY by:
 	//   - SET_INFO FileDispositionInformation with DeleteFile=TRUE (an
 	//     explicit commit by an opener), or
@@ -655,7 +657,7 @@ type OpenFile struct {
 	HasDeleteOnCloseParentKey bool
 
 	// BaseFileDeletePending is set on a stream handle when the base file was
-	// unlinked while this stream was still open. Per MS-FSA 2.1.5.4, the
+	// unlinked while this stream was still open. Per MS-FSA 2.1.5.5 ("Server Requests Closing of an Open"), the
 	// actual base-file removal is deferred until all handles (including
 	// stream handles) are closed. When the last such handle closes, the
 	// CLOSE handler uses BaseFileDeleteParentHandle / BaseFileDeleteFileName
@@ -2362,7 +2364,7 @@ func (h *Handler) isFileOrBaseDeletePending(
 
 // checkShareModeConflict checks if opening a file with the given access and sharing
 // modes would conflict with any existing opens on the same file or related
-// streams. Per MS-FSA 2.1.5.1.2 + Samba semantics, share mode enforcement is:
+// streams. Per MS-FSA 2.1.5.1.2.2 ("Algorithm to Check Sharing Access to an Existing Stream or Directory") + Samba semantics, share mode enforcement is:
 //   - Same stream (same metadata handle) → always checked
 //   - Base file vs its stream (or vice versa) → checked
 //   - Stream A vs Stream B (different streams, same base) → NOT checked

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -731,7 +731,7 @@ type OpenFile struct {
 	channelSeqSet bool
 
 	// PositionInfo is the FILE_POSITION_INFORMATION CurrentByteOffset
-	// (MS-FSCC 2.4.32). Servers track this per-handle so SET/GET via
+	// (MS-FSCC 2.4.40 (FilePositionInformation)). Servers track this per-handle so SET/GET via
 	// FilePositionInformation round-trips even though network filesystems
 	// do not use it for I/O dispatch. Preserved across durable handle
 	// disconnect/reconnect (smb2.durable-open.file-position).

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -579,7 +579,7 @@ type OpenFile struct {
 	// (smb2.create.dir-alloc-size). Per-handle, in-memory, lost on close.
 	RequestedAllocSize uint64
 
-	// Timestamp freeze/unfreeze state per MS-FSA 2.1.5.14.2.
+	// Timestamp freeze/unfreeze state per MS-FSA §2.1.5.15.2 ("FileBasicInformation").
 	// When a client sends SET_INFO with FILETIME -1, the corresponding timestamp
 	// is "frozen" and MUST NOT be auto-updated by subsequent operations (WRITE, etc.).
 	// When a client sends SET_INFO with FILETIME -2, the freeze is lifted.

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -2545,8 +2545,9 @@ func adsBaseName(fileName string) string {
 }
 
 // checkShareDeleteConflict checks if any other open handle on the same file
-// lacks FILE_SHARE_DELETE in its ShareAccess. Per MS-FSA 2.1.5.1.2.1 ("Algorithm to Check Access to an Existing File"), a rename
-// requires all other opens to permit delete sharing. Returns true if a conflict
+// lacks FILE_SHARE_DELETE in its ShareAccess. MS-FSA 2.1.5.15.12
+// ("FileRenameInformation") states no share-mode check; requiring all other
+// opens to permit delete sharing follows Samba `can_rename`. Returns true if a conflict
 // exists (rename should be blocked with STATUS_SHARING_VIOLATION).
 func (h *Handler) checkShareDeleteConflict(renameFile *OpenFile) bool {
 	const fileShareDelete = uint32(0x04) // FILE_SHARE_DELETE

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -657,7 +657,7 @@ type OpenFile struct {
 	HasDeleteOnCloseParentKey bool
 
 	// BaseFileDeletePending is set on a stream handle when the base file was
-	// unlinked while this stream was still open. Per MS-FSA 2.1.5.5 ("Server Requests Closing of an Open"), the
+	// unlinked while this stream was still open. Per MS-FSA 2.1.5.5 ("Server Requests Closing an Open"), the
 	// actual base-file removal is deferred until all handles (including
 	// stream handles) are closed. When the last such handle closes, the
 	// CLOSE handler uses BaseFileDeleteParentHandle / BaseFileDeleteFileName

--- a/internal/adapter/smb/handlers/handler_test.go
+++ b/internal/adapter/smb/handlers/handler_test.go
@@ -701,7 +701,7 @@ func TestCheckShareModeConflict_ADSCrossStream(t *testing.T) {
 		fileShareWrite = uint32(0x02)
 	)
 
-	// Per MS-FSA 2.1.5.1.2: share mode enforcement is per-stream.
+	// Per MS-FSA 2.1.5.1.2.2 ("Algorithm to Check Sharing Access to an Existing Stream or Directory"): share mode enforcement is per-stream.
 	// Opens on different streams of the same base file do NOT conflict.
 
 	t.Run("BaseFileVsStream_DeleteConflict", func(t *testing.T) {

--- a/internal/adapter/smb/handlers/ioctl_copychunk.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk.go
@@ -559,9 +559,10 @@ func (h *Handler) executeCopyChunks(
 	// Per MS-FSA §2.1.5.15.2 ("FileBasicInformation"): restore frozen timestamps after writes
 	h.restoreFrozenTimestamps(authCtx, dstOpen)
 
-	// Update LastAccessTime on the source per MS-FSA 2.1.4.20 ("Algorithm for
-	// Noting That a File Has Been Accessed") and the destination's modification
-	// time per 2.1.5.4 via 2.1.4.17.
+	// Update LastAccessTime on both the source (read) and the destination
+	// (written through, and so also accessed), per MS-FSA 2.1.4.20 ("Algorithm
+	// for Noting That a File Has Been Accessed"). The destination parent's atime
+	// is bumped too; MS-FSA specifies no parent-directory timestamp update here.
 	// Hoist a single timestamp for consistency (matches write.go pattern).
 	now := time.Now()
 	// IsAtimeFrozen takes the per-OpenFile read lock; see #606.

--- a/internal/adapter/smb/handlers/ioctl_copychunk.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk.go
@@ -556,7 +556,7 @@ func (h *Handler) executeCopyChunks(
 	// This ensures close.go flushes block store data correctly.
 	dstOpen.SetPayloadID(lastWritePayloadID)
 
-	// Per MS-FSA 2.1.5.14.2: restore frozen timestamps after writes
+	// Per MS-FSA §2.1.5.15.2 ("FileBasicInformation"): restore frozen timestamps after writes
 	h.restoreFrozenTimestamps(authCtx, dstOpen)
 
 	// Per MS-FSA 2.1.5.3: update LastAccessTime on source (read) and destination (write).

--- a/internal/adapter/smb/handlers/ioctl_copychunk.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk.go
@@ -559,7 +559,9 @@ func (h *Handler) executeCopyChunks(
 	// Per MS-FSA §2.1.5.15.2 ("FileBasicInformation"): restore frozen timestamps after writes
 	h.restoreFrozenTimestamps(authCtx, dstOpen)
 
-	// Per MS-FSA 2.1.5.3: update LastAccessTime on source (read) and destination (write).
+	// Update LastAccessTime on the source per MS-FSA 2.1.4.20 ("Algorithm for
+	// Noting That a File Has Been Accessed") and the destination's modification
+	// time per 2.1.5.4 via 2.1.4.17.
 	// Hoist a single timestamp for consistency (matches write.go pattern).
 	now := time.Now()
 	// IsAtimeFrozen takes the per-OpenFile read lock; see #606.

--- a/internal/adapter/smb/handlers/ioctl_dispatch.go
+++ b/internal/adapter/smb/handlers/ioctl_dispatch.go
@@ -230,7 +230,7 @@ func parseIoctlFileID(body []byte) ([16]byte, bool) {
 	return fileID, true
 }
 
-// handleIsPathnameValid handles FSCTL_IS_PATHNAME_VALID [MS-FSCC] 2.3.33.
+// handleIsPathnameValid handles FSCTL_IS_PATHNAME_VALID [MS-FSCC] 2.3.35 (FSCTL_IS_PATHNAME_VALID Request).
 // Returns STATUS_SUCCESS (all pathnames are considered valid).
 func (h *Handler) handleIsPathnameValid(ctx *SMBHandlerContext, body []byte) (*HandlerResult, error) {
 	logger.Debug("IOCTL FSCTL_IS_PATHNAME_VALID: returning success")

--- a/internal/adapter/smb/handlers/ioctl_fsctl.go
+++ b/internal/adapter/smb/handlers/ioctl_fsctl.go
@@ -126,7 +126,7 @@ func (h *Handler) handleSetCompression(ctx *SMBHandlerContext, body []byte) (*Ha
 }
 
 // handleGetIntegrityInfo handles FSCTL_GET_INTEGRITY_INFORMATION [MS-FSCC] 2.3.19 (FSCTL_GET_INTEGRITY_INFORMATION Request).
-// Per MS-FSA 2.1.5.9.15: if the object store does not implement this functionality,
+// Per MS-FSA 2.1.5.10.10 ("FSCTL_GET_INTEGRITY_INFORMATION"): if the object store does not implement this functionality,
 // the operation MUST be failed with STATUS_INVALID_DEVICE_REQUEST.
 func (h *Handler) handleGetIntegrityInfo(ctx *SMBHandlerContext, body []byte) (*HandlerResult, error) {
 	logger.Debug("IOCTL FSCTL_GET_INTEGRITY_INFORMATION: not supported (INVALID_DEVICE_REQUEST)")
@@ -134,7 +134,7 @@ func (h *Handler) handleGetIntegrityInfo(ctx *SMBHandlerContext, body []byte) (*
 }
 
 // handleSetIntegrityInfo handles FSCTL_SET_INTEGRITY_INFORMATION [MS-FSCC] 2.3.73 (FSCTL_SET_INTEGRITY_INFORMATION Request).
-// Per MS-FSA 2.1.5.9.29: if the object store does not implement this functionality,
+// Per MS-FSA 2.1.5.10.33 ("FSCTL_SET_INTEGRITY_INFORMATION"): if the object store does not implement this functionality,
 // the operation MUST be failed with STATUS_INVALID_DEVICE_REQUEST.
 func (h *Handler) handleSetIntegrityInfo(ctx *SMBHandlerContext, body []byte) (*HandlerResult, error) {
 	logger.Debug("IOCTL FSCTL_SET_INTEGRITY_INFORMATION: not supported (INVALID_DEVICE_REQUEST)")
@@ -143,7 +143,7 @@ func (h *Handler) handleSetIntegrityInfo(ctx *SMBHandlerContext, body []byte) (*
 
 // handleGetObjectID handles FSCTL_GET_OBJECT_ID [MS-FSCC] 2.3.25 (FSCTL_GET_OBJECT_ID Request).
 // Returns a deterministic object ID derived from the file handle.
-// Per MS-FSA 2.1.5.9.17: return the object ID for the file.
+// Per MS-FSA 2.1.5.10.13 ("FSCTL_GET_OBJECT_ID"): return the object ID for the file.
 func (h *Handler) handleGetObjectID(ctx *SMBHandlerContext, body []byte) (*HandlerResult, error) {
 	return h.buildObjectIDResponse(FsctlGetObjectID, body)
 }
@@ -190,7 +190,7 @@ func (h *Handler) buildObjectIDResponse(ctlCode uint32, body []byte) (*HandlerRe
 }
 
 // handleMarkHandle handles FSCTL_MARK_HANDLE [MS-FSCC] 2.3.39 (FSCTL_MARK_HANDLE Request).
-// Per MS-FSA 2.1.5.9.20: for directory streams, fail with STATUS_DIRECTORY_NOT_SUPPORTED.
+// Per MS-FSA 2.1.5.10.19 ("FSCTL_MARK_HANDLE"): for directory streams, fail with STATUS_DIRECTORY_NOT_SUPPORTED.
 // For data streams, return STATUS_SUCCESS.
 func (h *Handler) handleMarkHandle(ctx *SMBHandlerContext, body []byte) (*HandlerResult, error) {
 	fileID, ok := parseIoctlFileID(body)
@@ -205,7 +205,7 @@ func (h *Handler) handleMarkHandle(ctx *SMBHandlerContext, body []byte) (*Handle
 
 	logger.Debug("IOCTL FSCTL_MARK_HANDLE", "path", openFile.Name().Path, "isDir", openFile.IsDirectory)
 
-	// Per MS-FSA 2.1.5.9.20: if StreamType == DirectoryStream, fail
+	// Per MS-FSA 2.1.5.10.19 ("FSCTL_MARK_HANDLE"): if StreamType == DirectoryStream, fail
 	if openFile.IsDirectory {
 		return NewErrorResult(statusDirectoryNotSupported), nil
 	}

--- a/internal/adapter/smb/handlers/ioctl_fsctl.go
+++ b/internal/adapter/smb/handlers/ioctl_fsctl.go
@@ -10,7 +10,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// handleGetCompression handles FSCTL_GET_COMPRESSION [MS-FSCC] 2.3.9.
+// handleGetCompression handles FSCTL_GET_COMPRESSION [MS-FSCC] 2.3.17 (FSCTL_GET_COMPRESSION Request).
 // Returns the compression format for the open file. DittoFS does not actually
 // compress data, but tracks the compression state persistently in metadata.
 // The compression format is derived from the modeDOSCompressed mode bit.
@@ -44,11 +44,11 @@ func (h *Handler) handleGetCompression(ctx *SMBHandlerContext, body []byte) (*Ha
 	return NewResult(types.StatusSuccess, resp), nil
 }
 
-// handleSetCompression handles FSCTL_SET_COMPRESSION [MS-FSCC] 2.3.53.
+// handleSetCompression handles FSCTL_SET_COMPRESSION [MS-FSCC] 2.3.67 (FSCTL_SET_COMPRESSION Request).
 // Validates the compression format and persists the state to metadata.
 // DittoFS does not actually compress data but maintains protocol-correct state,
 // including FILE_ATTRIBUTE_COMPRESSED in file attributes.
-// Per MS-FSCC 2.3.53: valid values are 0 (NONE), 1 (DEFAULT), 2 (LZNT1).
+// Per MS-FSCC 2.3.67 (FSCTL_SET_COMPRESSION Request): valid values are 0 (NONE), 1 (DEFAULT), 2 (LZNT1).
 func (h *Handler) handleSetCompression(ctx *SMBHandlerContext, body []byte) (*HandlerResult, error) {
 	fileID, ok := parseIoctlFileID(body)
 	if !ok {
@@ -85,7 +85,7 @@ func (h *Handler) handleSetCompression(ctx *SMBHandlerContext, body []byte) (*Ha
 	format := uint16(inputData[0]) | uint16(inputData[1])<<8
 	logger.Debug("IOCTL FSCTL_SET_COMPRESSION", "format", format)
 
-	// Per MS-FSCC 2.3.53: valid formats are 0 (NONE), 1 (DEFAULT), 2 (LZNT1).
+	// Per MS-FSCC 2.3.67 (FSCTL_SET_COMPRESSION Request): valid formats are 0 (NONE), 1 (DEFAULT), 2 (LZNT1).
 	// DEFAULT and LZNT1 both map to LZNT1 (the only compression algorithm NTFS supports).
 	var compressed bool
 	switch format {
@@ -125,7 +125,7 @@ func (h *Handler) handleSetCompression(ctx *SMBHandlerContext, body []byte) (*Ha
 	return NewResult(types.StatusSuccess, resp), nil
 }
 
-// handleGetIntegrityInfo handles FSCTL_GET_INTEGRITY_INFORMATION [MS-FSCC] 2.3.25.
+// handleGetIntegrityInfo handles FSCTL_GET_INTEGRITY_INFORMATION [MS-FSCC] 2.3.19 (FSCTL_GET_INTEGRITY_INFORMATION Request).
 // Per MS-FSA 2.1.5.9.15: if the object store does not implement this functionality,
 // the operation MUST be failed with STATUS_INVALID_DEVICE_REQUEST.
 func (h *Handler) handleGetIntegrityInfo(ctx *SMBHandlerContext, body []byte) (*HandlerResult, error) {
@@ -133,7 +133,7 @@ func (h *Handler) handleGetIntegrityInfo(ctx *SMBHandlerContext, body []byte) (*
 	return NewErrorResult(types.StatusInvalidDeviceRequest), nil
 }
 
-// handleSetIntegrityInfo handles FSCTL_SET_INTEGRITY_INFORMATION [MS-FSCC] 2.3.55.
+// handleSetIntegrityInfo handles FSCTL_SET_INTEGRITY_INFORMATION [MS-FSCC] 2.3.73 (FSCTL_SET_INTEGRITY_INFORMATION Request).
 // Per MS-FSA 2.1.5.9.29: if the object store does not implement this functionality,
 // the operation MUST be failed with STATUS_INVALID_DEVICE_REQUEST.
 func (h *Handler) handleSetIntegrityInfo(ctx *SMBHandlerContext, body []byte) (*HandlerResult, error) {
@@ -141,14 +141,14 @@ func (h *Handler) handleSetIntegrityInfo(ctx *SMBHandlerContext, body []byte) (*
 	return NewErrorResult(types.StatusInvalidDeviceRequest), nil
 }
 
-// handleGetObjectID handles FSCTL_GET_OBJECT_ID [MS-FSCC] 2.3.28.
+// handleGetObjectID handles FSCTL_GET_OBJECT_ID [MS-FSCC] 2.3.25 (FSCTL_GET_OBJECT_ID Request).
 // Returns a deterministic object ID derived from the file handle.
 // Per MS-FSA 2.1.5.9.17: return the object ID for the file.
 func (h *Handler) handleGetObjectID(ctx *SMBHandlerContext, body []byte) (*HandlerResult, error) {
 	return h.buildObjectIDResponse(FsctlGetObjectID, body)
 }
 
-// handleCreateOrGetObjectID handles FSCTL_CREATE_OR_GET_OBJECT_ID [MS-FSCC] 2.3.7.
+// handleCreateOrGetObjectID handles FSCTL_CREATE_OR_GET_OBJECT_ID [MS-FSCC] 2.3.1 (FSCTL_CREATE_OR_GET_OBJECT_ID Request).
 // Returns the same object ID as FSCTL_GET_OBJECT_ID (creates if not present).
 func (h *Handler) handleCreateOrGetObjectID(ctx *SMBHandlerContext, body []byte) (*HandlerResult, error) {
 	return h.buildObjectIDResponse(FsctlCreateOrGetObjectID, body)
@@ -189,7 +189,7 @@ func (h *Handler) buildObjectIDResponse(ctlCode uint32, body []byte) (*HandlerRe
 	return NewResult(types.StatusSuccess, resp), nil
 }
 
-// handleMarkHandle handles FSCTL_MARK_HANDLE [MS-FSCC] 2.3.36.
+// handleMarkHandle handles FSCTL_MARK_HANDLE [MS-FSCC] 2.3.39 (FSCTL_MARK_HANDLE Request).
 // Per MS-FSA 2.1.5.9.20: for directory streams, fail with STATUS_DIRECTORY_NOT_SUPPORTED.
 // For data streams, return STATUS_SUCCESS.
 func (h *Handler) handleMarkHandle(ctx *SMBHandlerContext, body []byte) (*HandlerResult, error) {
@@ -214,7 +214,7 @@ func (h *Handler) handleMarkHandle(ctx *SMBHandlerContext, body []byte) (*Handle
 	return NewResult(types.StatusSuccess, resp), nil
 }
 
-// handleQueryFileRegions handles FSCTL_QUERY_FILE_REGIONS [MS-FSCC] 2.3.51.
+// handleQueryFileRegions handles FSCTL_QUERY_FILE_REGIONS [MS-FSCC] 2.3.55 (FSCTL_QUERY_FILE_REGIONS Request).
 // Returns a single region covering the entire file (all data is allocated).
 func (h *Handler) handleQueryFileRegions(ctx *SMBHandlerContext, body []byte) (*HandlerResult, error) {
 	fileID, ok := parseIoctlFileID(body)
@@ -237,7 +237,7 @@ func (h *Handler) handleQueryFileRegions(ctx *SMBHandlerContext, body []byte) (*
 	}
 	size := getSMBSize(&file.FileAttr)
 
-	// FILE_REGION_OUTPUT [MS-FSCC] 2.3.51:
+	// FILE_REGION_OUTPUT [MS-FSCC] 2.3.56 (FSCTL_QUERY_FILE_REGIONS Reply):
 	// Flags(4) + TotalRegionEntryCount(4) + RegionEntryCount(4) + Reserved(4)
 	// + FILE_REGION_INFO[]: FileOffset(8) + Length(8) + Usage(4) + Reserved(4)
 	var w *smbenc.Writer

--- a/internal/adapter/smb/handlers/ioctl_sparse.go
+++ b/internal/adapter/smb/handlers/ioctl_sparse.go
@@ -149,7 +149,9 @@ func (h *Handler) handleQueryAllocatedRanges(ctx *SMBHandlerContext, body []byte
 	}
 	path := openFile.Name().Path
 
-	// MS-FSA §2.1.5.10.4 / Samba `fsctl_qar`: requires FILE_READ_DATA.
+	// Samba `fsctl_qar` requires FILE_READ_DATA. MS-FSA 2.1.5.10.22 states no
+	// such gate; the requirement comes from the FSCTL access rules in MS-SMB2
+	// §3.3.5.15.
 	if openFile.GrantedAccess&uint32(types.FileReadData) == 0 {
 		logger.Debug("IOCTL FSCTL_QUERY_ALLOCATED_RANGES: handle lacks FILE_READ_DATA",
 			"path", path,
@@ -381,7 +383,7 @@ func (h *Handler) handleSetZeroData(ctx *SMBHandlerContext, body []byte) (*Handl
 		return NewErrorResult(types.StatusInvalidDeviceRequest), nil
 	}
 
-	// MS-FSA §2.1.5.10.35: SET_ZERO_DATA requires FILE_WRITE_DATA.
+	// MS-FSA §2.1.5.10.39 ("FSCTL_SET_ZERO_DATA"): SET_ZERO_DATA requires FILE_WRITE_DATA.
 	if openFile.GrantedAccess&uint32(types.FileWriteData) == 0 {
 		logger.Debug("IOCTL FSCTL_SET_ZERO_DATA: handle lacks FILE_WRITE_DATA",
 			"path", path,

--- a/internal/adapter/smb/handlers/ioctl_sparse.go
+++ b/internal/adapter/smb/handlers/ioctl_sparse.go
@@ -383,7 +383,9 @@ func (h *Handler) handleSetZeroData(ctx *SMBHandlerContext, body []byte) (*Handl
 		return NewErrorResult(types.StatusInvalidDeviceRequest), nil
 	}
 
-	// MS-FSA §2.1.5.10.39 ("FSCTL_SET_ZERO_DATA"): SET_ZERO_DATA requires FILE_WRITE_DATA.
+	// SET_ZERO_DATA requires FILE_WRITE_DATA. MS-FSA 2.1.5.10.39
+	// ("FSCTL_SET_ZERO_DATA") states no such gate; the requirement comes from the
+	// FSCTL access rules in MS-SMB2 §3.3.5.15.
 	if openFile.GrantedAccess&uint32(types.FileWriteData) == 0 {
 		logger.Debug("IOCTL FSCTL_SET_ZERO_DATA: handle lacks FILE_WRITE_DATA",
 			"path", path,

--- a/internal/adapter/smb/handlers/ioctl_sparse.go
+++ b/internal/adapter/smb/handlers/ioctl_sparse.go
@@ -24,13 +24,13 @@ import (
 // no STATUS_NOT_SUPPORTED) match without touching the on-disk format.
 //
 // Spec references:
-//   - FSCTL_SET_SPARSE             MS-FSCC §2.3.50 / §2.3.51
-//   - FSCTL_QUERY_ALLOCATED_RANGES MS-FSCC §2.3.32 / §2.3.33
-//   - FSCTL_SET_ZERO_DATA          MS-FSCC §2.3.67 / §2.3.68
+//   - FSCTL_SET_SPARSE             MS-FSCC §2.3.83 / §2.3.84 (Request / Reply)
+//   - FSCTL_QUERY_ALLOCATED_RANGES MS-FSCC §2.3.51 / §2.3.52 (Request / Reply)
+//   - FSCTL_SET_ZERO_DATA          MS-FSCC §2.3.85 / §2.3.86 (Request / Reply)
 //
 // Samba reference: source3/smbd/smb2_ioctl_filesys.c
 
-// handleSetSparse handles FSCTL_SET_SPARSE [MS-FSCC] 2.3.50.
+// handleSetSparse handles FSCTL_SET_SPARSE [MS-FSCC] 2.3.83 (FSCTL_SET_SPARSE Request).
 //
 // Input is optional: empty → set sparse (Samba `vfswrap_fsctl` default); a
 // 1+-byte FILE_SET_SPARSE_BUFFER where SetSparse byte 0 == 0 clears the
@@ -83,7 +83,7 @@ func (h *Handler) handleSetSparse(ctx *SMBHandlerContext, body []byte) (*Handler
 		return NewErrorResult(types.StatusAccessDenied), nil
 	}
 
-	// MS-FSCC §2.3.50: empty input defaults to SetSparse=TRUE. Any byte > 0
+	// MS-FSCC §2.3.83 (FSCTL_SET_SPARSE Request): empty input defaults to SetSparse=TRUE. Any byte > 0
 	// sets sparse, 0x00 clears. Inputs larger than 1 byte are accepted —
 	// only the first byte is inspected (Samba parity, sparse_set_oversize).
 	setSparse := true
@@ -246,7 +246,7 @@ func (h *Handler) handleQueryAllocatedRanges(ctx *SMBHandlerContext, body []byte
 	return NewResult(status, resp), nil
 }
 
-// allocatedRange mirrors FILE_ALLOCATED_RANGE_BUFFER (MS-FSCC §2.3.32).
+// allocatedRange mirrors FILE_ALLOCATED_RANGE_BUFFER (MS-FSCC §2.3.52 (FSCTL_QUERY_ALLOCATED_RANGES Reply)).
 type allocatedRange struct {
 	Offset uint64
 	Length uint64
@@ -258,7 +258,7 @@ type allocatedRange struct {
 // reports the hole accurately. Within a cluster, presence of any non-zero
 // byte marks the whole cluster as allocated — matches the "FSCTL_QUERY_
 // ALLOCATED_RANGES returns extents, not byte-level holes" semantic in
-// MS-FSCC §2.3.32 and avoids fragmenting pattern data (whose individual
+// MS-FSCC §2.3.52 (FSCTL_QUERY_ALLOCATED_RANGES Reply) and avoids fragmenting pattern data (whose individual
 // bytes contain interior zeros) into hundreds of tiny ranges.
 const sparseClusterSize = uint64(4096)
 
@@ -357,7 +357,7 @@ const fileZeroDataBufSize = 16
 // preceding FSCTL pushed the file past the WRITE cap.
 const zeroDataMaxFileSize = uint64(0xFFFFFFF0000) // ~16 TiB, identical to WRITE handler
 
-// handleSetZeroData handles FSCTL_SET_ZERO_DATA [MS-FSCC] 2.3.67.
+// handleSetZeroData handles FSCTL_SET_ZERO_DATA [MS-FSCC] 2.3.85 (FSCTL_SET_ZERO_DATA Request).
 //
 // Writes zeros across the [FileOffset, BeyondFinalZero) byte window. We
 // honour the request by issuing zero-filled writes through the standard

--- a/internal/adapter/smb/handlers/ioctl_sparse.go
+++ b/internal/adapter/smb/handlers/ioctl_sparse.go
@@ -60,7 +60,7 @@ func (h *Handler) handleSetSparse(ctx *SMBHandlerContext, body []byte) (*Handler
 	path := openFile.Name().Path
 
 	// FSCTL_SET_SPARSE is a file-only operation. Directories take
-	// STATUS_INVALID_PARAMETER per MS-FSA §2.1.5.9.36 and Windows behaviour.
+	// STATUS_INVALID_PARAMETER per MS-FSA §2.1.5.10.38 ("FSCTL_SET_SPARSE") and Windows behaviour.
 	if openFile.IsDirectory {
 		logger.Debug("IOCTL FSCTL_SET_SPARSE: rejected on directory",
 			"path", path)
@@ -131,7 +131,7 @@ const fileAllocatedRangeBufSize = 16
 // satisfies smb2.ioctl.sparse_punch which asserts that SET_ZERO_DATA on a
 // sparse file makes the punched range disappear from QAR.
 //
-// Output buffer handling (MS-FSA §2.1.5.10.4, Samba `fsctl_qar`):
+// Output buffer handling (MS-FSA §2.1.5.10.22 ("FSCTL_QUERY_ALLOCATED_RANGES"), Samba `fsctl_qar`):
 //   - MaxOutputResponse == 0 and at least one range to report:
 //     STATUS_BUFFER_TOO_SMALL (smb2.ioctl.sparse_qar_malformed).
 //   - MaxOutputResponse < total range bytes: truncate to whole entries that

--- a/internal/adapter/smb/handlers/ioctl_sparse_test.go
+++ b/internal/adapter/smb/handlers/ioctl_sparse_test.go
@@ -176,7 +176,7 @@ func TestQueryAllocatedRanges_NegativeOffset(t *testing.T) {
 }
 
 // TestSetZeroData_AccessDenied verifies the write-access gate. Read-only
-// handles must not be able to punch holes / zero data (MS-FSA §2.1.5.10.35).
+// handles must not be able to punch holes / zero data (MS-FSA §2.1.5.10.39 ("FSCTL_SET_ZERO_DATA")).
 func TestSetZeroData_AccessDenied(t *testing.T) {
 	h := NewHandler()
 	var fileID [16]byte

--- a/internal/adapter/smb/handlers/ioctl_sparse_test.go
+++ b/internal/adapter/smb/handlers/ioctl_sparse_test.go
@@ -176,7 +176,8 @@ func TestQueryAllocatedRanges_NegativeOffset(t *testing.T) {
 }
 
 // TestSetZeroData_AccessDenied verifies the write-access gate. Read-only
-// handles must not be able to punch holes / zero data (MS-FSA §2.1.5.10.39 ("FSCTL_SET_ZERO_DATA")).
+// handles must not be able to punch holes / zero data. The gate comes from the
+// FSCTL access rules in MS-SMB2 §3.3.5.15, not from MS-FSA 2.1.5.10.39.
 func TestSetZeroData_AccessDenied(t *testing.T) {
 	h := NewHandler()
 	var fileID [16]byte

--- a/internal/adapter/smb/handlers/query_directory.go
+++ b/internal/adapter/smb/handlers/query_directory.go
@@ -939,9 +939,10 @@ func filterDirEntries(entries []metadata.DirEntry, pattern string) []metadata.Di
 
 // matchSMBPattern matches a filename against an SMB/DOS search pattern.
 //
-// Per MS-FSCC 2.1.4.4, SMB uses DOS-style wildcards including:
+// Per MS-FSA §2.1.4.4 ("Algorithm for Determining if a FileName Is in an Expression"),
+// SMB uses DOS-style wildcards including:
 //   - * matches zero or more characters
-//   - ? matches exactly one character (including dot and end-of-name)
+//   - ? matches a single character
 //   - < (DOS_STAR) matches zero or more characters until the last dot
 //   - > (DOS_QM) matches any single character, or a dot, or end-of-name
 //   - " (DOS_DOT) matches a period or end-of-name
@@ -951,7 +952,8 @@ func matchSMBPattern(name, pattern string) bool {
 	return matchDOSWildcard(strings.ToLower(name), strings.ToLower(pattern))
 }
 
-// matchDOSWildcard implements MS-FSCC 2.1.4.4 pattern matching with DOS wildcards.
+// matchDOSWildcard implements the MS-FSA §2.1.4.4 ("Algorithm for Determining if a FileName Is in an Expression")
+// pattern matching with DOS wildcards.
 func matchDOSWildcard(name, pattern string) bool {
 	ni := 0 // name index
 	pi := 0 // pattern index
@@ -989,8 +991,9 @@ func matchDOSWildcard(name, pattern string) bool {
 		case '<':
 			// DOS_STAR: matches zero or more characters until encountering and
 			// matching the final "." in the name. If no dot exists, behaves like '*'.
-			// Per MS-FSCC 2.1.4.4, this effectively matches the "base name" portion
-			// of a filename before the extension.
+			// Per MS-FSA §2.1.4.4 ("Algorithm for Determining if a FileName Is in an Expression"),
+			// this effectively matches the "base name" portion of a filename before
+			// the extension.
 			pi++
 			lastDot := strings.LastIndex(name[ni:], ".")
 			if lastDot == -1 {
@@ -1008,8 +1011,9 @@ func matchDOSWildcard(name, pattern string) bool {
 				return false
 			}
 			// DOS_STAR matches zero or more characters until the last dot, inclusive.
-			// Per MS-FSCC 2.1.4.4: "If the pattern is * (DOS_STAR), consume through
-			// the last dot." We iterate up to dotAbsPos+1 to try the match at each
+			// Per MS-FSA §2.1.4.4 ("Algorithm for Determining if a FileName Is in an Expression"):
+			// DOS_STAR "matches zero or more characters until encountering and
+			// matching the final . in the name". We iterate up to dotAbsPos+1 to try the match at each
 			// position from ni through one past the dot (the char after the dot),
 			// which allows the remaining pattern to match the extension.
 			dotAbsPos := ni + lastDot

--- a/internal/adapter/smb/handlers/query_directory.go
+++ b/internal/adapter/smb/handlers/query_directory.go
@@ -579,7 +579,7 @@ doneLoop:
 	}
 	h.StoreOpenFile(openFile)
 
-	// Per MS-FSA 2.1.5.5: After a successful directory enumeration, update
+	// Per MS-FSA 2.1.5.6.3 ("Directory Information Queries"): After a successful directory enumeration, update
 	// LastAccessTime to the current system time, unless frozen via SET_INFO -1.
 	if !openFile.AtimeFrozen {
 		now := time.Now()

--- a/internal/adapter/smb/handlers/query_info.go
+++ b/internal/adapter/smb/handlers/query_info.go
@@ -300,7 +300,7 @@ func (h *Handler) QueryInfo(ctx *SMBHandlerContext, req *QueryInfoRequest) (*Que
 	// below still wins.
 	applySmbPendingAtime(openFile, file)
 
-	// Per MS-FSA 2.1.5.14.2: Apply frozen timestamp overrides.
+	// Per MS-FSA §2.1.5.15.2 ("FileBasicInformation"): Apply frozen timestamp overrides.
 	// When SET_INFO(-1) freezes a timestamp, subsequent operations (WRITE,
 	// child CREATE/DELETE for directories, truncate) may update the store
 	// or pending state. Override the returned values with frozen values so

--- a/internal/adapter/smb/handlers/query_info.go
+++ b/internal/adapter/smb/handlers/query_info.go
@@ -84,7 +84,7 @@ type FileBasicInfo struct {
 	FileAttributes types.FileAttributes
 }
 
-// FileStandardInfo represents FILE_STANDARD_INFORMATION [MS-FSCC] 2.4.41 (24 bytes).
+// FileStandardInfo represents FILE_STANDARD_INFORMATION [MS-FSCC] 2.4.47 (FileStandardInformation) (24 bytes).
 // Used by QUERY_INFO to return file size, link count, and deletion status.
 type FileStandardInfo struct {
 	AllocationSize uint64
@@ -94,7 +94,7 @@ type FileStandardInfo struct {
 	Directory      bool
 }
 
-// FileNetworkOpenInfo represents FILE_NETWORK_OPEN_INFORMATION [MS-FSCC] 2.4.27 (56 bytes).
+// FileNetworkOpenInfo represents FILE_NETWORK_OPEN_INFORMATION [MS-FSCC] 2.4.34 (FileNetworkOpenInformation) (56 bytes).
 // Optimized for network access, combining timestamps, sizes, and attributes.
 type FileNetworkOpenInfo struct {
 	CreationTime   time.Time
@@ -185,7 +185,7 @@ func DecodeFileBasicInfo(buf []byte) (*FileBasicInfo, error) {
 	}, nil
 }
 
-// EncodeFileStandardInfo builds FILE_STANDARD_INFORMATION [MS-FSCC] 2.4.41.
+// EncodeFileStandardInfo builds FILE_STANDARD_INFORMATION [MS-FSCC] 2.4.47 (FileStandardInformation).
 func EncodeFileStandardInfo(info *FileStandardInfo) []byte {
 	w := smbenc.NewWriter(24)
 	w.WriteUint64(info.AllocationSize)
@@ -204,7 +204,7 @@ func EncodeFileStandardInfo(info *FileStandardInfo) []byte {
 	return w.Bytes()
 }
 
-// EncodeFileNetworkOpenInfo builds FILE_NETWORK_OPEN_INFORMATION [MS-FSCC] 2.4.27.
+// EncodeFileNetworkOpenInfo builds FILE_NETWORK_OPEN_INFORMATION [MS-FSCC] 2.4.34 (FileNetworkOpenInformation).
 func EncodeFileNetworkOpenInfo(info *FileNetworkOpenInfo) []byte {
 	w := smbenc.NewWriter(56)
 	w.WriteUint64(types.TimeToFiletime(info.CreationTime))
@@ -690,14 +690,14 @@ func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *me
 		return EncodeFileStandardInfo(standardInfo), nil
 
 	case types.FileInternalInformation:
-		// FILE_INTERNAL_INFORMATION [MS-FSCC] 2.4.20 (8 bytes)
+		// FILE_INTERNAL_INFORMATION [MS-FSCC] 2.4.27 (FileInternalInformation) (8 bytes)
 		fileID := h.baseFileUUID(authCtx, name.ParentHandle, name.FileName, file.ID)
 		w := smbenc.NewWriter(8)
 		w.WriteUint64(binary.LittleEndian.Uint64(fileID[:8]))
 		return w.Bytes(), nil
 
 	case types.FileEaInformation:
-		// FILE_EA_INFORMATION [MS-FSCC] 2.4.12 (4 bytes): total size of the
+		// FILE_EA_INFORMATION [MS-FSCC] 2.4.13 (FileEaInformation) (4 bytes): total size of the
 		// file's extended attributes on the wire. ADS share the base file's
 		// EAs.
 		eaSrc := &file.FileAttr
@@ -720,7 +720,7 @@ func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *me
 		return w.Bytes(), nil
 
 	case types.FileStreamInformation:
-		// FileStreamInformation [MS-FSCC] 2.4.44
+		// FileStreamInformation [MS-FSCC] 2.4.49 (FileStreamInformation)
 		// Must enumerate ALL streams: the default unnamed data stream (::$DATA)
 		// plus any Alternate Data Streams (ADS) stored as siblings in the parent dir.
 		return h.buildFileStreamInformation(authCtx, file, openFile)
@@ -747,14 +747,14 @@ func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *me
 		return EncodeFileNetworkOpenInfo(networkInfo), nil
 
 	case types.FilePositionInformation:
-		// FILE_POSITION_INFORMATION [MS-FSCC] 2.4.32 (8 bytes)
+		// FILE_POSITION_INFORMATION [MS-FSCC] 2.4.40 (FilePositionInformation) (8 bytes)
 		// Round-trip the per-handle CurrentByteOffset (see set_info.go).
 		w := smbenc.NewWriter(8)
 		w.WriteUint64(openFile.PositionInfo)
 		return w.Bytes(), nil
 
 	case types.FileModeInformation:
-		// FILE_MODE_INFORMATION [MS-FSCC] 2.4.24 (4 bytes). Mode is the open's
+		// FILE_MODE_INFORMATION [MS-FSCC] 2.4.31 (FileModeInformation) (4 bytes). Mode is the open's
 		// settable mode flags, seeded from CreateOptions at CREATE and updated
 		// by SET_INFO FileModeInformation.
 		w := smbenc.NewWriter(4)
@@ -766,7 +766,7 @@ func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *me
 		return make([]byte, 4), nil // AlignmentRequirement = 0 (byte-aligned)
 
 	case types.FileNameInformation:
-		// FILE_NAME_INFORMATION [MS-FSCC] 2.4.26 (4 bytes + variable)
+		// FILE_NAME_INFORMATION [MS-FSCC] 2.4.32 (FileNameInformation) (4 bytes + variable)
 		nameBytes := encodeUTF16LE(toSMBPath(name.Path))
 		w := smbenc.NewWriter(4 + len(nameBytes))
 		w.WriteUint32(uint32(len(nameBytes))) // FileNameLength
@@ -787,7 +787,7 @@ func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *me
 		return w.Bytes(), nil
 
 	case types.FileNormalizedNameInformation:
-		// FILE_NORMALIZED_NAME_INFORMATION [MS-FSCC] 2.4.28 (4 bytes + variable)
+		// FILE_NORMALIZED_NAME_INFORMATION [MS-FSCC] 2.4.35 (FileNormalizedNameInformation) (4 bytes + variable)
 		//
 		// Returns the canonical name relative to the share root. Per
 		// smbtorture `smb2.getinfo.normalized`, the response must reflect
@@ -819,7 +819,7 @@ func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *me
 		return w.Bytes(), nil
 
 	case types.FileIdInformation:
-		// FILE_ID_INFORMATION [MS-FSCC] 2.4.46 (24 bytes)
+		// FILE_ID_INFORMATION [MS-FSCC] 2.4.26 (FileIdInformation) (24 bytes)
 		// VolumeSerialNumber (8 bytes) + FileId (16 bytes)
 		// ADS handles report the base file's UUID so a client comparing this
 		// against FileInternalInformation on the same handle gets a consistent
@@ -867,7 +867,7 @@ func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *me
 
 	case types.FileFullEaInformation:
 		// Enumerate the file's persisted extended attributes as a
-		// FILE_FULL_EA_INFORMATION chain (MS-FSCC §2.4.15). Per NTFS, ADS
+		// FILE_FULL_EA_INFORMATION chain (MS-FSCC §2.4.16 ("FileFullEaInformation")). Per NTFS, ADS
 		// share the base file's EAs, so resolve to the base attr when this
 		// open targets a stream.
 		eaSrc := &file.FileAttr
@@ -951,7 +951,7 @@ func (h *Handler) buildFileAllInformationFromStore(authCtx *metadata.AuthContext
 	return info
 }
 
-// buildFileStreamInformation builds FILE_STREAM_INFORMATION [MS-FSCC] 2.4.44.
+// buildFileStreamInformation builds FILE_STREAM_INFORMATION [MS-FSCC] 2.4.49 (FileStreamInformation).
 //
 // Enumerates all streams on a file: the default data stream (::$DATA) plus
 // any Alternate Data Streams (ADS). ADS are stored as children of the parent
@@ -982,7 +982,7 @@ func (h *Handler) buildFileStreamInformation(authCtx *metadata.AuthContext, file
 
 	var streams []streamEntry
 
-	// Per MS-FSCC 2.4.44 / NTFS semantics: directories do NOT have a default
+	// Per MS-FSCC 2.4.49 (FileStreamInformation) / NTFS semantics: directories do NOT have a default
 	// unnamed data stream (::$DATA). Only regular files include the default
 	// stream entry. Directories only enumerate their named alternate data streams.
 	//
@@ -1188,7 +1188,7 @@ func (h *Handler) buildFilesystemInfo(ctx context.Context, class types.FileInfoC
 		// ExtendedInfo is left as zeros (not required)
 		return info, nil
 
-	case 11: // FileFsSectorSizeInformation [MS-FSCC] 2.5.8
+	case 11: // FileFsSectorSizeInformation [MS-FSCC] 2.5.7 (FileFsSectorSizeInformation)
 		// 28 bytes structure (matching Samba's implementation)
 		bps := uint32(512) // bytes per sector
 		w := smbenc.NewWriter(28)
@@ -1283,7 +1283,7 @@ func fsInfoClassMinSize(class types.FileInfoClass) uint32 {
 		return 32
 	case 8: // FileFsObjectIdInformation [MS-FSCC §2.5.6] (64 bytes)
 		return 64
-	case 11: // FileFsSectorSizeInformation [MS-FSCC §2.5.8] (28 bytes)
+	case 11: // FileFsSectorSizeInformation [MS-FSCC §2.5.7 (FileFsSectorSizeInformation)] (28 bytes)
 		return 28
 	default:
 		return 0 // Variable-length or unknown
@@ -1355,7 +1355,7 @@ func fileInfoClassRequiredAccess(class types.FileInfoClass) (uint32, bool) {
 }
 
 // fileModeInformationModeMask is the set of CreateOptions bits surfaced as the
-// FILE_MODE_INFORMATION Mode field (MS-FSCC §2.4.24): FILE_WRITE_THROUGH,
+// FILE_MODE_INFORMATION Mode field (MS-FSCC §2.4.31 (FileModeInformation)): FILE_WRITE_THROUGH,
 // FILE_SEQUENTIAL_ONLY, FILE_NO_INTERMEDIATE_BUFFERING, FILE_SYNCHRONOUS_IO_*,
 // and FILE_DELETE_ON_CLOSE.
 const fileModeInformationModeMask = types.FileWriteThrough | types.FileSequentialOnly |

--- a/internal/adapter/smb/handlers/query_info.go
+++ b/internal/adapter/smb/handlers/query_info.go
@@ -675,7 +675,8 @@ func (h *Handler) buildFileInfoFromStore(authCtx *metadata.AuthContext, file *me
 			attr = baseAttr
 		}
 		// Use name-aware variant so dot-prefixed files surface HIDDEN per
-		// MS-FSCC §2.6 (matches QUERY_DIRECTORY which always sees the name).
+		// Samba's dot-prefix convention (MS-FSCC §2.6 defines FILE_ATTRIBUTE_HIDDEN
+		// but ties it to no filename rule; matches QUERY_DIRECTORY, which sees the name).
 		// Required by smb2.dosmode (source4/torture/smb2/dosmode.c).
 		basicInfo := FileAttrToFileBasicInfoWithName(attr, basenameForHidden(openFile))
 		return EncodeFileBasicInfo(basicInfo), nil

--- a/internal/adapter/smb/handlers/read.go
+++ b/internal/adapter/smb/handlers/read.go
@@ -134,7 +134,7 @@ func (resp *ReadResponse) Encode() ([]byte, error) {
 // recordReadProgress advances Open.CurrentByteOffset (the PositionInfo
 // field) to offset + bytesReturned after a successful READ. Centralised so
 // every success path — regular file, zero-length read, symlink — updates
-// the same field consistently. Per MS-FSA 2.1.5.2 (Server Algorithm for
+// the same field consistently. Per MS-FSA 2.1.5.3 ("Server Requests a Read") (Server Algorithm for
 // Reading a File): on success CurrentByteOffset := ByteOffset + BytesRead.
 // The smb2.read.position torture test asserts the value via GetInfo
 // FilePositionInformation.
@@ -362,8 +362,9 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	if req.Length == 0 && req.MinimumCount == 0 {
 		logger.Debug("READ: zero-length read (success)", "path", path,
 			"offset", req.Offset, "size", fileSize)
-		// MS-FSA 2.1.5.2: even a zero-byte successful READ advances
-		// CurrentByteOffset to req.Offset (offset + 0 bytes returned).
+		// A zero-byte successful READ advances CurrentByteOffset to req.Offset.
+		// MS-FSA 2.1.5.3 returns on ByteCount == 0 before touching the offset, so
+		// this follows smbtorture smb2.read.eof rather than the spec.
 		recordReadProgress(openFile, req.Offset, 0)
 		return &ReadResponse{
 			SMBResponseBase: SMBResponseBase{Status: types.StatusSuccess},
@@ -422,7 +423,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 		"actual", len(readResult.Data))
 
 	// ========================================================================
-	// Step 11b: Update CurrentByteOffset (MS-FSA 2.1.5.2 / smb2.read.position)
+	// Step 11b: Update CurrentByteOffset (MS-FSA 2.1.5.3 ("Server Requests a Read") / smb2.read.position)
 	// ========================================================================
 	//
 	// Per MS-FSA Server Algorithm for Reading a File: after a successful
@@ -438,7 +439,7 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 	// Step 12: Update LastAccessTime (MS-FSA Algorithm for Noting File Accessed)
 	// ========================================================================
 
-	// Per MS-FSA 2.1.5.4, after a successful read the server updates
+	// Per MS-FSA 2.1.5.3 ("Server Requests a Read"), after a successful read the server updates
 	// LastAccessTime to the current system time, unless frozen via SET_INFO -1.
 	// IsAtimeFrozen takes openFile.mu (read) so we observe a consistent value
 	// against a concurrent SET_INFO freeze/thaw on the same handle (#606).
@@ -528,7 +529,7 @@ func (h *Handler) handleSymlinkRead(
 		"requested", req.Length,
 		"actual", len(data))
 
-	// MS-FSA 2.1.5.2: advance CurrentByteOffset on the symlink success path
+	// MS-FSA 2.1.5.3 ("Server Requests a Read"): advance CurrentByteOffset on the symlink success path
 	// too. smb2.read.position asserts PositionInfo regardless of the
 	// underlying source of the returned bytes.
 	recordReadProgress(openFile, req.Offset, uint64(len(data)))

--- a/internal/adapter/smb/handlers/read_test.go
+++ b/internal/adapter/smb/handlers/read_test.go
@@ -100,7 +100,7 @@ func TestRead_SymlinkRead_LeavesReleaseDataNil(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Position semantics — MS-FSA 2.1.5.2: every successful READ advances
+// Position semantics — MS-FSA 2.1.5.3 ("Server Requests a Read"): every successful READ advances
 // Open.CurrentByteOffset to req.Offset + bytesReturned. The smb2.read.position
 // torture test reads that value back via GetInfo FilePositionInformation.
 // recordReadProgress() centralises the update so every success path —

--- a/internal/adapter/smb/handlers/rename_dst_parent_gate_test.go
+++ b/internal/adapter/smb/handlers/rename_dst_parent_gate_test.go
@@ -1,6 +1,6 @@
 // Destination-parent share-mode gate for SET_INFO rename.
 //
-// MS-FSA 2.1.5.15.12 step 8.1 opens the destination directory with
+// MS-FSA 2.1.5.15.12 ("FileRenameInformation") opens the destination directory with
 // DesiredAccess FILE_ADD_FILE|SYNCHRONIZE and ShareAccess
 // FILE_SHARE_READ|FILE_SHARE_WRITE. The cases below pin both directions of
 // that pairing: a write-sharing holder must not block the rename, and a

--- a/internal/adapter/smb/handlers/requests.go
+++ b/internal/adapter/smb/handlers/requests.go
@@ -29,31 +29,31 @@ const (
 	// FileBasicInformation returns timestamps and attributes [MS-FSCC] 2.4.7.
 	FileBasicInformation uint8 = 4
 
-	// FileStandardInformation returns file size and link count [MS-FSCC] 2.4.41.
+	// FileStandardInformation returns file size and link count [MS-FSCC] 2.4.47 (FileStandardInformation).
 	FileStandardInformation uint8 = 5
 
-	// FileInternalInformation returns the file index [MS-FSCC] 2.4.20.
+	// FileInternalInformation returns the file index [MS-FSCC] 2.4.27 (FileInternalInformation).
 	FileInternalInformation uint8 = 6
 
-	// FileEaInformation returns extended attributes size [MS-FSCC] 2.4.12.
+	// FileEaInformation returns extended attributes size [MS-FSCC] 2.4.13 (FileEaInformation).
 	FileEaInformation uint8 = 7
 
 	// FileAccessInformation returns access flags [MS-FSCC] 2.4.1.
 	FileAccessInformation uint8 = 8
 
-	// FileNameInformation returns the file name [MS-FSCC] 2.4.24.
+	// FileNameInformation returns the file name [MS-FSCC] 2.4.32 (FileNameInformation).
 	FileNameInformation uint8 = 9
 
-	// FileRenameInformation is used to rename files [MS-FSCC] 2.4.34.
+	// FileRenameInformation is used to rename files [MS-FSCC] 2.4.42 (FileRenameInformation).
 	FileRenameInformation uint8 = 10
 
 	// FileDispositionInformation is used to delete files [MS-FSCC] 2.4.11.
 	FileDispositionInformation uint8 = 13
 
-	// FilePositionInformation returns current position [MS-FSCC] 2.4.32.
+	// FilePositionInformation returns current position [MS-FSCC] 2.4.40 (FilePositionInformation).
 	FilePositionInformation uint8 = 14
 
-	// FileModeInformation returns file mode [MS-FSCC] 2.4.24.
+	// FileModeInformation returns file mode [MS-FSCC] 2.4.31 (FileModeInformation).
 	FileModeInformation uint8 = 16
 
 	// FileAlignmentInformation returns alignment requirement [MS-FSCC] 2.4.3.
@@ -65,19 +65,19 @@ const (
 	// FileAllocationInformation is used to set allocation size [MS-FSCC] 2.4.4.
 	FileAllocationInformation uint8 = 19
 
-	// FileEndOfFileInformation is used to set file size [MS-FSCC] 2.4.13.
+	// FileEndOfFileInformation is used to set file size [MS-FSCC] 2.4.14 (FileEndOfFileInformation).
 	FileEndOfFileInformation uint8 = 20
 
 	// FileAttributeTagInformation returns reparse point info [MS-FSCC] 2.4.6.
 	FileAttributeTagInformation uint8 = 35
 
-	// FileNetworkOpenInformation returns network open info [MS-FSCC] 2.4.27.
+	// FileNetworkOpenInformation returns network open info [MS-FSCC] 2.4.34 (FileNetworkOpenInformation).
 	FileNetworkOpenInformation uint8 = 34
 
-	// FileIdBothDirectoryInformation for directory listings [MS-FSCC] 2.4.17.
+	// FileIdBothDirectoryInformation for directory listings [MS-FSCC] 2.4.22 (FileIdBothDirectoryInformation).
 	FileIdBothDirectoryInformation uint8 = 37
 
-	// FileIdFullDirectoryInformation for directory listings [MS-FSCC] 2.4.18.
+	// FileIdFullDirectoryInformation for directory listings [MS-FSCC] 2.4.24 (FileIdFullDirectoryInformation).
 	FileIdFullDirectoryInformation uint8 = 38
 )
 

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -344,7 +344,7 @@ func (h *Handler) setFileInfoFromStore(
 			setAttrs.Hidden = &hiddenVal
 		}
 
-		// Per MS-FSA 2.1.5.14.2: Handle timestamp freeze/unfreeze sentinels.
+		// Per MS-FSA §2.1.5.15.2 ("FileBasicInformation"): Handle timestamp freeze/unfreeze sentinels.
 		// filetimeFreeze (-1): Freeze timestamp -- suppress auto-updates on subsequent operations.
 		// filetimeUnfreeze (-2): Unfreeze timestamp -- re-enable auto-updates.
 		// We capture the current timestamp value BEFORE applying changes so the frozen
@@ -364,7 +364,7 @@ func (h *Handler) setFileInfoFromStore(
 			"mtimeFT", fmt.Sprintf("0x%016X", mtimeFT),
 			"ctimeFT", fmt.Sprintf("0x%016X", ctimeFT))
 
-		// Per MS-FSA 2.1.5.14.2: All four timestamp fields support freeze/unfreeze.
+		// Per MS-FSA §2.1.5.15.2 ("FileBasicInformation"): All four timestamp fields support freeze/unfreeze.
 		// CreationTime freeze suppresses explicit changes from subsequent SET_INFO
 		// calls on this handle (the frozen value is returned instead).
 		hasFreezeOrUnfreeze := isFiletimeSentinel(creationFT) ||
@@ -372,7 +372,7 @@ func (h *Handler) setFileInfoFromStore(
 			isFiletimeSentinel(mtimeFT) ||
 			isFiletimeSentinel(ctimeFT)
 
-		// Per MS-FSA 2.1.5.14.2: Sentinel values (-1, -2) mean the object store
+		// Per MS-FSA §2.1.5.15.2 ("FileBasicInformation"): Sentinel values (-1, -2) mean the object store
 		// MUST NOT change the timestamp for THIS or subsequent operations on this
 		// handle. Pre-read the file to capture current timestamps, then pin
 		// sentinel timestamps to their current value in setAttrs to suppress
@@ -441,7 +441,7 @@ func (h *Handler) setFileInfoFromStore(
 			}
 		}
 
-		// Per MS-FSA 2.1.5.14.2: When a timestamp is frozen from a prior
+		// Per MS-FSA §2.1.5.15.2 ("FileBasicInformation"): When a timestamp is frozen from a prior
 		// SET_INFO call (no sentinel in this call, field==0), pin to the
 		// frozen value to prevent the metadata service from auto-updating it.
 		if creationFT == 0 && openFile.BtimeFrozen && openFile.FrozenBtime != nil {
@@ -469,7 +469,7 @@ func (h *Handler) setFileInfoFromStore(
 			setAttrs.Ctime = &preFile.Ctime
 		}
 
-		// Per MS-FSA 2.1.5.14.2: When FileAttributes change, the object store
+		// Per MS-FSA §2.1.5.15.2 ("FileBasicInformation"): When FileAttributes change, the object store
 		// SHOULD also update LastWriteTime. The metadata layer only auto-updates
 		// Ctime (POSIX semantics), so we handle Mtime auto-update here.
 		// Skip if: Mtime is being explicitly set, has a sentinel, or is frozen.
@@ -598,7 +598,7 @@ func (h *Handler) setFileInfoFromStore(
 			h.StoreOpenFile(openFile)
 		}
 
-		// Per MS-FSA 2.1.5.14.2: an explicit (non-zero, non-sentinel) timestamp
+		// Per MS-FSA §2.1.5.15.2 ("FileBasicInformation"): an explicit (non-zero, non-sentinel) timestamp
 		// set suppresses the automatic update of that field until the next
 		// explicit handle operation that would update it. smbtorture
 		// `smb2.setinfo` sets all four timestamps in one BasicInfo call, then a
@@ -1176,7 +1176,7 @@ func (h *Handler) setFileInfoFromStore(
 		// Restore mtime/ctime after rename
 		restoreTimestamps()
 
-		// Per MS-FSA 2.1.5.14.2: Restore frozen timestamps on parent directories.
+		// Per MS-FSA §2.1.5.15.2 ("FileBasicInformation"): Restore frozen timestamps on parent directories.
 		// Move updates both source and destination parent directory timestamps.
 		h.restoreParentDirFrozenTimestamps(authCtx, srcParentHandle)
 		if !bytes.Equal(toDir, srcParentHandle) {
@@ -1489,7 +1489,7 @@ func (h *Handler) setFileInfoFromStore(
 
 	case types.FilePositionInformation:
 		// FILE_POSITION_INFORMATION [MS-FSCC] 2.4.32 (8 bytes)
-		// Per MS-FSA 2.1.5.14.23: If InputBufferSize is less than the size of
+		// Per MS-FSA §2.1.5.15.10 ("FilePositionInformation"): If InputBufferSize is less than the size of
 		// FILE_POSITION_INFORMATION (8 bytes), return STATUS_INFO_LENGTH_MISMATCH.
 		if len(buffer) < 8 {
 			return setInfoStatus(types.StatusInfoLengthMismatch), nil
@@ -1765,7 +1765,7 @@ func (h *Handler) restoreFrozenTimestamps(authCtx *metadata.AuthContext, openFil
 // after child operations (create, delete, write) that unconditionally update parent
 // directory timestamps in the metadata layer.
 //
-// Per MS-FSA 2.1.5.14.2: When a timestamp is frozen via SET_INFO with -1 sentinel,
+// Per MS-FSA §2.1.5.15.2 ("FileBasicInformation"): When a timestamp is frozen via SET_INFO with -1 sentinel,
 // the timestamp MUST NOT be auto-updated by subsequent operations. The metadata layer
 // (createEntry, removeFile, etc.) always updates parent directory timestamps. This
 // method iterates open handles to find directory handles matching the given parent

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -682,7 +682,7 @@ func (h *Handler) setFileInfoFromStore(
 			return setInfoStatus(types.StatusInvalidParameter), nil
 		}
 
-		// Per MS-FSA 2.1.5.14.10: Rename requires DELETE access on the source file.
+		// Per MS-FSA 2.1.5.15.12 ("FileRenameInformation"): Rename requires DELETE access on the source file.
 		// Gate consults Open.GrantedAccess (post-DACL intersection at CREATE), not
 		// the pre-DACL DesiredAccess — same fix class as #616 (ChangeNotify).
 		if !hasDeleteAccess(openFile.GrantedAccess) {
@@ -692,7 +692,7 @@ func (h *Handler) setFileInfoFromStore(
 			return setInfoStatus(types.StatusAccessDenied), nil
 		}
 
-		// Per MS-FSA 2.1.5.14.10: Before renaming, check that no other open
+		// Per MS-FSA 2.1.5.1.2.1 ("Algorithm to Check Access to an Existing File"): Before renaming, check that no other open
 		// handle on the same file conflicts with the rename. Specifically,
 		// all other opens must have FILE_SHARE_DELETE (0x04) in ShareAccess.
 		// (Destination-parent share-mode probe runs further below, after toDir
@@ -748,7 +748,7 @@ func (h *Handler) setFileInfoFromStore(
 			oldFileName := oldName.FileName
 			oldParentPath := GetParentPath(oldName.Path)
 
-			// Per MS-FSA 2.1.5.14.10: Save mtime/ctime before rename
+			// Per MS-FSA 2.1.5.15.12 ("FileRenameInformation"): Save mtime/ctime before rename
 			restoreTimestamps := h.saveTimestamps(authCtx, openFile.MetadataHandle)
 
 			// Perform the rename
@@ -978,7 +978,7 @@ func (h *Handler) setFileInfoFromStore(
 			return setInfoStatus(types.StatusSharingViolation), nil
 		}
 
-		// Pre-rename lease break: per MS-FSA §2.1.5.14.10 + Samba
+		// Pre-rename lease break: per MS-FSA §2.1.5.15.12 ("FileRenameInformation") + Samba
 		// `source3/smbd/smb2_setinfo.c::smbd_smb2_rename`, dispatch breaks on
 		// any other-key lease holder of the source file (and, on overwrite,
 		// the destination too) before applying the rename. Sync wait (mirrors
@@ -997,7 +997,7 @@ func (h *Handler) setFileInfoFromStore(
 		// Destination handling: when ReplaceIfExists=true and the destination
 		// exists, dispatch the dst H-lease break (RWH→RW). Even after that
 		// break drains, ANY open handle on dst blocks the overwrite per
-		// MS-FSA §2.1.5.14.10 — surface STATUS_ACCESS_DENIED. The dst close
+		// MS-FSA §2.1.5.15.12 ("FileRenameInformation") — surface STATUS_ACCESS_DENIED. The dst close
 		// path (smbtorture v2_rename_target_overwrite stage 3) clears
 		// the open and the post-wait recheck then proceeds to the rename.
 		isOverwrite := renameInfo.ReplaceIfExists
@@ -1145,7 +1145,7 @@ func (h *Handler) setFileInfoFromStore(
 		oldParentPath := GetParentPath(oldPath)
 		srcParentHandle := oldName.ParentHandle
 
-		// Per MS-FSA 2.1.5.14.10: Save mtime/ctime before rename so we can
+		// Per MS-FSA 2.1.5.15.12 ("FileRenameInformation"): Save mtime/ctime before rename so we can
 		// restore them after. Rename should NOT update the file's timestamps.
 		restoreTimestamps := h.saveTimestamps(authCtx, openFile.MetadataHandle)
 
@@ -1183,8 +1183,9 @@ func (h *Handler) setFileInfoFromStore(
 			h.restoreParentDirFrozenTimestamps(authCtx, toDir)
 		}
 
-		// Per MS-FSA 2.1.5.14.10: On successful completion of a rename,
-		// if the file was marked for delete-on-close, clear that disposition.
+		// On successful completion of a rename, if the file was marked for
+		// delete-on-close, clear that disposition. MS-FSA states no such rule;
+		// 2.1.5.15.12 instead fails a rename whose Open.Link.IsDeleted is TRUE.
 		// This prevents the renamed file from being deleted when the handle closes.
 		openFile.mu.Lock()
 		clearedDOC := openFile.DeletePending
@@ -1241,7 +1242,7 @@ func (h *Handler) setFileInfoFromStore(
 		openFile.mu.Unlock()
 		h.StoreOpenFile(openFile)
 
-		// Per MS-FSA 2.1.5.14.10 (smbtorture smb2.dirlease.rename):
+		// Per MS-FSA 2.1.5.15.12 ("FileRenameInformation") (smbtorture smb2.dirlease.rename):
 		// rename changes directory contents on BOTH source and destination
 		// parents. Break Handle + Read dir leases on each (RH → ""), honoring
 		// the renamer's ParentLeaseKey suppression from C2. Skip the dst
@@ -1291,7 +1292,7 @@ func (h *Handler) setFileInfoFromStore(
 			return setInfoStatus(types.StatusAccessDenied), nil
 		}
 
-		// Per MS-FSA 2.1.5.14.3: Setting delete disposition requires DELETE access.
+		// Per MS-FSA 2.1.5.15.3 ("FileDispositionInformation"): Setting delete disposition requires DELETE access.
 		// Gate consults Open.GrantedAccess (post-DACL intersection at CREATE), not
 		// the pre-DACL DesiredAccess — same fix class as #616 (ChangeNotify).
 		if deletePending {
@@ -1339,7 +1340,7 @@ func (h *Handler) setFileInfoFromStore(
 			}
 		}
 
-		// Per MS-FSA 2.1.5.14.3 / Samba source3/smbd/smb2_setinfo.c
+		// Per MS-FSA 2.1.4.12 ("Algorithm to Check for an Oplock Break") / Samba source3/smbd/smb2_setinfo.c
 		// (smbd_smb2_setinfo_lease_break_fsp_check): when delete disposition
 		// is *being set* on a non-directory file, strip Handle caching from
 		// every other holder's lease (RH -> R, RWH -> RW). The file is on
@@ -1395,7 +1396,7 @@ func (h *Handler) setFileInfoFromStore(
 		authCtx.WriteAuthorizedByHandle = hasWriteAccess(openFile.GrantedAccess)
 
 		// Break Level II (Read) oplocks held by other clients.
-		// Per MS-SMB2 3.3.5.21.2 / MS-FSA 2.1.5.14.4: truncation is a
+		// Per MS-SMB2 3.3.5.21.2 / MS-FSA 2.1.5.15.5 ("FileEndOfFileInformation"): truncation is a
 		// data-modifying operation that invalidates read caches.
 		// Required by smbtorture smb2.oplock.batch11/batch12.
 		if h.LeaseManager != nil && len(openFile.MetadataHandle) > 0 {
@@ -1423,7 +1424,10 @@ func (h *Handler) setFileInfoFromStore(
 
 		metaSvc := h.Registry.GetMetadataService()
 
-		// Per MS-FSA 2.1.5.14.4: Check for conflicting byte-range locks.
+		// Check for conflicting byte-range locks. MS-FSA does not route a
+		// FileEndOfFileInformation set through the lock-conflict algorithm of
+		// 2.1.4.10; this reuses it to match Windows, which fails a truncate into
+		// a range another session holds locked.
 		// When truncating, the region from newSize to the current EOF must not
 		// have locks from other sessions. We check the entire range from newSize
 		// to max as a write operation (truncation is destructive).
@@ -1505,7 +1509,7 @@ func (h *Handler) setFileInfoFromStore(
 		// FILE_ALLOCATION_INFORMATION [MS-FSCC] 2.4.4.
 		//
 		// Allocation size is not persisted (DittoFS does not preallocate), but
-		// per MS-FSA 2.1.5.14.1 and Samba `smbd_smb2_setinfo_lease_break_fsp_check`
+		// per MS-FSA 2.1.5.15.1 ("FileAllocationInformation") and Samba `smbd_smb2_setinfo_lease_break_fsp_check`
 		// (source3/smbd/smb2_setinfo.c) setting allocation is a data-modifying
 		// operation: it must break Read (Level II) leases on the same file the
 		// same way SET_EOF does. Without this, a remote reader that cached the
@@ -1528,7 +1532,7 @@ func (h *Handler) setFileInfoFromStore(
 			requested := smbenc.NewReader(buffer[:8]).ReadUint64()
 			openFile.RequestedAllocSize = allocReservationFor(openFile.IsDirectory, requested)
 
-			// Per MS-FSA 2.1.5.14.1: when the requested AllocationSize is
+			// Per MS-FSA 2.1.5.15.1 ("FileAllocationInformation"): when the requested AllocationSize is
 			// smaller than the file's current EndOfFile, the EndOfFile is
 			// truncated down to the allocation size (allocation can never be
 			// less than the valid data length). smbtorture smb2.setinfo
@@ -1584,7 +1588,7 @@ func (h *Handler) setFileInfoFromStore(
 		}
 		modeMask := fileModeInformationModeMask
 		mode := types.CreateOptions(smbenc.NewReader(buffer[:4]).ReadUint32())
-		// Per MS-FSA 2.1.5.14.13: any bit set outside the valid FILE_MODE_*
+		// Per MS-FSA 2.1.5.15.8 ("FileModeInformation"): any bit set outside the valid FILE_MODE_*
 		// set is invalid and the server MUST return STATUS_INVALID_PARAMETER.
 		// smbtorture smb2.setinfo (setinfo.c:269) sets a reserved-bit value
 		// (e.g. FILE_DIRECTORY_FILE, 0x1) and asserts the rejection.
@@ -1684,7 +1688,7 @@ func applyFrozenTimestamps(openFile *OpenFile, file *metadata.File) {
 
 // saveTimestamps reads the current Mtime and Ctime of a file and returns a
 // restore function that writes them back. Used to preserve timestamps across
-// rename operations (per MS-FSA 2.1.5.14.10, rename should not change timestamps).
+// rename operations (per MS-FSA 2.1.5.15.12 ("FileRenameInformation"), rename should not change timestamps).
 // Returns a no-op if the read fails.
 func (h *Handler) saveTimestamps(authCtx *metadata.AuthContext, handle metadata.FileHandle) func() {
 	metaSvc := h.Registry.GetMetadataService()
@@ -2283,11 +2287,11 @@ func DecodeFileLinkInfo(buffer []byte) (*FileLinkInfo, error) {
 // 2.4.28 (FileLinkInformation): create a new hard link to the open file in the requested
 // destination directory.
 //
-// Per MS-FSA 2.1.5.14.5: the operation creates a NEW directory entry in the
+// Per MS-FSA 2.1.5.15.7 ("FileLinkInformation"): the operation creates a NEW directory entry in the
 // destination directory that references the same file ID as the open file.
 // Returns STATUS_OBJECT_NAME_COLLISION if the destination already exists and
 // ReplaceIfExists is FALSE; STATUS_FILE_IS_A_DIRECTORY if the open file is a
-// directory (hard-linking directories is forbidden, MS-FSA 2.1.5.14.5).
+// directory (hard-linking directories is forbidden, MS-FSA 2.1.5.15.7 ("FileLinkInformation")).
 //
 // Directory-lease coordination (smb2.dirlease.hardlink): a hardlink
 // is an add-entry in the destination parent. We thread the open file's RqLs
@@ -2312,7 +2316,7 @@ func (h *Handler) handleFileLinkInformation(
 		return setInfoStatus(types.StatusInvalidParameter), nil
 	}
 
-	// Hard-linking a directory is forbidden (MS-FSA 2.1.5.14.5).
+	// Hard-linking a directory is forbidden (MS-FSA 2.1.5.15.7 ("FileLinkInformation")).
 	if openFile.IsDirectory {
 		logger.Debug("SET_INFO: hardlink on directory rejected",
 			"path", openFile.Name().Path)

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -297,7 +297,8 @@ func (h *Handler) setFileInfoFromStore(
 			return setInfoStatus(types.StatusInfoLengthMismatch), nil
 		}
 
-		// Validate attribute constraints per MS-FSCC 2.4.7:
+		// Validate attribute constraints per MS-FSA 2.1.5.15.2 ("FileBasicInformation").
+		// MS-FSCC 2.4.7 defines the wire structure only:
 		// - FILE_ATTRIBUTE_DIRECTORY on a non-directory file -> INVALID_PARAMETER
 		// - FILE_ATTRIBUTE_TEMPORARY on a directory -> INVALID_PARAMETER
 		attrR := smbenc.NewReader(buffer[32:36])
@@ -316,13 +317,15 @@ func (h *Handler) setFileInfoFromStore(
 
 		metaSvc := h.Registry.GetMetadataService()
 
-		// Per MS-FSCC 2.6: Map FILE_ATTRIBUTE_READONLY to Unix mode.
+		// MS-FSCC 2.6 ("File Attributes") defines FILE_ATTRIBUTE_READONLY's meaning;
+		// mapping it onto a Unix mode bit is DittoFS's own storage rule.
 		// When FileAttributes != 0, the client is explicitly setting attributes.
 		// READONLY is stored in modeDOSReadonly (bit 0x100000); POSIX owner-write
 		// bits are preserved. calculatePermissions in pkg/metadata enforces the
 		// READONLY semantics for both NFS and SMB callers by clearing write when
 		// modeDOSExplicit + modeDOSReadonly are both set.
-		// Per MS-FSCC 2.4.7: FILE_ATTRIBUTE_COMPRESSED is NOT settable via
+		// Per MS-FSA 2.1.5.15.2 ("FileBasicInformation"), which lists the
+		// settable attributes: FILE_ATTRIBUTE_COMPRESSED is NOT settable via
 		// FileBasicInformation; it is controlled only via FSCTL_SET_COMPRESSION.
 		// Likewise, FILE_ATTRIBUTE_SPARSE_FILE is set only via FSCTL_SET_SPARSE.
 		// Preserve both FSCTL-managed bits so SET_INFO does not accidentally
@@ -338,7 +341,7 @@ func (h *Handler) setFileInfoFromStore(
 				mode |= curFile.Mode & (modeDOSCompressed | modeDOSSparse)
 			}
 			setAttrs.Mode = &mode
-			// Per MS-FSCC 2.6: propagate FILE_ATTRIBUTE_HIDDEN into the metadata
+			// Propagate FILE_ATTRIBUTE_HIDDEN (MS-FSCC 2.6 "File Attributes") into the metadata
 			// Hidden field so QUERY_INFO and QUERY_DIRECTORY round-trip correctly.
 			hiddenVal := fileAttrs&types.FileAttributeHidden != 0
 			setAttrs.Hidden = &hiddenVal
@@ -647,7 +650,7 @@ func (h *Handler) setFileInfoFromStore(
 
 		// Break parent directory leases on child metadata change (#470:
 		// smb2.dirlease.set{atime,btime,ctime,mtime,dos}). Per MS-FSA
-		// 2.1.5.14: any child SET_INFO that modifies file attributes or
+		// 2.1.5.15.2 ("FileBasicInformation"): any child SET_INFO that modifies file attributes or
 		// timestamps changes what READDIR returns, invalidating parent-dir
 		// Read + Handle caching. Parent-key suppression (C2) flows through
 		// the same breakParentDirLeasesForContentChange plumbing.
@@ -872,7 +875,7 @@ func (h *Handler) setFileInfoFromStore(
 		// Directory rename: break H-leases on every open child file (RH→R
 		// strip-H) and wait for each break to drain. After the wait, ANY
 		// remaining open child blocks the parent rename with STATUS_ACCESS_DENIED
-		// per MS-FSA §2.1.5.14 (smbtorture rename_dir_openfile: 8 sub-cases all
+		// per MS-FSA §2.1.5.15.12 ("FileRenameInformation") (smbtorture rename_dir_openfile: 8 sub-cases all
 		// hinge on whether every H-leased child closes-on-break or stays open
 		// after ACK). Children without an H-lease are no-op'd by
 		// ComputeLeaseBreakTo and stay open → the open-child recheck produces the
@@ -1480,7 +1483,7 @@ func (h *Handler) setFileInfoFromStore(
 		h.StoreOpenFile(openFile)
 
 		// Break parent directory leases on child EOF change (#470:
-		// smb2.dirlease.seteof). Per MS-FSA 2.1.5.14: size changes
+		// smb2.dirlease.seteof). Per MS-FSA 2.1.5.15.5 ("FileEndOfFileInformation"): size changes
 		// are visible in READDIR results, invalidating parent-dir
 		// Read + Handle caching. Parent-key suppression (C2) applies.
 		h.breakParentDirLeasesForContentChange(ctx, authCtx, openFile)
@@ -1877,7 +1880,7 @@ func (h *Handler) parseSDOptsForShare(shareName string) ParseSDOptions {
 // Parses the binary Security Descriptor from the client, extracts owner/group/ACL,
 // and applies the changes to the file via MetadataService.SetFileAttributes.
 //
-// Per MS-SMB2 §3.3.5.21.3 and MS-FSA §2.1.5.14, the access authorization for
+// Per MS-SMB2 §3.3.5.21.3 and MS-FSA §2.1.5.17 ("Server Requests Setting of Security Information"), the access authorization for
 // SET_INFO Security is performed against the OPEN'S granted access mask
 // (captured at CREATE time), NOT against the file's current DACL. The new
 // SD being installed is irrelevant to the authorization decision — installing
@@ -2101,7 +2104,7 @@ func mergeSecurityACL(parsed, current *acl.ACL, wantDACL, wantSACL bool) *acl.AC
 }
 
 // checkSetInfoSecurityAccess maps requested SECURITY_INFORMATION sections to
-// the access mask bits MS-SMB2 §3.3.5.21.3 / MS-FSA §2.1.5.14 require on the
+// the access mask bits MS-SMB2 §3.3.5.21.3 / MS-FSA §2.1.5.17 ("Server Requests Setting of Security Information") require on the
 // open's GrantedAccess, and verifies each requested section against the mask.
 //
 // Returns (StatusSuccess, true) when every requested section has the matching
@@ -2134,7 +2137,7 @@ func checkSetInfoSecurityAccess(grantedAccess, additionalInfo uint32) (types.Sta
 }
 
 // breakParentDirLeases breaks leases on the parent directory when a child
-// file's metadata or content changes (SET_INFO, WRITE, DELETE). Per MS-FSA 2.1.5.14:
+// file's metadata or content changes (SET_INFO, WRITE, DELETE). Per MS-FSA 2.1.4.12 ("Algorithm to Check for an Oplock Break"):
 //   - Handle caching is broken so clients revalidate cached directory handles
 //   - Read caching is broken so clients see updated directory listing metadata
 //     (timestamps, sizes, attributes visible in READDIR results)
@@ -2398,7 +2401,7 @@ func (h *Handler) handleFileLinkInformation(
 	}
 
 	// Break parent directory leases on the destination parent to None
-	// (MS-FSA 2.1.5.14: directory contents changed). Parent-key suppression
+	// (MS-FSA 2.1.5.15.7 ("FileLinkInformation"): directory contents changed). Parent-key suppression
 	// only — no ClientID exclusion per Samba dirlease_should_break. Single
 	// break-to-None matches Samba `contend_dirleases` / `do_dirlease_break_to_none`
 	// — required by smbtorture hardlink samedir-{wrong,no}-parent-leaskey

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -925,7 +925,7 @@ func (h *Handler) setFileInfoFromStore(
 			}
 		}
 
-		// Per MS-FSA 2.1.5.15.12 step 8.1: rename takes an implicit open on
+		// Per MS-FSA 2.1.5.15.12 ("FileRenameInformation"): rename takes an implicit open on
 		// the destination parent directory with FILE_ADD_FILE|SYNCHRONIZE
 		// (FILE_ADD_SUBDIRECTORY for a directory source) and ShareAccess
 		// FILE_SHARE_READ|FILE_SHARE_WRITE. Any existing open of that

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -695,9 +695,10 @@ func (h *Handler) setFileInfoFromStore(
 			return setInfoStatus(types.StatusAccessDenied), nil
 		}
 
-		// Per MS-FSA 2.1.5.1.2.1 ("Algorithm to Check Access to an Existing File"): Before renaming, check that no other open
-		// handle on the same file conflicts with the rename. Specifically,
-		// all other opens must have FILE_SHARE_DELETE (0x04) in ShareAccess.
+		// Before renaming, check that no other open handle on the same file
+		// conflicts with the rename: all other opens must have FILE_SHARE_DELETE
+		// (0x04) in ShareAccess. MS-FSA 2.1.5.15.12 ("FileRenameInformation")
+		// specifies no share-mode check; this follows Samba `can_rename`.
 		// (Destination-parent share-mode probe runs further below, after toDir
 		// is resolved and the stream-rename early return has been ruled out.)
 		//
@@ -751,7 +752,9 @@ func (h *Handler) setFileInfoFromStore(
 			oldFileName := oldName.FileName
 			oldParentPath := GetParentPath(oldName.Path)
 
-			// Per MS-FSA 2.1.5.15.12 ("FileRenameInformation"): Save mtime/ctime before rename
+			// Save mtime/ctime before the rename. MS-FSA 2.1.5.15.12 requires
+			// LastChangeTime to be updated; preserving it matches NTFS, which
+			// defers the update to handle close.
 			restoreTimestamps := h.saveTimestamps(authCtx, openFile.MetadataHandle)
 
 			// Perform the rename
@@ -1148,8 +1151,10 @@ func (h *Handler) setFileInfoFromStore(
 		oldParentPath := GetParentPath(oldPath)
 		srcParentHandle := oldName.ParentHandle
 
-		// Per MS-FSA 2.1.5.15.12 ("FileRenameInformation"): Save mtime/ctime before rename so we can
-		// restore them after. Rename should NOT update the file's timestamps.
+		// Save mtime/ctime before the rename so we can restore them after.
+		// MS-FSA 2.1.5.15.12 never touches LastModificationTime but does require
+		// LastChangeTime to be updated; preserving both matches NTFS, which
+		// defers that update to handle close.
 		restoreTimestamps := h.saveTimestamps(authCtx, openFile.MetadataHandle)
 
 		// Pre-overwrite the case-mismatched destination: Move's destination
@@ -1691,7 +1696,9 @@ func applyFrozenTimestamps(openFile *OpenFile, file *metadata.File) {
 
 // saveTimestamps reads the current Mtime and Ctime of a file and returns a
 // restore function that writes them back. Used to preserve timestamps across
-// rename operations (per MS-FSA 2.1.5.15.12 ("FileRenameInformation"), rename should not change timestamps).
+// rename operations. MS-FSA 2.1.5.15.12 leaves LastModificationTime alone but
+// requires LastChangeTime to be updated; preserving both matches NTFS, which
+// defers that update to handle close.
 // Returns a no-op if the read fails.
 func (h *Handler) saveTimestamps(authCtx *metadata.AuthContext, handle metadata.FileHandle) func() {
 	metaSvc := h.Registry.GetMetadataService()

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -71,7 +71,7 @@ func setInfoStatus(status types.Status) *SetInfoResponse {
 	return &SetInfoResponse{SMBResponseBase: SMBResponseBase{Status: status}}
 }
 
-// FileRenameInfo represents FILE_RENAME_INFORMATION [MS-FSCC] 2.4.34.
+// FileRenameInfo represents FILE_RENAME_INFORMATION [MS-FSCC] 2.4.42 (FileRenameInformation).
 // Used to rename or move a file.
 type FileRenameInfo struct {
 	// ReplaceIfExists indicates whether to replace an existing file.
@@ -143,7 +143,7 @@ func (resp *SetInfoResponse) Encode() ([]byte, error) {
 	return w.Bytes(), w.Err()
 }
 
-// DecodeFileRenameInfo parses FILE_RENAME_INFORMATION [MS-FSCC] 2.4.34.
+// DecodeFileRenameInfo parses FILE_RENAME_INFORMATION [MS-FSCC] 2.4.42 (FileRenameInformation).
 // Returns an error if the buffer is less than 20 bytes.
 func DecodeFileRenameInfo(buffer []byte) (*FileRenameInfo, error) {
 	if len(buffer) < 20 {
@@ -173,7 +173,7 @@ func DecodeFileRenameInfo(buffer []byte) (*FileRenameInfo, error) {
 	return info, nil
 }
 
-// decodeEndOfFileInfo decodes FILE_END_OF_FILE_INFORMATION [MS-FSCC] 2.4.13.
+// decodeEndOfFileInfo decodes FILE_END_OF_FILE_INFORMATION [MS-FSCC] 2.4.14 (FileEndOfFileInformation).
 func decodeEndOfFileInfo(buffer []byte) (uint64, error) {
 	if len(buffer) < 8 {
 		return 0, fmt.Errorf("buffer too short for FILE_END_OF_FILE_INFORMATION")
@@ -675,7 +675,7 @@ func (h *Handler) setFileInfoFromStore(
 		return setInfoStatus(types.StatusSuccess), nil
 
 	case types.FileRenameInformation:
-		// FILE_RENAME_INFORMATION [MS-FSCC] 2.4.34
+		// FILE_RENAME_INFORMATION [MS-FSCC] 2.4.42.2 (FileRenameInformation for SMB2)
 		renameInfo, err := DecodeFileRenameInfo(buffer)
 		if err != nil {
 			logger.Debug("SET_INFO: failed to decode rename info", "error", err)
@@ -815,7 +815,7 @@ func (h *Handler) setFileInfoFromStore(
 
 		// Determine source and destination.
 		//
-		// Per MS-FSCC 2.4.34 / MS-SMB2 2.2.39:
+		// Per MS-FSCC 2.4.42.2 (FileRenameInformation for SMB2) / MS-SMB2 2.2.39:
 		// - If RootDirectory is zero, FileName is a full path from the share root.
 		//   Even a bare filename like "foo.txt" means "put file at share root/foo.txt".
 		// - If RootDirectory is non-zero, FileName is relative to that directory handle.
@@ -1197,7 +1197,7 @@ func (h *Handler) setFileInfoFromStore(
 		}
 
 		// Notify watchers about the rename using paired notification.
-		// Per MS-FSCC 2.4.42, rename notifications MUST contain both
+		// Per MS-FSCC 2.7.1 (FILE_NOTIFY_INFORMATION), rename notifications MUST contain both
 		// FILE_ACTION_RENAMED_OLD_NAME and FILE_ACTION_RENAMED_NEW_NAME
 		// in a single response. CHANGE_NOTIFY is one-shot, so sending
 		// them separately would cause the second to be silently dropped.
@@ -1259,7 +1259,7 @@ func (h *Handler) setFileInfoFromStore(
 
 	case types.FileDispositionInformation, types.FileDispositionInformationEx:
 		// FILE_DISPOSITION_INFORMATION [MS-FSCC] 2.4.11
-		// FILE_DISPOSITION_INFORMATION_EX [MS-FSCC] 2.4.11.2
+		// FILE_DISPOSITION_INFORMATION_EX [MS-FSCC] 2.4.12 (FileDispositionInformationEx)
 		// DeletePending (1 byte for class 13, 4 bytes flags for class 64)
 		if len(buffer) < 1 {
 			return setInfoStatus(types.StatusInvalidParameter), nil
@@ -1267,7 +1267,7 @@ func (h *Handler) setFileInfoFromStore(
 
 		var deletePending bool
 		if class == types.FileDispositionInformationEx {
-			// FileDispositionInformationEx uses a 4-byte Flags field per MS-FSCC 2.4.11.2
+			// FileDispositionInformationEx uses a 4-byte Flags field per MS-FSCC 2.4.12 (FileDispositionInformationEx)
 			if len(buffer) < 4 {
 				return setInfoStatus(types.StatusInfoLengthMismatch), nil
 			}
@@ -1381,7 +1381,7 @@ func (h *Handler) setFileInfoFromStore(
 		return setInfoStatus(types.StatusSuccess), nil
 
 	case types.FileEndOfFileInformation:
-		// FILE_END_OF_FILE_INFORMATION [MS-FSCC] 2.4.13
+		// FILE_END_OF_FILE_INFORMATION [MS-FSCC] 2.4.14 (FileEndOfFileInformation)
 		newSize, err := decodeEndOfFileInfo(buffer)
 		if err != nil {
 			return setInfoStatus(types.StatusInvalidParameter), nil
@@ -1488,7 +1488,7 @@ func (h *Handler) setFileInfoFromStore(
 		return setInfoStatus(types.StatusSuccess), nil
 
 	case types.FilePositionInformation:
-		// FILE_POSITION_INFORMATION [MS-FSCC] 2.4.32 (8 bytes)
+		// FILE_POSITION_INFORMATION [MS-FSCC] 2.4.40 (FilePositionInformation) (8 bytes)
 		// Per MS-FSA §2.1.5.15.10 ("FilePositionInformation"): If InputBufferSize is less than the size of
 		// FILE_POSITION_INFORMATION (8 bytes), return STATUS_INFO_LENGTH_MISMATCH.
 		if len(buffer) < 8 {
@@ -1572,7 +1572,7 @@ func (h *Handler) setFileInfoFromStore(
 		return setInfoStatus(types.StatusSuccess), nil
 
 	case types.FileModeInformation:
-		// FILE_MODE_INFORMATION [MS-FSCC] 2.4.24 (4 bytes). SET adjusts the
+		// FILE_MODE_INFORMATION [MS-FSCC] 2.4.31 (FileModeInformation) (4 bytes). SET adjusts the
 		// open's mode flags (FILE_WRITE_THROUGH, FILE_SEQUENTIAL_ONLY,
 		// FILE_NO_INTERMEDIATE_BUFFERING, FILE_SYNCHRONOUS_IO_*,
 		// FILE_DELETE_ON_CLOSE). DittoFS does not change I/O behaviour based on
@@ -1602,12 +1602,12 @@ func (h *Handler) setFileInfoFromStore(
 		return setInfoStatus(types.StatusSuccess), nil
 
 	case types.FileLinkInformation:
-		// FILE_LINK_INFORMATION [MS-FSCC] 2.4.21.2 — hard link creation.
+		// FILE_LINK_INFORMATION [MS-FSCC] 2.4.28 (FileLinkInformation) — hard link creation.
 		// Wire format mirrors FILE_RENAME_INFORMATION: ReplaceIfExists (1B),
 		// Reserved (7B), RootDirectory (8B), FileNameLength (4B), FileName (UTF-16LE).
 		return h.handleFileLinkInformation(ctx, authCtx, openFile, buffer)
 
-	case types.FileFullEaInformation: // [MS-FSCC] 2.4.15 - Extended attributes
+	case types.FileFullEaInformation: // [MS-FSCC] 2.4.16 (FileFullEaInformation) - Extended attributes
 		// Reject SET on the reserved ACL xattr name with ACCESS_DENIED so the
 		// server-stored security descriptor cannot be tampered with through the
 		// FILE_FULL_EA_INFORMATION channel. Mirrors Samba vfs_acl_xattr (which
@@ -1632,8 +1632,10 @@ func (h *Handler) setFileInfoFromStore(
 
 		// Persist the EA set/delete mutations through the metadata layer.
 		// A zero-length value deletes the named EA; a non-empty value upserts
-		// it (MS-FSCC §2.4.15). EA names are case-insensitive and the metadata
-		// layer resolves them so casing round-trips.
+		// it (MS-FSCC §2.4.16 ("FileFullEaInformation")). EA-name matching is
+		// case-insensitive per NTFS semantics — MS-FSCC defines the structure but
+		// states no matching rule — and the metadata layer resolves them so casing
+		// round-trips.
 		metaSvc := h.Registry.GetMetadataService()
 		setAttrs := &metadata.SetAttrs{EAMutations: eaMutationsFromEntries(entries)}
 		if _, err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, setAttrs); err != nil {
@@ -2236,7 +2238,7 @@ func (h *Handler) breakDstParentDirHandleLeasesForRename(authCtx *metadata.AuthC
 	}
 }
 
-// FileLinkInfo represents FILE_LINK_INFORMATION [MS-FSCC] 2.4.21.2.
+// FileLinkInfo represents FILE_LINK_INFORMATION [MS-FSCC] 2.4.28.2 (FileLinkInformation for the SMB2 Protocol).
 // The wire format mirrors FILE_RENAME_INFORMATION (same byte layout).
 type FileLinkInfo struct {
 	// ReplaceIfExists indicates whether to replace an existing file at the
@@ -2251,7 +2253,7 @@ type FileLinkInfo struct {
 	FileName string
 }
 
-// DecodeFileLinkInfo parses FILE_LINK_INFORMATION [MS-FSCC] 2.4.21.2.
+// DecodeFileLinkInfo parses FILE_LINK_INFORMATION [MS-FSCC] 2.4.28.2 (FileLinkInformation for the SMB2 Protocol).
 // Returns an error if the buffer is less than 20 bytes (fixed header) or the
 // declared FileNameLength would read past buffer end.
 func DecodeFileLinkInfo(buffer []byte) (*FileLinkInfo, error) {
@@ -2278,7 +2280,7 @@ func DecodeFileLinkInfo(buffer []byte) (*FileLinkInfo, error) {
 }
 
 // handleFileLinkInformation implements SET_INFO FileLinkInformation [MS-FSCC]
-// 2.4.21.2: create a new hard link to the open file in the requested
+// 2.4.28 (FileLinkInformation): create a new hard link to the open file in the requested
 // destination directory.
 //
 // Per MS-FSA 2.1.5.14.5: the operation creates a NEW directory entry in the
@@ -2436,7 +2438,7 @@ func (h *Handler) handleFileLinkInformation(
 }
 
 // ============================================================================
-// FILE_FULL_EA_INFORMATION decoding (MS-FSCC §2.4.15)
+// FILE_FULL_EA_INFORMATION decoding (MS-FSCC §2.4.16 ("FileFullEaInformation"))
 // ============================================================================
 
 // reservedACLXattrName is the xattr name DittoFS reserves for the server's
@@ -2449,8 +2451,8 @@ func (h *Handler) handleFileLinkInformation(
 // (smbtorture smb2.ea.acl_xattr).
 //
 // The name is matched case-insensitively because EA names are NTFS-style
-// case-insensitive on the wire even though MS-FSCC §2.4.15 reserves the right
-// to canonicalize the casing. Samba's vfs_acl_xattr uses a fixed lower-case
+// case-insensitive on the wire; MS-FSCC §2.4.16 ("FileFullEaInformation") defines the
+// structure but states no name-matching rule. Samba's vfs_acl_xattr uses a fixed lower-case
 // constant; smbtorture's torture_setting_string returns the literal it was
 // configured with. Match either casing.
 const reservedACLXattrName = "security.NTACL"

--- a/internal/adapter/smb/handlers/set_info_ea_persist_test.go
+++ b/internal/adapter/smb/handlers/set_info_ea_persist_test.go
@@ -100,7 +100,7 @@ func queryEAs(t *testing.T, h *Handler, authCtx *metadata.AuthContext, open *Ope
 }
 
 // setEA issues a SET_INFO FileFullEaInformation with a single EA (zero-length
-// value deletes per MS-FSCC §2.4.15).
+// value deletes per MS-FSCC §2.4.16 ("FileFullEaInformation")).
 func setEA(t *testing.T, h *Handler, authCtx *metadata.AuthContext, open *OpenFile, name string, value []byte) types.Status {
 	t.Helper()
 	buf := encodeOneEAEntry(name, value)

--- a/internal/adapter/smb/handlers/set_info_link_info_test.go
+++ b/internal/adapter/smb/handlers/set_info_link_info_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // encodeFileLinkInfoWire serialises a FILE_LINK_INFORMATION blob in MS-FSCC
-// 2.4.21.2 wire format for use by tests:
+// 2.4.28.2 (FileLinkInformation for the SMB2 Protocol) wire format for use by tests:
 //
 //	+0   1B  ReplaceIfExists
 //	+1   7B  Reserved
@@ -33,7 +33,7 @@ func encodeFileLinkInfoWire(t *testing.T, replaceIfExists bool, rootDir [8]byte,
 }
 
 // TestDecodeFileLinkInfo_Basic round-trips the FILE_LINK_INFORMATION wire
-// format and pins MS-FSCC 2.4.21.2: ReplaceIfExists, RootDirectory, and
+// format and pins MS-FSCC 2.4.28.2 (FileLinkInformation for the SMB2 Protocol): ReplaceIfExists, RootDirectory, and
 // the UTF-16LE FileName field land in the decoded struct verbatim.
 func TestDecodeFileLinkInfo_Basic(t *testing.T) {
 	t.Parallel()

--- a/internal/adapter/smb/handlers/set_info_security_authz_test.go
+++ b/internal/adapter/smb/handlers/set_info_security_authz_test.go
@@ -1,6 +1,6 @@
 // Tests for SET_INFO Security access authorization against the open's
 // GrantedAccess (Samba `fsp->access_mask`). Per MS-SMB2 §3.3.5.21.3 and
-// MS-FSA §2.1.5.14 the SD-section→access-bit gate is:
+// MS-FSA §2.1.5.17 ("Server Requests Setting of Security Information") the SD-section→access-bit gate is:
 //
 //	SECINFO_DACL  → WRITE_DAC
 //	SECINFO_OWNER → WRITE_OWNER

--- a/internal/adapter/smb/handlers/set_info_sparse_preservation_test.go
+++ b/internal/adapter/smb/handlers/set_info_sparse_preservation_test.go
@@ -1,7 +1,8 @@
 // Handler-level coverage for SET_INFO BasicInformation preservation of the
 // FSCTL-managed modeDOSSparse bit on a non-stream (base) handle.
 //
-// Per MS-FSCC 2.4.7, FILE_ATTRIBUTE_SPARSE_FILE is not settable via
+// Per MS-FSA 2.1.5.15.2 ("FileBasicInformation"), whose ValidSetAttributes
+// list omits it, FILE_ATTRIBUTE_SPARSE_FILE is not settable via
 // FileBasicInformation — it is controlled exclusively via FSCTL_SET_SPARSE.
 // A SET_INFO that updates DOS attributes (HIDDEN, READONLY, ...) must
 // therefore preserve any existing modeDOSSparse bit rather than clearing it.

--- a/internal/adapter/smb/handlers/set_info_timestamp_preservation_test.go
+++ b/internal/adapter/smb/handlers/set_info_timestamp_preservation_test.go
@@ -5,7 +5,7 @@
 // BasicInfo call (block 1), then issues a second BasicInfo call that mutates
 // only FileAttributes while sending zero timestamps (block 2, "a zero time
 // means don't change"), and asserts the explicit values from block 1 survive
-// unbumped. Per MS-FSA 2.1.5.14.2 an explicit (non-zero, non-sentinel)
+// unbumped. Per MS-FSA §2.1.5.15.2 ("FileBasicInformation") an explicit (non-zero, non-sentinel)
 // timestamp set suppresses the automatic update of that field on subsequent
 // operations. Without that suppression the attribute-change path auto-bumps
 // LastWriteTime (set_info.go) and ChangeTime (metadata file_modify.go),

--- a/internal/adapter/smb/handlers/set_reparse_point.go
+++ b/internal/adapter/smb/handlers/set_reparse_point.go
@@ -11,7 +11,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// handleSetReparsePoint handles FSCTL_SET_REPARSE_POINT [MS-FSCC] 2.3.69 — the
+// handleSetReparsePoint handles FSCTL_SET_REPARSE_POINT [MS-FSCC] 2.3.81 (FSCTL_SET_REPARSE_POINT Request) — the
 // write half of reparse-point support (the read half is handleGetReparsePoint).
 //
 // macOS (mount_smbfs) and Windows create symbolic links over SMB by: CREATE an
@@ -46,7 +46,7 @@ func (h *Handler) handleSetReparsePoint(ctx *SMBHandlerContext, body []byte) (*H
 		return NewErrorResult(types.StatusInvalidParameter), nil
 	}
 
-	// REPARSE_DATA_BUFFER header [MS-FSCC] 2.1.2.1: ReparseTag(4),
+	// REPARSE_DATA_BUFFER header [MS-FSCC] 2.1.2.2 (REPARSE_DATA_BUFFER): ReparseTag(4),
 	// ReparseDataLength(2), Reserved(2), then the tag-specific DataBuffer.
 	r := smbenc.NewReader(input)
 	reparseTag := r.ReadUint32()

--- a/internal/adapter/smb/handlers/stub_handlers.go
+++ b/internal/adapter/smb/handlers/stub_handlers.go
@@ -22,29 +22,29 @@ var allFFFileID = bytes.Repeat([]byte{0xFF}, 16)
 
 // Common IOCTL/FSCTL codes [MS-FSCC] 2.3
 const (
-	FsctlPipeTransceive         uint32 = 0x0011C017 // [MS-FSCC] 2.3.50 - Named pipe transact
+	FsctlPipeTransceive         uint32 = 0x0011C017 // [MS-FSCC] 2.3.47 (FSCTL_PIPE_TRANSCEIVE Request) - Named pipe transact
 	FsctlValidateNegotiateInfo  uint32 = 0x00140204 // [MS-SMB2] 2.2.31.4
 	FsctlQueryNetworkInterfInfo uint32 = 0x001401FC // [MS-SMB2] 2.2.32.5
 	FsctlSrvEnumerateSnapshots  uint32 = 0x00144064 // [MS-SMB2] 2.2.32.2
 	FsctlSrvRequestResumeKey    uint32 = 0x00140078 // [MS-SMB2] 2.2.32.3
 	FsctlSrvCopyChunk           uint32 = 0x001440F2 // [MS-SMB2] 2.2.32.1
 	FsctlSrvCopyChunkWrite      uint32 = 0x001480F2 // [MS-SMB2] 2.2.32.1
-	FsctlGetReparsePoint        uint32 = 0x000900A8 // [MS-FSCC] 2.3.30
-	FsctlSetReparsePoint        uint32 = 0x000900D4 // [MS-FSCC] 2.3.69 - Set reparse point (symlink create)
-	FsctlIsPathnameValid        uint32 = 0x0009002C // [MS-FSCC] 2.3.33 - Pathname validation
-	FsctlGetNtfsVolumeData      uint32 = 0x00090064 // [MS-FSCC] 2.3.29 - NTFS volume data
-	FsctlReadFileUsnData        uint32 = 0x000900EB // [MS-FSCC] 2.3.56 - Read file USN data
-	FsctlGetCompression         uint32 = 0x0009003C // [MS-FSCC] 2.3.9 - Get compression state
-	FsctlSetCompression         uint32 = 0x0009C040 // [MS-FSCC] 2.3.53 - Set compression state
-	FsctlGetIntegrityInfo       uint32 = 0x0009027C // [MS-FSCC] 2.3.25 - Get integrity information
-	FsctlSetIntegrityInfo       uint32 = 0x0009C280 // [MS-FSCC] 2.3.55 - Set integrity information (WPTS uses READ|WRITE access)
-	FsctlCreateOrGetObjectID    uint32 = 0x000900C0 // [MS-FSCC] 2.3.7 - Create or get object ID
-	FsctlGetObjectID            uint32 = 0x0009009C // [MS-FSCC] 2.3.28 - Get object ID
-	FsctlMarkHandle             uint32 = 0x000900FC // [MS-FSCC] 2.3.36 - Mark handle
-	FsctlQueryFileRegions       uint32 = 0x00090284 // [MS-FSCC] 2.3.51 - Query file regions
-	FsctlSetSparse              uint32 = 0x000900C4 // [MS-FSCC] 2.3.50 - Set sparse attribute
-	FsctlQueryAllocatedRanges   uint32 = 0x000940CF // [MS-FSCC] 2.3.32 - Query allocated byte ranges
-	FsctlSetZeroData            uint32 = 0x000980C8 // [MS-FSCC] 2.3.67 - Zero a byte range
+	FsctlGetReparsePoint        uint32 = 0x000900A8 // [MS-FSCC] 2.3.27 (FSCTL_GET_REPARSE_POINT Request)
+	FsctlSetReparsePoint        uint32 = 0x000900D4 // [MS-FSCC] 2.3.81 (FSCTL_SET_REPARSE_POINT Request) - Set reparse point (symlink create)
+	FsctlIsPathnameValid        uint32 = 0x0009002C // [MS-FSCC] 2.3.35 (FSCTL_IS_PATHNAME_VALID Request) - Pathname validation
+	FsctlGetNtfsVolumeData      uint32 = 0x00090064 // [MS-FSCC] 2.3.21 (FSCTL_GET_NTFS_VOLUME_DATA Request) - NTFS volume data
+	FsctlReadFileUsnData        uint32 = 0x000900EB // [MS-FSCC] 2.3.61 (FSCTL_READ_FILE_USN_DATA Request) - Read file USN data
+	FsctlGetCompression         uint32 = 0x0009003C // [MS-FSCC] 2.3.17 (FSCTL_GET_COMPRESSION Request) - Get compression state
+	FsctlSetCompression         uint32 = 0x0009C040 // [MS-FSCC] 2.3.67 (FSCTL_SET_COMPRESSION Request) - Set compression state
+	FsctlGetIntegrityInfo       uint32 = 0x0009027C // [MS-FSCC] 2.3.19 (FSCTL_GET_INTEGRITY_INFORMATION Request) - Get integrity information
+	FsctlSetIntegrityInfo       uint32 = 0x0009C280 // [MS-FSCC] 2.3.73 (FSCTL_SET_INTEGRITY_INFORMATION Request) - Set integrity information (WPTS uses READ|WRITE access)
+	FsctlCreateOrGetObjectID    uint32 = 0x000900C0 // [MS-FSCC] 2.3.1 (FSCTL_CREATE_OR_GET_OBJECT_ID Request) - Create or get object ID
+	FsctlGetObjectID            uint32 = 0x0009009C // [MS-FSCC] 2.3.25 (FSCTL_GET_OBJECT_ID Request) - Get object ID
+	FsctlMarkHandle             uint32 = 0x000900FC // [MS-FSCC] 2.3.39 (FSCTL_MARK_HANDLE Request) - Mark handle
+	FsctlQueryFileRegions       uint32 = 0x00090284 // [MS-FSCC] 2.3.55 (FSCTL_QUERY_FILE_REGIONS Request) - Query file regions
+	FsctlSetSparse              uint32 = 0x000900C4 // [MS-FSCC] 2.3.83 (FSCTL_SET_SPARSE Request) - Set sparse attribute
+	FsctlQueryAllocatedRanges   uint32 = 0x000940CF // [MS-FSCC] 2.3.51 (FSCTL_QUERY_ALLOCATED_RANGES Request) - Query allocated byte ranges
+	FsctlSetZeroData            uint32 = 0x000980C8 // [MS-FSCC] 2.3.85 (FSCTL_SET_ZERO_DATA Request) - Zero a byte range
 
 	// FSCTL_SMBTORTURE_* are Samba's private torture control codes (see
 	// libcli/smb/smb_constants.h in samba). They have no MS-FSCC analog; the
@@ -997,7 +997,7 @@ func (h *Handler) handleOplockBreakAck(ctx *SMBHandlerContext, body []byte) (*Ha
 	return NewResult(types.StatusSuccess, respBytes), nil
 }
 
-// handleGetNtfsVolumeData handles FSCTL_GET_NTFS_VOLUME_DATA [MS-FSCC] 2.3.29.
+// handleGetNtfsVolumeData handles FSCTL_GET_NTFS_VOLUME_DATA [MS-FSCC] 2.3.21 (FSCTL_GET_NTFS_VOLUME_DATA Request).
 // Returns an NTFS_VOLUME_DATA_BUFFER with VolumeSerialNumber matching the value
 // used in FILE_ID_INFORMATION (ntfsVolumeSerialNumber). TotalClusters and BytesPerSector
 // must match FileFsFullSizeInformation values because WPTS tests verify
@@ -1029,7 +1029,7 @@ func (h *Handler) handleGetNtfsVolumeData(ctx *SMBHandlerContext, body []byte) (
 		freeClusters = stats.AvailableBytes / clusterSize
 	}
 
-	// Build NTFS_VOLUME_DATA_BUFFER [MS-FSCC] 2.5.1 (96 bytes)
+	// Build NTFS_VOLUME_DATA_BUFFER [MS-FSCC] 2.3.22 (FSCTL_GET_NTFS_VOLUME_DATA Reply) (96 bytes)
 	const ntfsVolumeDataSize = 96
 	w := smbenc.NewWriter(ntfsVolumeDataSize)
 	w.WriteUint64(ntfsVolumeSerialNumber)                 // VolumeSerialNumber
@@ -1056,7 +1056,7 @@ func (h *Handler) handleGetNtfsVolumeData(ctx *SMBHandlerContext, body []byte) (
 	return NewResult(types.StatusSuccess, resp), nil
 }
 
-// handleReadFileUsnData handles FSCTL_READ_FILE_USN_DATA [MS-FSCC] 2.3.56.
+// handleReadFileUsnData handles FSCTL_READ_FILE_USN_DATA [MS-FSCC] 2.3.61 (FSCTL_READ_FILE_USN_DATA Request).
 // Returns a USN_RECORD for the file. Supports both V2 and V3 formats based on
 // the MaxMajorVersion in the READ_FILE_USN_DATA input buffer.
 // V3 is required by WPTS FSA tests for FileIdInformation validation because
@@ -1083,7 +1083,7 @@ func (h *Handler) handleReadFileUsnData(ctx *SMBHandlerContext, body []byte) (*H
 	}
 
 	// Parse READ_FILE_USN_DATA input to determine requested version.
-	// Input structure [MS-FSCC] 2.3.56:
+	// Input structure [MS-FSCC] 2.3.61 (FSCTL_READ_FILE_USN_DATA Request):
 	//   MinMajorVersion: WORD (2 bytes)
 	//   MaxMajorVersion: WORD (2 bytes)
 	// The input is in the IOCTL buffer portion (offset 56 from body start).
@@ -1174,7 +1174,7 @@ func (h *Handler) handleReadFileUsnData(ctx *SMBHandlerContext, body []byte) (*H
 }
 
 // handlePipeTransceive handles FSCTL_PIPE_TRANSCEIVE for RPC over named pipes
-// This is a combined write+read operation used by Windows/Linux clients for RPC [MS-FSCC] 2.3.50
+// This is a combined write+read operation used by Windows/Linux clients for RPC [MS-FSCC] 2.3.47 (FSCTL_PIPE_TRANSCEIVE Request)
 func (h *Handler) handlePipeTransceive(ctx *SMBHandlerContext, body []byte) (*HandlerResult, error) {
 	if len(body) < 56 {
 		logger.Debug("IOCTL PIPE_TRANSCEIVE: request too small", "len", len(body))

--- a/internal/adapter/smb/handlers/stub_handlers.go
+++ b/internal/adapter/smb/handlers/stub_handlers.go
@@ -1102,15 +1102,16 @@ func (h *Handler) handleReadFileUsnData(ctx *SMBHandlerContext, body []byte) (*H
 	fileNameBytes := encodeUTF16LE(openFile.Name().FileName)
 	fileAttrs := uint32(FileAttrToSMBAttributes(&file.FileAttr))
 
-	// Note: Usn, TimeStamp, Reason, SourceInfo, SecurityId are stub zeros.
-	// Real NTFS populates these from the USN journal. Sufficient for WPTS conformance
-	// but would need real values if clients rely on USN journal functionality.
+	// Reason, TimeStamp, SourceInfo and SecurityId are zero because [MS-FSCC]
+	// 2.3.62.2 requires a USN_RECORD returned by this FSCTL to set them to 0.
+	// Usn itself is a stub: real NTFS draws it from the USN journal.
 	var output []byte
 	if useV3 {
-		// Build USN_RECORD_V3 [MS-FSCC] 2.4.51.1
+		// Build USN_RECORD_V3 [MS-FSCC] 2.3.62.3 ("USN_RECORD_V3")
 		const v3FixedSize = 76
 		recordLen := v3FixedSize + len(fileNameBytes)
-		// Pad to 8-byte boundary per MS-FSCC
+		// Pad to 8-byte boundary. MS-FSCC does not specify record alignment;
+		// this follows the quadword alignment NTFS emits.
 		recordLen = (recordLen + 7) &^ 7
 
 		w := smbenc.NewWriter(recordLen)
@@ -1132,10 +1133,11 @@ func (h *Handler) handleReadFileUsnData(ctx *SMBHandlerContext, body []byte) (*H
 		w.Pad(8)
 		output = w.Bytes()
 	} else {
-		// Build USN_RECORD_V2 [MS-FSCC] 2.4.51
+		// Build USN_RECORD_V2 [MS-FSCC] 2.3.62.2 ("USN_RECORD_V2")
 		const v2FixedSize = 60
 		recordLen := v2FixedSize + len(fileNameBytes)
-		// Pad to 8-byte boundary per MS-FSCC
+		// Pad to 8-byte boundary. MS-FSCC does not specify record alignment;
+		// this follows the quadword alignment NTFS emits.
 		recordLen = (recordLen + 7) &^ 7
 
 		w := smbenc.NewWriter(recordLen)

--- a/internal/adapter/smb/handlers/timestamps_test.go
+++ b/internal/adapter/smb/handlers/timestamps_test.go
@@ -853,7 +853,7 @@ func TestDirFreezeTimestamps_ChildCreate_SingleField(t *testing.T) {
 //  2. The client freezes ChangeTime on the ADS handle via SET_INFO -1.
 //  3. The client writes data to the ADS.
 //
-// Per MS-FSA 2.1.5.14.2 the freeze sentinel applies to the underlying object,
+// Per MS-FSA §2.1.5.15.2 ("FileBasicInformation") the freeze sentinel applies to the underlying object,
 // so the base's ChangeTime must not be bumped by the ADS write. The metadata
 // layer auto-bumps Ctime when SetFileAttributes is called with any modified
 // attribute and attrs.Ctime == nil; updateBaseObjectTimestampsForADSWrite

--- a/internal/adapter/smb/handlers/write.go
+++ b/internal/adapter/smb/handlers/write.go
@@ -496,7 +496,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 		}
 	}
 
-	// Per MS-FSA 2.1.5.14.2: If timestamps are frozen via SET_INFO with -1,
+	// Per MS-FSA §2.1.5.15.2 ("FileBasicInformation"): If timestamps are frozen via SET_INFO with -1,
 	// CommitWrite unconditionally updated Mtime/Ctime. Restore frozen values.
 	h.restoreFrozenTimestamps(authCtx, openFile)
 
@@ -535,7 +535,7 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 	}
 	if len(parentHandle) > 0 && noteSmbParentAccess(openFile, now) {
 		_, _ = metaSvc.SetFileAttributes(authCtx, parentHandle, &metadata.SetAttrs{Atime: &now})
-		// Per MS-FSA 2.1.5.14.2: Restore frozen timestamps on the parent directory
+		// Per MS-FSA §2.1.5.15.2 ("FileBasicInformation"): Restore frozen timestamps on the parent directory
 		// if any open handle has them frozen. The SetFileAttributes call above
 		// unconditionally updates atime; if a handle has atime frozen, restore it.
 		// Skipped along with a coalesced-away bump: nothing was written to restore.

--- a/internal/adapter/smb/handlers/write.go
+++ b/internal/adapter/smb/handlers/write.go
@@ -523,9 +523,10 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 		h.updateBaseObjectTimestampsForADSWrite(authCtx, metaSvc, openFile, parentHandle, baseFileName)
 	}
 
-	// Per MS-FSA 2.1.5.3: After a successful write, update LastAccessTime
+	// Per MS-FSA 2.1.5.4 ("Server Requests a Write"): After a successful write, update LastAccessTime
 	// to the current system time, unless frozen via SET_INFO -1.
-	// Per MS-FSA 2.1.4.4: Parent directory's LastAccessTime is also updated.
+	// The parent directory's LastAccessTime is also updated. MS-FSA specifies no
+	// parent-directory timestamp update on write; this matches Windows.
 	// Both bumps coalesce per handle the way READ's does — see noteSmbAccess
 	// and noteSmbParentAccess.
 	now := time.Now()

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -1187,7 +1187,7 @@ func (lm *LeaseManager) BreakParentHandleLeasesOnCreate(
 	// Parent directory Handle-lease break on child create: strip Handle
 	// (not Write) so cached entries are invalidated. SharingViolation
 	// reason selects the Handle-strip mask in ComputeLeaseBreakTo;
-	// semantically this is MS-FSA 2.1.5.14 (child-set change invalidates
+	// semantically this is MS-FSA 2.1.5.1.1 ("Creation of a New File") (child-set change invalidates
 	// directory Handle caching), not a share-mode violation, but the
 	// break-to matrix collapses to the same strip-H outcome.
 	if err := lockMgr.BreakLeasesOnOpenConflict(handleKey, excludeOwner, lock.BreakReasonSharingViolation); err != nil {
@@ -1287,7 +1287,7 @@ func (lm *LeaseManager) PrepareParentDirLeaseBreakOnContentChange(
 
 // BreakParentReadLeasesOnModify breaks Read leases on a parent directory
 // when a child file's metadata is modified via SET_INFO, WRITE, or DELETE.
-// Per MS-FSA 2.1.5.14: changes to directory contents invalidate Read caching,
+// Per MS-FSA 2.1.4.12 ("Algorithm to Check for an Oplock Break"): changes to directory contents invalidate Read caching,
 // so clients holding R or RW leases on the directory must be notified.
 // Breaks to None (full revocation of Read caching).
 //

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -1187,9 +1187,11 @@ func (lm *LeaseManager) BreakParentHandleLeasesOnCreate(
 	// Parent directory Handle-lease break on child create: strip Handle
 	// (not Write) so cached entries are invalidated. SharingViolation
 	// reason selects the Handle-strip mask in ComputeLeaseBreakTo;
-	// semantically this is MS-FSA 2.1.5.1.1 ("Creation of a New File") (child-set change invalidates
-	// directory Handle caching), not a share-mode violation, but the
-	// break-to matrix collapses to the same strip-H outcome.
+	// semantically this is a child-set change invalidating directory Handle
+	// caching, not a share-mode violation, but the break-to matrix collapses to
+	// the same strip-H outcome. MS-FSA 2.1.4.12 breaks a PARENT_OBJECT oplock to
+	// (READ_CACHING|WRITE_CACHING) and so does not strip Handle; the strip
+	// follows the MS-SMB2 directory-lease behaviour Samba implements.
 	if err := lockMgr.BreakLeasesOnOpenConflict(handleKey, excludeOwner, lock.BreakReasonSharingViolation); err != nil {
 		return err
 	}

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -1041,7 +1041,7 @@ func (lm *LeaseManager) BreakHandleLeasesOnOpenAsync(
 
 // BreakLeasesOnRename dispatches lease break notifications on the source
 // (and optionally destination) file before a SET_INFO FileRenameInformation
-// applies to metadata. Per MS-FSA §2.1.5.14.10 and Samba
+// applies to metadata. Per MS-FSA §2.1.4.12 ("Algorithm to Check for an Oplock Break") and Samba
 // `source3/smbd/smb2_setinfo.c::smbd_smb2_rename`, rename participates in the
 // same break processing as CREATE: any concurrent open whose Handle caching
 // would be invalidated by the rename must be notified first.
@@ -1091,7 +1091,7 @@ func (lm *LeaseManager) BreakLeasesOnRename(
 }
 
 // BreakFileHandleLeasesOnDelete strips Handle caching from all leases on a
-// file that is about to be unlinked (RH → R, RWH → RW). Per MS-FSA 2.1.5.1.5
+// file that is about to be unlinked (RH → R, RWH → RW). Per MS-FSA 2.1.4.12 ("Algorithm to Check for an Oplock Break")
 // and Samba: deleting a file invalidates Handle caching for every other open
 // (the reopen path no longer exists), but Read and Write remain valid for as
 // long as the in-flight handles stay alive.

--- a/internal/adapter/smb/lease/manager_test.go
+++ b/internal/adapter/smb/lease/manager_test.go
@@ -86,7 +86,7 @@ func (r *fakeResolver) GetLockManagerForShare(_ string) lock.LockManager {
 // BreakLeasesOnOpenConflict and BEFORE returning. Per MS-SMB2 3.3.4.7, the
 // server must wait for LEASE_BREAK_ACK before completing the triggering CREATE.
 // The parent-dir break uses BreakReasonSharingViolation to select the
-// Handle-strip mask (MS-FSA 2.1.5.14: child-set change invalidates directory
+// Handle-strip mask (MS-FSA 2.1.5.1.1 ("Creation of a New File"): child-set change invalidates directory
 // Handle cache).
 // TestMarkLeaseVersionIfUnset_StickyV2: a lease first marked V2 stays V2
 // even when MarkLeaseVersionIfUnset is later called with isV2=false. Per

--- a/internal/adapter/smb/lease/manager_test.go
+++ b/internal/adapter/smb/lease/manager_test.go
@@ -86,8 +86,10 @@ func (r *fakeResolver) GetLockManagerForShare(_ string) lock.LockManager {
 // BreakLeasesOnOpenConflict and BEFORE returning. Per MS-SMB2 3.3.4.7, the
 // server must wait for LEASE_BREAK_ACK before completing the triggering CREATE.
 // The parent-dir break uses BreakReasonSharingViolation to select the
-// Handle-strip mask (MS-FSA 2.1.5.1.1 ("Creation of a New File"): child-set change invalidates directory
-// Handle cache).
+// Handle-strip mask: a child-set change invalidates the directory Handle
+// cache. MS-FSA 2.1.4.12 breaks a PARENT_OBJECT oplock to
+// (READ_CACHING|WRITE_CACHING) and does not strip Handle; the strip follows
+// the MS-SMB2 directory-lease behaviour Samba implements.
 // TestMarkLeaseVersionIfUnset_StickyV2: a lease first marked V2 stays V2
 // even when MarkLeaseVersionIfUnset is later called with isV2=false. Per
 // smbtorture v2_epoch2 the V2 lease keeps producing V2 responses for V1

--- a/internal/adapter/smb/types/status.go
+++ b/internal/adapter/smb/types/status.go
@@ -223,7 +223,8 @@ const (
 
 	// StatusCannotDelete indicates the file cannot be deleted because
 	// it is read-only or otherwise protected.
-	// Per MS-FSA 2.1.5.1.2.1 and 2.1.5.14.3.
+	// Per MS-FSA 2.1.5.1.2.1 ("Algorithm to Check Access to an Existing File")
+	// and 2.1.5.15.3 ("FileDispositionInformation").
 	StatusCannotDelete Status = 0xC0000121
 
 	// StatusInvalidLockRange indicates the lock range (offset+length) overflows

--- a/pkg/metadata/acl/generic.go
+++ b/pkg/metadata/acl/generic.go
@@ -91,8 +91,8 @@ const (
 // post-mapping ACCESS_MASK must contain only specific rights (MS-DTYP
 // §2.5.3). Bits unrelated to the generic set pass through unchanged.
 //
-// Per MS-DTYP §2.5.3 this expansion MUST be applied (MS-FSA states none of the
-// three call sites below):
+// MS-DTYP §2.5.3 mandates the expansion; MS-FSA does not name any of the three
+// call sites below. It MUST be applied:
 //   - at SET_INFO Security on each ACE AccessMask before persisting;
 //   - on SMB CREATE DesiredAccess before access-check evaluation;
 //   - on the probe set and result of any MaximalAccess computation.

--- a/pkg/metadata/acl/generic.go
+++ b/pkg/metadata/acl/generic.go
@@ -91,7 +91,8 @@ const (
 // post-mapping ACCESS_MASK must contain only specific rights (MS-DTYP
 // §2.5.3). Bits unrelated to the generic set pass through unchanged.
 //
-// Per MS-DTYP §2.5.3 / MS-FSA §2.1.5.1.2.1, this expansion MUST be applied:
+// Per MS-DTYP §2.5.3 this expansion MUST be applied (MS-FSA states none of the
+// three call sites below):
 //   - at SET_INFO Security on each ACE AccessMask before persisting;
 //   - on SMB CREATE DesiredAccess before access-check evaluation;
 //   - on the probe set and result of any MaximalAccess computation.

--- a/pkg/metadata/auth_identity.go
+++ b/pkg/metadata/auth_identity.go
@@ -84,7 +84,7 @@ type AuthContext struct {
 
 	// HasDeleteAccess signals that the protocol handler already verified
 	// Windows-style DELETE access on the target of an unlink. Per MS-FSA
-	// 2.1.5.1.2.1, DELETE access on the file itself is sufficient to unlink,
+	// 2.1.5.15.3 ("FileDispositionInformation"), DELETE access on the file itself is sufficient to unlink,
 	// without POSIX WRITE on the parent. The metadata layer uses this flag to
 	// unlock the owner-of-target delete rule that would otherwise diverge from
 	// POSIX unlink(2) for NFS clients.
@@ -96,7 +96,7 @@ type AuthContext struct {
 
 	// BypassTraverseChecking signals that the caller holds the Windows
 	// SeChangeNotifyPrivilege ("Bypass traverse checking"). Per MS-DTYP
-	// §2.5.3.2 and MS-FSA §2.1.5.1.1, holders of this privilege are exempt
+	// §2.5.3.2 and MS-FSA §2.1.5.1 Phase 6 ("Location of file"), holders of this privilege are exempt
 	// from the per-directory FILE_TRAVERSE (FILE_EXECUTE) check during path
 	// resolution: a deny on an intermediate directory's DACL does not prevent
 	// resolving a child whose own DACL grants the requested access.

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -693,7 +693,7 @@ func (s *Service) CheckParentCreateAccessFile(ctx *AuthContext, parentHandle Fil
 //     already authorized upstream (e.g. SMB CREATE with
 //     FILE_DELETE_ON_CLOSE + desiredAccess=DELETE or SET_INFO
 //     FileDispositionInformation, both of which verify the caller's grant
-//     at open time). Per MS-FSA 2.1.5.5 ("Server Requests Closing of an Open"), DELETE_ON_CLOSE honors the handle's
+//     at open time). Per MS-FSA 2.1.5.5 ("Server Requests Closing an Open"), DELETE_ON_CLOSE honors the handle's
 //     frozen authorization regardless of the current identity — critical for
 //     SMB reauth flows where the session's UID/GID may shift between open
 //     and close for the same Kerberos principal (issue #388). Read-only

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -693,7 +693,7 @@ func (s *Service) CheckParentCreateAccessFile(ctx *AuthContext, parentHandle Fil
 //     already authorized upstream (e.g. SMB CREATE with
 //     FILE_DELETE_ON_CLOSE + desiredAccess=DELETE or SET_INFO
 //     FileDispositionInformation, both of which verify the caller's grant
-//     at open time). Per MS-FSA 2.1.5.4, DELETE_ON_CLOSE honors the handle's
+//     at open time). Per MS-FSA 2.1.5.5 ("Server Requests Closing of an Open"), DELETE_ON_CLOSE honors the handle's
 //     frozen authorization regardless of the current identity — critical for
 //     SMB reauth flows where the session's UID/GID may shift between open
 //     and close for the same Kerberos principal (issue #388). Read-only
@@ -925,11 +925,12 @@ func (s *Service) CheckFileAccessWithParentGeneric(file *File, parent *File, aut
 	evalCtx := buildFileAccessEvalContext(file, authCtx)
 	granted := acl.EvaluateGranted(file.ACL, evalCtx, explicit)
 
-	// MS-FSA §2.1.5.1.2.1 "Algorithm to Check Access to an Existing File":
-	// FILE_READ_ATTRIBUTES is always granted from the containing directory
-	// once traverse access to the file's path succeeds. The bit is unmasked
-	// from the file's DACL evaluation — even a DACL that explicitly omits
-	// READ_ATTRIBUTES still yields a successful open requesting it.
+	// MS-FSA §2.1.5.1.2.1 "Algorithm to Check Access to an Existing File"
+	// grants FILE_READ_ATTRIBUTES from the containing directory, conditional on
+	// AccessCheck(parent, FILE_LIST_DIRECTORY) returning TRUE. This grants it
+	// unconditionally once traverse access to the path succeeds, so the bit is
+	// unmasked from the file's DACL evaluation — even a DACL that explicitly
+	// omits READ_ATTRIBUTES still yields a successful open requesting it.
 	//
 	// Mirrors Samba source3/smbd/open.c::smbd_check_access_rights_fsp which
 	// sets `do_not_check_mask = FILE_READ_ATTRIBUTES` before invoking the

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -821,7 +821,7 @@ func (s *Service) CheckFileAccess(file *File, authCtx *AuthContext, desiredAcces
 }
 
 // CheckFileAccessWithParent extends CheckFileAccess with the standard
-// Windows "delete via parent" override per MS-FSA §2.1.4.13 / §2.1.5.1.2.4:
+// Windows "delete via parent" override per MS-FSA §2.1.5.1.2.1 ("Algorithm to Check Access to an Existing File"):
 // when the file's own DACL denies DELETE but the parent directory grants
 // FILE_DELETE_CHILD (ACE4_DELETE_CHILD, 0x40) to the caller, DELETE is
 // granted on the open. This mirrors Samba's parent_override_delete() in
@@ -925,7 +925,7 @@ func (s *Service) CheckFileAccessWithParentGeneric(file *File, parent *File, aut
 	evalCtx := buildFileAccessEvalContext(file, authCtx)
 	granted := acl.EvaluateGranted(file.ACL, evalCtx, explicit)
 
-	// MS-FSA §2.1.4.13 "Algorithm to Check Access to an Existing File":
+	// MS-FSA §2.1.5.1.2.1 "Algorithm to Check Access to an Existing File":
 	// FILE_READ_ATTRIBUTES is always granted from the containing directory
 	// once traverse access to the file's path succeeds. The bit is unmasked
 	// from the file's DACL evaluation — even a DACL that explicitly omits
@@ -941,7 +941,7 @@ func (s *Service) CheckFileAccessWithParentGeneric(file *File, parent *File, aut
 
 	// Parent override for DELETE: when the file's own DACL denied DELETE but
 	// the parent directory grants FILE_DELETE_CHILD to the caller, grant
-	// DELETE here (MS-FSA §2.1.4.13 / Samba parent_override_delete). The
+	// DELETE here (MS-FSA §2.1.5.1.2.1 ("Algorithm to Check Access to an Existing File") / Samba parent_override_delete). The
 	// override fires only when DELETE was actually requested and not yet
 	// granted, and only when a parent file is in scope. This is the same
 	// Windows semantics that lets administrators delete files with no DELETE
@@ -970,7 +970,7 @@ func (s *Service) CheckFileAccessWithParentGeneric(file *File, parent *File, aut
 		if parent != nil && parentGrantsDeleteChild(parent, authCtx) {
 			effective |= acl.ACE4_DELETE
 		}
-		// MS-FSA §2.1.4.13: FILE_READ_ATTRIBUTES is always granted from the
+		// MS-FSA §2.1.5.1.2.1 ("Algorithm to Check Access to an Existing File"): FILE_READ_ATTRIBUTES is always granted from the
 		// containing directory (see explicit-branch comment above). Surface it
 		// in the MaxAccess set so MxAc replies and MAXIMUM_ALLOWED opens carry
 		// the bit. Refs #559.
@@ -1015,7 +1015,7 @@ func (s *Service) CheckFileAccessWithParentGeneric(file *File, parent *File, aut
 
 // parentGrantsDeleteChild decides whether a parent directory grants
 // FILE_DELETE_CHILD (ACE4_DELETE_CHILD) to the requester for the purposes
-// of the MS-FSA §2.1.4.13 delete-via-parent override. Null DACL on the
+// of the MS-FSA §2.1.5.1.2.1 ("Algorithm to Check Access to an Existing File") delete-via-parent override. Null DACL on the
 // parent grants everything (MS-DTYP §2.5.3). Root and nil-identity callers
 // also bypass — consistent with the rest of CheckFileAccessWithParent.
 func parentGrantsDeleteChild(parent *File, authCtx *AuthContext) bool {

--- a/pkg/metadata/auth_permissions_bypass_traverse_test.go
+++ b/pkg/metadata/auth_permissions_bypass_traverse_test.go
@@ -23,7 +23,7 @@ import (
 // Before the fix, the Lookup on the restricted parent failed with
 // ErrAccessDenied (mapped to STATUS_ACCESS_DENIED) or the upstream walkPath
 // remapped it to STATUS_OBJECT_NAME_NOT_FOUND, neither of which matches the
-// MS-FSA §2.1.5.1.1 behavior.
+// MS-FSA §2.1.5.1 Phase 6 ("Location of file") behavior.
 func TestLookup_BypassTraverseChecking_GrantsAccess(t *testing.T) {
 	t.Parallel()
 	fx := newTestFixture(t)

--- a/pkg/metadata/auth_permissions_file_access_test.go
+++ b/pkg/metadata/auth_permissions_file_access_test.go
@@ -396,7 +396,7 @@ func TestCheckFileAccess_DenyErrorIsStoreError(t *testing.T) {
 // TestCheckFileAccessWithParent_DeleteOverrideViaParentDeleteChild covers
 // issue #547: when a file's own DACL denies DELETE but the parent directory
 // grants FILE_DELETE_CHILD to the caller, DELETE on the open must be
-// granted (MS-FSA §2.1.4.13, mirrors Samba parent_override_delete in
+// granted (MS-FSA §2.1.5.1.2.1 ("Algorithm to Check Access to an Existing File"), mirrors Samba parent_override_delete in
 // source3/smbd/open.c).
 //
 // Without this override, smbtorture's smb2_deltree algorithm cannot recover
@@ -641,7 +641,7 @@ func TestCheckFileAccessWithParent_NoOverrideWhenParentLacksDeleteChild(t *testi
 }
 
 // TestCheckFileAccess_ReadAttributesAlwaysGrantedFromParent covers MS-FSA
-// §2.1.4.13 "Algorithm to Check Access to an Existing File": FILE_READ_ATTRIBUTES
+// §2.1.5.1.2.1 "Algorithm to Check Access to an Existing File": FILE_READ_ATTRIBUTES
 // is unconditionally granted from the containing directory once traverse access
 // to the path succeeds. Even a DACL that explicitly omits READ_ATTRIBUTES must
 // not block an open that asks for it.

--- a/pkg/metadata/directory.go
+++ b/pkg/metadata/directory.go
@@ -267,7 +267,8 @@ func (s *Service) RemoveDirectory(ctx *AuthContext, parentHandle FileHandle, nam
 	}
 
 	// Coalesce the parent directory timestamp bump (Mtime/Ctime/Atime per
-	// MS-FSA 2.1.4.4) out of the transaction, same as create/unlink, so the
+	// POSIX rmdir(2); MS-FSA specifies no parent-time update on removal) out of
+	// the transaction, same as create/unlink, so the
 	// rmdir transaction touches only disjoint namespace keys and never the
 	// shared parent-inode key that made concurrent same-parent ops serialize
 	// (#1573/#1643). The read overlay (mergeDirTimes) makes the bump visible.

--- a/pkg/metadata/file_create.go
+++ b/pkg/metadata/file_create.go
@@ -511,7 +511,7 @@ func (s *Service) createEntry(
 		cc.WarmFileReadCache(newFile)
 	}
 
-	// Coalesce the parent directory timestamp bump. Per MS-FSA 2.1.4.4 a
+	// Coalesce the parent directory timestamp bump. Per MS-FSA 2.1.5.1.1 ("Creation of a New File") a
 	// directory modified by adding an entry updates Mtime, Ctime and Atime.
 	s.recordDirTimes(ctx.Context, parentHandle, now)
 	parent.Mtime = now

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -46,7 +46,7 @@ func (s *Service) Lookup(ctx *AuthContext, dirHandle FileHandle, name string) (*
 	//
 	// Skipped when the caller holds "Bypass traverse checking"
 	// (Windows SeChangeNotifyPrivilege, MS-DTYP §2.5.3.2 + MS-FSA
-	// §2.1.5.1.1). Every SMB session sets ctx.BypassTraverseChecking so
+	// §2.1.5.1 Phase 6 ("Location of file")). Every SMB session sets ctx.BypassTraverseChecking so
 	// that a parent directory whose DACL omits FILE_TRAVERSE does not
 	// block resolution of a child whose own DACL grants the request. NFS
 	// callers leave the flag false and continue to enforce POSIX execute

--- a/pkg/metadata/file_remove.go
+++ b/pkg/metadata/file_remove.go
@@ -12,7 +12,7 @@ import (
 // This handles:
 //   - Input validation
 //   - Permission checking via checkDeletePermission: ctx.HasDeleteAccess
-//     (Windows DELETE semantics — authorized upstream, MS-FSA 2.1.5.4) or
+//     (Windows DELETE semantics — authorized upstream, MS-FSA 2.1.5.5 ("Server Requests Closing of an Open")) or
 //     WRITE on parent (POSIX unlink(2))
 //   - Sticky bit enforcement
 //   - Hard link management (decrement or set nlink=0)
@@ -231,7 +231,8 @@ func (s *Service) RemoveFile(ctx *AuthContext, parentHandle FileHandle, name str
 	}
 
 	// Coalesce the parent directory timestamp bump (Mtime/Ctime/Atime per
-	// MS-FSA 2.1.4.4) out of the transaction, same as create (#1573).
+	// POSIX unlink(2)) out of the transaction, same as create (#1573). MS-FSA
+	// updates parent times on create (2.1.5.1.1) but specifies none on delete.
 	s.recordDirTimes(ctx.Context, parentHandle, now)
 	parent.Mtime = now
 	parent.Ctime = now

--- a/pkg/metadata/file_remove.go
+++ b/pkg/metadata/file_remove.go
@@ -12,7 +12,7 @@ import (
 // This handles:
 //   - Input validation
 //   - Permission checking via checkDeletePermission: ctx.HasDeleteAccess
-//     (Windows DELETE semantics — authorized upstream, MS-FSA 2.1.5.5 ("Server Requests Closing of an Open")) or
+//     (Windows DELETE semantics — authorized upstream, MS-FSA 2.1.5.5 ("Server Requests Closing an Open")) or
 //     WRITE on parent (POSIX unlink(2))
 //   - Sticky bit enforcement
 //   - Hard link management (decrement or set nlink=0)

--- a/pkg/metadata/file_types.go
+++ b/pkg/metadata/file_types.go
@@ -76,8 +76,8 @@ type FileAttr struct {
 	ACL *acl.ACL `json:"acl,omitempty"`
 
 	// EAs holds the file's extended attributes (SMB FILE_FULL_EA_INFORMATION,
-	// MS-FSCC §2.4.15). Keys are EA names stored in the casing supplied by the
-	// client; per MS-FSCC EA names are case-insensitive, so callers MUST resolve
+	// MS-FSCC §2.4.16 ("FileFullEaInformation")). Keys are EA names stored in the casing supplied by the
+	// client; EA names are case-insensitive per NTFS semantics, so callers MUST resolve
 	// names case-insensitively (helpers on this type do so). Values are raw
 	// bytes (may be empty but non-nil to distinguish a zero-length EA from an
 	// absent one). nil means no EAs are set.
@@ -230,7 +230,8 @@ type SetAttrs struct {
 
 // EAMutation is a single extended-attribute upsert or delete, applied via
 // SetAttrs.EAMutations. Name is matched case-insensitively against existing
-// EA names (MS-FSCC §2.4.15); a set with a new name records that name's casing.
+// EA names, case-insensitively per NTFS semantics (MS-FSCC §2.4.16 ("FileFullEaInformation")
+// defines the structure only); a set with a new name records that name's casing.
 type EAMutation struct {
 	// Name is the EA name (canonical NT form, no domain prefix).
 	Name string
@@ -241,7 +242,7 @@ type EAMutation struct {
 }
 
 // LookupEA returns the value of the named extended attribute and whether it is
-// present, resolving the name case-insensitively per MS-FSCC §2.4.15.
+// present, resolving the name case-insensitively per NTFS semantics.
 func (a *FileAttr) LookupEA(name string) ([]byte, bool) {
 	key, found := a.findEAKey(name)
 	if !found {

--- a/pkg/metadata/io.go
+++ b/pkg/metadata/io.go
@@ -550,7 +550,7 @@ func (s *Service) GetPendingSize(handle FileHandle) (uint64, bool) {
 }
 
 // UpdatePendingMtime updates the LastMtime in pending write state for a file handle.
-// Used by SMB frozen timestamp support (MS-FSA 2.1.5.14.2): when SET_INFO(-1) freezes
+// Used by SMB frozen timestamp support (MS-FSA §2.1.5.15.2 ("FileBasicInformation")): when SET_INFO(-1) freezes
 // Mtime, the pending state's LastMtime must reflect the frozen value so that GetFile()
 // merge returns frozen timestamps correctly.
 func (s *Service) UpdatePendingMtime(handle FileHandle, mtime time.Time) bool {

--- a/pkg/metadata/lock/break.go
+++ b/pkg/metadata/lock/break.go
@@ -45,7 +45,7 @@ func (lm *Manager) CheckAndBreakCachingForRead(handleKey string, excludeOwner *L
 
 // CheckAndBreakLeasesForSMBOpen breaks conflicting leases for an SMB CREATE.
 //
-// Per MS-SMB2 3.3.5.9 / MS-FSA 2.1.5.17.1: When a new SMB open arrives,
+// Per MS-SMB2 3.3.5.9 / MS-FSA 2.1.4.12 ("Algorithm to Check for an Oplock Break"): When a new SMB open arrives,
 // existing leases that hold Write caching must be broken. Unlike cross-protocol
 // breaks (CheckAndBreakCachingForWrite), the break strips only the Write bit,
 // preserving Read and Handle caching. This allows clients to continue read

--- a/pkg/metadata/lock/break.go
+++ b/pkg/metadata/lock/break.go
@@ -117,7 +117,7 @@ func (lm *Manager) PrepareBreakLeasesOnOpenConflict(handleKey string, excludeOwn
 }
 
 // BreakReadLeasesForParentDir breaks Read leases on a parent directory when
-// a child file is modified (SET_INFO, WRITE, DELETE). Per MS-FSA 2.1.5.14:
+// a child file is modified (SET_INFO, WRITE, DELETE). Per MS-FSA 2.1.4.12 ("Algorithm to Check for an Oplock Break"):
 // changes to directory contents or child metadata invalidate Read caching,
 // so clients holding R or RW leases on the directory must be notified.
 //

--- a/pkg/metadata/lock/cross_store_test.go
+++ b/pkg/metadata/lock/cross_store_test.go
@@ -6,7 +6,7 @@ import "testing"
 // via Manager.Lock) and NLM/NFSv4 byte-range locks (lm.unifiedLocks, via
 // Manager.AddUnifiedLock) live in two separate maps. Each acquisition / IO path
 // must cross-check the other map so a lock taken via one protocol blocks a
-// conflicting lock or write via the other (MS-FSA §2.1.5).
+// conflicting lock or write via the other (MS-FSA §2.1.4.10 ("Algorithm for Determining If a Range Access Conflicts with Byte-Range Locks")).
 
 const xHandle = "share-a:file-1"
 

--- a/pkg/metadata/lock/durable_store.go
+++ b/pkg/metadata/lock/durable_store.go
@@ -151,7 +151,7 @@ type PersistedDurableHandle struct {
 	IsDirectory   bool   // Whether the file is a directory
 
 	// PositionInfo is the FILE_POSITION_INFORMATION CurrentByteOffset
-	// (MS-FSCC 2.4.32) captured at disconnect. Restored to the OpenFile
+	// (MS-FSCC 2.4.40 (FilePositionInformation)) captured at disconnect. Restored to the OpenFile
 	// on reconnect so SET/GET FilePositionInformation round-trips across
 	// the disconnect (smb2.durable-open.file-position).
 	PositionInfo uint64

--- a/pkg/metadata/lock/manager.go
+++ b/pkg/metadata/lock/manager.go
@@ -252,7 +252,7 @@ type LockManager interface {
 
 	// BreakReadLeasesForParentDir breaks Read leases on a parent directory
 	// when directory content changes (CREATE, RENAME, DELETE on close).
-	// Per MS-FSA 2.1.5.14: changes to directory listing invalidate Read
+	// Per MS-FSA 2.1.4.12 ("Algorithm to Check for an Oplock Break"): changes to directory listing invalidate Read
 	// caching, so clients holding R or RW leases must be notified.
 	// Breaks to None (full revocation of Read caching).
 	BreakReadLeasesForParentDir(handleKey string, excludeOwner *LockOwner) error
@@ -624,7 +624,7 @@ func conflictFrom(fl *FileLock) *LockConflict {
 // byte-range locks in lm.unifiedLocks (Manager.AddUnifiedLock). The helpers
 // below let each acquisition/IO path cross-check the OTHER map so a lock taken
 // via one protocol blocks a conflicting lock or write via the other
-// (MS-FSA §2.1.5 cross-protocol byte-range conflict). Without this an NFS lock
+// (MS-FSA §2.1.4.10 ("Algorithm for Determining If a Range Access Conflicts with Byte-Range Locks") cross-protocol byte-range conflict). Without this an NFS lock
 // and an SMB lock on the same overlapping range could both be granted.
 
 // fileLockConflictsWithUnified reports whether an SMB byte-range FileLock and a

--- a/pkg/metadata/service_test.go
+++ b/pkg/metadata/service_test.go
@@ -611,8 +611,10 @@ func TestMetadataService_RemoveDirectory(t *testing.T) {
 // Delete permission model tests (issue #388)
 // ============================================================================
 //
-// These verify that RemoveFile/RemoveDirectory honor MS-FSA 2.1.5.1.2.1 delete
-// semantics: the caller must hold WRITE on parent OR own the target. Without the
+// These verify RemoveFile/RemoveDirectory delete semantics: the caller must
+// hold WRITE on the parent OR own the target. That disjunction is POSIX, not
+// MS-FSA, which gates delete on Open.GrantedAccess.DELETE (2.1.5.15.3) with a
+// parent FILE_DELETE_CHILD override (2.1.5.1.2.1). Without the
 // owner-path rule, SMB DELETE_ON_CLOSE loops forever when the file's creator
 // asks the server to clean up its own temp file with DELETE-only access.
 
@@ -679,7 +681,7 @@ func TestMetadataService_RemoveFile_DeletePermission(t *testing.T) {
 	})
 
 	// Rule 1 (SMB-gated): HasDeleteAccess bypasses parent-WRITE check
-	// regardless of current caller identity (MS-FSA 2.1.5.4 —
+	// regardless of current caller identity (MS-FSA 2.1.5.5 ("Server Requests Closing of an Open") —
 	// authorization was frozen at CREATE, survives reauth identity drift).
 	t.Run("HasDeleteAccess bypasses parent-WRITE", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/metadata/service_test.go
+++ b/pkg/metadata/service_test.go
@@ -681,7 +681,7 @@ func TestMetadataService_RemoveFile_DeletePermission(t *testing.T) {
 	})
 
 	// Rule 1 (SMB-gated): HasDeleteAccess bypasses parent-WRITE check
-	// regardless of current caller identity (MS-FSA 2.1.5.5 ("Server Requests Closing of an Open") —
+	// regardless of current caller identity (MS-FSA 2.1.5.5 ("Server Requests Closing an Open") —
 	// authorization was frozen at CREATE, survives reauth identity drift).
 	t.Run("HasDeleteAccess bypasses parent-WRITE", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/metadata/store/postgres/durable_handles.go
+++ b/pkg/metadata/store/postgres/durable_handles.go
@@ -260,7 +260,7 @@ func (s *postgresDurableStore) PutDurableHandle(ctx context.Context, handle *loc
 		handle.FileName,
 		handle.IsDirectory,
 		// PositionInfo is a file offset (FILE_POSITION_INFORMATION.CurrentByteOffset,
-		// MS-FSCC 2.4.32) stored as BIGINT (signed int64). File offsets fit in
+		// MS-FSCC 2.4.40 (FilePositionInformation)) stored as BIGINT (signed int64). File offsets fit in
 		// int64 in practice; reinterpret the bit pattern to preserve any high-bit
 		// value. The scan path mirrors this with uint64(int64) on read.
 		int64(handle.PositionInfo),

--- a/pkg/metadata/store/postgres/migrations/000017_durable_handle_position_and_original_fileid.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000017_durable_handle_position_and_original_fileid.up.sql
@@ -4,7 +4,7 @@
 -- the memory backend already round-trips and badger picks up via JSON:
 --
 --   * PositionInfo  — FILE_POSITION_INFORMATION CurrentByteOffset
---                     (MS-FSCC 2.4.32) captured at disconnect. Restoring this
+--                     (MS-FSCC 2.4.40 (FilePositionInformation)) captured at disconnect. Restoring this
 --                     on reconnect makes SET/GET FilePositionInformation
 --                     survive the disconnect (smb2.durable-open.file-position).
 --

--- a/pkg/metadata/store/postgres/migrations/000028_file_extended_attributes.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000028_file_extended_attributes.up.sql
@@ -1,5 +1,5 @@
 -- Persist extended attributes (EAs) on files (SMB FILE_FULL_EA_INFORMATION,
--- MS-FSCC §2.4.15).
+-- MS-FSCC §2.4.16 ("FileFullEaInformation")).
 --
 -- An SMB client may attach named extended attributes to a file via SET_INFO
 -- FileFullEaInformation or an SMB2_CREATE_EA_BUFFER create context, and read

--- a/pkg/metadata/store/sqlite/durable_handles.go
+++ b/pkg/metadata/store/sqlite/durable_handles.go
@@ -225,7 +225,7 @@ func (s *sqliteDurableStore) PutDurableHandle(ctx context.Context, handle *lock.
 		handle.FileName,
 		handle.IsDirectory,
 		// PositionInfo is a file offset (FILE_POSITION_INFORMATION.CurrentByteOffset,
-		// MS-FSCC 2.4.32) stored as BIGINT (signed int64). File offsets fit in
+		// MS-FSCC 2.4.40 (FilePositionInformation)) stored as BIGINT (signed int64). File offsets fit in
 		// int64 in practice; reinterpret the bit pattern to preserve any high-bit
 		// value. The scan path mirrors this with uint64(int64) on read.
 		int64(handle.PositionInfo),

--- a/pkg/metadata/storetest/ea_ops.go
+++ b/pkg/metadata/storetest/ea_ops.go
@@ -13,7 +13,7 @@ import (
 // deep-copy (aliasing) discipline on both the store-from-caller and
 // return-to-caller paths.
 //
-// EAs (SMB FILE_FULL_EA_INFORMATION, MS-FSCC §2.4.15) ride on FileAttr the
+// EAs (SMB FILE_FULL_EA_INFORMATION, MS-FSCC §2.4.16 ("FileFullEaInformation")) ride on FileAttr the
 // same way ACL does. The memory backend holds the map directly and must
 // deep-copy it; Badger/Postgres round-trip through JSON. This suite pins that
 // behaviour identically for every backend.

--- a/pkg/metadata/storetest/suite.go
+++ b/pkg/metadata/storetest/suite.go
@@ -85,7 +85,7 @@ func RunConformanceSuite(t *testing.T, factory StoreFactory) {
 		runACLAliasingTests(t, factory)
 	})
 
-	// EAOps covers FileAttr.EAs (SMB extended attributes, MS-FSCC §2.4.15):
+	// EAOps covers FileAttr.EAs (SMB extended attributes, MS-FSCC §2.4.16 ("FileFullEaInformation")):
 	// UpdateAttrs/GetFile round-trip, zero-length values, deletion, case-
 	// insensitive name resolution with set-case preservation, deep-copy
 	// (aliasing) discipline, and persistence across unrelated writes. Pins

--- a/pkg/metadata/xattr_test.go
+++ b/pkg/metadata/xattr_test.go
@@ -61,7 +61,7 @@ func TestServiceXattrRoundTrip(t *testing.T) {
 }
 
 // TestServiceXattrCaseInsensitive verifies the EA-name case-insensitivity
-// (MS-FSCC §2.4.15) shared with SMB carries over to the xattr accessors.
+// (NTFS semantics) shared with SMB carries over to the xattr accessors.
 func TestServiceXattrCaseInsensitive(t *testing.T) {
 	fx := newTestFixture(t)
 	ctx := fx.rootContext()


### PR DESCRIPTION
Closes #2155.

Sibling of #2156, which corrected the MS-SMB2 half. Same method, same two rulings applied:
section titles are added only to citations actually changed, and dated changelog entries are left
alone.

Comment-only — verified mechanically, not asserted. Stripping the trailing comment from every
changed line and diffing what remains leaves nothing but two SQL `--` comment lines.

## The issue undercounts by about 3.5x, because it tested the wrong thing

#2155 counted citations naming a section that **does not exist** and found 66. That count is
right, and this PR confirms it. But existence is the cheap test. A citation naming a section that
**does exist and says something else** is worse — it reads as authoritative and nothing ever flags
it — and there are far more of those.

| | fabricated section | real section, wrong subject | correct | total |
| --- | ---: | ---: | ---: | ---: |
| MS-FSCC | 12 | 89 | 49 | 151 |
| MS-FSA | 57 | 85 | 15 | 160 |

**About 243 of 311 MS-FSCC/MS-FSA citations were wrong.** The MS-FSA side is the worse of the two:
only 15 of 160 survived unchanged.

Two smaller corrections to the issue's arithmetic, both from sweeping the whole repository rather
than `internal/adapter/smb/` alone:

- Four more fabricated-section sites live outside that tree — `2.1.5.1.2.4`, `2.1.5.17.1`, and the
  22nd `2.1.5.14.2` — in `pkg/metadata/`. The defect class is not confined to the adapter.
- Three of the issue's apparent hits are false positives: MS-FSA "8.1" ×3 is a pseudocode *step*
  label inside the already-correct §2.1.5.15.12, and MS-FSCC "8.3" is the phrase "8.3 short name".

## Method

Both specs pulled as PDFs at their current published revisions, full body text extracted, so every
verdict is checked against the document rather than inferred from surrounding code:

| spec | revision | released | pages | sections |
| --- | --- | --- | ---: | ---: |
| MS-FSCC | 60.0 (`v20251121`) | 2025-11-21 | 243 | 255 |
| MS-FSA | 42.0 (`v20250909`) | 2025-09-09 | 287 | 215 |

**The section maps were validated before being trusted.** A parser that *misses* a real section
silently turns a correct citation into a fabricated-section "finding" — the failure direction that
invents work. So the maps were checked structurally, not spot-checked: TOC-derived and
body-heading-derived maps agree on every shared key (0 disagreements), no section has a missing
parent, and no gap in any sibling run has its number appear anywhere in the whitespace-flattened
text. Every section called fabricated below has **zero** occurrences across the whole document.

That check earned its keep immediately: my first FSCTL extraction pass reported
`FSCTL_MARK_HANDLE`'s value as absent from the spec, which would have made it a second
wrong-constant finding. The spec writes it `0x900FC` and my regex demanded `0X`. A case-sensitive
regex, not a defect.

### Deriving rather than transcribing

The 17 FSCTL constants were not corrected from a list someone wrote down. Each constant's *value*
is looked up in MS-FSCC §2.3's own name/code table to get the FSCTL name, and the name gives its
Request section. All 16 resolvable rows came out identical to the hand-audit — and the one that
would not resolve is a real bug (below).

The same idea drove a consistency sweep over the finished tree: for every MS-FSCC citation whose
comment names a structure or class, check the cited section's *title* against that identifier.
That caught 47 sites, including an entire info-class constant block in `requests.go` that the
manual passes had walked straight past, and after correction it caught two stragglers I had
missed. It is the single most useful instrument in this PR and it should probably become a CI
check.

## What was wrong

**There is no offset to apply.** The MS-SMB2 half established this and MS-FSCC/MS-FSA repeat it in
every cluster:

- FSCTL codes drift by −14 to +33, a different amount at every entry.
- `2.4.x` info classes drift by +1, +5, +6, +7, +8 at different sites.
- The `2.1.5.9.x` FSCTLs land on `2.1.5.10.x` with deltas of −5, −4, −1, +2, +4.

The near-miss the issue warned about is real and I hit its edge myself: a blind
`s/2.1.5.14.2/2.1.5.15.2/` also ate the prefix of `2.1.5.14.23`, leaving
`§2.1.5.15.2 ("FileBasicInformation")3`. Caught by grep, corrected to `2.1.5.15.10`
(`FilePositionInformation`) — which is where it belonged anyway, thirteen sections from where a
mechanical rule would have put it.

### Fabricated families

| cited | sites | why it cannot be right | corrected to |
| --- | ---: | --- | --- |
| `2.1.5.14.2/.3/.4/.5/.10/.13/.23` | 43 | MS-FSA §2.1.5.14 is *Query of Security Information* and has exactly one child, `.1` | per-class under §2.1.5.15 |
| `2.1.5.9.7/.15/.17/.20/.29/.36` | 9 | §2.1.5.9 is the byte-range unlock; no subsections | per-FSCTL under §2.1.5.10 |
| `2.4.51`, `2.4.51.1` | 2 | §2.4 stops at `2.4.50`; and V3 is a *sibling* of V2, so `.1` was structurally wrong too | `2.3.62.2` / `2.3.62.3` USN_RECORD |
| `2.4.21.2` | 4 | §2.4.21 is `FileIdAllExtdDirectoryInformation`, no subsections | `2.4.28` / `2.4.28.2` |
| `2.4.11.2` | 2 | §2.4.11 has no subsections | `2.4.12` FileDispositionInformationEx |
| `2.1.5.1.5`, `2.1.5.11.6`, `2.1.5.17.1`, `2.1.5.1.2.4` | 4 | none exist | §2.1.4.12, §2.1.5.12.27, §2.1.4.12, §2.1.5.1.2.1 |

### The wrong-spec cluster

Four `query_directory.go` sites cited **MS-FSCC 2.1.4.4** for DOS wildcard matching. MS-FSCC
§2.1.4 is *Alternate Data Streams*, and the token `DOS_STAR` occurs **zero times** in the entire
document. The algorithm is **MS-FSA §2.1.4.4** — the number was right and the specification name
was wrong, which is why it reads so plausibly.

Two things came out of that same comment block that are not renumberings:

- The sentence quoted as spec text — *"If the pattern is `*` (DOS_STAR), consume through the last
  dot."* — appears in no Microsoft specification. Replaced with the real wording.
- The gloss `? matches exactly one character (including dot and end-of-name)` describes DOS_QM,
  not `?`. MS-FSA §2.1.4.4: *"? (question mark) Matches a single character."* **The code is
  right**; only the parenthetical was wrong.

### The largest wrong-but-exists clusters

- **`2.4.15` → `2.4.16`, 21 sites.** Every `FILE_FULL_EA_INFORMATION` citation pointed at
  `FileFullDirectoryInformation`. Off by one, and wrong in every place EAs are touched.
- **The MS-FSA operation list, ~20 sites.** Read cited as `2.1.5.2` (*Named Pipe*), Write as
  `2.1.5.3` (*Read*), Close as `2.1.5.4` (*Write*), QueryDirectory as `2.1.5.5` (*Close*) — a
  consistent one-place slip, as if authored against a revision predating the named-pipe section.
  Consistent, but not universal, so each was matched by content rather than shifted.
- **Bare `2.1.5.14`, 13 sites.** *Query of Security Information* was standing in for three
  unrelated subjects: oplock breaks (§2.1.4.12), set-security (§2.1.5.17), and per-class SET_INFO.
- **`2.1.4.13`, 8 sites.** *Algorithm to Recompute the State of a Shared Oplock*, used for the
  parent-directory access override. Several of those comments already quote
  §2.1.5.1.2.1's title verbatim beside the wrong number — a plain transposition.

### Claims that lost their citation instead of gaining a number

Not everything wrong is a wrong number. Where MS-FSA or MS-FSCC simply does not say the thing,
forcing a section would have manufactured a new false citation:

| claim | real authority |
| --- | --- |
| parent-directory timestamps on unlink / rmdir | POSIX `unlink(2)` / `rmdir(2)` — MS-FSA updates parent times on create only |
| zero-byte READ advances CurrentByteOffset | smbtorture `smb2.read.eof`; §2.1.5.3 returns before touching the offset |
| READ/WRITE gated on `Open.GrantedAccess` | MS-SMB2 §3.3.5.12/§3.3.5.13 — MS-FSA's read and write algorithms never consult it |
| create-race fallback to the existing-file branch | smbtorture `smb2.create.mkdir-dup`; MS-FSA has no concurrency model |
| generic-mask expansion call sites | MS-DTYP §2.5.3 alone |
| EA-name case-insensitivity | NTFS; §2.4.16 defines the structure and no matching rule |
| dot-prefix implies HIDDEN | Samba's convention; §2.6 ties HIDDEN to no filename rule |
| byte-range-lock check on set-EOF | Windows behaviour; no MS-FSA section routes set-EOF through §2.1.4.10 |
| clearing delete disposition after rename | nothing — §2.1.5.15.12 *fails* a rename whose `Open.Link.IsDeleted` is TRUE |
| CreateOptions / notify-filter bits attributed to MS-FSCC §2.6 | MS-SMB2 §2.2.13 and §2.2.35 |

## The corrections were themselves re-verified, and six were wrong

A pass that replaces 243 citations can introduce the very defect it removes, so the finished diff
was re-checked against the spec text independently of how it was produced. That found six places
where my *new* citation named a real section that does not say what the comment claims:

| site | I wrote | why it is wrong |
| --- | --- | --- |
| `ioctl_sparse.go` SET_ZERO_DATA gate (×2) | MS-FSA §2.1.5.10.39 | that section states **no** access check — no `GrantedAccess`, no `FILE_WRITE_DATA`, no `ACCESS_DENIED`. The gate is MS-SMB2 §3.3.5.15 |
| rename share-delete check (×2) | MS-FSA §2.1.5.1.2.1 | its `FILE_SHARE_DELETE` clauses gate an **open** against existing opens; §2.1.5.15.12 has no share-mode check at all. The rule is Samba's `can_rename` |
| rename timestamp save/restore (×3) | MS-FSA §2.1.5.15.12 | the section requires the **opposite** — *"The object store MUST update Open.File.LastChangeTime"* |
| CREATE `STATUS_DELETE_PENDING` | MS-FSA §2.1.5.1 Phase 6 | Phase 6 specifies it for **intermediate path components**; this site gates the final one |
| directory Handle-lease strip (×2) | MS-FSA §2.1.5.1.1 / §2.1.4.12 | §2.1.4.12 breaks a `PARENT_OBJECT` oplock to `(READ_CACHING\|WRITE_CACHING)` — it does **not** strip Handle |

The SET_ZERO_DATA one is the instructive failure: the sibling site 43 lines above it makes the
identical claim for `QUERY_ALLOCATED_RANGES` and **was correctly disclaimed in this same diff**. I
recognised the pattern and then applied it inconsistently, which is precisely how the original
mess accumulated. All six are fixed in `a5d521067`.

The same pass confirmed the mechanical work held up: all 17 FSCTL constants, 31 Request/Reply
choices, 27 info-class numbers, the whole `2.1.5.x` operation list, and 22 sites across the five
confusable `2.1.5.1.x` siblings all check out, and no fabricated section survives anywhere.

## Two findings that are not documentation

Per the audit's own rule — a wrong citation and a wrong implementation look identical from inside
a source file — these are filed rather than papered over by repointing a comment at whatever
section matched the code.

**#2171 — `FSCTL_SET_REPARSE_POINT` is dispatched on the wrong code.** The constant is
`0x000900D4`; MS-FSCC §2.3 gives `0X900A4`, and `0x900D4` appears nowhere in the document. Samba
uses `0x000900A4`. The dispatch table keys on the constant, so a real client's `0x900A4` never
reaches the handler. Its test builds the request from the same constant, so it passes whichever
value is there — it pins the handler against itself rather than against the wire. Every other
FSCTL value in that block checks out; this is the lone outlier, and it is why the derivation pass
existed. This PR fixes only its **citation** (`2.3.69` → `2.3.81`), which is independently wrong.

**#2172 — six MS-FSA behaviour divergences**, including `FileDispositionInformationEx` honouring
only bit 0 (so `FILE_DISPOSITION_IGNORE_READONLY_ATTRIBUTE` does nothing), a missing
`Open.Link.IsDeleted` guard on rename, and `FileAllocationInformation` with no `FILE_WRITE_DATA`
gate. All are code reads, not reproductions, and the issue says so.

One of those is recorded in place rather than silently renumbered: `FILE_READ_ATTRIBUTES` is
granted unconditionally where §2.1.5.1.2.1 conditions it on the parent's `FILE_LIST_DIRECTORY`.
The comment now states the spec's condition **and** that the code does not apply it, instead of
claiming the spec is unconditional.

## Left alone deliberately

**Dated changelog entries keep their wrong citations.** `test/smb-conformance/KNOWN_FAILURES.md`
cites `MS-FSA 2.1.5.14.2` twice, under *"Phase 72-73 Improvements"* and a dated
*"v0.10.0 Phase 72 (2026-03-23)"* row; `smbtorture/KNOWN_FAILURES.md` cites `2.1.5.1.1` under a
dated 2026-05-29 heading. Those record what was believed at the time. History is append-only.

**Two SQL migration comments were corrected** (`2.4.15` → `2.4.16` for EAs, `2.4.32` → `2.4.40`
for `FILE_POSITION_INFORMATION`). Migrations are append-only for their *SQL*; these are comments
describing a live schema, and both named the structure explicitly while citing a section for a
different one. Flagging the judgment call in case a reviewer disagrees.

**Verified-correct citations keep bare numbers**, per the #2156 ruling — annotating them would
bury the real corrections. After this PR the heaviest correct sections are:

| section | title | sites |
| --- | --- | ---: |
| MS-FSA §2.1.5.15.2 | FileBasicInformation | 27 |
| MS-FSA §2.1.5.1.2.1 | Algorithm to Check Access to an Existing File | 22 |
| MS-FSCC §2.4.16 | FileFullEaInformation | 18 |
| MS-FSCC §2.6 | File Attributes | 14 |
| MS-FSA §2.1.5.15.12 | FileRenameInformation | 13 |
| MS-FSA §2.1.5.1.1 | Creation of a New File | 12 |
| MS-FSA §2.1.5.1.2 | Open of an Existing File | 9 |
| MS-FSA §2.1.5.5 | Server Requests Closing an Open | 9 |
| MS-FSCC §2.4.40 | FilePositionInformation | 7 |

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l` clean.
- `go test ./internal/adapter/smb/... ./pkg/metadata/...` green.
- Comment-only confirmed by stripping trailing comments and diffing the remainder.
- Post-change sweep: **zero** fabricated MS-FSCC/MS-FSA sections remain in the tree.
- Identifier-consistency sweep: 174 of 184 citations with a nearby structure name now agree with
  their section's title; the 10 remaining are family references (`§2.4`, `§2.5`, `§2.6`) that name
  no single structure.
- Every parenthetical title added here was checked back against the spec heading index. That found
  one I had got wrong — §2.1.5.5 written as *"Server Requests Closing of an Open"* against the
  spec's *"Server Requests Closing an Open"*, across 8 sites. A wrong title is the same defect
  class this PR exists to remove, so it is worth saying that the check caught an error rather than
  confirming a clean bill. The three `2.1.5.1 Phase N` labels used (*Parameter Validation*,
  *Location of file*, *Type of stream to open*) are verbatim spec headings.
