### PR TITLE
test(smb): make CLOSE observable on the handler fixtures

### DIFF
--- a/internal/adapter/smb/handlers/close_doc_dir_not_empty_test.go
+++ b/internal/adapter/smb/handlers/close_doc_dir_not_empty_test.go
@@ -170,8 +170,8 @@ func TestClose_DeleteOnClose_NonEmptyDirectorySucceeds(t *testing.T) {
 
 	// subdir-name, closed straight away.
 	fileID := dirTestCreate(t, h, ctx, "subdir-name", types.FileOpenIf, types.FileDirectoryFile)
-	if _, err := h.Close(ctx, &CloseRequest{FileID: fileID}); err != nil {
-		t.Fatalf("close subdir-name: %v", err)
+	if cr, err := h.Close(ctx, &CloseRequest{FileID: fileID}); err != nil || cr.GetStatus() != types.StatusSuccess {
+		t.Fatalf("close subdir-name: err=%v status=%v", err, cr.GetStatus())
 	}
 
 	// subname1 (a directory) renamed within subdir-name; handle left open.
@@ -224,8 +224,8 @@ func TestSetInfo_DeleteDisposition_NonEmptyDirectoryRefused(t *testing.T) {
 
 	parentID := dirTestCreate(t, h, ctx, "parent", types.FileOpenIf, types.FileDirectoryFile)
 	childID := dirTestCreate(t, h, ctx, "parent\\child", types.FileOpenIf, types.FileNonDirectoryFile)
-	if _, err := h.Close(ctx, &CloseRequest{FileID: childID}); err != nil {
-		t.Fatalf("close child: %v", err)
+	if cr, err := h.Close(ctx, &CloseRequest{FileID: childID}); err != nil || cr.GetStatus() != types.StatusSuccess {
+		t.Fatalf("close child: err=%v status=%v", err, cr.GetStatus())
 	}
 
 	resp, err := h.SetInfo(ctx, &SetInfoRequest{

--- a/internal/adapter/smb/handlers/close_doc_dir_not_empty_test.go
+++ b/internal/adapter/smb/handlers/close_doc_dir_not_empty_test.go
@@ -170,8 +170,12 @@ func TestClose_DeleteOnClose_NonEmptyDirectorySucceeds(t *testing.T) {
 
 	// subdir-name, closed straight away.
 	fileID := dirTestCreate(t, h, ctx, "subdir-name", types.FileOpenIf, types.FileDirectoryFile)
-	if cr, err := h.Close(ctx, &CloseRequest{FileID: fileID}); err != nil || cr.GetStatus() != types.StatusSuccess {
-		t.Fatalf("close subdir-name: err=%v status=%v", err, cr.GetStatus())
+	cr, err := h.Close(ctx, &CloseRequest{FileID: fileID})
+	if err != nil {
+		t.Fatalf("close subdir-name: %v", err)
+	}
+	if cr.GetStatus() != types.StatusSuccess {
+		t.Fatalf("close subdir-name status = %v, want STATUS_SUCCESS", cr.GetStatus())
 	}
 
 	// subname1 (a directory) renamed within subdir-name; handle left open.
@@ -224,8 +228,12 @@ func TestSetInfo_DeleteDisposition_NonEmptyDirectoryRefused(t *testing.T) {
 
 	parentID := dirTestCreate(t, h, ctx, "parent", types.FileOpenIf, types.FileDirectoryFile)
 	childID := dirTestCreate(t, h, ctx, "parent\\child", types.FileOpenIf, types.FileNonDirectoryFile)
-	if cr, err := h.Close(ctx, &CloseRequest{FileID: childID}); err != nil || cr.GetStatus() != types.StatusSuccess {
-		t.Fatalf("close child: err=%v status=%v", err, cr.GetStatus())
+	childClose, err := h.Close(ctx, &CloseRequest{FileID: childID})
+	if err != nil {
+		t.Fatalf("close child: %v", err)
+	}
+	if childClose.GetStatus() != types.StatusSuccess {
+		t.Fatalf("close child status = %v, want STATUS_SUCCESS", childClose.GetStatus())
 	}
 
 	resp, err := h.SetInfo(ctx, &SetInfoRequest{

--- a/internal/adapter/smb/handlers/close_frozen_timestamps_test.go
+++ b/internal/adapter/smb/handlers/close_frozen_timestamps_test.go
@@ -22,6 +22,12 @@ import (
 // and the restore are gated by the same ownership rule in the metadata layer,
 // so a handle that could not have frozen a timestamp is not a case this can
 // reach. The file is chowned to the session's user first for that reason.
+//
+// It pins the end-to-end outcome, not the mechanism: it still passes with the
+// CLOSE-time restore disabled, because the rename preserves ChangeTime on its
+// own and advances none of the other three. Use
+// TestClose_FrozenTimestampsSurviveOutOfBandAdvance below to cover the restore
+// itself.
 func TestClose_FrozenTimestampsSurviveRename(t *testing.T) {
 	h, smbCtx, _, fileID := setupReparseShare(t)
 	openFile, ok := h.GetOpenFile(fileID)
@@ -100,6 +106,95 @@ func TestClose_FrozenTimestampsSurviveRename(t *testing.T) {
 	} {
 		if !tc.got.Equal(past) {
 			t.Errorf("%s = %v after rename + CLOSE; want the frozen %v", tc.name, tc.got.UTC(), past)
+		}
+	}
+}
+
+// TestClose_FrozenTimestampsSurviveOutOfBandAdvance pins the configuration in
+// which CLOSE-time timestamp behaviour is observable at all: a block store is
+// wired, so CLOSE reaches step 4 rather than failing on the flush, and the file
+// carries no pending write, so FlushPendingWriteForFile returns early without
+// stamping Mtime/Ctime itself. What CLOSE does to the timestamps is then
+// attributable to the frozen restore and nothing else.
+//
+// The advance is made out of band, as a second handle or an NFS client would:
+// the renaming test above cannot separate the restore from the rename's own
+// stamp, and a flush-backed file cannot separate it from the flush.
+func TestClose_FrozenTimestampsSurviveOutOfBandAdvance(t *testing.T) {
+	h, smbCtx, _, fileID := setupReparseShare(t)
+	openFile, ok := h.GetOpenFile(fileID)
+	if !ok {
+		t.Fatal("open file missing")
+	}
+	metaSvc := h.Registry.GetMetadataService()
+
+	rootUID, rootGID := uint32(0), uint32(0)
+	rootCtx := &metadata.AuthContext{
+		Context:  context.Background(),
+		Identity: &metadata.Identity{UID: &rootUID, GID: &rootGID},
+	}
+	sessUID, sessGID := uint32(1000), uint32(1000)
+	past := time.Date(2021, 2, 3, 4, 5, 6, 0, time.UTC)
+	if _, err := metaSvc.SetFileAttributes(rootCtx, openFile.MetadataHandle, &metadata.SetAttrs{
+		UID: &sessUID, GID: &sessGID,
+		CreationTime: &past, Atime: &past, Mtime: &past, Ctime: &past,
+	}); err != nil {
+		t.Fatalf("seed owner + timestamps: %v", err)
+	}
+
+	access := uint32(types.FileReadData | types.FileWriteData |
+		types.FileReadAttributes | types.FileWriteAttributes | types.Delete)
+	openFile.DesiredAccess = access
+	openFile.GrantedAccess = access
+
+	h.primeAuthContextFromOpenFile(smbCtx, openFile)
+	authCtx, err := BuildAuthContext(smbCtx)
+	if err != nil {
+		t.Fatalf("BuildAuthContext: %v", err)
+	}
+
+	freeze := encodeBasicInfo(filetimeFreeze, filetimeFreeze, filetimeFreeze, filetimeFreeze, 0)
+	resp, err := h.setFileInfoFromStore(smbCtx, authCtx, openFile, types.FileBasicInformation, freeze)
+	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
+		t.Fatalf("freeze SET_INFO: err=%v resp=%v", err, resp)
+	}
+
+	// Advance Mtime and Ctime behind this handle's back.
+	future := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+	if _, err := metaSvc.SetFileAttributes(rootCtx, openFile.MetadataHandle, &metadata.SetAttrs{
+		Mtime: &future, Ctime: &future,
+	}); err != nil {
+		t.Fatalf("out-of-band advance: %v", err)
+	}
+	mid, err := metaSvc.GetFile(context.Background(), openFile.MetadataHandle)
+	if err != nil {
+		t.Fatalf("GetFile after advance: %v", err)
+	}
+	if !mid.Ctime.Equal(future) {
+		t.Fatalf("advance did not land: ChangeTime = %v, want %v", mid.Ctime.UTC(), future)
+	}
+
+	cresp, err := h.Close(smbCtx, &CloseRequest{FileID: fileID})
+	if err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if cresp.GetStatus() != types.StatusSuccess {
+		t.Fatalf("Close status = %v, want STATUS_SUCCESS", cresp.GetStatus())
+	}
+
+	final, err := metaSvc.GetFile(context.Background(), openFile.MetadataHandle)
+	if err != nil {
+		t.Fatalf("GetFile after close: %v", err)
+	}
+	for _, tc := range []struct {
+		name string
+		got  time.Time
+	}{
+		{"LastWriteTime", final.Mtime},
+		{"ChangeTime", final.Ctime},
+	} {
+		if !tc.got.Equal(past) {
+			t.Errorf("%s = %v after CLOSE; want the frozen %v", tc.name, tc.got.UTC(), past)
 		}
 	}
 }

--- a/internal/adapter/smb/handlers/close_notify_test.go
+++ b/internal/adapter/smb/handlers/close_notify_test.go
@@ -289,8 +289,12 @@ func TestClose_DirectoryDeleteOnClose_RetiresNotifyMarker(t *testing.T) {
 		t.Fatalf("a watch registering after the mark: got %v, want ErrDirectoryDeletePending", err)
 	}
 
-	if cr, err := h.Close(ctx, &CloseRequest{FileID: dirID}); err != nil || cr.GetStatus() != types.StatusSuccess {
-		t.Fatalf("close doomed: err=%v status=%v", err, cr.GetStatus())
+	doomedClose, err := h.Close(ctx, &CloseRequest{FileID: dirID})
+	if err != nil {
+		t.Fatalf("close doomed: %v", err)
+	}
+	if doomedClose.GetStatus() != types.StatusSuccess {
+		t.Fatalf("close doomed status = %v, want STATUS_SUCCESS", doomedClose.GetStatus())
 	}
 
 	if err := h.NotifyRegistry.Register(lateNotify(12)); err != nil {

--- a/internal/adapter/smb/handlers/close_notify_test.go
+++ b/internal/adapter/smb/handlers/close_notify_test.go
@@ -289,8 +289,8 @@ func TestClose_DirectoryDeleteOnClose_RetiresNotifyMarker(t *testing.T) {
 		t.Fatalf("a watch registering after the mark: got %v, want ErrDirectoryDeletePending", err)
 	}
 
-	if _, err := h.Close(ctx, &CloseRequest{FileID: dirID}); err != nil {
-		t.Fatalf("close doomed: %v", err)
+	if cr, err := h.Close(ctx, &CloseRequest{FileID: dirID}); err != nil || cr.GetStatus() != types.StatusSuccess {
+		t.Fatalf("close doomed: err=%v status=%v", err, cr.GetStatus())
 	}
 
 	if err := h.NotifyRegistry.Register(lateNotify(12)); err != nil {

--- a/internal/adapter/smb/handlers/create_streams_disabled_test.go
+++ b/internal/adapter/smb/handlers/create_streams_disabled_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	cpstore "github.com/marmos91/dittofs/pkg/controlplane/store"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
@@ -32,21 +33,48 @@ import (
 // and tree, and the share's root handle (the latter is unused by these tests
 // but matches the pattern used by other handler-level integration tests in
 // this package).
+//
+// The share owns a local memory block store. CLOSE flushes the block store for
+// any handle carrying a payload, so without one every CLOSE of a regular file
+// returns STATUS_INTERNAL_ERROR ("block store not available for handle") and
+// never reaches its metadata flush or its frozen-timestamp restore. A test that
+// checks only the Go error sees that as a pass.
 func setupStreamsDisabledShare(t *testing.T, streamsDisabled bool) (*Handler, *SMBHandlerContext, metadata.FileHandle) {
 	t.Helper()
 
-	rt := runtime.New(nil)
+	cps, err := cpstore.New(&cpstore.Config{
+		Type:   cpstore.DatabaseTypeSQLite,
+		SQLite: cpstore.SQLiteConfig{Path: ":memory:"},
+	})
+	if err != nil {
+		t.Fatalf("cpstore.New: %v", err)
+	}
+	rt := runtime.New(cps)
 	memStore := memory.NewMemoryMetadataStoreWithDefaults()
 	if err := rt.RegisterMetadataStore("streams-test-meta", memStore); err != nil {
 		t.Fatalf("RegisterMetadataStore: %v", err)
 	}
 
+	if _, err := cps.CreateMetadataStore(context.Background(), &models.MetadataStoreConfig{
+		Name: "streams-test-meta", Type: "memory",
+	}); err != nil {
+		t.Fatalf("CreateMetadataStore: %v", err)
+	}
+
+	localBSID, err := cps.CreateBlockStore(context.Background(), &models.BlockStoreConfig{
+		Name: "streams-test-bs", Kind: models.BlockStoreKindLocal, Type: "memory",
+	})
+	if err != nil {
+		t.Fatalf("CreateBlockStore: %v", err)
+	}
+
 	const shareName = "/streams-test"
 	if err := rt.AddShare(context.Background(), &runtime.ShareConfig{
-		Name:            shareName,
-		MetadataStore:   "streams-test-meta",
-		Enabled:         true,
-		StreamsDisabled: streamsDisabled,
+		Name:              shareName,
+		MetadataStore:     "streams-test-meta",
+		Enabled:           true,
+		LocalBlockStoreID: localBSID,
+		StreamsDisabled:   streamsDisabled,
 		RootAttr: &metadata.FileAttr{
 			Type: metadata.FileTypeDirectory,
 			Mode: 0o777,

--- a/internal/adapter/smb/handlers/ioctl_copychunk_sparse_integration_test.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk_sparse_integration_test.go
@@ -422,8 +422,12 @@ func TestCopyChunk_SparseDest_SurvivesPriorPayloadReuse(t *testing.T) {
 	// Delete-on-close the dest (real CLOSE path). This MUST purge the
 	// block-store payload so the reused PayloadID starts clean.
 	dst1.DeletePending = true
-	if cr, err := h.Close(smbCtx, &CloseRequest{FileID: dst1.FileID}); err != nil || cr.GetStatus() != types.StatusSuccess {
-		t.Fatalf("round1 Close (delete-on-close): err=%v status=%v", err, cr.GetStatus())
+	dst1Close, err := h.Close(smbCtx, &CloseRequest{FileID: dst1.FileID})
+	if err != nil {
+		t.Fatalf("round1 Close (delete-on-close): %v", err)
+	}
+	if dst1Close.GetStatus() != types.StatusSuccess {
+		t.Fatalf("round1 Close (delete-on-close) status = %v, want STATUS_SUCCESS", dst1Close.GetStatus())
 	}
 
 	// --- Round 2: recreate dest at the same path, then the sparse_dest copy

--- a/internal/adapter/smb/handlers/ioctl_copychunk_sparse_integration_test.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk_sparse_integration_test.go
@@ -422,8 +422,8 @@ func TestCopyChunk_SparseDest_SurvivesPriorPayloadReuse(t *testing.T) {
 	// Delete-on-close the dest (real CLOSE path). This MUST purge the
 	// block-store payload so the reused PayloadID starts clean.
 	dst1.DeletePending = true
-	if _, err := h.Close(smbCtx, &CloseRequest{FileID: dst1.FileID}); err != nil {
-		t.Fatalf("round1 Close (delete-on-close): %v", err)
+	if cr, err := h.Close(smbCtx, &CloseRequest{FileID: dst1.FileID}); err != nil || cr.GetStatus() != types.StatusSuccess {
+		t.Fatalf("round1 Close (delete-on-close): err=%v status=%v", err, cr.GetStatus())
 	}
 
 	// --- Round 2: recreate dest at the same path, then the sparse_dest copy


### PR DESCRIPTION
Closes #2201.

## Premises, measured before fixing

The issue makes two claims. One holds, one does not.

**Holds — `setupStreamsDisabledShare` cannot CLOSE a regular file.** The fixture wired no block store, so any handle carrying a payload fails CLOSEs block-store flush with `STATUS_INTERNAL_ERROR` and never reaches step 4 (metadata flush, LastAccessTime settle, frozen-timestamp restore). A file created directly in the metadata store closes fine, which is why this was not obvious; it needs the CREATE handler to allocate a payload to reproduce.

This was live in develop: `TestSetInfo_DeleteDisposition_NonEmptyDirectoryRefused` closes `parent\child` and checks only the Go error. Adding the status assertion on unmodified develop:

```
close_doc_dir_not_empty_test.go:228: close child: err=<nil> status=STATUS_INTERNAL_ERROR
```

Green on every run, with its CLOSE failing on every run.

**Does not hold — `setupReparseShare` does not mask the restore.** The issue expects the deferred-write flush to stamp Ctime unconditionally, and proposes building a third fixture that wires a block store but leaves no pending write. That fixture already exists: `setupReparseShare`s file is created and never written, so `FlushPendingWriteForFile` finds a cache-only state (`hasWriteData == false`) and returns before touching a timestamp. CLOSE-time behaviour is observable there today.

## What the mutant showed

Disabling `h.restoreFrozenTimestamps(authCtx, openFile)` in `close.go`:

| test | restore enabled | restore disabled |
| --- | --- | --- |
| `TestClose_FrozenTimestampsSurviveRename` (pre-existing) | PASS | **PASS** |
| `TestClose_FrozenTimestampsSurviveOutOfBandAdvance` (new) | PASS | FAIL |

So the issues suspicion about the existing test is confirmed, just for a different reason than the fixture: the rename preserves ChangeTime on its own since #2279 and advances none of the other three, so the restore never has anything to do. The test pins a true end-to-end outcome, it just does not cover the mechanism its name implies. Its doc comment now says so and points at the new test rather than deleting the coverage.

## Changes

- `create_streams_disabled_test.go` — cpstore + local memory block store on the share, so CLOSE completes.
- `close_doc_dir_not_empty_test.go`, `close_notify_test.go`, `ioctl_copychunk_sparse_integration_test.go` — assert `resp.GetStatus()` at the four close sites that checked only `err`.
- `close_frozen_timestamps_test.go` — `TestClose_FrozenTimestampsSurviveOutOfBandAdvance`: freeze via SET_INFO, advance Mtime/Ctime out of band as a second handle or an NFS client would, CLOSE, assert the frozen values won. Mutation-verified above.

Test-only. `go test -race ./internal/adapter/smb/handlers/` green; whole `internal/adapter/smb/...` green.

Removing the block store again reproduces the original failure through the new assertions, so the guard is verified to fire rather than merely being silent.