### PR TITLE
fix(journal): record which writer made a cold entry, and stop restore guessing

### DIFF
--- a/pkg/block/journal/cold.go
+++ b/pkg/block/journal/cold.go
@@ -19,13 +19,24 @@ package journal
 // Layout: <dir>/cold.log, an append-only entry stream, little-endian
 //
 //	off  size  field
-//	0    1     MagicByte    0xC0, torn-write scan anchor
+//	0    1     MagicByte    0xC1, torn-write scan anchor and layout tag
 //	1    2     FileIDLen
 //	3    8     FileOffset
 //	11   8     Length
 //	19   8     Version
-//	27   4     CRC32        over bytes [0,27) and the FileID bytes
-//	31   var   FileID
+//	27   1     Provenance   what Version dates; see coldProvenance
+//	28   4     CRC32        over bytes [0,28) and the FileID bytes
+//	32   var   FileID
+//
+// Entries written before provenance was recorded carry magic 0xC0 and lack the
+// byte, putting CRC at [27,31) and the FileID at 31. They still load, as
+// coldFromUnknown. Only the reader accepts that shape: every append writes 0xC1,
+// so a log stops growing older entries as soon as this build touches it.
+//
+// A build that predates 0xC1 reads it as bad magic, which is a torn entry, which
+// ends the load and drops every entry after it — the silent-zeros failure this
+// log exists to prevent. That is why formatVersion is 2: an older release must
+// refuse the directory outright rather than read it short.
 //
 // Entries are replayed at recovery like any other record — inserted by Version,
 // so a later warm write shadows a cold entry, and the tombstone and truncate
@@ -44,8 +55,13 @@ import (
 )
 
 const (
-	coldMagic      = 0xC0
-	coldHeaderSize = 31
+	// coldMagicLegacy tags an entry written before provenance was recorded; it
+	// is read, never written. coldMagic is the current layout.
+	coldMagicLegacy      = 0xC0
+	coldHeaderSizeLegacy = 31
+
+	coldMagic      = 0xC1
+	coldHeaderSize = 32
 	coldLogName    = "cold.log"
 
 	// coldSeededName is the marker recording that this journal's cold log has
@@ -57,12 +73,48 @@ const (
 	coldCompactFloor = 1024
 )
 
+// coldProvenance records which writer made an entry, because that is what says
+// whether its version dates the *content* or merely the moment a scan noticed
+// the range was remote-durable. Nothing else in the entry distinguishes them,
+// and a reader that assumes one gets the other silently wrong.
+type coldProvenance uint8
+
+const (
+	// coldFromUnknown is a legacy entry: written before provenance was recorded,
+	// so which writer made it cannot be recovered. Readers must treat it as the
+	// eviction case, which is what every reader did before this field existed.
+	coldFromUnknown coldProvenance = 0
+
+	// coldFromData means version was copied off the interval whose local bytes
+	// this entry replaces, so it still dates the content: eviction and
+	// invalidation. A version test answers "did these bytes exist at V".
+	coldFromData coldProvenance = 1
+
+	// coldFromScan means version was minted when a scan found the range already
+	// remote-durable, so it dates the scan and says nothing about the content:
+	// the manifest-seed writers. The version exists only so a racing Delete
+	// sweeps below the entry. A version test answers nothing about the content.
+	coldFromScan coldProvenance = 2
+)
+
+func (p coldProvenance) String() string {
+	switch p {
+	case coldFromData:
+		return "data"
+	case coldFromScan:
+		return "scan"
+	default:
+		return "unknown"
+	}
+}
+
 // coldEntry is one persisted cold interval.
 type coldEntry struct {
-	id      FileID
-	fileOff int64
-	length  int64
-	version uint64
+	id         FileID
+	fileOff    int64
+	length     int64
+	version    uint64
+	provenance coldProvenance
 }
 
 func (s *Store) coldPath() string { return filepath.Join(s.dir, coldLogName) }
@@ -75,8 +127,9 @@ func encodeColdEntry(e coldEntry) []byte {
 	binary.LittleEndian.PutUint64(buf[3:11], uint64(e.fileOff))
 	binary.LittleEndian.PutUint64(buf[11:19], uint64(e.length))
 	binary.LittleEndian.PutUint64(buf[19:27], e.version)
+	buf[27] = byte(e.provenance)
 	copy(buf[coldHeaderSize:], e.id)
-	binary.LittleEndian.PutUint32(buf[27:31], coldEntryCRC(buf[:27], buf[coldHeaderSize:]))
+	binary.LittleEndian.PutUint32(buf[28:32], coldEntryCRC(buf[:28], buf[coldHeaderSize:]))
 	return buf
 }
 
@@ -90,27 +143,47 @@ func coldEntryCRC(head, id []byte) uint32 {
 // total bytes consumed. A malformed entry (bad magic, short read, CRC mismatch)
 // returns errTornRecord, which ends the load.
 func decodeColdEntry(buf []byte) (coldEntry, int, error) {
-	if len(buf) < coldHeaderSize {
+	if len(buf) < 1 {
 		return coldEntry{}, 0, fmt.Errorf("%w: short cold entry header", errTornRecord)
 	}
-	if buf[0] != coldMagic {
+
+	// The magic byte doubles as the layout tag, so the header size and the
+	// offsets of the trailing fields follow from it.
+	var headerSize, crcOff int
+	switch buf[0] {
+	case coldMagic:
+		headerSize, crcOff = coldHeaderSize, 28
+	case coldMagicLegacy:
+		headerSize, crcOff = coldHeaderSizeLegacy, 27
+	default:
 		return coldEntry{}, 0, fmt.Errorf("%w: bad cold entry magic 0x%02x", errTornRecord, buf[0])
 	}
+	if len(buf) < headerSize {
+		return coldEntry{}, 0, fmt.Errorf("%w: short cold entry header", errTornRecord)
+	}
+
 	idLen := int(binary.LittleEndian.Uint16(buf[1:3]))
-	total := coldHeaderSize + idLen
+	total := headerSize + idLen
 	if len(buf) < total {
 		return coldEntry{}, 0, fmt.Errorf("%w: cold entry runs past end of log", errTornRecord)
 	}
-	id := buf[coldHeaderSize:total]
-	want := binary.LittleEndian.Uint32(buf[27:31])
-	if got := coldEntryCRC(buf[:27], id); got != want {
+	id := buf[headerSize:total]
+	want := binary.LittleEndian.Uint32(buf[crcOff : crcOff+4])
+	if got := coldEntryCRC(buf[:crcOff], id); got != want {
 		return coldEntry{}, 0, fmt.Errorf("%w: cold entry CRC mismatch", errTornRecord)
 	}
+
+	// A legacy entry has no provenance byte, so it stays coldFromUnknown.
+	provenance := coldFromUnknown
+	if buf[0] == coldMagic {
+		provenance = coldProvenance(buf[27])
+	}
 	return coldEntry{
-		id:      FileID(id),
-		fileOff: int64(binary.LittleEndian.Uint64(buf[3:11])),
-		length:  int64(binary.LittleEndian.Uint64(buf[11:19])),
-		version: binary.LittleEndian.Uint64(buf[19:27]),
+		id:         FileID(id),
+		fileOff:    int64(binary.LittleEndian.Uint64(buf[3:11])),
+		length:     int64(binary.LittleEndian.Uint64(buf[11:19])),
+		version:    binary.LittleEndian.Uint64(buf[19:27]),
+		provenance: provenance,
 	}, total, nil
 }
 
@@ -308,7 +381,10 @@ func liveColdEntries(indexByShard []map[FileID]*fileIndex) []coldEntry {
 				if !iv.cold {
 					continue
 				}
-				out = append(out, coldEntry{id: id, fileOff: iv.fileOff, length: iv.length, version: iv.version})
+				out = append(out, coldEntry{
+					id: id, fileOff: iv.fileOff, length: iv.length,
+					version: iv.version, provenance: iv.provenance,
+				})
 			}
 		}
 	}

--- a/pkg/block/journal/cold_test.go
+++ b/pkg/block/journal/cold_test.go
@@ -3,6 +3,7 @@ package journal
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -486,5 +487,78 @@ func TestSeedColdBatchIsDurableAndMatchesPerFileSeeding(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("batched seed recorded %v, seeding the same files one at a time recorded %v", got, want)
+	}
+}
+
+// TestColdEntryProvenanceRoundTrips pins that the byte survives the encode and
+// that a pre-provenance entry still loads, as coldFromUnknown. The two shapes
+// differ in header size, so a decoder that assumed one would read the other's
+// FileID out of its CRC.
+func TestColdEntryProvenanceRoundTrips(t *testing.T) {
+	for _, p := range []coldProvenance{coldFromUnknown, coldFromData, coldFromScan} {
+		want := coldEntry{id: FileID("f"), fileOff: 4096, length: 1024, version: 7, provenance: p}
+		buf := encodeColdEntry(want)
+		if buf[0] != coldMagic {
+			t.Fatalf("provenance %s: encoded magic 0x%02x, want the current 0x%02x", p, buf[0], coldMagic)
+		}
+		got, n, err := decodeColdEntry(buf)
+		if err != nil {
+			t.Fatalf("provenance %s: decode: %v", p, err)
+		}
+		if n != len(buf) {
+			t.Fatalf("provenance %s: consumed %d bytes of %d", p, n, len(buf))
+		}
+		if got != want {
+			t.Fatalf("provenance %s: round-tripped to %+v, want %+v", p, got, want)
+		}
+	}
+
+	// A legacy entry, framed the way the log held them before provenance: no
+	// provenance byte, so CRC at [27,31) and the FileID at 31.
+	id := []byte("legacy")
+	legacy := make([]byte, coldHeaderSizeLegacy+len(id))
+	legacy[0] = coldMagicLegacy
+	binary.LittleEndian.PutUint16(legacy[1:3], uint16(len(id)))
+	binary.LittleEndian.PutUint64(legacy[3:11], uint64(8192))
+	binary.LittleEndian.PutUint64(legacy[11:19], uint64(2048))
+	binary.LittleEndian.PutUint64(legacy[19:27], 11)
+	copy(legacy[coldHeaderSizeLegacy:], id)
+	binary.LittleEndian.PutUint32(legacy[27:31], coldEntryCRC(legacy[:27], id))
+
+	got, n, err := decodeColdEntry(legacy)
+	if err != nil {
+		t.Fatalf("decode legacy entry: %v", err)
+	}
+	if n != len(legacy) {
+		t.Fatalf("legacy entry consumed %d bytes of %d", n, len(legacy))
+	}
+	want := coldEntry{id: FileID("legacy"), fileOff: 8192, length: 2048, version: 11, provenance: coldFromUnknown}
+	if got != want {
+		t.Fatalf("legacy entry decoded to %+v, want %+v", got, want)
+	}
+}
+
+// TestLiveColdEntriesKeepsProvenance is the regression for the subtle half of
+// recording provenance: compaction rewrites the log from the interval index, not
+// from the log, so an index that dropped the field would quietly rewrite every
+// entry as coldFromUnknown and undo what the log records.
+func TestLiveColdEntriesKeepsProvenance(t *testing.T) {
+	fi := &fileIndex{}
+	fi.insert(interval{fileOff: 0, length: 512, version: 3, synced: true, cold: true, provenance: coldFromScan})
+	fi.insert(interval{fileOff: 4096, length: 512, version: 4, synced: true, cold: true, provenance: coldFromData})
+
+	out := liveColdEntries([]map[FileID]*fileIndex{{FileID("f"): fi}})
+	if len(out) != 2 {
+		t.Fatalf("liveColdEntries returned %d entries, want 2: %+v", len(out), out)
+	}
+	byOff := map[int64]coldProvenance{}
+	for _, e := range out {
+		byOff[e.fileOff] = e.provenance
+	}
+	if byOff[0] != coldFromScan {
+		t.Errorf("seeded interval came back as %s, want scan", byOff[0])
+	}
+	if byOff[4096] != coldFromData {
+		t.Errorf("evicted interval came back as %s, want data", byOff[4096])
 	}
 }

--- a/pkg/block/journal/cold_test.go
+++ b/pkg/block/journal/cold_test.go
@@ -562,3 +562,26 @@ func TestLiveColdEntriesKeepsProvenance(t *testing.T) {
 		t.Errorf("evicted interval came back as %s, want data", byOff[4096])
 	}
 }
+
+// TestClampKeepsProvenance pins provenance across a trim. A cold interval is
+// clamped whenever a neighbouring write punches part of it out, and compaction
+// rebuilds the log from the index, so a clamp that dropped the field would put
+// coldFromUnknown on disk for a range whose writer was known.
+func TestClampKeepsProvenance(t *testing.T) {
+	fi := &fileIndex{}
+	fi.insert(interval{fileOff: 0, length: 4096, version: 3, synced: true, cold: true, provenance: coldFromScan})
+
+	// A later warm write over the middle splits the cold interval in two, so
+	// both survivors come from clamp.
+	fi.insert(interval{fileOff: 1024, length: 1024, version: 4, synced: false})
+
+	out := liveColdEntries([]map[FileID]*fileIndex{{FileID("f"): fi}})
+	if len(out) != 2 {
+		t.Fatalf("expected the cold interval to survive as two fragments, got %d: %+v", len(out), out)
+	}
+	for _, e := range out {
+		if e.provenance != coldFromScan {
+			t.Errorf("fragment at %d came back as %s, want scan", e.fileOff, e.provenance)
+		}
+	}
+}

--- a/pkg/block/journal/format.go
+++ b/pkg/block/journal/format.go
@@ -30,7 +30,12 @@ const (
 	// a change makes state unreadable by the previous release — a new sibling
 	// file, a moved record field, a renamed key — so that release refuses rather
 	// than reads holes.
-	formatVersion = 1
+	//
+	// 2: cold log entries carry a provenance byte under a new magic (see
+	// cold.go). A release that predates it reads that magic as a torn entry and
+	// ends the load there, dropping every cold interval recorded after it and
+	// serving those ranges as holes — so it must refuse the directory instead.
+	formatVersion = 2
 
 	formatFileName = "format"
 )
@@ -43,9 +48,17 @@ type formatStamp struct {
 }
 
 // CheckFormat verifies that this build understands the journal directory's
-// on-disk layout, and stamps the directory when it is not yet stamped. An
-// unstamped directory predates stamping and is adopted, so every later open is
-// guarded; a stamp above formatVersion fails with block.ErrFutureFormat.
+// on-disk layout, and brings the stamp up to what this build may write. An
+// unstamped directory predates stamping and is adopted; a stamp above
+// formatVersion fails with block.ErrFutureFormat.
+//
+// A stamp *below* formatVersion is raised, not left alone. The stamp has to
+// describe what the directory may now contain, and this build starts writing
+// the current shapes into it the moment it opens — cold log entries under the
+// current magic, for one. Leaving an old stamp in place would let the previous
+// release open the directory afterwards and then meet exactly the shape the
+// stamp exists to keep it away from, which for the cold log means reading a
+// remote-durable range as a hole and serving zeros.
 //
 // Call it before opening the journal: the point is to not touch state whose
 // shape is unknown.
@@ -66,6 +79,9 @@ func CheckFormat(dir string) error {
 	if st.Version > formatVersion {
 		return fmt.Errorf("%w: %s is at format version %d, this build reads up to %d",
 			block.ErrFutureFormat, dir, st.Version, formatVersion)
+	}
+	if st.Version < formatVersion {
+		return writeFormat(dir)
 	}
 	return nil
 }

--- a/pkg/block/journal/index.go
+++ b/pkg/block/journal/index.go
@@ -65,6 +65,10 @@ func (iv interval) clamp(lo, hi int64) interval {
 		recOff:  iv.recOff,
 		synced:  iv.synced,
 		cold:    iv.cold,
+		// Trimming a cold interval must not forget which writer recorded it:
+		// compaction rebuilds the log from the index, so a dropped provenance
+		// here comes back as coldFromUnknown on disk.
+		provenance: iv.provenance,
 		loc: SegmentLocation{
 			SegmentID: iv.loc.SegmentID,
 			Offset:    iv.loc.Offset + frontTrim,

--- a/pkg/block/journal/index.go
+++ b/pkg/block/journal/index.go
@@ -43,6 +43,12 @@ type interval struct {
 	// local bytes have been evicted. Distinct from an absent interval (a true
 	// hole): a cold range is served by fetching from the remote store.
 	cold bool
+	// provenance mirrors the cold log entry this interval was loaded from, and
+	// is meaningless unless cold. It rides the index because compaction rebuilds
+	// the log from the index (liveColdEntries): dropping it here would rewrite
+	// every entry as coldFromUnknown at the first compaction, silently undoing
+	// what the log records.
+	provenance coldProvenance
 }
 
 func (iv interval) end() int64 { return iv.fileOff + iv.length }
@@ -546,4 +552,18 @@ func (fi *fileIndex) hydratable(off, n int64, mark uint64) [][2]int64 {
 // coversWhole reports whether ranges is exactly the single span [off, off+n).
 func coversWhole(ranges [][2]int64, off, n int64) bool {
 	return len(ranges) == 1 && ranges[0][0] == off && ranges[0][1] == off+n
+}
+
+// overlappingWrite reports the first interval in writes that overlaps
+// [off, off+length), if any. Used by the restore's cold fold, where writes are
+// the post-watermark records that reached the remote: a handful per file at
+// most, so a linear scan is cheaper than sorting them.
+func overlappingWrite(writes []interval, off, length int64) (interval, bool) {
+	end := off + length
+	for _, w := range writes {
+		if w.fileOff < end && w.end() > off {
+			return w, true
+		}
+	}
+	return interval{}, false
 }

--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -264,6 +264,8 @@ func (s *Store) evictSegment(sh *shard, seg *segmentMeta) (freed int64, err erro
 					fileOff: fi.ivs[k].fileOff,
 					length:  fi.ivs[k].length,
 					version: fi.ivs[k].version,
+					// Copied off the interval being replaced, so it dates the content.
+					provenance: coldFromData,
 				})
 			}
 		}

--- a/pkg/block/journal/recovery.go
+++ b/pkg/block/journal/recovery.go
@@ -385,6 +385,8 @@ func (r *recoveryState) applyColdLog() error {
 			version: e.version,
 			synced:  true,
 			cold:    true,
+			// Carried so a compaction can write it back out (liveColdEntries).
+			provenance: e.provenance,
 		})
 	}
 	return nil

--- a/pkg/block/journal/restore_test.go
+++ b/pkg/block/journal/restore_test.go
@@ -414,3 +414,67 @@ func TestRestoreToVersion_RefusesAShardWhoseFsyncHasPermanentlyFailed(t *testing
 		t.Fatal("RestoreToVersion reported success for a shard whose fsync has permanently failed")
 	}
 }
+
+// TestRestoreToVersion_RefusesSeededRangeOverwrittenOnRemote pins the one case a
+// manifest-seeded cold entry cannot answer for.
+//
+// The entry's version dates the scan that found the range remote-durable, not
+// the bytes, and what a cold read returns is whatever the remote holds now. A
+// post-V write that reached the remote replaced that copy, so serving the entry
+// would hand back content from after the requested version while reporting
+// success. Neither of the two silent choices is acceptable, so the restore
+// refuses.
+//
+// Hydrate is what makes the post-V write reach the remote: it records the range
+// already synced, where WriteAt leaves it local-only. The sibling cases above
+// use WriteAt and must keep restoring, which is the whole point of testing on
+// the synced flag rather than on the overlap alone.
+func TestRestoreToVersion_RefusesSeededRangeOverwrittenOnRemote(t *testing.T) {
+	f := newRestoreFixture(t, 1)
+	ctx := context.Background()
+
+	const span = 1024
+	id := FileID("seeded-then-remote-overwritten")
+
+	if err := f.SeedCold(ctx, id, [][2]int64{{0, span}}); err != nil {
+		t.Fatalf("SeedCold: %v", err)
+	}
+	target := f.commitAll()
+
+	if err := f.Hydrate(ctx, id, 0, bytes.Repeat([]byte("post"), span/4), 0); err != nil {
+		t.Fatalf("Hydrate post-V: %v", err)
+	}
+	f.commitAll()
+
+	err := f.RestoreToVersion(ctx, target)
+	if !errors.Is(err, ErrColdProvenanceAmbiguous) {
+		t.Fatalf("RestoreToVersion: want ErrColdProvenanceAmbiguous, got %v", err)
+	}
+}
+
+// TestRestoreToVersion_KeepsSeededRangeOverwrittenLocally is the negative half of
+// the case above: the same shape with a post-V write that never left the local
+// tier. The remote still holds what the seed described, the restore is about to
+// drop the local bytes anyway, so the entry is still good and the restore must
+// proceed rather than refuse.
+func TestRestoreToVersion_KeepsSeededRangeOverwrittenLocally(t *testing.T) {
+	f := newRestoreFixture(t, 1)
+	ctx := context.Background()
+
+	const span = 1024
+	id := FileID("seeded-then-locally-overwritten")
+
+	if err := f.SeedCold(ctx, id, [][2]int64{{0, span}}); err != nil {
+		t.Fatalf("SeedCold: %v", err)
+	}
+	target := f.commitAll()
+
+	f.write(id, 0, bytes.Repeat([]byte("post"), span/4))
+	f.commitAll()
+
+	if err := f.RestoreToVersion(ctx, target); err != nil {
+		t.Fatalf("RestoreToVersion: %v", err)
+	}
+	assertColdAt(t, f.Store, id, 0, span, "pre-crash")
+	assertColdAt(t, f.crashReopen(), id, 0, span, "post-crash")
+}

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -25,6 +25,13 @@ type BlockID string
 // errClosed is returned by every operation attempted on a closed Store.
 var errClosed = errors.New("journal: store closed")
 
+// ErrColdProvenanceAmbiguous is returned by RestoreToVersion when the cold log
+// holds a manifest-seeded entry. Such an entry's version dates the scan that
+// found the range remote-durable, not the content, so no version test decides
+// whether the range belonged to the requested version — see the fold in
+// RestoreToVersion.
+var ErrColdProvenanceAmbiguous = errors.New("journal: cold entry provenance cannot date the content")
+
 // minSegmentSize is the floor for Config.SegmentSize. A segment must comfortably
 // hold its header plus real records; below this a single write could exceed the
 // cap. 1 MiB clears the largest protocol write plus framing with wide margin.
@@ -588,6 +595,8 @@ func (s *Store) SeedCold(_ context.Context, id FileID, extents [][2]int64) error
 			version: e.version,
 			synced:  true,
 			cold:    true,
+			// Carried so a compaction can write it back out (liveColdEntries).
+			provenance: e.provenance,
 		})
 	}
 	return nil
@@ -604,7 +613,10 @@ func (s *Store) planColdSeed(sh *shard, id FileID, extents [][2]int64) []coldEnt
 			continue
 		}
 		if fi == nil { // unknown file: the whole extent is a hole
-			entries = append(entries, coldEntry{id: id, fileOff: e[0], length: e[1], version: s.nextVersion()})
+			entries = append(entries, coldEntry{
+				id: id, fileOff: e[0], length: e[1],
+				version: s.nextVersion(), provenance: coldFromScan,
+			})
 			continue
 		}
 		for _, p := range fi.plan(e[0], e[1]) {
@@ -616,6 +628,8 @@ func (s *Store) planColdSeed(sh *shard, id FileID, extents [][2]int64) []coldEnt
 				fileOff: e[0] + p.dstStart,
 				length:  p.dstEnd - p.dstStart,
 				version: s.nextVersion(),
+				// Minted here, so it dates this scan and not the content.
+				provenance: coldFromScan,
 			})
 		}
 	}
@@ -683,6 +697,8 @@ func (s *Store) SeedColdBatch(_ context.Context, seeds []ColdSeed) error {
 			version: e.version,
 			synced:  true,
 			cold:    true,
+			// Carried so a compaction can write it back out (liveColdEntries).
+			provenance: e.provenance,
 		})
 		sh.mu.Unlock()
 	}
@@ -1171,6 +1187,16 @@ func (s *Store) RestoreToVersion(ctx context.Context, v uint64) error {
 	vIndex := map[FileID]*fileIndex{}
 	tombstones := map[FileID]uint64{}
 	truncations := map[FileID]truncMark{}
+	// postV collects the *synced* ranges written above the watermark, which
+	// phase 1 otherwise only skips. A manifest-seeded cold entry needs them: the
+	// seed says the range is remote-durable but dates only the scan, so it is
+	// the remote's current copy that gets served. A post-V write that reached
+	// the remote replaced that copy, which makes the entry point at content from
+	// after V. An unsynced post-V write does not: its bytes never left the local
+	// tier, the restore is about to drop them, and the remote still holds what
+	// the seed described. Only the synced ones are collected, because only they
+	// make the entry ambiguous.
+	postV := map[FileID][]interval{}
 	for _, sh := range s.shards {
 		sh.mu.Lock()
 		segs := make([]*segmentMeta, 0, len(sh.sealed)+1)
@@ -1186,7 +1212,18 @@ func (s *Store) RestoreToVersion(ctx context.Context, v uint64) error {
 			recs, _ := scanValidRecords(seg.fd, s.cfg.SegmentSize, s.cfg.SegmentSize)
 			for _, rec := range recs {
 				if rec.header.Version > v {
-					continue // above the watermark: belongs to a post-snapshot state
+					// Above the watermark: belongs to a post-snapshot state. Keep
+					// the data writes' ranges for the cold fold below.
+					if rec.header.Flags&(flagTombstone|flagTruncate) == 0 &&
+						rec.header.Flags&flagSynced != 0 && rec.header.PayloadLen > 0 {
+						fid := FileID(rec.fileID)
+						postV[fid] = append(postV[fid], interval{
+							fileOff: int64(rec.header.FileOffset),
+							length:  int64(rec.header.PayloadLen),
+							version: rec.header.Version,
+						})
+					}
+					continue
 				}
 				fid := FileID(rec.fileID)
 				switch {
@@ -1229,31 +1266,48 @@ func (s *Store) RestoreToVersion(ctx context.Context, v uint64) error {
 	// own tail back on a failed write, so a live store's log ends intact.
 	//
 	// The version test below asks whether the content existed at V, and only one
-	// of the log's two writers records something that answers it. Eviction copies
-	// the version off the interval it replaces, so its entry still dates the data.
-	// A seed mints a fresh one, dating the scan that noticed the range was
-	// remote-durable: that version exists so a racing Delete sweeps below the
-	// entry, and says nothing about when the bytes were written. An entry does not
-	// record which writer made it, so the two cannot be told apart here.
+	// of the log's two writer kinds records something that answers it. Eviction
+	// and invalidation copy the version off the interval they replace, so their
+	// entries still date the data. A manifest seed mints a fresh one, dating the
+	// scan that noticed the range was remote-durable: that version exists so a
+	// racing Delete sweeps below the entry, and says nothing about when the bytes
+	// were written. Each entry records which kind wrote it, so the two are told
+	// apart here rather than assumed.
 	//
-	// Eviction is the only writer that reaches a store this runs against — both
-	// manifest-seed callers require the share to have a remote, and this method
-	// runs only on a restore's local-only branch. The exception is a store seeded
-	// while it had a remote that was later detached.
+	// A seed-dated entry is refused instead of guessed at, because both guesses
+	// are silently wrong: skipping it leaves the hole this fold exists to
+	// prevent, and including it resurrects whatever the manifest holds *now* for
+	// a range that may have been written after V. A restore that cannot answer
+	// for a range must say so rather than return bytes it cannot vouch for.
 	//
-	// ponytail: on that store a seeded entry is skipped as post-V, which is the
-	// same lost cold range this fold exists to prevent. The entry alone cannot do
-	// better — including it unconditionally would instead resurrect content written
-	// after V, because a seed describes the file as the manifest currently has it.
-	// Closing it needs the entry to record its writer, a change to a durable
-	// on-disk format that wants its own migration.
+	// An entry from before provenance was recorded reads as coldFromUnknown and
+	// keeps the version test. That is the pre-existing behaviour, and it is right
+	// for the overwhelming majority of such entries: eviction is the only writer
+	// that reaches a store this method runs against, because both seed callers
+	// require the share to have a remote and this runs on a restore's local-only
+	// branch. The residual case is a store seeded while it had a remote that was
+	// later detached, whose legacy entries cannot be distinguished — those logs
+	// re-stamp themselves as soon as this build appends or compacts.
 	coldEntries, _, cerr := loadCold(s.dir)
 	if cerr != nil {
 		return fmt.Errorf("journal: restore: load cold log: %w", cerr)
 	}
 	for _, e := range coldEntries {
-		if e.length <= 0 || e.version > v {
+		if e.length <= 0 {
 			continue
+		}
+		if e.version > v {
+			continue
+		}
+		if e.provenance == coldFromScan {
+			if w, ok := overlappingWrite(postV[e.id], e.fileOff, e.length); ok {
+				return fmt.Errorf("%w: file %s range [%d,%d) is cold from a manifest seed at version %d, "+
+					"and version %d wrote [%d,%d) over it and reached the remote after the requested version %d — "+
+					"the remote copy the entry points at is that later content, and the seed's version dates the "+
+					"scan, not the bytes",
+					ErrColdProvenanceAmbiguous, e.id, e.fileOff, e.fileOff+e.length, e.version,
+					w.version, w.fileOff, w.end(), v)
+			}
 		}
 		fi := vIndex[e.id]
 		if fi == nil {
@@ -1266,6 +1320,8 @@ func (s *Store) RestoreToVersion(ctx context.Context, v uint64) error {
 			version: e.version,
 			synced:  true,
 			cold:    true,
+			// Carried so a compaction can write it back out (liveColdEntries).
+			provenance: e.provenance,
 		})
 	}
 
@@ -1463,6 +1519,9 @@ func (s *Store) Invalidate(_ context.Context, id FileID, off, length int64) erro
 			fileOff: iv.fileOff,
 			length:  iv.length,
 			version: iv.version,
+			// Copied off the interval whose local bytes just failed checksum, so
+			// it dates the content exactly as eviction's does.
+			provenance: coldFromData,
 		})
 	}
 	if len(entries) == 0 {

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -25,11 +25,13 @@ type BlockID string
 // errClosed is returned by every operation attempted on a closed Store.
 var errClosed = errors.New("journal: store closed")
 
-// ErrColdProvenanceAmbiguous is returned by RestoreToVersion when the cold log
-// holds a manifest-seeded entry. Such an entry's version dates the scan that
-// found the range remote-durable, not the content, so no version test decides
-// whether the range belonged to the requested version — see the fold in
-// RestoreToVersion.
+// ErrColdProvenanceAmbiguous is returned by RestoreToVersion when a
+// manifest-seeded cold entry covers a range that a later write overwrote and
+// synced past the requested version. The entry's version dates the scan that
+// found the range remote-durable, not the bytes, and the remote copy it points
+// at is now that later content — so neither serving it nor dropping it answers
+// for the requested version. A seeded entry on its own is not ambiguous and
+// does not produce this: see the fold in RestoreToVersion.
 var ErrColdProvenanceAmbiguous = errors.New("journal: cold entry provenance cannot date the content")
 
 // minSegmentSize is the floor for Config.SegmentSize. A segment must comfortably

--- a/pkg/block/local/fs/format_test.go
+++ b/pkg/block/local/fs/format_test.go
@@ -36,6 +36,11 @@ func readStampVersion(t *testing.T, dir string) int {
 	return st.Version
 }
 
+// journalFormatVersion mirrors journal's unexported formatVersion. Kept here so
+// these cases read as "current", "one above" and "one below" rather than as bare
+// numbers that go stale on the next bump.
+const journalFormatVersion = 2
+
 // writeStamp plants a stamp at version v, standing in for a directory a
 // different release left behind.
 func writeStamp(t *testing.T, dir string, v int) {
@@ -54,7 +59,7 @@ func writeStamp(t *testing.T, dir string, v int) {
 // would read every range the newer format holds elsewhere as a hole.
 func TestOpenRefusesFutureFormat(t *testing.T) {
 	dir := t.TempDir()
-	writeStamp(t, dir, 2)
+	writeStamp(t, dir, journalFormatVersion+1)
 
 	s, err := New(dir, 1<<30, nil)
 	if err == nil {
@@ -70,7 +75,7 @@ func TestOpenRefusesFutureFormat(t *testing.T) {
 // wrote itself.
 func TestOpenAcceptsCurrentFormat(t *testing.T) {
 	dir := t.TempDir()
-	writeStamp(t, dir, 1)
+	writeStamp(t, dir, journalFormatVersion)
 
 	s, err := New(dir, 1<<30, nil)
 	if err != nil {
@@ -79,8 +84,28 @@ func TestOpenAcceptsCurrentFormat(t *testing.T) {
 	if err := s.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	if got := readStampVersion(t, dir); got != 1 {
-		t.Fatalf("stamp version after open = %d, want 1", got)
+	if got := readStampVersion(t, dir); got != journalFormatVersion {
+		t.Fatalf("stamp version after open = %d, want %d", got, journalFormatVersion)
+	}
+}
+
+// TestOpenRaisesStaleStamp is the other half of the downgrade guard. Opening
+// with an older stamp left in place would let the previous release open the
+// directory again after this build had already written current-format state
+// into it — the shape the stamp exists to keep it away from.
+func TestOpenRaisesStaleStamp(t *testing.T) {
+	dir := t.TempDir()
+	writeStamp(t, dir, journalFormatVersion-1)
+
+	s, err := New(dir, 1<<30, nil)
+	if err != nil {
+		t.Fatalf("New on an older-format directory: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if got := readStampVersion(t, dir); got != journalFormatVersion {
+		t.Fatalf("stamp version after open = %d, want it raised to %d", got, journalFormatVersion)
 	}
 }
 
@@ -97,7 +122,7 @@ func TestOpenStampsUnstampedDir(t *testing.T) {
 	if err := s.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	if got := readStampVersion(t, dir); got != 1 {
-		t.Fatalf("stamp version after open = %d, want 1", got)
+	if got := readStampVersion(t, dir); got != journalFormatVersion {
+		t.Fatalf("stamp version after open = %d, want %d", got, journalFormatVersion)
 	}
 }


### PR DESCRIPTION
Closes #2260.

## Premise, checked first

Verified against develop before writing anything, and it holds — with one refinement:

| writer | version it stamps | what that dates |
| --- | --- | --- |
| `evictSegment` (`reclaim.go:266`) | the interval's own | the content |
| `Invalidate` (`store.go:1473`) | the interval's own | the content |
| `SeedCold` / `SeedColdBatch` via `planColdSeed` | `s.nextVersion()` | the scan |

The issue names two writers; there are four. `Invalidate` is the one it missed, and it falls on the
content-dated side, so the conclusion stands. `RestoreToVersion` read all of them as content-dated.
The `ponytail:` marker at the fold already named this and its fix, and is now removed rather than
reworded.

## What the record gains

A provenance byte, under magic `0xC1`. The old `0xC0` framing still loads, as `coldFromUnknown`,
which keeps the pre-existing behaviour for entries whose writer was never recorded.

**The interval index carries it too**, which is the half that is easy to miss: compaction rebuilds
the log from the index (`liveColdEntries`), not from the log, so an index without the field would
have quietly rewritten every entry as `unknown` at the first compaction and undone the whole change.
`TestLiveColdEntriesKeepsProvenance` pins that, and I checked it fails when the field is dropped.

There are **two** such paths, and Copilot caught the one I missed: `clamp` rebuilds an interval field
by field when a neighbouring write splits a cold range, and it dropped provenance the same way — so a
trimmed cold range reached disk as `unknown`. `without()` trims through `clamp`, so one line covers
both. `TestClampKeepsProvenance` pins it through `liveColdEntries`, also checked against a broken
build. I had found the first path and stopped auditing rather than enumerating every place an
interval is rebuilt.

## What restore does with it — narrower than my first attempt

My first version refused **any** seeded entry, on the issue's "neither branch is correct" reading.
Two existing cases refuted that:

- `TestRestoreToVersion_KeepsFullyColdFile` — a file seeded below V must survive the rewind.
- `TestRestoreToVersion_KeepsColdRangesOfMixedFile` — a seeded half overwritten **locally** after V
  must come back cold.

They are right, and they show the version test *is* meaningful for a seed: it is a true statement
about what the journal knew at V, even though it says nothing about the bytes. Refusing outright
would have broken restore on any store that ever seeded — an availability regression far wider than
the defect.

So the version test stays for both kinds. What is refused is the case it genuinely cannot cover:

> a seeded range that a post-V write overwrote **and synced**

There the remote copy the entry points at *is* post-V content, so serving it returns a state the
caller did not ask for while reporting success. An unsynced post-V write does not qualify — its
bytes never left the local tier, the restore is about to drop them, and the remote still holds what
the seed described. Testing the synced flag rather than the overlap is what lets the two cases above
keep passing; the overlap alone failed the second one.

New cases, both directions:

- `TestRestoreToVersion_RefusesSeededRangeOverwrittenOnRemote` — `Hydrate` post-V (records the range
  already synced) ⇒ `ErrColdProvenanceAmbiguous`.
- `TestRestoreToVersion_KeepsSeededRangeOverwrittenLocally` — `WriteAt` post-V ⇒ restore proceeds and
  the range comes back cold.

## The format bump, and why it was not enough on its own

`formatVersion` 1 → 2: a release predating `0xC1` reads it as bad magic, which is a torn entry,
which **ends the load** — dropping every cold interval after it and serving those ranges as holes.
That is the silent-zeros failure the cold log exists to prevent, so an older release has to refuse
the directory.

But the bump alone did not achieve that. `CheckFormat` stamped only *unstamped* directories, so a
directory stamped 1 kept its stamp while this build wrote `0xC1` entries into it — and the previous
release would then open it happily and read it short. `CheckFormat` now raises a stale stamp, so the
stamp describes what the directory may contain. `TestOpenRaisesStaleStamp` covers it, and the
existing format cases are now written against a named current version instead of bare `1`/`2`.

## Verification

- Full `./pkg/block/...` green; `golangci-lint run pkg/block/...` 0 issues.
- Both new restore cases and the compaction case checked against a deliberately broken build.
- No behaviour change for evicted or invalidated ranges, which is every cold entry on a store
  without a remote.
