### PR TITLE
chore(ci): point dependabot at develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,17 @@
 # Dependabot raises the bump PRs for the alerts on the Security tab. Without
 # this file GitHub still reports vulnerabilities but never opens a PR for them,
 # so they accumulate until someone bumps by hand.
+#
+# Every ecosystem sets target-branch: develop. Unset, Dependabot opens against
+# the repository default branch, which is main — and main only ever fast-forwards
+# from develop, so a bump merged there directly would put a commit on main that
+# is not in develop and break the strict-ancestor invariant the release flow
+# depends on. It also left the PRs blocked behind main's protection rules.
 version: 2
 updates:
   - package-ecosystem: gomod
     directory: /
+    target-branch: develop
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
@@ -22,6 +29,7 @@ updates:
 
   - package-ecosystem: gomod
     directory: /k8s/dittofs-operator
+    target-branch: develop
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
@@ -37,6 +45,7 @@ updates:
 
   - package-ecosystem: github-actions
     directory: /
+    target-branch: develop
     schedule:
       interval: weekly
     open-pull-requests-limit: 5


### PR DESCRIPTION
## The problem

`.github/dependabot.yml` set no `target-branch` on any of its three ecosystems, so Dependabot fell back to the repository default branch — `main`.

Every Dependabot PR consequently opened against `main` while every human PR targets `develop`:

```
#2275 -> main    chore(deps): bump the operator-dependencies group
#2276 -> main    chore(ci): bump the actions group with 13 updates
#2277 -> main    chore(deps): bump the go-dependencies group with 32 updates
#2278 -> main    chore(deps): bump github.com/olekukonko/tablewriter
```

That is not cosmetic. `main` only ever fast-forwards from `develop` (see CLAUDE.md → Releases); it is currently `4d317e54b`, the v0.31.0 tag, with **0 commits not in develop**. Merging any bump straight into `main` would land a commit there that is not in `develop` and break the strict-ancestor invariant the release flow depends on — the mirror image of the v0.18.0/v0.19.0 breakage that left `main` stranded for 152 commits.

It also explains two things that looked unrelated:

- All four PRs were `BLOCKED`, and their workflow runs sat at `action_required` — they were up against `main`'s protection rules, so **none of them ever reported a single check**.
- The same default-branch mismatch is why CodeQL default setup scanned only `main` while every PR targeted `develop` (#2104).

## The change

`target-branch: develop` on all three ecosystems (root gomod, `/k8s/dittofs-operator` gomod, github-actions). One line each, plus a comment recording why, since the failure mode is silent — nothing errors, the PRs just quietly aim at the wrong branch and never run CI.

The four PRs already open were retargeted to `develop` by hand; this only fixes the ones raised from here on.
