### PR TITLE
fix(metadata): make the xattr read-modify-write atomic

### DIFF
--- a/pkg/metadata/store.go
+++ b/pkg/metadata/store.go
@@ -366,6 +366,24 @@ type Transactor interface {
 	WithTransaction(ctx context.Context, fn func(tx Transaction) error) error
 }
 
+// FileRowLocker is implemented by a Transaction that needs an explicit row lock
+// for a read-modify-write of one file's attribute record to serialise against
+// another writer.
+//
+// A backend whose transaction already serialises such a pair does not implement
+// it: sqlite and badger both refuse the second writer (SQLITE_BUSY, an SSI
+// conflict) and their retry loop re-runs the whole body, so the retried attempt
+// re-reads. Postgres under READ COMMITTED does neither — the second UPDATE
+// waits for the first to commit and then writes a value computed from the
+// pre-image, losing the first write with no error — so it takes the lock before
+// the read instead.
+type FileRowLocker interface {
+	// LockFileRow blocks until this transaction holds the file's row, and
+	// reports nil when the handle names no row: the caller's own read is what
+	// turns that into ErrNotFound.
+	LockFileRow(ctx context.Context, handle FileHandle) error
+}
+
 // RelaxedTransactor is an OPTIONAL store capability (#1573 Wall 1): running a
 // transaction whose commit may become durable with bounded lag instead of an
 // inline fsync. It is intended ONLY for pure-namespace/attr writes

--- a/pkg/metadata/store/postgres/transaction.go
+++ b/pkg/metadata/store/postgres/transaction.go
@@ -388,3 +388,40 @@ func (tx *postgresTransaction) SetFilesystemCapabilities(capabilities metadata.F
 // ============================================================================
 // Transaction Files Operations (additional)
 // ============================================================================
+
+// LockFileRow implements metadata.FileRowLocker so a read-modify-write of one
+// inode's attributes serialises.
+//
+// Postgres runs this transaction at READ COMMITTED, where a bare read followed
+// by an UPDATE loses a concurrent writer's change without reporting anything:
+// the second UPDATE waits for the first to commit and then writes attributes
+// computed from the pre-image it read earlier. Taking the row here, before that
+// read, makes the second transaction wait at the lock instead, so its read sees
+// the committed value. sqlite and badger need no equivalent — they refuse the
+// second writer and their retry re-reads.
+//
+// No rows come back when the handle names nothing; the caller's read reports
+// that as ErrNotFound.
+func (tx *postgresTransaction) LockFileRow(ctx context.Context, handle metadata.FileHandle) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	shareName, id, err := metadata.DecodeFileHandle(handle)
+	if err != nil {
+		return &metadata.StoreError{
+			Code:    metadata.ErrInvalidHandle,
+			Message: "invalid file handle",
+		}
+	}
+
+	const lockQuery = `SELECT 1 FROM inodes WHERE id = $1 AND share_name = $2 FOR UPDATE`
+	var one int
+	if err := tx.tx.QueryRow(ctx, lockQuery, id, shareName).Scan(&one); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		return mapPgError(err, "LockFileRow", "lock inode row")
+	}
+	return nil
+}

--- a/pkg/metadata/storetest/xattr_ops.go
+++ b/pkg/metadata/storetest/xattr_ops.go
@@ -37,6 +37,7 @@ func runXattrOpsTests(t *testing.T, factory StoreFactory) {
 	t.Run("StreamBackedGet", func(t *testing.T) { testXattrStreamBackedGet(t, factory) })
 	t.Run("StreamWinsPrecedence", func(t *testing.T) { testXattrStreamPrecedence(t, factory) })
 	t.Run("ConcurrentDistinctNames", func(t *testing.T) { testXattrConcurrentDistinctNames(t, factory) })
+	t.Run("TransactionIsNotATransactor", func(t *testing.T) { testXattrTransactionIsNotATransactor(t, factory) })
 }
 
 // testReader builds a StreamContentReader serving a fixed value for the given
@@ -398,5 +399,31 @@ func testXattrConcurrentDistinctNames(t *testing.T, factory StoreFactory) {
 	}
 	if accepted == 0 {
 		t.Fatalf("every concurrent SetXattr failed; the case proves nothing about lost updates: %v", errs)
+	}
+}
+
+// testXattrTransactionIsNotATransactor pins the invariant the xattr write path
+// depends on: a Transaction must NOT open transactions of its own.
+//
+// The resolvers wrap themselves in a transaction by asking whether the target
+// is a metadata.Transactor. An in-transaction caller has to fall through that
+// check unwrapped, which it does only because no backend's transaction type
+// carries WithTransaction. Nothing in the type system enforces that — a
+// transaction that grew the method later (savepoints, say) would silently make
+// every in-transaction SetXattr nest, and nesting is implementation-defined
+// per the Transactor doc, so the symptom would be a deadlock or a discarded
+// write rather than a compile error.
+func testXattrTransactionIsNotATransactor(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+
+	err := store.WithTransaction(t.Context(), func(tx metadata.Transaction) error {
+		if _, ok := tx.(metadata.Transactor); ok {
+			t.Error("this backend's Transaction implements Transactor: the xattr resolvers " +
+				"would open a nested transaction for an in-transaction caller")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WithTransaction: %v", err)
 	}
 }

--- a/pkg/metadata/storetest/xattr_ops.go
+++ b/pkg/metadata/storetest/xattr_ops.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"sort"
+	"sync"
 	"testing"
 
 	"github.com/marmos91/dittofs/pkg/metadata"
@@ -34,6 +36,7 @@ func runXattrOpsTests(t *testing.T, factory StoreFactory) {
 	t.Run("MergedListInlinePlusStream", func(t *testing.T) { testXattrMergedList(t, factory) })
 	t.Run("StreamBackedGet", func(t *testing.T) { testXattrStreamBackedGet(t, factory) })
 	t.Run("StreamWinsPrecedence", func(t *testing.T) { testXattrStreamPrecedence(t, factory) })
+	t.Run("ConcurrentDistinctNames", func(t *testing.T) { testXattrConcurrentDistinctNames(t, factory) })
 }
 
 // testReader builds a StreamContentReader serving a fixed value for the given
@@ -319,4 +322,81 @@ func equalNames(got, want []string) bool {
 		}
 	}
 	return true
+}
+
+// testXattrConcurrentDistinctNames pins that a SetXattr which reported success
+// is still readable afterwards, when several writers name *different* xattrs on
+// one file at the same time.
+//
+// The resolver writes the whole EA map: it loads the file, applies the mutation
+// to FileAttr.EAs and persists the file. Two writers that both load before
+// either persists each hold a map missing the other's name, so the second write
+// reinstates the pre-image and silently drops the first — the write returned nil
+// and the value is gone.
+//
+// Asserting on "returned nil implies readable" rather than "all names present"
+// keeps the case mechanism-independent: a backend is free to refuse a colliding
+// write (sqlite's BUSY, a serialization failure), and the caller can retry that.
+// What no backend may do is claim success and lose the value.
+//
+// The case discriminates on the persistent backends, which lose 13-15 of the 16
+// writes when the pair is not atomic. It does not discriminate on the in-memory
+// store: its critical sections are short enough that sixteen writers queued on
+// one mutex serialise by timing rather than by design, so it survives the
+// non-atomic form by luck. The contract is the same for all of them.
+func testXattrConcurrentDistinctNames(t *testing.T, factory StoreFactory) {
+	store := factory(t)
+	ctx := t.Context()
+	root := createTestShare(t, store, "/xattr-concurrent")
+	handle := createTestFile(t, store, "/xattr-concurrent", root, "f.txt", 0o600)
+
+	const writers = 16
+	names := make([]string, writers)
+	for i := range names {
+		names[i] = fmt.Sprintf("attr%02d", i)
+	}
+
+	// One gate released at once, so the loads overlap rather than queueing.
+	var gate sync.WaitGroup
+	var done sync.WaitGroup
+	gate.Add(1)
+	errs := make([]error, writers)
+	for i := range writers {
+		done.Add(1)
+		go func(i int) {
+			defer done.Done()
+			gate.Wait()
+			errs[i] = store.SetXattr(ctx, handle, names[i], []byte("v"))
+		}(i)
+	}
+	gate.Done()
+	done.Wait()
+
+	present, err := store.ListXattr(ctx, handle)
+	if err != nil {
+		t.Fatalf("ListXattr: %v", err)
+	}
+	have := make(map[string]bool, len(present))
+	for _, n := range present {
+		have[n] = true
+	}
+
+	var lost []string
+	accepted := 0
+	for i, name := range names {
+		if errs[i] != nil {
+			continue
+		}
+		accepted++
+		if !have[name] {
+			lost = append(lost, name)
+		}
+	}
+	if len(lost) > 0 {
+		t.Errorf("SetXattr reported success for %d names but %d are absent afterwards: %v\nListXattr returned: %v",
+			accepted, len(lost), lost, present)
+	}
+	if accepted == 0 {
+		t.Fatalf("every concurrent SetXattr failed; the case proves nothing about lost updates: %v", errs)
+	}
 }

--- a/pkg/metadata/xattr.go
+++ b/pkg/metadata/xattr.go
@@ -217,6 +217,24 @@ func ResolveGetXattr(ctx context.Context, files Files, handle FileHandle, name s
 	return nil, false, nil
 }
 
+// withFileTx runs fn against a transactional view of files when files can open
+// a transaction, and against files directly when it cannot.
+//
+// The two write resolvers below are read-modify-writes over the WHOLE EA map:
+// they load the file, apply one mutation to FileAttr.EAs and persist the file.
+// Run outside a transaction, two writers naming different attributes each load
+// before either persists, so each writes back a map missing the other's name
+// and the later write silently drops the earlier one — the call returned nil
+// and the value is gone. Only a store needs the wrap; a Transaction is already
+// inside one and does not implement Transactor, so it falls through.
+func withFileTx(ctx context.Context, files Files, fn func(Files) error) error {
+	tr, ok := files.(Transactor)
+	if !ok {
+		return fn(files)
+	}
+	return tr.WithTransaction(ctx, func(tx Transaction) error { return fn(tx) })
+}
+
 // ResolveSetXattr writes an xattr value into the inline backing when it fits
 // (<= XattrInlineMaxBytes), reusing ApplyEAMutations for case-insensitive,
 // casing-preserving upsert. Oversized values return ErrXattrTooLarge (PR1 does
@@ -225,12 +243,14 @@ func ResolveSetXattr(ctx context.Context, files Files, handle FileHandle, name s
 	if len(value) > XattrInlineMaxBytes {
 		return ErrXattrTooLarge
 	}
-	file, err := files.GetFile(ctx, handle)
-	if err != nil {
-		return err
-	}
-	file.ApplyEAMutations([]EAMutation{{Name: name, Value: value}})
-	return files.UpdateAttrs(ctx, file)
+	return withFileTx(ctx, files, func(files Files) error {
+		file, err := files.GetFile(ctx, handle)
+		if err != nil {
+			return err
+		}
+		file.ApplyEAMutations([]EAMutation{{Name: name, Value: value}})
+		return files.UpdateAttrs(ctx, file)
+	})
 }
 
 // ResolveRemoveXattr removes an xattr from the inline backing. Removing a name
@@ -240,15 +260,17 @@ func ResolveSetXattr(ctx context.Context, files Files, handle FileHandle, name s
 // backings removes only the inline copy (the stream entity is untouched), which
 // then makes the stream copy visible per the stream-wins precedence.
 func ResolveRemoveXattr(ctx context.Context, files Files, handle FileHandle, name string) error {
-	file, err := files.GetFile(ctx, handle)
-	if err != nil {
-		return err
-	}
-	if _, found := file.LookupEA(name); !found {
-		return &StoreError{Code: metaerrors.ErrNotFound, Message: "xattr not found"}
-	}
-	file.ApplyEAMutations([]EAMutation{{Name: name, Delete: true}})
-	return files.UpdateAttrs(ctx, file)
+	return withFileTx(ctx, files, func(files Files) error {
+		file, err := files.GetFile(ctx, handle)
+		if err != nil {
+			return err
+		}
+		if _, found := file.LookupEA(name); !found {
+			return &StoreError{Code: metaerrors.ErrNotFound, Message: "xattr not found"}
+		}
+		file.ApplyEAMutations([]EAMutation{{Name: name, Delete: true}})
+		return files.UpdateAttrs(ctx, file)
+	})
 }
 
 // ResolveListXattr returns every xattr name on the file, merged from both

--- a/pkg/metadata/xattr.go
+++ b/pkg/metadata/xattr.go
@@ -227,12 +227,21 @@ func ResolveGetXattr(ctx context.Context, files Files, handle FileHandle, name s
 // and the later write silently drops the earlier one — the call returned nil
 // and the value is gone. Only a store needs the wrap; a Transaction is already
 // inside one and does not implement Transactor, so it falls through.
-func withFileTx(ctx context.Context, files Files, fn func(Files) error) error {
+func withFileTx(ctx context.Context, files Files, handle FileHandle, fn func(Files) error) error {
 	tr, ok := files.(Transactor)
 	if !ok {
 		return fn(files)
 	}
-	return tr.WithTransaction(ctx, func(tx Transaction) error { return fn(tx) })
+	return tr.WithTransaction(ctx, func(tx Transaction) error {
+		// Before the read, so the value the body computes is the committed one
+		// on a backend that neither refuses nor retries the second writer.
+		if locker, ok := tx.(FileRowLocker); ok {
+			if err := locker.LockFileRow(ctx, handle); err != nil {
+				return err
+			}
+		}
+		return fn(tx)
+	})
 }
 
 // ResolveSetXattr writes an xattr value into the inline backing when it fits
@@ -243,7 +252,7 @@ func ResolveSetXattr(ctx context.Context, files Files, handle FileHandle, name s
 	if len(value) > XattrInlineMaxBytes {
 		return ErrXattrTooLarge
 	}
-	return withFileTx(ctx, files, func(files Files) error {
+	return withFileTx(ctx, files, handle, func(files Files) error {
 		file, err := files.GetFile(ctx, handle)
 		if err != nil {
 			return err
@@ -260,7 +269,7 @@ func ResolveSetXattr(ctx context.Context, files Files, handle FileHandle, name s
 // backings removes only the inline copy (the stream entity is untouched), which
 // then makes the stream copy visible per the stream-wins precedence.
 func ResolveRemoveXattr(ctx context.Context, files Files, handle FileHandle, name string) error {
-	return withFileTx(ctx, files, func(files Files) error {
+	return withFileTx(ctx, files, handle, func(files Files) error {
 		file, err := files.GetFile(ctx, handle)
 		if err != nil {
 			return err


### PR DESCRIPTION
Closes #2454

## The bug

`ResolveSetXattr` / `ResolveRemoveXattr` are read-modify-writes over the **whole** EA map:
load the file, apply one mutation to `FileAttr.EAs`, persist the file. Nothing wraps that pair
in a transaction on the store path, so two writers naming *different* attributes on one file
each load before either persists, and the later write reinstates a pre-image missing the
other's name.

**The call returns `nil` and the value is gone.** No error reaches the client.

This is reachable in production: `Service.SetXattr` passes the *store* to the resolver
(`pkg/metadata/xattr.go`), and the NFSv4 handlers call it — `setxattr.go:113`,
`removexattr.go:79`. It predates the `store/sql` unification and affects all four backends.

## Measured, before the fix

Sixteen writers, sixteen distinct names, one file:

| backend | names reported written | absent afterwards |
| --- | ---: | ---: |
| badger | 16 | **14** |
| badger (relaxed durability) | 16 | **15** |
| sqlite | 16 | **13** |
| memory | 16 | 0 — see below |

## The fix, part one: a transaction

The resolvers run inside a transaction when the target can open one:

```go
tr, ok := files.(Transactor)
if !ok {
    return fn(files)
}
return tr.WithTransaction(ctx, func(tx Transaction) error { return fn(tx) })
```

`Transaction` does not include `WithTransaction` and no concrete transaction type defines one
(checked), so an in-transaction caller falls through unwrapped and cannot nest. Because every
backend's store method delegates to the shared resolver, this covers all four without touching
any of them.

## Test

`storetest` gains `XattrOps/ConcurrentDistinctNames`, asserting **a write that reported success
is readable afterwards** — not "all sixteen present". A backend may legitimately refuse a
colliding write (sqlite BUSY, a serialization failure) and the caller can retry; what none may do
is claim success and lose the value. It also fails if *every* write errored, so it cannot pass by
proving nothing.

**It does not discriminate on the memory store**, and the comment says so: sixteen writers queued
on one short critical section serialise by timing, so memory survives the non-atomic form by luck
rather than design. It had the same bug shape and is fixed by the same change.

## The fix, part two: postgres needs a row lock

**The transaction wrap alone does not fix postgres, and I claimed it would.** CI's integration
suite caught it: 13 of 16 names still lost with the wrap in place.

Under READ COMMITTED the second writer's `UPDATE` waits for the first to commit and then writes
attributes computed from the pre-image it already read. Nothing errors, nothing retries, the write
is lost. sqlite and badger were never fixed by the wrap either — they were already correct for a
different reason: each *refuses* the second writer (`SQLITE_BUSY`, an SSI conflict) and the retry
loop re-runs the body, so the retried attempt re-reads.

So `metadata.FileRowLocker` is an optional interface a `Transaction` implements when it needs an
explicit row lock for that pair to serialise. Only the postgres transaction does, taking the row
with `SELECT 1 FROM inodes WHERE id = $1 AND share_name = $2 FOR UPDATE` before the read — the
same shape `UpdateAttrs` already uses in its leading CTE. It is taken first and covers one row, so
it introduces no lock-ordering hazard.

## Verification

- Fails on badger + sqlite before the change, passes after.
- Postgres, against a local postgres 16: **14 of 16 names lost with `LockFileRow` removed**, green
  with it. The lock is load-bearing, not decoration.
- Full postgres integration suite (`-tags=integration`, 78s): green.
- `-race` on the xattr suite across memory/badger/sqlite: clean.
- Full `./pkg/metadata/store/...` conformance green (badger, memory, sqlite, postgres units, sql).
- `golangci-lint run pkg/metadata/...`: 0 issues.

All four backends verified, postgres included — see below.

## Not in scope

`xattr.go` is still duplicated verbatim between the two dialect packages (52/52, receiver names
only), as are `clients.go` and `client_recovery.go` — about 190 lines. Merging them onto `Core`
was previously hazardous precisely because these bodies span more than one statement; now that
the resolver owns the transaction, that objection is gone. Left as a follow-up.