### PR TITLE
refactor(metadata): share what putFile marshals, keep what the dialects decide

### DIFF
--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -2,7 +2,6 @@ package postgres
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -218,24 +217,23 @@ func (tx *postgresTransaction) putFile(ctx context.Context, file *metadata.File,
 		return err
 	}
 
-	// For existing files (updates), use UPDATE directly to avoid unique constraint issues.
-	// This is more efficient and handles concurrent updates properly.
+	values, err := storesql.InodeValues(file)
+	if err != nil {
+		return mapPgError(err, "UpdateAttrs", "marshal attributes")
+	}
+
+	// Postgres is multi-writer, so the pre-update row cannot be read in a
+	// statement of its own: another transaction could change it before the
+	// UPDATE ran. The leading CTE reads it under FOR UPDATE and the UPDATE
+	// joins that locked row, so RETURNING hands back the old values in the
+	// same round-trip. Exactly one row comes back when the file existed and
+	// none when it did not, which is the signal to fall through to the INSERT.
 	//
-	// Namespace uniqueness lives in parent_child_map(parent_id, child_name); the
-	// inodes row no longer carries a path/path_hash column (#1166), so a Move is
-	// just a parent_child_map re-link (SetChild/DeleteChild) — there is nothing
-	// path-related to update on the inode row here. content_id is still set:
-	// it keys file_blocks and is consumed by GetFileByPayloadID.
-	//
-	// The leading CTE reads the pre-update size under FOR UPDATE and the UPDATE
-	// joins against it, so a single round-trip both locks the row and returns
-	// its old size for usedBytes delta tracking. This replaces a separate
-	// SELECT-then-UPDATE that left a serialization window between the two
-	// statements (the read size could be stale by the time the UPDATE ran).
-	// RETURNING old.size yields exactly one row when the file existed and zero
-	// rows when it did not — the same not-found signal the previous
-	// RowsAffected()==0 check relied on.
-	updateQuery := `
+	// Namespace uniqueness lives in parent_child_map(parent_id, child_name);
+	// the inodes row carries no path column, so a Move is a re-link there and
+	// touches nothing here. content_id is still written: it keys the
+	// file_blocks GetFileByPayloadID consumes.
+	const updateQuery = `
 		WITH old AS (
 			SELECT id, share_name, size, uid, gid, file_type, nlink
 			FROM inodes
@@ -268,91 +266,18 @@ func (tx *postgresTransaction) putFile(ctx context.Context, file *metadata.File,
 		RETURNING old.size, old.uid, old.gid, old.file_type, old.nlink
 	`
 
-	var deviceMajor, deviceMinor *int32
-	if file.Type == metadata.FileTypeBlockDevice || file.Type == metadata.FileTypeCharDevice {
-		major := int32(metadata.RdevMajor(file.Rdev))
-		minor := int32(metadata.RdevMinor(file.Rdev))
-		deviceMajor = &major
-		deviceMinor = &minor
-	}
+	var old storesql.OldInode
 
-	var payloadIDPtr *string
-	if file.PayloadID != "" {
-		str := string(file.PayloadID)
-		payloadIDPtr = &str
-	}
-
-	var linkTargetPtr *string
-	if file.LinkTarget != "" {
-		linkTargetPtr = &file.LinkTarget
-	}
-
-	// Marshal ACL to JSON for JSONB storage
-	var aclJSON []byte
-	if file.ACL != nil {
-		var marshalErr error
-		aclJSON, marshalErr = json.Marshal(file.ACL)
-		if marshalErr != nil {
-			return mapPgError(marshalErr, "UpdateAttrs", "marshal ACL")
-		}
-	}
-
-	// Marshal extended attributes to JSON for JSONB storage. Empty/nil EAs
-	// write SQL NULL so a file that never had EAs stores nothing.
-	var easJSON []byte
-	if len(file.EAs) > 0 {
-		var marshalErr error
-		easJSON, marshalErr = json.Marshal(file.EAs)
-		if marshalErr != nil {
-			return mapPgError(marshalErr, "UpdateAttrs", "marshal EAs")
-		}
-	}
-
-	// object_id BYTEA argument.
-	// Zero-valued ObjectID writes SQL NULL so the partial unique index
-	// (files_object_id_idx WHERE object_id IS NOT NULL) skips the row —
-	// legacy / never-quiesced / partially-flushed files never collide on
-	// the all-zero sentinel.
-	var objectIDArg interface{}
-	if !file.ObjectID.IsZero() {
-		objectIDArg = file.ObjectID[:]
-	}
-
-	// deleted_at is a BIGINT Windows-FILETIME column (#190), nullable: NULL marks
-	// a live node, a value records the recycle instant losslessly (same encoding
-	// as the other file timestamps — must use sqlcodec.TimeToFiletime, not UnixNano, so it
-	// decodes back correctly via sqlcodec.FiletimeToTime). Pass *int64 so a nil DeletedAt
-	// writes SQL NULL.
-	var deletedAtArg *int64
-	if file.DeletedAt != nil {
-		n := sqlcodec.TimeToFiletime(*file.DeletedAt)
-		deletedAtArg = &n
-	}
-
-	// Try UPDATE first (most common case for existing files). The CTE locks the
-	// row and RETURNING old.size hands back the pre-update size in the same
-	// round-trip, so there is no separate SELECT and no window between read and
-	// write. A returned row means the file existed (and we have its old size);
-	// pgx.ErrNoRows means it did not, so we fall through to INSERT.
-	var oldSizeVal sql.NullInt64
-	var oldUIDVal, oldGIDVal, oldTypeVal, oldNlinkVal sql.NullInt64
 	// A caller that knows the inode is new skips the probe entirely: on a
-	// create the round-trip can only ever report "no such row", and a stale
+	// create the round-trip could only ever report "no such row", and a stale
 	// claim surfaces as the INSERT's duplicate-key error.
 	updated := !file.NewInode
 	if updated {
 		scanErr := tx.tx.QueryRow(ctx, updateQuery,
-			file.Type, file.Mode, file.UID, file.GID, file.Size,
-			sqlcodec.TimeToFiletime(file.Atime), sqlcodec.TimeToFiletime(file.Mtime),
-			sqlcodec.TimeToFiletime(file.Ctime), sqlcodec.TimeToFiletime(file.CreationTime),
-			payloadIDPtr, linkTargetPtr, deviceMajor, deviceMinor,
-			file.Hidden, aclJSON, easJSON, objectIDArg,
-			deletedAtArg, file.OriginalPath, file.DeletedBy,
-			file.ID, file.ShareName,
-		).Scan(&oldSizeVal, &oldUIDVal, &oldGIDVal, &oldTypeVal, &oldNlinkVal)
+			append(values, file.ID, file.ShareName)...,
+		).Scan(&old.Size, &old.UID, &old.GID, &old.Type, &old.Nlink)
 		switch {
 		case scanErr == nil:
-			// Row existed and was updated; oldSizeVal holds the pre-update size.
 		case errors.Is(scanErr, pgx.ErrNoRows):
 			updated = false
 		default:
@@ -360,38 +285,16 @@ func (tx *postgresTransaction) putFile(ctx context.Context, file *metadata.File,
 		}
 	}
 
-	// Track size delta for regular files after a successful update.
-	// Accumulated on the tx and applied once after a successful commit so a
-	// serialization/deadlock retry never double-counts.
-	//
-	// nlink is not among the columns this write touches, so the pre-update
-	// count is also the post-update one.
-	if updated && basestore.Charged(file.Type, uint32(oldNlinkVal.Int64)) {
-		var oldSize uint64
-		if oldSizeVal.Valid {
-			oldSize = uint64(oldSizeVal.Int64)
-		}
-
-		// Per-identity usage. The previous row may not have been a regular file
-		// (type change), in which case it contributed nothing before.
-		oldWasRegular := oldTypeVal.Valid && metadata.FileType(oldTypeVal.Int64) == metadata.FileTypeRegular
-		oldUID := uint32(oldUIDVal.Int64)
-		oldGID := uint32(oldGIDVal.Int64)
-		switch {
-		case !oldWasRegular:
-			tx.quota.Add(file.ShareName, file.UID, file.GID, int64(file.Size), 1)
-		case oldUID == file.UID && oldGID == file.GID:
-			tx.quota.Add(file.ShareName, file.UID, file.GID, int64(file.Size)-int64(oldSize), 0)
-		default:
-			// Chown: move bytes + inode from old owner to new owner.
-			tx.quota.Add(file.ShareName, oldUID, oldGID, -int64(oldSize), -1)
-			tx.quota.Add(file.ShareName, file.UID, file.GID, int64(file.Size), 1)
-		}
+	// The usage delta is accumulated on the transaction and applied once after
+	// a successful commit, so a serialization or deadlock retry never
+	// double-counts it.
+	if updated {
+		storesql.ApplyPutQuota(&tx.quota, file, old)
 	}
 
 	// If no rows were updated, the file doesn't exist - do an INSERT
 	if !updated {
-		insertQuery := `
+		const insertQuery = `
 			INSERT INTO inodes (
 				id, share_name, file_type, mode, uid, gid, size,
 				atime, mtime, ctime, creation_time, content_id, link_target,
@@ -404,18 +307,12 @@ func (tx *postgresTransaction) putFile(ctx context.Context, file *metadata.File,
 		`
 
 		if _, err := tx.tx.Exec(ctx, insertQuery,
-			file.ID, file.ShareName,
-			file.Type, file.Mode, file.UID, file.GID, file.Size,
-			sqlcodec.TimeToFiletime(file.Atime), sqlcodec.TimeToFiletime(file.Mtime),
-			sqlcodec.TimeToFiletime(file.Ctime), sqlcodec.TimeToFiletime(file.CreationTime),
-			payloadIDPtr, linkTargetPtr, deviceMajor, deviceMinor,
-			file.Hidden, aclJSON, easJSON, objectIDArg,
-			deletedAtArg, file.OriginalPath, file.DeletedBy,
+			append([]any{file.ID, file.ShareName}, values...)...,
 		); err != nil {
 			return mapPgError(err, "UpdateAttrs", "")
 		}
 
-		// Charge the new regular file to its share and owner.
+		// Charge the new regular file to the share owner.
 		if file.Type == metadata.FileTypeRegular {
 			tx.quota.Add(file.ShareName, file.UID, file.GID, int64(file.Size), 1)
 		}

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -312,7 +312,7 @@ func (tx *postgresTransaction) putFile(ctx context.Context, file *metadata.File,
 			return mapPgError(err, "UpdateAttrs", "")
 		}
 
-		// Charge the new regular file to the share owner.
+		// Charge the new regular file to its owning identity.
 		if file.Type == metadata.FileTypeRegular {
 			tx.quota.Add(file.ShareName, file.UID, file.GID, int64(file.Size), 1)
 		}

--- a/pkg/metadata/store/sql/put_file.go
+++ b/pkg/metadata/store/sql/put_file.go
@@ -1,0 +1,128 @@
+package sql
+
+import (
+	"database/sql"
+	"encoding/json"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
+	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlcodec"
+)
+
+// InodeValues are the twenty column values an inode write sends, in the order
+// both the UPDATE and the INSERT name them. Keeping one builder for both means
+// a column added to the table cannot be wired into one statement and forgotten
+// in the other.
+//
+// The dialects place them differently — the UPDATE appends the id and share
+// name as the WHERE arguments, the INSERT prepends them as the first two
+// columns — so the caller adds those, and only those.
+func InodeValues(file *metadata.File) ([]any, error) {
+	// Device numbers are only meaningful for device nodes; every other type
+	// stores SQL NULL rather than a zero that would read back as major 0.
+	var deviceMajor, deviceMinor *int32
+	if file.Type == metadata.FileTypeBlockDevice || file.Type == metadata.FileTypeCharDevice {
+		major := int32(metadata.RdevMajor(file.Rdev))
+		minor := int32(metadata.RdevMinor(file.Rdev))
+		deviceMajor = &major
+		deviceMinor = &minor
+	}
+
+	var payloadIDPtr *string
+	if file.PayloadID != "" {
+		str := string(file.PayloadID)
+		payloadIDPtr = &str
+	}
+
+	var linkTargetPtr *string
+	if file.LinkTarget != "" {
+		linkTargetPtr = &file.LinkTarget
+	}
+
+	// ACL and EAs are stored as JSON. Empty or nil writes SQL NULL, so a file
+	// that never had either stores nothing rather than an empty document.
+	var aclJSON []byte
+	if file.ACL != nil {
+		var err error
+		if aclJSON, err = json.Marshal(file.ACL); err != nil {
+			return nil, err
+		}
+	}
+
+	var easJSON []byte
+	if len(file.EAs) > 0 {
+		var err error
+		if easJSON, err = json.Marshal(file.EAs); err != nil {
+			return nil, err
+		}
+	}
+
+	// A zero-valued ObjectID writes SQL NULL so the partial unique index
+	// (files_object_id_idx WHERE object_id IS NOT NULL) skips the row —
+	// legacy, never-quiesced and partially-flushed files must not collide on
+	// the all-zero sentinel.
+	var objectIDArg any
+	if !file.ObjectID.IsZero() {
+		objectIDArg = file.ObjectID[:]
+	}
+
+	// deleted_at is a nullable Windows-FILETIME column: NULL marks a live
+	// node, a value records the recycle instant losslessly. It has to travel
+	// through the same encoding as the other timestamps or it will not decode
+	// back through FiletimeToTime.
+	var deletedAtArg *int64
+	if file.DeletedAt != nil {
+		n := sqlcodec.TimeToFiletime(*file.DeletedAt)
+		deletedAtArg = &n
+	}
+
+	return []any{
+		file.Type, file.Mode, file.UID, file.GID, file.Size,
+		sqlcodec.TimeToFiletime(file.Atime), sqlcodec.TimeToFiletime(file.Mtime),
+		sqlcodec.TimeToFiletime(file.Ctime), sqlcodec.TimeToFiletime(file.CreationTime),
+		payloadIDPtr, linkTargetPtr, deviceMajor, deviceMinor,
+		file.Hidden, aclJSON, easJSON, objectIDArg,
+		deletedAtArg, file.OriginalPath, file.DeletedBy,
+	}, nil
+}
+
+// OldInode is the pre-update row an inode write reads so it can compute the
+// usage delta. Each dialect obtains it differently — postgres returns it from
+// the UPDATE's CTE, sqlite selects it first — but what it means is the same.
+type OldInode struct {
+	Size, UID, GID, Type, Nlink sql.NullInt64
+}
+
+// ApplyPutQuota records the usage change an inode write produces.
+//
+// Only an update charges a delta; an insert is charged by the caller once the
+// row exists. nlink is not among the columns a write touches, so the
+// pre-update count is also the post-update one and it is safe to decide
+// chargeability from the old row.
+func ApplyPutQuota(quota *basestore.QuotaDelta, file *metadata.File, old OldInode) {
+	if !basestore.Charged(file.Type, uint32(old.Nlink.Int64)) {
+		return
+	}
+
+	var oldSize uint64
+	if old.Size.Valid {
+		oldSize = uint64(old.Size.Int64)
+	}
+
+	// The previous row need not have been a regular file: after a type change
+	// it contributed nothing before, so the write adds the whole size.
+	oldWasRegular := old.Type.Valid && metadata.FileType(old.Type.Int64) == metadata.FileTypeRegular
+	oldUID := uint32(old.UID.Int64)
+	oldGID := uint32(old.GID.Int64)
+
+	switch {
+	case !oldWasRegular:
+		quota.Add(file.ShareName, file.UID, file.GID, int64(file.Size), 1)
+	case oldUID == file.UID && oldGID == file.GID:
+		quota.Add(file.ShareName, file.UID, file.GID, int64(file.Size)-int64(oldSize), 0)
+	default:
+		// Chown: the bytes and the inode move from the old owner to the new.
+		quota.Add(file.ShareName, oldUID, oldGID, -int64(oldSize), -1)
+		quota.Add(file.ShareName, file.UID, file.GID, int64(file.Size), 1)
+	}
+}

--- a/pkg/metadata/store/sql/put_file.go
+++ b/pkg/metadata/store/sql/put_file.go
@@ -58,7 +58,7 @@ func InodeValues(file *metadata.File) ([]any, error) {
 	}
 
 	// A zero-valued ObjectID writes SQL NULL so the partial unique index
-	// (files_object_id_idx WHERE object_id IS NOT NULL) skips the row —
+	// (inodes_object_id_idx WHERE object_id IS NOT NULL) skips the row —
 	// legacy, never-quiesced and partially-flushed files must not collide on
 	// the all-zero sentinel.
 	var objectIDArg any

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -258,7 +258,7 @@ func (tx *sqliteTransaction) putFile(ctx context.Context, file *metadata.File, w
 			return mapDBError(err, "UpdateAttrs", "")
 		}
 
-		// Charge the new regular file to the share owner.
+		// Charge the new regular file to its owning identity.
 		if file.Type == metadata.FileTypeRegular {
 			tx.quota.Add(file.ShareName, file.UID, file.GID, int64(file.Size), 1)
 		}

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -163,27 +163,29 @@ func (tx *sqliteTransaction) putFile(ctx context.Context, file *metadata.File, w
 		return err
 	}
 
-	// For existing files (updates), use UPDATE directly to avoid unique constraint issues.
-	// This is more efficient and handles concurrent updates properly.
+	values, err := storesql.InodeValues(file)
+	if err != nil {
+		return mapDBError(err, "UpdateAttrs", "marshal attributes")
+	}
+
+	// SQLite is a single-writer engine: the transaction holds an exclusive
+	// write lock for its duration, so a SELECT and the UPDATE that follows it
+	// cannot interleave with another writer. That is what lets the pre-update
+	// row be read in a separate statement here, where postgres has to lock and
+	// return it from the UPDATE itself. A zero-row read means the file does
+	// not exist, and the write falls through to the INSERT.
 	//
-	// Namespace uniqueness lives in parent_child_map(parent_id, child_name); the
-	// inodes row no longer carries a path/path_hash column (#1166), so a Move is
-	// just a parent_child_map re-link (SetChild/DeleteChild) — there is nothing
-	// path-related to update on the inode row here. content_id is still set:
-	// it keys file_blocks and is consumed by GetFileByPayloadID.
-	//
-	// SQLite is a single-writer engine: a transaction holds an exclusive write
-	// lock for its duration, so a SELECT-then-UPDATE inside the same tx has no
-	// interleaving window (unlike the multi-writer Postgres case the FROM/CTE
-	// FOR UPDATE form guarded against). Read the pre-update size/owner/type
-	// first, then UPDATE; a zero-row read means the file does not exist and we
-	// fall through to INSERT — the same not-found signal as before.
+	// Namespace uniqueness lives in parent_child_map(parent_id, child_name);
+	// the inodes row carries no path column, so a Move is a re-link there and
+	// touches nothing here. content_id is still written: it keys the
+	// file_blocks GetFileByPayloadID consumes.
 	const selectOldQuery = `
 		SELECT size, uid, gid, file_type, nlink
 		FROM inodes
 		WHERE id = ?1 AND share_name = ?2
 	`
-	updateQuery := `
+
+	const updateQuery = `
 		UPDATE inodes SET
 			file_type = ?1,
 			mode = ?2,
@@ -208,92 +210,18 @@ func (tx *sqliteTransaction) putFile(ctx context.Context, file *metadata.File, w
 		WHERE id = ?21 AND share_name = ?22
 	`
 
-	var deviceMajor, deviceMinor *int32
-	if file.Type == metadata.FileTypeBlockDevice || file.Type == metadata.FileTypeCharDevice {
-		major := int32(metadata.RdevMajor(file.Rdev))
-		minor := int32(metadata.RdevMinor(file.Rdev))
-		deviceMajor = &major
-		deviceMinor = &minor
-	}
+	var old storesql.OldInode
 
-	var payloadIDPtr *string
-	if file.PayloadID != "" {
-		str := string(file.PayloadID)
-		payloadIDPtr = &str
-	}
-
-	var linkTargetPtr *string
-	if file.LinkTarget != "" {
-		linkTargetPtr = &file.LinkTarget
-	}
-
-	// Marshal ACL to JSON for JSONB storage
-	var aclJSON []byte
-	if file.ACL != nil {
-		var marshalErr error
-		aclJSON, marshalErr = json.Marshal(file.ACL)
-		if marshalErr != nil {
-			return mapDBError(marshalErr, "UpdateAttrs", "marshal ACL")
-		}
-	}
-
-	// Marshal extended attributes to JSON for JSONB storage. Empty/nil EAs
-	// write SQL NULL so a file that never had EAs stores nothing.
-	var easJSON []byte
-	if len(file.EAs) > 0 {
-		var marshalErr error
-		easJSON, marshalErr = json.Marshal(file.EAs)
-		if marshalErr != nil {
-			return mapDBError(marshalErr, "UpdateAttrs", "marshal EAs")
-		}
-	}
-
-	// object_id BYTEA argument.
-	// Zero-valued ObjectID writes SQL NULL so the partial unique index
-	// (files_object_id_idx WHERE object_id IS NOT NULL) skips the row —
-	// legacy / never-quiesced / partially-flushed files never collide on
-	// the all-zero sentinel.
-	var objectIDArg interface{}
-	if !file.ObjectID.IsZero() {
-		objectIDArg = file.ObjectID[:]
-	}
-
-	// deleted_at is a BIGINT Windows-FILETIME column (#190), nullable: NULL marks
-	// a live node, a value records the recycle instant losslessly (same encoding
-	// as the other file timestamps — must use sqlcodec.TimeToFiletime, not UnixNano, so it
-	// decodes back correctly via sqlcodec.FiletimeToTime). Pass *int64 so a nil DeletedAt
-	// writes SQL NULL.
-	var deletedAtArg *int64
-	if file.DeletedAt != nil {
-		n := sqlcodec.TimeToFiletime(*file.DeletedAt)
-		deletedAtArg = &n
-	}
-
-	// Read the pre-update size/owner/type, then UPDATE. Under SQLite's single
-	// writer there is no interleaving between the two statements inside this
-	// transaction. A missing row (sql.ErrNoRows) means the file does not exist,
-	// so we fall through to INSERT.
-	var oldSizeVal sql.NullInt64
-	var oldUIDVal, oldGIDVal, oldTypeVal, oldNlinkVal sql.NullInt64
 	// A caller that knows the inode is new skips the probe entirely: on a
-	// create the round-trip can only ever report "no such row", and a stale
+	// create the round-trip could only ever report "no such row", and a stale
 	// claim surfaces as the INSERT's duplicate-key error.
 	updated := !file.NewInode
 	if updated {
 		scanErr := tx.tx.QueryRow(ctx, selectOldQuery, file.ID, file.ShareName).
-			Scan(&oldSizeVal, &oldUIDVal, &oldGIDVal, &oldTypeVal, &oldNlinkVal)
+			Scan(&old.Size, &old.UID, &old.GID, &old.Type, &old.Nlink)
 		switch {
 		case scanErr == nil:
-			// Row exists; update it in place.
-			if _, err := tx.tx.Exec(ctx, updateQuery,
-				file.Type, file.Mode, file.UID, file.GID, file.Size,
-				sqlcodec.TimeToFiletime(file.Atime), sqlcodec.TimeToFiletime(file.Mtime),
-				sqlcodec.TimeToFiletime(file.Ctime), sqlcodec.TimeToFiletime(file.CreationTime),
-				payloadIDPtr, linkTargetPtr, deviceMajor, deviceMinor,
-				file.Hidden, aclJSON, easJSON, objectIDArg,
-				deletedAtArg, file.OriginalPath, file.DeletedBy,
-				file.ID, file.ShareName,
-			); err != nil {
+			if _, err := tx.tx.Exec(ctx, updateQuery, append(values, file.ID, file.ShareName)...); err != nil {
 				return mapDBError(err, "UpdateAttrs", "")
 			}
 		case errors.Is(scanErr, sql.ErrNoRows):
@@ -303,38 +231,16 @@ func (tx *sqliteTransaction) putFile(ctx context.Context, file *metadata.File, w
 		}
 	}
 
-	// Track size delta for regular files after a successful update.
-	// Accumulated on the tx and applied once after a successful commit so a
-	// serialization/deadlock retry never double-counts.
-	//
-	// nlink is not among the columns this write touches, so the pre-update
-	// count is also the post-update one.
-	if updated && basestore.Charged(file.Type, uint32(oldNlinkVal.Int64)) {
-		var oldSize uint64
-		if oldSizeVal.Valid {
-			oldSize = uint64(oldSizeVal.Int64)
-		}
-
-		// Per-identity usage. The previous row may not have been a regular file
-		// (type change), in which case it contributed nothing before.
-		oldWasRegular := oldTypeVal.Valid && metadata.FileType(oldTypeVal.Int64) == metadata.FileTypeRegular
-		oldUID := uint32(oldUIDVal.Int64)
-		oldGID := uint32(oldGIDVal.Int64)
-		switch {
-		case !oldWasRegular:
-			tx.quota.Add(file.ShareName, file.UID, file.GID, int64(file.Size), 1)
-		case oldUID == file.UID && oldGID == file.GID:
-			tx.quota.Add(file.ShareName, file.UID, file.GID, int64(file.Size)-int64(oldSize), 0)
-		default:
-			// Chown: move bytes + inode from old owner to new owner.
-			tx.quota.Add(file.ShareName, oldUID, oldGID, -int64(oldSize), -1)
-			tx.quota.Add(file.ShareName, file.UID, file.GID, int64(file.Size), 1)
-		}
+	// The usage delta is accumulated on the transaction and applied once after
+	// a successful commit, so a serialization or deadlock retry never
+	// double-counts it.
+	if updated {
+		storesql.ApplyPutQuota(&tx.quota, file, old)
 	}
 
 	// If no rows were updated, the file doesn't exist - do an INSERT
 	if !updated {
-		insertQuery := `
+		const insertQuery = `
 			INSERT INTO inodes (
 				id, share_name, file_type, mode, uid, gid, size,
 				atime, mtime, ctime, creation_time, content_id, link_target,
@@ -347,18 +253,12 @@ func (tx *sqliteTransaction) putFile(ctx context.Context, file *metadata.File, w
 		`
 
 		if _, err := tx.tx.Exec(ctx, insertQuery,
-			file.ID, file.ShareName,
-			file.Type, file.Mode, file.UID, file.GID, file.Size,
-			sqlcodec.TimeToFiletime(file.Atime), sqlcodec.TimeToFiletime(file.Mtime),
-			sqlcodec.TimeToFiletime(file.Ctime), sqlcodec.TimeToFiletime(file.CreationTime),
-			payloadIDPtr, linkTargetPtr, deviceMajor, deviceMinor,
-			file.Hidden, aclJSON, easJSON, objectIDArg,
-			deletedAtArg, file.OriginalPath, file.DeletedBy,
+			append([]any{file.ID, file.ShareName}, values...)...,
 		); err != nil {
 			return mapDBError(err, "UpdateAttrs", "")
 		}
 
-		// Charge the new regular file to its share and owner.
+		// Charge the new regular file to the share owner.
 		if file.Type == metadata.FileTypeRegular {
 			tx.quota.Add(file.ShareName, file.UID, file.GID, int64(file.Size), 1)
 		}


### PR DESCRIPTION
Stage S6 of #1828. Supersedes #2294, which GitHub closed when #2293 merged and its base branch was deleted; this is the same commit rebased onto develop.

Both `putFile` bodies ran to ~240 lines and about 200 of them were the same work. Normalising placeholders and error helpers, the two functions differed in ~35 lines out of 162.

**Shared now:**
- `sql.InodeValues` turns a `metadata.File` into the twenty column values, in the order both the UPDATE and the INSERT name them. One builder for both statements means a column added to the table cannot be wired into one and forgotten in the other — previously each dialect had two hand-written copies of the same list, so four places to keep in step.
- `sql.ApplyPutQuota` holds the usage-delta arithmetic: the plain size change, the type change from a row that contributed nothing, and the chown that moves both the bytes and the inode from the old owner to the new.

**Per-dialect still, because the difference is real:**

Postgres is multi-writer, so it cannot read the pre-update row in a statement of its own — another transaction could change it before the UPDATE ran. It locks the row in a leading CTE and returns the old values from the UPDATE in the same round-trip. SQLite is single-writer and the transaction holds an exclusive write lock for its duration, so a SELECT followed by an UPDATE has no interleaving window, and it reads the row separately.

Writing those two the same way would either hand sqlite a CTE it does not need or hand postgres a race it cannot afford. The comments in each now say which property they are relying on, rather than describing the mechanics.

Each `putFile` is 139 lines, down from 239 and 255.

## Verification

The risk in this change is the quota arithmetic — it decides share usage counters, and a silent error there is the family of #2270. It is genuinely covered, which I confirmed rather than assumed: changing `ApplyPutQuota`'s chown branch from `-int64(oldSize)` to `0` fails `StoreSurface/GetQuotaUsageChown`.

- Full unit suite; `GetQuotaUsage`, `GetQuotaUsageChown` and `GetQuotaUsagePerShare` all run and pass
- **postgres integration against a real postgres 16** — the CTE path is not exercised by any unit test
- `golangci-lint`: 0 issues

