### PR TITLE
fix(journal): fail a restore whose shard can never be made durable

### DIFF
--- a/pkg/block/journal/restore_test.go
+++ b/pkg/block/journal/restore_test.go
@@ -3,6 +3,7 @@ package journal
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -361,5 +362,55 @@ func TestRestoreToVersion_KeepsEvictedRange(t *testing.T) {
 	assertColdAt(t, r, evicted, 0, chunk256, "post-reopen")
 	if got := readAll(t, r, peer, len(v1)); !bytes.Equal(got, v1) {
 		t.Fatalf("post-reopen %s: restore did not produce the V1 view", peer)
+	}
+}
+
+// TestRestoreToVersion_RefusesAShardWhoseFsyncHasPermanentlyFailed pins the one
+// case the closing barrier cannot see.
+//
+// syncFailed is sticky and freezes the shard's durable watermark, so dirty()
+// reports the shard clean forever and commitDirtyShards skips it — contributing
+// no error, and leaving the sweep to return nil for records that will never
+// reach the device. The restore then reports a durable V-view it does not have.
+//
+// The injected failure is transient on purpose: the device "recovers", so every
+// fsync the restore itself issues succeeds and nothing on that path can report
+// the problem. That is also the real shape of it — under Linux fsync-error
+// semantics the kernel drops the failed pages and the next fsync returns
+// success for bytes that never landed, which is why the flag is sticky.
+func TestRestoreToVersion_RefusesAShardWhoseFsyncHasPermanentlyFailed(t *testing.T) {
+	ctx := context.Background()
+	s := testStore(t, Config{ShardCount: 1, DirtyExpiry: -1, GCDeadRatioForce: 2})
+	sh := s.shards[0]
+
+	v1 := randBytes(4096, 23)
+	if err := s.WriteAt(ctx, "f", 0, v1); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if err := sh.groupCommit(); err != nil {
+		t.Fatalf("groupCommit: %v", err)
+	}
+	v := s.JournalVersion()
+
+	// Something for the restore to undo, so it is a real pass and not a no-op.
+	if err := s.WriteAt(ctx, "f", 0, bytes.Repeat([]byte{0xEE}, 4096)); err != nil {
+		t.Fatalf("WriteAt(post-V): %v", err)
+	}
+
+	inner := sh.segSync
+	sh.segSync = func(*segmentMeta) error { return errors.New("device gone") }
+	if err := sh.groupCommit(); err == nil {
+		t.Fatal("groupCommit: want the injected fsync failure")
+	}
+	sh.segSync = inner
+	if !sh.syncFailed.Load() {
+		t.Fatal("syncFailed not set: the injected failure did not take")
+	}
+	if sh.dirty() {
+		t.Fatal("shard reports dirty: the barrier would have covered it and this test proves nothing")
+	}
+
+	if err := s.RestoreToVersion(ctx, v); err == nil {
+		t.Fatal("RestoreToVersion reported success for a shard whose fsync has permanently failed")
 	}
 }

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -1341,6 +1341,23 @@ func (s *Store) RestoreToVersion(ctx context.Context, v uint64) error {
 	if err := s.commitDirtyShards(); err != nil {
 		return fmt.Errorf("journal: restore: commit re-materialized view: %w", err)
 	}
+	// The barrier skips a shard whose fsync has permanently failed, deliberately:
+	// syncFailed freezes the durable watermark, so a dirty-driven sweep would
+	// re-fsync every record on every pass forever. Right for syncLoop, which has
+	// no caller to report to; wrong here, because the skip contributes no error
+	// and the barrier returns nil for records that will never reach the device.
+	// The burials above fsynced themselves and may have landed before the failure
+	// while their replacements did not — the burial-without-replacement state the
+	// barrier exists to prevent, reported as a completed restore.
+	//
+	// Every shard, not only the ones this pass wrote: a restore replays all of
+	// them and tombstones every file at the head, and only a shard that has
+	// appended records can have failed an fsync in the first place.
+	for i, sh := range s.shards {
+		if sh.syncFailed.Load() {
+			return fmt.Errorf("journal: restore: shard %d holds records no fsync can make durable: an earlier fsync failed permanently", i)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Closes #2254.

`RestoreToVersion` ends with a `commitDirtyShards` barrier (#2229 / #2248). That sweep is dirty-driven, and `shard.dirty()` reports `false` for a shard whose `syncFailed` flag is set — so the shard is skipped, contributes no error, and the barrier returns `nil`. The restore then reports a durable V-view for records that will never reach the device, with its own tombstones possibly durable and their replacements not: the burial-without-replacement state the barrier exists to prevent.

## The fix

The check goes at the reporting boundary, not in `dirty()`. Treating `syncFailed` as not-dirty is deliberate and `syncLoop` depends on it — `syncFailed` freezes `syncedVersion` for good, so a dirty-driven sweep that kept retrying would re-fsync every record on every pass forever. `RestoreToVersion` sweeps the shards after its barrier and fails instead.

All shards, not only the ones the pass wrote: a restore replays every shard and tombstones every file at the head, and only a shard that has appended records can have failed an fsync at all, so the wider sweep has no reachable false positive.

The caller (`runtime/snapshot.go:1539`) already wraps the error as `ErrRestoreAborted` alongside its safety snapshot, so no caller change is needed.

## The test

`TestRestoreToVersion_RefusesAShardWhoseFsyncHasPermanentlyFailed` — **fails on unmodified develop** (verified by reverting `store.go` in place and re-running: `--- FAIL ... RestoreToVersion reported success for a shard whose fsync has permanently failed`), passes with the fix.

The injected fsync failure is transient on purpose. If fsync stayed broken, every fsync the restore itself issues would fail and some other path would report the problem — the test would pass against develop too and prove nothing. Letting the device "recover" is both the discriminating setup and the real shape of it: under Linux fsync-error semantics the kernel drops the failed pages and the next fsync returns success for bytes that never landed, which is exactly why the flag is sticky. The test also asserts `!sh.dirty()` before the restore, so it fails loudly if a future change makes the barrier cover the shard and quietly removes what is being pinned.

## Not addressed

The issue notes a second, related gap: `sealInPlace` fsyncs via `m.fd.Sync()` directly rather than through the per-shard `segSync` seam, so no test can pin rotation durability. That is a separate testability change and is left alone here.

`go test ./pkg/block/...` green; `golangci-lint` 0 issues.