### PR TITLE
fix(journal): fold the cold log into the version RestoreToVersion rewinds to

### DIFF
--- a/pkg/block/journal/restore_test.go
+++ b/pkg/block/journal/restore_test.go
@@ -302,3 +302,64 @@ func TestRestoreToVersion_KeepsColdRangesOfMixedFile(t *testing.T) {
 	check(f.Store, "pre-crash")
 	check(f.crashReopen(), "post-crash")
 }
+
+// TestRestoreToVersion_KeepsEvictedRange pins the provenance the issue reports:
+// a range whose local bytes eviction unlinked. It is a separate case from a
+// seeded one because the two writers stamp the entry's version differently —
+// eviction copies the version of the interval it is replacing, so the entry
+// still says when the data was written.
+//
+// The eviction here runs after the target version is captured, which is what
+// makes the test discriminating: the bytes were written below the watermark and
+// must be restored, even though the moment they stopped being local is above it.
+// A ceiling replay that judged the entry by when the range went cold, rather than
+// by the version the entry carries, would skip it and tombstone the file.
+func TestRestoreToVersion_KeepsEvictedRange(t *testing.T) {
+	ctx := context.Background()
+	s := testStore(t, Config{
+		ShardCount:       1,
+		SegmentSize:      minSegmentSize,
+		DirtyExpiry:      -1,
+		GCDeadRatioForce: 2,
+	})
+
+	// Hydrated records are born synced, so the whole shard qualifies for eviction.
+	evicted := FileID("evicted")
+	fillUntilSealed(t, s, evicted, true, 2)
+
+	// A warm peer whose head moves past V, so the restore has real work to do. Its
+	// records are unsynced, which also keeps its segment out of the eviction below.
+	peer := FileID("warm-peer")
+	v1 := bytes.Repeat([]byte("first-version-"), 64)
+	if err := s.WriteAt(ctx, peer, 0, v1); err != nil {
+		t.Fatalf("WriteAt peer: %v", err)
+	}
+	target := s.JournalVersion()
+
+	if _, err := s.Evict(ctx, 1<<30); err != nil {
+		t.Fatalf("Evict: %v", err)
+	}
+	if _, st, err := s.ReadAt(ctx, evicted, 0, make([]byte, chunk256)); err != nil {
+		t.Fatalf("ReadAt after evict: %v", err)
+	} else if !st.Cold {
+		t.Fatal("setup: the range is not cold after eviction, so this test would prove nothing")
+	}
+
+	if err := s.WriteAt(ctx, peer, 0, bytes.Repeat([]byte("second-version"), 64)); err != nil {
+		t.Fatalf("WriteAt peer post-V: %v", err)
+	}
+
+	if err := s.RestoreToVersion(ctx, target); err != nil {
+		t.Fatalf("RestoreToVersion: %v", err)
+	}
+	assertColdAt(t, s, evicted, 0, chunk256, "pre-reopen")
+
+	// A plain reopen is enough for this assertion: the re-asserted entry's
+	// durability comes from appendCold's own fsync of the cold log, not from
+	// buffered segment writes, so there is no page-cache masquerade to defeat.
+	r := reopen(t, s)
+	assertColdAt(t, r, evicted, 0, chunk256, "post-reopen")
+	if got := readAll(t, r, peer, len(v1)); !bytes.Equal(got, v1) {
+		t.Fatalf("post-reopen %s: restore did not produce the V1 view", peer)
+	}
+}

--- a/pkg/block/journal/restore_test.go
+++ b/pkg/block/journal/restore_test.go
@@ -226,8 +226,14 @@ func TestRestoreToVersion_KeepsFullyColdFile(t *testing.T) {
 	f.write(peer, 0, v1)
 	target := f.commitAll()
 
-	// Move the head past V so the restore has real work to do.
+	// Move the head past V so the restore has real work to do, and add a file
+	// that is cold only above V: folding the log in without honoring the
+	// watermark would resurrect it.
 	f.write(peer, 0, bytes.Repeat([]byte("second-version"), 64))
+	postV := FileID("cold-after-v")
+	if err := f.SeedCold(ctx, postV, [][2]int64{{0, coldLen}}); err != nil {
+		t.Fatalf("SeedCold post-V: %v", err)
+	}
 	f.commitAll()
 
 	if err := f.RestoreToVersion(ctx, target); err != nil {
@@ -235,10 +241,21 @@ func TestRestoreToVersion_KeepsFullyColdFile(t *testing.T) {
 	}
 	assertColdAt(t, f.Store, cold, 0, coldLen, "pre-crash")
 
+	if _, st, err := f.ReadAt(ctx, postV, 0, make([]byte, coldLen)); err != nil {
+		t.Fatalf("pre-crash ReadAt %s: %v", postV, err)
+	} else if st.Cold {
+		t.Fatalf("pre-crash: %s was cold only above V and must not survive the rewind", postV)
+	}
+
 	r := f.crashReopen()
 	assertColdAt(t, r, cold, 0, coldLen, "post-crash")
 	if got := readAll(t, r, peer, len(v1)); !bytes.Equal(got, v1) {
 		t.Fatalf("post-crash %s: restore did not produce the V1 view", peer)
+	}
+	if _, st, err := r.ReadAt(ctx, postV, 0, make([]byte, coldLen)); err != nil {
+		t.Fatalf("post-crash ReadAt %s: %v", postV, err)
+	} else if st.Cold {
+		t.Fatalf("post-crash: %s was cold only above V and must not survive the rewind", postV)
 	}
 }
 

--- a/pkg/block/journal/restore_test.go
+++ b/pkg/block/journal/restore_test.go
@@ -190,3 +190,98 @@ func TestRestoreToVersion_ReMaterializedViewSurvivesCrash(t *testing.T) {
 		}
 	}
 }
+
+// assertColdAt fails unless the store reports the range at off as cold — durable
+// on the remote and fetchable — rather than as a hole a read would zero-fill.
+func assertColdAt(t *testing.T, s *Store, id FileID, off, length int64, when string) {
+	t.Helper()
+	_, st, err := s.ReadAt(context.Background(), id, off, make([]byte, length))
+	if err != nil {
+		t.Fatalf("%s: ReadAt %s@%d: %v", when, id, off, err)
+	}
+	if !st.Cold {
+		t.Fatalf("%s: %s@%d+%d is no longer cold (hole=%v) — the range is durable on the "+
+			"remote, but the restored view calls it never-written, so a read zero-fills "+
+			"instead of fetching it back", when, id, off, length, st.Hole)
+	}
+}
+
+// TestRestoreToVersion_KeepsFullyColdFile pins a file whose every byte was cold
+// at the target version. It owns no segment record — eviction unlinked the bytes
+// and the cold log is the only trace — so a ceiling replay that reads records
+// alone finds nothing for it, files it under "present at head, absent at V", and
+// tombstones a file that is durably present on the remote.
+func TestRestoreToVersion_KeepsFullyColdFile(t *testing.T) {
+	f := newRestoreFixture(t, 1)
+	ctx := context.Background()
+
+	const coldLen = 4096
+	cold := FileID("cold-only")
+	peer := FileID("warm-peer")
+
+	if err := f.SeedCold(ctx, cold, [][2]int64{{0, coldLen}}); err != nil {
+		t.Fatalf("SeedCold: %v", err)
+	}
+	v1 := bytes.Repeat([]byte("first-version-"), 64)
+	f.write(peer, 0, v1)
+	target := f.commitAll()
+
+	// Move the head past V so the restore has real work to do.
+	f.write(peer, 0, bytes.Repeat([]byte("second-version"), 64))
+	f.commitAll()
+
+	if err := f.RestoreToVersion(ctx, target); err != nil {
+		t.Fatalf("RestoreToVersion: %v", err)
+	}
+	assertColdAt(t, f.Store, cold, 0, coldLen, "pre-crash")
+
+	r := f.crashReopen()
+	assertColdAt(t, r, cold, 0, coldLen, "post-crash")
+	if got := readAll(t, r, peer, len(v1)); !bytes.Equal(got, v1) {
+		t.Fatalf("post-crash %s: restore did not produce the V1 view", peer)
+	}
+}
+
+// TestRestoreToVersion_KeepsColdRangesOfMixedFile pins a file that was part warm
+// and part cold at the target version. The warm half has records and replays; the
+// cold half does not, so it is missing from the extents phase 2 re-asserts and the
+// burial tombstone leaves it a genuine POSIX hole — the hole-versus-cold
+// conflation the module treats as its cardinal sin.
+func TestRestoreToVersion_KeepsColdRangesOfMixedFile(t *testing.T) {
+	f := newRestoreFixture(t, 1)
+	ctx := context.Background()
+
+	const half = 1024
+	id := FileID("half-cold")
+	warm := bytes.Repeat([]byte("warm"), half/4)
+
+	f.write(id, 0, warm)
+	if err := f.SeedCold(ctx, id, [][2]int64{{half, half}}); err != nil {
+		t.Fatalf("SeedCold: %v", err)
+	}
+	target := f.commitAll()
+
+	// Post-V, the cold half is overwritten with local bytes. Restoring V has to
+	// take those bytes away again and put the cold marking back.
+	f.write(id, half, bytes.Repeat([]byte("post"), half/4))
+	f.commitAll()
+
+	if err := f.RestoreToVersion(ctx, target); err != nil {
+		t.Fatalf("RestoreToVersion: %v", err)
+	}
+	check := func(s *Store, when string) {
+		t.Helper()
+		got := make([]byte, half)
+		if _, st, err := s.ReadAt(ctx, id, 0, got); err != nil {
+			t.Fatalf("%s: ReadAt warm half: %v", when, err)
+		} else if st.Cold || st.Hole {
+			t.Fatalf("%s: warm half reports cold=%v hole=%v", when, st.Cold, st.Hole)
+		}
+		if !bytes.Equal(got, warm) {
+			t.Fatalf("%s: warm half did not restore to its V view", when)
+		}
+		assertColdAt(t, s, id, half, half, when)
+	}
+	check(f.Store, "pre-crash")
+	check(f.crashReopen(), "post-crash")
+}

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -1083,8 +1083,12 @@ func (s *Store) PinVersion() uint64 { return s.pinVersion.Load() }
 //     versions exceed everything, so recover() rebuilds V on reopen; a file
 //     present at head but absent at V is tombstoned away.
 //
-// The caller (restore orchestration) drains rollups afterward and holds the share
-// disabled, so no concurrent writer races this.
+// Precondition: the share is disabled, so nothing else is touching the store. The
+// caller (restore orchestration) enforces that and drains rollups afterward. It is
+// load-bearing rather than incidental — the cold ranges are re-asserted with one
+// batched append whose plan and fsync are not under a single shard lock, so a
+// Delete landing between them would bury an entry the insert then recreates.
+// Running this against a live share reintroduces that race silently.
 func (s *Store) RestoreToVersion(ctx context.Context, v uint64) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -1153,6 +1157,26 @@ func (s *Store) RestoreToVersion(ctx context.Context, v uint64) error {
 	// so the passes below clip it like any warm interval. The log needs no tail
 	// repair here: recovery already trimmed it at open, and appendCold rolls its
 	// own tail back on a failed write, so a live store's log ends intact.
+	//
+	// The version test below asks whether the content existed at V, and only one
+	// of the log's two writers records something that answers it. Eviction copies
+	// the version off the interval it replaces, so its entry still dates the data.
+	// A seed mints a fresh one, dating the scan that noticed the range was
+	// remote-durable: that version exists so a racing Delete sweeps below the
+	// entry, and says nothing about when the bytes were written. An entry does not
+	// record which writer made it, so the two cannot be told apart here.
+	//
+	// Eviction is the only writer that reaches a store this runs against — both
+	// manifest-seed callers require the share to have a remote, and this method
+	// runs only on a restore's local-only branch. The exception is a store seeded
+	// while it had a remote that was later detached.
+	//
+	// ponytail: on that store a seeded entry is skipped as post-V, which is the
+	// same lost cold range this fold exists to prevent. The entry alone cannot do
+	// better — including it unconditionally would instead resurrect content written
+	// after V, because a seed describes the file as the manifest currently has it.
+	// Closing it needs the entry to record its writer, a change to a durable
+	// on-disk format that wants its own migration.
 	coldEntries, _, cerr := loadCold(s.dir)
 	if cerr != nil {
 		return fmt.Errorf("journal: restore: load cold log: %w", cerr)
@@ -1275,9 +1299,9 @@ func (s *Store) RestoreToVersion(ctx context.Context, v uint64) error {
 	// log entries that described them, so the V-view's cold ranges are holes until
 	// they are re-asserted at a version above those tombstones. Seeding covers only
 	// what the index still calls a hole, which after the re-materialization above is
-	// exactly those ranges. One durable append covers the whole pass: the share is
-	// disabled for the restore, so nothing can delete through the plan/append gap
-	// SeedColdBatch documents.
+	// exactly those ranges. One durable append covers the whole pass, which is safe
+	// only under this method's disabled-share precondition: it is what closes the
+	// plan/append gap SeedColdBatch documents.
 	if err := s.SeedColdBatch(ctx, coldSeeds); err != nil {
 		return fmt.Errorf("journal: restore: re-assert cold ranges: %w", err)
 	}

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -1071,14 +1071,17 @@ func (s *Store) PinVersion() uint64 { return s.pinVersion.Load() }
 //
 //  1. Ceiling replay: scan every on-disk record and rebuild each file's coverage
 //     as of V — data records with Version<=V resolved newest-wins, tombstones and
-//     truncate markers with Version<=V honored, everything above V ignored. The
-//     pre-overwrite records survive because a live snapshot pinned their segments.
+//     truncate markers with Version<=V honored, everything above V ignored, and
+//     the cold log folded in so a range that is durable remotely but holds no
+//     local bytes counts as covered rather than as a hole. The pre-overwrite
+//     records survive because a live snapshot pinned their segments.
 //  2. Re-materialize: for each file, read the V-view bytes from their pinned
 //     source records and re-append them as fresh dirty records at the head (a
-//     tombstone first to bury the current head, then the V-view data), then fsync
-//     every shard still holding unsynced records — a superset of the shards this
-//     pass wrote. Fresh versions exceed everything, so recover() rebuilds V on
-//     reopen; a file present at head but absent at V is tombstoned away.
+//     tombstone first to bury the current head, then the V-view data), re-assert
+//     the V-view's cold ranges into the cold log, then fsync every shard still
+//     holding unsynced records — a superset of the shards this pass wrote. Fresh
+//     versions exceed everything, so recover() rebuilds V on reopen; a file
+//     present at head but absent at V is tombstoned away.
 //
 // The caller (restore orchestration) drains rollups afterward and holds the share
 // disabled, so no concurrent writer races this.
@@ -1143,6 +1146,35 @@ func (s *Store) RestoreToVersion(ctx context.Context, v uint64) error {
 			}
 		}
 	}
+	// A cold interval owns no record — eviction unlinked the bytes it described,
+	// or the range was seeded cold from a manifest — so the record scan above
+	// cannot see one and would read a remote-durable range as a hole. Fold the
+	// cold log in at each entry's persisted version, exactly as recover() does,
+	// so the passes below clip it like any warm interval. The log needs no tail
+	// repair here: recovery already trimmed it at open, and appendCold rolls its
+	// own tail back on a failed write, so a live store's log ends intact.
+	coldEntries, _, cerr := loadCold(s.dir)
+	if cerr != nil {
+		return fmt.Errorf("journal: restore: load cold log: %w", cerr)
+	}
+	for _, e := range coldEntries {
+		if e.length <= 0 || e.version > v {
+			continue
+		}
+		fi := vIndex[e.id]
+		if fi == nil {
+			fi = &fileIndex{}
+			vIndex[e.id] = fi
+		}
+		fi.insert(interval{
+			fileOff: e.fileOff,
+			length:  e.length,
+			version: e.version,
+			synced:  true,
+			cold:    true,
+		})
+	}
+
 	// Honor tombstones and truncate markers at or below V, mirroring recover().
 	for fid, fi := range vIndex {
 		if tv, ok := tombstones[fid]; ok {
@@ -1177,15 +1209,23 @@ func (s *Store) RestoreToVersion(ctx context.Context, v uint64) error {
 	for _, id := range s.ListFiles(ctx) {
 		head[id] = struct{}{}
 	}
+	var coldSeeds []ColdSeed
 	for id, fi := range vIndex {
 		type extent struct {
 			off  int64
 			data []byte
 		}
 		exts := make([]extent, 0, len(fi.ivs))
+		var coldExts [][2]int64
 		sh := s.shardFor(id)
 		for _, iv := range fi.ivs {
 			if iv.length <= 0 {
+				continue
+			}
+			// Nothing to read back for a cold range: it is re-asserted below,
+			// after the burial tombstone, as a fresh cold-log entry.
+			if iv.cold {
+				coldExts = append(coldExts, [2]int64{iv.fileOff, iv.length})
 				continue
 			}
 			sh.mu.Lock()
@@ -1218,6 +1258,9 @@ func (s *Store) RestoreToVersion(ctx context.Context, v uint64) error {
 				return fmt.Errorf("journal: restore: re-materialize %q@%d: %w", id, e.off, err)
 			}
 		}
+		if len(coldExts) > 0 {
+			coldSeeds = append(coldSeeds, ColdSeed{ID: id, Extents: coldExts})
+		}
 		delete(head, id)
 	}
 	// Files present at head but not in the V-view were created after V: tombstone
@@ -1226,6 +1269,17 @@ func (s *Store) RestoreToVersion(ctx context.Context, v uint64) error {
 		if err := s.Delete(ctx, id); err != nil {
 			return fmt.Errorf("journal: restore: tombstone post-V file %q: %w", id, err)
 		}
+	}
+
+	// The burials above swept every cold interval out of the index and buried the
+	// log entries that described them, so the V-view's cold ranges are holes until
+	// they are re-asserted at a version above those tombstones. Seeding covers only
+	// what the index still calls a hole, which after the re-materialization above is
+	// exactly those ranges. One durable append covers the whole pass: the share is
+	// disabled for the restore, so nothing can delete through the plan/append gap
+	// SeedColdBatch documents.
+	if err := s.SeedColdBatch(ctx, coldSeeds); err != nil {
+		return fmt.Errorf("journal: restore: re-assert cold ranges: %w", err)
 	}
 
 	// Every tombstone fsynced itself, but the V-view data went in through WriteAt,


### PR DESCRIPTION
`RestoreToVersion` rebuilt the point-in-time view it rewinds to from segment
records alone. A cold interval owns no segment record — `appendCold` writes only
to `cold.log`, and eviction has already unlinked the bytes — so every range that
was durable on the remote but held no local bytes was invisible to the replay
and came back as a POSIX hole. Two distinct losses followed:

1. **A file entirely cold at V was deleted.** With no `vIndex` entry it fell into
   the "present at head, absent at V" bucket and was unconditionally tombstoned,
   despite being durably present on the remote at V.
2. **A file with mixed warm/cold ranges lost its cold sub-ranges.** They were
   absent from the extents phase 2 re-asserts, so the burial tombstone left them
   as genuine holes. Reads zero-fill instead of fetching.

`recover()` has never had this problem: it folds the same log in via
`applyColdLog`, for the reason `cold.go`'s header states — *"without a durable
side-log every cold interval comes back from a restart as a POSIX hole, and a
read zero-fills instead of fetching from the remote."*

## Two provenances write `cold.log`, and they mean different things by `version`

This surfaced in cross-review and changes what this PR claims to fix, so it is
stated up front. `cold.log` has two writers, and they stamp `version` differently:

| writer | stamp | what the version means |
| --- | --- | --- |
| `evictSegment` (`reclaim.go:264`) | `version: fi.ivs[k].version` | the **data's** version, copied off the interval being replaced |
| `planColdSeed` (`store.go:563`) | `version: s.nextVersion()` | a **fresh** version at scan time, so a racing `Delete` sweeps below the entry |

The fold's test is `e.version > v → skip`, which asks *did this content exist at
V*. Only the eviction stamp answers that. A seeded entry's version dates the
manifest scan that noticed the range was remote-durable, not the write — so for
that provenance the comparison measures the wrong thing. Nothing in a `coldEntry`
(`{id, fileOff, length, version}`) says which writer produced it.

**Neither answer is available from the entry alone.** Skipping by seed version
over-skips. Including unconditionally would resurrect content written after V,
because a seed describes the file as the manifest *currently* has it — which is
what Mutation D below pins. And the manifest cannot supply the missing input:
`block.FileChunk` carries no journal version, and its wall-clock `CreatedAt`
is not comparable against an LSN. A correct fix requires the entry to record its
writer, which is a durable on-disk format change with its own migration story, so
it is deliberately **out of scope here** and reported separately.

### Is the seeded case reachable? Yes, but only after a remote detach

Traced rather than assumed:

- `seedColdIfNeeded` (share add) returns early on `!remoteConfigured`, with a
  comment saying seeding a local-only share would point reads at a store that
  cannot serve them. No seeded entries on a share born local-only.
- `SeedColdFromManifest` at `snapshot.go:1598` is inside `if remoteVerify` —
  remote-backed only. It also does **not** call `MarkColdSeeded`; that is only
  reached from the share-add path, so the `cold-seeded` marker cannot be used to
  detect this case.
- `engine.Store.SeedCold` (the single-file variant) has **no caller anywhere in
  the tree**.

So on a share that has only ever been local-only, eviction is the sole writer and
the guard is correct for every entry it can meet. The exception is a detach:
`internal/controlplane/api/handlers/shares.go:735-737` lets an update clear a
share's remote (`"" → nil`). That gives a reachable sequence — remote-backed
share, a remote-path restore at `T` seeds entries versioned `~T`, operator clears
the remote, share comes back local-only over the same journal directory, then a
restore to a snapshot with `V < T` skips every seeded entry as post-V and
reproduces this issue's symptom. It needs a deliberate operator action plus a
restore to a snapshot older than the last remote-path restore, so it is off any
default path — but it is not hypothetical. Worth noting those cold bytes are
already unreadable once the remote is detached; the added harm is that restore
*deletes* the files rather than leaving them recoverable on reattach.

**Scope:** this PR fixes the eviction provenance — the one the issue describes,
and the one the guard is correct for. The seeded provenance is documented at the
fold with a `ponytail:` marker naming the ceiling and the upgrade path.

## Premise re-verified

Develop has moved well past the audit baseline, so all three load-bearing claims
were re-checked against this branch's tree, not the report:

- **No compensation exists on this path.** `shares.SeedColdFromManifest`
  (`snapshot.go:1598`) sits inside `if remoteVerify {` at `:1595`;
  `RestoreToVersion` (`:1539`) sits inside the `} else {` opened at `:1518`.
  Confirmed by brace structure, not proximity — the two branches are mutually
  exclusive, so nothing re-seeds cold ranges after a local-only restore.
- **Cold intervals are reachable on a local-only share.**
  `blockstore_config.go:370` disables eviction when `remoteStore == nil`, but
  `bs.Start(ctx)` runs afterwards (`blockstore_config.go:483`) and
  `engine.go:271` re-enables it unconditionally with
  `SetEvictionEnabled(bs.syncer.IsRemoteHealthy())`. `syncer.go:309-312` returns
  `true` whenever `healthMonitor == nil`, and `healthMonitor` is only ever
  assigned from `m.remoteStore.HealthCheck` — so a local-only share has none and
  reports healthy. `SeedCold`/`SeedColdBatch` reach the same state without
  eviction at all.
- **Compaction is not a backstop.** `compactColdLog` is gated on
  `coldLoaded > 2*len(live) + 1024`, so small and medium logs never reach
  `rewriteCold`. Nothing on the restore path relies on it.

Pinned segments are safe from eviction (`reclaim.go:587` gates on `pinVersion`),
so the converse case — warm at V, evicted after V, source bytes gone — cannot
arise while the snapshot being restored is live. The two cases above are the
whole reachable set.

## The fix

**Phase 1** folds `loadCold(s.dir)` into `vIndex` at each entry's persisted
version, for `version <= V`, before the tombstone and truncate passes — so those
passes clip a cold interval exactly as they clip a warm one (`interval.clamp`
already carries `cold` through). No tail repair is done here: recovery trimmed
the log at open, and `appendCold` rolls its own tail back on a failed write, so
a live store's log ends at an intact entry.

**Phase 2** cannot read a source record for a cold interval — there is none, and
attempting to would fail on `sh.segment(0) == nil`. It collects those ranges
instead and re-asserts them after every burial with a single `SeedColdBatch`.
Batching is safe here for the reason its doc gives — the share is disabled for the
restore, so nothing can delete through the plan/append gap — and that precondition
is enforced caller-side rather than merely assumed: `RestoreSnapshot` requires
`Enabled == false` (or force-disables the share on the rollback path) across the
whole orchestration that contains this call. `planColdSeed` only
covers what the index still calls a hole, which after the re-materialization is
exactly the cold ranges — which also makes a re-run idempotent.

## Verification

Three tests across both provenances, four mutations. Each mutation was applied to
the **fixed** build; the matrix below says exactly which tests each one moves.

`TestRestoreToVersion_KeepsFullyColdFile` — a file seeded fully cold at V,
alongside a warm peer whose head moved past V. Asserts the file still reports
`ReadState.Cold` after the restore, and again after `restoreFixture.crashReopen()`
(which throws away every segment byte no completed fsync covered, so a plain
buffered write cannot masquerade as durable). It also carries a second file
seeded cold *above* V, asserted gone, which guards the opposite error: a fold
that ignored the watermark would resurrect post-snapshot files.

`TestRestoreToVersion_KeepsColdRangesOfMixedFile` — a file warm over `[0,1024)`
and cold over `[1024,2048)` at V, with the cold half overwritten by local bytes
after V. Asserts the warm half restores byte-for-byte and the cold half is cold
again, pre- and post-crash.

`TestRestoreToVersion_KeepsEvictedRange` — the eviction provenance. Hydrated
records (born synced, so the shard is evictable) are evicted **after** the target
version is captured, so the bytes were written below the watermark while the
moment they stopped being local is above it. That is what makes it discriminating:
a replay judging the entry by when the range went cold, rather than by the version
the entry carries, would skip it. It is the only test here whose cold entries come
from `evictSegment` rather than `SeedCold`.

**On unmodified `develop` (this branch's tests, develop's `store.go`) — all three
fail:**

```
=== RUN   TestRestoreToVersion_KeepsFullyColdFile
    restore_test.go:242: pre-crash: cold-only@0+4096 is no longer cold (hole=true) — the range is durable on the remote, but the restored view calls it never-written, so a read zero-fills instead of fetching it back
--- FAIL: TestRestoreToVersion_KeepsFullyColdFile (0.07s)
=== RUN   TestRestoreToVersion_KeepsColdRangesOfMixedFile
    restore_test.go:302: pre-crash: half-cold@1024+1024 is no longer cold (hole=true) — the range is durable on the remote, but the restored view calls it never-written, so a read zero-fills instead of fetching it back
--- FAIL: TestRestoreToVersion_KeepsColdRangesOfMixedFile (0.04s)
=== RUN   TestRestoreToVersion_KeepsEvictedRange
    restore_test.go:355: pre-reopen: evicted@0+262144 is no longer cold (hole=true) — the range is durable on the remote, but the restored view calls it never-written, so a read zero-fills instead of fetching it back
--- FAIL: TestRestoreToVersion_KeepsEvictedRange (0.11s)
```

**Mutation A** — fold cold entries only into files that already have a warm
`vIndex` entry (`if fi == nil { continue }`), which reintroduces defect 1 alone:

```
=== RUN   TestRestoreToVersion_KeepsFullyColdFile
    restore_test.go:242: pre-crash: cold-only@0+4096 is no longer cold (hole=true) — the range is durable on the remote, but the restored view calls it never-written, so a read zero-fills instead of fetching it back
--- FAIL: TestRestoreToVersion_KeepsFullyColdFile (0.04s)
=== RUN   TestRestoreToVersion_KeepsColdRangesOfMixedFile
--- PASS: TestRestoreToVersion_KeepsColdRangesOfMixedFile (0.06s)
=== RUN   TestRestoreToVersion_KeepsEvictedRange
--- PASS: TestRestoreToVersion_KeepsEvictedRange (0.11s)
```

**Mutation B** — fold cold entries only into files with no warm coverage at V
(`if fi != nil { continue }`), which reintroduces defect 2 alone:

```
=== RUN   TestRestoreToVersion_KeepsFullyColdFile
--- PASS: TestRestoreToVersion_KeepsFullyColdFile (0.06s)
=== RUN   TestRestoreToVersion_KeepsColdRangesOfMixedFile
    restore_test.go:302: pre-crash: half-cold@1024+1024 is no longer cold (hole=true) — the range is durable on the remote, but the restored view calls it never-written, so a read zero-fills instead of fetching it back
--- FAIL: TestRestoreToVersion_KeepsColdRangesOfMixedFile (0.04s)
=== RUN   TestRestoreToVersion_KeepsEvictedRange
    restore_test.go:355: pre-reopen: evicted@0+262144 is no longer cold (hole=true) — the range is durable on the remote, but the restored view calls it never-written, so a read zero-fills instead of fetching it back
--- FAIL: TestRestoreToVersion_KeepsEvictedRange (0.09s)
```

A and B are complements on the two seeded tests: each fails under exactly one of
them and passes under the other, so neither stands in for the other's defect.

**Mutation C** — keep the phase-1 fold, drop the phase-2 `SeedColdBatch`
re-assert. Both fail, which is what makes the phase-2 half load-bearing rather
than decorative — folding a cold interval into the V-view is worth nothing if
the burial tombstone then sweeps it away:

```
=== RUN   TestRestoreToVersion_KeepsFullyColdFile
    restore_test.go:242: pre-crash: cold-only@0+4096 is no longer cold (hole=true) — the range is durable on the remote, but the restored view calls it never-written, so a read zero-fills instead of fetching it back
--- FAIL: TestRestoreToVersion_KeepsFullyColdFile (0.07s)
=== RUN   TestRestoreToVersion_KeepsColdRangesOfMixedFile
    restore_test.go:302: pre-crash: half-cold@1024+1024 is no longer cold (hole=true) — the range is durable on the remote, but the restored view calls it never-written, so a read zero-fills instead of fetching it back
--- FAIL: TestRestoreToVersion_KeepsColdRangesOfMixedFile (0.04s)
=== RUN   TestRestoreToVersion_KeepsEvictedRange
    restore_test.go:355: pre-reopen: evicted@0+262144 is no longer cold (hole=true) — the range is durable on the remote, but the restored view calls it never-written, so a read zero-fills instead of fetching it back
--- FAIL: TestRestoreToVersion_KeepsEvictedRange (0.11s)
```

**Mutation D** — drop the `e.version > v` term from the fold's filter, so every
cold entry lands in the V-view regardless of the watermark. This is the failure
mode the other three mutations cannot see, because over-preserving looks
identical to a correct fix from the two cold ranges that *should* survive:

```
=== RUN   TestRestoreToVersion_KeepsFullyColdFile
    restore_test.go:247: pre-crash: cold-after-v was cold only above V and must not survive the rewind
--- FAIL: TestRestoreToVersion_KeepsFullyColdFile (0.05s)
=== RUN   TestRestoreToVersion_KeepsColdRangesOfMixedFile
--- PASS: TestRestoreToVersion_KeepsColdRangesOfMixedFile (0.04s)
=== RUN   TestRestoreToVersion_KeepsEvictedRange
--- PASS: TestRestoreToVersion_KeepsEvictedRange (0.08s)
```

`go test ./pkg/block/...` and `go test -race ./pkg/block/...` are green with the
fix in place (`-race` exit 0 across all sixteen packages, journal in 44s).

### Mutation matrix

Each mutation applied to the fixed build. `base` is unmodified `develop`.

| | FullyColdFile | MixedFile | EvictedRange |
| --- | --- | --- | --- |
| **base** (no fix) | FAIL | FAIL | FAIL |
| **A** fully-cold files not folded | FAIL | pass | pass |
| **B** cold dropped where warm coverage exists | pass | FAIL | FAIL |
| **C** folded but never re-asserted | FAIL | FAIL | FAIL |
| **D** watermark ignored | FAIL | pass | pass |
| **E** `evictSegment` mints a fresh version | pass | pass | **FAIL** |

A and D isolate `FullyColdFile`; B isolates the two mixed-shaped cases.

Mutations A-D are all *shape* mutations, and under them the eviction test is not
isolated: after `fillUntilSealed` the file retains warm coverage, so B and C catch
it alongside `MixedFile`. That was disclosed as a weakness. It is better read as a
missing mutation than as a weak test, because the property the test actually
carries is **provenance**, and no shape mutation can reach it.

**E** is that mutation. `evictSegment` stamps `version: fi.ivs[k].version` — the
interval's own version — while `planColdSeed` stamps `s.nextVersion()`. E changes
eviction to mint, which is precisely the "make the two paths agree" tidy-up a
future reader would attempt on learning the two provenances disagree. Under E,
across all thirteen `pkg/block/...` packages, `go test` exits 1 with **exactly one
failure**:

```
--- FAIL: TestRestoreToVersion_KeepsEvictedRange (0.49s)
FAIL    github.com/marmos91/dittofs/pkg/block/journal    56.962s
ok      (12 other packages)
```

So no seeded test is accidentally sensitive to eviction's stamping, the two
provenances are cleanly separated, and the eviction test is the only thing in the
tree that would catch that change. The provenance property is pinned rather than
argued. #2260 is the issue that would make the two paths agree deliberately.

## Deliberately not done here

`RestoreToVersion` was already carrying a LOW structural finding for being a
long, high-complexity function that its own doc splits into two named phases,
and this change makes it longer. Extracting `replayCeiling` and
`rematerializeVersion` would triple the review surface of a data-loss fix, and
the restructuring is already scoped elsewhere. `golangci-lint run
pkg/block/journal/...` reports 0 issues as it stands.

## Rebase note

Originally opened stacked on #2248 (issue #2229). That has since merged, and this
branch was replayed onto `develop` with `git rebase --onto`, so it now carries
only its own four commits. The one conflict was a doc comment: #2248 reworded
the phase-2 fsync sentence during review while this change was adding a clause to
the same sentence. Both wordings are kept. Every verification run above, the four
mutations included, was re-run against the post-rebase tree — the quoted output is
from that run, not the pre-rebase one.

The `restoreFixture` crash harness both new tests use is #2248's, now on develop.
Its documented gap (`DirtyExpiry: -1` disables the sync loop, so the
already-committed-shard case is argued rather than pinned) is untouched here: a
re-asserted cold range's durability comes from `appendCold`'s own fsync on
`cold.log`, not from the shard-commit sweep, so this change does not make that
case reachable in a new way.

Closes #2227

