### PR TITLE
fix(nfs): merge same-owner byte-range locks and keep one lease per client ID

### DIFF
--- a/internal/adapter/nfs/v4/state/lease_test.go
+++ b/internal/adapter/nfs/v4/state/lease_test.go
@@ -428,3 +428,47 @@ func TestLeaseRenewAfterStop(t *testing.T) {
 	// Renew after stop should not panic
 	ls.Renew()
 }
+
+// A re-SETCLIENTID reuses the client ID, so SETCLIENTID_CONFIRM must confirm the
+// record that already owns that ID rather than installing a second one beside
+// it. Two records under one ID leave whichever the maps do not point at holding
+// a lease timer nothing renews, and when that timer fires it reaps the client on
+// its original schedule no matter how often RENEW refreshed the live lease.
+func TestRenewLease_SurvivesReSetClientID(t *testing.T) {
+	const lease = time.Second
+
+	sm := NewStateManager(lease)
+	verifier := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+
+	setClientID := func(port string) uint64 {
+		t.Helper()
+		callback := CallbackInfo{Program: 0x40000000, NetID: "tcp", Addr: "10.0.0.1.8." + port}
+		result, err := sm.SetClientID("client-resetclientid", verifier, callback, "10.0.0.1:1234")
+		if err != nil {
+			t.Fatalf("SetClientID: %v", err)
+		}
+		if err := sm.ConfirmClientID(result.ClientID, result.ConfirmVerifier); err != nil {
+			t.Fatalf("ConfirmClientID: %v", err)
+		}
+		return result.ClientID
+	}
+
+	clientID := setClientID("1")
+	// Same verifier, new callback: RFC 7530 Case 5, which reuses the client ID.
+	if got := setClientID("2"); got != clientID {
+		t.Fatalf("re-SETCLIENTID returned client ID %d, want the reused %d", got, clientID)
+	}
+
+	// Renew inside the lease, then check the client is still live past the point
+	// where the first confirm's timer was originally due to fire.
+	for _, wait := range []time.Duration{lease * 6 / 10, lease * 6 / 10} {
+		time.Sleep(wait)
+		if err := sm.RenewLease(clientID); err != nil {
+			t.Fatalf("RenewLease after %v: %v", wait, err)
+		}
+	}
+
+	if sm.GetClient(clientID) == nil {
+		t.Fatal("client was reaped despite being renewed within its lease")
+	}
+}

--- a/internal/adapter/nfs/v4/state/lease_test.go
+++ b/internal/adapter/nfs/v4/state/lease_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -515,4 +516,112 @@ func TestConfirmClientID_StaleRetransmitLeavesRecordIntact(t *testing.T) {
 	if got := sm.GetClient(second.ClientID).Callback.Addr; got != "10.0.0.1.8.2" {
 		t.Fatalf("confirmed callback = %q, want 10.0.0.1.8.2", got)
 	}
+}
+
+// cbProbeHarness drives SETCLIENTID_CONFIRM with CB_NULL held under test
+// control, so a probe can be left in flight across a re-SETCLIENTID.
+type cbProbeHarness struct {
+	sm      *StateManager
+	t       *testing.T
+	probing chan string
+	release map[string]chan error
+}
+
+func newCBProbeHarness(t *testing.T, addrs ...string) *cbProbeHarness {
+	t.Helper()
+	h := &cbProbeHarness{
+		sm:      NewStateManager(time.Minute),
+		t:       t,
+		probing: make(chan string, 4),
+		release: map[string]chan error{},
+	}
+	for _, a := range addrs {
+		h.release[a] = make(chan error)
+	}
+	h.sm.cbNullFunc = func(_ context.Context, cb CallbackInfo) error {
+		h.probing <- cb.Addr
+		return <-h.release[cb.Addr]
+	}
+	return h
+}
+
+// confirm runs SETCLIENTID + SETCLIENTID_CONFIRM for addr and waits until its
+// CB_NULL probe has started, so the probe is reliably in flight on return.
+func (h *cbProbeHarness) confirm(addr string) uint64 {
+	h.t.Helper()
+	verifier := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+	result, err := h.sm.SetClientID("client-cbpath", verifier,
+		CallbackInfo{Program: 0x40000000, NetID: "tcp", Addr: addr}, "10.0.0.1:1234")
+	if err != nil {
+		h.t.Fatalf("SetClientID(%s): %v", addr, err)
+	}
+	if err := h.sm.ConfirmClientID(result.ClientID, result.ConfirmVerifier); err != nil {
+		h.t.Fatalf("ConfirmClientID(%s): %v", addr, err)
+	}
+	if got := <-h.probing; got != addr {
+		h.t.Fatalf("probe went to %q, want %q", got, addr)
+	}
+	return result.ClientID
+}
+
+func (h *cbProbeHarness) cbPathUp(clientID uint64) bool {
+	h.sm.mu.Lock()
+	defer h.sm.mu.Unlock()
+	return h.sm.clientsByID[clientID].CBPathUp
+}
+
+func (h *cbProbeHarness) waitCBPathUp(clientID uint64) {
+	h.t.Helper()
+	for deadline := time.Now().Add(2 * time.Second); !h.cbPathUp(clientID); {
+		if time.Now().After(deadline) {
+			h.t.Fatal("CB_NULL success never enabled the callback path")
+		}
+	}
+}
+
+// Delegations are gated on CBPathUp. A re-SETCLIENTID can move the client to a
+// new callback address, so confirming it must drop the verdict earned by the
+// address it replaces — otherwise a delegation is granted in the window before
+// the new address has been probed at all, and recalled somewhere this client is
+// not listening.
+func TestConfirmClientID_ReSetClientIDClearsCallbackVerdict(t *testing.T) {
+	const addr1, addr2 = "10.0.0.1.8.1", "10.0.0.1.8.2"
+	h := newCBProbeHarness(t, addr1, addr2)
+
+	clientID := h.confirm(addr1)
+	h.release[addr1] <- nil
+	h.waitCBPathUp(clientID)
+
+	if got := h.confirm(addr2); got != clientID {
+		t.Fatal("re-SETCLIENTID returned a different client ID")
+	}
+	if h.cbPathUp(clientID) {
+		t.Fatal("confirm kept the previous callback address's verdict for a new one")
+	}
+}
+
+// CB_NULL runs asynchronously, so a re-SETCLIENTID can land while the previous
+// address is still being probed. That probe's verdict is about an address the
+// client no longer uses and must not vouch for the one that replaced it.
+func TestConfirmClientID_StaleCallbackProbeDoesNotVouchForNewAddress(t *testing.T) {
+	const addr1, addr2 = "10.0.0.1.8.1", "10.0.0.1.8.2"
+	h := newCBProbeHarness(t, addr1, addr2)
+
+	clientID := h.confirm(addr1)
+	// Re-SETCLIENTID while the first probe is still in flight.
+	if got := h.confirm(addr2); got != clientID {
+		t.Fatal("re-SETCLIENTID returned a different client ID")
+	}
+
+	// The stale probe succeeds, about the replaced address.
+	h.release[addr1] <- nil
+	for deadline := time.Now().Add(500 * time.Millisecond); time.Now().Before(deadline); {
+		if h.cbPathUp(clientID) {
+			t.Fatal("a CB_NULL for the replaced address enabled the new one")
+		}
+	}
+
+	// Only the new address's own probe may enable the callback path.
+	h.release[addr2] <- nil
+	h.waitCBPathUp(clientID)
 }

--- a/internal/adapter/nfs/v4/state/lease_test.go
+++ b/internal/adapter/nfs/v4/state/lease_test.go
@@ -472,3 +472,47 @@ func TestRenewLease_SurvivesReSetClientID(t *testing.T) {
 		t.Fatal("client was reaped despite being renewed within its lease")
 	}
 }
+
+// A confirm carrying the wrong verifier must leave the live client exactly as it
+// was. Confirming a re-SETCLIENTID writes through to the record that already
+// owns the client ID, so validating after the write would let a stale retransmit
+// of the previous confirm install an unconfirmed callback address on a client
+// that is still using the old one, and then report failure.
+func TestConfirmClientID_StaleRetransmitLeavesRecordIntact(t *testing.T) {
+	sm := NewStateManager(time.Minute)
+	verifier := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+
+	setClientID := func(addr string) *SetClientIDResult {
+		t.Helper()
+		callback := CallbackInfo{Program: 0x40000000, NetID: "tcp", Addr: addr}
+		result, err := sm.SetClientID("client-stale-confirm", verifier, callback, "10.0.0.1:1234")
+		if err != nil {
+			t.Fatalf("SetClientID(%s): %v", addr, err)
+		}
+		return result
+	}
+
+	first := setClientID("10.0.0.1.8.1")
+	if err := sm.ConfirmClientID(first.ClientID, first.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID: %v", err)
+	}
+
+	// Same verifier, new callback: a re-SETCLIENTID, left pending.
+	second := setClientID("10.0.0.1.8.2")
+
+	// The first confirm arrives again while that one is pending.
+	if err := sm.ConfirmClientID(first.ClientID, first.ConfirmVerifier); err == nil {
+		t.Fatal("a confirm carrying the superseded verifier must be refused")
+	}
+	if got := sm.GetClient(first.ClientID).Callback.Addr; got != "10.0.0.1.8.1" {
+		t.Fatalf("refused confirm changed the live callback to %q, want the confirmed 10.0.0.1.8.1", got)
+	}
+
+	// The real confirm still lands and installs the new callback.
+	if err := sm.ConfirmClientID(second.ClientID, second.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID(re-SETCLIENTID): %v", err)
+	}
+	if got := sm.GetClient(second.ClientID).Callback.Addr; got != "10.0.0.1.8.2" {
+		t.Fatalf("confirmed callback = %q, want 10.0.0.1.8.2", got)
+	}
+}

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -616,6 +616,12 @@ func (sm *StateManager) ConfirmClientID(clientID uint64, confirmVerifier [8]byte
 			record.Callback = unconfirmed.Callback
 			record.ClientAddr = unconfirmed.ClientAddr
 			record.Principal = unconfirmed.Principal
+			// The callback address just changed, so the path to it is unproven
+			// again until the CB_NULL below says otherwise. Carrying the old
+			// generation's verdict forward would let delegations be granted in
+			// the window before that probe answers, and recalled to an address
+			// this client never confirmed it listens on.
+			record.CBPathUp = false
 		} else {
 			// True retransmit - validate verifier matches the confirmed record
 			if record.ConfirmVerifier != confirmVerifier {
@@ -684,10 +690,12 @@ func (sm *StateManager) ConfirmClientID(clientID uint64, confirmVerifier [8]byte
 			sm.mu.Lock()
 			defer sm.mu.Unlock()
 			rec, ok := sm.clientsByID[clientID]
-			if !ok || rec != recordPtr {
-				// Client was removed, or this client ID now points at a
-				// different record generation (reboot / re-SETCLIENTID) while
-				// CB_NULL was in flight. Do not touch the replacement.
+			if !ok || rec != recordPtr || rec.Callback != cbInfo {
+				// Client was removed, this client ID now points at a different
+				// record generation (reboot) while CB_NULL was in flight, or the
+				// record kept its identity but moved to another callback address
+				// (re-SETCLIENTID). Do not report this probe's verdict about an
+				// address the record no longer uses.
 				return
 			}
 			rec.CBPathUp = (err == nil)

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -602,6 +602,15 @@ func (sm *StateManager) ConfirmClientID(clientID uint64, confirmVerifier [8]byte
 			// records under one ID, and the one clientsByID does not point at
 			// keeps a lease timer that RENEW never refreshes yet that still
 			// fires and reaps the client.
+			//
+			// Validated before the fold, not by the shared check below: the
+			// fold writes through to the live client, so a confirm carrying the
+			// wrong verifier must be refused while the record it names is still
+			// untouched. A stale retransmit of the previous confirm reaches
+			// here whenever a re-SETCLIENTID is pending.
+			if unconfirmed.ConfirmVerifier != confirmVerifier {
+				return fmt.Errorf("%w: confirm verifier mismatch for client %d", ErrStaleClientID, clientID)
+			}
 			record.Verifier = unconfirmed.Verifier
 			record.ConfirmVerifier = unconfirmed.ConfirmVerifier
 			record.Callback = unconfirmed.Callback

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -598,8 +598,18 @@ func (sm *StateManager) ConfirmClientID(clientID uint64, confirmVerifier [8]byte
 		// Check if there's an unconfirmed record for the same client name
 		// that reuses this client ID (Case 5: re-SETCLIENTID for confirmed client)
 		if unconfirmed := sm.unconfirmedByName[record.ClientIDString]; unconfirmed != nil && unconfirmed.ClientID == clientID {
-			// Use the unconfirmed record instead - this is confirming the re-SETCLIENTID
-			record = unconfirmed
+			// Case 5 reuses the client ID, so confirming it updates the live
+			// client rather than replacing it. Fold the new record's fields
+			// into the one that already owns this ID's open state, lease and
+			// map entries, and confirm that one: swapping in the second record
+			// instead leaves clientsByID pointing at the first, so RENEW keeps
+			// refreshing a lease nobody watches while the confirmed record's
+			// own timer runs down and reaps the client.
+			record.Verifier = unconfirmed.Verifier
+			record.ConfirmVerifier = unconfirmed.ConfirmVerifier
+			record.Callback = unconfirmed.Callback
+			record.ClientAddr = unconfirmed.ClientAddr
+			record.Principal = unconfirmed.Principal
 		} else {
 			// True retransmit - validate verifier matches the confirmed record
 			if record.ConfirmVerifier != confirmVerifier {
@@ -636,7 +646,13 @@ func (sm *StateManager) ConfirmClientID(clientID uint64, confirmVerifier [8]byte
 	record.Confirmed = true
 	sm.clientsByName[record.ClientIDString] = record
 
-	// Create lease timer for the newly confirmed client
+	// Create lease timer for the newly confirmed client. Stop any timer the
+	// record already carries first: an orphaned timer still fires
+	// onLeaseExpired for this client ID on its original schedule and reaps the
+	// client however often RENEW refreshes the lease that replaced it.
+	if record.Lease != nil {
+		record.Lease.Stop()
+	}
 	record.Lease = NewLeaseState(clientID, sm.leaseDuration, sm.onLeaseExpired)
 	record.LastRenewal = time.Now()
 

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -595,16 +595,13 @@ func (sm *StateManager) ConfirmClientID(clientID uint64, confirmVerifier [8]byte
 	// If already confirmed, check for a pending re-SETCLIENTID (Case 5)
 	// where an unconfirmed record exists with the same client ID.
 	if record.Confirmed {
-		// Check if there's an unconfirmed record for the same client name
-		// that reuses this client ID (Case 5: re-SETCLIENTID for confirmed client)
 		if unconfirmed := sm.unconfirmedByName[record.ClientIDString]; unconfirmed != nil && unconfirmed.ClientID == clientID {
-			// Case 5 reuses the client ID, so confirming it updates the live
-			// client rather than replacing it. Fold the new record's fields
-			// into the one that already owns this ID's open state, lease and
-			// map entries, and confirm that one: swapping in the second record
-			// instead leaves clientsByID pointing at the first, so RENEW keeps
-			// refreshing a lease nobody watches while the confirmed record's
-			// own timer runs down and reaps the client.
+			// The re-SETCLIENTID reuses the client ID, so confirm the record
+			// that already owns it and fold in what the new one carried.
+			// Swapping the unconfirmed record in instead would leave two
+			// records under one ID, and the one clientsByID does not point at
+			// keeps a lease timer that RENEW never refreshes yet that still
+			// fires and reaps the client.
 			record.Verifier = unconfirmed.Verifier
 			record.ConfirmVerifier = unconfirmed.ConfirmVerifier
 			record.Callback = unconfirmed.Callback
@@ -646,9 +643,9 @@ func (sm *StateManager) ConfirmClientID(clientID uint64, confirmVerifier [8]byte
 	record.Confirmed = true
 	sm.clientsByName[record.ClientIDString] = record
 
-	// Create lease timer for the newly confirmed client. Stop any timer the
-	// record already carries first: an orphaned timer still fires
-	// onLeaseExpired for this client ID on its original schedule and reaps the
+	// Create the lease timer for the newly confirmed client, replacing any
+	// timer the record already carries: an orphaned timer still fires
+	// onLeaseExpired for this client ID on its original schedule, reaping the
 	// client however often RENEW refreshes the lease that replaced it.
 	if record.Lease != nil {
 		record.Lease.Stop()

--- a/pkg/adapter/nfs/nlm_merge_test.go
+++ b/pkg/adapter/nfs/nlm_merge_test.go
@@ -1,0 +1,58 @@
+package nfs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+	"github.com/stretchr/testify/require"
+)
+
+// Byte-range lock merging lives in the lock manager, which NLM and NFSv4 share,
+// so the two protocols must give one answer about the same file. These pin the
+// NLM side of that seam: abutting and overlapping ranges from one owner become a
+// single lock, and unlocking the union releases all of it.
+
+func newMergeNLMService() (*nlmService, *lock.Manager) {
+	lm := lock.NewManager()
+	return newNLMService(lm, graceFileChecker{}), lm
+}
+
+func TestNLM_AbuttingLocksMergeIntoOneRange(t *testing.T) {
+	svc, lm := newMergeNLMService()
+
+	handle := []byte("share-a:merge-file")
+	owner := lock.LockOwner{OwnerID: "nlm:client-1", ClientID: "client-1", ShareName: "share-a"}
+
+	// [25,100) then [50,125): overlapping, so one lock spanning [25,125).
+	for _, r := range [][2]uint64{{25, 75}, {50, 75}} {
+		_, err := svc.LockFileNLM(context.Background(), handle, owner, r[0], r[1], true, false)
+		require.NoErrorf(t, err, "LockFileNLM(%d,%d)", r[0], r[1])
+	}
+
+	locks := lm.ListUnifiedLocks(string(handle))
+	require.Len(t, locks, 1, "same-owner overlapping NLM locks must coalesce into one range")
+	require.Equal(t, uint64(25), locks[0].Offset)
+	require.Equal(t, uint64(100), locks[0].Length)
+
+	// The merged range is one logical lock, so unlocking the union clears it.
+	require.NoError(t, svc.UnlockFileNLM(context.Background(), handle, owner.OwnerID, 25, 100))
+	require.Empty(t, lm.ListUnifiedLocks(string(handle)),
+		"unlocking the merged union must leave nothing behind")
+}
+
+func TestNLM_OtherOwnerRangeNotAbsorbed(t *testing.T) {
+	svc, lm := newMergeNLMService()
+
+	handle := []byte("share-a:merge-file")
+	first := lock.LockOwner{OwnerID: "nlm:client-1", ClientID: "client-1", ShareName: "share-a"}
+	second := lock.LockOwner{OwnerID: "nlm:client-2", ClientID: "client-2", ShareName: "share-a"}
+
+	_, err := svc.LockFileNLM(context.Background(), handle, first, 0, 100, false, false)
+	require.NoError(t, err)
+	_, err = svc.LockFileNLM(context.Background(), handle, second, 100, 100, false, false)
+	require.NoError(t, err)
+
+	require.Len(t, lm.ListUnifiedLocks(string(handle)), 2,
+		"merging is per lock-owner: another owner's abutting range must survive intact")
+}

--- a/pkg/metadata/lock/byterange.go
+++ b/pkg/metadata/lock/byterange.go
@@ -374,6 +374,7 @@ func (lm *Manager) AddUnifiedLock(handleKey string, lock *UnifiedLock) error {
 	// type is an upgrade or downgrade, handled by the exact-match update above.
 	if !lock.IsLease() && !lock.IsDelegation() {
 		merged, kept := lock, existing
+		var absorbed []*UnifiedLock
 		for grew := true; grew; {
 			grew = false
 			var rest []*UnifiedLock
@@ -386,17 +387,32 @@ func (lm *Manager) AddUnifiedLock(handleKey string, lock *UnifiedLock) error {
 					continue
 				}
 				merged = mergeTwoLocks(merged, el)
-				lm.deleteUnifiedLockLocked(el)
+				absorbed = append(absorbed, el)
 				grew = true
 			}
 			kept = rest
 		}
-		// kept is existing minus every absorbed row, so a shorter slice means
-		// the new range joined at least one of them.
-		if len(kept) < len(existing) {
+		if len(absorbed) > 0 {
 			merged.AcquiredAt = time.Now()
-			lm.unifiedLocks[handleKey] = append(kept, merged)
+			final := append(kept, merged)
+			lm.unifiedLocks[handleKey] = final
 			lm.reindexHandleLocked(handleKey, existing)
+
+			// A persisted record is keyed by lock ID, and nothing stops a caller
+			// handing the same ID to more than one live row, so an absorbed row's
+			// ID may still belong to a row that survives. Drop only the records no
+			// survivor answers to: deleting by ID alone would strip the
+			// persistence out from under a lock that is still held, which surfaces
+			// after a restart as a lock that silently no longer exists.
+			survivors := make(map[string]struct{}, len(final))
+			for _, el := range final {
+				survivors[el.ID] = struct{}{}
+			}
+			for _, el := range absorbed {
+				if _, alive := survivors[el.ID]; !alive {
+					lm.deleteUnifiedLockLocked(el)
+				}
+			}
 			lm.persistUnifiedLockLocked(merged)
 			return nil
 		}

--- a/pkg/metadata/lock/byterange.go
+++ b/pkg/metadata/lock/byterange.go
@@ -183,33 +183,17 @@ func mergeRanges(locks []*UnifiedLock) []*UnifiedLock {
 	return result
 }
 
-// locksTouch reports whether two ranges overlap or abut, so together they cover
-// one contiguous region. canMerge assumes its arguments are sorted by offset;
-// this orders them first, for callers that hold an unsorted pair.
-func locksTouch(a, b *UnifiedLock) bool {
-	if a.Offset <= b.Offset {
-		return canMerge(a, b)
-	}
-	return canMerge(b, a)
-}
-
-// canMerge checks if two locks can be merged (adjacent or overlapping).
+// canMerge checks if two locks can be merged, i.e. whether they overlap or abut
+// and so together cover one contiguous region. Argument order does not matter:
+// it is the earlier-starting range that has to reach the other one's start.
 func canMerge(a, b *UnifiedLock) bool {
 	// Must be same owner, type, and file (assumed by caller grouping)
-
-	// Handle unbounded locks
-	if a.Length == 0 {
-		// a is unbounded - can merge with anything at or after a.Offset
-		return b.Offset >= a.Offset
+	if a.Offset > b.Offset {
+		a, b = b, a
 	}
-	if b.Length == 0 {
-		// b is unbounded - can merge if a overlaps or is adjacent to b.Offset
-		return a.End() >= b.Offset
-	}
-
-	// Both bounded - check if adjacent or overlapping
-	aEnd := a.End()
-	return aEnd >= b.Offset // Adjacent (aEnd == b.Offset) or overlapping
+	// End() is maxUint64 for an unbounded (Length 0) lock, which therefore
+	// reaches every offset at or after its own.
+	return a.End() >= b.Offset
 }
 
 // mergeTwoLocks combines two locks into one.
@@ -378,42 +362,38 @@ func (lm *Manager) AddUnifiedLock(handleKey string, lock *UnifiedLock) error {
 		}
 	}
 
-	// Adjacent and overlapping byte-range locks held by the same lock-owner on
-	// the same file are one logical lock (RFC 7530 Section 9.3), so absorb
-	// every same-owner, same-type row the new range touches into a single row
-	// spanning their union. Without this a LOCKT reports whichever fragment it
-	// scans first instead of the merged range, and a LOCKU over the union
-	// leaves the fragments it did not name behind.
+	// Adjacent and overlapping byte-range locks held by one lock-owner on one
+	// file are a single logical lock (RFC 7530 Section 9.3), so absorb every
+	// same-owner, same-type row the new range touches into one row spanning
+	// their union. Without this a LOCKT reports whichever fragment it scans
+	// first instead of the merged range, and a LOCKU over the union leaves the
+	// fragments it did not name behind. Absorbing a row can extend the span
+	// onto a row already passed over, so rescan until nothing more is absorbed.
 	//
-	// Locks of a different type are left alone: an overlapping range in the
-	// other type is an upgrade or downgrade, handled by the exact-match update
-	// above, not a merge.
+	// Rows of the other type are left alone: an overlapping range in the other
+	// type is an upgrade or downgrade, handled by the exact-match update above.
 	if !lock.IsLease() && !lock.IsDelegation() {
-		merged := lock
-		kept := existing
-		absorbed := false
-		for {
+		merged, kept := lock, existing
+		for grew := true; grew; {
+			grew = false
 			var rest []*UnifiedLock
-			grew := false
 			for _, el := range kept {
 				if el.IsLease() || el.IsDelegation() ||
 					el.Owner.OwnerID != lock.Owner.OwnerID ||
 					el.Type != lock.Type ||
-					!locksTouch(el, merged) {
+					!canMerge(el, merged) {
 					rest = append(rest, el)
 					continue
 				}
 				merged = mergeTwoLocks(merged, el)
 				lm.deleteUnifiedLockLocked(el)
 				grew = true
-				absorbed = true
 			}
 			kept = rest
-			if !grew {
-				break
-			}
 		}
-		if absorbed {
+		// kept is existing minus every absorbed row, so a shorter slice means
+		// the new range joined at least one of them.
+		if len(kept) < len(existing) {
 			merged.AcquiredAt = time.Now()
 			lm.unifiedLocks[handleKey] = append(kept, merged)
 			lm.reindexHandleLocked(handleKey, existing)

--- a/pkg/metadata/lock/byterange.go
+++ b/pkg/metadata/lock/byterange.go
@@ -183,6 +183,16 @@ func mergeRanges(locks []*UnifiedLock) []*UnifiedLock {
 	return result
 }
 
+// locksTouch reports whether two ranges overlap or abut, so together they cover
+// one contiguous region. canMerge assumes its arguments are sorted by offset;
+// this orders them first, for callers that hold an unsorted pair.
+func locksTouch(a, b *UnifiedLock) bool {
+	if a.Offset <= b.Offset {
+		return canMerge(a, b)
+	}
+	return canMerge(b, a)
+}
+
 // canMerge checks if two locks can be merged (adjacent or overlapping).
 func canMerge(a, b *UnifiedLock) bool {
 	// Must be same owner, type, and file (assumed by caller grouping)
@@ -364,6 +374,50 @@ func (lm *Manager) AddUnifiedLock(handleKey string, lock *UnifiedLock) error {
 			existing[i].Type = lock.Type
 			existing[i].AcquiredAt = time.Now()
 			lm.persistUnifiedLockLocked(existing[i])
+			return nil
+		}
+	}
+
+	// Adjacent and overlapping byte-range locks held by the same lock-owner on
+	// the same file are one logical lock (RFC 7530 Section 9.3), so absorb
+	// every same-owner, same-type row the new range touches into a single row
+	// spanning their union. Without this a LOCKT reports whichever fragment it
+	// scans first instead of the merged range, and a LOCKU over the union
+	// leaves the fragments it did not name behind.
+	//
+	// Locks of a different type are left alone: an overlapping range in the
+	// other type is an upgrade or downgrade, handled by the exact-match update
+	// above, not a merge.
+	if !lock.IsLease() && !lock.IsDelegation() {
+		merged := lock
+		kept := existing
+		absorbed := false
+		for {
+			var rest []*UnifiedLock
+			grew := false
+			for _, el := range kept {
+				if el.IsLease() || el.IsDelegation() ||
+					el.Owner.OwnerID != lock.Owner.OwnerID ||
+					el.Type != lock.Type ||
+					!locksTouch(el, merged) {
+					rest = append(rest, el)
+					continue
+				}
+				merged = mergeTwoLocks(merged, el)
+				lm.deleteUnifiedLockLocked(el)
+				grew = true
+				absorbed = true
+			}
+			kept = rest
+			if !grew {
+				break
+			}
+		}
+		if absorbed {
+			merged.AcquiredAt = time.Now()
+			lm.unifiedLocks[handleKey] = append(kept, merged)
+			lm.reindexHandleLocked(handleKey, existing)
+			lm.persistUnifiedLockLocked(merged)
 			return nil
 		}
 	}

--- a/pkg/metadata/lock/byterange_merge_test.go
+++ b/pkg/metadata/lock/byterange_merge_test.go
@@ -1,6 +1,9 @@
 package lock
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 // Adjacent and overlapping byte-range locks held by one lock-owner on one file
 // are a single logical lock (RFC 7530 Section 9.3). AddUnifiedLock must fold a
@@ -165,4 +168,57 @@ func TestAddUnifiedLock_MergeScopedToOwnerAndType(t *testing.T) {
 			t.Fatalf("downgraded lock = [%d,%d] type %v, want [25,75] shared", got.Offset, got.Length, got.Type)
 		}
 	})
+}
+
+// Persisted records are keyed by lock ID, and nothing stops a caller reusing one
+// ID for two live rows — a lock type change leaves the old row in place, so a
+// second row can arrive carrying the same ID. Absorbing one of those two must
+// not delete the record the other still depends on, or the survivor is a lock
+// that is held in memory and simply gone after a restart.
+func TestAddUnifiedLock_MergeKeepsRecordOfSameIDSurvivor(t *testing.T) {
+	t.Parallel()
+
+	store := newMockLockStore()
+	lm := NewManager()
+	lm.SetLockStore(store)
+	lm.SetShareName("share-dup")
+
+	add := func(id string, offset, length uint64, lt LockType) {
+		t.Helper()
+		l := mergeOwnerLock("owner-1", offset, length, lt)
+		l.ID = id
+		if err := lm.AddUnifiedLock(mergeHandle, l); err != nil {
+			t.Fatalf("AddUnifiedLock(%s, [%d,%d)): %v", id, offset, offset+length, err)
+		}
+	}
+	owner := LockOwner{OwnerID: "owner-1", ClientID: "client-1"}
+
+	// One row under "dup", promoted so a later shared row cannot merge with it.
+	add("dup", 0, 40, LockTypeShared)
+	if _, err := lm.UpgradeLock(mergeHandle, owner, 0, 40); err != nil {
+		t.Fatalf("UpgradeLock: %v", err)
+	}
+	// A second live row reusing that same ID: different type, so no merge and no
+	// exact-range update — it is appended alongside.
+	add("dup", 20, 40, LockTypeShared)
+	if got := len(lm.ListUnifiedLocks(mergeHandle)); got != 2 {
+		t.Fatalf("expected 2 rows sharing one ID, got %d", got)
+	}
+
+	// Absorb only the shared one. The exclusive row still answers to "dup".
+	add("other", 50, 20, LockTypeShared)
+
+	snap, err := store.ListLocks(context.Background(), LockQuery{ShareName: "share-dup"})
+	if err != nil {
+		t.Fatalf("ListLocks: %v", err)
+	}
+	stored := map[string]bool{}
+	for _, pl := range snap {
+		stored[pl.ID] = true
+	}
+	for id := range liveManagerPersistIDs(lm, mergeHandle) {
+		if !stored[id] {
+			t.Fatalf("in-memory lock %s has no store record after the merge", id)
+		}
+	}
 }

--- a/pkg/metadata/lock/byterange_merge_test.go
+++ b/pkg/metadata/lock/byterange_merge_test.go
@@ -1,0 +1,166 @@
+package lock
+
+import "testing"
+
+// Adjacent and overlapping byte-range locks held by one lock-owner on one file
+// are a single logical lock (RFC 7530 Section 9.3). AddUnifiedLock must fold a
+// new range into the rows it touches instead of stacking fragments, or LOCKT
+// reports whichever fragment it scans first and LOCKU over the union leaves the
+// unnamed fragments behind.
+
+const mergeHandle = "share-a:merge-file"
+
+func mergeOwnerLock(ownerID string, offset, length uint64, lt LockType) *UnifiedLock {
+	return &UnifiedLock{
+		Owner:      LockOwner{OwnerID: ownerID, ClientID: "client-1"},
+		FileHandle: FileHandle(mergeHandle),
+		Offset:     offset,
+		Length:     length,
+		Type:       lt,
+	}
+}
+
+// singleLock asserts exactly one lock remains and returns it.
+func singleLock(t *testing.T, lm *Manager) *UnifiedLock {
+	t.Helper()
+	locks := lm.ListUnifiedLocks(mergeHandle)
+	if len(locks) != 1 {
+		for _, l := range locks {
+			t.Logf("lock offset=%d length=%d type=%v owner=%s", l.Offset, l.Length, l.Type, l.Owner.OwnerID)
+		}
+		t.Fatalf("expected 1 merged lock, got %d", len(locks))
+	}
+	return locks[0]
+}
+
+func TestAddUnifiedLock_MergesSameOwnerRanges(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name                   string
+		first, second          [2]uint64 // offset, length
+		wantOffset, wantLength uint64
+	}{
+		// The pynfs LOCKMRG case: [25,100) then [50,125) is one lock [25,125).
+		{"overlapping", [2]uint64{25, 75}, [2]uint64{50, 75}, 25, 100},
+		{"abutting above", [2]uint64{0, 50}, [2]uint64{50, 50}, 0, 100},
+		{"abutting below", [2]uint64{50, 50}, [2]uint64{0, 50}, 0, 100},
+		{"contained", [2]uint64{0, 100}, [2]uint64{25, 25}, 0, 100},
+		{"containing", [2]uint64{25, 25}, [2]uint64{0, 100}, 0, 100},
+		{"identical", [2]uint64{10, 10}, [2]uint64{10, 10}, 10, 10},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			lm := NewManager()
+			for _, r := range [][2]uint64{tc.first, tc.second} {
+				if err := lm.AddUnifiedLock(mergeHandle, mergeOwnerLock("owner-1", r[0], r[1], LockTypeExclusive)); err != nil {
+					t.Fatalf("AddUnifiedLock(%d,%d): %v", r[0], r[1], err)
+				}
+			}
+			got := singleLock(t, lm)
+			if got.Offset != tc.wantOffset || got.Length != tc.wantLength {
+				t.Fatalf("merged lock = [%d,%d], want [%d,%d]", got.Offset, got.Length, tc.wantOffset, tc.wantLength)
+			}
+			if got.Type != LockTypeExclusive {
+				t.Fatalf("merged lock type = %v, want exclusive", got.Type)
+			}
+		})
+	}
+}
+
+// An unbounded (length 0) range swallows everything above its offset, and the
+// merged row must stay unbounded rather than acquire a finite length.
+func TestAddUnifiedLock_MergeKeepsUnbounded(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	if err := lm.AddUnifiedLock(mergeHandle, mergeOwnerLock("owner-1", 100, 0, LockTypeExclusive)); err != nil {
+		t.Fatalf("AddUnifiedLock(100,EOF): %v", err)
+	}
+	if err := lm.AddUnifiedLock(mergeHandle, mergeOwnerLock("owner-1", 0, 100, LockTypeExclusive)); err != nil {
+		t.Fatalf("AddUnifiedLock(0,100): %v", err)
+	}
+
+	got := singleLock(t, lm)
+	if got.Offset != 0 || got.Length != 0 {
+		t.Fatalf("merged lock = [%d,%d], want [0,EOF]", got.Offset, got.Length)
+	}
+}
+
+// A new range that bridges the gap between two rows must absorb both, leaving a
+// single span rather than merging only the row it happens to meet first.
+func TestAddUnifiedLock_MergeBridgesTwoRanges(t *testing.T) {
+	t.Parallel()
+
+	lm := NewManager()
+	for _, r := range [][2]uint64{{0, 10}, {90, 10}} {
+		if err := lm.AddUnifiedLock(mergeHandle, mergeOwnerLock("owner-1", r[0], r[1], LockTypeExclusive)); err != nil {
+			t.Fatalf("AddUnifiedLock(%d,%d): %v", r[0], r[1], err)
+		}
+	}
+	if len(lm.ListUnifiedLocks(mergeHandle)) != 2 {
+		t.Fatalf("disjoint ranges should not have merged")
+	}
+
+	if err := lm.AddUnifiedLock(mergeHandle, mergeOwnerLock("owner-1", 10, 80, LockTypeExclusive)); err != nil {
+		t.Fatalf("AddUnifiedLock(10,80): %v", err)
+	}
+
+	got := singleLock(t, lm)
+	if got.Offset != 0 || got.Length != 100 {
+		t.Fatalf("merged lock = [%d,%d], want [0,100]", got.Offset, got.Length)
+	}
+}
+
+// Merging is scoped to one owner and one lock type: a different owner's row, and
+// a row of the other type, must survive an overlapping acquire untouched.
+func TestAddUnifiedLock_MergeScopedToOwnerAndType(t *testing.T) {
+	t.Parallel()
+
+	t.Run("other owner untouched", func(t *testing.T) {
+		t.Parallel()
+		lm := NewManager()
+		if err := lm.AddUnifiedLock(mergeHandle, mergeOwnerLock("owner-1", 0, 100, LockTypeShared)); err != nil {
+			t.Fatalf("AddUnifiedLock(owner-1): %v", err)
+		}
+		if err := lm.AddUnifiedLock(mergeHandle, mergeOwnerLock("owner-2", 50, 100, LockTypeShared)); err != nil {
+			t.Fatalf("AddUnifiedLock(owner-2): %v", err)
+		}
+		if got := len(lm.ListUnifiedLocks(mergeHandle)); got != 2 {
+			t.Fatalf("expected 2 locks across owners, got %d", got)
+		}
+	})
+
+	t.Run("other type untouched", func(t *testing.T) {
+		t.Parallel()
+		lm := NewManager()
+		if err := lm.AddUnifiedLock(mergeHandle, mergeOwnerLock("owner-1", 0, 100, LockTypeExclusive)); err != nil {
+			t.Fatalf("AddUnifiedLock(exclusive): %v", err)
+		}
+		if err := lm.AddUnifiedLock(mergeHandle, mergeOwnerLock("owner-1", 50, 100, LockTypeShared)); err != nil {
+			t.Fatalf("AddUnifiedLock(shared): %v", err)
+		}
+		if got := len(lm.ListUnifiedLocks(mergeHandle)); got != 2 {
+			t.Fatalf("expected 2 locks across types, got %d", got)
+		}
+	})
+
+	// Same owner, same range, other type is an upgrade/downgrade, not a merge:
+	// the row keeps its identity and flips type.
+	t.Run("exact range downgrades in place", func(t *testing.T) {
+		t.Parallel()
+		lm := NewManager()
+		if err := lm.AddUnifiedLock(mergeHandle, mergeOwnerLock("owner-1", 25, 75, LockTypeExclusive)); err != nil {
+			t.Fatalf("AddUnifiedLock(exclusive): %v", err)
+		}
+		if err := lm.AddUnifiedLock(mergeHandle, mergeOwnerLock("owner-1", 25, 75, LockTypeShared)); err != nil {
+			t.Fatalf("AddUnifiedLock(shared): %v", err)
+		}
+		got := singleLock(t, lm)
+		if got.Type != LockTypeShared || got.Offset != 25 || got.Length != 75 {
+			t.Fatalf("downgraded lock = [%d,%d] type %v, want [25,75] shared", got.Offset, got.Length, got.Type)
+		}
+	})
+}

--- a/pkg/metadata/lock/byterange_merge_test.go
+++ b/pkg/metadata/lock/byterange_merge_test.go
@@ -90,12 +90,14 @@ func TestAddUnifiedLock_MergeKeepsUnbounded(t *testing.T) {
 }
 
 // A new range that bridges the gap between two rows must absorb both, leaving a
-// single span rather than merging only the row it happens to meet first.
+// single span rather than merging only the row it happens to meet first. The
+// rows go in descending order so the disjoint check below is also asked the
+// question the wrong way round, where the existing row starts after the new one.
 func TestAddUnifiedLock_MergeBridgesTwoRanges(t *testing.T) {
 	t.Parallel()
 
 	lm := NewManager()
-	for _, r := range [][2]uint64{{0, 10}, {90, 10}} {
+	for _, r := range [][2]uint64{{90, 10}, {0, 10}} {
 		if err := lm.AddUnifiedLock(mergeHandle, mergeOwnerLock("owner-1", r[0], r[1], LockTypeExclusive)); err != nil {
 			t.Fatalf("AddUnifiedLock(%d,%d): %v", r[0], r[1], err)
 		}

--- a/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
+++ b/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
@@ -98,8 +98,6 @@ Categories:
 | CID2 | bug | SETCLIENTID/SETCLIENTID_CONFIRM and RENEW validation | #2326 |
 | CID2a | bug | SETCLIENTID/SETCLIENTID_CONFIRM and RENEW validation | #2326 |
 | RENEW3 | bug | SETCLIENTID/SETCLIENTID_CONFIRM and RENEW validation | #2326 |
-| LOCK20 | bug | lock range merging and RENEW behaviour | #2331 |
-| LOCKMRG | bug | lock range merging and RENEW behaviour | #2331 |
 | CLOSE8 | bug | LOOKUP fails opening the test tree, so the test cannot run | #2332 |
 | CLOSE9 | bug | LOOKUP fails opening the test tree, so the test cannot run | #2332 |
 | LKU10 | bug | LOOKUP fails opening the test tree, so the test cannot run | #2332 |


### PR DESCRIPTION
Closes #2331

Two unrelated defects sat behind the two failing pynfs v4.0 tests. Both are fixed
here because the issue covers both, but they share nothing beyond the test file
they were found in.

## LOCKMRG — adjacent and overlapping locks never coalesced

`Manager.AddUnifiedLock` folded a new byte-range lock into an existing one only
on an **exact** `(owner, offset, length)` match. Anything else was appended as a
separate row, so a lock-owner that took `[25,100)` and then `[50,125)` ended up
holding two rows instead of one `[25,125)`. RFC 7530 §9.3 makes those a single
logical lock; LOCKT then reported whichever fragment it scanned first, which is
exactly what the test saw:

```
LOCKMRG  st_lock.testOverlap : FAILURE
           Merged lock had [offset,length] = [25,75], expected [25,100]
```

`AddUnifiedLock` now absorbs every same-owner, same-type row the new range
overlaps or abuts into one row spanning their union. A `MergeLocks` function
already existed a few lines below in the same file with no production caller;
the fix reuses its `mergeTwoLocks`/`canMerge` primitives rather than adding new
ones.

The merge is deliberately scoped to the *same* lock type. An overlapping range
of the other type is an upgrade or downgrade, which the exact-match branch above
already handles, and which must keep working — LOCKCHGD and LOCKCHGU cover it.

This is the shared seam, so both protocols get the fix: `AddUnifiedLock` has
three production callers — NFSv4 (`v4/state/manager.go`) and NLM
(`pkg/adapter/nfs/nlm.go`, twice). Fixing only the v4 path would have left v3
and v4 disagreeing about the same file.

### Why merging is safe to do inside the shared seam

The obvious objection is that a client could unlock a sub-range of a row the
server silently merged, and find the exact range it was granted no longer
exists. That path does not exist here, structurally rather than by observation:

- `GetUnifiedLock` is the only lookup in the lock package that matches on an
  exact `offset` + `length`, and it has **no production callers** — it survives
  only as a method on the `LockManager` interface.
- Both unlock paths — NFSv4 LOCKU and `nlmService.UnlockFileNLM` — go through
  `RemoveUnifiedLock`, which splits any *overlapping* same-owner row POSIX-style
  rather than matching an exact one. A merged row therefore unlocks correctly
  whatever sub-range the client names, producing the 0, 1 or 2 fragments POSIX
  requires.

So there is no caller that can observe the difference between two abutting rows
and the one row that replaces them, other than LOCKT — which is precisely the
observation LOCKMRG makes and the one that was wrong.

SMB is deliberately not affected, and must not be: its byte-range locks live in
the separate `lm.locks` (`FileLock`) map and never reach `AddUnifiedLock`.
Merging them would be a bug rather than a fix — SMB requires an unlock to name
exactly the range that was locked, where POSIX and NFS do not.

## LOCK20 — RENEW refreshed a lease nobody was watching

RFC 7530 Case 5: a client that re-issues SETCLIENTID with the *same* verifier
keeps its client ID and its state. DittoFS implemented that by creating a
**second** `ClientRecord` under the same ID. `ConfirmClientID` then swapped
`record` to the new one, pointed `clientsByName` at it and gave it a fresh
`LeaseState` — but left `clientsByID` pointing at the original record and never
stopped its timer.

RENEW resolves through `clientsByID`, so it kept refreshing the *original*
record's lease while the confirmed record's orphaned timer ran down unattended.
When it fired, `onLeaseExpired` deleted the client outright. Since pynfs
re-SETCLIENTIDs on every `create_confirm`, the server accumulated one
unrenewable timer per call, and the earliest one reaped a perfectly healthy
client. From the failing run's server log:

```
20:57:51  SETCLIENTID_CONFIRM: client confirmed   client_id=...003
20:58:36  NFSv4 RENEW: lease renewed              client_id=...003
20:59:21  NFSv4 client lease expired, cleaning up state  client_id=...003
20:59:21  NFSv4 RENEW failed  error=stale client ID  nfs_status=10022
```

The expiry lands at first-confirm + 90s exactly — the original lease deadline,
untouched by the renewal 45s earlier.

`ConfirmClientID` now folds the re-SETCLIENTID record's fields into the record
that already owns that client ID and confirms *that* one, so `clientsByID`,
`clientsByName`, the open state and the lease stay on a single object. It also
stops any lease already on the record before installing a new one, so no timer
can outlive the lease it belonged to.

## Evidence

pynfs v4.0, same invocation before and after (the dependency closure matters —
pynfs silently *skips* a test whose `DEPEND:` prerequisites did not run in the
same invocation, and a skipped run grades identically to a clean pass):

```
$ ./test/nfs-conformance/pynfs/run-pynfs.sh --profile memory --minor-version 4.0 \
    --no-setup --tests "INIT MKFILE LOCK1 LKTOVER LOCK20 LOCKMRG"
```

before:
```
LOCKMRG  st_lock.testOverlap        : FAILURE
           Merged lock had [offset,length] = [25,75], expected [25,100]
LOCK20   st_lock.testBlockTimeout   : FAILURE
           OP_RENEW should return NFS4_OK or NFS4ERR_CB_PATH_DOWN,
           instead got NFS4ERR_STALE_CLIENTID
Of those: 0 Skipped, 2 Failed, 0 Warned, 4 Passed
```

after:
```
LOCKMRG  st_lock.testOverlap        : PASS
LOCK20   st_lock.testBlockTimeout   : PASS
Of those: 0 Skipped, 0 Failed, 0 Warned, 6 Passed
```

Full 4.0 suite on the memory profile, no `--tests`:

```
Of those: 13 Skipped, 148 Failed, 5 Warned, 435 Passed
Known failures: 148    New failures: 0

LOCKMRG  st_lock.testOverlap        : PASS
LOCK20   st_lock.testBlockTimeout   : PASS
```

Their two rows are removed from `KNOWN_FAILURES_V40.md`, and nothing else is.
The count reconciles exactly: 151 blacklisted rows − LOCK20 − LOCKMRG −
`SATT12x` = 148. `SATT12x` is a postgres-only row under #2325, so a memory-profile
run never exercises it — which is also the reason the CI cells matter more than
this local run does: CI runs memory *and* postgres-s3, and a row like that is
only ever visible on the second.

`CID1`, `CID2`, `CID2a` and `RENEW3` were checked specifically and **did not
flip**. They sit under #2326 for "SETCLIENTID/SETCLIENTID_CONFIRM and RENEW
validation", which is the same function this PR changes, so the obvious question
is whether this already covers them. It does not — all four still fail — so
#2326 keeps its full scope.

Every regression test here was run against a deliberately broken build — the
fix reverted with `git checkout origin/develop -- <source files>`, the tests
kept, then restored with `git checkout HEAD -- <source files>` — and each one
fails there:

- `pkg/metadata/lock/byterange_merge_test.go` — abutting-below, abutting-above,
  overlapping, contained, containing, bridge-two-ranges and keep-unbounded all
  fail without the fix. The identical-range, other-owner, other-type and
  exact-range-downgrade subtests pass either way by design: they pin behaviour
  the fix must *not* change.
- `pkg/adapter/nfs/nlm_merge_test.go` — the same merge, driven through
  `LockFileNLM` instead. `AddUnifiedLock` is shared by NFSv4 and NLM, so this is
  the seam where the two protocols have to agree; without the fix it reports
  `should have 1 item(s), but has 2`.
- `TestRenewLease_SurvivesReSetClientID` — fails with `RenewLease after 600ms:
  stale client ID` without the fix. It is the only test here that turns on real
  timers, so: a 1s lease renewed at 600ms intervals leaves 400ms of slack against
  a reap, and it passed 13 consecutive runs (8 plain, 5 under `-race`). The
  runner would have to stall for most of a second to flip it.
- `TestConfirmClientID_StaleRetransmitLeavesRecordIntact` — see below.

A fourth test asserting LOCKU over the merged union passed on the broken build
too, so it was proving nothing and was dropped rather than shipped.

## A regression the fold introduced, and the check that stops it

Review caught a real defect in the first version of the LOCK20 fix, worth
recording because it is a hazard the change *created* rather than one it
inherited.

The old code confirmed a re-SETCLIENTID by reassigning a **local variable**
(`record = unconfirmed`), so the shared verifier check further down could fail
having touched no shared state. Folding fields into the live record instead
writes through immediately — and the Case-5 branch is entered whenever a pending
re-SETCLIENTID exists for the client ID, *whatever verifier the caller sent*. So
a stale retransmit of the previous confirm would overwrite the live client's
`Callback`, `ClientAddr`, `Principal` and verifiers with the pending
generation's, and only then fail the check and return an error.

That is not cosmetic: if the real confirm never arrives — the client abandons
the re-SETCLIENTID, reissues, or crashes — the live record permanently carries a
callback address that was never confirmed, and the next CB_RECALL goes to an
address the client is not listening on. #2218 established that delegation recall
has never actually worked against a Linux client; a second, quieter way to send
CB_RECALL into the void was not worth shipping alongside the fix for the first.

The general shape is worth naming, because it is what made this findable at all:
the defect exists *because* of the fix above it. Moving work from a local
variable to shared state is exactly the refactor that turns a harmless late
validation into a write-before-validate, and the hazard is invisible until
someone asks what the failing path leaves behind.

The verifier is now validated against the unconfirmed record *before* anything
is copied. `TestConfirmClientID_StaleRetransmitLeavesRecordIntact` pins it, and
fails on the pre-review build with:

```
refused confirm changed the live callback to "10.0.0.1.8.2",
want the confirmed 10.0.0.1.8.1
```

## The fold's third instance: a callback path proven for the wrong address

Copilot caught this one, and it is the same hazard as the verifier bug in a
different place — which is what makes it worth naming rather than just fixing.

Delegation grants are gated on `ClientRecord.CBPathUp`, and `CB_NULL` runs in a
goroutine so `SETCLIENTID_CONFIRM` can return immediately. The old code swapped
in a *fresh* record on Case 5, whose `CBPathUp` was the zero value, so a client
that moved to a new callback address was correctly ungated until the new probe
answered. Folding into the live record carries the previous generation's `true`
forward, so delegations could be granted against an address nothing had yet
proven the client listens on — and recalled there.

Reviewing the surrounding code for the same shape turned up a second half
Copilot did not mention. The async probe guards its write with
`rec != recordPtr`, whose comment says it is there to drop a probe whose client
ID has moved to "a different record generation (reboot / re-SETCLIENTID)". The
fold is precisely what makes a re-SETCLIENTID *keep* the pointer, so that guard
silently stopped covering the case it names: an in-flight probe for the old
address could land and vouch for the new one. It now also requires the record to
still be on the callback it probed.

Two tests, because one cannot cover both — each was checked against the mutant
that deletes only its own half:

- `TestConfirmClientID_ReSetClientIDClearsCallbackVerdict` — first probe
  completes and enables the path, then the address changes.
- `TestConfirmClientID_StaleCallbackProbeDoesNotVouchForNewAddress` — first probe
  is held in flight across the re-SETCLIENTID, then succeeds.

A single test covering "the address changed" killed only one mutant and passed
over the other, which is the whole reason they are separate.

## A durability bug the merge introduced, caught by the concurrency storm

Rebasing onto a newer develop turned `TestLockManager_ConcurrentStorm_StoreMatchesMemory`
red with `in-memory lock ul-o2-r1 has no store record (lost persist / reorder)`.
It was mine: 10/10 green with the source change reverted.

The name points at persist ordering, which it is not. A single-threaded replay of
the storm's op mix, checking the memory/store bijection after *every* operation,
reproduced it deterministically and named the cause. A persisted record is keyed
by lock ID, and nothing stops one ID belonging to two live rows: `UpgradeLock`
flips a row's type in place, and a later row of the other type carrying the same
ID neither merges with it nor matches its exact range, so it is appended
alongside. Absorbing one of that pair deleted the record the *other* still
depended on — a lock held in memory and simply gone after a restart.

Deleting by ID is what the merge added; before it, nothing removed a record while
a second row shared its key, so the duplicate was harmless. The merge now drops
only records no surviving row answers to.

`TestAddUnifiedLock_MergeKeepsRecordOfSameIDSurvivor` pins it deterministically
and fails on the unguarded version with `in-memory lock dup has no store record
after the merge`. That test matters more than the storm run it came from: on the
unguarded build the storm passed 3/3 while the deterministic test failed every
time. The storm is scheduler-probabilistic and had already gone green over this
bug on an earlier push.

## The ordering branch that no test could see

Worth calling out, because it is the more instructive half of this change.

The merge needed an "do these two ranges touch" predicate. `canMerge` already
existed but assumed its arguments were sorted by offset, so the first version of
this fix added a `locksTouch` wrapper that ordered the pair first. That wrapper
was **unverified**: deleting the swap left the entire merge suite green.

The reason is that the asymmetry only ever produces false *positives* — an
unordered `canMerge` claims two disjoint ranges touch when the existing row
starts *after* the new one — and every test happened to seed its rows in
ascending offset order, where the wrong branch gives the right answer by luck. A
guard that has never refused anything accrues confidence in proportion to how
long it is silently useless.

The fix was not another test but a one-word change to an existing one:
`TestAddUnifiedLock_MergeBridgesTwoRanges` now seeds `{90,10}` before `{0,10}`,
so its existing "disjoint ranges should not have merged" assertion is asked the
question the wrong way round. That mutant now fails. With ordering handled
inside `canMerge` itself, the `locksTouch` wrapper and both unbounded special
cases collapse — `End()` already returns `maxUint64` for a `Length == 0` lock,
so it reaches every offset at or after its own:

```go
func canMerge(a, b *UnifiedLock) bool {
	if a.Offset > b.Offset {
		a, b = b, a
	}
	return a.End() >= b.Offset
}
```

## Unrelated harness snag, noted for whoever hits it next

`setup-posix.sh` starts the server with `--foreground`, which writes no pidfile,
so the documented `dfs stop --force` teardown fails with `PID file not found`.
`teardown-posix.sh` needs root. The fallback inside `setup-posix.sh` is
`pkill -f "dfs start"`, which matches *any* agent's server, not just the one you
started — with several worktrees running concurrently that is a live hazard, not
a theoretical one. Identify the process by its full command line (its own
worktree's binary and config) and kill that PID.

Not fixed here; it is not what this PR is about.
