### PR TITLE
fix(test): stop the known-failures parser reading fenced examples as rows

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -122,6 +122,9 @@ jobs:
       - name: Test the common runner
         run: ./test/conformance/run_test.sh
 
+      - name: Test the shared known-failures parser
+        run: ./test/common/known-failures_test.sh
+
       - name: Test the smbtorture grader
         run: ./test/smb-conformance/smbtorture/parse-results_test.sh
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Test the common conformance runner
         run: ./test/conformance/run_test.sh
 
+      - name: Test the shared known-failures parser
+        run: ./test/common/known-failures_test.sh
+
   golangci-lint:
     name: golangci-lint
     runs-on: ubuntu-latest

--- a/test/common/known-failures.sh
+++ b/test/common/known-failures.sh
@@ -18,7 +18,9 @@
 # Only the first column (Test Name) and third column (Reason) are consumed;
 # Category/Issue are documentation for humans. Lines that are blank, start
 # with '#', do not start with '|', are separator rows (|---), or are the
-# header row ("Test Name") are ignored.
+# header row ("Test Name") are ignored. So is anything inside a ``` or ~~~
+# fence: these files carry worked examples of table rows, and parsing one
+# would silently excuse a passing test.
 #
 # Pattern matching supports two wildcard styles so SMB and POSIX names both
 # work:
@@ -55,8 +57,21 @@ kf_load() {
     local file="$1"
     [[ -f "$file" ]] || return 0
 
-    local line name reason
+    local line name reason bare in_fence=false
     while IFS= read -r line; do
+        bare="${line#"${line%%[![:space:]]*}"}"
+        # Fenced blocks carry worked examples, including example table rows and
+        # verdict lines. A line inside one is documentation, not an entry: a row
+        # parsed out of an example ADDS a name, which excuses a test that is
+        # currently passing, and nothing reports it. (A dropped row fails
+        # loudly; an added one goes quiet, so this direction is the dangerous
+        # one.) Both fence markers Markdown accepts are tracked, with any
+        # language tag and any indentation.
+        if [[ "$bare" == '```'* || "$bare" == '~~~'* ]]; then
+            if [[ "$in_fence" == true ]]; then in_fence=false; else in_fence=true; fi
+            continue
+        fi
+        [[ "$in_fence" == true ]] && continue
         [[ -z "$line" ]] && continue
         [[ "$line" == \#* ]] && continue
         # Only Markdown table rows.

--- a/test/common/known-failures_test.sh
+++ b/test/common/known-failures_test.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Unit tests for the shared known-failures (blacklist) parser.
+#
+# Every conformance suite grades against a table parsed by kf_load, so a
+# mis-parse here is silent in every suite at once. The asymmetry is what makes
+# this worth pinning: a row DROPPED makes a known failure look new and fails in
+# the hour, while a row ADDED excuses a test that is currently passing and
+# reports nothing at all. The assertions below are weighted toward the quiet
+# direction.
+#
+# Usage: ./known-failures_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./known-failures.sh
+source "${SCRIPT_DIR}/known-failures.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+FAILURES=0
+ASSERTIONS=0
+
+ok()   { ASSERTIONS=$((ASSERTIONS + 1)); echo "ok: $1"; }
+fail() { FAILURES=$((FAILURES + 1));     echo "FAIL: $1"; }
+
+# assert_known NAME TESTNAME
+assert_known() {
+    if kf_is_known "$2"; then ok "$1"; else fail "$1: '$2' should be known"; fi
+}
+
+# assert_not_known NAME TESTNAME
+assert_not_known() {
+    if kf_is_known "$2"; then fail "$1: '$2' should NOT be known"; else ok "$1"; fi
+}
+
+# assert_eq NAME EXPECTED ACTUAL
+assert_eq() {
+    if [[ "$2" == "$3" ]]; then ok "$1"; else fail "$1: expected '$2', got '$3'"; fi
+}
+
+reset_kf() {
+    unset KF_KNOWN KF_REASON
+    # shellcheck disable=SC2034  # populated and consumed by kf_load
+    declare -gA KF_KNOWN KF_REASON
+    KF_COUNT=0
+}
+
+# ---------------------------------------------------------------------------
+# A table shaped like the real ones: a prose header, a fenced worked example
+# that CONTAINS a table row, then the actual table.
+# ---------------------------------------------------------------------------
+cat > "${WORK}/fenced.md" <<'MD'
+# Known failures
+
+## Removing a row
+
+A row may only be removed on the literal verdict line from the artifact:
+
+```
+WRT2 st_write.testSizes : PASS
+| WRT2 | bug | example row inside a fence | #1234 |
+```
+
+## Expected Failures
+
+| Test Name | Category | Reason | Issue |
+|-----------|----------|--------|-------|
+| WRT18     | bug      | change attr frozen across a write | #2382 |
+| EID6g     | bug      | suffixed code, not just digits    | #2340 |
+| CSESS16a  | bug      | another suffixed code             | #2340 |
+| flock/*   | proto    | NLM not implemented               | -     |
+MD
+
+reset_kf
+kf_load "${WORK}/fenced.md"
+
+# The quiet direction: nothing inside the fence may become a row.
+assert_not_known "a table row inside a fence is not loaded" "WRT2"
+
+# The loud direction: real rows still load.
+assert_known "a plain row loads"                    "WRT18"
+assert_eq    "the row's reason is read from field 4" \
+             "change attr frozen across a write" "$(kf_reason WRT18)"
+
+# EID6g / CSESS16a separate "splits the row" from "matches the name's shape".
+# A pattern like ^\| [A-Z]+[0-9]+ \| drops both; kf_load must not.
+assert_known "a letter-suffixed code loads (EID6g)"    "EID6g"
+assert_known "a letter-suffixed code loads (CSESS16a)" "CSESS16a"
+
+assert_eq "the fence contributes no rows to the count" "4" "$KF_COUNT"
+
+# Globs still work alongside all of the above.
+assert_known "a glob row still matches" "flock/01.t"
+
+# ---------------------------------------------------------------------------
+# ~~~ is the other fence marker Markdown accepts, and fences may be indented.
+# ---------------------------------------------------------------------------
+cat > "${WORK}/tilde.md" <<'MD'
+| Test Name | Category | Reason | Issue |
+|-----------|----------|--------|-------|
+| REAL1     | bug      | a real row | - |
+
+~~~
+| TILDE1 | bug | inside a tilde fence | - |
+~~~
+
+  ```
+  | INDENTED1 | bug | inside an indented fence | - |
+  ```
+MD
+
+reset_kf
+kf_load "${WORK}/tilde.md"
+assert_known     "a row outside every fence loads"      "REAL1"
+assert_not_known "a ~~~ fence is honoured"              "TILDE1"
+assert_not_known "an indented fence is honoured"        "INDENTED1"
+assert_eq        "only the real row counted"    "1" "$KF_COUNT"
+
+# ---------------------------------------------------------------------------
+# An unterminated fence must not swallow the rest of the file silently... but
+# it must also not leak. Markdown treats EOF as closing it; what matters here
+# is that rows before it survive.
+# ---------------------------------------------------------------------------
+cat > "${WORK}/unterminated.md" <<'MD'
+| Test Name | Category | Reason | Issue |
+|-----------|----------|--------|-------|
+| BEFORE1   | bug      | before the fence | - |
+
+```
+| AFTER1 | bug | after an unterminated fence | - |
+MD
+
+reset_kf
+kf_load "${WORK}/unterminated.md"
+assert_known     "rows before an unterminated fence survive" "BEFORE1"
+assert_not_known "an unterminated fence still suppresses"    "AFTER1"
+
+# ---------------------------------------------------------------------------
+# A language tag on the fence must not defeat it.
+# ---------------------------------------------------------------------------
+cat > "${WORK}/tagged.md" <<'MD'
+| Test Name | Category | Reason | Issue |
+|-----------|----------|--------|-------|
+| KEEP1     | bug      | real | - |
+
+```bash
+| TAGGED1 | bug | inside a tagged fence | - |
+```
+MD
+
+reset_kf
+kf_load "${WORK}/tagged.md"
+assert_known     "a row outside a tagged fence loads" "KEEP1"
+assert_not_known 'a fence with a language tag is honoured' "TAGGED1"
+
+echo
+echo "assertions: ${ASSERTIONS}, failures: ${FAILURES}"
+[[ "$FAILURES" -eq 0 ]]


### PR DESCRIPTION
Part of #2322 (the shared-runner remainder, not the migration).

`kf_load` decided what is a blacklist row with one test — the line starts with
`|` — and had no awareness of code fences. These files carry worked examples of
table rows in fenced blocks, so an example was parsed as an entry.

**This is not hypothetical. It is already happening, twice, on develop:**

```
test/smb-conformance/KNOWN_FAILURES.md             49 rows → 48
test/smb-conformance/smbtorture/KNOWN_FAILURES.md  64 rows → 63
```

The two rows that disappear are `ExactTestName` and `smb2.exact.test.name`,
both template lines inside "Format for Expected Failures:" fences. They have
been in the loaded blacklist all along. Harmless only because no real test
carries those names — which is luck, not design. Every other table is byte-for-
byte unchanged (pynfs V40 16, V41 44, posix 19 and 13, kerberos 1).

## Why this direction of mis-parse is the dangerous one

A row **dropped** makes a known failure look new: CI goes red within the hour
and someone fixes it. A row **added** excuses a test that is currently passing,
and nothing reports anything — the tree gets quieter. So the failure mode here
is self-concealing, and it scales: `kf_load` is the one parser all five
conformance suites route through, so a single mis-parse is silent in all of
them at once.

The trigger was a near-miss. A removal-protocol section landed in the pynfs
KNOWN_FAILURES headers (#2409) containing a worked verdict example that
mentions `WRT2`. It is safe today purely because that example line does not
begin with `|`. Any later reformat that makes it table-shaped would have
blacklisted a passing test.

## The fix

Track ``` and ~~~ fences in `kf_load` and skip lines inside them. Language tags
and indentation are handled. Roughly three lines, in the one place every suite
routes through, rather than a guard per file.

## test/common/ had no tests at all

That is the actual gap, so this adds `known-failures_test.sh` — 15 assertions,
no server, no Docker, under a second — and wires it into both places
`run_test.sh` already runs (`lint.yml`, `conformance.yml`).

Verified against the unmodified parser rather than trusting a green run:

```
$ git checkout origin/develop -- test/common/known-failures.sh
$ ./test/common/known-failures_test.sh
assertions: 9, failures: 6
```

The six that fail are the fence cases, including the `WRT2`-shaped one.

Two fixtures are deliberate. `EID6g` and `CSESS16a` are letter-suffixed test
codes: they separate an implementation that *splits the row* from one that
*pattern-matches the name's shape*. A test using only `WRT18`-shaped codes
passes under both. This is a real failure mode, not an invented one — a peer
session counting rows with `^\| [A-Z]+[0-9]+ \|` silently lost twelve
`EID5c`–`EID6g` rows and reported V41 as 32 rows when it has 44.

One honest caveat: `an indented fence is honoured` passes against the old
parser too, since an indented row does not start with `|` and was already
skipped. It documents intent but does not discriminate. The other five do.
