### PR TITLE
fix(journal): order unstamped segments by age, not ahead of everything

### DIFF
--- a/pkg/block/journal/evict_test.go
+++ b/pkg/block/journal/evict_test.go
@@ -604,3 +604,85 @@ func TestEnsureSpaceReclaimsSyncedActiveBelowRotation(t *testing.T) {
 		t.Fatalf("cap never enforced: diskBytes=%d want <=%d", got, max)
 	}
 }
+
+// TestEvictPrefersOlderStampOverUnstamped pins the tiebreak for a segment that
+// is evictable while its lastAccess is still zero — a repack target, or any
+// sealed segment reconstructed at open. Zero must not sort ahead of a real
+// timestamp: the unstamped segment here was created a moment ago, the stamped
+// one was last touched an hour back, so the stamped one is the colder victim.
+func TestEvictPrefersOlderStampOverUnstamped(t *testing.T) {
+	s, clk := evictStore(t, Config{})
+	ctx := context.Background()
+
+	fillUntilSealed(t, s, "f", true, 2)
+	segs := sealedSegs(s.shardFor("f"))
+	if len(segs) < 2 {
+		t.Fatalf("want >=2 sealed segments, got %d", len(segs))
+	}
+	now := clk.Now()
+	// Never stamped, but created just now — the shape repackSegment produces.
+	fresh := segs[0]
+	fresh.lastAccess.Store(0)
+	fresh.createdAt = now
+	// Genuinely cold: last read an hour ago.
+	stale := segs[1]
+	stale.lastAccess.Store(now.Add(-time.Hour).UnixNano())
+	stale.createdAt = now.Add(-2 * time.Hour)
+	for _, seg := range segs[2:] {
+		seg.lastAccess.Store(now.UnixNano())
+	}
+
+	res, err := s.Evict(ctx, 0)
+	if err != nil {
+		t.Fatalf("Evict: %v", err)
+	}
+	if res.SegmentsEvicted != 1 {
+		t.Fatalf("targetBytes=0 must evict exactly one segment, got %d", res.SegmentsEvicted)
+	}
+	if _, err := os.Stat(s.segPath(stale.id)); !os.IsNotExist(err) {
+		t.Fatalf("segment %d, last touched an hour ago, should be the victim; stat err=%v", stale.id, err)
+	}
+	if _, err := os.Stat(s.segPath(fresh.id)); err != nil {
+		t.Fatalf("unstamped but freshly created segment %d must survive; stat err=%v", fresh.id, err)
+	}
+}
+
+// TestReopenedSegmentsHaveEvictionAge covers the second producer of unstamped
+// segments: recovery rebuilds every sealed segment from its header, and nothing
+// on that path stamps lastAccess. Left as zero they would all tie at the bottom
+// of the victim search, so the order among them falls to map iteration and the
+// approx-LRU stops approximating anything after a restart.
+func TestReopenedSegmentsHaveEvictionAge(t *testing.T) {
+	dir := t.TempDir()
+	clk := newFakeClock()
+	cfg := Config{ShardCount: 1, SegmentSize: minSegmentSize}
+
+	s, err := Open(dir, cfg, newFakeRemote(), clk)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	fillUntilSealed(t, s, "f", true, 2)
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	s2, err := Open(dir, cfg, newFakeRemote(), clk)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	t.Cleanup(func() { _ = s2.Close() })
+
+	segs := sealedSegs(s2.shardFor("f"))
+	if len(segs) < 2 {
+		t.Fatalf("want >=2 sealed segments after reopen, got %d", len(segs))
+	}
+	for _, seg := range segs {
+		if seg.lastAccess.Load() != 0 {
+			t.Fatalf("segment %d: recovery is expected to leave lastAccess unstamped, got %d",
+				seg.id, seg.lastAccess.Load())
+		}
+		if got := seg.evictionAge(); got <= 0 {
+			t.Errorf("segment %d: evictionAge = %d, want its creation stamp", seg.id, got)
+		}
+	}
+}

--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -186,7 +186,7 @@ func (s *Store) claimColdestEvictable() (*segmentMeta, *shard) {
 					// of an at-or-below-watermark record (local-only) — never evict.
 					continue
 				}
-				if la := seg.lastAccess.Load(); best == nil || la < bestAccess {
+				if la := seg.evictionAge(); best == nil || la < bestAccess {
 					best, bestShard, bestAccess = seg, sh, la
 				}
 			}

--- a/pkg/block/journal/segment.go
+++ b/pkg/block/journal/segment.go
@@ -53,7 +53,7 @@ type segmentMeta struct {
 	deadBytes     atomic.Int64 // superseded/tombstoned payload bytes (GC input)
 	records       atomic.Int64 // physical records appended (eviction synced-gate denominator)
 	syncedRecords atomic.Int64 // records with the synced flag set (eviction gate)
-	lastAccess    atomic.Int64 // unix nanos, approx-LRU victim key
+	lastAccess    atomic.Int64 // unix nanos, approx-LRU victim key; 0 = never stamped
 	// minVersion is the lowest record Version stored in this segment (0 = empty).
 	// Segments fill sequentially, so a segment's records span a contiguous
 	// [minVersion, maxVersion]; minVersion<=pinVersion means the segment holds a
@@ -179,6 +179,22 @@ func (s *Store) createSegment() (*segmentMeta, error) {
 	m.tail.Store(segHeaderSize)
 	s.diskBytes.Add(segHeaderSize)
 	return m, nil
+}
+
+// evictionAge is the approx-LRU victim key: when the segment was last touched,
+// or when it was created if nothing has touched it. Only the append and read
+// paths stamp lastAccess, so a segment can become evictable while still zero —
+// a repack target is filled by writeDataRecord, and every sealed segment
+// rebuilt at open starts unstamped. Zero would sort ahead of every real
+// timestamp, offering exactly those segments to eviction first: the ones GC
+// just consolidated, and after a restart every segment that survived it.
+// createdAt is durable (it round-trips through the segment header, including
+// the seal rewrite), so it orders unstamped segments by age instead.
+func (seg *segmentMeta) evictionAge() int64 {
+	if la := seg.lastAccess.Load(); la != 0 {
+		return la
+	}
+	return seg.createdAt.UnixNano()
 }
 
 // fsyncDir flushes a directory's entries so a freshly created file survives a


### PR DESCRIPTION
Closes #2251.

## The defect, and the half the issue did not have

`segmentMeta.lastAccess` is the approx-LRU victim key, read in exactly one place:

```go
// reclaim.go:189
if la := seg.lastAccess.Load(); best == nil || la < bestAccess {
```

Three writers stamp it, and all three are on the append or read paths (`segment.go:361` append, `segment.go:597` carve read, `index.go:353` client read). So a segment can become evictable while its stamp is still zero, and zero sorts ahead of every real timestamp.

**Two paths produce one**, not the one the issue names:

1. `repackSegment` fills its target through `writeDataRecord`, not the append path — so the segment holding the records GC just decided were worth keeping is offered to eviction first.
2. `recovery.go:230` rebuilds every sealed segment as `&segmentMeta{id, createdAt, fd}`. After **any restart**, every surviving sealed segment reads as zero, they all tie at the bottom of the search, and the order among them falls to Go map iteration over `sh.sealed` — which is randomized.

The second is the larger one: it is reachable on every restart of every remote-backed share, not only after a repack.

## The fix

Interpret the zero at the single reader rather than stamping at each producer:

```go
func (seg *segmentMeta) evictionAge() int64 {
	if la := seg.lastAccess.Load(); la != 0 {
		return la
	}
	return seg.createdAt.UnixNano()
}
```

`createdAt` is durable — encoded in the segment header and deliberately preserved across the seal rewrite (`segment.go:49`, `:213`) — so unstamped segments order by age instead of sinking below everything.

This is why neither candidate in the issue is right on its own: stamping in `repackSegment` leaves the recovery producer open, and stamping in `createSegment` closes neither (recovery does not call it, and rotation is already covered by the append stamp).

## Severity, stated honestly

Lower than "evicted first, always". Both producers self-heal, because reads restamp. The cost is a window after a repack or a restart in which the victim choice is wrong or random, paid as cold-read latency and remote traffic on data that was hot. No data loss: an evicted synced segment refetches.

## Tests

- `TestEvictPrefersOlderStampOverUnstamped` — an unstamped-but-new segment must outlive a stamped-but-old one.
- `TestReopenedSegmentsHaveEvictionAge` — after a reopen, `lastAccess` is still zero (pinning the second producer as a fact) while the eviction age is not.

Both verified to **fail** against a build with the fallback reverted; the first fails with the freshly-created segment chosen as victim.

`go test -race ./pkg/block/journal/` green.