### PR TITLE
docs(internals): RFC — split the block data flow into pier, crane and ferry

### DIFF
--- a/.planning/2026-09-01-block-dataflow-MASTER-PLAN.md
+++ b/.planning/2026-09-01-block-dataflow-MASTER-PLAN.md
@@ -1,12 +1,18 @@
 # Master plan — block data-flow: audit findings + pier/crane/ferry refactor
 
-Status: **FOR DISCUSSION.** No code written. HIGH findings filed as #2227-#2231.
+Status: **FOR DISCUSSION.** No code written. HIGH findings filed as #2227-#2231 and **#2238**.
 
-Inputs, both authoritative, neither superseded by this document:
-- `2026-09-01-journal-audit-report.md` — 59 verified findings (6 HIGH / 8 MED / 45 LOW), 70 agents, 7 lenses, adversarially verified.
+Inputs, all authoritative, none superseded by this document:
+- `2026-09-01-journal-audit-report.md` — 59 findings (6 HIGH / 8 MED / 45 LOW), 70 agents.
+- `2026-09-01-engine-audit-report.md` — 66 findings (1 HIGH / 13 MED / 52 LOW), 89 agents.
+- `2026-09-01-block-root-audit-report.md` — 22 findings (0 HIGH / 2 MED / 20 LOW), 45 agents.
 - `2026-09-01-pier-library-design-PLAN.md` — the target design (state model, three interfaces, folder structure, test/bench contracts).
 
-Baseline: `ff14b24cb` (origin/develop). Audit tree: `~/dittofs-worktrees/audit-journal` (immutable).
+All three audits ran 7 lenses and an adversarial verify gate. **196 findings over 19,632 LOC.**
+
+Baselines: journal at `ff14b24cb`, engine and root at `4ec814bc2` — so **journal findings must be
+re-verified before action**. Audit trees: `~/dittofs-worktrees/audit-journal` and
+`~/dittofs-worktrees/audit-engine`, both immutable.
 
 ---
 
@@ -25,6 +31,15 @@ That is the same signature as the entire prior field history (#1850, #1879, #188
 A design that makes that class unrepresentable is worth the disruption; one that merely
 re-tidies the same model is not.
 
+**Two qualifications this verdict has to carry, both from §12.** First, #2238 is an eleventh
+incident of the class but a *different mechanism*: a time-of-check/time-of-use race rather than a
+disagreement at rest. Making states explicit is necessary and not sufficient — the model must
+also pin **transitions under concurrency**. Second, and more uncomfortable: the extraction moves
+roughly 500 of engine's 11,304 LOC, and #2238 lives in `gc_sweep_index.go`, which does not move.
+The refactor does not reach the newest instance of the class it is justified by. That is an
+argument for doing §3d's work before the API boundary hardens — not against the split, but the
+verdict overstates its reach if read alone.
+
 Corroborating the extraction case specifically:
 - `RemoteStore`/`BlockID` are entirely dead — never implemented, never read, `nil` at the one
   production call site. The remote seam pier *actually* has is inbound-only (`Fill`), which is
@@ -32,7 +47,7 @@ Corroborating the extraction case specifically:
 - Import coupling is trivial: 11 `logger.Warn`, 2 `block.ErrFutureFormat`, one `blake3` call.
 - Semantic coupling is real but localised: three type-asserted manifest interfaces, all in carve.
 
-## 2. The five HIGH findings
+## 2. The five journal HIGH findings
 
 | # | Issue | Finding | Where | Model |
 |---|---|---|---|---|
@@ -87,7 +102,7 @@ Fix nothing here separately; the design eliminates the class.
 | `doc.go`'s false stdlib/two-interfaces claim | design-plan §8.1 import-graph **test** — a claim that cannot rot |
 | Dead API: `RemoteStore`, `BlockID`, `PinVersion`, `SegmentLocation`, `GC` | deleted; `RemoteStore` becomes `ferry.Store` |
 | Three type-asserted manifest interfaces | evaporate: one becomes `DurableTail`, two become the caller calling itself |
-| `store.go` 1297 / `reclaim.go` 999 / `carve.go` 995 | §6.2 file layout |
+| `store.go` 1297 / `reclaim.go` 999 / `carve.go` 995 | design-plan §6.2 file layout |
 | `segment.go`/`index.go` holding the hot paths their names disown | `write.go` / `read.go` |
 | Two files named `carve_dispatch.go` | one `ferry` |
 | Six near-duplicate test store-openers | one harness in `piertest/` |
@@ -100,16 +115,16 @@ These do not exist today. The design introduces them and must close them.
 
 | Risk | Mitigation | Source |
 |---|---|---|
-| A free-form `durable []Extent` lets a buggy `fn` flip a range pier never offered — today's `flipIdx` cursor makes that structurally impossible | pier validates every returned extent against the offered-and-unflipped set, matching on **(offset, length, version)** — offset alone would flip new bytes when old ones were uploaded, which is the #1872 shape | §4.1 C4 |
-| Reap outside the flush lock deletes the *next* pass's row — on a **2-second cadence**, not adversarial timing | `FlushOptions.AfterFile`, under the lock. **Mandatory** | §4.2 |
-| Concurrent `fn` calls race over block boundaries | `fn` called strictly sequentially; ALL upload concurrency lives in ferry | §4.1 C1 |
-| `DurableTail` computed eagerly per file loses the per-run cost property | computed lazily, per call | §4.1 C3 |
+| A free-form `durable []Extent` lets a buggy `fn` flip a range pier never offered — today's `flipIdx` cursor makes that structurally impossible | pier validates every returned extent against the offered-and-unflipped set, matching on **(offset, length, version)** — offset alone would flip new bytes when old ones were uploaded, which is the #1872 shape | design-plan §4.1 C4 |
+| Reap outside the flush lock deletes the *next* pass's row — on a **2-second cadence**, not adversarial timing | `FlushOptions.AfterFile`, under the lock. **Mandatory** | design-plan §4.2 |
+| Concurrent `fn` calls race over block boundaries | `fn` called strictly sequentially; ALL upload concurrency lives in ferry | design-plan §4.1 C1 |
+| `DurableTail` computed eagerly per file loses the per-run cost property | computed lazily, per call | design-plan §4.1 C3 |
 | `Extents()` collapsing five queries regresses the hot path | `Size` and `DurableExtent` stay separate methods; benchmark and keep receipts | review finding |
-| `fn` erroring skips the reap, stranding superseded rows that DID commit | on error pier flips validated extents and **still calls `AfterFile`** | §4.1 C5 |
-| Deferred credit bunches most flips onto the `Final` call on upload-bound files | accepted; must be **measured** (residency + time-to-flip vs today) before code | §4.4 |
-| A shared `ferry.Completions()` channel routes one file's upload completion to another file's callback — many files flush concurrently and `Submit` carries no `FileID` — silently losing durability credit | `Submit` returns a **per-call future**; no shared stream exists | §4.1 C3 |
-| Whole-extent credit matching forfeits a whole run when one unrelated byte moves — the common case on scattered writes, since `splitRuns` groups by offset only | validate and flip **per fragment**, mirroring `flipUpTo` | §4.1 C4 |
-| One `crane.Boxer` hoisted to `Syncer` lifetime interleaves two files' bytes into one block — **cross-file corruption**, and pier cannot detect it | stated caller obligation: `fn` and its accumulator constructed fresh per `Flush` | §4.1 C9 |
+| `fn` erroring skips the reap, stranding superseded rows that DID commit | on error pier flips validated extents and **still calls `AfterFile`** | design-plan §4.1 C5 |
+| Deferred credit bunches most flips onto the `Final` call on upload-bound files | accepted; must be **measured** (residency + time-to-flip vs today) before code | design-plan §4.4 |
+| A shared `ferry.Completions()` channel routes one file's upload completion to another file's callback — many files flush concurrently and `Submit` carries no `FileID` — silently losing durability credit | `Submit` returns a **per-call future**; no shared stream exists | design-plan §4.1 C3 |
+| Whole-extent credit matching forfeits a whole run when one unrelated byte moves — the common case on scattered writes, since `splitRuns` groups by offset only | validate and flip **per fragment**, mirroring `flipUpTo` | design-plan §4.1 C4 |
+| One `crane.Boxer` hoisted to `Syncer` lifetime interleaves two files' bytes into one block — **cross-file corruption**, and pier cannot detect it | **superseded by §11**: `harbour`'s per-`Flush` factory constructs the accumulator inside the closure, so a hoisted one is unrepresentable rather than merely forbidden | design-plan §4.1 C9 |
 
 ## 4. Sequencing
 
@@ -382,7 +397,7 @@ open-questions space, linking to it. **Discussions is currently disabled** on th
   **This also cheapens step 4 substantially** — see §4.
 
 
-## 10. The external API — what the runtime calls
+## 9. The external API — what the runtime calls
 
 Everything above is internal shape. This section fixes the surface DittoFS's control plane and
 protocol adapters actually call when a read or write handler touches a file. It is written last
@@ -513,12 +528,12 @@ Two rules, both forcing functions rather than aesthetics:
 ### 10.7 One integration test and one benchmark for the whole ingestion path
 
 Per §6.1 each module tests itself, but **composition is DittoFS's job**, and the ingestion path
-has never been exercised end to end in one place. Add exactly one of each, both driving the §10.3
+has never been exercised end to end in one place. Add exactly one of each, both driving the §9.3
 API in the shape an adapter drives it:
 
 - **Integration test** — adapter-shaped writes (unstable, then a range `Commit`) through
   `WriteAt → pier → crane → ferry → remote`, asserting the **residency transition after every
-  step** via §10.4's `Extents`, not just the final bytes. It must cover: unstable write leaves
+  step** via §9.4's `Extents`, not just the final bytes. It must cover: unstable write leaves
   `Dirty`; commit moves to `Synced`; eviction moves to `Cold`; a cold read faults back in; and a
   deliberately corrupted remote produces `Lost` **with an error**, never zeros. That last case is
   the one no existing test covers and the one that has shipped five times.
@@ -528,9 +543,9 @@ API in the shape an adapter drives it:
 
 Both live in DittoFS, not in a module: they test the seam, and the seam is what the split creates.
 
-## 11. Format migration
+## 10. Format migration
 
-Deferred from §14 open question 3 and now decided. This replaces that entry.
+Deferred from §13 open question 3 and now decided. This replaces that entry.
 
 ### 11.1 Compatibility classes, not a version number
 
@@ -610,7 +625,7 @@ transactional row update there, not an object write. This fences the reachable c
 share a bucket share a metadata store within one deployment.
 
 It does **not** fence two independent deployments pointed at one bucket. The answer to that is
-refusal, not emulation — §11.5 already makes major migrations an explicit operator action, and
+refusal, not emulation — §10.5 already makes major migrations an explicit operator action, and
 the runner states plainly that it cannot detect a second deployment.
 
 **Conditional PUT is hardening, not the foundation.** `PutObjectInput` in
@@ -649,12 +664,12 @@ cas→blocks pass runs backgrounded on every boot with no operator involvement.
 
 D4 says delete legacy paths rather than build scaffolding for users who do not exist, and it still
 holds — this machine is **not** a reason to keep any of §4's legacy surface. The two are about
-different things: D4 governs *this* cleanup, §11 governs *future* format changes, and its first
+different things: D4 governs *this* cleanup, §10 governs *future* format changes, and its first
 migration should be written when a real format change needs one, not speculatively. What ships
 with the refactor is the stamp, the three classes, the registry and the gate — the parts that must
 exist before the first migration, and no migrations at all.
 
-## 12. `harbour` — the assembly
+## 11. `harbour` — the assembly
 
 pier, crane and ferry are three libraries; something must wire them. Today §6.2 assigns that to
 `dittofs/pkg/block/engine`. Moving the wiring into the library set makes the trio testable and
@@ -693,19 +708,19 @@ harbour/
 **The name is load-bearing.** A harbour is the *place* a pier, its cranes and its ferries sit —
 not an actor. `harbourmaster` was the closer fit for "sequences the three" and was rejected for
 exactly that reason: a harbourmaster has authority, and a package named for authority invites the
-policy drift §12 exists to prevent. If someone proposes adding a decision to `harbour`, the name
+policy drift §11 exists to prevent. If someone proposes adding a decision to `harbour`, the name
 itself is the argument against it.
 
 **D10. The assembly is `harbour`**, ships with the library set, and holds no policy.
 
-§10.7's ingestion integration test and benchmark move here, since this is the smallest thing that
+§9.7's ingestion integration test and benchmark move here, since this is the smallest thing that
 can run the whole path without DittoFS in the tree.
 
-### D5-D10 — migration and assembly (§11, §12)
+### D5-D10 — migration and assembly (§10, §11)
 
 - **D5. Scope is the block store only.** The four metadata backends keep their existing schema
   handling. The block format is the one that has actually churned twice.
-- **D6. Compatibility classes, not a version integer**, and the runner/substrate split of §11.3
+- **D6. Compatibility classes, not a version integer**, and the runner/substrate split of §10.3
   is committed: one runner, `pier.Substrate` and `ferry.Substrate`, three injected primitives.
 - **D7. Revert means abort-in-progress and undo pre-contract only.** No downgrade of a completed
   destructive migration. `Down` is optional and its absence is a stated fact.
@@ -713,7 +728,7 @@ can run the whole path without DittoFS in the tree.
 - **D9. The remote fence lives in the metadata store**, not the bucket. Client-side CAS is
   forbidden. Conditional PUT is defence in depth where the backend supports it.
 
-## 13. Merged audit results — journal + engine + block root
+## 12. Merged audit results — journal + engine + block root
 
 Three audits, one rubric. `pkg/block/journal` (2026-09-01, baseline `ff14b24cb`),
 `pkg/block/engine` and `pkg/block` root (both at `4ec814bc2`). Reports:
@@ -750,7 +765,7 @@ log success.
 **Why this matters beyond one bug.** The journal audit's five HIGHs were state *disagreements at
 rest* — two views of the same byte, out of sync. This one is a **time-of-check/time-of-use race**:
 every view is individually correct, and the defect is that they are read at different instants
-while a writer moves between them. The five-state model in §10.4 is necessary but not sufficient;
+while a writer moves between them. The five-state model in §9.4 is necessary but not sufficient;
 it needs **transitions under concurrency**, not just states. Fold that into `piertest`'s state
 table — every transition needs a concurrent-writer case, not only a sequential one.
 
@@ -784,7 +799,7 @@ together. Both single-package audits, by construction, saw a coherent fragment.
 Deleting is consistent with "no production stores, delete eagerly", and removes the UNIQUE index
 that is the only thing the collision can currently hurt. Finishing it requires fixing
 `ComputeObjectID` first — mixing `Size`/`StartOffset` into the digest and bumping the domain
-prefix — which makes it **§11's first real migration customer**.
+prefix — which makes it **§10's first real migration customer**.
 
 ### 13.3 The uncomfortable conclusion about scope
 
@@ -814,9 +829,9 @@ the boundary hardens**, while the code is still one package and a cross-cutting 
 
 Three defects span packages, and each was invisible to at least one audit:
 
-1. **The ObjectID/dedup scaffolding** — §13.2. Spans `pkg/block`, `pkg/metadata`,
+1. **The ObjectID/dedup scaffolding** — §12.2. Spans `pkg/block`, `pkg/metadata`,
    `pkg/controlplane`, and the architecture doc.
-2. **The GC resurrection race** — §13.1. The dedup oracle is in `engine/blocksink.go`; the marker
+2. **The GC resurrection race** — §12.1. The dedup oracle is in `engine/blocksink.go`; the marker
    lifecycle is in `pkg/metadata`'s `SyncedHashStore`. Neither half is wrong alone.
 3. **DEALLOCATE's two-phase punch** (`pkg/metadata/sparse.go:99`, MED). The manifest prune commits
    durably **before** `blockStore.PunchHole` zeroes the bytes, with no compensating write. Phase
@@ -829,15 +844,15 @@ Three defects span packages, and each was invisible to at least one audit:
 1. **Filed as #2238.** Add it to step 0 alongside #2227-#2231. The cheap fix is to re-arm `syncedAt` on a dedup hit, so the existing grace gate covers the
    resurrection window; the correct fix is to revalidate liveness inside the transaction that
    deletes the marker.
-2. Decide §13.2: finish the dedup feature or delete its scaffolding.
-3. Delete the retired local-GC machinery (see §10.1) — dead since the journal switchover.
+2. Decide §12.2: finish the dedup feature or delete its scaffolding.
+3. Delete the retired local-GC machinery (see §9.1) — dead since the journal switchover.
 4. Triage the 117 LOW findings per D3 — fold into the step that touches the file, sweep the
    remainder at the end of step 3. Note the prior lesson that "duplicated"/"boilerplate"-looking
    LOW findings have twice concealed real drift bugs here; triage by diffing, never in bulk.
 5. Re-verify every journal finding before acting: that audit's baseline `ff14b24cb` predates
    `4ec814bc2`.
 
-## 14. Open questions
+## 13. Open questions
 
 1. **Who reviews step 3?** It rewrites the silent-zeros path. One reviewer is not enough, and the
    external contributors will not be up to speed in time.
@@ -847,6 +862,6 @@ Three defects span packages, and each was invisible to at least one audit:
 3. **Does the remote backend honour `If-None-Match`?** No longer blocking after D9 — the fence
    is in the metadata store — but it decides whether the second, independent check exists. One
    conditional PUT against a scratch key settles it; probe rather than assume.
-4. **Where does the assembly (§12) live in the tree, and what is it called?** It is small enough
+4. **Where does the assembly (§11) live in the tree, and what is it called?** It is small enough
    that "a package" and "a module" are both defensible; the split decision only matters at
    `git subtree split` time.

--- a/.planning/2026-09-01-block-dataflow-MASTER-PLAN.md
+++ b/.planning/2026-09-01-block-dataflow-MASTER-PLAN.md
@@ -856,7 +856,115 @@ Three defects span packages, and each was invisible to at least one audit:
    is what proves the mutual exclusion — `RestoreToVersion` sits 33 lines below the `if` that
    appears to enclose it and is actually inside the `else`. Check braces, not proximity.
 
-## 13. Open questions
+## 13. Prefetch
+
+Prefetch exists today and works. It is in this plan for one reason: **an extraction can lose
+behaviour silently, and this behaviour has no test that would notice.** A green suite has already
+failed to catch a data-path regression here once. So the job is not to design prefetch; it is to
+pin what exists, carry it across the boundary intact, and close the soundness gaps that are
+already open.
+
+### 13.1 What exists, and what must survive
+
+| behaviour | where | must survive as |
+|---|---|---|
+| sliding window, each block scheduled exactly once | `Syncer.planWindow`, `engine/readahead.go` | pinned by test before step 1 |
+| driven on **every** read, local hits included | `engine/readwrite.go:29` | a sequential reader must not stall once reads stop missing |
+| window size, default **64 blocks** | `engine.DefaultPrefetchBlocks` | configurable, same default |
+| anchor resets on a random jump | `planWindow` | a random reader drags no window |
+| lowest-priority transfer class | `TransferPrefetch`, `types.go:64` | never ahead of a demand fetch |
+| 4 workers | `block.DefaultPrefetchWorkers` | bounded, separate from demand concurrency |
+| all fetched bytes land here | `engine/fetch.go:201` → `local.Hydrate` | one landing point, still one |
+
+Every row is a **preservation contract**, not a description. Each needs a test that fails if the
+refactor drops it, written **before** step 1 — the extraction is the thing most likely to break
+them, so a test written afterwards is written against whatever the refactor happened to produce.
+
+### 13.2 The warm unit is one whole block. Never a partial read.
+
+**Invariant: the minimum unit warmed from the remote is exactly one block.** Not a byte range,
+not a sub-block extent, not the tail of a block.
+
+This is a correctness rule, not a performance preference. A block is **content-addressed** — its
+identity is the BLAKE3 hash of its full contents. You can verify only what you hold in full, so a
+partial fetch is **unverifiable by construction**. Warming a sub-range would place bytes in the
+local tier that were never checked against any hash, and the tier cannot later tell them apart
+from bytes that were. That is the same failure family as the residency states: two things that
+must be distinguishable rendered identically. `SetVerifyReads`'s per-read check cannot save it
+either, since there is nothing complete to check against.
+
+Consequences, all binding:
+
+1. **Gap-finding rounds outward to block boundaries.** A 4 KiB hole inside a 16 MiB block warms
+   that entire block, or nothing at all. Never the 4 KiB.
+2. **`ferry.GetRange` is not part of the warm path.** It exists for a demand read that can
+   tolerate and verify a partial answer. Prefetch calls `Get`, whole-block, always.
+3. **Partial residency within a block is not representable in the warm path.** If it becomes
+   representable, this invariant has already been broken somewhere upstream.
+4. A warm that cannot complete a whole block **fetches nothing** and records nothing (see S2).
+
+### 13.3 What is genuinely missing
+
+Block-index adjacency is built. What is not built is **gap awareness**: `planWindow` walks block
+indices forward from the read frontier, but never consults the residency map, so on a partially
+resident file it happily schedules blocks that are already local and skips past a non-resident
+gap that is not the next index. §9.4's `Extents` is what makes the gap expressible — and per
+§13.2 the fetch that results is still whole blocks, rounded out from the gap.
+
+### 13.4 Where it lands after the split
+
+- **Policy — when, how far, when to stop — stays in DittoFS.** It needs the manifest and the
+  access pattern; pier has neither, ferry has neither.
+- **Mechanism is `ferry.Get`**, whole-block, at a priority below demand fetches.
+- **Landing is `pier.Hydrate`.**
+- **`harbour` holds none of it.** Prefetch is policy, and §11 is explicit. If prefetch logic turns
+  up in the assembly, the boundary has already failed.
+
+### 13.5 Soundness — prefetch widens an open race, today
+
+**S1. Prefetch multiplies #2231 by the window size, and nothing cancels it.** `Store.Delete`
+(`engine/readwrite.go:362`) calls `bs.local.Delete` and cancels **no in-flight transfers**; there
+is no per-payload transfer cancellation anywhere in the package. With a 64-block window, up to 64
+speculative fetches can complete *after* a file is deleted, each landing via `Hydrate`. #2231's
+`hydratable` returns the **entire requested range** when `fi == nil` — exactly what `Delete`
+leaves behind. Prefetch turns #2231 from a demand-read race into a continuous speculative one,
+running for files no reader has touched recently.
+
+> **Ordering: #2231 is fixed before the window is widened, and its fence must cover the prefetch
+> path, not only demand reads.** Widening first scales a known silent-corruption window by 64.
+
+**S2. A failed or cancelled prefetch records nothing.** Not a hole, not zeros, not a cold marker.
+A speculative fetch that 404s, times out, or loses a race has learned **nothing** about residency.
+Recording anything makes `StateLost` indistinguishable from `StateAbsent` — the mechanism behind
+#1850, #1888 and #2084.
+
+**S3. A prefetch in flight is not a live reference.** It must not enter GC's mark set — that would
+make reclamation depend on speculation — and it must tolerate its target being reclaimed
+mid-flight, returning empty-handed rather than resurrecting it. #2238 seen from the other side,
+and the same discipline applies: revalidate at the landing, not at the decision.
+
+**S4. Prefetch must not consume the eviction budget it creates pressure on.** 64 blocks at up to
+16 MiB is up to 1 GiB of speculative residency per sequential reader. Speculative bytes are
+evictable **ahead of** demand-fetched bytes, or one large sequential scan evicts the working set
+of every other file on the share.
+
+### 13.6 Tests
+
+Every test below is run against a **deliberately broken build** first. S1 is not a guard that has
+never fired; it is a guard that has never existed.
+
+- **Preservation** (before step 1): each row of §13.1's table, asserted directly — window size,
+  scheduled-once, anchor reset on random jump, driven on local hits, priority below demand.
+- **S1:** delete a file with prefetches in flight; assert it stays deleted and no interval
+  reappears. **This test fails on current `develop`.**
+- **S2:** fault a prefetch (404, timeout, cancel); assert `Extents` is byte-identical either side.
+- **S3:** reclaim a prefetch target mid-flight; assert the prefetch returns empty, records nothing.
+- **S4:** sequential-scan a file larger than the local tier; assert a second file's demand-fetched
+  bytes survive.
+- **§13.2 invariant:** assert no warm-path call ever requests less than a whole block — including
+  when the triggering gap is a few KiB inside one.
+
+## 14. Open questions
 
 1. **Who reviews step 3?** It rewrites the silent-zeros path. One reviewer is not enough, and the
    external contributors will not be up to speed in time.

--- a/.planning/2026-09-01-block-dataflow-MASTER-PLAN.md
+++ b/.planning/2026-09-01-block-dataflow-MASTER-PLAN.md
@@ -849,8 +849,12 @@ Three defects span packages, and each was invisible to at least one audit:
 4. Triage the 117 LOW findings per D3 — fold into the step that touches the file, sweep the
    remainder at the end of step 3. Note the prior lesson that "duplicated"/"boilerplate"-looking
    LOW findings have twice concealed real drift bugs here; triage by diffing, never in bulk.
-5. Re-verify every journal finding before acting: that audit's baseline `ff14b24cb` predates
-   `4ec814bc2`.
+5. **Done — all six HIGH premises re-verified against `60e2bd9f7`, none refuted.** The ten commits
+   between `ff14b24cb` and current develop touch metadata, badger and nfs4 — none touch
+   `pkg/block/`. Each fix still needs its own premise check at the commit it is written on, but
+   the backlog is not stale. Method note: on #2227 the branch structure, not the line numbers,
+   is what proves the mutual exclusion — `RestoreToVersion` sits 33 lines below the `if` that
+   appears to enclose it and is actually inside the `else`. Check braces, not proximity.
 
 ## 13. Open questions
 

--- a/.planning/2026-09-01-block-dataflow-MASTER-PLAN.md
+++ b/.planning/2026-09-01-block-dataflow-MASTER-PLAN.md
@@ -885,22 +885,32 @@ them, so a test written afterwards is written against whatever the refactor happ
 **Invariant: the minimum unit warmed from the remote is exactly one block.** Not a byte range,
 not a sub-block extent, not the tail of a block.
 
-This is a correctness rule, not a performance preference. A block is **content-addressed** — its
-identity is the BLAKE3 hash of its full contents. You can verify only what you hold in full, so a
-partial fetch is **unverifiable by construction**. Warming a sub-range would place bytes in the
-local tier that were never checked against any hash, and the tier cannot later tell them apart
-from bytes that were. That is the same failure family as the residency states: two things that
-must be distinguishable rendered identically. `SetVerifyReads`'s per-read check cannot save it
-either, since there is nothing complete to check against.
+**The binding reason is request economics.** Object-store cost is dominated by per-request
+latency, and that latency is close to flat in object size — #2070's rig measured 240,000 requests
+against 234 for the identical bytes, with per-request latency around 0.45s regardless of size.
+(That measurement is on the write path; the asymmetry it demonstrates, cost per request rather
+than per byte, is a property of the store.) A partial read pays a whole request for a fraction of
+a block, so warming a block in N pieces costs N times the requests to move the same bytes. Whole
+blocks are how the request count stays proportional to bytes moved instead of to fragmentation.
+
+**It also makes S3 cheap to satisfy.** A whole-block fetch is all-or-nothing, so a prefetch whose
+target is reclaimed mid-flight discards one complete unit and records nothing. Partial reads would
+leave fragments of a reclaimed block half-landed, and "record nothing" stops being a discard and
+becomes a reconciliation.
+
+**And verification comes for free at that granularity.** `engine/fetch.go:346` already hashes what
+it fetched — `blake3.Sum256(data)` — against the content address. That check is only expressible
+over a complete block, so whole-block warming keeps it available rather than having to weaken or
+defer it. This is a real benefit but a secondary one; the request economics would force the same
+rule even without it.
 
 Consequences, all binding:
 
 1. **Gap-finding rounds outward to block boundaries.** A 4 KiB hole inside a 16 MiB block warms
    that entire block, or nothing at all. Never the 4 KiB.
 2. **`ferry.GetRange` is not part of the warm path.** It exists for a demand read that can
-   tolerate and verify a partial answer. Prefetch calls `Get`, whole-block, always.
-3. **Partial residency within a block is not representable in the warm path.** If it becomes
-   representable, this invariant has already been broken somewhere upstream.
+   tolerate a partial answer. Prefetch calls `Get`, whole-block, always.
+3. **Partial residency within a block is not representable in the warm path.**
 4. A warm that cannot complete a whole block **fetches nothing** and records nothing (see S2).
 
 ### 13.3 What is genuinely missing

--- a/.planning/2026-09-01-block-dataflow-MASTER-PLAN.md
+++ b/.planning/2026-09-01-block-dataflow-MASTER-PLAN.md
@@ -11,8 +11,8 @@ Inputs, all authoritative, none superseded by this document:
 All three audits ran 7 lenses and an adversarial verify gate. **196 findings over 19,632 LOC.**
 
 Baselines: journal at `ff14b24cb`, engine and root at `4ec814bc2` — so **journal findings must be
-re-verified before action**. Audit trees: `~/dittofs-worktrees/audit-journal` and
-`~/dittofs-worktrees/audit-engine`, both immutable.
+re-verified before action**. Each audit ran against an immutable detached worktree pinned to its
+baseline commit.
 
 ---
 
@@ -216,7 +216,7 @@ not legacy or shim, and each has a better home in pier:
    skipped by a caller. Note it is on the zero-test list in §2: it needs a test as it moves.
 2. The `filepath.Join(dir, "journal")` subdirectory convention — pier's own layout decision.
 3. `durable = true` — a field.
-4. The `nil` remote argument — that is the dead `journal.RemoteStore` seam, which §7.3 turns into
+4. The `nil` remote argument — that is the dead `journal.RemoteStore` seam, which design-plan §7.3 turns into
    `ferry.Store`. It disappears on its own.
 
 **What stays:** `local.LocalStore` — the interface DittoFS declares — is exactly the §5 mechanism
@@ -347,13 +347,13 @@ compile-time completeness check as §5, applied to behaviour:
 Concretely, per module:
 
 - **`piertest/`** — the one options-taking store-opener replacing today's six near-duplicate
-  openers (§6.3), plus the residency-truth state table: every operation's effect on all five
+  openers (design-plan §6.3), plus the residency-truth state table: every operation's effect on all five
   states, including `StateLost`. `RestoreToVersion` gets the real suite D2 promises here, not in
   a consumer.
 - **`cranetest/`** — boundary stability first (the same blob chunked in one call vs. many must
   yield identical boundaries, or fleet-wide dedup silently degrades), then packing determinism.
 - **`ferrytest/`** — ordered completion under concurrency, window saturation, retry idempotence,
-  and the per-call-future contract that replaces the shared `Completions()` channel (§4.1 C3).
+  and the per-call-future contract that replaces the shared `Completions()` channel (design-plan §4.1 C3).
 
 What stays in DittoFS: integration tests that cross module boundaries, the E2E suite, and the
 crash rigs — those test the composition, which is DittoFS's job and no library's.
@@ -403,7 +403,7 @@ Everything above is internal shape. This section fixes the surface DittoFS's con
 protocol adapters actually call when a read or write handler touches a file. It is written last
 because the module split only pays off if this boundary is narrow.
 
-### 10.1 Where it stands
+### 9.1 Where it stands
 
 `*engine.Store` exports **46 methods; 44 have callers outside `pkg/block`.** That is not an API,
 it is the absence of one. Measured on the same tree, it also contains:
@@ -416,7 +416,7 @@ it is the absence of one. Measured on the same tree, it also contains:
 | `HealthCheck` / `Healthcheck` | both exist, different signatures | casing drift on one concept, both externally called |
 | `Stats`, `GetStats`, `GetStatsLite`, `LocalStats`, `SyncCounts` | five | one concept |
 
-### 10.2 The shape follows from NFS and SMB, not from taste
+### 9.2 The shape follows from NFS and SMB, not from taste
 
 Both protocols have the **same** write model, and it is precisely *unstable write + explicit
 commit*:
@@ -440,7 +440,7 @@ already visible in the adapters and they do not even agree with each other:
 One adapter implements the capability, the other throws it away, because the block store has no
 way to express it. That is an API defect, not an adapter defect.
 
-### 10.3 The data plane — six methods
+### 9.3 The data plane — six methods
 
 ```go
 type Stability uint8
@@ -476,7 +476,7 @@ type DataPlane interface {
 `got Stability` and the range-scoped `Commit` are the two additions. Neither is speculative
 generality — each is a field the wire protocols already carry and the current API drops.
 
-### 10.4 Residency is part of the API, not an internal detail
+### 9.4 Residency is part of the API, not an internal detail
 
 Every one of H1-H5 was a disagreement about where bytes live, and **no interface exposed that
 question**, so no caller could ask and no test could pin it. The five-state model becomes public:
@@ -503,7 +503,7 @@ func (s *Store) Extents(ctx context.Context, f FileID) ([]Span, error)
 Lifecycle, drain, snapshot/restore, capacity and stats each get their own small interface. Mixing
 them into one receiver is how 46 methods happened.
 
-### 10.5 `pkg/block` root holds the API and nothing else
+### 9.5 `pkg/block` root holds the API and nothing else
 
 After §4.1 and the legacy deletion, the root keeps the contract and the types the contract names —
 `FileID`, `Stability`, `Verifier`, `State`, `Span`, `ContentHash`, `FileChunk`, `Locator` — and
@@ -511,21 +511,21 @@ nothing else. Everything that is machinery moves down into `pier` / `crane` / `f
 everything legacy is deleted outright rather than relocated. A reader opening `pkg/block/` should
 see what the block store promises, not how it keeps the promise.
 
-### 10.6 Folder and file structure
+### 9.6 Folder and file structure
 
 Two rules, both forcing functions rather than aesthetics:
 
 1. **No non-test file over ~400 LOC.** Current state: **18 of 108 files exceed it, 5,565 LOC above
    the line** — `journal/store.go` 1297, `engine/syncer.go` 1056, `journal/reclaim.go` 999,
    `journal/carve.go` 995, `engine/gc.go` 876, `remote/s3/store.go` 751, `engine/readwrite.go` 735,
-   `engine/fetch.go` 693. The journal side of that list is already scheduled by §6.2/§6.3; the
+   `engine/fetch.go` 693. The journal side of that list is already scheduled by §6.2/design-plan §6.3; the
    engine side is not, and needs the same treatment. The limit is a guideline with teeth: a file
    that will not fit is a file holding more than one responsibility, which is the condition every
-   one of §6.3's entries describes.
+   one of design-plan §6.3's entries describes.
 2. **A file's name states its responsibility.** `segment.go`/`index.go` holding the hot read and
    write paths is the anti-pattern; `write.go`/`read.go` is the fix.
 
-### 10.7 One integration test and one benchmark for the whole ingestion path
+### 9.7 One integration test and one benchmark for the whole ingestion path
 
 Per §6.1 each module tests itself, but **composition is DittoFS's job**, and the ingestion path
 has never been exercised end to end in one place. Add exactly one of each, both driving the §9.3
@@ -538,7 +538,7 @@ API in the shape an adapter drives it:
   deliberately corrupted remote produces `Lost` **with an error**, never zeros. That last case is
   the one no existing test covers and the one that has shipped five times.
 - **Benchmark** — the same path, measured, with the `Verifier` stable across the run. It is the
-  before/after number §6 item 4 requires, and it is what will show whether §4.4's deferred-credit
+  before/after number §6 item 4 requires, and it is what will show whether design-plan §4.4's deferred-credit
   change moved time-to-flip.
 
 Both live in DittoFS, not in a module: they test the seam, and the seam is what the split creates.
@@ -547,7 +547,7 @@ Both live in DittoFS, not in a module: they test the seam, and the seam is what 
 
 Deferred from §13 open question 3 and now decided. This replaces that entry.
 
-### 11.1 Compatibility classes, not a version number
+### 10.1 Compatibility classes, not a version number
 
 Do not ask "what version is this store". Ask **what an older binary must do when it meets
 something it does not understand** — the ext4/btrfs model, and the only one that keeps cheap
@@ -568,7 +568,7 @@ with unsupported `roCompat` features could be opened read-only and then *remount
 because the check ran before the read-only flag was set. Any future read-only mode inherits that
 trap.
 
-### 11.2 Registry — migrations are files in a folder
+### 10.2 Registry — migrations are files in a folder
 
 ```go
 type Class uint8 // Compat | ROCompat | Incompat
@@ -588,7 +588,7 @@ type Migration struct {
 One `.go` file per migration in a `migrations/` folder, self-registering via `init()`. The runner
 sorts by `From`/`To`, refuses a registry with a gap or a fork, and applies iteratively.
 
-### 11.3 One runner, two substrates
+### 10.3 One runner, two substrates
 
 The algorithm — read stamp, select, order, gate on class, apply, record, abort — is identical
 local and remote. Only three primitives differ, so only those are injected:
@@ -638,7 +638,7 @@ This is not hypothetical work in another sense either: the S3 layout has already
 
 `cas/{hh}/{hh}/{hex}` → `blocks/<blockID>`, migrated by the ad-hoc code §4 deletes.
 
-### 11.4 Revert means abort and un-expand, never downgrade
+### 10.4 Revert means abort and un-expand, never downgrade
 
 Roll-forward is the operational default; reverting a completed destructive change generally is not
 possible without a backup. What makes revert cheap is **expand/contract**: add the new form,
@@ -653,14 +653,14 @@ appear to offer a revert it cannot perform.
 The documented failure mode is stopping halfway — shipping the expand and never contracting,
 leaving both forms alive forever. Each migration names the release its contract phase lands in.
 
-### 11.5 Trigger
+### 10.5 Trigger
 
 `compat` and `roCompat` migrations apply automatically at open. `incompat` migrations **refuse to
 open** and print the `dfsctl` command to run, so a data-rewriting change is an operator decision
 with a window to take a backup. This is a deliberate change from today's behaviour, where the
 cas→blocks pass runs backgrounded on every boot with no operator involvement.
 
-### 11.6 Relationship to D4
+### 10.6 Relationship to D4
 
 D4 says delete legacy paths rather than build scaffolding for users who do not exist, and it still
 holds — this machine is **not** a reason to keep any of §4's legacy surface. The two are about
@@ -671,7 +671,7 @@ exist before the first migration, and no migrations at all.
 
 ## 11. `harbour` — the assembly
 
-pier, crane and ferry are three libraries; something must wire them. Today §6.2 assigns that to
+pier, crane and ferry are three libraries; something must wire them. Today design-plan §6.2 assigns that to
 `dittofs/pkg/block/engine`. Moving the wiring into the library set makes the trio testable and
 `git subtree split` shippable — otherwise the split yields three modules nobody can assemble
 without re-deriving the `Flush` seam from prose.
@@ -681,7 +681,7 @@ counts as durable, what the manifest says — stays in DittoFS. An assembly that
 the god object relocated, and it would re-absorb precisely the residency-truth judgements that
 produced H1-H5.
 
-Its scope is defined by subtraction. **Enforcement of the §4.1 seam contract stays in pier**, for
+Its scope is defined by subtraction. **Enforcement of the design-plan §4.1 seam contract stays in pier**, for
 everything pier can observe: per-fragment credit validation, strictly sequential `fn`,
 `AfterFile` under the flush lock. The assembly owns only the residue pier structurally *cannot*
 see:
@@ -742,7 +742,7 @@ Three audits, one rubric. `pkg/block/journal` (2026-09-01, baseline `ff14b24cb`)
 | block root | 2,038 | 0 | 2 | 20 | 45 |
 | **total** | **19,632** | **7** | **23** | **117** | **204** |
 
-### 13.1 The new HIGH extends the taxonomy
+### 12.1 The new HIGH extends the taxonomy
 
 **Remote sweep reclaims a hash a concurrent dedup write just re-referenced**
 (`engine/gc_sweep_index.go:69`). Independently re-verified here; two refutation attempts failed.
@@ -769,7 +769,7 @@ while a writer moves between them. The five-state model in §9.4 is necessary bu
 it needs **transitions under concurrency**, not just states. Fold that into `piertest`'s state
 table — every transition needs a concurrent-writer case, not only a sequential one.
 
-### 13.2 The finding that neither single-package audit could have found
+### 12.2 The finding that neither single-package audit could have found
 
 `ComputeObjectID` (`block/objectid.go:36`) folds only `ChunkRef.Hash` into its Merkle root,
 never `Size`/`StartOffset`. Since `PruneChunkRefsToSize` deliberately keeps a ref straddling the
@@ -801,14 +801,14 @@ that is the only thing the collision can currently hurt. Finishing it requires f
 `ComputeObjectID` first — mixing `Size`/`StartOffset` into the digest and bumping the domain
 prefix — which makes it **§10's first real migration customer**.
 
-### 13.3 The uncomfortable conclusion about scope
+### 12.3 The uncomfortable conclusion about scope
 
 Engine findings by area, most-hit first: `gc-mark-sweep-compaction` **15**,
 `reclaim-reconcile-audit` 10, `write-path-carve` 9, `syncer-upload-health` 9,
 `composition-lifecycle` 8, `read-path-cold-fetch` 6, `manifest-check-repair` 4,
 `offline-readiness` 3.
 
-Per §6.2, the extraction moves roughly **500 of engine's 11,304 LOC** into ferry — the upload
+Per design-plan §6.2, the extraction moves roughly **500 of engine's 11,304 LOC** into ferry — the upload
 window, the PUT, and a dead interface. GC, reclaim, manifest check/repair, cold-read resolution
 and offline readiness all stay. **The single new HIGH lives in `gc_sweep_index.go`, which does not
 move**, and the heaviest-hit area is the one least touched by the refactor.
@@ -825,7 +825,7 @@ So the merged result does not fit the three buckets of §3 cleanly, and a fourth
 That is an argument for sequencing, not against the refactor: **§3d work is worth doing before
 the boundary hardens**, while the code is still one package and a cross-cutting fix is one diff.
 
-### 13.4 Cross-boundary findings
+### 12.4 Cross-boundary findings
 
 Three defects span packages, and each was invisible to at least one audit:
 
@@ -839,7 +839,7 @@ Three defects span packages, and each was invisible to at least one audit:
    engine, and the NFSv4 adapter — outside all three audit scopes, found only because the engine
    audit was allowed to grep beyond its own package.
 
-### 13.5 Next actions
+### 12.5 Next actions
 
 1. **Filed as #2238.** Add it to step 0 alongside #2227-#2231. The cheap fix is to re-arm `syncedAt` on a dedup hit, so the existing grace gate covers the
    resurrection window; the correct fix is to revalidate liveness inside the transaction that

--- a/.planning/2026-09-01-block-dataflow-MASTER-PLAN.md
+++ b/.planning/2026-09-01-block-dataflow-MASTER-PLAN.md
@@ -1,0 +1,278 @@
+# Master plan — block data-flow: audit findings + pier/crane/ferry refactor
+
+Status: **FOR DISCUSSION.** No code written. HIGH findings filed as #2227-#2231.
+
+Inputs, both authoritative, neither superseded by this document:
+- `2026-09-01-journal-audit-report.md` — 59 verified findings (6 HIGH / 8 MED / 45 LOW), 70 agents, 7 lenses, adversarially verified.
+- `2026-09-01-pier-library-design-PLAN.md` — the target design (state model, three interfaces, folder structure, test/bench contracts).
+
+Baseline: `ff14b24cb` (origin/develop). Audit tree: `~/dittofs-worktrees/audit-journal` (immutable).
+
+---
+
+## 1. Verdict
+
+**Refactor, don't rewrite. Extract to package boundaries now, hold the repos.**
+
+The audit's central result is not the bug count. It is the *shape* of the bugs:
+
+> **All five distinct HIGH findings are residency-truth failures** — the cache's map of what
+> it holds disagreeing with what it holds, resolving to zeros or to reclaimed live data.
+> Not one is a throughput, eviction-policy or chunking bug.
+
+That is the same signature as the entire prior field history (#1850, #1879, #1888, #2084,
+#1872/#2073/#2093, #1956, #2110). Ten independent incidents, one defect class, over a year.
+A design that makes that class unrepresentable is worth the disruption; one that merely
+re-tidies the same model is not.
+
+Corroborating the extraction case specifically:
+- `RemoteStore`/`BlockID` are entirely dead — never implemented, never read, `nil` at the one
+  production call site. The remote seam pier *actually* has is inbound-only (`Fill`), which is
+  what makes the split viable.
+- Import coupling is trivial: 11 `logger.Warn`, 2 `block.ErrFutureFormat`, one `blake3` call.
+- Semantic coupling is real but localised: three type-asserted manifest interfaces, all in carve.
+
+## 2. The five HIGH findings
+
+| # | Issue | Finding | Where | Model |
+|---|---|---|---|---|
+| H1 | #2227 | `RestoreToVersion` blind to `cold.log`: deletes remote-durable files, zero-fills cold ranges | `store.go:1087` | `StateRemote` read as `StateAbsent` |
+| H2 | #2228 | `repackSegment` never sets `target.records`: synced-gate calls a still-dirty segment evictable | `reclaim.go:834` | `StateDirty` → `StateLost` |
+| H3 | #2229 | `RestoreToVersion` re-materializes via `WriteAt` and never fsyncs, against its own doc | `store.go:1079` | acknowledged ≠ `Durable` |
+| H4 | #2230 | Torn `cold.log` tail never physically truncated at recovery — poisons every future append | `recovery.go:358` | cold markers lost → `StateAbsent` |
+| H5 | #2231 | `Hydrate` has no delete-fence — a racing cold read resurrects a deleted file | `store.go:456` | tombstone fails to fence a transition |
+
+H2 was found independently by two lenses (`bugs` and `gaps`), which is the strongest confirmation
+signal the run produced.
+
+**Three of five (H1, H3, and H1's blast radius) are in `RestoreToVersion` — the method with
+ZERO test call sites across all 29 test files.** Package coverage is 79.2% and hides it entirely.
+`CheckFormat`, `JournalVersion`, `PinVersion`, `SetPinVersion` and `FileCount` are equally
+untested.
+
+**A mitigation I would have assumed, and which the verify gate killed:** for H1 one might expect
+`shares.SeedColdFromManifest` (snapshot.go:1595) to re-seed cold ranges afterwards. It is gated
+`if remoteVerify`, and `RestoreToVersion` runs *only* on the `!remoteVerify` local-only branch.
+There is no compensation, and the erroneous tombstones are fsynced before anything could undo
+them. Do not let this reasoning get re-derived optimistically later.
+
+## 3. Findings mapped against the design
+
+Three buckets. The bucket decides *when* the work happens, not whether.
+
+### 3a. Fix now, independent of the refactor (do not wait)
+
+These are live defects on `develop` today. They are not blocked by, and must not be bundled
+into, the extraction.
+
+| Finding | Fix | Effort |
+|---|---|---|
+| **H2** `target.records` never set | one `Store` beside the existing two at `reclaim.go:834-835` | trivial, high value |
+| **H4** torn `cold.log` tail | `loadCold` returns the intact offset; truncate+fsync before any later append, mirroring `loadSegment` | small |
+| **H1** restore cold-blindness | fold `loadCold` into phase 1 as `applyColdLog` already does; re-assert cold entries in phase 2 rather than `Delete` | medium |
+| **H3** restore never fsyncs | `groupCommit` per touched shard before returning | trivial |
+| **H5** `Hydrate` delete-fence | per-shard `tombVer[id]`, gate `Hydrate`/`hydratable` as `truncVer` already gates | medium |
+| **M** `Truncate`'s `truncVer` uses the pre-marker peek version | raise `truncVer` from the marker's real version in the same locked section | small |
+
+**Every one needs a regression test that fails on unmodified `develop` first.** H1/H3 need
+`RestoreToVersion` tests that do not exist at all — writing those is the prerequisite, and is
+independently valuable regardless of what happens to the refactor.
+
+### 3b. Closed by construction — the refactor removes the possibility
+
+Fix nothing here separately; the design eliminates the class.
+
+| Finding | Closed by |
+|---|---|
+| `doc.go`'s false stdlib/two-interfaces claim | §9.1 import-graph **test** — a claim that cannot rot |
+| Dead API: `RemoteStore`, `BlockID`, `PinVersion`, `SegmentLocation`, `GC` | deleted; `RemoteStore` becomes `ferry.Store` |
+| Three type-asserted manifest interfaces | evaporate: one becomes `DurableTail`, two become the caller calling itself |
+| `store.go` 1297 / `reclaim.go` 999 / `carve.go` 995 | §6.2 file layout |
+| `segment.go`/`index.go` holding the hot paths their names disown | `write.go` / `read.go` |
+| Two files named `carve_dispatch.go` | one `ferry` |
+| Six near-duplicate test store-openers | one harness in `piertest/` |
+| `SetCarveTargets` unsynchronized field write | gone — collaborators move to construction |
+| Doc drift (`gc.go`, `logblob.EvictBlob`) | rewritten wholesale |
+
+### 3c. Created by the refactor if not handled — the new risks
+
+These do not exist today. The design introduces them and must close them.
+
+| Risk | Mitigation | Source |
+|---|---|---|
+| A free-form `durable []Extent` lets a buggy `fn` flip a range pier never offered — today's `flipIdx` cursor makes that structurally impossible | pier validates extent provenance against the offered-and-unflipped set | v3.1 change 2 |
+| Reap outside the flush lock deletes the *next* pass's row — on a **2-second cadence**, not adversarial timing | `FlushOptions.AfterFile`, under the lock. **Mandatory** | v3.1 change 4 |
+| Concurrent `fn` calls race over block boundaries | `fn` called strictly sequentially; ALL upload concurrency lives in ferry | v3.1 change 1 |
+| `DurableTail` computed eagerly per file loses the per-run cost property | computed lazily, per call | v3.1 change 3 |
+| `Extents()` collapsing five queries regresses the hot path | `Size` and `DurableExtent` stay separate methods; benchmark and keep receipts | review finding |
+
+## 4. Sequencing
+
+**Order: ferry → crane → pier.** Reverse of the data flow: leaves first, trunk last.
+
+The property that earns this order: **steps 1 and 2 are behaviour-preserving.** No on-disk
+format change, no state-model change, no flip-contract change — pure extraction, verifiable by
+the existing suite plus the crash rigs. All semantic risk concentrates in step 3, taken last,
+when the other two modules are already proven in production.
+
+### Step 0 — the HIGH fixes (§3a), before any extraction
+
+Each its own PR, each with a regression test that fails on unmodified `develop`. Landing these
+first means the extraction starts from a correct baseline and is not competing with bug fixes
+for review attention.
+
+### Step 1 — ferry
+
+Touches `engine/carve_dispatch.go` (upload window), `journal/carve_dispatch.go` (dispatcher),
+`engine/blocksink.go` (the PUT). Does not touch on-disk format, state model, flip contract, or
+the interval index. Delivers the ordered-completion contract step 3 depends on.
+
+### Step 2 — crane
+
+Touches `journal/carve.go`'s packing loop and `pkg/block/chunker`. The critical test is
+**boundary stability**: the same blob chunked in one call vs. many must yield identical
+boundaries, or dedup silently stops working across the fleet.
+
+### Step 3 — pier
+
+The seam inversion, `StateLost`, `AfterFile`, provenance validation, the query collapse, the
+file reorganisation. Everything in §3c lands here.
+
+### Step 4 — legacy cleanup
+
+Separate, independently revertable workstream. **339 `legacy`/`Legacy` mentions in non-test
+`pkg/block/`**, most of it outside the journal: the legacy-CAS object layout, `materializeLegacy`
+called on **every** `WriteAt` and `ReadAt` in `fs.go`, vestigial config knobs
+(`use_append_log`, `rollup_workers`, `stabilization_ms`, `orphan_log_min_age_seconds`),
+`Locator`'s standalone form, `ContentHash`'s two legacy JSON encodings, `FileChunk`'s
+multi-row-per-hash tolerance.
+
+**Scope reduced by D4.** With no production stores in the field, most of this needs **deletion,
+not deprecation**. The expensive part of removing a migration path is the answer to "what happens
+to a store that skipped it" — and today there are no such stores. Do not build migration
+scaffolding, compatibility shims, or multi-release deprecation windows for users who do not
+exist; that is precisely the kind of speculative work this codebase's own conventions reject.
+
+What still needs care, and only this: any format-affecting removal must be reflected in
+`format.go`'s version stamp so a downgraded binary **refuses** rather than reading the result as
+holes. That guard is the entire migration story now.
+
+Still not bundled into refactor PRs — separate workstream, separate revert.
+
+## 5. API completeness — DittoFS uses only public APIs
+
+**Requirement: after extraction, DittoFS reaches pier, crane and ferry through their exported
+APIs only. No embedding, no type assertions on the concrete type, no unexported structural
+interfaces, no custom back doors.**
+
+### Why this is a correctness requirement, not a style one
+
+Today there are two contracts. `local.LocalStore` declares 18 methods. The informal one is
+reached by structural typing on the concrete type:
+
+| Site | Reaches | Failure mode |
+|---|---|---|
+| `local/fs/fs.go:68` | embeds `*journal.Store` — leaks all 31 exported methods onto `*FSStore` | any method added to pier silently appears on FSStore, ungated |
+| `engine/flush.go` | `restorer`, `pinner`, `versioner`, `coldSeeder` | **silent no-op** if the assertion fails |
+| `engine/offline.go` | `coldRangeReporter` | silent no-op |
+| `shares/legacy_verify.go` | `coldSeedTracker` | silent no-op |
+| `shares/blockstore_config.go:475` | `interface{ SetVerifyReads(bool) }` | silent no-op |
+
+Those assertions' own doc comments say "No-op when the local store is not journal-backed." So a
+method rename inside pier does not break the build — it silently disables snapshot pinning, cold
+seed tracking, or per-read verification, and every test not exercising that exact path stays
+green. **That is the same silent-failure shape as H1-H5.** `fs.go:57-63` already flags the embed
+as a known hazard; this requirement discharges it.
+
+### The enforcement mechanism
+
+> **Only the construction site may name `*pier.Cache` (likewise `*crane.Boxer`, `*ferry.Ferry`).
+> Everywhere else holds an interface DittoFS declares.**
+
+Consequences, all of them wanted:
+
+1. Any capability DittoFS needs must be on the library's exported API. A gap becomes a **compile
+   error at the interface declaration**, not a silent no-op at runtime.
+2. `FSStore` holds a named field, not an embed. Pass-throughs are written by hand — which is the
+   point: each one is a deliberate decision that this method belongs in the tier's contract.
+3. Every type assertion listed above is deleted. If the capability is real, it goes on the
+   interface; if it is not, its call site goes.
+4. **The API is complete iff DittoFS compiles.** That is a far better completeness test than any
+   amount of review, and it runs on every build.
+
+Greppable gate for "done":
+```
+rg '\*pier\.Cache|\*crane\.|\*ferry\.' --type go | grep -v _test.go
+```
+returns only the construction sites. Plus, in each library's own test suite:
+`var _ SomeConsumerInterface = (*pier.Cache)(nil)` — so the library itself pins the contract it
+promises.
+
+### The forcing function
+
+If DittoFS needs something the public API does not offer, that is a **signal the API is
+incomplete**, and the resolution is to add it deliberately — with a doc comment, a test, and a
+place in the surface — never to reach around it. Every such addition is a design decision made
+in the open rather than a structural interface added quietly in a consumer.
+
+This applies per step: ferry's consumers use only ferry's API at the end of step 1, crane's at
+the end of step 2, pier's at the end of step 3. The requirement is not deferred to a cleanup pass.
+
+## 6. The green bar
+
+Per step, all of:
+
+1. `go test ./...` and `go test -race ./...` green.
+2. E2E green (`test/e2e/run-e2e.sh`).
+3. **Crash rigs green on both the old and the new build**: `test/crash/device-loss.sh`,
+   `test/crash/invalidate-cold-loss.sh`. A rig that passes only on the new build proves nothing
+   about a regression.
+4. Benchmarks recorded before and after on the same hardware. **Not in Docker Desktop** — it
+   inflates DB round-trips ~2.7x and has already produced one wrong headline number here.
+5. New regression tests **run against a deliberately broken build** before being trusted. A test
+   that passes on unmodified code proves nothing about the bug it claims to pin.
+
+Expect to add regression tests as we go — the untested-method list in §2 is the starting set,
+not the complete one.
+
+## 7. Contributors
+
+External contributors are onboarding now and will reach the block module soon. **They should
+learn the target vocabulary, not the one being retired** — so the RFC goes out before they get
+there, not after.
+
+Proposed: an RFC PR into `docs/internals/` (line-level review, versioned with the code, lands as
+the permanent architecture doc) plus one GitHub Discussion as the announcement and
+open-questions space, linking to it. **Discussions is currently disabled** on the repo;
+`gh repo edit marmos91/dittofs --enable-discussions` turns it on.
+
+## 8. Decisions taken
+
+- **D1. Step 0 runs first, alone.** All five HIGH fixes plus their regression tests land before
+  any extraction begins. The refactor starts from a correct, tested baseline, and a regression
+  during steps 1-3 is unambiguously attributable to the refactor rather than to a concurrent bug
+  fix — which matters specifically because this is the silent-zeros path.
+- **D2. `RestoreToVersion` ships in pier, with a real test suite.** "Rewind to LSN V" is generic,
+  and it needs ceiling-replay machinery over on-disk records that the public surface will not
+  expose — keeping it DittoFS-side would mean widening pier's surface to let it reach in. The
+  cost is accepted: pier must carry it AND test it before it is fit to publish. Its tests are
+  part of step 0 (they are the prerequisite for fixing H1 and H3 at all), not deferred to step 3.
+- **D4. H1 is NOT an incident — no production exposure.** Customers are evaluating DittoFS;
+  nothing runs in production. So the five HIGH findings are serious bugs to fix on the normal
+  path, not a data-loss event to respond to, and step 0 does not need an emergency release.
+  **This also cheapens step 4 substantially** — see §4.
+- **D3. The 45 LOW findings fold into the step that touches their file.** No separate backlog, no
+  issue churn.
+  **Guard against the known failure mode of D3:** LOWs living in files no step rewrites would be
+  silently dropped. Therefore `2026-09-01-journal-audit-report.md` stays in the repo as the
+  record, and step 3 ends with an explicit sweep: walk all 45, mark each addressed / consciously
+  declined / still open. A LOW that is declined is a decision, not an oversight — but it has to
+  be written down as one.
+
+## 9. Open questions
+
+1. **Who reviews step 3?** It rewrites the silent-zeros path. One reviewer is not enough, and the
+   external contributors will not be up to speed in time.
+2. **Does step 0 ship as a release?** No production exposure (D4), so this is a judgement call
+   about testers' builds rather than an incident response. Cutting one anyway is cheap and gives
+   the refactor a clean tagged baseline to diff against.

--- a/.planning/2026-09-01-block-dataflow-MASTER-PLAN.md
+++ b/.planning/2026-09-01-block-dataflow-MASTER-PLAN.md
@@ -145,9 +145,23 @@ file reorganisation. Everything in §3c lands here.
 
 ### Step 4 — legacy cleanup
 
-Separate, independently revertable workstream. **339 `legacy`/`Legacy` mentions in non-test
-`pkg/block/`**, most of it outside the journal: the legacy-CAS object layout, `materializeLegacy`
-called on **every** `WriteAt` and `ReadAt` in `fs.go`, vestigial config knobs
+Separate, independently revertable workstream. **384 `legacy`/`Legacy` mentions in non-test
+`pkg/block/`** (measured 2026-09-01; the earlier 339 has grown), and they are not evenly spread:
+
+| package | LOC | legacy mentions |
+|---|---|---|
+| **`local/fs`** | 925 | **200** |
+| `engine` | 11,304 | 77 |
+| `remote` | 374 | 27 |
+| `pkg/block` root | 2,038 | 24 |
+| `remote/memory` | 579 | 20 |
+| `remote/s3` | 1,258 | 16 |
+| `compression` + `encryption` | 1,597 | 20 |
+| **`journal`** | 6,290 | **0** |
+
+`journal` is already clean. **`local/fs` alone holds 52% of the module's legacy surface**, which
+makes it the first thing step 4 removes — see §4.1 below. The remainder: the legacy-CAS object
+layout, vestigial config knobs
 (`use_append_log`, `rollup_workers`, `stabilization_ms`, `orphan_log_min_age_seconds`),
 `Locator`'s standalone form, `ContentHash`'s two legacy JSON encodings, `FileChunk`'s
 multi-row-per-hash tolerance.
@@ -164,6 +178,54 @@ holes. That guard is the entire migration story now.
 
 Still not bundled into refactor PRs — separate workstream, separate revert.
 
+#### 4.1 — delete `pkg/block/local/fs` outright
+
+`local/fs` is 925 non-test LOC in four files, and it is **not** a storage tier. It is a wrapper:
+
+| file | LOC | what it is |
+|---|---|---|
+| `fs.go` | 321 | ten one-line forwards to the embedded `*journal.Store`, plus the legacy gate |
+| `legacy_reader.go` | 254 | legacy |
+| `legacy_migrate.go` | 204 | legacy |
+| `legacy.go` | 146 | legacy |
+
+604 of those 925 lines are legacy and die with D4. The file's own header calls what remains
+*"string↔FileID data-plane shims (shadow the embedded FileID methods)"* — ten methods whose entire
+body is `journal.FileID(payloadID)`, plus `Start()` and `SetMetrics()`, which are empty stubs.
+
+Once the legacy is gone there is no tier left to keep. Only four behaviours in the package are
+not legacy or shim, and each has a better home in pier:
+
+1. `journal.CheckFormat(dir/journal)` **before** `Open` — the guard that stops a directory written
+   by a newer release from reading as holes. Move it *inside* `pier.Open`, where it cannot be
+   skipped by a caller. Note it is on the zero-test list in §2: it needs a test as it moves.
+2. The `filepath.Join(dir, "journal")` subdirectory convention — pier's own layout decision.
+3. `durable = true` — a field.
+4. The `nil` remote argument — that is the dead `journal.RemoteStore` seam, which §7.3 turns into
+   `ferry.Store`. It disappears on its own.
+
+**What stays:** `local.LocalStore` — the interface DittoFS declares — is exactly the §5 mechanism
+and must survive. It has two real implementations (`local/memory` is production-imported at
+`shares/blockstore_config.go:25`, not a test double), so it is not a one-implementation interface.
+It is the *wrapper* that goes, never the contract. `pier.Cache` satisfies `local.LocalStore`
+directly.
+
+**The one real decision — the ID type.** `journal.FileID` is a defined type (`type FileID string`),
+which is the only reason the ten shims exist. Either alias it (`type FileID = string`, zero
+call-site churn) or re-declare `local.LocalStore` in terms of `pier.FileID` and convert at the
+metadata boundary instead. **Take the second.** An alias discards the only type safety the
+conversion currently buys, and §5's entire premise is that this boundary is checked at compile
+time. The churn is mechanical and the compiler finds every site.
+
+**Why this leads step 4 rather than trailing it:** `local/fs` holds 200 of the module's 384 legacy
+mentions. One package deletion removes 52% of the legacy surface, and it removes the embed that
+§5 identifies as the live silent-failure hazard. It also shrinks §5's own workload — with the
+package gone, the "pass-throughs written by hand" item has nothing to write.
+
+**Reachability, checked:** no non-test caller reaches past `FSStore` to the embedded
+`*journal.Store`; every consumer holds `local.LocalStore`. So the shadowed-method hazard is
+prospective, not a live bug, and the deletion is not urgent — it is just clearly correct.
+
 ## 5. API completeness — DittoFS uses only public APIs
 
 **Requirement: after extraction, DittoFS reaches pier, crane and ferry through their exported
@@ -172,22 +234,35 @@ interfaces, no custom back doors.**
 
 ### Why this is a correctness requirement, not a style one
 
-Today there are two contracts. `local.LocalStore` declares 18 methods. The informal one is
-reached by structural typing on the concrete type:
+Today there are two contracts. `local.LocalStore` declares 20 methods. The informal one is
+reached by structural typing on the concrete type.
 
-| Site | Reaches | Failure mode |
+**Measured, not assumed** — a runtime type-assertion probe against `*fs.FSStore`, the production
+local store, resolves every site below. The result splits the table in two, and the halves need
+different fixes:
+
+| Site | Reaches | Holds today? |
 |---|---|---|
-| `local/fs/fs.go:68` | embeds `*journal.Store` — leaks all 31 exported methods onto `*FSStore` | any method added to pier silently appears on FSStore, ungated |
-| `engine/flush.go` | `restorer`, `pinner`, `versioner`, `coldSeeder` | **silent no-op** if the assertion fails |
-| `engine/offline.go` | `coldRangeReporter` | silent no-op |
-| `shares/legacy_verify.go` | `coldSeedTracker` | silent no-op |
-| `shares/blockstore_config.go:475` | `interface{ SetVerifyReads(bool) }` | silent no-op |
+| `local/fs/fs.go:68` | embeds `*journal.Store` — leaks all 31 exported methods onto `*FSStore` | n/a — this embed is *why* the rest hold |
+| `engine/flush.go:262,275,285` | `restorer`, `pinner`, `versioner` | ✅ yes, via promotion |
+| `engine/offline.go:59` | `coldRangeReporter` | ✅ yes |
+| `shares/legacy_verify.go:248,258` | `coldSeedTracker`, `legacyArchiveMigrator` | ✅ yes |
+| `shares/blockstore_config.go:475` | `interface{ SetVerifyReads(bool) }` | ✅ yes |
+| `engine/legacy_migration.go:66` | `legacyChunkFileMigrator{MigrateLegacyChunkFiles}` | ❌ **never — no implementation exists** |
+| `engine/legacy_migration.go:79` | `prober{HasLogBlobSubstrate}` | ❌ **never — no implementation exists** |
 
-Those assertions' own doc comments say "No-op when the local store is not journal-backed." So a
-method rename inside pier does not break the build — it silently disables snapshot pinning, cold
-seed tracking, or per-read verification, and every test not exercising that exact path stays
-green. **That is the same silent-failure shape as H1-H5.** `fs.go:57-63` already flags the embed
-as a known hazard; this requirement discharges it.
+So the hazard is **prospective, not live**. Seven assertions resolve because `FSStore` embeds
+`*journal.Store` and promotion covers them; a rename inside pier would not break the build, it
+would silently disable snapshot pinning, cold seed tracking, or per-read verification, and every
+test not exercising that exact path would stay green. **That is the same silent-failure shape as
+H1-H5, held off by nothing but an embed.** `fs.go:57-63` already flags it; this requirement
+discharges it.
+
+The last two are a different finding and are **already dead**. Neither `MigrateLegacyChunkFiles`
+nor `HasLogBlobSubstrate` is implemented anywhere in the repository — the doc comment at
+`legacy_migration.go:28` names `FSStore.MigrateLegacyChunkFiles`, which does not exist — so
+`migrateLegacyCAS`'s local phase is unreachable in every configuration. That is not an API-boundary
+problem; it is deletion work, and it belongs to step 4.
 
 ### The enforcement mechanism
 
@@ -240,6 +315,38 @@ Per step, all of:
 Expect to add regression tests as we go — the untested-method list in §2 is the starting set,
 not the complete one.
 
+### 6.1 Each module owns its own tests
+
+**A module's tests live in that module, and must pass with nothing else in the tree.** pier's
+suite runs against pier alone; likewise crane and ferry. This is not tidiness — it is the same
+compile-time completeness check as §5, applied to behaviour:
+
+1. A test that can only be written from DittoFS names a capability the library's public API does
+   not expose. That is a gap to close deliberately, exactly as §5's forcing function requires.
+2. `git subtree split` must stay mechanical. A module whose tests live in its consumer does not
+   survive extraction — it arrives at its new home green and untested.
+3. Today's suites are the opposite of this: the residency behaviour is pinned largely from
+   `pkg/block/engine` and `pkg/controlplane/runtime`, which is why a journal-level defect could
+   reach production five separate times with a green tree.
+
+Concretely, per module:
+
+- **`piertest/`** — the one options-taking store-opener replacing today's six near-duplicate
+  openers (§6.3), plus the residency-truth state table: every operation's effect on all five
+  states, including `StateLost`. `RestoreToVersion` gets the real suite D2 promises here, not in
+  a consumer.
+- **`cranetest/`** — boundary stability first (the same blob chunked in one call vs. many must
+  yield identical boundaries, or fleet-wide dedup silently degrades), then packing determinism.
+- **`ferrytest/`** — ordered completion under concurrency, window saturation, retry idempotence,
+  and the per-call-future contract that replaces the shared `Completions()` channel (§4.1 C3).
+
+What stays in DittoFS: integration tests that cross module boundaries, the E2E suite, and the
+crash rigs — those test the composition, which is DittoFS's job and no library's.
+
+Two rules carry over unchanged and apply inside each module: a new regression test is run against
+a **deliberately broken build** before it is trusted, and a guard that has never actually refused
+anything is unverified rather than proven.
+
 ## 7. Contributors
 
 External contributors are onboarding now and will reach the block module soon. **They should
@@ -274,6 +381,461 @@ open-questions space, linking to it. **Discussions is currently disabled** on th
   declined / still open. A LOW that is declined is a decision, not an oversight — but it has to
   be written down as one.
 
+## 10. The external API — what the runtime calls
+
+Everything above is internal shape. This section fixes the surface DittoFS's control plane and
+protocol adapters actually call when a read or write handler touches a file. It is written last
+because the module split only pays off if this boundary is narrow.
+
+### 10.1 Where it stands
+
+`*engine.Store` exports **46 methods; 44 have callers outside `pkg/block`.** That is not an API,
+it is the absence of one. Measured on the same tree, it also contains:
+
+| Method | State | Consequence |
+|---|---|---|
+| `EvictLocal` | takes the close lock, does `_ = payloadID`, returns `nil` | a **no-op that reports success**. `shares/blockstore_ops.go:365` increments `result.LocalFilesEvicted` per file, so the admin API reports N evicted when zero were. The real work is the `DrainLocalSynced` call below it. |
+| `LocalStore()` | `return nil`, unconditionally — **deliberate** | Not a defect: the journal switchover (`489594417`) made local GC obsolete, and the nil is how it was retired — the journal self-manages segment reclaim. But `ShareLocalStores()` therefore always returns empty, so `blockgc.go:196`'s `runLocalGC` loop body never executes. `runLocalGC`, `ShareLocalStores`, `LocalStoreEntry`, `collectGarbageLocalFn` and `engine.CollectGarbageLocal` are **dead machinery kept alive for a caller that cannot fire** — a step-4 deletion, not a bug. |
+| `Local()`, `RemoteStore()` | hand out the internal tiers | the §5 disease one level up: the runtime reaches around the API instead of through it |
+| `HealthCheck` / `Healthcheck` | both exist, different signatures | casing drift on one concept, both externally called |
+| `Stats`, `GetStats`, `GetStatsLite`, `LocalStats`, `SyncCounts` | five | one concept |
+
+### 10.2 The shape follows from NFS and SMB, not from taste
+
+Both protocols have the **same** write model, and it is precisely *unstable write + explicit
+commit*:
+
+| | NFS v3/v4 | SMB2/3 |
+|---|---|---|
+| write carries a stability request | `stable_how`: `UNSTABLE` / `DATA_SYNC` / `FILE_SYNC` | `SMB2_WRITEFLAG_WRITE_THROUGH` |
+| write reports what was achieved | `committed` + `writeverf` | status |
+| explicit commit | `COMMIT(offset, count)` — **range-scoped** | `SMB2 FLUSH` |
+
+Today's engine exposes `WriteAt(ctx, payloadID, offset, data) error` — no stability in, no
+durability out — and `Flush(ctx, payloadID)`, which is **whole-file**. The cost of that is
+already visible in the adapters and they do not even agree with each other:
+
+- `internal/adapter/nfs/v4/handlers/write.go:217` hardcodes `UNSTABLE4`, commented *"always
+  returns UNSTABLE4 (cache is always enabled)"*. The server cannot tell a client that bytes are
+  durable **even when they are**, so every NFS client must issue a COMMIT round-trip and hold its
+  retransmit buffer until it completes.
+- `internal/adapter/smb/handlers/write.go:461` computes and honours `writeThrough`.
+
+One adapter implements the capability, the other throws it away, because the block store has no
+way to express it. That is an API defect, not an adapter defect.
+
+### 10.3 The data plane — six methods
+
+```go
+type Stability uint8
+const (
+    Unstable Stability = iota // buffered; a Commit is required
+    DataSync                  // data durable, metadata may lag
+    FileSync                  // data + metadata durable
+)
+
+// Verifier changes if and only if the store lost unstable writes. It is the
+// client's ONLY signal to resend — NFS writeverf, and the same value SMB needs
+// after a session reconnect.
+type Verifier [8]byte
+
+type DataPlane interface {
+    // want is the caller's request; got is what was ACTUALLY achieved and may
+    // exceed want. Returning got is what lets an adapter answer NFS's committed
+    // field honestly and let the client drop its retransmit buffer without a
+    // COMMIT round-trip.
+    WriteAt(ctx context.Context, f FileID, off int64, p []byte, want Stability) (got Stability, err error)
+    ReadAt(ctx context.Context, f FileID, off int64, p []byte) (int, error)
+
+    // Range-scoped, mirroring NFS COMMIT(offset, count). length == 0 means
+    // "to end of file", which is the SMB FLUSH case.
+    Commit(ctx context.Context, f FileID, off, length int64) (Verifier, error)
+
+    Truncate(ctx context.Context, f FileID, size int64) error
+    PunchHole(ctx context.Context, f FileID, off, length int64) error
+    Delete(ctx context.Context, f FileID) error
+}
+```
+
+`got Stability` and the range-scoped `Commit` are the two additions. Neither is speculative
+generality — each is a field the wire protocols already carry and the current API drops.
+
+### 10.4 Residency is part of the API, not an internal detail
+
+Every one of H1-H5 was a disagreement about where bytes live, and **no interface exposed that
+question**, so no caller could ask and no test could pin it. The five-state model becomes public:
+
+```go
+type State uint8
+const (
+    Absent State = iota // never written; reading zeros is CORRECT
+    Dirty               // local only — the sole copy, never reclaimable
+    Synced              // local and remote-durable
+    Cold                // remote-durable, not local; a read faults it in
+    Lost                // was written, not retrievable — reads MUST error, never zero
+)
+
+type Span struct { Off, Len int64; State State }
+
+// Extents is the query that makes StateLost observable. OfflineReadiness,
+// manifest_check, and the offline gates all become callers of this instead of
+// each re-deriving residency from a different partial view — which is what let
+// #2110 report Safe() for a lost interval.
+func (s *Store) Extents(ctx context.Context, f FileID) ([]Span, error)
+```
+
+Lifecycle, drain, snapshot/restore, capacity and stats each get their own small interface. Mixing
+them into one receiver is how 46 methods happened.
+
+### 10.5 `pkg/block` root holds the API and nothing else
+
+After §4.1 and the legacy deletion, the root keeps the contract and the types the contract names —
+`FileID`, `Stability`, `Verifier`, `State`, `Span`, `ContentHash`, `FileChunk`, `Locator` — and
+nothing else. Everything that is machinery moves down into `pier` / `crane` / `ferry` / `engine`;
+everything legacy is deleted outright rather than relocated. A reader opening `pkg/block/` should
+see what the block store promises, not how it keeps the promise.
+
+### 10.6 Folder and file structure
+
+Two rules, both forcing functions rather than aesthetics:
+
+1. **No non-test file over ~400 LOC.** Current state: **18 of 108 files exceed it, 5,565 LOC above
+   the line** — `journal/store.go` 1297, `engine/syncer.go` 1056, `journal/reclaim.go` 999,
+   `journal/carve.go` 995, `engine/gc.go` 876, `remote/s3/store.go` 751, `engine/readwrite.go` 735,
+   `engine/fetch.go` 693. The journal side of that list is already scheduled by §6.2/§6.3; the
+   engine side is not, and needs the same treatment. The limit is a guideline with teeth: a file
+   that will not fit is a file holding more than one responsibility, which is the condition every
+   one of §6.3's entries describes.
+2. **A file's name states its responsibility.** `segment.go`/`index.go` holding the hot read and
+   write paths is the anti-pattern; `write.go`/`read.go` is the fix.
+
+### 10.7 One integration test and one benchmark for the whole ingestion path
+
+Per §6.1 each module tests itself, but **composition is DittoFS's job**, and the ingestion path
+has never been exercised end to end in one place. Add exactly one of each, both driving the §10.3
+API in the shape an adapter drives it:
+
+- **Integration test** — adapter-shaped writes (unstable, then a range `Commit`) through
+  `WriteAt → pier → crane → ferry → remote`, asserting the **residency transition after every
+  step** via §10.4's `Extents`, not just the final bytes. It must cover: unstable write leaves
+  `Dirty`; commit moves to `Synced`; eviction moves to `Cold`; a cold read faults back in; and a
+  deliberately corrupted remote produces `Lost` **with an error**, never zeros. That last case is
+  the one no existing test covers and the one that has shipped five times.
+- **Benchmark** — the same path, measured, with the `Verifier` stable across the run. It is the
+  before/after number §6 item 4 requires, and it is what will show whether §4.4's deferred-credit
+  change moved time-to-flip.
+
+Both live in DittoFS, not in a module: they test the seam, and the seam is what the split creates.
+
+## 11. Format migration
+
+Deferred from §9 open question 3 and now decided. This replaces that entry.
+
+### 11.1 Compatibility classes, not a version number
+
+Do not ask "what version is this store". Ask **what an older binary must do when it meets
+something it does not understand** — the ext4/btrfs model, and the only one that keeps cheap
+changes cheap:
+
+| Class | An older binary… | Your term |
+|---|---|---|
+| `compat` | opens read-write, ignores the feature | minor |
+| `roCompat` | may open **read-only** only | minor, one-way |
+| `incompat` | **must refuse** | major |
+
+A single monotonic integer collapses all three into "refuse", which is why every change becomes
+a major one. `format.go`'s stamp plus `journal.CheckFormat` already implement the `incompat` row;
+this generalises it. Carry the flags as three bit sets in the stamp, not one number.
+
+**Re-check the gate on every transition, not only at open.** btrfs shipped a bug where a store
+with unsupported `roCompat` features could be opened read-only and then *remounted read-write*,
+because the check ran before the read-only flag was set. Any future read-only mode inherits that
+trap.
+
+### 11.2 Registry — migrations are files in a folder
+
+```go
+type Class uint8 // Compat | ROCompat | Incompat
+
+type Migration struct {
+    From, To Stamp
+    Class    Class
+    Desc     string
+
+    Up   func(ctx context.Context, s Substrate) error
+    // Down is present ONLY where a revert is honestly possible. Its absence is
+    // a fact about the migration, not an omission — see 11.4.
+    Down func(ctx context.Context, s Substrate) error
+}
+```
+
+One `.go` file per migration in a `migrations/` folder, self-registering via `init()`. The runner
+sorts by `From`/`To`, refuses a registry with a gap or a fork, and applies iteratively.
+
+### 11.3 One runner, two substrates
+
+The algorithm — read stamp, select, order, gate on class, apply, record, abort — is identical
+local and remote. Only three primitives differ, so only those are injected:
+
+```go
+type Substrate interface {
+    ReadStamp(ctx context.Context) (Stamp, error)
+
+    // CompareAndSetStamp is the FENCE. It must fail if the stamp changed since
+    // ReadStamp. This is the whole concurrency story; everything else assumes it.
+    CompareAndSetStamp(ctx context.Context, from, to Stamp) error
+
+    Units(ctx context.Context, m Migration) iter.Seq2[Unit, error]
+}
+```
+
+- **`pier.Substrate`** — stamp is a file; the fence is write-temp + fsync + rename.
+- **`ferry.Substrate`** — stamp is an object at a well-known key; the fence is a conditional PUT.
+
+#### Where the remote fence lives
+
+Measured on this tree: `pkg/block/remote/` implements **no `If-None-Match`/`If-Match`**, and
+shares **do** share buckets (`acquireRemoteStore`/`releaseRemoteStore` ref-count by
+`remoteConfigID`). Two shares on one bucket, no conditional write, and no fsync to fall back on.
+
+**Client-side CAS is not an option and must not be attempted.** Compare-and-set cannot be built
+out of non-atomic primitives — read-check-write has a window under every schedule, and an
+emulation moves the race rather than closing it. A fence that cannot refuse is worse than no
+fence, because it accrues confidence in proportion to how long it is silently useless.
+
+**The fence goes in the metadata store instead.** All four backends implement `WithTransaction`
+(badger, sqlite, postgres, memory), so `CompareAndSetStamp` for the remote substrate is a
+transactional row update there, not an object write. This fences the reachable case: shares that
+share a bucket share a metadata store within one deployment.
+
+It does **not** fence two independent deployments pointed at one bucket. The answer to that is
+refusal, not emulation — §11.5 already makes major migrations an explicit operator action, and
+the runner states plainly that it cannot detect a second deployment.
+
+**Conditional PUT is hardening, not the foundation.** `PutObjectInput` in
+`aws-sdk-go-v2/service/s3 v1.97.3` already carries `IfNoneMatch`/`IfMatch`, so the client is
+capable; whether a given backend honours it is a per-backend fact to probe, not assume. Where it
+is supported, use it as a second, independent check. Where it is not, the metadata fence stands
+alone and the runner says so. Never let its absence silently degrade into no fence at all.
+
+This is not hypothetical work in another sense either: the S3 layout has already changed once.
+
+`cas/{hh}/{hh}/{hex}` → `blocks/<blockID>`, migrated by the ad-hoc code §4 deletes.
+
+### 11.4 Revert means abort and un-expand, never downgrade
+
+Roll-forward is the operational default; reverting a completed destructive change generally is not
+possible without a backup. What makes revert cheap is **expand/contract**: add the new form,
+dual-write, backfill, and only then remove the old. Everything before the contract step is
+reversible; the contract step is the point of no return.
+
+So `Down` exists for pre-contract steps and for aborting an in-progress `Up`, and the runner
+records which phase a migration reached so it knows which is available. A migration whose `Down`
+is `nil` past the contract point is stating a fact, and the runner must say so plainly rather than
+appear to offer a revert it cannot perform.
+
+The documented failure mode is stopping halfway — shipping the expand and never contracting,
+leaving both forms alive forever. Each migration names the release its contract phase lands in.
+
+### 11.5 Trigger
+
+`compat` and `roCompat` migrations apply automatically at open. `incompat` migrations **refuse to
+open** and print the `dfsctl` command to run, so a data-rewriting change is an operator decision
+with a window to take a backup. This is a deliberate change from today's behaviour, where the
+cas→blocks pass runs backgrounded on every boot with no operator involvement.
+
+### 11.6 Relationship to D4
+
+D4 says delete legacy paths rather than build scaffolding for users who do not exist, and it still
+holds — this machine is **not** a reason to keep any of §4's legacy surface. The two are about
+different things: D4 governs *this* cleanup, §11 governs *future* format changes, and its first
+migration should be written when a real format change needs one, not speculatively. What ships
+with the refactor is the stamp, the three classes, the registry and the gate — the parts that must
+exist before the first migration, and no migrations at all.
+
+## 12. `harbour` — the assembly
+
+pier, crane and ferry are three libraries; something must wire them. Today §6.2 assigns that to
+`dittofs/pkg/block/engine`. Moving the wiring into the library set makes the trio testable and
+`git subtree split` shippable — otherwise the split yields three modules nobody can assemble
+without re-deriving the `Flush` seam from prose.
+
+**It is not a fourth peer module, and it holds no policy.** Every judgement — when to evict, what
+counts as durable, what the manifest says — stays in DittoFS. An assembly that starts deciding is
+the god object relocated, and it would re-absorb precisely the residency-truth judgements that
+produced H1-H5.
+
+Its scope is defined by subtraction. **Enforcement of the §4.1 seam contract stays in pier**, for
+everything pier can observe: per-fragment credit validation, strictly sequential `fn`,
+`AfterFile` under the flush lock. The assembly owns only the residue pier structurally *cannot*
+see:
+
+1. **C9 — the fresh-per-`Flush` accumulator.** The design records that pier cannot detect a
+   hoisted `crane.Boxer`, and that hoisting interleaves two files' bytes into one block:
+   cross-file corruption, undetectable from pier. Today C9 is a *stated caller obligation*. The
+   assembly makes it structural by constructing the accumulator inside a per-`Flush` factory, so
+   a hoisted one cannot be expressed — the same move as ferry's per-call futures replacing the
+   shared `Completions()` channel.
+2. **Config consistency** — crane's chunk params must match what pier records, or dedup silently
+   degrades across the fleet. One constructor, one place to get it wrong.
+
+That is the whole surface: a constructor and a `fn` factory. If it grows a third responsibility,
+that is the signal it is absorbing policy.
+
+```
+harbour/
+  harbour.go    New(pier, crane, ferry, Options) — assembles, validates config consistency
+  flush.go      the per-Flush fn factory; C9 made structural
+  README.md
+```
+
+**The name is load-bearing.** A harbour is the *place* a pier, its cranes and its ferries sit —
+not an actor. `harbourmaster` was the closer fit for "sequences the three" and was rejected for
+exactly that reason: a harbourmaster has authority, and a package named for authority invites the
+policy drift §12 exists to prevent. If someone proposes adding a decision to `harbour`, the name
+itself is the argument against it.
+
+**D14. The assembly is `harbour`**, ships with the library set, and holds no policy.
+
+§10.7's ingestion integration test and benchmark move here, since this is the smallest thing that
+can run the whole path without DittoFS in the tree.
+
+### D9-D12 — migration and assembly (§11, §12)
+
+- **D9. Scope is the block store only.** The four metadata backends keep their existing schema
+  handling. The block format is the one that has actually churned twice.
+- **D10. Compatibility classes, not a version integer**, and the runner/substrate split of §11.3
+  is committed: one runner, `pier.Substrate` and `ferry.Substrate`, three injected primitives.
+- **D11. Revert means abort-in-progress and undo pre-contract only.** No downgrade of a completed
+  destructive migration. `Down` is optional and its absence is a stated fact.
+- **D12. Minor applies automatically, major refuses and requires an explicit command.**
+- **D13. The remote fence lives in the metadata store**, not the bucket. Client-side CAS is
+  forbidden. Conditional PUT is defence in depth where the backend supports it.
+
+## 13. Merged audit results — journal + engine + block root
+
+Three audits, one rubric. `pkg/block/journal` (2026-09-01, baseline `ff14b24cb`),
+`pkg/block/engine` and `pkg/block` root (both at `4ec814bc2`). Reports:
+`.planning/2026-09-01-journal-audit-report.md`, and `report.md` in each audited directory of the
+`audit-engine` worktree.
+
+| Audit | LOC | HIGH | MED | LOW | Agents |
+|---|---|---|---|---|---|
+| journal | 6,290 | 6 (5 distinct) | 8 | 45 | 70 |
+| engine | 11,304 | 1 | 13 | 52 | 89 |
+| block root | 2,038 | 0 | 2 | 20 | 45 |
+| **total** | **19,632** | **7** | **23** | **117** | **204** |
+
+### 13.1 The new HIGH extends the taxonomy
+
+**Remote sweep reclaims a hash a concurrent dedup write just re-referenced**
+(`engine/gc_sweep_index.go:69`). Independently re-verified here; two refutation attempts failed.
+
+1. `sweepFromSyncedIndex` decides orphan-vs-live from `syncedAt` vs grace cutoff and `gcs.Has(h)`
+   against a mark set snapshotted **before** the sweep, with no revalidation before
+   `ReclaimDeadChunk` + `DeleteSynced`.
+2. A dedup hit writes a manifest row and nothing else — `blocksink.go:298`,
+   `if c.Data == nil { continue // deduped: manifest row only, nothing to frame }` — so it never
+   reaches `MarkSynced` and **never refreshes `syncedAt`**.
+3. No unlink clears a marker: every non-test `DeleteSynced` caller is itself a GC or legacy path
+   (`blockgc.go:490`, `gc_sweep_index.go:113`, `gc_block.go:133,157`, `legacy_migration.go:208`).
+   So an orphaned hash keeps its ORIGINAL `syncedAt`, and `IsSynced` still answers true to the
+   write-side dedup oracle.
+
+A new file dedups onto a past-grace orphan; its manifest row is invisible to the already-taken
+snapshot; the sweep frees the only durable copy while a live row points at it. Both operations
+log success.
+
+**Why this matters beyond one bug.** The journal audit's five HIGHs were state *disagreements at
+rest* — two views of the same byte, out of sync. This one is a **time-of-check/time-of-use race**:
+every view is individually correct, and the defect is that they are read at different instants
+while a writer moves between them. The five-state model in §10.4 is necessary but not sufficient;
+it needs **transitions under concurrency**, not just states. Fold that into `piertest`'s state
+table — every transition needs a concurrent-writer case, not only a sequential one.
+
+### 13.2 The finding that neither single-package audit could have found
+
+`ComputeObjectID` (`block/objectid.go:36`) folds only `ChunkRef.Hash` into its Merkle root,
+never `Size`/`StartOffset`. Since `PruneChunkRefsToSize` deliberately keeps a ref straddling the
+new EOF **intact**, truncating a file 8 MiB → 4 MiB recomputes a byte-identical `ObjectID`. Two
+files with different content, one identity — the #1872 shape, lifted to whole-file identity.
+
+The reported harm was **refuted, and the refutation is the better finding**. The file-level dedup
+short-circuit that would conflate them does not exist:
+
+| layer | state |
+|---|---|
+| `docs/internals/architecture.md:1357-1391` | describes the feature |
+| `metadata/store.go:467` `FindByObjectID` | interface present |
+| `shares/coordinator.go:303` `ErrObjectIDConflict` | produced, **never consumed** |
+| `storetest/objectid_{lookup,roundtrip}.go` | ~450 lines of conformance tests |
+| partial UNIQUE index, both SQL dialects | enforced in schema |
+| **`applyFileLevelDedupHit`** | **never written** — named only in comments |
+
+Every supporting layer shipped; the consumer did not. `FindByObjectID` has exactly one non-test
+call site, itself an uncalled pass-through. The real consequence is narrow: the live UNIQUE index
+turns the collision into an unhandled 23505 on a legitimate truncate.
+
+This is only visible by reading `pkg/block`, `pkg/metadata`, `pkg/controlplane` and the docs
+together. Both single-package audits, by construction, saw a coherent fragment.
+
+**Decision needed — the D4 question again:** finish the feature, or delete the scaffolding.
+Deleting is consistent with "no production stores, delete eagerly", and removes the UNIQUE index
+that is the only thing the collision can currently hurt. Finishing it requires fixing
+`ComputeObjectID` first — mixing `Size`/`StartOffset` into the digest and bumping the domain
+prefix — which makes it **§11's first real migration customer**.
+
+### 13.3 The uncomfortable conclusion about scope
+
+Engine findings by area, most-hit first: `gc-mark-sweep-compaction` **15**,
+`reclaim-reconcile-audit` 10, `write-path-carve` 9, `syncer-upload-health` 9,
+`composition-lifecycle` 8, `read-path-cold-fetch` 6, `manifest-check-repair` 4,
+`offline-readiness` 3.
+
+Per §6.2, the extraction moves roughly **500 of engine's 11,304 LOC** into ferry — the upload
+window, the PUT, and a dead interface. GC, reclaim, manifest check/repair, cold-read resolution
+and offline readiness all stay. **The single new HIGH lives in `gc_sweep_index.go`, which does not
+move**, and the heaviest-hit area is the one least touched by the refactor.
+
+So the merged result does not fit the three buckets of §3 cleanly, and a fourth is needed:
+
+- **3a. Fix now** — the five journal HIGHs (#2227-#2231), plus the GC resurrection race.
+- **3b. Closed by construction** — unchanged.
+- **3c. Created by the refactor** — unchanged.
+- **3d. Untouched by the refactor.** The majority of engine's findings. The split neither fixes
+  nor endangers them; it moves a public API boundary *around* them, after which a residency-truth
+  defect in `gc.go` sits on the far side of an interface, harder to see rather than easier.
+
+That is an argument for sequencing, not against the refactor: **§3d work is worth doing before
+the boundary hardens**, while the code is still one package and a cross-cutting fix is one diff.
+
+### 13.4 Cross-boundary findings
+
+Three defects span packages, and each was invisible to at least one audit:
+
+1. **The ObjectID/dedup scaffolding** — §13.2. Spans `pkg/block`, `pkg/metadata`,
+   `pkg/controlplane`, and the architecture doc.
+2. **The GC resurrection race** — §13.1. The dedup oracle is in `engine/blocksink.go`; the marker
+   lifecycle is in `pkg/metadata`'s `SyncedHashStore`. Neither half is wrong alone.
+3. **DEALLOCATE's two-phase punch** (`pkg/metadata/sparse.go:99`, MED). The manifest prune commits
+   durably **before** `blockStore.PunchHole` zeroes the bytes, with no compensating write. Phase
+   two failing returns `NFS4ERR_IO` to the client while phase one's damage stands. Spans metadata,
+   engine, and the NFSv4 adapter — outside all three audit scopes, found only because the engine
+   audit was allowed to grep beyond its own package.
+
+### 13.5 Next actions
+
+1. **Filed as #2238.** Add it to step 0 alongside #2227-#2231. The cheap fix is to re-arm `syncedAt` on a dedup hit, so the existing grace gate covers the
+   resurrection window; the correct fix is to revalidate liveness inside the transaction that
+   deletes the marker.
+2. Decide §13.2: finish the dedup feature or delete its scaffolding.
+3. Delete the retired local-GC machinery (see §10.1) — dead since the journal switchover.
+4. Triage the 117 LOW findings per D3 — fold into the step that touches the file, sweep the
+   remainder at the end of step 3. Note the prior lesson that "duplicated"/"boilerplate"-looking
+   LOW findings have twice concealed real drift bugs here; triage by diffing, never in bulk.
+5. Re-verify every journal finding before acting: that audit's baseline `ff14b24cb` predates
+   `4ec814bc2`.
+
 ## 9. Open questions
 
 1. **Who reviews step 3?** It rewrites the silent-zeros path. One reviewer is not enough, and the
@@ -281,3 +843,9 @@ open-questions space, linking to it. **Discussions is currently disabled** on th
 2. **Does step 0 ship as a release?** No production exposure (D4), so this is a judgement call
    about testers' builds rather than an incident response. Cutting one anyway is cheap and gives
    the refactor a clean tagged baseline to diff against.
+3. **Does the remote backend honour `If-None-Match`?** No longer blocking after D13 — the fence
+   is in the metadata store — but it decides whether the second, independent check exists. One
+   conditional PUT against a scratch key settles it; probe rather than assume.
+4. **Where does the assembly (§12) live in the tree, and what is it called?** It is small enough
+   that "a package" and "a module" are both defensible; the split decision only matters at
+   `git subtree split` time.

--- a/.planning/2026-09-01-block-dataflow-MASTER-PLAN.md
+++ b/.planning/2026-09-01-block-dataflow-MASTER-PLAN.md
@@ -107,6 +107,9 @@ These do not exist today. The design introduces them and must close them.
 | `Extents()` collapsing five queries regresses the hot path | `Size` and `DurableExtent` stay separate methods; benchmark and keep receipts | review finding |
 | `fn` erroring skips the reap, stranding superseded rows that DID commit | on error pier flips validated extents and **still calls `AfterFile`** | §4.1 C5 |
 | Deferred credit bunches most flips onto the `Final` call on upload-bound files | accepted; must be **measured** (residency + time-to-flip vs today) before code | §4.4 |
+| A shared `ferry.Completions()` channel routes one file's upload completion to another file's callback — many files flush concurrently and `Submit` carries no `FileID` — silently losing durability credit | `Submit` returns a **per-call future**; no shared stream exists | §4.1 C3 |
+| Whole-extent credit matching forfeits a whole run when one unrelated byte moves — the common case on scattered writes, since `splitRuns` groups by offset only | validate and flip **per fragment**, mirroring `flipUpTo` | §4.1 C4 |
+| One `crane.Boxer` hoisted to `Syncer` lifetime interleaves two files' bytes into one block — **cross-file corruption**, and pier cannot detect it | stated caller obligation: `fn` and its accumulator constructed fresh per `Flush` | §4.1 C9 |
 
 ## 4. Sequencing
 

--- a/.planning/2026-09-01-block-dataflow-MASTER-PLAN.md
+++ b/.planning/2026-09-01-block-dataflow-MASTER-PLAN.md
@@ -100,11 +100,13 @@ These do not exist today. The design introduces them and must close them.
 
 | Risk | Mitigation | Source |
 |---|---|---|
-| A free-form `durable []Extent` lets a buggy `fn` flip a range pier never offered — today's `flipIdx` cursor makes that structurally impossible | pier validates extent provenance against the offered-and-unflipped set | v3.1 change 2 |
-| Reap outside the flush lock deletes the *next* pass's row — on a **2-second cadence**, not adversarial timing | `FlushOptions.AfterFile`, under the lock. **Mandatory** | v3.1 change 4 |
-| Concurrent `fn` calls race over block boundaries | `fn` called strictly sequentially; ALL upload concurrency lives in ferry | v3.1 change 1 |
-| `DurableTail` computed eagerly per file loses the per-run cost property | computed lazily, per call | v3.1 change 3 |
+| A free-form `durable []Extent` lets a buggy `fn` flip a range pier never offered — today's `flipIdx` cursor makes that structurally impossible | pier validates every returned extent against the offered-and-unflipped set, matching on **(offset, length, version)** — offset alone would flip new bytes when old ones were uploaded, which is the #1872 shape | §4.1 C4 |
+| Reap outside the flush lock deletes the *next* pass's row — on a **2-second cadence**, not adversarial timing | `FlushOptions.AfterFile`, under the lock. **Mandatory** | §4.2 |
+| Concurrent `fn` calls race over block boundaries | `fn` called strictly sequentially; ALL upload concurrency lives in ferry | §4.1 C1 |
+| `DurableTail` computed eagerly per file loses the per-run cost property | computed lazily, per call | §4.1 C3 |
 | `Extents()` collapsing five queries regresses the hot path | `Size` and `DurableExtent` stay separate methods; benchmark and keep receipts | review finding |
+| `fn` erroring skips the reap, stranding superseded rows that DID commit | on error pier flips validated extents and **still calls `AfterFile`** | §4.1 C5 |
+| Deferred credit bunches most flips onto the `Final` call on upload-bound files | accepted; must be **measured** (residency + time-to-flip vs today) before code | §4.4 |
 
 ## 4. Sequencing
 

--- a/.planning/2026-09-01-block-dataflow-MASTER-PLAN.md
+++ b/.planning/2026-09-01-block-dataflow-MASTER-PLAN.md
@@ -84,7 +84,7 @@ Fix nothing here separately; the design eliminates the class.
 
 | Finding | Closed by |
 |---|---|
-| `doc.go`'s false stdlib/two-interfaces claim | §9.1 import-graph **test** — a claim that cannot rot |
+| `doc.go`'s false stdlib/two-interfaces claim | design-plan §8.1 import-graph **test** — a claim that cannot rot |
 | Dead API: `RemoteStore`, `BlockID`, `PinVersion`, `SegmentLocation`, `GC` | deleted; `RemoteStore` becomes `ferry.Store` |
 | Three type-asserted manifest interfaces | evaporate: one becomes `DurableTail`, two become the caller calling itself |
 | `store.go` 1297 / `reclaim.go` 999 / `carve.go` 995 | §6.2 file layout |
@@ -369,10 +369,6 @@ open-questions space, linking to it. **Discussions is currently disabled** on th
   expose — keeping it DittoFS-side would mean widening pier's surface to let it reach in. The
   cost is accepted: pier must carry it AND test it before it is fit to publish. Its tests are
   part of step 0 (they are the prerequisite for fixing H1 and H3 at all), not deferred to step 3.
-- **D4. H1 is NOT an incident — no production exposure.** Customers are evaluating DittoFS;
-  nothing runs in production. So the five HIGH findings are serious bugs to fix on the normal
-  path, not a data-loss event to respond to, and step 0 does not need an emergency release.
-  **This also cheapens step 4 substantially** — see §4.
 - **D3. The 45 LOW findings fold into the step that touches their file.** No separate backlog, no
   issue churn.
   **Guard against the known failure mode of D3:** LOWs living in files no step rewrites would be
@@ -380,6 +376,11 @@ open-questions space, linking to it. **Discussions is currently disabled** on th
   record, and step 3 ends with an explicit sweep: walk all 45, mark each addressed / consciously
   declined / still open. A LOW that is declined is a decision, not an oversight — but it has to
   be written down as one.
+- **D4. H1 is NOT an incident — no production exposure.** Customers are evaluating DittoFS;
+  nothing runs in production. So the five HIGH findings are serious bugs to fix on the normal
+  path, not a data-loss event to respond to, and step 0 does not need an emergency release.
+  **This also cheapens step 4 substantially** — see §4.
+
 
 ## 10. The external API — what the runtime calls
 
@@ -529,7 +530,7 @@ Both live in DittoFS, not in a module: they test the seam, and the seam is what 
 
 ## 11. Format migration
 
-Deferred from §9 open question 3 and now decided. This replaces that entry.
+Deferred from §14 open question 3 and now decided. This replaces that entry.
 
 ### 11.1 Compatibility classes, not a version number
 
@@ -695,21 +696,21 @@ exactly that reason: a harbourmaster has authority, and a package named for auth
 policy drift §12 exists to prevent. If someone proposes adding a decision to `harbour`, the name
 itself is the argument against it.
 
-**D14. The assembly is `harbour`**, ships with the library set, and holds no policy.
+**D10. The assembly is `harbour`**, ships with the library set, and holds no policy.
 
 §10.7's ingestion integration test and benchmark move here, since this is the smallest thing that
 can run the whole path without DittoFS in the tree.
 
-### D9-D12 — migration and assembly (§11, §12)
+### D5-D10 — migration and assembly (§11, §12)
 
-- **D9. Scope is the block store only.** The four metadata backends keep their existing schema
+- **D5. Scope is the block store only.** The four metadata backends keep their existing schema
   handling. The block format is the one that has actually churned twice.
-- **D10. Compatibility classes, not a version integer**, and the runner/substrate split of §11.3
+- **D6. Compatibility classes, not a version integer**, and the runner/substrate split of §11.3
   is committed: one runner, `pier.Substrate` and `ferry.Substrate`, three injected primitives.
-- **D11. Revert means abort-in-progress and undo pre-contract only.** No downgrade of a completed
+- **D7. Revert means abort-in-progress and undo pre-contract only.** No downgrade of a completed
   destructive migration. `Down` is optional and its absence is a stated fact.
-- **D12. Minor applies automatically, major refuses and requires an explicit command.**
-- **D13. The remote fence lives in the metadata store**, not the bucket. Client-side CAS is
+- **D8. Minor applies automatically, major refuses and requires an explicit command.**
+- **D9. The remote fence lives in the metadata store**, not the bucket. Client-side CAS is
   forbidden. Conditional PUT is defence in depth where the backend supports it.
 
 ## 13. Merged audit results — journal + engine + block root
@@ -836,14 +837,14 @@ Three defects span packages, and each was invisible to at least one audit:
 5. Re-verify every journal finding before acting: that audit's baseline `ff14b24cb` predates
    `4ec814bc2`.
 
-## 9. Open questions
+## 14. Open questions
 
 1. **Who reviews step 3?** It rewrites the silent-zeros path. One reviewer is not enough, and the
    external contributors will not be up to speed in time.
 2. **Does step 0 ship as a release?** No production exposure (D4), so this is a judgement call
    about testers' builds rather than an incident response. Cutting one anyway is cheap and gives
    the refactor a clean tagged baseline to diff against.
-3. **Does the remote backend honour `If-None-Match`?** No longer blocking after D13 — the fence
+3. **Does the remote backend honour `If-None-Match`?** No longer blocking after D9 — the fence
    is in the metadata store — but it decides whether the second, independent check exists. One
    conditional PUT against a scratch key settles it; probe rather than assume.
 4. **Where does the assembly (§12) live in the tree, and what is it called?** It is small enough

--- a/.planning/2026-09-01-block-root-audit-report.md
+++ b/.planning/2026-09-01-block-root-audit-report.md
@@ -1,0 +1,207 @@
+# Audit Report — audit-engine (4ec814bc2)
+Stack: Go (module github.com/... single go.mod at repo root, no separate module under pkg/block). Package `block` (doc.go: "package blockstore" historically, now `block`) at pkg/block root — 14 non-test .go files, 2,038 LOC. Stdlib-only within this scope except `lukechampine.com/blake3` (objectid.go). No frameworks, no codegen, no build tooling beyond `go build`/`go test`. Consumed by sibling packages engine/, journal/, local/, remote/, compression/, encryption/, blockcodec/, blockstoretest/ (all import "pkg/block" for the shared types) — those are OUT OF SCOPE for this audit (separately audited) and exist here only as grep targets for reachability/callers/pinning tests. · Areas: 3 · Findings: 0 HIGH / 2 MED / 20 LOW
+
+## Summary by dimension
+
+| Dimension | HIGH | MED | LOW |
+|---|---|---|---|
+| bugs | 0 | 2 | 5 |
+| security | 0 | 0 | 0 |
+| slop | 0 | 0 | 4 |
+| perf | 0 | 0 | 2 |
+| structure | 0 | 0 | 4 |
+| bloat | 0 | 0 | 1 |
+| comments | 0 | 0 | 4 |
+
+## Summary by area
+
+| Area | Findings |
+|---|---|
+| cross | 3 |
+| manifest-identity-types | 5 |
+| store-contract-policy | 13 |
+| structures-and-legacy | 1 |
+
+## Findings
+
+### [LOW] doc.go Sub-packages list names 3 directories that don't exist under pkg/block · `structure` · area: store-contract-policy
+- **Where:** `pkg/block/doc.go:101`
+- **What:** Lines 101-121 "Sub-packages" list 8 entries incl migrate, gc, storetest. migrate/ doesn't exist anywhere. gc/ isn't a pkg/block dir (gc.go/gc_block.go are files inside engine/). storetest/ isn't under pkg/block (that's pkg/metadata/storetest, different pkg).
+- **Why it matters:** Repo has demonstrated pattern (3 prior confirmed instances) of doc.go overclaiming sub-packages. Contributor grepping pkg/block/migrate or pkg/block/gc wastes a round trip; misdirects on where GC/migration logic lives (embedded in engine/, already audited). List also omits real sub-packages journal, compression, encryption, blockcodec.
+- **Fix:** Drop migrate and gc bullets (no such packages; GC/migration live in engine/, documented there). Fix storetest bullet to point at pkg/metadata/storetest or delete. Add missing journal, compression, encryption, blockcodec entries.
+- **Verified:** CONFIRMED. Actual pkg/block dirs: blockcodec, blockstoretest, chunker, compression, encryption, engine, journal, local, remote. No migrate/, gc/, storetest/ under pkg/block.
+
+### [LOW] Doc comments reference nonexistent type "BlockStore" — the interface is named Store · `comments` · area: store-contract-policy
+- **Where:** `pkg/block/blockstore.go:1`
+- **What:** blockstore.go:1,19-20,27,93; doc.go:43,58,112; errors.go:201 all say "BlockStore." (e.g. "BlockStore.Head and BlockStore.Walk", "BlockStore.Get") but no such type exists — the declared interface is `type Store`.
+- **Why it matters:** Stale name from pre-rename state; godoc-style refs resolve to nothing, misleads a reader grepping for the type by name.
+- **Fix:** Replace "BlockStore." with "Store." throughout blockstore.go, doc.go, errors.go.
+- **Verified:** CONFIRMED. grep "type BlockStore" in pkg/block finds nothing; interface is `type Store`. All 8 cited refs present verbatim.
+
+### [LOW] ErrUnknownHash doc cites a file that doesn't exist and the wrong package for AddRef · `comments` · area: store-contract-policy
+- **Where:** `pkg/block/errors.go:145`
+- **What:** Comment says "The LRU hit path (Opt 1 — see pkg/block/local/fs/rollup.go)". No rollup.go exists anywhere. AddRef lives in pkg/metadata/store/{badger,sqlite,postgres,memory}/objects.go and store/sql/chunks.go, not pkg/block/local/fs.
+- **Why it matters:** Stale/misleading pointer; sends reader chasing a nonexistent file. Sentinel is prod-live (badger/objects.go:335, memory/objects.go:421/425).
+- **Fix:** Drop the "see pkg/block/local/fs/rollup.go" pointer, or repoint at the actual AddRef sites under pkg/metadata/store/.
+- **Verified:** CONFIRMED. find -name 'rollup*.go' empty; local/fs holds only fs.go/legacy*.go. Comment-only, severity LOW.
+
+### [LOW] chunker sub-package bullet contradicts doc.go's own removed-migration-tool statement · `comments` · area: store-contract-policy
+- **Where:** `pkg/block/doc.go:114`
+- **What:** Line 114-115: "chunker: FastCDC chunker used by both writes and by the migration tool." Contradicts doc.go:75-77: "dfs migrate-to-cas shipped through v0.21 and has been removed."
+- **Why it matters:** Self-contradictory within same doc block. Bonus: doc.go:116-117 lists a `migrate` sub-package with MigrateShareToCAS — dir doesn't exist, symbol not found by grep.
+- **Fix:** Cut "and by the migration tool" from chunker bullet; delete the migrate bullet entirely.
+- **Verified:** CONFIRMED. Real chunker importers: journal/{carve,index,store}.go, local/fs/fs.go, runtime/shares/blockstore_config.go, internal/dfsbench. No migration tool consumes it.
+
+### [LOW] ChunksForPayload silently accepts offsets above the package's own MaxInt64 ceiling, disagreeing with ParseChunkOffset/ChunkOffsetFor on the same ID string · `bugs` · area: cross
+- **Where:** `pkg/block/ids.go:125`
+- **What:** ChunksForPayload parses trailing numeric component via bare `strconv.ParseUint(suffix, 10, 64)` (ids.go:122), no `> math.MaxInt64` reject, unlike ParseChunkOffset (:28-29) and ChunkOffsetFor (:68-69). Doc comment (:16-21) says the guard "keeps the conversion total for all callers" — this caller skips it.
+- **Why it matters:** Reachable via memory/objects.go:510 and store/sql/chunks.go:199 (backs ListFileChunks for memory/sqlite/postgres). But keeping unplaceable rows is deliberate/documented (ids.go:105-107, "dropping it would hide the damage"), so membership divergence isn't a bug. Real delta: such a row sorts LAST at a huge key instead of the documented "keys as 0" (ids.go:114) — an ordering/doc mismatch, corrupted-row-only.
+- **Fix:** Route through ChunkOffsetFor(r.ID, payloadID), default off=0 when !ok, so all offset-placement decisions share one guarded impl.
+- **Verified:** CONFIRMED but narrower than claimed. Downgraded MED→LOW: doc-mismatch on ordering of corrupted rows, not a membership/correctness bug.
+
+### [LOW] FileChunk struct has inconsistent JSON field tagging · `structure` · area: manifest-identity-types
+- **Where:** `pkg/block/types.go:242`
+- **What:** Only LastSyncAttemptAt (:282, `json:"last_sync_attempt_at,omitempty"`) and State (:289, `json:"state"`) tagged; ID/Hash/DataSize/StartOffset/RefCount/LastAccess/CreatedAt untagged, serialize as bare Go names. ChunkRef in same file is fully tagged snake_case.
+- **Why it matters:** FileChunk IS json-marshaled in prod — badger's on-disk value (store/badger/objects.go:347 `json.Marshal(&block)`, read back :449 `json.Unmarshal(val, &fc)`). Six on-disk key names are unpinned Go field names: a field rename silently changes the badger record layout, old rows decode with zero values — same class as this repo's recurring silent-zeros bugs.
+- **Fix:** Tag all 8 fields snake_case matching ChunkRef — but it's a format change, needs a format-version bump or dual-read, not a blind retag.
+- **Verified:** CONFIRMED, more load-bearing than the claim assumed (on-disk encoding, not just a hypothetical debug dump).
+
+### [LOW] doc.go documents a TRANSITIONAL-marker grep convention with zero adoption anywhere in the repo · `structure` · area: store-contract-policy
+- **Where:** `pkg/block/doc.go:123`
+- **What:** Lines 123-146: 24 lines specifying TRANSITIONAL-PHASE-N / TRANSITIONAL-NEXT-MILESTONE marker convention + grep recipe. Repo-wide grep for TRANSITIONAL- hits only doc.go itself (:128/132/144) — zero usages.
+- **Why it matters:** Dead process doc; the documented grep returns empty, indistinguishable from "convention abandoned." Repo already has a live, adopted marker convention (`ponytail:`) doing this job.
+- **Fix:** Delete the 24 lines.
+- **Verified:** CONFIRMED. Zero adopters repo-wide.
+
+### [MED] ComputeObjectID's Merkle root hashes only ChunkRef.Hash, ignoring Size/StartOffset — two files with genuinely different byte content can collide on ObjectID and be conflated by the file-level dedup short-circuit · `bugs` · area: cross
+- **Where:** `pkg/block/objectid.go:36`
+- **What:** ComputeObjectID folds only `blocks[i].Hash` into BLAKE3 Merkle root (line 39-40), never Size/StartOffset. Hash = hash of FULL underlying chunk (types.go:249-271, 146-165); Size/StartOffset pick the sub-range a row actually claims, narrows on truncate/carve (types.go:264-270) while Hash stays same. Two ChunkRefs, same Hash H, diff Size/StartOffset (e.g. full 8MiB chunk vs same chunk narrowed to 2nd half 4MiB) → genuinely diff bytes, diff file size, same ComputeObjectID.
+- **Why it matters:** ObjectID persisted every quiesce: file_modify.go:458, sparse.go:91. Doc's own dedup-short-circuit story (coordinator FindByObjectID/PersistFileChunks/ErrObjectIDConflict) implied silent content conflation across files — refuted on verify: `applyFileLevelDedupHit`/`TrySpeculativeFileLevelDedup` = 0 Go hits, no `engine/dedup.go`, `FindByObjectID` has no non-test caller, `ErrObjectIDConflict` declared and never consumed. Real consequence: UNIQUE index is live (postgres `000013_object_id.up.sql`, sqlite `000001` `inodes_object_id_idx ... WHERE object_id IS NOT NULL`) → colliding 2nd file hits unhandled 23505 on SetManifest → spurious write failure, not silent corruption. objectid_test.go's `TestComputeObjectID_MutationDiff` only flips a Hash byte, never varies Size/StartOffset — zero coverage either way.
+- **Fix:** Fold Size + StartOffset into BLAKE3 input alongside Hash (`h.Write(blocks[i].Hash[:]); binary.Write(h, binary.BigEndian, blocks[i].StartOffset); binary.Write(h, binary.BigEndian, blocks[i].Size)`). Wire-format change — bump `objectIDDomainPrefix` to v2 per its own doc comment, needs migration note.
+- **Verified:** DEFECT CONFIRMED, stated dedup-conflation harm REFUTED — no consumer wired. Real effect narrower: unhandled unique-constraint violation on collision, not silent conflation. Reachable in prod (truncate keeps straddling ref intact per PruneChunkRefsToSize, ObjectID recomputed unchanged over it — collision needs no exotic setup).
+
+### [MED] DEALLOCATE's two-phase punch has no rollback: metadata-manifest prune commits durably before the block-store punch that actually zeroes bytes, and a phase-2 failure is reported to the client with phase-1 damage standing · `bugs` · area: cross
+- **Where:** `pkg/metadata/sparse.go:99`
+- **What:** `metadata.Service.PunchHole` prunes via `block.PunchHole` (sparse.go:84) and commits with `store.SetManifest` at sparse.go:99 — removes every fully-contained ChunkRef from manifest, so SEEK_HOLE/READ_PLUS now report hole there. Caller `internal/adapter/nfs/v4/handlers/deallocate.go:67-91` calls `metaSvc.PunchHole` FIRST (commits prune), then `blockStore.PunchHole` (engine) to zero bytes + reap refcounts. Phase-2 fail (I/O err, ctx cancel) → handler returns NFS4ERR_IO at :95, no compensating write, no re-add of pruned refs.
+- **Why it matters:** Handler's own comment (:73-80): read path resolves via dual-read shim off empty ChunkRef list, so metadata prune alone does NOT guarantee zero reads — only the block-store zero-overwrite does. Failed phase 2 leaves exactly that gap permanently: manifest says hole, refcounts never decremented (orphan leak blocking GC), bytes never zeroed — a plain READ can surface old pre-punch bytes while SEEK_HOLE disagrees. Client told op failed, no reason to retry, nothing drives convergence. Same residency-truth-failure class as RestoreToVersion/Truncate, one layer up from engine.Store.PunchHole itself.
+- **Fix:** Either reorder (engine zero+reap first, SetManifest after — physical-before-metadata, matches rule used elsewhere) or, if metadata-first order must stay for FlushPendingWriteForFile serialization, repair the manifest (re-add res.PreOpBlocks for still-physically-present chunks, or route through manifest_repair.go) when blockStore.PunchHole fails.
+- **Verified:** CONFIRMED. sparse.go:99 commits durably; deallocate.go:70→91→95 no compensating write on phase-2 error. Reachable via live NFSv4.2 DEALLOCATE (non-test, wired through h.Registry/common.ResolveForWrite). Severity HIGH→MED: needs phase-2 failure to fire (I/O error, ctx cancel), not every call.
+
+### [LOW] doc.go claims 'migrate' and 'gc' sub-packages that do not exist under pkg/block · `slop` · area: store-contract-policy
+- **Where:** `pkg/block/doc.go:116`
+- **What:** `# Sub-packages` lists `migrate: ... MigrateShareToCAS` and `gc: Mark-sweep garbage collection ...` as children of pkg/block. Neither dir exists (`ls pkg/block/migrate`, `ls pkg/block/gc` = nothing). `gc.go`/`gc_block.go`/`gcstate.go` actually live in `pkg/block/engine/`. `MigrateShareToCAS` appears NOWHERE else in repo — hallucinated symbol.
+- **Why it matters:** Contributor greps `pkg/block/migrate` or `MigrateShareToCAS` per this doc, finds nothing — wasted time, false confidence a dedicated GC/migrate package exists. Same overclaiming pattern flagged 3x elsewhere.
+- **Fix:** Delete `migrate:` bullet (tool already removed per doc.go's own "# On-disk format versions" section). Repoint `gc:` bullet at `pkg/block/engine`.
+- **Verified:** CONFIRMED. No `pkg/block/migrate`, 0 hits for `package migrate` or `MigrateShareToCAS` outside doc.go. gc lives in `pkg/block/engine/`. Doc-only, zero runtime effect → severity HIGH→LOW. Duplicate finding across idx 0/1/2/7 — count once.
+
+### [LOW] doc.go Sub-packages list names three directories that don't exist under pkg/block · `bloat` · area: store-contract-policy
+- **Where:** `pkg/block/doc.go:116`
+- **What:** `migrate:` (116-117) and `gc:` (118-119) — no such dirs; gc lives in `pkg/block/engine/`. `storetest:` (120-121) claims "Legacy conformance test suites for higher-level FileChunkStore implementations" as pkg/block child — real pkg is `pkg/metadata/storetest` (per CLAUDE.md: "Store contracts live in pkg/metadata/storetest"), not under pkg/block at all.
+- **Why it matters:** 3 of 8 bullets in Sub-packages section false. Contributor greps pkg/block/{migrate,gc,storetest}, finds nothing. Same overclaiming pattern confirmed 3x elsewhere (doc rule: comments must be factually true against actual layout).
+- **Fix:** Delete `migrate`, `gc`, `storetest` bullets. If gc location worth noting: "gc: mark-sweep GC lives in pkg/block/engine (gc.go et al.), not a separate package."
+- **Verified:** CONFIRMED, same defect as idx 0 plus storetest bullet. Real pkg/block sub-dirs: blockcodec, blockstoretest, chunker, compression, encryption, engine, journal, local, remote. Duplicate of idx 0/2/7 — count once. Doc-only → LOW.
+
+### [LOW] doc.go sub-package list names two directories that don't exist and misattributes a third · `comments` · area: store-contract-policy
+- **Where:** `pkg/block/doc.go:116`
+- **What:** `migrate:` (116-117), `gc:` (118-119) claimed as pkg/block sub-packages — neither exists (`Glob pkg/block/migrate/**`, `Glob pkg/block/gc/**` = nothing). gc.go lives in `pkg/block/engine/` (gc.go, gc_block.go, gc_sweep_index.go, gcstate.go). No migrate/ anywhere (offline migration tool removed, per doc.go's own 75-77). `storetest:` (120-121) — no `pkg/block/storetest`; description matches `pkg/metadata/storetest`.
+- **Why it matters:** Stale doc gives false directory map. 4th/5th/6th instance of same overclaiming pattern in this one list.
+- **Fix:** Delete `migrate`+`gc` bullets (or repoint gc at pkg/block/engine); delete or repoint `storetest` at pkg/metadata/storetest.
+- **Verified:** CONFIRMED, duplicate of idx 0/1/7. No pkg/block/migrate, no pkg/block/gc, no pkg/block/storetest; gc in engine, storetest in pkg/metadata. Doc-only → LOW, no runtime path.
+
+### [LOW] ContentHash.UnmarshalJSON legacy array form skips length validation — silently accepts a truncated/oversized hash instead of erroring · `bugs` · area: manifest-identity-types
+- **Where:** `/Users/marmos91/dittofs-worktrees/audit-engine/pkg/block/types.go:115`
+- **What:** Legacy branch: `var arr [HashSize]byte; json.Unmarshal(data, &arr)`, accepts on `err == nil`. encoding/json array-into-fixed-array: silently zero-pads short arrays, silently truncates long ones — never errors on length mismatch. `[]` → zero hash, no error. 10 or 40-element array → wrong hash, no error. Sibling branches (hex :125, base64 :133) both gate on `len(...) == HashSize` first — array branch is the ONLY one with no check.
+- **Why it matters:** Package's own ErrFutureFormat rationale explicitly rejects "decodes cleanly into ... the wrong thing." ContentHash flows into FileChunk.Hash/ChunkRef.Hash → dedup lookups, read-path chunk resolution.
+- **Fix:** Unmarshal into `[]byte` first, check `len(raw) == HashSize`, else return ErrInvalidHash-wrapped error — mirror hex/base64 branches.
+- **Verified:** CONFIRMED by execution: `json.Unmarshal([]byte("[1,2,3]"), &[32]byte{})` → err=nil zero-padded; 40-element → err=nil truncated to 32. Reachable: badger persists File/FileChunk as JSON (block_record_store.go:40 et al.), production decode path. Severity MED→LOW: array form only in v0.14.x-era rows (always 32 elements historically) — mismatch needs already-corrupt data; wrong-but-valid hash still fails closed downstream (ErrChunkContentMismatch/ErrChunkNotFound), not silent bad bytes served.
+
+### [LOW] doc.go Sub-packages list names two directories that don't exist under pkg/block (migrate, gc) plus a third pointing at the wrong tree (storetest) · `bugs` · area: store-contract-policy
+- **Where:** `pkg/block/doc.go:101`
+- **What:** Lines 101-121, 7 'sub-packages' incl. `migrate: ... MigrateShareToCAS`, `gc: Mark-sweep garbage collection ...`, `storetest: Legacy conformance test suites ...`. None exist under pkg/block: gc.go lives in `pkg/block/engine/gc.go`; real storetest is `pkg/metadata/storetest` (referenced from `pkg/metadata/storetest/file_block_ops.go`). Also `chunker` bullet (114-115) says chunker "used by both writes and by the migration tool" while doc.go's own text (75-78) says that tool "has been removed" — self-contradictory.
+- **Why it matters:** Every exported doc comment must be factually true against actual layout; demonstrated pattern (3 prior confirmed instances) of doc.go overclaiming. Misdirects on where mark-sweep GC / migration logic actually lives.
+- **Fix:** Delete `migrate`+`gc` bullets; fix or drop `storetest` (point at pkg/metadata/storetest); drop "and by the migration tool" clause from chunker bullet.
+- **Verified:** CONFIRMED, duplicate of idx 0/1/2 plus one extra true point: doc.go:114-115 vs :75-77 self-contradict on migration tool's existence. Doc-only → LOW.
+
+### [LOW] doc.go package-doc first line names the wrong package ("blockstore" vs actual package "block") · `bugs` · area: store-contract-policy
+- **Where:** `pkg/block/doc.go:1`
+- **What:** Line 1: "Package blockstore defines the unified content-addressed block storage contract..." — but `blockstore.go:12` declares `package block`. Doc still uses pre-rename name.
+- **Why it matters:** Go convention (and go/doc tooling) expects doc comment to start "Package \<actual-name\>"; go doc / pkg.go.dev renders mismatched header. Same overclaiming pattern flagged elsewhere in this file.
+- **Fix:** Change line 1 to "Package block defines...".
+- **Verified:** CONFIRMED. doc.go:1 says "Package blockstore..."; blockstore.go declares `package block`; doc.go's own last line says `package block`. Cosmetic, no runtime effect → severity MED→LOW.
+
+### [LOW] TRANSITIONAL-marker convention documented in doc.go is used nowhere in the entire repository · `bugs` · area: store-contract-policy
+- **Where:** `pkg/block/doc.go:123`
+- **What:** Lines 123-146 document `TRANSITIONAL-PHASE-N`/`TRANSITIONAL-NEXT-MILESTONE` as a live grep convention, doc.go:144 literally says `grep -rn 'TRANSITIONAL-' ./pkg/block`. Repo-wide grep for `TRANSITIONAL-` hits only doc.go itself + `.planning/audits/2026-08-05-dataplane/report.md:1088` (a prior audit that already flagged this exact paragraph as dead and suggested pointing at `engine/cache.go` instead — that site has no marker either).
+- **Why it matters:** Guard/convention never actually used is unverified, not proven — same class as "a guard that never fired." Documents process that doesn't exist.
+- **Fix:** Delete lines 123-146 (prior audit already recommended this, still unused).
+- **Verified:** CONFIRMED. Only files containing the string: pkg/block/doc.go itself and the planning report. Zero adopters anywhere, including the fallback site. Doc-only → severity MED→LOW.
+
+### [LOW] ContentHash.UnmarshalJSON legacy array branch skips length validation — malformed input silently decodes to a wrong/zero hash instead of erroring · `slop` · area: manifest-identity-types
+- **Where:** `pkg/block/types.go:115`
+- **What:** v0.14.x legacy-array branch: `if data[0]=='['{ var arr [HashSize]byte; if json.Unmarshal(data,&arr)==nil { *h=ContentHash(arr); return nil } }`. Array-into-fixed-array: short array zero-padded, long array truncated, no error either way. `[]` → all-zero hash, no error. Sibling hex branch checks `len==HashSize*2`, base64 checks `len==HashSize` — only array branch unchecked.
+- **Why it matters:** Answers the "can dual-JSON tolerance produce ambiguous decode" question directly — yes, for array branch. ContentHash zero value is the documented pending-sentinel for FileChunk.Hash, so a corrupted legacy array on a real row decodes cleanly to that sentinel with no error — "malformed record decodes into a different, valid-looking state" shape.
+- **Fix:** Decode into `[]byte` first, check `len == HashSize`, return same ErrInvalidHash-wrapped error as sibling branches instead of letting array-fill silently succeed.
+- **Verified:** Confirmed at types.go:115-125 (no length check) vs hex :127 / base64 :137 (both gated). Verified by running: `[]`→nil,zero; `[1,2,3]`→nil,padded; 40-elem→nil,truncated to 32. Reachable: badger encoding.go:84 marshal / :456 unmarshal → ChunkRef.Hash → this func. Downgraded MED→LOW: no producer ever emits wrong-length array (encoding/json always wrote 32 for [32]byte); byte-truncated badger value fails JSON parse outright — wrong-decode needs a corrupt/foreign writer, hardening gap not live bug. Duplicate of idx 5 — prefer deleting the array (and base64) branches per idx 8's fix over adding a length check alone.
+
+### [LOW] doc.go claims 'storetest' as a sub-package of pkg/block — it is actually pkg/metadata/storetest · `slop` · area: store-contract-policy
+- **Where:** `pkg/block/doc.go:120`
+- **What:** `storetest: Legacy conformance test suites for higher-level FileChunkStore implementations` listed under `# Sub-packages` — implies pkg/block/storetest, no such dir. Real package is `pkg/metadata/storetest`, a sibling tree, not a child of pkg/block.
+- **Why it matters:** Same overclaiming-doc pattern flagged as primary audit target; misleads on package ownership boundaries.
+- **Fix:** Drop bullet or correct path to `pkg/metadata/storetest`, note it's not a child.
+- **Verified:** Confirmed: doc.go:120-121. `ls pkg/block/` = blockcodec, blockstoretest, chunker, compression, encryption, engine, journal, local, remote — no storetest. Real pkg is `pkg/metadata/storetest` (file_block_ops.go et al.), sibling tree. Doc-only → LOW not MED.
+
+### [LOW] doc.go's 'Transitional-marker convention' documents markers that are used nowhere in the codebase · `slop` · area: store-contract-policy
+- **Where:** `pkg/block/doc.go:123`
+- **What:** Describes `TRANSITIONAL-PHASE-N:`/`TRANSITIONAL-NEXT-MILESTONE:` as established grep-able convention. `grep -rn 'TRANSITIONAL-' .` repo-wide returns doc.go as ONLY match — zero call sites use either marker.
+- **Why it matters:** Presented present-tense as codebase fact ("the goal is for `grep -rn 'TRANSITIONAL-' ./pkg/block` to enumerate every deferral surface") but never adopted. Contributor following doc gets zero results, wrongly concludes no deferred-deletion debt exists — debt does exist (legacy_cas.go migration-only surface), just unmarked.
+- **Fix:** Either apply markers to real transitional surfaces (legacy_cas.go, `remote.LegacyCASStore` legacy path), or delete this aspirational section.
+- **Verified:** Confirmed: `grep -rn 'TRANSITIONAL-'` over whole worktree hits only doc.go:128,132,144 (definition + own grep recipe) + `.planning/audits/2026-08-05-dataplane/report.md:1088` (already flagged this exact paragraph dead a month ago; its suggested fallback site `engine/cache.go` carries no marker either). Zero adopters. Doc-only → LOW.
+
+### [LOW] ContentHash.MarshalJSON allocates+discards via CASKey() instead of encoding hex directly into the preallocated buffer · `perf` · area: manifest-identity-types
+- **Where:** `/Users/marmos91/dittofs-worktrees/audit-engine/pkg/block/types.go:98`
+- **What:** MarshalJSON preallocates `out` exact-cap (99) then calls `h.CASKey()` (101), which does `hex.EncodeToString` (2 allocs) + `"blake3:"+...` concat (1 alloc) = 3 throwaway allocs, all copied into `out` then discarded.
+- **Why it matters:** Drives ChunkRef JSON serialization for every FileAttr.Blocks write to Postgres/Badger, once per chunk per manifest write/read — 3 extra allocs × N chunks on hot metadata path for large files.
+- **Fix:** Write directly into `out`: copy `"blake3:"` then `hex.Encode(out[tail:], h[:])` instead of calling CASKey(). 3 allocs → the 1 already-planned `out` alloc.
+- **Verified:** Confirmed from source: types.go:99 prealloc, :101 `append(out, h.CASKey()...)`, CASKey (types.go:33-35) = `"blake3:"+hex.EncodeToString(h[:])`, 3 throwaway allocs/chunk. Reachable: badger encoding.go:84 `json.Marshal(blocks)` on fm: manifest write path. Severity MED→LOW: dwarfed by JSON encoder's own reflection/buffer work on same path — micro-nit not hot-path defect.
+
+### [LOW] PunchHole re-sorts an already-sorted output — redundant O(n log n) every DEALLOCATE · `perf` · area: structures-and-legacy
+- **Where:** `pkg/block/holemap.go:230`
+- **What:** PunchHole filters refs (drop-only, no split/insert) then unconditionally calls `sortChunkRefsByOffset(out)` at :230. Input `refs` contractually sorted by Offset (holemap.go:9-10, `FileAttr.Blocks` documented sorted; sparse.go passes `file.Blocks` straight through). Drop-only filter preserves order → `out` already sorted when sort runs, every call, not just rare path. `TestPunchHole` (holemap_test.go:209) never exercises unsorted input — defensive branch unverified too.
+- **Why it matters:** Unnecessary sort pass (closure/interface overhead) on top of the O(n) filter that already produced correctly-ordered output, on every DEALLOCATE. No reordering step to justify it, unlike neighboring MergeChunkRefsByOffset/PruneChunkRefsToSize pattern.
+- **Fix:** Drop trailing `sortChunkRefsByOffset(out)` call — drop-only filter on sorted input preserves order. If defensive re-sort genuinely wanted, mark `ponytail:` naming the ceiling instead of paying cost silently.
+- **Verified:** Confirmed: holemap.go:219-231, drop-only filter, order preserved under documented invariant. Reachable: sparse.go:84 `block.PunchHole(file.Blocks,...)` ← Service.PunchHole:48 ← nfs/v4/handlers/deallocate.go:67. Two corrections → severity MED→LOW: (a) NOT O(n log n) — sort.Slice's pdqsort has presorted detection, degenerates ~O(n) here; (b) DEALLOCATE also does a real zero-overwrite in engine/readwrite.go:277, sort cost unmeasurable next to it. Genuine dead work, safe to drop, not a perf-worthy finding at MED.
+
+### [LOW] ContentHash legacy JSON-array decode has no length check — encoding/json silently zero-pads/truncates · `structure` · area: manifest-identity-types
+- **Where:** `pkg/block/types.go:115`
+- **What:** UnmarshalJSON legacy `[...]` branch: `json.Unmarshal(data, &arr)` into fixed `[HashSize]byte`. Short array → zero-filled tail, success. Long array → excess silently discarded, success. No length check (contrast canonical/base64 paths, both gate `len(...)==HashSize`).
+- **Why it matters:** Exact anti-pattern package's own ErrFutureFormat rationale rejects ("decodes successfully into ... the wrong thing"). Blast radius MED not HIGH: FileChunk.Hash doesn't physically locate bytes (ChunkLocator/synced-hash lookups keyed separately, fail closed on genuine miss per locator.go IsStandalone contract) — observable failure is a loud lookup miss, not silent zeros served. Also: this dead-Badger-build compat branch (+ base64 branch below it) is the "legacy surface for a migration nobody runs" pattern flagged elsewhere — first choice is deletion, not a length fix.
+- **Fix:** Given "no production stores in the field" decision, delete JSON-array + base64 legacy branches (111-122, 136-142) outright, keep only canonical `blake3:{hex}`/bare-hex forms. If fallback must stay: decode into `[]byte` first, reject `len(b) != HashSize` before copy, matching hex/base64 discipline already in same func.
+- **Verified:** Same defect as idx 2 (types.go:115-125 no gate; siblings :127/:137 gated), confirmed identically. Mitigation verified: hash not used to physically locate bytes, so failure mode is a loud lookup miss. Stronger point holds: branch exists only for pre-v0.14.x badger rows, matches repo's "no production stores in field → delete legacy eagerly" convention. Dedup with idx 2; prefer deleting array+base64 branches over adding a length check.
+
+## Implementation gaps vs reference
+
+No dedicated `gaps` findings this pass — table below cross-refs the reference checklist against what this audit actually verified in `pkg/block` root (doc.go/errors.go/types.go/retention.go/locator.go). Rows marked *not audited* fall in sibling pkgs (engine/local/remote/chunker) — out of scope per this report's header, need their own pass.
+
+| Expected (reference) | Our behavior | Gap | Source |
+|---|---|---|---|
+| Put idempotent on identical-hash content, no error on repeat | `ErrContentExists` sentinel defined in errors.go; doc.go states Put contract idempotent | Backend enforcement lives in engine/local/remote — not audited this pass | https://pkg.go.dev/github.com/containerd/containerd/content |
+| Get on missing key returns one centralized not-found sentinel | `ErrContentNotFound`/`ErrChunkNotFound` defined at interface level | Sentinel exists; per-backend translation (badger/S3/etc, sibling pkgs) not audited this pass | https://pkg.go.dev/github.com/ipfs/boxo/blockstore |
+| Every Store method takes `context.Context` first param | Not checked this pass — Store interface sig not diffed against convention | Unverified — add to next engine-scope pass | https://github.com/ipfs/go-ipfs-blockstore/blob/master/blockstore.go |
+| Walk uses sentinel early-exit (`ErrStopWalk`), not bool/context-cancel | Confirmed: doc.go/errors.go document `ErrStopWalk` mirroring `filepath.SkipDir` | None — matches, but doc comments say "BlockStore.Walk" (stale type name, no such type — see LOW finding above, comments/store-contract-policy) | https://pkg.go.dev/io/fs#SkipAll |
+| GetRange follows io.ReaderAt EOF/short-read semantics | Not checked this pass | Unverified — need GetRange impl read, out of scope (sibling pkg) | https://pkg.go.dev/io#ReaderAt |
+| Residency ≥3 states (not local/remote bool) | Confirmed: `BlockState` Pending→Syncing→Remote in types.go, matches Lustre EXISTS/ARCHIVED/DIRTY shape | None at type level | https://github.com/LiXi-storage/lustre_manual_markdown/blob/master/26-Hierarchical%20Storage%20Management%20(HSM).md |
+| "Synced" and "safe to reclaim" are separate predicates, not one bit | **Violated.** DEALLOCATE two-phase punch (`pkg/metadata/sparse.go:99` commits manifest prune before `blockStore.PunchHole` zeroes bytes) — phase-2 failure leaves manifest saying "reclaimed" with stale refcounts/bytes still standing, same class as #1850/#1888/#2084 | Reorder to physical-before-metadata, or repair manifest on phase-2 fail — see MED finding above (cross/bugs, sparse.go:99) | https://learn.microsoft.com/en-us/windows/win32/api/cfapi/nf-cfupdateplaceholder |
+| Confirmed-lost distinct from not-yet-uploaded | Confirmed: `ErrChunkLostBeforeMirror` sentinel, doc comment says hash retained for retry | None found | DittoFS `pkg/block/errors.go:ErrChunkLostBeforeMirror` |
+| Pin/retain is async intent, not a blocking guarantee | `RetentionPin` policy shape in retention.go — not exercised against a concurrent-eviction path this pass | Unverified — needs engine-scope eviction-path test | https://learn.microsoft.com/en-us/windows/win32/cfapi/build-a-cloud-file-sync-engine |
+| Sentinels are package `var`s, compared via `errors.Is` | Confirmed: `ErrStopWalk`, `ErrFutureFormat` etc documented this way | Doc text itself stale — refers to nonexistent `BlockStore` type and a nonexistent `rollup.go` path (LOW findings, comments/store-contract-policy) | https://pkg.go.dev/errors#Is |
+| Forward-incompatible format fails loud, never decodes silently | Confirmed: `ErrFutureFormat` doc states this explicitly, matches intent | ContentHash.UnmarshalJSON legacy array branch violates the same principle one type over: zero-pads/truncates instead of erroring (LOW finding above, types.go:115, bugs/structure/slop area: manifest-identity-types) | DittoFS `pkg/block/errors.go:ErrFutureFormat` |
+| "Not yet indexed" has own sentinel distinct from "not found" | Confirmed: `ErrUnknownHash` documents the LRU-hit fallback contract | Doc comment points at nonexistent `pkg/block/local/fs/rollup.go` — real AddRef sites are `pkg/metadata/store/*/objects.go` (LOW finding above, errors.go:145) | DittoFS `pkg/block/errors.go:ErrUnknownHash` |
+| Full 32-byte BLAKE3 digest as address, never truncated | Confirmed: `HashSize = 32` in types.go | None on ContentHash itself. Related gap one layer up: `ComputeObjectID`'s Merkle root hashes only `ChunkRef.Hash`, drops Size/StartOffset — two chunks sharing a Hash but different Size/StartOffset collide on ObjectID (MED finding above, objectid.go:36) | https://github.com/BLAKE3-team/BLAKE3-specs |
+| Recomputed hash checked against stored hash on read, bad bytes never reach caller | Confirmed: `ErrChunkContentMismatch` doc states this | None found this pass | https://pkg.go.dev/github.com/ipfs/boxo/blockstore |
+| BLAKE3 tree-chunking kept separate from storage-layer CDC chunking; chunk-size side channel (restic CVE-shape) considered | Not checked — `chunker/` is sibling pkg, out of scope | Unverified — flag for chunker-scope audit | https://github.com/restic/restic/blob/master/doc/design.rst |
+| Chunk logical hash kept separate from physical (block, offset, length) | Confirmed: `ChunkLocator{BlockID, WireOffset, WireLength}` matches restic pack-index / JuiceFS chunk-slice-block split | None found | https://github.com/restic/restic/blob/master/doc/design.rst |
+| Legacy locator format refused on live read path, fail-closed | `ChunkLocator.IsStandalone()` doc states this contract — not exercised against an actual legacy row this pass | Unverified — needs journal/migration-scope test | DittoFS `pkg/block` locator.go:IsStandalone |
+| GC never deletes an object mid-write; fails closed on zero timestamp | doc.go states GC "fails closed on a zero timestamp" but GC code itself lives in `pkg/block/engine/gc*.go`, out of scope here. Also: doc.go's own Sub-packages list still claims a `gc` sub-package under pkg/block that doesn't exist (multiple LOW findings above, store-contract-policy) | Contract not verified against actual engine/gc*.go this pass; doc's own package map for where to find it is wrong | https://git-scm.com/docs/git-gc |
+| Every backend stamps non-zero reliable write timestamp | Not checked — backend write paths are sibling pkgs (local/remote/badger etc), out of scope | Unverified — flag for backend-scope audit | DittoFS `pkg/block/doc.go` (internal invariant, no external source) |
+
+Path: `/Users/marmos91/dittofs-worktrees/audit-engine/pkg/block/report.md`

--- a/.planning/2026-09-01-block-root-audit-report.md
+++ b/.planning/2026-09-01-block-root-audit-report.md
@@ -109,7 +109,7 @@ Stack: Go (module github.com/... single go.mod at repo root, no separate module 
 - **Verified:** CONFIRMED, duplicate of idx 0/1/7. No pkg/block/migrate, no pkg/block/gc, no pkg/block/storetest; gc in engine, storetest in pkg/metadata. Doc-only → LOW, no runtime path.
 
 ### [LOW] ContentHash.UnmarshalJSON legacy array form skips length validation — silently accepts a truncated/oversized hash instead of erroring · `bugs` · area: manifest-identity-types
-- **Where:** `/Users/marmos91/dittofs-worktrees/audit-engine/pkg/block/types.go:115`
+- **Where:** `pkg/block/types.go:115`
 - **What:** Legacy branch: `var arr [HashSize]byte; json.Unmarshal(data, &arr)`, accepts on `err == nil`. encoding/json array-into-fixed-array: silently zero-pads short arrays, silently truncates long ones — never errors on length mismatch. `[]` → zero hash, no error. 10 or 40-element array → wrong hash, no error. Sibling branches (hex :125, base64 :133) both gate on `len(...) == HashSize` first — array branch is the ONLY one with no check.
 - **Why it matters:** Package's own ErrFutureFormat rationale explicitly rejects "decodes cleanly into ... the wrong thing." ContentHash flows into FileChunk.Hash/ChunkRef.Hash → dedup lookups, read-path chunk resolution.
 - **Fix:** Unmarshal into `[]byte` first, check `len(raw) == HashSize`, else return ErrInvalidHash-wrapped error — mirror hex/base64 branches.
@@ -158,7 +158,7 @@ Stack: Go (module github.com/... single go.mod at repo root, no separate module 
 - **Verified:** Confirmed: `grep -rn 'TRANSITIONAL-'` over whole worktree hits only doc.go:128,132,144 (definition + own grep recipe) + `.planning/audits/2026-08-05-dataplane/report.md:1088` (already flagged this exact paragraph dead a month ago; its suggested fallback site `engine/cache.go` carries no marker either). Zero adopters. Doc-only → LOW.
 
 ### [LOW] ContentHash.MarshalJSON allocates+discards via CASKey() instead of encoding hex directly into the preallocated buffer · `perf` · area: manifest-identity-types
-- **Where:** `/Users/marmos91/dittofs-worktrees/audit-engine/pkg/block/types.go:98`
+- **Where:** `pkg/block/types.go:98`
 - **What:** MarshalJSON preallocates `out` exact-cap (99) then calls `h.CASKey()` (101), which does `hex.EncodeToString` (2 allocs) + `"blake3:"+...` concat (1 alloc) = 3 throwaway allocs, all copied into `out` then discarded.
 - **Why it matters:** Drives ChunkRef JSON serialization for every FileAttr.Blocks write to Postgres/Badger, once per chunk per manifest write/read — 3 extra allocs × N chunks on hot metadata path for large files.
 - **Fix:** Write directly into `out`: copy `"blake3:"` then `hex.Encode(out[tail:], h[:])` instead of calling CASKey(). 3 allocs → the 1 already-planned `out` alloc.
@@ -204,4 +204,4 @@ No dedicated `gaps` findings this pass — table below cross-refs the reference 
 | GC never deletes an object mid-write; fails closed on zero timestamp | doc.go states GC "fails closed on a zero timestamp" but GC code itself lives in `pkg/block/engine/gc*.go`, out of scope here. Also: doc.go's own Sub-packages list still claims a `gc` sub-package under pkg/block that doesn't exist (multiple LOW findings above, store-contract-policy) | Contract not verified against actual engine/gc*.go this pass; doc's own package map for where to find it is wrong | https://git-scm.com/docs/git-gc |
 | Every backend stamps non-zero reliable write timestamp | Not checked — backend write paths are sibling pkgs (local/remote/badger etc), out of scope | Unverified — flag for backend-scope audit | DittoFS `pkg/block/doc.go` (internal invariant, no external source) |
 
-Path: `/Users/marmos91/dittofs-worktrees/audit-engine/pkg/block/report.md`
+Generated into the audit worktree; committed here as this file.

--- a/.planning/2026-09-01-engine-audit-report.md
+++ b/.planning/2026-09-01-engine-audit-report.md
@@ -1,0 +1,514 @@
+# Audit Report — dittofs (4ec814bc2)
+Stack: Go (module github.com/marmos91/dittofs, part of the `dfs` server binary — pkg/block/engine has no build root or deploy surface of its own; it is a library package compiled into cmd/dfs). Concurrency via stdlib sync/atomic/context, golang.org/x/sync/errgroup, a hand-rolled resizable dynamicSemaphore (x/sync/semaphore.Weighted can't resize live). Content hashing via lukechampine.com/blake3. Local persistence via pkg/block/journal (Badger-backed log-blob substrate) and pkg/block/local; durable tier via pkg/block/remote (S3-compatible). Standard `testing` package, table-driven tests, no test framework/mocking library observed. No HTTP/RPC framework in this package — it is the data-plane engine consumed by pkg/controlplane/runtime/shares/ (construction) and internal/adapter/{nfs,smb,common}/ (call sites), which own the actual protocol/API surfaces. · Areas: 8 · Findings: 1 HIGH / 13 MED / 52 LOW
+
+## Summary by dimension
+
+| Dimension | HIGH | MED | LOW |
+|---|---|---|---|
+| bugs | 0 | 6 | 4 |
+| security | 0 | 0 | 0 |
+| slop | 0 | 1 | 6 |
+| perf | 0 | 2 | 10 |
+| structure | 1 | 4 | 18 |
+| bloat | 0 | 0 | 6 |
+| comments | 0 | 0 | 8 |
+
+## Summary by area
+
+| Area | Findings |
+|---|---|
+| composition-lifecycle | 8 |
+| cross | 2 |
+| gc-mark-sweep-compaction | 15 |
+| manifest-check-repair | 4 |
+| offline-readiness | 3 |
+| read-path-cold-fetch | 6 |
+| reclaim-reconcile-audit | 10 |
+| syncer-upload-health | 9 |
+| write-path-carve | 9 |
+
+## Findings
+
+### [LOW] sweepByWalk and sweepFromSyncedIndex duplicate the same end-of-scan bookkeeping block verbatim · `bloat` · area: gc-mark-sweep-compaction
+- **Where:** `pkg/block/engine/gc.go:709`
+- **What:** gc.go:709-717 (sweepByWalk) and gc_sweep_index.go:127-138 (sweepFromSyncedIndex) both end w/ identical seq: lock statsMu, fold `scanned` into stats.ObjectsScanned, unlock, then if options.ProgressCallback != nil, lock again, snapshot `*stats`, unlock, invoke callback.
+- **Why it matters:** copy-paste of non-trivial lock/unlock/lock/unlock bookkeeping across two sweep kernels that already share other helpers (newSweepErrorRecorder, recordDryRunCandidate) for exactly this reason — a change to progress-snapshot logic must land in two places or drifts silently.
+- **Fix:** factor into one helper `finishSweepScan(stats *GCStats, mu *sync.Mutex, scanned int64, options *Options)`, call from both kernels.
+- **Verified:** CONFIRMED. gc.go:708-717 and gc_sweep_index.go:126-138 byte-identical (one comment differs). Both prod-reachable: CollectGarbage calls sweepByWalk (gc.go:481) and sweepFromSyncedIndex (gc.go:497).
+
+### [LOW] Dangling '(subsumes A6)' reference with no meaning anywhere in the repo · `comments` · area: read-path-cold-fetch
+- **Where:** `pkg/block/engine/fetch.go:236`
+- **What:** comment `// Legacy path deleted (subsumes A6). Any` — "A6" unresolved anywhere else in repo.
+- **Why it matters:** dangling pointer to an external plan/decision doc not in repo; adds zero info over "Legacy path deleted".
+- **Fix:** drop `(subsumes A6)` fragment.
+- **Verified:** CONFIRMED. `grep -rn 'A6'` over pkg/ hits only this line + unrelated hex literals. Reachable via dispatchRemoteFetch (Syncer). CLAUDE.md forbids decision IDs in source comments.
+
+### [LOW] Garbled comment punctuation ("GCStateRoot.: without this") · `comments` · area: gc-mark-sweep-compaction
+- **Where:** `pkg/block/engine/gc.go:55`
+- **What:** doc comment on gcRootLocks: "...share a GCStateRoot.: without this, two concurrent calls..." — period immediately followed by colon.
+- **Why it matters:** malformed punctuation breaks sentence, reader has to reparse; obscures intended meaning.
+- **Fix:** replace ".: " with ": " → "...share a GCStateRoot: without this, two concurrent calls...".
+- **Verified:** CONFIRMED gc.go:54-55. `.: ` artifact present verbatim; same comment also has mangled tail ("violation by data path"). gcRootLocks used by CollectGarbage.
+
+### [LOW] Garbled comment punctuation ("would also work).: included") · `comments` · area: gc-mark-sweep-compaction
+- **Where:** `pkg/block/engine/gc.go:200`
+- **What:** RemoteEndpointID doc: "...for S3 a bucket/prefix would also work).: included in the engine's start/complete log lines..." — same `.: ` glue, second clause has no subject.
+- **Why it matters:** same class as gc.go:55 — garbled punctuation, misleading rather than descriptive.
+- **Fix:** replace ").: " with ") — " or split into two sentences.
+- **Verified:** CONFIRMED gc.go:198-204, `.: ` artifact present verbatim. Reachable: Options.RemoteEndpointID set at runtime/blockgc.go:109,:310 (non-test), consumed gc.go:457/464/468/519 via collectGarbage; blockgc.go:397 `collectGarbageFn = engine.CollectGarbage` is prod binding. Doc-comment text only, cosmetic.
+
+### [LOW] Garbled comment punctuation + missing period in GCState.Add doc · `comments` · area: gc-mark-sweep-compaction
+- **Where:** `pkg/block/engine/gcstate.go:111`
+- **What:** Add() doc: "...hash are no-ops at the data layer.: writes are buffered through a Badger WriteBatch and flushed every gcAddBatchSize hashes FlushAdd() forces a flush..." — `.: ` glitch plus missing period before "FlushAdd()" runs two sentences together.
+- **Why it matters:** reads as one ungrammatical run-on; obscures FlushAdd() as a distinct operation from the batching just described.
+- **Fix:** reflow to "...no-ops at the data layer: writes are buffered through a Badger WriteBatch and flushed every gcAddBatchSize hashes. FlushAdd() forces a flush so callers can rely on Has() seeing every preceding Add()."
+- **Verified:** CONFIRMED gcstate.go:110-114, both defects present (`.: ` artifact + missing period before "FlushAdd()"). gcstate.go:61 is a separate correct sentence, not a fix of this one. Reachable: NewGCState (gc.go:432), FlushAdd (gc.go:599), Add via markPhase inside collectGarbage.
+
+### [LOW] Inline lock comment duplicates the gcRootLocks doc comment near-verbatim · `comments` · area: gc-mark-sweep-compaction
+- **Where:** `pkg/block/engine/gc.go:394`
+- **What:** comment at collectGarbage's rootLock acquisition (gc.go:394-399) restates almost word-for-word the package-level doc on `gcRootLocks` (gc.go:54-59), a few dozen lines above in same file.
+- **Why it matters:** redundant restatement adds no new info; maintenance hazard — the two copies already differ in wording (Run A/Run B vs one run/the other; "sweep" vs "delete") and can drift further.
+- **Fix:** trim inline comment to a one-line pointer, e.g. "// serializes against other CollectGarbage runs sharing this GCStateRoot — see gcRootLocks doc.", keep full rationale only on the gcRootLocks declaration.
+- **Verified:** CONFIRMED duplication (gc.go:54-59 vs gc.go:394-399), already drifted in wording; `.: ` artifact survives only in the var copy. Inline copy's only non-redundant line: "Lock is acquired before any disk-state work and released on return". Reachable: collectGarbage is body of CollectGarbage (gc.go:335) / CollectGarbageLocal (gc.go:348), bound prod at runtime/blockgc.go:167,:397.
+
+### [LOW] BlocksCached stat is documented as a live signal but is structurally always zero · `bloat` · area: composition-lifecycle
+- **Where:** `pkg/block/engine/stats.go:18`
+- **What:** `BlockStoreStats.BlocksCached` doc says lets operators see local-tier read-cache vs write-side split. `classifyBlocks` never increments it (own ponytail comment at stats.go:219-223 admits distinction "no longer observable and stays zero"). Exposed as `blocks_cached` JSON, printed by `dfsctl store block stats`.
+- **Why it matters:** doc promises a signal impl admits elsewhere it can never produce; permanent-0 counter shown to operators as meaningful.
+- **Fix:** drop field, or match `LocalMemMax`'s honest "always 0, kept for wire compat" treatment (stats.go:29-32).
+- **Verified:** CONFIRMED. Only write site (classifyBlocks) never touches it. Aggregation `runtime/shares/blockstore_ops.go:301` (+= 0). CLI row at `cmd/dfsctl/commands/store/block/stats.go:77`.
+
+### [LOW] MetadataReconciler/MultiShareReconciler split is speculative — weaker interface never satisfied alone · `bloat` · area: gc-mark-sweep-compaction
+- **Where:** `pkg/block/engine/gc.go:291`
+- **What:** `CollectGarbage`/`CollectGarbageLocal`/`markPhase` take `MetadataReconciler`, then type-assert to `MultiShareReconciler` via `sharesForReconciler` (gc.go:608-616). Miss → nil shares → `markPhase` hard-aborts ("reconciler reports zero shares", gc.go:538). Only implementers repo-wide: `perRemoteReconciler` (runtime/blockgc.go:249, prod) and `gcMSReconciler` (gc_test.go:52) — both satisfy the stronger interface. `ok==false` branch never tested.
+- **Why it matters:** weaker param type buys nothing; converts compile-time contract into runtime fail-closed abort in highest-consequence file.
+- **Fix:** change 3 signatures to `MultiShareReconciler` directly; drop/panic the assertion fallback; drop separately-exported `MetadataReconciler` if unused elsewhere.
+- **Verified:** CONFIRMED. No MetadataReconciler-only value ever passed.
+
+### [LOW] Duplicated atomic-write-JSON-to-tmp-then-rename instead of shared helper · `bloat` · area: reclaim-reconcile-audit
+- **Where:** `pkg/block/engine/audit_state.go:256`
+- **What:** `persistAuditLastRun` reimplements `PersistLastRunSummary`'s (gcstate.go:302) MkdirAll(0o755)→MarshalIndent→WriteFile(tmp,0o644)→Rename→remove-tmp-on-failure sequence. Own doc admits it "matches the engine.PersistLastRunSummary contract."
+- **Why it matters:** two copies of same atomic-write pattern to keep in sync.
+- **Fix:** factor shared `atomicWriteJSON(dir, name string, v any) error`; `PersistLastRunSummary` takes concrete `GCRunSummary` so needs signature change too (`any` param) — ~15 lines either way, low value.
+- **Verified:** CONFIRMED, both reachable in prod (audit via runtime/blockaudit.go:53, GC via gc.go:436/471/507). Low value.
+
+### [LOW] Stale comment references non-existent function ensureUploadLimiter · `comments` · area: syncer-upload-health
+- **Where:** `pkg/block/engine/syncer.go:120`
+- **What:** comment says uploadLimiter "Lazily created by ensureUploadLimiter." No such function anywhere (grep = 0). Actually eager: `newDynamicSemaphore(startWindow)` in `NewSyncer` at syncer.go:217.
+- **Why it matters:** misleads grep for lazy-init behavior that doesn't exist.
+- **Fix:** rewrite comment to describe eager construction in NewSyncer.
+- **Verified:** CONFIRMED. Field live prod (carve_dispatch.go:104-115, syncer.go:799).
+
+### [LOW] Stale comment references non-existent function carveChunkBytes · `comments` · area: syncer-upload-health
+- **Where:** `pkg/block/engine/syncer.go:277`
+- **What:** `recomputeCarveActive` doc names fallback path "carveChunkBytes" — 0 matches repo-wide.
+- **Why it matters:** misleads reader locating the described fallback.
+- **Fix:** name real hash-keyed fallback fn, or drop parenthetical.
+- **Verified:** CONFIRMED. recomputeCarveActive prod-called from NewSyncer / setRemoteBlockStore.
+
+### [LOW] Stale comment references non-existent function carveFlush (2 sites in this file) · `comments` · area: syncer-upload-health
+- **Where:** `pkg/block/engine/syncer.go:117`
+- **What:** comments at 117 (uploadLimiter doc) and 852 (SyncNow doc) say serialization happens "in carveFlush" — no such function exists (grep = 0, only carveMu/carveDispatcher/Carve are real). Line 392 Flush doc correctly says "carveMu", not carveFlush — claim of a 3rd site there is wrong, only 2 sites in this file.
+- **Why it matters:** dead-symbol reference repeated; real mechanism (journal.Carve/carveMu) left unnamed.
+- **Fix:** replace "carveFlush" with real call path at both sites.
+- **Verified:** CONFIRMED but count corrected: 2 sites (117, 852), not 3 — line 392 is clean.
+
+### [LOW] blockRefHashes doc comment claims it feeds OnRead's hint API; only feeds InvalidateFile · `slop` · area: read-path-cold-fetch
+- **Where:** `pkg/block/engine/read_internal.go:13`
+- **What:** doc says extracts ContentHash "for OnRead's hint API." Sole call site: readwrite.go:386, `InvalidateFile(payloadID, blockRefHashes(blocks))`. Every prod OnRead call passes nil hashes (readwrite.go:95,244,337,390; flush.go:246).
+- **Why it matters:** describes caller/API that doesn't exist for this helper.
+- **Fix:** rewrite doc to name `Cache.InvalidateFile`; consider moving helper beside that call site.
+- **Verified:** CONFIRMED, single call site is InvalidateFile not OnRead.
+
+### [LOW] sweepByWalk recomputes grace cutoff per-object instead of hoisting once · `perf` · area: gc-mark-sweep-compaction
+- **Where:** `pkg/block/engine/gc.go:680`
+- **What:** `meta.LastModified.After(snapshotTime.Add(-gracePeriod))` recomputed inside per-object Walk callback. Sibling `sweepFromSyncedIndex` (gc_sweep_index.go:47) hoists `graceCutoff := snapshotTime.Add(-gracePeriod)` once before its loop.
+- **Why it matters:** repeated arithmetic across a Walk spanning millions of local chunks; asymmetry with correctly-hoisted sibling shows oversight.
+- **Fix:** hoist `graceCutoff` once before `store.Walk`, matching sweepFromSyncedIndex.
+- **Verified:** CONFIRMED. Non-allocating so real perf delta is micro; value is symmetry with sibling kernel.
+
+### [LOW] blockRefHashes misplaced in read-path file; doc names wrong caller · `structure` · area: read-path-cold-fetch
+- **Where:** `pkg/block/engine/read_internal.go:15`
+- **What:** defined in read-path file, only called from write/delete-path (readwrite.go:386, inside `Store.Delete`). Doc says "for OnRead's hint API" but OnRead never receives it (nil everywhere).
+- **Why it matters:** one-concern-per-file violated; doc drift same class as elsewhere in package.
+- **Fix:** move next to InvalidateFile's call site (readwrite.go or cache.go); fix doc to name InvalidateFile.
+- **Verified:** CONFIRMED. Store.Delete is NFS REMOVE/SMB delete path — reachable prod.
+
+### [LOW] SyncQueue.downloadWorker takes context.Context and drops it · `structure` · area: syncer-upload-health
+- **Where:** `pkg/block/engine/sync_queue.go:188`
+- **What:** `downloadWorker(_ context.Context, id int)` — param named `_`, never read. Call site sync_queue.go:91 passes real ctx. Body uses `q.workerCtx` (captured at Start, sync_queue.go:77-79) instead.
+- **Why it matters:** looks load-bearing but isn't; misleads editor into thinking passing a different ctx changes behavior.
+- **Fix:** drop param — `func (q *SyncQueue) downloadWorker(id int)`, call site `go q.downloadWorker(i)`.
+- **Verified:** CONFIRMED. Reachable via q.Start(ctx) in Syncer.Start ← engine.go:265.
+
+### [LOW] Syncer.bs is a full *Store back-reference used for one narrow purpose · `structure` · area: syncer-upload-health
+- **Where:** `pkg/block/engine/syncer.go:424`
+- **What:** `dataplaneMetrics()` reaches through `m.bs` (full `*Store` field, syncer.go:70) just to read `bs.metrics.Load()`. Field comment (62-69) justifies whole-Store back-pointer via a `bs.cache`/InvalidateFile call site that no longer exists in the package.
+- **Why it matters:** bidirectional coupling, unbounded reach through bs vs. what's actually needed; stale justification comment.
+- **Fix:** replace `bs *Store` with narrow interface/setter for the metrics read (e.g. `SetMetricsRecorder(DataplaneMetrics)`); keep cache-invalidation need on its own seam.
+- **Verified:** CONFIRMED. `.bs` used only at syncer.go:425,428 + assignment engine.go:207.
+
+### [LOW] Compaction's per-item enumeration callbacks skip ctx cancellation check · `structure` · area: gc-mark-sweep-compaction
+- **Where:** `pkg/block/engine/compaction.go:143`
+- **What:** `EnumerateSynced` callback (143-148) and `WalkBlockRecords` callback (155-162) never check `ctx.Err()`; only outer candidate loop (167-169) does. Sibling sweep kernels (gc.go:665-667, gc_sweep_index.go:51-53) check inside their per-item callback.
+- **Why it matters:** shutdown mid-compaction-scan keeps churning instead of returning promptly; inconsistent with package's own convention.
+- **Fix:** add `if err := ctx.Err(); err != nil { return err }` at top of both callbacks.
+- **Verified:** CONFIRMED. Reachable via CompactBlocks ← runtime/blockgc.go:596. Impact bounded by whether underlying store query honours ctx.
+
+### [LOW] gcRootLock registry lives inline in gc.go instead of own file · `structure` · area: gc-mark-sweep-compaction
+- **Where:** `pkg/block/engine/gc.go:76`
+- **What:** `gcRootLocksMu`/`gcRootLocks`/`gcRootLock`/`acquireGCRootLock`/`releaseGCRootLock` (~52 lines, gc.go:76-127) is a generic per-path refcounted-mutex registry, unrelated to gc.go's own package doc. Has dedicated `gc_root_lock_test.go` but no matching `gc_root_lock.go`, unlike `gc_block.go`/`gc_sweep_index.go` which are properly split.
+- **Why it matters:** violates one-concern-per-file; gc.go already largest file in set (876 lines).
+- **Fix:** move type + 3 funcs into new `gc_root_lock.go`, no behavior change.
+- **Verified:** CONFIRMED. `wc -l gc.go` = 876. Reachable via acquireGCRootLock at gc.go:400 in CollectGarbage. Pure mechanical move.
+
+### [LOW] ReconcileMetaView.GetLocator is dead surface for both in-scope consumers · `structure` · area: reclaim-reconcile-audit
+- **Where:** `pkg/block/engine/reconcile.go:28`
+- **What:** `ReconcileMetaView` declares `GetLocator`; `Reconcile()` never calls it, `ReclaimMetaView` embeds it and never calls it either. Sole caller is `CompactMetaView` (compaction.go:237) via embedding. Doc comment overclaims scope ("the read-only per-share metadata surface the reporter consumes").
+- **Why it matters:** every implementer/fake forced to carry a method neither real caller invokes; violates minimize-interface-surface.
+- **Fix:** split `GetLocator` into its own tiny interface embedded only by `CompactMetaView` in compaction.go; leave `ReconcileMetaView` with just `EnumerateSynced`+`WalkBlockRecords`.
+- **Verified:** CONFIRMED, but method is live in prod via CompactBlocks ← runtime/blockgc.go:596 — misplaced, not dead code.
+
+### [LOW] Ad hoc error strings instead of package sentinel errors · `structure` · area: reclaim-reconcile-audit
+- **Where:** `pkg/block/engine/audit_state.go:103`
+- **What:** `AuditRefcounts` returns `errors.New("audit-refcounts: metadata store is nil")` (103) and `errors.New("audit-refcounts: share is empty")` (106) instead of sentinel vars. Package already has `ErrClosed`/`ErrStoreClosed` (types.go:9,17) as the sentinel convention.
+- **Why it matters:** callers can only string-match to distinguish these preconditions; errors.Is unavailable.
+- **Fix:** declare `ErrNilMetadataStore`/`ErrEmptyShare` sentinels next to `ErrClosed` in types.go, return directly.
+- **Verified:** CONFIRMED, reachable via runtime/blockaudit.go:26 ← handlers/blockstore_audit.go:72 ← dfsctl. Low value: no caller branches on these today.
+
+### [LOW] ResetLocalState deletes files sequentially, one fsync each, defeating the journal's own commit batching · `perf` · area: write-path-carve
+- **Where:** `pkg/block/engine/flush.go:307`
+- **What:** ResetLocalState loops sequential `bs.local.Delete` per payloadID, no concurrency. journal.Store.Delete → appendTombstone → groupCommit fsyncs per call; groupCommit only batches concurrent callers hitting the barrier together, never engaged by a sequential loop.
+- **Why it matters:** Snapshot-restore on remote-backed share w/ many resident files = N sequential fsyncs (only path reaching ResetLocalState: snapshot.go:1509). Minutes of restore time at scale when group-commit machinery already exists to collapse it.
+- **Fix:** Fan deletes out with bounded concurrency (errgroup + worker cap, mirror carvePass's uploadLimiter) so same-shard deletes overlap and ride groupCommit's single fsync.
+- **Verified:** CONFIRMED. flush.go:307-311 sequential; journal Delete (store.go:759-776) always appendTombstone→groupCommit (segment.go:466-471); sequential caller always becomes leader, pays full fsync. Rare operator path, no correctness impact.
+
+### [LOW] applyPayloadRepairs re-sorts entire covered-extent list on every repair action — O(n²log n), unnecessary sort · `perf` · area: manifest-check-repair
+- **Where:** `pkg/block/engine/manifest_repair.go:280`
+- **What:** `covered = coalesceExtents(append(covered, ...))` runs full sort.Slice+merge over ALL covered extents per action, not once. R actions × C covered = O(R*C log C). overlapsCovered (line 208), the only consumer, does unconditional linear scan, never relies on sort order.
+- **Why it matters:** Sort is pure waste even ignoring loop repetition — overlapsCovered behaves identically sorted or not. Repeating per action = redundant recompute on repair hot path, holds metadata tx open longer.
+- **Fix:** Drop resort: `covered = append(covered, [2]uint64{a.Offset, a.Offset+uint64(a.Size)})`. If overlapsCovered ever becomes order-dependent, coalesce once after the whole loop.
+- **Verified:** CONFIRMED. Reachable via CheckManifests→repairPayload→applyPayloadRepairs, ApplyRepairs settable from REST handler. Downgraded HIGH→LOW: actions capped ≤1000 (maxManifestCheckFindings), rare operator path not a hot loop.
+
+### [LOW] AuditRefcounts re-audits every hardlink to the same file — redundant ListFileChunks per link, not per unique payload · `perf` · area: reclaim-reconcile-audit
+- **Where:** `pkg/block/engine/audit_state.go:238`
+- **What:** walkAuditShareFiles calls GetFile + auditFileManifest (→ListFileChunks) once per dirent. No visited-handle/payloadID dedup. A hardlinked file appears as N dirents sharing one payloadID/FileChunk row-set; audit reruns full reconciliation per link.
+- **Why it matters:** Backup/snapshot-style trees with heavy hardlink use scale audit cost with total link count not unique file count — pure redundant recompute, each rerun a full metadata round trip + O(blocks) map rebuild.
+- **Fix:** Track visited-handle/payloadID set in AuditRefcounts/walkAuditShareFiles; skip GetFile/auditFileManifest for already-audited handle, still count per-link TotalFiles from cached result.
+- **Verified:** CONFIRMED. Reachable via dfsctl store block audit→BlockStoreAuditRefcounts. Downgraded HIGH→LOW: perf only, on-demand operator command, bites only hardlink-heavy trees.
+
+### [LOW] WarmAll silently drops unplaceable manifest rows with zero signal · `bugs` · area: read-path-cold-fetch
+- **Where:** `/Users/marmos91/dittofs-worktrees/audit-engine/pkg/block/engine/warm.go:116`
+- **What:** `absOff, ok := block.ParseChunkOffset(fb.ID); if !ok { continue }` drops row silently — no log, no counter. `total` computed AFTER filter so progress()/WarmResult look like a clean complete run even with excluded rows.
+- **Why it matters:** Every other consumer of this condition (findRowCoveringOffset→ErrManifestInconsistent, resolveNextChunkStart, DataExtents) treats it as reportable; WarmAll swallows it. WarmAll exists to pre-warm before going remote-unreachable — a skipped range is never fetched, caller has no way to know it wasn't warmed.
+- **Fix:** Count/log skipped unplaceable rows (Warn/Error w/ payloadID+fb.ID, or surface via WarmResult) instead of bare `continue`, mirror SeedColdFromManifest's report.unplaceable pattern.
+- **Verified:** CONFIRMED at warm.go:104-107. Reachable: shares/blockstore_ops.go:415 (dfsctl share warm). Downgraded MED→LOW: uncovered read still refuses via ErrManifestInconsistent (not silent data loss) — this is observability gap only.
+
+### [LOW] Health-monitor ticker never switches to fast unhealthy-probe cadence when remote already down at Start() · `bugs` · area: syncer-upload-health
+- **Where:** `pkg/block/engine/sync_health.go:140`
+- **What:** Start()'s eager synchronous probe can set healthy=false before monitorLoop even runs. monitorLoop unconditionally starts ticker at hm.healthyInterval (30s default). Only reset-to-fast site is guarded by `newCount>=threshold && hm.healthy.Load()`; if healthy already false at loop start, that gate never fires — ticker stuck slow for the whole outage.
+- **Why it matters:** HealthMonitor gates every fetch/carve/evict decision. Boot-time outage (misconfigured endpoint, network not up yet) delays recovery detection by up to ~25s (healthyInterval-unhealthyInterval). Untested: every test config sets both intervals equal/close, so this branch's correctness has never been exercised.
+- **Fix:** Seed ticker from current health state: `interval := hm.healthyInterval; if !hm.healthy.Load() { interval = hm.unhealthyInterval }`. Add regression test w/ distinct intervals starting already-failed, assert recovery within ~one unhealthyInterval.
+- **Verified:** CONFIRMED. Start (sync_health.go:79-100) sets healthy=false before monitorLoop; Reset gated by `&& hm.healthy.Load()` (164-171) never true once already false. Reachable via syncer.go:652/691 on real remote HealthCheck. Downgraded MED→LOW: only delays detection ~25s, no correctness impact.
+
+### [LOW] Reconcile() scans in the UNSAFE order — opposite of ReclaimRecords()'s documented TOCTOU-safe order · `bugs` · area: reclaim-reconcile-audit
+- **Where:** `pkg/block/engine/reconcile.go:169`
+- **What:** Reconcile builds refSet via EnumerateSynced FIRST then classifies via WalkBlockRecords SECOND. ReclaimRecords (reclaim.go:129-141) does the opposite, with a comment explaining a commit landing between the two scans would misclassify a live block as leaked if live-set were built first (the #1525 TOCTOU). reconcile.go has no comment/test addressing the identical race in its own inverted order.
+- **Why it matters:** A commit landing between Reconcile's two scans is invisible to refSet(T1) but visible to WalkBlockRecords(T2) → fresh healthy record misclassified as leaked; ReconcileReport (blockgc_reconcile_report.go:74) runs unlocked, fully concurrent with live commits — race window is real. Doesn't itself delete (ReclaimRecords re-derives correctly), but operator-facing leaked-count report can misstate under concurrent write load.
+- **Fix:** Swap scans to match reclaim.go: WalkBlockRecords first into candidate map, EnumerateSynced second to prune. Add raceView-style regression test mirroring TestReclaimRecords_CommitDuringScanNotDeleted.
+- **Verified:** CONFIRMED. reconcile.go:169-193 vs reclaim.go:129-141 (13-line comment on correct order). Unlocked at blockgc_reconcile_report.go:74. Downgraded MED→LOW: Reconcile mutates nothing, blast radius is a misstated count only.
+
+### [LOW] doc.go's package overview describes a ReadBuffer/Prefetcher API that no longer exists — replaced by Cache · `slop` · area: composition-lifecycle
+- **Where:** `pkg/block/engine/doc.go:16`
+- **What:** doc.go:16-36 describes "ReadBuffer" (NewReadBuffer(maxBytes)) and separate "Prefetcher" type. Neither exists — cache.go's single `Cache`/`NewCache` folded both together per engine.go:273-279. `NewReadBuffer` referenced only in doc.go:26 and engine.go:56, dead identifier.
+- **Why it matters:** Reader grepping ReadBuffer/Prefetcher/NewReadBuffer to understand the cache path finds nothing — package's own design-rationale doc points at dead names instead of Cache/NewCache.
+- **Fix:** Rewrite doc.go's cache section around Cache/NewCache (seqThreshold=3, maxPrefetchDepth=8 adaptive doubling, reqQueueSize=64 non-blocking submit — behavior facts still accurate). Fix NewReadBuffer ref in engine.go:56.
+- **Verified:** CONFIRMED. Repo-wide grep for NewReadBuffer: 2 hits, both comments (doc.go:26, engine.go:56). No ReadBuffer/Prefetcher type declared anywhere. Documentation drift only, no behavior.
+
+### [LOW] WriteAt doc comment cites a function that does not exist and a hook the package's own other comment says was removed · `slop` · area: write-path-carve
+- **Where:** `pkg/block/engine/readwrite.go:101`
+- **What:** WriteAt doc + inline comment (lines 67-77, 96-106) describe canonical []ChunkRef projection happening in "the post-Flush hook", citing `Syncer.snapshotChunkRefs` — zero grep matches anywhere, function doesn't exist. Also cites coordinator's `PersistFileChunks` — zero production call sites (test fakes only). coordinator.go:85-90 already states "the engine itself no longer drives it from a local-store chunk-lifecycle hook, of which none remain" — directly contradicts readwrite.go's claim. Real path: blocksink.go CommitBlock→metadata.CommitCarvedChunks/DefaultCommitBlock during carve.
+- **Why it matters:** Hallucinated/stale API ref on exported, heavily-relied-on write path. Maintainer trusting this would chase dead machinery (snapshotChunkRefs, PersistFileChunks) instead of the actual path when diagnosing a residency-projection bug.
+- **Fix:** Rewrite readwrite.go:67-77/96-106 to describe actual mechanism: FastCDC chunking + FileChunk rows + Blocks/ObjectID projection happen synchronously inside carve BlockSink's commit tx (blocksink.go CommitBlock→metadata.DefaultCommitBlock), not a post-Flush hook. Drop dead reference.
+- **Verified:** CONFIRMED. snapshotChunkRefs: single comment hit, nothing else. `.PersistFileChunks(` outside tests: zero call sites. coordinator.go:88-90 self-contradicts readwrite.go. Comment on production-reachable Store.WriteAt.
+
+### [LOW] Flush() comment claims a metadata quiesce runs on the default-policy early-return path; code does nothing of the sort · `slop` · area: write-path-carve
+- **Where:** `pkg/block/engine/flush.go:39`
+- **What:** Comment says branch "still performs the per-payload FileChunk metadata quiesce that syncer.Flush would ... only the remote carve drain is skipped." Code immediately following (42-44) is a bare early return, no Carve call, nothing manifest-related. The actual quiesce (`m.local.Carve(..., Force: true)`) lives inside Syncer.Flush (syncer.go:415), skipped entirely by this branch.
+- **Why it matters:** Comment describes behavior code doesn't implement. Misleads on restart-recovery safety: default async-remote policy leaves manifest projection to unforced background carve dispatcher (age/size gated), not quiesced here as claimed — wrong premise for diagnosing a later residency-truth bug.
+- **Fix:** Either (a) call `bs.local.Carve(ctx, journal.CarveOptions{FileID: journal.FileID(payloadID), Force: true})` before early return, or (b) correct comment to say quiesce is NOT performed here, left to background dispatcher, note the staleness window.
+- **Verified:** CONFIRMED. flush.go:39-41 claim vs 42-44 bare return. Manifest work is syncer.go:415's forced carve, skipped by this branch. LOW: comment-only, no behavior change implied — default async policy skip is the intended #1621 fix.
+
+### [LOW] HealthMonitor ticker never switches to fast unhealthy-probe interval when eager start-up probe fails (duplicate angle) · `slop` · area: syncer-upload-health
+- **Where:** `pkg/block/engine/sync_health.go:140`
+- **What:** monitorLoop unconditionally creates ticker at hm.healthyInterval regardless of current health state. Reset-to-fast only inside `newCount>=threshold && hm.healthy.Load()` — never fires if Start()'s eager probe already set healthy=false. Doc comment (169-170) says "Switch to faster probing for quicker recovery detection" — doesn't happen for a startup outage.
+- **Why it matters:** Same circuit breaker every evict/trust-remote decision depends on. Stuck at slow interval = recovery detection up to 6x slower after any start-of-process outage. Untested: fastHealthConfig() sets both intervals to identical 10ms, so this code path never distinguished under test — a guard that's never fired.
+- **Fix:** `interval := hm.healthyInterval; if !hm.healthy.Load() { interval = hm.unhealthyInterval }; ticker := time.NewTicker(interval)`. Test w/ distinct intervals + probe failing from first call, assert unhealthy cadence.
+- **Verified:** CONFIRMED sync_health.go:140/171/84-89. Reachable via syncer.go:691/652 production remote-backed share. Downgraded MED→LOW: only affects probe cadence (recovery in ≤30s vs ≤5s), no durability/data path wrong.
+
+### [LOW] Compaction candidate filter excludes exactly the husk blocks its own crash-recovery path exists to clean up · `slop` · area: gc-mark-sweep-compaction
+- **Where:** `pkg/block/engine/compaction.go:158`
+- **What:** `if lb > 0 && rec.Length > 0 && float64(lb)/float64(rec.Length) < opts.LiveRatio` — `lb==0` (zero live locators) is excluded from candidates by the `lb>0` conjunct, so compactOneBlock never runs for a full husk. Doc comment (40-42) claims "A re-run converges: ... compactOne finds nothing to move and simply deletes the husk" but that re-run can never reach compactOneBlock for lb==0 blocks — both husk-cleanup branches (len(moveable)==0 at :257, ErrChunkNotFound at :196) are unreachable via CompactBlocks' own loop for this case.
+- **Why it matters:** Compaction's documented crash-recovery guarantee (step2/step3 partial-crash leaves stale LiveChunkCount>0, zero real locators) is false — never self-heals via compaction. compaction_test.go only covers partial-dead (lb>0); husk path untested/unreachable.
+- **Fix:** Drop `lb > 0` conjunct: `if rec.Length > 0 && float64(lb)/float64(rec.Length) < opts.LiveRatio`. Zero lb ratios to 0, already `< opts.LiveRatio`. Add test seeding LiveChunkCount>0/zero-locators record, assert CompactBlocks reaps it.
+- **Verified:** CONFIRMED compaction.go:158/40-42. Reachable blockgc.go:596. Downgraded MED→LOW: refuted "permanently strands" claim — ReclaimRecords (reclaim.go:151-153) has NO lb>0 gate, reaps this husk on its own separately-scheduled pass (blockgc_reconcile_reclaim.go:122), so it's a delay not permanence.
+
+### [LOW] chunkWindowResolver rescans full row list per offset on non-badger backends — O(K*N) walk instead of O(N log N) · `perf` · area: read-path-cold-fetch
+- **Where:** `pkg/block/engine/read_internal.go:217`
+- **What:** rows cached once by list(), but coveringRow falls back to findRowCoveringOffset (O(N) linear) and nextPlaceableStart falls back to minStartAfter (O(N)) on every call for any store not implementing chunkAtOffsetResolver/chunkAtOrAfterOffsetResolver (badger only). collectCoveringChunks calls covering() once per chunk in window → O(K*N) total.
+- **Why it matters:** Row list already fully materialized in list() but re-scanned from scratch every lookup instead of indexed once. WarmAll (warm.go:101-131) already does the right pattern (slices.Sort + sort.Search) for the identical successor-lookup problem; chunkWindowResolver, serving actual cold-read/prefetch on sqlite/postgres, doesn't apply it.
+- **Fix:** In list(), build+cache a slice sorted by parsed absolute offset (unplaceable rows separated). Binary-search (sort.Search) in findRowCoveringOffset/minStartAfter instead of linear scan. O(N log N) once + O(K log N) lookups.
+- **Verified:** CONFIRMED read_internal.go:170/229/450, fetch.go:107. Downgraded MED→LOW: pure in-memory uint64 compares on already-materialized slice (~1e6 compares, sub-ms) next to K remote GETs at hundreds of ms each — nowhere near a bottleneck; file's own "not the profiled hot path" note (:311) directionally right.
+
+### [LOW] compactOneBlock re-fetches locators one-by-one, defeating the EnumerateSynced batching CompactBlocks just did · `perf` · area: gc-mark-sweep-compaction
+- **Where:** `/Users/marmos91/dittofs-worktrees/audit-engine/pkg/block/engine/compaction.go:237`
+- **What:** CompactBlocks (line 143) does one EnumerateSynced scan per share explicitly to avoid GetLocator-per-hash round trips (comment cites sqlite MaxOpenConns(1) O(N) serial cost) — but only keeps aggregated liveBytes[blockID], discards per-hash locator. compactOneBlock's moveable-selection loop then calls v.GetLocator once per chunk record in every candidate block — thousands of serial single-row queries on the same pool the batching was built to avoid.
+- **Why it matters:** Self-contradicts the file's own documented rationale two paragraphs above. N candidate blocks × M chunks each = O(N*M) individual queries instead of the one sequential scan already paid for.
+- **Fix:** Build hash→ChunkLocator (or hash→BlockID) map during the same EnumerateSynced pass used for liveBytes; thread into compactOneBlock so moveable loop does map lookup not GetLocator call.
+- **Verified:** CONFIRMED compaction.go:143-150/237. Reachable blockgc.go:596. Downgraded MED→LOW: only over CANDIDATE blocks (already below LiveRatio, ~128 records at 8MiB/64KiB not "thousands"), background GC pass off client path; naive fix has real memory tradeoff current code deliberately avoids.
+
+### [LOW] sweepByWalk hex-encodes every walked hash unconditionally, even on the common keep-alive path · `perf` · area: gc-mark-sweep-compaction
+- **Where:** `/Users/marmos91/dittofs-worktrees/audit-engine/pkg/block/engine/gc.go:668`
+- **What:** `key := h.String()` (hex.EncodeToString, fresh alloc) runs for every object before grace-window/live-set checks that usually return early. key only used on error/delete branches (addError, recordDryRunCandidate).
+- **Why it matters:** sweepByWalk runs over entire local chunk namespace; per-object allocation multiplied across millions of live/kept objects for a value thrown away unused most of the time.
+- **Fix:** Move `key := h.String()` down into each branch that actually needs it (addError calls, recordDryRunCandidate, delete-error path).
+- **Verified:** CONFIRMED gc.go:668 vs filters at 675-687; ContentHash.String is hex.EncodeToString(h[:]) (types.go:27-29). Reachable gc.go:481. LOW not MED: small alloc next to a disk-backed gcs.Has lookup already paid per object.
+
+### [LOW] sweepFromSyncedIndex hex-encodes every synced hash unconditionally, even on the common live-keep path · `perf` · area: gc-mark-sweep-compaction
+- **Where:** `/Users/marmos91/dittofs-worktrees/audit-engine/pkg/block/engine/gc_sweep_index.go:54`
+- **What:** `key := h.String()` runs for every marker EnumerateSynced yields, before syncedAt-zero/grace-window/live-set checks (present==true majority case). Same hex.EncodeToString allocation-per-call as gc.go:668.
+- **Why it matters:** This is the whole synced-hash index — whole live remote object population. Computing+discarding hex string per hash on common path wastes allocation at exactly the scale (millions of markers) surrounding code was engineered to bound.
+- **Fix:** Compute key lazily inside branches that use it (addError, recordDryRunCandidate) instead of unconditionally at callback top.
+- **Verified:** CONFIRMED gc_sweep_index.go:54 vs early returns at 59-77. Reachable gc.go:497. LOW, same reason as sweepByWalk — dominated by per-hash gcs.Has disk-backed probe in same iteration.
+
+### [LOW] AuditRefcounts share walk is fully sequential — no concurrency despite the package's established errgroup/semaphore pattern · `perf` · area: reclaim-reconcile-audit
+- **Where:** `pkg/block/engine/audit_state.go:207`
+- **What:** walkAuditShareFiles (207-249) recurses whole share tree one dir at a time; per regular file, GetFile (228) then ListFileChunks (167 via auditFileManifest 126) strictly series. No goroutines/errgroup/pool. syncer.go/fetch.go same pkg already use errgroup+dynsem for I/O-bound calls.
+- **Why it matters:** 2 sync metadata round trips/file, zero concurrency → linear wall-clock w/ file count. Same shape as reconcileMetadataSizeFromJournal, measured minutes at ~10M entries. Audit tool least useful exactly when share largest.
+- **Fix:** Parallelize per-dir-entry audit w/ bounded pool (errgroup + existing dynamicSemaphore, same shape as fetch.go/syncer.go); aggregate counters w/ atomics or mutex instead of closure-captured plain vars.
+- **Verified:** CONFIRMED. Serial walk confirmed at 207-249. Reachable: engine.AuditRefcounts <- runtime/blockaudit.go:53 <- handlers/blockstore_audit.go:72 <- dfsctl audit cmd. No correctness impact, no spec issue — on-demand operator tool, pure-read, per-entry GetFile load-bearing (comment 220-226). MED overstated -> LOW; parallelizing adds SSI/read contention on live store for a hand-run tool.
+
+### [LOW] manifestShortfall buffers every payload ID before processing instead of streaming inline · `perf` · area: offline-readiness
+- **Where:** `pkg/block/engine/offline.go:201`
+- **What:** manifestShortfall collects ALL payload IDs from EnumeratePayloads into `var payloads []string` (201-207), then second pass calls ListFileChunks/DataExtents/subtractExtents per ID (208-235). Holds full share's IDs in memory before any work starts.
+- **Why it matters:** Pure sequential fold, no concurrency needed — stats.go's populateBlockCounts already calls ListFileChunks directly inside the EnumeratePayloads callback (198-206), same pkg, same fileChunkStore, proving inline is safe (badger's EnumeratePayloads runs callback inside db.View). Buffering-first pays for an O(payload count) live-string slice (multi-hundred-MB at #1891-scale file counts) and defers first result byte until enumeration fully completes, for no benefit.
+- **Fix:** Move loop body (ctx.Err check, ListFileChunks, placedRanges, DataExtents, subtractExtents, confirmShortfall, accumulate) into the EnumeratePayloads callback closure, mirroring populateBlockCounts. Drops the `payloads []string` buffer.
+- **Verified:** CONFIRMED. Buffer-then-loop at 200-235. Counter-pattern real (stats.go:198-206). Reachable: manifestShortfall <- shortfallMemo.get (384) <- OfflineReadiness <- runtime/offline.go:22. No correctness impact, memoized behind shortfallInterval, cost is one string slice. LOW.
+
+### [LOW] doc.go's package doc describes a ReadBuffer/Prefetcher subsystem that pre-loads blocks; the actual Cache's loadFn is a permanent no-op miss, so nothing it describes ever fires · `structure` · area: composition-lifecycle
+- **Where:** `pkg/block/engine/doc.go:18`
+- **What:** doc.go:16-36 ("Read buffer and prefetch (formerly pkg/block/readbuffer)") names live types `ReadBuffer`/`Prefetcher`/`NewReadBuffer` w/ described LRU+RWMutex+adaptive-depth-prefetch behavior. None exist (zero declarations) — folded into single `Cache` type (cache.go, engine.go:107/274). Behavior claim also false: engine.go's loadByHash (290-299, ponytail-marked) is permanent no-op miss; cache.go:46-51 states plainly "no read-through: loadByHash always misses."
+- **Why it matters:** Aspirational/legacy description drift (same class as legacy_migration.go:28). Top-level, most-authoritative doc comment for the pkg — engineer investigating cold-read latency reads this, believes prefetch actively populates a read cache, misdiagnoses instead of finding the actually-dead read-through path the accurate internal comments describe.
+- **Fix:** Rewrite "Read buffer and prefetch" section to name `Cache` (not ReadBuffer/Prefetcher/NewReadBuffer); state plainly write-side-only today (populated via OnChunkComplete), loadByHash a permanent miss until journal local store gains hash-keyed lookup — point at engine.go's ponytail comment as authoritative status.
+- **Verified:** CONFIRMED. doc.go:16-36 names ReadBuffer/NewReadBuffer/Prefetcher as live; grep zero declarations anywhere (only retrospective mentions engine.go:56/107/275, cache.go:127). loadByHash (290-299) unconditional ErrChunkNotFound; cache.go:46-51 confirms no read-through. Package live (NewCache wired engine.go:281). Doc-only drift, no runtime effect -> LOW not MED.
+
+### [LOW] PutBlock-then-commit crash ordering is claimed safe but never exercised by a test that actually fails between PutBlock and the metadata commit · `structure` · area: write-path-carve
+- **Where:** `pkg/block/engine/blocksink.go:327`
+- **What:** blocksink.go:327-328 asserts "PutBlock first: a crash before the commit leaves an orphan block (GC reclaims it), never an unbacked record." blocksink_test.go's only fault-injection test (TestJournalCarveSeam_CrashMidCommitReCarveIsNoOp, line 171) uses failOnceSink whose CommitBlock (160) calls the REAL inner.CommitBlock (full PutBlock + successful DefaultCommitBlock) and injects error only AFTER real commit succeeded — tests "commit succeeded, then later failure," not "PutBlock succeeded, then metadata commit itself failed/crashed." No test makes s.rbs.PutBlock (329) succeed then s.committer.WithTransaction/DefaultCommitBlock (348) fail or crash before running.
+- **Why it matters:** Per repo rule ("a guard that has never REFUSED anything is unverified, not proven"), the single ordering claim justifying safety of every carve in the write-path — the exact seam the audit brief names as priority — has zero fault-injection coverage of its own documented failure mode. Whether the orphan block is actually invisible-but-harmless is asserted, not demonstrated.
+- **Fix:** Add test where PutBlock succeeds but WithTransaction/DefaultCommitBlock errors: assert (1) CommitBlock returns that error, (2) journal records stay dirty/re-carveable, (3) no FileChunk/BlockRecord rows landed, (4) re-carve after recovery works, orphaned remote object unreferenced (GC-reclaimable if plumbing reachable from this pkg's tests).
+- **Verified:** CONFIRMED. blocksink.go:327-329 ordering assertion; failOnceSink (blocksink_test.go:157-168) calls REAL inner.CommitBlock then errors after — its own comment says "commits for real, then returns injected error" = crash-after-commit, not mid-commit. No stub found making PutBlock succeed then WithTransaction/DefaultCommitBlock (348) fail; stubJournalRemote.PutBlock (21) only errors unconditionally. Coverage gap, not a live defect (ordering correct in code) -> LOW.
+
+### [LOW] ErrChunkNotFound wrap-and-log block duplicated between fetchResolvedBlock and inlineFetchOrWait, drift risk self-flagged in a comment · `structure` · area: read-path-cold-fetch
+- **Where:** `pkg/block/engine/fetch.go:649`
+- **What:** fetchResolvedBlock (436-451) and inlineFetchOrWait (636-648) both handle errors.Is(err, block.ErrChunkNotFound) w/ identical logger.Error("CAS object missing for live FileChunk — possible GC race or live-data-loss", block_id/store_key/hash) + near-identical fmt.Errorf wrap. inlineFetchOrWait's comment (649-654) explicitly says "Mirror the ErrChunkNotFound branch above... we MUST set completionErr to the same wrapped error the direct caller sees — otherwise the waiter receives the raw err."
+- **Why it matters:** Per repo convention, hand-synced duplicate whose own comment names the exact failure mode (waiter sees different error than direct caller) is a maintenance hazard, not incidental repetition — next edit to one copy's log fields/wrap silently breaks the invariant, nothing enforces it at compile time.
+- **Fix:** Extract helper `func (m *Syncer) wrapChunkNotFound(fb *block.FileChunk, storeKey string) error` doing the logger.Error + fmt.Errorf once; call from both fetchResolvedBlock and inlineFetchOrWait (assign to completionErr in latter). Removes hand-sync requirement.
+- **Verified:** CONFIRMED byte-identical dup: fetch.go:436-451 and 636-648, same log fields + same wrap, comment 649-654 states hand-sync is a correctness requirement. Both production. Currently IN sync -> no behavioral defect today, maintenance hazard only -> LOW. Fix: one casMissingErr(fb, storeKey) helper.
+
+### [LOW] HealthMonitor defaults duplicated as unnamed literals instead of reusing DefaultConfig's constants · `structure` · area: syncer-upload-health
+- **Where:** `pkg/block/engine/sync_health.go:49`
+- **What:** NewHealthMonitor falls back to bare literals 30*time.Second/5*time.Second/3 (50-59) when config fields unset. types.go's DefaultConfig() (154-156) independently hardcodes same 30s/3/5s trio as unnamed literals too (unlike rest of that func, which uses DefaultParallelDownloads/DefaultPrefetchBlocks/DefaultDemandFetchTimeout named consts, 146-153). Two copies, no shared source.
+- **Why it matters:** Pkg's own convention (named consts w/ justifying comment for thresholds/intervals) skipped here. Changing one without other silently desyncs DefaultConfig()'s SyncerConfig{} from NewHealthMonitor's fallback — caller building SyncerConfig{} by hand gets fallback-path values, DefaultConfig() callers get types.go copy, currently identical by coincidence not definition.
+- **Fix:** Add DefaultHealthCheckInterval/DefaultUnhealthyCheckInterval/DefaultHealthCheckFailureThreshold consts in types.go (same treatment as DefaultParallelDownloads), use in both NewHealthMonitor fallback and DefaultConfig().
+- **Verified:** CONFIRMED. sync_health.go:50-59 bare 30s/5s/3; types.go:154-156 DefaultConfig() repeats identical values while neighbors use named consts. Reachable: NewHealthMonitor <- syncer.go:691; config via runtime.DefaultConfig() (shares/blockstore_config.go:214) and hand-built SyncerConfig{} literals both live. No functional bug today (values identical), pure drift risk. LOW not MED — no observable behavior change.
+
+### [LOW] Drained downloads log at Error for expected shutdown-time context cancellation · `structure` · area: syncer-upload-health
+- **Where:** `pkg/block/engine/sync_queue.go:266`
+- **What:** drainDownloads (215-226, called from downloadWorker on stopCh close, 206-209) calls processRequest for every queued request at shutdown. ctx derives from q.workerCtx, already cancelled by Start goroutine (82-85) at this point. For TransferDownload, reaches recordResult (266-284), which does logger.Error("Transfer failed", ...) unconditionally on err != nil — no context.Canceled/ctx.Err() check. Every download pending at Stop() logs an ERROR for normal graceful shutdown.
+- **Why it matters:** Violates stated log-level discipline ("expected errors log at Debug, unexpected at Error"). Shutdown-caused cancellation is expected. HealthMonitor.monitorLoop, same pkg (sync_health.go:157-160), already does `if ctx.Err() != nil { return }` before treating probe failure as real — codebase knows the distinction; SyncQueue's drain path doesn't apply it.
+- **Fix:** In recordResult, check errors.Is(err, context.Canceled) (or q.workerCtx.Err() != nil) — but also check for ErrClosed (see Verified correction) — and log Debug/Info instead of Error for that case, keep Error for genuine failures.
+- **Verified:** CONFIRMED w/ correction. Chain confirmed (206-209 -> drain -> processRequest -> recordResult 266-284, unconditional Error). CORRECTION: err is not context.Canceled — fetchBlock (378) -> canProcess/checkReady (syncer.go:357-367) returns ctx.Err(), but fetchBlock converts it to ErrClosed; a fix testing only errors.Is(err, context.Canceled) misses it, must also test ErrClosed. Also pollutes q.lastError/lastErrorAt w/ shutdown artifact. LOW: shutdown-only log noise, no data effect.
+
+### [LOW] planPayloadRepairs accepts the full metadata.Store for a single IsSynced call, breaking the package's own narrow-interface convention · `structure` · area: manifest-check-repair
+- **Where:** `pkg/block/engine/manifest_repair.go:107`
+- **What:** planPayloadRepairs(ctx, store metadata.Store, path, payloadID string, f *metadata.File, rowIDs map[string]struct{}, unplaceable []*block.FileChunk, covered [][2]uint64, checkSynced bool) takes the entire metadata.Store interface (store.go:426-467) but body uses exactly one method: `store.IsSynced(ctx, ref.Hash)` at line 156.
+- **Why it matters:** Exact anti-pattern the pkg explicitly avoids elsewhere — gc.go:264-271's SyncedHashIndex is "the narrow slice of the synced-hash marker store the GC sweep depends on... GC declares only what it uses." manifest_repair.go widens a pure planning function's (read-only path, no transaction) coupling surface to the whole store contract, against "accept interfaces, return structs" / minimal-interface convention.
+- **Fix:** Accept a 1-method interface (or metadata.SyncedHashStore) in place of `store metadata.Store`: `type syncedChecker interface { IsSynced(ctx context.Context, hash block.ContentHash) (bool, error) }`, change param type.
+- **Verified:** CONFIRMED. planPayloadRepairs (107-116) takes metadata.Store, body uses only store.IsSynced (156). Reachable: sole caller repairPayload (manifest_check.go:389) <- engine.CheckManifests (221) <- runtime.CheckManifests (manifestcheck.go:48) <- integrity_scheduler.go:90 + dfsctl store check. Pkg precedent explicit (gc.go:264-271). Fix: one-method interface as param type. Pure structure, no behavior change — LOW.
+
+### [LOW] Repairs/RepairsPlanned silently stop being exact once the global cap fills, contradicting the struct's own 'every count is exact' doc comment — and the cross-payload case is untested · `structure` · area: manifest-check-repair
+- **Where:** `pkg/block/engine/manifest_check.go:385`
+- **What:** ManifestCheckResult doc (81) states "Every count is exact — the per-payload detail lists and the Findings list are capped, but the totals are taken as each defect is found, before anything is dropped for display." Holds for UncoveredRanges/ClaimedUncoveredRanges/DamagedPayloads. NOT for RepairsPlanned/Applied/Skipped: repairPayload's early return (385-388) skips planPayloadRepairs entirely for any payload walked after res.Repairs already holds maxManifestCheckFindings entries — so that payload's repairable rows never count into RepairsPlanned at all, not just omitted from display. Field comment (149-150) tries to disclose this but self-contradicts ("stops planning once full" IS stopping the work, for every subsequent payload).
+- **Why it matters:** Doc comments must describe current code, not aspirational (same class as confirmed legacy_migration.go:28). Operator reading RepairsPlanned would expect exactness like DamagedPayloads/UncoveredRanges, undercounting outstanding repairable damage past 1000 damaged payloads. TestRepairPlanHonoursTheReportCap only covers single-mega-payload case (exact there, capping happens after full counting inside one call) — doesn't pin the cross-payload early-return at 385-388.
+- **Fix:** Either make RepairsPlanned exact past cap (count candidates even when skipping display append) or fix field doc (139) to state RepairsPlanned undercounts past cap, rewrite self-contradictory sentence (149-150). Add table-driven test w/ >1 payload spanning cap boundary to pin chosen behavior.
+- **Verified:** CONFIRMED. manifest_check.go:385-388 returns before planPayloadRepairs once len(res.Repairs) >= maxManifestCheckFindings — counter not merely display-capped, contradicts struct doc :81-83. In-function trim comment (:398-401) true only within one payload; field comment :149-152 half-discloses. LOW — undercount in operator report, no data risk.
+
+### [LOW] Duplicated scan+classify algorithm — only one copy got the TOCTOU-safe order · `structure` · area: reclaim-reconcile-audit
+- **Where:** `pkg/block/engine/reconcile.go:169`
+- **What:** reconcile.go builds refSet via EnumerateSynced FIRST (169-177), classifies via WalkBlockRecords SECOND (179-193). reclaim.go's near-identical classify loop for same two classes does opposite order deliberately: WalkBlockRecords first (151-157), EnumerateSynced second (166-173), w/ 18-line comment (130-145) explaining live-set-first is unsafe — a DefaultCommitBlock landing between the two scans writes record+locator atomically, so a stale live-set built first misses the new locator while the later record walk sees LiveChunkCount>0 → false orphan/leaked classification. reclaim.go carries regression test TestReclaimRecords_CommitDuringScanNotDeleted (#1525 TOCTOU). reconcile.go never got the fix.
+- **Why it matters:** Two hand-copies of one algorithm instead of one shared helper — "duplicated/boilerplate hides drift bugs" class, already burned twice (#1980/#1981). ReclaimRecords' own doc says it "re-derives the classification here — never trusting a stale report," a tacit admission the two implementations are known to diverge in correctness. Fix landed in the wrong caller.
+- **Fix:** Extract `classifyOrphanRecords(ctx, view ReconcileMetaView, sink func(rec block.BlockRecord, leaked bool)) error` always walking WalkBlockRecords before EnumerateSynced (safe order); both Reconcile and ReclaimRecords call it — Reconcile feeding a tally sink, ReclaimRecords a delete-candidate-map sink.
+- **Verified:** CONFIRMED. reconcile.go:169-177 EnumerateSynced first, classify 179-193; reclaim.go:129-173 reverse order + 18-line hazard comment (130-145: DefaultCommitBlock writes record+locators atomically, mid-scan commit walked w/ LiveChunkCount>0 but missing from stale live set). reconcile.go has exact hazard -> false class-2 LeakedBlocks entry. Reachable: engine.Reconcile <- blockgc_reconcile_report.go:74. Severity LOW not MED: report read-only, ReclaimRecords re-derives (blockgc_reconcile_reclaim.go:122) so no deletion follows false positive — operator false alarm only. Fix: swap reconcile.go's two scans to record-walk-first.
+
+### [LOW] Four files each carry their own package doc comment, conflicting with doc.go · `structure` · area: reclaim-reconcile-audit
+- **Where:** `pkg/block/engine/reclaim.go:1`
+- **What:** gc_block.go:1 ("Package engine — block-aware GC reclaim..."), reclaim.go:1 ("Package engine — orphan-storage reclaim..."), reconcile.go:1 ("Package engine — read-only orphan-storage reporter..."), audit_state.go:1 ("Package engine — audit") each have a comment block directly above `package engine` w/ no blank line — makes each a package doc comment in Go's eyes. doc.go:1 already carries canonical package doc.
+- **Why it matters:** Go convention (staticcheck ST1000: at most one file/pkg should have a package comment) — go doc/pkg.go.dev pick one arbitrarily among several, so `go doc pkg/block/engine` output nondeterministic/misleading, and the four competing summaries contradict each other about what the package IS.
+- **Fix:** Insert blank line between each file's descriptive comment and `package engine` (demotes to ordinary file comment), or drop the "Package engine — " prefix and start sentence w/ file's own subject.
+- **Verified:** CONFIRMED. No blank line separates comment from package clause: gc_block.go 1-11/package :12; reclaim.go 1-20/package :21; audit_state.go 1-26/package :27; reconcile.go 1-5/package :6 — all four are package doc comments alongside doc.go:1's canonical one. Five package comments in one package; go doc picks arbitrarily. Not currently caught: .golangci.yml enables staticcheck but ST1000 not in enabled check set, lint green. Cosmetic — LOW.
+
+### [LOW] resolveGracePeriod forces reclaim/reconcile to fabricate a throwaway GC-sweep Options struct · `structure` · area: reclaim-reconcile-audit
+- **Where:** `pkg/block/engine/reclaim.go:246`
+- **What:** resolveGracePeriod(options *Options) (gc.go:362) takes the central GC-sweep config struct (GCStateRoot, SyncedHashIndex, BlockReclaimer, DryRun, GracePeriodSet, ...). reclaim.go:246 (`resolveGracePeriod(&Options{GracePeriod: opts.GracePeriod})`) and reconcile.go:149 (same pattern) each construct a mostly-zero-valued Options{} purely to read back one derived time.Duration.
+- **Why it matters:** ReclaimOptions/ReconcileOptions are already purpose-built independent option types — coupling to GC sweep's much wider Options type means a field added to Options for gc.go's own use silently becomes reachable (and misleadingly zero) inside reclaim.go/reconcile.go's call, and a reader must go read gc.go's Options doc to know which of a dozen fields matter here (only two).
+- **Fix:** Change resolveGracePeriod to take primitives: `resolveGracePeriod(period time.Duration, isSet bool) time.Duration`. gc.go's own call sites pass options.GracePeriod/GracePeriodSet; reclaim.go/reconcile.go pass opts.GracePeriod, false directly — no Options{} construction needed.
+- **Verified:** CONFIRMED. resolveGracePeriod(options *Options) gc.go:362; called w/ throwaway sweep-config struct at reclaim.go:246, reconcile.go:149 (identical). Both entry points have own option types (ReconcileOptions reconcile.go:121, ReclaimOptions). Side effect: neither plumbs GracePeriodSet, so operator-supplied explicit zero grace silently promoted to 1h default on these two paths (gc.go:369-371) — expressible on sweep path, not here. Reachable: blockgc_reconcile_report.go:74 / blockgc_reconcile_reclaim.go:122. LOW.
+
+### [LOW] manifestShortfall/confirmShortfall break package-wide %w error-wrapping convention · `structure` · area: offline-readiness
+- **Where:** `pkg/block/engine/offline.go:206`
+- **What:** manifestShortfall propagates bare `err` from chunks.EnumeratePayloads (206), chunks.ListFileChunks (214), index.DataExtents (222), confirmShortfall (229); confirmShortfall itself does same for its ListFileChunks re-read (267). None wrap w/ fmt.Errorf("...: %w", err) or name the failing payload ID.
+- **Why it matters:** Every sibling file in pkg (fetch.go, syncer.go, reconcile.go, manifest_repair.go, readwrite.go, carve_dispatch.go) wraps propagated errors w/ stage-name + %w — CLAUDE.md idiom rule states this explicitly. offlineReadinessOf turns this into operator-facing Reason string via `"manifest cross-check did not run: " + err.Error()` (156) — on this exact #2110-class residency cross-check path, unwrapped/unqualified error is the only diagnostic on gate refusal, and w/ EnumeratePayloads/ListFileChunks called once per payload in a loop, no way to tell which payload or which of four calls failed.
+- **Fix:** Wrap each propagation: `fmt.Errorf("enumerate payloads: %w", err)`, `fmt.Errorf("list file chunks %q: %w", id, err)`, `fmt.Errorf("data extents %q: %w", id, err)`, confirmShortfall's `fmt.Errorf("re-list file chunks %q: %w", payloadID, err)` — matching `"list file blocks for %s: %w"` style already in fetch.go:148, syncer.go:499.
+- **Verified:** CONFIRMED. Bare err propagation at 206/214/222/229, confirmShortfall 267. Sibling code wraps w/ stage name + %w (reconcile.go:176, reclaim.go:156, manifest_repair.go:155). Reachable: offlineReadinessOf <- Store.OfflineReadiness (93/99) <- runtime/offline.go:22, rendered as Reason string at :156 w/ no payload ID, no indication which of four calls failed. LOW — diagnostics only.
+
+### [LOW] doc.go package doc describes a removed ReadBuffer/Prefetcher design as if still current · `bloat` · area: composition-lifecycle
+- **Where:** `pkg/block/engine/doc.go:16`
+- **What:** Section "# Read buffer and prefetch (formerly pkg/block/readbuffer)" (16-36) describes `ReadBuffer` (LRU, RWMutex, copy-on-read, per-share instance, secondary payloadID->blockIdx index) and `Prefetcher` (adaptive 1->2->4->8 depth, bounded worker pool) as live design. Neither type exists — `type ReadBuffer`/`func NewReadBuffer`/`type Prefetcher` absent (grep confirmed). engine.go:273-279 + tests show both replaced by single `Cache` type (NewCache, cacheInterface, nullCache); engine.go's own comment says so ("A single Cache type replaces the legacy ReadBuffer + Prefetcher pair").
+- **Why it matters:** CLAUDE.md idiom rule: doc comments describe code now, not aspirational/legacy (same class as legacy_migration.go:28). `go doc engine` reader gets a deleted design — dead documentation for dead abstractions.
+- **Fix:** Rewrite section to describe current `Cache` type (cache.go) or delete section and point to cache.go's own doc comment.
+- **Verified:** CONFIRMED. doc.go:16-36 describes ReadBuffer (LRU, RWMutex, NewReadBuffer returns nil at 0, payloadID->blockIdx secondary index) and Prefetcher (adaptive, worker pool) as live. rg over repo: no `type ReadBuffer`, no `func NewReadBuffer`, no `type Prefetcher` — only survivors ReadBufferBytes config field (engine.go:57) and stats fields ReadBufferEntries/Used/Max (stats.go:41-43). engine.go:107/:275 confirm fold into Cache/cacheInterface/nullCache. Production file, surfaced by `go doc`. Fix: replace two paragraphs w/ Cache/nullCache description.
+
+### [LOW] doc.go's CollectGarbage usage example doesn't match the real signature/API · `bloat` · area: composition-lifecycle
+- **Where:** `pkg/block/engine/doc.go:74`
+- **What:** Usage example calls `engine.CollectGarbage(ctx, remoteStore, registry, &engine.Options{DryRun: true})` and reads `dryStats.OrphanBlocks`. Real signature (gc.go:335): `CollectGarbage(ctx context.Context, reconciler MetadataReconciler, options *Options) *GCStats` — no remoteStore/registry params.
+- **Why it matters:** Stale example that would not compile against current API. Reader following the doc example writes broken code.
+- **Fix:** Update example to `engine.CollectGarbage(ctx, reconciler, &engine.Options{DryRun: true})`.
+- **Verified:** PARTIALLY REFUTED but core defect CONFIRMED. Real sig gc.go:335 = CollectGarbage(ctx, reconciler MetadataReconciler, options *Options); doc example (74/78) passes 4 args (remoteStore, registry) — would not compile. Second half of claim is a MISREAD: GCStats DOES have OrphanBlocks (gc.go:160, legacy alias of ObjectsSwept, alongside OrphanFiles/BytesReclaimed/Errors, populated by finalizeStats) — no defect there. Fix: drop remoteStore+registry from the two example lines only.
+### [HIGH] Remote sweep reclaims a hash a concurrent dedup write just re-referenced — no write barrier between mark snapshot and delete · `structure` · area: gc-mark-sweep-compaction
+- **Where:** `pkg/block/engine/gc_sweep_index.go:69`
+- **What:** sweepFromSyncedIndex decides orphan-vs-live from syncedAt-vs-grace (60-67) + gcs.Has(h) (69-77), gcs = mark-phase live set snapshotted before sweep (markPhase, gc.go:464). Nothing revalidates between snapshot and delete+DeleteSynced (90-121). Dedup hit (engineDeduper.IsChunkDurable, blocksink.go:68-70) lets a new file reference an already-synced hash with zero footprint change — manifest row only, no journal write, no PutBlock — and never refreshes syncedAt. If that hash was already past-grace-orphaned at mark time, the resurrection manifest row can land after the mark snapshot; sweep then reclaims the block + DeleteSynced with the live row still pointing at it.
+- **Why it matters:** Classic CAS-GC resurrection TOCTOU (checklist #8/#9: mark/sweep needs refresh or serialization vs a concurrent writer). Reader of the new file's chunk gets an unresolvable hash — silent zeros/error, manifest claims data exists, no log names the collision. Distinct from all prior journal-audit bugs (seed/eviction/reap-boundary/marker-loss); this is a live mark-sweep race with no analogue among them.
+- **Fix:** On dedup hit, refresh/touch the synced marker's syncedAt (needs a Touch/Refresh on SyncedHashStore) so the existing grace-period gate protects resurrection the same way it protects a fresh upload. One write inside the already-open manifest transaction; no change to gc_sweep_index.go's decision logic.
+- **Verified:** CONFIRMED, both refutation attempts fail. (a) Dedup does NOT refresh syncedAt: CommitBlock (blocksink.go:295-300) `continue`s on Data==nil, deduped chunks never reach PutSyncedLocators/MarkSynced. (b) Unlink does NOT clear the marker: only DeleteSynced callers are gc_sweep_index.go:113, gc_block.go:133/157, legacy_migration.go:208 — no delete/reap path clears it, so an orphan keeps its original syncedAt and IsSynced still answers true. gcRootLock serializes GC-vs-GC only; nothing quiesces writers. Net: dedup onto a past-grace orphan + invisible-to-mark manifest row + sweep frees the only durable copy — live row, deleted block, local record already flagged synced/evictable.
+
+### [MED] GetStats() misclassifies local-only carved chunks as BlocksRemote, and BlocksLocal is never populated · `bugs` · area: composition-lifecycle
+- **Where:** `pkg/block/engine/stats.go:216`
+- **What:** classifyBlocks: BlockStatePending+nonzero-hash → BlocksRemote++ (comment: "remote copy is authoritative"). But manifestRows() (blocksink.go:100-116, shared by both sinks) writes every carved row State=Pending+nonzero-hash as the PERMANENT terminal state — nothing ever flips a per-file FileChunk row to BlockStateRemote (only BlockRecord.SyncState gets that). So a local-only share (remote==nil) counts every committed chunk into BlocksRemote though no remote exists. BlocksLocal (struct field, doc'd at engine.go:36) is never incremented anywhere.
+- **Why it matters:** Residency-truth reporting failure: `dfsctl store block stats` for a local-only share can show HasRemote=false, BlocksRemote>0, Blocks Local=0 — self-contradictory. No test (stats_test.go) asserts these counters, so it's never been caught.
+- **Fix:** Gate the Pending+nonzero-hash branch on bs.remote != nil before crediting BlocksRemote; count into BlocksLocal instead when remote is nil. Or rename the field / add a ponytail note on its real ceiling.
+- **Verified:** CONFIRMED. BlocksLocal has zero writers repo-wide (only struct field, docs, aggregator, dfsctl display). syncer.go:473-475 comment corroborates: carve path "never transitions FileChunk.State to BlockStateRemote." Every real BlockStateRemote assignment is BlockRecord.SyncState (compaction.go:313, legacy_migration.go:347, blocksink.go:338). Downgraded HIGH→MED: reporting-only, no eviction/reclaim decision reads it.
+
+### [MED] Truncate reaps manifest rows + decrements refcounts BEFORE the local physical truncate — late local.Truncate failure leaves reclaimed metadata pointing at un-clipped bytes · `bugs` · area: write-path-carve
+- **Where:** `pkg/block/engine/readwrite.go:223`
+- **What:** Order: narrowChunkRow(201) → DecrementRefCountAndReapMany(224) → ReprojectBlocks(230) — all committed — THEN bs.local.Truncate(236). If (236) fails (ctx cancel, ENOSPC, badger error), returns at 237 with no rollback: rows already reaped, refcounts already decremented (maybe to zero → GC-eligible), File.Blocks already reprojected. readAtInternal queries bs.local.ReadAt FIRST, so a still-live local interval past newSize is served as-is on a later read — stale, "deleted" content, no error, nothing logged. Doc comment (171-177) claims this "mirrors Delete's ordering" — false; Delete does local.Delete FIRST (367), reap SECOND (421-426), the opposite.
+- **Why it matters:** truncate_reclaim.go documents exactly this failure shape ("later re-extend re-exposes discarded data... silent data-integrity/info-leak bug") and is itself best-effort, so nothing upstream compensates. No test injects a local.Truncate failure.
+- **Fix:** Reorder: bs.local.Truncate first, coordinator reap/reproject only after it durably succeeds (match Delete's actual order). If coordinator-first is required for another reason, treat a subsequent local.Truncate failure as fatal and surface a distinct error/metric.
+- **Verified:** CONFIRMED. Doc comment factually inverted vs Delete's real order. Reachable: internal/adapter/common/truncate_reclaim.go:43 (NFSv3/v4 SETATTR + CREATE-truncate, SMB SetEndOfFile), create.go:526, clone.go:325 — best-effort by contract, own header names this exact failure shape. journal.Store.Truncate can genuinely fail (ctx.Err, errClosed, marker append/fsync). MED not HIGH: needs a failure precisely in that window.
+
+### [MED] PunchHole reaps refcounts/manifest BEFORE the zero-overwrite loop — mid-loop WriteAt failure leaves stale non-zero bytes readable after refcounts already dropped · `bugs` · area: write-path-carve
+- **Where:** `pkg/block/engine/readwrite.go:309`
+- **What:** Same ordering defect as Truncate. DecrementRefCountAndReapMany + ReprojectBlocks (309-318) for fully-covered blocks run BEFORE the zero-fill loop (324-335, 1MiB bs.local.WriteAt chunks). Mid-loop WriteAt failure (ctx cancel, disk error) returns at 332 with the range only partly zeroed — but covered blocks' rows already reaped, refcounts already decremented. Local ReadAt resolves the un-zeroed tail directly as warm data (no reconciliation), so a DEALLOCATE-region read returns leaked old bytes while the CAS refcount may already be GC-eligible.
+- **Why it matters:** Same residency-truth mismatch as Truncate. No test drives a mid-loop WriteAt failure.
+- **Fix:** Zero the range locally first, run coordinator reap/reproject only after every write in the loop succeeds — mirrors the Truncate fix, keeps both consistent with Delete's actual local-then-metadata order.
+- **Verified:** CONFIRMED, more reachable than the Truncate case. Reachable: internal/adapter/nfs/v4/handlers/deallocate.go:91, after metadata.Service.PunchHole already pruned FileAttr.Blocks. Trigger broader than disk faults: journal AppendWrite can return ErrPressureTimeout under append-log pressure alone, no disk fault needed for a multi-MiB deallocate to hit it mid-range.
+
+### [MED] ReconcileLocalView.ListUnsynced never implemented — class-4 (stranded dirty-local chunk) reporting is structurally dead in every real deployment · `slop` · area: reclaim-reconcile-audit
+- **Where:** `pkg/block/engine/reconcile.go:32`
+- **What:** Interface declares ListUnsynced; doc comment claims `*fs.FSStore satisfies it`. Repo-wide grep: only the decl, the use (reconcile.go:228), and a test-only `fakeUnsynced` stub. No production type implements it — not *fs.FSStore, not its embedded journal.Store (only exposes UnsyncedBytes() int64, a counter not an enumerator), not memory.MemoryStore. Only prod call site: blockgc_reconcile_report.go:30 `le.Store.(engine.ReconcileLocalView)` — always ok=false, `locals` stays empty, class-4 loop (reconcile.go:224-234) never runs on real data. No compile-time assertion would've caught it (contrast gc_block.go:164's `var _ BlockReclaimer = ...`).
+- **Why it matters:** Same shape as legacy_migration.go's dead-interface finding, landing on the class tied directly to residency-truth: class 4 is the detector for dirty-local-only chunks (the ONLY durable copy) gone stranded. Operator running ReconcileReport before a reclaim pass gets permanent false-zero StrandedLocalChunks for every real share. Green unit test proves nothing — it hand-supplies the fake.
+- **Fix:** Implement ListUnsynced for real on *fs.FSStore, or drop the false doc claim + add a compile-time assertion / explicit runtime warning (pattern already used at blockgc_reconcile_report.go:52-57) so a missing implementation is visible.
+- **Verified:** CONFIRMED and live. Served at GET /api/v1/blockstore/reconcile-report (router.go:334, handlers/block_gc.go:312) and `dfsctl store block reconcile` (cmd/dfsctl/commands/store/block/reconcile.go:58) — StrandedLocalChunks reports 0 for every share always. reconcile.go:33 comment is false.
+
+### [MED] PunchHole reaps refcount/manifest durably, then zero-overwrites on the same non-durable WriteAt path — no fsync barrier before client is ack'd · `structure` · area: write-path-carve
+- **Where:** `pkg/block/engine/readwrite.go:309`
+- **What:** PunchHole: (1) DecrementRefCountAndReapMany + ReprojectBlocks — durable metadata txn (309-318); (2) zero-fill via bs.local.WriteAt (324-335) — rides the same deferred-fsync path as an ordinary WRITE (journal appendRecord: "It never fsyncs", journal/segment.go:256). Sole caller internal/adapter/nfs/v4/handlers/deallocate.go returns NFS4_OK at line 101 with no Flush/Commit. So manifest-says-gone is durable before the zero-write is durable, nothing forces the write durable before the client is told it succeeded.
+- **Why it matters:** On power loss in that window, reap is durable, zeros aren't. Read path resolves local reads from the journal interval index directly, never consults the manifest for warm data — pre-punch bytes can reappear after an acked DEALLOCATE. No RFC 7862 verifier mechanism lets the client detect this, unlike WRITE. Contrast: journal.Store.Truncate explicitly fsyncs a fencing marker first for exactly this reason ("Durability first...", journal/store.go:975) — PunchHole is the odd one out among Delete/Truncate/PunchHole in this file.
+- **Fix:** Either call bs.local.Commit(ctx, payloadID) after the zero-overwrite loop before PunchHole returns (closes the gap for every caller), or have the NFSv4.2 DEALLOCATE handler call CommitBlockStore/Flush after PunchHole succeeds. Prefer the former.
+- **Verified:** CONFIRMED, ordering and durability both verified as described. Severity HIGH→MED: window is power-loss only (a SIGKILL keeps the pwrite in page cache), and needs no client COMMIT.
+
+### [MED] Repair's synced-hash check has no synchronization with GC's marker-clear ordering — boolean check where the pattern needs a lock/generation guard · `structure` · area: manifest-check-repair
+- **Where:** `pkg/block/engine/manifest_repair.go:155`
+- **What:** planPayloadRepairs gates RepairRecreateRow on store.IsSynced(hash) (155-162), re-checked in repairRow via tx.IsSynced (380-387) — plain boolean reads, zero coordination with concurrent GC. gc_block.go's ReclaimDeadChunk (last-chunk branch, 147-160) deletes the remote object THEN removes the block record THEN clears the synced marker (DeleteSynced, 157) — deliberate crash-safety ordering, but leaves IsSynced==true for a window after the bytes are actually gone. GC's live-set is built from FileChunk rows (coordinator.go:624) — exactly what's missing for the row repair is trying to recreate — so the hash needing repair is by construction sweep-eligible concurrently.
+- **Why it matters:** The CAS-GC mark/sweep race the checklist calls out (item #8/#9). If recreate lands in the DeleteBlock-to-DeleteSynced window, repair fabricates a manifest row pointing at bytes already gone — a genuinely Lost range gets written back as falsely Synced, no comment anywhere names the shared invariant.
+- **Fix:** Take the per-remote GC-exclusion lock around ApplyRepairs, or re-verify recreate evidence against the block record (not just the boolean marker) at write time. At minimum a ponytail: comment at :155 and :380 naming the window.
+- **Verified:** CONFIRMED, and worse than claimed: gcRootLock (gc.go:400) only serializes GC-vs-GC, never vs a writer/repairer, and markPhase snapshots the live set from FileChunk rows — precisely the rows a repair candidate is missing — so any hash needing repair is unconditionally sweep-eligible. Reachable via REST ApplyRepairs. Severity HIGH→MED: needs a damaged payload plus an operator repair-with-apply overlapping a GC run.
+
+### [MED] Cache subsystem fully wired in production but the read path never consults it — Get/Put dead, feature is a no-op that still costs memory and goroutines · `bugs` · area: cross
+- **Where:** `pkg/block/engine/cache.go:205`
+- **What:** Store.ReadAt uses Syncer.scheduleReadahead, a separate mechanism unrelated to Cache. Cache.Get has zero callers; Cache.Put's only caller is prefetchWorker, fed by Store.loadByHash (engine.go:297) which unconditionally returns ErrChunkNotFound. Every production loadCache() call passes nil hashes (OnRead(payloadID, nil, 0) — reset signal only), so seqTracker/prefetch logic can never fire. NewCache is constructed whenever ReadBufferBytes > 0 (default 12.5% of RAM floored at 64MiB), spinning up 4 background workers per share for nothing.
+- **Why it matters:** read_buffer_size is a documented per-share config knob and CacheStats is surfaced via GetStats()/dfsctl as if reflecting real cache behavior. In production this does nothing for read latency or S3 GET reduction while costing real memory reservation and idle goroutines per share. Operator tuning read_buffer_size gets zero effect, no signal it's inert.
+- **Fix:** Either wire Cache.Get into readAtInternal's local-miss path with real OnRead hashes from ReadAt (restore the promised behavior), or delete Cache/NewCache/prefetch pool/loadByHash entirely, drop ReadBufferBytes/PrefetchWorkers config, stop reporting CacheStats.
+- **Verified:** CONFIRMED, stronger than claimed. cache.go:46 comment ("populated on write side via OnChunkComplete") is stale — OnChunkComplete exists nowhere in non-test code. Severity HIGH→MED, memory claim REFUTED: nothing is ever Put, so the LRU stays empty — actual cost is 4 idle goroutines/share plus an inert knob, not a memory reservation. Partially self-acknowledged: ponytail: marker at engine.go:294-296 ("leaves the CAS read cache hint-only") — but the hint is dead too.
+
+### [MED] OfflineReadiness.Safe() can report true for up to 60s after a fresh residency loss, contradicting its "live, not stale" contract · `bugs` · area: cross
+- **Where:** `pkg/block/engine/offline.go:381`
+- **What:** offlineReadinessOf combines a fresh ColdExtents scan with shortfall(ctx,reporter) served from shortfallMemo.get, which returns the memoized (bytes,ranges) verbatim while time.Since(m.at) < shortfallInterval (=1 minute, :356), no re-run. A manifest row the local index doesn't describe, introduced after the memo last recorded "no shortfall," is invisible for up to a minute — offlineReadinessOf falls through to Known:true, RemoteOnlyBytes from stale data, and Safe() (Known && RemoteOnlyBytes==0) can report true.
+- **Why it matters:** Sole prod caller Runtime.ShareOffline documents this explicitly as "taken live rather than recorded by a scheduled pass... an operator running `dfsctl share warm` wants to watch the number fall, not learn about it tomorrow" — directly contradicted by the memo. An operator/decommission workflow polling before wiping local storage can see Safe():true and destroy the only copy of bytes a concurrent event just made remote-only-and-unconfirmed. The existing ponytail comment only defends the persistent-shortfall direction, not a zero-memo going stale as a new loss appears.
+- **Fix:** Either make Known false with a Reason whenever the shortfall answer came from a memo hit near the interval edge, or add a Store.OfflineReadinessFresh(ctx) that bypasses the memo for ShareOffline specifically while pollers/dashboards keep the cheap path. At minimum document the up-to-60s lag on Safe().
+- **Verified:** CONFIRMED. Contract quote verified verbatim at runtime/offline.go:12-16. Downgraded HIGH→MED: window only opens if an interval is genuinely lost mid-process (itself an anomaly), bounded to 60s, fresh process starts with empty memo.
+
+### [MED] Manifest cross-check reads EVERY share's payloads, not just this one's — permanently breaks OfflineReadiness for shares sharing a metadata store · `bugs` · area: offline-readiness
+- **Where:** `pkg/block/engine/offline.go:202`
+- **What:** manifestShortfall walks chunks.EnumeratePayloads with no share filter — bs.fileChunkStore is the raw per-name metadata.Store (blockstore_config.go:437), and EnumeratePayloads on every backend iterates the whole keyspace, no shareName prefix filter, though payload IDs are `{shareName}/{uuid}`. For a share sharing a metadata store with another (documented pattern, configuration.md:1188), the cross-check for share A also walks share B's payloads; A's local index has zero entries for B's payloadIDs, so every one of B's rows shows up as 100% shortfall against A.
+- **Why it matters:** /archive is literally the docs' worked example for OfflineReadiness (configuration.md:664-670) AND for shared metadata (:1188) — under the documented topology, OfflineReadiness for /archive always takes the missing>0 branch and returns Known:false, permanently, no matter how much data is warmed and pinned. Not silent-zeros (fails toward indeterminate) but a complete, permanent break of the residency signal on a first-party documented deployment shape. No test exercises two shares against one fileChunkStore.
+- **Fix:** Thread shareName/ShareID into engine.BlockStoreConfig, filter manifestShortfall's EnumeratePayloads callback to the `shareName+"/"` prefix before calling ListFileChunks/DataExtents, or add a share-scoped EnumeratePayloads to metadata.Store.
+- **Verified:** CONFIRMED end to end (EnumeratePayloads has no share filter on any backend; journal DataExtents returns nil,nil for an unseen id → full-gap subtraction → Known:false). Two corrections: not unconditional — seedColdIfNeeded/SeedColdFromManifest walks the same unfiltered enumeration and instead inflates RemoteOnlyBytes with foreign bytes at seed time (Safe() still never true); payloads created by the sibling share AFTER that one-shot seed produce the permanent Known:false as described. Either way the signal is cross-share contaminated.
+
+### [MED] GetStats() N+1 per-payload walk silently truncated by a fixed 5s timeout, producing inconsistent counts with no error surfaced · `perf` · area: composition-lifecycle
+- **Where:** `pkg/block/engine/stats.go:194`
+- **What:** populateBlockCounts does one EnumeratePayloads + one ListFileChunks round trip PER payload, under a hardcoded `context.WithTimeout(context.Background(), 5*time.Second)`. Per-payload error (including deadline-exceeded once the budget is spent) does `return nil // skip this payload, keep going` (202-203) — BlocksTotal/Dirty/Local/Remote silently undercount for every payload after the deadline trips, while stats.FileCount is still set from the full enumeration. GetStats() has no error return.
+- **Why it matters:** N+1 scales linearly with payload count; a share with hundreds of thousands of files (measured elsewhere at 1.2M) can blow the 5s budget on one admin/metrics-triggered call. Failure mode is silent partial-count corruption, not a bounded error.
+- **Fix:** Return an error / Truncated bool from populateBlockCounts and surface it, or thread a real ctx instead of the hardcoded 5s (already ponytail-noted at stats.go:181), or memoize like offline.go's shortfallMemo does for the same walk.
+- **Verified:** CONFIRMED as described. Reachable: shares/blockstore_ops.go:269,283 (REST stats), non-test. One correction: if the deadline trips inside EnumeratePayloads itself, FileCount can be left at 0 rather than "correct" — skew varies by backend, but silent partial counts either way.
+
+### [MED] carvePass dispatches every resident file through a goroutine+semaphore+shard-lock every tick, not just dirty ones · `perf` · area: write-path-carve
+- **Where:** `pkg/block/engine/carve_dispatch.go:74`
+- **What:** carvePass calls m.local.ListFiles(ctx) — walks every shard's full index, ALL resident files regardless of dirty state — then for EVERY entry does uploadLimiter.Acquire + spawns a goroutine calling m.local.Carve. Each per-file Carve takes sh.carveMu + sh.mu (journal/carve.go:238-269) just to discover most files have zero dirty bytes and bail. journal.Carve already has a cheap empty-FileID path that filters candidates per-shard internally — carve_dispatch.go never uses it.
+- **Why it matters:** On a share where only a small fraction of resident files is dirty at any tick, this is O(total_resident_files) goroutine spawns + semaphore round-trips + shard-mutex pairs every UploadInterval (2s default) — recurring overhead scaling with total file count, not dirty file count, competing for scheduler time with the actual upload work.
+- **Fix:** Add a cheap dirty-candidate accessor to journal.Store (factor carveCandidates' per-shard filtering out into something exported) and dispatch goroutines only over that filtered set instead of ListFiles' full population.
+- **Verified:** CONFIRMED as written. Caveat on the fix: calling Carve with an empty FileID would serialize every shard behind one sequential loop, destroying the per-file upload concurrency the dispatcher exists for (doc at :59-71) — right fix is a dirty-file set (journal already tracks fi.firstDirtyNanos) exposed as ListDirtyFiles, feeding the same concurrent loop. Reachable: carveDispatcher launched from startPeriodicUploader (syncer.go:723-727).
+
+### [MED] GetStats never sets BlocksLocal; local-only-share committed chunks misreported as BlocksRemote · `structure` · area: composition-lifecycle
+- **Where:** `pkg/block/engine/stats.go:224`
+- **What:** classifyBlocks only ever increments BlocksDirty or BlocksRemote. BlockStoreStats.BlocksLocal (stats.go:15) is declared and cross-share merged (blockstore_ops.go:298) but never assigned anywhere — permanently 0. For a local-only share (remote==nil), manifestRows() writes every committed row State=Pending with a real hash and never transitions it; classifyBlocks's Pending+nonzero-hash branch counts it as BlocksRemote with comment "the remote copy is authoritative" — false when there is no remote.
+- **Why it matters:** Same class this audit targets: GetStats() is the engine's own reporting surface disagreeing with actual byte placement. An operator reading `dfsctl store block stats` for a local-only share sees non-zero "Blocks Remote" and zero "Blocks Local" — exactly backwards — could conclude the local copy is disposable when it's the only copy. Confirmed not to gate any automated eviction/reclaim decision — reporting-only.
+- **Fix:** In classifyBlocks, branch on bs.remote before classifying a hashed Pending row: bs.remote==nil (or hash not remote-confirmed) → BlocksLocal++, not BlocksRemote++.
+- **Verified:** CONFIRMED. engine.go:34-36 claims GetStats() "populates BlocksLocal/BlocksRemote/BlocksTotal" — false, zero assignments outside cross-share merge and dfsctl display. Reachable: GetStats → API /status + dfsctl store block stats. Reporting-only, MED stands.
+
+### [MED] Flush's doc comment claims a metadata quiesce the early-return path never performs · `structure` · area: write-path-carve
+- **Where:** `pkg/block/engine/flush.go:39`
+- **What:** Comment (39-41) says the early-return branch (LocalDurable() && !RequireDurableCommit() — the DEFAULT policy on any share with the standard fs local store) "Still perform[s] the per-payload FileChunk metadata quiesce that syncer.Flush would... only the remote carve drain is skipped." The branch's only action before returning is bs.local.Commit(28) = journal Store.Commit → shard.groupCommit, a pure fsync, nothing metadata-related. The real quiesce (FileChunk rows / FileAttr.Blocks projection) only happens inside Carve→CommitBlock, reached exclusively via bs.syncer.Flush(46) or the explicit DrainRollups/DrainAllUploads helpers — all after the early return.
+- **Why it matters:** Same idiom this audit already flagged live in the package (legacy_migration.go:28 precedent). Not cosmetic: an operator reasoning about why FileChunk manifest / FileAttr.Blocks lags a successful COMMIT (clone/snapshot/restart-recovery reasoning) is told by this comment the manifest is already quiesced when it structurally is not — only the next background carveDispatcher tick closes the gap.
+- **Fix:** Rewrite the comment: nothing beyond the local fsync runs on this branch, no FileChunk rows written here; manifest catches up only via background carveDispatcher (bounded by UploadInterval) or an explicit DrainRollups/Flush(force) call. Drop the false "still perform the quiesce" claim.
+- **Verified:** CONFIRMED verbatim. Branch is the default path (LocalDurable && !RequireDurableCommit) — production common case, not an edge case.
+
+### [LOW] compaction: ErrChunkNotFound branch deletes block record with zero liveness verification and zero logging on the happy path · `bugs` · area: gc-mark-sweep-compaction
+- **Where:** `pkg/block/engine/compaction.go:196`
+- **What:** compactOneBlock: when rbs.GetBlock fails with block.ErrChunkNotFound, code assumes the only cause is "prior compaction's DeleteBlock landed, DeleteBlockRecord did not" and calls v.DeleteBlockRecord(blockID) unconditionally — no liveness check (can't, object is gone). Unlike the object-present path below (parses block, checks GetLocator per record first), success path has no log line at all; only DeleteBlockRecord failure logs a Warn. compaction_test.go has no test on this branch.
+- **Why it matters:** ErrChunkNotFound is also exactly what real remote object loss/corruption/accidental-deletion looks like — indistinguishable here from crash-recovery, same action either way. Per-hash synced-locator index untouched in this branch, so hashes still pointing at blockID keep believing they're synced/live forever — permanent hard failure with no repair path, never re-surfaced as orphans by later sweeps since the marker still says synced. Matches the #2084 shape: no log on the common path, no operator visibility.
+- **Fix:** Log unconditionally (slog.Warn) on branch entry before deleting — should be rare (crash-recovery only), a steady background rate is itself a signal. Add a CompactReport counter (e.g. HuskRecordsWithoutObject). Stronger: record a short-lived tombstone/moved-to marker in the old record before a successful compaction's final DeleteBlockRecord, so crash-recovered husks are distinguishable from genuinely lost objects.
+- **Verified:** CONFIRMED as written, reachable via CompactBlocks ← blockgc.go:596 (non-test, DryRun false). Harm narrower than claimed: deleting the husk record does not CAUSE the stale-locator condition — locators pointing at a lost blockID are already dead either way. What's genuinely defective is observability: a real remote object-loss event is indistinguishable from routine cleanup and passes with zero log output. Downgraded to LOW, reclassified observability. Fix: one slog.Warn naming block_id + rec.ChunkCount before the delete.
+
+## Implementation gaps vs reference
+
+| Expected behavior (reference) | Our behavior | Gap | Source |
+|---|---|---|---|
+| fsync/close must block till durable, or protocol layer says async | PunchHole zero-fill rides journal's deferred-fsync WRITE path, NFSv4.2 DEALLOCATE handler ACKs `NFS4_OK` w/ no Flush/Commit after | Reap (manifest gone) durable before zero-write durable — power-loss window, pre-punch bytes reappear, no verifier lets client detect it (unlike WRITE/COMMIT) | readwrite.go:309, deallocate.go:91 · https://juicefs.com/docs/community/internals/io_processing/ |
+| write-back ("ack before upload") must be opt-in, named risk | default async policy (`LocalDurable && !RequireDurableCommit`) early-returns from Flush; comment claims a metadata quiesce still runs on that branch | Comment false — no FileChunk/manifest work happens, only a bare fsync; risk window undocumented, not tunable/named like rclone's `--vfs-write-back` | flush.go:39 · https://rclone.org/commands/rclone_mount/ |
+| sequential vs random-write carve strategy differs, no read-modify-write of remote object | not exercised by this audit — no finding either way | n/a | — |
+| local read-cache and write buffer logically distinct (evicting one can't drop not-yet-uploaded data) | `Cache` (read side) fully wired (NewCache, 4 workers/share) but `Get` has zero callers, `loadByHash` is a permanent no-op miss — read path uses `scheduleReadahead` instead | Not a conflation bug — worse, read cache is dead code costing memory/goroutines for zero effect; conflation risk moot only because the cache never holds anything | cache.go:205 · https://juicefs.com/docs/cloud/guide/cache/ |
+| fault-in fetches by need (range), not whole object | not exercised by this audit — no finding either way | n/a | — |
+| concurrent fault-in of same cold range deduplicated (singleflight) | `fetchResolvedBlock`/`inlineFetchOrWait` do share a waiter path, but their `ErrChunkNotFound` wrap-and-log is hand-copied between the two, comment admits waiter must see identical wrapped error or it diverges | Drift risk on the exact seam that keeps waiter/direct-caller errors consistent — no compile-time enforcement | fetch.go:649 |
+| partial/failed fault-in must not poison cache with partial/zeroed block | none directly — but same failure *class*: remote sweep can reclaim a hash a concurrent dedup write just re-referenced, no re-verify between mark snapshot and delete | Live row survives, block gone underneath it — reader gets unresolvable hash / silent zeros, same shape as #2084/#1888/#1850 (project memory) | gc_sweep_index.go:69 (HIGH) |
+| GC must never delete on existence-check alone — mark must be refreshed, not just observed | `sweepFromSyncedIndex` decides orphan-vs-live from a mark-phase snapshot (`gcs.Has`) taken before sweep; nothing revalidates before delete+`DeleteSynced` | Dedup hit (`engineDeduper.IsChunkDurable`) never refreshes `syncedAt` — classic CAS-GC resurrection TOCTOU, checklist's exact #8 scenario, live in this codebase | gc_sweep_index.go:69 (HIGH) · https://github.com/restic/restic/pull/2718 |
+| mark and sweep separated in time / serialized vs concurrent writers | `gcRootLock` only serializes GC-vs-GC, never GC-vs-writer/repairer; `manifest_repair.go`'s recreate path checks `IsSynced` as a plain boolean w/ zero coordination with GC's DeleteBlock→DeleteSynced ordering | Repair can fabricate a manifest row pointing at bytes GC already deleted in the marker-clear window — Lost range written back as falsely Synced | manifest_repair.go:155 (MED) · https://restic.readthedocs.io/en/stable/060_forget.html |
+| deletion deferred/delayed, not synchronous with logical delete (grace window absorbs racing readers/writers) | Truncate and PunchHole both reap manifest rows + decrement refcounts BEFORE the physical local truncate/zero-write, with no rollback if the physical op then fails | Late local failure leaves reclaimed metadata pointing at un-clipped/un-zeroed bytes — stale content served with no error, no compensating grace window like Ceph RGW's deferred purge | readwrite.go:223 (MED), readwrite.go:309 (MED) · https://docs.ceph.com/en/reef/radosgw/config-ref/ |
+| orphaned multipart uploads cleaned up on their own path | not exercised by this audit — no finding either way | n/a | — |
+| don't assume S3 listing is strongly consistent for scan-then-act reconciliation | `Reconcile()` builds the live-set (`EnumerateSynced`) BEFORE walking records (`WalkBlockRecords`) — opposite of `ReclaimRecords()`'s deliberately TOCTOU-safe order, which has an 18-line comment + regression test for the identical race | A commit landing between Reconcile's two scans is invisible to the live-set but visible to the record walk → false leaked-block classification (report-only, doesn't delete) | reconcile.go:169 (LOW, duplicated of the HIGH-class race) |
+| never derive object identity/dedup from ETag | dedup keyed by blake3 content hash (`engineDeduper.IsChunkDurable`), not S3 ETag | none — compliant | gc_sweep_index.go:69 narrative · https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html |
+| conditional writes (If-Match/If-None-Match) for manifest updates that must not clobber a concurrent writer | not exercised by this audit — no finding either way | n/a | — |
+| NFSv3 UNSTABLE write is a real not-yet-durable state; COMMIT is the only thing that makes it durable | PunchHole's zero-overwrite rides the same never-fsyncs journal `appendRecord` path as an ordinary WRITE, but the DEALLOCATE handler that triggers it returns success with no COMMIT/Flush step at all | Reap-then-write ordering means the "durable" signal (manifest updated) precedes actual durability of the write it depends on — inverts the RFC 1813 contract | readwrite.go:309, journal/segment.go:256 · https://www.rfc-editor.org/rfc/rfc1813.html |
+| fsync/COMMIT success must mean safe against the failure domains the engine claims to survive, not just "in the write-back buffer" | Flush's default-policy branch does a bare local fsync and returns; doc comment claims a metadata quiesce also ran | Operator reasoning about "why does manifest lag a successful COMMIT" is told the quiesce happened when structurally it never does — same caveat ZeroFS documents explicitly for its own NFS mount, undocumented here | flush.go:39 (MED) · https://github.com/Barre/ZeroFS |
+| SMB2/3 durable/persistent handles gated on CA + lease, reconnect must re-assert at correct epoch | not exercised by this audit — engine package has no SMB session/lease code, out of scope | n/a | — |
+| grace period/generation number, not wall-clock, gates reclaim of anything an in-flight reader might still touch | `sweepFromSyncedIndex`'s orphan decision is a pure wall-clock `syncedAt` vs `gracePeriod` cutoff, no generation/touch-on-reference — a dedup hit never bumps `syncedAt` | Root cause of the HIGH finding above: wall-clock-only grace period is exactly the gap this checklist item warns about — a generation/touch mechanism on synced markers would close it | gc_sweep_index.go:69 (HIGH), gc.go:680 |

--- a/.planning/2026-09-01-engine-audit-report.md
+++ b/.planning/2026-09-01-engine-audit-report.md
@@ -198,7 +198,7 @@ Stack: Go (module github.com/marmos91/dittofs, part of the `dfs` server binary �
 - **Verified:** CONFIRMED. Reachable via dfsctl store block audit→BlockStoreAuditRefcounts. Downgraded HIGH→LOW: perf only, on-demand operator command, bites only hardlink-heavy trees.
 
 ### [LOW] WarmAll silently drops unplaceable manifest rows with zero signal · `bugs` · area: read-path-cold-fetch
-- **Where:** `/Users/marmos91/dittofs-worktrees/audit-engine/pkg/block/engine/warm.go:116`
+- **Where:** `pkg/block/engine/warm.go:116`
 - **What:** `absOff, ok := block.ParseChunkOffset(fb.ID); if !ok { continue }` drops row silently — no log, no counter. `total` computed AFTER filter so progress()/WarmResult look like a clean complete run even with excluded rows.
 - **Why it matters:** Every other consumer of this condition (findRowCoveringOffset→ErrManifestInconsistent, resolveNextChunkStart, DataExtents) treats it as reportable; WarmAll swallows it. WarmAll exists to pre-warm before going remote-unreachable — a skipped range is never fetched, caller has no way to know it wasn't warmed.
 - **Fix:** Count/log skipped unplaceable rows (Warn/Error w/ payloadID+fb.ID, or surface via WarmResult) instead of bare `continue`, mirror SeedColdFromManifest's report.unplaceable pattern.
@@ -261,21 +261,21 @@ Stack: Go (module github.com/marmos91/dittofs, part of the `dfs` server binary �
 - **Verified:** CONFIRMED read_internal.go:170/229/450, fetch.go:107. Downgraded MED→LOW: pure in-memory uint64 compares on already-materialized slice (~1e6 compares, sub-ms) next to K remote GETs at hundreds of ms each — nowhere near a bottleneck; file's own "not the profiled hot path" note (:311) directionally right.
 
 ### [LOW] compactOneBlock re-fetches locators one-by-one, defeating the EnumerateSynced batching CompactBlocks just did · `perf` · area: gc-mark-sweep-compaction
-- **Where:** `/Users/marmos91/dittofs-worktrees/audit-engine/pkg/block/engine/compaction.go:237`
+- **Where:** `pkg/block/engine/compaction.go:237`
 - **What:** CompactBlocks (line 143) does one EnumerateSynced scan per share explicitly to avoid GetLocator-per-hash round trips (comment cites sqlite MaxOpenConns(1) O(N) serial cost) — but only keeps aggregated liveBytes[blockID], discards per-hash locator. compactOneBlock's moveable-selection loop then calls v.GetLocator once per chunk record in every candidate block — thousands of serial single-row queries on the same pool the batching was built to avoid.
 - **Why it matters:** Self-contradicts the file's own documented rationale two paragraphs above. N candidate blocks × M chunks each = O(N*M) individual queries instead of the one sequential scan already paid for.
 - **Fix:** Build hash→ChunkLocator (or hash→BlockID) map during the same EnumerateSynced pass used for liveBytes; thread into compactOneBlock so moveable loop does map lookup not GetLocator call.
 - **Verified:** CONFIRMED compaction.go:143-150/237. Reachable blockgc.go:596. Downgraded MED→LOW: only over CANDIDATE blocks (already below LiveRatio, ~128 records at 8MiB/64KiB not "thousands"), background GC pass off client path; naive fix has real memory tradeoff current code deliberately avoids.
 
 ### [LOW] sweepByWalk hex-encodes every walked hash unconditionally, even on the common keep-alive path · `perf` · area: gc-mark-sweep-compaction
-- **Where:** `/Users/marmos91/dittofs-worktrees/audit-engine/pkg/block/engine/gc.go:668`
+- **Where:** `pkg/block/engine/gc.go:668`
 - **What:** `key := h.String()` (hex.EncodeToString, fresh alloc) runs for every object before grace-window/live-set checks that usually return early. key only used on error/delete branches (addError, recordDryRunCandidate).
 - **Why it matters:** sweepByWalk runs over entire local chunk namespace; per-object allocation multiplied across millions of live/kept objects for a value thrown away unused most of the time.
 - **Fix:** Move `key := h.String()` down into each branch that actually needs it (addError calls, recordDryRunCandidate, delete-error path).
 - **Verified:** CONFIRMED gc.go:668 vs filters at 675-687; ContentHash.String is hex.EncodeToString(h[:]) (types.go:27-29). Reachable gc.go:481. LOW not MED: small alloc next to a disk-backed gcs.Has lookup already paid per object.
 
 ### [LOW] sweepFromSyncedIndex hex-encodes every synced hash unconditionally, even on the common live-keep path · `perf` · area: gc-mark-sweep-compaction
-- **Where:** `/Users/marmos91/dittofs-worktrees/audit-engine/pkg/block/engine/gc_sweep_index.go:54`
+- **Where:** `pkg/block/engine/gc_sweep_index.go:54`
 - **What:** `key := h.String()` runs for every marker EnumerateSynced yields, before syncedAt-zero/grace-window/live-set checks (present==true majority case). Same hex.EncodeToString allocation-per-call as gc.go:668.
 - **Why it matters:** This is the whole synced-hash index — whole live remote object population. Computing+discarding hex string per hash on common path wastes allocation at exactly the scale (millions of markers) surrounding code was engineered to bound.
 - **Fix:** Compute key lazily inside branches that use it (addError, recordDryRunCandidate) instead of unconditionally at callback top.

--- a/.planning/2026-09-01-journal-audit-report.md
+++ b/.planning/2026-09-01-journal-audit-report.md
@@ -49,7 +49,7 @@ Stack: Go (1.x, stdlib-first). Package `pkg/block/journal` inside the single rep
 - **Verified:** CONFIRMED. Not drop-in: rr.rec is retained by caller (carve.go:955-957), so a shared pool needs release semantics — simpler fix is per-runReader scratch reused across records. LOW.
 
 ### [LOW] loadCold slurps the whole cold.log into one buffer instead of streaming · `perf` · area: cold-tier
-- **Where:** `/Users/marmos91/dittofs-worktrees/audit-journal/pkg/block/journal/cold.go:193`
+- **Where:** `pkg/block/journal/cold.go:193`
 - **What:** `os.ReadFile(...)` pulls entire cold.log before decoding one entry; decode loop (200-210) appends with no cap hint; compaction gate (recovery.go:397) only evaluated after the full load.
 - **Why:** Breaks the package's own bounded-read convention (record.go streams via fixed hdrBuf/ReaderAt); store-open memory becomes O(total historical cold churn), not O(live cold intervals).
 - **Fix:** Decode via bufio.Reader / fixed scratch buf, same pattern as readRecordAt; size out's initial cap from fileSize/(coldHeaderSize+typicalIDLen).
@@ -231,7 +231,7 @@ Stack: Go (1.x, stdlib-first). Package `pkg/block/journal` inside the single rep
 - **Verified:** CONFIRMED at groupcommit_durability_test.go:18. Only two such refs in the whole package (grep for #1xxx/#2xxx), these two. Fix: delete the parenthetical.
 
 ### [LOW] appendCold permanently skips directory-fsync retry after first failure, defeating D4's durability guarantee · `bugs` · area: cold-tier
-- **Where:** `/Users/marmos91/dittofs-worktrees/audit-journal/pkg/block/journal/cold.go:145`
+- **Where:** `pkg/block/journal/cold.go:145`
 - **What:** First appendCold call: OpenFile(O_CREATE) makes cold.log even if fsyncDir(s.dir) then fails; error returned, file not removed. coldFD nil, next call os.Stat finds file exists, created=false, fsyncDir skipped forever after.
 - **Why it matters:** cold.go's own doc says this fsync exists so a crash right after first eviction can't come back to no cold.log. Losing the dir entry loses every cold marker → ranges read as POSIX holes → silent zeros (#2084-class). Fails open, untested.
 - **Fix:** On fsyncDir failure, `os.Remove(s.coldPath())` before returning so next call retries: `if derr := fsyncDir(s.dir); derr != nil { _ = fd.Close(); _ = os.Remove(s.coldPath()); return fmt.Errorf(...) }`.
@@ -322,7 +322,7 @@ Stack: Go (1.x, stdlib-first). Package `pkg/block/journal` inside the single rep
 - **Verified:** CONFIRMED. store.go:276-282. Reachable: Open is the package's sole constructor. Needs already-full volume at Open → MED→LOW. Fix: drop `&& free > 0` guard or make else unconditional.
 
 ### [LOW] SeedColdBatch re-locks the same per-shard mutex once per cold entry instead of grouping by shard · `perf` · area: store-api
-- **Where:** `/Users/marmos91/dittofs-worktrees/audit-journal/pkg/block/journal/store.go:628`
+- **Where:** `pkg/block/journal/store.go:628`
 - **What:** After appendCold, insert loop does `for _, e := range entries { sh := s.shardFor(e.id); sh.mu.Lock(); sh.indexFor(e.id).insert(...); sh.mu.Unlock() }`. entries built by iterating seeds in order, so every extent of one file is contiguous → back-to-back Lock/Unlock of the same shard mutex.
 - **Why it matters:** SeedColdBatch is documented as a bulk primitive seeding "whole manifest at once" for share-add/snapshot-restore, scaling with file count × extents-per-file. Re-acquiring the same mutex per entry adds needless lock/unlock churn proportional to N instead of distinct shards touched.
 - **Fix:** Group entries by shard before the insert pass (bucket by s.shardFor(e.id)), take each shard's lock once, insert all its entries under one critical section.

--- a/.planning/2026-09-01-journal-audit-report.md
+++ b/.planning/2026-09-01-journal-audit-report.md
@@ -1,0 +1,451 @@
+# Audit Report — dittofs (ff14b24cb)
+Stack: Go (1.x, stdlib-first). Package `pkg/block/journal` inside the single repo-root Go module (no nested go.mod under this path). Test-only deps: standard `testing` + in-package fakes (no testify/mock framework observed in headers scanned). Non-test external imports: internal/logger (repo-internal), pkg/block, pkg/block/chunker (sibling repo packages), lukechampine.com/blake3 (1 call site), golang.org/x/sys (statfs_unix.go/statfs_windows.go, build-tag split). No web framework, no ORM, no CLI framework here — this is a pure data-plane library package, not a service entrypoint. Build via `go build`/`go test` at repo root; no package-local Makefile/Dockerfile. · Areas: 6 · Findings: 6 HIGH / 8 MED / 45 LOW
+
+## Summary by dimension
+
+| Dimension | HIGH | MED | LOW |
+|---|---|---|---|
+| bugs | 3 | 1 | 6 |
+| slop | 0 | 1 | 4 |
+| perf | 0 | 4 | 9 |
+| structure | 0 | 1 | 15 |
+| bloat | 0 | 1 | 6 |
+| comments | 0 | 0 | 3 |
+| gaps | 3 | 0 | 2 |
+
+## Summary by area
+
+| Area | Findings |
+|---|---|
+| append-index-record | 10 |
+| carve | 9 |
+| cold-tier | 5 |
+| cross | 3 |
+| reclaim | 6 |
+| recovery | 10 |
+| store-api | 16 |
+
+## Findings
+
+### [LOW] insert() exact-overwrite fast path still heap-allocs a 1-elem dead slice on every warm overwrite · `perf` · area: append-index-record
+- **Where:** `pkg/block/journal/index.go:151`
+- **What:** Case (b) exact-range overwrite avoids the 3 general-path allocs + sort.Slice, but `dead = []segDead{{seg: e.loc.SegmentID, bytes: e.length}}` still allocs a fresh slice every non-cold overwrite.
+- **Why it matters:** This is the steady-state random-4K-write shape per func's own comment, called once per appendRecord under sh.mu — avoidable alloc right next to two paths already hardened against it.
+- **Fix:** Return scalar (deadSeg segDead, hasDead bool) or caller-owned scratch array instead of a 1-elem slice.
+- **Verified:** CONFIRMED. Named return escapes to heap. Single small alloc next to a WriteAt already doing 3 pwrites — MED demoted to LOW.
+
+### [LOW] appendRecord: 3 separate heap allocs per record on the write hot path, no pooling · `perf` · area: append-index-record
+- **Where:** `pkg/block/journal/segment.go:291`
+- **What:** `fileID := []byte(id)` (291), encodeHeader's make() (record.go:95), idxEntry.encode's make() (index.go:491) — 3 allocs/record, no reuse.
+- **Why:** Shared hot-path primitive behind both WriteAt and Hydrate; package already has recordScratchPool for reads but nothing analogous for writes.
+- **Fix:** Copy id bytes directly into the header buf being built (skip standalone []byte(id)); give idxEntry.encode a caller-supplied buf or per-shard scratch instead of make()-ing 40B/record.
+- **Verified:** CONFIRMED segment.go:291/373/457/511, record.go:94, index.go:490. ~110B allocs/record behind 3 pwrites + group fsync — LOW.
+
+### [LOW] readRecord (carve's read path) never reuses recordScratchPool, unlike verifiedRead · `perf` · area: append-index-record
+- **Where:** `pkg/block/journal/segment.go:588`
+- **What:** `readVerifiedRecord(seg.fd, recOff, s.cfg.SegmentSize, id, nil)` — nil scratch, fresh alloc per call. verifiedRead (index.go:386-412) pools the identical shape.
+- **Why:** readRecord drives carve's sequential hot loop (runReader.Read, carve.go:970) — once per record boundary per pack pass, unpooled while its sibling is pooled.
+- **Fix:** Thread a reusable scratch buffer through runReader (single-threaded/sequential) into readRecord, or have it borrow from recordScratchPool.
+- **Verified:** CONFIRMED. Not drop-in: rr.rec is retained by caller (carve.go:955-957), so a shared pool needs release semantics — simpler fix is per-runReader scratch reused across records. LOW.
+
+### [LOW] loadCold slurps the whole cold.log into one buffer instead of streaming · `perf` · area: cold-tier
+- **Where:** `/Users/marmos91/dittofs-worktrees/audit-journal/pkg/block/journal/cold.go:193`
+- **What:** `os.ReadFile(...)` pulls entire cold.log before decoding one entry; decode loop (200-210) appends with no cap hint; compaction gate (recovery.go:397) only evaluated after the full load.
+- **Why:** Breaks the package's own bounded-read convention (record.go streams via fixed hdrBuf/ReaderAt); store-open memory becomes O(total historical cold churn), not O(live cold intervals).
+- **Fix:** Decode via bufio.Reader / fixed scratch buf, same pattern as readRecordAt; size out's initial cap from fileSize/(coldHeaderSize+typicalIDLen).
+- **Verified:** CONFIRMED os.ReadFile at cold.go:193, called every open (recovery.go:359) before compaction gate can act. Downgraded LOW: decoded []coldEntry retained either way; growth already ponytail-marked recovery.go:394-395 as bounded.
+
+### [LOW] FileID(rec.fileID) map-key conversion in replayRecords allocates per record, bypasses inline-index elision · `perf` · area: recovery
+- **Where:** `pkg/block/journal/recovery.go:318`
+- **What:** `fid := FileID(rec.fileID); fi := idxMap[fid]` via local var defeats compiler's no-copy special case for `m[string(b)]` used directly as index. Same shape at 304, 311.
+- **Why:** Extra heap alloc per replayed record in recover()'s hottest loop, every boot.
+- **Fix:** Index map directly inline (`idxMap[FileID(rec.fileID)]`) on the lookup; materialize a real string only on insert.
+- **Verified:** CONFIRMED but smaller than claimed — only the map-hit READ is elidable; tombstone/truncate/insert branches store into the map and need a real string regardless. One small alloc/record, once per boot. LOW.
+
+### [LOW] WriteVersion and JournalVersion are byte-identical implementations exposed as two exported names · `structure` · area: store-api
+- **Where:** `pkg/block/journal/store.go:468`
+- **What:** WriteVersion (468) and JournalVersion (1046) both `return s.version.Load()`; different callers use each (engine/fetch.go:103, warm.go:94 vs flush.go:287, snapshot.go:561/1535).
+- **Why it matters:** Two public names for one concept — violates minimize-interface-surface, invites drift if one is changed and not the other.
+- **Fix:** Keep JournalVersion (matches PinVersion/SetPinVersion vocab), delete WriteVersion or alias it with a doc comment.
+- **Verified:** CONFIRMED identical bodies. Partial mitigation: WriteVersion is interface-mandated (local.Store, MemoryStore); collapsing needs an interface change, not just a delete. LOW.
+
+### [LOW] RestoreToVersion is a 170-line, gocyclo-37 function despite its own doc naming two independent phases · `structure` · area: store-api
+- **Where:** `pkg/block/journal/store.go:1079`
+- **What:** Doc comment (1065-1078) names "phase 1: ceiling replay" / "phase 2: re-materialize", body has matching markers (1087, 1169) but both live in one function mixing scan, dispatch, bookkeeping, I/O.
+- **Why:** SRP smell the code's own comments already point the way out of; hard to review or unit-test in isolation.
+- **Fix:** Extract replayCeiling(...) and rematerializeVersion(...) at the documented split; RestoreToVersion becomes a ~10-line orchestrator.
+- **Verified:** CONFIRMED 141 lines, ~38 decision points. Maintainability only — no gocyclo/funlen lint gate configured in .golangci.yml. LOW.
+
+### [LOW] errClosed is unexported even though it's the sentinel every gated Store method returns · `structure` · area: store-api
+- **Where:** `pkg/block/journal/store.go:26`
+- **What:** `var errClosed = errors.New("journal: store closed")` unexported, returned by 14+ exported methods; ErrLocalStoreFull (reclaim.go:29) exported in same package.
+- **Why:** Inconsistent sentinel-export convention; no external caller can `errors.Is(err, journal.ErrClosed)`.
+- **Fix:** Export as `ErrClosed` matching ErrLocalStoreFull's naming.
+- **Verified:** CONFIRMED inconsistency, but motivating "workaround" evidence (fs.go/engine's own closed sentinels) REFUTED — different layer/purpose, no demonstrated consumer need. MED demoted LOW; one-line fix.
+
+### [LOW] appendRecord's closed-check breaks the package's error-sentinel convention · `structure` · area: append-index-record
+- **Where:** `pkg/block/journal/segment.go:276`
+- **What:** Returns `fmt.Errorf("journal: closed")` instead of the errClosed sentinel used at all 13 other closed-check sites; sole exception is the shared primitive behind WriteAt/Hydrate.
+- **Why it matters:** Breaks errors.Is(err, errClosed) for exactly the write path that most needs to distinguish clean shutdown from real failure.
+- **Fix:** Replace with `errClosed` at segment.go:276.
+- **Verified:** CONFIRMED sole non-sentinel site. Present impact nil (errClosed itself unexported; only in-package errors.Is check is gcLoop, not write path) — combinatorial with the finding above. One-line fix, LOW.
+
+### [LOW] packRuns is a god-function: 246-line orchestration loop with shared mutable closure state · `structure` · area: carve
+- **Where:** `pkg/block/journal/carve.go:388`
+- **What:** 246 lines (388-634), gocyclo ~35, 6 shared locals (pending/arenap/arena/arenaOff/batchBytes/blockFirstRun) mutated across closures + outer loop.
+- **Why:** Block-builder state has nothing to do with the outer per-run widening/clobber-guard prologue; hard to reason locally about who mutates what.
+- **Fix:** Extract blockBuilder struct with ensureArena()/flush() methods; extract per-run prologue (extendRunToRowEnd + clobberGuard) into its own helper.
+- **Verified:** CONFIRMED 246 lines, locals match. Claim overstated closure count (3 actual, not 6). Concurrency already extracted to carveDispatcher — the natural seam this asks for. MED demoted LOW, no defect.
+
+### [LOW] repackSegment is a god-function mixing 5+ responsibility layers · `structure` · area: reclaim
+- **Where:** `pkg/block/journal/reclaim.go:729`
+- **What:** ~170 lines: snapshot victim under lock, tombstone scan, target segment create+write+seal, diskBytes accounting, index repoint (findMove/movesByVersion), victim retire, caller live-bytes mutation, delta compute — all inline.
+- **Why:** Hard to unit-test in isolation; file already shows the extraction discipline elsewhere (movesByVersion:689, findMove:701).
+- **Fix:** Extract snapshotVictim(), writeSurvivors(), repointIndex() per the func's own implied phases.
+- **Verified:** CONFIRMED 172 lines (729-901), all named concerns present. Reachable via GC→gcShard→pickVictim, production path. No correctness issue — MED demoted LOW.
+
+### [LOW] loadSegment is a god function mixing 6 unrelated concerns · `structure` · area: recovery
+- **Where:** `pkg/block/journal/recovery.go:187`
+- **What:** ~100 lines, 7+ early returns: fd open, header decode+orphan classify, sealed-but-empty damage, torn-tail truncate+fsync, shard resolve, two-actives conflict resolve, idx rebuild dispatch, replay dispatch — one flat function.
+- **Why:** Breaks recover()'s own clean phase-method decomposition (scanSegments/applyColdLog/compactColdLog/assignActiveSegments).
+- **Fix:** Extract classifySegment(), truncateTornTail(), resolveActiveConflict() as recoveryState methods.
+- **Verified:** CONFIRMED, matches described flow exactly (recovery.go:187-288). Style/SRP only, no behavioral defect. LOW.
+
+### [LOW] Three parallel slices kept in lockstep by an implicit shared index · `structure` · area: recovery
+- **Where:** `pkg/block/journal/recovery.go:122`
+- **What:** actives/sealedByShard/indexByShard — 3 independent slices/maps indexed by the same shard int across scanSegments, loadSegment, assignActiveSegments, reconcileByteCounters.
+- **Why:** Struct-of-arrays anti-pattern; each future per-shard field is one more slice threaded by the same index.
+- **Fix:** Bundle into `shardRecoveryData struct{active, sealed, index}`; single `[]shardRecoveryData`.
+- **Verified:** PARTLY REFUTED — "nothing enforces same length" is false: newRecoveryState (138-153) is the sole alloc site, all three sized n=cfg.ShardCount, never appended to elsewhere; length invariant structurally guaranteed. Style preference only — MED demoted LOW.
+
+### [LOW] doc.go "See gc.go" points at a file that doesn't exist · `bloat` · area: store-api
+- **Where:** `pkg/block/journal/doc.go:23`
+- **What:** "...must not drive one concurrently. See gc.go." — no gc.go in the package; GC lives in reclaim.go:516 (`func (s *Store) GC`).
+- **Why:** Stale reference in the package doc comment; reader following it hits a missing file.
+- **Fix:** `s/gc.go/reclaim.go/`.
+- **Verified:** CONFIRMED, isolated stale ref (adjacent cross-refs elsewhere correct, e.g. store.go:200, segment.go:85). Doc-comment only, zero runtime effect. LOW.
+
+### [LOW] appendTombstone/appendTruncateMarker and writeTombstoneRecord/writeTruncateRecord are near-duplicate bodies · `bloat` · area: append-index-record
+- **Where:** `pkg/block/journal/segment.go:426`
+- **What:** appendTombstone (426-474) and appendTruncateMarker (481-526) duplicate ctx check / maxFileIDLen / fail-injection / recLen / lock / seal-if-full / version stamp / write*Record / noteMinVersion / idxEntry / unlock / groupCommit / err-wrap; differ only in fail-field name, flag, FileOffset. writeTombstoneRecord (554-572) / writeTruncateRecord (531-550) likewise duplicate the encode/WriteAt/advance-tail sequence.
+- **Why it matters:** ~90 lines of copy-paste in the hottest append-path file; any future change to marker framing has to be made and re-verified twice.
+- **Fix:** Collapse to one `writeMarkerRecord(seg, id, version, flags, fileOffset)` and one `appendMarker(ctx, id, flags, fileOffset, failInject, kind)` that both current functions become thin wrappers over.
+- **Verified:** CONFIRMED, deltas exactly as described. Reachable via Delete (store.go:773) / Truncate (store.go:976) + reclaim repack carry-forward. Pure duplication, no drift present today. LOW.
+
+### [LOW] doc.go's dependency claim is contradicted by carve.go's three optional capabilities · `bloat` · area: carve
+- **Where:** `pkg/block/journal/doc.go:6`
+- **What:** doc.go:6-10 claims journal "depends only on stdlib plus a pair of narrow injected interfaces (RemoteStore, Clock)" and "knows nothing about namespaces, protocols, permissions, or the metadata store." carve.go:108-162 defines 3 more optional BlockSink capabilities — supersededReaper.ReapSupersededManifest, manifestRowEnder.ManifestRowEndAfter, clobberGuard.PreserveClobberedRow — doc comments reason in manifest-row/CAS vocabulary ("the commit that writes a row is an upsert", "a punched hole must read as zeros", "gap-free, overlap-free tiling of [0,size)"). Metadata-store domain knowledge baked into journal's own interface contracts.
+- **Why it matters:** doc.go is the package's stated contract, primary rubric readers trust. Claim is false: only crash-safety commit-before-flip is metadata-agnostic, packing/reap correctness is not.
+- **Fix:** Narrow doc.go to name these 3 as an explicit extension point for CAS-manifest-shaped sinks, or move the manifest-row reasoning into pkg/block/engine/blocksink.go where concrete sinks live; keep journal-side interface docs generic ("reports how far downstream coverage of a range reaches").
+- **Verified:** CONFIRMED, stronger than claimed. doc.go:6-10 false twice: (a) non-test imports include internal/logger, pkg/block, pkg/block/chunker, lukechampine.com/blake3; (b) 2 more mandatory interfaces (Deduper, BlockSink) injected via SetCarveTargets (carve.go:170), plus the 3 optional ones. REACHABLE: engine/syncer.go:820,831 wire real sinks; engine/blocksink.go:167-235 implements all three. Doc-accuracy only.
+
+### [LOW] coldstats.go split from cold.go not justified — one method, no reuse boundary · `bloat` · area: cold-tier
+- **Where:** `pkg/block/journal/coldstats.go:29`
+- **What:** coldstats.go is 53 lines, one exported method ColdExtents (~20 lines code, rest doc comment). No test-only/build-tag reason to separate from cold.go (encode/decode, appendCold, loadCold, rewriteCold, liveColdEntries, ColdSeeded/MarkColdSeeded). ColdExtents duplicates liveColdEntries's (cold.go:268-281) walk-shards-filter-iv.cold shape.
+- **Why it matters:** CLAUDE.md flags unjustified file fragmentation (carve.go/carve_dispatch.go/carve_pack.go, reclaim.go precedent). Single-method file, no distinct lifecycle/locking/audience from cold.go — cost a 2nd file + doc preamble for zero cohesion gain.
+- **Fix:** Fold ColdExtents (+ coldstats_test.go) into cold.go / cold_test.go. Split into real cold/ subpackage only if cold-tier surface later grows enough to justify it.
+- **Verified:** CONFIRMED: 53 lines, one symbol at :29, ~20 lines code under 24-line doc comment, no build tag, same sh.mu-per-shard walk as cold.go. cold.go 324 lines already holds every other cold concern. REACHABLE: engine/offline.go:60 declares interface, offline.go:145 calls it. File-layout smell only.
+
+### [LOW] writeDataRecord duplicates appendRecord's frame+write+CRC sequence instead of being shared · `bloat` · area: reclaim
+- **Where:** `pkg/block/journal/reclaim.go:971`
+- **What:** reclaim.go:971-999 writeDataRecord (used only by repackSegment) re-implements the header-encode + 3x WriteAt (header, payload, CRC) + tail-advance sequence segment.go:328-353 does inline in appendRecord (live write path). ~20 near-identical lines, independent error strings ("write record header" vs "repack write header").
+- **Why it matters:** Package already extracted writeTombstoneRecord/writeTruncateRecord (segment.go:531-573) explicitly as helpers "shared by the live path and repack's marker carry-forward," called from reclaim.go. writeDataRecord is the same shape for data records but never wired back into appendRecord — duplicate logic that can drift.
+- **Fix:** Have appendRecord call writeDataRecord(seg, id, offset, version, synced, data) instead of inlining, mirroring the marker-record delegation. writeDataRecord already returns payloadOff for direct use.
+- **Verified:** CONFIRMED reclaim.go:967-999 writeDataRecord same sequence as segment.go ~328-353, differing only error strings. Established shared-helper pattern exists (segment.go:531-572, explicit doc comment) for marker records; data-record case is the odd one out. REACHABLE: writeDataRecord called reclaim.go:803 from repackSegment (GC path); appendRecord is live write path. No behavioral divergence today (reclaim.go:837 correctly notes deliberate diskBytes difference).
+
+### [LOW] doc.go points to a file that doesn't exist · `comments` · area: store-api
+- **Where:** `pkg/block/journal/doc.go:23`
+- **What:** "...journal must not drive one concurrently. See gc.go." — no gc.go in package. GC/reclaim lives in reclaim.go (confirmed by store.go:200 "(reclaim.go)" and segment.go:85 "reclaim.go" pointing correctly).
+- **Why it matters:** Stale cross-reference in the package's own doc contract, the primary rubric this audit treats as verifiable — a reader following it hits a 404.
+- **Fix:** Change "See gc.go." to "See reclaim.go."
+- **Verified:** DUPLICATE of doc.go:6 finding, same evidence: doc.go:23 'See gc.go.', no gc.go in package, GC is reclaim.go:516. Correct sibling refs at store.go:200 and segment.go:85 confirm intended target. Doc-only.
+
+### [LOW] Free-disk-space (statfs) is queried once at Open to size a static cap; the live eviction gate never re-polls it · `gaps` · area: store-api
+- **Where:** `pkg/block/journal/store.go:276`
+- **What:** diskFreeBytes (statfs_unix.go:10, statfs_windows.go:10) called exactly once, in Open (store.go:276-283), to derive static cfg.MaxLocalBytes = free*0.8 when unset. ensureSpace (reclaim.go:328-335) gates purely on s.diskBytes.Load()+needed > s.cfg.MaxLocalBytes — an in-memory counter never cross-checked against real disk free space again.
+- **Why it matters:** Reference write-back caches (rclone --vfs-cache-max-size/--vfs-cache-min-free-space, JuiceFS --free-space-ratio) combine a configured quota with a live statfs check because internal accounting can diverge from reality (other shares/host consuming the same volume after Open). Here the cap is a one-time startup snapshot, never refreshed.
+- **Fix:** Have ensureSpace (or a periodic check) re-probe diskFreeBytes(s.dir) and treat low live headroom as a second, independent eviction trigger alongside the MaxLocalBytes/diskBytes comparison.
+- **Verified:** CONFIRMED. Repo-wide diskFreeBytes call sites: statfs_unix.go:10/statfs_windows.go:10 (defs), store.go:277 (sole production call, inside `if cfg.MaxLocalBytes <= 0`), bounded_growth_test.go:17 (test). ensureSpace never re-polls statfs. NOT correctness-breaking: reclaim.go:319-327 documents MaxLocalBytes as "a soft pressure threshold, not a hard byte quota," store only over-fills its own accounting, never corrupts. Self-limiting: stale snapshot only exists when MaxLocalBytes left unset. Real gap vs rclone/JuiceFS but MED overstates it.
+
+### [LOW] Delete unconditionally wipes truncVer even when the tombstone loses the race, reopening the truncate-staleness hole for the file's surviving incarnation · `bugs` · area: cross
+- **Where:** `pkg/block/journal/store.go:807`
+- **What:** Store.Delete (store.go:759-813) appends a tombstone at tombVer, keeps intervals with `iv.version > tombVer` (store.go:785-786, "raced past the delete: survives"). Regardless of survivors, `delete(sh.truncVer, id)` (store.go:806-807) runs unconditionally under "The file is gone, so its truncate bound has nothing left to guard" — false exactly when intervals survived. truncVer is the only thing staleAfterTruncate (store.go:471-474) checks to refuse a stale Hydrate write-back predating the file's last Truncate.
+- **Why it matters:** A Hydrate in flight (notAfter sampled pre-truncate) that acquires sh.mu after this unconditional delete finds truncVer[id] absent, staleAfterTruncate returns false, fileIndex.hydratable (index.go:509-544) treats every gap as ordinary and hydratable — stale remote bytes get written back into the surviving file. The silent-stale-write-back class truncVer/doc.go D4 exist to prevent. Narrow (needs Truncate, then Delete racing a write, then a stale in-flight Hydrate on same file) but real, currently-unguarded, code path explicitly written and commented.
+- **Fix:** Gate `delete(sh.truncVer, id)` on the same `len(kept)==0` condition already computed for the index (mirrors the already-conditional `delete(sh.index, id)` at store.go:797-800). Leave truncVer entry in place when tombstone loses the race.
+- **Verified:** CONFIRMED store.go:806-807 unconditional, outside the `len(kept)==0` branch (785-786). truncVer sole reader staleAfterTruncate (store.go:471-474), sole writer Truncate (store.go:968). hydratable (index.go:509-544) fences only cold intervals by mark, plain holes always returned. REACHABLE non-test: Delete <- FSStore.Delete <- engine/readwrite.go:367 (NFS REMOVE/SMB delete) + flush.go:308; Hydrate <- engine/fetch.go:201 (cold-read write-back). Fix is one line. Severity lowered MED->LOW: narrow window, Delete records no version fence of its own anyway.
+
+### [LOW] rewriteCold leaves cold.log.tmp orphaned on every error path · `bugs` · area: cold-tier
+- **Where:** `pkg/block/journal/cold.go:234`
+- **What:** None of the failure returns in rewriteCold (Write error ~245, Sync error ~249, Close error ~252, and Rename error ~255) remove the temp file `path+".tmp"` already created/written. Stray file persists in the journal directory after a compaction failure.
+- **Why it matters:** Concrete resource leak on an otherwise carefully crash-safe path (temp+rename+fsyncDir); harmless to correctness since loadCold only reads cold.log, but leaves debris in a directory this package's crash-recovery model reasons carefully about.
+- **Fix:** `defer func(){ if err != nil { _ = os.Remove(tmp) } }()` at the top of rewriteCold with a named return, or explicit `_ = os.Remove(tmp)` on each error return.
+- **Verified:** CONFIRMED cold.go:217-262: tmp opened O_CREATE|O_TRUNC; Write/Sync/Close/Rename failure returns all leave tmp on disk (Rename failure return at ~255 also missed by the original claim). REACHABLE non-test: recovery.go:400 `r.s.rewriteCold(live)` on Open/recovery path. Trivial in practice: next rewrite reopens same path with O_TRUNC, at most one stale file.
+
+### [LOW] Wire-framing structs split between exported (PascalCase) and unexported (lowercase) field casing with no reflection/marshaling reason for either · `structure` · area: append-index-record
+- **Where:** `pkg/block/journal/record.go:77`
+- **What:** recordHeader (record.go:77-83) and idxEntry (index.go:479-486) use exported PascalCase fields as layout-table documentation only — both hand-encoded (encodeHeader/decodeHeader, idxEntry.encode()), never via reflection/encoding-json. interval (index.go:29-46), piece (index.go:235-246), segmentMeta (segment.go:47-82) — structurally identical in-memory mirrors — use lowercase unexported fields.
+- **Why it matters:** No functional difference, but unresolved style split within the same two files for the identical kind of struct, making exported casing look like it signals something (serialization, external API) when it doesn't.
+- **Fix:** Pick one convention for internal wire-framing structs (lowercase, none need reflection); lowercase recordHeader's and idxEntry's fields to match interval/piece/segmentMeta. Bundle with an unrelated touch to these files, not standalone.
+- **Verified:** CONFIRMED: recordHeader and idxEntry both hand-encoded, no reflection/struct tags anywhere. interval/piece/segmentMeta lowercase for identical kind of mirror. Both types used from non-test code. Pure style split, no functional effect.
+
+### [LOW] journal/carve_dispatch.go and engine/carve_dispatch.go share a filename across sibling packages for unrelated responsibilities · `structure` · area: carve
+- **Where:** `pkg/block/journal/carve_dispatch.go:1`
+- **What:** pkg/block/journal/carve_dispatch.go (209 lines) is the per-file commit/flip ordering pipeline (carveDispatcher, commit-before-flip invariant, sem-bounded worker pool). pkg/block/engine/carve_dispatch.go (140 lines) is the background ticker loop calling journal.Carve across a share's files (Syncer.carveDispatcher, carvePass, newBlockID). Complements, not duplicates — confirmed by diff against source, not correctness finding.
+- **Why it matters:** Identical basenames in sibling packages named around "carve dispatch" is a discoverability trap: grep -l, fuzzy-file-open, `git log --follow -- '**/carve_dispatch.go'` land on the wrong one without full path in view; a reader skimming names alone reasonably guesses these are one concept split across layers.
+- **Fix:** Rename journal/carve_dispatch.go to carve_pipeline.go (it's a per-block commit->flip pipeline, not a scheduler) — frees "dispatch" for the engine-side scheduling loop that actually dispatches carve work.
+- **Verified:** CONFIRMED both files production code: journal side = carveDispatcher (acquire/submit/commitAndFlip/discard/wait, commit-before-flip ordering); engine side = Syncer.carveDispatcher/carvePass/carveBlockSize/newBlockID (background ticker). Different responsibilities, identical basename in sibling packages. Discoverability nit only.
+
+### [LOW] ColdExtents breaks the package's established named-result-struct convention for tally APIs · `structure` · area: cold-tier
+- **Where:** `pkg/block/journal/coldstats.go:29`
+- **What:** ColdExtents returns bare `(bytes int64, extents int64, err error)`. The package's other multi-field tally report, Evict (reclaim.go:56), returns named EvictResult{SegmentsEvicted, BytesFreed} instead of positional ints. Shape already leaked: engine/offline.go:60 hand-declares `ColdExtents(ctx) (bytes int64, extents int64, err error)` as its own interface method to consume it.
+- **Why it matters:** Go idiom favors a named result struct over same-typed positional returns once there's more than one value: documents which int is which at call sites, can grow a field later without changing every signature. Package already applies this idiom for EvictResult; ColdExtents is the odd one out by omission.
+- **Fix:** If signature is still cheap to change (check offline.go's Store type + two test fakes mirroring the tuple), introduce `type ColdStats struct{ Bytes, Extents int64 }`, return `(ColdStats, error)`; otherwise bundle with next signature touch, don't do standalone.
+- **Verified:** CONFIRMED coldstats.go:29 tuple; EvictResult at reclaim.go:38-41 returned by Evict (reclaim.go:56). Shape leaked to engine/offline.go:60 coldRangeReporter, consumed at offline.go:145. Two same-typed positional returns are mis-orderable.
+
+### [LOW] evict's allowActiveSeal is an undocumented boolean-trap parameter · `structure` · area: reclaim
+- **Where:** `pkg/block/journal/reclaim.go:343`
+- **What:** s.evict(ctx, targetBytes, allowActiveSeal bool) called as s.evict(ctx, overage, false) at reclaim.go:343 (ensureSpace) and s.evict(ctx, targetBytes, true) at reclaim.go:57 (Evict). Bare true/false carries load-bearing meaning (whether the write-path capacity gate may force-seal its own active segment) invisible at either call site.
+- **Why it matters:** Classic boolean trap — reader of ensureSpace sees `false` and must jump to evict's doc to learn what it disables. Both call sites already carry multi-line comments compensating for the bool's opacity.
+- **Fix:** Name the constant at each call site (`const dontSealActive = false` / `const allowSealActive = true`), or two thin wrappers evictForce/evictWritePath, so the call reads without a doc jump.
+- **Verified:** CONFIRMED reclaim.go:65 signature, call sites reclaim.go:57 (true) and reclaim.go:343 (false), both with multi-line explanatory comments exactly as the finding names. Live non-test path (ensureSpace is the write-path capacity gate). Style-only.
+
+### [LOW] Idx-sidecar open flags/perm tuple duplicated verbatim in 3 places · `structure` · area: recovery
+- **Where:** `pkg/block/journal/recovery.go:258`
+- **What:** `os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)` for the .idx sidecar appears identically at recovery.go:258, recovery.go:462, and segment.go:177 — three independent copy-pasted literals.
+- **Why it matters:** DRY violation on a correctness-sensitive tuple (flags+perm for a durability-adjacent file). A future change (e.g. adding O_SYNC, tightening perms) applied to one site and missed on the others silently reintroduces divergent idx-write behavior between fresh-create, recovery-reopen, and pool-reuse paths.
+- **Fix:** Extract a single openIdxAppend(path string) (*os.File, error) helper in segment.go, call it from all three sites.
+- **Verified:** CONFIRMED byte-identical at recovery.go:258 (recovery-reopen), recovery.go:462 (pool-reuse), segment.go:177 (fresh-create). All three non-test paths; segment.go:177 via createSegment, both recovery sites via Store.recover. recovery.go:561 uses O_TRUNC, correctly excluded. Fix: one func (s *Store) openIdx(id uint64) *os.File; three sites collapse to it.
+
+### [LOW] Comment references an issue number, banned by repo convention · `comments` · area: store-api
+- **Where:** `pkg/block/journal/commit_bench_test.go:10`
+- **What:** "BenchmarkConcurrentCommit reproduces the fio rand-write-4k shape that #1736 regressed on" — embeds issue number #1736 in a source comment.
+- **Why it matters:** CLAUDE.md "Code comments": comments describe behaviour, never reference issue/PR numbers — those belong in commit messages/PR descriptions. No ponytail: prefix here (the sole sanctioned exception).
+- **Fix:** Drop the issue number, describe the shape directly (e.g. "reproduces a fio rand-write-4k burst: many concurrent 4 KiB writes each followed by a durability Commit..."); move #1736 pointer to a commit message if needed.
+- **Verified:** CONFIRMED at commit_bench_test.go:10. Rule not scoped to non-test files — this is committed, compiled source, not an unreachable path.
+
+### [LOW] Comment references an issue number, banned by repo convention · `comments` · area: store-api
+- **Where:** `pkg/block/journal/groupcommit_durability_test.go:18`
+- **What:** "...which is what proves they aren't hollow (see #1736 durability review)."
+- **Why it matters:** Same CLAUDE.md rule as above — no issue/PR references in source comments, no ponytail: prefix.
+- **Fix:** Drop "(see #1736 durability review)"; the preceding sentence already explains why the seam exists without needing the pointer.
+- **Verified:** CONFIRMED at groupcommit_durability_test.go:18. Only two such refs in the whole package (grep for #1xxx/#2xxx), these two. Fix: delete the parenthetical.
+
+### [LOW] appendCold permanently skips directory-fsync retry after first failure, defeating D4's durability guarantee · `bugs` · area: cold-tier
+- **Where:** `/Users/marmos91/dittofs-worktrees/audit-journal/pkg/block/journal/cold.go:145`
+- **What:** First appendCold call: OpenFile(O_CREATE) makes cold.log even if fsyncDir(s.dir) then fails; error returned, file not removed. coldFD nil, next call os.Stat finds file exists, created=false, fsyncDir skipped forever after.
+- **Why it matters:** cold.go's own doc says this fsync exists so a crash right after first eviction can't come back to no cold.log. Losing the dir entry loses every cold marker → ranges read as POSIX holes → silent zeros (#2084-class). Fails open, untested.
+- **Fix:** On fsyncDir failure, `os.Remove(s.coldPath())` before returning so next call retries: `if derr := fsyncDir(s.dir); derr != nil { _ = fd.Close(); _ = os.Remove(s.coldPath()); return fmt.Errorf(...) }`.
+- **Verified:** CONFIRMED cold.go:129-150. Reachable via reclaim.go:280 (evictSegment), store.go:531 (SeedCold), store.go:625 (SeedColdBatch), store.go:1290 (Invalidate). Needs dir-fsync error + later crash before writeback → LOW not HIGH.
+
+### [LOW] Sealed-segment corruption past first record silently dropped: no warning, no truncation, no disk-byte correction · `bugs` · area: recovery
+- **Where:** `pkg/block/journal/recovery.go:214`
+- **What:** loadSegment warns only when sealed segment scans as ZERO valid records. N good records then a torn record N+1 → recs short, validUpTo < fileSize, but truncate branch at line 243 is gated `!sealed` so nothing truncates AND nothing logs. m.tail.Store(validUpTo) under-reports segment size; diskBytes undercounts.
+- **Why it matters:** A sealed segment is trusted as fully durable. Any record dropping from the index via mid-stream corruption is indistinguishable from never-written data → HOLE/WARM conflation (D1 cardinal sin), zero diagnostic trace. TestSealedSegmentWithNoValidRecords only covers len(recs)==0, not the prefix-then-corrupt case.
+- **Fix:** After scanValidRecords, for sealed branch also check `validUpTo < fileSize(fd)` and logger.Warn naming segment id + dropped range. Use fileSize(fd) not validUpTo when summing `disk` in recover(). Add regression test with valid records ahead of corrupted tail.
+- **Verified:** CONFIRMED recovery.go:214-228 warns only on `sealed && len(recs)==0`; torn-tail branch at 243 gated `!sealed`. Reachable: loadSegment called from recover() on every open. Data past tear already untrustworthy regardless — actual defect is missing diagnostic + undercount, not new data loss → LOW.
+
+### [LOW] doc.go's stdlib-only dependency claim is contradicted by the package's own import block · `slop` · area: store-api
+- **Where:** `pkg/block/journal/doc.go:7`
+- **What:** doc.go claims journal "depends only on the standard library plus a pair of narrow injected interfaces (RemoteStore, Clock)". store.go:14-15 imports internal/logger and pkg/block/chunker directly (11 logger.Warn sites; chunker.Params/DefaultParams/Validate in Config.withDefaults). format.go imports pkg/block for block.ErrFutureFormat.
+- **Why it matters:** This is the doc's central testable D5 claim and it's false trivially — a grep of the package's own imports refutes it. internal/logger is an internal/ import, a hard Go-compiler blocker for the "stand alone as a library" extraction doc.go asserts is already true.
+- **Fix:** Either sever the deps (inject a narrow Logger interface instead of internal/logger; chunker/block deps harder to remove) or rewrite the doc claim to state the real dependency set.
+- **Verified:** CONFIRMED: doc.go:7-9 vs internal/logger (store.go:14-15), pkg/block/chunker (store.go:15), pkg/block (format.go). internal/ path makes extraction outright impossible. Documentation-only, no runtime effect → LOW.
+
+### [LOW] fileIndex.insert: tie-break on equal Version diverges between fast-path and general-path branches · `slop` · area: append-index-record
+- **Where:** `pkg/block/journal/index.go:166`
+- **What:** Exact-range fast path (line 147): `iv.version <= e.version` → existing wins tie. General multi-fragment path (line 166): `e.version > iv.version` (strict) → tie falls to else, new wins. Same rule, opposite outcome on equality.
+- **Why it matters:** Ties are real: recovery.go's applyColdLog (line 377) replays cold-log entries at their *original* persisted Version. A crash window (whole-range warm record replayed, then partial overwrite splits it, then cold entry re-inserted at original Version) produces a tie against a still-valid warm fragment, forced onto the general path, which now demotes an intact warm fragment to cold and charges it dead — needless remote fetch, skewed GC dead-byte signal. Breaks order-independence the fast path (and TestInsertNewestWinsByVersion) assumes. No test covers a Version tie in either branch.
+- **Fix:** Change line 166 to `if e.version >= iv.version {` to match fast path. Add tie regression test (exact match + multi-fragment overlap) in index_test.go.
+- **Verified:** CONFIRMED drift, index.go:147 vs :166. Ties producible via applyColdLog (recovery.go:377) reusing persisted Version, and repackSegment moves forward with m.version. Impact = needless remote fetch + skewed GC signal, not corruption (range still remote-durable via evictable() gate), needs narrow crash window → LOW not HIGH.
+
+### [LOW] syncedRanges does unbounded O(intervals) scan per dirty run instead of binary-search bound like its sibling anySyncedFrom · `perf` · area: carve
+- **Where:** `pkg/block/journal/carve.go:749`
+- **What:** syncedRanges(sh, id, from, to) walks `for k := range fi.ivs` from index 0 over every live interval, under sh.mu.Lock(). Called once per dirty run from packRuns (carve.go:500-507) whenever sink implements clobberGuard — which both production sinks do. Sibling anySyncedFrom (20 lines above) already bounds start via `sort.Search(len(fi.ivs), func(i int) bool { return fi.ivs[i].end() > off })` (carve.go:729) specifically to stay off hot paths.
+- **Why it matters:** O(runs × total_intervals) per file under a lock that blocks concurrent appends, on a path the same file already documents as needing this exact optimization.
+- **Fix:** `k := sort.Search(len(fi.ivs), func(i int) bool { return fi.ivs[i].end() > from })`, start walk from k, keep existing `iv.fileOff >= to` break.
+- **Verified:** CONFIRMED carve.go:759 loop from 0 vs sibling's sort.Search bound at :729. Reachable per dirty run via both production sinks (blocksink.go:171,:175 implement PreserveClobberedRow). LOW not HIGH: same per-run pass already pays a whole-manifest read in extendRunToRowEnd (ponytail-marked dominant cost), so this in-memory walk isn't the bottleneck.
+
+### [LOW] rebuildIdx: N unbuffered write() syscalls instead of one batched write · `perf` · area: recovery
+- **Where:** `pkg/block/journal/recovery.go:565`
+- **What:** `for _, rec := range recs { fd.Write(idxEntry{...}.encode()) }` — one raw fd.Write per record (40 bytes), no bufio, single Sync at end. fnv1a(string(rec.fileID)) allocates a fresh string per iteration.
+- **Why it matters:** Triggered whenever .idx sidecar is missing — exactly the failure recovery must handle promptly. Thousands of records = thousands of syscalls serially blocking Open().
+- **Fix:** Wrap fd in bufio.NewWriter (or accumulate into one []byte), single/few Write calls, Flush before Sync.
+- **Verified:** CONFIRMED recovery.go:565-578, fnv1a alloc at :568, Sync at :579. Reachable via loadSegment idxMissing→rebuildIdx (:279-283); repack targets ALWAYS lack a sidecar so every GC-repacked segment rebuilds on next Open. LOW not HIGH: nothing ever reads this path back — correct fix is deleting rebuildIdx, not bufio-wrapping it.
+
+### [LOW] Optional BlockSink capability interfaces are unexported — engine can never compile-check against them, so a method-name typo silently no-ops a correctness-critical hook · `structure` · area: carve
+- **Where:** `pkg/block/journal/carve.go:118`
+- **What:** supersededReaper (:118), manifestRowEnder (:133), clobberGuard (:160) unexported, detected via `s.sink.(supersededReaper)` etc. (carve.go:339/500/675). engine/blocksink.go implements all three by name only, zero `var _` guards anywhere.
+- **Why it matters:** A typo in ReapSupersededManifest/ManifestRowEndAfter/PreserveClobberedRow produces zero build error, zero panic — assertion returns ok=false, capability silently skipped. Stale manifest rows never reaped → stale row can win over fresh and serve old bytes on cold read (carve.go:321-324) — the package's own cardinal sin, reached via D5 seam instead of HOLE/COLD seam.
+- **Fix:** Export the three interfaces, add `var _ journal.SupersededReaper = engineBlockSink{}` etc. next to engineBlockSink/localBlockSink in blocksink.go.
+- **Verified:** DUPLICATE of the `gaps`-dimension finding below (same evidence). Premise "none CAN exist" REFUTED — engine can assert today via anonymous interface literal, no exported journal type needed. No present defect: all six methods currently match. Downgraded to LOW; report once, fix is 3 one-line assertions.
+
+### [LOW] D5 is false at the semantic level: the three optional capabilities bake DittoFS's CAS-manifest model into a package that claims to know nothing about the metadata store · `structure` · area: carve
+- **Where:** `pkg/block/journal/carve.go:108`
+- **What:** doc.go:6-10 claims journal "knows nothing about ... the metadata store". carve.go:108-162 (optional capabilities) reasons entirely in metadata-store vocabulary: "manifest row" (:110,124,144), "the commit that writes a row is an upsert" (:139), "gap-free, overlap-free tiling of [0,size)" (:111), "a punched hole must read as zeros" (:151). BlockSink/Deduper are generic; these three are not.
+- **Why it matters:** A third party extracting this as a standalone library gets eviction/carve hooks meaningless without reimplementing DittoFS's specific manifest semantics — falsifies the "standalone reusable cache" framing. Coupling is baked into contract vocabulary, not the import graph.
+- **Fix:** Reframe as fully generic append-cache terms, e.g. single `PostCommit(ctx, id, committedSpans, owedSpans) error` capability with zero "row"/"manifest"/"upsert" mention. Move manifest-specific reasoning into blocksink.go's doc comments.
+- **Verified:** CONFIRMED as stated but weak — design-taste judgement, coupling is opt-in (sink omitting methods just loses the reap), journal genuinely imports no metadata package. Report as doc-honesty note, not defect.
+
+### [LOW] doc.go's 'stdlib plus narrow interfaces' dependency claim is false — package imports internal/logger · `bloat` · area: store-api
+- **Where:** `pkg/block/journal/doc.go:7`
+- **What:** doc.go: "depends only on the standard library plus a pair of narrow injected interfaces (RemoteStore, Clock)." Actual: internal/logger imported by store.go:14, cold.go, reclaim.go, recovery.go (logger.Warn e.g. store.go:280,386,419); pkg/block/chunker imported by store.go:15/carve.go/index.go (Config.ChunkParams chunker.Params); pkg/block imported by format.go:25 (block.ErrFutureFormat).
+- **Why it matters:** internal/ import is the exact compiler-hard blocker the library-extractability rubric calls out — makes the package impossible to use outside this module regardless of interface narrowness. Doc isn't just imprecise, it's actively wrong about a hard constraint.
+- **Fix:** Drop internal/logger for an injected Logger interface and correct doc.go's chunker/block description, or rewrite doc.go to state the real dependency set.
+- **Verified:** CONFIRMED. doc.go:6-8 vs internal/logger (store.go:14, cold.go:43, reclaim.go:11, recovery.go:11), pkg/block/chunker (store.go:15, carve.go:15, index.go:11), pkg/block (format.go:25). Doc comment falsity, not runtime defect → LOW.
+
+### [LOW] Optional BlockSink capabilities (supersededReaper/manifestRowEnder/clobberGuard) are unexported interfaces detected only via runtime type-assertion, with zero compile-time conformance check anywhere in the repo · `gaps` · area: carve
+- **Where:** `pkg/block/journal/carve.go:118`
+- **What:** supersededReaper (:118), manifestRowEnder (:133), clobberGuard (:160) unexported. Detected via `s.sink.(supersededReaper)` (:339), `.(manifestRowEnder)` (:675), `.(clobberGuard)` (:500) — failed assertion is a silent no-op, no log/error. engine's engineBlockSink/localBlockSink (blocksink.go:171-237) implement all three by name only; unexported identifiers can't be referenced from engine for a `var _` guard. Repo-wide grep: zero conformance guards for any of the three.
+- **Why it matters:** Index/manifest must never silently diverge from the append-only log as a second source of truth. carveFile's own comments (carve.go:313-338) say a single missed reap leaves stale rows alive forever and can serve old bytes on cold read under greatest-start overlap. If any of the three methods silently stops being invoked (rename during refactor, new sink impl, copy-paste drop), manifest diverges from ground truth with no error, no log, no test failure — silent data corruption.
+- **Fix:** Export the three interfaces (SupersededReaper, ManifestRowEnder, ClobberGuard); add `var _ journal.SupersededReaper = engineBlockSink{}` (+ other two, + localBlockSink) in blocksink.go. Keep runtime ok-gated assertion in carve.go for legitimate fake-sink opt-out.
+- **Verified:** CONFIRMED as stated; keep this one, drop the `structure`-dimension duplicate above. Claim itself concedes "no live bug today". Stated impossibility REFUTED — engine can assert structurally via anonymous interface literal, no exported journal type required. Downgraded HIGH→LOW: 3-line zero-risk fix, guards a rename-during-refactor risk that hasn't occurred.
+
+### [LOW] fileIndex.insert breaks version ties in opposite directions on the fast vs. slow overlap path · `bugs` · area: append-index-record
+- **Where:** `pkg/block/journal/index.go:147`
+- **What:** Fast path (:141-158): `if iv.version <= e.version { return }` — existing wins tie. Slow path (:164-193): `if e.version > iv.version {...} else {...}` — tie falls to else, new wins. Doc comment (:85-88) says version breaks ties but not which way; the two paths disagree with each other.
+- **Why it matters:** Whether a duplicate-version reinsert is idempotent depends on incidental overlap shape (exact boundary vs partial) rather than a uniform intentional policy.
+- **Fix:** Change `if e.version > iv.version` to `if e.version >= iv.version` at index.go:166 so duplicate-version insert is idempotent regardless of overlap shape.
+- **Verified:** CONFIRMED asymmetry, no wrong-bytes outcome found. Both paths reachable (insert called from appendRecord segment.go:381, SeedColdBatch store.go:631). Production duplicate-version case (crash between appendCold and segment unlink) is an EXACT range match → hits fast path correctly. Partial-overlap variant needs cold entry to straddle a live warm fragment → spuriously-cold range, bytes provably remote-resident (evict only evicts synced segments) → redundant re-fetch, not corruption. Severity dropped MED→LOW.
+
+### [LOW] doc.go points at a file that does not exist ("See gc.go") · `slop` · area: store-api
+- **Where:** `pkg/block/journal/doc.go:23`
+- **What:** Package doc's closing sentence: "journal must not drive one concurrently. See gc.go." No gc.go exists; GC lives in reclaim.go alongside Evict.
+- **Why it matters:** Stale file pointer in the one file meant to be the package's authoritative contract — misleads a reader trying to find the GC implementation.
+- **Fix:** Change "See gc.go." to "See reclaim.go." (or name the function, e.g. "See Store.GC in reclaim.go.").
+- **Verified:** CONFIRMED. doc.go:23; directory listing has only gc_test.go, real impl (pickVictim, repackSegment, Evict) in reclaim.go.
+
+### [LOW] MaxLocalBytes free-space probe silently leaves the store uncapped when disk is full, contradicting its own comment · `slop` · area: store-api
+- **Where:** `pkg/block/journal/store.go:276`
+- **What:** Config.MaxLocalBytes doc (:63) and inline comment (:271-275) say uncapped only when the probe itself fails. Code: `if free, ferr := diskFreeBytes(dir); ferr == nil && free > 0 {...} else if ferr != nil { logger.Warn(...) }` — the ferr==nil && free==0 branch is unhandled: MaxLocalBytes stays 0 (unset/uncapped), no warning logged.
+- **Why it matters:** Plausible-but-wrong logic, silently swallows disk-full case with no log line, contradicting the adjacent comment. It's exactly the disk-full edge case the cap mechanism exists to guard against.
+- **Fix:** Fold free==0 into the warning branch (`else` instead of `else if ferr != nil`); clamp computed cap to at least 1 byte, e.g. `cfg.MaxLocalBytes = max(1, int64(float64(free)*defaultMaxLocalBytesFreeFraction))`.
+- **Verified:** CONFIRMED. store.go:276-282. Reachable: Open is the package's sole constructor. Needs already-full volume at Open → MED→LOW. Fix: drop `&& free > 0` guard or make else unconditional.
+
+### [LOW] SeedColdBatch re-locks the same per-shard mutex once per cold entry instead of grouping by shard · `perf` · area: store-api
+- **Where:** `/Users/marmos91/dittofs-worktrees/audit-journal/pkg/block/journal/store.go:628`
+- **What:** After appendCold, insert loop does `for _, e := range entries { sh := s.shardFor(e.id); sh.mu.Lock(); sh.indexFor(e.id).insert(...); sh.mu.Unlock() }`. entries built by iterating seeds in order, so every extent of one file is contiguous → back-to-back Lock/Unlock of the same shard mutex.
+- **Why it matters:** SeedColdBatch is documented as a bulk primitive seeding "whole manifest at once" for share-add/snapshot-restore, scaling with file count × extents-per-file. Re-acquiring the same mutex per entry adds needless lock/unlock churn proportional to N instead of distinct shards touched.
+- **Fix:** Group entries by shard before the insert pass (bucket by s.shardFor(e.id)), take each shard's lock once, insert all its entries under one critical section.
+- **Verified:** CONFIRMED. store.go:628-639. Reachable from engine/flush.go:135-143 (share add/snapshot restore). Sized honestly: ~20ns uncontended mutex round trip, whole point of the call is replacing per-file fsync with one batch fsync — ~2ms lock churn at 100k entries vs seconds saved. Real but immaterial → MED→LOW.
+
+### [LOW] ReadAt hot path allocates pieces+segs slices every call, no pooling · `perf` · area: append-index-record
+- **Where:** `pkg/block/journal/index.go:251`
+- **What:** fi.plan() (:251-280) builds `pieces []piece` via repeated append from nil; ReadAt (:324) does `segs := make([]*segmentMeta, len(pieces))` every call — fresh heap allocs even for the common single-interval warm read.
+- **Why it matters:** ReadAt is the named hot random-read data-plane path (randwrite_bench_test.go). Same file already pools the record-scratch buffer for verifiedRead (recordScratchPool, :376) — same class of per-request buffer left unpooled right next to the one that got pooled.
+- **Fix:** Pool a small piece/seg scratch (sync.Pool, reset+reuse like recordScratchPool), or fast-path len==1 without slicing when the whole read lands in one interval.
+- **Verified:** CONFIRMED. index.go:254 `var pieces []piece` grown by append; :324 `make([]*segmentMeta, len(pieces))`. Reachable from engine/read_internal.go. Downgraded MED→LOW: both small, pooling fiddly (segs held past sh.mu release through deferred releaseGuards, must be returned on all 4 error returns at :333/356/361). Fix if profile justifies: one sync.Pool holding struct{pieces []piece; segs []*segmentMeta}.
+
+### [HIGH] RestoreToVersion is blind to cold.log — deletes remote-durable files and zero-fills cold ranges instead of preserving them · `bugs` · area: store-api
+- **Where:** `pkg/block/journal/store.go:1087`
+- **What:** RestoreToVersion phase-1 ceiling replay (store.go:1087-1139) scans only scanValidRecords; never loadCold/applyColdLog like recover() (recovery.go:358). Cold intervals (Evict, SeedCold/SeedColdBatch — store.go:520,607) live only in cold.log+mem index, no seg record (cold.go:129 appendCold). Fully-cold file at V: no vIndex entry, falls into "head not in vIndex" bucket (store.go:1217-1223), unconditionally Delete'd though durable remotely. Mixed warm/cold file: cold sub-ranges absent from `exts`, become POSIX holes after Delete+WriteAt, reads return zeros.
+- **Why it matters:** doc.go names HOLE-vs-COLD conflation the module's cardinal sin; recover()'s applyColdLog exists for the identical reason. Only caller runtime/snapshot.go:1539 RestoreToVersion + shares.SeedColdFromManifest (:1598) is gated `if remoteVerify` (:1595) — but RestoreToVersion only runs in the !remoteVerify local-only branch (:1341), so the ONLY production path gets zero compensation. Cold intervals ARE reachable local-only: blockstore_config.go:370 disables eviction for remoteStore==nil but engine.go:271 `SetEvictionEnabled(bs.syncer.IsRemoteHealthy())` re-enables it, syncer.go:309-312 returns true when healthMonitor==nil, Start runs after :370.
+- **Fix:** fold loadCold(s.dir) into phase 1 like applyColdLog (insert cold:true/synced:true at version<=V, respect tombstone/truncate clip). Phase 2: re-assert cold vIndex entries via appendCold+insert instead of reading a source record.
+- **Verified:** CONFIRMED — zero loadCold/coldEntry refs in whole function; caller's mitigation only fires on the branch RestoreToVersion never takes.
+
+### [HIGH] repackSegment never sets target.records — synced-gate can misclassify a still-dirty repacked segment as evictable · `bugs` · area: reclaim
+- **Where:** `pkg/block/journal/reclaim.go:834`
+- **What:** repackSegment sets target.liveBytes (:834) and target.syncedRecords (:835), never target.records. records (segment.go:54, "eviction synced-gate denominator") incremented only by live append (segment.go:359) and recovery replay (recovery.go:340); createSegment leaves it 0. evictable() (reclaim.go:207-210) gates on syncedRecords==records. pickVictim (reclaim.go:621-672) picks by dead-byte ratio only, no synced check — an all-dirty victim gives syncedCount==0, so 0==0 reads evictable though holding never-synced data. evictSegment can then cold-mark+unlink it, losing the sole copy. (Mixed victim: opposite bug — permanently unevictable via Evict, lesser leak.)
+- **Why it matters:** violates D2 synced-gate ("Evict frees only sealed segments with NO unsynced record"); real data-loss path. TestGCForcedRepackPreservesData only checks syncedRecords, never records, never evicts post-repack.
+- **Fix:** add `target.records.Store(int64(len(moves)))` beside the existing Stores at :834-835; exclude tombstone/truncate markers, matching live-path semantics.
+- **Verified:** CONFIRMED via grep — only two non-test writers of records package-wide.
+
+### [HIGH] RestoreToVersion re-materializes the V-view via WriteAt (never fsyncs) while its own doc promises durable reconstruction — crash window can erase the file entirely · `gaps` · area: store-api
+- **Where:** `pkg/block/journal/store.go:1079`
+- **What:** Phase 2 (store.go:1169-1224): s.Delete fsyncs a tombstone via groupCommit (segment.go:426-474), then re-appends V-view bytes with s.WriteAt (:1211) which only buffers, never fsyncs (documented :424-425). No Commit/groupCommit call anywhere after.
+- **Why it matters:** doc (store.go:1057-1059) claims "re-materializes that view durably at the log head, so a crash-reopen reconstructs V" — false. Bound by DirtyExpiry (~30s) or next explicit Commit. Crash in that window: tombstone survives, new data doesn't — file reads empty. Each subsequent Delete's groupCommit fsyncs its own shard, so only the last restored file per shard is exposed, but that window is real on a local-only share where the journal is the only copy.
+- **Fix:** call sh.groupCommit()/s.Commit(ctx,id) at end of RestoreToVersion (per shard touched) before returning.
+- **Verified:** CONFIRMED — zero groupCommit/Commit refs in function; caller snapshot.go:1539-1546 only does DrainRollups after.
+
+### [HIGH] repackSegment never sets target.records — dirty-only repacked segment misclassifies as evictable, breaking write-back cache dirty/clean invariant · `gaps` · area: reclaim
+- **Where:** `pkg/block/journal/reclaim.go:834`
+- **What:** Same root defect as the bugs-dimension finding above, framed against write-back cache correctness: writeDataRecord (reclaim.go:971-999) never touches seg.records; target.records stays 0 after repack. pickVictim never checks synced state of a victim's live records. All-dirty victim -> syncedCount==0 -> evictable() reads 0==0 true -> Evict/ensureSpace cold-marks+unlinks a segment holding exclusively-dirty (never-carved) data.
+- **Why it matters:** reference write-back model (rclone/JuiceFS) requires dirty vs clean gate eviction; D2 contract is "Evict frees only sealed segments with NO unsynced record". Coincidental zero==zero defeats that gate — cold read later fetches from remote bytes never pushed there: silent data loss, not staleness. No test combines GC-repack of a dirty victim with subsequent Evict/ensureSpace.
+- **Fix:** `target.records.Store(int64(len(moves)+len(markers)))` right after :834-835, excluding tombstone/truncate consistent with live append semantics.
+- **Verified:** CONFIRMED, worst finding in report — evictSegment cold-marks every interval of the segment regardless of iv.synced, then unlinks; defeats Evict's own stated contract (reclaim.go:44-47).
+
+### [HIGH] Torn cold.log tail is never physically truncated at recovery — a crash silently poisons every future append · `gaps` · area: recovery
+- **Where:** `pkg/block/journal/recovery.go:358`
+- **What:** applyColdLog (recovery.go:358-386) calls loadCold (cold.go:192-212) for the intact prefix but never truncates cold.log on disk. loadSegment does this for .seg (fd.Truncate(validUpTo)+Sync, recovery.go:243-250); no equivalent for cold.log. appendCold reopens O_APPEND (cold.go:138), so new entries land after old garbage tail. Next restart's loadCold walks from 0, parses pre-crash intact entries, hits the still-present garbage, stops (cold.go:203-207) — discards every entry the intervening process appended, permanently.
+- **Why it matters:** compactColdLog (recovery.go:395-405), the only rewriteCold caller, gated by `coldLoaded <= 2*len(live)+coldCompactFloor(1024)` — never fires for realistic small/medium logs, so the torn tail is never repaired. Lost cold entry = silent zero-fill instead of remote fetch, per cold.go's own doc.
+- **Fix:** have loadCold return the intact byte offset; truncate+fsync cold.log to that offset in applyColdLog before any later append, mirroring loadSegment's active-tail repair.
+- **Verified:** CONFIRMED — no wholesale cold.log rewrite outside compactColdLog; reachable via Evict (reclaim.go:280) and SeedCold/SeedColdBatch (store.go:531/625/1290), all production paths.
+
+### [HIGH] Hydrate has no delete-fence, so a racing cold-read resurrects a deleted file · `bugs` · area: cross
+- **Where:** `pkg/block/journal/store.go:456`
+- **What:** Hydrate (store.go:449-467) gates only via staleAfterTruncate/truncVer. No tombVer/delete-fence map exists (shard.go). Delete (store.go:759-816) removes sh.index[id] outright, leaving no trace. With sh.index[id] nil, fileIndex.hydratable's nil-receiver case (index.go:512-514) fills the whole requested range unconditionally. Race: cold read samples notAfter, starts remote fetch; concurrently Delete tombstones+clears index; fetch completes; Hydrate appendRecord's writes stale pre-delete bytes back, recreating the deleted file.
+- **Why it matters:** Delete's own doc promises "a crash can never resurrect a file whose tombstone is already durable" — here no crash needed, plain concurrency resurrects it silently, no error, no log line. Top-severity silent-corruption class (cf. #1850/#1888/#2084).
+- **Fix:** add per-shard tombVer[id] map set on Delete; gate Hydrate/hydratable (and appendRecord's re-check under sh.mu) on notAfter <= tombVer the same way truncVer gates.
+- **Verified:** CONFIRMED — Delete deletes sh.truncVer[id] too (store.go:807), erasing the only existing fence; reachable via engine/readwrite.go:367 (Delete before manifest reap) racing engine/fetch.go:201 Hydrate whose `at` was sampled at fetch.go:103, window = whole remote fetch (hundreds of ms).
+
+### [MED] Double-active-segment recovery: pointer swap misattributes byte/record counters to the wrong segmentMeta · `slop` · area: recovery
+- **Where:** `pkg/block/journal/recovery.go:266`
+- **What:** In loadSegment's two-unsealed-actives branch (:257-274), `r.actives[sh], m = m, r.actives[sh]` swaps which struct `m` points at. Demotion bookkeeping (sealed, idxFD close, sealedByShard) correctly applies to demoted `m`. But :286 `r.replayRecords(m, sh, id, recs)` runs AFTER the swap, still using swapped `m` — now the OLD demoted segmentMeta, not the one matching just-scanned id/recs. replayRecords' noteMinVersion/liveBytes.Add/records.Add/syncedRecords.Add credit the wrong segment. loc.SegmentID is set independently to `id` so reads still resolve correctly — only the counters are wrong.
+- **Why it matters:** minVersion=0 is the "unset" sentinel (segment.go:57); liveBytes/records/syncedRecords feed GC victim selection and the eviction synced-gate. New active segment looks falsely empty, demoted segment looks falsely more dead. Untested: no recovery_test.go/segment_test.go path exercises two-active-segments. Reachable via repackSegment's createSegment-write-then-seal crashing mid-repack (reclaim.go:~800-832) — "should never happen" comment notwithstanding.
+- **Fix:** bind `m` to id/recs throughout; use a separate var for the demoted segment, e.g. capture `cur := m` before the swap and pass `cur` to replayRecords.
+- **Verified:** CONFIRMED at recovery.go:265-267/286.
+
+### [MED] Recovery always full-rescans+CRC-verifies .seg payload, .idx sidecar never read · `perf` · area: recovery
+- **Where:** `pkg/block/journal/recovery.go:212`
+- **What:** loadSegment always calls scanValidRecords(fd, SegmentSize, SegmentSize) — full read+CRC of every record's payload, sealed or not. idxEntry has encode() only, no decode anywhere; nothing in the package ever reads .idx content back. index.go:468-469 docs the sidecar as enabling a re-scan skip; never realized.
+- **Why it matters:** O(total journal bytes) read+CRC on every boot instead of O(records*40B) via sidecars; sealed/immutable segments already CRC-verified once at write time get re-verified every restart.
+- **Fix:** severity capped at MED not HIGH because idxEntry stores only FileIDHash, not FileID (index.go:479-487) — cannot rebuild the FileID-keyed index without a format change. Correct fix: delete the sidecar and its two write paths (pure write amplification today), not add a decoder.
+- **Verified:** CONFIRMED — grep shows idxEntry.decode does not exist; reachable via every Open() -> recover() -> loadSegment.
+
+### [MED] SetCarveTargets writes unsynchronized fields that Carve reads without a lock, contradicting Store's own concurrency contract · `structure` · area: store-api
+- **Where:** `pkg/block/journal/carve.go:170`
+- **What:** SetCarveTargets does `s.deduper = d; s.sink = sink` on plain non-atomic fields (store.go:181-182). Carve reads them unlocked (carve.go:202). store.go:168-170 documents all exported methods safe for concurrent use, with no carve-out. Sibling one-shot setter SetVerifyReads correctly uses atomic.Bool (store.go:219,249).
+- **Why it matters:** data race under the Go memory model. engine/syncer.go wireCarveTargets is explicitly one-shot-with-retry (syncer.go:806-831), returns early when blockCommitter/syncedHashStore not yet set — a started syncer's carve tick can read s.sink concurrently with a later SetRemoteStore attach writing it.
+- **Fix:** atomic.Value/atomic.Pointer for deduper+sink (mirror SetVerifyReads), or wire them via Open()/constructor so a returned *Store is always fully formed and SetCarveTargets disappears.
+- **Verified:** CONFIRMED; MED not HIGH — production wiring usually completes before Start, no corruption observed.
+
+### [MED] Truncate's truncVer stamp uses the pre-marker peek version, not the marker's real fenced version, leaving a version-range gap where Hydrate un-truncates a file · `bugs` · area: cross
+- **Where:** `pkg/block/journal/store.go:968`
+- **What:** Truncate stamps sh.truncVer[id] = s.version.Load() at peek time (:968), before appendTruncateMarker (:976) assigns the marker's real Version via s.nextVersion() (segment.go:481-522) under a separate lock. truncVer is never raised to the real marker version afterward — the clip section only uses a local var. staleAfterTruncate (store.go:473-475) fences only notAfter <= Vpeek, not Vmarker. Any unrelated write between peek and marker-fsync lands `at` in (Vpeek,Vmarker], passing the fence for a Hydrate racing the clip window; hydratable treats the not-yet-clipped span as an unversioned hole and fills it, and the resulting interval's fresh version can exceed truncVer, surviving the clip's own `iv.version > truncVer` test — persistent post-clip resurrection, not just transient.
+- **Why it matters:** Truncate's own doc says "a crash after the marker can never resurrect the truncated bytes" — this resurrects without any crash, via ordinary concurrent cold-read traffic.
+- **Fix:** after appendTruncateMarker returns its real version, raise sh.truncVer[id] = max(existing, truncVer) in the same locked clip section (~:981).
+- **Verified:** CONFIRMED; MED not HIGH — narrower window than the Hydrate delete-fence finding, needs `at` in a 1-version band plus a manifest row still covering past newSize.
+
+### [MED] recordHasDirtyFragment rescans the whole file's interval list per touched physical record on every block flip · `perf` · area: carve
+- **Where:** `pkg/block/journal/carve.go:888`
+- **What:** flipUpTo (:844) builds `touched` records past watermark; for each, recordHasDirtyFragment does `for k := range fi.ivs` over the ENTIRE file's interval slice, though fi.ivs is sorted by fileOff (index.go:85-88) and a record's live fragments can only fall in that record's own [fileOff,fileOff+len) window. Runs once per touched record per block, under sh.mu.
+- **Why it matters:** O(touched_records x total_file_intervals) per carve pass for heavily-overwritten/fragmented files, under the shard lock.
+- **Fix:** bound scan via sort.Search on fi.ivs (same idiom as findRecord), or maintain a live dirty-fragment refcount per physical record incrementally instead of rescanning.
+- **Verified:** CONFIRMED, carve.go:886-898.
+
+### [MED] repackSegment re-walks entire shard index a 2nd time; evictSegment's twin already avoids this exact walk · `perf` · area: reclaim
+- **Where:** `pkg/block/journal/reclaim.go:846`
+- **What:** Step 1a (:731-746) scans sh.index building `moves`. Step 4 (:843-865) scans sh.index again from scratch to repoint, though only files already in `moves` can match. gcShard loops repackSegment per victim (:554-579): O(V x total shard files) instead of O(V x touched files).
+- **Why it matters:** evictSegment (:245-310) already solved this with a `backed` map from its first scan (:273-276), narrow second pass (:296-308), plus a ponytail comment naming the remaining walk as accepted debt. repackSegment has neither.
+- **Fix:** build `movedFiles := map[FileID]struct{}` alongside `moves` in step 1a; iterate only those in step 4. Note: narrows the `remaining` catch-all's visibility (:851-856), same tradeoff evictSegment already accepted.
+- **Verified:** CONFIRMED, reclaim.go:731-746 / 843-865 vs evictSegment's 273-308.
+
+### [MED] Full per-record payload read into memory during scan is never used by recovery · `perf` · area: recovery
+- **Where:** `pkg/block/journal/recovery.go:212`
+- **What:** scanValidRecords/readRecordAt(scratch=nil) allocates a fresh buffer holding header+fileID+payload+CRC per record; recs[] keeps them all alive until loadSegment returns. replayRecords/rebuildIdx/RestoreToVersion phase1/victimMarkers only read header fields, segOff, fileID — grep confirms no .payload touch on the scan-only paths.
+- **Why it matters:** record.go's own comment justifying no-scratch ("recovery keeps every payload it scans") is stale for these callers — pure GC churn per segment, up to SegmentSize (256MB default) held live per segment, twice over (boot + RestoreToVersion).
+- **Fix:** bundled with the .idx-sidecar finding above if that lands (most segments skip scan entirely). Otherwise thread a reusable scratch buffer through scan callers that don't need payload — but copy fileID out first (aliases scratch, <=maxFileIDLen) before reuse.
+- **Verified:** CONFIRMED; disk read itself is mandatory for CRC verification, only the payload-retention/no-scratch part is waste.
+
+### [MED] Optional BlockSink capabilities are wired by unexported type assertion with no compile-time or structural conformance check · `bloat` · area: carve
+- **Where:** `pkg/block/journal/carve.go:118`
+- **What:** supersededReaper (:118), manifestRowEnder (:133), clobberGuard (:160) are unexported interfaces sniffed via type assertion at :339, :500, :675. Unexported means no other package can write a `var _ supersededReaper = (*engineBlockSink)(nil)` guard. Contrast: BlockSink itself is compiler-checked at every SetCarveTargets call because that param is the exported journal.BlockSink. grep of engine/blocksink.go for `var _ ` guards: none.
+- **Why it matters:** a method-name/signature typo on either side compiles clean and silently disables the capability — indistinguishable from the documented "test fakes don't implement it" fallback (:117/126/158). Silent-manifest-drift class this package has shipped bugs in before (stale superseded rows, lost clobbered-row ranges, unwidened runs).
+- **Fix:** add a compile-time guard in pkg/block/engine (blocksink.go or a _test.go) asserting engineBlockSink/localBlockSink satisfy the full three-method set via a local interface literal, keeping journal-side interfaces unexported.
+- **Verified:** CONFIRMED, no `var _ ` conformance guard anywhere for these three.
+
+### [LOW] appendTombstone/appendTruncateMarker never advance sh.lastVersion · `bugs` · area: append-index-record
+- **Where:** `pkg/block/journal/segment.go:426`
+- **What:** appendTombstone (:426-474) and appendTruncateMarker (:481-526) mint version via s.nextVersion() (:450,503), write, unlock (:465,519), never set sh.lastVersion = version. appendRecord does, at :357, under the same lock. recovery.go:478 restores it correctly from r.maxVersion on restart.
+- **Why it matters:** shard.go:41-46 documents lastVersion as "highest record Version appended to this shard"; groupCommit's fsync ceiling (store.go:700), dirty()'s auto-commit gate (shard.go:121-129), sealSegment's markSynced all key off it. Currently masked because both ops self-fsync via groupCommit before returning — but the field stays permanently understated until another write lands on the shard, a landmine for any future consumer trusting it (skip-if-clean optimization, metric, durability check).
+- **Fix:** add `sh.lastVersion = version` under sh.mu in both functions, mirroring appendRecord, before the Unlock at :465/:519.
+- **Verified:** CONFIRMED; understated only, never overstated — no reachable incorrect behavior today, hence LOW not HIGH.
+
+## Implementation gaps vs reference
+
+| Expected behavior (checklist) | Our behavior | Gap | Source |
+|---|---|---|---|
+| Data write durable before index/visible state flips — never index-before-data (#3) | `RestoreToVersion` phase 2 (store.go:1199-1214): `Delete` fsyncs tombstone via groupCommit, then `WriteAt` re-materializes V-view but only buffers — no `Commit`/groupCommit call anywhere after. Doc (store.go:1057-1059) claims "durably" regardless. | Crash in DirtyExpiry window (~30s) after restore: durable tombstone survives, re-materialized data doesn't → file reads empty, not pre- or post-restore state. Fix: one `s.Commit(ctx,id)` / per-shard `groupCommit()` at end of `RestoreToVersion`. | Bitcask write-then-update-KeyDir ordering — https://riak.com/assets/bitcask-intro.pdf |
+| Dirty (local-only) vs clean (synced-to-remote) must gate eviction; only clean data reclaimable (#7) | `repackSegment` (reclaim.go:833-835) sets `target.liveBytes`/`target.syncedRecords` but never `target.records`. Fresh `segmentMeta.records` defaults 0; only live-append (segment.go:359) and recovery replay (recovery.go:340) increment it. `pickVictim` (reclaim.go:621-670) never checks synced state, so an all-dirty victim can be repacked. Result: `syncedRecords(0)==records(0)` → `evictable()` (reclaim.go:207-210) reads a dirty-only repacked segment as fully synced. | GC repack of an unsynced-only victim, then `Evict`/`ensureSpace` cold-marks and unlinks it → data never carved to remote, later cold read gets zeros. Silent data loss, no test combines repack-of-dirty-victim with subsequent evict. Fix: `target.records.Store(int64(len(moves)))` beside reclaim.go:834-835. | rclone `--vfs-write-back` (no cleanup until backend write completes) — https://rclone.org/commands/rclone_mount/; JuiceFS cache_management (loss before upload = permanent) — https://juicefs.com/docs/community/cache_management/ |
+| Torn trailing record after crash detected via checksum, log truncated at that point — not silently skipped (#4) | `applyColdLog` (recovery.go:358-386) calls `loadCold` which stops at first torn entry and returns only the intact prefix — but never truncates `cold.log` on disk. `appendCold` reopens O_APPEND, so new entries land after the old garbage tail. `compactColdLog`'s only rewrite path is gated by a threshold (`coldCompactFloor=1024`) that never fires on a small/medium log. | Next restart's `loadCold` walks from offset 0, hits the same old tear, stops — discarding every well-formed entry appended since the first crash, permanently. Contrast: `loadSegment` (recovery.go:243-250) does `Truncate(validUpTo)+Sync` on a torn active `.seg`; cold.log gets no equivalent. Fix: have `loadCold` return intact byte length, truncate+fsync cold.log in `applyColdLog` before any append can extend it. | LevelDB log format resync-after-truncation — https://github.com/google/leveldb/blob/main/doc/log_format.md; SQLite WAL chained-checksum torn-tail detection — https://www.sqlite.org/walformat.html |
+| Index/manifest fully rebuildable from the append-only log alone — never a second source of truth that can silently diverge (#5) | `supersededReaper`/`manifestRowEnder`/`clobberGuard` (carve.go:118,133,160) are unexported; detected only by runtime type-assertion (carve.go:339,500,675) with silent no-op on failed assertion. Zero `var _ <iface> = engineBlockSink{}` compile-time guard anywhere in repo — can't exist across the package boundary since the interfaces aren't exported. | If a production sink's method is renamed/dropped in a refactor, manifest silently stops being reaped/ended — no build error, no log, no test failure — and can serve stale bytes on cold read (carve.go's own doc, 313-338). No live bug today; LOW since risk hasn't materialized. Fix: export the 3 interfaces + add compile-time `var _` guards in engine/blocksink.go. | Bitcask KeyDir/hint-file rebuild — https://riak.com/assets/bitcask-intro.pdf; Haystack index rebuild / orphan-needle detection — https://www.usenix.org/conference/osdi10/finding-needle-haystack-facebooks-photo-storage |
+| Two independent eviction triggers combine: configured quota + live free-disk headroom via `statfs`, not just internal byte accounting (#8) | `diskFreeBytes` (statfs_unix.go:10) called exactly once, in `Open` (store.go:276-283), to derive a static `cfg.MaxLocalBytes = free*0.8`. `ensureSpace` (reclaim.go:328-335) gates purely on `s.diskBytes.Load()` vs that static cap — never re-polls statfs. | External disk pressure (another share, another process on same volume) after `Open` produces no backpressure until the stale cap happens to still hold. Doc itself calls `MaxLocalBytes` "a soft pressure threshold" so not correctness-breaking — LOW. Fix: re-probe `diskFreeBytes(s.dir)` periodically in/near `ensureSpace`, treat low live headroom as a second independent trigger. | rclone `--vfs-cache-max-size`/`--vfs-cache-min-free-space` combo — https://rclone.org/commands/rclone_mount/; JuiceFS `--free-space-ratio` via statfs — https://juicefs.com/docs/community/cache_management/ |

--- a/.planning/2026-09-01-pier-library-design-PLAN.md
+++ b/.planning/2026-09-01-pier-library-design-PLAN.md
@@ -1,0 +1,976 @@
+# pier — target design for extracting `pkg/block/journal` as a library
+
+Status: **DESIGN / NOT APPROVED.** No code written. Audit of the current package
+(`/auditing-ai-codebases`, 7 lenses) still running at time of writing; findings will be
+folded in and may change §5.
+
+Baseline commit: `ff14b24cb` (origin/develop). Immutable audit worktree:
+`~/dittofs-worktrees/audit-journal`.
+
+Naming: **DECIDED — `pier`.** See §11.1 for the rationale and the vocabulary it gives us.
+
+---
+
+## 1. The job
+
+A write-back cache for object storage absorbs an impedance mismatch on four axes:
+
+| Client wants | Object store offers | Cache must supply |
+|---|---|---|
+| byte-range writes | immutable whole-object PUT | accumulation + chunking |
+| immediate ack | ~450ms round trip | durable local staging |
+| low-latency reads | high-latency GET | residency + prefetch |
+| unbounded working set | unbounded capacity | bounded disk + eviction |
+
+The current package does all four. Nothing in this design changes that.
+
+## 2. The one hard problem
+
+DittoFS's field bug history for this component, over roughly a year:
+
+| Issue | Symptom |
+|---|---|
+| #1850 | cold intervals held in memory only → zeros after any restart |
+| #1879 / #1888 | silent zeros; the guard meant to catch them was unreachable |
+| #2084 | `Invalidate` marked a live *dirty* record cold → zeros, nothing logged |
+| #1872 / #2073 / #2093 | reap classified rows by start offset → zeros, or resurrected old bytes |
+| #1956 | crane dropped deduped chunks' manifest rows → zeros |
+| #2110 | offline-readiness reported `Safe()` for a *lost* interval |
+
+Every one is the same defect: **the cache's map of what it holds disagreed with what it
+actually held, and the disagreement rendered as zeros.** None is a throughput, eviction-policy
+or chunking bug.
+
+The design goal that follows: make that bug class *unrepresentable*, not merely detectable.
+Zeros are the correct answer for a hole and catastrophic for lost data, and the two are
+byte-identical — so the distinction has to live in the type system, not in reviewer attention.
+
+## 3. The model: five states, and `Lost` is one of them
+
+```go
+type State uint8
+
+const (
+    StateAbsent   State = iota // never written — zeros are correct
+    StateDirty                 // local only; no other copy exists
+    StateResident              // local AND durable remotely; free to reclaim
+    StateRemote                // durable remotely only; fetch to read
+    StateLost                  // written; no copy anywhere; reads MUST fail
+)
+
+type Extent struct {
+    Off, Len int64
+    State    State
+    Durable  bool // survives device loss *now* (fsynced, or Resident/Remote)
+}
+```
+
+Four of these exist today as `hole` / `dirty` / `warm` / `cold`. **`StateLost` is the addition**,
+and it is the whole point: it is the state the bugs above kept falling into with nowhere to go,
+so they rendered as `StateAbsent`.
+
+`Durable` is deliberately a separate bit from `State`. A `StateDirty` range that has been
+fsynced survives a crash but still has no second copy. Collapsing those two questions is how
+a `DurableExtent` over-reports.
+
+### The transition table IS the specification
+
+| Operation | Legal transition | The trap it closes |
+|---|---|---|
+| `WriteAt` | `*` → `Dirty` | — |
+| `Flush` | `Dirty` → `Resident` | flip-before-commit (#1872 family) |
+| `Evict` | `Resident` → `Remote` | evicting `Dirty` = data loss |
+| `Fill` | `{Absent, Remote}` → `Resident` | overwriting newer local bytes |
+| `Invalidate` | `Resident` → `Remote` | **`Dirty` → `Remote` is #2084 exactly** |
+| `Seed` | `Absent` → `Remote` | seeding over live local bytes |
+| `Compact` | must never produce `Lost` | #2084, #2093 |
+
+`Fill` covering `Absent` is not a rounding error: `fileIndex.hydratable` (`index.go:509-544`)
+returns genuine holes as well as cold ranges, and the `Absent` side is the one behind #1888
+(cold seeding skipped unplaceable rows → silent zeros) and #1887. A transition table that omits
+it is not yet a specification.
+
+#2084 was `Invalidate` performing `Dirty → Remote` when the only truthful transition was
+`Dirty → Lost` — there was no remote copy to fetch. The shipped fix made it refuse. Here that
+refusal is the operation's definition rather than a guard someone remembered to add.
+
+### Three rules
+
+1. **Any transition that reduces residency is durable before it takes effect.** The cold.log
+   lesson (#1850), generalised. Today `Evict`, `Invalidate` and `Seed` each learned it
+   independently and #2084 proves one had not. Target: a single internal `demote()` chokepoint
+   that cannot run without first fsyncing its record.
+2. **Exposure is exactly queryable.** *"If this disk died now, what is lost?"* — bytes, files,
+   ETA. Answerable from the state map. `DurableExtent` already does the per-file half and is
+   ahead of the field (JuiceFS's write-back docs warn about loss with no way to quantify it).
+3. **In-flight uploads hold a pin.** A range being flushed must be pinned against evict and
+   compact for the duration, crash-reconstructibly. `SetPinVersion` is the coarse form of this.
+
+## 4. The surface
+
+```go
+// Package pier is a crash-safe local write-back cache for object storage.
+//
+// Bytes park in a container on the pier until a boat carries them out: a write
+// lands locally and is acknowledged at once, Sync bolts it down so a crash
+// cannot take it, and Flush puts it on the boat to the object store. A pier is
+// a waiting place, never a destination — pier always knows which of its bytes
+// have sailed, which have not, and which are gone.
+package pier
+
+type FileID string
+
+// ── lifecycle ──
+func Open(dir string, cfg Config) (*Cache, error)   // format check folded in
+func (c *Cache) Close() error
+
+// ── data plane ──
+func (c *Cache) WriteAt(ctx context.Context, id FileID, off int64, p []byte) error
+func (c *Cache) ReadAt(ctx context.Context, id FileID, off int64, dst []byte) (n int, fetch []Extent, err error)
+func (c *Cache) Fill(ctx context.Context, id FileID, off int64, p []byte, notAfter uint64) error
+func (c *Cache) Sync(ctx context.Context, id FileID) error
+
+// ── queries ──
+func (c *Cache) Size(ctx context.Context, id FileID) (int64, bool)
+func (c *Cache) Extents(ctx context.Context, id FileID) ([]Extent, error)
+func (c *Cache) DurableExtent(ctx context.Context, id FileID) (int64, bool) // NOT derivable — see 4.2
+func (c *Cache) ColdExtents(ctx context.Context) (bytes, extents int64, err error) // store-wide
+func (c *Cache) Files(ctx context.Context) []FileID
+func (c *Cache) Stats() Stats
+
+// ── transitions ──
+func (c *Cache) Flush(ctx context.Context, id FileID, opts FlushOptions,
+        fn func(context.Context, Block) (durable []Extent, err error)) error
+func (c *Cache) Evict(ctx context.Context, targetBytes int64) (Reclaimed, error)
+func (c *Cache) Invalidate(ctx context.Context, id FileID, off, length int64) error
+func (c *Cache) Seed(ctx context.Context, seeds []Seed) error
+func (c *Cache) Compact(ctx context.Context, opts CompactOptions) (Reclaimed, error)
+
+// ── mutation ──
+func (c *Cache) Delete(ctx context.Context, id FileID) error
+func (c *Cache) Truncate(ctx context.Context, id FileID, size int64) error
+
+// ── versions ──
+func (c *Cache) Version() uint64
+func (c *Cache) Pin(v uint64)
+func (c *Cache) Restore(ctx context.Context, v uint64) error
+
+// ── control ──
+func (c *Cache) SetEvictionEnabled(bool)
+func (c *Cache) MarkSeeded() error
+
+// ── errors: a closed set, each implying a different caller action ──
+var ErrFull   = errors.New("pier: local capacity exhausted, all segments pinned dirty")
+var ErrLost   = errors.New("pier: range has no surviving copy")
+var ErrClosed = errors.New("pier: closed")
+
+type CorruptError struct{ ID FileID; Off, Len int64 } // healable: invalidate + refetch
+```
+
+### `Flush` — the seam, corrected after adversarial review
+
+**The first draft of this section was wrong and was rejected.** It defined the callback as
+one-call-per-dirty-run returning `consumed int64`. See §4.2.
+
+```go
+// Block is one committed unit — what today is exactly one CommitBlock.
+// It may span several dirty runs; that is the point.
+type Block struct {
+    ID          FileID
+    Extents     []Extent // dirty extents this block covers, ascending, MAY SPAN RUNS
+    DurableTail []Extent // contiguous already-durable extents after the last one:
+                         // both Resident AND Remote, because a clobbered row's owed
+                         // range can straddle evicted bytes (carve.go:749 unions both)
+    io.ReaderAt          // bytes, addressed by file offset
+}
+```
+
+`fn` returns **the extents it actually made durable**, and may return a non-empty slice
+*together with* an error. `pier` flips exactly those, then stops. That is what expresses
+"committed 3 of 5 chunks, then failed" — which `consumed int64` could not, because credit is
+not always a prefix.
+
+Division of labour:
+
+| Owns | What |
+|---|---|
+| **pier** | what is dirty, run grouping, age/size gating, the version fence, watermark-ordered flip, crash safety. **Calls `fn` STRICTLY SEQUENTIALLY** — one file, one run at a time, ascending offset; call N+1 does not start until call N returns |
+| **crane** | chunk boundaries, accumulating chunks into `BlockSize` blocks |
+| **ferry** | ALL upload concurrency: bounded window, retry, ordered completion |
+| **DittoFS** | dedup oracle, manifest rows, scheduling |
+
+**pier does NOT accumulate blocks.** Verified at `carve.go:598-601`: the `batchBytes >=
+CarveBlockSize` flush fires *after* a whole chunk is appended, so a block boundary is always a
+chunk boundary. Block accumulation is therefore downstream of chunking, and pier — which must
+stay chunk-agnostic so a consumer can ingest blobs it never chunks — cannot know where a block
+may legally end.
+
+The seam that permits this: **`fn` may return an empty `durable` slice.** It is called once per
+dirty run and buffers internally; when it has a block's worth it uploads and returns those
+extents; pier flips exactly those, in order. A final call with `Block.Final == true` drains the
+partial batch — the same `final bool` pattern `chunker.Next(data []byte, final bool)` already
+uses.
+
+This answers the review's "the caller rebuilds the accumulator by hand" objection: it does not.
+The accumulator **is** the crane library — published, tested, reusable — not hand-rolled closure
+state.
+
+`manifestRowEnder`, `supersededReaper` and `clobberGuard` still evaporate: the first becomes
+`DurableTail`, and the other two become the caller calling its own manifest — the reap once
+after `Flush` returns, using spans its closure recorded across `fn` calls.
+
+### v3.1 — four changes required by the second review
+
+**1. Calls are sequential; upload concurrency lives in ferry.** v3 said pier owned "bounded
+concurrency" AND that `fn` buffers internally across calls. Those contradict: concurrent calls
+to one accumulator race over which run's bytes land in which block, and break the reap's
+contiguous-prefix assumption (`carve_pack.go:16-24`). Today's code already splits them — packing
+is single-goroutine (`carve.go:397-408`: "packing itself stays sequential"), only commit+flip is
+dispatched concurrently (`carve_dispatch.go`). v3.1 keeps that split, along module lines:
+
+- pier calls `fn` sequentially, ascending offset, one file at a time.
+- `fn` submits uploads into ferry's bounded window and returns `(nil, nil)`.
+- `fn` reports extents whose uploads have SINCE completed, on a later call.
+- the `Final` call drains ferry's in-flight set and returns the remainder.
+
+So `CarveUploadConcurrency` maps to **`ferry.Options.MaxConcurrent`, never `FlushOptions`** —
+§5.0's rename table said `FlushOptions`; that was wrong.
+
+**2. pier MUST validate extent provenance before flipping.** Today `flipUpTo` walks only the
+`run []interval` it was handed, advancing `flipIdx` (`carve.go:844-865`) — structurally incapable
+of flipping something it was not given. A free-form `durable []Extent` reopens that class: a
+buggy `fn` (bad offset maths, wrong file, an extent re-sent after cancellation) could flip a
+range pier never offered. pier must check every returned extent against this file's
+offered-and-unflipped set and reject the rest. **New required surface, not carried over.**
+
+**3. `Block.DurableTail` is computed per call, lazily** — matching `anySyncedFrom`'s gate
+(`carve.go:684`), NOT eagerly for the whole file, which is precisely what
+`extendRunToRowEnd`'s comment (`carve.go:469-483`) exists to avoid.
+
+**4. `FlushOptions.AfterFile` is MANDATORY — the reap is unsafe outside the lock.**
+
+The race fires on a predictable 2-second cadence, not adversarial timing.
+`engine/carve_dispatch.go:33-58` runs a pass per file every `UploadInterval` (default 2s), and
+manual `SyncNow` is a second trigger, so any pass outlasting one tick is re-entered. Today only
+`sh.carveMu` prevents overlap, and it is held across BOTH flip and reap (`carve.go:274-360`).
+Release it at `Flush` return and:
+
+1. `Flush(X)` packs, flips, returns; the caller's closure holds `spans`/`newOffsets`.
+2. The next tick starts `Flush(X)` again — the lock that held passes apart is gone.
+3. Pass 2 carves new dirty bytes inside pass 1's about-to-be-reaped span, commits a row.
+4. Pass 1's delayed reap runs against `newOffsets` captured before pass 2 existed, does not
+   recognise pass 2's row as its own, and **deletes a load-bearing row.**
+
+That is #1872/#2093 reintroduced by construction, on a timer. Therefore:
+
+```go
+type FlushOptions struct {
+    // AfterFile runs once per file after the last flip, WHILE pier still holds the
+    // shard's flush lock. The manifest reap goes here. Not optional: a caller that
+    // reaps after Flush returns reintroduces the race above.
+    AfterFile func(ctx context.Context, id FileID) error
+}
+```
+
+A caller-side lock is the wrong alternative — it makes the engine invent a second per-shard
+locking scheme with no visibility into pier's partitioning. Fold `maybeResetDirtyClock`
+(`carve.go:920-935`) in too, for symmetry; it is low-risk either way.
+
+**Confirmed sound by the same review:** `durable []Extent` does express the pinned partial-credit
+tests (`TestCarvePackFlipPlanWatermarks`, `TestCarvePackSpanningBlockFailureReapsTheCommittedPrefix`),
+and crash-safety between individual flips is no weaker than today's `flipUpTo` — unflipped
+extents stay dirty and the dedup oracle collapses the re-upload.
+
+### Method-count delta
+
+| | Today | Target |
+|---|---|---|
+| exported `*Store` methods | 31 | 22 |
+| package funcs | 3 (`Open`, `CheckFormat`, `SystemClock`) | 1 (`Open`) |
+| undeclared type-asserted interfaces | 3 | 0 |
+
+Nothing is a lost capability:
+
+- five queries → one (`FileSize`/`DataExtents`/`DurableExtent`/`ColdExtents`/warm-tail → `Extents`)
+- `SeedCold` + `SeedColdBatch` → `Seed` (single file is a one-element slice)
+- `SetVerifyReads` → `Config.VerifyReads` (set once at construction, never changes)
+- `CheckFormat` → folded into `Open` (a guard a caller can forget is not a guard)
+- crane moves out entirely (§5)
+- dead API deleted (§6)
+
+## 5. The split: subtraction, not partition
+
+**Do not create two packages.** Move crane *up* into `pkg/block/engine`, where the manifest it
+serves already lives. What remains in the package is the generic library.
+
+Evidence this is cheap: every crane helper — `splitRuns`, `warmTail`, `anySyncedFrom`,
+`syncedRanges`, `flipUpTo`, `flipRecordSynced`, `recordHasDirtyFragment`,
+`maybeResetDirtyClock`, `runReader` — has **zero** uses outside `carve*.go`. They become the
+body of `Flush` or move with crane.
+
+Counter-evidence to respect: crane touches `fi.ivs` 28× and `sh.mu` 20×. It is *inside* the
+index today, not a client of it. That is precisely why the seam must be a **callback**, not a
+lease — a lease API would have to materialise all that state as values and invent a token to
+fence what a held lock already fenced.
+
+Stays in the library (generic): segments, records, interval index, recovery, group-commit
+fsync + watermark, eviction, compaction, cold log, format stamp, version/pin/restore.
+
+Moves to engine (DittoFS policy): FastCDC chunking, BLAKE3 hashing, dedup oracle, block
+packing, every manifest call, and the cross-file scheduling that already lives in
+`engine/carve_dispatch.go`.
+
+Ordered work:
+
+1. Delete the dead API (§6). Pure subtraction, no consumer changes.
+2. Sever `internal/logger` → `Config.Logger *slog.Logger` (11 `Warn` sites, all advisory).
+   **This is the hard extraction blocker** — Go forbids importing `internal/` from outside
+   the module.
+3. Replace `block.ErrFutureFormat` with a package-local sentinel (2 uses, `format.go`).
+4. Collapse the five extent queries into `Extents`.
+5. Invert crane into `Flush` + `Run.WarmTail`; move chunking/hashing/manifest to engine.
+   `chunker` and `blake3` leave with it.
+6. Rename to the agreed name; convert `FSStore`'s embed to a named field (see §6).
+7. README, `Example_` tests, benchmark set, and the test suite closing §6's gaps.
+
+After step 5 the package's only non-stdlib import is `golang.org/x/sys` (statfs, build-tagged),
+at which point `git subtree split` is mechanical — **if** a second consumer ever justifies it.
+
+### 5.0 Vocabulary — one word, one meaning
+
+The family reads in order: **pier** stages -> **crane** cuts blocks -> **ferry** moves them ->
+**dittofs** orchestrates and decides what any of it means.
+
+#### Data flow — note the return path
+
+```
+WRITE                                                    ack ────┐
+  NFS/SMB ──► pier.WriteAt ──► staged locally, StateDirty ───────┘
+
+FLUSH  (dittofs schedules; pier offers, dittofs disposes)
+  pier.Flush(id, fn) ──► offers dirty runs ──► fn:
+                                                crane.Crane    cut blocks
+                                                ferry.Upload  PUT
+                                                dittofs        commit manifest rows
+                          ◄── returns durable []Extent ──────────┘
+  pier flips exactly those ──► StateResident        ← THE INVARIANT LIVES HERE
+
+READ
+  NFS/SMB ──► pier.ReadAt ──► (n, fetch []Extent)
+                 fetch non-empty ──► dittofs resolves manifest
+                                  ──► ferry.Fetch
+                                  ──► pier.Fill ──► StateResident ──► re-read
+```
+
+**Nothing reaches `StateResident` except by pier being told what became durable.** That is why
+`Flush` is a callback and not a pipeline stage: a linear `write -> crane -> sync` has nowhere to
+put the acknowledgement, and dropping it is the entire #1872 / #2073 / #2093 family. The flow is
+a loop, and the return edge is the crash-safety-critical one.
+
+**Modules are a distribution decision; packages are a design decision.** Four `go.mod` files for
+one team and one consumer is real overhead: CI matrices, version skew, cross-cutting fixes
+needing two PRs (see #1872, one defect spanning journal and engine). Get the four PACKAGE
+boundaries right in-tree now; promote to modules only when something is actually published.
+`git subtree split` stays mechanical as long as each package's imports stay clean, which is
+exactly what §7.1's import-graph test enforces.
+
+`crane` today means chunking AND packing AND uploading AND manifest commit AND flipping records
+— **541 occurrences across 60 non-test files**. The smear is visible in the type name
+`CarveChunk`, which needs two words to name one thing.
+
+| Term | Means exactly | Lives in |
+|---|---|---|
+| **write** | stage bytes locally and acknowledge the client | `pier.WriteAt` |
+| **sync** | make durable HERE (fsync) | `pier.Sync` |
+| **flush** | pier's pass: offer dirty runs, accept durability reports | `pier.Flush` |
+| **chunk** | find one content-defined boundary | inside `crane` |
+| **box** | group chunks into one BlockSize block | `crane.Box` |
+| **put** / **get** | make durable THERE / bring it back | `ferry.Put` / `ferry.Get` |
+
+`Box` is a verb; its output noun is **`Block`**, not `Box` — `crane.Box(...) []Block`. Never
+introduce a `Box` type. pier's on-disk unit stays **segment**; only crane produces **blocks**.
+"Container" is not a term of art in either package — it was ambiguous between the two.
+
+`crane` is kept, not invented: **file boxing** is standard digital-forensics vocabulary for
+extracting structured units from a raw byte blob with no metadata to guide you. That is exactly
+library two's job. What changes is that it stops also meaning "the upload pass" — that is
+`Flush` — so `CarveChunk` becomes `crane.Chunk`.
+
+Renames implied: `CarveOptions`/`CarveResult` -> gone (`FlushOptions`, and the result is what
+`fn` returns) - `SetCarveTargets` -> gone - `carveMu` -> `flushMu` - `CarveBlockSize` ->
+`crane.Options.BlockSize` - `CarveMaxAge`/`CarveUploadConcurrency` -> `FlushOptions` -
+engine `carvePass` -> `flushPass`.
+
+### 5.1 Topology — four packages, promoted to modules only on publication
+
+```
+pier    — stages bytes locally, crash-safe. Knows nothing of chunking, hashing, uploads
+          or manifests. Chunk-agnostic by requirement: a consumer may ingest blobs it
+          never chunks.
+          deps: stdlib + golang.org/x/sys
+
+crane   — cuts blocks out of a blob: content-defined chunk boundaries plus accumulation
+          into BlockSize blocks. OPTIONAL companion to pier.
+          deps: stdlib
+
+ferry   — moves blocks BOTH WAYS: Put (bounded/adaptive concurrency, retry, ORDERED
+          COMPLETION REPORTING, backpressure, remote-health) and Get/GetRange, which is
+          what feeds pier.Fill on a cold read. A ship sails away; a ferry returns — and
+          the return trip is the cold-read path that has had three bugs in it.
+          deps: stdlib (the remote itself is an injected interface)
+
+          Named `ferry` (what lifts containers from the pier onto the ship) rather than
+          `syncer`, because `pier.Sync` already means fsync. pier.Sync = durable HERE;
+          ferry.Upload = durable THERE. No collision.
+
+dittofs — policy only: dedup oracle, what a block means, manifest rows, scheduling.
+          deps: pier + crane + ferry + pkg/metadata + pkg/block/remote
+```
+
+**Chunking is optional by construction, not by configuration.** `Flush` hands the caller a `Run`
+— bytes plus an extent — and what becomes of those bytes is entirely the caller's. A consumer who
+wants content-defined dedup imports `fastcdc`; a consumer who wants to `PUT` each run as one
+object named by its offset imports nothing extra and writes four lines. Verified: after crane
+moves out, pier's only chunker references are `Config.ChunkParams` (crane config, leaves with it)
+and one arbitrary pool-sizing constant at `index.go:373` that becomes a local number.
+
+**Why `fastcdc` is its own module rather than a pier subpackage or in-tree with crane:**
+
+1. **Chunk boundaries are a compatibility surface.** Two pier users who chunk differently cannot
+   share a dedup pool. Publishing the boundary definition alongside pier is what makes interop
+   possible at all; withholding it guarantees fragmentation.
+2. **Different compatibility guarantees, therefore different semver.** The masks are pinned
+   forever — `params.go`'s `#1569` note records that changing them re-chunks all existing data.
+   That makes it a *format*. pier is an API and will evolve. Coupling their versions forces a
+   choice between freezing pier and breaking dedup.
+3. **It is already a library in everything but distribution** — 216 non-test LOC, **zero
+   non-stdlib imports**, 94.2% coverage, a clean contract (`Chunker`, `Params`, `Next`,
+   `Validate`). The cheapest module in the tree to publish.
+4. **It has a real differentiator.** `Next(data []byte, final bool) (int, bool)` is
+   allocation-free and I/O-free — no `io.Reader` wrapper, the caller owns the buffers — which is
+   why it composes with pooled arenas. Every published Go FastCDC alternative
+   (`jotfs/fastcdc-go`, `tigerwill90/fastcdc`) wraps a reader and allocates.
+
+**`ferry` resolves a structural oddity, it does not invent one.** Recon cleared
+`pkg/block/engine/carve_dispatch.go` (parallelises across files) and
+`pkg/block/journal/carve_dispatch.go` (overlaps blocks within one file) as "complementary, not
+duplicates". True but incurious: they are two halves of an upload scheduler that has no home.
+`ferry` is that home, and merging them is the point.
+
+**The dead `RemoteStore` is ferry's contract.** §6 records `journal.RemoteStore{PutBlock,
+GetBlock, GetRange}` as entirely dead — never implemented, never read, the one production call
+site passes `nil`. It was not a fossil of a design that was abandoned. It was **in the wrong
+package**: it is precisely the interface `ferry` injects. Finding its true owner is corroboration
+for this topology, not a coincidence.
+
+**Ordered completion is why ferry is separate rather than folded into crane.** pier can only flip
+in watermark order if something reports what completed and in what sequence. That reporting is
+ferry's contract with pier, and it is the reason the two carve_dispatch files exist at all.
+
+**The crane is not a library and must never become one.** What to upload, when, how to pack it,
+and how to reconcile the manifest are all DittoFS decisions. Crane is the thing being *removed*
+from the library, not extracted beside it.
+
+**Naming asymmetry, deliberate.** `pier` is coined because it is a novel component nobody
+searches for by algorithm — the name's job is to be memorable and unclaimed. `fastcdc` should be
+**descriptive**, because people searching for this will type "go fastcdc" and a themed name
+(`crate`, `bale`, `stow`, `parcel`) would be invisible to them. Discoverability wins where the
+thing is a known algorithm; distinctiveness wins where it is not.
+
+## 6. Code and folder structure
+
+### 6.1 pier stays ONE Go package — a justified exception
+
+CLAUDE.md prefers "subpackage over underscore filenames". pier is the exception, and the reason
+is mechanical: `Store` methods touch `shard.mu`, `fileIndex.ivs` and `segmentMeta.fd` throughout
+(`carve.go` alone: 28 `fi.ivs`, 20 `sh.mu`). A `segment/`, `index/` or `cold/` subpackage forces
+exporting every one of those internals, which is strictly worse than the file-length problem it
+would solve. Only code that touches NO `Store` state may be a subpackage — record framing and
+the statfs shims qualify; nothing else does.
+
+Navigability therefore comes from file naming, under one rule:
+
+> **A file named for a TYPE contains that type and its methods.
+> A file named for a VERB contains that code path, end to end.**
+
+Today this is violated where it matters most: `segment.go:271` holds `appendRecord` — the entire
+write hot path — and `index.go:295` holds `ReadAt`. A reader asking "how does a write land on
+disk" finds it in no file whose name suggests writing.
+
+### 6.2 Target layout
+
+```
+pier/
+  doc.go            the metaphor, the state model, the invariants
+  pier.go           Cache, Config, Stats, State, Extent, errors — the public vocabulary
+  open.go           Open, Close, background loops
+  write.go          WriteAt, Fill, appendRecord, tombstone + truncate markers   [was segment.go]
+  read.go           ReadAt, verifiedRead, Size, Extents, DurableExtent          [was index.go]
+  index.go          fileIndex, interval, insert, plan — ALGORITHM ONLY, no Store methods
+  shard.go          shard, group commit, Sync
+  segment.go        segmentMeta, create / seal / rotate — TYPE ONLY, no hot-path methods
+  flush.go          Flush, run grouping, the fence, watermark-ordered flip  [was carve*.go x3]
+  evict.go          Evict, ensureSpace, write-path backpressure              [was reclaim.go]
+  compact.go        Compact, repack, victim selection                       [was reclaim.go]
+  retire.go         the retirement tail evict and compact share             [was reclaim.go]
+  cold.go           cold log, Invalidate, Seed, MarkSeeded, ColdExtents     [+ coldstats.go]
+  recover.go        recoveryState and its phases
+  restore.go        Version, Pin, Restore
+  format.go         the on-disk format stamp
+  internal/wire/    record framing codec — pure, no Store                   [was record.go]
+  internal/fsutil/  statfs_unix.go, statfs_windows.go, fsyncDir
+  piertest/         exported conformance suite (mirrors pkg/metadata/storetest)
+  example_test.go   godoc-surfaced usage
+  README.md
+
+crane/
+  doc.go            "FastCDC content-defined chunking" in line one, for searchability
+  crane.go          Boxer, Options — cuts a blob into BlockSize blocks
+  chunker.go        FastCDC boundary finding
+  gear.go           the gear table
+  params.go         Params, Validate, DefaultParams — THE FORMAT; masks pinned (#1569)
+  README.md
+
+ferry/
+  doc.go
+  ferry.go          Ferry, Options, Upload, ordered completion reporting
+  window.go         adaptive concurrency window                    [was engine/carve_dispatch.go]
+  retry.go          backoff; safe by construction — content-addressed PUTs are idempotent
+  remote.go         the injected remote interface  [journal.RemoteStore, finally in the right package]
+  README.md
+
+dittofs/pkg/block/engine/
+                    orchestration only: schedules Flush, wires crane + ferry,
+                    owns the dedup oracle and the manifest.
+```
+
+### 6.3 What this closes
+
+| Problem today | Closed by |
+|---|---|
+| `store.go` 1297 lines, 8-9 responsibilities | `pier.go` + `open.go` + `write.go` + `read.go` + `restore.go` |
+| `reclaim.go` 999 lines, two policies + shared tail | `evict.go` + `compact.go` + `retire.go` |
+| `carve.go` 995 lines, gocyclo 35 | `flush.go` (fence + flip only) — chunking and packing leave |
+| `segment.go` / `index.go` hold the hot paths their names disown | `write.go` / `read.go` |
+| `carve_pack.go` — 37 lines, no independent identity | merged into `flush.go` |
+| `coldstats.go` vs `cold.go` — confusing adjacency, one method | merged into `cold.go` |
+| Two files named `carve_dispatch.go` in different packages | one `ferry/window.go` |
+| Six near-duplicate test store-openers | one options-taking harness in `piertest/` |
+
+`recover.go` keeps its current shape deliberately: `recoveryState`'s phased-builder is the best
+structure in the package and is the template for anything else here that grows multi-phase.
+
+## 7. The three public interfaces
+
+Each is designed to stand alone as its own OSS repository: no import of the others except
+where stated, no host-app types in a signature, and a contract a stranger can implement against.
+
+### 7.1 pier — the write-back cache over append blobs
+
+Full surface in §4. One-line contract: **stages byte ranges for many blobs on local disk,
+crash-safely, and always knows which of its bytes have sailed, which have not, and which are
+gone.** Imports nothing from crane or ferry — it never learns what a block is.
+
+### 7.2 crane — content-defined, content-addressed block assembly
+
+Takes a pier-shaped append blob and carves content-addressed blocks out of it: FastCDC
+boundaries, BLAKE3-256 identity, accumulation to `BlockSize`.
+
+```go
+package crane // FastCDC content-defined chunking with BLAKE3 content addressing
+
+type Hash [32]byte // BLAKE3-256 of the chunk's plaintext
+
+type Chunk struct {
+    Offset int64 // logical offset in the source blob
+    Size   int
+    Hash   Hash
+}
+
+type Block struct {
+    ID     Hash    // identity of the assembled block
+    Chunks []Chunk // ascending, contiguous
+    Bytes  []byte  // packed plaintext; EXCLUDES chunks Skip reported as already present
+}
+
+type Options struct {
+    Params    Params // FastCDC sizing; zero value = DefaultParams
+    BlockSize int64  // accumulate to at least this before emitting a Block
+    // Skip reports that a chunk is already durable elsewhere, so its bytes need not be
+    // packed. It still appears in Block.Chunks — the caller needs the record even when
+    // the payload is redundant. Nil means pack everything.
+    Skip func(Hash) (bool, error)
+}
+
+func New(o Options) *Boxer
+// Box consumes data at off and returns whatever complete Blocks it can. It buffers
+// across calls; final drains the remainder. Allocation-free on the boundary path.
+func (b *Boxer) Box(data []byte, off int64, final bool) (blocks []Block, consumed int, err error)
+
+type Params struct{ Min, Avg, Max int }
+func DefaultParams() Params
+func (p Params) Validate() error
+```
+
+**`Skip` is how dedup enters without the oracle entering.** DittoFS supplies a closure over its
+synced-hash store; a standalone consumer passes nil. crane never learns what a metadata store is.
+
+**`Params` is a FORMAT, not a tuning knob.** The masks are pinned (`#1569`: changing them
+re-chunks all existing data). Semver it as a format: a `Params` change is a major version.
+
+### 7.3 ferry — moving blocks to and from a block store
+
+```go
+package ferry // bounded, retried, order-reporting transport for immutable blocks
+
+type BlockID string
+
+// Store is the injected backend. S3 is one implementation; a filesystem, GCS, or an
+// in-memory map are others. ferry imports no cloud SDK.
+type Store interface {
+    Put(ctx context.Context, id BlockID, r io.Reader, size int64) error
+    Get(ctx context.Context, id BlockID) (io.ReadCloser, error)
+    GetRange(ctx context.Context, id BlockID, off, n int64) (io.ReadCloser, error)
+}
+
+func New(s Store, o Options) *Ferry
+
+// Put and Get are the synchronous forms.
+func (f *Ferry) Put(ctx context.Context, id BlockID, data []byte) error
+func (f *Ferry) Get(ctx context.Context, id BlockID, off, n int64) (io.ReadCloser, error)
+
+// Submit is the asynchronous form: uploads overlap up to the adaptive window, but
+// Completions reports them IN SUBMISSION ORDER. That ordering is exactly what lets
+// pier flip its watermark safely — it is ferry's real contract, not a convenience.
+func (f *Ferry) Submit(ctx context.Context, id BlockID, data []byte, tag any) error
+func (f *Ferry) Completions() <-chan Completion
+type Completion struct { Tag any; Err error }
+
+func (f *Ferry) Health() Health // drives pier.SetEvictionEnabled when the remote degrades
+
+type Options struct {
+    MaxConcurrent int           // 0 = adaptive
+    MaxAttempts   int           // retry is safe by construction: content-addressed PUTs
+    Backoff       func(int) time.Duration
+}
+```
+
+**Ordered completion is why ferry is a module and not a helper.** pier can only flip in
+watermark order if something reports what completed and in what sequence; that reporting is the
+contract between them, and it is why two files named `carve_dispatch.go` exist today in two
+different packages.
+
+**ferry owns the interface that was dead in journal.** `journal.RemoteStore{PutBlock, GetBlock,
+GetRange}` — never implemented, never read, `nil` at its one production call site — is
+`ferry.Store`. It was not an abandoned design; it was in the wrong package.
+
+### 7.4 What each may import
+
+| | pier | crane | ferry |
+|---|---|---|---|
+| stdlib | yes | yes | yes |
+| `golang.org/x/sys` | yes (statfs) | no | no |
+| BLAKE3 | no | yes | no |
+| the other two | **no** | **no** | **no** |
+| any DittoFS package | **no** | **no** | **no** |
+| any cloud SDK | no | no | **no** — `Store` is injected |
+
+Enforced by the import-graph test in §9.1, in each repo. Only DittoFS imports all three.
+
+## 8. Findings that motivate this (recon; audit verification pending)
+
+**Dead exported API — delete:**
+
+- `RemoteStore` and `BlockID` are **entirely dead**. `s.remote` is assigned in `Open`
+  (`store.go:174`, `:288`) and *never read anywhere in the package*. The one production call
+  passes `nil` (`local/fs/fs.go:165`). The only implementation in the tree is a test stub
+  (`engine/blocksink_test.go:17`). The engine fetches remote bytes itself and pushes them in via
+  `Hydrate` — **the real remote seam is already inbound-only**, which is why this design works.
+- `PinVersion()` — zero callers anywhere, including tests.
+- `SegmentLocation` — never referenced outside the package.
+- `GC`/`GCOptions`/`GCResult` — no external caller; only the internal background loop.
+  `engine/carve_dispatch.go:28` documents that the engine deliberately never calls it.
+
+**Doc drift:**
+
+- `doc.go:23` cites `gc.go`; no such file (the code is in `reclaim.go`).
+- `reclaim.go:46` cites `logblob.EvictBlob`; that package was removed in the journal switchover.
+- `doc.go:6-9` claims dependence on "the standard library plus a pair of narrow injected
+  interfaces (RemoteStore, Clock)". Actual non-stdlib imports: `internal/logger`, `pkg/block`,
+  `pkg/block/chunker`, `lukechampine.com/blake3`, `golang.org/x/sys` — and **one of the named
+  pair was never implemented**, while the interfaces that carry the design (`Deduper`,
+  `BlockSink`, plus three type-asserted ones) go unmentioned.
+
+**Untested exported API — zero call sites across all 29 test files:**
+`RestoreToVersion` (gocyclo 37, the snapshot-restore primitive, longest doc comment in the
+package), `CheckFormat` (the format-refusal guard), `JournalVersion`, `PinVersion`,
+`SetPinVersion`, `FileCount`. Package coverage is 79.2% and hides all six.
+
+**Surface leak:** `local/fs/fs.go:68` embeds `*journal.Store` rather than holding it as a
+field, with a first-party `ponytail:` comment (`fs.go:57-63`) naming the leak as a deferred
+hazard. `local.LocalStore` declares 18 methods; `*Store` exposes 31; `pkg/block/engine` reaches
+past the interface to the concrete type for `SeedColdBatch`, `RestoreToVersion`,
+`SetPinVersion` via unexported structural interfaces that **silently no-op if the assertion
+fails**. Two contracts exist, one declared and one informal.
+
+**Not findings (checked and cleared):**
+
+- `engine/carve_dispatch.go` vs `journal/carve_dispatch.go` are complementary, not duplicates:
+  the former parallelises across files, the latter overlaps blocks within one file. Only the
+  filename collides.
+- `index.go:203` `appendAssign` (gocritic) is a false positive — `survivors` starts nil and is
+  only appended to locally.
+- The 13 `ponytail:` markers are a sanctioned debt ledger per CLAUDE.md, not TODOs.
+
+## 9. Standalone test contract
+
+**Requirement: `pier`'s test suite must pass with zero imports outside stdlib + `golang.org/x/sys`.**
+Not as a policy — as a test.
+
+### 7.1 The enforcing mechanism
+
+```go
+// TestNoForeignImports fails if pier's non-test OR test files import anything
+// outside the standard library and golang.org/x/sys.
+func TestNoForeignImports(t *testing.T) { /* go/packages walk over the package */ }
+```
+
+This is the whole point. `doc.go`'s "depends only on the standard library plus a pair of narrow
+injected interfaces" drifted to false — five non-stdlib imports and one of the named pair never
+implemented — precisely because **nothing checked it**. A prose claim about the dependency graph
+rots; an assertion about it cannot. Everything else in this section is downstream of that test
+passing.
+
+Today's violations, all removable:
+
+| Import | Where | Fix |
+|---|---|---|
+| `internal/logger` | `cold.go`, `reclaim.go`, `recovery.go`, `store.go` (11 `Warn` sites) | `Config.Logger *slog.Logger`, nil = discard |
+| `pkg/block` | `format.go` (`ErrFutureFormat`, 2 uses) | package-local sentinel |
+| `pkg/block/chunker` | `carve.go`, `store.go`, `index.go:373` | leaves with crane; `index.go:373` becomes a local const |
+| `lukechampine.com/blake3` | `carve.go:558` (one call) | leaves with crane |
+| `badgerstore` (**test**) | `carve_pack_test.go:11`, used only by `BenchmarkCarveScatteredPass` | latency-injecting fake `Deduper`; the real-Badger measurement belongs in DittoFS's suite, not the library's |
+
+### 7.2 Coverage gaps to close
+
+Six exported methods have **zero** test call sites across all 29 test files — package coverage
+of 79.2% hides every one:
+
+`RestoreToVersion` (gocyclo 37, snapshot-restore primitive, longest doc comment in the package),
+`CheckFormat` (the format-refusal guard — a guard that has never refused anything is unverified,
+not proven), `JournalVersion`, `PinVersion`, `SetPinVersion`, `FileCount`.
+
+`Restore` is the priority: an audit finder flagged it as blind to `cold.log`, deleting
+remote-durable files and zero-filling cold ranges. Pending verification, but it is exactly the
+`StateRemote`-read-as-`StateAbsent` confusion this design exists to prevent.
+
+**Every new regression test must be run against a deliberately broken build before it is
+trusted.** A test that passes on unmodified code proves nothing about the bug it claims to pin.
+
+### 7.3 What a standalone suite needs that this one lacks
+
+1. **One canonical harness.** Six near-duplicate store-openers exist today — `testStore`,
+   `carveStore`, `evictStore`, `ctrlStore`, `openDirtyExpireStore`, `benchStore` — each
+   re-implementing `Open(t.TempDir(), cfg, fakes) + Cleanup`. Replace with one options-taking
+   helper.
+2. **`piertest` conformance suite**, exported, mirroring this repo's own convention
+   (`pkg/metadata/storetest`, `pkg/block/blockstoretest`). Lets a consumer validate a fake, and
+   lets a second implementation exist at all.
+3. **Property/model test for the interval index.** `fileIndex.insert`/`plan` is the algorithmic
+   core; test it against a naive `[]byte` + `[]state` oracle under randomised
+   write/overwrite/truncate/evict sequences. An audit finder reports the equal-`Version`
+   tie-break diverging between `insert`'s fast path and its general path (`index.go:166`) — a
+   model test finds that class automatically. Native `go test -fuzz` for the record and cold-log
+   decoders.
+4. **In-process crash injection.** The existing rigs (`test/crash/device-loss.sh`,
+   `invalidate-cold-loss.sh`) are shell + `dm-flakey`, live outside the package, and need Linux
+   and root. A library must be able to test torn writes, failed fsync and partial rename inside
+   `go test` on any platform — which means an injectable file seam (interface or failpoint)
+   rather than raw `os.File`. The hardware rigs stay in DittoFS as the belt to this suspenders.
+5. **`Example_` functions.** None exist. At minimum: open/write/sync/read, a `Flush` loop, and
+   handling `ErrFull`. These are the README's executable half.
+6. **README.** None exists. Lead with `DurableExtent`-equivalent exposure accounting — it is the
+   package's best idea and the thing the field does not have.
+
+## 10. Benchmark contract
+
+**One benchmark per state transition**, so the benchmark set and the transition table in §3 are
+the same list. Today 11 benchmarks cover the write path well and nothing else.
+
+| Transition | Today | Needed |
+|---|---|---|
+| `*` → `Dirty` (`WriteAt`) | `BenchmarkWriteAt`, `BenchmarkRandWrite4K`, `BenchmarkSeqWrite4K`, `BenchmarkRandWriteBounded` | keep |
+| durability (`Sync`) | `BenchmarkConcurrentCommit1/32/128`, `BenchmarkTinyWritesCommit` | keep |
+| `Dirty` → `Resident` (`Flush`) | `BenchmarkCarve`, `BenchmarkCarveScatteredPass` | de-Badger the second |
+| warm read | `BenchmarkReadWarm` | keep |
+| **cold read** | — | **add** |
+| `Remote` → `Resident` (`Fill`) | — | **add** |
+| `Resident` → `Remote` (`Evict`) | — | **add** |
+| `Compact` / repack | — | **add** |
+| recovery (`Open` on a populated dir) | — | **add — this is a startup-latency SLO** |
+| `Truncate` / `Delete` | — | **add** |
+| `Extents` (the merged query) | — | **add — it replaces five methods; prove it is not slower than the one it replaces on the hot path** |
+
+Rules:
+
+- **Every benchmark reports allocations.** Not one of the current 11 calls `b.ReportAllocs()`.
+- **Keep the custom metrics.** `randwrite_bench_test.go` reports `write-amp` (on-disk bytes ÷
+  payload bytes), `segments` and `intervals`. Write amplification is the number that decides
+  whether this design is viable at all; it belongs on every write-path benchmark.
+- **Baseline discipline.** A change ships only against a recorded before/after on the same
+  hardware. Measurements taken inside Docker Desktop are not admissible — it inflates DB
+  round-trips ~2.7x and has already produced one wrong headline number in this codebase.
+- **`Extents` needs a defence.** Collapsing `FileSize`/`DataExtents`/`DurableExtent`/
+  `ColdExtents` into one slice-returning query is the design's biggest performance risk:
+  `FileSize` is on the hot read path (`engine/readwrite.go:40,53`) and `ColdExtents` is
+  documented as O(live intervals) and deliberately avoids holding all shard locks at once.
+  `Size` stays separate for exactly this reason; benchmark it and keep the receipts.
+
+## 11. Open decisions
+
+1. **Name — DECIDED: `pier`.** One syllable, unambiguous to spell, no collision anywhere in
+   the tree, and it follows the coined-name convention of Go storage libraries (`bolt`,
+   `badger`, `pebble`, `pogreb`, `moss`).
+
+   **The metaphor, which is load-bearing:** bytes park in a *container* on the *pier* until a
+   *boat* carries them out to the object store. A pier is definitionally a waiting place, never
+   a destination — which is exactly the thing this component must never be confused about, and
+   exactly what every bug in §2 got wrong. The metaphor is also bidirectional, matching the
+   real data flow: goods stage on a pier before loading (`Flush`) and land on it after
+   unloading (`Fill`).
+
+   It also makes the `Sync`/`Flush` pair intuitive rather than merely conventional: `Sync`
+   bolts the container down so a storm cannot take it (durable locally); `Flush` puts it on the
+   boat (durable remotely). Two different guarantees, two different words, one picture.
+
+   Rejected: `blockcache` — `block` is the most overloaded word in the tree (`pkg/block`,
+   `block.Store`, `BlockSink`, `BlockID`, `blockcodec`), and a DB "block cache" is a
+   fixed-size-page buffer pool, which this is not. `journal` — in filesystems that means a
+   metadata write-ahead log for crash consistency; this is the data store itself, and the
+   misnomer is part of why `GC` was read as touching remote refcounts. Also considered:
+   `blobcache`, `rangecache`, `seglog`, `molo`, `rada`, `hopper`, `sluice`, `till`, `scree`.
+
+   **TODO before any public release:** verify the module path is free on `pkg.go.dev` and the
+   proxy. Not checked as of this writing.
+2. **`Files()`** exists so the caller drives a per-file flush loop. A `Flush` that walks
+   eligible files itself would delete it — but then the library owns scheduling policy, which
+   `engine/carve_dispatch.go`'s upload window currently does well. Recommend keeping `Files()`.
+3. **`Restore`.** "Rewind to LSN V" is generic, but it is ~180 lines, gocyclo 37, and has zero
+   tests. Keep and test, or move out? Recommend keep + test. Note the S2 restore-to-zeros bug
+   was exactly `Restore` leaving ranges `StateAbsent` that should have been `StateRemote` — a
+   good validation case for the model.
+4. **`Run` naming** — `Region` reads more clearly standalone; `Run` is the interval-literature
+   term and matches existing code.
+5. **Repo split: NOT NOW.** One consumer; fix history spans journal+engine (#1872 was one
+   defect touching both — across a module boundary that is a two-PR release dance); and the DBS
+   SDK reorg is about to move the thing on the other side of the remote seam. Trigger to
+   revisit: a second real consumer.
+
+## 12. Deliberately out of scope
+
+Gaps identified against mature implementations of this component class, recorded so they are
+not silently forgotten — none are prerequisites for the extraction:
+
+- **Degraded write-through** when local disk is full/unhealthy (bypass cache, write straight to
+  remote). Today: block, then `ErrFull`. This is the difference between degraded and down.
+- **Continuous background scrub** re-verifying resident ranges against CRCs and demoting
+  mismatches. Detector exists (#1882); #2076 records that it never runs on its own.
+- **Content-addressed local tier** — knowingly given up in the switchover, which is why
+  local-only clone is an O(n) copy rather than a refcount bump (#1795).
+- **Fetch as a scheduled, coalescing, prioritised queue** rather than serial demand (#1625).
+- **Preferential draining to empty whole segments of dirtiness**, so eviction always has
+  candidates (the policy JuiceFS gets structurally by splitting `rawstaging/` from `raw/`).
+
+## 13. What not to change
+
+Shared append-only segments over file-per-object (the reason small-file workloads survive);
+interval index with LSN newest-wins; group-commit fsync with a shared watermark (uncommon and
+correct); segment-granularity eviction (imprecise but fragmentation-free); and `DurableExtent`,
+which is the best idea in the package and the thing a README should lead with.
+
+## 14. Repo-wide documentation update
+
+The rename and the split are not done until the docs describe them. Every surface below
+currently describes "the journal" and its "carve pass"; both words are being retired.
+
+**Files to rewrite** (all confirmed to mention the journal today):
+
+| File | What changes |
+|---|---|
+| `docs/internals/architecture.md:245-330` | The "Block Store — Local Journal Tier" section. It explicitly defers to the package doc comment as authoritative, so it inherits every drift — rewrite as the four-part model (pier / crane / ferry / orchestration) with the data-flow diagram from §5.0. |
+| `docs/guide/durability.md` | fsync semantics and the loss window. Should now be able to state exposure exactly (`Sync` = durable here, `ferry.Put` = durable there) instead of describing it prose-wise. |
+| `docs/guide/configuration.md:298-325` | Journal-as-substrate-of-`fs`, plus the vestigial pre-journal knobs it already flags (`use_append_log`, `rollup_workers`, `stabilization_ms`, `orphan_log_min_age_seconds`). Delete the vestigial ones or say plainly that they do nothing. |
+| `docs/internals/implementing-stores.md:311-490` | Points implementers at `pkg/block/journal/` as the model to study. Repoint at pier, and at `piertest/` as the conformance suite they must pass. |
+| `docs/guide/snapshots.md:505` | Snapshot/restore now rests on `pier.Version`/`Pin`/`Restore`. |
+| `docs/guide/block-store-migration.md:22-31` | Tier vocabulary. |
+| `docs/guide/faq.md` | Known limitations — add the §12 gaps (no degraded write-through, no background scrub) so they are stated rather than discovered. |
+| `docs/BENCHMARKS.md` | Three journal mentions; repoint at the §10 benchmark set. |
+| `docs/internals/contributing.md:298-307` | "run the journal package tests" -> the three libraries' suites plus the conformance suite. |
+| `CLAUDE.md` | The Architecture-invariants section names the journal and its rules. Invariants 4, 5 and 6 change shape. |
+| `README.md` | If the feature matrix or architecture summary names the journal. |
+
+**Three READMEs that do not exist yet** — `pier/`, `crane/`, `ferry/`. Each is the front door of
+a would-be OSS repo, so each needs: what it is in one sentence, the model, a runnable example,
+the guarantees it makes, and the guarantees it explicitly does NOT make. pier's should lead with
+exposure accounting (`DurableExtent`), which is its best idea and the thing the field lacks.
+
+**Do NOT rewrite** `.planning/**` — those are historical records of decisions taken under the
+old vocabulary, and rewriting them destroys the audit trail. `docs/guide/cli.md` is generated by
+`cmd/gendocs`; change the Cobra definitions and regenerate, never hand-edit.
+
+**Grep gate for "done":** `rg -i 'journal|carve' docs/ README.md CLAUDE.md` returns only
+deliberate historical references. No user-facing config key or env var carries either word today
+(verified: yaml/mapstructure tags are clean, `DITTOFS_JOURNAL_ASYNC_COMMIT` is already gone from
+develop), so there is no breaking-change or deprecation story to write — this is docs and
+internals only.
+
+---
+
+## PENDING — to fold into the master plan
+
+Captured so they are not lost while the audit's verify gate and the second seam review complete.
+
+### P1. Test and benchmark contracts apply to ALL THREE libraries
+
+§9 and §10 currently specify pier only. Each library ships its own suite and its own benchmarks,
+because each is a candidate OSS repo:
+
+- **pier** — as specified in §9/§10.
+- **crane** — correctness: boundary stability across buffer splits (the same blob chunked in one
+  call vs. many must produce identical boundaries — this is the property that makes dedup work at
+  all), `Params` validation, `Skip` behaviour, block accumulation to `BlockSize`, `final` drain.
+  Benchmarks: throughput per MiB, allocations per block (target: zero on the boundary path),
+  and boundary-shift resistance under insertion.
+- **ferry** — correctness: ordered completion under concurrency, retry/backoff, partial failure,
+  cancellation, health transitions. Benchmarks: throughput vs. window size, latency
+  distribution, and behaviour under an injected-latency `Store` (no cloud SDK in the test path).
+
+Each repo gets its own import-graph test per §7.4.
+
+### P2. Legacy cleanup across the whole data flow
+
+Requirement: after the refactor lands in-tree, remove **all** legacy code around the data flow —
+not just what the refactor touches.
+
+Measured scope: **339 `legacy`/`Legacy` mentions in non-test `pkg/block/**`**, most of it NOT in
+the journal. Known clusters, to be inventoried properly before sequencing:
+
+- `pkg/block/legacy_cas.go` — migration-only standalone-CAS layout; write/read paths stopped
+  using it at #1493. Consumers are the remote backends' `legacy_cas_migration.go` accessors.
+- `pkg/block/local/fs/legacy_migrate.go` + `materializeLegacy`, called on **every** `WriteAt`
+  and `ReadAt` in `fs.go` — a per-op check for a pre-journal layout.
+- Vestigial config knobs already flagged in `docs/guide/configuration.md:298-325`:
+  `use_append_log`, `rollup_workers`, `stabilization_ms`, `orphan_log_min_age_seconds`.
+- `block.Locator`'s "legacy standalone form"; `block.ContentHash`'s two legacy JSON encodings;
+  `FileChunk`'s multi-row-per-hash tolerance for legacy data.
+- The `cas -> blocks` migration repacker referenced from `engine/carve_dispatch.go`.
+- The dead exported API in §8 (`RemoteStore`, `BlockID`, `PinVersion`, `SegmentLocation`, `GC`).
+- The `FSStore` embed leak and the informal structural interfaces in `engine/flush.go`
+  (`restorer`, `pinner`, `versioner`, `coldSeeder`) and `shares/legacy_verify.go`
+  (`coldSeedTracker`) — two contracts where there should be one.
+
+**Sequencing constraint:** legacy removal is a separate, independently-revertable workstream from
+the refactor. Removing a migration path is irreversible for anyone who has not yet migrated, so
+each removal needs its own answer to "which release forces the migration, and what happens to a
+store that skipped it". The repo's own release history (v0.18/v0.19 tagging off develop) is the
+cautionary note. Do not bundle these into the refactor PRs.

--- a/.planning/2026-09-01-pier-library-design-PLAN.md
+++ b/.planning/2026-09-01-pier-library-design-PLAN.md
@@ -1,11 +1,10 @@
 # pier — target design for extracting `pkg/block/journal` as a library
 
-Status: **DESIGN / NOT APPROVED.** No code written. Audit of the current package
-(`/auditing-ai-codebases`, 7 lenses) still running at time of writing; findings will be
-folded in and may change §5.
+Status: **DESIGN / NOT APPROVED.** No code written. The audit that was still running when this
+was drafted is **complete**, as are the sibling audits of `pkg/block/engine` and the `pkg/block`
+root. All three are folded into the master plan's §12 — read that alongside §5 here.
 
-Baseline commit: `ff14b24cb` (origin/develop). Immutable audit worktree:
-`~/dittofs-worktrees/audit-journal`.
+Baseline commit: `ff14b24cb` (origin/develop). Audited in an immutable detached worktree at that commit.
 
 Naming: **DECIDED — `pier`.** See §11.1 for the rationale and the vocabulary it gives us.
 

--- a/.planning/2026-09-01-pier-library-design-PLAN.md
+++ b/.planning/2026-09-01-pier-library-design-PLAN.md
@@ -167,9 +167,9 @@ var ErrClosed = errors.New("pier: closed")
 type CorruptError struct{ ID FileID; Off, Len int64 } // healable: invalidate + refetch
 ```
 
-### `Flush` — the seam (v4)
+### `Flush` — the seam (v5)
 
-Three earlier drafts were rejected. §4.3 records why, so they are not re-walked.
+Four earlier drafts were rejected. §4.3 records why, so they are not re-walked.
 
 ```go
 func (c *Cache) Flush(ctx context.Context, id FileID, opts FlushOptions,
@@ -218,16 +218,35 @@ would stall every read on the shard.
 **C3 — Deferred credit.** `fn` may return an empty `durable` slice for any number of calls while
 it buffers toward a block. It reports extents whose uploads have **since** completed on a later
 call. Consequence, accepted: for a file with few runs but slow uploads, most flips arrive on the
-`Final` call. `Final` must therefore drain — it blocks until ferry's in-flight set for this file
-resolves.
+`Final` call, which blocks until this file's in-flight uploads resolve.
 
-**C4 — Credit is validated, not trusted.** For every returned extent, pier verifies it is in
-this file's *offered-and-unflipped* set, matching on **(offset, length, version)** — not offset
-alone. A concurrent `WriteAt` bumps the interval's version, and flipping by offset alone would
-mark the *new* bytes synced when the *old* ones were uploaded. That is the #1872 shape exactly.
-Extents failing validation are **dropped, not flipped**, and the drop is logged. Today's
-`flipIdx` cursor (`carve.go:844-865`) makes this class impossible by construction; a free-form
-`[]Extent` reopens it, so the check is mandatory, not defensive.
+**Credit is tracked per `Submit` call, never through a shared stream.** `ferry.Submit` returns a
+future scoped to that one upload; `fn` waits on futures in submission order, exactly as
+`journal/carve_dispatch.go:109-114` chains `prev`/`mine` today. A single shared
+`Completions()` channel CANNOT work: Go delivers each message to exactly one receiver, and
+`engine/carve_dispatch.go:91-127` already flushes many files concurrently, so file B's completion
+would be delivered to file A's `fn` with no `FileID` in `Submit` and no demultiplexer anywhere.
+That loses durability credit silently — the disease this design exists to cure, relocated to the
+transport. See §7.3.
+
+**C4 — Credit is validated per FRAGMENT, not per extent.** pier decomposes each returned
+`(offset, length)` against its own retained snapshot of the fragments it offered, and flips
+**fragment by fragment**, skipping any whose version no longer matches while still flipping every
+sibling that does. This mirrors `flipUpTo` (`carve.go:844-865`), which already validates per live
+interval via `fi.findRecord(iv.fileOff, iv.version)`.
+
+A monolithic (offset, length, version) match on the whole returned extent would be WRONG, and
+routinely so: `splitRuns` (`carve.go:364-375`) groups runs by file-offset adjacency only, never
+by version, so one offered extent can already span differently-versioned fragments *before* any
+race — and a concurrent partial overwrite of one byte (`clamp`, `index.go:53-67`, which preserves
+version on untouched sub-ranges) splits it further. `fn` reports at block/chunk granularity, a
+different partitioning again. Whole-extent matching would forfeit credit for an entire run
+because one unrelated byte moved, on exactly the scattered-write workload this package is tuned
+for (`carve.go:377-387`).
+
+The version check itself is pier's own bookkeeping — `Extent` carries no version field and `fn`
+never sees one. Skipped fragments are logged and stay dirty; the next pass's dedup collapses the
+re-upload to a no-op, so this costs repeated CDC/hash work, not correctness.
 
 **C5 — Partial credit with error.** `fn` may return a non-empty `durable` **together with** a
 non-nil error: "these committed, then I failed." pier flips the validated extents, stops
@@ -246,10 +265,32 @@ already validated, and still calls `AfterFile`. A cancel between the last flip a
 strand superseded rows — the same window today's `ponytail:` marker at `carve.go:335` documents.
 Unchanged, and explicitly not made worse.
 
-**C8 — Buffer lifetime.** `Run`'s `ReaderAt` is valid only for the duration of the `fn` call.
-It reads from a pooled buffer pier reuses on the next call. An implementation that needs the
-bytes longer must copy them — the same contract `BlockSink.CommitBlock` states today
+**C8 — Buffer lifetime, and NO extra copy.** `Run`'s `ReaderAt` is a **lazy pass-through to the
+underlying record reads** — it does NOT pre-materialize into a pier-owned buffer. This is
+deliberate and is the difference between two copies and three:
+
+- today: record -> `buf` (pooled scratch, `carve.go:530`) -> `arena` (`copy`, `:589`). Two hops.
+- pre-materializing would add record -> pier-buf -> fn-scratch -> crane arena. Three.
+- lazy pass-through keeps it at two: `fn` reads straight into its own scratch, then crane copies
+  accepted chunk bytes into its block arena.
+
+`ReaderAt` is valid only for the duration of the `fn` call. An implementation needing the bytes
+longer must copy them — the same contract `BlockSink.CommitBlock` states today
 (`carve.go:100-103`).
+
+**C9 — `fn` and its accumulator MUST be constructed fresh per `Flush` call.** pier cannot enforce
+this and cannot detect a violation: it is chunk-agnostic, so it has no visibility into what `fn`
+does with the bytes. **Caller obligation, stated because it is silent when broken.**
+`engine/carve_dispatch.go:91-127` launches one goroutine per file, gated only by a *count*
+limiter, so files on different shards flush truly concurrently. Today that is safe because
+`packRuns` allocates its chunker (`carve.go:513`) and dispatcher (`:400`) fresh per call. In v5
+that state is `crane.Boxer`, living in the engine's closure — and hoisting it to a
+`Syncer`-lifetime field reads like harmless stateless config while actually interleaving two
+files' bytes into one block. That is cross-file corruption, worse than anything in §2.
+
+**C10 — One `Flush` per file at a time.** Guaranteed by `flushMu` being shard-scoped and
+`shardFor(id)` deterministic, so a manual `SyncNow` racing the periodic pass blocks rather than
+interleaving. Stated once here rather than left to be assembled from C1, C2 and §4.2.
 
 ### 4.2 `AfterFile` is mandatory
 
@@ -268,6 +309,17 @@ That is #1872/#2093 reintroduced by construction, on a timer. A caller-side lock
 alternative: it makes the engine invent a second per-shard scheme with no visibility into pier's
 partitioning. Fold `maybeResetDirtyClock` (`carve.go:920-935`) into `AfterFile` too.
 
+**`AfterFile` needs no parameters beyond the id**: `fn` and `AfterFile` share the caller's closure,
+so the `spans`/`newOffsets` the reap needs are already in scope.
+
+**`DurableTail` supplies residency only.** It answers "is anything durable past this run, and is
+it local or remote" — the `anySyncedFrom`/`warmAt` half of `extendRunToRowEnd` (`carve.go:673-711`).
+It does NOT answer where the manifest row ends: that is `ManifestRowEndAfter`
+(`blocksink.go:190-213`), a metadata-store call pier will never have, so `fn` makes it directly.
+And to re-chunk the tail, `fn` reads it via `pier.ReadAt` — `Run.ReaderAt` is scoped to
+`Run.Extent`, not the tail. A reader would otherwise assume `DurableTail` is self-sufficient and
+go looking for a manifest hook that will never exist.
+
 ### 4.3 Rejected drafts — do not re-walk
 
 | Draft | Shape | Why it failed |
@@ -275,6 +327,7 @@ partitioning. Fold `maybeResetDirtyClock` (`carve.go:920-935`) into `AfterFile` 
 | v1 | one call per run, returns `consumed int64` | Cannot name bytes from an *earlier* call. `packRuns` does not reset `blockFirstRun` per run (`carve.go:442`, `:600-603`), so one block routinely spans runs. Forced either one small object per run, or the caller rebuilding the accumulator. |
 | v2 | pier accumulates to `BlockSize`, calls `fn` per block | Impossible. `carve.go:598-601` closes a block only after a whole chunk is appended, so **block boundaries are always chunk boundaries** — and a chunk-agnostic pier cannot know where a block may legally end. |
 | v3 | v4's shape, but the parameter was named `Block` and pier owned "bounded concurrency" | Two errors: `Block` collides with crane's output type and implies pier understands blocks, which contradicts the chunk-agnostic requirement; and pier-owned concurrency contradicts C1's sequential calling — concurrent calls race over one accumulator. |
+| v4 | v5's shape, but ferry exposed one shared `Completions()` channel, C4 matched whole extents, C8 pre-materialized, and C9/C10 were unstated | `Completions()` is undemultiplexable: Go delivers each message to one receiver, `Submit` carries no `FileID`, and many files flush concurrently — file B's completion reaches file A's `fn`. Whole-extent matching forfeits credit whenever one unrelated byte moves, which is the common case. |
 
 ### 4.4 What still needs proving before code
 
@@ -646,12 +699,21 @@ func New(s Store, o Options) *Ferry
 func (f *Ferry) Put(ctx context.Context, id BlockID, data []byte) error
 func (f *Ferry) Get(ctx context.Context, id BlockID, off, n int64) (io.ReadCloser, error)
 
-// Submit is the asynchronous form: uploads overlap up to the adaptive window, but
-// Completions reports them IN SUBMISSION ORDER. That ordering is exactly what lets
-// pier flip its watermark safely — it is ferry's real contract, not a convenience.
-func (f *Ferry) Submit(ctx context.Context, id BlockID, data []byte, tag any) error
-func (f *Ferry) Completions() <-chan Completion
-type Completion struct { Tag any; Err error }
+// Submit queues an upload and returns a future for THAT CALL ONLY. Uploads overlap
+// up to the adaptive window; the caller waits on futures in submission order, which
+// is what lets pier flip its watermark safely.
+//
+// There is deliberately NO shared Completions() channel. Go delivers each message to
+// exactly one receiver, Submit carries no FileID, and many files flush concurrently
+// (engine/carve_dispatch.go:91-127) — so a shared stream routes one file's completion
+// to another file's callback, silently losing durability credit. Per-call futures make
+// that unrepresentable, and mirror journal/carve_dispatch.go:109-114's prev/mine chain.
+func (f *Ferry) Submit(ctx context.Context, id BlockID, data []byte) (<-chan Completion, error)
+type Completion struct { Err error }
+
+// A window slot is released when the upload RESOLVES — success, exhausted retries, or
+// cancellation — independent of whether anyone reads the returned future. Otherwise a
+// caller blocked in Submit could never free the slot it is waiting for.
 
 func (f *Ferry) Health() Health // drives pier.SetEvictionEnabled when the remote degrades
 

--- a/.planning/2026-09-01-pier-library-design-PLAN.md
+++ b/.planning/2026-09-01-pier-library-design-PLAN.md
@@ -432,7 +432,7 @@ one team and one consumer is real overhead: CI matrices, version skew, cross-cut
 needing two PRs (see #1872, one defect spanning journal and engine). Get the four PACKAGE
 boundaries right in-tree now; promote to modules only when something is actually published.
 `git subtree split` stays mechanical as long as each package's imports stay clean, which is
-exactly what §7.1's import-graph test enforces.
+exactly what §8.1's import-graph test enforces.
 
 `crane` today means chunking AND packing AND uploading AND manifest commit AND flipping records
 — **541 occurrences across 60 non-test files**. The smear is visible in the type name
@@ -744,7 +744,7 @@ GetRange}` — never implemented, never read, `nil` at its one production call s
 | any DittoFS package | **no** | **no** | **no** |
 | any cloud SDK | no | no | **no** — `Store` is injected |
 
-Enforced by the import-graph test in §9.1, in each repo. Only DittoFS imports all three.
+Enforced by the import-graph test in §8.1, in each repo. Only DittoFS imports all three.
 
 ## 8. Findings that motivate this (recon; audit verification pending)
 
@@ -796,12 +796,18 @@ fails**. Two contracts exist, one declared and one informal.
 **Requirement: `pier`'s test suite must pass with zero imports outside stdlib + `golang.org/x/sys`.**
 Not as a policy — as a test.
 
-### 7.1 The enforcing mechanism
+### 8.1 The enforcing mechanism
 
 ```go
 // TestNoForeignImports fails if pier's non-test OR test files import anything
 // outside the standard library and golang.org/x/sys.
-func TestNoForeignImports(t *testing.T) { /* go/packages walk over the package */ }
+func TestNoForeignImports(t *testing.T) {
+    // go/build is STDLIB and reports Imports + TestImports for a directory.
+    // Deliberately not go/packages: that lives in golang.org/x/tools, which is
+    // exactly what this test forbids — it would fail itself.
+    pkg, err := build.ImportDir(".", 0)
+    ...
+}
 ```
 
 This is the whole point. `doc.go`'s "depends only on the standard library plus a pair of narrow
@@ -820,7 +826,7 @@ Today's violations, all removable:
 | `lukechampine.com/blake3` | `carve.go:558` (one call) | leaves with crane |
 | `badgerstore` (**test**) | `carve_pack_test.go:11`, used only by `BenchmarkCarveScatteredPass` | latency-injecting fake `Deduper`; the real-Badger measurement belongs in DittoFS's suite, not the library's |
 
-### 7.2 Coverage gaps to close
+### 8.2 Coverage gaps to close
 
 Six exported methods have **zero** test call sites across all 29 test files — package coverage
 of 79.2% hides every one:
@@ -836,7 +842,7 @@ remote-durable files and zero-filling cold ranges. Pending verification, but it 
 **Every new regression test must be run against a deliberately broken build before it is
 trusted.** A test that passes on unmodified code proves nothing about the bug it claims to pin.
 
-### 7.3 What a standalone suite needs that this one lacks
+### 8.3 What a standalone suite needs that this one lacks
 
 1. **One canonical harness.** Six near-duplicate store-openers exist today — `testStore`,
    `carveStore`, `evictStore`, `ctrlStore`, `openDirtyExpireStore`, `benchStore` — each
@@ -1014,7 +1020,7 @@ because each is a candidate OSS repo:
   cancellation, health transitions. Benchmarks: throughput vs. window size, latency
   distribution, and behaviour under an injected-latency `Store` (no cloud SDK in the test path).
 
-Each repo gets its own import-graph test per §7.4.
+Each repo gets its own import-graph test per §8.1.
 
 ### P2. Legacy cleanup across the whole data flow
 

--- a/.planning/2026-09-01-pier-library-design-PLAN.md
+++ b/.planning/2026-09-01-pier-library-design-PLAN.md
@@ -140,7 +140,7 @@ func (c *Cache) Stats() Stats
 
 // ── transitions ──
 func (c *Cache) Flush(ctx context.Context, id FileID, opts FlushOptions,
-        fn func(context.Context, Block) (durable []Extent, err error)) error
+        fn func(context.Context, Run) (durable []Extent, err error)) error
 func (c *Cache) Evict(ctx context.Context, targetBytes int64) (Reclaimed, error)
 func (c *Cache) Invalidate(ctx context.Context, id FileID, off, length int64) error
 func (c *Cache) Seed(ctx context.Context, seeds []Seed) error
@@ -167,119 +167,126 @@ var ErrClosed = errors.New("pier: closed")
 type CorruptError struct{ ID FileID; Off, Len int64 } // healable: invalidate + refetch
 ```
 
-### `Flush` — the seam, corrected after adversarial review
+### `Flush` — the seam (v4)
 
-**The first draft of this section was wrong and was rejected.** It defined the callback as
-one-call-per-dirty-run returning `consumed int64`. See §4.2.
+Three earlier drafts were rejected. §4.3 records why, so they are not re-walked.
 
 ```go
-// Block is one committed unit — what today is exactly one CommitBlock.
-// It may span several dirty runs; that is the point.
-type Block struct {
+func (c *Cache) Flush(ctx context.Context, id FileID, opts FlushOptions,
+        fn func(ctx context.Context, r Run) (durable []Extent, err error)) error
+
+// Run is one offer: a contiguous dirty region of one file, plus its bytes.
+// It is NOT a block. pier does not know what a block is — that is the whole
+// point of being chunk-agnostic. crane turns Runs into Blocks.
+type Run struct {
     ID          FileID
-    Extents     []Extent // dirty extents this block covers, ascending, MAY SPAN RUNS
-    DurableTail []Extent // contiguous already-durable extents after the last one:
-                         // both Resident AND Remote, because a clobbered row's owed
+    Extent      Extent   // the dirty region being offered
+    DurableTail []Extent // contiguous already-durable extents immediately after:
+                         // BOTH Resident and Remote, because a clobbered row's owed
                          // range can straddle evicted bytes (carve.go:749 unions both)
-    io.ReaderAt          // bytes, addressed by file offset
+    Final       bool     // last call for this file; drain anything buffered
+    io.ReaderAt          // the run's bytes, addressed by file offset
 }
-```
 
-`fn` returns **the extents it actually made durable**, and may return a non-empty slice
-*together with* an error. `pier` flips exactly those, then stops. That is what expresses
-"committed 3 of 5 chunks, then failed" — which `consumed int64` could not, because credit is
-not always a prefix.
-
-Division of labour:
-
-| Owns | What |
-|---|---|
-| **pier** | what is dirty, run grouping, age/size gating, the version fence, watermark-ordered flip, crash safety. **Calls `fn` STRICTLY SEQUENTIALLY** — one file, one run at a time, ascending offset; call N+1 does not start until call N returns |
-| **crane** | chunk boundaries, accumulating chunks into `BlockSize` blocks |
-| **ferry** | ALL upload concurrency: bounded window, retry, ordered completion |
-| **DittoFS** | dedup oracle, manifest rows, scheduling |
-
-**pier does NOT accumulate blocks.** Verified at `carve.go:598-601`: the `batchBytes >=
-CarveBlockSize` flush fires *after* a whole chunk is appended, so a block boundary is always a
-chunk boundary. Block accumulation is therefore downstream of chunking, and pier — which must
-stay chunk-agnostic so a consumer can ingest blobs it never chunks — cannot know where a block
-may legally end.
-
-The seam that permits this: **`fn` may return an empty `durable` slice.** It is called once per
-dirty run and buffers internally; when it has a block's worth it uploads and returns those
-extents; pier flips exactly those, in order. A final call with `Block.Final == true` drains the
-partial batch — the same `final bool` pattern `chunker.Next(data []byte, final bool)` already
-uses.
-
-This answers the review's "the caller rebuilds the accumulator by hand" objection: it does not.
-The accumulator **is** the crane library — published, tested, reusable — not hand-rolled closure
-state.
-
-`manifestRowEnder`, `supersededReaper` and `clobberGuard` still evaporate: the first becomes
-`DurableTail`, and the other two become the caller calling its own manifest — the reap once
-after `Flush` returns, using spans its closure recorded across `fn` calls.
-
-### v3.1 — four changes required by the second review
-
-**1. Calls are sequential; upload concurrency lives in ferry.** v3 said pier owned "bounded
-concurrency" AND that `fn` buffers internally across calls. Those contradict: concurrent calls
-to one accumulator race over which run's bytes land in which block, and break the reap's
-contiguous-prefix assumption (`carve_pack.go:16-24`). Today's code already splits them — packing
-is single-goroutine (`carve.go:397-408`: "packing itself stays sequential"), only commit+flip is
-dispatched concurrently (`carve_dispatch.go`). v3.1 keeps that split, along module lines:
-
-- pier calls `fn` sequentially, ascending offset, one file at a time.
-- `fn` submits uploads into ferry's bounded window and returns `(nil, nil)`.
-- `fn` reports extents whose uploads have SINCE completed, on a later call.
-- the `Final` call drains ferry's in-flight set and returns the remainder.
-
-So `CarveUploadConcurrency` maps to **`ferry.Options.MaxConcurrent`, never `FlushOptions`** —
-§5.0's rename table said `FlushOptions`; that was wrong.
-
-**2. pier MUST validate extent provenance before flipping.** Today `flipUpTo` walks only the
-`run []interval` it was handed, advancing `flipIdx` (`carve.go:844-865`) — structurally incapable
-of flipping something it was not given. A free-form `durable []Extent` reopens that class: a
-buggy `fn` (bad offset maths, wrong file, an extent re-sent after cancellation) could flip a
-range pier never offered. pier must check every returned extent against this file's
-offered-and-unflipped set and reject the rest. **New required surface, not carried over.**
-
-**3. `Block.DurableTail` is computed per call, lazily** — matching `anySyncedFrom`'s gate
-(`carve.go:684`), NOT eagerly for the whole file, which is precisely what
-`extendRunToRowEnd`'s comment (`carve.go:469-483`) exists to avoid.
-
-**4. `FlushOptions.AfterFile` is MANDATORY — the reap is unsafe outside the lock.**
-
-The race fires on a predictable 2-second cadence, not adversarial timing.
-`engine/carve_dispatch.go:33-58` runs a pass per file every `UploadInterval` (default 2s), and
-manual `SyncNow` is a second trigger, so any pass outlasting one tick is re-entered. Today only
-`sh.carveMu` prevents overlap, and it is held across BOTH flip and reap (`carve.go:274-360`).
-Release it at `Flush` return and:
-
-1. `Flush(X)` packs, flips, returns; the caller's closure holds `spans`/`newOffsets`.
-2. The next tick starts `Flush(X)` again — the lock that held passes apart is gone.
-3. Pass 2 carves new dirty bytes inside pass 1's about-to-be-reaped span, commits a row.
-4. Pass 1's delayed reap runs against `newOffsets` captured before pass 2 existed, does not
-   recognise pass 2's row as its own, and **deletes a load-bearing row.**
-
-That is #1872/#2093 reintroduced by construction, on a timer. Therefore:
-
-```go
 type FlushOptions struct {
-    // AfterFile runs once per file after the last flip, WHILE pier still holds the
-    // shard's flush lock. The manifest reap goes here. Not optional: a caller that
-    // reaps after Flush returns reintroduces the race above.
+    MaxAge time.Duration // dirty-age eligibility gate
+    MinSize int64        // dirty-bytes eligibility gate
+
+    // AfterFile runs once per file after the last flip, WHILE pier still holds
+    // the shard's flush lock. The manifest reap goes here. MANDATORY — see §4.2.
     AfterFile func(ctx context.Context, id FileID) error
 }
 ```
 
-A caller-side lock is the wrong alternative — it makes the engine invent a second per-shard
-locking scheme with no visibility into pier's partitioning. Fold `maybeResetDirtyClock`
-(`carve.go:920-935`) in too, for symmetry; it is low-risk either way.
+**No `Concurrency` field.** All upload concurrency lives in ferry. pier is sequential.
 
-**Confirmed sound by the same review:** `durable []Extent` does express the pinned partial-credit
-tests (`TestCarvePackFlipPlanWatermarks`, `TestCarvePackSpanningBlockFailureReapsTheCommittedPrefix`),
-and crash-safety between individual flips is no weaker than today's `flipUpTo` — unflipped
-extents stay dirty and the dedup oracle collapses the re-upload.
+### 4.1 The contract, stated completely
+
+Everything below was implicit in v3.1 and is load-bearing.
+
+**C1 — Call ordering.** `fn` is called **strictly sequentially** for one file: one run at a
+time, ascending file offset, and call N+1 does not begin until call N returns. Block boundaries
+depend on it (a block is closed by accumulated size, and the accumulator is `fn`'s), and so does
+the reap's contiguous-prefix assumption (`carve_pack.go:16-24`).
+
+**C2 — Locks held when `fn` runs.** pier holds the shard's `flushMu` (which serializes passes
+for that shard) and **does NOT hold `sh.mu`**, the index lock. This mirrors today exactly:
+`sh.mu` is taken and released in short sections (`carve.go:239-240`, `:275-285`) and the sink
+call at `:449` runs outside it. `fn` performs network I/O; holding the index lock across it
+would stall every read on the shard.
+
+**C3 — Deferred credit.** `fn` may return an empty `durable` slice for any number of calls while
+it buffers toward a block. It reports extents whose uploads have **since** completed on a later
+call. Consequence, accepted: for a file with few runs but slow uploads, most flips arrive on the
+`Final` call. `Final` must therefore drain — it blocks until ferry's in-flight set for this file
+resolves.
+
+**C4 — Credit is validated, not trusted.** For every returned extent, pier verifies it is in
+this file's *offered-and-unflipped* set, matching on **(offset, length, version)** — not offset
+alone. A concurrent `WriteAt` bumps the interval's version, and flipping by offset alone would
+mark the *new* bytes synced when the *old* ones were uploaded. That is the #1872 shape exactly.
+Extents failing validation are **dropped, not flipped**, and the drop is logged. Today's
+`flipIdx` cursor (`carve.go:844-865`) makes this class impossible by construction; a free-form
+`[]Extent` reopens it, so the check is mandatory, not defensive.
+
+**C5 — Partial credit with error.** `fn` may return a non-empty `durable` **together with** a
+non-nil error: "these committed, then I failed." pier flips the validated extents, stops
+offering runs for this file, and **still calls `AfterFile`** — because the committed prefix must
+be reaped. `TestCarvePackSpanningBlockFailureReapsTheCommittedPrefix` pins exactly this. Then
+`Flush` returns the error; remaining dirty ranges stay dirty for the next pass, where the dedup
+oracle collapses any re-upload.
+
+**C6 — Backpressure.** If ferry's window is full, `fn` blocks in `Submit`, which stalls pier's
+sequential loop while `flushMu` is held. **Not a regression** — today's uploads run under
+`carveMu` for the same duration — but it means a slow remote delays that shard's next flush
+pass, not its reads or writes. `ctx` is the escape hatch.
+
+**C7 — Cancellation.** On `ctx` cancellation pier stops offering runs, flips whatever was
+already validated, and still calls `AfterFile`. A cancel between the last flip and the reap can
+strand superseded rows — the same window today's `ponytail:` marker at `carve.go:335` documents.
+Unchanged, and explicitly not made worse.
+
+**C8 — Buffer lifetime.** `Run`'s `ReaderAt` is valid only for the duration of the `fn` call.
+It reads from a pooled buffer pier reuses on the next call. An implementation that needs the
+bytes longer must copy them — the same contract `BlockSink.CommitBlock` states today
+(`carve.go:100-103`).
+
+### 4.2 `AfterFile` is mandatory
+
+The reap cannot move outside the lock. `engine/carve_dispatch.go:33-58` runs a pass per file
+every `UploadInterval` (default 2s), and manual `SyncNow` is a second trigger, so any pass
+outlasting one tick is re-entered. Today only `sh.carveMu` holds passes apart, and it covers
+BOTH the flip and the reap (`carve.go:274-360`). Release it at `Flush` return and:
+
+1. `Flush(X)` packs, flips, returns; the caller's closure holds `spans`/`newOffsets`.
+2. The next tick starts `Flush(X)` again — the lock that held passes apart is gone.
+3. Pass 2 commits a fresh manifest row inside pass 1's about-to-be-reaped span.
+4. Pass 1's delayed reap runs against a `newOffsets` captured before pass 2 existed, does not
+   recognise pass 2's row as its own, and **deletes a load-bearing row.**
+
+That is #1872/#2093 reintroduced by construction, on a timer. A caller-side lock is the wrong
+alternative: it makes the engine invent a second per-shard scheme with no visibility into pier's
+partitioning. Fold `maybeResetDirtyClock` (`carve.go:920-935`) into `AfterFile` too.
+
+### 4.3 Rejected drafts — do not re-walk
+
+| Draft | Shape | Why it failed |
+|---|---|---|
+| v1 | one call per run, returns `consumed int64` | Cannot name bytes from an *earlier* call. `packRuns` does not reset `blockFirstRun` per run (`carve.go:442`, `:600-603`), so one block routinely spans runs. Forced either one small object per run, or the caller rebuilding the accumulator. |
+| v2 | pier accumulates to `BlockSize`, calls `fn` per block | Impossible. `carve.go:598-601` closes a block only after a whole chunk is appended, so **block boundaries are always chunk boundaries** — and a chunk-agnostic pier cannot know where a block may legally end. |
+| v3 | v4's shape, but the parameter was named `Block` and pier owned "bounded concurrency" | Two errors: `Block` collides with crane's output type and implies pier understands blocks, which contradicts the chunk-agnostic requirement; and pier-owned concurrency contradicts C1's sequential calling — concurrent calls race over one accumulator. |
+
+### 4.4 What still needs proving before code
+
+1. **C3's latency.** Deferring most flips to `Final` on upload-bound files is accepted in theory.
+   Measure it: dirty-byte residency and time-to-flip vs. today, on a scattered-write workload.
+2. **C4's cost.** A per-extent index lookup replaces a cursor advance. Bounded by `sort.Search`
+   like `findRecord`, it should be negligible; benchmark against `BenchmarkCarveScatteredPass`.
+3. **The whole seam against the pinned tests.** `TestCarvePackFlipPlanWatermarks`,
+   `TestCarvePackSpanningBlockFailureReapsTheCommittedPrefix`,
+   `TestCarvePackSeamRunFailureLeavesSuffixDirty`, `TestCarveCommitStrictlyBeforeFlip` must all
+   be expressible and passing. Port them **before** rewriting the implementation.
+
 
 ### Method-count delta
 

--- a/docs/internals/rfc-block-dataflow.md
+++ b/docs/internals/rfc-block-dataflow.md
@@ -18,9 +18,12 @@ Three audits — `pkg/block/journal`, `pkg/block/engine` and the `pkg/block` roo
 with an adversarial verify gate, 204 agents over 19,632 LOC — produced **196 findings: 7 HIGH,
 23 MED, 117 LOW**. The bug count is not the interesting part. The shape is:
 
-> **Every one of the five distinct HIGH findings is a residency-truth failure** — the cache's
-> map of what it holds disagreeing with what it actually holds, resolving either to zeros or to
-> reclaiming live data. Not one is a throughput, eviction-policy or chunking bug.
+> **Every one of the journal audit's five distinct HIGH findings is a residency-truth failure**:
+> the cache's map of what it holds disagreeing with what it actually holds, resolving either to
+> zeros or to reclaiming live data. Not one is a throughput, eviction-policy or chunking bug.
+
+(Six HIGH were filed against the journal, five of them distinct defects; the engine audit adds a
+seventh, #2238, discussed below. Hence 7 HIGH in total but five in the claim above.)
 
 That is also the signature of the entire prior field history — #1850, #1879, #1888, #2084,
 #1872/#2073/#2093, #1956, #2110. Ten incidents, one defect class, over a year.

--- a/docs/internals/rfc-block-dataflow.md
+++ b/docs/internals/rfc-block-dataflow.md
@@ -4,7 +4,8 @@
 **Discussion:** https://github.com/marmos91/dittofs/discussions/2234
 **Detail:** `.planning/2026-09-01-block-dataflow-MASTER-PLAN.md` (plan),
 `.planning/2026-09-01-pier-library-design-PLAN.md` (design),
-`.planning/2026-09-01-journal-audit-report.md` (59 verified audit findings).
+`.planning/2026-09-01-journal-audit-report.md`, `-engine-audit-report.md` and
+`-block-root-audit-report.md` (196 verified findings across the three).
 
 If you are about to work in `pkg/block/`, read this first — it describes where that code is
 going, and retires two words (`journal`, `carve`) that currently mean several things each.
@@ -13,8 +14,9 @@ going, and retires two words (`journal`, `carve`) that currently mean several th
 
 ## 1. Why
 
-An audit of `pkg/block/journal` (7 lenses, 70 agents, adversarially verified) produced 59
-findings: 6 HIGH, 8 MED, 45 LOW. The bug count is not the interesting part. The shape is:
+Three audits — `pkg/block/journal`, `pkg/block/engine` and the `pkg/block` root, each 7 lenses
+with an adversarial verify gate, 204 agents over 19,632 LOC — produced **196 findings: 7 HIGH,
+23 MED, 117 LOW**. The bug count is not the interesting part. The shape is:
 
 > **Every one of the five distinct HIGH findings is a residency-truth failure** — the cache's
 > map of what it holds disagreeing with what it actually holds, resolving either to zeros or to
@@ -23,7 +25,20 @@ findings: 6 HIGH, 8 MED, 45 LOW. The bug count is not the interesting part. The 
 That is also the signature of the entire prior field history — #1850, #1879, #1888, #2084,
 #1872/#2073/#2093, #1956, #2110. Ten incidents, one defect class, over a year.
 
-The five HIGHs are filed as #2227, #2228, #2229, #2230, #2231.
+The five journal HIGHs are filed as #2227, #2228, #2229, #2230, #2231.
+
+The engine audit added a sixth, **#2238**, which extends the class rather than repeating it: a
+new file dedups onto a past-grace orphaned hash, writing only a manifest row that the GC's
+already-taken mark snapshot cannot see, and the sweep frees the only durable copy. Where the
+journal's five are disagreements *at rest*, this is a time-of-check/time-of-use race — every view
+individually correct, read at different instants. **Making the states explicit is necessary and
+not sufficient; the model has to pin transitions under concurrency too.**
+
+One caveat worth stating plainly rather than burying: the extraction moves roughly 500 of
+engine's 11,304 LOC, and #2238 lives in `gc_sweep_index.go`, which does not move. GC, reclaim,
+manifest check/repair and cold-read resolution all stay. The split is still worth doing, but it
+does not by itself reach the newest instance of the class that justifies it — which is why that
+work is sequenced *before* the API boundary hardens.
 
 Three of the five live in `RestoreToVersion` — a 180-line, gocyclo-37 method with **zero test
 call sites** across all 29 test files. Package coverage is 79.2% and hides that completely.
@@ -155,7 +170,7 @@ step 3, taken last.
 
 | Step | What | Risk |
 |---|---|---|
-| **0** | Fix #2227-#2231 with regression tests first | live bugs, unblocks everything |
+| **0** | Fix #2227-#2231 and #2238 with regression tests first | live bugs, unblocks everything |
 | **1** | ferry — upload transport, ordered completion | behaviour-preserving |
 | **2** | crane — chunking + block assembly | behaviour-preserving |
 | **3** | pier — the seam inversion and state model | the real change |
@@ -179,4 +194,4 @@ The parts most likely to be wrong, and where comment is most useful:
    The remainder still needs a benchmark to defend it.
 3. **Whether `RestoreToVersion` belongs in pier at all** — 180 lines, gocyclo 37, zero tests,
    three of the five HIGH findings.
-4. **Anything in the 45 LOW findings** you think is actually a MED or HIGH.
+4. **Anything in the 117 LOW findings** you think is actually a MED or HIGH.

--- a/docs/internals/rfc-block-dataflow.md
+++ b/docs/internals/rfc-block-dataflow.md
@@ -1,0 +1,182 @@
+# RFC: splitting the block data flow into pier, crane and ferry
+
+**Status:** proposed, open for comment. Nothing here is built.
+**Discussion:** see the linked GitHub Discussion for open questions.
+**Detail:** `.planning/2026-09-01-block-dataflow-MASTER-PLAN.md` (plan),
+`.planning/2026-09-01-pier-library-design-PLAN.md` (design),
+`.planning/2026-09-01-journal-audit-report.md` (59 verified audit findings).
+
+If you are about to work in `pkg/block/`, read this first — it describes where that code is
+going, and retires two words (`journal`, `carve`) that currently mean several things each.
+
+---
+
+## 1. Why
+
+An audit of `pkg/block/journal` (7 lenses, 70 agents, adversarially verified) produced 59
+findings: 6 HIGH, 8 MED, 45 LOW. The bug count is not the interesting part. The shape is:
+
+> **Every one of the five distinct HIGH findings is a residency-truth failure** — the cache's
+> map of what it holds disagreeing with what it actually holds, resolving either to zeros or to
+> reclaiming live data. Not one is a throughput, eviction-policy or chunking bug.
+
+That is also the signature of the entire prior field history — #1850, #1879, #1888, #2084,
+#1872/#2073/#2093, #1956, #2110. Ten incidents, one defect class, over a year.
+
+The five HIGHs are filed as #2227, #2228, #2229, #2230, #2231.
+
+Three of the five live in `RestoreToVersion` — a 180-line, gocyclo-37 method with **zero test
+call sites** across all 29 test files. Package coverage is 79.2% and hides that completely.
+
+## 2. The core idea
+
+Today a byte range is described by three booleans (`synced`, `cold`, plus "no interval at all").
+The bugs happen in the gaps between them: a range that is *gone* renders identically to a range
+that was *never written*, because both come back as zeros.
+
+Make the states explicit and total, and add the one that has no representation today:
+
+```go
+type State uint8
+const (
+    StateAbsent   State = iota // never written — zeros are CORRECT
+    StateDirty                 // local only; no other copy exists
+    StateResident              // local AND durable remotely; free to reclaim
+    StateRemote                // durable remotely only; fetch to read
+    StateLost                  // written; no copy anywhere; reads MUST fail
+)
+```
+
+`StateLost` is the point. It is the state the bugs kept falling into with nowhere to go, so they
+rendered it as `StateAbsent` and served zeros.
+
+Then every operation is a transition, and the transition table is the specification:
+
+| Operation | Legal transition | The trap it closes |
+|---|---|---|
+| `WriteAt` | `*` → `Dirty` | — |
+| `Flush` | `Dirty` → `Resident` | flip-before-commit (#1872 family) |
+| `Evict` | `Resident` → `Remote` | evicting `Dirty` is data loss (#2228) |
+| `Fill` | `{Absent, Remote}` → `Resident` | overwriting newer local bytes |
+| `Invalidate` | `Resident` → `Remote` | `Dirty` → `Remote` is #2084 exactly |
+| `Seed` | `Absent` → `Remote` | seeding over live local bytes |
+| `Compact` | must never produce `Lost` | #2084, #2093 |
+
+#2084 was `Invalidate` performing `Dirty → Remote` when the only truthful transition was
+`Dirty → Lost`. The shipped fix made it refuse. Here that refusal is the operation's definition,
+not a guard someone remembered to add.
+
+## 3. Three libraries
+
+```
+pier    — stages bytes locally, crash-safe. Chunk-agnostic: you can ingest blobs you
+          never chunk. deps: stdlib + golang.org/x/sys
+
+crane   — cuts content-addressed blocks out of a blob: FastCDC boundaries, BLAKE3
+          identity, accumulation to BlockSize. OPTIONAL. deps: stdlib
+
+ferry   — moves blocks BOTH WAYS: Put (bounded concurrency, retry, ordered completion
+          reporting) and Get/GetRange, which feeds pier.Fill on a cold read.
+          deps: stdlib — the block store itself is injected
+
+dittofs — orchestration and policy: dedup oracle, manifest rows, scheduling.
+```
+
+Data flow — **note the return edge, which is the crash-safety-critical one:**
+
+```
+WRITE                                                    ack ────┐
+  NFS/SMB ──► pier.WriteAt ──► staged locally, StateDirty ───────┘
+
+FLUSH  (dittofs schedules; pier offers, dittofs disposes)
+  pier.Flush(id, fn) ──► offers dirty runs ──► fn:
+                                                crane.Box   cut blocks
+                                                ferry.Put   upload
+                                                dittofs     commit manifest rows
+                          ◄── returns durable []Extent ──────────┘
+  pier flips exactly those ──► StateResident        ← THE INVARIANT LIVES HERE
+
+READ
+  NFS/SMB ──► pier.ReadAt ──► (n, fetch []Extent)
+                 fetch non-empty ──► dittofs resolves manifest
+                                  ──► ferry.Get
+                                  ──► pier.Fill ──► StateResident ──► re-read
+```
+
+Nothing reaches `StateResident` except by pier being **told** what became durable. `Flush` is a
+callback rather than a pipeline stage because a linear `write → carve → sync` has nowhere to put
+that acknowledgement — and dropping it is the #1872 family.
+
+## 4. Vocabulary — one word, one meaning
+
+`carve` currently means chunking AND packing AND uploading AND manifest commit AND flipping
+records: **541 occurrences across 60 non-test files**. The smear is visible in the type name
+`CarveChunk`, which needs two words to say one thing. It is retired, and nothing inherits it.
+
+| Term | Means exactly |
+|---|---|
+| **write** | stage bytes locally and acknowledge the client |
+| **sync** | make durable HERE (fsync) |
+| **flush** | pier's pass: offer dirty runs, accept durability reports |
+| **chunk** | find one content-defined boundary |
+| **box** | group chunks into one block |
+| **put** / **get** | make durable THERE / bring it back |
+
+`journal` goes too: in filesystems that word means a metadata write-ahead log for crash
+consistency. This is the data store itself, and the misnomer is part of why `GC` was read as
+touching remote refcounts (it never did — it is now `Compact`).
+
+## 5. Why libraries, and why not separate repos yet
+
+Designing to the external bar is the forcing function: it is what makes the manifest semantics
+currently hidden in three type-asserted interfaces move to the side that owns them. Each library
+gets a clean public API, its own tests, its own benchmarks, and an **import-graph test** that
+fails if it ever reaches back into DittoFS.
+
+But they stay in this repo for now. One consumer; fix history that spans journal *and* engine
+(#1872 was one defect touching both — across a module boundary that is a two-PR release dance);
+and the block-store SDK on the other side of the remote seam is about to move. `git subtree
+split` stays mechanical as long as the import-graph test passes, so the option costs nothing to
+hold.
+
+**DittoFS will use only the libraries' public APIs.** Today there are two contracts: the declared
+`local.LocalStore` (18 methods) and an informal one reached by embedding `*journal.Store` and by
+unexported structural interfaces (`restorer`, `pinner`, `versioner`, `coldSeeder`,
+`coldRangeReporter`, `coldSeedTracker`). Those assertions **no-op silently on failure** — a
+rename inside pier would quietly disable snapshot pinning rather than break the build. After the
+split, only the construction site may name the concrete type; everything else holds a declared
+interface, so a missing capability is a compile error.
+
+## 6. Plan
+
+**Order: ferry → crane → pier**, reverse of the data flow. Steps 1 and 2 are
+behaviour-preserving — no format change, no state-model change — so all semantic risk lands in
+step 3, taken last.
+
+| Step | What | Risk |
+|---|---|---|
+| **0** | Fix #2227-#2231 with regression tests first | live bugs, unblocks everything |
+| **1** | ferry — upload transport, ordered completion | behaviour-preserving |
+| **2** | crane — chunking + block assembly | behaviour-preserving |
+| **3** | pier — the seam inversion and state model | the real change |
+| **4** | legacy cleanup across the data flow | separate workstream |
+
+Green bar for every step: unit + race + E2E green, **crash rigs green on both the old and the new
+build** (a rig passing only on the new build proves nothing), benchmarks recorded before/after on
+the same hardware, and every new regression test verified against a deliberately broken build
+before it is trusted.
+
+## 7. Where to push back
+
+The parts most likely to be wrong, and where comment is most useful:
+
+1. **The `Flush` callback seam** (§4 of the design plan). It has already been redesigned twice
+   under adversarial review — v1 could not express blocks spanning multiple dirty runs; v2 put
+   block accumulation in pier, which is impossible because block boundaries are chunk boundaries
+   and pier is chunk-agnostic. v3.1 is the current form. It may still be wrong.
+2. **Collapsing five extent queries into `Extents()`.** `Size` and `DurableExtent` were pulled
+   back out after review showed the durable-frontier walk is not derivable from a flat slice.
+   The remainder still needs a benchmark to defend it.
+3. **Whether `RestoreToVersion` belongs in pier at all** — 180 lines, gocyclo 37, zero tests,
+   three of the five HIGH findings.
+4. **Anything in the 45 LOW findings** you think is actually a MED or HIGH.

--- a/docs/internals/rfc-block-dataflow.md
+++ b/docs/internals/rfc-block-dataflow.md
@@ -1,7 +1,7 @@
 # RFC: splitting the block data flow into pier, crane and ferry
 
 **Status:** proposed, open for comment. Nothing here is built.
-**Discussion:** see the linked GitHub Discussion for open questions.
+**Discussion:** https://github.com/marmos91/dittofs/discussions/2234
 **Detail:** `.planning/2026-09-01-block-dataflow-MASTER-PLAN.md` (plan),
 `.planning/2026-09-01-pier-library-design-PLAN.md` (design),
 `.planning/2026-09-01-journal-audit-report.md` (59 verified audit findings).


### PR DESCRIPTION
Docs-only. No code changes.

An audit of `pkg/block/journal` (7 lenses, 70 agents, adversarially verified) produced **59 findings: 6 HIGH / 8 MED / 45 LOW**. The five distinct HIGH findings are filed as #2227, #2228, #2229, #2230, #2231.

The interesting result is not the count, it's the shape:

> **Every one of the five distinct HIGH findings is a residency-truth failure** — the cache's map of what it holds disagreeing with what it actually holds, resolving either to zeros or to reclaiming live data. Not one is a throughput, eviction-policy or chunking bug.

That's also the signature of the entire prior field history — #1850, #1879, #1888, #2084, #1872/#2073/#2093, #1956, #2110. Ten incidents, one defect class, over a year.

Three of the five live in `RestoreToVersion`, which has **zero test call sites** across all 29 test files. Package coverage is 79.2% and hides it completely.

## What this RFC proposes

1. **An explicit five-state model** with `StateLost` — the state the bugs kept falling into with nowhere to go, so they rendered it as `StateAbsent` and served zeros. Every operation becomes a transition, and the transition table is the specification.
2. **A split into three libraries** with clean public APIs, own tests, own benchmarks, and an import-graph test that fails if they reach back into DittoFS: **pier** (staging), **crane** (block assembly), **ferry** (transport). They stay in this repo for now — designing to the external bar is the forcing function, not the goal.
3. **Retiring two words.** `carve` currently means chunking AND packing AND uploading AND manifest commit AND flipping records — 541 occurrences across 60 non-test files. `journal` means a metadata WAL in every other filesystem, which this is not.
4. **DittoFS uses only public APIs.** Today the engine reaches past `local.LocalStore` via an embed and six unexported structural interfaces whose assertions **no-op silently on failure** — a rename inside the journal would quietly disable snapshot pinning rather than break the build.

## Files

- `docs/internals/rfc-block-dataflow.md` — the RFC, start here
- `.planning/2026-09-01-block-dataflow-MASTER-PLAN.md` — findings mapped to design, sequencing, green bar
- `.planning/2026-09-01-pier-library-design-PLAN.md` — full design: state model, interfaces, folder structure, test/bench contracts
- `.planning/2026-09-01-journal-audit-report.md` — all 59 verified findings

## Where push-back is most useful

The `Flush` callback seam has already been redesigned twice under adversarial review and may still be wrong. See §7 of the RFC for the specific spots.

Nothing is built. Comments welcome on any line.
