### PR TITLE
ci: stop a lost diagnostics artifact from failing a passing suite

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -214,6 +214,10 @@ jobs:
 
       - name: Upload results
         if: always()
+        # A lost diagnostics zip must not invert a verdict the suite has already
+        # produced: the run step above decides pass or fail, this upload only
+        # preserves the evidence.
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: wpts-${{ matrix.profile }}
@@ -255,6 +259,10 @@ jobs:
 
       - name: Upload results
         if: always()
+        # A lost diagnostics zip must not invert a verdict the suite has already
+        # produced: the run step above decides pass or fail, this upload only
+        # preserves the evidence.
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: smbtorture-${{ matrix.profile }}
@@ -384,6 +392,10 @@ jobs:
 
       - name: Upload results
         if: always()
+        # A lost diagnostics zip must not invert a verdict the suite has already
+        # produced: the run step above decides pass or fail, this upload only
+        # preserves the evidence.
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: pjdfstest-v${{ matrix.variant }}-${{ matrix.profile }}
@@ -450,6 +462,10 @@ jobs:
 
       - name: Upload results
         if: always()
+        # A lost diagnostics zip must not invert a verdict the suite has already
+        # produced: the run step above decides pass or fail, this upload only
+        # preserves the evidence.
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: nfs-kerberos-results
@@ -508,6 +524,10 @@ jobs:
 
       - name: Upload results
         if: always()
+        # A lost diagnostics zip must not invert a verdict the suite has already
+        # produced: the run step above decides pass or fail, this upload only
+        # preserves the evidence.
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: smbtorture-kerberos

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -184,6 +184,10 @@ jobs:
 
       - name: Upload logs
         if: always()
+        # A lost diagnostics zip must not invert a verdict the suite has already
+        # produced: the run step above decides pass or fail, this upload only
+        # preserves the evidence.
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: e2e-logs

--- a/.github/workflows/nfs-pynfs.yml
+++ b/.github/workflows/nfs-pynfs.yml
@@ -252,6 +252,10 @@ jobs:
 
       - name: Upload results
         if: always()
+        # A lost diagnostics zip must not invert a verdict the suite has already
+        # produced: the run step above decides pass or fail, this upload only
+        # preserves the evidence.
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: pynfs-v${{ matrix.variant }}-${{ matrix.profile }}-results
@@ -287,6 +291,10 @@ jobs:
 
       - name: Upload baseline
         if: always()
+        # A lost diagnostics zip must not invert a verdict the suite has already
+        # produced: the run step above decides pass or fail, this upload only
+        # preserves the evidence.
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: pynfs-knfsd-baseline


### PR DESCRIPTION
Closes #2462.

Three PRs today reported red conformance or e2e cells with zero test failures. In each case the suite passed and the job then died uploading its diagnostics artifact:

```
##[error]Failed to FinalizeArtifact: Received non-retryable error: Failed request: (403) Forbidden: Error from intermediary with HTTP status code 403 "Forbidden"
```

On #2457, `WPTS BVT / memory` printed `New failures: 0`, `RESULT: All failures are known. CI green.` and `[CONFORMANCE] wpts / memory: pass` immediately before that line. On #2461, `NFS v4 / memory` ran pjdfstest successfully at step 13 and failed at step 15 "Upload results", while `NFS v4 / postgres-s3` passed on identical code.

**One lost zip produced two red cells.** `conformance.yml`'s `summary` job decides from `needs.*.result`, not from any artifact, so a failed upload marks the suite job `failure` and `Conformance summary` then fails because a needed job failed.

## What changed

`continue-on-error: true` on the eight post-verdict `if: always()` uploads — wpts, smbtorture, pjdfstest, nfs-kerberos and smbtorture-kerberos results in `conformance.yml`; pynfs results and the knfsd baseline in `nfs-pynfs.yml`; e2e logs in `e2e-tests.yml`. The step still shows as failed in the UI, so a genuine upload problem stays visible; it just no longer inverts a verdict the run step already produced.

**`Upload binaries` stays fatal.** That artifact gates: later jobs download `dfs-binaries`, and #2447 already retries the download side after the same class of blip.

`actions/upload-artifact` classifies a 403 as non-retryable and exposes no retry knob, so an external retry would mean a new action dependency or hand-rolled tar + curl. This is one line per step and no dependency.