### PR TITLE
fix(nfs): call the cross-protocol lock manager without holding the global state mutex

### DIFF
--- a/internal/adapter/nfs/v4/state/delegation.go
+++ b/internal/adapter/nfs/v4/state/delegation.go
@@ -174,6 +174,28 @@ func (sm *StateManager) countActiveDelegations() int {
 	return count
 }
 
+// delegationBudgetAvailableLocked reports whether another delegation fits
+// under the configured maximum. A maximum of zero or less means unlimited.
+//
+// Caller must hold sm.mu.
+func (sm *StateManager) delegationBudgetAvailableLocked() bool {
+	return sm.maxDelegations <= 0 || sm.countActiveDelegations() < sm.maxDelegations
+}
+
+// revokeInLockManagerUnlocked hands a delegation back to the cross-protocol
+// lock manager, for a grant that succeeded there but can no longer be
+// published. Without it the manager keeps a delegation no NFSv4 state
+// references, and it blocks every later conflicting lease and byte-range lock
+// on the file for the lifetime of the server.
+//
+// Caller must hold sm.mu; the mutex is released for the call and held again on
+// return, as everywhere else the lock manager is called from this package.
+func (sm *StateManager) revokeInLockManagerUnlocked(lm lock.LockManager, fhKey, delegID string) {
+	sm.mu.Unlock()
+	_ = lm.RevokeDelegation(fhKey, delegID)
+	sm.mu.Lock()
+}
+
 // removeDelegFromFile removes a delegation from the delegByFile map.
 // Cleans up the map entry if no delegations remain for the file.
 //
@@ -243,7 +265,7 @@ func (sm *StateManager) GrantDelegation(clientID uint64, fileHandle []byte, dele
 	sm.pruneStaleRecentlyRecalledLocked()
 
 	// Check total active delegation count against limit
-	if sm.maxDelegations > 0 && sm.countActiveDelegations() >= sm.maxDelegations {
+	if !sm.delegationBudgetAvailableLocked() {
 		return nil
 	}
 
@@ -285,13 +307,30 @@ func (sm *StateManager) GrantDelegation(clientID uint64, fileHandle []byte, dele
 		// (see acquireLock), so break paths that exclude by client can tell a
 		// client's own delegation from another client's.
 		lockDeleg := lock.NewDelegation(lmDelegType, nfsClientIdentity(clientID), "", false)
-		if err := lm.GrantDelegation(fhKey, lockDeleg); err != nil {
+
+		// The manager's grant path is cross-protocol, and sm.mu serializes every
+		// client's state operation server-wide, so the mutex is released across
+		// the call (see acquireLock in manager.go).
+		sm.mu.Unlock()
+		grantErr := lm.GrantDelegation(fhKey, lockDeleg)
+		sm.mu.Lock()
+		if grantErr != nil {
 			logger.Debug("delegation denied by lock manager",
 				"client_id", clientID,
 				"deleg_type", delegType,
-				"error", err)
+				"error", grantErr)
 			return nil
 		}
+
+		// Nothing published references this delegation yet, so the only fact the
+		// released mutex can falsify is the admission decision made above:
+		// concurrent grants may have taken the last of the budget. Hand the
+		// grant back rather than publish past the cap.
+		if !sm.delegationBudgetAvailableLocked() {
+			sm.revokeInLockManagerUnlocked(lm, fhKey, lockDeleg.DelegationID)
+			return nil
+		}
+
 		sm.delegStateidMap[lockDeleg.DelegationID] = stateid
 		deleg.LockManagerDelegID = lockDeleg.DelegationID
 	}

--- a/internal/adapter/nfs/v4/state/delegation.go
+++ b/internal/adapter/nfs/v4/state/delegation.go
@@ -182,7 +182,22 @@ func (sm *StateManager) delegationBudgetAvailableLocked() bool {
 	return sm.maxDelegations <= 0 || sm.countActiveDelegations() < sm.maxDelegations
 }
 
-// revokeInLockManagerUnlocked hands a delegation back to the cross-protocol
+// clientLeaseLiveLocked reports whether clientID names a client record, v4.0 or
+// v4.1, whose lease has not lapsed. A delegation is lease-backed state, so a
+// client without a live lease cannot hold one.
+//
+// Caller must hold sm.mu.
+func (sm *StateManager) clientLeaseLiveLocked(clientID uint64) bool {
+	if v40, ok := sm.clientsByID[clientID]; ok {
+		return v40.Lease != nil && !v40.Lease.IsExpired()
+	}
+	if v41, ok := sm.v41ClientsByID[clientID]; ok {
+		return v41.Lease != nil && !v41.Lease.IsExpired()
+	}
+	return false
+}
+
+// revokeInLockManagerLocked hands a delegation back to the cross-protocol
 // lock manager, for a grant that succeeded there but can no longer be
 // published. Without it the manager keeps a delegation no NFSv4 state
 // references, and it blocks every later conflicting lease and byte-range lock
@@ -190,7 +205,7 @@ func (sm *StateManager) delegationBudgetAvailableLocked() bool {
 //
 // Caller must hold sm.mu; the mutex is released for the call and held again on
 // return, as everywhere else the lock manager is called from this package.
-func (sm *StateManager) revokeInLockManagerUnlocked(lm lock.LockManager, fhKey, delegID string) {
+func (sm *StateManager) revokeInLockManagerLocked(lm lock.LockManager, fhKey, delegID string) {
 	sm.mu.Unlock()
 	_ = lm.RevokeDelegation(fhKey, delegID)
 	sm.mu.Lock()
@@ -269,6 +284,10 @@ func (sm *StateManager) GrantDelegation(clientID uint64, fileHandle []byte, dele
 		return nil
 	}
 
+	// Sampled for the recommit check below, not as an admission rule: this path
+	// has never required a live lease to grant.
+	clientWasLive := sm.clientLeaseLiveLocked(clientID)
+
 	other := sm.generateStateidOther(StateTypeDeleg)
 	stateid := types.Stateid4{
 		Seqid: 1,
@@ -322,12 +341,17 @@ func (sm *StateManager) GrantDelegation(clientID uint64, fileHandle []byte, dele
 			return nil
 		}
 
-		// Nothing published references this delegation yet, so the only fact the
-		// released mutex can falsify is the admission decision made above:
-		// concurrent grants may have taken the last of the budget. Hand the
-		// grant back rather than publish past the cap.
-		if !sm.delegationBudgetAvailableLocked() {
-			sm.revokeInLockManagerUnlocked(lm, fhKey, lockDeleg.DelegationID)
+		// Nothing published references this delegation yet, so what the released
+		// mutex can falsify is the inputs to the decision made above: concurrent
+		// grants may have taken the last of the budget, and a client that had a
+		// live lease going in may have been torn down. The teardown matters
+		// because the sweeper frees a client's delegations in one critical
+		// section and never revisits it, so a grant published after that sweep
+		// is unreachable from cleanup and blocks every later conflicting lease
+		// and byte-range lock on the file. Hand the grant back instead.
+		if !sm.delegationBudgetAvailableLocked() ||
+			(clientWasLive && !sm.clientLeaseLiveLocked(clientID)) {
+			sm.revokeInLockManagerLocked(lm, fhKey, lockDeleg.DelegationID)
 			return nil
 		}
 

--- a/internal/adapter/nfs/v4/state/dir_delegation.go
+++ b/internal/adapter/nfs/v4/state/dir_delegation.go
@@ -40,14 +40,7 @@ func (sm *StateManager) admitDirDelegationLocked(clientID uint64, fhKey string) 
 		return fmt.Errorf("delegations disabled")
 	}
 
-	// Check client has valid, non-expired lease (v4.0 or v4.1)
-	var leaseValid bool
-	if v40, ok := sm.clientsByID[clientID]; ok {
-		leaseValid = v40.Lease != nil && !v40.Lease.IsExpired()
-	} else if v41, ok := sm.v41ClientsByID[clientID]; ok {
-		leaseValid = v41.Lease != nil && !v41.Lease.IsExpired()
-	}
-	if !leaseValid {
+	if !sm.clientLeaseLiveLocked(clientID) {
 		return &NFS4StateError{
 			Status:  types.NFS4ERR_EXPIRED,
 			Message: fmt.Sprintf("client %d not found or lease expired", clientID),
@@ -132,7 +125,7 @@ func (sm *StateManager) GrantDirDelegation(clientID uint64, dirFH []byte, notifM
 		// been taken by concurrent grants, or the client could have been given a
 		// directory delegation on this same handle.
 		if err := sm.admitDirDelegationLocked(clientID, fhKey); err != nil {
-			sm.revokeInLockManagerUnlocked(lm, fhKey, lockDeleg.DelegationID)
+			sm.revokeInLockManagerLocked(lm, fhKey, lockDeleg.DelegationID)
 			return nil, err
 		}
 

--- a/internal/adapter/nfs/v4/state/dir_delegation.go
+++ b/internal/adapter/nfs/v4/state/dir_delegation.go
@@ -68,13 +68,8 @@ func (sm *StateManager) admitDirDelegationLocked(clientID uint64, fhKey string) 
 	return nil
 }
 
-// GrantDirDelegation creates a new directory delegation for a client.
-//
-// It performs the following checks before granting:
-//   - Delegations must be enabled
-//   - Client must have a valid lease
-//   - Total delegation count must be below maxDelegations limit
-//   - No duplicate directory delegation for same client+handle
+// GrantDirDelegation creates a new directory delegation for a client, subject
+// to the checks in admitDirDelegationLocked.
 //
 // Returns the DelegationState on success, or nil with an error.
 //
@@ -120,9 +115,7 @@ func (sm *StateManager) GrantDirDelegation(clientID uint64, dirFH []byte, notifM
 		lockDeleg := lock.NewDelegation(lock.DelegTypeRead, nfsClientIdentity(clientID), "", true)
 		lockDeleg.NotificationMask = notifMask
 
-		// sm.mu is released across the manager call: it is cross-protocol and
-		// sm.mu serializes every client's state operation server-wide (see
-		// acquireLock in manager.go).
+		// sm.mu is released across the manager call (see acquireLock in manager.go).
 		sm.mu.Unlock()
 		grantErr := lm.GrantDelegation(fhKey, lockDeleg)
 		sm.mu.Lock()

--- a/internal/adapter/nfs/v4/state/dir_delegation.go
+++ b/internal/adapter/nfs/v4/state/dir_delegation.go
@@ -26,6 +26,48 @@ import (
 // an immediate flush is triggered (count-based flush).
 const maxBatchSize = 100
 
+// admitDirDelegationLocked decides whether a directory delegation may be
+// granted to this client on this handle: delegations enabled, the client's
+// lease live, the server-wide delegation budget not exhausted, and no
+// directory delegation already held by the same client on the same handle.
+//
+// It is deliberately re-runnable, so it doubles as the recommit check for the
+// window in which GrantDirDelegation releases sm.mu to call the lock manager.
+//
+// Caller must hold sm.mu.
+func (sm *StateManager) admitDirDelegationLocked(clientID uint64, fhKey string) error {
+	if !sm.delegationsEnabled {
+		return fmt.Errorf("delegations disabled")
+	}
+
+	// Check client has valid, non-expired lease (v4.0 or v4.1)
+	var leaseValid bool
+	if v40, ok := sm.clientsByID[clientID]; ok {
+		leaseValid = v40.Lease != nil && !v40.Lease.IsExpired()
+	} else if v41, ok := sm.v41ClientsByID[clientID]; ok {
+		leaseValid = v41.Lease != nil && !v41.Lease.IsExpired()
+	}
+	if !leaseValid {
+		return &NFS4StateError{
+			Status:  types.NFS4ERR_EXPIRED,
+			Message: fmt.Sprintf("client %d not found or lease expired", clientID),
+		}
+	}
+
+	// Revoked delegations are excluded from the budget.
+	if !sm.delegationBudgetAvailableLocked() {
+		return fmt.Errorf("delegation limit exceeded (%d)", sm.maxDelegations)
+	}
+
+	for _, existing := range sm.delegByFile[fhKey] {
+		if existing.ClientID == clientID && existing.IsDirectory && !existing.Revoked {
+			return fmt.Errorf("duplicate directory delegation for client %d on handle", clientID)
+		}
+	}
+
+	return nil
+}
+
 // GrantDirDelegation creates a new directory delegation for a client.
 //
 // It performs the following checks before granting:
@@ -41,36 +83,9 @@ func (sm *StateManager) GrantDirDelegation(clientID uint64, dirFH []byte, notifM
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
-	// Check delegations enabled
-	if !sm.delegationsEnabled {
-		return nil, fmt.Errorf("delegations disabled")
-	}
-
-	// Check client has valid, non-expired lease (v4.0 or v4.1)
-	var leaseValid bool
-	if v40, ok := sm.clientsByID[clientID]; ok {
-		leaseValid = v40.Lease != nil && !v40.Lease.IsExpired()
-	} else if v41, ok := sm.v41ClientsByID[clientID]; ok {
-		leaseValid = v41.Lease != nil && !v41.Lease.IsExpired()
-	}
-	if !leaseValid {
-		return nil, &NFS4StateError{
-			Status:  types.NFS4ERR_EXPIRED,
-			Message: fmt.Sprintf("client %d not found or lease expired", clientID),
-		}
-	}
-
-	// Check total active delegation count against limit (revoked delegations excluded)
-	if sm.maxDelegations > 0 && sm.countActiveDelegations() >= sm.maxDelegations {
-		return nil, fmt.Errorf("delegation limit exceeded (%d)", sm.maxDelegations)
-	}
-
-	// Check no existing directory delegation for same client+handle
 	fhKey := string(dirFH)
-	for _, existing := range sm.delegByFile[fhKey] {
-		if existing.ClientID == clientID && existing.IsDirectory && !existing.Revoked {
-			return nil, fmt.Errorf("duplicate directory delegation for client %d on handle", clientID)
-		}
+	if err := sm.admitDirDelegationLocked(clientID, fhKey); err != nil {
+		return nil, err
 	}
 
 	// Generate stateid (same type byte 0x03 as file delegations)
@@ -104,12 +119,30 @@ func (sm *StateManager) GrantDirDelegation(clientID uint64, dirFH []byte, notifM
 		// See GrantDelegation comment: NFS delegations lack share context at this layer.
 		lockDeleg := lock.NewDelegation(lock.DelegTypeRead, nfsClientIdentity(clientID), "", true)
 		lockDeleg.NotificationMask = notifMask
-		if err := lm.GrantDelegation(fhKey, lockDeleg); err != nil {
+
+		// sm.mu is released across the manager call: it is cross-protocol and
+		// sm.mu serializes every client's state operation server-wide (see
+		// acquireLock in manager.go).
+		sm.mu.Unlock()
+		grantErr := lm.GrantDelegation(fhKey, lockDeleg)
+		sm.mu.Lock()
+		if grantErr != nil {
 			logger.Debug("directory delegation denied by lock manager",
 				"client_id", clientID,
-				"error", err)
+				"error", grantErr)
+			return nil, grantErr
+		}
+
+		// Nothing published references this delegation yet, so re-running
+		// admission is the whole of the recommit check: while the mutex was
+		// released the client's lease could have expired, the budget could have
+		// been taken by concurrent grants, or the client could have been given a
+		// directory delegation on this same handle.
+		if err := sm.admitDirDelegationLocked(clientID, fhKey); err != nil {
+			sm.revokeInLockManagerUnlocked(lm, fhKey, lockDeleg.DelegationID)
 			return nil, err
 		}
+
 		sm.delegStateidMap[lockDeleg.DelegationID] = stateid
 		deleg.LockManagerDelegID = lockDeleg.DelegationID
 	}

--- a/internal/adapter/nfs/v4/state/lock_manager_unlocked_test.go
+++ b/internal/adapter/nfs/v4/state/lock_manager_unlocked_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -28,24 +29,30 @@ type hookedLockManager struct {
 	onAddLock    func()
 	onRemoveLock func()
 	onGrantDeleg func()
-	fired        bool
+
+	mu    sync.Mutex
+	fired bool
 }
 
 // fire runs a hook at most once. The state-freeing paths these hooks trigger
-// call the lock manager themselves, so an unguarded hook would re-enter.
+// call the lock manager themselves, so the hook re-enters this method from the
+// goroutine it spawned, and the latch has to let that re-entrant call fall
+// straight through rather than wait for the first to finish.
 //
-// The latch has to let a re-entrant call fall straight through, which is why it
-// is a plain flag and not a sync.Once: Once.Do blocks every later caller until
-// the first returns, and the first is waiting on the goroutine whose lock
-// manager call re-enters here. The flag is written before the hook body starts
-// the goroutine that reads it, and read again only after that goroutine has
-// been joined, so the accesses are ordered.
+// That rules out sync.Once, whose Do blocks every later caller until the first
+// returns — and the first is blocked waiting on the very goroutine that
+// re-enters here. Only the claim is serialized; the hook itself runs unlocked.
 func (h *hookedLockManager) fire(hook func()) {
-	if hook == nil || h.fired {
+	if hook == nil {
 		return
 	}
+	h.mu.Lock()
+	first := !h.fired
 	h.fired = true
-	hook()
+	h.mu.Unlock()
+	if first {
+		hook()
+	}
 }
 
 func (h *hookedLockManager) AddUnifiedLock(handleKey string, l *lock.UnifiedLock) error {

--- a/internal/adapter/nfs/v4/state/lock_manager_unlocked_test.go
+++ b/internal/adapter/nfs/v4/state/lock_manager_unlocked_test.go
@@ -21,7 +21,7 @@ import (
 // very state the caller resolved, which is exactly the race the re-validation
 // has to catch.
 
-// hookedLockManager wraps a real lock manager and runs a hook at the point one
+// hookedLockManager wraps a realLM lock manager and runs a hook at the point one
 // chosen operation reaches it.
 type hookedLockManager struct {
 	lock.LockManager
@@ -79,10 +79,10 @@ func mutateUnderStateMutex(t *testing.T, what string, fn func()) {
 // window is refused instead of committing a seqid bump onto dead state.
 func TestLockNew_LockManagerCalledWithoutStateMutex(t *testing.T) {
 	sm := NewStateManager(90 * time.Second)
-	real := lock.NewManager()
+	realLM := lock.NewManager()
 
 	var clientID uint64
-	lm := &hookedLockManager{LockManager: real}
+	lm := &hookedLockManager{LockManager: realLM}
 	lm.onAddLock = func() {
 		mutateUnderStateMutex(t, "the lease sweeper", func() { sm.onLeaseExpired(clientID) })
 	}
@@ -101,7 +101,7 @@ func TestLockNew_LockManagerCalledWithoutStateMutex(t *testing.T) {
 
 	// The byte-range lock reached the manager before the state went away, so
 	// the refusal has to hand it back; otherwise nothing is left to release it.
-	if locks := real.ListUnifiedLocks(string(fileHandle)); len(locks) != 0 {
+	if locks := realLM.ListUnifiedLocks(string(fileHandle)); len(locks) != 0 {
 		t.Fatalf("refused LOCK stranded %d lock(s) in the lock manager", len(locks))
 	}
 }
@@ -111,17 +111,9 @@ func TestLockNew_LockManagerCalledWithoutStateMutex(t *testing.T) {
 // onto state freed in that window.
 func TestUnlockFile_LockManagerCalledWithoutStateMutex(t *testing.T) {
 	sm := NewStateManager(90 * time.Second)
-	real := lock.NewManager()
+	realLM := lock.NewManager()
 
-	var clientID uint64
-	release := false
-	lm := &hookedLockManager{LockManager: real}
-	lm.onRemoveLock = func() {
-		if !release {
-			return
-		}
-		mutateUnderStateMutex(t, "RemoveClient", func() { sm.RemoveClient(clientID) })
-	}
+	lm := &hookedLockManager{LockManager: realLM}
 	sm.SetLockManagerResolver(func(_ []byte) lock.LockManager { return lm })
 
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
@@ -135,6 +127,7 @@ func TestUnlockFile_LockManagerCalledWithoutStateMutex(t *testing.T) {
 		t.Fatalf("setup LOCK failed: err=%v denied=%v", err, locked)
 	}
 
+	// Hooked only now: the setup LOCK above must reach the manager unhooked.
 	lm.onRemoveLock = func() {
 		mutateUnderStateMutex(t, "the lease sweeper", func() { sm.onLeaseExpired(clientID) })
 	}
@@ -149,10 +142,10 @@ func TestUnlockFile_LockManagerCalledWithoutStateMutex(t *testing.T) {
 func TestGrantDelegation_LockManagerCalledWithoutStateMutex(t *testing.T) {
 	sm := NewStateManager(90 * time.Second)
 	sm.SetMaxDelegations(1)
-	real := lock.NewManager()
+	realLM := lock.NewManager()
 
 	fileHandle := []byte("/export:deleg-file")
-	lm := &hookedLockManager{LockManager: real}
+	lm := &hookedLockManager{LockManager: realLM}
 	lm.onGrantDeleg = func() {
 		// Take the last of the budget while the manager call is in flight.
 		mutateUnderStateMutex(t, "a competing delegation", func() {
@@ -168,7 +161,7 @@ func TestGrantDelegation_LockManagerCalledWithoutStateMutex(t *testing.T) {
 	if deleg := sm.GrantDelegation(clientID, fileHandle, types.OPEN_DELEGATE_READ); deleg != nil {
 		t.Fatal("delegation published past the budget that was taken while the lock manager was called")
 	}
-	if delegs := real.ListDelegations(string(fileHandle)); len(delegs) != 0 {
+	if delegs := realLM.ListDelegations(string(fileHandle)); len(delegs) != 0 {
 		t.Fatalf("refused delegation stranded %d delegation(s) in the lock manager", len(delegs))
 	}
 }
@@ -178,11 +171,11 @@ func TestGrantDelegation_LockManagerCalledWithoutStateMutex(t *testing.T) {
 // decision, so the window is closed here by expiring the client's lease.
 func TestGrantDirDelegation_LockManagerCalledWithoutStateMutex(t *testing.T) {
 	sm := NewStateManager(90 * time.Second)
-	real := lock.NewManager()
+	realLM := lock.NewManager()
 
 	dirFH := []byte("/export:deleg-dir")
 	var clientID uint64
-	lm := &hookedLockManager{LockManager: real}
+	lm := &hookedLockManager{LockManager: realLM}
 	lm.onGrantDeleg = func() {
 		mutateUnderStateMutex(t, "RemoveClient", func() { sm.RemoveClient(clientID) })
 	}
@@ -193,7 +186,7 @@ func TestGrantDirDelegation_LockManagerCalledWithoutStateMutex(t *testing.T) {
 	if _, err := sm.GrantDirDelegation(clientID, dirFH, 0xffff); err == nil {
 		t.Fatal("directory delegation published for a client removed while the lock manager was called")
 	}
-	if delegs := real.ListDelegations(string(dirFH)); len(delegs) != 0 {
+	if delegs := realLM.ListDelegations(string(dirFH)); len(delegs) != 0 {
 		t.Fatalf("refused delegation stranded %d delegation(s) in the lock manager", len(delegs))
 	}
 }

--- a/internal/adapter/nfs/v4/state/lock_manager_unlocked_test.go
+++ b/internal/adapter/nfs/v4/state/lock_manager_unlocked_test.go
@@ -33,6 +33,13 @@ type hookedLockManager struct {
 
 // fire runs a hook at most once. The state-freeing paths these hooks trigger
 // call the lock manager themselves, so an unguarded hook would re-enter.
+//
+// The latch has to let a re-entrant call fall straight through, which is why it
+// is a plain flag and not a sync.Once: Once.Do blocks every later caller until
+// the first returns, and the first is waiting on the goroutine whose lock
+// manager call re-enters here. The flag is written before the hook body starts
+// the goroutine that reads it, and read again only after that goroutine has
+// been joined, so the accesses are ordered.
 func (h *hookedLockManager) fire(hook func()) {
 	if hook == nil || h.fired {
 		return

--- a/internal/adapter/nfs/v4/state/lock_manager_unlocked_test.go
+++ b/internal/adapter/nfs/v4/state/lock_manager_unlocked_test.go
@@ -1,0 +1,199 @@
+package state
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// These tests pin two properties of every StateManager path that calls the
+// cross-protocol lock manager: the server-wide state mutex is not held across
+// the call, and the state resolved before the call is re-validated before the
+// result is committed.
+//
+// Both are asserted from inside the lock manager itself. A hook runs while the
+// manager call is in flight and, from another goroutine, performs an operation
+// that needs sm.mu. If sm.mu were still held the hook would block until the
+// timeout and fail the test; because it is not, the hook is free to mutate the
+// very state the caller resolved, which is exactly the race the re-validation
+// has to catch.
+
+// hookedLockManager wraps a real lock manager and runs a hook at the point one
+// chosen operation reaches it.
+type hookedLockManager struct {
+	lock.LockManager
+	onAddLock    func()
+	onRemoveLock func()
+	onGrantDeleg func()
+	fired        bool
+}
+
+// fire runs a hook at most once. The state-freeing paths these hooks trigger
+// call the lock manager themselves, so an unguarded hook would re-enter.
+func (h *hookedLockManager) fire(hook func()) {
+	if hook == nil || h.fired {
+		return
+	}
+	h.fired = true
+	hook()
+}
+
+func (h *hookedLockManager) AddUnifiedLock(handleKey string, l *lock.UnifiedLock) error {
+	h.fire(h.onAddLock)
+	return h.LockManager.AddUnifiedLock(handleKey, l)
+}
+
+func (h *hookedLockManager) RemoveUnifiedLock(handleKey string, owner lock.LockOwner, offset, length uint64) error {
+	h.fire(h.onRemoveLock)
+	return h.LockManager.RemoveUnifiedLock(handleKey, owner, offset, length)
+}
+
+func (h *hookedLockManager) GrantDelegation(handleKey string, d *lock.Delegation) error {
+	h.fire(h.onGrantDeleg)
+	return h.LockManager.GrantDelegation(handleKey, d)
+}
+
+// mutateUnderStateMutex runs fn on another goroutine and waits for it, failing
+// the test if it has not finished in time. fn must be something that needs
+// sm.mu, so a caller still holding the mutex is reported as a timeout rather
+// than deadlocking the test binary.
+func mutateUnderStateMutex(t *testing.T, what string, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Errorf("%s blocked while the lock manager was being called: the state mutex is still held across it", what)
+	}
+}
+
+// TestLockNew_LockManagerCalledWithoutStateMutex proves LOCK reaches the lock
+// manager with sm.mu released, and that a LOCK whose state is freed in that
+// window is refused instead of committing a seqid bump onto dead state.
+func TestLockNew_LockManagerCalledWithoutStateMutex(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	real := lock.NewManager()
+
+	var clientID uint64
+	lm := &hookedLockManager{LockManager: real}
+	lm.onAddLock = func() {
+		mutateUnderStateMutex(t, "the lease sweeper", func() { sm.onLeaseExpired(clientID) })
+	}
+	sm.SetLockManagerResolver(func(_ []byte) lock.LockManager { return lm })
+
+	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
+
+	res, err := sm.LockNew(context.Background(),
+		clientID, []byte("owner-a"), 1,
+		openStateid, openSeqid,
+		fileHandle, types.WRITE_LT, 0, 100, false,
+	)
+	if err == nil {
+		t.Fatalf("LOCK committed against state freed while the lock manager was called: %+v", res)
+	}
+
+	// The byte-range lock reached the manager before the state went away, so
+	// the refusal has to hand it back; otherwise nothing is left to release it.
+	if locks := real.ListUnifiedLocks(string(fileHandle)); len(locks) != 0 {
+		t.Fatalf("refused LOCK stranded %d lock(s) in the lock manager", len(locks))
+	}
+}
+
+// TestUnlockFile_LockManagerCalledWithoutStateMutex is the LOCKU counterpart:
+// the release reaches the manager unlocked, and the seqid bump is not committed
+// onto state freed in that window.
+func TestUnlockFile_LockManagerCalledWithoutStateMutex(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	real := lock.NewManager()
+
+	var clientID uint64
+	release := false
+	lm := &hookedLockManager{LockManager: real}
+	lm.onRemoveLock = func() {
+		if !release {
+			return
+		}
+		mutateUnderStateMutex(t, "RemoveClient", func() { sm.RemoveClient(clientID) })
+	}
+	sm.SetLockManagerResolver(func(_ []byte) lock.LockManager { return lm })
+
+	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
+
+	locked, err := sm.LockNew(context.Background(),
+		clientID, []byte("owner-a"), 1,
+		openStateid, openSeqid,
+		fileHandle, types.WRITE_LT, 0, 100, false,
+	)
+	if err != nil || locked.Denied != nil {
+		t.Fatalf("setup LOCK failed: err=%v denied=%v", err, locked)
+	}
+
+	lm.onRemoveLock = func() {
+		mutateUnderStateMutex(t, "the lease sweeper", func() { sm.onLeaseExpired(clientID) })
+	}
+	if _, err := sm.UnlockFile(&locked.Stateid, 2, types.WRITE_LT, 0, 100); err == nil {
+		t.Fatal("LOCKU committed a seqid bump against state freed while the lock manager was called")
+	}
+}
+
+// TestGrantDelegation_LockManagerCalledWithoutStateMutex proves OPEN reaches the
+// lock manager's delegation grant with sm.mu released, and that a grant which no
+// longer fits the delegation budget is handed back rather than published.
+func TestGrantDelegation_LockManagerCalledWithoutStateMutex(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	sm.SetMaxDelegations(1)
+	real := lock.NewManager()
+
+	fileHandle := []byte("/export:deleg-file")
+	lm := &hookedLockManager{LockManager: real}
+	lm.onGrantDeleg = func() {
+		// Take the last of the budget while the manager call is in flight.
+		mutateUnderStateMutex(t, "a competing delegation", func() {
+			sm.mu.Lock()
+			defer sm.mu.Unlock()
+			sm.delegByOther[[types.NFS4_OTHER_SIZE]byte{0xff}] = &DelegationState{ClientID: 999}
+		})
+	}
+	sm.SetLockManagerResolver(func(_ []byte) lock.LockManager { return lm })
+
+	clientID, _, _, _ := setupClientAndOpenState(t, sm)
+
+	if deleg := sm.GrantDelegation(clientID, fileHandle, types.OPEN_DELEGATE_READ); deleg != nil {
+		t.Fatal("delegation published past the budget that was taken while the lock manager was called")
+	}
+	if delegs := real.ListDelegations(string(fileHandle)); len(delegs) != 0 {
+		t.Fatalf("refused delegation stranded %d delegation(s) in the lock manager", len(delegs))
+	}
+}
+
+// TestGrantDirDelegation_LockManagerCalledWithoutStateMutex is the directory
+// delegation counterpart. Its recommit check re-runs the whole admission
+// decision, so the window is closed here by expiring the client's lease.
+func TestGrantDirDelegation_LockManagerCalledWithoutStateMutex(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	real := lock.NewManager()
+
+	dirFH := []byte("/export:deleg-dir")
+	var clientID uint64
+	lm := &hookedLockManager{LockManager: real}
+	lm.onGrantDeleg = func() {
+		mutateUnderStateMutex(t, "RemoveClient", func() { sm.RemoveClient(clientID) })
+	}
+	sm.SetLockManagerResolver(func(_ []byte) lock.LockManager { return lm })
+
+	clientID, _, _, _ = setupClientAndOpenState(t, sm)
+
+	if _, err := sm.GrantDirDelegation(clientID, dirFH, 0xffff); err == nil {
+		t.Fatal("directory delegation published for a client removed while the lock manager was called")
+	}
+	if delegs := real.ListDelegations(string(dirFH)); len(delegs) != 0 {
+		t.Fatalf("refused delegation stranded %d delegation(s) in the lock manager", len(delegs))
+	}
+}

--- a/internal/adapter/nfs/v4/state/lock_manager_unlocked_test.go
+++ b/internal/adapter/nfs/v4/state/lock_manager_unlocked_test.go
@@ -166,6 +166,33 @@ func TestGrantDelegation_LockManagerCalledWithoutStateMutex(t *testing.T) {
 	}
 }
 
+// TestGrantDelegation_ClientTornDownDuringLockManagerCall covers the other half
+// of the same recommit check: a client whose lease is swept while the manager
+// call is in flight. The sweeper frees that client's delegations once and never
+// revisits it, so a grant published afterwards would be unreachable from
+// cleanup.
+func TestGrantDelegation_ClientTornDownDuringLockManagerCall(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	realLM := lock.NewManager()
+
+	fileHandle := []byte("/export:deleg-file")
+	var clientID uint64
+	lm := &hookedLockManager{LockManager: realLM}
+	lm.onGrantDeleg = func() {
+		mutateUnderStateMutex(t, "the lease sweeper", func() { sm.onLeaseExpired(clientID) })
+	}
+	sm.SetLockManagerResolver(func(_ []byte) lock.LockManager { return lm })
+
+	clientID, _, _, _ = setupClientAndOpenState(t, sm)
+
+	if deleg := sm.GrantDelegation(clientID, fileHandle, types.OPEN_DELEGATE_READ); deleg != nil {
+		t.Fatal("delegation published for a client swept while the lock manager was called")
+	}
+	if delegs := realLM.ListDelegations(string(fileHandle)); len(delegs) != 0 {
+		t.Fatalf("refused delegation stranded %d delegation(s) in the lock manager", len(delegs))
+	}
+}
+
 // TestGrantDirDelegation_LockManagerCalledWithoutStateMutex is the directory
 // delegation counterpart. Its recommit check re-runs the whole admission
 // decision, so the window is closed here by expiring the client's lease.

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -2745,7 +2745,7 @@ func (sm *StateManager) acquireLock(ctx context.Context, lockState *LockState, l
 	}
 
 	sm.mu.Unlock()
-	denied, err := acquireUnifiedLock(ctx, lm, handleKey, enhLock, &owner, lockType, offset, length)
+	denied, err := acquireUnifiedLock(ctx, lm, handleKey, enhLock, lockType)
 	sm.mu.Lock()
 
 	if err != nil {
@@ -2798,7 +2798,8 @@ func (sm *StateManager) revalidateLockStateLocked(lockState *LockState) error {
 
 // acquireUnifiedLock performs the cross-protocol half of a byte-range lock
 // acquire: break conflicting leases, drain the break, insert the lock, and on
-// refusal describe the conflicting holder.
+// refusal describe the conflicting holder. lockType is the requested NFS4 lock
+// type, needed only to describe an unidentifiable conflict.
 //
 // It touches no StateManager state, so it runs without sm.mu.
 func acquireUnifiedLock(
@@ -2806,9 +2807,7 @@ func acquireUnifiedLock(
 	lm lock.LockManager,
 	handleKey string,
 	enhLock *lock.UnifiedLock,
-	owner *lock.LockOwner,
 	lockType uint32,
-	offset, length uint64,
 ) (*LOCK4denied, error) {
 	// Break any conflicting cross-protocol read leases (e.g. an SMB read/write
 	// oplock) before acquiring the byte-range lock. A held lease lets another
@@ -2819,7 +2818,7 @@ func acquireUnifiedLock(
 	// real byte-range lock is held. We pass this lock's owner as excludeOwner for
 	// symmetry with the SMB path; NFS owners never hold SMB leases, so in practice
 	// nothing is excluded.
-	_ = lm.BreakLeasesForByteRangeLock(handleKey, owner)
+	_ = lm.BreakLeasesForByteRangeLock(handleKey, &enhLock.Owner)
 
 	// Drain the in-flight lease break before inserting the lock: the break is
 	// fire-and-forget, so a still-present (Breaking, not-yet-ACKed) write lease is
@@ -2865,8 +2864,8 @@ func acquireUnifiedLock(
 
 		// Conflict exists but we couldn't identify the exact lock (shouldn't happen)
 		denied := &LOCK4denied{
-			Offset:   offset,
-			Length:   length,
+			Offset:   enhLock.Offset,
+			Length:   enhLock.Length,
 			LockType: lockType,
 		}
 		return denied, nil

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -2690,7 +2690,16 @@ func (sm *StateManager) LockExisting(
 // Returns (nil, nil) on success, (*LOCK4denied, nil) on conflict,
 // or (nil, error) on internal errors.
 //
-// Caller must hold sm.mu.
+// Caller must hold sm.mu. The mutex is RELEASED for the duration of the lock
+// manager call and held again on return: sm.mu serializes every client's state
+// operation server-wide, while the manager is cross-protocol and its acquire
+// path waits for an in-flight lease break in another protocol to drain, for as
+// long as lock.WaitForByteRangeLockBreak's timeout allows. Holding sm.mu across
+// that stalls every other client's SEQUENCE, OPEN, CLOSE and RENEW behind one
+// client's LOCK.
+//
+// The state the caller resolved before that gap is re-validated on return, so a
+// caller may treat a nil error as "still safe to commit against lockState".
 func (sm *StateManager) acquireLock(ctx context.Context, lockState *LockState, lockType uint32, offset, length uint64, reclaim bool) (*LOCK4denied, error) {
 	lm := sm.lockManagerFor(lockState.FileHandle)
 	if lm == nil {
@@ -2735,6 +2744,72 @@ func (sm *StateManager) acquireLock(ctx context.Context, lockState *LockState, l
 			lockState.LockOwner.ClientID, lockState.OpenState.Owner.ClientID)
 	}
 
+	sm.mu.Unlock()
+	denied, err := acquireUnifiedLock(ctx, lm, handleKey, enhLock, &owner, lockType, offset, length)
+	sm.mu.Lock()
+
+	if err != nil {
+		return nil, err
+	}
+
+	// While sm.mu was released the resolved state may have been freed under it —
+	// by a CLOSE, a RELEASE_LOCKOWNER, or the lease sweeper expiring the client.
+	// Committing a seqid bump onto freed state would hand the client a stateid
+	// the server no longer knows, and would strand the byte-range lock just
+	// inserted with no NFSv4 state left to ever release it. Give the lock back
+	// and fail the operation instead.
+	if staleErr := sm.revalidateLockStateLocked(lockState); staleErr != nil {
+		if denied == nil {
+			sm.mu.Unlock()
+			_ = lm.RemoveUnifiedLock(handleKey, owner, offset, length)
+			sm.mu.Lock()
+		}
+		return nil, staleErr
+	}
+
+	return denied, nil
+}
+
+// revalidateLockStateLocked reports whether the lock state and its lock-owner
+// are still the records the StateManager's maps point at. It is the recommit
+// check for a path that resolves state under sm.mu, releases the mutex for an
+// external call, and then writes a result back.
+//
+// The comparison is by pointer identity, not by presence: a stateid "other" and
+// a lock-owner key can both be handed out again once the original records are
+// freed, so "something exists under this key" does not mean "the record
+// resolved earlier is still live".
+//
+// The parent open state needs no separate check. Every path that frees an open
+// state frees its lock stateids in the same critical section — CLOSE at
+// openStateByOther, and the lease sweeper via releaseClientStateLocked — so a
+// live lock state implies a live open.
+//
+// Caller must hold sm.mu.
+func (sm *StateManager) revalidateLockStateLocked(lockState *LockState) error {
+	if sm.lockStateByOther[lockState.Stateid.Other] != lockState {
+		return sm.lockStateidMissError(lockState.Stateid.Other)
+	}
+	if lo := lockState.LockOwner; lo == nil || sm.lockOwners[lo.Key()] != lo {
+		return ErrBadStateid
+	}
+	return nil
+}
+
+// acquireUnifiedLock performs the cross-protocol half of a byte-range lock
+// acquire: break conflicting leases, drain the break, insert the lock, and on
+// refusal describe the conflicting holder.
+//
+// It touches no StateManager state, so it runs without sm.mu.
+func acquireUnifiedLock(
+	ctx context.Context,
+	lm lock.LockManager,
+	handleKey string,
+	enhLock *lock.UnifiedLock,
+	owner *lock.LockOwner,
+	lockType uint32,
+	offset, length uint64,
+) (*LOCK4denied, error) {
 	// Break any conflicting cross-protocol read leases (e.g. an SMB read/write
 	// oplock) before acquiring the byte-range lock. A held lease lets another
 	// protocol cache the bytes this lock is about to protect, so it must be
@@ -2744,7 +2819,7 @@ func (sm *StateManager) acquireLock(ctx context.Context, lockState *LockState, l
 	// real byte-range lock is held. We pass this lock's owner as excludeOwner for
 	// symmetry with the SMB path; NFS owners never hold SMB leases, so in practice
 	// nothing is excluded.
-	_ = lm.BreakLeasesForByteRangeLock(handleKey, &owner)
+	_ = lm.BreakLeasesForByteRangeLock(handleKey, owner)
 
 	// Drain the in-flight lease break before inserting the lock: the break is
 	// fire-and-forget, so a still-present (Breaking, not-yet-ACKed) write lease is
@@ -2973,7 +3048,9 @@ func (sm *StateManager) UnlockFile(
 		return nil, err
 	}
 
-	// 5. Release the lock via unified lock manager
+	// 5. Release the lock via the unified lock manager, with sm.mu released for
+	// the call: the manager is cross-protocol and sm.mu serializes every
+	// client's state operation server-wide (see acquireLock).
 	if lm := sm.lockManagerFor(lockState.FileHandle); lm != nil {
 		owner := lock.LockOwner{
 			OwnerID:   lockOwner.LockManagerOwnerID(),
@@ -2982,17 +3059,27 @@ func (sm *StateManager) UnlockFile(
 		}
 
 		handleKey := string(lockState.FileHandle)
-		err := lm.RemoveUnifiedLock(handleKey, owner, offset, length)
-		if err != nil {
+		sm.mu.Unlock()
+		rmErr := lm.RemoveUnifiedLock(handleKey, owner, offset, length)
+		sm.mu.Lock()
+		if rmErr != nil {
 			// Lock-not-found is OK for LOCKU (idempotent).
 			// Only fail on unexpected errors.
 			// RemoveUnifiedLock returns StoreError with ErrLockNotFound code.
 			// We treat all errors as non-fatal for idempotency.
 			logger.Debug("LOCKU: lock manager RemoveUnifiedLock returned error (idempotent OK)",
-				"error", err,
+				"error", rmErr,
 				"handle", handleKey,
 				"offset", offset,
 				"length", length)
+		}
+
+		// The state resolved above may have been freed while sm.mu was
+		// released. Removing the lock was the direction LOCKU was heading
+		// anyway, so it stands; the seqid bump below must not be committed onto
+		// state the server has since forgotten.
+		if staleErr := sm.revalidateLockStateLocked(lockState); staleErr != nil {
+			return nil, staleErr
 		}
 	}
 

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -2822,7 +2822,7 @@ func acquireUnifiedLock(
 
 	// Drain the in-flight lease break before inserting the lock: the break is
 	// fire-and-forget, so a still-present (Breaking, not-yet-ACKed) write lease is
-	// otherwise observed as a spurious DENIED → client EIO (#1501). See
+	// otherwise observed as a spurious DENIED → client EIO. See
 	// lock.WaitForByteRangeLockBreak for the deadlock-safety and timeout reasoning.
 	// A non-nil error means the originating request was cancelled, so don't insert
 	// a lock nobody is waiting for.


### PR DESCRIPTION
## What was wrong

`StateManager.sm.mu` is one `RWMutex` guarding every client record, open-owner, stateid and
lease for the whole server — not per-share, not per-file (`state/manager.go:28-30`). Five paths
called into the cross-protocol lock manager (`pkg/metadata/lock`) while holding it:

| Site | Lock-manager call under `sm.mu` |
|---|---|
| `LockNew` → `acquireLock` | `BreakLeasesForByteRangeLock`, `WaitForByteRangeLockBreak`, `AddUnifiedLock`, `ListUnifiedLocks` |
| `LockExisting` → `acquireLock` | same |
| `UnlockFile` | `RemoveUnifiedLock` |
| `GrantDelegation` | `GrantDelegation` |
| `GrantDirDelegation` | `GrantDelegation` |

`lock.WaitForByteRangeLockBreak` is not a map operation: it wraps the caller's context in a 5s
`byteRangeLockBreakWaitTimeout` (`pkg/metadata/lock/break.go:250,280`) and waits for an
in-flight SMB write-lease break to be acknowledged. So one client's LOCK racing an SMB writer
stalled every other NFSv4 client's SEQUENCE, OPEN, CLOSE, RENEW and DELEGRETURN for up to five
seconds, server-wide. Production reachability: `handlers/lock.go:155/194/472`,
`handlers/open.go:506/602`.

The lock manager also calls *back* into the StateManager — `NFSBreakHandler.OnDelegationRecall`
(`state/nfs_break_handler.go`) takes `sm.mu`. So holding `sm.mu` across `BreakLeasesForByteRangeLock`
risked a same-goroutine self-deadlock: the break it triggers dispatches a recall that re-enters
`sm.mu.Lock()`. That is the hazard `break.go`'s own doc comment works around by refusing to wait
on an NFSv4 delegation break at all ("DELEGRETURN needs the StateManager mutex this path holds").

`RevokeDelegation` (`manager.go:1199`) already avoided all of this in the same file, with the
comment *"Revoke in LockManager outside sm.mu (avoids deadlock per Pitfall 2)"*. This was a
deviation from an established local rule, not an unconsidered design.

## What changed

Each of the five sites now releases `sm.mu` for the manager call and re-acquires it before
returning, so callers keep their `defer sm.mu.Unlock()` and the deferred `consumeSeqidOnError`
closures still run under the mutex. `acquireLock`'s pure lock-manager half is split out as
`acquireUnifiedLock`, a package-level function that touches no `StateManager` state, which is
what makes "this runs unlocked" checkable rather than asserted.

### The recommit check, and why these sites owe one

The criterion recorded on #2398: release-call-recommit is safe *without* re-validation only when
the post-gap write is idempotent, keyed by something stable, and records a fact the gap cannot
falsify. `ReclaimComplete` (`manager.go:1338`) meets all three and needs nothing.

A stateid/seqid commit meets none. `LockNew`/`LockExisting`/`UnlockFile` write
`lockState.Stateid.Seqid` and `lockOwner.LastSeqID` and hand the bumped stateid back to the
client; the gap can falsify the liveness of both, via CLOSE, RELEASE_LOCKOWNER or the lease
sweeper. So `revalidateLockStateLocked` re-checks, by **pointer identity** rather than presence,
that the lock state and its lock-owner are still the records the maps point at — a stateid
`other` and a lock-owner key can both be issued again once the originals are freed. On failure
`acquireLock` hands the byte-range lock back to the manager, because a lock inserted with no
NFSv4 state left to release it is stranded for the life of the server.

The parent open state is deliberately *not* re-checked: every path that frees an open state
frees its lock stateids in the same critical section (`CloseFile`, and the sweeper via
`releaseClientStateLocked`), so a live lock state implies a live open. The doc comment says so,
so a future partial-removal path has something to contradict.

The two delegation grants publish a freshly-random stateid nothing else references, so what the
gap can falsify is the **inputs to the admission decision**. `GrantDirDelegation` re-runs
`admitDirDelegationLocked` whole (delegations enabled, lease live, budget, no duplicate on the
same handle) — extracting it made the recommit check a re-run rather than a second copy.
`GrantDelegation` re-checks the budget, and separately that a client which had a live lease going
in still has one: the lease sweeper frees a client's delegations in a single critical section and
never revisits that client, so a grant published after that sweep is unreachable from cleanup and
holds the file's conflicting leases and byte-range locks off until an unrelated conflict
eventually recalls and times it out. That liveness is *sampled* before the gap rather than
required, because this path has never demanded a live lease to grant and making it do so would be
a separate behaviour change. Either check failing hands the grant back to the manager and answers
`OPEN_DELEGATE_NONE`, which is always a legal answer.

That second half was missed in the first draft and caught in review: the asymmetry showed up as
`GrantDirDelegation` guarding client teardown while `GrantDelegation`, with the identical release
window, guarded only the budget.

`RevokeDelegation` was **not** copied for this part: it is only half the pattern — it discards
its result and commits nothing, so it re-validates nothing and could not be the precedent for
the CAS half.

### Fifth site

The issue names four sites. `GrantDirDelegation` (`dir_delegation.go`) is a sibling caller of
the same seam with the identical defect, found by grepping every `lm.` call in the package; it
is fixed here rather than left for a later "why was only the file-delegation path done" pass.

## Deliberately out of scope

`hasOutstandingLocksLocked`, `removeOwnerLocksLocked` and `ReleaseLockOwner` still call
`ListUnifiedLocks`/`RemoveUnifiedLock` under `sm.mu`. Those are map operations against the
manager's own mutex with no waiting, and they run in the middle of multi-step critical sections
(client expiry) that cannot be split without restructuring expiry itself. Not the blocking call
this issue is about.

## Evidence

Five new tests in `state/lock_manager_unlocked_test.go`, one per site plus one for the
client-teardown half of `GrantDelegation`'s check. Each wraps a real
`lock.Manager` in a hook that fires while the manager call is in flight and, from another
goroutine, performs an operation needing `sm.mu` — the lease sweeper expiring the client, or a
competing delegation taking the last of the budget. That single hook asserts both halves: a
still-held `sm.mu` shows up as the hook blocking to a 5s deadline, and a missing recommit check
shows up as a committed result.

Both halves verified by neutralizing the guard in a `go test -overlay` copy, without touching
the branch:

- Remove the `sm.mu.Unlock()`/`Lock()` pairs → every test reports *"the state mutex is still
  held across it"* after 5.00s each.
- Make `revalidateLockStateLocked` return nil and drop the two delegation re-checks → all five
  tests report a committed result (`LOCK committed against state freed while the lock manager
  was called`, `LOCKU committed a seqid bump…`, `delegation published past the budget…`,
  `delegation published for a client swept…`, `directory delegation published for a client
  removed…`).

`go test -race ./internal/adapter/nfs/... ./pkg/metadata/lock/...` green;
`golangci-lint run ./internal/adapter/nfs/v4/state/...` clean.

On lock ordering specifically: `lm.breakDelegations` (`pkg/metadata/lock/delegation.go`) releases
`lm.mu` before dispatching to `BreakCallbacks.OnDelegationRecall`, so there is no
`lm.mu → sm.mu` hold-and-wait from the manager side — the risk was only the self-deadlock
described above, and releasing `sm.mu` removes it.

## Note on seqid semantics

The re-validation's error lands in the right RFC 7530 §9.1.7 class with no special handling:
`failedSeqidReply` (`openowner.go:100`) exempts `NFS4ERR_BAD_STATEID` and
`NFS4ERR_STALE_STATEID` from consuming the owner seqid and consumes it for `NFS4ERR_EXPIRED`,
matching nfsd's `seqid_mutating_err()`.

Closes #2398
