### PR TITLE
fix(nfs/v4): READDIR argument validation, and the account pynfs's second client never had

### DIFF
--- a/internal/adapter/nfs/v4/attrs/encode.go
+++ b/internal/adapter/nfs/v4/attrs/encode.go
@@ -351,11 +351,11 @@ func HasUnsupportedAttr(requested, supported []uint32) bool {
 // responseAttrBitmap returns the attributes to encode in an attribute
 // response: the requested∩supported set, minus the settable-only bits.
 //
-// GETATTR, VERIFY and NVERIFY refuse a request naming a settable-only
-// attribute before reaching here. READDIR does not — it carries whatever
-// bitmap the client attached to it and has no way to report a per-attribute
-// error — so the encoder still drops those bits rather than reaching an
-// attribute it has no value to write.
+// Every operation that encodes attributes — GETATTR, VERIFY, NVERIFY and
+// READDIR — refuses a request naming a settable-only attribute before reaching
+// here, so clearing the bits is a backstop: it keeps the encoder from reaching
+// an attribute it has no value to write rather than being the only thing that
+// does.
 func responseAttrBitmap(requested, supported []uint32) []uint32 {
 	bitmap := Intersect(requested, supported)
 	for _, bit := range writeOnlyAttrs {

--- a/internal/adapter/nfs/v4/attrs/encode_test.go
+++ b/internal/adapter/nfs/v4/attrs/encode_test.go
@@ -552,10 +552,10 @@ func TestSupportedAttrsAdvertisesTimeSet(t *testing.T) {
 }
 
 // TestEncoderDropsWriteOnlyTimeSet verifies the encoder omits the settable-only
-// time bits rather than failing on an attribute it has no value to write. This
-// is what READDIR relies on: it carries a raw client bitmap and cannot report a
-// per-attribute error, so the bits are dropped and the surrounding entry still
-// encodes. GETATTR does not reach here — it refuses such a request outright.
+// time bits rather than failing on an attribute it has no value to write. Every
+// caller now refuses such a request before reaching the encoder, so this pins
+// the backstop that keeps a future one from encoding an attribute that has no
+// value.
 func TestEncoderDropsWriteOnlyTimeSet(t *testing.T) {
 	node := newMockNode()
 

--- a/internal/adapter/nfs/v4/handlers/ops_test.go
+++ b/internal/adapter/nfs/v4/handlers/ops_test.go
@@ -898,9 +898,9 @@ func TestReadDir_PseudoFSRoot(t *testing.T) {
 		t.Errorf("eof = %d, want 1 (true)", eof)
 	}
 
-	// Should contain ".", "..", then "data" and "export" (children sorted).
-	// "." has cookie 1, ".." cookie 2, children start at cookie 3.
-	want := []string{".", "..", "data", "export"}
+	// "." and ".." are not part of a READDIR listing, so only the children
+	// appear (sorted). Cookies 0, 1 and 2 are reserved, so they start at 3.
+	want := []string{"data", "export"}
 	if len(entryNames) != len(want) {
 		t.Fatalf("entry count = %d, want %d, got %v", len(entryNames), len(want), entryNames)
 	}
@@ -909,7 +909,7 @@ func TestReadDir_PseudoFSRoot(t *testing.T) {
 			t.Errorf("entry[%d] = %q, want %q", i, entryNames[i], w)
 		}
 	}
-	wantCookies := []uint64{1, 2, 3, 4}
+	wantCookies := []uint64{3, 4}
 	if len(entryCookies) != len(wantCookies) {
 		t.Fatalf("cookie count = %d, want %d, got %v", len(entryCookies), len(wantCookies), entryCookies)
 	}
@@ -921,16 +921,16 @@ func TestReadDir_PseudoFSRoot(t *testing.T) {
 }
 
 // TestReadDir_PseudoFSRoot_CookieContinuation verifies that resuming a READDIR
-// with a non-zero cookie skips already-returned entries (including the
-// synthesized "." and ".." entries) and continues from the next child.
+// with a non-zero cookie skips already-returned entries and continues from the
+// next child.
 func TestReadDir_PseudoFSRoot_CookieContinuation(t *testing.T) {
 	h := newTestHandlerWithShares([]string{"/export", "/data/archive"})
 	ctx := newOpsTestContext()
 
-	// Resume after cookie 2 ("..") -- should return only the children.
+	// Resume after cookie 3 ("data") -- should return only the entries past it.
 	data := encodeCompoundWithOps("", 0, []encodedOp{
 		encodePutRootFH(),
-		encodeReadDir(2, 8192, attrs.FATTR4_TYPE),
+		encodeReadDir(3, 8192, attrs.FATTR4_TYPE),
 	})
 
 	resp, err := h.ProcessCompound(ctx, data)
@@ -968,7 +968,7 @@ func TestReadDir_PseudoFSRoot_CookieContinuation(t *testing.T) {
 		_, _ = xdr.DecodeOpaque(extraReader)
 	}
 
-	want := []string{"data", "export"}
+	want := []string{"export"}
 	if len(entryNames) != len(want) {
 		t.Fatalf("entry count = %d, want %d, got %v", len(entryNames), len(want), entryNames)
 	}
@@ -977,7 +977,7 @@ func TestReadDir_PseudoFSRoot_CookieContinuation(t *testing.T) {
 			t.Errorf("entry[%d] = %q, want %q", i, entryNames[i], w)
 		}
 	}
-	wantCookies := []uint64{3, 4}
+	wantCookies := []uint64{4}
 	if len(entryCookies) != len(wantCookies) {
 		t.Fatalf("cookie count = %d, want %d, got %v", len(entryCookies), len(wantCookies), entryCookies)
 	}

--- a/internal/adapter/nfs/v4/handlers/readdir.go
+++ b/internal/adapter/nfs/v4/handlers/readdir.go
@@ -16,6 +16,25 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
+// maxcount bounds the READDIR4resok structure, which is the cookieverf
+// followed by the entry list; the operation status preceding it does not
+// count. An empty listing therefore already costs readDirMinResokSize bytes,
+// and a smaller budget cannot hold even that (RFC 7530 Section 16.24.4).
+const (
+	readDirCookieVerfSize = 8 // cookieverf
+	readDirListEndSize    = 8 // dirlist4 terminator (4) + eof flag (4)
+	readDirMinResokSize   = readDirCookieVerfSize + readDirListEndSize
+)
+
+// readDirError builds a status-only READDIR result.
+func readDirError(status uint32) *types.CompoundResult {
+	return &types.CompoundResult{
+		Status: status,
+		OpCode: types.OP_READDIR,
+		Data:   encodeStatusOnly(status),
+	}
+}
+
 // directoryMtimeVerifier generates an 8-byte cookie verifier from directory mtime.
 // Matches NFSv3 pattern in v3/handlers/readdir.go.
 func directoryMtimeVerifier(mtime time.Time) uint64 {
@@ -30,61 +49,57 @@ func directoryMtimeVerifier(mtime time.Time) uint64 {
 func (h *Handler) handleReadDir(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
 	// Require current filehandle
 	if status := types.RequireCurrentFH(ctx); status != types.NFS4_OK {
-		return &types.CompoundResult{
-			Status: status,
-			OpCode: types.OP_READDIR,
-			Data:   encodeStatusOnly(status),
-		}
+		return readDirError(status)
 	}
 
 	// Read cookie (uint64)
 	cookie, err := xdr.DecodeUint64(reader)
 	if err != nil {
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_BADXDR,
-			OpCode: types.OP_READDIR,
-			Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
-		}
+		return readDirError(types.NFS4ERR_BADXDR)
 	}
 
 	// Read cookieverf (8 raw bytes)
 	var cookieVerf [8]byte
 	if _, err := io.ReadFull(reader, cookieVerf[:]); err != nil {
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_BADXDR,
-			OpCode: types.OP_READDIR,
-			Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
-		}
+		return readDirError(types.NFS4ERR_BADXDR)
 	}
 
 	// Read dircount (uint32)
 	_, err = xdr.DecodeUint32(reader) // dircount (hint, not enforced)
 	if err != nil {
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_BADXDR,
-			OpCode: types.OP_READDIR,
-			Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
-		}
+		return readDirError(types.NFS4ERR_BADXDR)
 	}
 
 	// Read maxcount (uint32)
 	maxcount, err := xdr.DecodeUint32(reader)
 	if err != nil {
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_BADXDR,
-			OpCode: types.OP_READDIR,
-			Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
-		}
+		return readDirError(types.NFS4ERR_BADXDR)
 	}
 
 	// Read attr_request bitmap
 	attrRequest, err := attrs.DecodeBitmap4(reader)
 	if err != nil {
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_BADXDR,
-			OpCode: types.OP_READDIR,
-			Data:   encodeStatusOnly(types.NFS4ERR_BADXDR),
-		}
+		return readDirError(types.NFS4ERR_BADXDR)
+	}
+
+	// Cookies 0, 1 and 2 are reserved so a UNIX client can splice its own "."
+	// and ".." into the listing; the server never issues them as result
+	// cookies, so 1 or 2 arriving as an argument names a bookmark that cannot
+	// exist (RFC 7530 Section 16.24.4).
+	if cookie == 1 || cookie == 2 {
+		return readDirError(types.NFS4ERR_BAD_COOKIE)
+	}
+
+	if maxcount < readDirMinResokSize {
+		return readDirError(types.NFS4ERR_TOOSMALL)
+	}
+
+	// Per-entry attributes go through the same encoder GETATTR uses, which has
+	// no value to write for a settable-only attribute. fattr4_rdattr_error
+	// reports a failure to read one entry's attributes, not a request the
+	// server can never answer, so the whole operation fails instead.
+	if attrs.HasWriteOnlyAttr(attrRequest) {
+		return readDirError(types.NFS4ERR_INVAL)
 	}
 
 	// Check if current FH is a pseudo-fs handle
@@ -100,33 +115,19 @@ func (h *Handler) handleReadDir(ctx *types.CompoundContext, reader io.Reader) *t
 func (h *Handler) readDirRealFS(ctx *types.CompoundContext, cookie uint64, cookieVerf [8]byte, maxcount uint32, attrRequest []uint32) *types.CompoundResult {
 	authCtx, _, err := h.buildV4AuthContext(ctx, ctx.CurrentFH)
 	if err != nil {
-		st := nfs4StatusForAuthError(err)
-		return &types.CompoundResult{
-			Status: st,
-			OpCode: types.OP_READDIR,
-			Data:   encodeStatusOnly(st),
-		}
+		return readDirError(nfs4StatusForAuthError(err))
 	}
 
 	metaSvc, err := getMetadataServiceForCtx(h)
 	if err != nil {
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_SERVERFAULT,
-			OpCode: types.OP_READDIR,
-			Data:   encodeStatusOnly(types.NFS4ERR_SERVERFAULT),
-		}
+		return readDirError(types.NFS4ERR_SERVERFAULT)
 	}
 
 	dirHandle := metadata.FileHandle(ctx.CurrentFH)
 
 	page, err := metaSvc.ReadDirectory(authCtx, dirHandle, cookie, maxcount)
 	if err != nil {
-		status := common.MapToNFS4(err)
-		return &types.CompoundResult{
-			Status: status,
-			OpCode: types.OP_READDIR,
-			Data:   encodeStatusOnly(status),
-		}
+		return readDirError(common.MapToNFS4(err))
 	}
 
 	// Compute cookie verifier from directory mtime (RFC 7530 Section 16.24).
@@ -147,11 +148,7 @@ func (h *Handler) readDirRealFS(ctx *types.CompoundContext, cookie uint64, cooki
 			"incoming_verf", fmt.Sprintf("0x%016x", incomingVerf),
 			"current_verf", fmt.Sprintf("0x%016x", currentVerifier),
 			"client", ctx.ClientAddr)
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_BAD_COOKIE,
-			OpCode: types.OP_READDIR,
-			Data:   encodeStatusOnly(types.NFS4ERR_BAD_COOKIE),
-		}
+		return readDirError(types.NFS4ERR_BAD_COOKIE)
 	}
 
 	// Debug logging for READDIR
@@ -176,8 +173,9 @@ func (h *Handler) readDirRealFS(ctx *types.CompoundContext, cookie uint64, cooki
 	binary.BigEndian.PutUint64(verfBytes[:], currentVerifier)
 	buf.Write(verfBytes[:])
 
-	// Encode directory entries
-	encodedSize := uint32(buf.Len())
+	// Encode directory entries. The budget counts READDIR4resok bytes, of
+	// which the cookieverf is already written.
+	encodedSize := uint32(readDirCookieVerfSize)
 	entriesEncoded := 0
 	truncatedDueToSize := false
 	for _, entry := range page.Entries {
@@ -210,13 +208,9 @@ func (h *Handler) readDirRealFS(ctx *types.CompoundContext, cookie uint64, cooki
 
 		// Check maxcount limit
 		entrySize := uint32(entryBuf.Len())
-		if maxcount > 0 && encodedSize+entrySize+4 > maxcount { // +4 for eof bool
-			if encodedSize == uint32(12) { // status(4) + cookieverf(8)
-				return &types.CompoundResult{
-					Status: types.NFS4ERR_TOOSMALL,
-					OpCode: types.OP_READDIR,
-					Data:   encodeStatusOnly(types.NFS4ERR_TOOSMALL),
-				}
+		if encodedSize+entrySize+readDirListEndSize > maxcount {
+			if encodedSize == readDirCookieVerfSize { // not even one entry fits
+				return readDirError(types.NFS4ERR_TOOSMALL)
 			}
 			truncatedDueToSize = true
 			break
@@ -257,39 +251,14 @@ func (h *Handler) readDirPseudoFS(ctx *types.CompoundContext, cookie uint64, max
 	// Find the node by handle
 	node, ok := h.PseudoFS.LookupByHandle(ctx.CurrentFH)
 	if !ok {
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_STALE,
-			OpCode: types.OP_READDIR,
-			Data:   encodeStatusOnly(types.NFS4ERR_STALE),
-		}
+		return readDirError(types.NFS4ERR_STALE)
 	}
 
-	// List children (sorted by name)
+	// List children (sorted by name), which gives each one a stable cookie
+	// from its position. "." and ".." are not part of a READDIR listing, and
+	// cookies 0, 1 and 2 are reserved for the client to splice them in itself,
+	// so children start at cookie 3 (RFC 7530 Section 16.24.4).
 	children := h.PseudoFS.ListChildren(node)
-
-	// Build the ordered entry list with stable cookies. RFC 7530 directories
-	// are expected to include the "." (self) and ".." (parent) entries; some
-	// clients (and POSIX getdents-style readers) rely on them. They occupy the
-	// first two cookies so children start at cookie 3. The parent of the
-	// pseudo-fs root is itself (Parent points back to root), which yields the
-	// correct ".." == "." semantics at the top of the namespace.
-	parent := node.Parent
-	if parent == nil {
-		parent = node
-	}
-	type pseudoEntry struct {
-		cookie uint64
-		name   string
-		node   *pseudofs.PseudoNode
-	}
-	entries := make([]pseudoEntry, 0, len(children)+2)
-	entries = append(entries,
-		pseudoEntry{cookie: 1, name: ".", node: node},
-		pseudoEntry{cookie: 2, name: "..", node: parent},
-	)
-	for i, child := range children {
-		entries = append(entries, pseudoEntry{cookie: uint64(i + 3), name: child.Name, node: child})
-	}
 
 	// Build response
 	var buf bytes.Buffer
@@ -304,11 +273,15 @@ func (h *Handler) readDirPseudoFS(ctx *types.CompoundContext, cookie uint64, max
 	//   bool    eof;
 	//
 	// entry4: cookie (uint64) + name (XDR string) + attrs (fattr4)
-	encodedSize := uint32(buf.Len())
+	// The budget counts READDIR4resok bytes, of which the cookieverf is
+	// already written.
+	encodedSize := uint32(readDirCookieVerfSize)
 	allEntriesEncoded := true
-	for _, entry := range entries {
-		// Skip entries with cookie <= requested cookie (continuation support).
-		if entry.cookie <= cookie {
+	for i, child := range children {
+		entryCookie := uint64(i + 3)
+
+		// Skip entries already returned (continuation support).
+		if entryCookie <= cookie {
 			continue
 		}
 
@@ -319,24 +292,19 @@ func (h *Handler) readDirPseudoFS(ctx *types.CompoundContext, cookie uint64, max
 		_ = xdr.WriteUint32(&entryBuf, 1)
 
 		// cookie (uint64)
-		_ = xdr.WriteUint64(&entryBuf, entry.cookie)
+		_ = xdr.WriteUint64(&entryBuf, entryCookie)
 
 		// name (XDR string)
-		_ = xdr.WriteXDRString(&entryBuf, entry.name)
+		_ = xdr.WriteXDRString(&entryBuf, child.Name)
 
 		// attrs (fattr4)
-		_ = attrs.EncodePseudoFSAttrs(&entryBuf, attrRequest, ctx.MinorVersion, entry.node)
+		_ = attrs.EncodePseudoFSAttrs(&entryBuf, attrRequest, ctx.MinorVersion, child)
 
 		// Check maxcount limit (approximate: include overhead for remaining entries)
 		entrySize := uint32(entryBuf.Len())
-		if maxcount > 0 && encodedSize+entrySize+4 > maxcount { // +4 for eof bool
-			// Would exceed maxcount; if no entries encoded yet, return NFS4ERR_TOOSMALL
-			if encodedSize == uint32(12) { // status(4) + cookieverf(8)
-				return &types.CompoundResult{
-					Status: types.NFS4ERR_TOOSMALL,
-					OpCode: types.OP_READDIR,
-					Data:   encodeStatusOnly(types.NFS4ERR_TOOSMALL),
-				}
+		if encodedSize+entrySize+readDirListEndSize > maxcount {
+			if encodedSize == readDirCookieVerfSize { // not even one entry fits
+				return readDirError(types.NFS4ERR_TOOSMALL)
 			}
 			allEntriesEncoded = false
 			break

--- a/internal/adapter/nfs/v4/handlers/readdir_test.go
+++ b/internal/adapter/nfs/v4/handlers/readdir_test.go
@@ -1,0 +1,55 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/attrs"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+)
+
+// TestReadDir_ArgumentValidation covers the READDIR arguments RFC 7530
+// Section 16.24.4 requires the server to refuse: the cookie values reserved
+// for the client's own "." and "..", a maxcount too small to hold even an
+// empty listing, and an attribute request naming a settable-only attribute
+// the encoder has no value to write for.
+func TestReadDir_ArgumentValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		cookie   uint64
+		maxcount uint32
+		bits     []uint32
+		want     uint32
+	}{
+		{"reserved cookie 1", 1, 8192, []uint32{attrs.FATTR4_TYPE}, types.NFS4ERR_BAD_COOKIE},
+		{"reserved cookie 2", 2, 8192, []uint32{attrs.FATTR4_TYPE}, types.NFS4ERR_BAD_COOKIE},
+		{"maxcount zero", 0, 0, []uint32{attrs.FATTR4_TYPE}, types.NFS4ERR_TOOSMALL},
+		// Cookie 4 is past the last child, so the listing is empty and only
+		// the up-front maxcount check can reject it.
+		{"maxcount below an empty listing", 4, 15, []uint32{attrs.FATTR4_TYPE}, types.NFS4ERR_TOOSMALL},
+		{"write-only time_access_set", 0, 8192, []uint32{attrs.FATTR4_TIME_ACCESS_SET}, types.NFS4ERR_INVAL},
+		{"write-only time_modify_set", 0, 8192, []uint32{attrs.FATTR4_TIME_MODIFY_SET}, types.NFS4ERR_INVAL},
+		{"accepted", 0, 8192, []uint32{attrs.FATTR4_TYPE}, types.NFS4_OK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newTestHandlerWithShares([]string{"/export", "/data/archive"})
+			ctx := newOpsTestContext()
+
+			data := encodeCompoundWithOps("", 0, []encodedOp{
+				encodePutRootFH(),
+				encodeReadDir(tt.cookie, tt.maxcount, tt.bits...),
+			})
+
+			resp, err := h.ProcessCompound(ctx, data)
+			if err != nil {
+				t.Fatalf("ProcessCompound error: %v", err)
+			}
+
+			decoded, _ := decodeCompoundResp(resp)
+			if decoded.Results[1].Status != tt.want {
+				t.Errorf("READDIR status = %d, want %d", decoded.Results[1].Status, tt.want)
+			}
+		})
+	}
+}

--- a/internal/adapter/nfs/v4/state/lease_expiry_stateid_test.go
+++ b/internal/adapter/nfs/v4/state/lease_expiry_stateid_test.go
@@ -1,11 +1,13 @@
 package state
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
 // TestExpiredLease_StateidsReportExpired pins what a client is told when it
@@ -39,6 +41,47 @@ func TestExpiredLease_StateidsReportExpired(t *testing.T) {
 
 	if _, err := sm.ValidateStateid(unknown, fileHandle, StateidOpRead); !isStatus(err, types.NFS4ERR_BAD_STATEID) {
 		t.Fatalf("ValidateStateid of a never-issued stateid: got %v, want NFS4ERR_BAD_STATEID", err)
+	}
+}
+
+// TestExpiredLease_LockStateidsReportExpired covers the LOCK and LOCKU paths,
+// which look their stateid up in the lock table rather than through
+// ValidateStateid and used to answer NFS4ERR_BAD_STATEID for state the server
+// itself had freed.
+func TestExpiredLease_LockStateidsReportExpired(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	sm.SetLockManager(lock.NewManager())
+	defer sm.Shutdown()
+
+	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
+
+	lockResult, err := sm.LockNew(context.Background(),
+		clientID, []byte("lock-owner"), 1,
+		openStateid, openSeqid+1,
+		fileHandle, types.WRITE_LT, 0, 100, false,
+	)
+	if err != nil {
+		t.Fatalf("LockNew: %v", err)
+	}
+	lockStateid := lockResult.Stateid
+
+	unknown := &types.Stateid4{Seqid: 1}
+	unknown.Other = sm.generateStateidOther(StateTypeLock)
+
+	sm.onLeaseExpired(clientID)
+
+	if _, err := sm.UnlockFile(&lockStateid, 2, types.WRITE_LT, 0, 100); !isStatus(err, types.NFS4ERR_EXPIRED) {
+		t.Fatalf("UnlockFile after lease cancellation: got %v, want NFS4ERR_EXPIRED", err)
+	}
+
+	if _, err := sm.LockExisting(context.Background(),
+		&lockStateid, 2, fileHandle, types.WRITE_LT, 200, 100, false,
+	); !isStatus(err, types.NFS4ERR_EXPIRED) {
+		t.Fatalf("LockExisting after lease cancellation: got %v, want NFS4ERR_EXPIRED", err)
+	}
+
+	if _, err := sm.UnlockFile(unknown, 2, types.WRITE_LT, 0, 100); !isStatus(err, types.NFS4ERR_BAD_STATEID) {
+		t.Fatalf("UnlockFile of a never-issued stateid: got %v, want NFS4ERR_BAD_STATEID", err)
 	}
 }
 

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -886,6 +886,22 @@ func (sm *StateManager) markClientStateidsExpiredLocked(clientID uint64) {
 	}
 }
 
+// lockStateidMissError classifies a lock-stateid table miss: state freed by a
+// lease cancellation answers NFS4ERR_EXPIRED (RFC 7530 Section 9.6.3.2), a
+// stateid minted by an earlier server incarnation answers
+// NFS4ERR_STALE_STATEID, and anything else was never issued.
+//
+// Caller must hold sm.mu.
+func (sm *StateManager) lockStateidMissError(other [types.NFS4_OTHER_SIZE]byte) error {
+	if sm.isExpiredStateidLocked(other) {
+		return ErrExpired
+	}
+	if !sm.isCurrentEpoch(other) {
+		return ErrStaleStateid
+	}
+	return ErrBadStateid
+}
+
 // isExpiredStateidLocked reports whether the state this stateid named was freed
 // when the server cancelled the owning client's lease. Callers use it on a
 // table miss, before falling back to NFS4ERR_BAD_STATEID.
@@ -2370,10 +2386,7 @@ func (sm *StateManager) LockExisting(
 	// 1. Look up lock state
 	lockState, exists := sm.lockStateByOther[lockStateid.Other]
 	if !exists {
-		if !sm.isCurrentEpoch(lockStateid.Other) {
-			return nil, ErrStaleStateid
-		}
-		return nil, ErrBadStateid
+		return nil, sm.lockStateidMissError(lockStateid.Other)
 	}
 
 	lockOwner := lockState.LockOwner
@@ -2676,11 +2689,7 @@ func (sm *StateManager) UnlockFile(
 	// 1. Look up lock state
 	lockState, exists := sm.lockStateByOther[lockStateid.Other]
 	if !exists {
-		// Check if it's a stale stateid from a previous boot
-		if !sm.isCurrentEpoch(lockStateid.Other) {
-			return nil, ErrStaleStateid
-		}
-		return nil, ErrBadStateid
+		return nil, sm.lockStateidMissError(lockStateid.Other)
 	}
 
 	lockOwner := lockState.LockOwner

--- a/pkg/metadata/cookies.go
+++ b/pkg/metadata/cookies.go
@@ -92,9 +92,11 @@ func (cm *CookieManager) GenerateCookie(dirHandle FileHandle, name string) uint6
 	// Generate cookie by hashing dirHandle + name
 	cookie := fnv1a64(dirHandle, name)
 
-	// Ensure cookie is never 0 (reserved for start of directory)
-	if cookie == 0 {
-		cookie = 1
+	// Cookies 0, 1 and 2 are reserved: 0 starts a directory scan, and NFSv4
+	// keeps 1 and 2 for the client's own "." and ".." entries, so no result
+	// cookie may take those values (RFC 7530 Section 16.24.4).
+	if cookie <= 2 {
+		cookie = 3
 	}
 
 	// Store reverse mapping in the bounded LRU.

--- a/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
+++ b/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
@@ -34,17 +34,7 @@ Categories:
 | CID2 | bug | SETCLIENTID/SETCLIENTID_CONFIRM and RENEW validation | #2326 |
 | CID2a | bug | SETCLIENTID/SETCLIENTID_CONFIRM and RENEW validation | #2326 |
 | RENEW3 | bug | SETCLIENTID/SETCLIENTID_CONFIRM and RENEW validation | #2326 |
-| CLOSE8 | bug | LOOKUP fails opening the test tree, so the test cannot run | #2332 |
-| CLOSE9 | bug | LOOKUP fails opening the test tree, so the test cannot run | #2332 |
-| LKU10 | bug | LOOKUP fails opening the test tree, so the test cannot run | #2332 |
-| LOCK13 | bug | LOOKUP fails opening the test tree, so the test cannot run | #2332 |
-| LOCK15 | bug | LOOKUP fails opening the test tree, so the test cannot run | #2332 |
-| LOCK17 | bug | LOOKUP fails opening the test tree, so the test cannot run | #2332 |
 | OPEN4 | bug | exclusive re-create with the same verifier answers EXIST on the SQL backends, which do not persist the create verifier | #2317 |
-| RDDR10 | bug | READDIR cookie and attribute-request validation | #2336 |
-| RDDR7 | bug | READDIR cookie and attribute-request validation | #2336 |
-| RDDR8 | bug | READDIR cookie and attribute-request validation | #2336 |
-| RDDR9 | bug | READDIR cookie and attribute-request validation | #2336 |
 | CLOSE4 | bug | bad/old/stale stateid accepted | #2341 |
 | CLOSE5 | bug | bad/old/stale stateid accepted | #2341 |
 | CLOSE6 | bug | bad/old/stale stateid accepted | #2341 |

--- a/test/nfs-conformance/pynfs/run-pynfs.sh
+++ b/test/nfs-conformance/pynfs/run-pynfs.sh
@@ -186,10 +186,13 @@ if [[ "$NO_SETUP" != true ]]; then
     fi
 
     log "Creating an account for pynfs's second client (uid ${SECOND_UID})..."
-    if ! "${REPO_ROOT}/dfsctl" user create --username "$SECOND_USER" \
-            --password "$SECOND_PASSWORD" \
-            --uid "$SECOND_UID" --gid "$SECOND_GID" >/dev/null 2>&1 ||
-       ! "${REPO_ROOT}/dfsctl" share permission grant "$EXPORT_PATH" \
+    # The create is allowed to fail on an account that already exists; the grant
+    # is the step that must run either way, and it fails on its own if there is
+    # no such user, so one warning covers both.
+    "${REPO_ROOT}/dfsctl" user create --username "$SECOND_USER" \
+        --password "$SECOND_PASSWORD" \
+        --uid "$SECOND_UID" --gid "$SECOND_GID" >/dev/null 2>&1 || true
+    if ! "${REPO_ROOT}/dfsctl" share permission grant "$EXPORT_PATH" \
             --user "$SECOND_USER" --level read-write >/dev/null 2>&1; then
         log_warn "Could not provision uid ${SECOND_UID}; multi-client tests will fail on share access."
     fi

--- a/test/nfs-conformance/pynfs/run-pynfs.sh
+++ b/test/nfs-conformance/pynfs/run-pynfs.sh
@@ -36,6 +36,16 @@ LEASE_TIME=30
 # is the same identity pjdfstest runs as, so uid 0 gets a usable export root.
 TEST_UID=0
 TEST_GID=0
+# pynfs runs two clients, and the second one always authenticates as
+# TEST_UID+1 / TEST_GID+1 -- that is how the suite gets a second principal for
+# its multi-client and "as another user" cases. DittoFS refuses an NFS uid it
+# cannot map to an account when the share has no default permission, so that
+# second client needs an account of its own or every test that uses it fails
+# at the first LOOKUP.
+SECOND_UID=$((TEST_UID + 1))
+SECOND_GID=$((TEST_GID + 1))
+SECOND_USER="pynfs-client2"
+SECOND_PASSWORD="pynfs-client2-password-123"
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BOLD='\033[1m'; NC='\033[0m'
 log()       { echo -e "${GREEN}[PYNFS]${NC} $*"; }
@@ -173,6 +183,15 @@ if [[ "$NO_SETUP" != true ]]; then
     if ! "${REPO_ROOT}/dfsctl" adapter settings nfs update \
             --lease-time "$LEASE_TIME" >/dev/null 2>&1; then
         log_warn "Could not set lease time; expiry tests will run at the server default."
+    fi
+
+    log "Creating an account for pynfs's second client (uid ${SECOND_UID})..."
+    if ! "${REPO_ROOT}/dfsctl" user create --username "$SECOND_USER" \
+            --password "$SECOND_PASSWORD" \
+            --uid "$SECOND_UID" --gid "$SECOND_GID" >/dev/null 2>&1 ||
+       ! "${REPO_ROOT}/dfsctl" share permission grant "$EXPORT_PATH" \
+            --user "$SECOND_USER" --level read-write >/dev/null 2>&1; then
+        log_warn "Could not provision uid ${SECOND_UID}; multi-client tests will fail on share access."
     fi
 fi
 


### PR DESCRIPTION
Closes #2332
Closes #2336

## #2332 — the premise collapses: LOOKUP was never broken

The issue reads the six failures as a LOOKUP defect. It is not one. All six tests
reach for `env.c2`, pynfs's **second** client, and `servertests/environment.py`
builds that client with `rpc.SecAuthSys(0, machinename, opts.uid + 1, opts.gid + 1, [])`.
The harness passes `--uid 0 --gid 0`, so the second client authenticates as **uid 1**,
which nothing provisions.

The server log says so directly:

```
NFSv4 parsed Unix auth client=[::1]:63130 uid=1 gid=1 ngids=0
NFSv4 COMPOUND op dispatched op_index=1 opcode=15 op_name=LOOKUP status=0
NFS UID reverse lookup failed, treating as guest share=/export uid=1 error=user not found
Share access denied (unknown UID, no default or SID grant) share=/export uid=1
NFSv4 LOOKUP real-FS auth context failed error=share access denied
NFSv4 COMPOUND op dispatched op_index=2 opcode=15 op_name=LOOKUP status=13
```

`status=13` is `NFS4ERR_ACCESS`. The first LOOKUP (into the pseudo-fs junction)
succeeds; the second, the one that crosses into the real share and therefore builds
an auth context, is refused by the share gate in
`internal/adapter/nfs/auth/share_permission.go`. That refusal is deliberate product
policy — an NFS uid with no DittoFS account and no default permission on the share
gets nothing — and knfsd passes these tests only because it has no identity model at
all. The traversal code is fine, and this PR changes none of it.

`test/posix/setup-posix.sh` already provisions accounts for the three uids pjdfstest
runs as. `run-pynfs.sh` provisions none for pynfs's second principal, so every test
that reaches for it died on the first LOOKUP that crossed into the share. The fix is
one account, created where the harness already sets the lease time.

That change alone turns **five** of the six green. `LKU10` then failed on something
new, which is the second half of this PR.

## #2332 — the defect the harness fix uncovered

`LKU10` asserts RFC 7530 §8.6.3: unlocking with a stateid the server freed when it
cancelled the client's lease answers `NFS4ERR_EXPIRED`. It answered
`NFS4ERR_BAD_STATEID`.

`markClientStateidsExpiredLocked` already records every stateid freed by a lease
cancellation exactly so a later use can be told apart from a stateid that was never
issued (§9.6.3.2), and `ValidateStateid`, `CloseFile`, `ConfirmOpen` and
`DowngradeOpen` all consult it. `LockNew` and `UnlockFile` do not: they look the
stateid up in the lock table directly and a miss went straight to
`NFS4ERR_BAD_STATEID`. Both now route their miss through one classifier alongside the
existing stale-epoch check.

## #2336 — READDIR argument validation

Four gaps, all in one place, all quoted from RFC 7530 §16.24.4.

**maxcount** — *"the maximum number of bytes for the result. This maximum size
represents all of the data being returned within the READDIR4resok structure and
includes the XDR overhead."* `READDIR4resok` is `cookieverf` (8) plus a `dirlist4`,
and an empty `dirlist4` is the list terminator and the eof flag (4 each), so the floor
is 16 bytes. `maxcount=0` was read as "unlimited" and 15 was accepted, both returning
`NFS4_OK` (`RDDR7`, `RDDR8`). The per-entry budget also counted the four-byte
operation status against `maxcount`, which does not cover it, and then compensated
by charging only the eof flag for the list tail instead of the terminator as well.
The two errors cancel: every entry decision was already numerically right. It is
rewritten in `READDIR4resok` bytes anyway, because that is what the new floor is
derived from — but the only behaviour that changes here is the floor.

**Reserved cookies** — *"For READDIR arguments, cookie values of 1 and 2 SHOULD NOT be
used, and for READDIR results, cookie values of 0, 1, and 2 MUST NOT be returned."*
Both halves were wrong. Cookies 1 and 2 were accepted as arguments (`RDDR10`), and the
server was itself issuing them: the pseudo-fs listing synthesized `.` and `..` onto
cookies 1 and 2, and `CookieManager.GenerateCookie` collapsed a zero hash onto 1.
Rejecting the arguments without fixing the results would have made the server refuse
its own cookies, so both moved to 3. The synthesized entries are gone as well — the
same section says that where `.` and `..` exist *"they should not be returned to the
client as part of the READDIR response"*, which is why the cookies are reserved: the
client splices them in itself.

**Write-only attributes** — a per-entry attribute request naming
`FATTR4_TIME_ACCESS_SET` or `FATTR4_TIME_MODIFY_SET` returned `NFS4_OK` with the bits
silently dropped (`RDDR9`). #2363 landed `attrs.HasWriteOnlyAttr` for GETATTR, VERIFY
and NVERIFY and deliberately exempted READDIR on the grounds that it has no way to
report a per-attribute error. `fattr4_rdattr_error` reports a failure to *read* one
entry's attributes, not a request the server can never answer for any entry, so the
right answer is the same `NFS4ERR_INVAL` the other three give. READDIR now shares that
seam and the comment that exempted it is corrected.

## Evidence

Local runs are a full `pynfs` v4.0 sweep against a memory-backed server, base and
branch, on ports isolated from the other sessions running this repo. Row counts are
measured with `test/common/known-failures.sh` on this branch's own base, not carried
over from an earlier run.

| | base | branch |
| --- | --- | --- |
| `Loaded N known failures` (V40) | 73 | 63 |
| Skipped | 8 | 8 |
| Failed | 63 | 52 |
| Passed | 525 | 536 |
| New failures | 0 | 0 |

The base column is cell-for-cell identical to what CI measured, which matters because
a local pynfs run on a developer machine is not self-evidently trustworthy. `nfs-pynfs`
run 34069808736 (`5fe8954e9`, the commit this work started from) and run 34092361780
(`1906959dc`, the commit under the current rebase) both report `Loaded 73 known
failures` / `8 Skipped, 63 Failed, 5 Warned, 525 Passed` for `pynfs v4.0 / memory`, and
34069808736 reports the same on all four v4.0 backends. Nothing between those commits
and this branch's base touches the NFS tree or the table.

Eleven tests moved from FAILURE to PASS and nothing moved the other way:

```
CLOSE8 CLOSE9 LKU10 LOCK13 LOCK15 LOCK17   (#2332)
RDDR7 RDDR8 RDDR9 RDDR10                   (#2336)
RPLY8
```

**The count moved by eleven while ten rows come out.** The eleventh is `RPLY8`, whose
row stays: it is a `suite` row backed by knfsd also failing it, and one green local run
of a replay-of-a-waiting-LOCKU test is not enough to overturn that. A blacklisted test
that passes is invisible to the grader, so the row costs nothing where it is.

Worth stating because the opposite was expected: **`Skipped` did not move.** pynfs omits
a test whose `DEPEND` prerequisites did not run, which would have hidden work behind
these six — but their prerequisites are `INIT` and `MKFILE`, which always ran. The six
were failing in the open, not blocking others out of sight.

v4.1 was run the same way, base and branch, because `run-pynfs.sh` provisions that
account for both minor versions. Both runs grade identically (`Loaded 64`, one
pre-existing local-only `RECC1` failure present on *both* sides and absent from CI),
so nothing regressed there. The `COUR*` courtesy-client codes flap between runs on both
sides; all are already blacklisted under #2327.

Unit coverage: `TestReadDir_ArgumentValidation` and
`TestExpiredLease_LockStateidsReportExpired` were both run against the unmodified
`readdir.go` / `manager.go` first and fail there, so neither is self-satisfying.

## Not folded in

`FATTR4_SPACE_TOTAL`/`SPACE_FREE`/`SPACE_AVAIL` carry the wrong bit numbers (#2362).
Untouched.

#2377 is ahead of this branch and removes a disjoint 38 rows from
`KNOWN_FAILURES_V40.md` (73 → 35). The two row sets do not overlap — that PR takes the
`CMT2*`, `LKT2*`, `LOOKP2*`, `OPEN*`, `RM7`, `CR11`, `CR13` and `PUTFH2` rows, this one
takes `CLOSE8`, `CLOSE9`, `LKU10`, `LOCK13`, `LOCK15`, `LOCK17` and `RDDR7`–`RDDR10` —
so after both the table should be 25 rows. It also touches `ops_test.go`,
`state/manager.go` and both tables, so this branch will be rebased onto develop once it
lands and the counts re-measured against the new base.
