### PR TITLE
refactor(metadata): one body per share read, and one SetParent

### DIFF
--- a/pkg/metadata/store/postgres/dialect.go
+++ b/pkg/metadata/store/postgres/dialect.go
@@ -92,4 +92,14 @@ var fileQueries = storesql.FileQueries{
 		LIMIT 1`,
 }
 
+// Shares returns the postgres share read statements.
+func (dialect) Shares() *storesql.ShareQueries { return &shareQueries }
+
+var shareQueries = storesql.ShareQueries{
+	GetRootHandle:     `SELECT root_file_id FROM shares WHERE share_name = $1`,
+	GetShareOptions:   `SELECT options FROM shares WHERE share_name = $1`,
+	ListShares:        `SELECT share_name FROM shares`,
+	GetFilesystemMeta: `SELECT meta FROM filesystem_meta WHERE share_name = $1`,
+}
+
 var _ storesql.Dialect = dialect{}

--- a/pkg/metadata/store/postgres/files.go
+++ b/pkg/metadata/store/postgres/files.go
@@ -2,7 +2,6 @@ package postgres
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -62,47 +61,11 @@ func (s *PostgresMetadataStore) DeleteChild(ctx context.Context, dirHandle metad
 	})
 }
 
-// SetParent sets the parent handle for a file/directory.
-//
-// Parent tracking is handled implicitly by parent_child_map via SetChild, so
-// this performs no write. It still honours context cancellation, matching the
-// prior WithTransaction-based implementation, while avoiding the cost of
-// opening an empty transaction.
-func (s *PostgresMetadataStore) SetParent(ctx context.Context, handle metadata.FileHandle, parentHandle metadata.FileHandle) error {
-	return ctx.Err()
-}
-
 // SetLinkCount sets the hard link count for a file.
 func (s *PostgresMetadataStore) SetLinkCount(ctx context.Context, handle metadata.FileHandle, count uint32) error {
 	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
 		return tx.SetLinkCount(ctx, handle, count)
 	})
-}
-
-// GetFilesystemMeta retrieves filesystem metadata for a share.
-// Uses direct pool query without transaction for better performance.
-func (s *PostgresMetadataStore) GetFilesystemMeta(ctx context.Context, shareName string) (*metadata.FilesystemMeta, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	query := `SELECT meta FROM filesystem_meta WHERE share_name = $1`
-
-	var data []byte
-	err := s.queryRow(ctx, query, shareName).Scan(&data)
-	if err != nil {
-		// Return defaults if not found
-		return &metadata.FilesystemMeta{
-			Capabilities: s.capabilities,
-		}, nil
-	}
-
-	var meta metadata.FilesystemMeta
-	if err := json.Unmarshal(data, &meta); err != nil {
-		return nil, err
-	}
-
-	return &meta, nil
 }
 
 // PutFilesystemMeta stores filesystem metadata for a share.

--- a/pkg/metadata/store/postgres/server.go
+++ b/pkg/metadata/store/postgres/server.go
@@ -99,3 +99,10 @@ func (s *PostgresMetadataStore) GetFilesystemStatistics(ctx context.Context, han
 	}
 	return basestore.BuildStatistics(bytesUsed, filesUsed), nil
 }
+
+// currentCapabilities reports the capabilities the store is configured with
+// right now. SetFilesystemCapabilities replaces them, so the shared reads take
+// this rather than a copy captured at construction.
+func (s *PostgresMetadataStore) currentCapabilities() metadata.FilesystemCapabilities {
+	return s.capabilities
+}

--- a/pkg/metadata/store/postgres/shares.go
+++ b/pkg/metadata/store/postgres/shares.go
@@ -32,6 +32,12 @@ func (s *PostgresMetadataStore) GenerateHandle(ctx context.Context, shareName st
 // and decode are worth skipping. The returned value is always a deep copy, so
 // a caller can never reach the shared cache entry.
 func (s *PostgresMetadataStore) GetShareOptions(ctx context.Context, shareName string) (*metadata.ShareOptions, error) {
+	// Ahead of the cache lookup, not just inside the backing read: a hit must
+	// not report success for a request whose context has already given out.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	if cached, ok := s.shareCache.Get(shareName); ok {
 		return sharecache.Clone(cached), nil
 	}

--- a/pkg/metadata/store/postgres/shares.go
+++ b/pkg/metadata/store/postgres/shares.go
@@ -24,33 +24,14 @@ func (s *PostgresMetadataStore) GenerateHandle(ctx context.Context, shareName st
 	return basestore.GenerateHandle(ctx, shareName)
 }
 
-// GetRootHandle returns the root handle for a share.
-// Returns ErrNotFound if the share doesn't exist.
-func (s *PostgresMetadataStore) GetRootHandle(ctx context.Context, shareName string) (metadata.FileHandle, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	query := `SELECT root_file_id FROM shares WHERE share_name = $1`
-
-	var rootID uuid.UUID
-	err := s.queryRow(ctx, query, shareName).Scan(&rootID)
-	if err != nil {
-		return nil, mapPgError(err, "GetRootHandle", shareName)
-	}
-
-	return metadata.EncodeShareHandle(shareName, rootID)
-}
-
-// GetShareOptions returns the share configuration options.
-// Returns ErrNotFound if the share doesn't exist.
+// GetShareOptions returns the share configuration options, reporting
+// ErrNotFound if the share does not exist.
+//
+// This shadows the promoted Core.GetShareOptions to put the share cache in
+// front of it: every permission check funnels through this read, so the SELECT
+// and decode are worth skipping. The returned value is always a deep copy, so
+// a caller can never reach the shared cache entry.
 func (s *PostgresMetadataStore) GetShareOptions(ctx context.Context, shareName string) (*metadata.ShareOptions, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	// Cache fast path: skip the SELECT + decode on a hit. Return a deep copy so
-	// callers can never mutate the shared cache entry.
 	if cached, ok := s.shareCache.Get(shareName); ok {
 		return sharecache.Clone(cached), nil
 	}
@@ -59,23 +40,13 @@ func (s *PostgresMetadataStore) GetShareOptions(ctx context.Context, shareName s
 	// that races this read cannot leave a stale value cached (Store checks it).
 	gen := s.shareCache.Generation()
 
-	query := `SELECT options FROM shares WHERE share_name = $1`
-
-	var optionsJSON []byte
-	err := s.queryRow(ctx, query, shareName).Scan(&optionsJSON)
+	options, err := s.Core.GetShareOptions(ctx, shareName)
 	if err != nil {
-		return nil, mapPgError(err, "GetShareOptions", shareName)
+		return nil, err
 	}
 
-	var options metadata.ShareOptions
-	if len(optionsJSON) > 0 {
-		if err := json.Unmarshal(optionsJSON, &options); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal share options: %w", err)
-		}
-	}
-
-	s.shareCache.Store(shareName, &options, gen)
-	return sharecache.Clone(&options), nil
+	s.shareCache.Store(shareName, options, gen)
+	return sharecache.Clone(options), nil
 }
 
 // ============================================================================
@@ -183,36 +154,6 @@ func (s *PostgresMetadataStore) DeleteShare(ctx context.Context, shareName strin
 	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
 		return tx.DeleteShare(ctx, shareName)
 	})
-}
-
-// ListShares returns the names of all shares.
-func (s *PostgresMetadataStore) ListShares(ctx context.Context) ([]string, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	rows, err := s.query(ctx, `SELECT share_name FROM shares`)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var names []string
-	for rows.Next() {
-		var name string
-		if err := rows.Scan(&name); err != nil {
-			return nil, err
-		}
-		names = append(names, name)
-	}
-
-	// Surface any error that terminated the iteration early so a partial
-	// share list is not returned as if it were complete.
-	if err := rows.Err(); err != nil {
-		return nil, mapPgError(err, "ListShares", "")
-	}
-
-	return names, nil
 }
 
 // ============================================================================

--- a/pkg/metadata/store/postgres/store.go
+++ b/pkg/metadata/store/postgres/store.go
@@ -151,7 +151,7 @@ func NewPostgresMetadataStore(
 		quota:        basestore.NewQuotaCache(),
 	}
 	// The shared SQL bodies run on the pool for store-level calls.
-	store.Core = &storesql.Core{X: poolExecer{s: store}, D: pgDialect}
+	store.Core = &storesql.Core{X: poolExecer{s: store}, D: pgDialect, Caps: store.currentCapabilities}
 
 	// The substores derive only from pool, which is never reassigned, so bind
 	// them once here.

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -148,7 +148,7 @@ func (s *PostgresMetadataStore) withTransaction(ctx context.Context, fn func(tx 
 		}
 
 		ptx := &postgresTransaction{store: s, tx: tx}
-		ptx.Core = &storesql.Core{X: txExecer{tx: tx}, D: pgDialect}
+		ptx.Core = &storesql.Core{X: txExecer{tx: tx}, D: pgDialect, Caps: s.currentCapabilities}
 		if err := fn(ptx); err != nil {
 			// Apply timeout to rollback to prevent indefinite blocking
 			rollbackCtx, rollbackCancel := context.WithTimeout(ctx, poolConnectionAcquireTimeout)
@@ -565,12 +565,6 @@ func (tx *postgresTransaction) DeleteChild(ctx context.Context, dirHandle metada
 	return nil
 }
 
-func (tx *postgresTransaction) SetParent(ctx context.Context, handle metadata.FileHandle, parentHandle metadata.FileHandle) error {
-	// In PostgreSQL, parent is tracked via parent_child_map table
-	// This is already handled by SetChild
-	return nil
-}
-
 func (tx *postgresTransaction) SetLinkCount(ctx context.Context, handle metadata.FileHandle, count uint32) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -592,30 +586,6 @@ func (tx *postgresTransaction) SetLinkCount(ctx context.Context, handle metadata
 	}
 
 	return nil
-}
-
-func (tx *postgresTransaction) GetFilesystemMeta(ctx context.Context, shareName string) (*metadata.FilesystemMeta, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	query := `SELECT meta FROM filesystem_meta WHERE share_name = $1`
-
-	var data []byte
-	err := tx.tx.QueryRow(ctx, query, shareName).Scan(&data)
-	if err != nil {
-		// Return defaults if not found
-		return &metadata.FilesystemMeta{
-			Capabilities: tx.store.capabilities,
-		}, nil
-	}
-
-	var meta metadata.FilesystemMeta
-	if err := json.Unmarshal(data, &meta); err != nil {
-		return nil, err
-	}
-
-	return &meta, nil
 }
 
 func (tx *postgresTransaction) PutFilesystemMeta(ctx context.Context, shareName string, meta *metadata.FilesystemMeta) error {
@@ -649,45 +619,6 @@ func (tx *postgresTransaction) GenerateHandle(ctx context.Context, shareName str
 // ============================================================================
 // Transaction Shares Operations
 // ============================================================================
-
-func (tx *postgresTransaction) GetRootHandle(ctx context.Context, shareName string) (metadata.FileHandle, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	query := `SELECT root_file_id FROM shares WHERE share_name = $1`
-
-	var rootID uuid.UUID
-	err := tx.tx.QueryRow(ctx, query, shareName).Scan(&rootID)
-	if err != nil {
-		return nil, mapPgError(err, "GetRootHandle", shareName)
-	}
-
-	return metadata.EncodeShareHandle(shareName, rootID)
-}
-
-func (tx *postgresTransaction) GetShareOptions(ctx context.Context, shareName string) (*metadata.ShareOptions, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	query := `SELECT options FROM shares WHERE share_name = $1`
-
-	var optionsJSON []byte
-	err := tx.tx.QueryRow(ctx, query, shareName).Scan(&optionsJSON)
-	if err != nil {
-		return nil, mapPgError(err, "GetShareOptions", shareName)
-	}
-
-	var options metadata.ShareOptions
-	if len(optionsJSON) > 0 {
-		if err := json.Unmarshal(optionsJSON, &options); err != nil {
-			return nil, mapPgError(err, "GetShareOptions", shareName)
-		}
-	}
-
-	return &options, nil
-}
 
 func (tx *postgresTransaction) CreateShare(ctx context.Context, share *metadata.Share) error {
 	if err := ctx.Err(); err != nil {
@@ -820,35 +751,6 @@ func (tx *postgresTransaction) collectShareQuotaFreed(ctx context.Context, share
 		return mapPgError(err, "DeleteShare", shareName)
 	}
 	return nil
-}
-
-func (tx *postgresTransaction) ListShares(ctx context.Context) ([]string, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	rows, err := tx.tx.Query(ctx, `SELECT share_name FROM shares`)
-	if err != nil {
-		return nil, mapPgError(err, "ListShares", "")
-	}
-	defer rows.Close()
-
-	var names []string
-	for rows.Next() {
-		var name string
-		if err := rows.Scan(&name); err != nil {
-			return nil, err
-		}
-		names = append(names, name)
-	}
-
-	// Surface any error that terminated the iteration early so a partial
-	// share list is not returned as if it were complete.
-	if err := rows.Err(); err != nil {
-		return nil, mapPgError(err, "ListShares", "")
-	}
-
-	return names, nil
 }
 
 func (tx *postgresTransaction) CreateRootDirectory(ctx context.Context, shareName string, attr *metadata.FileAttr) (*metadata.File, error) {

--- a/pkg/metadata/store/sql/chunks.go
+++ b/pkg/metadata/store/sql/chunks.go
@@ -28,6 +28,11 @@ type Core struct {
 	X Executor
 	// D supplies statement text and classifies driver errors. Never nil.
 	D Dialect
+	// Caps reports the store's currently configured filesystem capabilities.
+	// It is a function rather than a value because SetFilesystemCapabilities
+	// replaces them at runtime, and a copy taken at construction would go
+	// stale. Never nil.
+	Caps func() metadata.FilesystemCapabilities
 }
 
 // GetFileChunk reads one chunk by id, reporting metadata.ErrFileChunkNotFound

--- a/pkg/metadata/store/sql/dialect.go
+++ b/pkg/metadata/store/sql/dialect.go
@@ -40,6 +40,27 @@ type Dialect interface {
 	// Files returns the dialect's file and directory read statements, under
 	// the same package-level-value expectation as Chunks.
 	Files() *FileQueries
+
+	// Shares returns the dialect's share read statements, under the same
+	// package-level-value expectation as Chunks.
+	Shares() *ShareQueries
+}
+
+// ShareQueries holds the share read statements in one dialect's syntax. These
+// differ only in placeholder syntax, but a placeholder is not a value a driver
+// will substitute, so each dialect still spells its own.
+type ShareQueries struct {
+	// GetRootHandle selects a share's root inode id. One parameter: the share
+	// name.
+	GetRootHandle string
+	// GetShareOptions selects a share's options blob. One parameter: the share
+	// name.
+	GetShareOptions string
+	// ListShares selects every share name. No parameters.
+	ListShares string
+	// GetFilesystemMeta selects a share's filesystem metadata blob. One
+	// parameter: the share name.
+	GetFilesystemMeta string
 }
 
 // FileQueries holds the file and directory read statements in one dialect's

--- a/pkg/metadata/store/sql/files.go
+++ b/pkg/metadata/store/sql/files.go
@@ -157,6 +157,15 @@ func (c *Core) GetFileByPayloadID(ctx context.Context, payloadID metadata.Payloa
 	return file, nil
 }
 
+// SetParent records a file's parent. It writes nothing: the parent edge lives
+// in parent_child_map, which SetChild already maintains, so there is no second
+// place to keep in step. It still reports cancellation, so a caller draining a
+// tree in a tight loop sees the context give out here as it would anywhere
+// else.
+func (c *Core) SetParent(ctx context.Context, handle metadata.FileHandle, parentHandle metadata.FileHandle) error {
+	return ctx.Err()
+}
+
 // listChildrenDefaultLimit is the page size applied when the caller passes a
 // non-positive limit.
 const listChildrenDefaultLimit = 1000

--- a/pkg/metadata/store/sql/shares.go
+++ b/pkg/metadata/store/sql/shares.go
@@ -1,0 +1,117 @@
+package sql
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// ============================================================================
+// Share reads
+// ============================================================================
+//
+// As with the file reads, these are pure and so want the identical body on the
+// pool path and the transaction path. GetShareOptions is the uncached backing
+// read; the store shadows it with its share cache and calls back into this one
+// for the miss.
+
+// GetRootHandle returns the root handle for a share, reporting ErrNotFound when
+// the share does not exist.
+func (c *Core) GetRootHandle(ctx context.Context, shareName string) (metadata.FileHandle, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	var rootID uuid.UUID
+	if err := c.X.QueryRow(ctx, c.D.Shares().GetRootHandle, shareName).Scan(&rootID); err != nil {
+		return nil, c.D.MapError(err, "GetRootHandle", shareName)
+	}
+
+	return metadata.EncodeShareHandle(shareName, rootID)
+}
+
+// GetShareOptions reads a share's options straight from the backing store,
+// reporting ErrNotFound when the share does not exist.
+//
+// The returned value is freshly decoded on every call and aliases nothing, so
+// a caller may hold or mutate it. That is what lets the store layer cache it
+// by handing out copies.
+func (c *Core) GetShareOptions(ctx context.Context, shareName string) (*metadata.ShareOptions, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	var optionsJSON []byte
+	if err := c.X.QueryRow(ctx, c.D.Shares().GetShareOptions, shareName).Scan(&optionsJSON); err != nil {
+		return nil, c.D.MapError(err, "GetShareOptions", shareName)
+	}
+
+	var options metadata.ShareOptions
+	if len(optionsJSON) > 0 {
+		if err := json.Unmarshal(optionsJSON, &options); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal share options: %w", err)
+		}
+	}
+
+	return &options, nil
+}
+
+// ListShares returns the names of every share in the store.
+func (c *Core) ListShares(ctx context.Context) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	rows, err := c.X.Query(ctx, c.D.Shares().ListShares)
+	if err != nil {
+		return nil, c.D.MapError(err, "ListShares", "")
+	}
+	defer rows.Close()
+
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		names = append(names, name)
+	}
+
+	// Surface an error that terminated the iteration early so a partial share
+	// list is not returned as if it were complete.
+	if err := rows.Err(); err != nil {
+		return nil, c.D.MapError(err, "ListShares", "")
+	}
+
+	return names, nil
+}
+
+// GetFilesystemMeta returns a share's stored filesystem metadata, or the
+// store's configured capabilities when the share has none.
+//
+// ponytail: any read failure — not just a missing row — reports the defaults,
+// because postgres has no filesystem_meta table at all and every call there
+// fails with an undefined-relation error. Tighten this to the no-rows case
+// alone once that table exists on both dialects; until then the strict version
+// fails the conformance suite on postgres.
+func (c *Core) GetFilesystemMeta(ctx context.Context, shareName string) (*metadata.FilesystemMeta, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	var data []byte
+	if err := c.X.QueryRow(ctx, c.D.Shares().GetFilesystemMeta, shareName).Scan(&data); err != nil {
+		return &metadata.FilesystemMeta{Capabilities: c.Caps()}, nil
+	}
+
+	var meta metadata.FilesystemMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, err
+	}
+
+	return &meta, nil
+}

--- a/pkg/metadata/store/sql/shares.go
+++ b/pkg/metadata/store/sql/shares.go
@@ -93,11 +93,13 @@ func (c *Core) ListShares(ctx context.Context) ([]string, error) {
 // GetFilesystemMeta returns a share's stored filesystem metadata, or the
 // store's configured capabilities when the share has none.
 //
-// ponytail: every read failure except a cancelled context — not just a missing
-// row — reports the defaults, because postgres has no filesystem_meta table at
-// all and each call there fails with an undefined-relation error. Narrow this
-// to the no-rows case alone once that table exists on both dialects; until
-// then the strict version fails the conformance suite on postgres.
+// ponytail: every read failure reports the defaults — not just a missing row —
+// because postgres has no filesystem_meta table at all and each call there
+// fails with an undefined-relation error. The one exception is a context that
+// has given out, cancelled or past its deadline alike, which is returned.
+// Narrow this to the no-rows case alone once that table exists on both
+// dialects; until then the strict version fails the conformance suite on
+// postgres.
 func (c *Core) GetFilesystemMeta(ctx context.Context, shareName string) (*metadata.FilesystemMeta, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -106,8 +108,8 @@ func (c *Core) GetFilesystemMeta(ctx context.Context, shareName string) (*metada
 	var data []byte
 	if err := c.X.QueryRow(ctx, c.D.Shares().GetFilesystemMeta, shareName).Scan(&data); err != nil {
 		// The context can give out while the query is in flight, and a
-		// cancelled request must not read as a share with default
-		// capabilities.
+		// request that is cancelled or past its deadline must not read as a
+		// share with default capabilities.
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, ctxErr
 		}

--- a/pkg/metadata/store/sql/shares.go
+++ b/pkg/metadata/store/sql/shares.go
@@ -93,11 +93,11 @@ func (c *Core) ListShares(ctx context.Context) ([]string, error) {
 // GetFilesystemMeta returns a share's stored filesystem metadata, or the
 // store's configured capabilities when the share has none.
 //
-// ponytail: any read failure — not just a missing row — reports the defaults,
-// because postgres has no filesystem_meta table at all and every call there
-// fails with an undefined-relation error. Tighten this to the no-rows case
-// alone once that table exists on both dialects; until then the strict version
-// fails the conformance suite on postgres.
+// ponytail: every read failure except a cancelled context — not just a missing
+// row — reports the defaults, because postgres has no filesystem_meta table at
+// all and each call there fails with an undefined-relation error. Narrow this
+// to the no-rows case alone once that table exists on both dialects; until
+// then the strict version fails the conformance suite on postgres.
 func (c *Core) GetFilesystemMeta(ctx context.Context, shareName string) (*metadata.FilesystemMeta, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -105,6 +105,12 @@ func (c *Core) GetFilesystemMeta(ctx context.Context, shareName string) (*metada
 
 	var data []byte
 	if err := c.X.QueryRow(ctx, c.D.Shares().GetFilesystemMeta, shareName).Scan(&data); err != nil {
+		// The context can give out while the query is in flight, and a
+		// cancelled request must not read as a share with default
+		// capabilities.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
 		return &metadata.FilesystemMeta{Capabilities: c.Caps()}, nil
 	}
 

--- a/pkg/metadata/store/sqlite/dialect.go
+++ b/pkg/metadata/store/sqlite/dialect.go
@@ -90,4 +90,14 @@ var fileQueries = storesql.FileQueries{
 		LIMIT 1`,
 }
 
+// Shares returns the SQLite share read statements.
+func (dialect) Shares() *storesql.ShareQueries { return &shareQueries }
+
+var shareQueries = storesql.ShareQueries{
+	GetRootHandle:     `SELECT root_file_id FROM shares WHERE share_name = ?1`,
+	GetShareOptions:   `SELECT options FROM shares WHERE share_name = ?1`,
+	ListShares:        `SELECT share_name FROM shares`,
+	GetFilesystemMeta: `SELECT meta FROM filesystem_meta WHERE share_name = ?1`,
+}
+
 var _ storesql.Dialect = dialect{}

--- a/pkg/metadata/store/sqlite/files.go
+++ b/pkg/metadata/store/sqlite/files.go
@@ -3,7 +3,6 @@ package sqlite
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -62,47 +61,11 @@ func (s *SQLiteMetadataStore) DeleteChild(ctx context.Context, dirHandle metadat
 	})
 }
 
-// SetParent sets the parent handle for a file/directory.
-//
-// Parent tracking is handled implicitly by parent_child_map via SetChild, so
-// this performs no write. It still honours context cancellation, matching the
-// prior WithTransaction-based implementation, while avoiding the cost of
-// opening an empty transaction.
-func (s *SQLiteMetadataStore) SetParent(ctx context.Context, handle metadata.FileHandle, parentHandle metadata.FileHandle) error {
-	return ctx.Err()
-}
-
 // SetLinkCount sets the hard link count for a file.
 func (s *SQLiteMetadataStore) SetLinkCount(ctx context.Context, handle metadata.FileHandle, count uint32) error {
 	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
 		return tx.SetLinkCount(ctx, handle, count)
 	})
-}
-
-// GetFilesystemMeta retrieves filesystem metadata for a share.
-// Uses direct pool query without transaction for better performance.
-func (s *SQLiteMetadataStore) GetFilesystemMeta(ctx context.Context, shareName string) (*metadata.FilesystemMeta, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	query := `SELECT meta FROM filesystem_meta WHERE share_name = ?1`
-
-	var data []byte
-	err := s.queryRow(ctx, query, shareName).Scan(&data)
-	if err != nil {
-		// Return defaults if not found
-		return &metadata.FilesystemMeta{
-			Capabilities: s.capabilities,
-		}, nil
-	}
-
-	var meta metadata.FilesystemMeta
-	if err := json.Unmarshal(data, &meta); err != nil {
-		return nil, err
-	}
-
-	return &meta, nil
 }
 
 // PutFilesystemMeta stores filesystem metadata for a share.

--- a/pkg/metadata/store/sqlite/server.go
+++ b/pkg/metadata/store/sqlite/server.go
@@ -111,3 +111,10 @@ func (s *SQLiteMetadataStore) GetFilesystemStatistics(ctx context.Context, handl
 	}
 	return basestore.BuildStatistics(bytesUsed, filesUsed), nil
 }
+
+// currentCapabilities reports the capabilities the store is configured with
+// right now. SetFilesystemCapabilities replaces them, so the shared reads take
+// this rather than a copy captured at construction.
+func (s *SQLiteMetadataStore) currentCapabilities() metadata.FilesystemCapabilities {
+	return s.capabilities
+}

--- a/pkg/metadata/store/sqlite/shares.go
+++ b/pkg/metadata/store/sqlite/shares.go
@@ -32,6 +32,12 @@ func (s *SQLiteMetadataStore) GenerateHandle(ctx context.Context, shareName stri
 // and decode are worth skipping. The returned value is always a deep copy, so
 // a caller can never reach the shared cache entry.
 func (s *SQLiteMetadataStore) GetShareOptions(ctx context.Context, shareName string) (*metadata.ShareOptions, error) {
+	// Ahead of the cache lookup, not just inside the backing read: a hit must
+	// not report success for a request whose context has already given out.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	if cached, ok := s.shareCache.Get(shareName); ok {
 		return sharecache.Clone(cached), nil
 	}

--- a/pkg/metadata/store/sqlite/shares.go
+++ b/pkg/metadata/store/sqlite/shares.go
@@ -24,33 +24,14 @@ func (s *SQLiteMetadataStore) GenerateHandle(ctx context.Context, shareName stri
 	return basestore.GenerateHandle(ctx, shareName)
 }
 
-// GetRootHandle returns the root handle for a share.
-// Returns ErrNotFound if the share doesn't exist.
-func (s *SQLiteMetadataStore) GetRootHandle(ctx context.Context, shareName string) (metadata.FileHandle, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	query := `SELECT root_file_id FROM shares WHERE share_name = ?1`
-
-	var rootID uuid.UUID
-	err := s.queryRow(ctx, query, shareName).Scan(&rootID)
-	if err != nil {
-		return nil, mapDBError(err, "GetRootHandle", shareName)
-	}
-
-	return metadata.EncodeShareHandle(shareName, rootID)
-}
-
-// GetShareOptions returns the share configuration options.
-// Returns ErrNotFound if the share doesn't exist.
+// GetShareOptions returns the share configuration options, reporting
+// ErrNotFound if the share does not exist.
+//
+// This shadows the promoted Core.GetShareOptions to put the share cache in
+// front of it: every permission check funnels through this read, so the SELECT
+// and decode are worth skipping. The returned value is always a deep copy, so
+// a caller can never reach the shared cache entry.
 func (s *SQLiteMetadataStore) GetShareOptions(ctx context.Context, shareName string) (*metadata.ShareOptions, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	// Cache fast path: skip the SELECT + decode on a hit. Return a deep copy so
-	// callers can never mutate the shared cache entry.
 	if cached, ok := s.shareCache.Get(shareName); ok {
 		return sharecache.Clone(cached), nil
 	}
@@ -59,23 +40,13 @@ func (s *SQLiteMetadataStore) GetShareOptions(ctx context.Context, shareName str
 	// that races this read cannot leave a stale value cached (Store checks it).
 	gen := s.shareCache.Generation()
 
-	query := `SELECT options FROM shares WHERE share_name = ?1`
-
-	var optionsJSON []byte
-	err := s.queryRow(ctx, query, shareName).Scan(&optionsJSON)
+	options, err := s.Core.GetShareOptions(ctx, shareName)
 	if err != nil {
-		return nil, mapDBError(err, "GetShareOptions", shareName)
+		return nil, err
 	}
 
-	var options metadata.ShareOptions
-	if len(optionsJSON) > 0 {
-		if err := json.Unmarshal(optionsJSON, &options); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal share options: %w", err)
-		}
-	}
-
-	s.shareCache.Store(shareName, &options, gen)
-	return sharecache.Clone(&options), nil
+	s.shareCache.Store(shareName, options, gen)
+	return sharecache.Clone(options), nil
 }
 
 // ============================================================================
@@ -183,36 +154,6 @@ func (s *SQLiteMetadataStore) DeleteShare(ctx context.Context, shareName string)
 	return s.WithTransaction(ctx, func(tx metadata.Transaction) error {
 		return tx.DeleteShare(ctx, shareName)
 	})
-}
-
-// ListShares returns the names of all shares.
-func (s *SQLiteMetadataStore) ListShares(ctx context.Context) ([]string, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	rows, err := s.query(ctx, `SELECT share_name FROM shares`)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var names []string
-	for rows.Next() {
-		var name string
-		if err := rows.Scan(&name); err != nil {
-			return nil, err
-		}
-		names = append(names, name)
-	}
-
-	// Surface any error that terminated the iteration early so a partial
-	// share list is not returned as if it were complete.
-	if err := rows.Err(); err != nil {
-		return nil, mapDBError(err, "ListShares", "")
-	}
-
-	return names, nil
 }
 
 // ============================================================================

--- a/pkg/metadata/store/sqlite/store.go
+++ b/pkg/metadata/store/sqlite/store.go
@@ -164,7 +164,7 @@ func NewSQLiteMetadataStore(
 		quota:        basestore.NewQuotaCache(),
 	}
 	// The shared SQL bodies run on the pool for store-level calls.
-	store.Core = &storesql.Core{X: store.conn(), D: sqliteDialect}
+	store.Core = &storesql.Core{X: store.conn(), D: sqliteDialect, Caps: store.currentCapabilities}
 
 	// The substores derive only from db, which is never reassigned, so bind
 	// them once here.

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -98,7 +98,7 @@ func (s *SQLiteMetadataStore) WithTransaction(ctx context.Context, fn func(tx me
 		}
 
 		ptx := &sqliteTransaction{store: s, tx: execer{e: rawTx, op: "tx"}}
-		ptx.Core = &storesql.Core{X: ptx.tx, D: sqliteDialect}
+		ptx.Core = &storesql.Core{X: ptx.tx, D: sqliteDialect, Caps: s.currentCapabilities}
 		if err := fn(ptx); err != nil {
 			_ = rawTx.Rollback()
 			if isBusyError(err) {
@@ -508,12 +508,6 @@ func (tx *sqliteTransaction) DeleteChild(ctx context.Context, dirHandle metadata
 	return nil
 }
 
-func (tx *sqliteTransaction) SetParent(ctx context.Context, handle metadata.FileHandle, parentHandle metadata.FileHandle) error {
-	// Parent is tracked via the parent_child_map table, already handled by SetChild.
-	// Still honours context cancellation, matching the store-level SetParent.
-	return ctx.Err()
-}
-
 func (tx *sqliteTransaction) SetLinkCount(ctx context.Context, handle metadata.FileHandle, count uint32) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -535,30 +529,6 @@ func (tx *sqliteTransaction) SetLinkCount(ctx context.Context, handle metadata.F
 	}
 
 	return nil
-}
-
-func (tx *sqliteTransaction) GetFilesystemMeta(ctx context.Context, shareName string) (*metadata.FilesystemMeta, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	query := `SELECT meta FROM filesystem_meta WHERE share_name = ?1`
-
-	var data []byte
-	err := tx.tx.QueryRow(ctx, query, shareName).Scan(&data)
-	if err != nil {
-		// Return defaults if not found
-		return &metadata.FilesystemMeta{
-			Capabilities: tx.store.capabilities,
-		}, nil
-	}
-
-	var meta metadata.FilesystemMeta
-	if err := json.Unmarshal(data, &meta); err != nil {
-		return nil, err
-	}
-
-	return &meta, nil
 }
 
 func (tx *sqliteTransaction) PutFilesystemMeta(ctx context.Context, shareName string, meta *metadata.FilesystemMeta) error {
@@ -592,45 +562,6 @@ func (tx *sqliteTransaction) GenerateHandle(ctx context.Context, shareName strin
 // ============================================================================
 // Transaction Shares Operations
 // ============================================================================
-
-func (tx *sqliteTransaction) GetRootHandle(ctx context.Context, shareName string) (metadata.FileHandle, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	query := `SELECT root_file_id FROM shares WHERE share_name = ?1`
-
-	var rootID uuid.UUID
-	err := tx.tx.QueryRow(ctx, query, shareName).Scan(&rootID)
-	if err != nil {
-		return nil, mapDBError(err, "GetRootHandle", shareName)
-	}
-
-	return metadata.EncodeShareHandle(shareName, rootID)
-}
-
-func (tx *sqliteTransaction) GetShareOptions(ctx context.Context, shareName string) (*metadata.ShareOptions, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	query := `SELECT options FROM shares WHERE share_name = ?1`
-
-	var optionsJSON []byte
-	err := tx.tx.QueryRow(ctx, query, shareName).Scan(&optionsJSON)
-	if err != nil {
-		return nil, mapDBError(err, "GetShareOptions", shareName)
-	}
-
-	var options metadata.ShareOptions
-	if len(optionsJSON) > 0 {
-		if err := json.Unmarshal(optionsJSON, &options); err != nil {
-			return nil, mapDBError(err, "GetShareOptions", shareName)
-		}
-	}
-
-	return &options, nil
-}
 
 func (tx *sqliteTransaction) CreateShare(ctx context.Context, share *metadata.Share) error {
 	if err := ctx.Err(); err != nil {
@@ -749,35 +680,6 @@ func (tx *sqliteTransaction) collectShareQuotaFreed(ctx context.Context, shareNa
 		return mapDBError(err, "DeleteShare", shareName)
 	}
 	return nil
-}
-
-func (tx *sqliteTransaction) ListShares(ctx context.Context) ([]string, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	rows, err := tx.tx.Query(ctx, `SELECT share_name FROM shares`)
-	if err != nil {
-		return nil, mapDBError(err, "ListShares", "")
-	}
-	defer rows.Close()
-
-	var names []string
-	for rows.Next() {
-		var name string
-		if err := rows.Scan(&name); err != nil {
-			return nil, err
-		}
-		names = append(names, name)
-	}
-
-	// Surface any error that terminated the iteration early so a partial
-	// share list is not returned as if it were complete.
-	if err := rows.Err(); err != nil {
-		return nil, mapDBError(err, "ListShares", "")
-	}
-
-	return names, nil
 }
 
 func (tx *sqliteTransaction) CreateRootDirectory(ctx context.Context, shareName string, attr *metadata.FileAttr) (*metadata.File, error) {

--- a/pkg/metadata/storetest/share_options_ops.go
+++ b/pkg/metadata/storetest/share_options_ops.go
@@ -1,6 +1,7 @@
 package storetest
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -75,6 +76,25 @@ func runShareOptionsOps(t *testing.T, factory StoreFactory) {
 
 		_, err = store.GetShareOptions(ctx, "/opts-delete")
 		require.Error(t, err, "read served options for a deleted share")
+	})
+
+	t.Run("CancelledContextIsRefused", func(t *testing.T) {
+		store := factory(t)
+		ctx := t.Context()
+		require.NoError(t, store.CreateShare(ctx, &metadata.Share{Name: "/opts-cancel"}))
+
+		// Read once so a caching backend is warm. The cache-hit path is the
+		// one that skips the backing read, so it is also the one that can
+		// answer a cancelled request without ever noticing.
+		_, err := store.GetShareOptions(ctx, "/opts-cancel")
+		require.NoError(t, err)
+
+		cancelled, cancel := context.WithCancel(ctx)
+		cancel()
+
+		_, err = store.GetShareOptions(cancelled, "/opts-cancel")
+		require.ErrorIs(t, err, context.Canceled,
+			"a cancelled request was served options anyway")
 	})
 
 	t.Run("RolledBackUpdateIsNotVisible", func(t *testing.T) {


### PR DESCRIPTION
Part of #1828. Stacked on #2235.

Same treatment as #2235, applied to the share reads: `GetRootHandle`,
`GetShareOptions`, `ListShares` and `GetFilesystemMeta` each existed as a store
copy and a transaction copy in both dialects. They now live once on
`store/sql.Core`. `SetParent` joins them (see below).

Two of them needed something the earlier stage did not:

- **`GetShareOptions` keeps its cache.** `Core.GetShareOptions` is the uncached
  backing read; each store *shadows* the promoted method with the cache wrapper
  and calls back into `s.Core.GetShareOptions` for the miss. This is the shape
  #2223 used for badger. The generation snapshot still straddles the backing
  read, and the caller still only ever sees a deep copy.
- **`Core.Caps`** is a new field: a `func() metadata.FilesystemCapabilities`
  rather than a value, because `SetFilesystemCapabilities` replaces them at
  runtime and a copy taken at construction would go stale.

`Dialect` gains `Shares() *ShareQueries`. Unlike `FileQueries` these four
statements differ *only* in placeholder syntax — but a placeholder is not a
value a driver substitutes, so each dialect still spells its own.

### `SetParent` — the Copilot finding on #2235

Three of the four implementations returned `ctx.Err()`; the postgres
transaction returned bare `nil`. It is a no-op on both dialects at both levels
(the parent edge lives in `parent_child_map` and `SetChild` writes it), so it
collapses to one shared body — which removes the outlier by construction
rather than patching it.

### What merging these turned up: #2236

Collapsing `GetFilesystemMeta` meant looking at its error handling, which in all
four copies was:

```go
err := ...Scan(&data)
if err != nil {
    // "Return defaults if not found"
    return &metadata.FilesystemMeta{Capabilities: caps}, nil
}
```

That branch catches *any* error, not just a missing row. Splitting it so only
the no-rows sentinel yields defaults immediately failed
`TestConformance/StoreSurface/FilesystemMetaStatsCaps` on postgres with
`[42P01] relation "filesystem_meta" does not exist`.

**Postgres has never had that table.** sqlite creates it in
`000001_initial_schema.up.sql`; no postgres migration does. Confirmed against a
live postgres 16 with all 45 migrations applied — `to_regclass` returns NULL. So
every postgres `GetFilesystemMeta` call has been failing and landing in the
swallow, and `PutFilesystemMeta` cannot ever have persisted anything. The one
conformance assertion — "returns a populated struct with a sane
`MaxFilenameLen`" — is satisfied by exactly the fallback, so the test passed on
a backend that could not read the table it was testing.

Filed as **#2236**. This PR restores the swallow verbatim under a `ponytail:`
marker naming the migration as the upgrade path, rather than shipping a strict
version that red-lines postgres. Neither method has a production caller, so
nothing is at risk today.

Also settled: the transaction `GetShareOptions` wrapped a JSON decode failure in
the driver-error mapper; the pool path wrapped it in `fmt.Errorf`. The shared
body takes the latter, since a malformed blob is not a driver error.

### Verification

- `go build ./...`, `go vet ./...`, `gofmt` clean
- `go test -tags=integration -p 1 ./pkg/metadata/...` green against a real
  postgres 16, plus badger / sqlite / memory

---

### Copilot round 1 — two fixes

- **`GetShareOptions` cache-hit path had lost its `ctx.Err()` check.** A real
  regression: the old store method checked before the cache lookup, my shadow
  only reached the check on a miss, so a warm cache answered a cancelled
  request. Restored ahead of the lookup — which is where badger already has it.
  Now pinned by `ShareOptionsOps/CancelledContextIsRefused`, which reads once to
  warm the cache and *then* cancels. Verified against the broken build: it fails
  on sqlite with the check removed and passes on memory and badger, which never
  had the bug.
- **`GetFilesystemMeta` could swallow a cancellation that arrived mid-query.**
  Pre-existing (the old blanket swallow did the same), but cheap to narrow while
  the body is being rewritten: the error branch now re-checks `ctx.Err()` and
  returns it rather than reporting default capabilities. The `ponytail:` marker
  says so.
