### PR TITLE
refactor(nfs): unify the v4.0 and v4.1 client records into one type

### DIFF
--- a/internal/adapter/nfs/v4/state/client.go
+++ b/internal/adapter/nfs/v4/state/client.go
@@ -52,36 +52,57 @@ func principalHijacks(stored, incoming string) bool {
 // Client Record
 // ============================================================================
 
-// ClientRecord represents the server-side state for a single NFSv4 client.
-// It tracks the client's identity, verifier, confirmation status, and
-// callback information for delegations.
+// ClientRecord represents the server-side state for a single NFSv4 client of
+// any minor version. It tracks the client's identity, verifier, confirmation
+// status, and callback information for delegations.
 //
-// Per RFC 7530 Section 9.1.1, each client is identified by:
+// A v4.0 client is established by SETCLIENTID + SETCLIENTID_CONFIRM and is
+// identified per RFC 7530 Section 9.1.1 by:
 //   - ClientIDString: opaque string from nfs_client_id4.id (unique per client)
 //   - Verifier: 8-byte value that changes on client reboot
 //   - ClientID: server-assigned 64-bit identifier
+//
+// A v4.1 client is established by EXCHANGE_ID + CREATE_SESSION and is
+// identified per RFC 8881 Section 18.35 by OwnerID (co_ownerid) and the same
+// Verifier (co_verifier) and ClientID. The two identity fields stay distinct
+// because they index different lookup maps and different durable
+// client-recovery keys; the wire formats they carry are not interchangeable.
+//
+// Fields that apply to only one minor version are marked as such and are left
+// at their zero value for the other. Anything version-independent — lease
+// timing, principal, callback-path liveness — is shared, so a policy decision
+// that reads it does not have to know which registration flow created the
+// record.
 type ClientRecord struct {
 	// ClientID is the server-assigned 64-bit client identifier.
 	// Generated using boot epoch (high 32) + sequence counter (low 32).
 	ClientID uint64
 
-	// ClientIDString is the client-provided opaque identifier (nfs_client_id4.id).
-	// This is the stable identity that persists across reboots.
+	// ClientIDString is the client-provided opaque identifier
+	// (nfs_client_id4.id). v4.0 only. This is the stable identity that
+	// persists across reboots.
 	ClientIDString string
 
+	// OwnerID is co_ownerid from client_owner4. v4.1 only. Stored as bytes
+	// for byte-exact comparison.
+	OwnerID []byte
+
 	// Verifier is the client-provided 8-byte value that changes on reboot.
-	// Used to detect client restarts.
+	// Used to detect client restarts. co_verifier on v4.1.
 	Verifier [8]byte
 
 	// ConfirmVerifier is the server-generated 8-byte verifier returned
-	// by SETCLIENTID and validated by SETCLIENTID_CONFIRM.
+	// by SETCLIENTID and validated by SETCLIENTID_CONFIRM. v4.0 only.
 	// Generated using crypto/rand for unpredictability.
 	ConfirmVerifier [8]byte
 
-	// Confirmed indicates whether SETCLIENTID_CONFIRM has been called.
+	// Confirmed indicates whether the client has completed registration:
+	// SETCLIENTID_CONFIRM on v4.0, CREATE_SESSION on v4.1.
 	Confirmed bool
 
 	// Callback holds the client's callback information for delegations.
+	// v4.0 only: a v4.1 client's callbacks travel over the session
+	// backchannel, which carries no separate address.
 	Callback CallbackInfo
 
 	// ClientAddr is the network address of the client (for logging/debugging).
@@ -89,25 +110,49 @@ type ClientRecord struct {
 
 	// Principal is the RPCSEC_GSS / AUTH_SYS principal that established this
 	// client (best-effort; "uid:N" for AUTH_SYS, the GSS principal otherwise,
-	// "" when unknown). Captured at SETCLIENTID and persisted into the durable
-	// client-recovery record at confirm time as a lease-stealing guard.
+	// "" when unknown). Captured at SETCLIENTID or EXCHANGE_ID and persisted
+	// into the durable client-recovery record at confirm time as a
+	// lease-stealing guard.
 	Principal string
+
+	// ImplDomain is the implementation domain from nfs_impl_id4
+	// (e.g. "kernel.org"). v4.1 only.
+	ImplDomain string
+
+	// ImplName is the implementation name from nfs_impl_id4
+	// (e.g. "Linux NFS client"). v4.1 only.
+	ImplName string
+
+	// ImplDate is the build date from nfs_impl_id4. v4.1 only.
+	ImplDate time.Time
+
+	// SequenceID is the CREATE_SESSION slot sequence ID, initialized to 0.
+	// v4.1 only. ExchangeID returns SequenceID+1 as eir_sequenceid so the
+	// client sends that value as csa_sequenceid. CreateSession validates
+	// csa_sequenceid == SequenceID+1 (the "new request" check per RFC 8881
+	// Section 18.36), then advances SequenceID to match.
+	SequenceID uint32
+
+	// CachedCreateSessionRes is the XDR-encoded CREATE_SESSION reply held for
+	// replay per RFC 8881 Section 18.36. v4.1 only. Set when CREATE_SESSION
+	// succeeds.
+	CachedCreateSessionRes []byte
 
 	// CreatedAt is when this record was created.
 	CreatedAt time.Time
 
 	// LastRenewal is the most recent lease renewal time.
-	// Updated by RENEW, OPEN, and any implicit lease renewal.
+	// Updated by RENEW, SEQUENCE, OPEN, and any implicit lease renewal.
 	LastRenewal time.Time
 
 	// Lease is the lease timer for this client.
-	// Created when the client is confirmed via SETCLIENTID_CONFIRM.
+	// Created when the client is confirmed.
 	// Fires onLeaseExpired callback when the lease duration elapses
 	// without renewal.
 	Lease *LeaseState
 
 	// OpenOwners tracks all open-owners for this client.
-	// Keyed by hex-encoded owner data. Populated in .
+	// Keyed by hex-encoded owner data. v4.0 only.
 	OpenOwners map[string]*OpenOwner
 
 	// CBPathUp indicates whether the callback path to this client has been

--- a/internal/adapter/nfs/v4/state/delegation.go
+++ b/internal/adapter/nfs/v4/state/delegation.go
@@ -188,13 +188,8 @@ func (sm *StateManager) delegationBudgetAvailableLocked() bool {
 //
 // Caller must hold sm.mu.
 func (sm *StateManager) clientLeaseLiveLocked(clientID uint64) bool {
-	if v40, ok := sm.clientsByID[clientID]; ok {
-		return v40.Lease != nil && !v40.Lease.IsExpired()
-	}
-	if v41, ok := sm.v41ClientsByID[clientID]; ok {
-		return v41.Lease != nil && !v41.Lease.IsExpired()
-	}
-	return false
+	record := sm.clientRecordLocked(clientID)
+	return record != nil && record.Lease != nil && !record.Lease.IsExpired()
 }
 
 // revokeInLockManagerLocked hands a delegation back to the cross-protocol

--- a/internal/adapter/nfs/v4/state/dir_delegation_test.go
+++ b/internal/adapter/nfs/v4/state/dir_delegation_test.go
@@ -541,7 +541,7 @@ func registerTestV41Client(t *testing.T, sm *StateManager) uint64 {
 	defer sm.mu.Unlock()
 
 	clientID := sm.generateClientID()
-	record := &V41ClientRecord{
+	record := &ClientRecord{
 		ClientID:   clientID,
 		OwnerID:    []byte("test-v41-client-dir-deleg"),
 		Confirmed:  true,

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -32,7 +32,10 @@ const DefaultLeaseDuration = 90 * time.Second
 type StateManager struct {
 	mu sync.RWMutex
 
-	// clientsByID maps server-assigned client IDs to client records.
+	// clientsByID maps server-assigned client IDs to v4.0 client records
+	// (those established by SETCLIENTID). v4.1 clients are indexed by
+	// v41ClientsByID; the two maps never hold the same ID because
+	// generateClientID draws both from one sequence.
 	clientsByID map[uint64]*ClientRecord
 
 	// clientsByName maps nfs_client_id4.id strings to confirmed client records.
@@ -188,11 +191,11 @@ type StateManager struct {
 	// ============================================================================
 
 	// v41ClientsByID maps server-assigned client IDs to v4.1 client records.
-	v41ClientsByID map[uint64]*V41ClientRecord
+	v41ClientsByID map[uint64]*ClientRecord
 
 	// v41ClientsByOwner maps owner ID bytes (string key) to v4.1 client records.
 	// Uses string(ownerID) for byte-exact comparison.
-	v41ClientsByOwner map[string]*V41ClientRecord
+	v41ClientsByOwner map[string]*ClientRecord
 
 	// sessionsByID maps session IDs to session objects.
 	sessionsByID map[types.SessionId4]*Session
@@ -289,8 +292,8 @@ func NewStateManager(leaseDuration time.Duration, graceDuration ...time.Duration
 		leaseDuration:       leaseDuration,
 		graceDuration:       gd,
 		// NFSv4.1 state
-		v41ClientsByID:       make(map[uint64]*V41ClientRecord),
-		v41ClientsByOwner:    make(map[string]*V41ClientRecord),
+		v41ClientsByID:       make(map[uint64]*ClientRecord),
+		v41ClientsByOwner:    make(map[string]*ClientRecord),
 		sessionsByID:         make(map[types.SessionId4]*Session),
 		sessionsByClientID:   make(map[uint64][]*Session),
 		maxSessionsPerClient: 16,
@@ -881,10 +884,10 @@ func (sm *StateManager) RemoveClient(clientID uint64) {
 // together with its open states, its lock states, and the locks those hold in
 // the unified lock manager.
 //
-// It scans sm.openOwners by ClientID rather than walking a per-client owner
-// list: V41ClientRecord carries no such list, and the v4.0 ClientRecord one
-// goes stale because freeOpenStateidLocked removes owners from sm.openOwners
-// without removing them there.
+// It scans sm.openOwners by ClientID rather than walking the record's
+// OpenOwners map: that map is only populated on the v4.0 path, and it goes
+// stale even there because freeOpenStateidLocked removes owners from
+// sm.openOwners without removing them from it.
 //
 // Caller must hold sm.mu.
 func (sm *StateManager) removeClientOpenStateLocked(clientID uint64) {
@@ -3614,7 +3617,7 @@ func (sm *StateManager) reapExpiredSessions() {
 	now := time.Now()
 
 	// Collect client IDs to purge (avoid modifying map during iteration)
-	var toPurge []*V41ClientRecord
+	var toPurge []*ClientRecord
 
 	for _, record := range sm.v41ClientsByID {
 		// Check lease expiry for confirmed clients

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -802,23 +802,40 @@ func (sm *StateManager) GetClient(clientID uint64) *ClientRecord {
 	return sm.clientsByID[clientID]
 }
 
+// clientRecordLocked returns the record for clientID from whichever index holds
+// it, or nil when no client owns that ID. The v4.0 index is consulted first;
+// the two never hold the same ID because generateClientID draws both from one
+// sequence, so the order only decides which map absorbs the lookup.
+//
+// Callers hold a client ID and have no reason to know which minor version
+// minted it, which is why version-independent policy reads the record through
+// here rather than naming a map.
+//
+// Caller must hold sm.mu.
+func (sm *StateManager) clientRecordLocked(clientID uint64) *ClientRecord {
+	if record := sm.clientsByID[clientID]; record != nil {
+		return record
+	}
+	return sm.v41ClientsByID[clientID]
+}
+
 // renewConfirmedClient admits a confirmed client whose lease is still live and
 // stamps the renewal. Shared by RENEW and by the implicit renewal every
 // operation carrying a valid clientid gets, so the two admission paths cannot
 // disagree about what a renewal updates.
 //
 // Caller must hold sm.mu.
-func renewConfirmedClient(confirmed bool, lease *LeaseState, lastRenewal *time.Time) error {
-	if !confirmed {
+func renewConfirmedClient(record *ClientRecord) error {
+	if !record.Confirmed {
 		return ErrStaleClientID
 	}
-	if lease != nil {
-		if lease.IsExpired() {
+	if record.Lease != nil {
+		if record.Lease.IsExpired() {
 			return ErrExpired
 		}
-		lease.Renew()
+		record.Lease.Renew()
 	}
-	*lastRenewal = time.Now()
+	record.LastRenewal = time.Now()
 	return nil
 }
 
@@ -838,13 +855,11 @@ func (sm *StateManager) ValidateAndRenewClient(clientID uint64) error {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
-	if record := sm.clientsByID[clientID]; record != nil {
-		return renewConfirmedClient(record.Confirmed, record.Lease, &record.LastRenewal)
+	record := sm.clientRecordLocked(clientID)
+	if record == nil {
+		return sm.unknownClientIDError(clientID)
 	}
-	if v41 := sm.v41ClientsByID[clientID]; v41 != nil {
-		return renewConfirmedClient(v41.Confirmed, v41.Lease, &v41.LastRenewal)
-	}
-	return sm.unknownClientIDError(clientID)
+	return renewConfirmedClient(record)
 }
 
 // RemoveClient removes a client record and all associated state.
@@ -994,13 +1009,8 @@ func (sm *StateManager) releaseClientStateLocked(clientID uint64) {
 //
 // Caller must hold sm.mu.
 func (sm *StateManager) clientLeaseLapsedLocked(clientID uint64) bool {
-	if record := sm.clientsByID[clientID]; record != nil {
-		return record.Confirmed && record.Lease != nil && record.Lease.IsExpired()
-	}
-	if v41 := sm.v41ClientsByID[clientID]; v41 != nil {
-		return v41.Confirmed && v41.Lease != nil && v41.Lease.IsExpired()
-	}
-	return false
+	record := sm.clientRecordLocked(clientID)
+	return record != nil && record.Confirmed && record.Lease != nil && record.Lease.IsExpired()
 }
 
 // expireLapsedHoldersLocked releases the state of every client that holds an
@@ -2328,7 +2338,7 @@ func (sm *StateManager) RenewLease(clientID uint64, principal ...string) error {
 		return ErrRenewAccess
 	}
 
-	if err := renewConfirmedClient(record.Confirmed, record.Lease, &record.LastRenewal); err != nil {
+	if err := renewConfirmedClient(record); err != nil {
 		return err
 	}
 

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -796,6 +796,11 @@ func (sm *StateManager) ConfirmClientID(clientID uint64, confirmVerifier [8]byte
 // GetClient returns the client record for the given client ID, or nil
 // if no record exists. Used by RENEW and other operations that need
 // to look up client state.
+//
+// v4.0 only: it reads the SETCLIENTID index, so a v4.1 client ID comes back
+// nil even though both minor versions now share the record type. Use
+// clientRecordLocked for a lookup that should not care which flow minted the
+// ID.
 func (sm *StateManager) GetClient(clientID uint64) *ClientRecord {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()

--- a/internal/adapter/nfs/v4/state/session_test.go
+++ b/internal/adapter/nfs/v4/state/session_test.go
@@ -1037,9 +1037,9 @@ func TestReaper_ActiveLeaseNotCleaned(t *testing.T) {
 
 // TestReaper_ExpiredLeaseReleasesOpenState checks that reaping a client whose
 // lease lapsed also releases the open state its owners hold. v4.1 OPENs run
-// through the same OpenFile path as v4.0 and land in sm.openOwners, but the
-// V41ClientRecord has no owner list of its own, so a purge that only walked the
-// record left them behind — with their share reservations still denying every
+// through the same OpenFile path as v4.0 and land in sm.openOwners, but a
+// v4.1 client record carries no owner list of its own, so a purge that only
+// walked the record left them behind — with their share reservations still denying every
 // other client, and no client record left to ever CLOSE them.
 func TestReaper_ExpiredLeaseReleasesOpenState(t *testing.T) {
 	const lease = 20 * time.Millisecond

--- a/internal/adapter/nfs/v4/state/stateid_authz_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_authz_test.go
@@ -308,7 +308,7 @@ func TestExchangeID_Case2_PrincipalMismatch(t *testing.T) {
 	}
 }
 
-func recPrincipal(rec *V41ClientRecord) string {
+func recPrincipal(rec *ClientRecord) string {
 	if rec == nil {
 		return ""
 	}

--- a/internal/adapter/nfs/v4/state/v41_client.go
+++ b/internal/adapter/nfs/v4/state/v41_client.go
@@ -14,68 +14,6 @@ import (
 var BuildDate string
 
 // ============================================================================
-// V41 Client Record (separate from v4.0 ClientRecord)
-// ============================================================================
-
-// V41ClientRecord represents the server-side state for a single NFSv4.1 client
-// registered via EXCHANGE_ID (op 42) per RFC 8881 Section 18.35.
-//
-// This is separate from the v4.0 ClientRecord because v4.1 uses a completely
-// different client registration flow (EXCHANGE_ID -> CREATE_SESSION vs
-// SETCLIENTID -> SETCLIENTID_CONFIRM).
-type V41ClientRecord struct {
-	// ClientID is the server-assigned 64-bit client identifier.
-	ClientID uint64
-
-	// OwnerID is the co_ownerid from client_owner4 (stored as bytes for byte-exact comparison).
-	OwnerID []byte
-
-	// Verifier is the co_verifier from client_owner4.
-	Verifier [8]byte
-
-	// ImplDomain is the implementation domain from nfs_impl_id4 (e.g. "kernel.org").
-	ImplDomain string
-
-	// ImplName is the implementation name from nfs_impl_id4 (e.g. "Linux NFS client").
-	ImplName string
-
-	// ImplDate is the build date from nfs_impl_id4.
-	ImplDate time.Time
-
-	// SequenceID is the CREATE_SESSION slot sequence ID, initialized to 0.
-	// ExchangeID returns SequenceID+1 as eir_sequenceid so the client
-	// sends that value as csa_sequenceid. CreateSession validates
-	// csa_sequenceid == SequenceID+1 (the "new request" check per
-	// RFC 8881 Section 18.36), then advances SequenceID to match.
-	SequenceID uint32
-
-	// Confirmed becomes true after CREATE_SESSION completes.
-	Confirmed bool
-
-	// ClientAddr is the network address of the client (for logging/debugging).
-	ClientAddr string
-
-	// Principal is the RPCSEC_GSS / AUTH_SYS principal that established this
-	// client (best-effort). Persisted into the durable client-recovery record
-	// at CREATE_SESSION confirm time as a lease-stealing guard.
-	Principal string
-
-	// CreatedAt is when this record was created.
-	CreatedAt time.Time
-
-	// LastRenewal is the most recent lease renewal time.
-	LastRenewal time.Time
-
-	// Lease is the lease timer for this client (shared behavior via pointer, same as v4.0 pattern).
-	Lease *LeaseState
-
-	// CachedCreateSessionRes holds the full XDR-encoded CREATE_SESSION
-	// response bytes for replay detection (RFC 8881 Section 18.36).
-	// nil until the first successful CREATE_SESSION.
-	CachedCreateSessionRes []byte
-}
-
-// ============================================================================
 // Server Identity (immutable singleton)
 // ============================================================================
 
@@ -185,7 +123,7 @@ func (sm *StateManager) ExchangeID(
 	princ := firstOrEmpty(principal)
 	existing := sm.v41ClientsByOwner[string(ownerID)]
 
-	var record *V41ClientRecord
+	var record *ClientRecord
 
 	switch {
 	case existing == nil:
@@ -256,7 +194,7 @@ func (sm *StateManager) ExchangeID(
 	}, nil
 }
 
-// createV41Client creates and stores a new V41ClientRecord.
+// createV41Client creates and stores a new ClientRecord.
 // Caller must hold sm.mu.
 func (sm *StateManager) createV41Client(
 	ownerID []byte,
@@ -264,10 +202,10 @@ func (sm *StateManager) createV41Client(
 	clientImplId []types.NfsImplId4,
 	clientAddr string,
 	principal string,
-) *V41ClientRecord {
+) *ClientRecord {
 	now := time.Now()
 
-	record := &V41ClientRecord{
+	record := &ClientRecord{
 		ClientID:    sm.generateClientID(),
 		OwnerID:     make([]byte, len(ownerID)),
 		Verifier:    verifier,
@@ -290,7 +228,7 @@ func (sm *StateManager) createV41Client(
 // applyImplInfo extracts the first nfs_impl_id4 entry from clientImplId
 // and applies it to the record. Shared between createV41Client and the
 // idempotent branch of ExchangeID.
-func applyImplInfo(record *V41ClientRecord, clientImplId []types.NfsImplId4) {
+func applyImplInfo(record *ClientRecord, clientImplId []types.NfsImplId4) {
 	if len(clientImplId) == 0 {
 		return
 	}
@@ -302,12 +240,12 @@ func applyImplInfo(record *V41ClientRecord, clientImplId []types.NfsImplId4) {
 	}
 }
 
-// purgeV41Client removes a V41ClientRecord from both lookup maps, releases the
+// purgeV41Client removes a ClientRecord from both lookup maps, releases the
 // open and lock state its owners hold, and destroys all associated sessions.
 // Only deletes from v41ClientsByOwner if the map entry still points to this
 // record (guards against a concurrent createV41Client having already replaced it).
 // Caller must hold sm.mu.
-func (sm *StateManager) purgeV41Client(record *V41ClientRecord) {
+func (sm *StateManager) purgeV41Client(record *ClientRecord) {
 	// Drop the durable recovery record: a purged client (eviction, DESTROY_CLIENTID,
 	// or reboot-replace) cannot reclaim under this identity. Best-effort; no-op when
 	// the client was never confirmed (no record was ever persisted) or no store wired.
@@ -355,11 +293,11 @@ func (sm *StateManager) purgeV41Client(record *V41ClientRecord) {
 
 // ListV41Clients returns pointers to all registered v4.1 client records.
 // Thread-safe: acquires sm.mu.RLock.
-func (sm *StateManager) ListV41Clients() []*V41ClientRecord {
+func (sm *StateManager) ListV41Clients() []*ClientRecord {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
 
-	clients := make([]*V41ClientRecord, 0, len(sm.v41ClientsByID))
+	clients := make([]*ClientRecord, 0, len(sm.v41ClientsByID))
 	for _, record := range sm.v41ClientsByID {
 		clients = append(clients, record)
 	}

--- a/internal/adapter/nfs/v4/state/v41_client_test.go
+++ b/internal/adapter/nfs/v4/state/v41_client_test.go
@@ -301,7 +301,7 @@ func TestListV41Clients(t *testing.T) {
 	}
 
 	// Verify returned values are pointers to internal records (not copies)
-	// to avoid copylocks issues with V41ClientRecord containing atomic fields.
+	// to avoid copylocks issues with ClientRecord containing atomic fields.
 	for _, c := range clients {
 		if c == nil {
 			t.Error("ListV41Clients returned nil pointer")

--- a/internal/adapter/nfs/v4/state/v41_client_test.go
+++ b/internal/adapter/nfs/v4/state/v41_client_test.go
@@ -300,8 +300,8 @@ func TestListV41Clients(t *testing.T) {
 		t.Fatalf("ListV41Clients returned %d clients, want 3", len(clients))
 	}
 
-	// Verify returned values are pointers to internal records (not copies)
-	// to avoid copylocks issues with ClientRecord containing atomic fields.
+	// The slice holds live pointers to the internal records, so every entry
+	// must be non-nil for a caller to read one without a check of its own.
 	for _, c := range clients {
 		if c == nil {
 			t.Error("ListV41Clients returned nil pointer")


### PR DESCRIPTION
NFSv4 state management kept two unrelated structs for the same thing: `ClientRecord` for a client established by SETCLIENTID + SETCLIENTID_CONFIRM, and `V41ClientRecord` for one established by EXCHANGE_ID + CREATE_SESSION. They overlapped on nine fields (client ID, verifier, confirmation, address, principal, creation/renewal times, lease) and diverged on the rest.

That split is the source of #2436. `CBPathUp` — whether the callback path to a client has been verified — lives on `ClientRecord` and has no counterpart on `V41ClientRecord`, so it is not that the flag is left false for a v4.1 client, it is that a v4.1 client is not represented by the struct that has one. `ShouldGrantDelegation` looks the caller up in `clientsByID`, the v4.0 index, and a v4.1 client ID never appears there, so every v4.1 OPEN bails at the *lookup* and never reaches the `CBPathUp` test the issue names.

This PR removes the asymmetry rather than working around it: the field union becomes a single `ClientRecord` and `V41ClientRecord` is deleted. Version-specific fields are marked "v4.0 only" / "v4.1 only" and left at their zero value for the other minor version; the nine shared fields plus `CBPathUp` are now genuinely shared, so a policy decision that reads callback liveness no longer has to know which registration flow created the record.

## Deliberately not in this PR

**The delegation grant itself.** A follow-up PR adds the v4.1 callback-liveness probe, points `ShouldGrantDelegation` at the version-agnostic lookup, and walks out the `DELEG` rows in `test/nfs-conformance/pynfs/KNOWN_FAILURES_V41.md`. Keeping the two apart is the point: a behaviour change buried in a mechanical retype of 40 sites is how a real bug hides.

**Merging the two lookup maps.** `clientsByID` (v4.0) and `v41ClientsByID` (v4.1) keep their separate membership; only their value type changed. Merging them is *not* behaviour-preserving — around twenty v4.0-only sites read `clientsByID` and would start seeing v4.1 records: `RenewLease` (RENEW does not exist in v4.1), `ConfirmClientID`, `RemoveClient` and `expireV40ClientLocked` (which delete from `clientsByName` by `ClientIDString` and would not destroy a v4.1 client's sessions), and `Shutdown`. Each would need an explicit version filter, which is more code and more risk than two maps of one type. The version-agnostic reads that already existed now go through one `clientRecordLocked` helper instead of branching on the record type.

## Evidence that this changes no behaviour

Not one executable statement in the retype changes. Isolating the non-comment changed lines in the diff leaves only `V41ClientRecord` → `ClientRecord` rename pairs and the field declarations moving out of the deleted struct:

```
$ git diff -M origin/develop -U0 | grep -E '^[-+]' | grep -vE '^(\+\+\+|---)' \
    | sed -E 's/^([-+])[[:space:]]*//' | grep -vE '^(//|$)' | sort | uniq -c
      2 record := &V41ClientRecord{
      2 record := &ClientRecord{
      2 OwnerID []byte
      ...
      1 func (sm *StateManager) purgeV41Client(record *V41ClientRecord) {
      1 func (sm *StateManager) purgeV41Client(record *ClientRecord) {
```

The three collapsed helpers are each a straight substitution of the same predicate:

- `clientLeaseLiveLocked` was `if v40, ok := clientsByID[id]; ok { return leaseLive(v40) }` then the same for `v41ClientsByID`, then `false`. Now one `clientRecordLocked` lookup and one lease check. v4.0 still wins on a (structurally impossible) collision.
- `renewConfirmedClient` took `(confirmed bool, lease *LeaseState, lastRenewal *time.Time)` unpacked from whichever record type the caller had; it now takes the record.
- `ValidateAndRenewClient` had the same two-branch shape as `clientLeaseLiveLocked`.

Every field kept its version gating, verified by grepping each field's read and write sites: `ClientIDString`, `ConfirmVerifier`, `Callback` and `OpenOwners` are touched only through `clientsByID`; `OwnerID`, `ImplDomain`, `ImplName`, `ImplDate`, `SequenceID` and `CachedCreateSessionRes` only through `v41ClientsByID` (`client_recovery.go`'s v4.1 read is gated behind a failed `clientsByID` lookup). Nothing serializes or reflects over `ClientRecord`, so no downstream observer sees the widened struct.

The two maps cannot hold the same ID: `generateClientID` is the only assigner of `ClientID` and draws both flows from one `nextClientSeq` counter under one `bootEpoch`.

`ClientIDString` (string, v4.0 `nfs_client_id4.id`) and `OwnerID` (bytes, v4.1 `co_ownerid`) stay separate fields on purpose — they key different lookup maps and different durable client-recovery records, and the wire formats are not interchangeable.

## Verification

Every existing test passes **unchanged**; no assertion was edited. Three comments were reworded where the deleted type name made them false.

```
$ go build ./... && go vet ./internal/adapter/nfs/...
$ go test -race ./internal/adapter/nfs/...
ok  github.com/marmos91/dittofs/internal/adapter/nfs/v4/state
ok  github.com/marmos91/dittofs/internal/adapter/nfs/v4/handlers
ok  github.com/marmos91/dittofs/internal/adapter/nfs/v4/v41/handlers
```

Closes #2436
