### PR TITLE
test(smbtorture): remove the rename_wait row, re-measured 10/10 across both filter conditions

### DIFF
--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -224,18 +224,16 @@ outstanding known failures in this category.
 
 ### Leases (Fix Candidate)
 
-Lease V2 is implemented but many smbtorture lease tests still fail due to
-incomplete break notification delivery and multi-client coordination.
+Lease V2 is implemented; no outstanding known failures in this category.
 
-The two rows below were not newly broken — they sit past the point where
-`smb2.lease` used to be cut short at 120s (it graded 25 of 45 tests), so they
-were being silently left ungraded rather than reported. Raising the budget made
-them visible; both fail identically on `memory` and `badger-fs`, so neither is a
-flake or a storage-backend artifact.
+The last two rows here (`v2_complex1`, `rename_wait`) were never newly broken —
+they sat past the point where `smb2.lease` used to be cut short at 120s (it
+graded 25 of 45 tests), so they were being left ungraded rather than reported.
+Raising the budget made them visible, and both have since been re-measured and
+removed; see the changelog.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| smb2.lease.rename_wait | Rename vs pending break | **Intermittent — measured 3/5 failures on `cf184bae`**, so a single green run means very little here. RENAME issued while a lease break is outstanding returns `NT_STATUS_INVALID_PARAMETER`; `lease.c:4160` requires `NT_STATUS_OK`. A deterministic bug does not pass 2 in 5, so the rate itself is evidence for the ordering race in #2127. Pre-existing; same cause of invisibility. | [#2114](https://github.com/marmos91/dittofs/issues/2114) |
 
 ### Sessions (Remaining)
 
@@ -366,6 +364,41 @@ These entries remain in CI's known-failure set (so they don't break the build) b
 `KNOWN_FAILURES_KERBEROS.md` now carries a single row (`smb2.reauth5`, an upstream Samba selftest knownfail) after the #686 Kerberos sweep harvested the stale multi-channel rows. It is loaded only when smbtorture runs with `--use-kerberos`, which the non-Kerberos v1.0 CI job (`.github/workflows/smb-conformance.yml`, running `./run.sh` without `--kerberos`) does not pass, so it does not gate v1.0.
 
 ## Changelog
+
+### 2026-08-26 — `rename_wait` removed: 10/10 pass, both filter conditions
+
+The row read "**Intermittent — measured 3/5 failures on `cf184bae`**". Re-measured
+on `41cab93ff`, which contains #2162 (per-connection response emission ordering):
+
+| condition | runs | result |
+| --- | --- | --- |
+| `--filter smb2.lease.rename_wait` — the condition the 3/5 was measured under | 5 | **5/5 pass** |
+| `--filter smb2.lease` — the whole family, 45 tests, share root carrying the suite's leftovers | 5 | **5/5 pass** |
+
+Graded on the verdict line only (`success: rename_wait`), as the 2026-08-25
+re-measurement was: single-filter mode drops the family prefix these patterns
+match on, so the harness's own known-failure accounting is not usable at this
+granularity. Provenance checked on the image the runs actually used —
+`strings /app/dfs` finds `releaseResponseOrder` and `RequestOrder`, both of which
+arrive with #2162 and are absent before it.
+
+**The claim is "not reproduced in 10 runs under the condition that previously
+produced 3/5", not "proven fixed".** A race that stops reproducing is not a race
+proven absent. The row goes because a known-failure list records observed
+failures and there is no longer one to record — not because the race has been
+shown to be gone. If it returns, it returns as a flake report with a fresh count,
+not as a reinstated deterministic row.
+
+The plausible mechanism is #2162, and the argument for it is structural rather
+than measured: `set_info.go`'s rename branch now releases its response-order
+token after the break notification is written and before it waits for the
+acknowledgement, so the CREATE the test pipelines behind the rename cannot be
+answered ahead of the break the rename owes. That is exactly what the test needs
+at `lease.c:4402`, where it copies the ack's lease key straight out of
+`lease_break_info` immediately after that first CREATE returns — an all-zero key
+there is what the ownership gate refused with `INVALID_PARAMETER`. No A/B against
+a tree without #2162 was run, so #2162 is not credited on evidence stronger than
+that.
 
 ### 2026-08-25 — lease rows re-measured: `v2_complex1` removed, `rename_wait` corrected to intermittent
 

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -365,7 +365,7 @@ These entries remain in CI's known-failure set (so they don't break the build) b
 
 ## Changelog
 
-### 2026-08-26 — `rename_wait` removed: 10/10 pass, both filter conditions
+### 2026-08-26 — `rename_wait` removed: 12/12 pass across three conditions
 
 The row read "**Intermittent — measured 3/5 failures on `cf184bae`**". Re-measured
 on `41cab93ff`, which contains #2162 (per-connection response emission ordering):
@@ -374,6 +374,7 @@ on `41cab93ff`, which contains #2162 (per-connection response emission ordering)
 | --- | --- | --- |
 | `--filter smb2.lease.rename_wait` — the condition the 3/5 was measured under | 5 | **5/5 pass** |
 | `--filter smb2.lease` — the whole family, 45 tests, share root carrying the suite's leftovers | 5 | **5/5 pass** |
+| CI `smbtorture / memory` + `/ badger-fs` — unfiltered, 634 tests, no truncation | 2 | **2/2 pass** |
 
 Graded on the verdict line only (`success: rename_wait`), as the 2026-08-25
 re-measurement was: single-filter mode drops the family prefix these patterns
@@ -382,8 +383,8 @@ granularity. Provenance checked on the image the runs actually used —
 `strings /app/dfs` finds `releaseResponseOrder` and `RequestOrder`, both of which
 arrive with #2162 and are absent before it.
 
-**The claim is "not reproduced in 10 runs under the condition that previously
-produced 3/5", not "proven fixed".** A race that stops reproducing is not a race
+**The claim is "not reproduced in 12 runs, 5 of them under the exact condition
+that previously produced 3/5", not "proven fixed".** A race that stops reproducing is not a race
 proven absent. The row goes because a known-failure list records observed
 failures and there is no longer one to record — not because the race has been
 shown to be gone. If it returns, it returns as a flake report with a fresh count,

--- a/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
+++ b/test/smb-conformance/smbtorture/KNOWN_FAILURES.md
@@ -226,11 +226,12 @@ outstanding known failures in this category.
 
 Lease V2 is implemented; no outstanding known failures in this category.
 
-The last two rows here (`v2_complex1`, `rename_wait`) were never newly broken —
-they sat past the point where `smb2.lease` used to be cut short at 120s (it
-graded 25 of 45 tests), so they were being left ungraded rather than reported.
-Raising the budget made them visible, and both have since been re-measured and
-removed; see the changelog.
+The two rows this section used to carry, `v2_complex1` and `rename_wait`, were
+never newly broken: they sat past the point where `smb2.lease` used to be cut
+short at 120s (it graded 25 of 45 tests), so they were left ungraded rather than
+reported. Raising the budget made them visible, and each was then re-measured and
+removed — `v2_complex1` on 2026-08-25, `rename_wait` on 2026-08-26. Both
+measurements are in the changelog below.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|


### PR DESCRIPTION
## The premise was worth re-testing, and it did not hold

`KNOWN_FAILURES.md` carried `smb2.lease.rename_wait` as **"Intermittent — measured
3/5 failures on `cf184bae`"**. That rate is the whole reason the row survived the
2026-08-25 re-measurement, and it is also what made it worth re-running rather
than fixing: a deterministic bug does not pass 2 in 5, so the rate was itself
evidence for the ordering race split out as #2127 — and #2127 shipped today in
#2162.

Re-measured on `41cab93ff`. **12 runs, 12 passes, across three conditions:**

| condition | runs | result |
| --- | --- | --- |
| `--filter smb2.lease.rename_wait` — the exact condition the 3/5 was measured under | 5 | 5/5 pass |
| `--filter smb2.lease` — the whole family, 45 tests, share root carrying the suite's own leftovers | 5 | 5/5 pass |
| CI `smbtorture / memory` + `/ badger-fs` on #2183 — unfiltered, 634 tests, no truncation | 2 | 2/2 pass |

All three were run because no one of them is enough. The isolated filter is
what the 3/5 was measured under, so it is the comparable number; but it leaves the
share root nearly empty, which is materially easier than what CI does, and a green
5/5 under easier-than-CI conditions would be worth very little on its own.

Graded on the verdict line only (`success: rename_wait`), the same way the
2026-08-25 measurement was graded: single-filter mode drops the family prefix these
patterns match on, so the harness's own known-failure accounting is not usable at
this granularity and a documented row can report as a *new* failure in a narrowed
run.

Provenance checked on the image the runs actually used, not on the checkout:
`strings /app/dfs` finds `releaseResponseOrder` (1) and `RequestOrder` (5), both of
which arrive with #2162 and are absent before it.

## What is and is not being claimed

**"Not reproduced in 12 runs, 5 of them under the exact condition that previously
produced 3/5."**
Not "proven fixed". A race that stops reproducing is not a race proven absent, and
this file has already burned one attribution on treating a single green draw as a
measurement (see the 2026-08-25 entry, which walked back exactly that).

The row goes because a known-failure list records *observed* failures and there is
no longer one to record. If it comes back it comes back as a flake report with a
fresh count, not as a reinstated deterministic row.

#2162 is the plausible mechanism, and that argument is structural rather than
measured — no A/B against a tree without #2162 was run, so it is not credited on
anything stronger. `set_info.go:1116` releases the rename's response-order token
after the break notification has been written and before it waits for the
acknowledgement, so the CREATE the test pipelines behind the rename cannot be
answered ahead of the break the rename owes. That is precisely what the test needs:
at `lease.c:4402` it copies the ack's lease key straight out of `lease_break_info`
immediately after that first CREATE returns, *before* its three retry creates — so
a break that arrives later than that CREATE's response leaves the ack carrying an
all-zero key, which is what the ownership gate refused with `INVALID_PARAMETER`.
The comment at that release site names `lease.rename_wait` explicitly.

Also worth recording: the issue's original title was wrong and the file's row text
inherited it. It is not the rename that returns `INVALID_PARAMETER` —
`lease.c:4160` is the `CHECK_STATUS` on the lease **break acknowledgement**. That
was established in the issue's own first comment; the row text was never corrected
to match, and is now removed rather than reworded.

## Note on CI coverage for this PR

This change is Markdown-only, so `smb-conformance.yml`'s `paths-ignore` skips both
conformance jobs here — this PR's own CI cannot grade the removal. The evidence is
the 10 local runs above plus the two CI draws on #2183, a code PR on the same base
that does run them — both logged `success: lease.rename_wait` with
`Suites cut short: 0`.

Closes #2114
