### PR TITLE
fix(nfs/v4): three NFSv4.0 conformance defects behind the RPLY failures

### DIFF
--- a/internal/adapter/nfs/v4/handlers/compound.go
+++ b/internal/adapter/nfs/v4/handlers/compound.go
@@ -387,9 +387,9 @@ func (h *Handler) dispatchV40(compCtx *types.CompoundContext, tag []byte, numOps
 		return encodeCompoundResponse(types.NFS4ERR_RESOURCE, tag, nil)
 	}
 
-	// v4.0 has no SEQUENCE/replay cache, so an opcode that fails to decode is a
-	// fatal protocol error (hardErrOnDecodeError) rather than a cached partial
-	// reply.
+	// v4.0 has no SEQUENCE, so an opcode that fails to decode is a fatal
+	// protocol error (hardErrOnDecodeError): there is no slot to cache a partial
+	// reply in.
 	results, lastStatus, err := h.runCompoundOps(compCtx, numOps, reader, compoundLoopParams{
 		isV41:                false,
 		hardErrOnDecodeError: true,
@@ -398,7 +398,40 @@ func (h *Handler) dispatchV40(compCtx *types.CompoundContext, tag []byte, numOps
 		return nil, err
 	}
 
+	// Tell the adapter whether this reply has to survive for a retransmission.
+	// Sequenced operations carry their own replay protection in the open- and
+	// lock-owner seqid caches; these four carry none, so re-executing a
+	// retransmitted one turns a success into NFS4ERR_EXIST or NFS4ERR_NOENT.
+	compCtx.CacheReply = compoundIsNonIdempotent(results)
+
 	return encodeCompoundResponse(lastStatus, tag, results)
+}
+
+// nonIdempotentV40Ops are the NFSv4.0 operations that change the namespace and
+// have no seqid of their own, and so rely entirely on the duplicate request
+// cache to survive a retransmission (RFC 7530 Section 16.16.6 refers to it as
+// "the server duplicate request cache mechanism").
+//
+// The rest of the operation set is either seqid-protected (OPEN, CLOSE, LOCK,
+// LOCKU, OPEN_CONFIRM, OPEN_DOWNGRADE, RELEASE_LOCKOWNER) or safe to repeat, and
+// caching a READ reply would pin megabytes to protect an operation that can
+// simply run again.
+var nonIdempotentV40Ops = map[uint32]bool{
+	types.OP_CREATE: true,
+	types.OP_REMOVE: true,
+	types.OP_RENAME: true,
+	types.OP_LINK:   true,
+}
+
+// compoundIsNonIdempotent reports whether a COMPOUND ran an operation that must
+// not be executed a second time.
+func compoundIsNonIdempotent(results []types.CompoundResult) bool {
+	for i := range results {
+		if nonIdempotentV40Ops[results[i].OpCode] {
+			return true
+		}
+	}
+	return false
 }
 
 // dispatchV41 executes the v4.1 COMPOUND dispatch loop with SEQUENCE gating.

--- a/internal/adapter/nfs/v4/handlers/compound_cacheable_test.go
+++ b/internal/adapter/nfs/v4/handlers/compound_cacheable_test.go
@@ -1,0 +1,82 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+)
+
+// TestDispatchV40_CacheReply pins which v4.0 COMPOUNDs ask the adapter to keep
+// their reply for a retransmission.
+//
+// NFSv4.0 has no SEQUENCE. Sequenced operations are covered by the open- and
+// lock-owner seqid replay caches, but CREATE, REMOVE, RENAME and LINK carry no
+// seqid: re-executing a retransmitted one reports NFS4ERR_EXIST or
+// NFS4ERR_NOENT for an operation that in fact succeeded. Everything else is
+// either seqid-protected or safe to repeat, and caching a READ reply would pin
+// megabytes to protect nothing.
+func TestDispatchV40_CacheReply(t *testing.T) {
+	cases := []struct {
+		name string
+		ops  []compoundOp
+		want bool
+	}{
+		{
+			name: "create",
+			ops:  []compoundOp{{opCode: types.OP_CREATE, data: encodeCreateDirArgs("subdir")}},
+			want: true,
+		},
+		{
+			name: "remove",
+			ops:  []compoundOp{{opCode: types.OP_REMOVE, data: encodeRemoveArgs("victim")}},
+			want: true,
+		},
+		{
+			name: "read-only",
+			ops:  []compoundOp{{opCode: types.OP_GETFH}},
+			want: false,
+		},
+		{
+			name: "no operations",
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := newRealFSTestFixture(t, "/export")
+			fx.createTestFile(t, fx.rootHandle, "victim", 0, 0o644, 0, 0)
+
+			ctx := newRealFSContext(0, 0)
+			ops := append([]compoundOp{{opCode: types.OP_PUTFH, data: encodePutFHArgs(fx.rootHandle)}}, tc.ops...)
+			data := buildCompoundArgsWithOps(nil, types.NFS4_MINOR_VERSION_0, ops)
+
+			if _, err := fx.handler.ProcessCompound(ctx, data); err != nil {
+				t.Fatalf("ProcessCompound error: %v", err)
+			}
+			if ctx.CacheReply != tc.want {
+				t.Fatalf("CacheReply = %v, want %v", ctx.CacheReply, tc.want)
+			}
+		})
+	}
+}
+
+// TestDispatchV41_NeverCachesReply checks the v4.1 path leaves CacheReply
+// alone: a v4.1 retransmission is recognised by the session slot table, and a
+// second cache answering it would be a second source of truth.
+func TestDispatchV41_NeverCachesReply(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+
+	ctx := newRealFSContext(0, 0)
+	data := buildCompoundArgsWithOps(nil, types.NFS4_MINOR_VERSION_1, []compoundOp{
+		{opCode: types.OP_PUTFH, data: encodePutFHArgs(fx.rootHandle)},
+		{opCode: types.OP_CREATE, data: encodeCreateDirArgs("subdir")},
+	})
+
+	if _, err := fx.handler.ProcessCompound(ctx, data); err != nil {
+		t.Fatalf("ProcessCompound error: %v", err)
+	}
+	if ctx.CacheReply {
+		t.Fatal("v4.1 COMPOUND asked for its reply to be cached")
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/open.go
+++ b/internal/adapter/nfs/v4/handlers/open.go
@@ -322,9 +322,10 @@ func (h *Handler) handleOpenClaimNull(
 		if encErr != nil {
 			return openError(types.NFS4ERR_SERVERFAULT)
 		}
-		// Check access permissions for the requested share_access
-		if accessErr := checkOpenAccess(metaSvc, authCtx, fh, shareAccess); accessErr != nil {
-			return openError(common.MapToNFS4(accessErr))
+		// Check that the target is a regular file the caller may open with the
+		// requested share_access.
+		if status := checkOpenTarget(metaSvc, authCtx, fh, shareAccess); status != types.NFS4_OK {
+			return openError(status)
 		}
 		fileHandle = fh
 
@@ -376,9 +377,10 @@ func (h *Handler) handleOpenClaimNull(
 			if encErr != nil {
 				return openError(types.NFS4ERR_SERVERFAULT)
 			}
-			// Check access permissions for the requested share_access
-			if accessErr := checkOpenAccess(metaSvc, authCtx, fh, shareAccess); accessErr != nil {
-				return openError(common.MapToNFS4(accessErr))
+			// Check that the target is a regular file the caller may open with
+			// the requested share_access.
+			if status := checkOpenTarget(metaSvc, authCtx, fh, shareAccess); status != types.NFS4_OK {
+				return openError(status)
 			}
 			fileHandle = fh
 
@@ -555,9 +557,9 @@ func (h *Handler) handleOpenClaimFH(
 		return openError(types.NFS4ERR_SERVERFAULT)
 	}
 
-	// Enforce the requested share_access against the file's permissions.
-	if accessErr := checkOpenAccess(metaSvc, authCtx, fileHandle, shareAccess); accessErr != nil {
-		return openError(common.MapToNFS4(accessErr))
+	// Enforce the file type and the requested share_access against the file.
+	if status := checkOpenTarget(metaSvc, authCtx, fileHandle, shareAccess); status != types.NFS4_OK {
+		return openError(status)
 	}
 
 	// If another client holds a conflicting delegation, recall it and ask the
@@ -898,8 +900,8 @@ func (h *Handler) handleOpenClaimDelegateCur(
 	// Enforce file permissions for the requested share_access, exactly as the
 	// CLAIM_NULL paths do. A delegation stateid proves the client held a
 	// delegation, not that this RPC caller may read/write the file.
-	if accessErr := checkOpenAccess(metaSvc, authCtx, fileHandle, shareAccess); accessErr != nil {
-		return openError(common.MapToNFS4(accessErr))
+	if status := checkOpenTarget(metaSvc, authCtx, fileHandle, shareAccess); status != types.NFS4_OK {
+		return openError(status)
 	}
 
 	ctx.CurrentFH = make([]byte, len(fileHandle))
@@ -967,10 +969,32 @@ func openError(status uint32) *types.CompoundResult {
 	}
 }
 
-// checkOpenAccess verifies that the caller has appropriate file-level permissions
-// for the requested share_access mode. This is required by NFSv4 OPEN to enforce
-// POSIX access control -- without it, any user can open any file regardless of mode bits.
-func checkOpenAccess(metaSvc *metadata.Service, authCtx *metadata.AuthContext, handle metadata.FileHandle, shareAccess uint32) error {
+// checkOpenTarget gates every OPEN of an object that already exists: the object
+// must be a regular file, and the caller must hold the file-level permissions
+// the requested share_access implies. It returns NFS4_OK when the open may
+// proceed and the NFS4 status to report otherwise.
+//
+// The type check is what keeps OPEN to the objects it is defined over. RFC 7530
+// Section 16.16.6: "If the component provided to OPEN resolves to something
+// other than a regular file (or a named attribute), an error will be returned
+// to the client. If it is a directory, NFS4ERR_ISDIR is returned; otherwise,
+// NFS4ERR_SYMLINK is returned" -- and NFS4ERR_SYMLINK covers special files of
+// every other type, not just symbolic links.
+//
+// The permission check enforces POSIX access control; without it any user could
+// open any file regardless of its mode bits.
+func checkOpenTarget(metaSvc *metadata.Service, authCtx *metadata.AuthContext, handle metadata.FileHandle, shareAccess uint32) uint32 {
+	file, err := metaSvc.GetFileForRead(authCtx.Context, handle)
+	if err != nil {
+		return common.MapToNFS4(err)
+	}
+	if file.Type != metadata.FileTypeRegular {
+		if file.Type == metadata.FileTypeDirectory {
+			return types.NFS4ERR_ISDIR
+		}
+		return types.NFS4ERR_SYMLINK
+	}
+
 	var requiredPerm metadata.Permission
 	if shareAccess&types.OPEN4_SHARE_ACCESS_READ != 0 {
 		requiredPerm |= metadata.PermissionRead
@@ -979,21 +1003,18 @@ func checkOpenAccess(metaSvc *metadata.Service, authCtx *metadata.AuthContext, h
 		requiredPerm |= metadata.PermissionWrite
 	}
 	if requiredPerm == 0 {
-		return nil
+		return types.NFS4_OK
 	}
 
 	granted, err := metaSvc.CheckPermissions(authCtx, handle, requiredPerm)
 	if err != nil {
-		return err
+		return common.MapToNFS4(err)
 	}
 
 	if granted&requiredPerm != requiredPerm {
-		return &metadata.StoreError{
-			Code:    metadata.ErrAccessDenied,
-			Message: "open access denied",
-		}
+		return types.NFS4ERR_ACCESS
 	}
-	return nil
+	return types.NFS4_OK
 }
 
 // effectiveUIDGID extracts the UID and GID from the auth context identity,

--- a/internal/adapter/nfs/v4/handlers/open.go
+++ b/internal/adapter/nfs/v4/handlers/open.go
@@ -324,7 +324,7 @@ func (h *Handler) handleOpenClaimNull(
 		}
 		// Check that the target is a regular file the caller may open with the
 		// requested share_access.
-		if status := checkOpenTarget(metaSvc, authCtx, fh, shareAccess); status != types.NFS4_OK {
+		if status := checkOpenTarget(metaSvc, authCtx, fh, child, shareAccess); status != types.NFS4_OK {
 			return openError(status)
 		}
 		fileHandle = fh
@@ -379,7 +379,7 @@ func (h *Handler) handleOpenClaimNull(
 			}
 			// Check that the target is a regular file the caller may open with
 			// the requested share_access.
-			if status := checkOpenTarget(metaSvc, authCtx, fh, shareAccess); status != types.NFS4_OK {
+			if status := checkOpenTarget(metaSvc, authCtx, fh, child, shareAccess); status != types.NFS4_OK {
 				return openError(status)
 			}
 			fileHandle = fh
@@ -558,7 +558,7 @@ func (h *Handler) handleOpenClaimFH(
 	}
 
 	// Enforce the file type and the requested share_access against the file.
-	if status := checkOpenTarget(metaSvc, authCtx, fileHandle, shareAccess); status != types.NFS4_OK {
+	if status := checkOpenTarget(metaSvc, authCtx, fileHandle, nil, shareAccess); status != types.NFS4_OK {
 		return openError(status)
 	}
 
@@ -900,7 +900,7 @@ func (h *Handler) handleOpenClaimDelegateCur(
 	// Enforce file permissions for the requested share_access, exactly as the
 	// CLAIM_NULL paths do. A delegation stateid proves the client held a
 	// delegation, not that this RPC caller may read/write the file.
-	if status := checkOpenTarget(metaSvc, authCtx, fileHandle, shareAccess); status != types.NFS4_OK {
+	if status := checkOpenTarget(metaSvc, authCtx, fileHandle, child, shareAccess); status != types.NFS4_OK {
 		return openError(status)
 	}
 
@@ -974,6 +974,11 @@ func openError(status uint32) *types.CompoundResult {
 // the requested share_access implies. It returns NFS4_OK when the open may
 // proceed and the NFS4 status to report otherwise.
 //
+// file is the already-resolved target when the caller has one and nil when it
+// does not, in which case it is fetched here. The claim types that resolve a
+// name have it from the lookup they just did; CLAIM_FH does not, because it
+// opens a filehandle the client already holds.
+//
 // The type check is what keeps OPEN to the objects it is defined over. RFC 7530
 // Section 16.16.6: "If the component provided to OPEN resolves to something
 // other than a regular file (or a named attribute), an error will be returned
@@ -983,15 +988,21 @@ func openError(status uint32) *types.CompoundResult {
 //
 // The permission check enforces POSIX access control; without it any user could
 // open any file regardless of its mode bits.
-func checkOpenTarget(metaSvc *metadata.Service, authCtx *metadata.AuthContext, handle metadata.FileHandle, shareAccess uint32) uint32 {
-	file, err := metaSvc.GetFileForRead(authCtx.Context, handle)
-	if err != nil {
-		return common.MapToNFS4(err)
-	}
-	if file.Type != metadata.FileTypeRegular {
-		if file.Type == metadata.FileTypeDirectory {
-			return types.NFS4ERR_ISDIR
+func checkOpenTarget(metaSvc *metadata.Service, authCtx *metadata.AuthContext, handle metadata.FileHandle, file *metadata.File, shareAccess uint32) uint32 {
+	if file == nil {
+		var err error
+		// GetFileForRead: handle-addressed, File.Path unused -- skip derivePath.
+		file, err = metaSvc.GetFileForRead(authCtx.Context, handle)
+		if err != nil {
+			return common.MapToNFS4(err)
 		}
+	}
+
+	switch file.Type {
+	case metadata.FileTypeRegular:
+	case metadata.FileTypeDirectory:
+		return types.NFS4ERR_ISDIR
+	default:
 		return types.NFS4ERR_SYMLINK
 	}
 
@@ -1017,8 +1028,6 @@ func checkOpenTarget(metaSvc *metadata.Service, authCtx *metadata.AuthContext, h
 	return types.NFS4_OK
 }
 
-// effectiveUIDGID extracts the UID and GID from the auth context identity,
-// defaulting to 0 (root) if the identity or its fields are nil.
 func effectiveUIDGID(authCtx *metadata.AuthContext) (uint32, uint32) {
 	var uid, gid uint32
 	if authCtx.Identity != nil {

--- a/internal/adapter/nfs/v4/handlers/open_nonregular_test.go
+++ b/internal/adapter/nfs/v4/handlers/open_nonregular_test.go
@@ -1,0 +1,84 @@
+package handlers
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// TestOpen_NonRegularTarget checks the type gate OPEN applies to an object that
+// already exists. RFC 7530 Section 16.16.6: "If the component provided to OPEN
+// resolves to something other than a regular file (or a named attribute), an
+// error will be returned to the client. If it is a directory, NFS4ERR_ISDIR is
+// returned; otherwise, NFS4ERR_SYMLINK is returned."
+//
+// Without the gate the handler resolved the name, found the mode bits allowed
+// the requested share_access, and opened a directory with NFS4_OK.
+func TestOpen_NonRegularTarget(t *testing.T) {
+	cases := []struct {
+		name     string
+		child    string
+		fileType metadata.FileType
+		want     uint32
+	}{
+		{"directory", "subdir", metadata.FileTypeDirectory, types.NFS4ERR_ISDIR},
+		{"symlink", "link", metadata.FileTypeSymlink, types.NFS4ERR_SYMLINK},
+		{"regular", "file.txt", metadata.FileTypeRegular, types.NFS4_OK},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := newRealFSTestFixture(t, "/export")
+			clientID := testClientID(t, fx.handler.StateManager, "open-type-client")
+			fx.createTestFile(t, fx.rootHandle, tc.child, tc.fileType, 0o755, 1000, 1000)
+
+			ctx := newRealFSContext(1000, 1000)
+			ctx.CurrentFH = make([]byte, len(fx.rootHandle))
+			copy(ctx.CurrentFH, fx.rootHandle)
+
+			args := encodeOpenArgs(
+				1,
+				types.OPEN4_SHARE_ACCESS_READ,
+				types.OPEN4_SHARE_DENY_NONE,
+				clientID, []byte("open-type-owner"),
+				types.OPEN4_NOCREATE, 0, types.CLAIM_NULL,
+				tc.child,
+			)
+
+			r := fx.handler.handleOpen(ctx, bytes.NewReader(args))
+			if r.Status != tc.want {
+				t.Fatalf("OPEN of %s: status = %d, want %d", tc.name, r.Status, tc.want)
+			}
+		})
+	}
+}
+
+// TestOpen_ClaimFH_NonRegularTarget covers the same gate on the CLAIM_FH path,
+// which re-opens a filehandle the client already holds and so never performs a
+// lookup of its own.
+func TestOpen_ClaimFH_NonRegularTarget(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+	clientID := testClientID(t, fx.handler.StateManager, "open-type-fh-client")
+	dirHandle := fx.createTestFile(t, fx.rootHandle, "subdir", metadata.FileTypeDirectory, 0o755, 1000, 1000)
+
+	ctx := newRealFSContext(1000, 1000)
+	ctx.SkipOwnerSeqid = true
+	ctx.CurrentFH = make([]byte, len(dirHandle))
+	copy(ctx.CurrentFH, dirHandle)
+
+	args := encodeOpenArgs(
+		0,
+		types.OPEN4_SHARE_ACCESS_READ,
+		types.OPEN4_SHARE_DENY_NONE,
+		clientID, []byte("open-type-fh-owner"),
+		types.OPEN4_NOCREATE, 0, types.CLAIM_FH,
+		"",
+	)
+
+	r := fx.handler.handleOpen(ctx, bytes.NewReader(args))
+	if r.Status != types.NFS4ERR_ISDIR {
+		t.Fatalf("CLAIM_FH OPEN of a directory: status = %d, want NFS4ERR_ISDIR", r.Status)
+	}
+}

--- a/internal/adapter/nfs/v4/state/lease_expiry_stateid_test.go
+++ b/internal/adapter/nfs/v4/state/lease_expiry_stateid_test.go
@@ -1,0 +1,48 @@
+package state
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+)
+
+// TestExpiredLease_StateidsReportExpired pins what a client is told when it
+// comes back after its lease was cancelled and uses a stateid the server freed
+// on the way out.
+//
+// RFC 7530 Section 9.6.3.2: "When a lease is canceled, all locking state
+// associated with it is freed, and the use of any of the associated stateids
+// will result in NFS4ERR_EXPIRED being returned." Lease expiry used to drop the
+// state without a trace, so the stateid was merely absent from the tables and
+// every path answered NFS4ERR_BAD_STATEID instead.
+func TestExpiredLease_StateidsReportExpired(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+
+	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
+
+	// A stateid the server never issued: the control that keeps this test from
+	// passing just because everything now answers NFS4ERR_EXPIRED.
+	unknown := &types.Stateid4{Seqid: 1}
+	unknown.Other = sm.generateStateidOther(StateTypeOpen)
+
+	sm.onLeaseExpired(clientID)
+
+	if _, err := sm.ValidateStateid(openStateid, fileHandle, StateidOpRead); !isStatus(err, types.NFS4ERR_EXPIRED) {
+		t.Fatalf("ValidateStateid after lease cancellation: got %v, want NFS4ERR_EXPIRED", err)
+	}
+
+	if _, err := sm.CloseFile(openStateid, openSeqid+1); !isStatus(err, types.NFS4ERR_EXPIRED) {
+		t.Fatalf("CloseFile after lease cancellation: got %v, want NFS4ERR_EXPIRED", err)
+	}
+
+	if _, err := sm.ValidateStateid(unknown, fileHandle, StateidOpRead); !isStatus(err, types.NFS4ERR_BAD_STATEID) {
+		t.Fatalf("ValidateStateid of a never-issued stateid: got %v, want NFS4ERR_BAD_STATEID", err)
+	}
+}
+
+func isStatus(err error, status uint32) bool {
+	var stateErr *NFS4StateError
+	return errors.As(err, &stateErr) && stateErr.Status == status
+}

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -66,6 +66,21 @@ type StateManager struct {
 	// when the owner is reaped (lease expiry) or the stateid is reused.
 	closedOwnerByOther map[[types.NFS4_OTHER_SIZE]byte]*OpenOwner
 
+	// expiredStateids holds the "other" of every stateid whose state was freed
+	// because the owning client's lease was cancelled. Without it the freed
+	// stateid is simply absent from the tables and looks like one the server
+	// never issued, so the client is told NFS4ERR_BAD_STATEID when RFC 7530
+	// §9.6.3.2 requires NFS4ERR_EXPIRED ("When a lease is canceled, all locking
+	// state associated with it is freed, and the use of any of the associated
+	// stateids will result in NFS4ERR_EXPIRED being returned").
+	//
+	// ponytail: capped and dropped wholesale on overflow rather than aged out
+	// per entry; losing an entry only degrades the answer to the
+	// NFS4ERR_BAD_STATEID the server gave before, and both statuses send the
+	// client into the same recovery. Give entries timestamps and sweep them if
+	// a deployment is ever seen to overflow the cap with clients still retrying.
+	expiredStateids map[[types.NFS4_OTHER_SIZE]byte]struct{}
+
 	// lockOwners maps lock-owner keys to LockOwner records.
 	// Key is composite of clientID + hex(ownerData), same pattern as openOwners.
 	lockOwners map[lockOwnerKey]*LockOwner
@@ -262,6 +277,7 @@ func NewStateManager(leaseDuration time.Duration, graceDuration ...time.Duration
 		openStateByFile:     make(map[string][]*OpenState),
 		openOwners:          make(map[openOwnerKey]*OpenOwner),
 		closedOwnerByOther:  make(map[[types.NFS4_OTHER_SIZE]byte]*OpenOwner),
+		expiredStateids:     make(map[[types.NFS4_OTHER_SIZE]byte]struct{}),
 		lockOwners:          make(map[lockOwnerKey]*LockOwner),
 		lockStateByOther:    make(map[[types.NFS4_OTHER_SIZE]byte]*LockState),
 		delegByOther:        make(map[[types.NFS4_OTHER_SIZE]byte]*DelegationState),
@@ -836,6 +852,50 @@ func (sm *StateManager) removeClientOpenStateLocked(clientID uint64) {
 	}
 }
 
+// maxExpiredStateids caps how many freed-by-lease-cancellation stateids the
+// server remembers; see the expiredStateids field for what overflow costs.
+const maxExpiredStateids = 4096
+
+// markClientStateidsExpiredLocked remembers every open, lock, and delegation
+// stateid belonging to clientID as freed by a lease cancellation, so later use
+// of one answers NFS4ERR_EXPIRED rather than NFS4ERR_BAD_STATEID (RFC 7530
+// Section 9.6.3.2). Call it before the state itself is dropped.
+//
+// Caller must hold sm.mu.
+func (sm *StateManager) markClientStateidsExpiredLocked(clientID uint64) {
+	if len(sm.expiredStateids) >= maxExpiredStateids {
+		sm.expiredStateids = make(map[[types.NFS4_OTHER_SIZE]byte]struct{})
+	}
+
+	for _, owner := range sm.openOwners {
+		if owner.ClientID != clientID {
+			continue
+		}
+		for _, openState := range owner.OpenStates {
+			sm.expiredStateids[openState.Stateid.Other] = struct{}{}
+			for _, lockState := range openState.LockStates {
+				sm.expiredStateids[lockState.Stateid.Other] = struct{}{}
+			}
+		}
+	}
+
+	for other, deleg := range sm.delegByOther {
+		if deleg.ClientID == clientID {
+			sm.expiredStateids[other] = struct{}{}
+		}
+	}
+}
+
+// isExpiredStateidLocked reports whether the state this stateid named was freed
+// when the server cancelled the owning client's lease. Callers use it on a
+// table miss, before falling back to NFS4ERR_BAD_STATEID.
+//
+// Caller must hold sm.mu (read or write).
+func (sm *StateManager) isExpiredStateidLocked(other [types.NFS4_OTHER_SIZE]byte) bool {
+	_, ok := sm.expiredStateids[other]
+	return ok
+}
+
 // onLeaseExpired is the callback invoked when a client's lease timer fires.
 // It cleans up all state for the expired client: open states, open owners,
 // and the client record itself.
@@ -861,6 +921,11 @@ func (sm *StateManager) onLeaseExpired(clientID uint64) {
 	// state, so drop its durable recovery record. Best-effort; no-op
 	// when no recovery store is wired.
 	sm.deleteClientRecoveryLocked(record.ClientIDString)
+
+	// Record what the cleanup below is about to free, so a client that comes
+	// back after the partition and uses one of these stateids is told the lease
+	// expired instead of being told the stateid was never valid.
+	sm.markClientStateidsExpiredLocked(clientID)
 
 	sm.removeClientOpenStateLocked(clientID)
 
@@ -1473,6 +1538,9 @@ func (sm *StateManager) ConfirmOpen(stateid *types.Stateid4, seqid uint32) (resu
 	// Look up the open state
 	openState, exists := sm.openStateByOther[stateid.Other]
 	if !exists {
+		if sm.isExpiredStateidLocked(stateid.Other) {
+			return nil, ErrExpired
+		}
 		return nil, &NFS4StateError{
 			Status:  types.NFS4ERR_BAD_STATEID,
 			Message: "stateid not found for OPEN_CONFIRM",
@@ -1579,6 +1647,9 @@ func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32) (result
 			if owner.ValidateSeqID(seqid) == SeqIDReplay && owner.LastResult != nil {
 				return nil, &ReplayError{Status: owner.LastResult.Status, Data: owner.LastResult.Data}
 			}
+		}
+		if sm.isExpiredStateidLocked(stateid.Other) {
+			return nil, ErrExpired
 		}
 		return nil, &NFS4StateError{
 			Status:  types.NFS4ERR_BAD_STATEID,
@@ -1758,6 +1829,9 @@ func (sm *StateManager) DowngradeOpen(stateid *types.Stateid4, seqid uint32, new
 	// Look up the open state
 	openState, exists := sm.openStateByOther[stateid.Other]
 	if !exists {
+		if sm.isExpiredStateidLocked(stateid.Other) {
+			return nil, ErrExpired
+		}
 		return nil, &NFS4StateError{
 			Status:  types.NFS4ERR_BAD_STATEID,
 			Message: "stateid not found for OPEN_DOWNGRADE",

--- a/internal/adapter/nfs/v4/state/stateid.go
+++ b/internal/adapter/nfs/v4/state/stateid.go
@@ -182,6 +182,9 @@ func (sm *StateManager) ValidateStateid(stateid *types.Stateid4, currentFH []byt
 	// Open stateids (type 0x01) use openStateByOther.
 	openState, exists := sm.openStateByOther[stateid.Other]
 	if !exists {
+		if sm.isExpiredStateidLocked(stateid.Other) {
+			return nil, ErrExpired
+		}
 		if !sm.isCurrentEpoch(stateid.Other) {
 			return nil, &NFS4StateError{
 				Status:  types.NFS4ERR_STALE_STATEID,
@@ -247,6 +250,9 @@ func (sm *StateManager) ValidateStateid(stateid *types.Stateid4, currentFH []byt
 func (sm *StateManager) validateDelegStateid(stateid *types.Stateid4, currentFH []byte) (*OpenState, error) {
 	deleg, exists := sm.delegByOther[stateid.Other]
 	if !exists {
+		if sm.isExpiredStateidLocked(stateid.Other) {
+			return nil, ErrExpired
+		}
 		if !sm.isCurrentEpoch(stateid.Other) {
 			return nil, &NFS4StateError{
 				Status:  types.NFS4ERR_STALE_STATEID,
@@ -313,6 +319,9 @@ func (sm *StateManager) validateDelegStateid(stateid *types.Stateid4, currentFH 
 func (sm *StateManager) validateLockStateid(stateid *types.Stateid4, currentFH []byte) (*OpenState, error) {
 	lockState, exists := sm.lockStateByOther[stateid.Other]
 	if !exists {
+		if sm.isExpiredStateidLocked(stateid.Other) {
+			return nil, ErrExpired
+		}
 		if !sm.isCurrentEpoch(stateid.Other) {
 			return nil, &NFS4StateError{
 				Status:  types.NFS4ERR_STALE_STATEID,

--- a/internal/adapter/nfs/v4/types/types.go
+++ b/internal/adapter/nfs/v4/types/types.go
@@ -135,6 +135,13 @@ type CompoundContext struct {
 	// BIND_CONN_TO_SESSION and connection draining checks.
 	ConnectionID uint64
 
+	// CacheReply is set by the v4.0 dispatcher when the COMPOUND executed an
+	// operation that must not run twice, so the adapter records its reply in the
+	// duplicate request cache and answers a retransmission from there. v4.1 and
+	// v4.2 get exactly-once semantics from the session slot table and never set
+	// it.
+	CacheReply bool
+
 	// RequestDigest is a fingerprint of the full COMPOUND request body,
 	// computed once in ProcessCompound. The v4.1 SEQUENCE path uses it as the
 	// slot request fingerprint to detect false retries (RFC 8881

--- a/pkg/adapter/nfs/drc_v40_test.go
+++ b/pkg/adapter/nfs/drc_v40_test.go
@@ -1,0 +1,103 @@
+package nfs
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc"
+	v4types "github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+
+	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+)
+
+// compoundPrefix encodes the leading fields of COMPOUND4args: the echoed tag
+// and the minorversion.
+func compoundPrefix(tag string, minorVersion uint32) []byte {
+	var buf bytes.Buffer
+	_ = xdr.WriteXDRString(&buf, tag)
+	_ = xdr.WriteUint32(&buf, minorVersion)
+	_ = xdr.WriteUint32(&buf, 0) // numops
+	return buf.Bytes()
+}
+
+// TestIsV40Compound covers the gate that keeps the duplicate request cache off
+// the v4.1 and v4.2 paths, which get exactly-once semantics from the session
+// slot table and must not have a retransmission answered from anywhere else.
+//
+// The tag is a variable-length opaque, so the minorversion does not sit at a
+// fixed offset: a non-empty tag has to be stepped over, padding included.
+func TestIsV40Compound(t *testing.T) {
+	cases := []struct {
+		name string
+		body []byte
+		want bool
+	}{
+		{"empty tag, v4.0", compoundPrefix("", 0), true},
+		{"tag, v4.0", compoundPrefix("dittofs", 0), true},
+		{"unpadded-length tag, v4.0", compoundPrefix("ab", 0), true},
+		{"empty tag, v4.1", compoundPrefix("", 1), false},
+		{"tag, v4.1", compoundPrefix("dittofs", 1), false},
+		{"tag, v4.2", compoundPrefix("dittofs", 2), false},
+		{"empty body", nil, false},
+		{"truncated before minorversion", compoundPrefix("", 0)[:4], false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isV40Compound(tc.body); got != tc.want {
+				t.Fatalf("isV40Compound(%q) = %v, want %v", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestV40Compound_ReleasesDRCSlotOnPanic checks that the in-progress slot a
+// v4.0 COMPOUND reserves is released even when the handler panics.
+//
+// This matters more than the usual panic-safety argument. lookup matches an
+// in-progress entry before it considers the entry's age, and the TTL sweep only
+// runs when a shard is at capacity, so a slot left behind is not reclaimed by
+// time: every later retransmission of that exact request is answered with a
+// silent drop. Request panics are recovered per request and leave the
+// connection open, so the client keeps its source port, keeps producing the
+// same cache key, and the request stays wedged for the life of the connection.
+//
+// The adapter here has no runtime, so v4Handler is nil and ProcessCompound
+// panics -- which is exactly the situation being pinned.
+func TestV40Compound_ReleasesDRCSlotOnPanic(t *testing.T) {
+	const (
+		xid        = uint32(0xBEEF)
+		clientAddr = "10.1.2.3:4321"
+	)
+
+	adapter := New(NFSConfig{Enabled: true, Port: 12049})
+	client, server := net.Pipe()
+	t.Cleanup(func() { _ = client.Close(); _ = server.Close() })
+	conn := NewNFSConnection(adapter, server, 1)
+
+	body := compoundPrefix("", 0)
+	call := &rpc.RPCCallMessage{
+		XID:       xid,
+		Program:   rpc.ProgramNFS,
+		Version:   rpc.NFSVersion4,
+		Procedure: v4types.NFSPROC4_COMPOUND,
+		Cred:      rpc.OpaqueAuth{Flavor: rpc.AuthNull, Body: []byte{}},
+		Verf:      rpc.OpaqueAuth{Flavor: rpc.AuthNull, Body: []byte{}},
+	}
+
+	panicked := false
+	func() {
+		defer func() { panicked = recover() != nil }()
+		_, _ = conn.handleNFSv4Procedure(context.Background(), call, body, clientAddr)
+	}()
+	if !panicked {
+		t.Fatal("handler did not panic; this test no longer exercises the release path")
+	}
+
+	// A slot left in-progress answers the retransmission with a drop.
+	if res, _ := adapter.drc.lookup(clientAddr, xid, body); res != drcMiss {
+		t.Fatalf("after a panicking COMPOUND, lookup = %v, want drcMiss (the reserved slot leaked)", res)
+	}
+}

--- a/pkg/adapter/nfs/drc_v40_test.go
+++ b/pkg/adapter/nfs/drc_v40_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc"
@@ -99,5 +100,69 @@ func TestV40Compound_ReleasesDRCSlotOnPanic(t *testing.T) {
 	// A slot left in-progress answers the retransmission with a drop.
 	if res, _ := adapter.drc.lookup(clientAddr, xid, body); res != drcMiss {
 		t.Fatalf("after a panicking COMPOUND, lookup = %v, want drcMiss (the reserved slot leaked)", res)
+	}
+}
+
+// TestDRCEligibleV40Compound covers the size bound that keeps bulk-data
+// compounds out of the duplicate request cache.
+//
+// Keying the cache checksums the whole request body, and the v4.0 path
+// checksums it twice -- once to reserve the slot and once to release it. On a
+// 1 MiB payload that is roughly half a millisecond of CRC-32 for a compound the
+// cache would never keep anyway, since only CREATE, REMOVE, RENAME and LINK are
+// recorded and those carry a filehandle and a name.
+func TestDRCEligibleV40Compound(t *testing.T) {
+	// A v4.0 compound padded past the bound with a long tag. The tag is echoed,
+	// not interpreted, so this is a well-formed request that is simply too big.
+	oversized := compoundPrefix(strings.Repeat("x", maxDupReqBytes), 0)
+	if len(oversized) <= maxDupReqBytes {
+		t.Fatalf("test body is %d bytes, expected more than %d", len(oversized), maxDupReqBytes)
+	}
+
+	cases := []struct {
+		name string
+		body []byte
+		want bool
+	}{
+		{"small v4.0", compoundPrefix("", 0), true},
+		{"small v4.1", compoundPrefix("", 1), false},
+		{"oversized v4.0", oversized, false},
+		{"exactly at the bound", append(compoundPrefix("", 0), make([]byte, maxDupReqBytes-len(compoundPrefix("", 0)))...), true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := drcEligibleV40Compound(tc.body); got != tc.want {
+				t.Fatalf("drcEligibleV40Compound(%d bytes) = %v, want %v", len(tc.body), got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDRCRecordableReply covers the reply-side half of the bound. The cache
+// caps how many entries it holds, not how large they are, so without this a
+// COMPOUND pairing a mutation with a large READ would pin its whole reply --
+// 4096 of those is a memory cap in name only.
+func TestDRCRecordableReply(t *testing.T) {
+	cases := []struct {
+		name       string
+		cacheReply bool
+		replyLen   int
+		want       bool
+	}{
+		{"small mutation", true, 512, true},
+		{"exactly at the bound", true, maxDupReqBytes, true},
+		{"one byte over", true, maxDupReqBytes + 1, false},
+		{"large mutation reply", true, 1 << 20, false},
+		{"small but not a mutation", false, 512, false},
+		{"large and not a mutation", false, 1 << 20, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := drcRecordableReply(tc.cacheReply, tc.replyLen); got != tc.want {
+				t.Fatalf("drcRecordableReply(%v, %d) = %v, want %v", tc.cacheReply, tc.replyLen, got, tc.want)
+			}
+		})
 	}
 }

--- a/pkg/adapter/nfs/handlers.go
+++ b/pkg/adapter/nfs/handlers.go
@@ -1,6 +1,7 @@
 package nfs
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"fmt"
@@ -20,6 +21,7 @@ import (
 	v4handlers "github.com/marmos91/dittofs/internal/adapter/nfs/v4/handlers"
 	v4state "github.com/marmos91/dittofs/internal/adapter/nfs/v4/state"
 	v4types "github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
 	"github.com/marmos91/dittofs/internal/logger"
 )
 
@@ -391,6 +393,21 @@ func (c *NFSConnection) handleNSMProcedure(ctx context.Context, call *rpc.RPCCal
 	return result.Data, err
 }
 
+// isV40Compound reports whether a COMPOUND request body declares minorversion 0.
+//
+// COMPOUND4args opens with the tag the server echoes back (an XDR opaque)
+// followed by the minorversion, so the dialect is two fields into the body and
+// is readable without decoding any operation. A body too malformed to yield
+// them is left to ProcessCompound to reject.
+func isV40Compound(data []byte) bool {
+	reader := bytes.NewReader(data)
+	if _, err := xdr.DecodeOpaque(reader); err != nil {
+		return false
+	}
+	minorVersion, err := xdr.DecodeUint32(reader)
+	return err == nil && minorVersion == v4types.NFS4_MINOR_VERSION_0
+}
+
 // handleNFSv4Procedure dispatches an NFSv4 procedure call to the appropriate handler.
 //
 // NFSv4 has only two RPC procedures (RFC 7530 Section 16):
@@ -427,6 +444,42 @@ func (c *NFSConnection) handleNFSv4Procedure(ctx context.Context, call *rpc.RPCC
 		}
 		compCtx.ConnectionID = c.connectionID
 
+		// Duplicate-request cache for NFSv4.0, which has no SEQUENCE and so no
+		// per-request exactly-once machinery of its own. A retransmitted CREATE,
+		// REMOVE, RENAME or LINK carries no seqid to recognise it by, and
+		// re-executing it turns a success the client never saw into
+		// NFS4ERR_EXIST or NFS4ERR_NOENT. Retransmits of v4.1 and v4.2 compounds
+		// are caught by the session slot table instead, so only minorversion 0
+		// consults the cache.
+		useDRC := c.server.drc != nil && isV40Compound(data)
+		if useDRC {
+			switch res, reply := c.server.drc.lookup(clientAddr, call.XID, data); res {
+			case drcReplay:
+				logger.DebugCtx(ctx, "NFSv4.0 COMPOUND replayed from DRC",
+					"client", clientAddr,
+					"xid", fmt.Sprintf("0x%x", call.XID))
+				return reply, nil
+			case drcInProgressDup:
+				// The original is still running and owns the XID; write nothing
+				// rather than a second reply on the same XID.
+				logger.DebugCtx(ctx, "NFSv4.0 duplicate of in-flight COMPOUND dropped",
+					"client", clientAddr,
+					"xid", fmt.Sprintf("0x%x", call.XID))
+				return nil, errDropReply
+			default:
+				// drcMiss: an in-progress slot is now reserved. Release it
+				// however this returns -- lookup matches an in-progress entry
+				// before it considers age, so one left behind answers every
+				// later retransmission of this exact request with a silent
+				// drop, for as long as the connection lives. A panic in
+				// ProcessCompound is recovered per request and leaves the
+				// connection open, so only a deferred release covers it.
+				// abort removes the entry only while it is still in-progress,
+				// which makes this a no-op once the reply below is recorded.
+				defer c.server.drc.abort(clientAddr, call.XID, data)
+			}
+		}
+
 		// COMPOUND status here is coarse: per-op NFS4ERR codes are encoded inside
 		// the XDR result and the RPC always succeeds, so err only reflects
 		// wire/decode failures. Per-op v4 RED needs ProcessCompound to surface a
@@ -434,6 +487,13 @@ func (c *NFSConnection) handleNFSv4Procedure(ctx context.Context, call *rpc.RPCC
 		start := time.Now()
 		result, err := c.server.v4Handler.ProcessCompound(compCtx, data)
 		c.recordOp("COMPOUND", start, err == nil)
+
+		// Record only what a retransmission must not re-run. Anything else
+		// leaves the slot to the deferred release above, so a later legitimate
+		// retry is not swallowed by it.
+		if useDRC && err == nil && compCtx.CacheReply {
+			c.server.drc.record(clientAddr, call.XID, data, result)
+		}
 
 		// The COMPOUND carries the minorversion, so the registry's "4" can now
 		// be refined to the exact dialect. A refused minorversion is not

--- a/pkg/adapter/nfs/handlers.go
+++ b/pkg/adapter/nfs/handlers.go
@@ -393,12 +393,48 @@ func (c *NFSConnection) handleNSMProcedure(ctx context.Context, call *rpc.RPCCal
 	return result.Data, err
 }
 
+// maxDupReqBytes bounds both the request a v4.0 COMPOUND may present and the
+// reply the duplicate request cache will keep for it.
+//
+// The cache exists for namespace mutations, and a CREATE, REMOVE, RENAME or
+// LINK compound is a filehandle and a name or two -- hundreds of bytes, with a
+// reply smaller still. Bulk-data compounds are far above this, and paying for
+// them is pure cost: keying the cache checksums the whole request body, so a
+// 1 MiB WRITE would buy nothing and pay for a checksum of every byte, twice,
+// once to reserve the slot and once to release it. Capping the reply likewise
+// keeps the cache bounded in bytes and not only in entries.
+//
+// ponytail: one bound for both directions, chosen to sit far above every
+// namespace-mutating compound rather than tuned. A compound above it is simply
+// left to re-execute on a retransmission, which is what the server did before
+// the cache covered v4.0 at all. Split it in two, or raise it, only if a real
+// workload is found whose mutations do not fit.
+const maxDupReqBytes = 8 << 10
+
+// drcEligibleV40Compound reports whether a COMPOUND should be tracked in the
+// duplicate request cache: it must be v4.0, which has no session slot table of
+// its own, and small enough that tracking it is worth what keying it costs.
+// The size test comes first because it is the cheap one.
+func drcEligibleV40Compound(data []byte) bool {
+	return len(data) <= maxDupReqBytes && isV40Compound(data)
+}
+
+// drcRecordableReply reports whether a finished COMPOUND's reply should be kept
+// for a retransmission to be answered from. The dispatcher decides whether the
+// COMPOUND ran anything that must not run twice; this adds the size bound, which
+// is what keeps a mutation bundled with a large read from pinning its whole
+// reply in the cache.
+func drcRecordableReply(cacheReply bool, replyLen int) bool {
+	return cacheReply && replyLen <= maxDupReqBytes
+}
+
 // isV40Compound reports whether a COMPOUND request body declares minorversion 0.
 //
-// COMPOUND4args opens with the tag the server echoes back (an XDR opaque)
-// followed by the minorversion, so the dialect is two fields into the body and
-// is readable without decoding any operation. A body too malformed to yield
-// them is left to ProcessCompound to reject.
+// COMPOUND4args opens with the tag the server echoes back, a utf8str_cs whose
+// wire encoding is that of a variable-length opaque, followed by the
+// minorversion -- so the dialect is two fields into the body and is readable
+// without decoding any operation. A body too malformed to yield them is left to
+// ProcessCompound to reject.
 func isV40Compound(data []byte) bool {
 	reader := bytes.NewReader(data)
 	if _, err := xdr.DecodeOpaque(reader); err != nil {
@@ -451,7 +487,7 @@ func (c *NFSConnection) handleNFSv4Procedure(ctx context.Context, call *rpc.RPCC
 		// NFS4ERR_EXIST or NFS4ERR_NOENT. Retransmits of v4.1 and v4.2 compounds
 		// are caught by the session slot table instead, so only minorversion 0
 		// consults the cache.
-		useDRC := c.server.drc != nil && isV40Compound(data)
+		useDRC := c.server.drc != nil && drcEligibleV40Compound(data)
 		if useDRC {
 			switch res, reply := c.server.drc.lookup(clientAddr, call.XID, data); res {
 			case drcReplay:
@@ -491,7 +527,7 @@ func (c *NFSConnection) handleNFSv4Procedure(ctx context.Context, call *rpc.RPCC
 		// Record only what a retransmission must not re-run. Anything else
 		// leaves the slot to the deferred release above, so a later legitimate
 		// retry is not swallowed by it.
-		if useDRC && err == nil && compCtx.CacheReply {
+		if useDRC && err == nil && drcRecordableReply(compCtx.CacheReply, len(result)) {
 			c.server.drc.record(clientAddr, call.XID, data, result)
 		}
 

--- a/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
+++ b/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
@@ -146,9 +146,6 @@ Categories:
 | RDDR7 | bug | READDIR cookie and attribute-request validation | #2336 |
 | RDDR8 | bug | READDIR cookie and attribute-request validation | #2336 |
 | RDDR9 | bug | READDIR cookie and attribute-request validation | #2336 |
-| RPLY10 | bug | duplicate request cache replays the wrong status | #2337 |
-| RPLY14 | bug | duplicate request cache replays the wrong status | #2337 |
-| RPLY3 | bug | duplicate request cache replays the wrong status | #2337 |
 | SEC2 | bug | SECINFO validation | #2339 |
 | SEC3 | bug | SECINFO validation | #2339 |
 | SEC5 | bug | SECINFO validation | #2339 |


### PR DESCRIPTION
## The issue's premise is only one-third right

#2337 is titled "the duplicate request cache replays the wrong status", and it
groups three pynfs NFSv4.0 failures under that one cause. Two of the three never
reach the duplicate request cache at all — they fail on the *first* call, before
anything is replayed. pynfs labels its checks, and the labels in the issue body
say which:

| Test | pynfs check that failed | What that means |
| --- | --- | --- |
| RPLY3 | `Call to be replayed should return NFS4ERR_ISDIR, instead got NFS4_OK` | the original call, not a replay |
| RPLY10 | `Call to be replayed should return NFS4_OK or NFS4ERR_EXPIRED, instead got NFS4ERR_BAD_STATEID` | the original call, not a replay |
| RPLY14 | `Replay the first time should return NFS4_OK, instead got NFS4ERR_EXIST` | an actual replay defect |

`_replay()` in `nfs4.0/servertests/st_replay.py` checks the first compound under
the label "Call to be replayed", captures whatever status came back, and only
then retransmits under "Replay the first time" / "Replay the second time". So
RPLY3 and RPLY10 are two independent bugs that happen to live in a file named
`st_replay.py`, and the third one is the DRC.

The third one also isn't the DRC "replaying the wrong status". The server has a
duplicate request cache; NFSv4.0 was simply never routed through it, so there was
nothing to replay.

Three separate root causes, one commit each.

## RPLY3 — OPEN had no file-type gate

OPEN is defined over regular files only. The handler resolved the component,
checked the caller's permissions against the requested `share_access`, and
opened whatever it found. Opening a directory therefore returned `NFS4_OK` and
handed back an open stateid for it.

RFC 7530 §16.16.6:

> If the component provided to OPEN resolves to something other than a regular
> file (or a named attribute), an error will be returned to the client. If it is
> a directory, NFS4ERR_ISDIR is returned; otherwise, NFS4ERR_SYMLINK is
> returned. Note that NFS4ERR_SYMLINK is returned for both symlinks and for
> special files of other types.

The fix folds the type check into `checkOpenTarget` (was `checkOpenAccess`), the
single gate every OPEN of an already-existing object passes through, so all four
paths get it rather than only the one the test exercises: CLAIM_NULL NOCREATE,
CLAIM_NULL CREATE landing on an existing name, CLAIM_FH, and
CLAIM_DELEGATE_CUR. The function now returns an `nfsstat4` because ISDIR and
SYMLINK have no `metadata.ExportError` spelling.

**One behaviour I traded, stated plainly.** The gate refuses in the handler,
before `StateManager.OpenFile`, which is where `consumeSeqidOnError` is deferred
— so an ISDIR rejection does not consume the open-owner seqid. Per RFC 7530
§9.1.7 it arguably should: the exempt list in `failedSeqidReply` is
STALE_CLIENTID, STALE_STATEID, BAD_STATEID, BAD_SEQID, BADXDR, RESOURCE,
NOFILEHANDLE and MOVED, matching nfsd's `seqid_mutating_err()`, and ISDIR is not
on it.

I did not change that, because it is deliberate and tested.
`TestOpen_ClientIDSpansPrincipals` says so in its own comment — "checkOpenAccess
refuses before the state layer sees the request, so seqid 3 is still unused when
the read OPEN below presents it" — and then reuses seqid 3. The same is already
true of NFS4ERR_ACCESS and predates this PR; my ISDIR and SYMLINK returns follow
that convention rather than break it.

So for the specific input "OPEN a directory" this PR does trade behaviour: it
used to wrongly succeed and consume the seqid, and now correctly returns ISDIR
and does not. If the pinned convention turns out to be the wrong one, this adds a
case to it. That question — whether a permission or type refusal has "reached the
owner's sequence" — is #2359, and it wants checking against knfsd and
nfs-ganesha rather than against the RFC alone.

## RPLY10 — lease cancellation left no trace

When a v4.0 lease lapsed, `onLeaseExpired` dropped the client's open, lock and
delegation state and removed the client record. Nothing recorded that the state
had ever existed, so a client returning after the partition and using one of
those stateids was answered `NFS4ERR_BAD_STATEID` — the code for a stateid the
server never issued.

RFC 7530 §9.6.3.2:

> When a lease is canceled, all locking state associated with it is freed, and
> the use of any of the associated stateids will result in NFS4ERR_EXPIRED being
> returned.

The two statuses send a client into the same recovery, so this is not a
correctness hole so much as a lie about *why*. It is still what the RFC
specifies, and it is what a client's error reporting shows the user.

The expiry callback now records the stateids it is about to free, and every miss
path a returning client can reach consults that set before falling back:
validation of open, lock and delegation stateids, plus CLOSE, OPEN_CONFIRM and
OPEN_DOWNGRADE. Deliberately **not** touched: the stale-vs-bad epoch
classification, which is #2341's surface — this change adds an `EXPIRED` branch
where a miss already existed and changes no existing classification.

The set is capped and dropped wholesale on overflow rather than aged out per
entry; it carries a `ponytail:` comment naming that ceiling. Losing an entry only
degrades the answer back to the `NFS4ERR_BAD_STATEID` the server gave before.

## RPLY14 — NFSv4.0 never reached a duplicate request cache

This is the real one, and the finding is that the cache was not being consulted
rather than that it replayed the wrong status.

NFSv4.0 has no SEQUENCE. Sequenced operations — OPEN, CLOSE, LOCK, LOCKU,
OPEN_CONFIRM, OPEN_DOWNGRADE, RELEASE_LOCKOWNER — are covered by the open- and
lock-owner seqid replay caches in the state manager, which is why RPLY1, RPLY2,
RPLY9 and friends already pass. CREATE, REMOVE, RENAME and LINK carry no seqid.
A retransmission of one of those after a lost reply is indistinguishable from a
new request, so it was executed a second time and the client was told
`NFS4ERR_EXIST` for a directory create that had in fact succeeded. RFC 7530
§16.16.6 calls the missing machinery "the server duplicate request cache
mechanism".

**The cache already existed.** `pkg/adapter/nfs/drc.go` has been in the tree
since June (`3e37a2add`): sharded, keyed on (source address, XID, CRC-32 of the request body),
with in-flight duplicate detection, a TTL and cap eviction, modelled on knfsd's
`fs/nfsd/nfscache.c`, and covered by nine tests in `drc_test.go`. The adapter
already gates every non-idempotent NFSv3 procedure through
`drc.lookup` / `drc.record` / `drc.abort`. NFSv4 simply never reached it.

So the defect is not "there is no duplicate request cache" but "v4.0 does not
route through the one we have", which is also what shrinks the risk here: a
reimplementation carrying its own eviction policy would have to earn trust on its
own, whereas a branch into infrastructure the v3 path has exercised for three months
inherits it. An earlier version of this commit did write that second cache, in
the v4 handlers, before I found this one; it is gone.

The wiring is: `handleNFSv4Procedure` consults the cache for minorversion-0
COMPOUNDs only, and `dispatchV40` sets `compCtx.CacheReply` when the COMPOUND
actually ran one of those four operations, so the adapter records the reply or
releases the reserved slot accordingly. v4.1 and v4.2 are gated out — they take
exactly-once semantics from the session slot table, and a second cache answering
their retransmissions would be a second source of truth.

Deciding cacheability *after* execution (from the result opcodes) rather than
before is what keeps READ replies out of the cache without having to decode
every operation's arguments up front to find out what the COMPOUND contains.

A side effect worth naming: v4.0 now also drops a duplicate that arrives while
the original is still executing, instead of running it twice concurrently. That
is the behaviour pynfs itself documents for the Linux server — `_replay()` sleeps
0.3s between retransmissions with the comment "we happen to know the current
Linux server implementation will drop a replay if it comes too quickly".

### Two things a reviewer will want to check

**Aliasing.** The cache hands the same backing array to every replay.
`drc.record` copies the reply before storing it, and the only consumer,
`rpc.MakeSuccessReply`, marshals into a freshly allocated buffer and patches the
record-marking fragment header inside *that* buffer — the payload it was handed
is never written through. Verified by reading
`internal/adapter/nfs/rpc/parser.go`, not assumed. This is the same property the
v3 path has depended on since the cache was written, which is why it holds rather
than merely happening to.

**Leaked in-progress slots.** `lookup` reserves a slot, and a slot never
released is worse than it first looks: `lookup` matches an in-progress entry
*before* it considers the entry's age, and `evictIfNeeded`'s TTL sweep only runs
when a shard is at capacity. So a leaked slot does not expire — it answers every
later retransmission of that exact request with a silent drop, indefinitely.

The normal paths are covered: between the reserve and the record, the only call
is `ProcessCompound`; the GSS auth-failure early return happens *before* the
lookup; and the two early returns after it — replay and in-flight duplicate —
reserve nothing.

The path that is not covered by ordinary control flow is a panic.
`ProcessCompound` has no internal recover, and `handleRequestPanic` recovers
**per request** and leaves the connection open — so the client keeps its source
port, keeps generating the same cache key, and that request stays wedged for the
life of the connection. The release is therefore a `defer`, not a trailing
branch. `abort` deletes an entry only while it is still in-progress, so it is a
no-op once the reply has been recorded and needs no flag to guard it.

This is the same mistake as the CRC cost below, in a different currency, and it
is the transferable lesson from this PR. Neither problem exists at v3's scale,
because v3's DRC covers nine small procedures. Routing *every* v4.0 COMPOUND
through the same machinery turned two things that were fine at a narrow blast
radius into problems at a wide one — an unguarded release that used to leak
rarely, and a per-byte checksum that used to run only on tiny requests. The
lesson is not "add a size bound" or "add a defer"; it is that widening a narrow
mechanism means re-checking every cost and every failure mode it was allowed to
have while it was narrow. I found this one twice, by two different routes.

The v3 path has the same unguarded shape. It is deliberately left alone here —
that is regression surface this PR has no reason to touch — and is tracked as
#2357. What made it worth fixing on the v4 path anyway is that this PR *widens*
the exposure considerably: v3 reserves a slot only for its nine non-idempotent
procedures, whereas every v4.0 COMPOUND now reserves one. "The v3 path has the
same shape" is an argument about precedent, and precedent stops transferring once
the rate changes by that much.

#2357 also carries the better question, which this PR does not attempt: whether
`lookup` should consider an entry's age *before* matching it as in-progress. That
would bound the damage of any future leak at the TTL, instead of leaving every
call site responsible for remembering the release.

A replayed reply returns early and so skips `maybeRegisterBackchannel` and the
`noteNFSVersion` refinement. Both are correct: backchannel registration only
fires for a connection carrying a v4.1 session binding, which a v4.0 COMPOUND
cannot have, and `noteNFSVersion("4")` has already run in the dispatcher before
the refinement to "4.0".

### What review caught

Copilot flagged that routing every v4.0 COMPOUND through the cache makes each
one pay a CRC-32 over the full request body, and that `record` keeps the whole
reply while the cache bounds entry count rather than bytes. Both were right, and
the first is worse than it was reported: the v4.0 path checksums the body
**twice**, once in `lookup` to reserve the slot and once in the deferred `abort`
to release it. Measured `crc32.ChecksumIEEE`:

| Payload | ns/op | throughput |
| --- | --- | --- |
| 1 MiB | 252,830 | 4.1 GB/s |
| 64 KiB | 11,122 | |
| 8 KiB | 1,369 | |
| 256 B | 25 | |

So a 1 MiB v4.0 WRITE was paying ~506µs of CRC-32 for a compound the cache would
never keep — only CREATE, REMOVE, RENAME and LINK are recorded, and those carry a
filehandle and a name. NFSv3 never pays this because its DRC covers nine small
procedures; putting it on the whole v4.0 surface is what made payload size
matter — the same widening that made the slot leak worth guarding, arrived at
by an entirely different route.

Copilot's second point was independent and equally right: bounding entry *count*
while storing whole replies is a memory bound in name only. 4096 entries times an
unbounded reply is not a cap.

Both directions are now bounded by `maxDupReqBytes` (8 KiB), far above any
namespace-mutating compound and far below bulk data. Anything larger is left to
re-execute on a retransmission, which is what the server did before the cache
covered v4.0. Worst-case cache footprint goes from unbounded to ~32 MiB.

The third comment was a wording fix — the COMPOUND tag is a `utf8str_cs`, not an
opaque, though the wire encoding is the same. Checked against RFC 7530 §15.2.2
before changing it.

## Evidence

`go build ./...`, `go vet ./...`, `gofmt` clean, `go test ./...` green,
`go test -race ./internal/adapter/nfs/...` green.

Every new test was run against a deliberately broken build before being trusted,
and that step earned its keep. The first version of the replay test had its
controls ordered so the differing-body control ran first and overwrote the cached
entry, which masked two mutations: keying the cache without the XID and keying it
without the client address both left the test green. That version of the cache is
gone, but the lesson stood up the replacement's tests, each of which now fails
under every mutation that would break the property it claims to pin:

| Test | Mutation | Result |
| --- | --- | --- |
| `TestIsV40Compound` | accept any minorversion (v4.1 leaks into the cache) | FAIL |
| `TestDispatchV40_CacheReply` | mark every COMPOUND cacheable | FAIL |
| `TestDispatchV40_CacheReply` | mark no COMPOUND cacheable | FAIL |
| `TestOpen_NonRegularTarget` | drop the ISDIR branch | FAIL |
| `TestOpen_NonRegularTarget` | drop the SYMLINK branch | FAIL |
| `TestExpiredLease_StateidsReportExpired` | drop the recording call | FAIL |
| `TestV40Compound_ReleasesDRCSlotOnPanic` | release the slot in a trailing branch instead of a `defer` | FAIL (`lookup` = `drcInProgressDup`) |
| `TestDRCEligibleV40Compound` | drop the request size gate | FAIL |
| `TestDRCRecordableReply` | drop the reply size bound | FAIL |
| `TestDRCRecordableReply` | ignore the "ran a mutation" flag | FAIL |
| all of the above | none (control) | ok |

Both halves of the size bound are pure predicates (`drcEligibleV40Compound`,
`drcRecordableReply`) precisely so they can be tested without standing up a
runtime to provoke an 8 KiB reply. The handler keeps one call to each.

`TestExpiredLease_StateidsReportExpired` also carries a never-issued stateid as a
control, so it cannot pass by everything answering `NFS4ERR_EXPIRED`.

The cache's own contract — replay on a match, a differing checksum treated as a
new request, in-flight duplicates dropped, TTL and cap eviction, concurrent
access — is already covered by the nine tests in `pkg/adapter/nfs/drc_test.go`
and is unchanged by this PR.

## pynfs verification

The three rows are **removed** from `test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md`
in this PR, which is what makes them verify anything. The grader counts only NEW
failures, so a blacklisted test that starts passing is invisible while its row
stands — the row has to come out before the test is load-bearing. With it gone,
`pynfs v4.0 / memory` and `pynfs v4.0 / postgres-s3` go red and name the code if
any of RPLY3, RPLY10 or RPLY14 still fails, and stay green only if all three
pass. Two backends, graded by the harness rather than by a human reading a
terminal.

The backend split is not decoration: some rows in these tables are
backend-specific — the SATT12x family is postgres-only — so a memory-only run
could walk out a row that fails on postgres. CI catches that; a local run would
not have.

**RPLY8 stays.** It is categorised `suite`, and `baseline-knfsd.md` records the
Linux kernel server failing it in this same harness, along with RPLY5, RPLY6 and
RPLY7. That baseline is also what establishes the three codes here are ours:
knfsd passes all three.

Verified on the merged base (`c810d03db`), with the rows removed, on both
backends:

```
pynfs v4.0 / memory        Loaded 140 known failures
                           13 Skipped, 130 Failed, 5 Warned, 453 Passed
                           New failures: 0

pynfs v4.0 / postgres-s3   Loaded 140 known failures
                           13 Skipped, 131 Failed, 5 Warned, 452 Passed
                           New failures: 0
```

`Loaded 140` is the load-bearing number. The table held 151 rows before this
batch; #2358 removed six (LINK2, LINK9, LOOK8, RNM10, RNM11, RNM20) and #2361
removed two (LOCK20, LOCKMRG), leaving 143, and this PR removes three more. If
the rebase had restored a row or dropped an extra one, that number would not be
140 — it is what proves the run graded against the merged table rather than a
stale copy.

601 tests ran on each backend, so the suite genuinely executed rather than
silently skipping. In both failing lists RPLY8 appears once and RPLY3, RPLY10 and
RPLY14 do not appear at all. RPLY8's presence is the control: it proves the
search can find a code that is there, so the other three absences mean something.

With the rows gone, a still-failing RPLY3, RPLY10 or RPLY14 is by definition a
NEW failure. Both backends report zero. That is the gate, not the absence.

Closes #2337
