### PR TITLE
ci(codeql): take the analyser toolchain from the operator go.mod

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,11 +40,19 @@ jobs:
       # version drift between here and the other workflows changes which
       # packages resolve, and an unresolved package is analyzed as empty
       # rather than reported as an error.
+      #
+      # Read the version from the operator's go.mod, the higher of the two
+      # floors in the repo — it builds the root module too, and no hardcoded
+      # version can serve both modules across a bump of either. Autobuild runs
+      # with GOTOOLCHAIN=local, so a toolchain below a module's floor does not
+      # downgrade the analysis, it drops the module: the operator failed to
+      # extract on every run between its go directive reaching 1.26.0 and this
+      # change. Matches operator-tests.yml and release.yml.
       - name: Set up Go
         if: matrix.language == 'go'
         uses: actions/setup-go@v7
         with:
-          go-version: "1.25.x"
+          go-version-file: k8s/dittofs-operator/go.mod
           cache: true
 
       - name: Initialize CodeQL


### PR DESCRIPTION
Closes #2296. Found while an unrelated test-only PR (#2295) went red on `Analyze (go)`.

## The defect

`codeql.yml` builds **two** modules — root (`go 1.25.0`) and `k8s/dittofs-operator` (`go 1.26.0` since `fe1a155c7`) — and pinned a single `go-version: "1.25.x"`. Autobuild runs `GOTOOLCHAIN=local`, so it cannot fetch a newer toolchain:

```
go: go.mod requires go >= 1.26.0 (running go 1.25.14; GOTOOLCHAIN=local)
Extraction failed for k8s/dittofs-operator: exit status 1
Warning: extraction failed for 1 project(s): k8s/dittofs-operator
```

Below a modules floor the analysis is not degraded, the module is **dropped**. 22 operator source files have gone unanalysed on every run since that bump. `fe1a155c7`s own CodeQL run was cancelled, so the check never reported on the commit that introduced it — same shape as #2104.

## The fix

`go-version-file: k8s/dittofs-operator/go.mod`, matching what `operator-tests.yml` and `release.yml` already do.

The existing comment argues for pinning rather than letting autobuild resolve, and that still holds — this keeps a pin, it just sources it. It has to be the operators floor: it is the higher of the two and builds the root module fine, whereas no hardcoded literal can serve both modules across a bump of either. Sourcing it from the file means the next bump of either module cannot silently reopen this.

Go 1.26.0 is known to resolve on these runners — `operator-tests.yml` reads the same file and is green on `82128705b`.

## Verification

The honest limit: this cannot be fully verified before merge, because the coverage guard that would confirm it is itself unreliable — see #2297. It currently reports `22 of 22` **while extraction is failing**, because it checks `src.zip` membership rather than extraction success, and its verdict turns on whether the extractor happened to be passed `--source-root`. So a green guard on this PR is necessary but not sufficient.

What to check on this PRs `Analyze (go)` run:

- [ ] guard reports `22 of 22`
- [ ] autobuild log contains **no** `Extraction failed for k8s/dittofs-operator`

The second is the one that matters, and is the condition #2297 will make the guard actually enforce.