### PR TITLE
refactor(metadata): name the SQL executor contract once in store/sql

### DIFF
--- a/pkg/metadata/store/postgres/pool_helpers.go
+++ b/pkg/metadata/store/postgres/pool_helpers.go
@@ -8,6 +8,8 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	storesql "github.com/marmos91/dittofs/pkg/metadata/store/sql"
 )
 
 // poolConnectionAcquireTimeout is the maximum time to wait for a connection from the pool.
@@ -194,3 +196,17 @@ func (r *poolRows) CommandTag() pgconn.CommandTag {
 func (r *poolRows) Conn() *pgx.Conn {
 	return r.rows.Conn()
 }
+
+// The pgx surface this store is written against must present the shared
+// SQL-family contract, which it does structurally: pgx.Row.Scan,
+// pgx.Rows.{Next,Scan,Close,Err} and pgconn.CommandTag.RowsAffected already
+// match. Asserting it here means a pgx upgrade that changed one of those shapes
+// breaks the build once, rather than at every shared call site once the merged
+// bodies ride on it.
+var (
+	_ storesql.Row        = (*poolRow)(nil)
+	_ storesql.Row        = (*errorRow)(nil)
+	_ storesql.Rows       = (*poolRows)(nil)
+	_ storesql.Rows       = (pgx.Rows)(nil)
+	_ storesql.CommandTag = pgconn.CommandTag{}
+)

--- a/pkg/metadata/store/sql/executor.go
+++ b/pkg/metadata/store/sql/executor.go
@@ -1,0 +1,68 @@
+// Package sql holds the implementation shared by the SQL-backed metadata stores.
+//
+// The two dialects, sqlite and postgres, were written twice: postgres against
+// pgx (pool.QueryRow(ctx, sql, args...)) and sqlite as a near-verbatim port that
+// presents the same surface over database/sql so the query bodies match line for
+// line. This package is where that shared surface is named once, so the method
+// bodies riding on it can live in one place instead of two.
+//
+// What crosses this seam is the executor and error classification — the things
+// that genuinely differ at runtime. SQL *text* does not: ?N versus $N, NOW()
+// versus CURRENT_TIMESTAMP and the handful of rewritten queries stay as
+// per-dialect constants, because a Placeholder(n) method would move the same
+// two-line difference into an indirection and buy nothing. The consequence to be
+// honest about is that this merges logic, not SQL: what costs us maintenance is
+// hand-maintained control flow duplicated around the queries, not the query text.
+//
+// The interface here is *consumed* by shared code; how an Executor is *produced*
+// stays per-dialect, in each dialect's pool_helpers.go. Connection acquisition
+// has no common shape (postgres acquires from a pgxpool with a timeout; a
+// bounded *sql.DB has no per-op acquire step), and neither does transaction
+// begin/commit/rollback, so neither is here.
+package sql
+
+import "context"
+
+// Row is the single-row scan surface. *pgx.Row and *sql.Row both satisfy it
+// as-is.
+type Row interface {
+	Scan(dest ...any) error
+}
+
+// Rows is the streaming surface. It is pgx.Rows minus the wire-format accessors
+// (Values/RawValues/FieldDescriptions), which only backup.go ever wanted and
+// which database/sql cannot offer; backup is implemented without them.
+//
+// Close returns nothing, matching pgx. database/sql's Close does return an
+// error, but a close error on a read is not actionable — iteration errors are
+// surfaced through Err instead.
+type Rows interface {
+	Next() bool
+	Scan(dest ...any) error
+	Close()
+	Err() error
+}
+
+// CommandTag reports how many rows a statement affected. pgconn.CommandTag
+// satisfies it as-is; database/sql's Result has an (int64, error) shape, so the
+// sqlite side captures the count eagerly at Exec time and presents it here.
+type CommandTag interface {
+	RowsAffected() int64
+}
+
+// Executor is what shared query bodies run against. Both a pool/connection and
+// an open transaction present it, which is what lets one body serve the
+// store-level and the transaction-level path.
+type Executor interface {
+	QueryRow(ctx context.Context, query string, args ...any) Row
+	Query(ctx context.Context, query string, args ...any) (Rows, error)
+	Exec(ctx context.Context, query string, args ...any) (CommandTag, error)
+}
+
+// ErrorRow defers an error to Scan, mirroring pgx's lazy error rows. It lets
+// QueryRow report a context cancellation or an acquire failure without changing
+// the call shape at every call site.
+type ErrorRow struct{ Err error }
+
+// Scan returns the deferred error.
+func (r ErrorRow) Scan(dest ...any) error { return r.Err }

--- a/pkg/metadata/store/sqlite/pool_helpers.go
+++ b/pkg/metadata/store/sqlite/pool_helpers.go
@@ -3,6 +3,8 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+
+	storesql "github.com/marmos91/dittofs/pkg/metadata/store/sql"
 )
 
 // ============================================================================
@@ -26,26 +28,13 @@ type sqlExecutor interface {
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 }
 
-// scanRow is the single-row scan surface used across the store (mirrors
-// pgx.Row).
-type scanRow interface {
-	Scan(dest ...any) error
-}
-
-// scanRows is the streaming surface used across the store (mirrors pgx.Rows,
-// minus the wire-format accessors only backup.go needed — backup is
-// reimplemented without them).
-type scanRows interface {
-	Next() bool
-	Scan(dest ...any) error
-	Close()
-	Err() error
-}
-
-// errorRow returns a deferred error from Scan (mirrors pgx's lazy error rows).
-type errorRow struct{ err error }
-
-func (r errorRow) Scan(dest ...any) error { return r.err }
+// The single-row, streaming and affected-count surfaces are the shared
+// SQL-family contract; only the database/sql adaptation that produces them is
+// dialect-specific and stays here.
+type (
+	scanRow  = storesql.Row
+	scanRows = storesql.Rows
+)
 
 // cmdResult mirrors pgx's CommandTag.RowsAffected() (single int64 return) so
 // the ported bodies can write `result.RowsAffected()` without the (n, err)
@@ -75,7 +64,7 @@ type execer struct {
 
 func (x execer) QueryRow(ctx context.Context, query string, args ...any) scanRow {
 	if err := ctx.Err(); err != nil {
-		return errorRow{err: err}
+		return storesql.ErrorRow{Err: err}
 	}
 	return x.e.QueryRowContext(ctx, query, args...)
 }
@@ -91,7 +80,7 @@ func (x execer) Query(ctx context.Context, query string, args ...any) (scanRows,
 	return sqlRows{r}, nil
 }
 
-func (x execer) Exec(ctx context.Context, query string, args ...any) (cmdResult, error) {
+func (x execer) Exec(ctx context.Context, query string, args ...any) (storesql.CommandTag, error) {
 	if err := ctx.Err(); err != nil {
 		return cmdResult{}, err
 	}
@@ -120,7 +109,7 @@ func (s *SQLiteMetadataStore) query(ctx context.Context, query string, args ...a
 
 // exec executes a statement against the shared *sql.DB and returns the result
 // for RowsAffected inspection.
-func (s *SQLiteMetadataStore) exec(ctx context.Context, query string, args ...any) (cmdResult, error) {
+func (s *SQLiteMetadataStore) exec(ctx context.Context, query string, args ...any) (storesql.CommandTag, error) {
 	return execer{e: s.db, op: "exec"}.Exec(ctx, query, args...)
 }
 
@@ -130,3 +119,11 @@ func (s *SQLiteMetadataStore) exec(ctx context.Context, query string, args ...an
 func (s *SQLiteMetadataStore) conn() execer {
 	return execer{e: s.db, op: "substore"}
 }
+
+// The database/sql adaptations above must present the shared SQL-family
+// contract; a drift here would surface at every call site instead of once.
+var (
+	_ storesql.Rows       = sqlRows{}
+	_ storesql.CommandTag = cmdResult{}
+	_ storesql.Executor   = execer{}
+)


### PR DESCRIPTION
First Track-S stage of the #1828 plan: the seam every later stage rides on, shipped alone so it can be reviewed on its own.

## Why

`sqlite/pool_helpers.go` says outright what it is: sqlite is a near-verbatim port of postgres, and the helpers there exist to present pgx's surface (`QueryRow(ctx, sql, args...)`) over `database/sql` so the query bodies match postgres line for line.

That shared surface was only ever implicit. sqlite named it locally (`scanRow`, `scanRows`, `cmdResult`, `errorRow`); postgres used pgx's types directly. Nothing checked the two agreed, which is exactly the standing drift the issue is about.

## What this does

Names it once in `store/sql`: `Row`, `Rows`, `CommandTag`, `Executor`, `ErrorRow`.

- **sqlite** — its local interfaces become aliases; `execer.Exec` returns the shared `CommandTag`.
- **postgres** — satisfies all of it structurally already (`pgx.Row.Scan`, `pgx.Rows.{Next,Scan,Close,Err}`, `pgconn.CommandTag.RowsAffected` all match), so it gains only compile-time assertions.

No behaviour change; net +81 lines, nearly all of it the package doc explaining what does and does not cross the seam.

## What deliberately does not cross it

Recorded in the package doc so the next stage doesn't relitigate it:

- **SQL text.** `?N` vs `$N`, `NOW()` vs `CURRENT_TIMESTAMP`, the rewritten recursive-CTE path queries and block-ref aggregates stay per-dialect *constants*. A `Placeholder(n int)` method would move the same two-line difference into an indirection and buy nothing. So this merges **logic, not SQL** — what costs maintenance is the hand-maintained control flow duplicated around the queries, not the query text.
- **Executor construction.** Connection acquisition has no common shape (postgres acquires from a `pgxpool` with a timeout; a bounded `*sql.DB` has no per-op acquire step), so the interface is *consumed* here and *produced* in each dialect's `pool_helpers.go`.
- **Transaction begin/commit/rollback**, whose retry-loop shapes differ enough to stay per-dialect.

## Verification

- `go build ./... && go vet ./pkg/metadata/...`
- `go test ./pkg/metadata/...` — green
- The assertions were checked by renaming `cmdResult.RowsAffected`: the build fails, so they bite.

Note on coverage: all 11 postgres test files are `//go:build integration`, so a local `go test ./pkg/metadata/store/postgres/` runs almost nothing. Postgres coverage for this PR comes from the **Integration Tests** job, which runs `go test -tags=integration ./...` against a live postgres.
