### PR TITLE
fix(journal): truncate the torn cold.log tail at recovery

### DIFF
--- a/pkg/block/journal/cold.go
+++ b/pkg/block/journal/cold.go
@@ -188,17 +188,20 @@ func (s *Store) appendCold(entries []coldEntry) error {
 
 // loadCold reads every intact entry from dir's cold log. A missing log is not an
 // error (no eviction or seed has happened yet). It stops at the first torn entry
-// and returns what precedes it.
-func loadCold(dir string) ([]coldEntry, error) {
+// and returns what precedes it, along with the byte offset just past the last
+// intact entry: anything between that offset and the end of the file is garbage
+// the caller is expected to drop with truncateColdTail before appending.
+func loadCold(dir string) ([]coldEntry, int64, error) {
 	raw, err := os.ReadFile(filepath.Join(dir, coldLogName))
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, nil
+			return nil, 0, nil
 		}
-		return nil, fmt.Errorf("journal: read cold log: %w", err)
+		return nil, 0, fmt.Errorf("journal: read cold log: %w", err)
 	}
 	var out []coldEntry
-	for off := 0; off < len(raw); {
+	off := 0
+	for off < len(raw) {
 		e, n, derr := decodeColdEntry(raw[off:])
 		if derr != nil {
 			logger.Warn("journal: cold log torn, keeping the intact entries",
@@ -208,7 +211,39 @@ func loadCold(dir string) ([]coldEntry, error) {
 		out = append(out, e)
 		off += n
 	}
-	return out, nil
+	return out, int64(off), nil
+}
+
+// truncateColdTail drops whatever follows the last intact entry and makes the
+// truncation durable. The log is only ever opened for append, so a torn tail
+// left in place sits in front of every later entry: the next load stops at the
+// same offset and discards everything appended in between, turning one torn
+// write into the permanent loss of every cold interval recorded after it.
+func truncateColdTail(dir string, validUpTo int64) error {
+	fd, err := os.OpenFile(filepath.Join(dir, coldLogName), os.O_WRONLY, 0o644)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("journal: open cold log for tail repair: %w", err)
+	}
+	defer func() { _ = fd.Close() }()
+	st, err := fd.Stat()
+	if err != nil {
+		return fmt.Errorf("journal: stat cold log: %w", err)
+	}
+	if st.Size() <= validUpTo {
+		return nil
+	}
+	logger.Warn("journal: dropping torn cold log tail",
+		"valid_up_to", validUpTo, "dropped_bytes", st.Size()-validUpTo)
+	if err := fd.Truncate(validUpTo); err != nil {
+		return fmt.Errorf("journal: truncate torn cold log tail: %w", err)
+	}
+	if err := fd.Sync(); err != nil {
+		return fmt.Errorf("journal: fsync truncated cold log: %w", err)
+	}
+	return nil
 }
 
 // rewriteCold replaces the log with exactly entries, dropping the ones recovery

--- a/pkg/block/journal/cold_test.go
+++ b/pkg/block/journal/cold_test.go
@@ -198,6 +198,68 @@ func TestColdLogTornTailKeepsIntactEntries(t *testing.T) {
 	}
 }
 
+// TestColdLogTornTailIsRepairedOnOpen: the log is opened for append, so a torn
+// tail that recovery reads past but leaves on disk sits in front of everything
+// written afterwards. The next load stops at the same offset again, so every
+// cold interval recorded by the intervening process is lost — and a lost cold
+// interval reads as a hole that zero-fills instead of fetching from the remote.
+func TestColdLogTornTailIsRepairedOnOpen(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfg := Config{ShardCount: 1, SegmentSize: minSegmentSize}
+
+	s, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := s.SeedCold(ctx, "f", [][2]int64{{0, 4096}}); err != nil {
+		t.Fatalf("SeedCold: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// A crash mid-append leaves a partial entry after the intact ones.
+	path := filepath.Join(dir, coldLogName)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read cold log: %v", err)
+	}
+	// The header lands, the FileID bytes behind it do not.
+	torn := append(raw, encodeColdEntry(coldEntry{id: "torn", length: 4096})[:coldHeaderSize]...)
+	if err := os.WriteFile(path, torn, 0o644); err != nil {
+		t.Fatalf("write torn cold log: %v", err)
+	}
+
+	// The process after the crash records another cold range.
+	s2, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	if err != nil {
+		t.Fatalf("reopen over the torn tail: %v", err)
+	}
+	if err := s2.SeedCold(ctx, "g", [][2]int64{{0, 4096}}); err != nil {
+		t.Fatalf("SeedCold after the torn tail: %v", err)
+	}
+	if err := s2.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	s3, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = s3.Close() }()
+
+	for _, id := range []FileID{"f", "g"} {
+		_, st, err := s3.ReadAt(ctx, id, 0, make([]byte, 4096))
+		if err != nil {
+			t.Fatalf("ReadAt %q: %v", id, err)
+		}
+		if !st.Cold {
+			t.Errorf("cold interval for %q was lost: the read reports a hole and zero-fills instead of fetching from the remote", id)
+		}
+	}
+}
+
 // TestSeedColdLeavesLocalBytesAlone is what makes a re-seed safe to run against a
 // store that is only partly missing its markers. A cold interval carries a fresh
 // version, so seeding a range the journal already holds would shadow those bytes
@@ -349,7 +411,7 @@ func TestEvictAppendsColdEntriesBeforeReturning(t *testing.T) {
 
 	// Deliberately no Close and no Sync from the test: whatever is on disk here,
 	// the eviction put there before it returned.
-	entries, err := loadCold(dir)
+	entries, _, err := loadCold(dir)
 	if err != nil {
 		t.Fatalf("loadCold: %v", err)
 	}
@@ -390,7 +452,7 @@ func TestSeedColdBatchIsDurableAndMatchesPerFileSeeding(t *testing.T) {
 	}
 
 	// Again no Close: a batch that only becomes durable on shutdown is the bug.
-	got, err := loadCold(batchDir)
+	got, _, err := loadCold(batchDir)
 	if err != nil {
 		t.Fatalf("loadCold after batch: %v", err)
 	}
@@ -418,7 +480,7 @@ func TestSeedColdBatchIsDurableAndMatchesPerFileSeeding(t *testing.T) {
 			t.Fatalf("SeedCold %q: %v", sd.ID, err)
 		}
 	}
-	want, err := loadCold(oneDir)
+	want, _, err := loadCold(oneDir)
 	if err != nil {
 		t.Fatalf("loadCold after per-file seeding: %v", err)
 	}

--- a/pkg/block/journal/recovery.go
+++ b/pkg/block/journal/recovery.go
@@ -356,8 +356,13 @@ func (r *recoveryState) replayRecords(m *segmentMeta, sh, id uint64, recs []reco
 // each entry's original Version, so a later warm write shadows it and the
 // tombstone/truncate passes clip it exactly like a warm interval.
 func (r *recoveryState) applyColdLog() error {
-	coldLoaded, err := loadCold(r.s.dir)
+	coldLoaded, validUpTo, err := loadCold(r.s.dir)
 	if err != nil {
+		return err
+	}
+	// Repair before anything appends: recovery is the only point where the log
+	// is known to end at an intact entry.
+	if err := truncateColdTail(r.s.dir, validUpTo); err != nil {
 		return err
 	}
 	r.coldLoaded = len(coldLoaded)


### PR DESCRIPTION
`cold.log` is the only durable record that a byte range is safe on the remote
block store but holds no local bytes. Lose an entry and the range comes back
after restart as a POSIX hole: the read zero-fills and never fetches. That is
the silent-zeros family from #1850 / #2084.

## What was wrong

`loadCold` stops at the first torn entry and returns the intact prefix — but
nothing truncated the file back to that point. `appendCold` reopens the log
`O_WRONLY|O_CREATE|O_APPEND` (`cold.go:138`), so every entry written after the
crash lands *behind* the surviving garbage.

The next recovery walks from offset 0, replays the pre-crash entries, hits the
same garbage, and stops there — permanently discarding everything the
intervening process appended. One torn write silently kills every cold interval
recorded from then on, for the life of the store.

`loadSegment` already does exactly this repair for an active `.seg`
(`fd.Truncate(validUpTo)` + `Sync`, `recovery.go:243-250`). There was no
equivalent for `cold.log`.

## Premise verification

Every claim was checked against unmodified `develop` (`e2ce799a3`) before any
code was written:

- **`loadCold` never truncates, and no caller does it on its behalf.**
  Confirmed. It has exactly one non-test caller, `applyColdLog`
  (`recovery.go:359`), which only replays the returned entries.
- **`cold.log` really is `O_APPEND` on the path that runs after recovery.**
  Confirmed at `cold.go:138`, reached from `Evict` (`reclaim.go:280`),
  `SeedCold` (`store.go:531`) and `SeedColdBatch` (`store.go:625`, `:1290`).
- **Nothing else rewrites the log wholesale.** `rewriteCold` has exactly one
  caller, `compactColdLog`.
- **Would compaction incidentally heal a torn tail?** Yes — `rewriteCold` is
  temp-file + rename, so a compaction pass does rebuild the file from the live
  set. But it is gated on `r.coldLoaded > 2*len(live) + coldCompactFloor`, and
  `coldCompactFloor` is 1024. The log must carry more than ~1024 dead entries
  beyond twice the live set before the heal can fire. Until then the poisoning
  is permanent, and every restart inside that window loses another process's
  worth of cold intervals. Small and medium logs never heal at all.

The premise holds in full.

## The fix

`loadCold` now returns the byte offset just past the last intact entry, and
`applyColdLog` drops and fsyncs everything after it before anything can append
— the same shape as the active-segment repair. Recovery is the only point where
the log is known to end at an intact entry, so it is the only place this can be
done.

```go
func loadCold(dir string) ([]coldEntry, int64, error)
func truncateColdTail(dir string, validUpTo int64) error
```

Truncation failure fails the open rather than warning. Continuing would append
onto a log already known to be poisoned, which is exactly the loss this change
exists to prevent. That is deliberately unlike `compactColdLog`, where a failure
only costs redundant replay and a warn is the right call.

### This changes `Open`'s failure surface, deliberately

Worth stating plainly, because it is an availability change and not only a
correctness one. `applyColdLog` propagates `truncateColdTail`'s error, so a
`cold.log` that cannot be opened `O_WRONLY` — a read-only mount, permissions
drift, a snapshot restored with tight modes — now refuses to open a store that
previously opened and merely logged a warning.

That is the intended trade. The alternative is to open anyway and let the next
`Evict` or `SeedCold` append behind a tail already known to be garbage, which
silently destroys every cold interval written from then on and surfaces later as
zero-filled reads with nothing in the log. Refusing to open is loud, immediate
and repairable; the other branch is silent and permanent. Note the two cases it
does *not* catch: a missing log returns nil, and an intact log costs one open
and one stat, so the new failure mode is reachable only when the log exists and
the process genuinely cannot write to it.

Anyone later tempted to soften this to a warning should move the repair rather
than drop it — the invariant `appendCold` depends on ("only the tail can tear")
has to be restored before any append, and recovery is the only point where the
log is known to end at an intact entry.

## Verification

`TestColdLogTornTailIsRepairedOnOpen` seeds a cold range, appends a truncated
entry header to simulate a torn write, reopens, seeds a *second* range, reopens
again, and asserts both ranges still read as cold.

Against a build with only the `truncateColdTail` call removed (test unchanged):

```
=== RUN   TestColdLogTornTailKeepsIntactEntries
--- PASS: TestColdLogTornTailKeepsIntactEntries (0.07s)
=== RUN   TestColdLogTornTailIsRepairedOnOpen
[WARN] journal: cold log torn, keeping the intact entries offset=32 intact_entries=1 err=journal: torn record: cold entry runs past end of log
[WARN] journal: cold log torn, keeping the intact entries offset=32 intact_entries=1 err=journal: torn record: cold entry CRC mismatch
    cold_test.go:258: cold interval for "g" was lost: the read reports a hole and zero-fills instead of fetching from the remote
--- FAIL: TestColdLogTornTailIsRepairedOnOpen (0.10s)
FAIL
```

The second warning is the poisoning itself: the torn header plus the entry
appended after it re-parse as one CRC-bad entry, so the second recovery stops at
the same offset and `g` is gone.

With the fix:

```
=== RUN   TestColdLogTornTailKeepsIntactEntries
[WARN] journal: cold log torn, keeping the intact entries offset=32 intact_entries=1 err=journal: torn record: cold entry runs past end of log
[WARN] journal: dropping torn cold log tail valid_up_to=32 dropped_bytes=31
--- PASS: TestColdLogTornTailKeepsIntactEntries (0.10s)
=== RUN   TestColdLogTornTailIsRepairedOnOpen
[WARN] journal: cold log torn, keeping the intact entries offset=32 intact_entries=1 err=journal: torn record: cold entry runs past end of log
[WARN] journal: dropping torn cold log tail valid_up_to=32 dropped_bytes=31
--- PASS: TestColdLogTornTailIsRepairedOnOpen (0.10s)
PASS
```

`go test ./pkg/block/journal/ -race` and `go test ./pkg/block/...` are green
(the arm64-only `TestBLAKE3FasterThanSHA256` CPU gate in `pkg/block` fails on
this laptop and is unrelated).

## Adjacent defects seen, not fixed here

- `rewriteCold` leaves `cold.log.tmp` behind on every one of its error returns.
- `appendCold` skips the directory fsync forever after its first failure: the
  `O_CREATE` open makes the file even when `fsyncDir` fails, so the next call
  sees it already exists and never retries.

Both are separate audit findings and out of scope for this change.

Closes #2230
