### PR TITLE
refactor(metadata): one body for the share options and share delete writes

### DIFF
--- a/pkg/metadata/store/postgres/dialect.go
+++ b/pkg/metadata/store/postgres/dialect.go
@@ -114,6 +114,11 @@ var shareQueries = storesql.ShareQueries{
 	PutFilesystemMeta: `INSERT INTO filesystem_meta (share_name, meta)
 		VALUES ($1, $2)
 		ON CONFLICT (share_name) DO UPDATE SET meta = EXCLUDED.meta`,
+	SetShareOptions:   `UPDATE shares SET options = $1 WHERE share_name = $2`,
+	DeleteShare:       `DELETE FROM shares WHERE share_name = $1`,
+	DeleteShareInodes: `DELETE FROM inodes WHERE share_name = $1`,
+	ShareQuotaFreed: `SELECT %s, COALESCE(SUM(size), 0), COUNT(*) FROM inodes
+		WHERE share_name = $1 AND file_type = $2 GROUP BY %s`,
 }
 
 var _ storesql.Dialect = dialect{}

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -507,6 +507,18 @@ func (tx *postgresTransaction) DeleteFile(ctx context.Context, handle metadata.F
 // ============================================================================
 // Transaction Shares Operations
 // ============================================================================
+//
+// UpdateShareOptions and DeleteShare shadow their promoted Core namesakes for
+// one reason: sharesDirty. It tells the commit path to drop the store's share
+// cache, it lives on the transaction, and Core has no way to reach it — so the
+// flag is set here and the statement runs there. Delete a shadow and the build
+// still passes, since the promoted method satisfies the interface, but the
+// cache then serves the options the transaction just overwrote.
+//
+// CreateShare keeps its own body: it runs the same UPDATE, but the memory and
+// badger transactions reject a name that already exists where these two
+// silently overwrite it, and collapsing the SQL pair onto Core would fix that
+// divergence in place rather than decide it.
 
 func (tx *postgresTransaction) CreateShare(ctx context.Context, share *metadata.Share) error {
 	if err := ctx.Err(); err != nil {
@@ -530,31 +542,8 @@ func (tx *postgresTransaction) CreateShare(ctx context.Context, share *metadata.
 }
 
 func (tx *postgresTransaction) UpdateShareOptions(ctx context.Context, shareName string, options *metadata.ShareOptions) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
 	tx.sharesDirty = true
-
-	optionsData, err := json.Marshal(options)
-	if err != nil {
-		return err
-	}
-
-	query := `UPDATE shares SET options = $1 WHERE share_name = $2`
-	result, err := tx.tx.Exec(ctx, query, optionsData, shareName)
-	if err != nil {
-		return mapPgError(err, "UpdateShareOptions", shareName)
-	}
-
-	if result.RowsAffected() == 0 {
-		return &metadata.StoreError{
-			Code:    metadata.ErrNotFound,
-			Message: "share not found",
-			Path:    shareName,
-		}
-	}
-
-	return nil
+	return tx.Core.UpdateShareOptions(ctx, shareName, options)
 }
 
 func (tx *postgresTransaction) DeleteShare(ctx context.Context, shareName string) error {
@@ -562,20 +551,6 @@ func (tx *postgresTransaction) DeleteShare(ctx context.Context, shareName string
 		return err
 	}
 	tx.sharesDirty = true
-
-	// Sum the regular-file bytes about to be removed so the usedBytes
-	// counter stays accurate without a full recompute. A failed Scan must not
-	// be swallowed: silently proceeding with freedBytes=0 would delete the
-	// files but never decrement the counter, drifting statfs for the process
-	// lifetime.
-	var freedBytes int64
-	if err := tx.tx.QueryRow(ctx,
-		`SELECT COALESCE(SUM(size), 0) FROM inodes
-		 WHERE share_name = $1 AND file_type = $2 AND size > 0`,
-		shareName, int(metadata.FileTypeRegular),
-	).Scan(&freedBytes); err != nil {
-		return mapPgError(err, "DeleteShare", shareName)
-	}
 
 	// Capture per-identity usage about to be removed (uid + gid) so the
 	// in-memory usage cache stays accurate. Aggregated before the rows are

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log/slog"
 	"time"
 
@@ -148,7 +147,7 @@ func (s *PostgresMetadataStore) withTransaction(ctx context.Context, fn func(tx 
 		}
 
 		ptx := &postgresTransaction{store: s, tx: tx}
-		ptx.Core = &storesql.Core{X: txExecer{tx: tx}, D: pgDialect, Caps: s.currentCapabilities}
+		ptx.Core = &storesql.Core{X: txExecer{tx: tx}, D: pgDialect, Caps: s.currentCapabilities, Quota: &ptx.quota}
 		if err := fn(ptx); err != nil {
 			// Apply timeout to rollback to prevent indefinite blocking
 			rollbackCtx, rollbackCancel := context.WithTimeout(ctx, poolConnectionAcquireTimeout)
@@ -547,73 +546,8 @@ func (tx *postgresTransaction) UpdateShareOptions(ctx context.Context, shareName
 }
 
 func (tx *postgresTransaction) DeleteShare(ctx context.Context, shareName string) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
 	tx.sharesDirty = true
-
-	// Capture per-identity usage about to be removed (uid + gid) so the
-	// in-memory usage cache stays accurate. Aggregated before the rows are
-	// deleted; applied to the tx quota delta (post-commit) below.
-	if err := tx.collectShareQuotaFreed(ctx, shareName, "uid", metadata.QuotaScopeUser); err != nil {
-		return err
-	}
-	if err := tx.collectShareQuotaFreed(ctx, shareName, "gid", metadata.QuotaScopeGroup); err != nil {
-		return err
-	}
-
-	// Drop the share row first: shares.root_file_id references inodes(id)
-	// WITHOUT ON DELETE CASCADE, so the inode rows cannot be removed while
-	// the share still points at the root inode.
-	result, err := tx.tx.Exec(ctx, `DELETE FROM shares WHERE share_name = $1`, shareName)
-	if err != nil {
-		return mapPgError(err, "DeleteShare", shareName)
-	}
-	if result.RowsAffected() == 0 {
-		return &metadata.StoreError{
-			Code:    metadata.ErrNotFound,
-			Message: "share not found",
-			Path:    shareName,
-		}
-	}
-
-	// Delete all inode rows for the share. The store.go:161 contract is
-	// "removes a share and all its metadata"; dropping only the share row
-	// orphans every inodes/parent_child_map/file_block_refs row.
-	// parent_child_map and file_block_refs both cascade from inodes(id).
-	if _, err := tx.tx.Exec(ctx, `DELETE FROM inodes WHERE share_name = $1`, shareName); err != nil {
-		return mapPgError(err, "DeleteShare", shareName)
-	}
-
-	return nil
-}
-
-// collectShareQuotaFreed aggregates per-identity usage for the regular files of
-// a share being deleted (grouped by uid or gid) and records the negative delta
-// on the tx so the in-memory usage cache is decremented post-commit. The column
-// is a fixed internal constant, never user input.
-func (tx *postgresTransaction) collectShareQuotaFreed(ctx context.Context, shareName, col string, scope metadata.QuotaScope) error {
-	query := fmt.Sprintf(
-		`SELECT %s, COALESCE(SUM(size), 0), COUNT(*) FROM inodes
-		 WHERE share_name = $1 AND file_type = $2 GROUP BY %s`,
-		col, col,
-	)
-	rows, err := tx.tx.Query(ctx, query, shareName, int(metadata.FileTypeRegular))
-	if err != nil {
-		return mapPgError(err, "DeleteShare", shareName)
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var id, bytes, files int64
-		if err := rows.Scan(&id, &bytes, &files); err != nil {
-			return mapPgError(err, "DeleteShare", shareName)
-		}
-		tx.quota.AddKeyed(basestore.QuotaKey{Share: shareName, Scope: scope, ID: uint32(id)}, metadata.UsageStat{Bytes: -bytes, Files: -files})
-	}
-	if err := rows.Err(); err != nil {
-		return mapPgError(err, "DeleteShare", shareName)
-	}
-	return nil
+	return tx.Core.DeleteShare(ctx, shareName)
 }
 
 func (tx *postgresTransaction) CreateRootDirectory(ctx context.Context, shareName string, attr *metadata.FileAttr) (*metadata.File, error) {

--- a/pkg/metadata/store/sql/chunks.go
+++ b/pkg/metadata/store/sql/chunks.go
@@ -38,6 +38,14 @@ type Core struct {
 	// cache, which applies them once the transaction commits. Set only on a
 	// transaction's Core; the pool's Core leaves it nil, and the one method
 	// that reads it is reached solely through a transaction-level shadow.
+	//
+	// Left unguarded on purpose. A guard would have to invent an error for a
+	// state the package cannot produce, and nothing could ever exercise it, so
+	// it would sit here accruing confidence without having refused anything.
+	// The bare dereference is the louder failure and it is a safe one:
+	// DeleteShare aggregates the usage before it deletes any row, and a panic
+	// inside a transaction unwinds past the commit, so nothing reaches the
+	// database either way.
 	Quota *basestore.QuotaDelta
 }
 

--- a/pkg/metadata/store/sql/chunks.go
+++ b/pkg/metadata/store/sql/chunks.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 )
 
 // Core is the shared half of a SQL-backed metadata store: an executor to run
@@ -33,6 +34,11 @@ type Core struct {
 	// replaces them at runtime, and a copy taken at construction would go
 	// stale. Never nil.
 	Caps func() metadata.FilesystemCapabilities
+	// Quota accumulates the usage changes a write owes the store's quota
+	// cache, which applies them once the transaction commits. Set only on a
+	// transaction's Core; the pool's Core leaves it nil, and the one method
+	// that reads it is reached solely through a transaction-level shadow.
+	Quota *basestore.QuotaDelta
 }
 
 // GetFileChunk reads one chunk by id, reporting metadata.ErrFileChunkNotFound

--- a/pkg/metadata/store/sql/dialect.go
+++ b/pkg/metadata/store/sql/dialect.go
@@ -68,6 +68,21 @@ type ShareQueries struct {
 	// PutFilesystemMeta upserts a share's filesystem metadata blob. Two
 	// parameters: the share name and the encoded blob.
 	PutFilesystemMeta string
+	// SetShareOptions writes a share's options blob over whatever is there.
+	// Two parameters: the encoded blob and the share name.
+	SetShareOptions string
+	// DeleteShare removes one share row. One parameter: the share name.
+	DeleteShare string
+	// DeleteShareInodes removes every inode row belonging to a share. One
+	// parameter: the share name.
+	DeleteShareInodes string
+	// ShareQuotaFreed is a format string, not a statement: it takes the
+	// owner column twice, for the SELECT and the GROUP BY, because a column
+	// name is not something a driver will substitute. The column is a fixed
+	// internal constant, never user input. Two parameters once formatted:
+	// the share name and the numeric regular-file type; three result
+	// columns: the identity, its summed bytes, its file count.
+	ShareQuotaFreed string
 }
 
 // FileQueries holds the file and directory statements in one dialect's

--- a/pkg/metadata/store/sql/shares.go
+++ b/pkg/metadata/store/sql/shares.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 )
 
 // ============================================================================
@@ -138,6 +139,100 @@ func (c *Core) PutFilesystemMeta(ctx context.Context, shareName string, meta *me
 
 	if _, err := c.X.Exec(ctx, c.D.Shares().PutFilesystemMeta, shareName, data); err != nil {
 		return c.D.MapError(err, "PutFilesystemMeta", shareName)
+	}
+	return nil
+}
+
+// UpdateShareOptions replaces an existing share's options, reporting
+// metadata.ErrNotFound when the share does not exist.
+func (c *Core) UpdateShareOptions(ctx context.Context, shareName string, options *metadata.ShareOptions) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	data, err := json.Marshal(options)
+	if err != nil {
+		return err
+	}
+
+	result, err := c.X.Exec(ctx, c.D.Shares().SetShareOptions, data, shareName)
+	if err != nil {
+		return c.D.MapError(err, "UpdateShareOptions", shareName)
+	}
+	if result.RowsAffected() == 0 {
+		return &metadata.StoreError{
+			Code:    metadata.ErrNotFound,
+			Message: "share not found",
+			Path:    shareName,
+		}
+	}
+	return nil
+}
+
+// DeleteShare removes a share and every inode belonging to it, reporting
+// metadata.ErrNotFound when the share does not exist.
+func (c *Core) DeleteShare(ctx context.Context, shareName string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	// Aggregate the usage about to disappear before the rows go, so the
+	// store's quota cache can be decremented once the transaction commits.
+	if err := c.collectShareQuotaFreed(ctx, shareName, "uid", metadata.QuotaScopeUser); err != nil {
+		return err
+	}
+	if err := c.collectShareQuotaFreed(ctx, shareName, "gid", metadata.QuotaScopeGroup); err != nil {
+		return err
+	}
+
+	// Drop the share row first: shares.root_file_id references inodes(id)
+	// WITHOUT ON DELETE CASCADE, so the inode rows cannot be removed while the
+	// share still points at the root inode.
+	result, err := c.X.Exec(ctx, c.D.Shares().DeleteShare, shareName)
+	if err != nil {
+		return c.D.MapError(err, "DeleteShare", shareName)
+	}
+	if result.RowsAffected() == 0 {
+		return &metadata.StoreError{
+			Code:    metadata.ErrNotFound,
+			Message: "share not found",
+			Path:    shareName,
+		}
+	}
+
+	// The contract is "removes a share and all its metadata"; dropping only the
+	// share row orphans every inodes/parent_child_map/file_block_refs row.
+	// parent_child_map and file_block_refs both cascade from inodes(id).
+	if _, err := c.X.Exec(ctx, c.D.Shares().DeleteShareInodes, shareName); err != nil {
+		return c.D.MapError(err, "DeleteShare", shareName)
+	}
+
+	return nil
+}
+
+// collectShareQuotaFreed aggregates the regular-file usage of a share being
+// deleted, grouped by uid or gid, and records the negative delta so the
+// in-memory usage cache is decremented after the commit.
+func (c *Core) collectShareQuotaFreed(ctx context.Context, shareName, col string, scope metadata.QuotaScope) error {
+	query := fmt.Sprintf(c.D.Shares().ShareQuotaFreed, col, col)
+	rows, err := c.X.Query(ctx, query, shareName, int(metadata.FileTypeRegular))
+	if err != nil {
+		return c.D.MapError(err, "DeleteShare", shareName)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var id, bytes, files int64
+		if err := rows.Scan(&id, &bytes, &files); err != nil {
+			return c.D.MapError(err, "DeleteShare", shareName)
+		}
+		c.Quota.AddKeyed(
+			basestore.QuotaKey{Share: shareName, Scope: scope, ID: uint32(id)},
+			metadata.UsageStat{Bytes: -bytes, Files: -files},
+		)
+	}
+	if err := rows.Err(); err != nil {
+		return c.D.MapError(err, "DeleteShare", shareName)
 	}
 	return nil
 }

--- a/pkg/metadata/store/sqlite/dialect.go
+++ b/pkg/metadata/store/sqlite/dialect.go
@@ -112,6 +112,11 @@ var shareQueries = storesql.ShareQueries{
 	PutFilesystemMeta: `INSERT INTO filesystem_meta (share_name, meta)
 		VALUES (?1, ?2)
 		ON CONFLICT (share_name) DO UPDATE SET meta = EXCLUDED.meta`,
+	SetShareOptions:   `UPDATE shares SET options = ?1 WHERE share_name = ?2`,
+	DeleteShare:       `DELETE FROM shares WHERE share_name = ?1`,
+	DeleteShareInodes: `DELETE FROM inodes WHERE share_name = ?1`,
+	ShareQuotaFreed: `SELECT %s, COALESCE(SUM(size), 0), COUNT(*) FROM inodes
+		WHERE share_name = ?1 AND file_type = ?2 GROUP BY %s`,
 }
 
 var _ storesql.Dialect = dialect{}

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log/slog"
 	"time"
 
@@ -98,7 +97,7 @@ func (s *SQLiteMetadataStore) WithTransaction(ctx context.Context, fn func(tx me
 		}
 
 		ptx := &sqliteTransaction{store: s, tx: execer{e: rawTx, op: "tx"}}
-		ptx.Core = &storesql.Core{X: ptx.tx, D: sqliteDialect, Caps: s.currentCapabilities}
+		ptx.Core = &storesql.Core{X: ptx.tx, D: sqliteDialect, Caps: s.currentCapabilities, Quota: &ptx.quota}
 		if err := fn(ptx); err != nil {
 			_ = rawTx.Rollback()
 			if isBusyError(err) {
@@ -450,6 +449,18 @@ func (tx *sqliteTransaction) DeleteFile(ctx context.Context, handle metadata.Fil
 // ============================================================================
 // Transaction Shares Operations
 // ============================================================================
+//
+// UpdateShareOptions and DeleteShare shadow their promoted Core namesakes for
+// one reason: sharesDirty. It tells the commit path to drop the store's share
+// cache, it lives on the transaction, and Core has no way to reach it — so the
+// flag is set here and the statement runs there. Delete a shadow and the build
+// still passes, since the promoted method satisfies the interface, but the
+// cache then serves the options the transaction just overwrote.
+//
+// CreateShare keeps its own body: it runs the same UPDATE, but the memory and
+// badger transactions reject a name that already exists where these two
+// silently overwrite it, and collapsing the SQL pair onto Core would fix that
+// divergence in place rather than decide it.
 
 func (tx *sqliteTransaction) CreateShare(ctx context.Context, share *metadata.Share) error {
 	if err := ctx.Err(); err != nil {
@@ -473,101 +484,13 @@ func (tx *sqliteTransaction) CreateShare(ctx context.Context, share *metadata.Sh
 }
 
 func (tx *sqliteTransaction) UpdateShareOptions(ctx context.Context, shareName string, options *metadata.ShareOptions) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
 	tx.sharesDirty = true
-
-	optionsData, err := json.Marshal(options)
-	if err != nil {
-		return err
-	}
-
-	query := `UPDATE shares SET options = ?1 WHERE share_name = ?2`
-	result, err := tx.tx.Exec(ctx, query, optionsData, shareName)
-	if err != nil {
-		return mapDBError(err, "UpdateShareOptions", shareName)
-	}
-
-	if result.RowsAffected() == 0 {
-		return &metadata.StoreError{
-			Code:    metadata.ErrNotFound,
-			Message: "share not found",
-			Path:    shareName,
-		}
-	}
-
-	return nil
+	return tx.Core.UpdateShareOptions(ctx, shareName, options)
 }
 
 func (tx *sqliteTransaction) DeleteShare(ctx context.Context, shareName string) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
 	tx.sharesDirty = true
-
-	// Capture per-identity usage about to be removed (uid + gid) so the
-	// in-memory usage cache stays accurate. Aggregated before the rows are
-	// deleted; applied to the tx quota delta (post-commit) below.
-	if err := tx.collectShareQuotaFreed(ctx, shareName, "uid", metadata.QuotaScopeUser); err != nil {
-		return err
-	}
-	if err := tx.collectShareQuotaFreed(ctx, shareName, "gid", metadata.QuotaScopeGroup); err != nil {
-		return err
-	}
-
-	// Drop the share row first: shares.root_file_id references inodes(id)
-	// WITHOUT ON DELETE CASCADE, so the inode rows cannot be removed while
-	// the share still points at the root inode.
-	result, err := tx.tx.Exec(ctx, `DELETE FROM shares WHERE share_name = ?1`, shareName)
-	if err != nil {
-		return mapDBError(err, "DeleteShare", shareName)
-	}
-	if result.RowsAffected() == 0 {
-		return &metadata.StoreError{
-			Code:    metadata.ErrNotFound,
-			Message: "share not found",
-			Path:    shareName,
-		}
-	}
-
-	// Delete all inode rows for the share. The store.go:161 contract is
-	// "removes a share and all its metadata"; dropping only the share row
-	// orphans every inodes/parent_child_map/file_block_refs row.
-	// parent_child_map and file_block_refs both cascade from inodes(id).
-	if _, err := tx.tx.Exec(ctx, `DELETE FROM inodes WHERE share_name = ?1`, shareName); err != nil {
-		return mapDBError(err, "DeleteShare", shareName)
-	}
-
-	return nil
-}
-
-// collectShareQuotaFreed aggregates per-identity usage for the regular files of
-// a share being deleted (grouped by uid or gid) and records the negative delta
-// on the tx so the in-memory usage cache is decremented post-commit. The column
-// is a fixed internal constant, never user input.
-func (tx *sqliteTransaction) collectShareQuotaFreed(ctx context.Context, shareName, col string, scope metadata.QuotaScope) error {
-	query := fmt.Sprintf(
-		`SELECT %s, COALESCE(SUM(size), 0), COUNT(*) FROM inodes
-		 WHERE share_name = ?1 AND file_type = ?2 GROUP BY %s`,
-		col, col,
-	)
-	rows, err := tx.tx.Query(ctx, query, shareName, int(metadata.FileTypeRegular))
-	if err != nil {
-		return mapDBError(err, "DeleteShare", shareName)
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var id, bytes, files int64
-		if err := rows.Scan(&id, &bytes, &files); err != nil {
-			return mapDBError(err, "DeleteShare", shareName)
-		}
-		tx.quota.AddKeyed(basestore.QuotaKey{Share: shareName, Scope: scope, ID: uint32(id)}, metadata.UsageStat{Bytes: -bytes, Files: -files})
-	}
-	if err := rows.Err(); err != nil {
-		return mapDBError(err, "DeleteShare", shareName)
-	}
-	return nil
+	return tx.Core.DeleteShare(ctx, shareName)
 }
 
 func (tx *sqliteTransaction) CreateRootDirectory(ctx context.Context, shareName string, attr *metadata.FileAttr) (*metadata.File, error) {

--- a/pkg/metadata/storetest/share_delete_quota_ops.go
+++ b/pkg/metadata/storetest/share_delete_quota_ops.go
@@ -1,0 +1,70 @@
+package storetest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// runShareDeleteQuotaOps pins that deleting a share releases the per-identity
+// usage its files held.
+//
+// The usage cache is in memory and is only ever adjusted by deltas, so a delete
+// that removes the rows without recording the release leaves the store
+// charging every owner for files that no longer exist — for the lifetime of
+// the process, and invisibly, since nothing recomputes it.
+//
+// Two owners, and a distinct uid and gid per owner: a delete that collects the
+// uid grouping but not the gid one (or the reverse) reads as correct if both
+// scopes name the same identity.
+func runShareDeleteQuotaOps(t *testing.T, factory StoreFactory) {
+	t.Helper()
+
+	t.Run("DeleteReleasesPerIdentityUsage", func(t *testing.T) {
+		store := factory(t)
+		ctx := t.Context()
+
+		root := createTestShare(t, store, "/quota-del")
+		createTestFileOwned(t, store, "/quota-del", root, "a.txt", 1001, 2001, 4096)
+		createTestFileOwned(t, store, "/quota-del", root, "b.txt", 1002, 2002, 8192)
+
+		for _, c := range []struct {
+			scope metadata.QuotaScope
+			id    uint32
+		}{
+			{metadata.QuotaScopeUser, 1001},
+			{metadata.QuotaScopeUser, 1002},
+			{metadata.QuotaScopeGroup, 2001},
+			{metadata.QuotaScopeGroup, 2002},
+		} {
+			used, err := store.GetQuotaUsage("/quota-del", c.scope, c.id)
+			require.NoError(t, err)
+			require.NotZero(t, used.Bytes,
+				"scope %v id %d holds no usage before the delete, so releasing it cannot be observed",
+				c.scope, c.id)
+		}
+
+		require.NoError(t, store.DeleteShare(ctx, "/quota-del"))
+
+		for _, c := range []struct {
+			scope metadata.QuotaScope
+			id    uint32
+		}{
+			{metadata.QuotaScopeUser, 1001},
+			{metadata.QuotaScopeUser, 1002},
+			{metadata.QuotaScopeGroup, 2001},
+			{metadata.QuotaScopeGroup, 2002},
+		} {
+			used, err := store.GetQuotaUsage("/quota-del", c.scope, c.id)
+			require.NoError(t, err)
+			require.Zero(t, used.Bytes,
+				"scope %v id %d still charged %d bytes after its share was deleted",
+				c.scope, c.id, used.Bytes)
+			require.Zero(t, used.Files,
+				"scope %v id %d still charged %d files after its share was deleted",
+				c.scope, c.id, used.Files)
+		}
+	})
+}

--- a/pkg/metadata/storetest/suite.go
+++ b/pkg/metadata/storetest/suite.go
@@ -204,6 +204,12 @@ func RunConformanceSuite(t *testing.T, factory StoreFactory) {
 		runStatfsOps(t, factory)
 	})
 
+	// ShareDeleteQuotaOps pins that deleting a share releases the per-identity
+	// usage its files held, which nothing recomputes if it is missed.
+	t.Run("ShareDeleteQuotaOps", func(t *testing.T) {
+		runShareDeleteQuotaOps(t, factory)
+	})
+
 	// FileReadTxOps pins that the transaction-level file and directory reads
 	// run inside the caller's transaction. Every other test here reads only
 	// committed state, which a read that escaped to the pool would answer just


### PR DESCRIPTION
Continues #1828. Stacked after #2240.

`UpdateShareOptions` and `DeleteShare` each existed twice, differing only in placeholder syntax and which error mapper they called, so the bodies move to `Core`. `DeleteShare` brings `collectShareQuotaFreed` with it; its column name is a format argument rather than a bind parameter, so the dialect supplies a template and the field says so.

`Core` gains a `Quota` field for that. The usage a delete releases is accumulated on the transaction and applied once it commits, which is state `Core` cannot otherwise reach. It is set only on a transaction's `Core`; the pool's leaves it nil, and every method that reads it is reached through a store-level delegate that opens a transaction first.

### The shadow, and why it is load-bearing

Both writes keep a three-line method on the transaction that sets `sharesDirty` and delegates. That flag tells the commit path to drop the store's share cache. **Deleting a shadow still builds** — the promoted `Core` method satisfies the interface — and the cache then serves the options the transaction just overwrote. Said once at the head of each `transaction.go` rather than on every method, and pinned: mutating either flag away trips `ShareOptionsOps/TxUpdateIsVisibleToNextRead` and `DeletedShareIsNotServed` respectively. Verified against the broken build.

### `CreateShare` is deliberately left alone

It runs the same `UPDATE`, but the memory and badger transactions reject a name that already exists where the two SQL ones silently overwrite it. Collapsing the pair onto `Core` would settle that divergence by accident rather than on purpose, so it waits on **#2241** (which also carries the `DeleteChild` case Copilot raised on #2240). Same for `CreateRootDirectory` and **#2224** — and that issue's claim that the SQL pair had already converged is wrong, corrected in a comment there.

### A dead query, and a coverage hole

- postgres's `DeleteShare` opened with an aggregate over every regular file in the share, scanned the sum into a local, and never read it. The comment above it claimed the sum kept `usedBytes` accurate; `collectShareQuotaFreed` three lines below is what actually does that, and sqlite never had the extra query. Removing it also left the two bodies identical.
- Deleting a share releases per-identity usage, and **the group half was uncovered** — dropping the whole `gid` collection passed the entire suite, while dropping `uid` tripped an existing case. `storetest.ShareDeleteQuotaOps` closes it, giving each owner a distinct uid *and* gid so the two scopes fail independently; if both scopes name the same identity the test reads as correct either way. Both mutations confirmed to trip it.

Green locally on sqlite, memory, badger, storetest, and the postgres integration suite against a real postgres 16.