### PR TITLE
fix(nfs4): open the reboot-grace window only when state is reclaimable

### DIFF
--- a/internal/adapter/nfs/v4/state/client_recovery.go
+++ b/internal/adapter/nfs/v4/state/client_recovery.go
@@ -155,32 +155,26 @@ func (sm *StateManager) validateReclaimVerifier(clientIDString string, bootVerif
 }
 
 // LoadClientRecovery reads the durable recovery records on boot and starts the
-// v4 grace period seeded with the prior clients' stable identity strings:
-// today the v4 roster is empty on a fresh process so v4 grace
-// is a no-op; now it is the durable prior-client set).
-//
-// Records whose ReclaimComplete is already true are NOT waited on (a second
+// v4 grace period seeded with the prior clients' stable identity strings.
+// Records whose ReclaimComplete is already true are NOT waited on: a second
 // restart inside one grace window must not re-wait on a client that already
-// finished reclaim — §3.2 RecordReclaimComplete rationale).
+// finished reclaim.
 //
 // The boot verifier snapshot is taken unconditionally, because the
 // CLAIM_PREVIOUS verifier gate must be armed for any prior client whether or
 // not a reclaim window is opened.
 //
-// armGrace decides whether the roster actually opens the 90s window. A record
-// is written for every client that reaches SETCLIENTID_CONFIRM, including one
-// that never opened or locked anything, so the roster alone does not mean there
-// is state to reclaim -- and a v4.0 client with nothing to reclaim can never
-// retire its own entry, since it returns with CLAIM_NULL and v4.0 has no
-// RECLAIM_COMPLETE. Opening the window on the roster alone therefore costs a
-// full grace duration on every subsequent start, refusing every CLAIM_NULL
-// OPEN, with no client able to end it early. The caller passes the same
-// reclaim-warranted signal the lock layer computes for its own window.
+// armGrace decides whether the roster opens a window. A record is written for
+// every client that reaches SETCLIENTID_CONFIRM, even one that never opened or
+// locked anything, and a v4.0 client with nothing to reclaim can never retire
+// its own entry (it returns with CLAIM_NULL, and v4.0 has no RECLAIM_COMPLETE).
+// Arming on the roster alone therefore burns a full grace duration on every
+// later start, refusing every CLAIM_NULL OPEN with no client able to end it
+// early.
 //
-// Returns the number of clients added to the expected reclaim roster. When no
-// recovery store is wired, the store has no waitable records, or armGrace is
-// false, no window is opened. The hard grace timer remains the backstop
-// regardless.
+// Returns the number of clients added to the expected reclaim roster; 0 when no
+// recovery store is wired, no records are waitable, or armGrace is false. The
+// hard grace timer remains the backstop regardless.
 //
 // Caller must NOT hold sm.mu.
 func (sm *StateManager) LoadClientRecovery(ctx context.Context, armGrace bool) int {

--- a/internal/adapter/nfs/v4/state/client_recovery.go
+++ b/internal/adapter/nfs/v4/state/client_recovery.go
@@ -163,14 +163,27 @@ func (sm *StateManager) validateReclaimVerifier(clientIDString string, bootVerif
 // restart inside one grace window must not re-wait on a client that already
 // finished reclaim — §3.2 RecordReclaimComplete rationale).
 //
+// The boot verifier snapshot is taken unconditionally, because the
+// CLAIM_PREVIOUS verifier gate must be armed for any prior client whether or
+// not a reclaim window is opened.
+//
+// armGrace decides whether the roster actually opens the 90s window. A record
+// is written for every client that reaches SETCLIENTID_CONFIRM, including one
+// that never opened or locked anything, so the roster alone does not mean there
+// is state to reclaim -- and a v4.0 client with nothing to reclaim can never
+// retire its own entry, since it returns with CLAIM_NULL and v4.0 has no
+// RECLAIM_COMPLETE. Opening the window on the roster alone therefore costs a
+// full grace duration on every subsequent start, refusing every CLAIM_NULL
+// OPEN, with no client able to end it early. The caller passes the same
+// reclaim-warranted signal the lock layer computes for its own window.
+//
 // Returns the number of clients added to the expected reclaim roster. When no
-// recovery store is wired, or the store has no waitable records, this is a
-// no-op and grace behaves exactly as on develop (empty roster -> skipped),
-// which preserves the fresh-CI fast path. The hard grace timer remains the
-// backstop regardless.
+// recovery store is wired, the store has no waitable records, or armGrace is
+// false, no window is opened. The hard grace timer remains the backstop
+// regardless.
 //
 // Caller must NOT hold sm.mu.
-func (sm *StateManager) LoadClientRecovery(ctx context.Context) int {
+func (sm *StateManager) LoadClientRecovery(ctx context.Context, armGrace bool) int {
 	sm.mu.RLock()
 	store := sm.recoveryStore
 	sm.mu.RUnlock()
@@ -209,6 +222,12 @@ func (sm *StateManager) LoadClientRecovery(ctx context.Context) int {
 
 	if len(expectedStrings) == 0 {
 		logger.Info("client-recovery boot load: no waitable prior clients; v4 grace not seeded")
+		return 0
+	}
+
+	if !armGrace {
+		logger.Info("client-recovery boot load: no reclaimable state on this start; v4 grace not seeded",
+			"prior_clients", len(expectedStrings))
 		return 0
 	}
 

--- a/internal/adapter/nfs/v4/state/client_recovery_test.go
+++ b/internal/adapter/nfs/v4/state/client_recovery_test.go
@@ -177,7 +177,7 @@ func TestClientRecovery_NilStore(t *testing.T) {
 		t.Fatal("HasClientRecoveryStore should be false with no store wired")
 	}
 	// Boot-load with no store is a no-op returning 0.
-	if n := sm.LoadClientRecovery(context.Background()); n != 0 {
+	if n := sm.LoadClientRecovery(context.Background(), true); n != 0 {
 		t.Fatalf("LoadClientRecovery with nil store = %d, want 0", n)
 	}
 }
@@ -222,7 +222,7 @@ func TestClientRecovery_BootLoadSeedsRoster(t *testing.T) {
 	sm := NewStateManager(5*time.Second, 5*time.Second)
 	sm.SetClientRecoveryStore(spy, 1)
 
-	n := sm.LoadClientRecovery(context.Background())
+	n := sm.LoadClientRecovery(context.Background(), true)
 	if n != 2 {
 		t.Fatalf("LoadClientRecovery seeded %d clients, want 2 (reclaim-complete excluded)", n)
 	}
@@ -247,7 +247,7 @@ func TestClientRecovery_BootLoadEmptySkipsGrace(t *testing.T) {
 	sm := NewStateManager(5*time.Second, 5*time.Second)
 	sm.SetClientRecoveryStore(spy, 1)
 
-	if n := sm.LoadClientRecovery(context.Background()); n != 0 {
+	if n := sm.LoadClientRecovery(context.Background(), true); n != 0 {
 		t.Fatalf("empty store should seed 0, got %d", n)
 	}
 	if sm.IsInGrace() {
@@ -262,11 +262,43 @@ func TestClientRecovery_BootLoadAllCompleteSkipsGrace(t *testing.T) {
 	sm := NewStateManager(5*time.Second, 5*time.Second)
 	sm.SetClientRecoveryStore(spy, 1)
 
-	if n := sm.LoadClientRecovery(context.Background()); n != 0 {
+	if n := sm.LoadClientRecovery(context.Background(), true); n != 0 {
 		t.Fatalf("all-complete store should seed 0, got %d", n)
 	}
 	if sm.IsInGrace() {
 		t.Fatal("all-reclaim-complete roster must NOT enter grace")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// armGrace=false: roster is read, verifier gate armed, but no window opened
+// ---------------------------------------------------------------------------
+
+func TestClientRecovery_NoReclaimableStateSkipsGrace(t *testing.T) {
+	spy := newSpyRecoveryStore()
+	verf := [8]byte{0xcd}
+	spy.records["idle-client"] = &lock.V4ClientRecoveryRecord{ClientIDString: "idle-client", BootVerifier: verf}
+
+	sm := NewStateManager(5*time.Second, 30*time.Second)
+	sm.SetClientRecoveryStore(spy, 1)
+
+	if n := sm.LoadClientRecovery(context.Background(), false); n != 0 {
+		t.Fatalf("seeded %d, want 0 when nothing is reclaimable", n)
+	}
+	if sm.IsInGrace() {
+		t.Fatal("a waitable roster must NOT open the grace window when no state is reclaimable")
+	}
+
+	// The verifier snapshot is still armed: it gates CLAIM_PREVIOUS for any
+	// prior client and must not depend on whether a window was opened.
+	sm.mu.RLock()
+	got, ok := sm.bootRecoveryVerifiers["idle-client"]
+	sm.mu.RUnlock()
+	if !ok {
+		t.Fatal("boot verifier snapshot must be taken even when grace is not seeded")
+	}
+	if got != verf {
+		t.Fatalf("boot verifier = %v, want %v", got, verf)
 	}
 }
 
@@ -281,7 +313,7 @@ func TestClientRecovery_ReclaimMatchingVerifierAndEarlyExit(t *testing.T) {
 
 	sm := NewStateManager(5*time.Second, 30*time.Second)
 	sm.SetClientRecoveryStore(spy, 1)
-	if n := sm.LoadClientRecovery(context.Background()); n != 1 {
+	if n := sm.LoadClientRecovery(context.Background(), true); n != 1 {
 		t.Fatalf("seeded %d, want 1", n)
 	}
 	if !sm.IsInGrace() {
@@ -318,7 +350,7 @@ func TestClientRecovery_ReclaimChangedVerifierRejected(t *testing.T) {
 
 	sm := NewStateManager(5*time.Second, 30*time.Second)
 	sm.SetClientRecoveryStore(spy, 1)
-	if n := sm.LoadClientRecovery(context.Background()); n != 1 {
+	if n := sm.LoadClientRecovery(context.Background(), true); n != 1 {
 		t.Fatalf("seeded %d, want 1", n)
 	}
 
@@ -348,7 +380,7 @@ func TestClientRecovery_GraceTimerBackstopLifts(t *testing.T) {
 
 	sm := NewStateManager(5*time.Second, 100*time.Millisecond)
 	sm.SetClientRecoveryStore(spy, 1)
-	if n := sm.LoadClientRecovery(context.Background()); n != 1 {
+	if n := sm.LoadClientRecovery(context.Background(), true); n != 1 {
 		t.Fatalf("seeded %d, want 1", n)
 	}
 	if !sm.IsInGrace() {
@@ -398,7 +430,7 @@ func TestClientRecovery_V41PersistAndReclaimComplete(t *testing.T) {
 	// Now simulate a restart roster containing this client, then RECLAIM_COMPLETE.
 	sm2 := NewStateManager(5*time.Second, 30*time.Second)
 	sm2.SetClientRecoveryStore(spy, 8)
-	if n := sm2.LoadClientRecovery(context.Background()); n != 1 {
+	if n := sm2.LoadClientRecovery(context.Background(), true); n != 1 {
 		t.Fatalf("post-restart seeded %d, want 1", n)
 	}
 	// Re-establish identity and a session, then RECLAIM_COMPLETE.

--- a/pkg/adapter/nfs/adapter.go
+++ b/pkg/adapter/nfs/adapter.go
@@ -535,6 +535,24 @@ func (s *NFSAdapter) SetKerberosConfig(cfg *config.KerberosConfig) {
 //
 // Thread safety:
 // Called exactly once before Serve(), no synchronization needed.
+// anyShareAwaitingReclaim reports whether any share opened a lock-reclaim
+// window on this start. The lock layer opens one only when the prior shutdown
+// was unclean or persisted locks were restored, which is the same question the
+// NFSv4 reboot-grace window needs answered: is there state a returning client
+// could reclaim?
+func anyShareAwaitingReclaim(rt *runtime.Runtime) bool {
+	metaSvc := rt.GetMetadataService()
+	if metaSvc == nil {
+		return false
+	}
+	for _, shareName := range rt.ListShares() {
+		if lm := metaSvc.GetLockManagerForShare(shareName); lm != nil && lm.IsInGracePeriod() {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *NFSAdapter) SetRuntime(rtAny any) {
 	s.BaseAdapter.SetRuntime(rtAny)
 	rt := rtAny.(*runtime.Runtime)
@@ -599,7 +617,12 @@ func (s *NFSAdapter) SetRuntime(rtAny any) {
 		// This is what gives the previously-no-op v4 grace a real expected set
 		// after an ungraceful restart. With an empty/fresh store the roster is
 		// empty and grace is skipped, exactly as on develop today.
-		n := v4StateManager.LoadClientRecovery(context.Background())
+		// Only open the reboot-grace window when some share actually has state a
+		// returning client could reclaim. The lock layer opens its own window on
+		// exactly that condition (unclean prior shutdown, or locks restored), so
+		// reuse its verdict instead of opening a window for every client that has
+		// ever confirmed against this metadata store.
+		n := v4StateManager.LoadClientRecovery(context.Background(), anyShareAwaitingReclaim(rt))
 		logger.Debug("NFSv4 client-recovery store designated", "boot_loaded_clients", n)
 	}
 

--- a/pkg/adapter/nfs/adapter.go
+++ b/pkg/adapter/nfs/adapter.go
@@ -522,24 +522,11 @@ func (s *NFSAdapter) SetKerberosConfig(cfg *config.KerberosConfig) {
 	}
 }
 
-// SetRuntime injects the runtime containing all stores and shares.
-//
-// Called by Runtime before Serve() is called. The runtime
-// provides access to all configured metadata stores, content stores, and shares.
-//
-// The NFS adapter stores the runtime and injects it into both the NFS and Mount
-// handlers so they can access stores based on share names.
-//
-// Parameters:
-//   - rt: Runtime containing all stores and shares
-//
-// Thread safety:
-// Called exactly once before Serve(), no synchronization needed.
-// anyShareAwaitingReclaim reports whether any share opened a lock-reclaim
-// window on this start. The lock layer opens one only when the prior shutdown
-// was unclean or persisted locks were restored, which is the same question the
-// NFSv4 reboot-grace window needs answered: is there state a returning client
-// could reclaim?
+// anyShareAwaitingReclaim reports whether any share opened a lock-reclaim window
+// on this start. The lock layer opens one only when the prior shutdown was
+// unclean or persisted locks were restored, which is the same question the NFSv4
+// reboot-grace window needs answered: is there state a returning client could
+// reclaim?
 func anyShareAwaitingReclaim(rt *runtime.Runtime) bool {
 	metaSvc := rt.GetMetadataService()
 	if metaSvc == nil {
@@ -553,6 +540,19 @@ func anyShareAwaitingReclaim(rt *runtime.Runtime) bool {
 	return false
 }
 
+// SetRuntime injects the runtime containing all stores and shares.
+//
+// Called by Runtime before Serve() is called. The runtime
+// provides access to all configured metadata stores, content stores, and shares.
+//
+// The NFS adapter stores the runtime and injects it into both the NFS and Mount
+// handlers so they can access stores based on share names.
+//
+// Parameters:
+//   - rt: Runtime containing all stores and shares
+//
+// Thread safety:
+// Called exactly once before Serve(), no synchronization needed.
 func (s *NFSAdapter) SetRuntime(rtAny any) {
 	s.BaseAdapter.SetRuntime(rtAny)
 	rt := rtAny.(*runtime.Runtime)
@@ -612,16 +612,11 @@ func (s *NFSAdapter) SetRuntime(rtAny any) {
 	}
 	if recoveryStore != nil {
 		v4StateManager.SetClientRecoveryStore(recoveryStore, uint64(v4StateManager.BootEpoch()))
-		// On boot, load the durable prior-client set and seed the v4 grace
-		// expected-reclaim roster (records already reclaim-complete are excluded).
-		// This is what gives the previously-no-op v4 grace a real expected set
-		// after an ungraceful restart. With an empty/fresh store the roster is
-		// empty and grace is skipped, exactly as on develop today.
-		// Only open the reboot-grace window when some share actually has state a
-		// returning client could reclaim. The lock layer opens its own window on
-		// exactly that condition (unclean prior shutdown, or locks restored), so
-		// reuse its verdict instead of opening a window for every client that has
-		// ever confirmed against this metadata store.
+		// Seed the v4 grace expected-reclaim roster from the durable prior-client
+		// set (records already reclaim-complete are excluded), but open the window
+		// only when a share actually holds state a returning client could reclaim.
+		// The lock layer opens its own window on exactly that condition, so reuse
+		// its verdict rather than gracing every client that ever confirmed here.
 		n := v4StateManager.LoadClientRecovery(context.Background(), anyShareAwaitingReclaim(rt))
 		logger.Debug("NFSv4 client-recovery store designated", "boot_loaded_clients", n)
 	}


### PR DESCRIPTION
Closes #2209

## What was wrong

The E2E suite blew its own 30 minute `go test` timeout. The panic named `TestStoreMatrixV4 (17m12s)` with `v4.1/postgres/memory/memory/CreateReadWriteFile` still running, and the test-process goroutine dump had exactly one interesting goroutine — blocked in `syscall.openat` (`os.Create`) on the NFS mount. Nothing was deadlocked in the test process; the kernel client was waiting on the server.

It is not one wedged cell, and it is not a slow matrix. Per-cell timings on a VM (kernel NFS client, `postgres:16-alpine`):

```
  43 cells   1-3s     every memory/* and badger/* cell, and every v3 cell
  11 cells   ~105s    postgres metadata under v4.0/v4.1, every cell after the first
```

Nothing wedges — all 11 recover and pass. The cell the CI alarm happened to catch was 26s into a window it would have left at 90s. So raising the timeout would have been the wrong fix.

The ~105s is the NFSv4 grace period. From a stalling cell's server log:

```
lock recovery: completed share=/export-v4matrix restored_locks=0 epoch=11 clients=0 \
    prior_shutdown_clean=true enter_grace=false
NFSv4 grace period started duration=1m30s expected_clients=0 expected_client_strings=1
client-recovery boot load: v4 grace period seeded expected_clients=1
NFSv4 OPEN blocked by grace period claim_type=CLAIM_NULL client=127.0.0.1:706
...   (client retries with exponential backoff across the full 90s)
```

`persistClientRecoveryLocked` writes a `v4_client_recovery` row at SETCLIENTID_CONFIRM for **every** client, whether or not it goes on to open or lock anything. On the next start `LoadClientRecovery` put every row with `reclaim_complete = false` on the waitable roster and opened the full 90s window, refusing every `OPEN(CLAIM_NULL)` with NFS4ERR_GRACE.

Two things make that permanent rather than a one-off:

**The roster entry is unsatisfiable for a v4.0 client.** `reclaim_complete` is set only by RECLAIM_COMPLETE (v4.1 only) or a successful CLAIM_PREVIOUS. A client with nothing to reclaim sends neither — it opens with CLAIM_NULL, as the log shows. So no client can end the window early and it always runs to the hard timer.

**The row cannot be retired.** The only deletion path, `deleteClientRecoveryLocked`, is reached from lease expiry / eviction / DESTROY_CLIENTID, all of which need an in-memory `sm.clientsByID` entry that a boot-loaded row does not have unless that client comes back. Observed mid-run, after the suite had moved from the v4.0 block into the v4.1 block:

```
 clientid_string                                   | server_epoch | reclaim_complete
---------------------------------------------------+--------------+------------------
 Linux NFSv4.0 dfs-e2e-storematrix/127.0.0.1       |   1787833870 | f
 v41:4c696e7578204e465376342e31206466732d653265... |   1787834310 | t
```

The v4.1 row is re-stamped with the current epoch each cell and correctly excluded. The v4.0 row is **frozen at a stale epoch** — no v4.0 client is connecting any more, nothing re-confirms it, nothing deletes it — and it keeps arming a 90s window on every start, in v4.1 cells too, since a `v41:`-keyed identity can never satisfy a v4.0 roster entry.

This is not only a harness artifact: any deployment on a persistent metadata store where a v4.0 client has ever confirmed and then gone away pays a full 90s window on every subsequent start, even after a clean shutdown with nothing to restore.

## The 90s is once per start, not once per OPEN

Worth pinning down, because the two readings give very different totals. Subtest breakdown of a stalling cell beside a fast one:

```
--- PASS: v4.1/postgres/memory/s3 (104.98s)      --- PASS: v4.1/badger/memory/s3 (1.61s)
    CreateReadWriteFile (103.36s)                    CreateReadWriteFile (0.09s)
    DirectoryOps          (0.18s)                    DirectoryOps         (0.11s)
    DeleteFile            (0.04s)                    DeleteFile           (0.03s)
    Rename                (0.09s)                    Rename               (0.07s)
```

`DirectoryOps`, `DeleteFile` and `Rename` all create files too, so each issues state-creating OPENs — and in the stalling cell they run at exactly the fast cell's speed. The window opens once at start, the first OPEN absorbs it, everything after is full speed. Cell cost ~105s = 90s grace + the client's final retry backoff.

That reconciles with the panic: cell order is v3(18), v4.0(18), v4.1(18); v4.0-postgres has 6 cells with the first free (5 stalls) and v4.1-postgres 6 cells all stalling, of which CI completed 4 and was 26s into the 5th. 9 x ~105s + 26s = 971s, plus 43 fast cells at CI speed (~60s) = **~17m11s against the 17m12s reported**. At 90s per OPEN 52 cells could not have fitted in 17m; at 90s once for the whole run the matrix would finish in ~2m. Only once-per-start lands on the observed figure.

## The fix

Open the reboot-grace window only when there is state a returning client could reclaim, using the verdict the lock layer already computes for its own reclaim window (`pkg/metadata/share_registry.go`):

```go
enterGrace = unclean || len(persisted) > 0
```

That is the same question the v4 window needs answered, and in the log above it had already evaluated to `enter_grace=false` — the v4 boot load then armed 90s anyway, because it never consulted it. `nfsGraceCoordinator` documents the identical class of self-harm it was given a `bootComplete` latch to prevent, and notes that `LoadClientRecovery` arms v4 grace independently of the coordinator, so none of the coordinator's gates applied to it.

`LoadClientRecovery` takes an `armGrace bool`; the boot verifier snapshot stays unconditional, since the CLAIM_PREVIOUS verifier gate must be armed for any prior client whether or not a window opens.

Only locks are persisted in this codebase — there is no persistence of v4 OPEN state — so on a clean shutdown with zero restored locks the server retains no record of a client's opens either way, and the window bought nothing.

## Verification

Same VM, same postgres database, and the poisoning row (`reclaim_complete = f`) still present in the table for both runs:

| | `TestStoreMatrixV4` | stalling cells |
|---|---|---|
| before | **1253.43s** | 11 at ~105s |
| after | **90.28s** | none; slowest cell 4s |

All 54 cells pass after the fix, and all 12 v4-postgres cells run in 1-2s.

Converse check, because a guard that has never refused anything is unverified — forcing `clean_shutdown = FALSE` in postgres with the same waitable row present:

```
--- PASS: TestStoreMatrixV4/v4.0/postgres/fs/none (105.46s)
```

The window still arms on an unclean prior shutdown, so the fix narrows the trigger rather than disabling the feature.

Also green: `go build ./...`, `go vet`, `go test ./internal/adapter/nfs/... ./pkg/adapter/nfs/... ./pkg/metadata/...`, `go test -race` on the two adapter trees, and the e2e grace/recovery set — `TestGracePeriodRecovery`, `TestGracePeriodUnclaimedLocks`, `TestGracePeriodNewLockBlocked`, `TestGracePeriodTiming`, `TestGracePeriodEarlyExit`, `TestGracePeriodWithSMBLeases`, `TestCrossProtocolReclaim`, `TestServerRestartRecovery`, `TestNFSv41SessionRecoveryAfterRestart`.

The new unit test was checked against a deliberately broken build: with the gate removed it fails with `seeded 1, want 0 when nothing is reclaimable`.

## Left for a follow-up (#2215)

Rows for clients that never return are still immortal, so on a genuinely unclean restart the roster can still contain long-dead clients and the window will run its full duration instead of exiting early. That is a separate, lower-severity defect — it no longer costs anything on a clean start, which is the case that was breaking CI — and retiring those rows safely needs its own change, since a returning client re-confirms under the same identity and its row must not be swept with the dead ones.
