### PR TITLE
fix(smb): make the rename ChangeTime preserve conditional

### DIFF
--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -778,10 +778,10 @@ func (h *Handler) setFileInfoFromStore(
 			// holding this handle open must keep observing the ChangeTime it
 			// was handed at CREATE, so put the pre-rename value back.
 			metaSvc := h.Registry.GetMetadataService()
-			restoreChangeTime := h.snapshotChangeTime(authCtx, openFile.MetadataHandle)
 
 			var clobberedStream *metadata.File
-			clobberedStream, _, err = metaSvc.Move(authCtx, toDir, oldFileName, toDir, toName)
+			var renameWcc *metadata.RenameWcc
+			clobberedStream, renameWcc, err = metaSvc.Move(authCtx, toDir, oldFileName, toDir, toName)
 			if err != nil {
 				logger.Debug("SET_INFO: stream rename failed",
 					"from", oldFileName,
@@ -790,7 +790,7 @@ func (h *Handler) setFileInfoFromStore(
 				return setInfoStatus(common.MapToSMB(err)), nil
 			}
 
-			restoreChangeTime()
+			h.restorePreRenameChangeTime(authCtx.Context, openFile.MetadataHandle, renameWcc)
 
 			// Renaming a stream onto an existing stream name unlinks the
 			// stream that was there; free its content.
@@ -1219,10 +1219,9 @@ func (h *Handler) setFileInfoFromStore(
 		// Move stamps the renamed inode's LastChangeTime. A client holding
 		// this handle open must keep observing the ChangeTime it was handed at
 		// CREATE, so put the pre-rename value back.
-		restoreChangeTime := h.snapshotChangeTime(authCtx, openFile.MetadataHandle)
-
 		var clobbered *metadata.File
-		clobbered, _, err = metaSvc.Move(authCtx, srcParentHandle, oldFileName, toDir, toName)
+		var renameWcc *metadata.RenameWcc
+		clobbered, renameWcc, err = metaSvc.Move(authCtx, srcParentHandle, oldFileName, toDir, toName)
 		if err != nil {
 			logger.Debug("SET_INFO: rename failed",
 				"from", openFile.Name().Path,
@@ -1231,7 +1230,7 @@ func (h *Handler) setFileInfoFromStore(
 			return setInfoStatus(common.MapToSMB(err)), nil
 		}
 
-		restoreChangeTime()
+		h.restorePreRenameChangeTime(authCtx.Context, openFile.MetadataHandle, renameWcc)
 
 		// The pre-remove above only fires for a case-mismatched destination, so
 		// an exact-case ReplaceIfExists overwrite reaches Move's own clobber
@@ -1818,57 +1817,59 @@ func applyFrozenTimestamps(openFile *OpenFile, file *metadata.File) {
 	}
 }
 
-// snapshotChangeTime reads a file's current ChangeTime and returns a function
-// that writes it back. Service.Move stamps the renamed inode's Ctime, but
-// MS-FSA 2.1.5.15.12 note <187> defers that stamp until the handle is closed,
-// so a client that renames through a handle it still holds open keeps
+// restorePreRenameChangeTime puts back the ChangeTime the renamed inode had
+// before Service.Move stamped its own. Move stamps the renamed inode's Ctime,
+// but MS-FSA 2.1.5.15.12 note <187> defers that stamp until the handle is
+// closed, so a client that renames through a handle it still holds open keeps
 // observing the pre-rename ChangeTime. The normative text of 2.1.5.15.12 says
 // only that a rename updates LastChangeTime; the note is the half that says
-// when it becomes visible. Conformance case smb2.rename.simple_modtime pins
-// it, by comparing a CREATE reply's change_time against a post-rename query on
-// the same handle — the two coincide because nothing else advances the file's
-// Ctime in between, which is the same assumption the ponytail note below
-// records.
+// when it becomes visible. Conformance case smb2.rename.simple_modtime pins it,
+// by comparing a CREATE reply's change_time against a post-rename query on the
+// same handle.
 //
-// The write-back runs as the system identity on purpose. An explicit timestamp
-// write is ownership-gated in the metadata layer while the rename itself is
-// authorized on the parent directory, so writing the stamp back as the caller
-// would land for an owner and be silently refused for everyone else: one
-// rename, two observable ChangeTimes, chosen by a permission check the caller
-// never asked for. As the system identity it lands for every caller, so the
-// ChangeTime a client observes does not depend on who owns the file. A
-// read-only share cannot reach here — Move would already have refused.
+// Both timestamps come from the rename's own transaction rather than from a
+// read taken here. That is what keeps the restore from erasing somebody else's
+// update: an advance committed before the rename is already in SourcePreCtime,
+// so putting it back is a no-op rather than a walk backwards, and the value
+// compared against has been through the store, so it still compares equal on
+// backends that truncate timestamps on the way in.
 //
-// Only Ctime is snapshotted: Move leaves the renamed inode's Mtime alone, and
-// the parent directories' timestamps are handled by
+// The first of those holds on backends whose transaction serialises the read
+// against concurrent writers. Under READ COMMITTED with an unlocked read —
+// postgres — a write can still land inside the rename's own window, so there the
+// erasure is narrowed rather than eliminated (#2324).
+//
+// There is no permission check on the restore. An explicit timestamp write is
+// ownership-gated in the metadata layer while the rename itself is authorized
+// on the parent directories, so writing the stamp back as the caller would land
+// for an owner and be refused for everyone else: one rename, two observable
+// ChangeTimes, chosen by a check the caller never asked for. A read-only share
+// cannot reach here, because Move would already have refused.
+//
+// Only Ctime is restored: Move leaves the renamed inode's Mtime alone, and the
+// parent directories' timestamps are handled by
 // restoreParentDirFrozenTimestamps.
-//
-// Returns a no-op if the read fails.
 //
 // ponytail: the rule being implemented is handle-scoped — what a handle that
 // was already open keeps observing — but this writes the stored timestamp, so
-// it is file-scoped, and a Ctime advanced between the read and the write-back
-// (a WRITE, truncate or SET_INFO on another handle, or over NFS) is walked
-// backwards for every observer. The two coincide whenever nothing else is
-// touching the file. Upgrade to a per-OpenFile overlay consulted by
-// QUERY_INFO — the seam applyFrozenTimestamps already uses — once that overlay
-// can also say when to stop applying: it has to yield to the next real Ctime
-// advance, including one made through a different handle, which an OpenFile
-// field cannot see on its own. A directory enumeration reports a child's
-// ChangeTime with no OpenFile at all, so an overlay does not cover that path
-// either.
-func (h *Handler) snapshotChangeTime(authCtx *metadata.AuthContext, handle metadata.FileHandle) func() {
-	metaSvc := h.Registry.GetMetadataService()
-	file, err := metaSvc.GetFile(authCtx.Context, handle)
-	if err != nil {
-		return func() {}
+// it stays file-scoped. The conditional restore removes the case that was
+// actively wrong, a concurrent advance being walked backwards for everyone; it
+// does not make the preserve per-handle, so a second handle on the same file
+// still observes the restored value rather than the one the rename stamped.
+// Upgrade to a per-OpenFile overlay consulted by QUERY_INFO — the seam
+// applyFrozenTimestamps already uses — once that overlay can also say when to
+// stop applying: it has to yield to the next real Ctime advance, including one
+// made through a different handle, which an OpenFile field cannot see on its
+// own. A directory enumeration reports a child's ChangeTime with no OpenFile at
+// all, so an overlay does not cover that path either.
+func (h *Handler) restorePreRenameChangeTime(ctx context.Context, handle metadata.FileHandle, wcc *metadata.RenameWcc) {
+	if wcc == nil {
+		return
 	}
-	ctime := file.Ctime
-	sysCtx := metadata.NewSystemAuthContext(authCtx.Context)
-	return func() {
-		if _, err := metaSvc.SetFileAttributes(sysCtx, handle, &metadata.SetAttrs{Ctime: &ctime}); err != nil {
-			logger.Debug("SET_INFO: restoring pre-rename ChangeTime failed", "error", err)
-		}
+	if err := h.Registry.GetMetadataService().RestoreChangeTimeIfUnchanged(
+		ctx, handle, wcc.SourceCtime, wcc.SourcePreCtime,
+	); err != nil {
+		logger.Debug("SET_INFO: restoring pre-rename ChangeTime failed", "error", err)
 	}
 }
 

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -1,6 +1,7 @@
 package metadata
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -205,6 +206,50 @@ func (s *Service) ReadSymlink(ctx *AuthContext, handle FileHandle) (string, *Fil
 	}
 
 	return file.LinkTarget, file, nil
+}
+
+// RestoreChangeTimeIfUnchanged writes want into the file's ChangeTime, but only
+// while the stored value is still expected. It is the conditional half of the
+// SMB rename ChangeTime preserve: the renaming handle reads a ChangeTime before
+// Move and asks for it back afterwards, and this refuses to put it back once
+// anything else has advanced the same file's ChangeTime in the meantime.
+//
+// The comparison and the write happen inside one transaction, against a row read
+// inside that transaction, so on a backend whose transaction serialises that
+// read against concurrent writers a WRITE either loses the race and is
+// overwritten by a value newer than its own, or wins it and is left alone.
+// Comparing outside the transaction would only move the window rather than
+// narrow it. What makes this safe is the store's isolation, not the shape of
+// this function: under READ COMMITTED with an unlocked read — postgres — the
+// pair is not atomic and the window stays open (#2324).
+//
+// On the losing path nothing is written at all. On the winning path the row
+// read in this transaction is written back with nothing but ChangeTime changed,
+// which spares a concurrent size or mtime advance only where that read is
+// serialised against the writer. Where it is not, a write committing between the
+// read and the update is overwritten wholesale, the same lost-update shape the
+// surrounding rename and attribute paths already have (#2324).
+//
+// There is no permission check: the caller is the rename itself, which the
+// metadata layer has already authorized on the parent directories, and the
+// stored value is only ever moved back to one this file already had. A
+// read-only share cannot reach here, because Move would have refused first.
+func (s *Service) RestoreChangeTimeIfUnchanged(ctx context.Context, handle FileHandle, expected, want time.Time) error {
+	store, err := s.storeForHandle(handle)
+	if err != nil {
+		return err
+	}
+	return withRelaxedTransaction(store, ctx, func(tx Transaction) error {
+		current, err := tx.GetFile(ctx, handle)
+		if err != nil {
+			return err
+		}
+		if !current.Ctime.Equal(expected) {
+			return nil
+		}
+		current.Ctime = want
+		return tx.UpdateAttrs(ctx, current)
+	})
 }
 
 // SetFileAttributes updates file attributes with validation and access control.
@@ -980,10 +1025,41 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 		// This is what makes hard links correct: renaming one name can never
 		// stale another name's path. UpdateAttrs is tx-critical: a failed ctime
 		// write must roll the whole rename back.
+		//
+		// Read the inode inside the transaction, both before and after the
+		// stamp, so a caller that wants to put the pre-rename ChangeTime back
+		// gets values the store actually holds.
+		//
+		// Before, because srcFile was read outside this transaction: anything
+		// that advanced the inode's ChangeTime since then is already committed,
+		// and restoring the outside-tx value would erase it. After, because the
+		// SQL backends store timestamps as FILETIME ticks and truncate; an
+		// in-memory time.Time would not compare equal to what was written, so a
+		// conditional restore keyed on it would silently never fire.
+		//
+		// Neither read may be discarded on error: a failed "before" with a
+		// successful "after" leaves a zero SourcePreCtime that still matches,
+		// and the restore would then write a zero ChangeTime.
+		//
+		// The "before" read covers the window only on backends whose
+		// transaction serialises it against concurrent writers. Under READ
+		// COMMITTED with an unlocked read — postgres — a write can still commit
+		// between this read and the row lock the update takes, narrowing the
+		// window rather than closing it (#2324).
+		pre, err := tx.GetFile(ctx.Context, srcHandle)
+		if err != nil {
+			return err
+		}
+		rename.SourcePreCtime = pre.Ctime
 		srcFile.Ctime = now
 		if err := tx.UpdateAttrs(ctx.Context, srcFile); err != nil {
 			return err
 		}
+		post, err := tx.GetFile(ctx.Context, srcHandle)
+		if err != nil {
+			return err
+		}
+		rename.SourceCtime = post.Ctime
 
 		return nil
 	})

--- a/pkg/metadata/rename_ctime_restore_test.go
+++ b/pkg/metadata/rename_ctime_restore_test.go
@@ -1,0 +1,218 @@
+package metadata_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/sqlite"
+	"github.com/stretchr/testify/require"
+)
+
+// The SMB rename ChangeTime preserve puts back the ChangeTime the renamed inode
+// had before Move stamped its own, but only while that stamp is still what the
+// store holds. Both values come from inside Move's transaction, which is what
+// makes the restore safe to apply and possible to apply at all.
+
+// newSQLiteRenameFixture builds a Service over sqlite. sqlite (like postgres)
+// stores timestamps as Windows FILETIME ticks and truncates on the way in, so
+// it is the backend where a value that never went through the store cannot be
+// compared against one that did.
+func newSQLiteRenameFixture(t *testing.T) (*metadata.Service, metadata.FileHandle, string) {
+	t.Helper()
+	return registerRenameStore(t, newSQLiteRenameStore(t))
+}
+
+// newSQLiteRenameStore builds the bare sqlite store, so a test can wrap it
+// before registering it with the Service.
+func newSQLiteRenameStore(t *testing.T) *sqlite.SQLiteMetadataStore {
+	t.Helper()
+	ctx := context.Background()
+	store, err := sqlite.NewSQLiteMetadataStore(ctx,
+		&sqlite.SQLiteMetadataStoreConfig{Path: filepath.Join(t.TempDir(), "m.db"), AutoMigrate: true},
+		metadata.FilesystemCapabilities{
+			MaxReadSize: 1048576, PreferredReadSize: 1048576,
+			MaxWriteSize: 1048576, PreferredWriteSize: 1048576,
+			MaxFileSize: 1 << 62, MaxFilenameLen: 255,
+			MaxPathLen: 4096, MaxHardLinkCount: 32767,
+			SupportsHardLinks: true, SupportsSymlinks: true,
+			CaseSensitive: true, CasePreserving: true, TimestampResolution: 1,
+		})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// registerRenameStore creates the share root and wires the store into a Service.
+func registerRenameStore(t *testing.T, store metadata.Store) (*metadata.Service, metadata.FileHandle, string) {
+	t.Helper()
+	ctx := context.Background()
+	const share = "/rn"
+	root, err := store.CreateRootDirectory(ctx, share,
+		&metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o777})
+	require.NoError(t, err)
+	rootHandle, err := metadata.EncodeShareHandle(share, root.ID)
+	require.NoError(t, err)
+
+	svc := metadata.New()
+	require.NoError(t, svc.RegisterStoreForShare(share, store))
+	return svc, rootHandle, share
+}
+
+// TestRenameCtimeRestore_SurvivesTruncatingBackend asserts the restore actually
+// fires on a backend that truncates timestamps.
+//
+// The value the restore compares against must be one the store returned, not an
+// in-memory time.Time: sqlite and postgres keep timestamps as FILETIME ticks
+// (100ns), so a wall clock reading full nanoseconds does not survive the round
+// trip. Comparing against the unstored value makes the restore a silent no-op —
+// green everywhere, and wrong on every SQL backend.
+func TestRenameCtimeRestore_SurvivesTruncatingBackend(t *testing.T) {
+	svc, rootHandle, share := newSQLiteRenameFixture(t)
+	root := rootAuth()
+
+	created, _, err := svc.CreateFile(root, rootHandle, "a.bin",
+		&metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o666})
+	require.NoError(t, err)
+	handle, err := metadata.EncodeShareHandle(share, created.ID)
+	require.NoError(t, err)
+
+	// A ChangeTime whose nanosecond part is NOT a multiple of 100, so it cannot
+	// survive a FILETIME round trip intact. A clock that reads full nanoseconds
+	// produces these routinely; one that reads only microseconds never does,
+	// which is exactly how this defect hides.
+	unaligned := time.Date(2030, 4, 5, 6, 7, 8, 123456789, time.UTC)
+	_, err = svc.SetFileAttributes(root, handle, &metadata.SetAttrs{Ctime: &unaligned})
+	require.NoError(t, err)
+
+	before, err := svc.GetFile(root.Context, handle)
+	require.NoError(t, err)
+	stored := before.Ctime
+	require.False(t, stored.Equal(unaligned),
+		"precondition: sqlite must truncate this timestamp, or the test proves nothing")
+
+	_, wcc, err := svc.Move(root, rootHandle, "a.bin", rootHandle, "b.bin")
+	require.NoError(t, err)
+	require.NotNil(t, wcc)
+
+	require.NoError(t, svc.RestoreChangeTimeIfUnchanged(
+		root.Context, handle, wcc.SourceCtime, wcc.SourcePreCtime))
+
+	after, err := svc.GetFile(root.Context, handle)
+	require.NoError(t, err)
+	require.True(t, after.Ctime.Equal(stored),
+		"ChangeTime = %v; the pre-rename %v was not restored, so the conditional never fired",
+		after.Ctime.UTC(), stored.UTC())
+}
+
+// TestRenameCtimeRestore_ComparesValuesTheStoreHolds pins the property that
+// makes the two tests above meaningful, without depending on the host clock.
+//
+// The conditional compares an exact instant. A backend that truncates on write
+// therefore only ever matches a value that has been through it, so the caller
+// must supply one the store returned. This is asserted directly here because
+// the natural way to catch it — a wall-clock timestamp that does not survive
+// the round trip — is invisible wherever the clock is coarser than the storage
+// granularity: a microsecond clock yields nanoseconds that are always a
+// multiple of 100 and so always round-trip intact, and only a clock reading
+// full nanoseconds shows the restore silently ceasing to fire.
+func TestRenameCtimeRestore_ComparesValuesTheStoreHolds(t *testing.T) {
+	svc, rootHandle, share := newSQLiteRenameFixture(t)
+	root := rootAuth()
+
+	created, _, err := svc.CreateFile(root, rootHandle, "e.bin",
+		&metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o666})
+	require.NoError(t, err)
+	handle, err := metadata.EncodeShareHandle(share, created.ID)
+	require.NoError(t, err)
+
+	unstored := time.Date(2030, 4, 5, 6, 7, 8, 123456789, time.UTC)
+	_, err = svc.SetFileAttributes(root, handle, &metadata.SetAttrs{Ctime: &unstored})
+	require.NoError(t, err)
+
+	held, err := svc.GetFile(root.Context, handle)
+	require.NoError(t, err)
+	require.False(t, held.Ctime.Equal(unstored),
+		"precondition: the backend must truncate this timestamp")
+
+	want := time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Keyed on the value that was never stored: must not fire.
+	require.NoError(t, svc.RestoreChangeTimeIfUnchanged(root.Context, handle, unstored, want))
+	got, err := svc.GetFile(root.Context, handle)
+	require.NoError(t, err)
+	require.True(t, got.Ctime.Equal(held.Ctime),
+		"restore fired on a value the store never held: ChangeTime moved to %v", got.Ctime.UTC())
+
+	// Keyed on the value the store holds: must fire.
+	require.NoError(t, svc.RestoreChangeTimeIfUnchanged(root.Context, handle, held.Ctime, want))
+	got, err = svc.GetFile(root.Context, handle)
+	require.NoError(t, err)
+	require.True(t, got.Ctime.Equal(want),
+		"restore did not fire on the stored value: ChangeTime = %v, want %v", got.Ctime.UTC(), want)
+}
+
+// TestRenameCtimeRestore_MovePopulatesBothWccTimestamps pins the two timestamps
+// Move reports, independently of any restore. They are the only inputs the
+// conditional has, so a rename that leaves them zero, swaps them, or reports a
+// stamp the store did not take makes the restore either a no-op or a write of
+// the wrong value, and no test of the restore itself would say which.
+//
+// What this deliberately does NOT cover: whether the pre-rename value was read
+// inside the rename's transaction or outside it. Absent a concurrent writer the
+// two reads return the same bytes — nothing mutates the inode between them and
+// the namespace relink does not touch ChangeTime — so the distinction is not
+// observable without landing a write inside that window. It matters only under
+// concurrency, and it is what keeps an advance committed just before the rename
+// from being erased.
+func TestRenameCtimeRestore_MovePopulatesBothWccTimestamps(t *testing.T) {
+	svc, rootHandle, share := newSQLiteRenameFixture(t)
+	root := rootAuth()
+
+	created, _, err := svc.CreateFile(root, rootHandle, "f.bin",
+		&metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o666})
+	require.NoError(t, err)
+	handle, err := metadata.EncodeShareHandle(share, created.ID)
+	require.NoError(t, err)
+
+	// Pin the starting ChangeTime so the assertions do not depend on clock
+	// resolution, and so the "before" value is one the store has truncated. It
+	// must be in the past, or the rename's own stamp would not be later than it.
+	pinned := time.Date(2001, 4, 5, 6, 7, 8, 123456789, time.UTC)
+	_, err = svc.SetFileAttributes(root, handle, &metadata.SetAttrs{Ctime: &pinned})
+	require.NoError(t, err)
+	before, err := svc.GetFile(root.Context, handle)
+	require.NoError(t, err)
+
+	_, wcc, err := svc.Move(root, rootHandle, "f.bin", rootHandle, "g.bin")
+	require.NoError(t, err)
+	require.NotNil(t, wcc)
+
+	after, err := svc.GetFile(root.Context, handle)
+	require.NoError(t, err)
+
+	require.False(t, wcc.SourcePreCtime.IsZero(), "SourcePreCtime must be populated")
+	require.False(t, wcc.SourceCtime.IsZero(), "SourceCtime must be populated")
+	require.True(t, wcc.SourcePreCtime.Equal(before.Ctime),
+		"SourcePreCtime = %v; want the ChangeTime held before the rename, %v",
+		wcc.SourcePreCtime.UTC(), before.Ctime.UTC())
+	require.True(t, wcc.SourceCtime.Equal(after.Ctime),
+		"SourceCtime = %v; want the ChangeTime the store holds after the rename, %v — "+
+			"a value that did not come back through the store cannot compare equal on a "+
+			"backend that truncates",
+		wcc.SourceCtime.UTC(), after.Ctime.UTC())
+	require.True(t, wcc.SourceCtime.After(wcc.SourcePreCtime),
+		"the rename must advance ChangeTime: pre=%v post=%v",
+		wcc.SourcePreCtime.UTC(), wcc.SourceCtime.UTC())
+}
+
+// rootAuth is the identity every test here runs as: the restore is not
+// permission-gated, so nothing in these tests turns on who the caller is.
+func rootAuth() *metadata.AuthContext {
+	return &metadata.AuthContext{
+		Context:  context.Background(),
+		Identity: &metadata.Identity{UID: metadata.Uint32Ptr(0), GID: metadata.Uint32Ptr(0)},
+	}
+}

--- a/pkg/metadata/rename_ctime_window_test.go
+++ b/pkg/metadata/rename_ctime_window_test.go
@@ -1,0 +1,98 @@
+package metadata_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/sqlite"
+	"github.com/stretchr/testify/require"
+)
+
+// windowStore is a sqlite store that runs beforeTx once, immediately before the
+// next transaction it opens. Service.Move reads the source inode outside any
+// transaction and then opens one to stamp it; the hook lands exactly in that
+// gap, which is the window an in-transaction re-read exists to cover.
+//
+// Only WithTransaction is overridden. sqlite does not implement
+// RelaxedTransactor, so Move's withRelaxedTransaction falls through to this
+// method; if sqlite ever gains WithTransactionRelaxed the promoted method would
+// bypass the hook, and the test then fails on "hook did not fire" rather than
+// passing vacuously.
+//
+// The hook fires once per WithTransaction CALL, before any attempt. A backend
+// that retries by re-running the closure inside one call — badger does — could
+// not re-fire it, and would take the relaxed path in any case, which is why this
+// is sqlite-bound. Nothing here touches production code: it works only because
+// RegisterStoreForShare accepts the metadata.Store interface.
+type windowStore struct {
+	*sqlite.SQLiteMetadataStore
+	beforeTx func()
+}
+
+func (w *windowStore) WithTransaction(ctx context.Context, fn func(tx metadata.Transaction) error) error {
+	// Cleared before it runs: the hook itself commits through this store, and
+	// that inner transaction must not re-enter it.
+	if hook := w.beforeTx; hook != nil {
+		w.beforeTx = nil
+		hook()
+	}
+	return w.SQLiteMetadataStore.WithTransaction(ctx, fn)
+}
+
+// TestRenameCtime_AdvanceInsideMoveWindowIsNotErased pins that SourcePreCtime is
+// read inside Move's transaction rather than from the copy Move took before
+// opening it.
+//
+// Those two reads return identical bytes unless a writer commits between them,
+// so the distinction is invisible to any test that cannot place a write in that
+// gap — which is why a test that merely advances the ChangeTime before calling
+// Move pins nothing. This one places it exactly, by hooking the store's
+// transaction entry. With the pre-rename value taken from the outside-tx read,
+// the advance committed in the window is erased and the ChangeTime lands back at
+// the pre-advance value.
+//
+// What this does NOT pin: anything about postgres. There the pre-read is a plain
+// SELECT under READ COMMITTED, so a writer can still commit between that read
+// and the row lock the update takes. What closes this window on sqlite, badger
+// and memory is the store's isolation, not anything about how Move is written.
+func TestRenameCtime_AdvanceInsideMoveWindowIsNotErased(t *testing.T) {
+	ws := &windowStore{SQLiteMetadataStore: newSQLiteRenameStore(t)}
+	svc, rootHandle, share := registerRenameStore(t, ws)
+	root := rootAuth()
+
+	created, _, err := svc.CreateFile(root, rootHandle, "w.bin",
+		&metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o666})
+	require.NoError(t, err)
+	handle, err := metadata.EncodeShareHandle(share, created.ID)
+	require.NoError(t, err)
+
+	c0, err := svc.GetFile(root.Context, handle)
+	require.NoError(t, err)
+
+	var mid *metadata.File
+	ws.beforeTx = func() {
+		advanced := c0.Ctime.Add(90 * time.Second)
+		_, hookErr := svc.SetFileAttributes(root, handle, &metadata.SetAttrs{Ctime: &advanced})
+		require.NoError(t, hookErr)
+		mid, hookErr = svc.GetFile(root.Context, handle)
+		require.NoError(t, hookErr)
+	}
+
+	_, wcc, err := svc.Move(root, rootHandle, "w.bin", rootHandle, "x.bin")
+	require.NoError(t, err)
+	require.NotNil(t, wcc)
+	require.NotNil(t, mid, "hook did not fire: Move opened no transaction through the wrapper")
+	require.True(t, mid.Ctime.After(c0.Ctime), "precondition: the injected advance must have landed")
+
+	require.NoError(t, svc.RestoreChangeTimeIfUnchanged(
+		root.Context, handle, wcc.SourceCtime, wcc.SourcePreCtime))
+
+	after, err := svc.GetFile(root.Context, handle)
+	require.NoError(t, err)
+	require.True(t, after.Ctime.Equal(mid.Ctime),
+		"ChangeTime = %v; want the advance %v that committed inside the rename's own window "+
+			"(pre-rename value was %v) — the pre-read came from outside the transaction and erased it",
+		after.Ctime.UTC(), mid.Ctime.UTC(), c0.Ctime.UTC())
+}

--- a/pkg/metadata/wcc.go
+++ b/pkg/metadata/wcc.go
@@ -1,5 +1,7 @@
 package metadata
 
+import "time"
+
 // DirWcc carries the parent-directory attributes captured atomically with a
 // mutating metadata operation, for protocol weak-cache-consistency (WCC) data.
 //
@@ -30,4 +32,23 @@ type RenameWcc struct {
 
 	// ToDir holds the destination parent directory's pre/post attributes.
 	ToDir *DirWcc
+
+	// SourcePreCtime is the renamed inode's ChangeTime as it stood immediately
+	// before the rename stamped its own, and SourceCtime is that stamp. Both are
+	// read back through the transaction that performed the rename, so both are
+	// values the store holds rather than values a caller computed.
+	//
+	// Together they let a caller undo the rename's bump without erasing anyone
+	// else's: restore SourcePreCtime only while the stored ChangeTime is still
+	// SourceCtime. Reading the "before" inside the transaction is what makes
+	// that safe — an update committed between the caller's own read and the
+	// rename is already reflected in it, so putting it back cannot walk that
+	// update backwards.
+	//
+	// That holds on backends whose transaction serialises the read against
+	// concurrent writers. Under READ COMMITTED with an unlocked read — postgres
+	// — a write can still land between the "before" read and the row lock, so
+	// the window is narrowed rather than closed (#2324).
+	SourcePreCtime time.Time
+	SourceCtime    time.Time
 }


### PR DESCRIPTION
## What was wrong

The SMB rename ChangeTime preserve read a file's ChangeTime before
`Service.Move` and wrote it back afterwards, unconditionally. The rule it
implements is handle-scoped — what a handle that is already open keeps
observing — but the implementation rewrote the *stored* timestamp. Anything
that advanced the same file's ChangeTime between the read and the write-back —
a WRITE, a truncate, a SET_INFO on another handle, or NFS on the same file —
was walked backwards for every observer.

Reproduced on unmodified `develop` (`0973be03d`) before writing anything:

```
T0=21:33:50.450252   concurrent advance=21:35:20.450252   final=21:33:50.450252
BACKWARDS WALK ON UNMODIFIED DEVELOP: stored ChangeTime 21:35:20 -> 21:33:50
```

## A root cause I refuted by running it

`Move` reads `srcFile` outside its transaction and writes that whole row back
inside it, which reads like a second, independent backwards-walker. It is not:
`Move` stamps `now`, which is always *later*, so it cannot walk ChangeTime
backwards. Only the write-back writes an older value. Trusting the code read
would have widened this PR into `Move` for nothing.

(The stale-row write is a real hazard for *other* fields — it can lose a
concurrent writer's `Size` and `Mtime`. That is a pre-existing family, filed
separately as #2324, deliberately not fixed here.)

The `Move`-side reasoning that *did* hold — that nothing assigns to `srcFile`
between its read and the transaction — is true but proves less than it looks:
the two reads are defined to differ exactly when a writer commits in that gap,
so their single-threaded coincidence says nothing about whether the defect is
closed. What closes it is the store's isolation, and the test below constructs
the concurrent writer rather than arguing it away.

## The fix

Put the value back only while the stored ChangeTime is still the one the rename
stamped. `Move` reports both timestamps on `RenameWcc`, each read back **through
the transaction that performed the rename**, and the comparison runs inside the
transaction that performs the restore.

`snapshotChangeTime` is deleted outright rather than narrowed. A caller-side
read that is usually fine is worse than no caller-side read at all.

Reading both values inside the transaction is what makes this work, and the
first two attempts at this fix were wrong in ways that only showed up when
attacked:

**The "before" must come from inside the transaction**, or it is stale by the
width of `Move`, and an advance committed in that window gets erased rather than
kept — the original defect, moved rather than fixed. Pinned by a regression test
that commits a write inside exactly that window (see Tests below).

**The "after" must come from inside the transaction too**, because the SQL
backends store timestamps as Windows FILETIME ticks and truncate on write
(`sqlcodec.go:60`, `int64(t.Nanosecond())/100`). Comparing against an in-memory
`time.Time` never matches, so the restore silently never fires — green
everywhere, and broken on sqlite and postgres in production.

## Why that second one hid, measured rather than argued

It is invisible on the machine most of this was written on:

```
darwin:  ns%100 != 0 in    0/1000 samples     <- microsecond clock, always round-trips intact
linux:   ns%100 != 0 in 1000/1000 samples     <- full nanoseconds, never round-trips intact
```

On darwin an unstored `time.Time` compares equal to its own truncated round
trip, so the no-op cannot be observed. On Linux `Equal` is false essentially
always. Presubmit smbtorture runs memory + badger-fs, both of which keep
nanosecond fidelity via `time.MarshalBinary`; sqlite/postgres smbtorture is
nightly, and the postgres presubmit job is WPTS BVT, which does not include
`smb2.rename`. A green run here would have said nothing about the backends that
break.

## Tests

Four, on a real sqlite store — the backend that truncates. Every row below is
**measured on both platforms**, not reasoned.

| Mutation to the fix | darwin | linux |
| --- | --- | --- |
| `SourceCtime` = in-memory `now` (defect B) | *none* | 3 tests |
| `SourcePreCtime` from the outside-tx read (defect A) | **1 test** | **1 test** |
| `SourcePreCtime` zero | 3 tests | 3 tests |
| `SourceCtime` zero | 3 tests | 3 tests |
| the two fields swapped | 3 tests | 3 tests |
| *(real tree)* | none | none |

The test that catches defect A hooks the store's `WithTransaction` from the test
side — no production code is touched — to commit a write in the gap between
`Move`'s read of the source inode and the transaction that rewrites it. That gap
is the only place the two reads differ, so a test that merely advances the
ChangeTime *before* calling `Move` pins nothing; an earlier version of this PR
had exactly that test, and it passed against the mutation it claimed to catch.

The hook is sqlite-bound on purpose: sqlite does not implement
`RelaxedTransactor`, so `Move`'s `withRelaxedTransaction` falls through to the
overridden method, and its single connection makes the ordering exact. badger
would take the relaxed path and re-run the closure on an SSI retry.

**Defect B is invisible on darwin.** No test in this PR fails the B mutation
there, because the darwin clock cannot produce a timestamp that fails to round
trip. CI runs Linux, where three tests catch it. `ComparesValuesTheStoreHolds`
is platform-independent, but it pins `RestoreChangeTimeIfUnchanged`'s `Equal`
semantics and never calls `Move` — it is not coverage for B.

## Scope and what this does not claim

This closes the window on badger, sqlite and memory and **narrows** it on
postgres. What closes it is the store's isolation, not the shape of `Move`:
badger retries under SSI, sqlite serialises on one connection, memory holds its
mutex across the closure. postgres begins without setting an isolation level
(`transaction.go:115`), so READ COMMITTED, and its pre-read is a plain `SELECT`
with no `FOR UPDATE` (`sql/files.go:66`) — a writer can still commit between
that read and the row lock the update takes.

**That is not a regression.** The old unconditional restore lost the same race
and produced the same result on that interleaving; this narrows the window from
[caller's snapshot .. Move commit] to [Move's pre-read .. Move's row lock].
Closing the postgres half needs a narrow conditional
`UPDATE … WHERE ctime = $expected`, which means a new store-interface method
across all backends plus the conformance suite — out of scope here, tracked in
#2324 along with the rest of the family.

Both in-transaction reads now return their error rather than discarding it. A
failed "before" with a successful "after" would leave `SourcePreCtime` zero and
still match, and the restore would write a zero ChangeTime; returning the error
removes the only path by which either field can be zero.

That error path is deliberately left untested: reverting either read to
`pre, _ := tx.GetFile(...)` would still pass all four tests, since nothing
forces those reads to fail. Pinning it needs a fault-injecting `Transaction`
wrapper stacked on the store wrapper, whose own correctness then becomes a
question, and the thing it would pin cannot produce an observable wrong result —
the error aborts the transaction, `Move` returns a nil `RenameWcc`, and both
restore call sites sit behind `Move`'s error guard, so no half-populated struct
can escape. The containment is structural, not probabilistic.

The preserve stays file-scoped rather than handle-scoped. The `ponytail:` marker
is kept and rewritten to say what remains and to name the per-`OpenFile` overlay
as the upgrade path.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` green on darwin **and** in a
  Linux container — the second is not optional here, since one whole defect
  class is invisible on darwin.
- `smb2.rename` **13/13**, 0 failures, no cell moved.
- Every test run against a build with the fix reverted, per defect.

Closes #2285
