### PR TITLE
fix(nfs4): reject the byte ranges RFC 7530 calls invalid in LOCK

### DIFF
--- a/internal/adapter/nfs/v4/handlers/lock.go
+++ b/internal/adapter/nfs/v4/handlers/lock.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"io"
+	"math"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/pseudofs"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/state"
@@ -10,6 +11,22 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
 	"github.com/marmos91/dittofs/internal/logger"
 )
+
+// lockRangeValid reports whether offset and length describe a byte range the
+// server will act on. RFC 7530 Section 16.10.4 rejects a length of zero, and
+// rejects a length that is not all-ones whose sum with the offset exceeds the
+// maximum 64-bit unsigned value. A length with every bit set means "from offset
+// through end-of-file" however long the file grows, so it is exempt from that
+// sum. Sections 16.11.4 and 16.12.4 apply the same two rules to LOCKT and LOCKU.
+func lockRangeValid(offset, length uint64) bool {
+	if length == 0 {
+		return false
+	}
+	if length == math.MaxUint64 {
+		return true
+	}
+	return offset <= math.MaxUint64-length
+}
 
 // handleLock implements the LOCK operation (RFC 7530 Section 16.10).
 // Acquires a byte-range lock on a file via new or existing lock-owner path.
@@ -70,6 +87,18 @@ func (h *Handler) handleLock(ctx *types.CompoundContext, reader io.Reader) *type
 			Status: types.NFS4ERR_BADXDR,
 			OpCode: types.OP_LOCK,
 			Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
+		}
+	}
+
+	if !lockRangeValid(offset, length) {
+		logger.Debug("NFSv4 LOCK invalid range",
+			"offset", offset,
+			"length", length,
+			"client", ctx.ClientAddr)
+		return &types.CompoundResult{
+			Status: types.NFS4ERR_INVAL,
+			OpCode: types.OP_LOCK,
+			Data:   encodeStatusOnly(types.NFS4ERR_INVAL),
 		}
 	}
 
@@ -304,6 +333,18 @@ func (h *Handler) handleLockT(ctx *types.CompoundContext, reader io.Reader) *typ
 		}
 	}
 
+	if !lockRangeValid(offset, length) {
+		logger.Debug("NFSv4 LOCKT invalid range",
+			"offset", offset,
+			"length", length,
+			"client", ctx.ClientAddr)
+		return &types.CompoundResult{
+			Status: types.NFS4ERR_INVAL,
+			OpCode: types.OP_LOCKT,
+			Data:   encodeStatusOnly(types.NFS4ERR_INVAL),
+		}
+	}
+
 	// lock_owner4: clientid + owner opaque
 	clientID, err := xdr.DecodeUint64(reader)
 	if err != nil {
@@ -438,6 +479,18 @@ func (h *Handler) handleLockU(ctx *types.CompoundContext, reader io.Reader) *typ
 			Status: types.NFS4ERR_BADXDR,
 			OpCode: types.OP_LOCKU,
 			Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
+		}
+	}
+
+	if !lockRangeValid(offset, length) {
+		logger.Debug("NFSv4 LOCKU invalid range",
+			"offset", offset,
+			"length", length,
+			"client", ctx.ClientAddr)
+		return &types.CompoundResult{
+			Status: types.NFS4ERR_INVAL,
+			OpCode: types.OP_LOCKU,
+			Data:   encodeStatusOnly(types.NFS4ERR_INVAL),
 		}
 	}
 

--- a/internal/adapter/nfs/v4/handlers/lock.go
+++ b/internal/adapter/nfs/v4/handlers/lock.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"bytes"
 	"io"
-	"math"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/pseudofs"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/state"
@@ -11,22 +10,6 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
 	"github.com/marmos91/dittofs/internal/logger"
 )
-
-// lockRangeValid reports whether offset and length describe a byte range the
-// server will act on. RFC 7530 Section 16.10.4 rejects a length of zero, and
-// rejects a length that is not all-ones whose sum with the offset exceeds the
-// maximum 64-bit unsigned value. A length with every bit set means "from offset
-// through end-of-file" however long the file grows, so it is exempt from that
-// sum. Sections 16.11.4 and 16.12.4 apply the same two rules to LOCKT and LOCKU.
-func lockRangeValid(offset, length uint64) bool {
-	if length == 0 {
-		return false
-	}
-	if length == math.MaxUint64 {
-		return true
-	}
-	return offset <= math.MaxUint64-length
-}
 
 // handleLock implements the LOCK operation (RFC 7530 Section 16.10).
 // Acquires a byte-range lock on a file via new or existing lock-owner path.
@@ -87,18 +70,6 @@ func (h *Handler) handleLock(ctx *types.CompoundContext, reader io.Reader) *type
 			Status: types.NFS4ERR_BADXDR,
 			OpCode: types.OP_LOCK,
 			Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
-		}
-	}
-
-	if !lockRangeValid(offset, length) {
-		logger.Debug("NFSv4 LOCK invalid range",
-			"offset", offset,
-			"length", length,
-			"client", ctx.ClientAddr)
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_INVAL,
-			OpCode: types.OP_LOCK,
-			Data:   encodeStatusOnly(types.NFS4ERR_INVAL),
 		}
 	}
 
@@ -333,18 +304,6 @@ func (h *Handler) handleLockT(ctx *types.CompoundContext, reader io.Reader) *typ
 		}
 	}
 
-	if !lockRangeValid(offset, length) {
-		logger.Debug("NFSv4 LOCKT invalid range",
-			"offset", offset,
-			"length", length,
-			"client", ctx.ClientAddr)
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_INVAL,
-			OpCode: types.OP_LOCKT,
-			Data:   encodeStatusOnly(types.NFS4ERR_INVAL),
-		}
-	}
-
 	// lock_owner4: clientid + owner opaque
 	clientID, err := xdr.DecodeUint64(reader)
 	if err != nil {
@@ -479,18 +438,6 @@ func (h *Handler) handleLockU(ctx *types.CompoundContext, reader io.Reader) *typ
 			Status: types.NFS4ERR_BADXDR,
 			OpCode: types.OP_LOCKU,
 			Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
-		}
-	}
-
-	if !lockRangeValid(offset, length) {
-		logger.Debug("NFSv4 LOCKU invalid range",
-			"offset", offset,
-			"length", length,
-			"client", ctx.ClientAddr)
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_INVAL,
-			OpCode: types.OP_LOCKU,
-			Data:   encodeStatusOnly(types.NFS4ERR_INVAL),
 		}
 	}
 

--- a/internal/adapter/nfs/v4/handlers/lock_test.go
+++ b/internal/adapter/nfs/v4/handlers/lock_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -1193,4 +1194,102 @@ func TestFullLockLifecycle(t *testing.T) {
 		t.Fatalf("Step 9: CLOSE failed: status=%d", closeResult.Status)
 	}
 	t.Logf("Step 9: CLOSE OK -- full lifecycle complete")
+}
+
+// ============================================================================
+// Byte-Range Validation
+// ============================================================================
+
+func TestLockRangeValid(t *testing.T) {
+	tests := []struct {
+		name   string
+		offset uint64
+		length uint64
+		want   bool
+	}{
+		{"ordinary range", 25, 75, true},
+		{"zero length", 25, 0, false},
+		{"zero length at zero offset", 0, 0, false},
+		{"all-ones length locks through EOF", 100, math.MaxUint64, true},
+		{"all-ones length from the highest offset", math.MaxUint64, math.MaxUint64, true},
+		{"sum lands exactly on the maximum", 1, math.MaxUint64 - 1, true},
+		{"sum passes the maximum by one", 2, math.MaxUint64 - 1, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := lockRangeValid(tt.offset, tt.length); got != tt.want {
+				t.Errorf("lockRangeValid(%d, %d) = %v, want %v",
+					tt.offset, tt.length, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHandleLock_InvalidRange drives the two ranges RFC 7530 Section 16.10.4
+// rejects through all three ops that carry one. Each reaches the range check
+// before it consults lock state, so an unlocked file and an unused stateid are
+// enough to reach the check and no lock state is created by any of these calls.
+func TestHandleLock_InvalidRange(t *testing.T) {
+	const overflowLength = uint64(0xfffffffffffffffe) // what pynfs puts on the wire
+
+	ranges := []struct {
+		name   string
+		offset uint64
+		length uint64
+	}{
+		{"zero length", 25, 0},
+		{"offset plus length overflows", 100, overflowLength},
+	}
+
+	for _, r := range ranges {
+		t.Run(r.name, func(t *testing.T) {
+			pfs := pseudofs.New()
+			pfs.Rebuild([]string{"/export"})
+
+			lm := lock.NewManager()
+			sm := state.NewStateManager(90 * time.Second)
+			sm.SetLockManager(lm)
+			h := NewHandler(nil, pfs, sm)
+
+			clientID, openStateid, _ := setupHandlerLockClient(t, h)
+
+			fileHandle := []byte("/export:lock-range-file")
+			newCtx := func() *types.CompoundContext {
+				ctx := &types.CompoundContext{
+					Context:    context.Background(),
+					ClientAddr: "127.0.0.1:9999",
+					CurrentFH:  make([]byte, len(fileHandle)),
+				}
+				copy(ctx.CurrentFH, fileHandle)
+				return ctx
+			}
+
+			lockArgs := encodeNewLockOwnerArgs(
+				types.WRITE_LT, r.offset, r.length,
+				1, openStateid, 0, clientID, []byte("range-owner"),
+			)
+			if got := h.handleLock(newCtx(), bytes.NewReader(lockArgs)); got.Status != types.NFS4ERR_INVAL {
+				t.Errorf("LOCK status = %d, want NFS4ERR_INVAL (%d)", got.Status, types.NFS4ERR_INVAL)
+			}
+
+			locktArgs := encodeLocktArgs(
+				types.WRITE_LT, r.offset, r.length, clientID, []byte("range-owner"),
+			)
+			if got := h.handleLockT(newCtx(), bytes.NewReader(locktArgs)); got.Status != types.NFS4ERR_INVAL {
+				t.Errorf("LOCKT status = %d, want NFS4ERR_INVAL (%d)", got.Status, types.NFS4ERR_INVAL)
+			}
+
+			// LOCKU4args: locktype, seqid, lock_stateid, offset, length.
+			var lockuArgs bytes.Buffer
+			_ = xdr.WriteUint32(&lockuArgs, types.WRITE_LT)
+			_ = xdr.WriteUint32(&lockuArgs, 1)
+			types.EncodeStateid4(&lockuArgs, openStateid)
+			_ = xdr.WriteUint64(&lockuArgs, r.offset)
+			_ = xdr.WriteUint64(&lockuArgs, r.length)
+			if got := h.handleLockU(newCtx(), bytes.NewReader(lockuArgs.Bytes())); got.Status != types.NFS4ERR_INVAL {
+				t.Errorf("LOCKU status = %d, want NFS4ERR_INVAL (%d)", got.Status, types.NFS4ERR_INVAL)
+			}
+		})
+	}
 }

--- a/internal/adapter/nfs/v4/handlers/lock_test.go
+++ b/internal/adapter/nfs/v4/handlers/lock_test.go
@@ -1264,7 +1264,8 @@ func TestHandleLock_InvalidRange(t *testing.T) {
 				t.Fatalf("failed to decode lock stateid: %v", err)
 			}
 
-			// LOCKT carries no seqid, so its range check sits in the handler.
+			// LOCKT carries no seqid, so state.TestLock rejects the range with
+			// no owner sequence to move.
 			locktArgs := encodeLocktArgs(types.WRITE_LT, r.offset, r.length, clientID, owner)
 			if got := h.handleLockT(ctx, bytes.NewReader(locktArgs)); got.Status != types.NFS4ERR_INVAL {
 				t.Errorf("LOCKT status = %d, want NFS4ERR_INVAL (%d)", got.Status, types.NFS4ERR_INVAL)

--- a/internal/adapter/nfs/v4/handlers/lock_test.go
+++ b/internal/adapter/nfs/v4/handlers/lock_test.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"bytes"
 	"context"
-	"math"
 	"testing"
 	"time"
 
@@ -1200,36 +1199,11 @@ func TestFullLockLifecycle(t *testing.T) {
 // Byte-Range Validation
 // ============================================================================
 
-func TestLockRangeValid(t *testing.T) {
-	tests := []struct {
-		name   string
-		offset uint64
-		length uint64
-		want   bool
-	}{
-		{"ordinary range", 25, 75, true},
-		{"zero length", 25, 0, false},
-		{"zero length at zero offset", 0, 0, false},
-		{"all-ones length locks through EOF", 100, math.MaxUint64, true},
-		{"all-ones length from the highest offset", math.MaxUint64, math.MaxUint64, true},
-		{"sum lands exactly on the maximum", 1, math.MaxUint64 - 1, true},
-		{"sum passes the maximum by one", 2, math.MaxUint64 - 1, false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := lockRangeValid(tt.offset, tt.length); got != tt.want {
-				t.Errorf("lockRangeValid(%d, %d) = %v, want %v",
-					tt.offset, tt.length, got, tt.want)
-			}
-		})
-	}
-}
-
 // TestHandleLock_InvalidRange drives the two ranges RFC 7530 Section 16.10.4
-// rejects through all three ops that carry one. Each reaches the range check
-// before it consults lock state, so an unlocked file and an unused stateid are
-// enough to reach the check and no lock state is created by any of these calls.
+// rejects through all three ops that carry one. LOCK and LOCKU are rejected
+// inside the state manager, past the seqid checks, so each rejection consumes
+// the owner seqid the way RFC 7530 Section 9.1.7 requires: the operations that
+// follow here use the next seqid in sequence and must succeed.
 func TestHandleLock_InvalidRange(t *testing.T) {
 	const overflowLength = uint64(0xfffffffffffffffe) // what pynfs puts on the wire
 
@@ -1252,43 +1226,70 @@ func TestHandleLock_InvalidRange(t *testing.T) {
 			sm.SetLockManager(lm)
 			h := NewHandler(nil, pfs, sm)
 
-			clientID, openStateid, _ := setupHandlerLockClient(t, h)
+			clientID, openStateid, openSeqid := setupHandlerLockClient(t, h)
 
-			fileHandle := []byte("/export:lock-range-file")
-			newCtx := func() *types.CompoundContext {
-				ctx := &types.CompoundContext{
-					Context:    context.Background(),
-					ClientAddr: "127.0.0.1:9999",
-					CurrentFH:  make([]byte, len(fileHandle)),
-				}
-				copy(ctx.CurrentFH, fileHandle)
-				return ctx
+			fileHandle := []byte("/export:lock-test-file")
+			ctx := &types.CompoundContext{
+				Context:    context.Background(),
+				ClientAddr: "127.0.0.1:9999",
+				CurrentFH:  make([]byte, len(fileHandle)),
 			}
+			copy(ctx.CurrentFH, fileHandle)
 
-			lockArgs := encodeNewLockOwnerArgs(
+			owner := []byte("range-owner")
+
+			badLock := encodeNewLockOwnerArgs(
 				types.WRITE_LT, r.offset, r.length,
-				1, openStateid, 0, clientID, []byte("range-owner"),
+				openSeqid+1, openStateid, 1, clientID, owner,
 			)
-			if got := h.handleLock(newCtx(), bytes.NewReader(lockArgs)); got.Status != types.NFS4ERR_INVAL {
-				t.Errorf("LOCK status = %d, want NFS4ERR_INVAL (%d)", got.Status, types.NFS4ERR_INVAL)
+			if got := h.handleLock(ctx, bytes.NewReader(badLock)); got.Status != types.NFS4ERR_INVAL {
+				t.Fatalf("LOCK status = %d, want NFS4ERR_INVAL (%d)", got.Status, types.NFS4ERR_INVAL)
 			}
 
-			locktArgs := encodeLocktArgs(
-				types.WRITE_LT, r.offset, r.length, clientID, []byte("range-owner"),
+			// Both the open-owner and the lock-owner sequences must have moved
+			// past the rejected LOCK; a server that kept them would answer this
+			// NFS4ERR_BAD_SEQID and stay one behind the client forever.
+			goodLock := encodeNewLockOwnerArgs(
+				types.WRITE_LT, 0, 100,
+				openSeqid+2, openStateid, 2, clientID, owner,
 			)
-			if got := h.handleLockT(newCtx(), bytes.NewReader(locktArgs)); got.Status != types.NFS4ERR_INVAL {
+			lockResult := h.handleLock(ctx, bytes.NewReader(goodLock))
+			if lockResult.Status != types.NFS4_OK {
+				t.Fatalf("LOCK after invalid range status = %d, want NFS4_OK", lockResult.Status)
+			}
+			lockReader := bytes.NewReader(lockResult.Data)
+			_, _ = xdr.DecodeUint32(lockReader) // status
+			lockStateid, err := types.DecodeStateid4(lockReader)
+			if err != nil {
+				t.Fatalf("failed to decode lock stateid: %v", err)
+			}
+
+			// LOCKT carries no seqid, so its range check sits in the handler.
+			locktArgs := encodeLocktArgs(types.WRITE_LT, r.offset, r.length, clientID, owner)
+			if got := h.handleLockT(ctx, bytes.NewReader(locktArgs)); got.Status != types.NFS4ERR_INVAL {
 				t.Errorf("LOCKT status = %d, want NFS4ERR_INVAL (%d)", got.Status, types.NFS4ERR_INVAL)
 			}
 
 			// LOCKU4args: locktype, seqid, lock_stateid, offset, length.
-			var lockuArgs bytes.Buffer
-			_ = xdr.WriteUint32(&lockuArgs, types.WRITE_LT)
-			_ = xdr.WriteUint32(&lockuArgs, 1)
-			types.EncodeStateid4(&lockuArgs, openStateid)
-			_ = xdr.WriteUint64(&lockuArgs, r.offset)
-			_ = xdr.WriteUint64(&lockuArgs, r.length)
-			if got := h.handleLockU(newCtx(), bytes.NewReader(lockuArgs.Bytes())); got.Status != types.NFS4ERR_INVAL {
-				t.Errorf("LOCKU status = %d, want NFS4ERR_INVAL (%d)", got.Status, types.NFS4ERR_INVAL)
+			encodeLockuArgs := func(seqid uint32, offset, length uint64) []byte {
+				var buf bytes.Buffer
+				_ = xdr.WriteUint32(&buf, types.WRITE_LT)
+				_ = xdr.WriteUint32(&buf, seqid)
+				types.EncodeStateid4(&buf, lockStateid)
+				_ = xdr.WriteUint64(&buf, offset)
+				_ = xdr.WriteUint64(&buf, length)
+				return buf.Bytes()
+			}
+
+			bad := encodeLockuArgs(3, r.offset, r.length)
+			if got := h.handleLockU(ctx, bytes.NewReader(bad)); got.Status != types.NFS4ERR_INVAL {
+				t.Fatalf("LOCKU status = %d, want NFS4ERR_INVAL (%d)", got.Status, types.NFS4ERR_INVAL)
+			}
+
+			// Same check for the lock-owner sequence after a rejected LOCKU.
+			good := encodeLockuArgs(4, 0, 100)
+			if got := h.handleLockU(ctx, bytes.NewReader(good)); got.Status != types.NFS4_OK {
+				t.Errorf("LOCKU after invalid range status = %d, want NFS4_OK", got.Status)
 			}
 		})
 	}

--- a/internal/adapter/nfs/v4/state/lockowner.go
+++ b/internal/adapter/nfs/v4/state/lockowner.go
@@ -175,9 +175,12 @@ func EncodeLOCK4denied(buf *bytes.Buffer, denied *LOCK4denied) {
 // validateLockRange checks that offset and length describe a byte range the
 // server will act on. RFC 7530 Section 16.10.4 rejects a length of zero, and
 // rejects a length that is not all-ones whose sum with the offset exceeds the
-// maximum 64-bit unsigned value. A length with every bit set means "from offset
-// through end-of-file", so it is exempt from that sum. Sections 16.11.4 and
-// 16.12.4 apply the same two rules to LOCKT and LOCKU.
+// maximum 64-bit unsigned value. A length with every bit set is the wire
+// encoding for "from offset to end-of-file", so it is exempt from that sum.
+// Sections 16.11.4 and 16.12.4 apply the same two rules to LOCKT and LOCKU.
+//
+// Exempting all-ones only admits the range: the lock manager still receives the
+// literal length, which is not the end-of-file range it names.
 //
 // Returns NFS4ERR_INVAL on a rejected range.
 func validateLockRange(offset, length uint64) error {

--- a/internal/adapter/nfs/v4/state/lockowner.go
+++ b/internal/adapter/nfs/v4/state/lockowner.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"math"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
@@ -170,6 +171,24 @@ func EncodeLOCK4denied(buf *bytes.Buffer, denied *LOCK4denied) {
 // ============================================================================
 // Validation Helpers
 // ============================================================================
+
+// validateLockRange checks that offset and length describe a byte range the
+// server will act on. RFC 7530 Section 16.10.4 rejects a length of zero, and
+// rejects a length that is not all-ones whose sum with the offset exceeds the
+// maximum 64-bit unsigned value. A length with every bit set means "from offset
+// through end-of-file", so it is exempt from that sum. Sections 16.11.4 and
+// 16.12.4 apply the same two rules to LOCKT and LOCKU.
+//
+// Returns NFS4ERR_INVAL on a rejected range.
+func validateLockRange(offset, length uint64) error {
+	if length != 0 && (length == math.MaxUint64 || offset <= math.MaxUint64-length) {
+		return nil
+	}
+	return &NFS4StateError{
+		Status:  types.NFS4ERR_INVAL,
+		Message: "invalid byte-range lock offset/length",
+	}
+}
 
 // validateOpenModeForLock checks that the open state's share_access mode
 // is compatible with the requested lock type.

--- a/internal/adapter/nfs/v4/state/lockowner_test.go
+++ b/internal/adapter/nfs/v4/state/lockowner_test.go
@@ -2,6 +2,8 @@ package state
 
 import (
 	"context"
+	"errors"
+	"math"
 	"testing"
 	"time"
 
@@ -941,5 +943,44 @@ func TestLockNew_BlockingType(t *testing.T) {
 	}
 	if lockResult2.Denied == nil {
 		t.Fatal("expected LOCK4denied for READW_LT on conflicting exclusive range")
+	}
+}
+
+// ============================================================================
+// ValidateLockRange Tests
+// ============================================================================
+
+func TestValidateLockRange(t *testing.T) {
+	tests := []struct {
+		name    string
+		offset  uint64
+		length  uint64
+		wantErr bool
+	}{
+		{"ordinary range", 25, 75, false},
+		{"zero length", 25, 0, true},
+		{"zero length at zero offset", 0, 0, true},
+		{"all-ones length locks through EOF", 100, math.MaxUint64, false},
+		{"all-ones length from the highest offset", math.MaxUint64, math.MaxUint64, false},
+		{"sum lands exactly on the maximum", 1, math.MaxUint64 - 1, false},
+		{"sum passes the maximum by one", 2, math.MaxUint64 - 1, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateLockRange(tt.offset, tt.length)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateLockRange(%d, %d) = %v, wantErr %v",
+					tt.offset, tt.length, err, tt.wantErr)
+			}
+			if err == nil {
+				return
+			}
+			var stateErr *NFS4StateError
+			if !errors.As(err, &stateErr) || stateErr.Status != types.NFS4ERR_INVAL {
+				t.Errorf("validateLockRange(%d, %d) error = %v, want NFS4ERR_INVAL",
+					tt.offset, tt.length, err)
+			}
+		})
 	}
 }

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -2107,9 +2107,12 @@ func (sm *StateManager) LockNew(
 	// this point is a seqid verdict, and those are exempt anyway.
 	defer func() { lockOwner.consumeSeqidOnError(lockSeqid, err) }()
 
-	// 6. Validate open mode for lock type. This runs after both seqid checks so
-	// a bad seqid, which must leave the sequence untouched, outranks
-	// NFS4ERR_OPENMODE, which consumes it.
+	// 6. Validate the byte range and the open mode for the lock type. Both run
+	// after the seqid checks so a bad seqid, which must leave the sequence
+	// untouched, outranks NFS4ERR_INVAL and NFS4ERR_OPENMODE, which consume it.
+	if err := validateLockRange(offset, length); err != nil {
+		return nil, err
+	}
 	if err := validateOpenModeForLock(openState, lockType); err != nil {
 		return nil, err
 	}
@@ -2245,12 +2248,15 @@ func (sm *StateManager) LockExisting(
 		}
 	}
 
-	// 4. Validate open mode for lock type
+	// 4. Validate the byte range and the open mode for the lock type
+	if err := validateLockRange(offset, length); err != nil {
+		return nil, err
+	}
 	if err := validateOpenModeForLock(lockState.OpenState, lockType); err != nil {
 		return nil, err
 	}
 
-	// 4. Acquire the lock
+	// 5. Acquire the lock
 	denied, err := sm.acquireLock(ctx, lockState, lockType, offset, length, reclaim)
 	if err != nil {
 		return nil, err
@@ -2265,7 +2271,7 @@ func (sm *StateManager) LockExisting(
 		}, nil
 	}
 
-	// 5. Success: update state
+	// 6. Success: update state
 	lockState.Stateid.Seqid = nextSeqID(lockState.Stateid.Seqid)
 	lockOwner.LastSeqID = lockSeqid
 
@@ -2398,6 +2404,10 @@ func (sm *StateManager) TestLock(
 	clientID uint64, ownerData []byte,
 	fileHandle []byte, lockType uint32, offset, length uint64,
 ) (*LOCK4denied, error) {
+	if err := validateLockRange(offset, length); err != nil {
+		return nil, err
+	}
+
 	lm := sm.lockManagerFor(fileHandle)
 	if lm == nil {
 		// No lock manager = no locks possible = no conflicts
@@ -2543,7 +2553,12 @@ func (sm *StateManager) UnlockFile(
 		}
 	}
 
-	// 4. Release the lock via unified lock manager
+	// 4. Validate the byte range
+	if err := validateLockRange(offset, length); err != nil {
+		return nil, err
+	}
+
+	// 5. Release the lock via unified lock manager
 	if lm := sm.lockManagerFor(lockState.FileHandle); lm != nil {
 		owner := lock.LockOwner{
 			OwnerID:   lockOwner.LockManagerOwnerID(),
@@ -2566,7 +2581,7 @@ func (sm *StateManager) UnlockFile(
 		}
 	}
 
-	// 5. Success: increment lock stateid seqid
+	// 6. Success: increment lock stateid seqid
 	lockState.Stateid.Seqid = nextSeqID(lockState.Stateid.Seqid)
 	lockOwner.LastSeqID = seqid
 


### PR DESCRIPTION

# Description

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)


## Changes Made

Validate LOCK, LOCKT, LOCKU ranges.

Makes 6 pynfs tests green.

## Testing

- [X] Unit tests pass (`go test ./...`)


## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published
