### PR TITLE
fix(journal): fence Hydrate against a racing Delete

### DIFF
--- a/pkg/block/journal/hydrate_delete_test.go
+++ b/pkg/block/journal/hydrate_delete_test.go
@@ -1,0 +1,102 @@
+package journal
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"testing"
+)
+
+// TestHydrateAfterDeleteIsDropped is the delete twin of
+// TestHydrateAfterTruncateIsDropped. A delete removes the file's index entry
+// outright, so hydratable's nil-receiver path offers the whole requested range
+// and a hydrate still in flight from before the delete would re-create the file
+// out of pre-delete remote bytes.
+func TestHydrateAfterDeleteIsDropped(t *testing.T) {
+	ctx := context.Background()
+	s, _ := evictStore(t, Config{})
+	data := bytes.Repeat([]byte{0xAB}, 4096)
+	if err := s.WriteAt(ctx, "f", 0, data); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	mark := s.WriteVersion() // a fetch resolves the pre-delete manifest here
+	if err := s.Delete(ctx, "f"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if err := s.Hydrate(ctx, "f", 0, data, mark); err != nil {
+		t.Fatalf("Hydrate: %v", err)
+	}
+	if sz, ok := s.FileSize(ctx, "f"); ok {
+		t.Fatalf("hydrate resurrected a deleted file: FileSize = %d", sz)
+	}
+	got := make([]byte, len(data))
+	if _, _, err := s.ReadAt(ctx, "f", 0, got); err != nil {
+		t.Fatalf("ReadAt: %v", err)
+	}
+	if !bytes.Equal(got, make([]byte, len(data))) {
+		t.Fatal("hydrate resurrected bytes a delete removed")
+	}
+}
+
+// TestHydrateRacingDeleteNeverResurrects runs the two against each other rather
+// than in a fixed order. Whichever wins the shard lock, a hydrate whose bound
+// was sampled before the delete must leave nothing behind: it either loses the
+// fence check or lands below the tombstone's Version and is buried by it.
+func TestHydrateRacingDeleteNeverResurrects(t *testing.T) {
+	ctx := context.Background()
+	data := bytes.Repeat([]byte{0xAB}, 4096)
+	for i := 0; i < 64; i++ {
+		s, _ := evictStore(t, Config{})
+		if err := s.WriteAt(ctx, "f", 0, data); err != nil {
+			t.Fatalf("WriteAt: %v", err)
+		}
+		mark := s.WriteVersion()
+
+		var wg sync.WaitGroup
+		var delErr, hydErr error
+		wg.Add(2)
+		go func() { defer wg.Done(); delErr = s.Delete(ctx, "f") }()
+		go func() { defer wg.Done(); hydErr = s.Hydrate(ctx, "f", 0, data, mark) }()
+		wg.Wait()
+		if delErr != nil {
+			t.Fatalf("Delete: %v", delErr)
+		}
+		if hydErr != nil {
+			t.Fatalf("Hydrate: %v", hydErr)
+		}
+		if sz, ok := s.FileSize(ctx, "f"); ok {
+			t.Fatalf("iteration %d: hydrate resurrected a deleted file: FileSize = %d", i, sz)
+		}
+		_ = s.Close()
+	}
+}
+
+// TestHydrateAfterDeleteAndRecreate pins the other side of the fence: it bounds
+// hydrates that predate the delete, not the file name forever. A file written
+// again after the delete accepts a hydrate whose bound was sampled after it.
+func TestHydrateAfterDeleteAndRecreate(t *testing.T) {
+	ctx := context.Background()
+	s, _ := evictStore(t, Config{})
+	head := bytes.Repeat([]byte{0x11}, 4096)
+	tail := bytes.Repeat([]byte{0x22}, 4096)
+
+	if err := s.WriteAt(ctx, "f", 0, head); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if err := s.Delete(ctx, "f"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if err := s.WriteAt(ctx, "f", 0, head); err != nil { // re-created after the unlink
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if err := s.Hydrate(ctx, "f", int64(len(head)), tail, s.WriteVersion()); err != nil {
+		t.Fatalf("Hydrate: %v", err)
+	}
+	got := make([]byte, len(head)+len(tail))
+	if _, _, err := s.ReadAt(ctx, "f", 0, got); err != nil {
+		t.Fatalf("ReadAt: %v", err)
+	}
+	if !bytes.Equal(got[len(head):], tail) {
+		t.Fatal("the delete fence outlived the file and blocked a hydrate of its replacement")
+	}
+}

--- a/pkg/block/journal/hydrate_delete_test.go
+++ b/pkg/block/journal/hydrate_delete_test.go
@@ -133,3 +133,46 @@ func TestDeleteFenceEvictionSparesARestampedFence(t *testing.T) {
 		t.Fatalf("eviction dropped a re-stamped fence: hydrateFence[x] = %d, want 99", got)
 	}
 }
+
+// TestHydrateOverEvictedFenceIsDropped pins the direction the FIFO fails in.
+// The cap is reachable — ShardCount may be 1, so every delete lands in one
+// shard, and a remote serving 503s stretches the fetch window widest exactly
+// when cold reads are most likely to be outstanding — so evicting a fence whose
+// hydrate is still in flight must not let that hydrate land. evictedFenceFloor
+// stands in for the dropped entry, which makes overflow cost a re-fetch instead
+// of a resurrection, and makes maxDeleteFences a memory knob rather than a
+// correctness bound.
+func TestHydrateOverEvictedFenceIsDropped(t *testing.T) {
+	ctx := context.Background()
+	s, _ := evictStore(t, Config{}) // single shard: every fence shares one FIFO
+	data := bytes.Repeat([]byte{0xAB}, 4096)
+	if err := s.WriteAt(ctx, "victim", 0, data); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	mark := s.WriteVersion() // a cold read resolves the pre-delete manifest here
+	if err := s.Delete(ctx, "victim"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	// Push the victim's fence out of the FIFO behind enough later deletes. Real
+	// deletes would each cost a tombstone fsync; the fences they stamp go through
+	// this same call.
+	sh := s.shardFor("victim")
+	sh.mu.Lock()
+	base := s.WriteVersion()
+	for i := 0; i <= maxDeleteFences; i++ {
+		sh.fenceDelete(FileID(fmt.Sprintf("later%d", i)), base+1+uint64(i))
+	}
+	_, stillFenced := sh.hydrateFence["victim"]
+	sh.mu.Unlock()
+	if stillFenced {
+		t.Fatal("setup: the victim's fence was not evicted, so this proves nothing")
+	}
+
+	if err := s.Hydrate(ctx, "victim", 0, data, mark); err != nil {
+		t.Fatalf("Hydrate: %v", err)
+	}
+	if sz, ok := s.FileSize(ctx, "victim"); ok {
+		t.Fatalf("a hydrate over an evicted fence resurrected the file: FileSize = %d", sz)
+	}
+}

--- a/pkg/block/journal/hydrate_delete_test.go
+++ b/pkg/block/journal/hydrate_delete_test.go
@@ -3,7 +3,7 @@ package journal
 import (
 	"bytes"
 	"context"
-	"sync"
+	"fmt"
 	"testing"
 )
 
@@ -38,36 +38,33 @@ func TestHydrateAfterDeleteIsDropped(t *testing.T) {
 	}
 }
 
-// TestHydrateRacingDeleteNeverResurrects runs the two against each other rather
-// than in a fixed order. Whichever wins the shard lock, a hydrate whose bound
-// was sampled before the delete must leave nothing behind: it either loses the
-// fence check or lands below the tombstone's Version and is buried by it.
-func TestHydrateRacingDeleteNeverResurrects(t *testing.T) {
+// TestHydrateBoundAtTombstoneVersionIsDropped pins WHICH Version the fence
+// carries. Delete cannot stamp it from a version peeked before calling
+// appendTombstone: the tombstone's own Version is minted later under a
+// different acquisition of the lock and is strictly higher, so a cold read
+// holding a bound in between clears the fence, finds the index entry already
+// scrubbed, and re-creates the whole file through hydratable's nil receiver.
+// Stamping in the same critical section that mints the Version is what leaves
+// no gap, and this is the test that says so — the plain
+// TestHydrateAfterDeleteIsDropped passes with the fence stamped either way.
+func TestHydrateBoundAtTombstoneVersionIsDropped(t *testing.T) {
 	ctx := context.Background()
+	s, _ := evictStore(t, Config{})
 	data := bytes.Repeat([]byte{0xAB}, 4096)
-	for i := 0; i < 64; i++ {
-		s, _ := evictStore(t, Config{})
-		if err := s.WriteAt(ctx, "f", 0, data); err != nil {
-			t.Fatalf("WriteAt: %v", err)
-		}
-		mark := s.WriteVersion()
-
-		var wg sync.WaitGroup
-		var delErr, hydErr error
-		wg.Add(2)
-		go func() { defer wg.Done(); delErr = s.Delete(ctx, "f") }()
-		go func() { defer wg.Done(); hydErr = s.Hydrate(ctx, "f", 0, data, mark) }()
-		wg.Wait()
-		if delErr != nil {
-			t.Fatalf("Delete: %v", delErr)
-		}
-		if hydErr != nil {
-			t.Fatalf("Hydrate: %v", hydErr)
-		}
-		if sz, ok := s.FileSize(ctx, "f"); ok {
-			t.Fatalf("iteration %d: hydrate resurrected a deleted file: FileSize = %d", i, sz)
-		}
-		_ = s.Close()
+	if err := s.WriteAt(ctx, "f", 0, data); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if err := s.Delete(ctx, "f"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	// Nothing appends after the tombstone, so this is exactly the tombstone's
+	// Version — above any version Delete could peek before minting it, and the
+	// record a fill would append lands above it too, where the scrub keeps it.
+	if err := s.Hydrate(ctx, "f", 0, data, s.WriteVersion()); err != nil {
+		t.Fatalf("Hydrate: %v", err)
+	}
+	if sz, ok := s.FileSize(ctx, "f"); ok {
+		t.Fatalf("a hydrate bounded at the tombstone's own Version resurrected the file: FileSize = %d", sz)
 	}
 }
 
@@ -98,5 +95,41 @@ func TestHydrateAfterDeleteAndRecreate(t *testing.T) {
 	}
 	if !bytes.Equal(got[len(head):], tail) {
 		t.Fatal("the delete fence outlived the file and blocked a hydrate of its replacement")
+	}
+}
+
+// TestDeleteFenceCountIsBounded pins the cap on a fence that has to outlive the
+// file's index entry: nothing else takes a delete fence back out, so without the
+// FIFO a shard would retain one entry per FileID the store has ever deleted.
+func TestDeleteFenceCountIsBounded(t *testing.T) {
+	sh := newShard(nil)
+	for i := 0; i < maxDeleteFences*3; i++ {
+		sh.fenceDelete(FileID(fmt.Sprintf("f%d", i)), uint64(i+1))
+	}
+	if n := len(sh.hydrateFence); n > maxDeleteFences {
+		t.Fatalf("delete fences grew unbounded: %d entries retained, cap is %d", n, maxDeleteFences)
+	}
+	if _, ok := sh.hydrateFence["f0"]; ok {
+		t.Fatal("the oldest delete fence was never evicted")
+	}
+	newest := FileID(fmt.Sprintf("f%d", maxDeleteFences*3-1))
+	if _, ok := sh.hydrateFence[newest]; !ok {
+		t.Fatal("the newest delete fence was evicted")
+	}
+}
+
+// TestDeleteFenceEvictionSparesARestampedFence covers the version guard. A file
+// deleted, written again and then truncated holds a truncate fence under the
+// same key; evicting the stale delete entry must leave that fence in place,
+// since the file is live and still needs it.
+func TestDeleteFenceEvictionSparesARestampedFence(t *testing.T) {
+	sh := newShard(nil)
+	sh.fenceDelete("x", 5)
+	sh.hydrateFence["x"] = 99 // a later Truncate re-stamps the same key
+	for i := 0; i < maxDeleteFences+1; i++ {
+		sh.fenceDelete(FileID(fmt.Sprintf("f%d", i)), uint64(i+100))
+	}
+	if got := sh.hydrateFence["x"]; got != 99 {
+		t.Fatalf("eviction dropped a re-stamped fence: hydrateFence[x] = %d, want 99", got)
 	}
 }

--- a/pkg/block/journal/segment.go
+++ b/pkg/block/journal/segment.go
@@ -448,6 +448,16 @@ func (s *Store) appendTombstone(ctx context.Context, id FileID) (uint64, error) 
 	}
 	seg := sh.active
 	version := s.nextVersion()
+	// Published in the same critical section that mints the Version, which is the
+	// only place it closes the whole window. A hydrate that takes sh.mu after this
+	// point is refused if its caller sampled a bound at or below the tombstone;
+	// one that got in before it stamped a lower Version and the scrub in Delete
+	// buries it. Stamping earlier (from Delete, before this call) leaves the fence
+	// below the Version this mints, so a hydrate holding a bound in between passes
+	// the fence, appends ABOVE the tombstone, and the scrub then reads it as a
+	// rewrite that raced past the delete and deliberately keeps it. Stamping later
+	// cannot help either: by then that record is already committed.
+	sh.fenceDelete(id, version)
 	recStart, err := writeTombstoneRecord(seg, id, version)
 	if err != nil {
 		sh.mu.Unlock()

--- a/pkg/block/journal/segment.go
+++ b/pkg/block/journal/segment.go
@@ -312,7 +312,7 @@ func (s *Store) appendRecord(ctx context.Context, id FileID, offset int64, data 
 	// and the fetched bytes are the wrong ones.
 	if synced {
 		n := int64(len(data))
-		if staleAfterTruncate(sh, id, notAfter) || !coversWhole(sh.index[id].hydratable(offset, n, notAfter), offset, n) {
+		if hydrateFenced(sh, id, notAfter) || !coversWhole(sh.index[id].hydratable(offset, n, notAfter), offset, n) {
 			return nil
 		}
 	}

--- a/pkg/block/journal/shard.go
+++ b/pkg/block/journal/shard.go
@@ -48,11 +48,19 @@ type shard struct {
 	//
 	// ponytail: a flat FIFO capped at maxDeleteFences per shard, evicting the
 	// oldest fence rather than the one that has outlived every hydrate that
-	// could still cite it. A fence only has to survive one in-flight remote
-	// fetch, so overflowing the cap takes maxDeleteFences deletes into a single
-	// shard inside that window; make it an age-based sweep only if a workload
-	// is measured doing that.
+	// could still cite it. evictedFenceFloor keeps that approximation safe, so
+	// the cap trades memory against re-fetches and is not load-bearing for
+	// correctness; raise it, or make it an age-based sweep, only if a workload
+	// is measured refusing hydrates it should have kept.
 	deleteFences []fenceEntry
+	// evictedFenceFloor is the highest version among the delete fences the FIFO
+	// has dropped. A hydrate at or below it is refused even though its own fence
+	// is gone, so overflowing the cap costs a re-fetch rather than letting a
+	// stale fill land. The cap is reachable — ShardCount may be 1, so every
+	// delete shares one FIFO, and a remote serving errors stretches the fetch
+	// window widest exactly when cold reads are most likely to be outstanding —
+	// and overflow must not fail open.
+	evictedFenceFloor uint64
 	// lastVersion is the highest record Version appended to this shard, stamped
 	// under mu once the record's write() returned. syncedVersion is the highest
 	// Version a completed fsync has covered — records above it exist only in the
@@ -141,6 +149,9 @@ func (sh *shard) fenceDelete(id FileID, ver uint64) {
 		if sh.hydrateFence[oldest.id] <= oldest.ver {
 			delete(sh.hydrateFence, oldest.id)
 		}
+		// Entries are appended in mint order, so this only ever climbs. It stands
+		// in for every fence dropped so far.
+		sh.evictedFenceFloor = oldest.ver
 	}
 }
 

--- a/pkg/block/journal/shard.go
+++ b/pkg/block/journal/shard.go
@@ -128,12 +128,17 @@ func newShard(active *segmentMeta) *shard {
 // fenceDelete publishes id's delete fence at ver and drops the oldest fence
 // once the shard holds more than maxDeleteFences of them. Caller holds sh.mu.
 func (sh *shard) fenceDelete(id FileID, ver uint64) {
-	sh.hydrateFence[id] = ver
+	if ver > sh.hydrateFence[id] {
+		sh.hydrateFence[id] = ver // never lower a fence a racing Truncate stamped higher
+	}
 	sh.deleteFences = append(sh.deleteFences, fenceEntry{id: id, ver: ver})
 	if len(sh.deleteFences) > maxDeleteFences {
 		oldest := sh.deleteFences[0]
 		sh.deleteFences = sh.deleteFences[1:]
-		if sh.hydrateFence[oldest.id] == oldest.ver {
+		// Only if nothing has raised the fence since. A Truncate re-stamp belongs
+		// to a file that is live again and still needs its fence; that entry is
+		// then bounded by the live file set, as every truncate fence always was.
+		if sh.hydrateFence[oldest.id] <= oldest.ver {
 			delete(sh.hydrateFence, oldest.id)
 		}
 	}

--- a/pkg/block/journal/shard.go
+++ b/pkg/block/journal/shard.go
@@ -32,12 +32,27 @@ type shard struct {
 	active *segmentMeta
 	sealed map[uint64]*segmentMeta
 	index  map[FileID]*fileIndex
-	// truncVer is, per file, the store LSN as it stood when that file's most
-	// recent truncate began. A hydrate whose caller sampled its bound at or
-	// below it is refused: truncate clips intervals away rather than recording
-	// one, so a range it emptied leaves nothing for hydratable to weigh a stale
-	// write-back against. Entries die with the file's index on delete.
-	truncVer map[FileID]uint64
+	// hydrateFence is, per file, the store LSN as it stood when that file's most
+	// recent truncate or delete began. A hydrate whose caller sampled its bound
+	// at or below it is refused: both mutations empty intervals away rather than
+	// recording over them, so the range they cleared leaves nothing for
+	// hydratable to weigh a stale write-back against — a delete leaves not even
+	// an index entry, and hydratable's nil receiver offers the whole range.
+	//
+	// A delete's entry therefore has to outlive the file's index entry, and
+	// deleteFences is what keeps that from growing without bound.
+	hydrateFence map[FileID]uint64
+	// deleteFences records the fences stamped by Delete, oldest first. Nothing
+	// else ever takes a delete fence back out of hydrateFence, so without this
+	// the map would retain one entry per FileID the store has ever deleted.
+	//
+	// ponytail: a flat FIFO capped at maxDeleteFences per shard, evicting the
+	// oldest fence rather than the one that has outlived every hydrate that
+	// could still cite it. A fence only has to survive one in-flight remote
+	// fetch, so overflowing the cap takes maxDeleteFences deletes into a single
+	// shard inside that window; make it an age-based sweep only if a workload
+	// is measured doing that.
+	deleteFences []fenceEntry
 	// lastVersion is the highest record Version appended to this shard, stamped
 	// under mu once the record's write() returned. syncedVersion is the highest
 	// Version a completed fsync has covered — records above it exist only in the
@@ -87,16 +102,41 @@ type shard struct {
 	segSync func(*segmentMeta) error
 }
 
+// maxDeleteFences caps how many delete fences one shard retains. See
+// shard.deleteFences.
+const maxDeleteFences = 4096
+
+// fenceEntry is one delete fence as it was stamped. The version is kept so an
+// eviction leaves alone a fence a later truncate has since re-stamped.
+type fenceEntry struct {
+	id  FileID
+	ver uint64
+}
+
 func newShard(active *segmentMeta) *shard {
 	sh := &shard{
-		active:   active,
-		sealed:   make(map[uint64]*segmentMeta),
-		index:    make(map[FileID]*fileIndex),
-		truncVer: make(map[FileID]uint64),
-		segSync:  func(seg *segmentMeta) error { return seg.fd.Sync() },
+		active:       active,
+		sealed:       make(map[uint64]*segmentMeta),
+		index:        make(map[FileID]*fileIndex),
+		hydrateFence: make(map[FileID]uint64),
+		segSync:      func(seg *segmentMeta) error { return seg.fd.Sync() },
 	}
 	sh.commitCond = sync.NewCond(&sh.commitMu)
 	return sh
+}
+
+// fenceDelete publishes id's delete fence at ver and drops the oldest fence
+// once the shard holds more than maxDeleteFences of them. Caller holds sh.mu.
+func (sh *shard) fenceDelete(id FileID, ver uint64) {
+	sh.hydrateFence[id] = ver
+	sh.deleteFences = append(sh.deleteFences, fenceEntry{id: id, ver: ver})
+	if len(sh.deleteFences) > maxDeleteFences {
+		oldest := sh.deleteFences[0]
+		sh.deleteFences = sh.deleteFences[1:]
+		if sh.hydrateFence[oldest.id] == oldest.ver {
+			delete(sh.hydrateFence, oldest.id)
+		}
+	}
 }
 
 // markSynced raises the shard's durable watermark to v, which must be a Version

--- a/pkg/block/journal/shard.go
+++ b/pkg/block/journal/shard.go
@@ -142,6 +142,10 @@ func (sh *shard) fenceDelete(id FileID, ver uint64) {
 	sh.deleteFences = append(sh.deleteFences, fenceEntry{id: id, ver: ver})
 	if len(sh.deleteFences) > maxDeleteFences {
 		oldest := sh.deleteFences[0]
+		// Clear the slot before the reslice: the backing array outlives the reslice
+		// until it reallocates, and until then it would pin every evicted FileID
+		// string for nothing.
+		sh.deleteFences[0] = fenceEntry{}
 		sh.deleteFences = sh.deleteFences[1:]
 		// Only if nothing has raised the fence since. A Truncate re-stamp belongs
 		// to a file that is live again and still needs its fence; that entry is

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -455,7 +455,7 @@ func (s *Store) Hydrate(ctx context.Context, id FileID, offset int64, data []byt
 	sh := s.shardFor(id)
 	sh.mu.Lock()
 	var ranges [][2]int64
-	if !staleAfterTruncate(sh, id, notAfter) {
+	if !hydrateFenced(sh, id, notAfter) {
 		ranges = sh.index[id].hydratable(offset, int64(len(data)), notAfter)
 	}
 	sh.mu.Unlock()
@@ -472,11 +472,11 @@ func (s *Store) Hydrate(ctx context.Context, id FileID, offset int64, data []byt
 // (see Hydrate).
 func (s *Store) WriteVersion() uint64 { return s.version.Load() }
 
-// staleAfterTruncate reports whether a hydrate's bound predates the file's most
-// recent truncate, which is the one mutation that leaves no interval behind to
-// compare against. Callers hold sh.mu.
-func staleAfterTruncate(sh *shard, id FileID, notAfter uint64) bool {
-	return notAfter > 0 && notAfter <= sh.truncVer[id]
+// hydrateFenced reports whether a hydrate's bound predates the file's most
+// recent truncate or delete — the two mutations that leave no interval behind
+// to compare against. Callers hold sh.mu.
+func hydrateFenced(sh *shard, id FileID, notAfter uint64) bool {
+	return notAfter > 0 && notAfter <= sh.hydrateFence[id]
 }
 
 // SeedCold registers a byte range as remote-durable-but-not-local: a read of it
@@ -768,6 +768,20 @@ func (s *Store) Delete(ctx context.Context, id FileID) error {
 	if s.closed.Load() {
 		return errClosed
 	}
+	sh := s.shardFor(id)
+	// Published before the tombstone's Version is minted, so a cold read that
+	// sampled its bound earlier is refused rather than racing the append: an
+	// in-flight hydrate is otherwise free to land above the tombstone's Version,
+	// where the scrub below reads it as a rewrite that survives and re-creates
+	// the file out of pre-delete remote bytes. A hydrate that samples after this
+	// point carries a higher bound and is left alone, so a file written again
+	// after the unlink still hydrates. If the append below fails the fence stays,
+	// costing at most a re-fetch — dropping a write-back cache fill is always
+	// safe, resurrecting a deleted file is not.
+	sh.mu.Lock()
+	sh.fenceDelete(id, s.version.Load())
+	sh.mu.Unlock()
+
 	// Durability first: persist and fsync the tombstone BEFORE touching the
 	// in-memory index or the counters. If the append fails, the file's ranges are
 	// left intact — a failed Delete never makes data disappear, and a crash can
@@ -780,7 +794,6 @@ func (s *Store) Delete(ctx context.Context, id FileID) error {
 		return err
 	}
 
-	sh := s.shardFor(id)
 	sh.mu.Lock()
 	fi := sh.index[id]
 	var dirty int64
@@ -808,8 +821,6 @@ func (s *Store) Delete(ctx context.Context, id FileID) error {
 			fi.ivs = kept
 		}
 	}
-	// The file is gone, so its truncate bound has nothing left to guard.
-	delete(sh.truncVer, id)
 	sh.mu.Unlock()
 	if dirty != 0 {
 		s.unsynced.Add(-dirty)
@@ -970,7 +981,7 @@ func (s *Store) Truncate(ctx context.Context, id FileID, newSize int64) error {
 	if past {
 		// Published before the marker is stamped, so a hydrate that samples its
 		// bound after this point is never mistaken for one that predates the clip.
-		sh.truncVer[id] = s.version.Load()
+		sh.hydrateFence[id] = s.version.Load()
 	}
 	sh.mu.Unlock()
 	if !past {

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -474,9 +474,11 @@ func (s *Store) WriteVersion() uint64 { return s.version.Load() }
 
 // hydrateFenced reports whether a hydrate's bound predates the file's most
 // recent truncate or delete — the two mutations that leave no interval behind
-// to compare against. Callers hold sh.mu.
+// to compare against. A delete's fence may have been evicted from the shard's
+// FIFO, in which case evictedFenceFloor still stands in for it. Callers hold
+// sh.mu.
 func hydrateFenced(sh *shard, id FileID, notAfter uint64) bool {
-	return notAfter > 0 && notAfter <= sh.hydrateFence[id]
+	return notAfter > 0 && (notAfter <= sh.hydrateFence[id] || notAfter <= sh.evictedFenceFloor)
 }
 
 // SeedCold registers a byte range as remote-durable-but-not-local: a read of it

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -768,8 +768,6 @@ func (s *Store) Delete(ctx context.Context, id FileID) error {
 	if s.closed.Load() {
 		return errClosed
 	}
-	sh := s.shardFor(id)
-
 	// Durability first: persist and fsync the tombstone BEFORE touching the
 	// in-memory index or the counters. If the append fails, the file's ranges are
 	// left intact — a failed Delete never makes data disappear, and a crash can
@@ -782,6 +780,7 @@ func (s *Store) Delete(ctx context.Context, id FileID) error {
 		return err
 	}
 
+	sh := s.shardFor(id)
 	sh.mu.Lock()
 	fi := sh.index[id]
 	var dirty int64

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -769,18 +769,6 @@ func (s *Store) Delete(ctx context.Context, id FileID) error {
 		return errClosed
 	}
 	sh := s.shardFor(id)
-	// Published before the tombstone's Version is minted, so a cold read that
-	// sampled its bound earlier is refused rather than racing the append: an
-	// in-flight hydrate is otherwise free to land above the tombstone's Version,
-	// where the scrub below reads it as a rewrite that survives and re-creates
-	// the file out of pre-delete remote bytes. A hydrate that samples after this
-	// point carries a higher bound and is left alone, so a file written again
-	// after the unlink still hydrates. If the append below fails the fence stays,
-	// costing at most a re-fetch — dropping a write-back cache fill is always
-	// safe, resurrecting a deleted file is not.
-	sh.mu.Lock()
-	sh.fenceDelete(id, s.version.Load())
-	sh.mu.Unlock()
 
 	// Durability first: persist and fsync the tombstone BEFORE touching the
 	// in-memory index or the counters. If the append fails, the file's ranges are


### PR DESCRIPTION
## What was wrong

`Hydrate` writes bytes fetched from remote during a cold read. Its caller samples a bound
(`notAfter`) **before** the fetch, and the journal's per-shard hydrate fence refuses a hydrate
whose bound is at or below it. The fence existed for `Truncate` and was missing entirely for
`Delete`.

`Delete` removed `sh.index[id]` and then did `delete(sh.truncVer, id)`, commented "The file is
gone, so its truncate bound has nothing left to guard". That erasure *was* the bug. A cold
read still waiting on its remote fetch then reached `fileIndex.hydratable` with a **nil
receiver**, which offers the entire requested range, and the fill re-created the deleted file
from pre-delete bytes.

Reachable in production: `engine/readwrite.go` issues the `Delete` before the manifest reap
while `engine/fetch.go` is mid-`Hydrate`, its bound sampled back at the start of
`collectCoveringChunks`. The window is the whole remote fetch. Same silent-corruption family
as #1850 / #1888 / #2084.

## Scope: the delete half only

The fence's **truncate** half has a separate defect — it stamps a version peeked before
`appendTruncateMarker` and never raises it to the Version that call mints — and that is
deliberately **out of scope here**, tracked in #2247. It was attempted in this PR and split
back out, because the truncate fence turned out to be two-state in a way the delete fence is
not: the same bound must be refused while the truncate is in flight and served once its clip
has been applied, so no single comparison against a fixed stamp is correct. The findings,
including a working implementation and the test that discriminates between four candidate
fixes, are written up on #2247. Nothing here depends on them.

`Delete` needs none of that: the file does not survive, so a reader whose view includes the
tombstone has nothing valid to write back, and the fence is never lowered.

## The part that matters, and that looks redundant

The fence is stamped **inside** `appendTombstone`, in the same critical section that mints the
tombstone's Version (`sh.fenceDelete(id, version)`). This placement is the fix, and a future
reader will want to "tidy" it into `Delete`:

- **Stamped earlier** — from `Delete`, off a peeked `s.version.Load()` — the fence sits below
  the Version `appendTombstone` mints, because that mint happens in a later acquisition of the
  same lock. A hydrate holding a bound in that gap clears the fence, finds the index entry
  already scrubbed, and re-creates the whole file. Worse, its record is stamped *above* the
  tombstone, so `Delete`'s scrub (`iv.version > tombVer` survives) reads it as a rewrite that
  raced past the delete and deliberately **keeps** it. Persistent, not transient.
- **Stamped later** — raised to the minted Version in the second locked section, the obvious
  three-line patch — cannot help. By then the stale record is already committed, and a raise
  does not retroactively remove it.

Mint-time stamping closes both directions: a hydrate that takes `sh.mu` **after** the stamp
sees a fence at or above its bound and is refused; one that got in **before** it minted a
strictly lower Version and is buried by the scrub. `appendRecord` re-checks the fence under
`sh.mu` before creating an index entry, so this holds for the racing path, not just the
ordered one.

## Deliberate deviation from the issue's prescribed fix

#2231 asks for a new per-shard `tombVer[id]` map. This adds no second map. `truncVer`'s own
documented semantics were already "a hydrate whose caller sampled its bound at or below it is
refused", which is exactly what a delete needs — so the fix stamps that fence instead of
erasing it. Renamed `truncVer` → `hydrateFence` and `staleAfterTruncate` → `hydrateFenced`,
since it now holds delete versions too and the old name would have lied. `hydratable` is
unchanged: its nil-receiver path is the *mechanism*, not the place to fix it, since the fence
is consulted before `hydratable` is ever reached.

## Bounding the fence

A delete fence must outlive the file's index entry — that entry is what a hydrate would
otherwise re-create — so nothing takes one back out, and the map would retain an entry per
FileID ever deleted. A per-shard FIFO capped at 4096 evicts the oldest.

Dropping the fence on legitimate re-create (the obvious alternative) is wrong twice: after a
re-create `hydratable` returns the *holes*, so a stale hydrate would write pre-delete bytes
into the new generation of the file; and it bounds nothing, since the common case is
deleted-and-never-re-created.

**Overflow is not fail-open.** Credit to cross-review for catching this. The cap is reachable:
`ShardCount` is configurable and `1` is legal (`1 & 0 == 0` passes the power-of-two check), so
every delete can share one FIFO, and a remote serving errors stretches the fetch window widest
exactly when cold reads are most likely to be outstanding. Evicting a fence whose hydrate is
still in flight would let that hydrate land. A per-shard `evictedFenceFloor` — the high-water
mark of evicted fence versions, checked alongside the map — refuses those hydrates anyway.
Overflow therefore costs a re-fetch, and **`maxDeleteFences` is a memory knob, not a
correctness bound**: the safety argument no longer rests on a claim about relative timescales.

Eviction is also guarded on the version, so a fence a later `Truncate` re-stamped is left
alone. `ponytail:`-marked with the age-based sweep as the upgrade path.

**Closes the related LOW at `store.go:807` for free**: `Delete` cleared the fence
unconditionally, even when intervals survived the tombstone race. It no longer clears it at
all.

## Evidence — every guard against a build with only that guard broken

| mutant | test that fails |
| --- | --- |
| M1 fence stamp removed | `TestHydrateAfterDeleteIsDropped`, `TestHydrateBoundAtTombstoneVersionIsDropped` |
| M2 fence stamped from a peek in `Delete` | **only** `TestHydrateBoundAtTombstoneVersionIsDropped` |
| M5 FIFO bound removed | `TestDeleteFenceCountIsBounded`, `TestHydrateOverEvictedFenceIsDropped` |
| M6 evicted-fence floor removed | **only** `TestHydrateOverEvictedFenceIsDropped` |
| M8 `Delete`'s fence erasure restored (develop's behaviour) | `TestHydrateAfterDeleteIsDropped`, `TestHydrateBoundAtTombstoneVersionIsDropped` |

Verbatim failures:

```
M1  hydrate resurrected a deleted file: FileSize = 4096
M2  a hydrate bounded at the tombstone's own Version resurrected the file: FileSize = 4096
M5  delete fences grew unbounded: 12288 entries retained, cap is 4096
M6  a hydrate over an evicted fence resurrected the file: FileSize = 4096
M8  hydrate resurrected a deleted file: FileSize = 4096
```

M2 and M6 are the rows that matter: each kills exactly one test.
`TestHydrateAfterDeleteIsDropped` **passes** against M2, so on its own it would have been
self-satisfying about where the fence is stamped. M6 fails with a real resurrection
(`FileSize = 4096`), not merely a count assertion.

- Premise confirmed before any production code was touched: written first,
  `TestHydrateAfterDeleteIsDropped` failed on unmodified `develop` with
  `hydrate resurrected a deleted file: FileSize = 4096` (reproduced above as M8).
- `go test ./...`: exit 0, 136 packages, zero failures.
- `go test -race ./pkg/block/...`: exit 0.
- `go test -race ./pkg/block/journal/ -count=100` on the fence tests: green.
- `go build ./...`, `go vet ./...`, `go fmt ./...`: clean.

All fence tests are deterministic; none relies on goroutine scheduling. An earlier revision
carried a goroutine-racing test, dropped rather than shipped with a caveat because it passed
against unmodified `develop` and so guarded nothing.

`TestHydrateAfterTruncateIsDropped` is pre-existing and untouched, and stays green throughout —
the truncate fence behaves exactly as it does on `develop`.

No docs regenerated — no Cobra command or flag changed.

Closes #2231
