### PR TITLE
fix(block): hold the retention pin in the local store so Start cannot lift it

### DIFF
--- a/pkg/block/engine/api_accessors_test.go
+++ b/pkg/block/engine/api_accessors_test.go
@@ -73,14 +73,6 @@ func TestStore_Accessors(t *testing.T) {
 	_ = bs.LocalStats()
 }
 
-// TestStore_EvictionSetter exercises the delegating setter (it must not panic).
-func TestStore_EvictionSetter(t *testing.T) {
-	bs := newTestEngine(t, 64*1024*1024, 0)
-
-	bs.SetEvictionEnabled(true)
-	bs.SetEvictionEnabled(false)
-}
-
 // TestStore_HealthCheck covers both the legacy error probe and the
 // structured Healthcheck for a healthy local-only engine.
 func TestStore_HealthCheck(t *testing.T) {

--- a/pkg/block/engine/health.go
+++ b/pkg/block/engine/health.go
@@ -86,3 +86,10 @@ func (bs *Store) HasRemoteStore() bool {
 func (bs *Store) SetEvictionEnabled(enabled bool) {
 	bs.local.SetEvictionEnabled(enabled)
 }
+
+// SetEvictionPinned pins the local store's bytes in place for a pin-retention
+// share. It survives the health-driven SetEvictionEnabled calls the syncer and
+// Start make, so it is the only correct way to express a retention pin.
+func (bs *Store) SetEvictionPinned(pinned bool) {
+	bs.local.SetEvictionPinned(pinned)
+}

--- a/pkg/block/engine/health.go
+++ b/pkg/block/engine/health.go
@@ -81,12 +81,6 @@ func (bs *Store) HasRemoteStore() bool {
 	return bs.remote != nil
 }
 
-// SetEvictionEnabled controls whether the local store can evict blocks to free disk space.
-// Delegates to the local store's SetEvictionEnabled method.
-func (bs *Store) SetEvictionEnabled(enabled bool) {
-	bs.local.SetEvictionEnabled(enabled)
-}
-
 // SetEvictionPinned pins the local store's bytes in place for a pin-retention
 // share. It survives the health-driven SetEvictionEnabled calls the syncer and
 // Start make, so it is the only correct way to express a retention pin.

--- a/pkg/block/engine/retention_pin_start_test.go
+++ b/pkg/block/engine/retention_pin_start_test.go
@@ -11,10 +11,11 @@ import (
 	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
-// premiseDrainFreed builds a remote-backed engine, optionally disables eviction
-// the way the share constructor does for a pinned share, fills it and reports
-// how many local bytes an explicit force-evict reclaims.
-func premiseDrainFreed(t *testing.T, pin bool) int64 {
+// drainAfterFill builds a remote-backed engine the way the share constructor
+// does — pinning the local store before Start when the share's retention policy
+// is pin — fills it with a file that is rolled up and uploaded, then force-evicts
+// and reports how many local bytes were reclaimed.
+func drainAfterFill(t *testing.T, pinned bool) int64 {
 	t.Helper()
 	ctx := context.Background()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
@@ -26,10 +27,7 @@ func premiseDrainFreed(t *testing.T, pin bool) int64 {
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions: %v", err)
 	}
-	// This is what blockstore_config.go does for a RetentionPin share, before Start.
-	if pin {
-		localStore.SetEvictionEnabled(false)
-	}
+	localStore.SetEvictionPinned(pinned)
 
 	syncer := engine.NewSyncer(localStore, mem, ms, engine.DefaultConfig())
 	syncer.SetSyncedHashStore(ms)
@@ -44,6 +42,8 @@ func premiseDrainFreed(t *testing.T, pin bool) int64 {
 	if err != nil {
 		t.Fatalf("engine.New: %v", err)
 	}
+	// Start probes the remote, finds it healthy and reconciles eviction against
+	// that health. The pin must survive it.
 	if err := bs.Start(ctx); err != nil {
 		t.Fatalf("engine.Start: %v", err)
 	}
@@ -77,18 +77,22 @@ func premiseDrainFreed(t *testing.T, pin bool) int64 {
 	return freed
 }
 
-func TestPremise_ControlUnpinnedEvicts(t *testing.T) {
-	if freed := premiseDrainFreed(t, false); freed == 0 {
-		t.Fatalf("control: unpinned share freed 0 bytes; the probe cannot detect eviction")
-	} else {
-		t.Logf("control: unpinned share freed %d bytes", freed)
-	}
-}
-
-func TestPremise_PinnedShareStillEvictsAfterStart(t *testing.T) {
-	freed := premiseDrainFreed(t, true)
-	t.Logf("pinned share freed %d bytes", freed)
-	if freed != 0 {
-		t.Fatalf("PREMISE CONFIRMED: pinned share freed %d local bytes after Start", freed)
-	}
+// TestRetentionPinSurvivesStart covers the pin being lifted by the eviction
+// reconcile at the end of engine Start: the constructor pinned the local store,
+// Start found the remote healthy, and every synced local byte then became
+// evictable again.
+//
+// The unpinned subtest is the control — without it a pinned share reporting
+// "freed 0" proves only that the probe cannot evict anything at all.
+func TestRetentionPinSurvivesStart(t *testing.T) {
+	t.Run("unpinned evicts", func(t *testing.T) {
+		if freed := drainAfterFill(t, false); freed == 0 {
+			t.Fatal("unpinned share freed 0 bytes; the probe cannot observe eviction")
+		}
+	})
+	t.Run("pinned keeps its bytes", func(t *testing.T) {
+		if freed := drainAfterFill(t, true); freed != 0 {
+			t.Fatalf("pinned share freed %d local bytes; the retention pin was lifted", freed)
+		}
+	})
 }

--- a/pkg/block/engine/retention_pin_start_test.go
+++ b/pkg/block/engine/retention_pin_start_test.go
@@ -54,8 +54,10 @@ func drainAfterFill(t *testing.T, pinned bool) int64 {
 
 	const oneMiB = 1024 * 1024
 	const fileSize = 16 * oneMiB
+	// Random, not zeros: a zero-filled file dedupes to a single chunk, which
+	// would leave the unpinned control with almost nothing to evict.
 	src := make([]byte, fileSize)
-	rand.New(rand.NewSource(0x2257)).Read(src) //nolint:gosec // deterministic fixture
+	rand.New(rand.NewSource(1)).Read(src) //nolint:gosec // deterministic fixture
 	for off := 0; off < fileSize; off += oneMiB {
 		if _, err := bs.WriteAt(ctx, pid, nil, src[off:off+oneMiB], uint64(off)); err != nil {
 			t.Fatalf("WriteAt off=%d: %v", off, err)

--- a/pkg/block/engine/retention_pin_start_test.go
+++ b/pkg/block/engine/retention_pin_start_test.go
@@ -1,0 +1,94 @@
+package engine_test
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/block/local/fs"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// premiseDrainFreed builds a remote-backed engine, optionally disables eviction
+// the way the share constructor does for a pinned share, fills it and reports
+// how many local bytes an explicit force-evict reclaims.
+func premiseDrainFreed(t *testing.T, pin bool) int64 {
+	t.Helper()
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	mem := remotememory.New()
+
+	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{
+		MaxLogBytes: 128 * 1024 * 1024,
+	})
+	if err != nil {
+		t.Fatalf("fs.NewWithOptions: %v", err)
+	}
+	// This is what blockstore_config.go does for a RetentionPin share, before Start.
+	if pin {
+		localStore.SetEvictionEnabled(false)
+	}
+
+	syncer := engine.NewSyncer(localStore, mem, ms, engine.DefaultConfig())
+	syncer.SetSyncedHashStore(ms)
+	syncer.SetRemoteBlockStore(mem)
+	bs, err := engine.New(engine.BlockStoreConfig{
+		Local:           localStore,
+		Syncer:          syncer,
+		FileChunkStore:  ms,
+		Coordinator:     &testCoordinator{store: ms},
+		SyncedHashStore: ms,
+	})
+	if err != nil {
+		t.Fatalf("engine.New: %v", err)
+	}
+	if err := bs.Start(ctx); err != nil {
+		t.Fatalf("engine.Start: %v", err)
+	}
+	t.Cleanup(func() { _ = bs.Close() })
+
+	rootHandle := createShare(t, ms, "pinshare")
+	pid, _ := createRealFile(t, ms, "pinshare", "big.bin", rootHandle)
+
+	const oneMiB = 1024 * 1024
+	const fileSize = 16 * oneMiB
+	src := make([]byte, fileSize)
+	rand.New(rand.NewSource(0x2257)).Read(src) //nolint:gosec // deterministic fixture
+	for off := 0; off < fileSize; off += oneMiB {
+		if _, err := bs.WriteAt(ctx, pid, nil, src[off:off+oneMiB], uint64(off)); err != nil {
+			t.Fatalf("WriteAt off=%d: %v", off, err)
+		}
+	}
+	if _, err := bs.Flush(ctx, pid); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if err := bs.DrainRollups(ctx); err != nil {
+		t.Fatalf("DrainRollups: %v", err)
+	}
+	if err := bs.DrainAllUploads(ctx); err != nil {
+		t.Fatalf("DrainAllUploads: %v", err)
+	}
+	freed, err := bs.DrainLocalSynced(ctx)
+	if err != nil {
+		t.Fatalf("DrainLocalSynced: %v", err)
+	}
+	return freed
+}
+
+func TestPremise_ControlUnpinnedEvicts(t *testing.T) {
+	if freed := premiseDrainFreed(t, false); freed == 0 {
+		t.Fatalf("control: unpinned share freed 0 bytes; the probe cannot detect eviction")
+	} else {
+		t.Logf("control: unpinned share freed %d bytes", freed)
+	}
+}
+
+func TestPremise_PinnedShareStillEvictsAfterStart(t *testing.T) {
+	freed := premiseDrainFreed(t, true)
+	t.Logf("pinned share freed %d bytes", freed)
+	if freed != 0 {
+		t.Fatalf("PREMISE CONFIRMED: pinned share freed %d local bytes after Start", freed)
+	}
+}

--- a/pkg/block/journal/gap_methods_test.go
+++ b/pkg/block/journal/gap_methods_test.go
@@ -93,3 +93,42 @@ func TestSetEvictionEnabledGatesEvict(t *testing.T) {
 		t.Fatalf("eviction enabled but nothing evicted")
 	}
 }
+
+func TestEvictionPinOutranksEnable(t *testing.T) {
+	// The pin and the health-driven gate are independent: whichever call comes
+	// last, a pinned store must not evict, and clearing the pin must restore
+	// whatever the health gate last asked for.
+	s, _ := evictStore(t, Config{})
+	ctx := context.Background()
+	fillUntilSealed(t, s, "f", true, 1) // Hydrate => synced => evictable
+
+	s.SetEvictionPinned(true)
+	s.SetEvictionEnabled(true) // what Start and SetRemoteStore do on a healthy remote
+	res, err := s.Evict(ctx, 1)
+	if err != nil {
+		t.Fatalf("Evict (pinned): %v", err)
+	}
+	if res.SegmentsEvicted != 0 {
+		t.Fatalf("pinned but evicted %d segments", res.SegmentsEvicted)
+	}
+
+	// Unpinned while the health gate is suspended: still no eviction.
+	s.SetEvictionEnabled(false)
+	s.SetEvictionPinned(false)
+	res, err = s.Evict(ctx, 1)
+	if err != nil {
+		t.Fatalf("Evict (unpinned, suspended): %v", err)
+	}
+	if res.SegmentsEvicted != 0 {
+		t.Fatalf("eviction suspended but evicted %d segments", res.SegmentsEvicted)
+	}
+
+	s.SetEvictionEnabled(true)
+	res, err = s.Evict(ctx, 1)
+	if err != nil {
+		t.Fatalf("Evict (unpinned, healthy): %v", err)
+	}
+	if res.SegmentsEvicted == 0 {
+		t.Fatalf("unpinned and healthy but nothing evicted")
+	}
+}

--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -370,14 +370,17 @@ func (s *Store) ensureSpace(ctx context.Context, needed int64) error {
 		if !warned {
 			// The fields are the discriminator, so state the observation and let
 			// them name the cause: unsynced_bytes>0 means carve is behind and the
-			// wait will clear; eviction_disabled means it never will; both zero
-			// and false leaves a snapshot pinning every candidate.
+			// wait will clear; either eviction flag means it never will, and they
+			// are reported apart because the operator's next move differs —
+			// suspended is a remote outage to fix, pinned is a retention policy to
+			// change. All zero and false leaves a snapshot pinning every candidate.
 			logger.Warn("journal local store full: nothing evictable, backpressuring writes",
 				"dir", s.dir,
 				"disk_bytes", s.diskBytes.Load(),
 				"max_local_bytes", s.cfg.MaxLocalBytes,
 				"unsynced_bytes", s.unsynced.Load(),
-				"eviction_disabled", s.evictionHeld())
+				"eviction_suspended", s.evictionSuspended.Load(),
+				"eviction_pinned", s.evictionPinned.Load())
 			warned = true
 		}
 		if time.Now().After(deadline) {

--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -70,7 +70,7 @@ func (s *Store) evict(ctx context.Context, targetBytes int64, allowActiveSeal bo
 	if s.closed.Load() {
 		return EvictResult{}, errClosed
 	}
-	if s.evictionDisabled.Load() {
+	if s.evictionHeld() {
 		return EvictResult{}, nil
 	}
 	var res EvictResult
@@ -377,7 +377,7 @@ func (s *Store) ensureSpace(ctx context.Context, needed int64) error {
 				"disk_bytes", s.diskBytes.Load(),
 				"max_local_bytes", s.cfg.MaxLocalBytes,
 				"unsynced_bytes", s.unsynced.Load(),
-				"eviction_disabled", s.evictionDisabled.Load())
+				"eviction_disabled", s.evictionHeld())
 			warned = true
 		}
 		if time.Now().After(deadline) {

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -206,15 +206,15 @@ type Store struct {
 	reads     atomic.Int64
 	coldReads atomic.Int64
 
-	// evictionDisabled gates Evict (and thus the write-path ensureSpace that
-	// drives it). It is the OR of the two independent reasons to hold eviction
-	// off, recomputed by refreshEviction; nothing writes it directly.
-	// Zero value = enabled, the safe default.
-	evictionDisabled atomic.Bool
-
-	// evictionSuspended is the health-driven reason: while the remote is
-	// unreachable, cold-marking a segment would strand bytes that can't be
-	// refetched, so eviction pauses until the remote returns.
+	// evictionSuspended and evictionPinned are the two independent reasons to
+	// hold eviction off; either one gates Evict (and thus the write-path
+	// ensureSpace that drives it). They are read together by evictionHeld rather
+	// than folded into one derived flag, so two concurrent setters cannot lose
+	// each other's update. Zero values = eviction enabled, the safe default.
+	//
+	// evictionSuspended is health-driven: while the remote is unreachable,
+	// cold-marking a segment would strand bytes that can't be refetched, so
+	// eviction pauses until the remote returns.
 	evictionSuspended atomic.Bool
 
 	// evictionPinned is the retention-policy reason: a pinned share keeps its
@@ -904,7 +904,6 @@ func (s *Store) DurableExtent(_ context.Context, id FileID) (int64, bool) {
 // remote returns. Enabling it does not lift a retention pin.
 func (s *Store) SetEvictionEnabled(enabled bool) {
 	s.evictionSuspended.Store(!enabled)
-	s.refreshEviction()
 }
 
 // SetEvictionPinned toggles the retention-policy half of the eviction gate. A
@@ -912,13 +911,11 @@ func (s *Store) SetEvictionEnabled(enabled bool) {
 // returns the store to whatever the health monitor last asked for.
 func (s *Store) SetEvictionPinned(pinned bool) {
 	s.evictionPinned.Store(pinned)
-	s.refreshEviction()
 }
 
-// refreshEviction recomputes the gate from its two independent reasons. Either
-// one holds eviction off.
-func (s *Store) refreshEviction() {
-	s.evictionDisabled.Store(s.evictionSuspended.Load() || s.evictionPinned.Load())
+// evictionHeld reports whether either reason currently holds eviction off.
+func (s *Store) evictionHeld() bool {
+	return s.evictionSuspended.Load() || s.evictionPinned.Load()
 }
 
 // FileCount reports how many files the journal indexes. It is what a caller that

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -207,10 +207,20 @@ type Store struct {
 	coldReads atomic.Int64
 
 	// evictionDisabled gates Evict (and thus the write-path ensureSpace that
-	// drives it). Health-driven: while the remote is unhealthy, cold-marking a
-	// segment would strand bytes that can't be refetched, so eviction is paused.
+	// drives it). It is the OR of the two independent reasons to hold eviction
+	// off, recomputed by refreshEviction; nothing writes it directly.
 	// Zero value = enabled, the safe default.
 	evictionDisabled atomic.Bool
+
+	// evictionSuspended is the health-driven reason: while the remote is
+	// unreachable, cold-marking a segment would strand bytes that can't be
+	// refetched, so eviction pauses until the remote returns.
+	evictionSuspended atomic.Bool
+
+	// evictionPinned is the retention-policy reason: a pinned share keeps its
+	// bytes local indefinitely. It is held here rather than in a caller so a
+	// health transition re-enabling eviction cannot lift it.
+	evictionPinned atomic.Bool
 
 	// verifyReads turns on per-read record-CRC verification of warm reads (opt-in
 	// for durable tiers; off for the fast writeback path). When off, ReadAt serves
@@ -887,12 +897,28 @@ func (s *Store) DurableExtent(_ context.Context, id FileID) (int64, bool) {
 	return size, true
 }
 
-// SetEvictionEnabled toggles whole-segment eviction. Disabling it pauses Evict
-// (and the write-path ensureSpace that drives it) so a health monitor can stop
-// the store shedding local bytes while the remote is unreachable — a cold-marked
-// range would otherwise be unrecoverable until the remote returns.
+// SetEvictionEnabled toggles the health-driven half of the eviction gate.
+// Disabling it pauses Evict (and the write-path ensureSpace that drives it) so a
+// health monitor can stop the store shedding local bytes while the remote is
+// unreachable — a cold-marked range would otherwise be unrecoverable until the
+// remote returns. Enabling it does not lift a retention pin.
 func (s *Store) SetEvictionEnabled(enabled bool) {
-	s.evictionDisabled.Store(!enabled)
+	s.evictionSuspended.Store(!enabled)
+	s.refreshEviction()
+}
+
+// SetEvictionPinned toggles the retention-policy half of the eviction gate. A
+// pinned store never evicts, whatever the remote's health does; clearing the pin
+// returns the store to whatever the health monitor last asked for.
+func (s *Store) SetEvictionPinned(pinned bool) {
+	s.evictionPinned.Store(pinned)
+	s.refreshEviction()
+}
+
+// refreshEviction recomputes the gate from its two independent reasons. Either
+// one holds eviction off.
+func (s *Store) refreshEviction() {
+	s.evictionDisabled.Store(s.evictionSuspended.Load() || s.evictionPinned.Load())
 }
 
 // FileCount reports how many files the journal indexes. It is what a caller that

--- a/pkg/block/local/local.go
+++ b/pkg/block/local/local.go
@@ -122,6 +122,11 @@ type LocalStore interface {
 	// eviction is paused.
 	SetEvictionEnabled(enabled bool)
 
+	// SetEvictionPinned gates eviction on the share's retention policy. It is
+	// independent of SetEvictionEnabled: a pinned store never evicts, so a
+	// health transition re-enabling eviction cannot shed a pinned share's bytes.
+	SetEvictionPinned(pinned bool)
+
 	// --- Lifecycle ---
 
 	// Start launches background goroutines (if any). Close flushes and marks the

--- a/pkg/block/local/memory/memory.go
+++ b/pkg/block/local/memory/memory.go
@@ -294,6 +294,9 @@ func (s *MemoryStore) Evict(context.Context, int64) (journal.EvictResult, error)
 // SetEvictionEnabled is a no-op.
 func (s *MemoryStore) SetEvictionEnabled(bool) {}
 
+// SetEvictionPinned is a no-op.
+func (s *MemoryStore) SetEvictionPinned(bool) {}
+
 // Start is a no-op.
 func (s *MemoryStore) Start(context.Context) {}
 

--- a/pkg/controlplane/runtime/shares/blockstore_config.go
+++ b/pkg/controlplane/runtime/shares/blockstore_config.go
@@ -365,9 +365,12 @@ func (s *Service) createBlockStoreForShare(
 		}
 	}
 
-	// Eviction requires a remote store (so evicted blocks can be re-fetched) and
-	// must not be pin mode (pin keeps blocks stored locally indefinitely).
-	localStore.SetEvictionEnabled(remoteStore != nil && config.RetentionPolicy != block.RetentionPin)
+	// Pin mode keeps blocks stored locally indefinitely. The pin is held by the
+	// local store itself so the health-driven SetEvictionEnabled calls that Start
+	// and the syncer make cannot lift it. Eviction also requires a remote store
+	// (so evicted blocks can be re-fetched); that half is enforced by Start
+	// reconciling against remote health, which is false without a remote.
+	localStore.SetEvictionPinned(config.RetentionPolicy == block.RetentionPin)
 	// Note: SetSkipFsync was removed. Local-disk durability is now
 	// unconditional (the syncer will refetch from S3 on the rare crash path).
 

--- a/pkg/controlplane/runtime/shares/blockstore_config.go
+++ b/pkg/controlplane/runtime/shares/blockstore_config.go
@@ -365,11 +365,10 @@ func (s *Service) createBlockStoreForShare(
 		}
 	}
 
-	// Pin mode keeps blocks stored locally indefinitely. The pin is held by the
-	// local store itself so the health-driven SetEvictionEnabled calls that Start
-	// and the syncer make cannot lift it. Eviction also requires a remote store
-	// (so evicted blocks can be re-fetched); that half is enforced by Start
-	// reconciling against remote health, which is false without a remote.
+	// Pin mode keeps blocks stored locally indefinitely. The local store holds the
+	// pin itself so the health-driven SetEvictionEnabled calls Start and the
+	// syncer make cannot lift it. Requiring a remote is Start's job: it reconciles
+	// eviction against remote health, which is false when there is no remote.
 	localStore.SetEvictionPinned(config.RetentionPolicy == block.RetentionPin)
 	// Note: SetSkipFsync was removed. Local-disk durability is now
 	// unconditional (the syncer will refetch from S3 on the rare crash path).

--- a/pkg/controlplane/runtime/shares/blockstore_config.go
+++ b/pkg/controlplane/runtime/shares/blockstore_config.go
@@ -366,9 +366,9 @@ func (s *Service) createBlockStoreForShare(
 	}
 
 	// Pin mode keeps blocks stored locally indefinitely. The local store holds the
-	// pin itself so the health-driven SetEvictionEnabled calls Start and the
-	// syncer make cannot lift it. Requiring a remote is Start's job: it reconciles
-	// eviction against remote health, which is false when there is no remote.
+	// pin itself, so the health-driven SetEvictionEnabled calls made by Start and
+	// by the syncer cannot lift it: those calls say only what they know about
+	// remote health, and either reason on its own holds eviction off.
 	localStore.SetEvictionPinned(config.RetentionPolicy == block.RetentionPin)
 	// Note: SetSkipFsync was removed. Local-disk durability is now
 	// unconditional (the syncer will refetch from S3 on the rare crash path).

--- a/pkg/controlplane/runtime/shares/share_config.go
+++ b/pkg/controlplane/runtime/shares/share_config.go
@@ -35,9 +35,9 @@ func (s *Service) UpdateShare(name string, readOnly *bool, defaultPermission *st
 	// evicts whole fully-synced segments approx-LRU and has no ttl or lru knob to
 	// receive, so the rest of the policy is metadata the API reports back.
 	if (retentionPolicy != nil || retentionTTL != nil) && share.BlockStore != nil {
-		// Pin mode disables eviction; switching away from pin returns the store to
-		// whatever the remote-health monitor last asked for, which is "disabled"
-		// for a local-only share.
+		// Pin mode holds eviction off. Switching away from pin drops only the pin,
+		// leaving the store on whatever the remote-health monitor last asked for,
+		// so an unpin during an outage does not start evicting.
 		share.BlockStore.SetEvictionPinned(share.RetentionPolicy == block.RetentionPin)
 	}
 

--- a/pkg/controlplane/runtime/shares/share_config.go
+++ b/pkg/controlplane/runtime/shares/share_config.go
@@ -35,13 +35,10 @@ func (s *Service) UpdateShare(name string, readOnly *bool, defaultPermission *st
 	// evicts whole fully-synced segments approx-LRU and has no ttl or lru knob to
 	// receive, so the rest of the policy is metadata the API reports back.
 	if (retentionPolicy != nil || retentionTTL != nil) && share.BlockStore != nil {
-		// Pin mode disables eviction; switching away from pin re-enables it
-		// (unless the share is local-only, in which case eviction stays disabled).
-		if share.RetentionPolicy == block.RetentionPin {
-			share.BlockStore.SetEvictionEnabled(false)
-		} else if share.BlockStore.HasRemoteStore() {
-			share.BlockStore.SetEvictionEnabled(true)
-		}
+		// Pin mode disables eviction; switching away from pin returns the store to
+		// whatever the remote-health monitor last asked for, which is "disabled"
+		// for a local-only share.
+		share.BlockStore.SetEvictionPinned(share.RetentionPolicy == block.RetentionPin)
 	}
 
 	return nil


### PR DESCRIPTION
Closes #2257.

## The defect

`blockstore_config.go` builds the local store with eviction gated on the retention policy, then `bs.Start` overwrites that decision with `bs.local.SetEvictionEnabled(bs.syncer.IsRemoteHealthy())` — which knows nothing about retention. `Start` runs on every boot, so **a share configured `RetentionPin` has eviction enabled from startup onward**. Two more writers had the same defect: the health-transition callback and the attach-a-remote path.

## Premise verification

Against unmodified `origin/develop`, a pinned share freed **all 16,778,528** of its local bytes after `Start` — byte-for-byte identical to an unpinned control run alongside it. `retention: pin` has never pinned anything on a healthy remote. The control matters: without it, "freed 0" would only prove the probe cannot evict at all.

## The fix

Retention stops being a value any health writer can clobber. The journal store holds `evictionSuspended` (health) and `evictionPinned` (policy) as independent atomics, and `evictionHeld()` reads them together. The three writers keep saying what they know about health; none can lift the pin.

`FSStore` inherits the new method through its embedded `*journal.Store`; only `MemoryStore` needed a no-op. `UpdateShare` collapses from a six-line if/else-if to one line.

Both review passes independently caught a race in the first attempt — I had cached the gate in a derived field refreshed by a helper, an unsynchronised read-modify-write over two atomics that reintroduced the same class of bug one layer down, on a health-flap-meets-admin-toggle interleaving. Computing on read is both correct and the smaller diff.

## A second latent bug, fixed incidentally

The old `UpdateShare` forced eviction back on when unpinning a remote-backed share **even if the remote was unhealthy**.

## Tests

`TestRetentionPinSurvivesStart` (real journal store, real memory remote, no fake sink, with an unpinned control) and `TestEvictionPinOutranksEnable`. Both verified against a deliberately broken build — with the pin dropped from `evictionHeld`, they fail with `pinned share freed 16778528 local bytes` and `pinned but evicted 1 segments`.

## One consequence to flag

The existing startup warning about pinned + bounded shares hitting `ErrDiskFull` described a state that could not previously occur, because the pin was lifted seconds after being set. It can occur now — which is the documented intent. `ensureSpace` degrades in a bounded way rather than hanging.