### PR TITLE
refactor(metadata): one chunk-store implementation shared by both SQL dialects

### DIFF
--- a/pkg/metadata/store/postgres/dialect.go
+++ b/pkg/metadata/store/postgres/dialect.go
@@ -1,0 +1,39 @@
+package postgres
+
+import (
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+
+	storesql "github.com/marmos91/dittofs/pkg/metadata/store/sql"
+)
+
+// dialect supplies postgres statement text and postgres error classification to
+// the shared SQL core. It is stateless, so one package-level value serves every
+// store and transaction.
+type dialect struct{}
+
+var pgDialect dialect
+
+// IsNoRows reports pgx's empty-result sentinel.
+func (dialect) IsNoRows(err error) bool { return errors.Is(err, pgx.ErrNoRows) }
+
+// Chunks returns the postgres file-chunk statements.
+func (dialect) Chunks() *storesql.ChunkQueries { return &chunkQueries }
+
+var chunkQueries = storesql.ChunkQueries{
+	SelectByID:   selectFileChunkByID,
+	SelectByHash: selectFileChunkByHash,
+	Upsert:       putFileChunkQuery,
+	Delete:       `DELETE FROM file_blocks WHERE id = $1`,
+	IncrementRef: `UPDATE file_blocks SET ref_count = ref_count + 1 WHERE id = $1`,
+	DecrementRef: `UPDATE file_blocks SET ref_count = GREATEST(ref_count - 1, 0) WHERE id = $1 RETURNING ref_count`,
+	// state = 2 (Remote) scoping mirrors SelectByHash and the memory/badger
+	// backends: a Pending row is not a valid dedup donor.
+	AddRef:             `UPDATE file_blocks SET ref_count = ref_count + 1 WHERE hash = $1 AND state = 2 /* Remote */`,
+	ReapZeroRef:        `DELETE FROM file_blocks WHERE id = $1 AND ref_count = 0`,
+	ListByPayloadRange: listFileChunksQuery,
+	EnumerateHashes:    enumerateHashesQuery,
+}
+
+var _ storesql.Dialect = dialect{}

--- a/pkg/metadata/store/postgres/objects.go
+++ b/pkg/metadata/store/postgres/objects.go
@@ -2,13 +2,10 @@ package postgres
 
 import (
 	"context"
-	"database/sql"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
 
-	"github.com/jackc/pgx/v5"
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
 
@@ -69,33 +66,6 @@ const putFileChunkQuery = insertFileChunk + `
 		state = EXCLUDED.state,
 		last_sync_attempt_at = EXCLUDED.last_sync_attempt_at`
 
-// GetFileChunk retrieves a file chunk by its ID. Not on the narrowed
-// FileChunkStore interface; kept as a backend
-// method for engine-internal callers.
-func (s *PostgresMetadataStore) GetFileChunk(ctx context.Context, id string) (*metadata.FileChunk, error) {
-	return getFileChunkTx(ctx, s.conn(), id)
-}
-
-// Put stores or updates a file chunk.
-func (s *PostgresMetadataStore) Put(ctx context.Context, chunk *metadata.FileChunk) error {
-	return putFileChunkTx(ctx, s.conn(), chunk)
-}
-
-// Delete removes a file chunk by its ID.
-func (s *PostgresMetadataStore) Delete(ctx context.Context, id string) error {
-	return deleteFileChunkTx(ctx, s.conn(), id)
-}
-
-// IncrementRefCount atomically increments a block's RefCount.
-func (s *PostgresMetadataStore) IncrementRefCount(ctx context.Context, id string) error {
-	return incrementRefCountTx(ctx, s.conn(), id)
-}
-
-// DecrementRefCount atomically decrements a block's RefCount.
-func (s *PostgresMetadataStore) DecrementRefCount(ctx context.Context, id string) (uint32, error) {
-	return decrementRefCountTx(ctx, s.conn(), id)
-}
-
 // DecrementRefCountAndReap atomically decrements ref_count and, when it hits 0,
 // deletes the row — both statements run inside ONE transaction so the
 // decrement-and-reap is atomic and TOCTOU-free against a concurrent AddRef
@@ -112,33 +82,6 @@ func (s *PostgresMetadataStore) DecrementRefCountAndReap(ctx context.Context, id
 	})
 	if err != nil {
 		return 0, err
-	}
-	return newCount, nil
-}
-
-// decrementAndReapTx runs the -1 UPDATE then a conditional DELETE. The
-// `ref_count = 0` predicate on the DELETE means a bump that landed between the
-// two statements leaves the row alive. Returns (0, nil) for an already-swept row
-// rather than ErrFileChunkNotFound.
-//
-// Callers must supply a transaction Executor: the two statements are only
-// atomic against a concurrent AddRef if they share one transaction.
-func decrementAndReapTx(ctx context.Context, x storesql.Executor, id string) (uint32, error) {
-	var newCount uint32
-	err := x.QueryRow(ctx,
-		`UPDATE file_blocks SET ref_count = GREATEST(ref_count - 1, 0) WHERE id = $1 RETURNING ref_count`,
-		id).Scan(&newCount)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return 0, nil // tolerate already-swept row
-	}
-	if err != nil {
-		return 0, fmt.Errorf("decrement ref count: %w", err)
-	}
-	if newCount == 0 {
-		if _, err := x.Exec(ctx,
-			`DELETE FROM file_blocks WHERE id = $1 AND ref_count = 0`, id); err != nil {
-			return 0, fmt.Errorf("reap zero-ref block: %w", err)
-		}
 	}
 	return newCount, nil
 }
@@ -165,192 +108,6 @@ func decrementAndReapManyTx(ctx context.Context, x storesql.Executor, ids []stri
 	return nil
 }
 
-// getFileChunkTx reads one chunk by id.
-func getFileChunkTx(ctx context.Context, x storesql.Executor, id string) (*metadata.FileChunk, error) {
-	chunk, err := scanFileChunk(x.QueryRow(ctx, selectFileChunkByID, id))
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, metadata.ErrFileChunkNotFound
-	}
-	if err != nil {
-		return nil, fmt.Errorf("get file chunk: %w", err)
-	}
-	return chunk, nil
-}
-
-// putFileChunkTx stores or updates a chunk row.
-//
-// The hash column is persisted whenever the chunk carries a non-zero content
-// hash, regardless of state. The content hash is derived at rollup time (long
-// before the block reaches the remote) and is the key the engine's CAS read path
-// uses to resolve a chunk. Gating the write on IsRemote() left every Pending row
-// with a NULL hash; reads then survived only while the bytes stayed in the local
-// append log or RAM cache, and broke the moment local state went cold (restart +
-// cache eviction, or a snapshot restore's ResetLocalState). The memory and badger
-// backends always store the hash inline on the row, so this matches them.
-//
-// LastSyncAttemptAt is persisted as NULL when zero so the janitor's
-// `last_sync_attempt_at < cutoff` predicate excludes never-claimed rows
-// naturally instead of matching every Pending row.
-func putFileChunkTx(ctx context.Context, x storesql.Executor, chunk *metadata.FileChunk) error {
-	var hashStr *string
-	if !chunk.Hash.IsZero() {
-		h := chunk.Hash.String()
-		hashStr = &h
-	}
-	var lastSyncAttemptAt *time.Time
-	if !chunk.LastSyncAttemptAt.IsZero() {
-		t := chunk.LastSyncAttemptAt
-		lastSyncAttemptAt = &t
-	}
-	if _, err := x.Exec(ctx, putFileChunkQuery,
-		chunk.ID, hashStr, chunk.DataSize, chunk.StartOffset,
-		chunk.RefCount, chunk.LastAccess, chunk.CreatedAt, chunk.State, lastSyncAttemptAt); err != nil {
-		return fmt.Errorf("put file chunk: %w", err)
-	}
-	return nil
-}
-
-// deleteFileChunkTx removes one chunk row by id.
-func deleteFileChunkTx(ctx context.Context, x storesql.Executor, id string) error {
-	result, err := x.Exec(ctx, `DELETE FROM file_blocks WHERE id = $1`, id)
-	if err != nil {
-		return fmt.Errorf("delete file chunk: %w", err)
-	}
-	if result.RowsAffected() == 0 {
-		return metadata.ErrFileChunkNotFound
-	}
-	return nil
-}
-
-// incrementRefCountTx atomically bumps one chunk's RefCount.
-func incrementRefCountTx(ctx context.Context, x storesql.Executor, id string) error {
-	result, err := x.Exec(ctx,
-		`UPDATE file_blocks SET ref_count = ref_count + 1 WHERE id = $1`, id)
-	if err != nil {
-		return fmt.Errorf("increment ref count: %w", err)
-	}
-	if result.RowsAffected() == 0 {
-		return metadata.ErrFileChunkNotFound
-	}
-	return nil
-}
-
-// decrementRefCountTx atomically decrements one chunk's RefCount, floored at 0.
-func decrementRefCountTx(ctx context.Context, x storesql.Executor, id string) (uint32, error) {
-	var newCount uint32
-	err := x.QueryRow(ctx,
-		`UPDATE file_blocks SET ref_count = GREATEST(ref_count - 1, 0) WHERE id = $1 RETURNING ref_count`,
-		id).Scan(&newCount)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return 0, metadata.ErrFileChunkNotFound
-	}
-	if err != nil {
-		return 0, fmt.Errorf("decrement ref count: %w", err)
-	}
-	return newCount, nil
-}
-
-// addRefTx bumps RefCount on the row(s) indexed by a content hash.
-//
-// Atomicity: a single UPDATE performs the bump — PostgreSQL's row-level locking
-// serializes contended updates against the same row, so this is TOCTOU-free
-// against a concurrent DecrementRefCount cascade.
-//
-// state = 2 (Remote) scoping mirrors GetByHash and the memory/badger backends,
-// whose AddRef resolves a hash only through the finalized hash index. The dedup
-// hit path references a block already confirmed on the remote; a Pending row
-// (which now also carries its hash) is not a valid dedup donor, so this must
-// miss it and return ErrUnknownHash, letting the caller fall back to full Put.
-//
-// The hash index on file_blocks is a NON-UNIQUE partial index (migration
-// 000011), so one hash may match multiple rows in legacy data. The UPDATE
-// deliberately omits LIMIT — all matching rows are bumped uniformly so refcount
-// accounting stays correct regardless of which row a later decrement targets.
-//
-// Only ref_count is mutated; block_state is never touched.
-func addRefTx(ctx context.Context, x storesql.Executor, hash block.ContentHash) error {
-	result, err := x.Exec(ctx,
-		`UPDATE file_blocks SET ref_count = ref_count + 1 WHERE hash = $1 AND state = 2 /* Remote */`,
-		hash.String())
-	if err != nil {
-		return fmt.Errorf("add ref: %w", err)
-	}
-	if result.RowsAffected() == 0 {
-		return metadata.ErrUnknownHash
-	}
-	return nil
-}
-
-// getByHashTx looks up a finalized chunk by content hash, returning (nil, nil)
-// when absent. Dedup matches only Remote (state=2) chunks — Pending or Syncing
-// rows have not been confirmed on the remote and are unsafe dedup targets.
-func getByHashTx(ctx context.Context, x storesql.Executor, hash metadata.ContentHash) (*metadata.FileChunk, error) {
-	chunk, err := scanFileChunk(x.QueryRow(ctx, selectFileChunkByHash, hash.String()))
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("find file chunk by hash: %w", err)
-	}
-	return chunk, nil
-}
-
-// listFileChunksTx returns the chunks belonging to one payload, in block order.
-func listFileChunksTx(ctx context.Context, x storesql.Executor, payloadID string) ([]*metadata.FileChunk, error) {
-	lo, hi := block.PayloadPrefixRange(payloadID)
-	rows, err := x.Query(ctx, listFileChunksQuery, lo, hi)
-	if err != nil {
-		return nil, fmt.Errorf("list file chunks: %w", err)
-	}
-	defer rows.Close()
-	result, err := scanFileChunkRows(rows)
-	if err != nil {
-		return nil, err
-	}
-	return block.ChunksForPayload(result, payloadID), nil
-}
-
-// enumerateFileChunksTx streams every live-set ContentHash through fn, unioning
-// the CAS index with the per-file manifest (see enumerateHashesQuery).
-func enumerateFileChunksTx(ctx context.Context, x storesql.Executor, fn func(block.ContentHash) error) error {
-	rows, err := x.Query(ctx, enumerateHashesQuery)
-	if err != nil {
-		return fmt.Errorf("enumerate file chunks: query: %w", err)
-	}
-	defer rows.Close()
-	for rows.Next() {
-		if err := ctx.Err(); err != nil {
-			return fmt.Errorf("enumerate file chunks: %w", err)
-		}
-		var hashStr sql.NullString
-		if err := rows.Scan(&hashStr); err != nil {
-			return fmt.Errorf("enumerate file chunks: scan: %w", err)
-		}
-		var h block.ContentHash
-		if hashStr.Valid {
-			parsed, perr := metadata.ParseContentHash(hashStr.String)
-			if perr != nil {
-				// Fail closed: a malformed hash row cannot be silently coerced
-				// to the zero hash — that would invite the GC mark phase to
-				// treat the row as a legacy pre-CAS entry and the sweep would
-				// reap a still-live CAS object once the grace TTL lapses.
-				// Surface the parse error so enumeration aborts and the sweep
-				// is skipped.
-				return fmt.Errorf("enumerate file chunks: parse hash %q: %w",
-					hashStr.String, perr)
-			}
-			h = parsed
-		}
-		if err := fn(h); err != nil {
-			return err
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("enumerate file chunks: rows: %w", err)
-	}
-	return nil
-}
-
 // AddRef atomically bumps RefCount on the FileChunk row(s) indexed by the
 // given content hash, implementing the FileChunkStore.AddRef contract used by
 // the in-memory hash dedup LRU hit path. Returns metadata.ErrUnknownHash when
@@ -358,13 +115,7 @@ func enumerateFileChunksTx(ctx context.Context, x storesql.Executor, fn func(blo
 func (s *PostgresMetadataStore) AddRef(ctx context.Context, hash block.ContentHash, _ string, _ block.ChunkRef) error {
 	// payloadID + blockRef are accepted for future GC traceability; this
 	// backend records ref count only, so they are intentionally blanked.
-	return addRefTx(ctx, s.conn(), hash)
-}
-
-// GetByHash looks up a finalized block by its content hash, returning
-// (nil, nil) when absent.
-func (s *PostgresMetadataStore) GetByHash(ctx context.Context, hash metadata.ContentHash) (*metadata.FileChunk, error) {
-	return getByHashTx(ctx, s.conn(), hash)
+	return s.Core.AddRef(ctx, hash)
 }
 
 // listFileChunksQuery takes the bounds of block.PayloadPrefixRange and is a
@@ -378,13 +129,6 @@ const listFileChunksQuery = `SELECT ` + fileChunkColumns + `
 	FROM file_blocks
 	WHERE id >= $1 COLLATE "C" AND id < $2 COLLATE "C"
 	ORDER BY id COLLATE "C" ASC`
-
-// ListFileChunks returns all blocks belonging to a file, ordered by block index.
-// Not on the narrowed FileChunkStore interface; kept as a backend method for
-// engine-internal callers.
-func (s *PostgresMetadataStore) ListFileChunks(ctx context.Context, payloadID string) ([]*metadata.FileChunk, error) {
-	return listFileChunksTx(ctx, s.conn(), payloadID)
-}
 
 // enumerateHashesQuery is the GC mark live-set query. It UNIONs the CAS index
 // (file_blocks.hash, VARCHAR hex) with the per-file manifest
@@ -492,54 +236,9 @@ func (s *PostgresMetadataStore) collectFileChunkIDs(ctx context.Context, query s
 	return ids, nil
 }
 
-// EnumerateFileChunks streams every live-set ContentHash through fn.
-func (s *PostgresMetadataStore) EnumerateFileChunks(ctx context.Context, fn func(block.ContentHash) error) error {
-	return enumerateFileChunksTx(ctx, s.conn(), fn)
-}
-
 // ============================================================================
 // Scan Helpers
 // ============================================================================
-
-// scanFileChunk scans a single row into a FileChunk.
-func scanFileChunk(row storesql.Row) (*metadata.FileChunk, error) {
-	var (
-		block             metadata.FileChunk
-		hashStr           sql.NullString
-		lastSyncAttemptAt sql.NullTime
-	)
-	if err := row.Scan(&block.ID, &hashStr, &block.DataSize, &block.StartOffset,
-		&block.RefCount, &block.LastAccess, &block.CreatedAt, &block.State, &lastSyncAttemptAt); err != nil {
-		return nil, err
-	}
-	if hashStr.Valid {
-		// do not silently coerce malformed CAS hashes to the
-		// zero hash — see EnumerateFileChunks for the data-loss scenario.
-		h, perr := metadata.ParseContentHash(hashStr.String)
-		if perr != nil {
-			return nil, fmt.Errorf("scan file chunk %s: parse hash %q: %w",
-				block.ID, hashStr.String, perr)
-		}
-		block.Hash = h
-	}
-	if lastSyncAttemptAt.Valid {
-		block.LastSyncAttemptAt = lastSyncAttemptAt.Time
-	}
-	return &block, nil
-}
-
-// scanFileChunkRows scans multiple rows into FileChunk slices.
-func scanFileChunkRows(rows storesql.Rows) ([]*metadata.FileChunk, error) {
-	var result []*metadata.FileChunk
-	for rows.Next() {
-		block, err := scanFileChunk(rows)
-		if err != nil {
-			return nil, fmt.Errorf("scan file chunk: %w", err)
-		}
-		result = append(result, block)
-	}
-	return result, rows.Err()
-}
 
 // ============================================================================
 // Transaction Support
@@ -557,36 +256,9 @@ var _ block.FileChunkStore = (*postgresTransaction)(nil)
 // leak). All proxies below are now tx-bound; non-mutating
 // helpers keep the pool path because no caller mutates state through them.
 
-func (tx *postgresTransaction) GetFileChunk(ctx context.Context, id string) (*metadata.FileChunk, error) {
-	return getFileChunkTx(ctx, tx.conn(), id)
-}
-
-func (tx *postgresTransaction) Put(ctx context.Context, chunk *metadata.FileChunk) error {
-	return putFileChunkTx(ctx, tx.conn(), chunk)
-}
-
-func (tx *postgresTransaction) Delete(ctx context.Context, id string) error {
-	return deleteFileChunkTx(ctx, tx.conn(), id)
-}
-
 // The ref-count mutators below run on the active pgx.Tx so a subsequent
 // rollback undoes them. Production callers reach them through
 // metadataCoordinator when ctx carries an active tx via metadata.WithTx.
-
-func (tx *postgresTransaction) IncrementRefCount(ctx context.Context, id string) error {
-	return incrementRefCountTx(ctx, tx.conn(), id)
-}
-
-func (tx *postgresTransaction) DecrementRefCount(ctx context.Context, id string) (uint32, error) {
-	return decrementRefCountTx(ctx, tx.conn(), id)
-}
-
-// DecrementRefCountAndReap runs the -1 UPDATE + reap-at-zero DELETE on the
-// active transaction so a rollback undoes both. Returns (0, nil) when the row is
-// already absent.
-func (tx *postgresTransaction) DecrementRefCountAndReap(ctx context.Context, id string) (uint32, error) {
-	return decrementAndReapTx(ctx, tx.conn(), id)
-}
 
 // DecrementRefCountAndReapMany is the batched form, applied to the whole id set
 // in two statements on the active transaction.
@@ -599,11 +271,7 @@ func (tx *postgresTransaction) DecrementRefCountAndReapMany(ctx context.Context,
 func (tx *postgresTransaction) AddRef(ctx context.Context, hash block.ContentHash, _ string, _ block.ChunkRef) error {
 	// payloadID + blockRef accepted for future GC traceability; intentionally
 	// blanked, as on the pool path.
-	return addRefTx(ctx, tx.conn(), hash)
-}
-
-func (tx *postgresTransaction) GetByHash(ctx context.Context, hash metadata.ContentHash) (*metadata.FileChunk, error) {
-	return getByHashTx(ctx, tx.conn(), hash)
+	return tx.Core.AddRef(ctx, hash)
 }
 
 // ListFileChunks and EnumerateFileChunks run on the active transaction, NOT the
@@ -612,14 +280,6 @@ func (tx *postgresTransaction) GetByHash(ctx context.Context, hash metadata.Cont
 // WithTransaction would miss the pending row — a read-after-write violation.
 // That is the whole reason these take an Executor rather than being called on
 // the store.
-
-func (tx *postgresTransaction) ListFileChunks(ctx context.Context, payloadID string) ([]*metadata.FileChunk, error) {
-	return listFileChunksTx(ctx, tx.conn(), payloadID)
-}
-
-func (tx *postgresTransaction) EnumerateFileChunks(ctx context.Context, fn func(block.ContentHash) error) error {
-	return enumerateFileChunksTx(ctx, tx.conn(), fn)
-}
 
 // The file_blocks table schema lives in
 // pkg/metadata/store/postgres/migrations/000010_file_blocks.up.sql.

--- a/pkg/metadata/store/postgres/store.go
+++ b/pkg/metadata/store/postgres/store.go
@@ -15,10 +15,18 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sharecache"
+
+	storesql "github.com/marmos91/dittofs/pkg/metadata/store/sql"
 )
 
 // PostgresMetadataStore implements the metadata.Store interface using PostgreSQL
 type PostgresMetadataStore struct {
+	// Core carries the executor and dialect the shared SQL bodies run on, and
+	// promotes those bodies onto this type so they exist once for both
+	// backends. Embedded by pointer: the transaction embeds its own Core over
+	// the open pgx.Tx, and nothing is shared between the two but the dialect.
+	*storesql.Core
+
 	// pool is the PostgreSQL connection pool
 	pool *pgxpool.Pool
 
@@ -142,6 +150,9 @@ func NewPostgresMetadataStore(
 		cancel:       cancel,
 		quota:        basestore.NewQuotaCache(),
 	}
+	// The shared SQL bodies run on the pool for store-level calls.
+	store.Core = &storesql.Core{X: poolExecer{s: store}, D: pgDialect}
+
 	// The substores derive only from pool, which is never reassigned, so bind
 	// them once here.
 	store.lockStore = newPostgresLockStore(pool)

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -18,6 +18,8 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlcodec"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/txretry"
+
+	storesql "github.com/marmos91/dittofs/pkg/metadata/store/sql"
 )
 
 // Transaction retry policy (#1769). Under write contention DittoFS must
@@ -39,6 +41,11 @@ import (
 // accumulating per-attempt and applying post-commit prevents double-counting
 // across retries.
 type postgresTransaction struct {
+	// Core runs the shared SQL bodies on THIS transaction, not the pool. A
+	// body reached through the pool would run on a separate connection and
+	// survive this transaction's rollback.
+	*storesql.Core
+
 	store *PostgresMetadataStore
 	tx    pgx.Tx
 	// quota accumulates usage changes (bytes + file count) keyed by share and
@@ -143,6 +150,7 @@ func (s *PostgresMetadataStore) withTransaction(ctx context.Context, fn func(tx 
 		}
 
 		ptx := &postgresTransaction{store: s, tx: tx}
+		ptx.Core = &storesql.Core{X: txExecer{tx: tx}, D: pgDialect}
 		if err := fn(ptx); err != nil {
 			// Apply timeout to rollback to prevent indefinite blocking
 			rollbackCtx, rollbackCancel := context.WithTimeout(ctx, poolConnectionAcquireTimeout)

--- a/pkg/metadata/store/sql/chunks.go
+++ b/pkg/metadata/store/sql/chunks.go
@@ -1,0 +1,238 @@
+package sql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// Core is the shared half of a SQL-backed metadata store: an executor to run
+// statements on and the dialect that supplies their text and classifies their
+// errors.
+//
+// Both a store and a transaction embed one. The store's carries a pool
+// executor, the transaction's an executor over the open transaction — which is
+// the whole point: one body serves both, and a transaction-level call cannot
+// silently escape to the pool and outlive a rollback.
+//
+// Embed it by pointer and anonymously, so its methods are promoted onto the
+// dialect type. That also keeps the durability asymmetry a compile-time fact:
+// a dialect that must not advertise an optional interface simply never declares
+// the method, and no shared type can hand it one by accident.
+type Core struct {
+	// X runs the statements. Never nil.
+	X Executor
+	// D supplies statement text and classifies driver errors. Never nil.
+	D Dialect
+}
+
+// GetFileChunk reads one chunk by id, reporting metadata.ErrFileChunkNotFound
+// when absent.
+func (c *Core) GetFileChunk(ctx context.Context, id string) (*metadata.FileChunk, error) {
+	chunk, err := ScanFileChunk(c.X.QueryRow(ctx, c.D.Chunks().SelectByID, id))
+	if c.D.IsNoRows(err) {
+		return nil, metadata.ErrFileChunkNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get file chunk: %w", err)
+	}
+	return chunk, nil
+}
+
+// GetByHash looks up a finalized chunk by content hash, returning (nil, nil)
+// when absent.
+//
+// Dedup matches only Remote chunks: Pending or Syncing rows have not been
+// confirmed on the remote and are unsafe dedup targets. That scoping lives in
+// the dialect's SelectByHash statement.
+func (c *Core) GetByHash(ctx context.Context, hash metadata.ContentHash) (*metadata.FileChunk, error) {
+	chunk, err := ScanFileChunk(c.X.QueryRow(ctx, c.D.Chunks().SelectByHash, hash.String()))
+	if c.D.IsNoRows(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("find file chunk by hash: %w", err)
+	}
+	return chunk, nil
+}
+
+// Put stores or updates a chunk row.
+//
+// The hash column is persisted whenever the chunk carries a non-zero content
+// hash, regardless of state. The hash is derived at rollup time — long before
+// the block reaches the remote — and is the key the engine's CAS read path uses
+// to resolve a chunk. Gating the write on IsRemote() left every Pending row with
+// a NULL hash; reads then survived only while the bytes stayed in the local
+// append log or RAM cache, and broke the moment local state went cold (restart
+// plus cache eviction, or a snapshot restore's ResetLocalState). The memory and
+// badger backends store the hash inline on the row, so this matches them.
+//
+// LastSyncAttemptAt is persisted as NULL when zero so the janitor's
+// last_sync_attempt_at < cutoff predicate excludes never-claimed rows naturally
+// instead of matching every Pending row.
+func (c *Core) Put(ctx context.Context, chunk *metadata.FileChunk) error {
+	var hash *string
+	if !chunk.Hash.IsZero() {
+		h := chunk.Hash.String()
+		hash = &h
+	}
+	var lastSyncAttemptAt *time.Time
+	if !chunk.LastSyncAttemptAt.IsZero() {
+		t := chunk.LastSyncAttemptAt
+		lastSyncAttemptAt = &t
+	}
+	if _, err := c.X.Exec(ctx, c.D.Chunks().Upsert,
+		chunk.ID, hash, chunk.DataSize, chunk.StartOffset,
+		chunk.RefCount, chunk.LastAccess, chunk.CreatedAt, chunk.State, lastSyncAttemptAt); err != nil {
+		return fmt.Errorf("put file chunk: %w", err)
+	}
+	return nil
+}
+
+// Delete removes one chunk row, reporting metadata.ErrFileChunkNotFound when
+// there was nothing to remove.
+func (c *Core) Delete(ctx context.Context, id string) error {
+	result, err := c.X.Exec(ctx, c.D.Chunks().Delete, id)
+	if err != nil {
+		return fmt.Errorf("delete file chunk: %w", err)
+	}
+	if result.RowsAffected() == 0 {
+		return metadata.ErrFileChunkNotFound
+	}
+	return nil
+}
+
+// IncrementRefCount atomically bumps one chunk's RefCount.
+func (c *Core) IncrementRefCount(ctx context.Context, id string) error {
+	result, err := c.X.Exec(ctx, c.D.Chunks().IncrementRef, id)
+	if err != nil {
+		return fmt.Errorf("increment ref count: %w", err)
+	}
+	if result.RowsAffected() == 0 {
+		return metadata.ErrFileChunkNotFound
+	}
+	return nil
+}
+
+// DecrementRefCount atomically decrements one chunk's RefCount, floored at zero,
+// and returns the new value.
+func (c *Core) DecrementRefCount(ctx context.Context, id string) (uint32, error) {
+	var newCount uint32
+	err := c.X.QueryRow(ctx, c.D.Chunks().DecrementRef, id).Scan(&newCount)
+	if c.D.IsNoRows(err) {
+		return 0, metadata.ErrFileChunkNotFound
+	}
+	if err != nil {
+		return 0, fmt.Errorf("decrement ref count: %w", err)
+	}
+	return newCount, nil
+}
+
+// DecrementRefCountAndReap decrements ref_count and, when it reaches zero,
+// deletes the row. The `ref_count = 0` predicate on the DELETE means a bump that
+// landed between the two statements leaves the row alive. Returns (0, nil) for
+// an already-swept row rather than an error.
+//
+// The caller must supply a transaction executor: the two statements are only
+// atomic against a concurrent AddRef if they share one transaction.
+func (c *Core) DecrementRefCountAndReap(ctx context.Context, id string) (uint32, error) {
+	var newCount uint32
+	err := c.X.QueryRow(ctx, c.D.Chunks().DecrementRef, id).Scan(&newCount)
+	if c.D.IsNoRows(err) {
+		return 0, nil // tolerate an already-swept row
+	}
+	if err != nil {
+		return 0, fmt.Errorf("decrement ref count: %w", err)
+	}
+	if newCount == 0 {
+		if _, err := c.X.Exec(ctx, c.D.Chunks().ReapZeroRef, id); err != nil {
+			return 0, fmt.Errorf("reap zero-ref block: %w", err)
+		}
+	}
+	return newCount, nil
+}
+
+// AddRef bumps RefCount on the row(s) indexed by a content hash, implementing
+// the FileChunkStore.AddRef contract the in-memory dedup LRU hit path uses to
+// reference an already-stored chunk without creating a row.
+//
+// A single UPDATE performs the bump, so row-level locking serializes contended
+// updates against the same row and this is TOCTOU-free against a concurrent
+// decrement cascade. The statement matches only Remote rows: a Pending row
+// (which now also carries its hash) is not a valid dedup donor, so this must
+// miss it and return metadata.ErrUnknownHash, letting the caller fall back to
+// the full Put path.
+//
+// The hash index is non-unique, so one hash may match several rows in legacy
+// data. The statement deliberately has no LIMIT — all matching rows are bumped
+// uniformly, so accounting stays correct regardless of which row a later
+// decrement targets. Only ref_count is touched; chunk state never is.
+func (c *Core) AddRef(ctx context.Context, hash block.ContentHash) error {
+	result, err := c.X.Exec(ctx, c.D.Chunks().AddRef, hash.String())
+	if err != nil {
+		return fmt.Errorf("add ref: %w", err)
+	}
+	if result.RowsAffected() == 0 {
+		return metadata.ErrUnknownHash
+	}
+	return nil
+}
+
+// ListFileChunks returns the chunks belonging to one payload, in block order.
+// The id range is a prefilter under byte ordering; block.ChunksForPayload
+// decides membership and final order.
+func (c *Core) ListFileChunks(ctx context.Context, payloadID string) ([]*metadata.FileChunk, error) {
+	lo, hi := block.PayloadPrefixRange(payloadID)
+	rows, err := c.X.Query(ctx, c.D.Chunks().ListByPayloadRange, lo, hi)
+	if err != nil {
+		return nil, fmt.Errorf("list file chunks: %w", err)
+	}
+	defer rows.Close()
+	result, err := ScanFileChunkRows(rows)
+	if err != nil {
+		return nil, err
+	}
+	return block.ChunksForPayload(result, payloadID), nil
+}
+
+// EnumerateFileChunks streams every live-set ContentHash through fn.
+//
+// A malformed hash aborts enumeration rather than being coerced to the zero
+// hash: coercing would invite the GC mark phase to read the row as a legacy
+// pre-CAS entry, and the sweep would reap a still-live CAS object once the grace
+// TTL lapsed. Failing closed here means the sweep is skipped instead.
+func (c *Core) EnumerateFileChunks(ctx context.Context, fn func(block.ContentHash) error) error {
+	rows, err := c.X.Query(ctx, c.D.Chunks().EnumerateHashes)
+	if err != nil {
+		return fmt.Errorf("enumerate file chunks: query: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("enumerate file chunks: %w", err)
+		}
+		var hash sql.NullString
+		if err := rows.Scan(&hash); err != nil {
+			return fmt.Errorf("enumerate file chunks: scan: %w", err)
+		}
+		var h block.ContentHash
+		if hash.Valid {
+			parsed, perr := metadata.ParseContentHash(hash.String)
+			if perr != nil {
+				return fmt.Errorf("enumerate file chunks: parse hash %q: %w", hash.String, perr)
+			}
+			h = parsed
+		}
+		if err := fn(h); err != nil {
+			return err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("enumerate file chunks: rows: %w", err)
+	}
+	return nil
+}

--- a/pkg/metadata/store/sql/dialect.go
+++ b/pkg/metadata/store/sql/dialect.go
@@ -1,0 +1,64 @@
+package sql
+
+// Dialect carries what genuinely differs at runtime between the SQL backends.
+//
+// It is deliberately narrow. The divergences between sqlite and postgres split
+// into two kinds and only one of them needs a runtime interface:
+//
+//   - Text divergence — ?N versus $N, NOW() versus CURRENT_TIMESTAMP, the two
+//     rewritten recursive-CTE path queries, the two block-ref aggregates. That
+//     is baked into per-dialect SQL constants, supplied here as a struct of
+//     statements. A Placeholder(n int) method would move the same two-line
+//     difference into an indirection and buy nothing.
+//   - Behavioural divergence — error classification, and whether an error is
+//     the driver's empty-result sentinel. Those are genuinely per-dialect
+//     behaviour, so they are methods.
+//
+// Error *mapping* (MapError) and retryability (IsRetryable) stay on each
+// dialect's own errors.go: postgres classifies by SQLSTATE via
+// errors.As(&pgErr) and carries five error classes sqlite has no analogue for,
+// while sqlite matches lowercased substrings. There is no merged errors.go and
+// there was never meant to be one.
+type Dialect interface {
+	// IsNoRows reports whether err is this driver's empty-result sentinel:
+	// sql.ErrNoRows for database/sql, pgx.ErrNoRows for pgx. A shared body
+	// cannot compare against either directly, and getting this wrong turns
+	// "absent" into a hard error rather than the not-found the callers expect.
+	IsNoRows(err error) bool
+
+	// Chunks returns the dialect's file-chunk statements. The pointer is
+	// expected to address a package-level value, not a fresh struct per call.
+	Chunks() *ChunkQueries
+}
+
+// ChunkQueries holds the file-chunk statements in one dialect's syntax. Field
+// names name the operation, not the SQL, so the shared bodies read the same
+// whichever dialect is underneath.
+type ChunkQueries struct {
+	// SelectByID selects one chunk row by id. One parameter: the id.
+	SelectByID string
+	// SelectByHash selects one finalized (Remote) chunk row by content hash.
+	// One parameter: the hex hash.
+	SelectByHash string
+	// Upsert inserts or updates a chunk row. Nine parameters, in the column
+	// order of the chunk table.
+	Upsert string
+	// Delete removes one chunk row by id. One parameter: the id.
+	Delete string
+	// IncrementRef bumps one row's ref_count by one. One parameter: the id.
+	IncrementRef string
+	// DecrementRef decrements one row's ref_count, floored at zero, and
+	// returns the new value. One parameter: the id.
+	DecrementRef string
+	// AddRef bumps ref_count on every Remote row carrying a content hash.
+	// One parameter: the hex hash.
+	AddRef string
+	// ReapZeroRef deletes one row by id only if its ref_count is still zero.
+	// One parameter: the id.
+	ReapZeroRef string
+	// ListByPayloadRange selects the chunk rows whose ids fall in a payload's
+	// prefix range, in byte order. Two parameters: the low and high bounds.
+	ListByPayloadRange string
+	// EnumerateHashes selects the GC live set. No parameters.
+	EnumerateHashes string
+}

--- a/pkg/metadata/store/sql/scan.go
+++ b/pkg/metadata/store/sql/scan.go
@@ -1,0 +1,51 @@
+package sql
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// ScanFileChunk reads one chunk row. Both dialects persist the same column
+// layout, so this is shared verbatim.
+//
+// A malformed hash is an error, never the zero hash: coercing it would let the
+// GC mark phase read the row as a legacy pre-CAS entry and reap a still-live CAS
+// object once the grace TTL lapsed. Fail closed here so the caller aborts.
+func ScanFileChunk(row Row) (*metadata.FileChunk, error) {
+	var (
+		chunk             metadata.FileChunk
+		hash              sql.NullString
+		lastSyncAttemptAt sql.NullTime
+	)
+	if err := row.Scan(&chunk.ID, &hash, &chunk.DataSize, &chunk.StartOffset,
+		&chunk.RefCount, &chunk.LastAccess, &chunk.CreatedAt, &chunk.State, &lastSyncAttemptAt); err != nil {
+		return nil, err
+	}
+	if hash.Valid {
+		h, perr := metadata.ParseContentHash(hash.String)
+		if perr != nil {
+			return nil, fmt.Errorf("scan file chunk %s: parse hash %q: %w",
+				chunk.ID, hash.String, perr)
+		}
+		chunk.Hash = h
+	}
+	if lastSyncAttemptAt.Valid {
+		chunk.LastSyncAttemptAt = lastSyncAttemptAt.Time
+	}
+	return &chunk, nil
+}
+
+// ScanFileChunkRows drains a chunk result set.
+func ScanFileChunkRows(rows Rows) ([]*metadata.FileChunk, error) {
+	var result []*metadata.FileChunk
+	for rows.Next() {
+		chunk, err := ScanFileChunk(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan file chunk: %w", err)
+		}
+		result = append(result, chunk)
+	}
+	return result, rows.Err()
+}

--- a/pkg/metadata/store/sqlite/dialect.go
+++ b/pkg/metadata/store/sqlite/dialect.go
@@ -1,0 +1,41 @@
+package sqlite
+
+import (
+	"database/sql"
+	"errors"
+
+	storesql "github.com/marmos91/dittofs/pkg/metadata/store/sql"
+)
+
+// dialect supplies SQLite statement text and database/sql error classification
+// to the shared SQL core. It is stateless, so one package-level value serves
+// every store and transaction.
+type dialect struct{}
+
+var sqliteDialect dialect
+
+// IsNoRows reports database/sql's empty-result sentinel.
+func (dialect) IsNoRows(err error) bool { return errors.Is(err, sql.ErrNoRows) }
+
+// Chunks returns the SQLite file-chunk statements. They differ from postgres in
+// placeholder syntax (?N against $N), the floor function (MAX against GREATEST)
+// and the byte-ordering collation name (BINARY against "C") — text only; the
+// logic that runs them is shared.
+func (dialect) Chunks() *storesql.ChunkQueries { return &chunkQueries }
+
+var chunkQueries = storesql.ChunkQueries{
+	SelectByID:   `SELECT ` + fileChunkColumns + ` FROM file_blocks WHERE id = ?1`,
+	SelectByHash: `SELECT ` + fileChunkColumns + ` FROM file_blocks WHERE hash = ?1 AND state = 2 /* Remote */`,
+	Upsert:       putFileChunkQuery,
+	Delete:       `DELETE FROM file_blocks WHERE id = ?1`,
+	IncrementRef: `UPDATE file_blocks SET ref_count = ref_count + 1 WHERE id = ?1`,
+	DecrementRef: `UPDATE file_blocks SET ref_count = MAX(ref_count - 1, 0) WHERE id = ?1 RETURNING ref_count`,
+	// state = 2 (Remote) scoping mirrors SelectByHash and the memory/badger
+	// backends: a Pending row is not a valid dedup donor.
+	AddRef:             `UPDATE file_blocks SET ref_count = ref_count + 1 WHERE hash = ?1 AND state = 2 /* Remote */`,
+	ReapZeroRef:        `DELETE FROM file_blocks WHERE id = ?1 AND ref_count = 0`,
+	ListByPayloadRange: listFileChunksQuery,
+	EnumerateHashes:    enumerateHashesQuery,
+}
+
+var _ storesql.Dialect = dialect{}

--- a/pkg/metadata/store/sqlite/objects.go
+++ b/pkg/metadata/store/sqlite/objects.go
@@ -83,43 +83,15 @@ const putFileChunkQuery = insertFileChunk + `
 		state = EXCLUDED.state,
 		last_sync_attempt_at = EXCLUDED.last_sync_attempt_at`
 
-// AddRef atomically bumps RefCount on the FileChunk row(s) indexed by
-// the given content hash. Implements the FileChunkStore.AddRef contract
-// used by the in-memory hash dedup LRU hit path to
-// reference an already-stored block without creating a new row.
-//
-// Atomicity: a single UPDATE statement performs the bump — the SQLite
-// single-writer engine serializes contended updates against the same row,
-// so AddRef is TOCTOU-free against concurrent DecrementRefCount cascade
-// (matches the existing IncrementRefCount idiom).
-//
-// Returns metadata.ErrUnknownHash when RowsAffected == 0 (no row exists
-// for this hash). Callers (the LRU hit site) fall back to the full Put
-// path on this sentinel.
-//
-// Multi-row-per-hash tolerance:
-// the hash index on file_blocks is a NON-UNIQUE partial index (migration
-// 000011), so a single hash may match multiple rows in legacy data. The
-// UPDATE deliberately omits LIMIT — all matching rows are bumped
-// uniformly so refcount accounting stays correct regardless of which
-// row a later DecrementRefCount targets. The conformance test seeds a
-// single row, so RefCount goes from N to N+1 exactly.
-//
-// Only ref_count is mutated. block_state is never touched: AddRef
-// references an existing block, and the LRU hit path never creates
-// or transitions one.
+// AddRef bumps RefCount on the rows indexed by the given content hash,
+// implementing the FileChunkStore.AddRef contract the in-memory dedup LRU hit
+// path uses. Returns metadata.ErrUnknownHash when no row matches; the caller
+// falls back to the full Put path on that sentinel. The reasoning about
+// atomicity, Remote-only scoping and multi-row tolerance lives on the shared
+// implementation in store/sql.
 func (s *SQLiteMetadataStore) AddRef(ctx context.Context, hash block.ContentHash, _ string, _ block.ChunkRef) error {
-	// payloadID + blockRef accepted for future GC traceability;
-	// postgres backend records ref count only — parameters intentionally
-	// blanked.
-	//
-	// state = 2 (Remote) scoping mirrors GetByHash and the memory/badger
-	// backends, whose AddRef resolves the hash only through the finalized
-	// hash index. The dedup hit path references a block already confirmed
-	// on the remote; a Pending row (which now also carries its hash) is
-	// not a valid dedup donor, so AddRef must miss it and return
-	// ErrUnknownHash exactly as before, letting the caller fall back to
-	// the full Put path.
+	// payloadID + blockRef are accepted for future GC traceability; this
+	// backend records ref count only, so they are intentionally blanked.
 	return s.Core.AddRef(ctx, hash)
 }
 
@@ -264,18 +236,17 @@ var _ block.FileChunkStore = (*sqliteTransaction)(nil)
 // subsequent rollback undoes it. Returns metadata.ErrUnknownHash when no row
 // matches.
 func (tx *sqliteTransaction) AddRef(ctx context.Context, hash block.ContentHash, _ string, _ block.ChunkRef) error {
-	// payloadID + blockRef accepted for future GC traceability;
-	// postgres backend records ref count only — parameters intentionally
-	// blanked.
+	// payloadID + blockRef are accepted for future GC traceability; this
+	// backend records ref count only, so they are intentionally blanked.
 	return tx.Core.AddRef(ctx, hash)
 }
 
-// ListFileChunks / EnumerateFileChunks run on the active
-// transaction (tx.tx), NOT the pool. Delegating to the pool opens a separate
-// connection that cannot see this transaction's uncommitted writes, so a Put
-// followed by a List in the same WithTransaction would miss the pending row
-// (read-after-write violation; the SQL is otherwise identical to the
-// store-level methods).
+// ListFileChunks and EnumerateFileChunks run on this transaction's executor,
+// NOT the pool. Going through the pool would open a separate connection that
+// cannot see this transaction's uncommitted writes, so a Put followed by a List
+// inside one WithTransaction would miss the pending row — a read-after-write
+// violation. On SQLite it is worse than a wrong answer: the pool write blocks
+// on the write lock this transaction holds, so it hangs.
 
 // The file_blocks table schema lives in
 // pkg/metadata/store/postgres/migrations/000010_file_blocks.up.sql.

--- a/pkg/metadata/store/sqlite/objects.go
+++ b/pkg/metadata/store/sqlite/objects.go
@@ -2,8 +2,6 @@ package sqlite
 
 import (
 	"context"
-	"database/sql"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -38,44 +36,6 @@ var _ block.FileChunkStore = (*SQLiteMetadataStore)(nil)
 // FileChunk Operations
 // ============================================================================
 
-// GetFileChunk retrieves a file chunk by its ID. Not on the narrowed
-// FileChunkStore interface; kept as a backend
-// method for engine-internal callers.
-func (s *SQLiteMetadataStore) GetFileChunk(ctx context.Context, id string) (*metadata.FileChunk, error) {
-	return getFileChunkTx(ctx, s.conn(), id)
-}
-
-// Put stores or updates a file chunk.
-//
-// The hash column is persisted whenever the block carries a non-zero
-// content hash, regardless of block state. The content hash is derived
-// at rollup time (long before the block reaches the remote) and is the
-// key the engine's CAS read path uses to resolve a chunk. Gating the
-// write on IsRemote() left every Pending row with a NULL hash; reads
-// then survived only while the bytes stayed in the local append log or
-// RAM cache, and broke the moment local state went cold (restart +
-// cache eviction, or a snapshot restore's ResetLocalState). The memory
-// and badger backends always store the hash inline on the row, so this
-// matches their behavior.
-func (s *SQLiteMetadataStore) Put(ctx context.Context, block *metadata.FileChunk) error {
-	return putFileChunkTx(ctx, s.conn(), block)
-}
-
-// Delete removes a file chunk by its ID.
-func (s *SQLiteMetadataStore) Delete(ctx context.Context, id string) error {
-	return deleteFileChunkTx(ctx, s.conn(), id)
-}
-
-// IncrementRefCount atomically increments a block's RefCount.
-func (s *SQLiteMetadataStore) IncrementRefCount(ctx context.Context, id string) error {
-	return incrementRefCountTx(ctx, s.conn(), id)
-}
-
-// DecrementRefCount atomically decrements a block's RefCount.
-func (s *SQLiteMetadataStore) DecrementRefCount(ctx context.Context, id string) (uint32, error) {
-	return decrementRefCountTx(ctx, s.conn(), id)
-}
-
 // DecrementRefCountAndReap atomically decrements ref_count and, when it hits 0,
 // deletes the row — both statements run inside ONE transaction so the
 // decrement-and-reap is atomic and TOCTOU-free against a concurrent AddRef
@@ -109,149 +69,19 @@ const fileChunkColumns = `id, hash, data_size, start_offset, ref_count, last_acc
 // ON CONFLICT clause.
 const insertFileChunk = `INSERT INTO file_blocks (` + fileChunkColumns + `) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)`
 
-// getFileChunkTx reads one chunk row by ID, mapping a missing row to
-// ErrFileChunkNotFound.
-func getFileChunkTx(ctx context.Context, x execer, id string) (*metadata.FileChunk, error) {
-	row := x.QueryRow(ctx, `SELECT `+fileChunkColumns+` FROM file_blocks WHERE id = ?1`, id)
-	chunk, err := scanFileChunk(row)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, metadata.ErrFileChunkNotFound
-	}
-	if err != nil {
-		return nil, fmt.Errorf("get file chunk: %w", err)
-	}
-	return chunk, nil
-}
-
-// putFileChunkTx inserts or updates one chunk row.
-//
-// ref_count is omitted from the ON CONFLICT update list so a concurrent
-// IncrementRefCount / DecrementRefCount (atomic SQL +1 / -1 UPDATEs) cannot be
-// overwritten by a stale in-memory RefCount; the INSERT path still writes the
-// caller's value verbatim. hash uses COALESCE so a zero-hash Put never NULLs a
-// previously persisted good hash. LastSyncAttemptAt persists as NULL when zero
-// so the janitor's `last_sync_attempt_at < cutoff` predicate skips
-// never-claimed rows instead of matching every Pending row.
-func putFileChunkTx(ctx context.Context, x execer, chunk *metadata.FileChunk) error {
-	var hashStr *string
-	if !chunk.Hash.IsZero() {
-		h := chunk.Hash.String()
-		hashStr = &h
-	}
-	var lastSyncAttemptAt *time.Time
-	if !chunk.LastSyncAttemptAt.IsZero() {
-		t := chunk.LastSyncAttemptAt
-		lastSyncAttemptAt = &t
-	}
-	_, err := x.Exec(ctx, insertFileChunk+`
-		ON CONFLICT (id) DO UPDATE SET
-			hash = COALESCE(EXCLUDED.hash, file_blocks.hash),
-			data_size = EXCLUDED.data_size,
-			start_offset = EXCLUDED.start_offset,
-			last_access = EXCLUDED.last_access,
-			state = EXCLUDED.state,
-			last_sync_attempt_at = EXCLUDED.last_sync_attempt_at`,
-		chunk.ID, hashStr, chunk.DataSize, chunk.StartOffset,
-		chunk.RefCount, chunk.LastAccess, chunk.CreatedAt, chunk.State, lastSyncAttemptAt)
-	if err != nil {
-		return fmt.Errorf("put file chunk: %w", err)
-	}
-	return nil
-}
-
-// deleteFileChunkTx removes one chunk row, reporting ErrFileChunkNotFound when
-// no row matched.
-func deleteFileChunkTx(ctx context.Context, x execer, id string) error {
-	result, err := x.Exec(ctx, `DELETE FROM file_blocks WHERE id = ?1`, id)
-	if err != nil {
-		return fmt.Errorf("delete file chunk: %w", err)
-	}
-	if result.RowsAffected() == 0 {
-		return metadata.ErrFileChunkNotFound
-	}
-	return nil
-}
-
-// incrementRefCountTx bumps one chunk's ref_count by 1.
-func incrementRefCountTx(ctx context.Context, x execer, id string) error {
-	result, err := x.Exec(ctx, `UPDATE file_blocks SET ref_count = ref_count + 1 WHERE id = ?1`, id)
-	if err != nil {
-		return fmt.Errorf("increment ref count: %w", err)
-	}
-	if result.RowsAffected() == 0 {
-		return metadata.ErrFileChunkNotFound
-	}
-	return nil
-}
-
-// decrementRefCountTx drops one chunk's ref_count by 1, flooring at 0, and
-// returns the remaining count.
-func decrementRefCountTx(ctx context.Context, x execer, id string) (uint32, error) {
-	var newCount uint32
-	err := x.QueryRow(ctx,
-		`UPDATE file_blocks SET ref_count = MAX(ref_count - 1, 0) WHERE id = ?1 RETURNING ref_count`,
-		id).Scan(&newCount)
-	if errors.Is(err, sql.ErrNoRows) {
-		return 0, metadata.ErrFileChunkNotFound
-	}
-	if err != nil {
-		return 0, fmt.Errorf("decrement ref count: %w", err)
-	}
-	return newCount, nil
-}
-
-// addRefTx bumps ref_count on every Remote row carrying hash, reporting
-// ErrUnknownHash when none does.
-func addRefTx(ctx context.Context, x execer, hash block.ContentHash) error {
-	result, err := x.Exec(ctx,
-		`UPDATE file_blocks SET ref_count = ref_count + 1 WHERE hash = ?1 AND state = 2 /* Remote */`,
-		hash.String())
-	if err != nil {
-		return fmt.Errorf("add ref: %w", err)
-	}
-	if result.RowsAffected() == 0 {
-		return metadata.ErrUnknownHash
-	}
-	return nil
-}
-
-// getByHashTx resolves a Remote chunk by content hash, returning (nil, nil)
-// when none matches.
-func getByHashTx(ctx context.Context, x execer, hash metadata.ContentHash) (*metadata.FileChunk, error) {
-	row := x.QueryRow(ctx, `SELECT `+fileChunkColumns+` FROM file_blocks WHERE hash = ?1 AND state = 2 /* Remote */`, hash.String())
-	chunk, err := scanFileChunk(row)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("find file chunk by hash: %w", err)
-	}
-	return chunk, nil
-}
-
-// decrementAndReapTx runs the -1 UPDATE then a conditional DELETE. The
-// `ref_count = 0` predicate on the DELETE means a bump that landed between the
-// two statements leaves the row alive. Returns (0, nil) for an already-swept
-// row rather than ErrFileChunkNotFound.
-func decrementAndReapTx(ctx context.Context, tx execer, id string) (uint32, error) {
-	var newCount uint32
-	err := tx.QueryRow(ctx,
-		`UPDATE file_blocks SET ref_count = MAX(ref_count - 1, 0) WHERE id = ?1 RETURNING ref_count`,
-		id).Scan(&newCount)
-	if errors.Is(err, sql.ErrNoRows) {
-		return 0, nil // tolerate already-swept row
-	}
-	if err != nil {
-		return 0, fmt.Errorf("decrement ref count: %w", err)
-	}
-	if newCount == 0 {
-		if _, err := tx.Exec(ctx,
-			`DELETE FROM file_blocks WHERE id = ?1 AND ref_count = 0`, id); err != nil {
-			return 0, fmt.Errorf("reap zero-ref block: %w", err)
-		}
-	}
-	return newCount, nil
-}
+// putFileChunkQuery omits ref_count from the ON CONFLICT update list so a
+// concurrent IncrementRefCount / DecrementRefCount (atomic SQL +1 / -1 UPDATEs)
+// cannot be overwritten by a stale in-memory RefCount; the INSERT path still
+// writes the caller's value verbatim. hash uses COALESCE so a zero-hash Put
+// never NULLs a previously persisted good hash.
+const putFileChunkQuery = insertFileChunk + `
+	ON CONFLICT (id) DO UPDATE SET
+		hash = COALESCE(EXCLUDED.hash, file_blocks.hash),
+		data_size = EXCLUDED.data_size,
+		start_offset = EXCLUDED.start_offset,
+		last_access = EXCLUDED.last_access,
+		state = EXCLUDED.state,
+		last_sync_attempt_at = EXCLUDED.last_sync_attempt_at`
 
 // AddRef atomically bumps RefCount on the FileChunk row(s) indexed by
 // the given content hash. Implements the FileChunkStore.AddRef contract
@@ -290,15 +120,7 @@ func (s *SQLiteMetadataStore) AddRef(ctx context.Context, hash block.ContentHash
 	// not a valid dedup donor, so AddRef must miss it and return
 	// ErrUnknownHash exactly as before, letting the caller fall back to
 	// the full Put path.
-	return addRefTx(ctx, s.conn(), hash)
-}
-
-// GetByHash looks up a finalized block by its content hash.
-// Returns nil without error if not found. Dedup matches only Remote
-// (state=2) blocks — Pending or Syncing rows have not been confirmed on
-// the remote and are unsafe dedup targets.
-func (s *SQLiteMetadataStore) GetByHash(ctx context.Context, hash metadata.ContentHash) (*metadata.FileChunk, error) {
-	return getByHashTx(ctx, s.conn(), hash)
+	return s.Core.AddRef(ctx, hash)
 }
 
 // listFileChunksQuery takes the bounds of block.PayloadPrefixRange and is a
@@ -312,23 +134,6 @@ const listFileChunksQuery = `SELECT ` + fileChunkColumns + `
 	FROM file_blocks
 	WHERE id >= ?1 COLLATE BINARY AND id < ?2 COLLATE BINARY
 	ORDER BY id COLLATE BINARY ASC`
-
-// ListFileChunks returns all blocks belonging to a file, ordered by block index.
-// Not on the narrowed FileChunkStore interface;
-// kept as a backend method for engine-internal callers.
-func (s *SQLiteMetadataStore) ListFileChunks(ctx context.Context, payloadID string) ([]*metadata.FileChunk, error) {
-	lo, hi := block.PayloadPrefixRange(payloadID)
-	rows, err := s.query(ctx, listFileChunksQuery, lo, hi)
-	if err != nil {
-		return nil, fmt.Errorf("list file chunks: %w", err)
-	}
-	defer rows.Close()
-	result, err := scanFileChunkRows(rows)
-	if err != nil {
-		return nil, err
-	}
-	return block.ChunksForPayload(result, payloadID), nil
-}
 
 // enumerateHashesQuery is the GC mark live-set query. It UNIONs the CAS index
 // (file_blocks.hash, VARCHAR hex) with the per-file manifest
@@ -438,90 +243,9 @@ func (s *SQLiteMetadataStore) collectFileChunkIDs(ctx context.Context, query str
 	return ids, nil
 }
 
-// EnumerateFileChunks streams every live-set ContentHash through fn, unioning
-// the CAS index with the per-file manifest (see enumerateHashesQuery).
-func (s *SQLiteMetadataStore) EnumerateFileChunks(ctx context.Context, fn func(block.ContentHash) error) error {
-	rows, err := s.query(ctx, enumerateHashesQuery)
-	if err != nil {
-		return fmt.Errorf("enumerate file chunks: query: %w", err)
-	}
-	defer rows.Close()
-	for rows.Next() {
-		if err := ctx.Err(); err != nil {
-			return fmt.Errorf("enumerate file chunks: %w", err)
-		}
-		var hashStr sql.NullString
-		if err := rows.Scan(&hashStr); err != nil {
-			return fmt.Errorf("enumerate file chunks: scan: %w", err)
-		}
-		var h block.ContentHash
-		if hashStr.Valid {
-			parsed, perr := metadata.ParseContentHash(hashStr.String)
-			if perr != nil {
-				// (mark fail-closed): a malformed hash row
-				// cannot be silently coerced to the zero hash — that would
-				// invite the GC mark phase to treat the row as a legacy
-				// pre-CAS entry and the sweep would reap a still-live CAS
-				// object once the grace TTL lapses. Surface the parse error
-				// so EnumerateFileChunks aborts and the sweep is skipped.
-				return fmt.Errorf("enumerate file chunks: parse hash %q: %w",
-					hashStr.String, perr)
-			}
-			h = parsed
-		}
-		if err := fn(h); err != nil {
-			return err
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("enumerate file chunks: rows: %w", err)
-	}
-	return nil
-}
-
 // ============================================================================
 // Scan Helpers
 // ============================================================================
-
-// scanFileChunk scans a single row into a FileChunk.
-func scanFileChunk(row scanRow) (*metadata.FileChunk, error) {
-	var (
-		block             metadata.FileChunk
-		hashStr           sql.NullString
-		lastSyncAttemptAt sql.NullTime
-	)
-	if err := row.Scan(&block.ID, &hashStr, &block.DataSize, &block.StartOffset,
-		&block.RefCount, &block.LastAccess, &block.CreatedAt, &block.State, &lastSyncAttemptAt); err != nil {
-		return nil, err
-	}
-	if hashStr.Valid {
-		// do not silently coerce malformed CAS hashes to the
-		// zero hash — see EnumerateFileChunks for the data-loss scenario.
-		h, perr := metadata.ParseContentHash(hashStr.String)
-		if perr != nil {
-			return nil, fmt.Errorf("scan file chunk %s: parse hash %q: %w",
-				block.ID, hashStr.String, perr)
-		}
-		block.Hash = h
-	}
-	if lastSyncAttemptAt.Valid {
-		block.LastSyncAttemptAt = lastSyncAttemptAt.Time
-	}
-	return &block, nil
-}
-
-// scanFileChunkRows scans multiple rows into FileChunk slices.
-func scanFileChunkRows(rows scanRows) ([]*metadata.FileChunk, error) {
-	var result []*metadata.FileChunk
-	for rows.Next() {
-		block, err := scanFileChunk(rows)
-		if err != nil {
-			return nil, fmt.Errorf("scan file chunk: %w", err)
-		}
-		result = append(result, block)
-	}
-	return result, rows.Err()
-}
 
 // ============================================================================
 // Transaction Support
@@ -536,38 +260,6 @@ var _ block.FileChunkStore = (*sqliteTransaction)(nil)
 // that bumped RefCount inside WithTransaction and then hit a downstream
 // UpdateAttrs failure would leak the bump.
 
-func (tx *sqliteTransaction) GetFileChunk(ctx context.Context, id string) (*metadata.FileChunk, error) {
-	return getFileChunkTx(ctx, tx.tx, id)
-}
-
-func (tx *sqliteTransaction) Put(ctx context.Context, block *metadata.FileChunk) error {
-	return putFileChunkTx(ctx, tx.tx, block)
-}
-
-func (tx *sqliteTransaction) Delete(ctx context.Context, id string) error {
-	return deleteFileChunkTx(ctx, tx.tx, id)
-}
-
-// IncrementRefCount bumps ref_count on the active transaction so a subsequent
-// rollback undoes it. Production callers reach here through
-// metadataCoordinator.IncrementRefCount when ctx carries an active tx.
-func (tx *sqliteTransaction) IncrementRefCount(ctx context.Context, id string) error {
-	return incrementRefCountTx(ctx, tx.tx, id)
-}
-
-// DecrementRefCount drops ref_count on the active transaction so a subsequent
-// rollback undoes it.
-func (tx *sqliteTransaction) DecrementRefCount(ctx context.Context, id string) (uint32, error) {
-	return decrementRefCountTx(ctx, tx.tx, id)
-}
-
-// DecrementRefCountAndReap runs the -1 UPDATE and the reap-at-zero DELETE on
-// the active transaction so a subsequent rollback undoes both. Returns
-// (0, nil) when the row is already absent.
-func (tx *sqliteTransaction) DecrementRefCountAndReap(ctx context.Context, id string) (uint32, error) {
-	return decrementAndReapTx(ctx, tx.tx, id)
-}
-
 // AddRef bumps ref_count keyed by hash on the active transaction so a
 // subsequent rollback undoes it. Returns metadata.ErrUnknownHash when no row
 // matches.
@@ -575,11 +267,7 @@ func (tx *sqliteTransaction) AddRef(ctx context.Context, hash block.ContentHash,
 	// payloadID + blockRef accepted for future GC traceability;
 	// postgres backend records ref count only — parameters intentionally
 	// blanked.
-	return addRefTx(ctx, tx.tx, hash)
-}
-
-func (tx *sqliteTransaction) GetByHash(ctx context.Context, hash metadata.ContentHash) (*metadata.FileChunk, error) {
-	return getByHashTx(ctx, tx.tx, hash)
+	return tx.Core.AddRef(ctx, hash)
 }
 
 // ListFileChunks / EnumerateFileChunks run on the active
@@ -588,52 +276,6 @@ func (tx *sqliteTransaction) GetByHash(ctx context.Context, hash metadata.Conten
 // followed by a List in the same WithTransaction would miss the pending row
 // (read-after-write violation; the SQL is otherwise identical to the
 // store-level methods).
-
-func (tx *sqliteTransaction) ListFileChunks(ctx context.Context, payloadID string) ([]*metadata.FileChunk, error) {
-	lo, hi := block.PayloadPrefixRange(payloadID)
-	rows, err := tx.tx.Query(ctx, listFileChunksQuery, lo, hi)
-	if err != nil {
-		return nil, fmt.Errorf("list file chunks: %w", err)
-	}
-	defer rows.Close()
-	result, err := scanFileChunkRows(rows)
-	if err != nil {
-		return nil, err
-	}
-	return block.ChunksForPayload(result, payloadID), nil
-}
-
-func (tx *sqliteTransaction) EnumerateFileChunks(ctx context.Context, fn func(block.ContentHash) error) error {
-	rows, err := tx.tx.Query(ctx, enumerateHashesQuery)
-	if err != nil {
-		return fmt.Errorf("enumerate file chunks: query: %w", err)
-	}
-	defer rows.Close()
-	for rows.Next() {
-		if err := ctx.Err(); err != nil {
-			return fmt.Errorf("enumerate file chunks: %w", err)
-		}
-		var hashStr sql.NullString
-		if err := rows.Scan(&hashStr); err != nil {
-			return fmt.Errorf("enumerate file chunks: scan: %w", err)
-		}
-		var h block.ContentHash
-		if hashStr.Valid {
-			parsed, perr := metadata.ParseContentHash(hashStr.String)
-			if perr != nil {
-				return fmt.Errorf("enumerate file chunks: parse hash %q: %w", hashStr.String, perr)
-			}
-			h = parsed
-		}
-		if err := fn(h); err != nil {
-			return err
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("enumerate file chunks: rows: %w", err)
-	}
-	return nil
-}
 
 // The file_blocks table schema lives in
 // pkg/metadata/store/postgres/migrations/000010_file_blocks.up.sql.

--- a/pkg/metadata/store/sqlite/objects_rollback_test.go
+++ b/pkg/metadata/store/sqlite/objects_rollback_test.go
@@ -1,0 +1,77 @@
+package sqlite_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/sqlite"
+)
+
+// TestTransactionChunkWritesRollBack pins the reason a transaction embeds its
+// own executor over the open transaction rather than reusing the store's pool
+// one.
+//
+// A write that reached the pool instead would run on a separate connection,
+// commit independently, and survive the enclosing transaction's rollback. The
+// rest of the suite never notices, because every other test commits: a chunk
+// written to the pool is indistinguishable from one written to a committed
+// transaction. On SQLite the mistake is even quieter to diagnose — the pool
+// write blocks on the write lock the transaction is holding, so it presents as
+// a hang rather than a wrong answer.
+func TestTransactionChunkWritesRollBack(t *testing.T) {
+	ctx := context.Background()
+	store, err := sqlite.NewSQLiteMetadataStore(ctx,
+		&sqlite.SQLiteMetadataStoreConfig{Path: t.TempDir() + "/m.db", AutoMigrate: true},
+		sqliteTestCapabilities())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const chunkID = "rollback-probe/0"
+	sum := sha256.Sum256([]byte("rollback-probe"))
+	var hash block.ContentHash
+	copy(hash[:], sum[:])
+
+	now := time.Now().UTC().Truncate(time.Second)
+	chunk := &metadata.FileChunk{
+		ID:          chunkID,
+		Hash:        hash,
+		DataSize:    64,
+		StartOffset: 0,
+		RefCount:    1,
+		LastAccess:  now,
+		CreatedAt:   now,
+		State:       block.BlockStateRemote,
+	}
+
+	sentinel := errors.New("roll this back")
+	err = store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		if putErr := tx.Put(ctx, chunk); putErr != nil {
+			return putErr
+		}
+		// Read-your-writes: the row must be visible inside the transaction that
+		// wrote it, which only holds if the write went to the transaction.
+		got, getErr := tx.GetFileChunk(ctx, chunkID)
+		if getErr != nil {
+			return getErr
+		}
+		if got.ID != chunkID {
+			t.Errorf("in-transaction read got id %q, want %q", got.ID, chunkID)
+		}
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("WithTransaction error = %v, want the sentinel", err)
+	}
+
+	// The rollback must have taken the chunk with it.
+	if _, err := store.GetFileChunk(ctx, chunkID); !errors.Is(err, metadata.ErrFileChunkNotFound) {
+		t.Fatalf("chunk survived a rolled-back transaction (err = %v) — the write escaped to the pool", err)
+	}
+}

--- a/pkg/metadata/store/sqlite/store.go
+++ b/pkg/metadata/store/sqlite/store.go
@@ -21,6 +21,8 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sharecache"
+
+	storesql "github.com/marmos91/dittofs/pkg/metadata/store/sql"
 )
 
 // sqliteDriverName is the database/sql driver name registered by the imported
@@ -33,6 +35,13 @@ const sqliteDriverName = "sqlite"
 // hard-link model (parent_child_map + nlink), and object_id dedup index are all
 // preserved, with SQL adapted to the SQLite dialect.
 type SQLiteMetadataStore struct {
+	// Core carries the executor and dialect the shared SQL bodies run on, and
+	// promotes those bodies onto this type so they exist once for both
+	// backends. Embedded by pointer: the transaction embeds its own Core over
+	// the open transaction, and nothing is shared between the two but the
+	// dialect.
+	*storesql.Core
+
 	// db is the database/sql handle over the single SQLite file. SQLite is a
 	// single-writer engine; the pool is bounded to keep contention predictable.
 	db *sql.DB
@@ -154,6 +163,9 @@ func NewSQLiteMetadataStore(
 		cancel:       cancel,
 		quota:        basestore.NewQuotaCache(),
 	}
+	// The shared SQL bodies run on the pool for store-level calls.
+	store.Core = &storesql.Core{X: store.conn(), D: sqliteDialect}
+
 	// The substores derive only from db, which is never reassigned, so bind
 	// them once here.
 	store.lockStore = newSQLiteLockStore(store.conn())

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -16,6 +16,8 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlcodec"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/txretry"
+
+	storesql "github.com/marmos91/dittofs/pkg/metadata/store/sql"
 )
 
 // Transaction retry policy (#1769). Under write contention DittoFS must
@@ -40,6 +42,11 @@ import (
 // tx is the pgx-shaped executor (QueryRow/Query/Exec with (ctx, sql, args...))
 // over the underlying *sql.Tx, so the ported query bodies use it unchanged.
 type sqliteTransaction struct {
+	// Core runs the shared SQL bodies on THIS transaction, not the pool. A
+	// body reached through the pool would run on a separate connection and
+	// survive this transaction's rollback.
+	*storesql.Core
+
 	store *SQLiteMetadataStore
 	tx    execer
 	// quota accumulates usage changes (bytes + file count) keyed by share and
@@ -93,6 +100,7 @@ func (s *SQLiteMetadataStore) WithTransaction(ctx context.Context, fn func(tx me
 		}
 
 		ptx := &sqliteTransaction{store: s, tx: execer{e: rawTx, op: "tx"}}
+		ptx.Core = &storesql.Core{X: ptx.tx, D: sqliteDialect}
 		if err := fn(ptx); err != nil {
 			_ = rawTx.Rollback()
 			if isBusyError(err) {

--- a/pkg/metadata/store/sqlite/xattr.go
+++ b/pkg/metadata/store/sqlite/xattr.go
@@ -7,9 +7,9 @@ import (
 )
 
 // Extended-attribute (xattr) operations delegate to the shared resolver in
-// pkg/metadata/xattr.go over the Files interface. Both the Postgres store and
-// its transaction satisfy metadata.Files, so the same Resolve* helpers serve
-// both. Inline values ride the existing eas JSONB column.
+// pkg/metadata/xattr.go over the Files interface. Both this store and its
+// transaction satisfy metadata.Files, so the same Resolve* helpers serve both.
+// Inline values ride the existing eas column.
 
 // GetXattr implements metadata.Files.
 func (s *SQLiteMetadataStore) GetXattr(ctx context.Context, handle metadata.FileHandle, name string) ([]byte, bool, error) {


### PR DESCRIPTION
Track-S stage from the #1828 plan, stacked on #2226. This is the stage that decides the shape everything after it rides on, so it is deliberately small in surface and thorough in verification.

## What it creates

`store/sql.Core` — the shared half of a SQL-backed store: an `Executor` to run statements on, and a `Dialect` supplying their text and classifying their errors. Both dialect stores and both dialect transactions embed one **by pointer, anonymously**, so the eleven chunk-store operations exist once instead of four times each (store + transaction, times two dialects).

Embedding by pointer is what keeps the durability asymmetry the plan worries about a *compile-time* fact rather than a comment: a dialect that must not advertise an optional interface simply never declares the method, and no shared type can hand it one by accident. A dialect that needs different behaviour (postgres's store-level `DecrementRefCountAndReap`, which wraps `WithTransaction`) declares its own method and shadows the promoted one.

## A deviation from the plan, and why

The plan proposed proving the embedding on `xattr.go` — 52/52 byte-identical, the cheapest possible subject. I confirmed the 52/52 claim, then dropped it: `xattr.go` is eight one-line delegations into `metadata.Resolve*Xattr`, passing the store itself as a `metadata.Files`. There is no logic to merge, and hoisting it requires the core to *already* implement `metadata.Files` — which is S3/S4's job. Hoisting it now would need a back-reference from the core to the outer store purely as scaffolding for an ordering constraint.

The chunk store is the honest first subject instead: real bodies, and it exercises the seam where it actually bites.

## What that surfaced

**The plan's Dialect seam was missing a hook.** The two dialects differ in *three* ways, not the two the plan enumerated:

1. the executor type — solved in #2225;
2. SQL text (`?N` vs `$N`, `MAX` vs `GREATEST`, `BINARY` vs `"C"` collation) — per-dialect constants, as planned;
3. **the driver's empty-result sentinel** — `sql.ErrNoRows` vs `pgx.ErrNoRows`.

A shared body cannot compare against either, and getting it wrong turns "absent" into a hard error rather than the not-found every caller expects. So `Dialect` carries `IsNoRows` alongside the statement table. Better to find that here than in S4's 1,188-line port.

Error *mapping* and retryability stay on each dialect's `errors.go`, exactly as planned — there is no merged `errors.go` and there was never meant to be one.

I also checked the one place the two upserts could have hidden a behavioural difference: both use `COALESCE(EXCLUDED.hash, ...)`, so a zero-hash `Put` preserves a previously persisted hash on **both** backends. Same semantics, different placeholder syntax.

## Verification

Both engines, **postgres 16.15 live** (DSN matching CI's), baselined against the parent commit first:

- `go build ./... && go vet ./pkg/metadata/...`
- `go test -count=1 -tags=integration -p 1 ./pkg/metadata/...` — green
- `go test -count=1 -race ./pkg/metadata/store/...` — green, all four backends

**Mutation test of the design's core invariant** — that a transaction's `Core` runs on the transaction, not the pool:

| mutation | result |
|---|---|
| postgres transaction `Core` points at the pool | CAUGHT by the suite |
| sqlite transaction `Core` points at the pool | **deadlocks** on the write lock rather than failing |

The sqlite case is the nastier one: the mistake presents as a hang, not a wrong answer. `TestTransactionChunkWritesRollBack` now pins it explicitly for sqlite too, so it fails loudly.

Net −149 lines, with `postgres/objects.go` down 745→301 and `sqlite/objects.go` down to 337 — what remains in each is genuinely dialect-specific (postgres's `= ANY($1)` batch reap, the payload-enumeration helpers, the test-only injector).
