### PR TITLE
fix(nfsv4): put space_avail/free/total at their RFC 7530 attribute numbers

### DIFF
--- a/internal/adapter/nfs/v4/attrs/encode.go
+++ b/internal/adapter/nfs/v4/attrs/encode.go
@@ -54,16 +54,16 @@ const (
 	FATTR4_OWNER              = 36 // utf8str_mixed: owner name
 	FATTR4_OWNER_GROUP        = 37 // utf8str_mixed: group owner name
 	FATTR4_RAWDEV             = 41 // specdata4: raw device (major/minor)
-	FATTR4_SPACE_USED         = 45 // uint64: disk space used
+	FATTR4_SPACE_AVAIL        = 42 // uint64: space available to the caller in bytes (RFC 7530 Section 5.8.2.28)
+	FATTR4_SPACE_FREE         = 43 // uint64: free filesystem space in bytes (RFC 7530 Section 5.8.2.29)
+	FATTR4_SPACE_TOTAL        = 44 // uint64: total filesystem space in bytes (RFC 7530 Section 5.8.2.30)
+	FATTR4_SPACE_USED         = 45 // uint64: disk space used by this file (RFC 7530 Section 5.8.2.31)
 	FATTR4_TIME_ACCESS        = 47 // nfstime4: last access time
 	FATTR4_TIME_ACCESS_SET    = 48 // settime4: set atime (writable)
 	FATTR4_TIME_METADATA      = 52 // nfstime4: last metadata change time (ctime)
 	FATTR4_TIME_MODIFY        = 53 // nfstime4: last modify time
 	FATTR4_TIME_MODIFY_SET    = 54 // settime4: set mtime (writable)
 	FATTR4_MOUNTED_ON_FILEID  = 55 // uint64: fileid of mounted-on dir
-	FATTR4_SPACE_TOTAL        = 59 // uint64: total filesystem space in bytes (RFC 7530 Section 5.8.2.28)
-	FATTR4_SPACE_FREE         = 60 // uint64: free filesystem space in bytes (RFC 7530 Section 5.8.2.29)
-	FATTR4_SPACE_AVAIL        = 61 // uint64: available space for caller in bytes (RFC 7530 Section 5.8.2.30)
 	FATTR4_SUPPATTR_EXCLCREAT = 75 // bitmap4: attrs settable during EXCLUSIVE4_1 create (RFC 8881 Section 5.8.1.10)
 	FATTR4_CLONE_BLKSIZE      = 77 // uint32: preferred block size for CLONE (RFC 7862 Section 12.2.1; word 2, bit 13)
 	FATTR4_XATTR_SUPPORT      = 82 // bool: extended attributes supported (RFC 8276 Section 8.4; word 2, bit 18)
@@ -262,10 +262,10 @@ func SupportedAttrs() []uint32 {
 	SetBit(&bitmap, FATTR4_NUMLINKS)
 	SetBit(&bitmap, FATTR4_OWNER)
 	SetBit(&bitmap, FATTR4_OWNER_GROUP)
-	SetBit(&bitmap, FATTR4_SPACE_USED)
-	SetBit(&bitmap, FATTR4_SPACE_TOTAL)
-	SetBit(&bitmap, FATTR4_SPACE_FREE)
 	SetBit(&bitmap, FATTR4_SPACE_AVAIL)
+	SetBit(&bitmap, FATTR4_SPACE_FREE)
+	SetBit(&bitmap, FATTR4_SPACE_TOTAL)
+	SetBit(&bitmap, FATTR4_SPACE_USED)
 	SetBit(&bitmap, FATTR4_TIME_ACCESS)
 	SetBit(&bitmap, FATTR4_TIME_ACCESS_SET)
 	SetBit(&bitmap, FATTR4_TIME_METADATA)
@@ -517,21 +517,21 @@ func encodeSingleAttr(buf *bytes.Buffer, bit uint32, minorVersion uint32, node P
 		// utf8str_mixed: numeric GID for nfs4_disable_idmapping=Y compatibility
 		return xdr.WriteXDRString(buf, resolveGroupString(0))
 
-	case FATTR4_SPACE_USED:
-		// uint64: 0 for pseudo-fs directories
-		return xdr.WriteUint64(buf, 0)
-
-	case FATTR4_SPACE_TOTAL:
-		// Pseudo-fs: report 1 PiB as unlimited sentinel
+	case FATTR4_SPACE_AVAIL:
+		// Pseudo-fs: report 1 PiB
 		return xdr.WriteUint64(buf, 1<<50)
 
 	case FATTR4_SPACE_FREE:
 		// Pseudo-fs: report 1 PiB
 		return xdr.WriteUint64(buf, 1<<50)
 
-	case FATTR4_SPACE_AVAIL:
-		// Pseudo-fs: report 1 PiB
+	case FATTR4_SPACE_TOTAL:
+		// Pseudo-fs: report 1 PiB as unlimited sentinel
 		return xdr.WriteUint64(buf, 1<<50)
+
+	case FATTR4_SPACE_USED:
+		// uint64: 0 for pseudo-fs directories
+		return xdr.WriteUint64(buf, 0)
 
 	case FATTR4_TIME_ACCESS:
 		// nfstime4: {seconds: 0, nseconds: 0} for pseudo-fs
@@ -750,13 +750,10 @@ func encodeRealFileAttr(buf *bytes.Buffer, bit uint32, minorVersion uint32, file
 		group := resolveGroupString(file.GID)
 		return xdr.WriteXDRString(buf, group)
 
-	case FATTR4_SPACE_USED:
-		return xdr.WriteUint64(buf, file.Size)
-
-	case FATTR4_SPACE_TOTAL:
-		// Filesystem total space (quota-adjusted via GetFilesystemStatistics)
+	case FATTR4_SPACE_AVAIL:
+		// Available space for caller
 		if fsStats != nil {
-			return xdr.WriteUint64(buf, fsStats.TotalBytes)
+			return xdr.WriteUint64(buf, fsStats.AvailableBytes)
 		}
 		return xdr.WriteUint64(buf, 1<<50) // 1 PiB fallback
 
@@ -767,12 +764,15 @@ func encodeRealFileAttr(buf *bytes.Buffer, bit uint32, minorVersion uint32, file
 		}
 		return xdr.WriteUint64(buf, 1<<50) // 1 PiB fallback
 
-	case FATTR4_SPACE_AVAIL:
-		// Available space for caller
+	case FATTR4_SPACE_TOTAL:
+		// Filesystem total space (quota-adjusted via GetFilesystemStatistics)
 		if fsStats != nil {
-			return xdr.WriteUint64(buf, fsStats.AvailableBytes)
+			return xdr.WriteUint64(buf, fsStats.TotalBytes)
 		}
 		return xdr.WriteUint64(buf, 1<<50) // 1 PiB fallback
+
+	case FATTR4_SPACE_USED:
+		return xdr.WriteUint64(buf, file.Size)
 
 	case FATTR4_TIME_ACCESS:
 		// nfstime4: seconds (int64) + nseconds (uint32)
@@ -838,13 +838,13 @@ func MapFileTypeToNFS4(fileType metadata.FileType) uint32 {
 }
 
 // NeedsFilesystemStats returns true if the requested bitmap includes any of
-// FATTR4_SPACE_TOTAL (59), FATTR4_SPACE_FREE (60), or FATTR4_SPACE_AVAIL (61).
+// FATTR4_SPACE_AVAIL (42), FATTR4_SPACE_FREE (43), or FATTR4_SPACE_TOTAL (44).
 // The caller should fetch FilesystemStatistics and pass it to EncodeRealFileAttrs
 // when this returns true.
 func NeedsFilesystemStats(requested []uint32) bool {
-	return IsBitSet(requested, FATTR4_SPACE_TOTAL) ||
+	return IsBitSet(requested, FATTR4_SPACE_AVAIL) ||
 		IsBitSet(requested, FATTR4_SPACE_FREE) ||
-		IsBitSet(requested, FATTR4_SPACE_AVAIL)
+		IsBitSet(requested, FATTR4_SPACE_TOTAL)
 }
 
 // ============================================================================

--- a/internal/adapter/nfs/v4/attrs/encode.go
+++ b/internal/adapter/nfs/v4/attrs/encode.go
@@ -615,7 +615,7 @@ func exclcreatAttrs() []uint32 {
 //   - minorVersion: COMPOUND minor version, bounding the attributes reported
 //   - file: The real file metadata
 //   - handle: The file handle (used for FILEHANDLE and FILEID attributes)
-//   - fsStats: Optional filesystem statistics for SPACE_TOTAL/FREE/AVAIL (can be nil)
+//   - fsStats: Optional filesystem statistics for SPACE_AVAIL/FREE/TOTAL (can be nil)
 func EncodeRealFileAttrs(buf *bytes.Buffer, requested []uint32, minorVersion uint32, file *metadata.File, handle metadata.FileHandle, fsStats ...*metadata.FilesystemStatistics) error {
 	supported := SupportedAttrsFor(minorVersion)
 	responseBitmap := responseAttrBitmap(requested, supported)
@@ -838,7 +838,7 @@ func MapFileTypeToNFS4(fileType metadata.FileType) uint32 {
 }
 
 // NeedsFilesystemStats returns true if the requested bitmap includes any of
-// FATTR4_SPACE_AVAIL (42), FATTR4_SPACE_FREE (43), or FATTR4_SPACE_TOTAL (44).
+// FATTR4_SPACE_AVAIL, FATTR4_SPACE_FREE, or FATTR4_SPACE_TOTAL.
 // The caller should fetch FilesystemStatistics and pass it to EncodeRealFileAttrs
 // when this returns true.
 func NeedsFilesystemStats(requested []uint32) bool {

--- a/internal/adapter/nfs/v4/attrs/space_attrs_test.go
+++ b/internal/adapter/nfs/v4/attrs/space_attrs_test.go
@@ -70,12 +70,14 @@ func TestFattr4AttributeNumbers(t *testing.T) {
 	}
 }
 
-// TestSupportedAttrsAdvertisesSpaceToV40Clients asserts the three
-// filesystem-space attributes reach a 4.0 client. They sit below
-// mounted_on_fileid, the highest attribute 4.0 defines, so the narrowing
-// SupportedAttrsFor applies must not touch them: a 4.0 client that is not shown
-// them never asks, and statfs over the mount has no space figures to report.
-func TestSupportedAttrsAdvertisesSpaceToV40Clients(t *testing.T) {
+// TestSupportedAttrsAdvertisesSpaceAtEveryMinorVersion asserts the three
+// filesystem-space attributes are advertised to a client of any minor version.
+// They sit below mounted_on_fileid, the highest attribute 4.0 defines, so the
+// narrowing SupportedAttrsFor applies must not reach them at any version; 4.0
+// is the binding case, because its ceiling is the lowest. A client that is not
+// shown them never asks, and statfs over the mount has no space figures to
+// report.
+func TestSupportedAttrsAdvertisesSpaceAtEveryMinorVersion(t *testing.T) {
 	for minorVersion := uint32(0); minorVersion <= 2; minorVersion++ {
 		bitmap := SupportedAttrsFor(minorVersion)
 		for _, bit := range []uint32{FATTR4_SPACE_AVAIL, FATTR4_SPACE_FREE, FATTR4_SPACE_TOTAL} {
@@ -87,10 +89,10 @@ func TestSupportedAttrsAdvertisesSpaceToV40Clients(t *testing.T) {
 }
 
 // TestSupportedAttrsWithholdsNFSv41ACLAttributes asserts the server never
-// advertises attributes 58-61. RFC 8881 assigns those to dacl, sacl,
-// change_policy and fs_status, none of which this server implements; a 4.1
-// client shown them would receive a uint64 where an nfsacl41 or a chg_policy4
-// belongs.
+// advertises attributes 58-61 at any minor version. RFC 8881 assigns those to
+// dacl, sacl, change_policy and fs_status, none of which this server
+// implements; a 4.1 client shown them would receive a uint64 where an nfsacl41
+// or a chg_policy4 belongs.
 func TestSupportedAttrsWithholdsNFSv41ACLAttributes(t *testing.T) {
 	for minorVersion := uint32(0); minorVersion <= 2; minorVersion++ {
 		bitmap := SupportedAttrsFor(minorVersion)

--- a/internal/adapter/nfs/v4/attrs/space_attrs_test.go
+++ b/internal/adapter/nfs/v4/attrs/space_attrs_test.go
@@ -1,0 +1,164 @@
+package attrs
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// TestFattr4AttributeNumbers pins every FATTR4 constant to the attribute number
+// the protocol assigns it. The numbers come from RFC 7530 Tables 3 and 4
+// (Sections 5.6 and 5.7) for attributes 0-55, from RFC 8881 Section 5.7 for
+// suppattr_exclcreat, from RFC 7862 for clone_blksize, and from RFC 8276 for
+// xattr_support.
+//
+// Attribute numbers are a wire contract with no local freedom: a constant that
+// disagrees with the table makes the server answer a client's request for one
+// attribute with the value of another, or withhold an attribute the client did
+// ask for. The whole block is asserted rather than the few attributes a change
+// happens to touch, because the failure is a silent transcription slip and the
+// only way to catch it is to check every number against the table.
+func TestFattr4AttributeNumbers(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		got  uint32
+		want uint32
+	}{
+		{"supported_attrs", FATTR4_SUPPORTED_ATTRS, 0},
+		{"type", FATTR4_TYPE, 1},
+		{"fh_expire_type", FATTR4_FH_EXPIRE_TYPE, 2},
+		{"change", FATTR4_CHANGE, 3},
+		{"size", FATTR4_SIZE, 4},
+		{"link_support", FATTR4_LINK_SUPPORT, 5},
+		{"symlink_support", FATTR4_SYMLINK_SUPPORT, 6},
+		{"named_attr", FATTR4_NAMED_ATTR, 7},
+		{"fsid", FATTR4_FSID, 8},
+		{"unique_handles", FATTR4_UNIQUE_HANDLES, 9},
+		{"lease_time", FATTR4_LEASE_TIME, 10},
+		{"rdattr_error", FATTR4_RDATTR_ERROR, 11},
+		{"acl", FATTR4_ACL, 12},
+		{"aclsupport", FATTR4_ACLSUPPORT, 13},
+		{"filehandle", FATTR4_FILEHANDLE, 19},
+		{"fileid", FATTR4_FILEID, 20},
+		{"maxfilesize", FATTR4_MAXFILESIZE, 27},
+		{"maxread", FATTR4_MAXREAD, 30},
+		{"maxwrite", FATTR4_MAXWRITE, 31},
+		{"mode", FATTR4_MODE, 33},
+		{"numlinks", FATTR4_NUMLINKS, 35},
+		{"owner", FATTR4_OWNER, 36},
+		{"owner_group", FATTR4_OWNER_GROUP, 37},
+		{"rawdev", FATTR4_RAWDEV, 41},
+		{"space_avail", FATTR4_SPACE_AVAIL, 42},
+		{"space_free", FATTR4_SPACE_FREE, 43},
+		{"space_total", FATTR4_SPACE_TOTAL, 44},
+		{"space_used", FATTR4_SPACE_USED, 45},
+		{"time_access", FATTR4_TIME_ACCESS, 47},
+		{"time_access_set", FATTR4_TIME_ACCESS_SET, 48},
+		{"time_metadata", FATTR4_TIME_METADATA, 52},
+		{"time_modify", FATTR4_TIME_MODIFY, 53},
+		{"time_modify_set", FATTR4_TIME_MODIFY_SET, 54},
+		{"mounted_on_fileid", FATTR4_MOUNTED_ON_FILEID, 55},
+		{"suppattr_exclcreat", FATTR4_SUPPATTR_EXCLCREAT, 75},
+		{"clone_blksize", FATTR4_CLONE_BLKSIZE, 77},
+		{"xattr_support", FATTR4_XATTR_SUPPORT, 82},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("%s = %d, want %d", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+// TestSupportedAttrsAdvertisesSpaceToV40Clients asserts the three
+// filesystem-space attributes reach a 4.0 client. They sit below
+// mounted_on_fileid, the highest attribute 4.0 defines, so the narrowing
+// SupportedAttrsFor applies must not touch them: a 4.0 client that is not shown
+// them never asks, and statfs over the mount has no space figures to report.
+func TestSupportedAttrsAdvertisesSpaceToV40Clients(t *testing.T) {
+	for minorVersion := uint32(0); minorVersion <= 2; minorVersion++ {
+		bitmap := SupportedAttrsFor(minorVersion)
+		for _, bit := range []uint32{FATTR4_SPACE_AVAIL, FATTR4_SPACE_FREE, FATTR4_SPACE_TOTAL} {
+			if !IsBitSet(bitmap, bit) {
+				t.Errorf("SupportedAttrsFor(%d) does not advertise space attribute %d", minorVersion, bit)
+			}
+		}
+	}
+}
+
+// TestSupportedAttrsWithholdsNFSv41ACLAttributes asserts the server never
+// advertises attributes 58-61. RFC 8881 assigns those to dacl, sacl,
+// change_policy and fs_status, none of which this server implements; a 4.1
+// client shown them would receive a uint64 where an nfsacl41 or a chg_policy4
+// belongs.
+func TestSupportedAttrsWithholdsNFSv41ACLAttributes(t *testing.T) {
+	for minorVersion := uint32(0); minorVersion <= 2; minorVersion++ {
+		bitmap := SupportedAttrsFor(minorVersion)
+		for bit := uint32(58); bit <= 61; bit++ {
+			if IsBitSet(bitmap, bit) {
+				t.Errorf("SupportedAttrsFor(%d) advertises attribute %d, which this server does not implement", minorVersion, bit)
+			}
+		}
+	}
+}
+
+// TestEncodeRealFileSpaceAttrs asserts a GETATTR naming the three space
+// attributes answers with the filesystem statistics, in ascending attribute
+// order as RFC 7530 Section 3.3.10 requires.
+func TestEncodeRealFileSpaceAttrs(t *testing.T) {
+	stats := &metadata.FilesystemStatistics{
+		TotalBytes:     4 << 30,
+		UsedBytes:      1 << 30,
+		AvailableBytes: 3 << 30,
+	}
+
+	var requested []uint32
+	SetBit(&requested, FATTR4_SPACE_AVAIL)
+	SetBit(&requested, FATTR4_SPACE_FREE)
+	SetBit(&requested, FATTR4_SPACE_TOTAL)
+
+	if !NeedsFilesystemStats(requested) {
+		t.Fatal("NeedsFilesystemStats() = false for a request naming the space attributes")
+	}
+
+	var buf bytes.Buffer
+	if err := EncodeRealFileAttrs(&buf, requested, 0, &metadata.File{}, metadata.FileHandle("/s:id"), stats); err != nil {
+		t.Fatalf("EncodeRealFileAttrs: %v", err)
+	}
+
+	reader := bytes.NewReader(buf.Bytes())
+	responseBitmap, err := DecodeBitmap4(reader)
+	if err != nil {
+		t.Fatalf("decode response bitmap: %v", err)
+	}
+	for _, bit := range []uint32{FATTR4_SPACE_AVAIL, FATTR4_SPACE_FREE, FATTR4_SPACE_TOTAL} {
+		if !IsBitSet(responseBitmap, bit) {
+			t.Fatalf("response bitmap does not carry space attribute %d", bit)
+		}
+	}
+
+	var opaqueLen uint32
+	if err := binary.Read(reader, binary.BigEndian, &opaqueLen); err != nil {
+		t.Fatalf("read attr data length: %v", err)
+	}
+	if opaqueLen != 24 {
+		t.Fatalf("attr data length = %d, want 24 (three uint64s)", opaqueLen)
+	}
+
+	for _, want := range []struct {
+		name  string
+		value uint64
+	}{
+		{"space_avail", stats.AvailableBytes},
+		{"space_free", stats.AvailableBytes},
+		{"space_total", stats.TotalBytes},
+	} {
+		var got uint64
+		if err := binary.Read(reader, binary.BigEndian, &got); err != nil {
+			t.Fatalf("read %s: %v", want.name, err)
+		}
+		if got != want.value {
+			t.Errorf("%s = %d, want %d", want.name, got, want.value)
+		}
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/getattr.go
+++ b/internal/adapter/nfs/v4/handlers/getattr.go
@@ -124,7 +124,7 @@ func (h *Handler) getAttrRealFS(ctx *types.CompoundContext, requested []uint32) 
 			"client", ctx.ClientAddr)
 	}
 
-	// Fetch filesystem statistics if any space attributes are requested (bits 42-44).
+	// Fetch filesystem statistics if any space attributes are requested.
 	// Pass the caller's identity so per-user/per-group quotas are reflected.
 	var fsStats *metadata.FilesystemStatistics
 	if attrs.NeedsFilesystemStats(requested) {

--- a/internal/adapter/nfs/v4/handlers/getattr.go
+++ b/internal/adapter/nfs/v4/handlers/getattr.go
@@ -124,7 +124,7 @@ func (h *Handler) getAttrRealFS(ctx *types.CompoundContext, requested []uint32) 
 			"client", ctx.ClientAddr)
 	}
 
-	// Fetch filesystem statistics if any space attributes are requested (bits 59-61).
+	// Fetch filesystem statistics if any space attributes are requested (bits 42-44).
 	// Pass the caller's identity so per-user/per-group quotas are reflected.
 	var fsStats *metadata.FilesystemStatistics
 	if attrs.NeedsFilesystemStats(requested) {


### PR DESCRIPTION
## What was wrong

NFSv4 attribute numbers are a wire contract. RFC 7530 Section 5.7 (Table 4) assigns:

| attribute | number |
| --- | --- |
| space_avail | 42 |
| space_free | 43 |
| space_total | 44 |
| space_used | 45 |

`internal/adapter/nfs/v4/attrs/encode.go` had `space_total = 59`, `space_free = 60`,
`space_avail = 61`. `space_used = 45` was already right, which is what marks the other
three as a transcription slip rather than a choice: the four are one contiguous run in
the table and only one of them landed on its number.

Both the `SUPPORTED_ATTRS` advertisement and both GETATTR encoder paths switch on the
constants, so every site was consistently wrong together — which is why no test failed.

## Two consequences, and why the first one is not what the issue said

**`df` over NFSv4 has never worked, but not because the bits were unrecognised.**
`SupportedAttrsFor(minorVersion)` clears every bit above a per-minor-version ceiling
(4.0: 55, 4.1: 76, 4.2: 82), because `SUPPORTED_ATTRS` is the client's contract for
which numbers it may name. 59/60/61 sit above the 4.0 ceiling, so a 4.0 client was
never shown the space attributes at all. The Linux client asks for 42/43/44
regardless; `responseAttrBitmap` intersects the request with the supported
set, so those bits were dropped from the response and the client had no space figures.

**A 4.1 or 4.2 client was advertised three attributes this server does not implement.**
59/60/61 are below the 4.1 ceiling of 76, so they were advertised. In RFC 8881 those
numbers are `sacl`, `change_policy` and `fs_status` — the issue named them
dacl/sacl/change_policy, which is off by one; `dacl` is 58. A client that asked for
one of the advertised numbers would have received a `uint64` where an `nfsacl41` or a
`chg_policy4` belongs.

## The fix

- The three constants move to 42, 43 and 44.
- The `SetBit` run in `SupportedAttrs()` and the switch cases in both
  `encodeSingleAttr` and `encodeRealFileAttr` are reordered to read in ascending
  attribute order. This is cosmetic — both encoders are driven by an ascending bit
  loop over the response bitmap, which is what actually satisfies RFC 7530
  Section 3.3.10's ordering requirement — but a run of cases that reads out of order
  is how the original slip stayed invisible.
- Three doc comments that restated the numbers now name the constants instead. A
  comment repeating a constant's value in a second place is the surface that went
  stale here: one of them read "bits 59-61" and looked authoritative.

## Audit of the rest of the FATTR4 block

Every other constant in the block was checked against RFC 7530 Tables 3 and 4, and
against RFC 8881 Section 5.7 / RFC 7862 / RFC 8276 for the three above 55. All 34 are
correct: 0-13, 19, 20, 27, 30, 31, 33, 35-37, 41, 45, 47, 48, 52-55, 75, 77, 82. The
three space attributes were the only mismatch. A repo-wide grep for the bare literals
59, 60 and 61 turned up no other site keyed on the old numbers — `OP_ALLOCATE = 59` in
`v4/types/constants.go` is an operation number, a separate namespace.

One adjacent gap, deliberately **not** fixed here because it is a feature rather than
the same class of typo: `files_avail`, `files_free` and `files_total` (21/22/23) are
not implemented, so `df -i` over NFSv4 reports zero inodes even after this change.
`df` itself only needs the space attributes.

## Verification

The new tests fail on unmodified `develop` and pass with the fix:

```
--- FAIL: TestFattr4AttributeNumbers
    space_attrs_test.go:68: space_avail = 61, want 42
    space_attrs_test.go:68: space_free = 60, want 43
    space_attrs_test.go:68: space_total = 59, want 44
--- FAIL: TestSupportedAttrsAdvertisesSpaceToV40Clients
    space_attrs_test.go:83: SupportedAttrsFor(0) does not advertise space attribute 61
    space_attrs_test.go:83: SupportedAttrsFor(0) does not advertise space attribute 60
    space_attrs_test.go:83: SupportedAttrsFor(0) does not advertise space attribute 59
--- FAIL: TestSupportedAttrsWithholdsNFSv41ACLAttributes
    space_attrs_test.go:99: SupportedAttrsFor(1) advertises attribute 59, which this server does not implement
    space_attrs_test.go:99: SupportedAttrsFor(1) advertises attribute 60, which this server does not implement
    space_attrs_test.go:99: SupportedAttrsFor(1) advertises attribute 61, which this server does not implement
    space_attrs_test.go:99: SupportedAttrsFor(2) advertises attribute 59, ...
--- FAIL: TestEncodeRealFileSpaceAttrs
    space_attrs_test.go:136: response bitmap does not carry space attribute 61
FAIL
```

`TestFattr4AttributeNumbers` pins the whole constant block rather than the three that
moved. The point of the pin is the failure mode: a wrong attribute number is silent at
every layer, so the only thing that catches the next one is checking every number
against the table.

`go build ./...`, `go vet ./...` and `go test ./internal/... ./pkg/...` are clean, as is
`go test -race ./internal/adapter/nfs/v4/...`.

pynfs GATT6 is deliberately not offered as evidence: it fails today for an independent
reason (minor-version narrowing, addressed by #2325), so it cannot distinguish this fix
from no fix. A real `df` against a v4.0 mount is the end-to-end check and has not been
run here — the mount-holding suites are serialized with other work in flight.

Closes #2362
