### PR TITLE
fix(nfs): check the stateid belongs to the caller in CLOSE, LOCK, LOCKU, OPEN_DOWNGRADE, OPEN_CONFIRM and TEST_STATEID

### DIFF
--- a/internal/adapter/nfs/v4/handlers/client_principal_test.go
+++ b/internal/adapter/nfs/v4/handlers/client_principal_test.go
@@ -70,7 +70,7 @@ func TestOpen_ClientIDSpansPrincipals(t *testing.T) {
 	setCurrentFH(victim, fx.rootHandle)
 	victimStateid := openStateid(t, fx, victim, 1, clientID, owner, "victim.txt",
 		types.OPEN4_CREATE, types.OPEN4_SHARE_ACCESS_BOTH)
-	if _, err := sm.ConfirmOpen(&victimStateid, 2); err != nil {
+	if _, err := sm.ConfirmOpen(&victimStateid, 2, 0); err != nil {
 		t.Fatalf("ConfirmOpen: %v", err)
 	}
 
@@ -131,7 +131,7 @@ func TestRenew_PrincipalBinding(t *testing.T) {
 		setCurrentFH(user, fx.rootHandle)
 		stateid := openStateid(t, fx, user, 1, clientID, []byte("open-owner-1000"), "u1000.txt",
 			types.OPEN4_CREATE, types.OPEN4_SHARE_ACCESS_BOTH)
-		if _, err := sm.ConfirmOpen(&stateid, 2); err != nil {
+		if _, err := sm.ConfirmOpen(&stateid, 2, 0); err != nil {
 			t.Fatalf("ConfirmOpen: %v", err)
 		}
 

--- a/internal/adapter/nfs/v4/handlers/close.go
+++ b/internal/adapter/nfs/v4/handlers/close.go
@@ -64,7 +64,7 @@ func (h *Handler) handleClose(ctx *types.CompoundContext, reader io.Reader) *typ
 		"client", ctx.ClientAddr)
 
 	// Delegate to StateManager for state cleanup
-	closeResult, stateErr := h.StateManager.CloseFile(stateid, closeSeqid)
+	closeResult, stateErr := h.StateManager.CloseFile(stateid, closeSeqid, ctx.SessionClientID)
 	if stateErr != nil {
 		if replay := asReplay(types.OP_CLOSE, stateErr); replay != nil {
 			return replay

--- a/internal/adapter/nfs/v4/handlers/lock.go
+++ b/internal/adapter/nfs/v4/handlers/lock.go
@@ -157,6 +157,7 @@ func (h *Handler) handleLock(ctx *types.CompoundContext, reader io.Reader) *type
 			lockOwnerClientID, lockOwnerData, lockSeqid,
 			openStateid, openSeqid,
 			ctx.CurrentFH, lockType, offset, length, reclaim,
+			ctx.SessionClientID,
 		)
 	} else {
 		// exist_lock_owner4 path
@@ -195,6 +196,7 @@ func (h *Handler) handleLock(ctx *types.CompoundContext, reader io.Reader) *type
 			ctx.Context,
 			lockStateid, lockSeqid,
 			ctx.CurrentFH, lockType, offset, length, reclaim,
+			ctx.SessionClientID,
 		)
 	}
 
@@ -471,6 +473,7 @@ func (h *Handler) handleLockU(ctx *types.CompoundContext, reader io.Reader) *typ
 	// Delegate to StateManager
 	unlockResult, stateErr := h.StateManager.UnlockFile(
 		lockStateid, seqid, lockType, offset, length,
+		ctx.SessionClientID,
 	)
 	if stateErr != nil {
 		if replay := asReplay(types.OP_LOCKU, stateErr); replay != nil {

--- a/internal/adapter/nfs/v4/handlers/lock_test.go
+++ b/internal/adapter/nfs/v4/handlers/lock_test.go
@@ -212,7 +212,7 @@ func setupHandlerLockClient(t *testing.T, h *Handler, fileHandle []byte) (client
 
 	// OPEN_CONFIRM
 	confirmOpenSeqid := openSeqid + 1
-	confirmRes, err := h.StateManager.ConfirmOpen(&openResult.Stateid, confirmOpenSeqid)
+	confirmRes, err := h.StateManager.ConfirmOpen(&openResult.Stateid, confirmOpenSeqid, 0)
 	if err != nil {
 		t.Fatalf("ConfirmOpen failed: %v", err)
 	}

--- a/internal/adapter/nfs/v4/handlers/open.go
+++ b/internal/adapter/nfs/v4/handlers/open.go
@@ -546,7 +546,7 @@ func (h *Handler) handleOpenClaimNull(
 		openResult.RFlags &^= types.OPEN4_RESULT_CONFIRM
 		// Auto-confirm the owner so subsequent OPENs don't require confirmation.
 		// Use ConfirmOpenV41 which does NOT increment seqid (must stay at 1).
-		_ = h.StateManager.ConfirmOpenV41(&openResult.Stateid)
+		_ = h.StateManager.ConfirmOpenV41(&openResult.Stateid, ctx.SessionClientID)
 	}
 
 	// Try to grant a delegation
@@ -644,7 +644,7 @@ func (h *Handler) handleOpenClaimFH(
 	// session, so strip OPEN4_RESULT_CONFIRM and auto-confirm.
 	if ctx.SkipOwnerSeqid && openResult.RFlags&types.OPEN4_RESULT_CONFIRM != 0 {
 		openResult.RFlags &^= types.OPEN4_RESULT_CONFIRM
-		_ = h.StateManager.ConfirmOpenV41(&openResult.Stateid)
+		_ = h.StateManager.ConfirmOpenV41(&openResult.Stateid, ctx.SessionClientID)
 	}
 
 	delegType, shouldGrant := h.StateManager.ShouldGrantDelegation(clientID, []byte(fileHandle), shareAccess)
@@ -727,7 +727,7 @@ func (h *Handler) handleOpenClaimPrevious(
 	// In NFSv4.1, OPEN_CONFIRM was removed; auto-confirm if needed.
 	if ctx.SkipOwnerSeqid && openResult.RFlags&types.OPEN4_RESULT_CONFIRM != 0 {
 		openResult.RFlags &^= types.OPEN4_RESULT_CONFIRM
-		_ = h.StateManager.ConfirmOpenV41(&openResult.Stateid)
+		_ = h.StateManager.ConfirmOpenV41(&openResult.Stateid, ctx.SessionClientID)
 	}
 
 	logger.Debug("NFSv4 OPEN CLAIM_PREVIOUS successful",
@@ -813,7 +813,7 @@ func (h *Handler) handleOpenConfirm(ctx *types.CompoundContext, reader io.Reader
 		"client", ctx.ClientAddr)
 
 	// Delegate to StateManager
-	confirmResult, stateErr := h.StateManager.ConfirmOpen(stateid, confirmSeqid)
+	confirmResult, stateErr := h.StateManager.ConfirmOpen(stateid, confirmSeqid, ctx.SessionClientID)
 	if stateErr != nil {
 		if replay := asReplay(types.OP_OPEN_CONFIRM, stateErr); replay != nil {
 			return replay
@@ -990,7 +990,7 @@ func (h *Handler) handleOpenClaimDelegateCur(
 	// In NFSv4.1, OPEN_CONFIRM was removed; auto-confirm if needed.
 	if ctx.SkipOwnerSeqid && openResult.RFlags&types.OPEN4_RESULT_CONFIRM != 0 {
 		openResult.RFlags &^= types.OPEN4_RESULT_CONFIRM
-		_ = h.StateManager.ConfirmOpenV41(&openResult.Stateid)
+		_ = h.StateManager.ConfirmOpenV41(&openResult.Stateid, ctx.SessionClientID)
 	}
 
 	logger.Debug("NFSv4 OPEN CLAIM_DELEGATE_CUR successful",

--- a/internal/adapter/nfs/v4/handlers/stubs.go
+++ b/internal/adapter/nfs/v4/handlers/stubs.go
@@ -108,7 +108,7 @@ func (h *Handler) handleOpenDowngrade(ctx *types.CompoundContext, reader io.Read
 
 	// Delegate to StateManager
 	downgradeResult, stateErr := h.StateManager.DowngradeOpen(
-		stateid, downgradeSeqid, newShareAccess, newShareDeny,
+		stateid, downgradeSeqid, newShareAccess, newShareDeny, ctx.SessionClientID,
 	)
 	if stateErr != nil {
 		if replay := asReplay(types.OP_OPEN_DOWNGRADE, stateErr); replay != nil {

--- a/internal/adapter/nfs/v4/state/batch_state_manager_test.go
+++ b/internal/adapter/nfs/v4/state/batch_state_manager_test.go
@@ -28,11 +28,8 @@ func TestLockNew_BadLockSeqidDoesNotLeakState(t *testing.T) {
 	ownerData := []byte("new-owner")
 
 	// Bad lock seqid for a brand-new lock-owner: only nextSeqID(0)==1 is valid.
-	_, err := sm.LockNew(context.Background(),
-		clientID, ownerData, 99,
-		openStateid, openSeqid+1,
-		fileHandle, types.WRITE_LT, 0, 100, false,
-	)
+	_, err := sm.LockNew(context.Background(), clientID, ownerData, 99, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
+
 	if err == nil {
 		t.Fatal("expected ErrBadSeqid for bad lock seqid on brand-new owner")
 	}
@@ -63,11 +60,7 @@ func TestLockNew_BadLockSeqidDoesNotLeakLockState(t *testing.T) {
 	ownerData := []byte("new-owner")
 
 	// Bad seqid rejection.
-	if _, err := sm.LockNew(context.Background(),
-		clientID, ownerData, 99,
-		openStateid, openSeqid+1,
-		fileHandle, types.WRITE_LT, 0, 100, false,
-	); err == nil {
+	if _, err := sm.LockNew(context.Background(), clientID, ownerData, 99, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, 0); err == nil {
 		t.Fatal("expected ErrBadSeqid for bad lock seqid")
 	}
 
@@ -76,11 +69,8 @@ func TestLockNew_BadLockSeqidDoesNotLeakLockState(t *testing.T) {
 	}
 
 	// A valid follow-up LOCK (seqid=1) must now succeed cleanly.
-	res, err := sm.LockNew(context.Background(),
-		clientID, ownerData, 1,
-		openStateid, openSeqid+1,
-		fileHandle, types.WRITE_LT, 0, 100, false,
-	)
+	res, err := sm.LockNew(context.Background(), clientID, ownerData, 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
+
 	if err != nil {
 		t.Fatalf("valid LockNew after rejection failed: %v", err)
 	}
@@ -180,7 +170,7 @@ func setupClientAndOpenStateForClient(t *testing.T, sm *StateManager, clientName
 	}
 
 	confirmSeqid := openSeqid + 1
-	confirmRes, err := sm.ConfirmOpen(&openResult.Stateid, confirmSeqid)
+	confirmRes, err := sm.ConfirmOpen(&openResult.Stateid, confirmSeqid, 0)
 	if err != nil {
 		t.Fatalf("ConfirmOpen(%s) failed: %v", clientName, err)
 	}
@@ -205,20 +195,13 @@ func TestAcquireLock_DeniedOwnerDataIsDecodedBytes(t *testing.T) {
 
 	// Client A acquires an exclusive lock on [0, 100).
 	ownerA := []byte("owner-a")
-	if _, err := sm.LockNew(context.Background(),
-		clientA, ownerA, 1,
-		stateidA, seqA+1,
-		fh, types.WRITE_LT, 0, 100, false,
-	); err != nil {
+	if _, err := sm.LockNew(context.Background(), clientA, ownerA, 1, stateidA, seqA+1, fh, types.WRITE_LT, 0, 100, false, 0); err != nil {
 		t.Fatalf("LockNew for A failed: %v", err)
 	}
 
 	// Client B requests an overlapping exclusive lock -> DENIED.
-	resB, err := sm.LockNew(context.Background(),
-		clientB, []byte("owner-b"), 1,
-		stateidB, seqB+1,
-		fh, types.WRITE_LT, 0, 100, false,
-	)
+	resB, err := sm.LockNew(context.Background(), clientB, []byte("owner-b"), 1, stateidB, seqB+1, fh, types.WRITE_LT, 0, 100, false, 0)
+
 	if err != nil {
 		t.Fatalf("LockNew for B error: %v", err)
 	}

--- a/internal/adapter/nfs/v4/state/batch_state_manager_test.go
+++ b/internal/adapter/nfs/v4/state/batch_state_manager_test.go
@@ -29,7 +29,6 @@ func TestLockNew_BadLockSeqidDoesNotLeakState(t *testing.T) {
 
 	// Bad lock seqid for a brand-new lock-owner: only nextSeqID(0)==1 is valid.
 	_, err := sm.LockNew(context.Background(), clientID, ownerData, 99, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
-
 	if err == nil {
 		t.Fatal("expected ErrBadSeqid for bad lock seqid on brand-new owner")
 	}
@@ -70,7 +69,6 @@ func TestLockNew_BadLockSeqidDoesNotLeakLockState(t *testing.T) {
 
 	// A valid follow-up LOCK (seqid=1) must now succeed cleanly.
 	res, err := sm.LockNew(context.Background(), clientID, ownerData, 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
-
 	if err != nil {
 		t.Fatalf("valid LockNew after rejection failed: %v", err)
 	}
@@ -201,7 +199,6 @@ func TestAcquireLock_DeniedOwnerDataIsDecodedBytes(t *testing.T) {
 
 	// Client B requests an overlapping exclusive lock -> DENIED.
 	resB, err := sm.LockNew(context.Background(), clientB, []byte("owner-b"), 1, stateidB, seqB+1, fh, types.WRITE_LT, 0, 100, false, 0)
-
 	if err != nil {
 		t.Fatalf("LockNew for B error: %v", err)
 	}

--- a/internal/adapter/nfs/v4/state/clientid_validation_test.go
+++ b/internal/adapter/nfs/v4/state/clientid_validation_test.go
@@ -50,7 +50,7 @@ func TestConfirmClientID_RebootReleasesPreviousIncarnationState(t *testing.T) {
 		t.Fatalf("ConfirmClientID after reboot: %v", err)
 	}
 
-	if _, err := sm.CloseFile(&stale, 2); !errors.Is(err, ErrExpired) {
+	if _, err := sm.CloseFile(&stale, 2, 0); !errors.Is(err, ErrExpired) {
 		t.Errorf("CLOSE with the pre-reboot stateid: got %v, want ErrExpired", err)
 	}
 
@@ -135,8 +135,7 @@ func TestSetClientID_LockOnlyStateStillBlocksAnotherPrincipal(t *testing.T) {
 	if err := sm.ConfirmClientID(locker.ClientID, locker.ConfirmVerifier); err != nil {
 		t.Fatalf("ConfirmClientID(locker): %v", err)
 	}
-	if _, err := sm.LockNew(context.Background(), locker.ClientID, []byte("lock-owner"), 1,
-		&open.Stateid, 2, fh, types.WRITE_LT, 0, 100, false); err != nil {
+	if _, err := sm.LockNew(context.Background(), locker.ClientID, []byte("lock-owner"), 1, &open.Stateid, 2, fh, types.WRITE_LT, 0, 100, false, 0); err != nil {
 		t.Fatalf("LockNew: %v", err)
 	}
 

--- a/internal/adapter/nfs/v4/state/close_seqid_test.go
+++ b/internal/adapter/nfs/v4/state/close_seqid_test.go
@@ -46,7 +46,6 @@ func TestCloseFile_LocksHeldStillAdvancesSeqid(t *testing.T) {
 	lockSeqid := uint32(1)
 	openSeqid++
 	lockRes, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner"), lockSeqid, openStateid, openSeqid, fileHandle, types.WRITE_LT, 0, 100, false, 0)
-
 	if err != nil {
 		t.Fatalf("LockNew failed: %v", err)
 	}
@@ -117,7 +116,6 @@ func TestUnlockFile_BadStateidLeavesLockOwnerSeqidUntouched(t *testing.T) {
 
 	lockSeqid := uint32(1)
 	lockRes, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner"), lockSeqid, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
-
 	if err != nil {
 		t.Fatalf("LockNew failed: %v", err)
 	}

--- a/internal/adapter/nfs/v4/state/close_seqid_test.go
+++ b/internal/adapter/nfs/v4/state/close_seqid_test.go
@@ -45,11 +45,8 @@ func TestCloseFile_LocksHeldStillAdvancesSeqid(t *testing.T) {
 	// Take a byte-range lock so the CLOSE below has something to trip over.
 	lockSeqid := uint32(1)
 	openSeqid++
-	lockRes, err := sm.LockNew(context.Background(),
-		clientID, []byte("lock-owner"), lockSeqid,
-		openStateid, openSeqid,
-		fileHandle, types.WRITE_LT, 0, 100, false,
-	)
+	lockRes, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner"), lockSeqid, openStateid, openSeqid, fileHandle, types.WRITE_LT, 0, 100, false, 0)
+
 	if err != nil {
 		t.Fatalf("LockNew failed: %v", err)
 	}
@@ -57,21 +54,21 @@ func TestCloseFile_LocksHeldStillAdvancesSeqid(t *testing.T) {
 	// CLOSE with locks outstanding: expected to fail, and expected to consume
 	// its seqid on the way out.
 	openSeqid++
-	_, err = sm.CloseFile(openStateid, openSeqid)
+	_, err = sm.CloseFile(openStateid, openSeqid, 0)
 	var stateErr *NFS4StateError
 	if !errors.As(err, &stateErr) || stateErr.Status != types.NFS4ERR_LOCKS_HELD {
 		t.Fatalf("CLOSE with locks held: got %v, want NFS4ERR_LOCKS_HELD", err)
 	}
 
 	// Release the lock, as a client does on being told LOCKS_HELD.
-	if _, err := sm.UnlockFile(&lockRes.Stateid, lockSeqid+1, types.WRITE_LT, 0, 100); err != nil {
+	if _, err := sm.UnlockFile(&lockRes.Stateid, lockSeqid+1, types.WRITE_LT, 0, 100, 0); err != nil {
 		t.Fatalf("UnlockFile failed: %v", err)
 	}
 
 	// The retry carries the next seqid. It must be accepted: the server owes
 	// the client agreement about where the sequence got to.
 	openSeqid++
-	if _, err := sm.CloseFile(openStateid, openSeqid); err != nil {
+	if _, err := sm.CloseFile(openStateid, openSeqid, 0); err != nil {
 		if errors.Is(err, ErrBadSeqid) {
 			t.Fatalf("CLOSE after LOCKS_HELD rejected with NFS4ERR_BAD_SEQID: "+
 				"the failed CLOSE did not advance the open-owner seqid, so the "+
@@ -97,12 +94,12 @@ func TestCloseFile_BadSeqidLeavesOwnerSeqidUntouched(t *testing.T) {
 
 	// A seqid the owner never reached: neither the expected next one nor a
 	// replay of the last.
-	if _, err := sm.CloseFile(openStateid, openSeqid+7); !errors.Is(err, ErrBadSeqid) {
+	if _, err := sm.CloseFile(openStateid, openSeqid+7, 0); !errors.Is(err, ErrBadSeqid) {
 		t.Fatalf("CLOSE at an out-of-sequence seqid: got %v, want NFS4ERR_BAD_SEQID", err)
 	}
 
 	// The client is still at the seqid it was, and so must the server be.
-	if _, err := sm.CloseFile(openStateid, openSeqid+1); err != nil {
+	if _, err := sm.CloseFile(openStateid, openSeqid+1, 0); err != nil {
 		t.Fatalf("CLOSE at the expected seqid after a rejected one failed: %v "+
 			"(the rejected request advanced the open-owner seqid; it must not)", err)
 	}
@@ -119,24 +116,21 @@ func TestUnlockFile_BadStateidLeavesLockOwnerSeqidUntouched(t *testing.T) {
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
 	lockSeqid := uint32(1)
-	lockRes, err := sm.LockNew(context.Background(),
-		clientID, []byte("lock-owner"), lockSeqid,
-		openStateid, openSeqid+1,
-		fileHandle, types.WRITE_LT, 0, 100, false,
-	)
+	lockRes, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner"), lockSeqid, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
+
 	if err != nil {
 		t.Fatalf("LockNew failed: %v", err)
 	}
 
 	ahead := lockRes.Stateid
 	ahead.Seqid = nextSeqID(ahead.Seqid)
-	if _, err := sm.UnlockFile(&ahead, lockSeqid+1, types.WRITE_LT, 0, 100); !errors.Is(err, ErrBadStateid) {
+	if _, err := sm.UnlockFile(&ahead, lockSeqid+1, types.WRITE_LT, 0, 100, 0); !errors.Is(err, ErrBadStateid) {
 		t.Fatalf("LOCKU with a stateid ahead of the server's: got %v, want NFS4ERR_BAD_STATEID", err)
 	}
 
 	// The retry carries the right stateid at the same lock-owner seqid, which
 	// the server must still be expecting.
-	if _, err := sm.UnlockFile(&lockRes.Stateid, lockSeqid+1, types.WRITE_LT, 0, 100); err != nil {
+	if _, err := sm.UnlockFile(&lockRes.Stateid, lockSeqid+1, types.WRITE_LT, 0, 100, 0); err != nil {
 		t.Fatalf("LOCKU retried after NFS4ERR_BAD_STATEID failed: %v "+
 			"(the rejected request advanced the lock-owner seqid; it must not)", err)
 	}
@@ -152,8 +146,7 @@ func TestDowngradeOpen_ReplayLeavesOwnerSeqidUntouched(t *testing.T) {
 	clientID, _, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
 	seqid := openSeqid + 1
-	if _, err := sm.DowngradeOpen(openStateid, seqid,
-		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE); err != nil {
+	if _, err := sm.DowngradeOpen(openStateid, seqid, types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, 0); err != nil {
 		t.Fatalf("OPEN_DOWNGRADE failed: %v", err)
 	}
 
@@ -163,8 +156,8 @@ func TestDowngradeOpen_ReplayLeavesOwnerSeqidUntouched(t *testing.T) {
 
 	// Every retransmit gets that reply back, not just the first.
 	for i := range 2 {
-		_, err := sm.DowngradeOpen(openStateid, seqid,
-			types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE)
+		_, err := sm.DowngradeOpen(openStateid, seqid, types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, 0)
+
 		var replayErr *ReplayError
 		if !errors.As(err, &replayErr) {
 			t.Fatalf("retransmit %d of OPEN_DOWNGRADE: got %v, want a replay", i+1, err)
@@ -177,8 +170,7 @@ func TestDowngradeOpen_ReplayLeavesOwnerSeqidUntouched(t *testing.T) {
 	}
 
 	// The sequence is still where the successful OPEN_DOWNGRADE left it.
-	if _, err := sm.DowngradeOpen(openStateid, seqid+1,
-		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE); err != nil {
+	if _, err := sm.DowngradeOpen(openStateid, seqid+1, types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, 0); err != nil {
 		t.Fatalf("OPEN_DOWNGRADE after replays failed: %v "+
 			"(a replay advanced the open-owner seqid; it must not)", err)
 	}

--- a/internal/adapter/nfs/v4/state/courtesy_test.go
+++ b/internal/adapter/nfs/v4/state/courtesy_test.go
@@ -127,8 +127,7 @@ func TestLock_ConflictExpiresLapsedByteRangeLock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("holder OpenFile: %v", err)
 	}
-	if _, err := sm.LockNew(context.Background(), holder, []byte("holder-lock-owner"), 0,
-		&holderOpen.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false); err != nil {
+	if _, err := sm.LockNew(context.Background(), holder, []byte("holder-lock-owner"), 0, &holderOpen.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false, 0); err != nil {
 		t.Fatalf("holder LockNew: %v", err)
 	}
 
@@ -140,8 +139,8 @@ func TestLock_ConflictExpiresLapsedByteRangeLock(t *testing.T) {
 	}
 
 	// While the lease is live the lock is enforced.
-	res, err := sm.LockNew(context.Background(), newcomer, []byte("newcomer-lock-owner"), 0,
-		&newcomerOpen.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false)
+	res, err := sm.LockNew(context.Background(), newcomer, []byte("newcomer-lock-owner"), 0, &newcomerOpen.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false, 0)
+
 	if err != nil {
 		t.Fatalf("newcomer LockNew against a live lock: %v", err)
 	}
@@ -151,8 +150,8 @@ func TestLock_ConflictExpiresLapsedByteRangeLock(t *testing.T) {
 
 	waitLeaseLapsed(t, sm, holder)
 
-	res, err = sm.LockNew(context.Background(), newcomer, []byte("newcomer-lock-owner-2"), 0,
-		&newcomerOpen.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false)
+	res, err = sm.LockNew(context.Background(), newcomer, []byte("newcomer-lock-owner-2"), 0, &newcomerOpen.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false, 0)
+
 	if err != nil {
 		t.Fatalf("newcomer LockNew after the holder's lease lapsed: %v", err)
 	}
@@ -202,8 +201,8 @@ func lockAcrossClients(t *testing.T, sm *StateManager, opener, locker uint64, fh
 	if err != nil {
 		t.Fatalf("OpenFile: %v", err)
 	}
-	res, err := sm.LockNew(context.Background(), locker, []byte("lock-owner-"+owner), 0,
-		&open.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false)
+	res, err := sm.LockNew(context.Background(), locker, []byte("lock-owner-"+owner), 0, &open.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false, 0)
+
 	if err != nil {
 		t.Fatalf("LockNew: %v", err)
 	}
@@ -269,8 +268,8 @@ func TestLock_ConflictExpiresLapsedCrossClientLock(t *testing.T) {
 		t.Fatalf("newcomer OpenFile: %v", err)
 	}
 
-	res, err := sm.LockNew(context.Background(), newcomer, []byte("newcomer-lock-owner"), 0,
-		&newcomerOpen.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false)
+	res, err := sm.LockNew(context.Background(), newcomer, []byte("newcomer-lock-owner"), 0, &newcomerOpen.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false, 0)
+
 	if err != nil {
 		t.Fatalf("newcomer LockNew: %v", err)
 	}

--- a/internal/adapter/nfs/v4/state/courtesy_test.go
+++ b/internal/adapter/nfs/v4/state/courtesy_test.go
@@ -140,7 +140,6 @@ func TestLock_ConflictExpiresLapsedByteRangeLock(t *testing.T) {
 
 	// While the lease is live the lock is enforced.
 	res, err := sm.LockNew(context.Background(), newcomer, []byte("newcomer-lock-owner"), 0, &newcomerOpen.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false, 0)
-
 	if err != nil {
 		t.Fatalf("newcomer LockNew against a live lock: %v", err)
 	}
@@ -151,7 +150,6 @@ func TestLock_ConflictExpiresLapsedByteRangeLock(t *testing.T) {
 	waitLeaseLapsed(t, sm, holder)
 
 	res, err = sm.LockNew(context.Background(), newcomer, []byte("newcomer-lock-owner-2"), 0, &newcomerOpen.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false, 0)
-
 	if err != nil {
 		t.Fatalf("newcomer LockNew after the holder's lease lapsed: %v", err)
 	}
@@ -202,7 +200,6 @@ func lockAcrossClients(t *testing.T, sm *StateManager, opener, locker uint64, fh
 		t.Fatalf("OpenFile: %v", err)
 	}
 	res, err := sm.LockNew(context.Background(), locker, []byte("lock-owner-"+owner), 0, &open.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false, 0)
-
 	if err != nil {
 		t.Fatalf("LockNew: %v", err)
 	}
@@ -269,7 +266,6 @@ func TestLock_ConflictExpiresLapsedCrossClientLock(t *testing.T) {
 	}
 
 	res, err := sm.LockNew(context.Background(), newcomer, []byte("newcomer-lock-owner"), 0, &newcomerOpen.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false, 0)
-
 	if err != nil {
 		t.Fatalf("newcomer LockNew: %v", err)
 	}

--- a/internal/adapter/nfs/v4/state/delegation_test.go
+++ b/internal/adapter/nfs/v4/state/delegation_test.go
@@ -1621,11 +1621,8 @@ func TestGrantDelegation_DeniedWhileForeignByteRangeLockHeld(t *testing.T) {
 	}
 
 	// The client, undelegated, sends the LOCK — which the NLM lock denies.
-	res, err := sm.LockNew(context.Background(),
-		clientID, []byte("nfs-owner"), 1,
-		openStateid, openSeqid,
-		fileHandle, types.WRITE_LT, 0, 100, false,
-	)
+	res, err := sm.LockNew(context.Background(), clientID, []byte("nfs-owner"), 1, openStateid, openSeqid, fileHandle, types.WRITE_LT, 0, 100, false, 0)
+
 	if err != nil {
 		t.Fatalf("LockNew returned error: %v", err)
 	}

--- a/internal/adapter/nfs/v4/state/delegation_test.go
+++ b/internal/adapter/nfs/v4/state/delegation_test.go
@@ -1622,7 +1622,6 @@ func TestGrantDelegation_DeniedWhileForeignByteRangeLockHeld(t *testing.T) {
 
 	// The client, undelegated, sends the LOCK — which the NLM lock denies.
 	res, err := sm.LockNew(context.Background(), clientID, []byte("nfs-owner"), 1, openStateid, openSeqid, fileHandle, types.WRITE_LT, 0, 100, false, 0)
-
 	if err != nil {
 		t.Fatalf("LockNew returned error: %v", err)
 	}

--- a/internal/adapter/nfs/v4/state/index_consistency_test.go
+++ b/internal/adapter/nfs/v4/state/index_consistency_test.go
@@ -72,7 +72,7 @@ func TestOpenStateByFile_OpenThenCloseRemovesFromIndex(t *testing.T) {
 	fileIndexMatchesAuthoritative(t, sm)
 
 	// CLOSE advances the owner seqid; open used 1, confirm used 2, close uses 3.
-	if _, err := sm.CloseFile(&stateid, 3); err != nil {
+	if _, err := sm.CloseFile(&stateid, 3, 0); err != nil {
 		t.Fatalf("CloseFile: %v", err)
 	}
 
@@ -98,7 +98,7 @@ func TestOpenStateByFile_MultipleOwnersSameFile(t *testing.T) {
 	fileIndexMatchesAuthoritative(t, sm)
 
 	// Closing one owner leaves the other indexed.
-	if _, err := sm.CloseFile(&sidA, 3); err != nil {
+	if _, err := sm.CloseFile(&sidA, 3, 0); err != nil {
 		t.Fatalf("CloseFile(A): %v", err)
 	}
 	if n := fileIndexLen(sm, fh); n != 1 {

--- a/internal/adapter/nfs/v4/state/lease_expiry_stateid_test.go
+++ b/internal/adapter/nfs/v4/state/lease_expiry_stateid_test.go
@@ -56,7 +56,6 @@ func TestExpiredLease_LockStateidsReportExpired(t *testing.T) {
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
 	lockResult, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner"), 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
-
 	if err != nil {
 		t.Fatalf("LockNew: %v", err)
 	}

--- a/internal/adapter/nfs/v4/state/lease_expiry_stateid_test.go
+++ b/internal/adapter/nfs/v4/state/lease_expiry_stateid_test.go
@@ -35,7 +35,7 @@ func TestExpiredLease_StateidsReportExpired(t *testing.T) {
 		t.Fatalf("ValidateStateid after lease cancellation: got %v, want NFS4ERR_EXPIRED", err)
 	}
 
-	if _, err := sm.CloseFile(openStateid, openSeqid+1); !isStatus(err, types.NFS4ERR_EXPIRED) {
+	if _, err := sm.CloseFile(openStateid, openSeqid+1, 0); !isStatus(err, types.NFS4ERR_EXPIRED) {
 		t.Fatalf("CloseFile after lease cancellation: got %v, want NFS4ERR_EXPIRED", err)
 	}
 
@@ -55,11 +55,8 @@ func TestExpiredLease_LockStateidsReportExpired(t *testing.T) {
 
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
-	lockResult, err := sm.LockNew(context.Background(),
-		clientID, []byte("lock-owner"), 1,
-		openStateid, openSeqid+1,
-		fileHandle, types.WRITE_LT, 0, 100, false,
-	)
+	lockResult, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner"), 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
+
 	if err != nil {
 		t.Fatalf("LockNew: %v", err)
 	}
@@ -70,17 +67,15 @@ func TestExpiredLease_LockStateidsReportExpired(t *testing.T) {
 
 	sm.onLeaseExpired(clientID)
 
-	if _, err := sm.UnlockFile(&lockStateid, 2, types.WRITE_LT, 0, 100); !isStatus(err, types.NFS4ERR_EXPIRED) {
+	if _, err := sm.UnlockFile(&lockStateid, 2, types.WRITE_LT, 0, 100, 0); !isStatus(err, types.NFS4ERR_EXPIRED) {
 		t.Fatalf("UnlockFile after lease cancellation: got %v, want NFS4ERR_EXPIRED", err)
 	}
 
-	if _, err := sm.LockExisting(context.Background(),
-		&lockStateid, 2, fileHandle, types.WRITE_LT, 200, 100, false,
-	); !isStatus(err, types.NFS4ERR_EXPIRED) {
+	if _, err := sm.LockExisting(context.Background(), &lockStateid, 2, fileHandle, types.WRITE_LT, 200, 100, false, 0); !isStatus(err, types.NFS4ERR_EXPIRED) {
 		t.Fatalf("LockExisting after lease cancellation: got %v, want NFS4ERR_EXPIRED", err)
 	}
 
-	if _, err := sm.UnlockFile(unknown, 2, types.WRITE_LT, 0, 100); !isStatus(err, types.NFS4ERR_BAD_STATEID) {
+	if _, err := sm.UnlockFile(unknown, 2, types.WRITE_LT, 0, 100, 0); !isStatus(err, types.NFS4ERR_BAD_STATEID) {
 		t.Fatalf("UnlockFile of a never-issued stateid: got %v, want NFS4ERR_BAD_STATEID", err)
 	}
 }

--- a/internal/adapter/nfs/v4/state/lease_test.go
+++ b/internal/adapter/nfs/v4/state/lease_test.go
@@ -85,7 +85,7 @@ func TestLeaseExpiration_CleansUpAllState(t *testing.T) {
 	}
 
 	// Confirm the open
-	_, err = sm.ConfirmOpen(&openResult.Stateid, 2)
+	_, err = sm.ConfirmOpen(&openResult.Stateid, 2, 0)
 	if err != nil {
 		t.Fatalf("ConfirmOpen: %v", err)
 	}
@@ -214,7 +214,7 @@ func TestImplicitRenewal_ViaValidateStateid(t *testing.T) {
 	}
 
 	// Confirm the open
-	confirmedRes, err := sm.ConfirmOpen(&openResult.Stateid, 2)
+	confirmedRes, err := sm.ConfirmOpen(&openResult.Stateid, 2, 0)
 	if err != nil {
 		t.Fatalf("ConfirmOpen: %v", err)
 	}
@@ -272,7 +272,7 @@ func TestLeaseExpired_ReturnsError(t *testing.T) {
 	}
 
 	// Confirm the open
-	confirmedRes, err := sm.ConfirmOpen(&openResult.Stateid, 2)
+	confirmedRes, err := sm.ConfirmOpen(&openResult.Stateid, 2, 0)
 	if err != nil {
 		t.Fatalf("ConfirmOpen: %v", err)
 	}

--- a/internal/adapter/nfs/v4/state/lock_manager_unlocked_test.go
+++ b/internal/adapter/nfs/v4/state/lock_manager_unlocked_test.go
@@ -105,7 +105,6 @@ func TestLockNew_LockManagerCalledWithoutStateMutex(t *testing.T) {
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
 	res, err := sm.LockNew(context.Background(), clientID, []byte("owner-a"), 1, openStateid, openSeqid, fileHandle, types.WRITE_LT, 0, 100, false, 0)
-
 	if err == nil {
 		t.Fatalf("LOCK committed against state freed while the lock manager was called: %+v", res)
 	}
@@ -130,7 +129,6 @@ func TestUnlockFile_LockManagerCalledWithoutStateMutex(t *testing.T) {
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
 	locked, err := sm.LockNew(context.Background(), clientID, []byte("owner-a"), 1, openStateid, openSeqid, fileHandle, types.WRITE_LT, 0, 100, false, 0)
-
 	if err != nil || locked.Denied != nil {
 		t.Fatalf("setup LOCK failed: err=%v denied=%v", err, locked)
 	}

--- a/internal/adapter/nfs/v4/state/lock_manager_unlocked_test.go
+++ b/internal/adapter/nfs/v4/state/lock_manager_unlocked_test.go
@@ -104,11 +104,8 @@ func TestLockNew_LockManagerCalledWithoutStateMutex(t *testing.T) {
 
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
-	res, err := sm.LockNew(context.Background(),
-		clientID, []byte("owner-a"), 1,
-		openStateid, openSeqid,
-		fileHandle, types.WRITE_LT, 0, 100, false,
-	)
+	res, err := sm.LockNew(context.Background(), clientID, []byte("owner-a"), 1, openStateid, openSeqid, fileHandle, types.WRITE_LT, 0, 100, false, 0)
+
 	if err == nil {
 		t.Fatalf("LOCK committed against state freed while the lock manager was called: %+v", res)
 	}
@@ -132,11 +129,8 @@ func TestUnlockFile_LockManagerCalledWithoutStateMutex(t *testing.T) {
 
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
-	locked, err := sm.LockNew(context.Background(),
-		clientID, []byte("owner-a"), 1,
-		openStateid, openSeqid,
-		fileHandle, types.WRITE_LT, 0, 100, false,
-	)
+	locked, err := sm.LockNew(context.Background(), clientID, []byte("owner-a"), 1, openStateid, openSeqid, fileHandle, types.WRITE_LT, 0, 100, false, 0)
+
 	if err != nil || locked.Denied != nil {
 		t.Fatalf("setup LOCK failed: err=%v denied=%v", err, locked)
 	}
@@ -145,7 +139,7 @@ func TestUnlockFile_LockManagerCalledWithoutStateMutex(t *testing.T) {
 	lm.onRemoveLock = func() {
 		mutateUnderStateMutex(t, "the lease sweeper", func() { sm.onLeaseExpired(clientID) })
 	}
-	if _, err := sm.UnlockFile(&locked.Stateid, 2, types.WRITE_LT, 0, 100); err == nil {
+	if _, err := sm.UnlockFile(&locked.Stateid, 2, types.WRITE_LT, 0, 100, 0); err == nil {
 		t.Fatal("LOCKU committed a seqid bump against state freed while the lock manager was called")
 	}
 }

--- a/internal/adapter/nfs/v4/state/lock_resolver_test.go
+++ b/internal/adapter/nfs/v4/state/lock_resolver_test.go
@@ -76,7 +76,6 @@ func TestLockManagerResolver_DetectsCrossProtocolConflict(t *testing.T) {
 
 	// NFSv4 LOCK for the same overlapping range must also be denied (not granted).
 	res, err := sm.LockNew(context.Background(), clientID, []byte("nfs-owner"), 1, openStateid, openSeqid, fileHandle, types.WRITE_LT, 50, 100, false, 0)
-
 	if err != nil {
 		t.Fatalf("LockNew returned error: %v", err)
 	}

--- a/internal/adapter/nfs/v4/state/lock_resolver_test.go
+++ b/internal/adapter/nfs/v4/state/lock_resolver_test.go
@@ -23,11 +23,7 @@ func TestLockManagerResolver_FixesMissingManager(t *testing.T) {
 	// No manager, no resolver: LOCK must fail (reproduces the EIO bug).
 	smBroken := NewStateManager(90 * time.Second)
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, smBroken)
-	if _, err := smBroken.LockNew(context.Background(),
-		clientID, []byte("owner-a"), 1,
-		openStateid, openSeqid,
-		fileHandle, types.WRITE_LT, 0, 100, false,
-	); err == nil {
+	if _, err := smBroken.LockNew(context.Background(), clientID, []byte("owner-a"), 1, openStateid, openSeqid, fileHandle, types.WRITE_LT, 0, 100, false, 0); err == nil {
 		t.Fatal("expected LOCK to fail when no lock manager is configured")
 	}
 
@@ -36,11 +32,7 @@ func TestLockManagerResolver_FixesMissingManager(t *testing.T) {
 	sm := NewStateManager(90 * time.Second)
 	sm.SetLockManagerResolver(func(_ []byte) lock.LockManager { return lm })
 	clientID, fileHandle, openStateid, openSeqid = setupClientAndOpenState(t, sm)
-	if _, err := sm.LockNew(context.Background(),
-		clientID, []byte("owner-a"), 1,
-		openStateid, openSeqid,
-		fileHandle, types.WRITE_LT, 0, 100, false,
-	); err != nil {
+	if _, err := sm.LockNew(context.Background(), clientID, []byte("owner-a"), 1, openStateid, openSeqid, fileHandle, types.WRITE_LT, 0, 100, false, 0); err != nil {
 		t.Fatalf("LOCK with resolved lock manager failed: %v", err)
 	}
 	if locks := lm.ListUnifiedLocks(string(fileHandle)); len(locks) != 1 {
@@ -83,11 +75,8 @@ func TestLockManagerResolver_DetectsCrossProtocolConflict(t *testing.T) {
 	}
 
 	// NFSv4 LOCK for the same overlapping range must also be denied (not granted).
-	res, err := sm.LockNew(context.Background(),
-		clientID, []byte("nfs-owner"), 1,
-		openStateid, openSeqid,
-		fileHandle, types.WRITE_LT, 50, 100, false,
-	)
+	res, err := sm.LockNew(context.Background(), clientID, []byte("nfs-owner"), 1, openStateid, openSeqid, fileHandle, types.WRITE_LT, 50, 100, false, 0)
+
 	if err != nil {
 		t.Fatalf("LockNew returned error: %v", err)
 	}

--- a/internal/adapter/nfs/v4/state/lockowner_test.go
+++ b/internal/adapter/nfs/v4/state/lockowner_test.go
@@ -189,7 +189,6 @@ func TestLockNew_CreatesLockOwnerAndState(t *testing.T) {
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
 	lockResult, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner-1"), 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
-
 	if err != nil {
 		t.Fatalf("LockNew failed: %v", err)
 	}
@@ -210,14 +209,12 @@ func TestLockNew_ExistingLockOwner(t *testing.T) {
 
 	// First lock
 	_, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner-1"), 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 50, false, 0)
-
 	if err != nil {
 		t.Fatalf("first LockNew failed: %v", err)
 	}
 
 	// Second lock with same owner on different range
 	result, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner-1"), 2, openStateid, openSeqid+2, fileHandle, types.WRITE_LT, 100, 50, false, 0)
-
 	if err != nil {
 		t.Fatalf("second LockNew failed: %v", err)
 	}
@@ -237,7 +234,6 @@ func TestLockNew_BadOpenStateid(t *testing.T) {
 	bogusStateid := &types.Stateid4{Seqid: 1}
 
 	_, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner-1"), 1, bogusStateid, 1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
-
 	if err == nil {
 		t.Fatal("expected error for bad open stateid")
 	}
@@ -259,7 +255,6 @@ func TestLockNew_BadOpenSeqid(t *testing.T) {
 
 	// Use a wrong open seqid (too high)
 	_, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner-1"), 1, openStateid, openSeqid+100, fileHandle, types.WRITE_LT, 0, 100, false, 0)
-
 	if err == nil {
 		t.Fatal("expected error for bad open seqid")
 	}
@@ -311,7 +306,6 @@ func TestLockNew_OpenModeViolation(t *testing.T) {
 
 	// Try to get a write lock on a read-only open
 	_, lockErr := sm.LockNew(context.Background(), result.ClientID, []byte("lock-owner"), 1, confirmedStateid, 3, fh, types.WRITE_LT, 0, 100, false, 0)
-
 	if lockErr == nil {
 		t.Fatal("expected NFS4ERR_OPENMODE for write lock on read-only open")
 	}
@@ -336,7 +330,6 @@ func TestLockNew_GracePeriod(t *testing.T) {
 
 	// Non-reclaim should be blocked
 	_, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner-1"), 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
-
 	if err == nil {
 		t.Fatal("expected NFS4ERR_GRACE for non-reclaim lock during grace period")
 	}
@@ -350,7 +343,6 @@ func TestLockNew_GracePeriod(t *testing.T) {
 
 	// Reclaim should be allowed
 	result, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner-1"), 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, true, 0)
-
 	if err != nil {
 		t.Fatalf("reclaim LockNew during grace period failed: %v", err)
 	}
@@ -375,14 +367,12 @@ func TestLockExisting_Success(t *testing.T) {
 
 	// First lock to get a lock stateid
 	lockResult, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner-1"), 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 50, false, 0)
-
 	if err != nil {
 		t.Fatalf("LockNew failed: %v", err)
 	}
 
 	// Second lock using existing lock stateid
 	existResult, err := sm.LockExisting(context.Background(), &lockResult.Stateid, 2, fileHandle, types.WRITE_LT, 100, 50, false, 0)
-
 	if err != nil {
 		t.Fatalf("LockExisting failed: %v", err)
 	}
@@ -408,7 +398,6 @@ func TestLockExisting_BadStateid(t *testing.T) {
 	bogusStateid := &types.Stateid4{Seqid: 1}
 
 	_, err := sm.LockExisting(context.Background(), bogusStateid, 1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
-
 	if err == nil {
 		t.Fatal("expected error for bad lock stateid")
 	}
@@ -432,14 +421,12 @@ func TestLockExisting_BadSeqid(t *testing.T) {
 
 	// First lock
 	lockResult, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner-1"), 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 50, false, 0)
-
 	if err != nil {
 		t.Fatalf("LockNew failed: %v", err)
 	}
 
 	// LockExisting with wrong seqid (too high)
 	_, err = sm.LockExisting(context.Background(), &lockResult.Stateid, 100, fileHandle, types.WRITE_LT, 100, 50, false, 0)
-
 	if err == nil {
 		t.Fatal("expected error for bad lock seqid")
 	}
@@ -505,7 +492,6 @@ func TestLockNew_Conflict(t *testing.T) {
 
 	// Client 1 acquires exclusive lock on range [0, 100)
 	lockResult1, err := sm.LockNew(context.Background(), res1.ClientID, []byte("lock-owner-1"), 1, confirmed1, 3, fh, types.WRITE_LT, 0, 100, false, 0)
-
 	if err != nil {
 		t.Fatalf("LockNew client 1 failed: %v", err)
 	}
@@ -515,7 +501,6 @@ func TestLockNew_Conflict(t *testing.T) {
 
 	// Client 2 tries to acquire exclusive lock on overlapping range [50, 150)
 	lockResult2, err := sm.LockNew(context.Background(), res2.ClientID, []byte("lock-owner-2"), 1, confirmed2, 3, fh, types.WRITE_LT, 50, 100, false, 0)
-
 	if err != nil {
 		t.Fatalf("LockNew client 2 error: %v", err)
 	}
@@ -558,7 +543,6 @@ func TestLockNew_SharedNoConflict(t *testing.T) {
 
 	// Client 1 acquires shared lock
 	lockResult1, err := sm.LockNew(context.Background(), res1.ClientID, []byte("lock-owner-1"), 1, confirmed1, 3, fh, types.READ_LT, 0, 100, false, 0)
-
 	if err != nil {
 		t.Fatalf("LockNew client 1 failed: %v", err)
 	}
@@ -568,7 +552,6 @@ func TestLockNew_SharedNoConflict(t *testing.T) {
 
 	// Client 2 acquires shared lock on same range -- should succeed
 	lockResult2, err := sm.LockNew(context.Background(), res2.ClientID, []byte("lock-owner-2"), 1, confirmed2, 3, fh, types.READ_LT, 0, 100, false, 0)
-
 	if err != nil {
 		t.Fatalf("LockNew client 2 failed: %v", err)
 	}
@@ -590,7 +573,6 @@ func TestCloseFile_LocksHeld(t *testing.T) {
 
 	// Acquire a lock
 	lockResult, err := sm.LockNew(context.Background(), clientID, []byte("close-lock-owner"), 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
-
 	if err != nil {
 		t.Fatalf("LockNew failed: %v", err)
 	}
@@ -649,7 +631,6 @@ func TestReleaseLockOwner_NoLocks(t *testing.T) {
 
 	// Create lock-owner via LockNew
 	lockResult, err := sm.LockNew(context.Background(), clientID, []byte("release-owner"), 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
-
 	if err != nil {
 		t.Fatalf("LockNew failed: %v", err)
 	}
@@ -682,7 +663,6 @@ func TestReleaseLockOwner_WithLocks(t *testing.T) {
 
 	// Create lock-owner and hold a lock
 	_, err := sm.LockNew(context.Background(), clientID, []byte("held-lock-owner"), 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
-
 	if err != nil {
 		t.Fatalf("LockNew failed: %v", err)
 	}
@@ -724,7 +704,6 @@ func TestLeaseExpiry_CleansLockState(t *testing.T) {
 
 	// Acquire a lock
 	lockResult, err := sm.LockNew(context.Background(), clientID, []byte("expiry-lock-owner"), 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
-
 	if err != nil {
 		t.Fatalf("LockNew failed: %v", err)
 	}
@@ -770,7 +749,6 @@ func TestLeaseExpiry_CleansLockManager(t *testing.T) {
 
 	// Acquire a lock with client 1
 	_, err := sm.LockNew(context.Background(), clientID1, []byte("client1-lock-owner"), 1, openStateid1, openSeqid1+1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
-
 	if err != nil {
 		t.Fatalf("LockNew failed: %v", err)
 	}
@@ -807,7 +785,6 @@ func TestLeaseExpiry_CleansLockManager(t *testing.T) {
 	// Client 2 should be able to acquire a lock on the same range
 	// (previously held by expired client 1)
 	lockResult2, err := sm.LockNew(context.Background(), res2.ClientID, []byte("client2-lock-owner"), 1, confirmed2, 3, fileHandle, types.WRITE_LT, 0, 100, false, 0)
-
 	if err != nil {
 		t.Fatalf("LockNew for client 2 failed: %v", err)
 	}
@@ -844,14 +821,12 @@ func TestLockNew_BlockingType(t *testing.T) {
 
 	// Client 1 acquires exclusive lock
 	_, err := sm.LockNew(context.Background(), res1.ClientID, []byte("lock-owner-1"), 1, confirmed1, 3, fh, types.WRITE_LT, 0, 100, false, 0)
-
 	if err != nil {
 		t.Fatalf("LockNew failed: %v", err)
 	}
 
 	// Client 2 tries blocking write lock (WRITEW_LT) -- should get DENIED, not block
 	lockResult, err := sm.LockNew(context.Background(), res2.ClientID, []byte("lock-owner-2"), 1, confirmed2, 3, fh, types.WRITEW_LT, 0, 100, false, 0)
-
 	if err != nil {
 		t.Fatalf("LockNew with WRITEW_LT failed: %v", err)
 	}
@@ -864,7 +839,6 @@ func TestLockNew_BlockingType(t *testing.T) {
 	// seqid-exempt error), so this reuse of the same open-owner uses the next
 	// open seqid (4), not 3.
 	lockResult2, err := sm.LockNew(context.Background(), res2.ClientID, []byte("lock-owner-2b"), 1, confirmed2, 4, fh, types.READW_LT, 0, 100, false, 0)
-
 	if err != nil {
 		t.Fatalf("LockNew with READW_LT failed: %v", err)
 	}
@@ -966,7 +940,6 @@ func TestLockToEndOfFile(t *testing.T) {
 	rivalConfirmed, _ := sm.ConfirmOpen(&rivalOpen.Stateid, 2, 0)
 
 	held, err := sm.LockNew(context.Background(), holder.ClientID, []byte("lock-owner-holder"), 1, &holderConfirmed.Stateid, 3, fh, types.WRITE_LT, 100, toEOF, false, 0)
-
 	if err != nil {
 		t.Fatalf("LOCK through end-of-file failed: %v", err)
 	}
@@ -989,7 +962,6 @@ func TestLockToEndOfFile(t *testing.T) {
 
 	// LOCK: the same range must be refused, not handed out.
 	rivalLock, err := sm.LockNew(context.Background(), rival.ClientID, []byte("lock-owner-rival"), 1, &rivalConfirmed.Stateid, 3, fh, types.WRITE_LT, 200, 100, false, 0)
-
 	if err != nil {
 		t.Fatalf("conflicting LOCK failed: %v", err)
 	}

--- a/internal/adapter/nfs/v4/state/lockowner_test.go
+++ b/internal/adapter/nfs/v4/state/lockowner_test.go
@@ -169,7 +169,7 @@ func setupClientAndOpenState(t *testing.T, sm *StateManager) (clientID uint64, f
 
 	// Confirm the open
 	confirmSeqid := openSeqid + 1
-	confirmRes, err := sm.ConfirmOpen(&openResult.Stateid, confirmSeqid)
+	confirmRes, err := sm.ConfirmOpen(&openResult.Stateid, confirmSeqid, 0)
 	if err != nil {
 		t.Fatalf("ConfirmOpen failed: %v", err)
 	}
@@ -188,11 +188,8 @@ func TestLockNew_CreatesLockOwnerAndState(t *testing.T) {
 
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
-	lockResult, err := sm.LockNew(context.Background(),
-		clientID, []byte("lock-owner-1"), 1,
-		openStateid, openSeqid+1,
-		fileHandle, types.WRITE_LT, 0, 100, false,
-	)
+	lockResult, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner-1"), 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
+
 	if err != nil {
 		t.Fatalf("LockNew failed: %v", err)
 	}
@@ -212,21 +209,15 @@ func TestLockNew_ExistingLockOwner(t *testing.T) {
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
 	// First lock
-	_, err := sm.LockNew(context.Background(),
-		clientID, []byte("lock-owner-1"), 1,
-		openStateid, openSeqid+1,
-		fileHandle, types.WRITE_LT, 0, 50, false,
-	)
+	_, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner-1"), 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 50, false, 0)
+
 	if err != nil {
 		t.Fatalf("first LockNew failed: %v", err)
 	}
 
 	// Second lock with same owner on different range
-	result, err := sm.LockNew(context.Background(),
-		clientID, []byte("lock-owner-1"), 2,
-		openStateid, openSeqid+2,
-		fileHandle, types.WRITE_LT, 100, 50, false,
-	)
+	result, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner-1"), 2, openStateid, openSeqid+2, fileHandle, types.WRITE_LT, 100, 50, false, 0)
+
 	if err != nil {
 		t.Fatalf("second LockNew failed: %v", err)
 	}
@@ -245,11 +236,8 @@ func TestLockNew_BadOpenStateid(t *testing.T) {
 	// Use a bogus open stateid
 	bogusStateid := &types.Stateid4{Seqid: 1}
 
-	_, err := sm.LockNew(context.Background(),
-		clientID, []byte("lock-owner-1"), 1,
-		bogusStateid, 1,
-		fileHandle, types.WRITE_LT, 0, 100, false,
-	)
+	_, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner-1"), 1, bogusStateid, 1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
+
 	if err == nil {
 		t.Fatal("expected error for bad open stateid")
 	}
@@ -270,11 +258,8 @@ func TestLockNew_BadOpenSeqid(t *testing.T) {
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
 	// Use a wrong open seqid (too high)
-	_, err := sm.LockNew(context.Background(),
-		clientID, []byte("lock-owner-1"), 1,
-		openStateid, openSeqid+100,
-		fileHandle, types.WRITE_LT, 0, 100, false,
-	)
+	_, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner-1"), 1, openStateid, openSeqid+100, fileHandle, types.WRITE_LT, 0, 100, false, 0)
+
 	if err == nil {
 		t.Fatal("expected error for bad open seqid")
 	}
@@ -318,18 +303,15 @@ func TestLockNew_OpenModeViolation(t *testing.T) {
 		t.Fatalf("OpenFile failed: %v", err)
 	}
 
-	confirmedRes, err := sm.ConfirmOpen(&openResult.Stateid, 2)
+	confirmedRes, err := sm.ConfirmOpen(&openResult.Stateid, 2, 0)
 	if err != nil {
 		t.Fatalf("ConfirmOpen failed: %v", err)
 	}
 	confirmedStateid := &confirmedRes.Stateid
 
 	// Try to get a write lock on a read-only open
-	_, lockErr := sm.LockNew(context.Background(),
-		result.ClientID, []byte("lock-owner"), 1,
-		confirmedStateid, 3,
-		fh, types.WRITE_LT, 0, 100, false,
-	)
+	_, lockErr := sm.LockNew(context.Background(), result.ClientID, []byte("lock-owner"), 1, confirmedStateid, 3, fh, types.WRITE_LT, 0, 100, false, 0)
+
 	if lockErr == nil {
 		t.Fatal("expected NFS4ERR_OPENMODE for write lock on read-only open")
 	}
@@ -353,11 +335,8 @@ func TestLockNew_GracePeriod(t *testing.T) {
 	sm.StartGracePeriod([]uint64{clientID})
 
 	// Non-reclaim should be blocked
-	_, err := sm.LockNew(context.Background(),
-		clientID, []byte("lock-owner-1"), 1,
-		openStateid, openSeqid+1,
-		fileHandle, types.WRITE_LT, 0, 100, false,
-	)
+	_, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner-1"), 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
+
 	if err == nil {
 		t.Fatal("expected NFS4ERR_GRACE for non-reclaim lock during grace period")
 	}
@@ -370,11 +349,8 @@ func TestLockNew_GracePeriod(t *testing.T) {
 	}
 
 	// Reclaim should be allowed
-	result, err := sm.LockNew(context.Background(),
-		clientID, []byte("lock-owner-1"), 1,
-		openStateid, openSeqid+1,
-		fileHandle, types.WRITE_LT, 0, 100, true,
-	)
+	result, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner-1"), 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, true, 0)
+
 	if err != nil {
 		t.Fatalf("reclaim LockNew during grace period failed: %v", err)
 	}
@@ -398,20 +374,15 @@ func TestLockExisting_Success(t *testing.T) {
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
 	// First lock to get a lock stateid
-	lockResult, err := sm.LockNew(context.Background(),
-		clientID, []byte("lock-owner-1"), 1,
-		openStateid, openSeqid+1,
-		fileHandle, types.WRITE_LT, 0, 50, false,
-	)
+	lockResult, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner-1"), 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 50, false, 0)
+
 	if err != nil {
 		t.Fatalf("LockNew failed: %v", err)
 	}
 
 	// Second lock using existing lock stateid
-	existResult, err := sm.LockExisting(context.Background(),
-		&lockResult.Stateid, 2,
-		fileHandle, types.WRITE_LT, 100, 50, false,
-	)
+	existResult, err := sm.LockExisting(context.Background(), &lockResult.Stateid, 2, fileHandle, types.WRITE_LT, 100, 50, false, 0)
+
 	if err != nil {
 		t.Fatalf("LockExisting failed: %v", err)
 	}
@@ -436,10 +407,8 @@ func TestLockExisting_BadStateid(t *testing.T) {
 	// The epoch bytes won't match current boot epoch, so it's stale.
 	bogusStateid := &types.Stateid4{Seqid: 1}
 
-	_, err := sm.LockExisting(context.Background(),
-		bogusStateid, 1,
-		fileHandle, types.WRITE_LT, 0, 100, false,
-	)
+	_, err := sm.LockExisting(context.Background(), bogusStateid, 1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
+
 	if err == nil {
 		t.Fatal("expected error for bad lock stateid")
 	}
@@ -462,20 +431,15 @@ func TestLockExisting_BadSeqid(t *testing.T) {
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
 	// First lock
-	lockResult, err := sm.LockNew(context.Background(),
-		clientID, []byte("lock-owner-1"), 1,
-		openStateid, openSeqid+1,
-		fileHandle, types.WRITE_LT, 0, 50, false,
-	)
+	lockResult, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner-1"), 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 50, false, 0)
+
 	if err != nil {
 		t.Fatalf("LockNew failed: %v", err)
 	}
 
 	// LockExisting with wrong seqid (too high)
-	_, err = sm.LockExisting(context.Background(),
-		&lockResult.Stateid, 100,
-		fileHandle, types.WRITE_LT, 100, 50, false,
-	)
+	_, err = sm.LockExisting(context.Background(), &lockResult.Stateid, 100, fileHandle, types.WRITE_LT, 100, 50, false, 0)
+
 	if err == nil {
 		t.Fatal("expected error for bad lock seqid")
 	}
@@ -515,7 +479,7 @@ func TestLockNew_Conflict(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenFile 1 failed: %v", err)
 	}
-	confirmed1Res, err := sm.ConfirmOpen(&open1.Stateid, 2)
+	confirmed1Res, err := sm.ConfirmOpen(&open1.Stateid, 2, 0)
 	if err != nil {
 		t.Fatalf("ConfirmOpen 1 failed: %v", err)
 	}
@@ -533,18 +497,15 @@ func TestLockNew_Conflict(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenFile 2 failed: %v", err)
 	}
-	confirmed2Res, err := sm.ConfirmOpen(&open2.Stateid, 2)
+	confirmed2Res, err := sm.ConfirmOpen(&open2.Stateid, 2, 0)
 	if err != nil {
 		t.Fatalf("ConfirmOpen 2 failed: %v", err)
 	}
 	confirmed2 := &confirmed2Res.Stateid
 
 	// Client 1 acquires exclusive lock on range [0, 100)
-	lockResult1, err := sm.LockNew(context.Background(),
-		res1.ClientID, []byte("lock-owner-1"), 1,
-		confirmed1, 3,
-		fh, types.WRITE_LT, 0, 100, false,
-	)
+	lockResult1, err := sm.LockNew(context.Background(), res1.ClientID, []byte("lock-owner-1"), 1, confirmed1, 3, fh, types.WRITE_LT, 0, 100, false, 0)
+
 	if err != nil {
 		t.Fatalf("LockNew client 1 failed: %v", err)
 	}
@@ -553,11 +514,8 @@ func TestLockNew_Conflict(t *testing.T) {
 	}
 
 	// Client 2 tries to acquire exclusive lock on overlapping range [50, 150)
-	lockResult2, err := sm.LockNew(context.Background(),
-		res2.ClientID, []byte("lock-owner-2"), 1,
-		confirmed2, 3,
-		fh, types.WRITE_LT, 50, 100, false,
-	)
+	lockResult2, err := sm.LockNew(context.Background(), res2.ClientID, []byte("lock-owner-2"), 1, confirmed2, 3, fh, types.WRITE_LT, 50, 100, false, 0)
+
 	if err != nil {
 		t.Fatalf("LockNew client 2 error: %v", err)
 	}
@@ -588,22 +546,19 @@ func TestLockNew_SharedNoConflict(t *testing.T) {
 	res1, _ := sm.SetClientID("client-shared-1", verifier1, callback, "10.0.0.1:1234")
 	_ = sm.ConfirmClientID(res1.ClientID, res1.ConfirmVerifier)
 	open1, _ := sm.OpenFile(res1.ClientID, []byte("owner-1"), 1, fh, types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
-	confirmed1Res, _ := sm.ConfirmOpen(&open1.Stateid, 2)
+	confirmed1Res, _ := sm.ConfirmOpen(&open1.Stateid, 2, 0)
 	confirmed1 := &confirmed1Res.Stateid
 
 	// Client 2
 	res2, _ := sm.SetClientID("client-shared-2", verifier2, callback, "10.0.0.2:1234")
 	_ = sm.ConfirmClientID(res2.ClientID, res2.ConfirmVerifier)
 	open2, _ := sm.OpenFile(res2.ClientID, []byte("owner-2"), 1, fh, types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
-	confirmed2Res, _ := sm.ConfirmOpen(&open2.Stateid, 2)
+	confirmed2Res, _ := sm.ConfirmOpen(&open2.Stateid, 2, 0)
 	confirmed2 := &confirmed2Res.Stateid
 
 	// Client 1 acquires shared lock
-	lockResult1, err := sm.LockNew(context.Background(),
-		res1.ClientID, []byte("lock-owner-1"), 1,
-		confirmed1, 3,
-		fh, types.READ_LT, 0, 100, false,
-	)
+	lockResult1, err := sm.LockNew(context.Background(), res1.ClientID, []byte("lock-owner-1"), 1, confirmed1, 3, fh, types.READ_LT, 0, 100, false, 0)
+
 	if err != nil {
 		t.Fatalf("LockNew client 1 failed: %v", err)
 	}
@@ -612,11 +567,8 @@ func TestLockNew_SharedNoConflict(t *testing.T) {
 	}
 
 	// Client 2 acquires shared lock on same range -- should succeed
-	lockResult2, err := sm.LockNew(context.Background(),
-		res2.ClientID, []byte("lock-owner-2"), 1,
-		confirmed2, 3,
-		fh, types.READ_LT, 0, 100, false,
-	)
+	lockResult2, err := sm.LockNew(context.Background(), res2.ClientID, []byte("lock-owner-2"), 1, confirmed2, 3, fh, types.READ_LT, 0, 100, false, 0)
+
 	if err != nil {
 		t.Fatalf("LockNew client 2 failed: %v", err)
 	}
@@ -637,11 +589,8 @@ func TestCloseFile_LocksHeld(t *testing.T) {
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
 	// Acquire a lock
-	lockResult, err := sm.LockNew(context.Background(),
-		clientID, []byte("close-lock-owner"), 1,
-		openStateid, openSeqid+1,
-		fileHandle, types.WRITE_LT, 0, 100, false,
-	)
+	lockResult, err := sm.LockNew(context.Background(), clientID, []byte("close-lock-owner"), 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
+
 	if err != nil {
 		t.Fatalf("LockNew failed: %v", err)
 	}
@@ -650,7 +599,7 @@ func TestCloseFile_LocksHeld(t *testing.T) {
 	}
 
 	// CLOSE should fail with NFS4ERR_LOCKS_HELD
-	_, closeErr := sm.CloseFile(openStateid, openSeqid+2)
+	_, closeErr := sm.CloseFile(openStateid, openSeqid+2, 0)
 	if closeErr == nil {
 		t.Fatal("expected NFS4ERR_LOCKS_HELD error from CloseFile")
 	}
@@ -663,7 +612,7 @@ func TestCloseFile_LocksHeld(t *testing.T) {
 	}
 
 	// LOCKU the lock
-	_, unlockErr := sm.UnlockFile(&lockResult.Stateid, 2, types.WRITE_LT, 0, 100)
+	_, unlockErr := sm.UnlockFile(&lockResult.Stateid, 2, types.WRITE_LT, 0, 100, 0)
 	if unlockErr != nil {
 		t.Fatalf("UnlockFile failed: %v", unlockErr)
 	}
@@ -678,7 +627,7 @@ func TestCloseFile_LocksHeld(t *testing.T) {
 
 	// The retry carries the NEXT seqid: the failed CLOSE consumed openSeqid+2,
 	// so resending that one would (correctly) replay its NFS4ERR_LOCKS_HELD.
-	closedRes, closeErr := sm.CloseFile(openStateid, openSeqid+3)
+	closedRes, closeErr := sm.CloseFile(openStateid, openSeqid+3, 0)
 	if closeErr != nil {
 		t.Fatalf("CloseFile after unlock+release failed: %v", closeErr)
 	}
@@ -699,17 +648,14 @@ func TestReleaseLockOwner_NoLocks(t *testing.T) {
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
 	// Create lock-owner via LockNew
-	lockResult, err := sm.LockNew(context.Background(),
-		clientID, []byte("release-owner"), 1,
-		openStateid, openSeqid+1,
-		fileHandle, types.WRITE_LT, 0, 100, false,
-	)
+	lockResult, err := sm.LockNew(context.Background(), clientID, []byte("release-owner"), 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
+
 	if err != nil {
 		t.Fatalf("LockNew failed: %v", err)
 	}
 
 	// LOCKU to remove the lock
-	_, unlockErr := sm.UnlockFile(&lockResult.Stateid, 2, types.WRITE_LT, 0, 100)
+	_, unlockErr := sm.UnlockFile(&lockResult.Stateid, 2, types.WRITE_LT, 0, 100, 0)
 	if unlockErr != nil {
 		t.Fatalf("UnlockFile failed: %v", unlockErr)
 	}
@@ -721,7 +667,7 @@ func TestReleaseLockOwner_NoLocks(t *testing.T) {
 	}
 
 	// Verify lock stateid is now invalid
-	_, valErr := sm.LockExisting(context.Background(), &lockResult.Stateid, 3, fileHandle, types.WRITE_LT, 0, 100, false)
+	_, valErr := sm.LockExisting(context.Background(), &lockResult.Stateid, 3, fileHandle, types.WRITE_LT, 0, 100, false, 0)
 	if valErr == nil {
 		t.Fatal("expected error for lock stateid after RELEASE_LOCKOWNER")
 	}
@@ -735,11 +681,8 @@ func TestReleaseLockOwner_WithLocks(t *testing.T) {
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
 	// Create lock-owner and hold a lock
-	_, err := sm.LockNew(context.Background(),
-		clientID, []byte("held-lock-owner"), 1,
-		openStateid, openSeqid+1,
-		fileHandle, types.WRITE_LT, 0, 100, false,
-	)
+	_, err := sm.LockNew(context.Background(), clientID, []byte("held-lock-owner"), 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
+
 	if err != nil {
 		t.Fatalf("LockNew failed: %v", err)
 	}
@@ -780,11 +723,8 @@ func TestLeaseExpiry_CleansLockState(t *testing.T) {
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
 	// Acquire a lock
-	lockResult, err := sm.LockNew(context.Background(),
-		clientID, []byte("expiry-lock-owner"), 1,
-		openStateid, openSeqid+1,
-		fileHandle, types.WRITE_LT, 0, 100, false,
-	)
+	lockResult, err := sm.LockNew(context.Background(), clientID, []byte("expiry-lock-owner"), 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
+
 	if err != nil {
 		t.Fatalf("LockNew failed: %v", err)
 	}
@@ -802,7 +742,7 @@ func TestLeaseExpiry_CleansLockState(t *testing.T) {
 	time.Sleep(150 * time.Millisecond)
 
 	// Verify lock stateid is now invalid (cleaned up by onLeaseExpired)
-	_, valErr := sm.LockExisting(context.Background(), &lockResult.Stateid, 2, fileHandle, types.WRITE_LT, 0, 100, false)
+	_, valErr := sm.LockExisting(context.Background(), &lockResult.Stateid, 2, fileHandle, types.WRITE_LT, 0, 100, false, 0)
 	if valErr == nil {
 		t.Fatal("expected error for lock stateid after lease expiry")
 	}
@@ -829,11 +769,8 @@ func TestLeaseExpiry_CleansLockManager(t *testing.T) {
 	clientID1, fileHandle, openStateid1, openSeqid1 := setupClientAndOpenState(t, sm)
 
 	// Acquire a lock with client 1
-	_, err := sm.LockNew(context.Background(),
-		clientID1, []byte("client1-lock-owner"), 1,
-		openStateid1, openSeqid1+1,
-		fileHandle, types.WRITE_LT, 0, 100, false,
-	)
+	_, err := sm.LockNew(context.Background(), clientID1, []byte("client1-lock-owner"), 1, openStateid1, openSeqid1+1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
+
 	if err != nil {
 		t.Fatalf("LockNew failed: %v", err)
 	}
@@ -861,7 +798,7 @@ func TestLeaseExpiry_CleansLockManager(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenFile for client 2 failed: %v", err)
 	}
-	confirmed2Res, err := sm.ConfirmOpen(&openResult2.Stateid, 2)
+	confirmed2Res, err := sm.ConfirmOpen(&openResult2.Stateid, 2, 0)
 	if err != nil {
 		t.Fatalf("ConfirmOpen for client 2 failed: %v", err)
 	}
@@ -869,11 +806,8 @@ func TestLeaseExpiry_CleansLockManager(t *testing.T) {
 
 	// Client 2 should be able to acquire a lock on the same range
 	// (previously held by expired client 1)
-	lockResult2, err := sm.LockNew(context.Background(),
-		res2.ClientID, []byte("client2-lock-owner"), 1,
-		confirmed2, 3,
-		fileHandle, types.WRITE_LT, 0, 100, false,
-	)
+	lockResult2, err := sm.LockNew(context.Background(), res2.ClientID, []byte("client2-lock-owner"), 1, confirmed2, 3, fileHandle, types.WRITE_LT, 0, 100, false, 0)
+
 	if err != nil {
 		t.Fatalf("LockNew for client 2 failed: %v", err)
 	}
@@ -899,31 +833,25 @@ func TestLockNew_BlockingType(t *testing.T) {
 	res1, _ := sm.SetClientID("client-block-1", verifier1, callback, "10.0.0.1:1234")
 	_ = sm.ConfirmClientID(res1.ClientID, res1.ConfirmVerifier)
 	open1, _ := sm.OpenFile(res1.ClientID, []byte("owner-1"), 1, fh, types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
-	confirmed1Res, _ := sm.ConfirmOpen(&open1.Stateid, 2)
+	confirmed1Res, _ := sm.ConfirmOpen(&open1.Stateid, 2, 0)
 	confirmed1 := &confirmed1Res.Stateid
 
 	res2, _ := sm.SetClientID("client-block-2", verifier2, callback, "10.0.0.2:1234")
 	_ = sm.ConfirmClientID(res2.ClientID, res2.ConfirmVerifier)
 	open2, _ := sm.OpenFile(res2.ClientID, []byte("owner-2"), 1, fh, types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
-	confirmed2Res, _ := sm.ConfirmOpen(&open2.Stateid, 2)
+	confirmed2Res, _ := sm.ConfirmOpen(&open2.Stateid, 2, 0)
 	confirmed2 := &confirmed2Res.Stateid
 
 	// Client 1 acquires exclusive lock
-	_, err := sm.LockNew(context.Background(),
-		res1.ClientID, []byte("lock-owner-1"), 1,
-		confirmed1, 3,
-		fh, types.WRITE_LT, 0, 100, false,
-	)
+	_, err := sm.LockNew(context.Background(), res1.ClientID, []byte("lock-owner-1"), 1, confirmed1, 3, fh, types.WRITE_LT, 0, 100, false, 0)
+
 	if err != nil {
 		t.Fatalf("LockNew failed: %v", err)
 	}
 
 	// Client 2 tries blocking write lock (WRITEW_LT) -- should get DENIED, not block
-	lockResult, err := sm.LockNew(context.Background(),
-		res2.ClientID, []byte("lock-owner-2"), 1,
-		confirmed2, 3,
-		fh, types.WRITEW_LT, 0, 100, false,
-	)
+	lockResult, err := sm.LockNew(context.Background(), res2.ClientID, []byte("lock-owner-2"), 1, confirmed2, 3, fh, types.WRITEW_LT, 0, 100, false, 0)
+
 	if err != nil {
 		t.Fatalf("LockNew with WRITEW_LT failed: %v", err)
 	}
@@ -935,11 +863,8 @@ func TestLockNew_BlockingType(t *testing.T) {
 	// the open-owner seqid (RFC 7530 §8.1.5: NFS4ERR_DENIED is not a
 	// seqid-exempt error), so this reuse of the same open-owner uses the next
 	// open seqid (4), not 3.
-	lockResult2, err := sm.LockNew(context.Background(),
-		res2.ClientID, []byte("lock-owner-2b"), 1,
-		confirmed2, 4,
-		fh, types.READW_LT, 0, 100, false,
-	)
+	lockResult2, err := sm.LockNew(context.Background(), res2.ClientID, []byte("lock-owner-2b"), 1, confirmed2, 4, fh, types.READW_LT, 0, 100, false, 0)
+
 	if err != nil {
 		t.Fatalf("LockNew with READW_LT failed: %v", err)
 	}
@@ -1032,19 +957,16 @@ func TestLockToEndOfFile(t *testing.T) {
 	_ = sm.ConfirmClientID(holder.ClientID, holder.ConfirmVerifier)
 	holderOpen, _ := sm.OpenFile(holder.ClientID, []byte("owner-holder"), 1, fh,
 		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
-	holderConfirmed, _ := sm.ConfirmOpen(&holderOpen.Stateid, 2)
+	holderConfirmed, _ := sm.ConfirmOpen(&holderOpen.Stateid, 2, 0)
 
 	rival, _ := sm.SetClientID("client-eof-rival", [8]byte{2}, callback, "10.0.0.2:1234")
 	_ = sm.ConfirmClientID(rival.ClientID, rival.ConfirmVerifier)
 	rivalOpen, _ := sm.OpenFile(rival.ClientID, []byte("owner-rival"), 1, fh,
 		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
-	rivalConfirmed, _ := sm.ConfirmOpen(&rivalOpen.Stateid, 2)
+	rivalConfirmed, _ := sm.ConfirmOpen(&rivalOpen.Stateid, 2, 0)
 
-	held, err := sm.LockNew(context.Background(),
-		holder.ClientID, []byte("lock-owner-holder"), 1,
-		&holderConfirmed.Stateid, 3,
-		fh, types.WRITE_LT, 100, toEOF, false,
-	)
+	held, err := sm.LockNew(context.Background(), holder.ClientID, []byte("lock-owner-holder"), 1, &holderConfirmed.Stateid, 3, fh, types.WRITE_LT, 100, toEOF, false, 0)
+
 	if err != nil {
 		t.Fatalf("LOCK through end-of-file failed: %v", err)
 	}
@@ -1066,11 +988,8 @@ func TestLockToEndOfFile(t *testing.T) {
 	}
 
 	// LOCK: the same range must be refused, not handed out.
-	rivalLock, err := sm.LockNew(context.Background(),
-		rival.ClientID, []byte("lock-owner-rival"), 1,
-		&rivalConfirmed.Stateid, 3,
-		fh, types.WRITE_LT, 200, 100, false,
-	)
+	rivalLock, err := sm.LockNew(context.Background(), rival.ClientID, []byte("lock-owner-rival"), 1, &rivalConfirmed.Stateid, 3, fh, types.WRITE_LT, 200, 100, false, 0)
+
 	if err != nil {
 		t.Fatalf("conflicting LOCK failed: %v", err)
 	}
@@ -1079,7 +998,7 @@ func TestLockToEndOfFile(t *testing.T) {
 	}
 
 	// LOCKU: releasing with the same all-ones length must clear the whole range.
-	if _, err := sm.UnlockFile(&held.Stateid, 2, types.WRITE_LT, 100, toEOF); err != nil {
+	if _, err := sm.UnlockFile(&held.Stateid, 2, types.WRITE_LT, 100, toEOF, 0); err != nil {
 		t.Fatalf("LOCKU through end-of-file failed: %v", err)
 	}
 	denied, err = sm.TestLock(rival.ClientID, []byte("lock-owner-rival"), fh, types.WRITE_LT, 200, 100)

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -1831,7 +1831,7 @@ func (sm *StateManager) CacheLockOwnerResult(clientID uint64, ownerData []byte, 
 //   - Increments the stateid seqid
 //
 // Caller must NOT hold sm.mu.
-func (sm *StateManager) ConfirmOpen(stateid *types.Stateid4, seqid uint32) (result *OpenSeqResult, err error) {
+func (sm *StateManager) ConfirmOpen(stateid *types.Stateid4, seqid uint32, callerClientID uint64) (result *OpenSeqResult, err error) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
@@ -1845,6 +1845,14 @@ func (sm *StateManager) ConfirmOpen(stateid *types.Stateid4, seqid uint32) (resu
 			Status:  types.NFS4ERR_BAD_STATEID,
 			Message: "stateid not found for OPEN_CONFIRM",
 		}
+	}
+
+	// A stateid is not a bearer token: reject one that names another client's
+	// state before acting on it (RFC 8881 Section 18.38.3). A zero
+	// callerClientID means the caller has no trusted client identity, which is
+	// every NFSv4.0 request; see checkStateidOwner.
+	if err := checkStateidOwner(callerClientID, openState.Owner.ClientID); err != nil {
+		return nil, err
 	}
 
 	owner := openState.Owner
@@ -1901,7 +1909,7 @@ func (sm *StateManager) ConfirmOpen(stateid *types.Stateid4, seqid uint32) (resu
 // nfs_set_open_stateid_locked() expects sequential stateids starting from 1.
 //
 // Caller must NOT hold sm.mu.
-func (sm *StateManager) ConfirmOpenV41(stateid *types.Stateid4) error {
+func (sm *StateManager) ConfirmOpenV41(stateid *types.Stateid4, callerClientID uint64) error {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
@@ -1911,6 +1919,12 @@ func (sm *StateManager) ConfirmOpenV41(stateid *types.Stateid4) error {
 			Status:  types.NFS4ERR_BAD_STATEID,
 			Message: "stateid not found for v4.1 auto-confirm",
 		}
+	}
+
+	// See ConfirmOpen: a stateid that names another client's open must not be
+	// confirmed through this caller.
+	if err := checkStateidOwner(callerClientID, openState.Owner.ClientID); err != nil {
+		return err
 	}
 
 	openState.Confirmed = true
@@ -1928,7 +1942,7 @@ func (sm *StateManager) ConfirmOpenV41(stateid *types.Stateid4) error {
 //   - Returns a zeroed stateid
 //
 // Caller must NOT hold sm.mu.
-func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32) (result *OpenSeqResult, err error) {
+func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32, callerClientID uint64) (result *OpenSeqResult, err error) {
 	// Handle special stateids (all-zeros, all-ones): no state to clean up
 	if stateid.IsSpecialStateid() {
 		return &OpenSeqResult{}, nil
@@ -1955,6 +1969,14 @@ func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32) (result
 			Status:  types.NFS4ERR_BAD_STATEID,
 			Message: "stateid not found for CLOSE",
 		}
+	}
+
+	// A stateid is not a bearer token: reject one that names another client's
+	// state before acting on it (RFC 8881 Section 18.38.3). A zero
+	// callerClientID means the caller has no trusted client identity, which is
+	// every NFSv4.0 request; see checkStateidOwner.
+	if err := checkStateidOwner(callerClientID, openState.Owner.ClientID); err != nil {
+		return nil, err
 	}
 
 	owner := openState.Owner
@@ -2122,7 +2144,7 @@ func (sm *StateManager) dropLockOwnerIfUnreferencedLocked(lockOwner *LockOwner) 
 //   - Increments the stateid seqid
 //
 // Caller must NOT hold sm.mu.
-func (sm *StateManager) DowngradeOpen(stateid *types.Stateid4, seqid uint32, newShareAccess, newShareDeny uint32) (result *OpenSeqResult, err error) {
+func (sm *StateManager) DowngradeOpen(stateid *types.Stateid4, seqid uint32, newShareAccess, newShareDeny uint32, callerClientID uint64) (result *OpenSeqResult, err error) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
@@ -2136,6 +2158,14 @@ func (sm *StateManager) DowngradeOpen(stateid *types.Stateid4, seqid uint32, new
 			Status:  types.NFS4ERR_BAD_STATEID,
 			Message: "stateid not found for OPEN_DOWNGRADE",
 		}
+	}
+
+	// A stateid is not a bearer token: reject one that names another client's
+	// state before acting on it (RFC 8881 Section 18.38.3). A zero
+	// callerClientID means the caller has no trusted client identity, which is
+	// every NFSv4.0 request; see checkStateidOwner.
+	if err := checkStateidOwner(callerClientID, openState.Owner.ClientID); err != nil {
+		return nil, err
 	}
 
 	owner := openState.Owner
@@ -2405,6 +2435,7 @@ func (sm *StateManager) LockNew(
 	lockClientID uint64, lockOwnerData []byte, lockSeqid uint32,
 	openStateid *types.Stateid4, openSeqid uint32,
 	fileHandle []byte, lockType uint32, offset, length uint64, reclaim bool,
+	callerClientID uint64,
 ) (result *LockResult, err error) {
 	// Grace period check (before acquiring sm.mu)
 	if !reclaim {
@@ -2420,6 +2451,14 @@ func (sm *StateManager) LockNew(
 	openState, exists := sm.openStateByOther[openStateid.Other]
 	if !exists {
 		return nil, ErrBadStateid
+	}
+
+	// A stateid is not a bearer token: reject one that names another client's
+	// state before acting on it (RFC 8881 Section 18.38.3). A zero
+	// callerClientID means the caller has no trusted client identity, which is
+	// every NFSv4.0 request; see checkStateidOwner.
+	if err := checkStateidOwner(callerClientID, openState.Owner.ClientID); err != nil {
+		return nil, err
 	}
 
 	// The request is attributable to this open-owner, so any failure below
@@ -2551,7 +2590,7 @@ func (sm *StateManager) LockNew(
 	}
 
 	// 8. Acquire the lock via unified lock manager
-	denied, err := sm.acquireLock(ctx, lockState, lockType, offset, length, reclaim)
+	denied, err := sm.acquireLock(ctx, lockState, lockType, offset, length, reclaim, callerClientID)
 	if err != nil {
 		return nil, err
 	}
@@ -2589,6 +2628,7 @@ func (sm *StateManager) LockExisting(
 	ctx context.Context,
 	lockStateid *types.Stateid4, lockSeqid uint32,
 	fileHandle []byte, lockType uint32, offset, length uint64, reclaim bool,
+	callerClientID uint64,
 ) (result *LockResult, err error) {
 	// Grace period check
 	if !reclaim {
@@ -2600,10 +2640,15 @@ func (sm *StateManager) LockExisting(
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
-	// 1. Look up lock state
+	// 1. Look up lock state. The same check runs again on recommit, once the
+	// lock manager has been called with sm.mu released; here it rejects a
+	// stateid that is not the caller's before any cross-protocol work happens.
 	lockState, exists := sm.lockStateByOther[lockStateid.Other]
 	if !exists {
 		return nil, sm.lockStateidMissError(lockStateid.Other)
+	}
+	if err := sm.revalidateLockStateLocked(lockState, callerClientID); err != nil {
+		return nil, err
 	}
 
 	lockOwner := lockState.LockOwner
@@ -2660,7 +2705,7 @@ func (sm *StateManager) LockExisting(
 	}
 
 	// 5. Acquire the lock
-	denied, err := sm.acquireLock(ctx, lockState, lockType, offset, length, reclaim)
+	denied, err := sm.acquireLock(ctx, lockState, lockType, offset, length, reclaim, callerClientID)
 	if err != nil {
 		return nil, err
 	}
@@ -2700,7 +2745,7 @@ func (sm *StateManager) LockExisting(
 //
 // The state the caller resolved before that gap is re-validated on return, so a
 // caller may treat a nil error as "still safe to commit against lockState".
-func (sm *StateManager) acquireLock(ctx context.Context, lockState *LockState, lockType uint32, offset, length uint64, reclaim bool) (*LOCK4denied, error) {
+func (sm *StateManager) acquireLock(ctx context.Context, lockState *LockState, lockType uint32, offset, length uint64, reclaim bool, callerClientID uint64) (*LOCK4denied, error) {
 	lm := sm.lockManagerFor(lockState.FileHandle)
 	if lm == nil {
 		return nil, fmt.Errorf("no lock manager configured")
@@ -2758,7 +2803,7 @@ func (sm *StateManager) acquireLock(ctx context.Context, lockState *LockState, l
 	// the server no longer knows, and would strand the byte-range lock just
 	// inserted with no NFSv4 state left to ever release it. Give the lock back
 	// and fail the operation instead.
-	if staleErr := sm.revalidateLockStateLocked(lockState); staleErr != nil {
+	if staleErr := sm.revalidateLockStateLocked(lockState, callerClientID); staleErr != nil {
 		if denied == nil {
 			sm.mu.Unlock()
 			_ = lm.RemoveUnifiedLock(handleKey, owner, offset, length)
@@ -2771,9 +2816,11 @@ func (sm *StateManager) acquireLock(ctx context.Context, lockState *LockState, l
 }
 
 // revalidateLockStateLocked reports whether the lock state and its lock-owner
-// are still the records the StateManager's maps point at. It is the recommit
-// check for a path that resolves state under sm.mu, releases the mutex for an
-// external call, and then writes a result back.
+// are still the records the StateManager's maps point at, and whether the
+// lock-owner belongs to the calling client. It is both the admission check for
+// a lock stateid arriving from the wire and the recommit check for a path that
+// resolves state under sm.mu, releases the mutex for an external call, and then
+// writes a result back — the same three facts have to hold at both points.
 //
 // The comparison is by pointer identity, not by presence: a stateid "other" and
 // a lock-owner key can both be handed out again once the original records are
@@ -2786,14 +2833,21 @@ func (sm *StateManager) acquireLock(ctx context.Context, lockState *LockState, l
 // live lock state implies a live open.
 //
 // Caller must hold sm.mu.
-func (sm *StateManager) revalidateLockStateLocked(lockState *LockState) error {
+func (sm *StateManager) revalidateLockStateLocked(lockState *LockState, callerClientID uint64) error {
 	if sm.lockStateByOther[lockState.Stateid.Other] != lockState {
 		return sm.lockStateidMissError(lockState.Stateid.Other)
 	}
-	if lo := lockState.LockOwner; lo == nil || sm.lockOwners[lo.Key()] != lo {
+	lockOwner := lockState.LockOwner
+	if lockOwner == nil || sm.lockOwners[lockOwner.Key()] != lockOwner {
 		return ErrBadStateid
 	}
-	return nil
+
+	// A stateid is not a bearer token: a client presenting another client's lock
+	// stateid could otherwise unlock, or lock inside, a byte range it has no
+	// state on (RFC 8881 Section 18.38.3). A zero callerClientID means the
+	// caller has no trusted client identity, which is every NFSv4.0 request;
+	// see checkStateidOwner.
+	return checkStateidOwner(callerClientID, lockOwner.ClientID)
 }
 
 // acquireUnifiedLock performs the cross-protocol half of a byte-range lock
@@ -2982,6 +3036,7 @@ func (sm *StateManager) TestLock(
 func (sm *StateManager) UnlockFile(
 	lockStateid *types.Stateid4, seqid uint32,
 	lockType uint32, offset, length uint64,
+	callerClientID uint64,
 ) (result *LockResult, err error) {
 	// Special stateids cannot be used with LOCKU
 	if lockStateid.IsSpecialStateid() {
@@ -2991,10 +3046,15 @@ func (sm *StateManager) UnlockFile(
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
-	// 1. Look up lock state
+	// 1. Look up lock state. As in LockExisting, the same check runs again on
+	// recommit; here it rejects a stateid that is not the caller's before the
+	// lock manager is touched.
 	lockState, exists := sm.lockStateByOther[lockStateid.Other]
 	if !exists {
 		return nil, sm.lockStateidMissError(lockStateid.Other)
+	}
+	if err := sm.revalidateLockStateLocked(lockState, callerClientID); err != nil {
+		return nil, err
 	}
 
 	lockOwner := lockState.LockOwner
@@ -3077,7 +3137,7 @@ func (sm *StateManager) UnlockFile(
 		// released. Removing the lock was the direction LOCKU was heading
 		// anyway, so it stands; the seqid bump below must not be committed onto
 		// state the server has since forgotten.
-		if staleErr := sm.revalidateLockStateLocked(lockState); staleErr != nil {
+		if staleErr := sm.revalidateLockStateLocked(lockState, callerClientID); staleErr != nil {
 			return nil, staleErr
 		}
 	}

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -1955,7 +1955,10 @@ func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32, callerC
 		// The state was already removed by a prior CLOSE. If this is a
 		// retransmit of that CLOSE (same owner-seqid), replay its cached reply
 		// (RFC 7530 §9.1.7) rather than returning NFS4ERR_BAD_STATEID.
-		if owner, ok := sm.closedOwnerByOther[stateid.Other]; ok && seqid != 0 {
+		// The cached reply belongs to the owner that sent the original CLOSE, so
+		// it is only replayed to that owner's client; see checkStateidOwner.
+		if owner, ok := sm.closedOwnerByOther[stateid.Other]; ok && seqid != 0 &&
+			checkStateidOwner(callerClientID, owner.ClientID) == nil {
 			if owner.ValidateSeqID(seqid) == SeqIDReplay && owner.LastResult != nil {
 				return nil, &ReplayError{Status: owner.LastResult.Status, Data: owner.LastResult.Data}
 			}

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -1848,9 +1848,7 @@ func (sm *StateManager) ConfirmOpen(stateid *types.Stateid4, seqid uint32, calle
 	}
 
 	// A stateid is not a bearer token: reject one that names another client's
-	// state before acting on it (RFC 8881 Section 18.38.3). A zero
-	// callerClientID means the caller has no trusted client identity, which is
-	// every NFSv4.0 request; see checkStateidOwner.
+	// state before acting on it; see checkStateidOwner.
 	if err := checkStateidOwner(callerClientID, openState.Owner.ClientID); err != nil {
 		return nil, err
 	}
@@ -1921,8 +1919,8 @@ func (sm *StateManager) ConfirmOpenV41(stateid *types.Stateid4, callerClientID u
 		}
 	}
 
-	// See ConfirmOpen: a stateid that names another client's open must not be
-	// confirmed through this caller.
+	// A stateid is not a bearer token: another client's open must not be
+	// confirmed through this caller; see checkStateidOwner.
 	if err := checkStateidOwner(callerClientID, openState.Owner.ClientID); err != nil {
 		return err
 	}
@@ -1972,9 +1970,7 @@ func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32, callerC
 	}
 
 	// A stateid is not a bearer token: reject one that names another client's
-	// state before acting on it (RFC 8881 Section 18.38.3). A zero
-	// callerClientID means the caller has no trusted client identity, which is
-	// every NFSv4.0 request; see checkStateidOwner.
+	// state before acting on it; see checkStateidOwner.
 	if err := checkStateidOwner(callerClientID, openState.Owner.ClientID); err != nil {
 		return nil, err
 	}
@@ -2161,9 +2157,7 @@ func (sm *StateManager) DowngradeOpen(stateid *types.Stateid4, seqid uint32, new
 	}
 
 	// A stateid is not a bearer token: reject one that names another client's
-	// state before acting on it (RFC 8881 Section 18.38.3). A zero
-	// callerClientID means the caller has no trusted client identity, which is
-	// every NFSv4.0 request; see checkStateidOwner.
+	// state before acting on it; see checkStateidOwner.
 	if err := checkStateidOwner(callerClientID, openState.Owner.ClientID); err != nil {
 		return nil, err
 	}
@@ -2454,9 +2448,7 @@ func (sm *StateManager) LockNew(
 	}
 
 	// A stateid is not a bearer token: reject one that names another client's
-	// state before acting on it (RFC 8881 Section 18.38.3). A zero
-	// callerClientID means the caller has no trusted client identity, which is
-	// every NFSv4.0 request; see checkStateidOwner.
+	// state before acting on it; see checkStateidOwner.
 	if err := checkStateidOwner(callerClientID, openState.Owner.ClientID); err != nil {
 		return nil, err
 	}
@@ -2844,9 +2836,7 @@ func (sm *StateManager) revalidateLockStateLocked(lockState *LockState, callerCl
 
 	// A stateid is not a bearer token: a client presenting another client's lock
 	// stateid could otherwise unlock, or lock inside, a byte range it has no
-	// state on (RFC 8881 Section 18.38.3). A zero callerClientID means the
-	// caller has no trusted client identity, which is every NFSv4.0 request;
-	// see checkStateidOwner.
+	// state on; see checkStateidOwner.
 	return checkStateidOwner(callerClientID, lockOwner.ClientID)
 }
 

--- a/internal/adapter/nfs/v4/state/open_files_test.go
+++ b/internal/adapter/nfs/v4/state/open_files_test.go
@@ -46,7 +46,7 @@ func TestEnumerateOpenFiles_OpenThenClose(t *testing.T) {
 	}
 
 	// Last close of A drops it from the enumeration.
-	if _, err := sm.CloseFile(&sidA, 3); err != nil {
+	if _, err := sm.CloseFile(&sidA, 3, 0); err != nil {
 		t.Fatalf("CloseFile: %v", err)
 	}
 	got = enumerateHandles(t, sm)

--- a/internal/adapter/nfs/v4/state/replay_cache_test.go
+++ b/internal/adapter/nfs/v4/state/replay_cache_test.go
@@ -150,7 +150,6 @@ func TestReplay_Lock_ReturnsCachedReply(t *testing.T) {
 
 	// LOCK (new lock-owner) at lock seqid 1.
 	res, err := sm.LockNew(context.Background(), clientID, []byte("lock-replay-owner"), 1, openStateid, openSeqid+1, fh, types.WRITE_LT, 0, 100, false, 0)
-
 	if err != nil {
 		t.Fatalf("LockNew: %v", err)
 	}
@@ -176,7 +175,6 @@ func TestReplay_LockU_ReturnsCachedReply(t *testing.T) {
 	clientID, fh, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
 	res, err := sm.LockNew(context.Background(), clientID, []byte("locku-replay-owner"), 1, openStateid, openSeqid+1, fh, types.WRITE_LT, 0, 100, false, 0)
-
 	if err != nil {
 		t.Fatalf("LockNew: %v", err)
 	}

--- a/internal/adapter/nfs/v4/state/replay_cache_test.go
+++ b/internal/adapter/nfs/v4/state/replay_cache_test.go
@@ -52,7 +52,7 @@ func setupConfirmedOpen(t *testing.T, sm *StateManager, ownerData []byte, fh []b
 	if err != nil {
 		t.Fatalf("OpenFile: %v", err)
 	}
-	confirmed, err := sm.ConfirmOpen(&open.Stateid, 2)
+	confirmed, err := sm.ConfirmOpen(&open.Stateid, 2, 0)
 	if err != nil {
 		t.Fatalf("ConfirmOpen: %v", err)
 	}
@@ -71,7 +71,7 @@ func TestReplay_Close_ReturnsCachedReply(t *testing.T) {
 	stateid, clientID := setupConfirmedOpen(t, sm, owner, []byte("fh-close"), types.OPEN4_SHARE_ACCESS_BOTH)
 
 	// CLOSE at seqid 3 (next open-owner seqid).
-	closed, err := sm.CloseFile(stateid, 3)
+	closed, err := sm.CloseFile(stateid, 3, 0)
 	if err != nil {
 		t.Fatalf("CloseFile: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestReplay_Close_ReturnsCachedReply(t *testing.T) {
 
 	// Retransmit CLOSE at the SAME seqid -> must replay the cached reply,
 	// not NFS4ERR_BAD_SEQID (which would happen with the old single-OPEN cache).
-	_, err = sm.CloseFile(stateid, 3)
+	_, err = sm.CloseFile(stateid, 3, 0)
 	mustReplay(t, err, types.NFS4_OK, cachedReply)
 }
 
@@ -91,7 +91,7 @@ func TestReplay_OpenDowngrade_ReturnsCachedReply(t *testing.T) {
 	owner := []byte("downgrade-replay-owner")
 	stateid, clientID := setupConfirmedOpen(t, sm, owner, []byte("fh-downgrade"), types.OPEN4_SHARE_ACCESS_BOTH)
 
-	dg, err := sm.DowngradeOpen(stateid, 3, types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE)
+	dg, err := sm.DowngradeOpen(stateid, 3, types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, 0)
 	if err != nil {
 		t.Fatalf("DowngradeOpen: %v", err)
 	}
@@ -100,7 +100,7 @@ func TestReplay_OpenDowngrade_ReturnsCachedReply(t *testing.T) {
 
 	// A second DOWNGRADE that would advance the stateid seqid must NOT run on a
 	// replay; the original encoded reply is returned verbatim.
-	_, err = sm.DowngradeOpen(stateid, 3, types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE)
+	_, err = sm.DowngradeOpen(stateid, 3, types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, 0)
 	mustReplay(t, err, types.NFS4_OK, cachedReply)
 }
 
@@ -124,7 +124,7 @@ func TestReplay_OpenConfirm_ReturnsCachedReply(t *testing.T) {
 		t.Fatalf("OpenFile: %v", err)
 	}
 
-	confirmed, err := sm.ConfirmOpen(&open.Stateid, 2)
+	confirmed, err := sm.ConfirmOpen(&open.Stateid, 2, 0)
 	if err != nil {
 		t.Fatalf("ConfirmOpen: %v", err)
 	}
@@ -132,7 +132,7 @@ func TestReplay_OpenConfirm_ReturnsCachedReply(t *testing.T) {
 	sm.CacheOpenOwnerResult(res.ClientID, confirmed.OwnerData, types.NFS4_OK, cachedReply)
 
 	// Retransmit OPEN_CONFIRM at seqid 2.
-	_, err = sm.ConfirmOpen(&open.Stateid, 2)
+	_, err = sm.ConfirmOpen(&open.Stateid, 2, 0)
 	mustReplay(t, err, types.NFS4_OK, cachedReply)
 }
 
@@ -149,8 +149,8 @@ func TestReplay_Lock_ReturnsCachedReply(t *testing.T) {
 	clientID, fh, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
 	// LOCK (new lock-owner) at lock seqid 1.
-	res, err := sm.LockNew(context.Background(), clientID, []byte("lock-replay-owner"), 1,
-		openStateid, openSeqid+1, fh, types.WRITE_LT, 0, 100, false)
+	res, err := sm.LockNew(context.Background(), clientID, []byte("lock-replay-owner"), 1, openStateid, openSeqid+1, fh, types.WRITE_LT, 0, 100, false, 0)
+
 	if err != nil {
 		t.Fatalf("LockNew: %v", err)
 	}
@@ -163,7 +163,7 @@ func TestReplay_Lock_ReturnsCachedReply(t *testing.T) {
 	// Retransmit the LOCK at the SAME lock seqid via the existing-lock-owner
 	// path. The old code returned NFS4ERR_BAD_SEQID here (fatal to the Linux
 	// client -> dropped lock-owner / silent lock loss); it must replay instead.
-	_, err = sm.LockExisting(context.Background(), &res.Stateid, 1, fh, types.WRITE_LT, 0, 100, false)
+	_, err = sm.LockExisting(context.Background(), &res.Stateid, 1, fh, types.WRITE_LT, 0, 100, false, 0)
 	mustReplay(t, err, types.NFS4_OK, cachedReply)
 }
 
@@ -175,14 +175,14 @@ func TestReplay_LockU_ReturnsCachedReply(t *testing.T) {
 
 	clientID, fh, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
-	res, err := sm.LockNew(context.Background(), clientID, []byte("locku-replay-owner"), 1,
-		openStateid, openSeqid+1, fh, types.WRITE_LT, 0, 100, false)
+	res, err := sm.LockNew(context.Background(), clientID, []byte("locku-replay-owner"), 1, openStateid, openSeqid+1, fh, types.WRITE_LT, 0, 100, false, 0)
+
 	if err != nil {
 		t.Fatalf("LockNew: %v", err)
 	}
 
 	// LOCKU at lock seqid 2.
-	unlock, err := sm.UnlockFile(&res.Stateid, 2, types.WRITE_LT, 0, 100)
+	unlock, err := sm.UnlockFile(&res.Stateid, 2, types.WRITE_LT, 0, 100, 0)
 	if err != nil {
 		t.Fatalf("UnlockFile: %v", err)
 	}
@@ -192,7 +192,7 @@ func TestReplay_LockU_ReturnsCachedReply(t *testing.T) {
 	// Retransmit LOCKU: the client resends the ORIGINAL (pre-LOCKU) lock
 	// stateid whose seqid is now one behind. This must be detected as a replay
 	// (returning the cached reply) and not rejected as NFS4ERR_OLD_STATEID.
-	_, err = sm.UnlockFile(&res.Stateid, 2, types.WRITE_LT, 0, 100)
+	_, err = sm.UnlockFile(&res.Stateid, 2, types.WRITE_LT, 0, 100, 0)
 	mustReplay(t, err, types.NFS4_OK, cachedReply)
 }
 
@@ -209,13 +209,13 @@ func TestReplay_Lock_Denied_CachesAndReplays(t *testing.T) {
 
 	// Client 1 holds an exclusive lock on [0,100).
 	c1, _, open1, seq1 := setupClientAndOpenStateNamed(t, sm, "denied-c1", "owner-1", fh)
-	if _, err := sm.LockNew(context.Background(), c1, []byte("lock-owner-1"), 1, open1, seq1+1, fh, types.WRITE_LT, 0, 100, false); err != nil {
+	if _, err := sm.LockNew(context.Background(), c1, []byte("lock-owner-1"), 1, open1, seq1+1, fh, types.WRITE_LT, 0, 100, false, 0); err != nil {
 		t.Fatalf("LockNew c1: %v", err)
 	}
 
 	// Client 2's overlapping LOCK is DENIED.
 	c2, _, open2, seq2 := setupClientAndOpenStateNamed(t, sm, "denied-c2", "owner-2", fh)
-	res, err := sm.LockNew(context.Background(), c2, []byte("lock-owner-2"), 1, open2, seq2+1, fh, types.WRITE_LT, 50, 100, false)
+	res, err := sm.LockNew(context.Background(), c2, []byte("lock-owner-2"), 1, open2, seq2+1, fh, types.WRITE_LT, 50, 100, false, 0)
 	if err != nil {
 		t.Fatalf("LockNew c2: %v", err)
 	}
@@ -227,7 +227,7 @@ func TestReplay_Lock_Denied_CachesAndReplays(t *testing.T) {
 
 	// Retransmit client 2's LOCK at the SAME open+lock seqids -> replay the
 	// cached DENIED reply (both seqids were advanced by the DENIED original).
-	_, err = sm.LockNew(context.Background(), c2, []byte("lock-owner-2"), 1, open2, seq2+1, fh, types.WRITE_LT, 50, 100, false)
+	_, err = sm.LockNew(context.Background(), c2, []byte("lock-owner-2"), 1, open2, seq2+1, fh, types.WRITE_LT, 50, 100, false, 0)
 	mustReplay(t, err, types.NFS4ERR_DENIED, cachedReply)
 }
 
@@ -250,7 +250,7 @@ func setupClientAndOpenStateNamed(t *testing.T, sm *StateManager, clientName, ow
 	if err != nil {
 		t.Fatalf("OpenFile %s: %v", clientName, err)
 	}
-	confirmed, err := sm.ConfirmOpen(&open.Stateid, 2)
+	confirmed, err := sm.ConfirmOpen(&open.Stateid, 2, 0)
 	if err != nil {
 		t.Fatalf("ConfirmOpen %s: %v", clientName, err)
 	}

--- a/internal/adapter/nfs/v4/state/session_test.go
+++ b/internal/adapter/nfs/v4/state/session_test.go
@@ -1069,11 +1069,7 @@ func TestReaper_ExpiredLeaseReleasesOpenState(t *testing.T) {
 
 	// A byte-range lock on top of the open: seqid 0 is the v4.1 bypass, the
 	// slot table provides the replay protection the seqids give v4.0.
-	if _, err := sm.LockNew(context.Background(),
-		clientID, []byte("lock-owner-a"), 0,
-		&open.Stateid, 0,
-		fh, types.WRITE_LT, 0, 100, false,
-	); err != nil {
+	if _, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner-a"), 0, &open.Stateid, 0, fh, types.WRITE_LT, 0, 100, false, 0); err != nil {
 		t.Fatalf("LockNew error: %v", err)
 	}
 	if got := len(lm.ListUnifiedLocks(string(fh))); got != 1 {

--- a/internal/adapter/nfs/v4/state/shareres_test.go
+++ b/internal/adapter/nfs/v4/state/shareres_test.go
@@ -21,7 +21,7 @@ func openConfirmed(t *testing.T, sm *StateManager, clientID uint64, owner, fileH
 	if err != nil {
 		t.Fatalf("OpenFile(%s): %v", owner, err)
 	}
-	confirmed, err := sm.ConfirmOpen(&res.Stateid, 2)
+	confirmed, err := sm.ConfirmOpen(&res.Stateid, 2, 0)
 	if err != nil {
 		t.Fatalf("ConfirmOpen(%s): %v", owner, err)
 	}
@@ -136,7 +136,7 @@ func TestOpenFile_ShareDeny_ReleasedAfterClose(t *testing.T) {
 	// Owner A opens with DENY_WRITE then closes.
 	aStateid := openConfirmed(t, sm, 0, []byte("ownerA"), fh,
 		types.OPEN4_SHARE_ACCESS_WRITE, types.OPEN4_SHARE_DENY_WRITE)
-	if _, err := sm.CloseFile(&aStateid, 3); err != nil {
+	if _, err := sm.CloseFile(&aStateid, 3, 0); err != nil {
 		t.Fatalf("CloseFile: %v", err)
 	}
 

--- a/internal/adapter/nfs/v4/state/stateid.go
+++ b/internal/adapter/nfs/v4/state/stateid.go
@@ -636,14 +636,20 @@ func (sm *StateManager) freeDelegStateidLocked(clientID uint64, stateid *types.S
 // This is a read-only operation with no side effects: it does NOT renew leases
 // (Pitfall 5 from research).
 //
+// A stateid belonging to another client is reported as NFS4ERR_BAD_STATEID
+// rather than as valid, so the operation cannot be used as an existence oracle
+// for state the caller has no claim to. As everywhere else, a zero
+// callerClientID (every NFSv4.0 request) skips that comparison; see
+// checkStateidOwner.
+//
 // Caller must NOT hold sm.mu.
-func (sm *StateManager) TestStateids(stateids []types.Stateid4) []uint32 {
+func (sm *StateManager) TestStateids(stateids []types.Stateid4, callerClientID uint64) []uint32 {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
 
 	results := make([]uint32, len(stateids))
 	for i := range stateids {
-		results[i] = sm.testSingleStateid(&stateids[i])
+		results[i] = sm.testSingleStateid(&stateids[i], callerClientID)
 	}
 
 	logger.Debug("TEST_STATEID: tested stateids",
@@ -655,7 +661,7 @@ func (sm *StateManager) TestStateids(stateids []types.Stateid4) []uint32 {
 // testSingleStateid validates a single stateid without lease renewal.
 // Returns the NFS4 status code for the stateid.
 // Caller must hold sm.mu.RLock.
-func (sm *StateManager) testSingleStateid(stateid *types.Stateid4) uint32 {
+func (sm *StateManager) testSingleStateid(stateid *types.Stateid4, callerClientID uint64) uint32 {
 	// Special stateids are always valid
 	if stateid.IsSpecialStateid() {
 		return types.NFS4_OK
@@ -670,11 +676,11 @@ func (sm *StateManager) testSingleStateid(stateid *types.Stateid4) uint32 {
 
 	switch stateType {
 	case StateTypeOpen:
-		return sm.testOpenStateid(stateid)
+		return sm.testOpenStateid(stateid, callerClientID)
 	case StateTypeLock:
-		return sm.testLockStateid(stateid)
+		return sm.testLockStateid(stateid, callerClientID)
 	case StateTypeDeleg:
-		return sm.testDelegStateid(stateid)
+		return sm.testDelegStateid(stateid, callerClientID)
 	default:
 		return types.NFS4ERR_BAD_STATEID
 	}
@@ -682,9 +688,12 @@ func (sm *StateManager) testSingleStateid(stateid *types.Stateid4) uint32 {
 
 // testOpenStateid validates an open stateid without lease renewal.
 // Caller must hold sm.mu.RLock.
-func (sm *StateManager) testOpenStateid(stateid *types.Stateid4) uint32 {
+func (sm *StateManager) testOpenStateid(stateid *types.Stateid4, callerClientID uint64) uint32 {
 	openState, exists := sm.openStateByOther[stateid.Other]
 	if !exists {
+		return types.NFS4ERR_BAD_STATEID
+	}
+	if err := checkStateidOwner(callerClientID, openState.Owner.ClientID); err != nil {
 		return types.NFS4ERR_BAD_STATEID
 	}
 
@@ -711,9 +720,12 @@ func (sm *StateManager) testOpenStateid(stateid *types.Stateid4) uint32 {
 
 // testLockStateid validates a lock stateid without lease renewal.
 // Caller must hold sm.mu.RLock.
-func (sm *StateManager) testLockStateid(stateid *types.Stateid4) uint32 {
+func (sm *StateManager) testLockStateid(stateid *types.Stateid4, callerClientID uint64) uint32 {
 	lockState, exists := sm.lockStateByOther[stateid.Other]
 	if !exists {
+		return types.NFS4ERR_BAD_STATEID
+	}
+	if err := checkStateidOwner(callerClientID, lockState.LockOwner.ClientID); err != nil {
 		return types.NFS4ERR_BAD_STATEID
 	}
 
@@ -732,9 +744,12 @@ func (sm *StateManager) testLockStateid(stateid *types.Stateid4) uint32 {
 
 // testDelegStateid validates a delegation stateid without lease renewal.
 // Caller must hold sm.mu.RLock.
-func (sm *StateManager) testDelegStateid(stateid *types.Stateid4) uint32 {
+func (sm *StateManager) testDelegStateid(stateid *types.Stateid4, callerClientID uint64) uint32 {
 	deleg, exists := sm.delegByOther[stateid.Other]
 	if !exists {
+		return types.NFS4ERR_BAD_STATEID
+	}
+	if err := checkStateidOwner(callerClientID, deleg.ClientID); err != nil {
 		return types.NFS4ERR_BAD_STATEID
 	}
 

--- a/internal/adapter/nfs/v4/state/stateid.go
+++ b/internal/adapter/nfs/v4/state/stateid.go
@@ -638,9 +638,7 @@ func (sm *StateManager) freeDelegStateidLocked(clientID uint64, stateid *types.S
 //
 // A stateid belonging to another client is reported as NFS4ERR_BAD_STATEID
 // rather than as valid, so the operation cannot be used as an existence oracle
-// for state the caller has no claim to. As everywhere else, a zero
-// callerClientID (every NFSv4.0 request) skips that comparison; see
-// checkStateidOwner.
+// for state the caller has no claim to; see checkStateidOwner.
 //
 // Caller must NOT hold sm.mu.
 func (sm *StateManager) TestStateids(stateids []types.Stateid4, callerClientID uint64) []uint32 {

--- a/internal/adapter/nfs/v4/state/stateid_authz_state_ops_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_authz_state_ops_test.go
@@ -1,0 +1,197 @@
+package state
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// The I/O operations resolve a stateid through ValidateStateid, which compares
+// the owning client. The state-changing operations resolve it themselves, and
+// these tests pin that they compare too.
+//
+// Each subtest asserts the same three things, because all three are part of the
+// rule: another client is refused NFS4ERR_BAD_STATEID, the owning client is
+// still served, and a caller with no trusted client identity — every NFSv4.0
+// request, which carries no clientid4 and has no session to derive one from —
+// is served as before.
+//
+// The refusals also double as a check that NFS4ERR_BAD_STATEID leaves the
+// owner's sequence untouched (RFC 7530 Section 9.1.7): every "owning client"
+// leg reuses the seqid the refused call was made with.
+
+const (
+	authzClientA uint64 = 0xA11CE
+	authzClientB uint64 = 0xB0B
+)
+
+// newConfirmedOpen opens and confirms a file for clientID, returning the
+// confirmed open stateid and the seqid the next operation on that owner must
+// use.
+func newConfirmedOpen(t *testing.T, sm *StateManager, clientID uint64, fh []byte) (types.Stateid4, uint32) {
+	t.Helper()
+	openResult, err := sm.OpenFile(clientID, []byte("owner-a"), 1, fh,
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	confirmed, err := sm.ConfirmOpen(&openResult.Stateid, 2, clientID)
+	if err != nil {
+		t.Fatalf("ConfirmOpen: %v", err)
+	}
+	return confirmed.Stateid, 3
+}
+
+func TestOpenConfirm_CrossClient(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	defer sm.Shutdown()
+
+	openResult, err := sm.OpenFile(authzClientA, []byte("owner-a"), 1, []byte("fh-confirm"),
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	sid := openResult.Stateid
+
+	if _, err := sm.ConfirmOpen(&sid, 2, authzClientB); !isStatus(err, types.NFS4ERR_BAD_STATEID) {
+		t.Errorf("client B confirming client A's open: err = %v, want NFS4ERR_BAD_STATEID", err)
+	}
+	if _, err := sm.ConfirmOpen(&sid, 2, authzClientA); err != nil {
+		t.Errorf("owning client rejected: %v", err)
+	}
+}
+
+func TestOpenConfirmV41_CrossClient(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	defer sm.Shutdown()
+
+	openResult, err := sm.OpenFile(authzClientA, []byte("owner-a"), 1, []byte("fh-confirm-v41"),
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	sid := openResult.Stateid
+
+	if err := sm.ConfirmOpenV41(&sid, authzClientB); !isStatus(err, types.NFS4ERR_BAD_STATEID) {
+		t.Errorf("client B auto-confirming client A's open: err = %v, want NFS4ERR_BAD_STATEID", err)
+	}
+	if err := sm.ConfirmOpenV41(&sid, authzClientA); err != nil {
+		t.Errorf("owning client rejected: %v", err)
+	}
+	if err := sm.ConfirmOpenV41(&sid, 0); err != nil {
+		t.Errorf("NFSv4.0 caller (no client identity) rejected: %v", err)
+	}
+}
+
+func TestOpenDowngrade_CrossClient(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	defer sm.Shutdown()
+
+	sid, seqid := newConfirmedOpen(t, sm, authzClientA, []byte("fh-downgrade"))
+
+	if _, err := sm.DowngradeOpen(&sid, seqid, types.OPEN4_SHARE_ACCESS_READ,
+		types.OPEN4_SHARE_DENY_NONE, authzClientB); !isStatus(err, types.NFS4ERR_BAD_STATEID) {
+		t.Errorf("client B downgrading client A's open: err = %v, want NFS4ERR_BAD_STATEID", err)
+	}
+	if _, err := sm.DowngradeOpen(&sid, seqid, types.OPEN4_SHARE_ACCESS_READ,
+		types.OPEN4_SHARE_DENY_NONE, authzClientA); err != nil {
+		t.Errorf("owning client rejected: %v", err)
+	}
+}
+
+func TestClose_CrossClient(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	defer sm.Shutdown()
+
+	sid, seqid := newConfirmedOpen(t, sm, authzClientA, []byte("fh-close"))
+
+	if _, err := sm.CloseFile(&sid, seqid, authzClientB); !isStatus(err, types.NFS4ERR_BAD_STATEID) {
+		t.Errorf("client B closing client A's open: err = %v, want NFS4ERR_BAD_STATEID", err)
+	}
+	if _, err := sm.CloseFile(&sid, seqid, authzClientA); err != nil {
+		t.Errorf("owning client rejected: %v", err)
+	}
+}
+
+// TestLockNew_CrossClientOpenStateid is the sharpest of these: without the
+// comparison a client can take a byte-range lock through another client's open,
+// because LockNew resolves the open stateid but keys the lock-owner by the
+// client ID it was handed.
+func TestLockNew_CrossClientOpenStateid(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	sm.SetLockManager(lock.NewManager())
+	defer sm.Shutdown()
+
+	fh := []byte("fh-locknew-cross")
+	sid, seqid := newConfirmedOpen(t, sm, authzClientA, fh)
+
+	_, err := sm.LockNew(context.Background(),
+		authzClientB, []byte("owner-b"), 1, &sid, seqid,
+		fh, types.WRITE_LT, 0, 100, false, authzClientB)
+	if !isStatus(err, types.NFS4ERR_BAD_STATEID) {
+		t.Errorf("client B locking through client A's open: err = %v, want NFS4ERR_BAD_STATEID", err)
+	}
+
+	res, err := sm.LockNew(context.Background(),
+		authzClientA, []byte("owner-a"), 1, &sid, seqid,
+		fh, types.WRITE_LT, 0, 100, false, authzClientA)
+	if err != nil || res.Denied != nil {
+		t.Fatalf("owning client rejected: err = %v denied = %v", err, res)
+	}
+
+	if _, err := sm.LockExisting(context.Background(), &res.Stateid, 2,
+		fh, types.WRITE_LT, 200, 100, false, authzClientB); !isStatus(err, types.NFS4ERR_BAD_STATEID) {
+		t.Errorf("client B extending client A's lock: err = %v, want NFS4ERR_BAD_STATEID", err)
+	}
+	if _, err := sm.UnlockFile(&res.Stateid, 2, types.WRITE_LT, 0, 100,
+		authzClientB); !isStatus(err, types.NFS4ERR_BAD_STATEID) {
+		t.Errorf("client B unlocking client A's lock: err = %v, want NFS4ERR_BAD_STATEID", err)
+	}
+	if _, err := sm.UnlockFile(&res.Stateid, 2, types.WRITE_LT, 0, 100, authzClientA); err != nil {
+		t.Errorf("owning client rejected on LOCKU: %v", err)
+	}
+}
+
+// TestTestStateids_CrossClient pins that TEST_STATEID is not an existence
+// oracle for another client's state, in all three stateid families.
+func TestTestStateids_CrossClient(t *testing.T) {
+	probe := func(t *testing.T, sm *StateManager, sid types.Stateid4) {
+		t.Helper()
+		if got := sm.TestStateids([]types.Stateid4{sid}, authzClientB); got[0] != types.NFS4ERR_BAD_STATEID {
+			t.Errorf("client B probing client A's stateid: got %d, want NFS4ERR_BAD_STATEID", got[0])
+		}
+		if got := sm.TestStateids([]types.Stateid4{sid}, authzClientA); got[0] != types.NFS4_OK {
+			t.Errorf("owning client rejected: got %d", got[0])
+		}
+		if got := sm.TestStateids([]types.Stateid4{sid}, 0); got[0] != types.NFS4_OK {
+			t.Errorf("NFSv4.0 caller (no client identity) rejected: got %d", got[0])
+		}
+	}
+
+	t.Run("open stateid", func(t *testing.T) {
+		sm := NewStateManager(90 * time.Second)
+		defer sm.Shutdown()
+		sid, _ := newConfirmedOpen(t, sm, authzClientA, []byte("fh-test-open"))
+		probe(t, sm, sid)
+	})
+
+	t.Run("lock stateid", func(t *testing.T) {
+		sm := NewStateManager(90 * time.Second)
+		sm.SetLockManager(lock.NewManager())
+		defer sm.Shutdown()
+		probe(t, sm, newLockedFile(t, sm, authzClientA, []byte("fh-test-lock")))
+	})
+
+	t.Run("delegation stateid", func(t *testing.T) {
+		sm := NewStateManager(90 * time.Second)
+		defer sm.Shutdown()
+		deleg := sm.GrantDelegation(authzClientA, []byte("fh-test-deleg"), types.OPEN_DELEGATE_READ)
+		if deleg == nil {
+			t.Fatal("GrantDelegation returned nil")
+		}
+		probe(t, sm, deleg.Stateid)
+	})
+}

--- a/internal/adapter/nfs/v4/state/stateid_authz_state_ops_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_authz_state_ops_test.go
@@ -13,11 +13,12 @@ import (
 // the owning client. The state-changing operations resolve it themselves, and
 // these tests pin that they compare too.
 //
-// Each subtest asserts the same three things, because all three are part of the
-// rule: another client is refused NFS4ERR_BAD_STATEID, the owning client is
-// still served, and a caller with no trusted client identity — every NFSv4.0
-// request, which carries no clientid4 and has no session to derive one from —
-// is served as before.
+// Each test asserts two halves of the rule: another client is refused
+// NFS4ERR_BAD_STATEID, and the owning client is still served. The third half —
+// a caller with no trusted client identity, every NFSv4.0 request, which
+// carries no clientid4 and has no session to derive one from, is served as
+// before — is what the rest of this package's tests pass 0 for; it is asserted
+// explicitly here only for the operations that have no other coverage of it.
 //
 // The refusals also double as a check that NFS4ERR_BAD_STATEID leaves the
 // owner's sequence untouched (RFC 7530 Section 9.1.7): every "owning client"
@@ -116,11 +117,12 @@ func TestClose_CrossClient(t *testing.T) {
 	}
 }
 
-// TestLockNew_CrossClientOpenStateid is the sharpest of these: without the
-// comparison a client can take a byte-range lock through another client's open,
-// because LockNew resolves the open stateid but keys the lock-owner by the
-// client ID it was handed.
-func TestLockNew_CrossClientOpenStateid(t *testing.T) {
+// TestLock_CrossClient covers LOCK on both paths and LOCKU. The open_to_lock
+// path is the sharpest case of all of these: without the comparison a client
+// can take a byte-range lock through another client's open, because LockNew
+// resolves the open stateid but keys the lock-owner by the client ID it was
+// handed.
+func TestLock_CrossClient(t *testing.T) {
 	sm := NewStateManager(90 * time.Second)
 	sm.SetLockManager(lock.NewManager())
 	defer sm.Shutdown()

--- a/internal/adapter/nfs/v4/state/stateid_authz_state_ops_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_authz_state_ops_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -115,6 +116,35 @@ func TestClose_CrossClient(t *testing.T) {
 	if _, err := sm.CloseFile(&sid, seqid, authzClientA); err != nil {
 		t.Errorf("owning client rejected: %v", err)
 	}
+
+	// The open is gone now, so a repeat CLOSE takes the already-closed branch,
+	// which replays the cached reply. That reply is the owner's, so another
+	// client must not be handed it either.
+	//
+	// The reply itself is cached by the handler layer, which is not in play in a
+	// StateManager test, so it is seeded here to reach the branch at all.
+	sm.mu.Lock()
+	closed := sm.closedOwnerByOther[sid.Other]
+	sm.mu.Unlock()
+	if closed == nil {
+		t.Fatal("CLOSE left no closed-owner entry to replay from")
+	}
+	closed.LastResult = &CachedResult{
+		Status: types.NFS4_OK,
+		Data:   encodeStatusReply(types.NFS4_OK),
+	}
+
+	if _, err := sm.CloseFile(&sid, seqid, authzClientB); !isStatus(err, types.NFS4ERR_BAD_STATEID) {
+		t.Errorf("client B replaying client A's CLOSE reply: err = %v, want NFS4ERR_BAD_STATEID", err)
+	}
+	if _, err := sm.CloseFile(&sid, seqid, authzClientA); !isReplay(err) {
+		t.Errorf("owning client denied its own CLOSE replay: %v", err)
+	}
+}
+
+func isReplay(err error) bool {
+	var replay *ReplayError
+	return errors.As(err, &replay)
 }
 
 // TestLock_CrossClient covers LOCK on both paths and LOCKU. The open_to_lock

--- a/internal/adapter/nfs/v4/state/stateid_authz_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_authz_test.go
@@ -27,7 +27,6 @@ func newLockedFile(t *testing.T, sm *StateManager, clientID uint64, fh []byte) t
 		t.Fatalf("ConfirmOpen: %v", err)
 	}
 	lockResult, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner"), 1, &confirmed.Stateid, 3, fh, types.WRITE_LT, 0, 100, false, 0)
-
 	if err != nil {
 		t.Fatalf("LockNew: %v", err)
 	}

--- a/internal/adapter/nfs/v4/state/stateid_authz_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_authz_test.go
@@ -22,15 +22,12 @@ func newLockedFile(t *testing.T, sm *StateManager, clientID uint64, fh []byte) t
 	if err != nil {
 		t.Fatalf("OpenFile: %v", err)
 	}
-	confirmed, err := sm.ConfirmOpen(&openResult.Stateid, 2)
+	confirmed, err := sm.ConfirmOpen(&openResult.Stateid, 2, 0)
 	if err != nil {
 		t.Fatalf("ConfirmOpen: %v", err)
 	}
-	lockResult, err := sm.LockNew(context.Background(),
-		clientID, []byte("lock-owner"), 1,
-		&confirmed.Stateid, 3,
-		fh, types.WRITE_LT, 0, 100, false,
-	)
+	lockResult, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner"), 1, &confirmed.Stateid, 3, fh, types.WRITE_LT, 0, 100, false, 0)
+
 	if err != nil {
 		t.Fatalf("LockNew: %v", err)
 	}
@@ -147,7 +144,7 @@ func TestFreeStateid_CrossClientOpen(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenFile: %v", err)
 	}
-	if _, err := sm.ConfirmOpen(&openResult.Stateid, 2); err != nil {
+	if _, err := sm.ConfirmOpen(&openResult.Stateid, 2, 0); err != nil {
 		t.Fatalf("ConfirmOpen: %v", err)
 	}
 
@@ -218,7 +215,7 @@ func TestLockExisting_V41Seqid0(t *testing.T) {
 	// protection). Extend the lock with a second byte range via LockExisting.
 	v41Stateid := lockStateid
 	v41Stateid.Seqid = 0
-	result, err := sm.LockExisting(context.Background(), &v41Stateid, 0, fh, types.WRITE_LT, 200, 100, false)
+	result, err := sm.LockExisting(context.Background(), &v41Stateid, 0, fh, types.WRITE_LT, 200, 100, false, 0)
 	if err != nil {
 		t.Fatalf("LockExisting with v4.1 stateid seqid=0: %v", err)
 	}
@@ -244,14 +241,14 @@ func TestUnlockFile_V41Seqid0(t *testing.T) {
 	// the LOCKU below is unambiguously after a seqid increment.
 	v41Lock := lockStateid
 	v41Lock.Seqid = 0
-	if _, err := sm.LockExisting(context.Background(), &v41Lock, 0, fh, types.WRITE_LT, 200, 100, false); err != nil {
+	if _, err := sm.LockExisting(context.Background(), &v41Lock, 0, fh, types.WRITE_LT, 200, 100, false, 0); err != nil {
 		t.Fatalf("LockExisting setup: %v", err)
 	}
 
 	// v4.1 LOCKU: stateid seqid=0, owner seqid=0.
 	unlockStateid := lockStateid
 	unlockStateid.Seqid = 0
-	if _, err := sm.UnlockFile(&unlockStateid, 0, types.WRITE_LT, 0, 100); err != nil {
+	if _, err := sm.UnlockFile(&unlockStateid, 0, types.WRITE_LT, 0, 100, 0); err != nil {
 		t.Fatalf("UnlockFile with v4.1 stateid seqid=0: %v", err)
 	}
 }
@@ -344,7 +341,7 @@ func TestValidateStateid_CrossClient(t *testing.T) {
 		if err != nil {
 			t.Fatalf("OpenFile: %v", err)
 		}
-		confirmed, err := sm.ConfirmOpen(&openResult.Stateid, 2)
+		confirmed, err := sm.ConfirmOpen(&openResult.Stateid, 2, 0)
 		if err != nil {
 			t.Fatalf("ConfirmOpen: %v", err)
 		}

--- a/internal/adapter/nfs/v4/state/stateid_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_test.go
@@ -878,7 +878,6 @@ func TestDowngradeOpen_Success(t *testing.T) {
 
 	// Downgrade to READ only
 	downgraded, err := sm.DowngradeOpen(&confirmed.Stateid, 3, types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, 0)
-
 	if err != nil {
 		t.Fatalf("DowngradeOpen: %v", err)
 	}
@@ -918,7 +917,6 @@ func TestDowngradeOpen_CannotAddBits(t *testing.T) {
 
 	// Try to "downgrade" to BOTH (adds WRITE bit) - should fail
 	_, err = sm.DowngradeOpen(&confirmed.Stateid, 3, types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, 0)
-
 	if err == nil {
 		t.Fatal("DowngradeOpen should fail when trying to add bits")
 	}
@@ -1154,7 +1152,6 @@ func TestFreeStateid(t *testing.T) {
 
 		// Create lock state
 		lockResult, err := sm.LockNew(context.Background(), 0, []byte("lock-owner1"), 1, confirmedStateid, 3, fh, types.WRITE_LT, 0, 100, false, 0)
-
 		if err != nil {
 			t.Fatalf("LockNew: %v", err)
 		}
@@ -1206,7 +1203,6 @@ func TestFreeStateid(t *testing.T) {
 
 		// Acquire a lock on file1 with the shared lock owner.
 		lock1, err := sm.LockNew(context.Background(), clientID, lockOwnerData, 1, &conf1.Stateid, 4, fh1, types.WRITE_LT, 0, 100, false, 0)
-
 		if err != nil {
 			t.Fatalf("LockNew on fh1: %v", err)
 		}
@@ -1223,7 +1219,6 @@ func TestFreeStateid(t *testing.T) {
 		// Acquire a lock on file2 with the SAME lock owner — this reuses the
 		// existing LockOwner entry in sm.lockOwners and creates a second LockState.
 		lock2, err := sm.LockNew(context.Background(), clientID, lockOwnerData, 3, &open2.Stateid, 5, fh2, types.WRITE_LT, 0, 50, false, 0)
-
 		if err != nil {
 			t.Fatalf("LockNew on fh2: %v", err)
 		}
@@ -1354,7 +1349,6 @@ func TestFreeStateid(t *testing.T) {
 
 		// Create a lock
 		_, err = sm.LockNew(context.Background(), 0, []byte("lock-owner1"), 1, confirmedStateid, 3, fh, types.WRITE_LT, 0, 100, false, 0)
-
 		if err != nil {
 			t.Fatalf("LockNew: %v", err)
 		}
@@ -1522,7 +1516,6 @@ func TestTestStateids(t *testing.T) {
 
 		stateids := []types.Stateid4{result1.Stateid, deleg.Stateid}
 		results := sm.TestStateids(stateids, 0)
-
 		if len(results) != 2 {
 			t.Fatalf("Expected 2 results, got %d", len(results))
 		}
@@ -1559,7 +1552,6 @@ func TestTestStateids(t *testing.T) {
 
 		stateids := []types.Stateid4{openResult.Stateid, invalidStateid, staleStateid}
 		results := sm.TestStateids(stateids, 0)
-
 		if len(results) != 3 {
 			t.Fatalf("Expected 3 results, got %d", len(results))
 		}
@@ -1614,7 +1606,6 @@ func TestTestStateids(t *testing.T) {
 
 		stateids := []types.Stateid4{openResult.Stateid}
 		results := sm.TestStateids(stateids, 0)
-
 		if len(results) != 1 {
 			t.Fatalf("Expected 1 result, got %d", len(results))
 		}
@@ -1659,7 +1650,6 @@ func TestTestStateids(t *testing.T) {
 		// TestStateids should NOT renew the lease
 		stateids := []types.Stateid4{openResult.Stateid}
 		results := sm.TestStateids(stateids, 0)
-
 		if results[0] != types.NFS4_OK {
 			t.Fatalf("TestStateids should return NFS4_OK, got %d", results[0])
 		}

--- a/internal/adapter/nfs/v4/state/stateid_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_test.go
@@ -250,7 +250,7 @@ func TestValidateStateid_OldSeqid(t *testing.T) {
 	}
 
 	// Confirm to increment seqid
-	_, err = sm.ConfirmOpen(&result.Stateid, 2)
+	_, err = sm.ConfirmOpen(&result.Stateid, 2, 0)
 	if err != nil {
 		t.Fatalf("ConfirmOpen: %v", err)
 	}
@@ -444,7 +444,7 @@ func TestValidateStateid_Seqid0_AcceptedAsAny(t *testing.T) {
 	}
 
 	// Confirm to increment seqid to 2
-	_, err = sm.ConfirmOpen(&result.Stateid, 2)
+	_, err = sm.ConfirmOpen(&result.Stateid, 2, 0)
 	if err != nil {
 		t.Fatalf("ConfirmOpen: %v", err)
 	}
@@ -544,7 +544,7 @@ func TestOpenFile_ConfirmedOwer_SecondOpen(t *testing.T) {
 	}
 
 	// Confirm
-	_, err = sm.ConfirmOpen(&result1.Stateid, 2)
+	_, err = sm.ConfirmOpen(&result1.Stateid, 2, 0)
 	if err != nil {
 		t.Fatalf("ConfirmOpen: %v", err)
 	}
@@ -583,7 +583,7 @@ func TestOpenFile_SameFile_ShareAccumulation(t *testing.T) {
 	}
 
 	// Confirm
-	_, err = sm.ConfirmOpen(&result1.Stateid, 2)
+	_, err = sm.ConfirmOpen(&result1.Stateid, 2, 0)
 	if err != nil {
 		t.Fatalf("ConfirmOpen: %v", err)
 	}
@@ -689,7 +689,7 @@ func TestConfirmOpen_Success(t *testing.T) {
 		t.Fatalf("OpenFile: %v", err)
 	}
 
-	confirmed, err := sm.ConfirmOpen(&result.Stateid, 2)
+	confirmed, err := sm.ConfirmOpen(&result.Stateid, 2, 0)
 	if err != nil {
 		t.Fatalf("ConfirmOpen: %v", err)
 	}
@@ -704,7 +704,7 @@ func TestConfirmOpen_BadStateid(t *testing.T) {
 	sm := NewStateManager(90 * time.Second)
 
 	badStateid := &types.Stateid4{Seqid: 1}
-	_, err := sm.ConfirmOpen(badStateid, 1)
+	_, err := sm.ConfirmOpen(badStateid, 1, 0)
 	if err == nil {
 		t.Fatal("ConfirmOpen should fail for unknown stateid")
 	}
@@ -720,7 +720,7 @@ func TestConfirmOpen_BadSeqid(t *testing.T) {
 	}
 
 	// Use wrong seqid (5 instead of expected 2)
-	_, err = sm.ConfirmOpen(&result.Stateid, 5)
+	_, err = sm.ConfirmOpen(&result.Stateid, 5, 0)
 	if err == nil {
 		t.Fatal("ConfirmOpen should fail with bad seqid")
 	}
@@ -741,13 +741,13 @@ func TestCloseFile_Success(t *testing.T) {
 	}
 
 	// Confirm
-	confirmed, err := sm.ConfirmOpen(&result.Stateid, 2)
+	confirmed, err := sm.ConfirmOpen(&result.Stateid, 2, 0)
 	if err != nil {
 		t.Fatalf("ConfirmOpen: %v", err)
 	}
 
 	// Close
-	closed, err := sm.CloseFile(&confirmed.Stateid, 3)
+	closed, err := sm.CloseFile(&confirmed.Stateid, 3, 0)
 	if err != nil {
 		t.Fatalf("CloseFile: %v", err)
 	}
@@ -773,7 +773,7 @@ func TestCloseFile_SpecialStateid(t *testing.T) {
 
 	// Close with anonymous (all-zeros) stateid
 	zeroed := &types.Stateid4{Seqid: 0}
-	closed, err := sm.CloseFile(zeroed, 1)
+	closed, err := sm.CloseFile(zeroed, 1, 0)
 	if err != nil {
 		t.Fatalf("CloseFile with special stateid: %v", err)
 	}
@@ -793,13 +793,13 @@ func TestCloseFile_CleansUpOwner(t *testing.T) {
 	}
 
 	// Confirm
-	confirmed, err := sm.ConfirmOpen(&result.Stateid, 2)
+	confirmed, err := sm.ConfirmOpen(&result.Stateid, 2, 0)
 	if err != nil {
 		t.Fatalf("ConfirmOpen: %v", err)
 	}
 
 	// Close
-	closed, err := sm.CloseFile(&confirmed.Stateid, 3)
+	closed, err := sm.CloseFile(&confirmed.Stateid, 3, 0)
 	if err != nil {
 		t.Fatalf("CloseFile: %v", err)
 	}
@@ -825,7 +825,7 @@ func TestCloseFile_CleansUpOwner(t *testing.T) {
 	}
 
 	// A retransmitted CLOSE at the same seqid must replay the cached reply.
-	_, replayErr := sm.CloseFile(&confirmed.Stateid, 3)
+	_, replayErr := sm.CloseFile(&confirmed.Stateid, 3, 0)
 	var re *ReplayError
 	if !errors.As(replayErr, &re) {
 		t.Fatalf("retransmitted CLOSE should replay, got %T: %v", replayErr, replayErr)
@@ -846,7 +846,7 @@ func TestCloseFile_BadStateid(t *testing.T) {
 	badStateid.Other[3] = byte(sm.bootEpoch)
 	badStateid.Other[4] = 0xFF // unique sequence that doesn't exist
 
-	_, err := sm.CloseFile(badStateid, 1)
+	_, err := sm.CloseFile(badStateid, 1, 0)
 	if err == nil {
 		t.Fatal("CloseFile should fail for unknown stateid")
 	}
@@ -871,16 +871,14 @@ func TestDowngradeOpen_Success(t *testing.T) {
 	}
 
 	// Confirm
-	confirmed, err := sm.ConfirmOpen(&result.Stateid, 2)
+	confirmed, err := sm.ConfirmOpen(&result.Stateid, 2, 0)
 	if err != nil {
 		t.Fatalf("ConfirmOpen: %v", err)
 	}
 
 	// Downgrade to READ only
-	downgraded, err := sm.DowngradeOpen(&confirmed.Stateid, 3,
-		types.OPEN4_SHARE_ACCESS_READ,
-		types.OPEN4_SHARE_DENY_NONE,
-	)
+	downgraded, err := sm.DowngradeOpen(&confirmed.Stateid, 3, types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, 0)
+
 	if err != nil {
 		t.Fatalf("DowngradeOpen: %v", err)
 	}
@@ -913,16 +911,14 @@ func TestDowngradeOpen_CannotAddBits(t *testing.T) {
 	}
 
 	// Confirm
-	confirmed, err := sm.ConfirmOpen(&result.Stateid, 2)
+	confirmed, err := sm.ConfirmOpen(&result.Stateid, 2, 0)
 	if err != nil {
 		t.Fatalf("ConfirmOpen: %v", err)
 	}
 
 	// Try to "downgrade" to BOTH (adds WRITE bit) - should fail
-	_, err = sm.DowngradeOpen(&confirmed.Stateid, 3,
-		types.OPEN4_SHARE_ACCESS_BOTH,
-		types.OPEN4_SHARE_DENY_NONE,
-	)
+	_, err = sm.DowngradeOpen(&confirmed.Stateid, 3, types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, 0)
+
 	if err == nil {
 		t.Fatal("DowngradeOpen should fail when trying to add bits")
 	}
@@ -951,13 +947,13 @@ func TestDowngradeOpen_ZeroAccess(t *testing.T) {
 	}
 
 	// Confirm
-	confirmed, err := sm.ConfirmOpen(&result.Stateid, 2)
+	confirmed, err := sm.ConfirmOpen(&result.Stateid, 2, 0)
 	if err != nil {
 		t.Fatalf("ConfirmOpen: %v", err)
 	}
 
 	// Downgrade to zero access - should fail
-	_, err = sm.DowngradeOpen(&confirmed.Stateid, 3, 0, 0)
+	_, err = sm.DowngradeOpen(&confirmed.Stateid, 3, 0, 0, 0)
 	if err == nil {
 		t.Fatal("DowngradeOpen should fail with zero share_access")
 	}
@@ -1095,7 +1091,7 @@ func TestFullLifecycle_OpenConfirmClose(t *testing.T) {
 	}
 
 	// OPEN_CONFIRM (seqid=2)
-	confirmed, err := sm.ConfirmOpen(&openResult.Stateid, 2)
+	confirmed, err := sm.ConfirmOpen(&openResult.Stateid, 2, 0)
 	if err != nil {
 		t.Fatalf("ConfirmOpen: %v", err)
 	}
@@ -1114,7 +1110,7 @@ func TestFullLifecycle_OpenConfirmClose(t *testing.T) {
 	}
 
 	// CLOSE (seqid=3)
-	closed, err := sm.CloseFile(confirmedStateid, 3)
+	closed, err := sm.CloseFile(confirmedStateid, 3, 0)
 	if err != nil {
 		t.Fatalf("CloseFile: %v", err)
 	}
@@ -1150,18 +1146,15 @@ func TestFreeStateid(t *testing.T) {
 		}
 
 		// Confirm open
-		confirmed, err := sm.ConfirmOpen(&openResult.Stateid, 2)
+		confirmed, err := sm.ConfirmOpen(&openResult.Stateid, 2, 0)
 		if err != nil {
 			t.Fatalf("ConfirmOpen: %v", err)
 		}
 		confirmedStateid := &confirmed.Stateid
 
 		// Create lock state
-		lockResult, err := sm.LockNew(context.Background(),
-			0, []byte("lock-owner1"), 1,
-			confirmedStateid, 3,
-			fh, types.WRITE_LT, 0, 100, false,
-		)
+		lockResult, err := sm.LockNew(context.Background(), 0, []byte("lock-owner1"), 1, confirmedStateid, 3, fh, types.WRITE_LT, 0, 100, false, 0)
+
 		if err != nil {
 			t.Fatalf("LockNew: %v", err)
 		}
@@ -1199,7 +1192,7 @@ func TestFreeStateid(t *testing.T) {
 		if err != nil {
 			t.Fatalf("OpenFile 1: %v", err)
 		}
-		conf1, err := sm.ConfirmOpen(&open1.Stateid, 2)
+		conf1, err := sm.ConfirmOpen(&open1.Stateid, 2, 0)
 		if err != nil {
 			t.Fatalf("ConfirmOpen 1: %v", err)
 		}
@@ -1212,11 +1205,8 @@ func TestFreeStateid(t *testing.T) {
 		// open2 uses a confirmed owner; no OPEN_CONFIRM needed.
 
 		// Acquire a lock on file1 with the shared lock owner.
-		lock1, err := sm.LockNew(context.Background(),
-			clientID, lockOwnerData, 1,
-			&conf1.Stateid, 4,
-			fh1, types.WRITE_LT, 0, 100, false,
-		)
+		lock1, err := sm.LockNew(context.Background(), clientID, lockOwnerData, 1, &conf1.Stateid, 4, fh1, types.WRITE_LT, 0, 100, false, 0)
+
 		if err != nil {
 			t.Fatalf("LockNew on fh1: %v", err)
 		}
@@ -1225,18 +1215,15 @@ func TestFreeStateid(t *testing.T) {
 		}
 
 		// LOCKU to release the actual byte-range lock before FREE_STATEID.
-		_, err = sm.UnlockFile(&lock1.Stateid, 2, types.WRITE_LT, 0, 100)
+		_, err = sm.UnlockFile(&lock1.Stateid, 2, types.WRITE_LT, 0, 100, 0)
 		if err != nil {
 			t.Fatalf("UnlockFile on fh1: %v", err)
 		}
 
 		// Acquire a lock on file2 with the SAME lock owner — this reuses the
 		// existing LockOwner entry in sm.lockOwners and creates a second LockState.
-		lock2, err := sm.LockNew(context.Background(),
-			clientID, lockOwnerData, 3,
-			&open2.Stateid, 5,
-			fh2, types.WRITE_LT, 0, 50, false,
-		)
+		lock2, err := sm.LockNew(context.Background(), clientID, lockOwnerData, 3, &open2.Stateid, 5, fh2, types.WRITE_LT, 0, 50, false, 0)
+
 		if err != nil {
 			t.Fatalf("LockNew on fh2: %v", err)
 		}
@@ -1295,7 +1282,7 @@ func TestFreeStateid(t *testing.T) {
 		}
 
 		// Now LOCKU and FREE_STATEID the second stateid; owner should be deleted then.
-		_, err = sm.UnlockFile(&lock2.Stateid, 4, types.WRITE_LT, 0, 50)
+		_, err = sm.UnlockFile(&lock2.Stateid, 4, types.WRITE_LT, 0, 50, 0)
 		if err != nil {
 			t.Fatalf("UnlockFile on fh2: %v", err)
 		}
@@ -1323,7 +1310,7 @@ func TestFreeStateid(t *testing.T) {
 		}
 
 		// Confirm open
-		_, err = sm.ConfirmOpen(&openResult.Stateid, 2)
+		_, err = sm.ConfirmOpen(&openResult.Stateid, 2, 0)
 		if err != nil {
 			t.Fatalf("ConfirmOpen: %v", err)
 		}
@@ -1359,18 +1346,15 @@ func TestFreeStateid(t *testing.T) {
 			t.Fatalf("OpenFile: %v", err)
 		}
 
-		confirmed, err := sm.ConfirmOpen(&openResult.Stateid, 2)
+		confirmed, err := sm.ConfirmOpen(&openResult.Stateid, 2, 0)
 		if err != nil {
 			t.Fatalf("ConfirmOpen: %v", err)
 		}
 		confirmedStateid := &confirmed.Stateid
 
 		// Create a lock
-		_, err = sm.LockNew(context.Background(),
-			0, []byte("lock-owner1"), 1,
-			confirmedStateid, 3,
-			fh, types.WRITE_LT, 0, 100, false,
-		)
+		_, err = sm.LockNew(context.Background(), 0, []byte("lock-owner1"), 1, confirmedStateid, 3, fh, types.WRITE_LT, 0, 100, false, 0)
+
 		if err != nil {
 			t.Fatalf("LockNew: %v", err)
 		}
@@ -1537,7 +1521,7 @@ func TestTestStateids(t *testing.T) {
 		deleg := sm.GrantDelegation(100, fh2, types.OPEN_DELEGATE_READ)
 
 		stateids := []types.Stateid4{result1.Stateid, deleg.Stateid}
-		results := sm.TestStateids(stateids)
+		results := sm.TestStateids(stateids, 0)
 
 		if len(results) != 2 {
 			t.Fatalf("Expected 2 results, got %d", len(results))
@@ -1574,7 +1558,7 @@ func TestTestStateids(t *testing.T) {
 		staleStateid := types.Stateid4{Seqid: 1, Other: staleOther}
 
 		stateids := []types.Stateid4{openResult.Stateid, invalidStateid, staleStateid}
-		results := sm.TestStateids(stateids)
+		results := sm.TestStateids(stateids, 0)
 
 		if len(results) != 3 {
 			t.Fatalf("Expected 3 results, got %d", len(results))
@@ -1594,7 +1578,7 @@ func TestTestStateids(t *testing.T) {
 		sm := NewStateManager(90 * time.Second)
 		defer sm.Shutdown()
 
-		results := sm.TestStateids([]types.Stateid4{})
+		results := sm.TestStateids([]types.Stateid4{}, 0)
 		if len(results) != 0 {
 			t.Errorf("Expected empty results for empty input, got %d", len(results))
 		}
@@ -1629,7 +1613,7 @@ func TestTestStateids(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 
 		stateids := []types.Stateid4{openResult.Stateid}
-		results := sm.TestStateids(stateids)
+		results := sm.TestStateids(stateids, 0)
 
 		if len(results) != 1 {
 			t.Fatalf("Expected 1 result, got %d", len(results))
@@ -1674,7 +1658,7 @@ func TestTestStateids(t *testing.T) {
 
 		// TestStateids should NOT renew the lease
 		stateids := []types.Stateid4{openResult.Stateid}
-		results := sm.TestStateids(stateids)
+		results := sm.TestStateids(stateids, 0)
 
 		if results[0] != types.NFS4_OK {
 			t.Fatalf("TestStateids should return NFS4_OK, got %d", results[0])

--- a/internal/adapter/nfs/v4/v41/handlers/test_stateid.go
+++ b/internal/adapter/nfs/v4/v41/handlers/test_stateid.go
@@ -35,7 +35,7 @@ func HandleTestStateid(
 	}
 
 	// Delegate to StateManager for per-stateid validation
-	statusCodes := d.StateManager.TestStateids(args.Stateids)
+	statusCodes := d.StateManager.TestStateids(args.Stateids, ctx.SessionClientID)
 
 	// Encode response with per-stateid status codes
 	res := &types.TestStateidRes{


### PR DESCRIPTION
**Stacked on #2459** (the `sm.mu` hoist). Its five commits are the first five here, so the diff
below is the union of both — every `pull_request` workflow in this repo is filtered to
`branches: [develop, main]`, so a PR based on a feature branch gets no CI at all and the base has
to be `develop` for this to be verifiable. Review starts at
`fix(nfs): check the stateid belongs to the caller in the state-changing operations`; merge #2459
first and this collapses to just those commits.

#2459 contains none of the ownership guards below.

## What was wrong

A stateid is not a bearer token. #2448 bound them to their owning client in `ValidateStateid`,
and every I/O site routes through it — but the **state-changing** operations never went through
`ValidateStateid` at all. They resolved the client-supplied stateid by its opaque `other` field
and acted on it with no owner comparison:

| Site | Operation | Owner it never checked |
|---|---|---|
| `CloseFile` | CLOSE | `openState.Owner.ClientID` |
| `DowngradeOpen` | OPEN_DOWNGRADE | `openState.Owner.ClientID` |
| `ConfirmOpen` | OPEN_CONFIRM | `openState.Owner.ClientID` |
| `ConfirmOpenV41` | OPEN (v4.1 auto-confirm) | `openState.Owner.ClientID` |
| `LockNew` | LOCK (open_to_lock_owner) | `openState.Owner.ClientID` |
| `LockExisting` | LOCK (exist_lock_owner) | `lockState.LockOwner.ClientID` |
| `UnlockFile` | LOCKU | `lockState.LockOwner.ClientID` |
| `testOpenStateid` / `testLockStateid` / `testDelegStateid` | TEST_STATEID | all three families |
| `CloseFile`'s already-closed branch | CLOSE retransmit | `closedOwnerByOther` |

`LockNew` is the sharpest: it resolves the caller's `openStateid`, then keys the new lock-owner by
the client ID it was handed, so on v4.1 a client could take a byte-range lock **through another
client's open** — and then hold it, extend it and release it through `LockExisting`/`UnlockFile`,
which had no compare either. CLOSE and OPEN_DOWNGRADE let one client tear down or narrow
another's open. TEST_STATEID is the mildest, an existence oracle for state the caller has no
claim to.

The last row came out of review rather than the issue: CLOSE's retransmit path resolves an
*already-closed* open through a separate map, `closedOwnerByOther`, and hands back the cached
reply. That map was outside the three the issue enumerates, and it had no owner check either — so
a client holding another's stateid bytes could read the status of a CLOSE it never sent. Only a
4-byte status code, but it is the same defect in the same function, so it is fixed here rather
than filed.

## Severity is bounded — deliberately not inflated

After #2448 a stateid `other` carries 64 `crypto/rand` bits, so none of this is enumerable:
reaching any of these needs an already-observed stateid, i.e. a wire capture on unencrypted
transport. Same defence-in-depth posture as #2395 and #2449, not a live remote hole. The
reachability above is from source, not from a wire reproduction.

## The fix

`checkStateidOwner` (`state/stateid.go`) already existed and already handles the case that makes
this subtle, so nothing new was invented: each site now takes the caller's **trusted** client ID
and routes it through that one function rather than growing a compare of its own.

Trusted means `ctx.SessionClientID` — non-zero only on NFSv4.1, which has a session to derive an
identity from. On NFSv4.0 it is zero and `checkStateidOwner` skips the comparison, which is
deliberate and unchanged: v4.0 carries no clientid4 on these operations, so the stateid stays a
bearer token there. Notably the `lock_owner4.clientid` on the wire is **not** used for this —
it is a client-supplied value that `EffectiveClientID` already overrides on v4.1 and that carries
no trust on v4.0, so comparing it would have changed v4.0 behaviour for no security gain.

For the three lock-stateid sites the compare lives inside `revalidateLockStateLocked`, the
recommit check #2459 introduced — the same three facts (lock state live, lock-owner live,
lock-owner is the caller's) have to hold both when the stateid arrives and again after the lock
manager has been called with `sm.mu` released. `LockExisting` and `UnlockFile` therefore call it
at both points: the early call is what stops a foreign client from causing cross-protocol
lease-break work before being refused.

### Already checked, not gaps

Every remaining read of `openStateByOther`, `lockStateByOther` and `delegByOther` in the state
package was classified; the ones that are not covered by this change are covered elsewhere:

- `ValidateDelegationStateid` (`delegation.go`) is existence-only, but its only caller
  (CLAIM_DELEGATE_CUR in `open.go`) re-compares `deleg.ClientID` itself.
- `ReturnDelegation` (`delegation.go`) already takes a client ID and compares.
- `freeOpenStateidLocked` / `freeLockStateidLocked` / `freeDelegStateidLocked` (`stateid.go`)
  compare inline and, unlike `checkStateidOwner`, reject a mismatch even for client ID 0 —
  FREE_STATEID's rule is genuinely the stricter one, and the two are not interchangeable.
- `GetOpenState` (`manager.go`) does an unchecked lookup, but has no production caller at all: it
  is used only by tests in this package. Left as is rather than churned.
- `RevokeDelegation` and `deleteDelegByOtherLocked` are internal (recall timeout, index upkeep),
  not driven by a wire-supplied stateid.

`closedOwnerByOther` was the one map that classification pass missed, which is why it is in the
table above and not in this list.

## Evidence

`state/stateid_authz_state_ops_test.go`, one test per operation. Each asserts that another client
is refused `NFS4ERR_BAD_STATEID` and that the owning client is still served. The third half of the
rule — a caller with no trusted identity is served as before — is what the ~100 existing call
sites in this package now exercise by passing 0, and it is asserted explicitly for the operations
that have no other coverage of it.

The "owning client is still served" leg does double duty: it reuses the exact seqid the refused
call was made with, so it also pins that `NFS4ERR_BAD_STATEID` leaves the owner's sequence
untouched (RFC 7530 §9.1.7, `failedSeqidReply`'s exempt set). With the guard neutralized in a
`go test -overlay` copy, that leg fails with `bad seqid` — a visible demonstration that the
refusal is the seqid-exempt kind.

Verified by neutralizing `checkStateidOwner` in an overlay copy, without touching the branch —
every new test fails:

```
--- FAIL: TestOpenConfirm_CrossClient
    client B confirming client A's open: err = <nil>, want NFS4ERR_BAD_STATEID
    owning client rejected: bad seqid
--- FAIL: TestOpenConfirmV41_CrossClient
    client B auto-confirming client A's open: err = <nil>, want NFS4ERR_BAD_STATEID
--- FAIL: TestOpenDowngrade_CrossClient
    client B downgrading client A's open: err = <nil>, want NFS4ERR_BAD_STATEID
    owning client rejected: bad seqid
--- FAIL: TestClose_CrossClient
    client B closing client A's open: err = <nil>, want NFS4ERR_BAD_STATEID
    owning client rejected: stateid not found for CLOSE
--- FAIL: TestLock_CrossClient
    client B locking through client A's open: err = <nil>, want NFS4ERR_BAD_STATEID
--- FAIL: TestTestStateids_CrossClient/{open,lock,delegation}_stateid
```

The CLOSE replay guard is verified the same way, separately, because it needs the cached reply to
exist at all — the test seeds it (the handler layer that normally caches it is not in play in a
StateManager test), and with only that guard removed the test reports
`client B replaying client A's CLOSE reply: err = replay of cached owner-seqid result, want
NFS4ERR_BAD_STATEID`.

`TestClose_CrossClient`'s second line is the interesting one: with the guard gone, client B's
CLOSE actually succeeded, so the owning client's own CLOSE then found nothing left.

`go test -race ./internal/adapter/nfs/...` green; `golangci-lint run ./internal/adapter/nfs/v4/...`
clean.

## A note on the diff size

The eight methods take a new explicit parameter rather than a variadic, so the compiler enumerates
every call site — the precedent from #2448, and the point of doing it this way. That means ~100
test call sites gained a `0` argument. They were rewritten with `gofmt -r` rather than by hand,
which is why some multi-line calls collapsed onto one line; that reformatting is the bulk of the
line count and none of the substance.

Closes #2451
