### PR TITLE
refactor(metadata): one file-chunk object implementation over both SQL dialects

### DIFF
--- a/pkg/metadata/store/postgres/dialect.go
+++ b/pkg/metadata/store/postgres/dialect.go
@@ -24,12 +24,14 @@ func (dialect) IsNoRows(err error) bool { return errors.Is(err, pgx.ErrNoRows) }
 func (dialect) Chunks() *storesql.ChunkQueries { return &chunkQueries }
 
 var chunkQueries = storesql.ChunkQueries{
-	SelectByID:   selectFileChunkByID,
-	SelectByHash: selectFileChunkByHash,
-	Upsert:       putFileChunkQuery,
-	Delete:       `DELETE FROM file_blocks WHERE id = $1`,
-	IncrementRef: `UPDATE file_blocks SET ref_count = ref_count + 1 WHERE id = $1`,
-	DecrementRef: `UPDATE file_blocks SET ref_count = GREATEST(ref_count - 1, 0) WHERE id = $1 RETURNING ref_count`,
+	SelectByID:       selectFileChunkByID,
+	SelectByHash:     selectFileChunkByHash,
+	Insert:           insertFileChunk,
+	Upsert:           insertFileChunk + storesql.FileChunkUpsertTail,
+	Delete:           `DELETE FROM file_blocks WHERE id = $1`,
+	IncrementRef:     `UPDATE file_blocks SET ref_count = ref_count + 1 WHERE id = $1`,
+	DecrementRef:     `UPDATE file_blocks SET ref_count = GREATEST(ref_count - 1, 0) WHERE id = $1 RETURNING ref_count`,
+	DecrementRefMany: `UPDATE file_blocks SET ref_count = GREATEST(ref_count - 1, 0)`,
 	// state = 2 (Remote) scoping mirrors SelectByHash and the memory/badger
 	// backends: a Pending row is not a valid dedup donor.
 	AddRef:             `UPDATE file_blocks SET ref_count = ref_count + 1 WHERE hash = $1 AND state = 2 /* Remote */`,

--- a/pkg/metadata/store/postgres/objects.go
+++ b/pkg/metadata/store/postgres/objects.go
@@ -1,10 +1,16 @@
+// FileChunkStore support for the PostgreSQL metadata store: content-addressed
+// file chunk tracking for deduplication and caching, over the file_blocks table.
+//
+// The statements and the bodies that run them live in store/sql, promoted onto
+// both the store and its transaction through the embedded Core. What stays here
+// is the dialect's own SQL text and the two entry points that must not be
+// promoted: DecrementRefCountAndReap, which needs a transaction Core is not one
+// of, and DecrementRefCountAndReapMany, whose two statements are only atomic
+// when they share the transaction the caller opened.
 package postgres
 
 import (
 	"context"
-	"fmt"
-	"strings"
-	"time"
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
@@ -12,59 +18,35 @@ import (
 	storesql "github.com/marmos91/dittofs/pkg/metadata/store/sql"
 )
 
-// ============================================================================
-// FileChunkStore Implementation for PostgreSQL Store
-// ============================================================================
-//
-// This file implements the FileChunkStore interface for the PostgreSQL metadata store.
-// It provides content-addressed file chunk tracking for deduplication and caching.
-//
-// The FileChunkStore interface is narrowed to 6 methods. The backend
-// retains the legacy GetFileChunk + ListFileChunks helpers as
-// concrete methods on the struct (not on the public interface) for
-// engine-internal callers.
-//
-// Table:
-//   - file_blocks: File block data with UUID as primary key and hash index
-//
-// Thread Safety: All operations use PostgreSQL transactions for ACID guarantees.
-//
-// ============================================================================
-
-// Ensure PostgresMetadataStore implements FileChunkStore
+// Both the store and its transaction satisfy the interface through the
+// promoted Core methods.
 var _ block.FileChunkStore = (*PostgresMetadataStore)(nil)
-
-// ============================================================================
-// FileChunk Operations
-// ============================================================================
-
-// fileChunkColumns is the file_blocks column list every chunk read and write
-// names, in the order scanFileChunk reads them. Naming it once is what keeps a
-// column added to one query from being missed by the others, or by the scan.
-const fileChunkColumns = `id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at`
+var _ block.FileChunkStore = (*postgresTransaction)(nil)
 
 const (
-	selectFileChunkByID   = `SELECT ` + fileChunkColumns + ` FROM file_blocks WHERE id = $1`
-	selectFileChunkByHash = `SELECT ` + fileChunkColumns + ` FROM file_blocks WHERE hash = $1 AND state = 2 /* Remote */`
-	insertFileChunk       = `INSERT INTO file_blocks (` + fileChunkColumns + `) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`
+	selectFileChunkByID   = `SELECT ` + storesql.FileChunkColumns + ` FROM file_blocks WHERE id = $1`
+	selectFileChunkByHash = `SELECT ` + storesql.FileChunkColumns + ` FROM file_blocks WHERE hash = $1 AND state = 2 /* Remote */`
+
+	// insertFileChunk is the INSERT the row writers share; each appends its
+	// own ON CONFLICT clause.
+	insertFileChunk = `INSERT INTO file_blocks (` + storesql.FileChunkColumns + `) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`
 )
 
-// putFileChunkQuery omits ref_count from the ON CONFLICT UPDATE list so
-// concurrent IncrementRefCount / DecrementRefCount (which run as atomic SQL
-// `+1` / `-1` UPDATEs) cannot be silently overwritten by a stale
-// Put-with-in-memory-RefCount. RefCount on the INSERT path is still set
-// verbatim from the caller's *FileChunk (matches the contract for new rows).
-// For existing rows, RefCount mutates exclusively through Increment/Decrement.
-// hash uses COALESCE so a zero-hash Put never NULLs a previously-persisted good
-// hash.
-const putFileChunkQuery = insertFileChunk + `
-	ON CONFLICT (id) DO UPDATE SET
-		hash = COALESCE(EXCLUDED.hash, file_blocks.hash),
-		data_size = EXCLUDED.data_size,
-		start_offset = EXCLUDED.start_offset,
-		last_access = EXCLUDED.last_access,
-		state = EXCLUDED.state,
-		last_sync_attempt_at = EXCLUDED.last_sync_attempt_at`
+// listFileChunksQuery is ChunkQueries.ListByPayloadRange for postgres; what the
+// bounds mean, and why the byte collation, lives on that field.
+const listFileChunksQuery = `SELECT ` + storesql.FileChunkColumns + `
+	FROM file_blocks
+	WHERE id >= $1 COLLATE "C" AND id < $2 COLLATE "C"
+	ORDER BY id COLLATE "C" ASC`
+
+// enumerateHashesQuery is ChunkQueries.EnumerateHashes for postgres; what the
+// union must cover, and why UNION ALL, lives on that field. The manifest arm
+// renders the BYTEA hash column as hex with encode(..., 'hex').
+const enumerateHashesQuery = `SELECT hash FROM file_blocks
+UNION ALL
+SELECT encode(fbr.hash, 'hex') FROM file_block_refs fbr
+JOIN inodes i ON fbr.file_id = i.id
+WHERE i.nlink > 0`
 
 // DecrementRefCountAndReap atomically decrements ref_count and, when it hits 0,
 // deletes the row — both statements run inside ONE transaction so the
@@ -86,216 +68,31 @@ func (s *PostgresMetadataStore) DecrementRefCountAndReap(ctx context.Context, id
 	return newCount, nil
 }
 
-// decrementAndReapManyTx applies the -1 UPDATE and the reap-at-zero DELETE to
-// the whole id set in two statements, so a rollback undoes both. The
-// `ref_count = 0` predicate means a bump that landed between the two leaves that
-// row alive, and an id with no row is a no-op — the same outcomes
-// decrementAndReapTx produces one row at a time.
-func decrementAndReapManyTx(ctx context.Context, x storesql.Executor, ids []string) error {
-	if len(ids) == 0 {
-		return nil
-	}
-	if _, err := x.Exec(ctx,
-		`UPDATE file_blocks SET ref_count = GREATEST(ref_count - 1, 0) WHERE id = ANY($1)`,
-		ids); err != nil {
-		return fmt.Errorf("decrement ref count: %w", err)
-	}
-	if _, err := x.Exec(ctx,
-		`DELETE FROM file_blocks WHERE id = ANY($1) AND ref_count = 0`,
-		ids); err != nil {
-		return fmt.Errorf("reap zero-ref block: %w", err)
-	}
-	return nil
+// DecrementRefCountAndReapMany runs the batched decrement + reap on this
+// transaction's executor so a subsequent rollback undoes the whole set. Going
+// through the pool would let the two statements autocommit separately and
+// survive that rollback.
+func (tx *postgresTransaction) DecrementRefCountAndReapMany(ctx context.Context, ids []string) error {
+	return storesql.DecrementAndReapMany(ctx, tx.conn(), pgDialect, ids)
 }
 
-// AddRef atomically bumps RefCount on the FileChunk row(s) indexed by the
-// given content hash, implementing the FileChunkStore.AddRef contract used by
-// the in-memory hash dedup LRU hit path. Returns metadata.ErrUnknownHash when
-// no row matches; callers fall back to the full Put path on that sentinel.
+// AddRef bumps RefCount on the row(s) indexed by the given content hash,
+// implementing the FileChunkStore.AddRef contract the in-memory dedup LRU hit
+// path uses. Returns metadata.ErrUnknownHash when no row matches; callers fall
+// back to the full Put path on that sentinel. The reasoning about atomicity,
+// Remote-only scoping and multi-row tolerance lives on the shared
+// implementation in store/sql.
 func (s *PostgresMetadataStore) AddRef(ctx context.Context, hash block.ContentHash, _ string, _ block.ChunkRef) error {
 	// payloadID + blockRef are accepted for future GC traceability; this
 	// backend records ref count only, so they are intentionally blanked.
 	return s.Core.AddRef(ctx, hash)
 }
 
-// listFileChunksQuery takes the bounds of block.PayloadPrefixRange and is a
-// prefilter; block.ChunksForPayload decides membership and order.
-//
-// The range is compared and ordered in byte collation, not the database
-// default: the bounds only bracket the prefix under byte ordering, and a
-// byte-ordered id column lets the primary-key index seek the range instead of
-// filtering the whole table.
-const listFileChunksQuery = `SELECT ` + fileChunkColumns + `
-	FROM file_blocks
-	WHERE id >= $1 COLLATE "C" AND id < $2 COLLATE "C"
-	ORDER BY id COLLATE "C" ASC`
-
-// enumerateHashesQuery is the GC mark live-set query. It UNIONs the CAS index
-// (file_blocks.hash, VARCHAR hex) with the per-file manifest
-// (file_block_refs.hash, BYTEA → encode hex) so the live set is a strict
-// SUPERSET of both structures, so a hash present in only one (e.g. a manifest
-// row whose CAS index row was never written or already reaped) still keeps its
-// chunk live. The manifest arm is filtered to nlink>0 inodes (#1433): once a
-// file is unlinked its manifest rows linger but the payload is dead, so
-// including them would pin orphaned chunks live forever and the sweep could
-// never reclaim them. Snapshot-held blocks are protected independently by the
-// GC HoldProvider (on-disk snapshot manifests), not by this union. NULL
-// hashes (legacy pre-CAS file_blocks rows) are emitted as the zero ContentHash
-// and skipped by the mark phase; file_block_refs.hash is NOT NULL.
-//
-// UNION ALL, not UNION: the consumer (GC mark phase) dedupes hashes into a set,
-// so cross-source and intra-source duplicates are harmless. UNION would force an
-// expensive sort/hash-aggregate to dedupe at the query layer for no benefit.
-const enumerateHashesQuery = `SELECT hash FROM file_blocks
-UNION ALL
-SELECT encode(fbr.hash, 'hex') FROM file_block_refs fbr
-JOIN inodes i ON fbr.file_id = i.id
-WHERE i.nlink > 0`
-
-// EnumeratePayloads streams every distinct payloadID that has at least one
-// FileChunk row through fn. FileChunk row IDs have the form
-// {payloadID}/{chunkOffset}; the payloadID is everything BEFORE THE LAST '/'
-// (payloadIDs are BuildPayloadID(shareName, filePath) and themselves contain
-// slashes, so a split_part on the FIRST slash would truncate every
-// subdirectory file to its share name). We therefore parse the payloadID in
-// Go on the last slash rather than in SQL.
-//
-// The rows cursor is fully drained and CLOSED before any fn callback runs:
-// fn may issue further reads, so we collect first then call — matching the
-// sqlite/badger/memory backends. (The pgx pool is multi-connection, so this
-// is for correctness/consistency rather than deadlock avoidance.)
-func (s *PostgresMetadataStore) EnumeratePayloads(ctx context.Context, fn func(payloadID string) error) error {
-	const query = `SELECT DISTINCT id FROM file_blocks`
-	ids, err := s.collectFileChunkIDs(ctx, query)
-	if err != nil {
-		return err
-	}
-
-	seen := make(map[string]struct{}, len(ids))
-	for _, id := range ids {
-		if err := ctx.Err(); err != nil {
-			return fmt.Errorf("enumerate payloads: %w", err)
-		}
-		i := strings.LastIndex(id, "/")
-		if i < 0 {
-			continue
-		}
-		payloadID := id[:i]
-		if _, ok := seen[payloadID]; ok {
-			continue
-		}
-		seen[payloadID] = struct{}{}
-		if err := fn(payloadID); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// EnumerateLivePayloadIDs streams every distinct content_id referenced by a
-// live inode. content_id IS the payloadID. Hardlinks share one inode row, so
-// DISTINCT yields one payloadID per content regardless of link count. nlink=0
-// (unlinked) inodes are excluded (#1433): their payload is dead, so the
-// reconcile must treat it as stranded, not live.
-func (s *PostgresMetadataStore) EnumerateLivePayloadIDs(ctx context.Context, fn func(payloadID string) error) error {
-	const query = `SELECT DISTINCT content_id FROM inodes WHERE content_id IS NOT NULL AND content_id != '' AND nlink > 0`
-	ids, err := s.collectFileChunkIDs(ctx, query)
-	if err != nil {
-		return err
-	}
-	for _, id := range ids {
-		if err := ctx.Err(); err != nil {
-			return fmt.Errorf("enumerate live payloads: %w", err)
-		}
-		if err := fn(id); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// collectFileChunkIDs runs query (which must SELECT a single TEXT id column),
-// scans every id into a slice, and closes the rows cursor before returning.
-func (s *PostgresMetadataStore) collectFileChunkIDs(ctx context.Context, query string) ([]string, error) {
-	rows, err := s.query(ctx, query)
-	if err != nil {
-		return nil, fmt.Errorf("enumerate payloads: query: %w", err)
-	}
-	defer rows.Close()
-	var ids []string
-	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			return nil, fmt.Errorf("enumerate payloads: scan: %w", err)
-		}
-		ids = append(ids, id)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("enumerate payloads: rows: %w", err)
-	}
-	return ids, nil
-}
-
-// ============================================================================
-// Scan Helpers
-// ============================================================================
-
-// ============================================================================
-// Transaction Support
-// ============================================================================
-
-// Ensure postgresTransaction implements FileChunkStore
-var _ block.FileChunkStore = (*postgresTransaction)(nil)
-
-// The FileChunkStore methods on
-// postgresTransaction MUST execute against the txn's own pgx.Tx, not the
-// public store's connection-pool helpers. Previously every method just
-// called `tx.store.X(...)` which routed through the pool — defeating
-// rollback for any caller that bumped RefCount inside WithTransaction
-// then encountered a downstream UpdateAttrs failure (silent
-// leak). All proxies below are now tx-bound; non-mutating
-// helpers keep the pool path because no caller mutates state through them.
-
-// The ref-count mutators below run on the active pgx.Tx so a subsequent
-// rollback undoes them. Production callers reach them through
-// metadataCoordinator when ctx carries an active tx via metadata.WithTx.
-
-// DecrementRefCountAndReapMany is the batched form, applied to the whole id set
-// in two statements on the active transaction.
-func (tx *postgresTransaction) DecrementRefCountAndReapMany(ctx context.Context, ids []string) error {
-	return decrementAndReapManyTx(ctx, tx.conn(), ids)
-}
-
-// AddRef bumps the ref count keyed by hash on the active transaction, giving
-// the LRU hit path rollback parity. Returns metadata.ErrUnknownHash on no match.
+// AddRef bumps ref_count keyed by hash on the active transaction so a
+// subsequent rollback undoes it, giving the LRU hit path rollback parity.
+// Returns metadata.ErrUnknownHash when no row matches.
 func (tx *postgresTransaction) AddRef(ctx context.Context, hash block.ContentHash, _ string, _ block.ChunkRef) error {
-	// payloadID + blockRef accepted for future GC traceability; intentionally
-	// blanked, as on the pool path.
+	// payloadID + blockRef are accepted for future GC traceability; this
+	// backend records ref count only, so they are intentionally blanked.
 	return tx.Core.AddRef(ctx, hash)
-}
-
-// ListFileChunks and EnumerateFileChunks run on the active transaction, NOT the
-// pool. Going through the pool would open a separate connection that cannot see
-// this transaction's uncommitted writes, so a Put followed by a List inside one
-// WithTransaction would miss the pending row — a read-after-write violation.
-// That is the whole reason these take an Executor rather than being called on
-// the store.
-
-// The file_blocks table schema lives in
-// pkg/metadata/store/postgres/migrations/000010_file_blocks.up.sql.
-
-// InjectCorruptHashRow stores a file_blocks row whose hash column holds a
-// syntactically malformed value. Test-only: implements the storetest
-// CorruptHashInjector capability so the conformance suite can exercise
-// fail-closed enumeration. The TEXT column lets us bypass the
-// Put contract that always serializes a valid ContentHash.String().
-func (s *PostgresMetadataStore) InjectCorruptHashRow(ctx context.Context, blockID string, badHash string) error {
-	now := time.Now()
-	_, err := s.exec(ctx, insertFileChunk+` ON CONFLICT (id) DO UPDATE SET hash = EXCLUDED.hash`,
-		blockID, badHash, uint32(64), uint32(0), uint32(1), now, now, int(block.BlockStateRemote), nil,
-	)
-	if err != nil {
-		return fmt.Errorf("inject corrupt hash row: %w", err)
-	}
-	return nil
 }

--- a/pkg/metadata/store/sql/dialect.go
+++ b/pkg/metadata/store/sql/dialect.go
@@ -217,6 +217,10 @@ type ChunkQueries struct {
 	// SelectByHash selects one finalized (Remote) chunk row by content hash.
 	// One parameter: the hex hash.
 	SelectByHash string
+	// Insert inserts one chunk row and stops there, leaving the caller to
+	// append its own conflict clause. Nine parameters, in FileChunkColumns
+	// order. Upsert is this plus FileChunkUpsertTail.
+	Insert string
 	// Upsert inserts or updates a chunk row. Nine parameters, in the column
 	// order of the chunk table.
 	Upsert string
@@ -227,6 +231,10 @@ type ChunkQueries struct {
 	// DecrementRef decrements one row's ref_count, floored at zero, and
 	// returns the new value. One parameter: the id.
 	DecrementRef string
+	// DecrementRefMany decrements ref_count, floored at zero, and carries NO
+	// predicate: the caller appends the IN-list naming the rows it applies to.
+	// Spelled MAX on sqlite and GREATEST on postgres.
+	DecrementRefMany string
 	// AddRef bumps ref_count on every Remote row carrying a content hash.
 	// One parameter: the hex hash.
 	AddRef string
@@ -235,7 +243,31 @@ type ChunkQueries struct {
 	ReapZeroRef string
 	// ListByPayloadRange selects the chunk rows whose ids fall in a payload's
 	// prefix range, in byte order. Two parameters: the low and high bounds.
+	//
+	// The bounds are block.PayloadPrefixRange's and only prefilter;
+	// block.ChunksForPayload decides membership and order. Both dialects
+	// compare and order in byte collation rather than the database default:
+	// the bounds bracket the prefix only under byte ordering, and a
+	// byte-ordered id column lets the primary-key index seek the range instead
+	// of filtering the whole table.
 	ListByPayloadRange string
 	// EnumerateHashes selects the GC live set. No parameters.
+	//
+	// It UNIONs the CAS index (file_blocks.hash, stored as hex text) with the
+	// per-file manifest (file_block_refs.hash, raw bytes rendered as hex) so
+	// the live set is a strict SUPERSET of both structures, and a hash present
+	// in only one — a manifest row whose CAS index row was never written or
+	// was already reaped — still keeps its chunk live. The manifest arm is
+	// filtered to nlink>0 inodes: once a file is unlinked its manifest rows
+	// linger but the payload is dead, so including them would pin orphaned
+	// chunks live forever and the sweep could never reclaim them.
+	// Snapshot-held blocks are protected independently by the GC HoldProvider
+	// (on-disk snapshot manifests), not by this union. NULL hashes (legacy
+	// pre-CAS file_blocks rows) are emitted as the zero ContentHash and
+	// skipped by the mark phase; file_block_refs.hash is NOT NULL.
+	//
+	// UNION ALL, not UNION: the consumer dedupes hashes into a set, so
+	// cross-source and intra-source duplicates are harmless, while UNION would
+	// force an expensive sort/hash-aggregate at the query layer for no benefit.
 	EnumerateHashes string
 }

--- a/pkg/metadata/store/sql/objects.go
+++ b/pkg/metadata/store/sql/objects.go
@@ -1,0 +1,201 @@
+package sql
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+)
+
+// objects carries the file_blocks surface that is more than a single-row read
+// or write: the payload enumerations the GC mark and the size reconcile walk,
+// the batched decrement-and-reap a truncate or unlink drives, and the test-only
+// corrupt-row injector.
+//
+// The plain CRUD half lives in chunks.go. Schema lives in
+// migrations/000010_file_blocks.up.sql.
+
+// FileChunkColumns is the file_blocks column list every chunk read and write
+// names, in the order ScanFileChunk reads them. Naming it once is what keeps a
+// column added to one statement from being missed by the others, or by the
+// scan. Both dialects spell the list identically, so it sits here rather than
+// in a query struct.
+const FileChunkColumns = `id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at`
+
+// FileChunkUpsertTail is the conflict clause each dialect appends to its own
+// insert to build ChunkQueries.Upsert. Only the insert's placeholders differ,
+// so the clause itself is spelled once here.
+//
+// It omits ref_count from the update list so a concurrent IncrementRefCount /
+// DecrementRefCount (which run as atomic SQL `+1` / `-1` UPDATEs) cannot be
+// silently overwritten by a Put carrying a stale in-memory RefCount. The INSERT
+// path still writes the caller's value verbatim, which is the contract for a new
+// row; for an existing row RefCount mutates exclusively through
+// Increment/Decrement. hash uses COALESCE so a zero-hash Put never NULLs a
+// previously-persisted good hash.
+const FileChunkUpsertTail = `
+	ON CONFLICT (id) DO UPDATE SET
+		hash = COALESCE(EXCLUDED.hash, file_blocks.hash),
+		data_size = EXCLUDED.data_size,
+		start_offset = EXCLUDED.start_offset,
+		last_access = EXCLUDED.last_access,
+		state = EXCLUDED.state,
+		last_sync_attempt_at = EXCLUDED.last_sync_attempt_at`
+
+// EnumeratePayloads streams every distinct payloadID that has at least one
+// FileChunk row through fn. FileChunk row IDs have the form
+// {payloadID}/{chunkOffset}; the payloadID is everything BEFORE THE LAST '/'
+// (payloadIDs are BuildPayloadID(shareName, filePath) and themselves contain
+// slashes, so splitting on the FIRST slash would truncate every subdirectory
+// file to its share name). We therefore parse the payloadID in Go on the last
+// slash rather than in SQL.
+//
+// The rows cursor is fully drained and CLOSED before any fn callback runs.
+// The sqlite pool is MaxOpenConns(1) and the warm/stats callbacks issue further
+// reads (ListFileChunks) that need that single connection, so calling fn with
+// the cursor still open would deadlock. This collect-then-call shape also
+// matches the badger and memory backends.
+func (c *Core) EnumeratePayloads(ctx context.Context, fn func(payloadID string) error) error {
+	const query = `SELECT DISTINCT id FROM file_blocks`
+	ids, err := c.collectIDs(ctx, query)
+	if err != nil {
+		return err
+	}
+
+	seen := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("enumerate payloads: %w", err)
+		}
+		i := strings.LastIndex(id, "/")
+		if i < 0 {
+			continue
+		}
+		payloadID := id[:i]
+		if _, ok := seen[payloadID]; ok {
+			continue
+		}
+		seen[payloadID] = struct{}{}
+		if err := fn(payloadID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// EnumerateLivePayloadIDs streams every distinct content_id referenced by a
+// live inode. content_id IS the payloadID, so no id-splitting is needed.
+// Hardlinks share one inode row, so DISTINCT yields one payloadID regardless of
+// link count. nlink=0 (unlinked) inodes are excluded: their payload is dead, so
+// the reconcile must treat it as stranded, not live.
+func (c *Core) EnumerateLivePayloadIDs(ctx context.Context, fn func(payloadID string) error) error {
+	const query = `SELECT DISTINCT content_id FROM inodes WHERE content_id IS NOT NULL AND content_id != '' AND nlink > 0`
+	ids, err := c.collectIDs(ctx, query)
+	if err != nil {
+		return err
+	}
+	for _, id := range ids {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("enumerate live payloads: %w", err)
+		}
+		if err := fn(id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// collectIDs runs query (which must SELECT a single TEXT id column), scans
+// every id into a slice, and closes the rows cursor before returning so the
+// caller may safely issue further queries on the single-connection pool. It
+// serves both the file_blocks and the inodes enumeration.
+func (c *Core) collectIDs(ctx context.Context, query string) ([]string, error) {
+	rows, err := c.X.Query(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("enumerate payloads: query: %w", err)
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("enumerate payloads: scan: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("enumerate payloads: rows: %w", err)
+	}
+	return ids, nil
+}
+
+// DecrementAndReapMany applies the -1 UPDATE and the reap-at-zero DELETE to a
+// whole id set, two statements per batch instead of two per id. The
+// `ref_count = 0` predicate on the DELETE means a bump that landed between the
+// two statements leaves that row alive, and an id with no row is a no-op — the
+// same outcomes Core.DecrementRefCountAndReap produces one row at a time. An
+// empty set runs no statement at all.
+//
+// It takes its executor rather than riding on Core because the pair only has
+// its meaning together: a method on Core would be promoted onto the pool-backed
+// store as well, where the UPDATE and the DELETE autocommit separately and a
+// rollback can no longer undo the decrement. Passing the executor keeps the
+// caller's transaction visible at the call site.
+//
+// Callers must supply distinct ids, which is what metadata.FileChunkStore
+// documents: a repeated id splits across two batches decrements its row twice.
+func DecrementAndReapMany(ctx context.Context, x Executor, d Dialect, ids []string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	for start := 0; start < len(ids); start += maxBoundParams {
+		batch := ids[start:min(start+maxBoundParams, len(ids))]
+		in, args := fileChunkIDInList(d, batch)
+		if _, err := x.Exec(ctx, d.Chunks().DecrementRefMany+in, args...); err != nil {
+			return fmt.Errorf("decrement ref count: %w", err)
+		}
+		// The DELETE needs no dialect entry: it carries no placeholder of its
+		// own, so both spell it identically.
+		if _, err := x.Exec(ctx, `DELETE FROM file_blocks`+in+` AND ref_count = 0`, args...); err != nil {
+			return fmt.Errorf("reap zero-ref block: %w", err)
+		}
+	}
+	return nil
+}
+
+// fileChunkIDInList renders ` WHERE id IN (?, ...)` for one batch of ids
+// together with the arguments to bind. The decrement and the reap share both,
+// so the two statements resolve the same set. One id binds one parameter and
+// nothing else does, so a batch of maxBoundParams ids is the ceiling.
+func fileChunkIDInList(d Dialect, batch []string) (string, []any) {
+	var sb strings.Builder
+	sb.WriteString(` WHERE id IN (`)
+	args := make([]any, 0, len(batch))
+	for i, id := range batch {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		sb.WriteString(d.Placeholder(i + 1))
+		args = append(args, id)
+	}
+	sb.WriteByte(')')
+	return sb.String(), args
+}
+
+// InjectCorruptHashRow stores a file_blocks row whose hash column holds a
+// syntactically malformed value. Test-only: it implements the storetest
+// CorruptHashInjector capability so the conformance suite can exercise
+// fail-closed enumeration. The TEXT column lets us bypass the Put contract that
+// always serializes a valid ContentHash.String().
+func (c *Core) InjectCorruptHashRow(ctx context.Context, blockID string, badHash string) error {
+	now := time.Now()
+	_, err := c.X.Exec(ctx, c.D.Chunks().Insert+` ON CONFLICT (id) DO UPDATE SET hash = EXCLUDED.hash`,
+		blockID, badHash, uint32(64), uint32(0), uint32(1), now, now, int(block.BlockStateRemote), nil,
+	)
+	if err != nil {
+		return fmt.Errorf("inject corrupt hash row: %w", err)
+	}
+	return nil
+}

--- a/pkg/metadata/store/sqlite/dialect.go
+++ b/pkg/metadata/store/sqlite/dialect.go
@@ -26,12 +26,14 @@ func (dialect) IsNoRows(err error) bool { return errors.Is(err, sql.ErrNoRows) }
 func (dialect) Chunks() *storesql.ChunkQueries { return &chunkQueries }
 
 var chunkQueries = storesql.ChunkQueries{
-	SelectByID:   `SELECT ` + fileChunkColumns + ` FROM file_blocks WHERE id = ?1`,
-	SelectByHash: `SELECT ` + fileChunkColumns + ` FROM file_blocks WHERE hash = ?1 AND state = 2 /* Remote */`,
-	Upsert:       putFileChunkQuery,
-	Delete:       `DELETE FROM file_blocks WHERE id = ?1`,
-	IncrementRef: `UPDATE file_blocks SET ref_count = ref_count + 1 WHERE id = ?1`,
-	DecrementRef: `UPDATE file_blocks SET ref_count = MAX(ref_count - 1, 0) WHERE id = ?1 RETURNING ref_count`,
+	SelectByID:       `SELECT ` + storesql.FileChunkColumns + ` FROM file_blocks WHERE id = ?1`,
+	SelectByHash:     `SELECT ` + storesql.FileChunkColumns + ` FROM file_blocks WHERE hash = ?1 AND state = 2 /* Remote */`,
+	Insert:           insertFileChunk,
+	Upsert:           insertFileChunk + storesql.FileChunkUpsertTail,
+	Delete:           `DELETE FROM file_blocks WHERE id = ?1`,
+	IncrementRef:     `UPDATE file_blocks SET ref_count = ref_count + 1 WHERE id = ?1`,
+	DecrementRef:     `UPDATE file_blocks SET ref_count = MAX(ref_count - 1, 0) WHERE id = ?1 RETURNING ref_count`,
+	DecrementRefMany: `UPDATE file_blocks SET ref_count = MAX(ref_count - 1, 0)`,
 	// state = 2 (Remote) scoping mirrors SelectByHash and the memory/badger
 	// backends: a Pending row is not a valid dedup donor.
 	AddRef:             `UPDATE file_blocks SET ref_count = ref_count + 1 WHERE hash = ?1 AND state = 2 /* Remote */`,

--- a/pkg/metadata/store/sqlite/objects.go
+++ b/pkg/metadata/store/sqlite/objects.go
@@ -1,40 +1,47 @@
+// FileChunkStore support for the SQLite metadata store: content-addressed file
+// chunk tracking for deduplication and caching, over the file_blocks table.
+//
+// The statements and the bodies that run them live in store/sql, promoted onto
+// both the store and its transaction through the embedded Core. What stays here
+// is the dialect's own SQL text and the two entry points that must not be
+// promoted: DecrementRefCountAndReap, which needs a transaction Core is not one
+// of, and DecrementRefCountAndReapMany, whose two statements are only atomic
+// when they share the transaction the caller opened.
 package sqlite
 
 import (
 	"context"
-	"fmt"
-	"strings"
-	"time"
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
+
+	storesql "github.com/marmos91/dittofs/pkg/metadata/store/sql"
 )
 
-// ============================================================================
-// FileChunkStore Implementation for SQLite Store
-// ============================================================================
-//
-// This file implements the FileChunkStore interface for the SQLite metadata store.
-// It provides content-addressed file chunk tracking for deduplication and caching.
-//
-// The FileChunkStore interface is narrowed to 6 methods. The backend
-// retains the legacy GetFileChunk + ListFileChunks helpers as
-// concrete methods on the struct (not on the public interface) for
-// engine-internal callers.
-//
-// Table:
-//   - file_blocks: File block data with UUID as primary key and hash index
-//
-// Thread Safety: All operations use SQLite transactions for ACID guarantees.
-//
-// ============================================================================
-
-// Ensure SQLiteMetadataStore implements FileChunkStore
+// Both the store and its transaction satisfy the interface through the
+// promoted Core methods.
 var _ block.FileChunkStore = (*SQLiteMetadataStore)(nil)
+var _ block.FileChunkStore = (*sqliteTransaction)(nil)
 
-// ============================================================================
-// FileChunk Operations
-// ============================================================================
+// insertFileChunk is the INSERT the row writers share; each appends its own
+// ON CONFLICT clause.
+const insertFileChunk = `INSERT INTO file_blocks (` + storesql.FileChunkColumns + `) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)`
+
+// listFileChunksQuery is ChunkQueries.ListByPayloadRange for sqlite; what the
+// bounds mean, and why the byte collation, lives on that field.
+const listFileChunksQuery = `SELECT ` + storesql.FileChunkColumns + `
+	FROM file_blocks
+	WHERE id >= ?1 COLLATE BINARY AND id < ?2 COLLATE BINARY
+	ORDER BY id COLLATE BINARY ASC`
+
+// enumerateHashesQuery is ChunkQueries.EnumerateHashes for sqlite; what the
+// union must cover, and why UNION ALL, lives on that field. The manifest arm
+// renders the BLOB hash column as hex with lower(hex(...)).
+const enumerateHashesQuery = `SELECT hash FROM file_blocks
+UNION ALL
+SELECT lower(hex(fbr.hash)) FROM file_block_refs fbr
+JOIN inodes i ON fbr.file_id = i.id
+WHERE i.nlink > 0`
 
 // DecrementRefCountAndReap atomically decrements ref_count and, when it hits 0,
 // deletes the row — both statements run inside ONE transaction so the
@@ -56,181 +63,25 @@ func (s *SQLiteMetadataStore) DecrementRefCountAndReap(ctx context.Context, id s
 	return newCount, nil
 }
 
-// The bodies below carry the file_blocks CRUD SQL once. Both the pool path and
-// the transaction path run them over their own executor, so the two surfaces
-// cannot drift apart.
+// DecrementRefCountAndReapMany runs the batched decrement + reap on this
+// transaction's executor so a subsequent rollback undoes the whole set. Going
+// through the pool would let the two statements autocommit separately and
+// survive that rollback.
+func (tx *sqliteTransaction) DecrementRefCountAndReapMany(ctx context.Context, ids []string) error {
+	return storesql.DecrementAndReapMany(ctx, tx.tx, sqliteDialect, ids)
+}
 
-// fileChunkColumns is the file_blocks column list every chunk read and write
-// names, in the order scanFileChunk reads them. Naming it once is what keeps a
-// column added to one query from being missed by the others, or by the scan.
-const fileChunkColumns = `id, hash, data_size, start_offset, ref_count, last_access, created_at, state, last_sync_attempt_at`
-
-// insertFileChunk is the INSERT the row writers share; each appends its own
-// ON CONFLICT clause.
-const insertFileChunk = `INSERT INTO file_blocks (` + fileChunkColumns + `) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)`
-
-// putFileChunkQuery omits ref_count from the ON CONFLICT update list so a
-// concurrent IncrementRefCount / DecrementRefCount (atomic SQL +1 / -1 UPDATEs)
-// cannot be overwritten by a stale in-memory RefCount; the INSERT path still
-// writes the caller's value verbatim. hash uses COALESCE so a zero-hash Put
-// never NULLs a previously persisted good hash.
-const putFileChunkQuery = insertFileChunk + `
-	ON CONFLICT (id) DO UPDATE SET
-		hash = COALESCE(EXCLUDED.hash, file_blocks.hash),
-		data_size = EXCLUDED.data_size,
-		start_offset = EXCLUDED.start_offset,
-		last_access = EXCLUDED.last_access,
-		state = EXCLUDED.state,
-		last_sync_attempt_at = EXCLUDED.last_sync_attempt_at`
-
-// AddRef bumps RefCount on the rows indexed by the given content hash,
+// AddRef bumps RefCount on the row(s) indexed by the given content hash,
 // implementing the FileChunkStore.AddRef contract the in-memory dedup LRU hit
-// path uses. Returns metadata.ErrUnknownHash when no row matches; the caller
-// falls back to the full Put path on that sentinel. The reasoning about
-// atomicity, Remote-only scoping and multi-row tolerance lives on the shared
+// path uses. Returns metadata.ErrUnknownHash when no row matches; callers fall
+// back to the full Put path on that sentinel. The reasoning about atomicity,
+// Remote-only scoping and multi-row tolerance lives on the shared
 // implementation in store/sql.
 func (s *SQLiteMetadataStore) AddRef(ctx context.Context, hash block.ContentHash, _ string, _ block.ChunkRef) error {
 	// payloadID + blockRef are accepted for future GC traceability; this
 	// backend records ref count only, so they are intentionally blanked.
 	return s.Core.AddRef(ctx, hash)
 }
-
-// listFileChunksQuery takes the bounds of block.PayloadPrefixRange and is a
-// prefilter; block.ChunksForPayload decides membership and order.
-//
-// The range is compared and ordered in byte collation, not the database
-// default: the bounds only bracket the prefix under byte ordering, and a
-// byte-ordered id column lets the primary-key index seek the range instead of
-// filtering the whole table.
-const listFileChunksQuery = `SELECT ` + fileChunkColumns + `
-	FROM file_blocks
-	WHERE id >= ?1 COLLATE BINARY AND id < ?2 COLLATE BINARY
-	ORDER BY id COLLATE BINARY ASC`
-
-// enumerateHashesQuery is the GC mark live-set query. It UNIONs the CAS index
-// (file_blocks.hash, VARCHAR hex) with the per-file manifest
-// (file_block_refs.hash, BYTEA → encode hex) so the live set is a strict
-// SUPERSET of both structures, so a hash present in only one (e.g. a manifest
-// row whose CAS index row was never written or already reaped) still keeps its
-// chunk live. The manifest arm is filtered to nlink>0 inodes (#1433): once a
-// file is unlinked its manifest rows linger but the payload is dead, so
-// including them would pin orphaned chunks live forever and the sweep could
-// never reclaim them. Snapshot-held blocks are protected independently by the
-// GC HoldProvider (on-disk snapshot manifests), not by this union. NULL
-// hashes (legacy pre-CAS file_blocks rows) are emitted as the zero ContentHash
-// and skipped by the mark phase; file_block_refs.hash is NOT NULL.
-//
-// UNION ALL, not UNION: the consumer (GC mark phase) dedupes hashes into a set,
-// so cross-source and intra-source duplicates are harmless. UNION would force an
-// expensive sort/hash-aggregate to dedupe at the query layer for no benefit.
-const enumerateHashesQuery = `SELECT hash FROM file_blocks
-UNION ALL
-SELECT lower(hex(fbr.hash)) FROM file_block_refs fbr
-JOIN inodes i ON fbr.file_id = i.id
-WHERE i.nlink > 0`
-
-// EnumeratePayloads streams every distinct payloadID that has at least one
-// FileChunk row through fn. FileChunk row IDs have the form
-// {payloadID}/{chunkOffset}; the payloadID is everything BEFORE THE LAST '/'
-// (payloadIDs are BuildPayloadID(shareName, filePath) and themselves contain
-// slashes, so a substr/split on the FIRST slash would truncate every
-// subdirectory file to its share name). We therefore parse the payloadID in
-// Go on the last slash rather than in SQL.
-//
-// The rows cursor is fully drained and CLOSED before any fn callback runs.
-// The SQLite pool is MaxOpenConns(1), and warm/stats fn callbacks issue
-// further reads (ListFileChunks) that need that single connection — calling fn
-// while the cursor is still open would deadlock. This collect-then-call shape
-// also matches the badger/memory backends.
-func (s *SQLiteMetadataStore) EnumeratePayloads(ctx context.Context, fn func(payloadID string) error) error {
-	const query = `SELECT DISTINCT id FROM file_blocks`
-	ids, err := s.collectFileChunkIDs(ctx, query)
-	if err != nil {
-		return err
-	}
-
-	seen := make(map[string]struct{}, len(ids))
-	for _, id := range ids {
-		if err := ctx.Err(); err != nil {
-			return fmt.Errorf("enumerate payloads: %w", err)
-		}
-		i := strings.LastIndex(id, "/")
-		if i < 0 {
-			continue
-		}
-		payloadID := id[:i]
-		if _, ok := seen[payloadID]; ok {
-			continue
-		}
-		seen[payloadID] = struct{}{}
-		if err := fn(payloadID); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// EnumerateLivePayloadIDs streams every distinct content_id referenced by a
-// live inode. content_id IS the payloadID, so no id-splitting is needed.
-// Hardlinks share one inode row, so DISTINCT yields one payloadID regardless of
-// link count. nlink=0 (unlinked) inodes are excluded (#1433): their payload is
-// dead, so the reconcile must treat it as stranded, not live.
-func (s *SQLiteMetadataStore) EnumerateLivePayloadIDs(ctx context.Context, fn func(payloadID string) error) error {
-	const query = `SELECT DISTINCT content_id FROM inodes WHERE content_id IS NOT NULL AND content_id != '' AND nlink > 0`
-	ids, err := s.collectFileChunkIDs(ctx, query)
-	if err != nil {
-		return err
-	}
-	for _, id := range ids {
-		if err := ctx.Err(); err != nil {
-			return fmt.Errorf("enumerate live payloads: %w", err)
-		}
-		if err := fn(id); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// collectFileChunkIDs runs query (which must SELECT a single TEXT id column),
-// scans every id into a slice, and closes the rows cursor before returning so
-// the caller may safely issue further queries on the single-connection pool.
-func (s *SQLiteMetadataStore) collectFileChunkIDs(ctx context.Context, query string) ([]string, error) {
-	rows, err := s.query(ctx, query)
-	if err != nil {
-		return nil, fmt.Errorf("enumerate payloads: query: %w", err)
-	}
-	defer rows.Close()
-	var ids []string
-	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			return nil, fmt.Errorf("enumerate payloads: scan: %w", err)
-		}
-		ids = append(ids, id)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("enumerate payloads: rows: %w", err)
-	}
-	return ids, nil
-}
-
-// ============================================================================
-// Scan Helpers
-// ============================================================================
-
-// ============================================================================
-// Transaction Support
-// ============================================================================
-
-// Ensure sqliteTransaction implements FileChunkStore
-var _ block.FileChunkStore = (*sqliteTransaction)(nil)
-
-// Every FileChunkStore method below runs on the transaction's own executor,
-// never the store's pool helpers: a pool connection cannot see the
-// transaction's uncommitted writes and would survive its rollback, so a caller
-// that bumped RefCount inside WithTransaction and then hit a downstream
-// UpdateAttrs failure would leak the bump.
 
 // AddRef bumps ref_count keyed by hash on the active transaction so a
 // subsequent rollback undoes it. Returns metadata.ErrUnknownHash when no row
@@ -239,70 +90,4 @@ func (tx *sqliteTransaction) AddRef(ctx context.Context, hash block.ContentHash,
 	// payloadID + blockRef are accepted for future GC traceability; this
 	// backend records ref count only, so they are intentionally blanked.
 	return tx.Core.AddRef(ctx, hash)
-}
-
-// ListFileChunks and EnumerateFileChunks run on this transaction's executor,
-// NOT the pool. Going through the pool would open a separate connection that
-// cannot see this transaction's uncommitted writes, so a Put followed by a List
-// inside one WithTransaction would miss the pending row — a read-after-write
-// violation. On SQLite it is worse than a wrong answer: the pool write blocks
-// on the write lock this transaction holds, so it hangs.
-
-// The file_blocks table schema lives in
-// pkg/metadata/store/postgres/migrations/000010_file_blocks.up.sql.
-
-// InjectCorruptHashRow stores a file_blocks row whose hash column holds a
-// syntactically malformed value. Test-only: implements the storetest
-// CorruptHashInjector capability so the conformance suite can exercise
-// fail-closed enumeration. The TEXT column lets us bypass the
-// Put contract that always serializes a valid ContentHash.String().
-func (s *SQLiteMetadataStore) InjectCorruptHashRow(ctx context.Context, blockID string, badHash string) error {
-	now := time.Now()
-	_, err := s.exec(ctx, insertFileChunk+` ON CONFLICT (id) DO UPDATE SET hash = EXCLUDED.hash`,
-		blockID, badHash, uint32(64), uint32(0), uint32(1), now, now, int(block.BlockStateRemote), nil,
-	)
-	if err != nil {
-		return fmt.Errorf("inject corrupt hash row: %w", err)
-	}
-	return nil
-}
-
-// decrementAndReapManyTx applies the -1 UPDATE and the reap-at-zero DELETE to a
-// whole id set, two statements per batch instead of two per id. The
-// `ref_count = 0` predicate on the DELETE means a bump that landed between the
-// two statements leaves that row alive, and an id with no row is a no-op — the
-// same outcomes decrementAndReapTx produces one row at a time. SQLite caps how
-// many parameters one statement may bind, so a large set runs as several
-// batches.
-func decrementAndReapManyTx(ctx context.Context, tx execer, ids []string) error {
-	const maxIDsPerStatement = 500
-	for len(ids) > 0 {
-		batch := ids[:min(len(ids), maxIDsPerStatement)]
-		ids = ids[len(batch):]
-
-		args := make([]any, len(batch))
-		for i, id := range batch {
-			args[i] = id
-		}
-		in := " WHERE id IN (?" + strings.Repeat(",?", len(batch)-1) + ")"
-
-		if _, err := tx.Exec(ctx,
-			`UPDATE file_blocks SET ref_count = MAX(ref_count - 1, 0)`+in, args...); err != nil {
-			return fmt.Errorf("decrement ref count: %w", err)
-		}
-		if _, err := tx.Exec(ctx,
-			`DELETE FROM file_blocks`+in+` AND ref_count = 0`, args...); err != nil {
-			return fmt.Errorf("reap zero-ref block: %w", err)
-		}
-	}
-	return nil
-}
-
-// DecrementRefCountAndReapMany runs the batched decrement + reap on the active
-// transaction so a subsequent rollback undoes the whole set.
-func (tx *sqliteTransaction) DecrementRefCountAndReapMany(ctx context.Context, ids []string) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	return decrementAndReapManyTx(ctx, tx.tx, ids)
 }

--- a/pkg/metadata/storetest/file_block_ops.go
+++ b/pkg/metadata/storetest/file_block_ops.go
@@ -376,6 +376,36 @@ func testDecrementRefCountAndReapMany(t *testing.T, factory StoreFactory) {
 		}
 	})
 
+	// Seeding at refcount 1 above cannot see a split that OVERLAPS: a boundary
+	// id landing in two batches is decremented twice, but the floor at zero and
+	// the reap leave exactly the state one decrement leaves. Only a row that
+	// has to survive the call can tell the two apart.
+	t.Run("SpansBatchBoundaryWithSurvivors", func(t *testing.T) {
+		store := factory(t)
+		ctx := t.Context()
+
+		ids := make([]string, 1201)
+		for i := range ids {
+			ids[i] = fmt.Sprintf("survive/%d", i*4096)
+		}
+		seedChunkRows(t, store, 2, ids...)
+
+		if err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+			return tx.DecrementRefCountAndReapMany(ctx, ids)
+		}); err != nil {
+			t.Fatalf("DecrementRefCountAndReapMany: %v", err)
+		}
+
+		// One decrement takes every row from two references to one, so the whole
+		// set must still be there. A row decremented twice reaches zero and is
+		// reaped, and the ids either side of a batch edge are where that happens.
+		for _, id := range []string{ids[0], ids[898], ids[899], ids[900], ids[901], ids[1199], ids[1200]} {
+			if !chunkRowPresent(t, store, id) {
+				t.Errorf("row %s was reaped by a single decrement; want it held at refcount 1", id)
+			}
+		}
+	})
+
 	// The whole set is one transaction, so an error raised after the batched
 	// call rolls every row back — no half-reaped manifest.
 	t.Run("RollsBackWholeSet", func(t *testing.T) {

--- a/pkg/metadata/storetest/file_block_ops.go
+++ b/pkg/metadata/storetest/file_block_ops.go
@@ -336,6 +336,46 @@ func testDecrementRefCountAndReapMany(t *testing.T, factory StoreFactory) {
 		}
 	})
 
+	// A set larger than one statement's bound-parameter ceiling still reaps
+	// every row. The SQL backends split it into several IN-list batches, so an
+	// off-by-one in the split leaves a tail of rows alive.
+	t.Run("SpansBatchBoundary", func(t *testing.T) {
+		store := factory(t)
+		ctx := t.Context()
+
+		// Comfortably past the 900-parameter ceiling the SQL backends batch at,
+		// and not a multiple of it, so the last batch is a partial one.
+		ids := make([]string, 1201)
+		for i := range ids {
+			ids[i] = fmt.Sprintf("batch/%d", i*4096)
+		}
+		if err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+			for _, id := range ids {
+				if err := tx.Put(ctx, &block.FileChunk{
+					ID: id, Hash: hashOfSeed(id), State: block.BlockStateRemote,
+					DataSize: 4096, RefCount: 1,
+					LastAccess: time.Now(), CreatedAt: time.Now(),
+				}); err != nil {
+					return err
+				}
+			}
+			return nil
+		}); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+
+		if err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+			return tx.DecrementRefCountAndReapMany(ctx, ids)
+		}); err != nil {
+			t.Fatalf("DecrementRefCountAndReapMany: %v", err)
+		}
+		for _, id := range []string{ids[0], ids[899], ids[900], ids[1199], ids[1200]} {
+			if chunkRowPresent(t, store, id) {
+				t.Errorf("row %s survived the batched reap; want it gone at refcount 0", id)
+			}
+		}
+	})
+
 	// The whole set is one transaction, so an error raised after the batched
 	// call rolls every row back — no half-reaped manifest.
 	t.Run("RollsBackWholeSet", func(t *testing.T) {


### PR DESCRIPTION
Part of #1828 (S6e), on top of #2365.

The two `objects.go` copies — payload enumeration, the id collector, and
ref-count reaping over `file_blocks` — collapse into one implementation in
`store/sql`, the way the manifest delta just did.

The enumerations, the id collector and the corrupt-hash test helper become
`Core` methods. `DecrementAndReapMany` does not: its UPDATE and DELETE are only
atomic inside the caller's transaction, and a `Core` method is promoted onto the
pool-backed store too, where the two statements would autocommit separately. It
takes an executor instead, for the same reason `PutFileChunkRefs` does.
`DecrementRefCountAndReap` keeps its per-dialect `WithTransaction` wrapper at
store level; only its body moved.

### Two differences the copies had drifted into

**Cancellation.** sqlite's reap returned early on a cancelled context; postgres
never looked. The shared body checks, so postgres gains it.

**Batching.** sqlite capped a reap at 500 ids per statement; postgres sent the
whole set in one `= ANY($1)` array with no cap. Both now batch at the ceiling
the manifest delta already uses.

That second one changes postgres's behaviour on malformed input, so it is worth
stating rather than burying: a repeated id split across two batches is
decremented twice, where an array — or a single IN-list — decrements it once.
`metadata.Store` already requires the ids be distinct and gives exactly this
reason ("a backend resolving the whole set in one statement cannot detect the
repeat"), and the only production caller passes them through `distinctOffsets`,
so this is a contract-violation path rather than a live defect. sqlite has
behaved this way all along.

### Dialect text kept as dialect text

`MAX` versus `GREATEST`, `COLLATE BINARY` versus `COLLATE "C"`, and
`lower(hex(...))` versus `encode(..., 'hex')` are real per-dialect spellings, not
drift, so they stay per-dialect. What was duplicated was the *rationale* around
them — the live-set union and the byte-collation range each carried the same
sixteen-line comment in both backends, differing only in a type name. Those now
live once on the query fields they describe.

The per-dialect statements fold into the existing `ChunkQueries`, which already
covers this table, rather than into a second struct beside it: `Insert` sits
next to `Upsert` and `DecrementRefMany` next to `DecrementRef`, where a reader
comparing them will find them together. The identical column list and upsert
tail become shared constants, so the two dialects cannot disagree about the
column order their INSERTs and Scans share.

### Tests

Two cases, because one alone cannot see both ways a batch split goes wrong.

`SpansBatchBoundary` reaps 1201 ids seeded at one reference — past the ceiling
and not a multiple of it — and catches a split that leaves a **gap**: the skipped
row survives at refcount 1.

It is blind to a split that **overlaps**, though, and that is the more dangerous
half. A boundary id landing in two batches is decremented twice, but the floor at
zero and the reap leave exactly the state one decrement leaves, so the final
state is identical. `SpansBatchBoundaryWithSurvivors` seeds the same set at two
references, where a doubly-decremented row reaches zero and is wrongly reaped —
deleting a chunk something still holds.

Both verified against deliberately broken builds, and they are complementary: an
overlapping stride passes the first and fails the second on the boundary row.

Integration-tagged `./pkg/metadata/...` green against a local postgres 16 and
sqlite; `golangci-lint run ./pkg/metadata/...` clean.
