### PR TITLE
test(pynfs): retire the OPEN4 row, and say what removing a row requires

### DIFF
--- a/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
+++ b/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
@@ -26,11 +26,34 @@ Categories:
 - **bug** — a real DittoFS defect, tracked by the linked issue. These are meant
   to leave the list; walk the row out when the fix lands.
 
+## Removing a row
+
+A row leaves this table on one piece of evidence: the literal verdict line
+
+```
+WRT2     st_write.testStateidOne                                  : PASS
+```
+
+read from the per-backend `pynfs.log` artifact, for every backend the suite
+runs on rather than just the one you reproduced against.
+
+A green grader is not that evidence. The grader exits with the count of
+failures that are *not* listed here, and a pynfs test whose `DEPEND:`
+prerequisites failed is skipped — it emits no `: FAILURE` line at all. Skip and
+pass are therefore indistinguishable to anything counting failures, so a
+prerequisite collapsing elsewhere in the suite reads exactly like the fix you
+were hoping for. Remove the row on that reading and the test stops being graded
+while it is still broken, which is the one outcome this table exists to prevent.
+
+Check each backend separately, because a row can be backend-dependent: `OPEN4`
+passed on `memory` and failed on the SQL backends for as long as those dropped
+the create verifier. Memory-passes/SQL-fails is a diagnosis worth keeping, not a
+flake worth re-running.
+
 ## Expected Failures
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| OPEN4 | bug | exclusive re-create with the same verifier answers EXIST on the SQL backends, which do not persist the create verifier | #2317 |
 | CLOSE4 | bug | bad/old/stale stateid accepted | #2341 |
 | CLOSE5 | bug | bad/old/stale stateid accepted | #2341 |
 | CLOSE6 | bug | bad/old/stale stateid accepted | #2341 |

--- a/test/nfs-conformance/pynfs/KNOWN_FAILURES_V41.md
+++ b/test/nfs-conformance/pynfs/KNOWN_FAILURES_V41.md
@@ -26,6 +26,30 @@ Categories:
 - **bug** — a real DittoFS defect, tracked by the linked issue. These are meant
   to leave the list; walk the row out when the fix lands.
 
+## Removing a row
+
+A row leaves this table on one piece of evidence: the literal verdict line
+
+```
+WRT2     st_write.testStateidOne                                  : PASS
+```
+
+read from the per-backend `pynfs.log` artifact, for every backend the suite
+runs on rather than just the one you reproduced against.
+
+A green grader is not that evidence. The grader exits with the count of
+failures that are *not* listed here, and a pynfs test whose `DEPEND:`
+prerequisites failed is skipped — it emits no `: FAILURE` line at all. Skip and
+pass are therefore indistinguishable to anything counting failures, so a
+prerequisite collapsing elsewhere in the suite reads exactly like the fix you
+were hoping for. Remove the row on that reading and the test stops being graded
+while it is still broken, which is the one outcome this table exists to prevent.
+
+Check each backend separately, because a row can be backend-dependent: `OPEN4`
+passed on `memory` and failed on the SQL backends for as long as those dropped
+the create verifier. Memory-passes/SQL-fails is a diagnosis worth keeping, not a
+flake worth re-running.
+
 ## Expected Failures
 
 | Test Name | Category | Reason | Issue |


### PR DESCRIPTION
`OPEN4` (`st_open.testCreatExclusiveFile`) now passes on both graded backends, so its blacklist row is retired.

## Why it was listed

The row was backend-split, not universally failing: `memory` passed it while the SQL backends answered `NFS4ERR_EXIST` to an exclusive re-create with the same verifier, because sqlite and postgres dropped `FileAttr.IdempotencyToken` and so did not persist the create verifier (#2317, since fixed). Memory-passes/SQL-fails was itself the diagnosis — persistence, not protocol.

## Evidence

Verdict lines read from the per-backend `pynfs.log` artifacts:

```
OPEN4    st_open.testCreatExclusiveFile                           : PASS   # v4.0 / memory
OPEN4    st_open.testCreatExclusiveFile                           : PASS   # v4.0 / postgres-s3
```

Removing the row is what makes the fix load-bearing. Blacklisted tests are invisible to a grader that counts only failures absent from the table, so a fix confirmed while the row is still present is observed but not defended — the row has to go for a regression to turn CI red.

Negative check, since a guard that has never refused anything is unverified:

| log | table | exit |
|---|---|---|
| real v4.0 postgres-s3 | edited | 0 |
| same log, `OPEN4` flipped to `FAILURE` | edited | **1**, naming `OPEN4` as new |

All four graded cells (v4.0 and v4.1 × memory and postgres-s3) exit 0 against the edited tables, and `parse-results_test.sh` passes.

## The section both tables gain

Removing a row is riskier than it looks, and the risk is invisible. The grader exits with the count of failures *not* in the table; a pynfs test whose `DEPEND:` prerequisites failed is **skipped and emits no `: FAILURE` line at all**. Skip and pass are therefore indistinguishable to it, so a prerequisite collapsing elsewhere in the suite reads exactly like the fix you were hoping for. A row removed on a green exit code alone can be a test that stopped running rather than one that started passing — and it then stops being graded while still broken, which is the one outcome the table exists to prevent.

The new section states the requirement where a future remover will actually meet it: the literal `CODE name : PASS` line from the per-backend artifact, checked per backend rather than only on the one you reproduced against.

Verified that the worked example inside that section is not itself parsed as a table row — `kf_is_known WRT2` returns false after the edit, while `CLOSE4`, `RPLY8` and `WRT18` still resolve with their reasons.

## What is deliberately left

`RPLY8` also passes on both backends and keeps its row. It is a `suite`-category entry for a timing-sensitive replay of a waiting `LOCKU` that knfsd does not pass either; one green run is not evidence that a flaky row is stable, and a row removed on that basis returns as a flake nobody can attribute.

## Notes

No closing keyword: #2317 is already closed by the fix this verifies, and no open issue tracks this cleanup. Markdown-only diff — no simplifier/reviewer pass, which would be disproportionate to one deleted table row.
