### PR TITLE
fix(smb): let rename update ChangeTime, keeping only an explicitly set one

### DIFF
--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -771,11 +771,6 @@ func (h *Handler) setFileInfoFromStore(
 			oldFileName := oldName.FileName
 			oldParentPath := GetParentPath(oldName.Path)
 
-			// Save mtime/ctime before the rename. MS-FSA 2.1.5.15.12 requires
-			// LastChangeTime to be updated; preserving it matches NTFS, which
-			// defers the update to handle close.
-			restoreTimestamps := h.saveTimestamps(authCtx, openFile.MetadataHandle)
-
 			// Perform the rename
 			metaSvc := h.Registry.GetMetadataService()
 			_, err = metaSvc.Move(authCtx, toDir, oldFileName, toDir, toName)
@@ -787,8 +782,11 @@ func (h *Handler) setFileInfoFromStore(
 				return setInfoStatus(common.MapToSMB(err)), nil
 			}
 
-			// Restore mtime/ctime after rename
-			restoreTimestamps()
+			// Move updates LastChangeTime, which MS-FSA 2.1.5.15.12 requires and
+			// which the old blanket save/restore reverted. Product note <187>
+			// exempts only a ChangeTime the user set explicitly, so restore just
+			// the sentinel-frozen fields rather than every stamp.
+			h.restoreFrozenTimestamps(authCtx, openFile)
 
 			// Clear delete-on-close after rename. Written under the handle
 			// lock: the delete-pending gates and the CLOSE delete-on-close
@@ -1183,12 +1181,6 @@ func (h *Handler) setFileInfoFromStore(
 		oldParentPath := GetParentPath(oldPath)
 		srcParentHandle := oldName.ParentHandle
 
-		// Save mtime/ctime before the rename so we can restore them after.
-		// MS-FSA 2.1.5.15.12 never touches LastModificationTime but does require
-		// LastChangeTime to be updated; preserving both matches NTFS, which
-		// defers that update to handle close.
-		restoreTimestamps := h.saveTimestamps(authCtx, openFile.MetadataHandle)
-
 		// Pre-overwrite the case-mismatched destination: Move's destination
 		// probe is exact-case GetChild(toName), so a destination that exists
 		// under a different casing (e.g. on disk "Foo.txt", client said
@@ -1213,8 +1205,11 @@ func (h *Handler) setFileInfoFromStore(
 			return setInfoStatus(common.MapToSMB(err)), nil
 		}
 
-		// Restore mtime/ctime after rename
-		restoreTimestamps()
+		// Move updates LastChangeTime, which MS-FSA 2.1.5.15.12 requires and which
+		// the old blanket save/restore reverted. Product note <187> exempts only a
+		// ChangeTime the user set explicitly, so restore just the sentinel-frozen
+		// fields rather than every stamp.
+		h.restoreFrozenTimestamps(authCtx, openFile)
 
 		// Per MS-FSA §2.1.5.15.2 ("FileBasicInformation"): Restore frozen timestamps on parent directories.
 		// Move updates both source and destination parent directory timestamps.
@@ -1767,28 +1762,6 @@ func applyFrozenTimestamps(openFile *OpenFile, file *metadata.File) {
 	}
 	if openFile.AtimeFrozen && openFile.FrozenAtime != nil {
 		file.Atime = *openFile.FrozenAtime
-	}
-}
-
-// saveTimestamps reads the current Mtime and Ctime of a file and returns a
-// restore function that writes them back. Used to preserve timestamps across
-// rename operations. MS-FSA 2.1.5.15.12 leaves LastModificationTime alone but
-// requires LastChangeTime to be updated; preserving both matches NTFS, which
-// defers that update to handle close.
-// Returns a no-op if the read fails.
-func (h *Handler) saveTimestamps(authCtx *metadata.AuthContext, handle metadata.FileHandle) func() {
-	metaSvc := h.Registry.GetMetadataService()
-	file, err := metaSvc.GetFile(authCtx.Context, handle)
-	if err != nil {
-		return func() {}
-	}
-	mtime := file.Mtime
-	ctime := file.Ctime
-	return func() {
-		_, _ = metaSvc.SetFileAttributes(authCtx, handle, &metadata.SetAttrs{
-			Mtime: &mtime,
-			Ctime: &ctime,
-		})
 	}
 }
 

--- a/internal/adapter/smb/handlers/set_info_rename_ctime_test.go
+++ b/internal/adapter/smb/handlers/set_info_rename_ctime_test.go
@@ -1,0 +1,113 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// TestSetInfo_Rename_UpdatesChangeTimeAndLeavesWriteTime pins MS-FSA 2.1.5.15.12:
+// "The object store MUST update Open.File.LastChangeTime." The section never
+// touches LastModificationTime, and Move already implements both halves — the
+// handler used to snapshot and write back both stamps, reverting the ctime
+// update the spec requires.
+func TestSetInfo_Rename_UpdatesChangeTimeAndLeavesWriteTime(t *testing.T) {
+	h, ctx, _ := setupStreamsDisabledShare(t, false)
+	metaSvc := h.Registry.GetMetadataService()
+	auth := dirTestAuthContext()
+
+	fileID := dirTestCreate(t, h, ctx, "before", types.FileOpenIf, types.FileNonDirectoryFile)
+	v, ok := h.files.Load(string(fileID[:]))
+	if !ok {
+		t.Fatal("open file not found after create")
+	}
+	handle := v.(*OpenFile).MetadataHandle
+
+	// Backdate both stamps directly rather than through SET_INFO: an explicit
+	// SET_INFO would freeze the field, which is the Open.UserSetChangeTime case
+	// product note <187> licenses and which restoreFrozenTimestamps still honours.
+	old := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	if _, err := metaSvc.SetFileAttributes(auth, handle, &metadata.SetAttrs{Mtime: &old, Ctime: &old}); err != nil {
+		t.Fatalf("backdate timestamps: %v", err)
+	}
+
+	resp, err := h.SetInfo(ctx, &SetInfoRequest{
+		InfoType:      types.SMB2InfoTypeFile,
+		FileInfoClass: uint8(types.FileRenameInformation),
+		FileID:        fileID,
+		Buffer:        encodeRenameInfo("after"),
+	})
+	if err != nil {
+		t.Fatalf("SetInfo rename: %v", err)
+	}
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("rename = %v, want STATUS_SUCCESS", resp.Status)
+	}
+
+	file, err := metaSvc.GetFile(auth.Context, handle)
+	if err != nil {
+		t.Fatalf("GetFile: %v", err)
+	}
+	if !file.Ctime.After(old) {
+		t.Errorf("Ctime = %v after rename; want it advanced past %v", file.Ctime.UTC(), old)
+	}
+	if !file.Mtime.Equal(old) {
+		t.Errorf("Mtime = %v after rename; want %v unchanged", file.Mtime.UTC(), old)
+	}
+}
+
+// TestSetInfo_Rename_KeepsFrozenChangeTime is the control for the above: the
+// -1 sentinel freeze is what product note <187> describes ("the file system only
+// updates LastChangeTime if no user has explicitly set LastChangeTime"), so
+// dropping the blanket save/restore must not disturb it.
+func TestSetInfo_Rename_KeepsFrozenChangeTime(t *testing.T) {
+	h, ctx, _ := setupStreamsDisabledShare(t, false)
+	metaSvc := h.Registry.GetMetadataService()
+	auth := dirTestAuthContext()
+
+	fileID := dirTestCreate(t, h, ctx, "frozen-before", types.FileOpenIf, types.FileNonDirectoryFile)
+	v, ok := h.files.Load(string(fileID[:]))
+	if !ok {
+		t.Fatal("open file not found after create")
+	}
+	open := v.(*OpenFile)
+
+	// Explicit ChangeTime through SET_INFO freezes the field.
+	pinned := time.Date(2021, 2, 3, 4, 5, 6, 0, time.UTC)
+	basic := encodeBasicInfo(0, 0, 0, types.TimeToFiletime(pinned), 0)
+	setResp, err := h.SetInfo(ctx, &SetInfoRequest{
+		InfoType:      types.SMB2InfoTypeFile,
+		FileInfoClass: uint8(types.FileBasicInformation),
+		FileID:        fileID,
+		Buffer:        basic,
+	})
+	if err != nil || setResp.Status != types.StatusSuccess {
+		t.Fatalf("SetInfo basic: err=%v status=%v", err, setResp)
+	}
+	if !open.CtimeFrozen {
+		t.Fatal("precondition: an explicit ChangeTime set must freeze the field")
+	}
+
+	renResp, err := h.SetInfo(ctx, &SetInfoRequest{
+		InfoType:      types.SMB2InfoTypeFile,
+		FileInfoClass: uint8(types.FileRenameInformation),
+		FileID:        fileID,
+		Buffer:        encodeRenameInfo("frozen-after"),
+	})
+	if err != nil {
+		t.Fatalf("SetInfo rename: %v", err)
+	}
+	if renResp.Status != types.StatusSuccess {
+		t.Fatalf("rename = %v, want STATUS_SUCCESS", renResp.Status)
+	}
+
+	file, err := metaSvc.GetFile(auth.Context, open.MetadataHandle)
+	if err != nil {
+		t.Fatalf("GetFile: %v", err)
+	}
+	if !file.Ctime.Equal(pinned) {
+		t.Errorf("frozen Ctime = %v after rename; want %v preserved", file.Ctime.UTC(), pinned)
+	}
+}


### PR DESCRIPTION
Closes #2182.

MS-FSA 2.1.5.15.12: *"The object store MUST update Open.File.LastChangeTime.`<187>`"*

`Move` already implements this correctly — `file_modify.go` sets `srcFile.Ctime = now` and never
touches the renamed file's `Mtime`. (The `Mtime`/`Ctime` pairs a few lines below it are the source
and destination **directories**, which is separate and correct.)

The handler then wrapped the call in a blanket snapshot-and-restore of both stamps. So:

- the **mtime** half restored a value nothing had changed — a no-op;
- the **ctime** half reverted the update the specification mandates.

## Why `<187>` does not excuse it

> Section 2.1.5.15.12: The file system only updates LastChangeTime if no user has explicitly set
> LastChangeTime. The NTFS and ReFS file systems defer setting LastChangeTime until the handle is
> closed.

That licenses **deferring** the update, and skipping it when the user set ChangeTime explicitly. It
does not license discarding it. DittoFS discarded: nothing anywhere defers a rename ctime to close,
so a client that reopened the file saw the pre-rename ChangeTime permanently. #2172 flagged this as
its weakest item on the theory that `<187>` might make the behaviour match Windows — it does not,
and *discard vs defer* is the distinction that settles it. From inside the handler the two look
identical; to a client that reopens the file they are not.

It was also cross-protocol inconsistent: an NFS rename goes through the same `Move` and reports the
ctime bump correctly, so the identical operation gave different answers per protocol.

## The straight deletion was wrong, and a control test caught it

#2182 was filed — by me — as "drop `saveTimestamps` and both call sites", on the reasoning that once
ctime is out, the mtime restore is a no-op and the whole helper is dead. The first half is right.
The second is not.

I wrote the deletion, and the control case for the `<187>` user-set half failed immediately: a
sentinel-frozen ChangeTime no longer survived a rename. `saveTimestamps` was doing double duty —
reverting the spec-mandated update *and* preserving an explicitly-set one — and nothing else covers
the renamed file, because the `restoreFrozenTimestamps` call already present on that path runs
against the **parent directories**, not the file.

So the blanket save/restore is replaced, not deleted, by `restoreFrozenTimestamps(authCtx,
openFile)` at both rename sites. That writes back only fields pinned by a `-1` sentinel — precisely
`Open.UserSetChangeTime` and nothing else — and lets `Move`'s ctime update stand.

Worth recording because the issue I filed prescribed the wrong fix, and only a test asserting the
behaviour I was about to remove surfaced it.

## Tests, and how they were checked

Both run against the **pre-change `set_info.go` from develop**, not a synthetic mutant:

| test | vs develop | vs this PR |
| --- | --- | --- |
| `..._UpdatesChangeTimeAndLeavesWriteTime` — unfrozen rename advances ctime, leaves mtime | **RED** (ctime reverted to the backdated value) | PASS |
| `..._KeepsFrozenChangeTime` — sentinel-frozen ctime survives a rename | PASS | PASS |

The split is the point: the first isolates the defect, the second pins the behaviour that must not
regress, and it already passed on develop — so it is a genuine guard rather than a restatement of
the fix. Removing the new `restoreFrozenTimestamps` call at the rename site turns it red.

The first test backdates the stamps through the metadata service rather than SET_INFO, deliberately:
an explicit SET_INFO would freeze the field and put the file in the `<187>` exempt case, testing the
opposite branch.

## Risk

No in-tree test pinned ctime across rename. The rename rows in `smbtorture/KNOWN_FAILURES.md` are
`smb2.lease.rename_wait` (a lease-ordering flake) and `smb2.streams.rename2`; neither asserts
timestamps. Torture sources are not available locally, so the conformance suites on this PR are the
check.
