### PR TITLE
fix(block): stop a reflink's destination serving the content it replaced

### DIFF
--- a/internal/adapter/common/clone.go
+++ b/internal/adapter/common/clone.go
@@ -24,12 +24,15 @@ import (
 // either file produces new CAS blocks under a new hash, leaving the other side
 // untouched.
 //
-// Everything is atomic in one metadata transaction:
+// The manifest side is atomic in one metadata transaction:
 //   - engine.CopyPayload's per-hash IncrementRefCount UPDATEs are bound to the
 //     txn (via metadata.WithTx) so they commit/roll back together with the
-//     destination UpdateAttrs. On any error nothing is committed — no partial
-//     dstFileAttr, no leaked RefCount bumps.
-//   - cache.InvalidateFile (if cache != nil) runs POST-txn, after the commit.
+//     destination UpdateAttrs. An error from inside the txn commits nothing —
+//     no partial dstFileAttr, no leaked RefCount bumps.
+//   - discardStaleDestination and cache.InvalidateFile run POST-txn, after the
+//     commit. An error out of the discard is therefore an error on a copy whose
+//     manifest is already durable — see its own comment for why it is still
+//     reported rather than swallowed.
 //
 // CLONE copies the source's CAS block manifest (FileAttr.Blocks). A freshly
 // written source whose bytes are still in the append log / in-memory buffer has
@@ -165,10 +168,16 @@ func CloneWholeFile(
 // dropped them could not get them back. What is left is the window between the
 // two, where a read still serves the replaced content.
 //
-// A failure fails the copy, which has already committed. The alternative is
-// reporting success on a destination whose every read serves the content the
-// copy replaced, and a caller that retries a copy it was told failed re-runs an
-// operation that lands on the same manifest and gets another chance at this.
+// A failure fails the copy, which has already committed — the one place in
+// these helpers where an error does not mean nothing landed. Reporting it is
+// still the better trade: the alternative is reporting success on a destination
+// whose every read serves the content the copy replaced, which is the defect
+// this exists to close. It is not free, though. A caller that retries a copy it
+// was told failed re-runs a copy whose manifest work is idempotent but whose
+// per-hash RefCount bumps are not, so each retry leaves the source's hashes
+// counted one higher than they are referenced. That errs toward keeping a
+// chunk nothing references rather than reclaiming one something does, which is
+// the direction the reclaim paths already prefer.
 func discardStaleDestination(ctx context.Context, blockStore *engine.Store, dstPayloadID metadata.PayloadID) error {
 	if err := blockStore.DiscardLocalContent(ctx, string(dstPayloadID)); err != nil {
 		return fmt.Errorf("discard the copy destination's replaced local ranges: %w", err)

--- a/internal/adapter/common/clone.go
+++ b/internal/adapter/common/clone.go
@@ -135,8 +135,11 @@ func CloneWholeFile(
 	// Order matters between these two. The discard takes the destination's
 	// replaced ranges back to holes; the seed then gives the local tier its
 	// account of the ranges the copy put there. Seeding first would find those
-	// ranges already described and skip them, leaving the tier holding the
-	// content the copy replaced.
+	// ranges still described by the content the copy replaced and skip them all,
+	// and the discard would then drop what little it had recorded — reads would
+	// still be right, resolving against the manifest, but the tier would end up
+	// describing none of the copy and nothing could report its remote-only
+	// bytes.
 	if err := discardStaleDestination(ctx, blockStore, dstPayloadID); err != nil {
 		return err
 	}

--- a/internal/adapter/common/clone.go
+++ b/internal/adapter/common/clone.go
@@ -122,12 +122,20 @@ func CloneWholeFile(
 	if err != nil {
 		return err
 	}
-	// A self-clone left the destination exactly as it was: it inherited no
-	// ranges the local tier has to account for, and its cached entries still
-	// describe the content it holds. Everything below is about a destination
-	// whose content changed.
+	// A self-clone left the destination exactly as it was: it holds the content
+	// its manifest describes, it inherited no ranges the local tier has to
+	// account for, and its cached entries still describe what it holds.
+	// Everything below is about a destination whose content changed.
 	if selfClone {
 		return nil
+	}
+	// Order matters between these two. The discard takes the destination's
+	// replaced ranges back to holes; the seed then gives the local tier its
+	// account of the ranges the copy put there. Seeding first would find those
+	// ranges already described and skip them, leaving the tier holding the
+	// content the copy replaced.
+	if err := discardStaleDestination(ctx, blockStore, dstPayloadID); err != nil {
+		return err
 	}
 	seedClonedRanges(ctx, blockStore, dstPayloadID, copied)
 
@@ -136,6 +144,34 @@ func CloneWholeFile(
 	// their entries warm (nil removedHashes => key off dstPayloadID only).
 	if cache != nil {
 		cache.InvalidateFile(dstPayloadID, nil)
+	}
+	return nil
+}
+
+// discardStaleDestination drops the local tier's account of a copy's
+// destination. Both reflink helpers in this package call it, post-commit, on
+// every destination whose content the copy replaced.
+//
+// The copy rewrites the destination's manifest wholesale and moves no byte, so
+// every range the destination still holds locally describes content it no
+// longer has. Those ranges are what the read path resolves first — a covered
+// warm range reports neither hole nor cold, so the read never reaches the new
+// manifest — and the destination serves its pre-copy content indefinitely with
+// nothing logged. Dropping them puts the copied span back in the state a fresh
+// destination is already in, where the manifest is what answers.
+//
+// It runs after the commit, never before: until the commit lands those bytes
+// are the destination's real content, and a rolled-back copy that had already
+// dropped them could not get them back. What is left is the window between the
+// two, where a read still serves the replaced content.
+//
+// A failure fails the copy, which has already committed. The alternative is
+// reporting success on a destination whose every read serves the content the
+// copy replaced, and a caller that retries a copy it was told failed re-runs an
+// operation that lands on the same manifest and gets another chance at this.
+func discardStaleDestination(ctx context.Context, blockStore *engine.Store, dstPayloadID metadata.PayloadID) error {
+	if err := blockStore.DiscardLocalContent(ctx, string(dstPayloadID)); err != nil {
+		return fmt.Errorf("discard the copy destination's replaced local ranges: %w", err)
 	}
 	return nil
 }

--- a/internal/adapter/common/clone_test.go
+++ b/internal/adapter/common/clone_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"testing"
@@ -192,5 +193,95 @@ func TestCloneWholeFile_SelfCloneSeedsNothing(t *testing.T) {
 	}
 	if len(described) != 0 {
 		t.Errorf("the self-clone seeded %v; it copied nothing and must describe nothing", described)
+	}
+}
+
+// TestCloneWholeFile_DropsTheDestinationsStaleLocalRanges pins the post-commit
+// step the destination's correctness depends on.
+//
+// The reflink replaces the destination's content wholesale and moves no byte,
+// so every local range the destination still holds describes content it no
+// longer has. Those ranges are what the read path resolves first — a covered
+// warm range reports neither hole nor cold, so the read never reaches the new
+// manifest — and without this step the destination serves its pre-clone content
+// indefinitely, with nothing logged.
+//
+// The bystander is the control: another payload holding local ranges of its
+// own, which the clone has nothing to do with and must leave described.
+func TestCloneWholeFile_DropsTheDestinationsStaleLocalRanges(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	bs, local := newCopyTestEngineWithLocal(t, &fakeCoordinator{}, ms)
+
+	srcBlocks := []block.ChunkRef{
+		{Hash: block.ContentHash{0x11}, Offset: 0, Size: 4096},
+		{Hash: block.ContentHash{0x22}, Offset: 4096, Size: 4096},
+	}
+	const size = 8192
+	srcHandle := putTestFile(t, ms, "/stale-src.bin", "stale-src-pid", srcBlocks, size)
+	dstHandle := putTestFile(t, ms, "/stale-dst.bin", "stale-dst-pid", nil, size)
+	putTestFile(t, ms, "/stale-bystander.bin", "stale-bystander-pid", nil, size)
+
+	// The destination and the bystander each hold their own bytes locally.
+	for _, pid := range []string{"stale-dst-pid", "stale-bystander-pid"} {
+		if _, err := bs.WriteAt(ctx, pid, nil, bytes.Repeat([]byte{0xAB}, size), 0); err != nil {
+			t.Fatalf("WriteAt(%s): %v", pid, err)
+		}
+		extents, err := local.DataExtents(ctx, pid, size)
+		if err != nil {
+			t.Fatalf("DataExtents(%s): %v", pid, err)
+		}
+		if len(extents) == 0 {
+			t.Fatalf("%s describes nothing before the clone, so the drop below would prove nothing", pid)
+		}
+	}
+
+	if err := CloneWholeFile(ctx, bs, ms, nil, srcHandle, dstHandle, "stale-dst-pid"); err != nil {
+		t.Fatalf("CloneWholeFile: %v", err)
+	}
+
+	described, err := local.DataExtents(ctx, "stale-dst-pid", size)
+	if err != nil {
+		t.Fatalf("DataExtents(dst) after the clone: %v", err)
+	}
+	if len(described) != 0 {
+		t.Errorf("the destination still describes %v locally; those ranges hold the content the clone replaced", described)
+	}
+
+	bystander, err := local.DataExtents(ctx, "stale-bystander-pid", size)
+	if err != nil {
+		t.Fatalf("DataExtents(bystander): %v", err)
+	}
+	if len(bystander) == 0 {
+		t.Error("the clone dropped a payload it had nothing to do with")
+	}
+}
+
+// TestCloneWholeFile_SelfCloneKeepsItsLocalRanges keeps the self-clone no-op
+// whole. The destination is the source: it holds exactly the content its
+// manifest describes, and dropping its local ranges would throw away bytes
+// nothing replaced.
+func TestCloneWholeFile_SelfCloneKeepsItsLocalRanges(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	bs, local := newCopyTestEngineWithLocal(t, &fakeCoordinator{}, ms)
+
+	const size = 4096
+	selfHandle := putTestFile(t, ms, "/self.bin", "self-pid",
+		[]block.ChunkRef{{Hash: block.ContentHash{0x44}, Offset: 0, Size: size}}, size)
+	if _, err := bs.WriteAt(ctx, "self-pid", nil, bytes.Repeat([]byte{0xCD}, size), 0); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+
+	if err := CloneWholeFile(ctx, bs, ms, nil, selfHandle, selfHandle, "self-pid"); err != nil {
+		t.Fatalf("CloneWholeFile self-clone: %v", err)
+	}
+
+	described, err := local.DataExtents(ctx, "self-pid", size)
+	if err != nil {
+		t.Fatalf("DataExtents: %v", err)
+	}
+	if len(described) == 0 {
+		t.Error("the self-clone dropped the payload's own local ranges; it replaced nothing")
 	}
 }

--- a/internal/adapter/common/clone_test.go
+++ b/internal/adapter/common/clone_test.go
@@ -206,12 +206,22 @@ func TestCloneWholeFile_SelfCloneSeedsNothing(t *testing.T) {
 // manifest — and without this step the destination serves its pre-clone content
 // indefinitely, with nothing logged.
 //
-// The bystander is the control: another payload holding local ranges of its
-// own, which the clone has nothing to do with and must leave described.
+// The assertion is on the bytes, not on the index, because the index alone
+// cannot say which of the two it is describing: the clone's own seed puts the
+// copied ranges back into it as cold ones, so a destination that dropped
+// nothing and one that dropped everything both come back described. What tells
+// them apart is what a read serves.
+//
+// The source's hashes are fabricated and reach no remote, so a destination that
+// correctly stopped answering from its own bytes has nowhere to hydrate from
+// and refuses. That refusal is the pass. The bystander is the control: another
+// payload holding local ranges of its own, which the clone has nothing to do
+// with and which must still read back as its own bytes — without it, a fixture
+// broken enough to fail every read would look like a pass.
 func TestCloneWholeFile_DropsTheDestinationsStaleLocalRanges(t *testing.T) {
 	ctx := context.Background()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	bs, local := newCopyTestEngineWithLocal(t, &fakeCoordinator{}, ms)
+	bs, _ := newCopyTestEngineWithLocal(t, &fakeCoordinator{}, ms)
 
 	srcBlocks := []block.ChunkRef{
 		{Hash: block.ContentHash{0x11}, Offset: 0, Size: 4096},
@@ -222,38 +232,39 @@ func TestCloneWholeFile_DropsTheDestinationsStaleLocalRanges(t *testing.T) {
 	dstHandle := putTestFile(t, ms, "/stale-dst.bin", "stale-dst-pid", nil, size)
 	putTestFile(t, ms, "/stale-bystander.bin", "stale-bystander-pid", nil, size)
 
-	// The destination and the bystander each hold their own bytes locally.
-	for _, pid := range []string{"stale-dst-pid", "stale-bystander-pid"} {
-		if _, err := bs.WriteAt(ctx, pid, nil, bytes.Repeat([]byte{0xAB}, size), 0); err != nil {
-			t.Fatalf("WriteAt(%s): %v", pid, err)
-		}
-		extents, err := local.DataExtents(ctx, pid, size)
-		if err != nil {
-			t.Fatalf("DataExtents(%s): %v", pid, err)
-		}
-		if len(extents) == 0 {
-			t.Fatalf("%s describes nothing before the clone, so the drop below would prove nothing", pid)
-		}
+	replaced := bytes.Repeat([]byte{0xAB}, size)
+	bystanderData := bytes.Repeat([]byte{0xCD}, size)
+	if _, err := bs.WriteAt(ctx, "stale-dst-pid", nil, replaced, 0); err != nil {
+		t.Fatalf("WriteAt(dst): %v", err)
+	}
+	if _, err := bs.WriteAt(ctx, "stale-bystander-pid", nil, bystanderData, 0); err != nil {
+		t.Fatalf("WriteAt(bystander): %v", err)
+	}
+	// The destination answers from its own bytes before the clone, or the
+	// assertion below would hold for a payload that never had any.
+	before := make([]byte, size)
+	if _, err := bs.ReadAt(ctx, "stale-dst-pid", before, 0); err != nil {
+		t.Fatalf("ReadAt(dst) before the clone: %v", err)
+	}
+	if !bytes.Equal(before, replaced) {
+		t.Fatalf("the destination did not hold its own bytes before the clone")
 	}
 
 	if err := CloneWholeFile(ctx, bs, ms, nil, srcHandle, dstHandle, "stale-dst-pid"); err != nil {
 		t.Fatalf("CloneWholeFile: %v", err)
 	}
 
-	described, err := local.DataExtents(ctx, "stale-dst-pid", size)
-	if err != nil {
-		t.Fatalf("DataExtents(dst) after the clone: %v", err)
-	}
-	if len(described) != 0 {
-		t.Errorf("the destination still describes %v locally; those ranges hold the content the clone replaced", described)
+	got := make([]byte, size)
+	if _, err := bs.ReadAt(ctx, "stale-dst-pid", got, 0); err == nil && bytes.Equal(got, replaced) {
+		t.Error("the destination still serves the content the clone replaced")
 	}
 
-	bystander, err := local.DataExtents(ctx, "stale-bystander-pid", size)
-	if err != nil {
-		t.Fatalf("DataExtents(bystander): %v", err)
+	bystanderBack := make([]byte, size)
+	if _, err := bs.ReadAt(ctx, "stale-bystander-pid", bystanderBack, 0); err != nil {
+		t.Fatalf("ReadAt(bystander) after the clone: %v", err)
 	}
-	if len(bystander) == 0 {
-		t.Error("the clone dropped a payload it had nothing to do with")
+	if !bytes.Equal(bystanderBack, bystanderData) {
+		t.Error("the clone disturbed a payload it had nothing to do with")
 	}
 }
 

--- a/internal/adapter/common/copy_payload.go
+++ b/internal/adapter/common/copy_payload.go
@@ -21,10 +21,11 @@ import (
 //     coordinator.IncrementRefCount for each unique src hash; the
 //     coordinator's RefCount UPDATEs share the same txn, so they
 //     commit/roll back atomically with UpdateAttrs(dst).
-//   - On any error (Increment failure, UpdateAttrs failure, ctx cancel), the
-//     txn rolls back ALL writes — no partial dstFileAttr, no partial
-//     RefCount bumps committed.
-//   - cache.InvalidateFile runs ONLY on success, AFTER the commit.
+//   - On any error from inside the txn (Increment failure, UpdateAttrs failure,
+//     ctx cancel), the txn rolls back ALL writes — no partial dstFileAttr, no
+//     partial RefCount bumps committed.
+//   - discardStaleDestination and cache.InvalidateFile run AFTER the commit, so
+//     an error out of the discard is an error on a copy that already landed.
 //
 // Wiring status: the helper is NOT yet routed from NFS/SMB CREATE-file
 // copy paths — those continue using their existing flows. File-level

--- a/internal/adapter/common/copy_payload.go
+++ b/internal/adapter/common/copy_payload.go
@@ -103,9 +103,10 @@ func CopyPayload(
 	// A copy of a payload onto itself replaced nothing, so the destination still
 	// holds the content its manifest describes and there is nothing stale to
 	// drop. Every other destination loses its replaced ranges before the seed
-	// below accounts for the ones the copy gave it — the seed skips a range the
-	// tier already describes, so seeding first would leave the replaced content
-	// in place.
+	// below accounts for the ones the copy gave it: the seed skips a range the
+	// tier already describes, so seeding first would skip the whole copy and the
+	// discard would then drop what it had recorded, leaving the tier describing
+	// none of it.
 	if srcPayloadID != dstPayloadID {
 		if err := discardStaleDestination(ctx, blockStore, dstPayloadID); err != nil {
 			return err

--- a/internal/adapter/common/copy_payload.go
+++ b/internal/adapter/common/copy_payload.go
@@ -99,6 +99,17 @@ func CopyPayload(
 	if err != nil {
 		return err
 	}
+	// A copy of a payload onto itself replaced nothing, so the destination still
+	// holds the content its manifest describes and there is nothing stale to
+	// drop. Every other destination loses its replaced ranges before the seed
+	// below accounts for the ones the copy gave it — the seed skips a range the
+	// tier already describes, so seeding first would leave the replaced content
+	// in place.
+	if srcPayloadID != dstPayloadID {
+		if err := discardStaleDestination(ctx, blockStore, dstPayloadID); err != nil {
+			return err
+		}
+	}
 	seedClonedRanges(ctx, blockStore, dstPayloadID, copied)
 
 	// POST-txn: conservative invalidation for dst — its content changed

--- a/internal/adapter/common/copy_payload_test.go
+++ b/internal/adapter/common/copy_payload_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -423,4 +424,33 @@ func (f *fakeCoordinator) DecrementRefCountAndReapMany(ctx context.Context, payl
 		}
 	}
 	return nil
+}
+
+// TestCopyPayload_SelfCopyKeepsItsLocalRanges pins the guard that keeps a copy
+// of a payload onto itself from dropping the payload's own local ranges. The
+// copy replaced nothing, so those ranges still hold exactly the content the
+// manifest describes, and dropping them would throw away bytes for no reason.
+func TestCopyPayload_SelfCopyKeepsItsLocalRanges(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	bs, local := newCopyTestEngineWithLocal(t, &fakeCoordinator{}, ms)
+
+	const size = 4096
+	handle := putTestFile(t, ms, "/self-copy.bin", "self-copy-pid",
+		[]block.ChunkRef{{Hash: block.ContentHash{0x55}, Offset: 0, Size: size}}, size)
+	if _, err := bs.WriteAt(ctx, "self-copy-pid", nil, bytes.Repeat([]byte{0xEF}, size), 0); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+
+	if err := CopyPayload(ctx, bs, ms, nil, handle, handle, "self-copy-pid", "self-copy-pid"); err != nil {
+		t.Fatalf("CopyPayload self-copy: %v", err)
+	}
+
+	described, err := local.DataExtents(ctx, "self-copy-pid", size)
+	if err != nil {
+		t.Fatalf("DataExtents: %v", err)
+	}
+	if len(described) == 0 {
+		t.Error("the self-copy dropped the payload's own local ranges; it replaced nothing")
+	}
 }

--- a/pkg/block/engine/clone_stale_destination_test.go
+++ b/pkg/block/engine/clone_stale_destination_test.go
@@ -1,0 +1,216 @@
+package engine_test
+
+import (
+	"bytes"
+	"context"
+	"math/rand"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/engine"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// refsOf turns a payload's carved rows into the ChunkRef list a server-side
+// copy hands its destination, which is what the adapter passes from the
+// source's FileAttr.Blocks.
+func refsOf(t *testing.T, ctx context.Context, ms metadata.Store, payloadID string) []block.ChunkRef {
+	t.Helper()
+	rows, err := ms.ListFileChunks(ctx, payloadID)
+	if err != nil {
+		t.Fatalf("ListFileChunks(%s): %v", payloadID, err)
+	}
+	var refs []block.ChunkRef
+	for _, r := range rows {
+		off, ok := block.ParseChunkOffset(r.ID)
+		if !ok || r.Hash.IsZero() {
+			continue
+		}
+		refs = append(refs, block.ChunkRef{Hash: r.Hash, Offset: off, Size: r.DataSize})
+	}
+	if len(refs) == 0 {
+		t.Fatalf("%s carved no placeable rows, so the copy would copy nothing", payloadID)
+	}
+	return refs
+}
+
+// serverSideCopy runs the sequence the adapter's reflink helpers run: the
+// engine's manifest-only copy, the destination's wholesale manifest
+// replacement, then the discard of the local ranges that replacement made
+// stale. Driving all three here is what makes the read-back below about the
+// destination the adapter leaves behind rather than about a half-applied copy.
+// The adapter binds the first two into one transaction; what they leave behind
+// is the same either way, and that is what these tests read.
+func serverSideCopy(t *testing.T, ctx context.Context, bs *engine.Store, ms metadata.Store, srcHandle, dstHandle metadata.FileHandle, srcPayloadID, dstPayloadID string) {
+	t.Helper()
+	srcFile, err := ms.GetFile(ctx, srcHandle)
+	if err != nil {
+		t.Fatalf("GetFile(src): %v", err)
+	}
+	newBlocks, err := bs.CopyPayload(ctx, srcPayloadID, dstPayloadID, refsOf(t, ctx, ms, srcPayloadID))
+	if err != nil {
+		t.Fatalf("CopyPayload: %v", err)
+	}
+	dstFile, err := ms.GetFile(ctx, dstHandle)
+	if err != nil {
+		t.Fatalf("GetFile(dst): %v", err)
+	}
+	dstFile.Blocks = newBlocks
+	dstFile.Size = srcFile.Size
+	if err := ms.SetManifest(ctx, dstFile); err != nil {
+		t.Fatalf("SetManifest(dst): %v", err)
+	}
+	if err := bs.DiscardLocalContent(ctx, dstPayloadID); err != nil {
+		t.Fatalf("DiscardLocalContent: %v", err)
+	}
+}
+
+// TestCopy_DestinationServesTheCopiedContent is the byte-level statement of the
+// contract a reflink owes: after the copy, reading the destination gives the
+// source's content, not the content the copy replaced.
+//
+// The destination here already holds its own bytes, warm and local, which is
+// the case the read path used to answer from and never look further. A
+// destination that was empty, or that a client truncated first, reaches the
+// manifest through a hole and was always served correctly — which is why an
+// `O_TRUNC` opener (`cp --reflink`) sees none of this.
+//
+// The bystander is the control: it is carved and warm exactly like the
+// destination, is not part of the copy, and must still read its own bytes
+// afterwards. Without it a discard that dropped every payload's local ranges
+// would pass this test on the destination alone.
+func TestCopy_DestinationServesTheCopiedContent(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	mem := remotememory.New()
+	bs, _ := openOfflineEngine(t, t.TempDir(), ms, mem)
+	t.Cleanup(func() { _ = bs.Close() })
+
+	root := createShare(t, ms, "copy")
+	src, srcHandle := createRealFile(t, ms, "copy", "src.bin", root)
+	dst, dstHandle := createRealFile(t, ms, "copy", "dst.bin", root)
+	bystander, _ := createRealFile(t, ms, "copy", "bystander.bin", root)
+
+	const size = 4 * 1024 * 1024
+	content := map[string][]byte{}
+	for i, pid := range []string{src, dst, bystander} {
+		buf := make([]byte, size)
+		rand.New(rand.NewSource(int64(i) + 1)).Read(buf) //nolint:gosec // deterministic fixture
+		if _, err := bs.WriteAt(ctx, pid, nil, buf, 0); err != nil {
+			t.Fatalf("WriteAt(%s): %v", pid, err)
+		}
+		content[pid] = buf
+		carve(t, bs, ctx, pid)
+		setSize(t, ctx, ms, pid, size)
+	}
+
+	serverSideCopy(t, ctx, bs, ms, srcHandle, dstHandle, src, dst)
+
+	// Read at two known offsets rather than the whole file, so a pass cannot
+	// come from the destination being uniformly wrong in a convenient way.
+	for _, off := range []uint64{0, 2 * 1024 * 1024} {
+		got := make([]byte, 64*1024)
+		if _, err := bs.ReadAt(ctx, dst, got, off); err != nil {
+			t.Fatalf("ReadAt(dst, %d): %v", off, err)
+		}
+		want := content[src][off : off+uint64(len(got))]
+		if bytes.Equal(got, content[dst][off:off+uint64(len(got))]) {
+			t.Fatalf("the destination at offset %d served the content the copy replaced", off)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("the destination at offset %d served neither the copied content nor its own", off)
+		}
+	}
+
+	back := make([]byte, size)
+	if _, err := bs.ReadAt(ctx, bystander, back, 0); err != nil {
+		t.Fatalf("ReadAt(bystander): %v", err)
+	}
+	if !bytes.Equal(back, content[bystander]) {
+		t.Error("the copy disturbed a payload it had nothing to do with")
+	}
+}
+
+// TestCopy_DestinationSparseRangeReadsAsZeros is the half of the contract that
+// an interval the destination merely lost does not have.
+//
+// The source is sparse across [1 MiB, 3 MiB): no manifest row covers it, so the
+// destination must read it as the zeros the source has there. The destination
+// holds its own real bytes over the whole span before the copy, and the copy
+// has to leave that range unresolvable by the local tier without making it
+// unreadable — a range marked remote-only instead would fail closed, because
+// there is nothing on the remote to hydrate it from.
+func TestCopy_DestinationSparseRangeReadsAsZeros(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	mem := remotememory.New()
+	bs, _ := openOfflineEngine(t, t.TempDir(), ms, mem)
+	t.Cleanup(func() { _ = bs.Close() })
+
+	root := createShare(t, ms, "sparse")
+	src, srcHandle := createRealFile(t, ms, "sparse", "src.bin", root)
+	dst, dstHandle := createRealFile(t, ms, "sparse", "dst.bin", root)
+
+	const mib = 1024 * 1024
+	head := make([]byte, mib)
+	tail := make([]byte, mib)
+	rand.New(rand.NewSource(11)).Read(head) //nolint:gosec // deterministic fixture
+	rand.New(rand.NewSource(12)).Read(tail) //nolint:gosec // deterministic fixture
+	if _, err := bs.WriteAt(ctx, src, nil, head, 0); err != nil {
+		t.Fatalf("WriteAt(src head): %v", err)
+	}
+	if _, err := bs.WriteAt(ctx, src, nil, tail, 3*mib); err != nil {
+		t.Fatalf("WriteAt(src tail): %v", err)
+	}
+	carve(t, bs, ctx, src)
+	setSize(t, ctx, ms, src, 4*mib)
+
+	dstData := make([]byte, 4*mib)
+	rand.New(rand.NewSource(13)).Read(dstData) //nolint:gosec // deterministic fixture
+	if _, err := bs.WriteAt(ctx, dst, nil, dstData, 0); err != nil {
+		t.Fatalf("WriteAt(dst): %v", err)
+	}
+	carve(t, bs, ctx, dst)
+	setSize(t, ctx, ms, dst, 4*mib)
+
+	serverSideCopy(t, ctx, bs, ms, srcHandle, dstHandle, src, dst)
+
+	for _, tc := range []struct {
+		name string
+		off  uint64
+		want []byte
+	}{
+		{name: "head", off: 0, want: head[:64*1024]},
+		{name: "sparse", off: 2 * mib, want: make([]byte, 64*1024)},
+		{name: "tail", off: 3 * mib, want: tail[:64*1024]},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := make([]byte, len(tc.want))
+			if _, err := bs.ReadAt(ctx, dst, got, tc.off); err != nil {
+				t.Fatalf("ReadAt(dst, %d): %v", tc.off, err)
+			}
+			if bytes.Equal(got, dstData[tc.off:tc.off+uint64(len(got))]) {
+				t.Fatalf("the destination at offset %d served the content the copy replaced", tc.off)
+			}
+			if !bytes.Equal(got, tc.want) {
+				t.Fatalf("the destination at offset %d did not serve the source's content", tc.off)
+			}
+		})
+	}
+}
+
+// setSize records the size a payload's writes gave it, which createRealFile
+// leaves at zero and the copy reads off the source.
+func setSize(t *testing.T, ctx context.Context, ms metadata.Store, payloadID string, size uint64) {
+	t.Helper()
+	file, err := ms.GetFileByPayloadID(ctx, metadata.PayloadID(payloadID))
+	if err != nil || file == nil {
+		t.Fatalf("GetFileByPayloadID(%s): %v", payloadID, err)
+	}
+	file.Size = size
+	if err := ms.UpdateAttrs(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs(%s): %v", payloadID, err)
+	}
+}

--- a/pkg/block/engine/clone_stale_destination_test.go
+++ b/pkg/block/engine/clone_stale_destination_test.go
@@ -214,3 +214,39 @@ func setSize(t *testing.T, ctx context.Context, ms metadata.Store, payloadID str
 		t.Fatalf("UpdateAttrs(%s): %v", payloadID, err)
 	}
 }
+
+// TestCopy_SelfCopyKeepsItsOwnRows pins the one case where the destination's
+// surviving rows are not stale: a payload copied onto itself replaced nothing.
+// The blocks handed in are the caller's snapshot of the payload's projection,
+// not the authority on which of its rows are live, so a row missing from them
+// is a row the reap would delete out from under a live file.
+func TestCopy_SelfCopyKeepsItsOwnRows(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	mem := remotememory.New()
+	bs, _ := openOfflineEngine(t, t.TempDir(), ms, mem)
+	t.Cleanup(func() { _ = bs.Close() })
+
+	root := createShare(t, ms, "selfcopy")
+	self, _ := createRealFile(t, ms, "selfcopy", "self.bin", root)
+
+	const size = 4 * 1024 * 1024
+	data := make([]byte, size)
+	rand.New(rand.NewSource(21)).Read(data) //nolint:gosec // deterministic fixture
+	if _, err := bs.WriteAt(ctx, self, nil, data, 0); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	carve(t, bs, ctx, self)
+
+	rows := refsOf(t, ctx, ms, self)
+	// Hand in a snapshot that is missing the payload's last row, the shape a
+	// stale projection has.
+	if _, err := bs.CopyPayload(ctx, self, self, rows[:len(rows)-1]); err != nil {
+		t.Fatalf("CopyPayload self-copy: %v", err)
+	}
+
+	after := refsOf(t, ctx, ms, self)
+	if len(after) != len(rows) {
+		t.Errorf("the self-copy reaped %d of the payload's own rows", len(rows)-len(after))
+	}
+}

--- a/pkg/block/engine/clone_stale_destination_test.go
+++ b/pkg/block/engine/clone_stale_destination_test.go
@@ -40,11 +40,18 @@ func refsOf(t *testing.T, ms metadata.Store, payloadID string) []block.ChunkRef 
 // is the same either way, and that is what these tests read.
 func serverSideCopy(t *testing.T, ctx context.Context, bs *engine.Store, ms metadata.Store, srcHandle, dstHandle metadata.FileHandle, srcPayloadID, dstPayloadID string) {
 	t.Helper()
+	serverSideCopyRefs(t, ctx, bs, ms, srcHandle, dstHandle, srcPayloadID, dstPayloadID, refsOf(t, ms, srcPayloadID))
+}
+
+// serverSideCopyRefs is serverSideCopy with the copied ChunkRef list supplied,
+// for the source whose list is legitimately empty.
+func serverSideCopyRefs(t *testing.T, ctx context.Context, bs *engine.Store, ms metadata.Store, srcHandle, dstHandle metadata.FileHandle, srcPayloadID, dstPayloadID string, refs []block.ChunkRef) {
+	t.Helper()
 	srcFile, err := ms.GetFile(ctx, srcHandle)
 	if err != nil {
 		t.Fatalf("GetFile(src): %v", err)
 	}
-	newBlocks, err := bs.CopyPayload(ctx, srcPayloadID, dstPayloadID, refsOf(t, ms, srcPayloadID))
+	newBlocks, err := bs.CopyPayload(ctx, srcPayloadID, dstPayloadID, refs)
 	if err != nil {
 		t.Fatalf("CopyPayload: %v", err)
 	}
@@ -244,4 +251,66 @@ func TestCopy_SelfCopyKeepsItsOwnRows(t *testing.T) {
 	if len(after) != len(rows) {
 		t.Errorf("the self-copy reaped %d of the payload's own rows", len(rows)-len(after))
 	}
+}
+
+// TestCopy_SparseSourceLeavesNothingOfTheDestination is the copy that places no
+// blocks at all. A source that was only ever sized — a file created and
+// truncated up, never written — carves no rows, so the destination inherits an
+// empty manifest and its whole content should read as the zeros the source has.
+//
+// The copy has no rows of its own to overwrite the destination's with, so the
+// destination's rows are the only thing a read can resolve through, and they
+// hold the content the copy replaced.
+func TestCopy_SparseSourceLeavesNothingOfTheDestination(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	mem := remotememory.New()
+	bs, _ := openOfflineEngine(t, t.TempDir(), ms, mem)
+	t.Cleanup(func() { _ = bs.Close() })
+
+	root := createShare(t, ms, "sparsesrc")
+	src, srcHandle := createRealFile(t, ms, "sparsesrc", "src.bin", root)
+	dst, dstHandle := createRealFile(t, ms, "sparsesrc", "dst.bin", root)
+
+	const size = 4 * 1024 * 1024
+	setSize(t, ctx, ms, src, size) // sized, never written: no rows to copy
+
+	dstData := make([]byte, size)
+	rand.New(rand.NewSource(31)).Read(dstData) //nolint:gosec // deterministic fixture
+	if _, err := bs.WriteAt(ctx, dst, nil, dstData, 0); err != nil {
+		t.Fatalf("WriteAt(dst): %v", err)
+	}
+	carve(t, bs, ctx, dst)
+	setSize(t, ctx, ms, dst, size)
+
+	if rows := refsOfSparse(t, ms, src); len(rows) != 0 {
+		t.Fatalf("the source carved %d rows, so it is not the sparse case", len(rows))
+	}
+	serverSideCopyRefs(t, ctx, bs, ms, srcHandle, dstHandle, src, dst, nil)
+
+	for _, off := range []uint64{0, 2 * 1024 * 1024} {
+		got := make([]byte, 64*1024)
+		if _, err := bs.ReadAt(ctx, dst, got, off); err != nil {
+			t.Fatalf("ReadAt(dst, %d): %v", off, err)
+		}
+		if bytes.Equal(got, dstData[off:off+uint64(len(got))]) {
+			t.Fatalf("the destination at offset %d served the content the copy replaced", off)
+		}
+		if !bytes.Equal(got, make([]byte, len(got))) {
+			t.Fatalf("the destination at offset %d did not read as the source's zeros", off)
+		}
+	}
+}
+
+// refsOfSparse is refsOf without its "carved something" assertion, for the
+// source that is supposed to have carved nothing.
+func refsOfSparse(t *testing.T, ms metadata.Store, payloadID string) []block.ChunkRef {
+	t.Helper()
+	var refs []block.ChunkRef
+	for _, r := range manifestRefs(t, ms, payloadID) {
+		if !r.Hash.IsZero() {
+			refs = append(refs, r)
+		}
+	}
+	return refs
 }

--- a/pkg/block/engine/clone_stale_destination_test.go
+++ b/pkg/block/engine/clone_stale_destination_test.go
@@ -13,22 +13,17 @@ import (
 	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
-// refsOf turns a payload's carved rows into the ChunkRef list a server-side
-// copy hands its destination, which is what the adapter passes from the
-// source's FileAttr.Blocks.
-func refsOf(t *testing.T, ctx context.Context, ms metadata.Store, payloadID string) []block.ChunkRef {
+// refsOf is manifestRefs without the rows a copy cannot hand on: a zero-hash
+// row carries no chunk, so it is not part of the ChunkRef list the adapter
+// passes from the source's FileAttr.Blocks.
+func refsOf(t *testing.T, ms metadata.Store, payloadID string) []block.ChunkRef {
 	t.Helper()
-	rows, err := ms.ListFileChunks(ctx, payloadID)
-	if err != nil {
-		t.Fatalf("ListFileChunks(%s): %v", payloadID, err)
-	}
 	var refs []block.ChunkRef
-	for _, r := range rows {
-		off, ok := block.ParseChunkOffset(r.ID)
-		if !ok || r.Hash.IsZero() {
+	for _, r := range manifestRefs(t, ms, payloadID) {
+		if r.Hash.IsZero() {
 			continue
 		}
-		refs = append(refs, block.ChunkRef{Hash: r.Hash, Offset: off, Size: r.DataSize})
+		refs = append(refs, r)
 	}
 	if len(refs) == 0 {
 		t.Fatalf("%s carved no placeable rows, so the copy would copy nothing", payloadID)
@@ -49,7 +44,7 @@ func serverSideCopy(t *testing.T, ctx context.Context, bs *engine.Store, ms meta
 	if err != nil {
 		t.Fatalf("GetFile(src): %v", err)
 	}
-	newBlocks, err := bs.CopyPayload(ctx, srcPayloadID, dstPayloadID, refsOf(t, ctx, ms, srcPayloadID))
+	newBlocks, err := bs.CopyPayload(ctx, srcPayloadID, dstPayloadID, refsOf(t, ms, srcPayloadID))
 	if err != nil {
 		t.Fatalf("CopyPayload: %v", err)
 	}
@@ -238,14 +233,14 @@ func TestCopy_SelfCopyKeepsItsOwnRows(t *testing.T) {
 	}
 	carve(t, bs, ctx, self)
 
-	rows := refsOf(t, ctx, ms, self)
+	rows := refsOf(t, ms, self)
 	// Hand in a snapshot that is missing the payload's last row, the shape a
 	// stale projection has.
 	if _, err := bs.CopyPayload(ctx, self, self, rows[:len(rows)-1]); err != nil {
 		t.Fatalf("CopyPayload self-copy: %v", err)
 	}
 
-	after := refsOf(t, ctx, ms, self)
+	after := refsOf(t, ms, self)
 	if len(after) != len(rows) {
 		t.Errorf("the self-copy reaped %d of the payload's own rows", len(rows)-len(after))
 	}

--- a/pkg/block/engine/close_gate_test.go
+++ b/pkg/block/engine/close_gate_test.go
@@ -195,6 +195,11 @@ func TestStore_OpAfterCloseReturnsErrStoreClosed(t *testing.T) {
 			t.Errorf("SeedColdRefs after Close = %v, want ErrStoreClosed; a copy's seed that slips past Close reopens the cold log behind a torn-down store", err)
 		}
 	})
+	t.Run("DiscardLocalContent", func(t *testing.T) {
+		if err := bs.DiscardLocalContent(ctx, "p"); !errors.Is(err, ErrStoreClosed) {
+			t.Errorf("DiscardLocalContent after Close = %v, want ErrStoreClosed; a copy's discard that slips past Close clips the index behind a torn-down store", err)
+		}
+	})
 	t.Run("EvictLocal", func(t *testing.T) {
 		if err := bs.EvictLocal(ctx, "p"); !errors.Is(err, ErrStoreClosed) {
 			t.Fatalf("want ErrStoreClosed, got %v", err)

--- a/pkg/block/engine/flush.go
+++ b/pkg/block/engine/flush.go
@@ -205,6 +205,39 @@ func (bs *Store) SeedColdRefs(ctx context.Context, payloadID string, refs []bloc
 	return cs.SeedCold(ctx, journal.FileID(payloadID), extents)
 }
 
+// DiscardLocalContent drops the local tier's whole account of a payload, so a
+// read of it resolves against the manifest instead of against bytes the tier
+// still holds.
+//
+// It is the local half of replacing a payload's content wholesale. A
+// server-side copy rewrites the destination's manifest and moves no byte, and
+// every range the destination still holds locally then describes content the
+// copy replaced. A covered warm range reports neither hole nor cold, so the
+// read never reaches the new manifest: the destination serves its pre-copy
+// content indefinitely, with nothing logged.
+//
+// What it leaves behind is holes, which is the state a range with no local copy
+// is supposed to be in and the state a fresh destination is already in: a hole
+// the manifest covers hydrates from the remote, and one it does not reads as
+// the zeros a sparse range is. Marking the span cold instead would fail the
+// sparse case closed, because an absent range and a stale one are not the same
+// state and only the manifest can tell them apart.
+//
+// The local tier makes the clip durable before it takes effect and fences it by
+// version, so a write that raced past it survives and a crash cannot resurrect
+// what it dropped.
+//
+// The caller owns the ordering: this runs after the copy's metadata transaction
+// commits, never before. Until that commit lands, the bytes it drops are the
+// destination's real content, and a rolled-back copy could not get them back.
+func (bs *Store) DiscardLocalContent(ctx context.Context, payloadID string) error {
+	if err := bs.enter(); err != nil {
+		return err
+	}
+	defer bs.closeMu.RUnlock()
+	return bs.local.Truncate(ctx, payloadID, 0)
+}
+
 // RestoreToVersion rewinds the local journal to a snapshot's version watermark
 // and re-materializes that point-in-time view durably at the log head. It is the
 // local-only snapshot-restore primitive the runtime calls instead of

--- a/pkg/block/engine/flush.go
+++ b/pkg/block/engine/flush.go
@@ -235,7 +235,16 @@ func (bs *Store) DiscardLocalContent(ctx context.Context, payloadID string) erro
 		return err
 	}
 	defer bs.closeMu.RUnlock()
-	return bs.local.Truncate(ctx, payloadID, 0)
+	if err := bs.local.Truncate(ctx, payloadID, 0); err != nil {
+		return err
+	}
+	// The read cache is keyed by content hash, so it cannot serve the dropped
+	// bytes for content that no longer addresses them. Its per-payload
+	// sequential tracker is keyed by payload, though, and would have prefetch
+	// chasing the hashes the payload held before — the same reset every other
+	// path that changes a payload's content underneath the tier does.
+	bs.loadCache().OnRead(payloadID, nil, 0)
+	return nil
 }
 
 // RestoreToVersion rewinds the local journal to a snapshot's version watermark

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -662,9 +662,19 @@ func (bs *Store) CopyPayload(ctx context.Context, srcPayloadID, dstPayloadID str
 	// and mirrors Truncate in reaping by exact "{payloadID}/{offset}" identity.
 	// A row at an offset a new row takes over is left to that row's put, which
 	// rewrites it in place.
-	stale, err := bs.staleDestinationOffsets(ctx, tx, dstPayloadID, srcBlocks)
-	if err != nil {
-		return nil, fmt.Errorf("CopyPayload: list the destination's rows for %s: %w", dstPayloadID, err)
+	//
+	// A payload copied onto itself replaced nothing and every row it has is a row
+	// it still needs, so there is nothing to reap. Reaping there would work off
+	// srcBlocks as the authority on which of the payload's own rows are live,
+	// which it is not: it is the caller's snapshot of the projection, and a row
+	// missing from it is a row this would delete out from under a live file.
+	var stale []uint64
+	if srcPayloadID != dstPayloadID {
+		var err error
+		stale, err = bs.staleDestinationOffsets(ctx, tx, dstPayloadID, srcBlocks)
+		if err != nil {
+			return nil, fmt.Errorf("CopyPayload: list the destination's rows for %s: %w", dstPayloadID, err)
+		}
 	}
 	if len(stale) > 0 {
 		if err := bs.coordinator.DecrementRefCountAndReapMany(ctx, dstPayloadID, stale); err != nil {

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -540,17 +540,21 @@ func (bs *Store) staleDestinationOffsets(ctx context.Context, tx metadata.Transa
 // per-file rows and the FileAttr.Blocks manifest reference the same hashes and
 // offsets.
 //
-// It creates no local-tier interval for those rows, and cannot: it runs inside
+// It touches no local-tier interval for those rows, and cannot: it runs inside
 // the caller's metadata txn, and intervals for rows a rolled-back copy never
-// wrote would make a read of the destination's sparse ranges fail closed. Giving
-// the local tier its account of the destination is the caller's step, after the
-// commit — SeedColdRefs over the returned list. Reads work either way; residency
-// accounting does not.
+// wrote would make a read of the destination's sparse ranges fail closed, while
+// dropping the ranges the destination still holds would destroy content the
+// rollback puts back. Both are the caller's step, after the commit —
+// DiscardLocalContent to take the destination's replaced ranges back to holes,
+// then SeedColdRefs over the returned list to account for the ones the copy
+// gave it.
 //
-// Empty srcBlocks => nil-safe path: copies nothing. CopyPayload no longer
-// copies data at all; adapter call sites that need a data copy drive
-// ReadAt+WriteAt directly. Production callers always supply a snapshot of
-// the source file's FileAttr.Blocks.
+// Empty srcBlocks => the destination places nothing afterwards, which is what
+// a fully sparse source gives it. That is not a no-op: the destination's own
+// rows are still reaped, or a read would go on resolving through them.
+// CopyPayload no longer copies data at all; adapter call sites that need a data
+// copy drive ReadAt+WriteAt directly. Production callers always supply a
+// snapshot of the source file's FileAttr.Blocks.
 //
 // Failure semantics: a genuine IncrementRefCount backend fault is surfaced
 // immediately without further increments (the caller's metadata txn rolls back).
@@ -568,11 +572,12 @@ func (bs *Store) CopyPayload(ctx context.Context, srcPayloadID, dstPayloadID str
 		return nil, err
 	}
 	defer bs.closeMu.RUnlock()
-	// Empty src => no work, nothing to coordinate.
-	if len(srcBlocks) == 0 {
-		return nil, nil
-	}
-	if bs.coordinator == nil {
+	// A source that places no blocks copies no content, but it still replaces
+	// the destination's: the copy hands it a file with nothing in it, so every
+	// row the destination holds is one the copy took away. The reap below runs
+	// for that source too, which is what a fully sparse one is, so there is no
+	// early return here for it.
+	if len(srcBlocks) > 0 && bs.coordinator == nil {
 		return nil, ErrMetadataCoordinatorNotWired
 	}
 
@@ -660,7 +665,7 @@ func (bs *Store) CopyPayload(ctx context.Context, srcPayloadID, dstPayloadID str
 	// srcBlocks as the authority on which of the payload's own rows are live,
 	// which it is not: it is the caller's snapshot of the projection, and a row
 	// missing from it is a row this would delete out from under a live file.
-	if srcPayloadID != dstPayloadID {
+	if srcPayloadID != dstPayloadID && bs.coordinator != nil {
 		stale, err := bs.staleDestinationOffsets(ctx, tx, dstPayloadID, srcBlocks)
 		if err != nil {
 			return nil, fmt.Errorf("CopyPayload: list the destination's rows for %s: %w", dstPayloadID, err)
@@ -699,6 +704,8 @@ func (bs *Store) CopyPayload(ctx context.Context, srcPayloadID, dstPayloadID str
 	// produces a fresh backing array independent of srcBlocks). The caller
 	// persists this as dst's FileAttr.Blocks in the same metadata txn, so the
 	// rows above and this manifest stay consistent (same hashes + offsets).
+	// An empty source lands here too and yields the nil list that says the
+	// destination now places nothing.
 	dst := append([]block.ChunkRef(nil), srcBlocks...)
 
 	return dst, nil

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -494,9 +494,6 @@ func (bs *Store) staleDestinationOffsets(ctx context.Context, tx metadata.Transa
 	if err != nil {
 		return nil, err
 	}
-	if len(rows) == 0 {
-		return nil, nil
-	}
 	taken := make(map[uint64]struct{}, len(srcBlocks))
 	for _, b := range srcBlocks {
 		if b.Hash.IsZero() {
@@ -504,8 +501,7 @@ func (bs *Store) staleDestinationOffsets(ctx context.Context, tx metadata.Transa
 		}
 		taken[b.Offset] = struct{}{}
 	}
-	var stale []uint64
-	seen := make(map[uint64]struct{}, len(rows))
+	stale := make([]block.ChunkRef, 0, len(rows))
 	for _, r := range rows {
 		if r == nil {
 			continue
@@ -517,13 +513,9 @@ func (bs *Store) staleDestinationOffsets(ctx context.Context, tx metadata.Transa
 		if _, keeping := taken[off]; keeping {
 			continue
 		}
-		if _, done := seen[off]; done {
-			continue
-		}
-		seen[off] = struct{}{}
-		stale = append(stale, off)
+		stale = append(stale, block.ChunkRef{Offset: off})
 	}
-	return stale, nil
+	return distinctOffsets(stale), nil
 }
 
 // CopyPayload duplicates a file's content by referencing the source's
@@ -668,17 +660,15 @@ func (bs *Store) CopyPayload(ctx context.Context, srcPayloadID, dstPayloadID str
 	// srcBlocks as the authority on which of the payload's own rows are live,
 	// which it is not: it is the caller's snapshot of the projection, and a row
 	// missing from it is a row this would delete out from under a live file.
-	var stale []uint64
 	if srcPayloadID != dstPayloadID {
-		var err error
-		stale, err = bs.staleDestinationOffsets(ctx, tx, dstPayloadID, srcBlocks)
+		stale, err := bs.staleDestinationOffsets(ctx, tx, dstPayloadID, srcBlocks)
 		if err != nil {
 			return nil, fmt.Errorf("CopyPayload: list the destination's rows for %s: %w", dstPayloadID, err)
 		}
-	}
-	if len(stale) > 0 {
-		if err := bs.coordinator.DecrementRefCountAndReapMany(ctx, dstPayloadID, stale); err != nil {
-			return nil, fmt.Errorf("CopyPayload: reap the destination's replaced rows for %s: %w", dstPayloadID, err)
+		if len(stale) > 0 {
+			if err := bs.coordinator.DecrementRefCountAndReapMany(ctx, dstPayloadID, stale); err != nil {
+				return nil, fmt.Errorf("CopyPayload: reap the destination's replaced rows for %s: %w", dstPayloadID, err)
+			}
 		}
 	}
 

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -468,6 +468,64 @@ func (bs *Store) payloadChunkRefs(ctx context.Context, payloadID string) []block
 	return refs
 }
 
+// staleDestinationOffsets returns the offsets of a copy destination's existing
+// manifest rows that the copy's own rows do not take over. Those rows outlive a
+// wholesale manifest replacement — SetManifest rewrites the Blocks projection,
+// which is a different structure from the per-chunk rows a read resolves
+// through — so they have to be reaped by name.
+//
+// It reads through the caller's transaction when there is one, so it sees the
+// destination as the copy is about to leave it and does not re-enter a backend
+// lock the transaction already holds. A row whose ID carries no offset cannot be
+// named for a reap and is left alone.
+func (bs *Store) staleDestinationOffsets(ctx context.Context, tx metadata.Transaction, dstPayloadID string, srcBlocks []block.ChunkRef) ([]uint64, error) {
+	var (
+		rows []*block.FileChunk
+		err  error
+	)
+	switch {
+	case tx != nil:
+		rows, err = tx.ListFileChunks(ctx, dstPayloadID)
+	case bs.fileChunkStore != nil:
+		rows, err = bs.fileChunkStore.ListFileChunks(ctx, dstPayloadID)
+	default:
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	taken := make(map[uint64]struct{}, len(srcBlocks))
+	for _, b := range srcBlocks {
+		if b.Hash.IsZero() {
+			continue
+		}
+		taken[b.Offset] = struct{}{}
+	}
+	var stale []uint64
+	seen := make(map[uint64]struct{}, len(rows))
+	for _, r := range rows {
+		if r == nil {
+			continue
+		}
+		off, ok := block.ParseChunkOffset(r.ID)
+		if !ok {
+			continue
+		}
+		if _, keeping := taken[off]; keeping {
+			continue
+		}
+		if _, done := seen[off]; done {
+			continue
+		}
+		seen[off] = struct{}{}
+		stale = append(stale, off)
+	}
+	return stale, nil
+}
+
 // CopyPayload duplicates a file's content by referencing the source's
 // content-addressed blocks — no data movement, O(blocks) metadata puts.
 // It does two things for the destination:
@@ -590,6 +648,30 @@ func (bs *Store) CopyPayload(ctx context.Context, srcPayloadID, dstPayloadID str
 	case bs.fileChunkStore != nil:
 		putRow = bs.fileChunkStore.Put
 	}
+
+	// Reap the destination's own rows the copy does not replace in place. They
+	// are the ones the read path resolves through, and this copy gives the
+	// destination the source's content wholesale, so a row still claiming the
+	// bytes it always claimed serves the content the copy replaced. The two
+	// files chunk their own content, so their offsets rarely line up and the
+	// rows that survive interleave with the copied ones: a read walks a mosaic
+	// of both files, picking whichever row starts latest over each offset.
+	//
+	// Reaping runs in the caller's transaction, ahead of the rows below, so a
+	// rolled-back copy leaves the destination's manifest exactly as it found it,
+	// and mirrors Truncate in reaping by exact "{payloadID}/{offset}" identity.
+	// A row at an offset a new row takes over is left to that row's put, which
+	// rewrites it in place.
+	stale, err := bs.staleDestinationOffsets(ctx, tx, dstPayloadID, srcBlocks)
+	if err != nil {
+		return nil, fmt.Errorf("CopyPayload: list the destination's rows for %s: %w", dstPayloadID, err)
+	}
+	if len(stale) > 0 {
+		if err := bs.coordinator.DecrementRefCountAndReapMany(ctx, dstPayloadID, stale); err != nil {
+			return nil, fmt.Errorf("CopyPayload: reap the destination's replaced rows for %s: %w", dstPayloadID, err)
+		}
+	}
+
 	for _, b := range srcBlocks {
 		if b.Hash.IsZero() {
 			continue


### PR DESCRIPTION
A whole-file reflink replaces the destination's content, and until now the
destination went on serving the content it replaced. The manifest said one
thing and every read said another, with nothing logged.

Confirmed on a real engine before any change — journal-backed local tier,
memory remote, both files written and carved, then `CopyPayload(src -> dst)`:

```
RESULT: destination reads its OWN PRE-CLONE bytes (stale)
```

`bytes.Equal(back, dstData)` — not `srcData`, not zeros.

## Two independent halves, and fixing only one is worse than fixing neither

The copy leaves the destination two kinds of stale state, and each on its own
is enough to serve the wrong bytes.

**The local tier.** `readAtInternal` asks the local tier first and only
reconciles against the manifest when the tier reports a hole or a cold range. A
covered warm range reports neither, so a destination that still holds its own
bytes never reaches the new manifest at all. This is the half the issue
describes.

**The manifest.** `engine.CopyPayload` writes one row per source block and
never removes the destination's own rows. `SetManifest` does not remove them
either: it rewrites the `Blocks` projection (`file_block_refs` on SQL,
`fm:<uuid>` on badger), which is a different structure from the per-chunk rows
a cold read resolves through (`ListFileChunks` reads `file_blocks`).
`CopyPayload`'s own doc-comment says so — "the cold-read path resolves a
payload's bytes via ListFileChunks(dstPayloadID), NOT via FileAttr.Blocks".

The two files chunk their own content, so their offsets rarely line up. The
destination's surviving rows interleave with the copied ones and
`findRowCoveringOffset` takes whichever starts latest — so a cold read of the
destination walks a **mosaic** of both files' content. Today that is reachable
by evicting the destination and reading it back; and it is exactly what fixing
only the local-tier half produces, which is why both are in this PR.

## The fix

- `engine.Store.DiscardLocalContent` drops the local tier's whole account of a
  payload, through the tier's existing durable, version-fenced clip. Both
  reflink helpers in `internal/adapter/common` call it **post-commit**: until
  the commit lands, those bytes are the destination's real content, and a
  rolled-back copy that had already dropped them could not get them back. A
  self-clone/self-copy is guarded — it replaced nothing.

- `engine.CopyPayload` reaps the destination's rows the copy does not take over
  at the same offset, by exact `{payloadID}/{offset}` identity, the way
  `Truncate` already reaps a dropped tail. It runs in the caller's transaction
  so a rolled-back copy leaves the destination's manifest as it found it.

**Holes, not cold.** What the discard leaves behind is holes. That is
deliberate and it is the distinction the fix turns on: an absent local range
and a stale one are not the same state, and only the manifest can tell them
apart. A hole the manifest covers hydrates from the remote; a hole it does not
cover reads as the zeros a sparse source has there. Marking the copied span
cold instead would fail the sparse case closed. `TestCopy_DestinationSparseRangeReadsAsZeros`
is what says so.

**Residual window, and what it costs.** The discard cannot be moved before the
commit, so a crash between the two leaves the destination serving the replaced
content until the copy is repeated. A discard that *fails* is reported rather
than swallowed, for the same reason — reporting success on a destination that
serves the content the copy replaced is the defect this closes. That makes the
discard the one place in these helpers where an error does not mean nothing
landed, and the doc comments that claimed otherwise are corrected here. It also
means a repeat is not free: `engine.CopyPayload`'s manifest work is idempotent
but its per-hash `RefCount` bumps are not, so each repeat counts the source's
hashes one higher. That drifts in the direction the reclaim paths already
prefer — keep a chunk nothing references rather than reclaim one something does
— and is filed as #2177 rather than fixed here, because the obvious fix
(skip the bump for a hash the destination already holds) cannot tell a repeat
from cross-file dedup and would count *down* on the latter.

## Why it was never noticed

`cp --reflink` opens the destination `O_TRUNC`, which issues a SETATTR size=0
first. That truncate clears both halves — the journal clip drops the intervals
and `engine.Truncate` reaps the rows — so the clone lands on an empty
destination and reads correctly. The bug needs a CLONE onto a destination that
still holds bytes: `xfs_io -c "reflink ..."` over an existing file, or any
client that does not truncate first. A reproduction built on `cp --reflink`
shows a passing system and tells you nothing.

## Tests

Every one of these was run against a deliberately broken build first and
watched go red; the `O_TRUNC` masking makes a self-satisfying test unusually
easy to write here.

- `TestCopy_DestinationServesTheCopiedContent` — byte-level read-back at two
  known offsets, with a **bystander payload** as the control: carved and warm
  exactly like the destination, not part of the copy, and still reading its own
  bytes afterwards. Fails on either half alone (stale content without the
  discard; the mosaic without the reap).
- `TestCopy_DestinationSparseRangeReadsAsZeros` — a sparse source, so the
  destination's middle must read as zeros rather than as its own old bytes or
  an error.
- `TestCopy_SelfCopyKeepsItsOwnRows` — the one destination whose surviving rows
  are not stale. The blocks handed in are the caller's snapshot of the
  projection, not the authority on which rows are live, so a row missing from
  them must not be reaped out from under a live file.
- `TestCloneWholeFile_DropsTheDestinationsStaleLocalRanges` /
  `TestCloneWholeFile_SelfCloneKeepsItsLocalRanges` /
  `TestCopyPayload_SelfCopyKeepsItsLocalRanges` — the wiring and the self-copy
  guard.
- `DiscardLocalContent` joins the close-gate table.

## Related

- #2161 is the adjacent half of this path, seen from residency accounting, and
  it is now merged. **The two compose, and the order between them is
  load-bearing**: the discard takes the destination's replaced ranges back to
  holes, and #2161's seed then accounts for the ones the copy gave it. Seeding
  first is not merely redundant — `SeedCold` skips a range the index already
  describes, so it would skip the whole copy and the discard would then drop
  what little it recorded, leaving the tier describing none of the copy. That
  ordering is pinned by #2161's own `TestCloneWholeFile_SeedsDestinationRanges`,
  which goes red ("the index describes 0 bytes of the clone's destination") when
  the two calls are swapped — verified by actually swapping them, not asserted.

  The rebase onto merged #2161 also changed what this PR's adapter-level test
  can assert. It used to check the destination's index was empty; with the seed
  in place the index is populated again, as **cold** ranges. A destination that
  dropped nothing and one that dropped everything now both come back described,
  so the index cannot tell them apart. That test now asserts the bytes instead —
  which is what the contract was always about.

- #2177 — `engine.CopyPayload`'s `RefCount` bumps are not idempotent; a repeated
  copy counts up and never comes back down. Pre-existing, and this PR adds one
  more way to reach it. Not "acceptable drift": the immediate failure is benign,
  but a count that only rises permanently blocks reclamation of blocks nothing
  references.
- #2176 is a narrower sibling this PR does not touch: `materializeLocalClone`
  (the local-only path) materializes real bytes over `[0, srcSize)`, which
  supersede by version, but leaves the destination's intervals and rows **past**
  the new size in place, where a later grow exposes them. Verified on a real
  engine and filed separately rather than folded in here — it is a different
  code path with a different trigger.

Closes #2160

