### PR TITLE
fix(nfs/v4.1): enforce the session's negotiated COMPOUND limits

### DIFF
--- a/internal/adapter/nfs/v4/handlers/compound.go
+++ b/internal/adapter/nfs/v4/handlers/compound.go
@@ -446,19 +446,28 @@ func compoundIsNonIdempotent(results []types.CompoundResult) bool {
 //  1. Validate op count
 //  2. Read first opcode
 //  3. If exempt op: dispatch all ops with v41ctx=nil (no session context)
-//  4. If SEQUENCE: validate session/slot/seqid, then dispatch remaining ops
-//  5. If neither: return NFS4ERR_OP_NOT_IN_SESSION
+//  4. If outside this minor version's op-number range: dispatch it, which
+//     answers OP_ILLEGAL/NFS4ERR_OP_ILLEGAL
+//  5. If SEQUENCE: validate session/slot/seqid, then dispatch remaining ops
+//  6. If none of those: return NFS4ERR_OP_NOT_IN_SESSION
 //
 // On SEQUENCE replay (duplicate slot+seqid), returns the cached COMPOUND
 // response bytes directly without re-executing any operations.
 func (h *Handler) dispatchV41(compCtx *types.CompoundContext, tag []byte, numOps uint32, reader io.Reader, isV42 bool) ([]byte, error) {
-	// Validate operation count limit
+	// Cap the op count before the session is known: numOps is client-supplied and
+	// sizes the result slice, so it is bounded here rather than after SEQUENCE
+	// parses. NFS4ERR_TOO_MANY_OPS is answerable without the session because
+	// negotiateChannelAttrs clamps every session's ca_maxoperations to
+	// MaxCompoundOps, so a COMPOUND over the global cap is over its session's
+	// limit too. NFS4ERR_RESOURCE, which the v4.0 path returns here, is an
+	// NFSv4.0 error (RFC 7530 Section 13.1.3.4) and is absent from both the
+	// NFSv4.1 error registry and every operation's valid-error list in RFC 8881.
 	if numOps > types.MaxCompoundOps {
 		logger.Debug("NFSv4.1 COMPOUND op count exceeds limit",
 			"count", numOps,
 			"max", types.MaxCompoundOps,
 			"client", compCtx.ClientAddr)
-		return encodeCompoundResponse(types.NFS4ERR_RESOURCE, tag, nil)
+		return encodeCompoundResponse(types.NFS4ERR_TOO_MANY_OPS, tag, nil)
 	}
 
 	// Empty compound: just return success
@@ -483,11 +492,12 @@ func (h *Handler) dispatchV41(compCtx *types.CompoundContext, tag []byte, numOps
 
 	// An opcode outside the operation-number range of this minor version is not
 	// an operation at all, so the SEQUENCE requirement does not reach it:
-	// NFS4ERR_OP_NOT_IN_SESSION is defined (RFC 8881 §15.1.3.5) for operations
-	// that are only valid inside a session, while RFC 8881 §16.2.3 says the reply
-	// to an out-of-range opcode encodes OP_ILLEGAL with NFS4ERR_OP_ILLEGAL and
-	// that the COMPOUND status is NFS4ERR_OP_ILLEGAL too. Dispatching it produces
-	// exactly that, and the non-OK status stops the COMPOUND there.
+	// NFS4ERR_OP_NOT_IN_SESSION is defined (RFC 8881 Section 15.1.3.5) for
+	// operations that are only valid inside a session, while RFC 8881
+	// Section 16.2.3 says the reply to an out-of-range opcode encodes OP_ILLEGAL
+	// with NFS4ERR_OP_ILLEGAL and that the COMPOUND status is NFS4ERR_OP_ILLEGAL
+	// too. Dispatching it produces exactly that, and the non-OK status stops the
+	// COMPOUND there.
 	if firstOpCode < types.OP_ACCESS || firstOpCode > h.maxValidOpCode(true, isV42) {
 		logger.Debug("NFSv4.1 COMPOUND illegal first opcode",
 			"opcode", firstOpCode,

--- a/internal/adapter/nfs/v4/handlers/compound.go
+++ b/internal/adapter/nfs/v4/handlers/compound.go
@@ -316,6 +316,7 @@ func (h *Handler) ProcessCompound(compCtx *types.CompoundContext, data []byte) (
 	// hash could allow a malicious client to engineer.
 	digest := sha256.Sum256(data)
 	compCtx.RequestDigest = digest[:]
+	compCtx.RequestSize = uint32(len(data))
 
 	reader := bytes.NewReader(data)
 
@@ -480,6 +481,20 @@ func (h *Handler) dispatchV41(compCtx *types.CompoundContext, tag []byte, numOps
 		return h.dispatchV41Ops(compCtx, tag, firstOpCode, numOps, nil, reader, isV42)
 	}
 
+	// An opcode outside the operation-number range of this minor version is not
+	// an operation at all, so the SEQUENCE requirement does not reach it:
+	// NFS4ERR_OP_NOT_IN_SESSION is defined (RFC 8881 §15.1.3.5) for operations
+	// that are only valid inside a session, while RFC 8881 §16.2.3 says the reply
+	// to an out-of-range opcode encodes OP_ILLEGAL with NFS4ERR_OP_ILLEGAL and
+	// that the COMPOUND status is NFS4ERR_OP_ILLEGAL too. Dispatching it produces
+	// exactly that, and the non-OK status stops the COMPOUND there.
+	if firstOpCode < types.OP_ACCESS || firstOpCode > h.maxValidOpCode(true, isV42) {
+		logger.Debug("NFSv4.1 COMPOUND illegal first opcode",
+			"opcode", firstOpCode,
+			"client", compCtx.ClientAddr)
+		return h.dispatchV41Ops(compCtx, tag, firstOpCode, numOps, nil, reader, isV42)
+	}
+
 	// Non-exempt: first op MUST be SEQUENCE
 	if firstOpCode != types.OP_SEQUENCE {
 		logger.Debug("NFSv4.1 COMPOUND missing SEQUENCE",
@@ -489,7 +504,7 @@ func (h *Handler) dispatchV41(compCtx *types.CompoundContext, tag []byte, numOps
 	}
 
 	// Process SEQUENCE
-	seqResult, v41ctx, sess, cachedReply, seqErr := v41handlers.HandleSequenceOp(h.v41Deps, compCtx, reader)
+	seqResult, v41ctx, sess, cachedReply, seqErr := v41handlers.HandleSequenceOp(h.v41Deps, compCtx, numOps, reader)
 	if seqErr != nil {
 		return nil, fmt.Errorf("SEQUENCE processing error: %w", seqErr)
 	}

--- a/internal/adapter/nfs/v4/handlers/compound.go
+++ b/internal/adapter/nfs/v4/handlers/compound.go
@@ -498,7 +498,14 @@ func (h *Handler) dispatchV41(compCtx *types.CompoundContext, tag []byte, numOps
 	// with NFS4ERR_OP_ILLEGAL and that the COMPOUND status is NFS4ERR_OP_ILLEGAL
 	// too. Dispatching it produces exactly that, and the non-OK status stops the
 	// COMPOUND there.
-	if firstOpCode < types.OP_ACCESS || firstOpCode > h.maxValidOpCode(true, isV42) {
+	//
+	// The v4.2 table is consulted alongside the range so a v4.2-only op arriving
+	// under v4.1 stays a known operation and still has to meet the SEQUENCE
+	// requirement, the way a v4.0-only op such as SETCLIENTID does. That leaves
+	// only opcodes no table recognises here, which are the ones dispatchOne
+	// answers from its illegal-opcode branch.
+	if h.v42DispatchTable[firstOpCode] == nil &&
+		(firstOpCode < types.OP_ACCESS || firstOpCode > h.maxValidOpCode(true, isV42)) {
 		logger.Debug("NFSv4.1 COMPOUND illegal first opcode",
 			"opcode", firstOpCode,
 			"client", compCtx.ClientAddr)

--- a/internal/adapter/nfs/v4/handlers/compound_test.go
+++ b/internal/adapter/nfs/v4/handlers/compound_test.go
@@ -748,9 +748,11 @@ func TestCompound_V41_IllegalOpOutsideRange(t *testing.T) {
 	h := newTestHandler()
 	ctx := newTestCompoundContext()
 
-	// Currently: opcode 99999 is not exempt from SEQUENCE.
-	// The first op check sees it's not exempt and not SEQUENCE, so
-	// NFS4ERR_OP_NOT_IN_SESSION is returned before opcode validation.
+	// Opcode 99999 is outside the operation-number range, so it is not an
+	// operation the session requirement can apply to: the reply carries a single
+	// result whose opcode is OP_ILLEGAL with NFS4ERR_OP_ILLEGAL, not the
+	// NFS4ERR_OP_NOT_IN_SESSION owed to a real op sent without SEQUENCE
+	// (RFC 8881 Sections 16.2.3 and 15.1.3.5).
 	data := buildCompoundArgs([]byte(""), 1, []uint32{99999})
 	resp, err := h.ProcessCompound(ctx, data)
 	if err != nil {
@@ -762,12 +764,16 @@ func TestCompound_V41_IllegalOpOutsideRange(t *testing.T) {
 		t.Fatalf("decode response error: %v", err)
 	}
 
-	if decoded.Status != types.NFS4ERR_OP_NOT_IN_SESSION {
-		t.Errorf("status = %d, want NFS4ERR_OP_NOT_IN_SESSION (%d)",
-			decoded.Status, types.NFS4ERR_OP_NOT_IN_SESSION)
+	if decoded.Status != types.NFS4ERR_OP_ILLEGAL {
+		t.Errorf("status = %d, want NFS4ERR_OP_ILLEGAL (%d)",
+			decoded.Status, types.NFS4ERR_OP_ILLEGAL)
 	}
-	if decoded.NumResults != 0 {
-		t.Errorf("numResults = %d, want 0 (no results without SEQUENCE)", decoded.NumResults)
+	if decoded.NumResults != 1 {
+		t.Fatalf("numResults = %d, want 1", decoded.NumResults)
+	}
+	if decoded.Results[0].OpCode != types.OP_ILLEGAL {
+		t.Errorf("result opcode = %d, want OP_ILLEGAL (%d) rather than the request's",
+			decoded.Results[0].OpCode, types.OP_ILLEGAL)
 	}
 }
 

--- a/internal/adapter/nfs/v4/handlers/compound_test.go
+++ b/internal/adapter/nfs/v4/handlers/compound_test.go
@@ -802,6 +802,11 @@ func TestCompound_V41_V42OpStillNeedsSequence(t *testing.T) {
 		t.Errorf("status = %d, want NFS4ERR_OP_NOT_IN_SESSION (%d)",
 			decoded.Status, types.NFS4ERR_OP_NOT_IN_SESSION)
 	}
+	// Nothing ran, so the reply carries no results, which is what separates this
+	// path from the OP_ILLEGAL one that emits a single ILLEGAL result.
+	if decoded.NumResults != 0 {
+		t.Errorf("numResults = %d, want 0 (no op executed without SEQUENCE)", decoded.NumResults)
+	}
 }
 
 func TestCompound_V41_EmptyCompound(t *testing.T) {

--- a/internal/adapter/nfs/v4/handlers/compound_test.go
+++ b/internal/adapter/nfs/v4/handlers/compound_test.go
@@ -777,6 +777,33 @@ func TestCompound_V41_IllegalOpOutsideRange(t *testing.T) {
 	}
 }
 
+// TestCompound_V41_V42OpStillNeedsSequence checks that an opcode a dispatch
+// table knows keeps meeting the SEQUENCE requirement even when it is not valid
+// in this minor version. GETXATTR is a v4.2 op, so under v4.1 it is out of the
+// operation-number range, but it is a real operation and so owes
+// NFS4ERR_OP_NOT_IN_SESSION rather than NFS4ERR_OP_ILLEGAL -- the same answer a
+// v4.0-only op such as SETCLIENTID gets here.
+func TestCompound_V41_V42OpStillNeedsSequence(t *testing.T) {
+	h := newTestHandler()
+	ctx := newTestCompoundContext()
+
+	data := buildCompoundArgs([]byte(""), 1, []uint32{types.OP_GETXATTR})
+	resp, err := h.ProcessCompound(ctx, data)
+	if err != nil {
+		t.Fatalf("ProcessCompound error: %v", err)
+	}
+
+	decoded, err := decodeCompoundResponse(resp)
+	if err != nil {
+		t.Fatalf("decode response error: %v", err)
+	}
+
+	if decoded.Status != types.NFS4ERR_OP_NOT_IN_SESSION {
+		t.Errorf("status = %d, want NFS4ERR_OP_NOT_IN_SESSION (%d)",
+			decoded.Status, types.NFS4ERR_OP_NOT_IN_SESSION)
+	}
+}
+
 func TestCompound_V41_EmptyCompound(t *testing.T) {
 	h := newTestHandler()
 	ctx := newTestCompoundContext()

--- a/internal/adapter/nfs/v4/handlers/sequence_handler_test.go
+++ b/internal/adapter/nfs/v4/handlers/sequence_handler_test.go
@@ -38,14 +38,18 @@ func createTestSession(t *testing.T) (*Handler, types.SessionId4) {
 func createSessionOn(t *testing.T, h *Handler, ownerID string) types.SessionId4 {
 	t.Helper()
 	clientID, seqID := registerExchangeID(t, h, ownerID)
-
-	ctx := newTestCompoundContext()
 	secParms := []types.CallbackSecParms4{{CbSecFlavor: 0}} // AUTH_NONE
-	csArgs := encodeCreateSessionArgsWithSec(clientID, seqID, 0, secParms)
-	ops := []compoundOp{{opCode: types.OP_CREATE_SESSION, data: csArgs}}
-	data := buildCompoundArgsWithOps([]byte("cs"), 1, ops)
+	return runCreateSession(t, h, encodeCreateSessionArgsWithSec(clientID, seqID, 0, secParms)).SessionID
+}
 
-	resp, err := h.ProcessCompound(ctx, data)
+// runCreateSession sends the given CREATE_SESSION args as a single-op COMPOUND
+// and returns the decoded result, failing the test unless the session was
+// created.
+func runCreateSession(t *testing.T, h *Handler, csArgs []byte) types.CreateSessionRes {
+	t.Helper()
+	ops := []compoundOp{{opCode: types.OP_CREATE_SESSION, data: csArgs}}
+	resp, err := h.ProcessCompound(newTestCompoundContext(),
+		buildCompoundArgsWithOps([]byte("cs"), 1, ops))
 	if err != nil {
 		t.Fatalf("CREATE_SESSION ProcessCompound error: %v", err)
 	}
@@ -67,7 +71,7 @@ func createSessionOn(t *testing.T, h *Handler, ownerID string) types.SessionId4 
 		t.Fatalf("CREATE_SESSION status = %d, want NFS4_OK", csRes.Status)
 	}
 
-	return csRes.SessionID
+	return csRes
 }
 
 // decodeSequenceRes decodes SEQUENCE4res from a COMPOUND response that has
@@ -807,9 +811,12 @@ func TestCompound_V41_OpCountLimit(t *testing.T) {
 		t.Fatalf("decode response error: %v", err)
 	}
 
-	if decoded.Status != types.NFS4ERR_RESOURCE {
-		t.Errorf("status = %d, want NFS4ERR_RESOURCE (%d)",
-			decoded.Status, types.NFS4ERR_RESOURCE)
+	// NFS4ERR_RESOURCE, which the v4.0 path answers here, is an NFSv4.0 error
+	// that RFC 8881 does not define; the v4.1 cap is below every session's
+	// negotiated ca_maxoperations, so NFS4ERR_TOO_MANY_OPS is what it owes.
+	if decoded.Status != types.NFS4ERR_TOO_MANY_OPS {
+		t.Errorf("status = %d, want NFS4ERR_TOO_MANY_OPS (%d)",
+			decoded.Status, types.NFS4ERR_TOO_MANY_OPS)
 	}
 }
 
@@ -989,25 +996,9 @@ func createLimitedSession(t *testing.T, h *Handler, ownerID string, maxOps, maxR
 		t.Fatalf("encode CreateSessionArgs: %v", err)
 	}
 
-	ops := []compoundOp{{opCode: types.OP_CREATE_SESSION, data: argBuf.Bytes()}}
-	resp, err := h.ProcessCompound(newTestCompoundContext(),
-		buildCompoundArgsWithOps([]byte("cs"), 1, ops))
-	if err != nil {
-		t.Fatalf("CREATE_SESSION ProcessCompound error: %v", err)
-	}
-
-	reader := bytes.NewReader(resp)
-	if status, _ := xdr.DecodeUint32(reader); status != types.NFS4_OK {
-		t.Fatalf("CREATE_SESSION overall status = %d, want NFS4_OK", status)
-	}
-	_, _ = xdr.DecodeOpaque(reader) // tag
-	_, _ = xdr.DecodeUint32(reader) // numResults
-	_, _ = xdr.DecodeUint32(reader) // opcode
-
-	var csRes types.CreateSessionRes
-	if err := csRes.Decode(reader); err != nil {
-		t.Fatalf("decode CreateSessionRes: %v", err)
-	}
+	// The server may negotiate the fore channel down but never up, so the test
+	// limits are only usable once the reply confirms them.
+	csRes := runCreateSession(t, h, argBuf.Bytes())
 	if csRes.ForeChannelAttrs.MaxOperations != maxOps {
 		t.Fatalf("negotiated MaxOperations = %d, want %d",
 			csRes.ForeChannelAttrs.MaxOperations, maxOps)

--- a/internal/adapter/nfs/v4/handlers/sequence_handler_test.go
+++ b/internal/adapter/nfs/v4/handlers/sequence_handler_test.go
@@ -957,3 +957,164 @@ func createTestSessionBench(b *testing.B, h *Handler, clientID uint64, seqID uin
 	}
 	return csRes.SessionID
 }
+
+// createLimitedSession creates a session whose fore channel negotiates the
+// given ca_maxoperations and ca_maxrequestsize, so the COMPOUND limits can be
+// tripped with a small request.
+func createLimitedSession(t *testing.T, h *Handler, ownerID string, maxOps, maxReqSize uint32) types.SessionId4 {
+	t.Helper()
+	clientID, seqID := registerExchangeID(t, h, ownerID)
+
+	var argBuf bytes.Buffer
+	args := types.CreateSessionArgs{
+		ClientID:   clientID,
+		SequenceID: seqID,
+		ForeChannelAttrs: types.ChannelAttrs{
+			MaxRequestSize:        maxReqSize,
+			MaxResponseSize:       1048576,
+			MaxResponseSizeCached: 4096,
+			MaxOperations:         maxOps,
+			MaxRequests:           64,
+		},
+		BackChannelAttrs: types.ChannelAttrs{
+			MaxRequestSize:  4096,
+			MaxResponseSize: 4096,
+			MaxOperations:   2,
+			MaxRequests:     1,
+		},
+		CbProgram:  0x40000000,
+		CbSecParms: []types.CallbackSecParms4{{CbSecFlavor: 0}},
+	}
+	if err := args.Encode(&argBuf); err != nil {
+		t.Fatalf("encode CreateSessionArgs: %v", err)
+	}
+
+	ops := []compoundOp{{opCode: types.OP_CREATE_SESSION, data: argBuf.Bytes()}}
+	resp, err := h.ProcessCompound(newTestCompoundContext(),
+		buildCompoundArgsWithOps([]byte("cs"), 1, ops))
+	if err != nil {
+		t.Fatalf("CREATE_SESSION ProcessCompound error: %v", err)
+	}
+
+	reader := bytes.NewReader(resp)
+	if status, _ := xdr.DecodeUint32(reader); status != types.NFS4_OK {
+		t.Fatalf("CREATE_SESSION overall status = %d, want NFS4_OK", status)
+	}
+	_, _ = xdr.DecodeOpaque(reader) // tag
+	_, _ = xdr.DecodeUint32(reader) // numResults
+	_, _ = xdr.DecodeUint32(reader) // opcode
+
+	var csRes types.CreateSessionRes
+	if err := csRes.Decode(reader); err != nil {
+		t.Fatalf("decode CreateSessionRes: %v", err)
+	}
+	if csRes.ForeChannelAttrs.MaxOperations != maxOps {
+		t.Fatalf("negotiated MaxOperations = %d, want %d",
+			csRes.ForeChannelAttrs.MaxOperations, maxOps)
+	}
+	if csRes.ForeChannelAttrs.MaxRequestSize != maxReqSize {
+		t.Fatalf("negotiated MaxRequestSize = %d, want %d",
+			csRes.ForeChannelAttrs.MaxRequestSize, maxReqSize)
+	}
+	return csRes.SessionID
+}
+
+// TestSequence_TooManyOps checks that a COMPOUND carrying more operations than
+// the session's negotiated ca_maxoperations is refused with
+// NFS4ERR_TOO_MANY_OPS (RFC 8881 Section 18.36.3), and that a COMPOUND at
+// exactly the limit still runs.
+func TestSequence_TooManyOps(t *testing.T) {
+	h := newTestHandler()
+	sessionID := createLimitedSession(t, h, "too-many-ops-client", 4, 1048576)
+
+	// SEQUENCE plus three PUTROOTFHs is exactly ca_maxoperations.
+	atLimit := []compoundOp{{opCode: types.OP_SEQUENCE, data: encodeSequenceArgs(sessionID, 0, 1, 0, false)}}
+	for range 3 {
+		atLimit = append(atLimit, compoundOp{opCode: types.OP_PUTROOTFH})
+	}
+	resp, err := h.ProcessCompound(newTestCompoundContext(),
+		buildCompoundArgsWithOps([]byte("ops"), 1, atLimit))
+	if err != nil {
+		t.Fatalf("ProcessCompound error: %v", err)
+	}
+	decoded, err := decodeCompoundResponse(resp)
+	if err != nil {
+		t.Fatalf("decode response error: %v", err)
+	}
+	if decoded.Status != types.NFS4_OK {
+		t.Fatalf("at-limit status = %d, want NFS4_OK", decoded.Status)
+	}
+
+	// One more operation exceeds it.
+	overLimit := append(atLimit, compoundOp{opCode: types.OP_PUTROOTFH})
+	overLimit[0].data = encodeSequenceArgs(sessionID, 0, 2, 0, false)
+	resp, err = h.ProcessCompound(newTestCompoundContext(),
+		buildCompoundArgsWithOps([]byte("ops"), 1, overLimit))
+	if err != nil {
+		t.Fatalf("ProcessCompound error: %v", err)
+	}
+	decoded, seqRes := decodeSequenceRes(t, resp)
+	if decoded.Status != types.NFS4ERR_TOO_MANY_OPS {
+		t.Errorf("status = %d, want NFS4ERR_TOO_MANY_OPS (%d)",
+			decoded.Status, types.NFS4ERR_TOO_MANY_OPS)
+	}
+	if decoded.NumResults != 1 {
+		t.Fatalf("numResults = %d, want 1 (SEQUENCE only, no op executed)", decoded.NumResults)
+	}
+	if seqRes == nil || decoded.Results[0].OpCode != types.OP_SEQUENCE {
+		t.Fatalf("result opcode = %d, want OP_SEQUENCE", decoded.Results[0].OpCode)
+	}
+
+	// The refusal is reported on SEQUENCE, so no operation executed and the slot
+	// is untouched: seqid 2 is still the next one the slot accepts. Had the
+	// refused request consumed it, this would come back as a retry instead.
+	resp, err = h.ProcessCompound(newTestCompoundContext(),
+		buildCompoundArgsWithOps([]byte("ops"), 1, []compoundOp{
+			{opCode: types.OP_SEQUENCE, data: encodeSequenceArgs(sessionID, 0, 2, 0, false)},
+		}))
+	if err != nil {
+		t.Fatalf("ProcessCompound error: %v", err)
+	}
+	if decoded, _ = decodeSequenceRes(t, resp); decoded.Status != types.NFS4_OK {
+		t.Errorf("reusing seqid 2 after the refusal: status = %d, want NFS4_OK", decoded.Status)
+	}
+}
+
+// TestSequence_RequestTooBig checks that a COMPOUND larger than the session's
+// negotiated ca_maxrequestsize is refused with NFS4ERR_REQ_TOO_BIG
+// (RFC 8881 Section 2.10.6.4) before the oversized operation runs.
+func TestSequence_RequestTooBig(t *testing.T) {
+	h := newTestHandler()
+	sessionID := createLimitedSession(t, h, "req-too-big-client", 128, 512)
+
+	// PUTROOTFH plus a LOOKUP whose name alone overruns ca_maxrequestsize. The
+	// name is also longer than NFS4_MAXNAMLEN, so answering NFS4ERR_NAMETOOLONG
+	// here would mean LOOKUP ran instead of the request being refused up front.
+	var nameBuf bytes.Buffer
+	if err := xdr.WriteXDROpaque(&nameBuf, bytes.Repeat([]byte("a"), 500)); err != nil {
+		t.Fatalf("encode LOOKUP name: %v", err)
+	}
+	ops := []compoundOp{
+		{opCode: types.OP_SEQUENCE, data: encodeSequenceArgs(sessionID, 0, 1, 0, false)},
+		{opCode: types.OP_PUTROOTFH},
+		{opCode: types.OP_LOOKUP, data: nameBuf.Bytes()},
+	}
+
+	data := buildCompoundArgsWithOps([]byte("big"), 1, ops)
+	if len(data) <= 512 {
+		t.Fatalf("test request is %d bytes, needs to exceed the negotiated 512", len(data))
+	}
+
+	resp, err := h.ProcessCompound(newTestCompoundContext(), data)
+	if err != nil {
+		t.Fatalf("ProcessCompound error: %v", err)
+	}
+	decoded, _ := decodeSequenceRes(t, resp)
+	if decoded.Status != types.NFS4ERR_REQ_TOO_BIG {
+		t.Errorf("status = %d, want NFS4ERR_REQ_TOO_BIG (%d)",
+			decoded.Status, types.NFS4ERR_REQ_TOO_BIG)
+	}
+	if decoded.NumResults != 1 {
+		t.Errorf("numResults = %d, want 1 (SEQUENCE only, no op executed)", decoded.NumResults)
+	}
+}

--- a/internal/adapter/nfs/v4/types/types.go
+++ b/internal/adapter/nfs/v4/types/types.go
@@ -148,6 +148,13 @@ type CompoundContext struct {
 	// Section 2.10.6.1.3 -- a slot+seqid reused for a different request).
 	RequestDigest []byte
 
+	// RequestSize is the length in bytes of the COMPOUND arguments, set
+	// alongside RequestDigest in ProcessCompound. SEQUENCE weighs it against the
+	// session's negotiated ca_maxrequestsize. It excludes the RPC header, so it
+	// undercounts what a client's own request-size accounting includes; the
+	// resulting check is more permissive than the negotiated limit, never less.
+	RequestSize uint32
+
 	// MinorVersion is the minorversion field decoded from the COMPOUND
 	// arguments (0 for NFSv4.0, 1 for NFSv4.1, 2 for NFSv4.2). ProcessCompound
 	// sets it only once the value has passed the accepted-range check, so it

--- a/internal/adapter/nfs/v4/v41/handlers/sequence.go
+++ b/internal/adapter/nfs/v4/v41/handlers/sequence.go
@@ -15,7 +15,8 @@ import (
 // Establishes slot-based exactly-once semantics as the first op in every non-exempt v4.1 COMPOUND.
 // Delegates to StateManager for session lookup, slot validation, replay detection, and lease renewal.
 // Validates session/slot/seqid; returns cached reply on replay; builds V41RequestContext for new requests.
-// Errors: NFS4ERR_BADSESSION, NFS4ERR_SEQ_MISORDERED, NFS4ERR_BAD_SLOT, NFS4ERR_BADXDR.
+// Errors: NFS4ERR_BADSESSION, NFS4ERR_SEQ_MISORDERED, NFS4ERR_BAD_SLOT, NFS4ERR_BADXDR,
+// NFS4ERR_TOO_MANY_OPS, NFS4ERR_REQ_TOO_BIG.
 func HandleSequenceOp(d *Deps, compCtx *types.CompoundContext, numOps uint32, reader io.Reader) (
 	sequenceResult *types.CompoundResult,
 	v41ctx *types.V41RequestContext,

--- a/internal/adapter/nfs/v4/v41/handlers/sequence.go
+++ b/internal/adapter/nfs/v4/v41/handlers/sequence.go
@@ -16,7 +16,7 @@ import (
 // Delegates to StateManager for session lookup, slot validation, replay detection, and lease renewal.
 // Validates session/slot/seqid; returns cached reply on replay; builds V41RequestContext for new requests.
 // Errors: NFS4ERR_BADSESSION, NFS4ERR_SEQ_MISORDERED, NFS4ERR_BAD_SLOT, NFS4ERR_BADXDR.
-func HandleSequenceOp(d *Deps, compCtx *types.CompoundContext, reader io.Reader) (
+func HandleSequenceOp(d *Deps, compCtx *types.CompoundContext, numOps uint32, reader io.Reader) (
 	sequenceResult *types.CompoundResult,
 	v41ctx *types.V41RequestContext,
 	session *state.Session,
@@ -44,6 +44,27 @@ func HandleSequenceOp(d *Deps, compCtx *types.CompoundContext, reader io.Reader)
 			Status: types.NFS4ERR_BADSESSION,
 			OpCode: types.OP_SEQUENCE,
 			Data:   EncodeStatusOnly(types.NFS4ERR_BADSESSION),
+		}, nil, nil, nil, nil
+	}
+
+	// Enforce the fore channel limits negotiated at CREATE_SESSION, before the
+	// slot is reserved. Reporting them on SEQUENCE is the arm of RFC 8881
+	// Section 2.10.6.4 where no operation executes and the slot's reply-cache
+	// state is unchanged, which is what refusing here achieves; SEQUENCE lists
+	// both errors among its valid ones.
+	if status := foreChannelLimitStatus(sess, numOps, compCtx.RequestSize); status != types.NFS4_OK {
+		logger.Debug("SEQUENCE: fore channel limit exceeded",
+			"session_id", args.SessionID.String(),
+			"status", status,
+			"num_ops", numOps,
+			"request_size", compCtx.RequestSize,
+			"max_operations", sess.ForeChannelAttrs.MaxOperations,
+			"max_request_size", sess.ForeChannelAttrs.MaxRequestSize,
+			"client", compCtx.ClientAddr)
+		return &types.CompoundResult{
+			Status: status,
+			OpCode: types.OP_SEQUENCE,
+			Data:   EncodeStatusOnly(status),
 		}, nil, nil, nil, nil
 	}
 
@@ -153,6 +174,23 @@ func HandleSequenceOp(d *Deps, compCtx *types.CompoundContext, reader io.Reader)
 		OpCode: types.OP_SEQUENCE,
 		Data:   EncodeStatusOnly(types.NFS4ERR_SERVERFAULT),
 	}, nil, nil, nil, nil
+}
+
+// foreChannelLimitStatus returns the error a COMPOUND owes for exceeding one of
+// the session's negotiated fore channel limits, or NFS4_OK when it fits.
+//
+// A COMPOUND carrying more operations than ca_maxoperations MUST be answered
+// with NFS4ERR_TOO_MANY_OPS (RFC 8881 Section 18.36.3); one larger than
+// ca_maxrequestsize is answered with NFS4ERR_REQ_TOO_BIG (Section 2.10.6.4).
+func foreChannelLimitStatus(sess *state.Session, numOps, requestSize uint32) uint32 {
+	switch {
+	case numOps > sess.ForeChannelAttrs.MaxOperations:
+		return types.NFS4ERR_TOO_MANY_OPS
+	case requestSize > sess.ForeChannelAttrs.MaxRequestSize:
+		return types.NFS4ERR_REQ_TOO_BIG
+	default:
+		return types.NFS4_OK
+	}
 }
 
 // isSessionExemptOp returns true if the given operation code is exempt from

--- a/test/nfs-conformance/pynfs/KNOWN_FAILURES_V41.md
+++ b/test/nfs-conformance/pynfs/KNOWN_FAILURES_V41.md
@@ -51,9 +51,6 @@ Categories:
 | DELEG6 | bug | no delegation is granted | #2329 |
 | DELEG7 | bug | no delegation is granted | #2329 |
 | DELEG8 | bug | no delegation is granted | #2329 |
-| COMP5 | bug | COMPOUND op-count and request-size limits not enforced | #2330 |
-| SEQ6 | bug | COMPOUND op-count and request-size limits not enforced | #2330 |
-| SEQ7 | bug | COMPOUND op-count and request-size limits not enforced | #2330 |
 | LKPP1a | bug | lookupp41 | #2335 |
 | LKPP1b | bug | lookupp41 | #2335 |
 | LKPP1c | bug | lookupp41 | #2335 |


### PR DESCRIPTION
Closes #2330

pynfs `COMP5`, `SEQ6` and `SEQ7` fail against DittoFS and pass against knfsd. All three are the v4.1 COMPOUND dispatcher answering the wrong error, for two unrelated reasons.

## The issue's premise, corrected

The title says op-count and request-size limits "are not enforced". An op-count cap *is* enforced — `dispatchV41` rejects a COMPOUND declaring more than the global `types.MaxCompoundOps` (128). What is missing is the **session-negotiated** limit: `ca_maxoperations` and `ca_maxrequestsize` come back from CREATE_SESSION per session and can be far lower than the global constant (pynfs asks for 4 and 512). We negotiated both correctly and then never looked at them again, so a client that asked to be held to 4 operations could send 128.

## What was wrong

**1. `ca_maxoperations` / `ca_maxrequestsize` never consulted.** `state.Session` carries the negotiated `ForeChannelAttrs`, but nothing on the request path read them. SEQ7 sent 5 operations to a session that negotiated 4 and got `NFS4_OK`; SEQ6 sent a 560-byte COMPOUND to a session that negotiated 512 and got `NFS4ERR_NAMETOOLONG` — the wrong error for the right reason, because LOOKUP actually ran and tripped its own name-length check instead of the request being refused up front.

**2. `NFS4ERR_OP_NOT_IN_SESSION` shadowed `NFS4ERR_OP_ILLEGAL`.** `dispatchV41` reads the first opcode and, if it is neither session-exempt nor SEQUENCE, returns `NFS4ERR_OP_NOT_IN_SESSION` before any opcode validation. COMP5 sends opcodes 0, 1, 2, 76 and 10044 in a bare COMPOUND and expects `NFS4ERR_OP_ILLEGAL`. RFC 8881 §15.1.3.5 defines `NFS4ERR_OP_NOT_IN_SESSION` for *operations* that are only valid inside a session; an opcode outside the operation-number range is not an operation, and §16.2.3 says the reply to one encodes `OP_ILLEGAL` with `NFS4ERR_OP_ILLEGAL` and that the COMPOUND status is `NFS4ERR_OP_ILLEGAL` too. Linux nfsd stamps ILLEGAL at decode time, which is why it passes.

**3. (found while in the function) `NFS4ERR_RESOURCE` is not an NFSv4.1 error.** The pre-session op-count cap in `dispatchV41` answered with it. `NFS4ERR_RESOURCE` (10018) appears **nowhere** in RFC 8881 — not in the §15.1 error registry (whose alphabetical table runs `NFS4ERR_REQ_TOO_BIG` → `NFS4ERR_RESTOREFH`, skipping it) and not in any operation's valid-error list in §15.2. It is an NFSv4.0 error, RFC 7530 §13.1.3.4. So the v4.1 path was returning a code the client is not supposed to see. This is a separate defect from the one the issue names; the v4.0 path keeps `NFS4ERR_RESOURCE`, which is correct there.

## The fix

`HandleSequenceOp` now weighs the COMPOUND against the session's negotiated fore-channel limits, between the session lookup and `ValidateSequence`:

- more operations than `ca_maxoperations` → `NFS4ERR_TOO_MANY_OPS`. RFC 8881 §18.36.3 is a MUST: "if a requester sends a COMPOUND or CB_COMPOUND with more operations than ca_maxoperations, the replier MUST return NFS4ERR_TOO_MANY_OPS."
- larger than `ca_maxrequestsize` → `NFS4ERR_REQ_TOO_BIG`, per §2.10.6.4.

**Placement and slot accounting.** §2.10.6.4 offers a choice for `REQ_TOO_BIG`: report it on SEQUENCE, "which means that no operations in the request executed and that the state of the slot in the reply cache is unchanged", or on a later operation, which means the slot state *does* change. Getting that half-right — erroring at SEQUENCE while still advancing the slot — would be a silent replay-correctness bug, so the check sits **before** `ValidateSequence` reserves the slot: nothing executes, the seqid is not advanced, nothing is cached. `TestSequence_TooManyOps` asserts this directly by reusing the refused seqid afterwards and requiring `NFS4_OK` rather than a retry. Both errors are listed among SEQUENCE's valid errors in §15.2. Linux nfsd does the same thing from inside `nfsd4_sequence`.

`RequestSize` is measured over the COMPOUND arguments, so the RPC header is not counted against `ca_maxrequestsize`. That undercounts what a client's own request-size accounting includes (a Linux client subtracts `nfs41_maxwrite_overhead` from the negotiated value when sizing writes), which makes the check strictly more permissive than the negotiated limit, never stricter — no request a conformant client sizes to fit can be refused by it.

For the illegal opcode, `dispatchV41` now checks the operation-number range before the SEQUENCE requirement and dispatches out-of-range opcodes, which produces the `OP_ILLEGAL` result the RFC asks for and stops the COMPOUND on the non-OK status.

The pre-session cap now answers `NFS4ERR_TOO_MANY_OPS` instead of `NFS4ERR_RESOURCE`. It stays as a guard — `numOps` is attacker-controlled and sizes an allocation — and the error is correct without knowing the session, because `negotiateChannelAttrs` clamps `ca_maxoperations` to `types.MaxCompoundOps`, so anything over the global cap is over every session's limit too.

## Evidence

The three new/updated unit tests reproduce all three pynfs symptoms exactly. Run against the pre-fix build (source files reverted, tests kept):

```
--- FAIL: TestCompound_V41_IllegalOpOutsideRange
    status = 10071, want NFS4ERR_OP_ILLEGAL (10044)          <- NFS4ERR_OP_NOT_IN_SESSION, COMP5
    numResults = 0, want 1
--- FAIL: TestSequence_TooManyOps
    status = 0, want NFS4ERR_TOO_MANY_OPS (10070)            <- NFS4_OK, SEQ7
    numResults = 5, want 1 (SEQUENCE only, no op executed)
--- FAIL: TestSequence_RequestTooBig
    status = 63, want NFS4ERR_REQ_TOO_BIG (10065)            <- NFS4ERR_NAMETOOLONG, SEQ6
    numResults = 3, want 1 (SEQUENCE only, no op executed)
```

All pass after. `go test -race ./internal/adapter/nfs/...` is green.

`COMP5`, `SEQ6` and `SEQ7` are removed from `KNOWN_FAILURES_V41.md`, so the pynfs job is now the check on this: the grader counts only new failures, and a blacklisted test that passes is invisible to it. The table drops from 71 known failures to 68 — the "Loaded N known failures" line in the NFS Protocol Conformance log should read 68 for v4.1.

The suite could not be run locally (a concurrent agent holds port 12049); CI's pynfs job covers memory and postgres-s3 at both minor versions.

## Review findings

**Applied:** an opcode a dispatch table recognises but that is not valid in the active minor version (a v4.2 xattr op under v4.1) was being treated as out-of-range by the new check and answered `NFS4ERR_NOTSUPP`, bypassing the SEQUENCE requirement. It is a real operation, so it owes `NFS4ERR_OP_NOT_IN_SESSION` — the same answer a v4.0-only op such as SETCLIENTID already got there. The range test now also consults the v4.2 table, which narrows this PR's behaviour change to opcodes no table recognises at all, exactly the set §16.2.3 describes. `TestCompound_V41_V42OpStillNeedsSequence` pins it, and fails with `NFS4ERR_NOTSUPP` without the guard.

**Not applied, deliberately:** review also flagged that `negotiateChannelAttrs` has no *floor* on `ca_maxoperations`/`ca_maxrequestsize`, so a client proposing `ca_maxoperations=0` now gets a session that refuses every COMPOUND, where before the field was inert. The proposed remedy — clamping `ca_maxrequestsize` up to the unused `ChannelLimits.MinRequestSize` (8192) — would silently re-break `SEQ6`, which negotiates 512 and depends on the server honouring it. Those `Min*Size` fields are dead because they are the floor for a **rejection**, not a clamp: RFC 8881 §18.36.3 lists `NFS4ERR_TOOSMALL` among CREATE_SESSION's valid errors, and pynfs `CSESS25`/`CSESS28` assert exactly that for degenerate channel attributes. Linux nfsd does the same (`if (ca->maxops < 2) return nfserr_toosmall`). Enforcing a negotiated value literally is the conformant behaviour; refusing the degenerate session at CREATE_SESSION is the missing guard, and it is #2340's scope (`CSESS25`-`CSESS28` are its blacklist rows). Clamping here would make that later rejection unreachable.
