### PR TITLE
test(smbtorture): skip the create benchmark subtest and reap the one-off client container

### DIFF
--- a/test/smb-conformance/smbtorture/run.sh
+++ b/test/smb-conformance/smbtorture/run.sh
@@ -20,9 +20,9 @@ CONFORMANCE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 VALID_PROFILES=("memory" "memory-fs" "badger-fs" "sqlite" "postgres" "memory-kerberos")
 
-# Name given to every one-off smbtorture container, so a client the CLI failed
-# to stop can still be found and removed. Scoped to this harness process so a
-# container leaked by an earlier one can never block the name.
+# Name given to every one-off smbtorture container so it stays addressable (see
+# run_smbtorture). Scoped to this harness process so a container leaked by an
+# earlier one can never block the name.
 SMBTORTURE_RUN_NAME="smbtorture-run-$$"
 
 # --------------------------------------------------------------------------
@@ -226,9 +226,9 @@ fi
 cleanup() {
     local exit_code=$?
 
-    # Reap the one-off client even under --keep: it holds no state worth
-    # inspecting (its output is already teed to the results file) and a wedged
-    # one spins a core for as long as it is left alive.
+    # Reaped even under --keep: the client holds no state worth inspecting, its
+    # output is already teed to the results file, and the compose down below
+    # does not cover one-off run containers.
     docker rm -f "$SMBTORTURE_RUN_NAME" >/dev/null 2>&1 || true
 
     if ! $KEEP; then
@@ -461,9 +461,8 @@ run_smbtorture() {
     # timeout fires, the CLI dies, --rm never runs, and the container keeps a
     # core busy for as long as the daemon is up. A panicked smbtorture reaches
     # exactly that state — smb_panic stops emitting output without exiting.
-    # Naming the one-off container makes it addressable, so it can be removed
-    # here whatever the CLI did or did not manage to tear down. Removing a
-    # container that already exited via --rm is a no-op.
+    # `docker compose down -v` in cleanup does not reap one-off run containers,
+    # so the name is what makes this removable at all.
     docker rm -f "$SMBTORTURE_RUN_NAME" >/dev/null 2>&1 || true
     # Classify the exit code (see _smbtorture_exit handling at end of file):
     #   124            -> the per-suite timeout fired: the harness gave up on this
@@ -629,9 +628,11 @@ else
         # client's own timer can resolve trips the assert, smbtorture panics
         # and the process stops emitting without exiting, so the rest of
         # smb2.create burns the budget ungraded. The same reasoning already
-        # excludes the whole smb2.bench family below; that exclusion is keyed
+        # excludes the whole smb2.bench family above; that exclusion is keyed
         # on the smb2.bench filter, which does not reach this copy of the
-        # benchmark inside a functional suite.
+        # benchmark inside a functional suite. Collapse these back into a
+        # single smb2.create entry once the benchmark no longer ships inside
+        # the create suite.
         "smb2.create.gentest:create"
         "smb2.create.blob:create"
         "smb2.create.open:create"
@@ -819,10 +820,12 @@ else
     # NOTE: Skipped interactive hold tests:
     #   smb2.hold-oplock    - waits 5 min for oplock events (no real test)
     #   smb2.hold-sharemode - blocks indefinitely waiting for SIGINT
-    # Also skipped: smb2.bench and smb2.create.bench-path-contention-shared
-    # (throughput benchmarks — flaky under load, no conformance signal; see the
-    # SUITES list above).
-    log_warn "Skipped: smb2.hold-oplock, smb2.hold-sharemode (interactive hold tests), smb2.bench and smb2.create.bench-path-contention-shared (benchmarks)"
+    # Also skipped: smb2.bench (throughput benchmarks — flaky under load, no
+    # conformance signal) and smb2.create.bench-path-contention-shared (the
+    # same benchmark reachable from inside a functional suite; see the SUITES
+    # list above for why it panics the client). Run them ad hoc with
+    # `--filter smb2.bench` and `--filter smb2.create.bench-path-contention-shared`.
+    log_warn "Skipped: smb2.hold-oplock, smb2.hold-sharemode (interactive hold tests), smb2.bench, smb2.create.bench-path-contention-shared (benchmarks)"
 fi
 
 # Collect DittoFS logs

--- a/test/smb-conformance/smbtorture/run.sh
+++ b/test/smb-conformance/smbtorture/run.sh
@@ -819,9 +819,10 @@ else
     # NOTE: Skipped interactive hold tests:
     #   smb2.hold-oplock    - waits 5 min for oplock events (no real test)
     #   smb2.hold-sharemode - blocks indefinitely waiting for SIGINT
-    # Also skipped: smb2.bench (throughput benchmarks — flaky under load, no
-    # conformance signal; see the SUITES list above).
-    log_warn "Skipped: smb2.hold-oplock, smb2.hold-sharemode (interactive hold tests), smb2.bench (benchmarks)"
+    # Also skipped: smb2.bench and smb2.create.bench-path-contention-shared
+    # (throughput benchmarks — flaky under load, no conformance signal; see the
+    # SUITES list above).
+    log_warn "Skipped: smb2.hold-oplock, smb2.hold-sharemode (interactive hold tests), smb2.bench and smb2.create.bench-path-contention-shared (benchmarks)"
 fi
 
 # Collect DittoFS logs

--- a/test/smb-conformance/smbtorture/run.sh
+++ b/test/smb-conformance/smbtorture/run.sh
@@ -20,6 +20,11 @@ CONFORMANCE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 VALID_PROFILES=("memory" "memory-fs" "badger-fs" "sqlite" "postgres" "memory-kerberos")
 
+# Name given to every one-off smbtorture container, so a client the CLI failed
+# to stop can still be found and removed. Scoped to this harness process so a
+# container leaked by an earlier one can never block the name.
+SMBTORTURE_RUN_NAME="smbtorture-run-$$"
+
 # --------------------------------------------------------------------------
 # Colors
 # --------------------------------------------------------------------------
@@ -220,6 +225,11 @@ fi
 # --------------------------------------------------------------------------
 cleanup() {
     local exit_code=$?
+
+    # Reap the one-off client even under --keep: it holds no state worth
+    # inspecting (its output is already teed to the results file) and a wedged
+    # one spins a core for as long as it is left alive.
+    docker rm -f "$SMBTORTURE_RUN_NAME" >/dev/null 2>&1 || true
 
     if ! $KEEP; then
         log_step "Cleaning up containers..."
@@ -436,16 +446,25 @@ run_smbtorture() {
     local rc=0
     if [[ -n "$suite_prefix" ]]; then
         ${TIMEOUT_CMD:+$TIMEOUT_CMD --signal=TERM --kill-after=30 "$per_timeout"} \
-            env PROFILE="$PROFILE" docker compose run --rm "$SMBTORTURE_SERVICE" \
+            env PROFILE="$PROFILE" docker compose run --rm --name "$SMBTORTURE_RUN_NAME" "$SMBTORTURE_SERVICE" \
             "$target" "${SMBTORTURE_AUTH_ARGS[@]}" "$filter" \
             2>&1 | sed -E "s/^(test|success|failure|error|skip): /\1: ${suite_prefix}./" \
             | tee -a "${RESULTS_DIR}/smbtorture-output.txt" || rc=${PIPESTATUS[0]}
     else
         ${TIMEOUT_CMD:+$TIMEOUT_CMD --signal=TERM --kill-after=30 "$per_timeout"} \
-            env PROFILE="$PROFILE" docker compose run --rm "$SMBTORTURE_SERVICE" \
+            env PROFILE="$PROFILE" docker compose run --rm --name "$SMBTORTURE_RUN_NAME" "$SMBTORTURE_SERVICE" \
             "$target" "${SMBTORTURE_AUTH_ARGS[@]}" "$filter" \
             2>&1 | tee -a "${RESULTS_DIR}/smbtorture-output.txt" || rc=${PIPESTATUS[0]}
     fi
+    # Killing `docker compose run` kills the CLI, not the container it started,
+    # and a client that stops responding to its own SIGTERM outlives both: the
+    # timeout fires, the CLI dies, --rm never runs, and the container keeps a
+    # core busy for as long as the daemon is up. A panicked smbtorture reaches
+    # exactly that state — smb_panic stops emitting output without exiting.
+    # Naming the one-off container makes it addressable, so it can be removed
+    # here whatever the CLI did or did not manage to tear down. Removing a
+    # container that already exited via --rm is a no-op.
+    docker rm -f "$SMBTORTURE_RUN_NAME" >/dev/null 2>&1 || true
     # Classify the exit code (see _smbtorture_exit handling at end of file):
     #   124            -> the per-suite timeout fired: the harness gave up on this
     #                     filter. Whatever the suite had not reached yet produced
@@ -603,7 +622,33 @@ else
         "smb2.compound:compound"
         "smb2.compound_async:compound_async"
         "smb2.compound_find:compound_find"
-        "smb2.create:create"
+        # smb2.create is run per-subtest with smb2.create.bench-path-contention-shared
+        # skipped: that subtest is a throughput benchmark, not a conformance
+        # test, and it asserts client-side that every measured round-trip is
+        # at least a microsecond. A round-trip that completes faster than the
+        # client's own timer can resolve trips the assert, smbtorture panics
+        # and the process stops emitting without exiting, so the rest of
+        # smb2.create burns the budget ungraded. The same reasoning already
+        # excludes the whole smb2.bench family below; that exclusion is keyed
+        # on the smb2.bench filter, which does not reach this copy of the
+        # benchmark inside a functional suite.
+        "smb2.create.gentest:create"
+        "smb2.create.blob:create"
+        "smb2.create.open:create"
+        "smb2.create.brlocked:create"
+        "smb2.create.multi:create"
+        "smb2.create.delete:create"
+        "smb2.create.leading-slash:create"
+        "smb2.create.impersonation:create"
+        "smb2.create.aclfile:create"
+        "smb2.create.acldir:create"
+        "smb2.create.nulldacl:create"
+        "smb2.create.mkdir-dup:create"
+        "smb2.create.mkdir-visible:create"
+        "smb2.create.dir-alloc-size:create"
+        "smb2.create.dosattr_tmp_dir:create"
+        "smb2.create.quota-fake-file:create"
+        "smb2.create.path-length:create"
         "smb2.create_no_streams:create_no_streams:create_no_streams"
         "smb2.credits:credits"
         "smb2.delete-on-close-perms:delete-on-close-perms"


### PR DESCRIPTION
`smb2.create` contains a throughput benchmark, `bench-path-contention-shared`,
which asserts client-side that every measured round-trip took at least a
microsecond. When one completes faster than smbtorture's own timer can resolve,
the assert trips and `smb_panic` fires. The process then stops emitting output
without exiting, so the rest of `smb2.create` burns its 300s budget ungraded and
lands in `timeouts.txt` with no sign-off — a job failure since #2168.

Nothing in the backtrace is server-side, and the test had been reporting healthy
numbers immediately before. This is a client-side timing assert, not a DittoFS
stall.

Two independent fixes.

## 1. Stop running the benchmark

The `SUITES` list already excludes the whole `smb2.bench` family for exactly
this reason, and says so. But that exclusion is keyed on the `smb2.bench`
filter, and the same benchmark is also reachable as
`smb2.create.bench-path-contention-shared`, inside a functional suite that is
very much run. The decision had been made and then bypassed by the suite layout.

`smb2.create` now runs per-subtest — the same treatment already applied to
`smb2.notify`, `smb2.scan` and `smb2.dirlease` — listing the 17 conformance
subtests and omitting the benchmark. Test-line prefixes are unchanged
(`create.gentest`, …), so `KNOWN_FAILURES.md` matching is unaffected.

The 17 names were checked exhaustively against the pinned client rather than
copied from a previous run. `smbtorture --list` on
`quay.io/samba.org/samba-toolbox:v0.8` reports exactly 18 `smb2.create`
subtests; the set difference against the new `SUITES` entries is exactly one
entry in one direction and empty in the other:

```
upstream=18 harness=17
--- in upstream but NOT run by the harness:
smb2.create.bench-path-contention-shared
--- in the harness but NOT a real upstream test:
(empty)
```

Each of the 17 was then resolved as an actual filter against the pinned image,
with a deliberate typo as the control so the check is known to be capable of
failing:

```
smb2.create.gentest      -> Failed to connect ... NT_STATUS_NO_MEMORY   (filter resolved)
smb2.create.path-length  -> Failed to connect ... NT_STATUS_NO_MEMORY   (filter resolved)
smb2.create.gentestXX    -> Unknown torture operation 'smb2.create.gentestXX'
```

All 17 resolve; none is silently dropped. This matches
`source4/torture/smb2/create.c:torture_smb2_create_init()` at samba-4.22.6.

## 2. Stop leaking the container

`timeout --signal=TERM --kill-after=30 ... docker compose run --rm` kills the
CLI, not the container it started. A client that no longer responds to SIGTERM
outlives both, `--rm` never fires, and the container keeps a core busy for as
long as the daemon is up. A panicked smbtorture is exactly that: `smb_panic`
stops producing output without exiting, and the reporter found the container
still `Up` two hours later at `C 99`.

The one-off container now gets an explicit name and is removed after every
invocation and in the EXIT trap.

**This was reproduced deliberately rather than assumed.** A throwaway compose
project with a container that ignores SIGTERM as PID 1 — the same condition as
smbtorture, which panics at `pid 1` — driven through the harness's exact
`timeout` invocation:

```
### BEFORE (no --name, no reap)
timeout --signal=TERM --kill-after=30 5 docker compose run --rm wedged
--- containers still Up:
leak2203-wedged-run-68ceb437b90f  Up 6 seconds
--- CPU of the leaked container:
leak2203-wedged-run-68ceb437b90f  CPU=99.89%
```

The CPU figure reproduces the reported `C 99` independently.

**The existing EXIT-trap cleanup does not cover this**, which is why the
container survived every subsequent run — `docker compose down -v` leaves
one-off `docker compose run` containers behind:

```
--- does 'docker compose down -v' at EXIT reap it?
 Network leak2203_default  Removing
 Network leak2203_default  Resource is still in use
still up: leak2203-wedged-run-68ceb437b90f  Up 16 seconds
```

That is the reason for naming the container rather than just adding a `down`.
With the fix's shape the wedged container is still orphaned by the timeout, and
is then reaped by name:

```
### AFTER (--name + docker rm -f following the timeout)
--- immediately after the CLI was killed:
smbtorture-run-8838  Up 6 seconds
--- after the reap the fix performs:
(empty — reaped)
--- reap when the container already exited via --rm:
no-op reap rc=0
```

## On the rate data

1 occurrence in 5 local runs (linux/amd64 under Rosetta on an arm64 host), 0 in
10 native-amd64 CI runs where it graded `success` every time. It is currently a
local-only flake — but it is a *timing* assert, and a fast enough runner is
precisely the trigger, so the CI record is not evidence that it is structurally
immune. Half 2 is worth doing on its own regardless: a leaked container spinning
a core survives the run that spawned it and every run after it.

## Verification

- `bash -n test/smb-conformance/smbtorture/run.sh` clean.
- `test/smb-conformance/smbtorture/parse-results_test.sh` — all grading tests pass.
- Subtest list and filter resolution verified against the pinned client as above.
- Container reap reproduced and verified as above.
- `KNOWN_FAILURES.md` is untouched: `create.bench-path-contention-shared` has no
  active row (it appears only in a 2026-04-24 changelog entry recording its
  removal), so nothing is left stale by no longer running it.

The behavioural half — 17 graded `create.*` lines and no
`create.bench-path-contention-shared` — is confirmed by this PR's own
`smbtorture / memory` and `smbtorture / badger-fs` jobs on native amd64.

Closes #2203
