### PR TITLE
refactor(metadata): one root-directory body, and one meaning for it

### DIFF
--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -437,6 +437,13 @@ type FilesystemMeta struct {
 //
 // Thread Safety:
 // Implementations must be safe for concurrent use by multiple goroutines.
+// DefaultRootMode is the mode a share root gets when the caller configures
+// none. Every backend and every entry point must use this one value: creating
+// a root and reconciling an existing one both compare against it, so two
+// defaults would each rewrite what the other wrote and a share's root mode
+// would flip depending on which call happened last.
+const DefaultRootMode = 0o755
+
 type Store interface {
 	Files                      // File CRUD operations (non-transactional calls)
 	Shares                     // Share lifecycle and handle management

--- a/pkg/metadata/store/badger/shares.go
+++ b/pkg/metadata/store/badger/shares.go
@@ -378,7 +378,7 @@ func (s *BadgerMetadataStore) loadExistingRoot(txn *badgerdb.Txn, item *badgerdb
 	// reconcile a defaulted root down to mode 0 on the next call.
 	mode := attr.Mode
 	if mode == 0 {
-		mode = defaultRootMode
+		mode = metadata.DefaultRootMode
 	}
 
 	// Update attributes if config changed
@@ -428,7 +428,7 @@ func (s *BadgerMetadataStore) createNewRoot(txn *badgerdb.Txn, shareName string,
 
 	rootAttrCopy := *attr
 	if rootAttrCopy.Mode == 0 {
-		rootAttrCopy.Mode = defaultRootMode
+		rootAttrCopy.Mode = metadata.DefaultRootMode
 	}
 	now := time.Now()
 	if rootAttrCopy.Atime.IsZero() {
@@ -506,9 +506,3 @@ func (s *BadgerMetadataStore) createNewRoot(txn *badgerdb.Txn, shareName string,
 
 	return nil
 }
-
-// defaultRootMode is the mode a share root gets when the caller configures
-// none. Creation and reconciliation must agree on it: the reconcile compares a
-// stored mode against it, so a raw zero here would rewrite a defaulted root to
-// mode 0 the second time a share is attached.
-const defaultRootMode = 0o755

--- a/pkg/metadata/store/badger/shares.go
+++ b/pkg/metadata/store/badger/shares.go
@@ -273,18 +273,13 @@ func (s *BadgerMetadataStore) ListShares(ctx context.Context) ([]string, error) 
 	return names, err
 }
 
-// CreateRootDirectory creates or retrieves the root directory for a share.
+// CreateRootDirectory creates a share's root directory, or reconciles an
+// existing one (from a previous server run) against the configured attrs, so
+// metadata persists across restarts and a changed config still lands.
 //
-// If a root directory already exists (from a previous server run), it is returned.
-// Otherwise, a new root directory is created. This idempotent behavior ensures
-// metadata persists across server restarts.
-//
-// This one deliberately does NOT delegate to the transaction path the way the
-// rest of this file does: the existing-share branch here reconciles the stored
-// root inode against the configured attrs (loadExistingRoot diffs mode/UID/GID
-// and rewrites it), which the transaction path does not do. Delegating would
-// silently drop that reconciliation, so the two stay split until the
-// transaction path grows it.
+// This one does not delegate to the transaction path the way the rest of this
+// file does: the two share loadExistingRoot, but only this path drops the cache
+// entries a reconciliation invalidates (see below).
 func (s *BadgerMetadataStore) CreateRootDirectory(ctx context.Context, shareName string, attr *metadata.FileAttr) (*metadata.File, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -378,14 +373,22 @@ func (s *BadgerMetadataStore) loadExistingRoot(txn *badgerdb.Txn, item *badgerdb
 	// default of 2.
 	(*rootFile).Nlink = fileLinkCountTxn(txn, *rootFile)
 
+	// A zero configured mode means "use the default", the same as it does when
+	// the root is first created. Comparing against the raw zero instead would
+	// reconcile a defaulted root down to mode 0 on the next call.
+	mode := attr.Mode
+	if mode == 0 {
+		mode = defaultRootMode
+	}
+
 	// Update attributes if config changed
 	needsUpdate := false
-	if (*rootFile).Mode != attr.Mode {
+	if (*rootFile).Mode != mode {
 		logger.Info("Updating root directory mode from config",
 			"share", shareName,
 			"oldMode", fmt.Sprintf("%o", (*rootFile).Mode),
-			"newMode", fmt.Sprintf("%o", attr.Mode))
-		(*rootFile).Mode = attr.Mode
+			"newMode", fmt.Sprintf("%o", mode))
+		(*rootFile).Mode = mode
 		needsUpdate = true
 	}
 	if (*rootFile).UID != attr.UID {
@@ -425,7 +428,7 @@ func (s *BadgerMetadataStore) createNewRoot(txn *badgerdb.Txn, shareName string,
 
 	rootAttrCopy := *attr
 	if rootAttrCopy.Mode == 0 {
-		rootAttrCopy.Mode = 0755
+		rootAttrCopy.Mode = defaultRootMode
 	}
 	now := time.Now()
 	if rootAttrCopy.Atime.IsZero() {
@@ -503,3 +506,9 @@ func (s *BadgerMetadataStore) createNewRoot(txn *badgerdb.Txn, shareName string,
 
 	return nil
 }
+
+// defaultRootMode is the mode a share root gets when the caller configures
+// none. Creation and reconciliation must agree on it: the reconcile compares a
+// stored mode against it, so a raw zero here would rewrite a defaulted root to
+// mode 0 the second time a share is attached.
+const defaultRootMode = 0o755

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -1245,7 +1245,7 @@ func (tx *badgerTransaction) CreateRootDirectory(ctx context.Context, shareName 
 	// Create new root directory
 	rootAttrCopy := *attr
 	if rootAttrCopy.Mode == 0 {
-		rootAttrCopy.Mode = defaultRootMode
+		rootAttrCopy.Mode = metadata.DefaultRootMode
 	}
 	now := time.Now()
 	if rootAttrCopy.Atime.IsZero() {

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -1218,15 +1218,24 @@ func (tx *badgerTransaction) CreateRootDirectory(ctx context.Context, shareName 
 		}
 	}
 
-	// Check if the share already exists. An existing root is reconciled
-	// against the configured attrs by the same body the pool path uses, so
-	// whether an operator's config change lands does not depend on which of
-	// the two entry points reached it.
+	// An existing root is reconciled against the configured attrs by the same
+	// body the pool path uses, so whether a config change lands does not depend
+	// on which of the two entry points reached it.
 	item, err := tx.txn.Get(keyShare(shareName))
 	if err == nil {
 		var rootFile *metadata.File
 		if err := tx.store.loadExistingRoot(tx.txn, item, shareName, attr, &rootFile); err != nil {
 			return nil, err
+		}
+
+		// loadExistingRoot may rewrite the root inode to match the configured
+		// attrs, a write that does not go through the methods that record a
+		// dirty file — so record it here, or the commit leaves the pre-reconcile
+		// mode/UID/GID cached. Recorded whether or not it actually rewrote:
+		// re-reading one root is cheaper than tracking which branch it took.
+		if rootFile != nil {
+			tx.dirtyFiles = append(tx.dirtyFiles, rootFile.ID.String())
+			tx.dirtyShares = append(tx.dirtyShares, shareName)
 		}
 		return rootFile, nil
 	} else if err != badgerdb.ErrKeyNotFound {
@@ -1236,7 +1245,7 @@ func (tx *badgerTransaction) CreateRootDirectory(ctx context.Context, shareName 
 	// Create new root directory
 	rootAttrCopy := *attr
 	if rootAttrCopy.Mode == 0 {
-		rootAttrCopy.Mode = 0755
+		rootAttrCopy.Mode = defaultRootMode
 	}
 	now := time.Now()
 	if rootAttrCopy.Atime.IsZero() {

--- a/pkg/metadata/store/badger/transaction.go
+++ b/pkg/metadata/store/badger/transaction.go
@@ -1218,50 +1218,16 @@ func (tx *badgerTransaction) CreateRootDirectory(ctx context.Context, shareName 
 		}
 	}
 
-	// Check if share already exists
+	// Check if the share already exists. An existing root is reconciled
+	// against the configured attrs by the same body the pool path uses, so
+	// whether an operator's config change lands does not depend on which of
+	// the two entry points reached it.
 	item, err := tx.txn.Get(keyShare(shareName))
 	if err == nil {
-		// Share exists - load and return existing root
-		var existingShareData *shareData
-		err := item.Value(func(val []byte) error {
-			sd, decErr := decodeShareData(val)
-			if decErr != nil {
-				return decErr
-			}
-			existingShareData = sd
-			return nil
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		_, rootID, err := metadata.DecodeFileHandle(existingShareData.RootHandle)
-		if err != nil {
-			return nil, err
-		}
-
-		rootItem, err := tx.txn.Get(keyFile(rootID))
-		if err != nil {
-			return nil, err
-		}
-
 		var rootFile *metadata.File
-		err = rootItem.Value(func(val []byte) error {
-			rf, decErr := decodeFile(val)
-			if decErr != nil {
-				return decErr
-			}
-			rootFile = rf
-			return nil
-		})
-		if err != nil {
+		if err := tx.store.loadExistingRoot(tx.txn, item, shareName, attr, &rootFile); err != nil {
 			return nil, err
 		}
-
-		// A root directory with no stored link count falls back to the
-		// directory default of 2.
-		rootFile.Nlink = fileLinkCountTxn(tx.txn, rootFile)
-
 		return rootFile, nil
 	} else if err != badgerdb.ErrKeyNotFound {
 		return nil, err

--- a/pkg/metadata/store/memory/shares.go
+++ b/pkg/metadata/store/memory/shares.go
@@ -224,7 +224,6 @@ func (store *MemoryMetadataStore) CreateRootDirectory(
 	// An existing root is reconciled against the configured attributes rather
 	// than returned as it stands (see reconcileRootAttrs).
 	if existingData, exists := store.files[key]; exists {
-		// Decode handle to get ID
 		_, id, err := metadata.DecodeFileHandle(rootHandle)
 		if err != nil {
 			return nil, &metadata.StoreError{
@@ -232,13 +231,14 @@ func (store *MemoryMetadataStore) CreateRootDirectory(
 				Message: "failed to decode root handle",
 			}
 		}
-		reconcileRootAttrs(existingData.Attr, attr)
+		reconciled := reconcileRootAttrs(existingData.Attr, attr)
+		store.files[key] = &fileData{Attr: reconciled, ShareName: existingData.ShareName}
 
 		return &metadata.File{
 			ID:        id,
 			ShareName: shareName,
 			Path:      "/",
-			FileAttr:  *existingData.Attr,
+			FileAttr:  *reconciled,
 		}, nil
 	}
 
@@ -246,7 +246,7 @@ func (store *MemoryMetadataStore) CreateRootDirectory(
 	// Complete root directory attributes with defaults
 	rootAttrCopy := *attr
 	if rootAttrCopy.Mode == 0 {
-		rootAttrCopy.Mode = 0777
+		rootAttrCopy.Mode = defaultRootMode
 	}
 	now := time.Now()
 	if rootAttrCopy.Atime.IsZero() {
@@ -321,16 +321,29 @@ func (store *MemoryMetadataStore) Close() error {
 // Both entry points call this, because a backend that reconciles on one and not
 // the other makes whether an operator's change lands depend on which call site
 // reached it.
-func reconcileRootAttrs(stored *metadata.FileAttr, configured *metadata.FileAttr) {
+func reconcileRootAttrs(stored *metadata.FileAttr, configured *metadata.FileAttr) *metadata.FileAttr {
 	mode := configured.Mode
 	if mode == 0 {
-		mode = 0o755
+		mode = defaultRootMode
 	}
 	if stored.Mode == mode && stored.UID == configured.UID && stored.GID == configured.GID {
-		return
+		return stored
 	}
-	stored.Mode = mode
-	stored.UID = configured.UID
-	stored.GID = configured.GID
-	stored.Ctime = time.Now()
+
+	// A copy rather than an edit in place: a transaction's rollback snapshot
+	// clones the file map only one level deep, so the *FileAttr behind an entry
+	// is shared with the snapshot and an edit through it would survive the
+	// rollback it is supposed to be undone by. Callers replace the entry.
+	updated := *stored
+	updated.Mode = mode
+	updated.UID = configured.UID
+	updated.GID = configured.GID
+	updated.Ctime = time.Now()
+	return &updated
 }
+
+// defaultRootMode is the mode a share root gets when the caller configures
+// none. Every backend and both entry points must agree on it: the reconcile
+// compares a stored mode against it, so two entry points with different
+// defaults would each rewrite what the other wrote.
+const defaultRootMode = 0o755

--- a/pkg/metadata/store/memory/shares.go
+++ b/pkg/metadata/store/memory/shares.go
@@ -221,9 +221,9 @@ func (store *MemoryMetadataStore) CreateRootDirectory(
 		}
 	}
 
-	// Check if root already exists - if so, just return success (idempotent)
+	// An existing root is reconciled against the configured attributes rather
+	// than returned as it stands (see reconcileRootAttrs).
 	if existingData, exists := store.files[key]; exists {
-		// Root already exists, this is OK (idempotent operation)
 		// Decode handle to get ID
 		_, id, err := metadata.DecodeFileHandle(rootHandle)
 		if err != nil {
@@ -232,6 +232,8 @@ func (store *MemoryMetadataStore) CreateRootDirectory(
 				Message: "failed to decode root handle",
 			}
 		}
+		reconcileRootAttrs(existingData.Attr, attr)
+
 		return &metadata.File{
 			ID:        id,
 			ShareName: shareName,
@@ -309,4 +311,26 @@ func (store *MemoryMetadataStore) Close() error {
 	store.lockStore.cleanShutdown = true
 	store.mu.Unlock()
 	return nil
+}
+
+// reconcileRootAttrs brings a stored root directory in line with the attributes
+// a share was configured with, so re-attaching a share with changed root
+// ownership or mode takes effect rather than silently keeping the old values.
+// The configuration is the intent; the stored root records a previous run's.
+//
+// Both entry points call this, because a backend that reconciles on one and not
+// the other makes whether an operator's change lands depend on which call site
+// reached it.
+func reconcileRootAttrs(stored *metadata.FileAttr, configured *metadata.FileAttr) {
+	mode := configured.Mode
+	if mode == 0 {
+		mode = 0o755
+	}
+	if stored.Mode == mode && stored.UID == configured.UID && stored.GID == configured.GID {
+		return
+	}
+	stored.Mode = mode
+	stored.UID = configured.UID
+	stored.GID = configured.GID
+	stored.Ctime = time.Now()
 }

--- a/pkg/metadata/store/memory/shares.go
+++ b/pkg/metadata/store/memory/shares.go
@@ -246,7 +246,7 @@ func (store *MemoryMetadataStore) CreateRootDirectory(
 	// Complete root directory attributes with defaults
 	rootAttrCopy := *attr
 	if rootAttrCopy.Mode == 0 {
-		rootAttrCopy.Mode = defaultRootMode
+		rootAttrCopy.Mode = metadata.DefaultRootMode
 	}
 	now := time.Now()
 	if rootAttrCopy.Atime.IsZero() {
@@ -324,7 +324,7 @@ func (store *MemoryMetadataStore) Close() error {
 func reconcileRootAttrs(stored *metadata.FileAttr, configured *metadata.FileAttr) *metadata.FileAttr {
 	mode := configured.Mode
 	if mode == 0 {
-		mode = defaultRootMode
+		mode = metadata.DefaultRootMode
 	}
 	if stored.Mode == mode && stored.UID == configured.UID && stored.GID == configured.GID {
 		return stored
@@ -341,9 +341,3 @@ func reconcileRootAttrs(stored *metadata.FileAttr, configured *metadata.FileAttr
 	updated.Ctime = time.Now()
 	return &updated
 }
-
-// defaultRootMode is the mode a share root gets when the caller configures
-// none. Every backend and both entry points must agree on it: the reconcile
-// compares a stored mode against it, so two entry points with different
-// defaults would each rewrite what the other wrote.
-const defaultRootMode = 0o755

--- a/pkg/metadata/store/memory/transaction.go
+++ b/pkg/metadata/store/memory/transaction.go
@@ -715,9 +715,7 @@ func (tx *memoryTransaction) CreateRootDirectory(ctx context.Context, shareName 
 	}
 
 	// An existing root is reconciled against the configured attributes rather
-	// than returned as it stands: the configuration is the intent, and the
-	// stored root records a previous run's intent. Without this, re-attaching
-	// a share with changed root ownership or mode silently keeps the old one.
+	// than returned as it stands (see reconcileRootAttrs).
 	if existingData, exists := tx.store.files[key]; exists {
 		_, id, err := metadata.DecodeFileHandle(rootHandle)
 		if err != nil {
@@ -727,20 +725,21 @@ func (tx *memoryTransaction) CreateRootDirectory(ctx context.Context, shareName 
 			}
 		}
 
-		reconcileRootAttrs(existingData.Attr, attr)
+		reconciled := reconcileRootAttrs(existingData.Attr, attr)
+		tx.store.files[key] = &fileData{Attr: reconciled, ShareName: existingData.ShareName}
 
 		return &metadata.File{
 			ID:        id,
 			ShareName: shareName,
 			Path:      "/",
-			FileAttr:  *existingData.Attr,
+			FileAttr:  *reconciled,
 		}, nil
 	}
 
 	// Complete root directory attributes with defaults
 	rootAttrCopy := *attr
 	if rootAttrCopy.Mode == 0 {
-		rootAttrCopy.Mode = 0755
+		rootAttrCopy.Mode = defaultRootMode
 	}
 	now := time.Now()
 	if rootAttrCopy.Atime.IsZero() {

--- a/pkg/metadata/store/memory/transaction.go
+++ b/pkg/metadata/store/memory/transaction.go
@@ -714,7 +714,10 @@ func (tx *memoryTransaction) CreateRootDirectory(ctx context.Context, shareName 
 		}
 	}
 
-	// Check if root already exists - if so, just return success (idempotent)
+	// An existing root is reconciled against the configured attributes rather
+	// than returned as it stands: the configuration is the intent, and the
+	// stored root records a previous run's intent. Without this, re-attaching
+	// a share with changed root ownership or mode silently keeps the old one.
 	if existingData, exists := tx.store.files[key]; exists {
 		_, id, err := metadata.DecodeFileHandle(rootHandle)
 		if err != nil {
@@ -723,6 +726,9 @@ func (tx *memoryTransaction) CreateRootDirectory(ctx context.Context, shareName 
 				Message: "failed to decode root handle",
 			}
 		}
+
+		reconcileRootAttrs(existingData.Attr, attr)
+
 		return &metadata.File{
 			ID:        id,
 			ShareName: shareName,

--- a/pkg/metadata/store/memory/transaction.go
+++ b/pkg/metadata/store/memory/transaction.go
@@ -739,7 +739,7 @@ func (tx *memoryTransaction) CreateRootDirectory(ctx context.Context, shareName 
 	// Complete root directory attributes with defaults
 	rootAttrCopy := *attr
 	if rootAttrCopy.Mode == 0 {
-		rootAttrCopy.Mode = defaultRootMode
+		rootAttrCopy.Mode = metadata.DefaultRootMode
 	}
 	now := time.Now()
 	if rootAttrCopy.Atime.IsZero() {

--- a/pkg/metadata/store/postgres/dialect.go
+++ b/pkg/metadata/store/postgres/dialect.go
@@ -248,6 +248,26 @@ var shareQueries = storesql.ShareQueries{
 	SetShareOptions:   `UPDATE shares SET options = $1 WHERE share_name = $2`,
 	DeleteShare:       `DELETE FROM shares WHERE share_name = $1`,
 	DeleteShareInodes: `DELETE FROM inodes WHERE share_name = $1`,
+	SelectRootInode: `
+		SELECT f.id, f.file_type, f.mode, f.uid, f.gid, f.size,
+		       f.atime, f.mtime, f.ctime, f.creation_time, f.hidden, f.nlink
+		FROM inodes f
+		WHERE f.id = (SELECT root_file_id FROM shares WHERE share_name = $1)`,
+	UpdateRootAttrs: `UPDATE inodes SET mode = $1, uid = $2, gid = $3, ctime = $4 WHERE id = $5`,
+	InsertRootInode: `
+		INSERT INTO inodes (
+			id, share_name, file_type, mode, uid, gid, size,
+			atime, mtime, ctime, creation_time, content_id,
+			link_target, device_major, device_minor, nlink
+		) VALUES (
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+			$11, $12, $13, $14, $15, 2
+		)`,
+	UpsertShareRoot: `
+		INSERT INTO shares (share_name, root_file_id)
+		VALUES ($1, $2)
+		ON CONFLICT (share_name) DO UPDATE
+		SET root_file_id = EXCLUDED.root_file_id`,
 	ShareQuotaFreed: `SELECT %s, COALESCE(SUM(size), 0), COUNT(*) FROM inodes
 		WHERE share_name = $1 AND file_type = $2 AND nlink > 0 GROUP BY %s`,
 }

--- a/pkg/metadata/store/postgres/pool_helpers.go
+++ b/pkg/metadata/store/postgres/pool_helpers.go
@@ -34,11 +34,6 @@ const poolConnectionAcquireTimeout = 10 * time.Second
 // All operations use the same poolConnectionAcquireTimeout (10s) as WithTransaction
 // for consistency.
 
-// rowQuerier is the single-row query surface an open transaction (pgx.Tx.QueryRow)
-// and the pool wrapper (PostgresMetadataStore.queryRow) both satisfy, so one
-// query body can run on either.
-type rowQuerier func(ctx context.Context, sql string, args ...any) pgx.Row
-
 // acquireConn checks out a pooled connection under the shared acquire timeout.
 // The timeout bounds ONLY the checkout: the returned connection is used with the
 // caller's own context so a lazily-read result set is not cancelled the moment

--- a/pkg/metadata/store/postgres/shares.go
+++ b/pkg/metadata/store/postgres/shares.go
@@ -3,15 +3,10 @@ package postgres
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"time"
 
-	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sharecache"
-	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlcodec"
 )
 
 // ============================================================================
@@ -79,7 +74,7 @@ func (s *PostgresMetadataStore) CreateShare(ctx context.Context, share *metadata
 	// primary key (the ON CONFLICT upsert just re-points root_file_id, leaving
 	// at most one root). (Production also serializes share creation upstream in
 	// the control plane.)
-	existing, err := s.getExistingRootDirectory(ctx, s.queryRow, share.Name)
+	existing, err := s.GetExistingRootDirectory(ctx, share.Name)
 	if err != nil {
 		return fmt.Errorf("create share %q: check existing: %w", share.Name, err)
 	}
@@ -162,269 +157,23 @@ func (s *PostgresMetadataStore) DeleteShare(ctx context.Context, shareName strin
 
 // CreateRootDirectory creates the root directory for a share.
 //
-// The whole probe-then-create sequence runs in one transaction through
-// WithTransaction, so a serialization failure or deadlock retries under the
-// package's backoff and a concurrent caller cannot slip between the probe and
-// the insert and leave an orphaned root inode behind.
+// The store path wraps the shared body in a transaction rather than promoting
+// it: the probe and the create must not have a commit between them, or a
+// concurrent caller slips in and leaves an orphaned root inode behind. The
+// transaction's own shadow is what marks the share cache dirty.
 func (s *PostgresMetadataStore) CreateRootDirectory(
 	ctx context.Context,
 	shareName string,
 	attr *metadata.FileAttr,
 ) (*metadata.File, error) {
-	if shareName == "" {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrInvalidArgument,
-			Message: "share name cannot be empty",
-		}
-	}
-
 	var root *metadata.File
-	err := s.WithTransaction(ctx, func(mtx metadata.Transaction) error {
-		ptx := mtx.(*postgresTransaction)
-		// The body rewrites the shares row without going through the tx method
-		// that would flag it, so flag it here.
-		ptx.sharesDirty = true
+	err := s.WithTransaction(ctx, func(tx metadata.Transaction) error {
 		var txErr error
-		root, txErr = s.createRootDirectoryTx(ctx, ptx.tx, shareName, attr)
+		root, txErr = tx.CreateRootDirectory(ctx, shareName, attr)
 		return txErr
 	})
 	if err != nil {
 		return nil, err
 	}
 	return root, nil
-}
-
-// createRootDirectoryTx holds the probe/reconcile/create body, run against the
-// caller's transaction.
-func (s *PostgresMetadataStore) createRootDirectoryTx(
-	ctx context.Context,
-	tx pgx.Tx,
-	shareName string,
-	attr *metadata.FileAttr,
-) (*metadata.File, error) {
-	// Apply defaults
-	uid := attr.UID
-	gid := attr.GID
-	mode := attr.Mode
-	if mode == 0 {
-		mode = 0o755
-	}
-
-	s.logger.Info("Creating root directory",
-		"share", shareName,
-		"uid", uid,
-		"gid", gid,
-	)
-
-	// Check if root directory already exists (idempotent behavior)
-	existingRoot, err := s.getExistingRootDirectory(ctx, tx.QueryRow, shareName)
-	if err == nil && existingRoot != nil {
-		// Check if root directory attributes need to be updated from config
-		// This handles the case where the config changed since the share was first created
-		needsUpdate := false
-		if mode != 0 && existingRoot.Mode != mode {
-			s.logger.Info("Updating root directory mode from config",
-				"share", shareName,
-				"oldMode", fmt.Sprintf("%o", existingRoot.Mode),
-				"newMode", fmt.Sprintf("%o", mode))
-			existingRoot.Mode = mode
-			needsUpdate = true
-		}
-		if existingRoot.UID != uid {
-			s.logger.Info("Updating root directory UID from config",
-				"share", shareName,
-				"oldUID", existingRoot.UID,
-				"newUID", uid)
-			existingRoot.UID = uid
-			needsUpdate = true
-		}
-		if existingRoot.GID != gid {
-			s.logger.Info("Updating root directory GID from config",
-				"share", shareName,
-				"oldGID", existingRoot.GID,
-				"newGID", gid)
-			existingRoot.GID = gid
-			needsUpdate = true
-		}
-
-		if needsUpdate {
-			now := time.Now()
-			updateQuery := `
-				UPDATE inodes
-				SET mode = $1, uid = $2, gid = $3, ctime = $4
-				WHERE id = $5
-			`
-			_, err := tx.Exec(ctx, updateQuery,
-				int32(existingRoot.Mode),
-				int32(existingRoot.UID),
-				int32(existingRoot.GID),
-				sqlcodec.TimeToFiletime(now),
-				existingRoot.ID,
-			)
-			if err != nil {
-				return nil, err
-			}
-			existingRoot.Ctime = now
-			s.logger.Info("Root directory attributes updated from config",
-				"share", shareName,
-				"root_id", existingRoot.ID)
-		} else {
-			s.logger.Info("Root directory already exists, returning existing",
-				"share", shareName,
-				"root_id", existingRoot.ID,
-			)
-		}
-		return existingRoot, nil
-	}
-
-	// Generate UUID for root directory
-	rootID := uuid.New()
-
-	now := time.Now()
-
-	// Insert root directory inode. Directories start with nlink = 2 ("." and the
-	// parent's entry). nlink is the sole source of truth for the hard-link count
-	// (#1166).
-	insertFileQuery := `
-		INSERT INTO inodes (
-			id, share_name,
-			file_type, mode, uid, gid, size,
-			atime, mtime, ctime, creation_time,
-			content_id, link_target, device_major, device_minor, nlink
-		) VALUES (
-			$1, $2,
-			$3, $4, $5, $6, $7,
-			$8, $9, $10, $11,
-			$12, $13, $14, $15, 2
-		)
-	`
-
-	_, err = tx.Exec(ctx, insertFileQuery,
-		rootID,                            // id
-		shareName,                         // share_name
-		int16(metadata.FileTypeDirectory), // file_type
-		int32(mode),                       // mode
-		int32(uid),                        // uid
-		int32(gid),                        // gid
-		int64(0),                          // size
-		sqlcodec.TimeToFiletime(now),      // atime
-		sqlcodec.TimeToFiletime(now),      // mtime
-		sqlcodec.TimeToFiletime(now),      // ctime
-		sqlcodec.TimeToFiletime(now),      // creation_time
-		nil,                               // content_id (NULL for directories)
-		nil,                               // link_target (NULL)
-		nil,                               // device_major (NULL)
-		nil,                               // device_minor (NULL)
-	)
-	if err != nil {
-		return nil, mapPgError(err, "CreateRootDirectory", shareName)
-	}
-
-	// Insert into shares table
-	insertShareQuery := `
-		INSERT INTO shares (share_name, root_file_id)
-		VALUES ($1, $2)
-		ON CONFLICT (share_name) DO UPDATE
-		SET root_file_id = EXCLUDED.root_file_id
-	`
-
-	_, err = tx.Exec(ctx, insertShareQuery, shareName, rootID)
-	if err != nil {
-		return nil, mapPgError(err, "CreateRootDirectory", shareName)
-	}
-
-	s.logger.Info("Root directory created successfully",
-		"share", shareName,
-		"root_id", rootID,
-	)
-
-	// Build File
-	file := &metadata.File{
-		ID:        rootID,
-		ShareName: shareName,
-		Path:      "/",
-		FileAttr: metadata.FileAttr{
-			Type:         metadata.FileTypeDirectory,
-			Mode:         mode,
-			Nlink:        2, // Root directories have 2 links ("." and parent's entry)
-			UID:          uid,
-			GID:          gid,
-			Size:         0,
-			Atime:        now,
-			Mtime:        now,
-			Ctime:        now,
-			CreationTime: now,
-		},
-	}
-
-	return file, nil
-}
-
-// getExistingRootDirectory checks if a root directory already exists for the share
-// and returns it if found. Returns nil, nil if not found.
-func (s *PostgresMetadataStore) getExistingRootDirectory(ctx context.Context, queryRow rowQuerier, shareName string) (*metadata.File, error) {
-	// Resolve the root inode via shares.root_file_id (the share row is the
-	// authoritative pointer to its root) now that the path column is gone (#1166).
-	query := `
-		SELECT f.id, f.file_type, f.mode, f.uid, f.gid, f.size,
-			   f.atime, f.mtime, f.ctime, f.creation_time, f.hidden, f.nlink
-		FROM inodes f
-		WHERE f.id = (SELECT root_file_id FROM shares WHERE share_name = $1)
-	`
-
-	var (
-		id           uuid.UUID
-		fileType     int16
-		mode         int32
-		uid          int32
-		gid          int32
-		size         int64
-		atime        int64
-		mtime        int64
-		ctime        int64
-		creationTime int64
-		hidden       bool
-		nlink        int32
-	)
-
-	err := queryRow(ctx, query, shareName).Scan(
-		&id,
-		&fileType,
-		&mode,
-		&uid,
-		&gid,
-		&size,
-		&atime,
-		&mtime,
-		&ctime,
-		&creationTime,
-		&hidden,
-		&nlink,
-	)
-
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, nil // Not found, not an error
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	return &metadata.File{
-		ID:        id,
-		ShareName: shareName,
-		Path:      "/",
-		FileAttr: metadata.FileAttr{
-			Type:         metadata.FileType(fileType),
-			Mode:         uint32(mode),
-			Nlink:        uint32(nlink),
-			UID:          uint32(uid),
-			GID:          uint32(gid),
-			Size:         uint64(size),
-			Atime:        sqlcodec.FiletimeToTime(atime),
-			Mtime:        sqlcodec.FiletimeToTime(mtime),
-			Ctime:        sqlcodec.FiletimeToTime(ctime),
-			CreationTime: sqlcodec.FiletimeToTime(creationTime),
-			Hidden:       hidden,
-		},
-	}, nil
 }

--- a/pkg/metadata/store/postgres/shares.go
+++ b/pkg/metadata/store/postgres/shares.go
@@ -157,10 +157,10 @@ func (s *PostgresMetadataStore) DeleteShare(ctx context.Context, shareName strin
 
 // CreateRootDirectory creates the root directory for a share.
 //
-// The store path wraps the shared body in a transaction rather than promoting
-// it: the probe and the create must not have a commit between them, or a
-// concurrent caller slips in and leaves an orphaned root inode behind. The
-// transaction's own shadow is what marks the share cache dirty.
+// The store path runs the shared body through a transaction rather than on the
+// pool: the probe and the create must not have a commit between them, or a
+// concurrent caller slips in and leaves an orphaned root inode behind. Going
+// through the transaction method is also what marks the share cache dirty.
 func (s *PostgresMetadataStore) CreateRootDirectory(
 	ctx context.Context,
 	shareName string,

--- a/pkg/metadata/store/postgres/store.go
+++ b/pkg/metadata/store/postgres/store.go
@@ -149,7 +149,7 @@ func NewPostgresMetadataStore(
 		quota:        basestore.NewQuotaCache(),
 	}
 	// The shared SQL bodies run on the pool for store-level calls.
-	store.Core = &storesql.Core{X: poolExecer{s: store}, D: pgDialect, Caps: store.currentCapabilities}
+	store.Core = &storesql.Core{X: poolExecer{s: store}, D: pgDialect, Caps: store.currentCapabilities, Log: log}
 
 	// The substores derive only from pool, which is never reassigned, so bind
 	// them once here.

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -5,14 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
-	"time"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
-	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlcodec"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/txretry"
 
 	storesql "github.com/marmos91/dittofs/pkg/metadata/store/sql"
@@ -146,7 +143,7 @@ func (s *PostgresMetadataStore) withTransaction(ctx context.Context, fn func(tx 
 		}
 
 		ptx := &postgresTransaction{store: s, tx: tx}
-		ptx.Core = &storesql.Core{X: txExecer{tx: tx}, D: pgDialect, Caps: s.currentCapabilities, Quota: &ptx.quota}
+		ptx.Core = &storesql.Core{X: txExecer{tx: tx}, D: pgDialect, Caps: s.currentCapabilities, Quota: &ptx.quota, Log: s.logger}
 		if err := fn(ptx); err != nil {
 			// Apply timeout to rollback to prevent indefinite blocking
 			rollbackCtx, rollbackCancel := context.WithTimeout(ctx, poolConnectionAcquireTimeout)
@@ -402,152 +399,8 @@ func (tx *postgresTransaction) DeleteShare(ctx context.Context, shareName string
 }
 
 func (tx *postgresTransaction) CreateRootDirectory(ctx context.Context, shareName string, attr *metadata.FileAttr) (*metadata.File, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
 	tx.sharesDirty = true
-
-	if shareName == "" {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrInvalidArgument,
-			Message: "share name cannot be empty",
-		}
-	}
-
-	// Apply defaults
-	uid := attr.UID
-	gid := attr.GID
-	mode := attr.Mode
-	if mode == 0 {
-		mode = 0o755
-	}
-
-	// Check if root directory already exists (idempotent behavior). The root is
-	// resolved via shares.root_file_id — with the path column gone (#1166), the
-	// share row is the authoritative pointer to its root inode.
-	checkQuery := `
-		SELECT f.id, f.file_type, f.mode, f.uid, f.gid, f.size,
-			   f.atime, f.mtime, f.ctime, f.creation_time, f.hidden, f.nlink
-		FROM inodes f
-		WHERE f.id = (SELECT root_file_id FROM shares WHERE share_name = $1)
-	`
-
-	var (
-		id           string
-		fileType     int16
-		existingMode int32
-		existingUID  int32
-		existingGID  int32
-		size         int64
-		atime        int64
-		mtime        int64
-		ctime        int64
-		creationTime int64
-		hidden       bool
-		nlink        int32
-	)
-
-	err := tx.tx.QueryRow(ctx, checkQuery, shareName).Scan(
-		&id, &fileType, &existingMode, &existingUID, &existingGID, &size,
-		&atime, &mtime, &ctime, &creationTime, &hidden, &nlink,
-	)
-
-	if err == nil {
-		// Root exists - return it
-		return &metadata.File{
-			ID:        uuid.MustParse(id),
-			ShareName: shareName,
-			Path:      "/",
-			FileAttr: metadata.FileAttr{
-				Type:         metadata.FileType(fileType),
-				Mode:         uint32(existingMode),
-				Nlink:        uint32(nlink),
-				UID:          uint32(existingUID),
-				GID:          uint32(existingGID),
-				Size:         uint64(size),
-				Atime:        sqlcodec.FiletimeToTime(atime),
-				Mtime:        sqlcodec.FiletimeToTime(mtime),
-				Ctime:        sqlcodec.FiletimeToTime(ctime),
-				CreationTime: sqlcodec.FiletimeToTime(creationTime),
-				Hidden:       hidden,
-			},
-		}, nil
-	}
-	if !errors.Is(err, pgx.ErrNoRows) {
-		return nil, mapPgError(err, "CreateRootDirectory", shareName)
-	}
-
-	// Create new root directory
-	rootID := uuid.New()
-	now := time.Now()
-
-	// Directories start with nlink = 2 ("." and the parent's entry). nlink is
-	// the sole source of truth for the hard-link count (#1166).
-	insertFileQuery := `
-		INSERT INTO inodes (
-			id, share_name,
-			file_type, mode, uid, gid, size,
-			atime, mtime, ctime, creation_time,
-			content_id, link_target, device_major, device_minor, nlink
-		) VALUES (
-			$1, $2,
-			$3, $4, $5, $6, $7,
-			$8, $9, $10, $11,
-			$12, $13, $14, $15, 2
-		)
-	`
-
-	_, err = tx.tx.Exec(ctx, insertFileQuery,
-		rootID,                            // id
-		shareName,                         // share_name
-		int16(metadata.FileTypeDirectory), // file_type
-		int32(mode),                       // mode
-		int32(uid),                        // uid
-		int32(gid),                        // gid
-		int64(0),                          // size
-		sqlcodec.TimeToFiletime(now),      // atime
-		sqlcodec.TimeToFiletime(now),      // mtime
-		sqlcodec.TimeToFiletime(now),      // ctime
-		sqlcodec.TimeToFiletime(now),      // creation_time
-		nil,                               // content_id (NULL for directories)
-		nil,                               // link_target (NULL)
-		nil,                               // device_major (NULL)
-		nil,                               // device_minor (NULL)
-	)
-	if err != nil {
-		return nil, mapPgError(err, "CreateRootDirectory", shareName)
-	}
-
-	// Insert into shares table
-	insertShareQuery := `
-		INSERT INTO shares (share_name, root_file_id)
-		VALUES ($1, $2)
-		ON CONFLICT (share_name) DO UPDATE
-		SET root_file_id = EXCLUDED.root_file_id
-	`
-
-	_, err = tx.tx.Exec(ctx, insertShareQuery, shareName, rootID)
-	if err != nil {
-		return nil, mapPgError(err, "CreateRootDirectory", shareName)
-	}
-
-	return &metadata.File{
-		ID:        rootID,
-		ShareName: shareName,
-		Path:      "/",
-		FileAttr: metadata.FileAttr{
-			Type:         metadata.FileTypeDirectory,
-			Mode:         mode,
-			Nlink:        2, // Root directories have 2 links (. and parent's entry)
-			UID:          uid,
-			GID:          gid,
-			Size:         0,
-			Atime:        now,
-			Mtime:        now,
-			Ctime:        now,
-			CreationTime: now,
-		},
-	}, nil
+	return tx.Core.CreateRootDirectory(ctx, shareName, attr)
 }
 
 // ============================================================================

--- a/pkg/metadata/store/sql/chunks.go
+++ b/pkg/metadata/store/sql/chunks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/marmos91/dittofs/pkg/block"
@@ -34,6 +35,11 @@ type Core struct {
 	// replaces them at runtime, and a copy taken at construction would go
 	// stale. Never nil.
 	Caps func() metadata.FilesystemCapabilities
+	// Log records what a shared body did when the operation is one an
+	// operator needs to see after the fact — a root inode rewritten to match
+	// a changed config, say. Each dialect passes its own component-tagged
+	// logger, so the backend stays identifiable in the output. Never nil.
+	Log *slog.Logger
 	// Quota accumulates the usage changes a write owes the store's quota
 	// cache, which applies them once the transaction commits. Set only on a
 	// transaction's Core; the pool's Core leaves it nil. Every method that

--- a/pkg/metadata/store/sql/dialect.go
+++ b/pkg/metadata/store/sql/dialect.go
@@ -96,6 +96,23 @@ type ShareQueries struct {
 	// DeleteShareInodes removes every inode row belonging to a share. One
 	// parameter: the share name.
 	DeleteShareInodes string
+
+	// SelectRootInode selects a share's root inode through the share row's
+	// root_file_id pointer, in the column order ScanRootInode expects. One
+	// parameter: the share name.
+	SelectRootInode string
+	// UpdateRootAttrs rewrites a root inode's mode, owner and change time to
+	// match the configured attributes. Five parameters: mode, uid, gid, ctime
+	// and the inode id.
+	UpdateRootAttrs string
+	// InsertRootInode inserts a share's root directory inode. Fifteen
+	// parameters, in the column order the statement lists; nlink is the
+	// literal 2, the directory default for "." plus the parent's entry.
+	InsertRootInode string
+	// UpsertShareRoot inserts the share row pointing at its root inode,
+	// repointing an existing row rather than failing. Two parameters: the
+	// share name and the root inode id.
+	UpsertShareRoot string
 	// ShareQuotaFreed is a format string, not a statement: it takes the
 	// owner column twice, for the SELECT and the GROUP BY, because a column
 	// name is not something a driver will substitute. The column is a fixed

--- a/pkg/metadata/store/sql/dialect.go
+++ b/pkg/metadata/store/sql/dialect.go
@@ -98,8 +98,8 @@ type ShareQueries struct {
 	DeleteShareInodes string
 
 	// SelectRootInode selects a share's root inode through the share row's
-	// root_file_id pointer, in the column order ScanRootInode expects. One
-	// parameter: the share name.
+	// root_file_id pointer, in the column order GetExistingRootDirectory
+	// scans. One parameter: the share name.
 	SelectRootInode string
 	// UpdateRootAttrs rewrites a root inode's mode, owner and change time to
 	// match the configured attributes. Five parameters: mode, uid, gid, ctime

--- a/pkg/metadata/store/sql/shares.go
+++ b/pkg/metadata/store/sql/shares.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
+	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlcodec"
 )
 
 // ============================================================================
@@ -234,4 +236,195 @@ func (c *Core) collectShareQuotaFreed(ctx context.Context, shareName, col string
 		return c.D.MapError(err, "DeleteShare", shareName)
 	}
 	return nil
+}
+
+// GetExistingRootDirectory loads a share's root directory, or (nil, nil) when
+// the share has no root yet.
+//
+// The root is resolved through the share row's root_file_id: with the path
+// column gone, that pointer is the authoritative answer to "which inode is
+// this share's root".
+func (c *Core) GetExistingRootDirectory(ctx context.Context, shareName string) (*metadata.File, error) {
+	var (
+		id           uuid.UUID
+		fileType     int16
+		mode         int32
+		uid          int32
+		gid          int32
+		size         int64
+		atime        int64
+		mtime        int64
+		ctime        int64
+		creationTime int64
+		hidden       bool
+		nlink        int32
+	)
+
+	err := c.X.QueryRow(ctx, c.D.Shares().SelectRootInode, shareName).Scan(
+		&id, &fileType, &mode, &uid, &gid, &size,
+		&atime, &mtime, &ctime, &creationTime, &hidden, &nlink,
+	)
+	if c.D.IsNoRows(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return &metadata.File{
+		ID:        id,
+		ShareName: shareName,
+		Path:      "/",
+		FileAttr: metadata.FileAttr{
+			Type:         metadata.FileType(fileType),
+			Mode:         uint32(mode),
+			Nlink:        uint32(nlink),
+			UID:          uint32(uid),
+			GID:          uint32(gid),
+			Size:         uint64(size),
+			Atime:        sqlcodec.FiletimeToTime(atime),
+			Mtime:        sqlcodec.FiletimeToTime(mtime),
+			Ctime:        sqlcodec.FiletimeToTime(ctime),
+			CreationTime: sqlcodec.FiletimeToTime(creationTime),
+			Hidden:       hidden,
+		},
+	}, nil
+}
+
+// CreateRootDirectory creates a share's root directory, or reconciles the
+// existing one against attr when the share already has a root.
+//
+// Reconciling rather than returning the stored root as-is is what makes
+// re-attaching a share with changed root ownership or mode take effect: the
+// configured attributes are the intent, and the stored inode is a cache of a
+// previous run's intent. A caller that only wants to read the root uses
+// GetExistingRootDirectory.
+//
+// The probe and the create are one statement pair with no commit between
+// them, so a concurrent caller cannot slip between them and leave an orphaned
+// root inode behind; the caller supplies the transaction by running this on a
+// Core bound to it.
+func (c *Core) CreateRootDirectory(ctx context.Context, shareName string, attr *metadata.FileAttr) (*metadata.File, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	if shareName == "" {
+		return nil, &metadata.StoreError{
+			Code:    metadata.ErrInvalidArgument,
+			Message: "share name cannot be empty",
+		}
+	}
+
+	uid := attr.UID
+	gid := attr.GID
+	mode := attr.Mode
+	if mode == 0 {
+		mode = 0o755
+	}
+
+	c.Log.Info("Creating root directory", "share", shareName, "uid", uid, "gid", gid)
+
+	existing, err := c.GetExistingRootDirectory(ctx, shareName)
+	if err != nil {
+		return nil, c.D.MapError(err, "CreateRootDirectory", shareName)
+	}
+	if existing != nil {
+		return c.reconcileRootDirectory(ctx, shareName, existing, mode, uid, gid)
+	}
+
+	rootID := uuid.New()
+	now := time.Now()
+
+	_, err = c.X.Exec(ctx, c.D.Shares().InsertRootInode,
+		rootID,
+		shareName,
+		int16(metadata.FileTypeDirectory),
+		int32(mode),
+		int32(uid),
+		int32(gid),
+		int64(0),
+		sqlcodec.TimeToFiletime(now), // atime
+		sqlcodec.TimeToFiletime(now), // mtime
+		sqlcodec.TimeToFiletime(now), // ctime
+		sqlcodec.TimeToFiletime(now), // creation_time
+		nil,                          // content_id, NULL for directories
+		nil,                          // link_target
+		nil,                          // device_major
+		nil,                          // device_minor
+	)
+	if err != nil {
+		return nil, c.D.MapError(err, "CreateRootDirectory", shareName)
+	}
+
+	if _, err := c.X.Exec(ctx, c.D.Shares().UpsertShareRoot, shareName, rootID); err != nil {
+		return nil, c.D.MapError(err, "CreateRootDirectory", shareName)
+	}
+
+	c.Log.Info("Root directory created", "share", shareName, "root_id", rootID)
+
+	return &metadata.File{
+		ID:        rootID,
+		ShareName: shareName,
+		Path:      "/",
+		FileAttr: metadata.FileAttr{
+			Type:         metadata.FileTypeDirectory,
+			Mode:         mode,
+			Nlink:        2, // "." and the parent's entry
+			UID:          uid,
+			GID:          gid,
+			Size:         0,
+			Atime:        now,
+			Mtime:        now,
+			Ctime:        now,
+			CreationTime: now,
+		},
+	}, nil
+}
+
+// reconcileRootDirectory brings an existing root inode in line with the
+// configured mode and owner, rewriting the row only when something actually
+// differs so an unchanged share costs one read and no write.
+func (c *Core) reconcileRootDirectory(ctx context.Context, shareName string, root *metadata.File, mode, uid, gid uint32) (*metadata.File, error) {
+	needsUpdate := false
+	if root.Mode != mode {
+		c.Log.Info("Updating root directory mode from config",
+			"share", shareName,
+			"oldMode", fmt.Sprintf("%o", root.Mode),
+			"newMode", fmt.Sprintf("%o", mode))
+		root.Mode = mode
+		needsUpdate = true
+	}
+	if root.UID != uid {
+		c.Log.Info("Updating root directory UID from config",
+			"share", shareName, "oldUID", root.UID, "newUID", uid)
+		root.UID = uid
+		needsUpdate = true
+	}
+	if root.GID != gid {
+		c.Log.Info("Updating root directory GID from config",
+			"share", shareName, "oldGID", root.GID, "newGID", gid)
+		root.GID = gid
+		needsUpdate = true
+	}
+
+	if !needsUpdate {
+		c.Log.Info("Root directory already exists, returning existing",
+			"share", shareName, "root_id", root.ID)
+		return root, nil
+	}
+
+	now := time.Now()
+	_, err := c.X.Exec(ctx, c.D.Shares().UpdateRootAttrs,
+		int32(root.Mode), int32(root.UID), int32(root.GID),
+		sqlcodec.TimeToFiletime(now), root.ID,
+	)
+	if err != nil {
+		return nil, c.D.MapError(err, "CreateRootDirectory", shareName)
+	}
+	root.Ctime = now
+
+	c.Log.Info("Root directory attributes updated from config",
+		"share", shareName, "root_id", root.ID)
+	return root, nil
 }

--- a/pkg/metadata/store/sql/shares.go
+++ b/pkg/metadata/store/sql/shares.go
@@ -241,9 +241,8 @@ func (c *Core) collectShareQuotaFreed(ctx context.Context, shareName, col string
 // GetExistingRootDirectory loads a share's root directory, or (nil, nil) when
 // the share has no root yet.
 //
-// The root is resolved through the share row's root_file_id: with the path
-// column gone, that pointer is the authoritative answer to "which inode is
-// this share's root".
+// The root is resolved through the share row's root_file_id, the authoritative
+// pointer to a share's root inode.
 func (c *Core) GetExistingRootDirectory(ctx context.Context, shareName string) (*metadata.File, error) {
 	var (
 		id           uuid.UUID
@@ -296,14 +295,13 @@ func (c *Core) GetExistingRootDirectory(ctx context.Context, shareName string) (
 //
 // Reconciling rather than returning the stored root as-is is what makes
 // re-attaching a share with changed root ownership or mode take effect: the
-// configured attributes are the intent, and the stored inode is a cache of a
-// previous run's intent. A caller that only wants to read the root uses
+// configured attributes are the intent, the stored inode records a previous
+// run's. A caller that only wants to read the root uses
 // GetExistingRootDirectory.
 //
-// The probe and the create are one statement pair with no commit between
-// them, so a concurrent caller cannot slip between them and leave an orphaned
-// root inode behind; the caller supplies the transaction by running this on a
-// Core bound to it.
+// The probe and the create must have no commit between them, or a concurrent
+// caller slips in and leaves an orphaned root inode behind — so run this on a
+// Core bound to a transaction.
 func (c *Core) CreateRootDirectory(ctx context.Context, shareName string, attr *metadata.FileAttr) (*metadata.File, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err

--- a/pkg/metadata/store/sql/shares.go
+++ b/pkg/metadata/store/sql/shares.go
@@ -318,7 +318,7 @@ func (c *Core) CreateRootDirectory(ctx context.Context, shareName string, attr *
 	gid := attr.GID
 	mode := attr.Mode
 	if mode == 0 {
-		mode = 0o755
+		mode = metadata.DefaultRootMode
 	}
 
 	c.Log.Info("Creating root directory", "share", shareName, "uid", uid, "gid", gid)

--- a/pkg/metadata/store/sqlite/dialect.go
+++ b/pkg/metadata/store/sqlite/dialect.go
@@ -247,6 +247,26 @@ var shareQueries = storesql.ShareQueries{
 	SetShareOptions:   `UPDATE shares SET options = ?1 WHERE share_name = ?2`,
 	DeleteShare:       `DELETE FROM shares WHERE share_name = ?1`,
 	DeleteShareInodes: `DELETE FROM inodes WHERE share_name = ?1`,
+	SelectRootInode: `
+		SELECT f.id, f.file_type, f.mode, f.uid, f.gid, f.size,
+		       f.atime, f.mtime, f.ctime, f.creation_time, f.hidden, f.nlink
+		FROM inodes f
+		WHERE f.id = (SELECT root_file_id FROM shares WHERE share_name = ?1)`,
+	UpdateRootAttrs: `UPDATE inodes SET mode = ?1, uid = ?2, gid = ?3, ctime = ?4 WHERE id = ?5`,
+	InsertRootInode: `
+		INSERT INTO inodes (
+			id, share_name, file_type, mode, uid, gid, size,
+			atime, mtime, ctime, creation_time, content_id,
+			link_target, device_major, device_minor, nlink
+		) VALUES (
+			?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10,
+			?11, ?12, ?13, ?14, ?15, 2
+		)`,
+	UpsertShareRoot: `
+		INSERT INTO shares (share_name, root_file_id)
+		VALUES (?1, ?2)
+		ON CONFLICT (share_name) DO UPDATE
+		SET root_file_id = EXCLUDED.root_file_id`,
 	ShareQuotaFreed: `SELECT %s, COALESCE(SUM(size), 0), COUNT(*) FROM inodes
 		WHERE share_name = ?1 AND file_type = ?2 AND nlink > 0 GROUP BY %s`,
 }

--- a/pkg/metadata/store/sqlite/shares.go
+++ b/pkg/metadata/store/sqlite/shares.go
@@ -2,16 +2,11 @@ package sqlite
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"time"
 
-	"github.com/google/uuid"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sharecache"
-	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlcodec"
 )
 
 // ============================================================================
@@ -79,7 +74,7 @@ func (s *SQLiteMetadataStore) CreateShare(ctx context.Context, share *metadata.S
 	// primary key (the ON CONFLICT upsert just re-points root_file_id, leaving
 	// at most one root). (Production also serializes share creation upstream in
 	// the control plane.)
-	existing, err := s.getExistingRootDirectory(ctx, s.conn(), share.Name)
+	existing, err := s.GetExistingRootDirectory(ctx, share.Name)
 	if err != nil {
 		return fmt.Errorf("create share %q: check existing: %w", share.Name, err)
 	}
@@ -162,269 +157,23 @@ func (s *SQLiteMetadataStore) DeleteShare(ctx context.Context, shareName string)
 
 // CreateRootDirectory creates the root directory for a share.
 //
-// The whole probe-then-create sequence runs in one transaction through
-// WithTransaction, so a SQLITE_BUSY collision retries under the package's
-// backoff and a concurrent caller cannot slip between the probe and the
-// insert and leave an orphaned root inode behind.
+// The store path wraps the shared body in a transaction rather than promoting
+// it: the probe and the create must not have a commit between them, or a
+// concurrent caller slips in and leaves an orphaned root inode behind. The
+// transaction's own shadow is what marks the share cache dirty.
 func (s *SQLiteMetadataStore) CreateRootDirectory(
 	ctx context.Context,
 	shareName string,
 	attr *metadata.FileAttr,
 ) (*metadata.File, error) {
-	if shareName == "" {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrInvalidArgument,
-			Message: "share name cannot be empty",
-		}
-	}
-
 	var root *metadata.File
-	err := s.WithTransaction(ctx, func(mtx metadata.Transaction) error {
-		stx := mtx.(*sqliteTransaction)
-		// The body rewrites the shares row without going through the tx method
-		// that would flag it, so flag it here.
-		stx.sharesDirty = true
+	err := s.WithTransaction(ctx, func(tx metadata.Transaction) error {
 		var txErr error
-		root, txErr = s.createRootDirectoryTx(ctx, stx.tx, shareName, attr)
+		root, txErr = tx.CreateRootDirectory(ctx, shareName, attr)
 		return txErr
 	})
 	if err != nil {
 		return nil, err
 	}
 	return root, nil
-}
-
-// createRootDirectoryTx holds the probe/reconcile/create body, run against the
-// caller's transaction.
-func (s *SQLiteMetadataStore) createRootDirectoryTx(
-	ctx context.Context,
-	tx execer,
-	shareName string,
-	attr *metadata.FileAttr,
-) (*metadata.File, error) {
-	// Apply defaults
-	uid := attr.UID
-	gid := attr.GID
-	mode := attr.Mode
-	if mode == 0 {
-		mode = 0o755
-	}
-
-	s.logger.Info("Creating root directory",
-		"share", shareName,
-		"uid", uid,
-		"gid", gid,
-	)
-
-	// Check if root directory already exists (idempotent behavior)
-	existingRoot, err := s.getExistingRootDirectory(ctx, tx, shareName)
-	if err == nil && existingRoot != nil {
-		// Check if root directory attributes need to be updated from config
-		// This handles the case where the config changed since the share was first created
-		needsUpdate := false
-		if mode != 0 && existingRoot.Mode != mode {
-			s.logger.Info("Updating root directory mode from config",
-				"share", shareName,
-				"oldMode", fmt.Sprintf("%o", existingRoot.Mode),
-				"newMode", fmt.Sprintf("%o", mode))
-			existingRoot.Mode = mode
-			needsUpdate = true
-		}
-		if existingRoot.UID != uid {
-			s.logger.Info("Updating root directory UID from config",
-				"share", shareName,
-				"oldUID", existingRoot.UID,
-				"newUID", uid)
-			existingRoot.UID = uid
-			needsUpdate = true
-		}
-		if existingRoot.GID != gid {
-			s.logger.Info("Updating root directory GID from config",
-				"share", shareName,
-				"oldGID", existingRoot.GID,
-				"newGID", gid)
-			existingRoot.GID = gid
-			needsUpdate = true
-		}
-
-		if needsUpdate {
-			now := time.Now()
-			updateQuery := `
-				UPDATE inodes
-				SET mode = ?1, uid = ?2, gid = ?3, ctime = ?4
-				WHERE id = ?5
-			`
-			_, err := tx.Exec(ctx, updateQuery,
-				int32(existingRoot.Mode),
-				int32(existingRoot.UID),
-				int32(existingRoot.GID),
-				sqlcodec.TimeToFiletime(now),
-				existingRoot.ID,
-			)
-			if err != nil {
-				return nil, err
-			}
-			existingRoot.Ctime = now
-			s.logger.Info("Root directory attributes updated from config",
-				"share", shareName,
-				"root_id", existingRoot.ID)
-		} else {
-			s.logger.Info("Root directory already exists, returning existing",
-				"share", shareName,
-				"root_id", existingRoot.ID,
-			)
-		}
-		return existingRoot, nil
-	}
-
-	// Generate UUID for root directory
-	rootID := uuid.New()
-
-	now := time.Now()
-
-	// Insert root directory inode. Directories start with nlink = 2 ("." and the
-	// parent's entry). nlink is the sole source of truth for the hard-link count
-	// (#1166).
-	insertFileQuery := `
-		INSERT INTO inodes (
-			id, share_name,
-			file_type, mode, uid, gid, size,
-			atime, mtime, ctime, creation_time,
-			content_id, link_target, device_major, device_minor, nlink
-		) VALUES (
-			?1, ?2,
-			?3, ?4, ?5, ?6, ?7,
-			?8, ?9, ?10, ?11,
-			?12, ?13, ?14, ?15, 2
-		)
-	`
-
-	_, err = tx.Exec(ctx, insertFileQuery,
-		rootID,                            // id
-		shareName,                         // share_name
-		int16(metadata.FileTypeDirectory), // file_type
-		int32(mode),                       // mode
-		int32(uid),                        // uid
-		int32(gid),                        // gid
-		int64(0),                          // size
-		sqlcodec.TimeToFiletime(now),      // atime
-		sqlcodec.TimeToFiletime(now),      // mtime
-		sqlcodec.TimeToFiletime(now),      // ctime
-		sqlcodec.TimeToFiletime(now),      // creation_time
-		nil,                               // content_id (NULL for directories)
-		nil,                               // link_target (NULL)
-		nil,                               // device_major (NULL)
-		nil,                               // device_minor (NULL)
-	)
-	if err != nil {
-		return nil, mapDBError(err, "CreateRootDirectory", shareName)
-	}
-
-	// Insert into shares table
-	insertShareQuery := `
-		INSERT INTO shares (share_name, root_file_id)
-		VALUES (?1, ?2)
-		ON CONFLICT (share_name) DO UPDATE
-		SET root_file_id = EXCLUDED.root_file_id
-	`
-
-	_, err = tx.Exec(ctx, insertShareQuery, shareName, rootID)
-	if err != nil {
-		return nil, mapDBError(err, "CreateRootDirectory", shareName)
-	}
-
-	s.logger.Info("Root directory created successfully",
-		"share", shareName,
-		"root_id", rootID,
-	)
-
-	// Build File
-	file := &metadata.File{
-		ID:        rootID,
-		ShareName: shareName,
-		Path:      "/",
-		FileAttr: metadata.FileAttr{
-			Type:         metadata.FileTypeDirectory,
-			Mode:         mode,
-			Nlink:        2, // Root directories have 2 links ("." and parent's entry)
-			UID:          uid,
-			GID:          gid,
-			Size:         0,
-			Atime:        now,
-			Mtime:        now,
-			Ctime:        now,
-			CreationTime: now,
-		},
-	}
-
-	return file, nil
-}
-
-// getExistingRootDirectory checks if a root directory already exists for the share
-// and returns it if found. Returns nil, nil if not found.
-func (s *SQLiteMetadataStore) getExistingRootDirectory(ctx context.Context, tx execer, shareName string) (*metadata.File, error) {
-	// Resolve the root inode via shares.root_file_id (the share row is the
-	// authoritative pointer to its root) now that the path column is gone (#1166).
-	query := `
-		SELECT f.id, f.file_type, f.mode, f.uid, f.gid, f.size,
-			   f.atime, f.mtime, f.ctime, f.creation_time, f.hidden, f.nlink
-		FROM inodes f
-		WHERE f.id = (SELECT root_file_id FROM shares WHERE share_name = ?1)
-	`
-
-	var (
-		id           uuid.UUID
-		fileType     int16
-		mode         int32
-		uid          int32
-		gid          int32
-		size         int64
-		atime        int64
-		mtime        int64
-		ctime        int64
-		creationTime int64
-		hidden       bool
-		nlink        int32
-	)
-
-	err := tx.QueryRow(ctx, query, shareName).Scan(
-		&id,
-		&fileType,
-		&mode,
-		&uid,
-		&gid,
-		&size,
-		&atime,
-		&mtime,
-		&ctime,
-		&creationTime,
-		&hidden,
-		&nlink,
-	)
-
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, nil // Not found, not an error
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	return &metadata.File{
-		ID:        id,
-		ShareName: shareName,
-		Path:      "/",
-		FileAttr: metadata.FileAttr{
-			Type:         metadata.FileType(fileType),
-			Mode:         uint32(mode),
-			Nlink:        uint32(nlink),
-			UID:          uint32(uid),
-			GID:          uint32(gid),
-			Size:         uint64(size),
-			Atime:        sqlcodec.FiletimeToTime(atime),
-			Mtime:        sqlcodec.FiletimeToTime(mtime),
-			Ctime:        sqlcodec.FiletimeToTime(ctime),
-			CreationTime: sqlcodec.FiletimeToTime(creationTime),
-			Hidden:       hidden,
-		},
-	}, nil
 }

--- a/pkg/metadata/store/sqlite/shares.go
+++ b/pkg/metadata/store/sqlite/shares.go
@@ -157,10 +157,10 @@ func (s *SQLiteMetadataStore) DeleteShare(ctx context.Context, shareName string)
 
 // CreateRootDirectory creates the root directory for a share.
 //
-// The store path wraps the shared body in a transaction rather than promoting
-// it: the probe and the create must not have a commit between them, or a
-// concurrent caller slips in and leaves an orphaned root inode behind. The
-// transaction's own shadow is what marks the share cache dirty.
+// The store path runs the shared body through a transaction rather than on the
+// pool: the probe and the create must not have a commit between them, or a
+// concurrent caller slips in and leaves an orphaned root inode behind. Going
+// through the transaction method is also what marks the share cache dirty.
 func (s *SQLiteMetadataStore) CreateRootDirectory(
 	ctx context.Context,
 	shareName string,

--- a/pkg/metadata/store/sqlite/store.go
+++ b/pkg/metadata/store/sqlite/store.go
@@ -164,7 +164,7 @@ func NewSQLiteMetadataStore(
 		quota:        basestore.NewQuotaCache(),
 	}
 	// The shared SQL bodies run on the pool for store-level calls.
-	store.Core = &storesql.Core{X: store.conn(), D: sqliteDialect, Caps: store.currentCapabilities}
+	store.Core = &storesql.Core{X: store.conn(), D: sqliteDialect, Caps: store.currentCapabilities, Log: log}
 
 	// The substores derive only from db, which is never reassigned, so bind
 	// them once here.

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -6,12 +6,9 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
-	"time"
 
-	"github.com/google/uuid"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/store/basestore"
-	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlcodec"
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/txretry"
 
 	storesql "github.com/marmos91/dittofs/pkg/metadata/store/sql"
@@ -97,7 +94,7 @@ func (s *SQLiteMetadataStore) WithTransaction(ctx context.Context, fn func(tx me
 		}
 
 		ptx := &sqliteTransaction{store: s, tx: execer{e: rawTx, op: "tx"}}
-		ptx.Core = &storesql.Core{X: ptx.tx, D: sqliteDialect, Caps: s.currentCapabilities, Quota: &ptx.quota}
+		ptx.Core = &storesql.Core{X: ptx.tx, D: sqliteDialect, Caps: s.currentCapabilities, Quota: &ptx.quota, Log: s.logger}
 		if err := fn(ptx); err != nil {
 			_ = rawTx.Rollback()
 			if isBusyError(err) {
@@ -348,152 +345,8 @@ func (tx *sqliteTransaction) DeleteShare(ctx context.Context, shareName string) 
 }
 
 func (tx *sqliteTransaction) CreateRootDirectory(ctx context.Context, shareName string, attr *metadata.FileAttr) (*metadata.File, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
 	tx.sharesDirty = true
-
-	if shareName == "" {
-		return nil, &metadata.StoreError{
-			Code:    metadata.ErrInvalidArgument,
-			Message: "share name cannot be empty",
-		}
-	}
-
-	// Apply defaults
-	uid := attr.UID
-	gid := attr.GID
-	mode := attr.Mode
-	if mode == 0 {
-		mode = 0o755
-	}
-
-	// Check if root directory already exists (idempotent behavior). The root is
-	// resolved via shares.root_file_id — with the path column gone (#1166), the
-	// share row is the authoritative pointer to its root inode.
-	checkQuery := `
-		SELECT f.id, f.file_type, f.mode, f.uid, f.gid, f.size,
-			   f.atime, f.mtime, f.ctime, f.creation_time, f.hidden, f.nlink
-		FROM inodes f
-		WHERE f.id = (SELECT root_file_id FROM shares WHERE share_name = ?1)
-	`
-
-	var (
-		id           string
-		fileType     int16
-		existingMode int32
-		existingUID  int32
-		existingGID  int32
-		size         int64
-		atime        int64
-		mtime        int64
-		ctime        int64
-		creationTime int64
-		hidden       bool
-		nlink        int32
-	)
-
-	err := tx.tx.QueryRow(ctx, checkQuery, shareName).Scan(
-		&id, &fileType, &existingMode, &existingUID, &existingGID, &size,
-		&atime, &mtime, &ctime, &creationTime, &hidden, &nlink,
-	)
-
-	if err == nil {
-		// Root exists - return it
-		return &metadata.File{
-			ID:        uuid.MustParse(id),
-			ShareName: shareName,
-			Path:      "/",
-			FileAttr: metadata.FileAttr{
-				Type:         metadata.FileType(fileType),
-				Mode:         uint32(existingMode),
-				Nlink:        uint32(nlink),
-				UID:          uint32(existingUID),
-				GID:          uint32(existingGID),
-				Size:         uint64(size),
-				Atime:        sqlcodec.FiletimeToTime(atime),
-				Mtime:        sqlcodec.FiletimeToTime(mtime),
-				Ctime:        sqlcodec.FiletimeToTime(ctime),
-				CreationTime: sqlcodec.FiletimeToTime(creationTime),
-				Hidden:       hidden,
-			},
-		}, nil
-	}
-	if !errors.Is(err, sql.ErrNoRows) {
-		return nil, mapDBError(err, "CreateRootDirectory", shareName)
-	}
-
-	// Create new root directory
-	rootID := uuid.New()
-	now := time.Now()
-
-	// Directories start with nlink = 2 ("." and the parent's entry). nlink is
-	// the sole source of truth for the hard-link count (#1166).
-	insertFileQuery := `
-		INSERT INTO inodes (
-			id, share_name,
-			file_type, mode, uid, gid, size,
-			atime, mtime, ctime, creation_time,
-			content_id, link_target, device_major, device_minor, nlink
-		) VALUES (
-			?1, ?2,
-			?3, ?4, ?5, ?6, ?7,
-			?8, ?9, ?10, ?11,
-			?12, ?13, ?14, ?15, 2
-		)
-	`
-
-	_, err = tx.tx.Exec(ctx, insertFileQuery,
-		rootID,                            // id
-		shareName,                         // share_name
-		int16(metadata.FileTypeDirectory), // file_type
-		int32(mode),                       // mode
-		int32(uid),                        // uid
-		int32(gid),                        // gid
-		int64(0),                          // size
-		sqlcodec.TimeToFiletime(now),      // atime
-		sqlcodec.TimeToFiletime(now),      // mtime
-		sqlcodec.TimeToFiletime(now),      // ctime
-		sqlcodec.TimeToFiletime(now),      // creation_time
-		nil,                               // content_id (NULL for directories)
-		nil,                               // link_target (NULL)
-		nil,                               // device_major (NULL)
-		nil,                               // device_minor (NULL)
-	)
-	if err != nil {
-		return nil, mapDBError(err, "CreateRootDirectory", shareName)
-	}
-
-	// Insert into shares table
-	insertShareQuery := `
-		INSERT INTO shares (share_name, root_file_id)
-		VALUES (?1, ?2)
-		ON CONFLICT (share_name) DO UPDATE
-		SET root_file_id = EXCLUDED.root_file_id
-	`
-
-	_, err = tx.tx.Exec(ctx, insertShareQuery, shareName, rootID)
-	if err != nil {
-		return nil, mapDBError(err, "CreateRootDirectory", shareName)
-	}
-
-	return &metadata.File{
-		ID:        rootID,
-		ShareName: shareName,
-		Path:      "/",
-		FileAttr: metadata.FileAttr{
-			Type:         metadata.FileTypeDirectory,
-			Mode:         mode,
-			Nlink:        2, // Root directories have 2 links (. and parent's entry)
-			UID:          uid,
-			GID:          gid,
-			Size:         0,
-			Atime:        now,
-			Mtime:        now,
-			Ctime:        now,
-			CreationTime: now,
-		},
-	}, nil
+	return tx.Core.CreateRootDirectory(ctx, shareName, attr)
 }
 
 // ============================================================================

--- a/pkg/metadata/storetest/dir_ops.go
+++ b/pkg/metadata/storetest/dir_ops.go
@@ -3,6 +3,7 @@ package storetest
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"sort"
@@ -312,11 +313,18 @@ func testRootDirectoryIdempotent(t *testing.T, factory StoreFactory) {
 // one and return the stored root untouched on the other, and then whether an
 // operator's config change lands depends on which call site reached it.
 func testRootDirectoryReconcilesAttrs(t *testing.T, factory StoreFactory) {
-	const shareName = "/reconcile"
+	const (
+		shareName = "/reconcile"
+		wantMode  = 0o700
+		wantUID   = 4242
+		wantGID   = 4343
+	)
 
-	// reconciled runs one create-then-recreate cycle through the caller's
-	// entry point and returns what the second call reported.
-	reconciled := func(t *testing.T, create func(context.Context, metadata.Store, *metadata.FileAttr) (*metadata.File, error)) (*metadata.File, metadata.Store) {
+	// check creates a root, re-creates it with different attributes through the
+	// caller's entry point, and asserts the returned root AND the stored one: a
+	// body that reports the new attributes without writing them would pass on
+	// the returned root alone.
+	check := func(t *testing.T, create func(context.Context, metadata.Store, *metadata.FileAttr) (*metadata.File, error)) {
 		t.Helper()
 		store := factory(t)
 		ctx := t.Context()
@@ -326,24 +334,26 @@ func testRootDirectoryReconcilesAttrs(t *testing.T, factory StoreFactory) {
 			t.Fatalf("first CreateRootDirectory() failed: %v", err)
 		}
 
-		changed := &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o700, UID: 4242, GID: 4343}
+		// Read the root before reconciling so any per-inode cache holds the
+		// pre-reconcile value. A backend that writes the new attrs but does not
+		// drop that entry then keeps serving the old ones, which a cold read
+		// after the write would not notice.
+		warm, err := store.GetRootHandle(ctx, shareName)
+		if err != nil {
+			t.Fatalf("GetRootHandle() before reconcile failed: %v", err)
+		}
+		if _, err := store.GetFile(ctx, warm); err != nil {
+			t.Fatalf("GetFile(root) before reconcile failed: %v", err)
+		}
+
+		changed := &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: wantMode, UID: wantUID, GID: wantGID}
 		got, err := create(ctx, store, changed)
 		if err != nil {
 			t.Fatalf("second CreateRootDirectory() failed: %v", err)
 		}
-		return got, store
-	}
-
-	// assertRoot checks the returned root AND the stored one: a body that
-	// returns the new attrs without writing them would pass on the first
-	// check alone.
-	assertRoot := func(t *testing.T, store metadata.Store, got *metadata.File) {
-		t.Helper()
-		ctx := t.Context()
-
-		if got.Mode != 0o700 || got.UID != 4242 || got.GID != 4343 {
-			t.Errorf("returned root not reconciled: mode=%o uid=%d gid=%d, want mode=700 uid=4242 gid=4343",
-				got.Mode, got.UID, got.GID)
+		if got.Mode != wantMode || got.UID != wantUID || got.GID != wantGID {
+			t.Errorf("returned root not reconciled: mode=%o uid=%d gid=%d, want mode=%o uid=%d gid=%d",
+				got.Mode, got.UID, got.GID, wantMode, wantUID, wantGID)
 		}
 
 		handle, err := store.GetRootHandle(ctx, shareName)
@@ -354,31 +364,105 @@ func testRootDirectoryReconcilesAttrs(t *testing.T, factory StoreFactory) {
 		if err != nil {
 			t.Fatalf("GetFile(root) failed: %v", err)
 		}
-		if stored.Mode != 0o700 || stored.UID != 4242 || stored.GID != 4343 {
-			t.Errorf("stored root not reconciled: mode=%o uid=%d gid=%d, want mode=700 uid=4242 gid=4343",
-				stored.Mode, stored.UID, stored.GID)
+		if stored.Mode != wantMode || stored.UID != wantUID || stored.GID != wantGID {
+			t.Errorf("stored root not reconciled: mode=%o uid=%d gid=%d, want mode=%o uid=%d gid=%d",
+				stored.Mode, stored.UID, stored.GID, wantMode, wantUID, wantGID)
 		}
 	}
 
 	t.Run("StorePath", func(t *testing.T) {
-		got, store := reconciled(t, func(ctx context.Context, store metadata.Store, attr *metadata.FileAttr) (*metadata.File, error) {
+		check(t, func(ctx context.Context, store metadata.Store, attr *metadata.FileAttr) (*metadata.File, error) {
 			return store.CreateRootDirectory(ctx, shareName, attr)
 		})
-		assertRoot(t, store, got)
 	})
 
 	t.Run("TransactionPath", func(t *testing.T) {
-		got, store := reconciled(t, func(ctx context.Context, store metadata.Store, attr *metadata.FileAttr) (*metadata.File, error) {
-			var root *metadata.File
-			err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
-				var txErr error
-				root, txErr = tx.CreateRootDirectory(ctx, shareName, attr)
-				return txErr
-			})
-			return root, err
-		})
-		assertRoot(t, store, got)
+		check(t, txCreateRoot(shareName))
 	})
+
+	// A zero mode means "use the default". Both entry points have to pick the
+	// SAME default, or each rewrites what the other wrote and re-creating a
+	// share flips its root mode back and forth.
+	t.Run("ZeroModeIsIdempotent", func(t *testing.T) {
+		for _, tc := range []struct {
+			name   string
+			create func(context.Context, metadata.Store, *metadata.FileAttr) (*metadata.File, error)
+		}{
+			{"StorePath", func(ctx context.Context, store metadata.Store, attr *metadata.FileAttr) (*metadata.File, error) {
+				return store.CreateRootDirectory(ctx, shareName, attr)
+			}},
+			{"TransactionPath", txCreateRoot(shareName)},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				store := factory(t)
+				ctx := t.Context()
+
+				zero := &metadata.FileAttr{Type: metadata.FileTypeDirectory}
+				first, err := tc.create(ctx, store, zero)
+				if err != nil {
+					t.Fatalf("first CreateRootDirectory() failed: %v", err)
+				}
+				second, err := tc.create(ctx, store, zero)
+				if err != nil {
+					t.Fatalf("second CreateRootDirectory() failed: %v", err)
+				}
+				if first.Mode != second.Mode {
+					t.Errorf("zero-mode root changed on re-create: %o then %o", first.Mode, second.Mode)
+				}
+			})
+		}
+	})
+
+	// A reconcile is a write like any other, so a transaction that fails after
+	// one must leave the root as it was.
+	t.Run("ReconcileRollsBack", func(t *testing.T) {
+		store := factory(t)
+		ctx := t.Context()
+
+		first := &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o755, UID: 1000, GID: 1000}
+		if _, err := store.CreateRootDirectory(ctx, shareName, first); err != nil {
+			t.Fatalf("CreateRootDirectory() failed: %v", err)
+		}
+
+		errRollback := errors.New("abandon the transaction")
+		changed := &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: wantMode, UID: wantUID, GID: wantGID}
+		err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+			if _, txErr := tx.CreateRootDirectory(ctx, shareName, changed); txErr != nil {
+				return txErr
+			}
+			return errRollback
+		})
+		if !errors.Is(err, errRollback) {
+			t.Fatalf("WithTransaction() error = %v, want %v", err, errRollback)
+		}
+
+		handle, err := store.GetRootHandle(ctx, shareName)
+		if err != nil {
+			t.Fatalf("GetRootHandle() failed: %v", err)
+		}
+		stored, err := store.GetFile(ctx, handle)
+		if err != nil {
+			t.Fatalf("GetFile(root) failed: %v", err)
+		}
+		if stored.Mode != first.Mode || stored.UID != first.UID || stored.GID != first.GID {
+			t.Errorf("reconcile survived rollback: mode=%o uid=%d gid=%d, want mode=%o uid=%d gid=%d",
+				stored.Mode, stored.UID, stored.GID, first.Mode, first.UID, first.GID)
+		}
+	})
+}
+
+// txCreateRoot returns a create func that runs CreateRootDirectory through a
+// transaction, so a caller can drive both entry points from one body.
+func txCreateRoot(shareName string) func(context.Context, metadata.Store, *metadata.FileAttr) (*metadata.File, error) {
+	return func(ctx context.Context, store metadata.Store, attr *metadata.FileAttr) (*metadata.File, error) {
+		var root *metadata.File
+		err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+			var txErr error
+			root, txErr = tx.CreateRootDirectory(ctx, shareName, attr)
+			return txErr
+		})
+		return root, err
+	}
 }
 
 // testLinkCountAgreesWithGetFile verifies that GetLinkCount reports the same

--- a/pkg/metadata/storetest/dir_ops.go
+++ b/pkg/metadata/storetest/dir_ops.go
@@ -337,13 +337,14 @@ func testRootDirectoryReconcilesAttrs(t *testing.T, factory StoreFactory) {
 		// Read the root before reconciling so any per-inode cache holds the
 		// pre-reconcile value. A backend that writes the new attrs but does not
 		// drop that entry then keeps serving the old ones, which a cold read
-		// after the write would not notice.
+		// after the write would not notice. The read has to go through the
+		// read fast path where one exists, because that is where the cache is.
 		warm, err := store.GetRootHandle(ctx, shareName)
 		if err != nil {
 			t.Fatalf("GetRootHandle() before reconcile failed: %v", err)
 		}
-		if _, err := store.GetFile(ctx, warm); err != nil {
-			t.Fatalf("GetFile(root) before reconcile failed: %v", err)
+		if _, err := readRootForCache(ctx, store, warm); err != nil {
+			t.Fatalf("read of root before reconcile failed: %v", err)
 		}
 
 		changed := &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: wantMode, UID: wantUID, GID: wantGID}
@@ -360,9 +361,9 @@ func testRootDirectoryReconcilesAttrs(t *testing.T, factory StoreFactory) {
 		if err != nil {
 			t.Fatalf("GetRootHandle() failed: %v", err)
 		}
-		stored, err := store.GetFile(ctx, handle)
+		stored, err := readRootForCache(ctx, store, handle)
 		if err != nil {
-			t.Fatalf("GetFile(root) failed: %v", err)
+			t.Fatalf("read of root failed: %v", err)
 		}
 		if stored.Mode != wantMode || stored.UID != wantUID || stored.GID != wantGID {
 			t.Errorf("stored root not reconciled: mode=%o uid=%d gid=%d, want mode=%o uid=%d gid=%d",
@@ -381,33 +382,38 @@ func testRootDirectoryReconcilesAttrs(t *testing.T, factory StoreFactory) {
 	})
 
 	// A zero mode means "use the default". Both entry points have to pick the
-	// SAME default, or each rewrites what the other wrote and re-creating a
-	// share flips its root mode back and forth.
-	t.Run("ZeroModeIsIdempotent", func(t *testing.T) {
+	// SAME default, so the create and the re-create go through DIFFERENT ones:
+	// two self-consistent but different defaults would each rewrite what the
+	// other wrote, and running one path twice could not tell.
+	t.Run("ZeroModeIsIdempotentAcrossEntryPoints", func(t *testing.T) {
+		storeCreate := func(ctx context.Context, store metadata.Store, attr *metadata.FileAttr) (*metadata.File, error) {
+			return store.CreateRootDirectory(ctx, shareName, attr)
+		}
+		txCreate := txCreateRoot(shareName)
+
 		for _, tc := range []struct {
-			name   string
-			create func(context.Context, metadata.Store, *metadata.FileAttr) (*metadata.File, error)
+			name          string
+			first, second func(context.Context, metadata.Store, *metadata.FileAttr) (*metadata.File, error)
 		}{
-			{"StorePath", func(ctx context.Context, store metadata.Store, attr *metadata.FileAttr) (*metadata.File, error) {
-				return store.CreateRootDirectory(ctx, shareName, attr)
-			}},
-			{"TransactionPath", txCreateRoot(shareName)},
+			{"StoreThenTransaction", storeCreate, txCreate},
+			{"TransactionThenStore", txCreate, storeCreate},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				store := factory(t)
 				ctx := t.Context()
 
 				zero := &metadata.FileAttr{Type: metadata.FileTypeDirectory}
-				first, err := tc.create(ctx, store, zero)
+				created, err := tc.first(ctx, store, zero)
 				if err != nil {
 					t.Fatalf("first CreateRootDirectory() failed: %v", err)
 				}
-				second, err := tc.create(ctx, store, zero)
+				recreated, err := tc.second(ctx, store, zero)
 				if err != nil {
 					t.Fatalf("second CreateRootDirectory() failed: %v", err)
 				}
-				if first.Mode != second.Mode {
-					t.Errorf("zero-mode root changed on re-create: %o then %o", first.Mode, second.Mode)
+				if created.Mode != recreated.Mode {
+					t.Errorf("zero-mode root changed when re-created through the other entry point: %o then %o",
+						created.Mode, recreated.Mode)
 				}
 			})
 		}
@@ -721,4 +727,13 @@ func testNamesOnlyMatchesWithAttrs(t *testing.T, factory StoreFactory) {
 			t.Errorf("resuming %v from a %v cursor yielded %v, want %v", c.second, c.first, got, paged)
 		}
 	}
+}
+
+// readRootForCache reads through the backend's cached path when it has one,
+// falling back to GetFile when it does not.
+func readRootForCache(ctx context.Context, store metadata.Store, handle metadata.FileHandle) (*metadata.File, error) {
+	if fr, ok := store.(fileForReadStore); ok {
+		return fr.GetFileForRead(ctx, handle)
+	}
+	return store.GetFile(ctx, handle)
 }

--- a/pkg/metadata/storetest/dir_ops.go
+++ b/pkg/metadata/storetest/dir_ops.go
@@ -2,6 +2,7 @@ package storetest
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"slices"
 	"sort"
@@ -19,6 +20,7 @@ func runDirOpsTests(t *testing.T, factory StoreFactory) {
 	t.Run("RemoveEmptyDirectory", func(t *testing.T) { testRemoveEmptyDirectory(t, factory) })
 	t.Run("NestedDirectories", func(t *testing.T) { testNestedDirectories(t, factory) })
 	t.Run("RootDirectoryIdempotent", func(t *testing.T) { testRootDirectoryIdempotent(t, factory) })
+	t.Run("RootDirectoryReconcilesAttrs", func(t *testing.T) { testRootDirectoryReconcilesAttrs(t, factory) })
 	t.Run("LinkCountAgreesWithGetFile", func(t *testing.T) { testLinkCountAgreesWithGetFile(t, factory) })
 	t.Run("DeleteChildIsIdempotent", func(t *testing.T) { testDeleteChildIsIdempotent(t, factory) })
 	t.Run("NamesOnlyMatchesWithAttrs", func(t *testing.T) { testNamesOnlyMatchesWithAttrs(t, factory) })
@@ -298,6 +300,85 @@ func testRootDirectoryIdempotent(t *testing.T, factory StoreFactory) {
 	if root1.ShareName != root2.ShareName {
 		t.Errorf("ShareName mismatch: %q vs %q", root1.ShareName, root2.ShareName)
 	}
+}
+
+// testRootDirectoryReconcilesAttrs pins what CreateRootDirectory does when the
+// share already has a root: the configured attributes win, and the stored
+// inode is rewritten to match.
+//
+// This is what makes re-attaching a share with changed root ownership or mode
+// take effect. It is asserted through the transaction as well as through the
+// store because the two are separate entry points — a backend can reconcile on
+// one and return the stored root untouched on the other, and then whether an
+// operator's config change lands depends on which call site reached it.
+func testRootDirectoryReconcilesAttrs(t *testing.T, factory StoreFactory) {
+	const shareName = "/reconcile"
+
+	// reconciled runs one create-then-recreate cycle through the caller's
+	// entry point and returns what the second call reported.
+	reconciled := func(t *testing.T, create func(context.Context, metadata.Store, *metadata.FileAttr) (*metadata.File, error)) (*metadata.File, metadata.Store) {
+		t.Helper()
+		store := factory(t)
+		ctx := t.Context()
+
+		first := &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o755, UID: 1000, GID: 1000}
+		if _, err := create(ctx, store, first); err != nil {
+			t.Fatalf("first CreateRootDirectory() failed: %v", err)
+		}
+
+		changed := &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o700, UID: 4242, GID: 4343}
+		got, err := create(ctx, store, changed)
+		if err != nil {
+			t.Fatalf("second CreateRootDirectory() failed: %v", err)
+		}
+		return got, store
+	}
+
+	// assertRoot checks the returned root AND the stored one: a body that
+	// returns the new attrs without writing them would pass on the first
+	// check alone.
+	assertRoot := func(t *testing.T, store metadata.Store, got *metadata.File) {
+		t.Helper()
+		ctx := t.Context()
+
+		if got.Mode != 0o700 || got.UID != 4242 || got.GID != 4343 {
+			t.Errorf("returned root not reconciled: mode=%o uid=%d gid=%d, want mode=700 uid=4242 gid=4343",
+				got.Mode, got.UID, got.GID)
+		}
+
+		handle, err := store.GetRootHandle(ctx, shareName)
+		if err != nil {
+			t.Fatalf("GetRootHandle() failed: %v", err)
+		}
+		stored, err := store.GetFile(ctx, handle)
+		if err != nil {
+			t.Fatalf("GetFile(root) failed: %v", err)
+		}
+		if stored.Mode != 0o700 || stored.UID != 4242 || stored.GID != 4343 {
+			t.Errorf("stored root not reconciled: mode=%o uid=%d gid=%d, want mode=700 uid=4242 gid=4343",
+				stored.Mode, stored.UID, stored.GID)
+		}
+	}
+
+	t.Run("StorePath", func(t *testing.T) {
+		got, store := reconciled(t, func(ctx context.Context, store metadata.Store, attr *metadata.FileAttr) (*metadata.File, error) {
+			return store.CreateRootDirectory(ctx, shareName, attr)
+		})
+		assertRoot(t, store, got)
+	})
+
+	t.Run("TransactionPath", func(t *testing.T) {
+		got, store := reconciled(t, func(ctx context.Context, store metadata.Store, attr *metadata.FileAttr) (*metadata.File, error) {
+			var root *metadata.File
+			err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+				var txErr error
+				root, txErr = tx.CreateRootDirectory(ctx, shareName, attr)
+				return txErr
+			})
+			return root, err
+		})
+		assertRoot(t, store, got)
+	})
 }
 
 // testLinkCountAgreesWithGetFile verifies that GetLinkCount reports the same


### PR DESCRIPTION
Part of #1828 (stage S6b). Closes #2224.

## The hoist turned into a decision

`CreateRootDirectory` existed in **eight bodies across four backends**, and they did not agree on what it does when the share already has a root:

| | pool path | transaction path |
|---|---|---|
| sqlite | reconciles | **returns stored root** |
| postgres | reconciles | **returns stored root** |
| badger | reconciles | **returns stored root** (#2224) |
| memory | **returns stored root** | **returns stored root** |

Reconciling means rewriting the stored root's mode/uid/gid to match the configured attributes, so re-attaching a share with changed root ownership takes effect. So whether an operator's config change landed depended on which entry point the caller happened to use.

Merging the copies meant choosing. **The choice is to reconcile**: the configuration is the intent, and the stored inode records a previous run's intent. That is also what three of the four pool paths — including the one production callers use (`lifecycle.go:413`) — already did.

## Note that #2224's premise is half wrong

#2224 says *"the SQL pair already converged here: #1949 routed both postgres and sqlite through `WithTransaction` and a shared `createRootDirectoryTx`."* They had not. #1949 converged the **store-level** call; `tx.CreateRootDirectory` remained a separate, non-reconciling copy in `transaction.go` on both dialects. And #2224 does not mention memory, which reconciles on neither path. The divergence was three backends wide, not one.

## The change

- SQL pair share one body on `Core`, reached by the store and the transaction over their own executor. `createRootDirectoryTx`, `getExistingRootDirectory` and both inline `transaction.go` copies are gone; the transaction keeps a two-line shadow for `sharesDirty`, matching the existing `UpdateShareOptions`/`DeleteShare` pattern.
- **badger**: the transaction path delegates to the pool path's `loadExistingRoot`.
- **memory**: its two bodies share one `reconcileRootAttrs` helper.
- `Core` gains a `Log`. These are the first shared bodies with something an operator needs to see after the fact; each dialect passes its own component-tagged logger, so the backend stays identifiable.

`-863 / +395`.

## Verification

`storetest` gains `RootDirectoryReconcilesAttrs`, asserted through **both** entry points and re-reading the stored inode via `GetFile` — a body that reports the new attributes without persisting them fails. That is not hypothetical: it is the mutation I checked it against (removing the `UpdateRootAttrs` exec while still returning the updated struct), and it fails as intended.

The test's value showed up immediately: it failed on **memory (both paths)** and **badger (transaction path)** before those were fixed, and passed on sqlite once the hoist was right.

sqlite conformance, `-race` and `golangci-lint` clean locally.

**One caveat worth stating plainly:** the postgres integration suite is *intermittent on my local postgres* right now — the package passes in isolation, but a whole-tree run failed once with six failures and once with one, and a rerun of the identical command on unmodified `develop` also failed and then passed. Timings swing 44s → 373s for the same work, so this reads as local contention rather than a defect. I am deliberately not claiming postgres green on local evidence; CI's clean container is the signal to judge this on.