### PR TITLE
fix(smb): authorize the parent-dir frozen-timestamp restore by the frozen handle's grant

### DIFF
--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -1958,6 +1958,13 @@ func (h *Handler) restoreFrozenTimestamps(authCtx *metadata.AuthContext, openFil
 // (createEntry, removeFile, etc.) always updates parent directory timestamps. This
 // method iterates open handles to find directory handles matching the given parent
 // metadata handle and restores any frozen timestamps.
+//
+// The restore writes explicit timestamps, which the metadata layer gates on
+// ownership, and the child operation's caller need not own the directory — so
+// it is authorized by the freezing handle's own FILE_WRITE_ATTRIBUTES grant
+// instead, the right SMB says governs a timestamp write. That grant is always
+// present: the frozen flags are only ever set by SET_INFO FileBasicInformation,
+// which is itself gated on FILE_WRITE_ATTRIBUTES.
 func (h *Handler) restoreParentDirFrozenTimestamps(authCtx *metadata.AuthContext, parentMetadataHandle metadata.FileHandle) {
 	if len(parentMetadataHandle) == 0 {
 		return
@@ -1977,7 +1984,11 @@ func (h *Handler) restoreParentDirFrozenTimestamps(authCtx *metadata.AuthContext
 		}
 
 		metaSvc := h.Registry.GetMetadataService()
-		if _, err := metaSvc.SetFileAttributes(authCtx, openFile.MetadataHandle, restoreAttrs); err != nil {
+		// Carry the grant of the handle that froze these values, rather than the
+		// identity of whoever drove the child operation.
+		if _, err := metaSvc.SetFileAttributes(
+			withTimestampHandleAuth(authCtx, openFile.GrantedAccess),
+			openFile.MetadataHandle, restoreAttrs); err != nil {
 			logger.Debug("restoreParentDirFrozenTimestamps: failed",
 				"path", openFile.Name().Path, "error", err)
 		} else {

--- a/internal/adapter/smb/handlers/set_info_parent_dir_frozen_authz_test.go
+++ b/internal/adapter/smb/handlers/set_info_parent_dir_frozen_authz_test.go
@@ -1,0 +1,207 @@
+// Coverage for restoreParentDirFrozenTimestamps when the freeze and the child
+// operation belong to DIFFERENT principals. The freeze belongs to whoever holds
+// the open directory handle and set the -1 sentinel on it; the restore is
+// driven by another user's child create / rename / delete. Running the restore
+// as the child-operation's caller makes a directory's frozen timestamps
+// survive or vanish according to who owns the directory.
+package handlers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// frozenDirOwnerUID owns the fixture directory and opened the freezing handle.
+// It is neither root nor the session caller the fixture's handler serves.
+const frozenDirOwnerUID = uint32(2002)
+
+// authContextForUID builds an AuthContext for a bare UID, with the GID equal to it.
+func authContextForUID(uid uint32) *metadata.AuthContext {
+	return &metadata.AuthContext{
+		Context:  context.Background(),
+		Identity: &metadata.Identity{UID: &uid, GID: &uid},
+	}
+}
+
+// frozenDirFixture builds a directory owned by frozenDirOwnerUID with its
+// timestamps pinned to a known value, plus a directory OpenFile opened by that
+// same UID with the given GrantedAccess and all four timestamps frozen on it.
+// The returned handler's session caller is neither the directory's owner nor
+// the handle's opener.
+func frozenDirFixture(t *testing.T, grantedAccess uint32) (
+	h *Handler,
+	ctx *SMBHandlerContext,
+	dirHandle metadata.FileHandle,
+	pinned time.Time,
+) {
+	t.Helper()
+
+	h, ctx, rootHandle := setupStreamsDisabledShare(t, false)
+
+	rootCtx := authContextForUID(0)
+	metaSvc := h.Registry.GetMetadataService()
+
+	// Mode 0o777 so the session caller may create a child in it: the child
+	// operation must succeed, or the restore would never be reached.
+	dir, _, err := metaSvc.CreateDirectory(rootCtx, rootHandle, "frozendir", &metadata.FileAttr{
+		Type: metadata.FileTypeDirectory,
+		Mode: 0o777,
+		UID:  frozenDirOwnerUID,
+		GID:  frozenDirOwnerUID,
+	})
+	if err != nil {
+		t.Fatalf("CreateDirectory: %v", err)
+	}
+	dirHandle, err = metadata.EncodeFileHandle(dir)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle: %v", err)
+	}
+
+	pinned = time.Date(2029, 3, 4, 5, 6, 7, 0, time.UTC)
+	if _, err := metaSvc.SetFileAttributes(rootCtx, dirHandle, &metadata.SetAttrs{
+		Mtime: &pinned, Ctime: &pinned, Atime: &pinned, CreationTime: &pinned,
+	}); err != nil {
+		t.Fatalf("pin directory timestamps: %v", err)
+	}
+
+	openerUID, openerGID := frozenDirOwnerUID, frozenDirOwnerUID
+	dirOpen := (&OpenFile{
+		FileID:         [16]byte{0xD1},
+		MetadataHandle: dirHandle,
+		ShareName:      ctx.ShareName,
+		SessionID:      ctx.SessionID,
+		TreeID:         ctx.TreeID,
+		IsDirectory:    true,
+		DesiredAccess:  grantedAccess,
+		GrantedAccess:  grantedAccess,
+		OpenerUser: &models.User{
+			Username: "dir-owner",
+			UID:      &openerUID,
+			Groups:   []models.Group{{GID: &openerGID}},
+		},
+		MtimeFrozen: true, FrozenMtime: &pinned,
+		CtimeFrozen: true, FrozenCtime: &pinned,
+		AtimeFrozen: true, FrozenAtime: &pinned,
+		BtimeFrozen: true, FrozenBtime: &pinned,
+	}).WithName(OpenName{Path: "frozendir", FileName: "frozendir", ParentHandle: rootHandle})
+	h.StoreOpenFile(dirOpen)
+
+	return h, ctx, dirHandle, pinned
+}
+
+// bumpDirTimestamps moves the directory's stored Mtime/Ctime off the frozen
+// value, standing in for the unconditional parent-directory bump a child
+// create / rename / delete performs. It is driven directly because the metadata
+// layer coalesces that bump, so it is not yet in the store when the restore
+// runs — and the restore's authorization, not the bump's timing, is what is
+// under test here.
+func bumpDirTimestamps(t *testing.T, h *Handler, dirHandle metadata.FileHandle) time.Time {
+	t.Helper()
+	bumped := time.Date(2032, 8, 9, 10, 11, 12, 0, time.UTC)
+	if _, err := h.Registry.GetMetadataService().SetFileAttributes(authContextForUID(0), dirHandle,
+		&metadata.SetAttrs{Mtime: &bumped, Ctime: &bumped}); err != nil {
+		t.Fatalf("bump directory timestamps: %v", err)
+	}
+	return bumped
+}
+
+// TestRestoreParentDirFrozenTimestamps_NonOwningChildCaller asserts a
+// directory's frozen timestamps survive a child operation driven by a caller
+// who neither owns the directory nor opened the freezing handle. The restore is
+// authorized by the freezing handle's FILE_WRITE_ATTRIBUTES grant, so it no
+// longer turns on the caller's relationship to the directory.
+func TestRestoreParentDirFrozenTimestamps_NonOwningChildCaller(t *testing.T) {
+	h, ctx, dirHandle, pinned := frozenDirFixture(t,
+		uint32(types.FileWriteAttributes)|uint32(types.FileReadAttributes))
+
+	metaSvc := h.Registry.GetMetadataService()
+	callerCtx, err := BuildAuthContext(ctx)
+	if err != nil {
+		t.Fatalf("BuildAuthContext: %v", err)
+	}
+	if uid := callerCtx.Identity.UID; uid == nil || *uid == frozenDirOwnerUID || *uid == 0 {
+		t.Fatalf("precondition: caller must be a non-owning, non-root principal, got UID %v", uid)
+	}
+	// The caller must be able to write in the directory, or the child operation
+	// that drives the restore could never have happened.
+	if _, _, err := metaSvc.CreateFile(callerCtx, dirHandle, "child.dat", &metadata.FileAttr{
+		Type: metadata.FileTypeRegular,
+		Mode: 0o644,
+	}); err != nil {
+		t.Fatalf("CreateFile(child) as the non-owning caller: %v", err)
+	}
+
+	bumped := bumpDirTimestamps(t, h, dirHandle)
+	h.restoreParentDirFrozenTimestamps(callerCtx, dirHandle)
+
+	got, err := metaSvc.GetFile(context.Background(), dirHandle)
+	if err != nil {
+		t.Fatalf("GetFile(dir): %v", err)
+	}
+	if got.Mtime.Equal(bumped) {
+		t.Errorf("directory Mtime is still the bumped %v after the restore; the frozen %v was lost "+
+			"because the restore was gated on the non-owning caller", bumped.UTC(), pinned)
+	} else if !got.Mtime.Equal(pinned) {
+		t.Errorf("directory Mtime = %v; want the frozen %v", got.Mtime.UTC(), pinned)
+	}
+	if !got.Ctime.Equal(pinned) {
+		t.Errorf("directory Ctime = %v; want the frozen %v", got.Ctime.UTC(), pinned)
+	}
+}
+
+// TestRestoreParentDirFrozenTimestamps_GrantIsWhatAuthorizes is the control
+// that pins WHY the previous case now works. The same non-owning caller drives
+// the same restore, but the directory handle carries no FILE_WRITE_ATTRIBUTES,
+// and the restore is refused — so the fix is keyed on the handle's access
+// right, not a blanket bypass of the metadata layer's ownership rule.
+//
+// The combination cannot occur through the protocol: the frozen flags are only
+// ever set by SET_INFO FileBasicInformation, which is itself gated on
+// FILE_WRITE_ATTRIBUTES, so a frozen handle always carries the right. It is
+// constructed here precisely because that is what makes it a control.
+func TestRestoreParentDirFrozenTimestamps_GrantIsWhatAuthorizes(t *testing.T) {
+	h, ctx, dirHandle, _ := frozenDirFixture(t, uint32(types.FileReadAttributes))
+
+	callerCtx, err := BuildAuthContext(ctx)
+	if err != nil {
+		t.Fatalf("BuildAuthContext: %v", err)
+	}
+
+	bumped := bumpDirTimestamps(t, h, dirHandle)
+	h.restoreParentDirFrozenTimestamps(callerCtx, dirHandle)
+
+	got, err := h.Registry.GetMetadataService().GetFile(context.Background(), dirHandle)
+	if err != nil {
+		t.Fatalf("GetFile(dir): %v", err)
+	}
+	if !got.Mtime.Equal(bumped) {
+		t.Errorf("directory Mtime = %v without FILE_WRITE_ATTRIBUTES on the frozen handle; "+
+			"want the un-restored %v — the restore must be authorized by the grant, not unconditionally",
+			got.Mtime.UTC(), bumped.UTC())
+	}
+}
+
+// TestRestoreParentDirFrozenTimestamps_OwningChildCaller is the compatibility
+// control: the restore driven by a caller who owns the directory already
+// worked, and must keep working.
+func TestRestoreParentDirFrozenTimestamps_OwningChildCaller(t *testing.T) {
+	h, _, dirHandle, pinned := frozenDirFixture(t,
+		uint32(types.FileWriteAttributes)|uint32(types.FileReadAttributes))
+
+	bumpDirTimestamps(t, h, dirHandle)
+	h.restoreParentDirFrozenTimestamps(authContextForUID(frozenDirOwnerUID), dirHandle)
+
+	got, err := h.Registry.GetMetadataService().GetFile(context.Background(), dirHandle)
+	if err != nil {
+		t.Fatalf("GetFile(dir): %v", err)
+	}
+	if !got.Mtime.Equal(pinned) {
+		t.Errorf("directory Mtime = %v after the owner drove the restore; want the frozen %v",
+			got.Mtime.UTC(), pinned)
+	}
+}


### PR DESCRIPTION
Stacked on #2313 — review that one first; this branch contains it.

## What was wrong

`restoreParentDirFrozenTimestamps` runs after a child create / rename / delete
has unconditionally bumped the parent directory's timestamps, and puts back the
values a still-open directory handle froze with the `-1` sentinel.

It issued that write as the **caller of the child operation**. But the freeze and
the restore belong to different principals: the freeze belongs to whoever holds
the open directory handle, while the restore is driven by whoever happens to
touch a child. The metadata layer gates an explicit timestamp write on ownership
of the target, so the restore silently succeeded for a caller who owned the
directory and was silently refused for one who did not — one operation, two
observable outcomes, selected by a permission check nobody asked for.

This is the same gate as #2205, but on the parent-directory path. Unlike #2196
it is reachable, precisely because freeze and restore do **not** share a
principal here.

## Premise check

Reproduced on this branch's base before writing the fix — a directory owned by
UID 2002 with all four timestamps frozen, a child create driven by UID 1000:

```
directory Mtime is still the bumped 2032-08-09 10:11:12 +0000 UTC after the restore;
the frozen 2029-03-04 05:06:07 +0000 UTC was lost
directory Ctime = 2032-08-09 10:11:12 +0000 UTC; want the frozen 2029-03-04 05:06:07 +0000 UTC
```

The same restore driven by the directory's owner passed. Same code, two
outcomes, exactly as reported.

## Why there are no threaded call sites

The issue prescribes threading `buildOpenerAuthContext` through five call sites
so the restore runs under the frozen handle's own principal, and says the
`FILE_WRITE_ATTRIBUTES` bridge cannot cover this case because the
child-creating caller holds no handle on the parent directory. A reviewer
reading #2280 will expect six files to change. None do, and that needs
explaining.

The premise is half right. The caller really does hold no handle on the
directory — but `restoreParentDirFrozenTimestamps` already has the
**directory's own** `OpenFile` in hand; that is how it found the frozen values
in the first place. Its `GrantedAccess` is right there. The bridge cannot be
reached from the caller's context, and does not need to be.

I built the threaded version first, exactly as specified. Its regression test
then passed against **both** deliberately broken builds — with the opener
context removed, and with the grant removed — because either half alone was
sufficient. A test satisfied by two mechanisms cannot tell you which one you
need, and that is what exposed the redundancy. It would have merged green.

The grant alone is sufficient, and provably always available: the frozen flags
are written in exactly one place, the `FileBasicInformation` branch of
`SetInfo`, which sits under a gate requiring `FILE_WRITE_ATTRIBUTES` on
`openFile.GrantedAccess`. No path freezes a timestamp on a handle lacking that
right, so there is no case the opener principal rescues that the grant does
not. (A prior review independently confirmed this holds through durable-handle
reconnect, which does not persist the frozen flags.)

So this is one line of production code and no signature changes, rather than
threading an `*SMBHandlerContext` through six call sites — the issue says five;
there are six, plus one reachable only with a bare `context.Context`, which
would have needed a second parameter. It also avoids issuing metadata writes
under a principal other than the caller's, which is not a privilege surface
worth opening for a redundant mechanism.

## The fix

```go
restoreCtx := withTimestampHandleAuth(authCtx, openFile.GrantedAccess)
```

The same helper and the same reasoning #2313 already applies to
`restoreFrozenTimestamps`: a handle-driven timestamp write is authorized by the
handle's access right, not by who owns the file.

Nothing else is relaxed. `withTimestampHandleAuth` sets only
`TimestampAuthorizedByHandle`, `buildFrozenAttrs` emits only the four
timestamps, and the metadata gate accepts the flag only for a timestamp-only
`SetAttrs`. Explicit DENY ACEs and both read-only share ceilings still win.

## Verification

Three tests, each pinning one thing:

- **`NonOwningChildCaller`** — the headline case. Fails on the unfixed build
  with the output quoted above.
- **`GrantIsWhatAuthorizes`** — the control. The same non-owning caller, same
  restore, but the frozen handle carries no `FILE_WRITE_ATTRIBUTES`, and the
  restore is refused. This pins that the fix is keyed on the access right rather
  than being a blanket bypass. The state is unreachable through the protocol,
  which is exactly why it is constructed by hand — it is the discriminator, not
  a scenario.
- **`OwningChildCaller`** — compatibility: the case that already worked keeps
  working, so the fix cannot be confused with one that stopped restoring.

Mutation-tested: with the fix reverted and the tests kept,
`NonOwningChildCaller` fails and the other two pass.

Also run: `go build ./...`, `go vet ./...`, `go test ./...`, and the
integration-tagged suite against a local postgres.

Closes #2280
