### PR TITLE
fix(journal): repack target never counted its records, so eviction could drop dirty bytes

### DIFF
--- a/pkg/block/journal/gc_test.go
+++ b/pkg/block/journal/gc_test.go
@@ -85,10 +85,12 @@ func TestDeadBytesOnTombstone(t *testing.T) {
 	}
 }
 
-// seedRepackable builds a store with one sealed segment holding a synced "keep"
-// record and a dirty "gone" record, then deletes "gone" so the sealed segment is
-// 70% dead. It returns the keep payload for byte-identity checks.
-func seedRepackable(t *testing.T, s *Store) []byte {
+// seedRepackable builds a store with one sealed segment holding a "keep" record
+// and a dirty "gone" record, then deletes "gone" so the sealed segment is 70%
+// dead. keepSynced decides whether "keep" lands already synced to the remote,
+// which is what makes the repack target evictable or not. It returns the keep
+// payload for byte-identity checks.
+func seedRepackable(t *testing.T, s *Store, keepSynced bool) []byte {
 	t.Helper()
 	ctx := context.Background()
 	keep := make([]byte, 300<<10)
@@ -96,7 +98,13 @@ func seedRepackable(t *testing.T, s *Store) []byte {
 	rand.New(rand.NewSource(1)).Read(keep)
 	rand.New(rand.NewSource(2)).Read(gone)
 
-	if err := s.Hydrate(ctx, "keep", 0, keep, 0); err != nil { // synced=true
+	var err error
+	if keepSynced {
+		err = s.Hydrate(ctx, "keep", 0, keep, 0)
+	} else {
+		err = s.WriteAt(ctx, "keep", 0, keep)
+	}
+	if err != nil {
 		t.Fatal(err)
 	}
 	if err := s.WriteAt(ctx, "gone", 0, gone); err != nil { // synced=false
@@ -115,7 +123,7 @@ func seedRepackable(t *testing.T, s *Store) []byte {
 func TestGCForcedRepackPreservesData(t *testing.T) {
 	s := testStore(t, Config{SegmentSize: minSegmentSize, ShardCount: 1})
 	ctx := context.Background()
-	keep := seedRepackable(t, s)
+	keep := seedRepackable(t, s, true)
 
 	victim := onlySealed(t, s, "keep")
 	occupied := victim.liveBytes.Load()
@@ -189,23 +197,9 @@ func TestGCForcedRepackPreservesData(t *testing.T) {
 func TestGCRepackDirtyTargetNotEvictable(t *testing.T) {
 	s := testStore(t, Config{SegmentSize: minSegmentSize, ShardCount: 1})
 	ctx := context.Background()
+	keep := seedRepackable(t, s, false)
 
-	keep := make([]byte, 300<<10)
-	rand.New(rand.NewSource(4)).Read(keep)
-	if err := s.WriteAt(ctx, "keep", 0, keep); err != nil { // synced=false
-		t.Fatal(err)
-	}
-	if err := s.WriteAt(ctx, "gone", 0, make([]byte, 700<<10)); err != nil {
-		t.Fatal(err)
-	}
-	// Roll the active segment over so keep+gone land in a sealed segment.
-	if err := s.WriteAt(ctx, "trigger", 0, make([]byte, 200<<10)); err != nil {
-		t.Fatal(err)
-	}
-	if err := s.Delete(ctx, "gone"); err != nil { // 70% dead: an auto pass repacks
-		t.Fatal(err)
-	}
-
+	// 0.7 dead ratio >= default GCDeadRatioForce (0.5): an auto pass repacks it.
 	res, err := s.GC(ctx, GCOptions{})
 	if err != nil {
 		t.Fatal(err)
@@ -282,7 +276,7 @@ func TestGCCrashBeforeUnlinkOrphanSwept(t *testing.T) {
 		t.Fatal(err)
 	}
 	ctx := context.Background()
-	keep := seedRepackable(t, s)
+	keep := seedRepackable(t, s, true)
 
 	// Repack but stop right before reclaiming the victim: on disk the target is
 	// durable while the victim still exists (crash-before-unlink).

--- a/pkg/block/journal/gc_test.go
+++ b/pkg/block/journal/gc_test.go
@@ -170,6 +170,75 @@ func TestGCForcedRepackPreservesData(t *testing.T) {
 	if newTarget == nil || newTarget.syncedRecords.Load() != 1 {
 		t.Fatalf("target syncedRecords not preserved")
 	}
+	// The relocated record is synced, so the target must still qualify for
+	// eviction: a record count left behind at zero makes the gate compare 1 == 0
+	// and strands the segment's space forever.
+	if !evictable(newTarget) {
+		t.Fatalf("fully synced target is not evictable: records=%d syncedRecords=%d",
+			newTarget.records.Load(), newTarget.syncedRecords.Load())
+	}
+	if got := newTarget.records.Load(); got != 1 {
+		t.Fatalf("target records = %d, want 1", got)
+	}
+}
+
+// TestGCRepackDirtyTargetNotEvictable pins the other side of the same gate: a
+// victim whose surviving records are all unsynced produces a target with a zero
+// synced count, so a record count left at zero reads as fully synced and lets
+// eviction cold-mark bytes that were never pushed to the remote store.
+func TestGCRepackDirtyTargetNotEvictable(t *testing.T) {
+	s := testStore(t, Config{SegmentSize: minSegmentSize, ShardCount: 1})
+	ctx := context.Background()
+
+	keep := make([]byte, 300<<10)
+	rand.New(rand.NewSource(4)).Read(keep)
+	if err := s.WriteAt(ctx, "keep", 0, keep); err != nil { // synced=false
+		t.Fatal(err)
+	}
+	if err := s.WriteAt(ctx, "gone", 0, make([]byte, 700<<10)); err != nil {
+		t.Fatal(err)
+	}
+	// Roll the active segment over so keep+gone land in a sealed segment.
+	if err := s.WriteAt(ctx, "trigger", 0, make([]byte, 200<<10)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Delete(ctx, "gone"); err != nil { // 70% dead: an auto pass repacks
+		t.Fatal(err)
+	}
+
+	res, err := s.GC(ctx, GCOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.SegmentsRepacked != 1 {
+		t.Fatalf("SegmentsRepacked = %d, want 1", res.SegmentsRepacked)
+	}
+
+	target := onlySealed(t, s, "keep")
+	if evictable(target) {
+		t.Fatalf("target holding an unsynced record is evictable: records=%d syncedRecords=%d",
+			target.records.Load(), target.syncedRecords.Load())
+	}
+
+	// That gate is all that stands between the dirty bytes and eviction, so an
+	// explicit pass must free nothing and leave keep readable locally.
+	ev, err := s.Evict(ctx, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ev.SegmentsEvicted != 0 {
+		t.Fatalf("evicted %d segments holding unsynced data, want 0", ev.SegmentsEvicted)
+	}
+	got := make([]byte, len(keep))
+	if _, st, err := s.ReadAt(ctx, "keep", 0, got); err != nil || st.Cold {
+		t.Fatalf("ReadAt keep after evict: err=%v cold=%v", err, st.Cold)
+	}
+	if !bytes.Equal(got, keep) {
+		t.Fatalf("keep not byte-identical after repack + evict")
+	}
+	if got := target.records.Load(); got != 1 {
+		t.Fatalf("target records = %d, want 1", got)
+	}
 }
 
 func TestGCBelowThresholdNeedsForce(t *testing.T) {

--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -832,13 +832,12 @@ func (s *Store) repackSegment(sh *shard, victim *segmentMeta, live map[uint64]in
 		return 0, err
 	}
 	target.liveBytes.Store(relocated)
-	// records counts data records only — the markers carried forward above are
-	// excluded, matching both the append path and the recovery replay, so a
-	// restart reconstructs the same denominator. Without it the target's
-	// synced-gate compares syncedCount against zero: a target holding only
-	// unsynced records reads as fully synced and eviction discards the sole copy
-	// of dirty bytes, while one holding synced records never reaches equality
-	// again and its space is never reclaimed.
+	// Data records only — the markers carried forward above are excluded, matching
+	// the append path and the recovery replay so a restart reconstructs the same
+	// denominator. Leaving it zero makes the synced-gate below compare against
+	// zero: a target holding only unsynced records reads as fully synced and
+	// eviction discards the sole copy of dirty bytes, while one holding synced
+	// records never reaches equality again and its space is never reclaimed.
 	target.records.Store(int64(len(moves)))
 	target.syncedRecords.Store(syncedCount)
 	// Account the relocated records + tombstones now durable in the target;

--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -832,6 +832,14 @@ func (s *Store) repackSegment(sh *shard, victim *segmentMeta, live map[uint64]in
 		return 0, err
 	}
 	target.liveBytes.Store(relocated)
+	// records counts data records only — the markers carried forward above are
+	// excluded, matching both the append path and the recovery replay, so a
+	// restart reconstructs the same denominator. Without it the target's
+	// synced-gate compares syncedCount against zero: a target holding only
+	// unsynced records reads as fully synced and eviction discards the sole copy
+	// of dirty bytes, while one holding synced records never reaches equality
+	// again and its space is never reclaimed.
+	target.records.Store(int64(len(moves)))
 	target.syncedRecords.Store(syncedCount)
 	// Account the relocated records + tombstones now durable in the target;
 	// writeDataRecord/writeTombstoneRecord don't touch diskBytes (unlike the

--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -834,7 +834,7 @@ func (s *Store) repackSegment(sh *shard, victim *segmentMeta, live map[uint64]in
 	target.liveBytes.Store(relocated)
 	// Data records only — the markers carried forward above are excluded, matching
 	// the append path and the recovery replay so a restart reconstructs the same
-	// denominator. Leaving it zero makes the synced-gate below compare against
+	// denominator. Leaving it zero makes evictable's synced-gate compare against
 	// zero: a target holding only unsynced records reads as fully synced and
 	// eviction discards the sole copy of dirty bytes, while one holding synced
 	// records never reaches equality again and its space is never reclaimed.

--- a/pkg/block/journal/verify_copy_test.go
+++ b/pkg/block/journal/verify_copy_test.go
@@ -93,7 +93,7 @@ func TestCarveRefusesCorruptedRecord(t *testing.T) {
 func TestRepackRefusesTruncatedRecordStream(t *testing.T) {
 	s := testStore(t, Config{SegmentSize: minSegmentSize, ShardCount: 1})
 	ctx := context.Background()
-	seedRepackable(t, s)
+	seedRepackable(t, s, true)
 
 	victim := onlySealed(t, s, "keep")
 	corruptFirstPayloadByte(t, s, "keep")
@@ -135,7 +135,7 @@ func TestRepackRefusesTruncatedRecordStream(t *testing.T) {
 func TestRepackRefusesRecordFramingAnotherFile(t *testing.T) {
 	s := testStore(t, Config{SegmentSize: minSegmentSize, ShardCount: 1})
 	ctx := context.Background()
-	seedRepackable(t, s)
+	seedRepackable(t, s, true)
 
 	victim := onlySealed(t, s, "keep")
 	iv := firstInterval(t, s, "keep")


### PR DESCRIPTION
Closes #2228

## What was wrong

`repackSegment` relocates a victim's live records into a fresh target and then
publishes the target's counters:

```go
target.liveBytes.Store(relocated)
target.syncedRecords.Store(syncedCount)
```

It never stored `target.records`, and `createSegment` leaves it zero. So a repack
target's eviction synced-gate — `evictable()`, which is
`sealed && !busy && syncedRecords == records` — compared a real numerator against
a permanent zero denominator. That is broken in *both* directions:

- **Data loss.** `pickVictim` selects purely on dead-byte ratio and never looks at
  whether the survivors are synced, so a victim can legitimately hold live records
  that were never pushed to the remote store. Then `syncedCount == 0`, and
  `0 == 0` reads as *fully synced*. The target becomes evictable while holding the
  only copy of dirty bytes; `evictSegment` cold-marks every interval regardless of
  `iv.synced`, and the subsequent cold read goes looking for bytes that were never
  uploaded. This defeats the contract `Evict` states in its own doc comment.
- **Disk leak.** The mirror case: a target whose survivors *were* synced gets
  `syncedRecords == N`, `records == 0`, so `N == 0` is never true and the segment
  can never be reclaimed. A later carve flip (`seg.syncedRecords.Add(1)`) only
  pushes the numerator further from a denominator that never moves.

## The fix

One store, next to the two that were already there:

```go
target.records.Store(int64(len(moves)))
```

`moves` is exactly the set of data records the `writeDataRecord` loop appends —
one call per entry, no batching or splitting. The tombstones and truncate markers
carried forward are deliberately excluded, which is what makes the value agree
with the other two writers of this counter: the live append path (`segment.go`)
and the recovery replay (`recovery.go`) both count data records only, so a restart
reconstructs the same denominator the live code holds.

The fix is deliberately *not* adding `records > 0` to `evictable()` the way
`sealableActive` has it. That would mask the data-loss direction and leave the
disk leak permanently in place; correcting the counter closes both.

Ordering is safe: both stores land before the `sh.mu` section that installs
`sh.sealed[target.id] = target` and repoints the index, and every path that can
discover the target goes through one of those two, so nothing can observe
`records == 0` alongside a non-zero `syncedRecords`.

## Evidence

The regression tests were run against a deliberately broken build (fix line
reverted, tests kept) before being trusted.

**Without the fix:**

```
=== RUN   TestGCForcedRepackPreservesData
    gc_test.go:185: fully synced target is not evictable: records=0 syncedRecords=1
--- FAIL: TestGCForcedRepackPreservesData (0.30s)
=== RUN   TestGCRepackDirtyTargetNotEvictable
    gc_test.go:213: target holding an unsynced record is evictable: records=0 syncedRecords=0
--- FAIL: TestGCRepackDirtyTargetNotEvictable (0.33s)
FAIL
```

A throwaway probe (not committed) that ran past the gate assertion to the actual
eviction confirms the loss is real rather than a counter cosmetic — 300 KiB
written with `WriteAt` (never synced), repacked, then a single `Evict` pass:

```
PROBE target: records=0 syncedRecords=0 evictable=true unsyncedBytes=512000
PROBE after Evict: segmentsEvicted=1 bytesFreed=307301 -> ReadAt keep err=<nil> cold=true
```

The same probe with the fix in place:

```
PROBE target: records=1 syncedRecords=0 evictable=false unsyncedBytes=512000
PROBE after Evict: segmentsEvicted=0 bytesFreed=0 -> ReadAt keep err=<nil> cold=false
```

**With the fix:**

```
=== RUN   TestGCForcedRepackPreservesData
--- PASS: TestGCForcedRepackPreservesData (0.34s)
=== RUN   TestGCRepackDirtyTargetNotEvictable
--- PASS: TestGCRepackDirtyTargetNotEvictable (0.27s)
PASS
```

`go test ./pkg/block/journal/... -race` and `go test ./pkg/block/...` are green.

## Coverage

`TestGCForcedRepackPreservesData` already reached a post-repack target, so the
synced-target (disk-leak) side is asserted there rather than duplicated.
`TestGCRepackDirtyTargetNotEvictable` is new and covers the data-loss side end to
end: repack, assert the gate, run a real `Evict` pass, then read the bytes back
byte-identical and warm. `seedRepackable` gained a `keepSynced` parameter so the
two tests share one setup instead of a near-verbatim copy that could drift; the
four existing call sites pass `true` and are unchanged. In both tests the
behavioural assertion precedes the raw counter assertion, so a regression reports
the symptom rather than the number.

## Adjacent defect, not fixed here

`repackSegment` never sets `target.lastAccess`, and `createSegment` does not
initialize it either, so a fresh repack target sits at the zero timestamp.
`claimColdestEvictable` treats that as the oldest possible access, so a target —
which by construction holds the *surviving* records of its victim — sorts to the
front of the approx-LRU and is evicted before genuinely colder segments. It is a
placement inversion rather than a correctness bug, it predates this change, and
it is left alone deliberately.
