### PR TITLE
fix(journal): fence a hydrate against the truncate marker's own version

### DIFF
--- a/pkg/block/journal/hydrate_delete_test.go
+++ b/pkg/block/journal/hydrate_delete_test.go
@@ -125,12 +125,12 @@ func TestDeleteFenceCountIsBounded(t *testing.T) {
 func TestDeleteFenceEvictionSparesARestampedFence(t *testing.T) {
 	sh := newShard(nil)
 	sh.fenceDelete("x", 5)
-	sh.hydrateFence["x"] = 99 // a later Truncate re-stamps the same key
+	sh.raiseHydrateFence("x", 99, 4096) // a later Truncate re-stamps the same key
 	for i := 0; i < maxDeleteFences+1; i++ {
 		sh.fenceDelete(FileID(fmt.Sprintf("f%d", i)), uint64(i+100))
 	}
-	if got := sh.hydrateFence["x"]; got != 99 {
-		t.Fatalf("eviction dropped a re-stamped fence: hydrateFence[x] = %d, want 99", got)
+	if got := sh.hydrateFence["x"]; got.minBound != 99 {
+		t.Fatalf("eviction dropped a re-stamped fence: hydrateFence[x].minBound = %d, want 99", got.minBound)
 	}
 }
 

--- a/pkg/block/journal/segment.go
+++ b/pkg/block/journal/segment.go
@@ -328,7 +328,7 @@ func (s *Store) appendRecord(ctx context.Context, id FileID, offset int64, data 
 	// and the fetched bytes are the wrong ones.
 	if synced {
 		n := int64(len(data))
-		if hydrateFenced(sh, id, notAfter) || !coversWhole(sh.index[id].hydratable(offset, n, notAfter), offset, n) {
+		if hydrateFenced(sh, id, notAfter, offset, n) || !coversWhole(sh.index[id].hydratable(offset, n, notAfter), offset, n) {
 			return nil
 		}
 	}

--- a/pkg/block/journal/shard.go
+++ b/pkg/block/journal/shard.go
@@ -32,16 +32,23 @@ type shard struct {
 	active *segmentMeta
 	sealed map[uint64]*segmentMeta
 	index  map[FileID]*fileIndex
-	// hydrateFence is, per file, the store LSN as it stood when that file's most
-	// recent truncate or delete began. A hydrate whose caller sampled its bound
-	// at or below it is refused: both mutations empty intervals away rather than
-	// recording over them, so the range they cleared leaves nothing for
-	// hydratable to weigh a stale write-back against — a delete leaves not even
-	// an index entry, and hydratable's nil receiver offers the whole range.
+	// hydrateFence is, per file, the version of that file's most recent truncate
+	// or delete together with the offset that mutation left standing. A hydrate
+	// whose caller sampled its bound at or below the version, and whose range
+	// reaches past the surviving offset, is refused: both mutations empty
+	// intervals away rather than recording over them, so the range they cleared
+	// leaves nothing for hydratable to weigh a stale write-back against — a
+	// delete leaves not even an index entry, and hydratable's nil receiver
+	// offers the whole range.
+	//
+	// The offset is what keeps a truncate from fencing off its own survivors:
+	// the prefix below newSize still holds its intervals and can be filled
+	// safely, and only the emptied tail has to be refused. A delete leaves
+	// nothing standing, so its offset is zero and it refuses every range.
 	//
 	// A delete's entry therefore has to outlive the file's index entry, and
 	// deleteFences is what keeps that from growing without bound.
-	hydrateFence map[FileID]uint64
+	hydrateFence map[FileID]hydrateFence
 	// deleteFences records the fences stamped by Delete, oldest first. Nothing
 	// else ever takes a delete fence back out of hydrateFence, so without this
 	// the map would retain one entry per FileID the store has ever deleted.
@@ -126,19 +133,41 @@ func newShard(active *segmentMeta) *shard {
 		active:       active,
 		sealed:       make(map[uint64]*segmentMeta),
 		index:        make(map[FileID]*fileIndex),
-		hydrateFence: make(map[FileID]uint64),
+		hydrateFence: make(map[FileID]hydrateFence),
 		segSync:      func(seg *segmentMeta) error { return seg.fd.Sync() },
 	}
 	sh.commitCond = sync.NewCond(&sh.commitMu)
 	return sh
 }
 
+// hydrateFence is the lowest bound a hydrate may still carry after a truncate
+// or delete emptied intervals away, and the offset that mutation left standing:
+// everything from survives upwards was cleared. A delete survives nothing, so
+// it fences from zero.
+type hydrateFence struct {
+	minBound uint64
+	survives int64
+}
+
+// raiseHydrateFence moves id's fence up to ver, never down. Truncate and Delete
+// both publish into it and neither orders against the other, so whichever
+// arrives second must not re-admit the hydrates the first was refusing. Caller
+// holds sh.mu.
+func (sh *shard) raiseHydrateFence(id FileID, minBound uint64, survives int64) {
+	if minBound > sh.hydrateFence[id].minBound {
+		sh.hydrateFence[id] = hydrateFence{minBound: minBound, survives: survives}
+	}
+}
+
 // fenceDelete publishes id's delete fence at ver and drops the oldest fence
 // once the shard holds more than maxDeleteFences of them. Caller holds sh.mu.
 func (sh *shard) fenceDelete(id FileID, ver uint64) {
-	if ver > sh.hydrateFence[id] {
-		sh.hydrateFence[id] = ver // never lower a fence a racing Truncate stamped higher
-	}
+	// ver+1, not ver: a delete scrubs the index entry outright, so between the
+	// tombstone being minted and the scrub landing there is no interval left for
+	// hydratable to arbitrate against — its nil receiver offers the whole range
+	// and a fill bounded at exactly ver re-creates the file. A truncate keeps
+	// its survivors and so can admit that bound; a delete cannot.
+	sh.raiseHydrateFence(id, ver+1, 0) // a delete leaves nothing standing
 	sh.deleteFences = append(sh.deleteFences, fenceEntry{id: id, ver: ver})
 	if len(sh.deleteFences) > maxDeleteFences {
 		oldest := sh.deleteFences[0]
@@ -150,7 +179,7 @@ func (sh *shard) fenceDelete(id FileID, ver uint64) {
 		// Only if nothing has raised the fence since. A Truncate re-stamp belongs
 		// to a file that is live again and still needs its fence; that entry is
 		// then bounded by the live file set, as every truncate fence always was.
-		if sh.hydrateFence[oldest.id] <= oldest.ver {
+		if sh.hydrateFence[oldest.id].minBound <= oldest.ver+1 {
 			delete(sh.hydrateFence, oldest.id)
 		}
 		// Entries are appended in mint order, so this only ever climbs. It stands

--- a/pkg/block/journal/shard.go
+++ b/pkg/block/journal/shard.go
@@ -154,9 +154,20 @@ type hydrateFence struct {
 // arrives second must not re-admit the hydrates the first was refusing. Caller
 // holds sh.mu.
 func (sh *shard) raiseHydrateFence(id FileID, minBound uint64, survives int64) {
-	if minBound > sh.hydrateFence[id].minBound {
-		sh.hydrateFence[id] = hydrateFence{minBound: minBound, survives: survives}
+	cur, had := sh.hydrateFence[id]
+	if had && minBound <= cur.minBound {
+		return
 	}
+	// survives only ever narrows. Raising minBound must not widen the range the
+	// fence admits: a delete survives nothing, and a file deleted, written again
+	// and then truncated would otherwise re-admit a pre-delete hydrate over the
+	// prefix, filling whatever holes the re-created file left there with content
+	// the delete removed. Two truncates narrow for the same reason — the lower
+	// newSize cleared more.
+	if had && cur.survives < survives {
+		survives = cur.survives
+	}
+	sh.hydrateFence[id] = hydrateFence{minBound: minBound, survives: survives}
 }
 
 // fenceDelete publishes id's delete fence at ver and drops the oldest fence

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -249,6 +249,11 @@ type Store struct {
 	// production.
 	failTombstone FileID
 	failTruncate  FileID
+	// beforeTruncateMarker is a test seam run between Truncate publishing its
+	// provisional fence and minting the marker that supersedes it, so a test can
+	// land the concurrent write that opens the window between the two versions.
+	// Always nil in production.
+	beforeTruncateMarker func()
 }
 
 // SetVerifyReads enables or disables per-read record-CRC verification of warm
@@ -465,7 +470,7 @@ func (s *Store) Hydrate(ctx context.Context, id FileID, offset int64, data []byt
 	sh := s.shardFor(id)
 	sh.mu.Lock()
 	var ranges [][2]int64
-	if !hydrateFenced(sh, id, notAfter) {
+	if !hydrateFenced(sh, id, notAfter, offset, int64(len(data))) {
 		ranges = sh.index[id].hydratable(offset, int64(len(data)), notAfter)
 	}
 	sh.mu.Unlock()
@@ -483,12 +488,39 @@ func (s *Store) Hydrate(ctx context.Context, id FileID, offset int64, data []byt
 func (s *Store) WriteVersion() uint64 { return s.version.Load() }
 
 // hydrateFenced reports whether a hydrate's bound predates the file's most
-// recent truncate or delete — the two mutations that leave no interval behind
-// to compare against. A delete's fence may have been evicted from the shard's
-// FIFO, in which case evictedFenceFloor still stands in for it. Callers hold
-// sh.mu.
-func hydrateFenced(sh *shard, id FileID, notAfter uint64) bool {
-	return notAfter > 0 && (notAfter <= sh.hydrateFence[id] || notAfter <= sh.evictedFenceFloor)
+// recent truncate or delete over a range that mutation emptied — the two
+// mutations that leave no interval behind to compare against.
+//
+// The range test is what keeps a truncate from refusing its own survivors: the
+// prefix below newSize kept its intervals, so hydratable can still weigh a
+// stale fill against them there, and only a range reaching into the cleared
+// tail has to be turned away. A straddling range is refused whole rather than
+// trimmed, matching how the caller treats a short answer. A delete survives
+// nothing and so refuses everything.
+//
+// minBound is the lowest bound the fence still admits, and the two mutations
+// set it differently. A truncate admits its own marker version: the survivors
+// it kept are there for hydratable to arbitrate against, and DiscardLocalContent
+// depends on it — that path truncates to zero and hydrates the copied content
+// straight back, under a bound sampled just after. A delete admits nothing at
+// its tombstone version, because it scrubs the index entry and leaves nothing
+// to arbitrate against, so it fences one version higher.
+//
+// evictedFenceFloor stands in for fences the shard's FIFO has dropped, which
+// are all deletes. It stays inclusive: it is the maximum over several dropped
+// fences rather than any one mutation's version, so there is no single version
+// for it to be strict about, and erring wide there costs only a re-fetch.
+//
+// Callers hold sh.mu.
+func hydrateFenced(sh *shard, id FileID, notAfter uint64, offset, n int64) bool {
+	if notAfter == 0 {
+		return false
+	}
+	if notAfter <= sh.evictedFenceFloor {
+		return true
+	}
+	f, ok := sh.hydrateFence[id]
+	return ok && notAfter < f.minBound && offset+n > f.survives
 }
 
 // SeedCold registers a byte range as remote-durable-but-not-local: a read of it
@@ -996,11 +1028,17 @@ func (s *Store) Truncate(ctx context.Context, id FileID, newSize int64) error {
 	if past {
 		// Published before the marker is stamped, so a hydrate that samples its
 		// bound after this point is never mistaken for one that predates the clip.
-		sh.hydrateFence[id] = s.version.Load()
+		// This is a floor, not the final fence: the marker's own version is not
+		// minted yet, and the fence is raised to it below.
+		sh.raiseHydrateFence(id, s.version.Load()+1, newSize)
 	}
 	sh.mu.Unlock()
 	if !past {
 		return nil
+	}
+
+	if s.beforeTruncateMarker != nil {
+		s.beforeTruncateMarker()
 	}
 
 	// Durability first: the marker must be on disk before the index is clipped.
@@ -1010,6 +1048,12 @@ func (s *Store) Truncate(ctx context.Context, id FileID, newSize int64) error {
 	}
 
 	sh.mu.Lock()
+	// The clip below keeps every interval versioned above truncVer, so the fence
+	// has to reach truncVer too. Left at the peek it admits a hydrate bound in
+	// between: above the peek, so not stale, and the interval it writes back is
+	// versioned above truncVer, so the clip keeps it. The tail would come back
+	// and stay back.
+	sh.raiseHydrateFence(id, truncVer, newSize)
 	fi = sh.index[id]
 	var dirty int64
 	if fi != nil {

--- a/pkg/block/journal/truncate_fence_test.go
+++ b/pkg/block/journal/truncate_fence_test.go
@@ -147,3 +147,48 @@ func TestTruncateDoesNotLowerADeleteFence(t *testing.T) {
 		t.Fatalf("Truncate lowered the fence from %d to %d", fenced, after)
 	}
 }
+
+// TestTruncateAfterDeleteDoesNotReAdmitPreDeleteHydrates covers the range half
+// of the same non-relaxation rule.
+//
+// A delete fences every range; a later truncate on the re-created file raises
+// the version but must not widen what the fence admits. Otherwise a hydrate
+// that predates the delete is let back in below newSize and fills whatever
+// holes the re-created file left there with the content the delete removed —
+// the delete-resurrection class again, limited to the prefix.
+func TestTruncateAfterDeleteDoesNotReAdmitPreDeleteHydrates(t *testing.T) {
+	ctx := context.Background()
+	s := testStore(t, Config{})
+
+	old := bytes.Repeat([]byte{0xAB}, 8192)
+	if err := s.WriteAt(ctx, "f", 0, old); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	// A cold read that resolved here, before the delete.
+	stale := s.WriteVersion()
+
+	if err := s.Delete(ctx, "f"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	// Re-created sparsely: [4096,8192) is written, [0,4096) is a hole the stale
+	// hydrate would land in.
+	if err := s.WriteAt(ctx, "f", 4096, bytes.Repeat([]byte{0xCD}, 4096)); err != nil {
+		t.Fatalf("WriteAt(recreate): %v", err)
+	}
+	if err := s.Truncate(ctx, "f", 6144); err != nil {
+		t.Fatalf("Truncate: %v", err)
+	}
+
+	if err := s.Hydrate(ctx, "f", 0, old[:4096], stale); err != nil {
+		t.Fatalf("Hydrate: %v", err)
+	}
+
+	got := make([]byte, 4096)
+	if _, _, err := s.ReadAt(ctx, "f", 0, got); err != nil {
+		t.Fatalf("ReadAt: %v", err)
+	}
+	if bytes.Equal(got, old[:4096]) {
+		t.Fatal("a truncate after a delete re-admitted a pre-delete hydrate: deleted content resurrected in the prefix")
+	}
+}

--- a/pkg/block/journal/truncate_fence_test.go
+++ b/pkg/block/journal/truncate_fence_test.go
@@ -1,0 +1,149 @@
+package journal
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+// TestHydrateInTheTruncateVersionWindowIsRefused covers the gap between the two
+// versions a truncate carries.
+//
+// Truncate publishes its fence from a peek taken before the marker exists, but
+// clips the index against the marker's own version, which is higher whenever an
+// unrelated write lands in between. A hydrate that sampled its bound inside
+// that window passes the fence — its bound is above the peek, so it does not
+// look stale — and the interval it writes back is stamped higher than the
+// marker, so it also survives the clip. The truncated tail comes back and stays
+// back, with no error and no log line.
+//
+// The seam lands the unrelated write that opens the window; in production any
+// concurrent writer to the store does the same thing.
+func TestHydrateInTheTruncateVersionWindowIsRefused(t *testing.T) {
+	s := testStore(t, Config{})
+	ctx := context.Background()
+
+	const (
+		full = 8192
+		half = 4096
+	)
+	data := randBytes(full, 11)
+	if err := s.WriteAt(ctx, "f", 0, data); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+
+	// Sampled inside the window: after Truncate peeked, before it minted its
+	// marker. This is the bound a cold read that started here would carry.
+	var inWindow uint64
+	s.beforeTruncateMarker = func() {
+		if err := s.WriteAt(ctx, "other", 0, data[:64]); err != nil {
+			t.Errorf("WriteAt(other): %v", err)
+		}
+		inWindow = s.WriteVersion()
+	}
+
+	if err := s.Truncate(ctx, "f", half); err != nil {
+		t.Fatalf("Truncate: %v", err)
+	}
+	s.beforeTruncateMarker = nil
+
+	if sz, ok := s.FileSize(ctx, "f"); !ok || sz != half {
+		t.Fatalf("FileSize after truncate = (%d,%v), want (%d,true)", sz, ok, half)
+	}
+	if fenced := s.shardFor("f").hydrateFence["f"].minBound; inWindow >= fenced {
+		t.Fatalf("window never opened: sampled %d, fence at %d — the seam did not land a write", inWindow, fenced)
+	}
+
+	// A fetch resolved from pre-truncate state, written back under that bound.
+	// The fence has to refuse it: the truncate emptied this range away, so
+	// there is no interval left for hydratable to weigh it against and it reads
+	// as an unwritten hole.
+	if err := s.Hydrate(ctx, "f", half, data[half:], inWindow); err != nil {
+		t.Fatalf("Hydrate: %v", err)
+	}
+
+	if sz, ok := s.FileSize(ctx, "f"); !ok || sz != half {
+		t.Fatalf("truncated tail resurrected: FileSize = (%d,%v), want (%d,true)", sz, ok, half)
+	}
+	got := make([]byte, full)
+	for i := range got {
+		got[i] = 0xFF
+	}
+	if _, _, err := s.ReadAt(ctx, "f", 0, got); err != nil {
+		t.Fatalf("ReadAt: %v", err)
+	}
+	if !bytes.Equal(got[:half], data[:half]) {
+		t.Fatalf("kept bytes mismatch")
+	}
+	if !zeroFilled(got[half:]) {
+		t.Fatalf("bytes past newSize are not zero: %x", got[half:half+8])
+	}
+}
+
+// TestTruncateDoesNotFenceOffItsOwnSurvivors is the other direction: the fence
+// is per-file, so raising it to the marker's version must not refuse a hydrate
+// of the prefix the truncate kept. DiscardLocalContent is the live caller that
+// depends on this — it truncates to zero and the copied content is hydrated
+// straight back, under a bound sampled after the truncate.
+func TestTruncateDoesNotFenceOffItsOwnSurvivors(t *testing.T) {
+	s := testStore(t, Config{})
+	ctx := context.Background()
+
+	data := randBytes(8192, 17)
+	if err := s.WriteAt(ctx, "f", 0, data); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if err := s.Truncate(ctx, "f", 4096); err != nil {
+		t.Fatalf("Truncate: %v", err)
+	}
+	if err := s.SeedCold(ctx, "f", [][2]int64{{0, 4096}}); err != nil {
+		t.Fatalf("SeedCold: %v", err)
+	}
+
+	// Sampled after the truncate: this fetch already reflects it.
+	notAfter := s.WriteVersion()
+	if err := s.Hydrate(ctx, "f", 0, data[:4096], notAfter); err != nil {
+		t.Fatalf("Hydrate: %v", err)
+	}
+
+	got := make([]byte, 4096)
+	if _, _, err := s.ReadAt(ctx, "f", 0, got); err != nil {
+		t.Fatalf("ReadAt: %v", err)
+	}
+	if !bytes.Equal(got, data[:4096]) {
+		t.Fatalf("the surviving prefix was fenced off: the hydrate did not land")
+	}
+}
+
+// TestTruncateDoesNotLowerADeleteFence covers the other half of the same stamp.
+//
+// fenceDelete raises the fence rather than assigning it, with the stated reason
+// that a racing Truncate may have published a higher one. Truncate assigned, so
+// the reverse ordering dropped the delete's fence to the truncate's peek and
+// re-admitted the hydrates the delete was refusing.
+func TestTruncateDoesNotLowerADeleteFence(t *testing.T) {
+	s := testStore(t, Config{})
+	ctx := context.Background()
+
+	data := randBytes(8192, 13)
+	if err := s.WriteAt(ctx, "f", 0, data); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+
+	sh := s.shardFor("f")
+	sh.mu.Lock()
+	sh.fenceDelete("f", s.version.Load()+1000) // a delete fence from far ahead
+	fenced := sh.hydrateFence["f"].minBound
+	sh.mu.Unlock()
+
+	if err := s.Truncate(ctx, "f", 4096); err != nil {
+		t.Fatalf("Truncate: %v", err)
+	}
+
+	sh.mu.Lock()
+	after := sh.hydrateFence["f"].minBound
+	sh.mu.Unlock()
+	if after < fenced {
+		t.Fatalf("Truncate lowered the fence from %d to %d", fenced, after)
+	}
+}


### PR DESCRIPTION
Closes #2247.

`Truncate` publishes its hydrate fence from a version peeked *before* the marker exists, then clips the index against the marker's version, which is higher whenever an unrelated write lands between the two locked sections. A hydrate that sampled its bound inside that window clears the fence — its bound is above the peek, so it does not read as stale — and the interval it writes back is versioned above the marker, so the clip keeps it too. The truncated tail comes back and **stays** back, with no error and no log line.

Same silent-corruption family as #1850 / #1888 / #2084, and adjacent to the delete fence #2252 added.

## Two things the issue's prescribed fix did not account for

The issue prescribed raising the fence to `truncVer` and nothing else. I applied exactly that; the two targeted repros went green and **four unrelated tests broke**.

**1. The fence is per file, so raising it also refuses the truncate's own survivors.** `DiscardLocalContent` is the live caller that breaks — server-side copy truncates the destination to zero and hydrates the copied content straight back. So the fence now also records the offset the mutation left standing, and refuses only ranges reaching past it. A truncate's survivors still arbitrate through `hydratable`; a delete leaves none, so it keeps refusing everything.

**2. The version boundary differs between truncate and delete.** A truncate admits a bound equal to its marker: that caller resolved its fetch with the marker already minted, and the survivors are there to weigh it against. A delete cannot — it scrubs the index entry, `hydratable`'s nil receiver then offers the whole range — so it fences one version higher. That is what it already did; the field is now named `minBound` and each producer sets it, rather than the difference being implied by an inclusive comparison.

Caught by running the package tree rather than the repro. `TestTruncateDoesNotFenceOffItsOwnSurvivors` is the regression guard: it passes on unmodified develop and fails only against the over-broad fix.

## A second defect in the same stamp

`Truncate` **assigned** the fence where `fenceDelete` raises it — and `fenceDelete`'s own comment says "never lower a fence a racing Truncate stamped higher". The reverse ordering was unhandled: a truncate following a delete dropped the delete's fence to its own peek and re-admitted the hydrates that delete was refusing. Both now go through `raiseHydrateFence`.

## Verification

The window needs a concurrent write to open, so a test seam lands one (`beforeTruncateMarker`, nil in production, alongside the existing `failTruncate`/`failTombstone` seams). In production any other writer to the store does the same thing.

Both defects reproduce on unmodified develop:

```
--- FAIL: TestHydrateInTheTruncateVersionWindowIsRefused
    truncated tail resurrected: FileSize = (8192,true), want (4096,true)
--- FAIL: TestTruncateDoesNotLowerADeleteFence
    Truncate lowered the fence from 1001 to 1
```

`go test ./pkg/block/...` green, `-race` on the journal package green.