### PR TITLE
docs: correct the default-branch claims that changing the default falsified

### DIFF
--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -291,10 +291,13 @@ git push -u origin fix/<issue>-<slug>
 gh pr create --base develop --assignee marmos91 --title "..." --body "..."
 ```
 
-The PR body must contain a closing keyword (`Closes #<N>`). GitHub's auto-close
-never fires for us — it only triggers on the default branch, and we merge to
-`develop` — so `.github/workflows/close-linked-issues.yml` greps PR bodies
-instead, at release time. The keyword is what makes that work.
+The PR body must contain a closing keyword (`Closes #<N>`). `develop` is the
+default branch, so GitHub's native auto-close fires on merge and the issue closes
+itself — do not also close it by hand. `gh issue close --comment` on an
+already-closed issue exits 0 and silently discards the comment, so verification
+notes posted that way are lost; use `gh issue comment` for those.
+`.github/workflows/close-linked-issues.yml` still runs at release time as a
+safety net for keywords that appear in a commit message but not a PR body.
 
 Write the body for a reviewer who has not read the issue: what was actually
 wrong, why the obvious fix is wrong if it is, and what evidence you have. If you

--- a/.claude/skills/solve-issues/SKILL.md
+++ b/.claude/skills/solve-issues/SKILL.md
@@ -184,7 +184,9 @@ work rather than the reverse. For each PR in turn:
 ```bash
 gh pr checks <PR>                                  # still green on the current base?
 gh pr merge <PR> --squash --delete-branch
-gh issue close <N> --comment "Fixed in #<PR>."     # manual — auto-close only fires on main
+# The issue auto-closes: develop is the default branch. To add verification
+# notes use `gh issue comment` — `gh issue close --comment` on an already-closed
+# issue exits 0 and drops the comment.
 ```
 
 Then, before the next one:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,11 +2,14 @@
 # this file GitHub still reports vulnerabilities but never opens a PR for them,
 # so they accumulate until someone bumps by hand.
 #
-# Every ecosystem sets target-branch: develop. Unset, Dependabot opens against
-# the repository default branch, which is main — and main only ever fast-forwards
-# from develop, so a bump merged there directly would put a commit on main that
-# is not in develop and break the strict-ancestor invariant the release flow
-# depends on. It also left the PRs blocked behind main's protection rules.
+# Every ecosystem sets target-branch: develop. That is now the default branch
+# too, so the setting is redundant — but it is kept because it is the only thing
+# in this file that survives the default moving again. Dependabot reads this
+# config from the DEFAULT branch, not from the PR base, so while main was the
+# default and carried a copy without target-branch, the setting on develop was
+# never consulted and every bump opened against main regardless. Bumps landing
+# on main directly would put commits there that develop does not have, breaking
+# the strict-ancestor invariant the release flow depends on.
 version: 2
 updates:
   - package-ecosystem: gomod

--- a/.github/workflows/close-linked-issues.yml
+++ b/.github/workflows/close-linked-issues.yml
@@ -16,8 +16,9 @@ name: Close linked issues on main
 #   1. Closing keywords ("Fixes #N") written directly in a commit message.
 #   2. The squash-merge convention `subject (#<issue>) (#<pr>)`: we take every
 #      "#N" in the commits, treat it as a PR, and grep that PR's DESCRIPTION
-#      for closing keywords. (We must grep the body ourselves —
-#      closingIssuesReferences is empty for develop-targeted PRs.)
+#      for closing keywords. (We grep the body rather than read
+#      closingIssuesReferences because this scans an arbitrary commit range on
+#      main, where the reference is attached to the PR and not to the commits.)
 #
 # All PR bodies are fetched in batched GraphQL calls (one request per ~50 PRs)
 # to avoid the secondary rate limit a per-PR REST loop would hit.

--- a/.github/workflows/close-linked-issues.yml
+++ b/.github/workflows/close-linked-issues.yml
@@ -2,12 +2,17 @@ name: Close linked issues on main
 
 # Closes issues linked to work that reaches main.
 #
-# Background: GitHub's built-in auto-close only fires when a PR merges into the
-# DEFAULT branch, and it only records closingIssuesReferences for PRs that
-# TARGET the default branch. We merge PRs into `develop` and only fast-forward
-# `main` at release time, so neither mechanism ever fires — issues linger open.
+# Background: GitHub's built-in auto-close fires when a PR merges into the
+# DEFAULT branch. `develop` is now the default, so a PR body carrying `Closes #N`
+# closes its issue on merge and this workflow finds it already closed and skips
+# it. That is the normal outcome; the value here is the remaining gap.
 #
-# This workflow closes them when the work lands on main, via two paths:
+# The gap is a closing keyword that appears in a COMMIT message but never in a
+# PR body — native auto-close reads only the PR body and its linked references,
+# so nothing else catches that case. This also still covers the window before
+# `develop` became the default, when neither mechanism fired for us at all.
+#
+# It closes issues when the work lands on main, via two paths:
 #   1. Closing keywords ("Fixes #N") written directly in a commit message.
 #   2. The squash-merge convention `subject (#<issue>) (#<pr>)`: we take every
 #      "#N" in the commits, treat it as a PR, and grep that PR's DESCRIPTION

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -502,8 +502,8 @@ jobs:
     # Nightly only. Regenerates baseline-results.md from a clean develop
     # memory-profile run so the documentation snapshot cannot drift. NOT a CI
     # gate — grading is done against KNOWN_FAILURES.md by parse-results.sh.
-    # Operates on develop explicitly because scheduled runs fire on the default
-    # branch (main), not develop.
+    # Checks out develop explicitly rather than relying on scheduled runs firing
+    # on the default branch, so this keeps working if the default moves.
     if: github.event_name == 'schedule'
     permissions:
       contents: write


### PR DESCRIPTION
Changing the repository default branch to `develop` (PR #2289's intent, finally
effective) fixed Dependabot, and silently falsified five comments that were true
when they were written. Comment-only; no behaviour changes.

The two that cost real work:

- `.claude/skills/fix-issue/SKILL.md` and `.claude/skills/solve-issues/SKILL.md`
  both said auto-close never fires for us and instructed closing issues by hand
  with `gh issue close --comment "..."`. Auto-close now fires on merge to
  `develop`, so by the time that command runs the issue is already closed — and
  **`gh issue close --comment` on an already-closed issue exits 0 and discards
  the comment.** Observed, not inferred: it swallowed the verification notes for
  #2372 earlier today, and nothing reported a failure. Both files now say the
  issue closes itself and that `gh issue comment` is the way to add notes.

The three that were merely wrong:

- `.github/dependabot.yml` said the default branch is main. It also stated the
  reason for `target-branch: develop` in a way that missed the actual failure
  mode — Dependabot reads this config from the **default branch**, not the PR
  base, so while main was the default and carried a copy without the setting,
  the version on develop was never consulted at all. That is why bumps kept
  opening against main despite this file. The setting is kept even though it is
  now redundant: it is the one thing here that survives the default moving again.

- `.github/workflows/conformance.yml` justified its explicit `develop` checkout
  with "scheduled runs fire on the default branch (main), not develop". The
  checkout is still right, for the opposite reason — it is what makes the job
  independent of where the default points.

- `.github/workflows/close-linked-issues.yml` opened with "neither mechanism
  ever fires — issues linger open", which is now the reverse of the truth. Kept
  rather than deleted: it degrades to logging `Skipping #N (state=CLOSED)`, and
  it still covers the one case native auto-close cannot — a closing keyword in a
  commit message that never appeared in a PR body. The header now says that is
  its remaining purpose, so the next reader does not mistake a quiet safety net
  for a broken one.

Not run: code-simplifier and code-reviewer. Every hunk is a comment; there is no
logic for either to judge. `yq` parses all three YAML files.
