### PR TITLE
refactor(postgres): one body per operation instead of a pool copy and a tx copy

### DIFF
--- a/pkg/metadata/store/postgres/block_record_store.go
+++ b/pkg/metadata/store/postgres/block_record_store.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
+
+	storesql "github.com/marmos91/dittofs/pkg/metadata/store/sql"
 )
 
 // Compile-time assertions: the store and its transaction both satisfy the
@@ -44,14 +46,7 @@ func (tx *postgresTransaction) PutBlockRecord(ctx context.Context, rec block.Blo
 }
 
 func (tx *postgresTransaction) GetBlockRecord(ctx context.Context, blockID string) (block.BlockRecord, bool, error) {
-	if err := ctx.Err(); err != nil {
-		return block.BlockRecord{}, false, err
-	}
-	return scanBlockRecord(tx.tx.QueryRow(ctx,
-		`SELECT block_id, block_hash, length, live_chunk_count, sync_state
-		 FROM block_records WHERE block_id = $1`,
-		blockID,
-	))
+	return getBlockRecordTx(ctx, tx.conn(), blockID)
 }
 
 func (tx *postgresTransaction) DeleteBlockRecord(ctx context.Context, blockID string) error {
@@ -66,17 +61,7 @@ func (tx *postgresTransaction) DeleteBlockRecord(ctx context.Context, blockID st
 }
 
 func (tx *postgresTransaction) WalkBlockRecords(ctx context.Context, fn func(block.BlockRecord) error) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	rows, err := tx.tx.Query(ctx,
-		`SELECT block_id, block_hash, length, live_chunk_count, sync_state FROM block_records`,
-	)
-	if err != nil {
-		return fmt.Errorf("postgres WalkBlockRecords: %w", err)
-	}
-	defer rows.Close()
-	return iterBlockRecordRows(rows, fn)
+	return walkBlockRecordsTx(ctx, tx.conn(), fn)
 }
 
 // DecrLiveChunkCount atomically floors live_chunk_count at 0.
@@ -113,14 +98,7 @@ func (s *PostgresMetadataStore) PutBlockRecord(ctx context.Context, rec block.Bl
 }
 
 func (s *PostgresMetadataStore) GetBlockRecord(ctx context.Context, blockID string) (block.BlockRecord, bool, error) {
-	if err := ctx.Err(); err != nil {
-		return block.BlockRecord{}, false, err
-	}
-	return scanBlockRecord(s.queryRow(ctx,
-		`SELECT block_id, block_hash, length, live_chunk_count, sync_state
-		 FROM block_records WHERE block_id = $1`,
-		blockID,
-	))
+	return getBlockRecordTx(ctx, s.conn(), blockID)
 }
 
 func (s *PostgresMetadataStore) DeleteBlockRecord(ctx context.Context, blockID string) error {
@@ -130,10 +108,21 @@ func (s *PostgresMetadataStore) DeleteBlockRecord(ctx context.Context, blockID s
 }
 
 func (s *PostgresMetadataStore) WalkBlockRecords(ctx context.Context, fn func(block.BlockRecord) error) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	rows, err := s.query(ctx,
+	return walkBlockRecordsTx(ctx, s.conn(), fn)
+}
+
+// getBlockRecordTx reads one block record, reporting (_, false, nil) when absent.
+func getBlockRecordTx(ctx context.Context, x storesql.Executor, blockID string) (block.BlockRecord, bool, error) {
+	return scanBlockRecord(x.QueryRow(ctx,
+		`SELECT block_id, block_hash, length, live_chunk_count, sync_state
+		 FROM block_records WHERE block_id = $1`,
+		blockID,
+	))
+}
+
+// walkBlockRecordsTx streams every block record through fn.
+func walkBlockRecordsTx(ctx context.Context, x storesql.Executor, fn func(block.BlockRecord) error) error {
+	rows, err := x.Query(ctx,
 		`SELECT block_id, block_hash, length, live_chunk_count, sync_state FROM block_records`,
 	)
 	if err != nil {
@@ -170,7 +159,7 @@ func (s *PostgresMetadataStore) CommitBlock(ctx context.Context, rec block.Block
 
 // scanBlockRecord reads a BlockRecord from a single pgx.Row (or pgx.Rows
 // result reused as a row). Returns (_, false, nil) on a missing row.
-func scanBlockRecord(row pgx.Row) (block.BlockRecord, bool, error) {
+func scanBlockRecord(row storesql.Row) (block.BlockRecord, bool, error) {
 	var (
 		blockID        string
 		blockHashRaw   []byte
@@ -200,7 +189,7 @@ func scanBlockRecord(row pgx.Row) (block.BlockRecord, bool, error) {
 }
 
 // iterBlockRecordRows calls fn for every row in rows, returning the first error.
-func iterBlockRecordRows(rows pgx.Rows, fn func(block.BlockRecord) error) error {
+func iterBlockRecordRows(rows storesql.Rows, fn func(block.BlockRecord) error) error {
 	for rows.Next() {
 		rec, ok, err := scanBlockRecord(rows)
 		if err != nil {

--- a/pkg/metadata/store/postgres/objects.go
+++ b/pkg/metadata/store/postgres/objects.go
@@ -11,6 +11,8 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
+
+	storesql "github.com/marmos91/dittofs/pkg/metadata/store/sql"
 )
 
 // ============================================================================
@@ -71,93 +73,27 @@ const putFileChunkQuery = insertFileChunk + `
 // FileChunkStore interface; kept as a backend
 // method for engine-internal callers.
 func (s *PostgresMetadataStore) GetFileChunk(ctx context.Context, id string) (*metadata.FileChunk, error) {
-	row := s.queryRow(ctx, selectFileChunkByID, id)
-
-	block, err := scanFileChunk(row)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, metadata.ErrFileChunkNotFound
-	}
-	if err != nil {
-		return nil, fmt.Errorf("get file chunk: %w", err)
-	}
-	return block, nil
+	return getFileChunkTx(ctx, s.conn(), id)
 }
 
 // Put stores or updates a file chunk.
-//
-// The hash column is persisted whenever the block carries a non-zero
-// content hash, regardless of block state. The content hash is derived
-// at rollup time (long before the block reaches the remote) and is the
-// key the engine's CAS read path uses to resolve a chunk. Gating the
-// write on IsRemote() left every Pending row with a NULL hash; reads
-// then survived only while the bytes stayed in the local append log or
-// RAM cache, and broke the moment local state went cold (restart +
-// cache eviction, or a snapshot restore's ResetLocalState). The memory
-// and badger backends always store the hash inline on the row, so this
-// matches their behavior.
-func (s *PostgresMetadataStore) Put(ctx context.Context, block *metadata.FileChunk) error {
-	var hashStr *string
-	if !block.Hash.IsZero() {
-		h := block.Hash.String()
-		hashStr = &h
-	}
-	// persist LastSyncAttemptAt as NULL when zero so the
-	// janitor's WHERE last_sync_attempt_at < cutoff predicate excludes
-	// never-claimed rows naturally instead of matching every Pending row.
-	var lastSyncAttemptAt *time.Time
-	if !block.LastSyncAttemptAt.IsZero() {
-		t := block.LastSyncAttemptAt
-		lastSyncAttemptAt = &t
-	}
-
-	_, err := s.exec(ctx, putFileChunkQuery,
-		block.ID, hashStr, block.DataSize, block.StartOffset,
-		block.RefCount, block.LastAccess, block.CreatedAt, block.State, lastSyncAttemptAt)
-	if err != nil {
-		return fmt.Errorf("put file chunk: %w", err)
-	}
-	return nil
+func (s *PostgresMetadataStore) Put(ctx context.Context, chunk *metadata.FileChunk) error {
+	return putFileChunkTx(ctx, s.conn(), chunk)
 }
 
 // Delete removes a file chunk by its ID.
 func (s *PostgresMetadataStore) Delete(ctx context.Context, id string) error {
-	result, err := s.exec(ctx, `DELETE FROM file_blocks WHERE id = $1`, id)
-	if err != nil {
-		return fmt.Errorf("delete file chunk: %w", err)
-	}
-	rows := result.RowsAffected()
-	if rows == 0 {
-		return metadata.ErrFileChunkNotFound
-	}
-	return nil
+	return deleteFileChunkTx(ctx, s.conn(), id)
 }
 
 // IncrementRefCount atomically increments a block's RefCount.
 func (s *PostgresMetadataStore) IncrementRefCount(ctx context.Context, id string) error {
-	result, err := s.exec(ctx,
-		`UPDATE file_blocks SET ref_count = ref_count + 1 WHERE id = $1`, id)
-	if err != nil {
-		return fmt.Errorf("increment ref count: %w", err)
-	}
-	rows := result.RowsAffected()
-	if rows == 0 {
-		return metadata.ErrFileChunkNotFound
-	}
-	return nil
+	return incrementRefCountTx(ctx, s.conn(), id)
 }
 
 // DecrementRefCount atomically decrements a block's RefCount.
 func (s *PostgresMetadataStore) DecrementRefCount(ctx context.Context, id string) (uint32, error) {
-	query := `UPDATE file_blocks SET ref_count = GREATEST(ref_count - 1, 0) WHERE id = $1 RETURNING ref_count`
-	var newCount uint32
-	err := s.queryRow(ctx, query, id).Scan(&newCount)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return 0, metadata.ErrFileChunkNotFound
-	}
-	if err != nil {
-		return 0, fmt.Errorf("decrement ref count: %w", err)
-	}
-	return newCount, nil
+	return decrementRefCountTx(ctx, s.conn(), id)
 }
 
 // DecrementRefCountAndReap atomically decrements ref_count and, when it hits 0,
@@ -180,13 +116,16 @@ func (s *PostgresMetadataStore) DecrementRefCountAndReap(ctx context.Context, id
 	return newCount, nil
 }
 
-// decrementAndReapTx runs the -1 UPDATE then a conditional DELETE on the given
-// pgx.Tx. The `ref_count = 0` predicate on the DELETE means a bump that landed
-// between the two statements leaves the row alive. Returns (0, nil) for an
-// already-swept row rather than ErrFileChunkNotFound.
-func decrementAndReapTx(ctx context.Context, tx pgx.Tx, id string) (uint32, error) {
+// decrementAndReapTx runs the -1 UPDATE then a conditional DELETE. The
+// `ref_count = 0` predicate on the DELETE means a bump that landed between the
+// two statements leaves the row alive. Returns (0, nil) for an already-swept row
+// rather than ErrFileChunkNotFound.
+//
+// Callers must supply a transaction Executor: the two statements are only
+// atomic against a concurrent AddRef if they share one transaction.
+func decrementAndReapTx(ctx context.Context, x storesql.Executor, id string) (uint32, error) {
 	var newCount uint32
-	err := tx.QueryRow(ctx,
+	err := x.QueryRow(ctx,
 		`UPDATE file_blocks SET ref_count = GREATEST(ref_count - 1, 0) WHERE id = $1 RETURNING ref_count`,
 		id).Scan(&newCount)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -196,7 +135,7 @@ func decrementAndReapTx(ctx context.Context, tx pgx.Tx, id string) (uint32, erro
 		return 0, fmt.Errorf("decrement ref count: %w", err)
 	}
 	if newCount == 0 {
-		if _, err := tx.Exec(ctx,
+		if _, err := x.Exec(ctx,
 			`DELETE FROM file_blocks WHERE id = $1 AND ref_count = 0`, id); err != nil {
 			return 0, fmt.Errorf("reap zero-ref block: %w", err)
 		}
@@ -204,44 +143,133 @@ func decrementAndReapTx(ctx context.Context, tx pgx.Tx, id string) (uint32, erro
 	return newCount, nil
 }
 
-// AddRef atomically bumps RefCount on the FileChunk row(s) indexed by
-// the given content hash. Implements the FileChunkStore.AddRef contract
-// used by the in-memory hash dedup LRU hit path to
-// reference an already-stored block without creating a new row.
+// decrementAndReapManyTx applies the -1 UPDATE and the reap-at-zero DELETE to
+// the whole id set in two statements, so a rollback undoes both. The
+// `ref_count = 0` predicate means a bump that landed between the two leaves that
+// row alive, and an id with no row is a no-op — the same outcomes
+// decrementAndReapTx produces one row at a time.
+func decrementAndReapManyTx(ctx context.Context, x storesql.Executor, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	if _, err := x.Exec(ctx,
+		`UPDATE file_blocks SET ref_count = GREATEST(ref_count - 1, 0) WHERE id = ANY($1)`,
+		ids); err != nil {
+		return fmt.Errorf("decrement ref count: %w", err)
+	}
+	if _, err := x.Exec(ctx,
+		`DELETE FROM file_blocks WHERE id = ANY($1) AND ref_count = 0`,
+		ids); err != nil {
+		return fmt.Errorf("reap zero-ref block: %w", err)
+	}
+	return nil
+}
+
+// getFileChunkTx reads one chunk by id.
+func getFileChunkTx(ctx context.Context, x storesql.Executor, id string) (*metadata.FileChunk, error) {
+	chunk, err := scanFileChunk(x.QueryRow(ctx, selectFileChunkByID, id))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, metadata.ErrFileChunkNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get file chunk: %w", err)
+	}
+	return chunk, nil
+}
+
+// putFileChunkTx stores or updates a chunk row.
 //
-// Atomicity: a single UPDATE statement performs the bump — PostgreSQL's
-// row-level locking serializes contended updates against the same row,
-// so AddRef is TOCTOU-free against concurrent DecrementRefCount cascade
-// (matches the existing IncrementRefCount idiom).
+// The hash column is persisted whenever the chunk carries a non-zero content
+// hash, regardless of state. The content hash is derived at rollup time (long
+// before the block reaches the remote) and is the key the engine's CAS read path
+// uses to resolve a chunk. Gating the write on IsRemote() left every Pending row
+// with a NULL hash; reads then survived only while the bytes stayed in the local
+// append log or RAM cache, and broke the moment local state went cold (restart +
+// cache eviction, or a snapshot restore's ResetLocalState). The memory and badger
+// backends always store the hash inline on the row, so this matches them.
 //
-// Returns metadata.ErrUnknownHash when RowsAffected == 0 (no row exists
-// for this hash). Callers (the LRU hit site) fall back to the full Put
-// path on this sentinel.
+// LastSyncAttemptAt is persisted as NULL when zero so the janitor's
+// `last_sync_attempt_at < cutoff` predicate excludes never-claimed rows
+// naturally instead of matching every Pending row.
+func putFileChunkTx(ctx context.Context, x storesql.Executor, chunk *metadata.FileChunk) error {
+	var hashStr *string
+	if !chunk.Hash.IsZero() {
+		h := chunk.Hash.String()
+		hashStr = &h
+	}
+	var lastSyncAttemptAt *time.Time
+	if !chunk.LastSyncAttemptAt.IsZero() {
+		t := chunk.LastSyncAttemptAt
+		lastSyncAttemptAt = &t
+	}
+	if _, err := x.Exec(ctx, putFileChunkQuery,
+		chunk.ID, hashStr, chunk.DataSize, chunk.StartOffset,
+		chunk.RefCount, chunk.LastAccess, chunk.CreatedAt, chunk.State, lastSyncAttemptAt); err != nil {
+		return fmt.Errorf("put file chunk: %w", err)
+	}
+	return nil
+}
+
+// deleteFileChunkTx removes one chunk row by id.
+func deleteFileChunkTx(ctx context.Context, x storesql.Executor, id string) error {
+	result, err := x.Exec(ctx, `DELETE FROM file_blocks WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("delete file chunk: %w", err)
+	}
+	if result.RowsAffected() == 0 {
+		return metadata.ErrFileChunkNotFound
+	}
+	return nil
+}
+
+// incrementRefCountTx atomically bumps one chunk's RefCount.
+func incrementRefCountTx(ctx context.Context, x storesql.Executor, id string) error {
+	result, err := x.Exec(ctx,
+		`UPDATE file_blocks SET ref_count = ref_count + 1 WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("increment ref count: %w", err)
+	}
+	if result.RowsAffected() == 0 {
+		return metadata.ErrFileChunkNotFound
+	}
+	return nil
+}
+
+// decrementRefCountTx atomically decrements one chunk's RefCount, floored at 0.
+func decrementRefCountTx(ctx context.Context, x storesql.Executor, id string) (uint32, error) {
+	var newCount uint32
+	err := x.QueryRow(ctx,
+		`UPDATE file_blocks SET ref_count = GREATEST(ref_count - 1, 0) WHERE id = $1 RETURNING ref_count`,
+		id).Scan(&newCount)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return 0, metadata.ErrFileChunkNotFound
+	}
+	if err != nil {
+		return 0, fmt.Errorf("decrement ref count: %w", err)
+	}
+	return newCount, nil
+}
+
+// addRefTx bumps RefCount on the row(s) indexed by a content hash.
 //
-// Multi-row-per-hash tolerance:
-// the hash index on file_blocks is a NON-UNIQUE partial index (migration
-// 000011), so a single hash may match multiple rows in legacy data. The
-// UPDATE deliberately omits LIMIT — all matching rows are bumped
-// uniformly so refcount accounting stays correct regardless of which
-// row a later DecrementRefCount targets. The conformance test seeds a
-// single row, so RefCount goes from N to N+1 exactly.
+// Atomicity: a single UPDATE performs the bump — PostgreSQL's row-level locking
+// serializes contended updates against the same row, so this is TOCTOU-free
+// against a concurrent DecrementRefCount cascade.
 //
-// Only ref_count is mutated. block_state is never touched: AddRef
-// references an existing block, and the LRU hit path never creates
-// or transitions one.
-func (s *PostgresMetadataStore) AddRef(ctx context.Context, hash block.ContentHash, _ string, _ block.ChunkRef) error {
-	// payloadID + blockRef accepted for future GC traceability;
-	// postgres backend records ref count only — parameters intentionally
-	// blanked.
-	//
-	// state = 2 (Remote) scoping mirrors GetByHash and the memory/badger
-	// backends, whose AddRef resolves the hash only through the finalized
-	// hash index. The dedup hit path references a block already confirmed
-	// on the remote; a Pending row (which now also carries its hash) is
-	// not a valid dedup donor, so AddRef must miss it and return
-	// ErrUnknownHash exactly as before, letting the caller fall back to
-	// the full Put path.
-	result, err := s.exec(ctx,
+// state = 2 (Remote) scoping mirrors GetByHash and the memory/badger backends,
+// whose AddRef resolves a hash only through the finalized hash index. The dedup
+// hit path references a block already confirmed on the remote; a Pending row
+// (which now also carries its hash) is not a valid dedup donor, so this must
+// miss it and return ErrUnknownHash, letting the caller fall back to full Put.
+//
+// The hash index on file_blocks is a NON-UNIQUE partial index (migration
+// 000011), so one hash may match multiple rows in legacy data. The UPDATE
+// deliberately omits LIMIT — all matching rows are bumped uniformly so refcount
+// accounting stays correct regardless of which row a later decrement targets.
+//
+// Only ref_count is mutated; block_state is never touched.
+func addRefTx(ctx context.Context, x storesql.Executor, hash block.ContentHash) error {
+	result, err := x.Exec(ctx,
 		`UPDATE file_blocks SET ref_count = ref_count + 1 WHERE hash = $1 AND state = 2 /* Remote */`,
 		hash.String())
 	if err != nil {
@@ -253,21 +281,90 @@ func (s *PostgresMetadataStore) AddRef(ctx context.Context, hash block.ContentHa
 	return nil
 }
 
-// GetByHash looks up a finalized block by its content hash.
-// Returns nil without error if not found. Dedup matches only Remote
-// (state=2) blocks — Pending or Syncing rows have not been confirmed on
-// the remote and are unsafe dedup targets.
-func (s *PostgresMetadataStore) GetByHash(ctx context.Context, hash metadata.ContentHash) (*metadata.FileChunk, error) {
-	row := s.queryRow(ctx, selectFileChunkByHash, hash.String())
-
-	block, err := scanFileChunk(row)
+// getByHashTx looks up a finalized chunk by content hash, returning (nil, nil)
+// when absent. Dedup matches only Remote (state=2) chunks — Pending or Syncing
+// rows have not been confirmed on the remote and are unsafe dedup targets.
+func getByHashTx(ctx context.Context, x storesql.Executor, hash metadata.ContentHash) (*metadata.FileChunk, error) {
+	chunk, err := scanFileChunk(x.QueryRow(ctx, selectFileChunkByHash, hash.String()))
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("find file chunk by hash: %w", err)
 	}
-	return block, nil
+	return chunk, nil
+}
+
+// listFileChunksTx returns the chunks belonging to one payload, in block order.
+func listFileChunksTx(ctx context.Context, x storesql.Executor, payloadID string) ([]*metadata.FileChunk, error) {
+	lo, hi := block.PayloadPrefixRange(payloadID)
+	rows, err := x.Query(ctx, listFileChunksQuery, lo, hi)
+	if err != nil {
+		return nil, fmt.Errorf("list file chunks: %w", err)
+	}
+	defer rows.Close()
+	result, err := scanFileChunkRows(rows)
+	if err != nil {
+		return nil, err
+	}
+	return block.ChunksForPayload(result, payloadID), nil
+}
+
+// enumerateFileChunksTx streams every live-set ContentHash through fn, unioning
+// the CAS index with the per-file manifest (see enumerateHashesQuery).
+func enumerateFileChunksTx(ctx context.Context, x storesql.Executor, fn func(block.ContentHash) error) error {
+	rows, err := x.Query(ctx, enumerateHashesQuery)
+	if err != nil {
+		return fmt.Errorf("enumerate file chunks: query: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("enumerate file chunks: %w", err)
+		}
+		var hashStr sql.NullString
+		if err := rows.Scan(&hashStr); err != nil {
+			return fmt.Errorf("enumerate file chunks: scan: %w", err)
+		}
+		var h block.ContentHash
+		if hashStr.Valid {
+			parsed, perr := metadata.ParseContentHash(hashStr.String)
+			if perr != nil {
+				// Fail closed: a malformed hash row cannot be silently coerced
+				// to the zero hash — that would invite the GC mark phase to
+				// treat the row as a legacy pre-CAS entry and the sweep would
+				// reap a still-live CAS object once the grace TTL lapses.
+				// Surface the parse error so enumeration aborts and the sweep
+				// is skipped.
+				return fmt.Errorf("enumerate file chunks: parse hash %q: %w",
+					hashStr.String, perr)
+			}
+			h = parsed
+		}
+		if err := fn(h); err != nil {
+			return err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("enumerate file chunks: rows: %w", err)
+	}
+	return nil
+}
+
+// AddRef atomically bumps RefCount on the FileChunk row(s) indexed by the
+// given content hash, implementing the FileChunkStore.AddRef contract used by
+// the in-memory hash dedup LRU hit path. Returns metadata.ErrUnknownHash when
+// no row matches; callers fall back to the full Put path on that sentinel.
+func (s *PostgresMetadataStore) AddRef(ctx context.Context, hash block.ContentHash, _ string, _ block.ChunkRef) error {
+	// payloadID + blockRef are accepted for future GC traceability; this
+	// backend records ref count only, so they are intentionally blanked.
+	return addRefTx(ctx, s.conn(), hash)
+}
+
+// GetByHash looks up a finalized block by its content hash, returning
+// (nil, nil) when absent.
+func (s *PostgresMetadataStore) GetByHash(ctx context.Context, hash metadata.ContentHash) (*metadata.FileChunk, error) {
+	return getByHashTx(ctx, s.conn(), hash)
 }
 
 // listFileChunksQuery takes the bounds of block.PayloadPrefixRange and is a
@@ -283,20 +380,10 @@ const listFileChunksQuery = `SELECT ` + fileChunkColumns + `
 	ORDER BY id COLLATE "C" ASC`
 
 // ListFileChunks returns all blocks belonging to a file, ordered by block index.
-// Not on the narrowed FileChunkStore interface;
-// kept as a backend method for engine-internal callers.
+// Not on the narrowed FileChunkStore interface; kept as a backend method for
+// engine-internal callers.
 func (s *PostgresMetadataStore) ListFileChunks(ctx context.Context, payloadID string) ([]*metadata.FileChunk, error) {
-	lo, hi := block.PayloadPrefixRange(payloadID)
-	rows, err := s.query(ctx, listFileChunksQuery, lo, hi)
-	if err != nil {
-		return nil, fmt.Errorf("list file chunks: %w", err)
-	}
-	defer rows.Close()
-	result, err := scanFileChunkRows(rows)
-	if err != nil {
-		return nil, err
-	}
-	return block.ChunksForPayload(result, payloadID), nil
+	return listFileChunksTx(ctx, s.conn(), payloadID)
 }
 
 // enumerateHashesQuery is the GC mark live-set query. It UNIONs the CAS index
@@ -405,45 +492,9 @@ func (s *PostgresMetadataStore) collectFileChunkIDs(ctx context.Context, query s
 	return ids, nil
 }
 
-// EnumerateFileChunks streams every live-set ContentHash through fn, unioning
-// the CAS index with the per-file manifest (see enumerateHashesQuery).
+// EnumerateFileChunks streams every live-set ContentHash through fn.
 func (s *PostgresMetadataStore) EnumerateFileChunks(ctx context.Context, fn func(block.ContentHash) error) error {
-	rows, err := s.query(ctx, enumerateHashesQuery)
-	if err != nil {
-		return fmt.Errorf("enumerate file chunks: query: %w", err)
-	}
-	defer rows.Close()
-	for rows.Next() {
-		if err := ctx.Err(); err != nil {
-			return fmt.Errorf("enumerate file chunks: %w", err)
-		}
-		var hashStr sql.NullString
-		if err := rows.Scan(&hashStr); err != nil {
-			return fmt.Errorf("enumerate file chunks: scan: %w", err)
-		}
-		var h block.ContentHash
-		if hashStr.Valid {
-			parsed, perr := metadata.ParseContentHash(hashStr.String)
-			if perr != nil {
-				// (mark fail-closed): a malformed hash row
-				// cannot be silently coerced to the zero hash — that would
-				// invite the GC mark phase to treat the row as a legacy
-				// pre-CAS entry and the sweep would reap a still-live CAS
-				// object once the grace TTL lapses. Surface the parse error
-				// so EnumerateFileChunks aborts and the sweep is skipped.
-				return fmt.Errorf("enumerate file chunks: parse hash %q: %w",
-					hashStr.String, perr)
-			}
-			h = parsed
-		}
-		if err := fn(h); err != nil {
-			return err
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("enumerate file chunks: rows: %w", err)
-	}
-	return nil
+	return enumerateFileChunksTx(ctx, s.conn(), fn)
 }
 
 // ============================================================================
@@ -451,7 +502,7 @@ func (s *PostgresMetadataStore) EnumerateFileChunks(ctx context.Context, fn func
 // ============================================================================
 
 // scanFileChunk scans a single row into a FileChunk.
-func scanFileChunk(row pgx.Row) (*metadata.FileChunk, error) {
+func scanFileChunk(row storesql.Row) (*metadata.FileChunk, error) {
 	var (
 		block             metadata.FileChunk
 		hashStr           sql.NullString
@@ -478,7 +529,7 @@ func scanFileChunk(row pgx.Row) (*metadata.FileChunk, error) {
 }
 
 // scanFileChunkRows scans multiple rows into FileChunk slices.
-func scanFileChunkRows(rows pgx.Rows) ([]*metadata.FileChunk, error) {
+func scanFileChunkRows(rows storesql.Rows) ([]*metadata.FileChunk, error) {
 	var result []*metadata.FileChunk
 	for rows.Next() {
 		block, err := scanFileChunk(rows)
@@ -507,193 +558,67 @@ var _ block.FileChunkStore = (*postgresTransaction)(nil)
 // helpers keep the pool path because no caller mutates state through them.
 
 func (tx *postgresTransaction) GetFileChunk(ctx context.Context, id string) (*metadata.FileChunk, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-	row := tx.tx.QueryRow(ctx, selectFileChunkByID, id)
-	block, err := scanFileChunk(row)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, metadata.ErrFileChunkNotFound
-	}
-	if err != nil {
-		return nil, fmt.Errorf("get file chunk: %w", err)
-	}
-	return block, nil
+	return getFileChunkTx(ctx, tx.conn(), id)
 }
 
-func (tx *postgresTransaction) Put(ctx context.Context, block *metadata.FileChunk) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	var hashStr *string
-	if !block.Hash.IsZero() {
-		h := block.Hash.String()
-		hashStr = &h
-	}
-	var lastSyncAttemptAt *time.Time
-	if !block.LastSyncAttemptAt.IsZero() {
-		t := block.LastSyncAttemptAt
-		lastSyncAttemptAt = &t
-	}
-	_, err := tx.tx.Exec(ctx, putFileChunkQuery,
-		block.ID, hashStr, block.DataSize, block.StartOffset,
-		block.RefCount, block.LastAccess, block.CreatedAt, block.State, lastSyncAttemptAt)
-	if err != nil {
-		return fmt.Errorf("put file chunk: %w", err)
-	}
-	return nil
+func (tx *postgresTransaction) Put(ctx context.Context, chunk *metadata.FileChunk) error {
+	return putFileChunkTx(ctx, tx.conn(), chunk)
 }
 
 func (tx *postgresTransaction) Delete(ctx context.Context, id string) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	result, err := tx.tx.Exec(ctx, `DELETE FROM file_blocks WHERE id = $1`, id)
-	if err != nil {
-		return fmt.Errorf("delete file chunk: %w", err)
-	}
-	if result.RowsAffected() == 0 {
-		return metadata.ErrFileChunkNotFound
-	}
-	return nil
+	return deleteFileChunkTx(ctx, tx.conn(), id)
 }
 
-// IncrementRefCount runs the +1 UPDATE on the active pgx.Tx so a
-// subsequent rollback undoes the bump (fix). Production callers
-// route here through metadataCoordinator.IncrementRefCount when ctx
-// carries an active tx via metadata.WithTx.
+// The ref-count mutators below run on the active pgx.Tx so a subsequent
+// rollback undoes them. Production callers reach them through
+// metadataCoordinator when ctx carries an active tx via metadata.WithTx.
+
 func (tx *postgresTransaction) IncrementRefCount(ctx context.Context, id string) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	result, err := tx.tx.Exec(ctx,
-		`UPDATE file_blocks SET ref_count = ref_count + 1 WHERE id = $1`, id)
-	if err != nil {
-		return fmt.Errorf("increment ref count: %w", err)
-	}
-	if result.RowsAffected() == 0 {
-		return metadata.ErrFileChunkNotFound
-	}
-	return nil
+	return incrementRefCountTx(ctx, tx.conn(), id)
 }
 
-// DecrementRefCount runs the -1 UPDATE on the active pgx.Tx so a
-// subsequent rollback undoes the decrement (fix).
 func (tx *postgresTransaction) DecrementRefCount(ctx context.Context, id string) (uint32, error) {
-	if err := ctx.Err(); err != nil {
-		return 0, err
-	}
-	query := `UPDATE file_blocks SET ref_count = GREATEST(ref_count - 1, 0) WHERE id = $1 RETURNING ref_count`
-	var newCount uint32
-	err := tx.tx.QueryRow(ctx, query, id).Scan(&newCount)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return 0, metadata.ErrFileChunkNotFound
-	}
-	if err != nil {
-		return 0, fmt.Errorf("decrement ref count: %w", err)
-	}
-	return newCount, nil
+	return decrementRefCountTx(ctx, tx.conn(), id)
 }
 
 // DecrementRefCountAndReap runs the -1 UPDATE + reap-at-zero DELETE on the
-// active pgx.Tx so a subsequent rollback undoes both. Returns (0, nil) when the
-// row is already absent.
+// active transaction so a rollback undoes both. Returns (0, nil) when the row is
+// already absent.
 func (tx *postgresTransaction) DecrementRefCountAndReap(ctx context.Context, id string) (uint32, error) {
-	if err := ctx.Err(); err != nil {
-		return 0, err
-	}
-	return decrementAndReapTx(ctx, tx.tx, id)
+	return decrementAndReapTx(ctx, tx.conn(), id)
 }
 
-// AddRef runs the +1 UPDATE keyed by hash on the active pgx.Tx so a
-// subsequent rollback undoes the bump (parity for the
-// LRU hit path). Returns metadata.ErrUnknownHash when no row matches.
+// DecrementRefCountAndReapMany is the batched form, applied to the whole id set
+// in two statements on the active transaction.
+func (tx *postgresTransaction) DecrementRefCountAndReapMany(ctx context.Context, ids []string) error {
+	return decrementAndReapManyTx(ctx, tx.conn(), ids)
+}
+
+// AddRef bumps the ref count keyed by hash on the active transaction, giving
+// the LRU hit path rollback parity. Returns metadata.ErrUnknownHash on no match.
 func (tx *postgresTransaction) AddRef(ctx context.Context, hash block.ContentHash, _ string, _ block.ChunkRef) error {
-	// payloadID + blockRef accepted for future GC traceability;
-	// postgres backend records ref count only — parameters intentionally
-	// blanked.
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	// state = 2 (Remote) scoping mirrors the pool-path AddRef and the
-	// memory/badger backends — a Pending row is not a valid dedup donor.
-	result, err := tx.tx.Exec(ctx,
-		`UPDATE file_blocks SET ref_count = ref_count + 1 WHERE hash = $1 AND state = 2 /* Remote */`,
-		hash.String())
-	if err != nil {
-		return fmt.Errorf("add ref: %w", err)
-	}
-	if result.RowsAffected() == 0 {
-		return metadata.ErrUnknownHash
-	}
-	return nil
+	// payloadID + blockRef accepted for future GC traceability; intentionally
+	// blanked, as on the pool path.
+	return addRefTx(ctx, tx.conn(), hash)
 }
 
 func (tx *postgresTransaction) GetByHash(ctx context.Context, hash metadata.ContentHash) (*metadata.FileChunk, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-	row := tx.tx.QueryRow(ctx, selectFileChunkByHash, hash.String())
-	block, err := scanFileChunk(row)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("find file chunk by hash: %w", err)
-	}
-	return block, nil
+	return getByHashTx(ctx, tx.conn(), hash)
 }
 
-// ListFileChunks / EnumerateFileChunks run on the active
-// transaction (tx.tx), NOT the pool. Delegating to the pool opens a separate
-// connection that cannot see this transaction's uncommitted writes, so a Put
-// followed by a List in the same WithTransaction would miss the pending row
-// (read-after-write violation; the SQL is otherwise identical to the
-// store-level methods).
+// ListFileChunks and EnumerateFileChunks run on the active transaction, NOT the
+// pool. Going through the pool would open a separate connection that cannot see
+// this transaction's uncommitted writes, so a Put followed by a List inside one
+// WithTransaction would miss the pending row — a read-after-write violation.
+// That is the whole reason these take an Executor rather than being called on
+// the store.
+
 func (tx *postgresTransaction) ListFileChunks(ctx context.Context, payloadID string) ([]*metadata.FileChunk, error) {
-	lo, hi := block.PayloadPrefixRange(payloadID)
-	rows, err := tx.tx.Query(ctx, listFileChunksQuery, lo, hi)
-	if err != nil {
-		return nil, fmt.Errorf("list file chunks: %w", err)
-	}
-	defer rows.Close()
-	result, err := scanFileChunkRows(rows)
-	if err != nil {
-		return nil, err
-	}
-	return block.ChunksForPayload(result, payloadID), nil
+	return listFileChunksTx(ctx, tx.conn(), payloadID)
 }
 
 func (tx *postgresTransaction) EnumerateFileChunks(ctx context.Context, fn func(block.ContentHash) error) error {
-	rows, err := tx.tx.Query(ctx, enumerateHashesQuery)
-	if err != nil {
-		return fmt.Errorf("enumerate file chunks: query: %w", err)
-	}
-	defer rows.Close()
-	for rows.Next() {
-		if err := ctx.Err(); err != nil {
-			return fmt.Errorf("enumerate file chunks: %w", err)
-		}
-		var hashStr sql.NullString
-		if err := rows.Scan(&hashStr); err != nil {
-			return fmt.Errorf("enumerate file chunks: scan: %w", err)
-		}
-		var h block.ContentHash
-		if hashStr.Valid {
-			parsed, perr := metadata.ParseContentHash(hashStr.String)
-			if perr != nil {
-				return fmt.Errorf("enumerate file chunks: parse hash %q: %w", hashStr.String, perr)
-			}
-			h = parsed
-		}
-		if err := fn(h); err != nil {
-			return err
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("enumerate file chunks: rows: %w", err)
-	}
-	return nil
+	return enumerateFileChunksTx(ctx, tx.conn(), fn)
 }
 
 // The file_blocks table schema lives in
@@ -711,32 +636,6 @@ func (s *PostgresMetadataStore) InjectCorruptHashRow(ctx context.Context, blockI
 	)
 	if err != nil {
 		return fmt.Errorf("inject corrupt hash row: %w", err)
-	}
-	return nil
-}
-
-// DecrementRefCountAndReapMany applies the -1 UPDATE and the reap-at-zero
-// DELETE to the whole id set in two statements on the active transaction, so a
-// subsequent rollback undoes both. The `ref_count = 0` predicate on the DELETE
-// means a bump that landed between the two statements leaves that row alive,
-// and an id with no row is a no-op — the same outcomes decrementAndReapTx
-// produces one row at a time.
-func (tx *postgresTransaction) DecrementRefCountAndReapMany(ctx context.Context, ids []string) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	if len(ids) == 0 {
-		return nil
-	}
-	if _, err := tx.tx.Exec(ctx,
-		`UPDATE file_blocks SET ref_count = GREATEST(ref_count - 1, 0) WHERE id = ANY($1)`,
-		ids); err != nil {
-		return fmt.Errorf("decrement ref count: %w", err)
-	}
-	if _, err := tx.tx.Exec(ctx,
-		`DELETE FROM file_blocks WHERE id = ANY($1) AND ref_count = 0`,
-		ids); err != nil {
-		return fmt.Errorf("reap zero-ref block: %w", err)
 	}
 	return nil
 }

--- a/pkg/metadata/store/postgres/objects_rollback_test.go
+++ b/pkg/metadata/store/postgres/objects_rollback_test.go
@@ -37,9 +37,12 @@ func TestTransactionChunkWritesRollBack(t *testing.T) {
 		State:       block.BlockStateRemote,
 	}
 
-	// Make sure the row is absent to begin with, so a pass cannot come from a
-	// leftover of an earlier run.
-	_ = store.Delete(ctx, chunkID)
+	// Assert the row is absent to begin with rather than deleting blindly: a
+	// leftover from an earlier run would otherwise make the final check pass or
+	// fail for the wrong reason.
+	if _, err := store.GetFileChunk(ctx, chunkID); !errors.Is(err, metadata.ErrFileChunkNotFound) {
+		t.Fatalf("probe chunk %q already present before the test (err = %v)", chunkID, err)
+	}
 
 	sentinel := errors.New("roll this back")
 	err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
@@ -63,7 +66,9 @@ func TestTransactionChunkWritesRollBack(t *testing.T) {
 
 	// The rollback must have taken the chunk with it.
 	if _, err := store.GetFileChunk(ctx, chunkID); !errors.Is(err, metadata.ErrFileChunkNotFound) {
-		_ = store.Delete(ctx, chunkID) // don't poison the shared database
+		// The database is shared across tests, so clear the stray row before
+		// failing or the next run reports the leftover instead of the bug.
+		_ = store.Delete(ctx, chunkID)
 		t.Fatalf("chunk survived a rolled-back transaction (err = %v) — the write escaped to the pool", err)
 	}
 }

--- a/pkg/metadata/store/postgres/objects_rollback_test.go
+++ b/pkg/metadata/store/postgres/objects_rollback_test.go
@@ -1,0 +1,69 @@
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// TestTransactionChunkWritesRollBack pins the reason the transaction-level
+// FileChunk methods take an Executor over the open pgx.Tx rather than the pool.
+//
+// A write that reached the pool instead would run on a separate connection,
+// commit independently, and survive the enclosing transaction's rollback. The
+// suite otherwise never notices: every other test commits, and a chunk written
+// to the pool is indistinguishable from one written to a committed transaction.
+func TestTransactionChunkWritesRollBack(t *testing.T) {
+	store := newTestStore(t)
+	defer func() { _ = store.Close() }()
+	ctx := context.Background()
+
+	const chunkID = "rollback-probe/0"
+	now := time.Now().UTC().Truncate(time.Second)
+	chunk := &metadata.FileChunk{
+		ID:          chunkID,
+		Hash:        hashOfSeed("rollback-probe"),
+		DataSize:    64,
+		StartOffset: 0,
+		RefCount:    1,
+		LastAccess:  now,
+		CreatedAt:   now,
+		State:       block.BlockStateRemote,
+	}
+
+	// Make sure the row is absent to begin with, so a pass cannot come from a
+	// leftover of an earlier run.
+	_ = store.Delete(ctx, chunkID)
+
+	sentinel := errors.New("roll this back")
+	err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		if putErr := tx.Put(ctx, chunk); putErr != nil {
+			return putErr
+		}
+		// Read-your-writes: the row must be visible inside the transaction that
+		// wrote it, which only holds if the write went to the transaction.
+		got, getErr := tx.GetFileChunk(ctx, chunkID)
+		if getErr != nil {
+			return getErr
+		}
+		if got.ID != chunkID {
+			t.Errorf("in-transaction read got id %q, want %q", got.ID, chunkID)
+		}
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("WithTransaction error = %v, want the sentinel", err)
+	}
+
+	// The rollback must have taken the chunk with it.
+	if _, err := store.GetFileChunk(ctx, chunkID); !errors.Is(err, metadata.ErrFileChunkNotFound) {
+		_ = store.Delete(ctx, chunkID) // don't poison the shared database
+		t.Fatalf("chunk survived a rolled-back transaction (err = %v) — the write escaped to the pool", err)
+	}
+}

--- a/pkg/metadata/store/postgres/pool_helpers.go
+++ b/pkg/metadata/store/postgres/pool_helpers.go
@@ -244,10 +244,13 @@ func (x poolExecer) Exec(ctx context.Context, sql string, args ...any) (storesql
 
 // txExecer runs statements on an open pgx.Tx, so a rollback undoes them.
 //
-// It checks the context and maps errors itself, which the pool helpers already
-// do on their side. That keeps the guard out of every shared body: a body that
-// carried its own ctx check would double-check on the pool path and be the only
-// thing standing between a cancelled context and the transaction on this one.
+// It checks the context and maps Query/Exec errors, which the pool helpers
+// already do on their side. That keeps the guard out of every shared body: a
+// body that carried its own ctx check would double-check on the pool path and
+// be the only thing standing between a cancelled context and the transaction on
+// this one. QueryRow is lazy in pgx, so its error surfaces from the caller's
+// Scan and is not mapped here — matching the pool path, which does not map it
+// either.
 type txExecer struct{ tx pgx.Tx }
 
 func (x txExecer) QueryRow(ctx context.Context, sql string, args ...any) storesql.Row {

--- a/pkg/metadata/store/postgres/pool_helpers.go
+++ b/pkg/metadata/store/postgres/pool_helpers.go
@@ -210,3 +210,82 @@ var (
 	_ storesql.Rows       = (pgx.Rows)(nil)
 	_ storesql.CommandTag = pgconn.CommandTag{}
 )
+
+// ============================================================================
+// Executor construction
+// ============================================================================
+//
+// The shared SQL-family contract is consumed by query bodies that must run
+// either against the pool or inside an open transaction. Postgres produces one
+// Executor for each; the bodies then exist once instead of twice, which is the
+// shape sqlite already had (see its execer).
+
+// poolExecer runs statements on the pool, acquiring and releasing a connection
+// per operation under the shared acquire timeout.
+type poolExecer struct{ s *PostgresMetadataStore }
+
+func (x poolExecer) QueryRow(ctx context.Context, sql string, args ...any) storesql.Row {
+	return x.s.queryRow(ctx, sql, args...)
+}
+
+func (x poolExecer) Query(ctx context.Context, sql string, args ...any) (storesql.Rows, error) {
+	rows, err := x.s.query(ctx, sql, args...)
+	if err != nil {
+		// Return an untyped nil: a typed nil pgx.Rows in a storesql.Rows would
+		// read as non-nil at the call site.
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (x poolExecer) Exec(ctx context.Context, sql string, args ...any) (storesql.CommandTag, error) {
+	return x.s.exec(ctx, sql, args...)
+}
+
+// txExecer runs statements on an open pgx.Tx, so a rollback undoes them.
+//
+// It checks the context and maps errors itself, which the pool helpers already
+// do on their side. That keeps the guard out of every shared body: a body that
+// carried its own ctx check would double-check on the pool path and be the only
+// thing standing between a cancelled context and the transaction on this one.
+type txExecer struct{ tx pgx.Tx }
+
+func (x txExecer) QueryRow(ctx context.Context, sql string, args ...any) storesql.Row {
+	if err := ctx.Err(); err != nil {
+		return &errorRow{err: err}
+	}
+	return x.tx.QueryRow(ctx, sql, args...)
+}
+
+func (x txExecer) Query(ctx context.Context, sql string, args ...any) (storesql.Rows, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	rows, err := x.tx.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, mapPgError(err, "query", sql)
+	}
+	return rows, nil
+}
+
+func (x txExecer) Exec(ctx context.Context, sql string, args ...any) (storesql.CommandTag, error) {
+	if err := ctx.Err(); err != nil {
+		return pgconn.CommandTag{}, err
+	}
+	tag, err := x.tx.Exec(ctx, sql, args...)
+	if err != nil {
+		return pgconn.CommandTag{}, mapPgError(err, "exec", sql)
+	}
+	return tag, nil
+}
+
+var (
+	_ storesql.Executor = poolExecer{}
+	_ storesql.Executor = txExecer{}
+)
+
+// conn returns the Executor over the pool.
+func (s *PostgresMetadataStore) conn() storesql.Executor { return poolExecer{s: s} }
+
+// conn returns the Executor over this transaction's open pgx.Tx.
+func (tx *postgresTransaction) conn() storesql.Executor { return txExecer{tx: tx.tx} }

--- a/pkg/metadata/store/postgres/synced_hash_store.go
+++ b/pkg/metadata/store/postgres/synced_hash_store.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
+
+	storesql "github.com/marmos91/dittofs/pkg/metadata/store/sql"
 )
 
 // Compile-time assertions: the Postgres engine and its transaction implement
@@ -85,15 +87,58 @@ func locatorFromCols(blockID sql.NullString, off, length sql.NullInt64) (block.C
 // Returns (false, nil) when no row exists for hash — an absent hash is
 // treated as "not yet synced", not as an error.
 func (s *PostgresMetadataStore) IsSynced(ctx context.Context, hash block.ContentHash) (bool, error) {
-	if err := ctx.Err(); err != nil {
-		return false, err
-	}
+	return isSyncedTx(ctx, s.conn(), hash)
+}
 
-	row := s.queryRow(ctx,
-		`SELECT 1 FROM synced_hashes WHERE hash = $1`,
-		hash[:])
+// MarkSynced records that hash has been mirrored to remote, persisting loc's
+// block columns atomically.
+func (s *PostgresMetadataStore) MarkSynced(ctx context.Context, hash block.ContentHash, loc block.ChunkLocator) error {
+	return markSyncedTx(ctx, s.conn(), hash, loc)
+}
+
+// GetLocator returns the recorded remote locator for hash.
+func (s *PostgresMetadataStore) GetLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error) {
+	return getLocatorTx(ctx, s.conn(), hash)
+}
+
+// DeleteSynced removes the synced marker for hash.
+func (s *PostgresMetadataStore) DeleteSynced(ctx context.Context, hash block.ContentHash) error {
+	return deleteSyncedTx(ctx, s.conn(), hash)
+}
+
+// ============================================================================
+// Transaction-level SyncedHashStore
+// ============================================================================
+//
+// The transaction variants run the same bodies against the enclosing pgx.Tx
+// instead of the pool. Postgres gives read-your-writes within a transaction, so
+// a MarkSynced after a DeleteSynced in the same tx records the new locator.
+
+func (tx *postgresTransaction) IsSynced(ctx context.Context, hash block.ContentHash) (bool, error) {
+	return isSyncedTx(ctx, tx.conn(), hash)
+}
+
+func (tx *postgresTransaction) MarkSynced(ctx context.Context, hash block.ContentHash, loc block.ChunkLocator) error {
+	return markSyncedTx(ctx, tx.conn(), hash, loc)
+}
+
+func (tx *postgresTransaction) GetLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error) {
+	return getLocatorTx(ctx, tx.conn(), hash)
+}
+
+func (tx *postgresTransaction) DeleteSynced(ctx context.Context, hash block.ContentHash) error {
+	return deleteSyncedTx(ctx, tx.conn(), hash)
+}
+
+// ============================================================================
+// Shared bodies
+// ============================================================================
+
+// isSyncedTx reports whether a synced marker exists for hash. An absent row is
+// "not yet synced", not an error.
+func isSyncedTx(ctx context.Context, x storesql.Executor, hash block.ContentHash) (bool, error) {
 	var dummy int
-	err := row.Scan(&dummy)
+	err := x.QueryRow(ctx, `SELECT 1 FROM synced_hashes WHERE hash = $1`, hash[:]).Scan(&dummy)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return false, nil
 	}
@@ -103,18 +148,14 @@ func (s *PostgresMetadataStore) IsSynced(ctx context.Context, hash block.Content
 	return true, nil
 }
 
-// MarkSynced records that hash has been mirrored to remote, persisting loc's
+// markSyncedTx records that hash has been mirrored to remote, persisting loc's
 // block columns atomically. Idempotent via ON CONFLICT (hash) DO NOTHING —
 // re-applying the same hash is a no-op that preserves the first locator. A
 // standalone locator (BlockID == "") leaves the block columns NULL, identical to
 // a pre-locator row, so existing data needs no migration.
-func (s *PostgresMetadataStore) MarkSynced(ctx context.Context, hash block.ContentHash, loc block.ChunkLocator) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-
+func markSyncedTx(ctx context.Context, x storesql.Executor, hash block.ContentHash, loc block.ChunkLocator) error {
 	blockID, off, length := locatorArgs(loc)
-	if _, err := s.exec(ctx,
+	if _, err := x.Exec(ctx,
 		`INSERT INTO synced_hashes (hash, synced_at, block_id, block_offset, block_length)
 			VALUES ($1, NOW(), $2, $3, $4)
 			ON CONFLICT (hash) DO NOTHING`,
@@ -124,20 +165,15 @@ func (s *PostgresMetadataStore) MarkSynced(ctx context.Context, hash block.Conte
 	return nil
 }
 
-// GetLocator returns the recorded remote locator for hash. (zero, false, nil)
+// getLocatorTx returns the recorded remote locator for hash: (zero, false, nil)
 // when no row exists; a synced row with NULL/empty block columns yields the zero
 // (standalone) locator with found == true.
-func (s *PostgresMetadataStore) GetLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error) {
-	if err := ctx.Err(); err != nil {
-		return block.ChunkLocator{}, false, err
-	}
-
-	row := s.queryRow(ctx,
-		`SELECT block_id, block_offset, block_length FROM synced_hashes WHERE hash = $1`,
-		hash[:])
+func getLocatorTx(ctx context.Context, x storesql.Executor, hash block.ContentHash) (block.ChunkLocator, bool, error) {
 	var blockID sql.NullString
 	var off, length sql.NullInt64
-	err := row.Scan(&blockID, &off, &length)
+	err := x.QueryRow(ctx,
+		`SELECT block_id, block_offset, block_length FROM synced_hashes WHERE hash = $1`,
+		hash[:]).Scan(&blockID, &off, &length)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return block.ChunkLocator{}, false, nil
 	}
@@ -153,6 +189,15 @@ func (s *PostgresMetadataStore) GetLocator(ctx context.Context, hash block.Conte
 	return block.ChunkLocator{BlockID: blockID.String, WireOffset: off.Int64, WireLength: length.Int64}, true, nil
 }
 
+// deleteSyncedTx removes the synced marker for hash. Idempotent: zero rows
+// affected is not an error.
+func deleteSyncedTx(ctx context.Context, x storesql.Executor, hash block.ContentHash) error {
+	if _, err := x.Exec(ctx, `DELETE FROM synced_hashes WHERE hash = $1`, hash[:]); err != nil {
+		return fmt.Errorf("postgres synced delete: %w", err)
+	}
+	return nil
+}
+
 // locatorArgs maps a ChunkLocator onto the (block_id, block_offset, block_length)
 // INSERT args: NULL for a standalone chunk (so its row is identical to a
 // pre-locator row), the recorded values for a block-resident chunk.
@@ -163,111 +208,6 @@ func locatorArgs(loc block.ChunkLocator) (blockID, off, length any) {
 	return loc.BlockID, loc.WireOffset, loc.WireLength
 }
 
-// DeleteSynced removes the synced marker for hash. Idempotent: DELETE
-// returns no error when the row does not exist (zero rows affected is
-// not an error condition).
-func (s *PostgresMetadataStore) DeleteSynced(ctx context.Context, hash block.ContentHash) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-
-	if _, err := s.exec(ctx,
-		`DELETE FROM synced_hashes WHERE hash = $1`,
-		hash[:]); err != nil {
-		return fmt.Errorf("postgres synced delete: %w", err)
-	}
-	return nil
-}
-
-// ============================================================================
-// Transaction-level SyncedHashStore
-// ============================================================================
-//
-// Same executor plumbing as the transaction-level BlockRecordStore /
-// LocalChunkIndex (block_record_store.go): each method runs its statement on
-// the enclosing pgx.Tx (tx.tx) instead of the pool helpers, sharing the
-// locatorArgs / scan logic with the store-level variants. Postgres gives
-// read-your-writes within a transaction, so a MarkSynced after a DeleteSynced
-// in the same tx records the new locator.
-
-func (tx *postgresTransaction) IsSynced(ctx context.Context, hash block.ContentHash) (bool, error) {
-	if err := ctx.Err(); err != nil {
-		return false, err
-	}
-	var dummy int
-	err := tx.tx.QueryRow(ctx,
-		`SELECT 1 FROM synced_hashes WHERE hash = $1`,
-		hash[:]).Scan(&dummy)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return false, nil
-	}
-	if err != nil {
-		return false, fmt.Errorf("postgres tx synced get: %w", err)
-	}
-	return true, nil
-}
-
-// MarkSynced records the synced marker inside the transaction. First-wins per
-// ON CONFLICT (hash) DO NOTHING, matching the store-level method — except
-// after a DeleteSynced in the same tx, whose pending delete makes this insert
-// take effect with the new locator (read-your-writes).
-func (tx *postgresTransaction) MarkSynced(ctx context.Context, hash block.ContentHash, loc block.ChunkLocator) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	blockID, off, length := locatorArgs(loc)
-	if _, err := tx.tx.Exec(ctx,
-		`INSERT INTO synced_hashes (hash, synced_at, block_id, block_offset, block_length)
-			VALUES ($1, NOW(), $2, $3, $4)
-			ON CONFLICT (hash) DO NOTHING`,
-		hash[:], blockID, off, length); err != nil {
-		return fmt.Errorf("postgres tx synced mark: %w", err)
-	}
-	return nil
-}
-
-func (tx *postgresTransaction) GetLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error) {
-	if err := ctx.Err(); err != nil {
-		return block.ChunkLocator{}, false, err
-	}
-	var blockID sql.NullString
-	var off, length sql.NullInt64
-	err := tx.tx.QueryRow(ctx,
-		`SELECT block_id, block_offset, block_length FROM synced_hashes WHERE hash = $1`,
-		hash[:]).Scan(&blockID, &off, &length)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return block.ChunkLocator{}, false, nil
-	}
-	if err != nil {
-		return block.ChunkLocator{}, false, fmt.Errorf("postgres tx synced get locator: %w", err)
-	}
-	if !blockID.Valid || blockID.String == "" {
-		return block.ChunkLocator{}, true, nil
-	}
-	if !off.Valid || !length.Valid {
-		return block.ChunkLocator{}, false, fmt.Errorf("corrupt locator row: block_id %q with NULL offset/length", blockID.String)
-	}
-	return block.ChunkLocator{BlockID: blockID.String, WireOffset: off.Int64, WireLength: length.Int64}, true, nil
-}
-
-func (tx *postgresTransaction) DeleteSynced(ctx context.Context, hash block.ContentHash) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	if _, err := tx.tx.Exec(ctx,
-		`DELETE FROM synced_hashes WHERE hash = $1`,
-		hash[:]); err != nil {
-		return fmt.Errorf("postgres tx synced delete: %w", err)
-	}
-	return nil
-}
-
-// PutSyncedLocators overwrites the marker of every chunk. The upserts are
-// pipelined as one batch, so a commit packing hundreds of chunks costs a single
-// network round trip instead of two per chunk. Each upsert is its own
-// statement, executed in slice order, so a repeated hash ends on the locator of
-// its last occurrence — the same row the sequential delete-then-mark pair
-// leaves behind.
 func (tx *postgresTransaction) PutSyncedLocators(ctx context.Context, chunks []block.BlockChunkCommit) error {
 	if err := ctx.Err(); err != nil {
 		return err

--- a/pkg/metadata/store/postgres/synced_hash_store.go
+++ b/pkg/metadata/store/postgres/synced_hash_store.go
@@ -87,23 +87,23 @@ func locatorFromCols(blockID sql.NullString, off, length sql.NullInt64) (block.C
 // Returns (false, nil) when no row exists for hash — an absent hash is
 // treated as "not yet synced", not as an error.
 func (s *PostgresMetadataStore) IsSynced(ctx context.Context, hash block.ContentHash) (bool, error) {
-	return isSyncedTx(ctx, s.conn(), hash)
+	return isSyncedTx(ctx, s.conn(), "postgres", hash)
 }
 
 // MarkSynced records that hash has been mirrored to remote, persisting loc's
 // block columns atomically.
 func (s *PostgresMetadataStore) MarkSynced(ctx context.Context, hash block.ContentHash, loc block.ChunkLocator) error {
-	return markSyncedTx(ctx, s.conn(), hash, loc)
+	return markSyncedTx(ctx, s.conn(), "postgres", hash, loc)
 }
 
 // GetLocator returns the recorded remote locator for hash.
 func (s *PostgresMetadataStore) GetLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error) {
-	return getLocatorTx(ctx, s.conn(), hash)
+	return getLocatorTx(ctx, s.conn(), "postgres", hash)
 }
 
 // DeleteSynced removes the synced marker for hash.
 func (s *PostgresMetadataStore) DeleteSynced(ctx context.Context, hash block.ContentHash) error {
-	return deleteSyncedTx(ctx, s.conn(), hash)
+	return deleteSyncedTx(ctx, s.conn(), "postgres", hash)
 }
 
 // ============================================================================
@@ -115,35 +115,41 @@ func (s *PostgresMetadataStore) DeleteSynced(ctx context.Context, hash block.Con
 // a MarkSynced after a DeleteSynced in the same tx records the new locator.
 
 func (tx *postgresTransaction) IsSynced(ctx context.Context, hash block.ContentHash) (bool, error) {
-	return isSyncedTx(ctx, tx.conn(), hash)
+	return isSyncedTx(ctx, tx.conn(), "postgres tx", hash)
 }
 
 func (tx *postgresTransaction) MarkSynced(ctx context.Context, hash block.ContentHash, loc block.ChunkLocator) error {
-	return markSyncedTx(ctx, tx.conn(), hash, loc)
+	return markSyncedTx(ctx, tx.conn(), "postgres tx", hash, loc)
 }
 
 func (tx *postgresTransaction) GetLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error) {
-	return getLocatorTx(ctx, tx.conn(), hash)
+	return getLocatorTx(ctx, tx.conn(), "postgres tx", hash)
 }
 
 func (tx *postgresTransaction) DeleteSynced(ctx context.Context, hash block.ContentHash) error {
-	return deleteSyncedTx(ctx, tx.conn(), hash)
+	return deleteSyncedTx(ctx, tx.conn(), "postgres tx", hash)
 }
 
 // ============================================================================
 // Shared bodies
 // ============================================================================
+//
+// Each takes the caller's op prefix ("postgres" or "postgres tx") so a failure
+// still records whether it happened on the pool path or inside a transaction.
+// Merging the bodies would otherwise erase that distinction, and it is the one
+// worth keeping here: the failures these report are usually visibility or
+// locking problems, where knowing there was an open transaction is the answer.
 
 // isSyncedTx reports whether a synced marker exists for hash. An absent row is
 // "not yet synced", not an error.
-func isSyncedTx(ctx context.Context, x storesql.Executor, hash block.ContentHash) (bool, error) {
+func isSyncedTx(ctx context.Context, x storesql.Executor, op string, hash block.ContentHash) (bool, error) {
 	var dummy int
 	err := x.QueryRow(ctx, `SELECT 1 FROM synced_hashes WHERE hash = $1`, hash[:]).Scan(&dummy)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return false, nil
 	}
 	if err != nil {
-		return false, fmt.Errorf("postgres synced get: %w", err)
+		return false, fmt.Errorf("%s synced get: %w", op, err)
 	}
 	return true, nil
 }
@@ -153,14 +159,14 @@ func isSyncedTx(ctx context.Context, x storesql.Executor, hash block.ContentHash
 // re-applying the same hash is a no-op that preserves the first locator. A
 // standalone locator (BlockID == "") leaves the block columns NULL, identical to
 // a pre-locator row, so existing data needs no migration.
-func markSyncedTx(ctx context.Context, x storesql.Executor, hash block.ContentHash, loc block.ChunkLocator) error {
+func markSyncedTx(ctx context.Context, x storesql.Executor, op string, hash block.ContentHash, loc block.ChunkLocator) error {
 	blockID, off, length := locatorArgs(loc)
 	if _, err := x.Exec(ctx,
 		`INSERT INTO synced_hashes (hash, synced_at, block_id, block_offset, block_length)
 			VALUES ($1, NOW(), $2, $3, $4)
 			ON CONFLICT (hash) DO NOTHING`,
 		hash[:], blockID, off, length); err != nil {
-		return fmt.Errorf("postgres synced mark: %w", err)
+		return fmt.Errorf("%s synced mark: %w", op, err)
 	}
 	return nil
 }
@@ -168,7 +174,7 @@ func markSyncedTx(ctx context.Context, x storesql.Executor, hash block.ContentHa
 // getLocatorTx returns the recorded remote locator for hash: (zero, false, nil)
 // when no row exists; a synced row with NULL/empty block columns yields the zero
 // (standalone) locator with found == true.
-func getLocatorTx(ctx context.Context, x storesql.Executor, hash block.ContentHash) (block.ChunkLocator, bool, error) {
+func getLocatorTx(ctx context.Context, x storesql.Executor, op string, hash block.ContentHash) (block.ChunkLocator, bool, error) {
 	var blockID sql.NullString
 	var off, length sql.NullInt64
 	err := x.QueryRow(ctx,
@@ -178,7 +184,7 @@ func getLocatorTx(ctx context.Context, x storesql.Executor, hash block.ContentHa
 		return block.ChunkLocator{}, false, nil
 	}
 	if err != nil {
-		return block.ChunkLocator{}, false, fmt.Errorf("postgres synced get locator: %w", err)
+		return block.ChunkLocator{}, false, fmt.Errorf("%s synced get locator: %w", op, err)
 	}
 	if !blockID.Valid || blockID.String == "" {
 		return block.ChunkLocator{}, true, nil
@@ -191,9 +197,9 @@ func getLocatorTx(ctx context.Context, x storesql.Executor, hash block.ContentHa
 
 // deleteSyncedTx removes the synced marker for hash. Idempotent: zero rows
 // affected is not an error.
-func deleteSyncedTx(ctx context.Context, x storesql.Executor, hash block.ContentHash) error {
+func deleteSyncedTx(ctx context.Context, x storesql.Executor, op string, hash block.ContentHash) error {
 	if _, err := x.Exec(ctx, `DELETE FROM synced_hashes WHERE hash = $1`, hash[:]); err != nil {
-		return fmt.Errorf("postgres synced delete: %w", err)
+		return fmt.Errorf("%s synced delete: %w", op, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Track-S stage from the #1828 plan, stacked on #2225. The plan calls this the highest value-per-risk stage, and the reason is that the hard structural work happens **inside the existing package**, where it is independently valuable and trivially revertable — the package move later becomes mechanical.

## Why

postgres wrote each chunk, synced-hash and block-record operation twice: once on `*PostgresMetadataStore` against the pool helpers, once on `*postgresTransaction` against `tx.tx`, bodies otherwise identical.

sqlite already had the answer. `sqlite/objects.go` is free functions over an executor — `getFileChunkTx(ctx, x, id)` and eight siblings — with both method sets as one-line delegations. So this is **finishing a refactor sqlite already completed**, not inventing an abstraction and porting two packages onto it.

## What changed

- Adds the two `Executor` implementations postgres was missing: `poolExecer` (acquire/release per op) and `txExecer` (runs on the open `pgx.Tx`).
- Collapses `objects.go` (11 pairs), `synced_hash_store.go` (4 pairs) and the `block_record_store.go` read pairs onto shared bodies.
- The `ctx.Err()` check lives in the executors rather than in every body, so a body can't forget it — and the transaction path, which previously carried the check by hand in each method, now gets it structurally.

Same queries, same errors, same behaviour. Net −93 lines here, but the point is that the count of places a fix has to be applied twice drops to zero for these three files.

Two things deliberately left alone: `durable_handles.go` has no store/tx duplication in postgres (it is a substore whose store-level methods are already one-line delegations), and `collectFileChunkIDs` / `InjectCorruptHashRow` are pool-only with no transaction twin.

## Tests

Mutation-testing the result found a real hole: **the suite could not tell a transaction-level chunk write from a pool write.** A write that escaped to the pool runs on a separate connection, commits independently, and survives the enclosing transaction's rollback — and every existing test commits, so nothing noticed.

Added `TestTransactionChunkWritesRollBack`, which asserts read-your-writes inside the transaction and absence after a rollback. Verified against deliberately broken builds:

| mutation | caught |
|---|---|
| `tx.Put` routed to the pool | ✅ |
| `tx.GetFileChunk` routed to the pool | ✅ |
| `tx.ListFileChunks` routed to the pool | ✅ (already caught by the existing suite) |

It is a backend-agnostic contract and a good candidate to move into `storetest/` later; kept local here to keep the stage to one package.

## Verification

All four backends, **including a real postgres** (`postgresql 16.15`, DSN matching CI's):

- `go build ./... && go vet ./pkg/metadata/...`
- `go test ./pkg/metadata/...` — green
- `go test -tags=integration -p 1 ./pkg/metadata/...` — green, `postgres 32.3s`
- Baselined the same suite on the parent commit first, so the green is a comparison, not an assertion.
