### PR TITLE
perf(journal): read the file high-water mark off the interval tail

### DIFF
--- a/pkg/block/journal/index_invariant_test.go
+++ b/pkg/block/journal/index_invariant_test.go
@@ -1,0 +1,124 @@
+package journal
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+)
+
+// checkSortedDisjoint asserts the invariant FileSize reads off the tail: the
+// intervals are sorted by fileOff, do not overlap, and so the last one carries
+// the maximum end offset.
+func checkSortedDisjoint(t *testing.T, s *Store, id FileID, when string) {
+	t.Helper()
+	sh := s.shardFor(id)
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	fi := sh.index[id]
+	if fi == nil {
+		return
+	}
+	var maxEnd int64
+	for i, iv := range fi.ivs {
+		if i > 0 {
+			prev := fi.ivs[i-1]
+			if iv.fileOff < prev.fileOff {
+				t.Fatalf("%s: ivs[%d].fileOff=%d < ivs[%d].fileOff=%d (unsorted)",
+					when, i, iv.fileOff, i-1, prev.fileOff)
+			}
+			if iv.fileOff < prev.end() {
+				t.Fatalf("%s: ivs[%d] [%d,%d) overlaps ivs[%d] [%d,%d)",
+					when, i, iv.fileOff, iv.end(), i-1, prev.fileOff, prev.end())
+			}
+		}
+		if e := iv.end(); e > maxEnd {
+			maxEnd = e
+		}
+	}
+	if n := len(fi.ivs); n > 0 && fi.ivs[n-1].end() != maxEnd {
+		t.Fatalf("%s: last end=%d but max end=%d — the tail is not the high-water mark",
+			when, fi.ivs[n-1].end(), maxEnd)
+	}
+}
+
+// TestIntervalIndexStaysSortedAndDisjoint pins the invariant FileSize now reads
+// off the tail instead of rescanning for.
+//
+// insert is the only path that can reorder intervals or introduce an overlap,
+// so that is what this hammers, through every caller that reaches it: WriteAt,
+// Truncate, Hydrate and SeedCold. The other rewrites of fi.ivs cannot break it
+// by construction — carve and reclaim only flip the synced and cold flags on
+// intervals already in place, and the filtering rewrites either drop an
+// interval or clamp its end downwards, neither of which can unsort a sorted set
+// or overlap a disjoint one. The reopen leg covers the one filter that
+// transforms rather than drops: recovery re-applying a truncate marker over a
+// replayed record, clipping the interval that straddles newSize.
+func TestIntervalIndexStaysSortedAndDisjoint(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	s, err := Open(dir, Config{ShardCount: 1}, newFakeRemote(), SystemClock())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	rng := rand.New(rand.NewSource(7))
+	buf := make([]byte, 8<<10)
+	// Offsets are drawn from a range narrow enough that writes collide often:
+	// a probe that only ever appends would never reach the punch-and-merge path
+	// that is the one able to produce an overlap.
+	randOff := func() int64 { return int64(rng.Intn(512)) * (4 << 10) }
+
+	const id = FileID("f")
+	for i := 0; i < 4000; i++ {
+		switch rng.Intn(7) {
+		case 0, 1, 2:
+			if err := s.WriteAt(ctx, id, randOff(), buf[:1+rng.Intn(len(buf))]); err != nil {
+				t.Fatalf("WriteAt: %v", err)
+			}
+		case 3:
+			if _, ok := s.FileSize(ctx, id); !ok {
+				continue
+			}
+		case 4:
+			if err := s.Truncate(ctx, id, randOff()); err != nil {
+				t.Fatalf("Truncate: %v", err)
+			}
+		case 5:
+			if err := s.Hydrate(ctx, id, randOff(), buf[:1+rng.Intn(len(buf))], 0); err != nil {
+				t.Fatalf("Hydrate: %v", err)
+			}
+		case 6:
+			off := randOff()
+			if err := s.SeedCold(ctx, id, [][2]int64{{off, int64(1 + rng.Intn(8<<10))}}); err != nil {
+				t.Fatalf("SeedCold: %v", err)
+			}
+		}
+		checkSortedDisjoint(t, s, id, "after mutation")
+	}
+
+	// A file that is deleted outright exercises the tombstone filter on replay.
+	if err := s.WriteAt(ctx, "doomed", 0, buf[:4096]); err != nil {
+		t.Fatalf("WriteAt doomed: %v", err)
+	}
+	if err := s.Delete(ctx, "doomed"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	want, ok := s.FileSize(ctx, id)
+	if !ok {
+		t.Fatalf("FileSize before reopen: no index entry")
+	}
+	_ = s.Close()
+
+	r, err := Open(dir, Config{ShardCount: 1}, newFakeRemote(), SystemClock())
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+
+	checkSortedDisjoint(t, r, id, "after recovery")
+	if got, ok := r.FileSize(ctx, id); !ok || got != want {
+		t.Fatalf("recovered FileSize = (%d,%v), want (%d,true)", got, ok, want)
+	}
+}

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -847,13 +847,16 @@ func (s *Store) FileSize(_ context.Context, id FileID) (int64, bool) {
 	if fi == nil {
 		return 0, false
 	}
-	var size int64
-	for _, iv := range fi.ivs {
-		if e := iv.end(); e > size {
-			size = e
-		}
+	if len(fi.ivs) == 0 {
+		return 0, true
 	}
-	return size, true
+	// ivs is sorted by fileOff and non-overlapping, so end() is strictly
+	// increasing and the last interval carries the high-water mark. insert is the
+	// only path that can reorder or overlap, and it maintains that; every other
+	// rewrite either drops intervals or clamps an end downwards. The same
+	// invariant is what makes the sort.Search predicates in index.go monotone, so
+	// a violation would already have broken lookup before it reached here.
+	return fi.ivs[len(fi.ivs)-1].end(), true
 }
 
 // DurableExtent reports how far a file's bytes survive device loss: the maximum


### PR DESCRIPTION
Closes #2366.

`journal.Store.FileSize` scanned every interval under the shard lock to find the maximum end offset. The interval index is sorted by `fileOff` and non-overlapping, so `end()` is strictly increasing and the last interval already carries that maximum — the scan recomputed what the tail states.

```go
return fi.ivs[len(fi.ivs)-1].end(), true
```

## Measured

`BenchmarkFileSize` on the recorded 32k-interval residency shape, M1 Max, `-count=3`:

| | ns/op | allocs |
|---|---|---|
| before | 25138 / 25071 / 26006 | 0 |
| after | 14.76 / 14.72 / 15.04 | 0 |

Linear → constant. The caller that pays it is `findStaleSizes` (`pkg/controlplane/runtime/shares/lifecycle.go:241`), once per locally-resident file at share start, so the saving lands on startup latency — the same thread of work as #1891 and #2075 — not on the read path.

## The issue's premise was wrong

#2366 proposed a guarded reverse scan, on the grounds that overlapping intervals are reachable and cite #1934. That is a conflation I introduced when filing it: #1934's overlaps are **manifest rows in the metadata store**, not intervals in this in-memory index. They are different structures.

The interval index holds the invariant outright:

- `insert` (`index.go`) is the only path that can reorder or overlap, and its own doc states the result "stays sorted and non-overlapping";
- `carve.go` and `reclaim.go` only flip the `synced` and `cold` flags on intervals already in place — neither assigns `fi.ivs`;
- the remaining six rewrites (`store.go` ×4, `recovery.go` `keepIntervals`) either drop an interval or clamp its end downwards. Neither can unsort a sorted set or overlap a disjoint one.

It is also already load-bearing: `findRecord`, `insert` and `DataExtents` all binary-search on the predicate `end() > x`, which is monotone only when the set is disjoint. A violation would have broken lookup long before it reached `FileSize`.

## Test

The fix now *depends* on that invariant rather than merely agreeing with it, so `TestIntervalIndexStaysSortedAndDisjoint` pins it: 4000 mixed writes, truncates, hydrates and cold seeds over deliberately colliding offsets, checked after every mutation and again after a recovery reopen (which covers the one filter that transforms rather than drops — recovery re-applying a truncate marker, clipping the interval that straddles `newSize`).

Verified it fails on broken builds, not just passes on the real one:

- `insert` sorting the merged run backwards → `ivs[10].fileOff=1126400 < ivs[9].fileOff=1132258 (unsorted)`
- `insert` skipping the overlap punch → `ivs[10] [1130496,1134161) overlaps ivs[9] [1126400,1132258)`

The second stays sorted, so the ordering check alone would have missed it — both legs earn their place.

`go test ./pkg/block/... ./pkg/controlplane/runtime/shares/...` green, `-race` on the journal package green.