### PR TITLE
fix(test/e2e): build against the testcontainers v0.44 port API

### DIFF
--- a/test/e2e/framework/containers.go
+++ b/test/e2e/framework/containers.go
@@ -509,7 +509,7 @@ func NewPostgresHelper(t *testing.T) *PostgresHelper {
 		T:         t,
 		Container: container,
 		Host:      host,
-		Port:      port.Int(),
+		Port:      int(port.Num()),
 		Database:  "dittofs_e2e",
 		User:      "dittofs_e2e",
 		Password:  "dittofs_e2e",

--- a/test/e2e/framework/kerberos.go
+++ b/test/e2e/framework/kerberos.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -73,7 +72,7 @@ func NewKDCHelper(t *testing.T, cfg KDCConfig) *KDCHelper {
 	require.NoError(t, err, "failed to start KDC container")
 
 	// Get the mapped port
-	mappedPort, err := container.MappedPort(ctx, nat.Port("88/tcp"))
+	mappedPort, err := container.MappedPort(ctx, "88/tcp")
 	require.NoError(t, err, "failed to get KDC port")
 
 	host, err := container.Host(ctx)
@@ -88,7 +87,7 @@ func NewKDCHelper(t *testing.T, cfg KDCConfig) *KDCHelper {
 		keytabDir: keytabDir,
 		ccacheDir: ccacheDir,
 		kdcHost:   host,
-		kdcPort:   mappedPort.Int(),
+		kdcPort:   int(mappedPort.Num()),
 	}
 
 	// Generate krb5.conf for this KDC instance


### PR DESCRIPTION
Closes #2300. Found while babysitting develop, which has been red on `E2E Tests` for six commits.

## The defect

`0cc2e2804` bumped `testcontainers-go` 0.40.0 → 0.44.0, changing the mapped-port API:

- `MappedPort(ctx, string)` takes a plain `string`, no longer a `nat.Port`
- it returns `moby/api/types/network.Port`, which has `Num() uint16` where `nat.Port` had `Int()`

Three call sites still used the old shape, so **three packages failed to build** and no E2E test has executed since:

```
FAIL github.com/marmos91/dittofs/test/e2e           [build failed]
FAIL github.com/marmos91/dittofs/test/e2e/framework [build failed]
FAIL github.com/marmos91/dittofs/test/e2e/helpers   [build failed]
```

## The change

Three lines, plus the now-unused `nat` import:

- `containers.go:512` — `port.Int()` → `int(port.Num())`
- `kerberos.go:76` — `MappedPort(ctx, nat.Port("88/tcp"))` → `MappedPort(ctx, "88/tcp")`
- `kerberos.go:91` — `mappedPort.Int()` → `int(mappedPort.Num())`

`Num()` returns `uint16`; both destination fields are `int` and are consumed as `int` throughout (`KDCHelper.kdcPort` into `krb5.conf`, `PostgresHelper.Port` into a DSN), so the conversion happens at the boundary rather than widening the field types and rippling through every caller.

I checked all four `MappedPort` call sites, not just the ones the compiler stopped at — `containers.go:114` and `:377` already pass strings and use the result without `Int()`, so they were already correct.

## Verification

The compiler is the test here, and it could not run before this change. All four e2e packages now build their **test binaries** (`go build` alone would not have caught this — it skips `_test.go`):

```
ok: github.com/marmos91/dittofs/test/e2e
ok: github.com/marmos91/dittofs/test/e2e/framework
ok: github.com/marmos91/dittofs/test/e2e/helpers
ok: github.com/marmos91/dittofs/test/e2e/snapshot
```

`go vet -tags=e2e ./test/e2e/...` clean, `go build ./...` unaffected. The pre-fix tree reproduces the three errors, so the change is load-bearing rather than cosmetic.

What this PR does **not** establish is that the E2E suite passes — it has not run in six commits, so this run is the first real signal since `9f35691f4`. If it comes back red on an actual test, that is a separate finding, not a regression from this diff.

## Follow-up, deliberately not here

A `go test -tags=e2e -c -o /dev/null ./test/e2e/...` job would have caught this inside the Dependabot PR in seconds with no docker or sudo. Build-tagged trees (`e2e`, `windows`, `darwin`) are invisible to the default matrix — noted in #2300.