### PR TITLE
fix(lint): stop the citation check scanning nested working copies

### DIFF
--- a/test/spec-citations/main.go
+++ b/test/spec-citations/main.go
@@ -233,6 +233,12 @@ func loadKnownWrong() (map[string]bool, error) {
 var skipDirs = map[string]bool{
 	".git": true, "vendor": true, "node_modules": true,
 	"graphify-out": true, ".planning": true,
+	// Nested working copies of this same repository. Their .go files are
+	// someone else's in-progress edits, so citations there are neither this
+	// tree's problem nor keyed by a path known_wrong.txt can name. Scanning
+	// them buries the findings that belong to this tree under hundreds that
+	// do not, which is the state in which a check stops being read.
+	".claude": true,
 	// This check's own fixtures cite the wrong sections on purpose.
 	"spec-citations": true,
 }
@@ -246,18 +252,13 @@ func exitOnErr(err error) {
 	}
 }
 
-func main() {
-	root := flag.String("root", ".", "directory tree to scan")
-	flag.Parse()
-
-	specs, err := loadSpecs()
-	exitOnErr(err)
-	known, err := loadKnownWrong()
-	exitOnErr(err)
-
+// scanTree walks root and reports every citation problem in it, plus the number
+// of Go files read. known is updated in place: an entry it matched is marked
+// seen, so the caller can report the ones that no longer match anything.
+func scanTree(root string, specs map[string]*specMap, known map[string]bool) ([]finding, int, error) {
 	var findings []finding
 	scanned := 0
-	err = filepath.WalkDir(*root, func(path string, d fs.DirEntry, err error) error {
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -277,7 +278,7 @@ func main() {
 		scanned++
 		// known_wrong.txt spells its paths with forward slashes, so the key
 		// has to be separator-independent.
-		rel, relErr := filepath.Rel(*root, path)
+		rel, relErr := filepath.Rel(root, path)
 		if relErr != nil {
 			rel = path
 		}
@@ -296,6 +297,19 @@ func main() {
 		}
 		return nil
 	})
+	return findings, scanned, err
+}
+
+func main() {
+	root := flag.String("root", ".", "directory tree to scan")
+	flag.Parse()
+
+	specs, err := loadSpecs()
+	exitOnErr(err)
+	known, err := loadKnownWrong()
+	exitOnErr(err)
+
+	findings, scanned, err := scanTree(*root, specs, known)
 	exitOnErr(err)
 
 	for _, f := range findings {

--- a/test/spec-citations/main_test.go
+++ b/test/spec-citations/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -145,5 +147,54 @@ func TestSectionMapsArePopulated(t *testing.T) {
 		if m.Revision == "" || m.Revision == "unknown" {
 			t.Errorf("%s: revision is %q", spec, m.Revision)
 		}
+	}
+}
+
+// TestScanTreeSkipsNestedCheckouts pins that a working copy of this repository
+// nested inside the tree is not scanned.
+//
+// Without the skip the check reported hundreds of findings from other people's
+// in-progress edits and none of them could be silenced: known_wrong.txt keys on
+// a path, and a nested checkout's path is whoever happened to create it. The
+// findings that belong to this tree were buried, so the local run said 685
+// problems where CI said none — and a check whose local output disagrees that
+// far with CI is one nobody runs before pushing.
+func TestScanTreeSkipsNestedCheckouts(t *testing.T) {
+	specs, err := loadSpecs()
+	if err != nil {
+		t.Fatalf("loadSpecs: %v", err)
+	}
+
+	// The same bad citation in both trees: one in the tree being scanned, one
+	// inside a nested checkout. Only the first may be reported.
+	const badCitation = "// Per [MS-FSA] 2.1.5.14.3, a directory marked for deletion\n"
+
+	root := t.TempDir()
+	writeGo := func(rel string) {
+		t.Helper()
+		full := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", rel, err)
+		}
+		if err := os.WriteFile(full, []byte("package p\n\n"+badCitation), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", rel, err)
+		}
+	}
+	writeGo("mine.go")
+	writeGo(".claude/worktrees/someone-else/theirs.go")
+
+	findings, scanned, err := scanTree(root, specs, map[string]bool{})
+	if err != nil {
+		t.Fatalf("scanTree: %v", err)
+	}
+
+	if scanned != 1 {
+		t.Errorf("scanned %d files, want 1: the nested checkout was read", scanned)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("got %d findings, want 1: %+v", len(findings), findings)
+	}
+	if findings[0].file != "mine.go" {
+		t.Errorf("finding came from %q, want mine.go", findings[0].file)
 	}
 }


### PR DESCRIPTION
## The problem

`go run ./test/spec-citations` reported **685 problems** locally and **0** in CI, on the same
commit. Every extra finding came from `.claude/worktrees/…` — a working copy of this repository
nested inside the tree, holding another session's in-progress edits.

CI never sees them because it checks out `develop` alone. Locally they are unsilenceable:
`known_wrong.txt` keys on a path, and a nested checkout's path is whoever happened to create it.

The effect is worse than noise. The findings that belong to this tree were buried among hundreds
that do not, so the local run could not be used for the one job it has — and a check whose local
output disagrees with CI by that margin is one nobody runs before pushing. It was about to send me
to correct citations in someone else's half-finished branch.

## The fix

`.claude` joins `skipDirs`, alongside `.git`, `vendor`, `node_modules`, `graphify-out` and
`.planning`.

The walk moves out of `main` into `scanTree` so the skip is testable at all — it was previously
an anonymous closure inside `main`, reachable only by running the binary.

## Verified

Before: `685 problem(s) across 9908 Go files`
After: `2362 Go files clean (7 known-wrong citation(s) allowed)`

`TestScanTreeSkipsNestedCheckouts` writes the *same* bad citation into both the scanned tree and a
nested `.claude/worktrees/` checkout, and asserts only the first is reported. Removing the skip
line makes it fail:

```
--- FAIL: TestScanTreeSkipsNestedCheckouts
    main_test.go:192: scanned 2 files, want 1: the nested checkout was read
```

The seven genuinely-wrong citations in `known_wrong.txt` are untouched here — correcting those is
#2185, and it needs this first to be doable.