### PR TITLE
ci: retry the binaries download once after an artifact-service blip

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -330,6 +330,22 @@ jobs:
           sudo apt-get install -y nfs-common
 
       - name: Download binaries
+        id: download-binaries
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: dfs-binaries
+
+      # The artifact service refuses for a few seconds at a time, long enough
+      # to fail two sibling jobs at once while others pull the same artifact
+      # minutes either side and succeed. One paused retry covers that window,
+      # and an artifact that genuinely is not there still fails the job.
+      - name: Pause before retrying the binaries download
+        if: steps.download-binaries.outcome == 'failure'
+        run: sleep 20
+
+      - name: Download binaries (second attempt)
+        if: steps.download-binaries.outcome == 'failure'
         uses: actions/download-artifact@v8
         with:
           name: dfs-binaries

--- a/.github/workflows/nfs-pynfs.yml
+++ b/.github/workflows/nfs-pynfs.yml
@@ -185,6 +185,22 @@ jobs:
         uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: Download binaries
+        id: download-binaries
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: dfs-binaries
+
+      # The artifact service refuses for a few seconds at a time, long enough
+      # to fail two sibling jobs at once while others pull the same artifact
+      # minutes either side and succeed. One paused retry covers that window,
+      # and an artifact that genuinely is not there still fails the job.
+      - name: Pause before retrying the binaries download
+        if: steps.download-binaries.outcome == 'failure'
+        run: sleep 20
+
+      - name: Download binaries (second attempt)
+        if: steps.download-binaries.outcome == 'failure'
         uses: actions/download-artifact@v8
         with:
           name: dfs-binaries


### PR DESCRIPTION
Two `pynfs v4.0` jobs failed at the **"Download binaries"** step on #2443 while nothing was wrong
with the artifact:

- `Build Binaries` succeeded and `dfs-binaries` was present on the run
- both `pynfs v4.1` jobs downloaded that same artifact successfully, minutes either side
- `needs: [matrix, build, grading]` is correctly declared, and the build finished **eleven minutes**
  before those jobs started, so it was not a race
- both failures re-ran clean with no code change

That is the artifact service refusing for a few seconds at a time. One brief window cost two full
conformance jobs.

## What this does

Adds a single paused retry to the two places that download `dfs-binaries` — `nfs-pynfs.yml` and
`conformance.yml`, which had byte-identical steps.

**The happy path is unchanged.** The first attempt is the same first-party action with the same
inputs; `continue-on-error` only suppresses the *job* failure so `outcome` can be tested. If the
first attempt succeeds, both new steps skip. If it fails, the job pauses 20s and tries once more,
and a second failure fails the job as before — an artifact that genuinely is not there still breaks
the build rather than being retried into a confusing timeout.

## Why not a bash retry loop

The house idiom for this is a bash loop with backoff (`integration-tests.yml`, the `docker pull`
retry), and I started there. Doing it that way means replacing `actions/download-artifact` with
`gh run download`, which changes the extract-path semantics (`--dir`) and depends on artifacts of an
*in-progress* run being fetchable. Both are probably fine, but "probably fine" is the wrong risk to
take on a shared CI path whose failure mode is every conformance job breaking at `chmod`. Two steps
that cannot regress the happy path beat one clever step that can.

One retry rather than five for the same reason: the observed window was short enough that sibling
jobs minutes away were unaffected, so a single pause covers it. If these reappear, the loop is the
next move and by then there will be evidence for what backoff it needs.
