### PR TITLE
build(nix): make the flake usable day to day

### DIFF
--- a/docs/internals/contributing.md
+++ b/docs/internals/contributing.md
@@ -42,6 +42,19 @@ The Nix flake provides:
 - golangci-lint for code quality
 - NFS utilities for E2E testing (Linux)
 - ACL libraries for POSIX compliance testing
+- pjdfstest for POSIX compliance testing (Linux)
+- pynfs for NFSv4 protocol conformance, as `pynfs-4.0` and `pynfs-4.1`
+- `dfs-postgres-start` / `dfs-postgres-stop` for a PostgreSQL test container
+
+`nix flake check` builds both binaries and runs the conformance graders, which is
+what decides whether a suite run counts as green.
+
+The binaries also run straight from the flake, without a clone:
+
+```bash
+nix run github:marmos91/dittofs#dfs -- start
+nix run github:marmos91/dittofs#dfsctl -- --help
+```
 
 ### Manual Setup (Alternative)
 

--- a/flake.nix
+++ b/flake.nix
@@ -171,7 +171,6 @@
           };
 
         # Helper script to start PostgreSQL for testing
-        # Uses sudo for docker commands to avoid docker group requirement
         dfs-postgres-start = pkgs.writeShellScriptBin "dfs-postgres-start" ''
           container_name="dittofs-postgres-test"
 
@@ -181,26 +180,31 @@
             exit 1
           fi
 
-          # Check if docker daemon is running (using sudo)
-          if ! sudo docker info &>/dev/null; then
+          # Docker Desktop and a rootless daemon answer to the invoking user;
+          # a system daemon usually does not. Probe before reaching for sudo,
+          # so the script neither demands a password it does not need nor
+          # loses, to sudo's secure_path, the docker it just found.
+          DOCKER=(docker)
+          docker info &>/dev/null || DOCKER=(sudo "$(command -v docker)")
+          if ! "''${DOCKER[@]}" info &>/dev/null; then
             echo "Error: Cannot connect to Docker daemon."
-            echo "Make sure Docker daemon is running: sudo systemctl start docker"
+            echo "Start it first (Linux: sudo systemctl start docker)."
             exit 1
           fi
 
           # Check if container already exists
-          if sudo docker ps -a --format '{{.Names}}' | grep -q "^$container_name$"; then
+          if "''${DOCKER[@]}" ps -a --format '{{.Names}}' | grep -q "^$container_name$"; then
             # Check if it's running
-            if sudo docker ps --format '{{.Names}}' | grep -q "^$container_name$"; then
+            if "''${DOCKER[@]}" ps --format '{{.Names}}' | grep -q "^$container_name$"; then
               echo "PostgreSQL container already running"
               exit 0
             else
               echo "Starting existing PostgreSQL container..."
-              sudo docker start "$container_name"
+              "''${DOCKER[@]}" start "$container_name"
             fi
           else
             echo "Creating PostgreSQL container for DittoFS testing..."
-            sudo docker run -d \
+            "''${DOCKER[@]}" run -d \
               --name "$container_name" \
               -e POSTGRES_USER=dittofs \
               -e POSTGRES_PASSWORD=dittofs \
@@ -210,8 +214,8 @@
           fi
 
           echo "Waiting for PostgreSQL to be ready..."
-          for i in $(seq 1 30); do
-            if sudo docker exec "$container_name" pg_isready -U dittofs -d dittofs_test &>/dev/null; then
+          for _ in $(seq 1 30); do
+            if "''${DOCKER[@]}" exec "$container_name" pg_isready -U dittofs -d dittofs_test &>/dev/null; then
               echo "PostgreSQL is ready!"
               echo ""
               echo "Connection details:"
@@ -232,15 +236,17 @@
         '';
 
         # Helper script to stop PostgreSQL test container
-        # Uses sudo for docker commands to avoid docker group requirement
         dfs-postgres-stop = pkgs.writeShellScriptBin "dfs-postgres-stop" ''
           container_name="dittofs-postgres-test"
 
-          if sudo docker ps -a --format '{{.Names}}' | grep -q "^$container_name$"; then
+          DOCKER=(docker)
+          docker info &>/dev/null || DOCKER=(sudo "$(command -v docker)")
+
+          if "''${DOCKER[@]}" ps -a --format '{{.Names}}' | grep -q "^$container_name$"; then
             echo "Stopping PostgreSQL container..."
-            sudo docker stop "$container_name" 2>/dev/null || true
+            "''${DOCKER[@]}" stop "$container_name" 2>/dev/null || true
             echo "Removing PostgreSQL container..."
-            sudo docker rm "$container_name" 2>/dev/null || true
+            "''${DOCKER[@]}" rm "$container_name" 2>/dev/null || true
             echo "PostgreSQL container removed"
           else
             echo "PostgreSQL container not found"
@@ -249,7 +255,8 @@
           # Also clean up content store
           if [ -d "/tmp/dittofs-content-postgres" ]; then
             echo "Cleaning up content store..."
-            sudo rm -rf /tmp/dittofs-content-postgres
+            rm -rf /tmp/dittofs-content-postgres 2>/dev/null \
+              || sudo rm -rf /tmp/dittofs-content-postgres
           fi
 
           echo "Cleanup complete"

--- a/flake.nix
+++ b/flake.nix
@@ -166,6 +166,7 @@
               homepage = "https://linux-nfs.org/wiki/index.php/Pynfs";
               license = licenses.gpl2Only;
               platforms = platforms.unix;
+              mainProgram = "pynfs-4.1";
             };
           };
 
@@ -352,14 +353,25 @@
           xmlstarlet # TRX result parsing
           curl # health checks in bootstrap/local mode
 
-          # Benchmark load generator for the dfsbench harness (bench/, cmd/bench)
-          fio
+          # NFSv4 conformance suite. Pure Python speaking NFSv4 over TCP, so it
+          # needs no kernel mount and runs on every platform. Kept on PATH so
+          # run-pynfs.sh finds it instead of rebuilding it per invocation.
+          pynfs
+
+          # PostgreSQL test container helpers. They only drive the docker CLI,
+          # which exists on macOS too.
+          dfs-postgres-start
+          dfs-postgres-stop
         ];
 
         # Platform-specific inputs
         linuxInputs =
           with pkgs;
           lib.optionals stdenv.isLinux [
+            # Benchmark load generator for the dfsbench harness (bench/, cmd/bench).
+            # Its libnbd dependency is Linux-only, and evaluating it on macOS
+            # fails outright, taking the whole dev shell with it.
+            fio
             # NFS testing tools (Linux only)
             nfs-utils
             # ACL support for POSIX compliance testing
@@ -372,13 +384,12 @@
             pjdfstest
             # Docker client for PostgreSQL testing (daemon must be running on host)
             docker-client
-            # Helper scripts (work in any shell - bash, zsh, etc.)
+            # Helper scripts that need the Linux NFS client, /proc/mounts or
+            # pjdfstest. The docker-only helpers live in commonBuildInputs.
             dfs-mount
             dfs-umount
             dfs-posix
             dfs-e2e
-            dfs-postgres-start
-            dfs-postgres-stop
           ];
 
         darwinInputs =
@@ -388,18 +399,18 @@
             # For pjdfstest on macOS, use Docker: see test/posix/README.md
           ];
 
-      in
-      {
-        # Development shell
-        devShells.default = pkgs.mkShell {
+        # Go cache locations, shared by every shell.
+        goEnv = ''
+          # Ensure Go modules are cached in user's home directory
+          export GOPATH="$HOME/go"
+          export GOMODCACHE="$HOME/go/pkg/mod"
+          export GOCACHE="$HOME/.cache/go-build"
+        '';
+
+        devShell = pkgs.mkShell {
           buildInputs = commonBuildInputs ++ linuxInputs ++ darwinInputs;
 
-          shellHook = ''
-            # Ensure Go modules are cached in user's home directory
-            export GOPATH="$HOME/go"
-            export GOMODCACHE="$HOME/go/pkg/mod"
-            export GOCACHE="$HOME/.cache/go-build"
-
+          shellHook = goEnv + ''
             echo "╔═══════════════════════════════════════════╗"
             echo "║     DittoFS Development Environment       ║"
             echo "╚═══════════════════════════════════════════╝"
@@ -429,14 +440,17 @@
               echo "  dfs-posix chmod             Run chmod tests only"
               echo "  dfs-posix chown             Run chown tests only"
               echo ""
-              echo "PostgreSQL testing:"
-              echo "  dfs-postgres-start          Start PostgreSQL container"
-              echo "  dfs-postgres-stop           Stop and remove container"
-              echo ""
               echo "E2E testing (requires sudo for NFS mounts):"
               echo "  dfs-e2e                     Run all E2E tests"
               echo "  dfs-e2e -run TestName       Run specific test"
+              echo ""
             fi
+            echo "PostgreSQL testing:"
+            echo "  dfs-postgres-start          Start PostgreSQL container"
+            echo "  dfs-postgres-stop           Stop and remove container"
+            echo ""
+            echo "NFSv4 protocol conformance (no mount, no root):"
+            echo "  pynfs-4.0 / pynfs-4.1       pynfs test client"
             echo ""
 
             # Use zsh if available and not already in zsh
@@ -447,18 +461,13 @@
             fi
           '';
         };
+      in
+      {
+        devShells.default = devShell;
 
-        # CI shell (minimal, for running tests in CI)
-        devShells.ci = pkgs.mkShell {
-          buildInputs = commonBuildInputs ++ linuxInputs;
-
-          shellHook = ''
-            # Ensure Go modules are cached in user's home directory
-            export GOPATH="$HOME/go"
-            export GOMODCACHE="$HOME/go/pkg/mod"
-            export GOCACHE="$HOME/.cache/go-build"
-          '';
-        };
+        # Same toolchain as the development shell, without the banner and
+        # without exec-ing into zsh.
+        devShells.ci = devShell.overrideAttrs { shellHook = goEnv; };
 
         # Packages for building DittoFS
         packages =
@@ -531,6 +540,28 @@
             inherit pjdfstest;
           };
 
+        # `nix run .#dfs` / `nix run github:marmos91/dittofs#dfsctl`, so the
+        # binaries are reachable without cloning and building first.
+        apps =
+          let
+            # mkApp alone leaves out meta, which `nix flake check` warns about.
+            app =
+              drv: name: description:
+              flake-utils.lib.mkApp { inherit drv name; } // { meta.description = description; };
+          in
+          rec {
+            default = dfs;
+            dfs = app self.packages.${system}.dfs "dfs" "DittoFS server daemon";
+            dfsctl = app self.packages.${system}.dfsctl "dfsctl" "DittoFS REST client";
+
+            # pynfs ships one entrypoint per NFSv4 minor version; `nix run .#pynfs`
+            # resolves to the 4.1 one through the package's mainProgram. The
+            # attribute names use an underscore because nix splits an attribute
+            # path on dots.
+            pynfs-4_0 = app pynfs "pynfs-4.0" "pynfs NFSv4.0 conformance client";
+            pynfs-4_1 = app pynfs "pynfs-4.1" "pynfs NFSv4.1 conformance client";
+          };
+
         # Flake checks - run with `nix flake check`
         checks = {
           # Verify the default package builds and contains both binaries
@@ -554,6 +585,33 @@
           dfsctl-binary = pkgs.runCommand "check-dfsctl-binary" { } ''
             ${self.packages.${system}.dfsctl}/bin/dfsctl version > /dev/null 2>&1 || \
             ${self.packages.${system}.dfsctl}/bin/dfsctl --help > /dev/null 2>&1
+            touch $out
+          '';
+
+          # The conformance graders decide whether a suite run counts as green.
+          # They run against synthetic output in about a second each, with no
+          # server and no network, so they belong in the pre-push check.
+          conformance-graders = pkgs.runCommand "check-conformance-graders" { } ''
+            mkdir -p test/smb-conformance test/nfs-conformance
+            cp -r ${./test/common} test/common
+            cp -r ${./test/smb-conformance/smbtorture} test/smb-conformance/smbtorture
+            cp -r ${./test/nfs-conformance/pynfs} test/nfs-conformance/pynfs
+            chmod -R u+w test
+
+            status=0
+            for suite in test/smb-conformance/smbtorture test/nfs-conformance/pynfs; do
+              echo "== $suite/parse-results_test.sh"
+              report="$(bash "$suite/parse-results_test.sh" 2>&1)" || status=1
+              printf '%s\n' "$report"
+              # A suite that matched no cases exits 0 having asserted nothing,
+              # which reads exactly like a pass.
+              if ! printf '%s\n' "$report" | grep -q '^ok:'; then
+                echo "$suite asserted nothing" >&2
+                status=1
+              fi
+            done
+
+            [ "$status" -eq 0 ]
             touch $out
           '';
         };


### PR DESCRIPTION
Closes #2323.

Six findings from the flake audit. Five produced a change; one legitimately found nothing.

## 1. No `apps` output

`nix run .#dfs` / `.#dfsctl` / `.#pynfs` had nothing to resolve to, so anyone
without a built checkout had to `nix build` and reach into `./result/bin`.

Adds `apps.{default,dfs,dfsctl,pynfs-4_0,pynfs-4_1}`. The pynfs attributes use an
underscore because `nix run` splits an attribute path on dots — `nix run .#pynfs-4.0`
is parsed as `pynfs-4` → `0` and fails with "does not provide attribute". A bare
`nix run .#pynfs` resolves through the new `meta.mainProgram = "pynfs-4.1"` on the
package, since pynfs ships one entrypoint per minor version and neither is "the" binary.

`apps.default` and `packages.default` both land on `dfs`, so the documented
`nix run github:marmos91/dittofs -- init` keeps working unchanged.

## 2. Helper scripts split by convenience rather than by need

`dfs-postgres-start` / `dfs-postgres-stop` only shell out to the docker CLI, which
exists on macOS, but they sat in `linuxInputs`. They move to `commonBuildInputs`.
`dfs-mount`, `dfs-umount`, `dfs-posix` and `dfs-e2e` stay Linux-only — they need the
Linux NFS client, `/proc/mounts` or pjdfstest.

**The macOS dev shell did not evaluate at all**, before this change and independently
of it: `fio` in `commonBuildInputs` pulls `libnbd`, whose `meta.platforms` is
Linux-only, so `nix develop` on aarch64-darwin failed with "not available on the
requested hostPlatform". Verified on unmodified `develop`:

```
$ nix eval --raw .#devShells.aarch64-darwin.default.drvPath
error: Package 'libnbd-1.22.5' ... is not available on the requested hostPlatform:
  hostPlatform.system = "aarch64-darwin"
```

`fio` moves to `linuxInputs`; the darwin shell now evaluates. Nothing on macOS
invoked `fio` — it could not have, the shell would not open.

The shell banner is reworked so the PostgreSQL and pynfs sections print on both
platforms instead of only in the Linux branch.

## 3. pynfs not on the dev-shell PATH

`run-pynfs.sh` shelled out to `nix build --no-link` per invocation; with no GC root,
a `nix store gc` between runs turned a two-second startup into a full rebuild that
looks like a hang. `pynfs` joins `commonBuildInputs`. It is cross-platform on purpose:
it speaks NFSv4 over TCP itself, so it needs no kernel mount and no privileges.

## 4. `stdenvNoCC` audit — nothing to change

The only `stdenv.mkDerivation` left is `pjdfstest`, which genuinely runs
`autoreconf`/`configure`/`make` and needs a compiler. `pynfs` is already
`stdenvNoCC`. Everything else in the file is `writeShellScriptBin` or `runCommand`,
both of which are `stdenvNoCC`-backed in nixpkgs already. No change.

## 5. The conformance graders are not covered by `nix flake check`

`test/smb-conformance/smbtorture/parse-results_test.sh` and
`test/nfs-conformance/pynfs/parse-results_test.sh` decide whether a conformance run
grades green, need no server or network, and run in about a second each. They now run
as `checks.conformance-graders`.

The check does not just take exit 0 for an answer. A test script that matched no cases
exits 0 having asserted nothing, which reads exactly like a pass, so the check also
requires each script to emit at least one `ok:` line. Both guards were verified against
deliberately broken inputs rather than assumed:

- grader stubbed to `exit 0` unconditionally → 32 of 43 smbtorture assertions fail, build red.
- test script replaced by one that prints `PASS:` and exits 0 without asserting →
  `test/nfs-conformance/pynfs asserted nothing`, build red.

Green on the real tree: 43 smbtorture assertions, 28 pynfs assertions.

## 6. `devShells.ci` duplicated `devShells.default`

Now `devShell.overrideAttrs { shellHook = goEnv; }` — same `buildInputs`, without the
banner and without exec-ing into zsh. `darwinInputs` is an always-empty list, so the
`ci` shell's package set is unchanged on every platform.

## Verification

- `nix flake check` green on aarch64-darwin (builds both binaries and both graders).
- `devShells.x86_64-linux.{ci,default}`, `packages.x86_64-linux.pjdfstest`,
  `checks.x86_64-linux.conformance-graders` and every app all evaluate.
- `nix run .#pynfs -- --help`, `.#pynfs-4_0 -- --help` and `.#dfsctl -- --help` all run.
- `version` and `vendorHash` untouched.
