### PR TITLE
fix(ci): analyse cold so a bumped go.sum cannot poison the lint cache

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -96,6 +96,16 @@ jobs:
         with:
           version: v2.12.2
           args: --timeout=5m
+          # Analyse cold every run. The action's cache key covers go.sum, but
+          # its restore-key fallback does not: when a dependency bump changes
+          # go.sum the run misses its own key, restores the pre-bump analysis
+          # cache, and then saves a fact set built from it under the new key.
+          # Every later run gets an exact hit on that entry, and staticcheck
+          # loses the cross-package fact that t.Fatal never returns — which
+          # turns every `if x == nil { t.Fatal(...) }` guard into a spurious
+          # SA5011 nil-dereference report. Restoring is what breaks it, so the
+          # cache is skipped rather than pinned: costs ~20s (112s -> 134s).
+          skip-cache: true
           # Skip the action's online `config verify` — it fetches the config
           # JSON schema over the network and times out intermittently, failing
           # the job for reasons unrelated to the diff. golangci-lint still


### PR DESCRIPTION
`develop` has failed `golangci-lint` since `4c87a857b`, blocking every open PR. Six SA5011
"possible nil pointer dereference" findings, all behind correct guards.

## The findings are false positives

Three sites, all the canonical shape:

```go
if result == nil {
    t.Fatal("expected non-nil result")
}
if result.IsGuest { ... }
```

`t.Fatal` calls `runtime.Goexit` and never returns, so the dereference is unreachable when
nil. staticcheck normally knows this. **The code is correct and is not changed here.**

## Root cause

The transition is not a source change — it is `8aa32ed7f`, the go-dependencies bump (#2419).
Every green run is before it, every red at or after:

| run | golangci cache key | size | result |
| --- | --- | --- | --- |
| `09d603415` | `…2957-48cdea3b` (primary hit) | 2,674,121 B | green |
| `8aa32ed7f` (bump) | `…2957-48cdea3b` (**restore-key** hit) | 2,674,121 B | green |
| `4c87a857b` | `…2957-dc24b537` (primary hit) | **2,170,079 B** | red |

The action's cache key covers `go.sum`; its restore-key fallback does not. The bump changed
`go.sum`, so the bump run's own primary key became `dc24b537`. Its log shows `Cache is not
found`, then `Cache hit for restore-key: …48cdea3b` — it restored the **pre-bump** analysis
cache, ran green on those stale-but-complete facts, and saved a fact set built from them
under the new key at half a megabyte smaller. Every run since sits on the new `go.sum`, gets
an exact hit on that entry, and staticcheck loses the cross-package fact that `t.Fatal` never
returns.

`setup-go`'s key moves at the same point (`3cd12adb` → `a3e51475`), both on go1.25.14 — the
same `go.sum` change showing through.

## Why skip the cache rather than pin anything

**This fires on every `go.sum` change, not just this one.** Each bump run misses its primary
key, restores a pre-bump cache through the fallback, and saves an inconsistent one under the
new key. The restore-key fallback is the defect, and it is not configurable — so the fix is
to stop restoring.

Cost, measured: **112s warm → 134s cold, about +20s (~18%)** on the lint job. Deliberate trade.

## Status: this is now preventive, not unblocking

**The immediate failure is already gone.** The develop-scoped cache entry was deleted manually at
~08:57Z, which unblocked the queue straight away — runs after that point are green *with caching
still enabled*, because they find nothing to restore. Both the poisoned `dc24b537` and the good
`48cdea3b` now return `total_count=0` on develop.

So this PR does not fix a currently-red `develop`. It prevents the **next** occurrence, which the
mechanism above makes certain: the next `go.sum` bump repeats the same miss → stale restore → save
sequence. Manual deletion is a 30-second remediation *once you know the cause*, and hours of
diagnosis before that; meanwhile every PR is blocked with a non-obvious symptom. That is the trade
this PR buys for ~20s per lint run, and it is worth stating plainly rather than implying urgency
that no longer exists.

## Verification — the `skip-cache` A/B has exactly one clean cell

For the narrow claim *"skipping the cache fixes it"*, only the probe is uncontaminated by the manual
deletion. (The mechanism itself has stronger evidence — see the next section.)

| evidence | golangci window | verdict |
| --- | --- | --- |
| **Probe #2435** — `skip-cache: true` sole change, off red `4c87a857b` | 08:43:59 → 08:46:13 | **before** the deletion, poisoned entry present and skipped → **green**. Valid. |
| PR head `7a6362cd6` logging `Cache not found` | 08:56:42 → 08:59:03 | **coincides** with the deletion; its miss was probably *caused* by it. Confounded. |
| This PR's own lint run (green, 2m13s) | 09:05:56 → 09:08:09 | **after** the deletion. Proves nothing — cached runs are green now too. Confounded. |

I originally listed all three as independent confirmations. Two of them are not, and the timings
above are why. The mechanism rests on the key/size forensics, not on the pass count.

Independent corroboration that does hold, from another session's logs pulled before this analysis:
a run restoring `48cdea3b` reported **no SA5011**; every run hitting `dc24b537` reported all six. And
`dc24b537` was written from three different source trees, confirming the key tracks `go.sum` rather
than content.

**Not** an argument from cache size, and an earlier version of this body wrongly made one. Three
entries written *cold* by runs that reported 0 issues are ~1.18 MB — smaller than the poisoned
2,170,079 B — so size tracks how many runs have chained onto an entry, not fact completeness. Size is
useful only to show two entries differ in content, never to show one is truncated. The diagnostic to
hand someone is **the key on the restore line, and whether the run's own `go.sum` matches the key it
hit**.

## The controlled comparison: same key, opposite outcomes

The strongest cell arrived last, and it isolates provenance by holding the key fixed. #2425's lint
run (34207010996) restored **the same key `dc24b537`** — but the PR-scoped copy, 1,177,678 B, written
by a post-purge run that had restored nothing and analysed cold — and **passed, 0 issues**.

| entry under key `dc24b537` | written by | size | result on restore |
| --- | --- | --- | --- |
| develop-scoped (now purged) | a run that restored a **stale** pre-bump cache | 2,170,079 B | **6x SA5011** |
| `refs/pull/2425/merge` | a run that restored **nothing** (cold) | 1,177,678 B | **0 issues** |

Identical cache key, opposite outcomes. So the defect is not the key, not the cache size, and not
caching as such — it is **an entry whose facts were computed on top of a stale restore**. That is
exactly the chain the restore-key fallback creates on every `go.sum` change, and skipping the restore
is what breaks the chain. It also settles the size question independently: the *smaller* entry is the
good one.

## Eliminated

Stale check runs; my own diff; build tags; the `go` directive; the merge commit; **toolchain drift**
(the green and both reds all ran go1.25.14 with lint v2.12.2); and a local warm-vs-cold cache, which
does not reproduce on darwin/arm64 — green both ways.

## Note for whoever hits the next bump

Three things not reconstructible from the diff.

The cancelled run at 08:10 shares the same post-bump key and its logs are unavailable, so it cannot
be fully excluded as the poisoner instead of the bump run — both are post-bump runs writing an
incomplete fact set under the same key.

Cache reads are scoped to the run's own ref plus the default branch, so a PR-written entry never
reaches another PR; only a develop-written one propagates. To reproduce this deliberately you have
to write the entry from develop. It also means **a green lint on a PR head is not evidence the
problem is gone** — that ref may simply not see the entry.

And **every** workflow in `.github/workflows/` gates on `pull_request: branches: [develop, main]`,
so a PR based on another PR branch runs *no CI at all* — not merely no lint. A stacked PR's clean
check list is an empty set, not a pass; it gets its first CI only when its base becomes develop.

Closes #2433
