### PR TITLE
fix(nfs4): report only the ACCESS rights the object and minorversion can answer

### DIFF
--- a/internal/adapter/nfs/v4/handlers/access.go
+++ b/internal/adapter/nfs/v4/handlers/access.go
@@ -35,20 +35,20 @@ const (
 )
 
 // accessSupportedFor returns the ACCESS4 bits the server can reliably check for
-// one object under one minorversion, before the requested mask narrows them
-// further.
+// one object under one minorversion, narrowed to the bits the client asked
+// about: RFC 7530 Section 16.1.4 says the reply's "supported" field "will
+// contain only as many values as were originally sent in the arguments".
 //
-// Three bits are not reportable against every object. RFC 7530 Section 16.1.4
-// gives ACCESS4_LOOKUP "no meaning for non-directory objects" and
-// ACCESS4_EXECUTE "no meaning for a directory". Section 16.1.5 has a server that
-// derives a file's delete permission from the directory holding it report
-// ACCESS4_DELETE as 0 for a non-directory, since the object's own handle cannot
-// answer that question; the client then ignores the bit.
+// Three bits are not reportable against every object. Section 16.1.4 gives
+// ACCESS4_LOOKUP "no meaning for non-directory objects" and ACCESS4_EXECUTE "no
+// meaning for a directory". Section 16.1.2 defines ACCESS4_DELETE as deleting a
+// directory entry, so it too is a right of the directory, not of the object the
+// entry names.
 //
 // The RFC 8276 extended-attribute bits belong to minorversion 2, which is the
 // gate the dispatch table already applies to the operations they advertise, so
 // reporting them to a v4.0 or v4.1 client would promise ops it cannot call.
-func accessSupportedFor(isDir bool, minorVersion uint32) uint32 {
+func accessSupportedFor(isDir bool, minorVersion, requested uint32) uint32 {
 	supported := uint32(ACCESS4_READ | ACCESS4_MODIFY | ACCESS4_EXTEND)
 
 	if isDir {
@@ -61,7 +61,7 @@ func accessSupportedFor(isDir bool, minorVersion uint32) uint32 {
 		supported |= ACCESS4_XAREAD | ACCESS4_XAWRITE | ACCESS4_XALIST
 	}
 
-	return supported
+	return supported & requested
 }
 
 // handleAccess implements the ACCESS operation (RFC 7530 Section 16.1).
@@ -96,7 +96,7 @@ func (h *Handler) handleAccess(ctx *types.CompoundContext, reader io.Reader) *ty
 		// both fields from the same mask keeps granted a subset of supported, and
 		// supported a subset of the request, even when the client sends unknown or
 		// reserved bits.
-		supported := accessSupportedFor(true, ctx.MinorVersion) & accessReq
+		supported := accessSupportedFor(true, ctx.MinorVersion, accessReq)
 
 		var buf bytes.Buffer
 		_ = xdr.WriteUint32(&buf, types.NFS4_OK)
@@ -171,10 +171,7 @@ func (h *Handler) accessRealFS(ctx *types.CompoundContext, accessReq uint32) *ty
 		}
 	}
 
-	// RFC 7530 Section 16.1.4: "the supported field will contain only as many
-	// values as were originally sent in the arguments", so the bits this object
-	// and minorversion can answer for are narrowed to the request.
-	supported := accessSupportedFor(file.Type == metadata.FileTypeDirectory, ctx.MinorVersion) & accessReq
+	supported := accessSupportedFor(file.Type == metadata.FileTypeDirectory, ctx.MinorVersion, accessReq)
 
 	// Granted is masked by supported rather than by the request: CheckPermissions
 	// returns a subset of the requested generic flags, but the

--- a/internal/adapter/nfs/v4/handlers/access.go
+++ b/internal/adapter/nfs/v4/handlers/access.go
@@ -34,6 +34,9 @@ const (
 	ACCESS4_XALIST  = 0x100 // list named attributes
 )
 
+// accessXattrBits is the RFC 8276 extended-attribute set.
+const accessXattrBits = uint32(ACCESS4_XAREAD | ACCESS4_XAWRITE | ACCESS4_XALIST)
+
 // accessSupportedFor returns the ACCESS4 bits the server can reliably check for
 // one object under one minorversion, narrowed to the bits the client asked
 // about: RFC 7530 Section 16.1.4 says the reply's "supported" field "will
@@ -41,7 +44,7 @@ const (
 //
 // Three bits are not reportable against every object. Section 16.1.4 gives
 // ACCESS4_LOOKUP "no meaning for non-directory objects" and ACCESS4_EXECUTE "no
-// meaning for a directory". Section 16.1.2 defines ACCESS4_DELETE as deleting a
+// meaning for a directory". It also defines ACCESS4_DELETE as deleting a
 // directory entry, so it too is a right of the directory, not of the object the
 // entry names.
 //
@@ -58,7 +61,7 @@ func accessSupportedFor(isDir bool, minorVersion, requested uint32) uint32 {
 	}
 
 	if minorVersion >= 2 {
-		supported |= ACCESS4_XAREAD | ACCESS4_XAWRITE | ACCESS4_XALIST
+		supported |= accessXattrBits
 	}
 
 	return supported & requested
@@ -96,7 +99,12 @@ func (h *Handler) handleAccess(ctx *types.CompoundContext, reader io.Reader) *ty
 		// both fields from the same mask keeps granted a subset of supported, and
 		// supported a subset of the request, even when the client sends unknown or
 		// reserved bits.
-		supported := accessSupportedFor(true, ctx.MinorVersion, accessReq)
+		//
+		// Pseudo-fs nodes hold no named attributes, whatever the minorversion:
+		// GETXATTR and LISTXATTRS answer NFS4ERR_NOTSUPP on these handles and
+		// SETXATTR answers NFS4ERR_ROFS, so claiming the RFC 8276 bits would send
+		// a v4.2 client into calls that cannot succeed.
+		supported := accessSupportedFor(true, ctx.MinorVersion, accessReq) &^ accessXattrBits
 
 		var buf bytes.Buffer
 		_ = xdr.WriteUint32(&buf, types.NFS4_OK)

--- a/internal/adapter/nfs/v4/handlers/access.go
+++ b/internal/adapter/nfs/v4/handlers/access.go
@@ -34,12 +34,35 @@ const (
 	ACCESS4_XALIST  = 0x100 // list named attributes
 )
 
-// accessSupported is every ACCESS4 bit this server can evaluate, reported in the
-// ACCESS reply's "supported" field. The "access" (granted) field is always a
-// subset of this.
-const accessSupported = uint32(ACCESS4_READ | ACCESS4_LOOKUP | ACCESS4_MODIFY |
-	ACCESS4_EXTEND | ACCESS4_DELETE | ACCESS4_EXECUTE |
-	ACCESS4_XAREAD | ACCESS4_XAWRITE | ACCESS4_XALIST)
+// accessSupportedFor returns the ACCESS4 bits the server can reliably check for
+// one object under one minorversion, before the requested mask narrows them
+// further.
+//
+// Three bits are not reportable against every object. RFC 7530 Section 16.1.4
+// gives ACCESS4_LOOKUP "no meaning for non-directory objects" and
+// ACCESS4_EXECUTE "no meaning for a directory". Section 16.1.5 has a server that
+// derives a file's delete permission from the directory holding it report
+// ACCESS4_DELETE as 0 for a non-directory, since the object's own handle cannot
+// answer that question; the client then ignores the bit.
+//
+// The RFC 8276 extended-attribute bits belong to minorversion 2, which is the
+// gate the dispatch table already applies to the operations they advertise, so
+// reporting them to a v4.0 or v4.1 client would promise ops it cannot call.
+func accessSupportedFor(isDir bool, minorVersion uint32) uint32 {
+	supported := uint32(ACCESS4_READ | ACCESS4_MODIFY | ACCESS4_EXTEND)
+
+	if isDir {
+		supported |= ACCESS4_LOOKUP | ACCESS4_DELETE
+	} else {
+		supported |= ACCESS4_EXECUTE
+	}
+
+	if minorVersion >= 2 {
+		supported |= ACCESS4_XAREAD | ACCESS4_XAWRITE | ACCESS4_XALIST
+	}
+
+	return supported
+}
 
 // handleAccess implements the ACCESS operation (RFC 7530 Section 16.1).
 // Checks access permissions for the current filehandle against a requested bitmask.
@@ -68,13 +91,17 @@ func (h *Handler) handleAccess(ctx *types.CompoundContext, reader io.Reader) *ty
 
 	// Check if current FH is a pseudo-fs handle
 	if pseudofs.IsPseudoFSHandle(ctx.CurrentFH) {
-		// Pseudo-fs directories are always accessible: grant every supported bit
-		// the client asked for. Masking by accessSupported keeps the granted set a
-		// subset of supported even if the client sends unknown/reserved bits.
+		// Pseudo-fs nodes are directories and are always accessible: grant every
+		// bit the client asked for that is checkable against a directory. Deriving
+		// both fields from the same mask keeps granted a subset of supported, and
+		// supported a subset of the request, even when the client sends unknown or
+		// reserved bits.
+		supported := accessSupportedFor(true, ctx.MinorVersion) & accessReq
+
 		var buf bytes.Buffer
 		_ = xdr.WriteUint32(&buf, types.NFS4_OK)
-		_ = xdr.WriteUint32(&buf, accessSupported)           // supported
-		_ = xdr.WriteUint32(&buf, accessReq&accessSupported) // access granted
+		_ = xdr.WriteUint32(&buf, supported) // supported
+		_ = xdr.WriteUint32(&buf, supported) // access granted
 
 		return &types.CompoundResult{
 			Status: types.NFS4_OK,
@@ -94,7 +121,8 @@ func (h *Handler) handleAccess(ctx *types.CompoundContext, reader io.Reader) *ty
 // so ACLs, DENY ACEs, and SID-based grants are honored identically across
 // protocols. The handler only translates protocol access bits to and from the
 // canonical metadata.Permission vocabulary; all permission logic lives in the
-// metadata layer. All 6 access bits are reported as supported.
+// metadata layer. The reported "supported" set is whatever accessSupportedFor
+// allows for this object and minorversion, narrowed to the requested bits.
 func (h *Handler) accessRealFS(ctx *types.CompoundContext, accessReq uint32) *types.CompoundResult {
 	authCtx, _, err := h.buildV4AuthContext(ctx, ctx.CurrentFH)
 	if err != nil {
@@ -143,16 +171,17 @@ func (h *Handler) accessRealFS(ctx *types.CompoundContext, accessReq uint32) *ty
 		}
 	}
 
-	// Mask back to what the client actually asked for; CheckPermissions only
-	// ever returns a subset of the requested generic flags, but the
-	// permission<->access translation is not perfectly bijective for
-	// directories (LOOKUP and EXECUTE both map to Traverse), so re-AND with
-	// the requested ACCESS4 bits.
-	granted := permissionsToNFSAccess(grantedPerms, file.Type) & accessReq
+	// RFC 7530 Section 16.1.4: "the supported field will contain only as many
+	// values as were originally sent in the arguments", so the bits this object
+	// and minorversion can answer for are narrowed to the request.
+	supported := accessSupportedFor(file.Type == metadata.FileTypeDirectory, ctx.MinorVersion) & accessReq
 
-	// Report all ACCESS4 bits the server can evaluate, including the RFC 8276
-	// extended-attribute bits so the NFSv4.2 client will issue xattr operations.
-	supported := accessSupported
+	// Granted is masked by supported rather than by the request: CheckPermissions
+	// returns a subset of the requested generic flags, but the
+	// permission<->access translation is not perfectly bijective for directories
+	// (LOOKUP and EXECUTE both map to Traverse), and a right the server declined
+	// to claim it can check must not come back granted.
+	granted := permissionsToNFSAccess(grantedPerms, file.Type) & supported
 
 	// Debug log the access check result
 	var uid, gid uint32

--- a/internal/adapter/nfs/v4/handlers/access_test.go
+++ b/internal/adapter/nfs/v4/handlers/access_test.go
@@ -14,15 +14,12 @@ const allValidAccessBits = uint32(ACCESS4_READ | ACCESS4_LOOKUP | ACCESS4_MODIFY
 // the RFC states, over every request an NFSv4.0 client can make. It mirrors what
 // pynfs asserts in st_access._try_all_combos and _try_invalid, so a change that
 // widens the reported set fails here rather than in a suite run.
-//
-// The narrowing to the requested bits happens at the call site, so the test
-// applies the same mask the handlers do.
 func TestAccessSupportedFor(t *testing.T) {
 	objects := []struct {
 		name  string
 		isDir bool
 		// forbid is the set with no meaning for this object type: RFC 7530
-		// Section 16.1.4 for LOOKUP and EXECUTE, Section 16.1.5 for DELETE.
+		// Section 16.1.4 for LOOKUP and EXECUTE, Section 16.1.2 for DELETE.
 		forbid uint32
 	}{
 		{"directory", true, ACCESS4_EXECUTE},
@@ -33,7 +30,7 @@ func TestAccessSupportedFor(t *testing.T) {
 		for _, minor := range []uint32{0, 1, 2} {
 			t.Run(fmt.Sprintf("%s/minor%d", obj.name, minor), func(t *testing.T) {
 				for requested := uint32(0); requested <= allValidAccessBits; requested++ {
-					supported := accessSupportedFor(obj.isDir, minor) & requested
+					supported := accessSupportedFor(obj.isDir, minor, requested)
 
 					if extra := supported &^ requested; extra != 0 {
 						t.Fatalf("minor %d, requested 0x%02x: supported 0x%02x is not a subset (extra 0x%02x)",
@@ -60,7 +57,7 @@ func TestAccessSupportedForUndefinedBits(t *testing.T) {
 	for _, isDir := range []bool{true, false} {
 		for _, minor := range []uint32{0, 1} {
 			for _, requested := range invalid {
-				supported := accessSupportedFor(isDir, minor) & requested
+				supported := accessSupportedFor(isDir, minor, requested)
 				if undefined := supported &^ allValidAccessBits; undefined != 0 {
 					t.Errorf("isDir=%v minor=%d requested=0x%02x: supported 0x%02x reports undefined bits 0x%02x",
 						isDir, minor, requested, supported, undefined)
@@ -70,7 +67,7 @@ func TestAccessSupportedForUndefinedBits(t *testing.T) {
 	}
 
 	// Minorversion 2 defines them, so there the bits are reportable.
-	if got := accessSupportedFor(false, 2) & ACCESS4_XAREAD; got != ACCESS4_XAREAD {
+	if got := accessSupportedFor(false, 2, ACCESS4_XAREAD); got != ACCESS4_XAREAD {
 		t.Errorf("minor 2 XAREAD = 0x%02x, want 0x%02x", got, ACCESS4_XAREAD)
 	}
 }

--- a/internal/adapter/nfs/v4/handlers/access_test.go
+++ b/internal/adapter/nfs/v4/handlers/access_test.go
@@ -1,0 +1,76 @@
+package handlers
+
+import (
+	"fmt"
+	"testing"
+)
+
+// allValidAccessBits is the ACCESS4 set RFC 7530 Section 16.1.2 defines. The
+// RFC 8276 extended-attribute bits sit above it and belong to minorversion 2.
+const allValidAccessBits = uint32(ACCESS4_READ | ACCESS4_LOOKUP | ACCESS4_MODIFY |
+	ACCESS4_EXTEND | ACCESS4_DELETE | ACCESS4_EXECUTE)
+
+// TestAccessSupportedFor holds the reply's "supported" field to the three rules
+// the RFC states, over every request an NFSv4.0 client can make. It mirrors what
+// pynfs asserts in st_access._try_all_combos and _try_invalid, so a change that
+// widens the reported set fails here rather than in a suite run.
+//
+// The narrowing to the requested bits happens at the call site, so the test
+// applies the same mask the handlers do.
+func TestAccessSupportedFor(t *testing.T) {
+	objects := []struct {
+		name  string
+		isDir bool
+		// forbid is the set with no meaning for this object type: RFC 7530
+		// Section 16.1.4 for LOOKUP and EXECUTE, Section 16.1.5 for DELETE.
+		forbid uint32
+	}{
+		{"directory", true, ACCESS4_EXECUTE},
+		{"non-directory", false, ACCESS4_LOOKUP | ACCESS4_DELETE},
+	}
+
+	for _, obj := range objects {
+		for _, minor := range []uint32{0, 1, 2} {
+			t.Run(fmt.Sprintf("%s/minor%d", obj.name, minor), func(t *testing.T) {
+				for requested := uint32(0); requested <= allValidAccessBits; requested++ {
+					supported := accessSupportedFor(obj.isDir, minor) & requested
+
+					if extra := supported &^ requested; extra != 0 {
+						t.Fatalf("minor %d, requested 0x%02x: supported 0x%02x is not a subset (extra 0x%02x)",
+							minor, requested, supported, extra)
+					}
+					if meaningless := supported & obj.forbid; meaningless != 0 {
+						t.Fatalf("minor %d, requested 0x%02x: supported 0x%02x claims bits with no meaning for a %s (0x%02x)",
+							minor, requested, supported, obj.name, meaningless)
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestAccessSupportedForUndefinedBits pins the minorversion gate on the RFC 8276
+// extended-attribute bits. A v4.0 or v4.1 client that asks for one must not be
+// told the server checks it, because the dispatch table refuses the xattr
+// operations it would advertise below minorversion 2.
+func TestAccessSupportedForUndefinedBits(t *testing.T) {
+	// The values pynfs sends in st_access._try_invalid.
+	invalid := []uint32{64, 65, 66, 127, 128, 129}
+
+	for _, isDir := range []bool{true, false} {
+		for _, minor := range []uint32{0, 1} {
+			for _, requested := range invalid {
+				supported := accessSupportedFor(isDir, minor) & requested
+				if undefined := supported &^ allValidAccessBits; undefined != 0 {
+					t.Errorf("isDir=%v minor=%d requested=0x%02x: supported 0x%02x reports undefined bits 0x%02x",
+						isDir, minor, requested, supported, undefined)
+				}
+			}
+		}
+	}
+
+	// Minorversion 2 defines them, so there the bits are reportable.
+	if got := accessSupportedFor(false, 2) & ACCESS4_XAREAD; got != ACCESS4_XAREAD {
+		t.Errorf("minor 2 XAREAD = 0x%02x, want 0x%02x", got, ACCESS4_XAREAD)
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/access_test.go
+++ b/internal/adapter/nfs/v4/handlers/access_test.go
@@ -19,7 +19,7 @@ func TestAccessSupportedFor(t *testing.T) {
 		name  string
 		isDir bool
 		// forbid is the set with no meaning for this object type: RFC 7530
-		// Section 16.1.4 for LOOKUP and EXECUTE, Section 16.1.2 for DELETE.
+		// Section 16.1.4 for LOOKUP, EXECUTE and DELETE.
 		forbid uint32
 	}{
 		{"directory", true, ACCESS4_EXECUTE},

--- a/internal/adapter/nfs/v4/handlers/ops_test.go
+++ b/internal/adapter/nfs/v4/handlers/ops_test.go
@@ -1023,11 +1023,19 @@ func TestAccess_PseudoFS(t *testing.T) {
 	supported := binary.BigEndian.Uint32(decoded.Results[1].ExtraData[0:4])
 	access := binary.BigEndian.Uint32(decoded.Results[1].ExtraData[4:8])
 
-	if supported != allBits {
-		t.Errorf("supported = 0x%x, want 0x%x", supported, allBits)
+	// The pseudo-fs root is a directory reached over a minorversion-0 COMPOUND,
+	// so the reply drops the three bits it cannot answer for: ACCESS4_EXECUTE
+	// has no meaning for a directory (RFC 7530 Section 16.1.4) and the RFC 8276
+	// extended-attribute bits are not defined below minorversion 2.
+	wantSupported := uint32(ACCESS4_READ | ACCESS4_LOOKUP | ACCESS4_MODIFY |
+		ACCESS4_EXTEND | ACCESS4_DELETE)
+
+	if supported != wantSupported {
+		t.Errorf("supported = 0x%x, want 0x%x", supported, wantSupported)
 	}
-	if access != allBits {
-		t.Errorf("access = 0x%x, want 0x%x", access, allBits)
+	// Pseudo-fs grants everything it reports as checkable.
+	if access != wantSupported {
+		t.Errorf("access = 0x%x, want 0x%x", access, wantSupported)
 	}
 }
 

--- a/internal/adapter/nfs/v4/handlers/realfs_test.go
+++ b/internal/adapter/nfs/v4/handlers/realfs_test.go
@@ -676,8 +676,8 @@ func TestAccess_RealFS_RootGetsAll(t *testing.T) {
 	// Only the bits that are MEANINGFUL for the object type are reportable, and
 	// the target is a regular file on a minorversion-0 context. ACCESS4_LOOKUP
 	// is a directory-search right (RFC 7530 Section 16.1.4), ACCESS4_DELETE
-	// deletes a directory entry and so belongs to the directory (Section
-	// 16.1.2), and the RFC 8276 extended-attribute bits are not defined below
+	// deletes a directory entry and so belongs to the directory (same section),
+	// and the RFC 8276 extended-attribute bits are not defined below
 	// minorversion 2.
 	wantSupported := uint32(ACCESS4_READ | ACCESS4_MODIFY | ACCESS4_EXTEND | ACCESS4_EXECUTE)
 
@@ -750,6 +750,77 @@ func TestAccess_RealFS_OtherPermissions(t *testing.T) {
 	// Other user should have NO access (mode 0700, other = ---)
 	if access != 0 {
 		t.Errorf("other user should have no access for mode 0700, got 0x%x", access)
+	}
+}
+
+// TestAccess_RealFS_SupportedNarrowsToRequest pins the rule at the call site
+// rather than in accessSupportedFor: a client that asks about one right is told
+// about that right alone, however many the server could have answered for the
+// object. The file is readable and executable, so the three bits left out of
+// the request are ones the reply could otherwise have carried.
+func TestAccess_RealFS_SupportedNarrowsToRequest(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+
+	fileHandle := fx.createTestFile(t, fx.rootHandle, "one-bit.txt", metadata.FileTypeRegular, 0o755, 1000, 1000)
+
+	ctx := newRealFSContext(1000, 1000) // owner
+	ctx.CurrentFH = make([]byte, len(fileHandle))
+	copy(ctx.CurrentFH, fileHandle)
+
+	result := fx.handler.accessRealFS(ctx, ACCESS4_READ)
+	if result.Status != types.NFS4_OK {
+		t.Fatalf("ACCESS status = %d, want NFS4_OK", result.Status)
+	}
+
+	reader := bytes.NewReader(result.Data)
+	_, _ = xdr.DecodeUint32(reader) // status
+	supported, _ := xdr.DecodeUint32(reader)
+	access, _ := xdr.DecodeUint32(reader)
+
+	if supported != ACCESS4_READ {
+		t.Errorf("supported = 0x%x, want 0x%x", supported, uint32(ACCESS4_READ))
+	}
+	if access != ACCESS4_READ {
+		t.Errorf("access = 0x%x, want 0x%x", access, uint32(ACCESS4_READ))
+	}
+}
+
+// TestAccess_PseudoFS_NarrowsAndDropsXattrBits pins the pseudo-fs call site.
+// Narrowing to the request is the same rule the real-FS path follows, and the
+// RFC 8276 bits stay out even at minorversion 2, where accessSupportedFor would
+// otherwise report them: the xattr operations refuse pseudo-fs handles, so a
+// v4.2 client told it may read or write named attributes here would only walk
+// into NFS4ERR_NOTSUPP and NFS4ERR_ROFS.
+func TestAccess_PseudoFS_NarrowsAndDropsXattrBits(t *testing.T) {
+	pfs := pseudofs.New()
+	pfs.Rebuild([]string{"/export"})
+	h := NewHandler(nil, pfs)
+
+	ctx := &types.CompoundContext{
+		Context:      context.Background(),
+		ClientAddr:   "127.0.0.1:9999",
+		CurrentFH:    pfs.GetRootHandle(),
+		MinorVersion: 2,
+	}
+
+	var req bytes.Buffer
+	_ = xdr.WriteUint32(&req, ACCESS4_READ|ACCESS4_XAREAD|ACCESS4_XAWRITE|ACCESS4_XALIST)
+
+	result := h.handleAccess(ctx, bytes.NewReader(req.Bytes()))
+	if result.Status != types.NFS4_OK {
+		t.Fatalf("ACCESS status = %d, want NFS4_OK", result.Status)
+	}
+
+	reader := bytes.NewReader(result.Data)
+	_, _ = xdr.DecodeUint32(reader) // status
+	supported, _ := xdr.DecodeUint32(reader)
+	access, _ := xdr.DecodeUint32(reader)
+
+	if supported != ACCESS4_READ {
+		t.Errorf("supported = 0x%x, want 0x%x", supported, uint32(ACCESS4_READ))
+	}
+	if access != ACCESS4_READ {
+		t.Errorf("access = 0x%x, want 0x%x", access, uint32(ACCESS4_READ))
 	}
 }
 

--- a/internal/adapter/nfs/v4/handlers/realfs_test.go
+++ b/internal/adapter/nfs/v4/handlers/realfs_test.go
@@ -673,19 +673,22 @@ func TestAccess_RealFS_RootGetsAll(t *testing.T) {
 	supported, _ := xdr.DecodeUint32(reader)
 	access, _ := xdr.DecodeUint32(reader)
 
-	if supported != allBits {
-		t.Errorf("supported = 0x%x, want 0x%x", supported, allBits)
+	// Only the bits that are MEANINGFUL for the object type are reportable, and
+	// the target is a regular file on a minorversion-0 context. ACCESS4_LOOKUP
+	// is a directory-search right (RFC 7530 Section 16.1.4), ACCESS4_DELETE on a
+	// non-directory is decided by the parent directory rather than the file, so
+	// the server cannot check it from this handle (Section 16.1.5), and the RFC
+	// 8276 extended-attribute bits are not defined below minorversion 2.
+	wantSupported := uint32(ACCESS4_READ | ACCESS4_MODIFY | ACCESS4_EXTEND | ACCESS4_EXECUTE)
+
+	if supported != wantSupported {
+		t.Errorf("supported = 0x%x, want 0x%x", supported, wantSupported)
 	}
 
-	// Root gets every bit that is MEANINGFUL for the object type. ACCESS4_LOOKUP
-	// (0x02) is a directory-search right; on a regular file it has no canonical
-	// permission mapping (RFC 7530 §6 / RFC 1813 §3.3.4) and is correctly NOT
-	// granted. This matches the NFSv3 ACCESS handler, which uses the identical
-	// nfsAccessToPermissions / permissionsToNFSAccess translation — the whole
-	// point of routing NFSv4 ACCESS through the central checker.
-	wantRoot := allBits &^ uint32(ACCESS4_LOOKUP)
-	if access != wantRoot {
-		t.Errorf("access = 0x%x, want 0x%x (root gets all meaningful bits; LOOKUP is directory-only)", access, wantRoot)
+	// Root gets everything the server was willing to claim it can check; a bit
+	// left out of supported must never come back granted.
+	if access != wantSupported {
+		t.Errorf("access = 0x%x, want 0x%x (root gets every reportable bit)", access, wantSupported)
 	}
 }
 

--- a/internal/adapter/nfs/v4/handlers/realfs_test.go
+++ b/internal/adapter/nfs/v4/handlers/realfs_test.go
@@ -675,10 +675,10 @@ func TestAccess_RealFS_RootGetsAll(t *testing.T) {
 
 	// Only the bits that are MEANINGFUL for the object type are reportable, and
 	// the target is a regular file on a minorversion-0 context. ACCESS4_LOOKUP
-	// is a directory-search right (RFC 7530 Section 16.1.4), ACCESS4_DELETE on a
-	// non-directory is decided by the parent directory rather than the file, so
-	// the server cannot check it from this handle (Section 16.1.5), and the RFC
-	// 8276 extended-attribute bits are not defined below minorversion 2.
+	// is a directory-search right (RFC 7530 Section 16.1.4), ACCESS4_DELETE
+	// deletes a directory entry and so belongs to the directory (Section
+	// 16.1.2), and the RFC 8276 extended-attribute bits are not defined below
+	// minorversion 2.
 	wantSupported := uint32(ACCESS4_READ | ACCESS4_MODIFY | ACCESS4_EXTEND | ACCESS4_EXECUTE)
 
 	if supported != wantSupported {


### PR DESCRIPTION

# Description

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)


## Changes Made

Report correct ACCESS:
* XATTR is supported only in NFS v4.2.
* Do not answer about the things the client didn't ask.
* Some combinations don't have meaning - ignore them.

## Testing

- [X] Unit tests pass (`go test ./...`)

Compared with the linux NFS server and ganesha implementations. 

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published
