### PR TITLE
fix(smb): break a deleted file's Handle leases only once teardown actually removed it

### DIFF
--- a/internal/adapter/smb/handlers/doc_election.go
+++ b/internal/adapter/smb/handlers/doc_election.go
@@ -280,8 +280,9 @@ func (h *Handler) rangeLiveStreamsOfBase(selfFileID [16]byte, parentHandle metad
 //
 //   - Lease breaks. CLOSE relies on the removal's own dir-change notification
 //     to break the parent's leases and deliberately does not dispatch a second
-//     one; the teardown breaks the file's Handle leases before the unlink and
-//     the parent's afterwards, because no SET_INFO disposition preceded it.
+//     one; the teardown dispatches both — the file's Handle leases and the
+//     parent's — once this call reports the entry actually gone, because no
+//     SET_INFO disposition preceded it.
 //   - The SMB CHANGE_NOTIFY event. CLOSE emits one; the teardown never has,
 //     and starting to emit one there is a change to the notify registry's
 //     traffic rather than to this removal.

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -1687,15 +1687,16 @@ func (h *Handler) purgeBlockStorePayload(ctx context.Context, handle metadata.Fi
 // handleDeleteOnClose performs the delete operation for files marked with
 // delete-on-close during session/tree/connection teardown.
 //
-// Two lease breaks fire around the delete:
+// Two lease breaks fire after the removal, and only when it happened:
 //
-//  1. Before the unlink, strip Handle from other sessions' leases on the
-//     file being deleted (RH → R, RWH → RW). The file is going away, so
-//     Handle caching becomes stale. Required by
-//     smb2.lease.initial_delete_tdis / logoff / disconnect.
+//  1. Strip Handle from other sessions' leases on the file that was
+//     deleted (RH → R, RWH → RW). Handle caching is only stale once the
+//     entry is actually gone — a delete-on-close that meets a non-empty
+//     directory declines the removal (MS-FSA 2.1.5.5 phase 1 step 2.1.1)
+//     and leaves every other holder's caching valid.
 //
-//  2. After the unlink, break the parent directory's Handle and Read leases
-//     (content change). Matches the explicit CLOSE path at close.go:334.
+//  2. Break the parent directory's Handle and Read leases (content
+//     change). Matches the explicit CLOSE path at close.go:334.
 //
 // Both breaks are async: the triggering SMB request (TDIS / LOGOFF / CLOSE /
 // transport close) is on tree2/session2, while the lease holder is on a
@@ -1717,18 +1718,6 @@ func (h *Handler) handleDeleteOnClose(ctx context.Context, sess *session.Session
 	if !docSetterKeysDiffer {
 		PropagateOpenFileParentLeaseKey(authCtx, openFile)
 	}
-	if h.LeaseManager != nil && len(openFile.MetadataHandle) > 0 {
-		lockFileHandle := lock.FileHandle(openFile.MetadataHandle)
-		// Exclude the closing session: its leases on this file are about to
-		// be released anyway, and firing self-breaks creates spurious
-		// notifications that leak into later tests (observed regressing
-		// smb2.lease.v1_bug15148 to count=2).
-		excludeOwner := &lock.LockOwner{ClientID: fmt.Sprintf("smb:%d", openFile.SessionID)}
-		if breakErr := h.LeaseManager.BreakFileHandleLeasesOnDelete(lockFileHandle, openFile.ShareName, excludeOwner); breakErr != nil {
-			logger.Debug(caller+": file Handle lease break on delete failed", "path", name.Path, "error", breakErr)
-		}
-	}
-
 	// Remove what the election resolved — for a stream handle carrying a
 	// base-file delete that is the base file, not the stream's own name —
 	// through the shared helper CLOSE also uses, so the cascade to stream
@@ -1737,6 +1726,18 @@ func (h *Handler) handleDeleteOnClose(ctx context.Context, sess *session.Session
 	_, removed, err := h.removeElectedTarget(ctx, authCtx, openFile, target, caller)
 
 	if err == nil && removed {
+		if h.LeaseManager != nil && len(openFile.MetadataHandle) > 0 {
+			lockFileHandle := lock.FileHandle(openFile.MetadataHandle)
+			// Exclude the closing session: its leases on this file are about to
+			// be released anyway, and firing self-breaks creates spurious
+			// notifications that leak into later tests (observed regressing
+			// smb2.lease.v1_bug15148 to count=2).
+			excludeOwner := &lock.LockOwner{ClientID: fmt.Sprintf("smb:%d", openFile.SessionID)}
+			if breakErr := h.LeaseManager.BreakFileHandleLeasesOnDelete(lockFileHandle, openFile.ShareName, excludeOwner); breakErr != nil {
+				logger.Debug(caller+": file Handle lease break on delete failed", "path", name.Path, "error", breakErr)
+			}
+		}
+
 		// No SMBHandlerContext available on the TDIS/LOGOFF/disconnect
 		// teardown path — pass nil so the helper falls back to inline
 		// dispatch (those paths don't ship a triggering response on the

--- a/internal/adapter/smb/handlers/session_teardown_doc_lease_test.go
+++ b/internal/adapter/smb/handlers/session_teardown_doc_lease_test.go
@@ -1,0 +1,197 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/lease"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// A delete-on-close carried into the LOGOFF / tree-disconnect / transport-drop
+// teardown breaks the closing file's Handle leases. Per MS-FSA 2.1.5.5 phase 1
+// step 2.1.1 a delete-on-close that meets a directory which still holds entries
+// declines the removal and the close still succeeds, so reaching that break
+// says nothing about whether anything was deleted. Handle caching on an entry
+// that is still there stays valid, and stripping it tells every other holder
+// its cached handle can no longer be reopened when it can.
+//
+// The break is directory-specific in practice: SET_INFO's equivalent is gated
+// on !IsDirectory and CLOSE has no pre-removal break at all, so the teardown
+// path is the only one that breaks a directory's Handle leases on
+// delete-on-close — and a declined removal is by definition a directory.
+
+// docLeaseBreakRecorder wraps a real lock manager and records the handle key of
+// every lease break dispatched through it. The teardown dispatches two breaks
+// against two different keys — the closing file's own handle for the Handle
+// break, the parent directory's for the content-change break — so recording the
+// key is what tells them apart. Dispatch is synchronous, so a break owed by a
+// teardown has been recorded by the time that teardown returns.
+type docLeaseBreakRecorder struct {
+	lock.LockManager
+	mu   sync.Mutex
+	keys []string
+}
+
+func (r *docLeaseBreakRecorder) BreakLeasesOnOpenConflict(
+	handleKey string, excludeOwner *lock.LockOwner, reason lock.BreakReason,
+) error {
+	r.mu.Lock()
+	r.keys = append(r.keys, handleKey)
+	r.mu.Unlock()
+	return r.LockManager.BreakLeasesOnOpenConflict(handleKey, excludeOwner, reason)
+}
+
+func (r *docLeaseBreakRecorder) sawBreakFor(handle metadata.FileHandle) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, k := range r.keys {
+		if k == string(handle) {
+			return true
+		}
+	}
+	return false
+}
+
+// docLeaseEnv is a share holding directory "docdir", a Handle-caching (RH)
+// directory lease on it owned by a session that is NOT the one being torn
+// down, and one open on "docdir" carrying a delete-on-close on the session the
+// test tears down.
+type docLeaseEnv struct {
+	h         *Handler
+	rec       *docLeaseBreakRecorder
+	root      metadata.FileHandle
+	dirFH     metadata.FileHandle
+	rootAuth  *metadata.AuthContext
+	docSessID uint64
+}
+
+// holderSessionID owns the directory lease; docSessionID owns the
+// delete-on-close open the teardown closes. They must differ: the break
+// excludes the closing session's own leases.
+const (
+	holderSessionID = uint64(0xA1)
+	docSessionID    = uint64(0xB2)
+)
+
+func newDocLeaseEnv(t *testing.T, withChild bool) *docLeaseEnv {
+	t.Helper()
+	h, rt, smbCtx, root, rootAuth := setupDaclTest(t)
+
+	rec := &docLeaseBreakRecorder{LockManager: lock.NewManager()}
+	h.LeaseManager = lease.NewLeaseManager(&staticLockResolver{mgr: rec}, nil)
+
+	metaSvc := rt.GetMetadataService()
+	dir, _, err := metaSvc.CreateDirectory(rootAuth, root, "docdir", &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory,
+		Mode: 0o755,
+	})
+	if err != nil {
+		t.Fatalf("CreateDirectory docdir: %v", err)
+	}
+	dirFH, err := metadata.EncodeFileHandle(dir)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle docdir: %v", err)
+	}
+	if withChild {
+		if _, _, err := metaSvc.CreateFile(rootAuth, dirFH, "child", &metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o644,
+		}); err != nil {
+			t.Fatalf("CreateFile docdir/child: %v", err)
+		}
+	}
+
+	// The other holder's RH directory lease. It has no open in h.files — the
+	// state a durable handle persisted across a transport drop leaves behind,
+	// and the state a concurrent CLOSE passes through between its
+	// delete-on-close election and its lease release.
+	holderKey := [16]byte{0xA1, 0xA1}
+	granted, _, err := h.LeaseManager.RequestLease(
+		context.Background(),
+		lock.FileHandle(dirFH),
+		holderKey,
+		[16]byte{},
+		holderSessionID,
+		[16]byte{0x01},
+		"owner-holder",
+		fmt.Sprintf("smb:%d", holderSessionID),
+		smbCtx.ShareName,
+		lock.LeaseStateRead|lock.LeaseStateHandle,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("RequestLease: %v", err)
+	}
+	if granted&lock.LeaseStateHandle == 0 {
+		t.Fatalf("precondition: RH dir lease granted %s, want Handle caching",
+			lock.LeaseStateToString(granted))
+	}
+
+	// The delete-on-close open the teardown will close.
+	docOpen := (&OpenFile{
+		FileID:         [16]byte{0xDC, 0x01},
+		SessionID:      docSessionID,
+		TreeID:         smbCtx.TreeID,
+		IsDirectory:    true,
+		ShareName:      smbCtx.ShareName,
+		MetadataHandle: dirFH,
+		DeletePending:  true,
+	}).WithName(OpenName{Path: "/docdir", FileName: "docdir", ParentHandle: root})
+	h.StoreOpenFile(docOpen)
+
+	return &docLeaseEnv{
+		h:         h,
+		rec:       rec,
+		root:      root,
+		dirFH:     dirFH,
+		rootAuth:  rootAuth,
+		docSessID: docSessionID,
+	}
+}
+
+// dirStillThere reports whether "docdir" survived the teardown.
+func (e *docLeaseEnv) dirStillThere(t *testing.T) bool {
+	t.Helper()
+	f, _, err := e.h.Registry.GetMetadataService().LookupCaseInsensitive(e.rootAuth, e.root, "docdir")
+	return err == nil && f != nil
+}
+
+// TestSessionTeardown_DeclinedDirRemoval_KeepsHandleLease is the regression:
+// the teardown must not strip another holder's Handle caching for a removal
+// that was declined.
+func TestSessionTeardown_DeclinedDirRemoval_KeepsHandleLease(t *testing.T) {
+	e := newDocLeaseEnv(t, true)
+
+	e.h.CloseAllFilesForSession(context.Background(), e.docSessID, false)
+
+	if !e.dirStillThere(t) {
+		t.Fatal("precondition: docdir holds an entry, so the delete-on-close must have " +
+			"declined its removal — the test cannot say anything about the break otherwise")
+	}
+	if e.rec.sawBreakFor(e.dirFH) {
+		t.Error("teardown broke the directory's Handle lease for a removal that was declined: " +
+			"docdir was not empty and is still there, so the holder's cached handle is still " +
+			"reopenable and its Handle caching must survive")
+	}
+}
+
+// TestSessionTeardown_DirRemoved_BreaksHandleLease is the other direction, and
+// the reason the fix gates the break rather than deleting it: when the removal
+// does happen, the Handle break still fires.
+func TestSessionTeardown_DirRemoved_BreaksHandleLease(t *testing.T) {
+	e := newDocLeaseEnv(t, false)
+
+	e.h.CloseAllFilesForSession(context.Background(), e.docSessID, false)
+
+	if e.dirStillThere(t) {
+		t.Fatal("precondition: docdir is empty, so the delete-on-close must have removed it")
+	}
+	if !e.rec.sawBreakFor(e.dirFH) {
+		t.Error("teardown removed docdir without breaking the directory's Handle lease: " +
+			"the entry is gone, so every other holder's cached handle is unreopenable")
+	}
+}

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -1101,7 +1101,16 @@ func (lm *LeaseManager) BreakLeasesOnRename(
 // transport. Waiting for the ACK here would deadlock the in-flight SMB
 // request; the holder acks on its own transport after we return.
 //
-// Required by smbtorture smb2.lease.initial_delete_tdis / logoff / disconnect.
+// Callers dispatch it only once the entry is actually gone: a delete-on-close
+// that meets a non-empty directory declines the removal, and Handle caching on
+// an entry that is still there stays valid.
+//
+// The teardown caller is NOT what makes smb2.lease.initial_delete_tdis /
+// logoff / disconnect pass, despite what this comment used to say. Their lease
+// holder keeps its handle open across the tdis, so the delete-on-close election
+// defers and the teardown never reaches this call; the RH -> R break those
+// tests observe comes from the second connection's CREATE, which selects
+// BreakReasonSharingViolation for FILE_DELETE_ON_CLOSE.
 func (lm *LeaseManager) BreakFileHandleLeasesOnDelete(
 	fileHandle lock.FileHandle,
 	shareName string,


### PR DESCRIPTION
## What was wrong

On the LOGOFF / tree-disconnect / transport-drop teardown, `handleDeleteOnClose`
broke the closing file's Handle leases *before* it knew whether the removal would
happen:

```go
h.LeaseManager.BreakFileHandleLeasesOnDelete(lockFileHandle, ...)   // unconditional
...
_, removed, err := h.removeElectedTarget(...)
if err == nil && removed {
    h.breakParentDirLeasesForContentChange(...)                      // gated
}
```

Since #2159 a delete-on-close that meets a directory still holding entries is an
ordinary outcome rather than an error: per MS-FSA 2.1.5.5 phase 1 step 2.1.1 the
removal is declined and the close succeeds, and `removeElectedTarget` reports
`removed=false` with a nil error. The parent break already respected that verdict.
The file break did not — so every other holder's Handle caching was stripped for a
directory that is still there and still reopenable.

This is the only site in the adapter that breaks a **directory's** Handle leases on
delete-on-close: `set_info.go:1349` gates its equivalent on `!openFile.IsDirectory`,
and `close.go` has no pre-removal break at all. A declined removal is by definition
a directory, so the teardown path is exactly where the mismatch bites.

## The fix

Move the file Handle break inside the existing `err == nil && removed` block, ahead
of the parent break. Three lines of movement.

I deliberately did **not** mirror `set_info.go`'s `!IsDirectory` gate. The two sites
differ in what they are reacting to: SET_INFO reacts to a disposition being *set*,
where a directory genuinely has nothing to announce yet, while this one reacts to an
entry actually being *unlinked* — and when a directory really is removed, its
holders' cached handles really are unreopenable. Gating on the verdict keeps that
break and drops only the one that was announcing a deletion which did not happen.

## A stale claim in the comment, corrected

The comment on the removed block said the break was *"Required by
smb2.lease.initial_delete_tdis / logoff / disconnect"*. It is not, and the same
sentence is repeated on `BreakFileHandleLeasesOnDelete` — worth knowing for anyone
working nearby, because it makes the block look load-bearing for three passing tests.

In `source4/torture/smb2/lease.c:5529` the lease holder's handle `h1` stays **open**
across the tdis:

```c
status = smb2_create(tree1, tree1, &c);      /* RH lease, LEASE1 */
h1 = c.out.file.handle;
...
c.in.create_options = NTCREATEX_OPTIONS_DELETE_ON_CLOSE;
status = smb2_create(tree2, tree2, &c);      /* second connection */
status = smb2_tdis(tree2);
CHECK_BREAK_INFO_V2(..., "RH", "R", LEASE1, 2);
status = smb2_util_close(tree1, h1);         /* only now */
```

With `h1` still in `h.files`, `electDeleteOnClose` finds a surviving open on the same
metadata handle and returns `docDecisionDeferred` — `handleDeleteOnClose` is never
called on tree2's teardown at all. The RH → R break those three tests check for comes
from tree2's **CREATE**, which selects `lock.BreakReasonSharingViolation` for
`FILE_DELETE_ON_CLOSE` (`create_post_break.go:292`) and strips Handle there. The
unlink itself lands on `h1`'s later CLOSE, which is what makes the trailing
`OBJECT_NAME_NOT_FOUND` assertion pass.

## Reachability

The issue predicted the defect from the code and said so. It holds, but narrowly, and
the narrowing is worth recording: because the election defers whenever another open on
the same file is still in `h.files`, this break can only ever reach a lease whose
owning open has **left the table while its lease record was kept**. Two ways that
happens:

- a durable handle persisted across a transport drop — `closeFilesWithFilter` removes
  it from `h.files` and deliberately does not release its lease;
- a concurrent CLOSE in the window between its own election (which sets `docLeaving`,
  making it invisible to a later election) and its `releaseHandleLeaseRecord`.

Both leave exactly the state the regression test builds: an RH directory lease on a
handle with no open behind it.

## Verification

Two tests in `internal/adapter/smb/handlers/session_teardown_doc_lease_test.go`, both
driving the real `CloseAllFilesForSession` teardown and observing which handle keys
the lock manager is asked to break.

Each was run against a deliberately broken build before being trusted:

| build | `DeclinedDirRemoval_KeepsHandleLease` | `DirRemoved_BreaksHandleLease` |
| --- | --- | --- |
| `origin/develop` (ungated break) | **FAIL** — "broke the directory's Handle lease for a removal that was declined" | pass |
| file Handle break deleted outright | pass | **FAIL** — "removed docdir without breaking the directory's Handle lease" |
| this branch | pass | pass |

The second row is why the fix gates the break instead of deleting it: a test that only
checked the declined case would have graded "delete the block" as correct.

`go build ./...`, `go vet ./...` and `go test -race ./internal/adapter/smb/...` are clean.

Closes #2165
