### PR TITLE
refactor(metadata): the postgres sub-stores speak the shared executor

### DIFF
--- a/pkg/metadata/store/postgres/client_recovery.go
+++ b/pkg/metadata/store/postgres/client_recovery.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
+	storesql "github.com/marmos91/dittofs/pkg/metadata/store/sql"
 )
 
 // ============================================================================
@@ -20,12 +21,12 @@ import (
 // Thread Safety:
 // All operations are single statements executed against the connection pool.
 type postgresRecoveryStore struct {
-	st *PostgresMetadataStore
+	pool storesql.Executor
 }
 
 // newPostgresRecoveryStore creates a new PostgreSQL client recovery store.
 func newPostgresRecoveryStore(st *PostgresMetadataStore) *postgresRecoveryStore {
-	return &postgresRecoveryStore{st: st}
+	return &postgresRecoveryStore{pool: poolExecer{s: st}}
 }
 
 // PutClientRecovery stores or replaces the record for a confirmed client using
@@ -52,7 +53,7 @@ func (s *postgresRecoveryStore) PutClientRecovery(ctx context.Context, rec *lock
 			reclaim_complete = EXCLUDED.reclaim_complete
 	`
 
-	_, err := s.st.exec(ctx, query,
+	_, err := s.pool.Exec(ctx, query,
 		rec.ClientIDString,
 		int64(rec.ClientID),
 		rec.BootVerifier[:], // [8]byte -> BYTEA
@@ -67,7 +68,7 @@ func (s *postgresRecoveryStore) PutClientRecovery(ctx context.Context, rec *lock
 // DeleteClientRecovery removes the record for a client.
 func (s *postgresRecoveryStore) DeleteClientRecovery(ctx context.Context, clientIDString string) error {
 	query := `DELETE FROM v4_client_recovery WHERE clientid_string = $1`
-	_, err := s.st.exec(ctx, query, clientIDString)
+	_, err := s.pool.Exec(ctx, query, clientIDString)
 	return err
 }
 
@@ -108,7 +109,7 @@ func (s *postgresRecoveryStore) ListClientRecovery(ctx context.Context) ([]*lock
 		ORDER BY confirmed_at
 	`
 
-	rows, err := s.st.query(ctx, query)
+	rows, err := s.pool.Query(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +133,7 @@ func (s *postgresRecoveryStore) ListClientRecovery(ctx context.Context) ([]*lock
 // record is a no-op (RowsAffected == 0), not an error.
 func (s *postgresRecoveryStore) RecordReclaimComplete(ctx context.Context, clientIDString string) error {
 	query := `UPDATE v4_client_recovery SET reclaim_complete = TRUE WHERE clientid_string = $1`
-	_, err := s.st.exec(ctx, query, clientIDString)
+	_, err := s.pool.Exec(ctx, query, clientIDString)
 	return err
 }
 

--- a/pkg/metadata/store/postgres/clients.go
+++ b/pkg/metadata/store/postgres/clients.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
+	storesql "github.com/marmos91/dittofs/pkg/metadata/store/sql"
 )
 
 // ============================================================================
@@ -25,13 +26,13 @@ import (
 // Thread Safety:
 // All operations use database transactions for atomicity.
 type postgresClientStore struct {
-	st *PostgresMetadataStore
+	pool storesql.Executor
 }
 
 // newPostgresClientStore creates a new PostgreSQL client registration store.
 func newPostgresClientStore(st *PostgresMetadataStore) *postgresClientStore {
 	return &postgresClientStore{
-		st: st,
+		pool: poolExecer{s: st},
 	}
 }
 
@@ -54,7 +55,7 @@ func (s *postgresClientStore) PutClientRegistration(ctx context.Context, reg *lo
 			server_epoch = EXCLUDED.server_epoch
 	`
 
-	_, err := s.st.exec(ctx, query,
+	_, err := s.pool.Exec(ctx, query,
 		reg.ClientID,
 		reg.MonName,
 		reg.Priv[:], // Convert [16]byte to slice
@@ -80,7 +81,7 @@ func (s *postgresClientStore) GetClientRegistration(ctx context.Context, clientI
 	var reg lock.PersistedClientRegistration
 	var privBytes []byte
 
-	err := s.st.queryRow(ctx, query, clientID).Scan(
+	err := s.pool.QueryRow(ctx, query, clientID).Scan(
 		&reg.ClientID,
 		&reg.MonName,
 		&privBytes,
@@ -110,7 +111,7 @@ func (s *postgresClientStore) GetClientRegistration(ctx context.Context, clientI
 // DeleteClientRegistration removes a registration by client ID.
 func (s *postgresClientStore) DeleteClientRegistration(ctx context.Context, clientID string) error {
 	query := `DELETE FROM nsm_client_registrations WHERE client_id = $1`
-	_, err := s.st.exec(ctx, query, clientID)
+	_, err := s.pool.Exec(ctx, query, clientID)
 	return err
 }
 
@@ -123,7 +124,7 @@ func (s *postgresClientStore) ListClientRegistrations(ctx context.Context) ([]*l
 		ORDER BY registered_at
 	`
 
-	rows, err := s.st.query(ctx, query)
+	rows, err := s.pool.Query(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +167,7 @@ func (s *postgresClientStore) ListClientRegistrations(ctx context.Context) ([]*l
 // DeleteAllClientRegistrations removes all registrations.
 func (s *postgresClientStore) DeleteAllClientRegistrations(ctx context.Context) (int, error) {
 	query := `DELETE FROM nsm_client_registrations`
-	result, err := s.st.exec(ctx, query)
+	result, err := s.pool.Exec(ctx, query)
 	if err != nil {
 		return 0, err
 	}
@@ -176,7 +177,7 @@ func (s *postgresClientStore) DeleteAllClientRegistrations(ctx context.Context) 
 // DeleteClientRegistrationsByMonName removes all registrations monitoring a specific host.
 func (s *postgresClientStore) DeleteClientRegistrationsByMonName(ctx context.Context, monName string) (int, error) {
 	query := `DELETE FROM nsm_client_registrations WHERE mon_name = $1`
-	result, err := s.st.exec(ctx, query, monName)
+	result, err := s.pool.Exec(ctx, query, monName)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/metadata/store/postgres/durable_handles.go
+++ b/pkg/metadata/store/postgres/durable_handles.go
@@ -7,16 +7,17 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
+	storesql "github.com/marmos91/dittofs/pkg/metadata/store/sql"
 )
 
 // postgresDurableStore implements lock.DurableHandleStore using PostgreSQL.
 type postgresDurableStore struct {
-	st *PostgresMetadataStore
+	pool storesql.Executor
 }
 
 func newPostgresDurableStore(st *PostgresMetadataStore) *postgresDurableStore {
 	return &postgresDurableStore{
-		st: st,
+		pool: poolExecer{s: st},
 	}
 }
 
@@ -90,7 +91,7 @@ func scanDurableHandle(row pgx.Row) (*lock.PersistedDurableHandle, error) {
 	return &h, nil
 }
 
-func scanDurableHandleRows(rows pgx.Rows) ([]*lock.PersistedDurableHandle, error) {
+func scanDurableHandleRows(rows storesql.Rows) ([]*lock.PersistedDurableHandle, error) {
 	defer rows.Close()
 
 	var result []*lock.PersistedDurableHandle
@@ -232,7 +233,7 @@ func (s *postgresDurableStore) PutDurableHandle(ctx context.Context, handle *loc
 			client_guid = EXCLUDED.client_guid
 	`
 
-	_, err := s.st.exec(ctx, query,
+	_, err := s.pool.Exec(ctx, query,
 		handle.ID,
 		handle.FileID[:],
 		handle.Path,
@@ -288,17 +289,17 @@ func (s *postgresDurableStore) PutDurableHandle(ctx context.Context, handle *loc
 
 func (s *postgresDurableStore) GetDurableHandle(ctx context.Context, id string) (*lock.PersistedDurableHandle, error) {
 	query := `SELECT ` + durableHandleColumns + ` FROM durable_handles WHERE id = $1`
-	return scanDurableHandle(s.st.queryRow(ctx, query, id))
+	return scanDurableHandle(s.pool.QueryRow(ctx, query, id))
 }
 
 func (s *postgresDurableStore) GetDurableHandleByFileID(ctx context.Context, fileID [16]byte) (*lock.PersistedDurableHandle, error) {
 	query := `SELECT ` + durableHandleColumns + ` FROM durable_handles WHERE file_id = $1 ORDER BY id LIMIT 1`
-	return scanDurableHandle(s.st.queryRow(ctx, query, fileID[:]))
+	return scanDurableHandle(s.pool.QueryRow(ctx, query, fileID[:]))
 }
 
 func (s *postgresDurableStore) GetDurableHandleByCreateGuid(ctx context.Context, createGuid [16]byte) (*lock.PersistedDurableHandle, error) {
 	query := `SELECT ` + durableHandleColumns + ` FROM durable_handles WHERE create_guid = $1 LIMIT 1`
-	return scanDurableHandle(s.st.queryRow(ctx, query, createGuid[:]))
+	return scanDurableHandle(s.pool.QueryRow(ctx, query, createGuid[:]))
 }
 
 // ConsumeDurableHandle atomically fetches and deletes via
@@ -306,12 +307,12 @@ func (s *postgresDurableStore) GetDurableHandleByCreateGuid(ctx context.Context,
 // caller validated and leaves the file's other handles untouched.
 func (s *postgresDurableStore) ConsumeDurableHandle(ctx context.Context, id string) (*lock.PersistedDurableHandle, error) {
 	query := `DELETE FROM durable_handles WHERE id = $1 RETURNING ` + durableHandleColumns
-	return scanDurableHandle(s.st.queryRow(ctx, query, id))
+	return scanDurableHandle(s.pool.QueryRow(ctx, query, id))
 }
 
 func (s *postgresDurableStore) GetDurableHandlesByAppInstanceId(ctx context.Context, appInstanceId [16]byte) ([]*lock.PersistedDurableHandle, error) {
 	query := `SELECT ` + durableHandleColumns + ` FROM durable_handles WHERE app_instance_id = $1 ORDER BY created_at`
-	rows, err := s.st.query(ctx, query, appInstanceId[:])
+	rows, err := s.pool.Query(ctx, query, appInstanceId[:])
 	if err != nil {
 		return nil, err
 	}
@@ -320,7 +321,7 @@ func (s *postgresDurableStore) GetDurableHandlesByAppInstanceId(ctx context.Cont
 
 func (s *postgresDurableStore) GetDurableHandlesByFileHandle(ctx context.Context, fileHandle []byte) ([]*lock.PersistedDurableHandle, error) {
 	query := `SELECT ` + durableHandleColumns + ` FROM durable_handles WHERE metadata_handle = $1 ORDER BY created_at`
-	rows, err := s.st.query(ctx, query, fileHandle)
+	rows, err := s.pool.Query(ctx, query, fileHandle)
 	if err != nil {
 		return nil, err
 	}
@@ -329,13 +330,13 @@ func (s *postgresDurableStore) GetDurableHandlesByFileHandle(ctx context.Context
 
 func (s *postgresDurableStore) DeleteDurableHandle(ctx context.Context, id string) error {
 	query := `DELETE FROM durable_handles WHERE id = $1`
-	_, err := s.st.exec(ctx, query, id)
+	_, err := s.pool.Exec(ctx, query, id)
 	return err
 }
 
 func (s *postgresDurableStore) ListDurableHandles(ctx context.Context) ([]*lock.PersistedDurableHandle, error) {
 	query := `SELECT ` + durableHandleColumns + ` FROM durable_handles ORDER BY created_at`
-	rows, err := s.st.query(ctx, query)
+	rows, err := s.pool.Query(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -344,7 +345,7 @@ func (s *postgresDurableStore) ListDurableHandles(ctx context.Context) ([]*lock.
 
 func (s *postgresDurableStore) ListDurableHandlesByShare(ctx context.Context, shareName string) ([]*lock.PersistedDurableHandle, error) {
 	query := `SELECT ` + durableHandleColumns + ` FROM durable_handles WHERE share_name = $1 ORDER BY created_at`
-	rows, err := s.st.query(ctx, query, shareName)
+	rows, err := s.pool.Query(ctx, query, shareName)
 	if err != nil {
 		return nil, err
 	}
@@ -356,7 +357,7 @@ func (s *postgresDurableStore) DeleteExpiredDurableHandles(ctx context.Context, 
 		DELETE FROM durable_handles
 		WHERE disconnected_at + (timeout_ms || ' milliseconds')::interval <= $1
 	`
-	result, err := s.st.exec(ctx, query, now)
+	result, err := s.pool.Exec(ctx, query, now)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/metadata/store/postgres/locks.go
+++ b/pkg/metadata/store/postgres/locks.go
@@ -167,8 +167,6 @@ func (s *postgresLockStore) putLockTx(ctx context.Context, tx storesql.Executor,
 // shares the scanLock destination layout.
 const selectByID = `SELECT ` + lockColumns + ` FROM locks WHERE id = $1`
 
-// rowScanner is satisfied by both pgx.Row (QueryRow) and pgx.Rows so a single
-// scanLock helper serves every read path.
 // scanLock scans one row into a PersistedLock. byte_offset/byte_length are
 // NUMERIC(20) (full uint64 range) and are scanned as decimal strings, then
 // parsed: pgx cannot scan a numeric above MaxInt64 into a Go uint64 directly.

--- a/pkg/metadata/store/postgres/locks.go
+++ b/pkg/metadata/store/postgres/locks.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/marmos91/dittofs/pkg/metadata/errors"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
+	storesql "github.com/marmos91/dittofs/pkg/metadata/store/sql"
 )
 
 // ============================================================================
@@ -29,11 +29,11 @@ import (
 // Thread Safety:
 // All operations use database transactions for atomicity.
 type postgresLockStore struct {
-	pool *pgxpool.Pool
+	pool storesql.Executor
 }
 
 // newPostgresLockStore creates a new PostgreSQL lock store.
-func newPostgresLockStore(pool *pgxpool.Pool) *postgresLockStore {
+func newPostgresLockStore(pool storesql.Executor) *postgresLockStore {
 	return &postgresLockStore{
 		pool: pool,
 	}
@@ -158,7 +158,7 @@ func (s *postgresLockStore) PutLock(ctx context.Context, lk *lock.PersistedLock)
 }
 
 // putLockTx persists a lock within an existing transaction.
-func (s *postgresLockStore) putLockTx(ctx context.Context, tx pgx.Tx, lk *lock.PersistedLock) error {
+func (s *postgresLockStore) putLockTx(ctx context.Context, tx storesql.Executor, lk *lock.PersistedLock) error {
 	_, err := tx.Exec(ctx, putLockSQL, putLockArgs(lk)...)
 	return err
 }
@@ -169,14 +169,10 @@ const selectByID = `SELECT ` + lockColumns + ` FROM locks WHERE id = $1`
 
 // rowScanner is satisfied by both pgx.Row (QueryRow) and pgx.Rows so a single
 // scanLock helper serves every read path.
-type rowScanner interface {
-	Scan(dest ...interface{}) error
-}
-
 // scanLock scans one row into a PersistedLock. byte_offset/byte_length are
 // NUMERIC(20) (full uint64 range) and are scanned as decimal strings, then
 // parsed: pgx cannot scan a numeric above MaxInt64 into a Go uint64 directly.
-func scanLock(row rowScanner) (*lock.PersistedLock, error) {
+func scanLock(row storesql.Row) (*lock.PersistedLock, error) {
 	var lk lock.PersistedLock
 	var offsetStr, lengthStr string
 	var breakStarted sql.NullTime
@@ -256,7 +252,7 @@ func (s *postgresLockStore) GetLock(ctx context.Context, lockID string) (*lock.P
 }
 
 // getLockTx retrieves a lock within an existing transaction.
-func (s *postgresLockStore) getLockTx(ctx context.Context, tx pgx.Tx, lockID string) (*lock.PersistedLock, error) {
+func (s *postgresLockStore) getLockTx(ctx context.Context, tx storesql.Executor, lockID string) (*lock.PersistedLock, error) {
 	lk, err := scanLock(tx.QueryRow(ctx, selectByID, lockID))
 	if err == pgx.ErrNoRows {
 		return nil, &errors.StoreError{
@@ -292,7 +288,7 @@ func (s *postgresLockStore) DeleteLock(ctx context.Context, lockID string) error
 }
 
 // deleteLockTx removes a lock within an existing transaction.
-func (s *postgresLockStore) deleteLockTx(ctx context.Context, tx pgx.Tx, lockID string) error {
+func (s *postgresLockStore) deleteLockTx(ctx context.Context, tx storesql.Executor, lockID string) error {
 	query := `DELETE FROM locks WHERE id = $1`
 	result, err := tx.Exec(ctx, query, lockID)
 	if err != nil {
@@ -364,7 +360,7 @@ func (s *postgresLockStore) ListLocks(ctx context.Context, query lock.LockQuery)
 }
 
 // listLocksTx lists locks within an existing transaction.
-func (s *postgresLockStore) listLocksTx(ctx context.Context, tx pgx.Tx, query lock.LockQuery) ([]*lock.PersistedLock, error) {
+func (s *postgresLockStore) listLocksTx(ctx context.Context, tx storesql.Executor, query lock.LockQuery) ([]*lock.PersistedLock, error) {
 	baseQuery, args := buildListQuery(query)
 
 	rows, err := tx.Query(ctx, baseQuery, args...)
@@ -397,7 +393,7 @@ func (s *postgresLockStore) DeleteLocksByClient(ctx context.Context, clientID st
 }
 
 // deleteLocksByClientTx removes locks within an existing transaction.
-func (s *postgresLockStore) deleteLocksByClientTx(ctx context.Context, tx pgx.Tx, clientID string) (int, error) {
+func (s *postgresLockStore) deleteLocksByClientTx(ctx context.Context, tx storesql.Executor, clientID string) (int, error) {
 	query := `DELETE FROM locks WHERE client_id = $1`
 	result, err := tx.Exec(ctx, query, clientID)
 	if err != nil {
@@ -419,7 +415,7 @@ func (s *postgresLockStore) DeleteLocksByFile(ctx context.Context, fileID string
 }
 
 // deleteLocksByFileTx removes locks within an existing transaction.
-func (s *postgresLockStore) deleteLocksByFileTx(ctx context.Context, tx pgx.Tx, fileID string) (int, error) {
+func (s *postgresLockStore) deleteLocksByFileTx(ctx context.Context, tx storesql.Executor, fileID string) (int, error) {
 	query := `DELETE FROM locks WHERE file_id = $1`
 	result, err := tx.Exec(ctx, query, fileID)
 	if err != nil {
@@ -444,7 +440,7 @@ func (s *postgresLockStore) GetServerEpoch(ctx context.Context) (uint64, error) 
 }
 
 // getServerEpochTx gets epoch within an existing transaction.
-func (s *postgresLockStore) getServerEpochTx(ctx context.Context, tx pgx.Tx) (uint64, error) {
+func (s *postgresLockStore) getServerEpochTx(ctx context.Context, tx storesql.Executor) (uint64, error) {
 	query := `SELECT epoch FROM server_epoch WHERE id = 1`
 	var epoch uint64
 	err := tx.QueryRow(ctx, query).Scan(&epoch)
@@ -473,7 +469,7 @@ func (s *postgresLockStore) IncrementServerEpoch(ctx context.Context) (uint64, e
 }
 
 // incrementServerEpochTx increments epoch within an existing transaction.
-func (s *postgresLockStore) incrementServerEpochTx(ctx context.Context, tx pgx.Tx) (uint64, error) {
+func (s *postgresLockStore) incrementServerEpochTx(ctx context.Context, tx storesql.Executor) (uint64, error) {
 	query := `
 		INSERT INTO server_epoch (id, epoch, updated_at)
 		VALUES (1, 1, NOW())
@@ -519,7 +515,7 @@ func (s *postgresLockStore) SetCleanShutdown(ctx context.Context, clean bool) er
 }
 
 // getCleanShutdownTx reads the marker within an existing transaction.
-func (s *postgresLockStore) getCleanShutdownTx(ctx context.Context, tx pgx.Tx) (bool, error) {
+func (s *postgresLockStore) getCleanShutdownTx(ctx context.Context, tx storesql.Executor) (bool, error) {
 	query := `SELECT clean_shutdown FROM server_epoch WHERE id = 1`
 	var clean bool
 	err := tx.QueryRow(ctx, query).Scan(&clean)
@@ -533,7 +529,7 @@ func (s *postgresLockStore) getCleanShutdownTx(ctx context.Context, tx pgx.Tx) (
 }
 
 // setCleanShutdownTx writes the marker within an existing transaction.
-func (s *postgresLockStore) setCleanShutdownTx(ctx context.Context, tx pgx.Tx, clean bool) error {
+func (s *postgresLockStore) setCleanShutdownTx(ctx context.Context, tx storesql.Executor, clean bool) error {
 	query := `
 		INSERT INTO server_epoch (id, epoch, clean_shutdown, updated_at)
 		VALUES (1, 0, $1, NOW())
@@ -582,7 +578,7 @@ func (s *postgresLockStore) ReclaimLease(ctx context.Context, fileHandle lock.Fi
 }
 
 // reclaimLeaseTx reclaims a lease within an existing transaction.
-func (s *postgresLockStore) reclaimLeaseTx(ctx context.Context, tx pgx.Tx, fileHandle lock.FileHandle, leaseKey [16]byte, _ string) (*lock.UnifiedLock, error) {
+func (s *postgresLockStore) reclaimLeaseTx(ctx context.Context, tx storesql.Executor, fileHandle lock.FileHandle, leaseKey [16]byte, _ string) (*lock.UnifiedLock, error) {
 	// Search for leases on this file with matching lease key
 	locks, err := s.listLocksTx(ctx, tx, lock.LockQuery{FileID: string(fileHandle)})
 	if err != nil {
@@ -686,45 +682,45 @@ func (s *PostgresMetadataStore) ReclaimLease(ctx context.Context, fileHandle loc
 var _ lock.LockStore = (*postgresTransaction)(nil)
 
 func (ptx *postgresTransaction) PutLock(ctx context.Context, lk *lock.PersistedLock) error {
-	return ptx.store.lockStore.putLockTx(ctx, ptx.tx, lk)
+	return ptx.store.lockStore.putLockTx(ctx, txExecer{tx: ptx.tx}, lk)
 }
 
 func (ptx *postgresTransaction) GetLock(ctx context.Context, lockID string) (*lock.PersistedLock, error) {
-	return ptx.store.lockStore.getLockTx(ctx, ptx.tx, lockID)
+	return ptx.store.lockStore.getLockTx(ctx, txExecer{tx: ptx.tx}, lockID)
 }
 
 func (ptx *postgresTransaction) DeleteLock(ctx context.Context, lockID string) error {
-	return ptx.store.lockStore.deleteLockTx(ctx, ptx.tx, lockID)
+	return ptx.store.lockStore.deleteLockTx(ctx, txExecer{tx: ptx.tx}, lockID)
 }
 
 func (ptx *postgresTransaction) ListLocks(ctx context.Context, query lock.LockQuery) ([]*lock.PersistedLock, error) {
-	return ptx.store.lockStore.listLocksTx(ctx, ptx.tx, query)
+	return ptx.store.lockStore.listLocksTx(ctx, txExecer{tx: ptx.tx}, query)
 }
 
 func (ptx *postgresTransaction) DeleteLocksByClient(ctx context.Context, clientID string) (int, error) {
-	return ptx.store.lockStore.deleteLocksByClientTx(ctx, ptx.tx, clientID)
+	return ptx.store.lockStore.deleteLocksByClientTx(ctx, txExecer{tx: ptx.tx}, clientID)
 }
 
 func (ptx *postgresTransaction) DeleteLocksByFile(ctx context.Context, fileID string) (int, error) {
-	return ptx.store.lockStore.deleteLocksByFileTx(ctx, ptx.tx, fileID)
+	return ptx.store.lockStore.deleteLocksByFileTx(ctx, txExecer{tx: ptx.tx}, fileID)
 }
 
 func (ptx *postgresTransaction) GetServerEpoch(ctx context.Context) (uint64, error) {
-	return ptx.store.lockStore.getServerEpochTx(ctx, ptx.tx)
+	return ptx.store.lockStore.getServerEpochTx(ctx, txExecer{tx: ptx.tx})
 }
 
 func (ptx *postgresTransaction) IncrementServerEpoch(ctx context.Context) (uint64, error) {
-	return ptx.store.lockStore.incrementServerEpochTx(ctx, ptx.tx)
+	return ptx.store.lockStore.incrementServerEpochTx(ctx, txExecer{tx: ptx.tx})
 }
 
 func (ptx *postgresTransaction) GetCleanShutdown(ctx context.Context) (bool, error) {
-	return ptx.store.lockStore.getCleanShutdownTx(ctx, ptx.tx)
+	return ptx.store.lockStore.getCleanShutdownTx(ctx, txExecer{tx: ptx.tx})
 }
 
 func (ptx *postgresTransaction) SetCleanShutdown(ctx context.Context, clean bool) error {
-	return ptx.store.lockStore.setCleanShutdownTx(ctx, ptx.tx, clean)
+	return ptx.store.lockStore.setCleanShutdownTx(ctx, txExecer{tx: ptx.tx}, clean)
 }
 
 func (ptx *postgresTransaction) ReclaimLease(ctx context.Context, fileHandle lock.FileHandle, leaseKey [16]byte, clientID string) (*lock.UnifiedLock, error) {
-	return ptx.store.lockStore.reclaimLeaseTx(ctx, ptx.tx, fileHandle, leaseKey, clientID)
+	return ptx.store.lockStore.reclaimLeaseTx(ctx, txExecer{tx: ptx.tx}, fileHandle, leaseKey, clientID)
 }

--- a/pkg/metadata/store/postgres/store.go
+++ b/pkg/metadata/store/postgres/store.go
@@ -155,7 +155,7 @@ func NewPostgresMetadataStore(
 
 	// The substores derive only from pool, which is never reassigned, so bind
 	// them once here.
-	store.lockStore = newPostgresLockStore(pool)
+	store.lockStore = newPostgresLockStore(poolExecer{s: store})
 	store.clientStore = newPostgresClientStore(store)
 	store.durableStore = newPostgresDurableStore(store)
 	store.recoveryStore = newPostgresRecoveryStore(store)


### PR DESCRIPTION
Continues #1828. Independent of the #2243/#2244 stack — this touches only the lock/client/handle sub-stores.

Groundwork for merging the lock, client, client-recovery and durable-handle bodies. Those four files are already 79-92% identical between the dialects once placeholders and error mappers are normalised, but they could not be merged while the two sides disagreed about what an executor *is*.

Each postgres sub-store reached the database its own way:

| sub-store | held | Tx variants took |
| --- | --- | --- |
| clients, client_recovery, durable_handles | `*PostgresMetadataStore` | — |
| locks | a raw `*pgxpool.Pool` | `pgx.Tx` |

Their sqlite counterparts have always held the package's `execer`. So most of what still separated the two sides was that plumbing, not any difference in what the code does. All four now hold a `storesql.Executor`, and the lock store's `Tx` variants take one too — the `poolExecer` / `txExecer` adapters this needs already exist from #2225.

Measured effect on the normalised diff, which is the point of the change:

| file | before | after |
| --- | --- | --- |
| `locks.go` | 92% shared | **94%** |
| `clients.go` | 89% | **96%** |
| `client_recovery.go` | 90% | **96%** |
| `durable_handles.go` | 79% | **85%** |

### One behaviour change, in the right direction

The lock store gains the pool-exhaustion guard the rest of the package already had. `pgxpool.Pool.QueryRow` acquires a connection bounded only by the caller's context, so a lock query could block indefinitely on an exhausted pool while every other query in the store failed after `poolConnectionAcquireTimeout` with a message naming the cause. Routing it through `poolExecer` puts it on the same footing.

Also drops the lock store's private `rowScanner` interface — it was `storesql.Row` under another name.

No SQL text changed and no logic moved; this is the type seam only. Green locally on `go test ./pkg/metadata/...`, `go vet`, golangci-lint, and the postgres integration suite against a real postgres 16.