### PR TITLE
fix(block): route the carve block size to the loop that reads it

### DIFF
--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -280,7 +280,8 @@ shard internally. Carving a file FastCDC-chunks its dirty ranges (min 1 MiB /
 avg 4 MiB / max 16 MiB by default), BLAKE3-hashes each chunk, and — via the
 engine-supplied `BlockSink` — dedups against remote-durable chunks, seals each
 chunk (compression/encryption), frames the survivors into a packed block
-(~16 MiB, `BlockCarveBytes`), uploads the block with one `PutBlock`, and
+(4 MiB by default, `journal.Config.CarveBlockSize`, settable through
+`fs.FSStoreOptions`), uploads the block with one `PutBlock`, and
 commits the block record, per-chunk synced markers, and per-file FileChunk
 manifest rows in a single metadata transaction (`metadata.DefaultCommitBlock`).
 `PutBlock` runs before the commit, so a crash in between leaves an orphan block

--- a/pkg/block/engine/carve_fixture_test.go
+++ b/pkg/block/engine/carve_fixture_test.go
@@ -56,17 +56,23 @@ type carveFixture struct {
 	off    int64 // running write offset within carveFixturePayload
 }
 
+// defaultTestCarveBlockSize is the pack size a fixture takes when the test does
+// not care: the journal's own default, so a fixture built with it behaves the
+// same as a share built from a config that names no size.
+const defaultTestCarveBlockSize int64 = 4 << 20
+
 func newCarveFixture(t *testing.T, rbs remote.RemoteStore, carveBytes int64) *carveFixture {
 	t.Helper()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
-	local, err := fs.NewWithOptions(t.TempDir(), 0, ms, fs.FSStoreOptions{})
+	// carveBytes reaches the carve loop through the local store: the journal owns
+	// the loop, so this is the only route to it.
+	local, err := fs.NewWithOptions(t.TempDir(), 0, ms, fs.FSStoreOptions{CarveBlockSize: carveBytes})
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions: %v", err)
 	}
 	t.Cleanup(func() { _ = local.Close() })
 
 	cfg := DefaultConfig()
-	cfg.BlockCarveBytes = carveBytes
 	cfg.ManualSync = true // explicit carve only; no background goroutine racing assertions
 
 	syncer := NewSyncer(local, rbs, ms, cfg)
@@ -147,3 +153,56 @@ var (
 	_ remote.RemoteBlockStore = (*latencyRemote)(nil)
 	_ remote.ChunkReader      = (*latencyRemote)(nil)
 )
+
+// TestCarveBlockSizeReachesTheCarveLoop pins the wiring the fixture's carveBytes
+// parameter depends on: the size travels FSStoreOptions -> journal.Config, and
+// nothing in the engine's syncer config has a say in it. Without the wiring both
+// sizes carve at the journal default and the block counts match.
+func TestCarveBlockSizeReachesTheCarveLoop(t *testing.T) {
+	const payloadSize = 8 << 20
+
+	carveInto := func(t *testing.T, blockSize int64) int {
+		t.Helper()
+		ctx := context.Background()
+		mem := remotememory.New()
+		mem.SetDurable(true)
+		fx := newCarveFixture(t, mem, blockSize)
+		bs, err := New(BlockStoreConfig{
+			Local:           fx.local,
+			Remote:          mem,
+			Syncer:          fx.syncer,
+			FileChunkStore:  fx.ms,
+			SyncedHashStore: fx.ms,
+		})
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		t.Cleanup(func() { _ = bs.Close() })
+		bs.SetRequireDurableCommit(true)
+
+		buf := make([]byte, 64<<10)
+		for i := range buf {
+			buf[i] = byte(i)
+		}
+		for written := 0; written < payloadSize; written += len(buf) {
+			// Vary the bytes so dedup does not collapse the writes into one chunk.
+			buf[0] = byte(written >> 16)
+			buf[1] = byte(written >> 8)
+			fx.storeChunk(t, ctx, buf)
+		}
+		if _, err := bs.Flush(ctx, carveFixturePayload); err != nil {
+			t.Fatalf("Flush(blockSize=%d): %v", blockSize, err)
+		}
+		return countRemoteBlocks(t, ctx, mem)
+	}
+
+	small := carveInto(t, 1<<20)
+	large := carveInto(t, 16<<20)
+	if small <= large {
+		t.Fatalf("a 1 MiB block size must produce more blocks for the same %d bytes than a 16 MiB one: got %d vs %d",
+			payloadSize, small, large)
+	}
+	if large != 1 {
+		t.Errorf("a 16 MiB block size should pack %d bytes into one block, got %d", payloadSize, large)
+	}
+}

--- a/pkg/block/engine/durability_test.go
+++ b/pkg/block/engine/durability_test.go
@@ -24,7 +24,7 @@ func TestEngine_Flush_DurableLocalDefault_NoSyncRemote(t *testing.T) {
 		ctx := context.Background()
 		mem := remotememory.New()
 		mem.SetDurable(true)
-		fx := newCarveFixture(t, mem, DefaultBlockCarveBytes) // durable fs local, ManualSync, wired carve
+		fx := newCarveFixture(t, mem, defaultTestCarveBlockSize) // durable fs local, ManualSync, wired carve
 		bs, err := New(BlockStoreConfig{
 			Local:           fx.local,
 			Remote:          mem,

--- a/pkg/block/engine/locator_fetch_test.go
+++ b/pkg/block/engine/locator_fetch_test.go
@@ -125,7 +125,7 @@ func TestDispatchRemoteFetch_SyncedStandaloneLocatorMissingFailsClosed(t *testin
 func TestDispatchRemoteFetch_CarvedChunkRoundTrip(t *testing.T) {
 	ctx := context.Background()
 	mem := remotememory.New()
-	f := newCarveFixture(t, mem, DefaultBlockCarveBytes)
+	f := newCarveFixture(t, mem, defaultTestCarveBlockSize)
 
 	data := bytes.Repeat([]byte("carved-round-trip-"), 512)
 	hash := f.storeChunk(t, ctx, data)

--- a/pkg/block/engine/read_path_test.go
+++ b/pkg/block/engine/read_path_test.go
@@ -19,7 +19,7 @@ import (
 func TestReadPath_BlockLocator_Plaintext(t *testing.T) {
 	ctx := context.Background()
 	mem := remotememory.New()
-	f := newCarveFixture(t, mem, DefaultBlockCarveBytes)
+	f := newCarveFixture(t, mem, defaultTestCarveBlockSize)
 
 	data := bytes.Repeat([]byte("read-path-plain-"), 512)
 	h := f.storeChunk(t, ctx, data)
@@ -54,7 +54,7 @@ func TestReadPath_BlockLocator_ThroughCompress(t *testing.T) {
 	if err != nil {
 		t.Fatalf("compression.NewRemote: %v", err)
 	}
-	f := newCarveFixture(t, dec, DefaultBlockCarveBytes)
+	f := newCarveFixture(t, dec, defaultTestCarveBlockSize)
 
 	data := bytes.Repeat([]byte("XXXX-YYYY-ZZZZ-"), 4096)
 	h := f.storeChunk(t, ctx, data)
@@ -93,7 +93,7 @@ func TestReadPath_BlockLocator_ThroughCompressEncrypt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("compression.NewRemote: %v", err)
 	}
-	f := newCarveFixture(t, dec, DefaultBlockCarveBytes)
+	f := newCarveFixture(t, dec, defaultTestCarveBlockSize)
 
 	data := bytes.Repeat([]byte("secret-read-path-"), 1024)
 	h := f.storeChunk(t, ctx, data)
@@ -126,7 +126,7 @@ func TestReadPath_BlockLocator_ThroughCompressEncrypt(t *testing.T) {
 func TestReadPath_StandaloneLocatorMissingEverywhere(t *testing.T) {
 	ctx := context.Background()
 	mem := remotememory.New()
-	f := newCarveFixture(t, mem, DefaultBlockCarveBytes)
+	f := newCarveFixture(t, mem, defaultTestCarveBlockSize)
 
 	// A standalone marker with no bytes anywhere (nothing planted on the remote,
 	// nothing stored locally).
@@ -149,7 +149,7 @@ func TestReadPath_StandaloneLocatorMissingEverywhere(t *testing.T) {
 func TestReadPath_CorruptBlock_FailClosed(t *testing.T) {
 	ctx := context.Background()
 	mem := remotememory.New()
-	f := newCarveFixture(t, mem, DefaultBlockCarveBytes)
+	f := newCarveFixture(t, mem, defaultTestCarveBlockSize)
 
 	data := bytes.Repeat([]byte("corrupt-check-data-"), 256)
 	h := f.storeChunk(t, ctx, data)

--- a/pkg/block/engine/types.go
+++ b/pkg/block/engine/types.go
@@ -20,11 +20,6 @@ var ErrStoreClosed = errors.New("engine: block store is closed")
 // With 200-connection S3 pool and 8MB blocks, 32 workers can saturate the pool.
 const DefaultParallelDownloads = 32
 
-// DefaultBlockCarveBytes is the default target size of a packed block object
-// (#1414): ~16 MiB. Large enough to amortize one PUT over many small chunks,
-// small enough to cap the carver's per-block RAM and keep ranged reads cheap.
-const DefaultBlockCarveBytes int64 = 16 << 20
-
 // Adaptive upload-concurrency bounds (#1407). When SyncerConfig.ParallelUploads
 // is unset (0), the carver auto-tunes concurrent block PUTs to saturate the
 // uplink: it starts at AdaptiveUploadFloor and ramps toward AdaptiveUploadCeiling,
@@ -92,14 +87,6 @@ type SyncerConfig struct {
 	UploadInterval     time.Duration // Periodic uploader scan interval (default: 2s)
 	UploadDelay        time.Duration // Min block age before periodic upload; Flush ignores this (default: 10s)
 
-	// BlockCarveBytes is the target size of a packed block object (#1414). The
-	// block carver accumulates synced-pending log-blob chunks and seals one
-	// block once the accumulated raw bytes reach this threshold; a partial
-	// block is flushed on idle (after UploadDelay with no new chunk) or on an
-	// explicit Flush/SyncNow. <= 0 falls back to DefaultBlockCarveBytes. The
-	// carver buffers at most one block (this many bytes) in RAM at a time.
-	BlockCarveBytes int64
-
 	// ParallelUploads bounds concurrent block PUTs from the carver (#1407 /
 	// #1432). 0 (the default, AdaptiveUploadDefault) means the carver auto-tunes
 	// the window between AdaptiveUploadFloor and AdaptiveUploadCeiling to
@@ -148,7 +135,6 @@ func DefaultConfig() SyncerConfig {
 		SmallFileThreshold:          0,
 		UploadInterval:              2 * time.Second,
 		UploadDelay:                 10 * time.Second,
-		BlockCarveBytes:             DefaultBlockCarveBytes,
 		ParallelUploads:             AdaptiveUploadDefault,
 		DemandFetchTimeout:          DefaultDemandFetchTimeout,
 		HealthCheckInterval:         30 * time.Second,

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -32,6 +32,11 @@ type FSStoreOptions struct {
 	BackpressureMaxWait time.Duration
 	MaxLogBytes         int64
 	ChunkParams         chunker.Params
+	// CarveBlockSize is the pack size the carver hands the remote store; see
+	// journal.Config.CarveBlockSize. Zero takes the journal default. This is
+	// the only route to it: the journal owns the carve loop, so the engine's
+	// syncer config has no say in it.
+	CarveBlockSize int64
 	// DirtyExpiry bounds how long a write may sit unfsynced; see
 	// journal.Config.DirtyExpiry. Zero takes the journal default, negative
 	// disables the loop.
@@ -150,10 +155,11 @@ func NewWithOptions(dir string, maxDisk int64, fileChunkStore block.EngineFileCh
 		}
 	}
 	cfg := journal.Config{
-		MaxLocalBytes: maxDisk,
-		EvictMaxWait:  opts.BackpressureMaxWait,
-		ChunkParams:   opts.ChunkParams,
-		DirtyExpiry:   opts.DirtyExpiry,
+		MaxLocalBytes:  maxDisk,
+		EvictMaxWait:   opts.BackpressureMaxWait,
+		ChunkParams:    opts.ChunkParams,
+		DirtyExpiry:    opts.DirtyExpiry,
+		CarveBlockSize: opts.CarveBlockSize,
 	}
 	// Check the format stamp before touching the journal: a directory a newer
 	// release wrote would otherwise read as holes wherever the newer format


### PR DESCRIPTION
Closes #2307. **Stacked on #2305** — base is `chore/delete-legacy-cas`, retarget to `develop` once that merges.

## Worse than the issue said

The issue reported one dead knob. There are two, and together they mean the documented block size has never been the real one.

- `engine.SyncerConfig.BlockCarveBytes` — eleven lines of documentation, `DefaultBlockCarveBytes = 16 MiB`, and after #2305 removes the migration repacker, **no reader at all**.
- `journal.Config.CarveBlockSize` — the field the carve loop actually consults (`journal/carve.go:600`) — is **never set in production either**. Every setter is a test, so `store.go:119` applies `defaultCarveBlockSize = 4 MiB` on every share.

So production has always packed at 4 MiB while the engine config, and `docs/internals/architecture.md:283`, both advertised ~16 MiB.

That is why deleting the field alone is not enough: it would leave block size unreachable from any caller.

## The fix

Delete the dead engine field and carry the size on `fs.FSStoreOptions`, which is the path that builds the journal config (`local/fs/fs.go:152`). The engine has no say in it — the journal owns the carve loop — and the comment on the new option says so, so the next reader does not go looking for an engine knob again.

Also corrects the architecture doc to name the field that exists and the size that runs.

## The fixture was lying

`newCarveFixture(t, remote, carveBytes)` documents "carveBytes sizes the block target" and set only the dead field. Six call sites pass `DefaultBlockCarveBytes` (16 MiB) and ran at 4 MiB. The parameter now reaches the journal; the call sites that do not care take a named `defaultTestCarveBlockSize` matching the journal default, so they behave as before rather than silently changing size.

## Test

`TestCarveBlockSizeReachesTheCarveLoop` carves 8 MiB at two block sizes and asserts the smaller produces more objects, and that 16 MiB packs it into one. Verified to **fail** with the wiring line removed — both sizes then carve at the journal default and report `2 vs 2`.

This matters beyond tidiness: the block-size branch in `.planning/2026-09-01-block-dataflow-MASTER-PLAN.md` picks a size by measurement, and a probe varying the engine knob would have measured nothing and reported flatness.

`go test ./pkg/block/...` green; golangci-lint 0 issues.