### PR TITLE
fix(clone): clip a local-only clone's destination past the source's size

### DIFF
--- a/internal/adapter/common/clone.go
+++ b/internal/adapter/common/clone.go
@@ -295,6 +295,38 @@ func materializeLocalClone(
 		return fmt.Errorf("materialize clone: drain dst rollups: %w", err)
 	}
 
+	// The copy wrote only [0, srcSize). Whatever the destination held past that
+	// is still there: the write path supersedes by version, it does not clip, so
+	// a destination that was longer than the source keeps its tail. The size
+	// stamped below hides it from every read that clamps — until something grows
+	// the file again, and the destination serves bytes it is supposed to have
+	// lost where a grown region owes zeros. That is the size-down whose tail
+	// nothing reclaims, which ReclaimTruncatedBlocks exists to stop for every
+	// protocol that shrinks a file; this path shrinks one and never drove it.
+	//
+	// Truncate is what clips all of it: it narrows a row that straddles the new
+	// size, reaps by exact "{payloadID}/{offset}" identity any row starting past
+	// it, and clips the local tier's intervals. The narrow is the load-bearing
+	// half here, not the reap — the overwrite re-marks the surviving fragment
+	// dirty, so the carve above emits one row spanning the copied content and
+	// the tail rather than leaving a separate row for the tail to reap. A reap
+	// keyed on offsets the copy did not take over would find nothing to do.
+	//
+	// It runs after the carve, so it clips the manifest the carve just wrote,
+	// and before the size below, so nothing observes a size the content no
+	// longer matches. The returned list is dropped for the same reason
+	// ReclaimTruncatedBlocks drops it: Truncate reprojects File.Blocks from the
+	// rows that survived, and the transaction below re-reads them.
+	dstPre, err := metadataStore.GetFile(ctx, dstHandle)
+	if err != nil {
+		return fmt.Errorf("materialize clone: fetch dst file: %w", err)
+	}
+	if srcFile.Size < dstPre.Size {
+		if _, err := blockStore.Truncate(ctx, string(dstPayloadID), dstPre.Blocks, srcFile.Size); err != nil {
+			return fmt.Errorf("materialize clone: clip dst past the source's size: %w", err)
+		}
+	}
+
 	// Block-level WriteAt does not set File.Size / Mtime / Ctime — stamp them on
 	// the destination to match the source and record the content change. The
 	// carve above already populated File.Blocks, so re-read inside the txn and

--- a/internal/adapter/common/clone_localonly_tail_test.go
+++ b/internal/adapter/common/clone_localonly_tail_test.go
@@ -1,0 +1,181 @@
+package common
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/block/local/fs"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// newLocalOnlyTestEngine builds a journal-backed engine with no remote, so
+// CloneWholeFile takes materializeLocalClone rather than the manifest-only
+// reflink. The engine's own tests cover the remote-backed path; this fixture is
+// the only way to reach the local-only one.
+func newLocalOnlyTestEngine(t *testing.T, coord *fakeCoordinator, ms *metadatamemory.MemoryMetadataStore) (*engine.Store, *fs.FSStore) {
+	t.Helper()
+	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{})
+	if err != nil {
+		t.Fatalf("fs.NewWithOptions failed: %v", err)
+	}
+	syncedHashStore, ok := metadata.Store(ms).(metadata.SyncedHashStore)
+	if !ok {
+		t.Fatalf("metadata store %T does not implement metadata.SyncedHashStore", ms)
+	}
+	syncer := engine.NewSyncer(localStore, nil, ms, engine.DefaultConfig())
+	syncer.SetSyncedHashStore(syncedHashStore)
+	bs, err := engine.New(engine.BlockStoreConfig{
+		Local:           localStore,
+		Syncer:          syncer,
+		FileChunkStore:  ms,
+		Coordinator:     coord,
+		SyncedHashStore: syncedHashStore,
+	})
+	if err != nil {
+		t.Fatalf("engine.New failed: %v", err)
+	}
+	if err := bs.Start(context.Background()); err != nil {
+		t.Fatalf("engine.Start failed: %v", err)
+	}
+	t.Cleanup(func() { _ = bs.Close() })
+	return bs, localStore
+}
+
+// writeAndSeal writes one payload's whole content and seals it into the
+// manifest the way a normal write plus commit does.
+func writeAndSeal(t *testing.T, ctx context.Context, bs *engine.Store, payloadID string, data []byte) {
+	t.Helper()
+	if _, err := bs.WriteAt(ctx, payloadID, nil, data, 0); err != nil {
+		t.Fatalf("WriteAt(%s): %v", payloadID, err)
+	}
+	if _, err := bs.Flush(ctx, payloadID); err != nil {
+		t.Fatalf("Flush(%s): %v", payloadID, err)
+	}
+	if err := bs.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups: %v", err)
+	}
+}
+
+// TestMaterializeLocalClone_KeepsNothingPastTheSourcesSize pins the half of the
+// clone contract the local-only path used to leave undone.
+//
+// That path copies real bytes over [0, srcSize) and lets the write path
+// supersede the destination's own intervals by version. Superseding is not
+// clipping, so a destination that was longer than the source keeps everything
+// past srcSize — interval, manifest row and all. The size stamped on the
+// destination hides it from every read that clamps, which is why it stays
+// invisible until something grows the file: a grown region owes zeros, and the
+// destination would serve the bytes the clone was supposed to take away.
+//
+// The assertions are on both tiers deliberately. Clipping only the local tier
+// would leave a row claiming bytes the file no longer has, and the two tiers
+// disagreeing about who owns a range is its own defect — one that reads as a
+// mosaic rather than as a clean stale read.
+func TestMaterializeLocalClone_KeepsNothingPastTheSourcesSize(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	bs, _ := newLocalOnlyTestEngine(t, &fakeCoordinator{}, ms)
+
+	const srcSize, dstSize = 4096, 8192
+	source := bytes.Repeat([]byte{0x11}, srcSize)
+	replaced := bytes.Repeat([]byte{0x22}, dstSize)
+
+	srcHandle := putTestFile(t, ms, "/tail-src.bin", "tail-src-pid", nil, srcSize)
+	dstHandle := putTestFile(t, ms, "/tail-dst.bin", "tail-dst-pid", nil, dstSize)
+	writeAndSeal(t, ctx, bs, "tail-src-pid", source)
+	writeAndSeal(t, ctx, bs, "tail-dst-pid", replaced)
+
+	if err := CloneWholeFile(ctx, bs, ms, nil, srcHandle, dstHandle, "tail-dst-pid"); err != nil {
+		t.Fatalf("CloneWholeFile: %v", err)
+	}
+
+	// The tail is the defect: past the source's size the destination must hold
+	// nothing, so the block store zero-fills it the way it does any range a file
+	// never had.
+	tail := make([]byte, dstSize-srcSize)
+	if _, err := bs.ReadAt(ctx, "tail-dst-pid", tail, srcSize); err != nil {
+		t.Fatalf("ReadAt(dst) past the source's size: %v", err)
+	}
+	if bytes.Equal(tail, replaced[srcSize:]) {
+		t.Error("past the source's size the destination still serves the content the clone replaced")
+	}
+	if !bytes.Equal(tail, make([]byte, len(tail))) {
+		t.Errorf("past the source's size the destination served %x…, want zeros", tail[:8])
+	}
+
+	// The control: the clip must take the tail and nothing else. Without this a
+	// clip that emptied the destination outright would pass the assertion above.
+	head := make([]byte, srcSize)
+	if _, err := bs.ReadAt(ctx, "tail-dst-pid", head, 0); err != nil {
+		t.Fatalf("ReadAt(dst) over the copied range: %v", err)
+	}
+	if !bytes.Equal(head, source) {
+		t.Error("the destination does not hold the content the clone gave it")
+	}
+
+	// The other tier: no row may go on claiming bytes the file no longer has.
+	for _, r := range mustListChunks(t, ctx, ms, "tail-dst-pid") {
+		off, ok := block.ParseChunkOffset(r.ID)
+		if !ok {
+			continue
+		}
+		if end := off + uint64(r.DataSize); end > srcSize {
+			t.Errorf("row %s claims [%d, %d), past the destination's new size %d", r.ID, off, end, srcSize)
+		}
+	}
+
+	// The source is a bystander: the clip is the destination's, and reading the
+	// source back proves the fixture is not simply broken for every payload.
+	srcBack := make([]byte, srcSize)
+	if _, err := bs.ReadAt(ctx, "tail-src-pid", srcBack, 0); err != nil {
+		t.Fatalf("ReadAt(src): %v", err)
+	}
+	if !bytes.Equal(srcBack, source) {
+		t.Error("the clone disturbed the source")
+	}
+}
+
+// TestMaterializeLocalClone_GrowsWithoutClipping is the other direction, and
+// what keeps the clip from ever being the thing that loses content: a source
+// longer than the destination grows it, and every copied byte must survive.
+func TestMaterializeLocalClone_GrowsWithoutClipping(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	bs, _ := newLocalOnlyTestEngine(t, &fakeCoordinator{}, ms)
+
+	const srcSize, dstSize = 8192, 4096
+	source := bytes.Repeat([]byte{0x33}, srcSize)
+
+	srcHandle := putTestFile(t, ms, "/grow-src.bin", "grow-src-pid", nil, srcSize)
+	dstHandle := putTestFile(t, ms, "/grow-dst.bin", "grow-dst-pid", nil, dstSize)
+	writeAndSeal(t, ctx, bs, "grow-src-pid", source)
+	writeAndSeal(t, ctx, bs, "grow-dst-pid", bytes.Repeat([]byte{0x44}, dstSize))
+
+	if err := CloneWholeFile(ctx, bs, ms, nil, srcHandle, dstHandle, "grow-dst-pid"); err != nil {
+		t.Fatalf("CloneWholeFile: %v", err)
+	}
+
+	back := make([]byte, srcSize)
+	if _, err := bs.ReadAt(ctx, "grow-dst-pid", back, 0); err != nil {
+		t.Fatalf("ReadAt(dst): %v", err)
+	}
+	if !bytes.Equal(back, source) {
+		t.Error("the destination does not hold the whole source after a clone that grew it")
+	}
+}
+
+func mustListChunks(t *testing.T, ctx context.Context, ms *metadatamemory.MemoryMetadataStore, payloadID string) []*block.FileChunk {
+	t.Helper()
+	rows, err := ms.ListFileChunks(ctx, payloadID)
+	if err != nil {
+		t.Fatalf("ListFileChunks(%s): %v", payloadID, err)
+	}
+	if len(rows) == 0 {
+		t.Fatalf("%s carved no rows, so the row assertion would hold vacuously", payloadID)
+	}
+	return rows
+}


### PR DESCRIPTION
A local-only clone copies real bytes over `[0, srcSize)` through the normal
write path, and the write path **supersedes by version — it does not clip**. A
destination that was longer than the source therefore keeps everything past
`srcSize`: the journal interval, the manifest row, and the `File.Blocks`
projection all still cover the tail. The size stamped on the destination hides
it from every read that clamps, which is why nothing has noticed.

Confirmed on a real engine before any change — journal-backed local tier, no
remote, source 4096 bytes of `0x11` onto a destination of 8192 bytes of `0x22`:

```
dst rows BEFORE clone: 1
dst extents AFTER clone (new size 4096): [[0 8192]]
  row ldst-pid/0 size=8192
dst size=4096 blocks=1
head is source(0x11)=true old-dst(0x22)=false
PREMISE HOLDS: tail past the new size still serves the destination's old bytes
```

The head is right; the tail is the destination's pre-clone content, and the row
claims all 8192 bytes of a file whose size is now 4096. Grow the file again —
`SETATTR` size-up, or a write past the new size — and the destination serves
bytes it was supposed to have lost, where POSIX owes zeros.

## This is not the shape #2160 was, and the fix is not the same

#2160's destination kept rows the copy never took over, at offsets of its own,
and the fix reaped them by exact `{payloadID}/{offset}` identity. **That reap
would find nothing to do here.** There is exactly one row, at offset 0, and it
is a row the copy legitimately keeps.

The reason is the overwrite itself: superseding `[0, 4096)` of an interval that
spans `[0, 8192)` leaves the surviving fragment `[4096, 8192)`, and
`remarkFragmentsDirty` re-marks it dirty so the carve re-chunks it. The carve
therefore emits **one** row spanning the copied content and the tail together,
rather than leaving a separate tail row for an identity reap to find. What the
tail needs is a **narrow**, not a reap — and that is a case identity cannot
express.

## The fix

There is already a single seam for exactly this defect.
`ReclaimTruncatedBlocks` exists so that "a later re-extend re-exposes the
discarded data as file content instead of a zero-filled hole (silent
data-integrity / info-leak bug)" cannot happen, and its doc says every protocol
that shrinks a file drives it "so the block-store truncate can never be
forgotten by one protocol while another gets it right". The local-only clone
shrinks a file and never drove it. That is the root cause.

So `materializeLocalClone` now clips the destination to the source's size
through `engine.Truncate`, which is what that seam drives. Truncate does all
three things the destination needs: it **narrows** the straddling row, reaps by
`{payloadID}/{offset}` identity any row that starts past the new size (the case
that appears once the old content carved into several chunks), and clips the
local tier's intervals so a later grow reads the zeros it owes. The returned
list is dropped for the same reason `ReclaimTruncatedBlocks` drops it — Truncate
reprojects `File.Blocks` from the surviving rows, and the transaction below
re-reads them.

It runs **after** the carve, so it clips the manifest the carve just wrote, and
**before** the size is stamped, so nothing observes a size the content no longer
matches. After rather than before the copy is deliberate: a failure earlier in
the copy then leaves the destination no worse off than it already was, and the
end state is identical either way.

Guarded on `srcFile.Size < dstPre.Size`, so a clone that grows the destination
skips a `ReprojectBlocks` transaction that would do nothing.

## Tests

Both were run against deliberately broken builds first and watched go red.

- `TestMaterializeLocalClone_KeepsNothingPastTheSourcesSize` — byte-level: the
  tail past the source's size must read as zeros and not as the replaced
  content; the head must still hold what the clone gave it (so a clip that
  emptied the destination cannot pass); no row may claim past the new size; and
  the source is a bystander that must read back intact.
- `TestMaterializeLocalClone_GrowsWithoutClipping` — the other direction, so the
  clip can never become the thing that loses content.

Three broken builds, each caught by a different assertion:

| broken build | what went red |
| --- | --- |
| no clip at all | tail serves `0x22`, **and** the row claims `[0, 8192)` |
| clip the local tier only (blocks not passed) | bytes fine — **only** the row assertion fires |
| clip to `0` instead of `srcSize` | the head no longer holds the copied content |

The middle row is the one worth keeping: clipping one tier and not the other
leaves the two disagreeing about who owns the range, which is the state that
reads as a mosaic rather than as a clean stale read. The row assertion is what
stands between this fix and that.

Closes #2176
