### PR TITLE
refactor(block): extract the upload-window mechanism into pkg/block/syncer

### DIFF
--- a/pkg/block/engine/carve_dispatch_test.go
+++ b/pkg/block/engine/carve_dispatch_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/marmos91/dittofs/pkg/block/journal"
 	"github.com/marmos91/dittofs/pkg/block/local"
+	"github.com/marmos91/dittofs/pkg/block/syncer"
 )
 
 // carveFanoutLocal is a minimal LocalStore that records per-file Carve calls and
@@ -53,7 +54,7 @@ func TestCarvePass_FansOutBoundedByUploadWindow(t *testing.T) {
 	const window = 3
 	m := &RemoteSync{
 		local:         fl,
-		uploadLimiter: newDynamicSemaphore(window),
+		uploadLimiter: syncer.NewDynamicSemaphore(window),
 		stopCh:        make(chan struct{}),
 		config:        DefaultConfig(),
 	}
@@ -91,7 +92,7 @@ func TestCarvePass_FansOutBoundedByUploadWindow(t *testing.T) {
 // TestCarvePass_NoFilesIsNoop guards the empty working-set path.
 func TestCarvePass_NoFilesIsNoop(t *testing.T) {
 	fl := &carveFanoutLocal{started: make(chan string, 1), release: make(chan struct{}), carved: map[string]int{}}
-	m := &RemoteSync{local: fl, uploadLimiter: newDynamicSemaphore(4), stopCh: make(chan struct{}), config: DefaultConfig()}
+	m := &RemoteSync{local: fl, uploadLimiter: syncer.NewDynamicSemaphore(4), stopCh: make(chan struct{}), config: DefaultConfig()}
 	m.carvePass(context.Background()) // returns immediately, acquires nothing
 	require.Equal(t, int32(0), fl.inFlight.Load())
 }

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -115,11 +115,14 @@ type RemoteSync struct {
 	completedSyncs atomic.Int64
 	failedSyncs    atomic.Int64
 
-	// uploadLimiter bounds concurrent block PUTs in carveFlush. When
-	// ParallelUploads is pinned (> 0) its limit is fixed at that value.
+	// uploadLimiter bounds concurrent whole-file carve passes: carveDispatcher
+	// acquires it before starting a file and releases it when that file's pass
+	// returns. It does not bound the block PUTs inside a pass — those have their
+	// own per-file semaphore sized by CarveUploadConcurrency — so the PUTs
+	// actually in flight are the product of the two windows, not this limit.
+	// When ParallelUploads is pinned (> 0) its limit is fixed at that value.
 	// When unset (adaptive mode) the uploadController resizes it every control
-	// interval to track the goodput knee. Lazily created by ensureUploadLimiter
-	// so directly-built test fixtures still get bounded concurrency.
+	// interval to track the goodput knee.
 	uploadLimiter *syncer.DynamicSemaphore
 	// uploadController is non-nil only in adaptive mode. It consumes one
 	// (goodput, windowLimited, sawError) sample per control interval and returns

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/block/journal"
 	"github.com/marmos91/dittofs/pkg/block/local"
 	"github.com/marmos91/dittofs/pkg/block/remote"
+	"github.com/marmos91/dittofs/pkg/block/syncer"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
@@ -119,11 +120,11 @@ type RemoteSync struct {
 	// When unset (adaptive mode) the uploadController resizes it every control
 	// interval to track the goodput knee. Lazily created by ensureUploadLimiter
 	// so directly-built test fixtures still get bounded concurrency.
-	uploadLimiter *dynamicSemaphore
+	uploadLimiter *syncer.DynamicSemaphore
 	// uploadController is non-nil only in adaptive mode. It consumes one
 	// (goodput, windowLimited, sawError) sample per control interval and returns
 	// the next target window, applied to uploadLimiter by the control goroutine.
-	uploadController *goodputController
+	uploadController *syncer.GoodputController
 	// uploadedBytesWindow accumulates bytes successfully PutBlock'd since the
 	// last control tick; uploadErrWindow counts block-upload errors in the same
 	// span. The control goroutine swaps both to zero each tick to compute the
@@ -199,11 +200,11 @@ func NewRemoteSync(local local.LocalStore, remoteStore remote.RemoteStore, fileC
 	// floor and ceiling. The limiter starts at the floor in adaptive mode and at
 	// the pinned value otherwise; the control goroutine (adaptive only, launched
 	// in Start) resizes it at runtime.
-	var uploadController *goodputController
+	var uploadController *syncer.GoodputController
 	startWindow := config.ParallelUploads
 	if config.ParallelUploads <= 0 {
 		startWindow = AdaptiveUploadFloor
-		uploadController = newGoodputController(AdaptiveUploadFloor, AdaptiveUploadCeiling)
+		uploadController = syncer.NewGoodputController(AdaptiveUploadFloor, AdaptiveUploadCeiling)
 	}
 
 	m := &RemoteSync{
@@ -214,7 +215,7 @@ func NewRemoteSync(local local.LocalStore, remoteStore remote.RemoteStore, fileC
 		inFlight:       make(map[string]*fetchResult),
 		stopCh:         make(chan struct{}),
 
-		uploadLimiter:    newDynamicSemaphore(startWindow),
+		uploadLimiter:    syncer.NewDynamicSemaphore(startWindow),
 		uploadController: uploadController,
 	}
 	m.hasRemote.Store(remoteStore != nil)
@@ -762,7 +763,7 @@ func (m *RemoteSync) startPeriodicUploader(ctx context.Context) {
 
 // runUploadController is the adaptive upload-concurrency control loop.
 // Every interval it turns the bytes/error accumulated by carveAndCommitBlock
-// into a goodput sample, feeds the goodputController, and applies the returned
+// into a goodput sample, feeds the GoodputController, and applies the returned
 // window to the shared uploadLimiter. Runs only in adaptive mode (controller
 // non-nil). Idle intervals (no bytes, nothing in flight, no error) are skipped
 // so a write pause is not misread as a goodput collapse.
@@ -798,7 +799,7 @@ func (m *RemoteSync) adaptiveUploadTick(intervalSec float64) {
 	// Peak in-flight over the interval distinguishes window-limited from
 	// app-limited: uploads that filled the window mean goodput reflects the
 	// window; otherwise the upstream carve pipeline was the constraint (see
-	// goodputController.observe).
+	// syncer.GoodputController.Observe).
 	peak := m.uploadLimiter.TakePeak()
 	windowLimited := peak >= m.uploadLimiter.Limit()
 
@@ -812,7 +813,7 @@ func (m *RemoteSync) adaptiveUploadTick(intervalSec float64) {
 	}
 
 	goodput := float64(bytes) / intervalSec
-	window := m.uploadController.observe(goodput, windowLimited, sawErr)
+	window := m.uploadController.Observe(goodput, windowLimited, sawErr)
 	m.uploadLimiter.SetLimit(window)
 	if mx := m.dataplaneMetrics(); mx != nil {
 		mx.SetUploadWindow(window)

--- a/pkg/block/engine/syncer_shutdown_test.go
+++ b/pkg/block/engine/syncer_shutdown_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/block"
 	memorylocal "github.com/marmos91/dittofs/pkg/block/local/memory"
 	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
+	"github.com/marmos91/dittofs/pkg/block/syncer"
 )
 
 // gatedChunkStore wraps a stubFileChunkStore so a download worker can be pinned
@@ -143,7 +144,7 @@ func TestSyncerClose_JoinsCarveDispatcher(t *testing.T) {
 	cfg.UploadInterval = time.Millisecond
 	m := &RemoteSync{
 		local:         fl,
-		uploadLimiter: newDynamicSemaphore(2),
+		uploadLimiter: syncer.NewDynamicSemaphore(2),
 		stopCh:        make(chan struct{}),
 		config:        cfg,
 	}

--- a/pkg/block/engine/types.go
+++ b/pkg/block/engine/types.go
@@ -21,11 +21,14 @@ var ErrStoreClosed = errors.New("engine: block store is closed")
 const DefaultParallelDownloads = 32
 
 // Adaptive upload-concurrency bounds (#1407). When RemoteSyncConfig.ParallelUploads
-// is unset (0), the carver auto-tunes concurrent block PUTs to saturate the
-// uplink: it starts at AdaptiveUploadFloor and ramps toward AdaptiveUploadCeiling,
+// is unset (0), the syncer auto-tunes the upload window to saturate the uplink:
+// it starts at AdaptiveUploadFloor and ramps toward AdaptiveUploadCeiling,
 // settling at the goodput knee. A pinned ParallelUploads > 0 overrides this with
-// a fixed window. Block PUTs are network-latency bound, so a serial carver leaves
-// the link idle — one in-flight PutBlock sustained only ~200 Mbit/s VM→fr-par.
+// a fixed window. The window bounds concurrent whole-file carve passes, not
+// individual block PUTs — each pass applies its own bound on concurrent
+// PutBlock calls, so the PUTs in flight are the product of the two. Block PUTs
+// are network-latency bound, so a serial carver leaves the link idle — one
+// in-flight PutBlock sustained only ~200 Mbit/s VM→fr-par.
 const (
 	AdaptiveUploadFloor   = 16  // starting window in adaptive mode (greedy start)
 	AdaptiveUploadCeiling = 64  // max window the adaptive controller ramps to

--- a/pkg/block/syncer/dynsem.go
+++ b/pkg/block/syncer/dynsem.go
@@ -1,13 +1,16 @@
-package engine
+// Package syncer holds the upload-window mechanism: a semaphore whose limit can
+// be resized while slots are held, and the goodput controller that decides the
+// limit.
+package syncer
 
 import (
 	"context"
 	gosync "sync"
 )
 
-// dynamicSemaphore is a counting semaphore whose limit can change while slots
-// are held. The adaptive upload controller (#1407) resizes it every control
-// interval, so the fixed-size golang.org/x/sync/semaphore.Weighted (size set at
+// DynamicSemaphore is a counting semaphore whose limit can change while slots
+// are held. The adaptive upload controller resizes it every control interval,
+// so the fixed-size golang.org/x/sync/semaphore.Weighted (size set at
 // construction) does not fit. Growing the limit wakes blocked Acquire callers
 // immediately; shrinking never preempts existing holders — it only withholds
 // new slots until in-flight falls below the new limit.
@@ -15,7 +18,7 @@ import (
 // It is also context-aware: Acquire returns ctx.Err() if the context is
 // cancelled while waiting, so a failing/cancelled mirror pass does not strand a
 // goroutine on a slot that will never free.
-type dynamicSemaphore struct {
+type DynamicSemaphore struct {
 	mu       gosync.Mutex
 	cond     *gosync.Cond
 	limit    int
@@ -23,26 +26,28 @@ type dynamicSemaphore struct {
 	peak     int // high-water mark of inflight since the last TakePeak
 }
 
-func newDynamicSemaphore(limit int) *dynamicSemaphore {
+// NewDynamicSemaphore returns a semaphore with the given starting limit,
+// clamped to at least 1.
+func NewDynamicSemaphore(limit int) *DynamicSemaphore {
 	if limit < 1 {
 		limit = 1
 	}
-	s := &dynamicSemaphore{limit: limit}
+	s := &DynamicSemaphore{limit: limit}
 	s.cond = gosync.NewCond(&s.mu)
 	return s
 }
 
 // Acquire blocks until a slot is available or ctx is done. On ctx cancellation
 // it returns ctx.Err() without consuming a slot.
-func (s *dynamicSemaphore) Acquire(ctx context.Context) error {
+func (s *DynamicSemaphore) Acquire(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
 
 	s.mu.Lock()
 	// Fast path: a slot is free now — take it without parking or spawning a
-	// cancellation watcher. This is the common case in the mirror loop (one
-	// Acquire per chunk), so it must not allocate a goroutine per call.
+	// cancellation watcher. This is the common case in the dispatch loop (one
+	// Acquire per carve pass), so it must not allocate a goroutine per call.
 	if s.inflight < s.limit {
 		s.inflight++
 		if s.inflight > s.peak {
@@ -91,8 +96,8 @@ func (s *dynamicSemaphore) Acquire(ctx context.Context) error {
 // TakePeak returns the high-water mark of in-flight slots since the last call
 // and resets it to the current in-flight count. The adaptive controller uses it
 // to tell window-limited intervals (peak reached the limit) from app-limited
-// ones (peak stayed below it) — see goodputController.observe.
-func (s *dynamicSemaphore) TakePeak() int {
+// ones (peak stayed below it) — see GoodputController.Observe.
+func (s *DynamicSemaphore) TakePeak() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	p := s.peak
@@ -105,7 +110,7 @@ func (s *dynamicSemaphore) TakePeak() int {
 // freed slot, so waking exactly one risks stranding it — Broadcast lets the
 // next live waiter take the slot. Signalling under s.mu serializes it against a
 // waiter's ctx-check/Wait window (no lost wakeup).
-func (s *dynamicSemaphore) Release() {
+func (s *DynamicSemaphore) Release() {
 	s.mu.Lock()
 	if s.inflight > 0 {
 		s.inflight--
@@ -117,7 +122,7 @@ func (s *dynamicSemaphore) Release() {
 // SetLimit changes the maximum concurrency. Growing wakes blocked waiters;
 // shrinking takes effect for future acquires only (current holders run to
 // completion).
-func (s *dynamicSemaphore) SetLimit(n int) {
+func (s *DynamicSemaphore) SetLimit(n int) {
 	if n < 1 {
 		n = 1
 	}
@@ -128,14 +133,14 @@ func (s *dynamicSemaphore) SetLimit(n int) {
 }
 
 // Limit returns the current maximum concurrency.
-func (s *dynamicSemaphore) Limit() int {
+func (s *DynamicSemaphore) Limit() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.limit
 }
 
 // InFlight returns the number of currently held slots.
-func (s *dynamicSemaphore) InFlight() int {
+func (s *DynamicSemaphore) InFlight() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.inflight

--- a/pkg/block/syncer/dynsem_test.go
+++ b/pkg/block/syncer/dynsem_test.go
@@ -1,4 +1,4 @@
-package engine
+package syncer
 
 import (
 	"context"
@@ -7,13 +7,13 @@ import (
 	"time"
 )
 
-// dynamicSemaphore is the concurrency primitive the adaptive upload controller
+// DynamicSemaphore is the concurrency primitive the adaptive upload controller
 // resizes at runtime. golang.org/x/sync/semaphore fixes its size at
 // construction, so the syncer needs one whose limit can grow and shrink while
 // slots are held. These tests pin the contract independently of the syncer.
 
 func TestDynamicSemaphore_BlocksAtLimit(t *testing.T) {
-	s := newDynamicSemaphore(2)
+	s := NewDynamicSemaphore(2)
 	ctx := context.Background()
 	if err := s.Acquire(ctx); err != nil {
 		t.Fatal(err)
@@ -46,7 +46,7 @@ func TestDynamicSemaphore_BlocksAtLimit(t *testing.T) {
 }
 
 func TestDynamicSemaphore_GrowUnblocksWaiter(t *testing.T) {
-	s := newDynamicSemaphore(1)
+	s := NewDynamicSemaphore(1)
 	ctx := context.Background()
 	if err := s.Acquire(ctx); err != nil {
 		t.Fatal(err)
@@ -74,7 +74,7 @@ func TestDynamicSemaphore_GrowUnblocksWaiter(t *testing.T) {
 }
 
 func TestDynamicSemaphore_ShrinkHoldsNewAcquires(t *testing.T) {
-	s := newDynamicSemaphore(4)
+	s := NewDynamicSemaphore(4)
 	ctx := context.Background()
 	for i := 0; i < 4; i++ {
 		if err := s.Acquire(ctx); err != nil {
@@ -111,7 +111,7 @@ func TestDynamicSemaphore_ShrinkHoldsNewAcquires(t *testing.T) {
 }
 
 func TestDynamicSemaphore_TakePeakTracksHighWater(t *testing.T) {
-	s := newDynamicSemaphore(8)
+	s := NewDynamicSemaphore(8)
 	ctx := context.Background()
 	for i := 0; i < 5; i++ {
 		if err := s.Acquire(ctx); err != nil {
@@ -132,7 +132,7 @@ func TestDynamicSemaphore_TakePeakTracksHighWater(t *testing.T) {
 }
 
 func TestDynamicSemaphore_AcquireRespectsContext(t *testing.T) {
-	s := newDynamicSemaphore(1)
+	s := NewDynamicSemaphore(1)
 	if err := s.Acquire(context.Background()); err != nil {
 		t.Fatal(err)
 	}
@@ -152,7 +152,7 @@ func TestDynamicSemaphore_AcquireRespectsContext(t *testing.T) {
 
 func TestDynamicSemaphore_ConcurrentNeverExceedsLimit(t *testing.T) {
 	const limit = 5
-	s := newDynamicSemaphore(limit)
+	s := NewDynamicSemaphore(limit)
 	ctx := context.Background()
 	var (
 		mu      sync.Mutex

--- a/pkg/block/syncer/upload_controller.go
+++ b/pkg/block/syncer/upload_controller.go
@@ -1,15 +1,15 @@
-package engine
+package syncer
 
 import "math"
 
-// goodputController is the pure decision core of adaptive upload concurrency
-// (#1407 / #1432). When the user does not pin parallel_uploads, the syncer ramps
-// the number of concurrent block PutBlock uploads in the carve path to saturate
-// the uplink on its own.
+// GoodputController is the pure decision core of adaptive upload concurrency.
+// When the user does not pin parallel_uploads, the syncer ramps the upload
+// window — the number of carve passes running concurrently, each of which
+// issues its own block PUTs — to saturate the uplink on its own.
 //
 // The control signal is GOODPUT (delivered bytes/sec), not latency. An earlier
-// latency-gradient design (#1400) read the per-PUT latency rise *caused by
-// useful concurrency* as congestion and collapsed the window to ~4, far below
+// latency-gradient design read the per-PUT latency rise *caused by useful
+// concurrency* as congestion and collapsed the window to ~4, far below
 // the bandwidth knee. Uploads here are network-latency bound, so opening more
 // connections raises both latency and throughput together until the link
 // saturates — the only honest saturation signal is "did goodput stop rising".
@@ -19,7 +19,7 @@ import "math"
 // that delivered the best goodput (the knee), and back off only on upload
 // errors or a goodput collapse. It is deterministic and depends on no clock,
 // network, or goroutine, so its behaviour is pinned entirely by unit tests.
-type goodputController struct {
+type GoodputController struct {
 	floor   int
 	ceiling int
 
@@ -30,7 +30,7 @@ type goodputController struct {
 	emaInit    bool
 	stall      int // consecutive samples without a meaningful improvement
 
-	// Tunables. Defaults chosen for the S3 upload path (see newGoodputController).
+	// Tunables. Defaults chosen for the S3 upload path (see NewGoodputController).
 	rampFactor    float64 // multiplicative window increase while improving
 	backoffFactor float64 // multiplicative decrease on error / collapse
 	improveFrac   float64 // min relative goodput gain that counts as "improving"
@@ -39,15 +39,15 @@ type goodputController struct {
 	stallLimit    int     // plateau samples before settling at the knee
 }
 
-// newGoodputController returns a controller that ramps within [floor, ceiling].
-func newGoodputController(floor, ceiling int) *goodputController {
+// NewGoodputController returns a controller that ramps within [floor, ceiling].
+func NewGoodputController(floor, ceiling int) *GoodputController {
 	if floor < 1 {
 		floor = 1
 	}
 	if ceiling < floor {
 		ceiling = floor
 	}
-	return &goodputController{
+	return &GoodputController{
 		floor:         floor,
 		ceiling:       ceiling,
 		cur:           floor,
@@ -62,9 +62,9 @@ func newGoodputController(floor, ceiling int) *goodputController {
 }
 
 // window returns the current target concurrency.
-func (c *goodputController) window() int { return c.cur }
+func (c *GoodputController) window() int { return c.cur }
 
-// observe feeds one control-interval sample and returns the next target window.
+// Observe feeds one control-interval sample and returns the next target window.
 // goodput is the delivered bytes/sec over the interval; windowLimited is true
 // when the window was actually saturated during the interval (in-flight uploads
 // reached the limit); sawError is true if any upload failed.
@@ -75,8 +75,8 @@ func (c *goodputController) window() int { return c.cur }
 // is app-limited, and reacting to it would shrink the window precisely when the
 // pipeline is about to burst a backlog that a wide window must drain fast. The
 // bursty rollup→upload pipeline does exactly this, so the controller only ramps
-// or backs off on window-limited samples and otherwise holds (#1407).
-func (c *goodputController) observe(goodput float64, windowLimited, sawError bool) int {
+// or backs off on window-limited samples and otherwise holds.
+func (c *GoodputController) Observe(goodput float64, windowLimited, sawError bool) int {
 	// Smooth the (noisy) per-interval goodput before any decision.
 	if !c.emaInit {
 		c.ema = goodput
@@ -133,7 +133,7 @@ func (c *goodputController) observe(goodput float64, windowLimited, sawError boo
 	return c.cur
 }
 
-func (c *goodputController) grow() {
+func (c *GoodputController) grow() {
 	next := int(math.Ceil(float64(c.cur) * c.rampFactor))
 	if next <= c.cur {
 		next = c.cur + 1
@@ -144,7 +144,7 @@ func (c *goodputController) grow() {
 	c.cur = next
 }
 
-func (c *goodputController) shrink() {
+func (c *GoodputController) shrink() {
 	next := int(math.Round(float64(c.cur) * c.backoffFactor))
 	if next >= c.cur {
 		next = c.cur - 1

--- a/pkg/block/syncer/upload_controller_test.go
+++ b/pkg/block/syncer/upload_controller_test.go
@@ -1,9 +1,9 @@
-package engine
+package syncer
 
 import "testing"
 
 // The goodput controller is the pure decision core of adaptive upload
-// concurrency (#1407). It consumes one (goodput, sawError) sample per control
+// concurrency. It consumes one (goodput, sawError) sample per control
 // interval and returns the next target window. It must:
 //   - start at the floor,
 //   - ramp up while delivered goodput keeps improving (TCP-slow-start-like),
@@ -15,20 +15,20 @@ import "testing"
 // clock, so a regression in the math is caught here rather than only on the VM.
 
 func TestGoodputController_StartsAtFloor(t *testing.T) {
-	c := newGoodputController(8, 64)
+	c := NewGoodputController(8, 64)
 	if got := c.window(); got != 8 {
 		t.Fatalf("initial window = %d, want floor 8", got)
 	}
 }
 
 func TestGoodputController_RampsUpWhileGoodputImproves(t *testing.T) {
-	c := newGoodputController(8, 64)
+	c := NewGoodputController(8, 64)
 	// Each wider window delivers strictly more goodput: the link is not yet
 	// saturated, so the controller must keep opening the window.
 	prev := c.window()
 	goodput := 10.0
 	for i := 0; i < 8; i++ {
-		w := c.observe(goodput, true, false)
+		w := c.Observe(goodput, true, false)
 		if w < prev {
 			t.Fatalf("sample %d: window shrank (%d -> %d) while goodput rising", i, prev, w)
 		}
@@ -44,34 +44,34 @@ func TestGoodputController_RampsUpWhileGoodputImproves(t *testing.T) {
 }
 
 func TestGoodputController_SettlesAtKneeWhenGoodputPlateaus(t *testing.T) {
-	c := newGoodputController(8, 64)
+	c := NewGoodputController(8, 64)
 	// Phase 1: goodput climbs, window ramps.
-	c.observe(10, true, false)
-	c.observe(20, true, false)
-	c.observe(30, true, false)
+	c.Observe(10, true, false)
+	c.Observe(20, true, false)
+	c.Observe(30, true, false)
 	peak := c.window()
 	// Phase 2: goodput flat (link saturated). The window must stop growing and
 	// converge — it must NOT keep climbing to the ceiling on a saturated link.
 	var last int
 	for i := 0; i < 8; i++ {
-		last = c.observe(30, true, false)
+		last = c.Observe(30, true, false)
 	}
 	if last > peak {
 		t.Fatalf("window kept growing past the knee on flat goodput: peak=%d last=%d", peak, last)
 	}
 	// And it must have converged (a second identical run of samples is stable).
-	stable := c.observe(30, true, false)
+	stable := c.Observe(30, true, false)
 	if stable != last {
 		t.Fatalf("window not converged on flat goodput: %d then %d", last, stable)
 	}
 }
 
 func TestGoodputController_DoesNotExceedCeiling(t *testing.T) {
-	c := newGoodputController(8, 32)
+	c := NewGoodputController(8, 32)
 	// Goodput improves forever; only the ceiling should stop the ramp.
 	goodput := 10.0
 	for i := 0; i < 20; i++ {
-		w := c.observe(goodput, true, false)
+		w := c.Observe(goodput, true, false)
 		if w > 32 {
 			t.Fatalf("window exceeded ceiling: %d", w)
 		}
@@ -83,42 +83,42 @@ func TestGoodputController_DoesNotExceedCeiling(t *testing.T) {
 }
 
 func TestGoodputController_BacksOffOnError(t *testing.T) {
-	c := newGoodputController(8, 64)
+	c := NewGoodputController(8, 64)
 	// Ramp up first.
-	c.observe(10, true, false)
-	c.observe(20, true, false)
-	c.observe(40, true, false)
+	c.Observe(10, true, false)
+	c.Observe(20, true, false)
+	c.Observe(40, true, false)
 	high := c.window()
 	if high <= 8 {
 		t.Fatalf("precondition: window should have ramped, got %d", high)
 	}
 	// An upload error must shrink the window (server pushback / overload).
-	after := c.observe(40, true, true)
+	after := c.Observe(40, true, true)
 	if after >= high {
 		t.Fatalf("window did not back off on error: %d -> %d", high, after)
 	}
 }
 
 func TestGoodputController_BacksOffOnGoodputCollapse(t *testing.T) {
-	c := newGoodputController(8, 64)
-	c.observe(10, true, false)
-	c.observe(40, true, false)
-	c.observe(80, true, false)
+	c := NewGoodputController(8, 64)
+	c.Observe(10, true, false)
+	c.Observe(40, true, false)
+	c.Observe(80, true, false)
 	high := c.window()
 	// Goodput collapses to a fraction of the best seen (congestion), no explicit
 	// error. The controller must still shrink.
-	after := c.observe(10, true, false)
+	after := c.Observe(10, true, false)
 	if after >= high {
 		t.Fatalf("window did not back off on goodput collapse: %d -> %d", high, after)
 	}
 }
 
 func TestGoodputController_NeverBelowFloor(t *testing.T) {
-	c := newGoodputController(8, 64)
-	c.observe(50, true, false)
+	c := NewGoodputController(8, 64)
+	c.Observe(50, true, false)
 	// Hammer it with errors; it must never drop below the floor.
 	for i := 0; i < 20; i++ {
-		w := c.observe(1, true, true)
+		w := c.Observe(1, true, true)
 		if w < 8 {
 			t.Fatalf("window dropped below floor: %d", w)
 		}
@@ -126,11 +126,11 @@ func TestGoodputController_NeverBelowFloor(t *testing.T) {
 }
 
 func TestGoodputController_HoldsWindowWhenAppLimited(t *testing.T) {
-	c := newGoodputController(8, 64)
+	c := NewGoodputController(8, 64)
 	// Ramp up while window-limited.
-	c.observe(10, true, false)
-	c.observe(20, true, false)
-	c.observe(40, true, false)
+	c.Observe(10, true, false)
+	c.Observe(20, true, false)
+	c.Observe(40, true, false)
 	high := c.window()
 	if high <= 8 {
 		t.Fatalf("precondition: expected ramp, got %d", high)
@@ -138,9 +138,9 @@ func TestGoodputController_HoldsWindowWhenAppLimited(t *testing.T) {
 	// Now the upstream pipeline starves the uploader: goodput collapses but the
 	// window was NOT the constraint (app-limited). The controller must HOLD the
 	// window — shrinking here would cripple throughput the moment upstream
-	// catches up (the bursty rollup→upload pipeline does exactly this, #1407).
+	// catches up (the bursty rollup→upload pipeline does exactly this).
 	for i := 0; i < 5; i++ {
-		w := c.observe(1, false, false) // low goodput, app-limited
+		w := c.Observe(1, false, false) // low goodput, app-limited
 		if w != high {
 			t.Fatalf("app-limited sample %d moved the window: %d -> %d", i, high, w)
 		}
@@ -148,11 +148,11 @@ func TestGoodputController_HoldsWindowWhenAppLimited(t *testing.T) {
 }
 
 func TestGoodputController_HoldsOnErrorWhenAppLimited(t *testing.T) {
-	c := newGoodputController(8, 64)
+	c := NewGoodputController(8, 64)
 	// Ramp up while window-limited.
-	c.observe(10, true, false)
-	c.observe(20, true, false)
-	c.observe(40, true, false)
+	c.Observe(10, true, false)
+	c.Observe(20, true, false)
+	c.Observe(40, true, false)
 	high := c.window()
 	if high <= 8 {
 		t.Fatalf("precondition: expected ramp, got %d", high)
@@ -160,22 +160,22 @@ func TestGoodputController_HoldsOnErrorWhenAppLimited(t *testing.T) {
 	// A stray error during an app-limited interval (window was NOT the
 	// constraint) must NOT shrink the window or corrupt the learned knee — that
 	// would needlessly deflate the next burst.
-	after := c.observe(1, false, true)
+	after := c.Observe(1, false, true)
 	if after != high {
 		t.Fatalf("app-limited error moved the window: %d -> %d", high, after)
 	}
 }
 
 func TestGoodputController_RecoversAfterBackoff(t *testing.T) {
-	c := newGoodputController(8, 64)
-	c.observe(10, true, false)
-	c.observe(20, true, false)
-	c.observe(40, true, false)
-	c.observe(40, true, true) // back off
+	c := NewGoodputController(8, 64)
+	c.Observe(10, true, false)
+	c.Observe(20, true, false)
+	c.Observe(40, true, false)
+	c.Observe(40, true, true) // back off
 	low := c.window()
 	// Conditions recover: goodput climbs again, window must re-open.
-	c.observe(80, true, false)
-	c.observe(160, true, false)
+	c.Observe(80, true, false)
+	c.Observe(160, true, false)
 	if c.window() <= low {
 		t.Fatalf("window did not recover after backoff: low=%d now=%d", low, c.window())
 	}


### PR DESCRIPTION
Step 1.3 of the block data-flow refactor. Stacked on `refactor/engine-remotesync-rename` (#2431).

Creates `pkg/block/syncer` and moves the upload-window mechanism into it — the adaptive semaphore and the goodput controller. These are the only parts of step 1 that port cleanly, and both were missing from the plan's original scope.

## What moved

| from | to |
|---|---|
| `engine/dynsem.go` (+ `_test.go`) | `syncer/dynsem.go` |
| `engine/upload_controller.go` (+ `_test.go`) | `syncer/upload_controller.go` |

Nothing else. `engine/carve_dispatch.go` is step 1.4; `journal/carve_dispatch.go` stays in `journal` for step 1; `engine/blocksink.go` stays.

Both moved files had zero imports beyond `context`/`sync`/`math`, so there is no dependency back into `engine` and no cycle.

## Exported surface

Kept to exactly what `engine` calls across the new boundary:

- `syncer.DynamicSemaphore` / `NewDynamicSemaphore` — methods `Acquire`, `Release`, `TakePeak`, `SetLimit`, `Limit` were already exported; `InFlight` was too and is used by the moved test.
- `syncer.GoodputController` / `NewGoodputController` — plus `Observe` (was `observe`), called from `syncer.go:809`.

`window()`, `grow()` and `shrink()` stay unexported: only the moved tests use them.

## `MaxParallelUploads`: kept in `engine`

The whole const block in `engine/types.go` stays put, `MaxParallelUploads` included. It is validation for `SyncerConfig.ParallelUploads` — the engine's *configuration* — not the window mechanism: `NewGoodputController(floor, ceiling)` and `NewDynamicSemaphore(limit)` take their bounds as parameters and reference no constant. Moving `MaxParallelUploads` would drag `blockstore_init.go` and `blockstore_config.go` into an extraction PR for no gain, and splitting the block (moving `AdaptiveUploadFloor`/`Ceiling` but not `Default`/`Max`) would separate four constants that document one setting together. `uploadControlInterval` stays for the same reason: the control *loop* (`runUploadController`) stays in `engine`, so its cadence does too.

## Behaviour

Unchanged. Same logic, same defaults, same semantics. The two nested upload semaphores are carried over verbatim — collapsing or retuning them is #2423 and ships separately.

## Comments

- Corrected the adaptive-bounds comment at `engine/types.go:22-30`: it claimed the window bounds concurrent block PUTs. It bounds concurrent whole-file carve passes; each pass applies its own bound on PUTs, so the PUTs in flight are the product of the two. The same false claim was in `upload_controller.go`'s type doc and is corrected in the moved copy rather than propagated.
- Fixed a stale note in `Acquire`: "one Acquire per chunk" — it is one Acquire per carve pass.
- Stripped issue numbers from the comments in the two new files, per the repo rule against external references in source. Left the pre-existing ones in `engine/types.go` alone; that is a separate cleanup.

Two comments known to carry the same PUT-bounding falsehood are **left untouched** because they belong to files this PR does not own: `engine/syncer.go:117` ("bounds concurrent block PUTs in carveFlush", and it also names a `ensureUploadLimiter` that does not exist) and `engine/carve_dispatch.go:56-58`. Both are step 1.4 / #2423 territory.

## Verification

| command | result |
|---|---|
| `go build ./...` | pass |
| `go vet ./pkg/block/...` | pass |
| `go vet -tags=integration ./...` | pass |
| `go test -count=1 ./pkg/block/... ./pkg/controlplane/...` | pass, 29 packages ok |
| `go test -count=1 -race ./pkg/block/syncer/...` | pass, all 16 tests |
| `gofmt -l ./pkg ./internal ./cmd` | empty |
| `golangci-lint run ./pkg/block/...` | 0 issues |

The 16 tests are the ones that moved: 6 `TestDynamicSemaphore_*` and 10 `TestGoodputController_*`. No test was added — this PR adds no contract, so there is nothing new to pin.
