### PR TITLE
test(metadata): read the acquire bound instead of mirroring it

### DIFF
--- a/pkg/metadata/store/postgres/export_test.go
+++ b/pkg/metadata/store/postgres/export_test.go
@@ -1,0 +1,9 @@
+package postgres
+
+import "time"
+
+// PoolConnectionAcquireTimeout exposes the checkout bound to the package's
+// external tests, so a test asserting on it reads the real value instead of
+// mirroring a copy that can drift. Test-only: the file is a _test.go, so it is
+// never compiled into the binary.
+const PoolConnectionAcquireTimeout time.Duration = poolConnectionAcquireTimeout

--- a/pkg/metadata/store/postgres/export_test.go
+++ b/pkg/metadata/store/postgres/export_test.go
@@ -4,6 +4,6 @@ import "time"
 
 // PoolConnectionAcquireTimeout exposes the checkout bound to the package's
 // external tests, so a test asserting on it reads the real value instead of
-// mirroring a copy that can drift. Test-only: the file is a _test.go, so it is
-// never compiled into the binary.
+// mirroring a copy that can drift. Test-only: a _test.go file is compiled into
+// the test binary and excluded from every non-test build, so nothing ships.
 const PoolConnectionAcquireTimeout time.Duration = poolConnectionAcquireTimeout

--- a/pkg/metadata/store/postgres/pool_exhaustion_test.go
+++ b/pkg/metadata/store/postgres/pool_exhaustion_test.go
@@ -12,10 +12,16 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/store/postgres"
 )
 
-// poolAcquireTimeout mirrors the unexported poolConnectionAcquireTimeout the
-// store applies to every checkout. If that constant changes, this test starts
-// failing on its deadline rather than silently passing for the wrong reason.
-const poolAcquireTimeout = 10 * time.Second
+// poolAcquireTimeout is the store's own checkout bound, read through
+// export_test.go rather than copied.
+//
+// It tracks the constant rather than detecting a change to it, and that is the
+// intent: the bound is a policy value somebody may legitimately tune, and what
+// has to hold is that the guard fires at whatever it is set to. A mirrored
+// literal could not say that — it would drift, and the timing assertion below
+// would then be checking the behaviour of the store against a number the store
+// no longer uses.
+const poolAcquireTimeout = postgres.PoolConnectionAcquireTimeout
 
 // TestPostgresLockPath_ExhaustedPoolFailsRatherThanBlocking pins what the lock
 // path does when the pool has no connection to give.
@@ -62,7 +68,7 @@ func TestPostgresLockPath_ExhaustedPoolFailsRatherThanBlocking(t *testing.T) {
 
 	select {
 	case <-held:
-	case <-time.After(30 * time.Second):
+	case <-time.After(poolAcquireTimeout * 3):
 		close(release)
 		t.Fatal("could not open the transaction that saturates the pool")
 	}
@@ -90,13 +96,16 @@ func TestPostgresLockPath_ExhaustedPoolFailsRatherThanBlocking(t *testing.T) {
 		if !strings.Contains(r.err.Error(), "pool may be exhausted") {
 			t.Fatalf("GetLock failed after %v, but the error does not name the cause: %v", r.elapsed, r.err)
 		}
-		// The bound is what produced this, not some faster unrelated failure:
-		// a checkout that gave up well before the timeout would mean something
-		// else refused the query and this test would not be pinning the guard.
-		if r.elapsed < poolAcquireTimeout/2 {
-			t.Fatalf("GetLock failed after only %v, far short of the %v acquire timeout — "+
-				"something other than the pool bound refused it, so this test is not "+
-				"exercising what it claims", r.elapsed, poolAcquireTimeout)
+		// The bound is what produced this, not some faster unrelated failure.
+		// Bracketing it on both sides matters: too early means something else
+		// refused the query and this test is not exercising the guard at all,
+		// too late means the checkout was not what gave up. The band is wide
+		// enough to absorb a loaded runner and narrow enough that it cannot sit
+		// astride a different value of the constant.
+		if r.elapsed < poolAcquireTimeout*9/10 || r.elapsed >= poolAcquireTimeout*2 {
+			t.Fatalf("GetLock failed after %v, outside the [%v, %v) the %v acquire bound "+
+				"should produce — something other than the pool bound decided this",
+				r.elapsed, poolAcquireTimeout*9/10, poolAcquireTimeout*2, poolAcquireTimeout)
 		}
 		t.Logf("lock read gave up after %v with: %v", r.elapsed, r.err)
 	case <-time.After(poolAcquireTimeout + 20*time.Second):

--- a/pkg/metadata/store/sqlite/bench_export_test.go
+++ b/pkg/metadata/store/sqlite/bench_export_test.go
@@ -4,5 +4,6 @@ import "database/sql"
 
 // DBForBench exposes the underlying pool to same-package-adjacent benchmarks so
 // they can prototype alternative write statements against the real schema.
-// Test-only: the file is a _test.go, so it is never compiled into the binary.
+// Test-only: a _test.go file is compiled into the test binary and excluded
+// from every non-test build, so nothing ships.
 func (s *SQLiteMetadataStore) DBForBench() *sql.DB { return s.db }


### PR DESCRIPTION
Review follow-up to #2256, which merged before I could land this.

Copilot was right and the finding was precise: the test carried its own `10 * time.Second` literal under a comment claiming the test would start failing if the store's constant changed. **It would not.** The timing assertion only required `elapsed >= poolAcquireTimeout/2`, so a bound shrunk to anywhere above five seconds passed it unchanged, and the comment promised a detection the code did not perform.

That is the same failure this stack keeps closing — a claim in a comment that the code does not back — so it is worth fixing properly rather than softening the wording.

**The literal is gone.** `export_test.go` publishes the real constant to the external test package, following the `bench_export_test.go` precedent already in the sqlite store. The assertion is now always against the value the store actually uses, and the band brackets it on both sides rather than beating a floor: too early means something other than the pool refused the query, too late means the checkout was not what gave up.

**On what this does and does not do**, since the first fix I wrote traded one over-promise for another. It **tracks** the bound rather than **detecting** a change to it — I checked, by moving the constant to six seconds, where the test follows it and still passes. That is the right intent: the timeout is a policy value somebody may legitimately tune, and what has to hold is that the guard fires at whatever it is set to. A mirrored literal could not say that; it would drift, and the timing assertion would end up checking the store's behaviour against a number the store no longer used. The comment now says exactly that rather than implying detection.

Also replaced the unrelated `30 * time.Second` literal guarding the saturating transaction with `poolAcquireTimeout * 3`, which was the same over-promise in miniature — Copilot flagged that line too.

Verified: passes at 10s (`gave up after 10.002637125s`), passes at 6s when the constant is moved, full postgres integration suite green against a real postgres 16.