### PR TITLE
fix(metadata): make DeleteChild idempotent across all four backends

### DIFF
--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -76,8 +76,16 @@ type Files interface {
 	// Overwrites existing mapping if name already exists.
 	SetChild(ctx context.Context, dirHandle FileHandle, name string, childHandle FileHandle) error
 
-	// DeleteChild removes a child entry from a directory.
-	// Returns ErrNotFound if name doesn't exist in the directory.
+	// DeleteChild removes a child entry from a directory. It is idempotent:
+	// a name that is not in the directory is not an error, and the call
+	// returns nil. A caller that needs to distinguish "was there" from "was
+	// not" must read the entry first.
+	//
+	// Idempotence is the only contract the backends can all keep. In the SQL
+	// backends the parent edge carries ON DELETE CASCADE, so deleting the
+	// inode takes the edge with it and a later DeleteChild for the same name
+	// legitimately finds nothing; reporting that as ErrNotFound would make
+	// the error depend on the order two statements happened to run in.
 	DeleteChild(ctx context.Context, dirHandle FileHandle, name string) error
 
 	// ListChildren returns directory entries with pagination support.

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -626,6 +626,13 @@ func (tx *badgerTransaction) DeleteChild(ctx context.Context, dirHandle metadata
 	}
 
 	item, err := tx.txn.Get(keyChild(dirID, name))
+	if goerrors.Is(err, badgerdb.ErrKeyNotFound) {
+		// Nothing under this name, which is the state DeleteChild is asked to
+		// reach. There is no forward edge to remove and so no reverse edge to
+		// repoint, and the dirent cache already holds no present entry for a
+		// key the store does not have.
+		return nil
+	}
 	if err != nil {
 		return mapBadgerError(err, "child", "")
 	}

--- a/pkg/metadata/store/memory/files.go
+++ b/pkg/metadata/store/memory/files.go
@@ -215,8 +215,8 @@ func (store *MemoryMetadataStore) SetChild(ctx context.Context, dirHandle metada
 	})
 }
 
-// DeleteChild removes a child entry from a directory.
-// Returns ErrNotFound if name doesn't exist.
+// DeleteChild removes a child entry from a directory. Absent names are not
+// an error.
 func (store *MemoryMetadataStore) DeleteChild(ctx context.Context, dirHandle metadata.FileHandle, name string) error {
 	return store.WithTransaction(ctx, func(tx metadata.Transaction) error {
 		return tx.DeleteChild(ctx, dirHandle, name)

--- a/pkg/metadata/store/memory/transaction.go
+++ b/pkg/metadata/store/memory/transaction.go
@@ -414,17 +414,9 @@ func (tx *memoryTransaction) DeleteChild(ctx context.Context, dirHandle metadata
 	dirKey := handleToKey(dirHandle)
 	childrenMap, exists := tx.store.children[dirKey]
 	if !exists {
-		return &metadata.StoreError{
-			Code:    metadata.ErrNotFound,
-			Message: "child not found",
-		}
-	}
-
-	if _, exists := childrenMap[name]; !exists {
-		return &metadata.StoreError{
-			Code:    metadata.ErrNotFound,
-			Message: "child not found",
-		}
+		// A directory with no children map has nothing under any name, which
+		// is the state DeleteChild is asked to reach.
+		return nil
 	}
 
 	delete(childrenMap, name)

--- a/pkg/metadata/storetest/dir_ops.go
+++ b/pkg/metadata/storetest/dir_ops.go
@@ -17,6 +17,7 @@ func runDirOpsTests(t *testing.T, factory StoreFactory) {
 	t.Run("NestedDirectories", func(t *testing.T) { testNestedDirectories(t, factory) })
 	t.Run("RootDirectoryIdempotent", func(t *testing.T) { testRootDirectoryIdempotent(t, factory) })
 	t.Run("LinkCountAgreesWithGetFile", func(t *testing.T) { testLinkCountAgreesWithGetFile(t, factory) })
+	t.Run("DeleteChildIsIdempotent", func(t *testing.T) { testDeleteChildIsIdempotent(t, factory) })
 }
 
 // testCreateDirectory verifies that creating a directory results in the correct type and link count.
@@ -371,5 +372,62 @@ func testLinkCountAgreesWithGetFile(t *testing.T, factory StoreFactory) {
 				t.Errorf("GetLinkCount() = %d, GetFile().Nlink = %d; both surfaces must agree", count, file.Nlink)
 			}
 		})
+	}
+}
+
+// testDeleteChildIsIdempotent pins DeleteChild's contract: removing a name the
+// directory does not hold succeeds and reports no error.
+//
+// Both halves matter and they fail differently. A backend that resolves the
+// name before deleting fails "NeverExisted"; a backend that reports how many
+// rows the delete matched fails "AlreadyRemoved", because the first call is
+// what leaves the second with nothing to do. The transaction path is checked
+// separately from the pool path — the two are distinct bodies in every backend
+// that has not yet collapsed them, and only the transaction path is what a
+// rename or an rmdir actually runs.
+func testDeleteChildIsIdempotent(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	rootHandle := createTestShare(t, store, "/test")
+	ctx := t.Context()
+
+	if err := store.DeleteChild(ctx, rootHandle, "never-existed"); err != nil {
+		t.Errorf("DeleteChild(absent name) = %v, want nil", err)
+	}
+
+	createTestDir(t, store, "/test", rootHandle, "victim")
+	if err := store.DeleteChild(ctx, rootHandle, "victim"); err != nil {
+		t.Fatalf("DeleteChild(present name) failed: %v", err)
+	}
+	if err := store.DeleteChild(ctx, rootHandle, "victim"); err != nil {
+		t.Errorf("DeleteChild(already removed) = %v, want nil", err)
+	}
+
+	err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		if txErr := tx.DeleteChild(ctx, rootHandle, "never-existed"); txErr != nil {
+			t.Errorf("tx.DeleteChild(absent name) = %v, want nil", txErr)
+		}
+		if txErr := tx.DeleteChild(ctx, rootHandle, "victim"); txErr != nil {
+			t.Errorf("tx.DeleteChild(already removed) = %v, want nil", txErr)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WithTransaction() failed: %v", err)
+	}
+
+	// The directory still has to be usable afterwards: a delete that found
+	// nothing must not have torn down state the next create depends on.
+	createTestDir(t, store, "/test", rootHandle, "after")
+	entries, _, err := store.ListChildren(ctx, rootHandle, "", 0)
+	if err != nil {
+		t.Fatalf("ListChildren() failed: %v", err)
+	}
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name)
+	}
+	sort.Strings(names)
+	if len(names) != 1 || names[0] != "after" {
+		t.Errorf("children after idempotent deletes = %v, want [after]", names)
 	}
 }


### PR DESCRIPTION
Closes half of #2241.

## What diverged

`DeleteChild` on a name the directory does not hold:

| backend | before |
| --- | --- |
| memory, badger | `ErrNotFound` |
| sqlite, postgres | `nil` |

The interface documented only the first. Nothing observable depended on
either: all three callers (`file_modify.go` rename, `directory.go` rmdir)
propagate the error without inspecting its class.

## Why idempotent is the one contract all four can keep

In the SQL backends the parent edge carries `ON DELETE CASCADE`, so deleting
an inode takes its dirent with it and a later `DeleteChild` for the same name
legitimately finds nothing. Reporting that as `ErrNotFound` would make the
error depend on the order two statements happened to run in. Strictness is
not available there without an extra read whose only purpose is to
manufacture an error no caller reads.

So memory and badger relax to match, and the interface says so.

## The test earns its place

`DirOps/DeleteChildIsIdempotent` covers both halves on both the pool and the
transaction path — the two are separate bodies in every backend that has not
collapsed them, and only the transaction path is what a rename or an rmdir
runs. The halves fail differently: a backend that resolves the name first
fails `never-existed`, one that checks rows-affected fails `already-removed`.

Verified by mutation, not by assumption. Reverting each fix in turn:

```
--- FAIL: TestConformance/DirOps/DeleteChildIsIdempotent   (memory)
--- FAIL: TestConformance/DirOps/DeleteChildIsIdempotent   (badger)
--- FAIL: TestConformance_RelaxedDurability/DirOps/DeleteChildIsIdempotent
```

## Not in this PR

The other half of #2241 — `tx.CreateShare` rejecting on memory/badger and
overwriting on SQL — is left alone deliberately. Reading it turned up
something bigger, written up on the issue: the SQL transaction body is a bare
`UPDATE shares SET options`, which cannot create a share at all, and the whole
`CreateShare` surface has no production caller in any backend. It wants
deleting, not aligning, and that is its own change.
