### PR TITLE
fix(smb): hardlink replace never freed the replaced file's bytes

### DIFF
--- a/internal/adapter/smb/handlers/ioctl_copychunk_sparse_integration_test.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk_sparse_integration_test.go
@@ -477,52 +477,8 @@ func TestCopyChunk_SparseDest_SurvivesPriorPayloadReuse(t *testing.T) {
 // PayloadID precisely when content must survive (nlink>1 or recycle-to-trash);
 // the purge must honour that signal rather than the open handle's PayloadID.
 func TestPurgeBlockStorePayload_PreservesHardLinkedContent(t *testing.T) {
-	ctx := context.Background()
-
-	cps, err := cpstore.New(&cpstore.Config{
-		Type:   cpstore.DatabaseTypeSQLite,
-		SQLite: cpstore.SQLiteConfig{Path: ":memory:"},
-	})
-	if err != nil {
-		t.Fatalf("cpstore.New: %v", err)
-	}
-	rt := runtime.New(cps)
-
-	if _, err := cps.CreateMetadataStore(ctx, &models.MetadataStoreConfig{Name: "hlmeta", Type: "memory"}); err != nil {
-		t.Fatalf("CreateMetadataStore: %v", err)
-	}
-	metaStore := metamemory.NewMemoryMetadataStoreWithDefaults()
-	if err := rt.RegisterMetadataStore("hlmeta", metaStore); err != nil {
-		t.Fatalf("RegisterMetadataStore: %v", err)
-	}
-	localBSID, err := cps.CreateBlockStore(ctx, &models.BlockStoreConfig{
-		Name: "hlbs", Kind: models.BlockStoreKindLocal, Type: "memory",
-	})
-	if err != nil {
-		t.Fatalf("CreateBlockStore: %v", err)
-	}
-
-	const shareName = "/hl"
-	if err := rt.AddShare(ctx, &runtime.ShareConfig{
-		Name:              shareName,
-		MetadataStore:     "hlmeta",
-		Enabled:           true,
-		LocalBlockStoreID: localBSID,
-		RootAttr:          &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o777},
-	}); err != nil {
-		t.Fatalf("AddShare: %v", err)
-	}
-
-	rootHandle, err := rt.GetRootHandle(shareName)
-	if err != nil {
-		t.Fatalf("GetRootHandle: %v", err)
-	}
-
-	uid, gid := uint32(0), uint32(0)
-	authCtx := &metadata.AuthContext{
-		Context:  ctx,
-		Identity: &metadata.Identity{UID: &uid, GID: &gid},
-	}
+	rt, rootHandle, authCtx := newHardlinkTestShare(t)
+	ctx := authCtx.Context
 	metaSvc := rt.GetMetadataService()
 
 	// Create "a", write a non-zero pattern, then hard-link it as "b".
@@ -573,11 +529,7 @@ func TestPurgeBlockStorePayload_PreservesHardLinkedContent(t *testing.T) {
 	if removed.PayloadID != "" {
 		t.Fatalf("RemoveFile of a hard-linked file should return empty PayloadID, got %q", removed.PayloadID)
 	}
-	var removedPayloadID metadata.PayloadID
-	if removed != nil {
-		removedPayloadID = removed.PayloadID
-	}
-	h.purgeBlockStorePayload(ctx, handle, removedPayloadID, "a", "TEST")
+	h.purgeBlockStorePayload(ctx, handle, removed.PayloadID, "a", "TEST")
 
 	// The surviving "b" link must still read the full pattern.
 	dst := make([]byte, 4096)

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -2571,7 +2571,7 @@ func (h *Handler) handleFileLinkInformation(
 			// Without it the replaced file's records stay indexed as live in
 			// the local tier, where no reclamation path can reach them.
 			if removed != nil {
-				h.purgeBlockStorePayload(ctx.Context, dstDir, removed.PayloadID, matchedName, "SET_INFO hardlink replace")
+				h.purgeBlockStorePayload(authCtx.Context, dstDir, removed.PayloadID, matchedName, "SET_INFO hardlink replace")
 			}
 		}
 	}

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -2559,6 +2559,17 @@ func (h *Handler) handleFileLinkInformation(
 	metaSvc := h.Registry.GetMetadataService()
 	if linkInfo.ReplaceIfExists {
 		if existing, matchedName, lookupErr := metaSvc.LookupCaseInsensitive(authCtx, dstDir, linkName); lookupErr == nil && existing != nil {
+			// A destination that already names the file being linked is the
+			// requested end state, so there is nothing to do. Removing it
+			// would drop the inode's last link and free its content, and the
+			// CreateHardLink below would then resurrect the name over bytes
+			// that no longer exist. Move takes the same shortcut for a rename
+			// onto its own name.
+			existingHandle, encErr := metadata.EncodeFileHandle(existing)
+			if encErr == nil && bytes.Equal(existingHandle, openFile.MetadataHandle) {
+				return setInfoStatus(types.StatusSuccess), nil
+			}
+
 			removed, _, rmErr := metaSvc.RemoveFile(authCtx, dstDir, matchedName)
 			if rmErr != nil {
 				logger.Debug("SET_INFO: hardlink replace failed to remove existing",

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -2559,10 +2559,19 @@ func (h *Handler) handleFileLinkInformation(
 	metaSvc := h.Registry.GetMetadataService()
 	if linkInfo.ReplaceIfExists {
 		if existing, matchedName, lookupErr := metaSvc.LookupCaseInsensitive(authCtx, dstDir, linkName); lookupErr == nil && existing != nil {
-			if _, _, rmErr := metaSvc.RemoveFile(authCtx, dstDir, matchedName); rmErr != nil {
+			removed, _, rmErr := metaSvc.RemoveFile(authCtx, dstDir, matchedName)
+			if rmErr != nil {
 				logger.Debug("SET_INFO: hardlink replace failed to remove existing",
 					"name", matchedName, "error", rmErr)
 				return setInfoStatus(common.MapToSMB(rmErr)), nil
+			}
+			// RemoveFile drops the name and the inode but never the bytes; the
+			// returned PayloadID is empty exactly when the content must
+			// survive, so releasing it here is hard-link- and trash-safe.
+			// Without it the replaced file's records stay indexed as live in
+			// the local tier, where no reclamation path can reach them.
+			if removed != nil {
+				h.purgeBlockStorePayload(ctx.Context, dstDir, removed.PayloadID, matchedName, "SET_INFO hardlink replace")
 			}
 		}
 	}

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -2566,7 +2566,15 @@ func (h *Handler) handleFileLinkInformation(
 			// that no longer exist. Move takes the same shortcut for a rename
 			// onto its own name.
 			existingHandle, encErr := metadata.EncodeFileHandle(existing)
-			if encErr == nil && bytes.Equal(existingHandle, openFile.MetadataHandle) {
+			if encErr != nil {
+				// Identity is unprovable, so the removal below cannot be shown
+				// to be safe. Refuse rather than fall through into it: the
+				// wrong branch here destroys the caller's content.
+				logger.Debug("SET_INFO: hardlink replace cannot identify existing destination",
+					"name", matchedName, "error", encErr)
+				return setInfoStatus(types.StatusInvalidParameter), nil
+			}
+			if bytes.Equal(existingHandle, openFile.MetadataHandle) {
 				return setInfoStatus(types.StatusSuccess), nil
 			}
 

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -2565,10 +2565,9 @@ func (h *Handler) handleFileLinkInformation(
 					"name", matchedName, "error", rmErr)
 				return setInfoStatus(common.MapToSMB(rmErr)), nil
 			}
-			// RemoveFile drops the name and the inode but never the bytes; the
-			// returned PayloadID is empty exactly when the content must
-			// survive, so releasing it here is hard-link- and trash-safe.
-			// Without it the replaced file's records stay indexed as live in
+			// RemoveFile drops the name and the inode but never the bytes; its
+			// PayloadID is empty whenever the content must survive. Left
+			// unreleased, the replaced file's records stay indexed as live in
 			// the local tier, where no reclamation path can reach them.
 			if removed != nil {
 				h.purgeBlockStorePayload(authCtx.Context, dstDir, removed.PayloadID, matchedName, "SET_INFO hardlink replace")

--- a/internal/adapter/smb/handlers/set_info_hardlink_replace_test.go
+++ b/internal/adapter/smb/handlers/set_info_hardlink_replace_test.go
@@ -1,0 +1,166 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	cpstore "github.com/marmos91/dittofs/pkg/controlplane/store"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// TestSetInfo_HardlinkReplace_ReclaimsReplacedPayload pins that a SET_INFO
+// FileLinkInformation with ReplaceIfExists=TRUE frees the content of the file it
+// replaced, not just its directory entry. The metadata layer deliberately never
+// deletes payload bytes — RemoveFile returns the removed file's PayloadID so the
+// handler can — and a handler that ignores that return leaves the replaced
+// file's records indexed as live in the local tier, where no reclamation path
+// treats them as dead and the bytes survive every restart.
+//
+// Asserting on observable block-store state pins both directions: the replaced
+// file's payload must be gone AND the newly linked file's payload must survive,
+// so releasing the wrong payload fails here instead of passing.
+func TestSetInfo_HardlinkReplace_ReclaimsReplacedPayload(t *testing.T) {
+	ctx := context.Background()
+
+	cps, err := cpstore.New(&cpstore.Config{
+		Type:   cpstore.DatabaseTypeSQLite,
+		SQLite: cpstore.SQLiteConfig{Path: ":memory:"},
+	})
+	if err != nil {
+		t.Fatalf("cpstore.New: %v", err)
+	}
+	rt := runtime.New(cps)
+
+	if _, err := cps.CreateMetadataStore(ctx, &models.MetadataStoreConfig{Name: "hlmeta", Type: "memory"}); err != nil {
+		t.Fatalf("CreateMetadataStore: %v", err)
+	}
+	if err := rt.RegisterMetadataStore("hlmeta", metamemory.NewMemoryMetadataStoreWithDefaults()); err != nil {
+		t.Fatalf("RegisterMetadataStore: %v", err)
+	}
+	localBSID, err := cps.CreateBlockStore(ctx, &models.BlockStoreConfig{
+		Name: "hlbs", Kind: models.BlockStoreKindLocal, Type: "memory",
+	})
+	if err != nil {
+		t.Fatalf("CreateBlockStore: %v", err)
+	}
+
+	const shareName = "/hl"
+	if err := rt.AddShare(ctx, &runtime.ShareConfig{
+		Name:              shareName,
+		MetadataStore:     "hlmeta",
+		Enabled:           true,
+		LocalBlockStoreID: localBSID,
+		RootAttr:          &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o777},
+	}); err != nil {
+		t.Fatalf("AddShare: %v", err)
+	}
+
+	rootHandle, err := rt.GetRootHandle(shareName)
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+
+	uid, gid := uint32(0), uint32(0)
+	authCtx := &metadata.AuthContext{
+		Context:  ctx,
+		Identity: &metadata.Identity{UID: &uid, GID: &gid},
+	}
+	metaSvc := rt.GetMetadataService()
+
+	// create makes a file with `size` bytes of content and returns its handle
+	// and payload id.
+	create := func(name string, size int) (metadata.FileHandle, string) {
+		t.Helper()
+		file, _, err := metaSvc.CreateFile(authCtx, rootHandle, name, &metadata.FileAttr{
+			Type: metadata.FileTypeRegular, Mode: 0o644,
+		})
+		if err != nil {
+			t.Fatalf("CreateFile %s: %v", name, err)
+		}
+		handle, err := metadata.EncodeFileHandle(file)
+		if err != nil {
+			t.Fatalf("EncodeFileHandle %s: %v", name, err)
+		}
+		bs, err := rt.GetBlockStoreForHandle(ctx, handle)
+		if err != nil {
+			t.Fatalf("GetBlockStoreForHandle %s: %v", name, err)
+		}
+		wop, err := metaSvc.PrepareWrite(authCtx, handle, uint64(size))
+		if err != nil {
+			t.Fatalf("PrepareWrite %s: %v", name, err)
+		}
+		data := make([]byte, size)
+		for i := range data {
+			data[i] = byte((i % 251) + 1)
+		}
+		if _, err := bs.WriteAt(ctx, string(wop.PayloadID), nil, data, 0); err != nil {
+			t.Fatalf("WriteAt %s: %v", name, err)
+		}
+		if _, err := metaSvc.CommitWrite(authCtx, wop); err != nil {
+			t.Fatalf("CommitWrite %s: %v", name, err)
+		}
+		if _, err := metaSvc.FlushPendingWriteForFile(authCtx, handle, true); err != nil {
+			t.Fatalf("Flush %s: %v", name, err)
+		}
+		return handle, string(wop.PayloadID)
+	}
+
+	// The file that ReplaceIfExists will destroy, and the file being linked
+	// over it. Distinct sizes so a mixed-up payload id cannot pass unnoticed.
+	_, victimPayload := create("victim.bin", 4096)
+	srcHandle, srcPayload := create("src.bin", 2048)
+
+	if victimPayload == srcPayload {
+		t.Fatalf("test setup: both files share payload %q, the assertions below cannot discriminate", victimPayload)
+	}
+
+	bs, err := rt.GetBlockStoreForHandle(ctx, srcHandle)
+	if err != nil {
+		t.Fatalf("GetBlockStoreForHandle: %v", err)
+	}
+	exists := func(payloadID string) bool {
+		t.Helper()
+		ok, err := bs.Exists(ctx, payloadID)
+		if err != nil {
+			t.Fatalf("Exists %s: %v", payloadID, err)
+		}
+		return ok
+	}
+	if !exists(victimPayload) {
+		t.Fatalf("setup broken: victim payload %q absent before the hardlink replace", victimPayload)
+	}
+
+	h := NewHandler()
+	h.Registry = rt
+	// A zero RootDirectory means the link name is resolved from the share
+	// root, which the handler reaches through the tree.
+	const treeID = uint32(7)
+	h.StoreTree(&TreeConnection{TreeID: treeID, ShareName: shareName})
+	open := (&OpenFile{
+		FileID:         [16]byte{0x2C, 0x71, 0x04, 0x18},
+		MetadataHandle: srcHandle,
+		ShareName:      shareName,
+		TreeID:         treeID,
+		DesiredAccess:  uint32(types.FileWriteAttributes),
+	}).WithName(OpenName{Path: "src.bin", FileName: "src.bin", ParentHandle: rootHandle})
+	h.StoreOpenFile(open)
+
+	// Hard-link src.bin onto the existing name victim.bin, replacing it.
+	buf := encodeFileLinkInfoWire(t, true, [8]byte{}, "victim.bin")
+	resp, err := h.setFileInfoFromStore(nil, authCtx, open, types.FileLinkInformation, buf)
+	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
+		t.Fatalf("setFileInfoFromStore(FileLinkInformation): err=%v resp=%v", err, resp)
+	}
+
+	if exists(victimPayload) {
+		size, _ := bs.GetSize(ctx, victimPayload)
+		t.Errorf("replaced payload %q still holds %d live bytes after the hardlink replace", victimPayload, size)
+	}
+	if !exists(srcPayload) {
+		t.Errorf("linked file's payload %q was dropped by the hardlink replace", srcPayload)
+	}
+}

--- a/internal/adapter/smb/handlers/set_info_hardlink_replace_test.go
+++ b/internal/adapter/smb/handlers/set_info_hardlink_replace_test.go
@@ -12,18 +12,13 @@ import (
 	metamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
-// TestSetInfo_HardlinkReplace_ReclaimsReplacedPayload pins that a SET_INFO
-// FileLinkInformation with ReplaceIfExists=TRUE frees the content of the file it
-// replaced, not just its directory entry. The metadata layer deliberately never
-// deletes payload bytes — RemoveFile returns the removed file's PayloadID so the
-// handler can — and a handler that ignores that return leaves the replaced
-// file's records indexed as live in the local tier, where no reclamation path
-// treats them as dead and the bytes survive every restart.
-//
-// Asserting on observable block-store state pins both directions: the replaced
-// file's payload must be gone AND the newly linked file's payload must survive,
-// so releasing the wrong payload fails here instead of passing.
-func TestSetInfo_HardlinkReplace_ReclaimsReplacedPayload(t *testing.T) {
+const hardlinkTestShareName = "/hl"
+
+// newHardlinkTestShare builds a memory-backed runtime holding one empty share
+// and returns it with that share's root handle and a root auth context. Tests
+// that need a plain context for block-store calls take authCtx.Context.
+func newHardlinkTestShare(t *testing.T) (*runtime.Runtime, metadata.FileHandle, *metadata.AuthContext) {
+	t.Helper()
 	ctx := context.Background()
 
 	cps, err := cpstore.New(&cpstore.Config{
@@ -48,9 +43,8 @@ func TestSetInfo_HardlinkReplace_ReclaimsReplacedPayload(t *testing.T) {
 		t.Fatalf("CreateBlockStore: %v", err)
 	}
 
-	const shareName = "/hl"
 	if err := rt.AddShare(ctx, &runtime.ShareConfig{
-		Name:              shareName,
+		Name:              hardlinkTestShareName,
 		MetadataStore:     "hlmeta",
 		Enabled:           true,
 		LocalBlockStoreID: localBSID,
@@ -59,20 +53,36 @@ func TestSetInfo_HardlinkReplace_ReclaimsReplacedPayload(t *testing.T) {
 		t.Fatalf("AddShare: %v", err)
 	}
 
-	rootHandle, err := rt.GetRootHandle(shareName)
+	rootHandle, err := rt.GetRootHandle(hardlinkTestShareName)
 	if err != nil {
 		t.Fatalf("GetRootHandle: %v", err)
 	}
 
 	uid, gid := uint32(0), uint32(0)
-	authCtx := &metadata.AuthContext{
+	return rt, rootHandle, &metadata.AuthContext{
 		Context:  ctx,
 		Identity: &metadata.Identity{UID: &uid, GID: &gid},
 	}
+}
+
+// TestSetInfo_HardlinkReplace_ReclaimsReplacedPayload pins that a SET_INFO
+// FileLinkInformation with ReplaceIfExists=TRUE frees the content of the file it
+// replaced, not just its directory entry. The metadata layer deliberately never
+// deletes payload bytes — RemoveFile returns the removed file's PayloadID so the
+// handler can — and a handler that ignores that return leaves the replaced
+// file's records indexed as live in the local tier, where no reclamation path
+// treats them as dead and the bytes survive every restart.
+//
+// Asserting on observable block-store state pins both directions: the replaced
+// file's payload must be gone AND the newly linked file's payload must survive,
+// so releasing the wrong payload fails here instead of passing.
+func TestSetInfo_HardlinkReplace_ReclaimsReplacedPayload(t *testing.T) {
+	rt, rootHandle, authCtx := newHardlinkTestShare(t)
+	ctx := authCtx.Context
 	metaSvc := rt.GetMetadataService()
 
-	// create makes a file with `size` bytes of content and returns its handle
-	// and payload id.
+	// create makes a file holding `size` bytes of a non-zero pattern and
+	// returns its handle and payload id.
 	create := func(name string, size int) (metadata.FileHandle, string) {
 		t.Helper()
 		file, _, err := metaSvc.CreateFile(authCtx, rootHandle, name, &metadata.FileAttr{
@@ -114,6 +124,8 @@ func TestSetInfo_HardlinkReplace_ReclaimsReplacedPayload(t *testing.T) {
 	_, victimPayload := create("victim.bin", 4096)
 	srcHandle, srcPayload := create("src.bin", 2048)
 
+	// Without this the two Exists assertions below could both be reading the
+	// same payload, and the test would pass whatever the handler did.
 	if victimPayload == srcPayload {
 		t.Fatalf("test setup: both files share payload %q, the assertions below cannot discriminate", victimPayload)
 	}
@@ -139,11 +151,11 @@ func TestSetInfo_HardlinkReplace_ReclaimsReplacedPayload(t *testing.T) {
 	// A zero RootDirectory means the link name is resolved from the share
 	// root, which the handler reaches through the tree.
 	const treeID = uint32(7)
-	h.StoreTree(&TreeConnection{TreeID: treeID, ShareName: shareName})
+	h.StoreTree(&TreeConnection{TreeID: treeID, ShareName: hardlinkTestShareName})
 	open := (&OpenFile{
 		FileID:         [16]byte{0x2C, 0x71, 0x04, 0x18},
 		MetadataHandle: srcHandle,
-		ShareName:      shareName,
+		ShareName:      hardlinkTestShareName,
 		TreeID:         treeID,
 		DesiredAccess:  uint32(types.FileWriteAttributes),
 	}).WithName(OpenName{Path: "src.bin", FileName: "src.bin", ParentHandle: rootHandle})

--- a/internal/adapter/smb/handlers/set_info_hardlink_replace_test.go
+++ b/internal/adapter/smb/handlers/set_info_hardlink_replace_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -179,5 +180,84 @@ func TestSetInfo_HardlinkReplace_ReclaimsReplacedPayload(t *testing.T) {
 	}
 	if !exists(srcPayload) {
 		t.Errorf("linked file's payload %q was dropped by the hardlink replace", srcPayload)
+	}
+}
+
+// TestSetInfo_HardlinkReplace_SelfLinkKeepsContent pins that linking a file
+// onto the name it already has is a no-op rather than a self-destruct.
+//
+// ReplaceIfExists removes the existing destination before creating the link. If
+// that destination IS the file being linked, and it holds the only link, the
+// removal drops the last link and hands back a non-empty PayloadID — so
+// releasing those bytes destroys the very content the operation was supposed to
+// leave in place, while CreateHardLink resurrects the name over nothing. The
+// client sees STATUS_SUCCESS and a file whose contents are gone.
+//
+// This is why the release is guarded on the destination being a different
+// inode, and this test is what proves the guard fires.
+func TestSetInfo_HardlinkReplace_SelfLinkKeepsContent(t *testing.T) {
+	rt, rootHandle, authCtx := newHardlinkTestShare(t)
+	ctx := authCtx.Context
+	metaSvc := rt.GetMetadataService()
+
+	file, _, err := metaSvc.CreateFile(authCtx, rootHandle, "a.txt", &metadata.FileAttr{
+		Type: metadata.FileTypeRegular, Mode: 0o644,
+	})
+	if err != nil {
+		t.Fatalf("CreateFile: %v", err)
+	}
+	handle, err := metadata.EncodeFileHandle(file)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle: %v", err)
+	}
+	bs, err := rt.GetBlockStoreForHandle(ctx, handle)
+	if err != nil {
+		t.Fatalf("GetBlockStoreForHandle: %v", err)
+	}
+	wop, err := metaSvc.PrepareWrite(authCtx, handle, 4096)
+	if err != nil {
+		t.Fatalf("PrepareWrite: %v", err)
+	}
+	if _, err := bs.WriteAt(ctx, string(wop.PayloadID), nil, bytes.Repeat([]byte{0xEE}, 4096), 0); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if _, err := metaSvc.CommitWrite(authCtx, wop); err != nil {
+		t.Fatalf("CommitWrite: %v", err)
+	}
+	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, handle, true); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	payloadID := string(wop.PayloadID)
+
+	h := NewHandler()
+	h.Registry = rt
+	const treeID = uint32(9)
+	h.StoreTree(&TreeConnection{TreeID: treeID, ShareName: hardlinkTestShareName})
+	open := (&OpenFile{
+		FileID:         [16]byte{0xAA, 0x03, 0x5E, 0x11},
+		MetadataHandle: handle,
+		ShareName:      hardlinkTestShareName,
+		TreeID:         treeID,
+		DesiredAccess:  uint32(types.FileWriteAttributes),
+	}).WithName(OpenName{Path: "a.txt", FileName: "a.txt", ParentHandle: rootHandle})
+	h.StoreOpenFile(open)
+
+	// Link a.txt onto its own name with ReplaceIfExists set.
+	buf := encodeFileLinkInfoWire(t, true, [8]byte{}, "a.txt")
+	resp, err := h.setFileInfoFromStore(nil, authCtx, open, types.FileLinkInformation, buf)
+	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
+		t.Fatalf("setFileInfoFromStore(self link): err=%v resp=%v", err, resp)
+	}
+
+	// The name must survive, and so must the bytes behind it.
+	if _, cErr := metaSvc.GetChild(ctx, rootHandle, "a.txt"); cErr != nil {
+		t.Fatalf("a.txt no longer resolves after linking it onto its own name: %v", cErr)
+	}
+	stillThere, exErr := bs.Exists(ctx, payloadID)
+	if exErr != nil {
+		t.Fatalf("Exists: %v", exErr)
+	}
+	if !stillThere {
+		t.Errorf("payload %q was destroyed by linking a.txt onto its own name", payloadID)
 	}
 }

--- a/internal/adapter/smb/handlers/set_info_hardlink_replace_test.go
+++ b/internal/adapter/smb/handlers/set_info_hardlink_replace_test.go
@@ -170,8 +170,12 @@ func TestSetInfo_HardlinkReplace_ReclaimsReplacedPayload(t *testing.T) {
 	}
 
 	if exists(victimPayload) {
-		size, _ := bs.GetSize(ctx, victimPayload)
-		t.Errorf("replaced payload %q still holds %d live bytes after the hardlink replace", victimPayload, size)
+		size, sizeErr := bs.GetSize(ctx, victimPayload)
+		if sizeErr != nil {
+			t.Errorf("replaced payload %q still present after the hardlink replace (size unreadable: %v)", victimPayload, sizeErr)
+		} else {
+			t.Errorf("replaced payload %q still holds %d live bytes after the hardlink replace", victimPayload, size)
+		}
 	}
 	if !exists(srcPayload) {
 		t.Errorf("linked file's payload %q was dropped by the hardlink replace", srcPayload)

--- a/internal/adapter/smb/handlers/set_info_hardlink_replace_test.go
+++ b/internal/adapter/smb/handlers/set_info_hardlink_replace_test.go
@@ -124,8 +124,9 @@ func TestSetInfo_HardlinkReplace_ReclaimsReplacedPayload(t *testing.T) {
 	_, victimPayload := create("victim.bin", 4096)
 	srcHandle, srcPayload := create("src.bin", 2048)
 
-	// Without this the two Exists assertions below could both be reading the
-	// same payload, and the test would pass whatever the handler did.
+	// Equal ids would make the two assertions below contradictory, so the test
+	// would fail either way; this just names the broken setup instead of
+	// reporting it as a handler bug.
 	if victimPayload == srcPayload {
 		t.Fatalf("test setup: both files share payload %q, the assertions below cannot discriminate", victimPayload)
 	}

--- a/internal/adapter/smb/handlers/set_info_hardlink_replace_test.go
+++ b/internal/adapter/smb/handlers/set_info_hardlink_replace_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"bytes"
 	"context"
 	"testing"
 
@@ -66,6 +65,84 @@ func newHardlinkTestShare(t *testing.T) (*runtime.Runtime, metadata.FileHandle, 
 	}
 }
 
+// createHardlinkTestFile creates name under parent holding size bytes of a
+// non-zero pattern, and returns the file's handle with the payload id backing
+// its content. The write is flushed, so the bytes are the block store's to
+// keep or reclaim by the time the caller drives a handler.
+func createHardlinkTestFile(
+	t *testing.T,
+	rt *runtime.Runtime,
+	authCtx *metadata.AuthContext,
+	parent metadata.FileHandle,
+	name string,
+	size int,
+) (metadata.FileHandle, string) {
+	t.Helper()
+	ctx := authCtx.Context
+	metaSvc := rt.GetMetadataService()
+
+	file, _, err := metaSvc.CreateFile(authCtx, parent, name, &metadata.FileAttr{
+		Type: metadata.FileTypeRegular, Mode: 0o644,
+	})
+	if err != nil {
+		t.Fatalf("CreateFile %s: %v", name, err)
+	}
+	handle, err := metadata.EncodeFileHandle(file)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle %s: %v", name, err)
+	}
+	bs, err := rt.GetBlockStoreForHandle(ctx, handle)
+	if err != nil {
+		t.Fatalf("GetBlockStoreForHandle %s: %v", name, err)
+	}
+	wop, err := metaSvc.PrepareWrite(authCtx, handle, uint64(size))
+	if err != nil {
+		t.Fatalf("PrepareWrite %s: %v", name, err)
+	}
+	data := make([]byte, size)
+	for i := range data {
+		data[i] = byte((i % 251) + 1)
+	}
+	if _, err := bs.WriteAt(ctx, string(wop.PayloadID), nil, data, 0); err != nil {
+		t.Fatalf("WriteAt %s: %v", name, err)
+	}
+	if _, err := metaSvc.CommitWrite(authCtx, wop); err != nil {
+		t.Fatalf("CommitWrite %s: %v", name, err)
+	}
+	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, handle, true); err != nil {
+		t.Fatalf("Flush %s: %v", name, err)
+	}
+	return handle, string(wop.PayloadID)
+}
+
+// openHardlinkTestFile returns a handler carrying one tree and one open handle
+// on name, which is everything setFileInfoFromStore needs to serve a link
+// request: a zero RootDirectory makes it resolve the link name from the share
+// root, and it reaches that root through the tree.
+func openHardlinkTestFile(
+	t *testing.T,
+	rt *runtime.Runtime,
+	parent metadata.FileHandle,
+	handle metadata.FileHandle,
+	name string,
+) (*Handler, *OpenFile) {
+	t.Helper()
+	const treeID = uint32(7)
+
+	h := NewHandler()
+	h.Registry = rt
+	h.StoreTree(&TreeConnection{TreeID: treeID, ShareName: hardlinkTestShareName})
+	open := (&OpenFile{
+		FileID:         [16]byte{0x2C, 0x71, 0x04, 0x18},
+		MetadataHandle: handle,
+		ShareName:      hardlinkTestShareName,
+		TreeID:         treeID,
+		DesiredAccess:  uint32(types.FileWriteAttributes),
+	}).WithName(OpenName{Path: name, FileName: name, ParentHandle: parent})
+	h.StoreOpenFile(open)
+	return h, open
+}
+
 // TestSetInfo_HardlinkReplace_ReclaimsReplacedPayload pins that a SET_INFO
 // FileLinkInformation with ReplaceIfExists=TRUE frees the content of the file it
 // replaced, not just its directory entry. The metadata layer deliberately never
@@ -80,50 +157,11 @@ func newHardlinkTestShare(t *testing.T) (*runtime.Runtime, metadata.FileHandle, 
 func TestSetInfo_HardlinkReplace_ReclaimsReplacedPayload(t *testing.T) {
 	rt, rootHandle, authCtx := newHardlinkTestShare(t)
 	ctx := authCtx.Context
-	metaSvc := rt.GetMetadataService()
-
-	// create makes a file holding `size` bytes of a non-zero pattern and
-	// returns its handle and payload id.
-	create := func(name string, size int) (metadata.FileHandle, string) {
-		t.Helper()
-		file, _, err := metaSvc.CreateFile(authCtx, rootHandle, name, &metadata.FileAttr{
-			Type: metadata.FileTypeRegular, Mode: 0o644,
-		})
-		if err != nil {
-			t.Fatalf("CreateFile %s: %v", name, err)
-		}
-		handle, err := metadata.EncodeFileHandle(file)
-		if err != nil {
-			t.Fatalf("EncodeFileHandle %s: %v", name, err)
-		}
-		bs, err := rt.GetBlockStoreForHandle(ctx, handle)
-		if err != nil {
-			t.Fatalf("GetBlockStoreForHandle %s: %v", name, err)
-		}
-		wop, err := metaSvc.PrepareWrite(authCtx, handle, uint64(size))
-		if err != nil {
-			t.Fatalf("PrepareWrite %s: %v", name, err)
-		}
-		data := make([]byte, size)
-		for i := range data {
-			data[i] = byte((i % 251) + 1)
-		}
-		if _, err := bs.WriteAt(ctx, string(wop.PayloadID), nil, data, 0); err != nil {
-			t.Fatalf("WriteAt %s: %v", name, err)
-		}
-		if _, err := metaSvc.CommitWrite(authCtx, wop); err != nil {
-			t.Fatalf("CommitWrite %s: %v", name, err)
-		}
-		if _, err := metaSvc.FlushPendingWriteForFile(authCtx, handle, true); err != nil {
-			t.Fatalf("Flush %s: %v", name, err)
-		}
-		return handle, string(wop.PayloadID)
-	}
 
 	// The file that ReplaceIfExists will destroy, and the file being linked
 	// over it. Distinct sizes so a mixed-up payload id cannot pass unnoticed.
-	_, victimPayload := create("victim.bin", 4096)
-	srcHandle, srcPayload := create("src.bin", 2048)
+	_, victimPayload := createHardlinkTestFile(t, rt, authCtx, rootHandle, "victim.bin", 4096)
+	srcHandle, srcPayload := createHardlinkTestFile(t, rt, authCtx, rootHandle, "src.bin", 2048)
 
 	// Equal ids would make the two assertions below contradictory, so the test
 	// would fail either way; this just names the broken setup instead of
@@ -148,20 +186,7 @@ func TestSetInfo_HardlinkReplace_ReclaimsReplacedPayload(t *testing.T) {
 		t.Fatalf("setup broken: victim payload %q absent before the hardlink replace", victimPayload)
 	}
 
-	h := NewHandler()
-	h.Registry = rt
-	// A zero RootDirectory means the link name is resolved from the share
-	// root, which the handler reaches through the tree.
-	const treeID = uint32(7)
-	h.StoreTree(&TreeConnection{TreeID: treeID, ShareName: hardlinkTestShareName})
-	open := (&OpenFile{
-		FileID:         [16]byte{0x2C, 0x71, 0x04, 0x18},
-		MetadataHandle: srcHandle,
-		ShareName:      hardlinkTestShareName,
-		TreeID:         treeID,
-		DesiredAccess:  uint32(types.FileWriteAttributes),
-	}).WithName(OpenName{Path: "src.bin", FileName: "src.bin", ParentHandle: rootHandle})
-	h.StoreOpenFile(open)
+	h, open := openHardlinkTestFile(t, rt, rootHandle, srcHandle, "src.bin")
 
 	// Hard-link src.bin onto the existing name victim.bin, replacing it.
 	buf := encodeFileLinkInfoWire(t, true, [8]byte{}, "victim.bin")
@@ -198,49 +223,14 @@ func TestSetInfo_HardlinkReplace_ReclaimsReplacedPayload(t *testing.T) {
 func TestSetInfo_HardlinkReplace_SelfLinkKeepsContent(t *testing.T) {
 	rt, rootHandle, authCtx := newHardlinkTestShare(t)
 	ctx := authCtx.Context
-	metaSvc := rt.GetMetadataService()
 
-	file, _, err := metaSvc.CreateFile(authCtx, rootHandle, "a.txt", &metadata.FileAttr{
-		Type: metadata.FileTypeRegular, Mode: 0o644,
-	})
-	if err != nil {
-		t.Fatalf("CreateFile: %v", err)
-	}
-	handle, err := metadata.EncodeFileHandle(file)
-	if err != nil {
-		t.Fatalf("EncodeFileHandle: %v", err)
-	}
+	handle, payloadID := createHardlinkTestFile(t, rt, authCtx, rootHandle, "a.txt", 4096)
 	bs, err := rt.GetBlockStoreForHandle(ctx, handle)
 	if err != nil {
 		t.Fatalf("GetBlockStoreForHandle: %v", err)
 	}
-	wop, err := metaSvc.PrepareWrite(authCtx, handle, 4096)
-	if err != nil {
-		t.Fatalf("PrepareWrite: %v", err)
-	}
-	if _, err := bs.WriteAt(ctx, string(wop.PayloadID), nil, bytes.Repeat([]byte{0xEE}, 4096), 0); err != nil {
-		t.Fatalf("WriteAt: %v", err)
-	}
-	if _, err := metaSvc.CommitWrite(authCtx, wop); err != nil {
-		t.Fatalf("CommitWrite: %v", err)
-	}
-	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, handle, true); err != nil {
-		t.Fatalf("Flush: %v", err)
-	}
-	payloadID := string(wop.PayloadID)
 
-	h := NewHandler()
-	h.Registry = rt
-	const treeID = uint32(9)
-	h.StoreTree(&TreeConnection{TreeID: treeID, ShareName: hardlinkTestShareName})
-	open := (&OpenFile{
-		FileID:         [16]byte{0xAA, 0x03, 0x5E, 0x11},
-		MetadataHandle: handle,
-		ShareName:      hardlinkTestShareName,
-		TreeID:         treeID,
-		DesiredAccess:  uint32(types.FileWriteAttributes),
-	}).WithName(OpenName{Path: "a.txt", FileName: "a.txt", ParentHandle: rootHandle})
-	h.StoreOpenFile(open)
+	h, open := openHardlinkTestFile(t, rt, rootHandle, handle, "a.txt")
 
 	// Link a.txt onto its own name with ReplaceIfExists set.
 	buf := encodeFileLinkInfoWire(t, true, [8]byte{}, "a.txt")
@@ -250,7 +240,7 @@ func TestSetInfo_HardlinkReplace_SelfLinkKeepsContent(t *testing.T) {
 	}
 
 	// The name must survive, and so must the bytes behind it.
-	if _, cErr := metaSvc.GetChild(ctx, rootHandle, "a.txt"); cErr != nil {
+	if _, cErr := rt.GetMetadataService().GetChild(ctx, rootHandle, "a.txt"); cErr != nil {
 		t.Fatalf("a.txt no longer resolves after linking it onto its own name: %v", cErr)
 	}
 	stillThere, exErr := bs.Exists(ctx, payloadID)


### PR DESCRIPTION
## What was wrong

SMB `SET_INFO` with `FileLinkInformation` and `ReplaceIfExists=TRUE` deletes the existing
destination before creating the hard link. It threw away what `RemoveFile` handed back:

```go
if _, _, rmErr := metaSvc.RemoveFile(authCtx, dstDir, matchedName); rmErr != nil {
```

`RemoveFile`'s contract is explicit that it drops the name and the inode but never the bytes —
the returned `File` carries the `PayloadID` so the caller can coordinate content deletion, and
it is empty exactly when the content must survive (a remaining hard link, or a recycle into the
trash bin). Discarding it meant `blockStore.Delete` was never called, so the replaced file's
records stayed indexed as **live** in the per-share local tier, where no reclamation path —
fast-path retire, eviction, repack — can treat them as dead. The bytes survived every restart.

Only the local tier was affected: remote block GC derives orphans from (synced − live) in the
metadata store, which the metadata removal alone already drives.

Same class as #2268 (fixed in #2286) and #2287 (fixed in #2309) — a caller discarding a
`PayloadID` the metadata layer handed it. Found while fixing #2287; kept out of that PR because
it is a different operation, and the neighbouring rename-overwrite pre-remove in this same file
is already fixed there.

## The fix

Capture the removed file and hand its `PayloadID` to the pre-existing `purgeBlockStorePayload`
helper, which already no-ops on an empty `PayloadID` and on an empty handle. Best-effort by
contract — the metadata removal has already committed, so a block-store failure is logged rather
than surfaced, consistent with every other release path.

One detail worth flagging for review: the purge is passed `authCtx.Context`, **not**
`ctx.Context`. `handleFileLinkInformation` takes a `ctx *SMBHandlerContext` that it dereferences
nowhere else, and the existing tests call `setFileInfoFromStore` with a nil `ctx` — so reaching
for it here would have been a nil-pointer panic on the very path the fix adds.

## The release alone WOULD have caused data loss — and the guard that stops it

Review caught this before merge, and I reproduced it on the real handler: releasing the payload
is unsafe when the destination name is the file being linked. A client that links a file onto
the name it already has, with `ReplaceIfExists=TRUE` and no other hard link, gets:

1. `LookupCaseInsensitive` finds the file's own directory entry.
2. `RemoveFile` drops its **last** link, so it correctly returns a **non-empty** `PayloadID`.
3. The new release destroys those bytes.
4. `CreateHardLink` re-attaches the name to the now-empty inode.

The client sees `STATUS_SUCCESS`, the file is still listed, and its contents are gone.
Reproduced against the handler before fixing:

```
PROBE status=STATUS_SUCCESS
PROBE payload "hl/70bd5423-..." exists after self-link-replace: false
PROBE entry a.txt still resolves: err=<nil>
DATA LOSS CONFIRMED: a.txt still exists but its payload was deleted
```

Note this is a regression the *release* introduces — before it, discarding the `PayloadID` made
the self-link case accidentally harmless. So the fix is not just "call the purge": it is
"call the purge only when the destination is a different inode".

The guard compares the destination's encoded handle to the open file's and short-circuits to
success, which is the requested end state — the same shortcut `Move` already takes for a rename
onto its own name. `TestSetInfo_HardlinkReplace_SelfLinkKeepsContent` pins it, and was verified
to fail (`payload ... was destroyed by linking a.txt onto its own name`) with the guard removed.

## A second, smaller safety fix: the guard used to fail open

The identity check reads the destination's handle, and the first version ignored the error:

```go
existingHandle, encErr := metadata.EncodeFileHandle(existing)
if encErr == nil && bytes.Equal(existingHandle, openFile.MetadataHandle) {
```

An encode failure fell straight through into the destructive remove-and-release. Unreachable
today — `EncodeFileHandle` only errors on an over-long handle, and `openFile.MetadataHandle`
already encoded for the same share — but the direction is wrong on this particular branch: when
identity is unprovable, the path that destroys the caller's content is precisely the one that
must not be taken by default. It now refuses with `STATUS_INVALID_PARAMETER`.

Neither of these two safety changes is implied by #2310's text, which is only about a leak. They
exist because making the leak fix correct required them.

## Why the remaining paths cannot lose data

The guard is the `PayloadID` itself, and the metadata layer is what decides it:

- **Remaining hard link** — `RemoveFile` reads the link count *inside* its transaction and, when
  more links remain, returns `PayloadID: ""`. Nothing is released.
- **Trash-enabled share** — the victim goes through `recycleNode`, which returns a copy with the
  `PayloadID` cleared. Nothing is released.
- **Last link** — the only case with a non-empty `PayloadID`, and the only case where the bytes
  are genuinely unreferenced.

- **Self-link** — guarded above, before `RemoveFile` is ever called.

The regression tests pin the surviving direction explicitly, and the existing
`TestPurgeBlockStorePayload_PreservesHardLinkedContent` already pins that a still-hard-linked
payload is untouched by this helper.

## Verification

New `TestSetInfo_HardlinkReplace_ReclaimsReplacedPayload` drives the real handler through
`setFileInfoFromStore(..., types.FileLinkInformation, ...)` against a real runtime, share and
block store. It asserts observable block-store state rather than that a function was called, and
pins both directions — the replaced payload must be gone AND the linked file's payload must
survive, so releasing the wrong payload fails here instead of passing. The two files are given
different sizes so a mixed-up payload id cannot slip through.

Both tests were run against deliberately broken builds first, each against the specific defect
it guards. With the purge stubbed out:

```
--- FAIL: TestSetInfo_HardlinkReplace_ReclaimsReplacedPayload (0.01s)
    set_info_hardlink_replace_test.go:161: replaced payload "hl/e9efae38-f1ba-4ef4-8c5e-65214101b110"
        still holds 4096 live bytes after the hardlink replace
```

and with the self-link guard removed:

```
--- FAIL: TestSetInfo_HardlinkReplace_SelfLinkKeepsContent (0.01s)
    set_info_hardlink_replace_test.go:261: payload "hl/adf859b2-..." was destroyed by
        linking a.txt onto its own name
```

Both pass with the fix. `go build ./...`, `go vet ./...` and `go test ./...` are clean.

## Not covered here

An independent sweep of the remaining SMB `RemoveFile` call sites found three more that discard
the returned `PayloadID`; they are recorded in a comment on #2310 rather than fixed here, since
none of them overwrite an existing name:

- `close.go` cascade ADS delete on CLOSE
- `durable_scavenger.go` delete-on-close
- `create_post_break.go` create-rollback (usually no bytes written yet)

Closes #2310
