### PR TITLE
ci(e2e): make a failing E2E run conclude failure instead of cancelled

### DIFF
--- a/.github/scripts/run-e2e-selftest.sh
+++ b/.github/scripts/run-e2e-selftest.sh
@@ -56,6 +56,15 @@ echo "=== RUN   TestThing"
 sleep 60
 EOF
 
+# Ignores TERM, so the wall must escalate to SIGKILL — a different exit status
+# and a different diagnosis from a plain timeout.
+cat >"$work/deaf.sh" <<'EOF'
+#!/usr/bin/env bash
+trap "" TERM
+echo "=== RUN   TestThing"
+sleep 60
+EOF
+
 # Exits 0 having produced no result — the false-green shape.
 cat >"$work/green.sh" <<'EOF'
 #!/usr/bin/env bash
@@ -101,6 +110,7 @@ run_case pass  0 10 30s "$work/pass.sh"
 run_case fail  1 10 30s "$work/fail.sh"
 run_case leak  1 10 30s "$work/leak.sh"
 run_case wedge 1 15  5s "$work/wedge.sh"
+run_case deaf  1 15  5s "$work/deaf.sh"
 run_case green 1 10 30s "$work/green.sh"
 
 # A wedge must fail *because of the wall*. Asserting only the exit code would let
@@ -113,6 +123,7 @@ reason() {
     fi
 }
 reason wedge "no result after"
+reason deaf  "killed by SIGKILL"
 reason green "no package reported ok"
 reason fail  "test command exited 1"
 

--- a/.github/scripts/run-e2e-selftest.sh
+++ b/.github/scripts/run-e2e-selftest.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# Self-test for run-e2e.sh. Drives the harness with stand-in test commands that
+# reproduce each way a real run loses its signal, and asserts the harness reports
+# failure, promptly, every time.
+#
+# Case 3 also runs the *old* pipeline shape against the same stand-in and asserts
+# it does NOT finish — without that, the case would pass against a harness that
+# never had to refuse anything.
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+harness="$here/run-e2e.sh"
+work="$(mktemp -d)"
+# The leak stand-in deliberately leaves a descriptor holder behind; its odd sleep
+# duration is what makes it identifiable, so reap it here rather than let it (and
+# the control case's `tee`, which it holds open) outlive this script.
+trap 'rm -rf "$work"; pkill -f "sleep 654321" >/dev/null 2>&1' EXIT
+
+# Stand-in test commands. Output mimics `go test -v` closely enough for grading.
+cat >"$work/pass.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "--- PASS: TestThing (0.01s)"
+echo "PASS"
+printf 'ok  \tgithub.com/example/pkg\t0.012s\n'
+EOF
+
+cat >"$work/fail.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "--- FAIL: TestThing (0.01s)"
+printf 'FAIL\tgithub.com/example/pkg\t0.012s\n'
+echo "FAIL"
+exit 1
+EOF
+
+# Times out internally (like `go test -timeout`), then exits — leaving a child
+# that still holds the inherited stdout/stderr descriptors.
+cat >"$work/leak.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "panic: test timed out after 30m0s"
+echo "	running tests:"
+printf 'FAIL\tgithub.com/example/pkg\t1800.031s\n'
+printf 'ok  \tgithub.com/example/pkg/other\t0.7s\n'
+echo "FAIL"
+sleep 654321 &
+exit 1
+EOF
+
+# Never finishes at all.
+cat >"$work/wedge.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "=== RUN   TestThing"
+sleep 60
+EOF
+
+# Exits 0 having produced no result — the false-green shape.
+cat >"$work/green.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "=== RUN   TestThing"
+exit 0
+EOF
+
+chmod +x "$work"/*.sh
+
+fails=0
+run_case() {
+    local name="$1" want="$2" max_s="$3" wall="$4"
+    shift 4
+    local start elapsed got
+    start=$SECONDS
+    # The harness is supposed to bound itself; bound it from outside too so a
+    # harness that has lost that property reports a clean failure here instead
+    # of hanging this script the way it hung the job.
+    E2E_LOG="$work/$name.log" E2E_WALL="$wall" E2E_WALL_GRACE=2s \
+        timeout --kill-after=5s "$((max_s + 10))s" "$harness" "$@" >"$work/$name.out" 2>&1
+    got=$?
+    elapsed=$((SECONDS - start))
+    if [ "$got" -eq 124 ] || [ "$got" -eq 137 ]; then
+        echo "FAIL $name: harness did not return within $((max_s + 10))s"
+        fails=$((fails + 1))
+        return
+    fi
+    if [ "$got" -ne "$want" ]; then
+        echo "FAIL $name: exit $got, want $want"
+        sed 's/^/    /' "$work/$name.out"
+        fails=$((fails + 1))
+        return
+    fi
+    if [ "$elapsed" -gt "$max_s" ]; then
+        echo "FAIL $name: took ${elapsed}s, want <= ${max_s}s"
+        fails=$((fails + 1))
+        return
+    fi
+    echo "ok   $name: exit $got in ${elapsed}s — $(grep -o '::error title=[^:]*::.*' "$work/$name.out" || echo 'passed')"
+}
+
+run_case pass  0 10 30s "$work/pass.sh"
+run_case fail  1 10 30s "$work/fail.sh"
+run_case leak  1 10 30s "$work/leak.sh"
+run_case wedge 1 15  5s "$work/wedge.sh"
+run_case green 1 10 30s "$work/green.sh"
+
+# A wedge must fail *because of the wall*. Asserting only the exit code would let
+# a stand-in that dies for some unrelated reason stand in for a wedge.
+reason() {
+    if ! grep -q "$2" "$work/$1.out"; then
+        echo "FAIL $1: failed for the wrong reason (wanted \"$2\")"
+        sed 's/^/    /' "$work/$1.out"
+        fails=$((fails + 1))
+    fi
+}
+reason wedge "no result after"
+reason green "no package reported ok"
+reason fail  "test command exited 1"
+
+# The real suite runs under sudo, where the harness may not be permitted to
+# signal what it started at all. A wall that only holds against a signalable
+# child is not a wall, so prove it against a root one wherever that is possible.
+if sudo -n true >/dev/null 2>&1; then
+    run_case sudo_wedge 1 15 5s sudo -n "$work/wedge.sh"
+    reason sudo_wedge "no result after"
+else
+    echo "skip sudo_wedge: sudo needs a password here"
+fi
+
+# The leak case must actually be able to hang something, or it proves nothing.
+# The old shape was `<cmd> 2>&1 | tee log`; give it 10s to finish and expect it
+# not to.
+start=$SECONDS
+timeout 10s bash -c 'set -o pipefail; "$1" 2>&1 | tee "$2" >/dev/null' _ "$work/leak.sh" "$work/old.log"
+old=$?
+if [ "$old" -eq 124 ]; then
+    echo "ok   control: old pipeline shape still running after $((SECONDS - start))s on the same stand-in"
+else
+    echo "FAIL control: old pipeline shape exited $old — the leak case no longer reproduces the defect"
+    fails=$((fails + 1))
+fi
+
+if [ "$fails" -ne 0 ]; then
+    echo "$fails case(s) failed"
+    exit 1
+fi
+echo "all cases passed"

--- a/.github/scripts/run-e2e-selftest.sh
+++ b/.github/scripts/run-e2e-selftest.sh
@@ -7,7 +7,10 @@
 # Case 3 also runs the *old* pipeline shape against the same stand-in and asserts
 # it does NOT finish — without that, the case would pass against a harness that
 # never had to refuse anything.
-set -uo pipefail
+# +e explicitly: every case here runs a command that is supposed to fail, and
+# errexit arriving from the environment via SHELLOPTS would abort at the first
+# one instead of recording it.
+set +e -uo pipefail
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 harness="$here/run-e2e.sh"
@@ -112,6 +115,20 @@ reason() {
 reason wedge "no result after"
 reason green "no package reported ok"
 reason fail  "test command exited 1"
+
+# errexit arriving through the environment would abort the harness at the test
+# command, before it can read the exit status that grading depends on.
+start=$SECONDS
+E2E_LOG="$work/errexit.log" env SHELLOPTS=errexit "$harness" "$work/fail.sh" \
+    >"$work/errexit.out" 2>&1
+got=$?
+if [ "$got" -eq 1 ] && grep -q "test command exited 1" "$work/errexit.out"; then
+    echo "ok   errexit: exit 1 in $((SECONDS - start))s — graded despite inherited errexit"
+else
+    echo "FAIL errexit: exit $got, and grading did not run"
+    sed 's/^/    /' "$work/errexit.out"
+    fails=$((fails + 1))
+fi
 
 # The real suite runs under sudo, where the harness may not be permitted to
 # signal what it started at all. A wall that only holds against a signalable

--- a/.github/scripts/run-e2e.sh
+++ b/.github/scripts/run-e2e.sh
@@ -20,7 +20,10 @@
 # Grading uses both the exit status and the log: the status alone was already
 # supposed to be sufficient and still lost the signal once, so a zero status
 # with a log that shows no completed pass is treated as a failure.
-set -uo pipefail
+# +e explicitly: errexit would abort before the exit status can be read, and
+# reading it is the point. It is not set here, but it can arrive from the
+# environment via SHELLOPTS.
+set +e -uo pipefail
 
 LOG="${E2E_LOG:?E2E_LOG must name the log file to write}"
 WALL="${E2E_WALL:-45m}"

--- a/.github/scripts/run-e2e.sh
+++ b/.github/scripts/run-e2e.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Runs the E2E suite passed as "$@", writes its combined output to $E2E_LOG, and
+# grades the result. Exits 0 only for a run that completed and passed.
+#
+# The output goes to a *file*, never through a pipe. A pipe reader sees EOF only
+# once every write end is closed, so one process the suite leaves behind holding
+# the inherited descriptor keeps the reader — and therefore this script, and the
+# whole job — alive long after the tests finished. A file has no such rendezvous:
+# leaked holders are then merely leaked, not load-bearing. The file is replayed
+# to stdout once it is complete and reading it cannot block.
+#
+# The run is bounded by E2E_WALL so that a wedge anywhere below this script fails
+# *this step*. That is the property that matters: a job ended by its own timeout
+# concludes `cancelled` rather than `failure`, and alarms that key on `failure`
+# then stay silent. The suite runs under sudo, so the bound rests on being able
+# to signal a privileged child — measured, not assumed: the self-test's
+# sudo_wedge case asserts it wherever passwordless sudo is available.
+#
+# Grading uses both the exit status and the log: the status alone was already
+# supposed to be sufficient and still lost the signal once, so a zero status
+# with a log that shows no completed pass is treated as a failure.
+set -uo pipefail
+
+LOG="${E2E_LOG:?E2E_LOG must name the log file to write}"
+WALL="${E2E_WALL:-45m}"
+GRACE="${E2E_WALL_GRACE:-2m}"
+
+if [ "$#" -eq 0 ]; then
+    echo "usage: $0 <test command> [args...]" >&2
+    exit 2
+fi
+
+mkdir -p "$(dirname "$LOG")"
+: >"$LOG"
+
+# TERM first so the suite can dump state, SIGKILL after GRACE for anything that
+# ignores it.
+timeout --signal=TERM --kill-after="$GRACE" "$WALL" "$@" >"$LOG" 2>&1
+status=$?
+
+if [ "$status" -eq 124 ] || [ "$status" -eq 137 ]; then
+    # Name what was still running. The holder of a wedge like this used to be
+    # invisible, which is why it took five silent runs to notice one.
+    echo "::group::processes still running at the wall"
+    ps -eo pid,ppid,pgid,stat,etimes,user,args 2>/dev/null || true
+    echo "::endgroup::"
+fi
+
+cat "$LOG"
+
+# Anything of ours still running is a leak. It can no longer hold this step open,
+# but it is worth naming.
+survivors=$(pgrep -a -f '(^|/)(dfs|dfsctl|mount\.nfs|mount\.cifs|rpc\.statd|rpcbind)( |$)' 2>/dev/null)
+if [ -n "$survivors" ]; then
+    echo "::warning title=Leaked processes::the suite left processes running"
+    printf '%s\n' "$survivors"
+fi
+
+fail() {
+    echo "::error title=E2E suite failed::$1"
+    exit 1
+}
+
+if [ "$status" -eq 124 ] || [ "$status" -eq 137 ]; then
+    fail "no result after $WALL — the suite or something it started never finished"
+fi
+if [ "$status" -ne 0 ]; then
+    fail "test command exited $status"
+fi
+if grep -qE '^(panic|fatal error):' "$LOG"; then
+    fail "the test binary panicked"
+fi
+if grep -qE '^(FAIL|--- FAIL)' "$LOG"; then
+    fail "at least one test failed"
+fi
+if ! grep -qE '^ok[[:space:]]' "$LOG"; then
+    fail "no package reported ok — the suite did not run to completion"
+fi
+
+echo "E2E suite passed"

--- a/.github/scripts/run-e2e.sh
+++ b/.github/scripts/run-e2e.sh
@@ -39,13 +39,15 @@ mkdir -p "$(dirname "$LOG")"
 
 # TERM first so the suite can dump state, SIGKILL after GRACE for anything that
 # ignores it.
+started=$SECONDS
 timeout --signal=TERM --kill-after="$GRACE" "$WALL" "$@" >"$LOG" 2>&1
 status=$?
+elapsed=$((SECONDS - started))
 
 if [ "$status" -eq 124 ] || [ "$status" -eq 137 ]; then
     # Name what was still running. The holder of a wedge like this used to be
     # invisible, which is why it took five silent runs to notice one.
-    echo "::group::processes still running at the wall"
+    echo "::group::processes still running when the run was killed"
     ps -eo pid,ppid,pgid,stat,etimes,user,args 2>/dev/null || true
     echo "::endgroup::"
 fi
@@ -54,7 +56,10 @@ cat "$LOG"
 
 # Anything of ours still running is a leak. It can no longer hold this step open,
 # but it is worth naming.
-survivors=$(pgrep -a -f '(^|/)(dfs|dfsctl|mount\.nfs|mount\.cifs|rpc\.statd|rpcbind)( |$)' 2>/dev/null)
+# Only processes the suite itself starts. rpcbind and rpc.statd are deliberately
+# left out: the runner installs and starts them, so matching them would warn on
+# every run, and a warning that always fires is read as background noise.
+survivors=$(pgrep -a -f '(^|/)(dfs|dfsctl|mount\.nfs|mount\.cifs)( |$)' 2>/dev/null)
 if [ -n "$survivors" ]; then
     echo "::warning title=Leaked processes::the suite left processes running"
     printf '%s\n' "$survivors"
@@ -65,8 +70,17 @@ fail() {
     exit 1
 }
 
-if [ "$status" -eq 124 ] || [ "$status" -eq 137 ]; then
+if [ "$status" -eq 124 ]; then
     fail "no result after $WALL — the suite or something it started never finished"
+fi
+if [ "$status" -eq 137 ]; then
+    # 137 is SIGKILL. The wall escalates to it when TERM is ignored, but so does
+    # the kernel out-of-memory killer, and the status alone cannot tell them
+    # apart. The elapsed time and the process table dumped above can: a wall
+    # kill lands at $WALL plus $GRACE, an out-of-memory kill lands wherever the
+    # allocation did. Both are failures with no result to grade, so the
+    # distinction changes the diagnosis, not the verdict.
+    fail "killed by SIGKILL after ${elapsed}s (wall $WALL + $GRACE) — the wall escalating past TERM, or the out-of-memory killer"
 fi
 if [ "$status" -ne 0 ]; then
     fail "test command exited $status"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -45,10 +45,11 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
-    # The suite runs `go test -timeout 30m`, plus a cold fetch+compile of the
-    # e2e-only test deps under sudo. 20m was only ever enough because the job
-    # was a no-op (go test never ran); a real run needs headroom past the 30m
-    # test timeout itself.
+    # Backstop only. The test step bounds itself at E2E_WALL (45m) so that a
+    # wedge fails the step; this number just has to stay comfortably above
+    # setup + that wall + the grace period, because a job killed by its own
+    # timeout concludes `cancelled` and every alarm that keys on `failure`
+    # stays silent.
     timeout-minutes: 75
 
     services:
@@ -118,21 +119,29 @@ jobs:
         run: nix develop .#ci --command go build -o dfs cmd/dfs/main.go
 
       - name: Run E2E tests
+        env:
+          E2E_LOG: ${{ github.workspace }}/e2e.log
+          # 30m of test timeout plus room for the sudo-side dependency
+          # fetch+compile, the panic dump, and the remaining packages. The
+          # observed worst case is 30m16s of productive work, so this fails a
+          # wedge roughly 15m past a legitimately slow run rather than letting
+          # it run out the job.
+          E2E_WALL: 45m
         run: |
-          set -o pipefail
-          # Full mode: all configurations including Docker-based stores.
-          # sudo resolves commands via secure_path (which omits the Nix profile),
-          # so `nix` was "command not found" under sudo and go test never ran.
-          # Pass the caller's PATH through so `nix` resolves; keep -E for the
-          # external-service env vars the suite reads. pipefail is required so the
-          # go-test exit code propagates through `tee` — without it the job was a
-          # false-green no-op regardless of whether the tests ran or passed.
+          # sudo resolves commands via secure_path (which omits the Nix
+          # profile), so `nix` was "command not found" under sudo and go test
+          # never ran. Pass the caller's PATH through so `nix` resolves; keep -E
+          # for the external-service env vars the suite reads.
           # DITTOFS_E2E_REQUIRE_NLM=1: the real-NLM lock-interop test hard-fails
           # (instead of skipping) if its prerequisites are missing, so a
           # misconfigured runner can't silently drop that coverage.
-          sudo -E env "PATH=$PATH" "DITTOFS_E2E_REQUIRE_NLM=1" nix develop .#ci --command \
-            go test -tags=e2e -v -timeout 30m ./test/e2e/... \
-            2>&1 | tee "$GITHUB_WORKSPACE/e2e.log"
+          # Full mode: all configurations including Docker-based stores.
+          #
+          # The harness owns redirection and grading — see the header of
+          # run-e2e.sh for why the output must not go through a pipe.
+          .github/scripts/run-e2e.sh \
+            sudo -E env "PATH=$PATH" "DITTOFS_E2E_REQUIRE_NLM=1" nix develop .#ci --command \
+            go test -tags=e2e -v -timeout 30m ./test/e2e/...
 
       - name: Generate summary
         if: always()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -120,3 +120,17 @@ jobs:
         with:
           scandir: .
           severity: warning
+
+  # The E2E harness is what decides whether a failing suite is visible at all,
+  # so it is exercised against deliberately failing, wedged and false-green
+  # stand-in test commands on every change.
+  e2e-harness:
+    name: E2E Harness Self-Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run harness self-test
+        run: .github/scripts/run-e2e-selftest.sh


### PR DESCRIPTION
Closes #2206

## What was wrong

A failing E2E run on `develop` reported to GitHub as **`cancelled`**, not `failure`.
`ci-health.yml` deliberately excludes `cancelled` from the develop-red alarm — the
conformance workflows set `cancel-in-progress`, so a superseded run is benign — and
that exclusion swallowed genuine failures too.

Run 33018102610, attempt 2:

| when | what |
|---|---|
| 10:28:44 | `Run E2E tests` starts |
| 10:59:00 | `panic: test timed out after 30m0s` → `FAIL .../test/e2e 1800.031s` → `ok .../test/e2e/snapshot 0.706s` → bare `FAIL` |
| 10:59:00 → 11:41:23 | **42 minutes, no output at all** |
| 11:41:23 | `##[error]The operation was canceled.` — the job's `timeout-minutes: 75` fires |
| 11:41:28 | `Cleaning up orphan processes` / `Terminate orphan process: pid (11869) (tee)` |

Run 32979575910 has the identical signature: panic 14:53:14, cancellation 15:35:34
(42m later), single leaked orphan `tee`.

`go test` had exited — it printed its final summary line. `tee` had not, and the
runner's own cleanup says so 42 minutes later. A pipe reader sees EOF only when
**every** write end is closed, so something the run left behind still held the
inherited descriptor. `bash` waits for `tee`; the step never ends; the job burns
its remaining budget; `timeout-minutes` converts a test failure into a
cancellation — and a cancelled job concludes `cancelled` no matter what its other
steps did.

## Two premises checked, one refuted

**"A leaked `dfs` inherited the pipe write end" — refuted.** No Go-spawned child in
the suite is *given* the step's stdout or stderr. `grep -rn 'os.Stdout|os.Stderr'
test/e2e/` finds exactly one hit, and it is an `os.Stdout.Sync()`. Every process
the suite starts has its stdio pointed elsewhere:

- `test/e2e/helpers/server.go:419`, `:124` — `dfs start --foreground`, stdout/stderr to a log file
- `cmd/dfs/commands/daemon_unix.go:91` — the daemonising path, log file + `Setsid`
- `test/e2e/smb_byte_range_lock_test.go:63` — re-exec'd lock holder, `StdoutPipe()`, stderr `/dev/null`
- `test/e2e/framework/{netns,mount,kerberos}.go` — `CombinedOutput()` or nil, i.e. `/dev/null`
- `test/e2e/testdata/nlm/nlm_axis_interop.sh:80` — backgrounded server block redirected to a file

Go's `os/exec` hands a child `/dev/null` for any unset stream, so that specific
story does not hold. What the evidence *does* pin is the mechanism: the pipeline
could only end once every inherited write end was closed, one was not, and the step
outlived the thing it was running. The retained logs cannot name the holder — the
runner named only `tee`, because a root-owned descendant that has left the runner's
process tree is invisible to its orphan sweep. So the fix is structural rather than
aimed at one process, and a diagnostic is included so the next occurrence names its
own leaker.

**"`timeout` cannot bound a `sudo` child" — also refuted, and this one changed the
diff.** I built a signal-free watchdog on the theory that GNU `timeout` in front of
`sudo` would try to signal a privileged process, be refused, and then block in
`wait()` forever — reintroducing the same bug in a new shape. Measured on an
`ubuntu-latest` runner instead of reasoned about:

```
+ timeout --kill-after=3s 5s sudo -n sleep 120
##[error]Process completed with exit code 124.      # at 5s, not 8s, not never
```

`timeout` returns 124 at the wall, and at the wall rather than after the
`--kill-after` grace, so the TERM was delivered and `sudo` relayed it. The watchdog
was ~15 lines solving a problem that does not exist; it is gone, and the wall is
one `timeout`. The self-test keeps a `sudo_wedge` case so the assumption stays
measured rather than remembered.

## The fix

`.github/scripts/run-e2e.sh` owns the invocation and the grading.

1. **No pipe.** The suite's combined output goes straight to `$E2E_LOG`; the file is
   replayed to stdout afterwards, when reading it cannot block. A leaked holder of a
   file descriptor is merely leaked, not load-bearing.

2. **A wall.** `timeout --signal=TERM --kill-after=2m 45m` around the whole
   invocation, so a wedge anywhere below fails *this step* rather than outliving it.
   When it fires, the step dumps the process table — the holder of a wedge like this
   used to be invisible, which is why it took five silent runs to notice one.

3. **Grading in the step that runs the tests.** `Generate summary` already graded the
   log under `if: always()`, but that could never help: a cancelled job concludes
   `cancelled` whatever its steps say. Grading now happens where it can set the
   conclusion, on both the exit status and the log — status alone was already
   supposed to be sufficient (`set -o pipefail`) and still lost the signal, so a
   zero status with a log showing no completed pass is a failure.

### The numbers

| knob | value | why |
|---|---|---|
| `go test -timeout` | **30m**, unchanged | the suite's own budget; it fired exactly as designed in the failing run |
| `E2E_WALL` | **45m** | observed worst case is 30m16s of productive work (step 10:28:44, last output 10:59:00) — the 30m test timeout plus ~16s of cached dependency compile. 45m leaves ~15m of headroom, so a legitimately slow run finishes while a wedge fails ~15m past the suite's own deadline instead of ~45m past it |
| job `timeout-minutes` | **75**, unchanged | backstop only. Setup is ~2.5m, so the step now fails by ~48m and the job ends around 50m — the job timeout keeps ~25m of slack and is never the thing that fires. That is the whole point: it is the step that has to fail |

## Verification

### By construction, on the runner

`.github/scripts/run-e2e-selftest.sh` drives the harness with a stand-in per way a
run can lose its signal, and is wired into `lint.yml` so it runs on every change.
From `ubuntu-latest`, run 33150884053:

```
ok   pass: exit 0 in 1s — passed
ok   fail: exit 1 in 2s — ::error title=E2E suite failed::test command exited 1
ok   leak: exit 1 in 1s — ::error title=E2E suite failed::test command exited 1
ok   wedge: exit 1 in 5s — ::error title=E2E suite failed::no result after 5s — the suite or something it started never finished
ok   deaf: exit 1 in 7s — ::error title=E2E suite failed::killed by SIGKILL after 7s (wall 5s + 2s) — the wall escalating past TERM, or the out-of-memory killer
ok   green: exit 1 in 1s — ::error title=E2E suite failed::no package reported ok — the suite did not run to completion
ok   errexit: exit 1 in 0s — graded despite inherited errexit
ok   sudo_wedge: exit 1 in 5s — ::error title=E2E suite failed::no result after 5s — the suite or something it started never finished
ok   control: old pipeline shape still running after 10s on the same stand-in
all cases passed
```

- `leak` is the reported defect: the stand-in prints a timeout panic, exits, and
  leaves a child holding the inherited descriptors.
- `control` runs the **old** `... 2>&1 | tee log` shape against that same stand-in
  and asserts it does *not* finish. Without it the `leak` case would be vacuous.
- `wedge` never finishes and must fail at the wall; `sudo_wedge` is the same under
  `sudo`, which is where the wall's signalling assumption actually lives.
- `deaf` ignores `TERM`, forcing the wall to escalate to `SIGKILL`. That is a
  different exit status and a different diagnosis, because 137 is any `SIGKILL` —
  measured: `timeout --kill-after=1s 2s bash -c 'trap "" TERM; sleep 30'` and
  `timeout --kill-after=5s 60s bash -c 'kill -9 $$'` both give 137, while a plain
  timeout gives 124. The status alone cannot separate the wall from the
  out-of-memory killer, so the message reports it as `SIGKILL` with the elapsed
  time, which can.
- `green` exits 0 having produced no result.
- `errexit` invokes the harness through `env SHELLOPTS=errexit`. Bash does import an
  exported `SHELLOPTS`, and errexit would abort the harness at the test command,
  before it reads the exit status grading depends on. It cannot arrive that way from
  a workflow step, but stripping the `set +e` and running the self-test under an
  inherited `-e` reduces it from eight assertions to one, which is why both scripts
  clear it explicitly.
- Each case asserts the *reason* it failed, not just the exit code. That caught a
  real self-satisfying test: a stand-in rewritten to use `exec -a` died instantly
  because `sleep` here is a multi-call coreutils binary that dispatches on `argv[0]`,
  and the wedge case sailed through on the right exit code for entirely the wrong
  reason.

### The guards were tested against deliberately broken harnesses

Each load-bearing property was removed in turn and the self-test re-run. Every one
is refused, by the case that targets it:

| harness broken by | self-test result |
|---|---|
| restoring the `\| tee` pipeline | `FAIL leak: harness did not return within 20s`, `FAIL wedge: harness did not return within 25s`, `FAIL wedge: failed for the wrong reason` |
| deleting the log grading | `FAIL green: exit 0, want 1`, `FAIL green: failed for the wrong reason` |
| deleting the wall | `FAIL wedge: harness did not return within 25s`, `FAIL wedge: failed for the wrong reason` |
| deleting the `SIGKILL` branch | `FAIL deaf: failed for the wrong reason (wanted "killed by SIGKILL")` |
| deleting the harness's `set +e` | `FAIL errexit: exit 1, and grading did not run` |
| deleting the self-test's `set +e`, under inherited `-e` | one case reported instead of eight, exit 1 |

### End to end on the real suite

`workflow_dispatch` on this branch, run
[33151205489](https://github.com/marmos91/dittofs/actions/runs/33151205489). The suite
is genuinely broken right now (#2207, #2208, #2209), so this is the same failure that
reported `cancelled` on `develop`, run through the new path:

| | before (33018102610) | after (33151205489) |
|---|---|---|
| `Run E2E tests` step | **cancelled** | **failure** |
| job conclusion | **cancelled** | **failure** |
| step duration | 72m54s — 30m16s of work, then 42m of nothing | **30m18s** — ends when `go test` ends |
| job duration | 75m19s, killed by `timeout-minutes` | 33m22s, ended by its own verdict |
| develop-red alarm | skipped (`cancelled` is excluded) | fires |

The 42-minute post-`FAIL` hang is gone: the step now ends 18 seconds after `go test`
hits its 30m timeout, instead of 42 minutes after. Every other step still succeeded,
exactly as before — the difference is that the step running the tests is now the one
that fails, so the job conclusion follows it.

## Sibling exposure, deliberately not fixed here

`posix-tests.yml:214` has the same `... 2>&1 | tee "$LOG_FILE" || true` shape and the
same latent exposure. It has not hit it: all its recent `cancelled` runs on `develop`
last ~30 seconds, i.e. ordinary `cancel-in-progress` supersedes, not wedges. Left
alone rather than speculatively rewritten.

Worth knowing when reading run history: `cancelled` on these workflows is genuinely
ambiguous today. Of the recent E2E cancellations on `develop`, two (33018102610,
32979575910) ran ~75m and are wedges; the rest lasted seconds to minutes and are
benign supersedes. The alarm cannot tell them apart, which is precisely why the
wedge hid for five runs.
