### PR TITLE
fix(nfs4): deliver delegation recalls — AUTH_SYS credential and the client's callback_ident

### DIFF
--- a/internal/adapter/nfs/v4/handlers/open.go
+++ b/internal/adapter/nfs/v4/handlers/open.go
@@ -516,7 +516,7 @@ func (h *Handler) handleOpenClaimNull(
 		"createMode", createMode,
 		"stateid_seqid", openResult.Stateid.Seqid,
 		"rflags", openResult.RFlags,
-		"delegation", delegType,
+		"delegation", encodedDelegType(deleg),
 		"client", ctx.ClientAddr)
 
 	// Encode OPEN4resok
@@ -605,7 +605,7 @@ func (h *Handler) handleOpenClaimFH(
 	logger.Debug("NFSv4 OPEN CLAIM_FH successful",
 		"stateid_seqid", openResult.Stateid.Seqid,
 		"rflags", openResult.RFlags,
-		"delegation", delegType,
+		"delegation", encodedDelegType(deleg),
 		"client", ctx.ClientAddr)
 
 	// CLAIM_FH does not create or change a directory, so change_info is empty.
@@ -1009,4 +1009,14 @@ func effectiveUIDGID(authCtx *metadata.AuthContext) (uint32, uint32) {
 		}
 	}
 	return uid, gid
+}
+
+// encodedDelegType reports the delegation type that OPEN actually puts on the
+// wire. A refused grant leaves deleg nil, which encodes as OPEN_DELEGATE_NONE —
+// distinct from the type the open attempted.
+func encodedDelegType(deleg *state.DelegationState) uint32 {
+	if deleg == nil {
+		return types.OPEN_DELEGATE_NONE
+	}
+	return deleg.DelegType
 }

--- a/internal/adapter/nfs/v4/handlers/ops_test.go
+++ b/internal/adapter/nfs/v4/handlers/ops_test.go
@@ -1388,3 +1388,38 @@ func TestReadDir_NoCurrentFH(t *testing.T) {
 			decoded.Status, types.NFS4ERR_NOFILEHANDLE)
 	}
 }
+
+// TestSetClientID_StoresCallbackIdent pins that SETCLIENTID keeps the client's
+// callback_ident. An NFSv4.0 client matches an incoming CB_COMPOUND to one of
+// its mounts by this value, so discarding it here leaves every later callback
+// carrying an identifier the client rejects, with nothing on the acquire path
+// to reveal it.
+func TestSetClientID_StoresCallbackIdent(t *testing.T) {
+	h := newTestHandlerWithShares([]string{"/export"})
+	ctx := newOpsTestContext()
+
+	data := encodeCompoundWithOps("", 0, []encodedOp{
+		encodeSetClientID("ident-test-client"),
+	})
+
+	resp, err := h.ProcessCompound(ctx, data)
+	if err != nil {
+		t.Fatalf("ProcessCompound error: %v", err)
+	}
+
+	decoded, _ := decodeCompoundResp(resp)
+	if decoded.Results[0].Status != types.NFS4_OK {
+		t.Fatalf("SETCLIENTID status = %d, want NFS4_OK", decoded.Results[0].Status)
+	}
+
+	clientID := binary.BigEndian.Uint64(decoded.Results[0].ExtraData[0:8])
+	client := h.StateManager.GetClient(clientID)
+	if client == nil {
+		t.Fatalf("no client record for id %d", clientID)
+	}
+
+	// encodeSetClientID sends callback_ident = 1.
+	if client.Callback.Ident != 1 {
+		t.Errorf("stored callback ident = %d, want 1 (the value the client sent)", client.Callback.Ident)
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/setclientid.go
+++ b/internal/adapter/nfs/v4/handlers/setclientid.go
@@ -65,7 +65,7 @@ func (h *Handler) handleSetClientID(ctx *types.CompoundContext, reader io.Reader
 	}
 
 	// Read callback_ident (uint32)
-	_, err = xdr.DecodeUint32(reader)
+	callbackIdent, err := xdr.DecodeUint32(reader)
 	if err != nil {
 		return &types.CompoundResult{
 			Status: types.NFS4ERR_BADXDR,
@@ -79,6 +79,7 @@ func (h *Handler) handleSetClientID(ctx *types.CompoundContext, reader io.Reader
 		Program: cbProgram,
 		NetID:   cbNetID,
 		Addr:    cbAddr,
+		Ident:   callbackIdent,
 	}
 
 	// Delegate to StateManager for the five-case algorithm

--- a/internal/adapter/nfs/v4/state/backchannel_test.go
+++ b/internal/adapter/nfs/v4/state/backchannel_test.go
@@ -392,17 +392,7 @@ func TestBackchannelSender_SequenceIDIncrement(t *testing.T) {
 		}
 		xid := binary.BigEndian.Uint32(body[0:4])
 
-		// Parse past RPC header (10 uint32s = 40 bytes) to get to CB_COMPOUND args
-		// XID(4) + msg_type(4) + rpc_vers(4) + prog(4) + vers(4) + proc(4) +
-		// cred_flavor(4) + cred_len(4) + verf_flavor(4) + verf_len(4) = 40 bytes
-		// Then CB_COMPOUND: tag_len(4) + minorversion(4) + callback_ident(4) +
-		// op_count(4) + first_op_code(4) = 20 bytes
-		// CB_SEQUENCE args start at offset 60
-		// CB_SEQUENCE args: sessionID(16 bytes) + seqID(4 bytes)
-		if len(body) < 60+16+4 {
-			t.Fatalf("body too short: %d bytes", len(body))
-		}
-		seqID := binary.BigEndian.Uint32(body[60+16 : 60+16+4])
+		seqID := cbSequenceSeqID(t, body)
 
 		replyBody := buildMockCBCompoundReplyBody(xid)
 		pending.Deliver(xid, replyBody)
@@ -472,11 +462,11 @@ func TestBackchannelSender_SeqIDAndXIDAreIndependent(t *testing.T) {
 		if _, err := io.ReadFull(clientConn, body); err != nil {
 			t.Fatalf("read body: %v", err)
 		}
-		if len(body) < 60+16+4 {
+		if len(body) < 4 {
 			t.Fatalf("body too short: %d bytes", len(body))
 		}
 		xid = binary.BigEndian.Uint32(body[0:4])
-		seqID = binary.BigEndian.Uint32(body[60+16 : 60+16+4])
+		seqID = cbSequenceSeqID(t, body)
 
 		pending.Deliver(xid, buildMockCBCompoundReplyBody(xid))
 		return xid, seqID
@@ -710,4 +700,32 @@ func buildMockCBCompoundReplyBody(xid uint32) []byte {
 	_ = binary.Write(&reply, binary.BigEndian, uint32(0))
 
 	return reply.Bytes()
+}
+
+// cbSequenceSeqID extracts the CB_SEQUENCE sequence ID from a callback RPC CALL
+// message. The credential and verifier are length-prefixed and their sizes
+// depend on the flavor in use, so both are skipped by their declared length
+// rather than by a fixed header size.
+func cbSequenceSeqID(t *testing.T, body []byte) uint32 {
+	t.Helper()
+
+	// XID + msg_type + rpc_vers + prog + vers + proc
+	off := 6 * 4
+
+	// Credential and verifier: flavor(4) + length(4) + body(length, padded).
+	for i := 0; i < 2; i++ {
+		if len(body) < off+8 {
+			t.Fatalf("body too short for auth field %d: %d bytes", i, len(body))
+		}
+		length := int(binary.BigEndian.Uint32(body[off+4 : off+8]))
+		off += 8 + (length+3)/4*4
+	}
+
+	// CB_COMPOUND: tag_len + minorversion + callback_ident + op_count +
+	// first_op_code, then CB_SEQUENCE args: sessionID(16) + seqID(4).
+	off += 5*4 + 16
+	if len(body) < off+4 {
+		t.Fatalf("body too short for CB_SEQUENCE seqID: %d bytes", len(body))
+	}
+	return binary.BigEndian.Uint32(body[off : off+4])
 }

--- a/internal/adapter/nfs/v4/state/callback.go
+++ b/internal/adapter/nfs/v4/state/callback.go
@@ -222,10 +222,12 @@ func SendCBRecall(ctx context.Context, callback CallbackInfo, stateid *types.Sta
 	}
 	defer func() { _ = conn.Close() }()
 
-	// Encode CB_RECALL wrapped in CB_COMPOUND
-	// callback_ident=0: client identifies via the program number
+	// Encode CB_RECALL wrapped in CB_COMPOUND. The callback_ident is echoed from
+	// SETCLIENTID: an NFSv4.0 client resolves an incoming CB_COMPOUND to one of
+	// its mounts by that value alone, and rejects an ident it does not recognise
+	// at the RPC layer, before the recall inside is decoded.
 	recallOp := EncodeCBRecallOp(stateid, truncate, fh)
-	compoundArgs := encodeCBCompound(0, recallOp)
+	compoundArgs := encodeCBCompound(callback.Ident, recallOp)
 
 	// Build and send RPC CALL message
 	xid := uint32(time.Now().UnixNano() & 0xFFFFFFFF)

--- a/internal/adapter/nfs/v4/state/callback_common.go
+++ b/internal/adapter/nfs/v4/state/callback_common.go
@@ -60,7 +60,34 @@ func EncodeCBRecallOp(stateid *types.Stateid4, truncate bool, fh []byte) []byte 
 	return buf.Bytes()
 }
 
-// BuildCBRPCCallMessage builds an RPC CALL message with AUTH_NULL credentials.
+// encodeAuthSysCred writes an AUTH_SYS credential carrying the server's own
+// identity, as flavor + length-prefixed authsys_parms body.
+//
+// Body per RFC 5531 Section 9.2:
+//
+//	stamp:       [uint32]
+//	machinename: [string<255>]
+//	uid:         [uint32]
+//	gid:         [uint32]
+//	gids:        [uint32<16>]
+//
+// The callback runs on the server's own behalf rather than any end user's, so
+// it presents uid/gid 0 with an empty machine name and no supplementary groups.
+// Receivers gate callbacks on the credential's flavor, not its contents; an
+// empty machine name keeps the encoding free of a hostname lookup that can fail.
+func encodeAuthSysCred(buf *bytes.Buffer) {
+	var body bytes.Buffer
+	_ = xdr.WriteUint32(&body, 0)     // stamp
+	_ = xdr.WriteXDRString(&body, "") // machinename
+	_ = xdr.WriteUint32(&body, 0)     // uid
+	_ = xdr.WriteUint32(&body, 0)     // gid
+	_ = xdr.WriteUint32(&body, 0)     // gids: empty array
+
+	_ = xdr.WriteUint32(buf, uint32(rpc.AuthUnix))
+	_ = xdr.WriteXDROpaque(buf, body.Bytes())
+}
+
+// BuildCBRPCCallMessage builds an RPC CALL message with AUTH_SYS credentials.
 //
 // Wire format per RFC 5531:
 //
@@ -70,9 +97,19 @@ func EncodeCBRecallOp(stateid *types.Stateid4, truncate bool, fh []byte) []byte 
 //	Program:    [uint32]
 //	Version:    [uint32]
 //	Procedure:  [uint32]
-//	Cred:       AUTH_NULL (flavor=0, length=0)
+//	Cred:       AUTH_SYS (flavor=1, authsys_parms body)
 //	Verf:       AUTH_NULL (flavor=0, length=0)
 //	Args:       [procedure args]
+//
+// Every callback procedure carries the same credential, the CB_NULL reachability
+// probe included. A probe sent under a credential the payload does not use
+// proves nothing about the payload: Linux clients accept AUTH_NULL for CB_NULL
+// alone and answer AUTH_BADCRED to every other procedure, so a CB_NULL-only
+// AUTH_NULL probe reports a healthy backchannel that cannot carry one recall.
+// AUTH_SYS is accepted for all of them, which keeps the probe honest.
+//
+// The verifier stays AUTH_NULL: RFC 5531 Section 9.2 pairs AUTH_SYS credentials
+// with an AUTH_NONE verifier.
 func BuildCBRPCCallMessage(xid, prog, vers, proc uint32, args []byte) []byte {
 	var buf bytes.Buffer
 
@@ -84,9 +121,7 @@ func BuildCBRPCCallMessage(xid, prog, vers, proc uint32, args []byte) []byte {
 	_ = xdr.WriteUint32(&buf, vers)
 	_ = xdr.WriteUint32(&buf, proc)
 
-	// Auth credentials: AUTH_NULL (flavor=0, length=0)
-	_ = xdr.WriteUint32(&buf, uint32(rpc.AuthNull))
-	_ = xdr.WriteUint32(&buf, 0)
+	encodeAuthSysCred(&buf)
 
 	// Auth verifier: AUTH_NULL (flavor=0, length=0)
 	_ = xdr.WriteUint32(&buf, uint32(rpc.AuthNull))

--- a/internal/adapter/nfs/v4/state/callback_test.go
+++ b/internal/adapter/nfs/v4/state/callback_test.go
@@ -1181,3 +1181,74 @@ func TestBuildCBRPCCallMessage_ProbeAndPayloadShareCredential(t *testing.T) {
 		t.Errorf("CB_NULL probe cred body = %v, CB_COMPOUND = %v; both must be identical", probeBody, payloadBody)
 	}
 }
+
+// TestSendCBRecall_EchoesCallbackIdent pins the callback_ident an NFSv4.0
+// CB_COMPOUND carries to the one the client supplied in SETCLIENTID. A client
+// resolves the callback to one of its mounts by this value alone and rejects an
+// unrecognised one at the RPC layer, so a hardcoded ident silently disables
+// every recall while the CB_NULL reachability probe still reports it healthy.
+func TestSendCBRecall_EchoesCallbackIdent(t *testing.T) {
+	enableLoopbackCallback(t)
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = l.Close() }()
+
+	callback := makeCallbackInfoFromListener(l)
+	callback.Ident = 0x2A
+
+	identCh := make(chan uint32, 1)
+	go func() {
+		conn, acceptErr := l.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		var headerBuf [4]byte
+		if _, readErr := io.ReadFull(conn, headerBuf[:]); readErr != nil {
+			return
+		}
+		body := make([]byte, binary.BigEndian.Uint32(headerBuf[:])&0x7FFFFFFF)
+		if _, readErr := io.ReadFull(conn, body); readErr != nil {
+			return
+		}
+
+		// Skip the RPC header, then the CB_COMPOUND tag and minorversion, to
+		// reach callback_ident. The credential and verifier are length-prefixed,
+		// so both are skipped by their declared length.
+		off := 6 * 4
+		for i := 0; i < 2; i++ {
+			if len(body) < off+8 {
+				return
+			}
+			off += 8 + (int(binary.BigEndian.Uint32(body[off+4:off+8]))+3)/4*4
+		}
+		if len(body) < off+4 {
+			return
+		}
+		off += 4 + (int(binary.BigEndian.Uint32(body[off:off+4]))+3)/4*4 // tag
+		off += 4                                                         // minorversion
+		if len(body) < off+4 {
+			return
+		}
+		identCh <- binary.BigEndian.Uint32(body[off : off+4])
+	}()
+
+	// The reply never arrives, so SendCBRecall errors out; the assertion is on
+	// what went onto the wire, not on the call succeeding.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_ = SendCBRecall(ctx, callback, &types.Stateid4{Seqid: 1}, false, []byte{0x01, 0x02})
+
+	select {
+	case got := <-identCh:
+		if got != callback.Ident {
+			t.Errorf("CB_COMPOUND callback_ident = 0x%X, want 0x%X (the value from SETCLIENTID)", got, callback.Ident)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("no CB_COMPOUND received")
+	}
+}

--- a/internal/adapter/nfs/v4/state/callback_test.go
+++ b/internal/adapter/nfs/v4/state/callback_test.go
@@ -347,12 +347,16 @@ func TestBuildCBRPCCallMessage(t *testing.T) {
 		t.Errorf("procedure = %d, want %d", gotProc, proc)
 	}
 
-	// AUTH_NULL credentials: flavor=0, length=0
+	// AUTH_SYS credentials: flavor=1 with an authsys_parms body
 	var credFlavor, credLen uint32
 	_ = binary.Read(reader, binary.BigEndian, &credFlavor)
 	_ = binary.Read(reader, binary.BigEndian, &credLen)
-	if credFlavor != rpc.AuthNull || credLen != 0 {
-		t.Errorf("cred = (flavor=%d, len=%d), want (0, 0)", credFlavor, credLen)
+	if credFlavor != rpc.AuthUnix {
+		t.Errorf("cred flavor = %d, want %d (AUTH_SYS)", credFlavor, rpc.AuthUnix)
+	}
+	credBody := make([]byte, credLen)
+	if _, err := io.ReadFull(reader, credBody); err != nil {
+		t.Fatalf("read cred body: %v", err)
 	}
 
 	// AUTH_NULL verifier: flavor=0, length=0
@@ -1100,5 +1104,80 @@ func TestSendCBNull_VerifyProcedure(t *testing.T) {
 	// Verify the procedure was CB_PROC_NULL
 	if receivedProc != types.CB_PROC_NULL {
 		t.Errorf("procedure = %d, want %d (CB_PROC_NULL)", receivedProc, types.CB_PROC_NULL)
+	}
+}
+
+// readCBCred returns the credential flavor and body of a callback RPC CALL
+// message, skipping the six fixed header words that precede them.
+func readCBCred(t *testing.T, msg []byte) (uint32, []byte) {
+	t.Helper()
+
+	reader := bytes.NewReader(msg)
+	var word uint32
+	for i := 0; i < 6; i++ { // xid, msgtype, rpcvers, prog, vers, proc
+		if err := binary.Read(reader, binary.BigEndian, &word); err != nil {
+			t.Fatalf("read header word %d: %v", i, err)
+		}
+	}
+
+	var flavor, length uint32
+	if err := binary.Read(reader, binary.BigEndian, &flavor); err != nil {
+		t.Fatalf("read cred flavor: %v", err)
+	}
+	if err := binary.Read(reader, binary.BigEndian, &length); err != nil {
+		t.Fatalf("read cred length: %v", err)
+	}
+	body := make([]byte, length)
+	if _, err := io.ReadFull(reader, body); err != nil {
+		t.Fatalf("read cred body (%d bytes): %v", length, err)
+	}
+	return flavor, body
+}
+
+// TestBuildCBRPCCallMessage_CredIsParseableAuthSys pins the credential a
+// callback carries to a well-formed AUTH_SYS record. A receiver that gates
+// callbacks on the flavor rejects AUTH_NULL, and one that parses the body
+// rejects a malformed one, so both halves have to hold.
+func TestBuildCBRPCCallMessage_CredIsParseableAuthSys(t *testing.T) {
+	flavor, body := readCBCred(t, BuildCBRPCCallMessage(1, 0x40000000, 1, types.CB_PROC_COMPOUND, []byte{0xCA, 0xFE}))
+
+	if flavor != rpc.AuthUnix {
+		t.Fatalf("cred flavor = %d, want %d (AUTH_SYS)", flavor, rpc.AuthUnix)
+	}
+
+	auth, err := rpc.ParseUnixAuth(body)
+	if err != nil {
+		t.Fatalf("AUTH_SYS body does not parse as authsys_parms: %v", err)
+	}
+	if auth.UID != 0 || auth.GID != 0 {
+		t.Errorf("cred uid/gid = %d/%d, want 0/0", auth.UID, auth.GID)
+	}
+
+	// Receivers that walk authsys_parms field by field require the declared
+	// credential length to balance to exactly zero, so a body that merely parses
+	// is not enough — a missing trailing field is rejected as a bad credential.
+	// stamp(4) + machinename length(4) + machinename(0) + uid(4) + gid(4) + gids
+	// count(4) = 20 bytes for an empty name and no supplementary groups.
+	const wantLen = 20
+	if len(body) != wantLen {
+		t.Errorf("AUTH_SYS body = %d bytes, want %d; every authsys_parms field must be present", len(body), wantLen)
+	}
+}
+
+// TestBuildCBRPCCallMessage_ProbeAndPayloadShareCredential pins the invariant
+// the CB_NULL reachability probe depends on: it must present the same
+// credential as the callbacks it vouches for. A probe sent under a credential
+// the payload does not use certifies a backchannel that can still reject every
+// recall, and the rejection only surfaces once a delegation needs recalling.
+func TestBuildCBRPCCallMessage_ProbeAndPayloadShareCredential(t *testing.T) {
+	probeFlavor, probeBody := readCBCred(t, BuildCBRPCCallMessage(1, 0x40000000, 1, types.CB_PROC_NULL, nil))
+	payloadFlavor, payloadBody := readCBCred(t, BuildCBRPCCallMessage(2, 0x40000000, 1, types.CB_PROC_COMPOUND, []byte{0xCA, 0xFE}))
+
+	if probeFlavor != payloadFlavor {
+		t.Errorf("CB_NULL probe cred flavor = %d, CB_COMPOUND = %d; the probe must use the credential it vouches for",
+			probeFlavor, payloadFlavor)
+	}
+	if !bytes.Equal(probeBody, payloadBody) {
+		t.Errorf("CB_NULL probe cred body = %v, CB_COMPOUND = %v; both must be identical", probeBody, payloadBody)
 	}
 }

--- a/internal/adapter/nfs/v4/state/client.go
+++ b/internal/adapter/nfs/v4/state/client.go
@@ -144,6 +144,13 @@ type CallbackInfo struct {
 
 	// Addr is the callback address in universal address format.
 	Addr string
+
+	// Ident is the callback_ident the client supplied in SETCLIENTID. NFSv4.0
+	// clients match an incoming CB_COMPOUND to their own mount by this value, so
+	// it has to be echoed back in every callback; a callback carrying the wrong
+	// one is rejected before any operation in it is looked at. NFSv4.1 replaced
+	// it with the session and ignores the field.
+	Ident uint32
 }
 
 // ============================================================================


### PR DESCRIPTION
Closes #2218

`TestNLMAxisInterop` fails two of its four axes on `develop`. The verdict block reads as a release
bug, and it is not one.

```
NLM_vs_SMB     conflict=BLOCKED  afterRelease=ACQUIRED
NLM_vs_NFSv4   conflict=BLOCKED  afterRelease=ACQUIRED
SMB_vs_NLM     conflict=BLOCKED  afterRelease=BLOCKED   <-- fail
NFSv4_vs_NLM   conflict=BLOCKED  afterRelease=BLOCKED   <-- fail
NLM_AXIS_RESULT=FAIL
```

## What is actually wrong

**No NFSv4 delegation could ever be recalled from a Linux client.** Every recall was rejected at the
RPC layer, so a granted whole-file delegation stayed on the file and denied foreign byte-range locks
until a scanner timeout swept it. Both failing axes are that one lingering row, not two release bugs.

Two independent defects gate the same path, which is why fixing either alone changes nothing:

| | AUTH_NULL cred | AUTH_SYS cred |
| --- | --- | --- |
| **callback_ident 0** | denied (flavor) | denied (ident) |
| **callback_ident echoed** | denied (flavor) | **delivered** |

**1. Callbacks were sent with AUTH_NULL.** Linux's callback service accepts AUTH_NULL for the
`CB_NULL` procedure only and answers `AUTH_BADCRED` to every other one
(`fs/nfs/callback.c`, `nfs_callback_authenticate`).

**2. `callback_ident` was decoded and thrown away, then hardcoded to 0.** For NFSv4.0 the client
resolves an incoming `CB_COMPOUND` to one of its mounts by that ident and reports a miss as
`badcred` — a misleading error, since the credential is fine and the *identifier* is wrong
(`fs/nfs/callback_xdr.c`, `nfs4_callback_compound` → `out_invalidcred`; `net/sunrpc/svc.c`,
`svc_process_common` re-checks `rq_auth_stat` after the dispatch). Linux allocates idents from 1
upward, so 0 never matched. `SendCBRecall` now echoes the value from SETCLIENTID. The v4.1
backchannel keeps 0 — the kernel marks the field "ignored by v4.1 and v4.2".

`CB_NULL` slipped through both gates: AUTH_NULL is explicitly allowed for it, and it carries no
`CB_COMPOUND` header and therefore no ident. So the one probe that set `CBPathUp` — and thereby
enabled delegation granting — was the only callback the client would ever accept. **The health check
certified a backchannel that could not carry a single recall**, and the failure only ever surfaced
once something needed recalling.

## Evidence

Server log, pre-fix, from the reproducing run:

```
CB_NULL succeeded, delegations enabled for client client_id=7680566251659198465
Delegation granted client_id=7680566251659198465 deleg_type=2
NFSBreakHandler: dispatching CB_RECALL delegationID=fb5e4dea-... clientID=7680566251659198465
CB_RECALL failed client_id=7680566251659198465 error=callback reply: RPC call denied: reply_stat=1
NFSv4 DELEGRETURN stateid_seqid=1        <-- 4s later, unprompted, long past the test window
```

Packet capture of the same run — the only denied RPC reply in it:

```
Call   CB_COMPOUND   Credentials Flavor: AUTH_NULL (0)
Reply  CB_COMPOUND   Reply State: denied (1) / Reject State: AUTH_ERROR (1) / Auth State: bad credential (1)

client SETCLIENTID   callback_ident: 0x00000001
our    CB_COMPOUND   callback_ident: 0x00000000
```

Extra probes added to the driver isolate the residual state and rule out the release path:

```
PROBE idle-lock.dat-NLM:            BLOCKED    <-- nothing held by anyone
PROBE idle-lock.dat-NLM-otherrange: BLOCKED    <-- offset 5000, a range no case ever touched
PROBE idle-lock.dat-SMB:            ACQUIRED
PROBE idle-lock.dat-V4:             ACQUIRED
PROBE virgin-file-NLM:              ACQUIRED
SMB_vs_NLM_FRESH   conflict=BLOCKED afterRelease=ACQUIRED   <-- passes on a fresh file
NFSv4_vs_NLM_FRESH conflict=BLOCKED afterRelease=ACQUIRED   <-- passes on a fresh file
```

With every lock released, NLM cannot lock the file at any range while SMB and NFSv4 lock it freely,
and both cases pass on a file the earlier cases never touched. That is a whole-file row conflicting
with the NLM owner but not the NFSv4 one — the delegation exemption in `UnifiedLock.ConflictsWith`
is keyed on `ClientID`, which is exactly that signature.

## Verified on hardware, two builds, one rig

The driver needs root, veth and rpcbind, so this was run on a VM with a real kernel NFSv3/NLM client
in a network namespace. Pre-fix build: the four-line FAIL above. Post-fix build, unmodified driver:

```
NLM_vs_SMB     conflict=BLOCKED  afterRelease=ACQUIRED
NLM_vs_NFSv4   conflict=BLOCKED  afterRelease=ACQUIRED
SMB_vs_NLM     conflict=BLOCKED  afterRelease=ACQUIRED
NFSv4_vs_NLM   conflict=BLOCKED  afterRelease=ACQUIRED
NLM_AXIS_RESULT=PASS
```

An intermediate build with only the credential fixed still failed identically, with AUTH_SYS
verified on the wire — that is what established that both defects are required.

## Long-standing, not a regression

Both defects date to `428711632` (2026-02-25), when the callback client was introduced. `git log -S`
over the credential lines and over `encodeCBCompound(0, …)` returns that commit and nothing else. No
recent lock-path change is involved; delegation recall has never worked against a Linux client. It
stayed hidden because the only thing exercising the backchannel was the probe that both gates let
through.

## Scope beyond this test

Every NFSv4 delegation recall against a Linux client: a conflicting SMB open, a conflicting NFSv4
open from another client, a cross-protocol byte-range lock, and `CB_NOTIFY` directory delegations.
The credential fix also applies to the v4.1 backchannel, which shares the message builder.

## Also in here

Two OPEN log lines reported the *attempted* delegation type even when the lock manager refused the
grant (`deleg == nil`, which encodes `OPEN_DELEGATE_NONE` on the wire). They read as "granted a write
delegation" on an OPEN that granted none, which cost real time during this investigation. They now
report what is encoded. Wire behaviour is unchanged.

## Tests

Three regression tests, each run against a deliberately broken build and confirmed to compile:

- `TestBuildCBRPCCallMessage_CredIsParseableAuthSys` — flavor is AUTH_SYS and the body parses as
  `authsys_parms` with every field present. Killed by reverting the credential and by dropping the
  trailing gids word.
- `TestBuildCBRPCCallMessage_ProbeAndPayloadShareCredential` — pins the invariant the probe depends
  on: `CB_NULL` must carry the same credential as the callbacks it vouches for. Killed by a mutant
  that gives the probe AUTH_NULL and the payload AUTH_SYS, i.e. the exact latent shape.
- `TestSendCBRecall_EchoesCallbackIdent` and `TestSetClientID_StoresCallbackIdent` — both halves of
  the ident wiring. Killed by hardcoding the ident to 0 at each end.

A mutant that dropped the ident in SETCLIENTID initially failed to compile rather than fail an
assertion; it was rewritten into a compiling form, which then survived until
`TestSetClientID_StoresCallbackIdent` was added.

Two backchannel tests parsed the outgoing callback at a hardcoded 40-byte RPC header. They now skip
the credential and verifier by their declared length, so they no longer depend on the flavor in use.
