### PR TITLE
fix(nfs/v4): resolve the current-stateid placeholder in OPEN's CLAIM_DELEGATE_CUR

### DIFF
--- a/internal/adapter/nfs/v4/handlers/open.go
+++ b/internal/adapter/nfs/v4/handlers/open.go
@@ -866,10 +866,10 @@ func (h *Handler) handleOpenClaimDelegateCur(
 	seqid, shareAccess, shareDeny uint32,
 	clientID uint64, ownerData []byte,
 ) *types.CompoundResult {
-	// Decode CLAIM_DELEGATE_CUR args: stateid4 + component4. OPEN is a v4.1
-	// operation, so the delegation stateid may be the current-stateid
-	// placeholder naming a stateid an earlier operation in this COMPOUND
-	// returned (RFC 8881 Section 16.2.3.1.2).
+	// Decode CLAIM_DELEGATE_CUR args: stateid4 + component4. OPEN is dispatched
+	// in v4.1 as well as v4.0, so the delegation stateid may be the
+	// current-stateid placeholder naming a stateid an earlier operation in this
+	// COMPOUND returned (RFC 8881 Section 16.2.3.1.2).
 	delegStateid, argStatus := types.DecodeStateidArg(ctx, reader)
 	if argStatus != types.NFS4_OK {
 		return openError(argStatus)

--- a/internal/adapter/nfs/v4/handlers/open.go
+++ b/internal/adapter/nfs/v4/handlers/open.go
@@ -864,10 +864,13 @@ func (h *Handler) handleOpenClaimDelegateCur(
 	seqid, shareAccess, shareDeny uint32,
 	clientID uint64, ownerData []byte,
 ) *types.CompoundResult {
-	// Decode CLAIM_DELEGATE_CUR args: stateid4 + component4
-	delegStateid, err := types.DecodeStateid4(reader)
-	if err != nil {
-		return openError(types.NFS4ERR_BADXDR)
+	// Decode CLAIM_DELEGATE_CUR args: stateid4 + component4. OPEN is a v4.1
+	// operation, so the delegation stateid may be the current-stateid
+	// placeholder naming a stateid an earlier operation in this COMPOUND
+	// returned; decoding it as a literal would reject a legal request.
+	delegStateid, argStatus := types.DecodeStateidArg(ctx, reader)
+	if argStatus != types.NFS4_OK {
+		return openError(argStatus)
 	}
 
 	filename, err := xdr.DecodeString(reader)

--- a/internal/adapter/nfs/v4/handlers/open.go
+++ b/internal/adapter/nfs/v4/handlers/open.go
@@ -786,7 +786,9 @@ func (h *Handler) handleOpenConfirm(ctx *types.CompoundContext, reader io.Reader
 		}
 	}
 
-	// Decode OPEN_CONFIRM4args: stateid4 + seqid
+	// Decode OPEN_CONFIRM4args: stateid4 + seqid. OPEN_CONFIRM exists only in
+	// v4.0, where (seqid 1, all-zeros other) is an ordinary stateid rather than
+	// the current-stateid placeholder, so this decodes literally.
 	stateid, err := types.DecodeStateid4(reader)
 	if err != nil {
 		return &types.CompoundResult{
@@ -867,7 +869,7 @@ func (h *Handler) handleOpenClaimDelegateCur(
 	// Decode CLAIM_DELEGATE_CUR args: stateid4 + component4. OPEN is a v4.1
 	// operation, so the delegation stateid may be the current-stateid
 	// placeholder naming a stateid an earlier operation in this COMPOUND
-	// returned; decoding it as a literal would reject a legal request.
+	// returned (RFC 8881 Section 16.2.3.1.2).
 	delegStateid, argStatus := types.DecodeStateidArg(ctx, reader)
 	if argStatus != types.NFS4_OK {
 		return openError(argStatus)

--- a/internal/adapter/nfs/v4/handlers/open_delegation_test.go
+++ b/internal/adapter/nfs/v4/handlers/open_delegation_test.go
@@ -471,84 +471,60 @@ func TestOpenClaimDelegateCur_EnforcesFilePermissions(t *testing.T) {
 }
 
 // TestOpenClaimDelegateCur_CurrentStateidPlaceholder covers the NFSv4.1
-// current-stateid placeholder — seqid 1 with an all-zeros "other" — appearing
-// as CLAIM_DELEGATE_CUR's delegation stateid. OPEN is a v4.1 operation, so a
-// client may name the stateid an earlier operation in the COMPOUND returned
-// instead of repeating it, and the placeholder has to resolve to the COMPOUND's
-// current stateid before the delegation lookup. Taken literally it is a stateid
-// the server never issued, so a legal OPEN is refused.
+// current-stateid placeholder — seqid 1 with an all-zeros "other" — as
+// CLAIM_DELEGATE_CUR's delegation stateid: it resolves to the COMPOUND's
+// current stateid before the delegation lookup, and with no current stateid
+// set the OPEN is refused rather than falling back to whatever delegation the
+// client happens to hold (RFC 8881 Section 16.2.3.1.2).
 func TestOpenClaimDelegateCur_CurrentStateidPlaceholder(t *testing.T) {
 	placeholder := types.Stateid4{Seqid: 1}
 
-	// v41Context builds the COMPOUND context the placeholder is only meaningful
-	// in: minorversion 1, accepted, with the directory as current filehandle.
-	v41Context := func(rootHandle []byte) *types.CompoundContext {
-		ctx := newRealFSContext(0, 0)
-		ctx.SkipOwnerSeqid = true // v4.1 session
-		ctx.MinorVersion = 1
-		ctx.MinorVersionAccepted = true
-		ctx.CurrentFH = make([]byte, len(rootHandle))
-		copy(ctx.CurrentFH, rootHandle)
-		return ctx
+	tests := []struct {
+		name              string
+		setCurrentStateid bool
+		wantStatus        uint32
+	}{
+		{"resolves to the current stateid", true, types.NFS4_OK},
+		{"refused without a current stateid", false, types.NFS4ERR_BAD_STATEID},
 	}
 
-	t.Run("resolves to the current stateid", func(t *testing.T) {
-		fx := newIOTestFixture(t, "/export")
-		clientA := testClientID(t, fx.handler.StateManager, "deleg-cur-placeholder")
-		fileHandle := fx.createRegularFile(t, fx.rootHandle, "placeholder.txt", 0o644, 0, 0)
-		deleg := fx.handler.StateManager.GrantDelegation(clientA, []byte(fileHandle), types.OPEN_DELEGATE_WRITE)
-		if deleg == nil {
-			t.Fatalf("GrantDelegation returned nil")
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fx := newIOTestFixture(t, "/export")
+			clientA := testClientID(t, fx.handler.StateManager, "deleg-cur-placeholder")
+			fileHandle := fx.createRegularFile(t, fx.rootHandle, "placeholder.txt", 0o644, 0, 0)
+			deleg := fx.handler.StateManager.GrantDelegation(clientA, []byte(fileHandle), types.OPEN_DELEGATE_WRITE)
+			if deleg == nil {
+				t.Fatalf("GrantDelegation returned nil")
+			}
 
-		ctx := v41Context(fx.rootHandle)
-		// As an earlier operation in the COMPOUND returning the delegation
-		// stateid would have left it.
-		ctx.SetCurrentStateid(&deleg.Stateid)
+			// The placeholder is only meaningful in a v4.1 COMPOUND.
+			ctx := newRealFSContext(0, 0)
+			ctx.SkipOwnerSeqid = true // v4.1 session
+			ctx.MinorVersion = 1
+			ctx.MinorVersionAccepted = true
+			ctx.CurrentFH = append([]byte(nil), fx.rootHandle...)
+			if tt.setCurrentStateid {
+				// As an earlier operation in the COMPOUND returning the
+				// delegation stateid would have left it.
+				ctx.SetCurrentStateid(&deleg.Stateid)
+			}
 
-		args := encodeOpenArgsDelegateCur(
-			1,
-			types.OPEN4_SHARE_ACCESS_BOTH,
-			types.OPEN4_SHARE_DENY_NONE,
-			clientA,
-			[]byte("owner-placeholder"),
-			types.OPEN4_NOCREATE,
-			&placeholder,
-			"placeholder.txt",
-		)
+			args := encodeOpenArgsDelegateCur(
+				1,
+				types.OPEN4_SHARE_ACCESS_BOTH,
+				types.OPEN4_SHARE_DENY_NONE,
+				clientA,
+				[]byte("owner-placeholder"),
+				types.OPEN4_NOCREATE,
+				&placeholder,
+				"placeholder.txt",
+			)
 
-		result := fx.handler.handleOpen(ctx, bytes.NewReader(args))
-		if result.Status != types.NFS4_OK {
-			t.Fatalf("OPEN CLAIM_DELEGATE_CUR with the current-stateid placeholder status = %d, want NFS4_OK", result.Status)
-		}
-	})
-
-	t.Run("without a current stateid is refused", func(t *testing.T) {
-		fx := newIOTestFixture(t, "/export")
-		clientA := testClientID(t, fx.handler.StateManager, "deleg-cur-placeholder-unset")
-		fileHandle := fx.createRegularFile(t, fx.rootHandle, "unset.txt", 0o644, 0, 0)
-		deleg := fx.handler.StateManager.GrantDelegation(clientA, []byte(fileHandle), types.OPEN_DELEGATE_WRITE)
-		if deleg == nil {
-			t.Fatalf("GrantDelegation returned nil")
-		}
-
-		// No SetCurrentStateid: the placeholder names a stateid this COMPOUND
-		// does not have, which must not fall back to the delegation the client
-		// happens to hold.
-		args := encodeOpenArgsDelegateCur(
-			1,
-			types.OPEN4_SHARE_ACCESS_BOTH,
-			types.OPEN4_SHARE_DENY_NONE,
-			clientA,
-			[]byte("owner-placeholder-unset"),
-			types.OPEN4_NOCREATE,
-			&placeholder,
-			"unset.txt",
-		)
-
-		result := fx.handler.handleOpen(v41Context(fx.rootHandle), bytes.NewReader(args))
-		if result.Status != types.NFS4ERR_BAD_STATEID {
-			t.Fatalf("OPEN CLAIM_DELEGATE_CUR placeholder with no current stateid status = %d, want NFS4ERR_BAD_STATEID", result.Status)
-		}
-	})
+			result := fx.handler.handleOpen(ctx, bytes.NewReader(args))
+			if result.Status != tt.wantStatus {
+				t.Fatalf("OPEN CLAIM_DELEGATE_CUR with the current-stateid placeholder status = %d, want %d", result.Status, tt.wantStatus)
+			}
+		})
+	}
 }

--- a/internal/adapter/nfs/v4/handlers/open_delegation_test.go
+++ b/internal/adapter/nfs/v4/handlers/open_delegation_test.go
@@ -469,3 +469,86 @@ func TestOpenClaimDelegateCur_EnforcesFilePermissions(t *testing.T) {
 		t.Fatalf("OPEN CLAIM_DELEGATE_CUR status = %d, want NFS4ERR_ACCESS", result.Status)
 	}
 }
+
+// TestOpenClaimDelegateCur_CurrentStateidPlaceholder covers the NFSv4.1
+// current-stateid placeholder — seqid 1 with an all-zeros "other" — appearing
+// as CLAIM_DELEGATE_CUR's delegation stateid. OPEN is a v4.1 operation, so a
+// client may name the stateid an earlier operation in the COMPOUND returned
+// instead of repeating it, and the placeholder has to resolve to the COMPOUND's
+// current stateid before the delegation lookup. Taken literally it is a stateid
+// the server never issued, so a legal OPEN is refused.
+func TestOpenClaimDelegateCur_CurrentStateidPlaceholder(t *testing.T) {
+	placeholder := types.Stateid4{Seqid: 1}
+
+	// v41Context builds the COMPOUND context the placeholder is only meaningful
+	// in: minorversion 1, accepted, with the directory as current filehandle.
+	v41Context := func(rootHandle []byte) *types.CompoundContext {
+		ctx := newRealFSContext(0, 0)
+		ctx.SkipOwnerSeqid = true // v4.1 session
+		ctx.MinorVersion = 1
+		ctx.MinorVersionAccepted = true
+		ctx.CurrentFH = make([]byte, len(rootHandle))
+		copy(ctx.CurrentFH, rootHandle)
+		return ctx
+	}
+
+	t.Run("resolves to the current stateid", func(t *testing.T) {
+		fx := newIOTestFixture(t, "/export")
+		clientA := testClientID(t, fx.handler.StateManager, "deleg-cur-placeholder")
+		fileHandle := fx.createRegularFile(t, fx.rootHandle, "placeholder.txt", 0o644, 0, 0)
+		deleg := fx.handler.StateManager.GrantDelegation(clientA, []byte(fileHandle), types.OPEN_DELEGATE_WRITE)
+		if deleg == nil {
+			t.Fatalf("GrantDelegation returned nil")
+		}
+
+		ctx := v41Context(fx.rootHandle)
+		// As an earlier operation in the COMPOUND returning the delegation
+		// stateid would have left it.
+		ctx.SetCurrentStateid(&deleg.Stateid)
+
+		args := encodeOpenArgsDelegateCur(
+			1,
+			types.OPEN4_SHARE_ACCESS_BOTH,
+			types.OPEN4_SHARE_DENY_NONE,
+			clientA,
+			[]byte("owner-placeholder"),
+			types.OPEN4_NOCREATE,
+			&placeholder,
+			"placeholder.txt",
+		)
+
+		result := fx.handler.handleOpen(ctx, bytes.NewReader(args))
+		if result.Status != types.NFS4_OK {
+			t.Fatalf("OPEN CLAIM_DELEGATE_CUR with the current-stateid placeholder status = %d, want NFS4_OK", result.Status)
+		}
+	})
+
+	t.Run("without a current stateid is refused", func(t *testing.T) {
+		fx := newIOTestFixture(t, "/export")
+		clientA := testClientID(t, fx.handler.StateManager, "deleg-cur-placeholder-unset")
+		fileHandle := fx.createRegularFile(t, fx.rootHandle, "unset.txt", 0o644, 0, 0)
+		deleg := fx.handler.StateManager.GrantDelegation(clientA, []byte(fileHandle), types.OPEN_DELEGATE_WRITE)
+		if deleg == nil {
+			t.Fatalf("GrantDelegation returned nil")
+		}
+
+		// No SetCurrentStateid: the placeholder names a stateid this COMPOUND
+		// does not have, which must not fall back to the delegation the client
+		// happens to hold.
+		args := encodeOpenArgsDelegateCur(
+			1,
+			types.OPEN4_SHARE_ACCESS_BOTH,
+			types.OPEN4_SHARE_DENY_NONE,
+			clientA,
+			[]byte("owner-placeholder-unset"),
+			types.OPEN4_NOCREATE,
+			&placeholder,
+			"unset.txt",
+		)
+
+		result := fx.handler.handleOpen(v41Context(fx.rootHandle), bytes.NewReader(args))
+		if result.Status != types.NFS4ERR_BAD_STATEID {
+			t.Fatalf("OPEN CLAIM_DELEGATE_CUR placeholder with no current stateid status = %d, want NFS4ERR_BAD_STATEID", result.Status)
+		}
+	})
+}


### PR DESCRIPTION
## What was wrong

#2380 routed every stateid-taking NFSv4 operation through `types.DecodeStateidArg`,
which resolves the NFSv4.1 current-stateid placeholder — seqid 1 with an all-zeros
`other` — to the stateid an earlier operation in the same COMPOUND returned
(RFC 8881 §16.2.3.1.2). OPEN's `CLAIM_DELEGATE_CUR` delegation stateid was left on
the plain `types.DecodeStateid4`.

OPEN *is* an NFSv4.1 operation, so a client is entitled to send the placeholder there
rather than repeating a stateid it has already been given. Decoded literally, the
placeholder is a stateid the server never issued, and the delegation lookup refuses a
legal request. On this tree the literal decode answers `NFS4ERR_STALE_STATEID` (10023),
because an all-zeros `other` carries boot epoch 0.

## The fix

One decode site, switched to `DecodeStateidArg` with `argStatus` propagated, matching
the operations #2380 converted:

```go
delegStateid, argStatus := types.DecodeStateidArg(ctx, reader)
if argStatus != types.NFS4_OK {
    return openError(argStatus)
}
```

`DecodeStateidArg` is a no-op for any other stateid, and for every stateid in a v4.0
COMPOUND, so nothing outside the placeholder case changes.

## The other decode site is not a defect

The issue also names `handleOpenConfirm`, which still calls `DecodeStateid4`. That one
is correct as it stands. RFC 8881 removed OPEN_CONFIRM from NFSv4.1, and the dispatcher
enforces that: `OP_OPEN_CONFIRM` is in `v40OnlyOps` (`compound.go:22`), and `dispatchOne`
tests `isV41 && v40OnlyOps[opCode]` *before* it reaches `v40DispatchTable`
(`compound.go:145` vs `164`), so in any v4.1+ COMPOUND the op is intercepted by
`rejectV40OnlyOp` and answered `NFS4ERR_NOTSUPP` — `handleOpenConfirm`'s decode only
ever runs from a v4.0 COMPOUND, where `tracksCurrentStateid()` is false and
`DecodeStateidArg` would be a no-op anyway. It is also registered in no other table
(`register_v40.go:44`). `consumeV40OnlyArgs` decodes it literally for the same reason:
it exists only to advance the XDR stream past a v4.0-only op. Both left alone;
`handleOpenConfirm`'s decode gains a comment saying why it stays literal, so the next
reader does not "fix" it.

## Reachability — this is a latent fix, not a live bug

`CLAIM_DELEGATE_CUR` requires the client to already hold a delegation, and DittoFS
never grants one (#2329); #2218 records that delegation recall never worked against a
Linux client either. So no client reaches this decode today. The path is dead for
reasons unrelated to the decode, and whoever makes it live has no particular reason to
notice the placeholder. Fixing the decode now is unconditional and independently
testable, which is why it is not deferred to #2329.

## Evidence

The new test drives a full v4.1 `CLAIM_DELEGATE_CUR` OPEN through `handleOpen` with the
placeholder as the delegation stateid, against a real metadata/block fixture:

- with the COMPOUND's current stateid set to a granted delegation stateid — as an
  earlier operation returning it would leave it — the OPEN succeeds (`NFS4_OK`);
- with no current stateid set, the placeholder is refused `NFS4ERR_BAD_STATEID` rather
  than silently falling back to a delegation the client happens to hold.

Reverting only the decode (via `go test -overlay`, `DecodeStateidArg` →
`DecodeStateid4`, everything else untouched) fails both cases:

```
--- FAIL: TestOpenClaimDelegateCur_CurrentStateidPlaceholder (0.62s)
    --- FAIL: .../resolves_to_the_current_stateid (0.31s)
        status = 10023, want 0
    --- FAIL: .../refused_without_a_current_stateid (0.31s)
        status = 10023, want 10025
```

10023 is `NFS4ERR_STALE_STATEID`: the literal placeholder's all-zeros `other`
carries boot epoch 0, so the delegation lookup rejects it as stale rather than
resolving it.

`go build ./...`, `go vet ./internal/adapter/nfs/...` and `go test ./internal/adapter/nfs/v4/...`
are green on the branch.

## Noticed, not touched

`CLAIM_DELEG_CUR_FH` (claim type 5) also carries a stateid and is v4.1-only, but OPEN
has no case for it at all — it falls through to `default:` and returns
`NFS4ERR_INVAL` without consuming its args. That is a separate gap from this decode,
and belongs with #2329 rather than here.

Closes #2399
