### PR TITLE
fix(conformance): stop reporting a setup failure as new test failures

### DIFF
--- a/test/conformance/run.sh
+++ b/test/conformance/run.sh
@@ -28,6 +28,12 @@ MANIFEST="${CONFORMANCE_MANIFEST:-${SCRIPT_DIR}/suites.json}"
 # CONFORMANCE_MANIFEST at a synthetic tree and get its own scripts dispatched.
 TEST_DIR="$(cd "$(dirname "$MANIFEST")/.." && pwd)"
 
+# The one step per suite whose exit status is a failure COUNT rather than a
+# plain shell status. Every other step — fetching dependencies, building an
+# image, mounting an export — either succeeds or leaves the suite ungraded, and
+# its exit code says nothing about how many tests regressed.
+GRADED_STEP="run"
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -233,7 +239,7 @@ run_one() {
     log_step "${SUITE} / ${label}"
     [[ -n "$kf" ]] && log_info "blacklist: ${kf#"${REPO_ROOT}/"}"
 
-    local status=0 i
+    local status=0 failed_step="" i
     for ((i = 0; i < step_count; i++)); do
         local name cmd needs_root always
         IFS=$'\t' read -r name cmd needs_root always < <(
@@ -286,21 +292,33 @@ run_one() {
 
         if [[ "$step_status" -ne 0 ]]; then
             log_error "step ${name} exited ${step_status}"
-            [[ "$always" == "true" ]] || status="$step_status"
+            if [[ "$always" != "true" ]]; then
+                status="$step_status"
+                failed_step="$name"
+            fi
         fi
     done
 
-    [[ "$DRY_RUN" == true ]] || write_summary "$label" "$status" "${results_dir}"
+    [[ "$DRY_RUN" == true ]] || write_summary "$label" "$status" "${results_dir}" "$failed_step"
     return "$status"
 }
 
-# write_summary LABEL STATUS RESULTS_DIR
+# write_summary LABEL STATUS RESULTS_DIR [FAILED_STEP]
+#
+# Only GRADED_STEP exits with a failure count; every other step exits with a
+# plain shell status. Reporting the two the same way spends "N new failure(s)" —
+# the phrase that means a test which used to pass now fails — on a toolchain
+# that could not download a dependency, and sends the reader hunting a
+# regression against a suite that never ran.
 write_summary() {
-    local label="$1" status="$2" results_dir="$3"
+    local label="$1" status="$2" results_dir="$3" failed_step="${4:-}"
     local verdict icon
     if [[ "$status" -eq 0 ]]; then
         verdict="pass"
         icon=":white_check_mark:"
+    elif [[ -n "$failed_step" && "$failed_step" != "$GRADED_STEP" ]]; then
+        verdict="${failed_step} failed (exit ${status}) — no tests were graded"
+        icon=":construction:"
     else
         verdict="${status} new failure(s)"
         icon=":x:"

--- a/test/conformance/run_test.sh
+++ b/test/conformance/run_test.sh
@@ -130,6 +130,18 @@ cat >"$FAKE_MANIFEST" <<'EOF'
         { "name": "run", "cmd": "fake/pass.sh", "args": [], "root": false }
       ]
     },
+    "brokensetup": {
+      "description": "setup fails, so the run step never grades anything",
+      "runner_dir": "fake",
+      "profiles": ["memory"],
+      "known_failures": null,
+      "tiers": { "pull_request": "all", "push": "all" },
+      "steps": [
+        { "name": "setup", "cmd": "fake/fail3.sh", "args": [], "root": false },
+        { "name": "run", "cmd": "fake/pass.sh", "args": [], "root": false },
+        { "name": "teardown", "cmd": "fake/teardown.sh", "args": [], "root": false, "always": true }
+      ]
+    },
     "privileged": {
       "description": "one step needs root, one does not",
       "runner_dir": "fake",
@@ -164,6 +176,24 @@ while IFS= read -r cmd; do
     [[ -x "${SCRIPT_DIR}/../${cmd}" ]] || MISSING="${MISSING} ${cmd}"
 done < <(jq -r '.suites[].steps[].cmd' "${SCRIPT_DIR}/suites.json")
 assert_eq "every declared step command is executable" "" "$MISSING"
+
+# The runner tells a graded failure from an infrastructure one by the step's
+# name, so a suite with no step called "run" would have every failure reported
+# as setup breakage. And a graded step marked "always" would have its failure
+# count discarded along with teardown's — a suite that reports pass while its
+# tests regressed, which is the dangerous direction of the same defect.
+UNGRADED=""
+ALWAYS_GRADED=""
+while IFS=$'\t' read -r suite has_run run_always; do
+    [[ "$has_run" == "true" ]] || UNGRADED="${UNGRADED} ${suite}"
+    [[ "$run_always" == "true" ]] && ALWAYS_GRADED="${ALWAYS_GRADED} ${suite}"
+done < <(jq -r '.suites | to_entries[] | [
+    .key,
+    ([.value.steps[] | select(.name == "run")] | length > 0),
+    ([.value.steps[] | select(.name == "run" and (.always // false))] | length > 0)
+] | @tsv' "${SCRIPT_DIR}/suites.json")
+assert_eq "every suite has a graded step named run" "" "$UNGRADED"
+assert_eq "no suite marks its graded step always" "" "$ALWAYS_GRADED"
 
 # Same for the blacklists.
 MISSING=""
@@ -259,6 +289,22 @@ assert_not_contains "steps after a failure are skipped" "ran pass.sh" "$OUT"
 
 OUT="$(run_fake --suite graded --profile memory --variant 4.0 --keep)"
 assert_not_contains "--keep skips teardown" "TEARDOWN RAN" "$OUT"
+
+assert_contains "a graded failure is reported as a failure count" "3 new failure(s)" \
+    "$(run_fake --suite graded --profile memory --variant 4.0)"
+
+# A step that is not the graded one exits with a shell status, not a count. It
+# must stay red — nothing here weakens that — but calling it "N new failure(s)"
+# claims a regression in a suite that never ran, and costs a real investigation
+# every time an image pull or a module fetch blips.
+OUT="$(run_fake --suite brokensetup --profile memory)"
+rc=$?
+assert_eq "a setup failure still fails the suite" "3" "$rc"
+assert_contains "a setup failure names the step that failed" "setup failed (exit 3)" "$OUT"
+assert_contains "a setup failure says nothing was graded" "no tests were graded" "$OUT"
+assert_not_contains "a setup failure is not reported as new failures" "new failure(s)" "$OUT"
+assert_not_contains "the graded step never ran" "ran pass.sh" "$OUT"
+assert_contains "teardown still runs after a failed setup" "TEARDOWN RAN" "$OUT"
 
 # ---------------------------------------------------------------------------
 # Per-variant blacklists. One path per suite cannot express these.


### PR DESCRIPTION
Closes #2465.

## The defect

`run.sh` kept one variable, `status`, for two different things: *whether a step failed*, and *how many tests regressed*. That conflation is deliberate for graders — they exit with a failure count, and `run.sh`'s header calls that out as the exit contract. But every other step lands in the same variable:

```bash
if [[ "$step_status" -ne 0 ]]; then
    [[ "$always" == "true" ]] || status="$step_status"
fi
...
verdict="${status} new failure(s)"
```

So a `setup` step exiting 1 because the Go module proxy dropped a stream, or Docker Hub returned 500 on the token endpoint, produced:

```
[CONFORMANCE] step setup exited 1
[CONFORMANCE] pjdfstest / memory-3: 1 new failure(s)
```

for a suite where pjdfstest never started.

## The fix

Track *which* step failed. Only `run` — the one step per suite whose exit status is a count — is reported as a failure count; anything else says which step failed and that nothing was graded.

```
[CONFORMANCE] pjdfstest / memory-3: setup failed (exit 1) — no tests were graded
```

**Exit codes are unchanged.** A setup failure was red before and is red now; only the label changes. The self-test asserts that explicitly, so a future "simplification" cannot turn this into a way of swallowing infra failures.

## The false-green direction

The issue asks whether the same path can report a *false* green. It cannot today, but one manifest edit away it could: `always: true` steps deliberately do not set `status`, so a graded step marked `always` would have its failure count discarded along with teardown's — reporting **pass** while tests regressed.

Two guards on the real manifest, both verified to fire against a violation:

| Guard | Violation injected | Result |
|---|---|---|
| every suite has a graded step named `run` | renamed wpts' step to `execute` | `expected '', got ' wpts'` |
| no suite marks its graded step `always` | set `always: true` on pynfs' run | `expected '', got ' pynfs'` |

The first also matters because the fix keys off the step name: a suite with no `run` step would have every failure reported as setup breakage.

## Verification

Against **unpatched** `run.sh`, the three new behavioural assertions fail — reproducing the issue exactly:

```
FAIL: a setup failure names the step that failed: output missing 'setup failed (exit 3)'
FAIL: a setup failure says nothing was graded: output missing 'no tests were graded'
FAIL: a setup failure is not reported as new failures: output unexpectedly contains 'new failure(s)'
```

Against the patched runner: **50 assertions pass**. `shellcheck --severity=warning` clean (CI's threshold; the only findings in these files are pre-existing SC2016 info on jq single-quotes).

A new synthetic suite `brokensetup` drives it — setup fails, run would have passed — so the case is covered by the harness self-test that already runs on every change, not only when a real image pull blips.

Related: #2462 / #2463 covered the mirror image, a *passing* suite reddened by a lost diagnostics artifact.