### PR TITLE
fix(api): drop RealIP so the request log records an unforgeable address

### DIFF
--- a/pkg/controlplane/api/router.go
+++ b/pkg/controlplane/api/router.go
@@ -26,7 +26,6 @@ const passwordChangePath = "/api/v1/users/me/password"
 //
 // The router is configured with:
 //   - Request ID middleware for request tracking
-//   - Real IP extraction for proper client identification
 //   - Custom request logging using the internal logger
 //   - Panic recovery to prevent server crashes
 //   - Request timeout to prevent hung requests

--- a/pkg/controlplane/api/router.go
+++ b/pkg/controlplane/api/router.go
@@ -61,7 +61,11 @@ func NewRouter(rt *runtime.Runtime, jwtService *auth.JWTService, cpStore store.S
 
 	// Middleware stack - order matters
 	r.Use(middleware.RequestID)
-	r.Use(middleware.RealIP)
+	// No RealIP: it rewrites RemoteAddr from X-Forwarded-For / True-Client-IP /
+	// X-Real-IP unconditionally, and DittoFS trusts no proxy list, so any client
+	// could choose the address the request log records for it. The TCP peer is
+	// less specific behind an ingress but cannot be forged. Honouring forwarded
+	// headers again needs a trusted-hop allowlist, not this middleware.
 	r.Use(requestLogger)
 	r.Use(middleware.Recoverer)
 


### PR DESCRIPTION
Closes #2290. Unblocks the `golangci-lint` failure on #2277.

## What

`middleware.RealIP` rewrites `r.RemoteAddr` from `X-Forwarded-For` / `True-Client-IP` / `X-Real-IP` on every request. DittoFS configures no trusted-proxy list, so those headers are honoured from any client that connects directly — meaning a client picks the address the API logs for its own requests.

chi deprecated it for exactly this (GHSA-3fxj-6jh8-hvhx, GHSA-rjr7-jggh-pgcp, GHSA-9g5q-2w5x-hmxf), and the deprecation is what surfaced it: #2277's dependency bump turned it into a `staticcheck` failure.

## Severity: log integrity, not access control

I traced every consumer before rating it. In the HTTP path there is exactly one, and it logs:

```go
// router.go:592
logger.Debug("API request started", ..., "remote_addr", r.RemoteAddr)
```

Nothing in `pkg/` makes an authorization, rate-limiting, ACL, audit or ban decision on `RemoteAddr`. The many other `RemoteAddr` hits are `net.Conn.RemoteAddr()` in the NFS/SMB adapters — `RealIP` only mutates `*http.Request`, so export-level access control is untouched.

So an attacker cannot escalate with this, but can choose the IP recorded against their API activity, which degrades incident response.

## Why removal rather than configuration

`git log -S` places the middleware in `947026856` (#108, a bulk package consolidation) rather than a deliberate decision to sit behind a proxy, and there is no trusted-proxy setting anywhere in `pkg/config/`.

Trade-off, stated plainly: behind an ingress — which the k8s operator deploys — the logged address becomes the proxy's rather than the end client's. That is less specific but true, which beats specific and attacker-controlled. Recovering the real client address there needs an allowlist that only honours forwarded headers from configured hops; that is a feature with a config surface and belongs in its own change.

No test asserts on the logged address, so there is nothing to update. `go build ./...` and `go vet` clean; the `middleware` import is still used for `RequestID`, `Recoverer`, `Timeout`, `GetReqID` and `NewWrapResponseWriter`.