### PR TITLE
refactor(badger): pool-path share and server methods delegate to the transaction path

### DIFF
--- a/pkg/metadata/store/badger/server.go
+++ b/pkg/metadata/store/badger/server.go
@@ -15,19 +15,8 @@ import (
 
 // SetServerConfig sets the server-wide configuration.
 func (s *BadgerMetadataStore) SetServerConfig(ctx context.Context, config metadata.MetadataServerConfig) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-
-	return s.db.Update(func(txn *badgerdb.Txn) error {
-		configBytes, err := encodeServerConfig(&config)
-		if err != nil {
-			return err
-		}
-		if err := txn.Set(keyServerConfig(), configBytes); err != nil {
-			return fmt.Errorf("failed to store server config: %w", err)
-		}
-		return nil
+	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return tx.SetServerConfig(ctx, config)
 	})
 }
 
@@ -38,33 +27,15 @@ func (s *BadgerMetadataStore) GetServerConfig(ctx context.Context) (metadata.Met
 	}
 
 	var config metadata.MetadataServerConfig
-
 	err := s.db.View(func(txn *badgerdb.Txn) error {
-		item, err := txn.Get(keyServerConfig())
-		if err == badgerdb.ErrKeyNotFound {
-			config = metadata.MetadataServerConfig{
-				CustomSettings: make(map[string]any),
-			}
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-
-		return item.Value(func(val []byte) error {
-			cfg, err := decodeServerConfig(val)
-			if err != nil {
-				return err
-			}
-			config = *cfg
-			return nil
-		})
+		tx := &badgerTransaction{store: s, txn: txn}
+		var err error
+		config, err = tx.GetServerConfig(ctx)
+		return err
 	})
-
 	if err != nil {
 		return metadata.MetadataServerConfig{}, fmt.Errorf("failed to get server config: %w", err)
 	}
-
 	return config, nil
 }
 
@@ -79,32 +50,15 @@ func (s *BadgerMetadataStore) GetFilesystemCapabilities(ctx context.Context, han
 	}
 
 	var caps *metadata.FilesystemCapabilities
-
 	err := s.db.View(func(txn *badgerdb.Txn) error {
-		item, err := txn.Get(keyFilesystemCapabilities())
-		if err == badgerdb.ErrKeyNotFound {
-			c := s.loadCapabilities()
-			caps = &c
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-
-		return item.Value(func(val []byte) error {
-			c, err := decodeFilesystemCapabilities(val)
-			if err != nil {
-				return err
-			}
-			caps = c
-			return nil
-		})
+		tx := &badgerTransaction{store: s, txn: txn}
+		var err error
+		caps, err = tx.GetFilesystemCapabilities(ctx, handle)
+		return err
 	})
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to get filesystem capabilities: %w", err)
 	}
-
 	return caps, nil
 }
 
@@ -143,6 +97,13 @@ func (s *BadgerMetadataStore) storeCapabilities(capabilities metadata.Filesystem
 
 // GetFilesystemStatistics returns dynamic filesystem statistics for the share
 // the handle belongs to.
+//
+// This one deliberately does NOT delegate to the transaction path the way the
+// rest of this file does. The transaction path scans every file key so a statfs
+// issued inside a transaction sees that transaction's own uncommitted writes;
+// outside a transaction there is nothing uncommitted to see, so this reads the
+// O(1) per-share usage bucket instead. Delegating would turn every statfs into
+// a full keyspace scan.
 //
 // The store instance is shared by every share naming the same metadata store
 // config, so usage is scoped to that share; the capacity ceilings

--- a/pkg/metadata/store/badger/share_options_cache_test.go
+++ b/pkg/metadata/store/badger/share_options_cache_test.go
@@ -1,0 +1,100 @@
+package badger
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// newShareOptionsStore opens a store holding one share whose options carry every
+// reference-bearing field the share cache has to defend.
+func newShareOptionsStore(t *testing.T) (*BadgerMetadataStore, string) {
+	t.Helper()
+	ctx := context.Background()
+	store, err := NewBadgerMetadataStoreWithDefaults(ctx, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	const shareName = "/opts"
+	anonUID := uint32(65534)
+	require.NoError(t, store.CreateShare(ctx, &metadata.Share{
+		Name: shareName,
+		Options: metadata.ShareOptions{
+			AllowedClients:     []string{"10.0.0.0/8"},
+			DeniedClients:      []string{"10.1.2.3"},
+			AllowedAuthMethods: []string{"sys"},
+			IdentityMapping:    &metadata.IdentityMapping{AnonymousUID: &anonUID},
+		},
+	}))
+	return store, shareName
+}
+
+// TestGetShareOptions_CallerCannotMutateCachedEntry is the mutation-safety guard
+// on the permission hot path. GetShareOptions serves the share cache, and the
+// options it returns decide access; if a caller's write reached the shared entry
+// it would silently change the permission answer given to every later caller of
+// that share. Every reference-bearing field has to be copied, not aliased.
+// Both paths out of GetShareOptions have to defend the entry: the populate path
+// hands back the very value it just cached, and the cache-hit path hands back
+// the stored one.
+func TestGetShareOptions_CallerCannotMutateCachedEntry(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		warmUpFirst bool
+	}{
+		{"populate path", false},
+		{"cache-hit path", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store, shareName := newShareOptionsStore(t)
+			ctx := context.Background()
+
+			if tc.warmUpFirst {
+				_, err := store.GetShareOptions(ctx, shareName)
+				require.NoError(t, err)
+			}
+
+			got, err := store.GetShareOptions(ctx, shareName)
+			require.NoError(t, err)
+
+			// A caller does what callers do with a value they believe they own.
+			got.ReadOnly = true
+			got.AllowedClients[0] = "0.0.0.0/0"
+			got.DeniedClients = append(got.DeniedClients, "192.168.0.1")
+			got.AllowedAuthMethods[0] = "none"
+			*got.IdentityMapping.AnonymousUID = 0
+
+			after, err := store.GetShareOptions(ctx, shareName)
+			require.NoError(t, err)
+
+			require.False(t, after.ReadOnly, "a caller's write reached the cached share entry")
+			require.Equal(t, []string{"10.0.0.0/8"}, after.AllowedClients,
+				"AllowedClients decides access and must not alias the cache")
+			require.Equal(t, []string{"10.1.2.3"}, after.DeniedClients)
+			require.Equal(t, []string{"sys"}, after.AllowedAuthMethods)
+			require.Equal(t, uint32(65534), *after.IdentityMapping.AnonymousUID,
+				"the anonymous UID squash target must not alias the cache")
+		})
+	}
+}
+
+// TestGetShareOptions_PopulatesCache pins the populate half: a first read must
+// leave the decoded options in the share cache, or the permission funnel pays a
+// badger View txn plus a record decode on every single operation.
+func TestGetShareOptions_PopulatesCache(t *testing.T) {
+	store, shareName := newShareOptionsStore(t)
+	ctx := context.Background()
+
+	// CreateShare invalidates the entry, so the cache starts cold.
+	_, cached := store.shareCache.Get(shareName)
+	require.False(t, cached, "cache should be cold before the first read")
+
+	_, err := store.GetShareOptions(ctx, shareName)
+	require.NoError(t, err)
+
+	_, cached = store.shareCache.Get(shareName)
+	require.True(t, cached, "a completed read must populate the share cache")
+}

--- a/pkg/metadata/store/badger/shares.go
+++ b/pkg/metadata/store/badger/shares.go
@@ -34,26 +34,12 @@ func (s *BadgerMetadataStore) GetRootHandle(ctx context.Context, shareName strin
 
 	var rootHandle metadata.FileHandle
 	err := s.db.View(func(txn *badgerdb.Txn) error {
-		item, err := txn.Get(keyShare(shareName))
-		if err != nil {
-			return mapBadgerError(err, "share", shareName)
-		}
-
-		return item.Value(func(val []byte) error {
-			data, err := decodeShareData(val)
-			if err != nil {
-				return err
-			}
-			rootHandle = data.RootHandle
-			return nil
-		})
+		tx := &badgerTransaction{store: s, txn: txn}
+		var err error
+		rootHandle, err = tx.GetRootHandle(ctx, shareName)
+		return err
 	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	return rootHandle, nil
+	return rootHandle, err
 }
 
 // GetShareOptions returns the share configuration options.
@@ -69,27 +55,16 @@ func (s *BadgerMetadataStore) GetShareOptions(ctx context.Context, shareName str
 	}
 
 	// Snapshot the invalidation generation BEFORE the backing read so a write
-	// that races this read cannot leave a stale value cached (store() checks it).
+	// that races this read cannot leave a stale value cached (Store checks it).
 	gen := s.shareCache.Generation()
 
 	var opts *metadata.ShareOptions
 	err := s.db.View(func(txn *badgerdb.Txn) error {
-		item, err := txn.Get(keyShare(shareName))
-		if err != nil {
-			return mapBadgerError(err, "share", shareName)
-		}
-
-		return item.Value(func(val []byte) error {
-			data, err := decodeShareData(val)
-			if err != nil {
-				return err
-			}
-			optsCopy := data.Share.Options
-			opts = &optsCopy
-			return nil
-		})
+		tx := &badgerTransaction{store: s, txn: txn}
+		var err error
+		opts, err = tx.GetShareOptions(ctx, shareName)
+		return err
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -104,112 +79,23 @@ func (s *BadgerMetadataStore) GetShareOptions(ctx context.Context, shareName str
 
 // CreateShare creates a new share with the given configuration.
 func (s *BadgerMetadataStore) CreateShare(ctx context.Context, share *metadata.Share) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-
-	err := s.updateWithConflictRetry(ctx, func(txn *badgerdb.Txn) error {
-		_, err := txn.Get(keyShare(share.Name))
-		if err == nil {
-			return &metadata.StoreError{
-				Code:    metadata.ErrAlreadyExists,
-				Message: "share already exists",
-				Path:    share.Name,
-			}
-		}
-		if err != badgerdb.ErrKeyNotFound {
-			return err
-		}
-
-		// Store as shareData for consistency with GetRootHandle and CreateRootDirectory
-		shareDataValue := &shareData{
-			Share: *share,
-			// RootHandle will be set by CreateRootDirectory
-		}
-
-		encoded, err := encodeShareData(shareDataValue)
-		if err != nil {
-			return err
-		}
-
-		return txn.Set(keyShare(share.Name), encoded)
+	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return tx.CreateShare(ctx, share)
 	})
-	if err == nil {
-		s.shareCache.Invalidate(share.Name)
-	}
-	return err
 }
 
 // UpdateShareOptions updates the share configuration options.
 func (s *BadgerMetadataStore) UpdateShareOptions(ctx context.Context, shareName string, options *metadata.ShareOptions) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-
-	err := s.updateWithConflictRetry(ctx, func(txn *badgerdb.Txn) error {
-		item, err := txn.Get(keyShare(shareName))
-		if err != nil {
-			return mapBadgerError(err, "share", shareName)
-		}
-
-		var data *shareData
-		err = item.Value(func(val []byte) error {
-			d, err := decodeShareData(val)
-			if err != nil {
-				return err
-			}
-			data = d
-			return nil
-		})
-		if err != nil {
-			return err
-		}
-
-		// Update options
-		data.Share.Options = *options
-
-		updatedData, err := encodeShareData(data)
-		if err != nil {
-			return err
-		}
-
-		return txn.Set(keyShare(shareName), updatedData)
+	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return tx.UpdateShareOptions(ctx, shareName, options)
 	})
-	if err == nil {
-		s.shareCache.Invalidate(shareName)
-	}
-	return err
 }
 
 // DeleteShare removes a share and all its metadata.
 func (s *BadgerMetadataStore) DeleteShare(ctx context.Context, shareName string) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-
-	var quotaFreed map[basestore.QuotaKey]metadata.UsageStat
-	err := s.updateWithConflictRetry(ctx, func(txn *badgerdb.Txn) error {
-		_, err := txn.Get(keyShare(shareName))
-		if err != nil {
-			return mapBadgerError(err, "share", shareName)
-		}
-
-		quota, err := s.deleteShareFiles(txn, shareName)
-		if err != nil {
-			return err
-		}
-		quotaFreed = quota
-
-		return txn.Delete(keyShare(shareName))
+	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		return tx.DeleteShare(ctx, shareName)
 	})
-	if err != nil {
-		return err
-	}
-	// Drop any cached options for the removed share, after a successful commit.
-	s.shareCache.Invalidate(shareName)
-	// Apply the usage decrement once, after a successful commit.
-	s.applyQuotaDelta(quotaFreed)
-	return nil
 }
 
 // applyQuotaDelta folds a per-identity usage delta into the in-memory usage
@@ -376,37 +262,27 @@ func (s *BadgerMetadataStore) ListShares(ctx context.Context) ([]string, error) 
 	}
 
 	var names []string
-
 	err := s.db.View(func(txn *badgerdb.Txn) error {
-		prefix := []byte(prefixShare)
-		opts := badgerdb.DefaultIteratorOptions
-		opts.Prefix = prefix
-		opts.PrefetchValues = false
-
-		it := txn.NewIterator(opts)
-		defer it.Close()
-
-		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
-			key := it.Item().Key()
-			name := string(key[len(prefix):])
-			names = append(names, name)
-		}
-
-		return nil
+		tx := &badgerTransaction{store: s, txn: txn}
+		var err error
+		names, err = tx.ListShares(ctx)
+		return err
 	})
-
 	return names, err
 }
-
-// ============================================================================
-// Root Directory Operations
-// ============================================================================
 
 // CreateRootDirectory creates or retrieves the root directory for a share.
 //
 // If a root directory already exists (from a previous server run), it is returned.
 // Otherwise, a new root directory is created. This idempotent behavior ensures
 // metadata persists across server restarts.
+//
+// This one deliberately does NOT delegate to the transaction path the way the
+// rest of this file does: the existing-share branch here reconciles the stored
+// root inode against the configured attrs (loadExistingRoot diffs mode/UID/GID
+// and rewrites it), which the transaction path does not do. Delegating would
+// silently drop that reconciliation, so the two stay split until the
+// transaction path grows it.
 func (s *BadgerMetadataStore) CreateRootDirectory(ctx context.Context, shareName string, attr *metadata.FileAttr) (*metadata.File, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err


### PR DESCRIPTION
Track-K stage from the #1828 plan, on top of #2221 and #2222.

## What was duplicated

Thirteen `*BadgerMetadataStore` methods in `shares.go` and `server.go` carried a second copy of a `*badgerTransaction` body. `files.go` already shows the intended shape: a thin adapter that builds a `badgerTransaction` inside `db.View` for reads, or calls `WithTransaction` for writes, and keeps the logic in exactly one place.

## What this does

**Eight delegate.** The writes gain `WithTransaction`'s conflict retry, error classification and post-commit cache invalidation in place of hand-rolled equivalents. `SetServerConfig` is the one that was actually exposed: it used a bare `s.db.Update` with no retry at all, so a raw `badgerdb.ErrConflict` could escape unmapped — unlike every SQL backend, which classifies the same condition. `GetShareOptions` keeps its share-cache wrapper and delegates only the backing read, so the 17.4%-of-CPU fast path is untouched.

**Two do not, and now say why in the code.** The plan expected these to collapse; reading the pairs showed both divergences are load-bearing, so collapsing them would have been a regression wearing a refactor's clothes:

- `GetFilesystemStatistics` — the transaction path scans every file key *so that an in-transaction statfs sees that transaction's own uncommitted writes*. Outside a transaction there is nothing uncommitted to see, so the pool path reads the O(1) per-share usage bucket. Delegating would turn every statfs into a full keyspace scan.
- `CreateRootDirectory` — the pool path's existing-share branch reconciles the stored root inode against the configured attrs (`loadExistingRoot` diffs mode/UID/GID and rewrites it); the transaction path does not. Delegating would silently drop that reconciliation. Filed separately rather than changed here.

## Tests

Mutation-testing the delegations against the existing suite found **two unguarded paths, both on the permission funnel**: `GetShareOptions` could stop deep-copying its result, or stop populating the cache, and nothing failed. Dropping the deep copy means a caller's write lands on the shared cache entry — a wrong permission decision for every later reader of that share.

Added tests for both. Each was checked against a build broken in exactly that way, and the mutation-safety test covers both exits (populate path and cache-hit path) because the first version only caught the cache-hit one:

| mutation | caught |
|---|---|
| cache-hit path skips `Clone` | ✅ |
| populate path skips `Clone` | ✅ |
| read never populates the cache | ✅ |

## Verification

- `go build ./... && go vet ./pkg/metadata/...`
- `go test ./pkg/metadata/...` — green
- `go test -race ./pkg/metadata/store/...` — green, all four backends
- `-race -count=2` on the conflict, restart-persistence and share-lifecycle tests

Net −63 lines, and `updateWithConflictRetry` loses four of its nine call sites.
