### PR TITLE
fix(badger): apply capabilities in memory only after the write commits

### DIFF
--- a/pkg/metadata/store/badger/capabilities_write_ordering_test.go
+++ b/pkg/metadata/store/badger/capabilities_write_ordering_test.go
@@ -1,0 +1,36 @@
+package badger
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSetFilesystemCapabilities_FailedPersistLeavesInMemoryValue pins the write
+// ordering of the pool-path setter: the in-memory copy that GetFilesystemMeta
+// reports must only advance once the write has actually committed. Closing the
+// store makes every subsequent write fail, standing in for any persist failure.
+func TestSetFilesystemCapabilities_FailedPersistLeavesInMemoryValue(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "metadata.db")
+
+	store, err := NewBadgerMetadataStoreWithDefaults(ctx, dbPath)
+	require.NoError(t, err)
+
+	const committed = uint64(1 << 20)
+	caps := store.loadCapabilities()
+	caps.MaxFileSize = committed
+	store.SetFilesystemCapabilities(caps)
+	require.Equal(t, committed, store.loadCapabilities().MaxFileSize,
+		"a capability write that commits must update the in-memory copy")
+
+	require.NoError(t, store.Close())
+
+	caps.MaxFileSize = 1 << 30
+	store.SetFilesystemCapabilities(caps)
+
+	require.Equal(t, committed, store.loadCapabilities().MaxFileSize,
+		"a capability write that never reached the store must not update the in-memory copy")
+}

--- a/pkg/metadata/store/badger/capabilities_write_ordering_test.go
+++ b/pkg/metadata/store/badger/capabilities_write_ordering_test.go
@@ -9,9 +9,10 @@ import (
 )
 
 // TestSetFilesystemCapabilities_FailedPersistLeavesInMemoryValue pins the write
-// ordering of the pool-path setter: the in-memory copy that GetFilesystemMeta
-// reports must only advance once the write has actually committed. Closing the
-// store makes every subsequent write fail, standing in for any persist failure.
+// ordering of BadgerMetadataStore.SetFilesystemCapabilities: the in-memory copy
+// that GetFilesystemMeta reports must only advance once the write has actually
+// committed. Closing the store makes every subsequent write fail, standing in
+// for any persist failure.
 func TestSetFilesystemCapabilities_FailedPersistLeavesInMemoryValue(t *testing.T) {
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "metadata.db")

--- a/pkg/metadata/store/badger/server.go
+++ b/pkg/metadata/store/badger/server.go
@@ -109,15 +109,14 @@ func (s *BadgerMetadataStore) GetFilesystemCapabilities(ctx context.Context, han
 }
 
 // SetFilesystemCapabilities updates the filesystem capabilities for this store.
+//
+// It delegates to the transaction path so the in-memory copy is staged and
+// applied only after a successful commit: updating it here before the write
+// would leave GetFilesystemMeta advertising capabilities that never reached
+// the store. The interface is void, so a failure can only be logged.
 func (s *BadgerMetadataStore) SetFilesystemCapabilities(capabilities metadata.FilesystemCapabilities) {
-	s.storeCapabilities(capabilities)
-
-	err := s.db.Update(func(txn *badgerdb.Txn) error {
-		data, err := encodeFilesystemCapabilities(&capabilities)
-		if err != nil {
-			return err
-		}
-		return txn.Set(keyFilesystemCapabilities(), data)
+	err := s.WithTransaction(context.Background(), func(tx metadata.Transaction) error {
+		return tx.(*badgerTransaction).writeCapabilities(capabilities)
 	})
 	if err != nil {
 		logger.Error("badger: failed to persist filesystem capabilities", "error", err)


### PR DESCRIPTION
Closes #2220. First of the Track-K stages from the #1828 plan (badger-local, no on-disk risk, no dependency on the SQL merge).

## The bug

`BadgerMetadataStore.SetFilesystemCapabilities` updated the in-memory copy *before* `s.db.Update`, and only logged a failure. A write that never reached the store left `GetFilesystemMeta` advertising capabilities the store does not have.

The transaction path already had this right — `writeCapabilities` stages into `tx.pendingCapabilities` and `withTransaction` applies it only after a successful commit, with a comment saying why. The fix had been applied to one copy of the logic and not the other.

## The fix

Delegate to `WithTransaction` instead of reordering two statements in a second copy. That is the pattern the 16 methods in `files.go` already use, so there is now one place where this ordering is decided. It also picks up conflict retry and cache invalidation, which the bare `s.db.Update` did not have.

## Test

`TestSetFilesystemCapabilities_FailedPersistLeavesInMemoryValue` closes the store so every subsequent write fails, then asserts the in-memory value did not advance. Verified it **fails on the unfixed build** (`expected 0x100000, actual 0x40000000`) and passes on the fixed one.

## Verification

- `go build ./... && go vet ./pkg/metadata/...`
- `go test ./pkg/metadata/...` — green
- `go test -race ./pkg/metadata/store/...` — green, all four backends
