### PR TITLE
fix(block): order the carve dedup oracle against the remote GC sweep

### DIFF
--- a/.planning/2026-09-01-block-dataflow-MASTER-PLAN.md
+++ b/.planning/2026-09-01-block-dataflow-MASTER-PLAN.md
@@ -842,18 +842,32 @@ Three defects span packages, and each was invisible to at least one audit:
 ### 12.5 Next actions
 
 1. **Filed as #2238.** Add it to step 0 alongside #2227-#2231. **Both fixes named here were
-   wrong; corrected while fixing the issue.** Re-arming `syncedAt` is implementable
-   (`PutSyncedLocators` already upserts the timestamp last-wins) but only narrows the window: it
-   publishes the adoption after the sweep has read `syncedAt` and consulted the live set, and the
-   sweep never looks again. Revalidating liveness inside the marker-deleting transaction is not
-   implementable at all — the production `SyncedHashIndex` is `multiSyncedHashStore`, a slice
-   whose `DeleteSynced` loops over N independent per-share metadata stores, so no transaction
-   spans it; the interface exposes no transaction handle; the evidence sought may live in a
-   different share's `file_chunks` than the marker being deleted; and the reclaim it would guard
-   includes a remote `DeleteBlock`, which cannot sit inside a database transaction. Both framings
-   also miss the ordering problem: the oracle's decision is what discards the bytes, and it
-   precedes the manifest row, so any check against committed metadata looks for evidence not yet
-   written. Fixed instead by ordering the two decisions at their decision points — see
+   wrong; corrected while fixing the issue.**
+
+   *"The cheap fix is to re-arm `syncedAt`"* mischaracterises it twice. It is cheaper than it
+   sounds — `MarkSynced` is first-wins on all four backends, but `Transaction.PutSyncedLocators`
+   already refreshes `synced_at` on all four (`syncedUpsert` on sqlite, `ON CONFLICT DO UPDATE`
+   on postgres, delete-then-mark on badger and memory), so no new store method and no new
+   conformance coverage are needed. It is also not a fix. Routing deduped chunks into that call
+   stamps the timestamp at *commit* time, which leaves the whole interval from the dedup decision
+   to the commit unprotected — and that interval is precisely where the bytes exist nowhere else,
+   because the carver has already dropped the plaintext. A sweep whose `EnumerateSynced` runs in
+   that interval reads the original, past-grace timestamp and reclaims. It narrows; it does not
+   close. (It also costs a `GetLocator` per deduped chunk on the carve path, since `CarveChunk`
+   carries no locator.)
+
+   *"The correct fix is to revalidate liveness inside the transaction that deletes the marker"*
+   describes a transaction that does not exist and cannot. The production `SyncedHashIndex` is
+   `multiSyncedHashStore` (`pkg/controlplane/runtime/blockgc.go:442`), whose `DeleteSynced`
+   (`:481`) loops over N independent per-share stores and `errors.Join`s the failures. The union
+   lives in `controlplane/runtime`, a layer *above* `engine`, so an engine-level sweep cannot open
+   a transaction spanning it even in principle; the interface exposes no transaction handle; the
+   evidence sought may live in a different share's `file_chunks` than the marker being deleted;
+   and the reclaim it would guard includes a remote `DeleteBlock`.
+
+   Both framings miss the ordering problem: the oracle's decision is what discards the bytes, and
+   it precedes the manifest row, so any check against committed metadata looks for evidence not
+   yet written. Fixed instead by ordering the two decisions at their decision points — see
    `dedupSweepGuard` in `pkg/block/engine/dedup_sweep_guard.go`.
 2. Decide §12.2: finish the dedup feature or delete its scaffolding.
 3. Delete the retired local-GC machinery (see §9.1) — dead since the journal switchover.

--- a/.planning/2026-09-01-block-dataflow-MASTER-PLAN.md
+++ b/.planning/2026-09-01-block-dataflow-MASTER-PLAN.md
@@ -841,9 +841,20 @@ Three defects span packages, and each was invisible to at least one audit:
 
 ### 12.5 Next actions
 
-1. **Filed as #2238.** Add it to step 0 alongside #2227-#2231. The cheap fix is to re-arm `syncedAt` on a dedup hit, so the existing grace gate covers the
-   resurrection window; the correct fix is to revalidate liveness inside the transaction that
-   deletes the marker.
+1. **Filed as #2238.** Add it to step 0 alongside #2227-#2231. **Both fixes named here were
+   wrong; corrected while fixing the issue.** Re-arming `syncedAt` is implementable
+   (`PutSyncedLocators` already upserts the timestamp last-wins) but only narrows the window: it
+   publishes the adoption after the sweep has read `syncedAt` and consulted the live set, and the
+   sweep never looks again. Revalidating liveness inside the marker-deleting transaction is not
+   implementable at all — the production `SyncedHashIndex` is `multiSyncedHashStore`, a slice
+   whose `DeleteSynced` loops over N independent per-share metadata stores, so no transaction
+   spans it; the interface exposes no transaction handle; the evidence sought may live in a
+   different share's `file_chunks` than the marker being deleted; and the reclaim it would guard
+   includes a remote `DeleteBlock`, which cannot sit inside a database transaction. Both framings
+   also miss the ordering problem: the oracle's decision is what discards the bytes, and it
+   precedes the manifest row, so any check against committed metadata looks for evidence not yet
+   written. Fixed instead by ordering the two decisions at their decision points — see
+   `dedupSweepGuard` in `pkg/block/engine/dedup_sweep_guard.go`.
 2. Decide §12.2: finish the dedup feature or delete its scaffolding.
 3. Delete the retired local-GC machinery (see §9.1) — dead since the journal switchover.
 4. Triage the 117 LOW findings per D3 — fold into the step that touches the file, sweep the

--- a/pkg/block/engine/blocksink.go
+++ b/pkg/block/engine/blocksink.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"sync"
+	"time"
 
 	"lukechampine.com/blake3"
 
@@ -65,8 +66,15 @@ type engineDeduper struct {
 	synced metadata.SyncedHashStore
 }
 
+// IsChunkDurable answers through dedupGuard, which records the adoption so a
+// remote sweep running concurrently cannot reclaim the hash the carver is about
+// to point a manifest row at. A true answer costs the carver its only copy of
+// the bytes, so it must not be given for a hash the sweep has already claimed.
 func (d engineDeduper) IsChunkDurable(ctx context.Context, hash journal.ChunkHash) (bool, error) {
-	return d.synced.IsSynced(ctx, block.ContentHash(hash))
+	h := block.ContentHash(hash)
+	return dedupGuard.adopt(h, time.Now(), func() (bool, error) {
+		return d.synced.IsSynced(ctx, h)
+	})
 }
 
 // localDeduper is the carve dedup oracle for a share with NO remote block store.

--- a/pkg/block/engine/blocksink.go
+++ b/pkg/block/engine/blocksink.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math"
 	"sync"
-	"time"
 
 	"lukechampine.com/blake3"
 
@@ -72,7 +71,7 @@ type engineDeduper struct {
 // the bytes, so it must not be given for a hash the sweep has already claimed.
 func (d engineDeduper) IsChunkDurable(ctx context.Context, hash journal.ChunkHash) (bool, error) {
 	h := block.ContentHash(hash)
-	return dedupGuard.adopt(h, time.Now(), func() (bool, error) {
+	return dedupGuard.adopt(h, func() (bool, error) {
 		return d.synced.IsSynced(ctx, h)
 	})
 }

--- a/pkg/block/engine/dedup_sweep_guard.go
+++ b/pkg/block/engine/dedup_sweep_guard.go
@@ -10,11 +10,6 @@ import (
 // numDedupGuardStripes must be a power of two so stripeFor can mask.
 const numDedupGuardStripes = 64
 
-// Compile-time guard: the mask below only yields a valid index when the count
-// is a power of two. If it is not, the unsigned subtraction underflows and the
-// build fails.
-const _ = uint(-(numDedupGuardStripes & (numDedupGuardStripes - 1)))
-
 // dedupSweepGuard orders the only two decisions in the engine that can destroy
 // the last copy of a chunk's bytes:
 //
@@ -83,9 +78,9 @@ const dedupPruneInterval = 512
 var dedupGuard dedupSweepGuard
 
 func (g *dedupSweepGuard) stripeFor(h block.ContentHash) *dedupGuardStripe {
-	// The hash is already uniformly distributed; its first two bytes are as
-	// good a stripe index as any derived mix.
-	return &g.stripes[(uint(h[0])<<8|uint(h[1]))&(numDedupGuardStripes-1)]
+	// The hash is already uniformly distributed; one byte of it is as good a
+	// stripe index as any derived mix.
+	return &g.stripes[uint(h[1])&(numDedupGuardStripes-1)]
 }
 
 // adopt runs probe under h's stripe and records an adoption when probe reports
@@ -95,7 +90,7 @@ func (g *dedupSweepGuard) stripeFor(h block.ContentHash) *dedupGuardStripe {
 //
 // Probing under the stripe is what orders the two decisions: the sweep cannot
 // claim h between the probe and the adoption being recorded.
-func (g *dedupSweepGuard) adopt(h block.ContentHash, now time.Time, probe func() (bool, error)) (bool, error) {
+func (g *dedupSweepGuard) adopt(h block.ContentHash, probe func() (bool, error)) (bool, error) {
 	s := g.stripeFor(h)
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -107,6 +102,7 @@ func (g *dedupSweepGuard) adopt(h block.ContentHash, now time.Time, probe func()
 	if err != nil || !durable {
 		return durable, err
 	}
+	now := time.Now()
 	if s.adopted == nil {
 		s.adopted = make(map[block.ContentHash]time.Time)
 	}
@@ -143,7 +139,7 @@ func (g *dedupSweepGuard) claim(h block.ContentHash) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if at, adopted := s.adopted[h]; adopted && !at.Before(time.Now().Add(-dedupAdoptionMaxAge)) {
+	if at, adopted := s.adopted[h]; adopted && time.Since(at) <= dedupAdoptionMaxAge {
 		return false
 	}
 	if s.claimed == nil {

--- a/pkg/block/engine/dedup_sweep_guard.go
+++ b/pkg/block/engine/dedup_sweep_guard.go
@@ -1,0 +1,145 @@
+package engine
+
+import (
+	"sync"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+)
+
+// numDedupGuardStripes must be a power of two so stripeFor can mask.
+const numDedupGuardStripes = 64
+
+// Compile-time guard: the mask below only yields a valid index when the count
+// is a power of two. If it is not, the unsigned subtraction underflows and the
+// build fails.
+const _ = uint(-(numDedupGuardStripes & (numDedupGuardStripes - 1)))
+
+// dedupSweepGuard orders the only two decisions in the engine that can destroy
+// the last copy of a chunk's bytes:
+//
+//   - the carve dedup oracle deciding a hash is already remote-durable, after
+//     which the carver drops the plaintext and writes a manifest row alone;
+//   - the remote sweep deciding a hash is a globally-dead orphan, after which
+//     the reclaimer decrements the enclosing block and frees its object.
+//
+// Neither decision appears in the other's inputs. A dedup hit refreshes no
+// synced marker, so the sweep's grace gate cannot see it, and its manifest row
+// lands after the mark phase has already snapshotted the live set, so the
+// live-set gate cannot see it either. Left unordered, an oracle that answers
+// "durable" for a hash the sweep is about to reclaim produces a file whose
+// chunk points at bytes that no longer exist.
+//
+// The guard makes the two mutually exclusive per hash: an adoption blocks a
+// claim and a claim blocks an adoption, and the loser of the race takes the
+// safe branch — the carver uploads the bytes it would have deduped, or the
+// sweep keeps the marker for the next pass.
+//
+// An adoption is held by age, not by an explicit release on commit: a carve
+// that fails between the oracle and its block commit would otherwise strand a
+// hold and make the hash permanently unreclaimable. The sweep supplies its own
+// grace cutoff as the age bound, so an adoption protects a hash for exactly as
+// long as the grace window already protects a freshly-synced one.
+//
+// ponytail: process-local, so it orders a sweep only against carves in the
+// same process — which is all the GC itself supports today (the run lock in
+// gc.go is process-local for the same reason). Cross-process safety needs the
+// adoption recorded on the synced marker itself, which means a store-level
+// conditional delete across all four backends; do that only when GC actually
+// runs outside the writing process.
+type dedupSweepGuard struct {
+	stripes [numDedupGuardStripes]dedupGuardStripe
+}
+
+type dedupGuardStripe struct {
+	mu sync.Mutex
+	// adopted holds the time each in-flight dedup adoption was taken. An
+	// entry survives until the sweep's grace cutoff passes it.
+	adopted map[block.ContentHash]time.Time
+	// claimed holds the hashes the sweep is currently reclaiming. Entries
+	// are short-lived: one reclamation each.
+	claimed map[block.ContentHash]struct{}
+}
+
+// dedupGuard is the process-wide instance. The carve oracle is constructed per
+// share while the sweep runs per remote store, so the two only meet at package
+// scope — the same reason the GC run lock lives here.
+var dedupGuard dedupSweepGuard
+
+func (g *dedupSweepGuard) stripeFor(h block.ContentHash) *dedupGuardStripe {
+	// The hash is already uniformly distributed; its first two bytes are as
+	// good a stripe index as any derived mix.
+	return &g.stripes[(uint(h[0])<<8|uint(h[1]))&(numDedupGuardStripes-1)]
+}
+
+// adopt runs probe under h's stripe and records an adoption when probe reports
+// the bytes are already remote-durable. It answers false without probing while
+// the sweep holds a claim on h, so a carver that loses the race uploads the
+// chunk instead of pointing at bytes about to be freed.
+//
+// Probing under the stripe is what orders the two decisions: the sweep cannot
+// claim h between the probe and the adoption being recorded.
+func (g *dedupSweepGuard) adopt(h block.ContentHash, now time.Time, probe func() (bool, error)) (bool, error) {
+	s := g.stripeFor(h)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, sweeping := s.claimed[h]; sweeping {
+		return false, nil
+	}
+	durable, err := probe()
+	if err != nil || !durable {
+		return durable, err
+	}
+	if s.adopted == nil {
+		s.adopted = make(map[block.ContentHash]time.Time)
+	}
+	s.adopted[h] = now
+	return true, nil
+}
+
+// claim reserves h for reclamation, locking the dedup oracle out until
+// releaseClaim. It refuses when an adoption taken at or after notBefore still
+// holds h: that carve's manifest row may not have landed before the mark phase
+// read its share, so the hash cannot be proven dead. Callers that get true MUST
+// pair it with releaseClaim.
+func (g *dedupSweepGuard) claim(h block.ContentHash, notBefore time.Time) bool {
+	s := g.stripeFor(h)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if at, adopted := s.adopted[h]; adopted && !at.Before(notBefore) {
+		return false
+	}
+	if s.claimed == nil {
+		s.claimed = make(map[block.ContentHash]struct{})
+	}
+	s.claimed[h] = struct{}{}
+	return true
+}
+
+// releaseClaim ends a reclamation. Once the marker is gone the oracle answers
+// "not durable" on its own; if the reclamation failed the marker survives and
+// the hash becomes adoptable again, which is the correct fail-open direction.
+func (g *dedupSweepGuard) releaseClaim(h block.ContentHash) {
+	s := g.stripeFor(h)
+	s.mu.Lock()
+	delete(s.claimed, h)
+	s.mu.Unlock()
+}
+
+// pruneAdoptions drops adoptions older than cutoff. Anything that old has
+// either committed its manifest row — where the mark phase takes over — or
+// belongs to a carve that died before committing one.
+func (g *dedupSweepGuard) pruneAdoptions(cutoff time.Time) {
+	for i := range g.stripes {
+		s := &g.stripes[i]
+		s.mu.Lock()
+		for h, at := range s.adopted {
+			if at.Before(cutoff) {
+				delete(s.adopted, h)
+			}
+		}
+		s.mu.Unlock()
+	}
+}

--- a/pkg/block/engine/dedup_sweep_guard.go
+++ b/pkg/block/engine/dedup_sweep_guard.go
@@ -105,8 +105,14 @@ func (g *dedupSweepGuard) stripeFor(h block.ContentHash) *dedupGuardStripe {
 // the sweep holds a claim on h, so a carver that loses the race uploads the
 // chunk instead of pointing at bytes about to be freed.
 //
-// Probing under the stripe is what orders the two decisions: the sweep cannot
-// claim h between the probe and the adoption being recorded.
+// The stripe mutex is deliberately held across probe, a metadata-store round
+// trip on the carve path. Narrowing it — check claimed, unlock, probe, relock,
+// re-check claimed — is not equivalent: a claim is released as soon as its
+// reclamation finishes, so an entire claim, reclaim and marker delete can begin
+// and complete inside the probe window, leaving the re-check nothing to see and
+// the carver deduping onto bytes freed while it was probing. Holding the lock
+// across the probe is what makes the two decisions totally ordered rather than
+// merely both visible at some instant, and that ordering is the point.
 func (g *dedupSweepGuard) adopt(h block.ContentHash, probe func() (bool, error)) (bool, error) {
 	s := g.stripeFor(h)
 	s.mu.Lock()

--- a/pkg/block/engine/dedup_sweep_guard.go
+++ b/pkg/block/engine/dedup_sweep_guard.go
@@ -35,18 +35,20 @@ const _ = uint(-(numDedupGuardStripes & (numDedupGuardStripes - 1)))
 // safe branch — the carver uploads the bytes it would have deduped, or the
 // sweep keeps the marker for the next pass.
 //
-// An adoption is held by age, not by an explicit release on commit: a carve
-// that fails between the oracle and its block commit would otherwise strand a
-// hold and make the hash permanently unreclaimable. The sweep supplies its own
-// grace cutoff as the age bound, so an adoption protects a hash for exactly as
-// long as the grace window already protects a freshly-synced one.
+// An adoption is held by age, not released explicitly when its manifest row
+// commits: two carves can adopt the same hash, so a release would need a
+// refcount, and a carve that dies between the oracle and its block commit would
+// strand its hold and make the hash unreclaimable for the life of the process.
 //
-// ponytail: process-local, so it orders a sweep only against carves in the
-// same process — which is all the GC itself supports today (the run lock in
-// gc.go is process-local for the same reason). Cross-process safety needs the
-// adoption recorded on the synced marker itself, which means a store-level
-// conditional delete across all four backends; do that only when GC actually
-// runs outside the writing process.
+// ponytail: two ceilings, both from that age bound. It holds only within one
+// process, which is all the GC supports today — the run lock in gc.go is
+// process-local for the same reason. And a carve whose dedup-to-commit gap
+// exceeds dedupAdoptionMaxAge drops out from under its own adoption while its
+// row is still unwritten, which the mark phase would then miss. Both close by
+// recording the adoption on the synced marker itself and deleting that marker
+// conditionally, which is a new store method across all four backends plus its
+// storetest conformance; do that when GC runs outside the writing process, or
+// when a carve pass can credibly stall for an hour mid-run.
 type dedupSweepGuard struct {
 	stripes [numDedupGuardStripes]dedupGuardStripe
 }
@@ -54,12 +56,26 @@ type dedupSweepGuard struct {
 type dedupGuardStripe struct {
 	mu sync.Mutex
 	// adopted holds the time each in-flight dedup adoption was taken. An
-	// entry survives until the sweep's grace cutoff passes it.
+	// entry survives until it ages past dedupAdoptionMaxAge.
 	adopted map[block.ContentHash]time.Time
 	// claimed holds the hashes the sweep is currently reclaiming. Entries
 	// are short-lived: one reclamation each.
 	claimed map[block.ContentHash]struct{}
+	// sinceSweep counts adoptions recorded since this stripe was last
+	// pruned, so a deployment with the GC scheduler switched off still
+	// sheds them.
+	sinceSweep int
 }
+
+// dedupAdoptionMaxAge is how long an adoption protects its hash. It only has to
+// outlive the carve's block commit, which follows the oracle by seconds; an
+// hour matches the default grace period and leaves the margin wide.
+const dedupAdoptionMaxAge = time.Hour
+
+// dedupPruneInterval is how many adoptions a stripe records before it sheds
+// aged ones itself. Large enough that the O(n) walk is amortized away, small
+// enough that the map tracks recent dedup traffic rather than all of it.
+const dedupPruneInterval = 512
 
 // dedupGuard is the process-wide instance. The carve oracle is constructed per
 // share while the sweep runs per remote store, so the two only meet at package
@@ -95,20 +111,39 @@ func (g *dedupSweepGuard) adopt(h block.ContentHash, now time.Time, probe func()
 		s.adopted = make(map[block.ContentHash]time.Time)
 	}
 	s.adopted[h] = now
+	s.sinceSweep++
+	if s.sinceSweep >= dedupPruneInterval {
+		s.pruneLocked(now.Add(-dedupAdoptionMaxAge))
+	}
 	return true, nil
 }
 
+// pruneLocked drops adoptions older than cutoff. Callers hold s.mu.
+func (s *dedupGuardStripe) pruneLocked(cutoff time.Time) {
+	for h, at := range s.adopted {
+		if at.Before(cutoff) {
+			delete(s.adopted, h)
+		}
+	}
+	s.sinceSweep = 0
+}
+
 // claim reserves h for reclamation, locking the dedup oracle out until
-// releaseClaim. It refuses when an adoption taken at or after notBefore still
-// holds h: that carve's manifest row may not have landed before the mark phase
-// read its share, so the hash cannot be proven dead. Callers that get true MUST
-// pair it with releaseClaim.
-func (g *dedupSweepGuard) claim(h block.ContentHash, notBefore time.Time) bool {
+// releaseClaim. It refuses while a recent adoption still holds h: that carve's
+// manifest row may not have landed before the mark phase read its share, so the
+// hash cannot be proven dead. Callers that get true MUST pair it with
+// releaseClaim.
+//
+// The age bound is dedupAdoptionMaxAge rather than the run's grace period on
+// purpose. Grace answers a different question — how long a freshly-committed
+// hash is spared — and an operator may legitimately set it to zero, which would
+// leave every adoption claimable the moment it is recorded.
+func (g *dedupSweepGuard) claim(h block.ContentHash) bool {
 	s := g.stripeFor(h)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if at, adopted := s.adopted[h]; adopted && !at.Before(notBefore) {
+	if at, adopted := s.adopted[h]; adopted && !at.Before(time.Now().Add(-dedupAdoptionMaxAge)) {
 		return false
 	}
 	if s.claimed == nil {
@@ -128,18 +163,15 @@ func (g *dedupSweepGuard) releaseClaim(h block.ContentHash) {
 	s.mu.Unlock()
 }
 
-// pruneAdoptions drops adoptions older than cutoff. Anything that old has
-// either committed its manifest row — where the mark phase takes over — or
+// pruneAdoptions drops adoptions past dedupAdoptionMaxAge. Anything that old
+// has either committed its manifest row — where the mark phase takes over — or
 // belongs to a carve that died before committing one.
-func (g *dedupSweepGuard) pruneAdoptions(cutoff time.Time) {
+func (g *dedupSweepGuard) pruneAdoptions() {
+	cutoff := time.Now().Add(-dedupAdoptionMaxAge)
 	for i := range g.stripes {
 		s := &g.stripes[i]
 		s.mu.Lock()
-		for h, at := range s.adopted {
-			if at.Before(cutoff) {
-				delete(s.adopted, h)
-			}
-		}
+		s.pruneLocked(cutoff)
 		s.mu.Unlock()
 	}
 }

--- a/pkg/block/engine/dedup_sweep_guard.go
+++ b/pkg/block/engine/dedup_sweep_guard.go
@@ -68,6 +68,20 @@ type dedupGuardStripe struct {
 // dedupAdoptionMaxAge is how long an adoption protects its hash. It only has to
 // outlive the carve's block commit, which follows the oracle by seconds; an
 // hour matches the default grace period and leaves the margin wide.
+//
+// It also sets the guard's memory ceiling. Only adopt() inserts, and it prunes
+// every dedupPruneInterval insertions, so the map cannot grow without bound —
+// it settles at roughly one dedup-adoption rate times this age, plus under one
+// prune interval per stripe. A stripe that goes quiet stops growing but does
+// not shrink until traffic resumes or a sweep prunes it.
+//
+// ponytail: that ceiling is an hour of dedup adoptions, which is megabytes at
+// a modest rate but not at a sustained heavy one. Shrinking this constant is
+// the wrong lever — it trades memory for the carve-stall ceiling above. The
+// upgrade is to release an adoption when its manifest row commits, which needs
+// a refcount because two carves can adopt the same hash, and leaves the map
+// tracking in-flight carves instead of an hour of history. Do that when the
+// guard shows up in a heap profile.
 const dedupAdoptionMaxAge = time.Hour
 
 // dedupPruneInterval is how many adoptions a stripe records before it sheds

--- a/pkg/block/engine/dedup_sweep_guard.go
+++ b/pkg/block/engine/dedup_sweep_guard.go
@@ -57,8 +57,11 @@ type dedupGuardStripe struct {
 	// are short-lived: one reclamation each.
 	claimed map[block.ContentHash]struct{}
 	// sinceSweep counts adoptions recorded since this stripe was last
-	// pruned, so a deployment with the GC scheduler switched off still
-	// sheds them.
+	// pruned. Every dedupPruneInterval adoptions the stripe sheds its aged
+	// entries, which bounds the map against ongoing dedup traffic even with
+	// the GC scheduler switched off. Traffic that stops leaves its final
+	// entries in place until it resumes or a sweep runs — a residue of under
+	// one interval per stripe.
 	sinceSweep int
 }
 

--- a/pkg/block/engine/gc.go
+++ b/pkg/block/engine/gc.go
@@ -246,8 +246,9 @@ type Options struct {
 	// the remote sweep. Every synced hash lives inside a blocks/<id> object, so this is the ONLY remote reclaim path: the sweep
 	// decrements the enclosing block and frees the block object + record when
 	// its last live chunk is gone. It is reached only after the sweep has
-	// proven the hash globally dead (past grace, absent from the live set),
-	// so freeing a block here can never race a live dedup sibling. A nil
+	// proven the hash globally dead (past grace, absent from the live set)
+	// and claimed it against a concurrent carve dedup, so freeing a block
+	// here cannot race a live sibling. A nil
 	// reclaimer — or a hash no share can resolve — is metadata drift: the
 	// sweep records the error and keeps the marker (fail-closed). Set ONLY
 	// for the remote tier (the index sweep); the local tier leaves it nil.

--- a/pkg/block/engine/gc_block.go
+++ b/pkg/block/engine/gc_block.go
@@ -8,7 +8,9 @@
 // globally dead (no sibling FileChunk row, in any file, still references it).
 // Deciding to free a block on a single file's unlink would corrupt a dedup
 // sibling that shares the content; the sweep reaches a hash only after that
-// hazard is excluded, so DecrLiveChunkCount here can never race a live sibling.
+// hazard is excluded — no live manifest row, past grace, and claimed against
+// any carve deduping onto it right now — so DecrLiveChunkCount here cannot
+// race a live sibling.
 package engine
 
 import (

--- a/pkg/block/engine/gc_sweep_dedup_race_test.go
+++ b/pkg/block/engine/gc_sweep_dedup_race_test.go
@@ -1,0 +1,118 @@
+package engine
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/journal"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+)
+
+// reclaimHook runs before delegating to the wrapped reclaimer, which places it
+// exactly in the sweep's decision window: the sweep has already read syncedAt
+// and consulted the mark-phase live set, and has not yet freed anything.
+type reclaimHook struct {
+	inner  BlockReclaimer
+	before func(block.ContentHash)
+}
+
+func (r reclaimHook) ReclaimDeadChunk(ctx context.Context, h block.ContentHash) (bool, int64, error) {
+	r.before(h)
+	return r.inner.ReclaimDeadChunk(ctx, h)
+}
+
+// TestGCIndexSweep_ConcurrentDedupKeepsBytes pins the invariant that binds the
+// carve dedup oracle to the remote sweep: whenever the oracle answers "already
+// remote-durable" for a hash, the bytes behind that hash must still be there
+// afterwards. The oracle's true answer costs the carver its only copy — the
+// carve drops the plaintext and writes a manifest row alone — so a sweep that
+// frees the block leaves that file pointing at nothing.
+//
+// Both orderings of the two decisions are driven deterministically; neither
+// subtest depends on goroutine scheduling.
+func TestGCIndexSweep_ConcurrentDedupKeepsBytes(t *testing.T) {
+	// The oracle wins: a carve deduped onto the hash before the sweep ran. Its
+	// manifest row lands after the mark phase, so the live set cannot show it —
+	// the sweep must keep the hash anyway.
+	t.Run("dedup before sweep", func(t *testing.T) {
+		ctx := t.Context()
+		rs := remotememory.New()
+		defer func() { _ = rs.Close() }()
+
+		rec := newGCMSReconciler()
+		st := rec.addShare("share-a")
+
+		h := hashFromString("dedup-race-before")
+		seedRemoteChunk(t, st, rs, h) // synced, backdated past grace, no manifest row
+
+		durable, err := (engineDeduper{synced: st}).IsChunkDurable(ctx, journal.ChunkHash(h))
+		if err != nil {
+			t.Fatalf("IsChunkDurable: %v", err)
+		}
+		if !durable {
+			t.Fatalf("IsChunkDurable = false for a synced hash; fixture no longer exercises a dedup hit")
+		}
+
+		stats := collectGarbageBlocks(t, rec, st, rs, &Options{
+			GCStateRoot: t.TempDir(),
+			GracePeriod: time.Hour,
+		})
+
+		if stats.ObjectsSwept != 0 {
+			t.Errorf("ObjectsSwept = %d, want 0 (a carve deduped onto the hash)", stats.ObjectsSwept)
+		}
+		if !chunkOnRemote(t, st, h) {
+			t.Fatal("bytes freed under a live dedup adoption: the deduped file's chunk now resolves to nothing")
+		}
+	})
+
+	// The sweep wins: it reaches the hash before any carve adopts it. The
+	// oracle must then refuse, so the carver uploads the chunk instead of
+	// pointing at bytes that are being freed as it answers.
+	t.Run("dedup during sweep", func(t *testing.T) {
+		ctx := t.Context()
+		rs := remotememory.New()
+		defer func() { _ = rs.Close() }()
+
+		rec := newGCMSReconciler()
+		st := rec.addShare("share-a")
+
+		h := hashFromString("dedup-race-during")
+		seedRemoteChunk(t, st, rs, h)
+
+		deduper := engineDeduper{synced: st}
+		var durable bool
+		var dedupErr error
+		opts := &Options{
+			GCStateRoot: t.TempDir(),
+			GracePeriod: time.Hour,
+		}
+		idx, ok := st.(SyncedHashIndex)
+		if !ok {
+			t.Fatalf("metadata store %T does not implement SyncedHashIndex", st)
+		}
+		opts.SyncedHashIndex = idx
+		opts.BlockReclaimer = reclaimHook{
+			inner: newBlockGCReclaimer(st, rs),
+			before: func(swept block.ContentHash) {
+				if swept != h {
+					return
+				}
+				durable, dedupErr = deduper.IsChunkDurable(ctx, journal.ChunkHash(swept))
+			},
+		}
+
+		stats := CollectGarbage(ctx, rec, opts)
+		if dedupErr != nil {
+			t.Fatalf("IsChunkDurable during sweep: %v", dedupErr)
+		}
+		if stats.ObjectsSwept != 1 {
+			t.Fatalf("ObjectsSwept = %d, want 1 (the hook must fire inside a real reclamation)", stats.ObjectsSwept)
+		}
+		if durable {
+			t.Fatal("dedup oracle claimed a hash the sweep was reclaiming: the carve drops its plaintext and the bytes are freed a moment later")
+		}
+	})
+}

--- a/pkg/block/engine/gc_sweep_index.go
+++ b/pkg/block/engine/gc_sweep_index.go
@@ -50,10 +50,10 @@ func sweepFromSyncedIndex(
 	graceCutoff := snapshotTime.Add(-gracePeriod)
 	var scanned int64
 
-	// Adoptions older than the cutoff can no longer protect anything: either
-	// their manifest row landed, and the live set takes over, or the carve
-	// that took them died without committing one.
-	dedupGuard.pruneAdoptions(graceCutoff)
+	// Adoptions too old to protect anything: either their manifest row landed,
+	// and the live set takes over, or the carve that took them died without
+	// committing one.
+	dedupGuard.pruneAdoptions()
 
 	enumErr := options.SyncedHashIndex.EnumerateSynced(ctx, func(h block.ContentHash, _ block.ChunkLocator, syncedAt time.Time) error {
 		if err := ctx.Err(); err != nil {
@@ -96,7 +96,7 @@ func sweepFromSyncedIndex(
 		// and writes its manifest row after the mark phase has passed. Claim h
 		// so that carve either already holds it (and the reclaim is skipped)
 		// or is locked out of adopting it for the rest of the reclamation.
-		if !dedupGuard.claim(h, graceCutoff) {
+		if !dedupGuard.claim(h) {
 			return nil // a live dedup adoption holds h — keep it
 		}
 		defer dedupGuard.releaseClaim(h)

--- a/pkg/block/engine/gc_sweep_index.go
+++ b/pkg/block/engine/gc_sweep_index.go
@@ -29,7 +29,10 @@ import (
 //
 // Fail-closed rules: a missing first-mirror timestamp (a legacy marker with no
 // recorded syncedAt) is preserved, the grace window protects freshly-committed
-// hashes, and a live-set hit keeps the marker. The per-object byte size is not
+// hashes, a live-set hit keeps the marker, and a hash a concurrent carve has
+// deduped onto is kept via dedupGuard — that write refreshes no timestamp and
+// commits its manifest row too late for the mark phase, so it is the one live
+// reference neither of the other gates can see. The per-object byte size is not
 // available from the index, so BytesFreed reflects what the reclaimer reports
 // (freed block bytes); ObjectsSwept counts reclaimed chunks.
 func sweepFromSyncedIndex(
@@ -46,6 +49,11 @@ func sweepFromSyncedIndex(
 
 	graceCutoff := snapshotTime.Add(-gracePeriod)
 	var scanned int64
+
+	// Adoptions older than the cutoff can no longer protect anything: either
+	// their manifest row landed, and the live set takes over, or the carve
+	// that took them died without committing one.
+	dedupGuard.pruneAdoptions(graceCutoff)
 
 	enumErr := options.SyncedHashIndex.EnumerateSynced(ctx, func(h block.ContentHash, _ block.ChunkLocator, syncedAt time.Time) error {
 		if err := ctx.Err(); err != nil {
@@ -81,12 +89,24 @@ func sweepFromSyncedIndex(
 			return nil
 		}
 
+		// Both gates above answer from state that predates this moment: the
+		// grace cutoff from a timestamp a dedup hit never refreshes, the live
+		// set from a snapshot taken before the sweep began. A carve that
+		// deduped onto h in between is invisible to both — it uploads nothing
+		// and writes its manifest row after the mark phase has passed. Claim h
+		// so that carve either already holds it (and the reclaim is skipped)
+		// or is locked out of adopting it for the rest of the reclamation.
+		if !dedupGuard.claim(h, graceCutoff) {
+			return nil // a live dedup adoption holds h — keep it
+		}
+		defer dedupGuard.releaseClaim(h)
+
 		// Block reclaim (#1414 object packing) is the ONLY remote reclaim
-		// path: the sweep reaches h only here, where it has already proven h
-		// globally dead (past grace, absent from the live set), so
-		// decrementing the enclosing block can never race a live dedup
-		// sibling. A deployment without a reclaimer cannot reclaim anything —
-		// record the drift and keep the marker (fail-closed).
+		// path: the sweep reaches h only here, past grace, absent from the
+		// live set and claimed against a concurrent dedup, so decrementing
+		// the enclosing block cannot race a live sibling. A deployment
+		// without a reclaimer cannot reclaim anything — record the drift and
+		// keep the marker (fail-closed).
 		if options.BlockReclaimer == nil {
 			addError("block-reclaim " + key + ": no block reclaimer wired — dead chunk kept (drift)")
 			return nil

--- a/pkg/block/engine/gc_sweep_index.go
+++ b/pkg/block/engine/gc_sweep_index.go
@@ -89,11 +89,8 @@ func sweepFromSyncedIndex(
 			return nil
 		}
 
-		// Both gates above answer from state that predates this moment: the
-		// grace cutoff from a timestamp a dedup hit never refreshes, the live
-		// set from a snapshot taken before the sweep began. A carve that
-		// deduped onto h in between is invisible to both — it uploads nothing
-		// and writes its manifest row after the mark phase has passed. Claim h
+		// Both gates above answer from state that predates this moment, so a
+		// carve that deduped onto h in between is invisible to both. Claim h
 		// so that carve either already holds it (and the reclaim is skipped)
 		// or is locked out of adopting it for the rest of the reclamation.
 		if !dedupGuard.claim(h) {


### PR DESCRIPTION
Closes #2238.

## What was wrong

The carve dedup oracle and the remote GC sweep can each destroy the last copy of a chunk's bytes, and neither appeared in the other's inputs.

When `engineDeduper.IsChunkDurable` answers "already remote-durable", the carver **drops the plaintext** (`carve.go:563` leaves `cc.Data == nil`) and the chunk reaches the sink with nothing to upload. `engineBlockSink.CommitBlock` skips every data-less chunk when building `commits`, so a deduped chunk never reaches `PutSyncedLocators`/`MarkSynced` — it writes a `FileChunk` manifest row and nothing else.

That row is invisible to both of the sweep's gates:

- **The grace gate** reads `syncedAt`, which a dedup hit never refreshes. `MarkSynced` is `ON CONFLICT DO NOTHING`, so the marker keeps its original timestamp — and since no unlink path clears it (every non-test `DeleteSynced` caller is GC itself or the legacy migration), a fully-orphaned hash sits past grace with `IsSynced` still answering `true` to the oracle.
- **The live-set gate** reads a mark-phase snapshot taken before the sweep began (`gc.go`, `markPhase` runs to completion, then `sweepFromSyncedIndex` queries the frozen `GCState`). The deduped row commits after that.

So: hash H loses its last reference; its marker survives, past grace; the mark phase correctly finds H absent; a concurrent write dedups onto H; the sweep frees H's packed block. The new file's chunk now points at bytes that no longer exist.

`gcRootLock` serializes GC against GC. Nothing quiesces writers.

## Why the two obvious fixes do not work

Both were considered and rejected on evidence, not taste:

**"Re-arm `syncedAt` on a dedup hit"** is cheaper than it looks and still not a fix.

`MarkSynced` is first-wins on all four backends, but `Transaction.PutSyncedLocators` already refreshes `synced_at` on all four — `syncedUpsert` on sqlite, `ON CONFLICT (hash) DO UPDATE SET synced_at = excluded.synced_at` on postgres, delete-then-mark on badger and memory. So routing deduped chunks into that existing call needs no new store method and no new conformance coverage.

It does not close the window, because it stamps the timestamp at **commit** time. The interval that matters runs from the *dedup decision* — the moment the carver drops the plaintext — to the commit, and that whole interval stays unprotected:

| | sweep reads `syncedAt` | outcome |
|---|---|---|
| commit already landed | fresh timestamp | kept — safe |
| **commit still pending** | **original, past-grace timestamp** | **reclaimed — bytes gone** |

The second row is the common case, not a corner: the mark phase has already passed the share, so the live-set gate cannot see the row either. Re-arming also does not help once the sweep has read `syncedAt` and is inside `ReclaimDeadChunk`, which on the last-chunk path spans a remote `DeleteBlock` before `DeleteSynced`. And it costs a `GetLocator` per deduped chunk on the carve hot path, since `CarveChunk` carries no locator.

It narrows the window. It does not close it.

**"Revalidate liveness inside the transaction that deletes the marker"** describes a transaction that does not exist and cannot. `SyncedHashIndex` in production is `multiSyncedHashStore` (`pkg/controlplane/runtime/blockgc.go:442`), whose `DeleteSynced` (`:481`) is a plain loop over N independent per-share metadata stores joined with `errors.Join`. The union lives in `controlplane/runtime`, a layer *above* `engine`, so an engine-level sweep cannot open a transaction spanning it even in principle. The interface exposes no transaction handle; the evidence being sought may live in a *different* share's `file_chunks` than the marker being deleted; and the reclaim it would guard includes a remote `DeleteBlock`, which cannot sit inside a database transaction. The liveness evidence is unavailable to the obvious query besides: the deduped row is written `State: BlockStatePending`, and `GetByHash` is Remote-gated, so only `EnumerateFileChunks` can see it.

More fundamentally, neither addresses the actual ordering problem: the oracle's decision, which is what costs the bytes, happens *before* the manifest row exists. Any check against committed metadata is looking for evidence that has not been written yet.

## The fix

`dedupSweepGuard` orders the two decisions directly, per hash, on a stripe:

- `adopt` runs the `IsSynced` probe **inside** the hash's stripe lock and records the adoption. Probing under the lock is the whole mechanism — the sweep cannot claim the hash between the probe and the record.
- `claim`, called by the sweep immediately before `ReclaimDeadChunk`, refuses while a recent adoption holds the hash, and otherwise marks it claimed until `releaseClaim`.

Whichever decision is taken first, the loser fails safe: the carver uploads the chunk it would have deduped, or the sweep keeps the marker for the next pass. No metadata store contract changes, no backend changes, no conformance work.

Adoptions expire by age rather than being released on commit: two carves can adopt the same hash (a release would need a refcount), and a carve that dies between the oracle and its block commit would strand its hold and make the hash unreclaimable for the life of the process. The bound is deliberately *not* the GC grace period — grace answers a different question and an operator may set it to zero.

## Does this close the race or narrow it?

**It closes the concurrent-interleaving race as filed.** The two decisions are now totally ordered by the stripe mutex, and both orderings are safe on every path, including a failed reclaim (the marker survives and the hash becomes adoptable again).

Two residual preconditions are left, both `// ponytail:`-marked on the type:

1. The guard is process-local. It orders a sweep only against carves in the same process — which is all the GC supports today; the run lock in `gc.go` is process-local for exactly the same reason.
2. A carve whose dedup-to-commit gap exceeds one hour would age out from under its own adoption while its row is still unwritten. That gap is seconds in practice; this is a staleness bound, not a scheduling race.

Both close the same way: record the adoption on the synced marker itself and delete that marker conditionally. That is the cross-backend store method described above, and it belongs in its own change.

## Evidence

`gc_sweep_dedup_race_test.go` drives both orderings deterministically — no goroutines, no `-race` dependence. The second subtest hooks `BlockReclaimer` to run the real oracle at the exact instant the sweep has proven the hash dead and is about to free it.

Against this branch:

```
--- PASS: TestGCIndexSweep_ConcurrentDedupKeepsBytes (0.56s)
    --- PASS: TestGCIndexSweep_ConcurrentDedupKeepsBytes/dedup_before_sweep (0.26s)
    --- PASS: TestGCIndexSweep_ConcurrentDedupKeepsBytes/dedup_during_sweep (0.29s)
```

With the production fix reverted and the test kept, both subtests fail on the real symptom (bytes freed / oracle adopting a hash being reclaimed), not on an incidental error:

```
=== RUN   TestGCIndexSweep_ConcurrentDedupKeepsBytes/dedup_before_sweep
    gc_sweep_dedup_race_test.go:64: ObjectsSwept = 1, want 0 (a carve deduped onto the hash)
    gc_sweep_dedup_race_test.go:67: bytes freed under a live dedup adoption: the deduped file's chunk now resolves to nothing
=== RUN   TestGCIndexSweep_ConcurrentDedupKeepsBytes/dedup_during_sweep
    gc_sweep_dedup_race_test.go:115: dedup oracle claimed a hash the sweep was reclaiming: the carve drops its plaintext and the bytes are freed a moment later
--- FAIL: TestGCIndexSweep_ConcurrentDedupKeepsBytes (0.23s)
```

`go test ./pkg/block/... -race` is green.

The doc comments in `gc_sweep_index.go`, `gc.go` and `gc_block.go` asserting the sweep "can never race a live dedup sibling" were the defect stated as an invariant; they now describe what actually makes it true.

`.planning/2026-09-01-block-dataflow-MASTER-PLAN.md` §12.5 item 1 prescribed both of the rejected fixes, so it is amended in place to record what the code actually permits. Every claim above was checked against `origin/develop` directly.
