### PR TITLE
refactor(metadata): one synced-hash implementation over both SQL dialects

### DIFF
--- a/pkg/metadata/store/postgres/dialect.go
+++ b/pkg/metadata/store/postgres/dialect.go
@@ -385,19 +385,5 @@ var blockRecordQueries = storesql.BlockRecordQueries{
 // Placeholder implements storesql.Dialect.
 func (dialect) Placeholder(i int) string { return "$" + strconv.Itoa(i) }
 
-func (dialect) SyncedHashes() *storesql.SyncedHashQueries { return &syncedHashQueries }
-
-var syncedHashQueries = storesql.SyncedHashQueries{
-	SelectPresence: `SELECT 1 FROM synced_hashes WHERE hash = $1`,
-	SelectLocator: `
-		SELECT ` + storesql.SyncedLocatorColumns + `
-		FROM synced_hashes
-		WHERE hash = $1`,
-	Mark: `
-		INSERT INTO synced_hashes (hash, synced_at, ` + storesql.SyncedLocatorColumns + `)
-		VALUES ($1, NOW(), $2, $3, $4)
-		ON CONFLICT (hash) DO NOTHING`,
-	Delete: `DELETE FROM synced_hashes WHERE hash = $1`,
-	// NOW() where sqlite spells CURRENT_TIMESTAMP.
-	Now: `NOW()`,
-}
+// Now implements storesql.Dialect.
+func (dialect) Now() string { return "NOW()" }

--- a/pkg/metadata/store/postgres/dialect.go
+++ b/pkg/metadata/store/postgres/dialect.go
@@ -384,3 +384,20 @@ var blockRecordQueries = storesql.BlockRecordQueries{
 
 // Placeholder implements storesql.Dialect.
 func (dialect) Placeholder(i int) string { return "$" + strconv.Itoa(i) }
+
+func (dialect) SyncedHashes() *storesql.SyncedHashQueries { return &syncedHashQueries }
+
+var syncedHashQueries = storesql.SyncedHashQueries{
+	SelectPresence: `SELECT 1 FROM synced_hashes WHERE hash = $1`,
+	SelectLocator: `
+		SELECT ` + storesql.SyncedLocatorColumns + `
+		FROM synced_hashes
+		WHERE hash = $1`,
+	Mark: `
+		INSERT INTO synced_hashes (hash, synced_at, ` + storesql.SyncedLocatorColumns + `)
+		VALUES ($1, NOW(), $2, $3, $4)
+		ON CONFLICT (hash) DO NOTHING`,
+	Delete: `DELETE FROM synced_hashes WHERE hash = $1`,
+	// NOW() where sqlite spells CURRENT_TIMESTAMP.
+	Now: `NOW()`,
+}

--- a/pkg/metadata/store/postgres/pool_helpers.go
+++ b/pkg/metadata/store/postgres/pool_helpers.go
@@ -282,8 +282,5 @@ var (
 	_ storesql.Executor = txExecer{}
 )
 
-// conn returns the Executor over the pool.
-func (s *PostgresMetadataStore) conn() storesql.Executor { return poolExecer{s: s} }
-
 // conn returns the Executor over this transaction's open pgx.Tx.
 func (tx *postgresTransaction) conn() storesql.Executor { return txExecer{tx: tx.tx} }

--- a/pkg/metadata/store/postgres/synced_hash_store.go
+++ b/pkg/metadata/store/postgres/synced_hash_store.go
@@ -1,18 +1,13 @@
-// Per-CAS-hash idempotent presence marker backed by the synced_hashes
-// table. See metadata.SyncedHashStore for the contract; this backend
-// uses a tiny indexed table keyed by the raw 32-byte BLAKE3 hash, with
-// ON CONFLICT DO NOTHING for idempotent MarkSynced and unconditional
-// DELETE for idempotent DeleteSynced.
+// Synced-hash support for the PostgreSQL metadata store. The statements and the
+// bodies that run them live in store/sql, promoted onto both the store and its
+// transaction through the embedded Core. One method stays here:
+// PutSyncedLocators, which spans several statements for a commit large enough
+// to batch, so store/sql exposes it as a function over an executor rather than
+// as a promoted method the pool-backed store would autocommit piecemeal.
 package postgres
 
 import (
 	"context"
-	"database/sql"
-	"errors"
-	"fmt"
-	"time"
-
-	"github.com/jackc/pgx/v5"
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
@@ -20,226 +15,16 @@ import (
 	storesql "github.com/marmos91/dittofs/pkg/metadata/store/sql"
 )
 
-// Compile-time assertions: the Postgres engine and its transaction implement
-// SyncedHashStore.
+// Both the store and its transaction satisfy the interface through the
+// promoted Core methods. Postgres gives read-your-writes within a transaction,
+// so a MarkSynced after a DeleteSynced in the same tx records the new locator.
 var (
 	_ metadata.SyncedHashStore = (*PostgresMetadataStore)(nil)
 	_ metadata.SyncedHashStore = (*postgresTransaction)(nil)
 )
 
-// EnumerateSynced streams every synced marker with its locator and first-mirror
-// time, read straight from the synced_hashes table. The locator columns live in
-// the same row, so yielding them here lets callers resolve locators in a single
-// scan instead of a GetLocator round trip per hash (#1554). A synced row with
-// NULL/empty block columns yields the zero (standalone) locator.
-func (s *PostgresMetadataStore) EnumerateSynced(ctx context.Context, fn func(hash block.ContentHash, loc block.ChunkLocator, syncedAt time.Time) error) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	rows, err := s.query(ctx, `SELECT hash, synced_at, block_id, block_offset, block_length FROM synced_hashes`)
-	if err != nil {
-		return fmt.Errorf("postgres synced enumerate: %w", err)
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var (
-			raw      []byte
-			syncedAt time.Time
-			blockID  sql.NullString
-			off, ln  sql.NullInt64
-		)
-		if err := rows.Scan(&raw, &syncedAt, &blockID, &off, &ln); err != nil {
-			return fmt.Errorf("postgres synced enumerate scan: %w", err)
-		}
-		if len(raw) != len(block.ContentHash{}) {
-			// Defensive: a malformed hash row cannot be reduced to a
-			// ContentHash. Skip it rather than corrupt the sweep candidate.
-			continue
-		}
-		var h block.ContentHash
-		copy(h[:], raw)
-		loc, err := locatorFromCols(blockID, off, ln)
-		if err != nil {
-			return fmt.Errorf("postgres synced enumerate: %w", err)
-		}
-		if err := fn(h, loc, syncedAt); err != nil {
-			return err
-		}
-	}
-	return rows.Err()
-}
-
-// locatorFromCols builds a ChunkLocator from already-scanned (block_id,
-// block_offset, block_length) columns. NULL/empty block_id yields the zero
-// (standalone) locator. Mirrors GetLocator's decode for the folded enumeration.
-func locatorFromCols(blockID sql.NullString, off, length sql.NullInt64) (block.ChunkLocator, error) {
-	if !blockID.Valid || blockID.String == "" {
-		return block.ChunkLocator{}, nil
-	}
-	if !off.Valid || !length.Valid {
-		return block.ChunkLocator{}, fmt.Errorf("corrupt locator row: block_id %q with NULL offset/length", blockID.String)
-	}
-	return block.ChunkLocator{BlockID: blockID.String, WireOffset: off.Int64, WireLength: length.Int64}, nil
-}
-
-// IsSynced reports whether hash has been MarkSynced'd at least once.
-// Returns (false, nil) when no row exists for hash — an absent hash is
-// treated as "not yet synced", not as an error.
-func (s *PostgresMetadataStore) IsSynced(ctx context.Context, hash block.ContentHash) (bool, error) {
-	return isSyncedTx(ctx, s.conn(), "postgres", hash)
-}
-
-// MarkSynced records that hash has been mirrored to remote, persisting loc's
-// block columns atomically.
-func (s *PostgresMetadataStore) MarkSynced(ctx context.Context, hash block.ContentHash, loc block.ChunkLocator) error {
-	return markSyncedTx(ctx, s.conn(), "postgres", hash, loc)
-}
-
-// GetLocator returns the recorded remote locator for hash.
-func (s *PostgresMetadataStore) GetLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error) {
-	return getLocatorTx(ctx, s.conn(), "postgres", hash)
-}
-
-// DeleteSynced removes the synced marker for hash.
-func (s *PostgresMetadataStore) DeleteSynced(ctx context.Context, hash block.ContentHash) error {
-	return deleteSyncedTx(ctx, s.conn(), "postgres", hash)
-}
-
-// ============================================================================
-// Transaction-level SyncedHashStore
-// ============================================================================
-//
-// The transaction variants run the same bodies against the enclosing pgx.Tx
-// instead of the pool. Postgres gives read-your-writes within a transaction, so
-// a MarkSynced after a DeleteSynced in the same tx records the new locator.
-
-func (tx *postgresTransaction) IsSynced(ctx context.Context, hash block.ContentHash) (bool, error) {
-	return isSyncedTx(ctx, tx.conn(), "postgres tx", hash)
-}
-
-func (tx *postgresTransaction) MarkSynced(ctx context.Context, hash block.ContentHash, loc block.ChunkLocator) error {
-	return markSyncedTx(ctx, tx.conn(), "postgres tx", hash, loc)
-}
-
-func (tx *postgresTransaction) GetLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error) {
-	return getLocatorTx(ctx, tx.conn(), "postgres tx", hash)
-}
-
-func (tx *postgresTransaction) DeleteSynced(ctx context.Context, hash block.ContentHash) error {
-	return deleteSyncedTx(ctx, tx.conn(), "postgres tx", hash)
-}
-
-// ============================================================================
-// Shared bodies
-// ============================================================================
-//
-// Each takes the caller's op prefix ("postgres" or "postgres tx") so a failure
-// still records whether it happened on the pool path or inside a transaction.
-// Merging the bodies would otherwise erase that distinction, and it is the one
-// worth keeping here: the failures these report are usually visibility or
-// locking problems, where knowing there was an open transaction is the answer.
-
-// isSyncedTx reports whether a synced marker exists for hash. An absent row is
-// "not yet synced", not an error.
-func isSyncedTx(ctx context.Context, x storesql.Executor, op string, hash block.ContentHash) (bool, error) {
-	var dummy int
-	err := x.QueryRow(ctx, `SELECT 1 FROM synced_hashes WHERE hash = $1`, hash[:]).Scan(&dummy)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return false, nil
-	}
-	if err != nil {
-		return false, fmt.Errorf("%s synced get: %w", op, err)
-	}
-	return true, nil
-}
-
-// markSyncedTx records that hash has been mirrored to remote, persisting loc's
-// block columns atomically. Idempotent via ON CONFLICT (hash) DO NOTHING —
-// re-applying the same hash is a no-op that preserves the first locator. A
-// standalone locator (BlockID == "") leaves the block columns NULL, identical to
-// a pre-locator row, so existing data needs no migration.
-func markSyncedTx(ctx context.Context, x storesql.Executor, op string, hash block.ContentHash, loc block.ChunkLocator) error {
-	blockID, off, length := locatorArgs(loc)
-	if _, err := x.Exec(ctx,
-		`INSERT INTO synced_hashes (hash, synced_at, block_id, block_offset, block_length)
-			VALUES ($1, NOW(), $2, $3, $4)
-			ON CONFLICT (hash) DO NOTHING`,
-		hash[:], blockID, off, length); err != nil {
-		return fmt.Errorf("%s synced mark: %w", op, err)
-	}
-	return nil
-}
-
-// getLocatorTx returns the recorded remote locator for hash: (zero, false, nil)
-// when no row exists; a synced row with NULL/empty block columns yields the zero
-// (standalone) locator with found == true.
-func getLocatorTx(ctx context.Context, x storesql.Executor, op string, hash block.ContentHash) (block.ChunkLocator, bool, error) {
-	var blockID sql.NullString
-	var off, length sql.NullInt64
-	err := x.QueryRow(ctx,
-		`SELECT block_id, block_offset, block_length FROM synced_hashes WHERE hash = $1`,
-		hash[:]).Scan(&blockID, &off, &length)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return block.ChunkLocator{}, false, nil
-	}
-	if err != nil {
-		return block.ChunkLocator{}, false, fmt.Errorf("%s synced get locator: %w", op, err)
-	}
-	if !blockID.Valid || blockID.String == "" {
-		return block.ChunkLocator{}, true, nil
-	}
-	if !off.Valid || !length.Valid {
-		return block.ChunkLocator{}, false, fmt.Errorf("corrupt locator row: block_id %q with NULL offset/length", blockID.String)
-	}
-	return block.ChunkLocator{BlockID: blockID.String, WireOffset: off.Int64, WireLength: length.Int64}, true, nil
-}
-
-// deleteSyncedTx removes the synced marker for hash. Idempotent: zero rows
-// affected is not an error.
-func deleteSyncedTx(ctx context.Context, x storesql.Executor, op string, hash block.ContentHash) error {
-	if _, err := x.Exec(ctx, `DELETE FROM synced_hashes WHERE hash = $1`, hash[:]); err != nil {
-		return fmt.Errorf("%s synced delete: %w", op, err)
-	}
-	return nil
-}
-
-// locatorArgs maps a ChunkLocator onto the (block_id, block_offset, block_length)
-// INSERT args: NULL for a standalone chunk (so its row is identical to a
-// pre-locator row), the recorded values for a block-resident chunk.
-func locatorArgs(loc block.ChunkLocator) (blockID, off, length any) {
-	if loc.IsStandalone() {
-		return nil, nil, nil
-	}
-	return loc.BlockID, loc.WireOffset, loc.WireLength
-}
-
+// PutSyncedLocators writes the marker and locator of every chunk inside this
+// transaction, last-wins per hash.
 func (tx *postgresTransaction) PutSyncedLocators(ctx context.Context, chunks []block.BlockChunkCommit) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	if len(chunks) == 0 {
-		return nil
-	}
-	batch := &pgx.Batch{}
-	for _, c := range chunks {
-		blockID, off, length := locatorArgs(c.Remote)
-		batch.Queue(
-			`INSERT INTO synced_hashes (hash, synced_at, block_id, block_offset, block_length)
-				VALUES ($1, NOW(), $2, $3, $4)
-				ON CONFLICT (hash) DO UPDATE SET
-					synced_at = excluded.synced_at,
-					block_id = excluded.block_id,
-					block_offset = excluded.block_offset,
-					block_length = excluded.block_length`,
-			c.Hash[:], blockID, off, length)
-	}
-	br := tx.tx.SendBatch(ctx, batch)
-	defer func() { _ = br.Close() }()
-	for range chunks {
-		if _, err := br.Exec(); err != nil {
-			return fmt.Errorf("postgres tx synced put locators: %w", err)
-		}
-	}
-	return nil
+	return storesql.PutSyncedLocators(ctx, tx.X, tx.D, chunks)
 }

--- a/pkg/metadata/store/sql/dialect.go
+++ b/pkg/metadata/store/sql/dialect.go
@@ -11,12 +11,14 @@ package sql
 //     statements, because moving a two-line difference into an indirection
 //     would buy nothing.
 //
-//     Placeholder is the exception, and only for the statements that have no
-//     constant to bake: a manifest delta binds one parameter per changed
-//     offset, so its IN-lists and multi-row VALUES groups are assembled at
-//     runtime and there is nothing for a dialect to spell in advance. Reach
-//     for it only there — a statement whose shape is known writes its own
-//     placeholders.
+//     Placeholder and Now are the exceptions, and only for the statements
+//     that have no constant to bake: a manifest delta binds one parameter per
+//     changed offset, so its IN-lists and multi-row VALUES groups are
+//     assembled at runtime and there is nothing for a dialect to spell in
+//     advance. They also carry the tables whose whole statement set is
+//     identical bar those two fragments, which spell it once in the shared
+//     body rather than twice in the dialects. Everything else stays in the
+//     statement structs.
 //
 //   - Behavioural divergence — error classification, and whether an error is
 //     the driver's empty-result sentinel. Those are genuinely per-dialect
@@ -36,9 +38,15 @@ type Dialect interface {
 	IsNoRows(err error) bool
 
 	// Placeholder renders the bind marker for the i'th parameter, 1-based:
-	// "?1" for sqlite, "$1" for postgres. Only for statements assembled at
-	// runtime from a variable-length list; see the type doc.
+	// "?1" for sqlite, "$1" for postgres. Only for statements the shared
+	// bodies assemble themselves; see the type doc.
 	Placeholder(i int) string
+
+	// Now renders the clock expression that stamps a timestamp column:
+	// CURRENT_TIMESTAMP for sqlite, NOW() for postgres. Like Placeholder it is
+	// a fragment, not a statement, for the statements that are assembled at
+	// runtime rather than baked into a constant.
+	Now() string
 
 	// MapError translates a driver error into the metadata.ExportError the
 	// callers switch on, tagging it with the operation name and the path it
@@ -81,32 +89,6 @@ type Dialect interface {
 	// BlockRecords returns the dialect's block-record statements, under the
 	// same package-level-value expectation as Chunks.
 	BlockRecords() *BlockRecordQueries
-
-	// SyncedHashes returns the dialect's synced-hash statements, under the
-	// same package-level-value expectation as Chunks.
-	SyncedHashes() *SyncedHashQueries
-}
-
-// SyncedHashQueries holds the per-hash synced-marker statements that differ
-// between the dialects. Every difference is placeholder syntax except Now,
-// which is not a statement at all: it is the clock expression PutSyncedLocators
-// splices into the multi-row INSERT it assembles, spelled CURRENT_TIMESTAMP on
-// sqlite and NOW() on postgres.
-type SyncedHashQueries struct {
-	// SelectPresence reads a marker's existence, selecting a constant rather
-	// than a column. One parameter: the raw hash.
-	SelectPresence string
-	// SelectLocator reads a marker's locator columns, in
-	// SyncedLocatorColumns order. One parameter: the raw hash.
-	SelectLocator string
-	// Mark inserts a marker, leaving an existing row untouched so the first
-	// recorded locator wins. Four parameters: the raw hash then the three
-	// locator values, synced_at being stamped by the statement itself.
-	Mark string
-	// Delete removes one marker. One parameter: the raw hash.
-	Delete string
-	// Now is the clock expression that stamps synced_at.
-	Now string
 }
 
 // ShareQueries holds the share statements in one dialect's syntax. These

--- a/pkg/metadata/store/sql/dialect.go
+++ b/pkg/metadata/store/sql/dialect.go
@@ -81,6 +81,32 @@ type Dialect interface {
 	// BlockRecords returns the dialect's block-record statements, under the
 	// same package-level-value expectation as Chunks.
 	BlockRecords() *BlockRecordQueries
+
+	// SyncedHashes returns the dialect's synced-hash statements, under the
+	// same package-level-value expectation as Chunks.
+	SyncedHashes() *SyncedHashQueries
+}
+
+// SyncedHashQueries holds the per-hash synced-marker statements that differ
+// between the dialects. Every difference is placeholder syntax except Now,
+// which is not a statement at all: it is the clock expression PutSyncedLocators
+// splices into the multi-row INSERT it assembles, spelled CURRENT_TIMESTAMP on
+// sqlite and NOW() on postgres.
+type SyncedHashQueries struct {
+	// SelectPresence reads a marker's existence, selecting a constant rather
+	// than a column. One parameter: the raw hash.
+	SelectPresence string
+	// SelectLocator reads a marker's locator columns, in
+	// SyncedLocatorColumns order. One parameter: the raw hash.
+	SelectLocator string
+	// Mark inserts a marker, leaving an existing row untouched so the first
+	// recorded locator wins. Four parameters: the raw hash then the three
+	// locator values, synced_at being stamped by the statement itself.
+	Mark string
+	// Delete removes one marker. One parameter: the raw hash.
+	Delete string
+	// Now is the clock expression that stamps synced_at.
+	Now string
 }
 
 // ShareQueries holds the share statements in one dialect's syntax. These

--- a/pkg/metadata/store/sql/executor.go
+++ b/pkg/metadata/store/sql/executor.go
@@ -10,9 +10,9 @@
 // that genuinely differ at runtime. SQL *text* mostly does not: ?N versus $N,
 // NOW() versus CURRENT_TIMESTAMP and the handful of rewritten queries stay as
 // per-dialect constants, because moving a two-line difference into an
-// indirection would buy nothing. The one text difference that does cross is
-// Dialect.Placeholder, for the statements assembled at runtime from a
-// variable-length list, which have no constant to bake. The consequence to be
+// indirection would buy nothing. The text differences that do cross are
+// Dialect.Placeholder and Dialect.Now, for the statements the shared bodies
+// assemble themselves and so have no constant to bake. The consequence to be
 // honest about is that this merges logic, not SQL: what costs us maintenance is
 // hand-maintained control flow duplicated around the queries, not the query text.
 //

--- a/pkg/metadata/store/sql/synced_hash.go
+++ b/pkg/metadata/store/sql/synced_hash.go
@@ -1,0 +1,259 @@
+package sql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/block"
+)
+
+// synced_hashes records, per CAS content hash, that the chunk has been mirrored
+// to the remote store at least once and where its bytes ended up: NULL block
+// columns for a standalone object, a (block_id, block_offset, block_length)
+// triple for a chunk packed inside a block object. Presence of the row is the
+// marker; absence means local-only.
+//
+// The columns and their decode are spelled once here. The per-hash statements
+// differ only in placeholder syntax and in the clock function that stamps
+// synced_at, both of which SyncedHashQueries supplies.
+
+// SyncedLocatorColumns is the locator column list every read names and every
+// write supplies, in the order the scans below read them. Naming it once is
+// what keeps a column added to one statement from being missed by the others.
+const SyncedLocatorColumns = `block_id, block_offset, block_length`
+
+// enumerateSyncedHashes carries no placeholder, so both dialects spell it
+// identically and it stays here rather than in SyncedHashQueries.
+const enumerateSyncedHashes = `SELECT hash, synced_at, ` + SyncedLocatorColumns + ` FROM synced_hashes`
+
+// syncedUpsertConflict is the last-wins tail PutSyncedLocators appends to the
+// multi-row INSERT it generates. Every column the table carries besides the key
+// is restated, so an upsert leaves exactly the row a DELETE followed by an
+// INSERT would.
+const syncedUpsertConflict = ` ON CONFLICT (hash) DO UPDATE SET` +
+	` synced_at = excluded.synced_at, block_id = excluded.block_id,` +
+	` block_offset = excluded.block_offset, block_length = excluded.block_length`
+
+// EnumerateSynced streams every synced marker with its locator and first-mirror
+// time. The locator columns live in the same row, so yielding them here lets a
+// caller resolve locators in a single scan instead of a GetLocator round trip
+// per hash — which on a pool limited to one connection costs one serial
+// statement per marker. A row with NULL/empty block columns yields the zero
+// (standalone) locator.
+func (c *Core) EnumerateSynced(ctx context.Context, fn func(hash block.ContentHash, loc block.ChunkLocator, syncedAt time.Time) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	rows, err := c.X.Query(ctx, enumerateSyncedHashes)
+	if err != nil {
+		return fmt.Errorf("synced enumerate: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			raw      []byte
+			syncedAt time.Time
+			blockID  sql.NullString
+			off, ln  sql.NullInt64
+		)
+		if err := rows.Scan(&raw, &syncedAt, &blockID, &off, &ln); err != nil {
+			return fmt.Errorf("synced enumerate scan: %w", err)
+		}
+		if len(raw) != len(block.ContentHash{}) {
+			// A malformed hash row cannot be reduced to a ContentHash. Skip it
+			// rather than corrupt the sweep's candidate set.
+			continue
+		}
+		var h block.ContentHash
+		copy(h[:], raw)
+		loc, err := locatorFromCols(blockID, off, ln)
+		if err != nil {
+			return fmt.Errorf("synced enumerate: %w", err)
+		}
+		if err := fn(h, loc, syncedAt); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}
+
+// IsSynced reports whether hash has been MarkSynced'd at least once. An absent
+// row is "not yet synced", not an error.
+func (c *Core) IsSynced(ctx context.Context, hash block.ContentHash) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	var dummy int
+	err := c.X.QueryRow(ctx, c.D.SyncedHashes().SelectPresence, hash[:]).Scan(&dummy)
+	if c.D.IsNoRows(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("synced get: %w", err)
+	}
+	return true, nil
+}
+
+// MarkSynced records that hash has been mirrored to remote, persisting loc's
+// block columns atomically with the marker. Idempotent and first-wins:
+// re-applying the same hash is a no-op that preserves the first locator. A
+// standalone locator (BlockID == "") leaves the block columns NULL, identical
+// to a pre-locator row, so existing data needs no migration.
+func (c *Core) MarkSynced(ctx context.Context, hash block.ContentHash, loc block.ChunkLocator) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	blockID, off, length := locatorArgs(loc)
+	if _, err := c.X.Exec(ctx, c.D.SyncedHashes().Mark, hash[:], blockID, off, length); err != nil {
+		return fmt.Errorf("synced mark: %w", err)
+	}
+	return nil
+}
+
+// GetLocator returns the recorded remote locator for hash: (zero, false, nil)
+// when no row exists; a synced row with NULL/empty block columns yields the
+// zero (standalone) locator with found == true.
+func (c *Core) GetLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return block.ChunkLocator{}, false, err
+	}
+	var blockID sql.NullString
+	var off, length sql.NullInt64
+	err := c.X.QueryRow(ctx, c.D.SyncedHashes().SelectLocator, hash[:]).Scan(&blockID, &off, &length)
+	if c.D.IsNoRows(err) {
+		return block.ChunkLocator{}, false, nil
+	}
+	if err != nil {
+		return block.ChunkLocator{}, false, fmt.Errorf("synced get locator: %w", err)
+	}
+	loc, err := locatorFromCols(blockID, off, length)
+	if err != nil {
+		return block.ChunkLocator{}, false, fmt.Errorf("synced get locator: %w", err)
+	}
+	return loc, true, nil
+}
+
+// DeleteSynced removes the synced marker for hash. Idempotent: zero rows
+// affected is not an error.
+func (c *Core) DeleteSynced(ctx context.Context, hash block.ContentHash) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if _, err := c.X.Exec(ctx, c.D.SyncedHashes().Delete, hash[:]); err != nil {
+		return fmt.Errorf("synced delete: %w", err)
+	}
+	return nil
+}
+
+// PutSyncedLocators writes the marker and locator of every chunk, overwriting
+// whatever marker each hash already carries. It is the batched, last-wins form
+// of DeleteSynced-then-MarkSynced per chunk and leaves the same rows, in one
+// generated INSERT per batch rather than two statements per chunk — a block
+// object packs hundreds of chunks into a single commit.
+//
+// It takes its executor rather than riding on Core, because a commit large
+// enough to span more than one batch runs several statements: on the
+// pool-backed store those would autocommit independently, and a crash between
+// them would leave some of the block's chunks pointing at the new object and
+// the rest at the old. Passing the executor keeps the caller's transaction
+// visible at the call site.
+//
+// An empty slice is a no-op.
+func PutSyncedLocators(ctx context.Context, x Executor, d Dialect, chunks []block.BlockChunkCommit) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	chunks = lastPerHash(chunks)
+
+	// synced_at is the dialect's clock expression rather than a bound value,
+	// so a row costs four parameters, not five. The rows per batch are DERIVED
+	// from that count rather than fixed, so a column added to the statement
+	// shrinks the batch instead of pushing it past maxBoundParams, where the
+	// whole Exec would fail.
+	const colsPerRow = 4
+	const rowsPerBatch = maxBoundParams / colsPerRow
+	now := d.SyncedHashes().Now
+
+	for start := 0; start < len(chunks); start += rowsPerBatch {
+		batch := chunks[start:min(start+rowsPerBatch, len(chunks))]
+		var sb strings.Builder
+		sb.WriteString(`INSERT INTO synced_hashes (hash, synced_at, ` + SyncedLocatorColumns + `) VALUES `)
+		args := make([]any, 0, len(batch)*colsPerRow)
+		for i, c := range batch {
+			if i > 0 {
+				sb.WriteByte(',')
+			}
+			sb.WriteByte('(')
+			sb.WriteString(d.Placeholder(len(args) + 1))
+			sb.WriteByte(',')
+			sb.WriteString(now)
+			for col := 1; col < colsPerRow; col++ {
+				sb.WriteByte(',')
+				sb.WriteString(d.Placeholder(len(args) + col + 1))
+			}
+			sb.WriteByte(')')
+			blockID, off, length := locatorArgs(c.Remote)
+			args = append(args, c.Hash[:], blockID, off, length)
+		}
+		sb.WriteString(syncedUpsertConflict)
+		if _, err := x.Exec(ctx, sb.String(), args...); err != nil {
+			return fmt.Errorf("synced put locators: %w", err)
+		}
+	}
+	return nil
+}
+
+// lastPerHash drops all but the final occurrence of each hash, keeping the
+// survivors in their original order, and returns chunks untouched when there is
+// nothing to drop.
+//
+// A repeated hash has to go before the rows reach one statement: postgres
+// rejects an ON CONFLICT DO UPDATE that would touch the same row twice in a
+// single INSERT, while sqlite quietly applies both. Keeping the last occurrence
+// is what a per-chunk sequential form would have left behind.
+func lastPerHash(chunks []block.BlockChunkCommit) []block.BlockChunkCommit {
+	last := make(map[block.ContentHash]int, len(chunks))
+	for i, c := range chunks {
+		last[c.Hash] = i
+	}
+	if len(last) == len(chunks) {
+		return chunks
+	}
+	out := make([]block.BlockChunkCommit, 0, len(last))
+	for i, c := range chunks {
+		if last[c.Hash] == i {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// locatorArgs maps a ChunkLocator onto the (block_id, block_offset,
+// block_length) write args: NULL for a standalone chunk, so its row is
+// identical to a pre-locator row, and the recorded values for a block-resident
+// one.
+func locatorArgs(loc block.ChunkLocator) (blockID, off, length any) {
+	if loc.IsStandalone() {
+		return nil, nil, nil
+	}
+	return loc.BlockID, loc.WireOffset, loc.WireLength
+}
+
+// locatorFromCols builds a ChunkLocator from already-scanned (block_id,
+// block_offset, block_length) columns. A NULL or empty block_id yields the zero
+// (standalone) locator; a block_id with either companion column missing is a
+// row no writer here can produce, and reporting it beats resolving the chunk to
+// the wrong bytes.
+func locatorFromCols(blockID sql.NullString, off, length sql.NullInt64) (block.ChunkLocator, error) {
+	if !blockID.Valid || blockID.String == "" {
+		return block.ChunkLocator{}, nil
+	}
+	if !off.Valid || !length.Valid {
+		return block.ChunkLocator{}, fmt.Errorf("corrupt locator row: block_id %q with NULL offset/length", blockID.String)
+	}
+	return block.ChunkLocator{BlockID: blockID.String, WireOffset: off.Int64, WireLength: length.Int64}, nil
+}

--- a/pkg/metadata/store/sql/synced_hash.go
+++ b/pkg/metadata/store/sql/synced_hash.go
@@ -16,18 +16,15 @@ import (
 // triple for a chunk packed inside a block object. Presence of the row is the
 // marker; absence means local-only.
 //
-// The columns and their decode are spelled once here. The per-hash statements
-// differ only in placeholder syntax and in the clock function that stamps
-// synced_at, both of which SyncedHashQueries supplies.
+// Every statement here is spelled once: the columns, the predicates and the
+// conflict clause are identical in both dialects, and only the placeholders and
+// the clock expression that stamps synced_at differ, which Dialect.Placeholder
+// and Dialect.Now supply.
 
-// SyncedLocatorColumns is the locator column list every read names and every
-// write supplies, in the order the scans below read them. Naming it once is
-// what keeps a column added to one statement from being missed by the others.
-const SyncedLocatorColumns = `block_id, block_offset, block_length`
-
-// enumerateSyncedHashes carries no placeholder, so both dialects spell it
-// identically and it stays here rather than in SyncedHashQueries.
-const enumerateSyncedHashes = `SELECT hash, synced_at, ` + SyncedLocatorColumns + ` FROM synced_hashes`
+// syncedLocatorCols is the locator column list every read names and every write
+// supplies, in the order the scans below read them. Naming it once is what
+// keeps a column added to one statement from being missed by the others.
+const syncedLocatorCols = `block_id, block_offset, block_length`
 
 // syncedUpsertConflict is the last-wins tail PutSyncedLocators appends to the
 // multi-row INSERT it generates. Every column the table carries besides the key
@@ -47,7 +44,7 @@ func (c *Core) EnumerateSynced(ctx context.Context, fn func(hash block.ContentHa
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	rows, err := c.X.Query(ctx, enumerateSyncedHashes)
+	rows, err := c.X.Query(ctx, `SELECT hash, synced_at, `+syncedLocatorCols+` FROM synced_hashes`)
 	if err != nil {
 		return fmt.Errorf("synced enumerate: %w", err)
 	}
@@ -87,8 +84,10 @@ func (c *Core) IsSynced(ctx context.Context, hash block.ContentHash) (bool, erro
 	if err := ctx.Err(); err != nil {
 		return false, err
 	}
-	var dummy int
-	err := c.X.QueryRow(ctx, c.D.SyncedHashes().SelectPresence, hash[:]).Scan(&dummy)
+	var present int
+	err := c.X.QueryRow(ctx,
+		`SELECT 1 FROM synced_hashes WHERE hash = `+c.D.Placeholder(1), hash[:],
+	).Scan(&present)
 	if c.D.IsNoRows(err) {
 		return false, nil
 	}
@@ -108,7 +107,13 @@ func (c *Core) MarkSynced(ctx context.Context, hash block.ContentHash, loc block
 		return err
 	}
 	blockID, off, length := locatorArgs(loc)
-	if _, err := c.X.Exec(ctx, c.D.SyncedHashes().Mark, hash[:], blockID, off, length); err != nil {
+	// synced_at is stamped by the statement's own clock, matching the rows
+	// PutSyncedLocators writes.
+	mark := `INSERT INTO synced_hashes (hash, synced_at, ` + syncedLocatorCols + `)` +
+		` VALUES (` + c.D.Placeholder(1) + `, ` + c.D.Now() + `, ` +
+		c.D.Placeholder(2) + `, ` + c.D.Placeholder(3) + `, ` + c.D.Placeholder(4) + `)` +
+		` ON CONFLICT (hash) DO NOTHING`
+	if _, err := c.X.Exec(ctx, mark, hash[:], blockID, off, length); err != nil {
 		return fmt.Errorf("synced mark: %w", err)
 	}
 	return nil
@@ -123,7 +128,9 @@ func (c *Core) GetLocator(ctx context.Context, hash block.ContentHash) (block.Ch
 	}
 	var blockID sql.NullString
 	var off, length sql.NullInt64
-	err := c.X.QueryRow(ctx, c.D.SyncedHashes().SelectLocator, hash[:]).Scan(&blockID, &off, &length)
+	err := c.X.QueryRow(ctx,
+		`SELECT `+syncedLocatorCols+` FROM synced_hashes WHERE hash = `+c.D.Placeholder(1), hash[:],
+	).Scan(&blockID, &off, &length)
 	if c.D.IsNoRows(err) {
 		return block.ChunkLocator{}, false, nil
 	}
@@ -143,7 +150,9 @@ func (c *Core) DeleteSynced(ctx context.Context, hash block.ContentHash) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if _, err := c.X.Exec(ctx, c.D.SyncedHashes().Delete, hash[:]); err != nil {
+	if _, err := c.X.Exec(ctx,
+		`DELETE FROM synced_hashes WHERE hash = `+c.D.Placeholder(1), hash[:],
+	); err != nil {
 		return fmt.Errorf("synced delete: %w", err)
 	}
 	return nil
@@ -176,24 +185,23 @@ func PutSyncedLocators(ctx context.Context, x Executor, d Dialect, chunks []bloc
 	// whole Exec would fail.
 	const colsPerRow = 4
 	const rowsPerBatch = maxBoundParams / colsPerRow
-	now := d.SyncedHashes().Now
+	now := d.Now()
 
 	for start := 0; start < len(chunks); start += rowsPerBatch {
 		batch := chunks[start:min(start+rowsPerBatch, len(chunks))]
 		var sb strings.Builder
-		sb.WriteString(`INSERT INTO synced_hashes (hash, synced_at, ` + SyncedLocatorColumns + `) VALUES `)
+		sb.WriteString(`INSERT INTO synced_hashes (hash, synced_at, ` + syncedLocatorCols + `) VALUES `)
 		args := make([]any, 0, len(batch)*colsPerRow)
 		for i, c := range batch {
 			if i > 0 {
 				sb.WriteByte(',')
 			}
-			sb.WriteByte('(')
-			sb.WriteString(d.Placeholder(len(args) + 1))
-			sb.WriteByte(',')
-			sb.WriteString(now)
+			// The row's bound columns are the hash and the three locator
+			// values; synced_at sits between them as the clock expression.
+			base := len(args)
+			sb.WriteString(`(` + d.Placeholder(base+1) + `,` + now)
 			for col := 1; col < colsPerRow; col++ {
-				sb.WriteByte(',')
-				sb.WriteString(d.Placeholder(len(args) + col + 1))
+				sb.WriteString(`,` + d.Placeholder(base+col+1))
 			}
 			sb.WriteByte(')')
 			blockID, off, length := locatorArgs(c.Remote)

--- a/pkg/metadata/store/sqlite/dialect.go
+++ b/pkg/metadata/store/sqlite/dialect.go
@@ -384,18 +384,5 @@ var blockRecordQueries = storesql.BlockRecordQueries{
 // Placeholder implements storesql.Dialect.
 func (dialect) Placeholder(i int) string { return "?" + strconv.Itoa(i) }
 
-func (dialect) SyncedHashes() *storesql.SyncedHashQueries { return &syncedHashQueries }
-
-var syncedHashQueries = storesql.SyncedHashQueries{
-	SelectPresence: `SELECT 1 FROM synced_hashes WHERE hash = ?1`,
-	SelectLocator: `
-		SELECT ` + storesql.SyncedLocatorColumns + `
-		FROM synced_hashes
-		WHERE hash = ?1`,
-	Mark: `
-		INSERT INTO synced_hashes (hash, synced_at, ` + storesql.SyncedLocatorColumns + `)
-		VALUES (?1, CURRENT_TIMESTAMP, ?2, ?3, ?4)
-		ON CONFLICT (hash) DO NOTHING`,
-	Delete: `DELETE FROM synced_hashes WHERE hash = ?1`,
-	Now:    `CURRENT_TIMESTAMP`,
-}
+// Now implements storesql.Dialect.
+func (dialect) Now() string { return "CURRENT_TIMESTAMP" }

--- a/pkg/metadata/store/sqlite/dialect.go
+++ b/pkg/metadata/store/sqlite/dialect.go
@@ -383,3 +383,19 @@ var blockRecordQueries = storesql.BlockRecordQueries{
 
 // Placeholder implements storesql.Dialect.
 func (dialect) Placeholder(i int) string { return "?" + strconv.Itoa(i) }
+
+func (dialect) SyncedHashes() *storesql.SyncedHashQueries { return &syncedHashQueries }
+
+var syncedHashQueries = storesql.SyncedHashQueries{
+	SelectPresence: `SELECT 1 FROM synced_hashes WHERE hash = ?1`,
+	SelectLocator: `
+		SELECT ` + storesql.SyncedLocatorColumns + `
+		FROM synced_hashes
+		WHERE hash = ?1`,
+	Mark: `
+		INSERT INTO synced_hashes (hash, synced_at, ` + storesql.SyncedLocatorColumns + `)
+		VALUES (?1, CURRENT_TIMESTAMP, ?2, ?3, ?4)
+		ON CONFLICT (hash) DO NOTHING`,
+	Delete: `DELETE FROM synced_hashes WHERE hash = ?1`,
+	Now:    `CURRENT_TIMESTAMP`,
+}

--- a/pkg/metadata/store/sqlite/pool_helpers.go
+++ b/pkg/metadata/store/sqlite/pool_helpers.go
@@ -101,12 +101,6 @@ func (s *SQLiteMetadataStore) queryRow(ctx context.Context, query string, args .
 	return execer{e: s.db, op: "queryRow"}.QueryRow(ctx, query, args...)
 }
 
-// query executes a multi-row query against the shared *sql.DB. The caller MUST
-// Close the returned rows.
-func (s *SQLiteMetadataStore) query(ctx context.Context, query string, args ...any) (scanRows, error) {
-	return execer{e: s.db, op: "query"}.Query(ctx, query, args...)
-}
-
 // exec executes a statement against the shared *sql.DB and returns the result
 // for RowsAffected inspection.
 func (s *SQLiteMetadataStore) exec(ctx context.Context, query string, args ...any) (storesql.CommandTag, error) {

--- a/pkg/metadata/store/sqlite/synced_hash_store.go
+++ b/pkg/metadata/store/sqlite/synced_hash_store.go
@@ -1,280 +1,30 @@
-// Per-CAS-hash idempotent presence marker backed by the synced_hashes
-// table. See metadata.SyncedHashStore for the contract; this backend
-// uses a tiny indexed table keyed by the raw 32-byte BLAKE3 hash, with
-// ON CONFLICT DO NOTHING for idempotent MarkSynced and unconditional
-// DELETE for idempotent DeleteSynced.
+// Synced-hash support for the SQLite metadata store. The statements and the
+// bodies that run them live in store/sql, promoted onto both the store and its
+// transaction through the embedded Core. One method stays here:
+// PutSyncedLocators, which spans several statements for a commit large enough
+// to batch, so store/sql exposes it as a function over an executor rather than
+// as a promoted method the pool-backed store would autocommit piecemeal.
 package sqlite
 
 import (
 	"context"
-	"database/sql"
-	"errors"
-	"fmt"
-	"time"
 
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/metadata"
+
+	storesql "github.com/marmos91/dittofs/pkg/metadata/store/sql"
 )
 
-// Compile-time assertions: the SQLite engine and its transaction implement
-// SyncedHashStore.
+// Both the store and its transaction satisfy the interface through the
+// promoted Core methods. Within a transaction SQLite gives read-your-writes, so
+// a MarkSynced after a DeleteSynced in the same tx records the new locator.
 var (
 	_ metadata.SyncedHashStore = (*SQLiteMetadataStore)(nil)
 	_ metadata.SyncedHashStore = (*sqliteTransaction)(nil)
 )
 
-// EnumerateSynced streams every synced marker with its locator and first-mirror
-// time, read straight from the synced_hashes table. The locator columns live in
-// the same row, so yielding them here lets callers resolve locators in a single
-// scan instead of a GetLocator round trip per hash — the O(N)-serial-statements
-// cost on the MaxOpenConns(1) pool behind the slow cold-start (#1554). A synced
-// row with NULL/empty block columns yields the zero (standalone) locator.
-func (s *SQLiteMetadataStore) EnumerateSynced(ctx context.Context, fn func(hash block.ContentHash, loc block.ChunkLocator, syncedAt time.Time) error) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	rows, err := s.query(ctx, `SELECT hash, synced_at, block_id, block_offset, block_length FROM synced_hashes`)
-	if err != nil {
-		return fmt.Errorf("sqlite synced enumerate: %w", err)
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var (
-			raw      []byte
-			syncedAt time.Time
-			blockID  sql.NullString
-			off, ln  sql.NullInt64
-		)
-		if err := rows.Scan(&raw, &syncedAt, &blockID, &off, &ln); err != nil {
-			return fmt.Errorf("sqlite synced enumerate scan: %w", err)
-		}
-		if len(raw) != len(block.ContentHash{}) {
-			// Defensive: a malformed hash row cannot be reduced to a
-			// ContentHash. Skip it rather than corrupt the sweep candidate.
-			continue
-		}
-		var h block.ContentHash
-		copy(h[:], raw)
-		loc, err := locatorFromCols(blockID, off, ln)
-		if err != nil {
-			return fmt.Errorf("sqlite synced enumerate: %w", err)
-		}
-		if err := fn(h, loc, syncedAt); err != nil {
-			return err
-		}
-	}
-	return rows.Err()
-}
-
-// ============================================================================
-// Shared bodies (executor-parameterized)
-// ============================================================================
-//
-// Both the store-level (pool) path and the transaction path present the same
-// pgx-shaped execer surface (see pool_helpers.go), so — unlike the ported
-// Postgres file — each query body exists exactly once, parameterized on the
-// executor. Within a transaction SQLite gives read-your-writes, so a
-// MarkSynced after a DeleteSynced in the same tx records the new locator.
-
-// syncedIsSynced reports marker presence via x.
-func syncedIsSynced(ctx context.Context, x execer, hash block.ContentHash) (bool, error) {
-	row := x.QueryRow(ctx,
-		`SELECT 1 FROM synced_hashes WHERE hash = ?1`,
-		hash[:])
-	var dummy int
-	err := row.Scan(&dummy)
-	if errors.Is(err, sql.ErrNoRows) {
-		return false, nil
-	}
-	if err != nil {
-		return false, fmt.Errorf("sqlite synced get: %w", err)
-	}
-	return true, nil
-}
-
-// syncedMark inserts the marker via x. First-wins per ON CONFLICT DO NOTHING.
-func syncedMark(ctx context.Context, x execer, hash block.ContentHash, loc block.ChunkLocator) error {
-	blockID, off, length := locatorArgs(loc)
-	if _, err := x.Exec(ctx,
-		`INSERT INTO synced_hashes (hash, synced_at, block_id, block_offset, block_length)
-			VALUES (?1, CURRENT_TIMESTAMP, ?2, ?3, ?4)
-			ON CONFLICT (hash) DO NOTHING`,
-		hash[:], blockID, off, length); err != nil {
-		return fmt.Errorf("sqlite synced mark: %w", err)
-	}
-	return nil
-}
-
-// syncedUpsert writes the marker via x, overwriting an existing row's timestamp
-// and locator (last-wins). The three locator columns plus synced_at are every
-// column the table carries besides the key, so this leaves the same row a
-// DELETE followed by an INSERT would.
-func syncedUpsert(ctx context.Context, x execer, hash block.ContentHash, loc block.ChunkLocator) error {
-	blockID, off, length := locatorArgs(loc)
-	if _, err := x.Exec(ctx,
-		`INSERT INTO synced_hashes (hash, synced_at, block_id, block_offset, block_length)
-			VALUES (?1, CURRENT_TIMESTAMP, ?2, ?3, ?4)
-			ON CONFLICT (hash) DO UPDATE SET
-				synced_at = excluded.synced_at,
-				block_id = excluded.block_id,
-				block_offset = excluded.block_offset,
-				block_length = excluded.block_length`,
-		hash[:], blockID, off, length); err != nil {
-		return fmt.Errorf("sqlite synced upsert: %w", err)
-	}
-	return nil
-}
-
-// syncedGetLocator reads the marker's locator via x.
-func syncedGetLocator(ctx context.Context, x execer, hash block.ContentHash) (block.ChunkLocator, bool, error) {
-	row := x.QueryRow(ctx,
-		`SELECT block_id, block_offset, block_length FROM synced_hashes WHERE hash = ?1`,
-		hash[:])
-	loc, err := scanLocatorRow(row)
-	if errors.Is(err, sql.ErrNoRows) {
-		return block.ChunkLocator{}, false, nil
-	}
-	if err != nil {
-		return block.ChunkLocator{}, false, fmt.Errorf("sqlite synced get locator: %w", err)
-	}
-	return loc, true, nil
-}
-
-// syncedDelete removes the marker via x. Idempotent.
-func syncedDelete(ctx context.Context, x execer, hash block.ContentHash) error {
-	if _, err := x.Exec(ctx,
-		`DELETE FROM synced_hashes WHERE hash = ?1`,
-		hash[:]); err != nil {
-		return fmt.Errorf("sqlite synced delete: %w", err)
-	}
-	return nil
-}
-
-// IsSynced reports whether hash has been MarkSynced'd at least once.
-// Returns (false, nil) when no row exists for hash — an absent hash is
-// treated as "not yet synced", not as an error.
-func (s *SQLiteMetadataStore) IsSynced(ctx context.Context, hash block.ContentHash) (bool, error) {
-	if err := ctx.Err(); err != nil {
-		return false, err
-	}
-	return syncedIsSynced(ctx, s.conn(), hash)
-}
-
-// MarkSynced records that hash has been mirrored to remote, persisting loc's
-// block columns atomically. Idempotent via ON CONFLICT (hash) DO NOTHING —
-// re-applying the same hash is a no-op that preserves the first locator. A
-// standalone locator (BlockID == "") leaves the block columns NULL, identical to
-// a pre-locator row, so existing data needs no migration.
-func (s *SQLiteMetadataStore) MarkSynced(ctx context.Context, hash block.ContentHash, loc block.ChunkLocator) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	return syncedMark(ctx, s.conn(), hash, loc)
-}
-
-// GetLocator returns the recorded remote locator for hash. (zero, false, nil)
-// when no row exists; a synced row with NULL/empty block columns yields the zero
-// (standalone) locator with found == true.
-func (s *SQLiteMetadataStore) GetLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error) {
-	if err := ctx.Err(); err != nil {
-		return block.ChunkLocator{}, false, err
-	}
-	return syncedGetLocator(ctx, s.conn(), hash)
-}
-
-// locatorArgs maps a ChunkLocator onto the (block_id, block_offset, block_length)
-// INSERT args: NULL for a standalone chunk (so its row is identical to a
-// pre-locator row), the recorded values for a block-resident chunk.
-func locatorArgs(loc block.ChunkLocator) (blockID, off, length any) {
-	if loc.IsStandalone() {
-		return nil, nil, nil
-	}
-	return loc.BlockID, loc.WireOffset, loc.WireLength
-}
-
-// scanLocatorRow scans a (block_id, block_offset, block_length) row into a
-// ChunkLocator. NULL/empty block_id yields the zero (standalone) locator.
-func scanLocatorRow(row scanRow) (block.ChunkLocator, error) {
-	var blockID sql.NullString
-	var off, length sql.NullInt64
-	if err := row.Scan(&blockID, &off, &length); err != nil {
-		return block.ChunkLocator{}, err
-	}
-	return locatorFromCols(blockID, off, length)
-}
-
-// locatorFromCols builds a ChunkLocator from already-scanned (block_id,
-// block_offset, block_length) columns. NULL/empty block_id yields the zero
-// (standalone) locator. Shared by scanLocatorRow (single-row lookup) and
-// EnumerateSynced (folded into the enumeration scan).
-func locatorFromCols(blockID sql.NullString, off, length sql.NullInt64) (block.ChunkLocator, error) {
-	if !blockID.Valid || blockID.String == "" {
-		return block.ChunkLocator{}, nil
-	}
-	if !off.Valid || !length.Valid {
-		return block.ChunkLocator{}, fmt.Errorf("corrupt locator row: block_id %q with NULL offset/length", blockID.String)
-	}
-	return block.ChunkLocator{BlockID: blockID.String, WireOffset: off.Int64, WireLength: length.Int64}, nil
-}
-
-// DeleteSynced removes the synced marker for hash. Idempotent: DELETE
-// returns no error when the row does not exist (zero rows affected is
-// not an error condition).
-func (s *SQLiteMetadataStore) DeleteSynced(ctx context.Context, hash block.ContentHash) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	return syncedDelete(ctx, s.conn(), hash)
-}
-
-// ============================================================================
-// Transaction-level SyncedHashStore
-// ============================================================================
-//
-// Same executor plumbing as the transaction-level BlockRecordStore /
-// LocalChunkIndex (block_record_store.go): run the shared bodies against the
-// enclosing transaction's execer (tx.tx).
-
-func (tx *sqliteTransaction) IsSynced(ctx context.Context, hash block.ContentHash) (bool, error) {
-	if err := ctx.Err(); err != nil {
-		return false, err
-	}
-	return syncedIsSynced(ctx, tx.tx, hash)
-}
-
-func (tx *sqliteTransaction) MarkSynced(ctx context.Context, hash block.ContentHash, loc block.ChunkLocator) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	return syncedMark(ctx, tx.tx, hash, loc)
-}
-
-func (tx *sqliteTransaction) GetLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error) {
-	if err := ctx.Err(); err != nil {
-		return block.ChunkLocator{}, false, err
-	}
-	return syncedGetLocator(ctx, tx.tx, hash)
-}
-
-func (tx *sqliteTransaction) DeleteSynced(ctx context.Context, hash block.ContentHash) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	return syncedDelete(ctx, tx.tx, hash)
-}
-
-// PutSyncedLocators overwrites the marker of every chunk. SQLite is in-process,
-// so the saving is per-chunk statement count: one upsert replaces the
-// DELETE + INSERT pair the sequential form issues.
+// PutSyncedLocators writes the marker and locator of every chunk inside this
+// transaction, last-wins per hash.
 func (tx *sqliteTransaction) PutSyncedLocators(ctx context.Context, chunks []block.BlockChunkCommit) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	for _, c := range chunks {
-		if err := syncedUpsert(ctx, tx.tx, c.Hash, c.Remote); err != nil {
-			return err
-		}
-	}
-	return nil
+	return storesql.PutSyncedLocators(ctx, tx.X, tx.D, chunks)
 }

--- a/pkg/metadata/storetest/synced_hash_tx_ops.go
+++ b/pkg/metadata/storetest/synced_hash_tx_ops.go
@@ -169,4 +169,57 @@ func runSyncedHashTxOps(t *testing.T, store metadata.Store) {
 		require.True(t, found)
 		assert.Equal(t, newLoc, got, "tx delete+mark must overwrite the committed standalone locator")
 	})
+
+	t.Run("PutSyncedLocatorsRepeatedHash", func(t *testing.T) {
+		// A hash repeated within one call keeps the locator of its last
+		// occurrence, matching what a per-chunk sequential form leaves behind.
+		// A backend that folds the call into one statement has to drop the
+		// earlier duplicate itself rather than hand the same row twice to an
+		// upsert.
+		h := makeHash(0x07)
+		first := blockLoc("tx-dup-first")
+		last := blockLoc("tx-dup-last")
+
+		require.NoError(t, store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+			return tx.PutSyncedLocators(ctx, []block.BlockChunkCommit{
+				{Hash: h, Remote: first},
+				{Hash: h, Remote: last},
+			})
+		}))
+
+		got, found, err := store.GetLocator(ctx, h)
+		require.NoError(t, err)
+		require.True(t, found)
+		assert.Equal(t, last, got, "the last occurrence of a repeated hash must win")
+	})
+
+	t.Run("PutSyncedLocatorsLargeCommit", func(t *testing.T) {
+		// A block object packs hundreds of chunks into one commit, which is
+		// more than a backend batching by bound-parameter count fits in a
+		// single statement. Every chunk must land, whichever batch carried it.
+		const n = 600
+		chunks := make([]block.BlockChunkCommit, n)
+		for i := range chunks {
+			var h block.ContentHash
+			h[0] = 0x7A
+			h[1] = 0xFF // namespace away from makeHash's single-byte seeds
+			h[2] = byte(i)
+			h[3] = byte(i >> 8)
+			chunks[i] = block.BlockChunkCommit{
+				Hash:   h,
+				Remote: block.ChunkLocator{BlockID: "tx-big", WireOffset: int64(i) * 512, WireLength: 512},
+			}
+		}
+
+		require.NoError(t, store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+			return tx.PutSyncedLocators(ctx, chunks)
+		}))
+
+		for i, c := range chunks {
+			got, found, err := store.GetLocator(ctx, c.Hash)
+			require.NoError(t, err)
+			require.Truef(t, found, "chunk %d must be marked synced", i)
+			require.Equalf(t, c.Remote, got, "chunk %d must keep its locator", i)
+		}
+	})
 }


### PR DESCRIPTION
Part of #1828 (S6f). This is the last of the sub-store pairs that can be
merged — see the note on `snapshot_store.go` at the end.

The five single-statement reads and writes move onto `Core`. `PutSyncedLocators`
does not: it generates one insert per batch of chunks, and a `Core` method is
promoted onto the pool-backed store as well, where those batches would
autocommit separately and leave half a block's chunks pointing at the new object
and half at the old. It takes an executor instead, like `PutFileChunkRefs` and
`DecrementAndReapMany`.

### A contract postgres was documented to meet and didn't

`metadata.SyncedHashStore` requires every method to return the context error
when `ctx` is already done at entry. sqlite guarded all ten entry points;
postgres guarded two, leaving eight unchecked. The shared bodies check, so
postgres gains the behaviour its own interface doc promised.

### Last-wins on a repeated hash

The interface promises that a hash repeated within one call keeps its last
locator. sqlite's per-chunk loop and postgres's queued batch both gave that for
free. One multi-row insert does not — postgres rejects two conflicting rows in a
single statement outright, and sqlite would silently apply both — so duplicates
are dropped before the rows are built. The dedup runs before batching, so a
repeat can never straddle a batch boundary and batch order decides nothing.

### On the batch ceiling

The 900 bound-parameter cap is shared with the manifest delta and is pure
margin here, but not for the reason a mutation would suggest: raising it to
100,000 fails no test, because the largest test commit is 2,400 parameters and
fits in one statement either way. That experiment only shows the limit exceeds
2,400. The real argument is structural — a commit's chunk count is bounded by
`CarveBlockSize` over `MinChunkSize`, so roughly four to twenty rows, two orders
of magnitude under the 225-row split and far under postgres's 65,535-parameter
wire limit.

### Two costs, stated rather than omitted

**Error prefixes.** Postgres's messages no longer say whether a failure came
from the pool or from inside a transaction. That prefix was deliberate — its
comment defended it for exactly the visibility and locking problems these
report — and it is not recoverable from the message alone. Nothing matches on
those strings, and the five files merged before this one all dropped their
prefixes, so restoring this one alone would leave the odd file out. If it is
wanted back, a tag field on `Core` restores it package-wide in one change.

**Statement structs.** `SyncedHashQueries` is gone. Four of its five fields
differed only in `?N` versus `$N`, which `Dialect.Placeholder` already supplies,
so keeping it meant the SQL was still written twice. The `Dialect` doc scoped
`Placeholder` to runtime-assembled statements only — wording the manifest delta
already contradicted in the same commit that introduced it, since five of its
fixed-shape statements use it too. The doc now describes both cases.

### Tests

`PutSyncedLocatorsRepeatedHash` and `PutSyncedLocatorsLargeCommit`, in the
shared suite so all four backends run them. Mutation results: removing the dedup
fails `RepeatedHash` on postgres with `ON CONFLICT DO UPDATE command cannot
affect row a second time`, which is the dialect the dedup exists for; breaking
after the first batch fails `LargeCommit` at chunk 225.

### What is left, and what cannot be merged

`snapshot_store.go` is the last pair and should not be merged. Postgres drives
it through raw `pgconn` COPY TO/FROM STDOUT inside a REPEATABLE READ
transaction; sqlite uses its own row-by-row binary encoding. Those are different
mechanisms, not two spellings of one — only `isKnownTable` and the envelope
format overlap. So S7's "delete the old packages" cannot be literal: the sqlite
and postgres packages survive as thin ones carrying dialect text, store
construction and snapshot.

Integration-tagged `./pkg/metadata/...` green against a local postgres 16 and
sqlite; `golangci-lint run ./pkg/metadata/...` clean.

Unrelated defect found while verifying, filed separately as #2372.
