### PR TITLE
fix(nfs/v4): object-type gates, OPEN seqid accounting, createattrs and share reservations

### DIFF
--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -430,6 +430,8 @@ SMB: STATUS_SHARING_VIOLATION or STATUS_LOCK_NOT_GRANTED
 
 **Cause:** An SMB client holds an exclusive lease (RWH) or byte-range lock on a file that an NFS client is trying to access, or vice versa.
 
+`NFS4ERR_SHARE_DENIED` and `NFS4ERR_LOCKED` also arise without SMB in the picture: an NFSv4 OPEN carrying a deny mode excludes later OPENs of the same file, including the same open-owner's, and excludes READ and WRITE issued under the anonymous stateid. If no SMB adapter is running, look for the NFSv4 OPEN that established the deny mode rather than for a cross-protocol break.
+
 **Diagnosis:**
 ```bash
 # Check active locks and leases via debug logging

--- a/internal/adapter/nfs/v4/handlers/client_principal_test.go
+++ b/internal/adapter/nfs/v4/handlers/client_principal_test.go
@@ -80,8 +80,8 @@ func TestOpen_ClientIDSpansPrincipals(t *testing.T) {
 
 	// The permission check is load-bearing: uid 1001 cannot write the file, and
 	// naming uid 1000's client ID and owner does not get it write access.
-	// checkOpenAccess refuses before the state layer sees the request, so seqid
-	// 3 is still unused when the read OPEN below presents it.
+	// NFS4ERR_ACCESS is one of the statuses RFC 7530 Section 9.1.7 consumes, so
+	// seqid 3 is spent on that refusal and the read OPEN below presents 4.
 	if status := doOpen(fx, other, 3, clientID, owner, "victim.txt",
 		types.OPEN4_NOCREATE, types.OPEN4_SHARE_ACCESS_BOTH).Status; status != types.NFS4ERR_ACCESS {
 		t.Errorf("OPEN for write by a uid without write permission: status = %d, want NFS4ERR_ACCESS", status)
@@ -89,7 +89,7 @@ func TestOpen_ClientIDSpansPrincipals(t *testing.T) {
 
 	// Read access it does have, and there it joins the existing open state --
 	// the documented shape of a shared client ID, not a defect.
-	shared := openStateid(t, fx, other, 3, clientID, owner, "victim.txt",
+	shared := openStateid(t, fx, other, 4, clientID, owner, "victim.txt",
 		types.OPEN4_NOCREATE, types.OPEN4_SHARE_ACCESS_READ)
 	if shared.Other != victimStateid.Other {
 		t.Errorf("second principal got a distinct open state (%x vs %x)", shared.Other, victimStateid.Other)

--- a/internal/adapter/nfs/v4/handlers/commit.go
+++ b/internal/adapter/nfs/v4/handlers/commit.go
@@ -66,6 +66,16 @@ func (h *Handler) handleCommit(ctx *types.CompoundContext, reader io.Reader) *ty
 		return commitErr(status)
 	}
 
+	// COMMIT is defined only over regular files: a directory is
+	// NFS4ERR_ISDIR and any other type NFS4ERR_INVAL. Without the gate the
+	// handler flushed whatever the handle named, and an object with no
+	// payload answered NFS4_OK.
+	if status := regularFileStatus(file.Type); status != types.NFS4_OK {
+		logger.Debug("NFSv4 COMMIT on non-regular file",
+			"type", file.Type, "status", status, "client", ctx.ClientAddr)
+		return commitErr(status)
+	}
+
 	// Enforce write permission before forcing anything to stable storage.
 	// COMMIT (RFC 7530 16.5) is the durability half of WRITE, so it takes the
 	// same gate WRITE takes via PrepareWrite — otherwise any client holding a

--- a/internal/adapter/nfs/v4/handlers/get_dir_delegation_handler_test.go
+++ b/internal/adapter/nfs/v4/handlers/get_dir_delegation_handler_test.go
@@ -4,10 +4,26 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/state"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+	"github.com/marmos91/dittofs/pkg/metadata"
 )
+
+// testDirFH returns a well-formed "<share>:<uuid>" filehandle. PUTFH refuses
+// any handle it cannot decode, so the directory handle these tests hand it has
+// to have that shape; GET_DIR_DELEGATION and DELEGRETURN only key delegation
+// state off the bytes and never resolve them, so it need not name a real
+// object.
+func testDirFH(t *testing.T) []byte {
+	t.Helper()
+	fh, err := metadata.EncodeShareHandle("/export", uuid.New())
+	if err != nil {
+		t.Fatalf("encode directory filehandle: %v", err)
+	}
+	return []byte(fh)
+}
 
 // encodeGetDirDelegationArgs encodes GET_DIR_DELEGATION4args for testing.
 func encodeGetDirDelegationArgs(notifMask uint32) []byte {
@@ -35,8 +51,7 @@ func TestGetDirDelegation_Success(t *testing.T) {
 	h, sessionID := createTestSession(t)
 	ctx := newTestCompoundContext()
 
-	// Set up a fake directory filehandle via PUTFH
-	dirFH := []byte("test-dir-fh-001")
+	dirFH := testDirFH(t)
 
 	notifMask := uint32((1 << types.NOTIFY4_ADD_ENTRY) | (1 << types.NOTIFY4_REMOVE_ENTRY))
 
@@ -121,7 +136,7 @@ func TestGetDirDelegation_Unavail_LimitReached(t *testing.T) {
 		t.Fatalf("pre-fill GrantDirDelegation error: %v", err)
 	}
 
-	dirFH := []byte("test-dir-fh-limit")
+	dirFH := testDirFH(t)
 	notifMask := uint32(1 << types.NOTIFY4_ADD_ENTRY)
 
 	seqArgs := encodeSequenceArgs(sessionID, 0, 1, 0, false)
@@ -183,7 +198,7 @@ func TestGetDirDelegation_Unavail_Disabled(t *testing.T) {
 	// Disable delegations
 	h.StateManager.SetDelegationsEnabled(false)
 
-	dirFH := []byte("test-dir-fh-disabled")
+	dirFH := testDirFH(t)
 	notifMask := uint32(1 << types.NOTIFY4_REMOVE_ENTRY)
 
 	seqArgs := encodeSequenceArgs(sessionID, 0, 1, 0, false)
@@ -270,7 +285,7 @@ func TestGetDirDelegation_BadSession(t *testing.T) {
 	copy(fakeSessionID[:], []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
 		0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF})
 
-	dirFH := []byte("test-dir-fh-badsession")
+	dirFH := testDirFH(t)
 	notifMask := uint32(1 << types.NOTIFY4_ADD_ENTRY)
 
 	seqArgs := encodeSequenceArgs(fakeSessionID, 0, 1, 0, false)
@@ -301,7 +316,7 @@ func TestGetDirDelegation_BadXDR(t *testing.T) {
 	h, sessionID := createTestSession(t)
 	ctx := newTestCompoundContext()
 
-	dirFH := []byte("test-dir-fh-badxdr")
+	dirFH := testDirFH(t)
 
 	seqArgs := encodeSequenceArgs(sessionID, 0, 1, 0, false)
 
@@ -330,7 +345,7 @@ func TestDelegReturn_FlushesDirectoryNotifications(t *testing.T) {
 	ctx := newTestCompoundContext()
 
 	// Grant a directory delegation
-	dirFH := []byte("test-dir-fh-flush")
+	dirFH := testDirFH(t)
 	notifMask := uint32((1 << types.NOTIFY4_ADD_ENTRY) | (1 << types.NOTIFY4_REMOVE_ENTRY))
 
 	// Get the client ID from the session

--- a/internal/adapter/nfs/v4/handlers/helpers.go
+++ b/internal/adapter/nfs/v4/handlers/helpers.go
@@ -295,3 +295,52 @@ func encodeChangeInfo4(buf *bytes.Buffer, atomic bool, before, after uint64) {
 	_ = xdr.WriteUint64(buf, before)
 	_ = xdr.WriteUint64(buf, after)
 }
+
+// regularFileStatus reports the status an operation defined only over regular
+// files must return for the type of object its current filehandle designates:
+// NFS4_OK for a regular file, NFS4ERR_ISDIR for a directory and NFS4ERR_INVAL
+// for every other type. COMMIT (RFC 7530 Section 16.5.4), LOCK, LOCKT and LOCKU
+// (Section 16.10.4) and READ and WRITE (Sections 16.22.4 and 16.36.4) all state
+// the rule in the same words.
+func regularFileStatus(fileType metadata.FileType) uint32 {
+	switch fileType {
+	case metadata.FileTypeRegular:
+		return types.NFS4_OK
+	case metadata.FileTypeDirectory:
+		return types.NFS4ERR_ISDIR
+	default:
+		return types.NFS4ERR_INVAL
+	}
+}
+
+// directoryStatus reports the status LOOKUP and LOOKUPP must return for the
+// type of object their current filehandle designates. RFC 7530 Section 16.15.4:
+// a symbolic link is reported as NFS4ERR_SYMLINK so the client knows to resolve
+// it, and every other non-directory type as NFS4ERR_NOTDIR.
+func directoryStatus(fileType metadata.FileType) uint32 {
+	switch fileType {
+	case metadata.FileTypeDirectory:
+		return types.NFS4_OK
+	case metadata.FileTypeSymlink:
+		return types.NFS4ERR_SYMLINK
+	default:
+		return types.NFS4ERR_NOTDIR
+	}
+}
+
+// fileTypeForHandle resolves the object type of a real-filesystem filehandle
+// for the operations that gate on it but never load the file otherwise. The
+// second return is NFS4_OK when the type is usable and the status to report
+// when the handle could not be resolved.
+func (h *Handler) fileTypeForHandle(ctx *types.CompoundContext, handle []byte) (metadata.FileType, uint32) {
+	metaSvc, err := getMetadataServiceForCtx(h)
+	if err != nil {
+		return 0, types.NFS4ERR_SERVERFAULT
+	}
+	// GetFileForRead: handle-addressed, File.Path unused -- skip derivePath.
+	file, err := metaSvc.GetFileForRead(ctx.Context, metadata.FileHandle(handle))
+	if err != nil {
+		return 0, common.MapToNFS4(err)
+	}
+	return file.Type, types.NFS4_OK
+}

--- a/internal/adapter/nfs/v4/handlers/lock.go
+++ b/internal/adapter/nfs/v4/handlers/lock.go
@@ -329,15 +329,11 @@ func (h *Handler) handleLockT(ctx *types.CompoundContext, reader io.Reader) *typ
 	// tables are keyed by filehandle bytes alone, so without this gate a
 	// probe against a directory or a device node answered NFS4_OK.
 	fileType, status := h.fileTypeForHandle(ctx, ctx.CurrentFH)
-	if status != types.NFS4_OK {
-		return &types.CompoundResult{
-			Status: status,
-			OpCode: types.OP_LOCKT,
-			Data:   encodeStatusOnly(status),
-		}
+	if status == types.NFS4_OK {
+		status = regularFileStatus(fileType)
 	}
-	if status := regularFileStatus(fileType); status != types.NFS4_OK {
-		logger.Debug("NFSv4 LOCKT on non-regular file",
+	if status != types.NFS4_OK {
+		logger.Debug("NFSv4 LOCKT refused",
 			"type", fileType, "status", status, "client", ctx.ClientAddr)
 		return &types.CompoundResult{
 			Status: status,

--- a/internal/adapter/nfs/v4/handlers/lock.go
+++ b/internal/adapter/nfs/v4/handlers/lock.go
@@ -324,6 +324,28 @@ func (h *Handler) handleLockT(ctx *types.CompoundContext, reader io.Reader) *typ
 		}
 	}
 
+	// LOCKT is defined only over regular files (RFC 7530 Section 16.10.4):
+	// a directory is NFS4ERR_ISDIR and any other type NFS4ERR_INVAL. The lock
+	// tables are keyed by filehandle bytes alone, so without this gate a
+	// probe against a directory or a device node answered NFS4_OK.
+	fileType, status := h.fileTypeForHandle(ctx, ctx.CurrentFH)
+	if status != types.NFS4_OK {
+		return &types.CompoundResult{
+			Status: status,
+			OpCode: types.OP_LOCKT,
+			Data:   encodeStatusOnly(status),
+		}
+	}
+	if status := regularFileStatus(fileType); status != types.NFS4_OK {
+		logger.Debug("NFSv4 LOCKT on non-regular file",
+			"type", fileType, "status", status, "client", ctx.ClientAddr)
+		return &types.CompoundResult{
+			Status: status,
+			OpCode: types.OP_LOCKT,
+			Data:   encodeStatusOnly(status),
+		}
+	}
+
 	logger.Debug("NFSv4 LOCKT",
 		"lock_type", lockType,
 		"offset", offset,

--- a/internal/adapter/nfs/v4/handlers/lock_test.go
+++ b/internal/adapter/nfs/v4/handlers/lock_test.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"context"
 	"testing"
-	"time"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/pseudofs"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/state"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
@@ -138,8 +138,23 @@ func TestHandleLock_BadXDR(t *testing.T) {
 	}
 }
 
+// newLockTestHandler builds a handler over a real metadata store and returns it
+// alongside the handle of a regular file to lock. LOCKT resolves the current
+// filehandle to check the object type (RFC 7530 Section 16.10.4), so the handle
+// the lock tests carry has to name a real regular file. The fixture's state
+// manager has no lock manager of its own.
+func newLockTestHandler(t *testing.T) (*Handler, []byte) {
+	t.Helper()
+
+	fx := newRealFSTestFixture(t, "/export")
+	fx.handler.StateManager.SetLockManager(lock.NewManager())
+	fh := fx.createTestFile(t, fx.rootHandle, "lock-test-file", metadata.FileTypeRegular, 0o644, 0, 0)
+
+	return fx.handler, []byte(fh)
+}
+
 // setupHandlerLockClient sets up a confirmed client and open state for handler-level tests.
-func setupHandlerLockClient(t *testing.T, h *Handler) (clientID uint64, openStateid *types.Stateid4, openSeqid uint32) {
+func setupHandlerLockClient(t *testing.T, h *Handler, fileHandle []byte) (clientID uint64, openStateid *types.Stateid4, openSeqid uint32) {
 	t.Helper()
 
 	ctx := &types.CompoundContext{
@@ -178,7 +193,6 @@ func setupHandlerLockClient(t *testing.T, h *Handler) (clientID uint64, openStat
 	}
 
 	// OPEN (create state)
-	fileHandle := []byte("/export:lock-test-file")
 	ctx.CurrentFH = make([]byte, len(fileHandle))
 	copy(ctx.CurrentFH, fileHandle)
 
@@ -207,17 +221,10 @@ func setupHandlerLockClient(t *testing.T, h *Handler) (clientID uint64, openStat
 }
 
 func TestHandleLock_NewLockOwner_Success(t *testing.T) {
-	pfs := pseudofs.New()
-	pfs.Rebuild([]string{"/export"})
+	h, fileHandle := newLockTestHandler(t)
 
-	lm := lock.NewManager()
-	sm := state.NewStateManager(90 * time.Second)
-	sm.SetLockManager(lm)
-	h := NewHandler(nil, pfs, sm)
+	clientID, openStateid, openSeqid := setupHandlerLockClient(t, h, fileHandle)
 
-	clientID, openStateid, openSeqid := setupHandlerLockClient(t, h)
-
-	fileHandle := []byte("/export:lock-test-file")
 	ctx := &types.CompoundContext{
 		Context:    context.Background(),
 		ClientAddr: "127.0.0.1:9999",
@@ -265,17 +272,10 @@ func TestHandleLock_NewLockOwner_Success(t *testing.T) {
 }
 
 func TestHandleLock_ExistingLockOwner_Success(t *testing.T) {
-	pfs := pseudofs.New()
-	pfs.Rebuild([]string{"/export"})
+	h, fileHandle := newLockTestHandler(t)
 
-	lm := lock.NewManager()
-	sm := state.NewStateManager(90 * time.Second)
-	sm.SetLockManager(lm)
-	h := NewHandler(nil, pfs, sm)
+	clientID, openStateid, openSeqid := setupHandlerLockClient(t, h, fileHandle)
 
-	clientID, openStateid, openSeqid := setupHandlerLockClient(t, h)
-
-	fileHandle := []byte("/export:lock-test-file")
 	ctx := &types.CompoundContext{
 		Context:    context.Background(),
 		ClientAddr: "127.0.0.1:9999",
@@ -356,10 +356,9 @@ func TestHandleLock_Dispatched(t *testing.T) {
 // returns the lock stateid and lock-owner seqid for further use.
 // ============================================================================
 
-func acquireLockForTest(t *testing.T, h *Handler, clientID uint64, openStateid *types.Stateid4, openSeqid uint32, lockOwnerData []byte, lockType uint32, offset, length uint64) (*types.Stateid4, uint32) {
+func acquireLockForTest(t *testing.T, h *Handler, fileHandle []byte, clientID uint64, openStateid *types.Stateid4, openSeqid uint32, lockOwnerData []byte, lockType uint32, offset, length uint64) (*types.Stateid4, uint32) {
 	t.Helper()
 
-	fileHandle := []byte("/export:lock-test-file")
 	ctx := &types.CompoundContext{
 		Context:    context.Background(),
 		ClientAddr: "127.0.0.1:9999",
@@ -401,17 +400,10 @@ func acquireLockForTest(t *testing.T, h *Handler, clientID uint64, openStateid *
 // ============================================================================
 
 func TestHandleLockT_NoConflict(t *testing.T) {
-	pfs := pseudofs.New()
-	pfs.Rebuild([]string{"/export"})
+	h, fileHandle := newLockTestHandler(t)
 
-	lm := lock.NewManager()
-	sm := state.NewStateManager(90 * time.Second)
-	sm.SetLockManager(lm)
-	h := NewHandler(nil, pfs, sm)
+	clientID, _, _ := setupHandlerLockClient(t, h, fileHandle)
 
-	clientID, _, _ := setupHandlerLockClient(t, h)
-
-	fileHandle := []byte("/export:lock-test-file")
 	ctx := &types.CompoundContext{
 		Context:    context.Background(),
 		ClientAddr: "127.0.0.1:9999",
@@ -440,20 +432,13 @@ func TestHandleLockT_NoConflict(t *testing.T) {
 }
 
 func TestHandleLockT_Conflict(t *testing.T) {
-	pfs := pseudofs.New()
-	pfs.Rebuild([]string{"/export"})
+	h, fileHandle := newLockTestHandler(t)
 
-	lm := lock.NewManager()
-	sm := state.NewStateManager(90 * time.Second)
-	sm.SetLockManager(lm)
-	h := NewHandler(nil, pfs, sm)
-
-	clientID, openStateid, openSeqid := setupHandlerLockClient(t, h)
+	clientID, openStateid, openSeqid := setupHandlerLockClient(t, h, fileHandle)
 
 	// First: acquire an exclusive lock via LOCK
-	acquireLockForTest(t, h, clientID, openStateid, openSeqid, []byte("holder-owner"), types.WRITE_LT, 0, 100)
+	acquireLockForTest(t, h, fileHandle, clientID, openStateid, openSeqid, []byte("holder-owner"), types.WRITE_LT, 0, 100)
 
-	fileHandle := []byte("/export:lock-test-file")
 	ctx := &types.CompoundContext{
 		Context:    context.Background(),
 		ClientAddr: "127.0.0.1:9999",
@@ -500,20 +485,13 @@ func TestHandleLockT_Conflict(t *testing.T) {
 }
 
 func TestHandleLockT_SharedNoConflict(t *testing.T) {
-	pfs := pseudofs.New()
-	pfs.Rebuild([]string{"/export"})
+	h, fileHandle := newLockTestHandler(t)
 
-	lm := lock.NewManager()
-	sm := state.NewStateManager(90 * time.Second)
-	sm.SetLockManager(lm)
-	h := NewHandler(nil, pfs, sm)
-
-	clientID, openStateid, openSeqid := setupHandlerLockClient(t, h)
+	clientID, openStateid, openSeqid := setupHandlerLockClient(t, h, fileHandle)
 
 	// First: acquire a shared (read) lock
-	acquireLockForTest(t, h, clientID, openStateid, openSeqid, []byte("reader-owner"), types.READ_LT, 0, 100)
+	acquireLockForTest(t, h, fileHandle, clientID, openStateid, openSeqid, []byte("reader-owner"), types.READ_LT, 0, 100)
 
-	fileHandle := []byte("/export:lock-test-file")
 	ctx := &types.CompoundContext{
 		Context:    context.Background(),
 		ClientAddr: "127.0.0.1:9999",
@@ -604,20 +582,13 @@ func TestHandleLockT_Dispatched(t *testing.T) {
 // ============================================================================
 
 func TestHandleLockU_Success(t *testing.T) {
-	pfs := pseudofs.New()
-	pfs.Rebuild([]string{"/export"})
+	h, fileHandle := newLockTestHandler(t)
 
-	lm := lock.NewManager()
-	sm := state.NewStateManager(90 * time.Second)
-	sm.SetLockManager(lm)
-	h := NewHandler(nil, pfs, sm)
-
-	clientID, openStateid, openSeqid := setupHandlerLockClient(t, h)
+	clientID, openStateid, openSeqid := setupHandlerLockClient(t, h, fileHandle)
 
 	// Acquire a lock
-	lockStateid, lockSeqid := acquireLockForTest(t, h, clientID, openStateid, openSeqid, []byte("unlock-owner"), types.WRITE_LT, 0, 100)
+	lockStateid, lockSeqid := acquireLockForTest(t, h, fileHandle, clientID, openStateid, openSeqid, []byte("unlock-owner"), types.WRITE_LT, 0, 100)
 
-	fileHandle := []byte("/export:lock-test-file")
 	ctx := &types.CompoundContext{
 		Context:    context.Background(),
 		ClientAddr: "127.0.0.1:9999",
@@ -664,15 +635,8 @@ func TestHandleLockU_Success(t *testing.T) {
 }
 
 func TestHandleLockU_BadStateid(t *testing.T) {
-	pfs := pseudofs.New()
-	pfs.Rebuild([]string{"/export"})
+	h, fileHandle := newLockTestHandler(t)
 
-	lm := lock.NewManager()
-	sm := state.NewStateManager(90 * time.Second)
-	sm.SetLockManager(lm)
-	h := NewHandler(nil, pfs, sm)
-
-	fileHandle := []byte("/export:lock-test-file")
 	ctx := &types.CompoundContext{
 		Context:    context.Background(),
 		ClientAddr: "127.0.0.1:9999",
@@ -686,9 +650,9 @@ func TestHandleLockU_BadStateid(t *testing.T) {
 	}
 	// Set the epoch bytes to match current boot epoch so we get BAD_STATEID not STALE
 	fakeStateid.Other[0] = state.StateTypeLock
-	fakeStateid.Other[1] = byte(sm.BootEpoch() >> 16)
-	fakeStateid.Other[2] = byte(sm.BootEpoch() >> 8)
-	fakeStateid.Other[3] = byte(sm.BootEpoch())
+	fakeStateid.Other[1] = byte(h.StateManager.BootEpoch() >> 16)
+	fakeStateid.Other[2] = byte(h.StateManager.BootEpoch() >> 8)
+	fakeStateid.Other[3] = byte(h.StateManager.BootEpoch())
 	// Bytes 4-11: random non-matching sequence
 	fakeStateid.Other[4] = 0xFF
 	fakeStateid.Other[5] = 0xFF
@@ -709,20 +673,13 @@ func TestHandleLockU_BadStateid(t *testing.T) {
 }
 
 func TestHandleLockU_BadSeqid(t *testing.T) {
-	pfs := pseudofs.New()
-	pfs.Rebuild([]string{"/export"})
+	h, fileHandle := newLockTestHandler(t)
 
-	lm := lock.NewManager()
-	sm := state.NewStateManager(90 * time.Second)
-	sm.SetLockManager(lm)
-	h := NewHandler(nil, pfs, sm)
-
-	clientID, openStateid, openSeqid := setupHandlerLockClient(t, h)
+	clientID, openStateid, openSeqid := setupHandlerLockClient(t, h, fileHandle)
 
 	// Acquire a lock
-	lockStateid, _ := acquireLockForTest(t, h, clientID, openStateid, openSeqid, []byte("seqid-test-owner"), types.WRITE_LT, 0, 100)
+	lockStateid, _ := acquireLockForTest(t, h, fileHandle, clientID, openStateid, openSeqid, []byte("seqid-test-owner"), types.WRITE_LT, 0, 100)
 
-	fileHandle := []byte("/export:lock-test-file")
 	ctx := &types.CompoundContext{
 		Context:    context.Background(),
 		ClientAddr: "127.0.0.1:9999",
@@ -747,20 +704,13 @@ func TestHandleLockU_BadSeqid(t *testing.T) {
 }
 
 func TestHandleLockU_PartialUnlock(t *testing.T) {
-	pfs := pseudofs.New()
-	pfs.Rebuild([]string{"/export"})
+	h, fileHandle := newLockTestHandler(t)
 
-	lm := lock.NewManager()
-	sm := state.NewStateManager(90 * time.Second)
-	sm.SetLockManager(lm)
-	h := NewHandler(nil, pfs, sm)
-
-	clientID, openStateid, openSeqid := setupHandlerLockClient(t, h)
+	clientID, openStateid, openSeqid := setupHandlerLockClient(t, h, fileHandle)
 
 	// Acquire a lock on full range [0, 100)
-	lockStateid, lockSeqid := acquireLockForTest(t, h, clientID, openStateid, openSeqid, []byte("partial-owner"), types.WRITE_LT, 0, 100)
+	lockStateid, lockSeqid := acquireLockForTest(t, h, fileHandle, clientID, openStateid, openSeqid, []byte("partial-owner"), types.WRITE_LT, 0, 100)
 
-	fileHandle := []byte("/export:lock-test-file")
 	ctx := &types.CompoundContext{
 		Context:    context.Background(),
 		ClientAddr: "127.0.0.1:9999",
@@ -854,21 +804,14 @@ func TestHandleLockU_Dispatched(t *testing.T) {
 // ============================================================================
 
 func TestHandleReleaseLockOwner_NoLocks(t *testing.T) {
-	pfs := pseudofs.New()
-	pfs.Rebuild([]string{"/export"})
+	h, fileHandle := newLockTestHandler(t)
 
-	lm := lock.NewManager()
-	sm := state.NewStateManager(90 * time.Second)
-	sm.SetLockManager(lm)
-	h := NewHandler(nil, pfs, sm)
-
-	clientID, openStateid, openSeqid := setupHandlerLockClient(t, h)
+	clientID, openStateid, openSeqid := setupHandlerLockClient(t, h, fileHandle)
 
 	// Acquire a lock, then release it
-	lockStateid, lockSeqid := acquireLockForTest(t, h, clientID, openStateid, openSeqid,
+	lockStateid, lockSeqid := acquireLockForTest(t, h, fileHandle, clientID, openStateid, openSeqid,
 		[]byte("release-handler-owner"), types.WRITE_LT, 0, 100)
 
-	fileHandle := []byte("/export:lock-test-file")
 	ctx := &types.CompoundContext{
 		Context:    context.Background(),
 		ClientAddr: "127.0.0.1:9999",
@@ -907,18 +850,12 @@ func TestHandleReleaseLockOwner_NoLocks(t *testing.T) {
 }
 
 func TestHandleReleaseLockOwner_LocksHeld(t *testing.T) {
-	pfs := pseudofs.New()
-	pfs.Rebuild([]string{"/export"})
+	h, fileHandle := newLockTestHandler(t)
 
-	lm := lock.NewManager()
-	sm := state.NewStateManager(90 * time.Second)
-	sm.SetLockManager(lm)
-	h := NewHandler(nil, pfs, sm)
-
-	clientID, openStateid, openSeqid := setupHandlerLockClient(t, h)
+	clientID, openStateid, openSeqid := setupHandlerLockClient(t, h, fileHandle)
 
 	// Acquire a lock but do NOT release it
-	acquireLockForTest(t, h, clientID, openStateid, openSeqid,
+	acquireLockForTest(t, h, fileHandle, clientID, openStateid, openSeqid,
 		[]byte("held-handler-owner"), types.WRITE_LT, 0, 100)
 
 	ctx := &types.CompoundContext{
@@ -944,21 +881,14 @@ func TestHandleReleaseLockOwner_LocksHeld(t *testing.T) {
 // ============================================================================
 
 func TestHandleClose_LocksHeld(t *testing.T) {
-	pfs := pseudofs.New()
-	pfs.Rebuild([]string{"/export"})
+	h, fileHandle := newLockTestHandler(t)
 
-	lm := lock.NewManager()
-	sm := state.NewStateManager(90 * time.Second)
-	sm.SetLockManager(lm)
-	h := NewHandler(nil, pfs, sm)
-
-	clientID, openStateid, openSeqid := setupHandlerLockClient(t, h)
+	clientID, openStateid, openSeqid := setupHandlerLockClient(t, h, fileHandle)
 
 	// Acquire a lock
-	acquireLockForTest(t, h, clientID, openStateid, openSeqid,
+	acquireLockForTest(t, h, fileHandle, clientID, openStateid, openSeqid,
 		[]byte("close-held-owner"), types.WRITE_LT, 0, 100)
 
-	fileHandle := []byte("/export:lock-test-file")
 	ctx := &types.CompoundContext{
 		Context:    context.Background(),
 		ClientAddr: "127.0.0.1:9999",
@@ -980,21 +910,14 @@ func TestHandleClose_LocksHeld(t *testing.T) {
 }
 
 func TestHandleClose_AfterUnlock(t *testing.T) {
-	pfs := pseudofs.New()
-	pfs.Rebuild([]string{"/export"})
+	h, fileHandle := newLockTestHandler(t)
 
-	lm := lock.NewManager()
-	sm := state.NewStateManager(90 * time.Second)
-	sm.SetLockManager(lm)
-	h := NewHandler(nil, pfs, sm)
-
-	clientID, openStateid, openSeqid := setupHandlerLockClient(t, h)
+	clientID, openStateid, openSeqid := setupHandlerLockClient(t, h, fileHandle)
 
 	// Acquire a lock
-	lockStateid, lockSeqid := acquireLockForTest(t, h, clientID, openStateid, openSeqid,
+	lockStateid, lockSeqid := acquireLockForTest(t, h, fileHandle, clientID, openStateid, openSeqid,
 		[]byte("close-unlock-owner"), types.WRITE_LT, 0, 100)
 
-	fileHandle := []byte("/export:lock-test-file")
 	ctx := &types.CompoundContext{
 		Context:    context.Background(),
 		ClientAddr: "127.0.0.1:9999",
@@ -1016,7 +939,7 @@ func TestHandleClose_AfterUnlock(t *testing.T) {
 	}
 
 	// RELEASE_LOCKOWNER to clean up lock state
-	relErr := sm.ReleaseLockOwner(clientID, []byte("close-unlock-owner"))
+	relErr := h.StateManager.ReleaseLockOwner(clientID, []byte("close-unlock-owner"))
 	if relErr != nil {
 		t.Fatalf("ReleaseLockOwner failed: %v", relErr)
 	}
@@ -1039,18 +962,11 @@ func TestHandleClose_AfterUnlock(t *testing.T) {
 // ============================================================================
 
 func TestFullLockLifecycle(t *testing.T) {
-	pfs := pseudofs.New()
-	pfs.Rebuild([]string{"/export"})
-
-	lm := lock.NewManager()
-	sm := state.NewStateManager(90 * time.Second)
-	sm.SetLockManager(lm)
-	h := NewHandler(nil, pfs, sm)
+	h, fileHandle := newLockTestHandler(t)
 
 	// 1. SETCLIENTID + CONFIRM
-	clientID, openStateid, openSeqid := setupHandlerLockClient(t, h)
+	clientID, openStateid, openSeqid := setupHandlerLockClient(t, h, fileHandle)
 
-	fileHandle := []byte("/export:lock-test-file")
 	ctx := &types.CompoundContext{
 		Context:    context.Background(),
 		ClientAddr: "127.0.0.1:9999",
@@ -1177,7 +1093,7 @@ func TestFullLockLifecycle(t *testing.T) {
 	t.Logf("Step 7: LOCKU OK")
 
 	// 8. RELEASE_LOCKOWNER
-	relErr := sm.ReleaseLockOwner(clientID, []byte("lifecycle-owner"))
+	relErr := h.StateManager.ReleaseLockOwner(clientID, []byte("lifecycle-owner"))
 	if relErr != nil {
 		t.Fatalf("Step 8: ReleaseLockOwner failed: %v", relErr)
 	}
@@ -1218,17 +1134,10 @@ func TestHandleLock_InvalidRange(t *testing.T) {
 
 	for _, r := range ranges {
 		t.Run(r.name, func(t *testing.T) {
-			pfs := pseudofs.New()
-			pfs.Rebuild([]string{"/export"})
+			h, fileHandle := newLockTestHandler(t)
 
-			lm := lock.NewManager()
-			sm := state.NewStateManager(90 * time.Second)
-			sm.SetLockManager(lm)
-			h := NewHandler(nil, pfs, sm)
+			clientID, openStateid, openSeqid := setupHandlerLockClient(t, h, fileHandle)
 
-			clientID, openStateid, openSeqid := setupHandlerLockClient(t, h)
-
-			fileHandle := []byte("/export:lock-test-file")
 			ctx := &types.CompoundContext{
 				Context:    context.Background(),
 				ClientAddr: "127.0.0.1:9999",

--- a/internal/adapter/nfs/v4/handlers/lookup.go
+++ b/internal/adapter/nfs/v4/handlers/lookup.go
@@ -81,6 +81,14 @@ func (h *Handler) lookupInRealFS(ctx *types.CompoundContext, name string) *types
 	child, err := metaSvc.Lookup(authCtx, metadata.FileHandle(ctx.CurrentFH), name)
 	if err != nil {
 		status := common.MapToNFS4(err)
+		// The store reports every non-directory the same way, but RFC 7530
+		// Section 16.15.4 separates a symbolic link out as NFS4ERR_SYMLINK so
+		// the client knows to resolve it rather than give up on the path.
+		if status == types.NFS4ERR_NOTDIR {
+			if fileType, st := h.fileTypeForHandle(ctx, ctx.CurrentFH); st == types.NFS4_OK {
+				status = directoryStatus(fileType)
+			}
+		}
 		return &types.CompoundResult{
 			Status: status,
 			OpCode: types.OP_LOOKUP,

--- a/internal/adapter/nfs/v4/handlers/lookup.go
+++ b/internal/adapter/nfs/v4/handlers/lookup.go
@@ -86,7 +86,13 @@ func (h *Handler) lookupInRealFS(ctx *types.CompoundContext, name string) *types
 		// the client knows to resolve it rather than give up on the path.
 		if status == types.NFS4ERR_NOTDIR {
 			if fileType, st := h.fileTypeForHandle(ctx, ctx.CurrentFH); st == types.NFS4_OK {
-				status = directoryStatus(fileType)
+				// Only ever narrows one failure into a more precise one. A
+				// directory maps to NFS4_OK, which here would report success
+				// for a lookup that resolved nothing and leave the current
+				// filehandle where it was.
+				if refined := directoryStatus(fileType); refined != types.NFS4_OK {
+					status = refined
+				}
 			}
 		}
 		return &types.CompoundResult{

--- a/internal/adapter/nfs/v4/handlers/lookupp.go
+++ b/internal/adapter/nfs/v4/handlers/lookupp.go
@@ -63,14 +63,10 @@ func (h *Handler) lookupParentInRealFS(ctx *types.CompoundContext) *types.Compou
 	// parent, so without this gate LOOKUPP on a file or a device node
 	// answered NFS4_OK with the parent directory's handle.
 	fileType, status := h.fileTypeForHandle(ctx, ctx.CurrentFH)
-	if status != types.NFS4_OK {
-		return &types.CompoundResult{
-			Status: status,
-			OpCode: types.OP_LOOKUPP,
-			Data:   encodeStatusOnly(status),
-		}
+	if status == types.NFS4_OK {
+		status = directoryStatus(fileType)
 	}
-	if status := directoryStatus(fileType); status != types.NFS4_OK {
+	if status != types.NFS4_OK {
 		return &types.CompoundResult{
 			Status: status,
 			OpCode: types.OP_LOOKUPP,
@@ -111,9 +107,16 @@ func (h *Handler) lookupParentInRealFS(ctx *types.CompoundContext) *types.Compou
 	}
 }
 
-// crossBackToPseudoFS sets the current filehandle to the pseudo-fs junction
-// for the given share name. Called when LOOKUPP at share root needs to go
-// back to the virtual namespace.
+// crossBackToPseudoFS sets the current filehandle to the parent of the
+// pseudo-fs junction for the given share name. Called when LOOKUPP at a share
+// root needs to go back to the virtual namespace.
+//
+// The junction node and the share root are two views of one directory -- a
+// share exported at /export is reached either as the pseudo-fs node /export or
+// as the real filesystem's root -- so answering with the junction itself left
+// the client in the directory it was already in, and a walk upwards stalled
+// there. The step out of the share lands on what contains it, which is the
+// junction's parent.
 func (h *Handler) crossBackToPseudoFS(ctx *types.CompoundContext, shareName string) *types.CompoundResult {
 	if h.PseudoFS == nil {
 		return &types.CompoundResult{
@@ -133,9 +136,16 @@ func (h *Handler) crossBackToPseudoFS(ctx *types.CompoundContext, shareName stri
 		}
 	}
 
-	// Set current FH to the junction's handle (copy-on-set)
-	ctx.CurrentFH = make([]byte, len(junction.Handle))
-	copy(ctx.CurrentFH, junction.Handle)
+	// A junction directly under the pseudo-fs root has the root as its parent;
+	// the root itself is never a junction, so there is always one to step to.
+	target := junction.Handle
+	if parent, ok := h.PseudoFS.LookupParent(junction); ok && parent != nil {
+		target = parent.Handle
+	}
+
+	// Set current FH to the parent's handle (copy-on-set)
+	ctx.CurrentFH = make([]byte, len(target))
+	copy(ctx.CurrentFH, target)
 
 	return &types.CompoundResult{
 		Status: types.NFS4_OK,

--- a/internal/adapter/nfs/v4/handlers/lookupp.go
+++ b/internal/adapter/nfs/v4/handlers/lookupp.go
@@ -58,6 +58,26 @@ func (h *Handler) lookupParentInRealFS(ctx *types.CompoundContext) *types.Compou
 		}
 	}
 
+	// LOOKUPP walks out of a directory, so a current filehandle of any other
+	// type is an error (RFC 7530 Section 16.16.4). Every object carries a
+	// parent, so without this gate LOOKUPP on a file or a device node
+	// answered NFS4_OK with the parent directory's handle.
+	fileType, status := h.fileTypeForHandle(ctx, ctx.CurrentFH)
+	if status != types.NFS4_OK {
+		return &types.CompoundResult{
+			Status: status,
+			OpCode: types.OP_LOOKUPP,
+			Data:   encodeStatusOnly(status),
+		}
+	}
+	if status := directoryStatus(fileType); status != types.NFS4_OK {
+		return &types.CompoundResult{
+			Status: status,
+			OpCode: types.OP_LOOKUPP,
+			Data:   encodeStatusOnly(status),
+		}
+	}
+
 	// Get current file's parent handle from metadata store
 	store, err := metaSvc.GetStoreForShare(shareName)
 	if err != nil {
@@ -136,13 +156,16 @@ func (h *Handler) lookupParentInPseudoFS(ctx *types.CompoundContext) *types.Comp
 		}
 	}
 
-	// Get parent node (root's parent is root itself)
+	// The pseudo-fs root has no parent to walk to, and RFC 7530
+	// Section 16.16.4 answers that with NFS4ERR_NOENT. LookupParent reports
+	// the root as its own parent, which would otherwise answer NFS4_OK and
+	// leave the current filehandle unchanged.
 	parent, ok := h.PseudoFS.LookupParent(node)
-	if !ok {
+	if !ok || parent == nil || parent == node {
 		return &types.CompoundResult{
-			Status: types.NFS4ERR_SERVERFAULT,
+			Status: types.NFS4ERR_NOENT,
 			OpCode: types.OP_LOOKUPP,
-			Data:   encodeStatusOnly(types.NFS4ERR_SERVERFAULT),
+			Data:   encodeStatusOnly(types.NFS4ERR_NOENT),
 		}
 	}
 

--- a/internal/adapter/nfs/v4/handlers/objecttype_test.go
+++ b/internal/adapter/nfs/v4/handlers/objecttype_test.go
@@ -1,0 +1,195 @@
+package handlers
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// The operations below are each defined over one kind of object, and each of
+// them used to act on whatever the current filehandle named. The tests pin the
+// status RFC 7530 requires for the wrong type, per operation.
+
+// TestCommit_NonRegularTarget covers RFC 7530 Section 16.5.4: COMMIT flushes a
+// regular file, so a directory is NFS4ERR_ISDIR and every other type
+// NFS4ERR_INVAL. An object with no payload used to answer NFS4_OK, because the
+// handler returned early on an empty PayloadID without ever looking at the type.
+func TestCommit_NonRegularTarget(t *testing.T) {
+	cases := []struct {
+		name     string
+		child    string
+		fileType metadata.FileType
+		want     uint32
+	}{
+		{"directory", "subdir", metadata.FileTypeDirectory, types.NFS4ERR_ISDIR},
+		{"symlink", "link", metadata.FileTypeSymlink, types.NFS4ERR_INVAL},
+		{"fifo", "fifo", metadata.FileTypeFIFO, types.NFS4ERR_INVAL},
+		{"socket", "sock", metadata.FileTypeSocket, types.NFS4ERR_INVAL},
+		{"regular", "file.txt", metadata.FileTypeRegular, types.NFS4_OK},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := newRealFSTestFixture(t, "/export")
+			handle := fx.createTestFile(t, fx.rootHandle, tc.child, tc.fileType, 0o755, 1000, 1000)
+
+			ctx := newRealFSContext(1000, 1000)
+			ctx.CurrentFH = append([]byte(nil), handle...)
+
+			var args bytes.Buffer
+			_ = xdr.WriteUint64(&args, 0) // offset
+			_ = xdr.WriteUint32(&args, 0) // count: whole file
+
+			r := fx.handler.handleCommit(ctx, bytes.NewReader(args.Bytes()))
+			if r.Status != tc.want {
+				t.Fatalf("COMMIT on %s: status = %d, want %d", tc.name, r.Status, tc.want)
+			}
+		})
+	}
+}
+
+// TestLockT_NonRegularTarget covers RFC 7530 Section 16.10.4. The lock tables
+// are keyed by filehandle bytes alone and never consulted the store, so a probe
+// against a directory or a device node found no conflict and answered NFS4_OK.
+func TestLockT_NonRegularTarget(t *testing.T) {
+	cases := []struct {
+		name     string
+		child    string
+		fileType metadata.FileType
+		want     uint32
+	}{
+		{"directory", "subdir", metadata.FileTypeDirectory, types.NFS4ERR_ISDIR},
+		{"symlink", "link", metadata.FileTypeSymlink, types.NFS4ERR_INVAL},
+		{"chardev", "chr", metadata.FileTypeCharDevice, types.NFS4ERR_INVAL},
+		{"regular", "file.txt", metadata.FileTypeRegular, types.NFS4_OK},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := newRealFSTestFixture(t, "/export")
+			clientID := testClientID(t, fx.handler.StateManager, "lockt-type-client")
+			handle := fx.createTestFile(t, fx.rootHandle, tc.child, tc.fileType, 0o644, 1000, 1000)
+
+			ctx := newRealFSContext(1000, 1000)
+			ctx.CurrentFH = append([]byte(nil), handle...)
+
+			var args bytes.Buffer
+			_ = xdr.WriteUint32(&args, types.WRITE_LT)
+			_ = xdr.WriteUint64(&args, 0)
+			_ = xdr.WriteUint64(&args, 100)
+			_ = xdr.WriteUint64(&args, clientID)
+			_ = xdr.WriteXDROpaque(&args, []byte("lockt-type-owner"))
+
+			r := fx.handler.handleLockT(ctx, bytes.NewReader(args.Bytes()))
+			if r.Status != tc.want {
+				t.Fatalf("LOCKT on %s: status = %d, want %d", tc.name, r.Status, tc.want)
+			}
+		})
+	}
+}
+
+// TestLookup_SymlinkCurrentFH covers RFC 7530 Section 16.15.4: a client that
+// used a symbolic link as the current filehandle must be told NFS4ERR_SYMLINK,
+// so it knows to resolve the link, rather than the NFS4ERR_NOTDIR the store
+// reports for every non-directory alike.
+func TestLookup_SymlinkCurrentFH(t *testing.T) {
+	cases := []struct {
+		name     string
+		child    string
+		fileType metadata.FileType
+		want     uint32
+	}{
+		{"symlink", "link", metadata.FileTypeSymlink, types.NFS4ERR_SYMLINK},
+		{"regular", "file.txt", metadata.FileTypeRegular, types.NFS4ERR_NOTDIR},
+		{"fifo", "fifo", metadata.FileTypeFIFO, types.NFS4ERR_NOTDIR},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := newRealFSTestFixture(t, "/export")
+			handle := fx.createTestFile(t, fx.rootHandle, tc.child, tc.fileType, 0o755, 1000, 1000)
+
+			ctx := newRealFSContext(1000, 1000)
+			ctx.CurrentFH = append([]byte(nil), handle...)
+
+			var args bytes.Buffer
+			_ = xdr.WriteXDRString(&args, "anything")
+
+			r := fx.handler.handleLookup(ctx, bytes.NewReader(args.Bytes()))
+			if r.Status != tc.want {
+				t.Fatalf("LOOKUP under %s: status = %d, want %d", tc.name, r.Status, tc.want)
+			}
+		})
+	}
+}
+
+// TestLookupP_NonDirectoryCurrentFH covers RFC 7530 Section 16.16.4. Every
+// object carries a parent, so LOOKUPP used to walk out of a file or a device
+// node just as happily as out of a directory.
+func TestLookupP_NonDirectoryCurrentFH(t *testing.T) {
+	cases := []struct {
+		name     string
+		child    string
+		fileType metadata.FileType
+		want     uint32
+	}{
+		{"regular", "file.txt", metadata.FileTypeRegular, types.NFS4ERR_NOTDIR},
+		{"symlink", "link", metadata.FileTypeSymlink, types.NFS4ERR_SYMLINK},
+		{"fifo", "fifo", metadata.FileTypeFIFO, types.NFS4ERR_NOTDIR},
+		{"socket", "sock", metadata.FileTypeSocket, types.NFS4ERR_NOTDIR},
+		{"directory", "subdir", metadata.FileTypeDirectory, types.NFS4_OK},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := newRealFSTestFixture(t, "/export")
+			handle := fx.createTestFile(t, fx.rootHandle, tc.child, tc.fileType, 0o755, 1000, 1000)
+
+			ctx := newRealFSContext(1000, 1000)
+			ctx.CurrentFH = append([]byte(nil), handle...)
+
+			r := fx.handler.handleLookupP(ctx, bytes.NewReader(nil))
+			if r.Status != tc.want {
+				t.Fatalf("LOOKUPP from %s: status = %d, want %d", tc.name, r.Status, tc.want)
+			}
+		})
+	}
+}
+
+// TestPutFH_UndecodableHandle covers RFC 7530 Section 16.21.4. A filehandle is
+// either a pseudo-fs handle or the "<share>:<uuid>" form this server mints;
+// anything else was never issued here. Accepting it deferred the error to
+// whichever later operation first tried to resolve the handle, which reported
+// the wrong status against the wrong operation.
+func TestPutFH_UndecodableHandle(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+
+	cases := []struct {
+		name   string
+		handle []byte
+		want   uint32
+	}{
+		{"garbage", []byte("abc"), types.NFS4ERR_BADHANDLE},
+		{"no uuid", []byte("/export:not-a-uuid"), types.NFS4ERR_BADHANDLE},
+		{"empty share", []byte(":00000000-0000-0000-0000-000000000001"), types.NFS4ERR_BADHANDLE},
+		{"real handle", fx.rootHandle, types.NFS4_OK},
+		{"pseudo-fs root", fx.handler.PseudoFS.GetRootHandle(), types.NFS4_OK},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := newRealFSContext(1000, 1000)
+
+			var args bytes.Buffer
+			_ = xdr.WriteXDROpaque(&args, tc.handle)
+
+			r := fx.handler.handlePutFH(ctx, bytes.NewReader(args.Bytes()))
+			if r.Status != tc.want {
+				t.Fatalf("PUTFH %s: status = %d, want %d", tc.name, r.Status, tc.want)
+			}
+		})
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/objecttype_test.go
+++ b/internal/adapter/nfs/v4/handlers/objecttype_test.go
@@ -193,3 +193,28 @@ func TestPutFH_UndecodableHandle(t *testing.T) {
 		})
 	}
 }
+
+// TestLookupP_ShareRootCrossesToJunctionParent pins the step out of a share.
+//
+// The pseudo-fs junction and the share root are two views of one directory: a
+// share exported at /export is reached either as the pseudo-fs node /export or
+// as the real filesystem's root. Answering LOOKUPP at the share root with the
+// junction therefore left the client in the directory it started in, and a walk
+// upwards stalled there instead of reaching the pseudo-fs root.
+func TestLookupP_ShareRootCrossesToJunctionParent(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+
+	ctx := newRealFSContext(1000, 1000)
+	ctx.CurrentFH = append([]byte(nil), fx.rootHandle...)
+
+	r := fx.handler.handleLookupP(ctx, bytes.NewReader(nil))
+	if r.Status != types.NFS4_OK {
+		t.Fatalf("LOOKUPP at the share root: status = %d, want NFS4_OK", r.Status)
+	}
+
+	pseudoRoot := fx.handler.PseudoFS.GetRootHandle()
+	if !bytes.Equal(ctx.CurrentFH, pseudoRoot) {
+		t.Fatalf("LOOKUPP at the share root landed on %q, want the pseudo-fs root %q",
+			ctx.CurrentFH, pseudoRoot)
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/open.go
+++ b/internal/adapter/nfs/v4/handlers/open.go
@@ -427,23 +427,26 @@ func (h *Handler) handleOpenClaimNull(
 				return openError(types.NFS4ERR_DELAY)
 			}
 
-			// UNCHECKED4 on an existing file applies the supplied createattrs
-			// (RFC 7530 §16.16: "the existing file is opened ... and the
-			// attributes specified are set"). Only the attributes the client
-			// actually sent are applied (the createAttrs bitmap), so e.g.
-			// size=0 truncates while unset attributes are left untouched.
-			// SetFileAttributes enforces its own permission checks. Exclusive
-			// creates do not carry settable createattrs in EXCLUSIVE4, and an
-			// EXCLUSIVE4_1 retry must not re-mutate the existing file, so this
-			// is gated to UNCHECKED4.
-			if createMode == types.UNCHECKED4 && createAttrs != nil {
-				// A size change is a write to the file. Mirror the SETATTR
-				// gating (RFC 7530 §5.11): a size-bearing createattrs on an
-				// open that does not carry WRITE access is rejected with
+			// RFC 7530 §16.16.3: "When an UNCHECKED4 create encounters an
+			// existing file, the attributes specified by createattrs are not
+			// used, except that when a size of zero is specified, the existing
+			// file is truncated."
+			//
+			// Applying the whole set let a client that merely reopened a file
+			// rewrite its mode and ownership as a side effect, and honoured a
+			// non-zero size as a truncation the specification does not ask for.
+			// EXCLUSIVE4 carries no settable createattrs and an EXCLUSIVE4_1
+			// retry must not re-mutate the file, so this stays gated to
+			// UNCHECKED4.
+			if createMode == types.UNCHECKED4 && createAttrs != nil &&
+				createAttrs.Size != nil && *createAttrs.Size == 0 {
+				// A truncation is a write to the file. Mirror the SETATTR
+				// gating (RFC 7530 §5.11): a truncating createattrs on an open
+				// that does not carry WRITE access is rejected with
 				// NFS4ERR_OPENMODE, so a read-only OPEN cannot truncate the
 				// file even when POSIX permissions would otherwise allow it.
-				if createAttrs.Size != nil && shareAccess&types.OPEN4_SHARE_ACCESS_WRITE == 0 {
-					logger.Debug("NFSv4 OPEN UNCHECKED4 rejected: size change on read-only open",
+				if shareAccess&types.OPEN4_SHARE_ACCESS_WRITE == 0 {
+					logger.Debug("NFSv4 OPEN UNCHECKED4 rejected: truncate on read-only open",
 						"file", filename,
 						"share_access", shareAccess,
 						"client", ctx.ClientAddr)
@@ -452,7 +455,8 @@ func (h *Handler) handleOpenClaimNull(
 				// child was fetched via Lookup above and still reflects the full
 				// pre-truncate extent, so it is the pre-op snapshot the reclaim
 				// needs. Shared with the SETATTR path.
-				if setErr := h.applySetAttrsWithTruncateReclaim(ctx, metaSvc, authCtx, fileHandle, child, createAttrs); setErr != nil {
+				truncate := &metadata.SetAttrs{Size: createAttrs.Size}
+				if setErr := h.applySetAttrsWithTruncateReclaim(ctx, metaSvc, authCtx, fileHandle, child, truncate); setErr != nil {
 					return openError(common.MapToNFS4(setErr))
 				}
 			}
@@ -484,6 +488,20 @@ func (h *Handler) handleOpenClaimNull(
 			}
 			fileHandle = fh
 			created = true
+
+			// RFC 7530 §16.16.3: on a create that actually creates,
+			// "createattrs specifies the initial set of attributes for the
+			// file". CreateFile takes the mode and the ownership; everything
+			// else the client asked for -- a size, timestamps -- goes through
+			// the same path SETATTR uses, which is what makes a create
+			// carrying size=N produce a file of N bytes rather than an empty
+			// one. EXCLUSIVE4 carries a verifier in place of attributes, so
+			// createAttrs is nil there and nothing is applied.
+			if createAttrs != nil {
+				if _, setErr := metaSvc.SetFileAttributes(authCtx, fileHandle, createAttrs); setErr != nil {
+					return openError(common.MapToNFS4(setErr))
+				}
+			}
 		}
 	}
 

--- a/internal/adapter/nfs/v4/handlers/open.go
+++ b/internal/adapter/nfs/v4/handlers/open.go
@@ -207,14 +207,10 @@ func (h *Handler) handleOpen(ctx *types.CompoundContext, reader io.Reader) (resu
 	// had when the client first asked. NFSv4.1 takes exactly-once from the
 	// session slot table and carries no owner seqid, so it stays out of both.
 	if !ctx.SkipOwnerSeqid {
-		if cached, ok := h.StateManager.ReplayOpenSeqid(clientID, ownerData, seqid); ok {
-			logger.Debug("NFSv4 OPEN replayed from the open-owner cache",
-				"seqid", seqid, "status", cached.Status, "client", ctx.ClientAddr)
-			return &types.CompoundResult{
-				Status: cached.Status,
-				OpCode: types.OP_OPEN,
-				Data:   cached.Data,
-			}
+		if status, ok := h.StateManager.ReplayOpenSeqid(clientID, ownerData, seqid); ok {
+			logger.Debug("NFSv4 OPEN refusal replayed",
+				"seqid", seqid, "status", status, "client", ctx.ClientAddr)
+			return openError(status)
 		}
 		defer func() {
 			if result != nil && result.Status != types.NFS4_OK {

--- a/internal/adapter/nfs/v4/handlers/open.go
+++ b/internal/adapter/nfs/v4/handlers/open.go
@@ -40,7 +40,7 @@ import (
 //	bitmap4     attrset      (empty - no attrs set by server)
 //	open_delegation4:
 //	  uint32    delegation_type (OPEN_DELEGATE_NONE / READ / WRITE)
-func (h *Handler) handleOpen(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
+func (h *Handler) handleOpen(ctx *types.CompoundContext, reader io.Reader) (result *types.CompoundResult) {
 	// Require current filehandle (parent directory for CLAIM_NULL)
 	if status := types.RequireCurrentFH(ctx); status != types.NFS4_OK {
 		return openError(status)
@@ -199,25 +199,30 @@ func (h *Handler) handleOpen(ctx *types.CompoundContext, reader io.Reader) *type
 	// put the server permanently one behind and answered every later OPEN for
 	// that owner NFS4ERR_BAD_SEQID. ConsumeOpenSeqid is a no-op when the state
 	// manager already accounted for this seqid.
-	result := h.dispatchOpenClaim(ctx, reader, seqid, shareAccess, shareDeny,
-		clientID, ownerData, openType, createMode, claimType, createAttrs, createVerifier)
-	if result.Status != types.NFS4_OK {
-		h.StateManager.ConsumeOpenSeqid(clientID, ownerData, seqid, result.Status)
+	//
+	// The two halves go together. A retransmission at the seqid the server last
+	// recorded must replay that reply rather than run the operation again, and
+	// answering a refusal here without also replaying it would re-execute the
+	// retransmission against the state of the world now instead of the state it
+	// had when the client first asked. NFSv4.1 takes exactly-once from the
+	// session slot table and carries no owner seqid, so it stays out of both.
+	if !ctx.SkipOwnerSeqid {
+		if cached, ok := h.StateManager.ReplayOpenSeqid(clientID, ownerData, seqid); ok {
+			logger.Debug("NFSv4 OPEN replayed from the open-owner cache",
+				"seqid", seqid, "status", cached.Status, "client", ctx.ClientAddr)
+			return &types.CompoundResult{
+				Status: cached.Status,
+				OpCode: types.OP_OPEN,
+				Data:   cached.Data,
+			}
+		}
+		defer func() {
+			if result != nil && result.Status != types.NFS4_OK {
+				h.StateManager.ConsumeOpenSeqid(clientID, ownerData, seqid, result.Status)
+			}
+		}()
 	}
-	return result
-}
 
-// dispatchOpenClaim routes an OPEN to the handler for its claim type.
-func (h *Handler) dispatchOpenClaim(
-	ctx *types.CompoundContext,
-	reader io.Reader,
-	seqid, shareAccess, shareDeny uint32,
-	clientID uint64,
-	ownerData []byte,
-	openType, createMode, claimType uint32,
-	createAttrs *metadata.SetAttrs,
-	createVerifier *uint64,
-) *types.CompoundResult {
 	switch claimType {
 	case types.CLAIM_NULL:
 		// New open: check grace period BEFORE file creation/lookup

--- a/internal/adapter/nfs/v4/handlers/open.go
+++ b/internal/adapter/nfs/v4/handlers/open.go
@@ -189,8 +189,35 @@ func (h *Handler) handleOpen(ctx *types.CompoundContext, reader io.Reader) *type
 		return openError(types.NFS4ERR_BADXDR)
 	}
 
-	// Dispatch by claim type
+	// Dispatch by claim type.
+	//
+	// An OPEN this handler refuses on its own -- a create collision, a target
+	// of the wrong object type, a name the server rejects -- never reaches the
+	// state manager, which is where an owner's seqid is normally consumed.
+	// RFC 7530 Section 9.1.7 consumes it for those failures just the same, and
+	// the client advances its own sequence either way, so leaving it unrecorded
+	// put the server permanently one behind and answered every later OPEN for
+	// that owner NFS4ERR_BAD_SEQID. ConsumeOpenSeqid is a no-op when the state
+	// manager already accounted for this seqid.
+	result := h.dispatchOpenClaim(ctx, reader, seqid, shareAccess, shareDeny,
+		clientID, ownerData, openType, createMode, claimType, createAttrs, createVerifier)
+	if result.Status != types.NFS4_OK {
+		h.StateManager.ConsumeOpenSeqid(clientID, ownerData, seqid, result.Status)
+	}
+	return result
+}
 
+// dispatchOpenClaim routes an OPEN to the handler for its claim type.
+func (h *Handler) dispatchOpenClaim(
+	ctx *types.CompoundContext,
+	reader io.Reader,
+	seqid, shareAccess, shareDeny uint32,
+	clientID uint64,
+	ownerData []byte,
+	openType, createMode, claimType uint32,
+	createAttrs *metadata.SetAttrs,
+	createVerifier *uint64,
+) *types.CompoundResult {
 	switch claimType {
 	case types.CLAIM_NULL:
 		// New open: check grace period BEFORE file creation/lookup

--- a/internal/adapter/nfs/v4/handlers/open_createattrs_test.go
+++ b/internal/adapter/nfs/v4/handlers/open_createattrs_test.go
@@ -1,0 +1,76 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// TestOpen_Unchecked4CreateAppliesCreateAttrs covers the first half of
+// RFC 7530 §16.16.3: on a create that actually creates, "createattrs specifies
+// the initial set of attributes for the file". Only the mode reached
+// CreateFile, so a create carrying a size produced an empty file instead.
+func TestOpen_Unchecked4CreateAppliesCreateAttrs(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+	clientID := testClientID(t, fx.handler.StateManager, "createattrs-client")
+	owner := []byte("createattrs-owner")
+
+	ctx := newRealFSContext(0, 0)
+	setCurrentFH(ctx, fx.rootHandle)
+	args := encodeOpenUncheckedSizeArgs(1, types.OPEN4_SHARE_ACCESS_BOTH,
+		types.OPEN4_SHARE_DENY_NONE, clientID, owner, 32, "sized.txt")
+
+	if r := fx.handler.handleOpen(ctx, bytes.NewReader(args)); r.Status != types.NFS4_OK {
+		t.Fatalf("create with size=32: status = %d, want NFS4_OK", r.Status)
+	}
+
+	file, err := fx.metaSvc.GetFile(context.Background(), metadata.FileHandle(ctx.CurrentFH))
+	if err != nil {
+		t.Fatalf("get created file: %v", err)
+	}
+	if file.Size != 32 {
+		t.Fatalf("size of a file created with size=32: got %d, want 32", file.Size)
+	}
+}
+
+// TestOpen_Unchecked4ExistingIgnoresNonZeroSize covers the second half:
+// "When an UNCHECKED4 create encounters an existing file, the attributes
+// specified by createattrs are not used, except that when a size of zero is
+// specified, the existing file is truncated." The whole set used to be applied,
+// so a plain reopen resized the file to whatever length the client named.
+func TestOpen_Unchecked4ExistingIgnoresNonZeroSize(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+	clientID := testClientID(t, fx.handler.StateManager, "resize-client")
+	owner := []byte("resize-owner")
+
+	fh := fx.createRegularFile(t, fx.rootHandle, "resize.txt", 0o644, 0, 0)
+	fx.writeContent(t, fh, []byte("hello world contents"))
+
+	pre, err := fx.metaSvc.GetFile(context.Background(), fh)
+	if err != nil {
+		t.Fatalf("get file pre: %v", err)
+	}
+	if pre.Size == 0 {
+		t.Fatalf("setup: expected non-zero size before the reopen")
+	}
+
+	ctx := newRealFSContext(0, 0)
+	setCurrentFH(ctx, fx.rootHandle)
+	args := encodeOpenUncheckedSizeArgs(1, types.OPEN4_SHARE_ACCESS_BOTH,
+		types.OPEN4_SHARE_DENY_NONE, clientID, owner, 4, "resize.txt")
+
+	if r := fx.handler.handleOpen(ctx, bytes.NewReader(args)); r.Status != types.NFS4_OK {
+		t.Fatalf("reopen with size=4: status = %d, want NFS4_OK", r.Status)
+	}
+
+	post, err := fx.metaSvc.GetFile(context.Background(), fh)
+	if err != nil {
+		t.Fatalf("get file post: %v", err)
+	}
+	if post.Size != pre.Size {
+		t.Fatalf("size after a reopen naming size=4: got %d, want it left at %d", post.Size, pre.Size)
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/open_exclusive_test.go
+++ b/internal/adapter/nfs/v4/handlers/open_exclusive_test.go
@@ -187,9 +187,9 @@ func TestOpen_Unchecked4_SizeOnReadOnlyOpenRejected(t *testing.T) {
 	}
 }
 
-// TestOpen_Unchecked4_ExistingFileTruncates verifies RFC 7530 §16.16: an
-// UNCHECKED4 OPEN of an existing file applies the supplied createattrs. A
-// requested size=0 must truncate the file's metadata size to zero.
+// TestOpen_Unchecked4_ExistingFileTruncates verifies the one createattr
+// RFC 7530 §16.16.3 still lets through to an existing file: "when a size of
+// zero is specified, the existing file is truncated".
 func TestOpen_Unchecked4_ExistingFileTruncates(t *testing.T) {
 	owner := []byte("unchecked-owner")
 

--- a/internal/adapter/nfs/v4/handlers/open_exclusive_test.go
+++ b/internal/adapter/nfs/v4/handlers/open_exclusive_test.go
@@ -113,19 +113,23 @@ func TestOpen_Exclusive4_RetryDifferentVerifier(t *testing.T) {
 	clientID := testClientID(t, fx.handler.StateManager, "excl-test-client")
 	ctx := newRealFSContext(0, 0)
 
-	open := func(verf uint64) *types.CompoundResult {
+	// Each OPEN carries its own seqid: two requests at the same seqid are a
+	// retransmission by RFC 7530 Section 9.1.7 and are answered from the
+	// open-owner's replay cache, which would test the cache rather than the
+	// verifier comparison this test is about.
+	open := func(seqid uint32, verf uint64) *types.CompoundResult {
 		ctx.CurrentFH = make([]byte, len(fx.rootHandle))
 		copy(ctx.CurrentFH, fx.rootHandle)
-		args := encodeOpenExclusiveArgs(1, types.OPEN4_SHARE_ACCESS_BOTH,
+		args := encodeOpenExclusiveArgs(seqid, types.OPEN4_SHARE_ACCESS_BOTH,
 			types.OPEN4_SHARE_DENY_NONE, clientID, owner, verf, "excl2.txt")
 		return fx.handler.handleOpen(ctx, bytes.NewReader(args))
 	}
 
-	if r := open(0x1111111111111111); r.Status != types.NFS4_OK {
+	if r := open(1, 0x1111111111111111); r.Status != types.NFS4_OK {
 		t.Fatalf("first EXCLUSIVE4 OPEN status = %d, want NFS4_OK", r.Status)
 	}
 
-	if r := open(0x2222222222222222); r.Status != types.NFS4ERR_EXIST {
+	if r := open(2, 0x2222222222222222); r.Status != types.NFS4ERR_EXIST {
 		t.Fatalf("EXCLUSIVE4 with different verifier status = %d, want NFS4ERR_EXIST", r.Status)
 	}
 }

--- a/internal/adapter/nfs/v4/handlers/open_seqid_test.go
+++ b/internal/adapter/nfs/v4/handlers/open_seqid_test.go
@@ -55,20 +55,23 @@ func TestOpen_HandlerRefusalConsumesSeqid(t *testing.T) {
 	}
 }
 
-// TestOpen_RefusalReplaysRatherThanConsumingTwice pins the other half of
-// Section 9.1.7: a retransmission at the seqid the refusal consumed replays that
-// refusal's status and does not advance the sequence a second time.
-func TestOpen_RefusalReplaysRatherThanConsumingTwice(t *testing.T) {
+// TestOpen_RefusalIsReplayedNotReExecuted pins the other half of
+// Section 9.1.7: a retransmission at the seqid a refusal consumed must return
+// that refusal's reply, not run the OPEN a second time.
+//
+// The distinction only shows when the condition behind the refusal has changed
+// in between, so the test removes the colliding name before retransmitting. Two
+// GUARDED4 creates in a row would answer NFS4ERR_EXIST whether the server
+// replayed the cached reply or simply re-ran the create, and would pass against
+// a server that does neither correctly.
+func TestOpen_RefusalIsReplayedNotReExecuted(t *testing.T) {
 	fx := newIOTestFixture(t, "/export")
 	clientID := testClientID(t, fx.handler.StateManager, "replay-client")
 	owner := []byte("replay-owner")
 
-	ctx := newRealFSContext(1000, 1000)
-	setCurrentFH(ctx, fx.rootHandle)
+	ctx := newRealFSContext(0, 0)
 
 	open := func(seqid, createMode uint32) *types.CompoundResult {
-		// OPEN leaves the created file as the current filehandle; every call
-		// here starts from the parent directory again.
 		setCurrentFH(ctx, fx.rootHandle)
 		args := encodeOpenArgs(seqid, types.OPEN4_SHARE_ACCESS_BOTH,
 			types.OPEN4_SHARE_DENY_NONE, clientID, owner,
@@ -82,8 +85,26 @@ func TestOpen_RefusalReplaysRatherThanConsumingTwice(t *testing.T) {
 	if r := open(2, types.GUARDED4); r.Status != types.NFS4ERR_EXIST {
 		t.Fatalf("GUARDED4 recreate: status = %d, want NFS4ERR_EXIST", r.Status)
 	}
+
+	// Take the collision away. A re-executed OPEN would now create the file and
+	// answer NFS4_OK; a replayed one still answers the refusal it cached.
+	setCurrentFH(ctx, fx.rootHandle)
+	rm := fx.handler.handleRemove(ctx, bytes.NewReader(encodeRemoveArgs("replayed.txt")))
+	if rm.Status != types.NFS4_OK {
+		t.Fatalf("REMOVE of the colliding name: status = %d, want NFS4_OK", rm.Status)
+	}
+
 	if r := open(2, types.GUARDED4); r.Status != types.NFS4ERR_EXIST {
-		t.Fatalf("retransmitted refusal: status = %d, want the replayed NFS4ERR_EXIST", r.Status)
+		t.Fatalf("retransmitted refusal after the collision was removed: status = %d, want the replayed NFS4ERR_EXIST (%d)",
+			r.Status, types.NFS4ERR_EXIST)
+	}
+
+	// The status alone does not separate a replay from a re-execution: an OPEN
+	// that runs again creates the file and is then answered NFS4ERR_EXIST by the
+	// state layer's own replay check, having already done the work. The side
+	// effect is what tells them apart, so assert the file was not recreated.
+	if _, err := fx.metaSvc.Lookup(newTestAuthCtx(0, 0), fx.rootHandle, "replayed.txt"); err == nil {
+		t.Fatal("the retransmitted OPEN recreated the file: it was re-executed, not replayed")
 	}
 
 	// The replay must not have consumed a second seqid.

--- a/internal/adapter/nfs/v4/handlers/open_seqid_test.go
+++ b/internal/adapter/nfs/v4/handlers/open_seqid_test.go
@@ -1,0 +1,93 @@
+package handlers
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+)
+
+// TestOpen_HandlerRefusalConsumesSeqid covers RFC 7530 Section 9.1.7: an OPEN
+// that reaches seqid checking consumes the open-owner's seqid whether it then
+// succeeds or fails, and the client advances its own sequence either way.
+//
+// An OPEN the handler refuses on its own never reached the state manager, which
+// is the only place that recorded a seqid, so the server stayed one behind the
+// client from the first refusal onwards and answered every later OPEN for that
+// owner NFS4ERR_BAD_SEQID -- an error a client can only escape by tearing the
+// open-owner down.
+//
+// GUARDED4 over a name that already exists is the shortest way to a refusal the
+// handler issues by itself: it returns NFS4ERR_EXIST from the create path,
+// above the state manager entirely.
+func TestOpen_HandlerRefusalConsumesSeqid(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+	clientID := testClientID(t, fx.handler.StateManager, "seqid-client")
+	owner := []byte("seqid-owner")
+
+	ctx := newRealFSContext(1000, 1000)
+	setCurrentFH(ctx, fx.rootHandle)
+
+	open := func(seqid, createMode uint32) *types.CompoundResult {
+		// OPEN leaves the created file as the current filehandle; every call
+		// here starts from the parent directory again.
+		setCurrentFH(ctx, fx.rootHandle)
+		args := encodeOpenArgs(seqid, types.OPEN4_SHARE_ACCESS_BOTH,
+			types.OPEN4_SHARE_DENY_NONE, clientID, owner,
+			types.OPEN4_CREATE, createMode, types.CLAIM_NULL, "guarded.txt")
+		return fx.handler.handleOpen(ctx, bytes.NewReader(args))
+	}
+
+	if r := open(1, types.GUARDED4); r.Status != types.NFS4_OK {
+		t.Fatalf("first GUARDED4 create: status = %d, want NFS4_OK", r.Status)
+	}
+
+	// Refused by the handler, above the state manager.
+	if r := open(2, types.GUARDED4); r.Status != types.NFS4ERR_EXIST {
+		t.Fatalf("GUARDED4 recreate: status = %d, want NFS4ERR_EXIST (%d)",
+			r.Status, types.NFS4ERR_EXIST)
+	}
+
+	// The refusal spent seqid 2, so the client's next OPEN presents 3. Before
+	// the fix the server still expected 2 here and answered NFS4ERR_BAD_SEQID.
+	if r := open(3, types.UNCHECKED4); r.Status != types.NFS4_OK {
+		t.Fatalf("OPEN after a refused OPEN: status = %d, want NFS4_OK", r.Status)
+	}
+}
+
+// TestOpen_RefusalReplaysRatherThanConsumingTwice pins the other half of
+// Section 9.1.7: a retransmission at the seqid the refusal consumed replays that
+// refusal's status and does not advance the sequence a second time.
+func TestOpen_RefusalReplaysRatherThanConsumingTwice(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+	clientID := testClientID(t, fx.handler.StateManager, "replay-client")
+	owner := []byte("replay-owner")
+
+	ctx := newRealFSContext(1000, 1000)
+	setCurrentFH(ctx, fx.rootHandle)
+
+	open := func(seqid, createMode uint32) *types.CompoundResult {
+		// OPEN leaves the created file as the current filehandle; every call
+		// here starts from the parent directory again.
+		setCurrentFH(ctx, fx.rootHandle)
+		args := encodeOpenArgs(seqid, types.OPEN4_SHARE_ACCESS_BOTH,
+			types.OPEN4_SHARE_DENY_NONE, clientID, owner,
+			types.OPEN4_CREATE, createMode, types.CLAIM_NULL, "replayed.txt")
+		return fx.handler.handleOpen(ctx, bytes.NewReader(args))
+	}
+
+	if r := open(1, types.GUARDED4); r.Status != types.NFS4_OK {
+		t.Fatalf("first GUARDED4 create: status = %d, want NFS4_OK", r.Status)
+	}
+	if r := open(2, types.GUARDED4); r.Status != types.NFS4ERR_EXIST {
+		t.Fatalf("GUARDED4 recreate: status = %d, want NFS4ERR_EXIST", r.Status)
+	}
+	if r := open(2, types.GUARDED4); r.Status != types.NFS4ERR_EXIST {
+		t.Fatalf("retransmitted refusal: status = %d, want the replayed NFS4ERR_EXIST", r.Status)
+	}
+
+	// The replay must not have consumed a second seqid.
+	if r := open(3, types.UNCHECKED4); r.Status != types.NFS4_OK {
+		t.Fatalf("OPEN after a replayed refusal: status = %d, want NFS4_OK", r.Status)
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/ops_test.go
+++ b/internal/adapter/nfs/v4/handlers/ops_test.go
@@ -641,14 +641,20 @@ func TestLookupP_ChildToRoot(t *testing.T) {
 	}
 }
 
-func TestLookupP_RootStaysAtRoot(t *testing.T) {
+// TestLookupP_RootHasNoParent pins the pseudo-fs root as the top of the
+// namespace: it has no parent to walk to, and RFC 7530 Section 16.16.4 answers
+// LOOKUPP there with NFS4ERR_NOENT.
+//
+// The tree stores the root as its own parent, so LOOKUPP used to answer NFS4_OK
+// and leave the current filehandle where it was. A client walking upwards then
+// never reached a terminating error and saw the root repeat forever.
+func TestLookupP_RootHasNoParent(t *testing.T) {
 	h := newTestHandlerWithShares([]string{"/export"})
 	ctx := newOpsTestContext()
 
 	data := encodeCompoundWithOps("", 0, []encodedOp{
 		encodePutRootFH(),
 		encodeLookupP(),
-		encodeGetFH(),
 	})
 
 	resp, err := h.ProcessCompound(ctx, data)
@@ -658,16 +664,9 @@ func TestLookupP_RootStaysAtRoot(t *testing.T) {
 
 	decoded, _ := decodeCompoundResp(resp)
 
-	if decoded.Status != types.NFS4_OK {
-		t.Fatalf("status = %d, want NFS4_OK", decoded.Status)
-	}
-
-	// LOOKUPP from root should return root (root's parent is root)
-	rootHandle := h.PseudoFS.GetRootHandle()
-	gotHandle := decoded.Results[2].ExtraData
-	if !bytes.Equal(gotHandle, rootHandle) {
-		t.Errorf("LOOKUPP from root should stay at root, got %q want %q",
-			string(gotHandle), string(rootHandle))
+	if decoded.Status != types.NFS4ERR_NOENT {
+		t.Fatalf("LOOKUPP at pseudo-fs root: status = %d, want NFS4ERR_NOENT (%d)",
+			decoded.Status, types.NFS4ERR_NOENT)
 	}
 }
 

--- a/internal/adapter/nfs/v4/handlers/putfh.go
+++ b/internal/adapter/nfs/v4/handlers/putfh.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"io"
 
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/pseudofs"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
 	"github.com/marmos91/dittofs/internal/logger"
@@ -41,6 +42,24 @@ func (h *Handler) handlePutFH(ctx *types.CompoundContext, reader io.Reader) *typ
 			Status: types.NFS4ERR_BADHANDLE,
 			OpCode: types.OP_PUTFH,
 			Data:   encodeStatusOnly(types.NFS4ERR_BADHANDLE),
+		}
+	}
+
+	// A filehandle is either one of the pseudo-fs handles this server mints
+	// or a "<share>:<uuid>" object handle. Anything that parses as neither
+	// was never issued here, and RFC 7530 Section 16.21.4 answers that with
+	// NFS4ERR_BADHANDLE. Accepting it instead deferred the error to whichever
+	// later operation first tried to resolve it, which reports the wrong
+	// status and blames the wrong operation.
+	if !pseudofs.IsPseudoFSHandle(handle) {
+		if _, _, decErr := metadata.DecodeFileHandle(metadata.FileHandle(handle)); decErr != nil {
+			logger.Debug("NFSv4 PUTFH refused: undecodable filehandle",
+				"len", len(handle), "client", ctx.ClientAddr)
+			return &types.CompoundResult{
+				Status: types.NFS4ERR_BADHANDLE,
+				OpCode: types.OP_PUTFH,
+				Data:   encodeStatusOnly(types.NFS4ERR_BADHANDLE),
+			}
 		}
 	}
 

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -1425,7 +1425,7 @@ func (sm *StateManager) OpenFile(
 // keeps the deny mask on the file (nfs4_file, fi_share_deny) for the same
 // reason.
 //
-// Caller must hold sm.mu.
+// Caller must hold sm.mu, for reading or for writing.
 func (sm *StateManager) shareConflictLocked(
 	fileHandle []byte,
 	reqAccess, reqDeny uint32,
@@ -1469,6 +1469,36 @@ func (sm *StateManager) removeOpenStateFromFileLocked(os *OpenState) {
 		}
 		return
 	}
+}
+
+// ReplayOpenSeqid returns the reply cached for an open-owner when seqid is a
+// retransmission of the last request the server processed for it, so the caller
+// can answer it byte-for-byte instead of running the operation a second time
+// (RFC 7530 Section 9.1.7).
+//
+// OpenFile answers replays for the OPENs that reach it, but an OPEN the handler
+// refuses on its own never does. Re-executing such a retransmission answers
+// from the state of the world now rather than the state it had when the client
+// first asked, so a refusal whose cause has since gone away -- the colliding
+// name removed, the permission granted -- came back as a success the client had
+// no reply slot for.
+//
+// It reports no replay for an owner that does not exist, for a seqid that is
+// the expected next one rather than a repeat, and for an owner with nothing
+// cached yet: a fresh owner's sequence starts at zero, which would otherwise
+// read as a replay of a request that never happened.
+func (sm *StateManager) ReplayOpenSeqid(clientID uint64, ownerData []byte, seqid uint32) (*CachedResult, bool) {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	owner, exists := sm.openOwners[makeOwnerKey(clientID, ownerData)]
+	if !exists || owner.LastResult == nil {
+		return nil, false
+	}
+	if owner.ValidateSeqID(seqid) != SeqIDReplay {
+		return nil, false
+	}
+	return owner.LastResult, true
 }
 
 // ConsumeOpenSeqid records against an open-owner's sequence an OPEN that failed

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -1323,17 +1323,15 @@ func (sm *StateManager) OpenFile(
 	// does, and the client advances either way.
 	defer func() { owner.consumeSeqidOnError(seqid, err) }()
 
-	// Enforce share reservations across open-owners (RFC 7530 Section 9.7 /
-	// Section 16.16.5; Linux nfsd nfs4_share_conflict). This runs AFTER the
-	// owner seqid/replay gate above: a replayed OPEN must return its cached
-	// result and a bad seqid must return NFS4ERR_BAD_SEQID — neither may be
-	// turned into NFS4ERR_SHARE_DENIED by a conflict that arose after the
-	// original request. Reclaim (CLAIM_PREVIOUS) re-establishes prior state and
-	// is exempt. The scan runs under sm.mu so it observes a consistent snapshot
-	// of every live open; opens by THIS owner are skipped (share bits
-	// accumulate per owner).
+	// Enforce share reservations (RFC 7530 Section 9.9; Linux nfsd
+	// nfs4_share_conflict). This runs AFTER the owner seqid/replay gate above:
+	// a replayed OPEN must return its cached result and a bad seqid must return
+	// NFS4ERR_BAD_SEQID — neither may be turned into NFS4ERR_SHARE_DENIED by a
+	// conflict that arose after the original request. Reclaim (CLAIM_PREVIOUS)
+	// re-establishes prior state and is exempt. The scan runs under sm.mu so it
+	// observes a consistent snapshot of every live open.
 	if claimType != types.CLAIM_PREVIOUS {
-		if conflict := sm.shareConflictLocked(ownerKey, fileHandle, shareAccess, shareDeny); conflict {
+		if conflict := sm.shareConflictLocked(fileHandle, shareAccess, shareDeny); conflict {
 			logger.Debug("OpenFile: share reservation conflict",
 				"client_id", clientID,
 				"owner", string(ownerData),
@@ -1413,26 +1411,28 @@ func (sm *StateManager) OpenFile(
 }
 
 // shareConflictLocked reports whether granting an OPEN with the requested
-// share_access / share_deny on fileHandle would conflict with an open held by a
-// DIFFERENT open-owner. A conflict exists when the requested access is denied by
-// an existing open, or the requested deny would exclude an existing open's
-// access (RFC 7530 Section 9.7; mirrors Linux nfsd nfs4_share_conflict /
-// test_share). Opens by the requesting owner (ownerKey) are skipped because
-// share bits accumulate per owner on the same file.
+// share_access / share_deny on fileHandle would conflict with an open already
+// held on it. A conflict exists when the requested access is denied by an
+// existing open, or the requested deny would exclude an existing open's access.
+//
+// RFC 7530 Section 9.9 gives the rule as pseudo-code over the file's
+// accumulated state -- "(request.access & file_state.deny) || (request.deny &
+// file_state.access)" -- and then says in as many words that "this checking of
+// share reservations on OPEN is done with no exception for an existing OPEN for
+// the same open-owner". Skipping the requesting owner's own opens, on the theory
+// that share bits merely accumulate per owner, let an owner that had denied
+// READ to everyone go on to open the same file for reading itself. Linux nfsd
+// keeps the deny mask on the file (nfs4_file, fi_share_deny) for the same
+// reason.
 //
 // Caller must hold sm.mu.
 func (sm *StateManager) shareConflictLocked(
-	ownerKey openOwnerKey,
 	fileHandle []byte,
 	reqAccess, reqDeny uint32,
 ) bool {
 	// Iterate only the opens on this file via the secondary per-file index
 	// (openStateByFile), not every open in the server.
 	for _, os := range sm.openStateByFile[string(fileHandle)] {
-		// Same owner: bits are OR-merged, never in conflict with themselves.
-		if os.Owner != nil && os.Owner.Key() == ownerKey {
-			continue
-		}
 		if reqAccess&os.ShareDeny != 0 || reqDeny&os.ShareAccess != 0 {
 			return true
 		}

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -1471,6 +1471,38 @@ func (sm *StateManager) removeOpenStateFromFileLocked(os *OpenState) {
 	}
 }
 
+// ConsumeOpenSeqid records against an open-owner's sequence an OPEN that failed
+// before it ever reached OpenFile, and caches the status so a retransmission
+// replays it.
+//
+// RFC 7530 Section 9.1.7 advances an owner's sequence for every OPEN that
+// reaches seqid checking, and the client advances its own whether the server
+// answered success or a consuming error. An OPEN the handler refuses on its own
+// -- a create collision, a target of the wrong object type, a name the server
+// rejects -- never reached the state manager, so its seqid went unrecorded and
+// the server fell one behind the client. Every later OPEN for that owner was
+// then answered NFS4ERR_BAD_SEQID, which a client can only escape by tearing
+// the owner down.
+//
+// It is a no-op for an owner that does not exist yet, because a first OPEN that
+// fails leaves no owner behind and the client's retry at seqid 1 is valid
+// against a fresh one; for a seqid that is not the owner's expected next one,
+// so a replay returns its cached reply rather than consuming a second seqid;
+// and for the statuses Section 9.1.7 exempts.
+func (sm *StateManager) ConsumeOpenSeqid(clientID uint64, ownerData []byte, seqid, status uint32) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	owner, exists := sm.openOwners[makeOwnerKey(clientID, ownerData)]
+	if !exists {
+		return
+	}
+	if owner.ValidateSeqID(seqid) != SeqIDOK {
+		return
+	}
+	owner.consumeSeqidOnError(seqid, &NFS4StateError{Status: status})
+}
+
 // CacheOpenOwnerResult stores the encoded reply for an open-owner so that a
 // replay (retransmit at the same seqid) returns the exact original response.
 //

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -1471,34 +1471,32 @@ func (sm *StateManager) removeOpenStateFromFileLocked(os *OpenState) {
 	}
 }
 
-// ReplayOpenSeqid returns the reply cached for an open-owner when seqid is a
-// retransmission of the last request the server processed for it, so the caller
-// can answer it byte-for-byte instead of running the operation a second time
-// (RFC 7530 Section 9.1.7).
+// ReplayOpenSeqid reports the status to replay when seqid retransmits an OPEN
+// this server refused on its own, so the caller can answer it without running
+// the OPEN a second time (RFC 7530 Section 9.1.7).
 //
-// OpenFile answers replays for the OPENs that reach it, but an OPEN the handler
-// refuses on its own never does. Re-executing such a retransmission answers
-// from the state of the world now rather than the state it had when the client
-// first asked, so a refusal whose cause has since gone away -- the colliding
-// name removed, the permission granted -- came back as a success the client had
-// no reply slot for.
+// Re-executing such a retransmission answers from the state of the world now
+// rather than the state it had when the client first asked, so a refusal whose
+// cause has since gone away -- the colliding name removed, the permission
+// granted -- came back as a success the client had no reply slot for.
 //
-// It reports no replay for an owner that does not exist, for a seqid that is
-// the expected next one rather than a repeat, and for an owner with nothing
-// cached yet: a fresh owner's sequence starts at zero, which would otherwise
-// read as a replay of a request that never happened.
-func (sm *StateManager) ReplayOpenSeqid(clientID uint64, ownerData []byte, seqid uint32) (*CachedResult, bool) {
+// It covers only the refusals ConsumeOpenSeqid recorded. An OPEN that reached
+// the state layer is replayed by OpenFile from the owner's shared reply cache,
+// and that cache must not be consulted here: CLOSE, OPEN_CONFIRM and
+// OPEN_DOWNGRADE write to it too, so it may hold a reply of a different shape,
+// which an OPEN replaying it would return under its own operation number.
+func (sm *StateManager) ReplayOpenSeqid(clientID uint64, ownerData []byte, seqid uint32) (uint32, bool) {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
 
 	owner, exists := sm.openOwners[makeOwnerKey(clientID, ownerData)]
-	if !exists || owner.LastResult == nil {
-		return nil, false
+	if !exists || owner.openRefusal == nil {
+		return 0, false
 	}
-	if owner.ValidateSeqID(seqid) != SeqIDReplay {
-		return nil, false
+	if owner.openRefusal.seqid != seqid || owner.ValidateSeqID(seqid) != SeqIDReplay {
+		return 0, false
 	}
-	return owner.LastResult, true
+	return owner.openRefusal.status, true
 }
 
 // ConsumeOpenSeqid records against an open-owner's sequence an OPEN that failed
@@ -1530,7 +1528,14 @@ func (sm *StateManager) ConsumeOpenSeqid(clientID uint64, ownerData []byte, seqi
 	if owner.ValidateSeqID(seqid) != SeqIDOK {
 		return
 	}
+	before := owner.LastSeqID
 	owner.consumeSeqidOnError(seqid, &NFS4StateError{Status: status})
+	// consumeSeqidOnError leaves the sequence alone for the statuses
+	// Section 9.1.7 exempts; nothing was recorded, so there is nothing to
+	// replay either.
+	if owner.LastSeqID != before {
+		owner.openRefusal = &openRefusal{seqid: seqid, status: status}
+	}
 }
 
 // CacheOpenOwnerResult stores the encoded reply for an open-owner so that a

--- a/internal/adapter/nfs/v4/state/openowner.go
+++ b/internal/adapter/nfs/v4/state/openowner.go
@@ -167,6 +167,9 @@ type OpenOwner struct {
 	// server" (RFC 7530 Section 16.28.5).
 	Principal string
 
+	// openRefusal is the last OPEN this server refused on its own, if any.
+	openRefusal *openRefusal
+
 	// ownerSeq carries this owner's seqid sequence and replay cache.
 	ownerSeq
 
@@ -216,6 +219,20 @@ type CachedResult struct {
 
 	// Data is the XDR-encoded operation-specific result data.
 	Data []byte
+}
+
+// openRefusal remembers an OPEN this server refused before the state layer saw
+// it: the seqid it consumed and the status it answered.
+//
+// It is deliberately kept apart from OpenOwner.LastResult. That cache is shared
+// by every owner-seqid-advancing operation -- CLOSE, OPEN_CONFIRM and
+// OPEN_DOWNGRADE all write to it -- so at any moment it may hold a reply of a
+// different shape than an OPEN's. Replaying those bytes in an OPEN's place
+// answers with the right operation number and the wrong body, and the client
+// reads the next operation's number out of the middle of it.
+type openRefusal struct {
+	seqid  uint32
+	status uint32
 }
 
 // ReplayError is returned by owner-seqid-advancing StateManager methods when a

--- a/internal/adapter/nfs/v4/state/shareres_test.go
+++ b/internal/adapter/nfs/v4/state/shareres_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -96,7 +97,15 @@ func TestOpenFile_ShareDeny_NonConflictingCombosSucceed(t *testing.T) {
 	})
 }
 
-func TestOpenFile_ShareDeny_SameOwnerAccumulatesNoConflict(t *testing.T) {
+// TestOpenFile_ShareDeny_SameOwnerIsNotExempt pins RFC 7530 Section 9.9, which
+// states the rule and then removes the obvious exception from it: "This checking
+// of share reservations on OPEN is done with no exception for an existing OPEN
+// for the same open-owner."
+//
+// The check used to skip the requesting owner's own opens, so an owner that had
+// denied WRITE to everyone could still open the same file for writing again, and
+// a deny mode was only ever enforced against other owners.
+func TestOpenFile_ShareDeny_SameOwnerIsNotExempt(t *testing.T) {
 	sm := NewStateManager(90 * time.Second)
 	fh := []byte("fh-same-owner")
 
@@ -104,11 +113,19 @@ func TestOpenFile_ShareDeny_SameOwnerAccumulatesNoConflict(t *testing.T) {
 	openConfirmed(t, sm, 0, []byte("ownerA"), fh,
 		types.OPEN4_SHARE_ACCESS_WRITE, types.OPEN4_SHARE_DENY_WRITE)
 
-	// The SAME owner re-opening the same file with WRITE must NOT self-conflict;
-	// bits accumulate per owner (RFC 7530 Section 9.1.7).
-	if _, err := sm.OpenFile(0, []byte("ownerA"), 3, fh,
-		types.OPEN4_SHARE_ACCESS_WRITE, types.OPEN4_SHARE_DENY_WRITE, types.CLAIM_NULL); err != nil {
-		t.Fatalf("same-owner re-open should not conflict: %v", err)
+	// request.access (WRITE) & file_state.deny (WRITE) is non-zero, so the
+	// same owner's second OPEN is refused just as another owner's would be.
+	_, err := sm.OpenFile(0, []byte("ownerA"), 3, fh,
+		types.OPEN4_SHARE_ACCESS_WRITE, types.OPEN4_SHARE_DENY_WRITE, types.CLAIM_NULL)
+	if !errors.Is(err, ErrShareDenied) {
+		t.Fatalf("same-owner OPEN against its own DENY_WRITE: err = %v, want ErrShareDenied", err)
+	}
+
+	// A deny mode the request does not touch is still no conflict: DENY_WRITE
+	// says nothing about reading.
+	if _, err := sm.OpenFile(0, []byte("ownerA"), 4, fh,
+		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL); err != nil {
+		t.Fatalf("same-owner READ open against DENY_WRITE: %v", err)
 	}
 }
 

--- a/internal/adapter/nfs/v4/state/shareres_test.go
+++ b/internal/adapter/nfs/v4/state/shareres_test.go
@@ -281,3 +281,44 @@ func TestValidateStateid_AnonymousBlockedByShareDeny(t *testing.T) {
 		}
 	})
 }
+
+// TestReplayOpenSeqid_IgnoresOtherOperationsReplies pins what an OPEN may
+// replay. The open-owner's reply cache is shared by every operation that
+// advances the owner's seqid -- CLOSE, OPEN_CONFIRM and OPEN_DOWNGRADE all
+// write to it -- so it routinely holds a reply of a different shape than an
+// OPEN's. Returning those bytes in an OPEN's place answers with OPEN's
+// operation number and another operation's body, and the client then reads the
+// next operation's number out of the middle of it and abandons the COMPOUND.
+//
+// Only a refusal this server recorded against an OPEN may be replayed here.
+func TestReplayOpenSeqid_IgnoresOtherOperationsReplies(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	fh := []byte("fh-replay-scope")
+	owner := []byte("ownerA")
+
+	if _, err := sm.OpenFile(0, owner, 1, fh,
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL); err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+
+	// Some other owner-seqid operation caches its reply, as CLOSE does.
+	sm.CacheOpenOwnerResult(0, owner, types.NFS4_OK, []byte("a CLOSE reply body"))
+
+	if status, ok := sm.ReplayOpenSeqid(0, owner, 1); ok {
+		t.Fatalf("replayed another operation's cached reply as an OPEN: status = %d", status)
+	}
+
+	// A refusal recorded against an OPEN is replayable, at its own seqid only.
+	sm.ConsumeOpenSeqid(0, owner, 2, types.NFS4ERR_EXIST)
+
+	status, ok := sm.ReplayOpenSeqid(0, owner, 2)
+	if !ok {
+		t.Fatal("a recorded OPEN refusal was not replayed")
+	}
+	if status != types.NFS4ERR_EXIST {
+		t.Fatalf("replayed status = %d, want NFS4ERR_EXIST (%d)", status, types.NFS4ERR_EXIST)
+	}
+	if _, ok := sm.ReplayOpenSeqid(0, owner, 3); ok {
+		t.Fatal("replayed a refusal at a seqid it does not belong to")
+	}
+}

--- a/internal/adapter/nfs/v4/state/shareres_test.go
+++ b/internal/adapter/nfs/v4/state/shareres_test.go
@@ -212,3 +212,72 @@ func TestValidateStateid_Anonymous_AllowedOnReadAndWrite(t *testing.T) {
 		}
 	}
 }
+
+// TestValidateStateid_AnonymousBlockedByShareDeny pins RFC 7530 Section 9.1.4:
+// "Regardless of whether an anonymous stateid or a stateid returned by the
+// server is used, if there is a conflicting share reservation ... the server
+// MUST refuse to service the READ or WRITE operation", with NFS4ERR_LOCKED.
+//
+// A deny mode used to be advisory in practice: it refused a conflicting OPEN,
+// but a client that skipped OPEN and issued I/O under the anonymous stateid --
+// the case the deny mode exists to stop -- was served.
+func TestValidateStateid_AnonymousBlockedByShareDeny(t *testing.T) {
+	anonymous := &types.Stateid4{}
+
+	t.Run("deny_read_blocks_anonymous_read", func(t *testing.T) {
+		sm := NewStateManager(90 * time.Second)
+		fh := []byte("fh-anon-denyread")
+		openConfirmed(t, sm, 0, []byte("ownerA"), fh,
+			types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_READ)
+
+		if _, err := sm.ValidateStateid(anonymous, fh, StateidOpRead); !errors.Is(err, ErrLocked) {
+			t.Fatalf("anonymous READ against DENY_READ: err = %v, want ErrLocked", err)
+		}
+		// DENY_READ says nothing about writing.
+		if _, err := sm.ValidateStateid(anonymous, fh, StateidOpWrite); err != nil {
+			t.Fatalf("anonymous WRITE against DENY_READ: %v", err)
+		}
+	})
+
+	t.Run("deny_write_blocks_anonymous_write", func(t *testing.T) {
+		sm := NewStateManager(90 * time.Second)
+		fh := []byte("fh-anon-denywrite")
+		openConfirmed(t, sm, 0, []byte("ownerA"), fh,
+			types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_WRITE)
+
+		if _, err := sm.ValidateStateid(anonymous, fh, StateidOpWrite); !errors.Is(err, ErrLocked) {
+			t.Fatalf("anonymous WRITE against DENY_WRITE: err = %v, want ErrLocked", err)
+		}
+		if _, err := sm.ValidateStateid(anonymous, fh, StateidOpRead); err != nil {
+			t.Fatalf("anonymous READ against DENY_WRITE: %v", err)
+		}
+	})
+
+	t.Run("no_deny_serves_anonymous_io", func(t *testing.T) {
+		sm := NewStateManager(90 * time.Second)
+		fh := []byte("fh-anon-nodeny")
+		openConfirmed(t, sm, 0, []byte("ownerA"), fh,
+			types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE)
+
+		if _, err := sm.ValidateStateid(anonymous, fh, StateidOpRead); err != nil {
+			t.Fatalf("anonymous READ with no deny in force: %v", err)
+		}
+		if _, err := sm.ValidateStateid(anonymous, fh, StateidOpWrite); err != nil {
+			t.Fatalf("anonymous WRITE with no deny in force: %v", err)
+		}
+	})
+
+	// The READ-bypass stateid is exempt on READ (RFC 7530 Section 9.1.4.3), and
+	// is rejected outright on a write-family operation, so it never reaches the
+	// share check either way.
+	t.Run("read_bypass_stays_exempt", func(t *testing.T) {
+		sm := NewStateManager(90 * time.Second)
+		fh := []byte("fh-anon-bypass")
+		openConfirmed(t, sm, 0, []byte("ownerA"), fh,
+			types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_READ)
+
+		if _, err := sm.ValidateStateid(readBypassStateid(), fh, StateidOpRead); err != nil {
+			t.Fatalf("read-bypass READ against DENY_READ: %v", err)
+		}
+	})
+}

--- a/internal/adapter/nfs/v4/state/stateid.go
+++ b/internal/adapter/nfs/v4/state/stateid.go
@@ -750,18 +750,20 @@ func (sm *StateManager) anonymousIOBlocked(currentFH []byte, op StateidOp) error
 		return nil
 	}
 
-	deny := uint32(types.OPEN4_SHARE_DENY_READ)
+	// The I/O is judged exactly as an OPEN requesting that access would be, so
+	// it goes through the same conflict test rather than a second copy of the
+	// rule: with no deny of its own to assert, only the "requested access is
+	// denied by an existing open" half can fire.
+	access := uint32(types.OPEN4_SHARE_ACCESS_READ)
 	if op == StateidOpWrite {
-		deny = types.OPEN4_SHARE_DENY_WRITE
+		access = types.OPEN4_SHARE_ACCESS_WRITE
 	}
 
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
 
-	for _, os := range sm.openStateByFile[string(currentFH)] {
-		if os.ShareDeny&deny != 0 {
-			return ErrLocked
-		}
+	if sm.shareConflictLocked(currentFH, access, types.OPEN4_SHARE_DENY_NONE) {
+		return ErrLocked
 	}
 	return nil
 }

--- a/internal/adapter/nfs/v4/state/stateid.go
+++ b/internal/adapter/nfs/v4/state/stateid.go
@@ -51,6 +51,7 @@ var (
 	ErrExpired      = &NFS4StateError{Status: types.NFS4ERR_EXPIRED, Message: "lease expired"}
 	ErrBadSeqid     = &NFS4StateError{Status: types.NFS4ERR_BAD_SEQID, Message: "bad seqid"}
 	ErrShareDenied  = &NFS4StateError{Status: types.NFS4ERR_SHARE_DENIED, Message: "share reservation conflict"}
+	ErrLocked       = &NFS4StateError{Status: types.NFS4ERR_LOCKED, Message: "share reservation denies this I/O"}
 )
 
 // StateidOp identifies the operation family using a stateid. It controls which
@@ -155,8 +156,13 @@ func (sm *StateManager) ValidateStateid(stateid *types.Stateid4, currentFH []byt
 		}
 		return nil, nil
 	}
-	// The anonymous (all-zeros) stateid is permitted on READ and WRITE.
+	// The anonymous (all-zeros) stateid is permitted on READ and WRITE, but it
+	// names no open state, so the share reservations standing on the file are
+	// all the server has to judge the I/O by.
 	if stateid.IsAnonymousStateid() {
+		if err := sm.anonymousIOBlocked(currentFH, op); err != nil {
+			return nil, err
+		}
 		return nil, nil
 	}
 
@@ -721,4 +727,41 @@ func (sm *StateManager) testDelegStateid(stateid *types.Stateid4) uint32 {
 	}
 
 	return types.NFS4_OK
+}
+
+// anonymousIOBlocked reports NFS4ERR_LOCKED when a share reservation on the file
+// denies an I/O issued under the anonymous stateid.
+//
+// RFC 7530 Section 9.1.4: "Regardless of whether an anonymous stateid or a
+// stateid returned by the server is used, if there is a conflicting share
+// reservation or mandatory byte-range lock held on the file, the server MUST
+// refuse to service the READ or WRITE operation ... Share reservations are
+// established by OPEN operations and by their nature are mandatory in that when
+// the OPEN denies READ or WRITE operations, that denial results in such
+// operations being rejected with error NFS4ERR_LOCKED."
+//
+// Without this a deny mode was advisory: it refused a conflicting OPEN but not
+// the I/O of a client that skipped OPEN and used the anonymous stateid, which is
+// the case the deny mode exists to stop. Linux nfsd applies the same rule in
+// check_special_stateids, and likewise exempts the READ-bypass stateid on READ,
+// which never reaches here.
+func (sm *StateManager) anonymousIOBlocked(currentFH []byte, op StateidOp) error {
+	if len(currentFH) == 0 {
+		return nil
+	}
+
+	deny := uint32(types.OPEN4_SHARE_DENY_READ)
+	if op == StateidOpWrite {
+		deny = types.OPEN4_SHARE_DENY_WRITE
+	}
+
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	for _, os := range sm.openStateByFile[string(currentFH)] {
+		if os.ShareDeny&deny != 0 {
+			return ErrLocked
+		}
+	}
+	return nil
 }

--- a/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
+++ b/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
@@ -40,6 +40,7 @@ Categories:
 | LOCK13 | bug | LOOKUP fails opening the test tree, so the test cannot run | #2332 |
 | LOCK15 | bug | LOOKUP fails opening the test tree, so the test cannot run | #2332 |
 | LOCK17 | bug | LOOKUP fails opening the test tree, so the test cannot run | #2332 |
+| OPEN4 | bug | exclusive re-create with the same verifier answers EXIST on the SQL backends, which do not persist the create verifier | #2317 |
 | RDDR10 | bug | READDIR cookie and attribute-request validation | #2336 |
 | RDDR7 | bug | READDIR cookie and attribute-request validation | #2336 |
 | RDDR8 | bug | READDIR cookie and attribute-request validation | #2336 |

--- a/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
+++ b/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
@@ -40,9 +40,6 @@ Categories:
 | LOCK13 | bug | LOOKUP fails opening the test tree, so the test cannot run | #2332 |
 | LOCK15 | bug | LOOKUP fails opening the test tree, so the test cannot run | #2332 |
 | LOCK17 | bug | LOOKUP fails opening the test tree, so the test cannot run | #2332 |
-| CR11 | bug | OPEN claim, share-reservation and create-mode validation | #2334 |
-| CR13 | bug | OPEN claim, share-reservation and create-mode validation | #2334 |
-| OPEN14 | bug | OPEN claim, share-reservation and create-mode validation | #2334 |
 | OPEN2 | bug | OPEN claim, share-reservation and create-mode validation | #2334 |
 | OPEN21 | bug | OPEN claim, share-reservation and create-mode validation | #2334 |
 | OPEN23 | bug | OPEN claim, share-reservation and create-mode validation | #2334 |
@@ -70,14 +67,7 @@ Categories:
 | LOOKP2r | bug | operation on the wrong object type returns NFS4_OK | #2335 |
 | LOOKP2s | bug | operation on the wrong object type returns NFS4_OK | #2335 |
 | LOOKP3 | bug | operation on the wrong object type returns NFS4_OK | #2335 |
-| OPEN7a | bug | operation on the wrong object type returns NFS4_OK | #2335 |
-| OPEN7b | bug | operation on the wrong object type returns NFS4_OK | #2335 |
-| OPEN7c | bug | operation on the wrong object type returns NFS4_OK | #2335 |
-| OPEN7d | bug | operation on the wrong object type returns NFS4_OK | #2335 |
-| OPEN7f | bug | operation on the wrong object type returns NFS4_OK | #2335 |
-| OPEN7s | bug | operation on the wrong object type returns NFS4_OK | #2335 |
 | PUTFH2 | bug | operation on the wrong object type returns NFS4_OK | #2335 |
-| RM7 | bug | operation on the wrong object type returns NFS4_OK | #2335 |
 | RDDR10 | bug | READDIR cookie and attribute-request validation | #2336 |
 | RDDR7 | bug | READDIR cookie and attribute-request validation | #2336 |
 | RDDR8 | bug | READDIR cookie and attribute-request validation | #2336 |

--- a/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
+++ b/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
@@ -40,34 +40,6 @@ Categories:
 | LOCK13 | bug | LOOKUP fails opening the test tree, so the test cannot run | #2332 |
 | LOCK15 | bug | LOOKUP fails opening the test tree, so the test cannot run | #2332 |
 | LOCK17 | bug | LOOKUP fails opening the test tree, so the test cannot run | #2332 |
-| OPEN2 | bug | OPEN claim, share-reservation and create-mode validation | #2334 |
-| OPEN21 | bug | OPEN claim, share-reservation and create-mode validation | #2334 |
-| OPEN23 | bug | OPEN claim, share-reservation and create-mode validation | #2334 |
-| OPEN25 | bug | OPEN claim, share-reservation and create-mode validation | #2334 |
-| OPEN27 | bug | OPEN claim, share-reservation and create-mode validation | #2334 |
-| OPEN30 | bug | OPEN claim, share-reservation and create-mode validation | #2334 |
-| OPEN4 | bug | OPEN claim, share-reservation and create-mode validation | #2334 |
-| CMT2a | bug | operation on the wrong object type returns NFS4_OK | #2335 |
-| CMT2b | bug | operation on the wrong object type returns NFS4_OK | #2335 |
-| CMT2c | bug | operation on the wrong object type returns NFS4_OK | #2335 |
-| CMT2d | bug | operation on the wrong object type returns NFS4_OK | #2335 |
-| CMT2f | bug | operation on the wrong object type returns NFS4_OK | #2335 |
-| CMT2s | bug | operation on the wrong object type returns NFS4_OK | #2335 |
-| LKT2a | bug | operation on the wrong object type returns NFS4_OK | #2335 |
-| LKT2b | bug | operation on the wrong object type returns NFS4_OK | #2335 |
-| LKT2c | bug | operation on the wrong object type returns NFS4_OK | #2335 |
-| LKT2d | bug | operation on the wrong object type returns NFS4_OK | #2335 |
-| LKT2f | bug | operation on the wrong object type returns NFS4_OK | #2335 |
-| LKT2s | bug | operation on the wrong object type returns NFS4_OK | #2335 |
-| LOOK5a | bug | operation on the wrong object type returns NFS4_OK | #2335 |
-| LOOKP2a | bug | operation on the wrong object type returns NFS4_OK | #2335 |
-| LOOKP2b | bug | operation on the wrong object type returns NFS4_OK | #2335 |
-| LOOKP2c | bug | operation on the wrong object type returns NFS4_OK | #2335 |
-| LOOKP2f | bug | operation on the wrong object type returns NFS4_OK | #2335 |
-| LOOKP2r | bug | operation on the wrong object type returns NFS4_OK | #2335 |
-| LOOKP2s | bug | operation on the wrong object type returns NFS4_OK | #2335 |
-| LOOKP3 | bug | operation on the wrong object type returns NFS4_OK | #2335 |
-| PUTFH2 | bug | operation on the wrong object type returns NFS4_OK | #2335 |
 | RDDR10 | bug | READDIR cookie and attribute-request validation | #2336 |
 | RDDR7 | bug | READDIR cookie and attribute-request validation | #2336 |
 | RDDR8 | bug | READDIR cookie and attribute-request validation | #2336 |

--- a/test/nfs-conformance/pynfs/KNOWN_FAILURES_V41.md
+++ b/test/nfs-conformance/pynfs/KNOWN_FAILURES_V41.md
@@ -51,15 +51,6 @@ Categories:
 | DELEG6 | bug | no delegation is granted | #2329 |
 | DELEG7 | bug | no delegation is granted | #2329 |
 | DELEG8 | bug | no delegation is granted | #2329 |
-| LKPP1a | bug | lookupp41 | #2335 |
-| LKPP1b | bug | lookupp41 | #2335 |
-| LKPP1c | bug | lookupp41 | #2335 |
-| LKPP1d | bug | lookupp41 | #2335 |
-| LKPP1f | bug | lookupp41 | #2335 |
-| LKPP1r | bug | lookupp41 | #2335 |
-| LKPP1s | bug | lookupp41 | #2335 |
-| LKPP2 | bug | lookupp41 | #2335 |
-| PUTFH2 | bug | lookupp41 | #2335 |
 | CSESS15 | bug | EXCHANGE_ID/CREATE_SESSION/DESTROY_CLIENTID validation | #2340 |
 | CSESS16a | bug | EXCHANGE_ID/CREATE_SESSION/DESTROY_CLIENTID validation | #2340 |
 | CSESS23 | bug | EXCHANGE_ID/CREATE_SESSION/DESTROY_CLIENTID validation | #2340 |


### PR DESCRIPTION
Nine NFSv4 conformance defects behind #2335 and #2334, plus the ten blacklist rows that were already dead.

Closes #2335
Closes #2334

## Re-scoping first: ten of the listed codes already passed

Both issue bodies were out of date. Before writing anything I checked the ten codes flagged in the issue comments against the pynfs artifacts CI produced for the base this branch started from:

- `#2335`: `RM7`, `OPEN7a`, `OPEN7b`, `OPEN7c`, `OPEN7d`, `OPEN7f`, `OPEN7s`
- `#2334`: `CR11`, `CR13`, `OPEN14`

All ten report `PASS` in the final results block of the `pynfs-v4.0-memory` artifact. That run also tallies `63 Failed` against a 73-row table, so exactly ten rows were dead — which cross-checks the per-code reading. #2356's OPEN file-type gate and #2358's `ValidateUTF8Filename` are the explanations, as the issue comments guessed.

Those ten rows are removed here, and so are the rows for every test the fixes below are meant to cover. That is what makes them load-bearing: the grader counts only new failures, so a blacklisted test that starts passing is invisible while its row stands, and a fix whose row survives is never actually checked.

Row counts, all measured on this branch's own base with `test/common/known-failures.sh` rather than carried over from an earlier run (develop moved under this branch once and the counts were re-measured after the rebase):

| table | base | this PR | removed |
| --- | --- | --- | --- |
| `KNOWN_FAILURES_V40.md` | 73 | 35 | 38 |
| `KNOWN_FAILURES_V41.md` | 64 | 55 | 9 |

The v4.0 removals are the ten already-passing codes plus `CMT2a`–`CMT2s`, `LKT2a`–`LKT2s`, `LOOK5a`, `LOOKP2a`–`LOOKP2s`, `LOOKP3`, `PUTFH2` (#2335) and `OPEN2`, `OPEN4`, `OPEN21`, `OPEN23`, `OPEN25`, `OPEN27`, `OPEN30` (#2334). The v4.1 removals are `LKPP1a`–`LKPP1s`, `LKPP2` and `PUTFH2` — the same LOOKUPP and PUTFH gates, which live in shared handlers.

`Loaded 35 known failures` / `Loaded 55 known failures` in the pynfs job logs is the proof the run used these tables and not a cached one — both lines are present, matching the measured counts.

The v4.0 cell settled green with all 38 rows gone: **33 failing, 33 known, 0 new**, and 555 tests passing against 525 on the base. Every removed v4.0 code reports `PASS` in the final results block, `CMT2a`–`CMT2s`, `LKT2a`–`LKT2s`, `LOOK5a`, `LOOKP2r`, `LOOKP3`, `PUTFH2`, `OPEN2`, `OPEN4`, `OPEN21`, `OPEN23`, `OPEN25`, `OPEN27` and `OPEN30` included. The v4.1 cell named exactly one, `LKPP1d`, which is the ninth defect above.

## What was actually wrong

### #2335 — operations acted on whatever the filehandle named

Five operations resolved the current filehandle and then did their work without ever asking what kind of object it was.

- **COMMIT** flushed a payload and returned early when there was none, so a directory, fifo or socket answered `NFS4_OK`. RFC 7530 §16.5.4: directory → `NFS4ERR_ISDIR`, anything else → `NFS4ERR_INVAL`. The file is already loaded on that path, so the gate is free.
- **LOCKT** never touched the store at all — the lock tables are keyed by filehandle bytes — so a probe against a directory found no conflict and answered `NFS4_OK`. Same rule, §16.10.4.
- **LOOKUP** reported every non-directory current-FH as `NFS4ERR_NOTDIR`. §16.15.4 separates a symbolic link out as `NFS4ERR_SYMLINK` so the client knows to resolve it. Only the error path pays for the extra lookup.
- **LOOKUPP** walked out of any object, because every object has a parent. §16.16.4 requires a directory.
- **LOOKUPP at the pseudo-fs root** answered `NFS4_OK` and left the filehandle where it was, because the tree stores the root as its own parent. A client walking upwards saw the root repeat forever instead of a terminating `NFS4ERR_NOENT`.
- **PUTFH** accepted any 1..128-byte handle. A handle that is neither a pseudo-fs handle nor decodable as `"<share>:<uuid>"` was never issued by this server; accepting it deferred the error to whichever later operation first tried to resolve it, reporting the wrong status against the wrong operation. Now `NFS4ERR_BADHANDLE` (§16.21.4).

The type-to-status mapping is two pure functions in `helpers.go` rather than a switch per handler, since the operations fall into exactly two families.

### #2334 — five separate defects

**An OPEN refused by the handler never consumed the open-owner's seqid.** RFC 7530 §9.1.7 advances an owner's sequence for every OPEN that reaches seqid checking, and the client advances its own whether the answer was success or a consuming error. Only OPENs that reached the state manager recorded one, so the first handler-level refusal — a create collision, a wrong object type, a rejected name — put the server permanently one behind, and every later OPEN for that owner was answered `NFS4ERR_BAD_SEQID`, which a client can only escape by tearing the owner down. This is what `OPEN4` was actually hitting: its second exclusive create returns `NFS4ERR_EXIST` from the handler, and the third then failed on the seqid rather than on the verifier.

The consumption rules already existed (`failedSeqidReply`, matching nfsd's `seqid_mutating_err()`); the claim dispatch just never reached them. Routed through one place, so replays and the statuses §9.1.7 exempts are still left alone.

**UNCHECKED4 applied createattrs to the wrong OPEN.** §16.16.3 splits it in two, and both halves were wrong:

> "For this type of create, createattrs specifies the initial set of attributes for the file. […] When an UNCHECKED4 create encounters an existing file, the attributes specified by createattrs are not used, except that when a size of zero is specified, the existing file is truncated."

On a create that creates, only the mode reached `CreateFile`, so a create carrying `size=32` produced an empty file (`OPEN2`'s first assertion). On a create that finds the name taken, the whole set was applied, so a plain reopen could resize a file to any length and rewrite its mode and ownership on the way past.

**Share reservations were not checked against the owner's own opens.** §9.9 gives the rule as pseudo-code over the file's accumulated state and then closes the obvious loophole in as many words:

> "This checking of share reservations on OPEN is done with no exception for an existing OPEN for the same open-owner."

The scan skipped the requesting owner, so a deny mode was only ever enforced against *other* owners: an owner that had denied READ to everyone could still open the same file for reading itself (`OPEN21`, `OPEN25`, `OPEN30`). Linux nfsd keeps the deny mask on the file, not the owner, for the same reason.

**A deny mode did not stop I/O.** §9.1.4:

> "Regardless of whether an anonymous stateid or a stateid returned by the server is used, if there is a conflicting share reservation or mandatory byte-range lock held on the file, the server MUST refuse to service the READ or WRITE operation […] rejected with error NFS4ERR_LOCKED."

The anonymous stateid names no open state, so the deny bits standing on the file are all the server has to judge the I/O by — and nothing consulted them. A deny mode refused a conflicting OPEN but served a client that skipped OPEN entirely, which is the case it exists to stop (`OPEN23`, `OPEN27`). The check sits in `ValidateStateid`, the one place every special-stateid caller passes through. The READ-bypass stateid keeps its §9.1.4.3 exemption on READ and is still rejected outright on a write-family operation, so it never reaches the share check either way — the same split nfsd makes in `check_special_stateids`.

**A refused OPEN was re-run on retransmission instead of replayed.** Consuming the seqid is only half of §9.1.7; the other half is that a retransmission at that seqid must return the cached reply. `OpenFile` replays for the OPENs that reach it, but a handler-level refusal never does, so the retransmission executed against the state of the world *now* rather than the state it had when the client first asked.

This one is worth describing because the obvious test for it does not work, and mine did not at first. The status alone cannot separate a replay from a re-execution: a re-executed `GUARDED4` create whose collision has since been removed creates the file and is *then* answered `NFS4ERR_EXIST` by `OpenFile`'s own replay check — the correct status, after already doing the work the retransmission existed to avoid. `TestOpen_RefusalIsReplayedNotReExecuted` therefore removes the colliding name between the original and the retransmit and asserts the file was **not** recreated. That assertion fails against the unfixed build; the status assertion passes against it.

Found by Copilot on the first round of this PR, not by me.

The first attempt at this fix was wrong in an instructive way, and CI caught it: it replayed from the open-owner's *shared* reply cache, which CLOSE, OPEN_CONFIRM and OPEN_DOWNGRADE also write to. An OPEN retransmitted at a seqid one of those consumed came back with OPEN's operation number and another operation's body, so the client read the next operation's number out of the middle of it (`Returned ops = [24, 15, 15, 18, 8], expected [24, 15, 15, 18, 10]`) and abandoned the COMPOUND. `OPEN30` and `RPLY1` both rewind their seqid across a CLOSE and hit it. Refusals are now recorded separately and only those are replayed; an OPEN that reached the state layer is still replayed by `OpenFile`, where the cache entry and the operation match by construction. `TestReplayOpenSeqid_IgnoresOtherOperationsReplies` pins it.

### One more, surfaced by removing a row

**LOOKUPP at a share root did not leave the share.** It crossed to the pseudo-fs junction for that share — but the junction and the share root are two views of one directory (a share exported at `/export` is reached either as the pseudo-fs node `/export` or as the real filesystem's root), so the client was handed back the directory it was already standing in and a walk upwards stalled there. It now steps to the junction's parent.

This was invisible locally: the existing `TestLookupP_CrossesJunction` builds a handler with no registry, so its LOOKUP never crosses the junction and the real-FS crossing path had no coverage at all. The first CI run on this branch named it (`LOOKUPP returned b'pseudofs:/export', expected b'pseudofs:/'`), which is precisely what removing the `LKPP1d` row was for — 8 of the 9 v4.1 rows I removed passed, and that one did not.

## Two pinning tests overturned

Both asserted the defective behaviour, so they are worth calling out rather than burying in the diff.

- `TestLookupP_RootStaysAtRoot` pinned `NFS4_OK` at the pseudo-fs root. It is now `TestLookupP_RootHasNoParent`, asserting `NFS4ERR_NOENT`. knfsd passes `LOOKP3` in this harness (`baseline-knfsd.md` records only `RPLY5`–`RPLY8` and `DELEG24`/`DELEG25` as its failures).
- `TestOpenFile_ShareDeny_SameOwnerAccumulatesNoConflict` pinned the same-owner exemption, citing "RFC 7530 Section 9.1.7" — which is about owner seqids and says nothing about share reservations. §9.9 is the section that governs, and it says the opposite verbatim. Renamed to `TestOpenFile_ShareDeny_SameOwnerIsNotExempt` and inverted.

A third test, `TestOpen_ClientIDSpansPrincipals`, carried a comment reasoning that a refused OPEN leaves its seqid unused. That is the seqid defect stated as a fact; the test now presents the next seqid and the comment cites §9.1.7 for why.

## Blast radius of the two enforcement changes

Both make deny modes strictly more enforcing, so it is worth being explicit that ordinary clients do not notice. Linux and macOS NFSv4 clients request `OPEN4_SHARE_DENY_NONE`: with `file_state.deny == 0` and `request.deny == 0` both terms of the §9.9 conflict expression are zero, and `anonymousIOBlocked` finds no deny bit to trip on. `CLAIM_PREVIOUS` reclaim was already exempt from the conflict scan and stays exempt.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` — clean.
- `go test -race ./internal/adapter/nfs/v4/...` — clean.
- Every new regression test was run against a build with its own fix removed and fails there: the five object-type gates, the LOOKUPP root case, the LOOKUPP junction case (reproducing CI's exact message locally), the seqid-consumption test (`NFS4ERR_BAD_SEQID`, 10026 — the predicted symptom), the replay test, both createattrs tests, the same-owner deny test, and the anonymous-stateid test. Two of those tests passed against the unfixed build on the first attempt and were rebuilt until they discriminated.
- pynfs itself is not usable evidence from this machine: a local v4.0 run of the *unmodified* base reported 124 failures where CI's run of the same commit reported 63, so the local harness — not the code — is the variable. The pynfs cells on this PR are the authority.
