### PR TITLE
fix(smb): dispatch FSCTL_SET_REPARSE_POINT on the code clients actually send

### DIFF
--- a/internal/adapter/smb/handlers/set_reparse_point_ctlcode_test.go
+++ b/internal/adapter/smb/handlers/set_reparse_point_ctlcode_test.go
@@ -1,0 +1,92 @@
+package handlers
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/smbenc"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// capturedMacOSSetReparseInput is the byte-for-byte InputBuffer a macOS
+// mount_smbfs client sends for `ln -s t.txt l.txt`, taken off a loopback SMB
+// session against a DittoFS server. Decoded, it is a REPARSE_DATA_BUFFER
+// [MS-FSCC] 2.1.2.4:
+//
+//	ReparseTag           0xA000000C  IO_REPARSE_TAG_SYMLINK
+//	ReparseDataLength    32
+//	SubstituteNameOffset 0    SubstituteNameLength 10
+//	PrintNameOffset      10   PrintNameLength      10
+//	Flags                1    SYMLINK_FLAG_RELATIVE
+//	PathBuffer           "t.txt" "t.txt" (UTF-16LE)
+//
+// It is kept as raw bytes rather than rebuilt with buildSymlinkReparseBuffer so
+// the test asserts against what a real client emits, not against our own encoder.
+const capturedMacOSSetReparseInput = "0c0000a02000000000000a000a000a000100000074002e0074007800740074002e00740078007400"
+
+// TestFsctlSetReparsePoint_MatchesWireValue pins the control code to the literal
+// value, never to the constant. The pre-existing test for this handler builds its
+// request with FsctlSetReparsePoint and so passed for as long as the constant was
+// wrong (0x000900D4), because request and dispatcher moved together. MS-FSCC 2.3
+// gives FSCTL_SET_REPARSE_POINT as 0x900A4, Samba uses 0x000900A4, and a macOS
+// client was observed sending 0x000900A4 on the wire.
+func TestFsctlSetReparsePoint_MatchesWireValue(t *testing.T) {
+	const wire = 0x000900A4
+	if FsctlSetReparsePoint != wire {
+		t.Errorf("FsctlSetReparsePoint = 0x%08X, want 0x%08X", FsctlSetReparsePoint, uint32(wire))
+	}
+	// The neighbouring GET code shares the 0x9009x/0x900Ax range and is a likely
+	// copy-paste source, so pin that the two are distinct.
+	if FsctlGetReparsePoint == FsctlSetReparsePoint {
+		t.Error("GET and SET reparse-point control codes must differ")
+	}
+}
+
+// TestIoctl_SetReparsePoint_DispatchesCapturedMacOSRequest drives the real IOCTL
+// dispatch path with the literal control code and a captured client payload. It
+// is the end-to-end form the handler never had: every existing test calls
+// handleSetReparsePoint directly, so none of them touch the dispatch table, which
+// is exactly where the defect lived.
+func TestIoctl_SetReparsePoint_DispatchesCapturedMacOSRequest(t *testing.T) {
+	h, smbCtx, rootHandle, fileID := setupReparseShare(t)
+
+	input, err := hex.DecodeString(capturedMacOSSetReparseInput)
+	if err != nil {
+		t.Fatalf("decode captured input: %v", err)
+	}
+
+	// Body built with the literal code, not FsctlSetReparsePoint.
+	w := smbenc.NewWriter(56 + len(input))
+	w.WriteUint16(57) // StructureSize
+	w.WriteUint16(0)  // Reserved
+	w.WriteUint32(0x000900A4)
+	w.WriteBytes(fileID[:])
+	w.WriteUint32(120)                // InputOffset (SMB2 header 64 + fixed body 56)
+	w.WriteUint32(uint32(len(input))) // InputCount
+	w.WriteUint32(0)                  // MaxInputResponse
+	w.WriteUint32(0)                  // OutputOffset
+	w.WriteUint32(0)                  // OutputCount
+	w.WriteUint32(0)                  // MaxOutputResponse
+	w.WriteUint32(1)                  // Flags: SMB2_0_IOCTL_IS_FSCTL, as captured
+	w.WriteUint32(0)                  // Reserved2
+
+	resp, err := h.Ioctl(smbCtx, append(w.Bytes(), input...))
+	if err != nil {
+		t.Fatalf("Ioctl: %v", err)
+	}
+	if resp.Status == types.StatusNotSupported {
+		t.Fatal("dispatch returned STATUS_NOT_SUPPORTED: the control code never reached the handler")
+	}
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("status = 0x%08X, want STATUS_SUCCESS", uint32(resp.Status))
+	}
+
+	gotType, gotTarget := symlinkTargetAfter(t, h, smbCtx, rootHandle)
+	if gotType != metadata.FileTypeSymlink {
+		t.Fatalf("type = %v, want FileTypeSymlink", gotType)
+	}
+	if gotTarget != "t.txt" {
+		t.Fatalf("target = %q, want %q", gotTarget, "t.txt")
+	}
+}

--- a/internal/adapter/smb/handlers/stub_handlers.go
+++ b/internal/adapter/smb/handlers/stub_handlers.go
@@ -29,7 +29,7 @@ const (
 	FsctlSrvCopyChunk           uint32 = 0x001440F2 // [MS-SMB2] 2.2.32.1
 	FsctlSrvCopyChunkWrite      uint32 = 0x001480F2 // [MS-SMB2] 2.2.32.1
 	FsctlGetReparsePoint        uint32 = 0x000900A8 // [MS-FSCC] 2.3.27 (FSCTL_GET_REPARSE_POINT Request)
-	FsctlSetReparsePoint        uint32 = 0x000900D4 // [MS-FSCC] 2.3.81 (FSCTL_SET_REPARSE_POINT Request) - Set reparse point (symlink create)
+	FsctlSetReparsePoint        uint32 = 0x000900A4 // [MS-FSCC] 2.3.81 (FSCTL_SET_REPARSE_POINT Request) - Set reparse point (symlink create)
 	FsctlIsPathnameValid        uint32 = 0x0009002C // [MS-FSCC] 2.3.35 (FSCTL_IS_PATHNAME_VALID Request) - Pathname validation
 	FsctlGetNtfsVolumeData      uint32 = 0x00090064 // [MS-FSCC] 2.3.21 (FSCTL_GET_NTFS_VOLUME_DATA Request) - NTFS volume data
 	FsctlReadFileUsnData        uint32 = 0x000900EB // [MS-FSCC] 2.3.61 (FSCTL_READ_FILE_USN_DATA Request) - Read file USN data


### PR DESCRIPTION
Closes #2171.

The constant was `0x000900D4`. MS-FSCC §2.3 gives `FSCTL_SET_REPARSE_POINT 0X900A4`; `0x900D4`
appears nowhere in the document; Samba uses `0x000900A4`. The dispatch table is keyed on the
constant, so a real client's request never reached `handleSetReparsePoint`.

## Captured on the wire, not reasoned about

Per the agreement on #2171 this was not corrected until a real client had been observed. A DittoFS
server was run on loopback (SMB on the default **12445**, never 445) and mounted with the machine's
own macOS client:

```
mount_smbfs //admin@127.0.0.1:12445/capture /tmp/…/mnt
ln -s t.txt l.txt
→ ln: failed to create symbolic link 'l.txt': Operation not supported
```

Server log, DEBUG:

```
IOCTL request ctlCode=0x000900A4 bodyLen=96
IOCTL unknown control code - not supported ctlCode=0x000900A4
```

So the client sends `0x000900A4`, the dispatcher does not recognise it, and symlink creation over
SMB from macOS has never worked.

## The handler already handles what arrives

Correcting the code switches traffic onto a handler that had never run against real input, so the
payload was decoded too. The captured 40-byte InputBuffer:

```
0c0000a0 2000 0000 0000 0a00 0a00 0a00 01000000 74002e0074007800740074002e00740078007400
```

decodes as a REPARSE_DATA_BUFFER ([MS-FSCC] 2.1.2.4):

| field | value |
| --- | --- |
| ReparseTag | `0xA000000C` IO_REPARSE_TAG_SYMLINK |
| ReparseDataLength | 32 |
| SubstituteNameOffset / Length | 0 / 10 |
| PrintNameOffset / Length | 10 / 10 |
| Flags | 1 — `SYMLINK_FLAG_RELATIVE` |
| PathBuffer | `"t.txt"` `"t.txt"` UTF-16LE |

`parseSymlinkReparseTarget` reads the path buffer at offset 12 and prefers PrintName, which
resolves to `t.txt` — correct for this layout. The IOCTL envelope also matches what the handler
expects (`StructureSize` 57, `InputOffset` 120, `InputCount` 40, `Flags` = `SMB2_0_IOCTL_IS_FSCTL`).
**No handler change was needed**, which is the thing that had to be established before touching the
constant.

## Why seven existing tests missed it

Every existing test calls `handleSetReparsePoint` directly, bypassing dispatch. The one that does go
through `Ioctl` — `TestSetReparsePoint_DispatchedViaIoctl` — builds its request with
`FsctlSetReparsePoint`, the same constant the dispatcher keys on, so request and dispatcher moved
together and it passed for whatever value the constant held.

Demonstrated rather than argued. Restoring `0x000900D4`:

```
--- FAIL: TestFsctlSetReparsePoint_MatchesWireValue
--- FAIL: TestIoctl_SetReparsePoint_DispatchesCapturedMacOSRequest
--- PASS: TestSetReparsePoint_CreatesRelativeSymlink
--- PASS: TestSetReparsePoint_AbsoluteTargetAllowed
--- PASS: TestSetReparsePoint_CloseAfterConvertIsNoop
--- PASS: TestSetReparsePoint_WrongTagRejected
--- PASS: TestSetReparsePoint_TruncatedBufferRejected
--- PASS: TestSetReparsePoint_NfsTagSymlink
--- PASS: TestSetReparsePoint_DispatchedViaIoctl
```

Two new tests, both of which have to be immune to that:

- `TestFsctlSetReparsePoint_MatchesWireValue` asserts the **literal** `0x000900A4`, never the
  constant, and that GET and SET differ.
- `TestIoctl_SetReparsePoint_DispatchesCapturedMacOSRequest` replays the captured client bytes
  through the real `Ioctl` entry point with the literal code, and asserts a symlink to `t.txt`
  results — failing explicitly if dispatch returns `STATUS_NOT_SUPPORTED`.

The captured buffer is kept as raw hex rather than rebuilt with `buildSymlinkReparseBuffer`, so the
test measures against what a client emits rather than against our own encoder.

## Scope

One constant and one test file. The other 16 FSCTL values in that block were re-derived from
MS-FSCC §2.3's name/code table during #2174 and all check out; this was the lone outlier.
