### PR TITLE
fix(nfs): make the NFSv4 stateid other unpredictable

### DIFF
--- a/internal/adapter/nfs/v4/state/dir_delegation.go
+++ b/internal/adapter/nfs/v4/state/dir_delegation.go
@@ -82,13 +82,7 @@ func (sm *StateManager) GrantDirDelegation(clientID uint64, dirFH []byte, notifM
 
 	// Generate random cookie verifier
 	var cookieVerf [8]byte
-	if _, err := rand.Read(cookieVerf[:]); err != nil {
-		// Fallback to time-based if crypto/rand fails
-		now := time.Now().UnixNano()
-		for i := range 8 {
-			cookieVerf[i] = byte(now >> (uint(i) * 8))
-		}
-	}
+	_, _ = rand.Read(cookieVerf[:])
 
 	fhCopy := make([]byte, len(dirFH))
 	copy(fhCopy, dirFH)

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -148,9 +148,6 @@ type StateManager struct {
 	// nextClientSeq is an atomic counter for the low 32 bits of client IDs.
 	nextClientSeq uint32
 
-	// nextStateSeq is an atomic counter for stateid "other" field generation.
-	nextStateSeq uint64
-
 	// leaseDuration is the configured lease duration for all clients.
 	leaseDuration time.Duration
 

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -330,18 +330,11 @@ func (sm *StateManager) generateClientID() uint64 {
 // using crypto/rand. This prevents malicious or stale clients from guessing
 // the verifier and confirming someone else's SETCLIENTID.
 //
-// Per research Pitfall 6: Do NOT use timestamps -- they are predictable.
+// Timestamps are not an acceptable source here: they are predictable, which is
+// the whole property the verifier must not have.
 func (sm *StateManager) generateConfirmVerifier() [8]byte {
 	var v [8]byte
-	if _, err := rand.Read(v[:]); err != nil {
-		// crypto/rand.Read should never fail on supported platforms.
-		// If it does, generate a non-zero fallback from time (degraded security).
-		logger.Error("crypto/rand.Read failed, using time-based fallback", "error", err)
-		now := time.Now().UnixNano()
-		for i := range 8 {
-			v[i] = byte(now >> (uint(i) * 8))
-		}
-	}
+	_, _ = rand.Read(v[:])
 	return v
 }
 

--- a/internal/adapter/nfs/v4/state/stateid.go
+++ b/internal/adapter/nfs/v4/state/stateid.go
@@ -2,9 +2,9 @@ package state
 
 import (
 	"bytes"
+	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"sync/atomic"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 	"github.com/marmos91/dittofs/internal/logger"
@@ -76,15 +76,22 @@ const (
 // Stateid Generation
 // ============================================================================
 
-// generateStateidOther creates a unique 12-byte "other" field for a stateid.
+// generateStateidOther creates a 12-byte "other" field for a stateid.
 //
 // Layout:
 //   - Byte 0:    state type tag (open=0x01, lock=0x02, deleg=0x03)
 //   - Bytes 1-3: boot epoch fragment (low 24 bits of sm.bootEpoch)
-//   - Bytes 4-11: atomic sequence counter (8 bytes, big-endian)
+//   - Bytes 4-11: 64 bits from crypto/rand
 //
 // The boot epoch fragment allows ValidateStateid to detect stale stateids
 // from a previous server incarnation without a map lookup.
+//
+// The low eight bytes are random rather than sequential, so holding one
+// stateid reveals nothing about any other.
+//
+// ponytail: uniqueness is probabilistic, around one chance in 40 million at a
+// million concurrent stateids; retry against the by-other map at each mint
+// site if a deployment ever holds enough live state to care.
 func (sm *StateManager) generateStateidOther(stateType byte) [types.NFS4_OTHER_SIZE]byte {
 	var other [types.NFS4_OTHER_SIZE]byte
 
@@ -96,16 +103,11 @@ func (sm *StateManager) generateStateidOther(stateType byte) [types.NFS4_OTHER_S
 	other[2] = byte(sm.bootEpoch >> 8)
 	other[3] = byte(sm.bootEpoch)
 
-	// Bytes 4-11: monotonic sequence counter
-	seq := atomic.AddUint64(&sm.nextStateSeq, 1)
-	other[4] = byte(seq >> 56)
-	other[5] = byte(seq >> 48)
-	other[6] = byte(seq >> 40)
-	other[7] = byte(seq >> 32)
-	other[8] = byte(seq >> 24)
-	other[9] = byte(seq >> 16)
-	other[10] = byte(seq >> 8)
-	other[11] = byte(seq)
+	// Bytes 4-11: unpredictable. From Go 1.24 the default crypto/rand Reader
+	// calls fatal() rather than returning an error, so a partial fill that
+	// leaves guessable zeros here is not reachable and the error is dead. If
+	// the module ever drops below Go 1.24 this must become a real error check.
+	_, _ = rand.Read(other[4:])
 
 	return other
 }

--- a/internal/adapter/nfs/v4/state/stateid_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_test.go
@@ -3,6 +3,7 @@ package state
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"sync"
 	"testing"
@@ -87,6 +88,26 @@ func TestGenerateStateidOther_ConcurrentUniqueness(t *testing.T) {
 			t.Fatalf("duplicate concurrent stateid other at index %d", i)
 		}
 		seen[other] = true
+	}
+}
+
+// TestGenerateStateidOther_NotSequential pins the low eight bytes as random
+// rather than sequential: a counter makes successive mints differ by exactly
+// one, so holding one stateid gives away its neighbours. Random bytes landing
+// adjacent has probability 2^-64 per pair.
+func TestGenerateStateidOther_NotSequential(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+
+	first := sm.generateStateidOther(StateTypeOpen)
+	prev := binary.BigEndian.Uint64(first[4:])
+	for i := 1; i < 32; i++ {
+		other := sm.generateStateidOther(StateTypeOpen)
+		cur := binary.BigEndian.Uint64(other[4:])
+		if cur == prev+1 {
+			t.Fatalf("mint %d is exactly one more than mint %d (%d, %d): sequential, not random",
+				i, i-1, prev, cur)
+		}
+		prev = cur
 	}
 }
 


### PR DESCRIPTION
Second of two PRs for #2395. The first, #2429, added the owner-to-client binding; this one removes the predictability that made guessing another client's stateid cheap in the first place. Stacked on #2429, which is stacked on #2427 — review those first.

## What was wrong

A stateid's 12-byte `other` field was laid out as:

- byte 0: state type tag (open `0x01`, lock `0x02`, delegation `0x03`)
- bytes 1-3: boot epoch fragment
- bytes 4-11: a **global `atomic.AddUint64` counter**

Every field was derivable. A client holding one of its own stateids knew the type tag, knew the epoch (constant for the server's lifetime), and could get its neighbours' low bytes by adding and subtracting one. Enumerating every live stateid on the server cost arithmetic, not traffic.

That is what made the missing owner-to-client check in #2429 cheap to exploit rather than theoretical: the attacker did not need to observe another client's stateid, only to hold one of their own and count.

## The fix

Bytes 4-11 come from `crypto/rand`. The type tag and boot epoch stay as they are — the tag routes the map lookup and the epoch lets a stateid from a previous server incarnation be spotted without one, and neither is a secret. The now-unused `nextStateSeq` counter field is deleted from `StateManager`.

No HMAC-with-server-secret scheme, deliberately: it would introduce a secret to manage, rotate and persist for no gain over 64 unpredictable bits. Minting happens on OPEN, LOCK and delegation grant, not per I/O, so the cost of a `crypto/rand` read is not on any hot path.

## Uniqueness is now probabilistic, and that is marked

The counter guaranteed uniqueness; 64 random bits per (type, epoch) does not. At a million concurrent stateids the collision probability is around one in forty million, and a collision would alias two states in the by-other maps. That is recorded as a `ponytail:` comment naming the ceiling and the upgrade path — retry against the relevant map at each of the four mint sites, all of which already hold the lock that would make the check free. It is not worth the code until a deployment holds enough live state for it to matter.

`crypto/rand.Read` fills the slice entirely or crashes the program (Go 1.24 onward; go.mod pins 1.25), so a short read cannot silently leave guessable zeros in the field.

## Second commit: a dead-code deletion this change exposed

`generateConfirmVerifier` and the directory-delegation cookie verifier both branched on a `crypto/rand.Read` error and fell back to eight bytes derived from `time.Now().UnixNano()`. On Go 1.24+ neither branch can execute, for the same reason the new comment above relies on.

They would be wrong if they could. `generateConfirmVerifier`'s own doc comment said "do NOT use timestamps -- they are predictable" directly above a fallback that derived the verifier from a timestamp. Crashing is the correct outcome for a security token whose entropy source has failed; degrading to a guessable one is strictly worse.

Kept as its own commit so it can be reverted independently — it is not part of the entropy fix, just something the entropy fix made visible.

## Test

`stateid_test.go` already pins everything structural about this function and pins it harder than a new file would have: `TestGenerateStateidOther_TypeTag` covers all three tags, `_Uniqueness` runs 1000 mints with a concurrent variant, and `_BootEpoch` plus `TestIsCurrentEpoch` cover the epoch fragment. Those all still pass unchanged, which is the regression evidence for the parts of the layout that did not move.

The one genuinely new property gets one test alongside them. `TestGenerateStateidOther_NotSequential` asserts no two successive mints differ by exactly one — which is precisely what a counter does, on the very first pair. Random values landing adjacent has probability 2^-64 per pair. Restoring the counter makes it fail:

```
--- FAIL: TestGenerateStateidOther_NotSequential
    mint 1 is exactly one more than mint 0 (1, 2): sequential, not random
```

Closes #2395
