### PR TITLE
fix(adapters): an out-of-range port panicked under the service lock and wedged the control plane

### DIFF
--- a/cmd/dfsctl/commands/adapter/edit.go
+++ b/cmd/dfsctl/commands/adapter/edit.go
@@ -66,7 +66,7 @@ func runEdit(cmd *cobra.Command, args []string) error {
 	req := &apiclient.UpdateAdapterRequest{}
 	hasUpdate := false
 
-	if editPort > 0 {
+	if cmd.Flags().Changed("port") {
 		req.Port = &editPort
 		hasUpdate = true
 	}

--- a/cmd/dfsctl/commands/adapter/enable.go
+++ b/cmd/dfsctl/commands/adapter/enable.go
@@ -48,7 +48,10 @@ func runEnable(cmd *cobra.Command, args []string) error {
 	updateReq := &apiclient.UpdateAdapterRequest{
 		Enabled: &enabled,
 	}
-	if enablePort > 0 {
+	// Forward the port whenever the flag was given, not only when it is
+	// positive: a port the server will refuse has to reach the server to be
+	// refused, and 0 is the request to go back to the type's default.
+	if cmd.Flags().Changed("port") {
 		updateReq.Port = &enablePort
 	}
 

--- a/internal/controlplane/api/handlers/adapters.go
+++ b/internal/controlplane/api/handlers/adapters.go
@@ -92,6 +92,11 @@ func (h *AdapterHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if err := adapter.Validate(); err != nil {
+		BadRequest(w, err.Error())
+		return
+	}
+
 	// CreateAdapter saves to store AND starts the adapter
 	if err := h.runtime.CreateAdapter(r.Context(), adapter); err != nil {
 		if errors.Is(err, models.ErrDuplicateAdapter) {
@@ -272,6 +277,11 @@ func (h *AdapterHandler) Update(w http.ResponseWriter, r *http.Request) {
 			BadRequest(w, "Invalid config format")
 			return
 		}
+	}
+
+	if err := adapter.Validate(); err != nil {
+		BadRequest(w, err.Error())
+		return
 	}
 
 	// UpdateAdapter updates store AND restarts the adapter

--- a/pkg/controlplane/models/adapter.go
+++ b/pkg/controlplane/models/adapter.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 )
 
@@ -39,6 +40,23 @@ func DefaultPort(adapterType string) int {
 	default:
 		return 0
 	}
+}
+
+// Validate reports whether the configuration describes an adapter the server
+// can actually build. It is the guard at the API boundary: the adapter
+// constructors treat an out-of-range port as a programmer error and panic on
+// it, and the type decides which constructor runs at all, so both have to be
+// refused before a row is persisted or a start is attempted.
+func (a *AdapterConfig) Validate() error {
+	// Only the types with a known default port have a constructor in the
+	// adapter factory, so a type without one has no adapter to build.
+	if DefaultPort(a.Type) == 0 {
+		return fmt.Errorf("unsupported adapter type %q: must be one of nfs, smb", a.Type)
+	}
+	if a.Port < 0 || a.Port > 65535 {
+		return fmt.Errorf("invalid port %d: must be 0-65535", a.Port)
+	}
+	return nil
 }
 
 // TableName returns the table name for AdapterConfig.

--- a/pkg/controlplane/models/adapter.go
+++ b/pkg/controlplane/models/adapter.go
@@ -43,10 +43,10 @@ func DefaultPort(adapterType string) int {
 }
 
 // Validate reports whether the configuration describes an adapter the server
-// can actually build. It is the guard at the API boundary: the adapter
-// constructors treat an out-of-range port as a programmer error and panic on
-// it, and the type decides which constructor runs at all, so both have to be
-// refused before a row is persisted or a start is attempted.
+// can actually build: the adapter constructors treat an out-of-range port as a
+// programmer error and panic on it, and the type decides which constructor runs
+// at all, so both have to be refused before a row is persisted or a start is
+// attempted.
 func (a *AdapterConfig) Validate() error {
 	// Only the types with a known default port have a constructor in the
 	// adapter factory, so a type without one has no adapter to build.

--- a/pkg/controlplane/runtime/adapters/service.go
+++ b/pkg/controlplane/runtime/adapters/service.go
@@ -293,28 +293,37 @@ func (s *Service) DisableAdapter(ctx context.Context, adapterType string) error 
 // start of the same type is refused while this one is still binding, and it is
 // dropped again if the bind fails.
 func (s *Service) startAdapter(cfg *models.AdapterConfig) error {
+	entry, err := s.claimAndRunAdapter(cfg)
+	if err != nil {
+		return err
+	}
+	return s.awaitListener(cfg.Type, entry)
+}
+
+// claimAndRunAdapter builds the adapter and registers its entry, holding mu for
+// the whole build so a competing start of the same type is refused while this
+// one is still constructing. The unlock is deferred rather than written out on
+// each exit: the factory constructs adapters from operator-supplied config and
+// a constructor that panics on it would otherwise leave mu held for the life of
+// the process, blocking every later adapter call including the read-only ones.
+func (s *Service) claimAndRunAdapter(cfg *models.AdapterConfig) (*adapterEntry, error) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	if err := s.typeClaimedLocked(cfg.Type); err != nil {
-		s.mu.Unlock()
-		return err
+		return nil, err
 	}
 
 	if s.factory == nil {
-		s.mu.Unlock()
-		return fmt.Errorf("adapter factory not set")
+		return nil, fmt.Errorf("adapter factory not set")
 	}
 
 	adp, err := s.factory(cfg)
 	if err != nil {
-		s.mu.Unlock()
-		return fmt.Errorf("failed to create adapter: %w", err)
+		return nil, fmt.Errorf("failed to create adapter: %w", err)
 	}
 
-	entry := s.registerAndRunAdapterLocked(adp, cfg)
-	s.mu.Unlock()
-
-	return s.awaitListener(cfg.Type, entry)
+	return s.registerAndRunAdapterLocked(adp, cfg), nil
 }
 
 // awaitListener blocks until the adapter has bound its listening socket, its

--- a/pkg/controlplane/runtime/adapters/service.go
+++ b/pkg/controlplane/runtime/adapters/service.go
@@ -293,6 +293,15 @@ func (s *Service) DisableAdapter(ctx context.Context, adapterType string) error 
 // start of the same type is refused while this one is still binding, and it is
 // dropped again if the bind fails.
 func (s *Service) startAdapter(cfg *models.AdapterConfig) error {
+	// Every start routes through here, which is the only place that covers all
+	// of them: the adapter constructors panic on a port they cannot bind, and
+	// the boot-time load runs with no recover above it, so a port persisted
+	// before it could be refused would otherwise kill the process at startup
+	// with no API left to correct it through.
+	if err := cfg.Validate(); err != nil {
+		return fmt.Errorf("invalid adapter config: %w", err)
+	}
+
 	entry, err := s.claimAndRunAdapter(cfg)
 	if err != nil {
 		return err
@@ -303,9 +312,9 @@ func (s *Service) startAdapter(cfg *models.AdapterConfig) error {
 // claimAndRunAdapter builds the adapter and registers its entry, holding mu for
 // the whole build so a competing start of the same type is refused while this
 // one is still constructing. The unlock is deferred rather than written out on
-// each exit: the factory constructs adapters from operator-supplied config and
-// a constructor that panics on it would otherwise leave mu held for the life of
-// the process, blocking every later adapter call including the read-only ones.
+// each exit: a constructor that panics under this lock would otherwise leave it
+// held for the life of the process, blocking every later adapter call including
+// the read-only ones.
 func (s *Service) claimAndRunAdapter(cfg *models.AdapterConfig) (*adapterEntry, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/controlplane/runtime/adapters/service.go
+++ b/pkg/controlplane/runtime/adapters/service.go
@@ -293,11 +293,11 @@ func (s *Service) DisableAdapter(ctx context.Context, adapterType string) error 
 // start of the same type is refused while this one is still binding, and it is
 // dropped again if the bind fails.
 func (s *Service) startAdapter(cfg *models.AdapterConfig) error {
-	// Every start routes through here, which is the only place that covers all
-	// of them: the adapter constructors panic on a port they cannot bind, and
-	// the boot-time load runs with no recover above it, so a port persisted
-	// before it could be refused would otherwise kill the process at startup
-	// with no API left to correct it through.
+	// Every start routes through here, so this is the one place that keeps a
+	// config the constructors would panic on away from them. The boot-time load
+	// runs with no recover above it, so a port persisted before it could be
+	// refused would otherwise kill the process at startup, leaving no API to
+	// correct it through.
 	if err := cfg.Validate(); err != nil {
 		return fmt.Errorf("invalid adapter config: %w", err)
 	}
@@ -310,11 +310,10 @@ func (s *Service) startAdapter(cfg *models.AdapterConfig) error {
 }
 
 // claimAndRunAdapter builds the adapter and registers its entry, holding mu for
-// the whole build so a competing start of the same type is refused while this
-// one is still constructing. The unlock is deferred rather than written out on
-// each exit: a constructor that panics under this lock would otherwise leave it
-// held for the life of the process, blocking every later adapter call including
-// the read-only ones.
+// the whole build so a competing start is refused while this one is still
+// constructing. The unlock is deferred rather than written out on each exit: a
+// constructor that panics under this lock would otherwise leave it held for the
+// life of the process, blocking every later adapter call.
 func (s *Service) claimAndRunAdapter(cfg *models.AdapterConfig) (*adapterEntry, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/controlplane/runtime/adapters/service_test.go
+++ b/pkg/controlplane/runtime/adapters/service_test.go
@@ -669,12 +669,25 @@ func TestLoadAdaptersFromStore_SkipsUnbindableAdapter(t *testing.T) {
 	}
 }
 
+// requireLockFree fails the test unless the service lock is free: a leak is what
+// wedged every adapter route, the read-only ones included.
+func requireLockFree(t *testing.T, svc *Service) {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() { defer close(done); _ = svc.ListRunningAdapters() }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("adapters service lock was not released")
+	}
+}
+
 // TestStartAdapter_RefusesUnbuildableConfigBeforeFactory pins the guard that
 // keeps operator-supplied config away from the adapter constructors, which treat
 // a port they cannot bind as a programmer error and panic on it. A panic raised
-// under the service lock leaks it for the life of the process, and the boot-time
-// load has no recover above it at all, so the config has to be refused before the
-// factory ever sees it.
+// under the service lock leaks it, and the boot-time load has no recover above
+// it at all, so the config has to be refused before the factory ever sees it.
 func TestStartAdapter_RefusesUnbuildableConfigBeforeFactory(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -710,15 +723,7 @@ func TestStartAdapter_RefusesUnbuildableConfigBeforeFactory(t *testing.T) {
 				t.Error("unbuildable adapter registered as running")
 			}
 
-			// The lock must still be free: a leak here is what wedged every
-			// adapter route, read-only ones included.
-			done := make(chan struct{})
-			go func() { defer close(done); _ = svc.ListRunningAdapters() }()
-			select {
-			case <-done:
-			case <-time.After(5 * time.Second):
-				t.Fatal("adapters service lock was not released")
-			}
+			requireLockFree(t, svc)
 		})
 	}
 }
@@ -745,11 +750,5 @@ func TestStartAdapter_ReleasesLockWhenFactoryPanics(t *testing.T) {
 			&models.AdapterConfig{Type: "nfs", Port: 12049, Enabled: true})
 	}()
 
-	done := make(chan struct{})
-	go func() { defer close(done); _ = svc.ListRunningAdapters() }()
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("adapters service lock was not released after the factory panicked")
-	}
+	requireLockFree(t, svc)
 }

--- a/pkg/controlplane/runtime/adapters/service_test.go
+++ b/pkg/controlplane/runtime/adapters/service_test.go
@@ -668,3 +668,88 @@ func TestLoadAdaptersFromStore_SkipsUnbindableAdapter(t *testing.T) {
 		t.Error("bindable adapter was not started")
 	}
 }
+
+// TestStartAdapter_RefusesUnbuildableConfigBeforeFactory pins the guard that
+// keeps operator-supplied config away from the adapter constructors, which treat
+// a port they cannot bind as a programmer error and panic on it. A panic raised
+// under the service lock leaks it for the life of the process, and the boot-time
+// load has no recover above it at all, so the config has to be refused before the
+// factory ever sees it.
+func TestStartAdapter_RefusesUnbuildableConfigBeforeFactory(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  *models.AdapterConfig
+	}{
+		{"port above range", &models.AdapterConfig{Type: "nfs", Port: 70000, Enabled: true}},
+		{"negative port", &models.AdapterConfig{Type: "nfs", Port: -1, Enabled: true}},
+		{"unsupported type", &models.AdapterConfig{Type: "gopher", Port: 7070, Enabled: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			st := newFakeAdapterStore()
+			ctx := context.Background()
+			if _, err := st.CreateAdapter(ctx, tc.cfg); err != nil {
+				t.Fatalf("seed adapter: %v", err)
+			}
+
+			svc := New(st, time.Second)
+			called := false
+			svc.SetAdapterFactory(func(cfg *models.AdapterConfig) (ProtocolAdapter, error) {
+				called = true
+				return newFakeListenerAdapter(cfg.Type, cfg.Port), nil
+			})
+
+			// The boot-time load is the caller with no recover above it, so it is
+			// the one that must survive the bad row.
+			if err := svc.LoadAdaptersFromStore(ctx); err != nil {
+				t.Fatalf("load failed on an unbuildable adapter: %v", err)
+			}
+			if called {
+				t.Error("factory was handed a config the server cannot build")
+			}
+			if svc.IsAdapterRunning(tc.cfg.Type) {
+				t.Error("unbuildable adapter registered as running")
+			}
+
+			// The lock must still be free: a leak here is what wedged every
+			// adapter route, read-only ones included.
+			done := make(chan struct{})
+			go func() { defer close(done); _ = svc.ListRunningAdapters() }()
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				t.Fatal("adapters service lock was not released")
+			}
+		})
+	}
+}
+
+// TestStartAdapter_ReleasesLockWhenFactoryPanics pins the lock discipline that
+// keeps one bad start from taking the whole service down with it. A factory can
+// panic for reasons the config guard does not cover, and the panic unwinds
+// through the start while the service lock is held: released on the way out the
+// caller sees the panic and nothing else breaks, held on the way out every later
+// adapter call blocks forever, read-only ones included.
+func TestStartAdapter_ReleasesLockWhenFactoryPanics(t *testing.T) {
+	svc := New(newFakeAdapterStore(), time.Second)
+	svc.SetAdapterFactory(func(*models.AdapterConfig) (ProtocolAdapter, error) {
+		panic("constructor rejected the config")
+	})
+
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Error("factory panic did not reach the caller")
+			}
+		}()
+		_ = svc.CreateAdapter(context.Background(),
+			&models.AdapterConfig{Type: "nfs", Port: 12049, Enabled: true})
+	}()
+
+	done := make(chan struct{})
+	go func() { defer close(done); _ = svc.ListRunningAdapters() }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("adapters service lock was not released after the factory panicked")
+	}
+}

--- a/test/e2e/adapters_test.go
+++ b/test/e2e/adapters_test.go
@@ -292,25 +292,15 @@ func testInvalidConfigRejection(t *testing.T, runner *helpers.CLIRunner) {
 
 	// Test 1: Invalid port number (port > 65535)
 	_, err := runner.EnableAdapter("nfs", helpers.WithAdapterPort(70000))
-	assert.Error(t, err, "Should reject port > 65535")
-	if err != nil {
-		t.Log("✓ Port > 65535 correctly rejected")
-	}
+	requireValidationRejection(t, runner, err, "must be 0-65535", "port > 65535")
 
 	// Test 2: Invalid port number (negative port)
-	// Note: CLI may not pass negative ports, but let's test the server validation
 	_, err = runner.EnableAdapter("nfs", helpers.WithAdapterPort(-1))
-	assert.Error(t, err, "Should reject negative port")
-	if err != nil {
-		t.Log("✓ Negative port correctly rejected")
-	}
+	requireValidationRejection(t, runner, err, "must be 0-65535", "negative port")
 
 	// Test 3: Unknown adapter type
 	_, err = runner.EnableAdapter("unknownprotocol")
-	assert.Error(t, err, "Should reject unknown adapter type")
-	if err != nil {
-		t.Log("✓ Unknown adapter type correctly rejected")
-	}
+	requireValidationRejection(t, runner, err, "unsupported adapter type", "unknown adapter type")
 
 	// Verify no invalid adapters were created
 	adapters, err := runner.ListAdapters()
@@ -320,4 +310,29 @@ func testInvalidConfigRejection(t *testing.T, runner *helpers.CLIRunner) {
 	}
 
 	t.Log("ADP-08: Invalid config rejection passed")
+}
+
+// requireValidationRejection fails the test unless err is the server refusing
+// the request on its merits, and unless the server is still answering
+// afterwards.
+//
+// A bare assert.Error is satisfied by the apiclient's 30 second HTTP timeout, so
+// a control plane that has stopped responding reads as a validation rejection
+// and the case passes for the wrong reason. Pinning the rejection to the
+// server's own message, rejecting a client timeout outright, and requiring a
+// following call to succeed are what make the assertion fail on a dead server.
+func requireValidationRejection(t *testing.T, runner *helpers.CLIRunner, err error, wantMessage, what string) {
+	t.Helper()
+
+	require.Error(t, err, "Should reject %s", what)
+	require.NotContains(t, err.Error(), "context deadline exceeded",
+		"%s must be refused by validation, not by an unresponsive server: %v", what, err)
+	require.Contains(t, err.Error(), wantMessage,
+		"rejection of %s should carry the server's validation message", what)
+
+	_, listErr := runner.ListAdapters()
+	require.NoError(t, listErr,
+		"control plane must still answer after rejecting %s", what)
+
+	t.Logf("✓ %s correctly rejected", what)
 }

--- a/test/e2e/adapters_test.go
+++ b/test/e2e/adapters_test.go
@@ -319,8 +319,12 @@ func testInvalidConfigRejection(t *testing.T, runner *helpers.CLIRunner) {
 // A bare assert.Error is satisfied by the apiclient's 30 second HTTP timeout, so
 // a control plane that has stopped responding reads as a validation rejection
 // and the case passes for the wrong reason. Pinning the rejection to the
-// server's own message, rejecting a client timeout outright, and requiring a
+// server's own message, naming the timeout as a disqualifier, and requiring a
 // following call to succeed are what make the assertion fail on a dead server.
+// The timeout check is not load-bearing on its own — a timeout error cannot
+// carry the validation message either — but it is what reports the real cause
+// instead of a bare "string did not contain", and it survives someone later
+// loosening the message match.
 func requireValidationRejection(t *testing.T, runner *helpers.CLIRunner, err error, wantMessage, what string) {
 	t.Helper()
 


### PR DESCRIPTION
Closes #2207
Closes #2208

Two defects, one of them concealing the other. The product bug is the severe one: a
single REST call with an out-of-range port permanently wedges the control plane, and on
the next restart the server will not boot at all.

## The product bug

`nfs.New` and `smb.New` **panic** when config validation fails
(`pkg/adapter/nfs/adapter.go:487`, `pkg/adapter/smb/adapter.go:159`). Their doc comments
justify it as "indicates programmer error" — but the port they validate arrives from an
operator over `PUT /api/v1/adapters/{type}`, so it is untrusted input at a trust
boundary. `Service.startAdapter` called the factory while holding `s.mu` with a bare
`Lock()`/`Unlock()` pair, so the panic unwound straight past the unlock to chi's
`Recoverer`, which turned it into a plain 500. **The write lock was never released.**

Reproduced on a Scaleway VM against a completely fresh server — no prior adapter
activity, one call:

```
enable nfs --port 70000   rc=1    0.01s  Error: ... request failed with status 500
list                      rc=1   30.01s  Error: ... Get "/api/v1/adapters": context deadline exceeded
```

Panic from the server log, with the frame that holds the lock in the middle:

```
panic: invalid NFS config: invalid port 70000: must be 0-65535
    cmd/dfs/commands/start.go:795                     (nfs.New)
    cmd/dfs/commands/start.go:756                     (createAdapterFactory)
    .../adapters/service.go:308                       (startAdapter, holding s.mu)
    .../adapters/service.go:200                       (UpdateAdapter)
    internal/.../handlers/adapters.go:278             (AdapterHandler.Update)
```

SIGQUIT dump from the wedged server. The lock has **no holder** — which is what a leaked
`Lock()` looks like, as opposed to a slow one:

```
goroutine 454 [sync.RWMutex.RLock, 1 minutes]:
  adapters.(*Service).IsAdapterRunning   service.go:497
  handlers.(*AdapterHandler).List        adapters.go:132   <- GET /api/v1/adapters

goroutine 390 [sync.RWMutex.RLock, 1 minutes]:   (second GET, same semaphore 0xc0002b914c)

goroutine 426 [sync.Mutex.Lock, 1 minutes]:
  sync.(*RWMutex).Lock(...)
  adapters.(*Service).startAdapter       service.go:296
  handlers.(*AdapterHandler).Create      adapters.go:96    <- POST /api/v1/adapters
```

Read-only routes are wedged too, so there is no way to observe or correct the state.

### The first fix was in the wrong place

My initial attempt validated only in the `Create`/`Update` handlers. That left the worst
caller broken. `UpdateAdapter` deliberately keeps a failed config persisted, and
`LoadAdaptersFromStore` reaches the same constructors at boot with **no `recover()`
anywhere above it** — the Recoverer only covers HTTP handlers. Measured: persist the bad
port with a build that predates the guard, then boot a build carrying only the
API-boundary guard.

```
### STEP 1: PRE-FIX binary persists port 70000 ###
persisted adapter row:  nfs|70000|1
                        smb|1445|1

### STEP 2: boot the build with only the API-boundary guard ###
RESULT: server DIED at boot
panic: invalid NFS config: invalid port 70000: must be 0-65535
```

So any deployment that ever accepted an out-of-range port was one restart away from a
server that will not start, with no API left to fix the row through. The guard moved to
the top of `startAdapter`, the one seam all four start callers route through
(`CreateAdapter`, `UpdateAdapter`, `EnableAdapter`, `LoadAdaptersFromStore`). Same DB,
same build, guard moved:

```
RESULT: server is ALIVE
panic lines in log: 0
[ERROR] Adapter failed to start; continuing without it type=nfs port=70000 \
        error=invalid adapter config: invalid port 70000: must be 0-65535
```

That is the behaviour `LoadAdaptersFromStore` already documents for an unusable persisted
config, SMB still starts, and the row is correctable over the API afterwards.

### Why both fixes, not either

Each covers callers the other cannot, and each is pinned by a mutant:

- **Validation at the seam** is what saves the boot path — no recover there, so the
  deferred unlock is irrelevant when the process is dying.
- **The deferred unlock** is what saves the HTTP path against any *other* panic the
  validation does not cover. Isolated with a mutant that keeps the validation but restores
  the original bare `Unlock()`, against a factory that panics:
  `--- FAIL: TestStartAdapter_ReleasesLockWhenFactoryPanics: adapters service lock was not released`.
  It passes with `defer`. So the panic genuinely unwinds *while holding* the lock rather
  than merely near it.

The handler-level `Validate()` call stays as well, for a third job: it makes the response
a 400 instead of a 500 and stops the bad port being persisted at all.

`AddAdapter` deliberately keeps its bare unlock — it never calls the factory (the adapter
arrives already built) and has no non-test callers, so there is no panic source under
that lock.

## The test defect

ADP-08 asserted only `assert.Error(...)` on all three calls, which the apiclient's 30 s
`http.Client` timeout satisfies. The wedge therefore logged three ✓ ticks and failed on
the one unrelated `require.NoError`. The timing decomposes exactly — 0.01 s + 30 + 30 + 30
= 90.03 s locally, against 90.06 s in CI run 33018102610. Only the first call was really
rejected; the other two ✓ were the server being dead.

**The negative-port case was also asserting something false.** `dfsctl adapter enable`
only forwarded `--port` when `enablePort > 0`, so `--port -1` was silently dropped and the
request *succeeded*:

```
# healthy server, nfs exists and is disabled (the state ADP-07 leaves)
enable nfs --port -1     rc=0   0.01s   Adapter 'nfs' enabled on port 56355
```

`assert.Error(t, err, "Should reject negative port")` had never been true; it only ever
"passed" because the previous call had already killed the server. Both `enable` and `edit`
now use `Flags().Changed("port")`, which also fixes `--port 0` being unable to return an
adapter to its default port.

### Both new assertion sets mutation-tested

Mutants confirmed to compile (`go vet -tags=e2e ./test/e2e/...` clean) before running — a
mutant that does not build is not a mutant.

| Mutant | Result |
| --- | --- |
| Original product code + hardened e2e test | FAIL in 0.01s on the validation-message guard, instead of three ✓ and 90s |
| Fixed product + `time.Sleep(2*time.Minute)` at the top of `AdapterHandler.Update` (deliberately unresponsive API) | FAIL: `port > 65535 must be refused by validation, not by an unresponsive server` |
| Seam `Validate()` removed | FAIL ×3: `factory was handed a config the server cannot build` |
| `defer` reverted to bare `Unlock()` | FAIL: `adapters service lock was not released after the factory panicked` |

The two unit tests matter because `e2e-tests` is postsubmit — they are what guards this on
a PR.

## Verification

Scaleway VM, go 1.25.5, sqlite control-plane store, same box before and after:

```
BEFORE  --- FAIL: TestAdapterLifecycle (109.82s)
            --- FAIL: ADP-08_invalid_config_rejection (90.03s)

AFTER   --- PASS: TestAdapterLifecycle (3.65s)
            --- PASS: ADP-08_invalid_config_rejection (0.05s)
```

ADP-01 through ADP-07 are innocent, incidentally — the wedge is not cumulative, a single
first call does it on a fresh server.

`go build ./...`, `go vet ./...`, `go vet -tags=e2e ./test/e2e/...`, `gofmt` clean,
`go test -race` green on `runtime/adapters`, `models` and `api/handlers`. No Cobra flag or
command definitions changed, so `go run ./cmd/gendocs` produces no diff.
