### PR TITLE
fix(smb): let rename's ChangeTime advance stand, and pin frozen timestamps across rename + CLOSE

### DIFF
--- a/internal/adapter/smb/handlers/close_frozen_timestamps_test.go
+++ b/internal/adapter/smb/handlers/close_frozen_timestamps_test.go
@@ -1,0 +1,105 @@
+// Handler-level coverage for frozen timestamps surviving a rename and the
+// CLOSE that follows it.
+//
+// Per MS-FSA 2.1.5.15.2 ("FileBasicInformation") a timestamp frozen with the
+// -1 sentinel must not be auto-updated by later operations on that handle.
+// CLOSE is where that is hardest to hold: it flushes the deferred write state,
+// which stamps Mtime/Ctime, and only then restores the frozen values. The
+// rename in between stamps ChangeTime as well.
+package handlers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// TestClose_FrozenTimestampsSurviveRename drives the whole flow through the
+// protocol handlers rather than seeding the freeze flags directly: the freeze
+// and the restore are gated by the same ownership rule in the metadata layer,
+// so a handle that could not have frozen a timestamp is not a case this can
+// reach. The file is chowned to the session's user first for that reason.
+func TestClose_FrozenTimestampsSurviveRename(t *testing.T) {
+	h, smbCtx, _, fileID := setupReparseShare(t)
+	openFile, ok := h.GetOpenFile(fileID)
+	if !ok {
+		t.Fatal("open file missing")
+	}
+	metaSvc := h.Registry.GetMetadataService()
+
+	// The fixture creates the file as root but authenticates the session as
+	// uid 1000. Hand the file to that user so it can freeze its timestamps at
+	// all — SET_INFO's explicit-timestamp write requires ownership.
+	rootUID, rootGID := uint32(0), uint32(0)
+	rootCtx := &metadata.AuthContext{
+		Context:  context.Background(),
+		Identity: &metadata.Identity{UID: &rootUID, GID: &rootGID},
+	}
+	sessUID, sessGID := uint32(1000), uint32(1000)
+	past := time.Date(2021, 2, 3, 4, 5, 6, 0, time.UTC)
+	if _, err := metaSvc.SetFileAttributes(rootCtx, openFile.MetadataHandle, &metadata.SetAttrs{
+		UID: &sessUID, GID: &sessGID,
+		CreationTime: &past, Atime: &past, Mtime: &past, Ctime: &past,
+	}); err != nil {
+		t.Fatalf("seed owner + timestamps: %v", err)
+	}
+
+	access := uint32(types.FileReadData | types.FileWriteData |
+		types.FileReadAttributes | types.FileWriteAttributes | types.Delete)
+	openFile.DesiredAccess = access
+	openFile.GrantedAccess = access
+
+	h.primeAuthContextFromOpenFile(smbCtx, openFile)
+	authCtx, err := BuildAuthContext(smbCtx)
+	if err != nil {
+		t.Fatalf("BuildAuthContext: %v", err)
+	}
+
+	// Freeze all four timestamps with the -1 sentinel.
+	freeze := encodeBasicInfo(filetimeFreeze, filetimeFreeze, filetimeFreeze, filetimeFreeze, 0)
+	resp, err := h.setFileInfoFromStore(smbCtx, authCtx, openFile, types.FileBasicInformation, freeze)
+	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
+		t.Fatalf("freeze SET_INFO: err=%v resp=%v", err, resp)
+	}
+	if !openFile.BtimeFrozen || !openFile.AtimeFrozen || !openFile.MtimeFrozen || !openFile.CtimeFrozen {
+		t.Fatalf("sentinel did not freeze all four fields: btime=%v atime=%v mtime=%v ctime=%v",
+			openFile.BtimeFrozen, openFile.AtimeFrozen, openFile.MtimeFrozen, openFile.CtimeFrozen)
+	}
+
+	// Rename, which stamps ChangeTime on the renamed inode.
+	resp, err = h.setFileInfoFromStore(smbCtx, authCtx, openFile, types.FileRenameInformation, encodeRenameInfo("link2"))
+	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
+		t.Fatalf("rename SET_INFO: err=%v resp=%v", err, resp)
+	}
+
+	// CLOSE must succeed, or the assertions below prove nothing about what
+	// CLOSE does — it would only prove CLOSE bailed out early.
+	cresp, err := h.Close(smbCtx, &CloseRequest{FileID: fileID})
+	if err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if cresp.GetStatus() != types.StatusSuccess {
+		t.Fatalf("Close status = %v, want STATUS_SUCCESS", cresp.GetStatus())
+	}
+
+	final, err := metaSvc.GetFile(context.Background(), openFile.MetadataHandle)
+	if err != nil {
+		t.Fatalf("GetFile after close: %v", err)
+	}
+	for _, tc := range []struct {
+		name string
+		got  time.Time
+	}{
+		{"CreationTime", final.CreationTime},
+		{"LastAccessTime", final.Atime},
+		{"LastWriteTime", final.Mtime},
+		{"ChangeTime", final.Ctime},
+	} {
+		if !tc.got.Equal(past) {
+			t.Errorf("%s = %v after rename + CLOSE; want the frozen %v", tc.name, tc.got.UTC(), past)
+		}
+	}
+}

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -762,12 +762,9 @@ func (h *Handler) setFileInfoFromStore(
 			oldFileName := oldName.FileName
 			oldParentPath := GetParentPath(oldName.Path)
 
-			// Save mtime/ctime before the rename. MS-FSA 2.1.5.15.12 requires
-			// LastChangeTime to be updated; preserving it matches NTFS, which
-			// defers the update to handle close.
-			restoreTimestamps := h.saveTimestamps(authCtx, openFile.MetadataHandle)
-
-			// Perform the rename
+			// Perform the rename. Move stamps LastChangeTime and leaves
+			// LastModificationTime untouched, which is what MS-FSA
+			// 2.1.5.15.12 asks for; neither is written back afterwards.
 			metaSvc := h.Registry.GetMetadataService()
 			_, err = metaSvc.Move(authCtx, toDir, oldFileName, toDir, toName)
 			if err != nil {
@@ -778,8 +775,10 @@ func (h *Handler) setFileInfoFromStore(
 				return setInfoStatus(common.MapToSMB(err)), nil
 			}
 
-			// Restore mtime/ctime after rename
-			restoreTimestamps()
+			// Move's LastChangeTime stamp is an automatic update, so a
+			// timestamp frozen on this handle has to be put back the same way
+			// WRITE and truncate put theirs back.
+			h.restoreFrozenTimestamps(authCtx, openFile)
 
 			// Clear delete-on-close after rename. Written under the handle
 			// lock: the delete-pending gates and the CLOSE delete-on-close
@@ -1174,12 +1173,6 @@ func (h *Handler) setFileInfoFromStore(
 		oldParentPath := GetParentPath(oldPath)
 		srcParentHandle := oldName.ParentHandle
 
-		// Save mtime/ctime before the rename so we can restore them after.
-		// MS-FSA 2.1.5.15.12 never touches LastModificationTime but does require
-		// LastChangeTime to be updated; preserving both matches NTFS, which
-		// defers that update to handle close.
-		restoreTimestamps := h.saveTimestamps(authCtx, openFile.MetadataHandle)
-
 		// Pre-overwrite the case-mismatched destination: Move's destination
 		// probe is exact-case GetChild(toName), so a destination that exists
 		// under a different casing (e.g. on disk "Foo.txt", client said
@@ -1194,7 +1187,11 @@ func (h *Handler) setFileInfoFromStore(
 			}
 		}
 
-		// Perform the rename/move
+		// Perform the rename/move. Move stamps LastChangeTime and leaves
+		// LastModificationTime untouched, matching MS-FSA 2.1.5.15.12. The
+		// advance stands: writing a stamp back is a write against the file,
+		// not the directory the rename was authorized on, so it would land or
+		// be denied depending on the file's mode.
 		_, err = metaSvc.Move(authCtx, srcParentHandle, oldFileName, toDir, toName)
 		if err != nil {
 			logger.Debug("SET_INFO: rename failed",
@@ -1204,8 +1201,10 @@ func (h *Handler) setFileInfoFromStore(
 			return setInfoStatus(common.MapToSMB(err)), nil
 		}
 
-		// Restore mtime/ctime after rename
-		restoreTimestamps()
+		// Move's LastChangeTime stamp is an automatic update, so a timestamp
+		// frozen on this handle has to be put back the same way WRITE and
+		// truncate put theirs back.
+		h.restoreFrozenTimestamps(authCtx, openFile)
 
 		// Per MS-FSA §2.1.5.15.2 ("FileBasicInformation"): Restore frozen timestamps on parent directories.
 		// Move updates both source and destination parent directory timestamps.
@@ -1758,28 +1757,6 @@ func applyFrozenTimestamps(openFile *OpenFile, file *metadata.File) {
 	}
 	if openFile.AtimeFrozen && openFile.FrozenAtime != nil {
 		file.Atime = *openFile.FrozenAtime
-	}
-}
-
-// saveTimestamps reads the current Mtime and Ctime of a file and returns a
-// restore function that writes them back. Used to preserve timestamps across
-// rename operations. MS-FSA 2.1.5.15.12 leaves LastModificationTime alone but
-// requires LastChangeTime to be updated; preserving both matches NTFS, which
-// defers that update to handle close.
-// Returns a no-op if the read fails.
-func (h *Handler) saveTimestamps(authCtx *metadata.AuthContext, handle metadata.FileHandle) func() {
-	metaSvc := h.Registry.GetMetadataService()
-	file, err := metaSvc.GetFile(authCtx.Context, handle)
-	if err != nil {
-		return func() {}
-	}
-	mtime := file.Mtime
-	ctime := file.Ctime
-	return func() {
-		_, _ = metaSvc.SetFileAttributes(authCtx, handle, &metadata.SetAttrs{
-			Mtime: &mtime,
-			Ctime: &ctime,
-		})
 	}
 }
 

--- a/internal/adapter/smb/handlers/set_info_rename_timestamps_test.go
+++ b/internal/adapter/smb/handlers/set_info_rename_timestamps_test.go
@@ -1,0 +1,142 @@
+// Handler-level coverage for the timestamps a SET_INFO rename leaves behind.
+//
+// Per MS-FSA 2.1.5.15.12 ("FileRenameInformation") a rename updates
+// LastChangeTime and leaves LastModificationTime alone. A rename is authorized
+// on the parent directory, so both must also hold for a caller who may rename
+// the file without being able to write that file's own attributes.
+package handlers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// setupRenameTimestampFixture reuses the BasicInfo timestamp share: it grants
+// the handle DELETE (which is what gates rename) and a tree connection (a
+// rename to a share-root-relative path resolves the root through it), hands
+// the file to fileUID/fileGID, and backdates its timestamps so any advance the
+// rename makes is unambiguous rather than sub-millisecond. Returns the
+// handler, an auth context for the calling identity, the open handle, and the
+// seeded time.
+func setupRenameTimestampFixture(t *testing.T, fileUID, fileGID, callerUID, callerGID uint32) (
+	*Handler, *metadata.AuthContext, *OpenFile, time.Time,
+) {
+	t.Helper()
+
+	h, rootCtx, fileHandle, open := setupBasicInfoTimestampTest(t)
+	access := uint32(types.FileReadAttributes | types.FileWriteAttributes | types.Delete)
+	open.DesiredAccess, open.GrantedAccess = access, access
+	open.TreeID = 1
+	h.StoreTree(&TreeConnection{
+		TreeID:     open.TreeID,
+		ShareName:  open.ShareName,
+		Permission: models.PermissionReadWrite,
+	})
+
+	past := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+	if _, err := h.Registry.GetMetadataService().SetFileAttributes(rootCtx, fileHandle, &metadata.SetAttrs{
+		UID: &fileUID, GID: &fileGID, Mtime: &past, Ctime: &past,
+	}); err != nil {
+		t.Fatalf("seed owner + timestamps: %v", err)
+	}
+
+	callerCtx := &metadata.AuthContext{
+		Context:  context.Background(),
+		Identity: &metadata.Identity{UID: &callerUID, GID: &callerGID},
+	}
+	return h, callerCtx, open, past
+}
+
+// TestSetInfo_Rename_ChangeTimeAdvancesForEveryCaller pins that a rename's
+// LastChangeTime update survives regardless of whether the caller could have
+// written the file's timestamps directly. The two cases differ only in file
+// ownership: both may rename (the parent directory is 0o777), only the owner
+// may set the file's timestamps explicitly. Before the fix the owner's rename
+// put the pre-rename ChangeTime back and the non-owner's did not.
+func TestSetInfo_Rename_ChangeTimeAdvancesForEveryCaller(t *testing.T) {
+	cases := []struct {
+		name                                   string
+		fileUID, fileGID, callerUID, callerGID uint32
+		callerMayWriteTimestamps               bool
+	}{
+		{"caller owns the file", 1000, 1000, 1000, 1000, true},
+		{"caller does not own the file", 1000, 1000, 2000, 2000, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, authCtx, open, past := setupRenameTimestampFixture(t,
+				tc.fileUID, tc.fileGID, tc.callerUID, tc.callerGID)
+			metaSvc := h.Registry.GetMetadataService()
+
+			// Establish that the two cases really do differ in the way the
+			// defect turned on, or they are not measuring anything.
+			probe := past
+			_, wErr := metaSvc.SetFileAttributes(authCtx, open.MetadataHandle, &metadata.SetAttrs{Ctime: &probe})
+			if tc.callerMayWriteTimestamps != (wErr == nil) {
+				t.Fatalf("precondition: caller timestamp write err=%v, want permitted=%v",
+					wErr, tc.callerMayWriteTimestamps)
+			}
+
+			resp, err := h.setFileInfoFromStore(
+				nil, authCtx, open, types.FileRenameInformation, encodeRenameInfo("renamed.txt"))
+			if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
+				t.Fatalf("rename: err=%v resp=%v", err, resp)
+			}
+
+			after, err := metaSvc.GetFile(context.Background(), open.MetadataHandle)
+			if err != nil {
+				t.Fatalf("GetFile after rename: %v", err)
+			}
+			if !after.Ctime.After(past) {
+				t.Errorf("ChangeTime = %v after rename; want an advance past %v (MS-FSA 2.1.5.15.12)",
+					after.Ctime.UTC(), past.UTC())
+			}
+			if !after.Mtime.Equal(past) {
+				t.Errorf("LastWriteTime = %v after rename; want %v unchanged (MS-FSA 2.1.5.15.12 does not update it)",
+					after.Mtime.UTC(), past.UTC())
+			}
+		})
+	}
+}
+
+// TestSetInfo_Rename_FrozenChangeTimeSurvivesRename covers the other half of
+// the rule the test above pins: the rename's LastChangeTime update is an
+// automatic one, so a handle that froze ChangeTime with the -1 sentinel must
+// not see it move. Reads the store directly rather than closing the handle,
+// because CLOSE runs its own frozen-timestamp restore and would mask whether
+// the rename path did anything.
+func TestSetInfo_Rename_FrozenChangeTimeSurvivesRename(t *testing.T) {
+	// Only an owner can freeze a timestamp — the sentinel pins the pre-image
+	// through the same ownership-gated write the restore uses — so there is no
+	// non-owning variant of this case to cover.
+	h, authCtx, open, past := setupRenameTimestampFixture(t, 1000, 1000, 1000, 1000)
+	metaSvc := h.Registry.GetMetadataService()
+
+	freeze := encodeBasicInfo(0, 0, 0, filetimeFreeze, 0)
+	resp, err := h.setFileInfoFromStore(nil, authCtx, open, types.FileBasicInformation, freeze)
+	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
+		t.Fatalf("freeze SET_INFO: err=%v resp=%v", err, resp)
+	}
+	if !open.CtimeFrozen {
+		t.Fatal("sentinel did not freeze ChangeTime; the assertion below would prove nothing")
+	}
+
+	resp, err = h.setFileInfoFromStore(nil, authCtx, open, types.FileRenameInformation, encodeRenameInfo("renamed.txt"))
+	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
+		t.Fatalf("rename: err=%v resp=%v", err, resp)
+	}
+
+	after, err := metaSvc.GetFile(context.Background(), open.MetadataHandle)
+	if err != nil {
+		t.Fatalf("GetFile after rename: %v", err)
+	}
+	if !after.Ctime.Equal(past) {
+		t.Errorf("ChangeTime = %v after renaming a handle with ChangeTime frozen; want the frozen %v",
+			after.Ctime.UTC(), past.UTC())
+	}
+}


### PR DESCRIPTION
Two issues on one seam in the SMB SET_INFO / CLOSE timestamp path. One is a real
defect with a fix; the other's premise does not hold and gets coverage instead.

## #2205 — rename's ChangeTime turned on file mode

`saveTimestamps` snapshotted a file's Mtime and Ctime before `Move` and wrote
them back afterwards, discarding the result:

```go
return func() {
    _, _ = metaSvc.SetFileAttributes(authCtx, handle, &metadata.SetAttrs{
        Mtime: &mtime, Ctime: &ctime,
    })
}
```

A rename is authorized on the **parent directory**; that restore writes the
**file**. The metadata layer requires ownership for an explicit timestamp write
(`file_modify.go`: `!isOwner && !isRoot` → `ErrPermissionDenied`), so a file
whose owner is not the caller, sitting in a directory the caller may write,
renames successfully and then keeps the advanced ChangeTime — while the same
rename on a file the caller owns gets the pre-rename value put back. Same
operation, two observable ChangeTimes, selected by an unchecked permission check
that nothing logged.

Measured on unmodified develop with a memory-backed handler fixture, parent
directory `0o777`, file `0o777` owned by uid 1000:

| caller | restore write | ChangeTime on the open handle |
| --- | --- | --- |
| uid 1000 (owner) | `nil` | pre-rename, preserved |
| uid 2000 (non-owner) | `PermissionDenied: operation not permitted` | post-rename, advanced |

**Fix: let the advance stand.** MS-FSA 2.1.5.15.12 requires the rename to update
LastChangeTime, so the helper and both of its call sites are deleted. This is
identical for every caller regardless of permissions, and it removes the failing
write, so there is no discarded error left to swallow.

The NTFS/ReFS product-note `<187>` behaviour (defer the update to handle CLOSE)
was considered and rejected: it is a much larger change, and #2197 already died
attempting a variant of it.

The Mtime half of the restore was already a no-op. `Service.Move`
(`pkg/metadata/file_modify.go`) stamps only `srcFile.Ctime` on the renamed inode
and carries LastModificationTime through untouched — it was restoring a value
nothing had changed. That is service-layer, so it holds for every backend.

One case must not take the advance: a timestamp frozen on the handle with the
`-1` sentinel, since the rename's stamp is an automatic update and MS-FSA
2.1.5.15.2 forbids those from moving a frozen field. The removed helper was
covering that incidentally, and only for owning callers. Both rename branches
now call `restoreFrozenTimestamps`, the way WRITE and truncate already do, which
puts the case under the single owner of freeze semantics rather than an ad-hoc
snapshot. It cannot reintroduce the divergence above: the sentinel pins the
pre-image through the same ownership-gated write, so a handle carrying a frozen
timestamp belongs to a caller whose restore is permitted.

New test `TestSetInfo_Rename_ChangeTimeAdvancesForEveryCaller` runs the same
rename as an owning and a non-owning caller and asserts ChangeTime advances and
LastWriteTime does not in both. Against unmodified `set_info.go` the owner
subtest fails and the non-owner subtest passes — the exact divergence the issue
describes. `TestSetInfo_Rename_FrozenChangeTimeSurvivesRename` covers the frozen
case and reads the store directly rather than closing the handle, so CLOSE's own
restore cannot mask whether the rename path did anything; deleting the restore
this PR adds fails it.

Closes #2205

## #2196 — premise refuted, no defect on this path

#2196 reported that `restoreFrozenTimestamps` drops a frozen ChangeTime across
rename + CLOSE, inferring from the absence of a `restoreFrozenTimestamps:
restoring` debug line that the restore never reaches its write.

It does reach its write. Driven end to end through the protocol handlers —
freeze all four fields with the SET_INFO `-1` sentinel, rename, CLOSE
(asserting `STATUS_SUCCESS`) — CreationTime, LastAccessTime, LastWriteTime and
ChangeTime all come back frozen.

The reproduction failed for a fixture reason. It seeded `CtimeFrozen` /
`FrozenCtime` directly onto the `OpenFile` struct, on a file `setupReparseShare`
creates as root while CLOSE authenticates as another user. That combination is
not reachable through the protocol: SET_INFO's `-1` sentinel pins the pre-image
through the same `SetFileAttributes` write the restore uses, so a caller who
cannot restore a timestamp cannot freeze one either — SET_INFO returns
`STATUS_ACCESS_DENIED` and no freeze flag is set. Measured:

| caller | `SET_INFO(ChangeTime = -1)` | `CtimeFrozen` |
| --- | --- | --- |
| owner | `STATUS_SUCCESS` | true |
| non-owner | `STATUS_ACCESS_DENIED` | false |

Freeze and restore are gated identically, on the same identity and the same
file, so the two cannot disagree.

The missing debug line is not evidence either way: handler tests run at INFO, so
no `Debug` line appears for anything.

Scope was checked across all four fields and all five callers rather than only
the one that was probed. `buildFrozenAttrs` builds CreationTime, Mtime, Ctime
and Atime together and the test asserts all four. `restoreFrozenTimestamps` has
five callers — WRITE, COPYCHUNK, two in SET_INFO, and CLOSE — and the four
non-CLOSE ones each set `WriteAuthorizedByHandle` from the handle's
`GrantedAccess` first. That flag does not reach the explicit-timestamp gate
(which is the flat ownership check above, decided before
`checkWritePermission` is consulted), so it makes no difference to this path
either way.

`TestClose_FrozenTimestampsSurviveRename` pins the working behaviour. Removing
the CLOSE-time `restoreFrozenTimestamps` call fails it on ChangeTime, so it
observes the mechanism rather than the fixture.

Closes #2196

## Adjacent findings, not fixed here

- `restoreParentDirFrozenTimestamps` **is** broken by the same ownership gate,
  and unlike the CLOSE path it is reachable: the freeze belongs to whoever holds
  the open directory handle, while the restore is driven by another user's child
  create / rename / delete with that user's identity. Measured — the directory's
  frozen Mtime and Ctime are lost when the child rename comes from a caller who
  does not own the directory, and survive when the caller may write them. Fixing it needs the
  restore to run under the frozen handle's own principal
  (`buildOpenerAuthContext`), which means threading an `*SMBHandlerContext`
  through five call sites; out of scope here.
- Underneath both: SMB grants the right to set timestamps with
  `FILE_WRITE_ATTRIBUTES`, while the metadata layer requires POSIX ownership for
  an explicit timestamp write and `WriteAuthorizedByHandle` does not bridge it.
  A non-owner holding a handle with `FILE_WRITE_ATTRIBUTES` therefore cannot set
  a timestamp over SMB at all.

## Verification

`go build ./... && go vet ./... && gofmt -l` clean; full `go test ./...` green.
Every new test was run against a deliberately broken build before being trusted,
and seen to fail:

- `TestSetInfo_Rename_ChangeTimeAdvancesForEveryCaller` against unmodified
  `set_info.go` — the owning-caller subtest fails, the non-owning one passes,
  which is the divergence itself.
- `TestSetInfo_Rename_FrozenChangeTimeSurvivesRename` with the rename-path
  `restoreFrozenTimestamps` call removed — fails on ChangeTime.
- `TestClose_FrozenTimestampsSurviveRename` with the CLOSE-time
  `restoreFrozenTimestamps` call removed — fails on ChangeTime.
