### PR TITLE
refactor(engine): rename Syncer to RemoteSync, freeing the syncer name

### DIFF
--- a/internal/adapter/common/clone_localonly_tail_test.go
+++ b/internal/adapter/common/clone_localonly_tail_test.go
@@ -26,11 +26,11 @@ func newLocalOnlyTestEngine(t *testing.T, coord *fakeCoordinator, ms *metadatame
 	if !ok {
 		t.Fatalf("metadata store %T does not implement metadata.SyncedHashStore", ms)
 	}
-	syncer := engine.NewSyncer(localStore, nil, ms, engine.DefaultConfig())
+	syncer := engine.NewRemoteSync(localStore, nil, ms, engine.DefaultConfig())
 	syncer.SetSyncedHashStore(syncedHashStore)
 	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:           localStore,
-		Syncer:          syncer,
+		RemoteSync:      syncer,
 		FileChunkStore:  ms,
 		Coordinator:     coord,
 		SyncedHashStore: syncedHashStore,

--- a/internal/adapter/common/commit_durability_test.go
+++ b/internal/adapter/common/commit_durability_test.go
@@ -32,14 +32,14 @@ func newMemoryEngine(t *testing.T, remote *remotememory.Store, durableLocalOverr
 	}
 	if remote != nil {
 		cfg.Remote = remote
-		cfg.Syncer = engine.NewSyncer(localStore, remote, ms, engine.DefaultConfig())
+		cfg.RemoteSync = engine.NewRemoteSync(localStore, remote, ms, engine.DefaultConfig())
 		// Mirror the production wiring (shares service): the block-keyed
 		// remote surface activates the carve path — the only upload path
 		// post-#1493. Memory local stores carve through the hash-keyed
 		// local read fallback.
-		cfg.Syncer.SetRemoteBlockStore(remote)
+		cfg.RemoteSync.SetRemoteBlockStore(remote)
 	} else {
-		cfg.Syncer = engine.NewSyncer(localStore, nil, ms, engine.DefaultConfig())
+		cfg.RemoteSync = engine.NewRemoteSync(localStore, nil, ms, engine.DefaultConfig())
 	}
 
 	bs, err := engine.New(cfg)

--- a/internal/adapter/common/copy_payload_test.go
+++ b/internal/adapter/common/copy_payload_test.go
@@ -73,7 +73,7 @@ func (f *fakeCoordinator) FindByObjectID(_ context.Context, _ block.ObjectID) ([
 }
 
 // GetFileObjectID stub. Adapter-common tests do not drive the
-// Syncer.Flush short-circuit path; returning the zero ObjectID + nil is
+// RemoteSync.Flush short-circuit path; returning the zero ObjectID + nil is
 // the "never quiesced" disposition that keeps the interface satisfied
 // without affecting any assertions.
 // ReprojectBlocks is a no-op: this fake does not model the Blocks
@@ -390,14 +390,14 @@ func newCopyTestEngineWithLocal(t *testing.T, coord *fakeCoordinator, ms *metada
 	if !ok {
 		t.Fatalf("metadata store %T does not implement metadata.SyncedHashStore", ms)
 	}
-	syncer := engine.NewSyncer(localStore, mem, ms, engine.DefaultConfig())
+	syncer := engine.NewRemoteSync(localStore, mem, ms, engine.DefaultConfig())
 	syncer.SetSyncedHashStore(syncedHashStore)
 	syncer.SetRemoteBlockStore(mem)
 
 	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:           localStore,
 		Remote:          mem,
-		Syncer:          syncer,
+		RemoteSync:      syncer,
 		FileChunkStore:  ms,
 		Coordinator:     coord,
 		SyncedHashStore: syncedHashStore,

--- a/internal/adapter/common/write_payload_test.go
+++ b/internal/adapter/common/write_payload_test.go
@@ -32,12 +32,12 @@ func newTestEngine(t *testing.T) *engine.Store {
 		t.Fatalf("fs.NewWithOptions failed: %v", err)
 	}
 
-	syncer := engine.NewSyncer(localStore, nil, ms, engine.DefaultConfig())
+	syncer := engine.NewRemoteSync(localStore, nil, ms, engine.DefaultConfig())
 
 	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:           localStore,
 		Remote:          nil,
-		Syncer:          syncer,
+		RemoteSync:      syncer,
 		FileChunkStore:  ms,
 		ReadBufferBytes: 0,
 		PrefetchWorkers: 0,

--- a/internal/adapter/nfs/v3/handlers/testing/fixtures.go
+++ b/internal/adapter/nfs/v3/handlers/testing/fixtures.go
@@ -113,11 +113,11 @@ func NewHandlerFixtureWithStore(
 		t.Fatalf("Failed to create local store: %v", err)
 	}
 	t.Cleanup(func() { _ = localStore.Close() })
-	syncer := engine.NewSyncer(localStore, nil, metaStore, engine.DefaultConfig())
+	syncer := engine.NewRemoteSync(localStore, nil, metaStore, engine.DefaultConfig())
 
 	blockSvc, err := engine.New(engine.BlockStoreConfig{
-		Local:  localStore,
-		Syncer: syncer,
+		Local:      localStore,
+		RemoteSync: syncer,
 	})
 	if err != nil {
 		t.Fatalf("Failed to create block store: %v", err)

--- a/internal/adapter/nfs/v4/handlers/io_test.go
+++ b/internal/adapter/nfs/v4/handlers/io_test.go
@@ -53,11 +53,11 @@ func newIOTestFixture(t *testing.T, shareName string) *ioTestFixture {
 		t.Fatalf("create local store: %v", err)
 	}
 	t.Cleanup(func() { _ = localStore.Close() })
-	syncer := engine.NewSyncer(localStore, nil, metaStore, engine.DefaultConfig())
+	syncer := engine.NewRemoteSync(localStore, nil, metaStore, engine.DefaultConfig())
 
 	blockSvc, err := engine.New(engine.BlockStoreConfig{
-		Local:  localStore,
-		Syncer: syncer,
+		Local:      localStore,
+		RemoteSync: syncer,
 	})
 	if err != nil {
 		t.Fatalf("create block store: %v", err)

--- a/internal/bench/phase19_test.go
+++ b/internal/bench/phase19_test.go
@@ -175,11 +175,11 @@ func newPhase19BlockStore(t *testing.T) *engine.Store {
 	t.Helper()
 	localStore := memory.New()
 	fbs := newAggregateStubFileChunkStore()
-	syncer := engine.NewSyncer(localStore, nil, fbs, engine.DefaultConfig())
+	syncer := engine.NewRemoteSync(localStore, nil, fbs, engine.DefaultConfig())
 	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:          localStore,
 		Remote:         nil,
-		Syncer:         syncer,
+		RemoteSync:     syncer,
 		FileChunkStore: fbs,
 	})
 	if err != nil {

--- a/pkg/block/engine/blocksink.go
+++ b/pkg/block/engine/blocksink.go
@@ -262,7 +262,7 @@ func (s engineBlockSink) ReapSupersededManifest(ctx context.Context, id journal.
 // engineBlockSink is journal's production BlockSink: it seals each carved chunk,
 // frames them into one block via blockcodec, uploads the block with PutBlock,
 // and atomically commits the block record + synced locators + per-file manifest
-// rows. It mirrors Syncer.carveAndCommitBlock minus the local-byte resolution —
+// rows. It mirrors RemoteSync.carveAndCommitBlock minus the local-byte resolution —
 // journal hands the plaintext in-hand on each CarveChunk.
 type engineBlockSink struct {
 	sealer      remote.ChunkSealer

--- a/pkg/block/engine/carve_dispatch.go
+++ b/pkg/block/engine/carve_dispatch.go
@@ -21,7 +21,7 @@ import (
 //
 // Runs only when a remote and the carve substrate are wired (carveActive) and
 // not in ManualSync mode (where Flush/SyncNow are the sole carve drivers).
-func (m *Syncer) carveDispatcher(ctx context.Context) {
+func (m *RemoteSync) carveDispatcher(ctx context.Context) {
 	logger.Info("Carve dispatcher started")
 	interval := m.config.UploadInterval
 	if interval <= 0 {
@@ -61,7 +61,7 @@ func (m *Syncer) carveDispatcher(ctx context.Context) {
 // without it the window is never consumed and stays pinned at the floor. Files
 // in one shard still serialize on the journal's internal carve lock, so the
 // concurrency here overlaps distinct shards' upload latency.
-func (m *Syncer) carvePass(ctx context.Context) {
+func (m *RemoteSync) carvePass(ctx context.Context) {
 	files := m.local.ListFiles(ctx)
 	if len(files) == 0 {
 		return

--- a/pkg/block/engine/carve_dispatch_test.go
+++ b/pkg/block/engine/carve_dispatch_test.go
@@ -51,7 +51,7 @@ func TestCarvePass_FansOutBoundedByUploadWindow(t *testing.T) {
 		carved:  map[string]int{},
 	}
 	const window = 3
-	m := &Syncer{
+	m := &RemoteSync{
 		local:         fl,
 		uploadLimiter: newDynamicSemaphore(window),
 		stopCh:        make(chan struct{}),
@@ -91,7 +91,7 @@ func TestCarvePass_FansOutBoundedByUploadWindow(t *testing.T) {
 // TestCarvePass_NoFilesIsNoop guards the empty working-set path.
 func TestCarvePass_NoFilesIsNoop(t *testing.T) {
 	fl := &carveFanoutLocal{started: make(chan string, 1), release: make(chan struct{}), carved: map[string]int{}}
-	m := &Syncer{local: fl, uploadLimiter: newDynamicSemaphore(4), stopCh: make(chan struct{}), config: DefaultConfig()}
+	m := &RemoteSync{local: fl, uploadLimiter: newDynamicSemaphore(4), stopCh: make(chan struct{}), config: DefaultConfig()}
 	m.carvePass(context.Background()) // returns immediately, acquires nothing
 	require.Equal(t, int32(0), fl.inFlight.Load())
 }

--- a/pkg/block/engine/carve_fixture_test.go
+++ b/pkg/block/engine/carve_fixture_test.go
@@ -45,14 +45,14 @@ const carveFixturePayload = "share/p1"
 
 // carveFixture wires a journal-backed *fs.FSStore, a memory metadata store (the
 // blockCommitter: Transactor + SyncedHashStore), and the
-// provided block-keyed remote into a Syncer with the carve substrate fully
+// provided block-keyed remote into a RemoteSync with the carve substrate fully
 // active (ManualSync — no background dispatcher racing assertions). carveBytes
 // sizes the block target.
 type carveFixture struct {
 	local  *fs.FSStore
 	ms     *metadatamemory.MemoryMetadataStore
 	remote remote.RemoteBlockStore
-	syncer *Syncer
+	syncer *RemoteSync
 	off    int64 // running write offset within carveFixturePayload
 }
 
@@ -75,7 +75,7 @@ func newCarveFixture(t *testing.T, rbs remote.RemoteStore, carveBytes int64) *ca
 	cfg := DefaultConfig()
 	cfg.ManualSync = true // explicit carve only; no background goroutine racing assertions
 
-	syncer := NewSyncer(local, rbs, ms, cfg)
+	syncer := NewRemoteSync(local, rbs, ms, cfg)
 	syncer.SetSyncedHashStore(ms)
 	rblock, ok := rbs.(remote.RemoteBlockStore)
 	if !ok {
@@ -170,7 +170,7 @@ func TestCarveBlockSizeReachesTheCarveLoop(t *testing.T) {
 		bs, err := New(BlockStoreConfig{
 			Local:           fx.local,
 			Remote:          mem,
-			Syncer:          fx.syncer,
+			RemoteSync:      fx.syncer,
 			FileChunkStore:  fx.ms,
 			SyncedHashStore: fx.ms,
 		})

--- a/pkg/block/engine/clone_localonly_test.go
+++ b/pkg/block/engine/clone_localonly_test.go
@@ -32,12 +32,12 @@ func newLocalOnlyEngine(t *testing.T, ms metadata.Store) *engine.Store {
 		t.Fatalf("metadata store %T does not implement metadata.SyncedHashStore", ms)
 	}
 	coord := &testCoordinator{store: ms}
-	syncer := engine.NewSyncer(localStore, nil, ms, engine.DefaultConfig())
+	syncer := engine.NewRemoteSync(localStore, nil, ms, engine.DefaultConfig())
 	// No remote block store: the journal owns the bytes and the local carve sink
 	// records the FileChunk manifest via the SyncedHashStore committer.
 	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:           localStore,
-		Syncer:          syncer,
+		RemoteSync:      syncer,
 		FileChunkStore:  ms,
 		Coordinator:     coord,
 		SyncedHashStore: syncedHashStore,

--- a/pkg/block/engine/cold_read_demand_timeout_test.go
+++ b/pkg/block/engine/cold_read_demand_timeout_test.go
@@ -46,11 +46,11 @@ var (
 	_ remote.ChunkReader      = (*blockingRemote)(nil)
 )
 
-// TestNewSyncer_DefaultsDemandFetchTimeout guards against the bound being dead
+// TestNewRemoteSync_DefaultsDemandFetchTimeout guards against the bound being dead
 // in production: a config that leaves DemandFetchTimeout unset (every path that
 // does not thread the field, e.g. pkg/config) must still get the default, or
 // EnsureAvailable would run unbounded and the hang would return.
-func TestNewSyncer_DefaultsDemandFetchTimeout(t *testing.T) {
+func TestNewRemoteSync_DefaultsDemandFetchTimeout(t *testing.T) {
 	fbs := newStubFileChunkStore()
 	m := NewRemoteSync(memorylocal.New(), remotememory.New(), fbs, RemoteSyncConfig{})
 	if m.config.DemandFetchTimeout != DefaultDemandFetchTimeout {

--- a/pkg/block/engine/cold_read_demand_timeout_test.go
+++ b/pkg/block/engine/cold_read_demand_timeout_test.go
@@ -52,9 +52,9 @@ var (
 // EnsureAvailable would run unbounded and the hang would return.
 func TestNewSyncer_DefaultsDemandFetchTimeout(t *testing.T) {
 	fbs := newStubFileChunkStore()
-	m := NewSyncer(memorylocal.New(), remotememory.New(), fbs, SyncerConfig{})
+	m := NewRemoteSync(memorylocal.New(), remotememory.New(), fbs, RemoteSyncConfig{})
 	if m.config.DemandFetchTimeout != DefaultDemandFetchTimeout {
-		t.Fatalf("NewSyncer left DemandFetchTimeout = %v; want default %v",
+		t.Fatalf("NewRemoteSync left DemandFetchTimeout = %v; want default %v",
 			m.config.DemandFetchTimeout, DefaultDemandFetchTimeout)
 	}
 }

--- a/pkg/block/engine/coordinator.go
+++ b/pkg/block/engine/coordinator.go
@@ -120,7 +120,7 @@ type MetadataCoordinator interface {
 
 	// GetFileObjectID returns the current FileAttr.ObjectID for
 	// payloadID, or the all-zero sentinel when the file has never
-	// quiesced (or does not exist). Used by Syncer.Flush to evaluate the
+	// quiesced (or does not exist). Used by RemoteSync.Flush to evaluate the
 	// trigger condition for the file-level dedup short-circuit BEFORE
 	// running the per-block upload pump.
 	//
@@ -148,7 +148,7 @@ var ErrMetadataCoordinatorNotWired = errors.New("engine: metadata coordinator no
 
 // ErrPersistFileChunksNotWired signals that PersistFileChunks was invoked
 // against a coordinator whose payloadID → fileHandle resolution chain has
-// not yet been wired. The Syncer's post-Flush
+// not yet been wired. The RemoteSync's post-Flush
 // hook recognises this sentinel and tolerates it (the dual-read shim keeps
 // reads correct), but logs a warning so the silent-drop window is
 // observable. Other callers should treat it as a hard error so a future

--- a/pkg/block/engine/coordinator_test.go
+++ b/pkg/block/engine/coordinator_test.go
@@ -64,7 +64,7 @@ type fakeCoordinator struct {
 	// unique-violation on the partial UNIQUE index.
 	persistErr error
 	// fileObjectIDs is the seedable per-payload current-ObjectID lookup
-	// for GetFileObjectID.: Syncer.Flush
+	// for GetFileObjectID.: RemoteSync.Flush
 	// reads this to evaluate the trigger condition before the
 	// per-block upload pump. Unset / zero-valued entries mean "never
 	// quiesced" (zero ObjectID), which lets the trigger condition fire

--- a/pkg/block/engine/delete_nilblocks_test.go
+++ b/pkg/block/engine/delete_nilblocks_test.go
@@ -16,11 +16,11 @@ import (
 func newReapFixture(t *testing.T, coord MetadataCoordinator, fbs *stubFileChunkStore) *Store {
 	t.Helper()
 	localStore := memory.New()
-	syncer := NewSyncer(localStore, nil, fbs, DefaultConfig())
+	syncer := NewRemoteSync(localStore, nil, fbs, DefaultConfig())
 	bs, err := New(BlockStoreConfig{
 		Local:          localStore,
 		Remote:         nil,
-		Syncer:         syncer,
+		RemoteSync:     syncer,
 		Coordinator:    coord,
 		FileChunkStore: fbs,
 	})

--- a/pkg/block/engine/doc.go
+++ b/pkg/block/engine/doc.go
@@ -35,7 +35,7 @@
 // Non-blocking submit drops requests when the worker channel is full
 // providing natural backpressure.
 //
-// # Syncer (formerly pkg/block/sync)
+// # RemoteSync (formerly pkg/block/sync)
 //
 // The syncer is responsible for moving data between the local store and the
 // remote block store (S3 or memory). It handles
@@ -55,7 +55,7 @@
 //   - In-flight deduplication: Avoid duplicate downloads for the same block
 //   - Non-blocking: Most operations return immediately; I/O happens in background
 //
-// The Syncer struct is created via NewSyncer() and requires a LocalStore
+// The RemoteSync struct is created via NewRemoteSync() and requires a LocalStore
 // RemoteStore, and FileChunkStore.
 //
 // # Block garbage collection (formerly pkg/block/gc)
@@ -78,6 +78,6 @@
 //	// Then actually delete
 //	stats := engine.CollectGarbage(ctx, remoteStore, registry, nil)
 //
-// The garbage collector has zero coupling to the Syncer - it only needs a
+// The garbage collector has zero coupling to the RemoteSync - it only needs a
 // RemoteStore and a MetadataReconciler to check metadata existence.
 package engine

--- a/pkg/block/engine/drain_reset_test.go
+++ b/pkg/block/engine/drain_reset_test.go
@@ -31,11 +31,11 @@ func newDrainResetFixture(t *testing.T) (*Store, *fs.FSStore) {
 	rem := remotememory.New()
 	cfg := DefaultConfig()
 	cfg.ManualSync = true
-	syncer := NewSyncer(localStore, rem, ms, cfg)
+	syncer := NewRemoteSync(localStore, rem, ms, cfg)
 	bs, err := New(BlockStoreConfig{
 		Local:           localStore,
 		Remote:          rem,
-		Syncer:          syncer,
+		RemoteSync:      syncer,
 		FileChunkStore:  ms,
 		SyncedHashStore: ms,
 		ReadBufferBytes: 64 * 1024 * 1024,

--- a/pkg/block/engine/durability_test.go
+++ b/pkg/block/engine/durability_test.go
@@ -28,7 +28,7 @@ func TestEngine_Flush_DurableLocalDefault_NoSyncRemote(t *testing.T) {
 		bs, err := New(BlockStoreConfig{
 			Local:           fx.local,
 			Remote:          mem,
-			Syncer:          fx.syncer,
+			RemoteSync:      fx.syncer,
 			FileChunkStore:  fx.ms,
 			SyncedHashStore: fx.ms,
 		})
@@ -58,8 +58,8 @@ func TestEngine_Flush_DurableLocalDefault_NoSyncRemote(t *testing.T) {
 func TestEngine_LocalDurable_MemoryDefaultsFalse(t *testing.T) {
 	localStore := localmemory.New()
 	fbs := newStubFileChunkStore()
-	syncer := NewSyncer(localStore, nil, fbs, DefaultConfig())
-	bs, err := New(BlockStoreConfig{Local: localStore, Syncer: syncer, FileChunkStore: fbs})
+	syncer := NewRemoteSync(localStore, nil, fbs, DefaultConfig())
+	bs, err := New(BlockStoreConfig{Local: localStore, RemoteSync: syncer, FileChunkStore: fbs})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -77,8 +77,8 @@ func TestEngine_LocalDurable_OverrideTrue(t *testing.T) {
 	localStore := localmemory.New()
 	localStore.SetDurable(true) // operator override
 	fbs := newStubFileChunkStore()
-	syncer := NewSyncer(localStore, nil, fbs, DefaultConfig())
-	bs, err := New(BlockStoreConfig{Local: localStore, Syncer: syncer, FileChunkStore: fbs})
+	syncer := NewRemoteSync(localStore, nil, fbs, DefaultConfig())
+	bs, err := New(BlockStoreConfig{Local: localStore, RemoteSync: syncer, FileChunkStore: fbs})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -93,8 +93,8 @@ func TestEngine_RemoteDurable_MemoryDefaultsFalse(t *testing.T) {
 	localStore := localmemory.New()
 	remoteStore := remotememory.New()
 	fbs := newStubFileChunkStore()
-	syncer := NewSyncer(localStore, remoteStore, fbs, DefaultConfig())
-	bs, err := New(BlockStoreConfig{Local: localStore, Remote: remoteStore, Syncer: syncer, FileChunkStore: fbs})
+	syncer := NewRemoteSync(localStore, remoteStore, fbs, DefaultConfig())
+	bs, err := New(BlockStoreConfig{Local: localStore, Remote: remoteStore, RemoteSync: syncer, FileChunkStore: fbs})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -110,8 +110,8 @@ func TestEngine_RemoteDurable_OverrideTrue(t *testing.T) {
 	remoteStore := remotememory.New()
 	remoteStore.SetDurable(true) // simulate a durable remote (s3 type-default)
 	fbs := newStubFileChunkStore()
-	syncer := NewSyncer(localStore, remoteStore, fbs, DefaultConfig())
-	bs, err := New(BlockStoreConfig{Local: localStore, Remote: remoteStore, Syncer: syncer, FileChunkStore: fbs})
+	syncer := NewRemoteSync(localStore, remoteStore, fbs, DefaultConfig())
+	bs, err := New(BlockStoreConfig{Local: localStore, Remote: remoteStore, RemoteSync: syncer, FileChunkStore: fbs})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -125,8 +125,8 @@ func TestEngine_RemoteDurable_OverrideTrue(t *testing.T) {
 func TestEngine_RequireDurableCommit_DefaultsFalse(t *testing.T) {
 	localStore := localmemory.New()
 	fbs := newStubFileChunkStore()
-	syncer := NewSyncer(localStore, nil, fbs, DefaultConfig())
-	bs, err := New(BlockStoreConfig{Local: localStore, Syncer: syncer, FileChunkStore: fbs})
+	syncer := NewRemoteSync(localStore, nil, fbs, DefaultConfig())
+	bs, err := New(BlockStoreConfig{Local: localStore, RemoteSync: syncer, FileChunkStore: fbs})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}

--- a/pkg/block/engine/engine.go
+++ b/pkg/block/engine/engine.go
@@ -160,7 +160,7 @@ func New(cfg BlockStoreConfig) (*Store, error) {
 		return nil, errors.New("local store is required")
 	}
 	if cfg.RemoteSync == nil {
-		return nil, errors.New("syncer is required")
+		return nil, errors.New("remote sync is required")
 	}
 
 	bs := &Store{

--- a/pkg/block/engine/engine.go
+++ b/pkg/block/engine/engine.go
@@ -26,8 +26,8 @@ type BlockStoreConfig struct {
 	// Remote is the durable backend store (nil for local-only mode).
 	Remote remote.RemoteStore
 
-	// Syncer handles async local-to-remote transfers (required).
-	Syncer *Syncer
+	// RemoteSync handles async local-to-remote transfers (required).
+	RemoteSync *RemoteSync
 
 	// FileChunkStore provides block metadata for block store statistics
 	// AND the engine-internal lookups (GetFileChunk, ListFileChunks) the
@@ -46,7 +46,7 @@ type BlockStoreConfig struct {
 
 	// SyncedHashStore persists per-CAS-hash local→remote sync state.
 	// Sourced from the same per-share metadata-store handle the
-	// Coordinator wraps. Threaded through to the Syncer so the carver
+	// Coordinator wraps. Threaded through to the RemoteSync so the carver
 	// can commit synced markers + block locators atomically
 	// (DefaultCommitBlock). Nil is accepted (local-only / no-remote
 	// fixtures); carve stays disabled in that mode.
@@ -72,7 +72,7 @@ type BlockStoreConfig struct {
 type Store struct {
 	local  local.LocalStore
 	remote remote.RemoteStore
-	syncer *Syncer
+	syncer *RemoteSync
 
 	// metrics is the engine-side data-plane metrics sink (carve/upload
 	// path). Retained from SetMetrics when the injected recorder also
@@ -100,7 +100,7 @@ type Store struct {
 
 	// syncedHashStore persists per-CAS-hash local→remote mirror state.
 	// Held alongside the coordinator so the engine constructor can thread
-	// it into the Syncer (via SetSyncedHashStore). May be nil in tests.
+	// it into the RemoteSync (via SetSyncedHashStore). May be nil in tests.
 	syncedHashStore metadata.SyncedHashStore
 
 	// cache is the CAS-keyed cache (CACHE-01..05). The block-coord
@@ -159,14 +159,14 @@ func New(cfg BlockStoreConfig) (*Store, error) {
 	if cfg.Local == nil {
 		return nil, errors.New("local store is required")
 	}
-	if cfg.Syncer == nil {
+	if cfg.RemoteSync == nil {
 		return nil, errors.New("syncer is required")
 	}
 
 	bs := &Store{
 		local:           cfg.Local,
 		remote:          cfg.Remote,
-		syncer:          cfg.Syncer,
+		syncer:          cfg.RemoteSync,
 		fileChunkStore:  cfg.FileChunkStore,
 		coordinator:     cfg.Coordinator,
 		syncedHashStore: cfg.SyncedHashStore,
@@ -178,26 +178,26 @@ func New(cfg BlockStoreConfig) (*Store, error) {
 	// so engine code can call bs.cache.* without nil-checks even before
 	// Start runs.
 	bs.cache = nullCache{}
-	// Thread the SyncedHashStore into the Syncer so the carver can commit
+	// Thread the SyncedHashStore into the RemoteSync so the carver can commit
 	// synced markers + block locators atomically. Nil is accepted
 	// (local-only / no-remote fixtures); carve stays disabled in that
 	// mode.
 	if cfg.SyncedHashStore != nil {
-		cfg.Syncer.SetSyncedHashStore(cfg.SyncedHashStore)
+		cfg.RemoteSync.SetSyncedHashStore(cfg.SyncedHashStore)
 	}
 	// Chunk-lifecycle hooks are gone with the journal switchover: chunking now
 	// happens at carve time inside the journal, and the carve BlockSink writes
 	// the per-(file,offset) FileChunk manifest rows atomically in its commit
 	// transaction (metadata.DefaultCommitBlock). There is no rollup-completion
 	// persister, no write-side cache warm hook, and no per-chunk emitter.
-	// wire the Store back-reference onto the Syncer so it can reach the
-	// owning Store for dataplane metrics (Syncer.dataplaneMetrics) and
+	// wire the Store back-reference onto the RemoteSync so it can reach the
+	// owning Store for dataplane metrics (RemoteSync.dataplaneMetrics) and
 	// cache access (InvalidateFile on delete). Reading through the
 	// back-reference (instead of caching a cacheInterface field on the
-	// Syncer at construction time) lets test code swap `bs.cache = rec`
+	// RemoteSync at construction time) lets test code swap `bs.cache = rec`
 	// post-construction and still observe the invalidation — mirrors the
 	// TestClose_ClosesCache pattern.
-	cfg.Syncer.bs = bs
+	cfg.RemoteSync.bs = bs
 	return bs, nil
 }
 
@@ -498,7 +498,7 @@ func (bs *Store) DrainLocalSynced(ctx context.Context) (int64, error) {
 // WarmAll proactively fetches every remote block of every payload in this
 // share onto the local CAS tier, delegating to the syncer's WarmAll under the
 // store's close-gate so a concurrent Close drains the run instead of racing
-// the local/syncer/remote teardown. See (*Syncer).WarmAll for semantics
+// the local/syncer/remote teardown. See (*RemoteSync).WarmAll for semantics
 // (bounded by ParallelDownloads, errors on a missing remote, terminal on
 // ErrDiskFull, honors ctx cancellation). progress may be nil.
 func (bs *Store) WarmAll(ctx context.Context, progress func(done, total int64)) (WarmResult, error) {

--- a/pkg/block/engine/engine_delete_test.go
+++ b/pkg/block/engine/engine_delete_test.go
@@ -229,12 +229,12 @@ func buildCascadeFixture(t *testing.T, coord MetadataCoordinator, syncedStore me
 	t.Helper()
 	localStore := memory.New()
 	fbs := newStubFileChunkStore()
-	syncer := NewSyncer(localStore, nil, fbs, DefaultConfig())
+	syncer := NewRemoteSync(localStore, nil, fbs, DefaultConfig())
 
 	bs, err := New(BlockStoreConfig{
 		Local:           localStore,
 		Remote:          nil,
-		Syncer:          syncer,
+		RemoteSync:      syncer,
 		Coordinator:     coord,
 		SyncedHashStore: syncedStore,
 	})

--- a/pkg/block/engine/engine_health_test.go
+++ b/pkg/block/engine/engine_health_test.go
@@ -73,7 +73,7 @@ func buildHealthTestEngine(t *testing.T) (*Store, *fakeRemoteStore) {
 
 	fakeRemote := newFakeRemoteStore()
 
-	syncCfg := SyncerConfig{
+	syncCfg := RemoteSyncConfig{
 		ParallelDownloads:           4,
 		PrefetchBlocks:              0,
 		UploadInterval:              50 * time.Millisecond,
@@ -83,12 +83,12 @@ func buildHealthTestEngine(t *testing.T) (*Store, *fakeRemoteStore) {
 		UnhealthyCheckInterval:      10 * time.Millisecond,
 	}
 
-	syncer := NewSyncer(localStore, fakeRemote, ms, syncCfg)
+	syncer := NewRemoteSync(localStore, fakeRemote, ms, syncCfg)
 
 	bs, err := New(BlockStoreConfig{
 		Local:           localStore,
 		Remote:          fakeRemote,
-		Syncer:          syncer,
+		RemoteSync:      syncer,
 		FileChunkStore:  ms,
 		SyncedHashStore: ms,
 	})

--- a/pkg/block/engine/engine_test.go
+++ b/pkg/block/engine/engine_test.go
@@ -130,12 +130,12 @@ func newTestEngine(t *testing.T, readBufferBytes int64, prefetchWorkers int) *St
 	t.Helper()
 	localStore := memory.New()
 	fbs := newStubFileChunkStore()
-	syncer := NewSyncer(localStore, nil, fbs, DefaultConfig())
+	syncer := NewRemoteSync(localStore, nil, fbs, DefaultConfig())
 
 	bs, err := New(BlockStoreConfig{
 		Local:           localStore,
 		Remote:          nil,
-		Syncer:          syncer,
+		RemoteSync:      syncer,
 		FileChunkStore:  fbs,
 		ReadBufferBytes: readBufferBytes,
 		PrefetchWorkers: prefetchWorkers,
@@ -153,17 +153,17 @@ func newTestEngine(t *testing.T, readBufferBytes int64, prefetchWorkers int) *St
 // newTestEngineWithCoordinator creates an engine.Store with the
 // supplied MetadataCoordinator wired in (Task 0).
 // Used by tests that assert engine-coordinator integration without
-// touching the heavier Syncer/Remote setup.
+// touching the heavier RemoteSync/Remote setup.
 func newTestEngineWithCoordinator(t *testing.T, c MetadataCoordinator) *Store {
 	t.Helper()
 	localStore := memory.New()
 	fbs := newStubFileChunkStore()
-	syncer := NewSyncer(localStore, nil, fbs, DefaultConfig())
+	syncer := NewRemoteSync(localStore, nil, fbs, DefaultConfig())
 
 	bs, err := New(BlockStoreConfig{
 		Local:          localStore,
 		Remote:         nil,
-		Syncer:         syncer,
+		RemoteSync:     syncer,
 		FileChunkStore: fbs,
 		Coordinator:    c,
 	})
@@ -236,7 +236,7 @@ func TestReadAt_CacheDisabled(t *testing.T) {
 
 // TestReadAt_DoesNotInvokeCacheOnReadPath guards the Step-1 retirement of the
 // dead cache read-prefetch trigger: readahead is now driven by the offset-based
-// Syncer.scheduleReadahead (covered in readahead_test.go), and the RAM Cache is
+// RemoteSync.scheduleReadahead (covered in readahead_test.go), and the RAM Cache is
 // off the read path entirely (readAtInternal serves from the local store). So a
 // successful ReadAt must NOT call cache.OnRead — even when the caller passes a
 // non-nil []ChunkRef (the argument is opaque to the read path). This prevents
@@ -364,12 +364,12 @@ func (r *recordingCache) Close() error      { r.closed.Store(true); return nil }
 func TestClose_ClosesCache(t *testing.T) {
 	localStore := memory.New()
 	fbs := newStubFileChunkStore()
-	syncer := NewSyncer(localStore, nil, fbs, DefaultConfig())
+	syncer := NewRemoteSync(localStore, nil, fbs, DefaultConfig())
 
 	bs, err := New(BlockStoreConfig{
-		Local:  localStore,
-		Remote: nil,
-		Syncer: syncer,
+		Local:      localStore,
+		Remote:     nil,
+		RemoteSync: syncer,
 	})
 	if err != nil {
 		t.Fatalf("New failed: %v", err)

--- a/pkg/block/engine/fetch.go
+++ b/pkg/block/engine/fetch.go
@@ -26,7 +26,7 @@ func inFlightKey(payloadID string, blockIdx uint64) string {
 // download concurrency the same way; the background SyncQueue prefetch pool is
 // separate. g.Go blocks once the limit is reached; the first task error cancels
 // the rest via the returned context.
-func (m *Syncer) fetchGroup(ctx context.Context) (*errgroup.Group, context.Context) {
+func (m *RemoteSync) fetchGroup(ctx context.Context) (*errgroup.Group, context.Context) {
 	parallel := m.config.ParallelDownloads
 	if parallel < 1 {
 		parallel = 1
@@ -90,7 +90,7 @@ type hydrateSpan struct {
 // so a window opening mid-chunk still hydrates that chunk whole and any row
 // hidden between the chunk's start and the window's is resolved rather than
 // written over.
-func (m *Syncer) collectCoveringChunks(ctx context.Context, payloadID string, start, end uint64) ([]coveringChunk, error) {
+func (m *RemoteSync) collectCoveringChunks(ctx context.Context, payloadID string, start, end uint64) ([]coveringChunk, error) {
 	if m.fileChunkStore == nil {
 		return nil, nil
 	}
@@ -139,7 +139,7 @@ func (m *Syncer) collectCoveringChunks(ctx context.Context, payloadID string, st
 // sparse / not-yet-uploaded payload (ErrFileChunkNotFound) yields (nil, nil).
 // Used by whole-manifest consumers (warm); the read path resolves a single
 // covering chunk via resolveCovering instead of enumerating.
-func (m *Syncer) listFileChunksSnapshot(ctx context.Context, payloadID string) ([]*block.FileChunk, error) {
+func (m *RemoteSync) listFileChunksSnapshot(ctx context.Context, payloadID string) ([]*block.FileChunk, error) {
 	rows, err := m.fileChunkStore.ListFileChunks(ctx, payloadID)
 	if err != nil {
 		if errors.Is(err, block.ErrFileChunkNotFound) {
@@ -170,7 +170,7 @@ func (m *Syncer) listFileChunksSnapshot(ctx context.Context, payloadID string) (
 // is the range the caller's walk resolved it for (see hydrateSpan). A zero span
 // writes the whole claimed extent, which is what a caller holding a row but no
 // window wants.
-func (m *Syncer) hydrateChunk(ctx context.Context, fb *block.FileChunk, data []byte, span hydrateSpan) error {
+func (m *RemoteSync) hydrateChunk(ctx context.Context, fb *block.FileChunk, data []byte, span hydrateSpan) error {
 	// The claim is [StartOffset, StartOffset+DataSize) of the chunk, and the
 	// row's ID names the file offset of its FIRST claimed byte, so the write-back
 	// stays aligned only if the head is trimmed off too. A claim the chunk cannot
@@ -232,7 +232,7 @@ var errPreBlockFormatLocator = errors.New("pre-block-format locator")
 //
 // Returns ("", nil, nil) if the FileChunk has no actionable key (sparse
 // or never-uploaded). Errors from the remote store flow through unchanged.
-func (m *Syncer) dispatchRemoteFetch(ctx context.Context, fb *block.FileChunk) (string, []byte, error) {
+func (m *RemoteSync) dispatchRemoteFetch(ctx context.Context, fb *block.FileChunk) (string, []byte, error) {
 	if fb == nil {
 		return "", nil, nil
 	}
@@ -279,7 +279,7 @@ func (m *Syncer) dispatchRemoteFetch(ctx context.Context, fb *block.FileChunk) (
 //     that predates the packed-block format. Nothing can read it any more, so it
 //     fails closed rather than falling through to an empty block key, tagged
 //     errPreBlockFormatLocator so the caller's retry does not repeat it.
-func (m *Syncer) resolveAndReadChunk(ctx context.Context, fb *block.FileChunk) (string, []byte, error) {
+func (m *RemoteSync) resolveAndReadChunk(ctx context.Context, fb *block.FileChunk) (string, []byte, error) {
 	loc, synced, err := m.resolveLocator(ctx, fb.Hash)
 	if err != nil {
 		return "", nil, err
@@ -309,7 +309,7 @@ func (m *Syncer) resolveAndReadChunk(ctx context.Context, fb *block.FileChunk) (
 // "not on remote" and falls back to local, NOT as drift. A synced hash with an
 // empty BlockID is the drift case the caller fails closed on. With no
 // SyncedHashStore wired (test fixtures) the hash is reported not synced.
-func (m *Syncer) resolveLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error) {
+func (m *RemoteSync) resolveLocator(ctx context.Context, hash block.ContentHash) (block.ChunkLocator, bool, error) {
 	m.mu.RLock()
 	hs := m.syncedHashStore
 	m.mu.RUnlock()
@@ -332,7 +332,7 @@ func (m *Syncer) resolveLocator(ctx context.Context, hash block.ContentHash) (bl
 // both the chunk's wire bytes and its plaintext-hash domain — ReadChunk
 // returns decrypted/decompressed plaintext, and we recompute over it so a
 // corrupt ranged read can never be served.
-func (m *Syncer) readChunkVerified(ctx context.Context, loc block.ChunkLocator, hash block.ContentHash) ([]byte, error) {
+func (m *RemoteSync) readChunkVerified(ctx context.Context, loc block.ChunkLocator, hash block.ContentHash) ([]byte, error) {
 	// remote.RemoteStore embeds ChunkReader, so ranged block reads are always
 	// available — no capability probe needed.
 	data, err := m.remoteStore.ReadChunk(ctx, loc.BlockID, loc.WireOffset, loc.WireLength, hash)
@@ -370,7 +370,7 @@ func (m *Syncer) readChunkVerified(ctx context.Context, loc block.ChunkLocator, 
 // demand read for the same chunk piggybacks on this prefetch instead of issuing
 // its own S3 GET. That shared budget is what keeps total remote concurrency
 // bounded when the readahead window overlaps demand.
-func (m *Syncer) fetchBlock(ctx context.Context, payloadID string, blockIdx uint64) error {
+func (m *RemoteSync) fetchBlock(ctx context.Context, payloadID string, blockIdx uint64) error {
 	if !m.canProcess(ctx) {
 		return ErrClosed
 	}
@@ -419,7 +419,7 @@ func (m *Syncer) fetchBlock(ctx context.Context, payloadID string, blockIdx uint
 // start at arbitrary, non-BlockSize-aligned offsets, and a blockIdx lookup
 // would miss every non-aligned chunk and silently skip it). Returns nil data
 // when the row has no actionable remote key (sparse / never-uploaded).
-func (m *Syncer) fetchResolvedBlock(ctx context.Context, fb *block.FileChunk, span hydrateSpan) ([]byte, error) {
+func (m *RemoteSync) fetchResolvedBlock(ctx context.Context, fb *block.FileChunk, span hydrateSpan) ([]byte, error) {
 	if fb == nil {
 		return nil, nil
 	}
@@ -470,7 +470,7 @@ func blockRange(offset uint64, length uint32) (start, end uint64) {
 // EnsureAvailable hydrates the local tier for [offset, offset+length) so
 // the caller's subsequent local read is served warm. Demanded chunks are
 // downloaded inline in the caller's goroutine; prefetch uses the worker pool.
-func (m *Syncer) EnsureAvailable(ctx context.Context, payloadID string, offset uint64, length uint32) error {
+func (m *RemoteSync) EnsureAvailable(ctx context.Context, payloadID string, offset uint64, length uint32) error {
 	if length == 0 {
 		return nil
 	}
@@ -574,7 +574,7 @@ func (m *Syncer) EnsureAvailable(ctx context.Context, payloadID string, offset u
 // fb is the caller's already-resolved covering FileChunk for the block; a nil
 // fb is a sparse block (nothing to fetch). span is the part of the chunk the
 // caller resolved this row for, which is what gets written back locally.
-func (m *Syncer) inlineFetchOrWait(ctx context.Context, payloadID string, blockIdx uint64, fb *block.FileChunk, span hydrateSpan) ([]byte, bool, error) {
+func (m *RemoteSync) inlineFetchOrWait(ctx context.Context, payloadID string, blockIdx uint64, fb *block.FileChunk, span hydrateSpan) ([]byte, bool, error) {
 	// Dedup key must be per-CHUNK, not per-block: a read window can span several
 	// chunks that live in the same 8 MiB block (FastCDC chunks are typically
 	// smaller than BlockSize), so keying by blockIdx alone would make the second
@@ -677,7 +677,7 @@ func (m *Syncer) inlineFetchOrWait(ctx context.Context, payloadID string, blockI
 }
 
 // completeInFlight signals completion to all waiters and cleans up tracking.
-func (m *Syncer) completeInFlight(key string, result *fetchResult, err error) {
+func (m *RemoteSync) completeInFlight(key string, result *fetchResult, err error) {
 	result.mu.Lock()
 	result.err = err
 	result.mu.Unlock()

--- a/pkg/block/engine/fetch_test.go
+++ b/pkg/block/engine/fetch_test.go
@@ -56,13 +56,13 @@ func (f *failingPutLocal) Hydrate(_ context.Context, _ string, _ int64, _ []byte
 	return errBoomLocalPut
 }
 
-// newFetchSyncer wires the minimum Syncer surface inlineFetchOrWait
+// newFetchSyncer wires the minimum RemoteSync surface inlineFetchOrWait
 // exercises: local, remoteStore, fileChunkStore, the SyncedHashStore the
 // post-#1493 fetch path resolves block locators from, the inFlight map, and a
 // nil HealthMonitor (so IsRemoteHealthy returns true). Coordinator is unused
 // on this path.
-func newFetchSyncer(localStore local.LocalStore, rs remote.RemoteStore, fbs block.EngineFileChunkStore, shs metadata.SyncedHashStore) *Syncer {
-	return &Syncer{
+func newFetchSyncer(localStore local.LocalStore, rs remote.RemoteStore, fbs block.EngineFileChunkStore, shs metadata.SyncedHashStore) *RemoteSync {
+	return &RemoteSync{
 		local:           localStore,
 		remoteStore:     rs,
 		fileChunkStore:  fbs,

--- a/pkg/block/engine/fetch_window_test.go
+++ b/pkg/block/engine/fetch_window_test.go
@@ -122,7 +122,7 @@ func TestReadAtInternal_StillColdAfterHydrateFailsClosed(t *testing.T) {
 	// the window is still cold on the re-read.
 	bs := &Store{
 		local:  alwaysColdLocal{},
-		syncer: &Syncer{stopCh: make(chan struct{}), config: DefaultConfig()},
+		syncer: &RemoteSync{stopCh: make(chan struct{}), config: DefaultConfig()},
 	}
 
 	data := bytes.Repeat([]byte{0xAA}, 4096)

--- a/pkg/block/engine/gc_test.go
+++ b/pkg/block/engine/gc_test.go
@@ -366,11 +366,11 @@ func newReapEngine(t *testing.T, st metadata.Store) *Store {
 	t.Helper()
 	localStore := memory.New()
 	fbs := newStubFileChunkStore()
-	syncer := NewSyncer(localStore, nil, fbs, DefaultConfig())
+	syncer := NewRemoteSync(localStore, nil, fbs, DefaultConfig())
 	bs, err := New(BlockStoreConfig{
 		Local:          localStore,
 		Remote:         nil,
-		Syncer:         syncer,
+		RemoteSync:     syncer,
 		FileChunkStore: fbs,
 		Coordinator:    &reapCoordinator{store: st},
 	})

--- a/pkg/block/engine/hydrate_after_mutation_test.go
+++ b/pkg/block/engine/hydrate_after_mutation_test.go
@@ -47,12 +47,12 @@ func newEngineWithGatedRemote(t *testing.T, ms metadata.Store, rem *gatedRemote)
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions: %v", err)
 	}
-	syncer := engine.NewSyncer(localStore, rem, ms, engine.DefaultConfig())
+	syncer := engine.NewRemoteSync(localStore, rem, ms, engine.DefaultConfig())
 	syncer.SetSyncedHashStore(syncedHashStore)
 	syncer.SetRemoteBlockStore(rem)
 	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:           localStore,
-		Syncer:          syncer,
+		RemoteSync:      syncer,
 		FileChunkStore:  ms,
 		Coordinator:     &testCoordinator{store: ms},
 		SyncedHashStore: syncedHashStore,

--- a/pkg/block/engine/localonly_eviction_test.go
+++ b/pkg/block/engine/localonly_eviction_test.go
@@ -25,10 +25,10 @@ func localOnlyPair(t *testing.T, ms metadata.Store) (*engine.Store, *fs.FSStore)
 	if !ok {
 		t.Fatalf("metadata store %T is not a SyncedHashStore", ms)
 	}
-	syncer := engine.NewSyncer(localStore, nil, ms, engine.DefaultConfig())
+	syncer := engine.NewRemoteSync(localStore, nil, ms, engine.DefaultConfig())
 	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:           localStore,
-		Syncer:          syncer,
+		RemoteSync:      syncer,
 		FileChunkStore:  ms,
 		Coordinator:     &testCoordinator{store: ms},
 		SyncedHashStore: syncedHashStore,

--- a/pkg/block/engine/locator_fetch_test.go
+++ b/pkg/block/engine/locator_fetch_test.go
@@ -14,10 +14,10 @@ import (
 	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
-// newLocatorFetchSyncer builds a Syncer over an in-memory local store, remote
+// newLocatorFetchSyncer builds a RemoteSync over an in-memory local store, remote
 // store, and synced-hash store — the minimal wiring dispatchRemoteFetch needs to
 // resolve a chunk locator and route the read.
-func newLocatorFetchSyncer(t *testing.T) (*Syncer, *remotememory.Store, *metadatamemory.MemoryMetadataStore) {
+func newLocatorFetchSyncer(t *testing.T) (*RemoteSync, *remotememory.Store, *metadatamemory.MemoryMetadataStore) {
 	t.Helper()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
 	t.Cleanup(func() { _ = ms.Close() })
@@ -30,7 +30,7 @@ func newLocatorFetchSyncer(t *testing.T) (*Syncer, *remotememory.Store, *metadat
 	t.Cleanup(func() { _ = localStore.Close() })
 
 	rem := remotememory.New()
-	syncer := NewSyncer(localStore, rem, ms, DefaultConfig())
+	syncer := NewRemoteSync(localStore, rem, ms, DefaultConfig())
 	syncer.SetSyncedHashStore(ms)
 	return syncer, rem, ms
 }

--- a/pkg/block/engine/nil_remotestore_test.go
+++ b/pkg/block/engine/nil_remotestore_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // newNilRemoteStoreEnv creates a test environment with nil remoteStore (local-only mode).
-func newNilRemoteStoreEnv(t *testing.T) (*Syncer, local.LocalStore, func()) {
+func newNilRemoteStoreEnv(t *testing.T) (*RemoteSync, local.LocalStore, func()) {
 	t.Helper()
 	tmpDir := t.TempDir()
 	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
@@ -21,7 +21,7 @@ func newNilRemoteStoreEnv(t *testing.T) (*Syncer, local.LocalStore, func()) {
 		t.Fatalf("fs.NewWithOptions() error = %v", err)
 	}
 	// nil remoteStore = local-only mode
-	m := NewSyncer(bc, nil, ms, DefaultConfig())
+	m := NewRemoteSync(bc, nil, ms, DefaultConfig())
 	return m, bc, func() {
 		_ = m.Close()
 		_ = bc.Close()

--- a/pkg/block/engine/offline_manifest_test.go
+++ b/pkg/block/engine/offline_manifest_test.go
@@ -42,13 +42,13 @@ func openOfflineEngine(t *testing.T, dir string, ms metadata.Store, mem *remotem
 	if err != nil {
 		t.Fatalf("fs.NewWithOptions: %v", err)
 	}
-	syncer := engine.NewSyncer(local, mem, ms, engine.DefaultConfig())
+	syncer := engine.NewRemoteSync(local, mem, ms, engine.DefaultConfig())
 	syncer.SetSyncedHashStore(shs)
 	syncer.SetRemoteBlockStore(mem)
 	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:           local,
 		Remote:          keepOpenRemote{mem},
-		Syncer:          syncer,
+		RemoteSync:      syncer,
 		FileChunkStore:  ms,
 		Coordinator:     &testCoordinator{store: ms},
 		SyncedHashStore: shs,

--- a/pkg/block/engine/perf_bench_phase12_test.go
+++ b/pkg/block/engine/perf_bench_phase12_test.go
@@ -136,12 +136,12 @@ func newPerfTestEngine(tb testing.TB, readBufferBytes int64, prefetchWorkers int
 	tb.Helper()
 	localStore := memory.New()
 	fbs := newStubFileChunkStore()
-	syncer := NewSyncer(localStore, nil, fbs, DefaultConfig())
+	syncer := NewRemoteSync(localStore, nil, fbs, DefaultConfig())
 
 	bs, err := New(BlockStoreConfig{
 		Local:           localStore,
 		Remote:          nil,
-		Syncer:          syncer,
+		RemoteSync:      syncer,
 		ReadBufferBytes: readBufferBytes,
 		PrefetchWorkers: prefetchWorkers,
 	})

--- a/pkg/block/engine/readahead.go
+++ b/pkg/block/engine/readahead.go
@@ -37,7 +37,7 @@ type raState struct {
 // (bounded by scheduledUpTo); the first read of a payload only establishes the
 // frontier, and a random jump resets the anchor so we never prefetch blocks a
 // random reader will not touch.
-func (m *Syncer) planWindow(payloadID string, start, end uint64) (from, to uint64, fire bool) {
+func (m *RemoteSync) planWindow(payloadID string, start, end uint64) (from, to uint64, fire bool) {
 	maxDepth := m.config.PrefetchBlocks
 	if maxDepth <= 0 {
 		return 0, 0, false // prefetch disabled
@@ -94,7 +94,7 @@ func (m *Syncer) planWindow(payloadID string, start, end uint64) (from, to uint6
 // time; entries are dropped in gosync.Map.Range order (arbitrary) — a dropped
 // payload just re-ramps from a cold frontier on its next read. readaheadN is
 // approximate under concurrent inserts, which is fine for a soft bound.
-func (m *Syncer) pruneReadahead() {
+func (m *RemoteSync) pruneReadahead() {
 	if !m.readaheadPruning.CompareAndSwap(false, true) {
 		return // another goroutine is already pruning
 	}
@@ -121,7 +121,7 @@ func (m *Syncer) pruneReadahead() {
 // No-op without a remote, while the remote is unhealthy, or for a zero-length
 // read. The hot-path cost is one in-memory frontier update (planWindow); the
 // per-block local/remote probes happen in the worker pool, off the read path.
-func (m *Syncer) scheduleReadahead(payloadID string, offset uint64, length uint32) {
+func (m *RemoteSync) scheduleReadahead(payloadID string, offset uint64, length uint32) {
 	if length == 0 || m.queue == nil {
 		return
 	}

--- a/pkg/block/engine/readahead_contention_bench_test.go
+++ b/pkg/block/engine/readahead_contention_bench_test.go
@@ -13,7 +13,7 @@ import (
 // readaheadMu, so ns/op here IS the per-read frontier-update cost under
 // contention. Run with -mutexprofile to confirm the lock, -cpuprofile for CPU.
 func BenchmarkPlanWindow_SinglePayloadConcurrent(b *testing.B) {
-	m := &Syncer{config: SyncerConfig{PrefetchBlocks: 8}}
+	m := &RemoteSync{config: RemoteSyncConfig{PrefetchBlocks: 8}}
 	b.RunParallel(func(pb *testing.PB) {
 		rng := rand.New(rand.NewSource(1)) //nolint:gosec // bench offsets
 		for pb.Next() {
@@ -27,7 +27,7 @@ func BenchmarkPlanWindow_SinglePayloadConcurrent(b *testing.B) {
 // reads spread across many payloads. A per-payload/sharded lock removes the
 // cross-payload contention this has today (all payloads share one readaheadMu).
 func BenchmarkPlanWindow_MultiPayloadConcurrent(b *testing.B) {
-	m := &Syncer{config: SyncerConfig{PrefetchBlocks: 8}}
+	m := &RemoteSync{config: RemoteSyncConfig{PrefetchBlocks: 8}}
 	payloads := make([]string, 256)
 	for i := range payloads {
 		payloads[i] = "payload-" + string(rune('a'+i%26)) + string(rune('a'+i/26))

--- a/pkg/block/engine/readahead_test.go
+++ b/pkg/block/engine/readahead_test.go
@@ -5,14 +5,14 @@ import (
 	"testing"
 )
 
-// newRAsyncer builds a Syncer exercising only planWindow (no queue/remote).
-func newRAsyncer(prefetch int) *Syncer {
-	return &Syncer{config: SyncerConfig{PrefetchBlocks: prefetch}}
+// newRAsyncer builds a RemoteSync exercising only planWindow (no queue/remote).
+func newRAsyncer(prefetch int) *RemoteSync {
+	return &RemoteSync{config: RemoteSyncConfig{PrefetchBlocks: prefetch}}
 }
 
 // window is a test helper: the block indices planWindow schedules for a read
 // spanning [start, end], or nil when it fires nothing.
-func (m *Syncer) window(payloadID string, start, end uint64) []uint64 {
+func (m *RemoteSync) window(payloadID string, start, end uint64) []uint64 {
 	from, to, fire := m.planWindow(payloadID, start, end)
 	if !fire {
 		return nil
@@ -91,10 +91,10 @@ func TestPlanWindow_MapBounded(t *testing.T) {
 	}
 }
 
-// newSchedSyncer builds a Syncer with a real (unstarted) SyncQueue so
+// newSchedSyncer builds a RemoteSync with a real (unstarted) SyncQueue so
 // scheduleReadahead enqueues into an inspectable prefetch channel.
-func newSchedSyncer(prefetch int) *Syncer {
-	m := &Syncer{config: SyncerConfig{PrefetchBlocks: prefetch}}
+func newSchedSyncer(prefetch int) *RemoteSync {
+	m := &RemoteSync{config: RemoteSyncConfig{PrefetchBlocks: prefetch}}
 	m.hasRemote.Store(true) // IsRemoteHealthy() is true with no health monitor
 	m.queue = NewSyncQueue(m, SyncQueueConfig{QueueSize: 1000, DownloadWorkers: 4})
 	return m

--- a/pkg/block/engine/readwrite.go
+++ b/pkg/block/engine/readwrite.go
@@ -14,7 +14,7 @@ import (
 // sparse holes.
 //
 // After a successful read the engine drives the offset-based readahead window
-// (Syncer.scheduleReadahead) so a sequential reader keeps the local read-serving
+// (RemoteSync.scheduleReadahead) so a sequential reader keeps the local read-serving
 // tier populated ahead of the read frontier. This fires on EVERY read; the
 // window is computed purely from offset+len(data).
 func (bs *Store) ReadAt(ctx context.Context, payloadID string, data []byte, offset uint64) (int, error) {
@@ -98,7 +98,7 @@ func (bs *Store) WriteAt(ctx context.Context, payloadID string, currentBlocks []
 	// carve.go carveRun) and lands as
 	// Pending FileChunks with chunk-hash populated. The canonical
 	// []ChunkRef projection is built at Flush time from
-	// ListFileChunks(payloadID) — see Syncer.snapshotChunkRefs
+	// ListFileChunks(payloadID) — see RemoteSync.snapshotChunkRefs
 	// (post-drain canonical list for the post-Flush hook). WriteAt
 	// itself remains a per-write append into the local store and does
 	// NOT need to return a merged []ChunkRef; the dual-read shim's

--- a/pkg/block/engine/retention_pin_start_test.go
+++ b/pkg/block/engine/retention_pin_start_test.go
@@ -29,12 +29,12 @@ func drainAfterFill(t *testing.T, pinned bool) int64 {
 	}
 	localStore.SetEvictionPinned(pinned)
 
-	syncer := engine.NewSyncer(localStore, mem, ms, engine.DefaultConfig())
+	syncer := engine.NewRemoteSync(localStore, mem, ms, engine.DefaultConfig())
 	syncer.SetSyncedHashStore(ms)
 	syncer.SetRemoteBlockStore(mem)
 	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:           localStore,
-		Syncer:          syncer,
+		RemoteSync:      syncer,
 		FileChunkStore:  ms,
 		Coordinator:     &testCoordinator{store: ms},
 		SyncedHashStore: ms,

--- a/pkg/block/engine/sync_health.go
+++ b/pkg/block/engine/sync_health.go
@@ -45,7 +45,7 @@ type HealthMonitor struct {
 
 // NewHealthMonitor creates a new HealthMonitor. If probeFunc is nil, the monitor
 // always reports healthy and Start() is a no-op.
-func NewHealthMonitor(probeFunc func(ctx context.Context) error, config SyncerConfig) *HealthMonitor {
+func NewHealthMonitor(probeFunc func(ctx context.Context) error, config RemoteSyncConfig) *HealthMonitor {
 	interval := config.HealthCheckInterval
 	if interval <= 0 {
 		interval = 30 * time.Second

--- a/pkg/block/engine/sync_health_test.go
+++ b/pkg/block/engine/sync_health_test.go
@@ -26,7 +26,7 @@ func controllableProbe(shouldFail *atomic.Bool) (func(ctx context.Context) error
 }
 
 // fastHealthConfig returns a Config with short probe intervals for unit tests.
-func fastHealthConfig() SyncerConfig {
+func fastHealthConfig() RemoteSyncConfig {
 	cfg := DefaultConfig()
 	cfg.HealthCheckInterval = 10 * time.Millisecond
 	cfg.UnhealthyCheckInterval = 10 * time.Millisecond
@@ -242,7 +242,7 @@ func TestHealthMonitor_OutageDuration(t *testing.T) {
 }
 
 // TestHealthMonitor_StopJoinsProbe pins that Stop() waits for an in-flight
-// probe. The probe dials the remote store, and Syncer.Close() stops the monitor
+// probe. The probe dials the remote store, and RemoteSync.Close() stops the monitor
 // right before the owning Store closes that remote — a Stop that only signalled
 // would leave a probe reading a closed store.
 func TestHealthMonitor_StopJoinsProbe(t *testing.T) {

--- a/pkg/block/engine/sync_queue.go
+++ b/pkg/block/engine/sync_queue.go
@@ -12,7 +12,7 @@ import (
 // worker pool. Uploads do not go through the queue: the carve dispatcher owns
 // the local→remote path.
 type SyncQueue struct {
-	manager *Syncer
+	manager *RemoteSync
 
 	// Priority channels
 	downloads chan TransferRequest // Processed by download workers
@@ -44,7 +44,7 @@ type SyncQueue struct {
 }
 
 // NewSyncQueue creates a new transfer queue with a dedicated worker pool.
-func NewSyncQueue(m *Syncer, cfg SyncQueueConfig) *SyncQueue {
+func NewSyncQueue(m *RemoteSync, cfg SyncQueueConfig) *SyncQueue {
 	if cfg.QueueSize <= 0 {
 		cfg.QueueSize = 1000
 	}

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -35,9 +35,9 @@ type fetchResult struct {
 // own collaborator with its own lock buys legibility and costs a second lock
 // order to get right; do it only once a hardware rig can prove the split
 // preserves the fetch/carve/close ordering.
-// Syncer handles async local-to-remote transfers with eager block carving,
+// RemoteSync handles async local-to-remote transfers with eager block carving,
 // parallel download, prefetch, in-flight dedup, and content-addressed dedup.
-type Syncer struct {
+type RemoteSync struct {
 	local       local.LocalStore
 	remoteStore remote.RemoteStore
 	// hasRemote mirrors "remoteStore != nil" as an atomic so hot-path gating
@@ -63,13 +63,13 @@ type Syncer struct {
 	// the file-level dedup short-circuit needs to reach
 	// Store.cache to fire InvalidateFile on orphaned speculative
 	// chunks. Reading through the back-reference (rather than copying a
-	// `cache` field on the Syncer at construction time) lets test code
+	// `cache` field on the RemoteSync at construction time) lets test code
 	// swap `bs.cache = rec` after construction and still observe the
 	// invalidation — mirrors the TestClose_ClosesCache pattern. May be
 	// nil in pre-wiring tests; callers must nil-check before use.
 	bs *Store
 
-	config SyncerConfig
+	config RemoteSyncConfig
 
 	queue *SyncQueue // Transfer queue for non-blocking operations
 
@@ -171,14 +171,14 @@ type blockCommitter interface {
 // remote. It is the journal's own dirty-byte counter — the backpressure signal
 // the eviction path consults: a non-zero value with a healthy remote means a
 // stalled writer can make progress once the carve dispatcher drains.
-func (m *Syncer) UnsyncedBytes() int64 {
+func (m *RemoteSync) UnsyncedBytes() int64 {
 	return m.local.UnsyncedBytes()
 }
 
-// NewSyncer creates a new Syncer. The fileChunkStore is required for content-addressed dedup.
-func NewSyncer(local local.LocalStore, remoteStore remote.RemoteStore, fileChunkStore block.EngineFileChunkStore, config SyncerConfig) *Syncer {
+// NewRemoteSync creates a new RemoteSync. The fileChunkStore is required for content-addressed dedup.
+func NewRemoteSync(local local.LocalStore, remoteStore remote.RemoteStore, fileChunkStore block.EngineFileChunkStore, config RemoteSyncConfig) *RemoteSync {
 	if fileChunkStore == nil {
-		panic("fileChunkStore is required for Syncer")
+		panic("fileChunkStore is required for RemoteSync")
 	}
 	if config.ParallelDownloads <= 0 {
 		config.ParallelDownloads = DefaultParallelDownloads
@@ -206,7 +206,7 @@ func NewSyncer(local local.LocalStore, remoteStore remote.RemoteStore, fileChunk
 		uploadController = newGoodputController(AdaptiveUploadFloor, AdaptiveUploadCeiling)
 	}
 
-	m := &Syncer{
+	m := &RemoteSync{
 		local:          local,
 		remoteStore:    remoteStore,
 		fileChunkStore: fileChunkStore,
@@ -228,14 +228,14 @@ func NewSyncer(local local.LocalStore, remoteStore remote.RemoteStore, fileChunk
 }
 
 // Queue returns the transfer queue for stats inspection.
-func (m *Syncer) Queue() *SyncQueue { return m.queue }
+func (m *RemoteSync) Queue() *SyncQueue { return m.queue }
 
 // SetSyncedHashStore wires the per-hash sync-state store the restart/drift
 // reseed consults via local.ListUnsynced and the carver updates through
-// DefaultCommitBlock. Idempotent. May be invoked after NewSyncer so the
+// DefaultCommitBlock. Idempotent. May be invoked after NewRemoteSync so the
 // construction sequence does not need to thread a SyncedHashStore through
-// the engine.NewSyncer signature.
-func (m *Syncer) SetSyncedHashStore(s metadata.SyncedHashStore) {
+// the engine.NewRemoteSync signature.
+func (m *RemoteSync) SetSyncedHashStore(s metadata.SyncedHashStore) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.syncedHashStore = s
@@ -259,7 +259,7 @@ func (m *Syncer) SetSyncedHashStore(s metadata.SyncedHashStore) {
 // leaves carve disabled: pending chunks then accumulate locally and Flush
 // reports Finalized=false (there is no legacy per-hash fallback). Idempotent;
 // safe to call before Start.
-func (m *Syncer) SetRemoteBlockStore(rbs remote.RemoteBlockStore) {
+func (m *RemoteSync) SetRemoteBlockStore(rbs remote.RemoteBlockStore) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.remoteBlockStore = rbs
@@ -279,7 +279,7 @@ func (m *Syncer) SetRemoteBlockStore(rbs remote.RemoteBlockStore) {
 // Carve routing does NOT gate on ManualSync: in manual mode the background
 // carver is suppressed but explicit Flush/SyncNow still drains the carve set,
 // so log-blob chunks must still route to it.
-func (m *Syncer) recomputeCarveActive() {
+func (m *RemoteSync) recomputeCarveActive() {
 	active := m.remoteBlockStore != nil &&
 		m.blockCommitter != nil &&
 		m.hasRemote.Load()
@@ -295,7 +295,7 @@ func (m *Syncer) recomputeCarveActive() {
 
 // SetHealthCallback sets the callback invoked when the remote store health state changes.
 // If the HealthMonitor is already running, the callback is forwarded to it immediately.
-func (m *Syncer) SetHealthCallback(fn healthTransitionCallback) {
+func (m *RemoteSync) SetHealthCallback(fn healthTransitionCallback) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.onHealthChanged = fn
@@ -315,7 +315,7 @@ func (m *Syncer) SetHealthCallback(fn healthTransitionCallback) {
 // remote at all reads as healthy, and a journal carrying synced records from a
 // previous remote-backed life would then satisfy the eviction gate and lose the
 // only copy of those bytes.
-func (m *Syncer) CanEvict() bool {
+func (m *RemoteSync) CanEvict() bool {
 	return m.carveActive.Load() && m.IsRemoteHealthy()
 }
 
@@ -323,7 +323,7 @@ func (m *Syncer) CanEvict() bool {
 // Returns true when there is no HealthMonitor (local-only mode) — which is why
 // it is not sufficient on its own to decide whether eviction is safe. Use
 // CanEvict for that.
-func (m *Syncer) IsRemoteHealthy() bool {
+func (m *RemoteSync) IsRemoteHealthy() bool {
 	if m.healthMonitor == nil {
 		return true
 	}
@@ -332,7 +332,7 @@ func (m *Syncer) IsRemoteHealthy() bool {
 
 // RemoteOutageDuration returns how long the remote store has been unhealthy.
 // Returns 0 when healthy or when there is no HealthMonitor.
-func (m *Syncer) RemoteOutageDuration() time.Duration {
+func (m *RemoteSync) RemoteOutageDuration() time.Duration {
 	if m.healthMonitor == nil {
 		return 0
 	}
@@ -340,21 +340,21 @@ func (m *Syncer) RemoteOutageDuration() time.Duration {
 }
 
 // remoteUnavailableError returns an ErrRemoteUnavailable wrapped with outage duration context.
-func (m *Syncer) remoteUnavailableError() error {
+func (m *RemoteSync) remoteUnavailableError() error {
 	dur := m.RemoteOutageDuration()
 	return fmt.Errorf("remote store unavailable (offline for %s): %w", dur.Truncate(time.Second), block.ErrRemoteUnavailable)
 }
 
 // OfflineReadsBlocked returns the count of read operations that failed
 // because the requested blocks were remote-only during an outage.
-func (m *Syncer) OfflineReadsBlocked() int64 {
+func (m *RemoteSync) OfflineReadsBlocked() int64 {
 	return m.offlineReadsBlocked.Load()
 }
 
 // logOfflineRead logs a read failure due to remote unavailability.
 // First failure after a healthy->unhealthy transition logs at WARN level
 // subsequent failures log at DEBUG to avoid log spam.
-func (m *Syncer) logOfflineRead(method, payloadID string, blockIdx uint64) {
+func (m *RemoteSync) logOfflineRead(method, payloadID string, blockIdx uint64) {
 	if m.firstOfflineRead.CompareAndSwap(false, true) {
 		logger.Warn("Read blocked: remote store unavailable",
 			"method", method,
@@ -371,7 +371,7 @@ func (m *Syncer) logOfflineRead(method, payloadID string, blockIdx uint64) {
 
 // checkReady returns nil if the syncer can process requests.
 // Returns ctx.Err() if the context is cancelled, or ErrClosed if the syncer is closed.
-func (m *Syncer) checkReady(ctx context.Context) error {
+func (m *RemoteSync) checkReady(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -384,7 +384,7 @@ func (m *Syncer) checkReady(ctx context.Context) error {
 }
 
 // canProcess returns false if the syncer is closed or context is cancelled.
-func (m *Syncer) canProcess(ctx context.Context) bool {
+func (m *RemoteSync) canProcess(ctx context.Context) bool {
 	return m.checkReady(ctx) == nil
 }
 
@@ -409,7 +409,7 @@ func (m *Syncer) canProcess(ctx context.Context) bool {
 // The carve drain serializes on carveMu against the background carve
 // dispatcher, so an explicit Flush may block for the duration of an
 // in-flight block build + PutBlock — bounded by one block (~16 MiB).
-func (m *Syncer) Flush(ctx context.Context, payloadID string) (*block.FlushResult, error) {
+func (m *RemoteSync) Flush(ctx context.Context, payloadID string) (*block.FlushResult, error) {
 	if err := m.checkReady(ctx); err != nil {
 		return nil, err
 	}
@@ -438,7 +438,7 @@ func (m *Syncer) Flush(ctx context.Context, payloadID string) (*block.FlushResul
 // dataplaneMetrics returns the engine's data-plane metrics sink, or nil when
 // the syncer is detached from a Store or no recorder was injected. Call sites
 // must guard the result: it is a plain interface, not a nil-safe *Metrics.
-func (m *Syncer) dataplaneMetrics() DataplaneMetrics {
+func (m *RemoteSync) dataplaneMetrics() DataplaneMetrics {
 	if m.bs == nil {
 		return nil
 	}
@@ -450,7 +450,7 @@ func (m *Syncer) dataplaneMetrics() DataplaneMetrics {
 
 // SyncCounts returns lifetime (completed, failed) sync counts: blocks that
 // reached remote and failed carve upload attempts.
-func (m *Syncer) SyncCounts() (completed, failed int) {
+func (m *RemoteSync) SyncCounts() (completed, failed int) {
 	return int(m.completedSyncs.Load()), int(m.failedSyncs.Load())
 }
 
@@ -459,7 +459,7 @@ func (m *Syncer) SyncCounts() (completed, failed int) {
 // background dispatcher and the drain's force-carve — the latter runs as a
 // single call that can span minutes, and counting only on its return would
 // leave the progress signal flat for that whole time.
-func (m *Syncer) noteBlockCommitted(bytes int64) {
+func (m *RemoteSync) noteBlockCommitted(bytes int64) {
 	m.completedSyncs.Add(1)
 	m.uploadedBytesWindow.Add(bytes)
 }
@@ -472,7 +472,7 @@ func (m *Syncer) noteBlockCommitted(bytes int64) {
 // Exposed via the REST API for the benchmark runner to call between test
 // phases, and used by Close() to ensure no blocks are left stranded in the
 // local store at shutdown.
-func (m *Syncer) DrainAllUploads(ctx context.Context) error {
+func (m *RemoteSync) DrainAllUploads(ctx context.Context) error {
 	if err := m.SyncNow(ctx); err != nil {
 		return err
 	}
@@ -496,7 +496,7 @@ func (m *Syncer) DrainAllUploads(ctx context.Context) error {
 // is not wired (test fixtures), no chunks count as remote-mirrored and
 // the function returns 0 — matching the pre-Phase-18 semantics where
 // State==Remote was never set in that configuration either.
-func (m *Syncer) GetFileSize(ctx context.Context, payloadID string) (uint64, error) {
+func (m *RemoteSync) GetFileSize(ctx context.Context, payloadID string) (uint64, error) {
 	if err := m.checkReady(ctx); err != nil {
 		return 0, err
 	}
@@ -564,7 +564,7 @@ func (m *Syncer) GetFileSize(ctx context.Context, payloadID string) (uint64, err
 // authoritative. If no SyncedHashStore is wired (test fixtures)
 // Exists returns false — matching the pre-fix behavior under the same
 // configuration.
-func (m *Syncer) Exists(ctx context.Context, payloadID string) (bool, error) {
+func (m *RemoteSync) Exists(ctx context.Context, payloadID string) (bool, error) {
 	if err := m.checkReady(ctx); err != nil {
 		return false, err
 	}
@@ -615,7 +615,7 @@ func (m *Syncer) Exists(ctx context.Context, payloadID string) (bool, error) {
 // a stable seam for callers — engine.Truncate invokes it unconditionally — and
 // so the absence of the legacy prefix scan is explicit rather than inferred
 // from a missing call.
-func (m *Syncer) Truncate(ctx context.Context, payloadID string, newSize uint64) error {
+func (m *RemoteSync) Truncate(ctx context.Context, payloadID string, newSize uint64) error {
 	if err := m.checkReady(ctx); err != nil {
 		return err
 	}
@@ -640,7 +640,7 @@ func (m *Syncer) Truncate(ctx context.Context, payloadID string, newSize uint64)
 // GC sweep reclaims the CAS objects that leaves orphaned. Nothing is removed or
 // recorded here. The legacy per-file prefix sweep is gone, and this method is
 // kept as a stable seam for the call in engine.Delete.
-func (m *Syncer) Delete(ctx context.Context, payloadID string) error {
+func (m *RemoteSync) Delete(ctx context.Context, payloadID string) error {
 	if err := m.checkReady(ctx); err != nil {
 		return err
 	}
@@ -660,7 +660,7 @@ func (m *Syncer) Delete(ctx context.Context, payloadID string) error {
 // Start begins background upload processing and periodic uploader.
 // Must be called after New() to enable async uploads.
 // When remoteStore is nil (local-only mode), the periodic syncer is skipped.
-func (m *Syncer) Start(ctx context.Context) {
+func (m *RemoteSync) Start(ctx context.Context) {
 	// The health monitor's eager probe is a network round trip, so it runs
 	// after m.mu is released: every read and flush path takes that lock, and
 	// holding it for a remote timeout stalls them all. Start still returns only
@@ -672,7 +672,7 @@ func (m *Syncer) Start(ctx context.Context) {
 
 // startLocked performs the locked half of Start and returns the health monitor
 // still to be started, or nil in local-only mode.
-func (m *Syncer) startLocked(ctx context.Context) *HealthMonitor {
+func (m *RemoteSync) startLocked(ctx context.Context) *HealthMonitor {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -681,7 +681,7 @@ func (m *Syncer) startLocked(ctx context.Context) *HealthMonitor {
 	}
 
 	if m.remoteStore == nil {
-		logger.Info("Syncer started in local-only mode (no remote store)")
+		logger.Info("RemoteSync started in local-only mode (no remote store)")
 		return nil
 	}
 
@@ -690,7 +690,7 @@ func (m *Syncer) startLocked(ctx context.Context) *HealthMonitor {
 	// Failure here is logged at WARN — a bad metadata read should not
 	// prevent the syncer from running its periodic loop.
 	if err := m.recoverStaleSyncing(ctx); err != nil {
-		logger.Warn("Syncer janitor: recoverStaleSyncing failed", "error", err)
+		logger.Warn("RemoteSync janitor: recoverStaleSyncing failed", "error", err)
 	}
 
 	// No pending-set to seed from disk: the journal owns the unsynced state
@@ -704,7 +704,7 @@ func (m *Syncer) startLocked(ctx context.Context) *HealthMonitor {
 
 // newHealthMonitorLocked creates and wires the health monitor for the remote
 // store, without starting it. Must be called with m.mu held.
-func (m *Syncer) newHealthMonitorLocked() *HealthMonitor {
+func (m *RemoteSync) newHealthMonitorLocked() *HealthMonitor {
 	m.healthMonitor = NewHealthMonitor(m.remoteStore.HealthCheck, m.config)
 	// Wrap the user's callback to also reset the offline-read WARN flag
 	// on each healthy->unhealthy transition.
@@ -722,7 +722,7 @@ func (m *Syncer) newHealthMonitorLocked() *HealthMonitor {
 
 // startPeriodicUploader launches the carve dispatcher and the maintenance
 // loop, if not already running. Must be called with m.mu held.
-func (m *Syncer) startPeriodicUploader(ctx context.Context) {
+func (m *RemoteSync) startPeriodicUploader(ctx context.Context) {
 	if m.periodicStarted {
 		return
 	}
@@ -766,7 +766,7 @@ func (m *Syncer) startPeriodicUploader(ctx context.Context) {
 // window to the shared uploadLimiter. Runs only in adaptive mode (controller
 // non-nil). Idle intervals (no bytes, nothing in flight, no error) are skipped
 // so a write pause is not misread as a goodput collapse.
-func (m *Syncer) runUploadController(ctx context.Context, interval time.Duration) {
+func (m *RemoteSync) runUploadController(ctx context.Context, interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	// Publish the starting window so the gauge is populated before the first
@@ -792,7 +792,7 @@ func (m *Syncer) runUploadController(ctx context.Context, interval time.Duration
 // resulting window to the upload limiter. Extracted from the goroutine loop so
 // the bytes→goodput→window glue is unit-testable without a clock. intervalSec
 // is the control interval in seconds.
-func (m *Syncer) adaptiveUploadTick(intervalSec float64) {
+func (m *RemoteSync) adaptiveUploadTick(intervalSec float64) {
 	bytes := m.uploadedBytesWindow.Swap(0)
 	sawErr := m.uploadErrWindow.Swap(0) > 0
 	// Peak in-flight over the interval distinguishes window-limited from
@@ -824,7 +824,7 @@ func (m *Syncer) adaptiveUploadTick(intervalSec float64) {
 // dedup oracle and the block sink that seals/frames/uploads/commits) built from
 // the syncer's wired remote/committer/synced deps. One-shot, guarded by m.mu;
 // safe to call again from a late SetRemoteStore attach.
-func (m *Syncer) wireCarveTargets() {
+func (m *RemoteSync) wireCarveTargets() {
 	if m.carveTargetsWired {
 		return
 	}
@@ -853,7 +853,7 @@ func (m *Syncer) wireCarveTargets() {
 // dependency call has run. For a remote-backed share this is a no-op (already
 // wired via recomputeCarveActive); for a local-only share it installs the
 // remote-less carve sink so DrainRollups/Flush populate the FileChunk manifest.
-func (m *Syncer) ensureCarveWired() {
+func (m *RemoteSync) ensureCarveWired() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.wireCarveTargets()
@@ -867,7 +867,7 @@ func (m *Syncer) ensureCarveWired() {
 //
 // Serializes against the background carve dispatcher via carveMu (inside
 // carveFlush), so the explicit drain never packs the same chunk twice.
-func (m *Syncer) SyncNow(ctx context.Context) error {
+func (m *RemoteSync) SyncNow(ctx context.Context) error {
 	if m.remoteStore == nil {
 		return nil
 	}
@@ -895,7 +895,7 @@ func (m *Syncer) SyncNow(ctx context.Context) error {
 //
 // Backends that opt in to syncingEnumerator return precise candidates
 // others degrade to a no-op.
-func (m *Syncer) recoverStaleSyncing(ctx context.Context) error {
+func (m *RemoteSync) recoverStaleSyncing(ctx context.Context) error {
 	if m.fileChunkStore == nil {
 		return nil
 	}
@@ -934,7 +934,7 @@ func (m *Syncer) recoverStaleSyncing(ctx context.Context) error {
 		requeued++
 	}
 	if requeued > 0 {
-		logger.Info("Syncer janitor requeued stale Syncing rows",
+		logger.Info("RemoteSync janitor requeued stale Syncing rows",
 			"count", requeued, "claim_timeout", m.config.ClaimTimeout)
 	}
 	if failed > 0 {
@@ -952,7 +952,7 @@ type syncingEnumerator interface {
 }
 
 // Close shuts down the syncer and waits for pending uploads.
-func (m *Syncer) Close() error {
+func (m *RemoteSync) Close() error {
 	m.mu.Lock()
 	if m.closed {
 		m.mu.Unlock()
@@ -985,7 +985,7 @@ func (m *Syncer) Close() error {
 	// returning while a pass is still reading the local store or writing the
 	// remote — the engine closes both the moment Close returns.
 	if !waitBounded(&m.bgWG, defaultShutdownTimeout) {
-		logger.Warn("Syncer background loops did not exit before shutdown timeout")
+		logger.Warn("RemoteSync background loops did not exit before shutdown timeout")
 	}
 
 	return nil
@@ -1010,7 +1010,7 @@ func waitBounded(wg *gosync.WaitGroup, timeout time.Duration) bool {
 
 // HealthCheck verifies the remote store is accessible.
 // Returns nil (healthy) when remoteStore is nil -- local-only mode is valid.
-func (m *Syncer) HealthCheck(ctx context.Context) error {
+func (m *RemoteSync) HealthCheck(ctx context.Context) error {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -1033,7 +1033,7 @@ func (m *Syncer) HealthCheck(ctx context.Context) error {
 // syncer was local-only are picked up by the next periodic drift reconcile
 // (seedPendingFromDisk), not immediately. Not currently wired into any
 // production control-plane path; Start() is the seeded entry point.
-func (m *Syncer) SetRemoteStore(ctx context.Context, remoteStore remote.RemoteStore) error {
+func (m *RemoteSync) SetRemoteStore(ctx context.Context, remoteStore remote.RemoteStore) error {
 	hm, err := m.setRemoteStoreLocked(ctx, remoteStore)
 	if err != nil {
 		return err
@@ -1048,7 +1048,7 @@ func (m *Syncer) SetRemoteStore(ctx context.Context, remoteStore remote.RemoteSt
 
 // setRemoteStoreLocked performs the locked half of SetRemoteStore and returns
 // the health monitor still to be started.
-func (m *Syncer) setRemoteStoreLocked(ctx context.Context, remoteStore remote.RemoteStore) (*HealthMonitor, error) {
+func (m *RemoteSync) setRemoteStoreLocked(ctx context.Context, remoteStore remote.RemoteStore) (*HealthMonitor, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -370,7 +370,7 @@ func (m *RemoteSync) logOfflineRead(method, payloadID string, blockIdx uint64) {
 }
 
 // checkReady returns nil if the syncer can process requests.
-// Returns ctx.Err() if the context is cancelled, or ErrClosed if the syncer is closed.
+// Returns ctx.Err() if the context is cancelled, or ErrClosed if the RemoteSync is closed.
 func (m *RemoteSync) checkReady(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -383,7 +383,7 @@ func (m *RemoteSync) checkReady(ctx context.Context) error {
 	return nil
 }
 
-// canProcess returns false if the syncer is closed or context is cancelled.
+// canProcess returns false if the RemoteSync is closed or context is cancelled.
 func (m *RemoteSync) canProcess(ctx context.Context) bool {
 	return m.checkReady(ctx) == nil
 }

--- a/pkg/block/engine/syncer_shutdown_test.go
+++ b/pkg/block/engine/syncer_shutdown_test.go
@@ -58,7 +58,7 @@ func (g *gatedChunkStore) Close() error {
 }
 
 // TestSyncerClose_JoinsInFlightDownloadWorker pins the shutdown ordering that
-// #1722 violated: Syncer.Close() (via SyncQueue.Stop) must block until every
+// #1722 violated: RemoteSync.Close() (via SyncQueue.Stop) must block until every
 // in-flight download worker has left the metadata store, so the store can then
 // be closed with no worker still reading it.
 //
@@ -73,8 +73,8 @@ func TestSyncerClose_JoinsInFlightDownloadWorker(t *testing.T) {
 	cfg.ParallelDownloads = 2
 	// A non-nil remote is required for fetchBlock to reach resolveFileChunk;
 	// a nil remote short-circuits before the store lookup. No HealthMonitor is
-	// started (we never call Syncer.Start), so IsRemoteHealthy() is true.
-	syncer := NewSyncer(memorylocal.New(), remotememory.New(), gs, cfg)
+	// started (we never call RemoteSync.Start), so IsRemoteHealthy() is true.
+	syncer := NewRemoteSync(memorylocal.New(), remotememory.New(), gs, cfg)
 
 	syncer.Queue().Start(context.Background())
 
@@ -99,7 +99,7 @@ func TestSyncerClose_JoinsInFlightDownloadWorker(t *testing.T) {
 	// did, the metadata store could be closed under a live worker -> #1722.
 	select {
 	case <-closeDone:
-		t.Fatal("Syncer.Close returned before the in-flight download worker finished — SyncQueue.Stop did not join workers (regression of #1722)")
+		t.Fatal("RemoteSync.Close returned before the in-flight download worker finished — SyncQueue.Stop did not join workers (regression of #1722)")
 	case <-time.After(150 * time.Millisecond):
 	}
 
@@ -110,7 +110,7 @@ func TestSyncerClose_JoinsInFlightDownloadWorker(t *testing.T) {
 	select {
 	case <-closeDone:
 	case <-time.After(5 * time.Second):
-		t.Fatal("Syncer.Close did not return after the worker was released")
+		t.Fatal("RemoteSync.Close did not return after the worker was released")
 	}
 
 	// Only now — after Close() has joined all workers — is it safe to close the
@@ -118,7 +118,7 @@ func TestSyncerClose_JoinsInFlightDownloadWorker(t *testing.T) {
 	_ = gs.Close()
 
 	if gs.accessedClosed.Load() {
-		t.Fatal("metadata store was accessed after Close — download worker outlived Syncer.Close (#1722)")
+		t.Fatal("metadata store was accessed after Close — download worker outlived RemoteSync.Close (#1722)")
 	}
 }
 
@@ -141,7 +141,7 @@ func TestSyncerClose_JoinsCarveDispatcher(t *testing.T) {
 
 	cfg := DefaultConfig()
 	cfg.UploadInterval = time.Millisecond
-	m := &Syncer{
+	m := &RemoteSync{
 		local:         fl,
 		uploadLimiter: newDynamicSemaphore(2),
 		stopCh:        make(chan struct{}),
@@ -165,7 +165,7 @@ func TestSyncerClose_JoinsCarveDispatcher(t *testing.T) {
 
 	select {
 	case <-closeDone:
-		t.Fatal("Syncer.Close returned while a carve pass was still inside the local store — the carve dispatcher was not joined")
+		t.Fatal("RemoteSync.Close returned while a carve pass was still inside the local store — the carve dispatcher was not joined")
 	case <-time.After(150 * time.Millisecond):
 	}
 
@@ -174,7 +174,7 @@ func TestSyncerClose_JoinsCarveDispatcher(t *testing.T) {
 	select {
 	case <-closeDone:
 	case <-time.After(5 * time.Second):
-		t.Fatal("Syncer.Close did not return after the carve was released")
+		t.Fatal("RemoteSync.Close did not return after the carve was released")
 	}
 
 	if n := fl.inFlight.Load(); n != 0 {

--- a/pkg/block/engine/syncer_start_lock_test.go
+++ b/pkg/block/engine/syncer_start_lock_test.go
@@ -23,7 +23,7 @@ func (r *probeHookRemote) HealthCheck(ctx context.Context) error { return r.prob
 // syncer lock across it, or every read and flush stalls for a remote timeout
 // while a share comes up.
 func TestSyncerStart_EagerProbeDoesNotHoldLock(t *testing.T) {
-	var m *Syncer
+	var m *RemoteSync
 	rem := &probeHookRemote{
 		RemoteStore: remotememory.New(),
 		probe: func(context.Context) error {
@@ -32,7 +32,7 @@ func TestSyncerStart_EagerProbeDoesNotHoldLock(t *testing.T) {
 			return nil
 		},
 	}
-	m = NewSyncer(memorylocal.New(), rem, newStubFileChunkStore(), DefaultConfig())
+	m = NewRemoteSync(memorylocal.New(), rem, newStubFileChunkStore(), DefaultConfig())
 
 	done := make(chan struct{})
 	go func() {
@@ -43,7 +43,7 @@ func TestSyncerStart_EagerProbeDoesNotHoldLock(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(5 * time.Second):
-		t.Fatal("Syncer.Start held its lock across the eager health probe")
+		t.Fatal("RemoteSync.Start held its lock across the eager health probe")
 	}
 	_ = m.Close()
 }

--- a/pkg/block/engine/types.go
+++ b/pkg/block/engine/types.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ErrClosed is returned when an operation is attempted on a closed RemoteSync.
-var ErrClosed = errors.New("syncer is closed")
+var ErrClosed = errors.New("remote sync is closed")
 
 // ErrStoreClosed is returned by a Store data op (WriteAt, ReadAt, Flush,
 // Truncate, Delete, …) that arrives after the Store has been Closed —

--- a/pkg/block/engine/types.go
+++ b/pkg/block/engine/types.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-// ErrClosed is returned when an operation is attempted on a closed Syncer.
+// ErrClosed is returned when an operation is attempted on a closed RemoteSync.
 var ErrClosed = errors.New("syncer is closed")
 
 // ErrStoreClosed is returned by a Store data op (WriteAt, ReadAt, Flush,
@@ -20,7 +20,7 @@ var ErrStoreClosed = errors.New("engine: block store is closed")
 // With 200-connection S3 pool and 8MB blocks, 32 workers can saturate the pool.
 const DefaultParallelDownloads = 32
 
-// Adaptive upload-concurrency bounds (#1407). When SyncerConfig.ParallelUploads
+// Adaptive upload-concurrency bounds (#1407). When RemoteSyncConfig.ParallelUploads
 // is unset (0), the carver auto-tunes concurrent block PUTs to saturate the
 // uplink: it starts at AdaptiveUploadFloor and ramps toward AdaptiveUploadCeiling,
 // settling at the goodput knee. A pinned ParallelUploads > 0 overrides this with
@@ -79,8 +79,8 @@ type TransferRequest struct {
 	Done       chan error   // Completion channel; nil for async (fire-and-forget)
 }
 
-// Config holds configuration for the Syncer.
-type SyncerConfig struct {
+// Config holds configuration for the RemoteSync.
+type RemoteSyncConfig struct {
 	ParallelDownloads  int           // Concurrent block downloads per file (default: 32)
 	PrefetchBlocks     int           // Blocks to prefetch ahead of reads; 0 = disabled (default: 64)
 	SmallFileThreshold int64         // Files below this are flushed synchronously; 0 = disabled
@@ -119,17 +119,15 @@ type SyncerConfig struct {
 	HealthCheckFailureThreshold int           // Consecutive failures to mark unhealthy (default: 3)
 	UnhealthyCheckInterval      time.Duration // Probe interval when unhealthy (default: 5s)
 
-	// — CAS upload-path knobs. The
-	// authoritative defaults live in pkg/config.SyncerConfig; these fields
-	// mirror them on the engine-local config struct so the syncer can be
-	// constructed without depending on pkg/config (avoids an import cycle
-	// from local/fs and other low-level callers).
+	// ClaimTimeout lives on the engine-local config struct rather than being
+	// read from pkg/config, so a RemoteSync can be constructed by low-level
+	// callers without an import cycle. Its default is set by DefaultConfig.
 	ClaimTimeout time.Duration // Max age of a Syncing row before the janitor requeues it (default: 10m)
 }
 
-// DefaultConfig returns the default Syncer configuration tuned for S3 performance.
-func DefaultConfig() SyncerConfig {
-	return SyncerConfig{
+// DefaultConfig returns the default RemoteSync configuration tuned for S3 performance.
+func DefaultConfig() RemoteSyncConfig {
+	return RemoteSyncConfig{
 		ParallelDownloads:           DefaultParallelDownloads,
 		PrefetchBlocks:              DefaultPrefetchBlocks,
 		SmallFileThreshold:          0,

--- a/pkg/block/engine/unplaceable_row_read_test.go
+++ b/pkg/block/engine/unplaceable_row_read_test.go
@@ -49,14 +49,14 @@ func newRemoteBackedEngine(t *testing.T, b manifestBackend) (*Store, block.Engin
 	localStore := memorylocal.New()
 	rs := remotememory.New()
 
-	syncer := NewSyncer(localStore, rs, fbs, DefaultConfig())
+	syncer := NewRemoteSync(localStore, rs, fbs, DefaultConfig())
 	syncer.SetSyncedHashStore(shs)
 	syncer.SetRemoteBlockStore(rs)
 
 	bs, err := New(BlockStoreConfig{
 		Local:           localStore,
 		Remote:          rs,
-		Syncer:          syncer,
+		RemoteSync:      syncer,
 		FileChunkStore:  fbs,
 		SyncedHashStore: shs,
 	})

--- a/pkg/block/engine/warm.go
+++ b/pkg/block/engine/warm.go
@@ -40,7 +40,7 @@ type warmTarget struct {
 // (fetchResolvedBlock). It enumerates payloads from the authoritative metadata
 // (fileChunkStore.EnumeratePayloads) and the per-payload FileChunk rows, and
 // fetches every one of them with bounded concurrency
-// (SyncerConfig.ParallelDownloads). Enumerating the metadata rather than the
+// (RemoteSyncConfig.ParallelDownloads). Enumerating the metadata rather than the
 // local store's ListFiles is what lets warm materialize payloads whose append
 // log was discarded after rollup — their FileChunk rows survive, but
 // local.ListFiles no longer reports them, so the old surface made warm a silent
@@ -61,7 +61,7 @@ type warmTarget struct {
 // fails with fs.ErrDiskFull is terminal — the bounded local tier cannot hold
 // the working set — so the whole run is cancelled and the error surfaced.
 // Context cancellation stops the run promptly.
-func (m *Syncer) WarmAll(ctx context.Context, progress func(done, total int64)) (WarmResult, error) {
+func (m *RemoteSync) WarmAll(ctx context.Context, progress func(done, total int64)) (WarmResult, error) {
 	if err := m.checkReady(ctx); err != nil {
 		return WarmResult{}, err
 	}

--- a/pkg/block/engine/warm_read_integrity_test.go
+++ b/pkg/block/engine/warm_read_integrity_test.go
@@ -35,12 +35,12 @@ func newEngineWithRemote(t *testing.T, ms metadata.Store, mem *remotememory.Stor
 		t.Fatalf("fs.NewWithOptions: %v", err)
 	}
 	coord := &testCoordinator{store: ms}
-	syncer := engine.NewSyncer(localStore, mem, ms, engine.DefaultConfig())
+	syncer := engine.NewRemoteSync(localStore, mem, ms, engine.DefaultConfig())
 	syncer.SetSyncedHashStore(syncedHashStore)
 	syncer.SetRemoteBlockStore(mem)
 	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:           localStore,
-		Syncer:          syncer,
+		RemoteSync:      syncer,
 		FileChunkStore:  ms,
 		Coordinator:     coord,
 		SyncedHashStore: syncedHashStore,

--- a/pkg/block/engine/warm_read_selfheal_test.go
+++ b/pkg/block/engine/warm_read_selfheal_test.go
@@ -47,15 +47,15 @@ func buildSelfHealEngine(t *testing.T, ms metadata.Store, mem *remotememory.Stor
 		ReadBufferBytes: 64 * 1024 * 1024,
 	}
 	if mem != nil {
-		syncer := engine.NewSyncer(localStore, mem, ms, engine.DefaultConfig())
+		syncer := engine.NewRemoteSync(localStore, mem, ms, engine.DefaultConfig())
 		syncer.SetSyncedHashStore(syncedHashStore)
 		syncer.SetRemoteBlockStore(mem)
-		cfg.Syncer = syncer
+		cfg.RemoteSync = syncer
 		cfg.Remote = mem
 	} else {
-		syncer := engine.NewSyncer(localStore, nil, ms, engine.DefaultConfig())
+		syncer := engine.NewRemoteSync(localStore, nil, ms, engine.DefaultConfig())
 		syncer.SetSyncedHashStore(syncedHashStore)
-		cfg.Syncer = syncer
+		cfg.RemoteSync = syncer
 	}
 	bs, err := engine.New(cfg)
 	if err != nil {

--- a/pkg/block/engine/write_bench_test.go
+++ b/pkg/block/engine/write_bench_test.go
@@ -1,6 +1,6 @@
 // Native Go benchmarks for the blockstore engine write path. Each
 // Benchmark* func wires a production-equivalent FSStore + memory remote
-// + memory metadata + rollup Syncer via newWriteBenchEngine, and the
+// + memory metadata + rollup RemoteSync via newWriteBenchEngine, and the
 // per-op shape mirrors the legacy bench/blockstore RunWorkload step
 // function 1:1 — but with seeding hoisted out of the timed region
 // (b.ResetTimer) so b.N measures only the per-op cost.
@@ -47,7 +47,7 @@ const (
 const writeBenchSeedChunkSize = 8 * 1024 * 1024
 
 // newWriteBenchEngine wires a production-equivalent FSStore + memory
-// remote + memory metadata + rollup Syncer for a single benchmark run,
+// remote + memory metadata + rollup RemoteSync for a single benchmark run,
 // mirroring the block/shares production factory. Cleanup closes the
 // engine (which also closes the remote).
 func newWriteBenchEngine(tb testing.TB) *Store {
@@ -60,11 +60,11 @@ func newWriteBenchEngine(tb testing.TB) *Store {
 		tb.Fatalf("fs.NewWithOptions: %v", err)
 	}
 	rem := remotememory.New()
-	syncer := NewSyncer(localStore, rem, ms, DefaultConfig())
+	syncer := NewRemoteSync(localStore, rem, ms, DefaultConfig())
 	bs, err := New(BlockStoreConfig{
 		Local:           localStore,
 		Remote:          rem,
-		Syncer:          syncer,
+		RemoteSync:      syncer,
 		FileChunkStore:  ms,
 		SyncedHashStore: ms,
 	})

--- a/pkg/controlplane/runtime/runtime_test.go
+++ b/pkg/controlplane/runtime/runtime_test.go
@@ -554,10 +554,10 @@ func TestGetBlockStoreForHandle(t *testing.T) {
 	// Create a minimal BlockStore with memory local store.
 	localStore := localmemory.New()
 	localStore.Start(context.Background())
-	syncer := engine.NewSyncer(localStore, nil, metaStore, engine.DefaultConfig())
+	syncer := engine.NewRemoteSync(localStore, nil, metaStore, engine.DefaultConfig())
 	bs, err := engine.New(engine.BlockStoreConfig{
-		Local:  localStore,
-		Syncer: syncer,
+		Local:      localStore,
+		RemoteSync: syncer,
 	})
 	if err != nil {
 		t.Fatalf("failed to create BlockStore: %v", err)

--- a/pkg/controlplane/runtime/shares/blockstore_config.go
+++ b/pkg/controlplane/runtime/shares/blockstore_config.go
@@ -209,8 +209,8 @@ func (n *nonClosingRemote) ReadChunk(ctx context.Context, blockID string, offset
 	return cr.ReadChunk(ctx, blockID, offset, length, hash)
 }
 
-// buildSyncerConfigFromDefaults merges SyncerDefaults into a engine.SyncerConfig.
-func buildSyncerConfigFromDefaults(defaults *SyncerDefaults) engine.SyncerConfig {
+// buildSyncerConfigFromDefaults merges SyncerDefaults into a engine.RemoteSyncConfig.
+func buildSyncerConfigFromDefaults(defaults *SyncerDefaults) engine.RemoteSyncConfig {
 	cfg := engine.DefaultConfig()
 	if defaults == nil {
 		return cfg
@@ -387,7 +387,7 @@ func (s *Service) createBlockStoreForShare(
 		engineRemote = &nonClosingRemote{remoteStore}
 	}
 
-	syncer := engine.NewSyncer(localStore, engineRemote, fileChunkStore, syncerCfg)
+	syncer := engine.NewRemoteSync(localStore, engineRemote, fileChunkStore, syncerCfg)
 
 	// Write-path backpressure is now internal to the journal-backed local store
 	// (Config.EvictMaxWait): a full local cache stalls the writer while the carve
@@ -435,7 +435,7 @@ func (s *Service) createBlockStoreForShare(
 	engineCfg := engine.BlockStoreConfig{
 		Local:          localStore,
 		Remote:         engineRemote,
-		Syncer:         syncer,
+		RemoteSync:     syncer,
 		FileChunkStore: fileChunkStore,
 		Coordinator:    coordinator,
 	}

--- a/pkg/controlplane/runtime/shares/coordinator.go
+++ b/pkg/controlplane/runtime/shares/coordinator.go
@@ -184,7 +184,7 @@ func (c *metadataCoordinator) ReprojectBlocks(ctx context.Context, payloadID str
 // (first-committer-wins) — or the equivalent mderrors.ErrConflict from
 // Memory/Badger — is wrapped into engine.ErrObjectIDConflict by
 // mapObjectIDConflict so the file-level dedup short-circuit retry path
-// in Syncer.applyFileLevelDedupHit detects the race uniformly across
+// in RemoteSync.applyFileLevelDedupHit detects the race uniformly across
 // backends.
 func (c *metadataCoordinator) PersistFileChunks(ctx context.Context, payloadID string, blocks []block.ChunkRef, objectID block.ObjectID) error {
 	return c.metadataStore.WithTransaction(ctx, func(tx metadata.Transaction) error {
@@ -322,7 +322,7 @@ func (c *metadataCoordinator) FindByObjectID(ctx context.Context, objectID block
 
 // GetFileObjectID reads the current FileAttr.ObjectID for payloadID
 // from the metadata store. Returns the all-zero ObjectID + nil when
-// the file does not exist or has never quiesced — callers (Syncer.Flush)
+// the file does not exist or has never quiesced — callers (RemoteSync.Flush)
 // treat zero as "evaluate short-circuit" / "skip short-circuit".
 //
 // Callers use this to evaluate the trigger condition for file-level

--- a/pkg/controlplane/runtime/shares/legacy_migrate_test.go
+++ b/pkg/controlplane/runtime/shares/legacy_migrate_test.go
@@ -31,11 +31,11 @@ func newMigrateEngine(t *testing.T, dir string, ms *metamem.MemoryMetadataStore,
 	// remote outlives the first store the same way ref-counting keeps it alive in
 	// production (a second engine reopens over the same remote after the upgrade).
 	engineRemote := &nonClosingRemote{rem}
-	syncer := engine.NewSyncer(localStore, engineRemote, ms, cfg)
+	syncer := engine.NewRemoteSync(localStore, engineRemote, ms, cfg)
 	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:           localStore,
 		Remote:          engineRemote,
-		Syncer:          syncer,
+		RemoteSync:      syncer,
 		FileChunkStore:  ms,
 		SyncedHashStore: ms,
 		ReadBufferBytes: 64 * 1024 * 1024,

--- a/pkg/controlplane/runtime/shares/non_closing_remote_durability_test.go
+++ b/pkg/controlplane/runtime/shares/non_closing_remote_durability_test.go
@@ -66,11 +66,11 @@ func TestNonClosingRemote_EngineRemoteDurableAndCommit(t *testing.T) {
 	// This is the production wrap: engine holds *nonClosingRemote, not the bare remote.
 	engineRemote := &nonClosingRemote{durableRemote}
 
-	syncer := engine.NewSyncer(localStore, engineRemote, ms, engine.DefaultConfig())
+	syncer := engine.NewRemoteSync(localStore, engineRemote, ms, engine.DefaultConfig())
 	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:           localStore,
 		Remote:          engineRemote,
-		Syncer:          syncer,
+		RemoteSync:      syncer,
 		FileChunkStore:  ms,
 		SyncedHashStore: ms,
 	})

--- a/pkg/controlplane/runtime/shares/remove_share_teardown_test.go
+++ b/pkg/controlplane/runtime/shares/remove_share_teardown_test.go
@@ -19,7 +19,7 @@ import (
 func newLocalEngineStore(t *testing.T) *engine.Store {
 	t.Helper()
 	local := memory.New()
-	// The in-memory metadata store satisfies EngineFileChunkStore (NewSyncer
+	// The in-memory metadata store satisfies EngineFileChunkStore (NewRemoteSync
 	// requires a non-nil one); the teardown path never exercises it.
 	fbs := metadatamemory.NewMemoryMetadataStoreWithDefaults()
 	t.Cleanup(func() { _ = fbs.Close() })

--- a/pkg/controlplane/runtime/shares/remove_share_teardown_test.go
+++ b/pkg/controlplane/runtime/shares/remove_share_teardown_test.go
@@ -23,10 +23,10 @@ func newLocalEngineStore(t *testing.T) *engine.Store {
 	// requires a non-nil one); the teardown path never exercises it.
 	fbs := metadatamemory.NewMemoryMetadataStoreWithDefaults()
 	t.Cleanup(func() { _ = fbs.Close() })
-	syncer := engine.NewSyncer(local, nil, fbs, engine.DefaultConfig())
+	syncer := engine.NewRemoteSync(local, nil, fbs, engine.DefaultConfig())
 	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:          local,
-		Syncer:         syncer,
+		RemoteSync:     syncer,
 		FileChunkStore: fbs,
 	})
 	if err != nil {

--- a/pkg/controlplane/runtime/snapshot_concurrency_test.go
+++ b/pkg/controlplane/runtime/snapshot_concurrency_test.go
@@ -101,13 +101,13 @@ func addConcShare(t *testing.T, rt *Runtime, backup *controlledSnapshotable, sha
 	innerRemote := remotememory.New()
 	t.Cleanup(func() { _ = innerRemote.Close() })
 	mem := backup.MemoryMetadataStore
-	syncer := engine.NewSyncer(localStore, innerRemote, mem, engine.SyncerConfig{
+	syncer := engine.NewRemoteSync(localStore, innerRemote, mem, engine.RemoteSyncConfig{
 		ParallelDownloads: 1,
 	})
 	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:          localStore,
 		Remote:         innerRemote,
-		Syncer:         syncer,
+		RemoteSync:     syncer,
 		FileChunkStore: mem,
 	})
 	if err != nil {

--- a/pkg/controlplane/runtime/snapshot_consistency_test.go
+++ b/pkg/controlplane/runtime/snapshot_consistency_test.go
@@ -289,13 +289,13 @@ func newRealBackupFixture(t *testing.T) *realBackupFixture {
 	localStore := bsmemory.New()
 	innerRemote := remotememory.New()
 	t.Cleanup(func() { _ = innerRemote.Close() })
-	syncer := engine.NewSyncer(localStore, innerRemote, mem, engine.SyncerConfig{
+	syncer := engine.NewRemoteSync(localStore, innerRemote, mem, engine.RemoteSyncConfig{
 		ParallelDownloads: 1,
 	})
 	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:          localStore,
 		Remote:         innerRemote,
-		Syncer:         syncer,
+		RemoteSync:     syncer,
 		FileChunkStore: mem,
 	})
 	if err != nil {

--- a/pkg/controlplane/runtime/snapshot_encryption_integration_test.go
+++ b/pkg/controlplane/runtime/snapshot_encryption_integration_test.go
@@ -101,13 +101,13 @@ func newEncryptedFixture(t *testing.T) *encryptedFixture {
 
 	enc := newEncryptedRemote(t, inner)
 
-	syncer := engine.NewSyncer(localStore, enc, mem, engine.SyncerConfig{
+	syncer := engine.NewRemoteSync(localStore, enc, mem, engine.RemoteSyncConfig{
 		ParallelDownloads: 1,
 	})
 	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:          localStore,
 		Remote:         enc,
-		Syncer:         syncer,
+		RemoteSync:     syncer,
 		FileChunkStore: mem,
 	})
 	if err != nil {

--- a/pkg/controlplane/runtime/snapshot_integration_test.go
+++ b/pkg/controlplane/runtime/snapshot_integration_test.go
@@ -482,13 +482,13 @@ func newOrchestrationFixture(t *testing.T) *orchestrationFixture {
 	innerRemote := remotememory.New()
 	t.Cleanup(func() { _ = innerRemote.Close() })
 	wrappedRemote := newInterceptingRemote(innerRemote)
-	syncer := engine.NewSyncer(localStore, wrappedRemote, mem, engine.SyncerConfig{
+	syncer := engine.NewRemoteSync(localStore, wrappedRemote, mem, engine.RemoteSyncConfig{
 		ParallelDownloads: 1,
 	})
 	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:          localStore,
 		Remote:         wrappedRemote,
-		Syncer:         syncer,
+		RemoteSync:     syncer,
 		FileChunkStore: mem,
 	})
 	if err != nil {

--- a/pkg/controlplane/runtime/snapshot_restore_test.go
+++ b/pkg/controlplane/runtime/snapshot_restore_test.go
@@ -613,13 +613,13 @@ func newRestoreFixture(t *testing.T, opts restoreFixtureOpts) *restoreFixture {
 		wrappedRemote = newRestoreRemote(innerRemote)
 		engineRemote = wrappedRemote
 	}
-	syncer := engine.NewSyncer(localStore, engineRemote, mem, engine.SyncerConfig{
+	syncer := engine.NewRemoteSync(localStore, engineRemote, mem, engine.RemoteSyncConfig{
 		ParallelDownloads: 1,
 	})
 	bs, err := engine.New(engine.BlockStoreConfig{
 		Local:          localStore,
 		Remote:         engineRemote,
-		Syncer:         syncer,
+		RemoteSync:     syncer,
 		FileChunkStore: mem,
 	})
 	if err != nil {

--- a/pkg/metadata/store/memory/objects.go
+++ b/pkg/metadata/store/memory/objects.go
@@ -265,7 +265,7 @@ func enumerateBlockHashes(ctx context.Context, snapshot []block.ContentHash, fn 
 }
 
 // EnumerateSyncingBlocks returns every FileChunk currently in
-// BlockStateSyncing. the engine.Syncer janitor uses this to
+// BlockStateSyncing. the engine.RemoteSync janitor uses this to
 // requeue rows abandoned by a previous syncer instance. The memory backend
 // implements this via direct map iteration; other backends may opt in
 // when their query surface allows.


### PR DESCRIPTION
Stacked on #2430. Step 1 of the block data-flow refactor (#2428) extracts a `syncer` package, and `engine.Syncer` already occupies the name — 1074 LOC, of which carve dispatch is about 10%. A new package sitting beside a type of the same name is a permanent source of confusion, so the type gives way.

Mechanical and compiler-checked: `gopls rename` on the type, `NewSyncer`, `SyncerConfig` and the `BlockStoreConfig.Syncer` field, then a sweep of the comments and log strings gopls does not touch. 62 files, 238 lines, no behaviour change.

**The user-facing `syncer:` config section is untouched.** `shares.SyncerDefaults`, `SetSyncerDefaults` and `buildSyncerConfigFromDefaults` keep their names deliberately: they sit against the YAML key `syncer:`, where the word stays correct. `SyncerDefaults` carries no yaml/mapstructure tags, so nothing here reaches a config file either way.

`go build ./...`, `gofmt`, and `go test ./pkg/block/... ./pkg/controlplane/...` all green.