### PR TITLE
fix(nfs/v4): reject '.' and '..' components, and correct saved-FH and hard-link rename status

### DIFF
--- a/internal/adapter/nfs/v4/handlers/clone.go
+++ b/internal/adapter/nfs/v4/handlers/clone.go
@@ -53,14 +53,12 @@ import (
 func (h *Handler) handleClone(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
 	// CURRENT_FH is the destination, SAVED_FH is the source. Both must be set
 	// (the client PUTFHs the source, SAVEFHs it, then PUTFHs the destination).
-	// A missing handle on either side is NFS4ERR_NOFILEHANDLE (RFC 7862 15.13);
-	// note RequireSavedFH returns NFS4ERR_RESTOREFH, which is RESTOREFH-specific
-	// and wrong here, so check SavedFH directly.
+	// A missing handle on either side is NFS4ERR_NOFILEHANDLE (RFC 7862 15.13).
 	if status := types.RequireCurrentFH(ctx); status != types.NFS4_OK {
 		return cloneErr(status)
 	}
-	if ctx.SavedFH == nil {
-		return cloneErr(types.NFS4ERR_NOFILEHANDLE)
+	if status := types.RequireSavedFHOperand(ctx); status != types.NFS4_OK {
+		return cloneErr(status)
 	}
 	// Neither side may be the read-only pseudo-filesystem.
 	if pseudofs.IsPseudoFSHandle(ctx.CurrentFH) || pseudofs.IsPseudoFSHandle(ctx.SavedFH) {

--- a/internal/adapter/nfs/v4/handlers/link.go
+++ b/internal/adapter/nfs/v4/handlers/link.go
@@ -28,7 +28,7 @@ func (h *Handler) handleLink(ctx *types.CompoundContext, reader io.Reader) *type
 	}
 
 	// Require saved filehandle (source file to link)
-	if status := types.RequireSavedFH(ctx); status != types.NFS4_OK {
+	if status := types.RequireSavedFHOperand(ctx); status != types.NFS4_OK {
 		return &types.CompoundResult{
 			Status: status,
 			OpCode: types.OP_LINK,

--- a/internal/adapter/nfs/v4/handlers/link.go
+++ b/internal/adapter/nfs/v4/handlers/link.go
@@ -16,7 +16,7 @@ import (
 // Creates a hard link from SavedFH (source file) into CurrentFH (target directory).
 // Delegates to MetadataService.Link after cross-share and pseudo-fs validation.
 // Adds a directory entry in the target directory pointing to the source file; returns change info.
-// Errors: NFS4ERR_NOFILEHANDLE, NFS4ERR_RESTOREFH, NFS4ERR_ISDIR, NFS4ERR_XDEV, NFS4ERR_EXIST.
+// Errors: NFS4ERR_NOFILEHANDLE, NFS4ERR_ISDIR, NFS4ERR_XDEV, NFS4ERR_EXIST.
 func (h *Handler) handleLink(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
 	// Require current filehandle (target directory)
 	if status := types.RequireCurrentFH(ctx); status != types.NFS4_OK {

--- a/internal/adapter/nfs/v4/handlers/link_rename_test.go
+++ b/internal/adapter/nfs/v4/handlers/link_rename_test.go
@@ -153,9 +153,9 @@ func TestHandleLink_NoSavedFH(t *testing.T) {
 	args := encodeLinkArgs("newlink")
 	result := fx.handler.handleLink(ctx, bytes.NewReader(args))
 
-	if result.Status != types.NFS4ERR_RESTOREFH {
-		t.Errorf("LINK without SavedFH status = %d, want NFS4ERR_RESTOREFH (%d)",
-			result.Status, types.NFS4ERR_RESTOREFH)
+	if result.Status != types.NFS4ERR_NOFILEHANDLE {
+		t.Errorf("LINK without SavedFH status = %d, want NFS4ERR_NOFILEHANDLE (%d)",
+			result.Status, types.NFS4ERR_NOFILEHANDLE)
 	}
 }
 
@@ -416,9 +416,9 @@ func TestHandleRename_NoSavedFH(t *testing.T) {
 	args := encodeRenameArgs("old", "new")
 	result := fx.handler.handleRename(ctx, bytes.NewReader(args))
 
-	if result.Status != types.NFS4ERR_RESTOREFH {
-		t.Errorf("RENAME without SavedFH status = %d, want NFS4ERR_RESTOREFH (%d)",
-			result.Status, types.NFS4ERR_RESTOREFH)
+	if result.Status != types.NFS4ERR_NOFILEHANDLE {
+		t.Errorf("RENAME without SavedFH status = %d, want NFS4ERR_NOFILEHANDLE (%d)",
+			result.Status, types.NFS4ERR_NOFILEHANDLE)
 	}
 }
 
@@ -624,5 +624,115 @@ func TestHandleRename_CompoundSequence(t *testing.T) {
 	}
 	if moved.Type != metadata.FileTypeRegular {
 		t.Errorf("moved type = %v, want regular", moved.Type)
+	}
+}
+
+// ============================================================================
+// Component name validation ('.' and '..')
+// ============================================================================
+
+// TestComponentDotsRejected covers the operations that take a component4 off
+// the wire: none of them may resolve or create "." or "..".
+func TestComponentDotsRejected(t *testing.T) {
+	for _, dots := range []string{".", ".."} {
+		t.Run("LOOKUP "+dots, func(t *testing.T) {
+			fx := newRealFSTestFixture(t, "/export")
+			ctx := newRealFSContext(0, 0)
+			setCurrentFH(ctx, fx.rootHandle)
+
+			var args bytes.Buffer
+			_ = xdr.WriteXDRString(&args, dots)
+			result := fx.handler.handleLookup(ctx, bytes.NewReader(args.Bytes()))
+
+			if result.Status != types.NFS4ERR_BADNAME {
+				t.Errorf("LOOKUP %q status = %d, want NFS4ERR_BADNAME (%d)",
+					dots, result.Status, types.NFS4ERR_BADNAME)
+			}
+		})
+
+		t.Run("LINK "+dots, func(t *testing.T) {
+			fx := newRealFSTestFixture(t, "/export")
+			fileHandle := fx.createTestFile(t, fx.rootHandle, "original.txt", metadata.FileTypeRegular, 0o644, 0, 0)
+
+			ctx := newRealFSContext(0, 0)
+			setCurrentFH(ctx, fx.rootHandle)
+			setSavedFH(ctx, fileHandle)
+
+			result := fx.handler.handleLink(ctx, bytes.NewReader(encodeLinkArgs(dots)))
+
+			if result.Status != types.NFS4ERR_BADNAME {
+				t.Errorf("LINK to %q status = %d, want NFS4ERR_BADNAME (%d)",
+					dots, result.Status, types.NFS4ERR_BADNAME)
+			}
+		})
+
+		t.Run("RENAME oldname "+dots, func(t *testing.T) {
+			fx := newRealFSTestFixture(t, "/export")
+			ctx := newRealFSContext(0, 0)
+			setCurrentFH(ctx, fx.rootHandle)
+			setSavedFH(ctx, fx.rootHandle)
+
+			result := fx.handler.handleRename(ctx, bytes.NewReader(encodeRenameArgs(dots, "target")))
+
+			if result.Status != types.NFS4ERR_BADNAME {
+				t.Errorf("RENAME from %q status = %d, want NFS4ERR_BADNAME (%d)",
+					dots, result.Status, types.NFS4ERR_BADNAME)
+			}
+		})
+
+		t.Run("RENAME newname "+dots, func(t *testing.T) {
+			fx := newRealFSTestFixture(t, "/export")
+			fx.createTestFile(t, fx.rootHandle, "source.txt", metadata.FileTypeRegular, 0o644, 0, 0)
+
+			ctx := newRealFSContext(0, 0)
+			setCurrentFH(ctx, fx.rootHandle)
+			setSavedFH(ctx, fx.rootHandle)
+
+			result := fx.handler.handleRename(ctx, bytes.NewReader(encodeRenameArgs("source.txt", dots)))
+
+			if result.Status != types.NFS4ERR_BADNAME {
+				t.Errorf("RENAME to %q status = %d, want NFS4ERR_BADNAME (%d)",
+					dots, result.Status, types.NFS4ERR_BADNAME)
+			}
+		})
+	}
+}
+
+// TestHandleRename_OntoOwnHardLink checks that renaming a file onto one of its
+// own hard links keeps both names and reports unchanged change_info4.
+func TestHandleRename_OntoOwnHardLink(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+	fileHandle := fx.createTestFile(t, fx.rootHandle, "file", metadata.FileTypeRegular, 0o644, 0, 0)
+
+	authCtx := newTestAuthCtx(0, 0)
+	if _, err := fx.metaSvc.CreateHardLink(authCtx, fx.rootHandle, "link", fileHandle); err != nil {
+		t.Fatalf("CreateHardLink: %v", err)
+	}
+
+	ctx := newRealFSContext(0, 0)
+	setCurrentFH(ctx, fx.rootHandle)
+	setSavedFH(ctx, fx.rootHandle)
+
+	result := fx.handler.handleRename(ctx, bytes.NewReader(encodeRenameArgs("file", "link")))
+	if result.Status != types.NFS4_OK {
+		t.Fatalf("RENAME onto own hard link status = %d, want NFS4_OK", result.Status)
+	}
+
+	reader := bytes.NewReader(result.Data)
+	if _, err := xdr.DecodeUint32(reader); err != nil {
+		t.Fatalf("decode status: %v", err)
+	}
+	_, srcBefore, srcAfter := parseChangeInfo4(reader)
+	_, tgtBefore, tgtAfter := parseChangeInfo4(reader)
+	if srcBefore != srcAfter || tgtBefore != tgtAfter {
+		t.Errorf("change_info4 changed (src %d->%d, tgt %d->%d), want unchanged",
+			srcBefore, srcAfter, tgtBefore, tgtAfter)
+	}
+
+	// Both names must survive the no-op.
+	for _, name := range []string{"file", "link"} {
+		if _, err := fx.metaSvc.Lookup(authCtx, fx.rootHandle, name); err != nil {
+			t.Errorf("Lookup %q after no-op rename: %v", name, err)
+		}
 	}
 }

--- a/internal/adapter/nfs/v4/handlers/rename.go
+++ b/internal/adapter/nfs/v4/handlers/rename.go
@@ -28,7 +28,7 @@ func (h *Handler) handleRename(ctx *types.CompoundContext, reader io.Reader) *ty
 	}
 
 	// Require saved filehandle (source directory)
-	if status := types.RequireSavedFH(ctx); status != types.NFS4_OK {
+	if status := types.RequireSavedFHOperand(ctx); status != types.NFS4_OK {
 		return &types.CompoundResult{
 			Status: status,
 			OpCode: types.OP_RENAME,

--- a/internal/adapter/nfs/v4/handlers/rename.go
+++ b/internal/adapter/nfs/v4/handlers/rename.go
@@ -16,7 +16,7 @@ import (
 // Moves/renames a file or directory from SavedFH (source dir) to CurrentFH (target dir).
 // Delegates to MetadataService.Move after cross-share and pseudo-fs validation.
 // Updates source and target directory entries and timestamps; returns change info for both dirs.
-// Errors: NFS4ERR_NOFILEHANDLE, NFS4ERR_RESTOREFH, NFS4ERR_NOENT, NFS4ERR_XDEV, NFS4ERR_BADXDR.
+// Errors: NFS4ERR_NOFILEHANDLE, NFS4ERR_NOENT, NFS4ERR_XDEV, NFS4ERR_BADXDR.
 func (h *Handler) handleRename(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
 	// Require current filehandle (target directory)
 	if status := types.RequireCurrentFH(ctx); status != types.NFS4_OK {

--- a/internal/adapter/nfs/v4/handlers/secinfo.go
+++ b/internal/adapter/nfs/v4/handlers/secinfo.go
@@ -53,6 +53,14 @@ func (h *Handler) handleSecInfo(ctx *types.CompoundContext, reader io.Reader) *t
 		}
 	}
 
+	if status := types.ValidateUTF8Filename(name); status != types.NFS4_OK {
+		return &types.CompoundResult{
+			Status: status,
+			OpCode: types.OP_SECINFO,
+			Data:   encodeStatusOnly(status),
+		}
+	}
+
 	// Per RFC 7530 Section 16.31.4: SECINFO consumes the current filehandle.
 	ctx.CurrentFH = nil
 

--- a/internal/adapter/nfs/v4/handlers/secinfo.go
+++ b/internal/adapter/nfs/v4/handlers/secinfo.go
@@ -53,6 +53,7 @@ func (h *Handler) handleSecInfo(ctx *types.CompoundContext, reader io.Reader) *t
 		}
 	}
 
+	// Validate UTF-8 filename
 	if status := types.ValidateUTF8Filename(name); status != types.NFS4_OK {
 		return &types.CompoundResult{
 			Status: status,

--- a/internal/adapter/nfs/v4/handlers/secinfo_test.go
+++ b/internal/adapter/nfs/v4/handlers/secinfo_test.go
@@ -410,3 +410,38 @@ func TestEncodeSecInfoGSSEntry_None(t *testing.T) {
 		t.Fatalf("service = %d, want 1 (none)", svc)
 	}
 }
+
+func TestHandleSecInfo_RejectsInvalidName(t *testing.T) {
+	pfs := pseudofs.New()
+	pfs.Rebuild([]string{"/export"})
+	h := NewHandler(nil, pfs)
+
+	rootHandle := pfs.GetRootHandle()
+
+	tests := []struct {
+		name string
+		want uint32
+	}{
+		{"", types.NFS4ERR_INVAL},
+		{".", types.NFS4ERR_BADNAME},
+		{"..", types.NFS4ERR_BADNAME},
+		{"a/b", types.NFS4ERR_BADNAME},
+	}
+
+	for _, tt := range tests {
+		ctx := &types.CompoundContext{
+			Context:    context.Background(),
+			ClientAddr: "127.0.0.1:9999",
+			CurrentFH:  make([]byte, len(rootHandle)),
+		}
+		copy(ctx.CurrentFH, rootHandle)
+
+		var args bytes.Buffer
+		_ = xdr.WriteXDRString(&args, tt.name)
+
+		result := h.handleSecInfo(ctx, bytes.NewReader(args.Bytes()))
+		if result.Status != tt.want {
+			t.Errorf("SECINFO %q status = %d, want %d", tt.name, result.Status, tt.want)
+		}
+	}
+}

--- a/internal/adapter/nfs/v4/types/constants_test.go
+++ b/internal/adapter/nfs/v4/types/constants_test.go
@@ -142,6 +142,24 @@ func TestRequireSavedFH(t *testing.T) {
 	})
 }
 
+func TestRequireSavedFHOperand(t *testing.T) {
+	t.Run("nil saved FH returns NFS4ERR_NOFILEHANDLE", func(t *testing.T) {
+		ctx := &CompoundContext{SavedFH: nil}
+		status := RequireSavedFHOperand(ctx)
+		if status != NFS4ERR_NOFILEHANDLE {
+			t.Errorf("RequireSavedFHOperand(nil) = %d, want %d", status, NFS4ERR_NOFILEHANDLE)
+		}
+	})
+
+	t.Run("non-nil saved FH returns NFS4_OK", func(t *testing.T) {
+		ctx := &CompoundContext{SavedFH: []byte("saved-handle")}
+		status := RequireSavedFHOperand(ctx)
+		if status != NFS4_OK {
+			t.Errorf("RequireSavedFHOperand(non-nil) = %d, want %d (NFS4_OK)", status, NFS4_OK)
+		}
+	})
+}
+
 // ============================================================================
 // ValidateUTF8Filename Tests
 // ============================================================================
@@ -220,6 +238,31 @@ func TestValidateUTF8Filename(t *testing.T) {
 		{
 			name:     "filename with spaces",
 			filename: "my file.txt",
+			expected: NFS4_OK,
+		},
+		{
+			name:     "dot component",
+			filename: ".",
+			expected: NFS4ERR_BADNAME,
+		},
+		{
+			name:     "dot-dot component",
+			filename: "..",
+			expected: NFS4ERR_BADNAME,
+		},
+		{
+			name:     "three dots is an ordinary name",
+			filename: "...",
+			expected: NFS4_OK,
+		},
+		{
+			name:     "dotfile is an ordinary name",
+			filename: ".config",
+			expected: NFS4_OK,
+		},
+		{
+			name:     "name ending in a dot is ordinary",
+			filename: "archive.",
 			expected: NFS4_OK,
 		},
 	}

--- a/internal/adapter/nfs/v4/types/errors.go
+++ b/internal/adapter/nfs/v4/types/errors.go
@@ -23,7 +23,7 @@ import (
 //   - NFS4_OK if the filename is valid
 //   - NFS4ERR_INVAL if the filename is empty
 //   - NFS4ERR_BADCHAR if the filename contains invalid UTF-8 or null bytes
-//   - NFS4ERR_BADNAME if the filename contains path separators ('/')
+//   - NFS4ERR_BADNAME if the filename contains path separators ('/'), or is "." or ".."
 //   - NFS4ERR_NAMETOOLONG if the filename exceeds 255 bytes
 func ValidateUTF8Filename(name string) uint32 {
 	// Empty filename is invalid
@@ -43,6 +43,12 @@ func ValidateUTF8Filename(name string) uint32 {
 
 	// Path separators are not allowed in component names
 	if strings.ContainsRune(name, '/') {
+		return NFS4ERR_BADNAME
+	}
+
+	// "." and ".." are directory-relative references, not names a client may
+	// pass as a component: the server must never resolve or create them.
+	if name == "." || name == ".." {
 		return NFS4ERR_BADNAME
 	}
 

--- a/internal/adapter/nfs/v4/types/types.go
+++ b/internal/adapter/nfs/v4/types/types.go
@@ -346,6 +346,19 @@ func RequireSavedFH(ctx *CompoundContext) uint32 {
 	return NFS4_OK
 }
 
+// RequireSavedFHOperand checks that the CompoundContext has a saved filehandle
+// for an operation that takes it as an operand (LINK, RENAME, CLONE).
+//
+// Returns NFS4_OK when SavedFH is set, NFS4ERR_NOFILEHANDLE otherwise.
+// NFS4ERR_RESTOREFH belongs to RESTOREFH alone and is not a valid status for
+// these operations.
+func RequireSavedFHOperand(ctx *CompoundContext) uint32 {
+	if ctx.SavedFH == nil {
+		return NFS4ERR_NOFILEHANDLE
+	}
+	return NFS4_OK
+}
+
 // ============================================================================
 // NFSv4.1 Request Context
 // ============================================================================

--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -773,6 +773,14 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 	var dstFile *File
 	dstHandle, err = store.GetChild(ctx.Context, toDir, toName)
 	if err == nil {
+		// Both names already resolve to the same file, so they are hard links
+		// of each other and the rename has nothing to move: renaming one over
+		// the other would destroy a link. POSIX rename(2) and RFC 7530
+		// section 16.27.4 both make this a successful no-op.
+		if string(srcHandle) == string(dstHandle) {
+			return nil, nil, nil
+		}
+
 		// Destination exists - check compatibility
 		dstFile, err = store.GetFile(ctx.Context, dstHandle)
 		if err != nil {

--- a/pkg/metadata/service_test.go
+++ b/pkg/metadata/service_test.go
@@ -965,6 +965,33 @@ func TestMetadataService_Move(t *testing.T) {
 		assert.Equal(t, original.Mode, file.Mode)
 	})
 
+	t.Run("rename onto own hard link is a no-op", func(t *testing.T) {
+		t.Parallel()
+		fx := newTestFixture(t)
+
+		_, _, err := fx.service.CreateFile(fx.rootContext(), fx.rootHandle, "file", &metadata.FileAttr{
+			Mode: 0644,
+		})
+		require.NoError(t, err)
+
+		fileHandle, err := fx.store.GetChild(context.Background(), fx.rootHandle, "file")
+		require.NoError(t, err)
+
+		_, err = fx.service.CreateHardLink(fx.rootContext(), fx.rootHandle, "link", fileHandle)
+		require.NoError(t, err)
+
+		clobbered, _, err := fx.service.Move(fx.rootContext(), fx.rootHandle, "file", fx.rootHandle, "link")
+		require.NoError(t, err)
+		assert.Nil(t, clobbered)
+
+		// Both names still resolve to the same file, and the link count is intact.
+		for _, name := range []string{"file", "link"} {
+			f, err := fx.service.Lookup(fx.rootContext(), fx.rootHandle, name)
+			require.NoError(t, err, "name %q", name)
+			assert.EqualValues(t, 2, f.Nlink, "name %q", name)
+		}
+	})
+
 	t.Run("move to different directory", func(t *testing.T) {
 		t.Parallel()
 		fx := newTestFixture(t)

--- a/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
+++ b/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
@@ -106,12 +106,6 @@ Categories:
 | LOCK13 | bug | LOOKUP fails opening the test tree, so the test cannot run | #2332 |
 | LOCK15 | bug | LOOKUP fails opening the test tree, so the test cannot run | #2332 |
 | LOCK17 | bug | LOOKUP fails opening the test tree, so the test cannot run | #2332 |
-| LINK2 | bug | '.' and '..' and malformed names not rejected | #2333 |
-| LINK9 | bug | '.' and '..' and malformed names not rejected | #2333 |
-| LOOK8 | bug | '.' and '..' and malformed names not rejected | #2333 |
-| RNM10 | bug | '.' and '..' and malformed names not rejected | #2333 |
-| RNM11 | bug | '.' and '..' and malformed names not rejected | #2333 |
-| RNM20 | bug | '.' and '..' and malformed names not rejected | #2333 |
 | CR11 | bug | OPEN claim, share-reservation and create-mode validation | #2334 |
 | CR13 | bug | OPEN claim, share-reservation and create-mode validation | #2334 |
 | OPEN14 | bug | OPEN claim, share-reservation and create-mode validation | #2334 |

--- a/test/nfs-conformance/pynfs/KNOWN_FAILURES_V41.md
+++ b/test/nfs-conformance/pynfs/KNOWN_FAILURES_V41.md
@@ -63,10 +63,6 @@ Categories:
 | LKPP1s | bug | lookupp41 | #2335 |
 | LKPP2 | bug | lookupp41 | #2335 |
 | PUTFH2 | bug | lookupp41 | #2335 |
-| RNM10 | bug | names41 | #2333 |
-| RNM11 | bug | names41 | #2333 |
-| RNM20 | bug | names41 | #2333 |
-| RNM4 | bug | names41 | #2333 |
 | CSESS15 | bug | EXCHANGE_ID/CREATE_SESSION/DESTROY_CLIENTID validation | #2340 |
 | CSESS16a | bug | EXCHANGE_ID/CREATE_SESSION/DESTROY_CLIENTID validation | #2340 |
 | CSESS23 | bug | EXCHANGE_ID/CREATE_SESSION/DESTROY_CLIENTID validation | #2340 |


### PR DESCRIPTION
Closes #2333

Ten pynfs rows tagged `#2333` turned out to be three distinct defects, all of them in shared code
rather than in the operations the issue names.

## 1. `.` and `..` were accepted as `component4` values

`types.ValidateUTF8Filename` is the one validator every NFSv4 operation that takes a name off the
wire already routes through. It checked UTF-8, null bytes, `/` and length — but not the two
directory-relative references. What happened next depended on which operation you asked:

- **LOOKUP** resolved `.` and returned `NFS4_OK`, handing the client a filehandle for a name the
  server should never have interpreted.
- **LINK** and **RENAME** got as far as `metadata.ValidateName`, which does reject them, but with
  `ErrInvalidArgument` → `NFS4ERR_INVAL`.

RFC 7530 §12.7 makes this `NFS4ERR_BADNAME` — "This includes such situations as file system
prohibitions of `.` and `..` as filenames for certain operations" — and §16.9.4 names it explicitly
for LINK. The Linux server does the whole check in one function, `check_filename()` in
`fs/nfsd/nfs4xdr.c`, which is why knfsd passes all of these in the same harness.

The fix is one check in the validator. That covers LOOKUP, LINK, RENAME (both names), CREATE, OPEN,
REMOVE and the xattr operations in a single edit rather than the three the issue names — patching
only those three would have left every sibling broken for a later run to refile.

## 2. LINK and RENAME reported a missing saved filehandle as `NFS4ERR_RESTOREFH`

RFC 7530 §13.1.4.12 scopes that error to exactly one operation: "The RESTOREFH operation does not
have a saved filehandle (identified by SAVEFH) to operate upon." LINK and RENAME take the saved
filehandle as an *operand*; a missing one is `NFS4ERR_NOFILEHANDLE`. CLONE had already noticed this
and open-coded the check with a comment explaining why it could not use the shared helper.

`types.RequireSavedFHOperand` now serves LINK, RENAME and CLONE; RESTOREFH keeps `RequireSavedFH`.
The two pinning tests that asserted `NFS4ERR_RESTOREFH` from LINK and RENAME were encoding the bug
and have been corrected.

## 3. RENAME onto one of the file's own hard links destroyed a link

`metadata.Service.Move` short-circuited only when source and destination were the same *name* in the
same directory. When `newname` was a different name already pointing at the same file, Move ran the
full rename: it unlinked the destination and moved the source over it, so two names became one and
`nlink` dropped. That is silent data loss.

POSIX `rename(2)` and RFC 7530 §16.27.4 agree: "If oldname and newname both refer to the same file
(they might be hard links of each other), then RENAME should perform no action and return success."

The guard sits in the metadata service rather than the v4 handler, so NFSv3 RENAME and SMB rename
get it too. Handle identity is the right test here because `CreateHardLink` points the new name at
the *same* `FileHandle` (`tx.SetChild(dir, name, targetHandle)`), and `EncodeShareHandle` is
deterministic, so two links of one file always encode byte-identically.

## Deliberately excluded: #2355

The Move no-op has a consequence on the SMB path. `set_info.go`'s FileRenameInformation handler
treats any `err == nil` from `Move` as "the rename happened" and unconditionally calls
`NotifyRename` and `openFile.SetName`. The hard-link case is the **first** where Move succeeds with
`oldFileName != toName` while mutating nothing — the pre-existing same-name no-op is harmless there
because old and new names are identical — so an assumption that held for years quietly stopped
holding. Watchers now get told a file disappeared while it still resolves.

This is strictly better than the previous behaviour, which silently destroyed a hard link: on-disk
state is now correct and one notification is stale. The fix belongs in the SMB handler and cannot be
validated without smbtorture, so it is tracked as **#2355** rather than folded into an NFSv4
name-validation PR.

## Evidence

**Every new test was run against the pre-fix source before being trusted.** All of them fail there:

```
--- FAIL: TestValidateUTF8Filename/dot_component
--- FAIL: TestValidateUTF8Filename/dot-dot_component
--- FAIL: TestRequireSavedFHOperand                    (build failure: helper does not exist)
--- FAIL: TestHandleLink_NoSavedFH
--- FAIL: TestHandleRename_NoSavedFH
--- FAIL: TestComponentDotsRejected/{LOOKUP,LINK,RENAME_oldname,RENAME_newname}_{.,..}
--- FAIL: TestHandleRename_OntoOwnHardLink
--- FAIL: TestHandleSecInfo_RejectsInvalidName
--- FAIL: TestMetadataService_Move/rename_onto_own_hard_link_is_a_no-op
```

The validator table also pins the inverse risk — over-strict validation would break the Linux client
and pjdfstest — so `...`, `.config` and `archive.` are asserted to stay legal. They pass both before
and after.

### pynfs, memory profile, full suite both versions

Scoped `--tests` runs were not used: pynfs skips any test whose `DEPEND:` prerequisites did not run
in the same invocation, and the grader counts only `FAILURE`, so a scoped run of these ten codes
reports `6 Skipped … CI green` while proving nothing. #2354 now refuses to grade such a run.

**v4.0** — `601 of 689 tests` / `13 Skipped, 141 Failed, 5 Warned, 442 Passed` → Failing 141,
Known 141, **New Failures 0**.

```
LOOK8    st_lookup.testDots         : PASS      RNM10    st_rename.testDotsOldname : PASS
LINK2    st_link.testNoSfh          : PASS      RNM11    st_rename.testDotsNewname : PASS
LINK9    st_link.testDots           : PASS      RNM20    st_rename.testLinkRename  : PASS
RNM4     st_rename.testNoSfh        : PASS
```

**v4.1** — `184 of 266 tests` / `1 Skipped, 69 Failed, 0 Warned, 114 Passed` → Failing 69, Known 69,
**New Failures 0**.

```
RNM4     st_rename.testNoSfh        : PASS      RNM11    st_rename.testDotsNewname : PASS
RNM10    st_rename.testDotsOldname  : PASS      RNM20    st_rename.testLinkRename  : PASS
```

Every removed row has an explicit `PASS` verdict in the results block, not an absence.

**POSIX suite was not verified locally.** `run-posix.sh` needs root to mount and no non-interactive
sudo was available in this environment; `posix-tests.yml` covers it on this PR. Recording it as
locally green when it never ran is not something I am willing to do.

## Known-failure rows removed

`KNOWN_FAILURES_V40.md`: LINK2, LINK9, LOOK8, RNM10, RNM11, RNM20
`KNOWN_FAILURES_V41.md`: RNM4, RNM10, RNM11, RNM20

Two rows that now pass were deliberately **left in place**:

- **SEC5** (`#2339`) — SECINFO validated nothing at all, so it is part of this seam and now calls the
  validator; zero-length names return `NFS4ERR_INVAL`. The row belongs to #2339, which this PR does
  not close: SEC2 (`NFS4ERR_NOTDIR`) and SEC3 (`NFS4ERR_NOENT`) are lookup and type defects this
  change does not touch. **#2339 reduces to SEC2 + SEC3.**
- **RNM4 on v4.0** passes but has no `KNOWN_FAILURES_V40` row to remove — it never failed there. The
  4.0 variant sends no PUTFH at all, so `RequireCurrentFH` already caught it before this change; only
  the 4.1 variant sets CurrentFH and needed the saved-FH fix. The asymmetry is expected, not a missed
  row.
