### PR TITLE
docs(block): name the split packages after what the tree already calls them

### DIFF
--- a/.planning/2026-09-01-block-dataflow-MASTER-PLAN.md
+++ b/.planning/2026-09-01-block-dataflow-MASTER-PLAN.md
@@ -1,4 +1,4 @@
-# Master plan — block data-flow: audit findings + pier/crane/ferry refactor
+# Master plan — block data-flow: audit findings + journal/carver/syncer refactor
 
 Status: **FOR DISCUSSION.** No code written. HIGH findings filed as #2227-#2231 and **#2238**.
 
@@ -6,7 +6,7 @@ Inputs, all authoritative, none superseded by this document:
 - `2026-09-01-journal-audit-report.md` — 59 findings (6 HIGH / 8 MED / 45 LOW), 70 agents.
 - `2026-09-01-engine-audit-report.md` — 66 findings (1 HIGH / 13 MED / 52 LOW), 89 agents.
 - `2026-09-01-block-root-audit-report.md` — 22 findings (0 HIGH / 2 MED / 20 LOW), 45 agents.
-- `2026-09-01-pier-library-design-PLAN.md` — the target design (state model, three interfaces, folder structure, test/bench contracts).
+- `2026-09-01-journal-library-design-PLAN.md` — the target design (state model, three interfaces, folder structure, test/bench contracts).
 
 All three audits ran 7 lenses and an adversarial verify gate. **196 findings over 19,632 LOC.**
 
@@ -42,7 +42,7 @@ verdict overstates its reach if read alone.
 
 Corroborating the extraction case specifically:
 - `RemoteStore`/`BlockID` are entirely dead — never implemented, never read, `nil` at the one
-  production call site. The remote seam pier *actually* has is inbound-only (`Fill`), which is
+  production call site. The remote seam journal *actually* has is inbound-only (`Fill`), which is
   what makes the split viable.
 - Import coupling is trivial: 11 `logger.Warn`, 2 `block.ErrFutureFormat`, one `blake3` call.
 - Semantic coupling is real but localised: three type-asserted manifest interfaces, all in carve.
@@ -100,12 +100,12 @@ Fix nothing here separately; the design eliminates the class.
 | Finding | Closed by |
 |---|---|
 | `doc.go`'s false stdlib/two-interfaces claim | design-plan §8.1 import-graph **test** — a claim that cannot rot |
-| Dead API: `RemoteStore`, `BlockID`, `PinVersion`, `SegmentLocation`, `GC` | deleted; `RemoteStore` becomes `ferry.Store` |
+| Dead API: `RemoteStore`, `BlockID`, `PinVersion`, `SegmentLocation`, `GC` | deleted; `RemoteStore` becomes `syncer.Store` |
 | Three type-asserted manifest interfaces | evaporate: one becomes `DurableTail`, two become the caller calling itself |
 | `store.go` 1297 / `reclaim.go` 999 / `carve.go` 995 | design-plan §6.2 file layout |
 | `segment.go`/`index.go` holding the hot paths their names disown | `write.go` / `read.go` |
-| Two files named `carve_dispatch.go` | one `ferry` |
-| Six near-duplicate test store-openers | one harness in `piertest/` |
+| Two files named `carve_dispatch.go` | one `syncer` |
+| Six near-duplicate test store-openers | one harness in `journaltest/` |
 | `SetCarveTargets` unsynchronized field write | gone — collaborators move to construction |
 | Doc drift (`gc.go`, `logblob.EvictBlob`) | rewritten wholesale |
 
@@ -115,20 +115,20 @@ These do not exist today. The design introduces them and must close them.
 
 | Risk | Mitigation | Source |
 |---|---|---|
-| A free-form `durable []Extent` lets a buggy `fn` flip a range pier never offered — today's `flipIdx` cursor makes that structurally impossible | pier validates every returned extent against the offered-and-unflipped set, matching on **(offset, length, version)** — offset alone would flip new bytes when old ones were uploaded, which is the #1872 shape | design-plan §4.1 C4 |
+| A free-form `durable []Extent` lets a buggy `fn` flip a range journal never offered — today's `flipIdx` cursor makes that structurally impossible | journal validates every returned extent against the offered-and-unflipped set, matching on **(offset, length, version)** — offset alone would flip new bytes when old ones were uploaded, which is the #1872 shape | design-plan §4.1 C4 |
 | Reap outside the flush lock deletes the *next* pass's row — on a **2-second cadence**, not adversarial timing | `FlushOptions.AfterFile`, under the lock. **Mandatory** | design-plan §4.2 |
-| Concurrent `fn` calls race over block boundaries | `fn` called strictly sequentially; ALL upload concurrency lives in ferry | design-plan §4.1 C1 |
+| Concurrent `fn` calls race over block boundaries | `fn` called strictly sequentially; ALL upload concurrency lives in syncer | design-plan §4.1 C1 |
 | `DurableTail` computed eagerly per file loses the per-run cost property | computed lazily, per call | design-plan §4.1 C3 |
 | `Extents()` collapsing five queries regresses the hot path | `Size` and `DurableExtent` stay separate methods; benchmark and keep receipts | review finding |
-| `fn` erroring skips the reap, stranding superseded rows that DID commit | on error pier flips validated extents and **still calls `AfterFile`** | design-plan §4.1 C5 |
+| `fn` erroring skips the reap, stranding superseded rows that DID commit | on error journal flips validated extents and **still calls `AfterFile`** | design-plan §4.1 C5 |
 | Deferred credit bunches most flips onto the `Final` call on upload-bound files | accepted; must be **measured** (residency + time-to-flip vs today) before code | design-plan §4.4 |
-| A shared `ferry.Completions()` channel routes one file's upload completion to another file's callback — many files flush concurrently and `Submit` carries no `FileID` — silently losing durability credit | `Submit` returns a **per-call future**; no shared stream exists | design-plan §4.1 C3 |
+| A shared `syncer.Completions()` channel routes one file's upload completion to another file's callback — many files flush concurrently and `Submit` carries no `FileID` — silently losing durability credit | `Submit` returns a **per-call future**; no shared stream exists | design-plan §4.1 C3 |
 | Whole-extent credit matching forfeits a whole run when one unrelated byte moves — the common case on scattered writes, since `splitRuns` groups by offset only | validate and flip **per fragment**, mirroring `flipUpTo` | design-plan §4.1 C4 |
-| One `crane.Boxer` hoisted to `Syncer` lifetime interleaves two files' bytes into one block — **cross-file corruption**, and pier cannot detect it | **superseded by §11**: `harbour`'s per-`Flush` factory constructs the accumulator inside the closure, so a hoisted one is unrepresentable rather than merely forbidden | design-plan §4.1 C9 |
+| One `carver.Carver` hoisted to `Syncer` lifetime interleaves two files' bytes into one block — **cross-file corruption**, and journal cannot detect it | **superseded by §11**: `engine`'s per-`Flush` factory constructs the accumulator inside the closure, so a hoisted one is unrepresentable rather than merely forbidden | design-plan §4.1 C9 |
 
 ## 4. Sequencing
 
-**Order: ferry → crane → pier.** Reverse of the data flow: leaves first, trunk last.
+**Order: syncer → carver → journal.** Reverse of the data flow: leaves first, trunk last.
 
 The property that earns this order: **steps 1 and 2 are behaviour-preserving.** No on-disk
 format change, no state-model change, no flip-contract change — pure extraction, verifiable by
@@ -141,19 +141,19 @@ Each its own PR, each with a regression test that fails on unmodified `develop`.
 first means the extraction starts from a correct baseline and is not competing with bug fixes
 for review attention.
 
-### Step 1 — ferry
+### Step 1 — syncer
 
 Touches `engine/carve_dispatch.go` (upload window), `journal/carve_dispatch.go` (dispatcher),
 `engine/blocksink.go` (the PUT). Does not touch on-disk format, state model, flip contract, or
 the interval index. Delivers the ordered-completion contract step 3 depends on.
 
-### Step 2 — crane
+### Step 2 — carver
 
 Touches `journal/carve.go`'s packing loop and `pkg/block/chunker`. The critical test is
 **boundary stability**: the same blob chunked in one call vs. many must yield identical
 boundaries, or dedup silently stops working across the fleet.
 
-### Step 3 — pier
+### Step 3 — journal
 
 The seam inversion, `StateLost`, `AfterFile`, provenance validation, the query collapse, the
 file reorganisation. Everything in §3c lands here.
@@ -209,25 +209,25 @@ Still not bundled into refactor PRs — separate workstream, separate revert.
 body is `journal.FileID(payloadID)`, plus `Start()` and `SetMetrics()`, which are empty stubs.
 
 Once the legacy is gone there is no tier left to keep. Only four behaviours in the package are
-not legacy or shim, and each has a better home in pier:
+not legacy or shim, and each has a better home in journal:
 
 1. `journal.CheckFormat(dir/journal)` **before** `Open` — the guard that stops a directory written
-   by a newer release from reading as holes. Move it *inside* `pier.Open`, where it cannot be
+   by a newer release from reading as holes. Move it *inside* `journal.Open`, where it cannot be
    skipped by a caller. Note it is on the zero-test list in §2: it needs a test as it moves.
-2. The `filepath.Join(dir, "journal")` subdirectory convention — pier's own layout decision.
+2. The `filepath.Join(dir, "journal")` subdirectory convention — journal's own layout decision.
 3. `durable = true` — a field.
 4. The `nil` remote argument — that is the dead `journal.RemoteStore` seam, which design-plan §7.3 turns into
-   `ferry.Store`. It disappears on its own.
+   `syncer.Store`. It disappears on its own.
 
 **What stays:** `local.LocalStore` — the interface DittoFS declares — is exactly the §5 mechanism
 and must survive. It has two real implementations (`local/memory` is production-imported at
 `shares/blockstore_config.go:25`, not a test double), so it is not a one-implementation interface.
-It is the *wrapper* that goes, never the contract. `pier.Cache` satisfies `local.LocalStore`
+It is the *wrapper* that goes, never the contract. `journal.Store` satisfies `local.LocalStore`
 directly.
 
 **The one real decision — the ID type.** `journal.FileID` is a defined type (`type FileID string`),
 which is the only reason the ten shims exist. Either alias it (`type FileID = string`, zero
-call-site churn) or re-declare `local.LocalStore` in terms of `pier.FileID` and convert at the
+call-site churn) or re-declare `local.LocalStore` in terms of `journal.FileID` and convert at the
 metadata boundary instead. **Take the second.** An alias discards the only type safety the
 conversion currently buys, and §5's entire premise is that this boundary is checked at compile
 time. The churn is mechanical and the compiler finds every site.
@@ -243,7 +243,7 @@ prospective, not a live bug, and the deletion is not urgent — it is just clear
 
 ## 5. API completeness — DittoFS uses only public APIs
 
-**Requirement: after extraction, DittoFS reaches pier, crane and ferry through their exported
+**Requirement: after extraction, DittoFS reaches journal, carver and syncer through their exported
 APIs only. No embedding, no type assertions on the concrete type, no unexported structural
 interfaces, no custom back doors.**
 
@@ -267,7 +267,7 @@ different fixes:
 | `engine/legacy_migration.go:79` | `prober{HasLogBlobSubstrate}` | ❌ **never — no implementation exists** |
 
 So the hazard is **prospective, not live**. Seven assertions resolve because `FSStore` embeds
-`*journal.Store` and promotion covers them; a rename inside pier would not break the build, it
+`*journal.Store` and promotion covers them; a rename inside journal would not break the build, it
 would silently disable snapshot pinning, cold seed tracking, or per-read verification, and every
 test not exercising that exact path would stay green. **That is the same silent-failure shape as
 H1-H5, held off by nothing but an embed.** `fs.go:57-63` already flags it; this requirement
@@ -281,7 +281,7 @@ problem; it is deletion work, and it belongs to step 4.
 
 ### The enforcement mechanism
 
-> **Only the construction site may name `*pier.Cache` (likewise `*crane.Boxer`, `*ferry.Ferry`).
+> **Only the construction site may name `*journal.Store` (likewise `*carver.Carver`, `*syncer.Syncer`).
 > Everywhere else holds an interface DittoFS declares.**
 
 Consequences, all of them wanted:
@@ -297,10 +297,10 @@ Consequences, all of them wanted:
 
 Greppable gate for "done":
 ```
-rg '\*pier\.Cache|\*crane\.|\*ferry\.' --type go | grep -v _test.go
+rg '\*journal\.Cache|\*carver\.|\*syncer\.' --type go | grep -v _test.go
 ```
 returns only the construction sites. Plus, in each library's own test suite:
-`var _ SomeConsumerInterface = (*pier.Cache)(nil)` — so the library itself pins the contract it
+`var _ SomeConsumerInterface = (*journal.Store)(nil)` — so the library itself pins the contract it
 promises.
 
 ### The forcing function
@@ -310,8 +310,8 @@ incomplete**, and the resolution is to add it deliberately — with a doc commen
 place in the surface — never to reach around it. Every such addition is a design decision made
 in the open rather than a structural interface added quietly in a consumer.
 
-This applies per step: ferry's consumers use only ferry's API at the end of step 1, crane's at
-the end of step 2, pier's at the end of step 3. The requirement is not deferred to a cleanup pass.
+This applies per step: syncer's consumers use only syncer's API at the end of step 1, carver's at
+the end of step 2, journal's at the end of step 3. The requirement is not deferred to a cleanup pass.
 
 ## 6. The green bar
 
@@ -332,8 +332,8 @@ not the complete one.
 
 ### 6.1 Each module owns its own tests
 
-**A module's tests live in that module, and must pass with nothing else in the tree.** pier's
-suite runs against pier alone; likewise crane and ferry. This is not tidiness — it is the same
+**A module's tests live in that module, and must pass with nothing else in the tree.** journal's
+suite runs against journal alone; likewise carver and syncer. This is not tidiness — it is the same
 compile-time completeness check as §5, applied to behaviour:
 
 1. A test that can only be written from DittoFS names a capability the library's public API does
@@ -346,13 +346,13 @@ compile-time completeness check as §5, applied to behaviour:
 
 Concretely, per module:
 
-- **`piertest/`** — the one options-taking store-opener replacing today's six near-duplicate
+- **`journaltest/`** — the one options-taking store-opener replacing today's six near-duplicate
   openers (design-plan §6.3), plus the residency-truth state table: every operation's effect on all five
   states, including `StateLost`. `RestoreToVersion` gets the real suite D2 promises here, not in
   a consumer.
-- **`cranetest/`** — boundary stability first (the same blob chunked in one call vs. many must
+- **`carvertest/`** — boundary stability first (the same blob chunked in one call vs. many must
   yield identical boundaries, or fleet-wide dedup silently degrades), then packing determinism.
-- **`ferrytest/`** — ordered completion under concurrency, window saturation, retry idempotence,
+- **`syncertest/`** — ordered completion under concurrency, window saturation, retry idempotence,
   and the per-call-future contract that replaces the shared `Completions()` channel (design-plan §4.1 C3).
 
 What stays in DittoFS: integration tests that cross module boundaries, the E2E suite, and the
@@ -379,10 +379,10 @@ open-questions space, linking to it. **Discussions is currently disabled** on th
   any extraction begins. The refactor starts from a correct, tested baseline, and a regression
   during steps 1-3 is unambiguously attributable to the refactor rather than to a concurrent bug
   fix — which matters specifically because this is the silent-zeros path.
-- **D2. `RestoreToVersion` ships in pier, with a real test suite.** "Rewind to LSN V" is generic,
+- **D2. `RestoreToVersion` ships in journal, with a real test suite.** "Rewind to LSN V" is generic,
   and it needs ceiling-replay machinery over on-disk records that the public surface will not
-  expose — keeping it DittoFS-side would mean widening pier's surface to let it reach in. The
-  cost is accepted: pier must carry it AND test it before it is fit to publish. Its tests are
+  expose — keeping it DittoFS-side would mean widening journal's surface to let it reach in. The
+  cost is accepted: journal must carry it AND test it before it is fit to publish. Its tests are
   part of step 0 (they are the prerequisite for fixing H1 and H3 at all), not deferred to step 3.
 - **D3. The 45 LOW findings fold into the step that touches their file.** No separate backlog, no
   issue churn.
@@ -507,7 +507,7 @@ them into one receiver is how 46 methods happened.
 
 After §4.1 and the legacy deletion, the root keeps the contract and the types the contract names —
 `FileID`, `Stability`, `Verifier`, `State`, `Span`, `ContentHash`, `FileChunk`, `Locator` — and
-nothing else. Everything that is machinery moves down into `pier` / `crane` / `ferry` / `engine`;
+nothing else. Everything that is machinery moves down into `journal` / `carver` / `syncer` / `engine`;
 everything legacy is deleted outright rather than relocated. A reader opening `pkg/block/` should
 see what the block store promises, not how it keeps the promise.
 
@@ -532,7 +532,7 @@ has never been exercised end to end in one place. Add exactly one of each, both 
 API in the shape an adapter drives it:
 
 - **Integration test** — adapter-shaped writes (unstable, then a range `Commit`) through
-  `WriteAt → pier → crane → ferry → remote`, asserting the **residency transition after every
+  `WriteAt → journal → carver → syncer → remote`, asserting the **residency transition after every
   step** via §9.4's `Extents`, not just the final bytes. It must cover: unstable write leaves
   `Dirty`; commit moves to `Synced`; eviction moves to `Cold`; a cold read faults back in; and a
   deliberately corrupted remote produces `Lost` **with an error**, never zeros. That last case is
@@ -605,8 +605,8 @@ type Substrate interface {
 }
 ```
 
-- **`pier.Substrate`** — stamp is a file; the fence is write-temp + fsync + rename.
-- **`ferry.Substrate`** — stamp is an object at a well-known key; the fence is a conditional PUT.
+- **`journal.Substrate`** — stamp is a file; the fence is write-temp + fsync + rename.
+- **`syncer.Substrate`** — stamp is an object at a well-known key; the fence is a conditional PUT.
 
 #### Where the remote fence lives
 
@@ -669,9 +669,9 @@ migration should be written when a real format change needs one, not speculative
 with the refactor is the stamp, the three classes, the registry and the gate — the parts that must
 exist before the first migration, and no migrations at all.
 
-## 11. `harbour` — the assembly
+## 11. `engine` — the assembly
 
-pier, crane and ferry are three libraries; something must wire them. Today design-plan §6.2 assigns that to
+journal, carver and syncer are three libraries; something must wire them. Today design-plan §6.2 assigns that to
 `dittofs/pkg/block/engine`. Moving the wiring into the library set makes the trio testable and
 `git subtree split` shippable — otherwise the split yields three modules nobody can assemble
 without re-deriving the `Flush` seam from prose.
@@ -681,37 +681,37 @@ counts as durable, what the manifest says — stays in DittoFS. An assembly that
 the god object relocated, and it would re-absorb precisely the residency-truth judgements that
 produced H1-H5.
 
-Its scope is defined by subtraction. **Enforcement of the design-plan §4.1 seam contract stays in pier**, for
-everything pier can observe: per-fragment credit validation, strictly sequential `fn`,
-`AfterFile` under the flush lock. The assembly owns only the residue pier structurally *cannot*
+Its scope is defined by subtraction. **Enforcement of the design-plan §4.1 seam contract stays in journal**, for
+everything journal can observe: per-fragment credit validation, strictly sequential `fn`,
+`AfterFile` under the flush lock. The assembly owns only the residue journal structurally *cannot*
 see:
 
-1. **C9 — the fresh-per-`Flush` accumulator.** The design records that pier cannot detect a
-   hoisted `crane.Boxer`, and that hoisting interleaves two files' bytes into one block:
-   cross-file corruption, undetectable from pier. Today C9 is a *stated caller obligation*. The
+1. **C9 — the fresh-per-`Flush` accumulator.** The design records that journal cannot detect a
+   hoisted `carver.Carver`, and that hoisting interleaves two files' bytes into one block:
+   cross-file corruption, undetectable from journal. Today C9 is a *stated caller obligation*. The
    assembly makes it structural by constructing the accumulator inside a per-`Flush` factory, so
-   a hoisted one cannot be expressed — the same move as ferry's per-call futures replacing the
+   a hoisted one cannot be expressed — the same move as syncer's per-call futures replacing the
    shared `Completions()` channel.
-2. **Config consistency** — crane's chunk params must match what pier records, or dedup silently
+2. **Config consistency** — carver's chunk params must match what journal records, or dedup silently
    degrades across the fleet. One constructor, one place to get it wrong.
 
 That is the whole surface: a constructor and a `fn` factory. If it grows a third responsibility,
 that is the signal it is absorbing policy.
 
 ```
-harbour/
-  harbour.go    New(pier, crane, ferry, Options) — assembles, validates config consistency
+engine/
+  engine.go    New(journal, carver, syncer, Options) — assembles, validates config consistency
   flush.go      the per-Flush fn factory; C9 made structural
   README.md
 ```
 
-**The name is load-bearing.** A harbour is the *place* a pier, its cranes and its ferries sit —
-not an actor. `harbourmaster` was the closer fit for "sequences the three" and was rejected for
-exactly that reason: a harbourmaster has authority, and a package named for authority invites the
-policy drift §11 exists to prevent. If someone proposes adding a decision to `harbour`, the name
-itself is the argument against it.
+**The name is load-bearing, and it already exists.** `engine` is where the three libraries are
+composed, and the package is already called that and already does exactly this job — so the
+assembly needs no new name, only a narrower one. What it must not become is an actor: a package
+that *sequences* the three will attract the decisions §11 exists to keep out. Anything proposing
+to add a policy to `engine` is proposing to make it something other than composition.
 
-**D10. The assembly is `harbour`**, ships with the library set, and holds no policy.
+**D10. The assembly is `engine`**, ships with the library set, and holds no policy.
 
 §9.7's ingestion integration test and benchmark move here, since this is the smallest thing that
 can run the whole path without DittoFS in the tree.
@@ -721,7 +721,7 @@ can run the whole path without DittoFS in the tree.
 - **D5. Scope is the block store only.** The four metadata backends keep their existing schema
   handling. The block format is the one that has actually churned twice.
 - **D6. Compatibility classes, not a version integer**, and the runner/substrate split of §10.3
-  is committed: one runner, `pier.Substrate` and `ferry.Substrate`, three injected primitives.
+  is committed: one runner, `journal.Substrate` and `syncer.Substrate`, three injected primitives.
 - **D7. Revert means abort-in-progress and undo pre-contract only.** No downgrade of a completed
   destructive migration. `Down` is optional and its absence is a stated fact.
 - **D8. Minor applies automatically, major refuses and requires an explicit command.**
@@ -766,7 +766,7 @@ log success.
 rest* — two views of the same byte, out of sync. This one is a **time-of-check/time-of-use race**:
 every view is individually correct, and the defect is that they are read at different instants
 while a writer moves between them. The five-state model in §9.4 is necessary but not sufficient;
-it needs **transitions under concurrency**, not just states. Fold that into `piertest`'s state
+it needs **transitions under concurrency**, not just states. Fold that into `journaltest`'s state
 table — every transition needs a concurrent-writer case, not only a sequential one.
 
 ### 12.2 The finding that neither single-package audit could have found
@@ -808,7 +808,7 @@ Engine findings by area, most-hit first: `gc-mark-sweep-compaction` **15**,
 `composition-lifecycle` 8, `read-path-cold-fetch` 6, `manifest-check-repair` 4,
 `offline-readiness` 3.
 
-Per design-plan §6.2, the extraction moves roughly **500 of engine's 11,304 LOC** into ferry — the upload
+Per design-plan §6.2, the extraction moves roughly **500 of engine's 11,304 LOC** into syncer — the upload
 window, the PUT, and a dead interface. GC, reclaim, manifest check/repair, cold-read resolution
 and offline readiness all stay. **The single new HIGH lives in `gc_sweep_index.go`, which does not
 move**, and the heaviest-hit area is the one least touched by the refactor.
@@ -933,7 +933,7 @@ Consequences, all binding:
 
 1. **Gap-finding rounds outward to block boundaries.** A 4 KiB hole inside a 16 MiB block warms
    that entire block, or nothing at all. Never the 4 KiB.
-2. **`ferry.GetRange` is not part of the warm path.** It exists for a demand read that can
+2. **`syncer.GetRange` is not part of the warm path.** It exists for a demand read that can
    tolerate a partial answer. Prefetch calls `Get`, whole-block, always.
 3. **Partial residency within a block is not representable in the warm path.**
 4. A warm that cannot complete a whole block **fetches nothing** and records nothing (see S2).
@@ -949,10 +949,10 @@ gap that is not the next index. §9.4's `Extents` is what makes the gap expressi
 ### 13.4 Where it lands after the split
 
 - **Policy — when, how far, when to stop — stays in DittoFS.** It needs the manifest and the
-  access pattern; pier has neither, ferry has neither.
-- **Mechanism is `ferry.Get`**, whole-block, at a priority below demand fetches.
-- **Landing is `pier.Hydrate`.**
-- **`harbour` holds none of it.** Prefetch is policy, and §11 is explicit. If prefetch logic turns
+  access pattern; journal has neither, syncer has neither.
+- **Mechanism is `syncer.Get`**, whole-block, at a priority below demand fetches.
+- **Landing is `journal.Hydrate`.**
+- **`engine` holds none of it.** Prefetch is policy, and §11 is explicit. If prefetch logic turns
   up in the assembly, the boundary has already failed.
 
 ### 13.5 Soundness — prefetch widens an open race, today

--- a/.planning/2026-09-01-journal-library-design-PLAN.md
+++ b/.planning/2026-09-01-journal-library-design-PLAN.md
@@ -1,4 +1,4 @@
-# pier — target design for extracting `pkg/block/journal` as a library
+# journal — target design for extracting `pkg/block/journal` as a library
 
 Status: **DESIGN / NOT APPROVED.** No code written. The audit that was still running when this
 was drafted is **complete**, as are the sibling audits of `pkg/block/engine` and the `pkg/block`
@@ -6,7 +6,7 @@ root. All three are folded into the master plan's §12 — read that alongside �
 
 Baseline commit: `ff14b24cb` (origin/develop). Audited in an immutable detached worktree at that commit.
 
-Naming: **DECIDED — `pier`.** See §11.1 for the rationale and the vocabulary it gives us.
+Naming: **DECIDED — `journal`.** See §11.1 for the rationale and the vocabulary it gives us.
 
 ---
 
@@ -33,7 +33,7 @@ DittoFS's field bug history for this component, over roughly a year:
 | #1879 / #1888 | silent zeros; the guard meant to catch them was unreachable |
 | #2084 | `Invalidate` marked a live *dirty* record cold → zeros, nothing logged |
 | #1872 / #2073 / #2093 | reap classified rows by start offset → zeros, or resurrected old bytes |
-| #1956 | crane dropped deduped chunks' manifest rows → zeros |
+| #1956 | carver dropped deduped chunks' manifest rows → zeros |
 | #2110 | offline-readiness reported `Safe()` for a *lost* interval |
 
 Every one is the same defect: **the cache's map of what it holds disagreed with what it
@@ -108,14 +108,16 @@ refusal is the operation's definition rather than a guard someone remembered to 
 ## 4. The surface
 
 ```go
-// Package pier is a crash-safe local write-back cache for object storage.
+// Package journal is a crash-safe local write-back cache for object storage.
 //
-// Bytes park in a container on the pier until a boat carries them out: a write
-// lands locally and is acknowledged at once, Sync bolts it down so a crash
-// cannot take it, and Flush puts it on the boat to the object store. A pier is
-// a waiting place, never a destination — pier always knows which of its bytes
-// have sailed, which have not, and which are gone.
-package pier
+// Bytes land locally and are acknowledged at once; Sync makes them durable on
+// this machine; Flush hands them to the object store. The journal is a waiting
+// place, never a destination — it always knows which of its bytes are durable
+// remotely, which are only local, and which are gone.
+//
+// Local durability and remote durability are two different guarantees, which is
+// why Sync and Flush are two different words.
+package journal
 
 type FileID string
 
@@ -159,9 +161,9 @@ func (c *Cache) SetEvictionEnabled(bool)
 func (c *Cache) MarkSeeded() error
 
 // ── errors: a closed set, each implying a different caller action ──
-var ErrFull   = errors.New("pier: local capacity exhausted, all segments pinned dirty")
-var ErrLost   = errors.New("pier: range has no surviving copy")
-var ErrClosed = errors.New("pier: closed")
+var ErrFull   = errors.New("journal: local capacity exhausted, all segments pinned dirty")
+var ErrLost   = errors.New("journal: range has no surviving copy")
+var ErrClosed = errors.New("journal: closed")
 
 type CorruptError struct{ ID FileID; Off, Len int64 } // healable: invalidate + refetch
 ```
@@ -175,8 +177,8 @@ func (c *Cache) Flush(ctx context.Context, id FileID, opts FlushOptions,
         fn func(ctx context.Context, r Run) (durable []Extent, err error)) error
 
 // Run is one offer: a contiguous dirty region of one file, plus its bytes.
-// It is NOT a block. pier does not know what a block is — that is the whole
-// point of being chunk-agnostic. crane turns Runs into Blocks.
+// It is NOT a block. journal does not know what a block is — that is the whole
+// point of being chunk-agnostic. carver turns Runs into Blocks.
 type Run struct {
     ID          FileID
     Extent      Extent   // the dirty region being offered
@@ -191,13 +193,13 @@ type FlushOptions struct {
     MaxAge time.Duration // dirty-age eligibility gate
     MinSize int64        // dirty-bytes eligibility gate
 
-    // AfterFile runs once per file after the last flip, WHILE pier still holds
+    // AfterFile runs once per file after the last flip, WHILE journal still holds
     // the shard's flush lock. The manifest reap goes here. MANDATORY — see §4.2.
     AfterFile func(ctx context.Context, id FileID) error
 }
 ```
 
-**No `Concurrency` field.** All upload concurrency lives in ferry. pier is sequential.
+**No `Concurrency` field.** All upload concurrency lives in syncer. journal is sequential.
 
 ### 4.1 The contract, stated completely
 
@@ -208,7 +210,7 @@ time, ascending file offset, and call N+1 does not begin until call N returns. B
 depend on it (a block is closed by accumulated size, and the accumulator is `fn`'s), and so does
 the reap's contiguous-prefix assumption (`carve_pack.go:16-24`).
 
-**C2 — Locks held when `fn` runs.** pier holds the shard's `flushMu` (which serializes passes
+**C2 — Locks held when `fn` runs.** journal holds the shard's `flushMu` (which serializes passes
 for that shard) and **does NOT hold `sh.mu`**, the index lock. This mirrors today exactly:
 `sh.mu` is taken and released in short sections (`carve.go:239-240`, `:275-285`) and the sink
 call at `:449` runs outside it. `fn` performs network I/O; holding the index lock across it
@@ -219,7 +221,7 @@ it buffers toward a block. It reports extents whose uploads have **since** compl
 call. Consequence, accepted: for a file with few runs but slow uploads, most flips arrive on the
 `Final` call, which blocks until this file's in-flight uploads resolve.
 
-**Credit is tracked per `Submit` call, never through a shared stream.** `ferry.Submit` returns a
+**Credit is tracked per `Submit` call, never through a shared stream.** `syncer.Submit` returns a
 future scoped to that one upload; `fn` waits on futures in submission order, exactly as
 `journal/carve_dispatch.go:109-114` chains `prev`/`mine` today. A single shared
 `Completions()` channel CANNOT work: Go delivers each message to exactly one receiver, and
@@ -228,7 +230,7 @@ would be delivered to file A's `fn` with no `FileID` in `Submit` and no demultip
 That loses durability credit silently — the disease this design exists to cure, relocated to the
 transport. See §7.3.
 
-**C4 — Credit is validated per FRAGMENT, not per extent.** pier decomposes each returned
+**C4 — Credit is validated per FRAGMENT, not per extent.** journal decomposes each returned
 `(offset, length)` against its own retained snapshot of the fragments it offered, and flips
 **fragment by fragment**, skipping any whose version no longer matches while still flipping every
 sibling that does. This mirrors `flipUpTo` (`carve.go:844-865`), which already validates per live
@@ -243,47 +245,47 @@ different partitioning again. Whole-extent matching would forfeit credit for an 
 because one unrelated byte moved, on exactly the scattered-write workload this package is tuned
 for (`carve.go:377-387`).
 
-The version check itself is pier's own bookkeeping — `Extent` carries no version field and `fn`
+The version check itself is journal's own bookkeeping — `Extent` carries no version field and `fn`
 never sees one. Skipped fragments are logged and stay dirty; the next pass's dedup collapses the
 re-upload to a no-op, so this costs repeated CDC/hash work, not correctness.
 
 **C5 — Partial credit with error.** `fn` may return a non-empty `durable` **together with** a
-non-nil error: "these committed, then I failed." pier flips the validated extents, stops
+non-nil error: "these committed, then I failed." journal flips the validated extents, stops
 offering runs for this file, and **still calls `AfterFile`** — because the committed prefix must
 be reaped. `TestCarvePackSpanningBlockFailureReapsTheCommittedPrefix` pins exactly this. Then
 `Flush` returns the error; remaining dirty ranges stay dirty for the next pass, where the dedup
 oracle collapses any re-upload.
 
-**C6 — Backpressure.** If ferry's window is full, `fn` blocks in `Submit`, which stalls pier's
+**C6 — Backpressure.** If syncer's window is full, `fn` blocks in `Submit`, which stalls journal's
 sequential loop while `flushMu` is held. **Not a regression** — today's uploads run under
 `carveMu` for the same duration — but it means a slow remote delays that shard's next flush
 pass, not its reads or writes. `ctx` is the escape hatch.
 
-**C7 — Cancellation.** On `ctx` cancellation pier stops offering runs, flips whatever was
+**C7 — Cancellation.** On `ctx` cancellation journal stops offering runs, flips whatever was
 already validated, and still calls `AfterFile`. A cancel between the last flip and the reap can
 strand superseded rows — the same window today's `ponytail:` marker at `carve.go:335` documents.
 Unchanged, and explicitly not made worse.
 
 **C8 — Buffer lifetime, and NO extra copy.** `Run`'s `ReaderAt` is a **lazy pass-through to the
-underlying record reads** — it does NOT pre-materialize into a pier-owned buffer. This is
+underlying record reads** — it does NOT pre-materialize into a journal-owned buffer. This is
 deliberate and is the difference between two copies and three:
 
 - today: record -> `buf` (pooled scratch, `carve.go:530`) -> `arena` (`copy`, `:589`). Two hops.
-- pre-materializing would add record -> pier-buf -> fn-scratch -> crane arena. Three.
-- lazy pass-through keeps it at two: `fn` reads straight into its own scratch, then crane copies
+- pre-materializing would add record -> journal-buf -> fn-scratch -> carver arena. Three.
+- lazy pass-through keeps it at two: `fn` reads straight into its own scratch, then carver copies
   accepted chunk bytes into its block arena.
 
 `ReaderAt` is valid only for the duration of the `fn` call. An implementation needing the bytes
 longer must copy them — the same contract `BlockSink.CommitBlock` states today
 (`carve.go:100-103`).
 
-**C9 — `fn` and its accumulator MUST be constructed fresh per `Flush` call.** pier cannot enforce
+**C9 — `fn` and its accumulator MUST be constructed fresh per `Flush` call.** journal cannot enforce
 this and cannot detect a violation: it is chunk-agnostic, so it has no visibility into what `fn`
 does with the bytes. **Caller obligation, stated because it is silent when broken.**
 `engine/carve_dispatch.go:91-127` launches one goroutine per file, gated only by a *count*
 limiter, so files on different shards flush truly concurrently. Today that is safe because
 `packRuns` allocates its chunker (`carve.go:513`) and dispatcher (`:400`) fresh per call. In v5
-that state is `crane.Boxer`, living in the engine's closure — and hoisting it to a
+that state is `carver.Carver`, living in the engine's closure — and hoisting it to a
 `Syncer`-lifetime field reads like harmless stateless config while actually interleaving two
 files' bytes into one block. That is cross-file corruption, worse than anything in §2.
 
@@ -305,7 +307,7 @@ BOTH the flip and the reap (`carve.go:274-360`). Release it at `Flush` return an
    recognise pass 2's row as its own, and **deletes a load-bearing row.**
 
 That is #1872/#2093 reintroduced by construction, on a timer. A caller-side lock is the wrong
-alternative: it makes the engine invent a second per-shard scheme with no visibility into pier's
+alternative: it makes the engine invent a second per-shard scheme with no visibility into journal's
 partitioning. Fold `maybeResetDirtyClock` (`carve.go:920-935`) into `AfterFile` too.
 
 **`AfterFile` needs no parameters beyond the id**: `fn` and `AfterFile` share the caller's closure,
@@ -314,8 +316,8 @@ so the `spans`/`newOffsets` the reap needs are already in scope.
 **`DurableTail` supplies residency only.** It answers "is anything durable past this run, and is
 it local or remote" — the `anySyncedFrom`/`warmAt` half of `extendRunToRowEnd` (`carve.go:673-711`).
 It does NOT answer where the manifest row ends: that is `ManifestRowEndAfter`
-(`blocksink.go:190-213`), a metadata-store call pier will never have, so `fn` makes it directly.
-And to re-chunk the tail, `fn` reads it via `pier.ReadAt` — `Run.ReaderAt` is scoped to
+(`blocksink.go:190-213`), a metadata-store call journal will never have, so `fn` makes it directly.
+And to re-chunk the tail, `fn` reads it via `journal.ReadAt` — `Run.ReaderAt` is scoped to
 `Run.Extent`, not the tail. A reader would otherwise assume `DurableTail` is self-sufficient and
 go looking for a manifest hook that will never exist.
 
@@ -324,9 +326,9 @@ go looking for a manifest hook that will never exist.
 | Draft | Shape | Why it failed |
 |---|---|---|
 | v1 | one call per run, returns `consumed int64` | Cannot name bytes from an *earlier* call. `packRuns` does not reset `blockFirstRun` per run (`carve.go:442`, `:600-603`), so one block routinely spans runs. Forced either one small object per run, or the caller rebuilding the accumulator. |
-| v2 | pier accumulates to `BlockSize`, calls `fn` per block | Impossible. `carve.go:598-601` closes a block only after a whole chunk is appended, so **block boundaries are always chunk boundaries** — and a chunk-agnostic pier cannot know where a block may legally end. |
-| v3 | v4's shape, but the parameter was named `Block` and pier owned "bounded concurrency" | Two errors: `Block` collides with crane's output type and implies pier understands blocks, which contradicts the chunk-agnostic requirement; and pier-owned concurrency contradicts C1's sequential calling — concurrent calls race over one accumulator. |
-| v4 | v5's shape, but ferry exposed one shared `Completions()` channel, C4 matched whole extents, C8 pre-materialized, and C9/C10 were unstated | `Completions()` is undemultiplexable: Go delivers each message to one receiver, `Submit` carries no `FileID`, and many files flush concurrently — file B's completion reaches file A's `fn`. Whole-extent matching forfeits credit whenever one unrelated byte moves, which is the common case. |
+| v2 | journal accumulates to `BlockSize`, calls `fn` per block | Impossible. `carve.go:598-601` closes a block only after a whole chunk is appended, so **block boundaries are always chunk boundaries** — and a chunk-agnostic journal cannot know where a block may legally end. |
+| v3 | v4's shape, but the parameter was named `Block` and journal owned "bounded concurrency" | Two errors: `Block` collides with carver's output type and implies journal understands blocks, which contradicts the chunk-agnostic requirement; and journal-owned concurrency contradicts C1's sequential calling — concurrent calls race over one accumulator. |
+| v4 | v5's shape, but syncer exposed one shared `Completions()` channel, C4 matched whole extents, C8 pre-materialized, and C9/C10 were unstated | `Completions()` is undemultiplexable: Go delivers each message to one receiver, `Submit` carries no `FileID`, and many files flush concurrently — file B's completion reaches file A's `fn`. Whole-extent matching forfeits credit whenever one unrelated byte moves, which is the common case. |
 
 ### 4.4 What still needs proving before code
 
@@ -354,20 +356,20 @@ Nothing is a lost capability:
 - `SeedCold` + `SeedColdBatch` → `Seed` (single file is a one-element slice)
 - `SetVerifyReads` → `Config.VerifyReads` (set once at construction, never changes)
 - `CheckFormat` → folded into `Open` (a guard a caller can forget is not a guard)
-- crane moves out entirely (§5)
+- carver moves out entirely (§5)
 - dead API deleted (§6)
 
 ## 5. The split: subtraction, not partition
 
-**Do not create two packages.** Move crane *up* into `pkg/block/engine`, where the manifest it
+**Do not create two packages.** Move carver *up* into `pkg/block/engine`, where the manifest it
 serves already lives. What remains in the package is the generic library.
 
-Evidence this is cheap: every crane helper — `splitRuns`, `warmTail`, `anySyncedFrom`,
+Evidence this is cheap: every carver helper — `splitRuns`, `warmTail`, `anySyncedFrom`,
 `syncedRanges`, `flipUpTo`, `flipRecordSynced`, `recordHasDirtyFragment`,
 `maybeResetDirtyClock`, `runReader` — has **zero** uses outside `carve*.go`. They become the
-body of `Flush` or move with crane.
+body of `Flush` or move with carver.
 
-Counter-evidence to respect: crane touches `fi.ivs` 28× and `sh.mu` 20×. It is *inside* the
+Counter-evidence to respect: carver touches `fi.ivs` 28× and `sh.mu` 20×. It is *inside* the
 index today, not a client of it. That is precisely why the seam must be a **callback**, not a
 lease — a lease API would have to materialise all that state as values and invent a token to
 fence what a held lock already fenced.
@@ -387,7 +389,7 @@ Ordered work:
    the module.
 3. Replace `block.ErrFutureFormat` with a package-local sentinel (2 uses, `format.go`).
 4. Collapse the five extent queries into `Extents`.
-5. Invert crane into `Flush` + `Run.WarmTail`; move chunking/hashing/manifest to engine.
+5. Invert carver into `Flush` + `Run.WarmTail`; move chunking/hashing/manifest to engine.
    `chunker` and `blake3` leave with it.
 6. Rename to the agreed name; convert `FSStore`'s embed to a named field (see §6).
 7. README, `Example_` tests, benchmark set, and the test suite closing §6's gaps.
@@ -397,32 +399,32 @@ at which point `git subtree split` is mechanical — **if** a second consumer ev
 
 ### 5.0 Vocabulary — one word, one meaning
 
-The family reads in order: **pier** stages -> **crane** cuts blocks -> **ferry** moves them ->
+The family reads in order: **journal** stages -> **carver** cuts blocks -> **syncer** moves them ->
 **dittofs** orchestrates and decides what any of it means.
 
 #### Data flow — note the return path
 
 ```
 WRITE                                                    ack ────┐
-  NFS/SMB ──► pier.WriteAt ──► staged locally, StateDirty ───────┘
+  NFS/SMB ──► journal.WriteAt ──► staged locally, StateDirty ───────┘
 
-FLUSH  (dittofs schedules; pier offers, dittofs disposes)
-  pier.Flush(id, fn) ──► offers dirty runs ──► fn:
-                                                crane.Crane    cut blocks
-                                                ferry.Upload  PUT
+FLUSH  (dittofs schedules; journal offers, dittofs disposes)
+  journal.Flush(id, fn) ──► offers dirty runs ──► fn:
+                                                carver.Carver    cut blocks
+                                                syncer.Upload  PUT
                                                 dittofs        commit manifest rows
                           ◄── returns durable []Extent ──────────┘
-  pier flips exactly those ──► StateResident        ← THE INVARIANT LIVES HERE
+  journal flips exactly those ──► StateResident        ← THE INVARIANT LIVES HERE
 
 READ
-  NFS/SMB ──► pier.ReadAt ──► (n, fetch []Extent)
+  NFS/SMB ──► journal.ReadAt ──► (n, fetch []Extent)
                  fetch non-empty ──► dittofs resolves manifest
-                                  ──► ferry.Fetch
-                                  ──► pier.Fill ──► StateResident ──► re-read
+                                  ──► syncer.Fetch
+                                  ──► journal.Fill ──► StateResident ──► re-read
 ```
 
-**Nothing reaches `StateResident` except by pier being told what became durable.** That is why
-`Flush` is a callback and not a pipeline stage: a linear `write -> crane -> sync` has nowhere to
+**Nothing reaches `StateResident` except by journal being told what became durable.** That is why
+`Flush` is a callback and not a pipeline stage: a linear `write -> carver -> sync` has nowhere to
 put the acknowledgement, and dropping it is the entire #1872 / #2073 / #2093 family. The flow is
 a loop, and the return edge is the crash-safety-critical one.
 
@@ -433,75 +435,75 @@ boundaries right in-tree now; promote to modules only when something is actually
 `git subtree split` stays mechanical as long as each package's imports stay clean, which is
 exactly what §8.1's import-graph test enforces.
 
-`crane` today means chunking AND packing AND uploading AND manifest commit AND flipping records
+`carver` today means chunking AND packing AND uploading AND manifest commit AND flipping records
 — **541 occurrences across 60 non-test files**. The smear is visible in the type name
 `CarveChunk`, which needs two words to name one thing.
 
 | Term | Means exactly | Lives in |
 |---|---|---|
-| **write** | stage bytes locally and acknowledge the client | `pier.WriteAt` |
-| **sync** | make durable HERE (fsync) | `pier.Sync` |
-| **flush** | pier's pass: offer dirty runs, accept durability reports | `pier.Flush` |
-| **chunk** | find one content-defined boundary | inside `crane` |
-| **box** | group chunks into one BlockSize block | `crane.Box` |
-| **put** / **get** | make durable THERE / bring it back | `ferry.Put` / `ferry.Get` |
+| **write** | stage bytes locally and acknowledge the client | `journal.WriteAt` |
+| **sync** | make durable HERE (fsync) | `journal.Sync` |
+| **flush** | journal's pass: offer dirty runs, accept durability reports | `journal.Flush` |
+| **chunk** | find one content-defined boundary | inside `carver` |
+| **box** | group chunks into one BlockSize block | `carver.Box` |
+| **put** / **get** | make durable THERE / bring it back | `syncer.Put` / `syncer.Get` |
 
-`Box` is a verb; its output noun is **`Block`**, not `Box` — `crane.Box(...) []Block`. Never
-introduce a `Box` type. pier's on-disk unit stays **segment**; only crane produces **blocks**.
+`Box` is a verb; its output noun is **`Block`**, not `Box` — `carver.Box(...) []Block`. Never
+introduce a `Box` type. journal's on-disk unit stays **segment**; only carver produces **blocks**.
 "Container" is not a term of art in either package — it was ambiguous between the two.
 
-`crane` is kept, not invented: **file boxing** is standard digital-forensics vocabulary for
+`carver` is kept, not invented: **file boxing** is standard digital-forensics vocabulary for
 extracting structured units from a raw byte blob with no metadata to guide you. That is exactly
 library two's job. What changes is that it stops also meaning "the upload pass" — that is
-`Flush` — so `CarveChunk` becomes `crane.Chunk`.
+`Flush` — so `CarveChunk` becomes `carver.Chunk`.
 
 Renames implied: `CarveOptions`/`CarveResult` -> gone (`FlushOptions`, and the result is what
 `fn` returns) - `SetCarveTargets` -> gone - `carveMu` -> `flushMu` - `CarveBlockSize` ->
-`crane.Options.BlockSize` - `CarveMaxAge`/`CarveUploadConcurrency` -> `FlushOptions` -
+`carver.Options.BlockSize` - `CarveMaxAge`/`CarveUploadConcurrency` -> `FlushOptions` -
 engine `carvePass` -> `flushPass`.
 
 ### 5.1 Topology — four packages, promoted to modules only on publication
 
 ```
-pier    — stages bytes locally, crash-safe. Knows nothing of chunking, hashing, uploads
+journal    — stages bytes locally, crash-safe. Knows nothing of chunking, hashing, uploads
           or manifests. Chunk-agnostic by requirement: a consumer may ingest blobs it
           never chunks.
           deps: stdlib + golang.org/x/sys
 
-crane   — cuts blocks out of a blob: content-defined chunk boundaries plus accumulation
-          into BlockSize blocks. OPTIONAL companion to pier.
+carver   — cuts blocks out of a blob: content-defined chunk boundaries plus accumulation
+          into BlockSize blocks. OPTIONAL companion to journal.
           deps: stdlib
 
-ferry   — moves blocks BOTH WAYS: Put (bounded/adaptive concurrency, retry, ORDERED
+syncer   — moves blocks BOTH WAYS: Put (bounded/adaptive concurrency, retry, ORDERED
           COMPLETION REPORTING, backpressure, remote-health) and Get/GetRange, which is
-          what feeds pier.Fill on a cold read. A ship sails away; a ferry returns — and
+          what feeds journal.Fill on a cold read. A ship sails away; a syncer returns — and
           the return trip is the cold-read path that has had three bugs in it.
           deps: stdlib (the remote itself is an injected interface)
 
-          Named `ferry` (what lifts containers from the pier onto the ship) rather than
-          `syncer`, because `pier.Sync` already means fsync. pier.Sync = durable HERE;
-          ferry.Upload = durable THERE. No collision.
+          Named `syncer` (what lifts containers from the journal onto the ship) rather than
+          `syncer`, because `journal.Sync` already means fsync. journal.Sync = durable HERE;
+          syncer.Upload = durable THERE. No collision.
 
 dittofs — policy only: dedup oracle, what a block means, manifest rows, scheduling.
-          deps: pier + crane + ferry + pkg/metadata + pkg/block/remote
+          deps: journal + carver + syncer + pkg/metadata + pkg/block/remote
 ```
 
 **Chunking is optional by construction, not by configuration.** `Flush` hands the caller a `Run`
 — bytes plus an extent — and what becomes of those bytes is entirely the caller's. A consumer who
 wants content-defined dedup imports `fastcdc`; a consumer who wants to `PUT` each run as one
-object named by its offset imports nothing extra and writes four lines. Verified: after crane
-moves out, pier's only chunker references are `Config.ChunkParams` (crane config, leaves with it)
+object named by its offset imports nothing extra and writes four lines. Verified: after carver
+moves out, journal's only chunker references are `Config.ChunkParams` (carver config, leaves with it)
 and one arbitrary pool-sizing constant at `index.go:373` that becomes a local number.
 
-**Why `fastcdc` is its own module rather than a pier subpackage or in-tree with crane:**
+**Why `fastcdc` is its own module rather than a journal subpackage or in-tree with carver:**
 
-1. **Chunk boundaries are a compatibility surface.** Two pier users who chunk differently cannot
-   share a dedup pool. Publishing the boundary definition alongside pier is what makes interop
+1. **Chunk boundaries are a compatibility surface.** Two journal users who chunk differently cannot
+   share a dedup pool. Publishing the boundary definition alongside journal is what makes interop
    possible at all; withholding it guarantees fragmentation.
 2. **Different compatibility guarantees, therefore different semver.** The masks are pinned
    forever — `params.go`'s `#1569` note records that changing them re-chunks all existing data.
-   That makes it a *format*. pier is an API and will evolve. Coupling their versions forces a
-   choice between freezing pier and breaking dedup.
+   That makes it a *format*. journal is an API and will evolve. Coupling their versions forces a
+   choice between freezing journal and breaking dedup.
 3. **It is already a library in everything but distribution** — 216 non-test LOC, **zero
    non-stdlib imports**, 94.2% coverage, a clean contract (`Chunker`, `Params`, `Next`,
    `Validate`). The cheapest module in the tree to publish.
@@ -510,27 +512,27 @@ and one arbitrary pool-sizing constant at `index.go:373` that becomes a local nu
    why it composes with pooled arenas. Every published Go FastCDC alternative
    (`jotfs/fastcdc-go`, `tigerwill90/fastcdc`) wraps a reader and allocates.
 
-**`ferry` resolves a structural oddity, it does not invent one.** Recon cleared
+**`syncer` resolves a structural oddity, it does not invent one.** Recon cleared
 `pkg/block/engine/carve_dispatch.go` (parallelises across files) and
 `pkg/block/journal/carve_dispatch.go` (overlaps blocks within one file) as "complementary, not
 duplicates". True but incurious: they are two halves of an upload scheduler that has no home.
-`ferry` is that home, and merging them is the point.
+`syncer` is that home, and merging them is the point.
 
-**The dead `RemoteStore` is ferry's contract.** §6 records `journal.RemoteStore{PutBlock,
+**The dead `RemoteStore` is syncer's contract.** §6 records `journal.RemoteStore{PutBlock,
 GetBlock, GetRange}` as entirely dead — never implemented, never read, the one production call
 site passes `nil`. It was not a fossil of a design that was abandoned. It was **in the wrong
-package**: it is precisely the interface `ferry` injects. Finding its true owner is corroboration
+package**: it is precisely the interface `syncer` injects. Finding its true owner is corroboration
 for this topology, not a coincidence.
 
-**Ordered completion is why ferry is separate rather than folded into crane.** pier can only flip
+**Ordered completion is why syncer is separate rather than folded into carver.** journal can only flip
 in watermark order if something reports what completed and in what sequence. That reporting is
-ferry's contract with pier, and it is the reason the two carve_dispatch files exist at all.
+syncer's contract with journal, and it is the reason the two carve_dispatch files exist at all.
 
-**The crane is not a library and must never become one.** What to upload, when, how to pack it,
-and how to reconcile the manifest are all DittoFS decisions. Crane is the thing being *removed*
+**The carver is not a library and must never become one.** What to upload, when, how to pack it,
+and how to reconcile the manifest are all DittoFS decisions. Carver is the thing being *removed*
 from the library, not extracted beside it.
 
-**Naming asymmetry, deliberate.** `pier` is coined because it is a novel component nobody
+**Naming asymmetry, deliberate.** `journal` is coined because it is a novel component nobody
 searches for by algorithm — the name's job is to be memorable and unclaimed. `fastcdc` should be
 **descriptive**, because people searching for this will type "go fastcdc" and a themed name
 (`crate`, `bale`, `stow`, `parcel`) would be invisible to them. Discoverability wins where the
@@ -538,9 +540,9 @@ thing is a known algorithm; distinctiveness wins where it is not.
 
 ## 6. Code and folder structure
 
-### 6.1 pier stays ONE Go package — a justified exception
+### 6.1 journal stays ONE Go package — a justified exception
 
-CLAUDE.md prefers "subpackage over underscore filenames". pier is the exception, and the reason
+CLAUDE.md prefers "subpackage over underscore filenames". journal is the exception, and the reason
 is mechanical: `Store` methods touch `shard.mu`, `fileIndex.ivs` and `segmentMeta.fd` throughout
 (`carve.go` alone: 28 `fi.ivs`, 20 `sh.mu`). A `segment/`, `index/` or `cold/` subpackage forces
 exporting every one of those internals, which is strictly worse than the file-length problem it
@@ -559,9 +561,9 @@ disk" finds it in no file whose name suggests writing.
 ### 6.2 Target layout
 
 ```
-pier/
+journal/
   doc.go            the metaphor, the state model, the invariants
-  pier.go           Cache, Config, Stats, State, Extent, errors — the public vocabulary
+  journal.go           Cache, Config, Stats, State, Extent, errors — the public vocabulary
   open.go           Open, Close, background loops
   write.go          WriteAt, Fill, appendRecord, tombstone + truncate markers   [was segment.go]
   read.go           ReadAt, verifiedRead, Size, Extents, DurableExtent          [was index.go]
@@ -578,43 +580,57 @@ pier/
   format.go         the on-disk format stamp
   internal/wire/    record framing codec — pure, no Store                   [was record.go]
   internal/fsutil/  statfs_unix.go, statfs_windows.go, fsyncDir
-  piertest/         exported conformance suite (mirrors pkg/metadata/storetest)
+  journaltest/         exported conformance suite (mirrors pkg/metadata/storetest)
   example_test.go   godoc-surfaced usage
   README.md
 
-crane/
+carver/             ABSORBS today's pkg/block/chunker — see note below
   doc.go            "FastCDC content-defined chunking" in line one, for searchability
-  crane.go          Boxer, Options — cuts a blob into BlockSize blocks
-  chunker.go        FastCDC boundary finding
-  gear.go           the gear table
-  params.go         Params, Validate, DefaultParams — THE FORMAT; masks pinned (#1569)
+  carver.go         Carver, Options — FastCDC chunks, accumulated into BlockSize blocks
+  chunker.go        FastCDC boundary finding                    [moved from pkg/block/chunker]
+  gear.go           the gear table                              [moved]
+  params.go         Params, Validate, DefaultParams — THE FORMAT; masks pinned (#1569)  [moved]
   README.md
 
-ferry/
+syncer/
   doc.go
-  ferry.go          Ferry, Options, Upload, ordered completion reporting
+  syncer.go         Syncer, Options, Upload, ordered completion reporting
   window.go         adaptive concurrency window                    [was engine/carve_dispatch.go]
   retry.go          backoff; safe by construction — content-addressed PUTs are idempotent
   remote.go         the injected remote interface  [journal.RemoteStore, finally in the right package]
   README.md
 
 dittofs/pkg/block/engine/
-                    orchestration only: schedules Flush, wires crane + ferry,
+                    orchestration only: schedules Flush, wires carver + syncer,
                     owns the dedup oracle and the manifest.
 ```
+
+**`pkg/block/chunker` folds into `carver` rather than surviving beside it.** It is already
+FastCDC boundary finding plus the gear table plus `Params` — exactly the three files listed
+under `carver/` — so keeping both would mean two packages for one job, and `Params` is a format
+contract that should sit with the code that carves by it. Ten files import `chunker` today, so
+the move is mechanical but not free; do it as part of the carver extraction, not before.
+
+**Sizing note, measured after this plan was written.** `Carve` is CPU-bound, but the leading
+term is neither chunking nor hashing: on an EPYC 7543, 53% of carve CPU is large-buffer
+allocation and zeroing under `packRuns` (the arena, plus the per-record read buffers in
+`readVerifiedRecord`/`readRecordAt`), against 23% BLAKE3 and 13% FastCDC. Pooling those buffers
+needs no format change and no dedup trade, and is worth roughly four times what removing
+content-defined chunking would buy. `carve.go:23` already carries a `ponytail:` marker on the
+buffer sizing.
 
 ### 6.3 What this closes
 
 | Problem today | Closed by |
 |---|---|
-| `store.go` 1297 lines, 8-9 responsibilities | `pier.go` + `open.go` + `write.go` + `read.go` + `restore.go` |
+| `store.go` 1297 lines, 8-9 responsibilities | `journal.go` + `open.go` + `write.go` + `read.go` + `restore.go` |
 | `reclaim.go` 999 lines, two policies + shared tail | `evict.go` + `compact.go` + `retire.go` |
 | `carve.go` 995 lines, gocyclo 35 | `flush.go` (fence + flip only) — chunking and packing leave |
 | `segment.go` / `index.go` hold the hot paths their names disown | `write.go` / `read.go` |
 | `carve_pack.go` — 37 lines, no independent identity | merged into `flush.go` |
 | `coldstats.go` vs `cold.go` — confusing adjacency, one method | merged into `cold.go` |
-| Two files named `carve_dispatch.go` in different packages | one `ferry/window.go` |
-| Six near-duplicate test store-openers | one options-taking harness in `piertest/` |
+| Two files named `carve_dispatch.go` in different packages | one `syncer/window.go` |
+| Six near-duplicate test store-openers | one options-taking harness in `journaltest/` |
 
 `recover.go` keeps its current shape deliberately: `recoveryState`'s phased-builder is the best
 structure in the package and is the template for anything else here that grows multi-phase.
@@ -624,19 +640,19 @@ structure in the package and is the template for anything else here that grows m
 Each is designed to stand alone as its own OSS repository: no import of the others except
 where stated, no host-app types in a signature, and a contract a stranger can implement against.
 
-### 7.1 pier — the write-back cache over append blobs
+### 7.1 journal — the write-back cache over append blobs
 
 Full surface in §4. One-line contract: **stages byte ranges for many blobs on local disk,
 crash-safely, and always knows which of its bytes have sailed, which have not, and which are
-gone.** Imports nothing from crane or ferry — it never learns what a block is.
+gone.** Imports nothing from carver or syncer — it never learns what a block is.
 
-### 7.2 crane — content-defined, content-addressed block assembly
+### 7.2 carver — content-defined, content-addressed block assembly
 
-Takes a pier-shaped append blob and carves content-addressed blocks out of it: FastCDC
+Takes a journal-shaped append blob and carves content-addressed blocks out of it: FastCDC
 boundaries, BLAKE3-256 identity, accumulation to `BlockSize`.
 
 ```go
-package crane // FastCDC content-defined chunking with BLAKE3 content addressing
+package carver // FastCDC content-defined chunking with BLAKE3 content addressing
 
 type Hash [32]byte // BLAKE3-256 of the chunk's plaintext
 
@@ -661,10 +677,10 @@ type Options struct {
     Skip func(Hash) (bool, error)
 }
 
-func New(o Options) *Boxer
+func New(o Options) *Carver
 // Box consumes data at off and returns whatever complete Blocks it can. It buffers
 // across calls; final drains the remainder. Allocation-free on the boundary path.
-func (b *Boxer) Box(data []byte, off int64, final bool) (blocks []Block, consumed int, err error)
+func (b *Carver) Box(data []byte, off int64, final bool) (blocks []Block, consumed int, err error)
 
 type Params struct{ Min, Avg, Max int }
 func DefaultParams() Params
@@ -672,49 +688,49 @@ func (p Params) Validate() error
 ```
 
 **`Skip` is how dedup enters without the oracle entering.** DittoFS supplies a closure over its
-synced-hash store; a standalone consumer passes nil. crane never learns what a metadata store is.
+synced-hash store; a standalone consumer passes nil. carver never learns what a metadata store is.
 
 **`Params` is a FORMAT, not a tuning knob.** The masks are pinned (`#1569`: changing them
 re-chunks all existing data). Semver it as a format: a `Params` change is a major version.
 
-### 7.3 ferry — moving blocks to and from a block store
+### 7.3 syncer — moving blocks to and from a block store
 
 ```go
-package ferry // bounded, retried, order-reporting transport for immutable blocks
+package syncer // bounded, retried, order-reporting transport for immutable blocks
 
 type BlockID string
 
 // Store is the injected backend. S3 is one implementation; a filesystem, GCS, or an
-// in-memory map are others. ferry imports no cloud SDK.
+// in-memory map are others. syncer imports no cloud SDK.
 type Store interface {
     Put(ctx context.Context, id BlockID, r io.Reader, size int64) error
     Get(ctx context.Context, id BlockID) (io.ReadCloser, error)
     GetRange(ctx context.Context, id BlockID, off, n int64) (io.ReadCloser, error)
 }
 
-func New(s Store, o Options) *Ferry
+func New(s Store, o Options) *Syncer
 
 // Put and Get are the synchronous forms.
-func (f *Ferry) Put(ctx context.Context, id BlockID, data []byte) error
-func (f *Ferry) Get(ctx context.Context, id BlockID, off, n int64) (io.ReadCloser, error)
+func (f *Syncer) Put(ctx context.Context, id BlockID, data []byte) error
+func (f *Syncer) Get(ctx context.Context, id BlockID, off, n int64) (io.ReadCloser, error)
 
 // Submit queues an upload and returns a future for THAT CALL ONLY. Uploads overlap
 // up to the adaptive window; the caller waits on futures in submission order, which
-// is what lets pier flip its watermark safely.
+// is what lets journal flip its watermark safely.
 //
 // There is deliberately NO shared Completions() channel. Go delivers each message to
 // exactly one receiver, Submit carries no FileID, and many files flush concurrently
 // (engine/carve_dispatch.go:91-127) — so a shared stream routes one file's completion
 // to another file's callback, silently losing durability credit. Per-call futures make
 // that unrepresentable, and mirror journal/carve_dispatch.go:109-114's prev/mine chain.
-func (f *Ferry) Submit(ctx context.Context, id BlockID, data []byte) (<-chan Completion, error)
+func (f *Syncer) Submit(ctx context.Context, id BlockID, data []byte) (<-chan Completion, error)
 type Completion struct { Err error }
 
 // A window slot is released when the upload RESOLVES — success, exhausted retries, or
 // cancellation — independent of whether anyone reads the returned future. Otherwise a
 // caller blocked in Submit could never free the slot it is waiting for.
 
-func (f *Ferry) Health() Health // drives pier.SetEvictionEnabled when the remote degrades
+func (f *Syncer) Health() Health // drives journal.SetEvictionEnabled when the remote degrades
 
 type Options struct {
     MaxConcurrent int           // 0 = adaptive
@@ -723,18 +739,18 @@ type Options struct {
 }
 ```
 
-**Ordered completion is why ferry is a module and not a helper.** pier can only flip in
+**Ordered completion is why syncer is a module and not a helper.** journal can only flip in
 watermark order if something reports what completed and in what sequence; that reporting is the
 contract between them, and it is why two files named `carve_dispatch.go` exist today in two
 different packages.
 
-**ferry owns the interface that was dead in journal.** `journal.RemoteStore{PutBlock, GetBlock,
+**syncer owns the interface that was dead in journal.** `journal.RemoteStore{PutBlock, GetBlock,
 GetRange}` — never implemented, never read, `nil` at its one production call site — is
-`ferry.Store`. It was not an abandoned design; it was in the wrong package.
+`syncer.Store`. It was not an abandoned design; it was in the wrong package.
 
 ### 7.4 What each may import
 
-| | pier | crane | ferry |
+| | journal | carver | syncer |
 |---|---|---|---|
 | stdlib | yes | yes | yes |
 | `golang.org/x/sys` | yes (statfs) | no | no |
@@ -792,13 +808,13 @@ fails**. Two contracts exist, one declared and one informal.
 
 ## 9. Standalone test contract
 
-**Requirement: `pier`'s test suite must pass with zero imports outside stdlib + `golang.org/x/sys`.**
+**Requirement: `journal`'s test suite must pass with zero imports outside stdlib + `golang.org/x/sys`.**
 Not as a policy — as a test.
 
 ### 8.1 The enforcing mechanism
 
 ```go
-// TestNoForeignImports fails if pier's non-test OR test files import anything
+// TestNoForeignImports fails if journal's non-test OR test files import anything
 // outside the standard library and golang.org/x/sys.
 func TestNoForeignImports(t *testing.T) {
     // go/build is STDLIB and reports Imports + TestImports for a directory.
@@ -821,8 +837,8 @@ Today's violations, all removable:
 |---|---|---|
 | `internal/logger` | `cold.go`, `reclaim.go`, `recovery.go`, `store.go` (11 `Warn` sites) | `Config.Logger *slog.Logger`, nil = discard |
 | `pkg/block` | `format.go` (`ErrFutureFormat`, 2 uses) | package-local sentinel |
-| `pkg/block/chunker` | `carve.go`, `store.go`, `index.go:373` | leaves with crane; `index.go:373` becomes a local const |
-| `lukechampine.com/blake3` | `carve.go:558` (one call) | leaves with crane |
+| `pkg/block/chunker` | `carve.go`, `store.go`, `index.go:373` | leaves with carver; `index.go:373` becomes a local const |
+| `lukechampine.com/blake3` | `carve.go:558` (one call) | leaves with carver |
 | `badgerstore` (**test**) | `carve_pack_test.go:11`, used only by `BenchmarkCarveScatteredPass` | latency-injecting fake `Deduper`; the real-Badger measurement belongs in DittoFS's suite, not the library's |
 
 ### 8.2 Coverage gaps to close
@@ -847,7 +863,7 @@ trusted.** A test that passes on unmodified code proves nothing about the bug it
    `carveStore`, `evictStore`, `ctrlStore`, `openDirtyExpireStore`, `benchStore` — each
    re-implementing `Open(t.TempDir(), cfg, fakes) + Cleanup`. Replace with one options-taking
    helper.
-2. **`piertest` conformance suite**, exported, mirroring this repo's own convention
+2. **`journaltest` conformance suite**, exported, mirroring this repo's own convention
    (`pkg/metadata/storetest`, `pkg/block/blockstoretest`). Lets a consumer validate a fake, and
    lets a second implementation exist at all.
 3. **Property/model test for the interval index.** `fileIndex.insert`/`plan` is the algorithmic
@@ -913,27 +929,33 @@ Rules:
 
 ## 11. Open decisions
 
-1. **Name — DECIDED: `pier`.** One syllable, unambiguous to spell, no collision anywhere in
-   the tree, and it follows the coined-name convention of Go storage libraries (`bolt`,
-   `badger`, `pebble`, `pogreb`, `moss`).
+1. **Names — DECIDED: keep the ones the tree already has.** `journal`, `carver`, `syncer`,
+   `engine`. The split introduces no new vocabulary at all.
 
-   **The metaphor, which is load-bearing:** bytes park in a *container* on the *pier* until a
-   *boat* carries them out to the object store. A pier is definitionally a waiting place, never
-   a destination — which is exactly the thing this component must never be confused about, and
-   exactly what every bug in §2 got wrong. The metaphor is also bidirectional, matching the
-   real data flow: goods stage on a pier before loading (`Flush`) and land on it after
-   unloading (`Fill`).
+   Three of the four are already in the codebase and already mean this: `pkg/block/journal` is
+   the package being reorganised; `carve` is the verb at every call site (`carve.go`,
+   `CarveChunk`, `carveMu`, two `carve_dispatch.go`); `engine/syncer.go` already declares
+   `type Syncer`, which today owns both transport *and* carve dispatch — the split narrows it to
+   transport, so the name becomes accurate rather than merely inherited. `engine` is where the
+   three are composed and is already exactly that.
 
-   It also makes the `Sync`/`Flush` pair intuitive rather than merely conventional: `Sync`
-   bolts the container down so a storm cannot take it (durable locally); `Flush` puts it on the
-   boat (durable remotely). Two different guarantees, two different words, one picture.
+   `journal` also matches the on-disk format stamp, `"DFSJRN1\0"` (`segment.go:18`). Renaming
+   the package would either desynchronise the name from the magic or force a format change for
+   cosmetic reasons.
 
-   Rejected: `blockcache` — `block` is the most overloaded word in the tree (`pkg/block`,
-   `block.Store`, `BlockSink`, `BlockID`, `blockcodec`), and a DB "block cache" is a
-   fixed-size-page buffer pool, which this is not. `journal` — in filesystems that means a
-   metadata write-ahead log for crash consistency; this is the data store itself, and the
-   misnomer is part of why `GC` was read as touching remote refcounts. Also considered:
-   `blobcache`, `rangecache`, `seglog`, `molo`, `rada`, `hopper`, `sluice`, `till`, `scree`.
+   **The objection, recorded rather than resolved:** in filesystem usage "journal" means a
+   metadata write-ahead log for crash consistency, and this is the data store itself. That
+   misnomer is part of why `GC` was once read as touching remote refcounts. It is accepted here
+   because the package already carries the name — the misnomer exists whatever this plan says —
+   and because a rename buys clarity only at the cost of the format stamp and every existing
+   reference.
+
+   Rejected: a coined nautical set (`pier`/`crane`/`ferry`/`harbour`), which was the earlier
+   decision. It reads well and the staging metaphor is genuinely apt, but it introduces four new
+   words for packages that already have names, and the clarity does not pay for the churn.
+   `blockcache` — `block` is the most overloaded word in the tree (`pkg/block`, `block.Store`,
+   `BlockSink`, `BlockID`, `blockcodec`), and a DB "block cache" is a fixed-size-page buffer
+   pool, which this is not.
 
    **TODO before any public release:** verify the module path is free on `pkg.go.dev` and the
    proxy. Not checked as of this writing.
@@ -982,11 +1004,11 @@ currently describes "the journal" and its "carve pass"; both words are being ret
 
 | File | What changes |
 |---|---|
-| `docs/internals/architecture.md:245-330` | The "Block Store — Local Journal Tier" section. It explicitly defers to the package doc comment as authoritative, so it inherits every drift — rewrite as the four-part model (pier / crane / ferry / orchestration) with the data-flow diagram from §5.0. |
-| `docs/guide/durability.md` | fsync semantics and the loss window. Should now be able to state exposure exactly (`Sync` = durable here, `ferry.Put` = durable there) instead of describing it prose-wise. |
+| `docs/internals/architecture.md:245-330` | The "Block Store — Local Journal Tier" section. It explicitly defers to the package doc comment as authoritative, so it inherits every drift — rewrite as the four-part model (journal / carver / syncer / orchestration) with the data-flow diagram from §5.0. |
+| `docs/guide/durability.md` | fsync semantics and the loss window. Should now be able to state exposure exactly (`Sync` = durable here, `syncer.Put` = durable there) instead of describing it prose-wise. |
 | `docs/guide/configuration.md:298-325` | Journal-as-substrate-of-`fs`, plus the vestigial pre-journal knobs it already flags (`use_append_log`, `rollup_workers`, `stabilization_ms`, `orphan_log_min_age_seconds`). Delete the vestigial ones or say plainly that they do nothing. |
-| `docs/internals/implementing-stores.md:311-490` | Points implementers at `pkg/block/journal/` as the model to study. Repoint at pier, and at `piertest/` as the conformance suite they must pass. |
-| `docs/guide/snapshots.md:505` | Snapshot/restore now rests on `pier.Version`/`Pin`/`Restore`. |
+| `docs/internals/implementing-stores.md:311-490` | Points implementers at `pkg/block/journal/` as the model to study. Repoint at journal, and at `journaltest/` as the conformance suite they must pass. |
+| `docs/guide/snapshots.md:505` | Snapshot/restore now rests on `journal.Version`/`Pin`/`Restore`. |
 | `docs/guide/block-store-migration.md:22-31` | Tier vocabulary. |
 | `docs/guide/faq.md` | Known limitations — add the §12 gaps (no degraded write-through, no background scrub) so they are stated rather than discovered. |
 | `docs/BENCHMARKS.md` | Three journal mentions; repoint at the §10 benchmark set. |
@@ -994,9 +1016,9 @@ currently describes "the journal" and its "carve pass"; both words are being ret
 | `CLAUDE.md` | The Architecture-invariants section names the journal and its rules. Invariants 4, 5 and 6 change shape. |
 | `README.md` | If the feature matrix or architecture summary names the journal. |
 
-**Three READMEs that do not exist yet** — `pier/`, `crane/`, `ferry/`. Each is the front door of
+**Three READMEs that do not exist yet** — `journal/`, `carver/`, `syncer/`. Each is the front door of
 a would-be OSS repo, so each needs: what it is in one sentence, the model, a runnable example,
-the guarantees it makes, and the guarantees it explicitly does NOT make. pier's should lead with
+the guarantees it makes, and the guarantees it explicitly does NOT make. journal's should lead with
 exposure accounting (`DurableExtent`), which is its best idea and the thing the field lacks.
 
 **Do NOT rewrite** `.planning/**` — those are historical records of decisions taken under the
@@ -1017,16 +1039,16 @@ Captured so they are not lost while the audit's verify gate and the second seam 
 
 ### P1. Test and benchmark contracts apply to ALL THREE libraries
 
-§9 and §10 currently specify pier only. Each library ships its own suite and its own benchmarks,
+§9 and §10 currently specify journal only. Each library ships its own suite and its own benchmarks,
 because each is a candidate OSS repo:
 
-- **pier** — as specified in §9/§10.
-- **crane** — correctness: boundary stability across buffer splits (the same blob chunked in one
+- **journal** — as specified in §9/§10.
+- **carver** — correctness: boundary stability across buffer splits (the same blob chunked in one
   call vs. many must produce identical boundaries — this is the property that makes dedup work at
   all), `Params` validation, `Skip` behaviour, block accumulation to `BlockSize`, `final` drain.
   Benchmarks: throughput per MiB, allocations per block (target: zero on the boundary path),
   and boundary-shift resistance under insertion.
-- **ferry** — correctness: ordered completion under concurrency, retry/backoff, partial failure,
+- **syncer** — correctness: ordered completion under concurrency, retry/backoff, partial failure,
   cancellation, health transitions. Benchmarks: throughput vs. window size, latency
   distribution, and behaviour under an injected-latency `Store` (no cloud SDK in the test path).
 

--- a/docs/internals/rfc-block-dataflow.md
+++ b/docs/internals/rfc-block-dataflow.md
@@ -1,9 +1,9 @@
-# RFC: splitting the block data flow into pier, crane and ferry
+# RFC: splitting the block data flow into journal, carver and syncer
 
 **Status:** proposed, open for comment. Nothing here is built.
 **Discussion:** https://github.com/marmos91/dittofs/discussions/2234
 **Detail:** `.planning/2026-09-01-block-dataflow-MASTER-PLAN.md` (plan),
-`.planning/2026-09-01-pier-library-design-PLAN.md` (design),
+`.planning/2026-09-01-journal-library-design-PLAN.md` (design),
 `.planning/2026-09-01-journal-audit-report.md`, `-engine-audit-report.md` and
 `-block-root-audit-report.md` (196 verified findings across the three).
 
@@ -87,14 +87,14 @@ not a guard someone remembered to add.
 ## 3. Three libraries
 
 ```
-pier    — stages bytes locally, crash-safe. Chunk-agnostic: you can ingest blobs you
+journal    — stages bytes locally, crash-safe. Chunk-agnostic: you can ingest blobs you
           never chunk. deps: stdlib + golang.org/x/sys
 
-crane   — cuts content-addressed blocks out of a blob: FastCDC boundaries, BLAKE3
+carver   — cuts content-addressed blocks out of a blob: FastCDC boundaries, BLAKE3
           identity, accumulation to BlockSize. OPTIONAL. deps: stdlib
 
-ferry   — moves blocks BOTH WAYS: Put (bounded concurrency, retry, ordered completion
-          reporting) and Get/GetRange, which feeds pier.Fill on a cold read.
+syncer   — moves blocks BOTH WAYS: Put (bounded concurrency, retry, ordered completion
+          reporting) and Get/GetRange, which feeds journal.Fill on a cold read.
           deps: stdlib — the block store itself is injected
 
 dittofs — orchestration and policy: dedup oracle, manifest rows, scheduling.
@@ -104,24 +104,24 @@ Data flow — **note the return edge, which is the crash-safety-critical one:**
 
 ```
 WRITE                                                    ack ────┐
-  NFS/SMB ──► pier.WriteAt ──► staged locally, StateDirty ───────┘
+  NFS/SMB ──► journal.WriteAt ──► staged locally, StateDirty ───────┘
 
-FLUSH  (dittofs schedules; pier offers, dittofs disposes)
-  pier.Flush(id, fn) ──► offers dirty runs ──► fn:
-                                                crane.Box   cut blocks
-                                                ferry.Put   upload
+FLUSH  (dittofs schedules; journal offers, dittofs disposes)
+  journal.Flush(id, fn) ──► offers dirty runs ──► fn:
+                                                carver.Box   cut blocks
+                                                syncer.Put   upload
                                                 dittofs     commit manifest rows
                           ◄── returns durable []Extent ──────────┘
-  pier flips exactly those ──► StateResident        ← THE INVARIANT LIVES HERE
+  journal flips exactly those ──► StateResident        ← THE INVARIANT LIVES HERE
 
 READ
-  NFS/SMB ──► pier.ReadAt ──► (n, fetch []Extent)
+  NFS/SMB ──► journal.ReadAt ──► (n, fetch []Extent)
                  fetch non-empty ──► dittofs resolves manifest
-                                  ──► ferry.Get
-                                  ──► pier.Fill ──► StateResident ──► re-read
+                                  ──► syncer.Get
+                                  ──► journal.Fill ──► StateResident ──► re-read
 ```
 
-Nothing reaches `StateResident` except by pier being **told** what became durable. `Flush` is a
+Nothing reaches `StateResident` except by journal being **told** what became durable. `Flush` is a
 callback rather than a pipeline stage because a linear `write → carve → sync` has nowhere to put
 that acknowledgement — and dropping it is the #1872 family.
 
@@ -135,7 +135,7 @@ records: **541 occurrences across 60 non-test files**. The smear is visible in t
 |---|---|
 | **write** | stage bytes locally and acknowledge the client |
 | **sync** | make durable HERE (fsync) |
-| **flush** | pier's pass: offer dirty runs, accept durability reports |
+| **flush** | journal's pass: offer dirty runs, accept durability reports |
 | **chunk** | find one content-defined boundary |
 | **box** | group chunks into one block |
 | **put** / **get** | make durable THERE / bring it back |
@@ -161,22 +161,22 @@ hold.
 `local.LocalStore` (18 methods) and an informal one reached by embedding `*journal.Store` and by
 unexported structural interfaces (`restorer`, `pinner`, `versioner`, `coldSeeder`,
 `coldRangeReporter`, `coldSeedTracker`). Those assertions **no-op silently on failure** — a
-rename inside pier would quietly disable snapshot pinning rather than break the build. After the
+rename inside journal would quietly disable snapshot pinning rather than break the build. After the
 split, only the construction site may name the concrete type; everything else holds a declared
 interface, so a missing capability is a compile error.
 
 ## 6. Plan
 
-**Order: ferry → crane → pier**, reverse of the data flow. Steps 1 and 2 are
+**Order: syncer → carver → journal**, reverse of the data flow. Steps 1 and 2 are
 behaviour-preserving — no format change, no state-model change — so all semantic risk lands in
 step 3, taken last.
 
 | Step | What | Risk |
 |---|---|---|
 | **0** | Fix #2227-#2231 and #2238 with regression tests first | live bugs, unblocks everything |
-| **1** | ferry — upload transport, ordered completion | behaviour-preserving |
-| **2** | crane — chunking + block assembly | behaviour-preserving |
-| **3** | pier — the seam inversion and state model | the real change |
+| **1** | syncer — upload transport, ordered completion | behaviour-preserving |
+| **2** | carver — chunking + block assembly | behaviour-preserving |
+| **3** | journal — the seam inversion and state model | the real change |
 | **4** | legacy cleanup across the data flow | separate workstream |
 
 Green bar for every step: unit + race + E2E green, **crash rigs green on both the old and the new
@@ -190,11 +190,11 @@ The parts most likely to be wrong, and where comment is most useful:
 
 1. **The `Flush` callback seam** (§4 of the design plan). It has already been redesigned twice
    under adversarial review — v1 could not express blocks spanning multiple dirty runs; v2 put
-   block accumulation in pier, which is impossible because block boundaries are chunk boundaries
-   and pier is chunk-agnostic. v3.1 is the current form. It may still be wrong.
+   block accumulation in journal, which is impossible because block boundaries are chunk boundaries
+   and journal is chunk-agnostic. v3.1 is the current form. It may still be wrong.
 2. **Collapsing five extent queries into `Extents()`.** `Size` and `DurableExtent` were pulled
    back out after review showed the durable-frontier walk is not derivable from a flat slice.
    The remainder still needs a benchmark to defend it.
-3. **Whether `RestoreToVersion` belongs in pier at all** — 180 lines, gocyclo 37, zero tests,
+3. **Whether `RestoreToVersion` belongs in journal at all** — 180 lines, gocyclo 37, zero tests,
    three of the five HIGH findings.
 4. **Anything in the 117 LOW findings** you think is actually a MED or HIGH.

--- a/pkg/block/journal/transition_bench_test.go
+++ b/pkg/block/journal/transition_bench_test.go
@@ -345,7 +345,7 @@ func BenchmarkDelete(b *testing.B) {
 }
 
 // The four residency queries below are the receipts for the merged Extents
-// query the pier design proposes. Collapsing them into one slice-returning call
+// query the design plan proposes. Collapsing them into one slice-returning call
 // is that design's biggest performance risk — ColdExtents is O(live intervals)
 // across every shard — so the before-numbers have to exist on the same hardware
 // before the after-numbers mean anything. Recorded now; compared when Extents


### PR DESCRIPTION
Renames the planned block data-flow split from `pier`/`crane`/`ferry`/`harbour` to **`journal` / `carver` / `syncer` / `engine`**, across the RFC and both planning docs.

## Why

Three of the four packages already exist under good names, and the fourth is the verb used at every call site. The split now introduces **no new vocabulary at all**:

| was | now | already in the tree as |
|---|---|---|
| `pier` | `journal` | `pkg/block/journal`, and the `"DFSJRN1\0"` format stamp (`segment.go:18`) |
| `crane` | `carver` | `carve.go`, `CarveChunk`, `carveMu`, two `carve_dispatch.go` |
| `ferry` | `syncer` | `engine/syncer.go` already declares `type Syncer` |
| `harbour` | `engine` | `pkg/block/engine`, already the composition layer |

`syncer` is the interesting one: today `Syncer` owns both transport *and* carve dispatch, so the split **narrows** it and the name becomes accurate rather than merely inherited.

## What needed rewriting rather than substituting

The docs argued *for* the nautical names, so a find-and-replace would have left nonsense behind:

- **§11 decision 1** rebuilt. It previously decided `pier` and explicitly **rejected `journal`** — "in filesystems that means a metadata write-ahead log; this is the data store itself, and the misnomer is part of why `GC` was read as touching remote refcounts." That objection is **kept and recorded**, not quietly dropped: it is accepted because the package already carries the name, so the misnomer exists regardless, and renaming would desynchronise the package from its own format magic.
- **The `doc.go` metaphor** ("bytes park in a container until a boat carries them out") rewritten to state the `Sync`/`Flush` distinction directly.
- **The `harbour` rationale** in the master plan rewritten — it argued against `harbourmaster` on authority grounds, which no longer parses once the package is `engine`.

## Structural changes beyond the rename

- **`pkg/block/chunker` folds into `carver`.** It is already FastCDC + gear table + `Params` — precisely the three files the layout lists under `carver/` — so keeping both would be two packages for one job, and `Params` is a format contract that belongs with the code that carves by it. Ten files import it today; noted as mechanical but not free, to be done with the extraction.
- **A measured sizing note.** `Carve` is CPU-bound, but not where the plan implies: on an EPYC 7543, **53% of carve CPU is large-buffer allocation and zeroing** under `packRuns`, against 23% BLAKE3 and 13% FastCDC. Pooling those buffers needs no format change and no dedup trade, and is worth ~4× what removing content-defined chunking would buy. This corrects the impression left by "FastCDC plus BLAKE3 plus dedup dominate" — that phrasing omits the leading term, and `BenchmarkCarve` stubs the oracle with `missDeduper`, so it never measured dedup at all.

## Verification

`rg` for `pier|crane|ferry|harbour|piertest|cranetest|ferrytest` across the repo returns nothing. `go build ./...` and `go vet ./pkg/block/journal/` clean. The design-plan file is renamed to match the reference the RFC already carries.

Docs and one test comment only — no production code.