### PR TITLE
fix(smb): scope the tree lookup to the requesting session

### DIFF
--- a/internal/adapter/smb/prepare_dispatch_test.go
+++ b/internal/adapter/smb/prepare_dispatch_test.go
@@ -130,30 +130,19 @@ func TestPrepareDispatch_DoesNotGateSMB2x(t *testing.T) {
 	}
 }
 
-// TestPrepareDispatch_RejectsTreeFromAnotherSession verifies that a
-// tree-scoped command carrying a TreeID owned by a different session is
-// rejected with STATUS_NETWORK_NAME_DELETED. Tree connections live in a
-// process-wide table keyed by a small sequential TreeID, so without this gate
-// any authenticated client can name another session's tree and act on it —
-// TREE_DISCONNECT on a stranger's tree deletes it and cancels the blocking
-// LOCKs parked on it, orphaning the owner's still-open handles. MS-SMB2
-// §3.3.5.2.11 requires the lookup to be scoped to Session.TreeConnectTable.
+// TestPrepareDispatch_RejectsTreeFromAnotherSession asserts that TREE_DISCONNECT
+// naming a live TreeID owned by a different session is refused with
+// STATUS_NETWORK_NAME_DELETED. See the gate in prepareDispatch for why.
 func TestPrepareDispatch_RejectsTreeFromAnotherSession(t *testing.T) {
 	victim := newConnInfoForDispatch(t, 1, types.Dialect0311)
 
-	// Second connection, same process-wide handler and session manager.
-	attacker := &ConnInfo{
-		ConnID:         2,
-		Conn:           fakeConn{},
-		Handler:        victim.Handler,
-		SessionManager: victim.SessionManager,
-		WriteMu:        &LockedWriter{},
-		WriteTimeout:   2 * time.Second,
-		CryptoState:    victim.CryptoState,
-	}
+	// Second connection, sharing only the process-wide tree table and session
+	// manager — as two real connections to one server do.
+	attacker := newConnInfoForDispatch(t, 2, types.Dialect0311)
+	attacker.Handler = victim.Handler
+	attacker.SessionManager = victim.SessionManager
 
 	victimSess := victim.Handler.CreateSession("127.0.0.1:1", false, "alice", "WORKGROUP")
-	victimSess.OriginConnID = victim.ConnID
 	attackerSess := victim.Handler.CreateSession("127.0.0.1:2", false, "mallory", "WORKGROUP")
 	attackerSess.OriginConnID = attacker.ConnID
 

--- a/internal/adapter/smb/prepare_dispatch_test.go
+++ b/internal/adapter/smb/prepare_dispatch_test.go
@@ -135,9 +135,9 @@ func TestPrepareDispatch_DoesNotGateSMB2x(t *testing.T) {
 // rejected with STATUS_NETWORK_NAME_DELETED. Tree connections live in a
 // process-wide table keyed by a small sequential TreeID, so without this gate
 // any authenticated client can name another session's tree and act on it —
-// TREE_DISCONNECT on a stranger's tree would close its opens and drop its
-// locks. MS-SMB2 §3.3.5.2.11 requires the lookup to be scoped to
-// Session.TreeConnectTable.
+// TREE_DISCONNECT on a stranger's tree deletes it and cancels the blocking
+// LOCKs parked on it, orphaning the owner's still-open handles. MS-SMB2
+// §3.3.5.2.11 requires the lookup to be scoped to Session.TreeConnectTable.
 func TestPrepareDispatch_RejectsTreeFromAnotherSession(t *testing.T) {
 	victim := newConnInfoForDispatch(t, 1, types.Dialect0311)
 

--- a/internal/adapter/smb/prepare_dispatch_test.go
+++ b/internal/adapter/smb/prepare_dispatch_test.go
@@ -129,3 +129,80 @@ func TestPrepareDispatch_DoesNotGateSMB2x(t *testing.T) {
 		t.Fatalf("errStatus=0x%x, want 0 for SMB 2.x (per-connection scoping handles cross-conn elsewhere)", errStatus)
 	}
 }
+
+// TestPrepareDispatch_RejectsTreeFromAnotherSession verifies that a
+// tree-scoped command carrying a TreeID owned by a different session is
+// rejected with STATUS_NETWORK_NAME_DELETED. Tree connections live in a
+// process-wide table keyed by a small sequential TreeID, so without this gate
+// any authenticated client can name another session's tree and act on it —
+// TREE_DISCONNECT on a stranger's tree would close its opens and drop its
+// locks. MS-SMB2 §3.3.5.2.11 requires the lookup to be scoped to
+// Session.TreeConnectTable.
+func TestPrepareDispatch_RejectsTreeFromAnotherSession(t *testing.T) {
+	victim := newConnInfoForDispatch(t, 1, types.Dialect0311)
+
+	// Second connection, same process-wide handler and session manager.
+	attacker := &ConnInfo{
+		ConnID:         2,
+		Conn:           fakeConn{},
+		Handler:        victim.Handler,
+		SessionManager: victim.SessionManager,
+		WriteMu:        &LockedWriter{},
+		WriteTimeout:   2 * time.Second,
+		CryptoState:    victim.CryptoState,
+	}
+
+	victimSess := victim.Handler.CreateSession("127.0.0.1:1", false, "alice", "WORKGROUP")
+	victimSess.OriginConnID = victim.ConnID
+	attackerSess := victim.Handler.CreateSession("127.0.0.1:2", false, "mallory", "WORKGROUP")
+	attackerSess.OriginConnID = attacker.ConnID
+
+	victimTree := &handlers.TreeConnection{
+		TreeID:    victim.Handler.GenerateTreeID(),
+		SessionID: victimSess.SessionID,
+		ShareName: "victimshare",
+	}
+	victim.Handler.StoreTree(victimTree)
+
+	hdr := &header.SMB2Header{
+		Command:   types.SMB2TreeDisconnect,
+		SessionID: attackerSess.SessionID,
+		TreeID:    victimTree.TreeID,
+		MessageID: 1,
+	}
+	_, _, errStatus := prepareDispatch(context.Background(), hdr, attacker)
+	if errStatus != types.StatusNetworkNameDeleted {
+		t.Fatalf("errStatus=0x%x, want StatusNetworkNameDeleted (0x%x) for a tree owned by another session",
+			errStatus, types.StatusNetworkNameDeleted)
+	}
+}
+
+// TestPrepareDispatch_AllowsOwnTree is the positive control for the ownership
+// gate: the session that owns the tree still dispatches, with ShareName
+// resolved from it.
+func TestPrepareDispatch_AllowsOwnTree(t *testing.T) {
+	ci := newConnInfoForDispatch(t, 1, types.Dialect0311)
+	sess := ci.Handler.CreateSession("127.0.0.1:1", false, "alice", "WORKGROUP")
+	sess.OriginConnID = ci.ConnID
+
+	tree := &handlers.TreeConnection{
+		TreeID:    ci.Handler.GenerateTreeID(),
+		SessionID: sess.SessionID,
+		ShareName: "myshare",
+	}
+	ci.Handler.StoreTree(tree)
+
+	hdr := &header.SMB2Header{
+		Command:   types.SMB2TreeDisconnect,
+		SessionID: sess.SessionID,
+		TreeID:    tree.TreeID,
+		MessageID: 1,
+	}
+	_, handlerCtx, errStatus := prepareDispatch(context.Background(), hdr, ci)
+	if errStatus != 0 {
+		t.Fatalf("errStatus=0x%x, want 0 for the session's own tree", errStatus)
+	}
+	if handlerCtx.ShareName != "myshare" {
+		t.Fatalf("ShareName=%q, want %q", handlerCtx.ShareName, "myshare")
+	}
+}

--- a/internal/adapter/smb/prepare_dispatch_test.go
+++ b/internal/adapter/smb/prepare_dispatch_test.go
@@ -172,7 +172,7 @@ func TestPrepareDispatch_RejectsTreeFromAnotherSession(t *testing.T) {
 	}
 	_, _, errStatus := prepareDispatch(context.Background(), hdr, attacker)
 	if errStatus != types.StatusNetworkNameDeleted {
-		t.Fatalf("errStatus=0x%x, want StatusNetworkNameDeleted (0x%x) for a tree owned by another session",
+		t.Fatalf("errStatus=%v, want %v for a tree owned by another session",
 			errStatus, types.StatusNetworkNameDeleted)
 	}
 }
@@ -200,7 +200,7 @@ func TestPrepareDispatch_AllowsOwnTree(t *testing.T) {
 	}
 	_, handlerCtx, errStatus := prepareDispatch(context.Background(), hdr, ci)
 	if errStatus != 0 {
-		t.Fatalf("errStatus=0x%x, want 0 for the session's own tree", errStatus)
+		t.Fatalf("errStatus=%v, want success for the session's own tree", errStatus)
 	}
 	if handlerCtx.ShareName != "myshare" {
 		t.Fatalf("ShareName=%q, want %q", handlerCtx.ShareName, "myshare")

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -517,10 +517,13 @@ func prepareDispatch(ctx context.Context, reqHeader *header.SMB2Header, connInfo
 		// exist somewhere on the server. Tree connections are held in one
 		// process-wide table keyed by a small sequential TreeID, so an
 		// existence-only lookup lets any authenticated session name another
-		// session's tree — TREE_DISCONNECT would then close that session's
-		// opens, drop its byte-range locks and delete the tree out from under
-		// it. Gating here covers every NeedsTree command at once, so the
-		// per-handler lookups downstream (TREE_DISCONNECT, CREATE) can stay
+		// session's tree. TREE_DISCONNECT is the sharpest edge: it deletes the
+		// tree and cancels every blocking LOCK parked on it (that registry is
+		// keyed by TreeID alone), while the file-close pass filters on both
+		// TreeID and SessionID and so spares the owner's opens — leaving those
+		// handles orphaned behind a tree that no longer exists, with no way to
+		// close them. Gating here covers every NeedsTree command at once, so
+		// the per-handler lookups downstream (TREE_DISCONNECT, CREATE) can stay
 		// existence-only.
 		tree, ok := connInfo.Handler.GetTree(reqHeader.TreeID)
 		if !ok || tree.SessionID != reqHeader.SessionID {

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -522,9 +522,15 @@ func prepareDispatch(ctx context.Context, reqHeader *header.SMB2Header, connInfo
 		// keyed by TreeID alone), while the file-close pass filters on both
 		// TreeID and SessionID and so spares the owner's opens — leaving those
 		// handles orphaned behind a tree that no longer exists, with no way to
-		// close them. Gating here covers every NeedsTree command at once, so
-		// the per-handler lookups downstream (TREE_DISCONNECT, CREATE) can stay
-		// existence-only.
+		// close them.
+		//
+		// ponytail: gating here covers every NeedsTree command at once, so the
+		// per-handler lookups downstream (TREE_DISCONNECT, CREATE) stay
+		// existence-only rather than each repeating the comparison. The ceiling
+		// is that ownership then holds only for commands that reach a handler
+		// through this function; a future path that invokes a handler directly
+		// would carry no tree-ownership check at all. Push the comparison down
+		// into the handlers only if such a path appears.
 		tree, ok := connInfo.Handler.GetTree(reqHeader.TreeID)
 		if !ok || tree.SessionID != reqHeader.SessionID {
 			logger.Debug("Tree not connected on this session",

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -512,8 +512,22 @@ func prepareDispatch(ctx context.Context, reqHeader *header.SMB2Header, connInfo
 	}
 
 	if cmd.NeedsTree && reqHeader.TreeID != 0 {
+		// MS-SMB2 §3.3.5.2.11: the tree connect must be found in the
+		// TreeConnectTable of the session the request arrived on, not merely
+		// exist somewhere on the server. Tree connections are held in one
+		// process-wide table keyed by a small sequential TreeID, so an
+		// existence-only lookup lets any authenticated session name another
+		// session's tree — TREE_DISCONNECT would then close that session's
+		// opens, drop its byte-range locks and delete the tree out from under
+		// it. Gating here covers every NeedsTree command at once, so the
+		// per-handler lookups downstream (TREE_DISCONNECT, CREATE) can stay
+		// existence-only.
 		tree, ok := connInfo.Handler.GetTree(reqHeader.TreeID)
-		if !ok {
+		if !ok || tree.SessionID != reqHeader.SessionID {
+			logger.Debug("Tree not connected on this session",
+				"command", reqHeader.Command.String(),
+				"treeID", reqHeader.TreeID,
+				"sessionID", reqHeader.SessionID)
 			return nil, nil, types.StatusNetworkNameDeleted
 		}
 		handlerCtx.ShareName = tree.ShareName


### PR DESCRIPTION
## What was wrong

SMB tree connections live in a single process-wide `sync.Map` on the `Handler`
(`handlers/handler.go:53`), keyed by a TreeID drawn from one global counter
seeded at 1 (`nextTreeID atomic.Uint32`, `GenerateTreeID`). TreeIDs are
therefore small, dense and shared across every session on the server.

The shared dispatch gate that resolves the tree for every `NeedsTree` command
looked one up by ID alone:

```go
tree, ok := connInfo.Handler.GetTree(reqHeader.TreeID)
if !ok {
    return nil, nil, types.StatusNetworkNameDeleted
}
```

`TreeConnection` already carries the `SessionID` of the session that connected
it — written once at `handlers/tree_connect.go:166` (disk) and `:288` (IPC$),
never reassigned — and `handler.go:1758` already uses it as an ownership key
when reaping a superseded session's trees. The request path simply never
consulted it.

So any authenticated session could name any other session's tree and act on it.
TREE_DISCONNECT is the sharpest edge, though not in the way the issue describes.
Its file-close pass filters on both IDs (`CloseAllFilesForTree` →
`f.TreeID == treeID && f.SessionID == sessionID`, `handler.go:1325`), so the
victim's *opens are not closed* by an attacker's disconnect. What is not scoped
by session is the rest of the handler: `PendingLockRegistry.UnregisterAllForTree`
takes a TreeID alone (`pending_lock_registry.go:211`) and completes every
blocking LOCK parked on the tree with `STATUS_RANGE_NOT_LOCKED`, and
`h.DeleteTree(ctx.TreeID)` removes the tree unconditionally.

The result is worse than a plain close: the victim keeps live handles behind a
tree that no longer exists. Every subsequent tree-scoped op on them — CLOSE
included — fails with `STATUS_NETWORK_NAME_DELETED`, so the owner cannot even
release them. Denial of service plus a permanent handle leak. CREATE
(`create.go:513`) took the same existence-only lookup.

READ and WRITE were already safe, but for an unrelated reason: they validate the
*handle* (`read.go:263`, `write.go:287` check `openFile.TreeID != ctx.TreeID ||
openFile.SessionID != ctx.SessionID`). That is MS-SMB2 3.3.5.2.5 handle
validation and it is what `smbtorture smb2.tcon` exercises. The *tree* itself
was never bound to its session, one layer up — so `smb2.tcon` passing was not
evidence of coverage here.

MS-SMB2 3.3.5.2.11 requires the server to locate the tree connect in
`Session.TreeConnectTable` — scoped to the session the request arrived on — and
fail the request otherwise.

## The fix

One comparison in the shared `NeedsTree` gate in `prepareDispatch`
(`internal/adapter/smb/response.go`). That single point covers TREE_DISCONNECT,
CREATE and every other `NeedsTree` command at once, so the downstream
per-handler lookups can stay existence-only rather than each growing its own
copy of the check.

## Why this cannot reject legitimate traffic

`TreeConnection.SessionID` is written at creation and never reassigned, and
nothing re-parents a tree to a different session:

- Session reauthentication reuses the same SessionID — the re-auth path is
  `GetSession(ctx.SessionID)`, so the tree's stored value still matches.
- SMB3 multichannel binds additional *connections* to one session; the SessionID
  on the wire is unchanged across channels.
- SMB 2.x already rejects cross-connection session use elsewhere in this gate.
- A superseded session's trees are reaped at `handler.go:1758`, not re-parented.

The compound path was the one real risk, because related sub-commands carry
sentinel `SessionID` `0xFFFFFFFFFFFFFFFF` and `TreeID` `0xFFFFFFFF` on the wire.
`compound.go:881-887` resolves both sentinels to the chain's `lastSessionID` /
`lastTreeID` *before* `prepareDispatch` runs, and both are populated from the
same sub-command's handler context (`compound.go:1009-1015`, `:258-264`), so they
cannot disagree. The gate compares whatever `(SessionID, TreeID)` pair ends up in
the header, so it does not matter how that pair was assembled — a compound that
seeds `lastTreeID` from an unvalidated first-command wire TreeID still has its
related members rejected, because the pair still fails to match.

## Evidence

New test `TestPrepareDispatch_RejectsTreeFromAnotherSession` builds two sessions
on one shared handler, stores a tree owned by the first, and dispatches
TREE_DISCONNECT from the second carrying the first's TreeID.

Before the fix — the attacker's request is admitted:

```
=== RUN   TestPrepareDispatch_RejectsTreeFromAnotherSession
    prepare_dispatch_test.go:175: errStatus=STATUS_SUCCESS, want STATUS_NETWORK_NAME_DELETED for a tree owned by another session
--- FAIL: TestPrepareDispatch_RejectsTreeFromAnotherSession (0.00s)
=== RUN   TestPrepareDispatch_AllowsOwnTree
--- PASS: TestPrepareDispatch_AllowsOwnTree (0.00s)
```

After: passes. `TestPrepareDispatch_AllowsOwnTree` is the positive control — the
owning session still dispatches and still gets `ShareName` resolved — so the
guard is shown to refuse the right request and only that one.

`go test ./...` and `go test -race ./internal/adapter/smb/...` are green;
`golangci-lint` reports 0 issues.

Also exercised against a real Linux `cifs.ko` client (Ubuntu 24.04, kernel
6.8.0-138, `vers=3.1.1`): mount, mkdir, write, read-back, an 8 MiB binary write
verified by md5, `ls`, `rm`, unmount and remount all succeed through the new
gate — ordinary tree-scoped traffic is unaffected.

Closes #2413
