### PR TITLE
fix(postgres): create the filesystem_meta table the share queries read

### DIFF
--- a/pkg/metadata/store/postgres/migrations/000046_filesystem_meta.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000046_filesystem_meta.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS filesystem_meta;

--- a/pkg/metadata/store/postgres/migrations/000046_filesystem_meta.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000046_filesystem_meta.up.sql
@@ -1,0 +1,11 @@
+-- Create the filesystem_meta table the share queries have always read and
+-- written. It was present in the sqlite schema from the start but never
+-- created here, so GetFilesystemMeta failed with an undefined-relation error
+-- on every call and PutFilesystemMeta persisted nothing.
+--
+-- Shape mirrors sqlite: one row per share holding the JSON-encoded
+-- metadata.FilesystemMeta blob.
+CREATE TABLE IF NOT EXISTS filesystem_meta (
+    share_name TEXT PRIMARY KEY,
+    meta       TEXT NOT NULL DEFAULT '{}'
+);

--- a/pkg/metadata/store/postgres/snapshot_store.go
+++ b/pkg/metadata/store/postgres/snapshot_store.go
@@ -51,7 +51,9 @@ const (
 	// by position and an older stream would run out of values partway through the
 	// row rather than default the new column — the version gate is what turns
 	// that into a legible refusal.
-	postgresSchemaVersion = uint32(10)
+	// v11 adds the filesystem_meta table section (migration 000046), raising
+	// the backup table count by one.
+	postgresSchemaVersion = uint32(11)
 )
 
 // backupTables lists every metadata table in FK-safe dependency order
@@ -66,6 +68,7 @@ var backupTables = []string{
 	"filesystem_capabilities",
 	"inodes",
 	"shares",
+	"filesystem_meta",
 	"parent_child_map",
 	"file_block_refs",
 	"file_blocks",

--- a/pkg/metadata/store/sql/shares.go
+++ b/pkg/metadata/store/sql/shares.go
@@ -94,13 +94,9 @@ func (c *Core) ListShares(ctx context.Context) ([]string, error) {
 // GetFilesystemMeta returns a share's stored filesystem metadata, or the
 // store's configured capabilities when the share has none.
 //
-// ponytail: every read failure reports the defaults — not just a missing row —
-// because postgres has no filesystem_meta table at all and each call there
-// fails with an undefined-relation error. The one exception is a context that
-// has given out, cancelled or past its deadline alike, which is returned.
-// Narrow this to the no-rows case alone once that table exists on both
-// dialects; until then the strict version fails the conformance suite on
-// postgres.
+// Only a missing row reports the defaults. Every other read failure is
+// returned, so a query that cannot reach its table is not mistaken for a share
+// that was never written to.
 func (c *Core) GetFilesystemMeta(ctx context.Context, shareName string) (*metadata.FilesystemMeta, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -113,6 +109,9 @@ func (c *Core) GetFilesystemMeta(ctx context.Context, shareName string) (*metada
 		// share with default capabilities.
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, ctxErr
+		}
+		if !c.D.IsNoRows(err) {
+			return nil, c.D.MapError(err, "GetFilesystemMeta", shareName)
 		}
 		return &metadata.FilesystemMeta{Capabilities: c.Caps()}, nil
 	}

--- a/pkg/metadata/storetest/store_surface.go
+++ b/pkg/metadata/storetest/store_surface.go
@@ -666,11 +666,11 @@ func assertPayloadBlocks(t *testing.T, variant string, got *metadata.File, want 
 // testFilesystemMetaStatsCaps verifies the filesystem metadata / statistics /
 // capabilities surfaces.
 //
-// Note: GetFilesystemMeta does NOT round-trip a prior PutFilesystemMeta on the
-// memory backend (memory always recomputes from store.capabilities + live
-// statistics rather than reading back a persisted blob), so the cross-backend
-// contract asserted here is the one every backend honors: GetFilesystemMeta
-// returns a populated struct, and SetFilesystemCapabilities is observable via
+// Note: only the capabilities half of FilesystemMeta round-trips on every
+// backend — memory and badger recompute statistics on demand rather than
+// reading back a persisted blob — so the cross-backend contract asserted here
+// is that capabilities written by PutFilesystemMeta come back out of
+// GetFilesystemMeta, and that SetFilesystemCapabilities is observable via
 // GetFilesystemCapabilities. Both capabilities and statistics resolve against
 // a live root handle.
 func testFilesystemMetaStatsCaps(t *testing.T, factory StoreFactory) {
@@ -691,6 +691,26 @@ func testFilesystemMetaStatsCaps(t *testing.T, factory StoreFactory) {
 	}
 	if meta.Capabilities.MaxFilenameLen == 0 {
 		t.Error("GetFilesystemMeta() Capabilities.MaxFilenameLen = 0, want a sane non-zero limit")
+	}
+
+	// Capabilities written through PutFilesystemMeta must come back out of
+	// GetFilesystemMeta. The value is deliberately one no backend's configured
+	// defaults produce, so a store that cannot read its own metadata and
+	// answers with those defaults instead fails here rather than passing on
+	// the strength of a plausible-looking struct.
+	stored := *meta
+	stored.Capabilities.MaxFilenameLen = meta.Capabilities.MaxFilenameLen + 41
+	if err := store.PutFilesystemMeta(ctx, shareName, &stored); err != nil {
+		t.Fatalf("PutFilesystemMeta() failed: %v", err)
+	}
+
+	roundTripped, err := store.GetFilesystemMeta(ctx, shareName)
+	if err != nil {
+		t.Fatalf("GetFilesystemMeta() after Put failed: %v", err)
+	}
+	if roundTripped.Capabilities.MaxFilenameLen != stored.Capabilities.MaxFilenameLen {
+		t.Errorf("GetFilesystemMeta() after Put: Capabilities.MaxFilenameLen = %d, want %d",
+			roundTripped.Capabilities.MaxFilenameLen, stored.Capabilities.MaxFilenameLen)
 	}
 
 	// Statistics resolve against the root handle and report a non-zero total.


### PR DESCRIPTION
Closes #2236.

## What

No postgres migration ever created `filesystem_meta` — sqlite creates it in `000001_initial_schema.up.sql`, postgres never did. So `GetFilesystemMeta` failed with `[42P01] relation "filesystem_meta" does not exist` on every call, and `PutFilesystemMeta` could never have persisted anything.

`Core.GetFilesystemMeta` swallowed *any* read error and returned the store's configured capabilities. That is exactly what the one conformance assertion checked for, so the suite passed on a backend that could not reach the table it was testing.

## Changes

- `000046_filesystem_meta.{up,down}.sql` — creates `filesystem_meta(share_name TEXT PRIMARY KEY, meta TEXT NOT NULL DEFAULT '{}')`, mirroring sqlite.
- `Core.GetFilesystemMeta` — only `c.D.IsNoRows(err)` yields defaults now; every other error is returned through `MapError`. The obsolete `ponytail:` marker is gone.
- Conformance suite — asserts a `PutFilesystemMeta` → `GetFilesystemMeta` capability round-trip using a value no backend's configured defaults produce, instead of only that a populated struct comes back.
- `backupTables` gains `filesystem_meta` (required by `TestBackupTablesCoversAllMigrations`, which caught the omission), and `postgresSchemaVersion` bumps 10 → 11 for the extra snapshot section.

## Evidence

Before, against the live postgres 16 test DB with all 45 migrations applied:

```
dittofs_test=# SELECT to_regclass('public.filesystem_meta');
 to_regclass
-------------

(1 row)
```

After the migration applies:

```
dittofs_test=# SELECT to_regclass('public.filesystem_meta');
   to_regclass
-----------------
 filesystem_meta
```

**The strengthened assertion was verified to fail without the migration.** With the migration file removed and both other production changes reverted (the swallow restored, `backupTables` untouched), so that only the new test body was in play:

```
--- FAIL: TestConformance/StoreSurface/FilesystemMetaStatsCaps
    store_surface.go:704: PutFilesystemMeta() failed: IOError: exec: database error
      [42P01] relation "filesystem_meta" does not exist
```

The *old* assertion, run against that same broken build, passed green — which is the whole reason this went unnoticed.

## Verification

- `DITTOFS_TEST_POSTGRES_DSN=... go test -count=1 -tags=integration -p 1 ./pkg/metadata/store/postgres/` → ok (32.7s)
- `go test -count=1 ./pkg/metadata/...` → all pass (memory, badger, sqlite)
- `go build ./...`, `gofmt -l pkg/` empty, `golangci-lint run ./pkg/...` → 0 issues
