### PR TITLE
refactor(metadata): one body for the inode delete and the server-config pair

### DIFF
--- a/pkg/metadata/store/memory/server.go
+++ b/pkg/metadata/store/memory/server.go
@@ -42,14 +42,22 @@ func (s *MemoryMetadataStore) GetServerConfig(ctx context.Context) (metadata.Met
 	return withSettings(s.serverConfig), nil
 }
 
-// withSettings guarantees a non-nil CustomSettings map, which a store that has
-// never had a config written would otherwise leave nil. The other three
-// backends all hand back an empty map there, and a caller that assigns into
-// what it reads panics on a nil one.
+// withSettings hands back a copy of the config with a non-nil CustomSettings
+// map.
+//
+// Both halves matter, and both are about matching the other three backends.
+// A store that has never had a config written leaves the map nil, where they
+// return an empty one, and a caller that assigns into what it read panics on
+// nil. And the map they return is freshly decoded per read, where this store
+// would otherwise hand out the live one — so a caller like the block-GC
+// reconcile marker, which reads the config, sets a key and writes it back,
+// would mutate store state before the write and outside the lock.
 func withSettings(config metadata.MetadataServerConfig) metadata.MetadataServerConfig {
-	if config.CustomSettings == nil {
-		config.CustomSettings = map[string]any{}
+	settings := make(map[string]any, len(config.CustomSettings))
+	for k, v := range config.CustomSettings {
+		settings[k] = v
 	}
+	config.CustomSettings = settings
 	return config
 }
 

--- a/pkg/metadata/store/memory/server.go
+++ b/pkg/metadata/store/memory/server.go
@@ -39,7 +39,18 @@ func (s *MemoryMetadataStore) GetServerConfig(ctx context.Context) (metadata.Met
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	return s.serverConfig, nil
+	return withSettings(s.serverConfig), nil
+}
+
+// withSettings guarantees a non-nil CustomSettings map, which a store that has
+// never had a config written would otherwise leave nil. The other three
+// backends all hand back an empty map there, and a caller that assigns into
+// what it reads panics on a nil one.
+func withSettings(config metadata.MetadataServerConfig) metadata.MetadataServerConfig {
+	if config.CustomSettings == nil {
+		config.CustomSettings = map[string]any{}
+	}
+	return config
 }
 
 // ============================================================================

--- a/pkg/metadata/store/memory/transaction.go
+++ b/pkg/metadata/store/memory/transaction.go
@@ -783,7 +783,7 @@ func (tx *memoryTransaction) GetServerConfig(ctx context.Context) (metadata.Meta
 		return metadata.MetadataServerConfig{}, err
 	}
 
-	return tx.store.serverConfig, nil
+	return withSettings(tx.store.serverConfig), nil
 }
 
 func (tx *memoryTransaction) GetFilesystemCapabilities(ctx context.Context, handle metadata.FileHandle) (*metadata.FilesystemCapabilities, error) {

--- a/pkg/metadata/store/postgres/dialect.go
+++ b/pkg/metadata/store/postgres/dialect.go
@@ -95,7 +95,9 @@ var fileQueries = storesql.FileQueries{
 
 	// inodes.nlink is the sole source of truth for the hard-link count, so
 	// GETATTR reads it straight off the inode row without a join.
-	SetLinkCount: `UPDATE inodes SET nlink = $1 WHERE id = $2`,
+	SetLinkCount:    `UPDATE inodes SET nlink = $1 WHERE id = $2`,
+	DeleteFileOwner: `SELECT file_type, size, uid, gid FROM inodes WHERE id = $1 AND share_name = $2`,
+	DeleteFile:      `DELETE FROM inodes WHERE id = $1 AND share_name = $2`,
 
 	GetFileByPayloadID: `SELECT ` + inodeSelectColumns + ` FROM inodes f
 		WHERE f.content_id_hash = md5($1)

--- a/pkg/metadata/store/postgres/dialect.go
+++ b/pkg/metadata/store/postgres/dialect.go
@@ -107,6 +107,15 @@ var fileQueries = storesql.FileQueries{
 // Shares returns the postgres share read statements.
 func (dialect) Shares() *storesql.ShareQueries { return &shareQueries }
 
+func (dialect) Server() *storesql.ServerQueries { return &serverQueries }
+
+var serverQueries = storesql.ServerQueries{
+	GetServerConfig: `SELECT config FROM server_config WHERE id = 1`,
+	SetServerConfig: `INSERT INTO server_config (id, config)
+		VALUES (1, $1)
+		ON CONFLICT (id) DO UPDATE SET config = EXCLUDED.config, updated_at = NOW()`,
+}
+
 var shareQueries = storesql.ShareQueries{
 	GetRootHandle:     `SELECT root_file_id FROM shares WHERE share_name = $1`,
 	GetShareOptions:   `SELECT options FROM shares WHERE share_name = $1`,

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -654,52 +654,6 @@ func (tx *postgresTransaction) CreateRootDirectory(ctx context.Context, shareNam
 // Transaction ServerConfig Operations
 // ============================================================================
 
-func (tx *postgresTransaction) SetServerConfig(ctx context.Context, config metadata.MetadataServerConfig) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-
-	query := `
-		INSERT INTO server_config (id, config)
-		VALUES (1, $1)
-		ON CONFLICT (id) DO UPDATE
-		SET config = EXCLUDED.config, updated_at = NOW()
-	`
-
-	_, err := tx.tx.Exec(ctx, query, config.CustomSettings)
-	if err != nil {
-		return mapPgError(err, "SetServerConfig", "")
-	}
-
-	return nil
-}
-
-func (tx *postgresTransaction) GetServerConfig(ctx context.Context) (metadata.MetadataServerConfig, error) {
-	if err := ctx.Err(); err != nil {
-		return metadata.MetadataServerConfig{}, err
-	}
-
-	query := `SELECT config FROM server_config WHERE id = 1`
-
-	var customSettings map[string]any
-	err := tx.tx.QueryRow(ctx, query).Scan(&customSettings)
-	if errors.Is(err, pgx.ErrNoRows) {
-		// Match the pool-path and the memory/badger backends: a missing
-		// config row is an empty (non-nil) config, not a not-found error.
-		return metadata.MetadataServerConfig{CustomSettings: map[string]any{}}, nil
-	}
-	if err != nil {
-		return metadata.MetadataServerConfig{}, mapPgError(err, "GetServerConfig", "")
-	}
-
-	if customSettings == nil {
-		customSettings = map[string]any{}
-	}
-	return metadata.MetadataServerConfig{
-		CustomSettings: customSettings,
-	}, nil
-}
-
 func (tx *postgresTransaction) SetFilesystemCapabilities(capabilities metadata.FilesystemCapabilities) {
 	tx.store.capabilities = capabilities
 }

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -454,55 +454,6 @@ func (tx *postgresTransaction) putFile(ctx context.Context, file *metadata.File,
 	return nil
 }
 
-func (tx *postgresTransaction) DeleteFile(ctx context.Context, handle metadata.FileHandle) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-
-	shareName, id, err := metadata.DecodeFileHandle(handle)
-	if err != nil {
-		return &metadata.StoreError{
-			Code:    metadata.ErrInvalidHandle,
-			Message: "invalid file handle",
-		}
-	}
-
-	// Read size + owner before deletion for counter tracking.
-	var fileType int
-	var fileSize int64
-	var fileUID, fileGID int64
-	_ = tx.tx.QueryRow(ctx,
-		`SELECT file_type, size, uid, gid FROM inodes WHERE id = $1 AND share_name = $2`,
-		id, shareName,
-	).Scan(&fileType, &fileSize, &fileUID, &fileGID)
-
-	// Delete the file. parent_child_map.parent_id declares ON DELETE CASCADE
-	// against inodes(id), so deleting the inode row reaps (if it is a directory)
-	// its child-map rows automatically. The hard-link count lives on the inode
-	// row itself (inodes.nlink), so it is removed with the row. We do NOT delete
-	// this file from its parent's children
-	// map here — that is the responsibility of DeleteChild, which the service
-	// layer calls separately. This matches the memory and badger stores.
-	result, err := tx.tx.Exec(ctx, `DELETE FROM inodes WHERE id = $1 AND share_name = $2`, id, shareName)
-	if err != nil {
-		return mapPgError(err, "DeleteFile", "")
-	}
-
-	if result.RowsAffected() == 0 {
-		return &metadata.StoreError{
-			Code:    metadata.ErrNotFound,
-			Message: "file not found",
-		}
-	}
-
-	// Subtract size from the pending delta + per-identity usage for regular files.
-	if metadata.FileType(fileType) == metadata.FileTypeRegular {
-		tx.quota.Add(shareName, uint32(fileUID), uint32(fileGID), -fileSize, -1)
-	}
-
-	return nil
-}
-
 // ============================================================================
 // Transaction Shares Operations
 // ============================================================================

--- a/pkg/metadata/store/sql/chunks.go
+++ b/pkg/metadata/store/sql/chunks.go
@@ -36,8 +36,9 @@ type Core struct {
 	Caps func() metadata.FilesystemCapabilities
 	// Quota accumulates the usage changes a write owes the store's quota
 	// cache, which applies them once the transaction commits. Set only on a
-	// transaction's Core; the pool's Core leaves it nil, and the one method
-	// that reads it is reached solely through a transaction-level shadow.
+	// transaction's Core; the pool's Core leaves it nil. Every method that
+	// reads it is reached only through a store-level delegate that opens a
+	// transaction first, so a nil here is unreachable.
 	//
 	// Left unguarded on purpose. A guard would have to invent an error for a
 	// state the package cannot produce, and nothing could ever exercise it, so
@@ -45,7 +46,7 @@ type Core struct {
 	// The bare dereference is the louder failure and it is a safe one:
 	// DeleteShare aggregates the usage before it deletes any row, and a panic
 	// inside a transaction unwinds past the commit, so nothing reaches the
-	// database either way.
+	// database either way whichever order the calls came in.
 	Quota *basestore.QuotaDelta
 }
 

--- a/pkg/metadata/store/sql/dialect.go
+++ b/pkg/metadata/store/sql/dialect.go
@@ -37,13 +37,17 @@ type Dialect interface {
 	// expected to address a package-level value, not a fresh struct per call.
 	Chunks() *ChunkQueries
 
-	// Files returns the dialect's file and directory read statements, under
+	// Files returns the dialect's file and directory statements, under
 	// the same package-level-value expectation as Chunks.
 	Files() *FileQueries
 
-	// Shares returns the dialect's share read statements, under the same
+	// Shares returns the dialect's share statements, under the same
 	// package-level-value expectation as Chunks.
 	Shares() *ShareQueries
+
+	// Server returns the dialect's server-config statements, under the same
+	// package-level-value expectation as Chunks.
+	Server() *ServerQueries
 }
 
 // ShareQueries holds the share statements in one dialect's syntax. These
@@ -83,6 +87,22 @@ type ShareQueries struct {
 	// the share name and the numeric regular-file type; three result
 	// columns: the identity, its summed bytes, its file count.
 	ShareQuotaFreed string
+}
+
+// ServerQueries holds the store-wide server-config statements in one dialect's
+// syntax.
+//
+// The config column is JSON on both dialects — TEXT on sqlite, jsonb on
+// postgres — and both bodies carry it as raw bytes. pgx encodes a []byte into
+// jsonb and decodes jsonb back into one without a cast, so the marshalling is
+// the same on either side and the statements differ only in their placeholder
+// and their clock function.
+type ServerQueries struct {
+	// GetServerConfig selects the single config blob. No parameters.
+	GetServerConfig string
+	// SetServerConfig upserts the single config blob. One parameter: the
+	// encoded blob.
+	SetServerConfig string
 }
 
 // FileQueries holds the file and directory statements in one dialect's

--- a/pkg/metadata/store/sql/dialect.go
+++ b/pkg/metadata/store/sql/dialect.go
@@ -120,6 +120,13 @@ type FileQueries struct {
 	// SetLinkCount writes one inode's nlink. Two parameters: the count and the
 	// file id.
 	SetLinkCount string
+	// DeleteFileOwner selects the type, size and owning uid/gid of the inode
+	// about to be deleted, in that column order. Two parameters: the file id
+	// and the share name.
+	DeleteFileOwner string
+	// DeleteFile removes one inode row. Two parameters: the file id and the
+	// share name.
+	DeleteFile string
 }
 
 // ChunkQueries holds the file-chunk statements in one dialect's syntax. Field

--- a/pkg/metadata/store/sql/files.go
+++ b/pkg/metadata/store/sql/files.go
@@ -402,18 +402,19 @@ func (c *Core) DeleteFile(ctx context.Context, handle metadata.FileHandle) error
 	// Read the size and owner before the row goes, so the usage counters can be
 	// decremented after the delete lands.
 	//
-	// ponytail: the scan error is dropped. A missing row is the common case and
-	// the RowsAffected check below turns it into ErrNotFound before the usage
-	// is touched, so the only cost is on a row that exists but fails to scan:
-	// FileTypeRegular is the zero value, so the delete then charges -1 file to
-	// uid 0 / gid 0 and leaves the real owner charged for a file that is gone.
-	// Distinguishing that from no-rows costs an IsNoRows branch; do it if a
-	// counter is ever seen drifting.
+	// A missing row is expected and not an error here: the RowsAffected check
+	// below turns it into ErrNotFound before the usage is touched. Any other
+	// scan failure is fatal, because FileTypeRegular is the zero value — a
+	// dropped error would charge -1 file to uid 0 and leave the real owner
+	// charged for a file that is gone, with nothing to notice it afterwards.
 	var fileType int
 	var fileSize int64
 	var fileUID, fileGID int64
-	_ = c.X.QueryRow(ctx, c.D.Files().DeleteFileOwner, id, shareName).
+	scanErr := c.X.QueryRow(ctx, c.D.Files().DeleteFileOwner, id, shareName).
 		Scan(&fileType, &fileSize, &fileUID, &fileGID)
+	if scanErr != nil && !c.D.IsNoRows(scanErr) {
+		return c.D.MapError(scanErr, "DeleteFile", "")
+	}
 
 	result, err := c.X.Exec(ctx, c.D.Files().DeleteFile, id, shareName)
 	if err != nil {

--- a/pkg/metadata/store/sql/files.go
+++ b/pkg/metadata/store/sql/files.go
@@ -380,3 +380,55 @@ func (c *Core) SetLinkCount(ctx context.Context, handle metadata.FileHandle, cou
 	}
 	return nil
 }
+
+// DeleteFile removes one inode, reporting metadata.ErrNotFound when it is not
+// there.
+//
+// parent_child_map.parent_id declares ON DELETE CASCADE against inodes(id), so
+// removing the inode reaps a directory's child-map rows with it, and the hard
+// link count lives on the inode row so it goes too. The entry naming this file
+// in its own parent is not touched here — that is DeleteChild, which the
+// service layer calls separately, matching the memory and badger stores.
+func (c *Core) DeleteFile(ctx context.Context, handle metadata.FileHandle) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	shareName, id, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		return invalidHandle("file")
+	}
+
+	// Read the size and owner before the row goes, so the usage counters can be
+	// decremented after the delete lands.
+	//
+	// ponytail: the scan error is dropped. A missing row is the common case and
+	// the RowsAffected check below turns it into ErrNotFound before the usage
+	// is touched, so the only cost is on a row that exists but fails to scan:
+	// FileTypeRegular is the zero value, so the delete then charges -1 file to
+	// uid 0 / gid 0 and leaves the real owner charged for a file that is gone.
+	// Distinguishing that from no-rows costs an IsNoRows branch; do it if a
+	// counter is ever seen drifting.
+	var fileType int
+	var fileSize int64
+	var fileUID, fileGID int64
+	_ = c.X.QueryRow(ctx, c.D.Files().DeleteFileOwner, id, shareName).
+		Scan(&fileType, &fileSize, &fileUID, &fileGID)
+
+	result, err := c.X.Exec(ctx, c.D.Files().DeleteFile, id, shareName)
+	if err != nil {
+		return c.D.MapError(err, "DeleteFile", "")
+	}
+	if result.RowsAffected() == 0 {
+		return &metadata.StoreError{
+			Code:    metadata.ErrNotFound,
+			Message: "file not found",
+		}
+	}
+
+	if metadata.FileType(fileType) == metadata.FileTypeRegular {
+		c.Quota.Add(shareName, uint32(fileUID), uint32(fileGID), -fileSize, -1)
+	}
+
+	return nil
+}

--- a/pkg/metadata/store/sql/server.go
+++ b/pkg/metadata/store/sql/server.go
@@ -2,13 +2,14 @@ package sql
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 )
 
 // ============================================================================
-// Server and filesystem reads
+// Server and filesystem operations
 // ============================================================================
 
 // GenerateHandle mints a handle for a new file in a share. The path plays no
@@ -53,4 +54,57 @@ func (c *Core) GetFilesystemStatistics(ctx context.Context, handle metadata.File
 	}
 
 	return basestore.BuildStatistics(bytesUsed, filesUsed), nil
+}
+
+// GetServerConfig reads the store-wide server configuration.
+//
+// A missing row is an empty configuration rather than a not-found error, which
+// is what the memory and badger backends report for a store that has never had
+// one written.
+func (c *Core) GetServerConfig(ctx context.Context) (metadata.MetadataServerConfig, error) {
+	if err := ctx.Err(); err != nil {
+		return metadata.MetadataServerConfig{}, err
+	}
+
+	var raw []byte
+	err := c.X.QueryRow(ctx, c.D.Server().GetServerConfig).Scan(&raw)
+	if c.D.IsNoRows(err) {
+		return metadata.MetadataServerConfig{CustomSettings: map[string]any{}}, nil
+	}
+	if err != nil {
+		return metadata.MetadataServerConfig{}, c.D.MapError(err, "GetServerConfig", "")
+	}
+
+	settings := map[string]any{}
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &settings); err != nil {
+			return metadata.MetadataServerConfig{}, c.D.MapError(err, "GetServerConfig", "")
+		}
+	}
+	return metadata.MetadataServerConfig{CustomSettings: settings}, nil
+}
+
+// SetServerConfig writes the store-wide server configuration, replacing
+// whatever was there.
+//
+// Nil settings are stored as an empty object, so the column never holds SQL
+// NULL and the read above never has to tell "no row" from "row holding null".
+func (c *Core) SetServerConfig(ctx context.Context, config metadata.MetadataServerConfig) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	settings := config.CustomSettings
+	if settings == nil {
+		settings = map[string]any{}
+	}
+	raw, err := json.Marshal(settings)
+	if err != nil {
+		return c.D.MapError(err, "SetServerConfig", "")
+	}
+
+	if _, err := c.X.Exec(ctx, c.D.Server().SetServerConfig, raw); err != nil {
+		return c.D.MapError(err, "SetServerConfig", "")
+	}
+	return nil
 }

--- a/pkg/metadata/store/sqlite/dialect.go
+++ b/pkg/metadata/store/sqlite/dialect.go
@@ -105,6 +105,15 @@ var fileQueries = storesql.FileQueries{
 // Shares returns the SQLite share read statements.
 func (dialect) Shares() *storesql.ShareQueries { return &shareQueries }
 
+func (dialect) Server() *storesql.ServerQueries { return &serverQueries }
+
+var serverQueries = storesql.ServerQueries{
+	GetServerConfig: `SELECT config FROM server_config WHERE id = 1`,
+	SetServerConfig: `INSERT INTO server_config (id, config)
+		VALUES (1, ?1)
+		ON CONFLICT (id) DO UPDATE SET config = EXCLUDED.config, updated_at = CURRENT_TIMESTAMP`,
+}
+
 var shareQueries = storesql.ShareQueries{
 	GetRootHandle:     `SELECT root_file_id FROM shares WHERE share_name = ?1`,
 	GetShareOptions:   `SELECT options FROM shares WHERE share_name = ?1`,

--- a/pkg/metadata/store/sqlite/dialect.go
+++ b/pkg/metadata/store/sqlite/dialect.go
@@ -93,7 +93,9 @@ var fileQueries = storesql.FileQueries{
 
 	// inodes.nlink is the sole source of truth for the hard-link count, so
 	// GETATTR reads it straight off the inode row without a join.
-	SetLinkCount: `UPDATE inodes SET nlink = ?1 WHERE id = ?2`,
+	SetLinkCount:    `UPDATE inodes SET nlink = ?1 WHERE id = ?2`,
+	DeleteFileOwner: `SELECT file_type, size, uid, gid FROM inodes WHERE id = ?1 AND share_name = ?2`,
+	DeleteFile:      `DELETE FROM inodes WHERE id = ?1 AND share_name = ?2`,
 
 	GetFileByPayloadID: `SELECT ` + inodeSelectColumns + ` FROM inodes f
 		WHERE f.content_id = ?1

--- a/pkg/metadata/store/sqlite/sqlite_conformance_test.go
+++ b/pkg/metadata/store/sqlite/sqlite_conformance_test.go
@@ -74,46 +74,6 @@ func TestLockPersistenceConformance(t *testing.T) {
 	})
 }
 
-// TestSQLite_TxServerConfigRoundTrip exercises the transaction-scoped
-// SetServerConfig / GetServerConfig path, which the shared conformance suite
-// does not cover (it only drives the pool path). The config column is JSON
-// TEXT, so the tx path must marshal/unmarshal explicitly rather than binding a
-// Go map directly to the driver.
-func TestSQLite_TxServerConfigRoundTrip(t *testing.T) {
-	ctx := context.Background()
-	store := newSQLiteStoreFactory()(t)
-
-	want := metadata.MetadataServerConfig{
-		CustomSettings: map[string]any{"feature": "on", "n": float64(7)},
-	}
-	if err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
-		return tx.SetServerConfig(ctx, want)
-	}); err != nil {
-		t.Fatalf("tx SetServerConfig failed: %v", err)
-	}
-
-	var got metadata.MetadataServerConfig
-	if err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
-		var err error
-		got, err = tx.GetServerConfig(ctx)
-		return err
-	}); err != nil {
-		t.Fatalf("tx GetServerConfig failed: %v", err)
-	}
-	if got.CustomSettings["feature"] != "on" || got.CustomSettings["n"] != float64(7) {
-		t.Fatalf("tx server config round-trip mismatch: got %#v", got.CustomSettings)
-	}
-
-	// The pool path must observe the tx-written config too.
-	poolGot, err := store.GetServerConfig(ctx)
-	if err != nil {
-		t.Fatalf("pool GetServerConfig failed: %v", err)
-	}
-	if poolGot.CustomSettings["feature"] != "on" {
-		t.Fatalf("pool path did not observe tx-written config: %#v", poolGot.CustomSettings)
-	}
-}
-
 // TestSQLite_CleanShutdownMarkerDurable pins that a graceful Close records the
 // clean-shutdown marker durably across a close+reopen against the same database
 // file: a freshly-opened store defaults to unclean; a graceful Close records

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -597,66 +597,6 @@ func (tx *sqliteTransaction) CreateRootDirectory(ctx context.Context, shareName 
 // Transaction ServerConfig Operations
 // ============================================================================
 
-func (tx *sqliteTransaction) SetServerConfig(ctx context.Context, config metadata.MetadataServerConfig) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-
-	query := `
-		INSERT INTO server_config (id, config)
-		VALUES (1, ?1)
-		ON CONFLICT (id) DO UPDATE
-		SET config = EXCLUDED.config, updated_at = CURRENT_TIMESTAMP
-	`
-
-	// config is a JSON TEXT column; marshal explicitly (SQLite, unlike Postgres
-	// JSONB, does not serialize a Go map bind value).
-	settings := config.CustomSettings
-	if settings == nil {
-		settings = map[string]any{}
-	}
-	raw, err := json.Marshal(settings)
-	if err != nil {
-		return mapDBError(err, "SetServerConfig", "")
-	}
-	if _, err := tx.tx.Exec(ctx, query, raw); err != nil {
-		return mapDBError(err, "SetServerConfig", "")
-	}
-
-	return nil
-}
-
-func (tx *sqliteTransaction) GetServerConfig(ctx context.Context) (metadata.MetadataServerConfig, error) {
-	if err := ctx.Err(); err != nil {
-		return metadata.MetadataServerConfig{}, err
-	}
-
-	query := `SELECT config FROM server_config WHERE id = 1`
-
-	// config is a JSON TEXT column; scan raw bytes and unmarshal (parity with
-	// the pool-path GetServerConfig).
-	var raw []byte
-	err := tx.tx.QueryRow(ctx, query).Scan(&raw)
-	if errors.Is(err, sql.ErrNoRows) {
-		// Match the pool-path and the memory/badger backends: a missing
-		// config row is an empty (non-nil) config, not a not-found error.
-		return metadata.MetadataServerConfig{CustomSettings: map[string]any{}}, nil
-	}
-	if err != nil {
-		return metadata.MetadataServerConfig{}, mapDBError(err, "GetServerConfig", "")
-	}
-
-	customSettings := map[string]any{}
-	if len(raw) > 0 {
-		if err := json.Unmarshal(raw, &customSettings); err != nil {
-			return metadata.MetadataServerConfig{}, mapDBError(err, "GetServerConfig", "")
-		}
-	}
-	return metadata.MetadataServerConfig{
-		CustomSettings: customSettings,
-	}, nil
-}
-
 func (tx *sqliteTransaction) SetFilesystemCapabilities(capabilities metadata.FilesystemCapabilities) {
 	tx.store.capabilities = capabilities
 }

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -397,55 +397,6 @@ func (tx *sqliteTransaction) putFile(ctx context.Context, file *metadata.File, w
 	return nil
 }
 
-func (tx *sqliteTransaction) DeleteFile(ctx context.Context, handle metadata.FileHandle) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-
-	shareName, id, err := metadata.DecodeFileHandle(handle)
-	if err != nil {
-		return &metadata.StoreError{
-			Code:    metadata.ErrInvalidHandle,
-			Message: "invalid file handle",
-		}
-	}
-
-	// Read size + owner before deletion for counter tracking.
-	var fileType int
-	var fileSize int64
-	var fileUID, fileGID int64
-	_ = tx.tx.QueryRow(ctx,
-		`SELECT file_type, size, uid, gid FROM inodes WHERE id = ?1 AND share_name = ?2`,
-		id, shareName,
-	).Scan(&fileType, &fileSize, &fileUID, &fileGID)
-
-	// Delete the file. parent_child_map.parent_id declares ON DELETE CASCADE
-	// against inodes(id), so deleting the inode row reaps (if it is a directory)
-	// its child-map rows automatically. The hard-link count lives on the inode
-	// row itself (inodes.nlink), so it is removed with the row. We do NOT delete
-	// this file from its parent's children
-	// map here — that is the responsibility of DeleteChild, which the service
-	// layer calls separately. This matches the memory and badger stores.
-	result, err := tx.tx.Exec(ctx, `DELETE FROM inodes WHERE id = ?1 AND share_name = ?2`, id, shareName)
-	if err != nil {
-		return mapDBError(err, "DeleteFile", "")
-	}
-
-	if result.RowsAffected() == 0 {
-		return &metadata.StoreError{
-			Code:    metadata.ErrNotFound,
-			Message: "file not found",
-		}
-	}
-
-	// Subtract size from the pending delta + per-identity usage for regular files.
-	if metadata.FileType(fileType) == metadata.FileTypeRegular {
-		tx.quota.Add(shareName, uint32(fileUID), uint32(fileGID), -fileSize, -1)
-	}
-
-	return nil
-}
-
 // ============================================================================
 // Transaction Shares Operations
 // ============================================================================

--- a/pkg/metadata/storetest/server_config_ops.go
+++ b/pkg/metadata/storetest/server_config_ops.go
@@ -1,0 +1,69 @@
+package storetest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// runServerConfigOps pins the store-wide server configuration round-trip.
+//
+// The settings deliberately carry a string, a number and a nested object: a
+// backend that stores the config as opaque bytes and one that stores it as a
+// structured column disagree about what survives, and only a value with shape
+// can tell them apart. Numbers come back as float64 because that is what
+// encoding/json produces for an untyped number, which every backend must match
+// whether or not it round-trips through JSON internally.
+func runServerConfigOps(t *testing.T, factory StoreFactory) {
+	t.Helper()
+
+	want := map[string]any{
+		"feature": "on",
+		"n":       float64(7),
+		"nested":  map[string]any{"deep": "value"},
+	}
+
+	t.Run("PoolRoundTrip", func(t *testing.T) {
+		store := factory(t)
+		ctx := t.Context()
+
+		require.NoError(t, store.SetServerConfig(ctx, metadata.MetadataServerConfig{CustomSettings: want}))
+
+		got, err := store.GetServerConfig(ctx)
+		require.NoError(t, err)
+		require.Equal(t, want, got.CustomSettings)
+	})
+
+	t.Run("TxWriteIsVisibleToPool", func(t *testing.T) {
+		store := factory(t)
+		ctx := t.Context()
+
+		require.NoError(t, store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+			return tx.SetServerConfig(ctx, metadata.MetadataServerConfig{CustomSettings: want})
+		}))
+
+		var inTx metadata.MetadataServerConfig
+		require.NoError(t, store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+			var err error
+			inTx, err = tx.GetServerConfig(ctx)
+			return err
+		}))
+		require.Equal(t, want, inTx.CustomSettings)
+
+		got, err := store.GetServerConfig(ctx)
+		require.NoError(t, err)
+		require.Equal(t, want, got.CustomSettings)
+	})
+
+	t.Run("UnwrittenConfigIsEmptyNotMissing", func(t *testing.T) {
+		store := factory(t)
+		ctx := t.Context()
+
+		got, err := store.GetServerConfig(ctx)
+		require.NoError(t, err, "a store that has never had a config written must not report an error")
+		require.NotNil(t, got.CustomSettings, "settings must be an empty map, not nil")
+		require.Empty(t, got.CustomSettings)
+	})
+}

--- a/pkg/metadata/storetest/server_config_ops.go
+++ b/pkg/metadata/storetest/server_config_ops.go
@@ -57,6 +57,48 @@ func runServerConfigOps(t *testing.T, factory StoreFactory) {
 		require.Equal(t, want, got.CustomSettings)
 	})
 
+	t.Run("PoolWriteIsVisibleInTx", func(t *testing.T) {
+		store := factory(t)
+		ctx := t.Context()
+
+		// The mirror of the case above, and the one that matters for a backend
+		// whose two paths encode the column differently: a pool write that the
+		// transaction path cannot decode would pass every assertion that only
+		// ever reads back what the same path wrote.
+		require.NoError(t, store.SetServerConfig(ctx, metadata.MetadataServerConfig{CustomSettings: want}))
+
+		var inTx metadata.MetadataServerConfig
+		require.NoError(t, store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+			var err error
+			inTx, err = tx.GetServerConfig(ctx)
+			return err
+		}))
+		require.Equal(t, want, inTx.CustomSettings)
+	})
+
+	t.Run("ReadIsNotAliasedToStoreState", func(t *testing.T) {
+		store := factory(t)
+		ctx := t.Context()
+
+		// A backend that decodes the config per read hands back a fresh map; an
+		// in-memory one can hand back the live one, and then a caller that reads
+		// the config, sets a key and writes it back — which the block-GC
+		// reconcile marker does — mutates store state before the write and
+		// outside whatever lock the read held.
+		require.NoError(t, store.SetServerConfig(ctx, metadata.MetadataServerConfig{
+			CustomSettings: map[string]any{"kept": "yes"},
+		}))
+
+		got, err := store.GetServerConfig(ctx)
+		require.NoError(t, err)
+		got.CustomSettings["scribbled"] = true
+
+		again, err := store.GetServerConfig(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, again.CustomSettings, "scribbled",
+			"mutating a read config changed store state without a write")
+	})
+
 	t.Run("UnwrittenConfigIsEmptyNotMissing", func(t *testing.T) {
 		store := factory(t)
 		ctx := t.Context()

--- a/pkg/metadata/storetest/suite.go
+++ b/pkg/metadata/storetest/suite.go
@@ -210,6 +210,13 @@ func RunConformanceSuite(t *testing.T, factory StoreFactory) {
 		runShareDeleteQuotaOps(t, factory)
 	})
 
+	// ServerConfigOps pins the store-wide config round-trip, including the
+	// shape of the values, which is where a structured column and an opaque
+	// blob disagree.
+	t.Run("ServerConfigOps", func(t *testing.T) {
+		runServerConfigOps(t, factory)
+	})
+
 	// FileReadTxOps pins that the transaction-level file and directory reads
 	// run inside the caller's transaction. Every other test here reads only
 	// committed state, which a read that escaped to the pool would answer just


### PR DESCRIPTION
Continues #1828. Stacked on #2243 — **review that first**; this PR targets it, and its base flips to `develop` once #2243 merges.

Two more writes off the per-dialect files. After this, the SQL `transaction.go` pair holds only `putFile`, the two share writes blocked on #2241/#2224, and the one-line delegates that reach them.

### `DeleteFile`

The last write outside `putFile` that differed only in placeholder syntax and error mapper. It reads the doomed row's type, size and owner, deletes it, and charges the release to the transaction's quota delta — which `Core` already carries from #2243.

Moving the body is where the pre-read's dropped scan error became visible, so it is now marked rather than silently carried: a missing row is caught by the `RowsAffected` check before the usage is touched, but a row that exists and fails to scan charges -1 file to uid 0, because `FileTypeRegular` is the zero value. Left as a `ponytail:` marker — the branch that would tell no-rows from a real scan failure has no way to fire in a test, and a guard that can never refuse anything is not worth the line.

### The server-config pair

These diverged in how the config column was carried, not in what they did: sqlite marshalled to bytes because its column is JSON `TEXT`, postgres bound a Go map straight to `jsonb` and scanned it back into one. pgx encodes a `[]byte` into `jsonb` and decodes `jsonb` into a `[]byte` with no cast — checked against a real postgres 16 before writing any of this — so both sides can carry bytes and the bodies collapse behind a new `Server()` query group.

**Neither backend had a shared test for the round-trip.** sqlite had a package test whose doc said the conformance suite covers only the pool path; postgres had nothing at all, which is exactly where the encoding changed. `storetest.ServerConfigOps` replaces it and runs on all four backends — the settings carry a string, a number and a nested object, because a value without shape cannot tell a structured column from an opaque blob. Confirmed to trip on postgres against a build with the unmarshal removed.

Writing it turned up a fourth-backend disagreement worth fixing in place: three backends hand back an empty `CustomSettings` map for a store that has never had a config written, and memory hands back nil — which panics a caller that assigns into what it read.

Green locally on sqlite, memory, badger, storetest, and the postgres integration suite.