### PR TITLE
fix(nfs): check read permission in NFSv4 READ, READ_PLUS and SEEK

### DIFF
--- a/internal/adapter/nfs/v4/handlers/helpers.go
+++ b/internal/adapter/nfs/v4/handlers/helpers.go
@@ -241,6 +241,40 @@ func (h *Handler) checkNetgroupAccess(ctx *types.CompoundContext, shareName stri
 	return nil
 }
 
+// checkReadPermission gates a data read on the caller's read permission for
+// handle, reporting the NFS4 status to answer with — NFS4_OK when the read may
+// proceed.
+//
+// The read-family operations all accept the anonymous (all-zero) and
+// READ-bypass (all-one) special stateids, which carry no open state and so
+// never went through OPEN's permission check. The share-access check on a real
+// open stateid does not cover it either: that constrains how the file was
+// opened, not who the caller is.
+//
+// The gate must stay unconditional rather than narrowing to the special-stateid
+// case. A non-nil open state says the file was opened with the right mode; it
+// says nothing about which client is presenting the stateid, so skipping the
+// check whenever one exists would reopen the same hole through another door.
+func checkReadPermission(
+	metaSvc *metadata.Service,
+	ctx *types.CompoundContext,
+	authCtx *metadata.AuthContext,
+	handle metadata.FileHandle,
+	file *metadata.File,
+	op uint32,
+) uint32 {
+	if err := metaSvc.CheckReadPermissionFile(authCtx, handle, file); err != nil {
+		status := common.MapToNFS4(err)
+		logger.Debug("NFSv4 read denied",
+			"op", types.OpName(op),
+			"nfs_status", status,
+			"error", err,
+			"client", ctx.ClientAddr)
+		return status
+	}
+	return types.NFS4_OK
+}
+
 // resolveBlockStore resolves the per-share block store for ctx.CurrentFH,
 // taking the write path when forWrite is set. On failure it returns the
 // SERVERFAULT result the caller returns unchanged, tagged with op.

--- a/internal/adapter/nfs/v4/handlers/io_test.go
+++ b/internal/adapter/nfs/v4/handlers/io_test.go
@@ -1729,3 +1729,74 @@ func TestRename_ReclaimsClobberedPayloadBytes(t *testing.T) {
 		t.Fatalf("renamed file's payload %q was dropped from the local tier by RENAME", survivorPayload)
 	}
 }
+
+// readFamilyOps are the v4 operations that serve, or derive from, file
+// content and therefore share one read-permission gate.
+var readFamilyOps = []struct {
+	name string
+	call func(*Handler, *types.CompoundContext) *types.CompoundResult
+}{
+	{"READ", func(h *Handler, ctx *types.CompoundContext) *types.CompoundResult {
+		return h.handleRead(ctx, bytes.NewReader(encodeReadArgs(&anonymousStateid, 0, 1024)))
+	}},
+	{"READ_PLUS", func(h *Handler, ctx *types.CompoundContext) *types.CompoundResult {
+		return h.handleReadPlus(ctx, bytes.NewReader(encodeReadArgs(&anonymousStateid, 0, 1024)))
+	}},
+	// SEEK reports where a file's data and holes begin. That map derives from
+	// the same content, so it is subject to the same gate: without it a caller
+	// who cannot read the file can still binary-search the layout of its
+	// non-zero bytes.
+	{"SEEK", func(h *Handler, ctx *types.CompoundContext) *types.CompoundResult {
+		return h.handleSeek(ctx, encSeekArgs(&anonymousStateid, 0, types.NFS4_CONTENT_DATA))
+	}},
+}
+
+// TestReadPermissionDenied runs the read-family operations against a
+// root-owned mode-0600 file as uid 1000, presenting the anonymous (all-zero)
+// stateid. That stateid carries no open state, so nothing else in the read
+// path consults the file's mode: without the gate the handlers answer NFS4_OK
+// and hand back the file's bytes.
+//
+// The mode is 0600 rather than 0000 because CreateFile treats a zero mode as
+// "unset" and substitutes the 0644 default, which would leave the file
+// world-readable and the test vacuous.
+func TestReadPermissionDenied(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+	fileHandle := fx.createRegularFile(t, fx.rootHandle, "rootsecret.txt", 0o600, 0, 0)
+	secret := []byte("root eyes only")
+	fx.writeContent(t, fileHandle, secret)
+
+	for _, op := range readFamilyOps {
+		t.Run(op.name, func(t *testing.T) {
+			ctx := newRealFSContext(1000, 1000)
+			ctx.CurrentFH = fileHandle
+			result := op.call(fx.handler, ctx)
+			if result.Status != types.NFS4ERR_ACCESS {
+				t.Errorf("status = %d, want NFS4ERR_ACCESS (%d)", result.Status, types.NFS4ERR_ACCESS)
+			}
+			if bytes.Contains(result.Data, secret) {
+				t.Errorf("leaked file content in a denied reply")
+			}
+		})
+	}
+}
+
+// TestReadPermissionGranted is the companion: the gate must cost an ordinary
+// owner read nothing. It also establishes that the denials above come from the
+// per-file check and not from the share-level policy, which is permissive for
+// uid 1000 in this fixture.
+func TestReadPermissionGranted(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+	fileHandle := fx.createRegularFile(t, fx.rootHandle, "mine.txt", 0o644, 1000, 1000)
+	fx.writeContent(t, fileHandle, []byte("owner readable"))
+
+	for _, op := range readFamilyOps {
+		t.Run(op.name, func(t *testing.T) {
+			ctx := newRealFSContext(1000, 1000)
+			ctx.CurrentFH = fileHandle
+			if result := op.call(fx.handler, ctx); result.Status != types.NFS4_OK {
+				t.Errorf("status = %d, want NFS4_OK", result.Status)
+			}
+		})
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/read.go
+++ b/internal/adapter/nfs/v4/handlers/read.go
@@ -18,7 +18,7 @@ import (
 // Reads file data at a given offset, returning bytes and EOF flag.
 // Delegates to BlockStore.ReadAt via pooled buffers; validates stateid for open state.
 // No side effects; read-only data operation using buffer pools to reduce GC pressure.
-// Errors: NFS4ERR_NOFILEHANDLE, NFS4ERR_ISDIR, NFS4ERR_STALE, NFS4ERR_IO, NFS4ERR_BADXDR.
+// Errors: NFS4ERR_NOFILEHANDLE, NFS4ERR_ISDIR, NFS4ERR_ACCESS, NFS4ERR_STALE, NFS4ERR_IO, NFS4ERR_BADXDR.
 func (h *Handler) handleRead(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
 	// Require current filehandle
 	if status := types.RequireCurrentFH(ctx); status != types.NFS4_OK {
@@ -108,6 +108,9 @@ func (h *Handler) handleRead(ctx *types.CompoundContext, reader io.Reader) *type
 		return readErr(status)
 	}
 
+	if status := checkReadPermission(metaSvc, ctx, authCtx, fileHandle, file, types.OP_READ); status != types.NFS4_OK {
+		return readErr(status)
+	}
 	// Empty file or no content
 	if file.Size == 0 || file.PayloadID == "" {
 		return encodeRead4resok(true, nil)

--- a/internal/adapter/nfs/v4/handlers/read_plus.go
+++ b/internal/adapter/nfs/v4/handlers/read_plus.go
@@ -90,12 +90,16 @@ func (h *Handler) handleReadPlus(ctx *types.CompoundContext, reader io.Reader) *
 	}
 
 	// GetFileForRead: handle-addressed, File.Path unused — skip derivePath.
-	file, err := metaSvc.GetFileForRead(authCtx.Context, metadata.FileHandle(ctx.CurrentFH))
+	fileHandle := metadata.FileHandle(ctx.CurrentFH)
+	file, err := metaSvc.GetFileForRead(authCtx.Context, fileHandle)
 	if err != nil {
 		return readPlusErr(common.MapToNFS4(err))
 	}
 	if file.Type != metadata.FileTypeRegular {
 		return readPlusErr(readTypeError(file.Type))
+	}
+	if status := checkReadPermission(metaSvc, ctx, authCtx, fileHandle, file, types.OP_READ_PLUS); status != types.NFS4_OK {
+		return readPlusErr(status)
 	}
 
 	// Empty file or read entirely past EOF: an empty content array with EOF set.

--- a/internal/adapter/nfs/v4/handlers/seek.go
+++ b/internal/adapter/nfs/v4/handlers/seek.go
@@ -80,12 +80,16 @@ func (h *Handler) handleSeek(ctx *types.CompoundContext, reader io.Reader) *type
 	}
 
 	// GetFileForRead: handle-addressed, File.Path unused — skip derivePath.
-	file, err := metaSvc.GetFileForRead(authCtx.Context, metadata.FileHandle(ctx.CurrentFH))
+	fileHandle := metadata.FileHandle(ctx.CurrentFH)
+	file, err := metaSvc.GetFileForRead(authCtx.Context, fileHandle)
 	if err != nil {
 		return seekErr(common.MapToNFS4(err))
 	}
 	if file.Type != metadata.FileTypeRegular {
 		return seekErr(types.NFS4ERR_ISDIR)
+	}
+	if status := checkReadPermission(metaSvc, ctx, authCtx, fileHandle, file, types.OP_SEEK); status != types.NFS4_OK {
+		return seekErr(status)
 	}
 
 	// sa_offset at or beyond EOF: no data and no in-file hole remain.
@@ -98,7 +102,7 @@ func (h *Handler) handleSeek(ctx *types.CompoundContext, reader io.Reader) *type
 	// manifest — the same view READ reconstructs. Deriving it from file.Blocks
 	// (the CAS block list) alone reports a hole where written-but-not-yet-
 	// rolled-up data exists, which RFC 7862 forbids and risks sparse-copy data
-	// loss (#1481). Fall back to the CAS-block-list path if the engine can't be
+	// loss. Fall back to the CAS-block-list path if the engine can't be
 	// resolved or errors, so SEEK never regresses below its prior behaviour.
 	var (
 		nextOffset uint64


### PR DESCRIPTION
## What was wrong

NFSv4 READ, READ_PLUS and SEEK performed no file-level permission check of any kind. They validated the stateid, enforced the open's share-access bits *when an open stateid was presented*, and then read the file.

The anonymous (all-zero) and READ-bypass (all-one) special stateids are legal on READ and return a `nil` openState, so for those the share-access check is skipped entirely and nothing else consults the file's mode or ACL. A client only needs execute permission on the parent directory to LOOKUP a filehandle; from there it could read the whole file.

NFSv3 has never had this hole — `v3/handlers/read.go` calls `CheckReadPermissionFile` explicitly. WRITE, COMMIT, CLONE, ALLOCATE/DEALLOCATE and the xattr ops all gate internally too. READ, READ_PLUS and SEEK were the v4 I/O operations with no file-level authorization at all.

## Premise re-verified on current develop

The audit that produced the issue was pinned at `40884ad4f`, before PR #2356. Re-checked on `fa173706a`: neither handler contains any call to `CheckReadPermissionFile` or `CheckPermissions`. The `anonymousIOBlocked` gate added by #2377/#2380 does not close it — that refuses anonymous-stateid I/O that conflicts with a *share reservation*, which is a different question from whether the caller may read the file.

## Verified on a real kernel-client host, two builds

A hand-crafted NFSv4.0 COMPOUND (`PUTROOTFH`, `LOOKUP`, `LOOKUP`, `READ` with an all-zero stateid) against a `dfs` server on Linux 6.8, reading a root-owned `mode 0600` file as uid 1000:

**Pre-fix build (`fa173706a`):**
```
compound status=0 ops=4
  op=24 status=0
  op=15 status=0
  op=15 status=0
  op=READ status=0 eof=1 bytes=20 data="root eyes only 2394\n"
```

**Post-fix build, same server state, same request:**
```
compound status=13 ops=4      <- NFS4ERR_ACCESS
  op=24 status=0
  op=15 status=0
  op=15 status=0
  op=25 status=13
```

The file's owner (uid 0) still reads it normally on the post-fix build.

## The fix

One shared helper, `checkReadPermission`, in `read.go`, called from `handleRead`, `handleReadPlus` and `handleSeek` after the regular-file type check and before any content is read, segmented or mapped. It mirrors what v3 READ does. The helper takes the operation name so a denial still logs under its own operation.

The check sits *before* the empty-file and past-EOF short-circuits, so a caller who cannot read the file gets `NFS4ERR_ACCESS` rather than a "successful" empty reply.

## SEEK

The issue names READ and READ_PLUS. Review of the shared seam found `handleSeek` has the identical bypass: it validates a stateid for read access with special stateids permitted, calls the same unchecked `GetFileForRead`, and then reports where the file's data and holes begin. That is content-derived information — enough to binary-search where a file's non-zero bytes live — reachable by a caller with no read permission. Fixing only the two operations named would have left a third caller on the same seam open, so SEEK is included here.

`READLINK` was checked and deliberately left alone: POSIX `readlink(2)` does not consult the symlink's own mode bits, so gating it would be non-conformant rather than a fix.

## Tests

`TestReadPermissionDenied` covers READ, READ_PLUS and SEEK against a root-owned `mode 0600` file read by uid 1000 with the anonymous stateid. It asserts `NFS4ERR_ACCESS` *and* that the reply body does not contain the file's bytes — a status-only assertion would pass a future refactor that serializes content before returning the error. `TestReadPermissionGranted` is the companion showing the gate costs the owner nothing.

Both fail on the pre-fix tree:
```
--- FAIL: TestReadPermissionDenied/READ
    io_test.go:1755: READ status = 0, want NFS4ERR_ACCESS (13)
    io_test.go:1758: READ leaked file content in a denied reply
--- FAIL: TestReadPermissionDenied/READ_PLUS
    io_test.go:1767: READ_PLUS status = 0, want NFS4ERR_ACCESS (13)
    io_test.go:1770: READ_PLUS leaked file content in a denied reply
```

Note for anyone writing a similar test: the mode must be `0600`, not `0000`. `CreateFile` treats a zero mode as "unset" and substitutes the `0644` default, which leaves the file world-readable and the test vacuous.

Closes #2394
