### PR TITLE
fix(nfs/v4): client-record and lease validation, and courtesy-client state at the conflict

### DIFF
--- a/internal/adapter/nfs/v4/handlers/client_principal_test.go
+++ b/internal/adapter/nfs/v4/handlers/client_principal_test.go
@@ -198,7 +198,16 @@ func TestSetClientID_IdentitylessCallerCannotTakeOver(t *testing.T) {
 	sm := fx.handler.StateManager
 
 	const name = "victim-client"
-	testClientID(t, sm, name, "uid:1000")
+	victim := testClientID(t, sm, name, "uid:1000")
+
+	// The bar exists to protect leased state (RFC 7530 Section 9.1.1), and
+	// Section 9.1.2 requires the takeover to be allowed against a client ID
+	// that holds none, so the victim has to hold some for this to be a test of
+	// the credential check rather than of that exemption.
+	if _, err := sm.OpenFile(victim, []byte("victim-owner"), 1, []byte("victim-fh"),
+		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL); err != nil {
+		t.Fatalf("OpenFile for the victim: %v", err)
+	}
 
 	cb := state.CallbackInfo{Program: 0x40000000, NetID: "tcp", Addr: "127.0.0.1.8.1"}
 

--- a/internal/adapter/nfs/v4/handlers/setclientid.go
+++ b/internal/adapter/nfs/v4/handlers/setclientid.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"io"
 
@@ -109,7 +110,7 @@ func (h *Handler) handleSetClientID(ctx *types.CompoundContext, reader io.Reader
 
 // encodeSetClientIDError encodes a failed SETCLIENTID4res. The result is a
 // union over the status, and its NFS4ERR_CLID_INUSE arm carries a clientaddr4
-// (RFC 7530 Section 16.33.2) -- two XDR strings the default arm does not have.
+// (RFC 7530 Section 16.33.3) -- two XDR strings the default arm does not have.
 // A status-only reply for that one status is therefore short on the wire, and
 // the client's decode runs off the end of the whole COMPOUND rather than
 // reading a CLID_INUSE it could act on.
@@ -122,11 +123,12 @@ func encodeSetClientIDError(status uint32) []byte {
 		return encodeStatusOnly(status)
 	}
 
-	var buf bytes.Buffer
-	_ = xdr.WriteUint32(&buf, status)
-	_ = xdr.WriteXDRString(&buf, "") // client_using.na_r_netid
-	_ = xdr.WriteXDRString(&buf, "") // client_using.na_r_addr
-	return buf.Bytes()
+	// The status, then client_using as two empty strings: an XDR string is a
+	// length followed by that many bytes, so an empty one is a zero length and
+	// nothing else, and all twelve bytes are zero but the status.
+	b := make([]byte, 12)
+	binary.BigEndian.PutUint32(b, status)
+	return b
 }
 
 // handleSetClientIDConfirm implements the SETCLIENTID_CONFIRM operation (RFC 7530 Section 16.34).

--- a/internal/adapter/nfs/v4/handlers/setclientid.go
+++ b/internal/adapter/nfs/v4/handlers/setclientid.go
@@ -90,7 +90,7 @@ func (h *Handler) handleSetClientID(ctx *types.CompoundContext, reader io.Reader
 		return &types.CompoundResult{
 			Status: nfsStatus,
 			OpCode: types.OP_SETCLIENTID,
-			Data:   encodeStatusOnly(nfsStatus),
+			Data:   encodeSetClientIDError(nfsStatus),
 		}
 	}
 
@@ -105,6 +105,28 @@ func (h *Handler) handleSetClientID(ctx *types.CompoundContext, reader io.Reader
 		OpCode: types.OP_SETCLIENTID,
 		Data:   buf.Bytes(),
 	}
+}
+
+// encodeSetClientIDError encodes a failed SETCLIENTID4res. The result is a
+// union over the status, and its NFS4ERR_CLID_INUSE arm carries a clientaddr4
+// (RFC 7530 Section 16.33.2) -- two XDR strings the default arm does not have.
+// A status-only reply for that one status is therefore short on the wire, and
+// the client's decode runs off the end of the whole COMPOUND rather than
+// reading a CLID_INUSE it could act on.
+//
+// ponytail: the address reported back is empty, as Linux nfsd's is. It names
+// the client already holding the id, which SETCLIENTID has no obligation to
+// track; fill it in only if a client turns up that does something with it.
+func encodeSetClientIDError(status uint32) []byte {
+	if status != types.NFS4ERR_CLID_INUSE {
+		return encodeStatusOnly(status)
+	}
+
+	var buf bytes.Buffer
+	_ = xdr.WriteUint32(&buf, status)
+	_ = xdr.WriteXDRString(&buf, "") // client_using.na_r_netid
+	_ = xdr.WriteXDRString(&buf, "") // client_using.na_r_addr
+	return buf.Bytes()
 }
 
 // handleSetClientIDConfirm implements the SETCLIENTID_CONFIRM operation (RFC 7530 Section 16.34).

--- a/internal/adapter/nfs/v4/handlers/setclientid_test.go
+++ b/internal/adapter/nfs/v4/handlers/setclientid_test.go
@@ -1,0 +1,46 @@
+package handlers
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+)
+
+// TestEncodeSetClientIDError_ClidInUseCarriesClientUsing pins the shape of the
+// SETCLIENTID4res union. Its NFS4ERR_CLID_INUSE arm carries a clientaddr4 that
+// no other arm has, so a status-only reply for that status is two XDR strings
+// short and the client's decode runs off the end of the whole COMPOUND instead
+// of reading an error it could act on.
+func TestEncodeSetClientIDError_ClidInUseCarriesClientUsing(t *testing.T) {
+	encoded := encodeSetClientIDError(types.NFS4ERR_CLID_INUSE)
+
+	reader := bytes.NewReader(encoded)
+	status, err := xdr.DecodeUint32(reader)
+	if err != nil {
+		t.Fatalf("decode status: %v", err)
+	}
+	if status != types.NFS4ERR_CLID_INUSE {
+		t.Fatalf("status = %d, want %d", status, types.NFS4ERR_CLID_INUSE)
+	}
+	if _, err := xdr.DecodeString(reader); err != nil {
+		t.Fatalf("decode client_using.na_r_netid: %v", err)
+	}
+	if _, err := xdr.DecodeString(reader); err != nil {
+		t.Fatalf("decode client_using.na_r_addr: %v", err)
+	}
+	if reader.Len() != 0 {
+		t.Errorf("%d trailing bytes after client_using", reader.Len())
+	}
+}
+
+// Every other status takes the void arm, so anything beyond the status would
+// be read as the next operation in the COMPOUND.
+func TestEncodeSetClientIDError_OtherStatusesAreStatusOnly(t *testing.T) {
+	for _, status := range []uint32{types.NFS4ERR_BADXDR, types.NFS4ERR_STALE_CLIENTID, types.NFS4ERR_INVAL} {
+		if got, want := len(encodeSetClientIDError(status)), 4; got != want {
+			t.Errorf("encodeSetClientIDError(%d) is %d bytes, want %d", status, got, want)
+		}
+	}
+}

--- a/internal/adapter/nfs/v4/state/batch_state_manager_test.go
+++ b/internal/adapter/nfs/v4/state/batch_state_manager_test.go
@@ -250,11 +250,54 @@ func TestSetClientID_PrincipalMismatchReturnsClientIDInUse(t *testing.T) {
 	if err := sm.ConfirmClientID(r1.ClientID, r1.ConfirmVerifier); err != nil {
 		t.Fatalf("ConfirmClientID failed: %v", err)
 	}
+	openClientState(t, sm, r1.ClientID, "hijack-owner", []byte("target-file"))
 
 	// Case 5 (same verifier) from a DIFFERENT principal -> CLID_INUSE.
 	_, err = sm.SetClientID("hijack-target", verifier, cb, "10.0.0.2:5678", "uid:9999")
 	if !errors.Is(err, ErrClientIDInUse) {
 		t.Errorf("expected ErrClientIDInUse, got %v", err)
+	}
+}
+
+// TestSetClientID_PrincipalMismatchAllowedWithoutState pins the condition on
+// that refusal. RFC 7530 Section 9.1.2 requires the SETCLIENTID to be allowed
+// when the recorded client ID holds no state, because the rule the principal
+// check enforces (Section 9.1.1) is a MUST NOT on cancelling *leased state*
+// established by another principal, and there is none here to cancel.
+//
+// Without the condition, whichever principal touches a client id string first
+// owns it for the life of the server: clients derive that string from the
+// hostname, not from their credential, so a second user on the same host can
+// never establish a client id at all.
+func TestSetClientID_PrincipalMismatchAllowedWithoutState(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	verifier := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+	cb := CallbackInfo{Program: 0x40000000, NetID: "tcp", Addr: "10.0.0.1.8.1"}
+
+	r1, err := sm.SetClientID("stateless-target", verifier, cb, "10.0.0.1:1234", "uid:1000")
+	if err != nil {
+		t.Fatalf("SetClientID failed: %v", err)
+	}
+	if err := sm.ConfirmClientID(r1.ClientID, r1.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID failed: %v", err)
+	}
+
+	if _, err := sm.SetClientID("stateless-target", verifier, cb, "10.0.0.2:5678", "uid:9999"); err != nil {
+		t.Errorf("SETCLIENTID from a different principal against a stateless client ID: got %v, want success", err)
+	}
+}
+
+// openClientState gives clientID a confirmed open so that it counts as holding
+// leased state.
+func openClientState(t *testing.T, sm *StateManager, clientID uint64, owner string, fh []byte) {
+	t.Helper()
+
+	if _, err := sm.OpenFile(
+		clientID, []byte(owner), 1, fh,
+		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE,
+		types.CLAIM_NULL,
+	); err != nil {
+		t.Fatalf("OpenFile: %v", err)
 	}
 }
 
@@ -270,6 +313,7 @@ func TestSetClientID_RebootPrincipalMismatchReturnsClientIDInUse(t *testing.T) {
 	if err := sm.ConfirmClientID(r1.ClientID, r1.ConfirmVerifier); err != nil {
 		t.Fatalf("ConfirmClientID failed: %v", err)
 	}
+	openClientState(t, sm, r1.ClientID, "reboot-hijack-owner", []byte("reboot-target-file"))
 
 	// Case 3 (different verifier = reboot) from a DIFFERENT principal -> CLID_INUSE.
 	verifier2 := [8]byte{9, 10, 11, 12, 13, 14, 15, 16}

--- a/internal/adapter/nfs/v4/state/clientid_validation_test.go
+++ b/internal/adapter/nfs/v4/state/clientid_validation_test.go
@@ -1,11 +1,13 @@
 package state
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
 // TestConfirmClientID_RebootReleasesPreviousIncarnationState covers the purge
@@ -94,5 +96,51 @@ func TestRenewLease_ForgottenClientIDIsExpiredNotStale(t *testing.T) {
 	}
 	if err := sm.RenewLease(0, "uid:0"); !errors.Is(err, ErrStaleClientID) {
 		t.Errorf("RENEW for client ID 0: got %v, want ErrStaleClientID", err)
+	}
+}
+
+// TestSetClientID_LockOnlyStateStillBlocksAnotherPrincipal covers the gap
+// between "holds an open" and "holds state". LOCK takes the lock-owner's
+// client ID from the wire and does not require it to match the client that
+// owns the open the lock hangs from, so a client can hold a live byte-range
+// lock while owning no open state of its own. That is still leased state a
+// SETCLIENTID from another principal would cancel.
+func TestSetClientID_LockOnlyStateStillBlocksAnotherPrincipal(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	defer sm.Shutdown()
+	sm.SetLockManager(lock.NewManager())
+
+	cb := CallbackInfo{Program: 0x40000000, NetID: "tcp", Addr: "10.0.0.1.8.1"}
+	fh := []byte("lock-only-fh")
+
+	// The client that owns the open, under one principal.
+	opener, err := sm.SetClientID("lock-only-opener", [8]byte{1}, cb, "10.0.0.1:1", "uid:1000")
+	if err != nil {
+		t.Fatalf("SetClientID(opener): %v", err)
+	}
+	if err := sm.ConfirmClientID(opener.ClientID, opener.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID(opener): %v", err)
+	}
+	open, err := sm.OpenFile(opener.ClientID, []byte("open-owner"), 1, fh,
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+
+	// A second client, holding only the lock.
+	locker, err := sm.SetClientID("lock-only-locker", [8]byte{2}, cb, "10.0.0.2:2", "uid:2000")
+	if err != nil {
+		t.Fatalf("SetClientID(locker): %v", err)
+	}
+	if err := sm.ConfirmClientID(locker.ClientID, locker.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID(locker): %v", err)
+	}
+	if _, err := sm.LockNew(context.Background(), locker.ClientID, []byte("lock-owner"), 1,
+		&open.Stateid, 2, fh, types.WRITE_LT, 0, 100, false); err != nil {
+		t.Fatalf("LockNew: %v", err)
+	}
+
+	if _, err := sm.SetClientID("lock-only-locker", [8]byte{2}, cb, "10.0.0.3:3", "uid:9999"); !errors.Is(err, ErrClientIDInUse) {
+		t.Errorf("SETCLIENTID from another principal against a lock-holding client ID: got %v, want ErrClientIDInUse", err)
 	}
 }

--- a/internal/adapter/nfs/v4/state/clientid_validation_test.go
+++ b/internal/adapter/nfs/v4/state/clientid_validation_test.go
@@ -1,0 +1,98 @@
+package state
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+)
+
+// TestConfirmClientID_RebootReleasesPreviousIncarnationState covers the purge
+// RFC 7530 Section 9.1.1 attaches to the confirm that replaces a confirmed
+// record: the previous incarnation's opens, locks and delegations go with the
+// record, and a stateid it held answers NFS4ERR_EXPIRED rather than still
+// working.
+//
+// Forgetting only the record leaves every file it opened share-reserved and
+// byte-range locked on behalf of an incarnation that will never close them.
+func TestConfirmClientID_RebootReleasesPreviousIncarnationState(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	defer sm.Shutdown()
+
+	cb := CallbackInfo{Program: 0x40000000, NetID: "tcp", Addr: "10.0.0.1.8.1"}
+	fh := []byte("reboot-fh")
+
+	first, err := sm.SetClientID("rebooter", [8]byte{1}, cb, "10.0.0.1:1", "uid:0")
+	if err != nil {
+		t.Fatalf("SetClientID: %v", err)
+	}
+	if err := sm.ConfirmClientID(first.ClientID, first.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID: %v", err)
+	}
+
+	open, err := sm.OpenFile(first.ClientID, []byte("owner"), 1, fh,
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_BOTH, types.CLAIM_NULL)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	stale := open.Stateid
+
+	// Same id string, different verifier: a reboot. Confirming it replaces the
+	// record established above.
+	second, err := sm.SetClientID("rebooter", [8]byte{2}, cb, "10.0.0.1:1", "uid:0")
+	if err != nil {
+		t.Fatalf("SetClientID after reboot: %v", err)
+	}
+	if err := sm.ConfirmClientID(second.ClientID, second.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID after reboot: %v", err)
+	}
+
+	if _, err := sm.CloseFile(&stale, 2); !errors.Is(err, ErrExpired) {
+		t.Errorf("CLOSE with the pre-reboot stateid: got %v, want ErrExpired", err)
+	}
+
+	// The share reservation went with it, so the file is openable again.
+	if _, err := sm.OpenFile(second.ClientID, []byte("owner2"), 1, fh,
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL); err != nil {
+		t.Errorf("OPEN after the reboot purge: got %v, want success", err)
+	}
+}
+
+// TestRenewLease_ForgottenClientIDIsExpiredNotStale pins the distinction RFC
+// 7530 Section 16.28.5 draws between the two ways a client ID goes unmatched.
+// An id this boot minted and has since released is NFS4ERR_EXPIRED, which
+// tells the client its lease lapsed; answering NFS4ERR_STALE_CLIENTID instead
+// tells it the server rebooted, which is a different and much larger recovery.
+func TestRenewLease_ForgottenClientIDIsExpiredNotStale(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	defer sm.Shutdown()
+
+	res, err := sm.SetClientID("renewer", [8]byte{1}, CallbackInfo{}, "10.0.0.1:1", "uid:0")
+	if err != nil {
+		t.Fatalf("SetClientID: %v", err)
+	}
+	if err := sm.ConfirmClientID(res.ClientID, res.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID: %v", err)
+	}
+
+	// Drop the record the way a lapsed lease does.
+	sm.RemoveClient(res.ClientID)
+
+	if err := sm.RenewLease(res.ClientID, "uid:0"); !errors.Is(err, ErrExpired) {
+		t.Errorf("RENEW for a released client ID from this boot: got %v, want ErrExpired", err)
+	}
+	if err := sm.ValidateAndRenewClient(res.ClientID); !errors.Is(err, ErrExpired) {
+		t.Errorf("ValidateAndRenewClient for a released client ID from this boot: got %v, want ErrExpired", err)
+	}
+
+	// An id no boot of this server could have issued stays STALE_CLIENTID:
+	// the client must re-run SETCLIENTID rather than reclaim.
+	otherBoot := uint64(sm.BootEpoch()+1)<<32 | 1
+	if err := sm.RenewLease(otherBoot, "uid:0"); !errors.Is(err, ErrStaleClientID) {
+		t.Errorf("RENEW for a client ID from another boot: got %v, want ErrStaleClientID", err)
+	}
+	if err := sm.RenewLease(0, "uid:0"); !errors.Is(err, ErrStaleClientID) {
+		t.Errorf("RENEW for client ID 0: got %v, want ErrStaleClientID", err)
+	}
+}

--- a/internal/adapter/nfs/v4/state/courtesy_test.go
+++ b/internal/adapter/nfs/v4/state/courtesy_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -11,7 +12,7 @@ import (
 
 // The lease these tests run under is short enough to lapse inside the test and
 // long enough that nothing lapses while the setup is still running.
-const courtesyLease = 40 * time.Millisecond
+const courtesyLease = 250 * time.Millisecond
 
 // courtesyClient registers a v4.1 client, confirms it with a session, and
 // returns its client ID. A v4.1 client's state outlives its lease until a
@@ -59,7 +60,7 @@ func TestOpen_ConflictExpiresLapsedShareReservation(t *testing.T) {
 	// While the lease is live the reservation is enforced.
 	newcomer := courtesyClient(t, sm, "courtesy-newcomer")
 	if _, err := sm.OpenFile(newcomer, []byte("newcomer-owner"), 0, fh,
-		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL); err != ErrShareDenied {
+		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL); !errors.Is(err, ErrShareDenied) {
 		t.Fatalf("OPEN against a live share reservation: got %v, want ErrShareDenied", err)
 	}
 
@@ -145,7 +146,7 @@ func TestOpen_ConflictKeepsLiveShareReservation(t *testing.T) {
 
 	newcomer := courtesyClient(t, sm, "mixed-newcomer")
 	if _, err := sm.OpenFile(newcomer, []byte("newcomer-owner"), 0, fh,
-		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL); err != ErrShareDenied {
+		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL); !errors.Is(err, ErrShareDenied) {
 		t.Errorf("OPEN against a live reservation held alongside a lapsed one: got %v, want ErrShareDenied", err)
 	}
 }

--- a/internal/adapter/nfs/v4/state/courtesy_test.go
+++ b/internal/adapter/nfs/v4/state/courtesy_test.go
@@ -1,0 +1,151 @@
+package state
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// The lease these tests run under is short enough to lapse inside the test and
+// long enough that nothing lapses while the setup is still running.
+const courtesyLease = 40 * time.Millisecond
+
+// courtesyClient registers a v4.1 client, confirms it with a session, and
+// returns its client ID. A v4.1 client's state outlives its lease until a
+// sweeper collects it, which is the courtesy window these tests exercise: the
+// session reaper is never started here, so nothing but a conflicting request
+// can release the state.
+func courtesyClient(t *testing.T, sm *StateManager, ownerID string) uint64 {
+	t.Helper()
+
+	var verifier [8]byte
+	copy(verifier[:], "verify01")
+
+	res, err := sm.ExchangeID([]byte(ownerID), verifier, 0, nil, "10.0.0.1:12345")
+	if err != nil {
+		t.Fatalf("ExchangeID(%s): %v", ownerID, err)
+	}
+	if _, _, err := sm.CreateSession(res.ClientID, res.SequenceID, 0,
+		defaultForeAttrs(), defaultBackAttrs(), 0, nil); err != nil {
+		t.Fatalf("CreateSession(%s): %v", ownerID, err)
+	}
+	return res.ClientID
+}
+
+// TestOpen_ConflictExpiresLapsedShareReservation covers a courtesy client's
+// share reservation meeting a conflicting OPEN. Holding the reservation past
+// the lease is what makes the server courteous; enforcing it against another
+// client once the lease has run out is not courtesy but a refusal on behalf of
+// a client that is gone.
+//
+// Nothing here waits for a sweeper, which is the point: with the release
+// driven by the sweep instead of by the conflict, the same OPEN succeeds or
+// fails depending on where in the sweep interval it lands.
+func TestOpen_ConflictExpiresLapsedShareReservation(t *testing.T) {
+	sm := NewStateManager(courtesyLease)
+	defer sm.Shutdown()
+
+	fh := []byte("courtesy-share-fh")
+	holder := courtesyClient(t, sm, "courtesy-holder")
+
+	if _, err := sm.OpenFile(holder, []byte("holder-owner"), 0, fh,
+		types.OPEN4_SHARE_ACCESS_WRITE, types.OPEN4_SHARE_DENY_READ, types.CLAIM_NULL); err != nil {
+		t.Fatalf("holder OpenFile: %v", err)
+	}
+
+	// While the lease is live the reservation is enforced.
+	newcomer := courtesyClient(t, sm, "courtesy-newcomer")
+	if _, err := sm.OpenFile(newcomer, []byte("newcomer-owner"), 0, fh,
+		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL); err != ErrShareDenied {
+		t.Fatalf("OPEN against a live share reservation: got %v, want ErrShareDenied", err)
+	}
+
+	time.Sleep(2 * courtesyLease)
+
+	if _, err := sm.OpenFile(newcomer, []byte("newcomer-owner"), 0, fh,
+		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL); err != nil {
+		t.Errorf("OPEN against a lapsed client's share reservation: got %v, want success", err)
+	}
+}
+
+// TestLock_ConflictExpiresLapsedByteRangeLock is the same rule for byte-range
+// locks, which are held in the cross-protocol lock manager rather than in the
+// share-reservation index, and so are released by a different path.
+func TestLock_ConflictExpiresLapsedByteRangeLock(t *testing.T) {
+	sm := NewStateManager(courtesyLease)
+	defer sm.Shutdown()
+	sm.SetLockManager(lock.NewManager())
+
+	fh := []byte("courtesy-lock-fh")
+
+	holder := courtesyClient(t, sm, "lock-holder")
+	holderOpen, err := sm.OpenFile(holder, []byte("holder-owner"), 0, fh,
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
+	if err != nil {
+		t.Fatalf("holder OpenFile: %v", err)
+	}
+	if _, err := sm.LockNew(context.Background(), holder, []byte("holder-lock-owner"), 0,
+		&holderOpen.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false); err != nil {
+		t.Fatalf("holder LockNew: %v", err)
+	}
+
+	newcomer := courtesyClient(t, sm, "lock-newcomer")
+	newcomerOpen, err := sm.OpenFile(newcomer, []byte("newcomer-owner"), 0, fh,
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
+	if err != nil {
+		t.Fatalf("newcomer OpenFile: %v", err)
+	}
+
+	// While the lease is live the lock is enforced.
+	res, err := sm.LockNew(context.Background(), newcomer, []byte("newcomer-lock-owner"), 0,
+		&newcomerOpen.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false)
+	if err != nil {
+		t.Fatalf("newcomer LockNew against a live lock: %v", err)
+	}
+	if res.Denied == nil {
+		t.Fatal("LOCK against a live conflicting lock: got success, want LOCK4denied")
+	}
+
+	time.Sleep(2 * courtesyLease)
+
+	res, err = sm.LockNew(context.Background(), newcomer, []byte("newcomer-lock-owner-2"), 0,
+		&newcomerOpen.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false)
+	if err != nil {
+		t.Fatalf("newcomer LockNew after the holder's lease lapsed: %v", err)
+	}
+	if res.Denied != nil {
+		t.Errorf("LOCK against a lapsed client's lock: got LOCK4denied, want success")
+	}
+}
+
+// A conflict must not reach past the lapsed clients: a live client's
+// reservation stays enforced even when a dead one is released alongside it.
+func TestOpen_ConflictKeepsLiveShareReservation(t *testing.T) {
+	sm := NewStateManager(courtesyLease)
+	defer sm.Shutdown()
+
+	fh := []byte("courtesy-mixed-fh")
+	lapsed := courtesyClient(t, sm, "mixed-lapsed")
+
+	if _, err := sm.OpenFile(lapsed, []byte("lapsed-owner"), 0, fh,
+		types.OPEN4_SHARE_ACCESS_WRITE, types.OPEN4_SHARE_DENY_READ, types.CLAIM_NULL); err != nil {
+		t.Fatalf("lapsed OpenFile: %v", err)
+	}
+	time.Sleep(2 * courtesyLease)
+
+	// Established after the first client's lease ran out, so this one is live.
+	live := courtesyClient(t, sm, "mixed-live")
+	if _, err := sm.OpenFile(live, []byte("live-owner"), 0, fh,
+		types.OPEN4_SHARE_ACCESS_WRITE, types.OPEN4_SHARE_DENY_READ, types.CLAIM_NULL); err != nil {
+		t.Fatalf("live OpenFile: %v", err)
+	}
+
+	newcomer := courtesyClient(t, sm, "mixed-newcomer")
+	if _, err := sm.OpenFile(newcomer, []byte("newcomer-owner"), 0, fh,
+		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL); err != ErrShareDenied {
+		t.Errorf("OPEN against a live reservation held alongside a lapsed one: got %v, want ErrShareDenied", err)
+	}
+}

--- a/internal/adapter/nfs/v4/state/courtesy_test.go
+++ b/internal/adapter/nfs/v4/state/courtesy_test.go
@@ -36,6 +36,45 @@ func courtesyClient(t *testing.T, sm *StateManager, ownerID string) uint64 {
 	return res.ClientID
 }
 
+// waitLeaseLapsed blocks until clientID's lease has run out, polling the same
+// predicate the production paths branch on rather than sleeping for a guessed
+// interval. A stalled runner makes it wait longer, never makes it proceed
+// early.
+func waitLeaseLapsed(t *testing.T, sm *StateManager, clientID uint64) {
+	t.Helper()
+
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		sm.mu.Lock()
+		lapsed := sm.clientLeaseLapsedLocked(clientID)
+		sm.mu.Unlock()
+		if lapsed {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("client %d lease still live after 30s (lease is %s)", clientID, courtesyLease)
+		}
+		time.Sleep(courtesyLease / 10)
+	}
+}
+
+// renewLease puts a client's lease back to full. Tests that need one client to
+// stay live while another lapses call this immediately before asserting: the
+// live client's lease is the same short one, so any stall between establishing
+// it and the assertion would otherwise lapse it too and the test would fail
+// for a reason it is not about.
+func renewLease(t *testing.T, sm *StateManager, clientID uint64) {
+	t.Helper()
+
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	record, ok := sm.v41ClientsByID[clientID]
+	if !ok || record.Lease == nil {
+		t.Fatalf("no v4.1 lease for client %d", clientID)
+	}
+	record.Lease.Renew()
+}
+
 // TestOpen_ConflictExpiresLapsedShareReservation covers a courtesy client's
 // share reservation meeting a conflicting OPEN. Holding the reservation past
 // the lease is what makes the server courteous; enforcing it against another
@@ -64,7 +103,7 @@ func TestOpen_ConflictExpiresLapsedShareReservation(t *testing.T) {
 		t.Fatalf("OPEN against a live share reservation: got %v, want ErrShareDenied", err)
 	}
 
-	time.Sleep(2 * courtesyLease)
+	waitLeaseLapsed(t, sm, holder)
 
 	if _, err := sm.OpenFile(newcomer, []byte("newcomer-owner"), 0, fh,
 		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL); err != nil {
@@ -110,7 +149,7 @@ func TestLock_ConflictExpiresLapsedByteRangeLock(t *testing.T) {
 		t.Fatal("LOCK against a live conflicting lock: got success, want LOCK4denied")
 	}
 
-	time.Sleep(2 * courtesyLease)
+	waitLeaseLapsed(t, sm, holder)
 
 	res, err = sm.LockNew(context.Background(), newcomer, []byte("newcomer-lock-owner-2"), 0,
 		&newcomerOpen.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false)
@@ -135,7 +174,7 @@ func TestOpen_ConflictKeepsLiveShareReservation(t *testing.T) {
 		types.OPEN4_SHARE_ACCESS_WRITE, types.OPEN4_SHARE_DENY_READ, types.CLAIM_NULL); err != nil {
 		t.Fatalf("lapsed OpenFile: %v", err)
 	}
-	time.Sleep(2 * courtesyLease)
+	waitLeaseLapsed(t, sm, lapsed)
 
 	// Established after the first client's lease ran out, so this one is live.
 	live := courtesyClient(t, sm, "mixed-live")
@@ -145,6 +184,7 @@ func TestOpen_ConflictKeepsLiveShareReservation(t *testing.T) {
 	}
 
 	newcomer := courtesyClient(t, sm, "mixed-newcomer")
+	renewLease(t, sm, live)
 	if _, err := sm.OpenFile(newcomer, []byte("newcomer-owner"), 0, fh,
 		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL); !errors.Is(err, ErrShareDenied) {
 		t.Errorf("OPEN against a live reservation held alongside a lapsed one: got %v, want ErrShareDenied", err)
@@ -215,14 +255,12 @@ func TestLock_ConflictExpiresLapsedCrossClientLock(t *testing.T) {
 	locker := courtesyClient(t, sm, "conflict-locker")
 	lockAcrossClients(t, sm, opener, locker, fh, "b")
 
-	time.Sleep(2 * courtesyLease)
+	waitLeaseLapsed(t, sm, locker)
 
 	// Only the lock-owner's client is allowed to lapse. If the open's owner
 	// lapses too, the sweep reaches the lock through that client's open and
 	// the test passes whether or not lock-owners are considered at all.
-	sm.mu.Lock()
-	sm.v41ClientsByID[opener].Lease.Renew()
-	sm.mu.Unlock()
+	renewLease(t, sm, opener)
 
 	newcomer := courtesyClient(t, sm, "conflict-newcomer")
 	newcomerOpen, err := sm.OpenFile(newcomer, []byte("newcomer-owner"), 0, fh,

--- a/internal/adapter/nfs/v4/state/courtesy_test.go
+++ b/internal/adapter/nfs/v4/state/courtesy_test.go
@@ -150,3 +150,93 @@ func TestOpen_ConflictKeepsLiveShareReservation(t *testing.T) {
 		t.Errorf("OPEN against a live reservation held alongside a lapsed one: got %v, want ErrShareDenied", err)
 	}
 }
+
+// lockAcrossClients has locker take a byte-range lock on an open owned by
+// opener, which LOCK permits: the lock-owner's client ID comes off the wire
+// and need not match the client owning the open.
+func lockAcrossClients(t *testing.T, sm *StateManager, opener, locker uint64, fh []byte, owner string) types.Stateid4 {
+	t.Helper()
+
+	open, err := sm.OpenFile(opener, []byte("open-owner-"+owner), 0, fh,
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	res, err := sm.LockNew(context.Background(), locker, []byte("lock-owner-"+owner), 0,
+		&open.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false)
+	if err != nil {
+		t.Fatalf("LockNew: %v", err)
+	}
+	if res.Denied != nil {
+		t.Fatalf("LockNew: got LOCK4denied, want success")
+	}
+	return open.Stateid
+}
+
+// TestExpireClient_ReleasesLocksHeldOnAnotherClientsOpen covers the lock a
+// client holds on an open it does not own. Reaching a client's locks through
+// its own opens misses those, and a lock left in the cross-protocol lock
+// manager after its owner is gone has nothing left that could unlock it.
+func TestExpireClient_ReleasesLocksHeldOnAnotherClientsOpen(t *testing.T) {
+	sm := NewStateManager(courtesyLease)
+	defer sm.Shutdown()
+	lm := lock.NewManager()
+	sm.SetLockManager(lm)
+
+	fh := []byte("cross-client-lock-fh")
+	opener := courtesyClient(t, sm, "cross-opener")
+	locker := courtesyClient(t, sm, "cross-locker")
+	lockAcrossClients(t, sm, opener, locker, fh, "a")
+
+	if got := len(lm.ListUnifiedLocks(string(fh))); got != 1 {
+		t.Fatalf("locks held before expiry = %d, want 1", got)
+	}
+
+	sm.mu.Lock()
+	sm.releaseClientStateLocked(locker)
+	sm.mu.Unlock()
+
+	if got := len(lm.ListUnifiedLocks(string(fh))); got != 0 {
+		t.Errorf("locks still held after the lock-owner's client was released = %d, want 0", got)
+	}
+}
+
+// TestLock_ConflictExpiresLapsedCrossClientLock is the same asymmetry on the
+// conflict side: the client whose lease lapsed holds the lock but not the
+// open, so looking only at open-owners leaves its courtesy lock enforced.
+func TestLock_ConflictExpiresLapsedCrossClientLock(t *testing.T) {
+	sm := NewStateManager(courtesyLease)
+	defer sm.Shutdown()
+	sm.SetLockManager(lock.NewManager())
+
+	fh := []byte("cross-client-conflict-fh")
+
+	opener := courtesyClient(t, sm, "conflict-opener")
+	locker := courtesyClient(t, sm, "conflict-locker")
+	lockAcrossClients(t, sm, opener, locker, fh, "b")
+
+	time.Sleep(2 * courtesyLease)
+
+	// Only the lock-owner's client is allowed to lapse. If the open's owner
+	// lapses too, the sweep reaches the lock through that client's open and
+	// the test passes whether or not lock-owners are considered at all.
+	sm.mu.Lock()
+	sm.v41ClientsByID[opener].Lease.Renew()
+	sm.mu.Unlock()
+
+	newcomer := courtesyClient(t, sm, "conflict-newcomer")
+	newcomerOpen, err := sm.OpenFile(newcomer, []byte("newcomer-owner"), 0, fh,
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
+	if err != nil {
+		t.Fatalf("newcomer OpenFile: %v", err)
+	}
+
+	res, err := sm.LockNew(context.Background(), newcomer, []byte("newcomer-lock-owner"), 0,
+		&newcomerOpen.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false)
+	if err != nil {
+		t.Fatalf("newcomer LockNew: %v", err)
+	}
+	if res.Denied != nil {
+		t.Errorf("LOCK against a lapsed lock-owner's lock on another client's open: got LOCK4denied, want success")
+	}
+}

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -1032,6 +1032,12 @@ func (sm *StateManager) clientLeaseLapsedLocked(clientID uint64) bool {
 func (sm *StateManager) expireLapsedHoldersLocked(fileHandle []byte, keepClientIDs ...uint64) {
 	// Collected before anything is released: expiring a client rewrites the
 	// index this ranges over.
+	//
+	// ponytail: linear scans of a slice rather than two sets. n is the distinct
+	// clients holding state on ONE file, which is one or two outside a
+	// share-reservation fight, and the allocation two maps would add lands on
+	// every OPEN and LOCK. Switch to sets if a file ever collects enough
+	// simultaneous holders for this to show up in a profile.
 	var lapsed []uint64
 	consider := func(clientID uint64) {
 		if slices.Contains(keepClientIDs, clientID) || slices.Contains(lapsed, clientID) {

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -931,6 +931,10 @@ func (sm *StateManager) releaseClientStateLocked(clientID uint64) {
 		if deleg.ClientID != clientID {
 			continue
 		}
+		// Both timers outlive the tables they fire against, so they are
+		// stopped before the delegation leaves them.
+		sm.cleanupDirDelegation(deleg)
+		deleg.StopRecallTimer()
 		sm.deleteDelegByOtherLocked(other)
 		sm.removeDelegFromFile(deleg)
 
@@ -1089,6 +1093,13 @@ func (sm *StateManager) expireV40ClientLocked(clientID uint64) {
 		"client_id", clientID,
 		"client_id_str", record.ClientIDString,
 		"client_addr", record.ClientAddr)
+
+	// The timer is already spent when its own callback brought us here, but a
+	// conflicting request can expire a lapsed client while the timer is still
+	// armed, and a later fire would look up a client that no longer exists.
+	if record.Lease != nil {
+		record.Lease.Stop()
+	}
 
 	// The client's lease lapsed without renewal: it no longer holds reclaimable
 	// state, so drop its durable recovery record. Best-effort; no-op

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -413,13 +413,13 @@ func firstOrEmpty(ss []string) string {
 // that another principal's SETCLIENTID would cancel: an open (byte-range locks
 // hang off one) or a delegation, under a lease that has not lapsed.
 //
-// This is what makes the principal check in Section 16.33.5 conditional.
-// Section 9.1.2 spells the condition out: when a SETCLIENTID arrives "for a
-// client ID that currently has no state, or it has state but the lease has
-// expired, rather than returning NFS4ERR_CLID_INUSE, the server MUST allow the
-// SETCLIENTID". The security rule the check exists for is the MUST NOT in
-// Section 9.1.1 against cancelling leased state established by a different
-// principal, and a record holding none has nothing to cancel.
+// This is what makes the principal check in RFC 7530 Section 16.33.5
+// conditional. Section 9.1.2 spells the condition out: when a SETCLIENTID
+// arrives "for a client ID that currently has no state, or it has state but
+// the lease has expired, rather than returning NFS4ERR_CLID_INUSE, the server
+// MUST allow the SETCLIENTID". The security rule the check exists for is the
+// MUST NOT in Section 9.1.1 against cancelling leased state established by a
+// different principal, and a record holding none has nothing to cancel.
 //
 // Refusing unconditionally makes a client id string permanently unusable by
 // every other principal once one has touched it. Clients derive that string
@@ -444,11 +444,13 @@ func (sm *StateManager) clientHasLiveStateLocked(clientID uint64) bool {
 	return false
 }
 
-// unknownClientIDError answers a client ID that no record matches. RFC 7530
-// Section 16.28.5 separates the two ways that happens: an id this boot of the
-// server minted and has since released is NFS4ERR_EXPIRED, which tells the
-// client its lease lapsed and its state is gone, while an id no boot of this
-// server could have issued is NFS4ERR_STALE_CLIENTID. generateClientID puts
+// unknownClientIDError answers a client ID that no record matches. There are
+// two ways that happens and they call for different errors. RFC 7530 Section
+// 9.6.3.2 covers the first: once a lease is cancelled, "the use of the
+// associated clientid will result in NFS4ERR_EXPIRED being returned", telling
+// the client its state is gone and a new client id is what it needs. An id no
+// boot of this server could have issued means something else entirely -- the
+// server restarted -- and stays NFS4ERR_STALE_CLIENTID. generateClientID puts
 // the boot epoch in the high 32 bits, which is what keeps the two apart.
 //
 // Answering STALE_CLIENTID for both makes a client that merely fell behind on
@@ -959,13 +961,16 @@ func (sm *StateManager) clientLeaseLapsedLocked(clientID uint64) bool {
 //
 // What keeps an expired client's opens and locks alive is courtesy: a client
 // that merely lost contact for a moment should not come back to find its locks
-// broken, so the state outlives the lease and a sweeper collects it later. The
-// courtesy is owed to nobody once another client's request actually collides
-// with that state, and the collision is the only event that says so. Deciding
-// the conflict on the sweeper's schedule instead refuses a request that
-// nothing live objects to, for however much of the sweep interval is left --
-// which is why the same request is granted or refused depending on when it
-// arrives.
+// broken, so the state outlives the lease and a sweeper collects it later.
+// RFC 7530 Section 9.6.3.1 says what happens when someone else then wants the
+// file: on "a lock or I/O request that conflicts with one of the courtesy
+// locks", a courtesy lock that is not a delegation "MUST free the courtesy
+// lock and grant the new request".
+//
+// So the collision, not the sweeper's schedule, is what ends the courtesy.
+// Deferring to the sweep refuses a request that nothing live objects to, for
+// however much of the sweep interval is left, which is why the same request is
+// granted or refused depending on when it arrives.
 //
 // Caller must hold sm.mu.
 func (sm *StateManager) expireLapsedHoldersLocked(fileHandle []byte, keepClientIDs ...uint64) {

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -952,9 +952,10 @@ func (sm *StateManager) clientLeaseLapsedLocked(clientID uint64) bool {
 	return false
 }
 
-// expireLapsedHoldersLocked releases the state of every client other than
-// exceptClientID that holds an open on fileHandle under a lease that has
-// already run out.
+// expireLapsedHoldersLocked releases the state of every client that holds an
+// open on fileHandle under a lease that has already run out, except for the
+// clients in keepClientIDs. Callers name every client whose records they are
+// holding a pointer into, since releasing one frees its opens and locks.
 //
 // What keeps an expired client's opens and locks alive is courtesy: a client
 // that merely lost contact for a moment should not come back to find its locks
@@ -967,12 +968,12 @@ func (sm *StateManager) clientLeaseLapsedLocked(clientID uint64) bool {
 // arrives.
 //
 // Caller must hold sm.mu.
-func (sm *StateManager) expireLapsedHoldersLocked(fileHandle []byte, exceptClientID uint64) {
+func (sm *StateManager) expireLapsedHoldersLocked(fileHandle []byte, keepClientIDs ...uint64) {
 	// Collected before anything is released: expiring a client rewrites the
 	// index this ranges over.
 	var lapsed []uint64
 	for _, os := range sm.openStateByFile[string(fileHandle)] {
-		if os.Owner == nil || os.Owner.ClientID == exceptClientID || slices.Contains(lapsed, os.Owner.ClientID) {
+		if os.Owner == nil || slices.Contains(keepClientIDs, os.Owner.ClientID) || slices.Contains(lapsed, os.Owner.ClientID) {
 			continue
 		}
 		if sm.clientLeaseLapsedLocked(os.Owner.ClientID) {
@@ -2642,7 +2643,8 @@ func (sm *StateManager) acquireLock(ctx context.Context, lockState *LockState, l
 	// courtesy state, and this request is the collision that ends the courtesy.
 	// Released here rather than left to the sweeper, the answer no longer
 	// depends on where in the sweep interval the request happened to land.
-	sm.expireLapsedHoldersLocked(lockState.FileHandle, lockState.LockOwner.ClientID)
+	sm.expireLapsedHoldersLocked(lockState.FileHandle,
+		lockState.LockOwner.ClientID, lockState.OpenState.Owner.ClientID)
 
 	// Break any conflicting cross-protocol read leases (e.g. an SMB read/write
 	// oplock) before acquiring the byte-range lock. A held lease lets another

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -924,6 +924,46 @@ func (sm *StateManager) removeClientOpenStateLocked(clientID uint64) {
 	}
 }
 
+// removeClientLockStateLocked frees the byte-range locks clientID holds on
+// opens it does not own. LOCK takes the lock-owner's client ID from the wire
+// and does not require it to match the client owning the open the lock hangs
+// from, so removeClientOpenStateLocked -- which reaches locks through this
+// client's own opens -- does not see these. Left behind, they stay held in the
+// cross-protocol lock manager on behalf of a client that is gone, with nothing
+// left that could ever unlock them.
+//
+// Caller must hold sm.mu.
+func (sm *StateManager) removeClientLockStateLocked(clientID uint64) {
+	for other, lockState := range sm.lockStateByOther {
+		if lockState.LockOwner == nil || lockState.LockOwner.ClientID != clientID {
+			continue
+		}
+
+		sm.removeOwnerLocksLocked(lockState)
+		delete(sm.lockStateByOther, other)
+		delete(sm.lockOwners, lockState.LockOwner.Key())
+		detachLockStateFromOpen(lockState)
+	}
+}
+
+// detachLockStateFromOpen drops a lock state from the open state it hangs off,
+// so the open does not keep reporting a lock that is gone.
+func detachLockStateFromOpen(lockState *LockState) {
+	if lockState.OpenState == nil {
+		return
+	}
+	for i, ls := range lockState.OpenState.LockStates {
+		if ls != lockState {
+			continue
+		}
+		lockState.OpenState.LockStates = append(
+			lockState.OpenState.LockStates[:i],
+			lockState.OpenState.LockStates[i+1:]...,
+		)
+		return
+	}
+}
+
 // releaseClientStateLocked frees every open, lock and delegation held by
 // clientID, first remembering the stateids so that a client which comes back
 // and uses one is told its lease expired rather than told the stateid was
@@ -936,6 +976,7 @@ func (sm *StateManager) removeClientOpenStateLocked(clientID uint64) {
 func (sm *StateManager) releaseClientStateLocked(clientID uint64) {
 	sm.markClientStateidsExpiredLocked(clientID)
 	sm.removeClientOpenStateLocked(clientID)
+	sm.removeClientLockStateLocked(clientID)
 
 	for other, deleg := range sm.delegByOther {
 		if deleg.ClientID != clientID {
@@ -992,12 +1033,24 @@ func (sm *StateManager) expireLapsedHoldersLocked(fileHandle []byte, keepClientI
 	// Collected before anything is released: expiring a client rewrites the
 	// index this ranges over.
 	var lapsed []uint64
-	for _, os := range sm.openStateByFile[string(fileHandle)] {
-		if os.Owner == nil || slices.Contains(keepClientIDs, os.Owner.ClientID) || slices.Contains(lapsed, os.Owner.ClientID) {
-			continue
+	consider := func(clientID uint64) {
+		if slices.Contains(keepClientIDs, clientID) || slices.Contains(lapsed, clientID) {
+			return
 		}
-		if sm.clientLeaseLapsedLocked(os.Owner.ClientID) {
-			lapsed = append(lapsed, os.Owner.ClientID)
+		if sm.clientLeaseLapsedLocked(clientID) {
+			lapsed = append(lapsed, clientID)
+		}
+	}
+	for _, os := range sm.openStateByFile[string(fileHandle)] {
+		if os.Owner != nil {
+			consider(os.Owner.ClientID)
+		}
+		// The lock-owner's client can differ from the open-owner's, and it is
+		// the one holding the lock this request may be colliding with.
+		for _, lockState := range os.LockStates {
+			if lockState.LockOwner != nil {
+				consider(lockState.LockOwner.ClientID)
+			}
 		}
 	}
 
@@ -1038,6 +1091,12 @@ func (sm *StateManager) markClientStateidsExpiredLocked(clientID uint64) {
 			for _, lockState := range openState.LockStates {
 				sm.expiredStateids[lockState.Stateid.Other] = struct{}{}
 			}
+		}
+	}
+
+	for other, lockState := range sm.lockStateByOther {
+		if lockState.LockOwner != nil && lockState.LockOwner.ClientID == clientID {
+			sm.expiredStateids[other] = struct{}{}
 		}
 	}
 

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -408,6 +408,57 @@ func firstOrEmpty(ss []string) string {
 	return ""
 }
 
+// clientHasLiveStateLocked reports whether clientID still holds leased state
+// that another principal's SETCLIENTID would cancel: an open (byte-range locks
+// hang off one) or a delegation, under a lease that has not lapsed.
+//
+// This is what makes the principal check in Section 16.33.5 conditional.
+// Section 9.1.2 spells the condition out: when a SETCLIENTID arrives "for a
+// client ID that currently has no state, or it has state but the lease has
+// expired, rather than returning NFS4ERR_CLID_INUSE, the server MUST allow the
+// SETCLIENTID". The security rule the check exists for is the MUST NOT in
+// Section 9.1.1 against cancelling leased state established by a different
+// principal, and a record holding none has nothing to cancel.
+//
+// Refusing unconditionally makes a client id string permanently unusable by
+// every other principal once one has touched it. Clients derive that string
+// from the hostname rather than from their credential, so a second user on the
+// same host would never get a client id at all.
+//
+// Caller must hold sm.mu.
+func (sm *StateManager) clientHasLiveStateLocked(clientID uint64) bool {
+	if record := sm.clientsByID[clientID]; record != nil && record.Lease != nil && record.Lease.IsExpired() {
+		return false
+	}
+	for _, owner := range sm.openOwners {
+		if owner.ClientID == clientID && len(owner.OpenStates) > 0 {
+			return true
+		}
+	}
+	for _, deleg := range sm.delegByOther {
+		if deleg.ClientID == clientID {
+			return true
+		}
+	}
+	return false
+}
+
+// unknownClientIDError answers a client ID that no record matches. RFC 7530
+// Section 16.28.5 separates the two ways that happens: an id this boot of the
+// server minted and has since released is NFS4ERR_EXPIRED, which tells the
+// client its lease lapsed and its state is gone, while an id no boot of this
+// server could have issued is NFS4ERR_STALE_CLIENTID. generateClientID puts
+// the boot epoch in the high 32 bits, which is what keeps the two apart.
+//
+// Answering STALE_CLIENTID for both makes a client that merely fell behind on
+// RENEW conclude the server rebooted.
+func (sm *StateManager) unknownClientIDError(clientID uint64) error {
+	if uint32(clientID>>32) == sm.bootEpoch {
+		return ErrExpired
+	}
+	return ErrStaleClientID
+}
+
 // createNewClient handles Case 1: completely new client.
 // Creates a new unconfirmed record with a fresh client ID and confirm verifier.
 // Caller must hold sm.mu.
@@ -450,8 +501,8 @@ func (sm *StateManager) createNewClient(clientIDStr string, verifier [8]byte, ca
 func (sm *StateManager) reuseConfirmedClient(confirmed *ClientRecord, clientIDStr string, verifier [8]byte, callback CallbackInfo, clientAddr, principal string) (*SetClientIDResult, error) {
 	// Reject a re-SETCLIENTID by anyone but the principal that established the
 	// confirmed record: it would hijack the client's lease and state. See
-	// principalHijacks.
-	if principalHijacks(confirmed.Principal, principal) {
+	// principalHijacks and clientHasLiveStateLocked.
+	if principalHijacks(confirmed.Principal, principal) && sm.clientHasLiveStateLocked(confirmed.ClientID) {
 		return nil, ErrClientIDInUse
 	}
 
@@ -505,9 +556,9 @@ func (sm *StateManager) reuseConfirmedClient(confirmed *ClientRecord, clientIDSt
 func (sm *StateManager) handleClientReboot(clientIDStr string, verifier [8]byte, callback CallbackInfo, clientAddr, principal string) (*SetClientIDResult, error) {
 	// A reboot (different verifier) claimed by anyone but the principal that
 	// established the confirmed record is a hijack attempt, not a real reboot.
-	// See principalHijacks.
+	// See principalHijacks and clientHasLiveStateLocked.
 	if confirmed := sm.clientsByName[clientIDStr]; confirmed != nil {
-		if principalHijacks(confirmed.Principal, principal) {
+		if principalHijacks(confirmed.Principal, principal) && sm.clientHasLiveStateLocked(confirmed.ClientID) {
 			return nil, ErrClientIDInUse
 		}
 	}
@@ -664,6 +715,13 @@ func (sm *StateManager) ConfirmClientID(clientID uint64, confirmVerifier [8]byte
 		if oldConfirmed.Lease != nil {
 			oldConfirmed.Lease.Stop()
 		}
+		// The client rebooted: RFC 7530 Section 9.1.1 has this confirm release
+		// the previous incarnation's locks, opens and delegations, not just
+		// forget the record that owned them. Leaving the state behind keeps
+		// every stateid the client held before the reboot working, so the
+		// files stay share-reserved and byte-range locked on behalf of an
+		// incarnation that no longer exists and will never close them.
+		sm.releaseClientStateLocked(oldConfirmed.ClientID)
 		delete(sm.clientsByID, oldConfirmed.ClientID)
 		logger.Info("SETCLIENTID_CONFIRM: replaced old confirmed client",
 			"old_client_id", oldConfirmed.ClientID,
@@ -779,7 +837,7 @@ func (sm *StateManager) ValidateAndRenewClient(clientID uint64) error {
 	if v41 := sm.v41ClientsByID[clientID]; v41 != nil {
 		return renewConfirmedClient(v41.Confirmed, v41.Lease, &v41.LastRenewal)
 	}
-	return ErrStaleClientID
+	return sm.unknownClientIDError(clientID)
 }
 
 // RemoveClient removes a client record and all associated state.
@@ -849,6 +907,32 @@ func (sm *StateManager) removeClientOpenStateLocked(clientID uint64) {
 		if owner.ClientID == clientID {
 			delete(sm.closedOwnerByOther, other)
 		}
+	}
+}
+
+// releaseClientStateLocked frees every open, lock and delegation held by
+// clientID, first remembering the stateids so that a client which comes back
+// and uses one is told its lease expired rather than told the stateid was
+// never valid.
+//
+// It does not touch the client record itself: the caller knows why the state
+// went away and which maps the record still belongs in.
+//
+// Caller must hold sm.mu.
+func (sm *StateManager) releaseClientStateLocked(clientID uint64) {
+	sm.markClientStateidsExpiredLocked(clientID)
+	sm.removeClientOpenStateLocked(clientID)
+
+	for other, deleg := range sm.delegByOther {
+		if deleg.ClientID != clientID {
+			continue
+		}
+		sm.deleteDelegByOtherLocked(other)
+		sm.removeDelegFromFile(deleg)
+
+		logger.Info("Delegation revoked with the client's state",
+			"client_id", clientID,
+			"deleg_type", deleg.DelegType)
 	}
 }
 
@@ -938,25 +1022,7 @@ func (sm *StateManager) onLeaseExpired(clientID uint64) {
 	// when no recovery store is wired.
 	sm.deleteClientRecoveryLocked(record.ClientIDString)
 
-	// Record what the cleanup below is about to free, so a client that comes
-	// back after the partition and uses one of these stateids is told the lease
-	// expired instead of being told the stateid was never valid.
-	sm.markClientStateidsExpiredLocked(clientID)
-
-	sm.removeClientOpenStateLocked(clientID)
-
-	// Clean up delegations for the expired client
-	for other, deleg := range sm.delegByOther {
-		if deleg.ClientID != clientID {
-			continue
-		}
-		sm.deleteDelegByOtherLocked(other)
-		sm.removeDelegFromFile(deleg)
-
-		logger.Info("Delegation revoked on lease expiry",
-			"client_id", clientID,
-			"deleg_type", deleg.DelegType)
-	}
+	sm.releaseClientStateLocked(clientID)
 
 	// Remove client from all maps
 	delete(sm.clientsByID, clientID)
@@ -2071,7 +2137,7 @@ func (sm *StateManager) RenewLease(clientID uint64, principal ...string) error {
 	// v4.0 only: RENEW does not exist in v4.1, where SEQUENCE renews the lease.
 	record, exists := sm.clientsByID[clientID]
 	if !exists {
-		return ErrStaleClientID
+		return sm.unknownClientIDError(clientID)
 	}
 
 	// Checked before the renewal below: a refused RENEW must leave the lease

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -410,8 +410,13 @@ func firstOrEmpty(ss []string) string {
 }
 
 // clientHasLiveStateLocked reports whether clientID still holds leased state
-// that another principal's SETCLIENTID would cancel: an open (byte-range locks
-// hang off one) or a delegation, under a lease that has not lapsed.
+// that another principal's SETCLIENTID would cancel -- an open, a byte-range
+// lock or a delegation -- under a lease that has not lapsed.
+//
+// Locks are counted separately from opens rather than through them: a lock
+// hangs off an open state, but LOCK takes the lock-owner's client ID from the
+// wire and does not require it to match the client that owns that open, so a
+// client can hold live lock state without owning an open here.
 //
 // This is what makes the principal check in RFC 7530 Section 16.33.5
 // conditional. Section 9.1.2 spells the condition out: when a SETCLIENTID
@@ -433,6 +438,11 @@ func (sm *StateManager) clientHasLiveStateLocked(clientID uint64) bool {
 	}
 	for _, owner := range sm.openOwners {
 		if owner.ClientID == clientID && len(owner.OpenStates) > 0 {
+			return true
+		}
+	}
+	for _, lockState := range sm.lockStateByOther {
+		if lockState.LockOwner != nil && lockState.LockOwner.ClientID == clientID {
 			return true
 		}
 	}

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -427,7 +427,7 @@ func firstOrEmpty(ss []string) string {
 //
 // Caller must hold sm.mu.
 func (sm *StateManager) clientHasLiveStateLocked(clientID uint64) bool {
-	if record := sm.clientsByID[clientID]; record != nil && record.Lease != nil && record.Lease.IsExpired() {
+	if sm.clientLeaseLapsedLocked(clientID) {
 		return false
 	}
 	for _, owner := range sm.openOwners {
@@ -936,6 +936,70 @@ func (sm *StateManager) releaseClientStateLocked(clientID uint64) {
 	}
 }
 
+// clientLeaseLapsedLocked reports whether a confirmed client's lease has run
+// out. Both client generations are checked: the caller has a client ID and no
+// reason to know which minor version minted it.
+//
+// Caller must hold sm.mu.
+func (sm *StateManager) clientLeaseLapsedLocked(clientID uint64) bool {
+	if record := sm.clientsByID[clientID]; record != nil {
+		return record.Confirmed && record.Lease != nil && record.Lease.IsExpired()
+	}
+	if v41 := sm.v41ClientsByID[clientID]; v41 != nil {
+		return v41.Confirmed && v41.Lease != nil && v41.Lease.IsExpired()
+	}
+	return false
+}
+
+// expireLapsedHoldersLocked releases the state of every client other than
+// exceptClientID that holds an open on fileHandle under a lease that has
+// already run out, and reports whether it released any.
+//
+// What keeps an expired client's opens and locks alive is courtesy: a client
+// that merely lost contact for a moment should not come back to find its locks
+// broken, so the state outlives the lease and a sweeper collects it later. The
+// courtesy is owed to nobody once another client's request actually collides
+// with that state, and the collision is the only event that says so. Deciding
+// the conflict on the sweeper's schedule instead refuses a request that
+// nothing live objects to, for however much of the sweep interval is left --
+// which is why the same request is granted or refused depending on when it
+// arrives.
+//
+// Caller must hold sm.mu.
+func (sm *StateManager) expireLapsedHoldersLocked(fileHandle []byte, exceptClientID uint64) bool {
+	var lapsed []uint64
+	seen := make(map[uint64]struct{})
+
+	for _, os := range sm.openStateByFile[string(fileHandle)] {
+		if os.Owner == nil || os.Owner.ClientID == exceptClientID {
+			continue
+		}
+		clientID := os.Owner.ClientID
+		if _, dup := seen[clientID]; dup {
+			continue
+		}
+		seen[clientID] = struct{}{}
+
+		if sm.clientLeaseLapsedLocked(clientID) {
+			lapsed = append(lapsed, clientID)
+		}
+	}
+
+	for _, clientID := range lapsed {
+		logger.Info("Expiring a lapsed client to resolve a conflicting request",
+			"client_id", clientID)
+
+		if v41 := sm.v41ClientsByID[clientID]; v41 != nil {
+			sm.markClientStateidsExpiredLocked(clientID)
+			sm.purgeV41Client(v41)
+			continue
+		}
+		sm.expireV40ClientLocked(clientID)
+	}
+
+	return len(lapsed) > 0
+}
+
 // maxExpiredStateids caps how many freed-by-lease-cancellation stateids the
 // server remembers; see the expiredStateids field for what overflow costs.
 const maxExpiredStateids = 4096
@@ -1007,6 +1071,15 @@ func (sm *StateManager) onLeaseExpired(clientID uint64) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
+	sm.expireV40ClientLocked(clientID)
+}
+
+// expireV40ClientLocked drops a v4.0 client and everything it holds. It is what
+// a lapsed lease does, and what a conflicting request does to a client whose
+// lease already lapsed.
+//
+// Caller must hold sm.mu.
+func (sm *StateManager) expireV40ClientLocked(clientID uint64) {
 	record, exists := sm.clientsByID[clientID]
 	if !exists {
 		return
@@ -1413,6 +1486,8 @@ func (sm *StateManager) OpenFile(
 	// re-establishes prior state and is exempt. The scan runs under sm.mu so it
 	// observes a consistent snapshot of every live open.
 	if claimType != types.CLAIM_PREVIOUS {
+		sm.expireLapsedHoldersLocked(fileHandle, clientID)
+
 		if conflict := sm.shareConflictLocked(fileHandle, shareAccess, shareDeny); conflict {
 			logger.Debug("OpenFile: share reservation conflict",
 				"client_id", clientID,
@@ -2569,6 +2644,12 @@ func (sm *StateManager) acquireLock(ctx context.Context, lockState *LockState, l
 	enhLock.Reclaim = reclaim
 
 	handleKey := string(lockState.FileHandle)
+
+	// A lock held on behalf of a client whose lease has already run out is
+	// courtesy state, and this request is the collision that ends the courtesy.
+	// Released here rather than left to the sweeper, the answer no longer
+	// depends on where in the sweep interval the request happened to land.
+	sm.expireLapsedHoldersLocked(lockState.FileHandle, lockState.LockOwner.ClientID)
 
 	// Break any conflicting cross-protocol read leases (e.g. an SMB read/write
 	// oplock) before acquiring the byte-range lock. A held lease lets another

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -953,7 +954,7 @@ func (sm *StateManager) clientLeaseLapsedLocked(clientID uint64) bool {
 
 // expireLapsedHoldersLocked releases the state of every client other than
 // exceptClientID that holds an open on fileHandle under a lease that has
-// already run out, and reports whether it released any.
+// already run out.
 //
 // What keeps an expired client's opens and locks alive is courtesy: a client
 // that merely lost contact for a moment should not come back to find its locks
@@ -966,22 +967,16 @@ func (sm *StateManager) clientLeaseLapsedLocked(clientID uint64) bool {
 // arrives.
 //
 // Caller must hold sm.mu.
-func (sm *StateManager) expireLapsedHoldersLocked(fileHandle []byte, exceptClientID uint64) bool {
+func (sm *StateManager) expireLapsedHoldersLocked(fileHandle []byte, exceptClientID uint64) {
+	// Collected before anything is released: expiring a client rewrites the
+	// index this ranges over.
 	var lapsed []uint64
-	seen := make(map[uint64]struct{})
-
 	for _, os := range sm.openStateByFile[string(fileHandle)] {
-		if os.Owner == nil || os.Owner.ClientID == exceptClientID {
+		if os.Owner == nil || os.Owner.ClientID == exceptClientID || slices.Contains(lapsed, os.Owner.ClientID) {
 			continue
 		}
-		clientID := os.Owner.ClientID
-		if _, dup := seen[clientID]; dup {
-			continue
-		}
-		seen[clientID] = struct{}{}
-
-		if sm.clientLeaseLapsedLocked(clientID) {
-			lapsed = append(lapsed, clientID)
+		if sm.clientLeaseLapsedLocked(os.Owner.ClientID) {
+			lapsed = append(lapsed, os.Owner.ClientID)
 		}
 	}
 
@@ -996,8 +991,6 @@ func (sm *StateManager) expireLapsedHoldersLocked(fileHandle []byte, exceptClien
 		}
 		sm.expireV40ClientLocked(clientID)
 	}
-
-	return len(lapsed) > 0
 }
 
 // maxExpiredStateids caps how many freed-by-lease-cancellation stateids the

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -718,9 +718,10 @@ func (sm *StateManager) ConfirmClientID(clientID uint64, confirmVerifier [8]byte
 		if oldConfirmed.Lease != nil {
 			oldConfirmed.Lease.Stop()
 		}
-		// The client rebooted: RFC 7530 Section 9.1.1 has this confirm release
-		// the previous incarnation's locks, opens and delegations, not just
-		// forget the record that owned them. Leaving the state behind keeps
+		// The client rebooted, and RFC 7530 Section 16.34.5 requires more of
+		// this confirm than forgetting the record: where a confirmed record
+		// for the same id string already exists, "the server MUST remove
+		// client x's relevant leased client state". Leaving it behind keeps
 		// every stateid the client held before the reboot working, so the
 		// files stay share-reserved and byte-range locked on behalf of an
 		// incarnation that no longer exists and will never close them.

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -2643,8 +2643,15 @@ func (sm *StateManager) acquireLock(ctx context.Context, lockState *LockState, l
 	// courtesy state, and this request is the collision that ends the courtesy.
 	// Released here rather than left to the sweeper, the answer no longer
 	// depends on where in the sweep interval the request happened to land.
-	sm.expireLapsedHoldersLocked(lockState.FileHandle,
-		lockState.LockOwner.ClientID, lockState.OpenState.Owner.ClientID)
+	//
+	// A reclaim is exempt, as CLAIM_PREVIOUS is on the OPEN side: during grace
+	// every client is re-establishing state it already held, and one that has
+	// reclaimed its opens but not yet its locks can outlive the fresh lease it
+	// was given, which would make its half-rebuilt state look abandoned.
+	if !reclaim {
+		sm.expireLapsedHoldersLocked(lockState.FileHandle,
+			lockState.LockOwner.ClientID, lockState.OpenState.Owner.ClientID)
+	}
 
 	// Break any conflicting cross-protocol read leases (e.g. an SMB read/write
 	// oplock) before acquiring the byte-range lock. A held lease lets another

--- a/internal/adapter/nfs/v4/state/v41_client.go
+++ b/internal/adapter/nfs/v4/state/v41_client.go
@@ -320,6 +320,7 @@ func (sm *StateManager) purgeV41Client(record *V41ClientRecord) {
 	}
 
 	sm.removeClientOpenStateLocked(record.ClientID)
+	sm.removeClientLockStateLocked(record.ClientID)
 
 	// Clean up all delegations (file + directory) for this client
 	for other, deleg := range sm.delegByOther {

--- a/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
+++ b/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
@@ -30,10 +30,6 @@ Categories:
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| CID1 | bug | SETCLIENTID/SETCLIENTID_CONFIRM and RENEW validation | #2326 |
-| CID2 | bug | SETCLIENTID/SETCLIENTID_CONFIRM and RENEW validation | #2326 |
-| CID2a | bug | SETCLIENTID/SETCLIENTID_CONFIRM and RENEW validation | #2326 |
-| RENEW3 | bug | SETCLIENTID/SETCLIENTID_CONFIRM and RENEW validation | #2326 |
 | OPEN4 | bug | exclusive re-create with the same verifier answers EXIST on the SQL backends, which do not persist the create verifier | #2317 |
 | CLOSE4 | bug | bad/old/stale stateid accepted | #2341 |
 | CLOSE5 | bug | bad/old/stale stateid accepted | #2341 |

--- a/test/nfs-conformance/pynfs/KNOWN_FAILURES_V41.md
+++ b/test/nfs-conformance/pynfs/KNOWN_FAILURES_V41.md
@@ -30,10 +30,6 @@ Categories:
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| COUR2 | bug | courtesy-client state reclaimed too aggressively | #2327 |
-| COUR3 | bug | courtesy-client state reclaimed too aggressively | #2327 |
-| COUR5 | bug | courtesy-client state reclaimed too aggressively | #2327 |
-| COUR6 | bug | courtesy-client state reclaimed too aggressively | #2327 |
 | CSID1 | bug | current stateid not tracked across a COMPOUND | #2328 |
 | CSID10 | bug | current stateid not tracked across a COMPOUND | #2328 |
 | CSID2 | bug | current stateid not tracked across a COMPOUND | #2328 |


### PR DESCRIPTION
Closes #2326
Closes #2327

Seven pynfs tests across two issues, all of them in client-record and lease handling. They turned out to be five separate defects plus one harness gap, and **#2327's premise is backwards**.

## #2327's premise is inverted

The issue and the blacklist rows read "courtesy-client state reclaimed too aggressively". The observed failures are the opposite: `COUR2` gets `NFS4ERR_DENIED`, `COUR5`/`COUR6` get `NFS4ERR_SHARE_DENIED`. State is not being reclaimed too eagerly; it is still being *enforced*, on behalf of a client whose lease ran out, against a request from a live one.

Why it looked flaky rather than broken: a v4.1 client's lease timer is created with a nil expiry callback (`CREATE_SESSION`), so nothing releases its state on the lease itself. The only thing that ever collects it is `StartSessionReaper`, on a **fixed 30-second tick** — and the suite runs at a 30-second lease and sleeps `lease + 10`. Whether the sweep lands before or after the conflicting request is decided by where in the tick the run started, so the same test passes or fails run to run. `COUR5` passed on one of my runs and failed on the next, on identical code.

This is not a judgement call: RFC 7530 §9.6.3.1 makes it a MUST.

> If lease cancellation has not occurred and the server receives a lock or I/O request that conflicts with one of the courtesy locks, the requirements are as follows:
> - In the case of a courtesy lock that is not a delegation, it MUST free the courtesy lock and grant the new request.

Keeping an expired client's opens and locks alive is deliberate — a client that briefly loses contact should not come back to find its locks broken — but the collision is what ends the courtesy, and it is the only event that says so. So before evaluating a share reservation or a byte-range lock, release the state of any *other* client holding an open on that file under a lapsed lease. Nothing then depends on timing, and a live client's reservation is still enforced (there is a test for exactly that).

## #2326: four defects, not one

**`CID2` / `CID2a` — the reply was short on the wire.** `SETCLIENTID4res` is a union whose `NFS4ERR_CLID_INUSE` arm carries a `clientaddr4` (RFC 7530 §16.33.3) that no other arm has. We encoded status-only, so the client's decode ran off the end of the whole COMPOUND — which is why the reported symptom was a bare `EOFError` rather than an error code. Both strings are now emitted empty, as Linux nfsd does; the field names the client already holding the id, which SETCLIENTID has no obligation to track.

**`CID2` — the principal check was unconditional.** This one is worth reading carefully, because it overturns two pinning tests from #2173.

§16.33.5 does say, flatly, "For any confirmed record with the same id string x, if the recorded principal does not match that of the SETCLIENTID call, then the server returns an NFS4ERR_CLID_INUSE error", and that is what we implemented. But §9.1.2 qualifies it:

> In that event, when the server gets a SETCLIENTID for a client ID that currently has no state, or it has state but the lease has expired, rather than returning NFS4ERR_CLID_INUSE, the server MUST allow the SETCLIENTID and confirm the new client ID if followed by the appropriate SETCLIENTID_CONFIRM.

A MUST, and we were violating it. The security rule the check exists for is the MUST NOT in §9.1.1 against cancelling *leased state* established by a different principal — a record holding none has nothing to cancel. Unconditional refusal also means whichever principal touches a client id string first owns it for the life of the server, and clients derive that string from the hostname rather than from their credential, so a second user on the same host could never establish a client id at all.

The two #2173 tests were written against §16.33.5 alone. They are kept, with the victim now actually holding an open, so they still pin the credential check; a third test pins the exemption. `TestSetClientID_IdentitylessCallerCannotTakeOver` got the same treatment.

**`CID1` — the reboot confirm forgot the record but kept its state.** `SETCLIENTID_CONFIRM` replacing a previously confirmed record stopped the old lease timer and deleted the map entry, and left every open, lock and delegation behind. §16.34.5 is explicit that this is not enough — where a confirmed record for the same id string already exists, "the server MUST remove client x's relevant leased client state and overwrite the callback state with k" (the callback half of that is what #2361 fixed). So a stateid from before the reboot still worked (`CLOSE` returned `NFS4_OK` where `NFS4ERR_EXPIRED` was required), and the files stayed share-reserved and byte-range locked on behalf of an incarnation that will never close them. The release path `onLeaseExpired` already had is now shared and called here too.

**`RENEW3` — `NFS4ERR_STALE_CLIENTID` where `NFS4ERR_EXPIRED` was required.** A client ID with no record got `STALE_CLIENTID` unconditionally, which tells the client the server rebooted rather than that its own lease lapsed — a much larger recovery than the situation calls for. §9.6.3.2: once a lease is cancelled, "the use of the associated clientid will result in NFS4ERR_EXPIRED being returned". `generateClientID` puts the boot epoch in the high 32 bits, so the two cases are distinguishable: an id this boot minted and has since released is `EXPIRED`, an id no boot of this server could have issued stays `STALE_CLIENTID`. Applied at both `RenewLease` and `ValidateAndRenewClient`, since every operation carrying a clientid faces the same question. `RENEW2` (`RENEW` with clientid 0) still gets `STALE_CLIENTID`.

## The harness gap behind `RENEW3` — `RENEW3`'s row stays

`RENEW3` does not reach the assertion above in the harness as it stands, and neither do the six tests in #2332. All of them use `env.c2`, and pynfs builds its second client at `opts.uid + 1` (`nfs4.0/servertests/environment.py:109`). The suite runs `--uid 0`, so `c2` is uid 1 — a UID the export has never heard of, refused at the gate before POSIX is consulted, which is the `OP_LOOKUP ... NFS4ERR_ACCESS` in both issues. `setup-posix.sh` grants the three pjdfstest UIDs for exactly this reason and nothing grants uid 1. knfsd has no such gate, hence the clean baseline.

That is a harness fix, and **#2383 has since landed it** — `setup-posix.sh` now provisions `TEST_UID + 1` and grants it on the export. So the blocker is gone from `develop`, and `RENEW3`'s row comes out here with the other three rather than being kept and repointed as an earlier revision of this PR did.

The `RENEW` defect behind the `ACCESS` is a separate one and is fixed here: once `c2` can reach the tree, `RENEW3` fails on `RENEW with expired lease should return NFS4ERR_EXPIRED, instead got NFS4ERR_STALE_CLIENTID`, which is what `TestRenewLease_ForgottenClientIDIsExpiredNotStale` pins. Both halves are now in place, so `RENEW3` is load-bearing on this branch — if it still fails it is a NEW failure and `pynfs v4.0` goes red.

## Evidence

All measurements below are from CI's own pynfs artifacts, not from a local run. A local pynfs run on this machine is not trustworthy — a sibling session measured 124 failures locally against 63 in CI on the same commit — so the base numbers, the failure reasons and the blacklist row counts are all read out of the CI artifacts for the base SHA (`5fe8954e9`, run `34069808736`).

Base, `pynfs v4.0 / memory`:

```
Loaded 73 known failures from KNOWN_FAILURES_V40.md
Of those: 8 Skipped, 63 Failed, 5 Warned, 525 Passed
  CID2   KNOWN     CID2a  KNOWN     CID1   KNOWN     RENEW3 KNOWN
```

with, from that run's `pynfs.log`:

```
CID2   st_setclientid.testNotInUse    : FAILURE   EOFError        (preceded by "Got error: Connection closed")
CID2a  st_setclientid.testInUse       : FAILURE   EOFError
CID1   st_setclientid.testClientReboot: FAILURE   Trying to use old stateid after SETCLIENTID_CONFIRM
                                                  purges state should return NFS4ERR_EXPIRED, instead got NFS4_OK
RENEW3 st_renew.testExpired           : FAILURE   nfs4lib.BadCompoundRes: Opening file b'RENEW3-1':
                                                  operation OP_LOOKUP should return NFS4_OK, instead got NFS4ERR_ACCESS
```

`RENEW3`'s `NFS4ERR_ACCESS` in CI is what confirms the harness gap is a CI-side fact and not a local-rig artifact.

Base, `pynfs v4.1 / memory`:

```
Loaded 64 known failures from KNOWN_FAILURES_V41.md
Of those: 1 Skipped, 63 Failed, 0 Warned, 120 Passed

COUR6  st_courtesy.testShareReservationDB03 : FAILURE  OP_OPEN should return NFS4_OK, instead got NFS4ERR_SHARE_DENIED
COUR5  st_courtesy.testShareReservationDB02 : FAILURE  OP_OPEN should return NFS4_OK, instead got NFS4ERR_SHARE_DENIED
COUR2  st_courtesy.testLockSleepLock        : FAILURE  OP_LOCK should return NFS4_OK, instead got NFS4ERR_DENIED
COUR3  st_courtesy.testShareReservation00   : PASS
```

Note `COUR3`: it was already passing in CI on the base, so its blacklist row was stale and invisible to the grader. Removing it here is what makes it load-bearing, not a claim that this change fixed it. The flake #2327 reports is the same mechanism seen from the other side — `COUR3` and `COUR5` land on either side of the sweep depending on timing, and which of them is failing on a given run is decided by that, not by the code.

After, this PR's own `nfs-pynfs` run — all four jobs green on both backends. Measured before a rebase, when the tables stood at 73 and 64 rows:

```
pynfs v4.0 / memory      Loaded 70 known failures from KNOWN_FAILURES_V40.md
                         Of those: 8 Skipped, 60 Failed, 5 Warned, 528 Passed
                         New failures: 0

pynfs v4.1 / memory      Loaded 60 known failures from KNOWN_FAILURES_V41.md
                         Of those: 1 Skipped, 60 Failed, 0 Warned, 123 Passed
                         New failures: 0
```

Read against the base numbers above: v4.0 goes 63 failed / 525 passed → **60 failed / 528 passed**, and v4.1 goes 63 / 120 → **60 / 123**. Three fewer failures and three more passes on each, which is `CID1`, `CID2`, `CID2a` on one side and `COUR2`, `COUR5`, `COUR6` on the other. Three rather than four on the v4.1 side because `COUR3` was already passing on the base — its row was stale, and removing it makes it load-bearing rather than fixed.

The `Loaded N` line is the proof a run graded against the edited tables rather than a cached copy, and it is what makes the removals count: with those rows gone, any of the seven failing would be a NEW failure and would turn the job red.

**The absolute numbers above are stale.** This branch has since been rebased twice, onto a `develop` that walked out a lot of rows of its own (#2377 and #2383 among them), so the tables are much shorter now — re-measured on the current base (`829aee44d`) rather than carried over:

| | develop | this branch | removed |
|---|---|---|---|
| `KNOWN_FAILURES_V40.md` | 26 | 22 | 4 |
| `KNOWN_FAILURES_V41.md` | 55 | 51 | 4 |

Eight rows now rather than seven, because `RENEW3` joins them once #2383 supplies the account. A `diff` of each table against `develop` shows those eight rows and nothing else. What has to stay true is `New failures: 0`.

The rebase also took a conflict in `OpenFile`: #2377 dropped the `ownerKey` parameter from `shareConflictLocked` and with it the same-owner skip. Resolved by keeping their signature and the sweep call ahead of it — the sweep keys off the calling client, not the owner, so the two are independent. Re-checked afterwards that all three courtesy tests still fail against a build with the sweep removed.

## Tests

Six new tests, each verified to fail against a build with its own fix removed:

- `TestEncodeSetClientIDError_ClidInUseCarriesClientUsing` (+ the void-arm counterpart)
- `TestSetClientID_PrincipalMismatchAllowedWithoutState`
- `TestConfirmClientID_RebootReleasesPreviousIncarnationState`
- `TestRenewLease_ForgottenClientIDIsExpiredNotStale`
- `TestOpen_ConflictExpiresLapsedShareReservation`
- `TestLock_ConflictExpiresLapsedByteRangeLock`
- `TestOpen_ConflictKeepsLiveShareReservation` (the guard against over-reaching)

The courtesy tests never start the session reaper, so a conflicting request is the only thing that can release the state — which is what makes them discriminate rather than race.

Two follow-ups from review, both narrowing when the sweep is allowed to fire:

- A `LOCK` does not require the lock-owner's client ID to match the client owning the open the lock hangs from, so the sweep now keeps **both** out, not just the lock-owner's — otherwise it could release the open state the same call still holds a pointer into.
- A lock **reclaim** is exempt, as `CLAIM_PREVIOUS` already is on the OPEN side. During grace every client is rebuilding state it already held, and one that has reclaimed its opens but not yet its locks can outlive the fresh lease it was given.

## Blacklist

`KNOWN_FAILURES_V40.md` 73 → 70 rows (CID1, CID2, CID2a out; RENEW3 repointed), `KNOWN_FAILURES_V41.md` 64 → 60 (COUR2, COUR3, COUR5, COUR6 out). Both counts measured on this branch's base, not carried over from an earlier run.
