### PR TITLE
fix(nfs4): translate the all-ones lock length into the manager's end-of-file range

### DIFF
--- a/internal/adapter/nfs/v4/state/lockowner.go
+++ b/internal/adapter/nfs/v4/state/lockowner.go
@@ -159,10 +159,19 @@ type LOCK4denied struct {
 	}
 }
 
-// EncodeLOCK4denied encodes a LOCK4denied structure in XDR format.
+// EncodeLOCK4denied encodes the LOCK4denied structure in XDR format.
+//
+// A stored length of zero is the lock manager's spelling for "to end-of-file";
+// on the wire that range is a length with every bit set. Zero is not a length a
+// client may send, so emitting it would name a range the client cannot parse
+// back into the lock it was denied by.
 func EncodeLOCK4denied(buf *bytes.Buffer, denied *LOCK4denied) {
+	length := denied.Length
+	if length == 0 {
+		length = math.MaxUint64
+	}
 	_ = xdr.WriteUint64(buf, denied.Offset)
-	_ = xdr.WriteUint64(buf, denied.Length)
+	_ = xdr.WriteUint64(buf, length)
 	_ = xdr.WriteUint32(buf, denied.LockType)
 	_ = xdr.WriteUint64(buf, denied.Owner.ClientID)
 	_ = xdr.WriteXDROpaque(buf, denied.Owner.OwnerData)
@@ -172,22 +181,29 @@ func EncodeLOCK4denied(buf *bytes.Buffer, denied *LOCK4denied) {
 // Validation Helpers
 // ============================================================================
 
-// validateLockRange checks that offset and length describe a byte range the
-// server will act on. RFC 7530 Section 16.10.4 rejects a length of zero, and
-// rejects a length that is not all-ones whose sum with the offset exceeds the
-// maximum 64-bit unsigned value. A length with every bit set is the wire
-// encoding for "from offset to end-of-file", so it is exempt from that sum.
-// Sections 16.11.4 and 16.12.4 apply the same two rules to LOCKT and LOCKU.
+// normalizeLockRange checks that offset and length describe a byte range the
+// server will act on, and translates it into the lock manager's spelling.
 //
-// Exempting all-ones only admits the range: the lock manager still receives the
-// literal length, which is not the end-of-file range it names.
+// RFC 7530 Section 16.10.4 rejects a length of zero, and rejects a length that
+// is not all-ones whose sum with the offset exceeds the maximum 64-bit unsigned
+// value. A length with every bit set is the wire encoding for "from offset to
+// end-of-file", so it is exempt from that sum. Sections 16.11.4 and 16.12.4
+// apply the same two rules to LOCKT and LOCKU.
+//
+// The lock manager spells that same end-of-file range as a length of zero, so
+// an accepted all-ones length is returned as zero and every other accepted
+// length is returned unchanged. Handing the literal all-ones length on would
+// overflow the manager's inclusive-end arithmetic and cover nothing.
 //
 // Returns NFS4ERR_INVAL on a rejected range.
-func validateLockRange(offset, length uint64) error {
-	if length != 0 && (length == math.MaxUint64 || offset <= math.MaxUint64-length) {
-		return nil
+func normalizeLockRange(offset, length uint64) (uint64, error) {
+	if length == math.MaxUint64 {
+		return 0, nil
 	}
-	return &NFS4StateError{
+	if length != 0 && offset <= math.MaxUint64-length {
+		return length, nil
+	}
+	return 0, &NFS4StateError{
 		Status:  types.NFS4ERR_INVAL,
 		Message: "invalid byte-range lock offset/length",
 	}

--- a/internal/adapter/nfs/v4/state/lockowner.go
+++ b/internal/adapter/nfs/v4/state/lockowner.go
@@ -192,8 +192,7 @@ func EncodeLOCK4denied(buf *bytes.Buffer, denied *LOCK4denied) {
 //
 // The lock manager spells that same end-of-file range as a length of zero, so
 // an accepted all-ones length is returned as zero and every other accepted
-// length is returned unchanged. Handing the literal all-ones length on would
-// overflow the manager's inclusive-end arithmetic and cover nothing.
+// length is returned unchanged.
 //
 // Returns NFS4ERR_INVAL on a rejected range.
 func normalizeLockRange(offset, length uint64) (uint64, error) {

--- a/internal/adapter/nfs/v4/state/lockowner_test.go
+++ b/internal/adapter/nfs/v4/state/lockowner_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"math"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
@@ -947,40 +949,144 @@ func TestLockNew_BlockingType(t *testing.T) {
 }
 
 // ============================================================================
-// ValidateLockRange Tests
+// NormalizeLockRange Tests
 // ============================================================================
 
-func TestValidateLockRange(t *testing.T) {
+func TestNormalizeLockRange(t *testing.T) {
 	tests := []struct {
-		name    string
-		offset  uint64
-		length  uint64
-		wantErr bool
+		name       string
+		offset     uint64
+		length     uint64
+		wantLength uint64
+		wantErr    bool
 	}{
-		{"ordinary range", 25, 75, false},
-		{"zero length", 25, 0, true},
-		{"zero length at zero offset", 0, 0, true},
-		{"all-ones length locks through EOF", 100, math.MaxUint64, false},
-		{"all-ones length from the highest offset", math.MaxUint64, math.MaxUint64, false},
-		{"sum lands exactly on the maximum", 1, math.MaxUint64 - 1, false},
-		{"sum passes the maximum by one", 2, math.MaxUint64 - 1, true},
+		{"ordinary range", 25, 75, 75, false},
+		{"zero length", 25, 0, 0, true},
+		{"zero length at zero offset", 0, 0, 0, true},
+		{"all-ones length becomes the unbounded range", 100, math.MaxUint64, 0, false},
+		{"all-ones length from the highest offset", math.MaxUint64, math.MaxUint64, 0, false},
+		{"sum lands exactly on the maximum", 1, math.MaxUint64 - 1, math.MaxUint64 - 1, false},
+		{"sum passes the maximum by one", 2, math.MaxUint64 - 1, 0, true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateLockRange(tt.offset, tt.length)
+			gotLength, err := normalizeLockRange(tt.offset, tt.length)
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("validateLockRange(%d, %d) = %v, wantErr %v",
+				t.Fatalf("normalizeLockRange(%d, %d) = %v, wantErr %v",
 					tt.offset, tt.length, err, tt.wantErr)
 			}
-			if err == nil {
+			if err != nil {
+				var stateErr *NFS4StateError
+				if !errors.As(err, &stateErr) || stateErr.Status != types.NFS4ERR_INVAL {
+					t.Errorf("normalizeLockRange(%d, %d) error = %v, want NFS4ERR_INVAL",
+						tt.offset, tt.length, err)
+				}
 				return
 			}
-			var stateErr *NFS4StateError
-			if !errors.As(err, &stateErr) || stateErr.Status != types.NFS4ERR_INVAL {
-				t.Errorf("validateLockRange(%d, %d) error = %v, want NFS4ERR_INVAL",
-					tt.offset, tt.length, err)
+			if gotLength != tt.wantLength {
+				t.Errorf("normalizeLockRange(%d, %d) length = %d, want %d",
+					tt.offset, tt.length, gotLength, tt.wantLength)
 			}
 		})
+	}
+}
+
+// TestEncodeLOCK4denied_UnboundedLength pins that the unbounded range travels
+// back to the client as the all-ones length it was requested with. A denial by
+// a to-EOF lock is the only way a client sees this field carry that range.
+func TestEncodeLOCK4denied_UnboundedLength(t *testing.T) {
+	var buf bytes.Buffer
+	EncodeLOCK4denied(&buf, &LOCK4denied{Offset: 100, Length: 0, LockType: types.WRITE_LT})
+
+	reader := bytes.NewReader(buf.Bytes())
+	offset, err := xdr.DecodeUint64(reader)
+	if err != nil {
+		t.Fatalf("decode offset: %v", err)
+	}
+	length, err := xdr.DecodeUint64(reader)
+	if err != nil {
+		t.Fatalf("decode length: %v", err)
+	}
+	if offset != 100 || length != math.MaxUint64 {
+		t.Errorf("encoded range = (%d, %d), want (100, %d)", offset, length, uint64(math.MaxUint64))
+	}
+}
+
+// TestLockToEndOfFile drives the all-ones length through all three ops that
+// carry one. A lock taken from offset 100 to end-of-file must deny a request at
+// 200, and releasing it with the same all-ones length must let that request
+// through: LOCK, LOCKT and LOCKU all read the same overlap primitive, so a
+// length that reached it untranslated made the lock cover nothing past 100.
+func TestLockToEndOfFile(t *testing.T) {
+	const toEOF = uint64(math.MaxUint64)
+
+	lm := lock.NewManager()
+	sm := NewStateManager(90 * time.Second)
+	sm.SetLockManager(lm)
+
+	callback := CallbackInfo{Program: 0x40000000, NetID: "tcp", Addr: "10.0.0.1.8.1"}
+	fh := []byte("/export:eof-file")
+
+	holder, _ := sm.SetClientID("client-eof-holder", [8]byte{1}, callback, "10.0.0.1:1234")
+	_ = sm.ConfirmClientID(holder.ClientID, holder.ConfirmVerifier)
+	holderOpen, _ := sm.OpenFile(holder.ClientID, []byte("owner-holder"), 1, fh,
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
+	holderConfirmed, _ := sm.ConfirmOpen(&holderOpen.Stateid, 2)
+
+	rival, _ := sm.SetClientID("client-eof-rival", [8]byte{2}, callback, "10.0.0.2:1234")
+	_ = sm.ConfirmClientID(rival.ClientID, rival.ConfirmVerifier)
+	rivalOpen, _ := sm.OpenFile(rival.ClientID, []byte("owner-rival"), 1, fh,
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
+	rivalConfirmed, _ := sm.ConfirmOpen(&rivalOpen.Stateid, 2)
+
+	held, err := sm.LockNew(context.Background(),
+		holder.ClientID, []byte("lock-owner-holder"), 1,
+		&holderConfirmed.Stateid, 3,
+		fh, types.WRITE_LT, 100, toEOF, false,
+	)
+	if err != nil {
+		t.Fatalf("LOCK through end-of-file failed: %v", err)
+	}
+	if held.Denied != nil {
+		t.Fatalf("LOCK through end-of-file was denied: %+v", held.Denied)
+	}
+
+	// LOCKT: the range at 200 sits inside the held lock.
+	denied, err := sm.TestLock(rival.ClientID, []byte("lock-owner-rival"), fh, types.WRITE_LT, 200, 100)
+	if err != nil {
+		t.Fatalf("LOCKT failed: %v", err)
+	}
+	if denied == nil {
+		t.Fatal("LOCKT at 200 reported no conflict with the lock held from 100 to end-of-file")
+	}
+	if denied.Offset != 100 || denied.Length != 0 {
+		t.Errorf("LOCKT conflict range = (%d, %d), want (100, 0) for the unbounded lock",
+			denied.Offset, denied.Length)
+	}
+
+	// LOCK: the same range must be refused, not handed out.
+	rivalLock, err := sm.LockNew(context.Background(),
+		rival.ClientID, []byte("lock-owner-rival"), 1,
+		&rivalConfirmed.Stateid, 3,
+		fh, types.WRITE_LT, 200, 100, false,
+	)
+	if err != nil {
+		t.Fatalf("conflicting LOCK failed: %v", err)
+	}
+	if rivalLock.Denied == nil {
+		t.Fatal("LOCK at 200 was granted over the lock held from 100 to end-of-file")
+	}
+
+	// LOCKU: releasing with the same all-ones length must clear the whole range.
+	if _, err := sm.UnlockFile(&held.Stateid, 2, types.WRITE_LT, 100, toEOF); err != nil {
+		t.Fatalf("LOCKU through end-of-file failed: %v", err)
+	}
+	denied, err = sm.TestLock(rival.ClientID, []byte("lock-owner-rival"), fh, types.WRITE_LT, 200, 100)
+	if err != nil {
+		t.Fatalf("LOCKT after unlock failed: %v", err)
+	}
+	if denied != nil {
+		t.Errorf("LOCKT at 200 still reports a conflict after the to-EOF lock was released: %+v", denied)
 	}
 }

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -2110,7 +2110,8 @@ func (sm *StateManager) LockNew(
 	// 6. Validate the byte range and the open mode for the lock type. Both run
 	// after the seqid checks so a bad seqid, which must leave the sequence
 	// untouched, outranks NFS4ERR_INVAL and NFS4ERR_OPENMODE, which consume it.
-	if err := validateLockRange(offset, length); err != nil {
+	length, err = normalizeLockRange(offset, length)
+	if err != nil {
 		return nil, err
 	}
 	if err := validateOpenModeForLock(openState, lockType); err != nil {
@@ -2249,7 +2250,8 @@ func (sm *StateManager) LockExisting(
 	}
 
 	// 4. Validate the byte range and the open mode for the lock type
-	if err := validateLockRange(offset, length); err != nil {
+	length, err = normalizeLockRange(offset, length)
+	if err != nil {
 		return nil, err
 	}
 	if err := validateOpenModeForLock(lockState.OpenState, lockType); err != nil {
@@ -2404,7 +2406,8 @@ func (sm *StateManager) TestLock(
 	clientID uint64, ownerData []byte,
 	fileHandle []byte, lockType uint32, offset, length uint64,
 ) (*LOCK4denied, error) {
-	if err := validateLockRange(offset, length); err != nil {
+	length, err := normalizeLockRange(offset, length)
+	if err != nil {
 		return nil, err
 	}
 
@@ -2554,7 +2557,8 @@ func (sm *StateManager) UnlockFile(
 	}
 
 	// 4. Validate the byte range
-	if err := validateLockRange(offset, length); err != nil {
+	length, err = normalizeLockRange(offset, length)
+	if err != nil {
 		return nil, err
 	}
 

--- a/pkg/metadata/lock/manager_test.go
+++ b/pkg/metadata/lock/manager_test.go
@@ -447,6 +447,10 @@ func TestRangesOverlap(t *testing.T) {
 		// still report self-overlap. Required for smb2.lock max/1 case.
 		{"max-byte self", ^uint64(0), 1, ^uint64(0), 1, true},
 		{"max-byte vs unbounded", ^uint64(0), 1, 0, 0, true},
+		// A length that carries the sum past the 64-bit maximum saturates
+		// rather than wrapping, so the range still covers everything above
+		// its own start instead of nothing.
+		{"overflowing length still covers what follows it", 100, ^uint64(0), 200, 100, true},
 	}
 
 	for _, tt := range tests {
@@ -1623,5 +1627,25 @@ func TestManager_ReleaseByOwnerPrefix_NoMatchIsSafe(t *testing.T) {
 	empty := NewManager()
 	if released := empty.ReleaseByOwnerPrefix("nlm:anyone:"); released != 0 {
 		t.Fatalf("want 0 released on empty manager, got %d", released)
+	}
+}
+
+// TestRangeLastNeverBelowOffset pins the invariant the overlap arithmetic rests
+// on: the inclusive last byte of a range is never before its first. A sum that
+// passes the 64-bit maximum saturates there, because a wrapped last byte
+// describes an inverted range that overlaps nothing above its own start.
+func TestRangeLastNeverBelowOffset(t *testing.T) {
+	t.Parallel()
+
+	max := ^uint64(0)
+	offsets := []uint64{0, 1, 100, max / 2, max - 1, max}
+	lengths := []uint64{0, 1, 2, 100, max - 1, max}
+
+	for _, offset := range offsets {
+		for _, length := range lengths {
+			if last := rangeLast(offset, length); last < offset {
+				t.Errorf("rangeLast(%d, %d) = %d, which is below the offset", offset, length, last)
+			}
+		}
 	}
 }

--- a/pkg/metadata/lock/types.go
+++ b/pkg/metadata/lock/types.go
@@ -408,11 +408,19 @@ func RangesOverlap(offset1, length1, offset2, length2 uint64) bool {
 
 // rangeLast returns the inclusive last byte of a byte range.
 // For unbounded ranges (length=0), returns max uint64 to represent infinity.
+//
+// The result is never below offset. A length that carries offset+length past
+// the 64-bit maximum saturates at that maximum instead of wrapping to an
+// inverted range that overlaps nothing above its own start.
 func rangeLast(offset, length uint64) uint64 {
 	if length == 0 {
 		return ^uint64(0)
 	}
-	return offset + length - 1
+	last := offset + length - 1
+	if last < offset {
+		return ^uint64(0)
+	}
+	return last
 }
 
 // rangeEnd returns the exclusive end of a byte range.

--- a/pkg/metadata/lock/types.go
+++ b/pkg/metadata/lock/types.go
@@ -394,10 +394,10 @@ func IsUnifiedLockConflicting(existing, requested *UnifiedLock) bool {
 // Length of 0 means "to end of file" (unbounded).
 //
 // Uses inclusive-end arithmetic (last = offset + length - 1) so single-byte
-// ranges at offset 2^64-1 do not wrap to a zero-length exclusive end. For
-// non-zero lengths, last1 = offset1 + length1 - 1 (which fits in uint64 iff
-// offset1 + length1 - 1 ≤ 2^64-1; callers above must reject ranges where
-// the last byte overflows). Unbounded ranges (length=0) use last=2^64-1.
+// ranges at offset 2^64-1 do not wrap to a zero-length exclusive end. A length
+// that carries that sum past 2^64-1 saturates there rather than wrapping, so no
+// caller has to reject an overflowing range to keep this answer meaningful.
+// Unbounded ranges (length=0) use last=2^64-1.
 //
 // Overlap iff offset1 ≤ last2 AND offset2 ≤ last1.
 func RangesOverlap(offset1, length1, offset2, length2 uint64) bool {


### PR DESCRIPTION
## What was wrong

NFSv4 spells "lock from offset through end-of-file" as a length with every bit set (RFC 7530 §16.10.4). `pkg/metadata/lock` spells the same range as `length == 0`. Nothing translated between the two, so an all-ones length reached `rangeLast`:

```go
func rangeLast(offset, length uint64) uint64 {
	if length == 0 {
		return ^uint64(0)
	}
	return offset + length - 1   // 100 + (2^64-1) - 1 wraps to 98
}
```

`RangesOverlap` is `offset1 <= last2 && offset2 <= last1`, so a lock held from offset 100 to end-of-file had `last == 98` and overlapped nothing above its own start. Every NFSv4 to-EOF byte-range lock covered nothing, and LOCK, LOCKT and LOCKU all read that same primitive.

Reproduced against unmodified `develop` with the regression test added here:

```
--- FAIL: TestLockToEndOfFile
    LOCKT at 200 reported no conflict with the lock held from 100 to end-of-file
```

That is a server handing out a conflicting write lock: `NFS4_OK` where the client is owed `NFS4ERR_DENIED`.

## The fix

**Translate at the NFSv4 boundary**, not by teaching `pkg/metadata/lock` a second spelling of infinity — the NFSv4 handler is the only caller that uses all-ones, and two conventions meaning the same thing is how the next caller gets it wrong.

- `validateLockRange` becomes `normalizeLockRange(offset, length) (uint64, error)`. It applies exactly the same RFC validation as before, and returns the length the lock manager should be given: an accepted all-ones length comes back as `0`, everything else unchanged. All four call sites in the state manager (`LockNew`, `LockExisting`, `TestLock`, `UnlockFile`) take the translated length, so LOCK, LOCKT and LOCKU all read the corrected answer.
- `EncodeLOCK4denied` translates back on the way out. A stored length of `0` goes on the wire as all-ones, because `0` is not a length a client may send — reporting it would name a range the client cannot parse back into the lock it was denied by. This also covers a denial by an NLM-held to-EOF lock, which is stored as `0` natively and had the same wire problem.

**Plus the invariant, as belt and braces.** `rangeLast` now saturates at the 64-bit maximum instead of wrapping, so its result is never below `offset`. The boundary translation is the fix; the invariant is what catches the next caller who forgets. It is pinned by a test that fails on the current code:

```
rangeLast(100, 18446744073709551615) = 98, which is below the offset
```

Both new tests were run against a deliberately broken build first and fail there for the right reason.

## Note on #2210

Found while reviewing #2210, which is not the cause — this was true on `develop` before it. That PR's comment honestly recorded the gap ("the lock manager still receives the literal length, which is not the end-of-file range it names"); with the translation in place that sentence is now wrong, so it is replaced by a description of what actually happens.

## Verification

- `go build ./...`, `go vet`, `golangci-lint` clean on the touched packages
- `go test ./...` green; `go test -race ./internal/adapter/nfs/v4/... ./pkg/metadata/lock/...` green

Closes #2216
