### PR TITLE
fix(nfs/v4): honour WRITE stability, and track the current stateid across a COMPOUND

### DIFF
--- a/internal/adapter/common/write_payload.go
+++ b/internal/adapter/common/write_payload.go
@@ -158,3 +158,38 @@ func CommitBlockStore(
 	// re-drives. The bytes remain in local CAS and the syncer keeps mirroring.
 	return ErrNotDurableYet
 }
+
+// FlushStableWrite forces a file's cached data — and, when fileSync is set, its
+// metadata — to stable storage so a WRITE that asked for more than UNSTABLE can
+// be acknowledged at the level it asked for. It mirrors the COMMIT path: flush
+// the block store, then persist the file's pending metadata.
+//
+// NFSv3 (RFC 1813 Section 3.3.7) and NFSv4 (RFC 7530 Section 16.36.4) draw the
+// same line between the two stable levels:
+//
+//   - DATA_SYNC: only the file data must be on stable storage. A metadata flush
+//     failure is tolerated — a later COMMIT or the share-start journal reconcile
+//     makes the size durable — and the write is still reported at DATA_SYNC.
+//   - FILE_SYNC: data AND metadata must be on stable storage before the reply,
+//     so a metadata flush failure propagates and the caller must report a weaker
+//     level rather than claim a durability it did not provide.
+func FlushStableWrite(
+	authCtx *metadata.AuthContext,
+	metaSvc *metadata.Service,
+	blockStore *engine.Store,
+	handle metadata.FileHandle,
+	payloadID metadata.PayloadID,
+	fileSync bool,
+) error {
+	if err := CommitBlockStore(authCtx.Context, blockStore, payloadID); err != nil {
+		return err
+	}
+	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, handle, fileSync); err != nil {
+		if fileSync {
+			return err
+		}
+		logger.WarnCtx(authCtx.Context, "WRITE: DATA_SYNC metadata flush failed (data durable, will reconcile)",
+			"error", err)
+	}
+	return nil
+}

--- a/internal/adapter/nfs/v3/handlers/write.go
+++ b/internal/adapter/nfs/v3/handlers/write.go
@@ -8,7 +8,6 @@ import (
 	"github.com/marmos91/dittofs/internal/adapter/nfs/xdr"
 	"github.com/marmos91/dittofs/internal/bytesize"
 	"github.com/marmos91/dittofs/internal/logger"
-	"github.com/marmos91/dittofs/pkg/block/engine"
 	"github.com/marmos91/dittofs/pkg/metadata"
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
@@ -297,7 +296,7 @@ func (h *Handler) Write(
 	// crash-safe cache and the client can retry COMMIT.
 	committed := uint32(UnstableWrite)
 	if req.Stable >= DataSyncWrite {
-		if err := h.flushStableWrite(ctx, metaSvc, blockStore, fileHandle, writeIntent.PayloadID, authCtx, req.Stable); err != nil {
+		if err := common.FlushStableWrite(authCtx, metaSvc, blockStore, fileHandle, writeIntent.PayloadID, req.Stable >= FileSyncWrite); err != nil {
 			logError(ctx.Context, err, "WRITE: stable flush failed, downgrading to UNSTABLE",
 				"handle", xdr.LazyHandle(req.Handle), "stable_requested", req.Stable, "client", clientIP)
 		} else {
@@ -325,44 +324,6 @@ func (h *Handler) Write(
 }
 
 // Write Helper Functions
-
-// flushStableWrite forces this file's cached data (and, for FILE_SYNC, metadata)
-// to stable storage so a DATA_SYNC / FILE_SYNC WRITE can be acknowledged as
-// committed, per RFC 1813 Section 3.3.7. It mirrors the COMMIT path: flush the
-// block store, then persist any pending metadata for the file.
-//
-// RFC 1813 distinguishes the two stable levels:
-//   - DATA_SYNC (1): only the file data must be on stable storage. A metadata
-//     flush failure is tolerated — it is reconciled by a later COMMIT — and the
-//     write is still reported at the requested level.
-//   - FILE_SYNC (2): both data AND metadata must be on stable storage before the
-//     reply. A metadata flush failure must therefore propagate so the caller
-//     reports UNSTABLE instead of falsely claiming FILE_SYNC durability.
-func (h *Handler) flushStableWrite(
-	ctx *NFSHandlerContext,
-	metaSvc *metadata.Service,
-	blockStore *engine.Store,
-	handle metadata.FileHandle,
-	payloadID metadata.PayloadID,
-	authCtx *metadata.AuthContext,
-	stable uint32,
-) error {
-	if err := common.CommitBlockStore(ctx.Context, blockStore, payloadID); err != nil {
-		return err
-	}
-	// FILE_SYNC (stable>=2) promised durable metadata → strict inline fsync.
-	// DATA_SYNC/UNSTABLE defer it via the relaxed path (#1687); a later COMMIT or
-	// the journal size reconcile on restart makes the size durable.
-	if _, err := metaSvc.FlushPendingWriteForFile(authCtx, handle, stable >= FileSyncWrite); err != nil {
-		if stable >= FileSyncWrite {
-			// FILE_SYNC requires durable metadata; surface the failure.
-			return err
-		}
-		logger.WarnCtx(ctx.Context, "WRITE: DATA_SYNC metadata flush failed (data durable, will reconcile)",
-			"handle", xdr.LazyHandle(handle), "error", err)
-	}
-	return nil
-}
 
 // buildWriteErrorResponse creates a consistent error response with WCC data.
 // This centralizes error response creation to reduce duplication.

--- a/internal/adapter/nfs/v4/handlers/allocate.go
+++ b/internal/adapter/nfs/v4/handlers/allocate.go
@@ -43,7 +43,7 @@ func (h *Handler) handleAllocate(ctx *types.CompoundContext, reader io.Reader) *
 		return allocErr(types.NFS4ERR_ROFS)
 	}
 
-	stateid, offset, length, st := decodeAllocArgs(reader)
+	stateid, offset, length, st := decodeAllocArgs(ctx, reader)
 	if st != types.NFS4_OK {
 		return allocErr(st)
 	}

--- a/internal/adapter/nfs/v4/handlers/clone.go
+++ b/internal/adapter/nfs/v4/handlers/clone.go
@@ -65,7 +65,7 @@ func (h *Handler) handleClone(ctx *types.CompoundContext, reader io.Reader) *typ
 		return cloneErr(types.NFS4ERR_ROFS)
 	}
 
-	srcStateid, dstStateid, srcOffset, dstOffset, count, st := decodeCloneArgs(reader)
+	srcStateid, dstStateid, srcOffset, dstOffset, count, st := decodeCloneArgs(ctx, reader)
 	if st != types.NFS4_OK {
 		return cloneErr(st)
 	}
@@ -213,14 +213,14 @@ func (h *Handler) handleClone(ctx *types.CompoundContext, reader io.Reader) *typ
 // cl_src_offset, cl_dst_offset, cl_count (RFC 7862 Section 15.13). Returns
 // NFS4ERR_BADXDR on a malformed stream and NFS4ERR_INVAL when src/dst range
 // arithmetic overflows uint64.
-func decodeCloneArgs(reader io.Reader) (srcStateid, dstStateid *types.Stateid4, srcOffset, dstOffset, count uint64, st uint32) {
-	src, err := types.DecodeStateid4(reader)
-	if err != nil {
-		return nil, nil, 0, 0, 0, types.NFS4ERR_BADXDR
+func decodeCloneArgs(ctx *types.CompoundContext, reader io.Reader) (srcStateid, dstStateid *types.Stateid4, srcOffset, dstOffset, count uint64, st uint32) {
+	src, argStatus := types.DecodeStateidArg(ctx, reader)
+	if argStatus != types.NFS4_OK {
+		return nil, nil, 0, 0, 0, argStatus
 	}
-	dst, err := types.DecodeStateid4(reader)
-	if err != nil {
-		return nil, nil, 0, 0, 0, types.NFS4ERR_BADXDR
+	dst, argStatus := types.DecodeStateidArg(ctx, reader)
+	if argStatus != types.NFS4_OK {
+		return nil, nil, 0, 0, 0, argStatus
 	}
 	so, err := xdr.DecodeUint64(reader)
 	if err != nil {

--- a/internal/adapter/nfs/v4/handlers/clone_test.go
+++ b/internal/adapter/nfs/v4/handlers/clone_test.go
@@ -31,7 +31,7 @@ func cloneCtx(current, saved []byte) *types.CompoundContext {
 
 func TestDecodeCloneArgs(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
-		src, dst, so, do, c, st := decodeCloneArgs(encCloneArgs(anonStateid(), anonStateid(), 100, 200, 300))
+		src, dst, so, do, c, st := decodeCloneArgs(&types.CompoundContext{}, encCloneArgs(anonStateid(), anonStateid(), 100, 200, 300))
 		if st != types.NFS4_OK {
 			t.Fatalf("status = %d, want OK", st)
 		}
@@ -41,21 +41,21 @@ func TestDecodeCloneArgs(t *testing.T) {
 	})
 
 	t.Run("whole-file (count 0)", func(t *testing.T) {
-		_, _, so, do, c, st := decodeCloneArgs(encCloneArgs(anonStateid(), anonStateid(), 0, 0, 0))
+		_, _, so, do, c, st := decodeCloneArgs(&types.CompoundContext{}, encCloneArgs(anonStateid(), anonStateid(), 0, 0, 0))
 		if st != types.NFS4_OK || so != 0 || do != 0 || c != 0 {
 			t.Fatalf("decoded (so=%d do=%d c=%d st=%d)", so, do, c, st)
 		}
 	})
 
 	t.Run("src overflow -> INVAL", func(t *testing.T) {
-		_, _, _, _, _, st := decodeCloneArgs(encCloneArgs(anonStateid(), anonStateid(), ^uint64(0)-5, 0, 100))
+		_, _, _, _, _, st := decodeCloneArgs(&types.CompoundContext{}, encCloneArgs(anonStateid(), anonStateid(), ^uint64(0)-5, 0, 100))
 		if st != types.NFS4ERR_INVAL {
 			t.Fatalf("status = %d, want INVAL", st)
 		}
 	})
 
 	t.Run("dst overflow -> INVAL", func(t *testing.T) {
-		_, _, _, _, _, st := decodeCloneArgs(encCloneArgs(anonStateid(), anonStateid(), 0, ^uint64(0)-5, 100))
+		_, _, _, _, _, st := decodeCloneArgs(&types.CompoundContext{}, encCloneArgs(anonStateid(), anonStateid(), 0, ^uint64(0)-5, 100))
 		if st != types.NFS4ERR_INVAL {
 			t.Fatalf("status = %d, want INVAL", st)
 		}
@@ -66,7 +66,7 @@ func TestDecodeCloneArgs(t *testing.T) {
 		writeStateid(&buf, anonStateid())
 		writeStateid(&buf, anonStateid())
 		_ = xdr.WriteUint64(&buf, 0) // src offset only; dst offset + count missing
-		_, _, _, _, _, st := decodeCloneArgs(bytes.NewReader(buf.Bytes()))
+		_, _, _, _, _, st := decodeCloneArgs(&types.CompoundContext{}, bytes.NewReader(buf.Bytes()))
 		if st != types.NFS4ERR_BADXDR {
 			t.Fatalf("status = %d, want BADXDR", st)
 		}

--- a/internal/adapter/nfs/v4/handlers/close.go
+++ b/internal/adapter/nfs/v4/handlers/close.go
@@ -49,12 +49,12 @@ func (h *Handler) handleClose(ctx *types.CompoundContext, reader io.Reader) *typ
 		closeSeqid = 0
 	}
 
-	stateid, err := types.DecodeStateid4(reader)
-	if err != nil {
+	stateid, argStatus := types.DecodeStateidArg(ctx, reader)
+	if argStatus != types.NFS4_OK {
 		return &types.CompoundResult{
-			Status: types.NFS4ERR_BADXDR,
+			Status: argStatus,
 			OpCode: types.OP_CLOSE,
-			Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
+			Data:   encodeStatusOnly(argStatus),
 		}
 	}
 
@@ -119,8 +119,9 @@ func (h *Handler) handleClose(ctx *types.CompoundContext, reader io.Reader) *typ
 	// NOTE: CLOSE does NOT clear ctx.CurrentFH per RFC 7530
 
 	return &types.CompoundResult{
-		Status: types.NFS4_OK,
-		OpCode: types.OP_CLOSE,
-		Data:   buf.Bytes(),
+		Status:  types.NFS4_OK,
+		Stateid: &closeResult.Stateid,
+		OpCode:  types.OP_CLOSE,
+		Data:    buf.Bytes(),
 	}
 }

--- a/internal/adapter/nfs/v4/handlers/compound.go
+++ b/internal/adapter/nfs/v4/handlers/compound.go
@@ -268,6 +268,20 @@ func (h *Handler) runCompoundOps(compCtx *types.CompoundContext, numOps uint32, 
 		results = append(results, *result)
 		lastStatus = result.Status
 
+		// Current stateid bookkeeping (RFC 8881 Section 16.2.3.1.2): an
+		// operation that returned a stateid becomes the current one; one that
+		// set the current filehandle without returning a stateid drops it.
+		// Everything else — including every operation that merely consumed a
+		// stateid — leaves it as it was.
+		if result.Status == types.NFS4_OK {
+			switch {
+			case result.Stateid != nil:
+				compCtx.SetCurrentStateid(result.Stateid)
+			case types.ClearsCurrentStateid(opCode):
+				compCtx.ClearCurrentStateid()
+			}
+		}
+
 		logger.Debug("NFSv4 COMPOUND op dispatched",
 			"op_index", i, "opcode", opCode, "op_name", types.OpName(opCode),
 			"status", result.Status, "client", compCtx.ClientAddr)

--- a/internal/adapter/nfs/v4/handlers/deallocate.go
+++ b/internal/adapter/nfs/v4/handlers/deallocate.go
@@ -39,7 +39,7 @@ func (h *Handler) handleDeallocate(ctx *types.CompoundContext, reader io.Reader)
 		return deallocErr(types.NFS4ERR_ROFS)
 	}
 
-	stateid, offset, length, st := decodeAllocArgs(reader)
+	stateid, offset, length, st := decodeAllocArgs(ctx, reader)
 	if st != types.NFS4_OK {
 		return deallocErr(st)
 	}
@@ -104,10 +104,10 @@ func (h *Handler) handleDeallocate(ctx *types.CompoundContext, reader io.Reader)
 // decodeAllocArgs decodes the shared (stateid, offset, length) argument tuple of
 // ALLOCATE and DEALLOCATE. Returns NFS4ERR_BADXDR on a malformed stream and
 // NFS4ERR_INVAL when offset+length overflows uint64.
-func decodeAllocArgs(reader io.Reader) (*types.Stateid4, uint64, uint64, uint32) {
-	stateid, err := types.DecodeStateid4(reader)
-	if err != nil {
-		return nil, 0, 0, types.NFS4ERR_BADXDR
+func decodeAllocArgs(ctx *types.CompoundContext, reader io.Reader) (*types.Stateid4, uint64, uint64, uint32) {
+	stateid, argStatus := types.DecodeStateidArg(ctx, reader)
+	if argStatus != types.NFS4_OK {
+		return nil, 0, 0, argStatus
 	}
 	offset, err := xdr.DecodeUint64(reader)
 	if err != nil {

--- a/internal/adapter/nfs/v4/handlers/delegreturn.go
+++ b/internal/adapter/nfs/v4/handlers/delegreturn.go
@@ -23,12 +23,12 @@ func (h *Handler) handleDelegReturn(ctx *types.CompoundContext, reader io.Reader
 	}
 
 	// Decode DELEGRETURN4args: stateid4
-	stateid, err := types.DecodeStateid4(reader)
-	if err != nil {
+	stateid, argStatus := types.DecodeStateidArg(ctx, reader)
+	if argStatus != types.NFS4_OK {
 		return &types.CompoundResult{
-			Status: types.NFS4ERR_BADXDR,
+			Status: argStatus,
 			OpCode: types.OP_DELEGRETURN,
-			Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
+			Data:   encodeStatusOnly(argStatus),
 		}
 	}
 

--- a/internal/adapter/nfs/v4/handlers/lock.go
+++ b/internal/adapter/nfs/v4/handlers/lock.go
@@ -101,12 +101,12 @@ func (h *Handler) handleLock(ctx *types.CompoundContext, reader io.Reader) *type
 			openSeqid = 0
 		}
 
-		openStateid, decErr := types.DecodeStateid4(reader)
-		if decErr != nil {
+		openStateid, argStatus := types.DecodeStateidArg(ctx, reader)
+		if argStatus != types.NFS4_OK {
 			return &types.CompoundResult{
-				Status: types.NFS4ERR_BADXDR,
+				Status: argStatus,
 				OpCode: types.OP_LOCK,
-				Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
+				Data:   encodeStatusOnly(argStatus),
 			}
 		}
 
@@ -160,12 +160,12 @@ func (h *Handler) handleLock(ctx *types.CompoundContext, reader io.Reader) *type
 		)
 	} else {
 		// exist_lock_owner4 path
-		lockStateid, decErr := types.DecodeStateid4(reader)
-		if decErr != nil {
+		lockStateid, argStatus := types.DecodeStateidArg(ctx, reader)
+		if argStatus != types.NFS4_OK {
 			return &types.CompoundResult{
-				Status: types.NFS4ERR_BADXDR,
+				Status: argStatus,
 				OpCode: types.OP_LOCK,
-				Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
+				Data:   encodeStatusOnly(argStatus),
 			}
 		}
 
@@ -246,9 +246,10 @@ func (h *Handler) handleLock(ctx *types.CompoundContext, reader io.Reader) *type
 	}
 
 	return &types.CompoundResult{
-		Status: types.NFS4_OK,
-		OpCode: types.OP_LOCK,
-		Data:   buf.Bytes(),
+		Status:  types.NFS4_OK,
+		Stateid: &result.Stateid,
+		OpCode:  types.OP_LOCK,
+		Data:    buf.Bytes(),
 	}
 }
 
@@ -432,12 +433,12 @@ func (h *Handler) handleLockU(ctx *types.CompoundContext, reader io.Reader) *typ
 		seqid = 0
 	}
 
-	lockStateid, err := types.DecodeStateid4(reader)
-	if err != nil {
+	lockStateid, argStatus := types.DecodeStateidArg(ctx, reader)
+	if argStatus != types.NFS4_OK {
 		return &types.CompoundResult{
-			Status: types.NFS4ERR_BADXDR,
+			Status: argStatus,
 			OpCode: types.OP_LOCKU,
-			Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
+			Data:   encodeStatusOnly(argStatus),
 		}
 	}
 
@@ -498,8 +499,9 @@ func (h *Handler) handleLockU(ctx *types.CompoundContext, reader io.Reader) *typ
 	}
 
 	return &types.CompoundResult{
-		Status: types.NFS4_OK,
-		OpCode: types.OP_LOCKU,
-		Data:   buf.Bytes(),
+		Status:  types.NFS4_OK,
+		Stateid: &unlockResult.Stateid,
+		OpCode:  types.OP_LOCKU,
+		Data:    buf.Bytes(),
 	}
 }

--- a/internal/adapter/nfs/v4/handlers/open.go
+++ b/internal/adapter/nfs/v4/handlers/open.go
@@ -764,9 +764,10 @@ func (h *Handler) encodeOpenResult(
 	h.StateManager.CacheOpenOwnerResult(clientID, ownerData, types.NFS4_OK, buf.Bytes())
 
 	return &types.CompoundResult{
-		Status: types.NFS4_OK,
-		OpCode: types.OP_OPEN,
-		Data:   buf.Bytes(),
+		Status:  types.NFS4_OK,
+		Stateid: stateid,
+		OpCode:  types.OP_OPEN,
+		Data:    buf.Bytes(),
 	}
 }
 
@@ -837,9 +838,10 @@ func (h *Handler) handleOpenConfirm(ctx *types.CompoundContext, reader io.Reader
 	}
 
 	return &types.CompoundResult{
-		Status: types.NFS4_OK,
-		OpCode: types.OP_OPEN_CONFIRM,
-		Data:   buf.Bytes(),
+		Status:  types.NFS4_OK,
+		Stateid: &confirmResult.Stateid,
+		OpCode:  types.OP_OPEN_CONFIRM,
+		Data:    buf.Bytes(),
 	}
 }
 

--- a/internal/adapter/nfs/v4/handlers/read.go
+++ b/internal/adapter/nfs/v4/handlers/read.go
@@ -31,9 +31,9 @@ func (h *Handler) handleRead(ctx *types.CompoundContext, reader io.Reader) *type
 	}
 
 	// Decode READ4args
-	stateid, err := types.DecodeStateid4(reader)
-	if err != nil {
-		return readErr(types.NFS4ERR_BADXDR)
+	stateid, argStatus := types.DecodeStateidArg(ctx, reader)
+	if argStatus != types.NFS4_OK {
+		return readErr(argStatus)
 	}
 
 	offset, err := xdr.DecodeUint64(reader)

--- a/internal/adapter/nfs/v4/handlers/read_plus.go
+++ b/internal/adapter/nfs/v4/handlers/read_plus.go
@@ -57,9 +57,9 @@ func (h *Handler) handleReadPlus(ctx *types.CompoundContext, reader io.Reader) *
 		return readPlusErr(types.NFS4ERR_ISDIR)
 	}
 
-	stateid, err := types.DecodeStateid4(reader)
-	if err != nil {
-		return readPlusErr(types.NFS4ERR_BADXDR)
+	stateid, argStatus := types.DecodeStateidArg(ctx, reader)
+	if argStatus != types.NFS4_OK {
+		return readPlusErr(argStatus)
 	}
 	offset, err := xdr.DecodeUint64(reader)
 	if err != nil {

--- a/internal/adapter/nfs/v4/handlers/restorefh.go
+++ b/internal/adapter/nfs/v4/handlers/restorefh.go
@@ -25,6 +25,10 @@ func (h *Handler) handleRestoreFH(ctx *types.CompoundContext, _ io.Reader) *type
 	ctx.CurrentFH = make([]byte, len(ctx.SavedFH))
 	copy(ctx.CurrentFH, ctx.SavedFH)
 
+	// The stateid SAVEFH stored comes back with the filehandle, rather than
+	// being dropped the way a plain PUTFH drops it.
+	ctx.RestoreCurrentStateid()
+
 	return &types.CompoundResult{
 		Status: types.NFS4_OK,
 		OpCode: types.OP_RESTOREFH,

--- a/internal/adapter/nfs/v4/handlers/savefh.go
+++ b/internal/adapter/nfs/v4/handlers/savefh.go
@@ -25,6 +25,10 @@ func (h *Handler) handleSaveFH(ctx *types.CompoundContext, _ io.Reader) *types.C
 	ctx.SavedFH = make([]byte, len(ctx.CurrentFH))
 	copy(ctx.SavedFH, ctx.CurrentFH)
 
+	// The current stateid is saved with it (RFC 8881 Section 16.2.3.1.2), so a
+	// later RESTOREFH brings back the pair the client left here.
+	ctx.SaveCurrentStateid()
+
 	return &types.CompoundResult{
 		Status: types.NFS4_OK,
 		OpCode: types.OP_SAVEFH,

--- a/internal/adapter/nfs/v4/handlers/seek.go
+++ b/internal/adapter/nfs/v4/handlers/seek.go
@@ -44,9 +44,9 @@ func (h *Handler) handleSeek(ctx *types.CompoundContext, reader io.Reader) *type
 		return seekErr(types.NFS4ERR_ISDIR)
 	}
 
-	stateid, err := types.DecodeStateid4(reader)
-	if err != nil {
-		return seekErr(types.NFS4ERR_BADXDR)
+	stateid, argStatus := types.DecodeStateidArg(ctx, reader)
+	if argStatus != types.NFS4_OK {
+		return seekErr(argStatus)
 	}
 	offset, err := xdr.DecodeUint64(reader)
 	if err != nil {

--- a/internal/adapter/nfs/v4/handlers/setattr.go
+++ b/internal/adapter/nfs/v4/handlers/setattr.go
@@ -41,13 +41,13 @@ func (h *Handler) handleSetAttr(ctx *types.CompoundContext, reader io.Reader) *t
 	}
 
 	// 3. Read stateid4 (16 bytes: uint32 seqid + [12]byte other)
-	stateid, err := types.DecodeStateid4(reader)
-	if err != nil {
-		logger.Error("NFSv4 SETATTR decode stateid failed", "error", err)
+	stateid, argStatus := types.DecodeStateidArg(ctx, reader)
+	if argStatus != types.NFS4_OK {
+		logger.Debug("NFSv4 SETATTR stateid argument rejected", "status", argStatus)
 		return &types.CompoundResult{
-			Status: types.NFS4ERR_BADXDR,
+			Status: argStatus,
 			OpCode: types.OP_SETATTR,
-			Data:   encodeSetAttrError(types.NFS4ERR_BADXDR),
+			Data:   encodeSetAttrError(argStatus),
 		}
 	}
 

--- a/internal/adapter/nfs/v4/handlers/shareres_test.go
+++ b/internal/adapter/nfs/v4/handlers/shareres_test.go
@@ -20,10 +20,11 @@ func readBypassStateidH() *types.Stateid4 {
 }
 
 // openFileAndGetStateid creates+opens a file via the OPEN handler with the given
-// share_access and returns the file handle and the real (confirmed) open stateid.
+// share_access and share_deny, returning the file handle and the real
+// (confirmed) open stateid.
 // It drives OPEN then OPEN_CONFIRM through the handler so the returned stateid is
 // usable on subsequent READ/WRITE ops.
-func openFileAndGetStateid(t *testing.T, fx *ioTestFixture, owner string, shareAccess uint32) (metadata.FileHandle, *types.Stateid4) {
+func openFileAndGetStateid(t *testing.T, fx *ioTestFixture, owner string, shareAccess, shareDeny uint32) (metadata.FileHandle, *types.Stateid4) {
 	t.Helper()
 
 	ctx := newRealFSContext(0, 0)
@@ -33,7 +34,7 @@ func openFileAndGetStateid(t *testing.T, fx *ioTestFixture, owner string, shareA
 	args := encodeOpenArgs(
 		1,
 		shareAccess,
-		types.OPEN4_SHARE_DENY_NONE,
+		shareDeny,
 		testClientID(t, fx.handler.StateManager, "shareres-client"),
 		[]byte(owner),
 		types.OPEN4_CREATE,
@@ -79,43 +80,71 @@ func openFileAndGetStateid(t *testing.T, fx *ioTestFixture, owner string, shareA
 }
 
 // ============================================================================
-// H3 — all-ones (READ-bypass) special stateid on write-family ops
+// Special stateids on write-family ops
 // ============================================================================
 
-func TestWrite_ReadBypassStateid_ReturnsBadStateid(t *testing.T) {
+// TestWrite_ReadBypassStateid_BehavesAsAnonymous checks that a WRITE carrying
+// the all-ones READ-bypass stateid is serviced. RFC 7530 Section 16.36.4:
+// "the WRITE is treated exactly the same as if the anonymous stateid were used".
+func TestWrite_ReadBypassStateid_BehavesAsAnonymous(t *testing.T) {
 	fx := newIOTestFixture(t, "/export")
 	fileHandle := fx.createRegularFile(t, fx.rootHandle, "wbypass.txt", 0o644, 0, 0)
 
 	ctx := newRealFSContext(0, 0)
 	setCurrentFH(ctx, fileHandle)
 
-	args := encodeWriteArgs(readBypassStateidH(), 0, types.UNSTABLE4, []byte("nope"))
+	args := encodeWriteArgs(readBypassStateidH(), 0, types.UNSTABLE4, []byte("yes"))
 	result := fx.handler.handleWrite(ctx, bytes.NewReader(args))
 
-	if result.Status != types.NFS4ERR_BAD_STATEID {
-		t.Errorf("WRITE with all-ones stateid status = %d, want NFS4ERR_BAD_STATEID (%d)",
-			result.Status, types.NFS4ERR_BAD_STATEID)
+	if result.Status != types.NFS4_OK {
+		t.Errorf("WRITE with all-ones stateid status = %d, want NFS4_OK", result.Status)
 	}
 }
 
-func TestSetAttr_ReadBypassStateid_OnSizeChange_ReturnsBadStateid(t *testing.T) {
+// TestWrite_SpecialStateid_DeniedByShareReservation is the other half of that
+// rule: neither special stateid may write past an open that denies writing
+// (RFC 7530 Section 9.1.4.3), and the refusal is NFS4ERR_LOCKED.
+func TestWrite_SpecialStateid_DeniedByShareReservation(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		stateid *types.Stateid4
+	}{
+		{"anonymous", &types.Stateid4{}},
+		{"read_bypass", readBypassStateidH()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := newIOTestFixture(t, "/export")
+			fileHandle, _ := openFileAndGetStateid(t, fx, "denywrite-"+tc.name,
+				types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_WRITE)
+
+			ctx := newRealFSContext(0, 0)
+			setCurrentFH(ctx, fileHandle)
+
+			args := encodeWriteArgs(tc.stateid, 0, types.UNSTABLE4, []byte("nope"))
+			result := fx.handler.handleWrite(ctx, bytes.NewReader(args))
+
+			if result.Status != types.NFS4ERR_LOCKED {
+				t.Errorf("WRITE status = %d, want NFS4ERR_LOCKED (%d)",
+					result.Status, types.NFS4ERR_LOCKED)
+			}
+		})
+	}
+}
+
+// TestSetAttr_ReadBypassStateid_OnSizeChange_BehavesAsAnonymous mirrors the
+// WRITE case for the other write-family operation that carries a stateid.
+func TestSetAttr_ReadBypassStateid_OnSizeChange_BehavesAsAnonymous(t *testing.T) {
 	fx := newIOTestFixture(t, "/export")
 	fileHandle := fx.createRegularFile(t, fx.rootHandle, "sbypass.txt", 0o644, 0, 0)
 
 	ctx := newRealFSContext(0, 0)
 	setCurrentFH(ctx, fileHandle)
 
-	var attrVals bytes.Buffer
-	_ = xdr.WriteUint64(&attrVals, 0) // truncate to 0
-	var bitmap []uint32
-	attrs.SetBit(&bitmap, attrs.FATTR4_SIZE)
-
-	args := encodeSetAttrArgs(t, readBypassStateidH(), bitmap, attrVals.Bytes())
+	args := encodeSetAttrSizeArgs(t, readBypassStateidH(), 0)
 	result := fx.handler.handleSetAttr(ctx, bytes.NewReader(args))
 
-	if result.Status != types.NFS4ERR_BAD_STATEID {
-		t.Errorf("SETATTR(size) with all-ones stateid status = %d, want NFS4ERR_BAD_STATEID (%d)",
-			result.Status, types.NFS4ERR_BAD_STATEID)
+	if result.Status != types.NFS4_OK {
+		t.Errorf("SETATTR(size) with all-ones stateid status = %d, want NFS4_OK", result.Status)
 	}
 }
 
@@ -164,7 +193,7 @@ func TestSetAttr_BogusStateid_OnSizeChange_ReturnsBadStateid(t *testing.T) {
 func TestSetAttr_ReadOnlyOpenStateid_OnSizeChange_ReturnsOpenMode(t *testing.T) {
 	fx := newIOTestFixture(t, "/export")
 
-	fileHandle, stateid := openFileAndGetStateid(t, fx, "rdonly", types.OPEN4_SHARE_ACCESS_READ)
+	fileHandle, stateid := openFileAndGetStateid(t, fx, "rdonly", types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE)
 	fx.writeContent(t, fileHandle, []byte("content"))
 
 	ctx := newRealFSContext(0, 0)
@@ -184,7 +213,7 @@ func TestSetAttr_ReadOnlyOpenStateid_OnSizeChange_ReturnsOpenMode(t *testing.T) 
 func TestSetAttr_WriteOpenStateid_OnSizeChange_Allowed(t *testing.T) {
 	fx := newIOTestFixture(t, "/export")
 
-	fileHandle, stateid := openFileAndGetStateid(t, fx, "rdwr", types.OPEN4_SHARE_ACCESS_BOTH)
+	fileHandle, stateid := openFileAndGetStateid(t, fx, "rdwr", types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE)
 	fx.writeContent(t, fileHandle, []byte("content"))
 
 	ctx := newRealFSContext(0, 0)
@@ -236,7 +265,7 @@ func TestRead_WriteOnlyOpenStateid_ReturnsOpenMode(t *testing.T) {
 	fx := newIOTestFixture(t, "/export")
 
 	// Open write-only and grab the real stateid.
-	fileHandle, stateid := openFileAndGetStateid(t, fx, "writeonly", types.OPEN4_SHARE_ACCESS_WRITE)
+	fileHandle, stateid := openFileAndGetStateid(t, fx, "writeonly", types.OPEN4_SHARE_ACCESS_WRITE, types.OPEN4_SHARE_DENY_NONE)
 
 	ctx := newRealFSContext(0, 0)
 	setCurrentFH(ctx, fileHandle)
@@ -253,7 +282,7 @@ func TestRead_WriteOnlyOpenStateid_ReturnsOpenMode(t *testing.T) {
 func TestRead_ReadWriteOpenStateid_Allowed(t *testing.T) {
 	fx := newIOTestFixture(t, "/export")
 
-	fileHandle, stateid := openFileAndGetStateid(t, fx, "readwrite", types.OPEN4_SHARE_ACCESS_BOTH)
+	fileHandle, stateid := openFileAndGetStateid(t, fx, "readwrite", types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE)
 	fx.writeContent(t, fileHandle, []byte("content"))
 
 	ctx := newRealFSContext(0, 0)

--- a/internal/adapter/nfs/v4/handlers/sparse_test.go
+++ b/internal/adapter/nfs/v4/handlers/sparse_test.go
@@ -164,7 +164,7 @@ func TestEncodeReadPlusResok(t *testing.T) {
 
 func TestDecodeAllocArgs(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
-		sid, off, length, st := decodeAllocArgs(encAllocArgs(anonStateid(), 100, 200))
+		sid, off, length, st := decodeAllocArgs(&types.CompoundContext{}, encAllocArgs(anonStateid(), 100, 200))
 		if st != types.NFS4_OK {
 			t.Fatalf("status = %d, want OK", st)
 		}
@@ -174,7 +174,7 @@ func TestDecodeAllocArgs(t *testing.T) {
 	})
 
 	t.Run("overflow -> INVAL", func(t *testing.T) {
-		_, _, _, st := decodeAllocArgs(encAllocArgs(anonStateid(), ^uint64(0)-5, 100))
+		_, _, _, st := decodeAllocArgs(&types.CompoundContext{}, encAllocArgs(anonStateid(), ^uint64(0)-5, 100))
 		if st != types.NFS4ERR_INVAL {
 			t.Fatalf("status = %d, want INVAL", st)
 		}
@@ -184,7 +184,7 @@ func TestDecodeAllocArgs(t *testing.T) {
 		var buf bytes.Buffer
 		writeStateid(&buf, anonStateid())
 		_ = xdr.WriteUint64(&buf, 0) // offset only, missing length
-		_, _, _, st := decodeAllocArgs(bytes.NewReader(buf.Bytes()))
+		_, _, _, st := decodeAllocArgs(&types.CompoundContext{}, bytes.NewReader(buf.Bytes()))
 		if st != types.NFS4ERR_BADXDR {
 			t.Fatalf("status = %d, want BADXDR", st)
 		}

--- a/internal/adapter/nfs/v4/handlers/stubs.go
+++ b/internal/adapter/nfs/v4/handlers/stubs.go
@@ -63,12 +63,12 @@ func (h *Handler) handleOpenDowngrade(ctx *types.CompoundContext, reader io.Read
 	}
 
 	// Decode args: stateid4 + seqid + share_access + share_deny
-	stateid, err := types.DecodeStateid4(reader)
-	if err != nil {
+	stateid, argStatus := types.DecodeStateidArg(ctx, reader)
+	if argStatus != types.NFS4_OK {
 		return &types.CompoundResult{
-			Status: types.NFS4ERR_BADXDR,
+			Status: argStatus,
 			OpCode: types.OP_OPEN_DOWNGRADE,
-			Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
+			Data:   encodeStatusOnly(argStatus),
 		}
 	}
 
@@ -136,9 +136,10 @@ func (h *Handler) handleOpenDowngrade(ctx *types.CompoundContext, reader io.Read
 	}
 
 	return &types.CompoundResult{
-		Status: types.NFS4_OK,
-		OpCode: types.OP_OPEN_DOWNGRADE,
-		Data:   buf.Bytes(),
+		Status:  types.NFS4_OK,
+		Stateid: &downgradeResult.Stateid,
+		OpCode:  types.OP_OPEN_DOWNGRADE,
+		Data:    buf.Bytes(),
 	}
 }
 

--- a/internal/adapter/nfs/v4/handlers/write.go
+++ b/internal/adapter/nfs/v4/handlers/write.go
@@ -74,9 +74,9 @@ func (h *Handler) handleWrite(ctx *types.CompoundContext, reader io.Reader) *typ
 	}
 
 	// Decode WRITE4args
-	stateid, err := types.DecodeStateid4(reader)
-	if err != nil {
-		return writeErr(types.NFS4ERR_BADXDR)
+	stateid, argStatus := types.DecodeStateidArg(ctx, reader)
+	if argStatus != types.NFS4_OK {
+		return writeErr(argStatus)
 	}
 
 	offset, err := xdr.DecodeUint64(reader)

--- a/internal/adapter/nfs/v4/handlers/write.go
+++ b/internal/adapter/nfs/v4/handlers/write.go
@@ -59,7 +59,8 @@ func bootVerifierBytes() [8]byte {
 // handleWrite implements the WRITE operation (RFC 7530 Section 16.36).
 // Writes data to a file using two-phase PrepareWrite/CommitWrite pattern with cache-backed I/O.
 // Delegates to MetadataService.PrepareWrite+CommitWrite and BlockStore.WriteAt.
-// Updates file size/timestamps via metadata; writes data to local store (flushed on COMMIT); always returns UNSTABLE4.
+// Updates file size/timestamps via metadata; writes data to the local store, flushing it
+// synchronously when the client asks for DATA_SYNC4 or FILE_SYNC4.
 // Errors: NFS4ERR_NOFILEHANDLE, NFS4ERR_ISDIR, NFS4ERR_FBIG, NFS4ERR_NOSPC, NFS4ERR_IO.
 func (h *Handler) handleWrite(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
 	// Require current filehandle
@@ -94,11 +95,13 @@ func (h *Handler) handleWrite(ctx *types.CompoundContext, reader io.Reader) *typ
 	}
 
 	// Validate stateid via StateManager for a write-family operation.
-	// The anonymous (all-zeros) special stateid is permitted; the READ-bypass
-	// (all-ones) special stateid is rejected with NFS4ERR_BAD_STATEID because it
-	// is READ-only (RFC 7530 Section 9.1.4.3). Real stateids are validated for
-	// correctness (seqid, epoch, filehandle match); implicit lease renewal
-	// happens inside ValidateStateid for real stateids.
+	// Both special stateids are accepted here and behave identically: RFC 7530
+	// Section 16.36.4 says a WRITE with the READ-bypass (all-ones) stateid "is
+	// treated exactly the same as if the anonymous stateid were used", so
+	// neither may bypass a share reservation — ValidateStateid answers
+	// NFS4ERR_LOCKED when an open on this file denies writing. Real stateids
+	// are validated for correctness (seqid, epoch, filehandle match); implicit
+	// lease renewal happens inside ValidateStateid for real stateids.
 	openState, stateErr := h.StateManager.ValidateStateid(stateid, ctx.CurrentFH, state.StateidOpWrite)
 	if stateErr != nil {
 		nfsStatus := mapStateError(stateErr)
@@ -165,6 +168,16 @@ func (h *Handler) handleWrite(ctx *types.CompoundContext, reader io.Reader) *typ
 		return writeErr(status)
 	}
 
+	// RFC 7530 Section 16.36.5: "a WRITE request with count set to 0 should not
+	// cause the time_modify attribute of the file to be updated". PrepareWrite
+	// above is the permission gate the zero-count case is still "subject to"
+	// (Section 16.36.4) and changes no metadata by itself, so returning here
+	// leaves the file untouched. Nothing was written, so any committed level is
+	// truthful; report the one the client asked for.
+	if len(data) == 0 {
+		return encodeWrite4resok(0, stable)
+	}
+
 	// Trace SUID/SGID-related writes for debugging
 	if intent.PreWriteAttr.Mode&0o6000 != 0 {
 		uid := uint32(0)
@@ -200,21 +213,44 @@ func (h *Handler) handleWrite(ctx *types.CompoundContext, reader io.Reader) *typ
 		return writeErr(status)
 	}
 
+	// Stability level (RFC 7530 Section 16.36.4). `stable` is what the client
+	// asked for; `committed` must report what the server actually did, and
+	// "it will not commit the data and metadata at a level less than that
+	// requested by the client". An UNSTABLE4 write leaves the bytes in the
+	// crash-safe local cache for a later COMMIT; DATA_SYNC4 and FILE_SYNC4 are
+	// honoured by flushing this file synchronously, exactly as COMMIT does. If
+	// that flush fails the reply drops back to UNSTABLE4 rather than claiming a
+	// durability that was not provided — the client then re-drives COMMIT.
+	committed := uint32(types.UNSTABLE4)
+	if stable >= types.DATA_SYNC4 {
+		if flushErr := common.FlushStableWrite(authCtx, metaSvc, blockStore, fileHandle, intent.PayloadID, stable >= types.FILE_SYNC4); flushErr != nil {
+			logger.Warn("NFSv4 WRITE stable flush failed, reporting UNSTABLE4",
+				"error", flushErr,
+				"stable_requested", stable,
+				"client", ctx.ClientAddr)
+		} else {
+			committed = stable
+		}
+	}
+
 	logger.Debug("NFSv4 WRITE successful",
 		"offset", offset,
 		"written", len(data),
 		"newSize", newSize,
+		"stable_requested", stable,
+		"committed", committed,
 		"client", ctx.ClientAddr)
 
-	// Encode WRITE4resok
+	return encodeWrite4resok(uint32(len(data)), committed)
+}
+
+// encodeWrite4resok encodes a successful WRITE4 response: the byte count, the
+// stability level actually achieved, and the server boot verifier.
+func encodeWrite4resok(count, committed uint32) *types.CompoundResult {
 	var buf bytes.Buffer
 	_ = xdr.WriteUint32(&buf, types.NFS4_OK)
-
-	// count (uint32): bytes written
-	_ = xdr.WriteUint32(&buf, uint32(len(data)))
-
-	// committed: always UNSTABLE4 (cache is always enabled)
-	_ = xdr.WriteUint32(&buf, types.UNSTABLE4)
+	_ = xdr.WriteUint32(&buf, count)
+	_ = xdr.WriteUint32(&buf, committed)
 
 	// writeverf: 8-byte server boot verifier (fixed-length, NOT XDR opaque)
 	verf := bootVerifierBytes()

--- a/internal/adapter/nfs/v4/handlers/write.go
+++ b/internal/adapter/nfs/v4/handlers/write.go
@@ -89,6 +89,18 @@ func (h *Handler) handleWrite(ctx *types.CompoundContext, reader io.Reader) *typ
 		return writeErr(types.NFS4ERR_BADXDR)
 	}
 
+	// stable_how4 is an enum of exactly three values (RFC 7530 Section 16.36.2).
+	// Anything else is an undefined enum on the wire, and the reply's committed
+	// field is drawn from the same enum -- echoing an out-of-range value back
+	// would put an invalid stable_how4 in a successful WRITE4resok. knfsd
+	// rejects it at the same point, as bad XDR rather than as a bad argument.
+	if stable > types.FILE_SYNC4 {
+		logger.Debug("NFSv4 WRITE rejected: stable_how4 out of range",
+			"stable", stable,
+			"client", ctx.ClientAddr)
+		return writeErr(types.NFS4ERR_BADXDR)
+	}
+
 	data, err := xdr.DecodeOpaque(reader)
 	if err != nil {
 		return writeErr(types.NFS4ERR_BADXDR)

--- a/internal/adapter/nfs/v4/handlers/write_stable_test.go
+++ b/internal/adapter/nfs/v4/handlers/write_stable_test.go
@@ -1,0 +1,104 @@
+package handlers
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+)
+
+// decodeWriteResok pulls count and committed out of a successful WRITE4res.
+func decodeWriteResok(t *testing.T, result *types.CompoundResult) (count, committed uint32) {
+	t.Helper()
+	if result.Status != types.NFS4_OK {
+		t.Fatalf("WRITE status = %d, want NFS4_OK", result.Status)
+	}
+	reader := bytes.NewReader(result.Data)
+	if _, err := xdr.DecodeUint32(reader); err != nil {
+		t.Fatalf("decode status: %v", err)
+	}
+	count, err := xdr.DecodeUint32(reader)
+	if err != nil {
+		t.Fatalf("decode count: %v", err)
+	}
+	committed, err = xdr.DecodeUint32(reader)
+	if err != nil {
+		t.Fatalf("decode committed: %v", err)
+	}
+	return count, committed
+}
+
+// TestWrite_CommittedMatchesRequestedStability pins RFC 7530 Section 16.36.4:
+// a WRITE that asked for FILE_SYNC4 must be answered with FILE_SYNC4, and one
+// that asked for DATA_SYNC4 with at least DATA_SYNC4. Reporting UNSTABLE4 for
+// either is a protocol violation, and reporting the stronger level without
+// having flushed would be a durability lie.
+func TestWrite_CommittedMatchesRequestedStability(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		requested uint32
+		wantMin   uint32
+	}{
+		{"unstable", types.UNSTABLE4, types.UNSTABLE4},
+		{"data_sync", types.DATA_SYNC4, types.DATA_SYNC4},
+		{"file_sync", types.FILE_SYNC4, types.FILE_SYNC4},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := newIOTestFixture(t, "/export")
+			fileHandle, stateid := openFileAndGetStateid(t, fx, "stable-"+tc.name,
+				types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE)
+
+			ctx := newRealFSContext(0, 0)
+			setCurrentFH(ctx, fileHandle)
+
+			args := encodeWriteArgs(stateid, 0, tc.requested, []byte("payload"))
+			count, committed := decodeWriteResok(t, fx.handler.handleWrite(ctx, bytes.NewReader(args)))
+
+			if count != uint32(len("payload")) {
+				t.Errorf("count = %d, want %d", count, len("payload"))
+			}
+			if committed < tc.wantMin {
+				t.Errorf("committed = %d, want at least %d", committed, tc.wantMin)
+			}
+		})
+	}
+}
+
+// TestWrite_ZeroCountLeavesTimeModify pins RFC 7530 Section 16.36.5: "a WRITE
+// request with count set to 0 should not cause the time_modify attribute of the
+// file to be updated".
+func TestWrite_ZeroCountLeavesTimeModify(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+	fileHandle, stateid := openFileAndGetStateid(t, fx, "zerocount",
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE)
+
+	metaSvc, err := getMetadataServiceForCtx(fx.handler)
+	if err != nil {
+		t.Fatalf("metadata service: %v", err)
+	}
+	before, err := metaSvc.GetFileForRead(t.Context(), fileHandle)
+	if err != nil {
+		t.Fatalf("GetFileForRead: %v", err)
+	}
+
+	ctx := newRealFSContext(0, 0)
+	setCurrentFH(ctx, fileHandle)
+
+	args := encodeWriteArgs(stateid, 5, types.UNSTABLE4, nil)
+	count, _ := decodeWriteResok(t, fx.handler.handleWrite(ctx, bytes.NewReader(args)))
+	if count != 0 {
+		t.Errorf("count = %d, want 0", count)
+	}
+
+	after, err := metaSvc.GetFileForRead(t.Context(), fileHandle)
+	if err != nil {
+		t.Fatalf("GetFileForRead: %v", err)
+	}
+	if !after.Mtime.Equal(before.Mtime) {
+		t.Errorf("time_modify moved on a zero-count WRITE: %v -> %v", before.Mtime, after.Mtime)
+	}
+	if after.Size != before.Size {
+		t.Errorf("size moved on a zero-count WRITE: %d -> %d", before.Size, after.Size)
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/write_stable_test.go
+++ b/internal/adapter/nfs/v4/handlers/write_stable_test.go
@@ -102,3 +102,24 @@ func TestWrite_ZeroCountLeavesTimeModify(t *testing.T) {
 		t.Errorf("size moved on a zero-count WRITE: %d -> %d", before.Size, after.Size)
 	}
 }
+
+// TestWrite_RejectsOutOfRangeStableHow pins that an undefined stable_how4 is
+// refused rather than echoed back. The reply's committed field is drawn from
+// the same three-value enum (RFC 7530 Section 16.36.2), so accepting the write
+// and reporting what was asked for would put an invalid enum on the wire.
+func TestWrite_RejectsOutOfRangeStableHow(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+	fileHandle, stateid := openFileAndGetStateid(t, fx, "badstable",
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE)
+
+	ctx := newRealFSContext(0, 0)
+	setCurrentFH(ctx, fileHandle)
+
+	args := encodeWriteArgs(stateid, 0, types.FILE_SYNC4+1, []byte("payload"))
+	result := fx.handler.handleWrite(ctx, bytes.NewReader(args))
+
+	if result.Status != types.NFS4ERR_BADXDR {
+		t.Errorf("WRITE with stable_how4=%d status = %d, want NFS4ERR_BADXDR (%d)",
+			types.FILE_SYNC4+1, result.Status, types.NFS4ERR_BADXDR)
+	}
+}

--- a/internal/adapter/nfs/v4/state/index_consistency_test.go
+++ b/internal/adapter/nfs/v4/state/index_consistency_test.go
@@ -136,7 +136,7 @@ func TestOpenStateByFile_EvictClearsIndex(t *testing.T) {
 	fileIndexMatchesAuthoritative(t, sm)
 }
 
-func TestOpenStateByFile_FreeStateidRemovesFromIndex(t *testing.T) {
+func TestOpenStateByFile_FreeStateidLeavesLiveOpenIndexed(t *testing.T) {
 	sm := NewStateManager(90 * time.Second)
 	fh := []byte("fh-free-stateid")
 
@@ -146,15 +146,17 @@ func TestOpenStateByFile_FreeStateidRemovesFromIndex(t *testing.T) {
 		t.Fatalf("after open: index len = %d, want 1", n)
 	}
 
+	// FREE_STATEID refuses a live open, so the per-file index — which is what
+	// share-reservation conflicts are decided from — must still list it.
 	sm.mu.Lock()
 	err := sm.freeOpenStateidLocked(0, &stateid)
 	sm.mu.Unlock()
-	if err != nil {
-		t.Fatalf("freeOpenStateidLocked: %v", err)
+	if stateErr, ok := err.(*NFS4StateError); !ok || stateErr.Status != types.NFS4ERR_LOCKS_HELD {
+		t.Fatalf("freeOpenStateidLocked: expected NFS4ERR_LOCKS_HELD, got %v", err)
 	}
 
-	if n := fileIndexLen(sm, fh); n != 0 {
-		t.Fatalf("after free: index len = %d, want 0", n)
+	if n := fileIndexLen(sm, fh); n != 1 {
+		t.Fatalf("after refused free: index len = %d, want 1", n)
 	}
 	fileIndexMatchesAuthoritative(t, sm)
 }

--- a/internal/adapter/nfs/v4/state/shareres_test.go
+++ b/internal/adapter/nfs/v4/state/shareres_test.go
@@ -172,7 +172,7 @@ func readBypassStateid() *types.Stateid4 {
 	return sid
 }
 
-func TestValidateStateid_ReadBypass_AllowedOnReadRejectedOnWrite(t *testing.T) {
+func TestValidateStateid_ReadBypass_AcceptedOnReadAndWrite(t *testing.T) {
 	sm := NewStateManager(90 * time.Second)
 
 	// READ: all-ones is permitted (returns nil openState, nil error).
@@ -184,17 +184,14 @@ func TestValidateStateid_ReadBypass_AllowedOnReadRejectedOnWrite(t *testing.T) {
 		t.Error("special stateid should return nil openState")
 	}
 
-	// WRITE: all-ones MUST be rejected with NFS4ERR_BAD_STATEID.
-	_, err = sm.ValidateStateid(readBypassStateid(), nil, StateidOpWrite)
-	if err == nil {
-		t.Fatal("read-bypass on WRITE should be rejected")
+	// WRITE: all-ones is accepted too, behaving as the anonymous stateid
+	// (RFC 7530 Section 16.36.4). With no open on the file nothing denies it.
+	openState, err = sm.ValidateStateid(readBypassStateid(), nil, StateidOpWrite)
+	if err != nil {
+		t.Fatalf("read-bypass on WRITE should be allowed: %v", err)
 	}
-	stateErr, ok := err.(*NFS4StateError)
-	if !ok {
-		t.Fatalf("expected *NFS4StateError, got %T", err)
-	}
-	if stateErr.Status != types.NFS4ERR_BAD_STATEID {
-		t.Errorf("status = %d, want NFS4ERR_BAD_STATEID (%d)", stateErr.Status, types.NFS4ERR_BAD_STATEID)
+	if openState != nil {
+		t.Error("special stateid should return nil openState")
 	}
 }
 

--- a/internal/adapter/nfs/v4/state/stateid.go
+++ b/internal/adapter/nfs/v4/state/stateid.go
@@ -54,19 +54,21 @@ var (
 	ErrLocked       = &NFS4StateError{Status: types.NFS4ERR_LOCKED, Message: "share reservation denies this I/O"}
 )
 
-// StateidOp identifies the operation family using a stateid. It controls which
-// special stateids are accepted: per RFC 7530 Section 9.1.4.3 the all-ones
-// "READ bypass" stateid is valid only on READ; using it on a write-family
-// operation (WRITE / SETATTR-size / LOCK) MUST yield NFS4ERR_BAD_STATEID.
+// StateidOp identifies the operation family using a stateid. It controls how
+// the two special stateids of RFC 7530 Section 9.1.4.3 are treated: on READ the
+// all-ones "READ bypass" stateid skips share-mode enforcement, while on a
+// write-family operation it is treated exactly like the anonymous stateid
+// (RFC 7530 Section 16.36.4).
 type StateidOp uint8
 
 const (
-	// StateidOpRead is a READ-family operation. Both the anonymous (all-zeros)
-	// and the READ-bypass (all-ones) special stateids are permitted.
+	// StateidOpRead is a READ-family operation. The anonymous (all-zeros)
+	// stateid is subject to the file's share-deny modes; the READ-bypass
+	// (all-ones) stateid is not.
 	StateidOpRead StateidOp = iota
 
 	// StateidOpWrite is a write-family operation (WRITE, SETATTR size change,
-	// LOCK). The anonymous stateid is permitted; the READ-bypass stateid is not.
+	// LOCK). Both special stateids are subject to the file's share-deny modes.
 	StateidOpWrite
 )
 
@@ -129,10 +131,12 @@ func (sm *StateManager) isCurrentEpoch(other [types.NFS4_OTHER_SIZE]byte) bool {
 // returns the associated OpenState.
 //
 // Per RFC 7530 Section 9.1.4, validation checks:
-//  1. Special stateids: the anonymous (all-zeros) stateid bypasses validation
-//     on any op; the READ-bypass (all-ones) stateid is accepted ONLY when
-//     op == StateidOpRead and otherwise rejected with NFS4ERR_BAD_STATEID
-//     (RFC 7530 Section 9.1.4.3). Both return (nil, nil) when accepted.
+//  1. Special stateids: the anonymous (all-zeros) stateid carries no open
+//     state, so it is checked against the share-deny modes of the opens that
+//     do exist on the file; the READ-bypass (all-ones) stateid skips that
+//     check on READ and is treated as the anonymous stateid everywhere else
+//     (RFC 7530 Sections 9.1.4.3 and 16.36.4). Both return (nil, nil) when
+//     accepted, and NFS4ERR_LOCKED when an open denies the access.
 //  2. Route by type tag: open -> openStateByOther, lock -> lockStateByOther
 //     (returns the parent open state), delegation -> delegByOther
 //  3. If not found -> NFS4ERR_BAD_STATEID (or NFS4ERR_STALE_STATEID for wrong epoch)
@@ -147,19 +151,16 @@ func (sm *StateManager) isCurrentEpoch(other [types.NFS4_OTHER_SIZE]byte) bool {
 // Caller must NOT hold sm.mu.
 func (sm *StateManager) ValidateStateid(stateid *types.Stateid4, currentFH []byte, op StateidOp) (*OpenState, error) {
 	// Step 1: Special stateids.
-	// The READ-bypass (all-ones) stateid is READ-only: reject it on
-	// write-family operations so a client cannot use it to bypass share-mode
-	// enforcement and byte-range locks (RFC 7530 Section 9.1.4.3).
-	if stateid.IsReadBypassStateid() {
-		if op != StateidOpRead {
-			return nil, ErrBadStateid
-		}
+	// The READ-bypass (all-ones) stateid asks the server to serve a READ even
+	// where an open would deny it, so on READ it skips the share-deny check
+	// below. On a write-family operation it carries no such licence: RFC 7530
+	// Section 16.36.4 makes it behave exactly like the anonymous stateid.
+	if stateid.IsReadBypassStateid() && op == StateidOpRead {
 		return nil, nil
 	}
-	// The anonymous (all-zeros) stateid is permitted on READ and WRITE, but it
-	// names no open state, so the share reservations standing on the file are
-	// all the server has to judge the I/O by.
-	if stateid.IsAnonymousStateid() {
+	// Neither special stateid names an open state, so the share reservations
+	// standing on the file are all the server has to judge the I/O by.
+	if stateid.IsSpecialStateid() {
 		if err := sm.anonymousIOBlocked(currentFH, op); err != nil {
 			return nil, err
 		}
@@ -505,8 +506,8 @@ func (sm *StateManager) freeLockStateidLocked(clientID uint64, stateid *types.St
 	return nil
 }
 
-// freeOpenStateidLocked frees an open stateid.
-// Returns NFS4ERR_LOCKS_HELD if the open has associated locks.
+// freeOpenStateidLocked answers FREE_STATEID for an open stateid.
+// A live open is itself a held lock, so this always refuses.
 // Caller must hold sm.mu.
 func (sm *StateManager) freeOpenStateidLocked(clientID uint64, stateid *types.Stateid4) error {
 	openState, exists := sm.openStateByOther[stateid.Other]
@@ -526,41 +527,15 @@ func (sm *StateManager) freeOpenStateidLocked(clientID uint64, stateid *types.St
 		}
 	}
 
-	// Check if any lock stateids reference this open
-	if len(openState.LockStates) > 0 {
-		return &NFS4StateError{
-			Status:  types.NFS4ERR_LOCKS_HELD,
-			Message: fmt.Sprintf("open stateid has %d locks held", len(openState.LockStates)),
-		}
+	// An open stateid that is still in openStateByOther names a live open, and
+	// RFC 8881 Section 18.38.3 counts an open among the "locks (of any kind)"
+	// that make FREE_STATEID return NFS4ERR_LOCKS_HELD. CLOSE, not FREE_STATEID,
+	// is what releases an open; freeing it here would drop the share
+	// reservation while the client still believes it holds one.
+	return &NFS4StateError{
+		Status:  types.NFS4ERR_LOCKS_HELD,
+		Message: fmt.Sprintf("open stateid is still open (%d lock stateids)", len(openState.LockStates)),
 	}
-
-	// Remove from openStateByOther and the per-file index
-	delete(sm.openStateByOther, stateid.Other)
-	sm.removeOpenStateFromFileLocked(openState)
-
-	// Remove from owner's OpenStates slice
-	if openState.Owner != nil {
-		for i, os := range openState.Owner.OpenStates {
-			if os == openState {
-				openState.Owner.OpenStates = append(
-					openState.Owner.OpenStates[:i],
-					openState.Owner.OpenStates[i+1:]...,
-				)
-				break
-			}
-		}
-
-		// If owner has no more open states, clean up the owner
-		if len(openState.Owner.OpenStates) == 0 {
-			delete(sm.openOwners, openState.Owner.Key())
-		}
-	}
-
-	logger.Info("FREE_STATEID: open stateid freed",
-		"client_id", clientID,
-		"stateid_other", hex.EncodeToString(stateid.Other[:]))
-
-	return nil
 }
 
 // freeDelegStateidLocked frees a delegation stateid.
@@ -743,8 +718,11 @@ func (sm *StateManager) testDelegStateid(stateid *types.Stateid4) uint32 {
 // Without this a deny mode was advisory: it refused a conflicting OPEN but not
 // the I/O of a client that skipped OPEN and used the anonymous stateid, which is
 // the case the deny mode exists to stop. Linux nfsd applies the same rule in
-// check_special_stateids, and likewise exempts the READ-bypass stateid on READ,
-// which never reaches here.
+// check_special_stateids.
+//
+// The READ-bypass stateid reaches this on a write-family operation, where
+// RFC 7530 Section 16.36.4 makes it behave exactly like the anonymous stateid.
+// On READ it does not: bypassing this check is the whole point of it.
 func (sm *StateManager) anonymousIOBlocked(currentFH []byte, op StateidOp) error {
 	if len(currentFH) == 0 {
 		return nil

--- a/internal/adapter/nfs/v4/state/stateid_authz_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_authz_test.go
@@ -162,9 +162,11 @@ func TestFreeStateid_CrossClientOpen(t *testing.T) {
 		t.Error("victim's open stateid was destroyed by another client")
 	}
 
-	// Owning client can still free it.
-	if err := sm.FreeStateid(victimClientID, &openResult.Stateid); err != nil {
-		t.Fatalf("FreeStateid by owning client: %v", err)
+	// The owning client gets a different refusal — LOCKS_HELD, because the open
+	// is still open — which is what distinguishes "not yours" from "not now".
+	err = sm.FreeStateid(victimClientID, &openResult.Stateid)
+	if stateErr, ok := err.(*NFS4StateError); !ok || stateErr.Status != types.NFS4ERR_LOCKS_HELD {
+		t.Errorf("expected NFS4ERR_LOCKS_HELD for the owning client, got %v", err)
 	}
 }
 

--- a/internal/adapter/nfs/v4/state/stateid_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_test.go
@@ -1290,7 +1290,7 @@ func TestFreeStateid(t *testing.T) {
 		}
 	})
 
-	t.Run("free_open_stateid", func(t *testing.T) {
+	t.Run("free_open_stateid_still_open", func(t *testing.T) {
 		sm := NewStateManager(90 * time.Second)
 		defer sm.Shutdown()
 
@@ -1307,15 +1307,21 @@ func TestFreeStateid(t *testing.T) {
 			t.Fatalf("ConfirmOpen: %v", err)
 		}
 
-		// Free the open stateid (no locks held)
+		// An open is itself one of the "locks (of any kind)" of RFC 8881
+		// Section 18.38.3, so FREE_STATEID refuses it even with no byte-range
+		// locks: CLOSE is what releases an open.
 		err = sm.FreeStateid(0, &openResult.Stateid)
-		if err != nil {
-			t.Fatalf("FreeStateid open: %v", err)
+		stateErr, ok := err.(*NFS4StateError)
+		if !ok {
+			t.Fatalf("FreeStateid on a live open: expected NFS4StateError, got %T (%v)", err, err)
+		}
+		if stateErr.Status != types.NFS4ERR_LOCKS_HELD {
+			t.Errorf("Status = %d, want NFS4ERR_LOCKS_HELD (%d)",
+				stateErr.Status, types.NFS4ERR_LOCKS_HELD)
 		}
 
-		// Verify open state is gone
-		if sm.GetOpenState(openResult.Stateid.Other) != nil {
-			t.Error("Open state should be removed after FreeStateid")
+		if sm.GetOpenState(openResult.Stateid.Other) == nil {
+			t.Error("Open state should survive a refused FreeStateid")
 		}
 	})
 

--- a/internal/adapter/nfs/v4/types/current_stateid.go
+++ b/internal/adapter/nfs/v4/types/current_stateid.go
@@ -23,18 +23,10 @@ import "io"
 // which is what RFC 8881 Section 16.2.3.1.2's last example requires and what
 // the Linux server does.
 
-// IsCurrentStateidPlaceholder reports whether this stateid is the NFSv4.1
+// isCurrentStateidPlaceholder reports whether this stateid is the NFSv4.1
 // "use the current stateid" value: seqid 1 with an all-zeros "other".
-func (s *Stateid4) IsCurrentStateidPlaceholder() bool {
-	if s.Seqid != 1 {
-		return false
-	}
-	for _, b := range s.Other {
-		if b != 0 {
-			return false
-		}
-	}
-	return true
+func (s *Stateid4) isCurrentStateidPlaceholder() bool {
+	return s.Seqid == 1 && s.Other == [NFS4_OTHER_SIZE]byte{}
 }
 
 // tracksCurrentStateid reports whether the placeholder is meaningful in this
@@ -72,12 +64,12 @@ func (c *CompoundContext) RestoreCurrentStateid() {
 	c.hasCurrentStateid = c.hasSavedStateid
 }
 
-// ResolveStateid substitutes the COMPOUND's current stateid for the placeholder
+// resolveStateid substitutes the COMPOUND's current stateid for the placeholder
 // value, returning the stateid the operation should act on and an NFSv4 status.
 // Any other stateid — and any stateid at all in a v4.0 COMPOUND — is returned
 // unchanged.
-func (c *CompoundContext) ResolveStateid(sid *Stateid4) (*Stateid4, uint32) {
-	if !c.tracksCurrentStateid() || !sid.IsCurrentStateidPlaceholder() {
+func (c *CompoundContext) resolveStateid(sid *Stateid4) (*Stateid4, uint32) {
+	if !c.tracksCurrentStateid() || !sid.isCurrentStateidPlaceholder() {
 		return sid, NFS4_OK
 	}
 	if !c.hasCurrentStateid {
@@ -97,7 +89,7 @@ func DecodeStateidArg(ctx *CompoundContext, reader io.Reader) (*Stateid4, uint32
 	if err != nil {
 		return nil, NFS4ERR_BADXDR
 	}
-	return ctx.ResolveStateid(sid)
+	return ctx.resolveStateid(sid)
 }
 
 // ClearsCurrentStateid reports whether an operation sets or voids the current

--- a/internal/adapter/nfs/v4/types/current_stateid.go
+++ b/internal/adapter/nfs/v4/types/current_stateid.go
@@ -1,0 +1,116 @@
+package types
+
+import "io"
+
+// Current stateid tracking (RFC 8881 Section 16.2.3.1.2).
+//
+// NFSv4.1 lets one operation in a COMPOUND hand its stateid to a later one
+// without the client having to name it: a stateid of seqid 1 with an all-zeros
+// "other" is a placeholder meaning "the current stateid". The COMPOUND keeps
+// that stateid alongside the current filehandle, under three rules:
+//
+//   - an operation that returns a stateid sets the current stateid to it;
+//   - an operation that sets the current filehandle without returning a
+//     stateid drops the current stateid;
+//   - an operation that merely uses a stateid leaves it alone.
+//
+// SAVEFH and RESTOREFH carry the stateid along with the filehandle they save
+// and restore.
+//
+// A COMPOUND that has no current stateid — nothing has set one, or a
+// filehandle operation dropped it — answers the placeholder with
+// NFS4ERR_BAD_STATEID rather than silently substituting the anonymous stateid,
+// which is what RFC 8881 Section 16.2.3.1.2's last example requires and what
+// the Linux server does.
+
+// IsCurrentStateidPlaceholder reports whether this stateid is the NFSv4.1
+// "use the current stateid" value: seqid 1 with an all-zeros "other".
+func (s *Stateid4) IsCurrentStateidPlaceholder() bool {
+	if s.Seqid != 1 {
+		return false
+	}
+	for _, b := range s.Other {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// tracksCurrentStateid reports whether the placeholder is meaningful in this
+// COMPOUND. It is an NFSv4.1 addition; in a v4.0 COMPOUND (1, 0) is just an
+// ordinary stateid the server never issued.
+func (c *CompoundContext) tracksCurrentStateid() bool {
+	return c.MinorVersionAccepted && c.MinorVersion >= 1
+}
+
+// SetCurrentStateid records the stateid an operation returned as the COMPOUND's
+// current stateid.
+func (c *CompoundContext) SetCurrentStateid(sid *Stateid4) {
+	c.currentStateid = *sid
+	c.hasCurrentStateid = true
+}
+
+// ClearCurrentStateid drops the current stateid, as an operation that sets the
+// current filehandle without returning a stateid must.
+func (c *CompoundContext) ClearCurrentStateid() {
+	c.currentStateid = Stateid4{}
+	c.hasCurrentStateid = false
+}
+
+// SaveCurrentStateid is SAVEFH's half of the pair: the saved filehandle takes
+// the current stateid with it.
+func (c *CompoundContext) SaveCurrentStateid() {
+	c.savedStateid = c.currentStateid
+	c.hasSavedStateid = c.hasCurrentStateid
+}
+
+// RestoreCurrentStateid is RESTOREFH's half: the restored filehandle brings
+// back the stateid saved with it.
+func (c *CompoundContext) RestoreCurrentStateid() {
+	c.currentStateid = c.savedStateid
+	c.hasCurrentStateid = c.hasSavedStateid
+}
+
+// ResolveStateid substitutes the COMPOUND's current stateid for the placeholder
+// value, returning the stateid the operation should act on and an NFSv4 status.
+// Any other stateid — and any stateid at all in a v4.0 COMPOUND — is returned
+// unchanged.
+func (c *CompoundContext) ResolveStateid(sid *Stateid4) (*Stateid4, uint32) {
+	if !c.tracksCurrentStateid() || !sid.IsCurrentStateidPlaceholder() {
+		return sid, NFS4_OK
+	}
+	if !c.hasCurrentStateid {
+		return nil, NFS4ERR_BAD_STATEID
+	}
+	current := c.currentStateid
+	return &current, NFS4_OK
+}
+
+// DecodeStateidArg decodes a stateid4 operation argument and resolves the
+// current-stateid placeholder in one step, so every operation that takes a
+// stateid gets the same treatment. It returns NFS4ERR_BADXDR if the argument
+// does not decode and NFS4ERR_BAD_STATEID if the placeholder names a current
+// stateid the COMPOUND does not have.
+func DecodeStateidArg(ctx *CompoundContext, reader io.Reader) (*Stateid4, uint32) {
+	sid, err := DecodeStateid4(reader)
+	if err != nil {
+		return nil, NFS4ERR_BADXDR
+	}
+	return ctx.ResolveStateid(sid)
+}
+
+// ClearsCurrentStateid reports whether an operation sets or voids the current
+// filehandle without returning a stateid, which per RFC 8881 Section
+// 16.2.3.1.2 drops the current stateid along with it. RESTOREFH is absent on
+// purpose: it restores the saved stateid instead of dropping one.
+func ClearsCurrentStateid(opCode uint32) bool {
+	switch opCode {
+	case OP_PUTFH, OP_PUTROOTFH, OP_PUTPUBFH,
+		OP_LOOKUP, OP_LOOKUPP, OP_CREATE, OP_OPENATTR,
+		OP_SECINFO, OP_SECINFO_NO_NAME:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/adapter/nfs/v4/types/current_stateid_test.go
+++ b/internal/adapter/nfs/v4/types/current_stateid_test.go
@@ -1,0 +1,111 @@
+package types
+
+import "testing"
+
+func v41Ctx() *CompoundContext {
+	return &CompoundContext{MinorVersion: 1, MinorVersionAccepted: true}
+}
+
+func realStateid(seqid uint32, tag byte) *Stateid4 {
+	sid := &Stateid4{Seqid: seqid}
+	sid.Other[0] = tag
+	return sid
+}
+
+func TestIsCurrentStateidPlaceholder(t *testing.T) {
+	placeholder := &Stateid4{Seqid: 1}
+	if !placeholder.IsCurrentStateidPlaceholder() {
+		t.Error("(1, all-zeros) should be the current-stateid placeholder")
+	}
+	// The anonymous stateid is (0, all-zeros) and must not be mistaken for it.
+	if (&Stateid4{}).IsCurrentStateidPlaceholder() {
+		t.Error("the anonymous stateid is not the placeholder")
+	}
+	if realStateid(1, 0x01).IsCurrentStateidPlaceholder() {
+		t.Error("a real stateid with seqid 1 is not the placeholder")
+	}
+}
+
+func TestResolveStateid_NoCurrentStateidIsBadStateid(t *testing.T) {
+	ctx := v41Ctx()
+	if _, status := ctx.ResolveStateid(&Stateid4{Seqid: 1}); status != NFS4ERR_BAD_STATEID {
+		t.Errorf("status = %d, want NFS4ERR_BAD_STATEID (%d)", status, NFS4ERR_BAD_STATEID)
+	}
+}
+
+func TestResolveStateid_SubstitutesCurrent(t *testing.T) {
+	ctx := v41Ctx()
+	open := realStateid(3, 0x01)
+	ctx.SetCurrentStateid(open)
+
+	got, status := ctx.ResolveStateid(&Stateid4{Seqid: 1})
+	if status != NFS4_OK {
+		t.Fatalf("status = %d, want NFS4_OK", status)
+	}
+	if *got != *open {
+		t.Errorf("resolved = %+v, want %+v", *got, *open)
+	}
+
+	// A filehandle operation drops it again.
+	ctx.ClearCurrentStateid()
+	if _, status := ctx.ResolveStateid(&Stateid4{Seqid: 1}); status != NFS4ERR_BAD_STATEID {
+		t.Errorf("after clear: status = %d, want NFS4ERR_BAD_STATEID", status)
+	}
+}
+
+func TestResolveStateid_V40LeavesPlaceholderAlone(t *testing.T) {
+	ctx := &CompoundContext{MinorVersion: 0, MinorVersionAccepted: true}
+	placeholder := &Stateid4{Seqid: 1}
+
+	got, status := ctx.ResolveStateid(placeholder)
+	if status != NFS4_OK {
+		t.Fatalf("status = %d, want NFS4_OK", status)
+	}
+	if got != placeholder {
+		t.Error("a v4.0 COMPOUND has no current stateid; (1, 0) is an ordinary stateid there")
+	}
+}
+
+func TestSaveRestoreCurrentStateid(t *testing.T) {
+	ctx := v41Ctx()
+	open := realStateid(3, 0x01)
+	ctx.SetCurrentStateid(open)
+
+	ctx.SaveCurrentStateid() // SAVEFH
+	ctx.ClearCurrentStateid()
+	ctx.RestoreCurrentStateid() // RESTOREFH
+
+	got, status := ctx.ResolveStateid(&Stateid4{Seqid: 1})
+	if status != NFS4_OK {
+		t.Fatalf("status = %d, want NFS4_OK", status)
+	}
+	if *got != *open {
+		t.Errorf("restored = %+v, want %+v", *got, *open)
+	}
+}
+
+func TestSaveCurrentStateid_CarriesAbsence(t *testing.T) {
+	ctx := v41Ctx()
+	ctx.SaveCurrentStateid() // SAVEFH with nothing current
+	ctx.SetCurrentStateid(realStateid(3, 0x01))
+	ctx.RestoreCurrentStateid()
+
+	if _, status := ctx.ResolveStateid(&Stateid4{Seqid: 1}); status != NFS4ERR_BAD_STATEID {
+		t.Errorf("status = %d, want NFS4ERR_BAD_STATEID: RESTOREFH must bring back the absence SAVEFH saved", status)
+	}
+}
+
+func TestClearsCurrentStateid(t *testing.T) {
+	for _, op := range []uint32{OP_PUTFH, OP_PUTROOTFH, OP_PUTPUBFH, OP_LOOKUP, OP_LOOKUPP, OP_CREATE, OP_OPENATTR} {
+		if !ClearsCurrentStateid(op) {
+			t.Errorf("%s sets the current filehandle without returning a stateid; it must drop the current stateid", OpName(op))
+		}
+	}
+	// RESTOREFH restores the saved stateid rather than dropping one, and the
+	// operations that merely consume a stateid leave it in place.
+	for _, op := range []uint32{OP_RESTOREFH, OP_SAVEFH, OP_READ, OP_WRITE, OP_SETATTR, OP_CLOSE, OP_LOCK, OP_LOCKU} {
+		if ClearsCurrentStateid(op) {
+			t.Errorf("%s must not drop the current stateid", OpName(op))
+		}
+	}
+}

--- a/internal/adapter/nfs/v4/types/current_stateid_test.go
+++ b/internal/adapter/nfs/v4/types/current_stateid_test.go
@@ -14,21 +14,21 @@ func realStateid(seqid uint32, tag byte) *Stateid4 {
 
 func TestIsCurrentStateidPlaceholder(t *testing.T) {
 	placeholder := &Stateid4{Seqid: 1}
-	if !placeholder.IsCurrentStateidPlaceholder() {
+	if !placeholder.isCurrentStateidPlaceholder() {
 		t.Error("(1, all-zeros) should be the current-stateid placeholder")
 	}
 	// The anonymous stateid is (0, all-zeros) and must not be mistaken for it.
-	if (&Stateid4{}).IsCurrentStateidPlaceholder() {
+	if (&Stateid4{}).isCurrentStateidPlaceholder() {
 		t.Error("the anonymous stateid is not the placeholder")
 	}
-	if realStateid(1, 0x01).IsCurrentStateidPlaceholder() {
+	if realStateid(1, 0x01).isCurrentStateidPlaceholder() {
 		t.Error("a real stateid with seqid 1 is not the placeholder")
 	}
 }
 
 func TestResolveStateid_NoCurrentStateidIsBadStateid(t *testing.T) {
 	ctx := v41Ctx()
-	if _, status := ctx.ResolveStateid(&Stateid4{Seqid: 1}); status != NFS4ERR_BAD_STATEID {
+	if _, status := ctx.resolveStateid(&Stateid4{Seqid: 1}); status != NFS4ERR_BAD_STATEID {
 		t.Errorf("status = %d, want NFS4ERR_BAD_STATEID (%d)", status, NFS4ERR_BAD_STATEID)
 	}
 }
@@ -38,7 +38,7 @@ func TestResolveStateid_SubstitutesCurrent(t *testing.T) {
 	open := realStateid(3, 0x01)
 	ctx.SetCurrentStateid(open)
 
-	got, status := ctx.ResolveStateid(&Stateid4{Seqid: 1})
+	got, status := ctx.resolveStateid(&Stateid4{Seqid: 1})
 	if status != NFS4_OK {
 		t.Fatalf("status = %d, want NFS4_OK", status)
 	}
@@ -48,7 +48,7 @@ func TestResolveStateid_SubstitutesCurrent(t *testing.T) {
 
 	// A filehandle operation drops it again.
 	ctx.ClearCurrentStateid()
-	if _, status := ctx.ResolveStateid(&Stateid4{Seqid: 1}); status != NFS4ERR_BAD_STATEID {
+	if _, status := ctx.resolveStateid(&Stateid4{Seqid: 1}); status != NFS4ERR_BAD_STATEID {
 		t.Errorf("after clear: status = %d, want NFS4ERR_BAD_STATEID", status)
 	}
 }
@@ -57,7 +57,7 @@ func TestResolveStateid_V40LeavesPlaceholderAlone(t *testing.T) {
 	ctx := &CompoundContext{MinorVersion: 0, MinorVersionAccepted: true}
 	placeholder := &Stateid4{Seqid: 1}
 
-	got, status := ctx.ResolveStateid(placeholder)
+	got, status := ctx.resolveStateid(placeholder)
 	if status != NFS4_OK {
 		t.Fatalf("status = %d, want NFS4_OK", status)
 	}
@@ -75,7 +75,7 @@ func TestSaveRestoreCurrentStateid(t *testing.T) {
 	ctx.ClearCurrentStateid()
 	ctx.RestoreCurrentStateid() // RESTOREFH
 
-	got, status := ctx.ResolveStateid(&Stateid4{Seqid: 1})
+	got, status := ctx.resolveStateid(&Stateid4{Seqid: 1})
 	if status != NFS4_OK {
 		t.Fatalf("status = %d, want NFS4_OK", status)
 	}
@@ -90,7 +90,7 @@ func TestSaveCurrentStateid_CarriesAbsence(t *testing.T) {
 	ctx.SetCurrentStateid(realStateid(3, 0x01))
 	ctx.RestoreCurrentStateid()
 
-	if _, status := ctx.ResolveStateid(&Stateid4{Seqid: 1}); status != NFS4ERR_BAD_STATEID {
+	if _, status := ctx.resolveStateid(&Stateid4{Seqid: 1}); status != NFS4ERR_BAD_STATEID {
 		t.Errorf("status = %d, want NFS4ERR_BAD_STATEID: RESTOREFH must bring back the absence SAVEFH saved", status)
 	}
 }

--- a/internal/adapter/nfs/v4/types/types.go
+++ b/internal/adapter/nfs/v4/types/types.go
@@ -56,6 +56,12 @@ type CompoundResult struct {
 
 	// Data contains the XDR-encoded operation-specific result.
 	Data []byte
+
+	// Stateid is the stateid this operation returned, when it returns one
+	// (OPEN, OPEN_CONFIRM, OPEN_DOWNGRADE, CLOSE, LOCK, LOCKU). The COMPOUND
+	// loop makes it the current stateid, per RFC 8881 Section 16.2.3.1.2. Nil
+	// for every other operation.
+	Stateid *Stateid4
 }
 
 // Compound4Response represents the COMPOUND4res XDR structure.
@@ -94,6 +100,16 @@ type CompoundContext struct {
 	// SavedFH is the saved filehandle for SAVEFH/RESTOREFH.
 	// Nil means no saved filehandle.
 	SavedFH []byte
+
+	// currentStateid / savedStateid are the NFSv4.1 current and saved stateids
+	// that travel with CurrentFH and SavedFH. The has* flags separate "no
+	// stateid" from the all-zeros stateid, which is a real (anonymous) value:
+	// the placeholder resolves to NFS4ERR_BAD_STATEID only in the former case.
+	// Reached through the methods in current_stateid.go.
+	currentStateid    Stateid4
+	savedStateid      Stateid4
+	hasCurrentStateid bool
+	hasSavedStateid   bool
 
 	// ClientAddr is the remote address of the client connection.
 	ClientAddr string

--- a/internal/adapter/nfs/v4/types/types.go
+++ b/internal/adapter/nfs/v4/types/types.go
@@ -58,9 +58,9 @@ type CompoundResult struct {
 	Data []byte
 
 	// Stateid is the stateid this operation returned, when it returns one
-	// (OPEN, OPEN_CONFIRM, OPEN_DOWNGRADE, CLOSE, LOCK, LOCKU). The COMPOUND
-	// loop makes it the current stateid, per RFC 8881 Section 16.2.3.1.2. Nil
-	// for every other operation.
+	// (OPEN, OPEN_CONFIRM, OPEN_DOWNGRADE, CLOSE, LOCK, LOCKU and
+	// GET_DIR_DELEGATION). The COMPOUND loop makes it the current stateid,
+	// per RFC 8881 Section 16.2.3.1.2. Nil for every other operation.
 	Stateid *Stateid4
 }
 

--- a/internal/adapter/nfs/v4/types/types.go
+++ b/internal/adapter/nfs/v4/types/types.go
@@ -296,8 +296,9 @@ func (s *Stateid4) IsAnonymousStateid() bool {
 
 // IsReadBypassStateid reports whether the stateid is the READ-bypass special
 // stateid (seqid=0xFFFFFFFF, other=all-ones). Per RFC 7530 Section 9.1.4.3 it
-// bypasses share-mode and byte-range-lock checks and is valid ONLY on READ;
-// callers MUST reject it on write-family operations with NFS4ERR_BAD_STATEID.
+// bypasses share-mode and byte-range-lock checks on READ; on a write-family
+// operation RFC 7530 Section 16.36.4 makes it behave exactly like the
+// anonymous stateid.
 func (s *Stateid4) IsReadBypassStateid() bool {
 	return s.isReadBypass()
 }

--- a/internal/adapter/nfs/v4/v41/handlers/free_stateid.go
+++ b/internal/adapter/nfs/v4/v41/handlers/free_stateid.go
@@ -26,15 +26,16 @@ func HandleFreeStateid(
 	v41ctx *types.V41RequestContext,
 	reader io.Reader,
 ) *types.CompoundResult {
-	var args types.FreeStateidArgs
-	if err := args.Decode(reader); err != nil {
-		logger.Debug("FREE_STATEID: decode error", "error", err, "client", ctx.ClientAddr)
+	stateid, argStatus := types.DecodeStateidArg(ctx, reader)
+	if argStatus != types.NFS4_OK {
+		logger.Debug("FREE_STATEID: stateid argument rejected", "status", argStatus, "client", ctx.ClientAddr)
 		return &types.CompoundResult{
-			Status: types.NFS4ERR_BADXDR,
+			Status: argStatus,
 			OpCode: types.OP_FREE_STATEID,
-			Data:   EncodeStatusOnly(types.NFS4ERR_BADXDR),
+			Data:   EncodeStatusOnly(argStatus),
 		}
 	}
+	args := types.FreeStateidArgs{Stateid: *stateid}
 
 	// FREE_STATEID requires SEQUENCE context for client authorization
 	if v41ctx == nil {

--- a/internal/adapter/nfs/v4/v41/handlers/free_stateid.go
+++ b/internal/adapter/nfs/v4/v41/handlers/free_stateid.go
@@ -35,7 +35,6 @@ func HandleFreeStateid(
 			Data:   EncodeStatusOnly(argStatus),
 		}
 	}
-	args := types.FreeStateidArgs{Stateid: *stateid}
 
 	// FREE_STATEID requires SEQUENCE context for client authorization
 	if v41ctx == nil {
@@ -63,13 +62,13 @@ func HandleFreeStateid(
 	clientID := session.ClientID
 
 	// Delegate to StateManager
-	err := d.StateManager.FreeStateid(clientID, &args.Stateid)
+	err := d.StateManager.FreeStateid(clientID, stateid)
 	if err != nil {
 		nfsStatus := MapStateError(err)
 		logger.Debug("FREE_STATEID: state error",
 			"error", err,
 			"client_id", fmt.Sprintf("0x%016x", clientID),
-			"stateid_other", hex.EncodeToString(args.Stateid.Other[:]),
+			"stateid_other", hex.EncodeToString(stateid.Other[:]),
 			"nfs_status", nfsStatus,
 			"client", ctx.ClientAddr)
 		return &types.CompoundResult{
@@ -93,7 +92,7 @@ func HandleFreeStateid(
 
 	logger.Info("FREE_STATEID: stateid freed",
 		"client_id", fmt.Sprintf("0x%016x", clientID),
-		"stateid_other", hex.EncodeToString(args.Stateid.Other[:]),
+		"stateid_other", hex.EncodeToString(stateid.Other[:]),
 		"client", ctx.ClientAddr)
 
 	return &types.CompoundResult{

--- a/internal/adapter/nfs/v4/v41/handlers/get_dir_delegation.go
+++ b/internal/adapter/nfs/v4/v41/handlers/get_dir_delegation.go
@@ -132,10 +132,16 @@ func encodeGetDirDelegationOK(deleg *state.DelegationState) *types.CompoundResul
 		}
 	}
 
+	// A granted delegation returns a stateid, so it becomes the COMPOUND's
+	// current stateid (RFC 8881 Section 16.2.3.1.2). RFC 8881 Section 18.39.3
+	// spells out the other side of this for the GDD4_UNAVAIL reply below --
+	// "the current stateid is not changed" -- which is only worth saying
+	// because the granted case does change it.
 	return &types.CompoundResult{
-		Status: types.NFS4_OK,
-		OpCode: types.OP_GET_DIR_DELEGATION,
-		Data:   buf.Bytes(),
+		Status:  types.NFS4_OK,
+		Stateid: &deleg.Stateid,
+		OpCode:  types.OP_GET_DIR_DELEGATION,
+		Data:    buf.Bytes(),
 	}
 }
 

--- a/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
+++ b/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
@@ -45,10 +45,5 @@ Categories:
 | OPDG3 | bug | bad/old/stale stateid accepted | #2341 |
 | OPDG6 | bug | bad/old/stale stateid accepted | #2341 |
 | OPDG7 | bug | bad/old/stale stateid accepted | #2341 |
-| WRT1 | bug | WRITE ignores requested stability and special stateids | #2342 |
-| WRT18 | bug | WRITE ignores requested stability and special stateids | #2342 |
-| WRT2 | bug | WRITE ignores requested stability and special stateids | #2342 |
-| WRT3 | bug | WRITE ignores requested stability and special stateids | #2342 |
-| WRT4 | bug | WRITE ignores requested stability and special stateids | #2342 |
-| WRT9 | bug | WRITE ignores requested stability and special stateids | #2342 |
+| WRT18 | bug | change attribute frozen across a write session | #2342 |
 | RPLY8 | suite | knfsd fails this too — replay of a waiting LOCKU | - |

--- a/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
+++ b/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
@@ -45,5 +45,5 @@ Categories:
 | OPDG3 | bug | bad/old/stale stateid accepted | #2341 |
 | OPDG6 | bug | bad/old/stale stateid accepted | #2341 |
 | OPDG7 | bug | bad/old/stale stateid accepted | #2341 |
-| WRT18 | bug | change attribute frozen across a write session | #2342 |
+| WRT18 | bug | change attribute frozen across a write session | #2382 |
 | RPLY8 | suite | knfsd fails this too — replay of a waiting LOCKU | - |

--- a/test/nfs-conformance/pynfs/KNOWN_FAILURES_V41.md
+++ b/test/nfs-conformance/pynfs/KNOWN_FAILURES_V41.md
@@ -30,13 +30,6 @@ Categories:
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| CSID1 | bug | current stateid not tracked across a COMPOUND | #2328 |
-| CSID10 | bug | current stateid not tracked across a COMPOUND | #2328 |
-| CSID2 | bug | current stateid not tracked across a COMPOUND | #2328 |
-| CSID3 | bug | current stateid not tracked across a COMPOUND | #2328 |
-| CSID4 | bug | current stateid not tracked across a COMPOUND | #2328 |
-| CSID8 | bug | current stateid not tracked across a COMPOUND | #2328 |
-| CSID9 | bug | current stateid not tracked across a COMPOUND | #2328 |
 | DELEG1 | bug | no delegation is granted | #2329 |
 | DELEG2 | bug | no delegation is granted | #2329 |
 | DELEG23 | bug | no delegation is granted | #2329 |


### PR DESCRIPTION
Two pynfs failure groups that both land in stateid handling and the COMPOUND
context. 12 of the 13 blacklisted tests they cover now pass; the thirteenth
turns out to be a design decision rather than a bug, and is described at the
bottom.

## The finding worth reading first: #2342 is partly an OPEN bug, and it loses data

#2342 is titled "WRITE ignores requested stability level and mishandles special
stateids". `WRT1` is neither. OPEN's create path built the new file's
`FileAttr` from `createAttrs.Mode` and nothing else, so a `createattrs` size was
dropped on the floor. RFC 7530 §16.16.5 makes createattrs the new file's
initial attributes, and because WRITE only ever *grows* a file's size, nothing
downstream can recover the dropped one: the file stays permanently shorter than
the client asked for, and the tail it should serve as a hole reads back as EOF.
`WRT1` creates a 32-byte file, writes 10 bytes at offset 0, reads 20 back, and
gets 10 bytes and EOF.

That is data loss wearing a conformance-failure costume, and nobody fixing
WRITE would have found it. It is also the reason to distrust an issue's title
before its symptoms.

**The fix for it shipped in #2377, not here.** #2377 applies the whole
`createattrs` on the create path, which supersedes the size-only version this
branch carried; this is rebased onto it with that hunk dropped. The finding is
recorded here because this is where it was found.

`WRT4` is the second one the title misattributes, and it carries the same
lesson about the suite rather than the code. A zero-count WRITE stamped
`time_modify`, which is what pynfs measures — but it *also* extended the file to
the write offset, and pynfs never looks. That half was caught by
`TestWrite_ZeroCountLeavesTimeModify`, written to pin the mtime rule, asserting
on size only because it was cheap. A green `WRT4` cell would not have meant the
zero-count path was correct; do not read one as coverage.

## #2328 — the current stateid was not tracked

RFC 8881 §16.2.3.1.2 lets one operation in a COMPOUND hand its stateid to a
later one: a stateid of seqid 1 with an all-zeros `other` is a placeholder
meaning "the current stateid". Nothing tracked it, so the placeholder fell
straight through to ordinary validation and came back `NFS4ERR_BAD_STATEID`
(`other` is special) or `NFS4ERR_STALE_STATEID` (wrong boot epoch).

`CompoundContext` now carries a current and a saved stateid, and the three
rules live in one place — the operation loop in `compound.go`:

- an operation that returns a stateid makes it current;
- an operation that sets the current filehandle without returning one drops it;
- everything else, including every operation that merely consumes a stateid,
  leaves it alone.

`SAVEFH` and `RESTOREFH` carry it with the filehandle they save and restore.

Absence is tracked separately from the all-zeros stateid, which is a real
(anonymous) value: the placeholder with nothing current is
`NFS4ERR_BAD_STATEID`, not a silent anonymous access. That is the last example
in §16.2.3.1.2, and what knfsd does — it keeps a validity flag rather than
storing `(0,0)`. `CSID5` and `CSID6`, which were already passing, depend on it.

Resolution happens where a stateid argument is decoded
(`types.DecodeStateidArg`), so every operation that takes a stateid is covered
rather than the four the failing tests happen to name. It is gated on the
accepted minor version: in a v4.0 COMPOUND `(1, 0)` stays an ordinary stateid
the server never issued.

`GET_DIR_DELEGATION` also returns a stateid on a grant, and now sets the
current one. That is worth a note because a reviewer checked it against Linux
nfsd and found no `OP_SET_CURR_STATEID` flag — but nfsd does not implement
GET_DIR_DELEGATION at all, so that is an absence, not a decision. RFC 8881
§18.39.3 settles it from the other side: for the `GDD4_UNAVAIL` reply it says
"the current stateid is not changed", which is only worth saying because the
granted case does change it.

One state-layer change came with it: `FREE_STATEID` on an open stateid that is
still open used to delete the open and return `NFS4_OK`, dropping the client's
share reservation behind its back. RFC 8881 §18.38.3 counts an open among the
"locks (of any kind)" that make `FREE_STATEID` return `NFS4ERR_LOCKS_HELD`, and
knfsd refuses `SC_TYPE_OPEN` unconditionally. `CLOSE`, not `FREE_STATEID`,
releases an open.

Walks `CSID1 CSID2 CSID3 CSID4 CSID8 CSID9 CSID10` out of
`KNOWN_FAILURES_V41.md`, confirmed the same way — the literal `: PASS` line per
backend, not the grader's verdict.

## #2342 — WRITE

`WRT1` and `WRT4` are covered at the top — the first is an OPEN bug whose fix
belongs to #2377, the second a zero-count WRITE. The zero-count fix is here: a
WRITE of no bytes is still "subject to permissions checking" (§16.36.4), which
`PrepareWrite` performs without changing metadata, so the handler returns
straight after it and touches neither mtime nor size.

The other four are WRITE:

**Stability (`WRT3`).** WRITE always reported `UNSTABLE4` and never flushed, so
a client asking for `FILE_SYNC4` was told its data was merely cached — which,
per §16.36.4, "constitutes a protocol violation". NFSv3 already had exactly
this flush, with the DATA_SYNC/FILE_SYNC split spelled out; it moved to
`internal/adapter/common` and both versions now use it. `committed` reports
what was actually done, and drops back to `UNSTABLE4` if the flush fails rather
than claiming a durability that was not provided.

Note the cost this makes real: a `FILE_SYNC4` WRITE now performs the block-store
flush and an inline metadata fsync, where before it returned immediately. That
is the price of the reply being true, and it is what the v3 path has always
paid. It also inherits v3's one caveat unchanged: a share that has opted into
the writeback tier downgrades even a FILE_SYNC metadata fsync to the deferred
path, which `FlushPendingWriteForFile` documents and bounds with the
share-start journal reconcile.

**The all-ones stateid (`WRT2`).** It was rejected on write-family operations
with `NFS4ERR_BAD_STATEID`. RFC 7530 §16.36.4 says the opposite: a WRITE with
the READ-bypass stateid "is treated exactly the same as if the anonymous
stateid were used". The bypass licence is READ's alone.

**Share reservations (`WRT9`).** Neither special stateid names an open, so
per §9.1.4.3 the request is checked against the reservations the opens on the
file do hold: "when an anonymous stateid value is used and an existing open
denies the form of access requested, then access will be denied to the
request". `ValidateStateid` now answers `NFS4ERR_LOCKED`. The check is in the
state layer, so SETATTR-size gets it too, and READ gets its half — except for
the all-ones stateid on READ, which is precisely the case that may bypass it.

Walks `WRT1 WRT2 WRT3 WRT4 WRT9` out of `KNOWN_FAILURES_V40.md`. `WRT18` stays
and is re-pointed at #2382, whose subject its reason actually describes.
`OPEN4` is left alone — it is blacklisted under #2317 for failing on the SQL
backends. Every removed row is confirmed by the literal `: PASS` line in this
PR's own per-backend pynfs artifacts, `memory` and `postgres-s3` both, not by
the grader's exit code: a test whose `DEPEND:` prerequisites failed is SKIPPED
and emits no `: FAILURE` line, so a skip and a pass are the same number to a
failure-counting grader.

## `WRT18` stays blacklisted — and #2342 stays open

`WRT18` fails for a reason that is not a WRITE bug and is not mine to decide.

`FATTR4_CHANGE` is encoded from `file.Ctime`. Under deferred commit — the
default — `PrepareWrite` reuses the pending write session's frozen `LastMtime`,
and `deferredCommitWrite` sets both `Mtime` and `Ctime` from it. So every WRITE
in a burst reports the same changeid, which is what `WRT18` measures across
four WRITEs in one COMPOUND.

The freeze is deliberate and documented in `pending_writes.go`: "this ensures
all WRITE responses return the same mtime, which is critical for NFS client
page cache stability". Unfreezing it — or splitting ctime out so the change
attribute moves while mtime stays put — defeats that optimisation for NFSv4
clients, which key their cache on the change attribute. It sits in
`pkg/metadata`, shared with NFSv3 and SMB.

So the row stays, with its reason narrowed from "WRITE ignores requested
stability and special stateids" to what actually fails, and #2342 stays open
for that one test. The question hiding behind it — that while the change
attribute is frozen, a second client's writes to the same file are unobservable
to the first — is now **#2382**, which also notes that knfsd's own behaviour
should be measured first: if Linux freezes too, `WRT18` is a `suite` row rather
than ours.

## Rebased onto #2377 — what was dropped, and the one thing that was not

#2377 merged first and this is rebased onto `d080dd88d`. Three of the hunks
this branch carried are superseded and gone:

- **`ErrLocked`** — develop's declaration kept, mine dropped. Both PRs
  introduced it and it exists nowhere on the old base, so the second merge
  would not have compiled.
- **`shareDeniesAccess`** — deleted in favour of develop's
  `anonymousIOBlocked`, which routes through the same `shareConflictLocked`
  test instead of keeping a second copy of the rule. Theirs is the better of
  the two.
- **The OPEN createattrs size fix** — deleted. `open.go` on develop applies the
  whole `createAttrs` after create, which is the general form of it.

**The fourth thing was not superseded, and this is the part worth checking if
you are reviewing the merge.** It was put to me that develop already covered
the all-ones READ-bypass stateid, on the strength of `ValidateStateid`
rejecting it with `ErrBadStateid` on any non-READ operation. That rejection is
not the coverage — it is the bug. RFC 7530 §16.36.4: "For a WRITE using the
special READ bypass stateid ... the WRITE is treated exactly the same as if the
anonymous stateid were used." Being *handled* and being handled *correctly for
a write* read the same in a diff and are opposites here, and `WRT2` is the test
that says so.

Measured rather than argued, by running the same probe against a pristine
`origin/develop` tree and against this branch:

```
develop:      ValidateStateid(all-ones, StateidOpWrite) = bad stateid
this branch:  ValidateStateid(all-ones, StateidOpWrite) = <nil>
```

Had that hunk been dropped as superseded, `WRT2` would have gone back to
failing with its blacklist row already removed — CI red, and red for a reason
that would have looked like a rebase accident rather than a reverted fix.

So the merged shape keeps develop's `anonymousIOBlocked` and routes **both**
special stateids into it, with the READ-bypass stateid exempted only on READ,
which is the one case that exemption exists for.
`TestWrite_SpecialStateid_DeniedByShareReservation` was checked against both
failure modes rather than inferred from a green suite: restoring develop's
read-bypass rejection fails its `read_bypass` subtest (`10025` where
`NFS4ERR_LOCKED` is wanted), and neutering `anonymousIOBlocked` fails both
subtests.

## Noticed, not fixed here

The OPEN handler's RFC citations have drifted, and none of it is this PR's code
— my own offending line went away with the createattrs hunk, so this is a
report rather than a diff. In RFC 7530, §16.16.2 is ARGUMENT, §16.16.3 is
RESULT, §16.16.4 is "Warning to Client Implementers" and §16.16.5 is
DESCRIPTION, which is where every semantic rule below actually lives:

- `open.go` cites §16.16.3 seven times for createattrs, UNCHECKED4-on-existing
  and the EXCLUSIVE4 verifier — all DESCRIPTION material (§16.16.5).
- `open.go:670` and `:853`, and `types/constants.go:378`, cite §16.16.4 for the
  claim types, which are defined in ARGUMENT (§16.16.2).

The `Spec Citations` check cannot catch this: every section named exists, just
not the one being quoted. Worth a sweep, but a comment-only diff across a file
two PRs just touched is the wrong thing to bundle into this one.

## Verification

- The graded before/after is CI's, not this laptop's — a sibling session found
  the local pynfs harness here disagreeing with CI on identical code. Base
  numbers above are read from the `nfs-pynfs` artifacts for `5fe8954e9`; the
  after-measurement is this PR's own `NFS v4.0` / `NFS v4.1` jobs, which grade
  against the edited tables and go red if a removed row still fails.
  (For what it is worth the local runs agreed: 4.1 base had one row already
  passing, which is what CI reports.)
- `go test ./internal/... ./pkg/...` green; `go vet` clean.
- Every new test was first run against a deliberately broken build. The
  stability and zero-count tests fail without the `write.go` change (the
  zero-count one is what caught the file being extended to the write offset),
  and the share-deny test fails without the `ValidateStateid` change.

Closes #2328
