### PR TITLE
fix(smb): answer a CHANGE_NOTIFY that registers after a directory is marked deleted

### DIFF
--- a/internal/adapter/smb/handlers/change_notify.go
+++ b/internal/adapter/smb/handlers/change_notify.go
@@ -353,7 +353,7 @@ type NotifyRegistry struct {
 	closeTombstones map[string]time.Time
 
 	// deletePendingDirs records directories whose delete disposition has been
-	// committed, keyed by (share, watch path). CompleteWatchersForDeletePending
+	// committed, keyed by (share, watch path). MarkDirectoryDeletePending
 	// sweeps the watches that are registered at that moment; this marker covers
 	// the ones that register afterwards, which that sweep cannot see and which
 	// nothing else would ever complete — the directory entry is still there

--- a/internal/adapter/smb/handlers/change_notify.go
+++ b/internal/adapter/smb/handlers/change_notify.go
@@ -364,19 +364,17 @@ type NotifyRegistry struct {
 	// must not become so. Those two cover a goroutine-scheduling race and are
 	// correct to expire; this one is the directory's own state. A TTL here
 	// would reinstate the hang for every CHANGE_NOTIFY arriving after it.
+	// ClearDeletePendingMark documents when entries are dropped.
 	//
-	// Entries are dropped when the entry actually goes away and the name can be
-	// reused, and when the disposition that set them is explicitly cleared —
-	// a marker that outlives the deletion is a directory that can never be
-	// watched again.
-	//
-	// ponytail: an entry for a directory whose delete-disposition was set but
-	// whose removal then failed for a reason nothing clears (a non-empty
-	// directory whose opener never retries) is retained for the process
-	// lifetime. One small entry per such path, so the ceiling is the number of
-	// distinct directories a client marks and abandons. Tie it to the
-	// directory's last open handle only if a workload is found that marks
-	// enough of them to show up in a heap profile.
+	// ponytail: an entry survives when nothing on the SMB close path retires
+	// it — a marked directory removed instead by an NFS RMDIR on the same
+	// share, which does not reach this registry at all. Such a path answers
+	// STATUS_DELETE_PENDING to a directory later created under the same name.
+	// The bound on that is the wider gap that SMB watches do not observe
+	// NFS-side changes in the first place: close it by driving the marker off
+	// the metadata store's own removal rather than off the SMB close paths,
+	// once anything else about cross-protocol notify fidelity is worth
+	// building. One small entry per abandoned path until then.
 	deletePendingDirs map[notifyDirKey]struct{}
 
 	// flushDelay is the per-registry accumulation window for buffered events.
@@ -894,10 +892,8 @@ func (r *NotifyRegistry) Register(notify *PendingNotify) error {
 	// Checked after the two tombstones above so a cancelled or closing request
 	// keeps the answer its own lifecycle owes it: a client that cancelled has
 	// stopped waiting, and a closing handle is owed STATUS_NOTIFY_CLEANUP.
-	if _, marked := r.deletePendingDirs[notifyDirKey{
-		ShareName: notify.ShareName,
-		Path:      notifyWatchPath(notify.WatchPath),
-	}]; marked {
+	dirKey := notifyDirKey{ShareName: notify.ShareName, Path: notifyWatchPath(notify.WatchPath)}
+	if _, marked := r.deletePendingDirs[dirKey]; marked {
 		logger.Debug("NotifyRegistry: register short-circuited by delete-pending directory",
 			"connID", notify.ConnID,
 			"messageID", notify.MessageID,
@@ -1797,14 +1793,37 @@ func (r *NotifyRegistry) deliverChanges(notify *PendingNotify, changes []FileNot
 // Watchers on ancestor directories are untouched even when recursive: their
 // subject still exists. They learn about the removal as a normal
 // FileActionRemoved event when the entry actually goes away.
+//
+// This is the sweep alone: it records nothing. Both close paths remove the
+// directory entry BEFORE they call it — CLOSE removes in step 8 and sweeps in
+// step 9, and the session/tree teardown removes in handleDeleteOnClose before
+// its docDirs loop — so by the time they get here the name is already free, and
+// a sticky marker recorded from here would outlive the directory it describes.
+// Marking is MarkDirectoryDeletePending's job, on the disposition path where
+// the directory is still there.
 func (r *NotifyRegistry) CompleteWatchersForDeletePending(shareName, dirPath string) int {
+	return r.completeWatchersForDeletePending(shareName, dirPath, false)
+}
+
+// MarkDirectoryDeletePending sweeps the directory's registered watchers exactly
+// as CompleteWatchersForDeletePending does, and additionally records the sticky
+// marker that answers the CHANGE_NOTIFYs registering after this moment.
+//
+// The sweep and the marker are written under one acquisition of the registry
+// mutex, and that is the point: performed as two calls, a Register slips
+// between them, misses the sweep because it is not registered yet and misses
+// the marker because it is not recorded yet, and parks forever.
+func (r *NotifyRegistry) MarkDirectoryDeletePending(shareName, dirPath string) int {
+	return r.completeWatchersForDeletePending(shareName, dirPath, true)
+}
+
+func (r *NotifyRegistry) completeWatchersForDeletePending(shareName, dirPath string, sticky bool) int {
 	dirPath = notifyWatchPath(dirPath)
 
 	r.mu.Lock()
-	// Record the mark before sweeping. The sweep only reaches watches that are
-	// registered right now; the marker is what answers the ones that register
-	// afterwards.
-	r.deletePendingDirs[notifyDirKey{ShareName: shareName, Path: dirPath}] = struct{}{}
+	if sticky {
+		r.deletePendingDirs[notifyDirKey{ShareName: shareName, Path: dirPath}] = struct{}{}
+	}
 	var marked []*PendingNotify
 	for _, w := range r.pending[dirPath] {
 		if w.ShareName == shareName {
@@ -1819,7 +1838,7 @@ func (r *NotifyRegistry) CompleteWatchersForDeletePending(shareName, dirPath str
 	for _, w := range marked {
 		r.sendFinalGated(w, &ChangeNotifyResponse{
 			SMBResponseBase: SMBResponseBase{Status: types.StatusDeletePending},
-		}, "CompleteWatchersForDeletePending")
+		}, "completeWatchersForDeletePending")
 	}
 
 	if len(marked) > 0 {
@@ -1832,7 +1851,7 @@ func (r *NotifyRegistry) CompleteWatchersForDeletePending(shareName, dirPath str
 }
 
 // ClearDeletePendingMark drops the delete-pending marker
-// CompleteWatchersForDeletePending recorded for a directory, so a later
+// MarkDirectoryDeletePending recorded for a directory, so a later
 // CHANGE_NOTIFY on that name registers normally again.
 //
 // Called when the marked directory entry actually goes away and the name

--- a/internal/adapter/smb/handlers/change_notify.go
+++ b/internal/adapter/smb/handlers/change_notify.go
@@ -352,6 +352,33 @@ type NotifyRegistry struct {
 	// then wait forever. Keyed by FileID, expiring on cancelTombstoneTTL.
 	closeTombstones map[string]time.Time
 
+	// deletePendingDirs records directories whose delete disposition has been
+	// committed, keyed by (share, watch path). CompleteWatchersForDeletePending
+	// sweeps the watches that are registered at that moment; this marker covers
+	// the ones that register afterwards, which that sweep cannot see and which
+	// nothing else would ever complete — the directory entry is still there
+	// (the watcher's own handle holds it open), so no FileActionRemoved is
+	// produced for it either, and the client waits forever.
+	//
+	// Unlike cancelTombstones and closeTombstones this is NOT time-based, and
+	// must not become so. Those two cover a goroutine-scheduling race and are
+	// correct to expire; this one is the directory's own state. A TTL here
+	// would reinstate the hang for every CHANGE_NOTIFY arriving after it.
+	//
+	// Entries are dropped when the entry actually goes away and the name can be
+	// reused, and when the disposition that set them is explicitly cleared —
+	// a marker that outlives the deletion is a directory that can never be
+	// watched again.
+	//
+	// ponytail: an entry for a directory whose delete-disposition was set but
+	// whose removal then failed for a reason nothing clears (a non-empty
+	// directory whose opener never retries) is retained for the process
+	// lifetime. One small entry per such path, so the ceiling is the number of
+	// distinct directories a client marks and abandons. Tie it to the
+	// directory's last open handle only if a workload is found that marks
+	// enough of them to show up in a heap profile.
+	deletePendingDirs map[notifyDirKey]struct{}
+
 	// flushDelay is the per-registry accumulation window for buffered events.
 	// Defaults to notifyFlushDelay (100µs) in production. Tests that drive
 	// delivery synchronously via FlushAll set this to a large value so the
@@ -426,18 +453,28 @@ type notifyMsgKey struct {
 	MessageID uint64
 }
 
+// notifyDirKey names a directory by share and share-relative watch path. It is
+// deliberately not handle-scoped: the state it keys outlives the handle that
+// produced it and must be visible to a CHANGE_NOTIFY arriving on a handle that
+// did not exist when the state was written.
+type notifyDirKey struct {
+	ShareName string
+	Path      string
+}
+
 // NewNotifyRegistry creates a new notify registry.
 func NewNotifyRegistry() *NotifyRegistry {
 	return &NotifyRegistry{
-		pending:          make(map[string][]*PendingNotify),
-		byFileID:         make(map[string][]*PendingNotify),
-		byMsgKey:         make(map[notifyMsgKey]*PendingNotify),
-		byAsyncId:        make(map[uint64]*PendingNotify),
-		inFlightNotify:   make(map[string][]notifyMsgKey),
-		armed:            make(map[string]*armedHandle),
-		cancelTombstones: make(map[notifyMsgKey]time.Time),
-		closeTombstones:  make(map[string]time.Time),
-		flushDelay:       notifyFlushDelay,
+		pending:           make(map[string][]*PendingNotify),
+		byFileID:          make(map[string][]*PendingNotify),
+		byMsgKey:          make(map[notifyMsgKey]*PendingNotify),
+		byAsyncId:         make(map[uint64]*PendingNotify),
+		inFlightNotify:    make(map[string][]notifyMsgKey),
+		armed:             make(map[string]*armedHandle),
+		cancelTombstones:  make(map[notifyMsgKey]time.Time),
+		closeTombstones:   make(map[string]time.Time),
+		deletePendingDirs: make(map[notifyDirKey]struct{}),
+		flushDelay:        notifyFlushDelay,
 	}
 }
 
@@ -549,6 +586,12 @@ func (r *NotifyRegistry) CancelByMessageID(connID, messageID uint64) *PendingNot
 // respond with STATUS_NOTIFY_CLEANUP synchronously instead of registering a
 // watch on a handle that is going away.
 var ErrHandleClosed = fmt.Errorf("change_notify handle closed before register")
+
+// ErrDirectoryDeletePending is returned from Register when the watched
+// directory's delete disposition was already committed. The handler must
+// respond with STATUS_DELETE_PENDING synchronously instead of registering a
+// watch that the mark-time sweep has already run past.
+var ErrDirectoryDeletePending = fmt.Errorf("change_notify directory marked for deletion before register")
 
 // CloseByFileID is the single completion path for a handle that is going
 // away. Under one acquisition of r.mu it disarms the handle's buffered-event
@@ -843,6 +886,25 @@ func (r *NotifyRegistry) Register(notify *PendingNotify) error {
 		return ErrHandleClosed
 	}
 	r.gcCloseTombstonesLocked()
+
+	// The directory's delete disposition was committed before this request
+	// arrived. Answer it now instead of parking a watch that the mark-time
+	// sweep has already passed and that nothing else will ever complete.
+	//
+	// Checked after the two tombstones above so a cancelled or closing request
+	// keeps the answer its own lifecycle owes it: a client that cancelled has
+	// stopped waiting, and a closing handle is owed STATUS_NOTIFY_CLEANUP.
+	if _, marked := r.deletePendingDirs[notifyDirKey{
+		ShareName: notify.ShareName,
+		Path:      notifyWatchPath(notify.WatchPath),
+	}]; marked {
+		logger.Debug("NotifyRegistry: register short-circuited by delete-pending directory",
+			"connID", notify.ConnID,
+			"messageID", notify.MessageID,
+			"share", notify.ShareName,
+			"path", notify.WatchPath)
+		return ErrDirectoryDeletePending
+	}
 
 	// A watch already registered on this FileID is NOT replaced: the client is
 	// entitled to keep several CHANGE_NOTIFYs outstanding on one handle and
@@ -1739,6 +1801,10 @@ func (r *NotifyRegistry) CompleteWatchersForDeletePending(shareName, dirPath str
 	dirPath = notifyWatchPath(dirPath)
 
 	r.mu.Lock()
+	// Record the mark before sweeping. The sweep only reaches watches that are
+	// registered right now; the marker is what answers the ones that register
+	// afterwards.
+	r.deletePendingDirs[notifyDirKey{ShareName: shareName, Path: dirPath}] = struct{}{}
 	var marked []*PendingNotify
 	for _, w := range r.pending[dirPath] {
 		if w.ShareName == shareName {
@@ -1763,6 +1829,29 @@ func (r *NotifyRegistry) CompleteWatchersForDeletePending(shareName, dirPath str
 			"count", len(marked))
 	}
 	return len(marked)
+}
+
+// ClearDeletePendingMark drops the delete-pending marker
+// CompleteWatchersForDeletePending recorded for a directory, so a later
+// CHANGE_NOTIFY on that name registers normally again.
+//
+// Called when the marked directory entry actually goes away and the name
+// becomes available for reuse, and when an opener explicitly clears the
+// disposition that set the marker. Without both, a directory that was marked
+// and then survived — the deletion cancelled, or the removal refused — could
+// never be watched again for the life of the process.
+func (r *NotifyRegistry) ClearDeletePendingMark(shareName, dirPath string) {
+	key := notifyDirKey{ShareName: shareName, Path: notifyWatchPath(dirPath)}
+	r.mu.Lock()
+	_, had := r.deletePendingDirs[key]
+	delete(r.deletePendingDirs, key)
+	r.mu.Unlock()
+
+	if had {
+		logger.Debug("CHANGE_NOTIFY: cleared directory delete-pending marker",
+			"path", key.Path,
+			"share", shareName)
+	}
 }
 
 // MarkNotifyInFlight records that a CHANGE_NOTIFY for fileID has been read off

--- a/internal/adapter/smb/handlers/change_notify_test.go
+++ b/internal/adapter/smb/handlers/change_notify_test.go
@@ -3800,3 +3800,147 @@ func TestBufferEventLocked_InterleavedEmissionsDoNotMerge(t *testing.T) {
 		{Action: FileActionAdded, FileName: "a2"},
 	})
 }
+
+// TestRegisterAfterDeletePendingMark covers the ordering the mark-time sweep
+// cannot: a CHANGE_NOTIFY that reaches Register after the directory's delete
+// disposition has already been committed. The sweep has nothing left to walk,
+// the directory entry is still there because the watcher's own handle holds it
+// open, and so nothing produces a FileActionRemoved for it either — without a
+// marker consulted at Register the request parks forever.
+func TestRegisterAfterDeletePendingMark(t *testing.T) {
+	r := newTestNotifyRegistry()
+
+	newNotify := func(fileID byte, messageID uint64, share, watchPath string) *PendingNotify {
+		return &PendingNotify{
+			FileID:           [16]byte{fileID},
+			SessionID:        1,
+			MessageID:        messageID,
+			AsyncId:          messageID * 10,
+			WatchPath:        watchPath,
+			ShareName:        share,
+			CompletionFilter: FileNotifyChangeFileName | FileNotifyChangeDirName,
+			MaxOutputLength:  4096,
+			AsyncCallback:    func(uint64, uint64, uint64, *ChangeNotifyResponse) error { return nil },
+		}
+	}
+
+	// Nothing is registered yet, so the sweep answers nobody.
+	if got := r.CompleteWatchersForDeletePending("share1", "/parent/target"); got != 0 {
+		t.Fatalf("expected the sweep to find no watchers, got %d", got)
+	}
+
+	// The late arrival must be refused, not parked.
+	err := r.Register(newNotify(1, 10, "share1", "/parent/target"))
+	if !errors.Is(err, ErrDirectoryDeletePending) {
+		t.Fatalf("Register on a delete-pending directory: got %v, want ErrDirectoryDeletePending", err)
+	}
+	if n := r.WatcherCount(); n != 0 {
+		t.Fatalf("a refused Register must leave no watcher behind, got %d", n)
+	}
+
+	// A trailing "/" or "." spelling of the same directory is the same
+	// directory: notifyWatchPath normalises both sides of the comparison.
+	if err := r.Register(newNotify(2, 11, "share1", "/parent/target/")); !errors.Is(err, ErrDirectoryDeletePending) {
+		t.Errorf("unnormalised path: got %v, want ErrDirectoryDeletePending", err)
+	}
+
+	// The mark is scoped to one directory on one share. An ancestor and a
+	// same-named directory on another share are unaffected.
+	if err := r.Register(newNotify(3, 12, "share1", "/parent")); err != nil {
+		t.Errorf("ancestor directory must still register: %v", err)
+	}
+	if err := r.Register(newNotify(4, 13, "share2", "/parent/target")); err != nil {
+		t.Errorf("same path on another share must still register: %v", err)
+	}
+}
+
+// TestClearDeletePendingMark pins the other half: the marker is sticky for the
+// directory, not permanent for the name. Once the entry is gone (or the
+// disposition is called off) the name must be watchable again, or a directory
+// created later under the same name can never be watched.
+func TestClearDeletePendingMark(t *testing.T) {
+	r := newTestNotifyRegistry()
+
+	notify := func(fileID byte, messageID uint64) *PendingNotify {
+		return &PendingNotify{
+			FileID:           [16]byte{fileID},
+			SessionID:        1,
+			MessageID:        messageID,
+			AsyncId:          messageID * 10,
+			WatchPath:        "/parent/target",
+			ShareName:        "share1",
+			CompletionFilter: FileNotifyChangeFileName,
+			MaxOutputLength:  4096,
+			AsyncCallback:    func(uint64, uint64, uint64, *ChangeNotifyResponse) error { return nil },
+		}
+	}
+
+	r.CompleteWatchersForDeletePending("share1", "/parent/target")
+	if err := r.Register(notify(1, 10)); !errors.Is(err, ErrDirectoryDeletePending) {
+		t.Fatalf("precondition: got %v, want ErrDirectoryDeletePending", err)
+	}
+
+	// Clearing a different share's mark must not touch this one.
+	r.ClearDeletePendingMark("share2", "/parent/target")
+	if err := r.Register(notify(2, 11)); !errors.Is(err, ErrDirectoryDeletePending) {
+		t.Fatalf("another share's clear must not lift this mark: got %v", err)
+	}
+
+	r.ClearDeletePendingMark("share1", "/parent/target")
+	if err := r.Register(notify(3, 12)); err != nil {
+		t.Fatalf("after the entry goes away the name must be watchable again: %v", err)
+	}
+	if n := r.WatcherCount(); n != 1 {
+		t.Errorf("expected the re-registered watch to be parked, got %d watchers", n)
+	}
+}
+
+// TestChangeNotify_DeletePendingDirectory_AnsweredSynchronously pins the wire
+// answer for the ordering #2199 describes: the directory's delete disposition
+// is committed, and only then does the CHANGE_NOTIFY reach the handler. It
+// must come back on its own MessageID with STATUS_DELETE_PENDING rather than
+// going async on a wait that has already been swept past.
+func TestChangeNotify_DeletePendingDirectory_AnsweredSynchronously(t *testing.T) {
+	h := NewHandler()
+	h.NotifyRegistry = NewNotifyRegistry()
+	h.MaxTransactSize = 1 << 20
+
+	fileID := [16]byte{0x44}
+	openFile := (&OpenFile{
+		FileID: fileID, IsDirectory: true, ShareName: "share1", SessionID: 1, TreeID: 1,
+		DesiredAccess: 0x00000001, GrantedAccess: 0x00000001,
+	}).WithName(OpenName{Path: "/dir"})
+	h.StoreOpenFile(openFile)
+
+	// Another handle marked the directory for deletion first. The sweep finds
+	// nothing: this watch has not registered yet.
+	h.NotifyRegistry.CompleteWatchersForDeletePending("share1", "/dir")
+
+	var wentAsync bool
+	ctx := &SMBHandlerContext{
+		SessionID: 1, TreeID: 1, MessageID: 79, ConnID: 5,
+		TryReserveAsync: func() bool { return true },
+		ReleaseAsync:    func() {},
+		AsyncNotifyCallback: func(_, _, _ uint64, _ *ChangeNotifyResponse) error {
+			wentAsync = true
+			return nil
+		},
+	}
+
+	res, err := h.ChangeNotify(ctx, encodeChangeNotifyReq(0, 1000, fileID, FileNotifyChangeFileName))
+	if err != nil {
+		t.Fatalf("ChangeNotify error: %v", err)
+	}
+	if res.Status != types.StatusDeletePending {
+		t.Fatalf("status = %v, want STATUS_DELETE_PENDING", res.Status)
+	}
+	if res.AsyncId != 0 {
+		t.Errorf("AsyncId = %d, want 0 — the reply is synchronous on the original MessageID", res.AsyncId)
+	}
+	if wentAsync {
+		t.Error("the request must not be parked as an async watch")
+	}
+	if n := h.NotifyRegistry.WatcherCount(); n != 0 {
+		t.Errorf("WatcherCount = %d, want 0 — nothing may be left waiting", n)
+	}
+}

--- a/internal/adapter/smb/handlers/change_notify_test.go
+++ b/internal/adapter/smb/handlers/change_notify_test.go
@@ -3825,7 +3825,7 @@ func TestRegisterAfterDeletePendingMark(t *testing.T) {
 	}
 
 	// Nothing is registered yet, so the sweep answers nobody.
-	if got := r.CompleteWatchersForDeletePending("share1", "/parent/target"); got != 0 {
+	if got := r.MarkDirectoryDeletePending("share1", "/parent/target"); got != 0 {
 		t.Fatalf("expected the sweep to find no watchers, got %d", got)
 	}
 
@@ -3875,7 +3875,7 @@ func TestClearDeletePendingMark(t *testing.T) {
 		}
 	}
 
-	r.CompleteWatchersForDeletePending("share1", "/parent/target")
+	r.MarkDirectoryDeletePending("share1", "/parent/target")
 	if err := r.Register(notify(1, 10)); !errors.Is(err, ErrDirectoryDeletePending) {
 		t.Fatalf("precondition: got %v, want ErrDirectoryDeletePending", err)
 	}
@@ -3896,8 +3896,8 @@ func TestClearDeletePendingMark(t *testing.T) {
 }
 
 // TestChangeNotify_DeletePendingDirectory_AnsweredSynchronously pins the wire
-// answer for the ordering #2199 describes: the directory's delete disposition
-// is committed, and only then does the CHANGE_NOTIFY reach the handler. It
+// answer for the late-arrival ordering: the directory's delete disposition is
+// committed, and only then does the CHANGE_NOTIFY reach the handler. It
 // must come back on its own MessageID with STATUS_DELETE_PENDING rather than
 // going async on a wait that has already been swept past.
 func TestChangeNotify_DeletePendingDirectory_AnsweredSynchronously(t *testing.T) {
@@ -3914,7 +3914,7 @@ func TestChangeNotify_DeletePendingDirectory_AnsweredSynchronously(t *testing.T)
 
 	// Another handle marked the directory for deletion first. The sweep finds
 	// nothing: this watch has not registered yet.
-	h.NotifyRegistry.CompleteWatchersForDeletePending("share1", "/dir")
+	h.NotifyRegistry.MarkDirectoryDeletePending("share1", "/dir")
 
 	var wentAsync bool
 	ctx := &SMBHandlerContext{
@@ -3942,5 +3942,35 @@ func TestChangeNotify_DeletePendingDirectory_AnsweredSynchronously(t *testing.T)
 	}
 	if n := h.NotifyRegistry.WatcherCount(); n != 0 {
 		t.Errorf("WatcherCount = %d, want 0 — nothing may be left waiting", n)
+	}
+}
+
+// TestCompleteWatchersForDeletePendingDoesNotStick pins the asymmetry between
+// the two entry points. Both close paths remove the directory entry before they
+// sweep, so a sticky marker recorded from the plain sweep would be stamped onto
+// a name that has just been freed — and every directory successfully deleted
+// over SMB would become permanently unwatchable under that name.
+func TestCompleteWatchersForDeletePendingDoesNotStick(t *testing.T) {
+	r := newTestNotifyRegistry()
+
+	notify := &PendingNotify{
+		FileID:           [16]byte{1},
+		SessionID:        1,
+		MessageID:        10,
+		AsyncId:          100,
+		WatchPath:        "/parent/target",
+		ShareName:        "share1",
+		CompletionFilter: FileNotifyChangeFileName,
+		MaxOutputLength:  4096,
+		AsyncCallback:    func(uint64, uint64, uint64, *ChangeNotifyResponse) error { return nil },
+	}
+
+	r.CompleteWatchersForDeletePending("share1", "/parent/target")
+
+	if err := r.Register(notify); err != nil {
+		t.Fatalf("the plain sweep must leave no sticky marker behind: %v", err)
+	}
+	if n := r.WatcherCount(); n != 1 {
+		t.Errorf("expected the watch to be parked normally, got %d watchers", n)
 	}
 }

--- a/internal/adapter/smb/handlers/close_notify_test.go
+++ b/internal/adapter/smb/handlers/close_notify_test.go
@@ -297,3 +297,71 @@ func TestClose_DirectoryDeleteOnClose_RetiresNotifyMarker(t *testing.T) {
 		t.Fatalf("once the entry is gone the name must be watchable again: %v", err)
 	}
 }
+
+// TestSetInfo_ClearDisposition_KeepsMarkerWhileASiblingStillHoldsIt covers the
+// asymmetry between the marker and the handle field the clear reads. The
+// disposition is per Open; the marker describes the directory. One open
+// retracting its own disposition while another still holds the directory
+// delete-pending must not retire the marker, or the CHANGE_NOTIFYs arriving
+// after the sweep go straight back to waiting on a sweep that has already run.
+func TestSetInfo_ClearDisposition_KeepsMarkerWhileASiblingStillHoldsIt(t *testing.T) {
+	h, ctx, _ := setupStreamsDisabledShare(t, false)
+	if h.NotifyRegistry == nil {
+		h.NotifyRegistry = NewNotifyRegistry()
+	}
+
+	// Both opens are taken before either marks: once a directory is
+	// delete-pending, CREATE refuses further opens of it.
+	markerID := dirTestCreate(t, h, ctx, "doomed", types.FileOpenIf, types.FileDirectoryFile)
+	retractorID := dirTestCreate(t, h, ctx, "doomed", types.FileOpen, types.FileDirectoryFile)
+
+	openFile, ok := h.GetOpenFile(markerID)
+	if !ok {
+		t.Fatal("directory handle missing from the open-file table")
+	}
+	shareName, watchPath := openFile.ShareName, openFile.Name().Path
+
+	setDisposition := func(fileID [16]byte, deleteFile bool) {
+		t.Helper()
+		resp, err := h.SetInfo(ctx, &SetInfoRequest{
+			InfoType:      types.SMB2InfoTypeFile,
+			FileInfoClass: uint8(types.FileDispositionInformation),
+			FileID:        fileID,
+			Buffer:        encodeDispositionInfo(deleteFile),
+		})
+		if err != nil {
+			t.Fatalf("SetInfo disposition(%v): %v", deleteFile, err)
+		}
+		if resp.Status != types.StatusSuccess {
+			t.Fatalf("SetInfo disposition(%v) = %v, want STATUS_SUCCESS", deleteFile, resp.Status)
+		}
+	}
+
+	lateNotify := func(messageID uint64) *PendingNotify {
+		return &PendingNotify{
+			FileID:           [16]byte{0x52, byte(messageID)},
+			SessionID:        ctx.SessionID,
+			MessageID:        messageID,
+			AsyncId:          messageID * 10,
+			WatchPath:        watchPath,
+			ShareName:        shareName,
+			CompletionFilter: FileNotifyChangeFileName,
+			MaxOutputLength:  4096,
+			AsyncCallback:    func(uint64, uint64, uint64, *ChangeNotifyResponse) error { return nil },
+		}
+	}
+
+	setDisposition(markerID, true)
+	setDisposition(retractorID, false)
+
+	if err := h.NotifyRegistry.Register(lateNotify(20)); !errors.Is(err, ErrDirectoryDeletePending) {
+		t.Fatalf("a sibling open still holds the directory delete-pending: got %v, want ErrDirectoryDeletePending", err)
+	}
+
+	// The open that set it retracts too, so nothing holds the directory now.
+	setDisposition(markerID, false)
+
+	if err := h.NotifyRegistry.Register(lateNotify(21)); err != nil {
+		t.Fatalf("with the deletion called off the directory must be watchable: %v", err)
+	}
+}

--- a/internal/adapter/smb/handlers/close_notify_test.go
+++ b/internal/adapter/smb/handlers/close_notify_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 
@@ -233,5 +234,66 @@ func TestClose_DeleteOnClose_CompletesOtherHandlesNotify(t *testing.T) {
 	}
 	if h.NotifyRegistry.WatcherCount() != 0 {
 		t.Errorf("watch survived the delete mark: %d", h.NotifyRegistry.WatcherCount())
+	}
+}
+
+// TestClose_DirectoryDeleteOnClose_RetiresNotifyMarker walks the marker's whole
+// life through the real handlers: SET_INFO commits the delete disposition, a
+// CHANGE_NOTIFY arriving after that is answered rather than parked, and the
+// CLOSE that actually removes the entry frees the name to be watched again.
+//
+// The clear is deliberately not wired to the close paths' own sweep: both of
+// them remove the directory entry before they sweep, so a marker recorded there
+// would be stamped onto a name that has just been freed.
+func TestClose_DirectoryDeleteOnClose_RetiresNotifyMarker(t *testing.T) {
+	h, ctx, _ := setupStreamsDisabledShare(t, false)
+	if h.NotifyRegistry == nil {
+		h.NotifyRegistry = NewNotifyRegistry()
+	}
+
+	dirID := dirTestCreate(t, h, ctx, "doomed", types.FileOpenIf, types.FileDirectoryFile)
+	openFile, ok := h.GetOpenFile(dirID)
+	if !ok {
+		t.Fatal("directory handle missing from the open-file table")
+	}
+	shareName, watchPath := openFile.ShareName, openFile.Name().Path
+
+	lateNotify := func(messageID uint64) *PendingNotify {
+		return &PendingNotify{
+			FileID:           [16]byte{0x51, byte(messageID)},
+			SessionID:        ctx.SessionID,
+			MessageID:        messageID,
+			AsyncId:          messageID * 10,
+			WatchPath:        watchPath,
+			ShareName:        shareName,
+			CompletionFilter: FileNotifyChangeFileName,
+			MaxOutputLength:  4096,
+			AsyncCallback:    func(uint64, uint64, uint64, *ChangeNotifyResponse) error { return nil },
+		}
+	}
+
+	resp, err := h.SetInfo(ctx, &SetInfoRequest{
+		InfoType:      types.SMB2InfoTypeFile,
+		FileInfoClass: uint8(types.FileDispositionInformation),
+		FileID:        dirID,
+		Buffer:        encodeDispositionInfo(true),
+	})
+	if err != nil {
+		t.Fatalf("SetInfo disposition: %v", err)
+	}
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("disposition on an empty directory = %v, want STATUS_SUCCESS", resp.Status)
+	}
+
+	if err := h.NotifyRegistry.Register(lateNotify(11)); !errors.Is(err, ErrDirectoryDeletePending) {
+		t.Fatalf("a watch registering after the mark: got %v, want ErrDirectoryDeletePending", err)
+	}
+
+	if _, err := h.Close(ctx, &CloseRequest{FileID: dirID}); err != nil {
+		t.Fatalf("close doomed: %v", err)
+	}
+
+	if err := h.NotifyRegistry.Register(lateNotify(12)); err != nil {
+		t.Fatalf("once the entry is gone the name must be watchable again: %v", err)
 	}
 }

--- a/internal/adapter/smb/handlers/doc_election.go
+++ b/internal/adapter/smb/handlers/doc_election.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"path"
 	"strings"
 
 	"github.com/marmos91/dittofs/internal/logger"
@@ -327,15 +326,23 @@ func (h *Handler) removeElectedTarget(
 	// right for both close paths, and it runs ahead of the removal so every
 	// exit below is covered.
 	//
-	// The path is rebuilt from the entry being removed rather than taken from
-	// target.Name, which is the closing handle's own name: reached through a
-	// stream handle carrying a deferred base delete, that name is the stream's,
-	// and clearing under it would leave the base directory's marker behind.
+	// target.Name is the closing handle's own name, which is the entry being
+	// removed except when a stream handle carries a deferred base delete —
+	// there it names the stream, and clearing under it would leave the base
+	// directory's marker behind. Only that case swaps the last component, and
+	// it swaps it textually: watch paths are keyed as the open spells them,
+	// which is not necessarily rooted, so rejoining through path.Join would
+	// produce a key that matches nothing.
 	if isDeleteTargetDir && h.NotifyRegistry != nil {
-		h.NotifyRegistry.ClearDeletePendingMark(
-			openFile.ShareName,
-			path.Join(GetParentPath(target.Name.Path), target.FileName),
-		)
+		clearedPath := target.Name.Path
+		if target.IsBaseFile {
+			if i := strings.LastIndex(clearedPath, "/"); i >= 0 {
+				clearedPath = clearedPath[:i+1] + target.FileName
+			} else {
+				clearedPath = target.FileName
+			}
+		}
+		h.NotifyRegistry.ClearDeletePendingMark(openFile.ShareName, clearedPath)
 	}
 
 	var removedPayloadID metadata.PayloadID

--- a/internal/adapter/smb/handlers/doc_election.go
+++ b/internal/adapter/smb/handlers/doc_election.go
@@ -365,5 +365,15 @@ func (h *Handler) removeElectedTarget(
 	h.purgeBlockStorePayload(ctx, deleteTargetHandle, removedPayloadID, target.Name.Path, caller)
 	h.restoreParentDirFrozenTimestamps(authCtx, target.ParentHandle)
 
+	// The name is free again, so the directory's delete-pending marker must go
+	// with it: a CHANGE_NOTIFY on a directory later created under the same name
+	// would otherwise be answered STATUS_DELETE_PENDING forever. This sits here
+	// rather than in the two callers because it is unconditionally right for
+	// both — it retires state the removal has just made false, not a
+	// notification whose shape differs by close path.
+	if isDeleteTargetDir && !target.IsBaseFile && h.NotifyRegistry != nil {
+		h.NotifyRegistry.ClearDeletePendingMark(openFile.ShareName, target.Name.Path)
+	}
+
 	return isDeleteTargetDir, true, nil
 }

--- a/internal/adapter/smb/handlers/doc_election.go
+++ b/internal/adapter/smb/handlers/doc_election.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"path"
 	"strings"
 
 	"github.com/marmos91/dittofs/internal/logger"
@@ -315,6 +316,28 @@ func (h *Handler) removeElectedTarget(
 		}
 	}
 
+	// Retire the directory's delete-pending marker. The handle carrying the
+	// disposition is the one closing here, so whichever way the removal below
+	// goes the marker has stopped describing anything: either the entry goes
+	// and the name is free for reuse, or it survives with nothing left holding
+	// it delete-pending. A marker that outlived either outcome would leave that
+	// name permanently unwatchable.
+	//
+	// Unlike the two things left to the callers above, this is unconditionally
+	// right for both close paths, and it runs ahead of the removal so every
+	// exit below is covered.
+	//
+	// The path is rebuilt from the entry being removed rather than taken from
+	// target.Name, which is the closing handle's own name: reached through a
+	// stream handle carrying a deferred base delete, that name is the stream's,
+	// and clearing under it would leave the base directory's marker behind.
+	if isDeleteTargetDir && h.NotifyRegistry != nil {
+		h.NotifyRegistry.ClearDeletePendingMark(
+			openFile.ShareName,
+			path.Join(GetParentPath(target.Name.Path), target.FileName),
+		)
+	}
+
 	var removedPayloadID metadata.PayloadID
 	if isDeleteTargetDir {
 		_, err = metaSvc.RemoveDirectory(authCtx, target.ParentHandle, target.FileName)
@@ -364,16 +387,6 @@ func (h *Handler) removeElectedTarget(
 
 	h.purgeBlockStorePayload(ctx, deleteTargetHandle, removedPayloadID, target.Name.Path, caller)
 	h.restoreParentDirFrozenTimestamps(authCtx, target.ParentHandle)
-
-	// The name is free again, so the directory's delete-pending marker must go
-	// with it: a CHANGE_NOTIFY on a directory later created under the same name
-	// would otherwise be answered STATUS_DELETE_PENDING forever. This sits here
-	// rather than in the two callers because it is unconditionally right for
-	// both — it retires state the removal has just made false, not a
-	// notification whose shape differs by close path.
-	if isDeleteTargetDir && !target.IsBaseFile && h.NotifyRegistry != nil {
-		h.NotifyRegistry.ClearDeletePendingMark(openFile.ShareName, target.Name.Path)
-	}
 
 	return isDeleteTargetDir, true, nil
 }

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -1446,10 +1446,17 @@ func (h *Handler) setFileInfoFromStore(
 		// whose flag dies with the handle; the marker here is scoped to the
 		// directory, so keeping it after the deletion has been called off would
 		// leave a live directory permanently unwatchable.
+		//
+		// Only once NO open still carries the disposition, though: the marker
+		// describes the directory, and the write above cleared one handle's
+		// view of it. Dropping it while a sibling open still holds the
+		// directory delete-pending would put the late-arriving CHANGE_NOTIFYs
+		// straight back to waiting on a sweep that has already run.
 		if openFile.IsDirectory && h.NotifyRegistry != nil {
-			if deletePending {
+			switch {
+			case deletePending:
 				h.NotifyRegistry.MarkDirectoryDeletePending(openFile.ShareName, openFile.Name().Path)
-			} else {
+			case !h.isFileDeletePending(openFile.MetadataHandle):
 				h.NotifyRegistry.ClearDeletePendingMark(openFile.ShareName, openFile.Name().Path)
 			}
 		}

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -1440,8 +1440,18 @@ func (h *Handler) setFileInfoFromStore(
 		// STATUS_DELETE_PENDING. The watcher is normally a different handle on
 		// the same directory, so this cannot be reached from the close path
 		// that answers this handle's own watch.
-		if deletePending && openFile.IsDirectory && h.NotifyRegistry != nil {
-			h.NotifyRegistry.CompleteWatchersForDeletePending(openFile.ShareName, openFile.Name().Path)
+		//
+		// Clearing the disposition drops the marker again. The one-way rule in
+		// [MS-FSA] 2.1.1.6 (Per Open, item 21) is scoped to a single Open,
+		// whose flag dies with the handle; the marker here is scoped to the
+		// directory, so keeping it after the deletion has been called off would
+		// leave a live directory permanently unwatchable.
+		if openFile.IsDirectory && h.NotifyRegistry != nil {
+			if deletePending {
+				h.NotifyRegistry.CompleteWatchersForDeletePending(openFile.ShareName, openFile.Name().Path)
+			} else {
+				h.NotifyRegistry.ClearDeletePendingMark(openFile.ShareName, openFile.Name().Path)
+			}
 		}
 
 		logger.Debug("SET_INFO: delete disposition set",

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -1448,7 +1448,7 @@ func (h *Handler) setFileInfoFromStore(
 		// leave a live directory permanently unwatchable.
 		if openFile.IsDirectory && h.NotifyRegistry != nil {
 			if deletePending {
-				h.NotifyRegistry.CompleteWatchersForDeletePending(openFile.ShareName, openFile.Name().Path)
+				h.NotifyRegistry.MarkDirectoryDeletePending(openFile.ShareName, openFile.Name().Path)
 			} else {
 				h.NotifyRegistry.ClearDeletePendingMark(openFile.ShareName, openFile.Name().Path)
 			}

--- a/internal/adapter/smb/handlers/stub_handlers.go
+++ b/internal/adapter/smb/handlers/stub_handlers.go
@@ -760,6 +760,17 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 				"messageID", ctx.MessageID)
 			return NewErrorResult(types.StatusCancelled), nil
 		}
+		// Per [MS-FSA] 2.1.5.11 step 4: a CHANGE_NOTIFY on a directory that
+		// is already marked for deletion is completed immediately with
+		// STATUS_DELETE_PENDING rather than left waiting. STATUS_DELETE_PENDING
+		// is error severity, so the error body is the right one here.
+		if errors.Is(err, ErrDirectoryDeletePending) {
+			logger.Debug("CHANGE_NOTIFY: directory marked for deletion — replying STATUS_DELETE_PENDING",
+				"path", watchPath,
+				"sessionID", ctx.SessionID,
+				"messageID", ctx.MessageID)
+			return NewErrorResult(types.StatusDeletePending), nil
+		}
 		logger.Warn("CHANGE_NOTIFY: rejected — too many pending watches",
 			"path", watchPath,
 			"sessionID", ctx.SessionID)


### PR DESCRIPTION
Closes #2199

## What was wrong

DittoFS implements one half of the delete-pending rule for CHANGE_NOTIFY and not
the other.

The half it has: `NotifyRegistry.CompleteWatchersForDeletePending` sweeps every
watcher that is *already registered* on a directory when its delete disposition
is committed, and answers each with `STATUS_DELETE_PENDING`.

The half it did not have: a CHANGE_NOTIFY that reaches `Register` *after* that
mark. The sweep has already run past it, so it parks. Nothing else ever
completes it — the directory entry is still on disk (the watcher's own handle
holds it open), so no `FileActionRemoved` is produced for it either. The client
waits forever.

`smb2_notify_send` zeroes the request timeout before submitting, and in the
upstream `notify.rmdir*` helpers the watched handle is only closed at a label
that is unreachable while blocked in `smb2_notify_recv`. So the failure mode is
an indefinite hang, not a fast error.

The ordering is not prevented by anything on the client side. `smb2_notify_send`
is fire-and-forget with no synchronisation before the delete goes out, and
`rmdir3`/`rmdir4` run the NOTIFY and the delete on two independent TCP
connections. It simply has not been observed: 15 of 15 draws pass today.

## The fix

`NotifyRegistry` gains a sticky per-directory marker keyed by
(share, normalised watch path):

- **Set** by `MarkDirectoryDeletePending`, which sweeps the registered watchers
  and records the marker under a single acquisition of the registry mutex. A
  `Register` cannot slip between the two.
- **Consulted** in `Register`, which returns the new `ErrDirectoryDeletePending`
  so the CHANGE_NOTIFY handler answers `STATUS_DELETE_PENDING` synchronously on
  the original MessageID instead of parking a watch and going async.
- **Cleared** by `ClearDeletePendingMark` when the marker's premise stops
  holding.

The check sits after the existing pre-arrival CANCEL and handle-close
short-circuits in `Register`, so a cancelled or closing request still gets the
answer its own lifecycle owes it.

## Where the marker is set, and where it is not

It is recorded only on the `FileDispositionInformation` /
`FileDispositionInformationEx` path in `set_info.go`. That is both the
spec-faithful placement and the only ordering-safe one:

- Spec: `ChangeNotifyDirectoryMarkedDeleted` is set by the
  `FileDispositionInformation` algorithms. The close-time delete-on-close
  election is a different rule, and DittoFS's sweep there stays a pure sweep.
- Ordering: both close paths *remove the directory entry before they sweep* —
  `close.go` does the removal in step 8 and the sweep in step 9, and the
  session/tree teardown removes at `handleDeleteOnClose` before its `docDirs`
  loop. Recording a sticky marker from those sites would stamp it onto a name
  that has just been freed, and every directory successfully deleted over SMB
  would become permanently unwatchable under that name.

## Clearing

A marker that outlives the directory is a directory that can never be watched
again, so both ways its premise can stop holding are covered:

- `removeElectedTarget` — the elected last handle is closing, so whichever way
  the removal goes the marker has stopped describing anything: the entry goes
  and the name is free, or it survives with nothing left holding it
  delete-pending. One site covering both close paths, placed ahead of the
  removal so every exit is covered. The path is rebuilt from the entry being
  removed rather than from the closing handle's own name, which is the stream's
  name when a stream handle carries a deferred base delete.
- The disposition being cleared again, and only once no open still carries it.
  The one-way rule for `ChangeNotifyDirectoryMarkedDeleted` is scoped to a
  single Open, whose flag dies with the handle. This marker is scoped to the
  directory, so keeping it after the deletion has been called off would leave a
  live directory unwatchable — strictly worse than the bug being fixed — while
  dropping it because one of several opens retracted would put the late
  arrivals straight back to waiting.

## Evidence

The issue is not currently reproducing, so there is no red suite to start from.
The regression tests construct the ordering directly and each was run against a
deliberately broken build first:

| mutation | test that caught it |
| --- | --- |
| mark not recorded by the sweep | `TestRegisterAfterDeletePendingMark`, `TestClearDeletePendingMark` |
| `ClearDeletePendingMark` made a no-op | `TestClearDeletePendingMark` |
| `Register` compares the unnormalised path | `TestRegisterAfterDeletePendingMark` |
| handler does not map `ErrDirectoryDeletePending` | `TestChangeNotify_DeletePendingDirectory_AnsweredSynchronously` |
| close-path sweep records the sticky marker | `TestCompleteWatchersForDeletePendingDoesNotStick` |
| clear removed from `removeElectedTarget` | `TestClose_DirectoryDeleteOnClose_RetiresNotifyMarker` |
| disposition-clear ignores sibling opens | `TestSetInfo_ClearDisposition_KeepsMarkerWhileASiblingStillHoldsIt` |

`TestClose_DirectoryDeleteOnClose_RetiresNotifyMarker` walks the marker's whole
life through the real handlers rather than the registry alone, and earned its
keep immediately: it caught the clear being keyed under a rooted path
(`path.Join` on the parent) while the watch is keyed as the open spells its
name, which is not necessarily rooted. The registry-level tests could not see
that, because they set and clear through the same spelling.

Tests assert on the registry answering, not on a timeout — the failure mode is a
hang, so a timeout-based assertion would only reproduce the symptom slowly.

`go build ./...`, `go vet ./...`, `go test ./...` and `go test -race
./internal/adapter/smb/...` are green.

## Known limit

An NFS `RMDIR` on the same share removes a marked directory without reaching the
SMB notify registry, so the marker survives it and a directory later created at
that name answers `STATUS_DELETE_PENDING`. This is carried as a `ponytail:` note
rather than fixed here: SMB CHANGE_NOTIFY does not observe NFS-side changes at
all today, and closing this one case properly means driving the marker off the
metadata store's own removal rather than off the SMB close paths.
