### PR TITLE
ci(codeql): attest the operator module's coverage instead of adding a second analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -96,7 +96,13 @@ jobs:
           # option is off by default, for both modules alike.
           want="${RUNNER_TEMP}/operator-sources.txt"
           got="${RUNNER_TEMP}/operator-extracted.txt"
+          # A git pathspec matches across directory separators, so this
+          # reaches the whole module, not just its top level.
           git ls-files 'k8s/dittofs-operator/*.go' | grep -v '_test\.go$' | sort >"${want}"
+          if [ ! -s "${want}" ]; then
+            echo "::error::found no operator sources to check for; has the module moved?"
+            exit 1
+          fi
           unzip -Z1 "${archive}" | grep -oE 'k8s/dittofs-operator/.*\.go$' | sort -u >"${got}" || true
 
           found=$(comm -12 "${want}" "${got}" | wc -l)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,6 +51,9 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
+          # Pinned so the coverage check below reads a path this file
+          # controls rather than the action's internal default.
+          db-location: ${{ runner.temp }}/codeql-db
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v4
@@ -63,3 +66,45 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"
+
+      # The repository holds two Go modules and no go.work. The autobuilder
+      # discovers every go.mod under the checkout and runs the extractor once
+      # per module, so the operator lands in this same database — but nothing
+      # announces it when that stops being true. A package that is never
+      # discovered is absent from the database rather than reported as an
+      # error, so an analysis narrowed to the root module still finishes green
+      # and still shows zero operator findings.
+      #
+      # Compare the operator's source files against the database's source
+      # archive, so a narrowing fails the job instead of passing as silence.
+      # The archive is written when the analysis finalizes the database, so
+      # this has to run after it. Only the operator is checked: the root module
+      # carries files behind windows, darwin and e2e build tags that are
+      # correctly absent from a linux database.
+      - name: Verify the operator module reached the database
+        if: matrix.language == 'go'
+        run: |
+          set -euo pipefail
+
+          archive=$(find "${RUNNER_TEMP}/codeql-db" -name src.zip -print -quit)
+          if [ -z "${archive}" ]; then
+            echo "::error::no CodeQL source archive under ${RUNNER_TEMP}/codeql-db"
+            exit 1
+          fi
+
+          # Test files are out of scope: the Go extractor's extract_tests
+          # option is off by default, for both modules alike.
+          want="${RUNNER_TEMP}/operator-sources.txt"
+          got="${RUNNER_TEMP}/operator-extracted.txt"
+          git ls-files 'k8s/dittofs-operator/*.go' | grep -v '_test\.go$' | sort >"${want}"
+          unzip -Z1 "${archive}" | grep -oE 'k8s/dittofs-operator/.*\.go$' | sort -u >"${got}" || true
+
+          found=$(comm -12 "${want}" "${got}" | wc -l)
+          echo "operator source files in the CodeQL database: ${found} of $(wc -l <"${want}")"
+
+          missing=$(comm -23 "${want}" "${got}")
+          if [ -n "${missing}" ]; then
+            echo "::error::CodeQL did not analyse these operator files:"
+            printf '%s\n' "${missing}"
+            exit 1
+          fi


### PR DESCRIPTION
Closes #2167.

## The issue's premise is wrong: the operator module is already analysed

#2167 states that the CodeQL Go autobuilder discovers `go.work` first and then a
single `go.mod` at the checkout root, so with two modules and no workspace file
the operator's 44 Go files "have never been analysed by CodeQL".

That is not what the autobuilder in CodeQL 2.26.3 does. From the `Analyze (go)`
job of an unmodified CodeQL run on `develop`:

```
Found no go.work files in the workspace; looking for go.mod files...
Found 2 go.mod files in: go.mod, k8s/dittofs-operator/go.mod.
Found 2 go.mod file(s).
...
Running extractor command 'go-extractor [./...]' from directory '.'.
...
Running extractor command 'go-extractor [./...]' from directory 'k8s/dittofs-operator'.
...
Done extracting .../k8s/dittofs-operator/internal/controller/dittoserver_controller.go
Success: extraction succeeded for all 2 discovered project(s).
```

It enumerates every `go.mod` under the checkout and invokes the extractor once
per module, into the same database, analysed under the same `/language:go`
category. Counting the distinct operator files named in that log gives 22 —
exactly the number of non-test `.go` files in `k8s/dittofs-operator` (the other
22 are `_test.go`, which the extractor skips by default in both modules alike).

So there is no coverage gap to close, and no second analysis to add. Adding one
would duplicate roughly two minutes of extraction per run and split the same
findings across two categories.

## What is real, and what this PR ships

The part of #2167 that holds up is its description of the failure mode: a
package that is never discovered is **absent** from the database rather than
reported as an error, so an analysis that narrowed to the root module would
still finish green and still show zero operator findings. Silence reads as
coverage. Today's behaviour is correct but entirely unattested — it would
regress on an autobuilder change without anyone noticing.

This adds one step to the `go` job. After analysis it compares the operator's
non-test sources against the finalized database's source archive and fails on
any that are missing, printing the count either way. `db-location` is pinned so
that step reads a known path instead of the action's internal default.

Only the operator is checked. The root module carries files behind `windows`,
`darwin` and `e2e` build tags that are legitimately absent from a linux
database, so the same equality is not an invariant there.

## Evidence the check is not self-satisfying

Run against a synthetic archive rebuilt from the real CI log's entry names, and
against two deliberately broken variants:

```
real archive         operator source files in the CodeQL database: 22 of 22   -> PASS
operator absent      operator source files in the CodeQL database: 0 of 22    -> exit 1
one package dropped  operator source files in the CodeQL database: 12 of 22   -> exit 1
```

The partial case matters: a guard that only asserted "more than zero" would have
passed it.

## Evidence from this PR's own CodeQL run

CodeQL runs on `pull_request`, so this PR exercised the change. Two independent
positive signals, because a green job proves nothing on its own here:

**1. The new step, in CI, reading the finalized database:**

```
operator source files in the CodeQL database: 22 of 22
```

**2. Queries are evaluated over operator source, not merely stored there.** An
earlier commit on this branch set `InsecureSkipVerify = true` in the operator's
control-plane HTTP client. The unmodified `/language:go` analysis reported it:

```
go/disabled-certificate-check | k8s/dittofs-operator/internal/controller/dittofs_client.go:90 | high
```

An alert located inside `k8s/dittofs-operator/`, from the single existing
analysis, with no change to what CodeQL builds. That commit has been dropped
from the branch; the alert closes with it. (The operator's own unit test
`valid CA installs RootCAs without skipping verification` also caught it, which
is a good sign for that test.)

## Unchanged

Default setup stays disabled, the trigger set stays `develop`/`main` on push and
pull_request, the categories stay `/language:<lang>` so the existing alert
dismissals stay attached, and CodeQL remains a non-required check.
