### PR TITLE
fix(smb): apply the three SET_INFO access gates MS-FSA states as MUSTs

### DIFF
--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -695,6 +695,18 @@ func (h *Handler) setFileInfoFromStore(
 			return setInfoStatus(types.StatusAccessDenied), nil
 		}
 
+		// Per MS-FSA 2.1.5.15.12 ("FileRenameInformation"): if Open.Link.IsDeleted
+		// is TRUE, the operation MUST be failed with STATUS_ACCESS_DENIED. The
+		// analogue of Open.Link.IsDeleted is the disposition set through SET_INFO
+		// FileDispositionInformation, not the FILE_DELETE_ON_CLOSE create option:
+		// that option is held per-handle as InitialDeleteOnClose and only promoted
+		// at CLOSE, matching 2.1.5.5 phase 1.
+		if openFile.IsDeletePending() {
+			logger.Debug("SET_INFO: rename of a link already marked for deletion",
+				"path", openFile.Name().Path)
+			return setInfoStatus(types.StatusAccessDenied), nil
+		}
+
 		// Before renaming, check that no other open handle on the same file
 		// conflicts with the rename: all other opens must have FILE_SHARE_DELETE
 		// (0x04) in ShareAccess. MS-FSA 2.1.5.15.12 ("FileRenameInformation")
@@ -1288,6 +1300,10 @@ func (h *Handler) setFileInfoFromStore(
 		}
 
 		var deletePending bool
+		// ignoreReadonly is only reachable through the Ex class; the 1-byte
+		// FileDispositionInformation carries no flags and so can never waive the
+		// read-only refusal below.
+		ignoreReadonly := false
 		if class == types.FileDispositionInformationEx {
 			// FileDispositionInformationEx uses a 4-byte Flags field per MS-FSCC 2.4.12 (FileDispositionInformationEx)
 			if len(buffer) < 4 {
@@ -1295,8 +1311,24 @@ func (h *Handler) setFileInfoFromStore(
 			}
 			dispR := smbenc.NewReader(buffer)
 			flags := dispR.ReadUint32()
-			// Bit 0 (FILE_DISPOSITION_DELETE) = delete on close
-			deletePending = (flags & 0x01) != 0
+
+			// Per MS-FSCC 2.4.12: FILE_DISPOSITION_ON_CLOSE updates the
+			// FILE_DELETE_ON_CLOSE state, and "if set and the file is not opened
+			// with FILE_DELETE_ON_CLOSE, STATUS_NOT_SUPPORTED MUST be returned".
+			// The create option is held per-handle as InitialDeleteOnClose.
+			if flags&types.FileDispositionOnClose != 0 && !openFile.InitialDeleteOnClose {
+				logger.Debug("SET_INFO: FILE_DISPOSITION_ON_CLOSE on a handle not opened delete-on-close",
+					"path", openFile.Name().Path)
+				return setInfoStatus(types.StatusNotSupported), nil
+			}
+
+			deletePending = flags&types.FileDispositionDelete != 0
+			ignoreReadonly = flags&types.FileDispositionIgnoreReadonlyAttribute != 0
+
+			// FILE_DISPOSITION_POSIX_SEMANTICS is accepted and not acted on: the
+			// link is removed from the namespace at close either way, and keeping
+			// the data streams readable through other handles after the unlink is
+			// not implemented.
 		} else {
 			deletePending = buffer[0] != 0
 		}
@@ -1324,8 +1356,11 @@ func (h *Handler) setFileInfoFromStore(
 				return setInfoStatus(types.StatusAccessDenied), nil
 			}
 
-			// Read-only files cannot be marked for deletion
-			if !openFile.IsDirectory {
+			// Read-only files cannot be marked for deletion unless the caller sent
+			// FILE_DISPOSITION_IGNORE_READONLY_ATTRIBUTE. Per MS-FSCC 2.4.12 that
+			// flag "allows files with the READ_ONLY attribute to be deleted
+			// anyway"; without it the refusal below is a MUST.
+			if !openFile.IsDirectory && !ignoreReadonly {
 				metaSvc := h.Registry.GetMetadataService()
 				file, fileErr := metaSvc.GetFile(authCtx.Context, openFile.MetadataHandle)
 				if fileErr == nil {
@@ -1537,6 +1572,19 @@ func (h *Handler) setFileInfoFromStore(
 
 	case types.FileAllocationInformation:
 		// FILE_ALLOCATION_INFORMATION [MS-FSCC] 2.4.4.
+		//
+		// Per MS-FSA 2.1.5.15.1 ("FileAllocationInformation"): if Open.GrantedAccess
+		// does not contain FILE_WRITE_DATA, the operation MUST be failed with
+		// STATUS_ACCESS_DENIED. This class is exempt from the FILE_WRITE_ATTRIBUTES
+		// gate above precisely because it carries this check, and the gate runs
+		// before the lease break so a handle that may not write cannot invalidate
+		// another client's cached read state.
+		if !hasAccessRight(openFile.GrantedAccess, uint32(types.FileWriteData)) {
+			logger.Debug("SET_INFO: allocation set without FILE_WRITE_DATA",
+				"path", openFile.Name().Path,
+				"grantedAccess", fmt.Sprintf("0x%x", openFile.GrantedAccess))
+			return setInfoStatus(types.StatusAccessDenied), nil
+		}
 		//
 		// Allocation size is not persisted (DittoFS does not preallocate), but
 		// per MS-FSA 2.1.5.15.1 ("FileAllocationInformation") and Samba `smbd_smb2_setinfo_lease_break_fsp_check`

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -1317,10 +1317,12 @@ func (h *Handler) setFileInfoFromStore(
 			dispR := smbenc.NewReader(buffer)
 			flags := dispR.ReadUint32()
 
-			// Per MS-FSCC 2.4.12: FILE_DISPOSITION_ON_CLOSE updates the
-			// FILE_DELETE_ON_CLOSE state, and "if set and the file is not opened
-			// with FILE_DELETE_ON_CLOSE, STATUS_NOT_SUPPORTED MUST be returned".
-			// The create option is held per-handle as InitialDeleteOnClose.
+			// Per MS-FSCC 2.4.12: "if set and the file is not opened with
+			// FILE_DELETE_ON_CLOSE, STATUS_NOT_SUPPORTED MUST be returned". That
+			// refusal is the whole of what this flag does here — the disposition it
+			// would otherwise select rides on the DELETE bit read below, so no
+			// separate delete-on-close state is written. The create option is held
+			// per-handle as InitialDeleteOnClose.
 			if flags&types.FileDispositionOnClose != 0 && !openFile.InitialDeleteOnClose {
 				logger.Debug("SET_INFO: FILE_DISPOSITION_ON_CLOSE on a handle not opened delete-on-close",
 					"path", openFile.Name().Path)

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -696,12 +696,19 @@ func (h *Handler) setFileInfoFromStore(
 		}
 
 		// Per MS-FSA 2.1.5.15.12 ("FileRenameInformation"): if Open.Link.IsDeleted
-		// is TRUE, the operation MUST be failed with STATUS_ACCESS_DENIED. The
-		// analogue of Open.Link.IsDeleted is the disposition set through SET_INFO
-		// FileDispositionInformation, not the FILE_DELETE_ON_CLOSE create option:
-		// that option is held per-handle as InitialDeleteOnClose and only promoted
-		// at CLOSE, matching 2.1.5.5 phase 1.
-		if openFile.IsDeletePending() {
+		// is TRUE, the operation MUST be failed with STATUS_ACCESS_DENIED.
+		//
+		// IsDeleted belongs to the link, not to the handle asking, so this is the
+		// cross-handle scan the CREATE gate already uses rather than this open's
+		// own flag: a disposition committed on one handle is not copied onto its
+		// siblings until the CLOSE election runs, so reading only openFile would
+		// let a second handle rename a link already marked for deletion.
+		//
+		// The analogue is the disposition set through SET_INFO, not the
+		// FILE_DELETE_ON_CLOSE create option: that is held per-handle as
+		// InitialDeleteOnClose, is deliberately invisible to this scan, and is
+		// promoted only at CLOSE, matching 2.1.5.5 phase 1.
+		if h.isFileDeletePending(openFile.MetadataHandle) {
 			logger.Debug("SET_INFO: rename of a link already marked for deletion",
 				"path", openFile.Name().Path)
 			return setInfoStatus(types.StatusAccessDenied), nil
@@ -1299,11 +1306,9 @@ func (h *Handler) setFileInfoFromStore(
 			return setInfoStatus(types.StatusInvalidParameter), nil
 		}
 
-		var deletePending bool
-		// ignoreReadonly is only reachable through the Ex class; the 1-byte
-		// FileDispositionInformation carries no flags and so can never waive the
-		// read-only refusal below.
-		ignoreReadonly := false
+		// ignoreReadonly stays false for the 1-byte FileDispositionInformation:
+		// it carries no flags and so can never waive the read-only refusal below.
+		var deletePending, ignoreReadonly bool
 		if class == types.FileDispositionInformationEx {
 			// FileDispositionInformationEx uses a 4-byte Flags field per MS-FSCC 2.4.12 (FileDispositionInformationEx)
 			if len(buffer) < 4 {
@@ -1356,10 +1361,9 @@ func (h *Handler) setFileInfoFromStore(
 				return setInfoStatus(types.StatusAccessDenied), nil
 			}
 
-			// Read-only files cannot be marked for deletion unless the caller sent
-			// FILE_DISPOSITION_IGNORE_READONLY_ATTRIBUTE. Per MS-FSCC 2.4.12 that
-			// flag "allows files with the READ_ONLY attribute to be deleted
-			// anyway"; without it the refusal below is a MUST.
+			// Per MS-FSCC 2.4.12 FILE_DISPOSITION_IGNORE_READONLY_ATTRIBUTE
+			// "allows files with the READ_ONLY attribute to be deleted anyway";
+			// without it the refusal below is a MUST.
 			if !openFile.IsDirectory && !ignoreReadonly {
 				metaSvc := h.Registry.GetMetadataService()
 				file, fileErr := metaSvc.GetFile(authCtx.Context, openFile.MetadataHandle)
@@ -1585,7 +1589,7 @@ func (h *Handler) setFileInfoFromStore(
 				"grantedAccess", fmt.Sprintf("0x%x", openFile.GrantedAccess))
 			return setInfoStatus(types.StatusAccessDenied), nil
 		}
-		//
+
 		// Allocation size is not persisted (DittoFS does not preallocate), but
 		// per MS-FSA 2.1.5.15.1 ("FileAllocationInformation") and Samba `smbd_smb2_setinfo_lease_break_fsp_check`
 		// (source3/smbd/smb2_setinfo.c) setting allocation is a data-modifying

--- a/internal/adapter/smb/handlers/set_info_fsa_gates_test.go
+++ b/internal/adapter/smb/handlers/set_info_fsa_gates_test.go
@@ -83,18 +83,7 @@ func TestSetInfo_DispositionEx_OnCloseRequiresDeleteOnClose(t *testing.T) {
 
 	open := func(name string, opts types.CreateOptions) [16]byte {
 		t.Helper()
-		resp, err := h.Create(ctx, &CreateRequest{
-			FileName:          name,
-			DesiredAccess:     secRightsFileAll,
-			FileAttributes:    types.FileAttributeNormal,
-			ShareAccess:       0x07,
-			CreateDisposition: types.FileOpenIf,
-			CreateOptions:     types.FileNonDirectoryFile | opts,
-		})
-		if err != nil {
-			t.Fatalf("Create(%q): %v", name, err)
-		}
-		return resp.FileID
+		return dirTestCreate(t, h, ctx, name, types.FileOpenIf, types.FileNonDirectoryFile|opts)
 	}
 
 	onClose := types.FileDispositionDelete | types.FileDispositionOnClose
@@ -214,5 +203,86 @@ func TestSetInfo_SetAllocation_RequiresWriteData(t *testing.T) {
 	// Control: the same call on a writable handle is accepted.
 	if got := setAlloc(open("alloc-rw", secRightsFileAll)); got != types.StatusSuccess {
 		t.Errorf("SetAlloc on a writable handle = %v, want STATUS_SUCCESS", got)
+	}
+}
+
+// TestSetInfo_Rename_AllowedOnDeleteOnCloseHandle guards the failure mode the
+// rename gate above could plausibly introduce. Open.Link.IsDeleted is the
+// disposition set through SET_INFO, not the FILE_DELETE_ON_CLOSE create option:
+// that option is held per-handle as InitialDeleteOnClose and promoted to
+// DeletePending only during the CLOSE election, matching MS-FSA 2.1.5.5 phase 1.
+// Conflating the two would make every delete-on-close handle un-renameable.
+func TestSetInfo_Rename_AllowedOnDeleteOnCloseHandle(t *testing.T) {
+	h, ctx, _ := setupStreamsDisabledShare(t, false)
+
+	resp, err := h.Create(ctx, &CreateRequest{
+		FileName:          "doc-renamable",
+		DesiredAccess:     secRightsFileAll,
+		FileAttributes:    types.FileAttributeNormal,
+		ShareAccess:       0x07,
+		CreateDisposition: types.FileOpenIf,
+		CreateOptions:     types.FileNonDirectoryFile | types.FileDeleteOnClose,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("Create = %v, want STATUS_SUCCESS", resp.Status)
+	}
+
+	setResp, err := h.SetInfo(ctx, &SetInfoRequest{
+		InfoType:      types.SMB2InfoTypeFile,
+		FileInfoClass: uint8(types.FileRenameInformation),
+		FileID:        resp.FileID,
+		Buffer:        encodeRenameInfo("doc-renamed"),
+	})
+	if err != nil {
+		t.Fatalf("SetInfo rename: %v", err)
+	}
+	if setResp.Status != types.StatusSuccess {
+		t.Errorf("rename of a delete-on-close handle = %v, want STATUS_SUCCESS", setResp.Status)
+	}
+}
+
+// TestSetInfo_Rename_RefusedOnSecondHandleWhenDeletePending covers the case the
+// single-handle form of this gate missed. Open.Link.IsDeleted is a property of
+// the link, so a disposition committed on one handle must block a rename issued
+// on any other open of the same file — and DeletePending is not copied onto
+// sibling handles until the CLOSE election runs.
+func TestSetInfo_Rename_RefusedOnSecondHandleWhenDeletePending(t *testing.T) {
+	h, ctx, _ := setupStreamsDisabledShare(t, false)
+
+	first := dirTestCreate(t, h, ctx, "shared", types.FileOpenIf, types.FileNonDirectoryFile)
+	second := dirTestCreate(t, h, ctx, "shared", types.FileOpen, types.FileNonDirectoryFile)
+	if first == second {
+		t.Fatal("expected two distinct opens on the same file")
+	}
+
+	dispResp, err := h.SetInfo(ctx, &SetInfoRequest{
+		InfoType:      types.SMB2InfoTypeFile,
+		FileInfoClass: uint8(types.FileDispositionInformation),
+		FileID:        first,
+		Buffer:        encodeDispositionInfo(true),
+	})
+	if err != nil {
+		t.Fatalf("SetInfo disposition on first handle: %v", err)
+	}
+	if dispResp.Status != types.StatusSuccess {
+		t.Fatalf("disposition = %v, want STATUS_SUCCESS", dispResp.Status)
+	}
+
+	// The rename arrives on the OTHER handle, which never set a disposition of
+	// its own and so still reports DeletePending == false.
+	renResp, err := h.SetInfo(ctx, &SetInfoRequest{
+		InfoType:      types.SMB2InfoTypeFile,
+		FileInfoClass: uint8(types.FileRenameInformation),
+		FileID:        second,
+		Buffer:        encodeRenameInfo("shared-moved"),
+	})
+	if err != nil {
+		t.Fatalf("SetInfo rename on second handle: %v", err)
+	}
+	if renResp.Status != types.StatusAccessDenied {
+		t.Errorf("rename on a sibling handle of a doomed link = %v, want STATUS_ACCESS_DENIED", renResp.Status)
 	}
 }

--- a/internal/adapter/smb/handlers/set_info_fsa_gates_test.go
+++ b/internal/adapter/smb/handlers/set_info_fsa_gates_test.go
@@ -1,0 +1,218 @@
+package handlers
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+// Gates that MS-FSA states as MUSTs on the SET_INFO path and that the handler
+// previously did not apply. Each case is paired with a control that must take
+// the opposite branch, so a test cannot pass by the gate never being reached.
+
+func encodeDispositionExInfo(flags uint32) []byte {
+	buf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf, flags)
+	return buf
+}
+
+func encodeAllocationInfo(size uint64) []byte {
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf, size)
+	return buf
+}
+
+// TestSetInfo_DispositionEx_IgnoreReadonlyAttribute pins MS-FSCC 2.4.12:
+// FILE_DISPOSITION_IGNORE_READONLY_ATTRIBUTE "allows files with the READ_ONLY
+// attribute to be deleted anyway", and without it the refusal is a MUST. Both
+// directions are asserted; honouring only bit 0 fails the first case.
+func TestSetInfo_DispositionEx_IgnoreReadonlyAttribute(t *testing.T) {
+	h, ctx, _ := setupStreamsDisabledShare(t, false)
+
+	newReadonly := func(name string) [16]byte {
+		t.Helper()
+		resp, err := h.Create(ctx, &CreateRequest{
+			FileName:          name,
+			DesiredAccess:     secRightsFileAll,
+			FileAttributes:    types.FileAttributeReadonly,
+			ShareAccess:       0x07,
+			CreateDisposition: types.FileOpenIf,
+			CreateOptions:     types.FileNonDirectoryFile,
+		})
+		if err != nil {
+			t.Fatalf("Create(%q): %v", name, err)
+		}
+		if resp.Status != types.StatusSuccess {
+			t.Fatalf("Create(%q) = %v, want STATUS_SUCCESS", name, resp.Status)
+		}
+		return resp.FileID
+	}
+
+	disposition := func(fid [16]byte, flags uint32) types.Status {
+		t.Helper()
+		resp, err := h.SetInfo(ctx, &SetInfoRequest{
+			InfoType:      types.SMB2InfoTypeFile,
+			FileInfoClass: uint8(types.FileDispositionInformationEx),
+			FileID:        fid,
+			Buffer:        encodeDispositionExInfo(flags),
+		})
+		if err != nil {
+			t.Fatalf("SetInfo disposition-ex: %v", err)
+		}
+		return resp.Status
+	}
+
+	// Control: DELETE alone on a read-only file MUST be refused.
+	if got := disposition(newReadonly("ro-plain"), types.FileDispositionDelete); got != types.StatusCannotDelete {
+		t.Errorf("DELETE on a read-only file = %v, want STATUS_CANNOT_DELETE", got)
+	}
+
+	// DELETE|IGNORE_READONLY_ATTRIBUTE must be permitted.
+	flags := types.FileDispositionDelete | types.FileDispositionIgnoreReadonlyAttribute
+	if got := disposition(newReadonly("ro-ignored"), flags); got != types.StatusSuccess {
+		t.Errorf("DELETE|IGNORE_READONLY on a read-only file = %v, want STATUS_SUCCESS", got)
+	}
+}
+
+// TestSetInfo_DispositionEx_OnCloseRequiresDeleteOnClose pins MS-FSCC 2.4.12:
+// FILE_DISPOSITION_ON_CLOSE "set and the file is not opened with
+// FILE_DELETE_ON_CLOSE, STATUS_NOT_SUPPORTED MUST be returned".
+func TestSetInfo_DispositionEx_OnCloseRequiresDeleteOnClose(t *testing.T) {
+	h, ctx, _ := setupStreamsDisabledShare(t, false)
+
+	open := func(name string, opts types.CreateOptions) [16]byte {
+		t.Helper()
+		resp, err := h.Create(ctx, &CreateRequest{
+			FileName:          name,
+			DesiredAccess:     secRightsFileAll,
+			FileAttributes:    types.FileAttributeNormal,
+			ShareAccess:       0x07,
+			CreateDisposition: types.FileOpenIf,
+			CreateOptions:     types.FileNonDirectoryFile | opts,
+		})
+		if err != nil {
+			t.Fatalf("Create(%q): %v", name, err)
+		}
+		return resp.FileID
+	}
+
+	onClose := types.FileDispositionDelete | types.FileDispositionOnClose
+	set := func(fid [16]byte) types.Status {
+		t.Helper()
+		resp, err := h.SetInfo(ctx, &SetInfoRequest{
+			InfoType:      types.SMB2InfoTypeFile,
+			FileInfoClass: uint8(types.FileDispositionInformationEx),
+			FileID:        fid,
+			Buffer:        encodeDispositionExInfo(onClose),
+		})
+		if err != nil {
+			t.Fatalf("SetInfo disposition-ex: %v", err)
+		}
+		return resp.Status
+	}
+
+	if got := set(open("doc-absent", 0)); got != types.StatusNotSupported {
+		t.Errorf("ON_CLOSE without FILE_DELETE_ON_CLOSE = %v, want STATUS_NOT_SUPPORTED", got)
+	}
+
+	// Control: the same flags on a handle opened delete-on-close are accepted.
+	if got := set(open("doc-present", types.FileDeleteOnClose)); got != types.StatusSuccess {
+		t.Errorf("ON_CLOSE on a delete-on-close handle = %v, want STATUS_SUCCESS", got)
+	}
+}
+
+// TestSetInfo_Rename_RefusedWhenDeletePending pins MS-FSA 2.1.5.15.12: "If
+// Open.Link.IsDeleted is TRUE, the operation MUST be failed with
+// STATUS_ACCESS_DENIED."
+func TestSetInfo_Rename_RefusedWhenDeletePending(t *testing.T) {
+	h, ctx, _ := setupStreamsDisabledShare(t, false)
+
+	rename := func(fid [16]byte, to string) types.Status {
+		t.Helper()
+		resp, err := h.SetInfo(ctx, &SetInfoRequest{
+			InfoType:      types.SMB2InfoTypeFile,
+			FileInfoClass: uint8(types.FileRenameInformation),
+			FileID:        fid,
+			Buffer:        encodeRenameInfo(to),
+		})
+		if err != nil {
+			t.Fatalf("SetInfo rename: %v", err)
+		}
+		return resp.Status
+	}
+
+	// Control: a rename with no disposition set succeeds, so the refusal below
+	// cannot be an artifact of the rename path being broken outright.
+	if got := rename(dirTestCreate(t, h, ctx, "live", types.FileOpenIf, types.FileNonDirectoryFile), "live-moved"); got != types.StatusSuccess {
+		t.Fatalf("rename of a live link = %v, want STATUS_SUCCESS", got)
+	}
+
+	doomed := dirTestCreate(t, h, ctx, "doomed", types.FileOpenIf, types.FileNonDirectoryFile)
+	dispResp, err := h.SetInfo(ctx, &SetInfoRequest{
+		InfoType:      types.SMB2InfoTypeFile,
+		FileInfoClass: uint8(types.FileDispositionInformation),
+		FileID:        doomed,
+		Buffer:        encodeDispositionInfo(true),
+	})
+	if err != nil {
+		t.Fatalf("SetInfo disposition: %v", err)
+	}
+	if dispResp.Status != types.StatusSuccess {
+		t.Fatalf("disposition = %v, want STATUS_SUCCESS", dispResp.Status)
+	}
+
+	if got := rename(doomed, "doomed-moved"); got != types.StatusAccessDenied {
+		t.Errorf("rename of a link marked deleted = %v, want STATUS_ACCESS_DENIED", got)
+	}
+}
+
+// TestSetInfo_SetAllocation_RequiresWriteData pins MS-FSA 2.1.5.15.1: "If
+// Open.GrantedAccess does not contain FILE_WRITE_DATA, the operation MUST be
+// failed with STATUS_ACCESS_DENIED."
+func TestSetInfo_SetAllocation_RequiresWriteData(t *testing.T) {
+	h, ctx, _ := setupStreamsDisabledShare(t, false)
+
+	open := func(name string, access uint32) [16]byte {
+		t.Helper()
+		resp, err := h.Create(ctx, &CreateRequest{
+			FileName:          name,
+			DesiredAccess:     access,
+			FileAttributes:    types.FileAttributeNormal,
+			ShareAccess:       0x07,
+			CreateDisposition: types.FileOpenIf,
+			CreateOptions:     types.FileNonDirectoryFile,
+		})
+		if err != nil {
+			t.Fatalf("Create(%q): %v", name, err)
+		}
+		if resp.Status != types.StatusSuccess {
+			t.Fatalf("Create(%q) = %v, want STATUS_SUCCESS", name, resp.Status)
+		}
+		return resp.FileID
+	}
+
+	setAlloc := func(fid [16]byte) types.Status {
+		t.Helper()
+		resp, err := h.SetInfo(ctx, &SetInfoRequest{
+			InfoType:      types.SMB2InfoTypeFile,
+			FileInfoClass: uint8(types.FileAllocationInformation),
+			FileID:        fid,
+			Buffer:        encodeAllocationInfo(4096),
+		})
+		if err != nil {
+			t.Fatalf("SetInfo allocation: %v", err)
+		}
+		return resp.Status
+	}
+
+	readOnly := uint32(types.FileReadData) | uint32(types.FileReadAttributes)
+	if got := setAlloc(open("alloc-ro", readOnly)); got != types.StatusAccessDenied {
+		t.Errorf("SetAlloc without FILE_WRITE_DATA = %v, want STATUS_ACCESS_DENIED", got)
+	}
+
+	// Control: the same call on a writable handle is accepted.
+	if got := setAlloc(open("alloc-rw", secRightsFileAll)); got != types.StatusSuccess {
+		t.Errorf("SetAlloc on a writable handle = %v, want STATUS_SUCCESS", got)
+	}
+}

--- a/internal/adapter/smb/types/constants.go
+++ b/internal/adapter/smb/types/constants.go
@@ -774,12 +774,15 @@ const (
 // FILE_DISPOSITION_INFORMATION_EX Flags field.
 // [MS-FSCC] Section 2.4.12
 const (
-	// FileDispositionDelete marks the link for deletion; when clear, no flag is
-	// set and the file MUST NOT be deleted.
+	// FileDispositionDelete marks the link for deletion. Clearing it does not by
+	// itself clear the other flags; MS-FSCC names the all-zero Flags word
+	// FILE_DISPOSITION_DO_NOT_DELETE_FILE, which is what cancels a pending
+	// deletion.
 	FileDispositionDelete uint32 = 0x00000001
-	// FileDispositionOnClose updates the FILE_DELETE_ON_CLOSE state. If set on a
-	// file that was not opened with FILE_DELETE_ON_CLOSE, the operation MUST
-	// return STATUS_NOT_SUPPORTED.
+	// FileDispositionOnClose selects delete-on-close semantics for the request.
+	// The handler acts on it only to refuse with STATUS_NOT_SUPPORTED when it is
+	// set on a file not opened with FILE_DELETE_ON_CLOSE; it carries no separate
+	// state here, since the disposition itself rides on FileDispositionDelete.
 	FileDispositionOnClose uint32 = 0x00000008
 	// FileDispositionIgnoreReadonlyAttribute permits deleting a file carrying
 	// READ_ONLY. Without it, deleting a read-only file MUST return

--- a/internal/adapter/smb/types/constants.go
+++ b/internal/adapter/smb/types/constants.go
@@ -767,7 +767,12 @@ const (
 	CipherAES256GCM uint16 = 0x0004
 )
 
-// FILE_DISPOSITION_INFORMATION_EX Flags field [MS-FSCC] 2.4.12.
+// =============================================================================
+// File Disposition Flags
+// =============================================================================
+
+// FILE_DISPOSITION_INFORMATION_EX Flags field.
+// [MS-FSCC] Section 2.4.12
 const (
 	// FileDispositionDelete marks the link for deletion; when clear, no flag is
 	// set and the file MUST NOT be deleted.

--- a/internal/adapter/smb/types/constants.go
+++ b/internal/adapter/smb/types/constants.go
@@ -766,3 +766,18 @@ const (
 	// CipherAES256GCM is AES-256 in GCM mode.
 	CipherAES256GCM uint16 = 0x0004
 )
+
+// FILE_DISPOSITION_INFORMATION_EX Flags field [MS-FSCC] 2.4.12.
+const (
+	// FileDispositionDelete marks the link for deletion; when clear, no flag is
+	// set and the file MUST NOT be deleted.
+	FileDispositionDelete uint32 = 0x00000001
+	// FileDispositionOnClose updates the FILE_DELETE_ON_CLOSE state. If set on a
+	// file that was not opened with FILE_DELETE_ON_CLOSE, the operation MUST
+	// return STATUS_NOT_SUPPORTED.
+	FileDispositionOnClose uint32 = 0x00000008
+	// FileDispositionIgnoreReadonlyAttribute permits deleting a file carrying
+	// READ_ONLY. Without it, deleting a read-only file MUST return
+	// STATUS_CANNOT_DELETE.
+	FileDispositionIgnoreReadonlyAttribute uint32 = 0x00000010
+)

--- a/pkg/metadata/auth_permissions.go
+++ b/pkg/metadata/auth_permissions.go
@@ -925,12 +925,16 @@ func (s *Service) CheckFileAccessWithParentGeneric(file *File, parent *File, aut
 	evalCtx := buildFileAccessEvalContext(file, authCtx)
 	granted := acl.EvaluateGranted(file.ACL, evalCtx, explicit)
 
-	// MS-FSA §2.1.5.1.2.1 "Algorithm to Check Access to an Existing File"
-	// grants FILE_READ_ATTRIBUTES from the containing directory, conditional on
-	// AccessCheck(parent, FILE_LIST_DIRECTORY) returning TRUE. This grants it
-	// unconditionally once traverse access to the path succeeds, so the bit is
-	// unmasked from the file's DACL evaluation — even a DACL that explicitly
-	// omits READ_ATTRIBUTES still yields a successful open requesting it.
+	// MS-FSA §2.1.5.1.2.1 "Algorithm to Check Access to an Existing File" adds
+	// FILE_READ_ATTRIBUTES when AccessCheck(parent, FILE_LIST_DIRECTORY) returns
+	// TRUE. That clause follows the file-DACL loop and only ever adds the bit —
+	// it is an override in the same shape as the DELETE-via-parent clause above
+	// it, not a gate over what the file's own DACL already granted. This grants
+	// the bit unconditionally once traverse access succeeds, so it is unmasked
+	// from the file's DACL evaluation — even a DACL that explicitly omits
+	// READ_ATTRIBUTES still yields a successful open requesting it. The two
+	// differ only where the file DACL denies the bit and the parent denies
+	// FILE_LIST_DIRECTORY.
 	//
 	// Mirrors Samba source3/smbd/open.c::smbd_check_access_rights_fsp which
 	// sets `do_not_check_mask = FILE_READ_ATTRIBUTES` before invoking the


### PR DESCRIPTION
Closes #2172.

Fixes three of the six divergences in #2172. The other three are triaged in a comment there: two
were split out as #2181 and #2182, and one was withdrawn as my own misreading of the spec.

These three are the unambiguous MUSTs with no plausible Samba-parity defence. The conformance-risky
ones are deliberately **not** bundled in, so a red suite here points at one change rather than four.

## 1. `FileDispositionInformationEx` read only bit 0 of its Flags field

MS-FSCC §2.4.12 defines five flags. The handler read `flags & 0x01` and discarded the rest, so:

- **`FILE_DISPOSITION_IGNORE_READONLY_ATTRIBUTE` (0x10) did nothing.** The spec: *"If set, allows
  files with the READ_ONLY attribute to be deleted anyway. Without this flag, deleting a read-only
  file MUST return STATUS_CANNOT_DELETE."* DittoFS implemented the MUST-refuse half and not the
  documented escape hatch, so a client sending `DELETE|IGNORE_READONLY` (`0x11`) against a
  read-only file got `STATUS_CANNOT_DELETE`.
- **`FILE_DISPOSITION_ON_CLOSE` (0x08) was never checked.** The spec requires
  `STATUS_NOT_SUPPORTED` when it is set on a handle not opened `FILE_DELETE_ON_CLOSE`.

`FILE_DISPOSITION_POSIX_SEMANTICS` (0x02) stays accepted-and-unimplemented — honouring it means
keeping data streams readable through other handles after the link is unlinked, which is a feature,
not a gate. It is now stated in the code instead of being silently ignored.

The 1-byte `FileDispositionInformation` (class 13) shares this arm and carries no flags, so it can
never reach the waiver; the read-only refusal is unchanged for it.

## 2. Rename never checked `Open.Link.IsDeleted`

MS-FSA §2.1.5.15.12: *"If Open.Link.IsDeleted is TRUE, the operation MUST be failed with
STATUS_ACCESS_DENIED."* There was no such check — the rename succeeded and then cleared the
disposition.

**The subtle part is which field is the analogue.** It is the disposition set through SET_INFO
(`DeletePending`), not the `FILE_DELETE_ON_CLOSE` create option. That option is held per-handle as
`InitialDeleteOnClose` and promoted to `DeletePending` only during the CLOSE election, matching
§2.1.5.5 phase 1 — `doc_election.go` says so in as many words, and the reason is
`smb2.dirlease.unlink_*_initial_and_close`.

Conflating them would make every delete-on-close handle un-renameable, which is the one plausible
regression this change could cause, so it has its own test
(`TestSetInfo_Rename_AllowedOnDeleteOnCloseHandle`) that fails if the two are OR-ed together.

**Review caught that my first version was under-inclusive.** It read `openFile.IsDeletePending()`
— this open's own flag. But `IsDeleted` belongs to the *link*, and a disposition committed on one
handle is not copied onto its siblings until the CLOSE election runs, so a second open of the same
file still reported false and its rename went through. It now uses `h.isFileDeletePending()`, the
cross-handle scan the CREATE gate already relies on — which is also deliberately blind to
`InitialDeleteOnClose`, so widening the gate does not reintroduce the conflation above.
`TestSetInfo_Rename_RefusedOnSecondHandleWhenDeletePending` pins it, and goes red against my own
original single-handle version.

## 3. `FileAllocationInformation` had no access check at all

The `FILE_WRITE_ATTRIBUTES` gate in `SetInfo` exempts a list of classes on the stated grounds that
they "have specific access checks in their handlers". `FileAllocationInformation` was on that list
and had none — the only authorization in the arm is a `WriteAuthorizedByHandle` assignment on the
truncating branch. MS-FSA §2.1.5.15.1: *"If Open.GrantedAccess does not contain FILE_WRITE_DATA,
the operation MUST be failed with STATUS_ACCESS_DENIED."*

**The gate is placed before the Level-II lease break, not after.** That ordering is the part worth
reviewing: previously a handle with no write access could still fire `BreakReadLeasesOnWrite` and
invalidate another client's cached read state, which is a denial-of-service shape rather than a
tidiness issue.

## Every test was run against a broken build first

Two agents in the current batch shipped tests that passed against the exact bug they were written
to catch, so each gate here was removed and its test observed to fail before the test was trusted:

| mutation | test | result |
| --- | --- | --- |
| read-only waiver forced off | `..._IgnoreReadonlyAttribute` | RED |
| `ON_CLOSE` check → `if false` | `..._OnCloseRequiresDeleteOnClose` | RED |
| rename guard → `if false` | `..._Rename_RefusedWhenDeletePending` | RED |
| `FILE_WRITE_DATA` gate → `if false` | `..._SetAllocation_RequiresWriteData` | RED |
| `IsDeletePending() \|\| InitialDeleteOnClose` (the conflation) | `..._Rename_AllowedOnDeleteOnCloseHandle` | RED |
| rename gate reverted to the single-handle `openFile.IsDeletePending()` | `..._Rename_RefusedOnSecondHandleWhenDeletePending` | RED |

All green with the gates restored. Every test also carries a control case taking the opposite
branch, so none can pass by the gate simply never being reached.

## Also here: one comment correction from the citation audit

#2174 added a comment in `pkg/metadata/auth_permissions.go` describing MS-FSA §2.1.5.1.2.1's
`FILE_READ_ATTRIBUTES` clause as *conditional* on `AccessCheck(parent, FILE_LIST_DIRECTORY)`. It is
not — the clause follows the file-DACL loop, has no `else` and no masking step, and only ever
**adds** the bit. It is an override in the same shape as the DELETE-via-parent clause directly above
it, which this codebase already implements as an override.

That misreading is what produced item 6 of #2172, now withdrawn: the real divergence is confined to
the case where the file DACL denies the bit *and* the parent denies `FILE_LIST_DIRECTORY`, and the
current unconditional grant is load-bearing for `smb2.acls.OWNER`. A mischaracterised spec clause is
the same defect class #2155 existed to remove, so it is corrected here rather than left standing.
