### PR TITLE
fix(smb): let FILE_WRITE_ATTRIBUTES authorize a timestamp write

### DIFF
--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -472,7 +472,17 @@ func (h *Handler) setFileInfoFromStore(
 			setAttrs.Ctime = &preFile.Ctime
 		}
 
-		if _, err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, setAttrs); err != nil {
+		// Per MS-FSA 2.1.5.15.2 ("FileBasicInformation") a timestamp write is
+		// authorized by FILE_WRITE_ATTRIBUTES on the open, not by ownership of
+		// the file. Carry that grant so the metadata layer's ownership gate
+		// reflects the protocol's rule. It is scoped to this call rather than
+		// stamped on authCtx, which the rename path also hands to the
+		// parent-directory restore — a different object, on which this handle's
+		// grant says nothing. It relaxes nothing else either: a SET_INFO that
+		// also changes DOS attributes is still ownership checked.
+		basicAuthCtx := withTimestampHandleAuth(authCtx, openFile.GrantedAccess)
+
+		if _, err := metaSvc.SetFileAttributes(basicAuthCtx, openFile.MetadataHandle, setAttrs); err != nil {
 			openFile.mu.Unlock() // release before returning; refs #606.
 			logger.Debug("SET_INFO: failed to set basic info", "path", openFile.Name().Path, "error", err)
 			return setInfoStatus(common.MapToSMB(err)), nil
@@ -534,7 +544,9 @@ func (h *Handler) setFileInfoFromStore(
 					basePropagate.Atime != nil || basePropagate.CreationTime != nil ||
 					basePropagate.Mode != nil || basePropagate.Hidden != nil {
 					if baseHandle, encErr := metadata.EncodeFileHandle(baseFile); encErr == nil {
-						_, _ = metaSvc.SetFileAttributes(authCtx, baseHandle, basePropagate)
+						// A stream shares its base file's security descriptor, so
+						// the grant carried on this handle is a grant on the base.
+						_, _ = metaSvc.SetFileAttributes(basicAuthCtx, baseHandle, basePropagate)
 					}
 				}
 			}
@@ -1860,6 +1872,16 @@ func (h *Handler) snapshotChangeTime(authCtx *metadata.AuthContext, handle metad
 	}
 }
 
+// withTimestampHandleAuth returns a copy of authCtx carrying the open handle's
+// FILE_WRITE_ATTRIBUTES grant, which authorizes an explicit timestamp write in
+// the metadata layer in place of POSIX ownership. A copy, because the caller's
+// AuthContext outlives the timestamp write the grant is meant for.
+func withTimestampHandleAuth(authCtx *metadata.AuthContext, grantedAccess uint32) *metadata.AuthContext {
+	scoped := *authCtx
+	scoped.TimestampAuthorizedByHandle = hasAccessRight(grantedAccess, uint32(types.FileWriteAttributes))
+	return &scoped
+}
+
 // restoreFrozenTimestamps restores timestamps that are frozen via SET_INFO -1 sentinel.
 // Called after operations that unconditionally update timestamps (WRITE, truncate).
 //
@@ -1905,7 +1927,13 @@ func (h *Handler) restoreFrozenTimestamps(authCtx *metadata.AuthContext, openFil
 		"frozenAtime", frozenAtime)
 
 	metaSvc := h.Registry.GetMetadataService()
-	if _, err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, restoreAttrs); err != nil {
+	// The restore writes explicit timestamps. The handle being restored is the
+	// one that froze them, and freezing required FILE_WRITE_ATTRIBUTES on it, so
+	// carry that grant through rather than letting the restore succeed or fail
+	// on who owns the file.
+	if _, err := metaSvc.SetFileAttributes(
+		withTimestampHandleAuth(authCtx, openFile.GrantedAccess),
+		openFile.MetadataHandle, restoreAttrs); err != nil {
 		logger.Debug("restoreFrozenTimestamps: failed", "path", openFile.Name().Path, "error", err)
 		return
 	}

--- a/internal/adapter/smb/handlers/set_info_timestamp_handle_authz_test.go
+++ b/internal/adapter/smb/handlers/set_info_timestamp_handle_authz_test.go
@@ -1,0 +1,134 @@
+// Handler-level coverage for the FILE_WRITE_ATTRIBUTES → timestamp-write
+// bridge. SMB authorizes a SET_INFO timestamp write by the access right on the
+// open handle (MS-FSA 2.1.5.15.2, "FileBasicInformation"), while the metadata
+// layer's POSIX gate requires ownership. Without the bridge a non-owner holding
+// exactly the right the protocol names is refused.
+package handlers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// storeForeignOwnedOpen creates a file owned by UID 2002 with mode 0o600 — so
+// the fixture's UID-1000 caller is neither owner nor POSIX-writer — and
+// registers a hand-built OpenFile for it carrying grantedAccess.
+func storeForeignOwnedOpen(
+	t *testing.T,
+	h *Handler,
+	ctx *SMBHandlerContext,
+	rootHandle metadata.FileHandle,
+	name string,
+	fileID byte,
+	grantedAccess uint32,
+) (*OpenFile, metadata.FileHandle) {
+	t.Helper()
+
+	rootUID, rootGID := uint32(0), uint32(0)
+	rootCtx := &metadata.AuthContext{
+		Context:  context.Background(),
+		Identity: &metadata.Identity{UID: &rootUID, GID: &rootGID},
+	}
+	metaSvc := h.Registry.GetMetadataService()
+	file, _, err := metaSvc.CreateFile(rootCtx, rootHandle, name, &metadata.FileAttr{
+		Type: metadata.FileTypeRegular,
+		Mode: 0o600,
+		UID:  2002,
+		GID:  2002,
+	})
+	if err != nil {
+		t.Fatalf("CreateFile(%q): %v", name, err)
+	}
+	fileHandle, err := metadata.EncodeFileHandle(file)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle: %v", err)
+	}
+
+	open := (&OpenFile{
+		FileID:         [16]byte{fileID},
+		MetadataHandle: fileHandle,
+		ShareName:      ctx.ShareName,
+		SessionID:      ctx.SessionID,
+		TreeID:         ctx.TreeID,
+		DesiredAccess:  grantedAccess,
+		GrantedAccess:  grantedAccess,
+	}).WithName(OpenName{Path: name, FileName: name, ParentHandle: rootHandle})
+	h.StoreOpenFile(open)
+	return open, fileHandle
+}
+
+// TestSetInfo_BasicInfo_WriteAttributesAuthorizesNonOwnerTimestamp asserts a
+// non-owner whose handle carries FILE_WRITE_ATTRIBUTES can set a timestamp
+// through SET_INFO, and that the stored value actually changed.
+func TestSetInfo_BasicInfo_WriteAttributesAuthorizesNonOwnerTimestamp(t *testing.T) {
+	h, ctx, rootHandle := setupStreamsDisabledShare(t, false)
+
+	open, fileHandle := storeForeignOwnedOpen(t, h, ctx, rootHandle, "foreign.txt", 0x01,
+		uint32(types.FileWriteAttributes)|uint32(types.FileReadAttributes))
+
+	want := time.Date(2031, 5, 6, 7, 8, 9, 0, time.UTC)
+	resp, err := h.SetInfo(ctx, &SetInfoRequest{
+		InfoType:      types.SMB2InfoTypeFile,
+		FileInfoClass: uint8(types.FileBasicInformation),
+		FileID:        open.FileID,
+		Buffer:        encodeBasicInfo(0, 0, types.TimeToFiletime(want), 0, 0),
+	})
+	if err != nil {
+		t.Fatalf("SetInfo: %v", err)
+	}
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("SET_INFO BasicInformation on a non-owned file with FILE_WRITE_ATTRIBUTES = %v, want STATUS_SUCCESS", resp.Status)
+	}
+
+	file, err := h.Registry.GetMetadataService().GetFile(context.Background(), fileHandle)
+	if err != nil {
+		t.Fatalf("GetFile: %v", err)
+	}
+	if !file.Mtime.Equal(want) {
+		t.Errorf("stored Mtime = %v, want %v — the timestamp write was accepted but did not land",
+			file.Mtime.UTC(), want)
+	}
+}
+
+// TestSetInfo_BasicInfo_WithoutWriteAttributesStillDenied is the control: the
+// bridge is keyed on the access right, so a handle lacking
+// FILE_WRITE_ATTRIBUTES is still refused at the SET_INFO gate. Without this the
+// first test could pass on a build that authorized every SET_INFO.
+func TestSetInfo_BasicInfo_WithoutWriteAttributesStillDenied(t *testing.T) {
+	h, ctx, rootHandle := setupStreamsDisabledShare(t, false)
+
+	open, fileHandle := storeForeignOwnedOpen(t, h, ctx, rootHandle, "noattr.txt", 0x02,
+		uint32(types.FileReadAttributes)|uint32(types.FileReadData))
+
+	before, err := h.Registry.GetMetadataService().GetFile(context.Background(), fileHandle)
+	if err != nil {
+		t.Fatalf("GetFile: %v", err)
+	}
+	wantUnchanged := before.Mtime
+
+	want := time.Date(2031, 5, 6, 7, 8, 9, 0, time.UTC)
+	resp, err := h.SetInfo(ctx, &SetInfoRequest{
+		InfoType:      types.SMB2InfoTypeFile,
+		FileInfoClass: uint8(types.FileBasicInformation),
+		FileID:        open.FileID,
+		Buffer:        encodeBasicInfo(0, 0, types.TimeToFiletime(want), 0, 0),
+	})
+	if err != nil {
+		t.Fatalf("SetInfo: %v", err)
+	}
+	if resp.Status != types.StatusAccessDenied {
+		t.Fatalf("SET_INFO BasicInformation without FILE_WRITE_ATTRIBUTES = %v, want STATUS_ACCESS_DENIED", resp.Status)
+	}
+
+	after, err := h.Registry.GetMetadataService().GetFile(context.Background(), fileHandle)
+	if err != nil {
+		t.Fatalf("GetFile: %v", err)
+	}
+	if !after.Mtime.Equal(wantUnchanged) {
+		t.Errorf("Mtime moved to %v on a denied SET_INFO; want %v", after.Mtime.UTC(), wantUnchanged.UTC())
+	}
+}

--- a/pkg/metadata/auth_identity.go
+++ b/pkg/metadata/auth_identity.go
@@ -62,6 +62,29 @@ type AuthContext struct {
 	// of this flag.
 	WriteAuthorizedByHandle bool
 
+	// TimestampAuthorizedByHandle indicates that the SMB open handle driving this
+	// operation was granted FILE_WRITE_ATTRIBUTES at CREATE time. When set, an
+	// explicit timestamp write (SetAttrs carrying only Atime / Mtime / Ctime /
+	// CreationTime) is authorized without POSIX ownership of the file: MS-FSA
+	// 2.1.5.15.2 ("FileBasicInformation") authorizes the write by that right on
+	// the open, where POSIX requires ownership (or root) for utimensat() with
+	// explicit times. Without this flag a non-owner holding a handle opened with
+	// exactly the right the protocol names is refused by the ownership gate.
+	//
+	// Deliberately NOT the same flag as WriteAuthorizedByHandle, which is derived
+	// from FILE_WRITE_DATA / FILE_APPEND_DATA: MS-FSCC 2.6 keeps the two rights
+	// distinct, so neither may confer the other.
+	//
+	// Scope is exactly the explicit-timestamp write — it does not relax chmod,
+	// chown, ACL replace, truncate or EA mutation — and it never overrides an
+	// explicit DENY ACE or either read-only share ceiling, both of which
+	// SetFileAttributes evaluates first.
+	//
+	// Set ONLY by SMB op handlers, derived from OpenFile.GrantedAccess. NFS is
+	// PATH-BASED — it has no handle and MUST leave this false, so POSIX timestamp
+	// semantics on the NFS path are unchanged.
+	TimestampAuthorizedByHandle bool
+
 	// LockClientID is the lock-layer client identifier used for lease exclusion.
 	// This must match the LockOwner.ClientID format used when acquiring leases.
 	// For SMB: "smb:<sessionID>", for NFS: the NFS client identifier.

--- a/pkg/metadata/auth_permissions_acl_short_circuit_test.go
+++ b/pkg/metadata/auth_permissions_acl_short_circuit_test.go
@@ -213,3 +213,74 @@ func TestCheckPermissions_AllowOnlyACLKeepsHandleWriteBypass(t *testing.T) {
 }
 
 func strPtr(s string) *string { return &s }
+
+// TestSetFileAttributes_ACLDenyOverridesHandleTimestamp is the timestamp
+// counterpart of TestCheckPermissions_ACLDenyOverridesHandleWrite: an explicit
+// DENY ACE beats TimestampAuthorizedByHandle, so a handle grant can never let a
+// caller past a deny the DACL expresses.
+//
+// As with the write bypass this cannot arise in production — the open-time DACL
+// gate strips FILE_WRITE_ATTRIBUTES when a deny ACE covers it, so the handler
+// never sets the flag on such a file. The flag is set here anyway to prove the
+// metadata-layer guard holds even if it were mis-set.
+func TestSetFileAttributes_ACLDenyOverridesHandleTimestamp(t *testing.T) {
+	f := newTestFixture(t)
+
+	requesterUID := uint32(1001)
+	requesterSID := "S-1-5-21-1-2-3-2001"
+
+	deniedACL := &acl.ACL{
+		ACEs: []acl.ACE{
+			{
+				Type:       acl.ACE4_ACCESS_DENIED_ACE_TYPE,
+				Who:        "sid:" + requesterSID,
+				AccessMask: acl.ACE4_WRITE_ATTRIBUTES,
+			},
+			{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        acl.SpecialEveryone,
+				AccessMask: 0xFFFFFFFF,
+			},
+		},
+	}
+	created, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "deny_ts.txt",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o777,
+			UID:  2002, // not the requester
+			GID:  2002,
+			ACL:  deniedACL,
+		})
+	require.NoError(t, err)
+	handle, err := metadata.EncodeShareHandle(f.shareName, created.ID)
+	require.NoError(t, err)
+
+	authCtx := f.authContext(requesterUID, 1001)
+	authCtx.Identity.SID = strPtr(requesterSID)
+	authCtx.TimestampAuthorizedByHandle = true
+	authCtx.ShareReadOnly = false
+
+	_, err = f.service.SetFileAttributes(authCtx, handle, &metadata.SetAttrs{Mtime: &stampTime})
+	require.Error(t, err, "an explicit deny ACE must beat TimestampAuthorizedByHandle")
+
+	// The same grant on a file with an allow-only ACL still works, so the guard
+	// is keyed on the deny and not on the mere presence of an ACL.
+	allowOnly, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "allow_ts.txt",
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: 0o777,
+			UID:  2002,
+			GID:  2002,
+			ACL: &acl.ACL{ACEs: []acl.ACE{{
+				Type:       acl.ACE4_ACCESS_ALLOWED_ACE_TYPE,
+				Who:        acl.SpecialEveryone,
+				AccessMask: 0xFFFFFFFF,
+			}}},
+		})
+	require.NoError(t, err)
+	allowHandle, err := metadata.EncodeShareHandle(f.shareName, allowOnly.ID)
+	require.NoError(t, err)
+
+	_, err = f.service.SetFileAttributes(authCtx, allowHandle, &metadata.SetAttrs{Mtime: &stampTime})
+	require.NoError(t, err, "an allow-only ACL must keep the handle timestamp grant working")
+}

--- a/pkg/metadata/auth_permissions_readonly_share_test.go
+++ b/pkg/metadata/auth_permissions_readonly_share_test.go
@@ -466,3 +466,53 @@ func TestRemoveFile_DeleteAccessStillSucceedsOnWritableShare(t *testing.T) {
 	_, _, err = f.service.RemoveFile(f.smbDeleteContext(uid, gid), f.rootHandle, "removable.txt")
 	require.NoError(t, err, "delete on a writable share must still succeed")
 }
+
+// TestSetFileAttributes_ReadOnlyShareBlocksHandleTimestamp asserts both
+// read-only ceilings beat TimestampAuthorizedByHandle: the per-user
+// AuthContext.ShareReadOnly flag and the store-level ShareOptions.ReadOnly. A
+// SETATTR is a write, so neither a read-only user nor any user on a read-only
+// share may set a timestamp, whatever the handle was granted.
+func TestSetFileAttributes_ReadOnlyShareBlocksHandleTimestamp(t *testing.T) {
+	uid, gid := uint32(1001), uint32(1001)
+
+	t.Run("per-user read-only", func(t *testing.T) {
+		f := newTestFixture(t)
+		created, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "ro_user.txt",
+			&metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o777, UID: 2002, GID: 2002})
+		require.NoError(t, err)
+		handle, err := metadata.EncodeShareHandle(f.shareName, created.ID)
+		require.NoError(t, err)
+
+		// Baseline: the handle grant works on a writable share.
+		rw := f.authContext(uid, gid)
+		rw.TimestampAuthorizedByHandle = true
+		_, err = f.service.SetFileAttributes(rw, handle, &metadata.SetAttrs{Mtime: &stampTime})
+		require.NoError(t, err, "precondition: handle timestamp grant works on a writable share")
+
+		ro := f.authContext(uid, gid)
+		ro.TimestampAuthorizedByHandle = true
+		ro.ShareReadOnly = true
+		_, err = f.service.SetFileAttributes(ro, handle, &metadata.SetAttrs{Mtime: &stampTime})
+		require.Error(t, err, "per-user read-only must beat TimestampAuthorizedByHandle")
+		requireErrorCode(t, err, metadata.ErrReadOnly)
+	})
+
+	t.Run("store-level read-only", func(t *testing.T) {
+		f := newTestFixture(t)
+		created, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, "ro_store.txt",
+			&metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o777, UID: 2002, GID: 2002})
+		require.NoError(t, err)
+		handle, err := metadata.EncodeShareHandle(f.shareName, created.ID)
+		require.NoError(t, err)
+
+		require.NoError(t, f.store.UpdateShareOptions(context.Background(), f.shareName,
+			&metadata.ShareOptions{ReadOnly: true}))
+
+		authCtx := f.authContext(uid, gid)
+		authCtx.TimestampAuthorizedByHandle = true
+		authCtx.ShareReadOnly = false
+		_, err = f.service.SetFileAttributes(authCtx, handle, &metadata.SetAttrs{Mtime: &stampTime})
+		require.Error(t, err, "store-level read-only must beat TimestampAuthorizedByHandle")
+		requireErrorCode(t, err, metadata.ErrReadOnly)
+	})
+}

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -306,11 +306,27 @@ func (s *Service) SetFileAttributes(ctx *AuthContext, handle FileHandle, attrs *
 	// as an alternative to ownership (POSIX semantics).
 	writePermSufficient := onlySettingTimesToNow || onlySettingSize || onlyClearingSuidSgid
 
+	// SMB authorizes an explicit timestamp write by FILE_WRITE_ATTRIBUTES on the
+	// open handle rather than by ownership, so such a handle satisfies the
+	// ownership gate below — but only for a SetAttrs that changes nothing except
+	// the four timestamps, and never past an explicit DENY ACE, which encodes
+	// intent POSIX bits cannot express (mirroring the handle write bypass in
+	// checkFilePermissions). Both read-only ceilings are already enforced by
+	// shareForbidsWrites above. See AuthContext.TimestampAuthorizedByHandle.
+	onlySettingExplicitTimes := noOwnershipAttrs && attrs.Size == nil &&
+		attrs.ModeOrMask == nil && attrs.ModeAndNotMask == nil &&
+		attrs.Hidden == nil && attrs.ACL == nil && len(attrs.EAMutations) == 0 &&
+		!attrs.AtimeNow && !attrs.MtimeNow &&
+		(attrs.Atime != nil || attrs.Mtime != nil ||
+			attrs.Ctime != nil || attrs.CreationTime != nil)
+	timestampAuthorizedByHandle := ctx.TimestampAuthorizedByHandle &&
+		onlySettingExplicitTimes && !acl.HasExplicitDeny(file.ACL)
+
 	if writePermSufficient && !isOwner && !isRoot {
 		if err := s.checkWritePermission(ctx, handle); err != nil {
 			return nil, err
 		}
-	} else if !isOwner && !isRoot {
+	} else if !isOwner && !isRoot && !timestampAuthorizedByHandle {
 		return nil, &StoreError{
 			Code:    ErrPermissionDenied,
 			Message: "operation not permitted",

--- a/pkg/metadata/file_modify_timestamp_handle_test.go
+++ b/pkg/metadata/file_modify_timestamp_handle_test.go
@@ -1,0 +1,209 @@
+package metadata_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/stretchr/testify/require"
+)
+
+// requireErrorCode asserts err is a StoreError carrying the given code.
+func requireErrorCode(t *testing.T, err error, want metadata.ErrorCode) {
+	t.Helper()
+	var storeErr *metadata.StoreError
+	require.ErrorAs(t, err, &storeErr)
+	require.Equal(t, want, storeErr.Code)
+}
+
+// requirePermissionDenied asserts err is a StoreError carrying
+// ErrPermissionDenied.
+func requirePermissionDenied(t *testing.T, err error) {
+	t.Helper()
+	requireErrorCode(t, err, metadata.ErrPermissionDenied)
+}
+
+// stampTime is an arbitrary fixed explicit timestamp used by the
+// TimestampAuthorizedByHandle tests.
+var stampTime = time.Unix(1_000_000, 0).UTC()
+
+// newForeignOwnedFile creates a regular file owned by UID 2002 under the
+// fixture root and returns its handle. Mode 0o600 gives a non-owner neither
+// POSIX write nor read, so nothing but the handle grant can authorize a
+// timestamp write on it.
+func newForeignOwnedFile(t *testing.T, f *testFixture, name string, mode uint32) metadata.FileHandle {
+	t.Helper()
+	created, _, err := f.service.CreateFile(f.rootContext(), f.rootHandle, name,
+		&metadata.FileAttr{
+			Type: metadata.FileTypeRegular,
+			Mode: mode,
+			UID:  2002,
+			GID:  2002,
+		})
+	require.NoError(t, err)
+	handle, err := metadata.EncodeShareHandle(f.shareName, created.ID)
+	require.NoError(t, err)
+	return handle
+}
+
+// TestSetFileAttributes_TimestampAuthorizedByHandleGrantsNonOwner asserts the
+// headline case: SMB authorizes a timestamp write by FILE_WRITE_ATTRIBUTES on
+// the open handle, not by ownership of the file, so a non-owner holding such a
+// handle can set an explicit timestamp the POSIX ownership gate would refuse.
+func TestSetFileAttributes_TimestampAuthorizedByHandleGrantsNonOwner(t *testing.T) {
+	f := newTestFixture(t)
+	handle := newForeignOwnedFile(t, f, "handle_ts.txt", 0o600)
+
+	// Precondition: without the handle grant the non-owner is refused.
+	denyCtx := f.authContext(1001, 1001)
+	_, err := f.service.SetFileAttributes(denyCtx, handle, &metadata.SetAttrs{Mtime: &stampTime})
+	require.Error(t, err, "precondition: non-owner explicit timestamp must be denied without the handle grant")
+	requirePermissionDenied(t, err)
+
+	// With the grant the same write lands.
+	authCtx := f.authContext(1001, 1001)
+	authCtx.TimestampAuthorizedByHandle = true
+	_, err = f.service.SetFileAttributes(authCtx, handle, &metadata.SetAttrs{Mtime: &stampTime})
+	require.NoError(t, err, "FILE_WRITE_ATTRIBUTES on the handle must authorize an explicit timestamp write")
+
+	file, err := f.service.GetFile(authCtx.Context, handle)
+	require.NoError(t, err)
+	require.True(t, file.Mtime.Equal(stampTime), "stored Mtime = %v, want %v", file.Mtime, stampTime)
+}
+
+// TestSetFileAttributes_TimestampHandleGrantCoversAllFourStamps asserts the
+// relaxation covers every timestamp FILE_BASIC_INFORMATION can carry, not just
+// Mtime.
+func TestSetFileAttributes_TimestampHandleGrantCoversAllFourStamps(t *testing.T) {
+	f := newTestFixture(t)
+
+	for _, tc := range []struct {
+		name  string
+		attrs *metadata.SetAttrs
+	}{
+		{"Atime", &metadata.SetAttrs{Atime: &stampTime}},
+		{"Mtime", &metadata.SetAttrs{Mtime: &stampTime}},
+		{"Ctime", &metadata.SetAttrs{Ctime: &stampTime}},
+		{"CreationTime", &metadata.SetAttrs{CreationTime: &stampTime}},
+		{"All", &metadata.SetAttrs{
+			Atime: &stampTime, Mtime: &stampTime,
+			Ctime: &stampTime, CreationTime: &stampTime,
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			handle := newForeignOwnedFile(t, f, "stamps_"+tc.name+".txt", 0o600)
+			authCtx := f.authContext(1001, 1001)
+			authCtx.TimestampAuthorizedByHandle = true
+			_, err := f.service.SetFileAttributes(authCtx, handle, tc.attrs)
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestSetFileAttributes_TimestampHandleGrantDoesNotWiden asserts the flag
+// relaxes the ownership gate for a timestamp-only change and nothing else. A
+// SetAttrs that also carries a mode, ownership, size, DOS-attribute or EA
+// change still requires ownership, so the flag cannot be used to smuggle a
+// chmod or a truncate past the gate by pairing it with a timestamp.
+func TestSetFileAttributes_TimestampHandleGrantDoesNotWiden(t *testing.T) {
+	f := newTestFixture(t)
+
+	mode := uint32(0o777)
+	uid := uint32(1001)
+	size := uint64(4096)
+	mask := uint32(0o6000)
+	hidden := true
+
+	for _, tc := range []struct {
+		name  string
+		attrs *metadata.SetAttrs
+	}{
+		{"mode", &metadata.SetAttrs{Mtime: &stampTime, Mode: &mode}},
+		{"uid", &metadata.SetAttrs{Mtime: &stampTime, UID: &uid}},
+		{"gid", &metadata.SetAttrs{Mtime: &stampTime, GID: &uid}},
+		{"size", &metadata.SetAttrs{Mtime: &stampTime, Size: &size}},
+		{"modeOrMask", &metadata.SetAttrs{Mtime: &stampTime, ModeOrMask: &mask}},
+		{"modeAndNotMask", &metadata.SetAttrs{Mtime: &stampTime, ModeAndNotMask: &mask}},
+		{"hidden", &metadata.SetAttrs{Mtime: &stampTime, Hidden: &hidden}},
+		{"ea", &metadata.SetAttrs{
+			Mtime:       &stampTime,
+			EAMutations: []metadata.EAMutation{{Name: "user.x", Value: []byte("v")}},
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			handle := newForeignOwnedFile(t, f, "widen_"+tc.name+".txt", 0o600)
+			authCtx := f.authContext(1001, 1001)
+			authCtx.TimestampAuthorizedByHandle = true
+			_, err := f.service.SetFileAttributes(authCtx, handle, tc.attrs)
+			// The denial code varies by field — a size change reaches the
+			// POSIX truncate branch and is refused as access-denied rather
+			// than not-permitted. What matters is that none of these are
+			// authorized by the timestamp handle grant.
+			require.Error(t, err, "handle timestamp grant must not authorize a %s change", tc.name)
+		})
+	}
+}
+
+// TestSetFileAttributes_TimestampAndWriteHandleGrantsAreDistinct asserts the
+// two handle grants stay separate, as MS-FSCC 2.6 requires: FILE_WRITE_DATA
+// does not confer the right to set timestamps, and FILE_WRITE_ATTRIBUTES does
+// not confer data write.
+func TestSetFileAttributes_TimestampAndWriteHandleGrantsAreDistinct(t *testing.T) {
+	f := newTestFixture(t)
+	handle := newForeignOwnedFile(t, f, "distinct.txt", 0o600)
+
+	// Data-write handle only: the timestamp write stays denied.
+	writeOnly := f.authContext(1001, 1001)
+	writeOnly.WriteAuthorizedByHandle = true
+	_, err := f.service.SetFileAttributes(writeOnly, handle, &metadata.SetAttrs{Mtime: &stampTime})
+	require.Error(t, err, "FILE_WRITE_DATA must not confer the right to set timestamps")
+	requirePermissionDenied(t, err)
+
+	// Attribute-write handle only: data write stays denied.
+	tsOnly := f.authContext(1001, 1001)
+	tsOnly.TimestampAuthorizedByHandle = true
+	got, err := f.service.CheckPermissions(tsOnly, handle, metadata.PermissionWrite)
+	require.NoError(t, err)
+	require.Zero(t, got&metadata.PermissionWrite,
+		"FILE_WRITE_ATTRIBUTES must not confer data write")
+}
+
+// TestSetFileAttributes_NFSTimestampSemanticsUnchanged pins that the NFS path
+// is untouched by the bridge. NFS is path-based, has no handle, and never sets
+// TimestampAuthorizedByHandle, so POSIX ownership remains the rule for an
+// explicit timestamp write and write permission alone remains insufficient —
+// while UTIME_NOW continues to be satisfied by write permission.
+func TestSetFileAttributes_NFSTimestampSemanticsUnchanged(t *testing.T) {
+	f := newTestFixture(t)
+	// Mode 0o666: a non-owner has POSIX write, which POSIX says is NOT enough
+	// for utimensat() with explicit times but IS enough for UTIME_NOW.
+	handle := newForeignOwnedFile(t, f, "nfs.txt", 0o666)
+
+	nfsCtx := f.authContext(1001, 1001)
+	require.False(t, nfsCtx.TimestampAuthorizedByHandle,
+		"an NFS AuthContext must never carry the SMB handle grant")
+
+	got, err := f.service.CheckPermissions(nfsCtx, handle, metadata.PermissionWrite)
+	require.NoError(t, err)
+	require.NotZero(t, got&metadata.PermissionWrite, "precondition: non-owner has POSIX write on 0o666")
+
+	_, err = f.service.SetFileAttributes(nfsCtx, handle, &metadata.SetAttrs{Mtime: &stampTime})
+	require.Error(t, err, "POSIX requires ownership for an explicit timestamp write")
+	requirePermissionDenied(t, err)
+
+	// UTIME_NOW is unchanged: write permission is sufficient.
+	_, err = f.service.SetFileAttributes(nfsCtx, handle, &metadata.SetAttrs{MtimeNow: true})
+	require.NoError(t, err, "UTIME_NOW must remain satisfied by write permission")
+}
+
+// TestSetFileAttributes_TimestampHandleGrantOwnerUnchanged asserts
+// the owner and root paths are unchanged: the flag is additive, so an owner who
+// never had a handle grant keeps working exactly as before.
+func TestSetFileAttributes_TimestampHandleGrantOwnerUnchanged(t *testing.T) {
+	f := newTestFixture(t)
+	handle := newForeignOwnedFile(t, f, "owner.txt", 0o600)
+
+	owner := f.authContext(2002, 2002)
+	_, err := f.service.SetFileAttributes(owner, handle, &metadata.SetAttrs{Mtime: &stampTime})
+	require.NoError(t, err, "owner must still be able to set an explicit timestamp without any handle grant")
+}


### PR DESCRIPTION
## What was wrong

SMB and POSIX disagree about who may set a timestamp, and the two models never met.

SMB authorizes it by an access right on the **open handle**: MS-FSA 2.1.5.15.2
("FileBasicInformation") requires `FILE_WRITE_ATTRIBUTES` on the open, and
MS-FSCC 2.6 keeps that right distinct from `FILE_WRITE_DATA`. POSIX authorizes it
by **ownership** — `utimensat()` with explicit times needs the owner or root;
write permission is only enough for `UTIME_NOW`.

`pkg/metadata/file_modify.go` implemented the POSIX rule alone:

```go
if writePermSufficient && !isOwner && !isRoot {
    ... checkWritePermission ...
} else if !isOwner && !isRoot {
    return nil, &StoreError{Code: ErrPermissionDenied, ...}
}
```

`writePermSufficient` covers `UTIME_NOW`, truncate and the SUID/SGID clear — not
an explicit timestamp. So an explicit timestamp write by a non-owner fell into
the flat `else if` and was refused before any handle information was consulted.

`AuthContext.WriteAuthorizedByHandle` did not help: it is only read inside
`checkWritePermission` (`auth_permissions.go`), which this path never reaches,
and it is derived from `FILE_WRITE_DATA` anyway — the wrong right.

The consequence is that a non-owner holding a handle opened with exactly the
right the protocol names could not set a timestamp over SMB at all. The same gate
is what made the frozen-timestamp restore succeed or fail on who owned the file.

## Premise check

Confirmed before writing anything, on unmodified `develop`:

```
non-owner explicit Mtime                             => PermissionDenied: operation not permitted (path: /p.txt)
non-owner + WriteAuthorizedByHandle explicit Mtime   => PermissionDenied: operation not permitted (path: /p.txt)
```

The second line is the load-bearing half: the existing handle flag makes no
difference on this path, so it could not be the fix.

## The fix

A new, dedicated `AuthContext.TimestampAuthorizedByHandle`, set from
`OpenFile.GrantedAccess`, satisfies the ownership gate for a `SetAttrs` that
changes **nothing but the four timestamps**.

Why a new flag rather than reusing `WriteAuthorizedByHandle`: that one is derived
from `hasWriteAccess` (`FILE_WRITE_DATA` / `FILE_APPEND_DATA`). Reusing it would
mean a handle with data write but no attribute write silently gains timestamp
rights, and a handle with attribute write but no data write still does not — both
wrong per MS-FSCC 2.6. The two rights stay two flags.

Why not refuse at open instead: the open is conformant. `FILE_WRITE_ATTRIBUTES`
is exactly the right a Windows client asks for when it intends to set a
timestamp, and refusing it would break clients that never needed ownership.

Constraints preserved, mirroring how `WriteAuthorizedByHandle` is fenced in
`auth_permissions.go`:

- **Explicit DENY ACE still wins.** A DENY encodes intent POSIX bits cannot
  express. Guarded with `!acl.HasExplicitDeny(file.ACL)`.
- **Both read-only ceilings still win** — the per-user `ctx.ShareReadOnly` and
  the store-level `ShareOptions.ReadOnly`. `shareForbidsWrites` already runs
  above the ownership gate, so a SETATTR on a read-only share never reaches it.
- **No widening.** The relaxation applies only when mode, ownership, size,
  DOS-attribute masks, Hidden, ACL and EA mutations are all absent. Pairing a
  timestamp with a chmod does not smuggle the chmod through.
- **NFS is untouched.** NFS is path-based, has no handle, and never sets the
  flag, so POSIX timestamp semantics on the NFS path are exactly as before —
  including that write permission remains insufficient for an explicit time and
  sufficient for `UTIME_NOW`.

The grant is scoped to the call it belongs to rather than stamped on the
operation's shared `AuthContext`, so it cannot leak onto a different object —
notably not onto the parent-directory restore, which is driven by a handle the
caller may not hold.

## Verification

Every new test was run against a deliberately broken build (fix reverted, test
kept) and confirmed to fail:

| Mutation | Caught by |
| --- | --- |
| gate reverted, flag never consulted | 4 tests fail |
| deny-ACE guard removed | `ACLDenyOverridesHandleTimestamp` fails |
| timestamp-only predicate forced true | `TimestampHandleGrantDoesNotWiden` fails |
| handler stops deriving the flag from `GrantedAccess` | `WriteAttributesAuthorizesNonOwnerTimestamp` fails |

The handler-level pair carries its own control: a handle **without**
`FILE_WRITE_ATTRIBUTES` must still get `STATUS_ACCESS_DENIED` and must not move
the stored Mtime, so the positive case cannot pass on a build that authorized
every SET_INFO.

Also run: `go build ./...`, `go vet ./...`, `go test ./...`, and the
integration-tagged suite against a local postgres
(`go test -tags=integration -p 1 ./pkg/metadata/...`) — postgres store tests are
invisible to a plain `go test ./...`.

Closes #2281
