### PR TITLE
chore(k8s): drop the 54.7 MB committed operator binary and the dead Dockerfile that needed it

### DIFF
--- a/k8s/dittofs-operator/.dockerignore
+++ b/k8s/dittofs-operator/.dockerignore
@@ -15,6 +15,3 @@
 # Re-include Go module files
 !go.mod
 !go.sum
-
-# Re-include pre-built binaries for cross-compilation
-!manager-*

--- a/k8s/dittofs-operator/Dockerfile.prebuilt
+++ b/k8s/dittofs-operator/Dockerfile.prebuilt
@@ -1,7 +1,0 @@
-# Pre-built binary Dockerfile
-# Use when Go version in Docker Hub doesn't match required version
-FROM gcr.io/distroless/static:nonroot
-WORKDIR /
-COPY manager-linux-amd64 /manager
-USER 65532:65532
-ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Closes #2186

`k8s/dittofs-operator/manager-linux-amd64` is a 54.7 MB compiled linux/amd64
ELF binary (the operator's `manager`) that has been tracked in git since a
single commit. This PR removes it, the one Dockerfile that consumed it, and
the `.dockerignore` line that existed only to feed that Dockerfile.

Three files, ten lines of text, one blob. **Working-tree half only** — the
history rewrite is deliberately not in scope; see the last section.

## What was verified before deleting

The failure mode for a deletion like this is silent: a deploy path that breaks
weeks later. So each claim below was checked rather than assumed.

**The binary is a single unchanging blob.** `git log --all -- <path>` returns
exactly one commit (`915deff59`, #113); it has never been rebuilt or updated.
It is tracked at HEAD, so every checkout and every worktree pays 57,389,240
bytes for it.

**The `.gitignore` rule was already there and has been inert.**
`.gitignore:84` already lists this exact path. The rule was added after the
file entered the index, and git keeps tracking what is already in the index —
so it has never done anything. No `.gitignore` change is needed here; removing
the file from the index is what switches the rule on. Demonstrated on this
branch: recreating the file at that path now produces an empty `git status`,
and `git check-ignore -v` attributes it to `.gitignore:84`.

**`Dockerfile.prebuilt` (the operator one) is built by nothing.** Its whole
body was `FROM gcr.io/distroless/static:nonroot` / `COPY manager-linux-amd64
/manager` / `ENTRYPOINT ["/manager"]`. Every path that actually produces an
operator image builds from source instead:

| Path | Dockerfile used | Source of `manager` |
| --- | --- | --- |
| `release.yml:206` (the only workflow that builds it) | `k8s/dittofs-operator/Dockerfile` | `RUN go build` in-container |
| `make docker-build` | `Dockerfile` (no `-f`, so the context default) | in-container |
| `make docker-buildx` | `Dockerfile.cross`, which the target itself generates from `Dockerfile` via `sed` and `rm`s afterwards | in-container |
| Helm chart | n/a — `chart/values.yaml` pulls the published `marmos91c/dittofs-operator` image | published image |

A repo-wide `git grep` for `Dockerfile.prebuilt` returns only `.gitignore:82`
and two lines under `.planning/audits/2026-08-05-dataplane/`, and those two are
about the **repo-root** `Dockerfile.prebuilt` (an EXPOSE-list finding for the
`dfs` server image) — a different, untouched file that happens to share a name.
`git grep manager-linux-amd64` returns only `.gitignore:84` and the deleted
`COPY` line itself. Nothing in `.github/`, the Makefile, `chart/`, `config/`,
`hack/`, `.devcontainer/`, `docs/`, `README.md` or the nix files refers to
either.

**`!manager-*` in `.dockerignore` served only that file.** The
`.dockerignore` starts with `**` and re-includes `!**/`, `!**/*.go`, `!go.mod`,
`!go.sum` — everything the from-source build needs. `!manager-*` re-included
the committed binary and nothing else; note `make build` writes to `bin/manager`,
which that glob never matched anyway. With the binary gone it un-ignores nothing.

## Checks run

The operator is a **separate Go module**, so a repo-root `go build ./...` does
not cover it. From `k8s/dittofs-operator/`:

- `go build ./...`, `go vet ./...` — clean
- `make build` — produces `bin/manager`, unaffected
- `make lint` (golangci-lint v2.5.0) — 0 issues
- `make manifests-verify` — "Generated manifests are in sync"
- `kustomize build config/default` — clean
- **`docker build -f Dockerfile .`** — the real thing the release workflow runs,
  with the trimmed `.dockerignore`. Builds and exports the image successfully.
  This is the check that matters: it proves the build context is still complete
  without `!manager-*`.

## Why `Dockerfile.prebuilt` goes rather than gets repointed

Its header explains it as a toolchain workaround — "Use when Go version in
Docker Hub doesn't match required version". That escape hatch has never been
wired into any automation, and the problem it works around is already handled
in the normal path: `Dockerfile` pins `golang:1.25.1` to match the `go.mod`
toolchain **and** runs both `go mod download` and `go build` under
`GOTOOLCHAIN=auto`, so a Docker Hub image whose Go version is too old fetches
the right toolchain instead of failing. `Dockerfile.cross` does the same.
Keeping the prebuilt variant would mean
rewriting it to `COPY bin/manager` (a `make build` artifact, since consuming a
committed binary is the thing being removed) and also re-adding a
`.dockerignore` negation for `bin/` — i.e. writing a new file, not preserving
this one. If the toolchain breaks again, six lines pointed at `make build`
output are cheaper to write then than to carry dead now.

## Not done here, on purpose

`git rm` does **not** shrink a clone. The blob stays reachable from
`915deff59` forever, so the ~18 MB it occupies in a ~184 MiB pack is still
downloaded. What this PR buys is 54.7 MB per working tree and per worktree, and
a `.gitignore` rule that finally works so a second copy cannot be committed later.

Reclaiming the packed 18 MB needs `git filter-repo`, which rewrites every SHA
after `915deff59` — invalidating open PR branches, every signed commit's
signature, and the tags on `main`. That is a separate, deliberate operation and
is explicitly **not** part of this PR.

## Adjacent, not fixed here

`k8s/dittofs-operator/Dockerfile.cross` is tracked and gitignored at
`.gitignore:83` — the same inert-ignore pattern. It is a *generated* file:
`make docker-buildx` creates it with `sed` and `rm`s it at the end, so running
that target deletes a tracked file and leaves a dirty worktree. Left alone to
keep this diff to the one thing #2186 asks for; worth its own issue.
