### PR TITLE
refactor(metadata): one body per file read instead of four

### DIFF
--- a/pkg/metadata/store/postgres/dialect.go
+++ b/pkg/metadata/store/postgres/dialect.go
@@ -36,4 +36,60 @@ var chunkQueries = storesql.ChunkQueries{
 	EnumerateHashes:    enumerateHashesQuery,
 }
 
+// MapError translates a driver error into an ExportError. It is this
+// package's own mapPgError, reached through the Dialect so a shared body can
+// classify an error without importing the driver that produced it.
+func (dialect) MapError(err error, operation, path string) error {
+	return mapPgError(err, operation, path)
+}
+
+// Files returns the postgres file and directory read statements.
+func (dialect) Files() *storesql.FileQueries { return &fileQueries }
+
+// inodeSelectColumns is the full inode projection GetFile and
+// GetFileByPayloadID share, block-ref aggregate included, in the column order
+// sqlcodec.FileRowToFileWithNlinkAndBlocks scans.
+const inodeSelectColumns = `
+	f.id, f.share_name, ` + inodePathExpr + `,
+	f.file_type, f.mode, f.uid, f.gid, f.size,
+	f.atime, f.mtime, f.ctime, f.creation_time,
+	f.content_id, f.link_target, f.device_major, f.device_minor,
+	f.hidden, f.acl, f.eas, f.object_id,
+	f.deleted_at, f.original_path, f.deleted_by, f.nlink,
+	` + blockRefsAggExpr + `
+`
+
+var fileQueries = storesql.FileQueries{
+	GetFile: `SELECT ` + inodeSelectColumns + ` FROM inodes f
+		WHERE f.id = $1 AND f.share_name = $2`,
+
+	GetChild: `SELECT dc.child_id FROM parent_child_map dc
+		WHERE dc.parent_id = $1 AND dc.child_name = $2`,
+
+	GetParent: `SELECT parent_id FROM parent_child_map WHERE child_id = $1 LIMIT 1`,
+
+	GetLinkCount: `SELECT nlink FROM inodes WHERE id = $1`,
+
+	// f.acl and f.eas are hydrated here so DirEntry.Attr carries them, matching
+	// the Memory and Badger backends: without those columns an ACL-aware caller
+	// iterating a listing would silently fall back to POSIX mode bits. They are
+	// small next to the row itself and save a GetFile per entry.
+	ListChildren: `SELECT dc.child_name, dc.child_id, f.file_type, f.mode, f.uid, f.gid, f.size,
+		       f.atime, f.mtime, f.ctime, f.creation_time, f.hidden, f.acl, f.eas, f.object_id,
+		       f.deleted_at, f.original_path, f.deleted_by, f.nlink
+		FROM parent_child_map dc
+		LEFT JOIN inodes f ON dc.child_id = f.id
+		WHERE dc.parent_id = $1 AND dc.child_name > $2
+		ORDER BY dc.child_name
+		LIMIT $3`,
+
+	// The lookup goes through content_id_hash (an md5 of content_id) because a
+	// content id for a path near PATH_MAX overruns postgres' 2704-byte btree
+	// key limit, which would make the index unusable for the long paths that
+	// need it most.
+	GetFileByPayloadID: `SELECT ` + inodeSelectColumns + ` FROM inodes f
+		WHERE f.content_id_hash = md5($1)
+		LIMIT 1`,
+}
+
 var _ storesql.Dialect = dialect{}

--- a/pkg/metadata/store/postgres/encoding.go
+++ b/pkg/metadata/store/postgres/encoding.go
@@ -1,22 +1,8 @@
 package postgres
 
-import (
-	"github.com/google/uuid"
-	"github.com/marmos91/dittofs/pkg/metadata"
-)
-
 // ============================================================================
-// File Handle Encoding/Decoding
+// Shared SELECT expressions
 // ============================================================================
-
-// encodeFileHandle creates a file handle from share name and UUID string
-func encodeFileHandle(shareName string, idStr string) (metadata.FileHandle, error) {
-	id, err := uuid.Parse(idStr)
-	if err != nil {
-		return nil, err
-	}
-	return metadata.EncodeShareHandle(shareName, id)
-}
 
 // blockRefsAggExpr is a correlated scalar subquery aggregating a file's
 // file_block_refs rows into a single JSON array, ordered by "offset" ASC to

--- a/pkg/metadata/store/postgres/files.go
+++ b/pkg/metadata/store/postgres/files.go
@@ -2,7 +2,6 @@ package postgres
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,59 +11,17 @@ import (
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
-	"github.com/marmos91/dittofs/pkg/metadata/acl"
-	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlcodec"
 )
 
 // ============================================================================
 // CRUD Operations
 // ============================================================================
 //
-// Read operations use direct pool queries for better performance (no transaction overhead).
-// Write operations use WithTransaction for atomicity.
-
-// GetFile retrieves file metadata by handle.
-// Uses direct pool query without transaction for better performance.
-// Returns ErrNotFound if handle doesn't exist.
-func (s *PostgresMetadataStore) GetFile(ctx context.Context, handle metadata.FileHandle) (*metadata.File, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	shareName, id, err := metadata.DecodeFileHandle(handle)
-	if err != nil {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrInvalidHandle,
-			Message: "invalid file handle",
-		}
-	}
-
-	// Fold FileAttr.Blocks into the metadata read via a correlated aggregate
-	// (#1176): one round-trip instead of the metadata SELECT plus a separate
-	// loadFileChunkRefs. blockRefsAggExpr yields NULL for directories,
-	// symlinks, and blockless files, so the decoded slice stays nil for them —
-	// byte-identical to the prior two-query behaviour.
-	query := `
-		SELECT
-			f.id, f.share_name, ` + inodePathExpr + `,
-			f.file_type, f.mode, f.uid, f.gid, f.size,
-			f.atime, f.mtime, f.ctime, f.creation_time,
-			f.content_id, f.link_target, f.device_major, f.device_minor,
-			f.hidden, f.acl, f.eas, f.object_id,
-			f.deleted_at, f.original_path, f.deleted_by, f.nlink,
-			` + blockRefsAggExpr + `
-		FROM inodes f
-		WHERE f.id = $1 AND f.share_name = $2
-	`
-
-	row := s.queryRow(ctx, query, id, shareName)
-	file, err := sqlcodec.FileRowToFileWithNlinkAndBlocks(row, true)
-	if err != nil {
-		return nil, mapPgError(err, "GetFile", "")
-	}
-
-	return file, nil
-}
+// Write operations open a transaction and delegate to its implementation, so
+// each exists once. The handle-addressed reads are shared further still: they
+// live on store/sql.Core, whose methods are promoted onto both this store and
+// its transaction. What is left here is what could not be either — the reads
+// that need store state, and the ones with no transaction-level counterpart.
 
 // UpdateAttrs stores or updates file metadata.
 // Creates the entry if it doesn't exist.
@@ -90,36 +47,6 @@ func (s *PostgresMetadataStore) DeleteFile(ctx context.Context, handle metadata.
 	})
 }
 
-// GetChild resolves a name in a directory to a file handle.
-// Uses direct pool query without transaction for better performance.
-// Returns ErrNotFound if name doesn't exist.
-func (s *PostgresMetadataStore) GetChild(ctx context.Context, dirHandle metadata.FileHandle, name string) (metadata.FileHandle, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	shareName, parentID, err := metadata.DecodeFileHandle(dirHandle)
-	if err != nil {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrInvalidHandle,
-			Message: "invalid directory handle",
-		}
-	}
-
-	query := `
-		SELECT dc.child_id FROM parent_child_map dc
-		WHERE dc.parent_id = $1 AND dc.child_name = $2
-	`
-
-	var childID string
-	err = s.queryRow(ctx, query, parentID, name).Scan(&childID)
-	if err != nil {
-		return nil, mapPgError(err, "GetChild", name)
-	}
-
-	return encodeFileHandle(shareName, childID)
-}
-
 // SetChild adds or updates a child entry in a directory.
 func (s *PostgresMetadataStore) SetChild(ctx context.Context, dirHandle metadata.FileHandle, name string, childHandle metadata.FileHandle) error {
 	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
@@ -135,33 +62,6 @@ func (s *PostgresMetadataStore) DeleteChild(ctx context.Context, dirHandle metad
 	})
 }
 
-// GetParent returns the parent handle for a file/directory.
-// Uses direct pool query without transaction for better performance.
-// Returns ErrNotFound for root directories (no parent).
-func (s *PostgresMetadataStore) GetParent(ctx context.Context, handle metadata.FileHandle) (metadata.FileHandle, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	shareName, childID, err := metadata.DecodeFileHandle(handle)
-	if err != nil {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrInvalidHandle,
-			Message: "invalid file handle",
-		}
-	}
-
-	query := `SELECT parent_id FROM parent_child_map WHERE child_id = $1 LIMIT 1`
-
-	var parentIDStr string
-	err = s.queryRow(ctx, query, childID).Scan(&parentIDStr)
-	if err != nil {
-		return nil, mapPgError(err, "GetParent", "")
-	}
-
-	return encodeFileHandle(shareName, parentIDStr)
-}
-
 // SetParent sets the parent handle for a file/directory.
 //
 // Parent tracking is handled implicitly by parent_child_map via SetChild, so
@@ -172,218 +72,11 @@ func (s *PostgresMetadataStore) SetParent(ctx context.Context, handle metadata.F
 	return ctx.Err()
 }
 
-// GetLinkCount returns the hard link count for a file.
-// Uses direct pool query without transaction for better performance.
-// Returns 0 if the file doesn't exist. nlink is the sole source of truth (#1166).
-func (s *PostgresMetadataStore) GetLinkCount(ctx context.Context, handle metadata.FileHandle) (uint32, error) {
-	if err := ctx.Err(); err != nil {
-		return 0, err
-	}
-
-	_, fileID, err := metadata.DecodeFileHandle(handle)
-	if err != nil {
-		return 0, &metadata.StoreError{
-			Code:    metadata.ErrInvalidHandle,
-			Message: "invalid file handle",
-		}
-	}
-
-	var count uint32
-	err = s.queryRow(ctx, `SELECT nlink FROM inodes WHERE id = $1`, fileID).Scan(&count)
-	if errors.Is(err, pgx.ErrNoRows) {
-		// Not found means count is 0
-		return 0, nil
-	}
-	if err != nil {
-		// A fabricated 0 would let callers treat live content as unreferenced.
-		return 0, mapPgError(err, "GetLinkCount", "")
-	}
-
-	return count, nil
-}
-
 // SetLinkCount sets the hard link count for a file.
 func (s *PostgresMetadataStore) SetLinkCount(ctx context.Context, handle metadata.FileHandle, count uint32) error {
 	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
 		return tx.SetLinkCount(ctx, handle, count)
 	})
-}
-
-// ListChildren returns directory entries with pagination support.
-// Uses direct pool query without transaction for better performance.
-func (s *PostgresMetadataStore) ListChildren(ctx context.Context, dirHandle metadata.FileHandle, cursor string, limit int) ([]metadata.DirEntry, string, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, "", err
-	}
-
-	shareName, parentID, err := metadata.DecodeFileHandle(dirHandle)
-	if err != nil {
-		return nil, "", &metadata.StoreError{
-			Code:    metadata.ErrInvalidHandle,
-			Message: "invalid directory handle",
-		}
-	}
-
-	if limit <= 0 {
-		limit = 1000
-	}
-
-	// Refs #532 (PR #536 review): hydrate f.acl so DirEntry.Attr.ACL is
-	// populated, matching the Memory/Badger backends. Without this column,
-	// access-based enumeration (and any other ACL-aware caller iterating
-	// DirEntry.Attr) silently degrades to POSIX mode bits even on files that
-	// have a DACL set. ACL JSONB rows are typically small relative to the
-	// listing row itself, so the extra column adds negligible per-row cost
-	// versus the per-entry GetFile() round trip it avoids.
-	query := `
-		SELECT dc.child_name, dc.child_id, f.file_type, f.mode, f.uid, f.gid, f.size,
-		       f.atime, f.mtime, f.ctime, f.creation_time, f.hidden, f.acl, f.eas, f.object_id,
-		       f.deleted_at, f.original_path, f.deleted_by, f.nlink
-		FROM parent_child_map dc
-		LEFT JOIN inodes f ON dc.child_id = f.id
-		WHERE dc.parent_id = $1 AND dc.child_name > $2
-		ORDER BY dc.child_name
-		LIMIT $3
-	`
-
-	rows, err := s.query(ctx, query, parentID, cursor, limit+1)
-	if err != nil {
-		return nil, "", mapPgError(err, "ListChildren", "")
-	}
-	defer rows.Close()
-
-	var entries []metadata.DirEntry
-	for rows.Next() && len(entries) < limit {
-		var name, childIDStr string
-		var fileType int16
-		var mode, uid, gid int32
-		var size int64
-		var atime, mtime, ctime, creationTime int64
-		var hidden bool
-		var aclJSON []byte
-		var easJSON []byte
-		var objectIDRaw []byte
-		var deletedAt sql.NullInt64
-		var originalPath string
-		var deletedBy string
-		var linkCount sql.NullInt32
-
-		err := rows.Scan(&name, &childIDStr, &fileType, &mode, &uid, &gid, &size,
-			&atime, &mtime, &ctime, &creationTime, &hidden, &aclJSON, &easJSON, &objectIDRaw,
-			&deletedAt, &originalPath, &deletedBy, &linkCount)
-		if err != nil {
-			return nil, "", err
-		}
-
-		childHandle, err := encodeFileHandle(shareName, childIDStr)
-		if err != nil {
-			return nil, "", err
-		}
-
-		// Determine Nlink value
-		var nlink uint32
-		if linkCount.Valid {
-			nlink = uint32(linkCount.Int32)
-		} else {
-			// Default based on file type
-			if metadata.FileType(fileType) == metadata.FileTypeDirectory {
-				nlink = 2
-			} else {
-				nlink = 1
-			}
-		}
-
-		// hydrate ObjectID for directory entries.
-		// NULL/empty -> zero (sentinel).
-		//
-		// The shape DOES NOT match GetFile in this backend. GetFile populates
-		// FileAttr.Blocks via loadFileChunkRefs; ListChildren intentionally does NOT (per-row
-		// ChunkRef hydration would be a quadratic cost on directory
-		// listings). Memory and Badger backends include Blocks on
-		// DirEntry.Attr because their underlying serialisation already
-		// carries the slice — Postgres' relational model splits
-		// FileAttr.Blocks into a separate table (file_block_refs) and
-		// listing rows skip the join. Callers MUST treat
-		// DirEntry.Attr.Blocks as not-loaded for Postgres and re-read
-		// via GetFile if the ChunkRef list is needed for hot-path
-		// resolution. Current short-circuit code (FindByObjectID-driven)
-		// never consults DirEntry.Attr.ObjectID, so this asymmetry is
-		// benign at the call surface.
-		attr := &metadata.FileAttr{
-			Type:         metadata.FileType(fileType),
-			Mode:         uint32(mode),
-			Nlink:        nlink,
-			UID:          uint32(uid),
-			GID:          uint32(gid),
-			Size:         uint64(size),
-			Atime:        sqlcodec.FiletimeToTime(atime),
-			Mtime:        sqlcodec.FiletimeToTime(mtime),
-			Ctime:        sqlcodec.FiletimeToTime(ctime),
-			CreationTime: sqlcodec.FiletimeToTime(creationTime),
-			Hidden:       hidden,
-		}
-		if len(objectIDRaw) > 0 {
-			if len(objectIDRaw) != block.HashSize {
-				return nil, "", fmt.Errorf(
-					"postgres ListChildren: object_id has invalid length %d (want %d)",
-					len(objectIDRaw), block.HashSize,
-				)
-			}
-			copy(attr.ObjectID[:], objectIDRaw)
-		}
-
-		// Recycle-bin metadata (#190): carried on DirEntry.Attr so trash
-		// enumeration via listing reflects recycle state without a re-read.
-		// deleted_at is BIGINT unix-nanoseconds; decode via sqlcodec.FiletimeToTime.
-		if deletedAt.Valid {
-			t := sqlcodec.FiletimeToTime(deletedAt.Int64)
-			attr.DeletedAt = &t
-		}
-		attr.OriginalPath = originalPath
-		attr.DeletedBy = deletedBy
-
-		// Refs #532 (PR #536 review): mirror sqlcodec.FileRowToFileWithNlink. A
-		// malformed ACL row is treated as "no ACL" rather than failing the
-		// whole listing — same lenient behaviour the GetFile path has had
-		// since the column was introduced.
-		if len(aclJSON) > 0 {
-			var fileACL acl.ACL
-			if err := json.Unmarshal(aclJSON, &fileACL); err == nil {
-				attr.ACL = &fileACL
-			}
-		}
-
-		// Hydrate EAs for directory entries (same lenient unmarshal as ACL).
-		if len(easJSON) > 0 {
-			var eas map[string][]byte
-			if err := json.Unmarshal(easJSON, &eas); err == nil && len(eas) > 0 {
-				attr.EAs = eas
-			}
-		}
-
-		entry := metadata.DirEntry{
-			ID:     metadata.HandleToINode(childHandle),
-			Name:   name,
-			Handle: childHandle,
-			Attr:   attr,
-		}
-
-		entries = append(entries, entry)
-	}
-
-	// Surface any error that terminated the iteration early (e.g. a network
-	// drop mid-stream). Without this check a partial result would be returned
-	// as a complete, successful listing.
-	if err := rows.Err(); err != nil {
-		return nil, "", mapPgError(err, "ListChildren", "")
-	}
-
-	nextCursor := ""
-	if len(entries) >= limit {
-		nextCursor = entries[len(entries)-1].Name
-	}
-
-	return entries, nextCursor, nil
 }
 
 // GetFilesystemMeta retrieves filesystem metadata for a share.
@@ -451,41 +144,6 @@ func (s *PostgresMetadataStore) FindByObjectID(ctx context.Context, objectID blo
 	}
 
 	return s.loadFileChunkRefs(ctx, fileID)
-}
-
-// GetFileByPayloadID retrieves a file by its content ID (used by cache flusher)
-func (s *PostgresMetadataStore) GetFileByPayloadID(ctx context.Context, payloadID metadata.PayloadID) (*metadata.File, error) {
-	if payloadID == "" {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrInvalidArgument,
-			Message: "content ID cannot be empty",
-		}
-	}
-
-	// Use content_id_hash (MD5 of content_id) for index lookup to avoid
-	// PostgreSQL btree 2704-byte limit. The content_id can exceed this limit
-	// for files with paths near PATH_MAX (4096 bytes).
-	query := `
-		SELECT
-			f.id, f.share_name, ` + inodePathExpr + `,
-			f.file_type, f.mode, f.uid, f.gid, f.size,
-			f.atime, f.mtime, f.ctime, f.creation_time,
-			f.content_id, f.link_target, f.device_major, f.device_minor,
-			f.hidden, f.acl, f.eas, f.object_id,
-			f.deleted_at, f.original_path, f.deleted_by, f.nlink,
-			` + blockRefsAggExpr + `
-		FROM inodes f
-		WHERE f.content_id_hash = md5($1)
-		LIMIT 1
-	`
-
-	row := s.queryRow(ctx, query, string(payloadID))
-	file, err := sqlcodec.FileRowToFileWithNlinkAndBlocks(row, true)
-	if err != nil {
-		return nil, mapPgError(err, "GetFileByPayloadID", string(payloadID))
-	}
-
-	return file, nil
 }
 
 // CountObjectIDIndexRows implements the storetest.ObjectIDIndexAccessor

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -12,9 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
-	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
-	"github.com/marmos91/dittofs/pkg/metadata/acl"
 	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlcodec"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/txretry"
@@ -203,55 +201,6 @@ func (s *PostgresMetadataStore) withTransaction(ctx context.Context, fn func(tx 
 // ============================================================================
 // Transaction CRUD Operations
 // ============================================================================
-
-func (tx *postgresTransaction) GetFile(ctx context.Context, handle metadata.FileHandle) (*metadata.File, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	shareName, id, err := metadata.DecodeFileHandle(handle)
-	if err != nil {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrInvalidHandle,
-			Message: "invalid file handle",
-		}
-	}
-
-	// Fold FileAttr.Blocks into the metadata read (#1176): one round-trip
-	// instead of the SELECT plus a separate getFileChunkRefs. See GetFile
-	// (pool path) and blockRefsAggExpr for the equivalence rationale.
-	query := `
-		SELECT
-			f.id, f.share_name, ` + inodePathExpr + `,
-			f.file_type, f.mode, f.uid, f.gid, f.size,
-			f.atime, f.mtime, f.ctime, f.creation_time,
-			f.content_id, f.link_target, f.device_major, f.device_minor,
-			f.hidden, f.acl, f.eas, f.object_id,
-			f.deleted_at, f.original_path, f.deleted_by, f.nlink,
-			` + blockRefsAggExpr + `
-		FROM inodes f
-		WHERE f.id = $1 AND f.share_name = $2
-	`
-
-	row := tx.tx.QueryRow(ctx, query, id, shareName)
-	file, err := sqlcodec.FileRowToFileWithNlinkAndBlocks(row, true)
-	if err != nil {
-		return nil, mapPgError(err, "GetFile", "")
-	}
-
-	// Debug logging to trace file type issues, gated so the id formatting and
-	// variadic boxing are skipped when Debug is off.
-	if tx.store.logger.Enabled(ctx, slog.LevelDebug) {
-		tx.store.logger.Debug("GetFile retrieved",
-			"id", id.String(),
-			"share", shareName,
-			"path", file.Path,
-			"file_type", int(file.Type),
-			"size", file.Size)
-	}
-
-	return file, nil
-}
 
 // UpdateAttrs persists the file's attributes and leaves the stored
 // file_block_refs manifest untouched.
@@ -555,44 +504,6 @@ func (tx *postgresTransaction) DeleteFile(ctx context.Context, handle metadata.F
 	return nil
 }
 
-func (tx *postgresTransaction) GetChild(ctx context.Context, dirHandle metadata.FileHandle, name string) (metadata.FileHandle, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	shareName, parentID, err := metadata.DecodeFileHandle(dirHandle)
-	if err != nil {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrInvalidHandle,
-			Message: "invalid directory handle",
-		}
-	}
-
-	query := `
-		SELECT dc.child_id FROM parent_child_map dc
-		WHERE dc.parent_id = $1 AND dc.child_name = $2
-	`
-
-	var childID string
-	err = tx.tx.QueryRow(ctx, query, parentID, name).Scan(&childID)
-	if err != nil {
-		return nil, mapPgError(err, "GetChild", name)
-	}
-
-	// Debug logging to trace child lookup, gated so the id formatting and
-	// variadic boxing are skipped when Debug is off. GetChild runs once per
-	// path component.
-	if tx.store.logger.Enabled(ctx, slog.LevelDebug) {
-		tx.store.logger.Debug("GetChild found",
-			"parent_id", parentID.String(),
-			"child_name", name,
-			"child_id", childID,
-			"share", shareName)
-	}
-
-	return encodeFileHandle(shareName, childID)
-}
-
 func (tx *postgresTransaction) SetChild(ctx context.Context, dirHandle metadata.FileHandle, name string, childHandle metadata.FileHandle) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -654,216 +565,10 @@ func (tx *postgresTransaction) DeleteChild(ctx context.Context, dirHandle metada
 	return nil
 }
 
-func (tx *postgresTransaction) ListChildren(ctx context.Context, dirHandle metadata.FileHandle, cursor string, limit int) ([]metadata.DirEntry, string, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, "", err
-	}
-
-	shareName, parentID, err := metadata.DecodeFileHandle(dirHandle)
-	if err != nil {
-		return nil, "", &metadata.StoreError{
-			Code:    metadata.ErrInvalidHandle,
-			Message: "invalid directory handle",
-		}
-	}
-
-	if limit <= 0 {
-		limit = 1000
-	}
-
-	// Refs #532 (PR #536 review): hydrate f.acl — keep parity with the
-	// pool-query ListChildren above. See files.go for rationale.
-	query := `
-		SELECT dc.child_name, dc.child_id, f.file_type, f.mode, f.uid, f.gid, f.size,
-		       f.atime, f.mtime, f.ctime, f.creation_time, f.hidden, f.acl, f.eas, f.object_id,
-		       f.deleted_at, f.original_path, f.deleted_by, f.nlink
-		FROM parent_child_map dc
-		LEFT JOIN inodes f ON dc.child_id = f.id
-		WHERE dc.parent_id = $1 AND dc.child_name > $2
-		ORDER BY dc.child_name
-		LIMIT $3
-	`
-
-	rows, err := tx.tx.Query(ctx, query, parentID, cursor, limit+1)
-	if err != nil {
-		return nil, "", mapPgError(err, "ListChildren", "")
-	}
-	defer rows.Close()
-
-	var entries []metadata.DirEntry
-	for rows.Next() && len(entries) < limit {
-		var name, childIDStr string
-		var fileType int16
-		var mode, uid, gid int32
-		var size int64
-		var atime, mtime, ctime, creationTime int64
-		var hidden bool
-		var aclJSON []byte
-		var easJSON []byte
-		var objectIDRaw []byte
-		var deletedAt sql.NullInt64
-		var originalPath string
-		var deletedBy string
-		var linkCount sql.NullInt32
-
-		err := rows.Scan(&name, &childIDStr, &fileType, &mode, &uid, &gid, &size,
-			&atime, &mtime, &ctime, &creationTime, &hidden, &aclJSON, &easJSON, &objectIDRaw,
-			&deletedAt, &originalPath, &deletedBy, &linkCount)
-		if err != nil {
-			return nil, "", err
-		}
-
-		childHandle, err := encodeFileHandle(shareName, childIDStr)
-		if err != nil {
-			return nil, "", err
-		}
-
-		// Determine Nlink value
-		var nlink uint32
-		if linkCount.Valid {
-			nlink = uint32(linkCount.Int32)
-		} else {
-			// Default based on file type
-			if metadata.FileType(fileType) == metadata.FileTypeDirectory {
-				nlink = 2
-			} else {
-				nlink = 1
-			}
-		}
-
-		// hydrate ObjectID for directory entries so the
-		// shape matches GetFile. NULL/empty -> zero (sentinel).
-		attr := &metadata.FileAttr{
-			Type:         metadata.FileType(fileType),
-			Mode:         uint32(mode),
-			Nlink:        nlink,
-			UID:          uint32(uid),
-			GID:          uint32(gid),
-			Size:         uint64(size),
-			Atime:        sqlcodec.FiletimeToTime(atime),
-			Mtime:        sqlcodec.FiletimeToTime(mtime),
-			Ctime:        sqlcodec.FiletimeToTime(ctime),
-			CreationTime: sqlcodec.FiletimeToTime(creationTime),
-			Hidden:       hidden,
-		}
-		if len(objectIDRaw) > 0 {
-			if len(objectIDRaw) != block.HashSize {
-				return nil, "", fmt.Errorf(
-					"postgres ListChildren: object_id has invalid length %d (want %d)",
-					len(objectIDRaw), block.HashSize,
-				)
-			}
-			copy(attr.ObjectID[:], objectIDRaw)
-		}
-
-		// Recycle-bin metadata (#190): carried on DirEntry.Attr so trash
-		// enumeration via listing reflects recycle state without a re-read,
-		// matching the pool-query path. deleted_at is BIGINT unix-nanoseconds;
-		// decode via sqlcodec.FiletimeToTime.
-		if deletedAt.Valid {
-			t := sqlcodec.FiletimeToTime(deletedAt.Int64)
-			attr.DeletedAt = &t
-		}
-		attr.OriginalPath = originalPath
-		attr.DeletedBy = deletedBy
-
-		// Refs #532 (PR #536 review): mirror sqlcodec.FileRowToFileWithNlink — soft
-		// failure on malformed ACL JSON, same as the pool-query path.
-		if len(aclJSON) > 0 {
-			var fileACL acl.ACL
-			if err := json.Unmarshal(aclJSON, &fileACL); err == nil {
-				attr.ACL = &fileACL
-			}
-		}
-
-		// Hydrate EAs for directory entries (same lenient unmarshal as ACL).
-		if len(easJSON) > 0 {
-			var eas map[string][]byte
-			if err := json.Unmarshal(easJSON, &eas); err == nil && len(eas) > 0 {
-				attr.EAs = eas
-			}
-		}
-
-		entry := metadata.DirEntry{
-			ID:     metadata.HandleToINode(childHandle),
-			Name:   name,
-			Handle: childHandle,
-			Attr:   attr,
-		}
-
-		entries = append(entries, entry)
-	}
-
-	// Surface any error that terminated the iteration early (e.g. a network
-	// drop mid-stream). Without this check a partial result would be returned
-	// as a complete, successful listing.
-	if err := rows.Err(); err != nil {
-		return nil, "", mapPgError(err, "ListChildren", "")
-	}
-
-	nextCursor := ""
-	if len(entries) >= limit {
-		nextCursor = entries[len(entries)-1].Name
-	}
-
-	return entries, nextCursor, nil
-}
-
-func (tx *postgresTransaction) GetParent(ctx context.Context, handle metadata.FileHandle) (metadata.FileHandle, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	shareName, childID, err := metadata.DecodeFileHandle(handle)
-	if err != nil {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrInvalidHandle,
-			Message: "invalid file handle",
-		}
-	}
-
-	query := `SELECT parent_id FROM parent_child_map WHERE child_id = $1 LIMIT 1`
-
-	var parentIDStr string
-	err = tx.tx.QueryRow(ctx, query, childID).Scan(&parentIDStr)
-	if err != nil {
-		return nil, mapPgError(err, "GetParent", "")
-	}
-
-	return encodeFileHandle(shareName, parentIDStr)
-}
-
 func (tx *postgresTransaction) SetParent(ctx context.Context, handle metadata.FileHandle, parentHandle metadata.FileHandle) error {
 	// In PostgreSQL, parent is tracked via parent_child_map table
 	// This is already handled by SetChild
 	return nil
-}
-
-func (tx *postgresTransaction) GetLinkCount(ctx context.Context, handle metadata.FileHandle) (uint32, error) {
-	if err := ctx.Err(); err != nil {
-		return 0, err
-	}
-
-	_, fileID, err := metadata.DecodeFileHandle(handle)
-	if err != nil {
-		return 0, &metadata.StoreError{
-			Code:    metadata.ErrInvalidHandle,
-			Message: "invalid file handle",
-		}
-	}
-
-	var count uint32
-	err = tx.tx.QueryRow(ctx, `SELECT nlink FROM inodes WHERE id = $1`, fileID).Scan(&count)
-	if errors.Is(err, pgx.ErrNoRows) {
-		// Not found means count is 0
-		return 0, nil
-	}
-	if err != nil {
-		// A fabricated 0 would let callers treat live content as unreferenced.
-		return 0, mapPgError(err, "GetLinkCount", "")
-	}
-
-	return count, nil
 }
 
 func (tx *postgresTransaction) SetLinkCount(ctx context.Context, handle metadata.FileHandle, count uint32) error {
@@ -1380,41 +1085,3 @@ func (tx *postgresTransaction) GetFilesystemStatistics(ctx context.Context, hand
 // ============================================================================
 // Transaction Files Operations (additional)
 // ============================================================================
-
-func (tx *postgresTransaction) GetFileByPayloadID(ctx context.Context, payloadID metadata.PayloadID) (*metadata.File, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	if payloadID == "" {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrInvalidArgument,
-			Message: "content ID cannot be empty",
-		}
-	}
-
-	// Use content_id_hash (MD5 of content_id) for index lookup to avoid
-	// PostgreSQL btree 2704-byte limit. The content_id can exceed this limit
-	// for files with paths near PATH_MAX (4096 bytes).
-	query := `
-		SELECT
-			f.id, f.share_name, ` + inodePathExpr + `,
-			f.file_type, f.mode, f.uid, f.gid, f.size,
-			f.atime, f.mtime, f.ctime, f.creation_time,
-			f.content_id, f.link_target, f.device_major, f.device_minor,
-			f.hidden, f.acl, f.eas, f.object_id,
-			f.deleted_at, f.original_path, f.deleted_by, f.nlink,
-			` + blockRefsAggExpr + `
-		FROM inodes f
-		WHERE f.content_id_hash = md5($1)
-		LIMIT 1
-	`
-
-	row := tx.tx.QueryRow(ctx, query, string(payloadID))
-	file, err := sqlcodec.FileRowToFileWithNlinkAndBlocks(row, true)
-	if err != nil {
-		return nil, mapPgError(err, "GetFileByPayloadID", string(payloadID))
-	}
-
-	return file, nil
-}

--- a/pkg/metadata/store/sql/dialect.go
+++ b/pkg/metadata/store/sql/dialect.go
@@ -14,11 +14,12 @@ package sql
 //     the driver's empty-result sentinel. Those are genuinely per-dialect
 //     behaviour, so they are methods.
 //
-// Error *mapping* (MapError) and retryability (IsRetryable) stay on each
-// dialect's own errors.go: postgres classifies by SQLSTATE via
-// errors.As(&pgErr) and carries five error classes sqlite has no analogue for,
-// while sqlite matches lowercased substrings. There is no merged errors.go and
-// there was never meant to be one.
+// Error mapping reaches the shared bodies as a MapError hook, but the mapping
+// itself stays on each dialect's own errors.go: postgres classifies by SQLSTATE
+// via errors.As(&pgErr) and carries five error classes sqlite has no analogue
+// for, while sqlite matches lowercased substrings. Retryability is not here at
+// all — only WithTransaction consults it, and that stays per-dialect. There is
+// no merged errors.go and there was never meant to be one.
 type Dialect interface {
 	// IsNoRows reports whether err is this driver's empty-result sentinel:
 	// sql.ErrNoRows for database/sql, pgx.ErrNoRows for pgx. A shared body
@@ -26,9 +27,47 @@ type Dialect interface {
 	// "absent" into a hard error rather than the not-found the callers expect.
 	IsNoRows(err error) bool
 
+	// MapError translates a driver error into the metadata.ExportError the
+	// callers switch on, tagging it with the operation name and the path it
+	// concerned (either may be empty). It dispatches to the dialect's own
+	// errors.go rather than merging the two classifiers.
+	MapError(err error, operation, path string) error
+
 	// Chunks returns the dialect's file-chunk statements. The pointer is
 	// expected to address a package-level value, not a fresh struct per call.
 	Chunks() *ChunkQueries
+
+	// Files returns the dialect's file and directory read statements, under
+	// the same package-level-value expectation as Chunks.
+	Files() *FileQueries
+}
+
+// FileQueries holds the file and directory read statements in one dialect's
+// syntax. Field names name the operation, not the SQL, so the shared bodies in
+// files.go read the same whichever dialect is underneath.
+//
+// These differ by more than placeholder syntax: the path column is a rewritten
+// recursive CTE per dialect, the block-ref aggregate likewise, and postgres
+// matches a payload id through an md5 of it because a content id near PATH_MAX
+// overruns its btree key limit.
+type FileQueries struct {
+	// GetFile selects one full inode row, block-ref aggregate included. Two
+	// parameters: the file id and the share name.
+	GetFile string
+	// GetChild selects a directory entry's child id. Two parameters: the
+	// parent id and the child name.
+	GetChild string
+	// GetParent selects one parent id for a child. One parameter: the child id.
+	GetParent string
+	// GetLinkCount selects one inode's nlink. One parameter: the file id.
+	GetLinkCount string
+	// ListChildren selects a page of directory entries joined to their inode
+	// rows, ordered by name. Three parameters: the parent id, the exclusive
+	// name cursor, and the row limit.
+	ListChildren string
+	// GetFileByPayloadID selects one full inode row by content id, block-ref
+	// aggregate included. One parameter: the content id.
+	GetFileByPayloadID string
 }
 
 // ChunkQueries holds the file-chunk statements in one dialect's syntax. Field

--- a/pkg/metadata/store/sql/files.go
+++ b/pkg/metadata/store/sql/files.go
@@ -1,0 +1,299 @@
+package sql
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/acl"
+	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlcodec"
+)
+
+// ============================================================================
+// File and directory reads
+// ============================================================================
+//
+// These are pure reads, so the pool path and the transaction path want the
+// identical body: the only thing that has to change between them is which
+// executor runs the statement, and that is what Core.X already is. Before this
+// they existed four times over — a store copy and a transaction copy in each of
+// the two dialects — which is how the pool path came to carry a ctx check the
+// transaction path did not, and the transaction path a debug log the pool path
+// did not.
+
+// EncodeFileHandle builds a share-scoped handle from a stringified row id.
+func EncodeFileHandle(shareName string, idStr string) (metadata.FileHandle, error) {
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		return nil, err
+	}
+	return metadata.EncodeShareHandle(shareName, id)
+}
+
+// invalidHandle is the error every decode failure below reports. The message
+// names what the handle was being used as, so a bad directory handle does not
+// read as a bad file handle.
+func invalidHandle(what string) error {
+	return &metadata.StoreError{
+		Code:    metadata.ErrInvalidHandle,
+		Message: "invalid " + what + " handle",
+	}
+}
+
+// GetFile retrieves file metadata by handle, reporting ErrNotFound when the
+// handle names no row.
+//
+// FileAttr.Blocks is folded into this read by the dialect's block-ref
+// aggregate rather than fetched by a second query. The aggregate yields NULL
+// for directories, symlinks and blockless files, so their decoded slice stays
+// nil.
+func (c *Core) GetFile(ctx context.Context, handle metadata.FileHandle) (*metadata.File, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	shareName, id, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		return nil, invalidHandle("file")
+	}
+
+	row := c.X.QueryRow(ctx, c.D.Files().GetFile, id, shareName)
+	file, err := sqlcodec.FileRowToFileWithNlinkAndBlocks(row, true)
+	if err != nil {
+		return nil, c.D.MapError(err, "GetFile", "")
+	}
+	return file, nil
+}
+
+// GetChild resolves a name in a directory to the child's handle, reporting
+// ErrNotFound when the name does not exist.
+func (c *Core) GetChild(ctx context.Context, dirHandle metadata.FileHandle, name string) (metadata.FileHandle, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	shareName, parentID, err := metadata.DecodeFileHandle(dirHandle)
+	if err != nil {
+		return nil, invalidHandle("directory")
+	}
+
+	var childID string
+	if err := c.X.QueryRow(ctx, c.D.Files().GetChild, parentID, name).Scan(&childID); err != nil {
+		return nil, c.D.MapError(err, "GetChild", name)
+	}
+
+	return EncodeFileHandle(shareName, childID)
+}
+
+// GetParent returns the parent handle for a file or directory, reporting
+// ErrNotFound for a root directory because it has no parent edge.
+func (c *Core) GetParent(ctx context.Context, handle metadata.FileHandle) (metadata.FileHandle, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	shareName, childID, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		return nil, invalidHandle("file")
+	}
+
+	var parentIDStr string
+	if err := c.X.QueryRow(ctx, c.D.Files().GetParent, childID).Scan(&parentIDStr); err != nil {
+		return nil, c.D.MapError(err, "GetParent", "")
+	}
+
+	return EncodeFileHandle(shareName, parentIDStr)
+}
+
+// GetLinkCount returns a file's hard link count, or 0 when the file does not
+// exist. nlink is the sole source of truth; it is never recomputed from the
+// parent edges.
+func (c *Core) GetLinkCount(ctx context.Context, handle metadata.FileHandle) (uint32, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+
+	_, fileID, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		return 0, invalidHandle("file")
+	}
+
+	var count uint32
+	err = c.X.QueryRow(ctx, c.D.Files().GetLinkCount, fileID).Scan(&count)
+	if c.D.IsNoRows(err) {
+		return 0, nil
+	}
+	if err != nil {
+		// A fabricated 0 would let callers treat live content as unreferenced.
+		return 0, c.D.MapError(err, "GetLinkCount", "")
+	}
+
+	return count, nil
+}
+
+// GetFileByPayloadID retrieves a file by its content ID, reporting ErrNotFound
+// when no row carries it. Block refs are folded in as for GetFile.
+func (c *Core) GetFileByPayloadID(ctx context.Context, payloadID metadata.PayloadID) (*metadata.File, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if payloadID == "" {
+		return nil, &metadata.StoreError{
+			Code:    metadata.ErrInvalidArgument,
+			Message: "content ID cannot be empty",
+		}
+	}
+
+	row := c.X.QueryRow(ctx, c.D.Files().GetFileByPayloadID, string(payloadID))
+	file, err := sqlcodec.FileRowToFileWithNlinkAndBlocks(row, true)
+	if err != nil {
+		return nil, c.D.MapError(err, "GetFileByPayloadID", string(payloadID))
+	}
+	return file, nil
+}
+
+// listChildrenDefaultLimit is the page size applied when the caller passes a
+// non-positive limit.
+const listChildrenDefaultLimit = 1000
+
+// ListChildren returns a page of directory entries plus the cursor for the
+// next page, empty when the listing is exhausted.
+//
+// Each entry carries the attributes the listing row already holds, which is
+// what lets READDIRPLUS answer without a GetFile per child. FileAttr.Blocks is
+// deliberately NOT among them: the relational model keeps block refs in a
+// separate table, and joining it per row would make a listing quadratic. The
+// Memory and Badger backends do populate Blocks here, because their
+// serialisation already carries the slice. Callers that need the ChunkRef list
+// must re-read through GetFile.
+func (c *Core) ListChildren(ctx context.Context, dirHandle metadata.FileHandle, cursor string, limit int) ([]metadata.DirEntry, string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, "", err
+	}
+
+	shareName, parentID, err := metadata.DecodeFileHandle(dirHandle)
+	if err != nil {
+		return nil, "", invalidHandle("directory")
+	}
+
+	if limit <= 0 {
+		limit = listChildrenDefaultLimit
+	}
+
+	rows, err := c.X.Query(ctx, c.D.Files().ListChildren, parentID, cursor, limit+1)
+	if err != nil {
+		return nil, "", c.D.MapError(err, "ListChildren", "")
+	}
+	defer rows.Close()
+
+	var entries []metadata.DirEntry
+	for rows.Next() && len(entries) < limit {
+		var name, childIDStr string
+		var fileType int16
+		var mode, uid, gid int32
+		var size int64
+		var atime, mtime, ctime, creationTime int64
+		var hidden bool
+		var aclJSON []byte
+		var easJSON []byte
+		var objectIDRaw []byte
+		var deletedAt sql.NullInt64
+		var originalPath string
+		var deletedBy string
+		var linkCount sql.NullInt32
+
+		err := rows.Scan(&name, &childIDStr, &fileType, &mode, &uid, &gid, &size,
+			&atime, &mtime, &ctime, &creationTime, &hidden, &aclJSON, &easJSON, &objectIDRaw,
+			&deletedAt, &originalPath, &deletedBy, &linkCount)
+		if err != nil {
+			return nil, "", err
+		}
+
+		childHandle, err := EncodeFileHandle(shareName, childIDStr)
+		if err != nil {
+			return nil, "", err
+		}
+
+		// A row with no inode join (nlink NULL) still has a type, so fall back
+		// to the type's link count rather than reporting an unlinked entry.
+		nlink := uint32(1)
+		switch {
+		case linkCount.Valid:
+			nlink = uint32(linkCount.Int32)
+		case metadata.FileType(fileType) == metadata.FileTypeDirectory:
+			nlink = 2
+		}
+
+		attr := &metadata.FileAttr{
+			Type:         metadata.FileType(fileType),
+			Mode:         uint32(mode),
+			Nlink:        nlink,
+			UID:          uint32(uid),
+			GID:          uint32(gid),
+			Size:         uint64(size),
+			Atime:        sqlcodec.FiletimeToTime(atime),
+			Mtime:        sqlcodec.FiletimeToTime(mtime),
+			Ctime:        sqlcodec.FiletimeToTime(ctime),
+			CreationTime: sqlcodec.FiletimeToTime(creationTime),
+			Hidden:       hidden,
+		}
+		if len(objectIDRaw) > 0 {
+			if len(objectIDRaw) != block.HashSize {
+				return nil, "", fmt.Errorf(
+					"ListChildren: object_id has invalid length %d (want %d)",
+					len(objectIDRaw), block.HashSize,
+				)
+			}
+			copy(attr.ObjectID[:], objectIDRaw)
+		}
+
+		// Recycle-bin state travels on the listing row so trash enumeration
+		// reflects it without a re-read.
+		if deletedAt.Valid {
+			t := sqlcodec.FiletimeToTime(deletedAt.Int64)
+			attr.DeletedAt = &t
+		}
+		attr.OriginalPath = originalPath
+		attr.DeletedBy = deletedBy
+
+		// A malformed ACL or EA blob is treated as absent rather than failing
+		// the whole listing, matching the GetFile decode path.
+		if len(aclJSON) > 0 {
+			var fileACL acl.ACL
+			if err := json.Unmarshal(aclJSON, &fileACL); err == nil {
+				attr.ACL = &fileACL
+			}
+		}
+		if len(easJSON) > 0 {
+			var eas map[string][]byte
+			if err := json.Unmarshal(easJSON, &eas); err == nil && len(eas) > 0 {
+				attr.EAs = eas
+			}
+		}
+
+		entries = append(entries, metadata.DirEntry{
+			ID:     metadata.HandleToINode(childHandle),
+			Name:   name,
+			Handle: childHandle,
+			Attr:   attr,
+		})
+	}
+
+	// Surface an error that terminated the iteration early. Without this a
+	// partial result would be returned as a complete, successful listing.
+	if err := rows.Err(); err != nil {
+		return nil, "", c.D.MapError(err, "ListChildren", "")
+	}
+
+	nextCursor := ""
+	if len(entries) >= limit {
+		nextCursor = entries[len(entries)-1].Name
+	}
+
+	return entries, nextCursor, nil
+}

--- a/pkg/metadata/store/sqlite/dialect.go
+++ b/pkg/metadata/store/sqlite/dialect.go
@@ -38,4 +38,56 @@ var chunkQueries = storesql.ChunkQueries{
 	EnumerateHashes:    enumerateHashesQuery,
 }
 
+// MapError translates a driver error into an ExportError. It is this
+// package's own mapDBError, reached through the Dialect so a shared body can
+// classify an error without importing the driver that produced it.
+func (dialect) MapError(err error, operation, path string) error {
+	return mapDBError(err, operation, path)
+}
+
+// Files returns the SQLite file and directory read statements.
+func (dialect) Files() *storesql.FileQueries { return &fileQueries }
+
+// inodeSelectColumns is the full inode projection GetFile and
+// GetFileByPayloadID share, block-ref aggregate included, in the column order
+// sqlcodec.FileRowToFileWithNlinkAndBlocks scans.
+const inodeSelectColumns = `
+	f.id, f.share_name, ` + inodePathExpr + `,
+	f.file_type, f.mode, f.uid, f.gid, f.size,
+	f.atime, f.mtime, f.ctime, f.creation_time,
+	f.content_id, f.link_target, f.device_major, f.device_minor,
+	f.hidden, f.acl, f.eas, f.object_id,
+	f.deleted_at, f.original_path, f.deleted_by, f.nlink,
+	` + blockRefsAggExpr + `
+`
+
+var fileQueries = storesql.FileQueries{
+	GetFile: `SELECT ` + inodeSelectColumns + ` FROM inodes f
+		WHERE f.id = ?1 AND f.share_name = ?2`,
+
+	GetChild: `SELECT dc.child_id FROM parent_child_map dc
+		WHERE dc.parent_id = ?1 AND dc.child_name = ?2`,
+
+	GetParent: `SELECT parent_id FROM parent_child_map WHERE child_id = ?1 LIMIT 1`,
+
+	GetLinkCount: `SELECT nlink FROM inodes WHERE id = ?1`,
+
+	// f.acl and f.eas are hydrated here so DirEntry.Attr carries them, matching
+	// the Memory and Badger backends: without those columns an ACL-aware caller
+	// iterating a listing would silently fall back to POSIX mode bits. They are
+	// small next to the row itself and save a GetFile per entry.
+	ListChildren: `SELECT dc.child_name, dc.child_id, f.file_type, f.mode, f.uid, f.gid, f.size,
+		       f.atime, f.mtime, f.ctime, f.creation_time, f.hidden, f.acl, f.eas, f.object_id,
+		       f.deleted_at, f.original_path, f.deleted_by, f.nlink
+		FROM parent_child_map dc
+		LEFT JOIN inodes f ON dc.child_id = f.id
+		WHERE dc.parent_id = ?1 AND dc.child_name > ?2
+		ORDER BY dc.child_name
+		LIMIT ?3`,
+
+	GetFileByPayloadID: `SELECT ` + inodeSelectColumns + ` FROM inodes f
+		WHERE f.content_id = ?1
+		LIMIT 1`,
+}
+
 var _ storesql.Dialect = dialect{}

--- a/pkg/metadata/store/sqlite/encoding.go
+++ b/pkg/metadata/store/sqlite/encoding.go
@@ -1,22 +1,8 @@
 package sqlite
 
-import (
-	"github.com/google/uuid"
-	"github.com/marmos91/dittofs/pkg/metadata"
-)
-
 // ============================================================================
-// File Handle Encoding/Decoding
+// Shared SELECT expressions
 // ============================================================================
-
-// encodeFileHandle creates a file handle from share name and UUID string
-func encodeFileHandle(shareName string, idStr string) (metadata.FileHandle, error) {
-	id, err := uuid.Parse(idStr)
-	if err != nil {
-		return nil, err
-	}
-	return metadata.EncodeShareHandle(shareName, id)
-}
 
 // blockRefsAggExpr is a correlated scalar subquery aggregating a file's
 // file_block_refs rows into a single JSON array, ordered by "offset" ASC to

--- a/pkg/metadata/store/sqlite/files.go
+++ b/pkg/metadata/store/sqlite/files.go
@@ -11,59 +11,17 @@ import (
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
-	"github.com/marmos91/dittofs/pkg/metadata/acl"
-	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlcodec"
 )
 
 // ============================================================================
 // CRUD Operations
 // ============================================================================
 //
-// Read operations use direct pool queries for better performance (no transaction overhead).
-// Write operations use WithTransaction for atomicity.
-
-// GetFile retrieves file metadata by handle.
-// Uses direct pool query without transaction for better performance.
-// Returns ErrNotFound if handle doesn't exist.
-func (s *SQLiteMetadataStore) GetFile(ctx context.Context, handle metadata.FileHandle) (*metadata.File, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	shareName, id, err := metadata.DecodeFileHandle(handle)
-	if err != nil {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrInvalidHandle,
-			Message: "invalid file handle",
-		}
-	}
-
-	// Fold FileAttr.Blocks into the metadata read via a correlated aggregate
-	// (#1176): one round-trip instead of the metadata SELECT plus a separate
-	// loadFileChunkRefs. blockRefsAggExpr yields NULL for directories,
-	// symlinks, and blockless files, so the decoded slice stays nil for them —
-	// byte-identical to the prior two-query behaviour.
-	query := `
-		SELECT
-			f.id, f.share_name, ` + inodePathExpr + `,
-			f.file_type, f.mode, f.uid, f.gid, f.size,
-			f.atime, f.mtime, f.ctime, f.creation_time,
-			f.content_id, f.link_target, f.device_major, f.device_minor,
-			f.hidden, f.acl, f.eas, f.object_id,
-			f.deleted_at, f.original_path, f.deleted_by, f.nlink,
-			` + blockRefsAggExpr + `
-		FROM inodes f
-		WHERE f.id = ?1 AND f.share_name = ?2
-	`
-
-	row := s.queryRow(ctx, query, id, shareName)
-	file, err := sqlcodec.FileRowToFileWithNlinkAndBlocks(row, true)
-	if err != nil {
-		return nil, mapDBError(err, "GetFile", "")
-	}
-
-	return file, nil
-}
+// Write operations open a transaction and delegate to its implementation, so
+// each exists once. The handle-addressed reads are shared further still: they
+// live on store/sql.Core, whose methods are promoted onto both this store and
+// its transaction. What is left here is what could not be either — the reads
+// that need store state, and the ones with no transaction-level counterpart.
 
 // UpdateAttrs stores or updates file metadata.
 // Creates the entry if it doesn't exist.
@@ -89,36 +47,6 @@ func (s *SQLiteMetadataStore) DeleteFile(ctx context.Context, handle metadata.Fi
 	})
 }
 
-// GetChild resolves a name in a directory to a file handle.
-// Uses direct pool query without transaction for better performance.
-// Returns ErrNotFound if name doesn't exist.
-func (s *SQLiteMetadataStore) GetChild(ctx context.Context, dirHandle metadata.FileHandle, name string) (metadata.FileHandle, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	shareName, parentID, err := metadata.DecodeFileHandle(dirHandle)
-	if err != nil {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrInvalidHandle,
-			Message: "invalid directory handle",
-		}
-	}
-
-	query := `
-		SELECT dc.child_id FROM parent_child_map dc
-		WHERE dc.parent_id = ?1 AND dc.child_name = ?2
-	`
-
-	var childID string
-	err = s.queryRow(ctx, query, parentID, name).Scan(&childID)
-	if err != nil {
-		return nil, mapDBError(err, "GetChild", name)
-	}
-
-	return encodeFileHandle(shareName, childID)
-}
-
 // SetChild adds or updates a child entry in a directory.
 func (s *SQLiteMetadataStore) SetChild(ctx context.Context, dirHandle metadata.FileHandle, name string, childHandle metadata.FileHandle) error {
 	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
@@ -134,33 +62,6 @@ func (s *SQLiteMetadataStore) DeleteChild(ctx context.Context, dirHandle metadat
 	})
 }
 
-// GetParent returns the parent handle for a file/directory.
-// Uses direct pool query without transaction for better performance.
-// Returns ErrNotFound for root directories (no parent).
-func (s *SQLiteMetadataStore) GetParent(ctx context.Context, handle metadata.FileHandle) (metadata.FileHandle, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	shareName, childID, err := metadata.DecodeFileHandle(handle)
-	if err != nil {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrInvalidHandle,
-			Message: "invalid file handle",
-		}
-	}
-
-	query := `SELECT parent_id FROM parent_child_map WHERE child_id = ?1 LIMIT 1`
-
-	var parentIDStr string
-	err = s.queryRow(ctx, query, childID).Scan(&parentIDStr)
-	if err != nil {
-		return nil, mapDBError(err, "GetParent", "")
-	}
-
-	return encodeFileHandle(shareName, parentIDStr)
-}
-
 // SetParent sets the parent handle for a file/directory.
 //
 // Parent tracking is handled implicitly by parent_child_map via SetChild, so
@@ -171,218 +72,11 @@ func (s *SQLiteMetadataStore) SetParent(ctx context.Context, handle metadata.Fil
 	return ctx.Err()
 }
 
-// GetLinkCount returns the hard link count for a file.
-// Uses direct pool query without transaction for better performance.
-// Returns 0 if the file doesn't exist. nlink is the sole source of truth (#1166).
-func (s *SQLiteMetadataStore) GetLinkCount(ctx context.Context, handle metadata.FileHandle) (uint32, error) {
-	if err := ctx.Err(); err != nil {
-		return 0, err
-	}
-
-	_, fileID, err := metadata.DecodeFileHandle(handle)
-	if err != nil {
-		return 0, &metadata.StoreError{
-			Code:    metadata.ErrInvalidHandle,
-			Message: "invalid file handle",
-		}
-	}
-
-	var count uint32
-	err = s.queryRow(ctx, `SELECT nlink FROM inodes WHERE id = ?1`, fileID).Scan(&count)
-	if errors.Is(err, sql.ErrNoRows) {
-		// Not found means count is 0
-		return 0, nil
-	}
-	if err != nil {
-		// A fabricated 0 would let callers treat live content as unreferenced.
-		return 0, mapDBError(err, "GetLinkCount", "")
-	}
-
-	return count, nil
-}
-
 // SetLinkCount sets the hard link count for a file.
 func (s *SQLiteMetadataStore) SetLinkCount(ctx context.Context, handle metadata.FileHandle, count uint32) error {
 	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
 		return tx.SetLinkCount(ctx, handle, count)
 	})
-}
-
-// ListChildren returns directory entries with pagination support.
-// Uses direct pool query without transaction for better performance.
-func (s *SQLiteMetadataStore) ListChildren(ctx context.Context, dirHandle metadata.FileHandle, cursor string, limit int) ([]metadata.DirEntry, string, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, "", err
-	}
-
-	shareName, parentID, err := metadata.DecodeFileHandle(dirHandle)
-	if err != nil {
-		return nil, "", &metadata.StoreError{
-			Code:    metadata.ErrInvalidHandle,
-			Message: "invalid directory handle",
-		}
-	}
-
-	if limit <= 0 {
-		limit = 1000
-	}
-
-	// Refs #532 (PR #536 review): hydrate f.acl so DirEntry.Attr.ACL is
-	// populated, matching the Memory/Badger backends. Without this column,
-	// access-based enumeration (and any other ACL-aware caller iterating
-	// DirEntry.Attr) silently degrades to POSIX mode bits even on files that
-	// have a DACL set. ACL JSONB rows are typically small relative to the
-	// listing row itself, so the extra column adds negligible per-row cost
-	// versus the per-entry GetFile() round trip it avoids.
-	query := `
-		SELECT dc.child_name, dc.child_id, f.file_type, f.mode, f.uid, f.gid, f.size,
-		       f.atime, f.mtime, f.ctime, f.creation_time, f.hidden, f.acl, f.eas, f.object_id,
-		       f.deleted_at, f.original_path, f.deleted_by, f.nlink
-		FROM parent_child_map dc
-		LEFT JOIN inodes f ON dc.child_id = f.id
-		WHERE dc.parent_id = ?1 AND dc.child_name > ?2
-		ORDER BY dc.child_name
-		LIMIT ?3
-	`
-
-	rows, err := s.query(ctx, query, parentID, cursor, limit+1)
-	if err != nil {
-		return nil, "", mapDBError(err, "ListChildren", "")
-	}
-	defer rows.Close()
-
-	var entries []metadata.DirEntry
-	for rows.Next() && len(entries) < limit {
-		var name, childIDStr string
-		var fileType int16
-		var mode, uid, gid int32
-		var size int64
-		var atime, mtime, ctime, creationTime int64
-		var hidden bool
-		var aclJSON []byte
-		var easJSON []byte
-		var objectIDRaw []byte
-		var deletedAt sql.NullInt64
-		var originalPath string
-		var deletedBy string
-		var linkCount sql.NullInt32
-
-		err := rows.Scan(&name, &childIDStr, &fileType, &mode, &uid, &gid, &size,
-			&atime, &mtime, &ctime, &creationTime, &hidden, &aclJSON, &easJSON, &objectIDRaw,
-			&deletedAt, &originalPath, &deletedBy, &linkCount)
-		if err != nil {
-			return nil, "", err
-		}
-
-		childHandle, err := encodeFileHandle(shareName, childIDStr)
-		if err != nil {
-			return nil, "", err
-		}
-
-		// Determine Nlink value
-		var nlink uint32
-		if linkCount.Valid {
-			nlink = uint32(linkCount.Int32)
-		} else {
-			// Default based on file type
-			if metadata.FileType(fileType) == metadata.FileTypeDirectory {
-				nlink = 2
-			} else {
-				nlink = 1
-			}
-		}
-
-		// hydrate ObjectID for directory entries.
-		// NULL/empty -> zero (sentinel).
-		//
-		// The shape DOES NOT match GetFile in this backend. GetFile populates
-		// FileAttr.Blocks via loadFileChunkRefs; ListChildren intentionally does NOT (per-row
-		// ChunkRef hydration would be a quadratic cost on directory
-		// listings). Memory and Badger backends include Blocks on
-		// DirEntry.Attr because their underlying serialisation already
-		// carries the slice — the relational model splits
-		// FileAttr.Blocks into a separate table (file_block_refs) and
-		// listing rows skip the join. Callers MUST treat
-		// DirEntry.Attr.Blocks as not-loaded for the SQLite store and re-read
-		// via GetFile if the ChunkRef list is needed for hot-path
-		// resolution. Current short-circuit code (FindByObjectID-driven)
-		// never consults DirEntry.Attr.ObjectID, so this asymmetry is
-		// benign at the call surface.
-		attr := &metadata.FileAttr{
-			Type:         metadata.FileType(fileType),
-			Mode:         uint32(mode),
-			Nlink:        nlink,
-			UID:          uint32(uid),
-			GID:          uint32(gid),
-			Size:         uint64(size),
-			Atime:        sqlcodec.FiletimeToTime(atime),
-			Mtime:        sqlcodec.FiletimeToTime(mtime),
-			Ctime:        sqlcodec.FiletimeToTime(ctime),
-			CreationTime: sqlcodec.FiletimeToTime(creationTime),
-			Hidden:       hidden,
-		}
-		if len(objectIDRaw) > 0 {
-			if len(objectIDRaw) != block.HashSize {
-				return nil, "", fmt.Errorf(
-					"ListChildren: object_id has invalid length %d (want %d)",
-					len(objectIDRaw), block.HashSize,
-				)
-			}
-			copy(attr.ObjectID[:], objectIDRaw)
-		}
-
-		// Recycle-bin metadata (#190): carried on DirEntry.Attr so trash
-		// enumeration via listing reflects recycle state without a re-read.
-		// deleted_at is BIGINT unix-nanoseconds; decode via sqlcodec.FiletimeToTime.
-		if deletedAt.Valid {
-			t := sqlcodec.FiletimeToTime(deletedAt.Int64)
-			attr.DeletedAt = &t
-		}
-		attr.OriginalPath = originalPath
-		attr.DeletedBy = deletedBy
-
-		// Refs #532 (PR #536 review): mirror sqlcodec.FileRowToFileWithNlink. A
-		// malformed ACL row is treated as "no ACL" rather than failing the
-		// whole listing — same lenient behaviour the GetFile path has had
-		// since the column was introduced.
-		if len(aclJSON) > 0 {
-			var fileACL acl.ACL
-			if err := json.Unmarshal(aclJSON, &fileACL); err == nil {
-				attr.ACL = &fileACL
-			}
-		}
-
-		// Hydrate EAs for directory entries (same lenient unmarshal as ACL).
-		if len(easJSON) > 0 {
-			var eas map[string][]byte
-			if err := json.Unmarshal(easJSON, &eas); err == nil && len(eas) > 0 {
-				attr.EAs = eas
-			}
-		}
-
-		entry := metadata.DirEntry{
-			ID:     metadata.HandleToINode(childHandle),
-			Name:   name,
-			Handle: childHandle,
-			Attr:   attr,
-		}
-
-		entries = append(entries, entry)
-	}
-
-	// Surface any error that terminated the iteration early (e.g. a network
-	// drop mid-stream). Without this check a partial result would be returned
-	// as a complete, successful listing.
-	if err := rows.Err(); err != nil {
-		return nil, "", mapDBError(err, "ListChildren", "")
-	}
-
-	nextCursor := ""
-	if len(entries) >= limit {
-		nextCursor = entries[len(entries)-1].Name
-	}
-
-	return entries, nextCursor, nil
 }
 
 // GetFilesystemMeta retrieves filesystem metadata for a share.
@@ -450,38 +144,6 @@ func (s *SQLiteMetadataStore) FindByObjectID(ctx context.Context, objectID block
 	}
 
 	return s.loadFileChunkRefs(ctx, fileID)
-}
-
-// GetFileByPayloadID retrieves a file by its content ID (used by cache flusher)
-func (s *SQLiteMetadataStore) GetFileByPayloadID(ctx context.Context, payloadID metadata.PayloadID) (*metadata.File, error) {
-	if payloadID == "" {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrInvalidArgument,
-			Message: "content ID cannot be empty",
-		}
-	}
-
-	query := `
-		SELECT
-			f.id, f.share_name, ` + inodePathExpr + `,
-			f.file_type, f.mode, f.uid, f.gid, f.size,
-			f.atime, f.mtime, f.ctime, f.creation_time,
-			f.content_id, f.link_target, f.device_major, f.device_minor,
-			f.hidden, f.acl, f.eas, f.object_id,
-			f.deleted_at, f.original_path, f.deleted_by, f.nlink,
-			` + blockRefsAggExpr + `
-		FROM inodes f
-		WHERE f.content_id = ?1
-		LIMIT 1
-	`
-
-	row := s.queryRow(ctx, query, string(payloadID))
-	file, err := sqlcodec.FileRowToFileWithNlinkAndBlocks(row, true)
-	if err != nil {
-		return nil, mapDBError(err, "GetFileByPayloadID", string(payloadID))
-	}
-
-	return file, nil
 }
 
 // CountObjectIDIndexRows implements the storetest.ObjectIDIndexAccessor

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -10,9 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
-	"github.com/marmos91/dittofs/pkg/metadata/acl"
 	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlcodec"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/txretry"
@@ -148,55 +146,6 @@ func (s *SQLiteMetadataStore) WithTransaction(ctx context.Context, fn func(tx me
 // ============================================================================
 // Transaction CRUD Operations
 // ============================================================================
-
-func (tx *sqliteTransaction) GetFile(ctx context.Context, handle metadata.FileHandle) (*metadata.File, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	shareName, id, err := metadata.DecodeFileHandle(handle)
-	if err != nil {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrInvalidHandle,
-			Message: "invalid file handle",
-		}
-	}
-
-	// Fold FileAttr.Blocks into the metadata read (#1176): one round-trip
-	// instead of the SELECT plus a separate getFileChunkRefs. See GetFile
-	// (pool path) and blockRefsAggExpr for the equivalence rationale.
-	query := `
-		SELECT
-			f.id, f.share_name, ` + inodePathExpr + `,
-			f.file_type, f.mode, f.uid, f.gid, f.size,
-			f.atime, f.mtime, f.ctime, f.creation_time,
-			f.content_id, f.link_target, f.device_major, f.device_minor,
-			f.hidden, f.acl, f.eas, f.object_id,
-			f.deleted_at, f.original_path, f.deleted_by, f.nlink,
-			` + blockRefsAggExpr + `
-		FROM inodes f
-		WHERE f.id = ?1 AND f.share_name = ?2
-	`
-
-	row := tx.tx.QueryRow(ctx, query, id, shareName)
-	file, err := sqlcodec.FileRowToFileWithNlinkAndBlocks(row, true)
-	if err != nil {
-		return nil, mapDBError(err, "GetFile", "")
-	}
-
-	// Debug logging to trace file type issues, gated so the id formatting and
-	// variadic boxing are skipped when Debug is off.
-	if tx.store.logger.Enabled(ctx, slog.LevelDebug) {
-		tx.store.logger.Debug("GetFile retrieved",
-			"id", id.String(),
-			"share", shareName,
-			"path", file.Path,
-			"file_type", int(file.Type),
-			"size", file.Size)
-	}
-
-	return file, nil
-}
 
 // UpdateAttrs persists the file's attributes and leaves the stored
 // file_block_refs manifest untouched.
@@ -498,43 +447,6 @@ func (tx *sqliteTransaction) DeleteFile(ctx context.Context, handle metadata.Fil
 	return nil
 }
 
-func (tx *sqliteTransaction) GetChild(ctx context.Context, dirHandle metadata.FileHandle, name string) (metadata.FileHandle, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	shareName, parentID, err := metadata.DecodeFileHandle(dirHandle)
-	if err != nil {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrInvalidHandle,
-			Message: "invalid directory handle",
-		}
-	}
-
-	query := `
-		SELECT dc.child_id FROM parent_child_map dc
-		WHERE dc.parent_id = ?1 AND dc.child_name = ?2
-	`
-
-	var childID string
-	err = tx.tx.QueryRow(ctx, query, parentID, name).Scan(&childID)
-	if err != nil {
-		return nil, mapDBError(err, "GetChild", name)
-	}
-
-	// Debug logging to trace child lookup, gated so the parent-id formatting is
-	// skipped when Debug is off.
-	if tx.store.logger.Enabled(ctx, slog.LevelDebug) {
-		tx.store.logger.Debug("GetChild found",
-			"parent_id", parentID.String(),
-			"child_name", name,
-			"child_id", childID,
-			"share", shareName)
-	}
-
-	return encodeFileHandle(shareName, childID)
-}
-
 func (tx *sqliteTransaction) SetChild(ctx context.Context, dirHandle metadata.FileHandle, name string, childHandle metadata.FileHandle) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -596,216 +508,10 @@ func (tx *sqliteTransaction) DeleteChild(ctx context.Context, dirHandle metadata
 	return nil
 }
 
-func (tx *sqliteTransaction) ListChildren(ctx context.Context, dirHandle metadata.FileHandle, cursor string, limit int) ([]metadata.DirEntry, string, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, "", err
-	}
-
-	shareName, parentID, err := metadata.DecodeFileHandle(dirHandle)
-	if err != nil {
-		return nil, "", &metadata.StoreError{
-			Code:    metadata.ErrInvalidHandle,
-			Message: "invalid directory handle",
-		}
-	}
-
-	if limit <= 0 {
-		limit = 1000
-	}
-
-	// Refs #532 (PR #536 review): hydrate f.acl — keep parity with the
-	// pool-query ListChildren above. See files.go for rationale.
-	query := `
-		SELECT dc.child_name, dc.child_id, f.file_type, f.mode, f.uid, f.gid, f.size,
-		       f.atime, f.mtime, f.ctime, f.creation_time, f.hidden, f.acl, f.eas, f.object_id,
-		       f.deleted_at, f.original_path, f.deleted_by, f.nlink
-		FROM parent_child_map dc
-		LEFT JOIN inodes f ON dc.child_id = f.id
-		WHERE dc.parent_id = ?1 AND dc.child_name > ?2
-		ORDER BY dc.child_name
-		LIMIT ?3
-	`
-
-	rows, err := tx.tx.Query(ctx, query, parentID, cursor, limit+1)
-	if err != nil {
-		return nil, "", mapDBError(err, "ListChildren", "")
-	}
-	defer rows.Close()
-
-	var entries []metadata.DirEntry
-	for rows.Next() && len(entries) < limit {
-		var name, childIDStr string
-		var fileType int16
-		var mode, uid, gid int32
-		var size int64
-		var atime, mtime, ctime, creationTime int64
-		var hidden bool
-		var aclJSON []byte
-		var easJSON []byte
-		var objectIDRaw []byte
-		var deletedAt sql.NullInt64
-		var originalPath string
-		var deletedBy string
-		var linkCount sql.NullInt32
-
-		err := rows.Scan(&name, &childIDStr, &fileType, &mode, &uid, &gid, &size,
-			&atime, &mtime, &ctime, &creationTime, &hidden, &aclJSON, &easJSON, &objectIDRaw,
-			&deletedAt, &originalPath, &deletedBy, &linkCount)
-		if err != nil {
-			return nil, "", err
-		}
-
-		childHandle, err := encodeFileHandle(shareName, childIDStr)
-		if err != nil {
-			return nil, "", err
-		}
-
-		// Determine Nlink value
-		var nlink uint32
-		if linkCount.Valid {
-			nlink = uint32(linkCount.Int32)
-		} else {
-			// Default based on file type
-			if metadata.FileType(fileType) == metadata.FileTypeDirectory {
-				nlink = 2
-			} else {
-				nlink = 1
-			}
-		}
-
-		// hydrate ObjectID for directory entries so the
-		// shape matches GetFile. NULL/empty -> zero (sentinel).
-		attr := &metadata.FileAttr{
-			Type:         metadata.FileType(fileType),
-			Mode:         uint32(mode),
-			Nlink:        nlink,
-			UID:          uint32(uid),
-			GID:          uint32(gid),
-			Size:         uint64(size),
-			Atime:        sqlcodec.FiletimeToTime(atime),
-			Mtime:        sqlcodec.FiletimeToTime(mtime),
-			Ctime:        sqlcodec.FiletimeToTime(ctime),
-			CreationTime: sqlcodec.FiletimeToTime(creationTime),
-			Hidden:       hidden,
-		}
-		if len(objectIDRaw) > 0 {
-			if len(objectIDRaw) != block.HashSize {
-				return nil, "", fmt.Errorf(
-					"ListChildren: object_id has invalid length %d (want %d)",
-					len(objectIDRaw), block.HashSize,
-				)
-			}
-			copy(attr.ObjectID[:], objectIDRaw)
-		}
-
-		// Recycle-bin metadata (#190): carried on DirEntry.Attr so trash
-		// enumeration via listing reflects recycle state without a re-read,
-		// matching the pool-query path. deleted_at is BIGINT unix-nanoseconds;
-		// decode via sqlcodec.FiletimeToTime.
-		if deletedAt.Valid {
-			t := sqlcodec.FiletimeToTime(deletedAt.Int64)
-			attr.DeletedAt = &t
-		}
-		attr.OriginalPath = originalPath
-		attr.DeletedBy = deletedBy
-
-		// Refs #532 (PR #536 review): mirror sqlcodec.FileRowToFileWithNlink — soft
-		// failure on malformed ACL JSON, same as the pool-query path.
-		if len(aclJSON) > 0 {
-			var fileACL acl.ACL
-			if err := json.Unmarshal(aclJSON, &fileACL); err == nil {
-				attr.ACL = &fileACL
-			}
-		}
-
-		// Hydrate EAs for directory entries (same lenient unmarshal as ACL).
-		if len(easJSON) > 0 {
-			var eas map[string][]byte
-			if err := json.Unmarshal(easJSON, &eas); err == nil && len(eas) > 0 {
-				attr.EAs = eas
-			}
-		}
-
-		entry := metadata.DirEntry{
-			ID:     metadata.HandleToINode(childHandle),
-			Name:   name,
-			Handle: childHandle,
-			Attr:   attr,
-		}
-
-		entries = append(entries, entry)
-	}
-
-	// Surface any error that terminated the iteration early (e.g. a network
-	// drop mid-stream). Without this check a partial result would be returned
-	// as a complete, successful listing.
-	if err := rows.Err(); err != nil {
-		return nil, "", mapDBError(err, "ListChildren", "")
-	}
-
-	nextCursor := ""
-	if len(entries) >= limit {
-		nextCursor = entries[len(entries)-1].Name
-	}
-
-	return entries, nextCursor, nil
-}
-
-func (tx *sqliteTransaction) GetParent(ctx context.Context, handle metadata.FileHandle) (metadata.FileHandle, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	shareName, childID, err := metadata.DecodeFileHandle(handle)
-	if err != nil {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrInvalidHandle,
-			Message: "invalid file handle",
-		}
-	}
-
-	query := `SELECT parent_id FROM parent_child_map WHERE child_id = ?1 LIMIT 1`
-
-	var parentIDStr string
-	err = tx.tx.QueryRow(ctx, query, childID).Scan(&parentIDStr)
-	if err != nil {
-		return nil, mapDBError(err, "GetParent", "")
-	}
-
-	return encodeFileHandle(shareName, parentIDStr)
-}
-
 func (tx *sqliteTransaction) SetParent(ctx context.Context, handle metadata.FileHandle, parentHandle metadata.FileHandle) error {
 	// Parent is tracked via the parent_child_map table, already handled by SetChild.
 	// Still honours context cancellation, matching the store-level SetParent.
 	return ctx.Err()
-}
-
-func (tx *sqliteTransaction) GetLinkCount(ctx context.Context, handle metadata.FileHandle) (uint32, error) {
-	if err := ctx.Err(); err != nil {
-		return 0, err
-	}
-
-	_, fileID, err := metadata.DecodeFileHandle(handle)
-	if err != nil {
-		return 0, &metadata.StoreError{
-			Code:    metadata.ErrInvalidHandle,
-			Message: "invalid file handle",
-		}
-	}
-
-	var count uint32
-	err = tx.tx.QueryRow(ctx, `SELECT nlink FROM inodes WHERE id = ?1`, fileID).Scan(&count)
-	if errors.Is(err, sql.ErrNoRows) {
-		// Not found means count is 0
-		return 0, nil
-	}
-	if err != nil {
-		// A fabricated 0 would let callers treat live content as unreferenced.
-		return 0, mapDBError(err, "GetLinkCount", "")
-	}
-
-	return count, nil
 }
 
 func (tx *sqliteTransaction) SetLinkCount(ctx context.Context, handle metadata.FileHandle, count uint32) error {
@@ -1322,38 +1028,3 @@ func (tx *sqliteTransaction) GetFilesystemStatistics(ctx context.Context, handle
 // ============================================================================
 // Transaction Files Operations (additional)
 // ============================================================================
-
-func (tx *sqliteTransaction) GetFileByPayloadID(ctx context.Context, payloadID metadata.PayloadID) (*metadata.File, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	if payloadID == "" {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrInvalidArgument,
-			Message: "content ID cannot be empty",
-		}
-	}
-
-	query := `
-		SELECT
-			f.id, f.share_name, ` + inodePathExpr + `,
-			f.file_type, f.mode, f.uid, f.gid, f.size,
-			f.atime, f.mtime, f.ctime, f.creation_time,
-			f.content_id, f.link_target, f.device_major, f.device_minor,
-			f.hidden, f.acl, f.eas, f.object_id,
-			f.deleted_at, f.original_path, f.deleted_by, f.nlink,
-			` + blockRefsAggExpr + `
-		FROM inodes f
-		WHERE f.content_id = ?1
-		LIMIT 1
-	`
-
-	row := tx.tx.QueryRow(ctx, query, string(payloadID))
-	file, err := sqlcodec.FileRowToFileWithNlinkAndBlocks(row, true)
-	if err != nil {
-		return nil, mapDBError(err, "GetFileByPayloadID", string(payloadID))
-	}
-
-	return file, nil
-}

--- a/pkg/metadata/storetest/file_read_tx_ops.go
+++ b/pkg/metadata/storetest/file_read_tx_ops.go
@@ -1,0 +1,157 @@
+package storetest
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// errFileReadTxRollback forces a rollback in the discard subtest.
+var errFileReadTxRollback = errors.New("forced rollback")
+
+// runFileReadTxOps pins that the transaction-level file and directory reads
+// run inside the caller's transaction rather than beside it.
+//
+// A backend can satisfy every other test in this suite while its
+// transaction-level GetFile reads from the pool: such a read still returns the
+// right answer for anything already committed, which is all the rest of the
+// suite asks about. What separates the two is covered here — a write is
+// visible to a read in the same transaction before commit, and a rolled-back
+// write is visible to nobody afterwards.
+//
+// A pooled backend fails this by wedging rather than erroring: the escaped
+// read waits on a connection the enclosing transaction is still holding, so
+// the symptom is the package's test timeout, not an assertion message.
+func runFileReadTxOps(t *testing.T, factory StoreFactory) {
+	t.Helper()
+
+	t.Run("ReadYourWrites", func(t *testing.T) {
+		store := factory(t)
+		ctx := context.Background()
+		root := createTestShare(t, store, "txread")
+
+		const name = "in-flight.txt"
+		path := childFullPath(t, store, root, name)
+		handle, err := store.GenerateHandle(ctx, "txread", path)
+		require.NoError(t, err)
+		_, id, err := metadata.DecodeFileHandle(handle)
+		require.NoError(t, err)
+
+		payloadID := metadata.PayloadID("txread-payload-ryw")
+		file := &metadata.File{
+			ID:        id,
+			ShareName: "txread",
+			Path:      path,
+			FileAttr: metadata.FileAttr{
+				PayloadID: payloadID,
+				Type:      metadata.FileTypeRegular,
+				Mode:      0644,
+				UID:       1000,
+				GID:       1000,
+			},
+		}
+
+		require.NoError(t, store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+			require.NoError(t, tx.UpdateAttrs(ctx, file))
+			require.NoError(t, tx.SetParent(ctx, handle, root))
+			require.NoError(t, tx.SetChild(ctx, root, name, handle))
+			require.NoError(t, tx.SetLinkCount(ctx, handle, 1))
+
+			got, err := tx.GetFile(ctx, handle)
+			require.NoError(t, err, "GetFile must see the write from its own transaction")
+			assert.Equal(t, id, got.ID)
+
+			child, err := tx.GetChild(ctx, root, name)
+			require.NoError(t, err, "GetChild must see the entry from its own transaction")
+			assert.Equal(t, handle, child)
+
+			parent, err := tx.GetParent(ctx, handle)
+			require.NoError(t, err, "GetParent must see the edge from its own transaction")
+			assert.Equal(t, root, parent)
+
+			nlink, err := tx.GetLinkCount(ctx, handle)
+			require.NoError(t, err)
+			assert.Equal(t, uint32(1), nlink, "GetLinkCount must see the count set in its own transaction")
+
+			byPayload, err := tx.GetFileByPayloadID(ctx, payloadID)
+			require.NoError(t, err, "GetFileByPayloadID must see the write from its own transaction")
+			assert.Equal(t, id, byPayload.ID)
+
+			entries, _, err := tx.ListChildren(ctx, root, "", 0)
+			require.NoError(t, err)
+			assert.True(t, hasEntryNamed(entries, name),
+				"ListChildren must see the entry added by its own transaction, got %v", entryNames(entries))
+			return nil
+		}))
+
+		// And it survived the commit.
+		got, err := store.GetFile(ctx, handle)
+		require.NoError(t, err)
+		assert.Equal(t, id, got.ID)
+	})
+
+	t.Run("RollbackDiscards", func(t *testing.T) {
+		store := factory(t)
+		ctx := context.Background()
+		root := createTestShare(t, store, "txread")
+
+		const name = "rolled-back.txt"
+		path := childFullPath(t, store, root, name)
+		handle, err := store.GenerateHandle(ctx, "txread", path)
+		require.NoError(t, err)
+		_, id, err := metadata.DecodeFileHandle(handle)
+		require.NoError(t, err)
+
+		err = store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+			require.NoError(t, tx.UpdateAttrs(ctx, &metadata.File{
+				ID:        id,
+				ShareName: "txread",
+				Path:      path,
+				FileAttr: metadata.FileAttr{
+					Type: metadata.FileTypeRegular,
+					Mode: 0644,
+					UID:  1000,
+					GID:  1000,
+				},
+			}))
+			require.NoError(t, tx.SetChild(ctx, root, name, handle))
+			return errFileReadTxRollback
+		})
+		require.ErrorIs(t, err, errFileReadTxRollback)
+
+		_, err = store.GetFile(ctx, handle)
+		assert.True(t, metadata.IsNotFoundError(err),
+			"a rolled-back file must not be readable afterwards, got %v", err)
+
+		_, err = store.GetChild(ctx, root, name)
+		assert.True(t, metadata.IsNotFoundError(err),
+			"a rolled-back directory entry must not resolve afterwards, got %v", err)
+
+		entries, _, err := store.ListChildren(ctx, root, "", 0)
+		require.NoError(t, err)
+		assert.False(t, hasEntryNamed(entries, name),
+			"a rolled-back entry must not appear in a listing, got %v", entryNames(entries))
+	})
+}
+
+func hasEntryNamed(entries []metadata.DirEntry, name string) bool {
+	for i := range entries {
+		if entries[i].Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func entryNames(entries []metadata.DirEntry) []string {
+	names := make([]string, 0, len(entries))
+	for i := range entries {
+		names = append(names, entries[i].Name)
+	}
+	return names
+}

--- a/pkg/metadata/storetest/suite.go
+++ b/pkg/metadata/storetest/suite.go
@@ -196,6 +196,14 @@ func RunConformanceSuite(t *testing.T, factory StoreFactory) {
 	t.Run("ShareOptionsOps", func(t *testing.T) {
 		runShareOptionsOps(t, factory)
 	})
+
+	// FileReadTxOps pins that the transaction-level file and directory reads
+	// run inside the caller's transaction. Every other test here reads only
+	// committed state, which a read that escaped to the pool would answer just
+	// as correctly.
+	t.Run("FileReadTxOps", func(t *testing.T) {
+		runFileReadTxOps(t, factory)
+	})
 }
 
 // createTestShare is a helper that creates a share and root directory for testing.


### PR DESCRIPTION
Part of #1828.

Six handle-addressed reads — `GetFile`, `GetChild`, `GetParent`, `GetLinkCount`,
`ListChildren`, `GetFileByPayloadID` — existed **four times each**: a store copy
and a transaction copy, in sqlite and in postgres. They are pure reads, so the
only thing that differs between a store copy and its transaction twin is which
executor runs the statement, which is exactly what `Core.X` already is.

They now live once, on `store/sql.Core`, promoted onto all four types. Net
−1,229 lines of production code.

### What had to become a hook

`Dialect` gains two members:

- **`MapError(err, operation, path)`** — dispatches to each package's own
  `mapDBError` / `mapPgError`. The classifiers stay split (postgres reads
  SQLSTATE via `errors.As(&pgErr)` and carries five classes sqlite has no
  analogue for); only the entry point is shared.
- **`Files() *FileQueries`** — the six statements per dialect. These differ by
  more than placeholder syntax: the path column and the block-ref aggregate are
  rewritten per dialect, and postgres matches a payload id through
  `content_id_hash = md5($1)` because a content id for a path near `PATH_MAX`
  overruns its 2704-byte btree key limit.

### Drift the four copies had already accumulated

Merging them settles three asymmetries rather than preserving them:

- the transaction `GetFile` carried a Debug log ("GetFile retrieved") the pool
  path never had, in both dialects. **Dropped** — it was a dev aid for a past
  file-type investigation, and the caller has the same fields.
- the store `GetFileByPayloadID` had no `ctx.Err()` check; its transaction twin
  did. Now both do.
- `ListChildren`'s nlink fallback was an `if`/nested-`if`; it is a `switch` now,
  same semantics.

### The coverage hole this found

A transaction-level file read that escapes to the **pool** — losing
read-your-writes and surviving a rollback — passed the entire postgres
integration suite. Nothing in the suite reads a file inside a transaction that
wrote it, so a pooled read answers every existing question correctly.

`storetest.FileReadTxOps` closes it for all four backends: a write is visible to
a read in the same transaction before commit, and a rolled-back write is visible
to nobody afterwards. Verified against the deliberately broken build — the
mutation survives without it and fails with it. (It fails by wedging on the
connection the transaction still holds, so the symptom is the package timeout,
not an assertion; that is noted in the test.)

### Verification

- `go build ./...`, `go vet ./...`, `gofmt` clean
- `go test -tags=integration -p 1 ./pkg/metadata/...` green against a real
  postgres 16, plus badger / sqlite / memory
- the new conformance test passes on all four backends and refuses the broken one
