### PR TITLE
test(storetest): scope synced-hash fixtures to the run

### DIFF
--- a/pkg/metadata/store/postgres/synced_hash_store_test.go
+++ b/pkg/metadata/store/postgres/synced_hash_store_test.go
@@ -24,12 +24,11 @@ import (
 // by ON CONFLICT DO NOTHING — see
 // pkg/metadata/store/postgres/synced_hash_store.go.
 //
-// State isolation across runs: the conformance suite picks distinct
-// hash seeds per subtest (via mustHash), and every subtest's
-// assertions are idempotent against rows left by prior runs (Mark is
-// idempotent; Delete is idempotent; IsSyncedBeforeMark uses a seed
-// that no other subtest mutates). No table truncation is required;
-// this mirrors the rollup_store sibling test exactly.
+// State isolation across runs: the conformance suite picks distinct hash
+// seeds per subtest and scopes them to the run, so no assertion turns on
+// the synced_hashes rows an earlier run against the same database left
+// behind — EnumerateSynced still scans them, it just never matches one.
+// No table truncation is required.
 func TestPostgresSyncedHashStore_Suite(t *testing.T) {
 	if os.Getenv("DITTOFS_TEST_POSTGRES_DSN") == "" {
 		t.Skip("DITTOFS_TEST_POSTGRES_DSN not set, skipping PostgreSQL synced-hash tests")

--- a/pkg/metadata/storetest/synced_hash_suite.go
+++ b/pkg/metadata/storetest/synced_hash_suite.go
@@ -7,6 +7,7 @@ package storetest
 
 import (
 	"context"
+	"crypto/rand"
 	"sync"
 	"testing"
 	"time"
@@ -17,11 +18,17 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// mustSyncedHash derives a deterministic ContentHash from a string. Used to
-// scope subtests on a shared store instance — each subtest picks a
-// distinct seed so its state cannot collide with another subtest's.
+// runID scopes this process's fixture hashes away from the rows an earlier run
+// left in a store that outlives the process: MarkSynced is first-wins, so a row
+// seeded under a fixed hash keeps the syncedAt of the run that created it.
+var runID = rand.Text()
+
+// mustSyncedHash derives a ContentHash from a string, stable within a process
+// and distinct from every other run's. Used to scope subtests on a shared store
+// instance — each subtest picks a distinct seed so its state cannot collide
+// with another subtest's, or another run's.
 func mustSyncedHash(seed string) block.ContentHash {
-	return blake3.Sum256([]byte(seed))
+	return blake3.Sum256([]byte(runID + "/" + seed))
 }
 
 // RunSyncedHashStoreSuite exercises the SyncedHashStore contract for a
@@ -32,9 +39,10 @@ func mustSyncedHash(seed string) block.ContentHash {
 //	    storetest.RunSyncedHashStoreSuite(t, s)
 //	}
 //
-// Each subtest uses a distinct hash seed so subtests on a shared store
-// instance do not collide. Callers MUST pass a freshly-created store —
-// the suite does not reset state between subtests.
+// Each subtest uses a distinct hash seed, scoped to the run (see runID), so
+// subtests on a shared store — or on a store that outlives the process — do
+// not collide. Callers MUST pass a freshly-created store — the suite does
+// not reset state between subtests.
 func RunSyncedHashStoreSuite(t *testing.T, s metadata.SyncedHashStore) {
 	t.Helper()
 


### PR DESCRIPTION
Fixes #2372.

## What was wrong

`mustSyncedHash` in `pkg/metadata/storetest/synced_hash_suite.go` derived its fixture hashes deterministically from fixed string seeds, so every run of the suite seeded the *same* seven `synced_hashes` rows. Against a store that outlives the process — a developer's local postgres — those rows survive to the next run, and `MarkSynced` is first-wins (`ON CONFLICT DO NOTHING`), which is correct production behaviour: the second run's mark is a no-op and the row keeps the `synced_at` the *first* run wrote.

`RunSyncedHashEnumeratorSuite`'s freshness assertion then reads a timestamp from whenever the database first saw the suite and fails:

```
synced_hash_suite.go:326: EnumerateSynced syncedAt 2026-09-07 10:08:55 precedes mark time 2026-09-07 10:10:33
```

Pre-existing, and invisible in CI because each job gets a fresh postgres service container. It only bites someone running the suite twice against the same database more than a minute apart.

## The fix

Prefix every fixture seed with `crypto/rand.Text()`, drawn once per process, so each run seeds its own rows. The freshness assertion stays, and `MarkSynced` is untouched.

Every seed still resolves to the same hash for the lifetime of the process, which is what lets the two suites mark a hash in one subtest and re-read it in another.

The two stale doc comments that claimed the old scheme was safe across runs — in the suite and in the postgres backend test — now say what actually makes it safe. The postgres one also pointed at a `rollup_store` sibling test that no longer exists, and at a helper by the wrong name; both go.

## Verification

The bug is a *second* run failing, so a single green run proves nothing. Against one postgres database, more than a minute apart:

| | run 1 | run 2 |
| --- | --- | --- |
| before | PASS | **FAIL** `EnumerateSynced syncedAt … precedes mark time` |
| after | PASS | PASS |

The "after" runs went against the same database that the "before" runs had already poisoned — it still held the stale rows (oldest `synced_at` three hours older than the run) alongside the new ones, and the suite passed anyway.

Also green: `memory`, `badger`, `sqlite` and `storetest` package tests.

Closes #2372
