### PR TITLE
test(block): the copy's RefCount bump reaches nothing — #2177 refuted, not fixed

### DIFF
--- a/pkg/block/engine/copy_refcount_test.go
+++ b/pkg/block/engine/copy_refcount_test.go
@@ -1,0 +1,140 @@
+package engine_test
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/engine"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// refCounts returns each of a payload's rows' RefCount, keyed by row ID.
+func refCounts(t *testing.T, ctx context.Context, ms *metadatamemory.MemoryMetadataStore, payloadID string) map[string]uint32 {
+	t.Helper()
+	rows, err := ms.ListFileChunks(ctx, payloadID)
+	if err != nil {
+		t.Fatalf("ListFileChunks(%s): %v", payloadID, err)
+	}
+	if len(rows) == 0 {
+		t.Fatalf("%s has no rows, so the counts below would say nothing", payloadID)
+	}
+	out := make(map[string]uint32, len(rows))
+	for _, r := range rows {
+		out[r.ID] = r.RefCount
+	}
+	return out
+}
+
+// copyFixture writes and carves one source, and returns the engine, the store,
+// the two payload IDs and the ChunkRef list a copy would hand the destination.
+func copyFixture(t *testing.T) (*engine.Store, *metadatamemory.MemoryMetadataStore, string, string, []block.ChunkRef) {
+	t.Helper()
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	bs, _ := openOfflineEngine(t, t.TempDir(), ms, remotememory.New())
+	t.Cleanup(func() { _ = bs.Close() })
+
+	root := createShare(t, ms, "refcount")
+	src, _ := createRealFile(t, ms, "refcount", "src.bin", root)
+	dst, _ := createRealFile(t, ms, "refcount", "dst.bin", root)
+
+	data := make([]byte, 2*1024*1024)
+	rand.New(rand.NewSource(5)).Read(data) //nolint:gosec // deterministic fixture
+	if _, err := bs.WriteAt(ctx, src, nil, data, 0); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	carve(t, bs, ctx, src)
+
+	var refs []block.ChunkRef
+	for _, r := range manifestRefs(t, ms, src) {
+		if !r.Hash.IsZero() {
+			refs = append(refs, r)
+		}
+	}
+	if len(refs) == 0 {
+		t.Fatal("the source carved no placeable rows")
+	}
+	return bs, ms, src, dst, refs
+}
+
+// TestCopyPayload_RefCountIncrementIsUnreachable records why a repeated
+// server-side copy does not inflate any RefCount today, so nobody sets out to
+// fix a leak that cannot happen and reaches for the one fix that would break
+// something real.
+//
+// CopyPayload bumps RefCount once per unique source hash, and that bump is the
+// only RefCount increment the system has. It goes through the coordinator,
+// which resolves the hash with GetByHash — and every backend scopes GetByHash
+// to rows in the Remote state (memory checks IsRemote; sqlite and postgres both
+// spell it `state = 2`). Nothing in production ever puts a row in that state:
+// the carve path records its sync markers through SyncedHashStore and leaves
+// FileChunk.State at Pending for the life of the payload, which the syncer's
+// own size and existence checks already say in as many words. So the lookup
+// resolves nothing, the increment is skipped as a tolerated miss, and the count
+// stays where it started however many times the copy runs.
+func TestCopyPayload_RefCountIncrementIsUnreachable(t *testing.T) {
+	ctx := context.Background()
+	bs, ms, src, dst, refs := copyFixture(t)
+
+	before := refCounts(t, ctx, ms, src)
+	for i := 1; i <= 3; i++ {
+		if _, err := bs.CopyPayload(ctx, src, dst, refs); err != nil {
+			t.Fatalf("CopyPayload #%d: %v", i, err)
+		}
+	}
+	for id, want := range before {
+		if got := refCounts(t, ctx, ms, src)[id]; got != want {
+			t.Errorf("row %s went from RefCount %d to %d over three copies; "+
+				"the increment is reachable after all, and it is not idempotent", id, want, got)
+		}
+	}
+}
+
+// TestCopyPayload_RefCountWouldInflateOnceReachable is the other half, and the
+// one that matters later: it opens the gate by hand and shows what the copy
+// does on the far side of it.
+//
+// With a source row moved to Remote, the coordinator's lookup resolves, the
+// increment lands, and each repeat of the same copy counts the hash one higher
+// with nothing to bring it back down — the copy's manifest work is idempotent
+// and its counting is not. If the carve path is ever changed to transition rows
+// to Remote, this test is what says the increment just came alive and still has
+// no way to tell a repeat from two files that happen to share a chunk.
+func TestCopyPayload_RefCountWouldInflateOnceReachable(t *testing.T) {
+	ctx := context.Background()
+	bs, ms, src, dst, refs := copyFixture(t)
+
+	rows, err := ms.ListFileChunks(ctx, src)
+	if err != nil {
+		t.Fatalf("ListFileChunks: %v", err)
+	}
+	opened := rows[0]
+	opened.State = block.BlockStateRemote
+	if err := ms.Put(ctx, opened); err != nil {
+		t.Fatalf("Put(%s) to open the gate: %v", opened.ID, err)
+	}
+	resolved, err := ms.GetByHash(ctx, opened.Hash)
+	if err != nil || resolved == nil {
+		t.Fatalf("the gate did not open: GetByHash(%x) = %v, %v", opened.Hash[:4], resolved, err)
+	}
+
+	before := refCounts(t, ctx, ms, src)[opened.ID]
+	for i := 1; i <= 3; i++ {
+		if _, err := bs.CopyPayload(ctx, src, dst, refs); err != nil {
+			t.Fatalf("CopyPayload #%d: %v", i, err)
+		}
+	}
+	after := refCounts(t, ctx, ms, src)[opened.ID]
+	if after <= before {
+		t.Fatalf("row %s stayed at RefCount %d with the gate open; "+
+			"this test no longer demonstrates anything", opened.ID, after)
+	}
+	if after != before+3 {
+		t.Errorf("row %s went from %d to %d over three copies, want %d — "+
+			"the copy counts once per run, so a repeat is what inflates it",
+			opened.ID, before, after, before+3)
+	}
+}

--- a/pkg/block/engine/copy_refcount_test.go
+++ b/pkg/block/engine/copy_refcount_test.go
@@ -66,8 +66,10 @@ func copyFixture(t *testing.T) (*engine.Store, *metadatamemory.MemoryMetadataSto
 // something real.
 //
 // CopyPayload bumps RefCount once per unique source hash, and that bump is the
-// only RefCount increment the system has. It goes through the coordinator,
-// which resolves the hash with GetByHash — and every backend scopes GetByHash
+// only production call site that raises one — the stores also expose AddRef and
+// a store-level IncrementRefCount, but nothing in production calls AddRef and
+// the coordinator this goes through is the only caller of the other. The
+// coordinator resolves the hash with GetByHash — and every backend scopes GetByHash
 // to rows in the Remote state (memory checks IsRemote; sqlite and postgres both
 // spell it `state = 2`). Nothing in production ever puts a row in that state:
 // the carve path records its sync markers through SyncedHashStore and leaves

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -585,6 +585,26 @@ func (bs *Store) CopyPayload(ctx context.Context, srcPayloadID, dstPayloadID str
 	// hashes (a single CAS object referenced by multiple ChunkRefs in
 	// the same file — file-level dedup) are bumped exactly
 	// once per CopyPayload call.
+	//
+	// ponytail: this is the only RefCount increment in the system and it
+	// currently reaches nothing. The coordinator resolves the hash with
+	// GetByHash, which every backend scopes to rows in the Remote state (memory
+	// checks IsRemote, sqlite and postgres both spell it `state = 2`), and no
+	// production path ever puts a row in that state — the carve records its
+	// sync markers through SyncedHashStore and leaves FileChunk.State at
+	// Pending for the life of the payload. So every call here is the tolerated
+	// miss below, and the count never moves.
+	//
+	// That is a ceiling, not a design: the counting is once per call and the
+	// rest of the copy is idempotent, so the moment rows do transition to
+	// Remote, a copy repeated for any reason counts its source's hashes one
+	// higher with nothing to bring them back down, and a count that only rises
+	// blocks reclamation of chunks nothing references. Whoever opens that gate
+	// owes this loop a way to tell a repeat of the same copy from two files
+	// that happen to share a chunk — the destination's existing rows cannot say
+	// which it is looking at, and skipping the bump for a hash the destination
+	// already holds counts DOWN on the dedup case, which is the dangerous
+	// direction. Both states are pinned by the copy-refcount tests.
 	seen := make(map[block.ContentHash]struct{}, len(srcBlocks))
 	for _, b := range srcBlocks {
 		if _, ok := seen[b.Hash]; ok {

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -586,14 +586,17 @@ func (bs *Store) CopyPayload(ctx context.Context, srcPayloadID, dstPayloadID str
 	// the same file — file-level dedup) are bumped exactly
 	// once per CopyPayload call.
 	//
-	// ponytail: this is the only RefCount increment in the system and it
-	// currently reaches nothing. The coordinator resolves the hash with
-	// GetByHash, which every backend scopes to rows in the Remote state (memory
-	// checks IsRemote, sqlite and postgres both spell it `state = 2`), and no
+	// ponytail: this is the only production call site that raises a RefCount,
+	// and it currently reaches nothing. The stores expose two ways to raise one
+	// — AddRef and a store-level IncrementRefCount — but nothing in production
+	// calls AddRef, and the coordinator this loop goes through is the only
+	// caller of the other. That coordinator resolves the hash with GetByHash,
+	// which every backend scopes to rows in the Remote state (memory checks
+	// IsRemote, sqlite and postgres both spell it `state = 2`), and no
 	// production path ever puts a row in that state — the carve records its
 	// sync markers through SyncedHashStore and leaves FileChunk.State at
 	// Pending for the life of the payload. So every call here is the tolerated
-	// miss below, and the count never moves.
+	// miss below, and no count moves.
 	//
 	// That is a ceiling, not a design: the counting is once per call and the
 	// rest of the copy is idempotent, so the moment rows do transition to


### PR DESCRIPTION
**The premise of #2177 does not hold, and this PR does not fix the leak —
because there is no leak to fix.** It records why, in code and in two tests, so
that the fix nobody should write does not get written later.

## What I went looking for

#2177 says a repeated server-side copy counts the source's hashes up every time
and never brings them down. `engine.CopyPayload` does bump `RefCount` once per
unique source hash while everything else it does is idempotent, so the shape of
the claim is right.

## What is actually true

That bump reaches nothing, on any backend, and never has.

The coordinator resolves the hash with `GetByHash`, and **every backend scopes
`GetByHash` to rows in the `Remote` state** — memory checks `IsRemote()`, sqlite
and postgres both spell it `state = 2 /* Remote */`, and sqlite's increment is
itself `UPDATE file_blocks SET ref_count = ref_count + 1 WHERE hash = ?1 AND
state = 2`. **No production path ever puts a row in that state.** The codebase
already says so twice, in comments written for other reasons:

> The carve path records synced markers via DefaultCommitBlock but never
> transitions FileChunk.State to BlockStateRemote (the row state remains
> Pending/Syncing for the life of the payload). The authoritative per-hash sync
> signal is therefore SyncedHashStore — not FileChunk.State.

So the lookup resolves nothing, `IncrementRefCount` returns
`ErrFileChunkNotFound`, and `CopyPayload` skips it as the tolerated miss it
already documents. The count never moves.

This is a structural kill, not a numeric one: `bs.coordinator.IncrementRefCount`
has exactly one production caller (this loop), its only implementation is gated
on a state transition no production code performs, and `AddRef` — the other way
a count could rise — has no production caller at all. Corroborated on a real
engine: three repeated copies, every row still `state=Pending refcount=0`.

## Why the obvious fix would have been actively harmful

Skipping the bump for a hash the destination already holds a row for makes a
repeat free. It also skips it when the destination genuinely held that hash
before the copy — cross-file dedup on a *first* run — which counts **down**.
Under-counting is the dangerous direction: a row reaped one decrement early is
data a file still needs. So the fix for a leak that cannot happen would have
traded it for corruption of a counter other things trust.

## What this PR leaves behind instead

- A `ponytail:` marker on the increment naming the ceiling (unreachable because
  rows never reach `Remote`; `SyncedHashStore` is the authoritative signal) and
  the upgrade path (whoever opens that gate owes this loop a way to tell a
  repeat from cross-file dedup, and the destination's rows cannot say which it
  is looking at).
- `TestCopyPayload_RefCountIncrementIsUnreachable` — three repeated copies leave
  every count where it started.
- `TestCopyPayload_RefCountWouldInflateOnceReachable` — moves one row to
  `Remote` by hand, confirms the lookup now resolves, and shows the count going
  up by exactly one per copy with nothing to bring it back. This is what makes
  the first test meaningful rather than vacuous, and it is what will fail the
  day someone turns the transition on without fixing the counting.

Verified against a deliberately broken build: opening the gate for every row in
the fixture makes the unreachability test fail with *"went from RefCount 0 to 3
over three copies; the increment is reachable after all, and it is not
idempotent."*

## Recommendation

#2177 should be closed as refuted rather than fixed, and this PR's marker and
tests are what carry the finding forward. The separate question this raises —
whether an increment that can never fire should exist at all, or whether the
`Remote` transition is itself the missing piece — is a design call I have not
made here.

Closes #2177
