### PR TITLE
fix(smb): keep the ChangeTime a client observed across rename

### DIFF
--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -1768,17 +1768,17 @@ func applyFrozenTimestamps(openFile *OpenFile, file *metadata.File) {
 
 // snapshotChangeTime reads a file's current ChangeTime and returns a function
 // that writes it back. Service.Move stamps the renamed inode's Ctime, but a
-// client that renames through an outstanding handle must keep observing the
-// ChangeTime it was handed in the CREATE reply — smbtorture
-// smb2.rename.simple_modtime compares exactly those two values.
+// client that renames through a handle it still holds open must keep observing
+// the ChangeTime that handle was handed in its CREATE reply, so the stamp is
+// put back.
 //
 // The write-back runs as the system identity on purpose. An explicit timestamp
 // write is ownership-gated in the metadata layer while the rename itself is
 // authorized on the parent directory, so writing the stamp back as the caller
-// lands for an owner and is silently refused for everyone else: one rename,
-// two observable ChangeTimes, selected by a permission check the caller never
-// asked for (#2205). As the system identity it lands for every caller, so the
-// ChangeTime a client observes no longer depends on who owns the file. A
+// would land for an owner and be silently refused for everyone else: one
+// rename, two observable ChangeTimes, chosen by a permission check the caller
+// never asked for. As the system identity it lands for every caller, so the
+// ChangeTime a client observes does not depend on who owns the file. A
 // read-only share cannot reach here — Move would already have refused.
 //
 // Only Ctime is snapshotted: Move leaves the renamed inode's Mtime alone, and
@@ -1787,9 +1787,18 @@ func applyFrozenTimestamps(openFile *OpenFile, file *metadata.File) {
 //
 // Returns a no-op if the read fails.
 //
-// ponytail: read-then-write-back costs an extra store round-trip per rename;
-// teach Service.Move to skip the stamp for its SMB caller only if rename
-// throughput ever shows up in a profile.
+// ponytail: the rule being implemented is handle-scoped — what a handle that
+// was already open keeps observing — but this writes the stored timestamp, so
+// it is file-scoped, and a Ctime advanced between the read and the write-back
+// (a WRITE, truncate or SET_INFO on another handle, or over NFS) is walked
+// backwards for every observer. The two coincide whenever nothing else is
+// touching the file. Upgrade to a per-OpenFile overlay consulted by
+// QUERY_INFO — the seam applyFrozenTimestamps already uses — once that overlay
+// can also say when to stop applying: it has to yield to the next real Ctime
+// advance, including one made through a different handle, which an OpenFile
+// field cannot see on its own. A directory enumeration reports a child's
+// ChangeTime with no OpenFile at all, so an overlay does not cover that path
+// either.
 func (h *Handler) snapshotChangeTime(authCtx *metadata.AuthContext, handle metadata.FileHandle) func() {
 	metaSvc := h.Registry.GetMetadataService()
 	file, err := metaSvc.GetFile(authCtx.Context, handle)

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -762,10 +762,12 @@ func (h *Handler) setFileInfoFromStore(
 			oldFileName := oldName.FileName
 			oldParentPath := GetParentPath(oldName.Path)
 
-			// Perform the rename. Move stamps LastChangeTime and leaves
-			// LastModificationTime untouched, which is what MS-FSA
-			// 2.1.5.15.12 asks for; neither is written back afterwards.
+			// Move stamps the renamed inode's LastChangeTime. A client
+			// holding this handle open must keep observing the ChangeTime it
+			// was handed at CREATE, so put the pre-rename value back.
 			metaSvc := h.Registry.GetMetadataService()
+			restoreChangeTime := h.snapshotChangeTime(authCtx, openFile.MetadataHandle)
+
 			_, err = metaSvc.Move(authCtx, toDir, oldFileName, toDir, toName)
 			if err != nil {
 				logger.Debug("SET_INFO: stream rename failed",
@@ -774,6 +776,8 @@ func (h *Handler) setFileInfoFromStore(
 					"error", err)
 				return setInfoStatus(common.MapToSMB(err)), nil
 			}
+
+			restoreChangeTime()
 
 			// Move's LastChangeTime stamp is an automatic update, so a
 			// timestamp frozen on this handle has to be put back the same way
@@ -1187,11 +1191,11 @@ func (h *Handler) setFileInfoFromStore(
 			}
 		}
 
-		// Perform the rename/move. Move stamps LastChangeTime and leaves
-		// LastModificationTime untouched, matching MS-FSA 2.1.5.15.12. The
-		// advance stands: writing a stamp back is a write against the file,
-		// not the directory the rename was authorized on, so it would land or
-		// be denied depending on the file's mode.
+		// Move stamps the renamed inode's LastChangeTime. A client holding
+		// this handle open must keep observing the ChangeTime it was handed at
+		// CREATE, so put the pre-rename value back.
+		restoreChangeTime := h.snapshotChangeTime(authCtx, openFile.MetadataHandle)
+
 		_, err = metaSvc.Move(authCtx, srcParentHandle, oldFileName, toDir, toName)
 		if err != nil {
 			logger.Debug("SET_INFO: rename failed",
@@ -1200,6 +1204,8 @@ func (h *Handler) setFileInfoFromStore(
 				"error", err)
 			return setInfoStatus(common.MapToSMB(err)), nil
 		}
+
+		restoreChangeTime()
 
 		// Move's LastChangeTime stamp is an automatic update, so a timestamp
 		// frozen on this handle has to be put back the same way WRITE and
@@ -1757,6 +1763,41 @@ func applyFrozenTimestamps(openFile *OpenFile, file *metadata.File) {
 	}
 	if openFile.AtimeFrozen && openFile.FrozenAtime != nil {
 		file.Atime = *openFile.FrozenAtime
+	}
+}
+
+// snapshotChangeTime reads a file's current ChangeTime and returns a function
+// that writes it back. Service.Move stamps the renamed inode's Ctime, but a
+// client that renames through an outstanding handle must keep observing the
+// ChangeTime it was handed in the CREATE reply — smbtorture
+// smb2.rename.simple_modtime compares exactly those two values.
+//
+// The write-back runs as the system identity on purpose. An explicit timestamp
+// write is ownership-gated in the metadata layer while the rename itself is
+// authorized on the parent directory, so writing the stamp back as the caller
+// lands for an owner and is silently refused for everyone else: one rename,
+// two observable ChangeTimes, selected by a permission check the caller never
+// asked for (#2205). As the system identity it lands for every caller, so the
+// ChangeTime a client observes no longer depends on who owns the file. A
+// read-only share cannot reach here — Move would already have refused.
+//
+// Only Ctime is snapshotted: Move leaves the renamed inode's Mtime alone, and
+// the parent directories' timestamps are handled by
+// restoreParentDirFrozenTimestamps.
+//
+// Returns a no-op if the read fails.
+func (h *Handler) snapshotChangeTime(authCtx *metadata.AuthContext, handle metadata.FileHandle) func() {
+	metaSvc := h.Registry.GetMetadataService()
+	file, err := metaSvc.GetFile(authCtx.Context, handle)
+	if err != nil {
+		return func() {}
+	}
+	ctime := file.Ctime
+	sysCtx := metadata.NewSystemAuthContext(authCtx.Context)
+	return func() {
+		if _, err := metaSvc.SetFileAttributes(sysCtx, handle, &metadata.SetAttrs{Ctime: &ctime}); err != nil {
+			logger.Debug("SET_INFO: restoring pre-rename ChangeTime failed", "error", err)
+		}
 	}
 }
 

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -1767,10 +1767,13 @@ func applyFrozenTimestamps(openFile *OpenFile, file *metadata.File) {
 }
 
 // snapshotChangeTime reads a file's current ChangeTime and returns a function
-// that writes it back. Service.Move stamps the renamed inode's Ctime, but a
-// client that renames through a handle it still holds open must keep observing
-// the ChangeTime that handle was handed in its CREATE reply, so the stamp is
-// put back.
+// that writes it back. Service.Move stamps the renamed inode's Ctime, but
+// MS-FSA 2.1.5.15.12 note <187> defers that stamp until the handle is closed,
+// so a client that renames through a handle it still holds open keeps
+// observing the ChangeTime that handle was handed in its CREATE reply. The
+// normative text of 2.1.5.15.12 says only that a rename updates LastChangeTime;
+// the note is the half that says when it becomes visible. Conformance case
+// smb2.rename.simple_modtime pins it.
 //
 // The write-back runs as the system identity on purpose. An explicit timestamp
 // write is ownership-gated in the metadata layer while the rename itself is

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -1770,10 +1770,13 @@ func applyFrozenTimestamps(openFile *OpenFile, file *metadata.File) {
 // that writes it back. Service.Move stamps the renamed inode's Ctime, but
 // MS-FSA 2.1.5.15.12 note <187> defers that stamp until the handle is closed,
 // so a client that renames through a handle it still holds open keeps
-// observing the ChangeTime that handle was handed in its CREATE reply. The
-// normative text of 2.1.5.15.12 says only that a rename updates LastChangeTime;
-// the note is the half that says when it becomes visible. Conformance case
-// smb2.rename.simple_modtime pins it.
+// observing the pre-rename ChangeTime. The normative text of 2.1.5.15.12 says
+// only that a rename updates LastChangeTime; the note is the half that says
+// when it becomes visible. Conformance case smb2.rename.simple_modtime pins
+// it, by comparing a CREATE reply's change_time against a post-rename query on
+// the same handle — the two coincide because nothing else advances the file's
+// Ctime in between, which is the same assumption the ponytail note below
+// records.
 //
 // The write-back runs as the system identity on purpose. An explicit timestamp
 // write is ownership-gated in the metadata layer while the rename itself is

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -1786,6 +1786,10 @@ func applyFrozenTimestamps(openFile *OpenFile, file *metadata.File) {
 // restoreParentDirFrozenTimestamps.
 //
 // Returns a no-op if the read fails.
+//
+// ponytail: read-then-write-back costs an extra store round-trip per rename;
+// teach Service.Move to skip the stamp for its SMB caller only if rename
+// throughput ever shows up in a profile.
 func (h *Handler) snapshotChangeTime(authCtx *metadata.AuthContext, handle metadata.FileHandle) func() {
 	metaSvc := h.Registry.GetMetadataService()
 	file, err := metaSvc.GetFile(authCtx.Context, handle)

--- a/internal/adapter/smb/handlers/set_info_rename_timestamps_test.go
+++ b/internal/adapter/smb/handlers/set_info_rename_timestamps_test.go
@@ -1,12 +1,10 @@
 // Handler-level coverage for the timestamps a SET_INFO rename leaves behind.
 //
-// A client holding the renamed file open must keep observing the ChangeTime it
-// was handed in the CREATE reply: smbtorture smb2.rename.simple_modtime renames
-// through an outstanding handle and compares the CREATE reply's change_time
-// against a post-rename query on that same handle. LastModificationTime is left
-// alone either way. A rename is authorized on the parent directory, so both
-// must hold for a caller who may rename the file without being able to write
-// that file's own attributes.
+// A client that renames through a handle it still holds open must keep
+// observing the ChangeTime that handle was handed in its CREATE reply.
+// LastModificationTime is left alone either way. A rename is authorized on the
+// parent directory, so both must hold for a caller who may rename the file
+// without being able to write that file's own attributes.
 package handlers
 
 import (
@@ -60,9 +58,9 @@ func setupRenameTimestampFixture(t *testing.T, fileUID, fileGID, callerUID, call
 // regardless of whether the caller could have written the file's timestamps
 // directly. The two cases differ only in file ownership: both may rename (the
 // parent directory is 0o777), only the owner may set the file's timestamps
-// explicitly. The preserve must not turn on that difference — one rename that
-// reports two different ChangeTimes depending on who ran it is the defect
-// #2205 named.
+// explicitly. The preserve must not turn on that difference: one rename that
+// reports two different ChangeTimes depending on who ran it is a defect in its
+// own right.
 func TestSetInfo_Rename_ChangeTimePreservedForEveryCaller(t *testing.T) {
 	cases := []struct {
 		name                                   string
@@ -98,7 +96,7 @@ func TestSetInfo_Rename_ChangeTimePreservedForEveryCaller(t *testing.T) {
 				t.Fatalf("GetFile after rename: %v", err)
 			}
 			if !after.Ctime.Equal(past) {
-				t.Errorf("ChangeTime = %v after rename; want %v unchanged (smb2.rename.simple_modtime)",
+				t.Errorf("ChangeTime = %v after rename; want %v unchanged for a handle held open across it",
 					after.Ctime.UTC(), past.UTC())
 			}
 			if !after.Mtime.Equal(past) {

--- a/internal/adapter/smb/handlers/set_info_rename_timestamps_test.go
+++ b/internal/adapter/smb/handlers/set_info_rename_timestamps_test.go
@@ -1,10 +1,10 @@
 // Handler-level coverage for the timestamps a SET_INFO rename leaves behind.
 //
 // A client that renames through a handle it still holds open must keep
-// observing the ChangeTime that handle was handed in its CREATE reply: MS-FSA
-// 2.1.5.15.12 note <187> defers the rename's LastChangeTime stamp until the
-// handle is closed, and conformance case smb2.rename.simple_modtime pins it.
-// LastModificationTime is left alone either way. A rename is authorized on the
+// observing the pre-rename ChangeTime: MS-FSA 2.1.5.15.12 note <187> defers the
+// rename's LastChangeTime stamp until the handle is closed, and conformance
+// case smb2.rename.simple_modtime pins it. LastModificationTime is left alone
+// either way. A rename is authorized on the
 // parent directory, so both must hold for a caller who may rename the file
 // without being able to write that file's own attributes.
 package handlers

--- a/internal/adapter/smb/handlers/set_info_rename_timestamps_test.go
+++ b/internal/adapter/smb/handlers/set_info_rename_timestamps_test.go
@@ -1,7 +1,9 @@
 // Handler-level coverage for the timestamps a SET_INFO rename leaves behind.
 //
 // A client that renames through a handle it still holds open must keep
-// observing the ChangeTime that handle was handed in its CREATE reply.
+// observing the ChangeTime that handle was handed in its CREATE reply: MS-FSA
+// 2.1.5.15.12 note <187> defers the rename's LastChangeTime stamp until the
+// handle is closed, and conformance case smb2.rename.simple_modtime pins it.
 // LastModificationTime is left alone either way. A rename is authorized on the
 // parent directory, so both must hold for a caller who may rename the file
 // without being able to write that file's own attributes.
@@ -96,7 +98,8 @@ func TestSetInfo_Rename_ChangeTimePreservedForEveryCaller(t *testing.T) {
 				t.Fatalf("GetFile after rename: %v", err)
 			}
 			if !after.Ctime.Equal(past) {
-				t.Errorf("ChangeTime = %v after rename; want %v unchanged for a handle held open across it",
+				t.Errorf("ChangeTime = %v after rename; want %v unchanged while the handle is open "+
+					"(MS-FSA 2.1.5.15.12 note <187>; smb2.rename.simple_modtime)",
 					after.Ctime.UTC(), past.UTC())
 			}
 			if !after.Mtime.Equal(past) {

--- a/internal/adapter/smb/handlers/set_info_rename_timestamps_test.go
+++ b/internal/adapter/smb/handlers/set_info_rename_timestamps_test.go
@@ -1,9 +1,12 @@
 // Handler-level coverage for the timestamps a SET_INFO rename leaves behind.
 //
-// Per MS-FSA 2.1.5.15.12 ("FileRenameInformation") a rename updates
-// LastChangeTime and leaves LastModificationTime alone. A rename is authorized
-// on the parent directory, so both must also hold for a caller who may rename
-// the file without being able to write that file's own attributes.
+// A client holding the renamed file open must keep observing the ChangeTime it
+// was handed in the CREATE reply: smbtorture smb2.rename.simple_modtime renames
+// through an outstanding handle and compares the CREATE reply's change_time
+// against a post-rename query on that same handle. LastModificationTime is left
+// alone either way. A rename is authorized on the parent directory, so both
+// must hold for a caller who may rename the file without being able to write
+// that file's own attributes.
 package handlers
 
 import (
@@ -52,13 +55,15 @@ func setupRenameTimestampFixture(t *testing.T, fileUID, fileGID, callerUID, call
 	return h, callerCtx, open, past
 }
 
-// TestSetInfo_Rename_ChangeTimeAdvancesForEveryCaller pins that a rename's
-// LastChangeTime update survives regardless of whether the caller could have
-// written the file's timestamps directly. The two cases differ only in file
-// ownership: both may rename (the parent directory is 0o777), only the owner
-// may set the file's timestamps explicitly. Before the fix the owner's rename
-// put the pre-rename ChangeTime back and the non-owner's did not.
-func TestSetInfo_Rename_ChangeTimeAdvancesForEveryCaller(t *testing.T) {
+// TestSetInfo_Rename_ChangeTimePreservedForEveryCaller pins that a rename
+// leaves the ChangeTime a client already observed alone, and that it does so
+// regardless of whether the caller could have written the file's timestamps
+// directly. The two cases differ only in file ownership: both may rename (the
+// parent directory is 0o777), only the owner may set the file's timestamps
+// explicitly. The preserve must not turn on that difference — one rename that
+// reports two different ChangeTimes depending on who ran it is the defect
+// #2205 named.
+func TestSetInfo_Rename_ChangeTimePreservedForEveryCaller(t *testing.T) {
 	cases := []struct {
 		name                                   string
 		fileUID, fileGID, callerUID, callerGID uint32
@@ -92,24 +97,23 @@ func TestSetInfo_Rename_ChangeTimeAdvancesForEveryCaller(t *testing.T) {
 			if err != nil {
 				t.Fatalf("GetFile after rename: %v", err)
 			}
-			if !after.Ctime.After(past) {
-				t.Errorf("ChangeTime = %v after rename; want an advance past %v (MS-FSA 2.1.5.15.12)",
+			if !after.Ctime.Equal(past) {
+				t.Errorf("ChangeTime = %v after rename; want %v unchanged (smb2.rename.simple_modtime)",
 					after.Ctime.UTC(), past.UTC())
 			}
 			if !after.Mtime.Equal(past) {
-				t.Errorf("LastWriteTime = %v after rename; want %v unchanged (MS-FSA 2.1.5.15.12 does not update it)",
+				t.Errorf("LastWriteTime = %v after rename; want %v unchanged",
 					after.Mtime.UTC(), past.UTC())
 			}
 		})
 	}
 }
 
-// TestSetInfo_Rename_FrozenChangeTimeSurvivesRename covers the other half of
-// the rule the test above pins: the rename's LastChangeTime update is an
-// automatic one, so a handle that froze ChangeTime with the -1 sentinel must
-// not see it move. Reads the store directly rather than closing the handle,
-// because CLOSE runs its own frozen-timestamp restore and would mask whether
-// the rename path did anything.
+// TestSetInfo_Rename_FrozenChangeTimeSurvivesRename covers the -1 sentinel on
+// the same path: a handle that froze ChangeTime must not see it move either.
+// Reads the store directly rather than closing the handle, because CLOSE runs
+// its own frozen-timestamp restore and would mask whether the rename path did
+// anything.
 func TestSetInfo_Rename_FrozenChangeTimeSurvivesRename(t *testing.T) {
 	// Only an owner can freeze a timestamp — the sentinel pins the pre-image
 	// through the same ownership-gated write the restore uses — so there is no


### PR DESCRIPTION
`smb2.rename.simple_modtime` has failed on every metadata backend since #2279
landed, and it is not in `KNOWN_FAILURES.md`, so it fails the job. It is
currently the only new failure on #2282 and #2283 as well, which inherit it
from develop.

## What the test asserts

`simple_modtime` creates `file1.txt`, sleeps 5 seconds, renames it through the
*still-open* handle, then queries that handle:

```c
torture_assert_nttime_equal(torture, c1.out.change_time,
                            gi.all_info.out.change_time, "Bad timestamp\n");
```

`torture_assert_nttime_equal` stringifies its `got` argument into the message,
so

```
rename.c:1527: c1.out.change_time was 14:32:00 UTC, expected 14:32:05 UTC
```

reads as: the CREATE reply's ChangeTime was 14:32:00, the post-rename query
returned 14:32:05, and the test requires them equal. The 5-second gap is the
test's own `sleep(5)`. ChangeTime is not failing to advance — it **is**
advancing, and the test requires it not to while a handle is outstanding.

## Root cause

#2279 deleted `saveTimestamps`, which had put the pre-rename Ctime back after
`Service.Move` stamps it. That was the only thing keeping this test green.

The `restoreFrozenTimestamps` calls #2279 added to both rename branches are not
implicated: `buildFrozenAttrs` returns nil unless a `-1` sentinel actually froze
a field on the handle, and `simple_modtime` never sends one, so those calls are
inert here.

## Why #2279's unit test disagreed with conformance

`TestSetInfo_Rename_ChangeTimeAdvancesForEveryCaller` and smbtorture measure the
same field on the same path. They disagree about the correct answer, not about
the mechanism: the unit test was written from #2279's own premise and asserted
`after.Ctime.After(past)` — precisely the behaviour that breaks the conformance
run. It has been inverted to assert preservation, so the two layers can no
longer disagree. It fails on unmodified develop for both callers.

## The authority #2279 missed

MS-FSA 2.1.5.15.12's normative text says a rename updates LastChangeTime, which
is what #2279 acted on. That section's own product behaviour note says when it
becomes visible:

> **<187> Section 2.1.5.15.12**: The file system only updates LastChangeTime if
> no user has explicitly set LastChangeTime. **The NTFS and ReFS file systems
> defer setting LastChangeTime until the handle is closed.**

Both halves are needed. The normative line alone reads as an unconditional
update, and that reading is what turned the conformance run red. Both the code
comment and the test now cite the note alongside the conformance case.

## The fix

#2279 fixed a real defect (#2205): the write-back went through the
ownership-gated `SetFileAttributes` as the caller, so an owner's rename put the
old ChangeTime back and a non-owner's did not — one operation, two observable
ChangeTimes, selected by an unchecked permission check. #2279 resolved that
divergence by letting the advance stand for everyone. Note <187> and
conformance both say the other direction is the correct one, so the preserve is
restored and the divergence is closed by writing it back as
`metadata.NewSystemAuthContext`, which lands for every caller. Only Ctime is
snapshotted — `Move` leaves the renamed inode's Mtime alone, as #2279
established.

**This narrows a pre-existing clobber surface rather than introducing one.**
The write-back after `Move` is what `saveTimestamps` already did before #2279
removed it, and it did so for Mtime **and** Ctime. Restoring one field is
strictly less exposed than what shipped for months. A reviewer seeing "writes
the store after `Move`" will reasonably flag the concurrency hazard — it is
real and tracked in #2285; see the follow-up section.

This is not #2280 or #2281. Both concern the ownership gate on
`restoreFrozenTimestamps` / `restoreParentDirFrozenTimestamps`; neither is on
this path, and neither is touched here.

## Verification

Local `smb2.rename`, memory profile, same pinned samba-toolbox image as CI:

| | Total | Passed | New failures |
|---|---|---|---|
| develop `a39ec44a` | 13 | 12 | 1 — `smb2.simple_modtime` |
| this branch | 13 | 13 | 0 |

The baseline run reproduced the CI assertion character for character, so the rig
sees the bug rather than passing vacuously. `smb2.setinfo` is green on this
branch. `go test ./internal/adapter/smb/... ./pkg/metadata/...` passes.

Refs #2279, #2205. Unblocks #2282 and #2283.

## Review follow-up

**Issue numbers removed from source comments.** Both sites now state the
rationale in terms of the code, per CLAUDE.md. The references live here instead.

**The concurrency finding is real and is deliberately deferred, marked
`ponytail:` and tracked in #2285.** The rule is handle-scoped; this implements
it file-scoped by rewriting the stored timestamp, so a Ctime advanced between
the read and the write-back is walked backwards for every observer. Reachable:
`RequestOrder` orders only response emission — "Handlers keep running
concurrently" — so a pipelining client can have a WRITE in flight on the same
file, and a second handle or NFS can do it too.

Kept anyway, on three grounds:

1. It is the pre-existing behaviour, narrowed. `saveTimestamps` did the same
   read-then-write-back for Mtime **and** Ctime; this restores one field, so the
   clobber surface is strictly smaller than what shipped before #2279.
2. The overlay's read seam is small — `applyFrozenTimestamps` has two call
   sites — but its *invalidation* is not. The overlay must stop applying at the
   next genuine Ctime advance, including one through a different handle, which
   an `OpenFile` field cannot observe. Left applying too long it silently
   reports a stale ChangeTime for the life of the handle: worse than the race,
   and harder to notice. It also does not cover directory enumeration, which
   reports a child's ChangeTime with no `OpenFile` at all.
3. Develop is red on all five metadata backends and #2282/#2283 are blocked
   behind it.
