### PR TITLE
fix(block): never evict bytes a share has no way to fetch back

### DIFF
--- a/pkg/block/engine/engine.go
+++ b/pkg/block/engine/engine.go
@@ -221,10 +221,19 @@ func (bs *Store) Start(ctx context.Context) error {
 	// When remote goes unhealthy, suspend eviction to prevent evicting blocks
 	// that cannot be re-downloaded. When healthy again, re-enable eviction.
 	bs.syncer.SetHealthCallback(func(healthy bool) {
-		bs.local.SetEvictionEnabled(bs.syncer.CanEvict())
-		if healthy {
+		// Log what was actually decided, not what health alone implies: a healthy
+		// remote no longer means eviction resumes, because carve must also be
+		// wired to it. Saying "re-enabled" while eviction stays off would leave a
+		// log that disagrees with the store, which is the hazard this gate exists
+		// to remove.
+		canEvict := bs.syncer.CanEvict()
+		bs.local.SetEvictionEnabled(canEvict)
+		switch {
+		case canEvict:
 			logger.Info("Remote store healthy: eviction re-enabled")
-		} else {
+		case healthy:
+			logger.Info("Remote store healthy but carve is not wired to it: eviction stays suspended")
+		default:
 			logger.Warn("Remote store unhealthy: eviction suspended")
 		}
 	})

--- a/pkg/block/engine/engine.go
+++ b/pkg/block/engine/engine.go
@@ -221,7 +221,7 @@ func (bs *Store) Start(ctx context.Context) error {
 	// When remote goes unhealthy, suspend eviction to prevent evicting blocks
 	// that cannot be re-downloaded. When healthy again, re-enable eviction.
 	bs.syncer.SetHealthCallback(func(healthy bool) {
-		bs.local.SetEvictionEnabled(healthy)
+		bs.local.SetEvictionEnabled(bs.syncer.CanEvict())
 		if healthy {
 			logger.Info("Remote store healthy: eviction re-enabled")
 		} else {
@@ -242,7 +242,7 @@ func (bs *Store) Start(ctx context.Context) error {
 	// where the initial probe settled health without driving a transition
 	// callback (e.g. it started unhealthy with no prior state to transition
 	// from).
-	bs.local.SetEvictionEnabled(bs.syncer.IsRemoteHealthy())
+	bs.local.SetEvictionEnabled(bs.syncer.CanEvict())
 
 	// Wire the Cache in Start so the loadByHash closure captures bs and
 	// NewCache spawns workers immediately. A single Cache type replaces

--- a/pkg/block/engine/localonly_eviction_test.go
+++ b/pkg/block/engine/localonly_eviction_test.go
@@ -1,0 +1,92 @@
+package engine_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block/engine"
+	"github.com/marmos91/dittofs/pkg/block/local/fs"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// localOnlyPair is newLocalOnlyEngine but hands back the local store too, so the
+// test can drive the journal directly the way a replayed journal would arrive.
+func localOnlyPair(t *testing.T, ms metadata.Store) (*engine.Store, *fs.FSStore) {
+	t.Helper()
+	localStore, err := fs.NewWithOptions(t.TempDir(), 100*1024*1024, ms, fs.FSStoreOptions{
+		MaxLogBytes: 128 * 1024 * 1024,
+	})
+	if err != nil {
+		t.Fatalf("fs.NewWithOptions: %v", err)
+	}
+	syncedHashStore, ok := ms.(metadata.SyncedHashStore)
+	if !ok {
+		t.Fatalf("metadata store %T is not a SyncedHashStore", ms)
+	}
+	syncer := engine.NewSyncer(localStore, nil, ms, engine.DefaultConfig())
+	bs, err := engine.New(engine.BlockStoreConfig{
+		Local:           localStore,
+		Syncer:          syncer,
+		FileChunkStore:  ms,
+		Coordinator:     &testCoordinator{store: ms},
+		SyncedHashStore: syncedHashStore,
+		ReadBufferBytes: 64 * 1024 * 1024,
+	})
+	if err != nil {
+		t.Fatalf("engine.New: %v", err)
+	}
+	t.Cleanup(func() { _ = bs.Close() })
+	return bs, localStore
+}
+
+// TestLocalOnlyShareNeverEvictsItsOnlyCopy pins #2314. A journal replayed from
+// a share's earlier remote-backed life carries records still flagged synced. If
+// that journal is reopened under a share with no remote, those records satisfy
+// the eviction gate — and there is nothing to fetch them back from, so eviction
+// destroys the only copy.
+//
+// The gate used to be IsRemoteHealthy(), which reports true for a nil health
+// monitor, so a share with no remote at all read as healthy. It is now
+// CanEvict(), which also requires the carve path to be wired to a remote.
+func TestLocalOnlyShareNeverEvictsItsOnlyCopy(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	bs, localStore := localOnlyPair(t, ms)
+
+	const payloadID = "p2314"
+	want := bytes.Repeat([]byte("A"), 1<<20)
+
+	// Hydrate appends records already marked synced — the state a replay of a
+	// formerly remote-backed journal restores.
+	if err := localStore.Hydrate(ctx, payloadID, 0, want, 0); err != nil {
+		t.Fatalf("Hydrate: %v", err)
+	}
+
+	// Start is what decides the eviction gate for the share.
+	if err := bs.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Force-evict. On a share whose bytes cannot be fetched back this must
+	// reclaim nothing, however much pressure it is under.
+	res, err := localStore.Evict(ctx, 0)
+	if err != nil {
+		t.Fatalf("Evict: %v", err)
+	}
+	if res.SegmentsEvicted != 0 {
+		t.Errorf("evicted %d segment(s) / %d bytes from a share with no remote — "+
+			"those bytes existed nowhere else", res.SegmentsEvicted, res.BytesFreed)
+	}
+
+	// And the bytes must still read back. A read that fails closed is better
+	// than zeros, but the data should never have been dropped in the first place.
+	got := make([]byte, len(want))
+	if _, err := bs.ReadAt(ctx, payloadID, got, 0); err != nil {
+		t.Fatalf("read after eviction attempt failed: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("read returned %d zero bytes of %d", bytes.Count(got, []byte{0}), len(got))
+	}
+}

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -304,8 +304,6 @@ func (m *Syncer) SetHealthCallback(fn healthTransitionCallback) {
 	}
 }
 
-// IsRemoteHealthy returns the health state of the remote store.
-// Returns true when there is no HealthMonitor (local-only mode).
 // CanEvict reports whether reclaiming local bytes is safe: they may only be
 // dropped when something can fetch them back. That is carveActive — the carve
 // path wired to a remote — AND that remote being healthy.
@@ -321,6 +319,10 @@ func (m *Syncer) CanEvict() bool {
 	return m.carveActive.Load() && m.IsRemoteHealthy()
 }
 
+// IsRemoteHealthy returns the health state of the remote store.
+// Returns true when there is no HealthMonitor (local-only mode) — which is why
+// it is not sufficient on its own to decide whether eviction is safe. Use
+// CanEvict for that.
 func (m *Syncer) IsRemoteHealthy() bool {
 	if m.healthMonitor == nil {
 		return true

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -306,6 +306,21 @@ func (m *Syncer) SetHealthCallback(fn healthTransitionCallback) {
 
 // IsRemoteHealthy returns the health state of the remote store.
 // Returns true when there is no HealthMonitor (local-only mode).
+// CanEvict reports whether reclaiming local bytes is safe: they may only be
+// dropped when something can fetch them back. That is carveActive — the carve
+// path wired to a remote — AND that remote being healthy.
+//
+// carveActive is deliberately the same flag that decides whether a record can
+// ever become synced, so "may be evicted" and "can be re-fetched" are one answer
+// by construction rather than two that agree by luck. Health alone is not
+// enough: IsRemoteHealthy reports true for a nil monitor, so a share with no
+// remote at all reads as healthy, and a journal carrying synced records from a
+// previous remote-backed life would then satisfy the eviction gate and lose the
+// only copy of those bytes.
+func (m *Syncer) CanEvict() bool {
+	return m.carveActive.Load() && m.IsRemoteHealthy()
+}
+
 func (m *Syncer) IsRemoteHealthy() bool {
 	if m.healthMonitor == nil {
 		return true


### PR DESCRIPTION
Closes #2314.

## The issue's premise had half expired — reproduced before fixing

#2314 was verified at `40884ad4f`. Re-run on current `develop`, its steps 1-4 hold and
**step 5 does not**:

```
evicted 1 segment(s), 1048678 bytes
READ FAILED CLOSED (good): window for p2314 at offset 0 (1048576 bytes)
                           is still cold after hydrate: chunk not found
```

A local-only share really does evict a megabyte that exists nowhere else. But the read no
longer serves silent zeros — `ensureAndReadFromLocal` re-checks the cold flag after
hydrating and returns `ErrChunkNotFound`. That landed after the issue was written, so the
bug had already changed shape: **silent corruption → loud data loss**, with nobody
noticing the reclassification.

So only half the proposed fix was still needed. The issue nominated failing closed on the
fetch path as "what stops the class"; that is already in the tree. The destruction path
was not.

## The fix

Eviction was gated on `IsRemoteHealthy()`, which returns `true` for a **nil** health
monitor — so a share with no remote at all reads as healthy. A journal replayed from the
share's earlier remote-backed life carries records still flagged synced, those satisfy the
gate, and nothing can fetch them back.

It is now `CanEvict()`, which additionally requires `carveActive` — the carve path wired
to a remote. That is deliberately the same flag that decides whether a record can ever
*become* synced, so "may be evicted" and "can be re-fetched" are one answer by
construction rather than two that agree by luck.

Two details that matter:

- **Gated at both call sites**, not only the one in `Start`. The health callback re-enables
  eviction on every transition to healthy and would have reopened the hole on the next flap.
- **`carveActive`, not `HasRemoteStore()`.** The issue flagged this: `HasRemoteStore()`
  reads `bs.remote`, while the fetch path uses the syncer's `remoteBlockStore`, wired
  separately. Gating on the former would suppress eviction on shares that do have a working
  remote — a real regression. `carveActive` reads the field the fetch path uses.

## Verification

`TestLocalOnlyShareNeverEvictsItsOnlyCopy` fails on the unfixed build with the defect
itself — `evicted 1 segment(s) / 1048678 bytes from a share with no remote` — and passes
with the fix. Full `pkg/block/...` green, including the retention-pin and clone-local-only
configurations the issue warned could regress.

## Not in scope

The fetch path is left alone: it already fails closed, and this PR does not change that
behaviour. The issue body still describes the expired premise and needs correcting
separately so nobody builds on it.
