### PR TITLE
fix(smb): scope async-flagged CANCEL lookups to the arriving connection

### DIFF
--- a/internal/adapter/smb/handlers/cancel_asyncid_scope_test.go
+++ b/internal/adapter/smb/handlers/cancel_asyncid_scope_test.go
@@ -1,0 +1,109 @@
+package handlers
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+)
+
+// A CANCEL carrying SMB2_FLAGS_ASYNC_COMMAND is resolved by the AsyncId in its
+// header, and that AsyncId is whatever the peer put on the wire. MS-SMB2
+// 3.3.5.16 confines the search to Connection.AsyncCommandList — the list of the
+// connection the CANCEL arrived on — and 3.3.1.13 only guarantees an AsyncId to
+// be unique "among all requests currently processed asynchronously on a
+// specified SMB2 transport connection". So an AsyncId that resolves an entry
+// parked on a different connection must resolve nothing: the victim's request
+// stays parked and completes on its own terms.
+//
+// Each case registers a victim on connection 1 and fires the cancel from
+// connection 2 with the victim's AsyncId.
+
+func TestPendingCreateRegistry_UnregisterByAsyncIdIsConnectionScoped(t *testing.T) {
+	r := NewPendingCreateRegistry()
+	var calls atomic.Int32
+	victim := newTestPendingCreate(1, 10, 100, 7, &calls)
+	if err := r.Register(victim); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	if got := r.UnregisterByAsyncId(2, 7); got != nil {
+		t.Errorf("UnregisterByAsyncId(conn 2, victim's asyncId) = %v, want nil", got)
+	}
+	if r.Len() != 1 {
+		t.Errorf("Len after foreign cancel = %d, want 1 (victim still parked)", r.Len())
+	}
+
+	// The owning connection still cancels it.
+	if got := r.UnregisterByAsyncId(1, 7); got != victim {
+		t.Errorf("UnregisterByAsyncId(conn 1) = %v, want victim", got)
+	}
+}
+
+func TestPendingLockRegistry_UnregisterByAsyncIdIsConnectionScoped(t *testing.T) {
+	r := NewPendingLockRegistry()
+	var cancels atomic.Int32
+	victim := newTestPendingLock(1, 10, 100, 1000, 50, &cancels)
+	if err := r.Register(victim); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	if got := r.UnregisterByAsyncId(2, 1000); got != nil {
+		t.Errorf("UnregisterByAsyncId(conn 2, victim's asyncId) = %v, want nil", got)
+	}
+	if n := cancels.Load(); n != 0 {
+		t.Errorf("victim's Cancel fired %d times on a foreign cancel, want 0", n)
+	}
+	if r.Len() != 1 {
+		t.Errorf("Len after foreign cancel = %d, want 1 (victim still parked)", r.Len())
+	}
+
+	if got := r.UnregisterByAsyncId(1, 1000); got != victim {
+		t.Errorf("UnregisterByAsyncId(conn 1) = %v, want victim", got)
+	}
+	if n := cancels.Load(); n != 1 {
+		t.Errorf("Cancel fired %d times on the owning cancel, want 1", n)
+	}
+}
+
+func TestPipeReadRegistry_UnregisterByAsyncIdIsConnectionScoped(t *testing.T) {
+	r := NewPipeReadRegistry()
+	done := make(chan types.Status, 1)
+	victim := newTestPipeRead(1, 10, 100, 1000, done)
+	victim.ConnID = 1
+	r.Register(victim)
+
+	if got := r.UnregisterByAsyncId(2, 1000); got != nil {
+		t.Errorf("UnregisterByAsyncId(conn 2, victim's asyncId) = %v, want nil", got)
+	}
+	// The MessageID key is per-connection too, so the same cancel arriving
+	// without the async flag must miss as well.
+	if got := r.UnregisterByMessageID(2, 100); got != nil {
+		t.Errorf("UnregisterByMessageID(conn 2, victim's messageID) = %v, want nil", got)
+	}
+	if got := r.UnregisterByAsyncId(1, 1000); got != victim {
+		t.Errorf("UnregisterByAsyncId(conn 1) = %v, want victim", got)
+	}
+}
+
+func TestNotifyRegistry_UnregisterByAsyncIdIsConnectionScoped(t *testing.T) {
+	r := newTestNotifyRegistry()
+	victim := &PendingNotify{
+		FileID:           [16]byte{1},
+		SessionID:        10,
+		ConnID:           1,
+		MessageID:        100,
+		AsyncId:          777,
+		WatchPath:        "/dir",
+		ShareName:        "share",
+		CompletionFilter: FileNotifyChangeDirName,
+	}
+	mustRegister(t, r, victim)
+
+	if got := r.UnregisterByAsyncId(2, 777); got != nil {
+		t.Errorf("UnregisterByAsyncId(conn 2, victim's asyncId) = %v, want nil", got)
+	}
+	if got := r.UnregisterByAsyncId(1, 777); got != victim {
+		t.Errorf("UnregisterByAsyncId(conn 1) = %v, want victim", got)
+	}
+}

--- a/internal/adapter/smb/handlers/cancel_asyncid_scope_test.go
+++ b/internal/adapter/smb/handlers/cancel_asyncid_scope_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"sync/atomic"
 	"testing"
 
@@ -69,8 +70,7 @@ func TestPendingLockRegistry_UnregisterByAsyncIdIsConnectionScoped(t *testing.T)
 func TestPipeReadRegistry_UnregisterByAsyncIdIsConnectionScoped(t *testing.T) {
 	r := NewPipeReadRegistry()
 	done := make(chan types.Status, 1)
-	victim := newTestPipeRead(1, 10, 100, 1000, done)
-	victim.ConnID = 1
+	victim := newTestPipeRead(1, 1, 10, 100, 1000, done)
 	r.Register(victim)
 
 	if got := r.UnregisterByAsyncId(2, 1000); got != nil {
@@ -105,5 +105,49 @@ func TestNotifyRegistry_UnregisterByAsyncIdIsConnectionScoped(t *testing.T) {
 	}
 	if got := r.UnregisterByAsyncId(1, 777); got != victim {
 		t.Errorf("UnregisterByAsyncId(conn 1) = %v, want victim", got)
+	}
+}
+
+// The inline-retry fallback parks its cancel func in h.pendingLocks rather than
+// in a registry, and is taken whenever async parking is unavailable. Its key
+// carries the ConnID for the same reason the registries' do — and here the
+// collision needs no attacker: MessageIDs are per-connection sequence numbers
+// and every connection's window starts near zero, so two clients blocking on
+// locks routinely hold the same MessageID at the same time.
+//
+// This drives the real Handler.Cancel dispatch path rather than the map.
+func TestCancel_InlineBlockingLockIsConnectionScoped(t *testing.T) {
+	h := &Handler{}
+	const messageID = 100
+
+	lockCtx, cancel := context.WithCancel(context.Background())
+	h.pendingLocks.Store(lockMsgKey{ConnID: 1, MessageID: messageID}, context.CancelFunc(cancel))
+
+	cancelBody := []byte{4, 0, 0, 0} // StructureSize = 4, Reserved
+
+	// A CANCEL from another connection carrying the same MessageID.
+	if _, err := h.Cancel(&SMBHandlerContext{ConnID: 2, MessageID: messageID}, cancelBody); err != nil {
+		t.Fatalf("Cancel(conn 2): %v", err)
+	}
+	select {
+	case <-lockCtx.Done():
+		t.Fatal("a CANCEL from another connection tore down the inline LOCK")
+	default:
+	}
+	if _, ok := h.pendingLocks.Load(lockMsgKey{ConnID: 1, MessageID: messageID}); !ok {
+		t.Fatal("inline LOCK was unregistered by another connection's CANCEL")
+	}
+
+	// The owning connection still cancels it.
+	if _, err := h.Cancel(&SMBHandlerContext{ConnID: 1, MessageID: messageID}, cancelBody); err != nil {
+		t.Fatalf("Cancel(conn 1): %v", err)
+	}
+	select {
+	case <-lockCtx.Done():
+	default:
+		t.Fatal("the owning connection's CANCEL did not tear down the inline LOCK")
+	}
+	if _, ok := h.pendingLocks.Load(lockMsgKey{ConnID: 1, MessageID: messageID}); ok {
+		t.Fatal("inline LOCK still registered after its own connection cancelled it")
 	}
 }

--- a/internal/adapter/smb/handlers/change_notify.go
+++ b/internal/adapter/smb/handlers/change_notify.go
@@ -994,12 +994,10 @@ func (r *NotifyRegistry) Unregister(fileID [16]byte) *PendingNotify {
 	return r.unregisterLocked(waiters[0])
 }
 
-// UnregisterByAsyncId removes the pending notification registered on connID
-// under asyncId. Called by CANCEL when the client sends a cancel with
-// SMB2_FLAGS_ASYNC_COMMAND. The AsyncId arrives verbatim off the wire, so it is
-// matched against the connection the cancel came in on: a notify registered on
-// another connection does not match and is left waiting. Returns the removed
-// PendingNotify, or nil if not found.
+// UnregisterByAsyncId removes the pending notification registered on
+// (connID, asyncId). Called by CANCEL when the client sends a cancel with
+// SMB2_FLAGS_ASYNC_COMMAND. Returns the removed PendingNotify, or nil if not
+// found.
 func (r *NotifyRegistry) UnregisterByAsyncId(connID, asyncId uint64) *PendingNotify {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/adapter/smb/handlers/change_notify.go
+++ b/internal/adapter/smb/handlers/change_notify.go
@@ -994,15 +994,18 @@ func (r *NotifyRegistry) Unregister(fileID [16]byte) *PendingNotify {
 	return r.unregisterLocked(waiters[0])
 }
 
-// UnregisterByAsyncId removes a pending notification by AsyncId.
-// Called by CANCEL when the client sends a cancel with SMB2_FLAGS_ASYNC_COMMAND.
-// Returns the removed PendingNotify, or nil if not found.
-func (r *NotifyRegistry) UnregisterByAsyncId(asyncId uint64) *PendingNotify {
+// UnregisterByAsyncId removes the pending notification registered on connID
+// under asyncId. Called by CANCEL when the client sends a cancel with
+// SMB2_FLAGS_ASYNC_COMMAND. The AsyncId arrives verbatim off the wire, so it is
+// matched against the connection the cancel came in on: a notify registered on
+// another connection does not match and is left waiting. Returns the removed
+// PendingNotify, or nil if not found.
+func (r *NotifyRegistry) UnregisterByAsyncId(connID, asyncId uint64) *PendingNotify {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	notify, ok := r.byAsyncId[asyncId]
-	if !ok {
+	if !ok || notify.ConnID != connID {
 		return nil
 	}
 

--- a/internal/adapter/smb/handlers/change_notify_test.go
+++ b/internal/adapter/smb/handlers/change_notify_test.go
@@ -198,6 +198,7 @@ func TestNotifyRegistry_UnregisterByAsyncId(t *testing.T) {
 	notify := &PendingNotify{
 		FileID:           [16]byte{2},
 		SessionID:        100,
+		ConnID:           1,
 		MessageID:        50,
 		AsyncId:          777,
 		WatchPath:        "/dir2",
@@ -207,7 +208,7 @@ func TestNotifyRegistry_UnregisterByAsyncId(t *testing.T) {
 	mustRegister(t, r, notify)
 
 	// Unregister by async ID
-	removed := r.UnregisterByAsyncId(0, 777)
+	removed := r.UnregisterByAsyncId(1, 777)
 	if removed == nil {
 		t.Fatal("expected non-nil removed notify")
 	}
@@ -216,7 +217,7 @@ func TestNotifyRegistry_UnregisterByAsyncId(t *testing.T) {
 	}
 
 	// Should not find it again
-	removed = r.UnregisterByAsyncId(0, 777)
+	removed = r.UnregisterByAsyncId(1, 777)
 	if removed != nil {
 		t.Error("expected nil on second unregister")
 	}

--- a/internal/adapter/smb/handlers/change_notify_test.go
+++ b/internal/adapter/smb/handlers/change_notify_test.go
@@ -113,10 +113,10 @@ func TestNotifyRegistry_Register_CrossConnectionMessageIDNoEvict(t *testing.T) {
 	mustRegister(t, r, b)
 
 	// Both must still be resolvable — B's Register must NOT have evicted A.
-	if got := r.UnregisterByAsyncId(3600); got == nil || got.AsyncId != 3600 {
+	if got := r.UnregisterByAsyncId(1, 3600); got == nil || got.AsyncId != 3600 {
 		t.Fatalf("A (asyncId=3600) missing after B registered with same MessageID on a different ConnID")
 	}
-	if got := r.UnregisterByAsyncId(3605); got == nil || got.AsyncId != 3605 {
+	if got := r.UnregisterByAsyncId(2, 3605); got == nil || got.AsyncId != 3605 {
 		t.Fatalf("B (asyncId=3605) missing")
 	}
 }
@@ -207,7 +207,7 @@ func TestNotifyRegistry_UnregisterByAsyncId(t *testing.T) {
 	mustRegister(t, r, notify)
 
 	// Unregister by async ID
-	removed := r.UnregisterByAsyncId(777)
+	removed := r.UnregisterByAsyncId(0, 777)
 	if removed == nil {
 		t.Fatal("expected non-nil removed notify")
 	}
@@ -216,7 +216,7 @@ func TestNotifyRegistry_UnregisterByAsyncId(t *testing.T) {
 	}
 
 	// Should not find it again
-	removed = r.UnregisterByAsyncId(777)
+	removed = r.UnregisterByAsyncId(0, 777)
 	if removed != nil {
 		t.Error("expected nil on second unregister")
 	}
@@ -1334,7 +1334,7 @@ func TestArmedBuffer_OverflowsAfterCancelWithNoLiveWatcher(t *testing.T) {
 
 	// Client cancels the initial notify (smbtorture does this to "set up
 	// the buffer"). Pending entry is removed but the handle stays armed.
-	if got := r.UnregisterByAsyncId(100); got == nil {
+	if got := r.UnregisterByAsyncId(1, 100); got == nil {
 		t.Fatalf("expected to unregister live watcher on cancel")
 	}
 
@@ -1387,7 +1387,7 @@ func TestArmedBuffer_ResetClearsOverflowForNextWindow(t *testing.T) {
 		AsyncCallback:    func(_, _, _ uint64, _ *ChangeNotifyResponse) error { return nil },
 		OnOverflow:       func(_ [16]byte) { atomic.AddInt32(&overflowFireCount, 1) },
 	})
-	if got := r.UnregisterByAsyncId(200); got == nil {
+	if got := r.UnregisterByAsyncId(1, 200); got == nil {
 		t.Fatalf("cancel")
 	}
 
@@ -1443,7 +1443,7 @@ func TestArmedBuffer_ScopedByShareAndPath(t *testing.T) {
 		AsyncCallback:    func(_, _, _ uint64, _ *ChangeNotifyResponse) error { return nil },
 		OnOverflow:       func(_ [16]byte) { atomic.AddInt32(&overflowFireCount, 1) },
 	})
-	if got := r.UnregisterByAsyncId(300); got == nil {
+	if got := r.UnregisterByAsyncId(1, 300); got == nil {
 		t.Fatalf("cancel")
 	}
 
@@ -1540,7 +1540,7 @@ func TestArmedBuffer_RecursiveWatcherChargesRelativePath(t *testing.T) {
 		AsyncCallback:    func(_, _, _ uint64, _ *ChangeNotifyResponse) error { return nil },
 		OnOverflow:       func(_ [16]byte) { atomic.AddInt32(&overflowFireCount, 1) },
 	})
-	if r.UnregisterByAsyncId(500) == nil {
+	if r.UnregisterByAsyncId(1, 500) == nil {
 		t.Fatalf("cancel pending watcher to leave handle armed-but-unwatched")
 	}
 
@@ -2236,7 +2236,7 @@ func TestArmedBuffer_ReplayDeliversBufferedEventsOnReregister(t *testing.T) {
 		AsyncCallback:   func(uint64, uint64, uint64, *ChangeNotifyResponse) error { return nil },
 	}
 	mustRegister(t, r, first)
-	if got := r.UnregisterByAsyncId(100); got == nil {
+	if got := r.UnregisterByAsyncId(1, 100); got == nil {
 		t.Fatalf("expected to unregister first watcher")
 	}
 
@@ -2299,7 +2299,7 @@ func TestArmedBuffer_CancelClearsBufferedEvents(t *testing.T) {
 	mustRegister(t, r, first)
 	// Cancel via UnregisterByAsyncId (the CANCEL path in stub_handlers calls
 	// this and then ClearBufferedEvents).
-	if got := r.UnregisterByAsyncId(100); got == nil {
+	if got := r.UnregisterByAsyncId(1, 100); got == nil {
 		t.Fatalf("expected to unregister")
 	}
 
@@ -2353,7 +2353,7 @@ func TestArmedBuffer_OverflowClearsBufferedEvents(t *testing.T) {
 		AsyncCallback:   func(uint64, uint64, uint64, *ChangeNotifyResponse) error { return nil },
 	}
 	mustRegister(t, r, first)
-	if got := r.UnregisterByAsyncId(100); got == nil {
+	if got := r.UnregisterByAsyncId(1, 100); got == nil {
 		t.Fatalf("expected to unregister")
 	}
 
@@ -2812,7 +2812,7 @@ func TestArmedBuffer_RenameDoesNotDoubleChargeAncestorWatcher(t *testing.T) {
 	}
 	mustRegister(t, r, first)
 	// Cancel to leave handle armed-but-unwatched.
-	if r.UnregisterByAsyncId(100) == nil {
+	if r.UnregisterByAsyncId(1, 100) == nil {
 		t.Fatal("expected to unregister")
 	}
 

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -148,11 +148,6 @@ type Handler struct {
 	// path for inline retry inside the request goroutine — used as a
 	// fallback when async parking is unavailable (no callback wired,
 	// async-credit pool exhausted, or registry full).
-	//
-	// The key carries the ConnID because SMB2 scopes MessageIDs per
-	// connection, and every connection starts its sequence window near zero:
-	// keyed by MessageID alone, one connection's CANCEL tears down another
-	// connection's inline LOCK.
 	pendingLocks sync.Map
 
 	// Configuration

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -144,10 +144,16 @@ type Handler struct {
 	// smb2.lock.open-brlock-deadlock / ctdb-delrec-deadlock).
 	LockWaitGraph *lock.WaitForGraph
 
-	// Pending blocking lock operations (messageID -> cancel func). Legacy
+	// Pending blocking lock operations (lockMsgKey -> cancel func). Legacy
 	// path for inline retry inside the request goroutine — used as a
 	// fallback when async parking is unavailable (no callback wired,
 	// async-credit pool exhausted, or registry full).
+	//
+	// The key carries the ConnID because SMB2 scopes MessageIDs per
+	// connection: keyed by MessageID alone, a CANCEL on one connection
+	// cancels an unrelated connection's inline LOCK that happens to hold the
+	// same MessageID, and both connections start their sequence window near
+	// zero.
 	pendingLocks sync.Map
 
 	// Configuration

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -150,10 +150,9 @@ type Handler struct {
 	// async-credit pool exhausted, or registry full).
 	//
 	// The key carries the ConnID because SMB2 scopes MessageIDs per
-	// connection: keyed by MessageID alone, a CANCEL on one connection
-	// cancels an unrelated connection's inline LOCK that happens to hold the
-	// same MessageID, and both connections start their sequence window near
-	// zero.
+	// connection, and every connection starts its sequence window near zero:
+	// keyed by MessageID alone, one connection's CANCEL tears down another
+	// connection's inline LOCK.
 	pendingLocks sync.Map
 
 	// Configuration

--- a/internal/adapter/smb/handlers/lock.go
+++ b/internal/adapter/smb/handlers/lock.go
@@ -545,11 +545,11 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 				Context:  cancelCtx,
 				Identity: authCtx.Identity,
 			}
-			h.pendingLocks.Store(ctx.MessageID, cancelFn)
+			h.pendingLocks.Store(lockMsgKey{ConnID: ctx.ConnID, MessageID: ctx.MessageID}, cancelFn)
 
 			err = h.acquireLockWithRetry(lockAuthCtx, metaSvc, openFile.MetadataHandle, fileLock, false)
 			ctxErr := lockAuthCtx.Context.Err()
-			h.pendingLocks.LoadAndDelete(ctx.MessageID)
+			h.pendingLocks.LoadAndDelete(lockMsgKey{ConnID: ctx.ConnID, MessageID: ctx.MessageID})
 			cancelFn()
 
 			if err != nil {

--- a/internal/adapter/smb/handlers/lock.go
+++ b/internal/adapter/smb/handlers/lock.go
@@ -545,11 +545,12 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 				Context:  cancelCtx,
 				Identity: authCtx.Identity,
 			}
-			h.pendingLocks.Store(lockMsgKey{ConnID: ctx.ConnID, MessageID: ctx.MessageID}, cancelFn)
+			pendingKey := lockMsgKey{ConnID: ctx.ConnID, MessageID: ctx.MessageID}
+			h.pendingLocks.Store(pendingKey, cancelFn)
 
 			err = h.acquireLockWithRetry(lockAuthCtx, metaSvc, openFile.MetadataHandle, fileLock, false)
 			ctxErr := lockAuthCtx.Context.Err()
-			h.pendingLocks.LoadAndDelete(lockMsgKey{ConnID: ctx.ConnID, MessageID: ctx.MessageID})
+			h.pendingLocks.LoadAndDelete(pendingKey)
 			cancelFn()
 
 			if err != nil {

--- a/internal/adapter/smb/handlers/lock_test.go
+++ b/internal/adapter/smb/handlers/lock_test.go
@@ -213,53 +213,6 @@ func TestAcquireLockWithRetry(t *testing.T) {
 // =============================================================================
 
 func TestPendingLockCancel(t *testing.T) {
-	t.Run("CancelInterruptsBlockingLock", func(t *testing.T) {
-		h := &Handler{}
-		messageID := uint64(42)
-
-		// Simulate a blocking lock: register a cancel function
-		ctx, cancel := context.WithCancel(context.Background())
-		h.pendingLocks.Store(messageID, cancel)
-
-		// Verify the pending lock is registered
-		_, loaded := h.pendingLocks.Load(messageID)
-		if !loaded {
-			t.Fatal("Expected pending lock to be registered")
-		}
-
-		// Simulate CANCEL: load and call the cancel function
-		cancelFnVal, ok := h.pendingLocks.LoadAndDelete(messageID)
-		if !ok {
-			t.Fatal("Expected to find pending lock for cancellation")
-		}
-		cancelFnVal.(context.CancelFunc)()
-
-		// Verify context was cancelled
-		select {
-		case <-ctx.Done():
-			// Expected
-		default:
-			t.Error("Expected context to be cancelled")
-		}
-
-		// Verify pending lock was removed
-		_, loaded = h.pendingLocks.Load(messageID)
-		if loaded {
-			t.Error("Expected pending lock to be removed after cancel")
-		}
-	})
-
-	t.Run("CancelNonexistentLock", func(t *testing.T) {
-		h := &Handler{}
-		messageID := uint64(99)
-
-		// Try to cancel a non-existent pending lock
-		_, ok := h.pendingLocks.LoadAndDelete(messageID)
-		if ok {
-			t.Error("Expected no pending lock for unknown messageID")
-		}
-	})
-
 	t.Run("BlockingLockReturnsOnContextCancel", func(t *testing.T) {
 		store := newMockLockStore()
 		store.lockAvailable.Store(false) // Lock never becomes available

--- a/internal/adapter/smb/handlers/pending_create_registry.go
+++ b/internal/adapter/smb/handlers/pending_create_registry.go
@@ -149,6 +149,7 @@ func NewPendingCreateRegistry() *PendingCreateRegistry {
 	return &PendingCreateRegistry{
 		reg: newPendingRegistry(registryConfig[PendingCreate]{
 			asyncID: func(p *PendingCreate) uint64 { return p.AsyncId },
+			connID:  func(p *PendingCreate) uint64 { return p.ConnID },
 			indexes: []keyFunc[PendingCreate]{
 				func(p *PendingCreate) any {
 					return createMsgKey{ConnID: p.ConnID, MessageID: p.MessageID}
@@ -217,13 +218,10 @@ func (r *PendingCreateRegistry) UnregisterByMessageID(connID, messageID uint64) 
 	return p
 }
 
-// UnregisterByAsyncId removes the pending CREATE parked on connID under
-// asyncId and invokes its Cancel closure. Used by async-flagged SMB2_CANCEL.
-// An entry parked on a different connection does not match and is left alone.
+// UnregisterByAsyncId removes the pending CREATE parked on (connID, asyncId)
+// and invokes its Cancel closure. Used by async-flagged SMB2_CANCEL.
 func (r *PendingCreateRegistry) UnregisterByAsyncId(connID, asyncId uint64) *PendingCreate {
-	p := r.reg.unregisterByAsyncIDOwnedBy(asyncId, func(p *PendingCreate) bool {
-		return p.ConnID == connID
-	})
+	p := r.reg.unregisterByAsyncIDOn(asyncId, connID)
 	if p != nil {
 		markStarted(p)
 		if p.Cancel != nil {

--- a/internal/adapter/smb/handlers/pending_create_registry.go
+++ b/internal/adapter/smb/handlers/pending_create_registry.go
@@ -217,10 +217,13 @@ func (r *PendingCreateRegistry) UnregisterByMessageID(connID, messageID uint64) 
 	return p
 }
 
-// UnregisterByAsyncId removes a pending CREATE matching asyncId and invokes
-// its Cancel closure. Used by async-flagged SMB2_CANCEL.
-func (r *PendingCreateRegistry) UnregisterByAsyncId(asyncId uint64) *PendingCreate {
-	p := r.reg.unregisterByAsyncID(asyncId)
+// UnregisterByAsyncId removes the pending CREATE parked on connID under
+// asyncId and invokes its Cancel closure. Used by async-flagged SMB2_CANCEL.
+// An entry parked on a different connection does not match and is left alone.
+func (r *PendingCreateRegistry) UnregisterByAsyncId(connID, asyncId uint64) *PendingCreate {
+	p := r.reg.unregisterByAsyncIDOwnedBy(asyncId, func(p *PendingCreate) bool {
+		return p.ConnID == connID
+	})
 	if p != nil {
 		markStarted(p)
 		if p.Cancel != nil {

--- a/internal/adapter/smb/handlers/pending_create_registry_test.go
+++ b/internal/adapter/smb/handlers/pending_create_registry_test.go
@@ -87,10 +87,10 @@ func TestPendingCreateRegistry_UnregisterByAsyncId(t *testing.T) {
 	if err := r.Register(p); err != nil {
 		t.Fatalf("Register: %v", err)
 	}
-	if got := r.UnregisterByAsyncId(99); got != nil {
+	if got := r.UnregisterByAsyncId(1, 99); got != nil {
 		t.Errorf("UnregisterByAsyncId(missing) = %v, want nil", got)
 	}
-	if got := r.UnregisterByAsyncId(7); got != p {
+	if got := r.UnregisterByAsyncId(1, 7); got != p {
 		t.Errorf("UnregisterByAsyncId = %v, want %v", got, p)
 	}
 	if r.Len() != 0 {
@@ -273,7 +273,7 @@ func TestPendingCreateRegistry_CancelReleasesGate(t *testing.T) {
 		{
 			name: "UnregisterByAsyncId",
 			cancel: func(r *PendingCreateRegistry, p *PendingCreate) {
-				r.UnregisterByAsyncId(p.AsyncId)
+				r.UnregisterByAsyncId(p.ConnID, p.AsyncId)
 			},
 		},
 		{

--- a/internal/adapter/smb/handlers/pending_lock_registry.go
+++ b/internal/adapter/smb/handlers/pending_lock_registry.go
@@ -185,10 +185,13 @@ func (r *PendingLockRegistry) UnregisterByMessageID(connID, messageID uint64) *P
 	return p
 }
 
-// UnregisterByAsyncId removes a pending LOCK matching asyncId and invokes its
-// Cancel closure. Used by async-flagged SMB2_CANCEL.
-func (r *PendingLockRegistry) UnregisterByAsyncId(asyncId uint64) *PendingLock {
-	p := r.reg.unregisterByAsyncID(asyncId)
+// UnregisterByAsyncId removes the pending LOCK parked on connID under asyncId
+// and invokes its Cancel closure. Used by async-flagged SMB2_CANCEL. An entry
+// parked on a different connection does not match and is left alone.
+func (r *PendingLockRegistry) UnregisterByAsyncId(connID, asyncId uint64) *PendingLock {
+	p := r.reg.unregisterByAsyncIDOwnedBy(asyncId, func(p *PendingLock) bool {
+		return p.ConnID == connID
+	})
 	if p != nil && p.Cancel != nil {
 		p.Cancel()
 	}

--- a/internal/adapter/smb/handlers/pending_lock_registry.go
+++ b/internal/adapter/smb/handlers/pending_lock_registry.go
@@ -122,6 +122,7 @@ func NewPendingLockRegistry() *PendingLockRegistry {
 	return &PendingLockRegistry{
 		reg: newPendingRegistry(registryConfig[PendingLock]{
 			asyncID: func(p *PendingLock) uint64 { return p.AsyncId },
+			connID:  func(p *PendingLock) uint64 { return p.ConnID },
 			indexes: []keyFunc[PendingLock]{
 				func(p *PendingLock) any {
 					return lockMsgKey{ConnID: p.ConnID, MessageID: p.MessageID}
@@ -185,13 +186,10 @@ func (r *PendingLockRegistry) UnregisterByMessageID(connID, messageID uint64) *P
 	return p
 }
 
-// UnregisterByAsyncId removes the pending LOCK parked on connID under asyncId
-// and invokes its Cancel closure. Used by async-flagged SMB2_CANCEL. An entry
-// parked on a different connection does not match and is left alone.
+// UnregisterByAsyncId removes the pending LOCK parked on (connID, asyncId) and
+// invokes its Cancel closure. Used by async-flagged SMB2_CANCEL.
 func (r *PendingLockRegistry) UnregisterByAsyncId(connID, asyncId uint64) *PendingLock {
-	p := r.reg.unregisterByAsyncIDOwnedBy(asyncId, func(p *PendingLock) bool {
-		return p.ConnID == connID
-	})
+	p := r.reg.unregisterByAsyncIDOn(asyncId, connID)
 	if p != nil && p.Cancel != nil {
 		p.Cancel()
 	}

--- a/internal/adapter/smb/handlers/pending_registry.go
+++ b/internal/adapter/smb/handlers/pending_registry.go
@@ -33,6 +33,7 @@ type pendingRegistry[V any] struct {
 	byAsyncID map[uint64]*V
 
 	asyncID func(*V) uint64
+	connID  func(*V) uint64
 
 	indexes []*uniqueIndex[V]
 	buckets []*bucketIndex[V]
@@ -64,6 +65,9 @@ type keyFunc[V any] func(*V) any
 // is configured by a key extractor and addressed by its ordinal position.
 type registryConfig[V any] struct {
 	asyncID func(*V) uint64
+	// connID extracts the connection an entry was parked on, so a lookup
+	// driven by a client-supplied AsyncId can be confined to it.
+	connID  func(*V) uint64
 	indexes []keyFunc[V]
 	buckets []keyFunc[V]
 	maxOps  int
@@ -73,6 +77,7 @@ func newPendingRegistry[V any](cfg registryConfig[V]) *pendingRegistry[V] {
 	r := &pendingRegistry[V]{
 		byAsyncID: make(map[uint64]*V),
 		asyncID:   cfg.asyncID,
+		connID:    cfg.connID,
 		maxOps:    cfg.maxOps,
 	}
 	for _, keyFn := range cfg.indexes {
@@ -140,25 +145,29 @@ func (r *pendingRegistry[V]) Len() int {
 }
 
 // unregisterByAsyncID removes the entry keyed by asyncID, returning it (or nil).
-// The AsyncId alone identifies the entry, so this is for server-internal
-// callers that already own the entry (the resume goroutine after it has
-// delivered its final response). Anything acting on a client-supplied AsyncId
-// must go through unregisterByAsyncIDOwnedBy.
+// For server-internal callers that already own the entry — the resume
+// goroutine retiring its own parked request after it has delivered the final
+// response. A lookup driven by a client-supplied AsyncId must use
+// unregisterByAsyncIDOn instead.
 func (r *pendingRegistry[V]) unregisterByAsyncID(asyncID uint64) *V {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.removeLocked(asyncID)
 }
 
-// unregisterByAsyncIDOwnedBy removes the entry keyed by asyncID only when owns
-// reports true for it, and returns nil otherwise. An AsyncId that arrives on
-// the wire is just a number the peer chose, so every client-driven lookup
-// pairs it with an ownership predicate on the entry it resolves to.
-func (r *pendingRegistry[V]) unregisterByAsyncIDOwnedBy(asyncID uint64, owns func(*V) bool) *V {
+// unregisterByAsyncIDOn removes the entry keyed by asyncID only when it was
+// parked on connID, and returns nil otherwise.
+//
+// An AsyncId is unique only among the requests being processed asynchronously
+// on one transport connection, and one that arrives on the wire is just a
+// number the peer chose. So a client-driven lookup resolves an (AsyncId,
+// connection) pair, never an AsyncId alone — the same way the MessageID
+// indexes carry a ConnID.
+func (r *pendingRegistry[V]) unregisterByAsyncIDOn(asyncID, connID uint64) *V {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	p, ok := r.byAsyncID[asyncID]
-	if !ok || !owns(p) {
+	if !ok || r.connID(p) != connID {
 		return nil
 	}
 	return r.removeLocked(asyncID)

--- a/internal/adapter/smb/handlers/pending_registry.go
+++ b/internal/adapter/smb/handlers/pending_registry.go
@@ -140,9 +140,27 @@ func (r *pendingRegistry[V]) Len() int {
 }
 
 // unregisterByAsyncID removes the entry keyed by asyncID, returning it (or nil).
+// The AsyncId alone identifies the entry, so this is for server-internal
+// callers that already own the entry (the resume goroutine after it has
+// delivered its final response). Anything acting on a client-supplied AsyncId
+// must go through unregisterByAsyncIDOwnedBy.
 func (r *pendingRegistry[V]) unregisterByAsyncID(asyncID uint64) *V {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	return r.removeLocked(asyncID)
+}
+
+// unregisterByAsyncIDOwnedBy removes the entry keyed by asyncID only when owns
+// reports true for it, and returns nil otherwise. An AsyncId that arrives on
+// the wire is just a number the peer chose, so every client-driven lookup
+// pairs it with an ownership predicate on the entry it resolves to.
+func (r *pendingRegistry[V]) unregisterByAsyncIDOwnedBy(asyncID uint64, owns func(*V) bool) *V {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	p, ok := r.byAsyncID[asyncID]
+	if !ok || !owns(p) {
+		return nil
+	}
 	return r.removeLocked(asyncID)
 }
 

--- a/internal/adapter/smb/handlers/pipe_read_registry.go
+++ b/internal/adapter/smb/handlers/pipe_read_registry.go
@@ -14,6 +14,11 @@ type AsyncPipeReadCallback func(sessionID, messageID, asyncId uint64, status typ
 type PendingPipeRead struct {
 	FileID    [16]byte
 	SessionID uint64
+	// ConnID is the stable per-TCP-connection identifier the READ arrived on.
+	// Both cancel keys are scoped to it: MessageID because SMB2 scopes
+	// MessageIDs per connection, and AsyncId because a client-supplied AsyncId
+	// must not reach a read parked on somebody else's connection.
+	ConnID    uint64
 	MessageID uint64
 	AsyncId   uint64
 	MaxLen    int
@@ -23,8 +28,15 @@ type PendingPipeRead struct {
 // Secondary-index slots for PipeReadRegistry, in configured order.
 const (
 	pipeIdxFileID = iota
-	pipeIdxMessageID
+	pipeIdxMsgKey
 )
+
+// pipeMsgKey identifies a pending pipe READ by the connection it arrived on
+// plus its MessageID, which is only unique within that connection.
+type pipeMsgKey struct {
+	ConnID    uint64
+	MessageID uint64
+}
 
 // PipeReadRegistry tracks outstanding async pipe READ operations.
 // Each named-pipe handle can have at most one pending read at a time.
@@ -40,7 +52,9 @@ func NewPipeReadRegistry() *PipeReadRegistry {
 			asyncID: func(p *PendingPipeRead) uint64 { return p.AsyncId },
 			indexes: []keyFunc[PendingPipeRead]{
 				func(p *PendingPipeRead) any { return p.FileID },
-				func(p *PendingPipeRead) any { return p.MessageID },
+				func(p *PendingPipeRead) any {
+					return pipeMsgKey{ConnID: p.ConnID, MessageID: p.MessageID}
+				},
 			},
 		}),
 	}
@@ -77,16 +91,19 @@ func (r *PipeReadRegistry) UnregisterByFileID(fileID [16]byte) *PendingPipeRead 
 	return r.reg.unregisterByIndex(pipeIdxFileID, fileID)
 }
 
-// UnregisterByMessageID removes and returns the pending read with the given MessageID.
-// Returns nil if none is registered.
-func (r *PipeReadRegistry) UnregisterByMessageID(messageID uint64) *PendingPipeRead {
-	return r.reg.unregisterByIndex(pipeIdxMessageID, messageID)
+// UnregisterByMessageID removes and returns the pending read matching
+// (connID, messageID). Returns nil if none is registered.
+func (r *PipeReadRegistry) UnregisterByMessageID(connID, messageID uint64) *PendingPipeRead {
+	return r.reg.unregisterByIndex(pipeIdxMsgKey, pipeMsgKey{ConnID: connID, MessageID: messageID})
 }
 
-// UnregisterByAsyncId removes and returns the pending read with the given AsyncId.
-// Returns nil if none is registered.
-func (r *PipeReadRegistry) UnregisterByAsyncId(asyncId uint64) *PendingPipeRead {
-	return r.reg.unregisterByAsyncID(asyncId)
+// UnregisterByAsyncId removes and returns the pending read parked on connID
+// under asyncId. A read parked on a different connection does not match and is
+// left alone. Returns nil if none is registered.
+func (r *PipeReadRegistry) UnregisterByAsyncId(connID, asyncId uint64) *PendingPipeRead {
+	return r.reg.unregisterByAsyncIDOwnedBy(asyncId, func(p *PendingPipeRead) bool {
+		return p.ConnID == connID
+	})
 }
 
 // UnregisterAllForSession removes and returns all pending reads for the given session.

--- a/internal/adapter/smb/handlers/pipe_read_registry.go
+++ b/internal/adapter/smb/handlers/pipe_read_registry.go
@@ -14,10 +14,8 @@ type AsyncPipeReadCallback func(sessionID, messageID, asyncId uint64, status typ
 type PendingPipeRead struct {
 	FileID    [16]byte
 	SessionID uint64
-	// ConnID is the stable per-TCP-connection identifier the READ arrived on.
-	// Both cancel keys are scoped to it: MessageID because SMB2 scopes
-	// MessageIDs per connection, and AsyncId because a client-supplied AsyncId
-	// must not reach a read parked on somebody else's connection.
+	// ConnID scopes both cancel keys: a MessageID and an AsyncId are unique
+	// only within the connection the request arrived on.
 	ConnID    uint64
 	MessageID uint64
 	AsyncId   uint64

--- a/internal/adapter/smb/handlers/pipe_read_registry.go
+++ b/internal/adapter/smb/handlers/pipe_read_registry.go
@@ -14,8 +14,8 @@ type AsyncPipeReadCallback func(sessionID, messageID, asyncId uint64, status typ
 type PendingPipeRead struct {
 	FileID    [16]byte
 	SessionID uint64
-	// ConnID scopes both cancel keys: a MessageID and an AsyncId are unique
-	// only within the connection the request arrived on.
+	// ConnID is the connection the READ arrived on; both cancel keys are
+	// scoped to it.
 	ConnID    uint64
 	MessageID uint64
 	AsyncId   uint64
@@ -48,6 +48,7 @@ func NewPipeReadRegistry() *PipeReadRegistry {
 	return &PipeReadRegistry{
 		reg: newPendingRegistry(registryConfig[PendingPipeRead]{
 			asyncID: func(p *PendingPipeRead) uint64 { return p.AsyncId },
+			connID:  func(p *PendingPipeRead) uint64 { return p.ConnID },
 			indexes: []keyFunc[PendingPipeRead]{
 				func(p *PendingPipeRead) any { return p.FileID },
 				func(p *PendingPipeRead) any {
@@ -95,13 +96,10 @@ func (r *PipeReadRegistry) UnregisterByMessageID(connID, messageID uint64) *Pend
 	return r.reg.unregisterByIndex(pipeIdxMsgKey, pipeMsgKey{ConnID: connID, MessageID: messageID})
 }
 
-// UnregisterByAsyncId removes and returns the pending read parked on connID
-// under asyncId. A read parked on a different connection does not match and is
-// left alone. Returns nil if none is registered.
+// UnregisterByAsyncId removes and returns the pending read parked on
+// (connID, asyncId). Returns nil if none is registered.
 func (r *PipeReadRegistry) UnregisterByAsyncId(connID, asyncId uint64) *PendingPipeRead {
-	return r.reg.unregisterByAsyncIDOwnedBy(asyncId, func(p *PendingPipeRead) bool {
-		return p.ConnID == connID
-	})
+	return r.reg.unregisterByAsyncIDOn(asyncId, connID)
 }
 
 // UnregisterAllForSession removes and returns all pending reads for the given session.

--- a/internal/adapter/smb/handlers/pipe_read_registry_test.go
+++ b/internal/adapter/smb/handlers/pipe_read_registry_test.go
@@ -32,14 +32,14 @@ func TestPipeReadRegistry_RegisterAndUnregisterByFileID(t *testing.T) {
 	p := newTestPipeRead(1, 10, 100, 1000, nil)
 	r.Register(p)
 
-	if got := r.UnregisterByMessageID(100); got != p {
+	if got := r.UnregisterByMessageID(0, 100); got != p {
 		t.Fatalf("UnregisterByMessageID = %v, want p", got)
 	}
 	// Now gone from all indexes.
 	if got := r.UnregisterByFileID(p.FileID); got != nil {
 		t.Fatalf("UnregisterByFileID after removal = %v, want nil", got)
 	}
-	if got := r.UnregisterByAsyncId(1000); got != nil {
+	if got := r.UnregisterByAsyncId(0, 1000); got != nil {
 		t.Fatalf("UnregisterByAsyncId after removal = %v, want nil", got)
 	}
 }
@@ -67,7 +67,7 @@ func TestPipeReadRegistry_RegisterDisplacesSameFileID(t *testing.T) {
 	}
 
 	// Only the newer entry remains; old indexes are gone.
-	if got := r.UnregisterByAsyncId(1000); got != nil {
+	if got := r.UnregisterByAsyncId(0, 1000); got != nil {
 		t.Errorf("old entry still present: %v", got)
 	}
 	if got := r.UnregisterByFileID(newer.FileID); got != newer {
@@ -86,7 +86,7 @@ func TestPipeReadRegistry_UnregisterAllForSession(t *testing.T) {
 		t.Fatalf("UnregisterAllForSession(10) = %d, want 2", len(got))
 	}
 	// Session 11 entry survives.
-	if got := r.UnregisterByAsyncId(1002); got == nil {
+	if got := r.UnregisterByAsyncId(0, 1002); got == nil {
 		t.Errorf("session 11 entry should survive teardown of session 10")
 	}
 }

--- a/internal/adapter/smb/handlers/pipe_read_registry_test.go
+++ b/internal/adapter/smb/handlers/pipe_read_registry_test.go
@@ -10,11 +10,12 @@ import (
 // newTestPipeRead builds a PendingPipeRead. If done is non-nil it receives the
 // callback status exactly once, letting tests wait deterministically for an
 // async displaced-callback completion.
-func newTestPipeRead(fileID byte, sessionID, messageID, asyncId uint64, done chan<- types.Status) *PendingPipeRead {
+func newTestPipeRead(fileID byte, connID, sessionID, messageID, asyncId uint64, done chan<- types.Status) *PendingPipeRead {
 	var fid [16]byte
 	fid[0] = fileID
 	return &PendingPipeRead{
 		FileID:    fid,
+		ConnID:    connID,
 		SessionID: sessionID,
 		MessageID: messageID,
 		AsyncId:   asyncId,
@@ -29,17 +30,17 @@ func newTestPipeRead(fileID byte, sessionID, messageID, asyncId uint64, done cha
 
 func TestPipeReadRegistry_RegisterAndUnregisterByFileID(t *testing.T) {
 	r := NewPipeReadRegistry()
-	p := newTestPipeRead(1, 10, 100, 1000, nil)
+	p := newTestPipeRead(1, 1, 10, 100, 1000, nil)
 	r.Register(p)
 
-	if got := r.UnregisterByMessageID(0, 100); got != p {
+	if got := r.UnregisterByMessageID(1, 100); got != p {
 		t.Fatalf("UnregisterByMessageID = %v, want p", got)
 	}
 	// Now gone from all indexes.
 	if got := r.UnregisterByFileID(p.FileID); got != nil {
 		t.Fatalf("UnregisterByFileID after removal = %v, want nil", got)
 	}
-	if got := r.UnregisterByAsyncId(0, 1000); got != nil {
+	if got := r.UnregisterByAsyncId(1, 1000); got != nil {
 		t.Fatalf("UnregisterByAsyncId after removal = %v, want nil", got)
 	}
 }
@@ -50,10 +51,10 @@ func TestPipeReadRegistry_RegisterAndUnregisterByFileID(t *testing.T) {
 func TestPipeReadRegistry_RegisterDisplacesSameFileID(t *testing.T) {
 	r := NewPipeReadRegistry()
 	done := make(chan types.Status, 1)
-	old := newTestPipeRead(1, 10, 100, 1000, done)
+	old := newTestPipeRead(1, 1, 10, 100, 1000, done)
 	r.Register(old)
 
-	newer := newTestPipeRead(1, 10, 101, 1001, nil) // same FileID
+	newer := newTestPipeRead(1, 1, 10, 101, 1001, nil) // same FileID
 	r.Register(newer)
 
 	// The displaced entry's callback fires asynchronously with STATUS_CANCELLED.
@@ -67,7 +68,7 @@ func TestPipeReadRegistry_RegisterDisplacesSameFileID(t *testing.T) {
 	}
 
 	// Only the newer entry remains; old indexes are gone.
-	if got := r.UnregisterByAsyncId(0, 1000); got != nil {
+	if got := r.UnregisterByAsyncId(1, 1000); got != nil {
 		t.Errorf("old entry still present: %v", got)
 	}
 	if got := r.UnregisterByFileID(newer.FileID); got != newer {
@@ -77,16 +78,16 @@ func TestPipeReadRegistry_RegisterDisplacesSameFileID(t *testing.T) {
 
 func TestPipeReadRegistry_UnregisterAllForSession(t *testing.T) {
 	r := NewPipeReadRegistry()
-	r.Register(newTestPipeRead(1, 10, 100, 1000, nil))
-	r.Register(newTestPipeRead(2, 10, 101, 1001, nil))
-	r.Register(newTestPipeRead(3, 11, 102, 1002, nil)) // different session
+	r.Register(newTestPipeRead(1, 1, 10, 100, 1000, nil))
+	r.Register(newTestPipeRead(2, 1, 10, 101, 1001, nil))
+	r.Register(newTestPipeRead(3, 1, 11, 102, 1002, nil)) // different session
 
 	got := r.UnregisterAllForSession(10)
 	if len(got) != 2 {
 		t.Fatalf("UnregisterAllForSession(10) = %d, want 2", len(got))
 	}
 	// Session 11 entry survives.
-	if got := r.UnregisterByAsyncId(0, 1002); got == nil {
+	if got := r.UnregisterByAsyncId(1, 1002); got == nil {
 		t.Errorf("session 11 entry should survive teardown of session 10")
 	}
 }

--- a/internal/adapter/smb/handlers/read.go
+++ b/internal/adapter/smb/handlers/read.go
@@ -587,6 +587,7 @@ func (h *Handler) handlePipeRead(ctx *SMBHandlerContext, req *ReadRequest, openF
 		pending := &PendingPipeRead{
 			FileID:    req.FileID,
 			SessionID: ctx.SessionID,
+			ConnID:    ctx.ConnID,
 			MessageID: ctx.MessageID,
 			AsyncId:   asyncId,
 			MaxLen:    int(req.Length),

--- a/internal/adapter/smb/handlers/stub_handlers.go
+++ b/internal/adapter/smb/handlers/stub_handlers.go
@@ -373,7 +373,7 @@ func (h *Handler) Cancel(ctx *SMBHandlerContext, body []byte) (*HandlerResult, e
 			}
 		}
 	}
-	if cancelFn, ok := h.pendingLocks.LoadAndDelete(ctx.MessageID); ok {
+	if cancelFn, ok := h.pendingLocks.LoadAndDelete(lockMsgKey{ConnID: ctx.ConnID, MessageID: ctx.MessageID}); ok {
 		cancelledSomething = true
 		cancelFn.(context.CancelFunc)()
 		logger.Debug("CANCEL: cancelled inline blocking LOCK",

--- a/internal/adapter/smb/handlers/stub_handlers.go
+++ b/internal/adapter/smb/handlers/stub_handlers.go
@@ -248,7 +248,7 @@ func (h *Handler) Cancel(ctx *SMBHandlerContext, body []byte) (*HandlerResult, e
 	if h.NotifyRegistry != nil {
 		var cancelled *PendingNotify
 		if ctx.RequestAsyncId != 0 {
-			cancelled = h.NotifyRegistry.UnregisterByAsyncId(ctx.RequestAsyncId)
+			cancelled = h.NotifyRegistry.UnregisterByAsyncId(ctx.ConnID, ctx.RequestAsyncId)
 		} else {
 			cancelled = h.NotifyRegistry.CancelByMessageID(ctx.ConnID, ctx.MessageID)
 		}
@@ -310,9 +310,9 @@ func (h *Handler) Cancel(ctx *SMBHandlerContext, body []byte) (*HandlerResult, e
 	if h.PipeReadRegistry != nil {
 		var pendingRead *PendingPipeRead
 		if ctx.RequestAsyncId != 0 {
-			pendingRead = h.PipeReadRegistry.UnregisterByAsyncId(ctx.RequestAsyncId)
+			pendingRead = h.PipeReadRegistry.UnregisterByAsyncId(ctx.ConnID, ctx.RequestAsyncId)
 		} else {
-			pendingRead = h.PipeReadRegistry.UnregisterByMessageID(ctx.MessageID)
+			pendingRead = h.PipeReadRegistry.UnregisterByMessageID(ctx.ConnID, ctx.MessageID)
 		}
 		if pendingRead != nil {
 			cancelledSomething = true
@@ -350,7 +350,7 @@ func (h *Handler) Cancel(ctx *SMBHandlerContext, body []byte) (*HandlerResult, e
 	if h.PendingLockRegistry != nil {
 		var parked *PendingLock
 		if ctx.RequestAsyncId != 0 {
-			parked = h.PendingLockRegistry.UnregisterByAsyncId(ctx.RequestAsyncId)
+			parked = h.PendingLockRegistry.UnregisterByAsyncId(ctx.ConnID, ctx.RequestAsyncId)
 		} else {
 			parked = h.PendingLockRegistry.UnregisterByMessageID(ctx.ConnID, ctx.MessageID)
 		}
@@ -386,7 +386,7 @@ func (h *Handler) Cancel(ctx *SMBHandlerContext, body []byte) (*HandlerResult, e
 	if h.PendingCreateRegistry != nil {
 		var parked *PendingCreate
 		if ctx.RequestAsyncId != 0 {
-			parked = h.PendingCreateRegistry.UnregisterByAsyncId(ctx.RequestAsyncId)
+			parked = h.PendingCreateRegistry.UnregisterByAsyncId(ctx.ConnID, ctx.RequestAsyncId)
 		} else {
 			parked = h.PendingCreateRegistry.UnregisterByMessageID(ctx.ConnID, ctx.MessageID)
 		}


### PR DESCRIPTION
SMB2 CANCEL resolved a parked request by an identifier taken off the wire without checking the entry belonged to the connection the cancel arrived on. This fixes that across **three key spaces**, not one — the reported `AsyncId` path, plus two `MessageID`-keyed paths that turned out to have the same hole.

## 1. The reported defect: AsyncId, unscoped

`Handler.Cancel` resolved async-flagged cancels with `UnregisterByAsyncId(ctx.RequestAsyncId)` — a bare global lookup across all four registries (CHANGE_NOTIFY, blocking LOCK, pipe READ, lease-parked CREATE). `ctx.RequestAsyncId` is copied verbatim from `reqHeader.AsyncId`.

`AsyncId`s come from a single server-wide `atomic.Uint64` on the shared `Handler` (`handler.go`, `generateAsyncId`), counting from 1 — not per-connection, not random, not sparse. The ids worth trying are the small integers.

For a parked CREATE the damage outlives the cancel: `Handler.Cancel` runs `p.releaseReplay()`, clearing the victim's DH2Q `CreateGuid` reservation. The existing comment on `releaseReplay` already explains why an out-of-turn release is dangerous — the reservation is keyed by `CreateGuid` alone, not by CREATE instance, so it can clear a *different, newer* CREATE's reservation. A cross-connection cancel is exactly that case, reached from an angle that comment did not anticipate.

## 2. and 3. Two MessageID paths were unscoped too

The issue records the MessageID branch as connection-scoped and "Correct". That holds for three of the five cancel paths. Two were keyed by bare `MessageID`:

- **`PipeReadRegistry`** — `UnregisterByMessageID(ctx.MessageID)`; `PendingPipeRead` carried no `ConnID` at all.
- **`h.pendingLocks`** — the inline blocking-LOCK fallback (`lock.go`), a `sync.Map` keyed on `ctx.MessageID`.

**The `pendingLocks` one needs no attacker.** MessageIDs are per-connection sequence numbers and every connection's window starts near zero, so two clients blocking on locks concurrently routinely hold the same MessageID at the same time — and either one's CANCEL tore down the other's LOCK. That is a live correctness bug, not hardening. The path is reached whenever async parking is declined: compound chain, `LockCount != 1`, async-credit pool exhausted, or registry full.

Both are fixed here. Leaving `UnregisterByMessageID(messageID)` cross-connection-collidable two functions above the AsyncId fix would have been indefensible, and the inline-LOCK map reuses the existing `lockMsgKey` in four lines.

## Why the connection, and not the session

The issue proposed `SessionID`, reasoning that SMB3 multi-channel lets one session span connections, so a `ConnectionID` check would reject a legitimate cancel from a client that failed over to another channel. The spec says otherwise, three times.

MS-SMB2 3.3.5.16, *Receiving an SMB2 CANCEL Request*:

> If SMB2\_FLAGS\_ASYNC\_COMMAND is set in the Flags field of the SMB2 header of the cancel request, the server SHOULD search for a request in **Connection.AsyncCommandList** where **Request.AsyncId** matches the **AsyncId** of the incoming cancel request.

The search set is the connection's list. Session identity plays no part in the match — under 3.3.5.16 it gates only signature verification.

MS-SMB2 3.3.1.13, *Per Request*, is what makes session scoping not merely laxer but ill-defined:

> **Request.AsyncId**: [...] This identifier MUST uniquely identify the **Request** among all requests currently being processed asynchronously on the specified SMB2 transport connection.

Uniqueness is guaranteed per connection only. A compliant server may therefore have the same `AsyncId` live on two channels of one session at once, so a `ConnID`-blind lookup can resolve the *wrong* request by design, and `(SessionID, AsyncId)` does not name one request either.

The multi-channel worry does not survive the client side. MS-SMB2 3.2.4.24 has the client locate the request in a specific `Connection.OutstandingRequests` before building the CANCEL, so a compliant client never redirects a cancel to a sibling channel. One that arrives on another channel is required by 3.3.5.16 to find nothing and be dropped silently — which is what this change now does.

`ConnID` is also what the MessageID indexes already use, so both branches of `Handler.Cancel` end up the same shape.

## The change

`registryConfig` gains a `connID` extractor alongside the existing `asyncID` one, and `pendingRegistry` gains `unregisterByAsyncIDOn(asyncID, connID)`. Each registry's `UnregisterByAsyncId` becomes a one-liner; no per-call-site closures. The unchecked `unregisterByAsyncID` stays for the server-internal caller that legitimately owns the entry — the resume goroutine retiring its own request after delivering the final response — so the checked and unchecked paths stay visibly distinct. `NotifyRegistry` keeps its hand-written index and carries the same check inline.

All four `UnregisterByAsyncId` methods had exactly one production caller, `Handler.Cancel`, so nothing else is affected.

## Reproduction

`cancel_asyncid_scope_test.go` parks a victim on connection 1 and fires the cancel from connection 2, for each of the four registries plus the inline-LOCK path. Against the unscoped lookups:

```
--- FAIL: TestPendingCreateRegistry_UnregisterByAsyncIdIsConnectionScoped
    UnregisterByAsyncId(conn 2, victim's asyncId) = &{1 10 100 7 ...}, want nil
    Len after foreign cancel = 0, want 1 (victim still parked)
--- FAIL: TestPendingLockRegistry_UnregisterByAsyncIdIsConnectionScoped
    victim's Cancel fired 1 times on a foreign cancel, want 0
--- FAIL: TestPipeReadRegistry_UnregisterByAsyncIdIsConnectionScoped
--- FAIL: TestNotifyRegistry_UnregisterByAsyncIdIsConnectionScoped
--- FAIL: TestCancel_InlineBlockingLockIsConnectionScoped
    a CANCEL from another connection tore down the inline LOCK
```

`TestCancel_InlineBlockingLockIsConnectionScoped` drives the real `Handler.Cancel` dispatch path rather than poking the map. Every case also asserts the owning connection's cancel still succeeds, so none can pass by refusing everything.

Two subtests in `lock_test.go` (`TestPendingLockCancel/CancelInterruptsBlockingLock` and `/CancelNonexistentLock`) are deleted. They stored and loaded `h.pendingLocks` under a bare `uint64` without ever calling `h.Lock()` or `h.Cancel()` — a `sync.Map` tautology that proved nothing about the handler, and after this change asserted against a key shape production no longer uses. `TestCancel_InlineBlockingLockIsConnectionScoped` is their honest replacement. `/BlockingLockReturnsOnContextCancel` is real and stays.

Verified against current `develop`, not the audit's pin: all four `UnregisterByAsyncId` still took `asyncId` alone.

## Not changed

An async-flagged CANCEL carrying `AsyncId == 0` falls through to the MessageID branch rather than searching the async list and missing. `generateAsyncId` starts at 1, so no async entry could ever match a zero anyway, but a client can reach a *synchronous* request by MessageID this way, which 3.3.5.16 does not permit. That fallthrough is load-bearing for the CHANGE_NOTIFY tombstone race documented at the branch, so untangling it belongs in its own change with its own test.

## Testing

`go build ./...`, `go vet ./...`, `go test ./...`, `go test -race ./internal/adapter/smb/...`, and `golangci-lint` all pass.

Closes #2414
