### PR TITLE
fix(metadata): persist the create verifier on SQL backends, and rename the row the transaction read

### DIFF
--- a/pkg/metadata/file_modify.go
+++ b/pkg/metadata/file_modify.go
@@ -221,14 +221,15 @@ func (s *Service) ReadSymlink(ctx *AuthContext, handle FileHandle) (string, *Fil
 // Comparing outside the transaction would only move the window rather than
 // narrow it. What makes this safe is the store's isolation, not the shape of
 // this function: under READ COMMITTED with an unlocked read — postgres — the
-// pair is not atomic and the window stays open (#2324).
+// pair is not atomic and the window stays open.
 //
 // On the losing path nothing is written at all. On the winning path the row
 // read in this transaction is written back with nothing but ChangeTime changed,
 // which spares a concurrent size or mtime advance only where that read is
 // serialised against the writer. Where it is not, a write committing between the
-// read and the update is overwritten wholesale, the same lost-update shape the
-// surrounding rename and attribute paths already have (#2324).
+// read and the update is overwritten wholesale — the residual half of the
+// lost-update shape the rename path shares, which writing the in-transaction
+// row narrows but only the store's isolation can close.
 //
 // There is no permission check: the caller is the rename itself, which the
 // metadata layer has already authorized on the parent directories, and the
@@ -1072,14 +1073,19 @@ func (s *Service) Move(ctx *AuthContext, fromDir FileHandle, fromName string, to
 		// transaction serialises it against concurrent writers. Under READ
 		// COMMITTED with an unlocked read — postgres — a write can still commit
 		// between this read and the row lock the update takes, narrowing the
-		// window rather than closing it (#2324).
+		// window rather than closing it.
 		pre, err := tx.GetFile(ctx.Context, srcHandle)
 		if err != nil {
 			return err
 		}
 		rename.SourcePreCtime = pre.Ctime
-		srcFile.Ctime = now
-		if err := tx.UpdateAttrs(ctx.Context, srcFile); err != nil {
+		// Write the row this transaction read, not the one read before it
+		// opened. Ctime is the only field a rename changes on the source
+		// inode, so every other column must come from committed state:
+		// writing the earlier snapshot back would silently restore whatever
+		// Size or Mtime a concurrent write had already committed.
+		pre.Ctime = now
+		if err := tx.UpdateAttrs(ctx.Context, pre); err != nil {
 			return err
 		}
 		post, err := tx.GetFile(ctx.Context, srcHandle)

--- a/pkg/metadata/rename_ctime_window_test.go
+++ b/pkg/metadata/rename_ctime_window_test.go
@@ -96,3 +96,50 @@ func TestRenameCtime_AdvanceInsideMoveWindowIsNotErased(t *testing.T) {
 			"(pre-rename value was %v) — the pre-read came from outside the transaction and erased it",
 		after.Ctime.UTC(), mid.Ctime.UTC(), c0.Ctime.UTC())
 }
+
+// TestRenameCtime_SizeCommittedInMoveWindowSurvives pins that Move writes the
+// row its own transaction read, not the copy it took before opening one.
+//
+// ChangeTime is the only field a rename changes on the source inode, so every
+// other column on the row it writes must come from committed state. Writing the
+// earlier snapshot back restores whatever that snapshot held — here a Size that
+// a WRITE has since superseded — which is a lost update rather than a rename.
+//
+// The distinction is invisible unless a writer commits between the two reads,
+// so the hook places one exactly there, the same way the ChangeTime case does.
+// Asserting on Size rather than ChangeTime is deliberate: the rename is entitled
+// to move ChangeTime, so ChangeTime cannot show whether the rest of the row came
+// from the stale copy.
+func TestRenameCtime_SizeCommittedInMoveWindowSurvives(t *testing.T) {
+	ws := &windowStore{SQLiteMetadataStore: newSQLiteRenameStore(t)}
+	svc, rootHandle, share := registerRenameStore(t, ws)
+	root := rootAuth()
+
+	created, _, err := svc.CreateFile(root, rootHandle, "s.bin",
+		&metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o666})
+	require.NoError(t, err)
+	handle, err := metadata.EncodeShareHandle(share, created.ID)
+	require.NoError(t, err)
+
+	const grown = uint64(4096)
+	var mid *metadata.File
+	ws.beforeTx = func() {
+		size := grown
+		_, hookErr := svc.SetFileAttributes(root, handle, &metadata.SetAttrs{Size: &size})
+		require.NoError(t, hookErr)
+		mid, hookErr = svc.GetFile(root.Context, handle)
+		require.NoError(t, hookErr)
+	}
+
+	_, _, err = svc.Move(root, rootHandle, "s.bin", rootHandle, "t.bin")
+	require.NoError(t, err)
+	require.NotNil(t, mid, "hook did not fire: Move opened no transaction through the wrapper")
+	require.Equal(t, grown, mid.Size, "precondition: the injected size must have committed")
+
+	after, err := svc.GetFile(root.Context, handle)
+	require.NoError(t, err)
+	require.Equal(t, grown, after.Size,
+		"Size = %d; want the %d committed inside the rename's own window — Move wrote back the "+
+			"inode snapshot it read before opening its transaction, discarding the newer size",
+		after.Size, grown)
+}

--- a/pkg/metadata/store/internal/sqlcodec/sqlcodec.go
+++ b/pkg/metadata/store/internal/sqlcodec/sqlcodec.go
@@ -121,8 +121,10 @@ func FileRowToFileWithNlinkAndBlocks(r Row, withBlocks bool) (*metadata.File, er
 		deletedAt    sql.NullInt64
 		originalPath string
 		deletedBy    string
-		nlink        int32
-		blocksJSON   []byte
+		// Signed bit pattern of the opaque create verifier; see InodeValues.
+		idempotencyToken int64
+		nlink            int32
+		blocksJSON       []byte
 	)
 
 	dest := []any{
@@ -149,6 +151,7 @@ func FileRowToFileWithNlinkAndBlocks(r Row, withBlocks bool) (*metadata.File, er
 		&deletedAt,
 		&originalPath,
 		&deletedBy,
+		&idempotencyToken,
 		&nlink,
 	}
 	if withBlocks {
@@ -164,17 +167,18 @@ func FileRowToFileWithNlinkAndBlocks(r Row, withBlocks bool) (*metadata.File, er
 		ShareName: shareName,
 		Path:      path,
 		FileAttr: metadata.FileAttr{
-			Type:         metadata.FileType(fileType),
-			Mode:         uint32(mode),
-			UID:          uint32(uid),
-			GID:          uint32(gid),
-			Nlink:        uint32(nlink),
-			Size:         uint64(size),
-			Atime:        FiletimeToTime(atime),
-			Mtime:        FiletimeToTime(mtime),
-			Ctime:        FiletimeToTime(ctime),
-			CreationTime: FiletimeToTime(creationTime),
-			Hidden:       hidden,
+			Type:             metadata.FileType(fileType),
+			Mode:             uint32(mode),
+			UID:              uint32(uid),
+			GID:              uint32(gid),
+			Nlink:            uint32(nlink),
+			Size:             uint64(size),
+			Atime:            FiletimeToTime(atime),
+			Mtime:            FiletimeToTime(mtime),
+			Ctime:            FiletimeToTime(ctime),
+			CreationTime:     FiletimeToTime(creationTime),
+			Hidden:           hidden,
+			IdempotencyToken: uint64(idempotencyToken),
 		},
 	}
 

--- a/pkg/metadata/store/postgres/dialect.go
+++ b/pkg/metadata/store/postgres/dialect.go
@@ -59,7 +59,7 @@ const inodeSelectColumns = `
 	f.atime, f.mtime, f.ctime, f.creation_time,
 	f.content_id, f.link_target, f.device_major, f.device_minor,
 	f.hidden, f.acl, f.eas, f.object_id,
-	f.deleted_at, f.original_path, f.deleted_by, f.nlink,
+	f.deleted_at, f.original_path, f.deleted_by, f.idempotency_token, f.nlink,
 	` + blockRefsAggExpr + `
 `
 

--- a/pkg/metadata/store/postgres/migrations/000047_inode_idempotency_token.down.sql
+++ b/pkg/metadata/store/postgres/migrations/000047_inode_idempotency_token.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE inodes DROP COLUMN IF EXISTS idempotency_token;

--- a/pkg/metadata/store/postgres/migrations/000047_inode_idempotency_token.up.sql
+++ b/pkg/metadata/store/postgres/migrations/000047_inode_idempotency_token.up.sql
@@ -1,0 +1,10 @@
+-- The create verifier an exclusive CREATE/OPEN carries, so a retransmitted
+-- request can be recognised as a replay of the one that already committed
+-- rather than answered EEXIST. The column existed in neither SQL dialect, so
+-- the value round-tripped on the KV backends and read back as zero here, and
+-- every retry compared the client's verifier against 0 and mismatched.
+--
+-- BIGINT holds the signed bit pattern of the uint64: the token is opaque, only
+-- ever compared for equality, and values above 2^63 are ordinary and must
+-- survive the trip rather than saturate.
+ALTER TABLE inodes ADD COLUMN IF NOT EXISTS idempotency_token BIGINT NOT NULL DEFAULT 0;

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -233,7 +233,7 @@ func (tx *postgresTransaction) putFile(ctx context.Context, file *metadata.File,
 		WITH old AS (
 			SELECT id, share_name, size, uid, gid, file_type, nlink
 			FROM inodes
-			WHERE id = $21 AND share_name = $22
+			WHERE id = $22 AND share_name = $23
 			FOR UPDATE
 		)
 		UPDATE inodes SET
@@ -256,7 +256,8 @@ func (tx *postgresTransaction) putFile(ctx context.Context, file *metadata.File,
 			object_id = $17,
 			deleted_at = $18,
 			original_path = $19,
-			deleted_by = $20
+			deleted_by = $20,
+			idempotency_token = $21
 		FROM old
 		WHERE inodes.id = old.id AND inodes.share_name = old.share_name
 		RETURNING old.size, old.uid, old.gid, old.file_type, old.nlink
@@ -295,10 +296,10 @@ func (tx *postgresTransaction) putFile(ctx context.Context, file *metadata.File,
 				id, share_name, file_type, mode, uid, gid, size,
 				atime, mtime, ctime, creation_time, content_id, link_target,
 				device_major, device_minor, hidden, acl, eas, object_id,
-				deleted_at, original_path, deleted_by
+				deleted_at, original_path, deleted_by, idempotency_token
 			) VALUES (
 				$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18,
-				$19, $20, $21, $22
+				$19, $20, $21, $22, $23
 			)
 		`
 

--- a/pkg/metadata/store/sql/put_file.go
+++ b/pkg/metadata/store/sql/put_file.go
@@ -9,7 +9,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlcodec"
 )
 
-// InodeValues are the twenty column values an inode write sends, in the order
+// InodeValues are the twenty-one column values an inode write sends, in the order
 // both the UPDATE and the INSERT name them. Keeping one builder for both means
 // a column added to the table cannot be wired into one statement and forgotten
 // in the other.
@@ -83,6 +83,9 @@ func InodeValues(file *metadata.File) ([]any, error) {
 		payloadIDPtr, linkTargetPtr, deviceMajor, deviceMinor,
 		file.Hidden, aclJSON, easJSON, objectIDArg,
 		deletedAtArg, file.OriginalPath, file.DeletedBy,
+		// Opaque create verifier: compared only for equality, so it travels as
+		// the signed bit pattern rather than being clamped into int64 range.
+		int64(file.IdempotencyToken),
 	}, nil
 }
 

--- a/pkg/metadata/store/sqlite/dialect.go
+++ b/pkg/metadata/store/sqlite/dialect.go
@@ -61,7 +61,7 @@ const inodeSelectColumns = `
 	f.atime, f.mtime, f.ctime, f.creation_time,
 	f.content_id, f.link_target, f.device_major, f.device_minor,
 	f.hidden, f.acl, f.eas, f.object_id,
-	f.deleted_at, f.original_path, f.deleted_by, f.nlink,
+	f.deleted_at, f.original_path, f.deleted_by, f.idempotency_token, f.nlink,
 	` + blockRefsAggExpr + `
 `
 

--- a/pkg/metadata/store/sqlite/migrations/000010_inode_idempotency_token.down.sql
+++ b/pkg/metadata/store/sqlite/migrations/000010_inode_idempotency_token.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE inodes DROP COLUMN idempotency_token;

--- a/pkg/metadata/store/sqlite/migrations/000010_inode_idempotency_token.up.sql
+++ b/pkg/metadata/store/sqlite/migrations/000010_inode_idempotency_token.up.sql
@@ -1,0 +1,10 @@
+-- The create verifier an exclusive CREATE/OPEN carries, so a retransmitted
+-- request can be recognised as a replay of the one that already committed
+-- rather than answered EEXIST. The column existed in neither SQL dialect, so
+-- the value round-tripped on the KV backends and read back as zero here, and
+-- every retry compared the client's verifier against 0 and mismatched.
+--
+-- Stored as the signed bit pattern of the uint64: the token is opaque, only
+-- ever compared for equality, and values above 2^63 are ordinary and must
+-- survive the trip rather than saturate.
+ALTER TABLE inodes ADD COLUMN idempotency_token INTEGER NOT NULL DEFAULT 0;

--- a/pkg/metadata/store/sqlite/start_offset_migration_test.go
+++ b/pkg/metadata/store/sqlite/start_offset_migration_test.go
@@ -45,7 +45,7 @@ func TestStartOffsetMigration_PreExistingRowClaimsChunkStart(t *testing.T) {
 	}{
 		{q: `ALTER TABLE file_blocks DROP COLUMN start_offset`},
 		{q: `ALTER TABLE file_block_refs DROP COLUMN start_offset`},
-		{q: `DELETE FROM schema_migrations WHERE version >= 9`},
+		{q: `DELETE FROM schema_migrations WHERE version = 9`},
 		{
 			q: `INSERT INTO file_blocks (id, hash, data_size, ref_count, last_access, created_at, state)
 			    VALUES (?1, ?2, ?3, 1, ?4, ?4, 2)`,

--- a/pkg/metadata/store/sqlite/transaction.go
+++ b/pkg/metadata/store/sqlite/transaction.go
@@ -202,8 +202,9 @@ func (tx *sqliteTransaction) putFile(ctx context.Context, file *metadata.File, w
 			object_id = ?17,
 			deleted_at = ?18,
 			original_path = ?19,
-			deleted_by = ?20
-		WHERE id = ?21 AND share_name = ?22
+			deleted_by = ?20,
+			idempotency_token = ?21
+		WHERE id = ?22 AND share_name = ?23
 	`
 
 	var old storesql.OldInode
@@ -241,10 +242,10 @@ func (tx *sqliteTransaction) putFile(ctx context.Context, file *metadata.File, w
 				id, share_name, file_type, mode, uid, gid, size,
 				atime, mtime, ctime, creation_time, content_id, link_target,
 				device_major, device_minor, hidden, acl, eas, object_id,
-				deleted_at, original_path, deleted_by
+				deleted_at, original_path, deleted_by, idempotency_token
 			) VALUES (
 				?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18,
-				?19, ?20, ?21, ?22
+				?19, ?20, ?21, ?22, ?23
 			)
 		`
 

--- a/pkg/metadata/storetest/store_surface.go
+++ b/pkg/metadata/storetest/store_surface.go
@@ -29,6 +29,7 @@ func runStoreSurfaceTests(t *testing.T, factory StoreFactory) {
 	t.Run("GetFileByPayloadID", func(t *testing.T) { testGetFileByPayloadID(t, factory) })
 	t.Run("FilesystemMetaStatsCaps", func(t *testing.T) { testFilesystemMetaStatsCaps(t, factory) })
 	t.Run("ServerConfigRoundTrip", func(t *testing.T) { testServerConfigRoundTrip(t, factory) })
+	t.Run("IdempotencyTokenRoundTrip", func(t *testing.T) { testIdempotencyTokenRoundTrip(t, factory) })
 	t.Run("Healthcheck", func(t *testing.T) { testHealthcheck(t, factory) })
 	t.Run("Pagination", func(t *testing.T) { testListChildrenPagination(t, factory) })
 	t.Run("DeleteSharePurgesUsedBytesAndObjectIndex", func(t *testing.T) { testDeleteSharePurgesCounters(t, factory) })
@@ -920,4 +921,73 @@ func testGetQuotaUsagePerShare(t *testing.T, factory StoreFactory) {
 
 	// An unknown share reports no usage for a known identity.
 	wantUsage(t, store, "/no-such-share", metadata.QuotaScopeUser, 1000, 0, 0)
+}
+
+// testIdempotencyTokenRoundTrip pins FileAttr.IdempotencyToken through both
+// inode write paths. The token is the create verifier an exclusive CREATE/OPEN
+// carries: a retransmitted request is recognised as a replay by comparing the
+// client's verifier against the stored one, so a backend that reads it back as
+// zero answers EEXIST to every retry instead.
+//
+// The value deliberately sits above 2^63. The field is uint64 and the SQL
+// column is signed, so a backend that clamps rather than carrying the bit
+// pattern loses exactly the high half of the space and still passes a
+// small-value check.
+//
+// Both paths are exercised because the insert and the update are separate
+// statements: wiring a column into one and forgetting the other is the failure
+// this guards.
+func testIdempotencyTokenRoundTrip(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+
+	const shareName = "/idem"
+	const want = uint64(0xdeadbeefcafef00d)
+	rootHandle := createTestShare(t, store, shareName)
+
+	// Update path: an existing inode takes the token on a later write.
+	handle := createTestFile(t, store, shareName, rootHandle, "updated.dat", 0o644)
+	file, err := store.GetFile(ctx, handle)
+	if err != nil {
+		t.Fatalf("GetFile() failed: %v", err)
+	}
+	file.IdempotencyToken = want
+	if err := store.UpdateAttrs(ctx, file); err != nil {
+		t.Fatalf("UpdateAttrs() with IdempotencyToken failed: %v", err)
+	}
+	got, err := store.GetFile(ctx, handle)
+	if err != nil {
+		t.Fatalf("GetFile() after UpdateAttrs failed: %v", err)
+	}
+	if got.IdempotencyToken != want {
+		t.Errorf("IdempotencyToken after UpdateAttrs = %#x, want %#x — the token does not survive the update path, so an exclusive-create retry compares against the wrong value",
+			got.IdempotencyToken, want)
+	}
+
+	// Insert path: the token is present on the very first write of the inode.
+	created := createTestFile(t, store, shareName, rootHandle, "created.dat", 0o644)
+	newFile, err := store.GetFile(ctx, created)
+	if err != nil {
+		t.Fatalf("GetFile() failed: %v", err)
+	}
+	newFile.IdempotencyToken = want
+	if err := store.UpdateAttrs(ctx, newFile); err != nil {
+		t.Fatalf("UpdateAttrs() failed: %v", err)
+	}
+	if got, err = store.GetFile(ctx, created); err != nil {
+		t.Fatalf("GetFile() failed: %v", err)
+	} else if got.IdempotencyToken != want {
+		t.Errorf("IdempotencyToken on second file = %#x, want %#x", got.IdempotencyToken, want)
+	}
+
+	// A file that never carried a token still reads back zero, so the absence
+	// of a verifier stays distinguishable from a stored one.
+	untouched := createTestFile(t, store, shareName, rootHandle, "plain.dat", 0o644)
+	plain, err := store.GetFile(ctx, untouched)
+	if err != nil {
+		t.Fatalf("GetFile() failed: %v", err)
+	}
+	if plain.IdempotencyToken != 0 {
+		t.Errorf("IdempotencyToken on an untouched file = %#x, want 0", plain.IdempotencyToken)
+	}
 }

--- a/pkg/metadata/storetest/store_surface.go
+++ b/pkg/metadata/storetest/store_surface.go
@@ -964,20 +964,38 @@ func testIdempotencyTokenRoundTrip(t *testing.T, factory StoreFactory) {
 			got.IdempotencyToken, want)
 	}
 
-	// Insert path: the token is present on the very first write of the inode.
-	created := createTestFile(t, store, shareName, rootHandle, "created.dat", 0o644)
-	newFile, err := store.GetFile(ctx, created)
+	// Insert path: the token must be on the inode's very FIRST write, so the
+	// insert statement carries the column. Going through createTestFile would
+	// insert the row with a zero token and then set it, which is the update
+	// path again and leaves the insert's column list untested.
+	insertPath := childFullPath(t, store, rootHandle, "created.dat")
+	insertHandle, err := store.GenerateHandle(ctx, shareName, insertPath)
 	if err != nil {
-		t.Fatalf("GetFile() failed: %v", err)
+		t.Fatalf("GenerateHandle() failed: %v", err)
 	}
-	newFile.IdempotencyToken = want
-	if err := store.UpdateAttrs(ctx, newFile); err != nil {
-		t.Fatalf("UpdateAttrs() failed: %v", err)
+	_, insertID, err := metadata.DecodeFileHandle(insertHandle)
+	if err != nil {
+		t.Fatalf("DecodeFileHandle() failed: %v", err)
 	}
-	if got, err = store.GetFile(ctx, created); err != nil {
-		t.Fatalf("GetFile() failed: %v", err)
+	if err := store.UpdateAttrs(ctx, &metadata.File{
+		ShareName: shareName,
+		Path:      insertPath,
+		ID:        insertID,
+		FileAttr: metadata.FileAttr{
+			Type:             metadata.FileTypeRegular,
+			Mode:             0o644,
+			UID:              1000,
+			GID:              1000,
+			IdempotencyToken: want,
+		},
+	}); err != nil {
+		t.Fatalf("UpdateAttrs() inserting with a token failed: %v", err)
+	}
+	if got, err = store.GetFile(ctx, insertHandle); err != nil {
+		t.Fatalf("GetFile() after insert failed: %v", err)
 	} else if got.IdempotencyToken != want {
-		t.Errorf("IdempotencyToken on second file = %#x, want %#x", got.IdempotencyToken, want)
+		t.Errorf("IdempotencyToken after insert = %#x, want %#x — the insert statement does not carry the column",
+			got.IdempotencyToken, want)
 	}
 
 	// A file that never carried a token still reads back zero, so the absence


### PR DESCRIPTION
## What was wrong

**#2317 — the create verifier was never stored on the SQL backends.**
`FileAttr.IdempotencyToken` round-tripped on memory and badger and read back as
zero on sqlite and postgres: no `idempotency_token` column existed in either
dialect, so `InodeValues` never sent it and the inode projection never scanned
it. Every retransmitted exclusive CREATE/OPEN therefore compared the client's
verifier against `0`, mismatched, and answered EEXIST.

**#2324 (source-inode half) — rename wrote a row it had already stopped
holding.** `Move` read the source inode before opening its transaction and
wrote that struct back inside it, so every column came from the earlier
snapshot. A WRITE committing in the gap had its `Size` and `Mtime` silently
restored — a lost update wearing a rename's clothes.

## What changed

`IdempotencyToken` is now wired through the one shared marshalling seam —
`InodeValues` plus the shared `sqlcodec` scan — so it is added once rather than
per dialect, with one migration each (sqlite `000010`, postgres `000047`; the
two dialects number independently). It travels as the signed bit pattern of the
`uint64`: the token is opaque and only compared for equality, so values above
2^63 must survive rather than saturate.

`ListChildren` keeps its narrower projection. A directory listing has no use
for a create verifier, and it scans its own column set.

`Move` now writes the row its own transaction read. ChangeTime is the only
field a rename changes on the source inode, so every other column comes from
committed state.

## Verification

Both regression tests were run against a build broken in the specific way they
guard, and both fail there:

- `IdempotencyTokenRoundTrip` on unmodified develop: `0x0, want 0xdeadbeefcafef00d`
- `SizeCommittedInMoveWindowSurvives` with the pre-fix write restored: `Size = 0; want 4096`

The token test covers **both** write paths — the insert and the update are
separate statements, and wiring a column into one and forgetting the other is
exactly what `InodeValues`' own doc comment warns about. Its value sits above
2^63 so a clamping implementation still fails it.

Postgres was exercised explicitly, not inferred: full `TestConformance` green
against a local postgres 16.15, and the new subtest confirmed to have actually
run there rather than being silently skipped by a `-run` pattern.

While wiring the projection I broke 13 unrelated subtests — `ListChildren` has
its own 19-column scanner — and caught it only by running the same suite on
unmodified develop at the same commit and finding it green.

## Not in this PR

#2324's second member, the `SetFileAttributes` non-size path, is **not** fixed
here, so that issue stays open. It reads the inode outside the transaction and
writes the whole row back inside it, the same shape. The fix is larger than the
rename's: the path conditionally mutates nine fields, and `mergeDirTimes`
overlays pending directory timestamps that legitimately must persist, so a
naive re-read-and-write would drop them. That needs its own change with its own
discriminating test rather than being appended here.

Closes #2317


---

**Correction (after review).** An earlier revision of this PR claimed the token
test covered both write paths. It did not. The insert half went through the
shared create helper, which inserts the inode with a zero token, so setting the
token afterwards and writing again exercised the update path a second time and
left the insert statement's column list untested — while this text asserted the
opposite. Caught in review, not by me.

The insert case now builds the inode with the token on its first write. It was
confirmed to discriminate by unwiring only the insert: the new assertion reports
`IdempotencyToken after insert = 0x0` while the update assertion still passes,
so the two halves fail independently.
