### PR TITLE
fix(smb): settle a rename's ChangeTime at CLOSE instead of discarding it

### DIFF
--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -290,6 +290,25 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 				}
 			}
 
+			// Settle the LastChangeTime a rename on this handle owed the file.
+			// MS-FSA 2.1.5.15.12 requires the update; product note <187> defers it
+			// to close on NTFS and ReFS, and holding it until here is what lets a
+			// client reading through the still-open handle keep seeing the
+			// pre-rename value.
+			//
+			// No frozen check here. restoreFrozenTimestamps below owns freeze
+			// semantics for every field, and a second guard would duplicate that
+			// ownership while being impossible to observe failing: the deferred
+			// write flush above already sets Ctime unconditionally, so a
+			// sentinel-frozen ChangeTime does not survive this path with or without
+			// one. That is a pre-existing gap in the frozen restore, not something
+			// this write introduces.
+			if pending := takeSmbPendingCtime(openFile); !pending.IsZero() {
+				if _, ctimeErr := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, &metadata.SetAttrs{Ctime: &pending}); ctimeErr != nil {
+					logger.Warn("CLOSE: deferred LastChangeTime flush failed", "path", closePath, "error", ctimeErr)
+				}
+			}
+
 			// Per MS-FSA §2.1.5.15.2 ("FileBasicInformation"): After flushing pending writes (which may overwrite
 			// frozen timestamps), restore any timestamps that were frozen via SET_INFO -1.
 			// The deferred commit flush sets Mtime/Ctime to the WRITE time, but if the

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -613,6 +613,11 @@ type OpenFile struct {
 	// persisted at CLOSE.
 	SmbAtimeWrittenAt time.Time // when the last READ-driven atime reached the store
 	SmbPendingAtime   time.Time // newest access time not yet written to the store (zero ⇒ none)
+	// SmbPendingCtime is the LastChangeTime a rename on this handle owes the
+	// file, settled at CLOSE (zero ⇒ none). It is deliberately NOT surfaced by
+	// QUERY_INFO: while the handle is open the pre-rename ChangeTime is what
+	// the client must still see.
+	SmbPendingCtime time.Time
 
 	// SmbParentAtimeWrittenAt bounds the parent-directory LastAccessTime bump a
 	// WRITE performs, the way SmbAtimeWrittenAt bounds the file's. A suppressed

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -781,6 +781,20 @@ func (h *Handler) setFileInfoFromStore(
 			// Restore mtime/ctime after rename
 			restoreTimestamps()
 
+			// Move set LastChangeTime and restoreTimestamps has just put the
+			// pre-rename value back, which is what a client reading through this
+			// still-open handle must see. MS-FSA 2.1.5.15.12 still requires the
+			// update, so record it and let CLOSE settle it, matching the NTFS and
+			// ReFS deferral described in product note <187>.
+			noteSmbRenameChange(openFile, time.Now())
+
+			// Move set LastChangeTime and restoreTimestamps has just put the
+			// pre-rename value back, which is what a client reading through this
+			// still-open handle must see. MS-FSA 2.1.5.15.12 still requires the
+			// update, so record it and let CLOSE settle it, matching the NTFS and
+			// ReFS deferral described in product note <187>.
+			noteSmbRenameChange(openFile, time.Now())
+
 			// Clear delete-on-close after rename. Written under the handle
 			// lock: the delete-pending gates and the CLOSE delete-on-close
 			// election read this field under it.

--- a/internal/adapter/smb/handlers/set_info_rename_ctime_test.go
+++ b/internal/adapter/smb/handlers/set_info_rename_ctime_test.go
@@ -1,0 +1,139 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// MS-FSA 2.1.5.15.12 requires a rename to update LastChangeTime, and product
+// note <187> says NTFS and ReFS defer that update until the handle closes. Both
+// halves are pinned here, because a fix satisfying only the first is
+// indistinguishable from the original bug — which held the old value forever —
+// and a fix satisfying only the second breaks smb2.rename.simple_modtime, which
+// renames through a handle and then queries that same handle.
+
+// renameCtimeFixture returns an open file, its metadata handle, and the
+// ChangeTime it was created with. setupReparseShare is used because it wires a
+// local block store, without which CLOSE fails its flush step for a regular
+// file — and CLOSE is half of what these tests measure.
+//
+// The stamp is read rather than written: a SET_INFO would freeze the field (the
+// Open.UserSetChangeTime case <187> exempts, covered separately below). The short
+// sleep guarantees the rename lands on a distinguishable timestamp.
+func renameCtimeFixture(t *testing.T) (*Handler, *SMBHandlerContext, [16]byte, metadata.FileHandle, time.Time) {
+	t.Helper()
+	h, smbCtx, _, fileID := setupReparseShare(t)
+
+	v, ok := h.files.Load(string(fileID[:]))
+	if !ok {
+		t.Fatal("open file not found")
+	}
+	open := v.(*OpenFile)
+	handle := open.MetadataHandle
+	// setupReparseShare grants only READ|WRITE data; rename needs DELETE and the
+	// frozen-ChangeTime case needs WRITE_ATTRIBUTES.
+	open.GrantedAccess = secRightsFileAll
+
+	file, err := h.Registry.GetMetadataService().GetFile(smbCtx.Context, handle)
+	if err != nil {
+		t.Fatalf("GetFile at create: %v", err)
+	}
+	time.Sleep(5 * time.Millisecond)
+	return h, smbCtx, fileID, handle, file.Ctime
+}
+
+func renameVia(t *testing.T, h *Handler, ctx *SMBHandlerContext, fileID [16]byte, to string) {
+	t.Helper()
+	resp, err := h.SetInfo(ctx, &SetInfoRequest{
+		InfoType:      types.SMB2InfoTypeFile,
+		FileInfoClass: uint8(types.FileRenameInformation),
+		FileID:        fileID,
+		Buffer:        encodeRenameInfo(to),
+	})
+	if err != nil {
+		t.Fatalf("SetInfo rename: %v", err)
+	}
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("rename = %v, want STATUS_SUCCESS", resp.Status)
+	}
+}
+
+// TestSetInfo_Rename_ChangeTimeUnchangedWhileHandleOpen is the half that
+// smbtorture smb2.rename.simple_modtime measures: it renames through h1 and then
+// issues a getinfo on that same still-open handle, asserting ChangeTime equals
+// the value from before the rename. QUERY_INFO applies no ChangeTime overlay, so
+// what the store holds is what that client reads.
+func TestSetInfo_Rename_ChangeTimeUnchangedWhileHandleOpen(t *testing.T) {
+	// setupStreamsDisabledShare here, not the block-store fixture: this half never
+	// closes, and its auth context can actually apply the post-rename timestamp
+	// restore that delivers the unchanged value.
+	h, ctx, _ := setupStreamsDisabledShare(t, false)
+	metaSvc := h.Registry.GetMetadataService()
+
+	fileID := dirTestCreate(t, h, ctx, "open-before", types.FileOpenIf, types.FileNonDirectoryFile)
+	v, ok := h.files.Load(string(fileID[:]))
+	if !ok {
+		t.Fatal("open file not found after create")
+	}
+	handle := v.(*OpenFile).MetadataHandle
+
+	created, err := metaSvc.GetFile(dirTestAuthContext().Context, handle)
+	if err != nil {
+		t.Fatalf("GetFile at create: %v", err)
+	}
+	old := created.Ctime
+	time.Sleep(5 * time.Millisecond)
+
+	renameVia(t, h, ctx, fileID, "open-after")
+
+	file, err := metaSvc.GetFile(dirTestAuthContext().Context, handle)
+	if err != nil {
+		t.Fatalf("GetFile: %v", err)
+	}
+	if !file.Ctime.Equal(old) {
+		t.Errorf("Ctime = %v while the renaming handle is still open; want %v unchanged",
+			file.Ctime.UTC(), old)
+	}
+	if !file.Mtime.Equal(old) {
+		t.Errorf("Mtime = %v after rename; want %v unchanged", file.Mtime.UTC(), old)
+	}
+}
+
+// TestSetInfo_Rename_ChangeTimeSettlesOnClose is the other half. Once the handle
+// closes, the update MS-FSA requires must have landed — otherwise the file keeps
+// its pre-rename ChangeTime forever, which is the defect this replaces.
+func TestSetInfo_Rename_ChangeTimeSettlesOnClose(t *testing.T) {
+	h, ctx, fileID, handle, old := renameCtimeFixture(t)
+	renameVia(t, h, ctx, fileID, "close-after")
+
+	resp, err := h.Close(ctx, &CloseRequest{FileID: fileID})
+	if err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("close = %v, want STATUS_SUCCESS", resp.Status)
+	}
+
+	file, err := h.Registry.GetMetadataService().GetFile(ctx.Context, handle)
+	if err != nil {
+		t.Fatalf("GetFile after close: %v", err)
+	}
+	if !file.Ctime.After(old) {
+		t.Errorf("Ctime = %v after the renaming handle closed; want it advanced past %v",
+			file.Ctime.UTC(), old)
+	}
+	if !file.Mtime.Equal(old) {
+		t.Errorf("Mtime = %v after close; want %v unchanged — rename never modifies content",
+			file.Mtime.UTC(), old)
+	}
+}
+
+// The <187> user-set half — a sentinel-frozen ChangeTime outlasting the deferred
+// update — is deliberately not asserted here. Preserving a frozen ChangeTime
+// across rename+close is already broken on develop, independently of this change:
+// a test setting CtimeFrozen/FrozenCtime and closing reads back the flush time on
+// unmodified develop as well. Pinning it in this PR would assert a bug rather than
+// the behaviour, so it is tracked separately.

--- a/internal/adapter/smb/handlers/timestamps.go
+++ b/internal/adapter/smb/handlers/timestamps.go
@@ -84,6 +84,42 @@ func noteSmbParentAccess(openFile *OpenFile, t time.Time) bool {
 	return true
 }
 
+// noteSmbRenameChange records that a rename on this handle owes the file a
+// LastChangeTime of t. MS-FSA 2.1.5.15.12 requires the update, and product note
+// <187> says NTFS and ReFS defer it until the handle closes — so it is held here
+// rather than written now. smbtorture smb2.rename.simple_modtime renames through
+// a handle and then queries that same handle, and requires the ChangeTime it
+// reads to be unchanged.
+//
+// Latest rename wins: several renames on one handle owe only the last one.
+//
+// Takes openFile.mu (write).
+func noteSmbRenameChange(openFile *OpenFile, t time.Time) {
+	if openFile == nil {
+		return
+	}
+	openFile.mu.Lock()
+	defer openFile.mu.Unlock()
+	if t.After(openFile.SmbPendingCtime) {
+		openFile.SmbPendingCtime = t
+	}
+}
+
+// takeSmbPendingCtime removes and returns the change time a rename left owing on
+// the handle, or the zero time when there is none. Called at CLOSE.
+//
+// Takes openFile.mu (write).
+func takeSmbPendingCtime(openFile *OpenFile) time.Time {
+	if openFile == nil {
+		return time.Time{}
+	}
+	openFile.mu.Lock()
+	defer openFile.mu.Unlock()
+	pending := openFile.SmbPendingCtime
+	openFile.SmbPendingCtime = time.Time{}
+	return pending
+}
+
 // takeSmbPendingAtime removes and returns the access time held on the handle
 // since the last store write, or the zero time when there is none. Called at
 // CLOSE so a coalesced bump is not lost with the handle.


### PR DESCRIPTION
Closes #2182. Replaces #2193, which was the same diagnosis with the wrong remedy.

MS-FSA 2.1.5.15.12 requires a rename to update `LastChangeTime`. `Move` already does — it sets
`Ctime` on the renamed file and never touches `Mtime`. The handler then snapshotted both stamps
around the call and wrote them back, so the update was never persisted: a file reopened after close
kept its pre-rename ChangeTime permanently, while the NFS path renaming through the same `Move`
reported it correctly.

## Why the obvious fix is wrong

Letting `Move`'s write stand — #2193 — fails `smb2.rename.simple_modtime` on both backends:

```
c1.out.change_time was 13:19:13 (creation), expected 13:19:18 (post-rename)
```

The test renames through `h1` and then queries **that same still-open handle**, asserting ChangeTime
is unchanged. That is product note `<187>`:

> The NTFS and ReFS file systems defer setting LastChangeTime until the handle is closed.

So the update must happen, but must not be observable until the handle closes. Discarding it and
applying it immediately are both wrong, in opposite directions.

## The shape

The rename records what it owes on the handle; CLOSE settles it. This mirrors the pending-atime
mechanism sitting immediately above it in `close.go` — `noteSmbRenameChange` / `takeSmbPendingCtime`
against `noteSmbAccess` / `takeSmbPendingAtime`.

One deliberate difference: `SmbPendingAtime` is surfaced by QUERY_INFO through `applySmbPendingAtime`,
and `SmbPendingCtime` is **not**. Overlaying it would defeat the point — while the handle is open the
pre-rename value is exactly what the client must read. That asymmetry is the whole fix, so it is
stated on the field.

A `!IsCtimeFrozen()` guard on the CLOSE-time write was considered and left out. The deferred write
flush already sets Ctime unconditionally on this path, so the guard could never be observed failing
— the "guard that never fired" anti-pattern. Freeze semantics get one owner,
`restoreFrozenTimestamps`, which turns out to be independently broken here → **#2196**, filed
separately and reproduced on unmodified develop.

## Both halves are pinned, and each was run against a build missing it

A fix satisfying only the first is indistinguishable from the original bug; one satisfying only the
second breaks the torture case.

| mutation | test | result |
| --- | --- | --- |
| CLOSE settle removed | `..._ChangeTimeSettlesOnClose` | RED |
| rename writes immediately (restore removed) | `..._ChangeTimeUnchangedWhileHandleOpen` | RED |

Both green with the change intact. The two tests use different fixtures on purpose — the
open-handle half never closes, so it uses the simpler share; the close half needs the
block-store-backed one, without which CLOSE fails its flush step for a regular file and the
assertion would pass vacuously. That second point was found the hard way: an earlier version of the
close test passed while CLOSE was returning `STATUS_INTERNAL_ERROR` unchecked, so close status is
now asserted.

## Method note, because this PR is the argument for it

#2193 was mutation-tested and still shipped the wrong behaviour. Mutation testing proves a test is
not vacuous. It cannot prove the specification the test encodes is the right one — and there the
encoded spec was wrong, so every check agreed with itself. The reasoning was right, the code was
wrong, and the code looked like the reasoning: `<187>` was quoted correctly in the issue, used as
the entire argument for why the old behaviour was wrong, and then implemented as an immediate
update, which is neither deferral nor the status quo.

Only an independent encoding of the behaviour caught it — Samba's `simple_modtime`, which asserts
ChangeTime is *unchanged* across a rename on a still-open handle. The conclusion is not "be more
careful": it is that a spec reading which changes observable protocol behaviour should be run
against conformance **before** it is trusted, not after it is merged. The two halves pinned here
exist so the next person changing this cannot satisfy one and believe they are done.
