### PR TITLE
test(metadata): pin commits-per-operation and give metabench a postgres cell

### DIFF
--- a/pkg/metadata/commit_count_test.go
+++ b/pkg/metadata/commit_count_test.go
@@ -1,0 +1,71 @@
+package metadata_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The commit *count* per file operation is the only lever left on the postgres
+// per-commit WAL fsync: the fsync cost of a commit that promised durability
+// cannot be removed without weakening the promise, so a win has to come from
+// firing fewer such commits. These tests pin how many each leg of a
+// create + UNSTABLE WRITE + COMMIT sequence actually fires, so a claim that
+// several commits are available to collapse into one is checked against the
+// write path rather than asserted.
+//
+// The counts below are the whole answer: no leg fires more than one commit, so
+// there is no intra-operation batch to collapse. What remains is one commit per
+// distinct protocol RPC, which the store layer cannot merge because the RPCs
+// arrive separately and each must be acked before the next is sent.
+
+// TestCommitCount_DeferredWritePathFiresOneRelaxedCommitPerLeg pins the default
+// posture (deferred commits on, no writeback tier): the namespace create and
+// the deferrable flush each commit exactly once through the relaxed path, and a
+// buffered UNSTABLE WRITE commits not at all.
+func TestCommitCount_DeferredWritePathFiresOneRelaxedCommitPerLeg(t *testing.T) {
+	svc, spy, root, authCtx := newWritebackFixture(t)
+
+	spy.reset()
+	handle := createChild(t, svc, spy, authCtx, root, "f.txt")
+	createDurable, createRelaxed := spy.durable, spy.relaxed
+
+	spy.reset()
+	bufferPendingWrite(t, svc, authCtx, handle, 4096)
+	writeDurable, writeRelaxed := spy.durable, spy.relaxed
+
+	spy.reset()
+	flushed, err := svc.FlushPendingWriteForFile(authCtx, handle, false) // deferrable ack
+	require.NoError(t, err)
+	require.True(t, flushed)
+	flushDurable, flushRelaxed := spy.durable, spy.relaxed
+
+	require.Equal(t, 0, createDurable, "create is a pure namespace op: nothing data-paired to fsync")
+	require.Equal(t, 1, createRelaxed, "create must fire exactly one relaxed commit")
+
+	require.Equal(t, 0, writeDurable, "a buffered UNSTABLE WRITE must not commit")
+	require.Equal(t, 0, writeRelaxed, "a buffered UNSTABLE WRITE must not commit")
+
+	require.Equal(t, 0, flushDurable, "a deferrable flush must not take the inline durable path")
+	require.Equal(t, 1, flushRelaxed, "a deferrable flush must fire exactly one relaxed commit")
+}
+
+// TestCommitCount_DurableFlushFiresOneDurableCommit pins the FILE_SYNC leg: the
+// one commit whose fsync a client was actually promised. It is a single commit,
+// so there is nothing to coalesce with it inside the operation; collapsing it
+// with the commits of neighbouring RPCs would move the fsync behind an ack that
+// already claimed the metadata was stable.
+func TestCommitCount_DurableFlushFiresOneDurableCommit(t *testing.T) {
+	svc, spy, root, authCtx := newWritebackFixture(t)
+
+	handle := createChild(t, svc, spy, authCtx, root, "f.txt")
+	bufferPendingWrite(t, svc, authCtx, handle, 4096)
+
+	spy.reset()
+	flushed, err := svc.FlushPendingWriteForFile(authCtx, handle, true) // FILE_SYNC
+	require.NoError(t, err)
+	require.True(t, flushed)
+
+	require.Equal(t, 1, spy.durable, "a FILE_SYNC flush must fire exactly one durable commit")
+	require.Equal(t, 0, spy.relaxed, "a FILE_SYNC flush must not take the relaxed path")
+}

--- a/pkg/metadata/store/metabench/write_compare_bench_test.go
+++ b/pkg/metadata/store/metabench/write_compare_bench_test.go
@@ -15,6 +15,10 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/store/sqlite"
 )
 
+// nFiles is shared by every cell so the scatter is identical across backends;
+// a cell that seeded a different population would not be comparable.
+const nFiles = 20000
+
 // caps is the minimal filesystem-capability set every backend needs to open.
 func caps() metadata.FilesystemCapabilities {
 	return metadata.FilesystemCapabilities{
@@ -26,10 +30,14 @@ func caps() metadata.FilesystemCapabilities {
 }
 
 // backend names a metadata store the write-path comparison drives. Durability
-// is equalized to fsync-free across all three (badger SyncWrites=false, sqlite
-// WAL+synchronous=NORMAL, and — for postgres — synchronous_commit=off via the
-// relaxed path) so any gap that remains is access-pattern/round-trip/CPU, i.e.
-// design, not the disk's fsync cost.
+// is equalized to fsync-free across these two (badger SyncWrites=false, sqlite
+// WAL+synchronous=NORMAL) so any gap that remains is access-pattern/round-trip/
+// CPU, i.e. design, not the disk's fsync cost.
+//
+// Postgres is deliberately absent here: it needs a running server, so its cell
+// lives in the integration-tagged twin of this file. That cell measures the
+// opposite thing on purpose — postgres at its default synchronous_commit=on,
+// where the per-commit WAL fsync IS the subject.
 type backend struct {
 	name string
 	open func(b *testing.B) metadata.Store
@@ -66,74 +74,88 @@ func backends() []backend {
 //	  -benchtime 3s -cpuprofile /tmp/badger.prof ./pkg/metadata/store/metabench/
 //	go tool pprof -top /tmp/badger.prof
 func BenchmarkWriteCompare(b *testing.B) {
-	const nFiles = 20000
-	ctx := context.Background()
 	for _, be := range backends() {
 		b.Run(be.name, func(b *testing.B) {
-			store := be.open(b)
-			b.Cleanup(func() { _ = store.Close() })
-
-			const share = "/hot"
-			root, err := store.CreateRootDirectory(ctx, share, &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o755})
-			if err != nil {
-				b.Fatalf("CreateRootDirectory: %v", err)
-			}
-			rootHandle, err := store.GetRootHandle(ctx, share)
-			if err != nil {
-				b.Fatalf("GetRootHandle: %v", err)
-			}
-
-			handles := make([]metadata.FileHandle, nFiles)
-			for i := 0; i < nFiles; i++ {
-				name := fmt.Sprintf("f%06d", i)
-				fp := path.Join(root.Path, name)
-				h, err := store.GenerateHandle(ctx, share, fp)
-				if err != nil {
-					b.Fatalf("GenerateHandle: %v", err)
-				}
-				_, id, err := metadata.DecodeFileHandle(h)
-				if err != nil {
-					b.Fatalf("DecodeFileHandle: %v", err)
-				}
-				f := &metadata.File{
-					ShareName: share, Path: fp, ID: id,
-					FileAttr: metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644, UID: 1000, GID: 1000},
-				}
-				if err := store.UpdateAttrs(ctx, f); err != nil {
-					b.Fatalf("UpdateAttrs seed: %v", err)
-				}
-				if err := store.SetParent(ctx, h, rootHandle); err != nil {
-					b.Fatalf("SetParent: %v", err)
-				}
-				if err := store.SetChild(ctx, rootHandle, name, h); err != nil {
-					b.Fatalf("SetChild: %v", err)
-				}
-				handles[i] = h
-			}
-
-			var ops int64
-			b.ResetTimer()
-			b.RunParallel(func(pb *testing.PB) {
-				rng := rand.New(rand.NewSource(rand.Int63()))
-				for pb.Next() {
-					h := handles[rng.Intn(nFiles)]
-					if err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
-						f, err := tx.GetFile(ctx, h)
-						if err != nil {
-							return err
-						}
-						f.Mtime = time.Now()
-						return tx.UpdateAttrs(ctx, f)
-					}); err != nil {
-						b.Fatalf("write txn: %v", err)
-					}
-					atomic.AddInt64(&ops, 1)
-				}
-			})
-			b.StopTimer()
-			if secs := b.Elapsed().Seconds(); secs > 0 {
-				b.ReportMetric(float64(atomic.LoadInt64(&ops))/secs, "iops")
-			}
+			benchmarkDataWriteRMW(b, be.open(b), "/hot")
 		})
+	}
+}
+
+// benchmarkDataWriteRMW seeds share with nFiles files and then drives the 4k
+// WRITE metadata RMW — GetFile then UpdateAttrs in one transaction — scattered
+// over them from GOMAXPROCS goroutines, reporting IOPS. It closes store.
+//
+// The seed is untimed but is NOT sized from b.N, so it does not grow with the
+// timed region; it does re-run on each invocation the framework makes while
+// growing b.N, which for a networked store costs more than the measurement.
+// Pass -benchtime=<N>x to pin the iteration count and keep that to one real
+// invocation rather than letting a duration walk b.N upward.
+//
+// Concurrency is the point, not incidental: a lever that coalesces concurrent
+// commits has nothing to work with in a serial benchmark, so a cell run at
+// -cpu=1 can only show such a lever's cost and never its benefit.
+func benchmarkDataWriteRMW(b *testing.B, store metadata.Store, share string) {
+	ctx := context.Background()
+	b.Cleanup(func() { _ = store.Close() })
+
+	root, err := store.CreateRootDirectory(ctx, share, &metadata.FileAttr{Type: metadata.FileTypeDirectory, Mode: 0o755})
+	if err != nil {
+		b.Fatalf("CreateRootDirectory: %v", err)
+	}
+	rootHandle, err := store.GetRootHandle(ctx, share)
+	if err != nil {
+		b.Fatalf("GetRootHandle: %v", err)
+	}
+
+	handles := make([]metadata.FileHandle, nFiles)
+	for i := 0; i < nFiles; i++ {
+		name := fmt.Sprintf("f%06d", i)
+		fp := path.Join(root.Path, name)
+		h, err := store.GenerateHandle(ctx, share, fp)
+		if err != nil {
+			b.Fatalf("GenerateHandle: %v", err)
+		}
+		_, id, err := metadata.DecodeFileHandle(h)
+		if err != nil {
+			b.Fatalf("DecodeFileHandle: %v", err)
+		}
+		f := &metadata.File{
+			ShareName: share, Path: fp, ID: id,
+			FileAttr: metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o644, UID: 1000, GID: 1000},
+		}
+		if err := store.UpdateAttrs(ctx, f); err != nil {
+			b.Fatalf("UpdateAttrs seed: %v", err)
+		}
+		if err := store.SetParent(ctx, h, rootHandle); err != nil {
+			b.Fatalf("SetParent: %v", err)
+		}
+		if err := store.SetChild(ctx, rootHandle, name, h); err != nil {
+			b.Fatalf("SetChild: %v", err)
+		}
+		handles[i] = h
+	}
+
+	var ops int64
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		rng := rand.New(rand.NewSource(rand.Int63()))
+		for pb.Next() {
+			h := handles[rng.Intn(nFiles)]
+			if err := store.WithTransaction(ctx, func(tx metadata.Transaction) error {
+				f, err := tx.GetFile(ctx, h)
+				if err != nil {
+					return err
+				}
+				f.Mtime = time.Now()
+				return tx.UpdateAttrs(ctx, f)
+			}); err != nil {
+				b.Fatalf("write txn: %v", err)
+			}
+			atomic.AddInt64(&ops, 1)
+		}
+	})
+	b.StopTimer()
+	if secs := b.Elapsed().Seconds(); secs > 0 {
+		b.ReportMetric(float64(atomic.LoadInt64(&ops))/secs, "iops")
 	}
 }

--- a/pkg/metadata/store/metabench/write_compare_postgres_bench_test.go
+++ b/pkg/metadata/store/metabench/write_compare_postgres_bench_test.go
@@ -1,0 +1,63 @@
+//go:build integration
+
+package metabench
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/postgres"
+)
+
+// BenchmarkWriteComparePostgres is the postgres cell of the write-path
+// comparison. It runs the same data-write RMW as the embedded backends, but at
+// postgres's DEFAULT durability: RelaxedDurability is left false, so every
+// transaction commits with synchronous_commit=on and waits for a WAL fsync.
+// That is deliberate — this cell exists to measure the per-commit fsync, which
+// is the one cost the store layer cannot shape away, so equalizing it to
+// fsync-free the way the badger and sqlite cells do would erase the subject.
+//
+// It reads no knobs of its own. commit_delay and commit_siblings are server
+// GUCs, so an A/B over them is applied to the server between runs
+// (ALTER SYSTEM SET ... ; SELECT pg_reload_conf()) and needs no code here.
+// Both are SIGHUP-scoped, so a reload is enough and no restart is required.
+//
+//	ALTER SYSTEM SET commit_delay = 50; SELECT pg_reload_conf();
+//	DITTOFS_LOGGING_LEVEL=ERROR DITTOFS_TEST_POSTGRES_DSN=1 \
+//	  go test -tags=integration -run '^$' -bench WriteComparePostgres \
+//	  -benchtime 20000x -cpu 8 ./pkg/metadata/store/metabench/
+//
+// Report the server's commit_delay alongside the number: the benchmark cannot
+// see it, so a result recorded without it cannot be placed in the A/B.
+func BenchmarkWriteComparePostgres(b *testing.B) {
+	if os.Getenv("DITTOFS_TEST_POSTGRES_DSN") == "" {
+		b.Skip("DITTOFS_TEST_POSTGRES_DSN not set, skipping postgres write-path cell")
+	}
+
+	cfg := &postgres.PostgresMetadataStoreConfig{
+		Host:        "localhost",
+		Port:        5432,
+		Database:    "dittofs_test",
+		User:        "postgres",
+		Password:    "postgres",
+		SSLMode:     "disable",
+		AutoMigrate: true,
+		// RelaxedDurability deliberately left false: see the comment above.
+	}
+	store, err := postgres.NewPostgresMetadataStore(context.Background(), cfg, caps())
+	if err != nil {
+		b.Fatalf("NewPostgresMetadataStore: %v", err)
+	}
+
+	// The database persists across runs, so a fixed share name would collide
+	// with every previous run's seeded population.
+	benchmarkDataWriteRMW(b, store, fmt.Sprintf("/hot-%d", time.Now().UnixNano()))
+}
+
+// interface assertion: the cell is only meaningful if the store it opens really
+// is the one the service layer commits through.
+var _ metadata.Store = (*postgres.PostgresMetadataStore)(nil)


### PR DESCRIPTION
Groundwork and evidence for #1828's last stage (S8, "postgres commit batching"). No production code changes.

## Why

S8 proposed batching several file operations into one transaction before one commit. The write path's commit *count* is the only lever there, because the fsync of a commit that promised durability cannot be removed without weakening the promise. Nothing pinned that count, so the claim that several commits were available to collapse had no way to be checked.

## What is here

**`commit_count_test.go`** records the count through the existing `transactorSpy`:

| leg | durable | relaxed |
|---|---|---|
| create | 0 | 1 |
| buffered UNSTABLE WRITE | 0 | 0 |
| deferrable flush | 0 | 1 |
| FILE_SYNC flush | 1 | 0 |

One commit per leg, maximum — so there is no intra-operation batch to collapse. What remains is one commit per protocol RPC, which the store layer cannot merge because the RPCs arrive separately and each is acked before the next is sent.

**The metabench postgres cell.** `metabench` claimed to cover postgres — its backend comment described `synchronous_commit=off` "for postgres" — while `backends()` only ever built badger and sqlite. No postgres write-path number ever came from that harness. The benchmark body is extracted so the new cell reuses it rather than duplicating 60 lines, and the cell runs at postgres's default `synchronous_commit=on`, since the per-commit fsync is the subject there rather than something to equalize away.

## Measured on hardware

A dedicated 8-vCPU POP2 VM, postgres 16.15 co-located, `fdatasync` at 1548 µs (`pg_test_fsync`). `commit_delay`/`commit_siblings` is postgres's own group commit and the one commit-level lever that costs no durability, so it was the honest version of S8 to test. Medians of 3 reps, baseline `commit_delay=0` at 3499 iops / 85,207 syncs:

| `commit_delay` | siblings | iops | wal_sync |
|---|---|---|---|
| 0 | 5 | **3499** | 85,207 |
| 400 | 5 | 2762 | 85,007 |
| 800 | 5 | 2980 | 82,784 |
| 1500 | 5 | 2419 | 82,771 |
| 800 | 2 | 3108 | 82,688 |
| 1500 | 2 | 2434 | 82,686 |

Isolating the concurrent region with a seed-only run (the serial seed is 40,212 commits at 0.9986 syncs/commit and cannot coalesce at all): **0.760 → 0.708 syncs/commit, a 6.8% fsync reduction for an 11% throughput loss** in its best cell. Every setting is a net regression, and the fsync count floors at ~82,686 so more delay buys nothing.

The mechanism is that postgres already coalesces these commits unaided — 0.76 syncs/commit with no help — so the knob whose job is to create batching has almost nothing left to create.

Scope: one rig with a 1548 µs SBS fsync. A local-NVMe deployment has a smaller wall and less for the knob to win back. `commit_delay` also trades latency for flushes, which is the wrong currency for a synchronous metadata path regardless of the throughput arithmetic.

Per the project's stop-on-no-win rule, no `commit_delay` default is shipped.

#1828 stays open: five sqlite/postgres pairs are still unmerged and are being addressed separately.