### PR TITLE
refactor(metadata): one capability set for the SQL backends, and stop overstating timestamp precision

### DIFF
--- a/cmd/dfsctl/commands/store/metadata/add.go
+++ b/cmd/dfsctl/commands/store/metadata/add.go
@@ -15,7 +15,7 @@ var (
 	addName   string
 	addType   string
 	addConfig string
-	// BadgerDB specific
+	// badger and sqlite
 	addDBPath string
 )
 
@@ -27,11 +27,15 @@ var addCmd = &cobra.Command{
 Supported types:
   - memory: In-memory store (fast, ephemeral)
   - badger: BadgerDB store (persistent, embedded)
+  - sqlite: SQLite store (persistent, embedded)
   - postgres: PostgreSQL store (persistent, distributed)
 
 Type-specific options:
   badger:
     --db-path: Path to BadgerDB directory (or prompted interactively)
+
+  sqlite:
+    --db-path: Path to the SQLite database file (or prompted interactively)
 
   postgres:
     --config: JSON with connection settings, or omit for interactive prompts
@@ -46,6 +50,9 @@ Examples:
   # Add a BadgerDB store interactively
   dfsctl store metadata add --name persistent-meta --type badger
 
+  # Add a SQLite store with flags
+  dfsctl store metadata add --name persistent-meta --type sqlite --db-path /data/meta.db
+
   # Add a PostgreSQL store with JSON config
   dfsctl store metadata add --name pg-meta --type postgres --config '{"host":"localhost","dbname":"dittofs"}'
 
@@ -56,9 +63,9 @@ Examples:
 
 func init() {
 	addCmd.Flags().StringVar(&addName, "name", "", "Store name (required)")
-	addCmd.Flags().StringVar(&addType, "type", "", "Store type: memory, badger, postgres (required)")
+	addCmd.Flags().StringVar(&addType, "type", "", "Store type: memory, badger, sqlite, postgres (required)")
 	addCmd.Flags().StringVar(&addConfig, "config", "", "Store configuration as JSON (for advanced config)")
-	addCmd.Flags().StringVar(&addDBPath, "db-path", "", "Database path (required for badger)")
+	addCmd.Flags().StringVar(&addDBPath, "db-path", "", "Database path (required for badger and sqlite)")
 	_ = addCmd.MarkFlagRequired("name")
 	_ = addCmd.MarkFlagRequired("type")
 }
@@ -104,7 +111,9 @@ func buildMetadataConfig(storeType, jsonConfig, dbPath string) (any, error) {
 	case "memory":
 		return nil, nil
 
-	case "badger":
+	// Both take a single path — a directory for badger, a database file for
+	// sqlite — so one prompt covers them.
+	case "badger", "sqlite":
 		path := dbPath
 		if path == "" {
 			var err error
@@ -156,6 +165,6 @@ func buildMetadataConfig(storeType, jsonConfig, dbPath string) (any, error) {
 		}, nil
 
 	default:
-		return nil, fmt.Errorf("unknown store type: %s (supported: memory, badger, postgres)", storeType)
+		return nil, fmt.Errorf("unknown store type: %s (supported: memory, badger, sqlite, postgres)", storeType)
 	}
 }

--- a/cmd/dfsctl/commands/store/metadata/edit.go
+++ b/cmd/dfsctl/commands/store/metadata/edit.go
@@ -43,9 +43,9 @@ Examples:
 }
 
 func init() {
-	editCmd.Flags().StringVar(&editType, "type", "", "Store type: memory, badger, postgres")
+	editCmd.Flags().StringVar(&editType, "type", "", "Store type: memory, badger, sqlite, postgres")
 	editCmd.Flags().StringVar(&editConfig, "config", "", "Store configuration as JSON")
-	editCmd.Flags().StringVar(&editDBPath, "db-path", "", "Database path (for badger)")
+	editCmd.Flags().StringVar(&editDBPath, "db-path", "", "Database path (for badger and sqlite)")
 }
 
 func runEdit(cmd *cobra.Command, args []string) error {
@@ -119,7 +119,7 @@ func runEditInteractive(client *apiclient.Client, name string, current *apiclien
 
 	// Based on store type, prompt for relevant fields
 	switch current.Type {
-	case "badger":
+	case "badger", "sqlite":
 		currentPath := ""
 		if currentConfig != nil {
 			if p, ok := currentConfig["path"].(string); ok {

--- a/cmd/dfsctl/commands/store/metadata/metadata.go
+++ b/cmd/dfsctl/commands/store/metadata/metadata.go
@@ -12,7 +12,7 @@ var Cmd = &cobra.Command{
 	Long: `Manage metadata stores on the DittoFS server.
 
 Metadata stores hold file system structure, attributes, and permissions.
-Supported types: memory, badger, postgres
+Supported types: memory, badger, sqlite, postgres
 
 Examples:
   # List metadata stores

--- a/cmd/dfsctl/commands/store/metadata/metadata_test.go
+++ b/cmd/dfsctl/commands/store/metadata/metadata_test.go
@@ -14,3 +14,25 @@ func TestMetadataCmd_RegistersExistingVerbs(t *testing.T) {
 		}
 	}
 }
+
+// TestBuildMetadataConfig_AcceptsServerSupportedTypes pins the CLI's accepted
+// store types to the server's. The switch in
+// pkg/controlplane/runtime.CreateMetadataStoreFromConfig is what actually
+// decides whether a store can be built; a type missing here is one an operator
+// cannot create or edit interactively even though the server would take it.
+//
+// postgres is absent because its branch prompts for connection settings and
+// would block on stdin. The types below all take their config from flags.
+func TestBuildMetadataConfig_AcceptsServerSupportedTypes(t *testing.T) {
+	for _, storeType := range []string{"memory", "badger", "sqlite"} {
+		t.Run(storeType, func(t *testing.T) {
+			if _, err := buildMetadataConfig(storeType, "", t.TempDir()); err != nil {
+				t.Errorf("server supports %q but the CLI rejects it: %v", storeType, err)
+			}
+		})
+	}
+
+	if _, err := buildMetadataConfig("nonesuch", "", ""); err == nil {
+		t.Error("an unsupported type should be rejected, got nil error")
+	}
+}

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -6518,7 +6518,7 @@ Manage metadata stores
 Manage metadata stores on the DittoFS server.
 
 Metadata stores hold file system structure, attributes, and permissions.
-Supported types: memory, badger, postgres
+Supported types: memory, badger, sqlite, postgres
 
 **Examples:**
 
@@ -6558,6 +6558,7 @@ Supported types:
 ```
 - memory: In-memory store (fast, ephemeral)
 - badger: BadgerDB store (persistent, embedded)
+- sqlite: SQLite store (persistent, embedded)
 - postgres: PostgreSQL store (persistent, distributed)
 ```
 
@@ -6566,6 +6567,9 @@ Type-specific options:
 ```
 badger:
   --db-path: Path to BadgerDB directory (or prompted interactively)
+
+sqlite:
+  --db-path: Path to the SQLite database file (or prompted interactively)
 
 postgres:
   --config: JSON with connection settings, or omit for interactive prompts
@@ -6587,6 +6591,9 @@ dfsctl store metadata add --name persistent-meta --type badger --db-path /data/m
 # Add a BadgerDB store interactively
 dfsctl store metadata add --name persistent-meta --type badger
 
+# Add a SQLite store with flags
+dfsctl store metadata add --name persistent-meta --type sqlite --db-path /data/meta.db
+
 # Add a PostgreSQL store with JSON config
 dfsctl store metadata add --name pg-meta --type postgres --config '{"host":"localhost","dbname":"dittofs"}'
 
@@ -6598,9 +6605,9 @@ Flags:
 
 ```
       --config string    Store configuration as JSON (for advanced config)
-      --db-path string   Database path (required for badger)
+      --db-path string   Database path (required for badger and sqlite)
       --name string      Store name (required)
-      --type string      Store type: memory, badger, postgres (required)
+      --type string      Store type: memory, badger, sqlite, postgres (required)
 ```
 
 Global flags:
@@ -6650,8 +6657,8 @@ Flags:
 
 ```
       --config string    Store configuration as JSON
-      --db-path string   Database path (for badger)
-      --type string      Store type: memory, badger, postgres
+      --db-path string   Database path (for badger and sqlite)
+      --type string      Store type: memory, badger, sqlite, postgres
 ```
 
 Global flags:

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1138,8 +1138,9 @@ Metadata stores are managed at runtime via `dfsctl` and persisted in the control
   --config '{"path":"/tmp/dittofs-metadata-isolated"}'
 
 # SQLite for a persistent single-binary / edge appliance (pure-Go, no cgo).
-# Reuses the PostgreSQL data model (parent_child_map hard links, nlink,
-# recursive-CTE path reconstruction, object_id dedup index).
+# Same implementation as PostgreSQL over a different dialect: one schema
+# (parent_child_map hard links, nlink, recursive-CTE path reconstruction,
+# object_id dedup index) and one set of operation bodies.
 ./dfsctl store metadata add --name sqlite-edge --type sqlite \
   --config '{"path":"/var/lib/dittofs/metadata.db"}'
 
@@ -1158,6 +1159,7 @@ Metadata stores are managed at runtime via `dfsctl` and persisted in the control
 > **Persistence Options**:
 > - **Memory**: Fast but ephemeral - all data lost on restart. Ideal for caching and temporary workloads.
 > - **BadgerDB**: Persistent embedded database - single-node deployments. File handles and metadata survive restarts.
+> - **SQLite**: Persistent embedded database - single-node deployments, pure-Go with no cgo. Shares its implementation with PostgreSQL, so the two behave alike apart from concurrency.
 > - **PostgreSQL**: Persistent distributed database - multi-node deployments with horizontal scaling. Survives restarts and supports multiple DittoFS instances sharing the same metadata.
 
 ### 8. Shares (Exports)

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -154,7 +154,12 @@ DittoFS uses a **Runtime-centric architecture** where the Runtime is the single 
 - Implementations:
   - `pkg/metadata/store/memory/`: In-memory (fast, ephemeral, full hard link support)
   - `pkg/metadata/store/badger/`: BadgerDB (persistent, embedded, path-based handles)
+  - `pkg/metadata/store/sqlite/`: SQLite (persistent, embedded, UUID-based handles)
   - `pkg/metadata/store/postgres/`: PostgreSQL (persistent, distributed, UUID-based handles)
+- The two SQL backends share one schema and most of their operation bodies,
+  which live in `pkg/metadata/store/sql/`; their own packages carry connection
+  setup, error mapping, statement text, snapshot export, and the few bodies
+  whose mechanism diverges
 - File handles are opaque identifiers (implementation-specific format)
 
 ## Per-Share Block Store Isolation
@@ -889,7 +894,7 @@ No custom code required - configure via CLI:
 
 ```bash
 # Create stores
-./dfsctl store metadata add --name default-meta --type memory  # or badger, postgres
+./dfsctl store metadata add --name default-meta --type memory  # or badger, sqlite, postgres
 ./dfsctl store block local add --name default-local --type fs \
   --config '{"path":"/data/blocks"}'
 
@@ -952,7 +957,11 @@ dittofs/
 │   │   └── store/                # Store implementations
 │   │       ├── memory/           # In-memory (ephemeral)
 │   │       ├── badger/           # BadgerDB (persistent)
-│   │       └── postgres/         # PostgreSQL (distributed)
+│   │       ├── sql/              # Shared bodies for the two SQL backends
+│   │       ├── sqlite/           # SQLite dialect (persistent, embedded)
+│   │       ├── postgres/         # PostgreSQL dialect (distributed)
+│   │       ├── basestore/        # Helpers shared by every backend
+│   │       └── internal/         # Row codec, caches, retry
 │   │
 │   ├── blockstore/               # Per-share block storage
 │   │   ├── doc.go                # Package documentation

--- a/docs/internals/implementing-stores.md
+++ b/docs/internals/implementing-stores.md
@@ -107,7 +107,40 @@ The metadata store interface and implementation guide remains the same as before
 
 - `pkg/metadata/store/memory/`: In-memory (fast, ephemeral)
 - `pkg/metadata/store/badger/`: BadgerDB (persistent, embedded)
+- `pkg/metadata/store/sqlite/`: SQLite (persistent, embedded)
 - `pkg/metadata/store/postgres/`: PostgreSQL (persistent, distributed)
+
+The two SQL backends are one implementation over two dialects. Most
+operation bodies live once in `pkg/metadata/store/sql/`, embedded by both the
+store and its transaction so a method written there is reachable from either.
+The `sqlite/` and `postgres/` packages carry what genuinely differs —
+connection setup, driver error mapping, statement text (via the
+`sql.Dialect` interface), snapshot export, and the handful of bodies whose
+mechanism diverges, such as `ApplyDataWrite` (sqlite selects then updates
+under the single-writer lock; postgres folds both into one statement) —
+along with the store-level wrappers described next. Read
+`pkg/metadata/store/sql/` first when tracing a SQL backend; most of what a
+caller reaches is there, not in the dialect package.
+
+**Multi-statement work needs a transaction, and `Core` cannot supply one.**
+`Core` is embedded by the pool-backed store as well as by the transaction, so
+a `Core` method also runs on the pool, where each statement autocommits
+independently and a crash between two of them leaves torn state. There are
+two ways to keep that from happening, and both are in the tree:
+
+- Make it a package-level function taking `(ctx, x Executor, d Dialect, ...)`,
+  so it can only be called with an executor the caller has already chosen —
+  `PutFileChunkRefs`, `DecrementAndReapMany`, `PutSyncedLocators`.
+- Or write it as a `Core` method and **shadow it** in each dialect package with
+  a store-level wrapper that runs it inside `WithTransaction` —
+  `DeleteShare`, `CreateRootDirectory`, `DecrementRefCountAndReap`.
+
+The shadows are load-bearing and easy to delete by accident: removing one does
+not break the build, because the promoted `Core` method still satisfies the
+interface. The write simply starts going straight to the pool. If you add a
+multi-statement `Core` method, add its shadow to **both** dialect packages in
+the same change, or use the package-level form instead. Single-statement work
+is safe as a plain `Core` method.
 
 Conformance tests: `pkg/metadata/storetest/`
 
@@ -195,8 +228,8 @@ type FileChunkStore interface {
 
 **Engine-internal companion interface:** `pkg/block.EngineFileChunkStore`
 extends `FileChunkStore` with `GetFileChunk(ctx, id)` and
-`ListFileChunks(ctx, payloadID)` for the engine's hot paths. All three built-in
-backends (memory, badger, postgres) satisfy it without changes — the
+`ListFileChunks(ctx, payloadID)` for the engine's hot paths. All four built-in
+backends (memory, badger, sqlite, postgres) satisfy it without changes — the
 narrow public surface is a documentation concern, not a runtime
 restriction. Custom backends implementing `FileChunkStore` SHOULD also
 implement the engine-internal helpers if they intend to slot into the
@@ -251,7 +284,7 @@ The `pkg/metadata/storetest/` suite includes:
 5. **Refcount concurrent fuzz** (`pkg/metadata/storetest/inv02_fuzz_test.go`):
    100-iteration property-based fuzzer creating, deleting, and copying
    files concurrently; asserts the invariant after each operation
-   batch. Runs against all three built-in backends and any custom backend
+   batch. Runs against all four built-in backends and any custom backend
    wired into the conformance harness.
 
 ### FileAttr.ObjectID + FindByObjectID
@@ -877,7 +910,7 @@ Users can then create your store via CLI:
 - **Reference Implementations**:
   - Local: `pkg/block/local/fs/`, `pkg/block/local/memory/`
   - Remote: `pkg/block/remote/s3/`, `pkg/block/remote/memory/`
-  - Metadata: `pkg/metadata/store/memory/`, `pkg/metadata/store/badger/`, `pkg/metadata/store/postgres/`
+  - Metadata: `pkg/metadata/store/memory/`, `pkg/metadata/store/badger/`, `pkg/metadata/store/sqlite/`, `pkg/metadata/store/postgres/` (the SQL pair share `pkg/metadata/store/sql/`)
 - **Conformance Tests**: `pkg/block/blockstoretest/` (block stores), `pkg/metadata/storetest/` (metadata stores)
 - **Architecture**: `docs/ARCHITECTURE.md`
 - **Configuration**: `docs/CONFIGURATION.md`

--- a/pkg/controlplane/runtime/init.go
+++ b/pkg/controlplane/runtime/init.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/internal/pathutil"
@@ -17,6 +16,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/store/badger"
 	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
 	"github.com/marmos91/dittofs/pkg/metadata/store/postgres"
+	storesql "github.com/marmos91/dittofs/pkg/metadata/store/sql"
 	"github.com/marmos91/dittofs/pkg/metadata/store/sqlite"
 )
 
@@ -149,27 +149,7 @@ func CreateMetadataStoreFromConfig(ctx context.Context, storeType string, cfg in
 
 		pgCfg.AutoMigrate = true
 
-		capabilities := metadata.FilesystemCapabilities{
-			MaxReadSize:           1024 * 1024,
-			PreferredReadSize:     64 * 1024,
-			MaxWriteSize:          1024 * 1024,
-			PreferredWriteSize:    64 * 1024,
-			MaxFileSize:           1024 * 1024 * 1024 * 100, // 100 GB
-			MaxFilenameLen:        255,
-			MaxPathLen:            4096,
-			MaxHardLinkCount:      32767,
-			SupportsHardLinks:     true,
-			SupportsSymlinks:      true,
-			CaseSensitive:         true,
-			CasePreserving:        true,
-			SupportsACLs:          false,
-			SupportsExtendedAttrs: true, // EAs persist in the inodes.eas JSONB column (migration 000028)
-			// File timestamps are stored as BIGINT unix nanoseconds (lossless),
-			// so nanosecond resolution is accurate for the postgres backend.
-			TimestampResolution: time.Nanosecond,
-		}
-
-		return postgres.NewPostgresMetadataStore(ctx, pgCfg, capabilities)
+		return postgres.NewPostgresMetadataStore(ctx, pgCfg, sqlCapabilities())
 
 	case "sqlite":
 		dbPath, ok := config["path"].(string)
@@ -189,29 +169,37 @@ func CreateMetadataStoreFromConfig(ctx context.Context, storeType string, cfg in
 			AutoMigrate: true,
 		}
 
-		capabilities := metadata.FilesystemCapabilities{
-			MaxReadSize:           1024 * 1024,
-			PreferredReadSize:     64 * 1024,
-			MaxWriteSize:          1024 * 1024,
-			PreferredWriteSize:    64 * 1024,
-			MaxFileSize:           1024 * 1024 * 1024 * 100, // 100 GB
-			MaxFilenameLen:        255,
-			MaxPathLen:            4096,
-			MaxHardLinkCount:      32767,
-			SupportsHardLinks:     true,
-			SupportsSymlinks:      true,
-			CaseSensitive:         true,
-			CasePreserving:        true,
-			SupportsACLs:          false,
-			SupportsExtendedAttrs: true, // EAs persist in the inodes.eas column.
-			// File timestamps are stored as INTEGER unix nanoseconds (lossless).
-			TimestampResolution: time.Nanosecond,
-		}
-
-		return sqlite.NewSQLiteMetadataStore(ctx, sqliteCfg, capabilities)
+		return sqlite.NewSQLiteMetadataStore(ctx, sqliteCfg, sqlCapabilities())
 
 	default:
 		return nil, fmt.Errorf("unsupported metadata store type: %s", storeType)
+	}
+}
+
+// sqlCapabilities returns the filesystem capabilities both SQL-backed metadata
+// stores advertise. They share a schema and a row codec, so anything a client
+// is told about one is true of the other.
+//
+// These are advertised to clients, not enforced here: the transfer sizes are
+// the shipped defaults rather than a backend limit, and ACLs are reported off
+// because neither store persists them yet.
+func sqlCapabilities() metadata.FilesystemCapabilities {
+	return metadata.FilesystemCapabilities{
+		MaxReadSize:           1024 * 1024,
+		PreferredReadSize:     64 * 1024,
+		MaxWriteSize:          1024 * 1024,
+		PreferredWriteSize:    64 * 1024,
+		MaxFileSize:           1024 * 1024 * 1024 * 100, // 100 GB
+		MaxFilenameLen:        255,
+		MaxPathLen:            4096,
+		MaxHardLinkCount:      32767,
+		SupportsHardLinks:     true,
+		SupportsSymlinks:      true,
+		CaseSensitive:         true,
+		CasePreserving:        true,
+		SupportsACLs:          false,
+		SupportsExtendedAttrs: true, // EAs persist in the inodes.eas column.
+		TimestampResolution:   storesql.TimestampResolution,
 	}
 }
 

--- a/pkg/controlplane/runtime/snapshot.go
+++ b/pkg/controlplane/runtime/snapshot.go
@@ -121,7 +121,7 @@ func (r *Runtime) CreateSnapshot(ctx context.Context, shareName string, opts Cre
 	}
 
 	// (2b) Resolve the metadata-store engine type ("memory" | "badger" |
-	// "postgres") so Snapshot.MetadataEngine can be populated on the
+	// "sqlite" | "postgres") so Snapshot.MetadataEngine can be populated on the
 	// fresh-create row. The retry path inherits MetadataEngine from the
 	// existing failed row, so it does not need to look this up. Restore
 	// consumes MetadataEngine to dispatch the per-engine Restoreable

--- a/pkg/metadata/store/sql/timestamp.go
+++ b/pkg/metadata/store/sql/timestamp.go
@@ -1,0 +1,12 @@
+package sql
+
+import "time"
+
+// TimestampResolution is the finest timestamp step the SQL backends can store.
+//
+// Both encode file times as a Windows FILETIME — 100ns ticks since 1601 — so a
+// caller setting a finer time has it rounded down on the way in. This is what
+// the backends advertise in FilesystemCapabilities, and NFSv3 passes it on to
+// clients verbatim as FSINFO time_delta, so it has to describe the row rather
+// than the precision of a Go time.Time.
+const TimestampResolution = 100 * time.Nanosecond

--- a/pkg/metadata/store/sql/timestamp_test.go
+++ b/pkg/metadata/store/sql/timestamp_test.go
@@ -1,0 +1,39 @@
+package sql
+
+import (
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata/store/internal/sqlcodec"
+)
+
+// The advertised resolution has to be the one the row codec actually keeps.
+// Too fine and the backends promise clients a precision they discard; too
+// coarse and they understate what they can hold.
+//
+// The expectation is measured out of the codec rather than derived from the
+// constant, so a wrong constant cannot agree with it by construction.
+func TestTimestampResolutionMatchesCodec(t *testing.T) {
+	base := time.Unix(1700000000, 0).UTC()
+
+	survives := func(d time.Duration) bool {
+		stepped := base.Add(d)
+		return sqlcodec.FiletimeToTime(sqlcodec.TimeToFiletime(stepped)).Equal(stepped)
+	}
+
+	// The smallest positive step the round trip preserves.
+	var granularity time.Duration
+	for d := time.Nanosecond; d <= time.Microsecond; d += time.Nanosecond {
+		if survives(d) {
+			granularity = d
+			break
+		}
+	}
+	if granularity == 0 {
+		t.Fatal("no step up to 1µs survived the round trip; the codec is coarser than this test can measure")
+	}
+
+	if TimestampResolution != granularity {
+		t.Errorf("TimestampResolution is %v but the codec keeps %v", TimestampResolution, granularity)
+	}
+}

--- a/pkg/metadata/types.go
+++ b/pkg/metadata/types.go
@@ -9,7 +9,13 @@
 // Store implementations are in subpackages:
 //   - pkg/metadata/store/memory - In-memory store (for testing)
 //   - pkg/metadata/store/badger - BadgerDB persistent store
+//   - pkg/metadata/store/sqlite - SQLite persistent store
 //   - pkg/metadata/store/postgres - PostgreSQL distributed store
+//
+// The two SQL backends share one schema and most of their operation bodies,
+// which live in pkg/metadata/store/sql. Their own packages hold what
+// genuinely differs — connection handling, error mapping, statement text,
+// snapshots, and the few bodies whose mechanism diverges.
 package metadata
 
 import (


### PR DESCRIPTION
Stage S7 of #1828.

## S7 is not what the plan said it was

The plan's S7 was "switch the factory, delete the old packages". That premise is dead: `snapshot_store.go` is a genuine mechanism divergence — postgres drives raw `pgconn` COPY TO/FROM STDOUT under REPEATABLE READ, sqlite does row-by-row binary encoding — so `sqlite/` and `postgres/` stay as packages and there is no factory to switch. What follows is the part of S7 that survives that finding, plus two defects the fold surfaced.

## One capability set, and an honest resolution

The postgres and sqlite branches of `CreateMetadataStoreFromConfig` each built their own 15-field `FilesystemCapabilities` literal. Every value was identical. The comments were not:

```go
// File timestamps are stored as BIGINT unix nanoseconds (lossless),   <- postgres
// File timestamps are stored as INTEGER unix nanoseconds (lossless).  <- sqlite
TimestampResolution: time.Nanosecond,
```

Both are stale. Both stores have encoded file times as a Windows FILETIME — 100ns ticks since 1601 — since migrations `000005` (sqlite) and `000038` (postgres). Measured against the real codec before changing anything:

```
offset   1ns -> round-trip delta 0s
offset  50ns -> round-trip delta 0s
offset  99ns -> round-trip delta 0s
offset 100ns -> round-trip delta 100ns
```

**This is client-visible.** `TimestampResolution` is not internal bookkeeping — NFSv3 hands it to clients as FSINFO `time_delta` (`fsinfo.go:180`). Both SQL backends have been advertising a precision they silently discard. After this change the wire value goes from `{0, 1}` to `{0, 100}`; `durationToTimeVal` handles it correctly, and no NFSv4 or SMB path reads the field.

The value now lives as `sql.TimestampResolution`, beside the codec that decides it, rather than hand-typed in a caller that cannot see the encoding.

## dfsctl never learned about sqlite

`init.go` has accepted `--type sqlite` for as long as the branch has existed. The CLI never did — sqlite is missing from every `--type` enum, every help string, and both interactive switches. The practical effect: the store could only be created by hand-writing `--config` JSON (which bypasses the switch), and `dfsctl store metadata edit` on one failed outright with `unknown store type: sqlite`. Folded into the existing `badger` cases, since both take a single path.

## Docs

They described the pre-merge shape — independent backends, no `store/sql` — and omitted sqlite throughout. Updated `implementing-stores.md`, `architecture.md`, `configuration.md`, the `types.go` package doc, and the snapshot engine list. `cli.md` is regenerated, not hand-edited.

The interesting part is what the adversarial review made me rewrite. My first draft asserted a rule I had been following myself:

> anything running more than one statement must be a package-level function taking `(ctx, x Executor, d Dialect, ...)`, never a method on `sql.Core`

That describes the exception, not the rule. Three multi-statement bodies are `Core` methods today — `DeleteShare`, `CreateRootDirectory`, `DecrementRefCountAndReap` — and they are safe for a different reason: each is shadowed in **both** dialect packages by a store-level wrapper that runs it inside `WithTransaction`. The docs now state that actual invariant, including the part that makes it dangerous: deleting a shadow does not break the build, because the promoted `Core` method still satisfies the interface — the write just starts going to the pool.

## Verification

Every new test was run against a deliberately broken build.

`TestTimestampResolutionMatchesCodec` measures the codec's real granularity by scanning for the smallest surviving step, then compares — the expectation is derived from the codec, not restated from the constant, so a wrong value cannot agree with it by construction. Mutations, all caught:

| constant | result |
| --- | --- |
| `time.Nanosecond` (the value on develop) | FAIL |
| `200 * time.Nanosecond` | FAIL |
| `500 * time.Nanosecond` | FAIL |
| `time.Microsecond` | FAIL |

The 500ns case matters: an earlier two-probe version of this test passed against it, and the adversarial review found that. Every odd multiple of 100ns slipped through. Measuring the granularity directly closes the class rather than the instance.

`TestBuildMetadataConfig_AcceptsServerSupportedTypes` pins the CLI's accepted set to the server's. Reverting the sqlite case fails it with `server supports "sqlite" but the CLI rejects it`.

`gofmt`, `go vet`, `go run ./cmd/gendocs` (no diff) and the full `go test ./...` are green.

## Review

Three passes. The simplifier caught a real defect: inserting `sqlCapabilities()` above `configInt64` split that function from its doc comment and silently annexed it. The reviewer verified the identical-literals claim field by field against develop and traced the FSINFO arithmetic. The adversarial pass refuted the doc doctrine above and found the 500ns test gap.

## Not in this PR

`sqlite/files.go` and `sqlite/shares.go` are still 90–97% identical to their postgres counterparts — they differ only in receiver name, error sentinel, error mapper, and placeholder style, all of which `Dialect` already abstracts. Merging them needs a `Transactor` indirection because `WithTransaction` is store-only, which is a different shape of change and does not belong in a docs-and-CLI stage.
