### PR TITLE
fix(nfs3): narrow ACCESS replies to the request and drop DELETE for non-directories

### DIFF
--- a/internal/adapter/nfs/v3/handlers/access.go
+++ b/internal/adapter/nfs/v3/handlers/access.go
@@ -175,7 +175,12 @@ func (h *Handler) Access(
 		return &AccessResponse{NFSResponseBase: NFSResponseBase{Status: types.NFS3ErrIO}}, nil
 	}
 
-	grantedAccess := permissionsToNFSAccess(grantedPerms, file.Type)
+	// Narrow the reply to the rights the client asked about. RFC 1813 Section
+	// 3.3.4 defines the returned mask as the subset of the request that is
+	// permitted, and the Linux client caches this mask and answers later,
+	// different access checks from it without returning to the server, so a bit
+	// the client never asked about becomes a grant nothing here evaluated.
+	grantedAccess := permissionsToNFSAccess(grantedPerms, file.Type) & req.Access
 
 	logger.DebugCtx(ctx.Context, "ACCESS translation",
 		"generic_perms", fmt.Sprintf("0x%x", grantedPerms),
@@ -214,7 +219,7 @@ func (h *Handler) Access(
 //   - AccessLookup (0x0002): Look up names in directory
 //   - AccessModify (0x0004): Modify file data
 //   - AccessExtend (0x0008): Extend file (write beyond EOF)
-//   - AccessDelete (0x0010): Delete file or directory
+//   - AccessDelete (0x0010): Delete an existing directory entry
 //   - AccessExecute (0x0020): Execute file or search directory
 //
 // Generic Permission flags:
@@ -272,7 +277,12 @@ func nfsAccessToPermissions(nfsAccess uint32, fileType metadata.FileType) metada
 
 // permissionsToNFSAccess translates generic Permission flags back to NFS ACCESS bits.
 //
-// This is the inverse of nfsAccessToPermissions and must maintain consistency.
+// This is the inverse of nfsAccessToPermissions, with two asymmetries the caller
+// has to account for. It is not injective — one PermissionWrite comes back as
+// both AccessModify and AccessExtend, and one PermissionTraverse as both
+// AccessLookup and AccessExecute — so a reply built from it must be re-masked
+// with the bits the client actually requested. And AccessDelete is dropped for
+// non-directories, so a round trip through both functions loses it there.
 func permissionsToNFSAccess(perms metadata.Permission, fileType metadata.FileType) uint32 {
 	var nfsAccess uint32
 
@@ -303,8 +313,13 @@ func permissionsToNFSAccess(perms metadata.Permission, fileType metadata.FileTyp
 		}
 	}
 
-	// PermissionDelete maps directly
-	if perms&metadata.PermissionDelete != 0 {
+	// AccessDelete is the right to remove a directory entry, so it belongs to the
+	// containing directory rather than to the object the entry names. RFC 1813
+	// Section 3.3.4 says the bit is to be set to 0 in the reply for a
+	// non-directory object. PermissionDelete is not a safe stand-in there either:
+	// on the POSIX path CalculatePermissionsFromBits derives it from the object's
+	// own write bit, which grants nothing about deleting the object.
+	if fileType == metadata.FileTypeDirectory && perms&metadata.PermissionDelete != 0 {
 		nfsAccess |= types.AccessDelete
 	}
 

--- a/internal/adapter/nfs/v3/handlers/access_test.go
+++ b/internal/adapter/nfs/v3/handlers/access_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/nfs/types"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v3/handlers"
 	handlertesting "github.com/marmos91/dittofs/internal/adapter/nfs/v3/handlers/testing"
+	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -45,4 +46,84 @@ func TestAccess_Directory(t *testing.T) {
 	assert.EqualValues(t, types.NFS3OK, resp.Status, "ACCESS should succeed for directory")
 	assert.NotNil(t, resp.Attr, "Should return attributes")
 	assert.EqualValues(t, types.NF3DIR, resp.Attr.Type, "Should be a directory")
+}
+
+// TestAccess_NarrowsToRequest pins that the reply carries only the rights the
+// client asked about. CheckPermissions already returns a subset of the generic
+// permissions it was handed, so the widening comes entirely from the back
+// translation, which is not bijective: one PermissionWrite becomes both
+// AccessModify and AccessExtend, and one PermissionTraverse becomes both
+// AccessLookup and AccessExecute. The Linux client caches this mask and answers
+// later, different access checks from it without returning to the server, so a
+// bit it never asked about becomes a grant nothing here evaluated.
+func TestAccess_NarrowsToRequest(t *testing.T) {
+	fx := handlertesting.NewHandlerFixture(t)
+
+	fileHandle := fx.CreateFile("narrow.txt", []byte("content"))
+	dirHandle := fx.CreateDirectory("narrowdir")
+
+	tests := []struct {
+		name      string
+		handle    metadata.FileHandle
+		requested uint32
+	}{
+		{"file/modify does not imply extend", fileHandle, types.AccessModify},
+		{"file/extend does not imply modify", fileHandle, types.AccessExtend},
+		{"dir/lookup does not imply execute", dirHandle, types.AccessLookup},
+		{"dir/execute does not imply lookup", dirHandle, types.AccessExecute},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &handlers.AccessRequest{Handle: tt.handle, Access: tt.requested}
+			resp, err := fx.Handler.Access(fx.Context(), req)
+
+			require.NoError(t, err)
+			require.EqualValues(t, types.NFS3OK, resp.Status)
+			assert.EqualValues(t, tt.requested, resp.Access,
+				"reply must be the requested bits, not every right the object could answer for")
+		})
+	}
+}
+
+// TestAccess_NoDeleteOnRegularFile pins RFC 1813 Section 3.3.4: ACCESS3_DELETE
+// is the right to remove a directory entry, so a non-directory object reports it
+// as 0 even when the client asks and the object is writable by the caller.
+func TestAccess_NoDeleteOnRegularFile(t *testing.T) {
+	fx := handlertesting.NewHandlerFixture(t)
+
+	fileHandle := fx.CreateFile("deletable.txt", []byte("content"))
+
+	req := &handlers.AccessRequest{
+		Handle: fileHandle,
+		Access: types.AccessRead | types.AccessModify | types.AccessDelete,
+	}
+	resp, err := fx.Handler.Access(fx.Context(), req)
+
+	require.NoError(t, err)
+	require.EqualValues(t, types.NFS3OK, resp.Status)
+	assert.Zero(t, resp.Access&types.AccessDelete,
+		"AccessDelete has no meaning for a regular file")
+	assert.NotZero(t, resp.Access&types.AccessModify,
+		"the writable file should still report AccessModify")
+}
+
+// TestAccess_DeleteOnDirectory is the other half of the rule: a directory the
+// caller may write does report AccessDelete, so dropping it for files did not
+// drop it everywhere.
+func TestAccess_DeleteOnDirectory(t *testing.T) {
+	fx := handlertesting.NewHandlerFixture(t)
+
+	dirHandle := fx.CreateDirectory("deletabledir")
+
+	req := &handlers.AccessRequest{
+		Handle: dirHandle,
+		Access: types.AccessDelete,
+	}
+	resp, err := fx.Handler.Access(fx.Context(), req)
+
+	require.NoError(t, err)
+	require.EqualValues(t, types.NFS3OK, resp.Status)
+	assert.EqualValues(t, types.AccessDelete, resp.Access,
+		"a writable directory grants AccessDelete")
 }


### PR DESCRIPTION
# Description

The NFSv3 twin of #2211, applying the same two rules to `internal/adapter/nfs/v3/handlers/access.go` so the two ACCESS handlers read the same way side by side. They deliberately share the `nfsAccessToPermissions` / `permissionsToNFSAccess` translation, and only the v4 half had been narrowed.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## What was wrong

`Handler.Access` put the translated bitmask straight into the reply:

```go
grantedAccess := permissionsToNFSAccess(grantedPerms, file.Type)
```

Nothing on that path re-ANDed with `req.Access`, and `permissionsToNFSAccess` set `AccessDelete` from `PermissionDelete` for every file type.

### Correction to the issue's first premise

The issue predicts that "a client asking only `ACCESS3_READ` on a writable file gets `READ|MODIFY|EXTEND|DELETE` back". That is not what happens, and a test written from it passes on unmodified `develop` — I wrote one and had to throw it away. `CheckPermissions` returns a subset of the generic permissions it was handed: every path through `pkg/metadata/auth_permissions.go` ends in `granted & requested` (`calculatePermissions`, `evaluateWithACL`, the root bypass, and the `WriteAuthorizedByHandle` branch alike). So the reply cannot pick up a *generic* right the client did not ask about.

The widening is real but narrower, and comes entirely from the back translation not being injective:

| client asks | generic perm | comes back as |
| --- | --- | --- |
| `AccessModify` on a file | `PermissionWrite` | `AccessModify \| AccessExtend` |
| `AccessExtend` on a file | `PermissionWrite` | `AccessModify \| AccessExtend` |
| `AccessLookup` on a dir | `PermissionTraverse` | `AccessLookup \| AccessExecute` |
| `AccessExecute` on a dir | `PermissionTraverse` | `AccessLookup \| AccessExecute` |

This is the same asymmetry #2211's comment names on the v4 side; v4 handles it by masking granted with `supported`, which is itself narrowed to the request.

### The `AccessDelete` half

`AccessDelete` is the right to remove a *directory entry*, so it is a right of the containing directory, not of the object the entry names. On the POSIX path `CalculatePermissionsFromBits` (`pkg/metadata/auth_permissions.go:199`) derives `PermissionDelete` from the object's own write bit, which says nothing about whether the object can be unlinked — so every writable regular file reported `ACCESS3_DELETE`. RFC 1813 §3.3.4 is explicit that the bit is to be set to 0 for a non-directory object.

## Why it matters

RFC 1813 has no `supported` field, so unlike the NFSv4 case there is no hard subset rule being violated — this is a correctness smell, not a protocol break. The reason it still matters is client-side caching: the Linux NFSv3 client stores the reply's `access` value and satisfies later, *different* access checks from it locally without asking the server again. An over-wide reply therefore becomes an over-wide cached grant, answering a check the server never evaluated until the entry expires.

## Changes Made

- `Handler.Access` masks the granted bitmask with `req.Access`.
- `permissionsToNFSAccess` only sets `AccessDelete` for directories. This is the single place it belongs: the function is unexported and `access.go:178` is its only caller.
- Doc comments: `permissionsToNFSAccess` now states both asymmetries (non-injective, and lossy for `AccessDelete` on non-directories) so the re-mask at the call site is not mistaken for redundancy; the `AccessDelete` line in the bit list now matches the RFC wording.

`nfsAccessToPermissions` still maps `AccessDelete` to `PermissionDelete` on the request side for non-directories. That mirrors the merged v4 handler, which likewise leaves the request-side mapping alone and drops the bit on the reply; `CheckPermissions` treats an unsatisfiable request as an ordinary partial grant, so it has no side effect.

## Testing

- [X] Unit tests pass (`go test ./...`)

Three tests added to `internal/adapter/nfs/v3/handlers/access_test.go`. Each was run against the unfixed `access.go` first — a test derived from a fix's own premise certifies the bug rather than catching it, which is exactly how the discarded first version of the narrowing test passed:

```
--- FAIL: TestAccess_NarrowsToRequest
    --- FAIL: TestAccess_NarrowsToRequest/file/modify_does_not_imply_extend
    --- FAIL: TestAccess_NarrowsToRequest/file/extend_does_not_imply_modify
    --- FAIL: TestAccess_NarrowsToRequest/dir/lookup_does_not_imply_execute
    --- FAIL: TestAccess_NarrowsToRequest/dir/execute_does_not_imply_lookup
--- FAIL: TestAccess_NoDeleteOnRegularFile
```

`TestAccess_DeleteOnDirectory` passes both before and after by design — it is the guard that the `AccessDelete` drop did not become a drop everywhere.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published

Closes #2217
