### PR TITLE
test(block): one benchmark per journal state transition, and the recorded baseline

### DIFF
--- a/.planning/2026-09-01-pier-library-design-PLAN.md
+++ b/.planning/2026-09-01-pier-library-design-PLAN.md
@@ -896,9 +896,20 @@ Rules:
   round-trips ~2.7x and has already produced one wrong headline number in this codebase.
 - **`Extents` needs a defence.** Collapsing `FileSize`/`DataExtents`/`DurableExtent`/
   `ColdExtents` into one slice-returning query is the design's biggest performance risk:
-  `FileSize` is on the hot read path (`engine/readwrite.go:40,53`) and `ColdExtents` is
-  documented as O(live intervals) and deliberately avoids holding all shard locks at once.
-  `Size` stays separate for exactly this reason; benchmark it and keep the receipts.
+  `ColdExtents` is documented as O(live intervals) and deliberately avoids holding all
+  shard locks at once. Benchmark it and keep the receipts.
+
+  **Corrected 2026-09-06, from the receipts.** This paragraph originally kept `Size`
+  separate on the grounds that `FileSize` is on the hot read path, citing
+  `engine/readwrite.go:40,53`. Those lines are inside `engine.Store.GetSize` and
+  `engine.Store.Exists`, and **neither has a non-test caller**, nor does the
+  `block.Reader` interface declaring them — a dead surface of the same shape as the
+  hash-keyed CAS island. `FileSize`'s one live caller is `findStaleSizes`
+  (`controlplane/runtime/shares/lifecycle.go:241`), which runs at share start over every
+  locally-resident file. It *is* O(intervals) under the shard lock and measurably linear
+  (#2366), but the cost lands on startup latency, not on reads. So the hot-path argument
+  for keeping `Size` out of `Extents` does not hold; if `Size` stays separate it needs a
+  different reason. Nothing else in this section changes.
 
 ## 11. Open decisions
 

--- a/.planning/perf/2026-09-06-block-transitions/README.md
+++ b/.planning/perf/2026-09-06-block-transitions/README.md
@@ -123,6 +123,19 @@ move is about a fifth, and only at low queue depth. It has to stand on residency
 correctness, which is what the plan claims for it anyway. The one place block-engine work
 *does* pay is the code-bound set above: `FileSize`, recovery, and the carve CPU path.
 
+## Known gap in this baseline
+
+`BenchmarkColdExtentsStoreWide` was added **after** these numbers were recorded and is not
+in the tables above. It exists because `BenchmarkColdExtents` could not answer the
+question the design plan asks: `ColdExtents` walks every shard, every file in it and every
+interval of each, and a single-file store exercises none of that fan-out. Spreading the
+same work over 2048 files costs **12.6× more** (108.9 µs vs 8.6 µs on a laptop,
+shape-only) and grows with file count — so the plan's concern about that query is real,
+and the 10.31 µs in the table above understates the store-wide cost it would otherwise be
+quoted for.
+
+Record it on reference hardware with the next baseline run.
+
 ## Caveats
 
 - One machine, one run each. Six samples per point, sequential tiers, no other load.

--- a/.planning/perf/2026-09-06-block-transitions/README.md
+++ b/.planning/perf/2026-09-06-block-transitions/README.md
@@ -1,0 +1,133 @@
+# Block state-transition baseline — recorded 2026-09-06
+
+The before-numbers for the pier/crane/ferry refactor. Design-plan §10 asks for one
+benchmark per state transition, allocations on every one, write amplification on the
+write path, and a recorded baseline on real hardware. This is that baseline.
+
+Raw `go test -bench` output is in `bench-5k.txt`, `bench-15k.txt`, `bench-tmpfs.txt`;
+machine and method in `bench-env.txt`. Compare a later run with:
+
+```sh
+benchstat sbs5k=bench-5k.txt new=<later>.txt
+```
+
+## Machine
+
+AMD EPYC 7543, 32 cores, 62 GiB, Linux 6.8.0-138, Go 1.25.0, Scaleway `fr-par-1`
+`POP2-HC-32C-64G` — the `vmType` already recorded in `bench/infra/Pulumi.bench.yaml`,
+so these sit alongside the earlier DittoFS baselines. Commit `74a74e812`.
+
+Not a laptop and not Docker Desktop, per the plan's admissibility rule.
+
+## Method
+
+Two invocations per tier, `-count=6` on both:
+
+```sh
+go test ./pkg/block/journal/ -run '^$' -bench . -skip "$HEAVY" -benchtime=1s  -count=6
+go test ./pkg/block/journal/ -run '^$' -bench "$HEAVY"          -benchtime=200x -count=6
+HEAVY='BenchmarkCarve$|BenchmarkCarveScatteredPass$|BenchmarkEvict$|BenchmarkGCRepack$|BenchmarkTruncate$|BenchmarkDelete$'
+```
+
+Those six rebuild their state inside `StopTimer` every iteration. Go sizes `b.N` from
+the timed region alone, so on a fast device it picks a count whose *untimed* setup runs
+for tens of minutes — `Truncate` reached 28k iterations on tmpfs, each rebuilding 4096
+intervals. They get an explicit iteration cap. `ns/op` stays comparable across the
+split; only the sample count differs.
+
+## The tiers, and a correction to what they were meant to show
+
+Three store locations, one machine, run sequentially so they never contend:
+
+| tier | device | `fdatasync=1` 4k IOPS (fio control) |
+|---|---|---|
+| `sbs5k` | Scaleway SBS, default | 476 |
+| `sbs15k` | Scaleway SBS, provisioned 15000 IOPS | 451 |
+| `ram` | tmpfs | 455,000 |
+
+**The two block tiers are the same device for this workload.** 476 vs 451 IOPS, and the
+benchmark geomean differs by +4.78% in the *slower* direction for the provisioned volume
+— noise, not signal. Provisioned IOPS raises a parallel-throughput ceiling; it does not
+move the ~2.1 ms network round-trip that a serialised fsync chain pays per barrier. So
+the two-tier disk-sensitivity curve this run was commissioned to produce does not exist,
+and `sbs15k` is retained only as evidence of that.
+
+The RAM tier is what supplies the fast end. It is not a machine anyone should run on —
+it is an upper bound that separates *device* cost from *code* cost, which is the split
+the block-size decision actually needs.
+
+## Results — `sbs5k` is the baseline, RAM shows what the device is buying
+
+| transition | benchmark | sbs5k | ram | device share |
+|---|---|---|---|---|
+| tombstone | `Delete` | 14.13 ms | 14.03 µs | **1007×** |
+| clip | `Truncate` | 24.62 ms | 36.67 µs | **671×** |
+| durability, tiny writes | `TinyWritesCommit` | 1.714 ms | 6.071 µs | **282×** |
+| durability, depth 1 | `ConcurrentCommit1` | 1.818 ms | 7.971 µs | **228×** |
+| Resident → Remote | `Evict` | 2.063 ms | 194.7 µs | 10.6× |
+| durability, depth 32 | `ConcurrentCommit32` | 125.9 µs | 11.75 µs | 10.7× |
+| compaction | `GCRepack` | 4.828 ms | 1.004 ms | 4.8× |
+| durability, depth 128 | `ConcurrentCommit128` | 42.56 µs | 12.91 µs | 3.3× |
+| dirty write | `WriteAt` (64 KiB) | 99.63 µs | 35.09 µs | 2.8× |
+| Remote → Resident | `Hydrate` | 55.09 µs | 35.42 µs | 1.6× |
+| seq write | `SeqWrite4K` | 11.33 µs | 7.725 µs | 1.5× |
+| bounded rand write | `RandWriteBounded` | 11.15 µs | 7.631 µs | 1.5× |
+| **code-bound below this line** | | | | |
+| carve | `Carve` (8 MiB) | 11.71 ms | 11.70 ms | 1.0× |
+| carve, scattered | `CarveScatteredPass` | 406.7 ms | 405.2 ms | 1.0× |
+| residency | `FileSize` | 23.93 µs | 23.91 µs | 1.0× |
+| residency | `DataExtents` | 21.49 µs | 21.45 µs | 1.0× |
+| residency | `ColdExtents` | 10.31 µs | 10.34 µs | 1.0× |
+| residency | `DurableExtent` | 16.80 ns | 16.83 ns | 1.0× |
+| cold read | `ReadCold` | 771.8 ns | 789.0 ns | 1.0× |
+| warm read | `ReadWarm` | 4.744 µs | 5.719 µs | 0.8× |
+| unbounded rand write | `RandWrite4K` | 103.7 µs | 118.4 µs | 0.9× |
+| recovery | `OpenRecovery` (512 files) | 18.74 ms | 21.11 ms | 0.9× |
+
+A ratio below 1.0 means RAM was *slower*: the work is CPU- or allocation-bound and the
+32 GiB tmpfs competes with the process for memory. Those are not disk measurements at all.
+
+## What this settles
+
+**1. The durability path is the device, and group commit is why it is survivable.**
+`ConcurrentCommit1` at 1.818 ms sits on the disk's synchronous-append floor. At depth 128
+the same work costs 42.56 µs — one barrier amortised across the batch, a 43× reduction.
+Any change to batching gets measured here first.
+
+**2. `Truncate` and `Delete` are almost pure fsync.** 671× and 1007×. Both append one
+marker and fsync it; on a network-backed volume the marker's barrier is the entire cost.
+Worth knowing before anyone optimises the index-clip half, which is under 0.2% of it.
+
+**3. The residency queries are pure CPU, and `FileSize` is the outlier.** Identical on
+every tier, to three digits. `DurableExtent` answers in 16.8 ns; `FileSize` takes
+23.93 µs — **1424× more** for a narrower question, because it scans every interval
+(#2366). That gap is code, and no disk will close it.
+
+**4. Carve is CPU-bound.** `Carve` is within noise across a 1000× device range: FastCDC
+plus BLAKE3 plus dedup dominate, not the write-out. `CarveScatteredPass` is flat by
+construction — the injected 50 µs deduper latency is most of its 406 ms.
+
+**5. Recovery is allocation-bound, not read-bound.** `OpenRecovery` is *slower* on RAM.
+36 MiB and 3426 allocations to replay 512 files, and it is a startup-latency SLO. It
+lands next to #2366 on the share-start thread, not on the I/O thread.
+
+## The stop condition: does the protocol layer bind before the block engine?
+
+**Yes, on the write path.** #1735 measured the create wall at ~1062 ops/s ≈ 940 µs per
+create, with block COMMIT fsync ~20% of it at nj=8. `ConcurrentCommit32` at 125.9 µs is
+the right order for that share, from an independent direction. Roughly four fifths of a
+create is spent above the block engine.
+
+So the refactor cannot be justified on create-path throughput — the ceiling it could
+move is about a fifth, and only at low queue depth. It has to stand on residency
+correctness, which is what the plan claims for it anyway. The one place block-engine work
+*does* pay is the code-bound set above: `FileSize`, recovery, and the carve CPU path.
+
+## Caveats
+
+- One machine, one run each. Six samples per point, sequential tiers, no other load.
+- The remote store is `fakeRemote` (in-memory). Nothing here measures S3.
+- `CarveScatteredPass` measures the packer against an *injected* 50 µs oracle latency,
+  not a real one. Re-measure against the real oracle on this hardware before quoting it
+  as an absolute.
+- `sbs15k` is retained as evidence that the tier is not a variable, not as a data point.

--- a/.planning/perf/2026-09-06-block-transitions/bench-15k.txt
+++ b/.planning/perf/2026-09-06-block-transitions/bench-15k.txt
@@ -1,0 +1,144 @@
+goos: linux
+goarch: amd64
+pkg: github.com/marmos91/dittofs/pkg/block/journal
+cpu: AMD EPYC 7543 32-Core Processor                
+BenchmarkConcurrentCommit1-32      	     721	   2067279 ns/op	   1.98 MB/s	       256.0 intervals	        16.00 segments	         1.010 write-amp	     113 B/op	       2 allocs/op
+BenchmarkConcurrentCommit1-32      	     652	   2386758 ns/op	   1.72 MB/s	       256.0 intervals	        16.00 segments	         1.010 write-amp	     117 B/op	       2 allocs/op
+BenchmarkConcurrentCommit1-32      	     664	   2568961 ns/op	   1.59 MB/s	       256.0 intervals	        16.00 segments	         1.010 write-amp	     116 B/op	       2 allocs/op
+BenchmarkConcurrentCommit1-32      	     604	   2759954 ns/op	   1.48 MB/s	       256.0 intervals	        16.00 segments	         1.010 write-amp	     121 B/op	       2 allocs/op
+BenchmarkConcurrentCommit1-32      	     603	   1974534 ns/op	   2.07 MB/s	       256.0 intervals	        16.00 segments	         1.010 write-amp	     121 B/op	       2 allocs/op
+BenchmarkConcurrentCommit1-32      	     704	   2007480 ns/op	   2.04 MB/s	       256.0 intervals	        16.00 segments	         1.010 write-amp	     114 B/op	       2 allocs/op
+BenchmarkConcurrentCommit32-32     	   10000	    182053 ns/op	  22.50 MB/s	       256.0 intervals	        16.00 segments	         1.010 write-amp	     165 B/op	       2 allocs/op
+BenchmarkConcurrentCommit32-32     	    7677	    136485 ns/op	  30.01 MB/s	       239.0 intervals	        16.00 segments	         1.010 write-amp	     195 B/op	       2 allocs/op
+BenchmarkConcurrentCommit32-32     	    7429	    206075 ns/op	  19.88 MB/s	       232.0 intervals	        16.00 segments	         1.010 write-amp	     198 B/op	       2 allocs/op
+BenchmarkConcurrentCommit32-32     	    8940	    149351 ns/op	  27.43 MB/s	       256.0 intervals	        16.00 segments	         1.010 write-amp	     175 B/op	       2 allocs/op
+BenchmarkConcurrentCommit32-32     	    9640	    184753 ns/op	  22.17 MB/s	       256.0 intervals	        16.00 segments	         1.010 write-amp	     168 B/op	       2 allocs/op
+BenchmarkConcurrentCommit32-32     	    8368	    150546 ns/op	  27.21 MB/s	       256.0 intervals	        16.00 segments	         1.010 write-amp	     182 B/op	       2 allocs/op
+BenchmarkConcurrentCommit128-32    	   21910	     51483 ns/op	  79.56 MB/s	       171.0 intervals	        16.00 segments	         1.010 write-amp	     250 B/op	       2 allocs/op
+BenchmarkConcurrentCommit128-32    	   18684	     59353 ns/op	  69.01 MB/s	       145.0 intervals	        16.00 segments	         1.010 write-amp	     282 B/op	       2 allocs/op
+BenchmarkConcurrentCommit128-32    	   23338	     46656 ns/op	  87.79 MB/s	       182.0 intervals	        16.00 segments	         1.010 write-amp	     236 B/op	       2 allocs/op
+BenchmarkConcurrentCommit128-32    	   25347	     48336 ns/op	  84.74 MB/s	       198.0 intervals	        16.00 segments	         1.010 write-amp	     222 B/op	       2 allocs/op
+BenchmarkConcurrentCommit128-32    	   27812	     47915 ns/op	  85.48 MB/s	       217.0 intervals	        16.00 segments	         1.010 write-amp	     207 B/op	       2 allocs/op
+BenchmarkConcurrentCommit128-32    	   25165	     51386 ns/op	  79.71 MB/s	       196.0 intervals	        16.00 segments	         1.010 write-amp	     223 B/op	       2 allocs/op
+BenchmarkWriteAt-32                	   10000	    151211 ns/op	 433.41 MB/s	     10000 intervals	        18.00 segments	         1.001 write-amp	     330 B/op	       2 allocs/op
+BenchmarkWriteAt-32                	   12926	    103096 ns/op	 635.68 MB/s	     12926 intervals	        19.00 segments	         1.001 write-amp	     335 B/op	       2 allocs/op
+BenchmarkWriteAt-32                	   10000	    112281 ns/op	 583.68 MB/s	     10000 intervals	        18.00 segments	         1.001 write-amp	     330 B/op	       2 allocs/op
+BenchmarkWriteAt-32                	   12974	     99048 ns/op	 661.66 MB/s	     12974 intervals	        19.00 segments	         1.001 write-amp	     334 B/op	       2 allocs/op
+BenchmarkWriteAt-32                	   12631	    103081 ns/op	 635.77 MB/s	     12631 intervals	        19.00 segments	         1.001 write-amp	     341 B/op	       2 allocs/op
+BenchmarkWriteAt-32                	   12765	    111987 ns/op	 585.21 MB/s	     12765 intervals	        19.00 segments	         1.001 write-amp	     338 B/op	       2 allocs/op
+BenchmarkTinyWritesCommit-32       	     589	   1807876 ns/op	   0.28 MB/s	       589.0 intervals	        16.00 segments	         1.087 write-amp	     274 B/op	       2 allocs/op
+BenchmarkTinyWritesCommit-32       	     670	   1826060 ns/op	   0.28 MB/s	       670.0 intervals	        16.00 segments	         1.087 write-amp	     248 B/op	       2 allocs/op
+BenchmarkTinyWritesCommit-32       	     639	   1607130 ns/op	   0.32 MB/s	       639.0 intervals	        16.00 segments	         1.087 write-amp	     256 B/op	       2 allocs/op
+BenchmarkTinyWritesCommit-32       	     756	   1671340 ns/op	   0.31 MB/s	       756.0 intervals	        16.00 segments	         1.087 write-amp	     227 B/op	       2 allocs/op
+BenchmarkTinyWritesCommit-32       	     636	   2621266 ns/op	   0.20 MB/s	       636.0 intervals	        16.00 segments	         1.087 write-amp	     259 B/op	       2 allocs/op
+BenchmarkTinyWritesCommit-32       	     710	   2087735 ns/op	   0.25 MB/s	       710.0 intervals	        16.00 segments	         1.087 write-amp	     238 B/op	       2 allocs/op
+BenchmarkReadWarm-32               	  220322	      4664 ns/op	14050.61 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadWarm-32               	  281937	      5351 ns/op	12246.35 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadWarm-32               	  293410	      4733 ns/op	13845.88 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadWarm-32               	  249306	      4912 ns/op	13342.53 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadWarm-32               	  243085	      4671 ns/op	14029.26 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadWarm-32               	  286610	      4641 ns/op	14120.70 MB/s	      64 B/op	       1 allocs/op
+BenchmarkRandWrite4K-32            	   99327	    102546 ns/op	  39.94 MB/s	     99327 intervals	        17.00 segments	         1.008 write-amp	     364 B/op	       2 allocs/op
+BenchmarkRandWrite4K-32            	   98799	    101124 ns/op	  40.50 MB/s	     98799 intervals	        17.00 segments	         1.008 write-amp	     366 B/op	       2 allocs/op
+BenchmarkRandWrite4K-32            	  101241	    103584 ns/op	  39.54 MB/s	    101241 intervals	        17.00 segments	         1.008 write-amp	     358 B/op	       2 allocs/op
+BenchmarkRandWrite4K-32            	  101942	    105650 ns/op	  38.77 MB/s	    101942 intervals	        17.00 segments	         1.008 write-amp	     356 B/op	       2 allocs/op
+BenchmarkRandWrite4K-32            	   98923	    101808 ns/op	  40.23 MB/s	     98923 intervals	        17.00 segments	         1.008 write-amp	     366 B/op	       2 allocs/op
+BenchmarkRandWrite4K-32            	   99181	    103613 ns/op	  39.53 MB/s	     99181 intervals	        17.00 segments	         1.008 write-amp	     365 B/op	       2 allocs/op
+BenchmarkRandWriteBounded-32       	  118219	     11052 ns/op	 370.60 MB/s	      4096 intervals	        17.00 segments	         1.008 write-amp	      64 B/op	       2 allocs/op
+BenchmarkRandWriteBounded-32       	  115964	     11168 ns/op	 366.75 MB/s	      4096 intervals	        17.00 segments	         1.008 write-amp	      64 B/op	       2 allocs/op
+BenchmarkRandWriteBounded-32       	  121561	     11096 ns/op	 369.16 MB/s	      4096 intervals	        17.00 segments	         1.008 write-amp	      64 B/op	       2 allocs/op
+BenchmarkRandWriteBounded-32       	  117289	     11118 ns/op	 368.42 MB/s	      4096 intervals	        17.00 segments	         1.008 write-amp	      64 B/op	       2 allocs/op
+BenchmarkRandWriteBounded-32       	  121191	     10958 ns/op	 373.79 MB/s	      4096 intervals	        17.00 segments	         1.008 write-amp	      64 B/op	       2 allocs/op
+BenchmarkRandWriteBounded-32       	  116541	     12086 ns/op	 338.91 MB/s	      4096 intervals	        17.00 segments	         1.008 write-amp	      64 B/op	       2 allocs/op
+BenchmarkSeqWrite4K-32             	  119886	     11975 ns/op	 342.06 MB/s	    119886 intervals	        17.00 segments	         1.008 write-amp	     379 B/op	       2 allocs/op
+BenchmarkSeqWrite4K-32             	  124075	     11411 ns/op	 358.95 MB/s	    124075 intervals	        17.00 segments	         1.008 write-amp	     367 B/op	       2 allocs/op
+BenchmarkSeqWrite4K-32             	  121096	     16623 ns/op	 246.40 MB/s	    121096 intervals	        17.00 segments	         1.008 write-amp	     375 B/op	       2 allocs/op
+BenchmarkSeqWrite4K-32             	  122744	     11128 ns/op	 368.08 MB/s	    122744 intervals	        17.00 segments	         1.008 write-amp	     371 B/op	       2 allocs/op
+BenchmarkSeqWrite4K-32             	  116367	     11146 ns/op	 367.48 MB/s	    116367 intervals	        17.00 segments	         1.008 write-amp	     389 B/op	       2 allocs/op
+BenchmarkSeqWrite4K-32             	  123396	     11328 ns/op	 361.58 MB/s	    123396 intervals	        17.00 segments	         1.008 write-amp	     369 B/op	       2 allocs/op
+BenchmarkReadCold-32               	 1549267	       774.6 ns/op	84601.22 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadCold-32               	 1545277	       775.0 ns/op	84563.03 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadCold-32               	 1545998	       773.2 ns/op	84758.49 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadCold-32               	 1548726	       773.4 ns/op	84735.05 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadCold-32               	 1549768	       775.5 ns/op	84512.62 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadCold-32               	 1541196	       775.5 ns/op	84510.27 MB/s	      64 B/op	       1 allocs/op
+BenchmarkHydrate-32                	   21577	     55015 ns/op	1191.25 MB/s	      88 B/op	       4 allocs/op
+BenchmarkHydrate-32                	   21663	     55152 ns/op	1188.28 MB/s	      88 B/op	       4 allocs/op
+BenchmarkHydrate-32                	   21344	     55707 ns/op	1176.43 MB/s	      88 B/op	       4 allocs/op
+BenchmarkHydrate-32                	   21249	     55172 ns/op	1187.86 MB/s	      88 B/op	       4 allocs/op
+BenchmarkHydrate-32                	   21516	     55048 ns/op	1190.53 MB/s	      88 B/op	       4 allocs/op
+BenchmarkHydrate-32                	   21302	     55109 ns/op	1189.21 MB/s	      88 B/op	       4 allocs/op
+BenchmarkOpenRecovery-32           	      54	  18978301 ns/op	38174171 B/op	    3424 allocs/op
+BenchmarkOpenRecovery-32           	      64	  18366354 ns/op	38174019 B/op	    3424 allocs/op
+BenchmarkOpenRecovery-32           	      60	  18703386 ns/op	38175623 B/op	    3422 allocs/op
+BenchmarkOpenRecovery-32           	      56	  18288463 ns/op	38175837 B/op	    3422 allocs/op
+BenchmarkOpenRecovery-32           	      63	  18672064 ns/op	38175184 B/op	    3424 allocs/op
+BenchmarkOpenRecovery-32           	      64	  19578927 ns/op	38175863 B/op	    3423 allocs/op
+BenchmarkFileSize-32               	   50138	     24022 ns/op	       0 B/op	       0 allocs/op
+BenchmarkFileSize-32               	   50278	     23874 ns/op	       0 B/op	       0 allocs/op
+BenchmarkFileSize-32               	   50178	     23905 ns/op	       0 B/op	       0 allocs/op
+BenchmarkFileSize-32               	   50065	     23939 ns/op	       0 B/op	       0 allocs/op
+BenchmarkFileSize-32               	   50200	     23917 ns/op	       0 B/op	       0 allocs/op
+BenchmarkFileSize-32               	   49857	     23927 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDataExtents-32            	   55958	     21446 ns/op	      16 B/op	       1 allocs/op
+BenchmarkDataExtents-32            	   55896	     21597 ns/op	      16 B/op	       1 allocs/op
+BenchmarkDataExtents-32            	   55692	     21691 ns/op	      16 B/op	       1 allocs/op
+BenchmarkDataExtents-32            	   55881	     21546 ns/op	      16 B/op	       1 allocs/op
+BenchmarkDataExtents-32            	   55603	     21580 ns/op	      16 B/op	       1 allocs/op
+BenchmarkDataExtents-32            	   56025	     21438 ns/op	      16 B/op	       1 allocs/op
+BenchmarkDurableExtent-32          	70228446	        17.80 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDurableExtent-32          	67646881	        17.39 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDurableExtent-32          	68934710	        17.56 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDurableExtent-32          	69410418	        17.55 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDurableExtent-32          	68848683	        17.71 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDurableExtent-32          	68926062	        17.65 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColdExtents-32            	  109318	     10319 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColdExtents-32            	  115142	     10607 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColdExtents-32            	  116763	     11282 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColdExtents-32            	  115588	     10399 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColdExtents-32            	  117423	     10300 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColdExtents-32            	  116348	     10317 ns/op	       0 B/op	       0 allocs/op
+PASS
+ok  	github.com/marmos91/dittofs/pkg/block/journal	237.470s
+goos: linux
+goarch: amd64
+pkg: github.com/marmos91/dittofs/pkg/block/journal
+cpu: AMD EPYC 7543 32-Core Processor                
+BenchmarkCarveScatteredPass-32    	     200	 402006195 ns/op	75495209 B/op	   80225 allocs/op
+BenchmarkCarveScatteredPass-32    	     200	 405786196 ns/op	70774053 B/op	   80220 allocs/op
+BenchmarkCarveScatteredPass-32    	     200	 405194297 ns/op	71025337 B/op	   80217 allocs/op
+BenchmarkCarveScatteredPass-32    	     200	 405445673 ns/op	70837007 B/op	   80220 allocs/op
+BenchmarkCarveScatteredPass-32    	     200	 405865728 ns/op	70543250 B/op	   80220 allocs/op
+BenchmarkCarveScatteredPass-32    	     200	 406294064 ns/op	70501146 B/op	   80217 allocs/op
+BenchmarkCarve-32                 	     200	  10081836 ns/op	 832.05 MB/s	26386571 B/op	    1105 allocs/op
+BenchmarkCarve-32                 	     200	  11776875 ns/op	 712.29 MB/s	24287667 B/op	    1103 allocs/op
+BenchmarkCarve-32                 	     200	  11854726 ns/op	 707.62 MB/s	25545879 B/op	    1101 allocs/op
+BenchmarkCarve-32                 	     200	  11535144 ns/op	 727.22 MB/s	25357061 B/op	    1101 allocs/op
+BenchmarkCarve-32                 	     200	  11634352 ns/op	 721.02 MB/s	23448617 B/op	    1101 allocs/op
+BenchmarkCarve-32                 	     200	  11939354 ns/op	 702.60 MB/s	26175136 B/op	    1102 allocs/op
+BenchmarkEvict-32                 	     200	   2020769 ns/op	    2181 B/op	      22 allocs/op
+BenchmarkEvict-32                 	     200	   2163340 ns/op	    2179 B/op	      22 allocs/op
+BenchmarkEvict-32                 	     200	   2119460 ns/op	    2179 B/op	      22 allocs/op
+BenchmarkEvict-32                 	     200	   2571750 ns/op	    2181 B/op	      22 allocs/op
+BenchmarkEvict-32                 	     200	   2203743 ns/op	    2181 B/op	      22 allocs/op
+BenchmarkEvict-32                 	     200	   2105331 ns/op	    2181 B/op	      22 allocs/op
+BenchmarkGCRepack-32              	     200	   5187942 ns/op	  835102 B/op	      38 allocs/op
+BenchmarkGCRepack-32              	     200	   4975887 ns/op	  841491 B/op	      38 allocs/op
+BenchmarkGCRepack-32              	     200	   5224562 ns/op	  827646 B/op	      39 allocs/op
+BenchmarkGCRepack-32              	     200	   4962642 ns/op	  834567 B/op	      38 allocs/op
+BenchmarkGCRepack-32              	     200	   5534682 ns/op	  839160 B/op	      38 allocs/op
+BenchmarkGCRepack-32              	     200	   5241725 ns/op	  835467 B/op	      39 allocs/op
+BenchmarkTruncate-32              	     200	  27388721 ns/op	      65 B/op	       2 allocs/op
+BenchmarkTruncate-32              	     200	  28763000 ns/op	      65 B/op	       2 allocs/op
+BenchmarkTruncate-32              	     200	  28876464 ns/op	      65 B/op	       2 allocs/op
+BenchmarkTruncate-32              	     200	  29037846 ns/op	      65 B/op	       2 allocs/op
+BenchmarkTruncate-32              	     200	  22975137 ns/op	      65 B/op	       2 allocs/op
+BenchmarkTruncate-32              	     200	  24540164 ns/op	      65 B/op	       2 allocs/op
+BenchmarkDelete-32                	     200	  14063353 ns/op	     176 B/op	       2 allocs/op
+BenchmarkDelete-32                	     200	  13719863 ns/op	     176 B/op	       2 allocs/op
+BenchmarkDelete-32                	     200	  17970749 ns/op	     176 B/op	       2 allocs/op
+BenchmarkDelete-32                	     200	  13516082 ns/op	     176 B/op	       2 allocs/op
+BenchmarkDelete-32                	     200	  13757999 ns/op	     176 B/op	       2 allocs/op
+BenchmarkDelete-32                	     200	  12994399 ns/op	     176 B/op	       2 allocs/op
+PASS
+ok  	github.com/marmos91/dittofs/pkg/block/journal	890.343s

--- a/.planning/perf/2026-09-06-block-transitions/bench-5k.txt
+++ b/.planning/perf/2026-09-06-block-transitions/bench-5k.txt
@@ -1,0 +1,144 @@
+goos: linux
+goarch: amd64
+pkg: github.com/marmos91/dittofs/pkg/block/journal
+cpu: AMD EPYC 7543 32-Core Processor                
+BenchmarkConcurrentCommit1-32      	     729	   1660250 ns/op	   2.47 MB/s	       256.0 intervals	        16.00 segments	         1.010 write-amp	     113 B/op	       2 allocs/op
+BenchmarkConcurrentCommit1-32      	     722	   1964410 ns/op	   2.09 MB/s	       256.0 intervals	        16.00 segments	         1.010 write-amp	     113 B/op	       2 allocs/op
+BenchmarkConcurrentCommit1-32      	     679	   1905395 ns/op	   2.15 MB/s	       256.0 intervals	        16.00 segments	         1.010 write-amp	     116 B/op	       2 allocs/op
+BenchmarkConcurrentCommit1-32      	     609	   1790510 ns/op	   2.29 MB/s	       256.0 intervals	        16.00 segments	         1.010 write-amp	     121 B/op	       2 allocs/op
+BenchmarkConcurrentCommit1-32      	     672	   1767792 ns/op	   2.32 MB/s	       256.0 intervals	        16.00 segments	         1.010 write-amp	     116 B/op	       2 allocs/op
+BenchmarkConcurrentCommit1-32      	     775	   1845865 ns/op	   2.22 MB/s	       256.0 intervals	        16.00 segments	         1.010 write-amp	     110 B/op	       2 allocs/op
+BenchmarkConcurrentCommit32-32     	    8752	    120355 ns/op	  34.03 MB/s	       256.0 intervals	        16.00 segments	         1.010 write-amp	     177 B/op	       2 allocs/op
+BenchmarkConcurrentCommit32-32     	   10000	    118933 ns/op	  34.44 MB/s	       256.0 intervals	        16.00 segments	         1.010 write-amp	     165 B/op	       2 allocs/op
+BenchmarkConcurrentCommit32-32     	   10000	    128875 ns/op	  31.78 MB/s	       256.0 intervals	        16.00 segments	         1.010 write-amp	     164 B/op	       2 allocs/op
+BenchmarkConcurrentCommit32-32     	    8365	    125521 ns/op	  32.63 MB/s	       256.0 intervals	        16.00 segments	         1.010 write-amp	     182 B/op	       2 allocs/op
+BenchmarkConcurrentCommit32-32     	   10000	    143696 ns/op	  28.50 MB/s	       256.0 intervals	        16.00 segments	         1.010 write-amp	     164 B/op	       2 allocs/op
+BenchmarkConcurrentCommit32-32     	   10000	    126284 ns/op	  32.43 MB/s	       256.0 intervals	        16.00 segments	         1.010 write-amp	     166 B/op	       2 allocs/op
+BenchmarkConcurrentCommit128-32    	   28856	     43495 ns/op	  94.17 MB/s	       225.0 intervals	        16.00 segments	         1.010 write-amp	     202 B/op	       2 allocs/op
+BenchmarkConcurrentCommit128-32    	   29796	     41627 ns/op	  98.40 MB/s	       232.0 intervals	        16.00 segments	         1.010 write-amp	     197 B/op	       2 allocs/op
+BenchmarkConcurrentCommit128-32    	   27708	     41058 ns/op	  99.76 MB/s	       216.0 intervals	        16.00 segments	         1.010 write-amp	     209 B/op	       2 allocs/op
+BenchmarkConcurrentCommit128-32    	   30061	     43071 ns/op	  95.10 MB/s	       234.0 intervals	        16.00 segments	         1.010 write-amp	     196 B/op	       2 allocs/op
+BenchmarkConcurrentCommit128-32    	   29824	     42039 ns/op	  97.43 MB/s	       233.0 intervals	        16.00 segments	         1.010 write-amp	     197 B/op	       2 allocs/op
+BenchmarkConcurrentCommit128-32    	   29756	     44130 ns/op	  92.82 MB/s	       232.0 intervals	        16.00 segments	         1.010 write-amp	     197 B/op	       2 allocs/op
+BenchmarkWriteAt-32                	   13282	     95580 ns/op	 685.67 MB/s	     13282 intervals	        19.00 segments	         1.001 write-amp	     408 B/op	       2 allocs/op
+BenchmarkWriteAt-32                	   12483	     99385 ns/op	 659.42 MB/s	     12483 intervals	        19.00 segments	         1.001 write-amp	     344 B/op	       2 allocs/op
+BenchmarkWriteAt-32                	   12708	     97083 ns/op	 675.05 MB/s	     12708 intervals	        19.00 segments	         1.001 write-amp	     339 B/op	       2 allocs/op
+BenchmarkWriteAt-32                	   13207	    102504 ns/op	 639.35 MB/s	     13207 intervals	        19.00 segments	         1.001 write-amp	     410 B/op	       2 allocs/op
+BenchmarkWriteAt-32                	   13305	    107787 ns/op	 608.01 MB/s	     13305 intervals	        19.00 segments	         1.001 write-amp	     408 B/op	       2 allocs/op
+BenchmarkWriteAt-32                	   13365	     99881 ns/op	 656.14 MB/s	     13365 intervals	        19.00 segments	         1.001 write-amp	     406 B/op	       2 allocs/op
+BenchmarkTinyWritesCommit-32       	     710	   1507957 ns/op	   0.34 MB/s	       710.0 intervals	        16.00 segments	         1.087 write-amp	     238 B/op	       2 allocs/op
+BenchmarkTinyWritesCommit-32       	     764	   1829415 ns/op	   0.28 MB/s	       764.0 intervals	        16.00 segments	         1.087 write-amp	     225 B/op	       2 allocs/op
+BenchmarkTinyWritesCommit-32       	     718	   1717201 ns/op	   0.30 MB/s	       718.0 intervals	        16.00 segments	         1.087 write-amp	     236 B/op	       2 allocs/op
+BenchmarkTinyWritesCommit-32       	     714	   1576917 ns/op	   0.32 MB/s	       714.0 intervals	        16.00 segments	         1.087 write-amp	     237 B/op	       2 allocs/op
+BenchmarkTinyWritesCommit-32       	     765	   1867756 ns/op	   0.27 MB/s	       765.0 intervals	        16.00 segments	         1.087 write-amp	     225 B/op	       2 allocs/op
+BenchmarkTinyWritesCommit-32       	     700	   1711493 ns/op	   0.30 MB/s	       700.0 intervals	        16.00 segments	         1.087 write-amp	     240 B/op	       2 allocs/op
+BenchmarkReadWarm-32               	  251707	      5396 ns/op	12144.73 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadWarm-32               	  210730	      4756 ns/op	13780.95 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadWarm-32               	  261164	      4731 ns/op	13851.84 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadWarm-32               	  237426	      5045 ns/op	12990.83 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadWarm-32               	  241176	      4574 ns/op	14326.68 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadWarm-32               	  226099	      4580 ns/op	14308.82 MB/s	      64 B/op	       1 allocs/op
+BenchmarkRandWrite4K-32            	   97684	    102025 ns/op	  40.15 MB/s	     97684 intervals	        17.00 segments	         1.008 write-amp	     370 B/op	       2 allocs/op
+BenchmarkRandWrite4K-32            	  100808	    104285 ns/op	  39.28 MB/s	    100808 intervals	        17.00 segments	         1.008 write-amp	     360 B/op	       2 allocs/op
+BenchmarkRandWrite4K-32            	  101707	    104631 ns/op	  39.15 MB/s	    101707 intervals	        17.00 segments	         1.008 write-amp	     357 B/op	       2 allocs/op
+BenchmarkRandWrite4K-32            	  102248	    105544 ns/op	  38.81 MB/s	    102248 intervals	        17.00 segments	         1.008 write-amp	     355 B/op	       2 allocs/op
+BenchmarkRandWrite4K-32            	   99030	    102157 ns/op	  40.10 MB/s	     99030 intervals	        17.00 segments	         1.008 write-amp	     365 B/op	       2 allocs/op
+BenchmarkRandWrite4K-32            	  100689	    103171 ns/op	  39.70 MB/s	    100689 intervals	        17.00 segments	         1.008 write-amp	     360 B/op	       2 allocs/op
+BenchmarkRandWriteBounded-32       	  121606	     11177 ns/op	 366.46 MB/s	      4096 intervals	        17.00 segments	         1.008 write-amp	      64 B/op	       2 allocs/op
+BenchmarkRandWriteBounded-32       	  116954	     11142 ns/op	 367.61 MB/s	      4096 intervals	        17.00 segments	         1.008 write-amp	      64 B/op	       2 allocs/op
+BenchmarkRandWriteBounded-32       	  121299	     11098 ns/op	 369.07 MB/s	      4096 intervals	        17.00 segments	         1.008 write-amp	      64 B/op	       2 allocs/op
+BenchmarkRandWriteBounded-32       	  116329	     11151 ns/op	 367.34 MB/s	      4096 intervals	        17.00 segments	         1.008 write-amp	      64 B/op	       2 allocs/op
+BenchmarkRandWriteBounded-32       	  120513	     11028 ns/op	 371.43 MB/s	      4096 intervals	        17.00 segments	         1.008 write-amp	      64 B/op	       2 allocs/op
+BenchmarkRandWriteBounded-32       	  121093	     11186 ns/op	 366.18 MB/s	      4096 intervals	        17.00 segments	         1.008 write-amp	      64 B/op	       2 allocs/op
+BenchmarkSeqWrite4K-32             	  118136	     11375 ns/op	 360.10 MB/s	    118136 intervals	        17.00 segments	         1.008 write-amp	     384 B/op	       2 allocs/op
+BenchmarkSeqWrite4K-32             	  124321	     11050 ns/op	 370.68 MB/s	    124321 intervals	        17.00 segments	         1.008 write-amp	     367 B/op	       2 allocs/op
+BenchmarkSeqWrite4K-32             	  124771	     11476 ns/op	 356.92 MB/s	    124771 intervals	        17.00 segments	         1.008 write-amp	     365 B/op	       2 allocs/op
+BenchmarkSeqWrite4K-32             	  123991	     16499 ns/op	 248.26 MB/s	    123991 intervals	        17.00 segments	         1.008 write-amp	     368 B/op	       2 allocs/op
+BenchmarkSeqWrite4K-32             	  123892	     11289 ns/op	 362.84 MB/s	    123892 intervals	        17.00 segments	         1.008 write-amp	     368 B/op	       2 allocs/op
+BenchmarkSeqWrite4K-32             	  119864	     11283 ns/op	 363.01 MB/s	    119864 intervals	        17.00 segments	         1.008 write-amp	     379 B/op	       2 allocs/op
+BenchmarkReadCold-32               	 1550907	       773.0 ns/op	84782.03 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadCold-32               	 1544480	       771.4 ns/op	84952.71 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadCold-32               	 1550852	       772.6 ns/op	84827.02 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadCold-32               	 1550228	       772.1 ns/op	84880.39 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadCold-32               	 1550706	       770.4 ns/op	85072.96 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadCold-32               	 1545984	       770.5 ns/op	85061.76 MB/s	      64 B/op	       1 allocs/op
+BenchmarkHydrate-32                	   21698	     54808 ns/op	1195.75 MB/s	      88 B/op	       4 allocs/op
+BenchmarkHydrate-32                	   21634	     54940 ns/op	1192.86 MB/s	      88 B/op	       4 allocs/op
+BenchmarkHydrate-32                	   21582	     55321 ns/op	1184.64 MB/s	      88 B/op	       4 allocs/op
+BenchmarkHydrate-32                	   21714	     55211 ns/op	1187.01 MB/s	      88 B/op	       4 allocs/op
+BenchmarkHydrate-32                	   21706	     55224 ns/op	1186.73 MB/s	      88 B/op	       4 allocs/op
+BenchmarkHydrate-32                	   21110	     54973 ns/op	1192.15 MB/s	      88 B/op	       4 allocs/op
+BenchmarkOpenRecovery-32           	      64	  19182039 ns/op	38174931 B/op	    3421 allocs/op
+BenchmarkOpenRecovery-32           	      58	  18965507 ns/op	38174522 B/op	    3422 allocs/op
+BenchmarkOpenRecovery-32           	      57	  18520803 ns/op	38174696 B/op	    3422 allocs/op
+BenchmarkOpenRecovery-32           	      58	  17871051 ns/op	38174523 B/op	    3422 allocs/op
+BenchmarkOpenRecovery-32           	      62	  19138088 ns/op	38175974 B/op	    3420 allocs/op
+BenchmarkOpenRecovery-32           	      68	  18371415 ns/op	38175128 B/op	    3423 allocs/op
+BenchmarkFileSize-32               	   50342	     23947 ns/op	       0 B/op	       0 allocs/op
+BenchmarkFileSize-32               	   50586	     23877 ns/op	       0 B/op	       0 allocs/op
+BenchmarkFileSize-32               	   50156	     24142 ns/op	       0 B/op	       0 allocs/op
+BenchmarkFileSize-32               	   50449	     24040 ns/op	       0 B/op	       0 allocs/op
+BenchmarkFileSize-32               	   50302	     23903 ns/op	       0 B/op	       0 allocs/op
+BenchmarkFileSize-32               	   50199	     23832 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDataExtents-32            	   55429	     21603 ns/op	      16 B/op	       1 allocs/op
+BenchmarkDataExtents-32            	   54476	     21365 ns/op	      16 B/op	       1 allocs/op
+BenchmarkDataExtents-32            	   55832	     21510 ns/op	      16 B/op	       1 allocs/op
+BenchmarkDataExtents-32            	   56182	     21462 ns/op	      16 B/op	       1 allocs/op
+BenchmarkDataExtents-32            	   55983	     21589 ns/op	      16 B/op	       1 allocs/op
+BenchmarkDataExtents-32            	   55754	     21456 ns/op	      16 B/op	       1 allocs/op
+BenchmarkDurableExtent-32          	64703640	        16.78 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDurableExtent-32          	71555667	        16.79 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDurableExtent-32          	71578672	        16.78 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDurableExtent-32          	71025060	        16.85 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDurableExtent-32          	71305611	        16.85 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDurableExtent-32          	70007595	        16.81 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColdExtents-32            	  118146	     10291 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColdExtents-32            	  116542	     10250 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColdExtents-32            	  109812	     10333 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColdExtents-32            	  114916	     10390 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColdExtents-32            	  116635	     10415 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColdExtents-32            	  117548	     10217 ns/op	       0 B/op	       0 allocs/op
+PASS
+ok  	github.com/marmos91/dittofs/pkg/block/journal	233.206s
+goos: linux
+goarch: amd64
+pkg: github.com/marmos91/dittofs/pkg/block/journal
+cpu: AMD EPYC 7543 32-Core Processor                
+BenchmarkCarveScatteredPass-32    	     200	 402201876 ns/op	74278615 B/op	   80221 allocs/op
+BenchmarkCarveScatteredPass-32    	     200	 407112170 ns/op	70753080 B/op	   80218 allocs/op
+BenchmarkCarveScatteredPass-32    	     200	 406316111 ns/op	70396214 B/op	   80215 allocs/op
+BenchmarkCarveScatteredPass-32    	     200	 406631115 ns/op	70480328 B/op	   80221 allocs/op
+BenchmarkCarveScatteredPass-32    	     200	 406802090 ns/op	70920786 B/op	   80220 allocs/op
+BenchmarkCarveScatteredPass-32    	     200	 407098961 ns/op	70941691 B/op	   80222 allocs/op
+BenchmarkCarve-32                 	     200	   9890242 ns/op	 848.17 MB/s	25337948 B/op	    1105 allocs/op
+BenchmarkCarve-32                 	     200	  11857529 ns/op	 707.45 MB/s	26070498 B/op	    1103 allocs/op
+BenchmarkCarve-32                 	     200	  11968289 ns/op	 700.90 MB/s	25755742 B/op	    1101 allocs/op
+BenchmarkCarve-32                 	     200	  11501013 ns/op	 729.38 MB/s	24287420 B/op	    1101 allocs/op
+BenchmarkCarve-32                 	     200	  11944141 ns/op	 702.32 MB/s	24602013 B/op	    1101 allocs/op
+BenchmarkCarve-32                 	     200	  11561775 ns/op	 725.55 MB/s	24811905 B/op	    1102 allocs/op
+BenchmarkEvict-32                 	     200	   2071277 ns/op	    2179 B/op	      22 allocs/op
+BenchmarkEvict-32                 	     200	   2054388 ns/op	    2181 B/op	      22 allocs/op
+BenchmarkEvict-32                 	     200	   2093587 ns/op	    2179 B/op	      22 allocs/op
+BenchmarkEvict-32                 	     200	   2079943 ns/op	    2182 B/op	      22 allocs/op
+BenchmarkEvict-32                 	     200	   2018397 ns/op	    2180 B/op	      22 allocs/op
+BenchmarkEvict-32                 	     200	   1953751 ns/op	    2181 B/op	      22 allocs/op
+BenchmarkGCRepack-32              	     200	   5169174 ns/op	  833235 B/op	      39 allocs/op
+BenchmarkGCRepack-32              	     200	   4389389 ns/op	  847379 B/op	      37 allocs/op
+BenchmarkGCRepack-32              	     200	   4667023 ns/op	  853396 B/op	      38 allocs/op
+BenchmarkGCRepack-32              	     200	   5036323 ns/op	  840795 B/op	      39 allocs/op
+BenchmarkGCRepack-32              	     200	   4463252 ns/op	  849052 B/op	      38 allocs/op
+BenchmarkGCRepack-32              	     200	   4988101 ns/op	  830362 B/op	      39 allocs/op
+BenchmarkTruncate-32              	     200	  23529598 ns/op	      65 B/op	       2 allocs/op
+BenchmarkTruncate-32              	     200	  27326756 ns/op	      65 B/op	       2 allocs/op
+BenchmarkTruncate-32              	     200	  25491400 ns/op	      65 B/op	       2 allocs/op
+BenchmarkTruncate-32              	     200	  24056438 ns/op	      65 B/op	       2 allocs/op
+BenchmarkTruncate-32              	     200	  25175206 ns/op	      65 B/op	       2 allocs/op
+BenchmarkTruncate-32              	     200	  23014748 ns/op	      65 B/op	       2 allocs/op
+BenchmarkDelete-32                	     200	  16165764 ns/op	     176 B/op	       2 allocs/op
+BenchmarkDelete-32                	     200	  13226521 ns/op	     176 B/op	       2 allocs/op
+BenchmarkDelete-32                	     200	  15001656 ns/op	     176 B/op	       2 allocs/op
+BenchmarkDelete-32                	     200	  13811104 ns/op	     176 B/op	       2 allocs/op
+BenchmarkDelete-32                	     200	  14457597 ns/op	     176 B/op	       2 allocs/op
+BenchmarkDelete-32                	     200	  13619581 ns/op	     176 B/op	       2 allocs/op
+PASS
+ok  	github.com/marmos91/dittofs/pkg/block/journal	882.508s

--- a/.planning/perf/2026-09-06-block-transitions/bench-env.txt
+++ b/.planning/perf/2026-09-06-block-transitions/bench-env.txt
@@ -1,0 +1,9 @@
+commit:  74a74e812f49b7515bfcba044a955b981a733fd0
+kernel:  6.8.0-138-generic
+cpu:     AMD EPYC 7543 32-Core Processor
+cores:   32
+mem:     62G
+go:      go version go1.25.0 linux/amd64
+method:  light set -benchtime=1s -count=6; heavy set -benchtime=200x -count=6
+heavy:   BenchmarkCarve$|BenchmarkCarveScatteredPass$|BenchmarkEvict$|BenchmarkGCRepack$|BenchmarkTruncate$|BenchmarkDelete$
+started: 2026-09-06T22:41:21+00:00

--- a/.planning/perf/2026-09-06-block-transitions/bench-tmpfs.txt
+++ b/.planning/perf/2026-09-06-block-transitions/bench-tmpfs.txt
@@ -1,0 +1,144 @@
+goos: linux
+goarch: amd64
+pkg: github.com/marmos91/dittofs/pkg/block/journal
+cpu: AMD EPYC 7543 32-Core Processor                
+BenchmarkConcurrentCommit1-32      	  145936	      8017 ns/op	 510.93 MB/s	       256.0 intervals	        18.00 segments	         1.009 write-amp	      72 B/op	       2 allocs/op
+BenchmarkConcurrentCommit1-32      	  148136	      7958 ns/op	 514.71 MB/s	       256.0 intervals	        18.00 segments	         1.009 write-amp	      72 B/op	       2 allocs/op
+BenchmarkConcurrentCommit1-32      	  149028	      7951 ns/op	 515.13 MB/s	       256.0 intervals	        18.00 segments	         1.009 write-amp	      72 B/op	       2 allocs/op
+BenchmarkConcurrentCommit1-32      	  147831	      7984 ns/op	 513.01 MB/s	       256.0 intervals	        18.00 segments	         1.009 write-amp	      72 B/op	       2 allocs/op
+BenchmarkConcurrentCommit1-32      	  145659	      7945 ns/op	 515.53 MB/s	       256.0 intervals	        18.00 segments	         1.009 write-amp	      72 B/op	       2 allocs/op
+BenchmarkConcurrentCommit1-32      	  151120	      8010 ns/op	 511.34 MB/s	       256.0 intervals	        18.00 segments	         1.009 write-amp	      72 B/op	       2 allocs/op
+BenchmarkConcurrentCommit32-32     	  103857	     11776 ns/op	 347.84 MB/s	       256.0 intervals	        17.00 segments	         1.009 write-amp	      81 B/op	       2 allocs/op
+BenchmarkConcurrentCommit32-32     	  101368	     11763 ns/op	 348.20 MB/s	       256.0 intervals	        17.00 segments	         1.009 write-amp	      81 B/op	       2 allocs/op
+BenchmarkConcurrentCommit32-32     	  103738	     11636 ns/op	 352.01 MB/s	       256.0 intervals	        17.00 segments	         1.009 write-amp	      81 B/op	       2 allocs/op
+BenchmarkConcurrentCommit32-32     	  105111	     11733 ns/op	 349.10 MB/s	       256.0 intervals	        17.00 segments	         1.009 write-amp	      81 B/op	       2 allocs/op
+BenchmarkConcurrentCommit32-32     	  101373	     11560 ns/op	 354.33 MB/s	       256.0 intervals	        17.00 segments	         1.009 write-amp	      81 B/op	       2 allocs/op
+BenchmarkConcurrentCommit32-32     	  103768	     11816 ns/op	 346.66 MB/s	       256.0 intervals	        17.00 segments	         1.009 write-amp	      81 B/op	       2 allocs/op
+BenchmarkConcurrentCommit128-32    	   90228	     12951 ns/op	 316.26 MB/s	       256.0 intervals	        17.00 segments	         1.010 write-amp	     113 B/op	       2 allocs/op
+BenchmarkConcurrentCommit128-32    	   90838	     12887 ns/op	 317.85 MB/s	       256.0 intervals	        17.00 segments	         1.010 write-amp	     113 B/op	       2 allocs/op
+BenchmarkConcurrentCommit128-32    	   91492	     12790 ns/op	 320.24 MB/s	       256.0 intervals	        17.00 segments	         1.010 write-amp	     112 B/op	       2 allocs/op
+BenchmarkConcurrentCommit128-32    	   93573	     12759 ns/op	 321.04 MB/s	       256.0 intervals	        17.00 segments	         1.010 write-amp	     111 B/op	       2 allocs/op
+BenchmarkConcurrentCommit128-32    	   92449	     12927 ns/op	 316.85 MB/s	       256.0 intervals	        17.00 segments	         1.010 write-amp	     112 B/op	       2 allocs/op
+BenchmarkConcurrentCommit128-32    	   89857	     13044 ns/op	 314.02 MB/s	       256.0 intervals	        17.00 segments	         1.010 write-amp	     113 B/op	       2 allocs/op
+BenchmarkWriteAt-32                	   33853	     35442 ns/op	1849.11 MB/s	     33853 intervals	        24.00 segments	         1.001 write-amp	     434 B/op	       2 allocs/op
+BenchmarkWriteAt-32                	   33168	     34671 ns/op	1890.24 MB/s	     33168 intervals	        24.00 segments	         1.001 write-amp	     359 B/op	       2 allocs/op
+BenchmarkWriteAt-32                	   34000	     35187 ns/op	1862.48 MB/s	     34000 intervals	        24.00 segments	         1.001 write-amp	     432 B/op	       2 allocs/op
+BenchmarkWriteAt-32                	   33735	     35465 ns/op	1847.91 MB/s	     33735 intervals	        24.00 segments	         1.001 write-amp	     435 B/op	       2 allocs/op
+BenchmarkWriteAt-32                	   33158	     34930 ns/op	1876.21 MB/s	     33158 intervals	        24.00 segments	         1.001 write-amp	     360 B/op	       2 allocs/op
+BenchmarkWriteAt-32                	   33776	     34984 ns/op	1873.30 MB/s	     33776 intervals	        24.00 segments	         1.001 write-amp	     434 B/op	       2 allocs/op
+BenchmarkTinyWritesCommit-32       	  201925	      6065 ns/op	  84.42 MB/s	    201925 intervals	        16.00 segments	         1.084 write-amp	     382 B/op	       2 allocs/op
+BenchmarkTinyWritesCommit-32       	  202320	      6026 ns/op	  84.96 MB/s	    202320 intervals	        16.00 segments	         1.084 write-amp	     382 B/op	       2 allocs/op
+BenchmarkTinyWritesCommit-32       	  199300	      6077 ns/op	  84.25 MB/s	    199300 intervals	        16.00 segments	         1.084 write-amp	     386 B/op	       2 allocs/op
+BenchmarkTinyWritesCommit-32       	  203761	      6102 ns/op	  83.91 MB/s	    203761 intervals	        16.00 segments	         1.084 write-amp	     379 B/op	       2 allocs/op
+BenchmarkTinyWritesCommit-32       	  204075	      6096 ns/op	  83.99 MB/s	    204075 intervals	        16.00 segments	         1.084 write-amp	     379 B/op	       2 allocs/op
+BenchmarkTinyWritesCommit-32       	  204474	      5984 ns/op	  85.56 MB/s	    204474 intervals	        16.00 segments	         1.084 write-amp	     378 B/op	       2 allocs/op
+BenchmarkReadWarm-32               	  198134	      5666 ns/op	11566.51 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadWarm-32               	  203499	      5737 ns/op	11422.62 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadWarm-32               	  208062	      5700 ns/op	11497.90 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadWarm-32               	  200661	      5928 ns/op	11055.47 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadWarm-32               	  203800	      6128 ns/op	10694.47 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadWarm-32               	  206673	      5623 ns/op	11654.12 MB/s	      64 B/op	       1 allocs/op
+BenchmarkRandWrite4K-32            	  119492	    119073 ns/op	  34.40 MB/s	    119492 intervals	        17.00 segments	         1.008 write-amp	     380 B/op	       2 allocs/op
+BenchmarkRandWrite4K-32            	  119752	    118759 ns/op	  34.49 MB/s	    119752 intervals	        17.00 segments	         1.008 write-amp	     379 B/op	       2 allocs/op
+BenchmarkRandWrite4K-32            	  120150	    117530 ns/op	  34.85 MB/s	    120150 intervals	        17.00 segments	         1.008 write-amp	     378 B/op	       2 allocs/op
+BenchmarkRandWrite4K-32            	  119004	    117713 ns/op	  34.80 MB/s	    119004 intervals	        17.00 segments	         1.008 write-amp	     381 B/op	       2 allocs/op
+BenchmarkRandWrite4K-32            	  122280	    121714 ns/op	  33.65 MB/s	    122280 intervals	        17.00 segments	         1.008 write-amp	     372 B/op	       2 allocs/op
+BenchmarkRandWrite4K-32            	  119049	    118036 ns/op	  34.70 MB/s	    119049 intervals	        17.00 segments	         1.008 write-amp	     381 B/op	       2 allocs/op
+BenchmarkRandWriteBounded-32       	  150288	      7649 ns/op	 535.50 MB/s	      4096 intervals	        18.00 segments	         1.008 write-amp	      62 B/op	       2 allocs/op
+BenchmarkRandWriteBounded-32       	  151977	      7628 ns/op	 537.00 MB/s	      4096 intervals	        18.00 segments	         1.008 write-amp	      62 B/op	       2 allocs/op
+BenchmarkRandWriteBounded-32       	  146740	      7633 ns/op	 536.60 MB/s	      4096 intervals	        18.00 segments	         1.008 write-amp	      62 B/op	       2 allocs/op
+BenchmarkRandWriteBounded-32       	  149552	      7589 ns/op	 539.73 MB/s	      4096 intervals	        18.00 segments	         1.008 write-amp	      62 B/op	       2 allocs/op
+BenchmarkRandWriteBounded-32       	  146348	      7607 ns/op	 538.44 MB/s	      4096 intervals	        18.00 segments	         1.008 write-amp	      62 B/op	       2 allocs/op
+BenchmarkRandWriteBounded-32       	  151392	      7659 ns/op	 534.78 MB/s	      4096 intervals	        18.00 segments	         1.008 write-amp	      62 B/op	       2 allocs/op
+BenchmarkSeqWrite4K-32             	  154966	      7757 ns/op	 528.07 MB/s	    154966 intervals	        18.00 segments	         1.008 write-amp	     370 B/op	       2 allocs/op
+BenchmarkSeqWrite4K-32             	  153340	      7816 ns/op	 524.08 MB/s	    153340 intervals	        18.00 segments	         1.008 write-amp	     373 B/op	       2 allocs/op
+BenchmarkSeqWrite4K-32             	  152060	      7741 ns/op	 529.13 MB/s	    152060 intervals	        18.00 segments	         1.008 write-amp	     376 B/op	       2 allocs/op
+BenchmarkSeqWrite4K-32             	  153688	      7707 ns/op	 531.45 MB/s	    153688 intervals	        18.00 segments	         1.008 write-amp	     373 B/op	       2 allocs/op
+BenchmarkSeqWrite4K-32             	  156874	      7687 ns/op	 532.85 MB/s	    156874 intervals	        18.00 segments	         1.008 write-amp	     366 B/op	       2 allocs/op
+BenchmarkSeqWrite4K-32             	  158146	      7708 ns/op	 531.40 MB/s	    158146 intervals	        18.00 segments	         1.008 write-amp	     363 B/op	       2 allocs/op
+BenchmarkReadCold-32               	 1521974	       787.7 ns/op	83197.17 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadCold-32               	 1516330	       793.7 ns/op	82572.25 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadCold-32               	 1508374	       788.8 ns/op	83078.94 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadCold-32               	 1519368	       789.2 ns/op	83041.87 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadCold-32               	 1515050	       791.6 ns/op	82789.87 MB/s	      64 B/op	       1 allocs/op
+BenchmarkReadCold-32               	 1515261	       788.2 ns/op	83147.37 MB/s	      64 B/op	       1 allocs/op
+BenchmarkHydrate-32                	   33351	     35342 ns/op	1854.33 MB/s	      88 B/op	       4 allocs/op
+BenchmarkHydrate-32                	   33459	     35559 ns/op	1843.01 MB/s	      88 B/op	       4 allocs/op
+BenchmarkHydrate-32                	   32967	     35586 ns/op	1841.63 MB/s	      88 B/op	       4 allocs/op
+BenchmarkHydrate-32                	   33234	     35388 ns/op	1851.94 MB/s	      88 B/op	       4 allocs/op
+BenchmarkHydrate-32                	   32995	     35444 ns/op	1849.00 MB/s	      88 B/op	       4 allocs/op
+BenchmarkHydrate-32                	   33337	     35284 ns/op	1857.36 MB/s	      88 B/op	       4 allocs/op
+BenchmarkOpenRecovery-32           	      50	  24099544 ns/op	38170740 B/op	    3424 allocs/op
+BenchmarkOpenRecovery-32           	      54	  22113998 ns/op	38173304 B/op	    3422 allocs/op
+BenchmarkOpenRecovery-32           	      56	  21242479 ns/op	38175025 B/op	    3424 allocs/op
+BenchmarkOpenRecovery-32           	      54	  20971090 ns/op	38174358 B/op	    3423 allocs/op
+BenchmarkOpenRecovery-32           	      51	  20789402 ns/op	38175248 B/op	    3422 allocs/op
+BenchmarkOpenRecovery-32           	      52	  20754497 ns/op	38175515 B/op	    3422 allocs/op
+BenchmarkFileSize-32               	   50360	     24019 ns/op	       0 B/op	       0 allocs/op
+BenchmarkFileSize-32               	   50049	     23983 ns/op	       0 B/op	       0 allocs/op
+BenchmarkFileSize-32               	   50218	     23861 ns/op	       0 B/op	       0 allocs/op
+BenchmarkFileSize-32               	   50264	     23906 ns/op	       0 B/op	       0 allocs/op
+BenchmarkFileSize-32               	   50176	     23895 ns/op	       0 B/op	       0 allocs/op
+BenchmarkFileSize-32               	   50097	     23918 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDataExtents-32            	   56307	     21312 ns/op	      16 B/op	       1 allocs/op
+BenchmarkDataExtents-32            	   56176	     21454 ns/op	      16 B/op	       1 allocs/op
+BenchmarkDataExtents-32            	   56073	     21556 ns/op	      16 B/op	       1 allocs/op
+BenchmarkDataExtents-32            	   56049	     21440 ns/op	      16 B/op	       1 allocs/op
+BenchmarkDataExtents-32            	   55429	     21522 ns/op	      16 B/op	       1 allocs/op
+BenchmarkDataExtents-32            	   56396	     21282 ns/op	      16 B/op	       1 allocs/op
+BenchmarkDurableExtent-32          	68572360	        16.79 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDurableExtent-32          	69892748	        16.78 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDurableExtent-32          	69464740	        16.82 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDurableExtent-32          	70351143	        16.90 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDurableExtent-32          	69741078	        16.97 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDurableExtent-32          	71121036	        16.83 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColdExtents-32            	  115434	     10240 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColdExtents-32            	  116012	     10394 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColdExtents-32            	  115602	     10211 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColdExtents-32            	  117292	     10372 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColdExtents-32            	  117003	     10553 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColdExtents-32            	  116274	     10303 ns/op	       0 B/op	       0 allocs/op
+PASS
+ok  	github.com/marmos91/dittofs/pkg/block/journal	226.583s
+goos: linux
+goarch: amd64
+pkg: github.com/marmos91/dittofs/pkg/block/journal
+cpu: AMD EPYC 7543 32-Core Processor                
+BenchmarkCarveScatteredPass-32    	     200	 402184898 ns/op	74635240 B/op	   80222 allocs/op
+BenchmarkCarveScatteredPass-32    	     200	 405076525 ns/op	70375531 B/op	   80219 allocs/op
+BenchmarkCarveScatteredPass-32    	     200	 404996588 ns/op	70396417 B/op	   80219 allocs/op
+BenchmarkCarveScatteredPass-32    	     200	 405308790 ns/op	71067322 B/op	   80215 allocs/op
+BenchmarkCarveScatteredPass-32    	     200	 405775421 ns/op	70731811 B/op	   80217 allocs/op
+BenchmarkCarveScatteredPass-32    	     200	 405834631 ns/op	70186804 B/op	   80220 allocs/op
+BenchmarkCarve-32                 	     200	  10131611 ns/op	 827.96 MB/s	26596067 B/op	    1105 allocs/op
+BenchmarkCarve-32                 	     200	  10831559 ns/op	 774.46 MB/s	25671895 B/op	    1103 allocs/op
+BenchmarkCarve-32                 	     200	  12097561 ns/op	 693.41 MB/s	26070261 B/op	    1101 allocs/op
+BenchmarkCarve-32                 	     200	  11750091 ns/op	 713.92 MB/s	26279978 B/op	    1102 allocs/op
+BenchmarkCarve-32                 	     200	  11647102 ns/op	 720.23 MB/s	26070105 B/op	    1101 allocs/op
+BenchmarkCarve-32                 	     200	  11784954 ns/op	 711.81 MB/s	25336206 B/op	    1101 allocs/op
+BenchmarkEvict-32                 	     200	    193460 ns/op	    2211 B/op	      22 allocs/op
+BenchmarkEvict-32                 	     200	    188488 ns/op	    2211 B/op	      22 allocs/op
+BenchmarkEvict-32                 	     200	    194532 ns/op	    2213 B/op	      22 allocs/op
+BenchmarkEvict-32                 	     200	    196512 ns/op	    2211 B/op	      22 allocs/op
+BenchmarkEvict-32                 	     200	    195615 ns/op	    2211 B/op	      22 allocs/op
+BenchmarkEvict-32                 	     200	    194959 ns/op	    2211 B/op	      22 allocs/op
+BenchmarkGCRepack-32              	     200	   1002482 ns/op	  840521 B/op	      38 allocs/op
+BenchmarkGCRepack-32              	     200	   1005110 ns/op	  837573 B/op	      38 allocs/op
+BenchmarkGCRepack-32              	     200	   1007982 ns/op	  836206 B/op	      39 allocs/op
+BenchmarkGCRepack-32              	     200	    998096 ns/op	  846633 B/op	      38 allocs/op
+BenchmarkGCRepack-32              	     200	    967298 ns/op	  839451 B/op	      39 allocs/op
+BenchmarkGCRepack-32              	     200	   1019963 ns/op	  850484 B/op	      39 allocs/op
+BenchmarkTruncate-32              	     200	     36212 ns/op	      65 B/op	       2 allocs/op
+BenchmarkTruncate-32              	     200	     37252 ns/op	      65 B/op	       2 allocs/op
+BenchmarkTruncate-32              	     200	     37812 ns/op	      65 B/op	       2 allocs/op
+BenchmarkTruncate-32              	     200	     36169 ns/op	      65 B/op	       2 allocs/op
+BenchmarkTruncate-32              	     200	     36647 ns/op	      65 B/op	       2 allocs/op
+BenchmarkTruncate-32              	     200	     36702 ns/op	      65 B/op	       2 allocs/op
+BenchmarkDelete-32                	     200	     13970 ns/op	     176 B/op	       2 allocs/op
+BenchmarkDelete-32                	     200	     13891 ns/op	     176 B/op	       2 allocs/op
+BenchmarkDelete-32                	     200	     13825 ns/op	     176 B/op	       2 allocs/op
+BenchmarkDelete-32                	     200	     14227 ns/op	     176 B/op	       2 allocs/op
+BenchmarkDelete-32                	     200	     14098 ns/op	     176 B/op	       2 allocs/op
+BenchmarkDelete-32                	     200	     14196 ns/op	     176 B/op	       2 allocs/op
+PASS
+ok  	github.com/marmos91/dittofs/pkg/block/journal	717.359s

--- a/pkg/block/journal/carve_pack_test.go
+++ b/pkg/block/journal/carve_pack_test.go
@@ -5,10 +5,9 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
-	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/chunker"
-	badgerstore "github.com/marmos91/dittofs/pkg/metadata/store/badger"
 )
 
 // TestCarvePackReachesBlockSizeOnScatteredRuns pins the defect this plan fixes:
@@ -308,24 +307,42 @@ func TestCarvePackSeamRunFailureLeavesSuffixDirty(t *testing.T) {
 	}
 }
 
-// badgerDeduper answers IsChunkDurable from a real BadgerMetadataStore's
-// IsSynced, the same lookup production wiring uses (pkg/block/engine's
-// engineDeduper). Unlike fakeDeduper's mutex-guarded map, each call opens an
-// actual Badger read transaction — the per-call cost BenchmarkCarveScatteredPass
-// exists to measure. Never marked synced by this benchmark, so every lookup is
-// a miss, which matches carve encountering novel scattered writes.
-type badgerDeduper struct {
-	store *badgerstore.BadgerMetadataStore
+// slowDeduper answers IsChunkDurable after a fixed delay, standing in for a
+// real key-value oracle without importing one. The delay is what matters: every
+// lookup is serialised through the single packer goroutine, so a map-backed fake
+// elides the very cost the benchmark exists to show.
+//
+// It spins rather than sleeping because the delay is tens of microseconds, well
+// under the scheduler's sleep granularity, and the figure being measured is the
+// packer's blocked time — sleep noise would land directly on it.
+//
+// ponytail: one flat delay, no distribution and no cache-hit skew. A real store
+// is bimodal (page cache vs. disk); model that only if a pass ever needs to
+// predict absolute latency rather than compare two packer designs. The
+// against-real-Badger measurement belongs in DittoFS's own suite, not here —
+// this package must not depend on a metadata store to benchmark itself.
+type slowDeduper struct {
+	delay time.Duration
 }
 
-func (d badgerDeduper) IsChunkDurable(ctx context.Context, h ChunkHash) (bool, error) {
-	return d.store.IsSynced(ctx, block.ContentHash(h))
+// deduperLookupDelay approximates a warm point lookup in an embedded LSM store.
+// A calibration knob, not a constant of nature: re-measure it against the real
+// oracle on the hardware a run is quoting before reading absolute numbers off
+// this benchmark.
+const deduperLookupDelay = 50 * time.Microsecond
+
+func (d slowDeduper) IsChunkDurable(_ context.Context, _ ChunkHash) (bool, error) {
+	for start := time.Now(); time.Since(start) < d.delay; {
+	}
+	return false, nil
 }
 
 // BenchmarkCarveScatteredPass measures a full scattered carve pass against a
-// real dedup oracle, so the cost of serialising IsChunkDurable through one
-// packer goroutine is visible rather than elided by a map-backed fake.
+// latency-injecting dedup oracle, so the cost of serialising IsChunkDurable
+// through one packer goroutine is visible rather than elided by a map-backed
+// fake.
 func BenchmarkCarveScatteredPass(b *testing.B) {
+	b.ReportAllocs()
 	const (
 		runs    = 5000
 		runSize = 4 << 10
@@ -339,12 +356,7 @@ func BenchmarkCarveScatteredPass(b *testing.B) {
 			CarveUploadConcurrency: 8,
 			ChunkParams:            chunker.Params{Min: 1 << 10, Avg: 2 << 10, Max: 8 << 10},
 		})
-		md, err := badgerstore.NewBadgerMetadataStoreWithDefaults(ctx, b.TempDir())
-		if err != nil {
-			b.Fatalf("open badger metadata store: %v", err)
-		}
-		b.Cleanup(func() { _ = md.Close() })
-		s.SetCarveTargets(badgerDeduper{md}, sink)
+		s.SetCarveTargets(slowDeduper{delay: deduperLookupDelay}, sink)
 		for r := 0; r < runs; r++ {
 			if err := s.WriteAt(ctx, "f", int64(r)*gap, randBytes(runSize, int64(r))); err != nil {
 				b.Fatalf("WriteAt %d: %v", r, err)

--- a/pkg/block/journal/commit_bench_test.go
+++ b/pkg/block/journal/commit_bench_test.go
@@ -19,7 +19,7 @@ import (
 // All ops target files that hash to a single shard so the fsync contention is
 // real and not spread across shards.
 func benchConcurrentCommit(b *testing.B, parallelism int) {
-	s := benchStore(b)
+	s, dir := benchStoreDir(b, Config{})
 	ctx := context.Background()
 	data := make([]byte, 4<<10)
 
@@ -35,6 +35,7 @@ func benchConcurrentCommit(b *testing.B, parallelism int) {
 	}
 
 	b.SetBytes(int64(len(data)))
+	b.ReportAllocs()
 	b.ResetTimer()
 
 	var wg sync.WaitGroup
@@ -56,6 +57,9 @@ func benchConcurrentCommit(b *testing.B, parallelism int) {
 		}(ids[g])
 	}
 	wg.Wait()
+	b.StopTimer()
+
+	reportWriteAmp(b, s, dir, ids[0], int64(perG)*int64(parallelism)*int64(len(data)))
 }
 
 func BenchmarkConcurrentCommit1(b *testing.B)   { benchConcurrentCommit(b, 1) }

--- a/pkg/block/journal/gc_test.go
+++ b/pkg/block/journal/gc_test.go
@@ -90,7 +90,7 @@ func TestDeadBytesOnTombstone(t *testing.T) {
 // dead. keepSynced decides whether "keep" lands already synced to the remote,
 // which is what makes the repack target evictable or not. It returns the keep
 // payload for byte-identity checks.
-func seedRepackable(t *testing.T, s *Store, keepSynced bool) []byte {
+func seedRepackable(t testing.TB, s *Store, keepSynced bool) []byte {
 	t.Helper()
 	ctx := context.Background()
 	keep := make([]byte, 300<<10)

--- a/pkg/block/journal/journal_bench_test.go
+++ b/pkg/block/journal/journal_bench_test.go
@@ -59,37 +59,37 @@ func (f *fakeRemote) GetRange(_ context.Context, id BlockID, off, length int64) 
 
 func benchStore(b *testing.B) *Store {
 	b.Helper()
-	s, err := Open(b.TempDir(), Config{}, newFakeRemote(), SystemClock())
-	if err != nil {
-		b.Fatalf("Open: %v", err)
-	}
-	b.Cleanup(func() { _ = s.Close() })
+	s, _ := benchStoreDir(b, Config{})
 	return s
 }
 
 // BenchmarkWriteAt measures the dirty-write append path with a 64 KiB payload.
 func BenchmarkWriteAt(b *testing.B) {
-	s := benchStore(b)
+	s, dir := benchStoreDir(b, Config{})
 	ctx := context.Background()
 	data := bytes.Repeat([]byte("x"), 64<<10)
 
 	b.SetBytes(int64(len(data)))
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if err := s.WriteAt(ctx, "bench-file", int64(i)*int64(len(data)), data); err != nil {
 			b.Fatalf("WriteAt: %v", err)
 		}
 	}
+	b.StopTimer()
+	reportWriteAmp(b, s, dir, "bench-file", int64(b.N)*int64(len(data)))
 }
 
 // BenchmarkTinyWritesCommit measures the many-tiny-scattered-writes-then-COMMIT
 // burst that pays full per-record framing overhead before any record merge.
 func BenchmarkTinyWritesCommit(b *testing.B) {
-	s := benchStore(b)
+	s, dir := benchStoreDir(b, Config{})
 	ctx := context.Background()
 	data := bytes.Repeat([]byte("x"), 512)
 
 	b.SetBytes(int64(len(data)))
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if err := s.WriteAt(ctx, "bench-tiny", int64(i)*int64(len(data)), data); err != nil {
@@ -99,6 +99,8 @@ func BenchmarkTinyWritesCommit(b *testing.B) {
 			b.Fatalf("Commit: %v", err)
 		}
 	}
+	b.StopTimer()
+	reportWriteAmp(b, s, dir, "bench-tiny", int64(b.N)*int64(len(data)))
 }
 
 // BenchmarkReadWarm measures the warm-read path (index lookup + pread) over a
@@ -117,6 +119,7 @@ func BenchmarkReadWarm(b *testing.B) {
 
 	dst := make([]byte, chunk)
 	b.SetBytes(int64(chunk))
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		off := int64(i%spans) * int64(chunk)
@@ -141,6 +144,7 @@ func BenchmarkCarve(b *testing.B) {
 	data := bytes.Repeat([]byte("dittofs-journal-carve-"), (8<<20)/22)
 
 	b.SetBytes(int64(len(data)))
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()

--- a/pkg/block/journal/randwrite_bench_test.go
+++ b/pkg/block/journal/randwrite_bench_test.go
@@ -39,16 +39,12 @@ func diskBytesOnDisk(b *testing.B, dir string) int64 {
 // any gap between the two isolates the offset-dependent cost (index insertion
 // position). Reports ns/op plus segments and write-amp as custom metrics.
 func benchWrites(b *testing.B, offsets []int64) {
-	dir := b.TempDir()
-	s, err := Open(dir, Config{}, newFakeRemote(), SystemClock())
-	if err != nil {
-		b.Fatalf("Open: %v", err)
-	}
-	b.Cleanup(func() { _ = s.Close() })
+	s, dir := benchStoreDir(b, Config{})
 	ctx := context.Background()
 	data := make([]byte, 4<<10)
 
 	b.SetBytes(int64(len(data)))
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if err := s.WriteAt(ctx, "f", offsets[i%len(offsets)], data); err != nil {
@@ -57,11 +53,7 @@ func benchWrites(b *testing.B, offsets []int64) {
 	}
 	b.StopTimer()
 
-	disk := diskBytesOnDisk(b, dir)
-	st := s.Stats()
-	b.ReportMetric(float64(st.Segments), "segments")
-	b.ReportMetric(float64(disk)/float64(int64(b.N)*int64(len(data))), "write-amp")
-	b.ReportMetric(float64(len(s.shardFor("f").index["f"].ivs)), "intervals")
+	reportWriteAmp(b, s, dir, "f", int64(b.N)*int64(len(data)))
 }
 
 const randSpan = 1 << 20 // 1 Mi distinct 4 KiB slots => a 4 GiB address space

--- a/pkg/block/journal/transition_bench_test.go
+++ b/pkg/block/journal/transition_bench_test.go
@@ -6,6 +6,20 @@ import (
 	"testing"
 )
 
+// Running these: six of them rebuild their state inside StopTimer on every
+// iteration — Carve, CarveScatteredPass, Evict, GCRepack, Truncate and Delete.
+// Go sizes b.N from the timed region alone, so on a fast device it picks an
+// iteration count whose *untimed* setup runs for tens of minutes; Truncate
+// reached 28k iterations on tmpfs, each rebuilding 4096 intervals. Give that
+// group an explicit iteration cap rather than a duration:
+//
+//	go test -run '^$' -bench . -benchtime=1s -count=6                        # the rest
+//	go test -run '^$' -bench 'Carve|Evict|GCRepack|Truncate|Delete' \
+//	        -benchtime=200x -count=6                                          # this group
+//
+// ns/op stays directly comparable between the two invocations; only the sample
+// count differs.
+//
 // This file completes the benchmark contract: one benchmark per state
 // transition, so the benchmark set and the state model are the same list. The
 // write path was already covered; everything a byte does after it is written —

--- a/pkg/block/journal/transition_bench_test.go
+++ b/pkg/block/journal/transition_bench_test.go
@@ -39,6 +39,27 @@ func intervalCount(s *Store, id FileID) int {
 	return len(fi.ivs)
 }
 
+// coldIntervalCount reports how many of a file's intervals are cold. Counting
+// intervals alone cannot tell a seeded-cold file from a written one — both hold
+// the same number — so any check that a range is genuinely remote-only has to
+// look at the flag.
+func coldIntervalCount(s *Store, id FileID) int {
+	sh := s.shardFor(id)
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	fi := sh.index[id]
+	if fi == nil {
+		return 0
+	}
+	n := 0
+	for _, iv := range fi.ivs {
+		if iv.cold {
+			n++
+		}
+	}
+	return n
+}
+
 // reportWriteAmp attaches the three write-path metrics to any benchmark that
 // appends: segment count, write amplification (on-disk bytes over payload
 // bytes) and the file's interval count. Write amplification is the number that
@@ -117,6 +138,12 @@ func BenchmarkHydrate(b *testing.B) {
 			if err := s.SeedCold(ctx, id, ext); err != nil {
 				b.Fatalf("SeedCold: %v", err)
 			}
+			// SeedCold only fills holes. If it ever stopped taking, every Hydrate
+			// below would be an ordinary append and this would quietly become a
+			// second write benchmark.
+			if got := coldIntervalCount(s, id); got != spans {
+				b.Fatalf("seeded %d cold intervals, want %d", got, spans)
+			}
 			b.StartTimer()
 		}
 		if err := s.Hydrate(ctx, id, int64(i%spans)*chunk, buf, 0); err != nil {
@@ -156,8 +183,15 @@ func BenchmarkEvict(b *testing.B) {
 		}
 		// targetBytes <= 0 evicts a single qualifying segment, which is the unit
 		// this benchmark is timing.
-		if _, err := s.Evict(ctx, 0); err != nil {
+		res, err := s.Evict(ctx, 0)
+		if err != nil {
 			b.Fatalf("Evict: %v", err)
+		}
+		// A pass that qualifies nothing returns cleanly and costs almost nothing,
+		// so without this the benchmark would keep reporting a fast, meaningless
+		// number if the fill ever stopped producing evictable segments.
+		if res.SegmentsEvicted == 0 {
+			b.Fatal("nothing evicted: the benchmark is timing an empty pass")
 		}
 	}
 }

--- a/pkg/block/journal/transition_bench_test.go
+++ b/pkg/block/journal/transition_bench_test.go
@@ -419,6 +419,47 @@ func BenchmarkDurableExtent(b *testing.B) {
 	}
 }
 
+// BenchmarkColdExtentsStoreWide is the one that bears on the design plan's
+// stated worry. ColdExtents walks every shard, every file in it and every
+// interval of each; a single-file store exercises none of that fan-out, so
+// BenchmarkColdExtents below measures one file's interval walk and understates
+// the store-wide cost it is usually quoted for. This spreads the same number of
+// cold intervals over many files so the shard walk and the per-shard map
+// iteration are actually in the measurement.
+func BenchmarkColdExtentsStoreWide(b *testing.B) {
+	s := benchStore(b)
+	ctx := context.Background()
+	const (
+		files    = 2048
+		perFile  = 16
+		chunk    = 4 << 10
+		wantCold = files * perFile
+	)
+	ext := make([][2]int64, perFile)
+	for j := range ext {
+		ext[j] = [2]int64{int64(j) * chunk * 2, chunk}
+	}
+	for i := 0; i < files; i++ {
+		if err := s.SeedCold(ctx, FileID(fmt.Sprintf("cw-%d", i)), ext); err != nil {
+			b.Fatalf("SeedCold: %v", err)
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, extents, err := s.ColdExtents(ctx)
+		if err != nil {
+			b.Fatalf("ColdExtents: %v", err)
+		}
+		// Without this the benchmark would keep timing a walk over an empty or
+		// half-seeded store if the fan-out ever stopped being built.
+		if extents != wantCold {
+			b.Fatalf("walked %d cold extents, want %d", extents, wantCold)
+		}
+	}
+}
+
 func BenchmarkColdExtents(b *testing.B) {
 	s, _, _ := residencyStore(b)
 	ctx := context.Background()

--- a/pkg/block/journal/transition_bench_test.go
+++ b/pkg/block/journal/transition_bench_test.go
@@ -346,10 +346,15 @@ func BenchmarkDelete(b *testing.B) {
 
 // The four residency queries below are the receipts for the merged Extents
 // query the pier design proposes. Collapsing them into one slice-returning call
-// is that design's biggest performance risk — FileSize sits on the hot read
-// path and ColdExtents is O(live intervals) across every shard — so the
-// before-numbers have to exist on the same hardware before the after-numbers
-// mean anything. Recorded now; compared when Extents lands.
+// is that design's biggest performance risk — ColdExtents is O(live intervals)
+// across every shard — so the before-numbers have to exist on the same hardware
+// before the after-numbers mean anything. Recorded now; compared when Extents
+// lands.
+//
+// FileSize is the one to watch, but not because it is on the read path: it is
+// reached only from share start, and it is an O(intervals) scan that costs
+// three orders of magnitude more than DurableExtent for a narrower answer.
+// Measuring the four separately is what makes that visible.
 
 // residencyStore builds a file deep enough in intervals for the query cost to
 // be visible, with a cold tail so ColdExtents has something to walk.

--- a/pkg/block/journal/transition_bench_test.go
+++ b/pkg/block/journal/transition_bench_test.go
@@ -152,17 +152,21 @@ func BenchmarkHydrate(b *testing.B) {
 	}
 }
 
-// BenchmarkEvict measures Resident -> Remote: reclaiming whole sealed segments
+// BenchmarkEvict measures Resident -> Remote: reclaiming a whole sealed segment
 // under storage pressure. Only fully-synced segments qualify, so the fill uses
 // Hydrate, which appends records already marked synced; a WriteAt fill would
 // measure a pass that correctly declines to evict anything.
+//
+// The refill runs once per iteration and writes just past a segment's worth, so
+// the rotation it forces leaves exactly one sealed segment for the Evict that
+// follows. Filling several iterations ahead does not work — a refill's bytes
+// coalesce into a single active segment, so the second Evict onwards finds
+// nothing and times an empty pass.
 func BenchmarkEvict(b *testing.B) {
 	s, _ := benchStoreDir(b, Config{SegmentSize: minSegmentSize, ShardCount: 1})
 	ctx := context.Background()
-	const (
-		span    = 256 << 10
-		perFill = 8 // segments made available per refill
-	)
+	const span = 128 << 10
+	perFill := int(minSegmentSize/span) + 1
 	buf := make([]byte, span)
 	fill := func(round int) {
 		for j := 0; j < perFill; j++ {
@@ -176,11 +180,9 @@ func BenchmarkEvict(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if i%perFill == 0 {
-			b.StopTimer()
-			fill(i / perFill)
-			b.StartTimer()
-		}
+		b.StopTimer()
+		fill(i)
+		b.StartTimer()
 		// targetBytes <= 0 evicts a single qualifying segment, which is the unit
 		// this benchmark is timing.
 		res, err := s.Evict(ctx, 0)

--- a/pkg/block/journal/transition_bench_test.go
+++ b/pkg/block/journal/transition_bench_test.go
@@ -1,0 +1,377 @@
+package journal
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// This file completes the benchmark contract: one benchmark per state
+// transition, so the benchmark set and the state model are the same list. The
+// write path was already covered; everything a byte does after it is written —
+// going cold, coming back, being reclaimed, surviving a restart — was not, and
+// an extraction can lose that behaviour without a single number moving.
+
+// benchStoreDir is benchStore plus the store directory, which the on-disk
+// write-amplification metric needs and the recovery benchmark reopens.
+func benchStoreDir(b *testing.B, cfg Config) (*Store, string) {
+	b.Helper()
+	dir := b.TempDir()
+	s, err := Open(dir, cfg, newFakeRemote(), SystemClock())
+	if err != nil {
+		b.Fatalf("Open: %v", err)
+	}
+	b.Cleanup(func() { _ = s.Close() })
+	return s, dir
+}
+
+// intervalCount reports how many index intervals a file holds, taking the shard
+// lock rather than reading the map bare: a parallel benchmark otherwise races
+// its own store.
+func intervalCount(s *Store, id FileID) int {
+	sh := s.shardFor(id)
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	fi := sh.index[id]
+	if fi == nil {
+		return 0
+	}
+	return len(fi.ivs)
+}
+
+// reportWriteAmp attaches the three write-path metrics to any benchmark that
+// appends: segment count, write amplification (on-disk bytes over payload
+// bytes) and the file's interval count. Write amplification is the number that
+// decides whether the storage design is viable at all, so it belongs on every
+// benchmark that writes, not only the random-write pair it started on.
+func reportWriteAmp(b *testing.B, s *Store, dir string, id FileID, payloadBytes int64) {
+	b.Helper()
+	st := s.Stats()
+	b.ReportMetric(float64(st.Segments), "segments")
+	if payloadBytes > 0 {
+		b.ReportMetric(float64(diskBytesOnDisk(b, dir))/float64(payloadBytes), "write-amp")
+	}
+	b.ReportMetric(float64(intervalCount(s, id)), "intervals")
+}
+
+// BenchmarkReadCold measures the cold-read resolution path: the index knows the
+// bytes were written and evicted, so ReadAt zero-fills and reports Cold for the
+// caller to hydrate. It is the read half of every silent-zeros incident this
+// store has had, and until now it had no benchmark at all — a regression here
+// shows up as corruption, not as a slow test.
+func BenchmarkReadCold(b *testing.B) {
+	s := benchStore(b)
+	ctx := context.Background()
+	const (
+		chunk = 64 << 10
+		spans = 256
+	)
+	ext := make([][2]int64, spans)
+	for i := range ext {
+		ext[i] = [2]int64{int64(i) * chunk, chunk}
+	}
+	if err := s.SeedCold(ctx, "cold", ext); err != nil {
+		b.Fatalf("SeedCold: %v", err)
+	}
+
+	dst := make([]byte, chunk)
+	b.SetBytes(chunk)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, st, err := s.ReadAt(ctx, "cold", int64(i%spans)*chunk, dst)
+		if err != nil {
+			b.Fatalf("ReadAt: %v", err)
+		}
+		if !st.Cold {
+			b.Fatal("read resolved warm: the benchmark is measuring the wrong path")
+		}
+	}
+}
+
+// BenchmarkHydrate measures Remote -> Resident: the local half of a cold fill,
+// appending fetched bytes back under the version fence. Each group of spans
+// gets a fresh file because SeedCold only fills holes — re-seeding a hydrated
+// range is a no-op, which would silently turn this into a warm-write benchmark.
+func BenchmarkHydrate(b *testing.B) {
+	s := benchStore(b)
+	ctx := context.Background()
+	const (
+		chunk = 64 << 10
+		spans = 64
+	)
+	ext := make([][2]int64, spans)
+	for i := range ext {
+		ext[i] = [2]int64{int64(i) * chunk, chunk}
+	}
+	buf := make([]byte, chunk)
+
+	b.SetBytes(chunk)
+	b.ReportAllocs()
+	b.ResetTimer()
+	var id FileID
+	for i := 0; i < b.N; i++ {
+		if i%spans == 0 {
+			b.StopTimer()
+			id = FileID(fmt.Sprintf("fill-%d", i/spans))
+			if err := s.SeedCold(ctx, id, ext); err != nil {
+				b.Fatalf("SeedCold: %v", err)
+			}
+			b.StartTimer()
+		}
+		if err := s.Hydrate(ctx, id, int64(i%spans)*chunk, buf, 0); err != nil {
+			b.Fatalf("Hydrate: %v", err)
+		}
+	}
+}
+
+// BenchmarkEvict measures Resident -> Remote: reclaiming whole sealed segments
+// under storage pressure. Only fully-synced segments qualify, so the fill uses
+// Hydrate, which appends records already marked synced; a WriteAt fill would
+// measure a pass that correctly declines to evict anything.
+func BenchmarkEvict(b *testing.B) {
+	s, _ := benchStoreDir(b, Config{SegmentSize: minSegmentSize, ShardCount: 1})
+	ctx := context.Background()
+	const (
+		span    = 256 << 10
+		perFill = 8 // segments made available per refill
+	)
+	buf := make([]byte, span)
+	fill := func(round int) {
+		for j := 0; j < perFill; j++ {
+			id := FileID(fmt.Sprintf("evict-%d-%d", round, j))
+			if err := s.Hydrate(ctx, id, 0, buf, 0); err != nil {
+				b.Fatalf("Hydrate: %v", err)
+			}
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if i%perFill == 0 {
+			b.StopTimer()
+			fill(i / perFill)
+			b.StartTimer()
+		}
+		// targetBytes <= 0 evicts a single qualifying segment, which is the unit
+		// this benchmark is timing.
+		if _, err := s.Evict(ctx, 0); err != nil {
+			b.Fatalf("Evict: %v", err)
+		}
+	}
+}
+
+// BenchmarkGCRepack measures the compaction transition: relocating a sealed
+// segment's still-live records into a fresh one and retiring the victim. The
+// per-iteration seed is the same shape gc_test uses — 300 KiB kept, 700 KiB
+// deleted, a rollover to seal it — which clears the forced dead-byte ratio.
+func BenchmarkGCRepack(b *testing.B) {
+	s, _ := benchStoreDir(b, Config{SegmentSize: minSegmentSize, ShardCount: 1})
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		seedRepackable(b, s, true)
+		b.StartTimer()
+		res, err := s.GC(ctx, GCOptions{Force: true})
+		if err != nil {
+			b.Fatalf("GC: %v", err)
+		}
+		if res.SegmentsRepacked == 0 {
+			b.Fatal("nothing repacked: the benchmark is timing an empty pass")
+		}
+		b.StopTimer()
+		if err := s.Delete(ctx, "keep"); err != nil {
+			b.Fatalf("Delete: %v", err)
+		}
+		b.StartTimer()
+	}
+}
+
+// BenchmarkOpenRecovery measures replaying a populated store directory at
+// startup. This is a startup-latency SLO, not a curiosity: recovery walks every
+// segment's records to rebuild the interval index, so its cost scales with what
+// the share holds, and a share that takes minutes to open is indistinguishable
+// from one that is down.
+func BenchmarkOpenRecovery(b *testing.B) {
+	const (
+		files = 512
+		span  = 64 << 10
+	)
+	dir := b.TempDir()
+	seed, err := Open(dir, Config{}, newFakeRemote(), SystemClock())
+	if err != nil {
+		b.Fatalf("Open: %v", err)
+	}
+	ctx := context.Background()
+	data := make([]byte, span)
+	for i := 0; i < files; i++ {
+		if err := seed.WriteAt(ctx, FileID(fmt.Sprintf("rec-%d", i)), 0, data); err != nil {
+			b.Fatalf("seed WriteAt: %v", err)
+		}
+	}
+	if err := seed.Close(); err != nil {
+		b.Fatalf("Close: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s, err := Open(dir, Config{}, newFakeRemote(), SystemClock())
+		if err != nil {
+			b.Fatalf("Open: %v", err)
+		}
+		b.StopTimer()
+		if got := s.FileCount(); got != files {
+			b.Fatalf("recovered %d files, want %d", got, files)
+		}
+		if err := s.Close(); err != nil {
+			b.Fatalf("Close: %v", err)
+		}
+		b.StartTimer()
+	}
+}
+
+// BenchmarkTruncate measures clipping a file's tail: a marker append plus the
+// index clip over a deep interval list, which is where the cost lives.
+func BenchmarkTruncate(b *testing.B) {
+	s := benchStore(b)
+	ctx := context.Background()
+	const (
+		chunk = 4 << 10
+		spans = 4096
+	)
+	data := make([]byte, chunk)
+	size := int64(spans) * chunk
+	refill := func() {
+		for j := 0; j < spans; j++ {
+			if err := s.WriteAt(ctx, "trunc", int64(j)*chunk, data); err != nil {
+				b.Fatalf("WriteAt: %v", err)
+			}
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		refill()
+		b.StartTimer()
+		if err := s.Truncate(ctx, "trunc", size/2); err != nil {
+			b.Fatalf("Truncate: %v", err)
+		}
+	}
+}
+
+// BenchmarkDelete measures tombstoning a file with a deep interval list: the
+// index drop plus the dead-byte charge against every segment it touched.
+func BenchmarkDelete(b *testing.B) {
+	s := benchStore(b)
+	ctx := context.Background()
+	const (
+		chunk = 4 << 10
+		spans = 1024
+	)
+	data := make([]byte, chunk)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		id := FileID(fmt.Sprintf("del-%d", i))
+		for j := 0; j < spans; j++ {
+			if err := s.WriteAt(ctx, id, int64(j)*chunk, data); err != nil {
+				b.Fatalf("WriteAt: %v", err)
+			}
+		}
+		b.StartTimer()
+		if err := s.Delete(ctx, id); err != nil {
+			b.Fatalf("Delete: %v", err)
+		}
+	}
+}
+
+// The four residency queries below are the receipts for the merged Extents
+// query the pier design proposes. Collapsing them into one slice-returning call
+// is that design's biggest performance risk — FileSize sits on the hot read
+// path and ColdExtents is O(live intervals) across every shard — so the
+// before-numbers have to exist on the same hardware before the after-numbers
+// mean anything. Recorded now; compared when Extents lands.
+
+// residencyStore builds a file deep enough in intervals for the query cost to
+// be visible, with a cold tail so ColdExtents has something to walk.
+func residencyStore(b *testing.B) (*Store, FileID, int64) {
+	b.Helper()
+	s := benchStore(b)
+	ctx := context.Background()
+	const (
+		chunk = 4 << 10
+		spans = 4096
+	)
+	data := make([]byte, chunk)
+	// A gap between spans keeps the intervals from merging into one run, which
+	// is what makes the index deep rather than trivially short.
+	for j := 0; j < spans; j++ {
+		if err := s.WriteAt(ctx, "res", int64(j)*chunk*2, data); err != nil {
+			b.Fatalf("WriteAt: %v", err)
+		}
+	}
+	size := int64(spans) * chunk * 2
+	cold := make([][2]int64, spans)
+	for j := range cold {
+		cold[j] = [2]int64{int64(j)*chunk*2 + chunk, chunk}
+	}
+	if err := s.SeedCold(ctx, "res", cold); err != nil {
+		b.Fatalf("SeedCold: %v", err)
+	}
+	return s, "res", size
+}
+
+func BenchmarkFileSize(b *testing.B) {
+	s, id, _ := residencyStore(b)
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, ok := s.FileSize(ctx, id); !ok {
+			b.Fatal("FileSize: file not found")
+		}
+	}
+}
+
+func BenchmarkDataExtents(b *testing.B) {
+	s, id, size := residencyStore(b)
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := s.DataExtents(ctx, id, size); err != nil {
+			b.Fatalf("DataExtents: %v", err)
+		}
+	}
+}
+
+func BenchmarkDurableExtent(b *testing.B) {
+	s, id, _ := residencyStore(b)
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.DurableExtent(ctx, id)
+	}
+}
+
+func BenchmarkColdExtents(b *testing.B) {
+	s, _, _ := residencyStore(b)
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, _, err := s.ColdExtents(ctx); err != nil {
+			b.Fatalf("ColdExtents: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
Completes design-plan §10's benchmark contract — one benchmark per state transition —
and records the baseline the pier/crane/ferry refactor will be measured against.

The write path already had eleven benchmarks. Everything a byte does *after* it is
written — going cold, coming back, being reclaimed, surviving a restart — had none, so
an extraction could lose that behaviour without a single number moving. A green suite
has already failed to catch a data-path regression here once.

## What's in it

- **Seven new transition benchmarks**: cold read, hydrate, evict, GC repack, `Open`
  recovery, truncate, delete.
- **Four residency benchmarks** — `FileSize`, `DataExtents`, `DurableExtent`,
  `ColdExtents` — as the before-receipts for the merged `Extents` query, so the
  after-numbers have something to be compared against on the same hardware.
- **Allocations on all 22.** Not one of the original eleven called `b.ReportAllocs()`.
- **Write amplification across the whole write path**, not just the random-write pair it
  started on. It is the number that decides whether the storage design is viable.
- **`BenchmarkCarveScatteredPass` no longer imports a metadata store.** A
  latency-injecting deduper shows the same packer serialisation without this package
  depending on Badger to benchmark itself.
- **The recorded baseline** under `.planning/perf/2026-09-06-block-transitions/`.

## The baseline

AMD EPYC 7543, 32C/62G, Scaleway `POP2-HC-32C-64G` — the `vmType` already in
`bench/infra/Pulumi.bench.yaml`. Three store tiers, six samples each, run sequentially.
Not a laptop, not Docker Desktop.

The two Scaleway block tiers turned out to be **the same device** for this workload —
476 vs 451 IOPS under `fdatasync=1`, geomean differing 4.78% in the *slower* direction
for the provisioned-15k volume. Provisioned IOPS raises a parallel-throughput ceiling; it
does not move the ~2.1 ms round trip a serialised fsync chain pays per barrier. tmpfs
supplies the fast end instead, which separates device cost from code cost — the split the
block-size default actually needs.

| | sbs5k | ram | |
|---|---|---|---|
| `Delete` | 14.13 ms | 14.03 µs | 1007× — almost pure fsync |
| `Truncate` | 24.62 ms | 36.67 µs | 671× — almost pure fsync |
| `ConcurrentCommit1` | 1.818 ms | 7.971 µs | 228× — on the disk's append floor |
| `ConcurrentCommit128` | 42.56 µs | 12.91 µs | 3.3× — group commit buys 43× over depth 1 |
| `Carve` | 11.71 ms | 11.70 ms | 1.0× — CPU-bound, FastCDC + BLAKE3 |
| `FileSize` | 23.93 µs | 23.91 µs | 1.0× — pure CPU |
| `DurableExtent` | 16.80 ns | 16.83 ns | 1.0× |
| `OpenRecovery` | 18.74 ms | 21.11 ms | 0.9× — allocation-bound, *slower* on RAM |

## Findings

**`FileSize` is O(intervals) under the shard lock** — filed as #2366. It answers a
narrower question than `DurableExtent` for **1424×** the time, and no disk closes that gap.

**The design plan's reason for keeping `Size` out of `Extents` was wrong**, and this PR
corrects it in place. The cited hot-read call sites are `engine.Store.GetSize` and
`engine.Store.Exists`; neither has a non-test caller, nor does the `block.Reader`
interface declaring them. A third dead island, the same shape as the hash-keyed CAS one —
worth folding into the legacy-deletion scope. `FileSize`'s one live caller is
`findStaleSizes`, which runs at share start over every locally-resident file, so the cost
lands on startup latency, not on reads.

**The stop condition is answered: the protocol layer binds first.** Against #1735's
~940 µs create wall (block COMMIT fsync ~20% of it at nj=8), `ConcurrentCommit32` at
125.9 µs is the right order for that share from an independent direction. Roughly four
fifths of a create is spent above the block engine, so the refactor cannot be justified on
create-path throughput — it has to stand on residency correctness, which is what the plan
claims for it anyway.

## Two benchmarks that were lying, and how they were caught

Both were mine, and both were caught by the machine rather than by review.

`BenchmarkEvict` reported nothing evicted in all twelve server runs. The refill assumed
eight hydrated files yield eight evictable segments; they coalesce into one active
segment, so only the first `Evict` found anything. It survived twenty iterations on a
laptop. Without the liveness guard, a fast meaningless number would have entered the
baseline as the eviction cost.

`BenchmarkHydrate`'s first guard **passed against a deliberately broken build** — counting
intervals cannot distinguish a seeded-cold file from a written one, since both hold the
same number. It counts cold intervals now, and fails on the broken build as it should.

Both guards were re-verified against deliberately broken setups.

Related: the six setup-heavy benchmarks rebuild state inside `StopTimer`, and Go sizes
`b.N` from the timed region alone — so the faster the device, the more untimed setup it
does. `Truncate` reached 28k iterations on tmpfs. They take an explicit iteration cap,
documented in the file, since that is a property of the run rather than of the source.

## Not in scope

No production code changes. Measurement only; #2366 carries the `FileSize` fix.
