### PR TITLE
fix(metadata): release a file's bytes from the share usage counters when its last link goes

### DIFF
--- a/cmd/dfsctl/commands/store/metadata/metadata.go
+++ b/cmd/dfsctl/commands/store/metadata/metadata.go
@@ -31,4 +31,5 @@ func init() {
 	Cmd.AddCommand(editCmd)
 	Cmd.AddCommand(removeCmd)
 	Cmd.AddCommand(healthCmd)
+	Cmd.AddCommand(recomputeUsageCmd)
 }

--- a/cmd/dfsctl/commands/store/metadata/recompute_usage.go
+++ b/cmd/dfsctl/commands/store/metadata/recompute_usage.go
@@ -73,11 +73,23 @@ func runRecomputeUsage(_ *cobra.Command, args []string) error {
 // reported usage was not backed by any file.
 func printRecomputeUsageTable(res *apiclient.UsageRecomputeResult) error {
 	r := res.Result
+	// The rebuild normally only ever removes bytes the share does not hold, but
+	// a write landing during it can leave the share genuinely larger than
+	// before. ByteSize is unsigned, so render that as growth rather than
+	// wrapping the subtraction.
+	moved := "0 B"
+	label := "Reclaimed"
+	if r.BeforeBytes > r.AfterBytes {
+		moved = bytesize.ByteSize(r.BeforeBytes - r.AfterBytes).String()
+	} else if r.AfterBytes > r.BeforeBytes {
+		label = "Added"
+		moved = bytesize.ByteSize(r.AfterBytes - r.BeforeBytes).String()
+	}
 	pairs := [][2]string{
 		{"Share", r.ShareName},
 		{"Used before", bytesize.ByteSize(r.BeforeBytes).String()},
 		{"Used after", bytesize.ByteSize(r.AfterBytes).String()},
-		{"Reclaimed", bytesize.ByteSize(r.BeforeBytes - r.AfterBytes).String()},
+		{label, moved},
 		{"Duration", fmt.Sprintf("%dms", r.DurationMS)},
 	}
 	return output.SimpleTable(os.Stdout, pairs)

--- a/cmd/dfsctl/commands/store/metadata/recompute_usage.go
+++ b/cmd/dfsctl/commands/store/metadata/recompute_usage.go
@@ -1,0 +1,84 @@
+package metadata
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/marmos91/dittofs/cmd/dfsctl/cmdutil"
+	"github.com/marmos91/dittofs/internal/bytesize"
+	"github.com/marmos91/dittofs/internal/cli/output"
+	"github.com/marmos91/dittofs/pkg/apiclient"
+)
+
+// recomputeUsageCmd rebuilds a metadata store's used-bytes counters from its
+// file rows and reports what the named share held before and after.
+var recomputeUsageCmd = &cobra.Command{
+	Use:   "recompute-usage <share>",
+	Short: "Rebuild a share's used-bytes counter from its files",
+	Long: `Rebuild the used-bytes counters of the metadata store backing the named share.
+
+The counters are maintained transactionally as files are written and removed, so
+they are normally already correct. This repairs a store where they are not: a
+share carrying bytes it no longer holds reports itself fuller than it is, and
+because that figure is what the share quota is checked against, it can refuse
+writes to a share that is actually empty.
+
+The rebuild scans every file row in the store, so it takes time in proportion to
+the store's size, and it repairs every share that store serves — not only the
+one named here. Nothing runs it automatically; a per-file walk on every server
+start is a cost every share would pay forever to fix a number that is almost
+always already right.
+
+Examples:
+  dfsctl store metadata recompute-usage myshare
+  dfsctl store metadata recompute-usage myshare -o json`,
+	Args: cobra.ExactArgs(1),
+	RunE: runRecomputeUsage,
+}
+
+func runRecomputeUsage(_ *cobra.Command, args []string) error {
+	share := args[0]
+	client, err := cmdutil.GetAuthenticatedClient()
+	if err != nil {
+		return err
+	}
+
+	res, err := client.RecomputeShareUsage(share)
+	if err != nil {
+		return fmt.Errorf("failed to recompute usage: %w", err)
+	}
+	if res == nil || res.Result == nil {
+		return fmt.Errorf("recompute usage: server returned empty response")
+	}
+
+	format, err := cmdutil.GetOutputFormatParsed()
+	if err != nil {
+		return err
+	}
+
+	switch format {
+	case output.FormatJSON:
+		return output.PrintJSON(os.Stdout, res)
+	case output.FormatYAML:
+		return output.PrintYAML(os.Stdout, res)
+	default:
+		return printRecomputeUsageTable(res)
+	}
+}
+
+// printRecomputeUsageTable renders the repair summary as a key/value table.
+// The reclaimed row is what an operator is here for: how much of the share's
+// reported usage was not backed by any file.
+func printRecomputeUsageTable(res *apiclient.UsageRecomputeResult) error {
+	r := res.Result
+	pairs := [][2]string{
+		{"Share", r.ShareName},
+		{"Used before", bytesize.ByteSize(r.BeforeBytes).String()},
+		{"Used after", bytesize.ByteSize(r.AfterBytes).String()},
+		{"Reclaimed", bytesize.ByteSize(r.BeforeBytes - r.AfterBytes).String()},
+		{"Duration", fmt.Sprintf("%dms", r.DurationMS)},
+	}
+	return output.SimpleTable(os.Stdout, pairs)
+}

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -724,6 +724,7 @@ Global flags:
       - [`dfsctl store metadata edit`](#dfsctl-store-metadata-edit) — Edit a metadata store
       - [`dfsctl store metadata health`](#dfsctl-store-metadata-health) — Check metadata store health
       - [`dfsctl store metadata list`](#dfsctl-store-metadata-list) — List metadata stores
+      - [`dfsctl store metadata recompute-usage`](#dfsctl-store-metadata-recompute-usage) — Rebuild a share's used-bytes counter from its files
       - [`dfsctl store metadata remove`](#dfsctl-store-metadata-remove) — Remove a metadata store
   - [`dfsctl switch-user`](#dfsctl-switch-user) — Switch to a different user on the current server
   - [`dfsctl system`](#dfsctl-system) — System operations
@@ -6738,6 +6739,49 @@ dfsctl store metadata list -o json
 
 # List as YAML
 dfsctl store metadata list -o yaml
+```
+
+Global flags:
+
+```
+      --cacert string        Path to a PEM CA bundle trusted for the server certificate (overrides stored)
+      --client-cert string   Path to a PEM client certificate for mutual TLS (overrides stored)
+      --client-key string    Path to the PEM client private key for mutual TLS (overrides stored)
+      --no-color             Disable colored output
+  -o, --output string        Output format (table|json|yaml) (default "table")
+      --server string        Server URL (overrides stored credential)
+      --tls-skip-verify      Disable TLS certificate verification (insecure; overrides stored)
+      --token string         Bearer token (overrides stored credential)
+  -v, --verbose              Enable verbose output
+```
+
+### `dfsctl store metadata recompute-usage`
+
+Rebuild a share's used-bytes counter from its files
+
+Rebuild the used-bytes counters of the metadata store backing the named share.
+
+The counters are maintained transactionally as files are written and removed, so
+they are normally already correct. This repairs a store where they are not: a
+share carrying bytes it no longer holds reports itself fuller than it is, and
+because that figure is what the share quota is checked against, it can refuse
+writes to a share that is actually empty.
+
+The rebuild scans every file row in the store, so it takes time in proportion to
+the store's size, and it repairs every share that store serves — not only the
+one named here. Nothing runs it automatically; a per-file walk on every server
+start is a cost every share would pay forever to fix a number that is almost
+always already right.
+
+```
+dfsctl store metadata recompute-usage <share>
+```
+
+**Examples:**
+
+```bash
+dfsctl store metadata recompute-usage myshare
+dfsctl store metadata recompute-usage myshare -o json
 ```
 
 Global flags:

--- a/docs/guide/quotas.md
+++ b/docs/guide/quotas.md
@@ -52,3 +52,19 @@ dfsctl quota remove /export --scope user --id 1000
 
 Quota limits live in the control-plane database and are also reachable via the REST API
 at `/api/v1/shares/{name}/quotas`.
+
+## Repairing a drifted usage figure
+
+Usage counters are maintained transactionally as files are written and removed, so they
+are normally already correct. If a share reports more bytes than its files hold — most
+visibly, it refuses writes while `dfsctl share list` shows it far from full — rebuild them
+from the file rows:
+
+```bash
+dfsctl store metadata recompute-usage /export
+```
+
+The rebuild scans every file row in the metadata store, so it takes time in proportion to
+the store's size, and it repairs every share that store serves rather than only the one
+named. Nothing runs it automatically: a per-file walk on every server start would be a
+cost every share pays forever to correct a number that is almost always already right.

--- a/internal/controlplane/api/handlers/usage_recompute.go
+++ b/internal/controlplane/api/handlers/usage_recompute.go
@@ -43,13 +43,9 @@ type UsageRecomputeResponse struct {
 // Recompute handles POST /api/v1/shares/{name}/usage/recompute.
 //
 // It rebuilds the metadata store's used-bytes counters from its file rows and
-// reports the named share's figure before and after. A share carrying bytes it
-// no longer holds reports itself fuller than it is, and that figure gates
-// writes through the share quota — this is the repair for one.
-//
-// The rebuild scans every file row in the store, so it is slow in proportion to
-// the store's size and covers every share the store serves, not only the named
-// one.
+// reports the named share's figure before and after. The scan covers every file
+// row in the store, so it is slow in proportion to the store's size and repairs
+// every share that store serves, not only the named one.
 //
 // Status codes:
 //   - 200 OK with UsageRecomputeResponse on success

--- a/internal/controlplane/api/handlers/usage_recompute.go
+++ b/internal/controlplane/api/handlers/usage_recompute.go
@@ -1,0 +1,85 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime/shares"
+)
+
+// UsageRecomputeRuntime is the narrow Runtime surface needed by
+// UsageRecomputeHandler. Declaring it here rather than depending on
+// *runtime.Runtime keeps the handler unit-testable with a fake.
+type UsageRecomputeRuntime interface {
+	// RecomputeShareUsage rebuilds the metadata store's used-bytes counters
+	// from its file rows and reports what the named share held before and
+	// after.
+	RecomputeShareUsage(ctx context.Context, shareName string) (*runtime.UsageRecomputeResult, error)
+}
+
+// UsageRecomputeHandler exposes the on-demand used-bytes repair endpoint.
+type UsageRecomputeHandler struct {
+	runtime UsageRecomputeRuntime
+}
+
+// NewUsageRecomputeHandler constructs a handler bound to the given Runtime
+// surface. A nil runtime is refused per-request so the server still boots in
+// degraded modes.
+func NewUsageRecomputeHandler(rt UsageRecomputeRuntime) *UsageRecomputeHandler {
+	return &UsageRecomputeHandler{runtime: rt}
+}
+
+// UsageRecomputeResponse wraps the repair result for JSON output. Returned by
+// POST /api/v1/shares/{name}/usage/recompute.
+type UsageRecomputeResponse struct {
+	Result *runtime.UsageRecomputeResult `json:"result"`
+}
+
+// Recompute handles POST /api/v1/shares/{name}/usage/recompute.
+//
+// It rebuilds the metadata store's used-bytes counters from its file rows and
+// reports the named share's figure before and after. A share carrying bytes it
+// no longer holds reports itself fuller than it is, and that figure gates
+// writes through the share quota — this is the repair for one.
+//
+// The rebuild scans every file row in the store, so it is slow in proportion to
+// the store's size and covers every share the store serves, not only the named
+// one.
+//
+// Status codes:
+//   - 200 OK with UsageRecomputeResponse on success
+//   - 400 Bad Request when {name} is empty
+//   - 404 Not Found when {name} is not a registered share
+//   - 500 Internal Server Error on unexpected runtime errors
+func (h *UsageRecomputeHandler) Recompute(w http.ResponseWriter, r *http.Request) {
+	if h.runtime == nil {
+		InternalServerError(w, "runtime not initialized")
+		return
+	}
+
+	name := normalizeShareName(chi.URLParam(r, "name"))
+	if name == "/" {
+		BadRequest(w, "share name is required")
+		return
+	}
+
+	res, err := h.runtime.RecomputeShareUsage(r.Context(), name)
+	if err != nil {
+		if errors.Is(err, shares.ErrShareNotFound) {
+			NotFound(w, "share not found: "+name)
+			return
+		}
+		// The underlying error can carry filesystem paths and DSNs, so it is
+		// logged rather than returned.
+		logger.Debug("Share used-bytes recompute error", "share", name, "error", err)
+		InternalServerError(w, "usage recompute failed")
+		return
+	}
+
+	WriteJSONOK(w, UsageRecomputeResponse{Result: res})
+}

--- a/internal/controlplane/api/handlers/usage_recompute_test.go
+++ b/internal/controlplane/api/handlers/usage_recompute_test.go
@@ -1,0 +1,97 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime/shares"
+)
+
+// fakeUsageRecomputeRuntime is a recording stand-in for
+// handlers.UsageRecomputeRuntime.
+type fakeUsageRecomputeRuntime struct {
+	res   *runtime.UsageRecomputeResult
+	err   error
+	calls []string
+}
+
+func (f *fakeUsageRecomputeRuntime) RecomputeShareUsage(_ context.Context, shareName string) (*runtime.UsageRecomputeResult, error) {
+	f.calls = append(f.calls, shareName)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.res, nil
+}
+
+func newRecomputeRequest(share string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/shares/"+share+"/usage/recompute", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("name", share)
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
+
+func TestUsageRecomputeHandler_Success(t *testing.T) {
+	fake := &fakeUsageRecomputeRuntime{
+		res: &runtime.UsageRecomputeResult{
+			ShareName:   "/myshare",
+			BeforeBytes: 1256,
+			AfterBytes:  256,
+			DurationMS:  7,
+		},
+	}
+	h := NewUsageRecomputeHandler(fake)
+
+	w := httptest.NewRecorder()
+	h.Recompute(w, newRecomputeRequest("myshare"))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	var got UsageRecomputeResponse
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got.Result == nil || got.Result.BeforeBytes != 1256 || got.Result.AfterBytes != 256 {
+		t.Fatalf("result = %+v, want the runtime's before/after round-tripped", got.Result)
+	}
+	if len(fake.calls) != 1 || fake.calls[0] != "/myshare" {
+		t.Fatalf("runtime calls = %v, want one call for /myshare", fake.calls)
+	}
+}
+
+func TestUsageRecomputeHandler_UnknownShare(t *testing.T) {
+	fake := &fakeUsageRecomputeRuntime{err: fmt.Errorf("resolve: %w", shares.ErrShareNotFound)}
+	h := NewUsageRecomputeHandler(fake)
+
+	w := httptest.NewRecorder()
+	h.Recompute(w, newRecomputeRequest("ghost"))
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+// TestUsageRecomputeHandler_ErrorNotEchoed pins that an unexpected failure is
+// reported without the underlying error text, which can carry DSNs and paths.
+func TestUsageRecomputeHandler_ErrorNotEchoed(t *testing.T) {
+	fake := &fakeUsageRecomputeRuntime{err: fmt.Errorf("dial postgres://user:hunter2@db:5432: refused")}
+	h := NewUsageRecomputeHandler(fake)
+
+	w := httptest.NewRecorder()
+	h.Recompute(w, newRecomputeRequest("myshare"))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+	if body := w.Body.String(); strings.Contains(body, "hunter2") {
+		t.Fatalf("response body leaked the underlying error: %s", body)
+	}
+}

--- a/pkg/apiclient/usage.go
+++ b/pkg/apiclient/usage.go
@@ -1,0 +1,29 @@
+package apiclient
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+)
+
+// UsageRecomputeResult is the response body for RecomputeShareUsage. Mirrors
+// the server-side handlers.UsageRecomputeResponse shape.
+type UsageRecomputeResult struct {
+	Result *runtime.UsageRecomputeResult `json:"result"`
+}
+
+// RecomputeShareUsage rebuilds the metadata store's used-bytes counters from
+// its file rows and returns the named share's figure before and after.
+//
+// A share whose counter drifted above what its files hold reports itself
+// fuller than it is, and that figure gates writes through the share quota. The
+// rebuild scans every file row in the store, so it is slow in proportion to the
+// store's size and repairs every share that store serves, not only this one.
+func (c *Client) RecomputeShareUsage(shareName string) (*UsageRecomputeResult, error) {
+	return createResource[UsageRecomputeResult](
+		c,
+		fmt.Sprintf("/api/v1/shares/%s/usage/recompute", url.PathEscape(normalizeShareNameForAPI(shareName))),
+		struct{}{},
+	)
+}

--- a/pkg/apiclient/usage.go
+++ b/pkg/apiclient/usage.go
@@ -15,11 +15,8 @@ type UsageRecomputeResult struct {
 
 // RecomputeShareUsage rebuilds the metadata store's used-bytes counters from
 // its file rows and returns the named share's figure before and after.
-//
-// A share whose counter drifted above what its files hold reports itself
-// fuller than it is, and that figure gates writes through the share quota. The
-// rebuild scans every file row in the store, so it is slow in proportion to the
-// store's size and repairs every share that store serves, not only this one.
+// The scan covers every file row in the store, so it is slow in proportion to
+// the store's size and repairs every share that store serves, not only this one.
 func (c *Client) RecomputeShareUsage(shareName string) (*UsageRecomputeResult, error) {
 	return createResource[UsageRecomputeResult](
 		c,

--- a/pkg/apiclient/usage.go
+++ b/pkg/apiclient/usage.go
@@ -3,14 +3,26 @@ package apiclient
 import (
 	"fmt"
 	"net/url"
-
-	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
 )
 
 // UsageRecomputeResult is the response body for RecomputeShareUsage. Mirrors
 // the server-side handlers.UsageRecomputeResponse shape.
 type UsageRecomputeResult struct {
-	Result *runtime.UsageRecomputeResult `json:"result"`
+	Result *ShareUsageRecompute `json:"result"`
+}
+
+// ShareUsageRecompute reports what a share's used-bytes repair moved. Declared
+// here rather than reused from the server so a client build does not pull in
+// the control-plane runtime.
+type ShareUsageRecompute struct {
+	// ShareName is the share the counter was read for.
+	ShareName string `json:"share_name"`
+	// BeforeBytes is the share's used bytes as reported before the rebuild.
+	BeforeBytes int64 `json:"before_bytes"`
+	// AfterBytes is what its live files actually add up to.
+	AfterBytes int64 `json:"after_bytes"`
+	// DurationMS is how long the rebuild took.
+	DurationMS int64 `json:"duration_ms"`
 }
 
 // RecomputeShareUsage rebuilds the metadata store's used-bytes counters from

--- a/pkg/controlplane/api/router.go
+++ b/pkg/controlplane/api/router.go
@@ -200,6 +200,7 @@ func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.S
 			blockGCHandler := handlers.NewBlockStoreGCHandler(rt)
 			blockAuditHandler := handlers.NewBlockStoreAuditHandler(rt)
 			manifestCheckHandler := handlers.NewBlockStoreManifestCheckHandler(rt)
+			usageRecomputeHandler := handlers.NewUsageRecomputeHandler(rt)
 			mountHandler := handlers.NewMountHandler(rt)
 
 			// Share management (admin only)
@@ -310,6 +311,7 @@ func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.S
 				// inherited admin middleware); persists last-inv02.json
 				// under the share's audit-state directory.
 				r.Post("/{name}/audit/refcounts", blockAuditHandler.RunAudit)
+				r.Post("/{name}/usage/recompute", usageRecomputeHandler.Recompute)
 
 				// Per-share manifest-coverage scan. Metadata-only: it
 				// reads no block data and touches no remote store.

--- a/pkg/controlplane/runtime/usage_recompute.go
+++ b/pkg/controlplane/runtime/usage_recompute.go
@@ -22,20 +22,10 @@ type UsageRecomputeResult struct {
 // RecomputeShareUsage rebuilds the used-bytes counters from the metadata
 // store's file rows and reports what the named share held before and after.
 //
-// The counters are maintained transactionally and are correct on a store that
-// has only ever run code that maintains them. This repairs one that has not:
-// a share carrying bytes from a version that never released them on unlink
-// reports itself fuller than it is, and since that figure gates writes through
-// the share quota, it can report itself full while holding nothing.
-//
-// The rebuild is a full scan of the store's file rows, so this is an
-// operator-invoked repair, not something the server does at startup — a
-// per-file walk on every boot is a cost every share pays forever to fix a
-// number that is almost always already right.
-//
-// It covers every share served by the same metadata store instance, not only
-// the named one: they share the scan, and rebuilding one share's buckets alone
-// would cost exactly the same.
+// The rebuild is a full scan of the store's file rows, which is why it runs
+// only when asked. It covers every share served by that store instance, not
+// only the named one: rebuilding one share's buckets alone costs the same
+// scan.
 //
 // Returns ErrShareNotFound (wrapped) when the share is unknown.
 func (r *Runtime) RecomputeShareUsage(ctx context.Context, shareName string) (*UsageRecomputeResult, error) {

--- a/pkg/controlplane/runtime/usage_recompute.go
+++ b/pkg/controlplane/runtime/usage_recompute.go
@@ -1,0 +1,76 @@
+package runtime
+
+import (
+	"context"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/logger"
+)
+
+// UsageRecomputeResult reports what a share's used-bytes repair moved.
+type UsageRecomputeResult struct {
+	// ShareName is the share the counter was read for.
+	ShareName string `json:"share_name"`
+	// BeforeBytes is the share's used bytes as reported before the rebuild.
+	BeforeBytes int64 `json:"before_bytes"`
+	// AfterBytes is what its live files actually add up to.
+	AfterBytes int64 `json:"after_bytes"`
+	// DurationMS is how long the rebuild took.
+	DurationMS int64 `json:"duration_ms"`
+}
+
+// RecomputeShareUsage rebuilds the used-bytes counters from the metadata
+// store's file rows and reports what the named share held before and after.
+//
+// The counters are maintained transactionally and are correct on a store that
+// has only ever run code that maintains them. This repairs one that has not:
+// a share carrying bytes from a version that never released them on unlink
+// reports itself fuller than it is, and since that figure gates writes through
+// the share quota, it can report itself full while holding nothing.
+//
+// The rebuild is a full scan of the store's file rows, so this is an
+// operator-invoked repair, not something the server does at startup — a
+// per-file walk on every boot is a cost every share pays forever to fix a
+// number that is almost always already right.
+//
+// It covers every share served by the same metadata store instance, not only
+// the named one: they share the scan, and rebuilding one share's buckets alone
+// would cost exactly the same.
+//
+// Returns ErrShareNotFound (wrapped) when the share is unknown.
+func (r *Runtime) RecomputeShareUsage(ctx context.Context, shareName string) (*UsageRecomputeResult, error) {
+	mds, err := r.GetMetadataStoreForShare(shareName)
+	if err != nil {
+		return nil, err
+	}
+
+	before, err := mds.GetUsedBytesForShare(ctx, shareName)
+	if err != nil {
+		return nil, err
+	}
+
+	start := time.Now()
+	if err := mds.RecomputeUsage(ctx); err != nil {
+		return nil, err
+	}
+	elapsed := time.Since(start)
+
+	after, err := mds.GetUsedBytesForShare(ctx, shareName)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Info("Share used-bytes recompute complete",
+		"share", shareName,
+		"beforeBytes", before,
+		"afterBytes", after,
+		"durationMs", elapsed.Milliseconds(),
+	)
+
+	return &UsageRecomputeResult{
+		ShareName:   shareName,
+		BeforeBytes: before,
+		AfterBytes:  after,
+		DurationMS:  elapsed.Milliseconds(),
+	}, nil
+}

--- a/pkg/metadata/quota_unlink_test.go
+++ b/pkg/metadata/quota_unlink_test.go
@@ -1,0 +1,82 @@
+package metadata_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// TestRemoveFileReleasesShareUsage walks the production unlink path and pins
+// that it gives the share's bytes back.
+//
+// RemoveFile deliberately does not delete the inode — it drops the directory
+// entry and sets nlink to 0, so fstat(2) on a descriptor that is still open
+// keeps working. The usage counter therefore cannot key off the row's
+// existence, and a quota'd share whose counter only ever rises fills
+// permanently: a delete frees no space and the next write is refused.
+func TestRemoveFileReleasesShareUsage(t *testing.T) {
+	store := memory.NewMemoryMetadataStoreWithDefaults()
+	ctx := context.Background()
+	svc := metadata.New()
+	svc.SetDeferredCommit(false)
+
+	const share = "/usage"
+	root, err := store.CreateRootDirectory(ctx, share, &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory, Mode: 0o777,
+	})
+	require.NoError(t, err)
+	require.NoError(t, svc.RegisterStoreForShare(share, store))
+	rootHandle, err := metadata.EncodeShareHandle(share, root.ID)
+	require.NoError(t, err)
+
+	auth := &metadata.AuthContext{
+		Context: ctx, AuthMethod: "unix",
+		Identity: &metadata.Identity{UID: metadata.Uint32Ptr(0), GID: metadata.Uint32Ptr(0), GIDs: []uint32{0}},
+	}
+
+	file, _, err := svc.CreateFile(auth, rootHandle, "big.bin", &metadata.FileAttr{
+		Type: metadata.FileTypeRegular, Mode: 0o644,
+	})
+	require.NoError(t, err)
+	handle, err := metadata.EncodeShareHandle(share, file.ID)
+	require.NoError(t, err)
+
+	require.NoError(t, store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+		f, gErr := tx.GetFile(ctx, handle)
+		if gErr != nil {
+			return gErr
+		}
+		f.Size = 50 << 20
+		return tx.UpdateAttrs(ctx, f)
+	}))
+
+	used, err := store.GetUsedBytesForShare(ctx, share)
+	require.NoError(t, err)
+	require.Equal(t, int64(50<<20), used, "the write must be charged to the share")
+
+	_, _, err = svc.RemoveFile(auth, rootHandle, "big.bin")
+	require.NoError(t, err)
+
+	used, err = store.GetUsedBytesForShare(ctx, share)
+	require.NoError(t, err)
+	require.Zero(t, used, "unlinking the only file must give the share its bytes back")
+
+	// The inode is still there for any descriptor that outlived the unlink.
+	_, err = store.GetFile(ctx, handle)
+	require.NoError(t, err, "RemoveFile must keep the inode for open descriptors")
+
+	// A quota that the stale figure would have filled still admits a write.
+	svc.SetQuotaForShare(share, 60<<20)
+	next, _, err := svc.CreateFile(auth, rootHandle, "next.bin", &metadata.FileAttr{
+		Type: metadata.FileTypeRegular, Mode: 0o644,
+	})
+	require.NoError(t, err)
+	nextHandle, err := metadata.EncodeShareHandle(share, next.ID)
+	require.NoError(t, err)
+	_, err = svc.PrepareWrite(auth, nextHandle, 50<<20)
+	require.NoError(t, err, "the share is empty again, so a write that fits the quota must be admitted")
+}

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -549,6 +549,22 @@ type Store interface {
 	// accumulated (memory).
 	GetQuotaUsage(shareName string, scope QuotaScope, id uint32) (UsageStat, error)
 
+	// RecomputeUsage rebuilds the usage counters from the durable file rows,
+	// replacing whatever the in-memory buckets currently hold.
+	//
+	// The counters are maintained by transactional deltas, so a backend bug or
+	// an upgrade from a version that accounted differently leaves a share
+	// reporting a figure its files do not support — and since the number gates
+	// writes through the share quota, a share can report itself full while
+	// holding nothing. This is the repair, run on demand: it is a full scan of
+	// the store's file rows, which is why nothing calls it on the write path or
+	// at startup.
+	//
+	// It is store-wide rather than per-share: one store instance backs every
+	// share naming the same metadata store config, and rebuilding one share's
+	// buckets costs the same scan as rebuilding all of them.
+	RecomputeUsage(ctx context.Context) error
+
 	// ========================================================================
 	// Store Lifecycle (not transactional)
 	// ========================================================================

--- a/pkg/metadata/store/badger/shares.go
+++ b/pkg/metadata/store/badger/shares.go
@@ -163,9 +163,11 @@ func (s *BadgerMetadataStore) deleteShareFiles(txn *badgerdb.Txn, shareName stri
 			payloadID: file.PayloadID,
 			isDir:     file.Type == metadata.FileTypeDirectory,
 			size:      file.Size,
-			isReg:     file.Type == metadata.FileTypeRegular,
-			uid:       file.UID,
-			gid:       file.GID,
+			// An unlinked-but-open inode released its bytes when its last name
+			// went, so the share has none of them left to give back here.
+			isReg: basestore.Charged(file.Type, fileLinkCountTxn(txn, file)),
+			uid:   file.UID,
+			gid:   file.GID,
 		})
 	}
 	it.Close()

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -888,3 +888,14 @@ func (s *BadgerMetadataStore) GetStoreID() string { return s.storeID }
 
 // Compile-time assertion: the Badger engine exposes GetStoreID.
 var _ interface{ GetStoreID() string } = (*BadgerMetadataStore)(nil)
+
+// RecomputeUsage rebuilds the usage counters from the durable file rows,
+// discarding whatever the in-memory buckets hold. Same scan the store runs at
+// open, re-run on demand; the payload index is already built by then, so
+// nothing is staged this time.
+func (s *BadgerMetadataStore) RecomputeUsage(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return s.initUsedBytesCounter(nil)
+}

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -897,5 +897,11 @@ func (s *BadgerMetadataStore) RecomputeUsage(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	// The scan runs with no lock held, so arm the cache to record what commits
+	// during it — otherwise a transaction landing between the scan and the seed
+	// is scanned out and then overwritten.
+	s.quotaMu.Lock()
+	s.quota.BeginRebuild()
+	s.quotaMu.Unlock()
 	return s.initUsedBytesCounter(nil)
 }

--- a/pkg/metadata/store/badger/store.go
+++ b/pkg/metadata/store/badger/store.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	badger "github.com/dgraph-io/badger/v4"
+	"github.com/google/uuid"
 	"github.com/oklog/ulid/v2"
 
 	"github.com/marmos91/dittofs/pkg/block"
@@ -657,6 +658,31 @@ func (s *BadgerMetadataStore) initUsedBytesCounter(indexBatch *badger.WriteBatch
 	}
 
 	err := s.db.View(func(txn *badger.Txn) error {
+		// An unlinked-but-open inode keeps its row so fstat(2) on a live
+		// descriptor still works, but it no longer holds any of the share's
+		// bytes. Collect those first — the l: values are four bytes each, so
+		// this pass costs a fraction of the file decode below, and only the
+		// unlinked ids are retained.
+		unlinked := make(map[uuid.UUID]struct{})
+		lcOpts := badger.DefaultIteratorOptions
+		lcOpts.Prefix = []byte(prefixLinkCount)
+		lcOpts.PrefetchValues = true
+		lcIt := txn.NewIterator(lcOpts)
+		for lcIt.Rewind(); lcIt.Valid(); lcIt.Next() {
+			item := lcIt.Item()
+			id, idErr := uuid.Parse(string(item.Key()[len(prefixLinkCount):]))
+			if idErr != nil {
+				continue
+			}
+			_ = item.Value(func(val []byte) error {
+				if c, decErr := decodeUint32(val); decErr == nil && c == 0 {
+					unlinked[id] = struct{}{}
+				}
+				return nil
+			})
+		}
+		lcIt.Close()
+
 		opts := badger.DefaultIteratorOptions
 		opts.Prefix = []byte(prefixFile)
 		opts.PrefetchValues = true
@@ -671,7 +697,8 @@ func (s *BadgerMetadataStore) initUsedBytesCounter(indexBatch *badger.WriteBatch
 				if err != nil {
 					return nil // Skip corrupted entries
 				}
-				if file.Type == metadata.FileTypeRegular {
+				_, isUnlinked := unlinked[file.ID]
+				if file.Type == metadata.FileTypeRegular && !isUnlinked {
 					addUsage(basestore.QuotaKey{Share: file.ShareName, Scope: metadata.QuotaScopeUser, ID: file.UID}, int64(file.Size))
 					addUsage(basestore.QuotaKey{Share: file.ShareName, Scope: metadata.QuotaScopeGroup, ID: file.GID}, int64(file.Size))
 				}

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -397,10 +397,8 @@ func (tx *badgerTransaction) putFile(ctx context.Context, file *metadata.File, w
 	// Track size delta for regular files. Accumulated on the tx and applied
 	// once after a successful commit so a conflict-retry never double-counts.
 	//
-	// This write never touches the l: key, so the link count is the same before
-	// and after: an inode whose last name is already gone holds no share bytes
-	// to move, and a write through a still-open descriptor must not put them
-	// back.
+	// This write never touches the l: key, so the pre-write count is also the
+	// post-write one.
 	if basestore.Charged(file.Type, fileLinkCountTxn(tx.txn, file)) {
 		switch {
 		case !hadOldRegular:
@@ -945,7 +943,11 @@ func (tx *badgerTransaction) SetLinkCount(ctx context.Context, handle metadata.F
 	// what puts an inode's bytes into the share's usage or takes them back out,
 	// and once the l: key is overwritten there is no way to tell which side it
 	// came from. A missing inode owes the counters nothing.
-	if item, gErr := tx.txn.Get(keyFile(fileID)); gErr == nil {
+	item, gErr := tx.txn.Get(keyFile(fileID))
+	if gErr != nil && !goerrors.Is(gErr, badgerdb.ErrKeyNotFound) {
+		return gErr
+	}
+	if gErr == nil {
 		raw, vErr := item.ValueCopy(nil)
 		if vErr != nil {
 			return vErr
@@ -958,14 +960,13 @@ func (tx *badgerTransaction) SetLinkCount(ctx context.Context, handle metadata.F
 		// dropping a hard link alongside others leaves the inode charged
 		// exactly once either way.
 		was := basestore.Charged(file.Type, fileLinkCountTxn(tx.txn, file))
-		switch now := basestore.Charged(file.Type, count); {
+		now := basestore.Charged(file.Type, count)
+		switch {
 		case was && !now:
 			tx.quota.Add(file.ShareName, file.UID, file.GID, -int64(file.Size), -1)
 		case !was && now:
 			tx.quota.Add(file.ShareName, file.UID, file.GID, int64(file.Size), 1)
 		}
-	} else if gErr != badgerdb.ErrKeyNotFound {
-		return gErr
 	}
 
 	tx.dirtyFiles = append(tx.dirtyFiles, fileID.String())

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -396,7 +396,12 @@ func (tx *badgerTransaction) putFile(ctx context.Context, file *metadata.File, w
 
 	// Track size delta for regular files. Accumulated on the tx and applied
 	// once after a successful commit so a conflict-retry never double-counts.
-	if file.Type == metadata.FileTypeRegular {
+	//
+	// This write never touches the l: key, so the link count is the same before
+	// and after: an inode whose last name is already gone holds no share bytes
+	// to move, and a write through a still-open descriptor must not put them
+	// back.
+	if basestore.Charged(file.Type, fileLinkCountTxn(tx.txn, file)) {
 		switch {
 		case !hadOldRegular:
 			tx.quota.Add(file.ShareName, file.UID, file.GID, int64(file.Size), 1)
@@ -522,17 +527,21 @@ func (tx *badgerTransaction) DeleteFile(ctx context.Context, handle metadata.Fil
 	// PayloadID for secondary-index cleanup.
 	var existingObjectID metadata.ContentHash
 	var existingPayloadID metadata.PayloadID
+	var existing *metadata.File
 	_ = item.Value(func(val []byte) error {
 		file, decErr := decodeFile(val)
 		if decErr == nil {
-			if file.Type == metadata.FileTypeRegular {
-				tx.quota.Add(file.ShareName, file.UID, file.GID, -int64(file.Size), -1)
-			}
+			existing = file
 			existingObjectID = file.ObjectID
 			existingPayloadID = file.PayloadID
 		}
 		return nil
 	})
+	// An inode whose last name went already gave its bytes back, so removing
+	// the row itself owes the counters nothing.
+	if existing != nil && basestore.Charged(existing.Type, fileLinkCountTxn(tx.txn, existing)) {
+		tx.quota.Add(existing.ShareName, existing.UID, existing.GID, -int64(existing.Size), -1)
+	}
 
 	// Delete the primary file row plus parent/link-count/ObjectID/PayloadID
 	// keys via the shared per-file teardown (also used by DeleteShare).
@@ -930,6 +939,33 @@ func (tx *badgerTransaction) SetLinkCount(ctx context.Context, handle metadata.F
 			Code:    metadata.ErrInvalidHandle,
 			Message: "invalid file handle",
 		}
+	}
+
+	// Read the pre-image before the count moves. A link count crossing zero is
+	// what puts an inode's bytes into the share's usage or takes them back out,
+	// and once the l: key is overwritten there is no way to tell which side it
+	// came from. A missing inode owes the counters nothing.
+	if item, gErr := tx.txn.Get(keyFile(fileID)); gErr == nil {
+		raw, vErr := item.ValueCopy(nil)
+		if vErr != nil {
+			return vErr
+		}
+		file, decErr := decodeFile(raw)
+		if decErr != nil {
+			return decErr
+		}
+		// Only the crossing between zero and non-zero moves usage: adding or
+		// dropping a hard link alongside others leaves the inode charged
+		// exactly once either way.
+		was := basestore.Charged(file.Type, fileLinkCountTxn(tx.txn, file))
+		switch now := basestore.Charged(file.Type, count); {
+		case was && !now:
+			tx.quota.Add(file.ShareName, file.UID, file.GID, -int64(file.Size), -1)
+		case !was && now:
+			tx.quota.Add(file.ShareName, file.UID, file.GID, int64(file.Size), 1)
+		}
+	} else if gErr != badgerdb.ErrKeyNotFound {
+		return gErr
 	}
 
 	tx.dirtyFiles = append(tx.dirtyFiles, fileID.String())

--- a/pkg/metadata/store/basestore/quota.go
+++ b/pkg/metadata/store/basestore/quota.go
@@ -208,3 +208,16 @@ func (d *QuotaDelta) AddKeyed(k QuotaKey, s metadata.UsageStat) {
 func (d *QuotaDelta) Map() map[QuotaKey]metadata.UsageStat {
 	return d.m
 }
+
+// Charged reports whether an inode contributes to the usage counters. Only
+// regular files hold logical bytes, and only while at least one directory
+// entry still names them.
+//
+// The link count is the deciding term because unlinking the last name does not
+// remove the inode: the row survives with nlink=0 so fstat(2) on a descriptor
+// that is still open keeps reporting the file. Keying usage off the row's
+// existence instead would charge the share for that inode forever, since
+// nothing ever deletes it.
+func Charged(fileType metadata.FileType, nlink uint32) bool {
+	return fileType == metadata.FileTypeRegular && nlink > 0
+}

--- a/pkg/metadata/store/basestore/quota.go
+++ b/pkg/metadata/store/basestore/quota.go
@@ -38,6 +38,12 @@ type QuotaKey struct {
 type QuotaCache struct {
 	byIdentity map[QuotaKey]*metadata.UsageStat
 	byShare    map[string]*metadata.UsageStat
+	// captured accumulates every delta applied while a rebuild is in flight.
+	// A rebuild reads the durable rows with no lock held, so a transaction that
+	// commits between its scan and its Seed would be scanned out and then have
+	// its applied delta overwritten. Seed folds this back in. nil when no
+	// rebuild is in flight.
+	captured map[QuotaKey]metadata.UsageStat
 }
 
 // NewQuotaCache returns an empty, ready-to-use QuotaCache.
@@ -52,6 +58,17 @@ func NewQuotaCache() *QuotaCache {
 func (c *QuotaCache) Reset() {
 	c.byIdentity = make(map[QuotaKey]*metadata.UsageStat)
 	c.byShare = make(map[string]*metadata.UsageStat)
+	c.captured = nil
+}
+
+// BeginRebuild marks the start of a rebuild: until the next Seed, every
+// applied delta is also recorded, so a commit that lands while the rebuild is
+// scanning survives the Seed that replaces the buckets.
+//
+// Startup rebuilds do not need it — nothing is committing yet — and calling
+// Seed without it behaves exactly as before.
+func (c *QuotaCache) BeginRebuild() {
+	c.captured = make(map[QuotaKey]metadata.UsageStat)
 }
 
 // Seed replaces the cache contents with usage pre-aggregated from durable rows
@@ -79,6 +96,15 @@ func (c *QuotaCache) Seed(byIdentity map[QuotaKey]*metadata.UsageStat, byShare m
 	}
 	c.byIdentity = byIdentity
 	c.byShare = byShare
+
+	// Fold back anything that committed while the rebuild was scanning; its
+	// bytes are in the cache's buckets but not in the scan that just replaced
+	// them.
+	if c.captured != nil {
+		replay := c.captured
+		c.captured = nil
+		c.Apply(replay)
+	}
 }
 
 // Get returns the usage for one identity within one share. A missing key
@@ -118,6 +144,17 @@ func (c *QuotaCache) DropShare(share string) {
 // contributes one user-scope entry and one group-scope entry for the same
 // bytes, so counting both would double the share total.
 func (c *QuotaCache) Apply(delta map[QuotaKey]metadata.UsageStat) {
+	// Record the delta for a rebuild in flight, so replacing the buckets does
+	// not drop a commit the rebuild's scan happened to miss.
+	if c.captured != nil {
+		for k, d := range delta {
+			u := c.captured[k]
+			u.Bytes += d.Bytes
+			u.Files += d.Files
+			c.captured[k] = u
+		}
+	}
+
 	// Per-share movements are summed across the share's owners before being
 	// applied, so the result does not depend on map iteration order: applying
 	// them one owner at a time lets the clamp below fire on an intermediate

--- a/pkg/metadata/store/basestore/quota_test.go
+++ b/pkg/metadata/store/basestore/quota_test.go
@@ -94,3 +94,54 @@ func TestApplyPerShareIsOrderIndependent(t *testing.T) {
 		}
 	}
 }
+
+// TestRebuildKeepsConcurrentCommit pins that a rebuild does not discard a
+// transaction that commits while it is scanning.
+//
+// A rebuild reads the durable rows with no lock held and then replaces the
+// cache wholesale. A commit landing in that window is missing from the scan and
+// has already been applied to the buckets the Seed is about to overwrite, so
+// without the capture its bytes vanish until the next mutation touches that
+// owner — on an endpoint whose whole purpose is to make the counter trustworthy.
+func TestRebuildKeepsConcurrentCommit(t *testing.T) {
+	c := NewQuotaCache()
+
+	// A share already holding one 1000-byte file owned by uid 7 / gid 3.
+	var seeded QuotaDelta
+	seeded.Add("/s", 7, 3, 1000, 1)
+	c.Apply(seeded.Map())
+
+	// Seed takes ownership of the map it is handed and mutates it when it
+	// replays, so every rebuild builds its own — exactly as the backends do.
+	scan := func() map[QuotaKey]*metadata.UsageStat {
+		return map[QuotaKey]*metadata.UsageStat{
+			{Share: "/s", Scope: metadata.QuotaScopeUser, ID: 7}:  {Bytes: 1000, Files: 1},
+			{Share: "/s", Scope: metadata.QuotaScopeGroup, ID: 3}: {Bytes: 1000, Files: 1},
+		}
+	}
+
+	// The rebuild starts and reads the rows: it sees only that one file.
+	c.BeginRebuild()
+	scanned := scan()
+
+	// A second file commits before the scan's result is installed.
+	var mid QuotaDelta
+	mid.Add("/s", 7, 3, 500, 1)
+	c.Apply(mid.Map())
+
+	c.Seed(scanned, nil)
+
+	if got := c.Share("/s"); got.Bytes != 1500 || got.Files != 2 {
+		t.Fatalf("share usage after rebuild = %+v, want {1500 2} — the commit that landed mid-scan was dropped", got)
+	}
+	if got := c.Get("/s", metadata.QuotaScopeUser, 7); got.Bytes != 1500 || got.Files != 2 {
+		t.Fatalf("user usage after rebuild = %+v, want {1500 2}", got)
+	}
+
+	// The capture ends with the Seed: a later rebuild must not replay it again.
+	c.BeginRebuild()
+	c.Seed(scan(), nil)
+	if got := c.Share("/s"); got.Bytes != 1000 || got.Files != 1 {
+		t.Fatalf("share usage after a second rebuild = %+v, want {1000 1} — the capture replayed twice", got)
+	}
+}

--- a/pkg/metadata/store/memory/store.go
+++ b/pkg/metadata/store/memory/store.go
@@ -618,35 +618,25 @@ func (store *MemoryMetadataStore) RecomputeUsage(ctx context.Context) error {
 		return err
 	}
 
-	store.mu.RLock()
 	byIdentity := make(map[basestore.QuotaKey]*metadata.UsageStat)
+	addUsage := func(k basestore.QuotaKey, bytes int64) {
+		u := byIdentity[k]
+		if u == nil {
+			u = &metadata.UsageStat{}
+			byIdentity[k] = u
+		}
+		u.Bytes += bytes
+		u.Files++
+	}
+
+	store.mu.RLock()
 	for key, fd := range store.files {
-		if fd.Attr == nil {
+		if fd.Attr == nil || !store.chargedLocked(key, fd.Attr.Type) {
 			continue
 		}
-		count, ok := store.linkCounts[key]
-		if !ok {
-			count = 1
-			if fd.Attr.Type == metadata.FileTypeDirectory {
-				count = 2
-			}
-		}
-		if !basestore.Charged(fd.Attr.Type, count) {
-			continue
-		}
-		for scope, id := range map[metadata.QuotaScope]uint32{
-			metadata.QuotaScopeUser:  fd.Attr.UID,
-			metadata.QuotaScopeGroup: fd.Attr.GID,
-		} {
-			k := basestore.QuotaKey{Share: fd.ShareName, Scope: scope, ID: id}
-			u := byIdentity[k]
-			if u == nil {
-				u = &metadata.UsageStat{}
-				byIdentity[k] = u
-			}
-			u.Bytes += int64(fd.Attr.Size)
-			u.Files++
-		}
+		size := int64(fd.Attr.Size)
+		addUsage(basestore.QuotaKey{Share: fd.ShareName, Scope: metadata.QuotaScopeUser, ID: fd.Attr.UID}, size)
+		addUsage(basestore.QuotaKey{Share: fd.ShareName, Scope: metadata.QuotaScopeGroup, ID: fd.Attr.GID}, size)
 	}
 	store.mu.RUnlock()
 
@@ -654,4 +644,23 @@ func (store *MemoryMetadataStore) RecomputeUsage(ctx context.Context) error {
 	defer store.quotaMu.Unlock()
 	store.quota.Seed(byIdentity, nil)
 	return nil
+}
+
+// chargedLocked reports whether the inode stored under key currently holds
+// share bytes: a regular file with at least one name still reaching it. Must
+// be called with store.mu held.
+//
+// An absent linkCounts entry means no count was ever written, which mirrors
+// GetFile's default-by-type rather than "unlinked" — only an explicit
+// SetLinkCount(0) puts a zero there, and that is what marks an inode as
+// unlinked-but-open.
+func (store *MemoryMetadataStore) chargedLocked(key string, fileType metadata.FileType) bool {
+	count, ok := store.linkCounts[key]
+	if !ok {
+		count = 1
+		if fileType == metadata.FileTypeDirectory {
+			count = 2
+		}
+	}
+	return basestore.Charged(fileType, count)
 }

--- a/pkg/metadata/store/memory/store.go
+++ b/pkg/metadata/store/memory/store.go
@@ -608,3 +608,50 @@ func childPageStart(sortedNames []string, cursor string) int {
 	}
 	return idx
 }
+
+// RecomputeUsage rebuilds the usage counters from the stored file records,
+// discarding whatever the buckets hold. The memory store has no durable rows
+// behind its counters — the records ARE the source of truth — so this is a
+// walk of them under the store lock.
+func (store *MemoryMetadataStore) RecomputeUsage(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	store.mu.RLock()
+	byIdentity := make(map[basestore.QuotaKey]*metadata.UsageStat)
+	for key, fd := range store.files {
+		if fd.Attr == nil {
+			continue
+		}
+		count, ok := store.linkCounts[key]
+		if !ok {
+			count = 1
+			if fd.Attr.Type == metadata.FileTypeDirectory {
+				count = 2
+			}
+		}
+		if !basestore.Charged(fd.Attr.Type, count) {
+			continue
+		}
+		for scope, id := range map[metadata.QuotaScope]uint32{
+			metadata.QuotaScopeUser:  fd.Attr.UID,
+			metadata.QuotaScopeGroup: fd.Attr.GID,
+		} {
+			k := basestore.QuotaKey{Share: fd.ShareName, Scope: scope, ID: id}
+			u := byIdentity[k]
+			if u == nil {
+				u = &metadata.UsageStat{}
+				byIdentity[k] = u
+			}
+			u.Bytes += int64(fd.Attr.Size)
+			u.Files++
+		}
+	}
+	store.mu.RUnlock()
+
+	store.quotaMu.Lock()
+	defer store.quotaMu.Unlock()
+	store.quota.Seed(byIdentity, nil)
+	return nil
+}

--- a/pkg/metadata/store/memory/store.go
+++ b/pkg/metadata/store/memory/store.go
@@ -618,6 +618,13 @@ func (store *MemoryMetadataStore) RecomputeUsage(ctx context.Context) error {
 		return err
 	}
 
+	// The walk drops store.mu before the seed takes quotaMu, so arm the cache to
+	// record what commits in between — otherwise that transaction's delta is
+	// applied and then overwritten. The two locks are never held at once.
+	store.quotaMu.Lock()
+	store.quota.BeginRebuild()
+	store.quotaMu.Unlock()
+
 	byIdentity := make(map[basestore.QuotaKey]*metadata.UsageStat)
 	addUsage := func(k basestore.QuotaKey, bytes int64) {
 		u := byIdentity[k]

--- a/pkg/metadata/store/memory/transaction.go
+++ b/pkg/metadata/store/memory/transaction.go
@@ -264,7 +264,11 @@ func (tx *memoryTransaction) UpdateAttrs(ctx context.Context, file *metadata.Fil
 	// usage. Handles three cases: new regular file (count +1, bytes +size),
 	// in-place size change (same owner, bytes delta), and chown (move
 	// bytes+count from old owner identity to new).
-	if file.Type == metadata.FileTypeRegular {
+	//
+	// This write never touches linkCounts, so the count is the same before and
+	// after: an inode whose last name is already gone holds no share bytes to
+	// move, and a write through a still-open descriptor must not put them back.
+	if tx.chargedLocked(key, file.Type) {
 		var oldSize uint64
 		var hadOldRegular bool
 		var oldUID, oldGID uint32
@@ -361,7 +365,9 @@ func (tx *memoryTransaction) DeleteFile(ctx context.Context, handle metadata.Fil
 	}
 
 	// Remove the inode + bytes from the owner's per-share, per-identity usage.
-	if existing.Attr.Type == metadata.FileTypeRegular {
+	// An inode whose last name went already gave them back, so removing the
+	// record itself owes the counters nothing.
+	if tx.chargedLocked(key, existing.Attr.Type) {
 		tx.quota.Add(existing.ShareName, existing.Attr.UID, existing.Attr.GID, -int64(existing.Attr.Size), -1)
 	}
 
@@ -464,6 +470,20 @@ func (tx *memoryTransaction) SetLinkCount(ctx context.Context, handle metadata.F
 	}
 
 	key := handleToKey(handle)
+
+	// A link count crossing zero is what puts an inode's bytes into the share's
+	// usage or takes them back out; any other change (a hard link added or
+	// dropped alongside others) leaves it charged exactly once either way.
+	if existing, exists := tx.store.files[key]; exists {
+		was := tx.chargedLocked(key, existing.Attr.Type)
+		switch now := basestore.Charged(existing.Attr.Type, count); {
+		case was && !now:
+			tx.quota.Add(existing.ShareName, existing.Attr.UID, existing.Attr.GID, -int64(existing.Attr.Size), -1)
+		case !was && now:
+			tx.quota.Add(existing.ShareName, existing.Attr.UID, existing.Attr.GID, int64(existing.Attr.Size), 1)
+		}
+	}
+
 	tx.store.linkCounts[key] = count
 	return nil
 }
@@ -628,8 +648,10 @@ func (tx *memoryTransaction) DeleteShare(ctx context.Context, shareName string) 
 	for key, fd := range tx.store.files {
 		if fd.ShareName == shareName {
 			// Remove the inode + bytes from the owner's per-share,
-			// per-identity usage.
-			if fd.Attr.Type == metadata.FileTypeRegular {
+			// per-identity usage. An unlinked-but-open inode released them
+			// when its last name went, so the share has none left to give
+			// back for it.
+			if tx.chargedLocked(key, fd.Attr.Type) {
 				tx.quota.Add(fd.ShareName, fd.Attr.UID, fd.Attr.GID, -int64(fd.Attr.Size), -1)
 			}
 			// drop ObjectID secondary entry too.
@@ -803,4 +825,22 @@ func (tx *memoryTransaction) GetFilesystemStatistics(ctx context.Context, handle
 
 	stats := tx.store.computeStatistics(shareName)
 	return &stats, nil
+}
+
+// chargedLocked reports whether the inode stored under key currently holds
+// share bytes: a regular file with at least one name still reaching it.
+//
+// An absent linkCounts entry means no count was ever written, which mirrors
+// GetFile's default-by-type rather than "unlinked" — only an explicit
+// SetLinkCount(0) puts a zero there, and that is what marks an inode as
+// unlinked-but-open.
+func (tx *memoryTransaction) chargedLocked(key string, fileType metadata.FileType) bool {
+	count, ok := tx.store.linkCounts[key]
+	if !ok {
+		count = 1
+		if fileType == metadata.FileTypeDirectory {
+			count = 2
+		}
+	}
+	return basestore.Charged(fileType, count)
 }

--- a/pkg/metadata/store/memory/transaction.go
+++ b/pkg/metadata/store/memory/transaction.go
@@ -265,10 +265,9 @@ func (tx *memoryTransaction) UpdateAttrs(ctx context.Context, file *metadata.Fil
 	// in-place size change (same owner, bytes delta), and chown (move
 	// bytes+count from old owner identity to new).
 	//
-	// This write never touches linkCounts, so the count is the same before and
-	// after: an inode whose last name is already gone holds no share bytes to
-	// move, and a write through a still-open descriptor must not put them back.
-	if tx.chargedLocked(key, file.Type) {
+	// This write never touches linkCounts, so the pre-write count is also the
+	// post-write one.
+	if tx.store.chargedLocked(key, file.Type) {
 		var oldSize uint64
 		var hadOldRegular bool
 		var oldUID, oldGID uint32
@@ -367,7 +366,7 @@ func (tx *memoryTransaction) DeleteFile(ctx context.Context, handle metadata.Fil
 	// Remove the inode + bytes from the owner's per-share, per-identity usage.
 	// An inode whose last name went already gave them back, so removing the
 	// record itself owes the counters nothing.
-	if tx.chargedLocked(key, existing.Attr.Type) {
+	if tx.store.chargedLocked(key, existing.Attr.Type) {
 		tx.quota.Add(existing.ShareName, existing.Attr.UID, existing.Attr.GID, -int64(existing.Attr.Size), -1)
 	}
 
@@ -475,8 +474,9 @@ func (tx *memoryTransaction) SetLinkCount(ctx context.Context, handle metadata.F
 	// usage or takes them back out; any other change (a hard link added or
 	// dropped alongside others) leaves it charged exactly once either way.
 	if existing, exists := tx.store.files[key]; exists {
-		was := tx.chargedLocked(key, existing.Attr.Type)
-		switch now := basestore.Charged(existing.Attr.Type, count); {
+		was := tx.store.chargedLocked(key, existing.Attr.Type)
+		now := basestore.Charged(existing.Attr.Type, count)
+		switch {
 		case was && !now:
 			tx.quota.Add(existing.ShareName, existing.Attr.UID, existing.Attr.GID, -int64(existing.Attr.Size), -1)
 		case !was && now:
@@ -651,7 +651,7 @@ func (tx *memoryTransaction) DeleteShare(ctx context.Context, shareName string) 
 			// per-identity usage. An unlinked-but-open inode released them
 			// when its last name went, so the share has none left to give
 			// back for it.
-			if tx.chargedLocked(key, fd.Attr.Type) {
+			if tx.store.chargedLocked(key, fd.Attr.Type) {
 				tx.quota.Add(fd.ShareName, fd.Attr.UID, fd.Attr.GID, -int64(fd.Attr.Size), -1)
 			}
 			// drop ObjectID secondary entry too.
@@ -825,22 +825,4 @@ func (tx *memoryTransaction) GetFilesystemStatistics(ctx context.Context, handle
 
 	stats := tx.store.computeStatistics(shareName)
 	return &stats, nil
-}
-
-// chargedLocked reports whether the inode stored under key currently holds
-// share bytes: a regular file with at least one name still reaching it.
-//
-// An absent linkCounts entry means no count was ever written, which mirrors
-// GetFile's default-by-type rather than "unlinked" — only an explicit
-// SetLinkCount(0) puts a zero there, and that is what marks an inode as
-// unlinked-but-open.
-func (tx *memoryTransaction) chargedLocked(key string, fileType metadata.FileType) bool {
-	count, ok := tx.store.linkCounts[key]
-	if !ok {
-		count = 1
-		if fileType == metadata.FileTypeDirectory {
-			count = 2
-		}
-	}
-	return basestore.Charged(fileType, count)
 }

--- a/pkg/metadata/store/postgres/data_write.go
+++ b/pkg/metadata/store/postgres/data_write.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlcodec"
 )
 
@@ -41,7 +42,7 @@ func (tx *postgresTransaction) ApplyDataWrite(
 	// An empty old (missing row) yields zero rows.
 	const q = `
 		WITH old AS (
-			SELECT size, uid, gid, file_type FROM inodes
+			SELECT size, uid, gid, file_type, nlink FROM inodes
 			WHERE id = $1 AND share_name = $2
 			FOR UPDATE
 		),
@@ -54,13 +55,14 @@ func (tx *postgresTransaction) ApplyDataWrite(
 			WHERE inodes.id = $1 AND inodes.share_name = $2 AND inodes.file_type = $6::smallint
 			RETURNING inodes.size
 		)
-		SELECT (SELECT size FROM upd), old.size, old.uid, old.gid FROM old
+		SELECT (SELECT size FROM upd), old.size, old.uid, old.gid, old.nlink FROM old
 	`
 	var newSz *int64
 	var oldSize int64
 	var oldUID, oldGID int32
+	var oldNlink int32
 	err = tx.tx.QueryRow(ctx, q, id, shareName, int64(newSize), ft, mask, int16(metadata.FileTypeRegular)).
-		Scan(&newSz, &oldSize, &oldUID, &oldGID)
+		Scan(&newSz, &oldSize, &oldUID, &oldGID, &oldNlink)
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
 		return 0, &metadata.StoreError{Code: metadata.ErrNotFound, Message: "file not found"}
@@ -72,8 +74,11 @@ func (tx *postgresTransaction) ApplyDataWrite(
 		return 0, &metadata.StoreError{Code: metadata.ErrIsDirectory, Message: "not a regular file"}
 	}
 
+	// An unlinked-but-open file still accepts writes, but it gave its bytes
+	// back to the share when its last name went, so its growth is not the
+	// share's to account for.
 	finalSize := *newSz
-	if delta := finalSize - oldSize; delta != 0 {
+	if delta := finalSize - oldSize; delta != 0 && basestore.Charged(metadata.FileTypeRegular, uint32(oldNlink)) {
 		tx.quota.Add(shareName, uint32(oldUID), uint32(oldGID), delta, 0)
 	}
 	return uint64(finalSize), nil

--- a/pkg/metadata/store/postgres/dialect.go
+++ b/pkg/metadata/store/postgres/dialect.go
@@ -96,7 +96,7 @@ var fileQueries = storesql.FileQueries{
 	// inodes.nlink is the sole source of truth for the hard-link count, so
 	// GETATTR reads it straight off the inode row without a join.
 	SetLinkCount:    `UPDATE inodes SET nlink = $1 WHERE id = $2`,
-	DeleteFileOwner: `SELECT file_type, size, uid, gid FROM inodes WHERE id = $1 AND share_name = $2`,
+	FileUsageRow:    `SELECT file_type, size, uid, gid, nlink FROM inodes WHERE id = $1 AND share_name = $2`,
 	DeleteFile:      `DELETE FROM inodes WHERE id = $1 AND share_name = $2`,
 
 	GetFileByPayloadID: `SELECT ` + inodeSelectColumns + ` FROM inodes f
@@ -187,7 +187,7 @@ var shareQueries = storesql.ShareQueries{
 	DeleteShare:       `DELETE FROM shares WHERE share_name = $1`,
 	DeleteShareInodes: `DELETE FROM inodes WHERE share_name = $1`,
 	ShareQuotaFreed: `SELECT %s, COALESCE(SUM(size), 0), COUNT(*) FROM inodes
-		WHERE share_name = $1 AND file_type = $2 GROUP BY %s`,
+		WHERE share_name = $1 AND file_type = $2 AND nlink > 0 GROUP BY %s`,
 }
 
 var _ storesql.Dialect = dialect{}

--- a/pkg/metadata/store/postgres/dialect.go
+++ b/pkg/metadata/store/postgres/dialect.go
@@ -95,9 +95,9 @@ var fileQueries = storesql.FileQueries{
 
 	// inodes.nlink is the sole source of truth for the hard-link count, so
 	// GETATTR reads it straight off the inode row without a join.
-	SetLinkCount:    `UPDATE inodes SET nlink = $1 WHERE id = $2`,
-	FileUsageRow:    `SELECT file_type, size, uid, gid, nlink FROM inodes WHERE id = $1 AND share_name = $2`,
-	DeleteFile:      `DELETE FROM inodes WHERE id = $1 AND share_name = $2`,
+	SetLinkCount: `UPDATE inodes SET nlink = $1 WHERE id = $2`,
+	FileUsageRow: `SELECT file_type, size, uid, gid, nlink FROM inodes WHERE id = $1 AND share_name = $2`,
+	DeleteFile:   `DELETE FROM inodes WHERE id = $1 AND share_name = $2`,
 
 	GetFileByPayloadID: `SELECT ` + inodeSelectColumns + ` FROM inodes f
 		WHERE f.content_id_hash = md5($1)

--- a/pkg/metadata/store/postgres/store.go
+++ b/pkg/metadata/store/postgres/store.go
@@ -398,3 +398,10 @@ func initializeFilesystemCapabilities(ctx context.Context, pool *pgxpool.Pool, c
 	_, err := pool.Exec(ctx, upsertCapabilitiesSQL, capabilityArgs(caps)...)
 	return err
 }
+
+// RecomputeUsage rebuilds the usage counters from the inodes table, discarding
+// whatever the in-memory buckets hold. Same aggregate the store runs at open,
+// re-run on demand.
+func (s *PostgresMetadataStore) RecomputeUsage(ctx context.Context) error {
+	return s.initUsedBytesCounter(ctx)
+}

--- a/pkg/metadata/store/postgres/store.go
+++ b/pkg/metadata/store/postgres/store.go
@@ -229,7 +229,7 @@ func (s *PostgresMetadataStore) initUsedBytesCounter(ctx context.Context) error 
 // never user input.
 func (s *PostgresMetadataStore) seedUsageByColumn(ctx context.Context, col string, scope metadata.QuotaScope, out map[basestore.QuotaKey]*metadata.UsageStat) error {
 	query := fmt.Sprintf(
-		`SELECT share_name, %s, COALESCE(SUM(size), 0), COUNT(*) FROM inodes WHERE file_type = $1 GROUP BY share_name, %s`,
+		`SELECT share_name, %s, COALESCE(SUM(size), 0), COUNT(*) FROM inodes WHERE file_type = $1 AND nlink > 0 GROUP BY share_name, %s`,
 		col, col,
 	)
 	rows, err := s.pool.Query(ctx, query, int(metadata.FileTypeRegular))

--- a/pkg/metadata/store/postgres/store.go
+++ b/pkg/metadata/store/postgres/store.go
@@ -403,5 +403,11 @@ func initializeFilesystemCapabilities(ctx context.Context, pool *pgxpool.Pool, c
 // whatever the in-memory buckets hold. Same aggregate the store runs at open,
 // re-run on demand.
 func (s *PostgresMetadataStore) RecomputeUsage(ctx context.Context) error {
+	// The aggregate runs with no lock held, so arm the cache to record what
+	// commits during it — otherwise a transaction landing between the query and
+	// the seed is scanned out and then overwritten.
+	s.quotaMu.Lock()
+	s.quota.BeginRebuild()
+	s.quotaMu.Unlock()
 	return s.initUsedBytesCounter(ctx)
 }

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -265,7 +265,7 @@ func (tx *postgresTransaction) putFile(ctx context.Context, file *metadata.File,
 			deleted_by = $20
 		FROM old
 		WHERE inodes.id = old.id AND inodes.share_name = old.share_name
-		RETURNING old.size, old.uid, old.gid, old.file_type
+		RETURNING old.size, old.uid, old.gid, old.file_type, old.nlink
 	`
 
 	var deviceMajor, deviceMinor *int32
@@ -335,7 +335,7 @@ func (tx *postgresTransaction) putFile(ctx context.Context, file *metadata.File,
 	// write. A returned row means the file existed (and we have its old size);
 	// pgx.ErrNoRows means it did not, so we fall through to INSERT.
 	var oldSizeVal sql.NullInt64
-	var oldUIDVal, oldGIDVal, oldTypeVal sql.NullInt64
+	var oldUIDVal, oldGIDVal, oldTypeVal, oldNlinkVal sql.NullInt64
 	// A caller that knows the inode is new skips the probe entirely: on a
 	// create the round-trip can only ever report "no such row", and a stale
 	// claim surfaces as the INSERT's duplicate-key error.
@@ -349,7 +349,7 @@ func (tx *postgresTransaction) putFile(ctx context.Context, file *metadata.File,
 			file.Hidden, aclJSON, easJSON, objectIDArg,
 			deletedAtArg, file.OriginalPath, file.DeletedBy,
 			file.ID, file.ShareName,
-		).Scan(&oldSizeVal, &oldUIDVal, &oldGIDVal, &oldTypeVal)
+		).Scan(&oldSizeVal, &oldUIDVal, &oldGIDVal, &oldTypeVal, &oldNlinkVal)
 		switch {
 		case scanErr == nil:
 			// Row existed and was updated; oldSizeVal holds the pre-update size.
@@ -363,7 +363,12 @@ func (tx *postgresTransaction) putFile(ctx context.Context, file *metadata.File,
 	// Track size delta for regular files after a successful update.
 	// Accumulated on the tx and applied once after a successful commit so a
 	// serialization/deadlock retry never double-counts.
-	if updated && file.Type == metadata.FileTypeRegular {
+	//
+	// nlink is not one of the columns this write touches, so the row's link
+	// count is the same before and after: an inode whose last name is already
+	// gone holds no share bytes to move, and a write through a still-open
+	// descriptor must not put them back.
+	if updated && basestore.Charged(file.Type, uint32(oldNlinkVal.Int64)) {
 		var oldSize uint64
 		if oldSizeVal.Valid {
 			oldSize = uint64(oldSizeVal.Int64)

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -237,7 +237,7 @@ func (tx *postgresTransaction) putFile(ctx context.Context, file *metadata.File,
 	// RowsAffected()==0 check relied on.
 	updateQuery := `
 		WITH old AS (
-			SELECT id, share_name, size, uid, gid, file_type
+			SELECT id, share_name, size, uid, gid, file_type, nlink
 			FROM inodes
 			WHERE id = $21 AND share_name = $22
 			FOR UPDATE

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -364,10 +364,8 @@ func (tx *postgresTransaction) putFile(ctx context.Context, file *metadata.File,
 	// Accumulated on the tx and applied once after a successful commit so a
 	// serialization/deadlock retry never double-counts.
 	//
-	// nlink is not one of the columns this write touches, so the row's link
-	// count is the same before and after: an inode whose last name is already
-	// gone holds no share bytes to move, and a write through a still-open
-	// descriptor must not put them back.
+	// nlink is not among the columns this write touches, so the pre-update
+	// count is also the post-update one.
 	if updated && basestore.Charged(file.Type, uint32(oldNlinkVal.Int64)) {
 		var oldSize uint64
 		if oldSizeVal.Valid {

--- a/pkg/metadata/store/sql/dialect.go
+++ b/pkg/metadata/store/sql/dialect.go
@@ -148,10 +148,10 @@ type FileQueries struct {
 	// SetLinkCount writes one inode's nlink. Two parameters: the count and the
 	// file id.
 	SetLinkCount string
-	// DeleteFileOwner selects the type, size and owning uid/gid of the inode
-	// about to be deleted, in that column order. Two parameters: the file id
-	// and the share name.
-	DeleteFileOwner string
+	// FileUsageRow selects everything the usage counters need about one
+	// inode — its type, size, owning uid/gid and link count, in that column
+	// order. Two parameters: the file id and the share name.
+	FileUsageRow string
 	// DeleteFile removes one inode row. Two parameters: the file id and the
 	// share name.
 	DeleteFile string

--- a/pkg/metadata/store/sql/files.go
+++ b/pkg/metadata/store/sql/files.go
@@ -394,7 +394,8 @@ func (c *Core) SetLinkCount(ctx context.Context, handle metadata.FileHandle, cou
 		// dropping a hard link alongside others leaves the inode charged
 		// exactly once either way.
 		was := basestore.Charged(metadata.FileType(pre.fileType), uint32(pre.nlink))
-		switch now := basestore.Charged(metadata.FileType(pre.fileType), count); {
+		now := basestore.Charged(metadata.FileType(pre.fileType), count)
+		switch {
 		case was && !now:
 			c.Quota.Add(shareName, uint32(pre.uid), uint32(pre.gid), -pre.size, -1)
 		case !was && now:

--- a/pkg/metadata/store/sql/files.go
+++ b/pkg/metadata/store/sql/files.go
@@ -11,6 +11,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/acl"
+	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlcodec"
 )
 
@@ -370,15 +371,66 @@ func (c *Core) SetLinkCount(ctx context.Context, handle metadata.FileHandle, cou
 		return err
 	}
 
-	_, fileID, err := metadata.DecodeFileHandle(handle)
+	shareName, fileID, err := metadata.DecodeFileHandle(handle)
 	if err != nil {
 		return invalidHandle("file")
+	}
+
+	// Read the pre-image before the count moves. A link count crossing zero is
+	// what puts an inode's bytes into the share's usage or takes them back out,
+	// and once the UPDATE has landed there is no way to tell which side it came
+	// from.
+	pre, err := c.fileUsage(ctx, shareName, fileID, "SetLinkCount")
+	if err != nil {
+		return err
 	}
 
 	if _, err := c.X.Exec(ctx, c.D.Files().SetLinkCount, count, fileID); err != nil {
 		return c.D.MapError(err, "SetLinkCount", "")
 	}
+
+	if pre != nil {
+		// Only the crossing between zero and non-zero moves usage: adding or
+		// dropping a hard link alongside others leaves the inode charged
+		// exactly once either way.
+		was := basestore.Charged(metadata.FileType(pre.fileType), uint32(pre.nlink))
+		switch now := basestore.Charged(metadata.FileType(pre.fileType), count); {
+		case was && !now:
+			c.Quota.Add(shareName, uint32(pre.uid), uint32(pre.gid), -pre.size, -1)
+		case !was && now:
+			c.Quota.Add(shareName, uint32(pre.uid), uint32(pre.gid), pre.size, 1)
+		}
+	}
 	return nil
+}
+
+// usageRow is the inode pre-image the usage counters are computed from.
+type usageRow struct {
+	fileType int
+	size     int64
+	uid, gid int64
+	nlink    int64
+}
+
+// fileUsage reads one inode's usage pre-image. A row that is not there yields
+// (nil, nil): it owes the counters nothing, and callers that need to know it
+// was missing learn that from their own write's RowsAffected.
+//
+// Any other scan failure is fatal rather than silenced, because FileTypeRegular
+// is the zero value: a dropped error would move bytes on uid 0's bucket and
+// leave the real owner's wrong, with nothing to notice it afterwards.
+func (c *Core) fileUsage(ctx context.Context, shareName string, fileID uuid.UUID, op string) (*usageRow, error) {
+	var u usageRow
+	err := c.X.QueryRow(ctx, c.D.Files().FileUsageRow, fileID, shareName).
+		Scan(&u.fileType, &u.size, &u.uid, &u.gid, &u.nlink)
+	switch {
+	case err == nil:
+		return &u, nil
+	case c.D.IsNoRows(err):
+		return nil, nil
+	default:
+		return nil, c.D.MapError(err, op, "")
+	}
 }
 
 // DeleteFile removes one inode, reporting metadata.ErrNotFound when it is not
@@ -400,20 +452,12 @@ func (c *Core) DeleteFile(ctx context.Context, handle metadata.FileHandle) error
 	}
 
 	// Read the size and owner before the row goes, so the usage counters can be
-	// decremented after the delete lands.
-	//
-	// A missing row is expected and not an error here: the RowsAffected check
-	// below turns it into ErrNotFound before the usage is touched. Any other
-	// scan failure is fatal, because FileTypeRegular is the zero value — a
-	// dropped error would charge -1 file to uid 0 and leave the real owner
-	// charged for a file that is gone, with nothing to notice it afterwards.
-	var fileType int
-	var fileSize int64
-	var fileUID, fileGID int64
-	scanErr := c.X.QueryRow(ctx, c.D.Files().DeleteFileOwner, id, shareName).
-		Scan(&fileType, &fileSize, &fileUID, &fileGID)
-	if scanErr != nil && !c.D.IsNoRows(scanErr) {
-		return c.D.MapError(scanErr, "DeleteFile", "")
+	// decremented after the delete lands. A missing row is expected and not an
+	// error here: the RowsAffected check below turns it into ErrNotFound before
+	// the usage is touched.
+	pre, err := c.fileUsage(ctx, shareName, id, "DeleteFile")
+	if err != nil {
+		return err
 	}
 
 	result, err := c.X.Exec(ctx, c.D.Files().DeleteFile, id, shareName)
@@ -427,8 +471,10 @@ func (c *Core) DeleteFile(ctx context.Context, handle metadata.FileHandle) error
 		}
 	}
 
-	if metadata.FileType(fileType) == metadata.FileTypeRegular {
-		c.Quota.Add(shareName, uint32(fileUID), uint32(fileGID), -fileSize, -1)
+	// An inode whose last name went already gave its bytes back, so removing the
+	// row itself owes the counters nothing.
+	if pre != nil && basestore.Charged(metadata.FileType(pre.fileType), uint32(pre.nlink)) {
+		c.Quota.Add(shareName, uint32(pre.uid), uint32(pre.gid), -pre.size, -1)
 	}
 
 	return nil

--- a/pkg/metadata/store/sqlite/data_write.go
+++ b/pkg/metadata/store/sqlite/data_write.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlcodec"
 )
 
@@ -33,9 +34,10 @@ func (tx *sqliteTransaction) ApplyDataWrite(
 	var oldSize int64
 	var oldUID, oldGID uint32
 	var oldType int
+	var oldNlink uint32
 	err = tx.tx.QueryRow(ctx,
-		`SELECT size, uid, gid, file_type FROM inodes WHERE id = ?1 AND share_name = ?2`,
-		id, shareName).Scan(&oldSize, &oldUID, &oldGID, &oldType)
+		`SELECT size, uid, gid, file_type, nlink FROM inodes WHERE id = ?1 AND share_name = ?2`,
+		id, shareName).Scan(&oldSize, &oldUID, &oldGID, &oldType, &oldNlink)
 	switch {
 	case errors.Is(err, sql.ErrNoRows):
 		return 0, &metadata.StoreError{Code: metadata.ErrNotFound, Message: "file not found"}
@@ -62,7 +64,10 @@ func (tx *sqliteTransaction) ApplyDataWrite(
 		return 0, mapDBError(err, "ApplyDataWrite", "")
 	}
 
-	if delta := finalSize - oldSize; delta != 0 {
+	// An unlinked-but-open file still accepts writes, but it gave its bytes
+	// back to the share when its last name went, so its growth is not the
+	// share's to account for.
+	if delta := finalSize - oldSize; delta != 0 && basestore.Charged(metadata.FileTypeRegular, oldNlink) {
 		tx.quota.Add(shareName, oldUID, oldGID, delta, 0)
 	}
 	return uint64(finalSize), nil

--- a/pkg/metadata/store/sqlite/dialect.go
+++ b/pkg/metadata/store/sqlite/dialect.go
@@ -94,7 +94,7 @@ var fileQueries = storesql.FileQueries{
 	// inodes.nlink is the sole source of truth for the hard-link count, so
 	// GETATTR reads it straight off the inode row without a join.
 	SetLinkCount:    `UPDATE inodes SET nlink = ?1 WHERE id = ?2`,
-	DeleteFileOwner: `SELECT file_type, size, uid, gid FROM inodes WHERE id = ?1 AND share_name = ?2`,
+	FileUsageRow:    `SELECT file_type, size, uid, gid, nlink FROM inodes WHERE id = ?1 AND share_name = ?2`,
 	DeleteFile:      `DELETE FROM inodes WHERE id = ?1 AND share_name = ?2`,
 
 	GetFileByPayloadID: `SELECT ` + inodeSelectColumns + ` FROM inodes f
@@ -185,7 +185,7 @@ var shareQueries = storesql.ShareQueries{
 	DeleteShare:       `DELETE FROM shares WHERE share_name = ?1`,
 	DeleteShareInodes: `DELETE FROM inodes WHERE share_name = ?1`,
 	ShareQuotaFreed: `SELECT %s, COALESCE(SUM(size), 0), COUNT(*) FROM inodes
-		WHERE share_name = ?1 AND file_type = ?2 GROUP BY %s`,
+		WHERE share_name = ?1 AND file_type = ?2 AND nlink > 0 GROUP BY %s`,
 }
 
 var _ storesql.Dialect = dialect{}

--- a/pkg/metadata/store/sqlite/dialect.go
+++ b/pkg/metadata/store/sqlite/dialect.go
@@ -93,9 +93,9 @@ var fileQueries = storesql.FileQueries{
 
 	// inodes.nlink is the sole source of truth for the hard-link count, so
 	// GETATTR reads it straight off the inode row without a join.
-	SetLinkCount:    `UPDATE inodes SET nlink = ?1 WHERE id = ?2`,
-	FileUsageRow:    `SELECT file_type, size, uid, gid, nlink FROM inodes WHERE id = ?1 AND share_name = ?2`,
-	DeleteFile:      `DELETE FROM inodes WHERE id = ?1 AND share_name = ?2`,
+	SetLinkCount: `UPDATE inodes SET nlink = ?1 WHERE id = ?2`,
+	FileUsageRow: `SELECT file_type, size, uid, gid, nlink FROM inodes WHERE id = ?1 AND share_name = ?2`,
+	DeleteFile:   `DELETE FROM inodes WHERE id = ?1 AND share_name = ?2`,
 
 	GetFileByPayloadID: `SELECT ` + inodeSelectColumns + ` FROM inodes f
 		WHERE f.content_id = ?1

--- a/pkg/metadata/store/sqlite/store.go
+++ b/pkg/metadata/store/sqlite/store.go
@@ -381,5 +381,11 @@ func initializeFilesystemCapabilities(ctx context.Context, db *sql.DB, caps meta
 // whatever the in-memory buckets hold. Same aggregate the store runs at open,
 // re-run on demand.
 func (s *SQLiteMetadataStore) RecomputeUsage(ctx context.Context) error {
+	// The aggregate runs with no lock held, so arm the cache to record what
+	// commits during it — otherwise a transaction landing between the query and
+	// the seed is scanned out and then overwritten.
+	s.quotaMu.Lock()
+	s.quota.BeginRebuild()
+	s.quotaMu.Unlock()
 	return s.initUsedBytesCounter(ctx)
 }

--- a/pkg/metadata/store/sqlite/store.go
+++ b/pkg/metadata/store/sqlite/store.go
@@ -376,3 +376,10 @@ func initializeFilesystemCapabilities(ctx context.Context, db *sql.DB, caps meta
 	_, err := db.ExecContext(ctx, upsertCapabilitiesSQL, capabilityArgs(caps)...)
 	return err
 }
+
+// RecomputeUsage rebuilds the usage counters from the inodes table, discarding
+// whatever the in-memory buckets hold. Same aggregate the store runs at open,
+// re-run on demand.
+func (s *SQLiteMetadataStore) RecomputeUsage(ctx context.Context) error {
+	return s.initUsedBytesCounter(ctx)
+}

--- a/pkg/metadata/store/sqlite/store.go
+++ b/pkg/metadata/store/sqlite/store.go
@@ -229,7 +229,7 @@ func (s *SQLiteMetadataStore) initUsedBytesCounter(ctx context.Context) error {
 // never user input.
 func (s *SQLiteMetadataStore) seedUsageByColumn(ctx context.Context, col string, scope metadata.QuotaScope, out map[basestore.QuotaKey]*metadata.UsageStat) error {
 	query := fmt.Sprintf(
-		`SELECT share_name, %s, COALESCE(SUM(size), 0), COUNT(*) FROM inodes WHERE file_type = ?1 GROUP BY share_name, %s`,
+		`SELECT share_name, %s, COALESCE(SUM(size), 0), COUNT(*) FROM inodes WHERE file_type = ?1 AND nlink > 0 GROUP BY share_name, %s`,
 		col, col,
 	)
 	rows, err := s.db.QueryContext(ctx, query, int(metadata.FileTypeRegular))

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -179,7 +179,7 @@ func (tx *sqliteTransaction) putFile(ctx context.Context, file *metadata.File, w
 	// first, then UPDATE; a zero-row read means the file does not exist and we
 	// fall through to INSERT — the same not-found signal as before.
 	const selectOldQuery = `
-		SELECT size, uid, gid, file_type
+		SELECT size, uid, gid, file_type, nlink
 		FROM inodes
 		WHERE id = ?1 AND share_name = ?2
 	`
@@ -274,14 +274,14 @@ func (tx *sqliteTransaction) putFile(ctx context.Context, file *metadata.File, w
 	// transaction. A missing row (sql.ErrNoRows) means the file does not exist,
 	// so we fall through to INSERT.
 	var oldSizeVal sql.NullInt64
-	var oldUIDVal, oldGIDVal, oldTypeVal sql.NullInt64
+	var oldUIDVal, oldGIDVal, oldTypeVal, oldNlinkVal sql.NullInt64
 	// A caller that knows the inode is new skips the probe entirely: on a
 	// create the round-trip can only ever report "no such row", and a stale
 	// claim surfaces as the INSERT's duplicate-key error.
 	updated := !file.NewInode
 	if updated {
 		scanErr := tx.tx.QueryRow(ctx, selectOldQuery, file.ID, file.ShareName).
-			Scan(&oldSizeVal, &oldUIDVal, &oldGIDVal, &oldTypeVal)
+			Scan(&oldSizeVal, &oldUIDVal, &oldGIDVal, &oldTypeVal, &oldNlinkVal)
 		switch {
 		case scanErr == nil:
 			// Row exists; update it in place.
@@ -306,7 +306,12 @@ func (tx *sqliteTransaction) putFile(ctx context.Context, file *metadata.File, w
 	// Track size delta for regular files after a successful update.
 	// Accumulated on the tx and applied once after a successful commit so a
 	// serialization/deadlock retry never double-counts.
-	if updated && file.Type == metadata.FileTypeRegular {
+	//
+	// nlink is not one of the columns this write touches, so the row's link
+	// count is the same before and after: an inode whose last name is already
+	// gone holds no share bytes to move, and a write through a still-open
+	// descriptor must not put them back.
+	if updated && basestore.Charged(file.Type, uint32(oldNlinkVal.Int64)) {
 		var oldSize uint64
 		if oldSizeVal.Valid {
 			oldSize = uint64(oldSizeVal.Int64)

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -307,10 +307,8 @@ func (tx *sqliteTransaction) putFile(ctx context.Context, file *metadata.File, w
 	// Accumulated on the tx and applied once after a successful commit so a
 	// serialization/deadlock retry never double-counts.
 	//
-	// nlink is not one of the columns this write touches, so the row's link
-	// count is the same before and after: an inode whose last name is already
-	// gone holds no share bytes to move, and a write through a still-open
-	// descriptor must not put them back.
+	// nlink is not among the columns this write touches, so the pre-update
+	// count is also the post-update one.
 	if updated && basestore.Charged(file.Type, uint32(oldNlinkVal.Int64)) {
 		var oldSize uint64
 		if oldSizeVal.Valid {

--- a/pkg/metadata/storetest/store_surface.go
+++ b/pkg/metadata/storetest/store_surface.go
@@ -35,6 +35,7 @@ func runStoreSurfaceTests(t *testing.T, factory StoreFactory) {
 	t.Run("Pagination", func(t *testing.T) { testListChildrenPagination(t, factory) })
 	t.Run("DeleteSharePurgesUsedBytesAndObjectIndex", func(t *testing.T) { testDeleteSharePurgesCounters(t, factory) })
 	t.Run("ListChildrenCursorAfterDeletedEntry", func(t *testing.T) { testListChildrenCursorAfterDelete(t, factory) })
+	t.Run("UnlinkReleasesUsedBytes", func(t *testing.T) { testUnlinkReleasesUsedBytes(t, factory) })
 }
 
 func testDeleteSharePurgesCounters(t *testing.T, factory StoreFactory) {
@@ -139,6 +140,77 @@ func testListChildrenCursorAfterDelete(t *testing.T, factory StoreFactory) {
 	if page2[0].Name != "c" {
 		t.Errorf("page2[0] = %q, want 'c' — cursor must resume after the deleted entry's sorted position", page2[0].Name)
 	}
+}
+
+// testUnlinkReleasesUsedBytes pins the per-file half of usage accounting: a
+// share's used bytes must fall when a file is unlinked, not only when the whole
+// share is deleted.
+//
+// Unlinking the last name for a regular file does NOT remove its inode — the
+// row is retained with nlink=0 so fstat(2) on a still-open descriptor keeps
+// working — so the usage counters cannot key off the inode's existence. They
+// key off its link count: a regular inode contributes its size and one file to
+// the share and to its owner's identity buckets exactly while nlink > 0.
+// Dropping one of several hard links moves nothing; dropping the last one
+// releases everything the inode held.
+func testUnlinkReleasesUsedBytes(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+
+	const shareName = "/unlink-usage"
+	const uid, gid = uint32(1001), uint32(2002)
+	rootHandle := createTestShare(t, store, shareName)
+
+	assertShareUsed := func(what string, want int64) {
+		t.Helper()
+		got, err := store.GetUsedBytesForShare(ctx, shareName)
+		if err != nil {
+			t.Fatalf("GetUsedBytesForShare(%q) failed after %s: %v", shareName, what, err)
+		}
+		if got != want {
+			t.Fatalf("GetUsedBytesForShare(%q) = %d, want %d after %s", shareName, got, want, what)
+		}
+	}
+
+	handle := createTestFileOwned(t, store, shareName, rootHandle, "big.bin", uid, gid, 8192)
+	assertShareUsed("creating big.bin", 8192)
+	wantUsage(t, store, shareName, metadata.QuotaScopeUser, uid, 8192, 1)
+
+	// A second hard link adds a name, not bytes: one inode, still 8192.
+	if err := store.SetChild(ctx, rootHandle, "link.bin", handle); err != nil {
+		t.Fatalf("SetChild(link.bin) failed: %v", err)
+	}
+	if err := store.SetLinkCount(ctx, handle, 2); err != nil {
+		t.Fatalf("SetLinkCount(2) failed: %v", err)
+	}
+	assertShareUsed("hard-linking big.bin", 8192)
+	wantUsage(t, store, shareName, metadata.QuotaScopeUser, uid, 8192, 1)
+
+	// Dropping one of two names leaves the inode reachable, so it keeps its
+	// bytes.
+	if err := store.DeleteChild(ctx, rootHandle, "link.bin"); err != nil {
+		t.Fatalf("DeleteChild(link.bin) failed: %v", err)
+	}
+	if err := store.SetLinkCount(ctx, handle, 1); err != nil {
+		t.Fatalf("SetLinkCount(1) failed: %v", err)
+	}
+	assertShareUsed("unlinking one of two names", 8192)
+	wantUsage(t, store, shareName, metadata.QuotaScopeUser, uid, 8192, 1)
+
+	// Dropping the last name releases the bytes, even though the inode itself
+	// survives for POSIX open-but-unlinked semantics.
+	if err := store.DeleteChild(ctx, rootHandle, "big.bin"); err != nil {
+		t.Fatalf("DeleteChild(big.bin) failed: %v", err)
+	}
+	if err := store.SetLinkCount(ctx, handle, 0); err != nil {
+		t.Fatalf("SetLinkCount(0) failed: %v", err)
+	}
+	if _, err := store.GetFile(ctx, handle); err != nil {
+		t.Fatalf("GetFile after last unlink: %v — the inode must survive for open descriptors", err)
+	}
+	assertShareUsed("unlinking the last name", 0)
+	wantUsage(t, store, shareName, metadata.QuotaScopeUser, uid, 0, 0)
+	wantUsage(t, store, shareName, metadata.QuotaScopeGroup, gid, 0, 0)
 }
 
 func namesOf(entries []metadata.DirEntry) []string {

--- a/pkg/metadata/storetest/store_surface.go
+++ b/pkg/metadata/storetest/store_surface.go
@@ -211,6 +211,25 @@ func testUnlinkReleasesUsedBytes(t *testing.T, factory StoreFactory) {
 	assertShareUsed("unlinking the last name", 0)
 	wantUsage(t, store, shareName, metadata.QuotaScopeUser, uid, 0, 0)
 	wantUsage(t, store, shareName, metadata.QuotaScopeGroup, gid, 0, 0)
+
+	// The on-demand repair rebuilds the counters from the stored rows, so it
+	// must read the retained inode the same way the transactional deltas did.
+	// A recompute that counted it would put the bytes back — and, for the
+	// backends that seed their counters the same way, so would a restart.
+	if err := store.RecomputeUsage(ctx); err != nil {
+		t.Fatalf("RecomputeUsage() failed: %v", err)
+	}
+	assertShareUsed("recomputing usage", 0)
+	wantUsage(t, store, shareName, metadata.QuotaScopeUser, uid, 0, 0)
+
+	// And it must agree with the live counter for files that are still linked.
+	createTestFileOwned(t, store, shareName, rootHandle, "kept.bin", uid, gid, 4096)
+	assertShareUsed("creating kept.bin", 4096)
+	if err := store.RecomputeUsage(ctx); err != nil {
+		t.Fatalf("RecomputeUsage() after kept.bin failed: %v", err)
+	}
+	assertShareUsed("recomputing usage with a live file", 4096)
+	wantUsage(t, store, shareName, metadata.QuotaScopeUser, uid, 4096, 1)
 }
 
 func namesOf(entries []metadata.DirEntry) []string {


### PR DESCRIPTION
## What was wrong

A share's `USED` figure only ever went up. Writing 50 MB and then deleting the file left the share reporting 50 MB with zero files in it, and the number survived a restart. Because that same figure is what the share quota is checked against, a quota'd share fills permanently: once it reports full, deleting everything in it frees nothing and every subsequent write is refused.

The cause is not a missing decrement in the delete path. It is that **there is no delete path for the inode**, and the usage counters were keyed off the inode's existence.

`Service.RemoveFile` deliberately does not remove the inode. It drops the directory entry and sets `nlink = 0`, so `fstat(2)` on a descriptor that outlived the unlink keeps working (`pkg/metadata/file_remove.go:197-214`, POSIX open-but-unlinked). Nothing ever reaps that row afterwards — the only production callers of `Store.DeleteFile` are `RemoveDirectory` (directories carry no bytes) and rename-over-a-directory-destination. So for a regular file:

- the counters charged the inode at create and on every size change,
- released it only in `DeleteFile` and `DeleteShare`,
- and every backend's startup seed re-summed **all** regular inodes, which is why the number came back after a restart.

The inode outlives its last name forever, so the bytes did too. The block store had already reclaimed the objects — the reporting VM's bucket was verified empty at 1.17 GiB reported.

This is pre-existing, not a regression from the most recent release: the reporter measured the same behaviour on both the current build and the prior one.

## The fix

An inode contributes to usage **while it is a regular file with at least one link**, not while its row exists. That predicate is stated once, in `basestore.Charged(fileType, nlink)`, and applied at every point the counters move, in all four backends:

- `SetLinkCount` charges the crossing of zero — down releases the inode's bytes and its file count, up re-charges them, and any other change (a hard link added or dropped alongside others) moves nothing. This is the seam all three unlink paths route through: `RemoveFile`, rename-over-an-existing-destination, and `MarkFileAsOrphaned` (NFS silly-rename).
- `DeleteFile` / `DeleteShare` no longer subtract for an inode that already gave its bytes back.
- `UpdateAttrs` / `ApplyDataWrite` no longer move bytes for an inode with no links — an unlinked-but-open file still accepts writes, and without this the growth would be charged and never released.
- The startup seeds (`initUsedBytesCounter` in sqlite/postgres/badger) skip unlinked inodes, so a restart no longer re-inflates the figure.

Reading the nlink pre-image is free everywhere: the SQL family already pre-read the row for its size delta (`nlink` is one more column on the same `SELECT`/`RETURNING`), and badger/memory already had the record in hand. Badger's seed adds one scan of the tiny `l:` prefix to find the unlinked ids, which is a fraction of the file-row decode it already does.

Deliberate simplification, marked as such in the code: usage is released at unlink, not at last close. A file that is unlinked while still open has its bytes returned to the share slightly before the block store reclaims them. The alternative — charging until last close — needs a reaper that does not exist, and is what produced the permanent leak in the first place.

## Repair for already-deployed shares

`RecomputeUsage(ctx)` is new on `metadata.Store` (all four backends) and rebuilds the counters from the durable file rows. It is surfaced as:

```
dfsctl store metadata recompute-usage <share>
```
→ `POST /api/v1/shares/{name}/usage/recompute` → `Runtime.RecomputeShareUsage`, reporting the share's used bytes before and after.

It is operator-invoked only. There is deliberately **no automatic startup reconcile**: the rebuild is a full scan of the store's file rows, and a per-file walk on every boot is a cost every share would pay forever to correct a number that is almost always already right.

`docs/guide/cli.md` regenerated with `go run ./cmd/gendocs`; `docs/guide/quotas.md` gains a short section on when to reach for it.

## Evidence

The per-file delete decrement had **no conformance coverage at all** — `DeleteSharePurgesUsedBytesAndObjectIndex` covers deleting a whole share, and `testGetUsedBytesForShare` drives `DeleteFile`, which the unlink path never calls. That missing case is as much the finding as the fix, so the regression test went into the shared suite where all four backends are held to it.

`storetest.UnlinkReleasesUsedBytes` on the parent commit (`bc580345b`):

```
--- FAIL: TestConformance/StoreSurface/UnlinkReleasesUsedBytes
    store_surface.go:211: GetUsedBytesForShare("/unlink-usage") = 8192, want 0 after unlinking the last name
FAIL	github.com/marmos91/dittofs/pkg/metadata/store/memory

--- FAIL: TestConformance/StoreSurface/UnlinkReleasesUsedBytes
--- FAIL: TestConformance_RelaxedDurability/StoreSurface/UnlinkReleasesUsedBytes
    store_surface.go:211: GetUsedBytesForShare("/unlink-usage") = 8192, want 0 after unlinking the last name
FAIL	github.com/marmos91/dittofs/pkg/metadata/store/badger

--- FAIL: TestConformance/StoreSurface/UnlinkReleasesUsedBytes
    store_surface.go:211: GetUsedBytesForShare("/unlink-usage") = 8192, want 0 after unlinking the last name
FAIL	github.com/marmos91/dittofs/pkg/metadata/store/sqlite
```

`TestRemoveFileReleasesShareUsage` walks the real service path (`svc.RemoveFile`) and reproduces the reported numbers exactly — 50 MiB written, file deleted, counter unmoved. On the parent commit:

```
    Error Trace:	pkg/metadata/quota_unlink_test.go:66
    Error:      	Should be zero, but was 52428800
--- FAIL: TestRemoveFileReleasesShareUsage (0.00s)
FAIL	github.com/marmos91/dittofs/pkg/metadata
```

Both pass on this branch. The conformance case also asserts that `RecomputeUsage` agrees with the maintained counter; removing the seed's `nlink > 0` filter makes it fail (`= 8192, want 0 after recomputing usage`), so the seed half is pinned too.

Also run: full `go test ./...`, `go vet ./...`, and the postgres integration suite against a local postgres 16 (`-tags=integration -p 1 ./pkg/metadata/...`).

That last one earned its keep. Every postgres store test is `//go:build integration`, so the whole SQL change was green under a plain `go test ./...` while postgres was broken outright: `UpdateAttrs` reads its pre-image through a CTE, and adding `old.nlink` to the `RETURNING` without projecting `nlink` in the CTE's own select list fails at runtime with `column old.nlink does not exist` — twelve postgres tests down, none of them visible without a live database. Fixed on this branch; the suite is green after it.

Closes #2270
