### PR TITLE
fix(nfsv4): REMOVE never freed the removed file's payload bytes

### DIFF
--- a/internal/adapter/nfs/v4/handlers/io_test.go
+++ b/internal/adapter/nfs/v4/handlers/io_test.go
@@ -3,6 +3,8 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -31,6 +33,10 @@ type ioTestFixture struct {
 	store      metadata.Store
 	rootHandle metadata.FileHandle
 	shareName  string
+	// localStore and localDir are the local tier and its directory, so a test can
+	// observe the bytes a payload actually occupies on disk.
+	localStore *fs.FSStore
+	localDir   string
 }
 
 // newIOTestFixture creates a test fixture with metadata service and block store.
@@ -108,6 +114,8 @@ func newIOTestFixture(t *testing.T, shareName string) *ioTestFixture {
 		store:      metaStore,
 		rootHandle: rootHandle,
 		shareName:  shareName,
+		localStore: localStore,
+		localDir:   tmpDir,
 	}
 }
 
@@ -1598,5 +1606,69 @@ func TestReadNonRegularType(t *testing.T) {
 				t.Errorf("READ_PLUS status = %d, want %d", got, tc.want)
 			}
 		})
+	}
+}
+
+// localDirBytes sums every file under dir: the bytes the local tier actually
+// occupies, which is what an operator sees and what survives a restart.
+func localDirBytes(t *testing.T, dir string) int64 {
+	t.Helper()
+	var total int64
+	if err := filepath.Walk(dir, func(_ string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !fi.IsDir() {
+			total += fi.Size()
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walk local dir: %v", err)
+	}
+	return total
+}
+
+// TestRemove_ReclaimsLocalPayloadBytes pins that a v4 REMOVE frees the removed
+// file's content, not just its name. The metadata layer deliberately never
+// deletes payload bytes — it returns the removed file's PayloadID so the
+// protocol handler can — so a handler that discards that return value never
+// tells the block store the file is gone. Its records stay indexed as live, no
+// reclamation path (fast-path retire, eviction, repack) will ever treat them as
+// dead, and the share keeps those bytes on disk across restarts even once every
+// file in it has been removed.
+//
+// The assertion is on block-store state an operator can observe rather than on
+// how the handler achieves it: after the unlink the payload must be unknown to
+// the local tier, which is the precondition every reclamation path shares.
+func TestRemove_ReclaimsLocalPayloadBytes(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+	ctxBg := context.Background()
+
+	fh := fx.createRegularFile(t, fx.rootHandle, "big.bin", 0o644, 1000, 1000)
+	file, err := fx.metaSvc.GetFile(ctxBg, fh)
+	if err != nil {
+		t.Fatalf("get file: %v", err)
+	}
+	payloadID := string(file.PayloadID)
+	payload := bytes.Repeat([]byte{0xAB}, 4<<20)
+	fx.writeContent(t, fh, payload)
+
+	if size, ok := fx.localStore.FileSize(ctxBg, payloadID); !ok || size != int64(len(payload)) {
+		t.Fatalf("local tier holds %d bytes (present=%v) before REMOVE, want %d", size, ok, len(payload))
+	}
+	if before := localDirBytes(t, fx.localDir); before < int64(len(payload)) {
+		t.Fatalf("local dir holds %d bytes before REMOVE, want at least the %d written", before, len(payload))
+	}
+
+	ctx := newRealFSContext(1000, 1000)
+	ctx.CurrentFH = append([]byte(nil), fx.rootHandle...)
+
+	result := fx.handler.handleRemove(ctx, bytes.NewReader(encodeRemoveArgs("big.bin")))
+	if result.Status != types.NFS4_OK {
+		t.Fatalf("REMOVE status = %d, want NFS4_OK", result.Status)
+	}
+
+	if size, ok := fx.localStore.FileSize(ctxBg, payloadID); ok {
+		t.Fatalf("payload %q still holds %d live bytes in the local tier after REMOVE", payloadID, size)
 	}
 }

--- a/internal/adapter/nfs/v4/handlers/remove.go
+++ b/internal/adapter/nfs/v4/handlers/remove.go
@@ -109,7 +109,7 @@ func (h *Handler) handleRemove(ctx *types.CompoundContext, reader io.Reader) *ty
 	}
 
 	// Try RemoveFile first (works for regular files, symlinks, etc.)
-	_, _, removeErr := metaSvc.RemoveFile(authCtx, parentHandle, target)
+	removedFile, _, removeErr := metaSvc.RemoveFile(authCtx, parentHandle, target)
 	if removeErr != nil {
 		// Check if the error indicates this is a directory (ErrIsDirectory)
 		var storeErr *metaerrors.StoreError
@@ -130,6 +130,26 @@ func (h *Handler) handleRemove(ctx *types.CompoundContext, reader io.Reader) *ty
 			Status: status,
 			OpCode: types.OP_REMOVE,
 			Data:   encodeStatusOnly(status),
+		}
+	}
+
+	// RemoveFile drops the name and the inode but never the bytes: the caller
+	// coordinates content deletion from the PayloadID it returns, which is empty
+	// whenever the content must survive (a remaining hard link, or a recycle to
+	// trash). Skipping this leaves the payload's local journal records indexed as
+	// live, so their segments are never reclaimed and the share keeps its bytes on
+	// disk across restarts even once every file in it is gone. Best-effort: the
+	// entry is already removed from the client's view, and the block GC sweep
+	// reclaims a straggler payload.
+	if removedFile != nil && removedFile.PayloadID != "" {
+		payloadID := string(removedFile.PayloadID)
+		blockStore, bsErr := common.ResolveForWrite(ctx.Context, h.Registry, parentHandle)
+		if bsErr != nil {
+			logger.Warn("NFSv4 REMOVE: no block store for content delete",
+				"target", target, "payload_id", payloadID, "error", bsErr)
+		} else if delErr := blockStore.Delete(ctx.Context, payloadID, nil); delErr != nil {
+			logger.Warn("NFSv4 REMOVE: failed to delete content",
+				"target", target, "payload_id", payloadID, "error", delErr)
 		}
 	}
 


### PR DESCRIPTION
## The issue's premise was wrong

#2268 was filed against `reclaimEmptied` in `pkg/block/journal/reclaim.go`, on the theory that local reclamation only ever scans the sealed set and so strands a fully-dead active segment. That is not what happened, and `reclaimEmptied` is not at fault — **it was never reached, because the NFSv4 REMOVE handler never told the block store anything had been deleted.**

`metadata.Service.RemoveFile` is explicit about its contract (`pkg/metadata/file_remove.go`):

```
// Important: Does NOT delete the file's content data.
// The returned File includes PayloadID for caller to coordinate content deletion.
// PayloadID is empty if other hard links still reference the content.
```

The NFSv4 handler discarded that return value outright:

```go
_, _, removeErr := metaSvc.RemoveFile(authCtx, parentHandle, target)
```

so `blockStore.Delete` was never called, the journal never got a tombstone, the removed file's records stayed indexed as **live**, and no reclamation path — fast-path retire, eviction, or repack — could ever treat them as dead. The bytes survived the unlink and every subsequent restart.

The gap is NFSv4-only. NFSv3 REMOVE has done this since forever (`internal/adapter/nfs/v3/handlers/remove.go`), and SMB has `purgeBlockStorePayload` (`internal/adapter/smb/handlers/handler.go`). Before this PR there was not a single `blockStore.Delete` call anywhere under `internal/adapter/nfs/v4/`:

```
$ grep -rn "\.Delete(ctx" internal/adapter/nfs/v4/ | grep -v _test
(no output)
```

The v4 handler's own doc comment already claimed `Removes directory entry and metadata; deletes payload content for files` — it just never did.

This also explains the field measurement in the issue: S3 dropped to 0 objects because the block-GC sweep derives orphans from (synced − live) in the metadata store, which the metadata removal alone is enough to drive. Only the **local** tier depended on the missing `blockStore.Delete`.

## The fix

Capture the removed file and purge its payload, guarded on the PayloadID contract, best-effort — the same shape as v3 and SMB. An empty PayloadID is exactly the signal that the content must survive (a remaining hard link, or a recycle into the trash bin — `recycleNode` returns a copy with PayloadID cleared), so the guard is hard-link- and trash-safe.

## Verification

`reclaimEmptied` was put on trial first and acquitted by running it. With the journal told about the delete, it already reclaims everything, on both the hydrated-synced and the write-then-carve paths:

```
before delete: sealed=5 activeID=5 actRec=1 actSynced=1 index=1
   sealed 0..4  rec=3 synced=3 busy=false tail=786598
   diskBytes=4195232  onDisk=4195872
after delete:  sealed=0 activeID=6 actRec=0 actSynced=0 index=0
   diskBytes=30       onDisk=64
```

New regression test `TestRemove_ReclaimsLocalPayloadBytes` (`internal/adapter/nfs/v4/handlers/io_test.go`) writes 4 MiB through the real journal-backed local tier, drives the real `handleRemove`, and asserts the payload is gone from the local tier afterwards. It was run against a deliberately unfixed build first (fix stashed, test kept):

```
--- FAIL: TestRemove_ReclaimsLocalPayloadBytes (0.14s)
    io_test.go:1672: payload "export/9850f946-4a24-4f3d-be93-c9214f3ce658" still holds 4194304 live bytes in the local tier after REMOVE
FAIL
```

and with the fix:

```
ok  github.com/marmos91/dittofs/internal/adapter/nfs/v4/handlers  0.812s
```

It asserts block-store state an operator can observe (the payload is unknown to the local tier), not the handler's internal mechanism — that is the precondition every reclamation path shares.

Also green: `go test -race ./pkg/block/...`, `go test ./internal/adapter/nfs/...`, `go test ./pkg/metadata/...`, `go vet`.

## Adjacent finding, deliberately not fixed here

While proving `reclaimEmptied` innocent I measured one real residual, which is a separate design call and not what #2268 reports:

On a **local-only** share (no remote), a deleted file's records are never `synced`, so `sealableActive`/`evictable`'s synced gate refuses a segment that backs zero live intervals. Sealed segments in that state are still reclaimed — the 30 s GC repack has no synced gate and treats a fully-dead segment as ratio 1.0 (measured: `gc pass 0: {SegmentsRepacked:3 BytesReclaimed:2359296}`) — but a fully-dead **active** segment is reclaimed by nothing until enough new writes rotate it, so up to `SegmentSize` (256 MiB default) per shard can sit until the share is written to again. Loosening the synced gate for a zero-live segment would trade against the wedge #2266 just fixed, so it is left alone here.

A sweep of every other last-link-dropping call site in the v4 adapter found no second instance of this defect class. It did turn up one **pre-existing gap shared by v3 and v4**: a rename that clobbers an existing destination file leaks that file's payload (`internal/adapter/nfs/v4/handlers/rename.go:152`, `internal/adapter/nfs/v3/handlers/rename.go:258`). It is not fixable in the adapters — `metadata.Service.Move` (`pkg/metadata/file_modify.go:605`) drops the victim's last link inside its transaction and never surfaces its PayloadID — and trash-enabled shares are already covered by `recycleNode`. Out of scope here.

Closes #2268
