### PR TITLE
docs(nfs): document the write-session change-attribute freeze instead of unfreezing it

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -736,8 +736,12 @@ common case is one writer per file — and it is why the pynfs `WRT18` case is
 listed as a documented divergence rather than a bug. Applications that need two
 clients to observe each other's writes to the *same* file should coordinate
 through locking (NFSv4 in-protocol locks, or NLM over NFSv3) rather than by
-polling attributes. Once the writer stops and its pending metadata is committed,
-timestamps and `change` advance normally and all clients converge.
+polling attributes.
+
+The window is exactly the open write session. Ending it commits the frozen
+timestamp rather than a fresh one, so `change` does not jump at commit time
+either — it advances again on the first write of the *next* session, which
+carries a current timestamp.
 
 ### SMB Client Limitations
 

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -706,6 +706,34 @@ hole until written) and grows the file size, but does **not** pre-reserve space
 — an out-of-space condition surfaces on the eventual write, exactly as for an
 ordinary sparse file.
 
+#### Concurrent Writers and the Change Attribute
+
+| Status | Reason |
+|--------|--------|
+| NFSv4: `change` does not advance during another client's write session | Timestamps are held stable for the duration of a write session |
+
+While a client is writing to a file, DittoFS holds that file's `mtime` and
+`ctime` at the value from the first write of the session instead of advancing
+them on every WRITE. The Linux NFS client keys its page cache on
+`(mtime, ctime, size)` and drops the cache whenever the timestamps move, so
+without this a client would invalidate its own cache on each write it had just
+issued.
+
+The freeze is per file, not per client. NFSv4's `change` attribute is derived
+from `ctime`, so for as long as a write session is open a *second* client's
+writes to the same file are not observable: the first client re-reads `change`,
+sees the unchanged value, and keeps serving its cached copy. RFC 7530 §5.4 makes
+`change` exactly the attribute a client uses to decide whether its cached copy
+is still valid, so this is a real divergence and not just a coarse timestamp.
+
+This is a deliberate trade — DittoFS is single-node and the overwhelmingly
+common case is one writer per file — and it is why the pynfs `WRT18` case is
+listed as a documented divergence rather than a bug. Applications that need two
+clients to observe each other's writes to the *same* file should coordinate
+through locking (NFSv4 in-protocol locks, or NLM over NFSv3) rather than by
+polling attributes. Once the writer stops and its pending metadata is committed,
+timestamps and `change` advance normally and all clients converge.
+
 ### SMB Client Limitations
 
 #### macOS Mount Owner-Only Access

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -710,7 +710,7 @@ ordinary sparse file.
 
 | Status | Reason |
 |--------|--------|
-| NFSv4: `change` does not advance during another client's write session | Timestamps are held stable for the duration of a write session |
+| NFSv4: `change` is stable within a write session | Timestamps are frozen per session, and `change` derives from `ctime` |
 
 While a client is writing to a file, DittoFS holds that file's `mtime` and
 `ctime` at the value from the first write of the session instead of advancing

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -723,8 +723,8 @@ The freeze is per file, not per client, and it bites from the *second* write of
 a session onward. NFSv4's `change` attribute is derived from `ctime`, so the
 first write of a session does move `change` and is seen — but every later write
 in that same session leaves it untouched. A second client that noticed the first
-write, refetched the file and re-cached it will then keep serving that copy no
-matter how much more the writer changes.
+write, refetched the file and re-cached it will then keep serving that copy
+through every later in-place write of that session.
 
 RFC 7530 is specific about why that matters. §10.3.1 has the client revalidate a
 cached file by fetching `change` and comparing it with the cached value, and

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -721,10 +721,15 @@ issued.
 
 The freeze is per file, not per client. NFSv4's `change` attribute is derived
 from `ctime`, so for as long as a write session is open a *second* client's
-writes to the same file are not observable: the first client re-reads `change`,
-sees the unchanged value, and keeps serving its cached copy. RFC 7530 §5.4 makes
+writes to the same file go unannounced: the first client re-reads `change`, sees
+the unchanged value, and keeps serving its cached copy. RFC 7530 §5.4 makes
 `change` exactly the attribute a client uses to decide whether its cached copy
 is still valid, so this is a real divergence and not just a coarse timestamp.
+
+`size` is not frozen, so a second client that *appends* still moves an attribute
+the Linux client watches and may be noticed by luck. A write that overwrites
+bytes in place changes no attribute at all and is invisible until the write
+session ends.
 
 This is a deliberate trade — DittoFS is single-node and the overwhelmingly
 common case is one writer per file — and it is why the pynfs `WRT18` case is

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -724,9 +724,18 @@ a session onward. NFSv4's `change` attribute is derived from `ctime`, so the
 first write of a session does move `change` and is seen — but every later write
 in that same session leaves it untouched. A second client that noticed the first
 write, refetched the file and re-cached it will then keep serving that copy no
-matter how much more the writer changes. RFC 7530 §5.4 makes `change` exactly
-the attribute a client uses to decide whether its cached copy is still valid, so
-this is a real divergence and not merely a coarse timestamp.
+matter how much more the writer changes.
+
+RFC 7530 is specific about why that matters. §10.3.1 has the client revalidate a
+cached file by fetching `change` and comparing it with the cached value, and
+warns implementers off using `time_modify` in its place precisely because
+"[t]he change attribute is guaranteed to change for each update to the file",
+so substituting a timestamp "runs the risk of the client incorrectly marking
+stale data as valid". §5.8.1.4 does allow a server to derive `change` from
+`time_metadata`, but only "if the file system object cannot be updated more
+frequently than the resolution of time_metadata" — and a file under an open
+write session can be. DittoFS is knowingly outside that condition, so this is a
+real divergence rather than merely a coarse timestamp.
 
 `size` is not frozen, so a later write that *extends* the file still moves
 `size`, which the Linux client also watches, and may be noticed on that basis

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -719,17 +719,18 @@ them on every WRITE. The Linux NFS client keys its page cache on
 without this a client would invalidate its own cache on each write it had just
 issued.
 
-The freeze is per file, not per client. NFSv4's `change` attribute is derived
-from `ctime`, so for as long as a write session is open a *second* client's
-writes to the same file go unannounced: the first client re-reads `change`, sees
-the unchanged value, and keeps serving its cached copy. RFC 7530 §5.4 makes
-`change` exactly the attribute a client uses to decide whether its cached copy
-is still valid, so this is a real divergence and not just a coarse timestamp.
+The freeze is per file, not per client, and it bites from the *second* write of
+a session onward. NFSv4's `change` attribute is derived from `ctime`, so the
+first write of a session does move `change` and is seen — but every later write
+in that same session leaves it untouched. A second client that noticed the first
+write, refetched the file and re-cached it will then keep serving that copy no
+matter how much more the writer changes. RFC 7530 §5.4 makes `change` exactly
+the attribute a client uses to decide whether its cached copy is still valid, so
+this is a real divergence and not merely a coarse timestamp.
 
-`size` is not frozen, so a second client that *appends* still moves an attribute
-the Linux client watches and may be noticed by luck. A write that overwrites
-bytes in place changes no attribute at all and is invisible until the write
-session ends.
+`size` is not frozen, so a later write that *extends* the file still moves
+`size`, which the Linux client also watches, and may be noticed on that basis
+alone. A later write that overwrites bytes in place moves no attribute at all.
 
 This is a deliberate trade — DittoFS is single-node and the overwhelmingly
 common case is one writer per file — and it is why the pynfs `WRT18` case is

--- a/pkg/metadata/pending_writes.go
+++ b/pkg/metadata/pending_writes.go
@@ -108,7 +108,7 @@ func (t *PendingWritesTracker) RecordWrite(handle FileHandle, intent *WriteOpera
 		// The stable mtime/ctime it buys one writer also holds the NFSv4 change
 		// attribute still, since that attribute is encoded from ctime. So from
 		// the second write of a session onward, another client's writes to the
-		// same file go unannounced: MaxSize below still grows, so a write that
+		// same file go unannounced: MaxSize is not frozen, so a write that
 		// extends the file moves size, but one that overwrites in place moves
 		// no attribute at all, and a reader re-reading the change attribute
 		// sees the frozen value and keeps serving its cached copy. Upgrade to a

--- a/pkg/metadata/pending_writes.go
+++ b/pkg/metadata/pending_writes.go
@@ -106,12 +106,15 @@ func (t *PendingWritesTracker) RecordWrite(handle FileHandle, intent *WriteOpera
 		// ponytail: the freeze is keyed by file handle alone, with no notion of
 		// which client wrote, so it applies to every client at once. The stable
 		// mtime/ctime it buys one writer also holds the NFSv4 change attribute
-		// still (that attribute is encoded from ctime), so while a write session
-		// is open a second client's writes to the same file are unobservable: a
-		// reader re-reading the change attribute sees the frozen value and keeps
-		// serving its cached copy. Upgrade to a per-client freeze — the writing
-		// client sees its own stable value while other clients observe the real
-		// one — if concurrent writers to a single file become a case to serve.
+		// still, since that attribute is encoded from ctime. So while a write
+		// session is open, a second client's writes to the same file go
+		// unannounced: MaxSize below still grows, so an appending writer moves
+		// size, but a write that overwrites in place changes no attribute at
+		// all, and a reader re-reading the change attribute sees the frozen
+		// value and keeps serving its cached copy. Upgrade to a per-client
+		// freeze — the writing client sees its own stable value while other
+		// clients observe the real one — if concurrent writers to a single
+		// file become a case to serve.
 		if state.LastMtime.IsZero() {
 			state.LastMtime = intent.NewMtime
 		}

--- a/pkg/metadata/pending_writes.go
+++ b/pkg/metadata/pending_writes.go
@@ -103,18 +103,18 @@ func (t *PendingWritesTracker) RecordWrite(handle FileHandle, intent *WriteOpera
 		// keys its cache on (mtime, ctime, size) and invalidates it if mtime
 		// changes between WRITEs.
 		//
-		// ponytail: the freeze is keyed by file handle alone, with no notion of
-		// which client wrote, so it applies to every client at once. The stable
-		// mtime/ctime it buys one writer also holds the NFSv4 change attribute
-		// still, since that attribute is encoded from ctime. So while a write
-		// session is open, a second client's writes to the same file go
-		// unannounced: MaxSize below still grows, so an appending writer moves
-		// size, but a write that overwrites in place changes no attribute at
-		// all, and a reader re-reading the change attribute sees the frozen
-		// value and keeps serving its cached copy. Upgrade to a per-client
-		// freeze — the writing client sees its own stable value while other
-		// clients observe the real one — if concurrent writers to a single
-		// file become a case to serve.
+		// ponytail: this state is keyed by file handle alone, with no notion of
+		// which client wrote, so the freeze applies to every client at once.
+		// The stable mtime/ctime it buys one writer also holds the NFSv4 change
+		// attribute still, since that attribute is encoded from ctime. So from
+		// the second write of a session onward, another client's writes to the
+		// same file go unannounced: MaxSize below still grows, so a write that
+		// extends the file moves size, but one that overwrites in place moves
+		// no attribute at all, and a reader re-reading the change attribute
+		// sees the frozen value and keeps serving its cached copy. Upgrade to a
+		// per-client freeze — the writing client sees its own stable value
+		// while other clients observe the real one — if concurrent writers to
+		// a single file become a case to serve.
 		if state.LastMtime.IsZero() {
 			state.LastMtime = intent.NewMtime
 		}

--- a/pkg/metadata/pending_writes.go
+++ b/pkg/metadata/pending_writes.go
@@ -102,6 +102,16 @@ func (t *PendingWritesTracker) RecordWrite(handle FileHandle, intent *WriteOpera
 		// critical for NFS client page cache stability. The Linux NFS client
 		// keys its cache on (mtime, ctime, size) and invalidates it if mtime
 		// changes between WRITEs.
+		//
+		// ponytail: the freeze is keyed by file handle alone, with no notion of
+		// which client wrote, so it applies to every client at once. The stable
+		// mtime/ctime it buys one writer also holds the NFSv4 change attribute
+		// still (that attribute is encoded from ctime), so while a write session
+		// is open a second client's writes to the same file are unobservable: a
+		// reader re-reading the change attribute sees the frozen value and keeps
+		// serving its cached copy. Upgrade to a per-client freeze — the writing
+		// client sees its own stable value while other clients observe the real
+		// one — if concurrent writers to a single file become a case to serve.
 		if state.LastMtime.IsZero() {
 			state.LastMtime = intent.NewMtime
 		}

--- a/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
+++ b/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
@@ -68,5 +68,5 @@ flake worth re-running.
 | OPDG3 | bug | bad/old/stale stateid accepted | #2341 |
 | OPDG6 | bug | bad/old/stale stateid accepted | #2341 |
 | OPDG7 | bug | bad/old/stale stateid accepted | #2341 |
-| WRT18 | proto | write-session timestamp freeze holds ctime, so change cannot advance | - |
+| WRT18 | feature | write-session freeze deliberately holds ctime, so change cannot advance | - |
 | RPLY8 | suite | knfsd fails this too — replay of a waiting LOCKU | - |

--- a/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
+++ b/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
@@ -68,5 +68,5 @@ flake worth re-running.
 | OPDG3 | bug | bad/old/stale stateid accepted | #2341 |
 | OPDG6 | bug | bad/old/stale stateid accepted | #2341 |
 | OPDG7 | bug | bad/old/stale stateid accepted | #2341 |
-| WRT18 | bug | change attribute frozen across a write session | #2382 |
+| WRT18 | proto | write-session timestamp freeze holds ctime, so change cannot advance | - |
 | RPLY8 | suite | knfsd fails this too — replay of a waiting LOCKU | - |


### PR DESCRIPTION
Documents a trade DittoFS already makes, rather than changing it. **No production
behaviour changes here.**

## What the code does

`PendingWritesTracker.RecordWrite` sets `LastMtime` on the first write of a
session and then leaves it alone (`pkg/metadata/pending_writes.go`). That frozen
value is merged over the stored attributes on every read —
`mergePendingWrites` assigns it to **both** `Mtime` and `Ctime`
(`pkg/metadata/service.go:413-415`, mirrored in `GetFileCached`) — and NFSv4's
change attribute is encoded straight from `Ctime`
(`internal/adapter/nfs/v4/attrs/encode.go`, `FATTR4_CHANGE` case).

So the freeze reaches `change`. The tracker is keyed by `handleKey(handle)` — the file handle alone, with no
client identity anywhere in it — so the freeze is per *file*, not per *client*.

Two nuances the docs now state precisely, because the loose version of each is
wrong:

- The freeze bites from the **second** write of a session onward, not the first.
  The first write of a session sets `LastMtime` and so does move `change`; every
  later write in that session leaves it alone. This is exactly the shape of the
  `WRT18` failure — its `chattr1 != chattr2` comparison passes and
  `chattr2 == chattr3` is what fails.
- `MaxSize` is *not* frozen, so a later write that **extends** the file still
  moves `size`, which the Linux client also watches. Only a later write that
  overwrites in place moves no attribute at all.

Ending the session commits the frozen value rather than a fresh one
(`flushPendingWrite` writes `state.LastMtime`), so `change` does not jump at
commit either — the next session's first write is what advances it.

## The issue's RFC citation was wrong, and the right one is sharper

The issue cites RFC 7530 §5.4 for `change` being the cache-validation attribute.
§5.4 is "Classification of Attributes" and says nothing of the kind. The
sections that actually govern this are better for the argument, not worse, so
the FAQ cites them instead:

- **§10.3.1 (Data Caching and OPENs)** is the real cache-validation text: the
  client fetches `change`, compares it with its cached value, and invalidates if
  they differ. It then explicitly cautions implementers against validating with
  `time_modify` instead, because "[t]he change attribute is guaranteed to change
  for each update to the file", and doing so "runs the risk of the client
  incorrectly marking stale data as valid". That is a description of this exact
  divergence.
- **§5.8.1.4 (Attribute 3: change)** does permit deriving `change` from
  `time_metadata` — "but only if the file system object cannot be updated more
  frequently than the resolution of time_metadata". A file under an open write
  session can be, so DittoFS is knowingly outside the condition that would make
  a timestamp-derived `change` conformant.

Both quotes were checked verbatim against the downloaded RFC text rather than
recalled.

## Why this is documented and not fixed

Unfreezing would make every NFSv4 client invalidate its own page cache on each
write it had just issued, in code shared with NFSv3 and SMB — a large
behavioural regression traded for one conformance row. The honest fix is a
per-client freeze (the writer sees its own stable value, other clients observe
the real one), which is a design change with its own investigation. Declining it
here is deliberate.

## knfsd behaves differently — so this is a divergence, not an unsatisfiable test

The repo only allows the `suite` category with knfsd evidence, and
`test/nfs-conformance/pynfs/baseline-knfsd.md` (kernel 6.17.0-1022-azure,
generated 2026-09-03) lists the NFSv4.0 tests the Linux kernel server does not
pass as exactly RPLY5, RPLY6, RPLY7 and RPLY8, out of 589 passed. `WRT18` is not
among them, so knfsd passes it: Linux advances the change attribute across
consecutive WRITEs and does not freeze it. `WRT18` therefore tests something a
server can satisfy, which rules out `suite`.

It also rules out `proto`. That category means "NFSv4 protocol behaviour, not a
server bug" — but the same knfsd evidence disproves it: advancing `change` across
consecutive writes is exactly what the protocol and another server do. What is
left is a deliberate DittoFS choice not to, which is what `feature` labels:
"something DittoFS deliberately does not implement". So the row is `feature`,
with its reason narrowed to name the cause.

For reference, `WRT18` is `st_write.testChangeGranularityWrite`: one COMPOUND
issuing four `WRITE(UNSTABLE4)`s with a GETATTR between each, failing if any two
consecutive `change` values are equal. It is a single-client granularity
assertion; the multi-client coherence consequence is the same root cause seen
from the other side.

## Changes

- `pkg/metadata/pending_writes.go` — a `ponytail:` marker on the freeze naming
  the ceiling (single-writer page-cache stability bought with multi-client
  coherence) and the upgrade path (per-client freeze). Behaviour-only wording.
- `docs/guide/faq.md` — a new "Concurrent Writers and the Change Attribute"
  entry under Known Limitations → NFS Protocol Limitations, matching the
  surrounding status-table-plus-prose style.
- `test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md` — `WRT18` moves from `bug`
  to `feature`, reason narrowed to name the cause, issue column `-` like the
  other non-`bug` row.

## Verification

```
go build ./...            ok
go vet ./pkg/metadata/    ok
gofmt -l                  clean
go test ./pkg/metadata/   ok  (3.6s)

./test/nfs-conformance/pynfs/parse-results_test.sh   PASS: all grading tests passed
./test/common/known-failures_test.sh                 assertions: 15, failures: 0

# the reclassified row still loads with a non-empty reason:
kf_load KNOWN_FAILURES_V40.md -> count=16
kf_is_known WRT18 -> known
kf_reason WRT18 -> [write-session freeze deliberately holds ctime, so change cannot advance]
parse-results.sh <synthetic WRT18 FAILURE> -> exit 0, 'All failures known'
```

## On #2342

Left untouched and **not** referenced by a closing keyword here. Worth flagging
that it is already `CLOSED` — GitHub auto-closed it when PR #2380 merged — so
there is no open tracker for `WRT18` to link. That is why the reclassified row
carries `-` in the Issue column rather than a link to a closed issue.

Closes #2382
