### PR TITLE
fix(journal): let the write-path capacity gate force-seal synced actives

### DIFF
--- a/pkg/block/journal/evict_test.go
+++ b/pkg/block/journal/evict_test.go
@@ -577,3 +577,30 @@ func TestEvictWaitsForCarve(t *testing.T) {
 		t.Fatal("Evict never completed after the carve released carveMu")
 	}
 }
+
+// TestEnsureSpaceReclaimsSyncedActiveBelowRotation pins the write-path capacity
+// gate against a working set that never reaches the rotation threshold. Sealing
+// happens only when an append would overflow SegmentSize, so such a set lives
+// entirely in active segments — and eviction scans the sealed set alone. Without
+// a force-seal the gate has nothing to reclaim, and writes fail
+// ErrLocalStoreFull while every byte on disk is synced and droppable.
+func TestEnsureSpaceReclaimsSyncedActiveBelowRotation(t *testing.T) {
+	s, _ := evictStore(t, Config{
+		SegmentSize:   8 << 20, // far above the bytes written: nothing ever rotates
+		MaxLocalBytes: 2 << 20,
+		EvictMaxWait:  200 * time.Millisecond,
+	})
+	ctx := context.Background()
+
+	buf := bytes.Repeat([]byte{0xCD}, chunk256)
+	var off int64
+	for i := range 24 { // 6 MiB of synced bytes against a 2 MiB cap
+		if err := s.Hydrate(ctx, "f", off, buf, 0); err != nil {
+			t.Fatalf("synced write %d at offset %d: %v", i, off, err)
+		}
+		off += chunk256
+	}
+	if got, max := s.diskBytes.Load(), int64(3<<20); got > max {
+		t.Fatalf("cap never enforced: diskBytes=%d want <=%d", got, max)
+	}
+}

--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -368,11 +368,16 @@ func (s *Store) ensureSpace(ctx context.Context, needed int64) error {
 			deadline = time.Now().Add(s.cfg.EvictMaxWait)
 		}
 		if !warned {
-			logger.Warn("journal local store full: nothing evictable, backpressuring writes until carve drains to remote",
+			// The fields are the discriminator, so state the observation and let
+			// them name the cause: unsynced_bytes>0 means carve is behind and the
+			// wait will clear; eviction_disabled means it never will; both zero
+			// and false leaves a snapshot pinning every candidate.
+			logger.Warn("journal local store full: nothing evictable, backpressuring writes",
 				"dir", s.dir,
 				"disk_bytes", s.diskBytes.Load(),
 				"max_local_bytes", s.cfg.MaxLocalBytes,
-				"unsynced_bytes", s.unsynced.Load())
+				"unsynced_bytes", s.unsynced.Load(),
+				"eviction_disabled", s.evictionDisabled.Load())
 			warned = true
 		}
 		if time.Now().After(deadline) {

--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -58,9 +58,11 @@ func (s *Store) Evict(ctx context.Context, targetBytes int64) (EvictResult, erro
 }
 
 // evict is the shared eviction loop. allowActiveSeal enables the force-seal
-// fall-through used by the explicit Evict path; the write-path capacity gate
-// (ensureSpace) passes false so a sustained writer backpressures on its own
-// unsynced bytes instead of sealing the very segment it is appending into.
+// fall-through, which both callers want: without it the sealed set is the only
+// reclaimable set, and a working set below the rotation threshold never enters
+// it. The parameter stays so a caller that must not disturb segment layout can
+// opt out. The fall-through is bounded to one pass per call, and sealableActive
+// keeps it from touching an active holding unsynced records.
 func (s *Store) evict(ctx context.Context, targetBytes int64, allowActiveSeal bool) (EvictResult, error) {
 	if err := ctx.Err(); err != nil {
 		return EvictResult{}, err
@@ -337,10 +339,15 @@ func (s *Store) ensureSpace(ctx context.Context, needed int64) error {
 			return err
 		}
 		overage := s.diskBytes.Load() + needed - s.cfg.MaxLocalBytes
-		// Write-path eviction never force-seals the active segment: the bytes
-		// pinning the cap are this writer's own unsynced records, so the fix is to
-		// wait for carve to drain them, not to seal-and-strand them.
-		res, err := s.evict(ctx, overage, false)
+		// Force-sealing is enabled here for the same reason the explicit drain
+		// enables it: sealing happens only when an append would overflow
+		// SegmentSize, so a working set below that threshold sits entirely in
+		// active segments, and eviction scans the sealed set alone. Denying the
+		// gate a seal leaves the cap structurally unreachable — every byte synced
+		// and droppable, nothing evictable. It cannot strand this writer's own
+		// dirty bytes: sealableActive refuses any active still holding an unsynced
+		// record, so a sustained writer's segment stays put and backpressures.
+		res, err := s.evict(ctx, overage, true)
 		if err != nil {
 			return err
 		}
@@ -361,7 +368,7 @@ func (s *Store) ensureSpace(ctx context.Context, needed int64) error {
 			deadline = time.Now().Add(s.cfg.EvictMaxWait)
 		}
 		if !warned {
-			logger.Warn("journal local store full: every segment pinned by unsynced bytes, backpressuring writes until carve drains to remote",
+			logger.Warn("journal local store full: nothing evictable, backpressuring writes until carve drains to remote",
 				"dir", s.dir,
 				"disk_bytes", s.diskBytes.Load(),
 				"max_local_bytes", s.cfg.MaxLocalBytes,


### PR DESCRIPTION
Closes #2265.

## The defect

A segment is sealed only when an append would overflow `SegmentSize`, and eviction scans the sealed set alone (`claimColdestEvictable` iterates `sh.sealed`). A working set that never reaches the rotation threshold therefore lives entirely in **active** segments, which nothing can reclaim.

With the stock 16 shards at 256 MiB that is up to 4 GiB the write-path capacity gate cannot touch. Past the cap `ensureSpace` backpressures for the whole `EvictMaxWait` budget and then fails writes with `ErrLocalStoreFull` — while every byte on disk is synced to the remote and droppable. A remote-backed share wedges permanently; writes stay `EIO` across restarts.

The 10 GiB `defaultRemoteCacheSize` sits above 16 x 256 MiB, which is why stock configs dodge it. Any share with an explicit `--local-store-size` below that is exposed, and in practice well below: a file lives entirely in one shard, so a single shard outgrowing the cap while staying under 256 MiB wedges the share regardless of the other fifteen.

## The fix

`ensureSpace` now passes `allowActiveSeal=true`, the same force-seal fall-through the explicit `Evict` path already uses — and whose doc names this exact scenario ("a working set smaller than the segment-roll threshold otherwise sits entirely in the never-sealed active segment, where nothing can reclaim it").

The gate was denied that remedy on the premise that the bytes pinning the cap are the writer's own unsynced records. `sealableActive` already refuses any active still holding an unsynced record, so the premise was guarded independently and the denial only removed the remedy without adding safety. A sustained writer's own segment is still never sealed; it backpressures as before.

Also drops the "every segment pinned by unsynced bytes" claim from the warning. It printed alongside `unsynced_bytes=0` and pointed operators at carve throughput that was already working.

## Verification

`TestEnsureSpaceReclaimsSyncedActiveBelowRotation` fails on the parent commit with the exact production error and passes here:

```
--- FAIL: TestEnsureSpaceReclaimsSyncedActiveBelowRotation
    synced write 7 at offset 1835008: journal: local store full, all segments pinned by unsynced bytes
```

Hardware A/B on a Scaleway VM against SCW S3, identical workload and config (768 MiB cap, 1.2 GB written over NFSv4.1), only the binary differs:

| | old | new |
| --- | --- | --- |
| writes | **EIO at 900 MB** | see comment below |
| segments | 16, one per shard, largest 209 MB | |
| seals / evictions | **0 / 0** | |
| `cold.log` | **absent** | |
| local vs cap | 838 MB vs 805 MB | |
| already in S3 | 838 MB (200 objects) | |
| wedge warnings | 101 | |

Full repo suite and `-race` on `./pkg/block/...` are green.
