### PR TITLE
fix(nfs): narrow the SECINFO flavor list to the target share's auth-flavor policy

### DIFF
--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -358,6 +358,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 		rt.SetNetlogonController(nlController)
 	}
 
+	rt.SetKerberosEnabled(effectiveKerberos.Enabled)
 	rt.SetAdapterFactory(createAdapterFactory(&effectiveKerberos, nlAuth))
 
 	// Create and set API server

--- a/docs/guide/nfs.md
+++ b/docs/guide/nfs.md
@@ -612,6 +612,16 @@ operation that resolves the export handle — v4 has no MOUNT call). A refusal
 surfaces as `NFS4ERR_WRONGSEC` (v4) / `MNT3ERR_ACCES` (v3), prompting the client
 to retry with the correct flavor.
 
+On NFSv4 the retry is guided by SECINFO, which reports only the flavors the
+target share's policy actually permits — a share never advertises a flavor it
+would then refuse. A name that crosses an export junction reports the policy of
+the share it lands in, not the parent's; a pseudo-filesystem path, which belongs
+to no share, reports the full set the server offers.
+
+`require_kerberos=true` is rejected when the server has no Kerberos configured:
+such a share would be reachable by no auth flavor at all, and SECINFO would have
+nothing to report. Configure `kerberos.enabled` first.
+
 `min_kerberos_level` only constrains RPCSEC_GSS sessions: it rejects a Kerberos
 session whose negotiated service level is below the floor (e.g. a plain `krb5`
 authentication-only session on a `krb5p` privacy share). Non-GSS flavors are

--- a/internal/adapter/nfs/v4/handlers/secinfo.go
+++ b/internal/adapter/nfs/v4/handlers/secinfo.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"io"
+	"slices"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/auth"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc/gss"
@@ -25,9 +26,17 @@ var krb5OIDDER = []byte{0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x12, 0x01, 0x
 // RPCSEC_GSS auth flavor value per RFC 2203.
 const authRPCSECGSS uint32 = 6
 
+// The non-GSS auth flavors SECINFO can offer.
+const (
+	authNoneFlavor uint32 = 0
+	authSysFlavor  uint32 = 1
+)
+
 // handleSecInfo implements the SECINFO operation (RFC 7530 Section 16.31).
 // Resolves a name in the current directory, then returns the security
-// mechanisms (AUTH_SYS, AUTH_NONE, optionally Kerberos) the server offers.
+// mechanisms usable on what it resolved to -- AUTH_SYS, AUTH_NONE and the
+// Kerberos services, less whatever the target share's export auth-flavor
+// policy refuses.
 // Errors: NFS4ERR_NOFILEHANDLE, NFS4ERR_BADXDR, NFS4ERR_INVAL, NFS4ERR_NOTDIR,
 // NFS4ERR_NOENT, NFS4ERR_ACCESS.
 func (h *Handler) handleSecInfo(ctx *types.CompoundContext, reader io.Reader) *types.CompoundResult {
@@ -109,7 +118,7 @@ func (h *Handler) secInfoLookupStatus(ctx *types.CompoundContext, name string) (
 	if status == types.NFS4ERR_WRONGSEC {
 		// The lookup never advanced the filehandle, so the policy reported is
 		// the refusing share's own -- which is the one the client needs.
-		return types.NFS4_OK, target
+		status = types.NFS4_OK
 	}
 	return status, target
 }
@@ -156,18 +165,13 @@ func (h *Handler) shareForHandle(handle []byte) *runtime.Share {
 // (RFC 8881 Section 18.45.2) and so shares this encoding.
 //
 // The candidate set is server-wide -- it depends on whether Kerberos is
-// configured -- but the answer is per-object, because share carries the export
-// auth-flavor policy buildV4AuthContext enforces on every real operation.
-// Advertising a flavor that policy rejects is the exact failure SECINFO exists
-// to prevent: the client picks a listed flavor, gets NFS4ERR_WRONGSEC, asks
-// SECINFO again and is handed the same list. A nil share means no policy is
-// known, so nothing is narrowed.
+// configured -- but the answer is per-object, because the share carries the
+// export auth-flavor policy buildV4AuthContext enforces on every real
+// operation. Advertising a flavor that policy rejects is the exact failure
+// SECINFO exists to prevent: the client picks a listed flavor, gets
+// NFS4ERR_WRONGSEC, asks SECINFO again and is handed the same list. A nil
+// share means no policy is known, so nothing is narrowed.
 func encodeSecInfoFlavors(kerberosEnabled bool, share *runtime.Share) []byte {
-	const (
-		authNoneFlavor = 0
-		authSysFlavor  = 1
-	)
-
 	var gssServices []uint32
 	if kerberosEnabled {
 		gssServices = []uint32{gss.RPCGSSSvcPrivacy, gss.RPCGSSSvcIntegrity, gss.RPCGSSSvcNone}
@@ -186,13 +190,9 @@ func encodeSecInfoFlavors(kerberosEnabled bool, share *runtime.Share) []byte {
 		}
 		// MinKerberosLevel is a floor on the negotiated GSS service, so any
 		// weaker service is unusable on this share.
-		kept := make([]uint32, 0, len(gssServices))
-		for _, svc := range gssServices {
-			if auth.MeetsMinKerberosLevel(share.MinKerberosLevel, svc) {
-				kept = append(kept, svc)
-			}
-		}
-		gssServices = kept
+		gssServices = slices.DeleteFunc(gssServices, func(svc uint32) bool {
+			return !auth.MeetsMinKerberosLevel(share.MinKerberosLevel, svc)
+		})
 	}
 
 	var buf bytes.Buffer

--- a/internal/adapter/nfs/v4/handlers/secinfo.go
+++ b/internal/adapter/nfs/v4/handlers/secinfo.go
@@ -4,10 +4,14 @@ import (
 	"bytes"
 	"io"
 
+	"github.com/marmos91/dittofs/internal/adapter/nfs/auth"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc/gss"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/pseudofs"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
 	"github.com/marmos91/dittofs/internal/logger"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
 // krb5OIDDER is the DER-encoded OID for the Kerberos 5 GSS-API mechanism.
@@ -17,14 +21,6 @@ import (
 // Per RFC 7530 Section 3.2.1, sec_oid4 is opaque<> containing the
 // mechanism OID in DER format.
 var krb5OIDDER = []byte{0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x12, 0x01, 0x02, 0x02}
-
-// RPCSEC_GSS service levels for SECINFO responses.
-// These match the rpc_gss_svc_t values from RFC 2203 Section 5.3.1.
-const (
-	rpcGSSSvcNone      uint32 = 1
-	rpcGSSSvcIntegrity uint32 = 2
-	rpcGSSSvcPrivacy   uint32 = 3
-)
 
 // RPCSEC_GSS auth flavor value per RFC 2203.
 const authRPCSECGSS uint32 = 6
@@ -52,8 +48,12 @@ func (h *Handler) handleSecInfo(ctx *types.CompoundContext, reader io.Reader) *t
 	}
 
 	// SECINFO reports on an existing directory entry, so the name has to
-	// resolve before any flavor list is built.
-	if status := h.secInfoLookupStatus(ctx, name); status != types.NFS4_OK {
+	// resolve before any flavor list is built. The resolved handle is what the
+	// flavor list is about: a name that crosses an export junction lands in
+	// another share, whose auth-flavor policy -- not the parent's -- is the one
+	// the client will meet.
+	status, target := h.secInfoLookupStatus(ctx, name)
+	if status != types.NFS4_OK {
 		logger.Debug("SECINFO: name did not resolve",
 			"name", name,
 			"status", status,
@@ -72,19 +72,21 @@ func (h *Handler) handleSecInfo(ctx *types.CompoundContext, reader io.Reader) *t
 	return &types.CompoundResult{
 		Status: types.NFS4_OK,
 		OpCode: types.OP_SECINFO,
-		Data:   encodeSecInfoFlavors(h.KerberosEnabled),
+		Data:   h.secInfoFlavorsForHandle(target),
 	}
 }
 
 // secInfoLookupStatus resolves name under the current filehandle and reports
-// the status of that resolution, leaving the current filehandle unchanged.
+// the status of that resolution together with the handle it resolved to,
+// leaving the current filehandle unchanged. The returned handle is the current
+// filehandle itself when the resolution did not advance it.
 //
 // SECINFO applies the same access methodology as LOOKUP (RFC 7530
 // Section 16.31.4): a non-directory current filehandle answers NFS4ERR_NOTDIR,
 // a name that is not there NFS4ERR_NOENT, and a directory the caller may not
 // search NFS4ERR_ACCESS. Reusing the LOOKUP path is what keeps the two in
 // step; only LOOKUP's effect on the current filehandle is discarded.
-func (h *Handler) secInfoLookupStatus(ctx *types.CompoundContext, name string) uint32 {
+func (h *Handler) secInfoLookupStatus(ctx *types.CompoundContext, name string) (uint32, []byte) {
 	saved := ctx.CurrentFH
 	defer func() { ctx.CurrentFH = saved }()
 
@@ -94,6 +96,7 @@ func (h *Handler) secInfoLookupStatus(ctx *types.CompoundContext, name string) u
 	} else {
 		status = h.lookupInRealFS(ctx, name).Status
 	}
+	target := ctx.CurrentFH
 
 	// A WRONGSEC from the export's auth-flavor policy is the one status that
 	// must not reach the caller: it is the answer to the question SECINFO was
@@ -104,9 +107,11 @@ func (h *Handler) secInfoLookupStatus(ctx *types.CompoundContext, name string) u
 	// the entry exists goes unreported, and it is unreachable on this flavor
 	// either way.
 	if status == types.NFS4ERR_WRONGSEC {
-		return types.NFS4_OK
+		// The lookup never advanced the filehandle, so the policy reported is
+		// the refusing share's own -- which is the one the client needs.
+		return types.NFS4_OK, target
 	}
-	return status
+	return status, target
 }
 
 // secInfoErr builds a status-only result for SECINFO or SECINFO_NO_NAME.
@@ -118,36 +123,87 @@ func secInfoErr(opCode, status uint32) *types.CompoundResult {
 	}
 }
 
+// secInfoFlavorsForHandle encodes the SECINFO4res flavor list for the object
+// handle designates, narrowed to the export auth-flavor policy of the share
+// owning it. A pseudo-filesystem handle belongs to no share and gets the
+// server-wide list.
+func (h *Handler) secInfoFlavorsForHandle(handle []byte) []byte {
+	return encodeSecInfoFlavors(h.KerberosEnabled, h.shareForHandle(handle))
+}
+
+// shareForHandle resolves the share a real-filesystem filehandle belongs to.
+// It returns nil for a pseudo-filesystem handle, an undecodable handle, or a
+// share the registry no longer holds -- all cases where no per-share policy is
+// known.
+func (h *Handler) shareForHandle(handle []byte) *runtime.Share {
+	if h.Registry == nil || pseudofs.IsPseudoFSHandle(handle) {
+		return nil
+	}
+	shareName, _, err := metadata.DecodeFileHandle(metadata.FileHandle(handle))
+	if err != nil {
+		return nil
+	}
+	share, err := h.Registry.GetShare(shareName)
+	if err != nil {
+		return nil
+	}
+	return share
+}
+
 // encodeSecInfoFlavors encodes a SECINFO4res body: NFS4_OK followed by the
-// secinfo4 array the server offers, most preferred first (RFC 7530
-// Section 16.31.4). SECINFO_NO_NAME shares the result type (RFC 8881
-// Section 18.45.2) and so shares this encoding.
+// secinfo4 array the server offers for one object, most preferred first
+// (RFC 7530 Section 16.31.4). SECINFO_NO_NAME shares the result type
+// (RFC 8881 Section 18.45.2) and so shares this encoding.
 //
-// The list is server-wide rather than per-object: it depends only on whether
-// Kerberos is configured.
-func encodeSecInfoFlavors(kerberosEnabled bool) []byte {
+// The candidate set is server-wide -- it depends on whether Kerberos is
+// configured -- but the answer is per-object, because share carries the export
+// auth-flavor policy buildV4AuthContext enforces on every real operation.
+// Advertising a flavor that policy rejects is the exact failure SECINFO exists
+// to prevent: the client picks a listed flavor, gets NFS4ERR_WRONGSEC, asks
+// SECINFO again and is handed the same list. A nil share means no policy is
+// known, so nothing is narrowed.
+func encodeSecInfoFlavors(kerberosEnabled bool, share *runtime.Share) []byte {
 	const (
 		authNoneFlavor = 0
 		authSysFlavor  = 1
 	)
 
-	var buf bytes.Buffer
-	_ = xdr.WriteUint32(&buf, types.NFS4_OK)
-
+	var gssServices []uint32
 	if kerberosEnabled {
-		// krb5p, krb5i, krb5, AUTH_SYS, AUTH_NONE -- most secure first.
-		_ = xdr.WriteUint32(&buf, 5)
-		encodeSecInfoGSSEntry(&buf, rpcGSSSvcPrivacy)
-		encodeSecInfoGSSEntry(&buf, rpcGSSSvcIntegrity)
-		encodeSecInfoGSSEntry(&buf, rpcGSSSvcNone)
-		_ = xdr.WriteUint32(&buf, authSysFlavor)
-		_ = xdr.WriteUint32(&buf, authNoneFlavor)
-	} else {
-		_ = xdr.WriteUint32(&buf, 2)
-		_ = xdr.WriteUint32(&buf, authSysFlavor)
-		_ = xdr.WriteUint32(&buf, authNoneFlavor)
+		gssServices = []uint32{gss.RPCGSSSvcPrivacy, gss.RPCGSSSvcIntegrity, gss.RPCGSSSvcNone}
+	}
+	rawFlavors := []uint32{authSysFlavor, authNoneFlavor}
+
+	if share != nil {
+		// RequireKerberos refuses every non-GSS flavor; AllowAuthSys=false
+		// refuses only AUTH_SYS. Same two conditions, same order, as the
+		// checks in buildV4AuthContext.
+		switch {
+		case share.RequireKerberos:
+			rawFlavors = nil
+		case !share.AllowAuthSys:
+			rawFlavors = []uint32{authNoneFlavor}
+		}
+		// MinKerberosLevel is a floor on the negotiated GSS service, so any
+		// weaker service is unusable on this share.
+		kept := make([]uint32, 0, len(gssServices))
+		for _, svc := range gssServices {
+			if auth.MeetsMinKerberosLevel(share.MinKerberosLevel, svc) {
+				kept = append(kept, svc)
+			}
+		}
+		gssServices = kept
 	}
 
+	var buf bytes.Buffer
+	_ = xdr.WriteUint32(&buf, types.NFS4_OK)
+	_ = xdr.WriteUint32(&buf, uint32(len(gssServices)+len(rawFlavors)))
+	for _, svc := range gssServices {
+		encodeSecInfoGSSEntry(&buf, svc)
+	}
+	for _, flavor := range rawFlavors {
+		_ = xdr.WriteUint32(&buf, flavor)
+	}
 	return buf.Bytes()
 }
 

--- a/internal/adapter/nfs/v4/handlers/secinfo_no_name.go
+++ b/internal/adapter/nfs/v4/handlers/secinfo_no_name.go
@@ -46,12 +46,18 @@ func (h *Handler) handleSecInfoNoName(
 		return secInfoErr(types.OP_SECINFO_NO_NAME, types.NFS4ERR_INVAL)
 	}
 
+	// Both styles report on the share the current filehandle belongs to: for
+	// SECINFO_STYLE4_CURRENT_FH it is the object itself, and a parent within a
+	// real share carries that same share's policy. Read it before the
+	// filehandle is consumed below.
+	flavors := h.secInfoFlavorsForHandle(ctx.CurrentFH)
+
 	ctx.CurrentFH = nil
 
 	return &types.CompoundResult{
 		Status: types.NFS4_OK,
 		OpCode: types.OP_SECINFO_NO_NAME,
-		Data:   encodeSecInfoFlavors(h.KerberosEnabled),
+		Data:   flavors,
 	}
 }
 
@@ -80,5 +86,6 @@ func (h *Handler) secInfoParentStatus(ctx *types.CompoundContext) uint32 {
 
 	// Resolving "." applies the directory-type and search-permission checks
 	// LOOKUPP would, without needing the parent handle the caller never sees.
-	return h.secInfoLookupStatus(ctx, ".")
+	status, _ := h.secInfoLookupStatus(ctx, ".")
+	return status
 }

--- a/internal/adapter/nfs/v4/handlers/secinfo_policy_test.go
+++ b/internal/adapter/nfs/v4/handlers/secinfo_policy_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"slices"
 	"testing"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc/gss"
@@ -63,8 +64,8 @@ func decodeSecInfoFlavors(t *testing.T, data []byte) []secInfoEntry {
 	return entries
 }
 
-// secInfoOnName runs SECINFO for name against the fixture's share root and
-// returns the decoded flavor list.
+// secInfoOnName runs SECINFO for name under the current filehandle and returns
+// the decoded flavor list.
 func secInfoOnName(t *testing.T, fx *realFSTestFixture, current metadata.FileHandle, name string) []secInfoEntry {
 	t.Helper()
 
@@ -79,27 +80,16 @@ func secInfoOnName(t *testing.T, fx *realFSTestFixture, current metadata.FileHan
 }
 
 func hasFlavor(entries []secInfoEntry, flavor uint32) bool {
-	for _, e := range entries {
-		if e.Flavor == flavor {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(entries, func(e secInfoEntry) bool {
+		return e.Flavor == flavor
+	})
 }
 
 func hasGSSService(entries []secInfoEntry, service uint32) bool {
-	for _, e := range entries {
-		if e.Flavor == authRPCSECGSS && e.GSSService == service {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(entries, func(e secInfoEntry) bool {
+		return e.Flavor == authRPCSECGSS && e.GSSService == service
+	})
 }
-
-const (
-	testAuthNoneFlavor = 0
-	testAuthSysFlavor  = 1
-)
 
 // TestSecInfo_AllowAuthSysFalseDropsAuthSys pins the AllowAuthSys narrowing:
 // buildV4AuthContext answers NFS4ERR_WRONGSEC on AUTH_SYS for such a share, so
@@ -114,10 +104,10 @@ func TestSecInfo_AllowAuthSysFalseDropsAuthSys(t *testing.T) {
 
 	entries := secInfoOnName(t, fx, fx.rootHandle, "hello.txt")
 
-	if hasFlavor(entries, testAuthSysFlavor) {
+	if hasFlavor(entries, authSysFlavor) {
 		t.Errorf("SECINFO offered AUTH_SYS on an allow_auth_sys=false share: %+v", entries)
 	}
-	if !hasFlavor(entries, testAuthNoneFlavor) {
+	if !hasFlavor(entries, authNoneFlavor) {
 		t.Errorf("SECINFO dropped AUTH_NONE, which allow_auth_sys=false does not refuse: %+v", entries)
 	}
 }
@@ -136,7 +126,7 @@ func TestSecInfo_RequireKerberosDropsNonGSS(t *testing.T) {
 
 	entries := secInfoOnName(t, fx, fx.rootHandle, "hello.txt")
 
-	if hasFlavor(entries, testAuthSysFlavor) || hasFlavor(entries, testAuthNoneFlavor) {
+	if hasFlavor(entries, authSysFlavor) || hasFlavor(entries, authNoneFlavor) {
 		t.Errorf("SECINFO offered a non-GSS flavor on a require_kerberos share: %+v", entries)
 	}
 	if len(entries) != 3 {
@@ -188,10 +178,10 @@ func TestSecInfo_JunctionReportsTargetPolicy(t *testing.T) {
 	pseudoRoot := fx.handler.PseudoFS.GetRootHandle()
 	entries := secInfoOnName(t, fx, pseudoRoot, "export")
 
-	if hasFlavor(entries, testAuthSysFlavor) {
+	if hasFlavor(entries, authSysFlavor) {
 		t.Errorf("SECINFO across a junction offered AUTH_SYS, which the target share refuses: %+v", entries)
 	}
-	if !hasFlavor(entries, testAuthNoneFlavor) {
+	if !hasFlavor(entries, authNoneFlavor) {
 		t.Errorf("SECINFO across a junction dropped AUTH_NONE: %+v", entries)
 	}
 }
@@ -209,15 +199,14 @@ func TestSecInfoNoName_PseudoFSKeepsServerWideList(t *testing.T) {
 	ctx := newRealFSContext(0, 0)
 	ctx.CurrentFH = append([]byte(nil), fx.handler.PseudoFS.GetRootHandle()...)
 
-	args := encodeSecInfoNoNameArgs(types.SECINFO_STYLE4_CURRENT_FH)
-
-	result := fx.handler.handleSecInfoNoName(ctx, nil, bytes.NewReader(args))
+	args := bytes.NewReader(encodeSecInfoNoNameArgs(types.SECINFO_STYLE4_CURRENT_FH))
+	result := fx.handler.handleSecInfoNoName(ctx, nil, args)
 	if result.Status != types.NFS4_OK {
 		t.Fatalf("SECINFO_NO_NAME status = %d, want NFS4_OK", result.Status)
 	}
 
 	entries := decodeSecInfoFlavors(t, result.Data)
-	if !hasFlavor(entries, testAuthSysFlavor) || !hasFlavor(entries, testAuthNoneFlavor) {
+	if !hasFlavor(entries, authSysFlavor) || !hasFlavor(entries, authNoneFlavor) {
 		t.Errorf("SECINFO_NO_NAME on the pseudo-fs root narrowed to a share's policy: %+v", entries)
 	}
 }

--- a/internal/adapter/nfs/v4/handlers/secinfo_policy_test.go
+++ b/internal/adapter/nfs/v4/handlers/secinfo_policy_test.go
@@ -1,0 +1,223 @@
+package handlers
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc/gss"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// secInfoEntry is one decoded secinfo4 entry. GSSService is zero for the
+// non-GSS flavors, which carry no service level.
+type secInfoEntry struct {
+	Flavor     uint32
+	GSSService uint32
+}
+
+// decodeSecInfoFlavors parses a SECINFO4res body into its flavor entries.
+func decodeSecInfoFlavors(t *testing.T, data []byte) []secInfoEntry {
+	t.Helper()
+
+	reader := bytes.NewReader(data)
+	status, err := xdr.DecodeUint32(reader)
+	if err != nil {
+		t.Fatalf("decode status: %v", err)
+	}
+	if status != types.NFS4_OK {
+		t.Fatalf("encoded status = %d, want NFS4_OK", status)
+	}
+	count, err := xdr.DecodeUint32(reader)
+	if err != nil {
+		t.Fatalf("decode array length: %v", err)
+	}
+
+	entries := make([]secInfoEntry, 0, count)
+	for i := uint32(0); i < count; i++ {
+		flavor, err := xdr.DecodeUint32(reader)
+		if err != nil {
+			t.Fatalf("decode flavor[%d]: %v", i, err)
+		}
+		entry := secInfoEntry{Flavor: flavor}
+		if flavor == authRPCSECGSS {
+			if _, err := xdr.DecodeOpaque(reader); err != nil {
+				t.Fatalf("decode oid[%d]: %v", i, err)
+			}
+			if _, err := xdr.DecodeUint32(reader); err != nil {
+				t.Fatalf("decode qop[%d]: %v", i, err)
+			}
+			svc, err := xdr.DecodeUint32(reader)
+			if err != nil {
+				t.Fatalf("decode service[%d]: %v", i, err)
+			}
+			entry.GSSService = svc
+		}
+		entries = append(entries, entry)
+	}
+	if reader.Len() != 0 {
+		t.Fatalf("SECINFO4res has %d trailing bytes", reader.Len())
+	}
+	return entries
+}
+
+// secInfoOnName runs SECINFO for name against the fixture's share root and
+// returns the decoded flavor list.
+func secInfoOnName(t *testing.T, fx *realFSTestFixture, current metadata.FileHandle, name string) []secInfoEntry {
+	t.Helper()
+
+	ctx := newRealFSContext(0, 0)
+	ctx.CurrentFH = append([]byte(nil), current...)
+
+	result := fx.handler.handleSecInfo(ctx, bytes.NewReader(encodeSecInfoArgs(name)))
+	if result.Status != types.NFS4_OK {
+		t.Fatalf("SECINFO(%q) status = %d, want NFS4_OK", name, result.Status)
+	}
+	return decodeSecInfoFlavors(t, result.Data)
+}
+
+func hasFlavor(entries []secInfoEntry, flavor uint32) bool {
+	for _, e := range entries {
+		if e.Flavor == flavor {
+			return true
+		}
+	}
+	return false
+}
+
+func hasGSSService(entries []secInfoEntry, service uint32) bool {
+	for _, e := range entries {
+		if e.Flavor == authRPCSECGSS && e.GSSService == service {
+			return true
+		}
+	}
+	return false
+}
+
+const (
+	testAuthNoneFlavor = 0
+	testAuthSysFlavor  = 1
+)
+
+// TestSecInfo_AllowAuthSysFalseDropsAuthSys pins the AllowAuthSys narrowing:
+// buildV4AuthContext answers NFS4ERR_WRONGSEC on AUTH_SYS for such a share, so
+// SECINFO must not offer it. AUTH_NONE is untouched by that field.
+func TestSecInfo_AllowAuthSysFalseDropsAuthSys(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+	fx.createTestFile(t, fx.rootHandle, "hello.txt", metadata.FileTypeRegular, 0o644, 0, 0)
+
+	if err := fx.rt.SetExportAuthPolicyForTesting("/export", false, false); err != nil {
+		t.Fatalf("SetExportAuthPolicyForTesting: %v", err)
+	}
+
+	entries := secInfoOnName(t, fx, fx.rootHandle, "hello.txt")
+
+	if hasFlavor(entries, testAuthSysFlavor) {
+		t.Errorf("SECINFO offered AUTH_SYS on an allow_auth_sys=false share: %+v", entries)
+	}
+	if !hasFlavor(entries, testAuthNoneFlavor) {
+		t.Errorf("SECINFO dropped AUTH_NONE, which allow_auth_sys=false does not refuse: %+v", entries)
+	}
+}
+
+// TestSecInfo_RequireKerberosDropsNonGSS pins the RequireKerberos narrowing:
+// the share refuses every non-GSS flavor, so neither AUTH_SYS nor AUTH_NONE may
+// be advertised. Kerberos is enabled here, so the list is non-empty.
+func TestSecInfo_RequireKerberosDropsNonGSS(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+	fx.handler.KerberosEnabled = true
+	fx.createTestFile(t, fx.rootHandle, "hello.txt", metadata.FileTypeRegular, 0o644, 0, 0)
+
+	if err := fx.rt.SetExportAuthPolicyForTesting("/export", true, true); err != nil {
+		t.Fatalf("SetExportAuthPolicyForTesting: %v", err)
+	}
+
+	entries := secInfoOnName(t, fx, fx.rootHandle, "hello.txt")
+
+	if hasFlavor(entries, testAuthSysFlavor) || hasFlavor(entries, testAuthNoneFlavor) {
+		t.Errorf("SECINFO offered a non-GSS flavor on a require_kerberos share: %+v", entries)
+	}
+	if len(entries) != 3 {
+		t.Errorf("SECINFO offered %d flavors, want the 3 Kerberos services: %+v", len(entries), entries)
+	}
+}
+
+// TestSecInfo_MinKerberosLevelDropsWeakerServices pins the MinKerberosLevel
+// floor: a krb5p share rejects a negotiated krb5 or krb5i session, so only the
+// privacy entry may be advertised.
+func TestSecInfo_MinKerberosLevelDropsWeakerServices(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+	fx.handler.KerberosEnabled = true
+	fx.createTestFile(t, fx.rootHandle, "hello.txt", metadata.FileTypeRegular, 0o644, 0, 0)
+
+	if err := fx.rt.SetMinKerberosLevelForTesting("/export", models.KerberosLevelKrb5p); err != nil {
+		t.Fatalf("SetMinKerberosLevelForTesting: %v", err)
+	}
+
+	entries := secInfoOnName(t, fx, fx.rootHandle, "hello.txt")
+
+	if !hasGSSService(entries, gss.RPCGSSSvcPrivacy) {
+		t.Errorf("SECINFO dropped krb5p on a min_kerberos_level=krb5p share: %+v", entries)
+	}
+	if hasGSSService(entries, gss.RPCGSSSvcIntegrity) {
+		t.Errorf("SECINFO offered krb5i below the krb5p floor: %+v", entries)
+	}
+	if hasGSSService(entries, gss.RPCGSSSvcNone) {
+		t.Errorf("SECINFO offered plain krb5 below the krb5p floor: %+v", entries)
+	}
+}
+
+// TestSecInfo_JunctionReportsTargetPolicy pins that a name resolving across an
+// export junction reports the target share's policy. The current filehandle is
+// the pseudo-fs root, which has no policy of its own; the flavor list has to
+// come from the share the name lands in.
+func TestSecInfo_JunctionReportsTargetPolicy(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+
+	if err := fx.rt.SetExportAuthPolicyForTesting("/export", false, false); err != nil {
+		t.Fatalf("SetExportAuthPolicyForTesting: %v", err)
+	}
+	// RegisterShareForTesting leaves RootHandle empty; the junction crossing
+	// needs it to reach the share root the way a real export does.
+	if err := fx.rt.SetRootHandleForTesting("/export", fx.rootHandle); err != nil {
+		t.Fatalf("SetRootHandleForTesting: %v", err)
+	}
+
+	pseudoRoot := fx.handler.PseudoFS.GetRootHandle()
+	entries := secInfoOnName(t, fx, pseudoRoot, "export")
+
+	if hasFlavor(entries, testAuthSysFlavor) {
+		t.Errorf("SECINFO across a junction offered AUTH_SYS, which the target share refuses: %+v", entries)
+	}
+	if !hasFlavor(entries, testAuthNoneFlavor) {
+		t.Errorf("SECINFO across a junction dropped AUTH_NONE: %+v", entries)
+	}
+}
+
+// TestSecInfoNoName_PseudoFSKeepsServerWideList pins that a pseudo-fs
+// filehandle, which belongs to no share, is answered with the server-wide list
+// even when every configured share narrows its own.
+func TestSecInfoNoName_PseudoFSKeepsServerWideList(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+
+	if err := fx.rt.SetExportAuthPolicyForTesting("/export", false, true); err != nil {
+		t.Fatalf("SetExportAuthPolicyForTesting: %v", err)
+	}
+
+	ctx := newRealFSContext(0, 0)
+	ctx.CurrentFH = append([]byte(nil), fx.handler.PseudoFS.GetRootHandle()...)
+
+	args := encodeSecInfoNoNameArgs(types.SECINFO_STYLE4_CURRENT_FH)
+
+	result := fx.handler.handleSecInfoNoName(ctx, nil, bytes.NewReader(args))
+	if result.Status != types.NFS4_OK {
+		t.Fatalf("SECINFO_NO_NAME status = %d, want NFS4_OK", result.Status)
+	}
+
+	entries := decodeSecInfoFlavors(t, result.Data)
+	if !hasFlavor(entries, testAuthSysFlavor) || !hasFlavor(entries, testAuthNoneFlavor) {
+		t.Errorf("SECINFO_NO_NAME on the pseudo-fs root narrowed to a share's policy: %+v", entries)
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/secinfo_test.go
+++ b/internal/adapter/nfs/v4/handlers/secinfo_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc/gss"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/pseudofs"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
@@ -332,7 +333,7 @@ func TestHandleSecInfo_KRB5OIDFormat(t *testing.T) {
 
 func TestEncodeSecInfoGSSEntry_Privacy(t *testing.T) {
 	var buf bytes.Buffer
-	encodeSecInfoGSSEntry(&buf, rpcGSSSvcPrivacy)
+	encodeSecInfoGSSEntry(&buf, gss.RPCGSSSvcPrivacy)
 
 	reader := bytes.NewReader(buf.Bytes())
 
@@ -359,7 +360,7 @@ func TestEncodeSecInfoGSSEntry_Privacy(t *testing.T) {
 
 func TestEncodeSecInfoGSSEntry_Integrity(t *testing.T) {
 	var buf bytes.Buffer
-	encodeSecInfoGSSEntry(&buf, rpcGSSSvcIntegrity)
+	encodeSecInfoGSSEntry(&buf, gss.RPCGSSSvcIntegrity)
 
 	reader := bytes.NewReader(buf.Bytes())
 
@@ -379,7 +380,7 @@ func TestEncodeSecInfoGSSEntry_Integrity(t *testing.T) {
 
 func TestEncodeSecInfoGSSEntry_None(t *testing.T) {
 	var buf bytes.Buffer
-	encodeSecInfoGSSEntry(&buf, rpcGSSSvcNone)
+	encodeSecInfoGSSEntry(&buf, gss.RPCGSSSvcNone)
 
 	reader := bytes.NewReader(buf.Bytes())
 

--- a/internal/controlplane/api/handlers/share_adapter_config.go
+++ b/internal/controlplane/api/handlers/share_adapter_config.go
@@ -143,9 +143,8 @@ func (h *ShareNFSConfigHandler) Patch(w http.ResponseWriter, r *http.Request) {
 		// A share that requires Kerberos on a server without Kerberos
 		// configured is reachable by no auth flavor at all: AUTH_SYS and
 		// AUTH_NONE are refused by the policy and RPCSEC_GSS cannot be
-		// negotiated. Refusing it here is also what keeps SECINFO from having
-		// to answer with a zero-length flavor list, which RFC 7530 does not
-		// provide for.
+		// negotiated. Refusing it here is also what leaves SECINFO with at
+		// least one flavor to report for every share.
 		if *req.RequireKerberos && h.runtime != nil && !h.runtime.KerberosEnabled() {
 			BadRequest(w, "require_kerberos needs Kerberos configured on this server")
 			return

--- a/internal/controlplane/api/handlers/share_adapter_config.go
+++ b/internal/controlplane/api/handlers/share_adapter_config.go
@@ -140,6 +140,16 @@ func (h *ShareNFSConfigHandler) Patch(w http.ResponseWriter, r *http.Request) {
 		opts.AllowAuthSys = *req.AllowAuthSys
 	}
 	if req.RequireKerberos != nil {
+		// A share that requires Kerberos on a server without Kerberos
+		// configured is reachable by no auth flavor at all: AUTH_SYS and
+		// AUTH_NONE are refused by the policy and RPCSEC_GSS cannot be
+		// negotiated. Refusing it here is also what keeps SECINFO from having
+		// to answer with a zero-length flavor list, which RFC 7530 does not
+		// provide for.
+		if *req.RequireKerberos && h.runtime != nil && !h.runtime.KerberosEnabled() {
+			BadRequest(w, "require_kerberos needs Kerberos configured on this server")
+			return
+		}
 		opts.RequireKerberos = *req.RequireKerberos
 	}
 	if req.MinKerberosLevel != nil {

--- a/internal/controlplane/api/handlers/share_adapter_config_test.go
+++ b/internal/controlplane/api/handlers/share_adapter_config_test.go
@@ -52,12 +52,16 @@ func setupShareNFSConfigTest(t *testing.T) (*store.GORMStore, *ShareNFSConfigHan
 		t.Fatalf("CreateShare: %v", err)
 	}
 
-	handler := NewShareNFSConfigHandler(struct {
+	return cpStore, nfsConfigHandler(cpStore, nil), share.ID
+}
+
+// nfsConfigHandler builds a ShareNFSConfigHandler over cpStore, which satisfies
+// both halves of the handler's composite store interface.
+func nfsConfigHandler(cpStore *store.GORMStore, rt *runtime.Runtime) *ShareNFSConfigHandler {
+	return NewShareNFSConfigHandler(struct {
 		store.ShareStore
 		store.NetgroupStore
-	}{cpStore, cpStore}, nil)
-
-	return cpStore, handler, share.ID
+	}{cpStore, cpStore}, rt)
 }
 
 // doRequest runs a request against a handler func and returns the recorder.
@@ -249,10 +253,7 @@ func TestShareNFSConfig_PatchRejectsInvalidSquash(t *testing.T) {
 func TestShareNFSConfig_PatchRequireKerberosNeedsKerberos(t *testing.T) {
 	cpStore, _, shareID := setupShareNFSConfigTest(t)
 	rt := runtime.New(nil)
-	handler := NewShareNFSConfigHandler(struct {
-		store.ShareStore
-		store.NetgroupStore
-	}{cpStore, cpStore}, rt)
+	handler := nfsConfigHandler(cpStore, rt)
 
 	w := doRequest(t, handler.Patch, http.MethodPatch, `{"require_kerberos":true}`)
 	if w.Code != http.StatusBadRequest {

--- a/internal/controlplane/api/handlers/share_adapter_config_test.go
+++ b/internal/controlplane/api/handlers/share_adapter_config_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
 	"github.com/marmos91/dittofs/pkg/controlplane/store"
 )
 
@@ -238,5 +239,54 @@ func TestShareNFSConfig_PatchRejectsInvalidSquash(t *testing.T) {
 		if w.Code != http.StatusBadRequest {
 			t.Errorf("Patch(squash=%q) status = %d, want 400, body = %s", bad, w.Code, w.Body.String())
 		}
+	}
+}
+
+// TestShareNFSConfig_PatchRequireKerberosNeedsKerberos pins the config-time
+// guard: require_kerberos on a server without Kerberos leaves the share
+// reachable by no auth flavor at all, and would force SECINFO to answer with a
+// zero-length flavor list.
+func TestShareNFSConfig_PatchRequireKerberosNeedsKerberos(t *testing.T) {
+	cpStore, _, shareID := setupShareNFSConfigTest(t)
+	rt := runtime.New(nil)
+	handler := NewShareNFSConfigHandler(struct {
+		store.ShareStore
+		store.NetgroupStore
+	}{cpStore, cpStore}, rt)
+
+	w := doRequest(t, handler.Patch, http.MethodPatch, `{"require_kerberos":true}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("Patch(require_kerberos) with Kerberos disabled status = %d, want 400, body = %s",
+			w.Code, w.Body.String())
+	}
+
+	// Nothing was persisted by the refused request.
+	cfg, err := cpStore.GetShareAdapterConfig(context.Background(), shareID, "nfs")
+	if err != nil {
+		t.Fatalf("GetShareAdapterConfig: %v", err)
+	}
+	if cfg != nil {
+		var opts models.NFSExportOptions
+		if err := cfg.ParseConfig(&opts); err != nil {
+			t.Fatalf("ParseConfig: %v", err)
+		}
+		if opts.RequireKerberos {
+			t.Errorf("refused request persisted require_kerberos=true")
+		}
+	}
+
+	// With Kerberos configured the same request is accepted.
+	rt.SetKerberosEnabled(true)
+	w = doRequest(t, handler.Patch, http.MethodPatch, `{"require_kerberos":true}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("Patch(require_kerberos) with Kerberos enabled status = %d, want 200, body = %s",
+			w.Code, w.Body.String())
+	}
+	var resp ShareNFSConfigResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !resp.RequireKerberos {
+		t.Errorf("RequireKerberos = false, want true")
 	}
 }

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -221,9 +221,8 @@ type Runtime struct {
 	ldapConfig *ldap.Config
 
 	// kerberosEnabled records whether the server has Kerberos (RPCSEC_GSS)
-	// configured. Set at startup from the effective Kerberos config, so the
-	// share-config API can refuse a per-share policy only Kerberos could
-	// satisfy. Guarded by mu.
+	// configured, so the share-config API can refuse a per-share policy only
+	// Kerberos could satisfy. Set at startup by SetKerberosEnabled. Guarded by mu.
 	kerberosEnabled bool
 
 	// netlogonCredential is the optional NETLOGON machine credential / DC binding

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -1156,6 +1156,11 @@ func (r *Runtime) SetExportAuthPolicyForTesting(name string, allowAuthSys, requi
 	return r.sharesSvc.SetExportAuthPolicyForTesting(name, allowAuthSys, requireKerberos)
 }
 
+// SetRootHandleForTesting sets a registered share's root filehandle. Test-only.
+func (r *Runtime) SetRootHandleForTesting(name string, handle metadata.FileHandle) error {
+	return r.sharesSvc.SetRootHandleForTesting(name, handle)
+}
+
 // SetMinKerberosLevelForTesting overrides a registered share's MinKerberosLevel
 // GSS protection floor ("", "krb5", "krb5i", "krb5p"). Test-only.
 func (r *Runtime) SetMinKerberosLevelForTesting(name, minLevel string) error {

--- a/pkg/controlplane/runtime/runtime.go
+++ b/pkg/controlplane/runtime/runtime.go
@@ -220,6 +220,12 @@ type Runtime struct {
 	// registers an LDAP provider in the identity resolution chain. Guarded by mu.
 	ldapConfig *ldap.Config
 
+	// kerberosEnabled records whether the server has Kerberos (RPCSEC_GSS)
+	// configured. Set at startup from the effective Kerberos config, so the
+	// share-config API can refuse a per-share policy only Kerberos could
+	// satisfy. Guarded by mu.
+	kerberosEnabled bool
+
 	// netlogonCredential is the optional NETLOGON machine credential / DC binding
 	// used for SMB NTLM pass-through. Set at startup from the Kerberos
 	// machine-account config and updated by the identity-provider API; nil when
@@ -1180,6 +1186,26 @@ func (r *Runtime) LDAPConfig() *ldap.Config {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return r.ldapConfig
+}
+
+// SetKerberosEnabled records whether the server has Kerberos configured,
+// sourced from the same effective Kerberos config the adapter factory is built
+// with at startup. A Kerberos config change applies on the next restart -- the
+// NFS and SMB adapters read it at startup -- so a value fixed at startup here
+// matches what the adapters actually run with.
+func (r *Runtime) SetKerberosEnabled(enabled bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.kerberosEnabled = enabled
+}
+
+// KerberosEnabled reports whether RPCSEC_GSS is available on this server. It
+// gates share policies that only Kerberos can satisfy: a share that requires
+// Kerberos on a server without it can be reached by no auth flavor at all.
+func (r *Runtime) KerberosEnabled() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.kerberosEnabled
 }
 
 // ResolveDirectoryPrincipalSID resolves an AD principal NAME (bare

--- a/pkg/controlplane/runtime/shares/testing.go
+++ b/pkg/controlplane/runtime/shares/testing.go
@@ -46,6 +46,9 @@ func (s *Service) RegisterShareForTesting(name string) {
 // LOOKUP across the share's pseudo-fs export junction land on a zero-length
 // handle instead of the share root. Returns ErrShareNotFound if the share is
 // not registered.
+//
+// The handle is copied, so a caller that reuses or mutates its slice afterwards
+// cannot reach into registry state.
 func (s *Service) SetRootHandleForTesting(name string, handle metadata.FileHandle) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -53,7 +56,7 @@ func (s *Service) SetRootHandleForTesting(name string, handle metadata.FileHandl
 	if !ok {
 		return fmt.Errorf("%w: %q", ErrShareNotFound, name)
 	}
-	share.RootHandle = handle
+	share.RootHandle = append(metadata.FileHandle(nil), handle...)
 	return nil
 }
 

--- a/pkg/controlplane/runtime/shares/testing.go
+++ b/pkg/controlplane/runtime/shares/testing.go
@@ -6,6 +6,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/block/engine"
 	"github.com/marmos91/dittofs/pkg/block/remote"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
 // InjectShareForTesting inserts a share directly, bypassing AddShare validation.
@@ -38,6 +39,22 @@ func (s *Service) RegisterShareForTesting(name string) {
 		// auth-flavor policy denies every AUTH_UNIX op.
 		AllowAuthSys: true,
 	}
+}
+
+// SetRootHandleForTesting sets a share's RootHandle in the registry under lock.
+// Test-only — RegisterShareForTesting leaves it empty, which makes an NFSv4
+// LOOKUP across the share's pseudo-fs export junction land on a zero-length
+// handle instead of the share root. Returns ErrShareNotFound if the share is
+// not registered.
+func (s *Service) SetRootHandleForTesting(name string, handle metadata.FileHandle) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	share, ok := s.registry[name]
+	if !ok {
+		return fmt.Errorf("%w: %q", ErrShareNotFound, name)
+	}
+	share.RootHandle = handle
+	return nil
 }
 
 // SetLocalStoreDirForTesting overrides the per-share localStoreDir field.


### PR DESCRIPTION
## What was wrong

`encodeSecInfoFlavors` built one server-wide flavor list — AUTH_SYS + AUTH_NONE, plus
krb5p/krb5i/krb5 when `Handler.KerberosEnabled` — and handed the same bytes back for every
filehandle, in both SECINFO and SECINFO_NO_NAME.

The export auth-flavor policy is per share and is enforced somewhere else entirely, in
`buildV4AuthContext` (`internal/adapter/nfs/v4/handlers/helpers.go`):

- `AllowAuthSys=false` → `NFS4ERR_WRONGSEC` on AUTH_SYS
- `RequireKerberos=true` → `NFS4ERR_WRONGSEC` on every non-GSS flavor, AUTH_NONE included
- `MinKerberosLevel` → `NFS4ERR_WRONGSEC` on a GSS session negotiated below the floor

So a share could advertise a flavor and then refuse it. That is the exact failure SECINFO
exists to prevent: the client picks a listed flavor, gets `NFS4ERR_WRONGSEC`, calls SECINFO
again, and is handed the identical list. There is no escape from that loop.

Not introduced by #2368 — that PR made SECINFO resolve the name and shared the encoder with
SECINFO_NO_NAME, but the list's *content* was already share-blind: before it, `handleSecInfo`
never consulted the share either.

## The fix

`encodeSecInfoFlavors` now takes the target share and narrows the candidate set with the same
two conditions, in the same order, as `buildV4AuthContext`: `RequireKerberos` drops every
non-GSS flavor, `AllowAuthSys=false` drops AUTH_SYS only, and `MeetsMinKerberosLevel` — the
same predicate the enforcement path calls — filters the GSS entries. A nil share means no
policy is known and nothing is narrowed.

Which share that is, per operation:

- **SECINFO** reports on the *resolved* name. `secInfoLookupStatus` now returns the handle it
  resolved to, so a name crossing an export junction reports the target share's policy, not the
  parent's. On `NFS4ERR_WRONGSEC` the lookup never advanced the filehandle, so the refusing
  share's own policy is reported — which is the one the client needs.
- **SECINFO_NO_NAME** reports on the current filehandle for both styles. The flavor list is now
  computed *before* the filehandle is consumed; reading it after would have handed every 4.1
  client the unnarrowed list.
- A **pseudo-fs filehandle** belongs to no share and keeps the server-wide list.

`secinfo.go` also drops its private copies of the `rpc_gss_svc_t` constants in favour of
`gss.RPCGSSSvc*`, which is what `MeetsMinKerberosLevel` compares against.

## The empty-list case, and what I did not do

`RequireKerberos=true` on a server with no Kerberos configured narrows to nothing. That share is
already unreachable by any auth flavor — AUTH_SYS and AUTH_NONE are refused by the policy and
RPCSEC_GSS cannot be negotiated — so it is a misconfiguration rather than a state SECINFO should
paper over. `PATCH /shares/{name}/adapters/nfs/config` now refuses it with 400, gated on a new
`Runtime.KerberosEnabled()` set at startup from the same effective Kerberos config the adapter
factory is built with. (A Kerberos config change already only applies on restart — the NFS and
SMB adapters read it at startup — so a startup-fixed value matches what the adapters run with.)

Two things worth flagging:

1. **Share creation cannot set this policy at all.** `POST /shares` writes
   `models.DefaultNFSExportOptions()` verbatim (`AllowAuthSys=true`, `RequireKerberos=false`),
   so the PATCH endpoint is the *only* write path for `require_kerberos=true`. There is no
   second entry point to guard, contrary to what I expected going in.

2. **A share can already be in that state in a persisted config, and config drift can put it
   there.** `buildShareConfig` (`pkg/controlplane/runtime/init.go:356`) copies
   `nfsOpts.RequireKerberos` straight into the runtime at startup with no re-validation, and
   Kerberos is enabled through an entirely separate channel (`resolveIdentityProviders` →
   `rt.SetKerberosEnabled`). So the guard only holds going forward, not against drift:

   > enable Kerberos → PATCH a share to `require_kerberos=true` (guard passes) → later
   > decommission Kerberos → restart. Now `kerberosEnabled=false` while the share's persisted
   > `RequireKerberos` is still `true`, so `encodeSecInfoFlavors` narrows to a zero-length
   > array while `buildV4AuthContext` still refuses every non-GSS flavor. The share is
   > unreachable by any flavor and SECINFO gives the client nothing to retry with.

   I did **not** add a load-time refusal or a silent force-downgrade. Refusing would fail
   startup on an existing deployment and downgrading would quietly weaken a share's stated
   security posture; that trade is not mine to make. Flagging it as the one open decision here.
   Note the state is already reachable today on any such persisted row — this PR does not
   create it, and a zero-length array is at least well-formed XDR rather than a list of lies.

## Verification

Both conformance suites are blind to this — neither pynfs harness configures a per-share
auth-flavor policy, so a green SEC1 proves nothing about the narrowing. Unit coverage is the
real check, against `SetExportAuthPolicyForTesting` / `SetMinKerberosLevelForTesting`:

| test | pins |
| --- | --- |
| `TestSecInfo_AllowAuthSysFalseDropsAuthSys` | AUTH_SYS dropped, AUTH_NONE kept |
| `TestSecInfo_RequireKerberosDropsNonGSS` | both non-GSS flavors dropped, 3 GSS entries remain |
| `TestSecInfo_MinKerberosLevelDropsWeakerServices` | krb5p floor drops krb5i and plain krb5 |
| `TestSecInfo_JunctionReportsTargetPolicy` | junction reports the target share, not the parent |
| `TestSecInfoNoName_PseudoFSKeepsServerWideList` | pseudo-fs handle keeps the server-wide list |
| `TestShareNFSConfig_PatchRequireKerberosNeedsKerberos` | 400 without Kerberos, 200 with, nothing persisted on refusal |

Every one of them was confirmed to fail when its branch is removed, using `go test -overlay`
so the repo was never touched. Six mutants, six kills, each by exactly the intended test:

```
norequire       --- FAIL: TestSecInfo_RequireKerberosDropsNonGSS
noallowsys      --- FAIL: TestSecInfo_AllowAuthSysFalseDropsAuthSys
                --- FAIL: TestSecInfo_JunctionReportsTargetPolicy
nofloor         --- FAIL: TestSecInfo_MinKerberosLevelDropsWeakerServices
noresolve       --- FAIL: TestSecInfo_JunctionReportsTargetPolicy
nopseudoguard   --- FAIL: TestSecInfoNoName_PseudoFSKeepsServerWideList
noguard         --- FAIL: TestShareNFSConfig_PatchRequireKerberosNeedsKerberos
```

`go build ./...`, `go vet ./...`, `gofmt -l .` and the full `go test ./...` are clean.

`SetRootHandleForTesting` is new test-only plumbing: `RegisterShareForTesting` leaves
`RootHandle` empty, which makes a LOOKUP across the share's pseudo-fs export junction land on a
zero-length handle instead of the share root — the junction test needs it to behave like a real
export.

Closes #2369
