### PR TITLE
fix(smb): stop bumping LastWriteTime on an attribute-only SET_INFO

### DIFF
--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -472,15 +472,6 @@ func (h *Handler) setFileInfoFromStore(
 			setAttrs.Ctime = &preFile.Ctime
 		}
 
-		// Per MS-FSA §2.1.5.15.2 ("FileBasicInformation"): When FileAttributes change, the object store
-		// SHOULD also update LastWriteTime. The metadata layer only auto-updates
-		// Ctime (POSIX semantics), so we handle Mtime auto-update here.
-		// Skip if: Mtime is being explicitly set, has a sentinel, or is frozen.
-		if fileAttrs != 0 && setAttrs.Mtime == nil && mtimeFT == 0 && !openFile.MtimeFrozen {
-			now := time.Now()
-			setAttrs.Mtime = &now
-		}
-
 		if _, err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, setAttrs); err != nil {
 			openFile.mu.Unlock() // release before returning; refs #606.
 			logger.Debug("SET_INFO: failed to set basic info", "path", openFile.Name().Path, "error", err)

--- a/internal/adapter/smb/handlers/set_info_timestamp_preservation_test.go
+++ b/internal/adapter/smb/handlers/set_info_timestamp_preservation_test.go
@@ -225,3 +225,66 @@ func TestSetInfo_BasicInfo_ExplicitSetThenSentinelUnfreeze(t *testing.T) {
 		t.Errorf("FrozenMtime not cleared after -2 unfreeze")
 	}
 }
+
+// TestSetInfo_BasicInfo_AttributeSetLeavesLastWriteTime covers the case the two
+// tests above do not: a handle that has never set a timestamp explicitly, so
+// nothing is frozen and the suppression guards do not apply. MS-FSA 2.1.5.15.2's
+// attribute branch updates LastChangeTime and never LastModificationTime, so an
+// attribute-only SET_INFO must leave Mtime where it was.
+func TestSetInfo_BasicInfo_AttributeSetLeavesLastWriteTime(t *testing.T) {
+	h, authCtx, fileHandle, open := setupBasicInfoTimestampTest(t)
+	metaSvc := h.Registry.GetMetadataService()
+
+	before, err := metaSvc.GetFile(authCtx.Context, fileHandle)
+	if err != nil {
+		t.Fatalf("GetFile before: %v", err)
+	}
+	wantMtime := before.Mtime
+	if open.MtimeFrozen {
+		t.Fatal("precondition: a fresh handle must not have Mtime frozen")
+	}
+
+	// Attribute-only set: every timestamp field zero ("do not change").
+	buf := encodeBasicInfo(0, 0, 0, 0, types.FileAttributeHidden)
+	resp, err := h.setFileInfoFromStore(nil, authCtx, open, types.FileBasicInformation, buf)
+	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
+		t.Fatalf("attribute-only setFileInfoFromStore: err=%v status=%v", err, resp)
+	}
+
+	after, err := metaSvc.GetFile(authCtx.Context, fileHandle)
+	if err != nil {
+		t.Fatalf("GetFile after: %v", err)
+	}
+	if !after.Mtime.Equal(wantMtime) {
+		t.Errorf("Mtime = %v after an attribute-only SET_INFO; want %v unchanged",
+			after.Mtime.UTC(), wantMtime.UTC())
+	}
+	// The attribute itself must still have landed, or the assertion above would
+	// pass simply because nothing happened.
+	if FileAttrToSMBAttributes(&after.FileAttr)&types.FileAttributeHidden == 0 {
+		t.Error("HIDDEN was not applied; the Mtime assertion above proves nothing")
+	}
+}
+
+// TestSetInfo_BasicInfo_ExplicitLastWriteTimeStillLands is the control for the
+// test above: removing the attribute-driven bump must not disturb an explicit
+// LastWriteTime set on an otherwise untouched handle.
+func TestSetInfo_BasicInfo_ExplicitLastWriteTimeStillLands(t *testing.T) {
+	h, authCtx, fileHandle, open := setupBasicInfoTimestampTest(t)
+	metaSvc := h.Registry.GetMetadataService()
+
+	wantWrite := time.Date(2032, 3, 4, 5, 6, 7, 0, time.UTC)
+	buf := encodeBasicInfo(0, 0, types.TimeToFiletime(wantWrite), 0, 0)
+	resp, err := h.setFileInfoFromStore(nil, authCtx, open, types.FileBasicInformation, buf)
+	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
+		t.Fatalf("explicit LastWriteTime setFileInfoFromStore: err=%v status=%v", err, resp)
+	}
+
+	file, err := metaSvc.GetFile(authCtx.Context, fileHandle)
+	if err != nil {
+		t.Fatalf("GetFile: %v", err)
+	}
+	if !file.Mtime.Equal(wantWrite) {
+		t.Errorf("Mtime = %v after an explicit set; want %v", file.Mtime.UTC(), wantWrite.UTC())
+	}
+}


### PR DESCRIPTION
Closes #2181.

MS-FSA 2.1.5.15.2's attribute branch updates exactly one timestamp:

> If Open.UserSetChangeTime is FALSE and InputBuffer.ChangeTime != -1, the object store MUST set
> Open.File.LastChangeTime to CurrentTime.

`LastModificationTime` appears in the section only under `If InputBuffer.LastWriteTime != 0`, i.e.
where the client sets it explicitly. The branch's one outbound call, 2.1.4.19, *copies* a
modification time rather than setting one; 2.1.4.17 is never invoked from here. The section's only
product note, `<179>`, is about FAT32 ignoring ChangeTime.

The handler bumped `Mtime` anyway, under a comment reading *"When FileAttributes change, the object
store SHOULD also update LastWriteTime."*

## That sentence is not in the specification

It arrived in `bb07b48a1` ("resolve 20+ WPTS known failures") attached to a citation of
`2.1.5.14.2` — a section that does not exist. #2174 then renumbered that citation to the real
`2.1.5.15.2` **without re-reading the claim underneath it**, and added the section's genuine title
alongside.

So the audit made this site *worse as evidence*: an invented quote that previously carried a
nonexistent section number — two things that might have tipped off a reader — ended up attached to
a number that resolves cleanly, with a correct title next to it. That is the "laundering" failure
mode now recorded as Rule 3 on #2179, and this is the site it was found at.

## What changes for users

Setting a DOS attribute (Hidden, ReadOnly) no longer advances mtime, so backup and sync tools stop
treating an attribute change as a content change. NTFS does not bump write time for this, and
neither does Samba.

It also removes a cross-protocol disagreement: `file_modify.go` already moves only ctime for the
NFS path, so the same logical operation reported different timestamps depending on which protocol
performed it.

## Risk, and what was checked

Low, but this is a conformance-visible change, so the evidence:

- The two existing tests in `set_info_timestamp_preservation_test.go` pin the **frozen** path —
  both assert `Mtime == <explicit value>`, which the suppression guards (`mtimeFT == 0`,
  `!openFile.MtimeFrozen`) already delivered. Neither exercised the branch being removed. They
  still pass.
- The WPTS timestamp cases named in `test/smb-conformance/KNOWN_FAILURES.md` —
  `FileInfo_Set_FileBasicInformation_Timestamp_MinusTwo_Dir_LastWriteTime` and
  `..._MinusOne_Dir_ChangeTime` — are `-1`/`-2` sentinel paths, which `mtimeFT == 0` already
  excluded from the bump. No KNOWN_FAILURES row mentions attribute-driven write-time behaviour.
- The adjacent ChangeTime-stickiness block is untouched. It implements the `Open.UserSetChangeTime`
  guard and is what `smb2.setinfo` (setinfo.c:203) asserts; that assertion is about ChangeTime, not
  LastWriteTime.

**Not verified against smbtorture/WPTS sources** — those are not available locally, so an unlisted
case asserting a write-time change on an attribute-only set cannot be fully excluded. The
conformance suites on this PR are the check. If one goes red I will report it rather than restore
the bump, since the bump has no specification behind it either way.

## Tests

Two new cases covering the path the existing ones do not — an unfrozen handle, where the bump
actually fired:

- `..._AttributeSetLeavesLastWriteTime` — attribute-only set leaves mtime alone, **and** asserts
  HIDDEN actually landed, so the timestamp assertion cannot pass by nothing having happened.
- `..._ExplicitLastWriteTimeStillLands` — control: an explicit LastWriteTime set still takes effect.

Restoring the removed block turns the first test red; it was run that way before being trusted.
