### PR TITLE
fix(metadata): rename over an existing file never freed the clobbered file's bytes

### DIFF
--- a/internal/adapter/common/rename_reclaim.go
+++ b/internal/adapter/common/rename_reclaim.go
@@ -1,0 +1,53 @@
+package common
+
+import (
+	"context"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// ReleaseClobberedPayload frees the content of the file a rename silently
+// unlinked by renaming over it.
+//
+// POSIX rename onto an existing name removes whatever was there.
+// metadata.Service.Move drops that victim's last link but, like RemoveFile,
+// never its bytes — it returns the victim so the caller can coordinate content
+// deletion. Without this call the victim's records stay indexed as live in the
+// per-share local tier, so no reclamation path (fast-path retire, eviction,
+// repack) can treat them as dead and the bytes survive every restart. Only the
+// local tier depends on it: the remote block GC derives orphans from
+// (synced − live) in the metadata store, which the unlink alone already drives.
+//
+// This is the single seam every protocol adapter drives after a clobbering
+// rename, so one protocol cannot forget it while another gets it right.
+//
+// No-ops when there is nothing to release: no victim (the rename replaced
+// nothing, replaced a directory, or trash recycled the victim), or an empty
+// PayloadID, which is the contract's signal that the content must survive
+// because another hard link still references it.
+//
+// Best-effort by contract — the rename has already committed and the client
+// already has its answer, so callers log a non-nil error rather than failing
+// the operation. `handle` only has to belong to the victim's share; handles are
+// opaque and encode share identity, so the destination directory resolves the
+// same per-share block store the victim's content lives in.
+func ReleaseClobberedPayload(
+	ctx context.Context,
+	reg BlockStoreRegistry,
+	handle metadata.FileHandle,
+	clobbered *metadata.File,
+) error {
+	if clobbered == nil || clobbered.PayloadID == "" {
+		return nil
+	}
+
+	blockStore, err := ResolveForWrite(ctx, reg, handle)
+	if err != nil {
+		return err
+	}
+
+	// Pass nil blocks: the block store resolves this payload's manifest itself
+	// and reaps each row's refcount so the chunks become GC-eligible, in
+	// addition to purging the append log and the tracked size.
+	return blockStore.Delete(ctx, string(clobbered.PayloadID), nil)
+}

--- a/internal/adapter/common/rename_reclaim.go
+++ b/internal/adapter/common/rename_reclaim.go
@@ -7,30 +7,25 @@ import (
 )
 
 // ReleaseClobberedPayload frees the content of the file a rename silently
-// unlinked by renaming over it.
+// unlinked by renaming over it. metadata.Service.Move drops that victim's last
+// link but, like RemoveFile, never its bytes — it returns the victim so the
+// caller can coordinate content deletion. Without this call the victim's
+// records stay indexed as live in the per-share local tier, so no reclamation
+// path (fast-path retire, eviction, repack) can treat them as dead and the
+// bytes survive every restart. The remote tier needs nothing: its GC derives
+// orphans from (synced − live) in the metadata store, which the unlink already
+// drives.
 //
-// POSIX rename onto an existing name removes whatever was there.
-// metadata.Service.Move drops that victim's last link but, like RemoveFile,
-// never its bytes — it returns the victim so the caller can coordinate content
-// deletion. Without this call the victim's records stay indexed as live in the
-// per-share local tier, so no reclamation path (fast-path retire, eviction,
-// repack) can treat them as dead and the bytes survive every restart. Only the
-// local tier depends on it: the remote block GC derives orphans from
-// (synced − live) in the metadata store, which the unlink alone already drives.
-//
-// This is the single seam every protocol adapter drives after a clobbering
+// This is the single seam all protocol adapters drive after a clobbering
 // rename, so one protocol cannot forget it while another gets it right.
 //
 // No-ops when there is nothing to release: no victim (the rename replaced
 // nothing, replaced a directory, or trash recycled the victim), or an empty
-// PayloadID, which is the contract's signal that the content must survive
-// because another hard link still references it.
-//
-// Best-effort by contract — the rename has already committed and the client
-// already has its answer, so callers log a non-nil error rather than failing
-// the operation. `handle` only has to belong to the victim's share; handles are
-// opaque and encode share identity, so the destination directory resolves the
-// same per-share block store the victim's content lives in.
+// PayloadID, Move's signal that the content must survive a remaining hard link.
+// Best-effort by contract — the rename is already committed and the client has
+// its answer, so callers log a non-nil error rather than failing the operation.
+// `handle` only has to belong to the victim's share, which the destination
+// directory does.
 func ReleaseClobberedPayload(
 	ctx context.Context,
 	reg BlockStoreRegistry,

--- a/internal/adapter/common/rename_reclaim.go
+++ b/internal/adapter/common/rename_reclaim.go
@@ -16,8 +16,8 @@ import (
 // orphans from (synced − live) in the metadata store, which the unlink already
 // drives.
 //
-// This is the single seam all protocol adapters drive after a clobbering
-// rename, so one protocol cannot forget it while another gets it right.
+// SMB reaches the same block-store delete through its own
+// purgeBlockStorePayload, which additionally resolves the handle it is given.
 //
 // No-ops when there is nothing to release: no victim (the rename replaced
 // nothing, replaced a directory, or trash recycled the victim), or an empty

--- a/internal/adapter/nfs/v3/handlers/rename.go
+++ b/internal/adapter/nfs/v3/handlers/rename.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/marmos91/dittofs/internal/adapter/common"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/types"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/xdr"
 	"github.com/marmos91/dittofs/internal/logger"
@@ -255,8 +256,16 @@ func (h *Handler) Rename(
 	// We don't check for cancellation inside RenameFile to maintain atomicity.
 	// The store should respect context internally for its operations.
 
-	renameWcc, err := metaSvc.Move(authCtx, fromDirHandle, req.FromName, toDirHandle, req.ToName)
+	clobbered, renameWcc, err := metaSvc.Move(authCtx, fromDirHandle, req.FromName, toDirHandle, req.ToName)
 	if err == nil {
+		// Renaming onto an existing name silently unlinked whatever was there.
+		// Best-effort: the rename has already committed and the client has its
+		// answer, so a failure to free the victim's bytes is logged, not surfaced.
+		if relErr := common.ReleaseClobberedPayload(ctx.Context, h.Registry, toDirHandle, clobbered); relErr != nil {
+			logger.WarnCtx(ctx.Context, "RENAME: failed to delete clobbered content",
+				"name", req.ToName, "payload_id", clobbered.PayloadID, "error", relErr)
+		}
+
 		// NFS-specific: Handle silly rename (.nfs* pattern)
 		// When an NFS client deletes a file that's still open, it renames the
 		// file to a temporary name starting with ".nfs". We mark such files as

--- a/internal/adapter/nfs/v3/handlers/rename.go
+++ b/internal/adapter/nfs/v3/handlers/rename.go
@@ -258,9 +258,9 @@ func (h *Handler) Rename(
 
 	clobbered, renameWcc, err := metaSvc.Move(authCtx, fromDirHandle, req.FromName, toDirHandle, req.ToName)
 	if err == nil {
-		// Renaming onto an existing name silently unlinked whatever was there.
-		// Best-effort: the rename has already committed and the client has its
-		// answer, so a failure to free the victim's bytes is logged, not surfaced.
+		// Free the bytes of whatever this rename renamed over. The rename is
+		// already committed and the client has its answer, so a failure to
+		// release them is logged rather than surfaced.
 		if relErr := common.ReleaseClobberedPayload(ctx.Context, h.Registry, toDirHandle, clobbered); relErr != nil {
 			logger.WarnCtx(ctx.Context, "RENAME: failed to delete clobbered content",
 				"name", req.ToName, "payload_id", clobbered.PayloadID, "error", relErr)

--- a/internal/adapter/nfs/v3/handlers/rename_test.go
+++ b/internal/adapter/nfs/v3/handlers/rename_test.go
@@ -1,6 +1,8 @@
 package handlers_test
 
 import (
+	"bytes"
+	"context"
 	"testing"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/types"
@@ -420,4 +422,61 @@ func TestRename_NestedDirectory(t *testing.T) {
 
 	assert.Nil(t, fx.GetHandle("a/b/c/nested.txt"))
 	assert.NotNil(t, fx.GetHandle("a/b/c/renamed.txt"))
+}
+
+// TestRename_ReclaimsClobberedPayloadBytes pins that a v3 RENAME onto an
+// existing name frees the clobbered file's content, not just its directory
+// entry. POSIX rename silently unlinks whatever was at the destination, and the
+// metadata layer deliberately never deletes payload bytes — Move returns the
+// clobbered victim so the protocol handler can. A handler that ignores that
+// return leaves the victim's records indexed as live in the local tier, where no
+// reclamation path (fast-path retire, eviction, repack) will ever treat them as
+// dead, so the bytes survive every restart.
+//
+// The assertion is on block-store state an operator can observe rather than on
+// how the handler achieves it, and it pins both directions: the victim's payload
+// must be gone AND the renamed file's payload must survive, so a fix that
+// releases the wrong payload fails here instead of passing.
+func TestRename_ReclaimsClobberedPayloadBytes(t *testing.T) {
+	fx := handlertesting.NewHandlerFixture(t)
+	ctxBg := context.Background()
+
+	payloadIDOf := func(name string) string {
+		t.Helper()
+		handle, err := fx.MetadataService.GetChild(ctxBg, fx.RootHandle, name)
+		require.NoError(t, err)
+		file, err := fx.MetadataService.GetFile(ctxBg, handle)
+		require.NoError(t, err)
+		return string(file.PayloadID)
+	}
+
+	victimBytes := bytes.Repeat([]byte{0xAB}, 1<<20)
+	fx.CreateFile("victim.bin", victimBytes)
+	fx.CreateFile("incoming.bin", bytes.Repeat([]byte{0xCD}, 4096))
+
+	victimPayload := payloadIDOf("victim.bin")
+	survivorPayload := payloadIDOf("incoming.bin")
+	require.NotEqual(t, victimPayload, survivorPayload,
+		"test setup: both files share a payload, the assertions below cannot discriminate")
+
+	size, ok := fx.LocalStore.FileSize(ctxBg, victimPayload)
+	require.True(t, ok, "victim payload absent from the local tier before RENAME")
+	require.Equal(t, int64(len(victimBytes)), size)
+
+	resp, err := fx.Handler.Rename(fx.ContextWithUID(0, 0), &handlers.RenameRequest{
+		FromDirHandle: fx.RootHandle,
+		FromName:      "incoming.bin",
+		ToDirHandle:   fx.RootHandle,
+		ToName:        "victim.bin",
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, types.NFS3OK, resp.Status)
+
+	leaked, stillThere := fx.LocalStore.FileSize(ctxBg, victimPayload)
+	assert.Falsef(t, stillThere,
+		"clobbered payload %q still holds %d live bytes in the local tier after RENAME", victimPayload, leaked)
+
+	_, survived := fx.LocalStore.FileSize(ctxBg, survivorPayload)
+	assert.Truef(t, survived,
+		"renamed file's payload %q was dropped from the local tier by RENAME", survivorPayload)
 }

--- a/internal/adapter/nfs/v3/handlers/rename_test.go
+++ b/internal/adapter/nfs/v3/handlers/rename_test.go
@@ -424,19 +424,16 @@ func TestRename_NestedDirectory(t *testing.T) {
 	assert.NotNil(t, fx.GetHandle("a/b/c/renamed.txt"))
 }
 
-// TestRename_ReclaimsClobberedPayloadBytes pins that a v3 RENAME onto an
-// existing name frees the clobbered file's content, not just its directory
-// entry. POSIX rename silently unlinks whatever was at the destination, and the
+// TestRename_ReclaimsClobberedPayloadBytes pins that a RENAME onto an existing
+// name frees the clobbered file's content, not just its directory entry. The
 // metadata layer deliberately never deletes payload bytes — Move returns the
-// clobbered victim so the protocol handler can. A handler that ignores that
-// return leaves the victim's records indexed as live in the local tier, where no
-// reclamation path (fast-path retire, eviction, repack) will ever treat them as
-// dead, so the bytes survive every restart.
+// clobbered victim so the handler can — and a handler that ignores that return
+// leaves the victim's records indexed as live in the local tier, where no
+// reclamation path treats them as dead and the bytes survive every restart.
 //
-// The assertion is on block-store state an operator can observe rather than on
-// how the handler achieves it, and it pins both directions: the victim's payload
-// must be gone AND the renamed file's payload must survive, so a fix that
-// releases the wrong payload fails here instead of passing.
+// Asserting on observable block-store state pins both directions: the victim's
+// payload must be gone AND the renamed file's must survive, so releasing the
+// wrong payload fails here instead of passing.
 func TestRename_ReclaimsClobberedPayloadBytes(t *testing.T) {
 	fx := handlertesting.NewHandlerFixture(t)
 	ctxBg := context.Background()

--- a/internal/adapter/nfs/v3/handlers/testing/fixtures.go
+++ b/internal/adapter/nfs/v3/handlers/testing/fixtures.go
@@ -56,6 +56,11 @@ type HandlerTestFixture struct {
 	// BlockStore provides block storage for content operations.
 	BlockStore *engine.Store
 
+	// LocalStore is the block store's local tier. Exposed so tests can assert
+	// that a payload's bytes actually left the disk, which is the precondition
+	// every reclamation path shares.
+	LocalStore *fs.FSStore
+
 	// ShareName is the name of the test share.
 	ShareName string
 
@@ -174,6 +179,7 @@ func NewHandlerFixtureWithStore(
 		MetadataService: reg.GetMetadataService(),
 		MetaStore:       metaStore,
 		BlockStore:      blockSvc,
+		LocalStore:      localStore,
 		ShareName:       DefaultShareName,
 		RootHandle:      rootHandle,
 	}

--- a/internal/adapter/nfs/v4/handlers/io_test.go
+++ b/internal/adapter/nfs/v4/handlers/io_test.go
@@ -1674,19 +1674,16 @@ func TestRemove_ReclaimsLocalPayloadBytes(t *testing.T) {
 }
 
 // TestRename_ReclaimsClobberedPayloadBytes pins that renaming onto an existing
-// name frees the clobbered file's content, not just its directory entry. POSIX
-// rename silently unlinks whatever was at the destination, and the metadata
-// layer deliberately never deletes payload bytes — Move returns the clobbered
-// victim so the protocol handler can. A handler that ignores that return leaves
-// the victim's records indexed as live in the local tier, where no reclamation
-// path (fast-path retire, eviction, repack) will ever treat them as dead, so the
-// bytes survive every restart. Write-to-temp-then-rename makes this a steady
-// churn rather than a corner case.
+// name frees the clobbered file's content, not just its directory entry. The
+// metadata layer deliberately never deletes payload bytes — Move returns the
+// clobbered victim so the handler can — and a handler that ignores that return
+// leaves the victim's records indexed as live in the local tier, where no
+// reclamation path treats them as dead and the bytes survive every restart.
+// Write-to-temp-then-rename makes this a steady churn, not a corner case.
 //
-// The assertion is on block-store state an operator can observe rather than on
-// how the handler achieves it, and it pins both directions: the victim's payload
-// must be gone AND the renamed file's payload must survive, so a fix that
-// releases the wrong payload fails here instead of passing.
+// Asserting on observable block-store state pins both directions: the victim's
+// payload must be gone AND the renamed file's must survive, so releasing the
+// wrong payload fails here instead of passing.
 func TestRename_ReclaimsClobberedPayloadBytes(t *testing.T) {
 	fx := newIOTestFixture(t, "/export")
 	ctxBg := context.Background()

--- a/internal/adapter/nfs/v4/handlers/io_test.go
+++ b/internal/adapter/nfs/v4/handlers/io_test.go
@@ -1672,3 +1672,63 @@ func TestRemove_ReclaimsLocalPayloadBytes(t *testing.T) {
 		t.Fatalf("payload %q still holds %d live bytes in the local tier after REMOVE", payloadID, size)
 	}
 }
+
+// TestRename_ReclaimsClobberedPayloadBytes pins that renaming onto an existing
+// name frees the clobbered file's content, not just its directory entry. POSIX
+// rename silently unlinks whatever was at the destination, and the metadata
+// layer deliberately never deletes payload bytes — Move returns the clobbered
+// victim so the protocol handler can. A handler that ignores that return leaves
+// the victim's records indexed as live in the local tier, where no reclamation
+// path (fast-path retire, eviction, repack) will ever treat them as dead, so the
+// bytes survive every restart. Write-to-temp-then-rename makes this a steady
+// churn rather than a corner case.
+//
+// The assertion is on block-store state an operator can observe rather than on
+// how the handler achieves it, and it pins both directions: the victim's payload
+// must be gone AND the renamed file's payload must survive, so a fix that
+// releases the wrong payload fails here instead of passing.
+func TestRename_ReclaimsClobberedPayloadBytes(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+	ctxBg := context.Background()
+
+	payloadIDOf := func(fh metadata.FileHandle) string {
+		t.Helper()
+		file, err := fx.metaSvc.GetFile(ctxBg, fh)
+		if err != nil {
+			t.Fatalf("get file: %v", err)
+		}
+		return string(file.PayloadID)
+	}
+
+	victimFH := fx.createRegularFile(t, fx.rootHandle, "victim.bin", 0o644, 1000, 1000)
+	victimPayload := payloadIDOf(victimFH)
+	victimBytes := bytes.Repeat([]byte{0xAB}, 4<<20)
+	fx.writeContent(t, victimFH, victimBytes)
+
+	survivorFH := fx.createRegularFile(t, fx.rootHandle, "incoming.bin", 0o644, 1000, 1000)
+	survivorPayload := payloadIDOf(survivorFH)
+	fx.writeContent(t, survivorFH, bytes.Repeat([]byte{0xCD}, 1<<20))
+
+	if survivorPayload == victimPayload {
+		t.Fatalf("test setup: both files share payload %q, the assertions below cannot discriminate", victimPayload)
+	}
+	if size, ok := fx.localStore.FileSize(ctxBg, victimPayload); !ok || size != int64(len(victimBytes)) {
+		t.Fatalf("local tier holds %d bytes (present=%v) for the victim before RENAME, want %d", size, ok, len(victimBytes))
+	}
+
+	ctx := newRealFSContext(1000, 1000)
+	setCurrentFH(ctx, fx.rootHandle) // target dir
+	setSavedFH(ctx, fx.rootHandle)   // source dir
+
+	result := fx.handler.handleRename(ctx, bytes.NewReader(encodeRenameArgs("incoming.bin", "victim.bin")))
+	if result.Status != types.NFS4_OK {
+		t.Fatalf("RENAME status = %d, want NFS4_OK", result.Status)
+	}
+
+	if size, ok := fx.localStore.FileSize(ctxBg, victimPayload); ok {
+		t.Fatalf("clobbered payload %q still holds %d live bytes in the local tier after RENAME", victimPayload, size)
+	}
+	if _, ok := fx.localStore.FileSize(ctxBg, survivorPayload); !ok {
+		t.Fatalf("renamed file's payload %q was dropped from the local tier by RENAME", survivorPayload)
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/rename.go
+++ b/internal/adapter/nfs/v4/handlers/rename.go
@@ -165,9 +165,9 @@ func (h *Handler) handleRename(ctx *types.CompoundContext, reader io.Reader) *ty
 		}
 	}
 
-	// Renaming onto an existing name silently unlinked whatever was there.
-	// Best-effort: the rename has already committed and the client has its
-	// answer, so a failure to free the victim's bytes is logged, not surfaced.
+	// Free the bytes of whatever this rename renamed over. The rename is
+	// already committed and the client has its answer, so a failure to release
+	// them is logged rather than surfaced.
 	if relErr := common.ReleaseClobberedPayload(ctx.Context, h.Registry, tgtDirHandle, clobbered); relErr != nil {
 		logger.Warn("NFSv4 RENAME: failed to delete clobbered content",
 			"newname", newName,

--- a/internal/adapter/nfs/v4/handlers/rename.go
+++ b/internal/adapter/nfs/v4/handlers/rename.go
@@ -149,7 +149,7 @@ func (h *Handler) handleRename(ctx *types.CompoundContext, reader io.Reader) *ty
 	tgtBeforeCtime := uint64(tgtDirFile.Ctime.UnixNano())
 
 	// Perform the rename: Move(fromDir, fromName, toDir, toName)
-	_, renameErr := metaSvc.Move(authCtx, srcDirHandle, oldName, tgtDirHandle, newName)
+	clobbered, _, renameErr := metaSvc.Move(authCtx, srcDirHandle, oldName, tgtDirHandle, newName)
 	if renameErr != nil {
 		status := common.MapToNFS4(renameErr)
 		logger.Debug("NFSv4 RENAME failed",
@@ -163,6 +163,16 @@ func (h *Handler) handleRename(ctx *types.CompoundContext, reader io.Reader) *ty
 			OpCode: types.OP_RENAME,
 			Data:   encodeStatusOnly(status),
 		}
+	}
+
+	// Renaming onto an existing name silently unlinked whatever was there.
+	// Best-effort: the rename has already committed and the client has its
+	// answer, so a failure to free the victim's bytes is logged, not surfaced.
+	if relErr := common.ReleaseClobberedPayload(ctx.Context, h.Registry, tgtDirHandle, clobbered); relErr != nil {
+		logger.Warn("NFSv4 RENAME: failed to delete clobbered content",
+			"newname", newName,
+			"payload_id", clobbered.PayloadID,
+			"error", relErr)
 	}
 
 	// Get post-operation attributes for both directories

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -1221,10 +1221,9 @@ func (h *Handler) setFileInfoFromStore(
 
 		restoreChangeTime()
 
-		// ReplaceIfExists renames over an existing name, which silently unlinks
-		// it. The pre-remove above only fires for a case-mismatched
-		// destination, so an exact-case overwrite reaches Move's clobber path
-		// and its victim's bytes are released here.
+		// The pre-remove above only fires for a case-mismatched destination, so
+		// an exact-case ReplaceIfExists overwrite reaches Move's own clobber
+		// path instead, and its victim's bytes are released here.
 		if clobbered != nil {
 			h.purgeBlockStorePayload(ctx.Context, toDir, clobbered.PayloadID, toName, "SET_INFO rename")
 		}

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -768,7 +768,8 @@ func (h *Handler) setFileInfoFromStore(
 			metaSvc := h.Registry.GetMetadataService()
 			restoreChangeTime := h.snapshotChangeTime(authCtx, openFile.MetadataHandle)
 
-			_, err = metaSvc.Move(authCtx, toDir, oldFileName, toDir, toName)
+			var clobberedStream *metadata.File
+			clobberedStream, _, err = metaSvc.Move(authCtx, toDir, oldFileName, toDir, toName)
 			if err != nil {
 				logger.Debug("SET_INFO: stream rename failed",
 					"from", oldFileName,
@@ -778,6 +779,12 @@ func (h *Handler) setFileInfoFromStore(
 			}
 
 			restoreChangeTime()
+
+			// Renaming a stream onto an existing stream name unlinks the
+			// stream that was there; free its content.
+			if clobberedStream != nil {
+				h.purgeBlockStorePayload(ctx.Context, toDir, clobberedStream.PayloadID, toName, "SET_INFO stream rename")
+			}
 
 			// Move's LastChangeTime stamp is an automatic update, so a
 			// timestamp frozen on this handle has to be put back the same way
@@ -1184,10 +1191,16 @@ func (h *Handler) setFileInfoFromStore(
 		// sibling entry. Remove the matched-case destination upfront so Move
 		// inserts the source under the client-requested casing.
 		if isOverwrite && dstMatchedName != "" && dstMatchedName != toName {
-			if _, _, rmErr := metaSvc.RemoveFile(authCtx, toDir, dstMatchedName); rmErr != nil {
+			removed, _, rmErr := metaSvc.RemoveFile(authCtx, toDir, dstMatchedName)
+			if rmErr != nil {
 				logger.Debug("SET_INFO: rename overwrite pre-remove failed",
 					"name", dstMatchedName, "error", rmErr)
 				return setInfoStatus(common.MapToSMB(rmErr)), nil
+			}
+			// RemoveFile drops the name and the inode but never the bytes; its
+			// PayloadID is empty whenever the content must survive.
+			if removed != nil {
+				h.purgeBlockStorePayload(ctx.Context, toDir, removed.PayloadID, dstMatchedName, "SET_INFO rename overwrite")
 			}
 		}
 
@@ -1196,7 +1209,8 @@ func (h *Handler) setFileInfoFromStore(
 		// CREATE, so put the pre-rename value back.
 		restoreChangeTime := h.snapshotChangeTime(authCtx, openFile.MetadataHandle)
 
-		_, err = metaSvc.Move(authCtx, srcParentHandle, oldFileName, toDir, toName)
+		var clobbered *metadata.File
+		clobbered, _, err = metaSvc.Move(authCtx, srcParentHandle, oldFileName, toDir, toName)
 		if err != nil {
 			logger.Debug("SET_INFO: rename failed",
 				"from", openFile.Name().Path,
@@ -1206,6 +1220,14 @@ func (h *Handler) setFileInfoFromStore(
 		}
 
 		restoreChangeTime()
+
+		// ReplaceIfExists renames over an existing name, which silently unlinks
+		// it. The pre-remove above only fires for a case-mismatched
+		// destination, so an exact-case overwrite reaches Move's clobber path
+		// and its victim's bytes are released here.
+		if clobbered != nil {
+			h.purgeBlockStorePayload(ctx.Context, toDir, clobbered.PayloadID, toName, "SET_INFO rename")
+		}
 
 		// Move's LastChangeTime stamp is an automatic update, so a timestamp
 		// frozen on this handle has to be put back the same way WRITE and

--- a/pkg/controlplane/runtime/trash/service.go
+++ b/pkg/controlplane/runtime/trash/service.go
@@ -326,7 +326,7 @@ func (s *Service) Restore(ctx *metadata.AuthContext, shareName, binPath, dest st
 	}
 
 	// Move the entry out of the bin, then clear its deletion stamp in place.
-	if _, err := svc.Move(ctx, binSrcParent, binSrcName, destParent, destName); err != nil {
+	if _, _, err := svc.Move(ctx, binSrcParent, binSrcName, destParent, destName); err != nil {
 		return err
 	}
 	return clearStamp(ctx, svc, shareName, destParent, destName)

--- a/pkg/metadata/batcha_test.go
+++ b/pkg/metadata/batcha_test.go
@@ -36,7 +36,7 @@ func TestBatchA_Move_DescendantPathUpdate(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "/parent/child.txt", childBefore.Path)
 
-	_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "parent", fx.rootHandle, "renamed")
+	_, _, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "parent", fx.rootHandle, "renamed")
 	require.NoError(t, err, "rename of directory with children must succeed")
 
 	childAfter, err := fx.store.GetFile(ctx, childHandle)

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -602,32 +602,41 @@ func (s *Service) SetFileAttributes(ctx *AuthContext, handle FileHandle, attrs *
 }
 
 // Move moves or renames a file or directory atomically.
-func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, toDir FileHandle, toName string) (*RenameWcc, error) {
+//
+// POSIX rename silently unlinks an existing destination. The clobbered victim
+// is returned as the first result so the caller can coordinate content
+// deletion, the same contract RemoveFile carries: nil when the rename replaced
+// nothing (or replaced a directory, which owns no content), and a non-nil File
+// whose PayloadID is empty whenever the content must survive — a remaining hard
+// link, or a recycle into the trash bin. Move itself never touches the block
+// store; without this the victim's bytes stay indexed as live in the local tier
+// and no reclamation path can ever free them.
+func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, toDir FileHandle, toName string) (*File, *RenameWcc, error) {
 	store, err := s.storeForHandle(fromDir)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Validate names
 	if err := ValidateName(fromName); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if err := ValidateName(toName); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Same directory and same name - no-op (POSIX rename semantics)
 	if string(fromDir) == string(toDir) && fromName == toName {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	// Get source directory
 	srcDir, err := store.GetFile(ctx.Context, fromDir)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if srcDir.Type != FileTypeDirectory {
-		return nil, &StoreError{
+		return nil, nil, &StoreError{
 			Code:    ErrNotDirectory,
 			Message: "source parent is not a directory",
 		}
@@ -636,10 +645,10 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 	// Get destination directory
 	dstDir, err := store.GetFile(ctx.Context, toDir)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if dstDir.Type != FileTypeDirectory {
-		return nil, &StoreError{
+		return nil, nil, &StoreError{
 			Code:    ErrNotDirectory,
 			Message: "destination parent is not a directory",
 		}
@@ -648,30 +657,30 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 	// Validate destination path length (POSIX PATH_MAX compliance)
 	destPath := buildPath(dstDir.Path, toName)
 	if err := ValidatePath(destPath); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Check write permission on both directories
 	if err := s.checkWritePermission(ctx, fromDir); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if err := s.checkWritePermission(ctx, toDir); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Get source file
 	srcHandle, err := store.GetChild(ctx.Context, fromDir, fromName)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	srcFile, err := store.GetFile(ctx.Context, srcHandle)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Check sticky bit on source directory
 	if err := CheckStickyBitRestriction(ctx, &srcDir.FileAttr, &srcFile.FileAttr); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// POSIX: When moving a directory to a different parent from a sticky directory,
@@ -692,7 +701,7 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 				"reason", "caller does not own directory being moved",
 				"src_file_uid", srcFile.UID,
 				"caller_uid", callerUID)
-			return nil, &StoreError{
+			return nil, nil, &StoreError{
 				Code:    ErrAccessDenied,
 				Message: "sticky bit set: cannot move directory you don't own to different parent",
 			}
@@ -707,18 +716,18 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 		// Destination exists - check compatibility
 		dstFile, err = store.GetFile(ctx.Context, dstHandle)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		// Check sticky bit on destination directory
 		if err := CheckStickyBitRestriction(ctx, &dstDir.FileAttr, &dstFile.FileAttr); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		// Type compatibility checks
 		if srcFile.Type == FileTypeDirectory {
 			if dstFile.Type != FileTypeDirectory {
-				return nil, &StoreError{
+				return nil, nil, &StoreError{
 					Code:    ErrNotDirectory,
 					Message: "cannot overwrite non-directory with directory",
 				}
@@ -726,14 +735,14 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 			// Check if destination directory is empty
 			entries, _, err := store.ListChildren(ctx.Context, dstHandle, "", 1, NamesOnly)
 			if err == nil && len(entries) > 0 {
-				return nil, &StoreError{
+				return nil, nil, &StoreError{
 					Code:    ErrNotEmpty,
 					Message: "destination directory not empty",
 				}
 			}
 		} else {
 			if dstFile.Type == FileTypeDirectory {
-				return nil, &StoreError{
+				return nil, nil, &StoreError{
 					Code:    ErrIsDirectory,
 					Message: "cannot overwrite directory with non-directory",
 				}
@@ -761,7 +770,7 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 						// into #recycle (the reaper frees its blocks later), so we
 						// have no blocks to release here.
 						if _, err := s.recycleNode(ctx, shareName, toDir, toName, victimRel); err != nil {
-							return nil, err // never silently clobber
+							return nil, nil, err // never silently clobber
 						}
 						// The victim has moved into #recycle, so the destination
 						// name is now free. Drop the cached dest-exists state so
@@ -774,7 +783,7 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 			}
 		}
 	} else if !IsNotFoundError(err) {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// rename carries the source/destination directory pre/post attributes for
@@ -804,6 +813,9 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 	// so this is pure namespace. A crash can lose the rename (old name
 	// persists), never corrupt data.
 	now := time.Now()
+	// Link count the clobbered destination is left with, written by the
+	// transaction below. Only meaningful when a non-directory victim exists.
+	var clobberedNlink uint32
 	txErr := withRelaxedTransaction(store, ctx.Context, func(tx Transaction) error {
 		// The GetChild lookups above ran outside this transaction and are
 		// advisory only: no lock covers a file rename, so a concurrent rename
@@ -882,6 +894,12 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 				if err := tx.SetLinkCount(ctx.Context, dstHandle, newCount); err != nil {
 					return err
 				}
+				// Record what the victim ends up with so the post-commit
+				// return value reports content ownership from the count the
+				// transaction actually wrote. Assigned unconditionally: an
+				// optimistic backend may run this closure more than once, and
+				// only the committing attempt's value must survive.
+				clobberedNlink = newCount
 				// Update ctime on the file being unlinked (affects remaining hard links)
 				dstFile.Ctime = now
 				if err := tx.UpdateAttrs(ctx.Context, dstFile); err != nil {
@@ -957,7 +975,26 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 	})
 
 	if txErr != nil {
-		return nil, txErr
+		return nil, nil, txErr
+	}
+
+	// Report the clobbered victim, if the rename replaced a file. Directories
+	// own no content, and dstFile is nil both when the destination was absent
+	// and when trash recycled it above, so neither case reports one. The
+	// PayloadID contract mirrors RemoveFile: empty means the content must
+	// survive because another hard link still references it.
+	var clobbered *File
+	if dstFile != nil && dstFile.Type != FileTypeDirectory {
+		clobbered = &File{
+			ID:        dstFile.ID,
+			ShareName: dstFile.ShareName,
+			Path:      dstFile.Path,
+			FileAttr:  *CopyFileAttr(&dstFile.FileAttr),
+		}
+		clobbered.Nlink = clobberedNlink
+		if clobberedNlink > 0 {
+			clobbered.PayloadID = ""
+		}
 	}
 
 	// Coalesce the parent directory mtime/ctime bumps out of the transaction so
@@ -982,7 +1019,7 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 		s.notifyDirChange(shareNameForHandle(toDir), toDir, lock.DirChangeAddEntry, ctx)
 	}
 
-	return rename, nil
+	return clobbered, rename, nil
 }
 
 // MarkFileAsOrphaned sets a file's link count to 0, marking it as orphaned.

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -603,14 +603,13 @@ func (s *Service) SetFileAttributes(ctx *AuthContext, handle FileHandle, attrs *
 
 // Move moves or renames a file or directory atomically.
 //
-// POSIX rename silently unlinks an existing destination. The clobbered victim
-// is returned as the first result so the caller can coordinate content
-// deletion, the same contract RemoveFile carries: nil when the rename replaced
-// nothing (or replaced a directory, which owns no content), and a non-nil File
-// whose PayloadID is empty whenever the content must survive — a remaining hard
-// link, or a recycle into the trash bin. Move itself never touches the block
-// store; without this the victim's bytes stay indexed as live in the local tier
-// and no reclamation path can ever free them.
+// POSIX rename silently unlinks an existing destination, and Move never
+// touches the block store. The clobbered victim is returned as the first
+// result so the caller can coordinate content deletion, the same contract
+// RemoveFile carries: nil when the rename replaced nothing (or replaced a
+// directory, which owns no content), and a non-nil File whose PayloadID is
+// empty whenever the content must survive — a remaining hard link, or a
+// recycle into the trash bin.
 func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, toDir FileHandle, toName string) (*File, *RenameWcc, error) {
 	store, err := s.storeForHandle(fromDir)
 	if err != nil {
@@ -813,8 +812,8 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 	// so this is pure namespace. A crash can lose the rename (old name
 	// persists), never corrupt data.
 	now := time.Now()
-	// Link count the clobbered destination is left with, written by the
-	// transaction below. Only meaningful when a non-directory victim exists.
+	// Link count the transaction below leaves the clobbered destination with.
+	// Only meaningful when a non-directory victim exists.
 	var clobberedNlink uint32
 	txErr := withRelaxedTransaction(store, ctx.Context, func(tx Transaction) error {
 		// The GetChild lookups above ran outside this transaction and are
@@ -894,11 +893,10 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 				if err := tx.SetLinkCount(ctx.Context, dstHandle, newCount); err != nil {
 					return err
 				}
-				// Record what the victim ends up with so the post-commit
-				// return value reports content ownership from the count the
-				// transaction actually wrote. Assigned unconditionally: an
-				// optimistic backend may run this closure more than once, and
-				// only the committing attempt's value must survive.
+				// Report content ownership from the count actually written.
+				// Assigned unconditionally: an optimistic backend may run this
+				// closure more than once, and only the committing attempt's
+				// value must survive.
 				clobberedNlink = newCount
 				// Update ctime on the file being unlinked (affects remaining hard links)
 				dstFile.Ctime = now
@@ -980,21 +978,18 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 
 	// Report the clobbered victim, if the rename replaced a file. Directories
 	// own no content, and dstFile is nil both when the destination was absent
-	// and when trash recycled it above, so neither case reports one. The
-	// PayloadID contract mirrors RemoveFile: empty means the content must
-	// survive because another hard link still references it.
+	// and when trash recycled it above, so neither case reports one.
 	var clobbered *File
 	if dstFile != nil && dstFile.Type != FileTypeDirectory {
-		clobbered = &File{
-			ID:        dstFile.ID,
-			ShareName: dstFile.ShareName,
-			Path:      dstFile.Path,
-			FileAttr:  *CopyFileAttr(&dstFile.FileAttr),
-		}
-		clobbered.Nlink = clobberedNlink
+		victim := *dstFile
+		victim.FileAttr = *CopyFileAttr(&dstFile.FileAttr)
+		victim.Nlink = clobberedNlink
 		if clobberedNlink > 0 {
-			clobbered.PayloadID = ""
+			// Another hard link still references the content, so it must
+			// survive. An empty PayloadID is how RemoveFile says that too.
+			victim.PayloadID = ""
 		}
+		clobbered = &victim
 	}
 
 	// Coalesce the parent directory mtime/ctime bumps out of the transaction so

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -606,10 +606,10 @@ func (s *Service) SetFileAttributes(ctx *AuthContext, handle FileHandle, attrs *
 // POSIX rename silently unlinks an existing destination, and Move never
 // touches the block store. The clobbered victim is returned as the first
 // result so the caller can coordinate content deletion, the same contract
-// RemoveFile carries: nil when the rename replaced nothing (or replaced a
-// directory, which owns no content), and a non-nil File whose PayloadID is
-// empty whenever the content must survive — a remaining hard link, or a
-// recycle into the trash bin.
+// RemoveFile carries: nil when the rename replaced nothing, replaced a
+// directory (which owns no content), or recycled the victim into the trash bin
+// rather than destroying it; and a non-nil File whose PayloadID is empty when
+// a remaining hard link means the content must survive.
 func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, toDir FileHandle, toName string) (*File, *RenameWcc, error) {
 	store, err := s.storeForHandle(fromDir)
 	if err != nil {

--- a/pkg/metadata/file_modify_test.go
+++ b/pkg/metadata/file_modify_test.go
@@ -43,7 +43,7 @@ func TestMove_UpdatesFilePath(t *testing.T) {
 	assert.Equal(t, "/myfile.txt", file.Path)
 
 	// Move file to dest directory
-	_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "myfile.txt", destHandle, "moved.txt")
+	_, _, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "myfile.txt", destHandle, "moved.txt")
 	require.NoError(t, err)
 
 	// Verify path updated in store
@@ -72,7 +72,7 @@ func TestMove_UpdatesDirectoryPath(t *testing.T) {
 	assert.Equal(t, "/olddir", dir.Path)
 
 	// Rename directory
-	_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "olddir", fx.rootHandle, "newdir")
+	_, _, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "olddir", fx.rootHandle, "newdir")
 	require.NoError(t, err)
 
 	// Verify path updated in store
@@ -137,7 +137,7 @@ func TestMove_UpdatesDescendantPaths(t *testing.T) {
 	assert.Equal(t, "/a/b/c/file.txt", leafFile.Path)
 
 	// Rename /a to /x
-	_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "a", fx.rootHandle, "x")
+	_, _, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "a", fx.rootHandle, "x")
 	require.NoError(t, err)
 
 	// Verify all paths updated recursively
@@ -178,7 +178,7 @@ func TestMove_SameDirectoryRename(t *testing.T) {
 	assert.Equal(t, "/old.txt", file.Path)
 
 	// Rename within same directory
-	_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "old.txt", fx.rootHandle, "new.txt")
+	_, _, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "old.txt", fx.rootHandle, "new.txt")
 	require.NoError(t, err)
 
 	// Verify path updated
@@ -207,7 +207,7 @@ func TestMove_EmptyDirectoryRename(t *testing.T) {
 	assert.Equal(t, "/empty", dir.Path)
 
 	// Rename empty directory
-	_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "empty", fx.rootHandle, "renamed")
+	_, _, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "empty", fx.rootHandle, "renamed")
 	require.NoError(t, err)
 
 	// Verify path updated (no children to traverse)

--- a/pkg/metadata/file_recycle.go
+++ b/pkg/metadata/file_recycle.go
@@ -103,7 +103,7 @@ func (s *Service) recycleNode(ctx *AuthContext, shareName string, parentHandle F
 	//    a directory moves its whole subtree as one entry). If this fails, the
 	//    source is still live but marked-deleted: clear the stamp best-effort so
 	//    a live file is not left looking recycled, then surface the move error.
-	if _, err := s.Move(ctx, parentHandle, name, destParent, destName); err != nil {
+	if _, _, err := s.Move(ctx, parentHandle, name, destParent, destName); err != nil {
 		if clearErr := s.clearRecycleStamp(ctx, victimHandle); clearErr != nil {
 			return nil, &StoreError{
 				Code:    ErrIOError,

--- a/pkg/metadata/file_recycle_test.go
+++ b/pkg/metadata/file_recycle_test.go
@@ -212,7 +212,7 @@ func TestRemoveFile_RecyclesWhenTrashEnabled(t *testing.T) {
 		require.NoError(t, err)
 
 		// Rename "b" onto "a" — an overwrite. The old "a" must be recycled.
-		_, mvErr := fx.service.Move(fx.rootContext(), fx.rootHandle, "b", fx.rootHandle, "a")
+		_, _, mvErr := fx.service.Move(fx.rootContext(), fx.rootHandle, "b", fx.rootHandle, "a")
 		require.NoError(t, mvErr)
 
 		// Source "b" is gone.
@@ -244,7 +244,7 @@ func TestRemoveFile_RecyclesWhenTrashEnabled(t *testing.T) {
 		require.NoError(t, err)
 
 		// "c" does not exist: a plain rename must not touch the bin.
-		_, mvErr := fx.service.Move(fx.rootContext(), fx.rootHandle, "b", fx.rootHandle, "c")
+		_, _, mvErr := fx.service.Move(fx.rootContext(), fx.rootHandle, "b", fx.rootHandle, "c")
 		require.NoError(t, mvErr)
 
 		_, err = fx.service.Lookup(fx.rootContext(), fx.rootHandle, "c")

--- a/pkg/metadata/parent_nlink_contention_test.go
+++ b/pkg/metadata/parent_nlink_contention_test.go
@@ -146,7 +146,7 @@ func TestConcurrentDirRenameNoParentLinkConflict(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			name := fmt.Sprintf("c-%d", i)
-			_, err := svc.Move(auth, fromHandle, name, toHandle, name)
+			_, _, err := svc.Move(auth, fromHandle, name, toHandle, name)
 			switch {
 			case err == nil:
 				atomic.AddInt64(&ok, 1)

--- a/pkg/metadata/service_extended_test.go
+++ b/pkg/metadata/service_extended_test.go
@@ -361,7 +361,7 @@ func TestMetadataService_Move_Extended(t *testing.T) {
 		require.NoError(t, err)
 
 		// Rename it
-		_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "original.txt", fx.rootHandle, "renamed.txt")
+		_, _, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "original.txt", fx.rootHandle, "renamed.txt")
 
 		require.NoError(t, err)
 
@@ -395,7 +395,7 @@ func TestMetadataService_Move_Extended(t *testing.T) {
 		require.NoError(t, err)
 
 		// Move file
-		_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "moveme.txt", destHandle, "moved.txt")
+		_, _, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "moveme.txt", destHandle, "moved.txt")
 
 		require.NoError(t, err)
 
@@ -428,7 +428,7 @@ func TestMetadataService_Move_Extended(t *testing.T) {
 		require.NoError(t, err)
 
 		// Move (overwrite)
-		_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "source.txt", fx.rootHandle, "dest.txt")
+		_, _, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "source.txt", fx.rootHandle, "dest.txt")
 
 		require.NoError(t, err)
 
@@ -453,7 +453,7 @@ func TestMetadataService_Move_Extended(t *testing.T) {
 		require.NoError(t, err)
 
 		// Rename directory
-		_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "srcdir", fx.rootHandle, "newdir")
+		_, _, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "srcdir", fx.rootHandle, "newdir")
 
 		require.NoError(t, err)
 
@@ -477,7 +477,7 @@ func TestMetadataService_Move_Extended(t *testing.T) {
 		require.NoError(t, err)
 
 		// Move to same location
-		_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "same.txt", fx.rootHandle, "same.txt")
+		_, _, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "same.txt", fx.rootHandle, "same.txt")
 
 		require.NoError(t, err)
 
@@ -503,7 +503,7 @@ func TestMetadataService_Move_Extended(t *testing.T) {
 		require.NoError(t, err)
 
 		// Try to move file over directory
-		_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "file.txt", fx.rootHandle, "dir")
+		_, _, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "file.txt", fx.rootHandle, "dir")
 
 		require.Error(t, err)
 	})
@@ -525,7 +525,7 @@ func TestMetadataService_Move_Extended(t *testing.T) {
 		require.NoError(t, err)
 
 		// Try to move directory over file
-		_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "srcdir", fx.rootHandle, "destfile.txt")
+		_, _, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "srcdir", fx.rootHandle, "destfile.txt")
 
 		require.Error(t, err)
 	})

--- a/pkg/metadata/service_test.go
+++ b/pkg/metadata/service_test.go
@@ -931,7 +931,7 @@ func TestMetadataService_Move(t *testing.T) {
 		require.NoError(t, err)
 
 		// Rename it
-		_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "old.txt", fx.rootHandle, "new.txt")
+		_, _, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "old.txt", fx.rootHandle, "new.txt")
 
 		require.NoError(t, err)
 
@@ -955,7 +955,7 @@ func TestMetadataService_Move(t *testing.T) {
 		require.NoError(t, err)
 
 		// Move to same name
-		_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "test.txt", fx.rootHandle, "test.txt")
+		_, _, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "test.txt", fx.rootHandle, "test.txt")
 
 		require.NoError(t, err)
 
@@ -990,7 +990,7 @@ func TestMetadataService_Move(t *testing.T) {
 		require.NoError(t, err)
 
 		// Move to destination
-		_, err = fx.service.Move(fx.rootContext(), srcDir, "test.txt", dstDir, "test.txt")
+		_, _, err = fx.service.Move(fx.rootContext(), srcDir, "test.txt", dstDir, "test.txt")
 
 		require.NoError(t, err)
 
@@ -1019,7 +1019,7 @@ func TestMetadataService_Move(t *testing.T) {
 		require.NoError(t, err)
 
 		// Try to move directory over file
-		_, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "dir", fx.rootHandle, "file.txt")
+		_, _, err = fx.service.Move(fx.rootContext(), fx.rootHandle, "dir", fx.rootHandle, "file.txt")
 
 		require.Error(t, err)
 		var storeErr *metadata.StoreError
@@ -1068,7 +1068,7 @@ func TestMetadataService_Move(t *testing.T) {
 		// - User 65534 does not own the file (file owned by UID 0)
 		// - User 65534 does not own the directory (dir owned by UID 0)
 		nobodyCtx := fx.authContext(65534, 65534)
-		_, err = fx.service.Move(nobodyCtx, stickyDirHandle, "rootfile.txt", destDirHandle, "renamed.txt")
+		_, _, err = fx.service.Move(nobodyCtx, stickyDirHandle, "rootfile.txt", destDirHandle, "renamed.txt")
 
 		// Should return ErrAccessDenied
 		require.Error(t, err, "rename should fail due to sticky bit restriction")
@@ -1116,7 +1116,7 @@ func TestMetadataService_Move(t *testing.T) {
 		require.NoError(t, err)
 
 		// User 65534 should be able to rename their own file
-		_, err = fx.service.Move(userCtx, stickyDirHandle, "myfile.txt", destDirHandle, "renamed.txt")
+		_, _, err = fx.service.Move(userCtx, stickyDirHandle, "myfile.txt", destDirHandle, "renamed.txt")
 		require.NoError(t, err, "owner should be able to rename their own file despite sticky bit")
 	})
 }

--- a/pkg/metadata/storetest/trash_conformance.go
+++ b/pkg/metadata/storetest/trash_conformance.go
@@ -336,7 +336,7 @@ func testOverwriteRecyclesVictim(t *testing.T, factory StoreFactory) {
 	fx.trashCreateFile(t, fx.rootHandle, "b", modeB)
 
 	// Rename "b" onto "a" — an overwrite that recycles the old "a".
-	if _, err := fx.svc.Move(fx.ctx, fx.rootHandle, "b", fx.rootHandle, "a"); err != nil {
+	if _, _, err := fx.svc.Move(fx.ctx, fx.rootHandle, "b", fx.rootHandle, "a"); err != nil {
 		t.Fatalf("Move(b -> a) failed: %v", err)
 	}
 

--- a/pkg/metadata/tx_integrity_test.go
+++ b/pkg/metadata/tx_integrity_test.go
@@ -237,7 +237,7 @@ func TestMove_RollsBackOnPutFileFailure(t *testing.T) {
 	fx.faulty.failID = srcID
 
 	// The move must fail with the injected error.
-	_, err = fx.svc.Move(fx.ctx, fx.root, "myfile.txt", destHandle, "moved.txt")
+	_, _, err = fx.svc.Move(fx.ctx, fx.root, "myfile.txt", destHandle, "moved.txt")
 	require.ErrorIs(t, err, errPutFileInjected, "Move must surface the injected UpdateAttrs failure, not swallow it")
 
 	// Full rollback: source still at its original name/path...
@@ -302,7 +302,7 @@ func TestMove_AbortsWhenSourceEntryChangedInTransaction(t *testing.T) {
 		return nil, nil, false
 	}
 
-	_, err = fx.svc.Move(fx.ctx, fx.root, "myfile.txt", fx.root, "moved.txt")
+	_, _, err = fx.svc.Move(fx.ctx, fx.root, "myfile.txt", fx.root, "moved.txt")
 	require.Error(t, err, "Move must abort when the source entry changed inside the transaction")
 
 	// The destination name was never created.
@@ -338,7 +338,7 @@ func TestMove_AbortsWhenDestinationAppearedInTransaction(t *testing.T) {
 		return nil, nil, false
 	}
 
-	_, err = fx.svc.Move(fx.ctx, fx.root, "myfile.txt", fx.root, "moved.txt")
+	_, _, err = fx.svc.Move(fx.ctx, fx.root, "myfile.txt", fx.root, "moved.txt")
 	require.Error(t, err, "Move must abort when the destination appeared inside the transaction")
 	var storeErr *metadata.StoreError
 	require.ErrorAs(t, err, &storeErr)

--- a/pkg/metadata/wcc_contract_test.go
+++ b/pkg/metadata/wcc_contract_test.go
@@ -141,7 +141,7 @@ func TestWCC_Move_ReturnsBothDirAttrs(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	rw, err := fx.service.Move(fx.rootContext(), srcDir, "f.txt", dstDir, "f.txt")
+	_, rw, err := fx.service.Move(fx.rootContext(), srcDir, "f.txt", dstDir, "f.txt")
 	require.NoError(t, err)
 	require.NotNil(t, rw)
 	assertBracketsMutation(t, rw.FromDir)
@@ -156,7 +156,7 @@ func TestWCC_Move_SameDirectorySharesDirWcc(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	rw, err := fx.service.Move(fx.rootContext(), fx.rootHandle, "a.txt", fx.rootHandle, "b.txt")
+	_, rw, err := fx.service.Move(fx.rootContext(), fx.rootHandle, "a.txt", fx.rootHandle, "b.txt")
 	require.NoError(t, err)
 	require.NotNil(t, rw)
 	assert.Same(t, rw.FromDir, rw.ToDir, "intra-directory move must share one DirWcc")


### PR DESCRIPTION
## What was wrong

POSIX rename onto an existing name silently unlinks whatever was there. `metadata.Service.Move`
did that unlink inside its own transaction and returned only WCC data, so the clobbered file's
`PayloadID` never left the metadata layer:

```go
func (s *Service) Move(...) (*RenameWcc, error)
```

No adapter could call `blockStore.Delete` for the victim even if it wanted to. The victim's
records therefore stayed indexed as **live** in the per-share local tier, where no reclamation
path — fast-path retire, eviction, repack — can treat them as dead, and the bytes survived every
restart. Only the local tier was affected: remote block GC derives orphans from (synced − live)
in the metadata store, which the metadata unlink alone already drives.

Write-to-temp-then-rename is one of the most common write patterns there is, so this churns
steadily rather than being a corner case.

This is the same class as #2268 (fixed in #2286: a caller discarding a `PayloadID` the metadata
layer handed it), but it was not fixable the same way — there was nothing to discard yet.

## The issue's premise was partly wrong: SMB is not exempt

The issue reasoned that SMB is safe because it pre-deletes the destination. It does not, in
general. In `internal/adapter/smb/handlers/set_info.go` the pre-remove is gated on a *case
mismatch*:

```go
if isOverwrite && dstMatchedName != "" && dstMatchedName != toName {
    if _, _, rmErr := metaSvc.RemoveFile(authCtx, toDir, dstMatchedName); rmErr != nil {
```

An exact-case `ReplaceIfExists` rename — the overwhelmingly common case — skips that branch
entirely and reaches `Move`'s clobber path exactly like NFS does. And the branch that *does*
fire discarded `RemoveFile`'s returned file, so it leaked the payload too, in the #2268 shape.

Both SMB sites are fixed here. Stream rename (`foo.txt:a` → `foo.txt:b`) had the same exposure
and is fixed as well.

Trash-enabled shares really are exempt, as the issue says — `recycleNode` relocates the victim
instead of destroying it, and `Move` nils its destination snapshot on that path, so nothing is
released.

## The fix

`Move` now returns the clobbered victim, mirroring the contract `RemoveFile` has carried all
along:

```go
func (s *Service) Move(...) (*File, *RenameWcc, error)
```

`nil` when the rename replaced nothing, replaced a directory (which owns no content), or trash
recycled the victim. Non-nil with an empty `PayloadID` when a remaining hard link still
references the content. The link count the transaction actually wrote is captured inside the
closure, so the ownership decision comes from the committing attempt rather than from a read
taken outside it.

**No metadata store interface change was needed.** The victim's `PayloadID` was already read
outside the transaction (`store.GetFile(ctx, dstHandle)`), and the transaction aborts with
`ErrConflict` if the destination's identity changed under it, so that snapshot is guaranteed to
name the entry the transaction unlinked. No backend, and no `storetest` contract, gains a
method.

Adapters release the bytes through one shared seam, `common.ReleaseClobberedPayload`, modelled
on the existing `common.ReclaimTruncatedBlocks` — so a future protocol adapter cannot forget it
while another gets it right. Best-effort by contract: the metadata rename has already committed
and the client already has its answer, so a block-store failure is logged rather than surfaced,
consistent with every other release path.

## Verification

Two regression tests, both asserting the observable outcome — the victim's bytes actually leave
the local tier — rather than that a particular function was called. Each pins **both**
directions: the victim's payload must be gone AND the renamed file's payload must survive, so a
fix that releases the wrong payload fails instead of passing.

Both were run against a deliberately unfixed build first (the release call stubbed out, tests
kept):

```
--- FAIL: TestRename_ReclaimsClobberedPayloadBytes (0.65s)
    io_test.go:1729: clobbered payload "export/e9d8ed0d-36df-47ec-82df-6d110dd87984"
        still holds 4194304 live bytes in the local tier after RENAME

--- FAIL: TestRename_ReclaimsClobberedPayloadBytes (0.31s)
    rename_test.go:476: clobbered payload "export/fd48cc45-18b3-419a-bfdc-996d57009687"
        still holds 1048576 live bytes in the local tier after RENAME
```

and pass with the fix. `go build ./...`, `go vet ./...`, `go vet -tags integration ./...` and
`go test ./...` are all clean.

Closes #2287
