### PR TITLE
ci(codeql): assert the operator was analysed, not archived

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,7 +56,6 @@ jobs:
           cache: true
 
       - name: Initialize CodeQL
-        id: init
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
@@ -77,66 +76,60 @@ jobs:
           category: "/language:${{ matrix.language }}"
 
       # The repository holds two Go modules and no go.work. The autobuilder
-      # discovers every go.mod under the checkout and runs the extractor once
-      # per module, so the operator lands in this same database — but nothing
-      # announces it when that stops being true. A package that is never
-      # discovered is absent from the database rather than reported as an
-      # error, so an analysis narrowed to the root module still finishes green
-      # and still shows zero operator findings.
+      # discovers every go.mod under the checkout and extracts each module in
+      # turn, but a module it never discovers, or fails to extract, is simply
+      # absent from the database rather than reported as an error: the analysis
+      # still finishes green and still shows zero operator findings.
       #
-      # Compare the operator's source files against the database's source
-      # archive, so a narrowing fails the job instead of passing as silence.
-      # The archive is written when the analysis finalizes the database, so
-      # this has to run after it. Only the operator is checked: the root module
-      # carries files behind windows, darwin and e2e build tags that are
-      # correctly absent from a linux database.
-      - name: Verify the operator module reached the database
+      # Read the extractor's own report of what it did. The database's source
+      # archive cannot answer this — it holds the text of files the extractor
+      # merely saw, and the database is built as an overlay on a cached base, so
+      # the archive also carries text from an earlier run. A module can sit in
+      # the archive in full while this run extracted none of it.
+      #
+      # Diagnostics accumulate the same way, so both checks below are scoped to
+      # the ones this run wrote. Anything that cannot be confirmed positively —
+      # no diagnostics, no discovery report, no way to tell this run's from the
+      # base's — fails the job.
+      - name: Verify the operator module was extracted
         if: matrix.language == 'go'
         run: |
           set -euo pipefail
 
-          archive=$(find "${RUNNER_TEMP}/codeql-db" -name src.zip -print -quit)
-          if [ -z "${archive}" ]; then
-            echo "::error::no CodeQL source archive under ${RUNNER_TEMP}/codeql-db"
+          diagnostics="${RUNNER_TEMP}/codeql-db/go/diagnostic/extractors/go"
+          if [ -z "$(find "${diagnostics}" -name '*.json' -print -quit 2>/dev/null)" ]; then
+            echo "::error::no Go extractor diagnostics under ${diagnostics}; cannot confirm what was extracted"
             exit 1
           fi
 
-          # Test files are out of scope: the Go extractor's extract_tests
-          # option is off by default, for both modules alike.
-          want="${RUNNER_TEMP}/operator-sources.txt"
-          got="${RUNNER_TEMP}/operator-extracted.txt"
-          # A git pathspec matches across directory separators, so this
-          # reaches the whole module, not just its top level.
-          git ls-files 'k8s/dittofs-operator/*.go' | grep -v '_test\.go$' | sort >"${want}"
-          if [ ! -s "${want}" ]; then
-            echo "::error::found no operator sources to check for; has the module moved?"
-            exit 1
-          fi
-          unzip -Z1 "${archive}" | grep -oE 'k8s/dittofs-operator/.*\.go$' | sort -u >"${got}" || true
-
-          found=$(comm -12 "${want}" "${got}" | wc -l)
-          echo "operator source files in the CodeQL database: ${found} of $(wc -l <"${want}")"
-
-          missing=$(comm -23 "${want}" "${got}")
-          if [ -n "${missing}" ]; then
-            echo "::error::CodeQL did not analyse these operator files:"
-            printf '%s\n' "${missing}"
+          since="${CODEQL_WORKFLOW_STARTED_AT:-}"
+          if [ -z "${since}" ]; then
+            echo "::error::CODEQL_WORKFLOW_STARTED_AT is unset; cannot separate this run's extractor diagnostics from the overlay base's"
             exit 1
           fi
 
-      - name: DEBUG dump codeql db layout
-        if: ${{ always() && matrix.language == 'go' }}
-        run: |
-          echo "codeql-path=${{ steps.init.outputs.codeql-path }}"
-          echo "=== tree (depth 4) ==="
-          find "${RUNNER_TEMP}/codeql-db" -maxdepth 4 | head -200
-          echo "=== any log/json/diagnostic ==="
-          find "${RUNNER_TEMP}/codeql-db" \( -name '*.log' -o -name '*.json' -o -path '*diagnostic*' \) | head -100
-          echo "=== files mentioning extraction failure ==="
-          grep -ril 'xtraction failed' "${RUNNER_TEMP}/codeql-db" 2>/dev/null | head -50 || true
-          echo "=== files mentioning dittofs-operator (non-src.zip) ==="
-          grep -rl 'dittofs-operator' "${RUNNER_TEMP}/codeql-db" --include='*.log' --include='*.json' --include='*.yml' 2>/dev/null | head -50 || true
-          echo "=== diagnostic json contents ==="
-          find "${RUNNER_TEMP}/codeql-db" -path '*diagnostic*' -type f | head -40 | while read -r f; do echo "--- $f"; cat "$f"; echo; done
-          echo "=== log greps ==="
-          find "${RUNNER_TEMP}/codeql-db" -name '*.log' | head -20 | while read -r f; do echo "--- $f"; wc -l "$f"; grep -in 'xtraction\|dittofs-operator\|requires go >=' "$f" | head -40; done
+          # Timestamps are ISO 8601 in UTC, so they order lexicographically.
+          mine="${RUNNER_TEMP}/go-extractor-diagnostics.json"
+          jq -s --arg since "${since}" '[.[] | select(.timestamp >= $since)]' \
+            "${diagnostics}"/*.json >"${mine}"
+
+          # The autobuilder names every go.mod it found. Discovery is what makes
+          # a module's disappearance observable: one that is never discovered is
+          # never extracted, and never reported as a failure either.
+          if ! jq -e --arg mod 'k8s/dittofs-operator/go.mod' \
+            'any(.[]; (.markdownMessage // "") | contains($mod))' "${mine}" >/dev/null; then
+            echo "::error::the Go autobuilder did not report discovering k8s/dittofs-operator/go.mod; either the operator was not analysed, or the module moved and this check needs its path updated"
+            jq -r '.[] | "\(.source.id): \(.markdownMessage // .source.name)"' "${mine}"
+            exit 1
+          fi
+
+          # Projects the extractor could not build are named here, one message
+          # per project set. Their sources are archived regardless.
+          failed=$(jq -r '.[] | select((.source.id // "") | contains("extraction-failed")) | .markdownMessage // .source.name' "${mine}")
+          if [ -n "${failed}" ]; then
+            echo "::error::the Go extractor could not extract every project:"
+            printf '%s\n' "${failed}"
+            exit 1
+          fi
+
+          echo "the Go extractor discovered k8s/dittofs-operator and reported no extraction failures"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,10 +52,11 @@ jobs:
         if: matrix.language == 'go'
         uses: actions/setup-go@v7
         with:
-          go-version-file: k8s/dittofs-operator/go.mod
+          go-version: "1.25.x"
           cache: true
 
       - name: Initialize CodeQL
+        id: init
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
@@ -122,3 +123,20 @@ jobs:
             printf '%s\n' "${missing}"
             exit 1
           fi
+
+      - name: DEBUG dump codeql db layout
+        if: ${{ always() && matrix.language == 'go' }}
+        run: |
+          echo "codeql-path=${{ steps.init.outputs.codeql-path }}"
+          echo "=== tree (depth 4) ==="
+          find "${RUNNER_TEMP}/codeql-db" -maxdepth 4 | head -200
+          echo "=== any log/json/diagnostic ==="
+          find "${RUNNER_TEMP}/codeql-db" \( -name '*.log' -o -name '*.json' -o -path '*diagnostic*' \) | head -100
+          echo "=== files mentioning extraction failure ==="
+          grep -ril 'xtraction failed' "${RUNNER_TEMP}/codeql-db" 2>/dev/null | head -50 || true
+          echo "=== files mentioning dittofs-operator (non-src.zip) ==="
+          grep -rl 'dittofs-operator' "${RUNNER_TEMP}/codeql-db" --include='*.log' --include='*.json' --include='*.yml' 2>/dev/null | head -50 || true
+          echo "=== diagnostic json contents ==="
+          find "${RUNNER_TEMP}/codeql-db" -path '*diagnostic*' -type f | head -40 | while read -r f; do echo "--- $f"; cat "$f"; echo; done
+          echo "=== log greps ==="
+          find "${RUNNER_TEMP}/codeql-db" -name '*.log' | head -20 | while read -r f; do echo "--- $f"; wc -l "$f"; grep -in 'xtraction\|dittofs-operator\|requires go >=' "$f" | head -40; done

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -115,10 +115,15 @@ jobs:
           # them. Discovery is what makes a module's disappearance observable: one
           # that is never discovered is never extracted, and is never reported as
           # a failure either. Only this run's report counts, since the overlay
-          # base carries the previous one alongside it. Timestamps are ISO 8601 in
-          # UTC, so they order lexicographically.
-          if ! jq -e --arg since "${since}" \
-            'any(.[]; .timestamp >= $since and ((.markdownMessage // "") | contains("k8s/dittofs-operator/go.mod")))' \
+          # base carries the previous one alongside it. Both sides write UTC ISO
+          # 8601 with fractional seconds, which jq's ISO parser rejects, so the
+          # fraction is dropped before parsing; a timestamp that still will not
+          # parse aborts jq and fails the step.
+          if ! jq -e --arg since "${since}" '
+            def epoch: sub("\\.[0-9]+"; "") | fromdateiso8601;
+            ($since | epoch) as $start
+            | any(.[]; (.timestamp | epoch) >= $start
+                       and ((.markdownMessage // "") | contains("k8s/dittofs-operator/go.mod")))' \
             >/dev/null <<<"${all}"; then
             echo "::error::the Go autobuilder did not report discovering k8s/dittofs-operator/go.mod in this run; either the operator was not analysed, the module moved and this check needs its new path, or the extractor stopped emitting that report"
             jq -r '.[] | "\(.timestamp) \(.source.id): \(.markdownMessage // .source.name)"' <<<"${all}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,7 +52,7 @@ jobs:
         if: matrix.language == 'go'
         uses: actions/setup-go@v7
         with:
-          go-version: "1.25.x"
+          go-version-file: k8s/dittofs-operator/go.mod
           cache: true
 
       - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -140,4 +140,9 @@ jobs:
             exit 1
           fi
 
+          # ponytail: a project counts as extracted even when individual packages
+          # inside it fail to resolve, which is the extractor's own definition of
+          # success; proving that every operator file reached the database would
+          # mean running a QL query against the finalized one. Upgrade to that if
+          # a package-level gap ever ships.
           echo "the Go extractor discovered k8s/dittofs-operator and reported no extraction failures"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -75,11 +75,11 @@ jobs:
         with:
           category: "/language:${{ matrix.language }}"
 
-      # The repository holds two Go modules and no go.work. The autobuilder
-      # discovers every go.mod under the checkout and extracts each module in
-      # turn, but a module it never discovers, or fails to extract, is simply
-      # absent from the database rather than reported as an error: the analysis
-      # still finishes green and still shows zero operator findings.
+      # The repository holds two Go modules. The autobuilder discovers every
+      # go.mod under the checkout and extracts each module in turn, but a module
+      # it never discovers, or fails to extract, is simply absent from the
+      # database rather than reported as an error: the analysis still finishes
+      # green and still shows zero operator findings.
       #
       # Read the extractor's own report of what it did. The database's source
       # archive cannot answer this — it holds the text of files the extractor
@@ -87,18 +87,19 @@ jobs:
       # the archive also carries text from an earlier run. A module can sit in
       # the archive in full while this run extracted none of it.
       #
-      # Diagnostics accumulate the same way, so both checks below are scoped to
-      # the ones this run wrote. Anything that cannot be confirmed positively —
-      # no diagnostics, no discovery report, no way to tell this run's from the
-      # base's — fails the job.
+      # Anything that cannot be confirmed positively fails the job: no
+      # diagnostics, no discovery report from this run, no way to tell this
+      # run's diagnostics from the base's, or a diagnostic stream truncated to
+      # the point where it can no longer be trusted to report a failure.
       - name: Verify the operator module was extracted
         if: matrix.language == 'go'
         run: |
           set -euo pipefail
 
-          diagnostics="${RUNNER_TEMP}/codeql-db/go/diagnostic/extractors/go"
-          if [ -z "$(find "${diagnostics}" -name '*.json' -print -quit 2>/dev/null)" ]; then
-            echo "::error::no Go extractor diagnostics under ${diagnostics}; cannot confirm what was extracted"
+          dir="${RUNNER_TEMP}/codeql-db/go/diagnostic/extractors/go"
+          diagnostics=("${dir}"/*.json)
+          if [ ! -e "${diagnostics[0]}" ]; then
+            echo "::error::no Go extractor diagnostics under ${dir}; cannot confirm what was extracted"
             exit 1
           fi
 
@@ -108,27 +109,34 @@ jobs:
             exit 1
           fi
 
-          # Timestamps are ISO 8601 in UTC, so they order lexicographically.
-          mine="${RUNNER_TEMP}/go-extractor-diagnostics.json"
-          jq -s --arg since "${since}" '[.[] | select(.timestamp >= $since)]' \
-            "${diagnostics}"/*.json >"${mine}"
+          all=$(jq -s . "${diagnostics[@]}")
 
-          # The autobuilder names every go.mod it found. Discovery is what makes
-          # a module's disappearance observable: one that is never discovered is
-          # never extracted, and never reported as a failure either.
-          if ! jq -e --arg mod 'k8s/dittofs-operator/go.mod' \
-            'any(.[]; (.markdownMessage // "") | contains($mod))' "${mine}" >/dev/null; then
-            echo "::error::the Go autobuilder did not report discovering k8s/dittofs-operator/go.mod; either the operator was not analysed, or the module moved and this check needs its path updated"
-            jq -r '.[] | "\(.source.id): \(.markdownMessage // .source.name)"' "${mine}"
+          # The autobuilder names every go.mod it found, before extracting any of
+          # them. Discovery is what makes a module's disappearance observable: one
+          # that is never discovered is never extracted, and is never reported as
+          # a failure either. Only this run's report counts, since the overlay
+          # base carries the previous one alongside it. Timestamps are ISO 8601 in
+          # UTC, so they order lexicographically.
+          if ! jq -e --arg since "${since}" \
+            'any(.[]; .timestamp >= $since and ((.markdownMessage // "") | contains("k8s/dittofs-operator/go.mod")))' \
+            >/dev/null <<<"${all}"; then
+            echo "::error::the Go autobuilder did not report discovering k8s/dittofs-operator/go.mod in this run; either the operator was not analysed, the module moved and this check needs its new path, or the extractor stopped emitting that report"
+            jq -r '.[] | "\(.timestamp) \(.source.id): \(.markdownMessage // .source.name)"' <<<"${all}"
             exit 1
           fi
 
-          # Projects the extractor could not build are named here, one message
-          # per project set. Their sources are archived regardless.
-          failed=$(jq -r '.[] | select((.source.id // "") | contains("extraction-failed")) | .markdownMessage // .source.name' "${mine}")
-          if [ -n "${failed}" ]; then
-            echo "::error::the Go extractor could not extract every project:"
-            printf '%s\n' "${failed}"
+          # Whatever says a project did not build — or that the diagnostic stream
+          # was truncated, and so can no longer be trusted to say so. Deliberately
+          # not scoped to this run: overlay extraction reuses the files the base
+          # already holds, so a module the base failed on is missing from this
+          # analysis too, and stays missing until a push to a default branch
+          # rebuilds the base.
+          unclean=$(jq -r '.[]
+            | select(((.source.id // "") | test("extraction-failed|diagnostic-limit-reached")) or .severity == "error")
+            | "\(.timestamp) \(.source.id): \(.markdownMessage // .source.name)"' <<<"${all}")
+          if [ -n "${unclean}" ]; then
+            echo "::error::the Go extractor did not extract every project cleanly:"
+            printf '%s\n' "${unclean}"
             exit 1
           fi
 


### PR DESCRIPTION
The operator coverage guard read the CodeQL **source archive** and checked that the
operator's `.go` files were members of it. Membership in `src.zip` means the extractor
*saw* a file, not that it compiled and was analysed — so the guard could not tell "the
operator was analysed" from "the operator failed to extract but its sources were archived
anyway". It reported the strongest possible green, `22 of 22`, on two consecutive PRs where
the operator had not been analysed at all.

## Reproduced, then refuted the guard on a live runner

Reintroducing the toolchain mismatch on this branch (`go-version: "1.25.x"` against an
operator module whose floor is `go 1.26.0`) reproduces the reported state exactly:

```
Autobuild   go: go.mod requires go >= 1.26.0 (running go 1.25.14; GOTOOLCHAIN=local)
Autobuild   Extraction failed for k8s/dittofs-operator: exit status 1
```

| run | guard said | `Analyze (go)` |
| --- | --- | --- |
| [33755740663](https://github.com/marmos91/dittofs/actions/runs/33755740663) — old guard, pin mismatched | `operator source files in the CodeQL database: 22 of 22` | **pass**, whole run green |
| [33756566116](https://github.com/marmos91/dittofs/actions/runs/33756566116) — new guard, pin mismatched | `the Go extractor could not extract every project: … k8s/dittofs-operator` | **fail** |
| [33756830492](https://github.com/marmos91/dittofs/actions/runs/33756830492) — new guard, pin restored | `the Go extractor discovered k8s/dittofs-operator and reported no extraction failures` | **pass** |

The `Autobuild` step concludes `success` in every one of them. Nothing else in the job
noticed.

## Why the archive cannot answer the question

The first reason is the one the issue names: `src.zip` holds source text, written for files
the extractor saw.

The second only shows up on a runner. The database is built as an **overlay** —
`codeql-db/go/db-go/default` is a base cached from an earlier run, `db-go/overlay` is this
run, and `base-database-oids.json` sits alongside. So the archive carries text from a
previous run as well as this one.

That also settles the issue's open question about `--source-root`. The autobuilder passes
that flag only when it is doing an overlay extraction, so the two runs that reported
`22 of 22` were overlay runs reading a base built the previous day — before the `go 1.26.0`
bump landed (`fe1a155c7`, this morning), while the operator still extracted cleanly. The one
run that reported `0 of 22` was a full rebuild. The old guard was measuring the run mode.
Normalising the paths would not have fixed it; it would have made the false green
unconditional.

## What the guard asserts now

The Go extractor writes its own verdict as JSON under
`codeql-db/go/diagnostic/extractors/go/`. The guard reads that instead, in two halves:

- **Discovery, scoped to this run.** Some diagnostic from this run must name
  `k8s/dittofs-operator/go.mod`. This is the positive half. A module that is never
  discovered is never extracted *and* never reported as a failure, so without it the guard
  would pass on silence — the original narrowing the check exists to catch. It is scoped by
  `timestamp >= CODEQL_WORKFLOW_STARTED_AT` because the overlay base carries the previous
  run's report alongside this one's.

- **Nothing unclean, across all diagnostics.** No `source.id` containing
  `extraction-failed`, none containing `diagnostic-limit-reached`, and nothing of
  `severity: error`. The failure id is what the extractor emits when a project does not
  build (`go/autobuilder/extraction-failed-for-project`). The other two matter because the
  extractor caps itself at 100 diagnostics globally and emits the extraction-failure summary
  *last* — so the one diagnostic this check depends on is the first thing a truncated stream
  drops. A truncated stream is not a clean run, it is an unknown one, and it fails.

  This half is deliberately **not** scoped to this run. Overlay extraction reuses the files
  the base already holds, so a module the base failed on is missing from this analysis too,
  and stays missing until a push to a default branch rebuilds the base. A failure inherited
  from the base is a live gap, not stale noise.

Everything it cannot positively confirm fails the job: no diagnostics directory, no
diagnostics at all, no discovery report from this run, `CODEQL_WORKFLOW_STARTED_AT` unset,
or unparseable JSON.

The `src.zip` comparison is removed rather than kept as a secondary signal. It was not
merely uninformative — it was flaky in the other direction too: the one run that did fail
(`0 of 22`) failed because of the extraction mode, not because of coverage. A check that can
fail for a reason unrelated to what it measures is a check that gets deleted the first time
it blocks someone.

## Known ceiling

A project can be marked extracted while individual packages inside it fail
(`package-not-found`, `package-different-os-architecture`); the extractor emits no
extraction failure for that, because it matches CodeQL's own definition of success. Proving
per-file analysis would mean running a QL query against the finalized database. Out of scope
here.

## Verified

- Red and green on the same branch, above — including that the discovery half holds when
  extraction *succeeds*, which no fixture can prove.
- The guard script was also driven directly against the three diagnostic files captured
  verbatim from the runner, and against fixtures for: failure inherited from the overlay
  base (fails), diagnostic limit reached (fails), `severity: error` (fails), discovery
  present only in a base diagnostic (fails), empty and missing diagnostics directory
  (fails), `CODEQL_WORKFLOW_STARTED_AT` unset (fails), malformed JSON (fails).

Closes #2297
