### PR TITLE
fix(smb): don't announce a rename that a hard link made a no-op

### DIFF
--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -1060,7 +1060,7 @@ func (h *Handler) setFileInfoFromStore(
 		// case-mismatched destination still falls through to the overwrite
 		// path below and replaces the entry it found.
 		if dstHandle, childErr := metaSvc.GetChild(authCtx.Context, toDir, toName); childErr == nil &&
-			bytes.Equal(dstHandle, openFile.MetadataHandle) {
+			len(openFile.MetadataHandle) > 0 && bytes.Equal(dstHandle, openFile.MetadataHandle) {
 			logger.Debug("SET_INFO: rename destination is another link to the source",
 				"from", openFile.Name().Path,
 				"to", newPath)

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -1047,16 +1047,16 @@ func (h *Handler) setFileInfoFromStore(
 		isOverwrite := renameInfo.ReplaceIfExists
 		metaSvc := h.Registry.GetMetadataService()
 
-		// A destination name that already resolves to the file being renamed is
-		// another hard link to it, so the rename has nothing to move and
-		// unlinking either name would drop a link the caller never asked to
-		// lose. Move returns success without touching the store in that case,
-		// which leaves everything below describing a change that did not
-		// happen: the lease breaks, the paired rename notification, and the
-		// handle's own name. Take the same shortcut the link path takes when
-		// asked to link a file onto a name it already answers to.
+		// A destination name that already resolves to the file being renamed
+		// is another hard link to it, so there is nothing to move: unlinking
+		// either name would drop a link the caller never asked to lose, and
+		// Move returns success without touching the store. Everything below
+		// would then describe a change that did not happen — the lease
+		// breaks, the paired rename notification, and the handle's own name.
+		// The link path takes the same shortcut for a link onto a name the
+		// file already answers to.
 		//
-		// The probe is exact-case to match the GetChild inside Move, so a
+		// The probe is exact-case, matching the GetChild inside Move, so a
 		// case-mismatched destination still falls through to the overwrite
 		// path below and replaces the entry it found.
 		if dstHandle, childErr := metaSvc.GetChild(authCtx.Context, toDir, toName); childErr == nil &&

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -1047,6 +1047,26 @@ func (h *Handler) setFileInfoFromStore(
 		isOverwrite := renameInfo.ReplaceIfExists
 		metaSvc := h.Registry.GetMetadataService()
 
+		// A destination name that already resolves to the file being renamed is
+		// another hard link to it, so the rename has nothing to move and
+		// unlinking either name would drop a link the caller never asked to
+		// lose. Move returns success without touching the store in that case,
+		// which leaves everything below describing a change that did not
+		// happen: the lease breaks, the paired rename notification, and the
+		// handle's own name. Take the same shortcut the link path takes when
+		// asked to link a file onto a name it already answers to.
+		//
+		// The probe is exact-case to match the GetChild inside Move, so a
+		// case-mismatched destination still falls through to the overwrite
+		// path below and replaces the entry it found.
+		if dstHandle, childErr := metaSvc.GetChild(authCtx.Context, toDir, toName); childErr == nil &&
+			bytes.Equal(dstHandle, openFile.MetadataHandle) {
+			logger.Debug("SET_INFO: rename destination is another link to the source",
+				"from", openFile.Name().Path,
+				"to", newPath)
+			return setInfoStatus(types.StatusSuccess), nil
+		}
+
 		// Dispatch the SOURCE file's break ahead of the destination lookup
 		// below. Every gate that can still reject this rename has already run,
 		// and the source break needs nothing the lookup produces.

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -1056,11 +1056,20 @@ func (h *Handler) setFileInfoFromStore(
 		// The link path takes the same shortcut for a link onto a name the
 		// file already answers to.
 		//
+		// Renaming an entry onto itself is excluded. It reaches the same
+		// no-op inside Move, but it is the ordinary "rename to the name I
+		// already have" request rather than a second link, and the work that
+		// request carries is still owed — a client holding a lease on the
+		// file is broken for it.
+		//
 		// The probe is exact-case, matching the GetChild inside Move, so a
 		// case-mismatched destination still falls through to the overwrite
 		// path below and replaces the entry it found.
+		srcName := openFile.Name()
+		renamingOntoOwnEntry := toName == srcName.FileName && bytes.Equal(toDir, srcName.ParentHandle)
 		if dstHandle, childErr := metaSvc.GetChild(authCtx.Context, toDir, toName); childErr == nil &&
-			len(openFile.MetadataHandle) > 0 && bytes.Equal(dstHandle, openFile.MetadataHandle) {
+			!renamingOntoOwnEntry && len(openFile.MetadataHandle) > 0 &&
+			bytes.Equal(dstHandle, openFile.MetadataHandle) {
 			logger.Debug("SET_INFO: rename destination is another link to the source",
 				"from", openFile.Name().Path,
 				"to", newPath)

--- a/internal/adapter/smb/handlers/set_info_rename_hardlink_test.go
+++ b/internal/adapter/smb/handlers/set_info_rename_hardlink_test.go
@@ -15,12 +15,11 @@ func encodeFileRenameInfoWire(t *testing.T, replaceIfExists bool, rootDir [8]byt
 	return encodeFileLinkInfoWire(t, replaceIfExists, rootDir, fileName)
 }
 
-// renameWatcher arms reg with a watcher on the share root and reports through
-// the returned pointer whether a name-change notification reached it. Delivery
-// is buffered, so callers must FlushAll before reading the flag.
-func renameWatcher(t *testing.T, reg *NotifyRegistry) *bool {
+// renameWatcher arms reg with a watcher on the share root that sets *notified
+// when a name-change notification reaches it. Delivery is buffered, so callers
+// must FlushAll before reading the flag.
+func renameWatcher(t *testing.T, reg *NotifyRegistry, notified *bool) {
 	t.Helper()
-	notified := false
 	mustRegister(t, reg, &PendingNotify{
 		FileID:           [16]byte{0x9E},
 		SessionID:        1,
@@ -31,11 +30,10 @@ func renameWatcher(t *testing.T, reg *NotifyRegistry) *bool {
 		CompletionFilter: FileNotifyChangeFileName,
 		MaxOutputLength:  4096,
 		AsyncCallback: func(sessionID, messageID, asyncId uint64, response *ChangeNotifyResponse) error {
-			notified = true
+			*notified = true
 			return nil
 		},
 	})
-	return &notified
 }
 
 // TestSetInfo_Rename_OntoOwnHardLink pins that renaming a file onto a name
@@ -62,7 +60,8 @@ func TestSetInfo_Rename_OntoOwnHardLink(t *testing.T) {
 	h, open := openHardlinkTestFile(t, rt, rootHandle, handle, "a.txt")
 	open.GrantedAccess = uint32(types.Delete)
 	h.NotifyRegistry = newTestNotifyRegistry()
-	notified := renameWatcher(t, h.NotifyRegistry)
+	notified := false
+	renameWatcher(t, h.NotifyRegistry, &notified)
 
 	// Rename a.txt onto b.txt, which is the same inode reached by its other
 	// link. Exact case, so the case-mismatch pre-remove branch stays out.
@@ -73,7 +72,7 @@ func TestSetInfo_Rename_OntoOwnHardLink(t *testing.T) {
 	}
 
 	h.NotifyRegistry.FlushAll()
-	if *notified {
+	if notified {
 		t.Error("watcher told a.txt was renamed away, but both links still resolve")
 	}
 
@@ -105,7 +104,8 @@ func TestSetInfo_Rename_DistinctDestination(t *testing.T) {
 	h, open := openHardlinkTestFile(t, rt, rootHandle, handle, "a.txt")
 	open.GrantedAccess = uint32(types.Delete)
 	h.NotifyRegistry = newTestNotifyRegistry()
-	notified := renameWatcher(t, h.NotifyRegistry)
+	notified := false
+	renameWatcher(t, h.NotifyRegistry, &notified)
 
 	buf := encodeFileRenameInfoWire(t, true, [8]byte{}, "c.txt")
 	resp, err := h.setFileInfoFromStore(nil, authCtx, open, types.FileRenameInformation, buf)
@@ -114,7 +114,7 @@ func TestSetInfo_Rename_DistinctDestination(t *testing.T) {
 	}
 
 	h.NotifyRegistry.FlushAll()
-	if !*notified {
+	if !notified {
 		t.Error("watcher missed a rename that did move the file")
 	}
 

--- a/internal/adapter/smb/handlers/set_info_rename_hardlink_test.go
+++ b/internal/adapter/smb/handlers/set_info_rename_hardlink_test.go
@@ -66,7 +66,7 @@ func TestSetInfo_Rename_OntoOwnHardLink(t *testing.T) {
 	// Rename a.txt onto b.txt, which is the same inode reached by its other
 	// link. Exact case, so the case-mismatch pre-remove branch stays out.
 	buf := encodeFileRenameInfoWire(t, true, [8]byte{}, "b.txt")
-	resp, err := h.setFileInfoFromStore(nil, authCtx, open, types.FileRenameInformation, buf)
+	resp, err := h.setFileInfoFromStore(&SMBHandlerContext{Context: ctx}, authCtx, open, types.FileRenameInformation, buf)
 	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
 		t.Fatalf("setFileInfoFromStore(rename onto own link): err=%v resp=%v", err, resp)
 	}
@@ -108,7 +108,7 @@ func TestSetInfo_Rename_DistinctDestination(t *testing.T) {
 	renameWatcher(t, h.NotifyRegistry, &notified)
 
 	buf := encodeFileRenameInfoWire(t, true, [8]byte{}, "c.txt")
-	resp, err := h.setFileInfoFromStore(nil, authCtx, open, types.FileRenameInformation, buf)
+	resp, err := h.setFileInfoFromStore(&SMBHandlerContext{Context: ctx}, authCtx, open, types.FileRenameInformation, buf)
 	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
 		t.Fatalf("setFileInfoFromStore(rename): err=%v resp=%v", err, resp)
 	}
@@ -157,11 +157,8 @@ func TestSetInfo_Rename_OverwritesUnrelatedFile(t *testing.T) {
 	notified := false
 	renameWatcher(t, h.NotifyRegistry, &notified)
 
-	// This is the only rename in the file that clobbers a victim, and the
-	// clobber path releases the replaced payload through the handler context.
 	buf := encodeFileRenameInfoWire(t, true, [8]byte{}, "d.txt")
-	hctx := &SMBHandlerContext{Context: ctx}
-	resp, err := h.setFileInfoFromStore(hctx, authCtx, open, types.FileRenameInformation, buf)
+	resp, err := h.setFileInfoFromStore(&SMBHandlerContext{Context: ctx}, authCtx, open, types.FileRenameInformation, buf)
 	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
 		t.Fatalf("setFileInfoFromStore(overwrite rename): err=%v resp=%v", err, resp)
 	}
@@ -183,5 +180,53 @@ func TestSetInfo_Rename_OverwritesUnrelatedFile(t *testing.T) {
 	}
 	if got := open.Name().FileName; got != "d.txt" {
 		t.Errorf("open handle still named %q after the overwrite rename", got)
+	}
+}
+
+// TestSetInfo_Rename_OntoOwnHardLinkWithSecondOpenHandle covers the shape a
+// real client produces: it holds both links open at once. The destination
+// resolves to the file being renamed, so the open-handle gate that protects an
+// overwrite victim sees the renamer's own inode through the sibling handle and
+// refuses the rename with ACCESS_DENIED. That gate exists to stop an unlink
+// under a live handle, and this rename unlinks nothing, so recognising the
+// self-link first is what makes the refusal go away.
+func TestSetInfo_Rename_OntoOwnHardLinkWithSecondOpenHandle(t *testing.T) {
+	rt, rootHandle, authCtx := newHardlinkTestShare(t)
+	ctx := authCtx.Context
+	metaSvc := rt.GetMetadataService()
+
+	handle, _ := createHardlinkTestFile(t, rt, authCtx, rootHandle, "a.txt", 1024)
+	if _, err := metaSvc.CreateHardLink(authCtx, rootHandle, "b.txt", handle); err != nil {
+		t.Fatalf("CreateHardLink b.txt: %v", err)
+	}
+
+	h, open := openHardlinkTestFile(t, rt, rootHandle, handle, "a.txt")
+	open.GrantedAccess = uint32(types.Delete)
+
+	// A second handle on the same inode, reached through the other link. Its
+	// FileID must differ from the renamer's or the gate would exclude it as
+	// the renamer's own open.
+	sibling := (&OpenFile{
+		FileID:         [16]byte{0x5A, 0x11, 0x99, 0x01},
+		MetadataHandle: handle,
+		ShareName:      hardlinkTestShareName,
+		TreeID:         open.TreeID,
+		ShareAccess:    uint32(types.FileShareRead | types.FileShareWrite | types.FileShareDelete),
+	}).WithName(OpenName{Path: "b.txt", FileName: "b.txt", ParentHandle: rootHandle})
+	h.StoreOpenFile(sibling)
+
+	buf := encodeFileRenameInfoWire(t, true, [8]byte{}, "b.txt")
+	resp, err := h.setFileInfoFromStore(&SMBHandlerContext{Context: ctx}, authCtx, open, types.FileRenameInformation, buf)
+	if err != nil {
+		t.Fatalf("setFileInfoFromStore: %v", err)
+	}
+	if resp == nil || resp.GetStatus() != types.StatusSuccess {
+		t.Fatalf("rename onto own link refused while a sibling handle is open: status=%v", resp.GetStatus())
+	}
+
+	for _, name := range []string{"a.txt", "b.txt"} {
+		if _, cErr := metaSvc.GetChild(ctx, rootHandle, name); cErr != nil {
+			t.Errorf("%s no longer resolves: %v", name, cErr)
+		}
 	}
 }

--- a/internal/adapter/smb/handlers/set_info_rename_hardlink_test.go
+++ b/internal/adapter/smb/handlers/set_info_rename_hardlink_test.go
@@ -1,0 +1,135 @@
+package handlers
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+// encodeFileRenameInfoWire serialises a FILE_RENAME_INFORMATION blob. MS-FSCC
+// 2.4.42.2 (FileRenameInformation for the SMB2 Protocol) and 2.4.28.2 share a
+// field-for-field identical layout, so the link encoder produces both.
+func encodeFileRenameInfoWire(t *testing.T, replaceIfExists bool, rootDir [8]byte, fileName string) []byte {
+	t.Helper()
+	return encodeFileLinkInfoWire(t, replaceIfExists, rootDir, fileName)
+}
+
+// renameWatcher arms reg with a watcher on the share root and reports through
+// the returned pointer whether a name-change notification reached it. Delivery
+// is buffered, so callers must FlushAll before reading the flag.
+func renameWatcher(t *testing.T, reg *NotifyRegistry) *bool {
+	t.Helper()
+	notified := false
+	mustRegister(t, reg, &PendingNotify{
+		FileID:           [16]byte{0x9E},
+		SessionID:        1,
+		MessageID:        10,
+		AsyncId:          100,
+		WatchPath:        "/",
+		ShareName:        hardlinkTestShareName,
+		CompletionFilter: FileNotifyChangeFileName,
+		MaxOutputLength:  4096,
+		AsyncCallback: func(sessionID, messageID, asyncId uint64, response *ChangeNotifyResponse) error {
+			notified = true
+			return nil
+		},
+	})
+	return &notified
+}
+
+// TestSetInfo_Rename_OntoOwnHardLink pins that renaming a file onto a name
+// that is already another hard link to it changes nothing a client can see.
+// The metadata layer refuses to move one link over the other — destroying a
+// link is not a rename — and returns success without touching the store, so
+// the handler must not follow that success with a rename notification telling
+// watchers the source name disappeared, nor repoint the open handle at a name
+// the rename never gave it.
+//
+// The sibling control below renames onto a name that does not exist yet and
+// asserts the opposite on the same fixture: without it a broken watcher or a
+// missing DELETE grant would let this test pass while pinning nothing.
+func TestSetInfo_Rename_OntoOwnHardLink(t *testing.T) {
+	rt, rootHandle, authCtx := newHardlinkTestShare(t)
+	ctx := authCtx.Context
+	metaSvc := rt.GetMetadataService()
+
+	handle, _ := createHardlinkTestFile(t, rt, authCtx, rootHandle, "a.txt", 1024)
+	if _, err := metaSvc.CreateHardLink(authCtx, rootHandle, "b.txt", handle); err != nil {
+		t.Fatalf("CreateHardLink b.txt: %v", err)
+	}
+
+	h, open := openHardlinkTestFile(t, rt, rootHandle, handle, "a.txt")
+	open.GrantedAccess = uint32(types.Delete)
+	h.NotifyRegistry = newTestNotifyRegistry()
+	notified := renameWatcher(t, h.NotifyRegistry)
+
+	// Rename a.txt onto b.txt, which is the same inode reached by its other
+	// link. Exact case, so the case-mismatch pre-remove branch stays out.
+	buf := encodeFileRenameInfoWire(t, true, [8]byte{}, "b.txt")
+	resp, err := h.setFileInfoFromStore(nil, authCtx, open, types.FileRenameInformation, buf)
+	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
+		t.Fatalf("setFileInfoFromStore(rename onto own link): err=%v resp=%v", err, resp)
+	}
+
+	h.NotifyRegistry.FlushAll()
+	if *notified {
+		t.Error("watcher told a.txt was renamed away, but both links still resolve")
+	}
+
+	if got := open.Name().FileName; got != "a.txt" {
+		t.Errorf("open handle renamed to %q by a rename that moved nothing", got)
+	}
+
+	for _, name := range []string{"a.txt", "b.txt"} {
+		child, cErr := metaSvc.GetChild(ctx, rootHandle, name)
+		if cErr != nil {
+			t.Fatalf("%s no longer resolves after renaming a.txt onto its own link: %v", name, cErr)
+		}
+		if !bytes.Equal(child, handle) {
+			t.Errorf("%s resolves to a different file after the rename", name)
+		}
+	}
+}
+
+// TestSetInfo_Rename_DistinctDestination is the control for the test above: on
+// the same fixture, a rename to a name that is not already a link to the
+// source must still notify watchers and repoint the handle.
+func TestSetInfo_Rename_DistinctDestination(t *testing.T) {
+	rt, rootHandle, authCtx := newHardlinkTestShare(t)
+	ctx := authCtx.Context
+	metaSvc := rt.GetMetadataService()
+
+	handle, _ := createHardlinkTestFile(t, rt, authCtx, rootHandle, "a.txt", 1024)
+
+	h, open := openHardlinkTestFile(t, rt, rootHandle, handle, "a.txt")
+	open.GrantedAccess = uint32(types.Delete)
+	h.NotifyRegistry = newTestNotifyRegistry()
+	notified := renameWatcher(t, h.NotifyRegistry)
+
+	buf := encodeFileRenameInfoWire(t, true, [8]byte{}, "c.txt")
+	resp, err := h.setFileInfoFromStore(nil, authCtx, open, types.FileRenameInformation, buf)
+	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
+		t.Fatalf("setFileInfoFromStore(rename): err=%v resp=%v", err, resp)
+	}
+
+	h.NotifyRegistry.FlushAll()
+	if !*notified {
+		t.Error("watcher missed a rename that did move the file")
+	}
+
+	if got := open.Name().FileName; got != "c.txt" {
+		t.Errorf("open handle still named %q after the file was renamed to c.txt", got)
+	}
+
+	if _, cErr := metaSvc.GetChild(ctx, rootHandle, "a.txt"); cErr == nil {
+		t.Error("a.txt still resolves after being renamed to c.txt")
+	}
+	child, cErr := metaSvc.GetChild(ctx, rootHandle, "c.txt")
+	if cErr != nil {
+		t.Fatalf("c.txt does not resolve after the rename: %v", cErr)
+	}
+	if !bytes.Equal(child, handle) {
+		t.Error("c.txt resolves to a different file than the one renamed")
+	}
+}

--- a/internal/adapter/smb/handlers/set_info_rename_hardlink_test.go
+++ b/internal/adapter/smb/handlers/set_info_rename_hardlink_test.go
@@ -133,3 +133,55 @@ func TestSetInfo_Rename_DistinctDestination(t *testing.T) {
 		t.Error("c.txt resolves to a different file than the one renamed")
 	}
 }
+
+// TestSetInfo_Rename_OverwritesUnrelatedFile is the second control: the guard
+// must recognise only the file being renamed. A destination that exists but is
+// a different file is a real overwrite, and it has to stay one — a guard that
+// fired on any resolvable destination would turn every ReplaceIfExists rename
+// into a silent no-op, which the two tests above cannot tell apart from the
+// fix working.
+func TestSetInfo_Rename_OverwritesUnrelatedFile(t *testing.T) {
+	rt, rootHandle, authCtx := newHardlinkTestShare(t)
+	ctx := authCtx.Context
+	metaSvc := rt.GetMetadataService()
+
+	handle, _ := createHardlinkTestFile(t, rt, authCtx, rootHandle, "a.txt", 1024)
+	victim, _ := createHardlinkTestFile(t, rt, authCtx, rootHandle, "d.txt", 2048)
+	if bytes.Equal(handle, victim) {
+		t.Fatal("test setup: source and victim are the same file")
+	}
+
+	h, open := openHardlinkTestFile(t, rt, rootHandle, handle, "a.txt")
+	open.GrantedAccess = uint32(types.Delete)
+	h.NotifyRegistry = newTestNotifyRegistry()
+	notified := false
+	renameWatcher(t, h.NotifyRegistry, &notified)
+
+	// This is the only rename in the file that clobbers a victim, and the
+	// clobber path releases the replaced payload through the handler context.
+	buf := encodeFileRenameInfoWire(t, true, [8]byte{}, "d.txt")
+	hctx := &SMBHandlerContext{Context: ctx}
+	resp, err := h.setFileInfoFromStore(hctx, authCtx, open, types.FileRenameInformation, buf)
+	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
+		t.Fatalf("setFileInfoFromStore(overwrite rename): err=%v resp=%v", err, resp)
+	}
+
+	h.NotifyRegistry.FlushAll()
+	if !notified {
+		t.Error("watcher missed a rename that overwrote an unrelated file")
+	}
+
+	child, cErr := metaSvc.GetChild(ctx, rootHandle, "d.txt")
+	if cErr != nil {
+		t.Fatalf("d.txt does not resolve after being overwritten: %v", cErr)
+	}
+	if !bytes.Equal(child, handle) {
+		t.Error("d.txt was not replaced by the renamed file")
+	}
+	if _, cErr := metaSvc.GetChild(ctx, rootHandle, "a.txt"); cErr == nil {
+		t.Error("a.txt still resolves after being renamed over d.txt")
+	}
+	if got := open.Name().FileName; got != "d.txt" {
+		t.Errorf("open handle still named %q after the overwrite rename", got)
+	}
+}

--- a/internal/adapter/smb/handlers/set_info_rename_hardlink_test.go
+++ b/internal/adapter/smb/handlers/set_info_rename_hardlink_test.go
@@ -230,3 +230,34 @@ func TestSetInfo_Rename_OntoOwnHardLinkWithSecondOpenHandle(t *testing.T) {
 		}
 	}
 }
+
+// TestSetInfo_Rename_OntoItsOwnNameStillActs guards the boundary of the
+// self-link shortcut. Renaming an entry onto its own name reaches the same
+// no-op inside Move, but it is an ordinary rename request rather than a
+// second link, and the work it carries is still owed: the conformance suite
+// requires a lease break for it, and a watcher still expects the
+// notification. Only a destination reached through a *different* entry may be
+// short-circuited.
+func TestSetInfo_Rename_OntoItsOwnNameStillActs(t *testing.T) {
+	rt, rootHandle, authCtx := newHardlinkTestShare(t)
+	ctx := authCtx.Context
+
+	handle, _ := createHardlinkTestFile(t, rt, authCtx, rootHandle, "a.txt", 1024)
+
+	h, open := openHardlinkTestFile(t, rt, rootHandle, handle, "a.txt")
+	open.GrantedAccess = uint32(types.Delete)
+	h.NotifyRegistry = newTestNotifyRegistry()
+	notified := false
+	renameWatcher(t, h.NotifyRegistry, &notified)
+
+	buf := encodeFileRenameInfoWire(t, true, [8]byte{}, "a.txt")
+	resp, err := h.setFileInfoFromStore(&SMBHandlerContext{Context: ctx}, authCtx, open, types.FileRenameInformation, buf)
+	if err != nil || resp == nil || resp.GetStatus() != types.StatusSuccess {
+		t.Fatalf("setFileInfoFromStore(rename onto own name): err=%v resp=%v", err, resp)
+	}
+
+	h.NotifyRegistry.FlushAll()
+	if !notified {
+		t.Error("rename onto the file's own name was short-circuited; it must still run the rename path")
+	}
+}


### PR DESCRIPTION
Closes #2355.

## What was wrong

`metadata.Service.Move` returns `(nil, nil, nil)` — a successful no-op — when the
source and destination names already resolve to the same file handle. They are
hard links of each other, so there is nothing to move and unlinking either name
would destroy a link the caller never asked to lose.

The SMB `FileRenameInformation` handler read any `err == nil` from `Move` as
"the rename happened" and went on to do both of the things a real rename owes:

- `NotifyRegistry.NotifyRename(share, oldParent, "A", newParent, "B", filter)`,
  telling every watcher that `A` disappeared and became `B`
- `openFile.SetName(...)`, repointing the open handle at `B`

`A` still resolves the whole time, so watchers and the handle both end up
describing a rename that did not happen. It is reachable from a plain client:
DittoFS supports SMB hard links through `FileLinkInformation`, so a client can
link `B` onto an open file `A` and then rename `A` → `B`. The case-mismatch
pre-remove branch only fires when `dstMatchedName != toName`, so an exact-case
`ReplaceIfExists` request goes straight into the no-op.

On-disk behaviour was already correct. What is left is the notification, the
handle name, and — for a client holding both links open — a status, covered
below.

## The fix

One guard in `internal/adapter/smb/handlers/set_info.go`, mirroring the self-link
guard the `FileLinkInformation` path already carries: an exact-case
`GetChild(toDir, toName)` probe that returns `STATUS_SUCCESS` immediately when
the destination name already resolves to the file being renamed.

It sits after every gate that can still refuse the rename (DELETE access,
delete-pending, source share-mode, dir-rename open child, destination-parent
conflict) and before the first thing that mutates client-visible state — the
source lease-break dispatch. So a rename that moves nothing now also breaks no
leases and emits no notification.

Renaming an entry onto *its own name* is excluded from the shortcut. It reaches
the same no-op inside `Move`, but it is the ordinary "rename to the name I
already have" request, not a second link, and the work it carries is still owed:
`smb2.compound_async.rename_same_srcdst_non_compound_no_async` requires a lease
break for it (`lease_break_info.count` must be 1). A first cut of this guard
keyed only on inode identity, swallowed that case too, and failed the test on
both smbtorture profiles. The issue names the right discriminator — the
hard-link case is the first where `Move` succeeds with `oldFileName != toName` —
and the guard now keys on it.

The probe is exact-case to match the `GetChild` inside `Move`: a case-mismatched
destination still falls through to the overwrite path and replaces the entry it
found, exactly as before. It is deliberately not gated on `ReplaceIfExists` —
`Move` takes no such argument and no-ops either way, so gating it would leave the
non-overwrite rename still reproducing the bug. MS-FSA 2.1.5.15.12 agrees: its
`STATUS_OBJECT_NAME_COLLISION` step is gated on `TargetExistsSameFile` being
FALSE, so a destination that is another link to the source bypasses the collision
failure regardless of `ReplaceIfExists`.

### One status does change, in the shape a real client produces

For a single open handle the status is unchanged — `Move` already returned
success. But a client that holds *both* links open hits something else: with a
self-link destination `dstMetaHandle` equals the renamer's own metadata handle,
so the open-handle gate that protects an overwrite victim
(`hasOpenHandleOnFile`, which excludes only the renamer's own `FileID`) sees the
sibling handle on the same inode and refused the whole rename:

```
pre-fix:  STATUS_ACCESS_DENIED
after:    STATUS_SUCCESS
```

That gate exists to stop a victim being unlinked under a live handle. This
rename unlinks nothing, so recognising the self-link before the gate runs is
what makes the refusal go away. `TestSetInfo_Rename_OntoOwnHardLinkWithSecondOpenHandle`
pins it, and fails with ACCESS_DENIED against the pre-fix build.

## Verification

`TestSetInfo_Rename_OntoOwnHardLink` drives `setFileInfoFromStore` end to end
over a memory-backed share with a real `NotifyRegistry` watcher, and asserts the
watcher stays silent, the handle keeps its name, and both links still resolve to
the same file.

It was run against a build broken in the specific way it guards — `set_info.go`
reverted to develop, everything else held — and fails there on both symptoms:

```
    set_info_rename_hardlink_test.go:76: watcher told a.txt was renamed away, but both links still resolve
    set_info_rename_hardlink_test.go:80: open handle renamed to "b.txt" by a rename that moved nothing
```

Two controls on the same fixture pin the other two directions, so the guard is
verified for both firing and refusing to fire:

- `TestSetInfo_Rename_DistinctDestination` — a rename to a name that is not
  already a link must still notify and still repoint the handle. It passes
  against both builds, which is what makes the failure above attributable to the
  guard rather than to a dead watcher.
- `TestSetInfo_Rename_OverwritesUnrelatedFile` — a `ReplaceIfExists` rename onto
  a destination that exists but is a *different* file must still overwrite it.
  Run against a guard deliberately widened to fire on any resolvable destination
  (`len(dstHandle) > 0` in place of the identity check), it fails on all four of
  its assertions while the two tests above stay green. Without this one the
  guard's *condition* is unpinned: a mutant that swallows every rename with an
  existing destination leaves the rest of the package green.
- `TestSetInfo_Rename_OntoItsOwnNameStillActs` — a rename onto the file's own
  name must still run the full rename path. This is the unit-level
  reproduction of the smbtorture failure above: it fails against the over-broad
  first cut and passes once the guard excludes the source's own entry.

`go test ./internal/adapter/smb/...` and `go test -race
./internal/adapter/smb/... ./pkg/metadata/...` are green.
