### PR TITLE
fix(test/nfs): refuse to grade a pynfs run whose tests never executed

### DIFF
--- a/test/nfs-conformance/pynfs/parse-results.sh
+++ b/test/nfs-conformance/pynfs/parse-results.sh
@@ -66,6 +66,18 @@ if grep -q '^Tests interrupted!' "$OUTPUT_FILE"; then
     exit 1
 fi
 
+# A run in which nothing executed produces no FAILURE lines, and would otherwise
+# grade exactly like a clean pass. pynfs skips any test whose DEPEND
+# prerequisites did not run in the same invocation, so this is reachable
+# whenever a caller names a subset of tests.
+if [[ "$TALLY" =~ ^Of\ those:\ ([0-9]+)\ Skipped,\ ([0-9]+)\ Failed,\ ([0-9]+)\ Warned,\ ([0-9]+)\ Passed ]]; then
+    if (( BASH_REMATCH[2] + BASH_REMATCH[3] + BASH_REMATCH[4] == 0 )); then
+        echo -e "${RED}ERROR: every test was skipped — this run is not evidence.${NC}"
+        echo "$TALLY"
+        exit 1
+    fi
+fi
+
 kf_load "$KNOWN_FAILURES_FILE"
 echo -e "${BOLD}Loaded ${KF_COUNT} known failures from $(basename "${KNOWN_FAILURES_FILE:-<none>}")${NC}"
 echo "$TALLY"

--- a/test/nfs-conformance/pynfs/parse-results_test.sh
+++ b/test/nfs-conformance/pynfs/parse-results_test.sh
@@ -204,6 +204,30 @@ fi
 assert_output "blacklist row now new" "- LOOK1"
 assert_output "empty table reported" "Loaded 0 known failures"
 
+# A run in which every test skipped emits no FAILURE line. Without a guard it is
+# indistinguishable from a clean pass, which is how a scoped run that never
+# executed its targets grades green.
+run_case "all tests skipped is refused" 1 <<'EOF'
+Command line asked for 2 of 689 tests
+**************************************************
+LOCK20   st_lock.testLockMerge                                    : OMIT
+LOCKMRG  st_lock.testMergeRanges                                  : OMIT
+**************************************************
+Of those: 2 Skipped, 0 Failed, 0 Warned, 0 Passed
+EOF
+assert_output "skip refusal names the cause" "every test was skipped"
+
+# A partial skip still has real results, so the grader keeps grading; refusing
+# the scoped case is run-pynfs.sh's job, since only it knows what was requested.
+run_case "partial skip with a real pass still grades" 0 <<'EOF'
+Command line asked for 2 of 689 tests
+**************************************************
+LOCK20   st_lock.testLockMerge                                    : OMIT
+LOCKMRG  st_lock.testMergeRanges                                  : PASS
+**************************************************
+Of those: 1 Skipped, 0 Failed, 0 Warned, 1 Passed
+EOF
+
 echo ""
 if [[ "$FAILURES" -eq 0 ]]; then
     echo "PASS: all parse-results.sh grading tests passed"

--- a/test/nfs-conformance/pynfs/run-pynfs.sh
+++ b/test/nfs-conformance/pynfs/run-pynfs.sh
@@ -217,6 +217,26 @@ fi
 # not a harness error, so the verdict comes from parse-results.sh alone.
 cp /tmp/dittofs-posix-server.log "${RESULTS_DIR}/dittofs.log" 2>/dev/null || true
 
+# pynfs skips any test whose DEPEND prerequisites did not run in the same
+# invocation. Naming a subset therefore skips the targets instead of running
+# them, and a skip emits no FAILURE line, so the grader would report a clean
+# pass for a run that proved nothing. A scoped run is only evidence when it
+# names the whole dependency closure and nothing skips.
+if [[ "$TESTS" != "all" ]]; then
+    SCOPED_TALLY="$(grep -E '^Of those: [0-9]+ Skipped' "$LOG_FILE" | tail -1 || true)"
+    if [[ "$SCOPED_TALLY" =~ ^Of\ those:\ ([0-9]+)\ Skipped ]] && (( BASH_REMATCH[1] > 0 )); then
+        echo ""
+        echo -e "${RED}${BOLD}ERROR: ${BASH_REMATCH[1]} of the requested tests were skipped.${NC}"
+        echo "$SCOPED_TALLY"
+        echo "A skipped test emits no FAILURE line, so grading this run would report"
+        echo "a pass for tests that never executed. Add the DEPEND prerequisites to"
+        echo "--tests, or drop --tests and run the full suite."
+        echo ""
+        log "Log:     ${LOG_FILE}"
+        exit 1
+    fi
+fi
+
 echo ""
 echo -e "${BOLD}=== Grading against $(basename "$KNOWN_FAILURES") ===${NC}"
 "${SCRIPT_DIR}/parse-results.sh" "$LOG_FILE" "$KNOWN_FAILURES" "$RESULTS_DIR"


### PR DESCRIPTION
## The defect

`parse-results.sh` grades a pynfs log by counting lines matching `: FAILURE`. A
skipped test emits no such line, so a run in which the requested tests never
executed scored zero new failures and printed:

```
RESULT: All failures known. CI green.
```

That is reachable in normal use. pynfs skips any test whose `DEPEND:`
prerequisites did not run in the same invocation, so a scoped
`--tests "LOOK8 LINK2 LINK9 RNM4 RNM10 RNM11 RNM20"` run produced:

```
Command line asked for 7 of 689 tests
Of those: 6 Skipped, 0 Failed, 0 Warned, 1 Passed
```

Six of the seven never ran, and the harness called it green. `LOOK8` depends on
`MKDIR`, `LINK2`/`LINK9` on `LINKS`, `RNM20` on `LINKS`+`MKFILE`.

The full-suite runs that CI performs are unaffected — the workflow passes no
`--tests`, and the committed blacklists were built from full runs, so the
baseline is sound. What was broken is the per-fix verification loop: the
scoped run is exactly what you reach for when checking whether a fix moved a
specific row, and it was the one shape that could report green on no evidence.

## The fix

Two layers, because only one of them knows what was asked for.

`run-pynfs.sh` has the requested list, so it refuses a scoped run with any
skips and names the two ways out — include the `DEPEND` closure, or drop
`--tests` and run the full suite. A scoped run remains valid evidence when it
names the whole closure and nothing skips.

`parse-results.sh` cannot know what was requested, so it takes the weaker but
caller-independent guard: a run in which nothing executed at all is refused.

A partial skip alongside real results still grades, deliberately. Only the
caller can say whether the skipped test was one that mattered, and silently
failing there would break full-suite runs, where skips are routine.

## Verification

Two cases added to `parse-results_test.sh`, and both were run against the
unfixed grader first:

```
FAIL: all tests skipped is refused: exit 0, want 1
FAIL: skip refusal names the cause: output missing 'every test was skipped'
```

Exit 0 on an all-skipped log is the false green, reproduced. With the fix, the
full self-test passes. The `partial skip with a real pass still grades` case
passes on both builds on purpose — it pins behaviour the fix must not change.

## Provenance

Found while verifying fixes for the pynfs issues filed from #2204: a scoped run
reported green for six tests that had not run. Two in-flight fixes had their
evidence re-taken against full or dependency-closed runs as a result.
