### PR TITLE
fix(journal): fsync the view RestoreToVersion re-materializes

### DIFF
--- a/pkg/block/journal/restore_test.go
+++ b/pkg/block/journal/restore_test.go
@@ -23,12 +23,14 @@ type restoreFixture struct {
 	durable map[uint64]int64
 }
 
-// newRestoreFixture opens a store over a fresh directory with shardCount shards
-// and the dirty-age sync loop disabled, so the only fsyncs are the ones the code
-// under test issues.
+// newRestoreFixture opens a store over a fresh directory with shardCount shards.
+// The dirty-age sync loop is disabled and the background repack is put out of
+// reach (no segment's dead ratio can exceed 1), so the only fsyncs are the ones
+// the code under test issues and no pass moves records between the segments the
+// crash model tracks.
 func newRestoreFixture(t *testing.T, shardCount int) *restoreFixture {
 	t.Helper()
-	s := testStore(t, Config{ShardCount: shardCount, DirtyExpiry: -1})
+	s := testStore(t, Config{ShardCount: shardCount, DirtyExpiry: -1, GCDeadRatioForce: 2})
 	f := &restoreFixture{Store: s, t: t, durable: map[uint64]int64{}}
 	for _, sh := range s.shards {
 		inner := sh.segSync
@@ -77,7 +79,7 @@ func (f *restoreFixture) commitAll() uint64 {
 // helper's own Close is a no-op.
 func (f *restoreFixture) crashReopen() *Store {
 	f.t.Helper()
-	if err := f.Store.Close(); err != nil {
+	if err := f.Close(); err != nil {
 		f.t.Fatalf("Close: %v", err)
 	}
 	ids, err := scanSegmentIDs(f.dir)

--- a/pkg/block/journal/restore_test.go
+++ b/pkg/block/journal/restore_test.go
@@ -1,0 +1,206 @@
+package journal
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+)
+
+// restoreFixture is a store whose fsyncs are tracked so a test can throw away
+// every segment byte no completed fsync covered — precisely what a power cut
+// takes. Reopening the same directory proves nothing on its own: the page cache
+// serves buffered writes back exactly like fsynced ones, so a plain reopen
+// cannot tell a durable record from one that only reached the page cache.
+type restoreFixture struct {
+	*Store
+	t   *testing.T
+	dir string
+	cfg Config
+
+	mu sync.Mutex
+	// durable maps a segment id to the tail some completed fsync covered.
+	durable map[uint64]int64
+}
+
+// newRestoreFixture opens a store over a fresh directory with shardCount shards
+// and the dirty-age sync loop disabled, so the only fsyncs are the ones the code
+// under test issues.
+func newRestoreFixture(t *testing.T, shardCount int) *restoreFixture {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := Config{ShardCount: shardCount, DirtyExpiry: -1}
+	s, err := Open(dir, cfg, newFakeRemote(), SystemClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	f := &restoreFixture{Store: s, t: t, dir: dir, cfg: cfg, durable: map[uint64]int64{}}
+	for _, sh := range s.shards {
+		inner := sh.segSync
+		sh.segSync = func(seg *segmentMeta) error {
+			// Sample the tail before the barrier: only bytes already written when
+			// the fsync started are certainly covered by it.
+			tail := seg.tail.Load()
+			if err := inner(seg); err != nil {
+				return err
+			}
+			f.mu.Lock()
+			if tail > f.durable[seg.id] {
+				f.durable[seg.id] = tail
+			}
+			f.mu.Unlock()
+			return nil
+		}
+	}
+	return f
+}
+
+// write appends data at off, the plain buffered client write.
+func (f *restoreFixture) write(id FileID, off int64, data []byte) {
+	f.t.Helper()
+	if err := f.WriteAt(context.Background(), id, off, data); err != nil {
+		f.t.Fatalf("WriteAt %s@%d: %v", id, off, err)
+	}
+}
+
+// commitAll makes everything written so far durable and returns the watermark
+// naming that point-in-time view, ready to hand to RestoreToVersion.
+func (f *restoreFixture) commitAll() uint64 {
+	f.t.Helper()
+	for _, sh := range f.shards {
+		if err := sh.groupCommit(); err != nil {
+			f.t.Fatalf("groupCommit: %v", err)
+		}
+	}
+	return f.JournalVersion()
+}
+
+// crashReopen models a power cut: every segment is cut back to the tail its last
+// completed fsync covered and a fresh store is opened over the directory. Close
+// is safe to call first because it issues no fsync of its own — it only stops the
+// background loops and closes the fds.
+func (f *restoreFixture) crashReopen() *Store {
+	f.t.Helper()
+	if err := f.Store.Close(); err != nil {
+		f.t.Fatalf("Close: %v", err)
+	}
+	ids, err := scanSegmentIDs(f.dir)
+	if err != nil {
+		f.t.Fatalf("scanSegmentIDs: %v", err)
+	}
+	for _, id := range ids {
+		path := f.segPath(id)
+		fd, err := os.OpenFile(path, os.O_RDWR, 0o644)
+		if err != nil {
+			f.t.Fatalf("open segment %d: %v", id, err)
+		}
+		var hdr [segHeaderSize]byte
+		if _, rerr := fd.ReadAt(hdr[:], 0); rerr != nil {
+			_ = fd.Close()
+			continue
+		}
+		_, _, flags, ok := decodeSegHeader(hdr[:])
+		// A sealed segment fsyncs itself before it sets the sealed bit, so all of
+		// it is durable and none of it is dropped.
+		if ok && flags&segFlagSealed == 0 {
+			f.mu.Lock()
+			tail := f.durable[id]
+			f.mu.Unlock()
+			// The header is kept even when nothing fsynced this segment: it carries
+			// no records, so keeping it costs the test nothing and spares recovery a
+			// torn-create sweep that has no bearing on what is being asserted.
+			if tail < segHeaderSize {
+				tail = segHeaderSize
+			}
+			if err := fd.Truncate(tail); err != nil {
+				_ = fd.Close()
+				f.t.Fatalf("truncate segment %d to %d: %v", id, tail, err)
+			}
+		}
+		if err := fd.Close(); err != nil {
+			f.t.Fatalf("close segment %d: %v", id, err)
+		}
+	}
+	r, err := Open(f.dir, f.cfg, newFakeRemote(), SystemClock())
+	if err != nil {
+		f.t.Fatalf("reopen after crash: %v", err)
+	}
+	f.t.Cleanup(func() { _ = r.Close() })
+	return r
+}
+
+// idsOnDistinctShards returns one FileID per shard index in [0, n), so a test
+// spanning them exercises a per-shard barrier rather than a single shard's.
+func idsOnDistinctShards(t *testing.T, s *Store, n int) []FileID {
+	t.Helper()
+	ids := make([]FileID, n)
+	found := 0
+	for i := 0; found < n; i++ {
+		if i > 10000 {
+			t.Fatalf("could not find ids covering %d shards", n)
+		}
+		id := FileID(fmt.Sprintf("restore-%d", i))
+		sh := s.shardIndex(id)
+		if sh < uint64(n) && ids[sh] == "" {
+			ids[sh] = id
+			found++
+		}
+	}
+	return ids
+}
+
+// TestRestoreToVersion_ReMaterializedViewSurvivesCrash pins the durability the
+// method's doc promises: once RestoreToVersion returns, the re-materialized view
+// is on stable storage. Each file's burial tombstone fsyncs itself, so without a
+// barrier for the data that replaces it a crash keeps the burial and loses the
+// replacement, and every restored file reads empty. The files span two shards,
+// so a barrier that covered only the last shard written would still fail here.
+func TestRestoreToVersion_ReMaterializedViewSurvivesCrash(t *testing.T) {
+	const shards = 2
+	f := newRestoreFixture(t, shards)
+	ctx := context.Background()
+
+	ids := idsOnDistinctShards(t, f.Store, shards)
+	v1 := bytes.Repeat([]byte("first-version-"), 64)
+	v2 := bytes.Repeat([]byte("second-version"), 64)
+
+	// V1 across both shards, made durable so the restore's source bytes are never
+	// themselves the thing at risk.
+	for _, id := range ids {
+		f.write(id, 0, v1)
+	}
+	target := f.commitAll()
+
+	// V2 on top, also durable: the pre-restore state is what a crash must not
+	// leave behind.
+	for _, id := range ids {
+		f.write(id, 0, v2)
+	}
+	f.commitAll()
+
+	if err := f.RestoreToVersion(ctx, target); err != nil {
+		t.Fatalf("RestoreToVersion: %v", err)
+	}
+	for _, id := range ids {
+		if got := readAll(t, f.Store, id, len(v1)); !bytes.Equal(got, v1) {
+			t.Fatalf("pre-crash %s: restore did not produce the V1 view", id)
+		}
+	}
+
+	r := f.crashReopen()
+	for _, id := range ids {
+		got := make([]byte, len(v1))
+		if _, _, err := r.ReadAt(ctx, id, 0, got); err != nil {
+			t.Fatalf("post-crash ReadAt %s: %v", id, err)
+		}
+		if !bytes.Equal(got, v1) {
+			empty := bytes.Equal(got, make([]byte, len(v1)))
+			t.Fatalf("post-crash %s: restored view lost (reads-empty=%v, reads-V2=%v); "+
+				"the burial tombstone was fsynced but its replacement data was not",
+				id, empty, bytes.Equal(got, v2))
+		}
+	}
+}

--- a/pkg/block/journal/restore_test.go
+++ b/pkg/block/journal/restore_test.go
@@ -16,9 +16,7 @@ import (
 // cannot tell a durable record from one that only reached the page cache.
 type restoreFixture struct {
 	*Store
-	t   *testing.T
-	dir string
-	cfg Config
+	t *testing.T
 
 	mu sync.Mutex
 	// durable maps a segment id to the tail some completed fsync covered.
@@ -30,14 +28,8 @@ type restoreFixture struct {
 // under test issues.
 func newRestoreFixture(t *testing.T, shardCount int) *restoreFixture {
 	t.Helper()
-	dir := t.TempDir()
-	cfg := Config{ShardCount: shardCount, DirtyExpiry: -1}
-	s, err := Open(dir, cfg, newFakeRemote(), SystemClock())
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	t.Cleanup(func() { _ = s.Close() })
-	f := &restoreFixture{Store: s, t: t, dir: dir, cfg: cfg, durable: map[uint64]int64{}}
+	s := testStore(t, Config{ShardCount: shardCount, DirtyExpiry: -1})
+	f := &restoreFixture{Store: s, t: t, durable: map[uint64]int64{}}
 	for _, sh := range s.shards {
 		inner := sh.segSync
 		sh.segSync = func(seg *segmentMeta) error {
@@ -48,9 +40,7 @@ func newRestoreFixture(t *testing.T, shardCount int) *restoreFixture {
 				return err
 			}
 			f.mu.Lock()
-			if tail > f.durable[seg.id] {
-				f.durable[seg.id] = tail
-			}
+			f.durable[seg.id] = max(f.durable[seg.id], tail)
 			f.mu.Unlock()
 			return nil
 		}
@@ -67,7 +57,9 @@ func (f *restoreFixture) write(id FileID, off int64, data []byte) {
 }
 
 // commitAll makes everything written so far durable and returns the watermark
-// naming that point-in-time view, ready to hand to RestoreToVersion.
+// naming that point-in-time view, ready to hand to RestoreToVersion. It fsyncs
+// the shards itself rather than calling the store's own dirty-shard sweep, so a
+// test asserting that sweep runs cannot be set up by the very call it is pinning.
 func (f *restoreFixture) commitAll() uint64 {
 	f.t.Helper()
 	for _, sh := range f.shards {
@@ -80,8 +72,9 @@ func (f *restoreFixture) commitAll() uint64 {
 
 // crashReopen models a power cut: every segment is cut back to the tail its last
 // completed fsync covered and a fresh store is opened over the directory. Close
-// is safe to call first because it issues no fsync of its own — it only stops the
-// background loops and closes the fds.
+// is safe to call here because it issues no fsync of its own — it only stops the
+// background loops and closes the fds — and it is idempotent, so the reopen
+// helper's own Close is a no-op.
 func (f *restoreFixture) crashReopen() *Store {
 	f.t.Helper()
 	if err := f.Store.Close(); err != nil {
@@ -92,8 +85,7 @@ func (f *restoreFixture) crashReopen() *Store {
 		f.t.Fatalf("scanSegmentIDs: %v", err)
 	}
 	for _, id := range ids {
-		path := f.segPath(id)
-		fd, err := os.OpenFile(path, os.O_RDWR, 0o644)
+		fd, err := os.OpenFile(f.segPath(id), os.O_RDWR, 0o644)
 		if err != nil {
 			f.t.Fatalf("open segment %d: %v", id, err)
 		}
@@ -107,14 +99,11 @@ func (f *restoreFixture) crashReopen() *Store {
 		// it is durable and none of it is dropped.
 		if ok && flags&segFlagSealed == 0 {
 			f.mu.Lock()
-			tail := f.durable[id]
-			f.mu.Unlock()
 			// The header is kept even when nothing fsynced this segment: it carries
 			// no records, so keeping it costs the test nothing and spares recovery a
 			// torn-create sweep that has no bearing on what is being asserted.
-			if tail < segHeaderSize {
-				tail = segHeaderSize
-			}
+			tail := max(f.durable[id], int64(segHeaderSize))
+			f.mu.Unlock()
 			if err := fd.Truncate(tail); err != nil {
 				_ = fd.Close()
 				f.t.Fatalf("truncate segment %d to %d: %v", id, tail, err)
@@ -124,12 +113,7 @@ func (f *restoreFixture) crashReopen() *Store {
 			f.t.Fatalf("close segment %d: %v", id, err)
 		}
 	}
-	r, err := Open(f.dir, f.cfg, newFakeRemote(), SystemClock())
-	if err != nil {
-		f.t.Fatalf("reopen after crash: %v", err)
-	}
-	f.t.Cleanup(func() { _ = r.Close() })
-	return r
+	return reopen(f.t, f.Store)
 }
 
 // idsOnDistinctShards returns one FileID per shard index in [0, n), so a test

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -401,24 +401,29 @@ func (s *Store) syncLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-t.C:
-			s.commitDirtyShards()
+			if err := s.commitDirtyShards(); err != nil {
+				logger.Warn("journal: dirty-age commit failed", "error", err)
+			}
 		}
 	}
 }
 
 // commitDirtyShards fsyncs each shard holding records above its durable
-// watermark. groupCommit coalesces with any concurrent client commit, so
+// watermark and reports the first failure, having still attempted every other
+// dirty shard. groupCommit coalesces with any concurrent client commit, so
 // overlapping with a carve pass or an explicit Commit costs at most one extra
 // fsync and never duplicates work.
-func (s *Store) commitDirtyShards() {
+func (s *Store) commitDirtyShards() error {
+	var firstErr error
 	for _, sh := range s.shards {
 		if !sh.dirty() {
 			continue
 		}
-		if err := sh.groupCommit(); err != nil {
-			logger.Warn("journal: dirty-age commit failed", "error", err)
+		if err := sh.groupCommit(); err != nil && firstErr == nil {
+			firstErr = err
 		}
 	}
+	return firstErr
 }
 
 // WriteAt buffers a dirty client write. It never fsyncs; durability is a
@@ -1070,9 +1075,10 @@ func (s *Store) PinVersion() uint64 { return s.pinVersion.Load() }
 //     pre-overwrite records survive because a live snapshot pinned their segments.
 //  2. Re-materialize: for each file, read the V-view bytes from their pinned
 //     source records and re-append them as fresh dirty records at the head (a
-//     tombstone first to bury the current head, then the V-view data). Fresh
-//     versions exceed everything, so recover() rebuilds V on reopen; a file
-//     present at head but absent at V is tombstoned away.
+//     tombstone first to bury the current head, then the V-view data), and fsync
+//     every shard the pass touched. Fresh versions exceed everything, so
+//     recover() rebuilds V on reopen; a file present at head but absent at V is
+//     tombstoned away.
 //
 // The caller (restore orchestration) drains rollups afterward and holds the share
 // disabled, so no concurrent writer races this.
@@ -1220,6 +1226,15 @@ func (s *Store) RestoreToVersion(ctx context.Context, v uint64) error {
 		if err := s.Delete(ctx, id); err != nil {
 			return fmt.Errorf("journal: restore: tombstone post-V file %q: %w", id, err)
 		}
+	}
+
+	// Every tombstone fsynced itself, but the V-view data went in through WriteAt,
+	// which only buffers. A crash before the next commit would leave each burial
+	// durable and its replacement not, and the restored files would read empty.
+	// The barrier covers every shard rather than the last one written, because a
+	// restore touches whichever shards its files hash to.
+	if err := s.commitDirtyShards(); err != nil {
+		return fmt.Errorf("journal: restore: commit re-materialized view: %w", err)
 	}
 	return nil
 }

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -1075,10 +1075,10 @@ func (s *Store) PinVersion() uint64 { return s.pinVersion.Load() }
 //     pre-overwrite records survive because a live snapshot pinned their segments.
 //  2. Re-materialize: for each file, read the V-view bytes from their pinned
 //     source records and re-append them as fresh dirty records at the head (a
-//     tombstone first to bury the current head, then the V-view data), and fsync
-//     every shard the pass touched. Fresh versions exceed everything, so
-//     recover() rebuilds V on reopen; a file present at head but absent at V is
-//     tombstoned away.
+//     tombstone first to bury the current head, then the V-view data), then fsync
+//     every shard still holding unsynced records — a superset of the shards this
+//     pass wrote. Fresh versions exceed everything, so recover() rebuilds V on
+//     reopen; a file present at head but absent at V is tombstoned away.
 //
 // The caller (restore orchestration) drains rollups afterward and holds the share
 // disabled, so no concurrent writer races this.
@@ -1231,8 +1231,9 @@ func (s *Store) RestoreToVersion(ctx context.Context, v uint64) error {
 	// Every tombstone fsynced itself, but the V-view data went in through WriteAt,
 	// which only buffers. A crash before the next commit would leave each burial
 	// durable and its replacement not, and the restored files would read empty.
-	// The barrier covers every shard rather than the last one written, because a
-	// restore touches whichever shards its files hash to.
+	// The sweep covers every shard still holding unsynced records rather than the
+	// last one written: a restore's files hash across shards, and a shard already
+	// at its durable watermark is skipped, so the superset costs nothing.
 	if err := s.commitDirtyShards(); err != nil {
 		return fmt.Errorf("journal: restore: commit re-materialized view: %w", err)
 	}


### PR DESCRIPTION
## What was wrong

`Store.RestoreToVersion` phase 2 re-materializes each file's target-version view at
the log head in two steps: `s.Delete` buries the current head with a tombstone, then
`s.WriteAt` re-appends the V-view bytes on top of it.

Those two steps have different durability. `Delete` goes through `appendTombstone`,
which fsyncs the shard before it returns. `WriteAt` only buffers — that is its
documented contract, durability is a separate `Commit`. And there was no
`Commit`/`groupCommit` anywhere after: not in `RestoreToVersion`, and not in the
caller, which only runs `DrainRollups` (a carve pass, which never fsyncs the journal).

So the window between the tombstone and the next barrier — bounded only by
`DirtyExpiry` (~30s) or an unrelated client `Commit` — held a **durable burial with a
buffered replacement**. A crash inside it reconstructs the tombstone and not the data,
and the restored file reads empty. The method's own doc claimed it
"re-materializes that view durably at the log head, so a crash-reopen reconstructs V";
that was false as written.

`RestoreToVersion` is the local-only restore primitive, so on those shares the journal
is the only durable copy of the bytes. There is nothing to re-seed from.

## Premise check

The issue's claims were verified on unmodified `develop` before any code was written:

- The whole package has exactly four fsync call sites (`store.go:404` dirty-age loop,
  `store.go:653` `Commit`, `segment.go:470` `appendTombstone`, `segment.go:522`
  `appendTruncateMarker`), plus `sealInPlace`'s direct `fd.Sync`. None is reachable
  from `WriteAt`, and none appeared in `RestoreToVersion`'s body.
- The caller (`snapshot.go:1539`) follows the restore with `DrainRollups`, which is
  `local.Carve(Force: true)` — it rolls dirty payloads into CAS + the manifest and
  issues no journal fsync. It does not incidentally cover the window.
- `RestoreToVersion` touches whichever shards its file IDs hash to, not one, so the
  fix has to be shard-wide. The issue's "in practice only the last restored file per
  shard is exposed" is right, and it comes from a *subsequent* `Delete` incidentally
  fsyncing that shard — which is exactly the partial-coverage shape a fix must not
  inherit.

Premise confirmed.

## The fix

`commitDirtyShards` — which already walked every shard holding records above its
durable watermark — now returns the first failure instead of only logging, and
`RestoreToVersion` calls it once at the end. `syncLoop`, its only other caller, logs
the returned error as before. Sweeping every shard still holding unsynced records
rather than the last one written is the point: a naive "commit the shard of the last
file" fix reproduces the same partial coverage the defect already had. A shard already
at its durable watermark is skipped, so the superset costs nothing.

## Evidence

`RestoreToVersion` had **zero test call sites** across the package's 29 test files, so
`restore_test.go` is new. It carries a reusable fixture rather than a one-off, because
#2227 fixes a different defect in the same method and will extend it.

The fixture matters because `groupcommit_durability_test.go` already documents why the
obvious test is hollow: *"the crash-recovery tests reopen from the same tmpfiles, where
the OS page cache serves the bytes whether or not fsync ran — so they cannot tell a
real fsync from a no-op."* So `restoreFixture` hooks each shard's `segSync` seam to
record, per segment, the tail some **completed** fsync covered, and `crashReopen()`
truncates every unsealed segment back to that tail before reopening — a real power-cut
model, not a reopen. Sealed segments are left whole (`sealInPlace` fsyncs before it
sets the sealed bit, so they are durable by construction). `Close` is called first and
issues no fsync of its own. The dirty-age loop is disabled and the background repack is
put out of reach, so the only fsyncs in the test are the ones the code under test issues.

The test restores two files that hash to two different shards, so a barrier covering
only one shard still fails it.

Run against a deliberately broken build, three ways:

```
# with the fix
--- PASS: TestRestoreToVersion_ReMaterializedViewSurvivesCrash (0.46s)

# fix reverted (the defect as filed)
restore_test.go:187: post-crash restore-0: restored view lost (reads-empty=true, reads-V2=false);
    the burial tombstone was fsynced but its replacement data was not
--- FAIL: TestRestoreToVersion_ReMaterializedViewSurvivesCrash (0.52s)

# partial fix injected (commit shard 0 only) — pins the shard-wide requirement
restore_test.go:185: post-crash restore-1: restored view lost (reads-empty=true, reads-V2=false);
    the burial tombstone was fsynced but its replacement data was not
--- FAIL: TestRestoreToVersion_ReMaterializedViewSurvivesCrash (0.76s)
```

`go test ./pkg/block/journal/... -race` → `ok 87.800s`. `./pkg/block/...` and
`./pkg/controlplane/runtime/...` green. 260 repeats of the new test under three
concurrent full-package runs: clean. `go build ./...`, `go vet ./...`, `gofmt` and
`golangci-lint` clean.

### Known, deliberate gap in the test

`commitDirtyShards` skips a shard whose `dirty()` is already false, and the fixture
sets `DirtyExpiry: -1` so the dirty-age loop never runs. The test therefore never
exercises the case where the sweep meets a shard some earlier commit already covered.
That path is fine by inspection — already durable means there is nothing to fsync —
but it is argued rather than pinned, and it is left that way on purpose rather than
overlooked.

## Adjacent, not fixed

- `shard.dirty()` reports false once `syncFailed` is set, so a shard whose fsync has
  permanently failed is skipped and `RestoreToVersion` returns nil for it. That is the
  store's existing sticky-failure policy everywhere (`markSynced`, `groupCommit`,
  `syncLoop` all treat it the same), and the store is already wedged by then — left
  alone rather than given a special case on this path.
- `sealInPlace` fsyncs through `m.fd.Sync()` directly rather than the per-shard
  `segSync` seam the durability tests hook, so a broken rotation fsync is invisible to
  that seam. It is a limit of the seam, not a hole in this test: sealed segments are
  legitimately durable and the crash model leaves them whole.

Closes #2229
