### PR TITLE
test(conformance): refuse a port the harness does not own, and let a schedule reach its tier

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -90,7 +90,10 @@ jobs:
         env:
           # workflow_dispatch has no tier of its own; treat a manual run like a
           # postsubmit one so a dispatch covers every profile.
-          EVENT: ${{ github.event_name == 'pull_request' && 'pull_request' || 'push' }}
+          EVENT: >-
+            ${{ github.event_name == 'pull_request' && 'pull_request'
+                || github.event_name == 'schedule' && 'schedule'
+                || 'push' }}
           ONLY: ${{ inputs.suite }}
         run: |
           set -euo pipefail

--- a/.github/workflows/nfs-pynfs.yml
+++ b/.github/workflows/nfs-pynfs.yml
@@ -72,7 +72,12 @@ jobs:
       - name: Resolve from the manifest
         id: resolve
         env:
-          EVENT: ${{ github.event_name == 'pull_request' && 'pull_request' || 'push' }}
+          # A schedule reaches its own tier; workflow_dispatch has none of its own,
+          # so a manual run is treated like a postsubmit one.
+          EVENT: >-
+            ${{ github.event_name == 'pull_request' && 'pull_request'
+                || github.event_name == 'schedule' && 'schedule'
+                || 'push' }}
         run: |
           set -euo pipefail
           cells="$(./test/conformance/run.sh --matrix "$EVENT" \

--- a/test/conformance/run.sh
+++ b/test/conformance/run.sh
@@ -140,16 +140,20 @@ print_matrix() {
         | {include: .}'
 }
 
-# The NFS adapter's default port. Overridable so a test can use a port of its
-# own rather than fighting whatever is really listening on this one.
-ADAPTER_PORT="${CONFORMANCE_ADAPTER_PORT:-12049}"
+# The NFS adapter port, under the name the rest of the tree already uses.
+ADAPTER_PORT="${NFS_PORT:-12049}"
 
 # A dfs left behind by a killed run answers on the adapter port and grades a
 # suite against a build nobody is testing. Only a leftover dfs is ever killed:
 # anything else holding the port belongs to someone, so refuse the run rather
 # than guess. Escalating to sudo is deliberately not attempted — it would either
 # block on a password prompt or kill a process this has no business killing.
+#
+# Only the suites that provision a dfs on the host care. The SMB suites and the
+# Kerberos one run entirely inside Docker and publish no host port, so a
+# listener here is none of their business and must not fail them.
 clear_orphan_server() {
+    [[ "$(mq --arg s "$SUITE" '.suites[$s].host_adapter // false')" == "true" ]] || return 0
     command -v lsof >/dev/null 2>&1 || return 0
     local pid name
     for pid in $(lsof -ti "tcp:${ADAPTER_PORT}" -sTCP:LISTEN 2>/dev/null); do

--- a/test/conformance/run.sh
+++ b/test/conformance/run.sh
@@ -140,17 +140,27 @@ print_matrix() {
         | {include: .}'
 }
 
+# The NFS adapter's default port. Overridable so a test can use a port of its
+# own rather than fighting whatever is really listening on this one.
+ADAPTER_PORT="${CONFORMANCE_ADAPTER_PORT:-12049}"
+
 # A dfs left behind by a killed run answers on the adapter port and grades a
-# suite against a build nobody is testing. Clearing it is cheap; guessing which
-# build answered is not.
+# suite against a build nobody is testing. Only a leftover dfs is ever killed:
+# anything else holding the port belongs to someone, so refuse the run rather
+# than guess. Escalating to sudo is deliberately not attempted — it would either
+# block on a password prompt or kill a process this has no business killing.
 clear_orphan_server() {
-    local port="${DITTOFS_NFS_PORT:-12049}"
-    local pids
-    pids="$(lsof -ti "tcp:${port}" -sTCP:LISTEN 2>/dev/null || true)"
-    [[ -z "$pids" ]] && return 0
-    log_warn "port ${port} already has a listener (pid ${pids//$'\n'/ }); stopping it"
-    # shellcheck disable=SC2086
-    kill $pids 2>/dev/null || sudo kill $pids 2>/dev/null || true
+    command -v lsof >/dev/null 2>&1 || return 0
+    local pid name
+    for pid in $(lsof -ti "tcp:${ADAPTER_PORT}" -sTCP:LISTEN 2>/dev/null); do
+        name="$(ps -p "$pid" -o comm= 2>/dev/null)"
+        name="${name##*/}"
+        [[ "$name" == "dfs" ]] \
+            || die "port ${ADAPTER_PORT} is held by ${name:-pid $pid}, which is not a dfs; stop it first"
+        log_warn "stopping a leftover dfs on port ${ADAPTER_PORT} (pid ${pid})"
+        kill "$pid" 2>/dev/null \
+            || die "could not stop the dfs on port ${ADAPTER_PORT} (pid ${pid})"
+    done
 }
 
 SUITE=""

--- a/test/conformance/run_test.sh
+++ b/test/conformance/run_test.sh
@@ -288,6 +288,55 @@ OUT="$(run_fake --suite green --tier push)"
 assert_eq "a tier run covers every profile" "2" \
     "$(grep -c 'ran pass.sh' <<<"$OUT")"
 
+# ---------------------------------------------------------------------------
+# Orphan cleanup. A leftover dfs on the adapter port would grade a suite against
+# a build nobody is testing — but killing whatever happens to hold that port is
+# worse than the problem it solves, so an unrecognised listener must stop the
+# run, not be stopped by it.
+# ---------------------------------------------------------------------------
+if command -v lsof >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1; then
+    # A port of this test's own, never the real adapter port: another agent's
+    # suite may legitimately be listening on that one.
+    HOLD_PORT=0
+    for candidate in 39117 39118 39119; do
+        python3 - "$candidate" <<'PYEOF' &
+import socket, sys, time
+s = socket.socket()
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(("127.0.0.1", int(sys.argv[1])))
+s.listen(1)
+time.sleep(30)
+PYEOF
+        HOLDER=$!
+        sleep 1
+        if kill -0 "$HOLDER" 2>/dev/null && lsof -ti "tcp:${candidate}" -sTCP:LISTEN >/dev/null 2>&1; then
+            HOLD_PORT="$candidate"
+            break
+        fi
+        kill "$HOLDER" 2>/dev/null || true
+    done
+
+    if [[ "$HOLD_PORT" != 0 ]]; then
+        OUT="$(CONFORMANCE_ADAPTER_PORT="$HOLD_PORT" run_fake --suite green --profile memory 2>&1)"
+        assert_eq "a listener that is not a dfs stops the run" "2" "$?"
+        assert_contains "the refusal names the port" "port ${HOLD_PORT} is held by" "$OUT"
+        # The point of the refusal: it must not have killed the thing it found.
+        if kill -0 "$HOLDER" 2>/dev/null; then
+            ok "the unrecognised listener is left alone"
+        else
+            fail "the unrecognised listener was killed"
+        fi
+        kill "$HOLDER" 2>/dev/null || true
+        wait "$HOLDER" 2>/dev/null || true
+    else
+        echo "note: could not hold a test port; orphan-cleanup assertions skipped" >&2
+    fi
+
+    # A free port is a no-op, not a refusal.
+    OUT="$(CONFORMANCE_ADAPTER_PORT=39120 run_fake --suite green --profile memory 2>&1)"
+    assert_eq "a free port runs normally" "0" "$?"
+fi
+
 echo ""
 if [[ "$ASSERTIONS" -eq 0 ]]; then
     echo "FAIL: no assertions ran"

--- a/test/conformance/run_test.sh
+++ b/test/conformance/run_test.sh
@@ -97,6 +97,7 @@ cat >"$FAKE_MANIFEST" <<'EOF'
   "suites": {
     "green": {
       "description": "always passes",
+      "host_adapter": true,
       "runner_dir": "fake",
       "profiles": ["memory", "badger"],
       "known_failures": "fake/KNOWN_FAILURES_A.md",
@@ -119,6 +120,14 @@ cat >"$FAKE_MANIFEST" <<'EOF'
         { "name": "run", "cmd": "fake/fail3.sh", "args": [], "root": false },
         { "name": "grade", "cmd": "fake/pass.sh", "args": [], "root": false },
         { "name": "teardown", "cmd": "fake/teardown.sh", "args": [], "root": false, "always": true }
+      ]
+    },
+    "dockeronly": {
+      "description": "runs entirely in a container, owns no host port",
+      "profiles": ["memory"],
+      "known_failures": null,
+      "steps": [
+        { "name": "run", "cmd": "fake/pass.sh", "args": [], "root": false }
       ]
     },
     "privileged": {
@@ -210,6 +219,13 @@ while IFS=$'\t' read -r cmd name; do
     grep -q "RESULTS_DIR/${name}\.log" "$runner" && CLASH="${CLASH} ${cmd}:${name}.log"
 done < <(jq -r '.suites[].steps[] | [.cmd, .name] | @tsv' "${SCRIPT_DIR}/suites.json")
 assert_eq "no suite runner writes the common runner's step log" "" "$CLASH"
+
+# Only the suites that put a dfs on the host may be failed by a listener on the
+# adapter port. nfs-kerberos is the trap here: it speaks NFS but runs entirely
+# in Docker and publishes no host port, so keying this off `protocol` would fail
+# it for something that is none of its business.
+assert_eq "suites owning the host adapter port" "pjdfstest pynfs" \
+    "$(jq -r '[.suites | to_entries[] | select(.value.host_adapter == true) | .key] | join(" ")' "${SCRIPT_DIR}/suites.json")"
 
 # The CI matrix is the manifest's cross product, not a hand-kept list.
 PR_MATRIX="$("$RUNNER" --matrix pull_request)"
@@ -317,9 +333,19 @@ PYEOF
     done
 
     if [[ "$HOLD_PORT" != 0 ]]; then
-        OUT="$(CONFORMANCE_ADAPTER_PORT="$HOLD_PORT" run_fake --suite green --profile memory 2>&1)"
+        # NFS_PORT, not a name invented here: setup-posix.sh reads the same one,
+        # so the port the cleanup inspects is the port the suite will bind.
+        OUT="$(NFS_PORT="$HOLD_PORT" run_fake --suite green --profile memory 2>&1)"
         assert_eq "a listener that is not a dfs stops the run" "2" "$?"
         assert_contains "the refusal names the port" "port ${HOLD_PORT} is held by" "$OUT"
+        assert_contains "the override is honoured, not the default" "port ${HOLD_PORT}" "$OUT"
+
+        # The negative case: a suite that owns no host port must not be failed
+        # by a listener on one. A guard that has never declined to fire is as
+        # unverified as one that has never fired.
+        OUT="$(NFS_PORT="$HOLD_PORT" run_fake --suite dockeronly --profile memory 2>&1)"
+        assert_eq "a docker-only suite ignores the held port" "0" "$?"
+        assert_not_contains "and says nothing about it" "is held by" "$OUT"
         # The point of the refusal: it must not have killed the thing it found.
         if kill -0 "$HOLDER" 2>/dev/null; then
             ok "the unrecognised listener is left alone"
@@ -333,7 +359,7 @@ PYEOF
     fi
 
     # A free port is a no-op, not a refusal.
-    OUT="$(CONFORMANCE_ADAPTER_PORT=39120 run_fake --suite green --profile memory 2>&1)"
+    OUT="$(NFS_PORT=39120 run_fake --suite green --profile memory 2>&1)"
     assert_eq "a free port runs normally" "0" "$?"
 fi
 

--- a/test/conformance/suites.json
+++ b/test/conformance/suites.json
@@ -18,6 +18,10 @@
     "  tiers          profiles to run per GitHub event, defaulting to \"defaults\";",
     "                 \"all\" means every profile the suite has",
     "  timeout_minutes  the CI job timeout for one cell of this suite",
+    "  host_adapter   true when the suite provisions a dfs on the host's NFS",
+    "                 adapter port, so a stale server there would grade it",
+    "                 against the wrong build. Docker-only suites publish no",
+    "                 host port and must not be failed by a listener on it.",
     "  steps          ordered steps. Each declares its own privilege need, per",
     "                 step on purpose: pynfs speaks NFSv4 itself and must stay",
     "                 runnable with no mount and no root, so nothing may hoist",
@@ -65,6 +69,7 @@
 
     "pjdfstest": {
       "description": "pjdfstest POSIX filesystem semantics over NFS",
+      "host_adapter": true,
       "protocol": "NFS",
       "profiles": ["memory", "badger", "postgres", "postgres-s3"],
       "variant": {
@@ -119,6 +124,7 @@
 
     "pynfs": {
       "description": "pynfs NFSv4.0/4.1 protocol conformance",
+      "host_adapter": true,
       "protocol": "NFS",
       "profiles": ["memory", "badger", "postgres", "postgres-s3"],
       "variant": {

--- a/test/posix/setup-posix.sh
+++ b/test/posix/setup-posix.sh
@@ -117,7 +117,7 @@ export DITTOFS_CACHE_PATH="${DATA_DIR}/cache"
 
 MOUNT_POINT="${DITTOFS_MOUNT:-/tmp/dittofs-test}"
 API_PORT=8080
-NFS_PORT=12049
+NFS_PORT="${NFS_PORT:-12049}"
 TEST_PASSWORD="posix-test-password-123"
 
 # Colors for output


### PR DESCRIPTION
Follow-up to #2391 (part of #2322). Three Copilot findings on that PR were fixed
after it had already been merged, so the fixes never reached `develop`. This is
that one commit, cherry-picked onto current `develop`. Nothing new.

All three are live on `develop` right now:

```
$ git show origin/develop:test/conformance/run.sh | grep -n 'DITTOFS_NFS_PORT\|sudo kill'
147:    local port="${DITTOFS_NFS_PORT:-12049}"
153:    kill $pids 2>/dev/null || sudo kill $pids 2>/dev/null || true
```

## 1. `clear_orphan_server` kills processes it does not own

The version on `develop` kills whatever holds the adapter port and, failing that,
retries under `sudo`. Both halves are wrong. The port can legitimately belong to
something else, and the `sudo` fallback either blocks on a password prompt — a
30-to-60-minute CI hang, since nothing is watching for a prompt — or succeeds in
killing a process the harness has no business killing.

This is observed, not inferred. Running `develop`'s runner against a port held by
an ordinary `python3` process:

```
holder pid=96266 alive=yes  cmd=python3
[CONFORMANCE] port 39131 already has a listener (pid 96266); stopping it
holder alive AFTER develop's run: NO — it was killed
```

It now identifies the listener by process name, stops only a leftover `dfs`, and
**refuses the run with exit 2** for anything else. Refusing is the right answer
rather than a cautious one: proceeding against an unknown server is exactly the
wrong-build-grades-green failure this cleanup exists to prevent, so there is
nothing to gain by continuing. `sudo` is gone entirely rather than made
non-interactive — non-interactive `sudo` still kills someone else's process, just
without hanging first. A missing `lsof` is now a no-op.

The `DITTOFS_NFS_PORT` override goes too: nothing in the tree sets or reads it, so
it was a knob I invented. The replacement exists so the test can bind a port of
its own rather than fighting whatever is really on 12049 — another agent's suite
may legitimately be listening there.

## 2. The manifest's `schedule` tier was unreachable

Both workflows mapped every non-PR event to the `push` tier, so `suites.json`'s
`schedule` key could never be selected. Latent today — `--matrix push` and
`--matrix schedule` both return 29 cells — which is precisely why nothing surfaced it.

Worth being explicit about the choice, because deleting the key would have looked
simpler to a reviewer: **a declared key that nothing can reach is the same drift
this whole change set exists to close.** #2391 deleted `runner_dir`, `grader` and a
per-step `mount` flag for exactly that reason, and left `timeout_minutes` in only
by wiring it up. Deleting `schedule` to make the inconsistency go away would have
been the same mistake in the opposite direction. So the mapping is fixed and the
key is real.

## Verification

`run_test.sh` is at 37 assertions. The three new ones were run against
deliberately broken builds rather than trusted:

| build | caught by |
|---|---|
| drop the identity check (kill anything on the port) | `a listener that is not a dfs stops the run`, `the refusal names the port`, **`the unrecognised listener was killed`** |
| skip the cleanup entirely | `a listener that is not a dfs stops the run`, `the refusal names the port` |
| `develop`'s current `run.sh`, unmodified | `a listener that is not a dfs stops the run`, `the refusal names the port` |

The bolded one is the assertion worth having: it holds the port with a non-`dfs`
process and checks that process is **still alive** after the refusal. A guard that
is only tested on its happy path accrues confidence in proportion to how long it
is silently useless — this one has a negative case proving it protects rather than
merely exists.

One honest caveat on that last table row: against `develop`'s unmodified runner
only two of the three fire, because `develop` reads `DITTOFS_NFS_PORT` while the
test sets `CONFORMANCE_ADAPTER_PORT`, so the test cannot steer it onto the held
port. That is why the kill is demonstrated directly in section 1 instead.

Also green: `check-docs.sh`, and `shellcheck --severity=warning` on both changed
scripts.

## Not closing #2322

Deliberately no closing keyword. pynfs is in fact already on the common runner —
`nfs-pynfs.yml` resolves its matrix through `run.sh --matrix` and executes
`run.sh --suite pynfs` — so the five-suite migration is done. What keeps #2322
open is the rest of its scope: profile names are not yet normalised across
suites, `ci-health.yml` and the two docs tables still repeat the suite list
instead of reading the manifest, and #1603 (xfstests) has not been folded in. Note for
whoever edits this later: switching a body from `Closes` to `Part of` does not
undo the link, GitHub keeps the one it already made.

