### PR TITLE
fix(nfs): reject a DELEGRETURN from a client that does not hold the delegation

### DIFF
--- a/internal/adapter/nfs/v4/handlers/delegreturn.go
+++ b/internal/adapter/nfs/v4/handlers/delegreturn.go
@@ -11,6 +11,7 @@ import (
 // Returns a delegation to the server after CB_RECALL or when the client no longer needs it.
 // Delegates to StateManager.ReturnDelegation to remove the delegation tracking state.
 // Releases delegation state; idempotent (returning an already-returned delegation succeeds).
+// A delegation held by another client is refused on NFSv4.1 and later.
 // Errors: NFS4ERR_NOFILEHANDLE, NFS4ERR_BAD_STATEID, NFS4ERR_BADXDR.
 func (h *Handler) handleDelegReturn(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
 	// Require current filehandle
@@ -37,7 +38,7 @@ func (h *Handler) handleDelegReturn(ctx *types.CompoundContext, reader io.Reader
 		"client", ctx.ClientAddr)
 
 	// Remove delegation state
-	stateErr := h.StateManager.ReturnDelegation(stateid)
+	stateErr := h.StateManager.ReturnDelegation(stateid, ctx.SessionClientID)
 	if stateErr != nil {
 		nfsStatus := mapStateError(stateErr)
 		logger.Debug("NFSv4 DELEGRETURN failed",

--- a/internal/adapter/nfs/v4/handlers/delegreturn_test.go
+++ b/internal/adapter/nfs/v4/handlers/delegreturn_test.go
@@ -138,7 +138,7 @@ func TestHandleDelegReturn_AlreadyReturned_Idempotent(t *testing.T) {
 
 	// Grant and return a delegation
 	deleg := sm.GrantDelegation(100, fh, types.OPEN_DELEGATE_READ)
-	err := sm.ReturnDelegation(&deleg.Stateid)
+	err := sm.ReturnDelegation(&deleg.Stateid, 0)
 	if err != nil {
 		t.Fatalf("ReturnDelegation: %v", err)
 	}
@@ -169,5 +169,59 @@ func TestHandleDelegReturn_Registered(t *testing.T) {
 	// Verify DELEGRETURN is registered in the dispatch table
 	if _, exists := h.v40DispatchTable[types.OP_DELEGRETURN]; !exists {
 		t.Error("OP_DELEGRETURN should be registered in dispatch table")
+	}
+}
+
+// TestHandleDelegReturn_CrossClient covers the ownership check on DELEGRETURN.
+// A delegation names state one client holds; another client returning it would
+// stop the holder's recall timer and invalidate its cache authority without the
+// holder ever knowing.
+func TestHandleDelegReturn_CrossClient(t *testing.T) {
+	const holder uint64 = 0xAAAA
+
+	tests := []struct {
+		name       string
+		callerID   uint64
+		wantStatus uint32
+		wantDelegs int
+	}{
+		{"another client is refused", 0xBBBB, types.NFS4ERR_BAD_STATEID, 1},
+		{"the holding client succeeds", holder, types.NFS4_OK, 0},
+		// NFSv4.0 sends no clientid4 on DELEGRETURN and has no session to
+		// derive one from, so there is nothing to compare and the delegation
+		// stays a bearer token.
+		{"no client identity to check", 0, types.NFS4_OK, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pfs := pseudofs.New()
+			pfs.Rebuild([]string{"/export"})
+			sm := state.NewStateManager(90 * time.Second)
+			h := NewHandler(nil, pfs, sm)
+
+			fh := []byte("fh-delegreturn-cross-client")
+			deleg := sm.GrantDelegation(holder, fh, types.OPEN_DELEGATE_READ)
+
+			var args bytes.Buffer
+			types.EncodeStateid4(&args, &deleg.Stateid)
+
+			result := h.handleDelegReturn(&types.CompoundContext{
+				Context:         context.Background(),
+				ClientAddr:      "127.0.0.1:9999",
+				CurrentFH:       fh,
+				SessionClientID: tt.callerID,
+			}, bytes.NewReader(args.Bytes()))
+
+			if result.Status != tt.wantStatus {
+				t.Errorf("status = %d, want %d", result.Status, tt.wantStatus)
+			}
+			// A refused return must leave the delegation in place, or the guard
+			// has merely changed the status code on a revocation that still
+			// happened.
+			if got := len(sm.GetDelegationsForFile(fh)); got != tt.wantDelegs {
+				t.Errorf("delegations after DELEGRETURN = %d, want %d", got, tt.wantDelegs)
+			}
+		})
 	}
 }

--- a/internal/adapter/nfs/v4/state/delegation.go
+++ b/internal/adapter/nfs/v4/state/delegation.go
@@ -319,11 +319,16 @@ func (sm *StateManager) GrantDelegation(clientID uint64, fileHandle []byte, dele
 // Idempotent: returning an already-returned delegation succeeds with nil error
 // (per Pitfall 3 from research -- race between DELEGRETURN and CB_RECALL).
 //
-// Returns nil on success. Returns NFS4ERR_STALE_STATEID if the stateid
-// is from a previous server incarnation.
+// Returns nil on success. Returns NFS4ERR_STALE_STATEID if the stateid is from
+// a previous server incarnation, and NFS4ERR_BAD_STATEID when the delegation
+// belongs to a client other than clientID: any client could otherwise revoke a
+// delegation it never held, stopping the holder's recall timer and invalidating
+// its cache authority. A zero clientID means the caller has no trusted client
+// identity — DELEGRETURN carries no clientid4 on NFSv4.0 and there is no
+// session to derive one from — and skips the check; see checkStateidOwner.
 //
 // Caller must NOT hold sm.mu (method acquires it).
-func (sm *StateManager) ReturnDelegation(stateid *types.Stateid4) error {
+func (sm *StateManager) ReturnDelegation(stateid *types.Stateid4, clientID uint64) error {
 	sm.mu.Lock()
 	deleg, exists := sm.delegByOther[stateid.Other]
 	if !exists {
@@ -334,6 +339,11 @@ func (sm *StateManager) ReturnDelegation(stateid *types.Stateid4) error {
 		}
 		// Current epoch but not found: already returned (idempotent)
 		return nil
+	}
+
+	if err := checkStateidOwner(clientID, deleg.ClientID); err != nil {
+		sm.mu.Unlock()
+		return err
 	}
 
 	deleg.StopRecallTimer()

--- a/internal/adapter/nfs/v4/state/delegation_test.go
+++ b/internal/adapter/nfs/v4/state/delegation_test.go
@@ -81,7 +81,7 @@ func TestReturnDelegation_Success(t *testing.T) {
 
 	deleg := sm.GrantDelegation(100, []byte("fh-return-test"), types.OPEN_DELEGATE_READ)
 
-	err := sm.ReturnDelegation(&deleg.Stateid)
+	err := sm.ReturnDelegation(&deleg.Stateid, 0)
 	if err != nil {
 		t.Fatalf("ReturnDelegation: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestReturnDelegation_NotFound(t *testing.T) {
 	stateid := &types.Stateid4{Seqid: 1, Other: other}
 
 	// Not found but current epoch: idempotent success (per Pitfall 3)
-	err := sm.ReturnDelegation(stateid)
+	err := sm.ReturnDelegation(stateid, 0)
 	if err != nil {
 		t.Errorf("ReturnDelegation for unknown but current-epoch stateid should succeed, got %v", err)
 	}
@@ -124,7 +124,7 @@ func TestReturnDelegation_StaleStateid(t *testing.T) {
 
 	stateid := &types.Stateid4{Seqid: 1, Other: other}
 
-	err := sm.ReturnDelegation(stateid)
+	err := sm.ReturnDelegation(stateid, 0)
 	if err == nil {
 		t.Fatal("ReturnDelegation should fail for stale stateid")
 	}
@@ -143,13 +143,13 @@ func TestReturnDelegation_Idempotent(t *testing.T) {
 	deleg := sm.GrantDelegation(100, []byte("fh-idempotent"), types.OPEN_DELEGATE_READ)
 
 	// First return
-	err := sm.ReturnDelegation(&deleg.Stateid)
+	err := sm.ReturnDelegation(&deleg.Stateid, 0)
 	if err != nil {
 		t.Fatalf("first ReturnDelegation: %v", err)
 	}
 
 	// Second return (idempotent) -- should succeed
-	err = sm.ReturnDelegation(&deleg.Stateid)
+	err = sm.ReturnDelegation(&deleg.Stateid, 0)
 	if err != nil {
 		t.Errorf("second ReturnDelegation should be idempotent, got %v", err)
 	}
@@ -424,7 +424,7 @@ func TestReturnDelegation_CleansFileMap(t *testing.T) {
 	_ = sm.GrantDelegation(200, fh, types.OPEN_DELEGATE_READ)
 
 	// Return first delegation
-	err := sm.ReturnDelegation(&deleg1.Stateid)
+	err := sm.ReturnDelegation(&deleg1.Stateid, 0)
 	if err != nil {
 		t.Fatalf("ReturnDelegation: %v", err)
 	}
@@ -975,7 +975,7 @@ func TestRecallTimer_CancelledOnReturn(t *testing.T) {
 	})
 
 	// Return delegation before timer fires (cancels timer)
-	err := sm.ReturnDelegation(&deleg.Stateid)
+	err := sm.ReturnDelegation(&deleg.Stateid, 0)
 	if err != nil {
 		t.Fatalf("ReturnDelegation: %v", err)
 	}
@@ -1028,7 +1028,7 @@ func TestRevokeDelegation_AlreadyReturned(t *testing.T) {
 	deleg := sm.GrantDelegation(100, fh, types.OPEN_DELEGATE_READ)
 
 	// Return first
-	err := sm.ReturnDelegation(&deleg.Stateid)
+	err := sm.ReturnDelegation(&deleg.Stateid, 0)
 	if err != nil {
 		t.Fatalf("ReturnDelegation: %v", err)
 	}
@@ -1090,7 +1090,7 @@ func TestRevokedDelegation_ReturnSucceeds(t *testing.T) {
 	sm.RevokeDelegation(deleg.Stateid.Other)
 
 	// Client sends DELEGRETURN for revoked delegation: should succeed (NFS4_OK)
-	err := sm.ReturnDelegation(&deleg.Stateid)
+	err := sm.ReturnDelegation(&deleg.Stateid, 0)
 	if err != nil {
 		t.Fatalf("ReturnDelegation for revoked delegation should succeed, got %v", err)
 	}
@@ -1426,7 +1426,7 @@ func TestReturnDelegation_ConcurrentRevoke(t *testing.T) {
 
 	go func() {
 		defer wg.Done()
-		_ = sm.ReturnDelegation(&deleg.Stateid)
+		_ = sm.ReturnDelegation(&deleg.Stateid, 0)
 	}()
 
 	go func() {

--- a/internal/adapter/nfs/v4/state/index_consistency_test.go
+++ b/internal/adapter/nfs/v4/state/index_consistency_test.go
@@ -202,7 +202,7 @@ func TestRevokedDelegIndex_SetOnRevokeClearedOnReturn(t *testing.T) {
 
 	// Returning the (revoked) delegation frees it from delegByOther and must
 	// clear the revoked index entry.
-	if err := sm.ReturnDelegation(&deleg.Stateid); err != nil {
+	if err := sm.ReturnDelegation(&deleg.Stateid, 0); err != nil {
 		t.Fatalf("ReturnDelegation: %v", err)
 	}
 	if c := revokedCount(sm, clientID); c != 0 {
@@ -287,7 +287,7 @@ func TestRevokedDelegIndex_NonRevokedFreeDoesNotUnderflow(t *testing.T) {
 	if deleg == nil {
 		t.Fatal("GrantDelegation returned nil")
 	}
-	if err := sm.ReturnDelegation(&deleg.Stateid); err != nil {
+	if err := sm.ReturnDelegation(&deleg.Stateid, 0); err != nil {
 		t.Fatalf("ReturnDelegation: %v", err)
 	}
 	if c := revokedCount(sm, clientID); c != 0 {


### PR DESCRIPTION
Stacked on #2434 → #2429 → #2427. Review those first; this PR reuses `checkStateidOwner`, added in #2429.

## What was wrong

`StateManager.ReturnDelegation(stateid)` looked a delegation up solely by `sm.delegByOther[stateid.Other]`, removed it from both maps and returned success. No client ID parameter, and `deleg.ClientID` never consulted. Its only caller, `handleDelegReturn`, decoded the stateid off the wire and passed it straight through.

So any client could return a delegation it never held: stop the holder's recall timer, flush its directory-delegation CB_NOTIFY batches, and drop its cache authority — with the holder never told. `freeDelegStateidLocked` a few hundred lines away already refuses exactly this (`if deleg.ClientID != clientID` → `NFS4ERR_BAD_STATEID`, RFC 8881 §18.38.3), and OPEN's CLAIM_DELEGATE_CUR path re-checks it explicitly. DELEGRETURN was the one delegation operation that did not.

## The fix

`ReturnDelegation` takes the caller's trusted client ID and calls `checkStateidOwner` — the same helper the I/O-path guard in #2429 uses, which is itself the discipline `freeDelegStateidLocked` established. `handleDelegReturn` passes `ctx.SessionClientID`.

## Premise checks

**Is DELEGRETURN reachable at all?** #2218 established that delegation recall never actually worked against Linux until #2219 — callbacks went out AUTH_NULL and SETCLIENTID discarded `callback_ident`, so CB_RECALL was hardcoded to ident 0 and never matched. If that were still true, this would be a guard on dead code.

It is not. On a Linux 6.8 kernel client against current develop, a full lifecycle was observed — grant, conflict, recall, return:

```
[INFO]  Delegation granted client_id=... deleg_type=1 stateid_seqid=1
[DEBUG] CB_RECALL sent successfully client_id=... deleg_type=1
[DEBUG] NFSv4 DELEGRETURN stateid_seqid=1 client=...
[DEBUG] NFSv4 COMPOUND op dispatched op_index=2 opcode=8 op_name=DELEGRETURN status=0
```

The path is live. The same sequence runs identically on the post-fix build, so the guard costs the legitimate flow nothing.

**But there is a second finding that changes what this PR is worth today.**

Delegations are granted **only on NFSv4.0**. `ShouldGrantDelegation` refuses unless `client.CBPathUp` is true, and `CBPathUp` is assigned true in exactly one place in the tree — `ConfirmClientID` in `state/manager.go`, the SETCLIENTID_CONFIRM path, which is v4.0-only. Nothing in the v4.1 EXCHANGE_ID / CREATE_SESSION path sets it. Empirically, the same client that gets `delegation=1` on a v4.0 mount gets `delegation=0` on every OPEN over v4.1.

And `ctx.SessionClientID` is zero on v4.0, so the guard is skipped there.

**The guard is therefore enforced on the minor versions where delegations are never granted, and inert on the one where they are.** It is correct, it matches the settled design, and it protects nothing in practice until one of the two ends closes. Both are filed:

- #2436 — NFSv4.1/4.2 never grants a delegation (CBPathUp only set on the v4.0 path)
- #2437 — NFSv4.0 has no trusted client identity, so every stateid-ownership guard is a no-op there

Binding v4.0 connections to a clientid is not attempted here — deliberately, and #2437 records the reasoning. What v4.0 does after this PR is what RFC 7530 leaves a server with: no `clientid4` on DELEGRETURN, no session to derive one from, so the stateid stays a bearer token. That is documented on `ReturnDelegation`, on `handleDelegReturn`, and asserted by a test rather than left implicit.

## Tests

`TestHandleDelegReturn_CrossClient` drives the handler, not just the state manager, so it covers the `ctx.SessionClientID` wiring as well as the check. Three rows over one axis — the caller's client ID — each asserting both the status and the number of delegations left on the file:

| caller | status | delegations after |
| --- | --- | --- |
| another client | `NFS4ERR_BAD_STATEID` | 1 |
| the holding client | `NFS4_OK` | 0 |
| no client identity (NFSv4.0) | `NFS4_OK` | 0 |

The delegation count is what makes the first row mean something: a fix that changed the status code while still revoking would pass a status-only assertion. Checking it on the success rows too proves those genuinely removed the delegation rather than being refused for some other reason. The v4.0 row keeps the version-scoping visible in the test suite rather than as a claim in a comment.

Reverting the client ID passed to `checkStateidOwner` to a literal zero makes it fail:

```
--- FAIL: TestHandleDelegReturn_CrossClient/another_client_is_refused
    status = 0, want 10025
    delegations after DELEGRETURN = 0, want 1
```

Closes #2396
