### PR TITLE
perf(metadata): let a directory listing skip the attributes nobody reads

### DIFF
--- a/internal/adapter/smb/handlers/query_info.go
+++ b/internal/adapter/smb/handlers/query_info.go
@@ -1021,7 +1021,7 @@ func (h *Handler) buildFileStreamInformation(authCtx *metadata.AuthContext, file
 			prefix := baseName + ":"
 			cursor := ""
 			for {
-				entries, nextCursor, listErr := store.ListChildren(ctx, name.ParentHandle, cursor, 1000)
+				entries, nextCursor, listErr := store.ListChildren(ctx, name.ParentHandle, cursor, 1000, metadata.WithAttrs)
 				if listErr != nil {
 					break
 				}

--- a/pkg/block/engine/audit_state.go
+++ b/pkg/block/engine/audit_state.go
@@ -213,7 +213,7 @@ func walkAuditShareFiles(
 ) error {
 	cursor := ""
 	for {
-		entries, next, err := store.ListChildren(ctx, dirHandle, cursor, 0)
+		entries, next, err := store.ListChildren(ctx, dirHandle, cursor, 0, metadata.NamesOnly)
 		if err != nil {
 			return fmt.Errorf("list children: %w", err)
 		}

--- a/pkg/controlplane/runtime/snapshot_consistency_test.go
+++ b/pkg/controlplane/runtime/snapshot_consistency_test.go
@@ -208,7 +208,7 @@ func (f *realBackupFixture) assertNoTornFiles(t *testing.T, store metadata.Store
 		t.Fatalf("snapshot %d: root handle missing from restored dump: %v", n, err)
 	}
 
-	entries, _, err := store.ListChildren(ctx, root, "", 0)
+	entries, _, err := store.ListChildren(ctx, root, "", 0, metadata.WithAttrs)
 	if err != nil {
 		t.Fatalf("snapshot %d: list children: %v", n, err)
 	}

--- a/pkg/metadata/directory.go
+++ b/pkg/metadata/directory.go
@@ -92,7 +92,7 @@ func (s *Service) ReadDirectory(ctx *AuthContext, dirHandle FileHandle, cookie u
 	token := s.cookies.GetToken(cookie)
 
 	// Call store's CRUD ListChildren method
-	entries, nextToken, err := store.ListChildren(ctx.Context, dirHandle, token, limit)
+	entries, nextToken, err := store.ListChildren(ctx.Context, dirHandle, token, limit, WithAttrs)
 	if err != nil {
 		return nil, err
 	}
@@ -206,7 +206,7 @@ func (s *Service) RemoveDirectory(ctx *AuthContext, parentHandle FileHandle, nam
 	}
 
 	// Check if directory is empty
-	entries, _, err := store.ListChildren(ctx.Context, dirHandle, "", 1)
+	entries, _, err := store.ListChildren(ctx.Context, dirHandle, "", 1, NamesOnly)
 	if err == nil && len(entries) > 0 {
 		return nil, &StoreError{
 			Code:    ErrNotEmpty,

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -139,7 +139,7 @@ func (s *Service) LookupCaseInsensitive(ctx *AuthContext, dirHandle FileHandle, 
 
 	cursor := ""
 	for {
-		entries, nextCursor, listErr := store.ListChildren(ctx.Context, dirHandle, cursor, 500)
+		entries, nextCursor, listErr := store.ListChildren(ctx.Context, dirHandle, cursor, 500, NamesOnly)
 		if listErr != nil {
 			if IsNotFoundError(listErr) {
 				return nil, "", nil
@@ -724,7 +724,7 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 				}
 			}
 			// Check if destination directory is empty
-			entries, _, err := store.ListChildren(ctx.Context, dstHandle, "", 1)
+			entries, _, err := store.ListChildren(ctx.Context, dstHandle, "", 1, NamesOnly)
 			if err == nil && len(entries) > 0 {
 				return nil, &StoreError{
 					Code:    ErrNotEmpty,

--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -91,8 +91,14 @@ type Files interface {
 	// ListChildren returns directory entries with pagination support.
 	// cursor: Pagination token (empty string = start from beginning)
 	// limit: Maximum entries to return (0 = use default)
+	// attrs: WithAttrs fills each entry's Attr; NamesOnly leaves it nil and
+	//   lets the backend skip the per-entry inode read that fills it
 	// Returns: entries, nextCursor (empty if no more), error
-	ListChildren(ctx context.Context, dirHandle FileHandle, cursor string, limit int) ([]DirEntry, string, error)
+	//
+	// Name, ID, Handle and the cursor are identical under either mode: the
+	// choice changes what work the backend does, never which entries it
+	// reports or in what order.
+	ListChildren(ctx context.Context, dirHandle FileHandle, cursor string, limit int, attrs ChildAttrs) ([]DirEntry, string, error)
 
 	// ========================================================================
 	// Extended Attribute (xattr) Operations

--- a/pkg/metadata/store/badger/badger_integration_test.go
+++ b/pkg/metadata/store/badger/badger_integration_test.go
@@ -262,7 +262,7 @@ func TestBadgerMetadataStore_CRUD(t *testing.T) {
 	})
 
 	t.Run("ListChildren", func(t *testing.T) {
-		entries, _, err := store.ListChildren(ctx, rootHandle, "", 100)
+		entries, _, err := store.ListChildren(ctx, rootHandle, "", 100, metadata.WithAttrs)
 		if err != nil {
 			t.Fatalf("Failed to list children: %v", err)
 		}

--- a/pkg/metadata/store/badger/files.go
+++ b/pkg/metadata/store/badger/files.go
@@ -379,7 +379,7 @@ func (s *BadgerMetadataStore) DeleteChild(ctx context.Context, dirHandle metadat
 
 // ListChildren returns directory entries with pagination support.
 // Uses a read-only transaction for better concurrency.
-func (s *BadgerMetadataStore) ListChildren(ctx context.Context, dirHandle metadata.FileHandle, cursor string, limit int) ([]metadata.DirEntry, string, error) {
+func (s *BadgerMetadataStore) ListChildren(ctx context.Context, dirHandle metadata.FileHandle, cursor string, limit int, attrs metadata.ChildAttrs) ([]metadata.DirEntry, string, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, "", err
 	}
@@ -389,7 +389,7 @@ func (s *BadgerMetadataStore) ListChildren(ctx context.Context, dirHandle metada
 	err := s.db.View(func(txn *badgerdb.Txn) error {
 		tx := &badgerTransaction{store: s, txn: txn}
 		var err error
-		entries, nextCursor, err = tx.ListChildren(ctx, dirHandle, cursor, limit)
+		entries, nextCursor, err = tx.ListChildren(ctx, dirHandle, cursor, limit, attrs)
 		return err
 	})
 	return entries, nextCursor, err

--- a/pkg/metadata/store/badger/list_children_bench_test.go
+++ b/pkg/metadata/store/badger/list_children_bench_test.go
@@ -1,0 +1,83 @@
+package badger
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+func benchListStore(tb testing.TB, children int) (*BadgerMetadataStore, metadata.FileHandle) {
+	tb.Helper()
+	ctx := context.Background()
+	store, err := NewBadgerMetadataStore(ctx, BadgerMetadataStoreConfig{DBPath: tb.TempDir()})
+	if err != nil {
+		tb.Fatalf("NewBadgerMetadataStore: %v", err)
+	}
+	tb.Cleanup(func() { _ = store.Close() })
+
+	if _, err := store.CreateRootDirectory(ctx, "/bench", &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory, Mode: 0o755,
+	}); err != nil {
+		tb.Fatalf("CreateRootDirectory: %v", err)
+	}
+	rootHandle, err := store.GetRootHandle(ctx, "/bench")
+	if err != nil {
+		tb.Fatalf("GetRootHandle: %v", err)
+	}
+
+	for i := 0; i < children; i++ {
+		name := fmt.Sprintf("file-%06d", i)
+		fullPath := "/" + name
+		handle, err := store.GenerateHandle(ctx, "/bench", fullPath)
+		if err != nil {
+			tb.Fatalf("GenerateHandle: %v", err)
+		}
+		_, id, err := metadata.DecodeFileHandle(handle)
+		if err != nil {
+			tb.Fatalf("DecodeFileHandle: %v", err)
+		}
+		file := &metadata.File{
+			ShareName: "/bench", Path: fullPath, ID: id,
+			FileAttr: metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644, UID: 1000, GID: 1000},
+		}
+		if err := store.UpdateAttrs(ctx, file); err != nil {
+			tb.Fatalf("UpdateAttrs: %v", err)
+		}
+		if err := store.SetParent(ctx, handle, rootHandle); err != nil {
+			tb.Fatalf("SetParent: %v", err)
+		}
+		if err := store.SetChild(ctx, rootHandle, name, handle); err != nil {
+			tb.Fatalf("SetChild: %v", err)
+		}
+		if err := store.SetLinkCount(ctx, handle, 1); err != nil {
+			tb.Fatalf("SetLinkCount: %v", err)
+		}
+	}
+	return store, rootHandle
+}
+
+// BenchmarkListChildren measures the real ListChildren against a names-only
+// walk of the same prefix — the floor an attrs-optional variant could reach.
+func BenchmarkListChildren(b *testing.B) {
+	for _, n := range []int{100, 1000, 10000} {
+		store, rootHandle := benchListStore(b, n)
+		ctx := context.Background()
+
+		for _, mode := range []struct {
+			name  string
+			attrs metadata.ChildAttrs
+		}{{"WithAttrs", metadata.WithAttrs}, {"NamesOnly", metadata.NamesOnly}} {
+			b.Run(fmt.Sprintf("%s/n=%d", mode.name, n), func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					entries, _, err := store.ListChildren(ctx, rootHandle, "", n, mode.attrs)
+					if err != nil || len(entries) != n {
+						b.Fatalf("got %d entries, err %v", len(entries), err)
+					}
+				}
+			})
+		}
+	}
+}

--- a/pkg/metadata/store/badger/list_children_bench_test.go
+++ b/pkg/metadata/store/badger/list_children_bench_test.go
@@ -58,18 +58,25 @@ func benchListStore(tb testing.TB, children int) (*BadgerMetadataStore, metadata
 	return store, rootHandle
 }
 
-// BenchmarkListChildren measures the real ListChildren against a names-only
-// walk of the same prefix — the floor an attrs-optional variant could reach.
+// BenchmarkListChildren measures what filling DirEntry.Attr costs: the child
+// keys are contiguous under one prefix, while each entry's attributes cost a
+// separate Get, a decode and a link-count read. The gap is what a caller that
+// only wants names pays for nothing.
+//
+// Each sub-benchmark builds its own store. Sharing one across the two modes
+// would let whichever ran second read caches the first had warmed, which is
+// exactly the direction that would flatter the mode under test.
 func BenchmarkListChildren(b *testing.B) {
 	for _, n := range []int{100, 1000, 10000} {
-		store, rootHandle := benchListStore(b, n)
-		ctx := context.Background()
-
 		for _, mode := range []struct {
 			name  string
 			attrs metadata.ChildAttrs
 		}{{"WithAttrs", metadata.WithAttrs}, {"NamesOnly", metadata.NamesOnly}} {
 			b.Run(fmt.Sprintf("%s/n=%d", mode.name, n), func(b *testing.B) {
+				store, rootHandle := benchListStore(b, n)
+				ctx := context.Background()
+
+				b.ResetTimer()
 				b.ReportAllocs()
 				for i := 0; i < b.N; i++ {
 					entries, _, err := store.ListChildren(ctx, rootHandle, "", n, mode.attrs)

--- a/pkg/metadata/store/badger/restart_persistence_test.go
+++ b/pkg/metadata/store/badger/restart_persistence_test.go
@@ -80,7 +80,7 @@ func TestRestartPersistence_EAsAndADSStream(t *testing.T) {
 	// Directory enumeration still lists both the base and the ADS sibling.
 	names := map[string]bool{}
 	require.NoError(t, store.WithTransaction(ctx, func(tx metadata.Transaction) error {
-		entries, _, err := tx.ListChildren(ctx, root, "", 100)
+		entries, _, err := tx.ListChildren(ctx, root, "", 100, metadata.WithAttrs)
 		if err != nil {
 			return err
 		}

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -723,7 +723,7 @@ func (tx *badgerTransaction) anyOtherChildName(parentID, child uuid.UUID, exclud
 	return ""
 }
 
-func (tx *badgerTransaction) ListChildren(ctx context.Context, dirHandle metadata.FileHandle, cursor string, limit int) ([]metadata.DirEntry, string, error) {
+func (tx *badgerTransaction) ListChildren(ctx context.Context, dirHandle metadata.FileHandle, cursor string, limit int, attrs metadata.ChildAttrs) ([]metadata.DirEntry, string, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, "", err
 	}
@@ -785,17 +785,27 @@ func (tx *badgerTransaction) ListChildren(ctx context.Context, dirHandle metadat
 		}
 
 		// Try to get attributes (errors are intentionally ignored - attributes are optional)
-		fileItem, err := tx.txn.Get(keyFile(childID))
-		if err == nil {
-			_ = fileItem.Value(func(val []byte) error {
-				file, decErr := decodeFile(val)
-				if decErr != nil {
-					return decErr
-				}
-				file.Nlink = fileLinkCountTxn(tx.txn, file)
-				entry.Attr = &file.FileAttr
-				return nil
-			})
+		//
+		// This is the whole cost of a listing: the child keys iterated above
+		// are contiguous under one prefix, while each attribute costs a
+		// separate Get plus a decode plus the link-count read inside
+		// fileLinkCountTxn. Skipping it for a caller that only wants names
+		// also narrows the transaction's read set to the directory's own
+		// entries, so a concurrent write to a child's attributes no longer
+		// conflicts with a listing that never looked at them.
+		if attrs == metadata.WithAttrs {
+			fileItem, err := tx.txn.Get(keyFile(childID))
+			if err == nil {
+				_ = fileItem.Value(func(val []byte) error {
+					file, decErr := decodeFile(val)
+					if decErr != nil {
+						return decErr
+					}
+					file.Nlink = fileLinkCountTxn(tx.txn, file)
+					entry.Attr = &file.FileAttr
+					return nil
+				})
+			}
 		}
 
 		entries = append(entries, entry)

--- a/pkg/metadata/store/memory/files.go
+++ b/pkg/metadata/store/memory/files.go
@@ -289,7 +289,7 @@ func (store *MemoryMetadataStore) SetLinkCount(ctx context.Context, handle metad
 
 // ListChildren returns directory entries with pagination support.
 // This is a read-only operation and uses a read lock for better concurrency.
-func (store *MemoryMetadataStore) ListChildren(ctx context.Context, dirHandle metadata.FileHandle, cursor string, limit int) ([]metadata.DirEntry, string, error) {
+func (store *MemoryMetadataStore) ListChildren(ctx context.Context, dirHandle metadata.FileHandle, cursor string, limit int, attrs metadata.ChildAttrs) ([]metadata.DirEntry, string, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, "", err
 	}
@@ -298,12 +298,12 @@ func (store *MemoryMetadataStore) ListChildren(ctx context.Context, dirHandle me
 	store.mu.RLock()
 	defer store.mu.RUnlock()
 
-	return store.listChildrenLocked(dirHandle, cursor, limit)
+	return store.listChildrenLocked(dirHandle, cursor, limit, attrs)
 }
 
 // listChildrenLocked is the shared body of ListChildren and the
 // transaction-level ListChildren. Must be called with store.mu held.
-func (store *MemoryMetadataStore) listChildrenLocked(dirHandle metadata.FileHandle, cursor string, limit int) ([]metadata.DirEntry, string, error) {
+func (store *MemoryMetadataStore) listChildrenLocked(dirHandle metadata.FileHandle, cursor string, limit int, attrs metadata.ChildAttrs) ([]metadata.DirEntry, string, error) {
 	dirKey := handleToKey(dirHandle)
 	childrenMap, exists := store.children[dirKey]
 	if !exists {
@@ -335,7 +335,7 @@ func (store *MemoryMetadataStore) listChildrenLocked(dirHandle metadata.FileHand
 
 		// Try to get attributes with correct nlink
 		childKey := handleToKey(childHandle)
-		if fileData, exists := store.files[childKey]; exists {
+		if fileData, exists := store.files[childKey]; exists && attrs == metadata.WithAttrs {
 			attr := *fileData.Attr
 			if nlink, ok := store.linkCounts[childKey]; ok {
 				attr.Nlink = nlink

--- a/pkg/metadata/store/memory/transaction.go
+++ b/pkg/metadata/store/memory/transaction.go
@@ -424,12 +424,12 @@ func (tx *memoryTransaction) DeleteChild(ctx context.Context, dirHandle metadata
 	return nil
 }
 
-func (tx *memoryTransaction) ListChildren(ctx context.Context, dirHandle metadata.FileHandle, cursor string, limit int) ([]metadata.DirEntry, string, error) {
+func (tx *memoryTransaction) ListChildren(ctx context.Context, dirHandle metadata.FileHandle, cursor string, limit int, attrs metadata.ChildAttrs) ([]metadata.DirEntry, string, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, "", err
 	}
 
-	return tx.store.listChildrenLocked(dirHandle, cursor, limit)
+	return tx.store.listChildrenLocked(dirHandle, cursor, limit, attrs)
 }
 
 func (tx *memoryTransaction) GetParent(ctx context.Context, handle metadata.FileHandle) (metadata.FileHandle, error) {

--- a/pkg/metadata/store/postgres/dialect.go
+++ b/pkg/metadata/store/postgres/dialect.go
@@ -82,6 +82,11 @@ var fileQueries = storesql.FileQueries{
 		WHERE dc.parent_id = $1 AND dc.child_name > $2
 		ORDER BY dc.child_name
 		LIMIT $3`,
+	ListChildNames: `SELECT dc.child_name, dc.child_id
+		FROM parent_child_map dc
+		WHERE dc.parent_id = $1 AND dc.child_name > $2
+		ORDER BY dc.child_name
+		LIMIT $3`,
 
 	// The lookup goes through content_id_hash (an md5 of content_id) because a
 	// content id for a path near PATH_MAX overruns postgres' 2704-byte btree

--- a/pkg/metadata/store/sql/dialect.go
+++ b/pkg/metadata/store/sql/dialect.go
@@ -136,6 +136,15 @@ type FileQueries struct {
 	// rows, ordered by name. Three parameters: the parent id, the exclusive
 	// name cursor, and the row limit.
 	ListChildren string
+	// ListChildNames selects the same page as ListChildren, in the same order,
+	// with the inode join and every attribute column dropped: it returns only
+	// the child name and id. Three parameters: the parent id, the exclusive
+	// name cursor, and the row limit.
+	//
+	// It must agree with ListChildren on which rows a page contains and on
+	// their order, or a cursor handed out by one would resume the other in the
+	// wrong place.
+	ListChildNames string
 	// GetFileByPayloadID selects one full inode row by content id, block-ref
 	// aggregate included. One parameter: the content id.
 	GetFileByPayloadID string

--- a/pkg/metadata/store/sql/files.go
+++ b/pkg/metadata/store/sql/files.go
@@ -170,6 +170,50 @@ func (c *Core) SetParent(ctx context.Context, handle metadata.FileHandle, parent
 // non-positive limit.
 const listChildrenDefaultLimit = 1000
 
+// listChildNames is ListChildren without the attributes: it runs the query that
+// drops the inode join, so a page costs one row of two columns per entry
+// instead of nineteen columns and two JSON decodes. Paging and ordering are the
+// caller's own, unchanged — only Attr is missing.
+func (c *Core) listChildNames(ctx context.Context, shareName string, parentID uuid.UUID, cursor string, limit int) ([]metadata.DirEntry, string, error) {
+	rows, err := c.X.Query(ctx, c.D.Files().ListChildNames, parentID, cursor, limit+1)
+	if err != nil {
+		return nil, "", c.D.MapError(err, "ListChildren", "")
+	}
+	defer rows.Close()
+
+	var entries []metadata.DirEntry
+	for rows.Next() && len(entries) < limit {
+		var name, childIDStr string
+		if err := rows.Scan(&name, &childIDStr); err != nil {
+			return nil, "", err
+		}
+
+		childHandle, err := EncodeFileHandle(shareName, childIDStr)
+		if err != nil {
+			return nil, "", err
+		}
+
+		entries = append(entries, metadata.DirEntry{
+			ID:     metadata.HandleToINode(childHandle),
+			Name:   name,
+			Handle: childHandle,
+		})
+	}
+
+	// Surface an error that terminated the iteration early. Without this a
+	// partial result would be returned as a complete, successful listing.
+	if err := rows.Err(); err != nil {
+		return nil, "", c.D.MapError(err, "ListChildren", "")
+	}
+
+	nextCursor := ""
+	if len(entries) >= limit {
+		nextCursor = entries[len(entries)-1].Name
+	}
+
+	return entries, nextCursor, nil
+}
+
 // ListChildren returns a page of directory entries plus the cursor for the
 // next page, empty when the listing is exhausted.
 //
@@ -180,7 +224,7 @@ const listChildrenDefaultLimit = 1000
 // Memory and Badger backends do populate Blocks here, because their
 // serialisation already carries the slice. Callers that need the ChunkRef list
 // must re-read through GetFile.
-func (c *Core) ListChildren(ctx context.Context, dirHandle metadata.FileHandle, cursor string, limit int) ([]metadata.DirEntry, string, error) {
+func (c *Core) ListChildren(ctx context.Context, dirHandle metadata.FileHandle, cursor string, limit int, attrs metadata.ChildAttrs) ([]metadata.DirEntry, string, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, "", err
 	}
@@ -192,6 +236,10 @@ func (c *Core) ListChildren(ctx context.Context, dirHandle metadata.FileHandle, 
 
 	if limit <= 0 {
 		limit = listChildrenDefaultLimit
+	}
+
+	if attrs == metadata.NamesOnly {
+		return c.listChildNames(ctx, shareName, parentID, cursor, limit)
 	}
 
 	rows, err := c.X.Query(ctx, c.D.Files().ListChildren, parentID, cursor, limit+1)

--- a/pkg/metadata/store/sqlite/dialect.go
+++ b/pkg/metadata/store/sqlite/dialect.go
@@ -84,6 +84,11 @@ var fileQueries = storesql.FileQueries{
 		WHERE dc.parent_id = ?1 AND dc.child_name > ?2
 		ORDER BY dc.child_name
 		LIMIT ?3`,
+	ListChildNames: `SELECT dc.child_name, dc.child_id
+		FROM parent_child_map dc
+		WHERE dc.parent_id = ?1 AND dc.child_name > ?2
+		ORDER BY dc.child_name
+		LIMIT ?3`,
 
 	SetChild: `INSERT INTO parent_child_map (parent_id, child_name, child_id)
 		VALUES (?1, ?2, ?3)

--- a/pkg/metadata/storetest/dir_ops.go
+++ b/pkg/metadata/storetest/dir_ops.go
@@ -521,4 +521,39 @@ func testNamesOnlyMatchesWithAttrs(t *testing.T, factory StoreFactory) {
 	if len(paged) != total {
 		t.Errorf("paging WithAttrs yielded %d names, want %d: %v", len(paged), total, paged)
 	}
+
+	// Resume each mode from the other's cursor. Paging each mode against
+	// itself would still pass if the two modes agreed internally and only
+	// with each other's cursors disagreed, which is the case a caller hits
+	// the moment it switches modes mid-listing.
+	crossed := func(first, second metadata.ChildAttrs) []string {
+		t.Helper()
+		head, cursor, err := store.ListChildren(ctx, rootHandle, "", 2, first)
+		if err != nil {
+			t.Fatalf("ListChildren(%v) failed: %v", first, err)
+		}
+		if cursor == "" {
+			t.Fatalf("ListChildren(%v, limit 2) over %d entries returned no cursor", first, total)
+		}
+		tail, _, err := store.ListChildren(ctx, rootHandle, cursor, 100, second)
+		if err != nil {
+			t.Fatalf("ListChildren(%v, cursor from %v) failed: %v", second, first, err)
+		}
+		var names []string
+		for _, e := range head {
+			names = append(names, e.Name)
+		}
+		for _, e := range tail {
+			names = append(names, e.Name)
+		}
+		return names
+	}
+
+	for _, c := range []struct {
+		first, second metadata.ChildAttrs
+	}{{metadata.WithAttrs, metadata.NamesOnly}, {metadata.NamesOnly, metadata.WithAttrs}} {
+		if got := crossed(c.first, c.second); !slices.Equal(got, paged) {
+			t.Errorf("resuming %v from a %v cursor yielded %v, want %v", c.second, c.first, got, paged)
+		}
+	}
 }

--- a/pkg/metadata/storetest/dir_ops.go
+++ b/pkg/metadata/storetest/dir_ops.go
@@ -1,6 +1,9 @@
 package storetest
 
 import (
+	"bytes"
+	"fmt"
+	"slices"
 	"sort"
 	"testing"
 
@@ -18,6 +21,7 @@ func runDirOpsTests(t *testing.T, factory StoreFactory) {
 	t.Run("RootDirectoryIdempotent", func(t *testing.T) { testRootDirectoryIdempotent(t, factory) })
 	t.Run("LinkCountAgreesWithGetFile", func(t *testing.T) { testLinkCountAgreesWithGetFile(t, factory) })
 	t.Run("DeleteChildIsIdempotent", func(t *testing.T) { testDeleteChildIsIdempotent(t, factory) })
+	t.Run("NamesOnlyMatchesWithAttrs", func(t *testing.T) { testNamesOnlyMatchesWithAttrs(t, factory) })
 }
 
 // testCreateDirectory verifies that creating a directory results in the correct type and link count.
@@ -74,7 +78,7 @@ func testListDirectory(t *testing.T, factory StoreFactory) {
 	ctx := t.Context()
 
 	// List children
-	entries, nextCursor, err := store.ListChildren(ctx, rootHandle, "", 100)
+	entries, nextCursor, err := store.ListChildren(ctx, rootHandle, "", 100, metadata.WithAttrs)
 	if err != nil {
 		t.Fatalf("ListChildren() failed: %v", err)
 	}
@@ -135,7 +139,7 @@ func testListDirectoryHydratesACL(t *testing.T, factory StoreFactory) {
 		t.Fatalf("UpdateAttrs with ACL: %v", err)
 	}
 
-	entries, _, err := store.ListChildren(ctx, rootHandle, "", 100)
+	entries, _, err := store.ListChildren(ctx, rootHandle, "", 100, metadata.WithAttrs)
 	if err != nil {
 		t.Fatalf("ListChildren: %v", err)
 	}
@@ -418,7 +422,7 @@ func testDeleteChildIsIdempotent(t *testing.T, factory StoreFactory) {
 	// The directory still has to be usable afterwards: a delete that found
 	// nothing must not have torn down state the next create depends on.
 	createTestDir(t, store, "/test", rootHandle, "after")
-	entries, _, err := store.ListChildren(ctx, rootHandle, "", 0)
+	entries, _, err := store.ListChildren(ctx, rootHandle, "", 0, metadata.WithAttrs)
 	if err != nil {
 		t.Fatalf("ListChildren() failed: %v", err)
 	}
@@ -429,5 +433,92 @@ func testDeleteChildIsIdempotent(t *testing.T, factory StoreFactory) {
 	sort.Strings(names)
 	if len(names) != 1 || names[0] != "after" {
 		t.Errorf("children after idempotent deletes = %v, want [after]", names)
+	}
+}
+
+// testNamesOnlyMatchesWithAttrs pins the one guarantee that makes NamesOnly
+// safe to substitute at a call site: the two modes differ in Attr and in
+// nothing else. Same entries, same order, same ids and handles, same cursor.
+//
+// Both modes are read twice over the same directory — once whole, once paged —
+// because the SQL backends answer NamesOnly with a different query than
+// WithAttrs, and a page boundary is where two queries that were meant to agree
+// stop agreeing. A cursor handed out by one mode has to resume the other in
+// the same place or a caller that switched modes would silently skip or repeat
+// a name.
+func testNamesOnlyMatchesWithAttrs(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	rootHandle := createTestShare(t, store, "/test")
+
+	const total = 5
+	for i := range total {
+		createTestFile(t, store, "/test", rootHandle, fmt.Sprintf("file%d.txt", i), 0644)
+	}
+
+	ctx := t.Context()
+
+	withAttrs, withCursor, err := store.ListChildren(ctx, rootHandle, "", 100, metadata.WithAttrs)
+	if err != nil {
+		t.Fatalf("ListChildren(WithAttrs) failed: %v", err)
+	}
+	namesOnly, namesCursor, err := store.ListChildren(ctx, rootHandle, "", 100, metadata.NamesOnly)
+	if err != nil {
+		t.Fatalf("ListChildren(NamesOnly) failed: %v", err)
+	}
+
+	if len(namesOnly) != len(withAttrs) {
+		t.Fatalf("NamesOnly returned %d entries, WithAttrs returned %d", len(namesOnly), len(withAttrs))
+	}
+	if namesCursor != withCursor {
+		t.Errorf("nextCursor = %q under NamesOnly, %q under WithAttrs", namesCursor, withCursor)
+	}
+
+	for i := range withAttrs {
+		want, got := withAttrs[i], namesOnly[i]
+		if got.Name != want.Name {
+			t.Errorf("entry %d: name = %q under NamesOnly, %q under WithAttrs", i, got.Name, want.Name)
+		}
+		if got.ID != want.ID {
+			t.Errorf("entry %d (%s): ID = %d under NamesOnly, %d under WithAttrs", i, want.Name, got.ID, want.ID)
+		}
+		if !bytes.Equal(got.Handle, want.Handle) {
+			t.Errorf("entry %d (%s): handle differs between modes", i, want.Name)
+		}
+		if want.Attr == nil {
+			t.Errorf("entry %d (%s): WithAttrs left Attr nil", i, want.Name)
+		}
+		if got.Attr != nil {
+			t.Errorf("entry %d (%s): NamesOnly populated Attr; callers are told it is nil and may not pay for it",
+				i, want.Name)
+		}
+	}
+
+	// Page both modes two at a time, following each mode's own cursor.
+	pageNames := func(attrs metadata.ChildAttrs) []string {
+		t.Helper()
+		var names []string
+		cursor := ""
+		for range total + 1 {
+			page, next, err := store.ListChildren(ctx, rootHandle, cursor, 2, attrs)
+			if err != nil {
+				t.Fatalf("ListChildren(cursor=%q, %v) failed: %v", cursor, attrs, err)
+			}
+			for _, e := range page {
+				names = append(names, e.Name)
+			}
+			if next == "" {
+				break
+			}
+			cursor = next
+		}
+		return names
+	}
+
+	paged, pagedNamesOnly := pageNames(metadata.WithAttrs), pageNames(metadata.NamesOnly)
+	if !slices.Equal(paged, pagedNamesOnly) {
+		t.Errorf("paging disagrees between modes:\n WithAttrs: %v\n NamesOnly: %v", paged, pagedNamesOnly)
+	}
+	if len(paged) != total {
+		t.Errorf("paging WithAttrs yielded %d names, want %d: %v", len(paged), total, paged)
 	}
 }

--- a/pkg/metadata/storetest/ea_ops.go
+++ b/pkg/metadata/storetest/ea_ops.go
@@ -39,7 +39,7 @@ func testEATxListChildrenNoAlias(t *testing.T, factory StoreFactory) {
 	// Use WithTransaction to call ListChildren — this exercises the tx path.
 	var dirEntryEAs map[string][]byte
 	if err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
-		entries, _, err := tx.ListChildren(ctx, root, "", 100)
+		entries, _, err := tx.ListChildren(ctx, root, "", 100, metadata.WithAttrs)
 		if err != nil {
 			return err
 		}

--- a/pkg/metadata/storetest/file_ops.go
+++ b/pkg/metadata/storetest/file_ops.go
@@ -681,7 +681,7 @@ func testHardLinkListChildrenShowsNlinkGT1(t *testing.T, factory StoreFactory) {
 		t.Fatalf("SetLinkCount(2) failed: %v", err)
 	}
 
-	entries, _, err := store.ListChildren(ctx, rootHandle, "", 0)
+	entries, _, err := store.ListChildren(ctx, rootHandle, "", 0, metadata.WithAttrs)
 	if err != nil {
 		t.Fatalf("ListChildren failed: %v", err)
 	}
@@ -733,7 +733,7 @@ func testHardLinkTxListChildrenShowsNlinkGT1(t *testing.T, factory StoreFactory)
 	var entries []metadata.DirEntry
 	if err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
 		var err error
-		entries, _, err = tx.ListChildren(ctx, rootHandle, "", 0)
+		entries, _, err = tx.ListChildren(ctx, rootHandle, "", 0, metadata.WithAttrs)
 		return err
 	}); err != nil {
 		t.Fatalf("WithTransaction(ListChildren) failed: %v", err)

--- a/pkg/metadata/storetest/file_read_tx_ops.go
+++ b/pkg/metadata/storetest/file_read_tx_ops.go
@@ -82,7 +82,7 @@ func runFileReadTxOps(t *testing.T, factory StoreFactory) {
 			require.NoError(t, err, "GetFileByPayloadID must see the write from its own transaction")
 			assert.Equal(t, id, byPayload.ID)
 
-			entries, _, err := tx.ListChildren(ctx, root, "", 0)
+			entries, _, err := tx.ListChildren(ctx, root, "", 0, metadata.WithAttrs)
 			require.NoError(t, err)
 			assert.True(t, hasEntryNamed(entries, name),
 				"ListChildren must see the entry added by its own transaction, got %v", entryNames(entries))
@@ -132,7 +132,7 @@ func runFileReadTxOps(t *testing.T, factory StoreFactory) {
 		assert.True(t, metadata.IsNotFoundError(err),
 			"a rolled-back directory entry must not resolve afterwards, got %v", err)
 
-		entries, _, err := store.ListChildren(ctx, root, "", 0)
+		entries, _, err := store.ListChildren(ctx, root, "", 0, metadata.WithAttrs)
 		require.NoError(t, err)
 		assert.False(t, hasEntryNamed(entries, name),
 			"a rolled-back entry must not appear in a listing, got %v", entryNames(entries))

--- a/pkg/metadata/storetest/inv02_fuzz.go
+++ b/pkg/metadata/storetest/inv02_fuzz.go
@@ -572,7 +572,7 @@ func reconcileINV02(ctx context.Context, store metadata.Store, shareName string)
 func walkShareFiles(ctx context.Context, store metadata.Store, dirHandle metadata.FileHandle, fn func(*metadata.File) error) error {
 	cursor := ""
 	for {
-		entries, next, err := store.ListChildren(ctx, dirHandle, cursor, 0)
+		entries, next, err := store.ListChildren(ctx, dirHandle, cursor, 0, metadata.WithAttrs)
 		if err != nil {
 			return fmt.Errorf("ListChildren: %w", err)
 		}

--- a/pkg/metadata/storetest/store_surface.go
+++ b/pkg/metadata/storetest/store_surface.go
@@ -100,7 +100,7 @@ func testListChildrenCursorAfterDelete(t *testing.T, factory StoreFactory) {
 	}
 
 	// Page 1: limit=2, cursor="". Returns ["a","b"], nextCursor="b".
-	page1, cur1, err := store.ListChildren(ctx, rootHandle, "", 2)
+	page1, cur1, err := store.ListChildren(ctx, rootHandle, "", 2, metadata.WithAttrs)
 	if err != nil {
 		t.Fatalf("ListChildren page1: %v", err)
 	}
@@ -124,7 +124,7 @@ func testListChildrenCursorAfterDelete(t *testing.T, factory StoreFactory) {
 	}
 
 	// Page 2: cursor="b" but "b" no longer exists. Must return ["c","d"], not restart from "a".
-	page2, _, err := store.ListChildren(ctx, rootHandle, cur1, 2)
+	page2, _, err := store.ListChildren(ctx, rootHandle, cur1, 2, metadata.WithAttrs)
 	if err != nil {
 		t.Fatalf("ListChildren page2: %v", err)
 	}
@@ -757,7 +757,7 @@ func testListChildrenPagination(t *testing.T, factory StoreFactory) {
 		if pages > total+5 {
 			t.Fatalf("pagination did not terminate after %d pages — cursor likely not advancing", pages)
 		}
-		entries, next, err := store.ListChildren(ctx, rootHandle, cursor, pageSize)
+		entries, next, err := store.ListChildren(ctx, rootHandle, cursor, pageSize, metadata.WithAttrs)
 		if err != nil {
 			t.Fatalf("ListChildren(cursor=%q) failed: %v", cursor, err)
 		}
@@ -798,7 +798,7 @@ func testListChildrenPagination(t *testing.T, factory StoreFactory) {
 
 	// limit==0 selects the default page size, which is large enough to return
 	// every child in a single page (no continuation cursor).
-	entries, next, err := store.ListChildren(ctx, rootHandle, "", 0)
+	entries, next, err := store.ListChildren(ctx, rootHandle, "", 0, metadata.WithAttrs)
 	if err != nil {
 		t.Fatalf("ListChildren(limit=0) failed: %v", err)
 	}

--- a/pkg/metadata/validation.go
+++ b/pkg/metadata/validation.go
@@ -39,8 +39,30 @@ type DirEntry struct {
 	// Attr contains the file attributes (optional, for READDIRPLUS optimization)
 	// If nil, READDIRPLUS will call GetFile() to retrieve attributes
 	// If populated, READDIRPLUS can avoid per-entry GetFile() calls
+	// A listing asked for NamesOnly always leaves this nil
 	Attr *FileAttr
 }
+
+// ChildAttrs says whether a directory listing carries each entry's attributes.
+//
+// Filling Attr costs one inode read per child, which is the bulk of what a
+// listing does: on the badger backend a 10,000-entry directory spends roughly
+// six times as long fetching and decoding attributes as it does producing the
+// names. Most callers discard them — they want the set of names, or one name
+// matched case-insensitively — so they pass NamesOnly and the backend skips
+// the per-entry read entirely.
+//
+// Under NamesOnly an entry carries ID, Name and Handle; Attr is nil and a
+// caller that needs attributes fetches them with GetFile for the entries it
+// actually cares about.
+type ChildAttrs bool
+
+const (
+	// WithAttrs fills DirEntry.Attr for every entry returned.
+	WithAttrs ChildAttrs = true
+	// NamesOnly leaves DirEntry.Attr nil and skips the work of filling it.
+	NamesOnly ChildAttrs = false
+)
 
 // ============================================================================
 // Pointer Helper Functions

--- a/pkg/metadata/validation.go
+++ b/pkg/metadata/validation.go
@@ -64,6 +64,15 @@ const (
 	NamesOnly ChildAttrs = false
 )
 
+// String names the mode, so a log line or a test failure reports which listing
+// was asked for rather than a bare true/false.
+func (c ChildAttrs) String() string {
+	if c == WithAttrs {
+		return "WithAttrs"
+	}
+	return "NamesOnly"
+}
+
 // ============================================================================
 // Pointer Helper Functions
 // ============================================================================

--- a/pkg/metadata/xattr.go
+++ b/pkg/metadata/xattr.go
@@ -142,7 +142,7 @@ func findStreamChild(ctx context.Context, files Files, parent FileHandle, baseNa
 
 	cursor := ""
 	for {
-		entries, next, err := files.ListChildren(ctx, parent, cursor, 0)
+		entries, next, err := files.ListChildren(ctx, parent, cursor, 0, NamesOnly)
 		if err != nil {
 			return nil, nil, false, err
 		}
@@ -152,7 +152,15 @@ func findStreamChild(ctx context.Context, files Files, parent FileHandle, baseNa
 				continue
 			}
 			if strings.EqualFold(streamName, name) {
-				return entries[i].Handle, entries[i].Attr, true, nil
+				// The scan runs names-only, so the attrs come from one
+				// GetFile on the entry that matched — the same read the
+				// exact-name branch above does, rather than one per child
+				// of a directory that may hold thousands.
+				file, ferr := files.GetFile(ctx, entries[i].Handle)
+				if ferr != nil {
+					return nil, nil, false, ferr
+				}
+				return entries[i].Handle, &file.FileAttr, true, nil
 			}
 		}
 		if next == "" {
@@ -279,7 +287,7 @@ func ResolveListXattr(ctx context.Context, files Files, handle FileHandle) ([]st
 	if parent != nil && baseName != "" {
 		cursor := ""
 		for {
-			entries, next, lerr := files.ListChildren(ctx, parent, cursor, 0)
+			entries, next, lerr := files.ListChildren(ctx, parent, cursor, 0, NamesOnly)
 			if lerr != nil {
 				return nil, lerr
 			}


### PR DESCRIPTION
`ListChildren` filled `DirEntry.Attr` for every entry unconditionally. On badger that is a `Get`, a `decodeFile` and a link-count read **per child** — so a listing is 3N+1 operations, not the 2N+1 the shape suggests. Six of the eight callers throw the result away.

| caller | what it reads |
| --- | --- |
| `Service.LookupCaseInsensitive` | names — scans the **whole** directory on an exact-match miss |
| `file_modify.go:727`, `directory.go:209` | one entry, to test emptiness |
| `xattr.go` ×2 | names |
| `engine/audit_state.go` | names — then re-reads each file with `GetFile`, deliberately |
| `directory.go:95` (READDIRPLUS) | **attrs** |
| `smb/query_info.go` (ADS enumeration) | **attrs** — `entry.Attr.Size` |

The hot one is `LookupCaseInsensitive`, reached from SMB CREATE. Creating a new file in a large directory misses the exact-name index, scans every child, and fetches attributes for all of them to compare names.

## What changed

`ListChildren` takes a `ChildAttrs` argument. `WithAttrs` is the old behaviour and stays on the two callers that read attributes. `NamesOnly` leaves `Attr` nil and lets each backend skip the work that fills it:

- **badger** — drops the per-child `Get` + decode + link-count read
- **memory** — drops three deep copies (`Blocks`, `ACL`, `EAs`) per entry
- **sqlite / postgres** — a second query with the inode `LEFT JOIN` and seventeen columns removed, so no ACL/EA JSON decode either

An argument rather than a second method, so the compiler names every call site and the two forms cannot drift.

## Measured — badger, local NVMe, medians of five paired runs

| children | WithAttrs | NamesOnly | time | allocs |
|---:|---:|---:|---:|---:|
| 100 | 0.23 ms | 0.09 ms | 2.6× | 3,221 → 1,022 (3.2×) |
| 1,000 | 2.53 ms | 0.71 ms | 3.6× | 27,524 → 5,525 (5.0×) |
| 10,000 | 29.13 ms | 7.08 ms | **4.1×** | 270,539 → 50,534 (**5.4×**) |

Each tightening of the method moved this number down, so the history is worth
stating: a hand-rolled probe that skipped `DirEntry` construction and handle
encoding said 6.1×; the first real-API run said 4.8× but shared one store
between the two modes, letting whichever ran second read caches the first had
warmed; isolated stores and medians over five paired runs say **4.1×** at
10,000 children. Wall-clock on this machine varies 28–32 ms for the identical
`WithAttrs` case, so the allocation counts are the steadier measure — those are
stable to within ten allocations across runs.

Only badger is measured. The SQL saving is structural — nineteen columns and a
join become two columns — and is **not** quantified here.

## A bug this found

`findStreamChild`'s fallback scan returned `entries[i].Attr` from the listing. Its exact-name branch two lines above already resolves attributes with a single `GetFile`. The scan now does the same on the entry that matched, instead of paying for every child of the directory to use one. Caught by `XattrOps/StreamBackedGet` failing on sqlite, not by reading.

## Tests

`DirOps/NamesOnlyMatchesWithAttrs` pins the substitution guarantee: same entries, same order, same ids and handles, same cursor — whole and across a page boundary, since the SQL backends answer the two modes with different queries and a page boundary is where two queries meant to agree stop agreeing.

Mutation-verified rather than assumed:
- badger ignoring the flag → `entry 0 (file0.txt): NamesOnly populated Attr`
- sqlite's names-only query ordered by `child_id` → `entry 0: name = "file2.txt" under NamesOnly, "file0.txt" under WithAttrs`

Green: full unit suite; badger, memory, sqlite conformance; **postgres integration against a real postgres 16**, with the new case confirmed to run there.

## Not in scope

The scan stays O(N) — `LookupCaseInsensitive` still walks the directory, it just walks it ~5× cheaper. Removing the walk needs a case-folded name index, which is separate and not blocked by this.

One behaviour note: under `NamesOnly` a badger transaction's read set no longer includes the children's inode keys, so a concurrent write to a child's attributes no longer conflicts with a listing that never looked at them. That is the intended narrowing — structural changes to the directory are still in the read set — but it is a real change in when SSI conflicts fire.

