### PR TITLE
fix(smb): bind a client-supplied FileId to the session that opened it

### DIFF
--- a/internal/adapter/smb/handlers/auth_helper.go
+++ b/internal/adapter/smb/handlers/auth_helper.go
@@ -261,18 +261,19 @@ func mergeImplicitAuthSIDs(userGroupSIDs []string) []string {
 }
 
 // primeAuthContextFromOpenFile hand-offs the open's recorded session/tree
-// identity onto ctx BEFORE BuildAuthContext is called (refs #603). Follow-up
-// operations arrive keyed only by FileID — the SMB2 dispatcher has no user
-// state to prefill ctx.User with. Without this hand-off
-// BuildAuthContext takes the ctx.User==nil arm and synthesises an
+// identity onto ctx BEFORE BuildAuthContext is called (refs #603). A
+// handle-based request carries its SessionID and TreeID in the SMB2 header,
+// but no user state for the dispatcher to prefill ctx.User from. Without this
+// hand-off BuildAuthContext takes the ctx.User==nil arm and synthesises an
 // unprivileged nobody (65534) identity instead of the authenticated user's
 // UID, causing follow-up ops to be authorized as nobody rather than the
 // real opener.
 //
-// We also realign ctx.TreeID / ctx.SessionID onto the IDs the open was
-// created against. Downstream gates (notably treeHasAccessBasedEnumeration
-// in QueryDirectory) read ctx.TreeID directly; if the dispatcher left a
-// stale or zero TreeID on ctx, ABE would be decided against the wrong tree.
+// It also resolves the open's tree onto ctx.ShareName / ctx.Permission, which
+// downstream gates consult — treeHasAccessBasedEnumeration in QueryDirectory
+// decides ABE from the tree ctx.TreeID names. The ctx.TreeID and ctx.SessionID
+// assignments themselves are no-ops by the time they run, since the ownership
+// check below has already established that they equal the open's.
 //
 // The sess.User nil-guard on the User assignment is load-bearing: GetSession(0)
 // returns the manager's seeded anonymous pre-auth session with User=nil, and

--- a/internal/adapter/smb/handlers/auth_helper.go
+++ b/internal/adapter/smb/handlers/auth_helper.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/auth/sid"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
@@ -282,8 +283,48 @@ func mergeImplicitAuthSIDs(userGroupSIDs []string) []string {
 // sessions are created with User=nil and IsGuest=true (see
 // session.NewSession), and the BuildAuthContext guest arm is what maps them
 // to UID/GID 65534 instead of root.
-func (h *Handler) primeAuthContextFromOpenFile(ctx *SMBHandlerContext, openFile *OpenFile) {
+// It returns StatusFileClosed without touching ctx when the handle was not
+// opened on the tree and session the request arrived on — see
+// openFileBelongsToRequest. Callers must surface that status instead of
+// proceeding: everything this helper sets is the located handle's identity, so
+// priming from a handle the requester does not own executes the request as that
+// handle's user, against that handle's share, with that handle's tree
+// permission.
+//
+// ponytail: one gate inside the priming helper covers every handle-based
+// command at once, because they all adopt the handle's identity through here.
+// The ceiling is that Go does not force a caller to consume a non-error return,
+// so a future call site can drop the status silently and prime unchecked; a
+// dispatch-level gate would close that, but cannot replace this one, because
+// COPYCHUNK resolves its source handle from a resume key inside the handler
+// body rather than from a FileId in the request header.
+func (h *Handler) primeAuthContextFromOpenFile(ctx *SMBHandlerContext, openFile *OpenFile) types.Status {
+	if !openFileBelongsToRequest(ctx, openFile) {
+		logger.Debug("Handle does not belong to the request's tree/session",
+			"handleTreeID", openFile.TreeID, "reqTreeID", ctx.TreeID,
+			"handleSessionID", openFile.SessionID, "reqSessionID", ctx.SessionID)
+		return types.StatusFileClosed
+	}
 	h.primeAuthContext(ctx, openFile.TreeID, openFile.SessionID)
+	return types.StatusSuccess
+}
+
+// openFileBelongsToRequest reports whether openFile was opened on the tree and
+// session that this request arrived on.
+//
+// MS-SMB2 §3.3.5.2.5 resolves a FileId against Session.OpenTable: the handle
+// must belong to the requesting session, not merely exist somewhere on the
+// server. Opens live in one process-wide table keyed by the FileId alone, so
+// GetOpenFile answers "does this handle exist" and this answers "may this
+// requester use it".
+//
+// StatusFileClosed is the refusal used for a handle that fails this, which
+// keeps a foreign FileId indistinguishable from a closed one and matches what
+// these handlers already return for an unknown FileId. smbtorture smb2.tcon
+// deliberately mis-sets the wire-level TreeID/SessionID and expects an error
+// there (Samba returns FILE_CLOSED).
+func openFileBelongsToRequest(ctx *SMBHandlerContext, openFile *OpenFile) bool {
+	return openFile.SessionID == ctx.SessionID && openFile.TreeID == ctx.TreeID
 }
 
 // primeAuthContext is the same as primeAuthContextFromOpenFile but takes raw

--- a/internal/adapter/smb/handlers/auth_helper.go
+++ b/internal/adapter/smb/handlers/auth_helper.go
@@ -262,9 +262,8 @@ func mergeImplicitAuthSIDs(userGroupSIDs []string) []string {
 
 // primeAuthContextFromOpenFile hand-offs the open's recorded session/tree
 // identity onto ctx BEFORE BuildAuthContext is called (refs #603). Follow-up
-// operations CREATE / READ / WRITE / QUERY_DIRECTORY (the four current
-// callers of this helper) arrive keyed only by FileID — the SMB2 dispatcher
-// has no user state to prefill ctx.User with. Without this hand-off
+// operations arrive keyed only by FileID — the SMB2 dispatcher has no user
+// state to prefill ctx.User with. Without this hand-off
 // BuildAuthContext takes the ctx.User==nil arm and synthesises an
 // unprivileged nobody (65534) identity instead of the authenticated user's
 // UID, causing follow-up ops to be authorized as nobody rather than the
@@ -283,21 +282,21 @@ func mergeImplicitAuthSIDs(userGroupSIDs []string) []string {
 // sessions are created with User=nil and IsGuest=true (see
 // session.NewSession), and the BuildAuthContext guest arm is what maps them
 // to UID/GID 65534 instead of root.
-// It returns StatusFileClosed without touching ctx when the handle was not
-// opened on the tree and session the request arrived on — see
-// openFileBelongsToRequest. Callers must surface that status instead of
-// proceeding: everything this helper sets is the located handle's identity, so
-// priming from a handle the requester does not own executes the request as that
-// handle's user, against that handle's share, with that handle's tree
-// permission.
 //
-// ponytail: one gate inside the priming helper covers every handle-based
-// command at once, because they all adopt the handle's identity through here.
-// The ceiling is that Go does not force a caller to consume a non-error return,
-// so a future call site can drop the status silently and prime unchecked; a
-// dispatch-level gate would close that, but cannot replace this one, because
-// COPYCHUNK resolves its source handle from a resume key inside the handler
-// body rather than from a FileId in the request header.
+// It refuses a handle the requester does not own (openFileBelongsToRequest),
+// returning StatusFileClosed without touching ctx; callers must surface that
+// status rather than proceed, because everything primed here is the located
+// handle's identity — priming from a foreign handle runs the request as that
+// handle's user, against its share, with its tree permission. StatusFileClosed
+// is what these handlers already return for an unknown FileId, so a handle
+// belonging to somebody else stays indistinguishable from a closed one.
+//
+// ponytail: one gate here covers every handle-based command, since they all
+// adopt the handle's identity through this helper. The ceiling is that Go does
+// not force a caller to consume a non-error return, so a new call site can
+// prime unchecked; a dispatch-level gate would close that but cannot replace
+// this one, because COPYCHUNK resolves its source handle from a resume key in
+// the handler body rather than from a FileId in the request header.
 func (h *Handler) primeAuthContextFromOpenFile(ctx *SMBHandlerContext, openFile *OpenFile) types.Status {
 	if !openFileBelongsToRequest(ctx, openFile) {
 		logger.Debug("Handle does not belong to the request's tree/session",
@@ -310,19 +309,14 @@ func (h *Handler) primeAuthContextFromOpenFile(ctx *SMBHandlerContext, openFile 
 }
 
 // openFileBelongsToRequest reports whether openFile was opened on the tree and
-// session that this request arrived on.
+// session this request arrived on.
 //
 // MS-SMB2 §3.3.5.2.5 resolves a FileId against Session.OpenTable: the handle
 // must belong to the requesting session, not merely exist somewhere on the
 // server. Opens live in one process-wide table keyed by the FileId alone, so
 // GetOpenFile answers "does this handle exist" and this answers "may this
-// requester use it".
-//
-// StatusFileClosed is the refusal used for a handle that fails this, which
-// keeps a foreign FileId indistinguishable from a closed one and matches what
-// these handlers already return for an unknown FileId. smbtorture smb2.tcon
-// deliberately mis-sets the wire-level TreeID/SessionID and expects an error
-// there (Samba returns FILE_CLOSED).
+// requester use it". smbtorture smb2.tcon deliberately mis-sets the wire-level
+// TreeID/SessionID and expects an error here (Samba returns FILE_CLOSED).
 func openFileBelongsToRequest(ctx *SMBHandlerContext, openFile *OpenFile) bool {
 	return openFile.SessionID == ctx.SessionID && openFile.TreeID == ctx.TreeID
 }

--- a/internal/adapter/smb/handlers/auth_priming_test.go
+++ b/internal/adapter/smb/handlers/auth_priming_test.go
@@ -61,9 +61,10 @@ func TestClose_PrimesAuthContextFromOpenFile(t *testing.T) {
 	}).WithName(OpenName{Path: "/share/a.txt"})
 	h.StoreOpenFile(openFile)
 
-	// Build a ctx with zero session/tree state — mirrors the dispatcher,
-	// which arrives keyed only by FileID.
-	ctx := NewSMBHandlerContext(context.TODO(), "127.0.0.1:0", 0 /*session*/, 0 /*tree*/, 1 /*msg*/)
+	// Build a ctx carrying the session/tree the handle was opened on — as the
+	// dispatcher does from the request header — but no user state, which is
+	// what the prime has to supply.
+	ctx := NewSMBHandlerContext(context.TODO(), "127.0.0.1:0", sess.SessionID, treeID, 1 /*msg*/)
 	if ctx.User != nil {
 		t.Fatal("precondition: ctx.User should start nil so the prime is observable")
 	}
@@ -126,7 +127,7 @@ func TestFlush_PrimesAuthContextFromOpenFile(t *testing.T) {
 		SessionID: sess.SessionID,
 	}).WithName(OpenName{Path: "/share2/b.txt"})
 
-	ctx := NewSMBHandlerContext(context.TODO(), "127.0.0.1:0", 0, 0, 1)
+	ctx := NewSMBHandlerContext(context.TODO(), "127.0.0.1:0", sess.SessionID, treeID, 1)
 	if ctx.User != nil {
 		t.Fatal("precondition: ctx.User should start nil")
 	}

--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -188,7 +188,9 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	// would take the ctx.User==nil arm and synthesise UID-0 (root), bypassing
 	// DACL checks on the downstream metadata flush, delete-on-close unlink,
 	// and MFsymlink conversion (#619, same class as #603).
-	h.primeAuthContextFromOpenFile(ctx, openFile)
+	if st := h.primeAuthContextFromOpenFile(ctx, openFile); st != types.StatusSuccess {
+		return &CloseResponse{SMBResponseBase: SMBResponseBase{Status: st}}, nil
+	}
 
 	// ========================================================================
 	// Step 3: Flush cached data to block store (ensures durability)
@@ -825,12 +827,12 @@ func (h *Handler) convertToRealSymlink(ctx *SMBHandlerContext, openFile *OpenFil
 		return fmt.Errorf("missing parent handle or filename for MFsymlink conversion")
 	}
 
-	// Prime ctx.User / IsGuest / TreeID from the OpenFile's recorded session
-	// BEFORE BuildAuthContext — otherwise ctx.User==nil falls into the
-	// anonymous arm and synthesises UID-0 (root), bypassing DACL checks on
-	// the RemoveFile + CreateSymlink (#619, same class as #603).
-	h.primeAuthContextFromOpenFile(ctx, openFile)
-
+	// ctx is already primed with this handle's session by Close, the only path
+	// that reaches here, so ctx.User is set and BuildAuthContext will not take
+	// the ctx.User==nil arm and synthesise UID-0 (root) over the RemoveFile +
+	// CreateSymlink below (#619, same class as #603). Close's priming also
+	// established that the handle belongs to the requesting session; re-priming
+	// the same handle here would be a no-op.
 	authCtx, err := BuildAuthContext(ctx)
 	if err != nil {
 		return err

--- a/internal/adapter/smb/handlers/close.go
+++ b/internal/adapter/smb/handlers/close.go
@@ -188,8 +188,8 @@ func (h *Handler) Close(ctx *SMBHandlerContext, req *CloseRequest) (*CloseRespon
 	// would take the ctx.User==nil arm and synthesise UID-0 (root), bypassing
 	// DACL checks on the downstream metadata flush, delete-on-close unlink,
 	// and MFsymlink conversion (#619, same class as #603).
-	if st := h.primeAuthContextFromOpenFile(ctx, openFile); st != types.StatusSuccess {
-		return &CloseResponse{SMBResponseBase: SMBResponseBase{Status: st}}, nil
+	if status := h.primeAuthContextFromOpenFile(ctx, openFile); status != types.StatusSuccess {
+		return &CloseResponse{SMBResponseBase: SMBResponseBase{Status: status}}, nil
 	}
 
 	// ========================================================================
@@ -827,12 +827,11 @@ func (h *Handler) convertToRealSymlink(ctx *SMBHandlerContext, openFile *OpenFil
 		return fmt.Errorf("missing parent handle or filename for MFsymlink conversion")
 	}
 
-	// ctx is already primed with this handle's session by Close, the only path
-	// that reaches here, so ctx.User is set and BuildAuthContext will not take
-	// the ctx.User==nil arm and synthesise UID-0 (root) over the RemoveFile +
-	// CreateSymlink below (#619, same class as #603). Close's priming also
-	// established that the handle belongs to the requesting session; re-priming
-	// the same handle here would be a no-op.
+	// Close, the only path in, primed ctx from this handle's session and so
+	// already refused a handle the requester does not own. ctx.User is set,
+	// so BuildAuthContext will not take the ctx.User==nil arm and synthesise
+	// UID-0 (root) over the RemoveFile + CreateSymlink below (#619, same class
+	// as #603).
 	authCtx, err := BuildAuthContext(ctx)
 	if err != nil {
 		return err

--- a/internal/adapter/smb/handlers/close_dirlease_break_order_test.go
+++ b/internal/adapter/smb/handlers/close_dirlease_break_order_test.go
@@ -115,6 +115,7 @@ func TestClose_DirLeaseRelease_AfterOpenFileRemoval(t *testing.T) {
 		FileID:         fileID,
 		IsDirectory:    true,
 		ShareName:      shareName,
+		SessionID:      1,
 		OplockLevel:    OplockLevelLease,
 		LeaseKey:       leaseKey,
 		MetadataHandle: dirMetaHandle,

--- a/internal/adapter/smb/handlers/close_notify_test.go
+++ b/internal/adapter/smb/handlers/close_notify_test.go
@@ -32,6 +32,7 @@ func TestClose_PendingNotifyCleanup_DeferredViaPostSend(t *testing.T) {
 		FileID:      fileID,
 		IsDirectory: true,
 		ShareName:   "share",
+		SessionID:   42,
 		OplockLevel: OplockLevelNone,
 	}).WithName(OpenName{Path: "/share/watched-dir", FileName: "watched-dir"})
 	h.StoreOpenFile(openFile)
@@ -135,6 +136,7 @@ func TestClose_NoPendingNotify_PostSendNil(t *testing.T) {
 		FileID:      fileID,
 		IsDirectory: true,
 		ShareName:   "share",
+		SessionID:   1,
 		OplockLevel: OplockLevelNone,
 	}).WithName(OpenName{Path: "/share/plain-dir", FileName: "plain-dir"})
 	h.StoreOpenFile(openFile)
@@ -188,6 +190,7 @@ func TestClose_DeleteOnClose_CompletesOtherHandlesNotify(t *testing.T) {
 		FileID:               deleterID,
 		IsDirectory:          true,
 		ShareName:            "share",
+		SessionID:            42,
 		MetadataHandle:       metaHandle,
 		InitialDeleteOnClose: true,
 		OplockLevel:          OplockLevelNone,

--- a/internal/adapter/smb/handlers/flush.go
+++ b/internal/adapter/smb/handlers/flush.go
@@ -260,8 +260,8 @@ func (h *Handler) Flush(ctx *SMBHandlerContext, req *FlushRequest) (*FlushRespon
 	// BEFORE BuildAuthContext — otherwise ctx.User==nil falls into the
 	// anonymous arm and synthesises UID-0 (root), bypassing DACL checks on
 	// the metadata flush (#619, same class as #603).
-	if st := h.primeAuthContextFromOpenFile(ctx, openFile); st != types.StatusSuccess {
-		return &FlushResponse{SMBResponseBase: SMBResponseBase{Status: st}}, nil
+	if status := h.primeAuthContextFromOpenFile(ctx, openFile); status != types.StatusSuccess {
+		return &FlushResponse{SMBResponseBase: SMBResponseBase{Status: status}}, nil
 	}
 
 	authCtx, authErr := BuildAuthContext(ctx)

--- a/internal/adapter/smb/handlers/flush.go
+++ b/internal/adapter/smb/handlers/flush.go
@@ -260,7 +260,9 @@ func (h *Handler) Flush(ctx *SMBHandlerContext, req *FlushRequest) (*FlushRespon
 	// BEFORE BuildAuthContext — otherwise ctx.User==nil falls into the
 	// anonymous arm and synthesises UID-0 (root), bypassing DACL checks on
 	// the metadata flush (#619, same class as #603).
-	h.primeAuthContextFromOpenFile(ctx, openFile)
+	if st := h.primeAuthContextFromOpenFile(ctx, openFile); st != types.StatusSuccess {
+		return &FlushResponse{SMBResponseBase: SMBResponseBase{Status: st}}, nil
+	}
 
 	authCtx, authErr := BuildAuthContext(ctx)
 	if authErr != nil {

--- a/internal/adapter/smb/handlers/handle_ownership_test.go
+++ b/internal/adapter/smb/handlers/handle_ownership_test.go
@@ -17,15 +17,14 @@ import (
 // Opens live in one process-wide table keyed by the FileId alone, so
 // GetOpenFile hands any live handle to any caller that names it. Every
 // handle-based command then adopts that handle's session, tree, share and
-// permission through primeAuthContextFromOpenFile before building the
-// AuthContext, which means an unowned handle would run the request as its
-// owner, against its share, with its tree permission. These tests pin the
-// refusal, per site class.
+// permission through primeAuthContextFromOpenFile, so an unowned handle would
+// run the request as its owner, against its share, with its tree permission.
+// These tests pin the refusal, one command per site class.
 
-// ownedHandleFixture builds a share with a handle owned by the session
-// setupReparseShare creates, then adds a second session with its own tree —
-// the shape prepareDispatch guarantees, since it already refuses a tree
-// belonging to another session. It returns a ctx for each.
+// ownedHandleFixture builds a share holding a handle owned by the session
+// setupReparseShare creates, then adds a second session with a tree of its
+// own — the shape prepareDispatch guarantees, since it already refuses a tree
+// belonging to another session. It returns a ctx for each session.
 //
 // The owner's handle gains FILE_WRITE_ATTRIBUTES so SET_INFO clears its own
 // GrantedAccess gate, which sits ahead of the priming call.
@@ -105,8 +104,10 @@ func storeSecondHandle(t *testing.T, h *Handler, ownerCtx *SMBHandlerContext, na
 }
 
 // buildIoctlRequestBody encodes an SMB2 IOCTL request body [MS-SMB2] 2.2.31.
-// maxOutput matters to COPYCHUNK, which rejects a response buffer too small
-// for SRV_COPYCHUNK_RESPONSE before it ever resolves the source handle.
+// The offsets are reported relative to the SMB2 header so the production
+// parser, which sees the body from offset 56, resolves to the bytes written
+// here. maxOutput matters to COPYCHUNK, which rejects a response buffer too
+// small for SRV_COPYCHUNK_RESPONSE before it resolves the source handle.
 func buildIoctlRequestBody(ctlCode uint32, fileID [16]byte, input []byte, maxOutput uint32) []byte {
 	const fixedSize = 56
 	w := smbenc.NewWriter(fixedSize + len(input))
@@ -147,10 +148,10 @@ func copyChunkInput(resumeKey [resumeKeyLen]byte) []byte {
 // handlers return for a FileId that does not exist, so a handle belonging to
 // somebody else stays indistinguishable from a closed one.
 //
-// The owner arm is the positive control the refusal needs: it asserts the guard
-// does not fire on the session that opened the handle. It checks only that the
-// status is not the refusal, because what each handler goes on to return past
-// that point is its own business, covered by its own tests.
+// The owner arm is the positive control: it asserts the guard does not fire on
+// the session that opened the handle. It checks only that the status is not the
+// refusal, since what each handler returns past that point is its own business,
+// covered by its own tests.
 func TestHandleOwnership_ForeignSessionRefused(t *testing.T) {
 	ioctlOp := func(ctlCode uint32, input []byte) func(*Handler, *SMBHandlerContext, [16]byte) types.Status {
 		return func(h *Handler, ctx *SMBHandlerContext, fileID [16]byte) types.Status {
@@ -206,14 +207,17 @@ func TestHandleOwnership_ForeignSessionRefused(t *testing.T) {
 		{"IOCTL FSCTL_GET_REPARSE_POINT", ioctlOp(FsctlGetReparsePoint, nil)},
 	}
 
+	// A fixture per arm, since several of these commands consume the handle.
 	for _, op := range ops {
-		t.Run(op.name, func(t *testing.T) {
+		t.Run(op.name+"/foreign", func(t *testing.T) {
 			h, _, other, fileID := ownedHandleFixture(t)
 			if got := op.call(h, other, fileID); got != types.StatusFileClosed {
 				t.Errorf("%s from a second session = %v, want %v — the handle belongs to another session",
 					op.name, got, types.StatusFileClosed)
 			}
+		})
 
+		t.Run(op.name+"/owner", func(t *testing.T) {
 			h, owner, _, fileID := ownedHandleFixture(t)
 			if got := op.call(h, owner, fileID); got == types.StatusFileClosed {
 				t.Errorf("%s from the owning session = %v, want anything but the ownership refusal",
@@ -224,9 +228,8 @@ func TestHandleOwnership_ForeignSessionRefused(t *testing.T) {
 }
 
 // TestHandleOwnership_CopyChunkForeignHandles covers the one command that holds
-// two handles at once. Its check compared the source and destination to each
-// other rather than to the requester, so a caller supplying two FileIds that
-// both belong to one *other* session satisfied it.
+// two handles at once: two FileIds that belong to a single other session agree
+// with each other, so only anchoring both to the requester refuses them.
 func TestHandleOwnership_CopyChunkForeignHandles(t *testing.T) {
 	h, owner, other, srcFileID := ownedHandleFixture(t)
 	dstFileID := storeSecondHandle(t, h, owner, "dst", owner.TreeID)
@@ -237,10 +240,8 @@ func TestHandleOwnership_CopyChunkForeignHandles(t *testing.T) {
 	}
 	body := buildIoctlRequestBody(FsctlSrvCopyChunk, dstFileID, copyChunkInput(resumeKey), 4096)
 
-	// Both handles belong to the owner and so agree with each other, which is
-	// all the old src-vs-dst comparison asked. STATUS_OBJECT_NAME_NOT_FOUND is
-	// what this path already returns for a source the requester may not use
-	// (MS-SMB2 3.3.5.15.6).
+	// STATUS_OBJECT_NAME_NOT_FOUND is what this path already returns for a
+	// source the requester may not use (MS-SMB2 3.3.5.15.6).
 	res, err := h.Ioctl(other, body)
 	if err != nil {
 		t.Fatalf("Ioctl: %v", err)
@@ -265,7 +266,7 @@ func TestHandleOwnership_CopyChunkForeignHandles(t *testing.T) {
 // than a TreeID, and MS-SMB2 3.3.5.15.6 scopes it to the requester's session,
 // not to one tree connect. A server-side copy reading from another tree the
 // same session holds is legitimate, so the source is checked on SessionID
-// alone. Tightening it to the full tree+session predicate would break this.
+// alone — the full tree+session predicate would refuse it.
 func TestHandleOwnership_CopyChunkCrossTreeSourceAllowed(t *testing.T) {
 	h, owner, _, _ := ownedHandleFixture(t)
 

--- a/internal/adapter/smb/handlers/handle_ownership_test.go
+++ b/internal/adapter/smb/handlers/handle_ownership_test.go
@@ -1,0 +1,296 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/smbenc"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// =============================================================================
+// Cross-session handle ownership
+// =============================================================================
+//
+// Opens live in one process-wide table keyed by the FileId alone, so
+// GetOpenFile hands any live handle to any caller that names it. Every
+// handle-based command then adopts that handle's session, tree, share and
+// permission through primeAuthContextFromOpenFile before building the
+// AuthContext, which means an unowned handle would run the request as its
+// owner, against its share, with its tree permission. These tests pin the
+// refusal, per site class.
+
+// ownedHandleFixture builds a share with a handle owned by the session
+// setupReparseShare creates, then adds a second session with its own tree —
+// the shape prepareDispatch guarantees, since it already refuses a tree
+// belonging to another session. It returns a ctx for each.
+//
+// The owner's handle gains FILE_WRITE_ATTRIBUTES so SET_INFO clears its own
+// GrantedAccess gate, which sits ahead of the priming call.
+func ownedHandleFixture(t *testing.T) (h *Handler, owner, other *SMBHandlerContext, fileID [16]byte) {
+	t.Helper()
+
+	h, owner, _, fileID = setupReparseShare(t)
+
+	openFile, ok := h.GetOpenFile(fileID)
+	if !ok {
+		t.Fatal("fixture handle missing")
+	}
+	granted := openFile.GrantedAccess | uint32(types.FileWriteAttributes)
+	openFile.DesiredAccess = granted
+	openFile.GrantedAccess = granted
+
+	uid := uint32(1002)
+	mallory := h.CreateSession("127.0.0.1:2", false, "mallory", "")
+	mallory.User = &models.User{ID: "mallory", Username: "mallory", UID: &uid}
+
+	const malloryTree uint32 = 2
+	h.StoreTree(&TreeConnection{
+		TreeID:     malloryTree,
+		SessionID:  mallory.SessionID,
+		ShareName:  owner.ShareName,
+		Permission: models.PermissionReadWrite,
+	})
+
+	other = &SMBHandlerContext{
+		Context:   context.Background(),
+		SessionID: mallory.SessionID,
+		TreeID:    malloryTree,
+		ShareName: owner.ShareName,
+	}
+	return h, owner, other, fileID
+}
+
+// storeSecondHandle creates another file on the share and registers an open for
+// it on treeID, owned by the session in ownerCtx.
+func storeSecondHandle(t *testing.T, h *Handler, ownerCtx *SMBHandlerContext, name string, treeID uint32) [16]byte {
+	t.Helper()
+
+	rt := h.Registry
+	rootHandle, err := rt.GetRootHandle(ownerCtx.ShareName)
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+	uid, gid := uint32(0), uint32(0)
+	authCtx := &metadata.AuthContext{
+		Context:  context.Background(),
+		Identity: &metadata.Identity{UID: &uid, GID: &gid},
+	}
+	file, _, err := rt.GetMetadataService().CreateFile(authCtx, rootHandle, name, &metadata.FileAttr{
+		Type: metadata.FileTypeRegular, Mode: 0o644,
+	})
+	if err != nil {
+		t.Fatalf("CreateFile(%s): %v", name, err)
+	}
+	fileHandle, err := metadata.EncodeFileHandle(file)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle: %v", err)
+	}
+
+	var fileID [16]byte
+	copy(fileID[:], name)
+	granted := uint32(types.FileReadData | types.FileWriteData | types.FileWriteAttributes)
+	h.StoreOpenFile((&OpenFile{
+		FileID:         fileID,
+		TreeID:         treeID,
+		SessionID:      ownerCtx.SessionID,
+		ShareName:      ownerCtx.ShareName,
+		DesiredAccess:  granted,
+		GrantedAccess:  granted,
+		MetadataHandle: fileHandle,
+	}).WithName(OpenName{Path: name, FileName: name, ParentHandle: rootHandle}))
+	return fileID
+}
+
+// buildIoctlRequestBody encodes an SMB2 IOCTL request body [MS-SMB2] 2.2.31.
+// maxOutput matters to COPYCHUNK, which rejects a response buffer too small
+// for SRV_COPYCHUNK_RESPONSE before it ever resolves the source handle.
+func buildIoctlRequestBody(ctlCode uint32, fileID [16]byte, input []byte, maxOutput uint32) []byte {
+	const fixedSize = 56
+	w := smbenc.NewWriter(fixedSize + len(input))
+	w.WriteUint16(57)                     // StructureSize
+	w.WriteUint16(0)                      // Reserved
+	w.WriteUint32(ctlCode)                // CtlCode
+	w.WriteBytes(fileID[:])               // FileId
+	w.WriteUint32(uint32(64 + fixedSize)) // InputOffset
+	w.WriteUint32(uint32(len(input)))     // InputCount
+	w.WriteUint32(0)                      // MaxInputResponse
+	w.WriteUint32(uint32(64 + fixedSize)) // OutputOffset
+	w.WriteUint32(0)                      // OutputCount
+	w.WriteUint32(maxOutput)              // MaxOutputResponse
+	w.WriteUint32(0)                      // Flags
+	w.WriteUint32(0)                      // Reserved2
+	if len(input) > 0 {
+		w.WriteBytes(input)
+	}
+	return w.Bytes()
+}
+
+// copyChunkInput encodes SRV_COPYCHUNK_COPY [MS-SMB2] 2.2.32.1 for one chunk.
+func copyChunkInput(resumeKey [resumeKeyLen]byte) []byte {
+	w := smbenc.NewWriter(32 + 24)
+	w.WriteBytes(resumeKey[:])
+	w.WriteUint32(1) // ChunkCount
+	w.WriteUint32(0) // Reserved
+	w.WriteUint64(0) // SourceOffset
+	w.WriteUint64(0) // TargetOffset
+	w.WriteUint32(4) // Length
+	w.WriteUint32(0) // Reserved
+	return w.Bytes()
+}
+
+// TestHandleOwnership_ForeignSessionRefused drives one command per site class
+// that adopts a handle's identity, and asserts a second session naming the
+// first's FileId is refused with STATUS_FILE_CLOSED — the same status these
+// handlers return for a FileId that does not exist, so a handle belonging to
+// somebody else stays indistinguishable from a closed one.
+//
+// The owner arm is the positive control the refusal needs: it asserts the guard
+// does not fire on the session that opened the handle. It checks only that the
+// status is not the refusal, because what each handler goes on to return past
+// that point is its own business, covered by its own tests.
+func TestHandleOwnership_ForeignSessionRefused(t *testing.T) {
+	ioctlOp := func(ctlCode uint32, input []byte) func(*Handler, *SMBHandlerContext, [16]byte) types.Status {
+		return func(h *Handler, ctx *SMBHandlerContext, fileID [16]byte) types.Status {
+			res, err := h.Ioctl(ctx, buildIoctlRequestBody(ctlCode, fileID, input, 4096))
+			if err != nil {
+				return types.StatusInternalError
+			}
+			return res.Status
+		}
+	}
+
+	byteRange := func() []byte {
+		w := smbenc.NewWriter(16)
+		w.WriteUint64(0)   // FileOffset
+		w.WriteUint64(512) // Length / BeyondFinalZero
+		return w.Bytes()
+	}()
+
+	ops := []struct {
+		name string
+		call func(*Handler, *SMBHandlerContext, [16]byte) types.Status
+	}{
+		{"CLOSE", func(h *Handler, ctx *SMBHandlerContext, fileID [16]byte) types.Status {
+			resp, err := h.Close(ctx, &CloseRequest{FileID: fileID})
+			if err != nil {
+				return types.StatusInternalError
+			}
+			return resp.Status
+		}},
+		{"FLUSH", func(h *Handler, ctx *SMBHandlerContext, fileID [16]byte) types.Status {
+			resp, err := h.Flush(ctx, &FlushRequest{FileID: fileID})
+			if err != nil {
+				return types.StatusInternalError
+			}
+			return resp.Status
+		}},
+		{"SET_INFO", func(h *Handler, ctx *SMBHandlerContext, fileID [16]byte) types.Status {
+			resp, err := h.SetInfo(ctx, &SetInfoRequest{
+				FileID:        fileID,
+				InfoType:      uint8(types.SMB2InfoTypeFile),
+				FileInfoClass: uint8(types.FileBasicInformation),
+				Buffer:        make([]byte, 40),
+			})
+			if err != nil {
+				return types.StatusInternalError
+			}
+			return resp.Status
+		}},
+		{"IOCTL FSCTL_SET_SPARSE", ioctlOp(FsctlSetSparse, []byte{1})},
+		{"IOCTL FSCTL_QUERY_ALLOCATED_RANGES", ioctlOp(FsctlQueryAllocatedRanges, byteRange)},
+		{"IOCTL FSCTL_SET_ZERO_DATA", ioctlOp(FsctlSetZeroData, byteRange)},
+		{"IOCTL FSCTL_SET_COMPRESSION", ioctlOp(FsctlSetCompression, []byte{0, 0})},
+		{"IOCTL FSCTL_GET_REPARSE_POINT", ioctlOp(FsctlGetReparsePoint, nil)},
+	}
+
+	for _, op := range ops {
+		t.Run(op.name, func(t *testing.T) {
+			h, _, other, fileID := ownedHandleFixture(t)
+			if got := op.call(h, other, fileID); got != types.StatusFileClosed {
+				t.Errorf("%s from a second session = %v, want %v — the handle belongs to another session",
+					op.name, got, types.StatusFileClosed)
+			}
+
+			h, owner, _, fileID := ownedHandleFixture(t)
+			if got := op.call(h, owner, fileID); got == types.StatusFileClosed {
+				t.Errorf("%s from the owning session = %v, want anything but the ownership refusal",
+					op.name, got)
+			}
+		})
+	}
+}
+
+// TestHandleOwnership_CopyChunkForeignHandles covers the one command that holds
+// two handles at once. Its check compared the source and destination to each
+// other rather than to the requester, so a caller supplying two FileIds that
+// both belong to one *other* session satisfied it.
+func TestHandleOwnership_CopyChunkForeignHandles(t *testing.T) {
+	h, owner, other, srcFileID := ownedHandleFixture(t)
+	dstFileID := storeSecondHandle(t, h, owner, "dst", owner.TreeID)
+
+	resumeKey, err := h.resumeKeys.issue(srcFileID)
+	if err != nil {
+		t.Fatalf("issue resume key: %v", err)
+	}
+	body := buildIoctlRequestBody(FsctlSrvCopyChunk, dstFileID, copyChunkInput(resumeKey), 4096)
+
+	// Both handles belong to the owner and so agree with each other, which is
+	// all the old src-vs-dst comparison asked. STATUS_OBJECT_NAME_NOT_FOUND is
+	// what this path already returns for a source the requester may not use
+	// (MS-SMB2 3.3.5.15.6).
+	res, err := h.Ioctl(other, body)
+	if err != nil {
+		t.Fatalf("Ioctl: %v", err)
+	}
+	if res.Status != types.StatusObjectNameNotFound {
+		t.Errorf("COPYCHUNK with two handles from another session = %v, want %v",
+			res.Status, types.StatusObjectNameNotFound)
+	}
+
+	res, err = h.Ioctl(owner, body)
+	if err != nil {
+		t.Fatalf("Ioctl (owner): %v", err)
+	}
+	if res.Status == types.StatusObjectNameNotFound {
+		t.Errorf("COPYCHUNK from the owning session = %v, want anything but the ownership refusal",
+			res.Status)
+	}
+}
+
+// TestHandleOwnership_CopyChunkCrossTreeSourceAllowed pins the deliberate
+// asymmetry in the COPYCHUNK gate: the source arrives as a resume key rather
+// than a TreeID, and MS-SMB2 3.3.5.15.6 scopes it to the requester's session,
+// not to one tree connect. A server-side copy reading from another tree the
+// same session holds is legitimate, so the source is checked on SessionID
+// alone. Tightening it to the full tree+session predicate would break this.
+func TestHandleOwnership_CopyChunkCrossTreeSourceAllowed(t *testing.T) {
+	h, owner, _, _ := ownedHandleFixture(t)
+
+	// A second tree for the same session, with the source handle opened on it.
+	const otherTree uint32 = 3
+	h.StoreTree(&TreeConnection{
+		TreeID:     otherTree,
+		SessionID:  owner.SessionID,
+		ShareName:  owner.ShareName,
+		Permission: models.PermissionReadWrite,
+	})
+	srcFileID := storeSecondHandle(t, h, owner, "src", otherTree)
+	dstFileID := storeSecondHandle(t, h, owner, "dst", owner.TreeID)
+
+	resumeKey, err := h.resumeKeys.issue(srcFileID)
+	if err != nil {
+		t.Fatalf("issue resume key: %v", err)
+	}
+
+	res, err := h.Ioctl(owner, buildIoctlRequestBody(FsctlSrvCopyChunk, dstFileID, copyChunkInput(resumeKey), 4096))
+	if err != nil {
+		t.Fatalf("Ioctl: %v", err)
+	}
+	if res.Status == types.StatusObjectNameNotFound {
+		t.Error("COPYCHUNK with a source on another tree of the same session was refused; " +
+			"3.3.5.15.6 scopes the source to the session, not to the tree connect")
+	}
+}

--- a/internal/adapter/smb/handlers/ioctl_copychunk.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk.go
@@ -199,10 +199,21 @@ func (h *Handler) handleSrvCopyChunk(ctx *SMBHandlerContext, body []byte) (*Hand
 		return NewErrorResult(types.StatusObjectNameNotFound), nil
 	}
 
-	// Per [MS-SMB2] 3.3.5.15.6: source and destination must be in the same session
-	if srcOpen.SessionID != dstOpen.SessionID {
-		logger.Debug("COPYCHUNK: cross-session copy not allowed",
-			"srcSession", srcOpen.SessionID, "dstSession", dstOpen.SessionID)
+	// Per [MS-SMB2] 3.3.5.15.6: source and destination must be in the same
+	// session — and that session must be the requester's. Comparing the two
+	// handles only to each other is satisfied by any caller that supplies two
+	// foreign FileIds belonging to one other session, so anchor both to ctx.
+	//
+	// SessionID alone, deliberately: the source is reached through a resume key
+	// rather than a TreeID, and §3.3.5.15.6 constrains it to the session, not
+	// the tree connect. A server-side copy between two shares the session holds
+	// is legitimate, so requiring srcOpen.TreeID == ctx.TreeID would break it.
+	// The destination is this IOCTL's own handle and gets the full tree+session
+	// ownership check when it primes the auth context below.
+	if srcOpen.SessionID != ctx.SessionID || dstOpen.SessionID != ctx.SessionID {
+		logger.Debug("COPYCHUNK: handle does not belong to the requesting session",
+			"srcSession", srcOpen.SessionID, "dstSession", dstOpen.SessionID,
+			"reqSession", ctx.SessionID)
 		return NewErrorResult(types.StatusObjectNameNotFound), nil
 	}
 
@@ -388,7 +399,9 @@ func (h *Handler) executeCopyChunks(
 	// on the destination write (#619, same class as #603). srcOpen and
 	// dstOpen are required to share a SessionID by the upstream validator,
 	// so priming from dstOpen is equivalent to priming from srcOpen.
-	h.primeAuthContextFromOpenFile(ctx, dstOpen)
+	if st := h.primeAuthContextFromOpenFile(ctx, dstOpen); st != types.StatusSuccess {
+		return NewErrorResult(st), nil
+	}
 
 	authCtx, err := BuildAuthContext(ctx)
 	if err != nil {

--- a/internal/adapter/smb/handlers/ioctl_copychunk.go
+++ b/internal/adapter/smb/handlers/ioctl_copychunk.go
@@ -200,9 +200,8 @@ func (h *Handler) handleSrvCopyChunk(ctx *SMBHandlerContext, body []byte) (*Hand
 	}
 
 	// Per [MS-SMB2] 3.3.5.15.6: source and destination must be in the same
-	// session — and that session must be the requester's. Comparing the two
-	// handles only to each other is satisfied by any caller that supplies two
-	// foreign FileIds belonging to one other session, so anchor both to ctx.
+	// session — and that session must be the requester's, not merely each
+	// other's.
 	//
 	// SessionID alone, deliberately: the source is reached through a resume key
 	// rather than a TreeID, and §3.3.5.15.6 constrains it to the session, not
@@ -399,8 +398,8 @@ func (h *Handler) executeCopyChunks(
 	// on the destination write (#619, same class as #603). srcOpen and
 	// dstOpen are required to share a SessionID by the upstream validator,
 	// so priming from dstOpen is equivalent to priming from srcOpen.
-	if st := h.primeAuthContextFromOpenFile(ctx, dstOpen); st != types.StatusSuccess {
-		return NewErrorResult(st), nil
+	if status := h.primeAuthContextFromOpenFile(ctx, dstOpen); status != types.StatusSuccess {
+		return NewErrorResult(status), nil
 	}
 
 	authCtx, err := BuildAuthContext(ctx)

--- a/internal/adapter/smb/handlers/ioctl_fsctl.go
+++ b/internal/adapter/smb/handlers/ioctl_fsctl.go
@@ -105,8 +105,8 @@ func (h *Handler) handleSetCompression(ctx *SMBHandlerContext, body []byte) (*Ha
 	// session BEFORE BuildAuthContext — otherwise ctx.User==nil falls
 	// into the anonymous arm and synthesises UID-0 (root), bypassing
 	// DACL checks on SetFileAttributes (#619, same class as #603).
-	if st := h.primeAuthContextFromOpenFile(ctx, openFile); st != types.StatusSuccess {
-		return NewErrorResult(st), nil
+	if status := h.primeAuthContextFromOpenFile(ctx, openFile); status != types.StatusSuccess {
+		return NewErrorResult(status), nil
 	}
 	authCtx, authErr := BuildAuthContext(ctx)
 	if authErr != nil {

--- a/internal/adapter/smb/handlers/ioctl_fsctl.go
+++ b/internal/adapter/smb/handlers/ioctl_fsctl.go
@@ -105,7 +105,9 @@ func (h *Handler) handleSetCompression(ctx *SMBHandlerContext, body []byte) (*Ha
 	// session BEFORE BuildAuthContext — otherwise ctx.User==nil falls
 	// into the anonymous arm and synthesises UID-0 (root), bypassing
 	// DACL checks on SetFileAttributes (#619, same class as #603).
-	h.primeAuthContextFromOpenFile(ctx, openFile)
+	if st := h.primeAuthContextFromOpenFile(ctx, openFile); st != types.StatusSuccess {
+		return NewErrorResult(st), nil
+	}
 	authCtx, authErr := BuildAuthContext(ctx)
 	if authErr != nil {
 		logger.Warn("FSCTL_SET_COMPRESSION: failed to build auth context", "error", authErr)

--- a/internal/adapter/smb/handlers/ioctl_sparse.go
+++ b/internal/adapter/smb/handlers/ioctl_sparse.go
@@ -93,8 +93,8 @@ func (h *Handler) handleSetSparse(ctx *SMBHandlerContext, body []byte) (*Handler
 
 	// Persist the sparse bit via SetFileAttributes so QUERY_INFO and
 	// subsequent CREATEs see the FILE_ATTRIBUTE_SPARSE_FILE attribute.
-	if st := h.primeAuthContextFromOpenFile(ctx, openFile); st != types.StatusSuccess {
-		return NewErrorResult(st), nil
+	if status := h.primeAuthContextFromOpenFile(ctx, openFile); status != types.StatusSuccess {
+		return NewErrorResult(status), nil
 	}
 	authCtx, err := BuildAuthContext(ctx)
 	if err != nil {
@@ -184,8 +184,8 @@ func (h *Handler) handleQueryAllocatedRanges(ctx *SMBHandlerContext, body []byte
 	// Prime ctx with the OpenFile's recorded session state — without this
 	// hand-off BuildAuthContext takes the ctx.User==nil arm and synthesises
 	// UID-0 (root), bypassing DACL checks on the GetFile probe (#619).
-	if st := h.primeAuthContextFromOpenFile(ctx, openFile); st != types.StatusSuccess {
-		return NewErrorResult(st), nil
+	if status := h.primeAuthContextFromOpenFile(ctx, openFile); status != types.StatusSuccess {
+		return NewErrorResult(status), nil
 	}
 	authCtx, err := BuildAuthContext(ctx)
 	if err != nil {
@@ -426,8 +426,8 @@ func (h *Handler) handleSetZeroData(ctx *SMBHandlerContext, body []byte) (*Handl
 	// Without this, FileID-only IOCTL requests fall through to anonymous
 	// UID-0 (root) and CommitWrite skips the non-root SUID/SGID clearing
 	// path (#619, same class as #603).
-	if st := h.primeAuthContextFromOpenFile(ctx, openFile); st != types.StatusSuccess {
-		return NewErrorResult(st), nil
+	if status := h.primeAuthContextFromOpenFile(ctx, openFile); status != types.StatusSuccess {
+		return NewErrorResult(status), nil
 	}
 	authCtx, err := BuildAuthContext(ctx)
 	if err != nil {

--- a/internal/adapter/smb/handlers/ioctl_sparse.go
+++ b/internal/adapter/smb/handlers/ioctl_sparse.go
@@ -93,7 +93,9 @@ func (h *Handler) handleSetSparse(ctx *SMBHandlerContext, body []byte) (*Handler
 
 	// Persist the sparse bit via SetFileAttributes so QUERY_INFO and
 	// subsequent CREATEs see the FILE_ATTRIBUTE_SPARSE_FILE attribute.
-	h.primeAuthContextFromOpenFile(ctx, openFile)
+	if st := h.primeAuthContextFromOpenFile(ctx, openFile); st != types.StatusSuccess {
+		return NewErrorResult(st), nil
+	}
 	authCtx, err := BuildAuthContext(ctx)
 	if err != nil {
 		return NewErrorResult(types.StatusAccessDenied), nil
@@ -182,7 +184,9 @@ func (h *Handler) handleQueryAllocatedRanges(ctx *SMBHandlerContext, body []byte
 	// Prime ctx with the OpenFile's recorded session state — without this
 	// hand-off BuildAuthContext takes the ctx.User==nil arm and synthesises
 	// UID-0 (root), bypassing DACL checks on the GetFile probe (#619).
-	h.primeAuthContextFromOpenFile(ctx, openFile)
+	if st := h.primeAuthContextFromOpenFile(ctx, openFile); st != types.StatusSuccess {
+		return NewErrorResult(st), nil
+	}
 	authCtx, err := BuildAuthContext(ctx)
 	if err != nil {
 		return NewErrorResult(types.StatusAccessDenied), nil
@@ -422,7 +426,9 @@ func (h *Handler) handleSetZeroData(ctx *SMBHandlerContext, body []byte) (*Handl
 	// Without this, FileID-only IOCTL requests fall through to anonymous
 	// UID-0 (root) and CommitWrite skips the non-root SUID/SGID clearing
 	// path (#619, same class as #603).
-	h.primeAuthContextFromOpenFile(ctx, openFile)
+	if st := h.primeAuthContextFromOpenFile(ctx, openFile); st != types.StatusSuccess {
+		return NewErrorResult(st), nil
+	}
 	authCtx, err := BuildAuthContext(ctx)
 	if err != nil {
 		return NewErrorResult(types.StatusAccessDenied), nil

--- a/internal/adapter/smb/handlers/ioctl_sparse_test.go
+++ b/internal/adapter/smb/handlers/ioctl_sparse_test.go
@@ -9,28 +9,10 @@ import (
 )
 
 // buildSparseIoctlRequest assembles an SMB2 IOCTL request body with an
-// optional input buffer. The InputOffset is reported relative to the SMB2
-// header so the production parser (which lives at offset 56 of the body)
-// resolves to the same bytes the test wrote.
+// optional input buffer and no output-buffer allowance, which is all the
+// sparse FSCTLs look at.
 func buildSparseIoctlRequest(ctlCode uint32, fileID [16]byte, input []byte) []byte {
-	const fixedSize = 56
-	w := smbenc.NewWriter(fixedSize + len(input))
-	w.WriteUint16(57)                     // StructureSize
-	w.WriteUint16(0)                      // Reserved
-	w.WriteUint32(ctlCode)                // CtlCode
-	w.WriteBytes(fileID[:])               // FileId
-	w.WriteUint32(uint32(64 + fixedSize)) // InputOffset (header + fixed)
-	w.WriteUint32(uint32(len(input)))     // InputCount
-	w.WriteUint32(0)                      // MaxInputResponse
-	w.WriteUint32(uint32(64 + fixedSize)) // OutputOffset
-	w.WriteUint32(0)                      // OutputCount
-	w.WriteUint32(0)                      // MaxOutputResponse
-	w.WriteUint32(0)                      // Flags
-	w.WriteUint32(0)                      // Reserved2
-	if len(input) > 0 {
-		w.WriteBytes(input)
-	}
-	return w.Bytes()
+	return buildIoctlRequestBody(ctlCode, fileID, input, 0)
 }
 
 // TestSetSparse_NoHandle returns STATUS_FILE_CLOSED when the FileID has no

--- a/internal/adapter/smb/handlers/lock.go
+++ b/internal/adapter/smb/handlers/lock.go
@@ -250,7 +250,9 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 	// BEFORE BuildAuthContext — otherwise ctx.User==nil falls into the
 	// anonymous arm and synthesises UID-0 (root), bypassing DACL checks on
 	// the downstream lock/unlock metadata operations (#619, same class as #603).
-	h.primeAuthContextFromOpenFile(ctx, openFile)
+	if st := h.primeAuthContextFromOpenFile(ctx, openFile); st != types.StatusSuccess {
+		return NewErrorResult(st), nil
+	}
 
 	// Build auth context
 	authCtx, err := BuildAuthContext(ctx)

--- a/internal/adapter/smb/handlers/lock.go
+++ b/internal/adapter/smb/handlers/lock.go
@@ -250,8 +250,8 @@ func (h *Handler) Lock(ctx *SMBHandlerContext, body []byte) (*HandlerResult, err
 	// BEFORE BuildAuthContext — otherwise ctx.User==nil falls into the
 	// anonymous arm and synthesises UID-0 (root), bypassing DACL checks on
 	// the downstream lock/unlock metadata operations (#619, same class as #603).
-	if st := h.primeAuthContextFromOpenFile(ctx, openFile); st != types.StatusSuccess {
-		return NewErrorResult(st), nil
+	if status := h.primeAuthContextFromOpenFile(ctx, openFile); status != types.StatusSuccess {
+		return NewErrorResult(status), nil
 	}
 
 	// Build auth context

--- a/internal/adapter/smb/handlers/query_directory.go
+++ b/internal/adapter/smb/handlers/query_directory.go
@@ -307,7 +307,9 @@ func (h *Handler) QueryDirectory(ctx *SMBHandlerContext, req *QueryDirectoryRequ
 	// QUERY_DIRECTORY arrives keyed only by FileID, so the dispatcher
 	// cannot prefill ctx.User. See primeAuthContextFromOpenFile for the
 	// UID-0 root-bypass this prevents (refs #603 — ABE filterByAccess).
-	h.primeAuthContextFromOpenFile(ctx, openFile)
+	if st := h.primeAuthContextFromOpenFile(ctx, openFile); st != types.StatusSuccess {
+		return &QueryDirectoryResponse{SMBResponseBase: SMBResponseBase{Status: st}}, nil
+	}
 
 	// Build AuthContext
 	authCtx, err := BuildAuthContext(ctx)

--- a/internal/adapter/smb/handlers/query_directory.go
+++ b/internal/adapter/smb/handlers/query_directory.go
@@ -307,8 +307,8 @@ func (h *Handler) QueryDirectory(ctx *SMBHandlerContext, req *QueryDirectoryRequ
 	// QUERY_DIRECTORY arrives keyed only by FileID, so the dispatcher
 	// cannot prefill ctx.User. See primeAuthContextFromOpenFile for the
 	// UID-0 root-bypass this prevents (refs #603 — ABE filterByAccess).
-	if st := h.primeAuthContextFromOpenFile(ctx, openFile); st != types.StatusSuccess {
-		return &QueryDirectoryResponse{SMBResponseBase: SMBResponseBase{Status: st}}, nil
+	if status := h.primeAuthContextFromOpenFile(ctx, openFile); status != types.StatusSuccess {
+		return &QueryDirectoryResponse{SMBResponseBase: SMBResponseBase{Status: status}}, nil
 	}
 
 	// Build AuthContext

--- a/internal/adapter/smb/handlers/query_info.go
+++ b/internal/adapter/smb/handlers/query_info.go
@@ -351,7 +351,9 @@ func (h *Handler) QueryInfo(ctx *SMBHandlerContext, req *QueryInfoRequest) (*Que
 	// BEFORE BuildAuthContext — otherwise ctx.User==nil falls into the
 	// anonymous arm and synthesises UID-0 (root), bypassing all DACL checks
 	// in the metadata layer (#619, same class as #603).
-	h.primeAuthContextFromOpenFile(ctx, openFile)
+	if st := h.primeAuthContextFromOpenFile(ctx, openFile); st != types.StatusSuccess {
+		return &QueryInfoResponse{SMBResponseBase: SMBResponseBase{Status: st}}, nil
+	}
 
 	authCtx, authErr := BuildAuthContext(ctx)
 	if authErr != nil {

--- a/internal/adapter/smb/handlers/query_info.go
+++ b/internal/adapter/smb/handlers/query_info.go
@@ -351,8 +351,8 @@ func (h *Handler) QueryInfo(ctx *SMBHandlerContext, req *QueryInfoRequest) (*Que
 	// BEFORE BuildAuthContext — otherwise ctx.User==nil falls into the
 	// anonymous arm and synthesises UID-0 (root), bypassing all DACL checks
 	// in the metadata layer (#619, same class as #603).
-	if st := h.primeAuthContextFromOpenFile(ctx, openFile); st != types.StatusSuccess {
-		return &QueryInfoResponse{SMBResponseBase: SMBResponseBase{Status: st}}, nil
+	if status := h.primeAuthContextFromOpenFile(ctx, openFile); status != types.StatusSuccess {
+		return &QueryInfoResponse{SMBResponseBase: SMBResponseBase{Status: status}}, nil
 	}
 
 	authCtx, authErr := BuildAuthContext(ctx)

--- a/internal/adapter/smb/handlers/read.go
+++ b/internal/adapter/smb/handlers/read.go
@@ -257,11 +257,10 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 		logger.Debug("READ: invalid session ID", "sessionID", openFile.SessionID)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusUserSessionDeleted}}, nil
 	}
-	// Priming refuses a handle that does not belong to this request's
-	// TreeConnect/Session (MS-SMB2 §3.3.5.2.5) — the gate the smb2.tcon torture
-	// test exercises by mis-setting the wire-level TID/SID.
-	if st := h.primeAuthContextFromOpenFile(ctx, openFile); st != types.StatusSuccess {
-		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: st}}, nil
+	// Priming also refuses a handle that does not belong to this request's
+	// TreeConnect/Session (MS-SMB2 §3.3.5.2.5).
+	if status := h.primeAuthContextFromOpenFile(ctx, openFile); status != types.StatusSuccess {
+		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: status}}, nil
 	}
 
 	// ========================================================================

--- a/internal/adapter/smb/handlers/read.go
+++ b/internal/adapter/smb/handlers/read.go
@@ -257,16 +257,12 @@ func (h *Handler) Read(ctx *SMBHandlerContext, req *ReadRequest) (*ReadResponse,
 		logger.Debug("READ: invalid session ID", "sessionID", openFile.SessionID)
 		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusUserSessionDeleted}}, nil
 	}
-	// Per MS-SMB2 §3.3.5.2.5: verify the request's TreeID/SessionID match
-	// the handle's owning TreeConnect/Session — mirrors the gate added to
-	// WRITE/CHANGE_NOTIFY for the smb2.tcon torture test.
-	if openFile.TreeID != ctx.TreeID || openFile.SessionID != ctx.SessionID {
-		logger.Debug("READ: handle does not belong to request's tree/session",
-			"handleTreeID", openFile.TreeID, "reqTreeID", ctx.TreeID,
-			"handleSessionID", openFile.SessionID, "reqSessionID", ctx.SessionID)
-		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusFileClosed}}, nil
+	// Priming refuses a handle that does not belong to this request's
+	// TreeConnect/Session (MS-SMB2 §3.3.5.2.5) — the gate the smb2.tcon torture
+	// test exercises by mis-setting the wire-level TID/SID.
+	if st := h.primeAuthContextFromOpenFile(ctx, openFile); st != types.StatusSuccess {
+		return &ReadResponse{SMBResponseBase: SMBResponseBase{Status: st}}, nil
 	}
-	h.primeAuthContextFromOpenFile(ctx, openFile)
 
 	// ========================================================================
 	// Step 5: Get metadata service and block store

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -241,7 +241,9 @@ func (h *Handler) SetInfo(ctx *SMBHandlerContext, req *SetInfoRequest) (*SetInfo
 	// BEFORE BuildAuthContext — otherwise ctx.User==nil falls into the
 	// anonymous arm and synthesises UID-0 (root), bypassing all DACL checks
 	// in the metadata layer (#619, same class as #603).
-	h.primeAuthContextFromOpenFile(ctx, openFile)
+	if st := h.primeAuthContextFromOpenFile(ctx, openFile); st != types.StatusSuccess {
+		return setInfoStatus(st), nil
+	}
 
 	authCtx, err := BuildAuthContext(ctx)
 	if err != nil {

--- a/internal/adapter/smb/handlers/set_info.go
+++ b/internal/adapter/smb/handlers/set_info.go
@@ -241,8 +241,8 @@ func (h *Handler) SetInfo(ctx *SMBHandlerContext, req *SetInfoRequest) (*SetInfo
 	// BEFORE BuildAuthContext — otherwise ctx.User==nil falls into the
 	// anonymous arm and synthesises UID-0 (root), bypassing all DACL checks
 	// in the metadata layer (#619, same class as #603).
-	if st := h.primeAuthContextFromOpenFile(ctx, openFile); st != types.StatusSuccess {
-		return setInfoStatus(st), nil
+	if status := h.primeAuthContextFromOpenFile(ctx, openFile); status != types.StatusSuccess {
+		return setInfoStatus(status), nil
 	}
 
 	authCtx, err := BuildAuthContext(ctx)

--- a/internal/adapter/smb/handlers/set_reparse_point.go
+++ b/internal/adapter/smb/handlers/set_reparse_point.go
@@ -40,6 +40,16 @@ func (h *Handler) handleSetReparsePoint(ctx *SMBHandlerContext, body []byte) (*H
 		return NewErrorResult(types.StatusInvalidParameter), nil
 	}
 
+	// Prime ctx.User / IsGuest / TreeID from the handle's recorded session
+	// BEFORE BuildAuthContext — otherwise ctx.User==nil synthesises UID-0
+	// (root), bypassing DACL checks on the RemoveFile + CreateSymlink in
+	// convertOpenFileToNativeSymlink (#619). Priming here rather than inside
+	// that helper keeps the ownership refusal on the handler's own status path,
+	// where it can be reported as-is instead of being mapped from an error.
+	if st := h.primeAuthContextFromOpenFile(ctx, openFile); st != types.StatusSuccess {
+		return NewErrorResult(st), nil
+	}
+
 	input := parseIoctlInputData(body)
 	if len(input) < 8 {
 		logger.Debug("IOCTL SET_REPARSE_POINT: input too small", "len", len(input))
@@ -201,11 +211,10 @@ func (h *Handler) convertOpenFileToNativeSymlink(ctx *SMBHandlerContext, openFil
 		return fmt.Errorf("missing parent handle or filename for symlink conversion")
 	}
 
-	// Prime ctx.User / IsGuest / TreeID from the OpenFile's recorded session
-	// BEFORE BuildAuthContext — otherwise ctx.User==nil synthesises UID-0
-	// (root), bypassing DACL checks on RemoveFile + CreateSymlink (#619).
-	h.primeAuthContextFromOpenFile(ctx, openFile)
-
+	// ctx is already primed with this handle's session by handleSetReparsePoint,
+	// the only path that reaches here, so BuildAuthContext will not take the
+	// ctx.User==nil arm and synthesise UID-0 (root) over the RemoveFile +
+	// CreateSymlink below (#619).
 	authCtx, err := BuildAuthContext(ctx)
 	if err != nil {
 		return err

--- a/internal/adapter/smb/handlers/set_reparse_point.go
+++ b/internal/adapter/smb/handlers/set_reparse_point.go
@@ -44,10 +44,10 @@ func (h *Handler) handleSetReparsePoint(ctx *SMBHandlerContext, body []byte) (*H
 	// BEFORE BuildAuthContext — otherwise ctx.User==nil synthesises UID-0
 	// (root), bypassing DACL checks on the RemoveFile + CreateSymlink in
 	// convertOpenFileToNativeSymlink (#619). Priming here rather than inside
-	// that helper keeps the ownership refusal on the handler's own status path,
-	// where it can be reported as-is instead of being mapped from an error.
-	if st := h.primeAuthContextFromOpenFile(ctx, openFile); st != types.StatusSuccess {
-		return NewErrorResult(st), nil
+	// that helper keeps the ownership refusal on the handler's status path,
+	// which returns it as-is instead of mapping it from an error.
+	if status := h.primeAuthContextFromOpenFile(ctx, openFile); status != types.StatusSuccess {
+		return NewErrorResult(status), nil
 	}
 
 	input := parseIoctlInputData(body)
@@ -211,10 +211,9 @@ func (h *Handler) convertOpenFileToNativeSymlink(ctx *SMBHandlerContext, openFil
 		return fmt.Errorf("missing parent handle or filename for symlink conversion")
 	}
 
-	// ctx is already primed with this handle's session by handleSetReparsePoint,
-	// the only path that reaches here, so BuildAuthContext will not take the
-	// ctx.User==nil arm and synthesise UID-0 (root) over the RemoveFile +
-	// CreateSymlink below (#619).
+	// handleSetReparsePoint, the only path in, primed ctx from this handle's
+	// session, so BuildAuthContext will not take the ctx.User==nil arm and
+	// synthesise UID-0 (root) over the RemoveFile + CreateSymlink below (#619).
 	authCtx, err := BuildAuthContext(ctx)
 	if err != nil {
 		return err

--- a/internal/adapter/smb/handlers/stub_handlers.go
+++ b/internal/adapter/smb/handlers/stub_handlers.go
@@ -114,7 +114,9 @@ func (h *Handler) handleGetReparsePoint(ctx *SMBHandlerContext, body []byte) (*H
 	// BEFORE BuildAuthContext — otherwise ctx.User==nil falls into the
 	// anonymous arm and synthesises UID-0 (root), bypassing DACL checks on
 	// the downstream ReadSymlink (#619, same class as #603).
-	h.primeAuthContextFromOpenFile(ctx, openFile)
+	if st := h.primeAuthContextFromOpenFile(ctx, openFile); st != types.StatusSuccess {
+		return NewErrorResult(st), nil
+	}
 
 	// Build auth context
 	authCtx, err := BuildAuthContext(ctx)
@@ -506,9 +508,14 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 		return NewErrorResult(types.StatusAccessDenied), nil
 	}
 
-	// Verify session and tree match
-	if openFile.SessionID != ctx.SessionID || openFile.TreeID != ctx.TreeID {
-		logger.Debug("CHANGE_NOTIFY: session/tree mismatch")
+	// CHANGE_NOTIFY does not prime an auth context off the handle, so it checks
+	// the same ownership predicate the priming helper applies. It keeps
+	// StatusInvalidHandle rather than the helper's StatusFileClosed, which is
+	// the status this path has always returned.
+	if !openFileBelongsToRequest(ctx, openFile) {
+		logger.Debug("CHANGE_NOTIFY: handle does not belong to the request's tree/session",
+			"handleTreeID", openFile.TreeID, "reqTreeID", ctx.TreeID,
+			"handleSessionID", openFile.SessionID, "reqSessionID", ctx.SessionID)
 		return NewErrorResult(types.StatusInvalidHandle), nil
 	}
 

--- a/internal/adapter/smb/handlers/stub_handlers.go
+++ b/internal/adapter/smb/handlers/stub_handlers.go
@@ -114,8 +114,8 @@ func (h *Handler) handleGetReparsePoint(ctx *SMBHandlerContext, body []byte) (*H
 	// BEFORE BuildAuthContext — otherwise ctx.User==nil falls into the
 	// anonymous arm and synthesises UID-0 (root), bypassing DACL checks on
 	// the downstream ReadSymlink (#619, same class as #603).
-	if st := h.primeAuthContextFromOpenFile(ctx, openFile); st != types.StatusSuccess {
-		return NewErrorResult(st), nil
+	if status := h.primeAuthContextFromOpenFile(ctx, openFile); status != types.StatusSuccess {
+		return NewErrorResult(status), nil
 	}
 
 	// Build auth context
@@ -508,10 +508,9 @@ func (h *Handler) ChangeNotify(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 		return NewErrorResult(types.StatusAccessDenied), nil
 	}
 
-	// CHANGE_NOTIFY does not prime an auth context off the handle, so it checks
-	// the same ownership predicate the priming helper applies. It keeps
-	// StatusInvalidHandle rather than the helper's StatusFileClosed, which is
-	// the status this path has always returned.
+	// CHANGE_NOTIFY primes no auth context off the handle, so it applies the
+	// ownership predicate directly. It keeps StatusInvalidHandle, the status
+	// this path has always returned, rather than the helper's StatusFileClosed.
 	if !openFileBelongsToRequest(ctx, openFile) {
 		logger.Debug("CHANGE_NOTIFY: handle does not belong to the request's tree/session",
 			"handleTreeID", openFile.TreeID, "reqTreeID", ctx.TreeID,

--- a/internal/adapter/smb/handlers/write.go
+++ b/internal/adapter/smb/handlers/write.go
@@ -280,17 +280,13 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 		logger.Debug("WRITE: invalid session ID", "sessionID", openFile.SessionID)
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusUserSessionDeleted}}, nil
 	}
-	// Per MS-SMB2 §3.3.5.2.5: verify the request's TreeID/SessionID match
-	// the handle's owning TreeConnect/Session. The smb2.tcon torture test
-	// exercises this by deliberately mis-setting the wire-level TID/SID
-	// and expecting an error (Samba returns FILE_CLOSED).
-	if openFile.TreeID != ctx.TreeID || openFile.SessionID != ctx.SessionID {
-		logger.Debug("WRITE: handle does not belong to request's tree/session",
-			"handleTreeID", openFile.TreeID, "reqTreeID", ctx.TreeID,
-			"handleSessionID", openFile.SessionID, "reqSessionID", ctx.SessionID)
-		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusFileClosed}}, nil
+	// Priming refuses a handle that does not belong to this request's
+	// TreeConnect/Session (MS-SMB2 §3.3.5.2.5). The smb2.tcon torture test
+	// exercises this by deliberately mis-setting the wire-level TID/SID and
+	// expecting an error (Samba returns FILE_CLOSED).
+	if st := h.primeAuthContextFromOpenFile(ctx, openFile); st != types.StatusSuccess {
+		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: st}}, nil
 	}
-	h.primeAuthContextFromOpenFile(ctx, openFile)
 
 	// ========================================================================
 	// Step 5: Check write permission at share level

--- a/internal/adapter/smb/handlers/write.go
+++ b/internal/adapter/smb/handlers/write.go
@@ -280,12 +280,10 @@ func (h *Handler) Write(ctx *SMBHandlerContext, req *WriteRequest) (*WriteRespon
 		logger.Debug("WRITE: invalid session ID", "sessionID", openFile.SessionID)
 		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusUserSessionDeleted}}, nil
 	}
-	// Priming refuses a handle that does not belong to this request's
-	// TreeConnect/Session (MS-SMB2 §3.3.5.2.5). The smb2.tcon torture test
-	// exercises this by deliberately mis-setting the wire-level TID/SID and
-	// expecting an error (Samba returns FILE_CLOSED).
-	if st := h.primeAuthContextFromOpenFile(ctx, openFile); st != types.StatusSuccess {
-		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: st}}, nil
+	// Priming also refuses a handle that does not belong to this request's
+	// TreeConnect/Session (MS-SMB2 §3.3.5.2.5).
+	if status := h.primeAuthContextFromOpenFile(ctx, openFile); status != types.StatusSuccess {
+		return &WriteResponse{SMBResponseBase: SMBResponseBase{Status: status}}, nil
 	}
 
 	// ========================================================================


### PR DESCRIPTION
## What was wrong

SMB2 opens live in one process-wide map keyed by the 16-byte FileId, and
`Handler.GetOpenFile` (`handlers/handler.go:1128`) takes no session argument —
it answers "does this handle exist", never "may this requester use it".

That would be a stray read on its own. What makes it an identity problem is
what the handlers do next. `primeAuthContextFromOpenFile` adopts the located
handle's `SessionID` and `TreeID`, and from its tree the `ShareName` and
`Permission`; `BuildAuthContext` then derives the caller's credentials from
that session. So a request naming another session's FileId did not merely
reach that handle — it executed **as that handle's user, against that handle's
share, with that handle's tree permission**.

The priming itself is correct and deliberate (#619 added it so `ctx.User == nil`
would not fall into the anonymous arm and synthesise UID 0). The gap was that
it adopted the identity without first checking the handle belonged to the
requester. Of the 16 sites that prime, 2 checked first (READ, WRITE); 14 did not.

Direct sibling of #2413 / #2424, which bound a client-supplied **TreeID** to
its session at the dispatch choke point. This is the same missing binding for
a client-supplied **FileId**.

## Severity — defence in depth, not a live remote hole

`GenerateFileID` (`handler.go:2178`) builds the FileId as an 8-byte monotonic
counter plus 8 bytes from `crypto/rand`. The volatile half is 64 bits of real
entropy, so **forging another session's FileId over the wire is not feasible**,
and this is not remotely exploitable by guessing. It matters where a FileId is
obtained rather than guessed, and it removes the only thing standing between a
future FileId-minting regression and cross-session identity assumption. Same
posture as #2395's stateid binding: worth having on its own terms.

## The fix

One guard, inside the priming helper that all 16 sites already funnel through,
rather than 14 separate edits. `primeAuthContextFromOpenFile` now returns a
`types.Status` and refuses without touching `ctx` when the handle was not
opened on the request's tree and session; every call site surfaces that status.
The comparison itself lives in one predicate, `openFileBelongsToRequest`.

**Refusal status: `STATUS_FILE_CLOSED`.** It is what these handlers already
return for a FileId that does not exist, so a handle belonging to someone else
stays indistinguishable from a closed one, which leaks least. It is also what
READ and WRITE already returned from their hand-rolled checks, and what Samba
returns for the smbtorture `smb2.tcon` case that mis-sets the wire TID/SID.
CHANGE_NOTIFY deliberately keeps its existing `STATUS_INVALID_HANDLE` — it does
not prime, so it only borrows the predicate, and changing its status would be
an unrelated observable change.

Three hand-rolled copies of the comparison are retired in favour of the shared
predicate: `read.go`, `write.go`, and CHANGE_NOTIFY in `stub_handlers.go`.

## Two corrections to the issue text

**1. There were three hand-rolled copies, not two.** The issue says only
`read.go` and `write.go` hand-roll the check. True of the *priming* sites, but
`stub_handlers.go` (CHANGE_NOTIFY) carries a third instance of the identical
compare. It does not prime, so it was never one of the 14 — but consolidating
the rule had to retire three copies.

**2. COPYCHUNK's check was weaker than "destination only".**
`ioctl_copychunk.go` compared `srcOpen.SessionID != dstOpen.SessionID` — the
two handles to *each other*, never to the requester. A caller supplying two
foreign FileIds that both belong to one other session satisfied it completely.
Both are now anchored to `ctx.SessionID`.

## One deliberate asymmetry, now pinned by a test

COPYCHUNK's **source** is checked on `SessionID` alone, not the full
tree+session predicate. The source arrives as an opaque resume key rather than
a TreeID, and MS-SMB2 3.3.5.15.6 scopes it to the requester's session, not to
one tree connect — a server-side copy reading from another share the same
session holds is legitimate. Tightening it to the two-field predicate would
break that, so `TestHandleOwnership_CopyChunkCrossTreeSourceAllowed` fails if
anyone does.

The destination is this IOCTL's own handle and gets the full tree+session check
when it primes.

## Why the guard compares TreeID as well as SessionID

`SessionID` is the axis that carries privilege, so it was worth establishing
that the `TreeID` half is safe rather than copying it from `read.go`:

- `SMBHandlerContext` has exactly one production construction site
  (`response.go:407`), which always populates both fields from the request
  header.
- Compound related operations resolve the `0xFF..` sentinel (and zero) to the
  previous command's values before dispatch (`compound.go:877-886`), so a
  chained op never arrives with a zero TreeID.
- Durable-handle reconnect rewrites **both** fields onto the reconnecting
  session (`create.go:848-849`), so a reconnected handle is not stale.
- Decisively: READ and WRITE — the two highest-traffic handle commands — have
  enforced this exact two-field compare in production all along. If `ctx.TreeID`
  were unreliable at priming time, they would already be broken for every client.

The "stale or zero TreeID" caveat in the priming helper's own doc comment is a
hypothetical the dispatcher no longer permits.

## Checked for legitimate cross-boundary priming (none found)

A guard here is only correct if nothing legitimately primes from a handle it
does not own. Each of these is structurally clean, not merely unobserved:

- **Durable/persistent reconnect** — `create.go:848-849` and
  `durable_context.go:820` assign the *reconnecting* session's IDs; the
  persisted record carries no session identity of its own.
- **Blocking LOCK resume** — `resumePendingLock` takes no `*SMBHandlerContext`
  in its signature (`lock_async.go:178`), so priming is unreachable from the
  resume goroutine; it rebuilds auth from an identity snapshot instead.
- **Teardown reapers** (LOGOFF, TREE_DISCONNECT, disconnect, previous-session
  cleanup) — `closeFilesWithFilter` takes a plain `context.Context` and uses
  `buildCleanupAuthContext`; it never primes. These do legitimately touch
  handles the current ctx does not own, which is exactly why they bypass this
  path.
- **SMB3 multichannel** — one session spans connections but keeps one
  `SessionID`, so a session-scoped compare is the right axis.
- `convertToRealSymlink` and `convertOpenFileToNativeSymlink` each have exactly
  one caller. Their redundant re-prime of the same handle is removed; the
  SET_REPARSE_POINT prime moves up into the handler so the refusal reports a
  status directly instead of being mapped from an error.

## An adjacent class this does NOT fix — bears on the #2420 docs rule

Sweeping all 27 `GetOpenFile` call sites turned up ten that resolve a handle and
act on it **without** adopting its identity. They were never among the 14,
because #2449 is scoped to identity adoption — but they are the same
unowned-handle class by a different mechanism, and they matter because the Wave
1 ownership rule going into `docs/internals/architecture.md` would have them as
counterexamples if it is phrased as "handlers verify handle ownership":

`handlePipeTransceive` (`stub_handlers.go:1226`) · `handleOplockBreakAck`
(`:972`) · `handleGetNtfsVolumeData` (`:1032`) · `handleReadFileUsnData`
(`:1092`) · `handleSrvRequestResumeKey` (`ioctl_copychunk.go:97`) ·
`handleGetCompression` (`ioctl_fsctl.go:23`) · `buildObjectIDResponse` (`:168`) ·
`handleMarkHandle` (`:203`) · `handleQueryFileRegions` (`:227`), plus a second
lookup inside `ChangeNotify` (`stub_handlers.go:657`) that sits *after* that
function's own predicate check and is therefore fine.

Two are worth separating out rather than lumping:

- **`handlePipeTransceive` does real I/O on an unowned handle.** It checks
  `IsPipe` and the pipe registry, never the requester. This is the sharpest of
  the ten.
- **`handleOplockBreakAck` is already partly self-guarding downstream.** It does
  not check the handle, but it passes `ctx.SessionID` into
  `AcknowledgeLeaseBreak`, so the lease layer gets the requester's real session
  rather than the handle's.

`handleSrvRequestResumeKey` is now bounded by this PR even though it is
unguarded: it will still mint a resume key for a foreign handle, but COPYCHUNK
refuses a source outside the requester's session, so the key is no longer
usable.

Each of the ten needs its own spec read and status choice, so they are a
follow-up rather than scope creep here — and they now have
`openFileBelongsToRequest` ready to use.

## Verification

`go build ./...`, `go vet ./...`, `gofmt`, the full `go test ./...`, and
`go test -race ./internal/adapter/smb/...` are green.

New `handle_ownership_test.go` drives a second session against the first's
FileId across nine commands — CLOSE, FLUSH, SET_INFO, and the
SET_SPARSE / QUERY_ALLOCATED_RANGES / SET_ZERO_DATA / SET_COMPRESSION /
GET_REPARSE_POINT IOCTLs — plus COPYCHUNK's two-foreign-handles case, each with
the owning session as a positive control.

Both arms were confirmed to be real coverage with `go test -overlay`, since a
test that passes with and without the guard is not coverage:

- Neutralising the guard (`if false`) and restoring COPYCHUNK's original
  src-vs-dst compare: **every refusal subtest fails**, all nine plus copychunk.
- Over-tightening COPYCHUNK's source to the two-field predicate:
  `CopyChunkCrossTreeSourceAllowed` **fails**, so it is not a no-op either.

Six pre-existing Close/Flush fixtures needed pairing rather than weakening.
Three left `OpenFile.SessionID` zero while their ctx carried a session; the two
auth-priming fixtures built a ctx with zero session/tree on the stated premise
that the dispatcher "arrives keyed only by FileID". That premise is false —
`response.go:407` populates both from the header, and CREATE stamps
`ctx.SessionID` onto every `OpenFile` it registers, so no real request has ever
had the shape those fixtures described. `bareCtx` stays unpaired: it is
deliberately never primed.

Closes #2449
