### PR TITLE
fix(nfs): bind NFSv4 I/O stateids to the client that owns them

### DIFF
--- a/internal/adapter/nfs/v4/handlers/allocate.go
+++ b/internal/adapter/nfs/v4/handlers/allocate.go
@@ -50,7 +50,7 @@ func (h *Handler) handleAllocate(ctx *types.CompoundContext, reader io.Reader) *
 
 	// ALLOCATE may change the file size: validate the stateid as a write op and
 	// require WRITE share-access on a real open stateid (special stateids pass).
-	if openState, stateErr := h.StateManager.ValidateStateid(stateid, ctx.CurrentFH, state.StateidOpWrite); stateErr != nil {
+	if openState, stateErr := h.StateManager.ValidateStateid(stateid, ctx.CurrentFH, state.StateidOpWrite, ctx.SessionClientID); stateErr != nil {
 		s := mapStateError(stateErr)
 		logger.Debug("NFSv4.2 ALLOCATE stateid validation failed", "error", stateErr, "nfs_status", s, "client", ctx.ClientAddr)
 		return allocErr(s)

--- a/internal/adapter/nfs/v4/handlers/clone.go
+++ b/internal/adapter/nfs/v4/handlers/clone.go
@@ -80,14 +80,14 @@ func (h *Handler) handleClone(ctx *types.CompoundContext, reader io.Reader) *typ
 
 	// Validate the source stateid for READ and the destination for WRITE. Special
 	// stateids pass; a real open must carry the matching share-access bit.
-	if openState, err := h.StateManager.ValidateStateid(srcStateid, ctx.SavedFH, state.StateidOpRead); err != nil {
+	if openState, err := h.StateManager.ValidateStateid(srcStateid, ctx.SavedFH, state.StateidOpRead, ctx.SessionClientID); err != nil {
 		s := mapStateError(err)
 		logger.Debug("NFSv4.2 CLONE src stateid validation failed", "error", err, "nfs_status", s, "client", ctx.ClientAddr)
 		return cloneErr(s)
 	} else if openState != nil && openState.ShareAccess&types.OPEN4_SHARE_ACCESS_READ == 0 {
 		return cloneErr(types.NFS4ERR_OPENMODE)
 	}
-	if openState, err := h.StateManager.ValidateStateid(dstStateid, ctx.CurrentFH, state.StateidOpWrite); err != nil {
+	if openState, err := h.StateManager.ValidateStateid(dstStateid, ctx.CurrentFH, state.StateidOpWrite, ctx.SessionClientID); err != nil {
 		s := mapStateError(err)
 		logger.Debug("NFSv4.2 CLONE dst stateid validation failed", "error", err, "nfs_status", s, "client", ctx.ClientAddr)
 		return cloneErr(s)

--- a/internal/adapter/nfs/v4/handlers/deallocate.go
+++ b/internal/adapter/nfs/v4/handlers/deallocate.go
@@ -46,7 +46,7 @@ func (h *Handler) handleDeallocate(ctx *types.CompoundContext, reader io.Reader)
 
 	// DEALLOCATE modifies file content: validate the stateid as a write op and
 	// require WRITE share-access on a real open stateid (special stateids pass).
-	if openState, stateErr := h.StateManager.ValidateStateid(stateid, ctx.CurrentFH, state.StateidOpWrite); stateErr != nil {
+	if openState, stateErr := h.StateManager.ValidateStateid(stateid, ctx.CurrentFH, state.StateidOpWrite, ctx.SessionClientID); stateErr != nil {
 		s := mapStateError(stateErr)
 		logger.Debug("NFSv4.2 DEALLOCATE stateid validation failed", "error", stateErr, "nfs_status", s, "client", ctx.ClientAddr)
 		return deallocErr(s)

--- a/internal/adapter/nfs/v4/handlers/read.go
+++ b/internal/adapter/nfs/v4/handlers/read.go
@@ -51,7 +51,7 @@ func (h *Handler) handleRead(ctx *types.CompoundContext, reader io.Reader) *type
 	// permitted on READ and return a nil openState. Real open stateids are
 	// validated for correctness (seqid, epoch, filehandle match) and carry the
 	// open's share-access bits.
-	openState, stateErr := h.StateManager.ValidateStateid(stateid, ctx.CurrentFH, state.StateidOpRead)
+	openState, stateErr := h.StateManager.ValidateStateid(stateid, ctx.CurrentFH, state.StateidOpRead, ctx.SessionClientID)
 	if stateErr != nil {
 		nfsStatus := mapStateError(stateErr)
 		logger.Debug("NFSv4 READ stateid validation failed",

--- a/internal/adapter/nfs/v4/handlers/read_plus.go
+++ b/internal/adapter/nfs/v4/handlers/read_plus.go
@@ -72,7 +72,7 @@ func (h *Handler) handleReadPlus(ctx *types.CompoundContext, reader io.Reader) *
 
 	// READ_PLUS shares READ's stateid semantics: special stateids are allowed,
 	// a real open stateid must carry READ access.
-	if openState, stateErr := h.StateManager.ValidateStateid(stateid, ctx.CurrentFH, state.StateidOpRead); stateErr != nil {
+	if openState, stateErr := h.StateManager.ValidateStateid(stateid, ctx.CurrentFH, state.StateidOpRead, ctx.SessionClientID); stateErr != nil {
 		st := mapStateError(stateErr)
 		logger.Debug("NFSv4.2 READ_PLUS stateid validation failed", "error", stateErr, "nfs_status", st, "client", ctx.ClientAddr)
 		return readPlusErr(st)

--- a/internal/adapter/nfs/v4/handlers/seek.go
+++ b/internal/adapter/nfs/v4/handlers/seek.go
@@ -62,7 +62,7 @@ func (h *Handler) handleSeek(ctx *types.CompoundContext, reader io.Reader) *type
 
 	// SEEK is a read-family operation: validate the stateid for read access
 	// (special stateids permitted), mirroring READ.
-	if openState, stateErr := h.StateManager.ValidateStateid(stateid, ctx.CurrentFH, state.StateidOpRead); stateErr != nil {
+	if openState, stateErr := h.StateManager.ValidateStateid(stateid, ctx.CurrentFH, state.StateidOpRead, ctx.SessionClientID); stateErr != nil {
 		st := mapStateError(stateErr)
 		logger.Debug("NFSv4.2 SEEK stateid validation failed", "error", stateErr, "nfs_status", st, "client", ctx.ClientAddr)
 		return seekErr(st)

--- a/internal/adapter/nfs/v4/handlers/setattr.go
+++ b/internal/adapter/nfs/v4/handlers/setattr.go
@@ -97,7 +97,7 @@ func (h *Handler) handleSetAttr(ctx *types.CompoundContext, reader io.Reader) *t
 		if sizeChange {
 			op = state.StateidOpWrite
 		}
-		openState, stateErr := h.StateManager.ValidateStateid(stateid, ctx.CurrentFH, op)
+		openState, stateErr := h.StateManager.ValidateStateid(stateid, ctx.CurrentFH, op, ctx.SessionClientID)
 		if stateErr != nil {
 			nfsStatus := mapStateError(stateErr)
 			logger.Debug("NFSv4 SETATTR stateid validation failed",

--- a/internal/adapter/nfs/v4/handlers/stateid_client_binding_test.go
+++ b/internal/adapter/nfs/v4/handlers/stateid_client_binding_test.go
@@ -1,0 +1,93 @@
+package handlers
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// TestCompoundV41_ReadRejectsAnotherClientsStateid drives the owner-to-client
+// binding end to end: two clients each get their own EXCHANGE_ID and
+// CREATE_SESSION, one opens a file, and the other presents the resulting open
+// stateid to READ.
+//
+// The StateManager tests hand ValidateStateid a client ID directly, so they
+// prove the guard works but not that the handlers reach it. This covers the
+// wiring — SEQUENCE putting the session's client on the compound context, and
+// the READ call site passing it through — which is what silently breaks when a
+// new I/O call site is added or the context is refactored.
+func TestCompoundV41_ReadRejectsAnotherClientsStateid(t *testing.T) {
+	const filename = "v41-cross-client-read.txt"
+
+	fx := newIOTestFixture(t, "/export")
+	sessionA := createSessionOn(t, fx.handler, "cross-client-a")
+	sessionB := createSessionOn(t, fx.handler, "cross-client-b")
+
+	// Client A opens the file and keeps the stateid.
+	openArgs := encodeOpenArgs(
+		0, types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE,
+		0, []byte("owner-a"),
+		types.OPEN4_CREATE, types.UNCHECKED4, types.CLAIM_NULL, filename,
+	)
+	resp := processV41Compound(t, fx.handler, "open", fx.rootHandle, []compoundOp{
+		{opCode: types.OP_SEQUENCE, data: encodeSequenceArgs(sessionA, 0, 1, 0, false)},
+		{opCode: types.OP_OPEN, data: openArgs},
+	})
+	openStateid, err := types.DecodeStateid4(skipToLastResult(t, resp, 2, types.OP_OPEN))
+	if err != nil {
+		t.Fatalf("decode OPEN stateid: %v", err)
+	}
+
+	file, err := fx.metaSvc.Lookup(newTestAuthCtx(0, 0), fx.rootHandle, filename)
+	if err != nil {
+		t.Fatalf("lookup %s: %v", filename, err)
+	}
+	fileHandle, err := metadata.EncodeFileHandle(file)
+	if err != nil {
+		t.Fatalf("encode handle: %v", err)
+	}
+
+	readArgs := encodeReadArgs(openStateid, 0, 1024)
+
+	// Client B presenting client A's stateid must be refused.
+	if got := readStatusV41(t, fx.handler, fileHandle, sessionB, 1, readArgs); got != types.NFS4ERR_BAD_STATEID {
+		t.Errorf("READ from the other client = %d, want NFS4ERR_BAD_STATEID (%d)", got, types.NFS4ERR_BAD_STATEID)
+	}
+
+	// The owning client must still be able to use it.
+	if got := readStatusV41(t, fx.handler, fileHandle, sessionA, 2, readArgs); got != types.NFS4_OK {
+		t.Errorf("READ from the owning client = %d, want NFS4_OK", got)
+	}
+}
+
+// readStatusV41 runs SEQUENCE + READ on the given session and returns the READ
+// operation's status. A COMPOUND reports the status of its last executed
+// operation as the overall status, so with both results present that is READ's
+// own. It deliberately does not assert success: the refusal case is the point.
+func readStatusV41(t *testing.T, h *Handler, fh metadata.FileHandle, sessionID types.SessionId4, slotSeq uint32, readArgs []byte) uint32 {
+	t.Helper()
+
+	ctx := newTestCompoundContext()
+	ctx.CurrentFH = make([]byte, len(fh))
+	copy(ctx.CurrentFH, fh)
+
+	resp, err := h.ProcessCompound(ctx, buildCompoundArgsWithOps([]byte("read"), 1, []compoundOp{
+		{opCode: types.OP_SEQUENCE, data: encodeSequenceArgs(sessionID, 0, slotSeq, 0, false)},
+		{opCode: types.OP_READ, data: readArgs},
+	}))
+	if err != nil {
+		t.Fatalf("READ COMPOUND error: %v", err)
+	}
+
+	reader := bytes.NewReader(resp)
+	status, _ := xdr.DecodeUint32(reader)
+	_, _ = xdr.DecodeOpaque(reader) // tag
+	numResults, _ := xdr.DecodeUint32(reader)
+	if numResults != 2 {
+		t.Fatalf("numResults = %d, want 2 (READ did not run; SEQUENCE status %d)", numResults, status)
+	}
+	return status
+}

--- a/internal/adapter/nfs/v4/handlers/write.go
+++ b/internal/adapter/nfs/v4/handlers/write.go
@@ -114,7 +114,7 @@ func (h *Handler) handleWrite(ctx *types.CompoundContext, reader io.Reader) *typ
 	// NFS4ERR_LOCKED when an open on this file denies writing. Real stateids
 	// are validated for correctness (seqid, epoch, filehandle match); implicit
 	// lease renewal happens inside ValidateStateid for real stateids.
-	openState, stateErr := h.StateManager.ValidateStateid(stateid, ctx.CurrentFH, state.StateidOpWrite)
+	openState, stateErr := h.StateManager.ValidateStateid(stateid, ctx.CurrentFH, state.StateidOpWrite, ctx.SessionClientID)
 	if stateErr != nil {
 		nfsStatus := mapStateError(stateErr)
 		logger.Debug("NFSv4 WRITE stateid validation failed",

--- a/internal/adapter/nfs/v4/state/lease_expiry_stateid_test.go
+++ b/internal/adapter/nfs/v4/state/lease_expiry_stateid_test.go
@@ -31,7 +31,7 @@ func TestExpiredLease_StateidsReportExpired(t *testing.T) {
 
 	sm.onLeaseExpired(clientID)
 
-	if _, err := sm.ValidateStateid(openStateid, fileHandle, StateidOpRead); !isStatus(err, types.NFS4ERR_EXPIRED) {
+	if _, err := sm.ValidateStateid(openStateid, fileHandle, StateidOpRead, 0); !isStatus(err, types.NFS4ERR_EXPIRED) {
 		t.Fatalf("ValidateStateid after lease cancellation: got %v, want NFS4ERR_EXPIRED", err)
 	}
 
@@ -39,7 +39,7 @@ func TestExpiredLease_StateidsReportExpired(t *testing.T) {
 		t.Fatalf("CloseFile after lease cancellation: got %v, want NFS4ERR_EXPIRED", err)
 	}
 
-	if _, err := sm.ValidateStateid(unknown, fileHandle, StateidOpRead); !isStatus(err, types.NFS4ERR_BAD_STATEID) {
+	if _, err := sm.ValidateStateid(unknown, fileHandle, StateidOpRead, 0); !isStatus(err, types.NFS4ERR_BAD_STATEID) {
 		t.Fatalf("ValidateStateid of a never-issued stateid: got %v, want NFS4ERR_BAD_STATEID", err)
 	}
 }

--- a/internal/adapter/nfs/v4/state/lease_test.go
+++ b/internal/adapter/nfs/v4/state/lease_test.go
@@ -230,7 +230,7 @@ func TestImplicitRenewal_ViaValidateStateid(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 
 	// ValidateStateid should implicitly renew the lease
-	openState, err := sm.ValidateStateid(confirmedStateid, []byte("fh-implicit-renew"), StateidOpRead)
+	openState, err := sm.ValidateStateid(confirmedStateid, []byte("fh-implicit-renew"), StateidOpRead, 0)
 	if err != nil {
 		t.Fatalf("ValidateStateid: %v", err)
 	}
@@ -289,7 +289,7 @@ func TestLeaseExpired_ReturnsError(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// ValidateStateid should return NFS4ERR_EXPIRED
-	_, err = sm.ValidateStateid(confirmedStateid, []byte("fh-expired"), StateidOpRead)
+	_, err = sm.ValidateStateid(confirmedStateid, []byte("fh-expired"), StateidOpRead, 0)
 	if err == nil {
 		t.Fatal("ValidateStateid should fail for expired lease")
 	}

--- a/internal/adapter/nfs/v4/state/lockowner_test.go
+++ b/internal/adapter/nfs/v4/state/lockowner_test.go
@@ -814,7 +814,7 @@ func TestLeaseExpiry_CleansLockState(t *testing.T) {
 	}
 
 	// Verify open state is also removed
-	_, openValErr := sm.ValidateStateid(openStateid, fileHandle, StateidOpRead)
+	_, openValErr := sm.ValidateStateid(openStateid, fileHandle, StateidOpRead, 0)
 	if openValErr == nil {
 		t.Fatal("expected error for open stateid after lease expiry")
 	}

--- a/internal/adapter/nfs/v4/state/shareres_test.go
+++ b/internal/adapter/nfs/v4/state/shareres_test.go
@@ -176,7 +176,7 @@ func TestValidateStateid_ReadBypass_AcceptedOnReadAndWrite(t *testing.T) {
 	sm := NewStateManager(90 * time.Second)
 
 	// READ: all-ones is permitted (returns nil openState, nil error).
-	openState, err := sm.ValidateStateid(readBypassStateid(), nil, StateidOpRead)
+	openState, err := sm.ValidateStateid(readBypassStateid(), nil, StateidOpRead, 0)
 	if err != nil {
 		t.Fatalf("read-bypass on READ should be allowed: %v", err)
 	}
@@ -186,7 +186,7 @@ func TestValidateStateid_ReadBypass_AcceptedOnReadAndWrite(t *testing.T) {
 
 	// WRITE: all-ones is accepted too, behaving as the anonymous stateid
 	// (RFC 7530 Section 16.36.4). With no open on the file nothing denies it.
-	openState, err = sm.ValidateStateid(readBypassStateid(), nil, StateidOpWrite)
+	openState, err = sm.ValidateStateid(readBypassStateid(), nil, StateidOpWrite, 0)
 	if err != nil {
 		t.Fatalf("read-bypass on WRITE should be allowed: %v", err)
 	}
@@ -200,7 +200,7 @@ func TestValidateStateid_Anonymous_AllowedOnReadAndWrite(t *testing.T) {
 	anon := &types.Stateid4{Seqid: 0} // all-zeros other
 
 	for _, op := range []StateidOp{StateidOpRead, StateidOpWrite} {
-		openState, err := sm.ValidateStateid(anon, nil, op)
+		openState, err := sm.ValidateStateid(anon, nil, op, 0)
 		if err != nil {
 			t.Fatalf("anonymous stateid (op=%d) should be allowed: %v", op, err)
 		}
@@ -227,11 +227,11 @@ func TestValidateStateid_AnonymousBlockedByShareDeny(t *testing.T) {
 		openConfirmed(t, sm, 0, []byte("ownerA"), fh,
 			types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_READ)
 
-		if _, err := sm.ValidateStateid(anonymous, fh, StateidOpRead); !errors.Is(err, ErrLocked) {
+		if _, err := sm.ValidateStateid(anonymous, fh, StateidOpRead, 0); !errors.Is(err, ErrLocked) {
 			t.Fatalf("anonymous READ against DENY_READ: err = %v, want ErrLocked", err)
 		}
 		// DENY_READ says nothing about writing.
-		if _, err := sm.ValidateStateid(anonymous, fh, StateidOpWrite); err != nil {
+		if _, err := sm.ValidateStateid(anonymous, fh, StateidOpWrite, 0); err != nil {
 			t.Fatalf("anonymous WRITE against DENY_READ: %v", err)
 		}
 	})
@@ -242,10 +242,10 @@ func TestValidateStateid_AnonymousBlockedByShareDeny(t *testing.T) {
 		openConfirmed(t, sm, 0, []byte("ownerA"), fh,
 			types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_WRITE)
 
-		if _, err := sm.ValidateStateid(anonymous, fh, StateidOpWrite); !errors.Is(err, ErrLocked) {
+		if _, err := sm.ValidateStateid(anonymous, fh, StateidOpWrite, 0); !errors.Is(err, ErrLocked) {
 			t.Fatalf("anonymous WRITE against DENY_WRITE: err = %v, want ErrLocked", err)
 		}
-		if _, err := sm.ValidateStateid(anonymous, fh, StateidOpRead); err != nil {
+		if _, err := sm.ValidateStateid(anonymous, fh, StateidOpRead, 0); err != nil {
 			t.Fatalf("anonymous READ against DENY_WRITE: %v", err)
 		}
 	})
@@ -256,10 +256,10 @@ func TestValidateStateid_AnonymousBlockedByShareDeny(t *testing.T) {
 		openConfirmed(t, sm, 0, []byte("ownerA"), fh,
 			types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE)
 
-		if _, err := sm.ValidateStateid(anonymous, fh, StateidOpRead); err != nil {
+		if _, err := sm.ValidateStateid(anonymous, fh, StateidOpRead, 0); err != nil {
 			t.Fatalf("anonymous READ with no deny in force: %v", err)
 		}
-		if _, err := sm.ValidateStateid(anonymous, fh, StateidOpWrite); err != nil {
+		if _, err := sm.ValidateStateid(anonymous, fh, StateidOpWrite, 0); err != nil {
 			t.Fatalf("anonymous WRITE with no deny in force: %v", err)
 		}
 	})
@@ -273,7 +273,7 @@ func TestValidateStateid_AnonymousBlockedByShareDeny(t *testing.T) {
 		openConfirmed(t, sm, 0, []byte("ownerA"), fh,
 			types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_READ)
 
-		if _, err := sm.ValidateStateid(readBypassStateid(), fh, StateidOpRead); err != nil {
+		if _, err := sm.ValidateStateid(readBypassStateid(), fh, StateidOpRead, 0); err != nil {
 			t.Fatalf("read-bypass READ against DENY_READ: %v", err)
 		}
 	})

--- a/internal/adapter/nfs/v4/state/stateid.go
+++ b/internal/adapter/nfs/v4/state/stateid.go
@@ -127,6 +127,31 @@ func (sm *StateManager) isCurrentEpoch(other [types.NFS4_OTHER_SIZE]byte) bool {
 // Stateid Validation
 // ============================================================================
 
+// checkStateidOwner returns NFS4ERR_BAD_STATEID when a stateid names state
+// owned by a client other than the caller, and nil when the caller may use it
+// (RFC 8881 Section 18.38.3). A stateid is not a bearer token: a client
+// presenting another client's stateid could otherwise write through that
+// client's exclusive-deny open, or inside a byte range it holds an exclusive
+// lock on.
+//
+// A zero callerClientID means the caller has no trusted client identity —
+// NFSv4.0 carries no clientid4 on an I/O operation and has no session to
+// derive one from — so the comparison is skipped and the stateid stays a
+// bearer token there.
+//
+// That zero-skip is why the free*StateidLocked helpers below compare inline
+// rather than calling this: FREE_STATEID rejects a mismatch whatever the
+// caller's client ID, including zero. The two rules look alike and are not.
+func checkStateidOwner(callerClientID, ownerClientID uint64) error {
+	if callerClientID == 0 || callerClientID == ownerClientID {
+		return nil
+	}
+	return &NFS4StateError{
+		Status:  types.NFS4ERR_BAD_STATEID,
+		Message: "stateid does not belong to the calling client",
+	}
+}
+
 // ValidateStateid validates a stateid for the given operation family and
 // returns the associated OpenState.
 //
@@ -140,16 +165,19 @@ func (sm *StateManager) isCurrentEpoch(other [types.NFS4_OTHER_SIZE]byte) bool {
 //  2. Route by type tag: open -> openStateByOther, lock -> lockStateByOther
 //     (returns the parent open state), delegation -> delegByOther
 //  3. If not found -> NFS4ERR_BAD_STATEID (or NFS4ERR_STALE_STATEID for wrong epoch)
-//  4. Compare seqid: < current -> NFS4ERR_OLD_STATEID; > current -> NFS4ERR_BAD_STATEID
-//  5. Verify filehandle matches (if provided and non-nil) -> NFS4ERR_BAD_STATEID
-//  6. Check lease expiry and implicit renewal on success
+//  4. Verify the state belongs to clientID, the caller's trusted client
+//     identity -> NFS4ERR_BAD_STATEID. A zero clientID means the caller has
+//     none (NFSv4.0) and skips the check; see checkStateidOwner.
+//  5. Compare seqid: < current -> NFS4ERR_OLD_STATEID; > current -> NFS4ERR_BAD_STATEID
+//  6. Verify filehandle matches (if provided and non-nil) -> NFS4ERR_BAD_STATEID
+//  7. Check lease expiry and implicit renewal on success
 //
 // For delegation stateids (type 0x03), returns nil OpenState on success
 // (same as special stateids). The caller's permission checks at the metadata
 // layer (PrepareWrite) still apply.
 //
 // Caller must NOT hold sm.mu.
-func (sm *StateManager) ValidateStateid(stateid *types.Stateid4, currentFH []byte, op StateidOp) (*OpenState, error) {
+func (sm *StateManager) ValidateStateid(stateid *types.Stateid4, currentFH []byte, op StateidOp, clientID uint64) (*OpenState, error) {
 	// Step 1: Special stateids.
 	// The READ-bypass (all-ones) stateid asks the server to serve a READ even
 	// where an open would deny it, so on READ it skips the share-deny check
@@ -175,7 +203,7 @@ func (sm *StateManager) ValidateStateid(stateid *types.Stateid4, currentFH []byt
 
 	// Delegation stateids (type 0x03) are stored in delegByOther, not openStateByOther.
 	if stateType == StateTypeDeleg {
-		return sm.validateDelegStateid(stateid, currentFH)
+		return sm.validateDelegStateid(stateid, currentFH, clientID)
 	}
 
 	// Lock stateids (type 0x02) are stored in lockStateByOther, never in
@@ -183,7 +211,7 @@ func (sm *StateManager) ValidateStateid(stateid *types.Stateid4, currentFH []byt
 	// READ/WRITE, so validate it against the lock state and return the parent
 	// open state (whose share-access bits the caller enforces).
 	if stateType == StateTypeLock {
-		return sm.validateLockStateid(stateid, currentFH)
+		return sm.validateLockStateid(stateid, currentFH, clientID)
 	}
 
 	// Open stateids (type 0x01) use openStateByOther.
@@ -204,7 +232,16 @@ func (sm *StateManager) ValidateStateid(stateid *types.Stateid4, currentFH []byt
 		}
 	}
 
-	// Step 4: Compare seqid.
+	// Step 4: the state must belong to the calling client.
+	var ownerClientID uint64
+	if openState.Owner != nil {
+		ownerClientID = openState.Owner.ClientID
+	}
+	if err := checkStateidOwner(clientID, ownerClientID); err != nil {
+		return nil, err
+	}
+
+	// Step 5: Compare seqid.
 	// Per RFC 8881 Section 8.2.2 (NFSv4.1): if the client sends seqid=0
 	// in a non-special stateid, the server MUST accept it regardless of
 	// the current seqid value.  This is safe for v4.0 too since v4.0
@@ -224,7 +261,7 @@ func (sm *StateManager) ValidateStateid(stateid *types.Stateid4, currentFH []byt
 		}
 	}
 
-	// Step 5: Verify filehandle matches (if provided)
+	// Step 6: Verify filehandle matches (if provided)
 	if len(currentFH) > 0 && len(openState.FileHandle) > 0 {
 		if !bytes.Equal(currentFH, openState.FileHandle) {
 			return nil, &NFS4StateError{
@@ -234,7 +271,7 @@ func (sm *StateManager) ValidateStateid(stateid *types.Stateid4, currentFH []byt
 		}
 	}
 
-	// Step 6: Lease check and implicit renewal
+	// Step 7: Lease check and implicit renewal
 	// Per RFC 7530 Section 9.6: any operation that uses a stateid implicitly
 	// renews the lease for the associated client. This prevents READ-only
 	// clients from having their state expire (Pitfall 3).
@@ -254,7 +291,7 @@ func (sm *StateManager) ValidateStateid(stateid *types.Stateid4, currentFH []byt
 // validateDelegStateid validates a delegation stateid (type 0x03).
 // Returns nil OpenState on success (delegation validated, caller should proceed).
 // Caller must hold sm.mu.RLock.
-func (sm *StateManager) validateDelegStateid(stateid *types.Stateid4, currentFH []byte) (*OpenState, error) {
+func (sm *StateManager) validateDelegStateid(stateid *types.Stateid4, currentFH []byte, clientID uint64) (*OpenState, error) {
 	deleg, exists := sm.delegByOther[stateid.Other]
 	if !exists {
 		if sm.isExpiredStateidLocked(stateid.Other) {
@@ -278,6 +315,10 @@ func (sm *StateManager) validateDelegStateid(stateid *types.Stateid4, currentFH 
 			Status:  types.NFS4ERR_BAD_STATEID,
 			Message: "delegation has been revoked",
 		}
+	}
+
+	if err := checkStateidOwner(clientID, deleg.ClientID); err != nil {
+		return nil, err
 	}
 
 	// Compare seqid (seqid=0 means "any" per RFC 8881 Section 8.2.2)
@@ -323,7 +364,7 @@ func (sm *StateManager) validateDelegStateid(stateid *types.Stateid4, currentFH 
 // lockStateByOther; on success this returns the parent OpenState so the caller
 // can enforce that open's share-access mode (RFC 7530 Section 9.1.4.1).
 // Caller must hold sm.mu.RLock.
-func (sm *StateManager) validateLockStateid(stateid *types.Stateid4, currentFH []byte) (*OpenState, error) {
+func (sm *StateManager) validateLockStateid(stateid *types.Stateid4, currentFH []byte, clientID uint64) (*OpenState, error) {
 	lockState, exists := sm.lockStateByOther[stateid.Other]
 	if !exists {
 		if sm.isExpiredStateidLocked(stateid.Other) {
@@ -339,6 +380,14 @@ func (sm *StateManager) validateLockStateid(stateid *types.Stateid4, currentFH [
 			Status:  types.NFS4ERR_BAD_STATEID,
 			Message: "lock stateid not found",
 		}
+	}
+
+	var ownerClientID uint64
+	if lockState.LockOwner != nil {
+		ownerClientID = lockState.LockOwner.ClientID
+	}
+	if err := checkStateidOwner(clientID, ownerClientID); err != nil {
+		return nil, err
 	}
 
 	// Compare seqid. Per RFC 8881 Section 8.2.2, seqid=0 in a non-special

--- a/internal/adapter/nfs/v4/state/stateid_authz_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_authz_test.go
@@ -55,7 +55,7 @@ func TestValidateStateid_LockStateid_RoutedToLockMap(t *testing.T) {
 
 	// A lock stateid presented to WRITE must validate and return the parent
 	// open state (carrying the share-access bits the caller enforces).
-	openState, err := sm.ValidateStateid(&lockStateid, fh, StateidOpWrite)
+	openState, err := sm.ValidateStateid(&lockStateid, fh, StateidOpWrite, 0)
 	if err != nil {
 		t.Fatalf("ValidateStateid on lock stateid (WRITE): %v", err)
 	}
@@ -67,7 +67,7 @@ func TestValidateStateid_LockStateid_RoutedToLockMap(t *testing.T) {
 	}
 
 	// Same lock stateid must also validate on READ.
-	if _, err := sm.ValidateStateid(&lockStateid, fh, StateidOpRead); err != nil {
+	if _, err := sm.ValidateStateid(&lockStateid, fh, StateidOpRead, 0); err != nil {
 		t.Fatalf("ValidateStateid on lock stateid (READ): %v", err)
 	}
 }
@@ -84,7 +84,7 @@ func TestValidateStateid_LockStateid_Seqid0(t *testing.T) {
 	lockStateid := newLockedFile(t, sm, 0, fh)
 	lockStateid.Seqid = 0
 
-	if _, err := sm.ValidateStateid(&lockStateid, fh, StateidOpRead); err != nil {
+	if _, err := sm.ValidateStateid(&lockStateid, fh, StateidOpRead, 0); err != nil {
 		t.Fatalf("ValidateStateid on lock stateid with seqid=0: %v", err)
 	}
 }
@@ -317,4 +317,89 @@ func recPrincipal(rec *V41ClientRecord) string {
 		return ""
 	}
 	return rec.Principal
+}
+
+// TestValidateStateid_CrossClient covers the owner-to-client binding on the
+// I/O path. A stateid names state owned by one client; another client that
+// learns or guesses its bytes must not be able to use it, the same rule
+// FREE_STATEID already enforces.
+//
+// Each case also asserts the owning client is still accepted, so the guard
+// cannot pass by rejecting everything, and that a zero caller client ID — an
+// NFSv4.0 request, which carries no clientid4 — still validates, since v4.0
+// has no identity to compare against.
+func TestValidateStateid_CrossClient(t *testing.T) {
+	const (
+		clientA uint64 = 0xAAAA
+		clientB uint64 = 0xBBBB
+	)
+
+	t.Run("open stateid", func(t *testing.T) {
+		sm := NewStateManager(90 * time.Second)
+		defer sm.Shutdown()
+
+		fh := []byte("fh-cross-client-open")
+		openResult, err := sm.OpenFile(clientA, []byte("owner-a"), 1, fh,
+			types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
+		if err != nil {
+			t.Fatalf("OpenFile: %v", err)
+		}
+		confirmed, err := sm.ConfirmOpen(&openResult.Stateid, 2)
+		if err != nil {
+			t.Fatalf("ConfirmOpen: %v", err)
+		}
+		sid := confirmed.Stateid
+
+		if _, err := sm.ValidateStateid(&sid, fh, StateidOpWrite, clientB); !isStatus(err, types.NFS4ERR_BAD_STATEID) {
+			t.Errorf("client B writing through client A's open stateid: err = %v, want NFS4ERR_BAD_STATEID", err)
+		}
+		if _, err := sm.ValidateStateid(&sid, fh, StateidOpWrite, clientA); err != nil {
+			t.Errorf("owning client rejected: %v", err)
+		}
+		if _, err := sm.ValidateStateid(&sid, fh, StateidOpWrite, 0); err != nil {
+			t.Errorf("NFSv4.0 caller (no client identity) rejected: %v", err)
+		}
+	})
+
+	t.Run("lock stateid", func(t *testing.T) {
+		lm := lock.NewManager()
+		sm := NewStateManager(90 * time.Second)
+		sm.SetLockManager(lm)
+		defer sm.Shutdown()
+
+		fh := []byte("fh-cross-client-lock")
+		sid := newLockedFile(t, sm, clientA, fh)
+
+		if _, err := sm.ValidateStateid(&sid, fh, StateidOpWrite, clientB); !isStatus(err, types.NFS4ERR_BAD_STATEID) {
+			t.Errorf("client B writing through client A's lock stateid: err = %v, want NFS4ERR_BAD_STATEID", err)
+		}
+		if _, err := sm.ValidateStateid(&sid, fh, StateidOpWrite, clientA); err != nil {
+			t.Errorf("owning client rejected: %v", err)
+		}
+		if _, err := sm.ValidateStateid(&sid, fh, StateidOpWrite, 0); err != nil {
+			t.Errorf("NFSv4.0 caller (no client identity) rejected: %v", err)
+		}
+	})
+
+	t.Run("delegation stateid", func(t *testing.T) {
+		sm := NewStateManager(90 * time.Second)
+		defer sm.Shutdown()
+
+		fh := []byte("fh-cross-client-deleg")
+		deleg := sm.GrantDelegation(clientA, fh, types.OPEN_DELEGATE_READ)
+		if deleg == nil {
+			t.Fatal("GrantDelegation returned nil")
+		}
+		sid := deleg.Stateid
+
+		if _, err := sm.ValidateStateid(&sid, fh, StateidOpRead, clientB); !isStatus(err, types.NFS4ERR_BAD_STATEID) {
+			t.Errorf("client B reading through client A's delegation stateid: err = %v, want NFS4ERR_BAD_STATEID", err)
+		}
+		if _, err := sm.ValidateStateid(&sid, fh, StateidOpRead, clientA); err != nil {
+			t.Errorf("owning client rejected: %v", err)
+		}
+		if _, err := sm.ValidateStateid(&sid, fh, StateidOpRead, 0); err != nil {
+			t.Errorf("NFSv4.0 caller (no client identity) rejected: %v", err)
+		}
+	})
 }

--- a/internal/adapter/nfs/v4/state/stateid_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_test.go
@@ -120,7 +120,7 @@ func TestValidateStateid_SpecialStateid_AllZeros(t *testing.T) {
 
 	stateid := &types.Stateid4{Seqid: 0}
 	// Other is default zero
-	openState, err := sm.ValidateStateid(stateid, nil, StateidOpRead)
+	openState, err := sm.ValidateStateid(stateid, nil, StateidOpRead, 0)
 	if err != nil {
 		t.Fatalf("ValidateStateid for all-zeros: %v", err)
 	}
@@ -138,7 +138,7 @@ func TestValidateStateid_SpecialStateid_AllOnes(t *testing.T) {
 		stateid.Other[i] = 0xFF
 	}
 
-	openState, err := sm.ValidateStateid(stateid, nil, StateidOpRead)
+	openState, err := sm.ValidateStateid(stateid, nil, StateidOpRead, 0)
 	if err != nil {
 		t.Fatalf("ValidateStateid for all-ones READ bypass: %v", err)
 	}
@@ -154,7 +154,7 @@ func TestValidateStateid_NotFound(t *testing.T) {
 	other := sm.generateStateidOther(StateTypeOpen)
 	stateid := &types.Stateid4{Seqid: 1, Other: other}
 
-	_, err := sm.ValidateStateid(stateid, nil, StateidOpRead)
+	_, err := sm.ValidateStateid(stateid, nil, StateidOpRead, 0)
 	if err == nil {
 		t.Fatal("ValidateStateid should fail for unknown stateid")
 	}
@@ -181,7 +181,7 @@ func TestValidateStateid_StaleStateid(t *testing.T) {
 	other[3] = 0xFF
 	stateid := &types.Stateid4{Seqid: 1, Other: other}
 
-	_, err := sm.ValidateStateid(stateid, nil, StateidOpRead)
+	_, err := sm.ValidateStateid(stateid, nil, StateidOpRead, 0)
 	if err == nil {
 		t.Fatal("ValidateStateid should fail for stale epoch")
 	}
@@ -207,7 +207,7 @@ func TestValidateStateid_Success(t *testing.T) {
 	}
 
 	// Validate the returned stateid
-	openState, err := sm.ValidateStateid(&result.Stateid, fileHandle, StateidOpRead)
+	openState, err := sm.ValidateStateid(&result.Stateid, fileHandle, StateidOpRead, 0)
 	if err != nil {
 		t.Fatalf("ValidateStateid: %v", err)
 	}
@@ -236,7 +236,7 @@ func TestValidateStateid_OldSeqid(t *testing.T) {
 
 	// Now use the OLD seqid (1), current is 2
 	oldStateid := result.Stateid // has seqid=1
-	_, err = sm.ValidateStateid(&oldStateid, nil, StateidOpRead)
+	_, err = sm.ValidateStateid(&oldStateid, nil, StateidOpRead, 0)
 	if err == nil {
 		t.Fatal("ValidateStateid should fail for old seqid")
 	}
@@ -263,7 +263,7 @@ func TestValidateStateid_FutureSeqid(t *testing.T) {
 	// Use a seqid higher than current
 	futureStateid := result.Stateid
 	futureStateid.Seqid = 99
-	_, err = sm.ValidateStateid(&futureStateid, nil, StateidOpRead)
+	_, err = sm.ValidateStateid(&futureStateid, nil, StateidOpRead, 0)
 	if err == nil {
 		t.Fatal("ValidateStateid should fail for future seqid")
 	}
@@ -289,7 +289,7 @@ func TestValidateStateid_FilehandleMismatch(t *testing.T) {
 
 	// Validate with different filehandle
 	wrongFH := []byte("wrong-handle-456")
-	_, err = sm.ValidateStateid(&result.Stateid, wrongFH, StateidOpRead)
+	_, err = sm.ValidateStateid(&result.Stateid, wrongFH, StateidOpRead, 0)
 	if err == nil {
 		t.Fatal("ValidateStateid should fail for filehandle mismatch")
 	}
@@ -315,7 +315,7 @@ func TestValidateStateid_DelegationStateid_Success(t *testing.T) {
 	deleg := sm.GrantDelegation(100, fileHandle, types.OPEN_DELEGATE_WRITE)
 
 	// Validate the delegation stateid
-	openState, err := sm.ValidateStateid(&deleg.Stateid, fileHandle, StateidOpRead)
+	openState, err := sm.ValidateStateid(&deleg.Stateid, fileHandle, StateidOpRead, 0)
 	if err != nil {
 		t.Fatalf("ValidateStateid for delegation: %v", err)
 	}
@@ -331,7 +331,7 @@ func TestValidateStateid_DelegationStateid_NotFound(t *testing.T) {
 	other := sm.generateStateidOther(StateTypeDeleg)
 	stateid := &types.Stateid4{Seqid: 1, Other: other}
 
-	_, err := sm.ValidateStateid(stateid, nil, StateidOpRead)
+	_, err := sm.ValidateStateid(stateid, nil, StateidOpRead, 0)
 	if err == nil {
 		t.Fatal("ValidateStateid should fail for unknown delegation stateid")
 	}
@@ -356,7 +356,7 @@ func TestValidateStateid_DelegationStateid_Revoked(t *testing.T) {
 	deleg.Revoked = true
 	sm.mu.Unlock()
 
-	_, err := sm.ValidateStateid(&deleg.Stateid, fileHandle, StateidOpRead)
+	_, err := sm.ValidateStateid(&deleg.Stateid, fileHandle, StateidOpRead, 0)
 	if err == nil {
 		t.Fatal("ValidateStateid should fail for revoked delegation")
 	}
@@ -376,7 +376,7 @@ func TestValidateStateid_DelegationStateid_FilehandleMismatch(t *testing.T) {
 	deleg := sm.GrantDelegation(100, []byte("fh-deleg-mismatch"), types.OPEN_DELEGATE_READ)
 
 	wrongFH := []byte("fh-wrong-handle")
-	_, err := sm.ValidateStateid(&deleg.Stateid, wrongFH, StateidOpRead)
+	_, err := sm.ValidateStateid(&deleg.Stateid, wrongFH, StateidOpRead, 0)
 	if err == nil {
 		t.Fatal("ValidateStateid should fail for filehandle mismatch")
 	}
@@ -399,7 +399,7 @@ func TestValidateStateid_DelegationStateid_OldSeqid(t *testing.T) {
 	// to trigger OLD_STATEID. We manually bump the delegation seqid first.
 	deleg.Stateid.Seqid = 3 // simulate the server having advanced the seqid
 	oldStateid := types.Stateid4{Seqid: 1, Other: deleg.Stateid.Other}
-	_, err := sm.ValidateStateid(&oldStateid, nil, StateidOpRead)
+	_, err := sm.ValidateStateid(&oldStateid, nil, StateidOpRead, 0)
 	if err == nil {
 		t.Fatal("ValidateStateid should fail for old delegation seqid")
 	}
@@ -431,7 +431,7 @@ func TestValidateStateid_Seqid0_AcceptedAsAny(t *testing.T) {
 	// Per RFC 8881 Section 8.2.2, seqid=0 means "any seqid" and
 	// MUST be accepted regardless of the current seqid value.
 	anyStateid := types.Stateid4{Seqid: 0, Other: result.Stateid.Other}
-	_, err = sm.ValidateStateid(&anyStateid, nil, StateidOpRead)
+	_, err = sm.ValidateStateid(&anyStateid, nil, StateidOpRead, 0)
 	if err != nil {
 		t.Errorf("ValidateStateid should accept seqid=0 (any), got: %v", err)
 	}
@@ -1081,7 +1081,7 @@ func TestFullLifecycle_OpenConfirmClose(t *testing.T) {
 	confirmedStateid := &confirmed.Stateid
 
 	// Validate the confirmed stateid
-	openState, err := sm.ValidateStateid(confirmedStateid, []byte("file-handle-test"), StateidOpRead)
+	openState, err := sm.ValidateStateid(confirmedStateid, []byte("file-handle-test"), StateidOpRead, 0)
 	if err != nil {
 		t.Fatalf("ValidateStateid: %v", err)
 	}


### PR DESCRIPTION
First of two PRs for #2395, which is really two defects. This one is the owner-to-client binding; the predictable stateid `other` follows in a second PR and carries the `Closes` keyword.

Stacked on #2427 — review that one first.

## What was wrong

`ValidateStateid` is the single gate every NFSv4 I/O operation passes through: READ, WRITE, SETATTR-size, ALLOCATE, DEALLOCATE, CLONE, SEEK, READ_PLUS. It took no client identity and never compared the stateid's owning client against the caller. It checked only that the stateid existed in a map, that its seqid was in order, that the filehandle matched, and that the lease had not expired.

So a stateid was a bearer token on the I/O path. Any client that learned or guessed another client's 12-byte `other` could present it and the server would honour it — writing through that client's `OPEN4_SHARE_DENY_WRITE` open, or inside a byte range another client holds an exclusive lock on. It does not bypass POSIX permissions (the auth context still carries the caller's own credentials), but it defeats NFSv4 share-reservation and lock-owner isolation between clients entirely.

The codebase already holds the opposite invariant a few hundred lines down: `freeOpenStateidLocked`, `freeLockStateidLocked` and `freeDelegStateidLocked` all refuse a cross-client stateid per RFC 8881 §18.38.3. FREE_STATEID could not destroy another client's lock state, but WRITE could corrupt the data it protects.

## Premise re-verified on current develop

The audit behind #2395 was pinned at `40884ad4f`, before PR #2356. Re-checked on `fa173706a`: the signature was still `ValidateStateid(stateid, currentFH, op)` with no client parameter, so no call site could supply one even if it wanted to.

## The fix

`ValidateStateid`, `validateLockStateid` and `validateDelegStateid` take the caller's trusted client ID. One helper, `checkStateidOwner`, returns `NFS4ERR_BAD_STATEID` on a mismatch — mirroring the discipline the `free*StateidLocked` helpers already use rather than inventing a second one. The nine production call sites pass `ctx.SessionClientID`.

The check sits after the not-found/stale-epoch branch and before the seqid and filehandle comparisons. It can only change an outcome when the caller genuinely is a different client, so no same-client status code moves.

This has no dependency on #2398 and does not need a lock refactor: `ValidateStateid` already takes `sm.mu.RLock()`, and a field comparison under a read lock adds nothing to the write-side critical section.

## The NFSv4.0 limitation, stated plainly

`ctx.SessionClientID` is derived from the SEQUENCE-validated session and is zero on NFSv4.0, which carries no `clientid4` on an I/O operation and has no session to derive one from. A zero caller ID therefore skips the comparison, and on v4.0 a stateid remains a bearer token.

That is what RFC 7530 leaves a server with, not a shortcut. Binding v4.0 connections to a clientid is a much larger change and is deliberately out of scope here.

**State this plainly when reading the PR: the guard is an unconditional no-op for every NFSv4.0 I/O request. An NFSv4.0 mount is exactly as exposed to cross-client stateid use after this PR as before it.** The security benefit is NFSv4.1 and 4.2 only. A follow-up issue tracks the v4.0 gap, together with the identical limitation on DELEGRETURN — same root cause, no trusted client identity on the wire in v4.0.

## Tests

`TestValidateStateid_CrossClient` covers all three stateid types — open, lock and delegation. For each: client A mints it, client B presenting it must get `NFS4ERR_BAD_STATEID`, client A must still be accepted, and a zero caller ID (an NFSv4.0 request) must still be accepted. The second and third assertions matter as much as the first — a guard that passes by rejecting everything is not a guard.

`TestCompoundV41_ReadRejectsAnotherClientsStateid` covers the wiring rather than the guard: two clients each get their own EXCHANGE_ID and CREATE_SESSION, one OPENs a file, the other presents the resulting stateid to READ through a real SEQUENCE-led compound. The StateManager test proves the guard works when handed correct inputs; this one proves the handlers actually reach it, which is what silently breaks when a tenth call site is added. Reverting just `read.go`'s call site to pass a literal `0` makes it fail:

```
--- FAIL: TestCompoundV41_ReadRejectsAnotherClientsStateid
    READ from the other client = 0, want NFS4ERR_BAD_STATEID (10025)
```

Fails on the pre-fix tree:
```
--- FAIL: TestValidateStateid_CrossClient/open_stateid
    client B writing through client A's open stateid: err = <nil>, want NFS4ERR_BAD_STATEID
--- FAIL: TestValidateStateid_CrossClient/lock_stateid
    client B writing through client A's lock stateid: err = <nil>, want NFS4ERR_BAD_STATEID
--- FAIL: TestValidateStateid_CrossClient/delegation_stateid
    client B reading through client A's delegation stateid: err = <nil>, want NFS4ERR_BAD_STATEID
```

## No regression on a real kernel client

This guard now fires on every v4.1/4.2 I/O operation, so it was checked against a Linux 6.8 kernel NFS client rather than only in-process doubles. Mounted at each minor version in turn, wrote 4 MiB, synced, read back, and truncated:

```
4.0 OK size=4194304    4.0 setattr-size OK
4.1 OK size=4194304    4.1 setattr-size OK
4.2 OK size=4194304    4.2 setattr-size OK
```

Relates to #2395
