### PR TITLE
fix(test/posix): always rebuild the binaries the suite is about to run

### DIFF
--- a/test/posix/setup-posix.sh
+++ b/test/posix/setup-posix.sh
@@ -159,15 +159,16 @@ fi
 DITTOFS_BIN="$REPO_ROOT/dfs"
 DITTOFSCTL_BIN="$REPO_ROOT/dfsctl"
 
-if [[ ! -x "$DITTOFS_BIN" ]]; then
-    log_info "Building dfs..."
-    (cd "$REPO_ROOT" && go build -o dfs ./cmd/dfs)
-fi
+# Always rebuild. Building only when the binary is absent silently serves a
+# stale one to every later run, so a suite reports on code that is not the code
+# under test — a fix reads as not working, and a regression reads as absent.
+# Go's build cache makes the no-change case cheap enough that skipping is not
+# worth the failure mode.
+log_info "Building dfs..."
+(cd "$REPO_ROOT" && go build -o dfs ./cmd/dfs)
 
-if [[ ! -x "$DITTOFSCTL_BIN" ]]; then
-    log_info "Building dfsctl..."
-    (cd "$REPO_ROOT" && go build -o dfsctl ./cmd/dfsctl)
-fi
+log_info "Building dfsctl..."
+(cd "$REPO_ROOT" && go build -o dfsctl ./cmd/dfsctl)
 
 # Clean up any existing state
 cleanup_existing() {

--- a/test/posix/setup-posix.sh
+++ b/test/posix/setup-posix.sh
@@ -155,7 +155,7 @@ if [[ ! -f "$CONFIG_FILE" ]]; then
     exit 1
 fi
 
-# Check if binaries exist
+# Binaries the suite runs against.
 DITTOFS_BIN="$REPO_ROOT/dfs"
 DITTOFSCTL_BIN="$REPO_ROOT/dfsctl"
 


### PR DESCRIPTION
## The defect

`setup-posix.sh` built the binaries only when they were missing:

```bash
if [[ ! -x "$DITTOFS_BIN" ]]; then
    log_info "Building dfs..."
    (cd "$REPO_ROOT" && go build -o dfs ./cmd/dfs)
fi
```

A worktree that has built `dfs` once serves that binary to every later run. The
suite then reports on code that is not the code under test.

Both directions are silent and neither announces itself:

- A fix reads as **not working** — you change the code, run the suite, and get
  the identical failure, because the server answering was built before the fix.
- A regression reads as **absent** — the suite passes against a binary that
  predates the change.

The first costs time; the second is the one that ships.

## Found by

An agent verifying an NFSv4 lock fix against pynfs got a byte-identical failure
after a change it had good reason to believe was correct, and spent time
treating a stale binary as evidence about the fix. Same family as the pynfs
grader that reported green on tests that never ran (#2354): the harness quietly
measured something other than what it claimed to measure.

## The fix

Build unconditionally. Go's build cache makes a no-change rebuild cheap enough
that the skip was never worth the failure mode it created — and the cost is
paid once per suite run, against suites that take tens of minutes.

## Verification

`bash -n` clean. The behaviour is a removed conditional rather than new logic,
so there is nothing to unit-test that is not the `go build` invocation itself;
the check is that `posix-tests.yml` still passes, which exercises this script on
every profile it runs.
