### PR TITLE
ci(lint): stop restoring the golangci-lint analysis cache

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -96,6 +96,12 @@ jobs:
         with:
           version: v2.12.2
           args: --timeout=5m
+          # Analyse from scratch every run. The restored analysis cache carries
+          # staticcheck's per-package facts, and a stale entry loses the fact
+          # that `t.Fatal` never returns — SA5011 then reports the dereference
+          # after a nil guard as reachable, on files the diff never touched.
+          # A cold analysis recomputes the facts and costs about a minute.
+          skip-cache: true
           # Skip the action's online `config verify` — it fetches the config
           # JSON schema over the network and times out intermittently, failing
           # the job for reasons unrelated to the diff. golangci-lint still


### PR DESCRIPTION
Fixes #2433.

`golangci-lint` is red on develop and on every open PR with six SA5011
findings in two test files that none of those PRs touch — including a
docs-only PR. Every site is the same correct shape:

```go
if result == nil {
    t.Fatal("expected non-nil result")
}
if result.User == nil {   // SA5011 flags this
```

`t.Fatal` calls `runtime.Goexit`, so the dereference is unreachable. The
findings are false positives.

## Root cause

The restored **golangci-lint analysis cache**. It stores staticcheck's
per-package facts; a stale entry no longer carries the "does not return"
fact for `(*testing.common).Fatal`, so SA5011 treats the guarded
dereference as reachable.

The single-variable test is [#2435](https://github.com/marmos91/dittofs/pull/2435),
a probe branched from `4c87a857b` — the develop commit whose `golangci-lint`
job is red, reproducibly. It changes nothing but `skip-cache: true`:

| | tree | Go build cache (setup-go) | analysis cache | result |
|---|---|---|---|---|
| develop `4c87a857b` | red tree | hit `a3e51475` | hit `dc24b537` | **6 SA5011** |
| probe `9bf0bece` | same tree | hit `a3e51475` | **skipped** | **0 issues** |

The Go build cache is identical in both, so it is exonerated; the analysis
cache is the only thing that moved.

Two things the eliminated hypotheses cost, recorded so they are not retried:

- **Not the toolchain.** Reproduced clean under Go 1.25.14 — the exact CI
  patch version — both locally and in a `golang:1.25.14` Linux container
  running the official `golangci-lint v2.12.2` release binary. 0 issues in
  both, with a cold and with a warm Go build cache.
- **Not the base commit.** #2425 is based on `8aa32ed7`, the last green
  develop run. Same tree, same go.sum, same linter — green there because
  that run was the only one with no restored cache at all.

## The change

One line: `skip-cache: true` on `golangci-lint-action`. It disables both
restore and save, so the poisoned entry also stops propagating.

Cost is about a minute: the last cold run took 133s, the probe 134s, warm
runs 50–120s. Cheap next to every PR being red.

## Alternatives rejected

- **`//nolint:staticcheck`** — silences a linter bug at six call sites and
  leaves the next occurrence to be rediscovered.
- **Rewriting the guards** (`require.NotNil`, an `else` branch) — edits
  correct test code to satisfy a false positive.
- **`cache-invalidation-interval: 1`** — shrinks the window, still restores
  stale facts within it.

## Note for whoever picks this up

The poisoned entry is live in the develop cache scope, so open PRs stay red
until they carry this change. Deleting the `golangci-lint.cache-Linux-*`
caches unblocks them immediately — not done here, since #2435's evidence
rests on them.
