### PR TITLE
feat(nfs): grant delegations to NFSv4.1 clients on a verified callback path

### DIFF
--- a/internal/adapter/nfs/v4/handlers/open.go
+++ b/internal/adapter/nfs/v4/handlers/open.go
@@ -78,13 +78,25 @@ func (h *Handler) handleOpen(ctx *types.CompoundContext, reader io.Reader) (resu
 	}
 	logger.Debug("NFSv4 OPEN share", "access", shareAccess, "deny", shareDeny)
 
+	// A v4.1 client can use the high share_access bits to say it wants no
+	// delegation, or to cancel a standing want. Read that before the mask
+	// below discards them, since it is the only thing outside the access mode
+	// that this server acts on. A v4.0 client's high bits mean nothing in RFC
+	// 7530 and it could not decode the reply arm that reports a reason, so it
+	// is never asked.
+	var noDelegWhy *uint32
+	if ctx.IsV41OrLater() {
+		if why, refuse := state.DelegationWantReason(shareAccess); refuse {
+			noDelegWhy = &why
+		}
+	}
+
 	// Validate the share_access / share_deny modes (RFC 7530 Section 16.16).
 	// The access mode (low 2 bits) must be exactly READ, WRITE, or BOTH; the
 	// deny mode must be a subset of {READ, WRITE}. Reject anything else with
-	// NFS4ERR_INVAL before touching state. The server ignores any higher
-	// share_access bits (e.g. the v4.1 want-delegation hints), so the access
-	// mode is masked to OPEN4_SHARE_ACCESS_BOTH and the masked value carried
-	// forward consistently with the rest of the handler.
+	// NFS4ERR_INVAL before touching state. Every remaining share_access bit is
+	// ignored, so the access mode is masked to OPEN4_SHARE_ACCESS_BOTH and the
+	// masked value carried forward consistently with the rest of the handler.
 	accessMode := shareAccess & uint32(types.OPEN4_SHARE_ACCESS_BOTH)
 	if accessMode == 0 {
 		logger.Debug("NFSv4 OPEN invalid share_access", "access", shareAccess, "client", ctx.ClientAddr)
@@ -231,7 +243,8 @@ func (h *Handler) handleOpen(ctx *types.CompoundContext, reader io.Reader) (resu
 		}
 
 		return h.handleOpenClaimNull(ctx, reader, seqid, shareAccess, shareDeny,
-			clientID, ownerData, openType, createMode, claimType, createAttrs, createVerifier)
+			clientID, ownerData, openType, createMode, claimType, createAttrs, createVerifier,
+			noDelegWhy)
 
 	case types.CLAIM_FH:
 		// CLAIM_FH (RFC 8881 Section 18.16.3): re-open the file named by the
@@ -254,7 +267,7 @@ func (h *Handler) handleOpen(ctx *types.CompoundContext, reader io.Reader) (resu
 			return openError(types.NFS4ERR_INVAL)
 		}
 		return h.handleOpenClaimFH(ctx, seqid, shareAccess, shareDeny,
-			clientID, ownerData, claimType)
+			clientID, ownerData, claimType, noDelegWhy)
 
 	case types.CLAIM_PREVIOUS:
 		return h.handleOpenClaimPrevious(ctx, reader, seqid, shareAccess, shareDeny,
@@ -286,6 +299,7 @@ func (h *Handler) handleOpenClaimNull(
 	openType, createMode, claimType uint32,
 	createAttrs *metadata.SetAttrs,
 	createVerifier *uint64,
+	noDelegWhy *uint32,
 ) *types.CompoundResult {
 	// CLAIM_NULL: decode filename (component4 = XDR string)
 	filename, err := xdr.DecodeString(reader)
@@ -551,7 +565,7 @@ func (h *Handler) handleOpenClaimNull(
 
 	// Try to grant a delegation
 
-	deleg, noneExtWhy := h.resolveDelegation(ctx, clientID, []byte(fileHandle), shareAccess)
+	deleg, noneExtWhy := h.resolveDelegation(clientID, []byte(fileHandle), shareAccess, noDelegWhy)
 
 	// Directory change notifications for OPEN+CREATE are now handled by
 	// MetadataService.CreateFile via DirChangeNotifier -> LockManager -> BreakCallbacks.
@@ -584,6 +598,7 @@ func (h *Handler) handleOpenClaimFH(
 	seqid, shareAccess, shareDeny uint32,
 	clientID uint64, ownerData []byte,
 	claimType uint32,
+	noDelegWhy *uint32,
 ) *types.CompoundResult {
 	// The current filehandle is the file being opened.
 	fileHandle := make(metadata.FileHandle, len(ctx.CurrentFH))
@@ -643,7 +658,7 @@ func (h *Handler) handleOpenClaimFH(
 		_ = h.StateManager.ConfirmOpenV41(&openResult.Stateid, ctx.SessionClientID)
 	}
 
-	deleg, noneExtWhy := h.resolveDelegation(ctx, clientID, []byte(fileHandle), shareAccess)
+	deleg, noneExtWhy := h.resolveDelegation(clientID, []byte(fileHandle), shareAccess, noDelegWhy)
 
 	logger.Debug("NFSv4 OPEN CLAIM_FH successful",
 		"stateid_seqid", openResult.Stateid.Seqid,
@@ -749,15 +764,13 @@ func (h *Handler) handleOpenClaimPrevious(
 // (WND4_CONTENTION, WND4_RESOURCE) each carry a promise to follow up when the
 // obstacle clears that this server does not keep.
 func (h *Handler) resolveDelegation(
-	ctx *types.CompoundContext,
 	clientID uint64,
 	fileHandle []byte,
 	shareAccess uint32,
+	noDelegWhy *uint32,
 ) (*state.DelegationState, *uint32) {
-	if ctx.IsV41OrLater() {
-		if why, refuse := state.DelegationWantReason(shareAccess); refuse {
-			return nil, &why
-		}
+	if noDelegWhy != nil {
+		return nil, noDelegWhy
 	}
 
 	delegType, shouldGrant := h.StateManager.ShouldGrantDelegation(clientID, fileHandle, shareAccess)

--- a/internal/adapter/nfs/v4/handlers/open.go
+++ b/internal/adapter/nfs/v4/handlers/open.go
@@ -551,11 +551,7 @@ func (h *Handler) handleOpenClaimNull(
 
 	// Try to grant a delegation
 
-	delegType, shouldGrant := h.StateManager.ShouldGrantDelegation(clientID, []byte(fileHandle), shareAccess)
-	var deleg *state.DelegationState
-	if shouldGrant {
-		deleg = h.StateManager.GrantDelegation(clientID, []byte(fileHandle), delegType)
-	}
+	deleg, noneExtWhy := h.resolveDelegation(ctx, clientID, []byte(fileHandle), shareAccess)
 
 	// Directory change notifications for OPEN+CREATE are now handled by
 	// MetadataService.CreateFile via DirChangeNotifier -> LockManager -> BreakCallbacks.
@@ -573,7 +569,7 @@ func (h *Handler) handleOpenClaimNull(
 	// Encode OPEN4resok
 
 	return h.encodeOpenResult(clientID, ownerData, &openResult.Stateid, openResult.RFlags,
-		beforeCtime, afterCtime, deleg)
+		beforeCtime, afterCtime, deleg, noneExtWhy)
 }
 
 // handleOpenClaimFH handles the CLAIM_FH path for OPEN (NFSv4.1).
@@ -647,11 +643,7 @@ func (h *Handler) handleOpenClaimFH(
 		_ = h.StateManager.ConfirmOpenV41(&openResult.Stateid, ctx.SessionClientID)
 	}
 
-	delegType, shouldGrant := h.StateManager.ShouldGrantDelegation(clientID, []byte(fileHandle), shareAccess)
-	var deleg *state.DelegationState
-	if shouldGrant {
-		deleg = h.StateManager.GrantDelegation(clientID, []byte(fileHandle), delegType)
-	}
+	deleg, noneExtWhy := h.resolveDelegation(ctx, clientID, []byte(fileHandle), shareAccess)
 
 	logger.Debug("NFSv4 OPEN CLAIM_FH successful",
 		"stateid_seqid", openResult.Stateid.Seqid,
@@ -661,7 +653,7 @@ func (h *Handler) handleOpenClaimFH(
 
 	// CLAIM_FH does not create or change a directory, so change_info is empty.
 	return h.encodeOpenResult(clientID, ownerData, &openResult.Stateid, openResult.RFlags,
-		0, 0, deleg)
+		0, 0, deleg, noneExtWhy)
 }
 
 // handleOpenClaimPrevious handles the CLAIM_PREVIOUS path for OPEN.
@@ -737,19 +729,59 @@ func (h *Handler) handleOpenClaimPrevious(
 
 	// Use dummy change_info (reclaim doesn't create new files)
 	return h.encodeOpenResult(clientID, ownerData, &openResult.Stateid, openResult.RFlags,
-		0, 0, nil)
+		0, 0, nil, nil)
+}
+
+// resolveDelegation decides the open_delegation4 arm for an OPEN that is
+// eligible to receive a delegation, returning either the delegation it granted
+// or the why_no_delegation4 reason to report for withholding one.
+//
+// A v4.1 client can say in share_access that it does not want a delegation, or
+// that it is cancelling a standing want. Those are answers, not preferences, so
+// they skip the grant policy entirely and come back as a reason. A v4.0 client
+// cannot decode OPEN_DELEGATE_NONE_EXT, so it never gets a reason -- its want
+// bits are meaningless in RFC 7530 and its refusals stay a plain
+// OPEN_DELEGATE_NONE.
+//
+// Everything else -- no callback path, contention, an existing delegation on
+// the file -- also answers plain OPEN_DELEGATE_NONE. Reporting a reason there
+// is permitted but not required, and the reasons that would apply
+// (WND4_CONTENTION, WND4_RESOURCE) each carry a promise to follow up when the
+// obstacle clears that this server does not keep.
+func (h *Handler) resolveDelegation(
+	ctx *types.CompoundContext,
+	clientID uint64,
+	fileHandle []byte,
+	shareAccess uint32,
+) (*state.DelegationState, *uint32) {
+	if ctx.IsV41OrLater() {
+		if why, refuse := state.DelegationWantReason(shareAccess); refuse {
+			return nil, &why
+		}
+	}
+
+	delegType, shouldGrant := h.StateManager.ShouldGrantDelegation(clientID, fileHandle, shareAccess)
+	if !shouldGrant {
+		return nil, nil
+	}
+	return h.StateManager.GrantDelegation(clientID, fileHandle, delegType), nil
 }
 
 // encodeOpenResult encodes the OPEN4resok response shared by all claim paths.
 //
-// The deleg parameter controls the open_delegation4 response:
-//   - nil: OPEN_DELEGATE_NONE
-//   - non-nil: full delegation encoding (stateid, recall, ACE, space limit)
+// deleg and noneExtWhy together pick the open_delegation4 arm:
+//   - deleg non-nil: full delegation encoding (stateid, recall, ACE, space limit)
+//   - noneExtWhy non-nil: OPEN_DELEGATE_NONE_EXT carrying that reason (v4.1+)
+//   - both nil: OPEN_DELEGATE_NONE
+//
+// A granted delegation wins if a caller ever supplies both, since the client
+// gets something either way and the reason would contradict it.
 func (h *Handler) encodeOpenResult(
 	clientID uint64, ownerData []byte,
 	stateid *types.Stateid4, rflags uint32,
 	beforeCtime, afterCtime uint64,
 	deleg *state.DelegationState,
+	noneExtWhy *uint32,
 ) *types.CompoundResult {
 	var buf bytes.Buffer
 	_ = xdr.WriteUint32(&buf, types.NFS4_OK)
@@ -758,7 +790,11 @@ func (h *Handler) encodeOpenResult(
 	encodeChangeInfo4(&buf, true, beforeCtime, afterCtime)
 	_ = xdr.WriteUint32(&buf, rflags)
 	_ = xdr.WriteUint32(&buf, 0) // attrset: empty bitmap
-	state.EncodeDelegation(&buf, deleg)
+	if deleg == nil && noneExtWhy != nil {
+		state.EncodeNoDelegationExt(&buf, *noneExtWhy)
+	} else {
+		state.EncodeDelegation(&buf, deleg)
+	}
 
 	// Cache the result for replay detection
 	h.StateManager.CacheOpenOwnerResult(clientID, ownerData, types.NFS4_OK, buf.Bytes())
@@ -1000,7 +1036,7 @@ func (h *Handler) handleOpenClaimDelegateCur(
 
 	// No delegation grant (client already has one)
 	return h.encodeOpenResult(clientID, ownerData, &openResult.Stateid, openResult.RFlags,
-		beforeCtime, beforeCtime, nil)
+		beforeCtime, beforeCtime, nil, nil)
 }
 
 // decodeVerifier reads an 8-byte createverf4 and returns it as a uint64

--- a/internal/adapter/nfs/v4/handlers/open_none_ext_test.go
+++ b/internal/adapter/nfs/v4/handlers/open_none_ext_test.go
@@ -1,0 +1,153 @@
+package handlers
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+)
+
+// delegationArmFromOpenResult skips past OPEN4resok's fixed prefix and returns
+// the open_delegation4 discriminant plus whatever follows it.
+//
+// Layout: status, stateid4, change_info4 (atomic + before + after), rflags,
+// attrset bitmap length, then the delegation union.
+func delegationArmFromOpenResult(t *testing.T, data []byte) (uint32, []uint32) {
+	t.Helper()
+
+	reader := bytes.NewReader(data)
+	if _, err := xdr.DecodeUint32(reader); err != nil { // status
+		t.Fatalf("decode status: %v", err)
+	}
+	if _, err := types.DecodeStateid4(reader); err != nil {
+		t.Fatalf("decode stateid: %v", err)
+	}
+	_, _ = xdr.DecodeUint32(reader) // change_info4.atomic
+	_, _ = xdr.DecodeUint64(reader) // change_info4.before
+	_, _ = xdr.DecodeUint64(reader) // change_info4.after
+	_, _ = xdr.DecodeUint32(reader) // rflags
+
+	bitmapLen, err := xdr.DecodeUint32(reader)
+	if err != nil {
+		t.Fatalf("decode attrset length: %v", err)
+	}
+	for range bitmapLen {
+		_, _ = xdr.DecodeUint32(reader)
+	}
+
+	delegType, err := xdr.DecodeUint32(reader)
+	if err != nil {
+		t.Fatalf("decode delegation type: %v", err)
+	}
+
+	var rest []uint32
+	for {
+		word, err := xdr.DecodeUint32(reader)
+		if err != nil {
+			break
+		}
+		rest = append(rest, word)
+	}
+	return delegType, rest
+}
+
+// TestOpen_DelegationWantBits checks the open_delegation4 arm an OPEN reply
+// carries when the client used share_access to say what it wants.
+//
+// A v4.1 client that says it wants no delegation gets a reason back
+// (OPEN_DELEGATE_NONE_EXT + WND4_NOT_WANTED, RFC 8881 Section 18.16.3) rather
+// than a bare refusal it cannot tell apart from the server declining. A v4.0
+// client gets a bare OPEN_DELEGATE_NONE whatever bits it set: the extended arm
+// does not exist in RFC 7530, so encoding it would hand the client bytes it
+// cannot decode, and the want bits themselves are meaningless there.
+func TestOpen_DelegationWantBits(t *testing.T) {
+	tests := []struct {
+		name        string
+		minorVer    uint32
+		shareAccess uint32
+		wantArm     uint32
+		wantRest    []uint32
+	}{
+		{
+			name:        "v4.1 want-no-deleg is answered with a reason",
+			minorVer:    1,
+			shareAccess: types.OPEN4_SHARE_ACCESS_BOTH | types.OPEN4_SHARE_ACCESS_WANT_NO_DELEG,
+			wantArm:     types.OPEN_DELEGATE_NONE_EXT,
+			wantRest:    []uint32{types.WND4_NOT_WANTED},
+		},
+		{
+			name:        "v4.1 want-cancel is answered with a reason",
+			minorVer:    1,
+			shareAccess: types.OPEN4_SHARE_ACCESS_BOTH | types.OPEN4_SHARE_ACCESS_WANT_CANCEL,
+			wantArm:     types.OPEN_DELEGATE_NONE_EXT,
+			wantRest:    []uint32{types.WND4_CANCELLED},
+		},
+		{
+			name:        "v4.1 no want bits falls through to the grant policy",
+			minorVer:    1,
+			shareAccess: types.OPEN4_SHARE_ACCESS_BOTH,
+			wantArm:     types.OPEN_DELEGATE_NONE,
+			wantRest:    nil,
+		},
+		{
+			name:        "v4.1 want-read is a preference, not an answer",
+			minorVer:    1,
+			shareAccess: types.OPEN4_SHARE_ACCESS_BOTH | types.OPEN4_SHARE_ACCESS_WANT_READ_DELEG,
+			wantArm:     types.OPEN_DELEGATE_NONE,
+			wantRest:    nil,
+		},
+		{
+			name:        "v4.0 never sees the extended arm",
+			minorVer:    0,
+			shareAccess: types.OPEN4_SHARE_ACCESS_BOTH | types.OPEN4_SHARE_ACCESS_WANT_NO_DELEG,
+			wantArm:     types.OPEN_DELEGATE_NONE,
+			wantRest:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fx := newIOTestFixture(t, "/export")
+			clientID := testClientID(t, fx.handler.StateManager, "want-bits-"+tt.name)
+			fx.createRegularFile(t, fx.rootHandle, "want.txt", 0o644, 0, 0)
+
+			ctx := newRealFSContext(0, 0)
+			ctx.MinorVersion = tt.minorVer
+			ctx.MinorVersionAccepted = true
+			ctx.SkipOwnerSeqid = tt.minorVer >= 1
+			ctx.CurrentFH = append([]byte(nil), fx.rootHandle...)
+
+			args := encodeOpenArgs(
+				1,
+				tt.shareAccess,
+				types.OPEN4_SHARE_DENY_NONE,
+				clientID,
+				[]byte("owner-want"),
+				types.OPEN4_NOCREATE,
+				0,
+				types.CLAIM_NULL,
+				"want.txt",
+			)
+
+			result := fx.handler.handleOpen(ctx, bytes.NewReader(args))
+			if result.Status != types.NFS4_OK {
+				t.Fatalf("OPEN status = %d, want NFS4_OK", result.Status)
+			}
+
+			arm, rest := delegationArmFromOpenResult(t, result.Data)
+			if arm != tt.wantArm {
+				t.Fatalf("open_delegation4 discriminant = %d, want %d", arm, tt.wantArm)
+			}
+			if len(rest) != len(tt.wantRest) {
+				t.Fatalf("delegation arm carried %d words %v, want %d %v",
+					len(rest), rest, len(tt.wantRest), tt.wantRest)
+			}
+			for i := range rest {
+				if rest[i] != tt.wantRest[i] {
+					t.Errorf("arm word %d = %d, want %d", i, rest[i], tt.wantRest[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/secinfo.go
+++ b/internal/adapter/nfs/v4/handlers/secinfo.go
@@ -74,7 +74,7 @@ func (h *Handler) handleSecInfo(ctx *types.CompoundContext, reader io.Reader) *t
 	// finds none (RFC 8881 Section 2.6.3.1.1.8). NFSv4.0 retains it
 	// (RFC 7530 Section 16.31.4), and that difference is deliberate in the
 	// spec: 4.1 relies on it to resolve NFS4ERR_WRONGSEC.
-	if ctx.MinorVersionAccepted && ctx.MinorVersion > 0 {
+	if ctx.IsV41OrLater() {
 		ctx.CurrentFH = nil
 	}
 

--- a/internal/adapter/nfs/v4/state/backchannel.go
+++ b/internal/adapter/nfs/v4/state/backchannel.go
@@ -427,6 +427,13 @@ func encodeCBSequenceOp(sessionID types.SessionId4, seqID, slotID, highestSlotID
 //   - the write to it fails
 //   - no reply arrives within the callback timeout
 //   - the reply is not an accepted, successful RPC
+//
+// A failed write ends the probe rather than falling back to a second
+// back-bound connection the way sendCallback does. That is stricter than a
+// real CB_RECALL, so a client whose recalls would have landed on its second
+// connection is judged unreachable and gets no delegation. Withholding one is
+// the safe direction: the cost is a client that caches less, where the reverse
+// is a delegation the server cannot recall.
 func (bs *BackchannelSender) probeCallbackPath(ctx context.Context) error {
 	xid := bs.nextXID.Add(1)
 	callMsg := BuildCBRPCCallMessage(xid, bs.cbProgram.Load(), types.NFS4_CALLBACK_VERSION, types.CB_PROC_NULL, nil)

--- a/internal/adapter/nfs/v4/state/backchannel.go
+++ b/internal/adapter/nfs/v4/state/backchannel.go
@@ -404,3 +404,99 @@ func encodeCBSequenceOp(sessionID types.SessionId4, seqID, slotID, highestSlotID
 
 	return buf.Bytes()
 }
+
+// ============================================================================
+// Callback Path Liveness (CB_NULL over the back channel)
+// ============================================================================
+
+// probeCallbackPath sends a CB_NULL over the session's back channel and reports
+// whether the client answered it.
+//
+// CB_NULL is RPC procedure 0, not a CB_COMPOUND operation, so it carries no
+// CB_SEQUENCE and consumes no back-channel slot. The reply demultiplexes by XID
+// like every other back-channel reply.
+//
+// This is the v4.1 counterpart of SendCBNull, which dials out to the address a
+// v4.0 client supplied in SETCLIENTID. A v4.1 client supplies no address: its
+// callbacks travel back over a connection it opened, so the probe writes to a
+// back-bound connection instead of dialing.
+//
+// Every step can fail, and each failure means the same thing to the caller --
+// the server cannot reach this client's callback service:
+//   - no connection has been bound for the back channel
+//   - the write to it fails
+//   - no reply arrives within the callback timeout
+//   - the reply is not an accepted, successful RPC
+func (bs *BackchannelSender) probeCallbackPath(ctx context.Context) error {
+	xid := bs.nextXID.Add(1)
+	callMsg := BuildCBRPCCallMessage(xid, bs.cbProgram.Load(), types.NFS4_CALLBACK_VERSION, types.CB_PROC_NULL, nil)
+	framedMsg := AddCBRecordMark(callMsg, true)
+
+	connID, writer, pending, ok := bs.sm.getBackBoundConnWriter(bs.sessionID, 0)
+	if !ok {
+		return fmt.Errorf("no back-bound connection for session %s", bs.sessionID.String())
+	}
+
+	replyCh := pending.Register(xid)
+	if err := writer(framedMsg); err != nil {
+		pending.Cancel(xid)
+		return fmt.Errorf("write CB_NULL to back-bound connection %d: %w", connID, err)
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, bs.callbackTimeout)
+	defer cancel()
+
+	select {
+	case <-timeoutCtx.Done():
+		pending.Cancel(xid)
+		return fmt.Errorf("CB_NULL timed out after %s", bs.callbackTimeout)
+	case <-bs.stopCh:
+		pending.Cancel(xid)
+		return fmt.Errorf("backchannel sender stopped")
+	case replyBytes := <-replyCh:
+		if err := ValidateCBReply(replyBytes); err != nil {
+			return fmt.Errorf("CB_NULL reply: %w", err)
+		}
+		return nil
+	}
+}
+
+// probeV41CallbackPath runs probeCallbackPath and records the verdict on the
+// client record, so ShouldGrantDelegation can read callback liveness the same
+// way for both minor versions.
+//
+// It runs asynchronously rather than inside CREATE_SESSION: a client that has
+// just asked for a back channel is not required to be serving callbacks by the
+// time its reply is written, and making every mount wait for a callback
+// round-trip would pay for a delegation the client may never ask for.
+//
+// The verdict is a snapshot, not a subscription. It goes stale when the client
+// stops answering, which is why a failed CB_RECALL clears CBPathUp again.
+func (sm *StateManager) probeV41CallbackPath(ctx context.Context, bs *BackchannelSender) {
+	err := bs.probeCallbackPath(ctx)
+	sm.setCBPathUp(bs.clientID, err == nil)
+
+	if err != nil {
+		logger.Info("CB_NULL failed, delegations stay disabled for client",
+			"client_id", fmt.Sprintf("0x%x", bs.clientID),
+			"session_id", bs.sessionID.String(),
+			"error", err)
+		return
+	}
+
+	logger.Info("CB_NULL succeeded, delegations enabled for client",
+		"client_id", fmt.Sprintf("0x%x", bs.clientID),
+		"session_id", bs.sessionID.String())
+}
+
+// setCBPathUp records the outcome of a callback-path probe on the client
+// record, whichever index holds it.
+//
+// Thread-safe: acquires sm.mu.Lock.
+func (sm *StateManager) setCBPathUp(clientID uint64, up bool) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	if record := sm.clientRecordLocked(clientID); record != nil {
+		record.CBPathUp = up
+	}
+}

--- a/internal/adapter/nfs/v4/state/delegation.go
+++ b/internal/adapter/nfs/v4/state/delegation.go
@@ -727,6 +727,53 @@ func (sm *StateManager) sendRecallV40(deleg *DelegationState) {
 // EncodeDelegation
 // ============================================================================
 
+// DelegationWantReason reads the delegation-want bits a v4.1 client set in
+// share_access and reports the why_no_delegation4 reason they compel, if they
+// compel refusing a delegation outright (RFC 8881 Section 18.16.3).
+//
+// Only two of the want values are answers in themselves. WANT_NO_DELEG says
+// the client does not want one, which is WND4_NOT_WANTED. WANT_CANCEL
+// withdraws a standing want, and since this server keeps no want queue there
+// is nothing left outstanding to satisfy, which is WND4_CANCELLED. Every other
+// value -- no preference, or a preference for a particular type -- leaves the
+// decision to the normal grant policy, so this reports false for them and the
+// caller goes on to ShouldGrantDelegation.
+func DelegationWantReason(shareAccess uint32) (uint32, bool) {
+	switch shareAccess & types.OPEN4_SHARE_ACCESS_WANT_DELEG_MASK {
+	case types.OPEN4_SHARE_ACCESS_WANT_NO_DELEG:
+		return types.WND4_NOT_WANTED, true
+	case types.OPEN4_SHARE_ACCESS_WANT_CANCEL:
+		return types.WND4_CANCELLED, true
+	default:
+		return 0, false
+	}
+}
+
+// EncodeNoDelegationExt encodes the OPEN_DELEGATE_NONE_EXT arm of
+// open_delegation4, which tells a v4.1 client why it is getting no delegation
+// (RFC 8881 Section 18.16.3):
+//
+//	OPEN_DELEGATE_NONE_EXT: why_no_delegation4 + arm
+//	  WND4_CONTENTION: bool ond_server_will_push_deleg
+//	  WND4_RESOURCE:   bool ond_server_will_signal_avail
+//	  default:         void
+//
+// The two reasons carrying a bool promise a later callback when the obstacle
+// clears. This server makes no such promise, so it encodes false for them
+// rather than leaving the arm off and truncating the reply.
+//
+// Never encode this for a v4.0 client: the arm did not exist in RFC 7530 and a
+// v4.0 client cannot decode past the discriminant.
+func EncodeNoDelegationExt(buf *bytes.Buffer, why uint32) {
+	_ = xdr.WriteUint32(buf, types.OPEN_DELEGATE_NONE_EXT)
+	_ = xdr.WriteUint32(buf, why)
+
+	switch why {
+	case types.WND4_CONTENTION, types.WND4_RESOURCE:
+		_ = xdr.WriteBool(buf, false)
+	}
+}
+
 // EncodeDelegation encodes an open_delegation4 into the given buffer.
 //
 // If deleg is nil, writes OPEN_DELEGATE_NONE (uint32 = 0).

--- a/internal/adapter/nfs/v4/state/delegation.go
+++ b/internal/adapter/nfs/v4/state/delegation.go
@@ -528,8 +528,8 @@ func (sm *StateManager) ShouldGrantDelegation(clientID uint64, fileHandle []byte
 		return types.OPEN_DELEGATE_NONE, false
 	}
 
-	client, exists := sm.clientsByID[clientID]
-	if !exists {
+	client := sm.clientRecordLocked(clientID)
+	if client == nil {
 		return types.OPEN_DELEGATE_NONE, false
 	}
 	if !client.CBPathUp {
@@ -663,6 +663,10 @@ func (sm *StateManager) sendRecallV41(deleg *DelegationState, sender *Backchanne
 			logger.Warn("CB_RECALL (v4.1) failed",
 				"client_id", deleg.ClientID,
 				"error", err)
+			// The callback path this client was granted a delegation on no
+			// longer answers, so stop granting more until a probe says
+			// otherwise, exactly as the v4.0 path does.
+			sm.setCBPathUp(deleg.ClientID, false)
 			sm.startRevocationTimer(deleg, 5*time.Second)
 			return
 		}
@@ -709,11 +713,7 @@ func (sm *StateManager) sendRecallV40(deleg *DelegationState) {
 			"client_id", deleg.ClientID,
 			"error", err)
 		sm.startRevocationTimer(deleg, 5*time.Second)
-		sm.mu.Lock()
-		if c, ok := sm.clientsByID[deleg.ClientID]; ok {
-			c.CBPathUp = false
-		}
-		sm.mu.Unlock()
+		sm.setCBPathUp(deleg.ClientID, false)
 		return
 	}
 

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -3988,6 +3988,13 @@ func (sm *StateManager) StartBackchannelSender(ctx context.Context, sessionID ty
 
 	go sender.Run(ctx)
 
+	// The back channel just became writable, which is the first moment a
+	// CB_NULL to this client can succeed or fail for a real reason. Probing
+	// here rather than in CreateSession keeps the callback round-trip off the
+	// mount path, and this function is the once-per-session gate: it returned
+	// above if a sender already existed.
+	go sm.probeV41CallbackPath(ctx, sender)
+
 	logger.Info("BackchannelSender started for session",
 		"session_id", sessionID.String(),
 		"client_id", fmt.Sprintf("0x%x", session.ClientID))

--- a/internal/adapter/nfs/v4/state/v41_delegation_test.go
+++ b/internal/adapter/nfs/v4/state/v41_delegation_test.go
@@ -69,6 +69,11 @@ func bindBackchannel(t *testing.T, sm *StateManager, sessionID types.SessionId4,
 // TestProbeCallbackPath_AnsweredCBNullEnablesDelegation is the positive half of
 // the guard: a client that answers CB_NULL over its back channel gets
 // CBPathUp, and an OPEN on an uncontended file is then offered a delegation.
+//
+// It drives probeV41CallbackPath, the function production calls, rather than
+// the probe underneath it plus a hand-set flag. Setting the flag by hand would
+// leave the recording step unpinned: a probe that succeeded but stopped writing
+// its verdict down would still pass, which is the whole behaviour under test.
 func TestProbeCallbackPath_AnsweredCBNullEnablesDelegation(t *testing.T) {
 	sender, sm, sessionID := createTestBackchannelSender(t)
 	defer sm.Shutdown()
@@ -86,15 +91,11 @@ func TestProbeCallbackPath_AnsweredCBNullEnablesDelegation(t *testing.T) {
 		pending.Deliver(xid, buildMockCBNullReplyBody(xid))
 	}()
 
-	if err := sender.probeCallbackPath(context.Background()); err != nil {
-		t.Fatalf("probeCallbackPath on a live back channel: %v", err)
-	}
+	sm.probeV41CallbackPath(context.Background(), sender)
 
 	if proc := <-gotProc; proc != types.CB_PROC_NULL {
 		t.Errorf("probe sent callback procedure %d, want CB_PROC_NULL (%d)", proc, types.CB_PROC_NULL)
 	}
-
-	sm.setCBPathUp(sender.clientID, true)
 
 	sm.mu.RLock()
 	record := sm.clientRecordLocked(sender.clientID)

--- a/internal/adapter/nfs/v4/state/v41_delegation_test.go
+++ b/internal/adapter/nfs/v4/state/v41_delegation_test.go
@@ -1,0 +1,343 @@
+package state
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+)
+
+// buildMockCBNullReplyBody builds the RPC reply a client sends for CB_NULL.
+// Unlike a CB_COMPOUND reply it carries no results at all: procedure 0 returns
+// void, so the message ends at accept_stat.
+func buildMockCBNullReplyBody(xid uint32) []byte {
+	var reply bytes.Buffer
+	_ = binary.Write(&reply, binary.BigEndian, xid)
+	_ = binary.Write(&reply, binary.BigEndian, uint32(rpc.RPCReply))
+	_ = binary.Write(&reply, binary.BigEndian, uint32(rpc.RPCMsgAccepted))
+	_ = binary.Write(&reply, binary.BigEndian, uint32(rpc.AuthNull))
+	_ = binary.Write(&reply, binary.BigEndian, uint32(0))
+	_ = binary.Write(&reply, binary.BigEndian, uint32(rpc.RPCSuccess))
+	return reply.Bytes()
+}
+
+// readCBCall reads one record-marked RPC call off conn and returns its XID and
+// procedure number.
+func readCBCall(conn net.Conn) (xid, proc uint32, err error) {
+	var headerBuf [4]byte
+	if _, err = io.ReadFull(conn, headerBuf[:]); err != nil {
+		return 0, 0, fmt.Errorf("read header: %w", err)
+	}
+	fragLen := binary.BigEndian.Uint32(headerBuf[:]) & 0x7FFFFFFF
+	body := make([]byte, fragLen)
+	if _, err = io.ReadFull(conn, body); err != nil {
+		return 0, 0, fmt.Errorf("read body: %w", err)
+	}
+	if len(body) < 24 {
+		return 0, 0, fmt.Errorf("call too short: %d bytes", len(body))
+	}
+	// xid, msg_type, rpcvers, prog, vers, proc
+	return binary.BigEndian.Uint32(body[0:4]), binary.BigEndian.Uint32(body[20:24]), nil
+}
+
+// bindBackchannel wires a net.Pipe to the session as a back-bound connection
+// and returns the client end plus the reply router for it.
+func bindBackchannel(t *testing.T, sm *StateManager, sessionID types.SessionId4, connID uint64) (net.Conn, *PendingCBReplies) {
+	t.Helper()
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() { _ = clientConn.Close() })
+	t.Cleanup(func() { _ = serverConn.Close() })
+
+	pending := sm.RegisterConnWriter(connID, func(data []byte) error {
+		_, err := serverConn.Write(data)
+		return err
+	})
+	if _, err := sm.BindConnToSession(connID, sessionID, types.CDFC4_FORE_OR_BOTH); err != nil {
+		t.Fatalf("BindConnToSession: %v", err)
+	}
+	return clientConn, pending
+}
+
+// TestProbeCallbackPath_AnsweredCBNullEnablesDelegation is the positive half of
+// the guard: a client that answers CB_NULL over its back channel gets
+// CBPathUp, and an OPEN on an uncontended file is then offered a delegation.
+func TestProbeCallbackPath_AnsweredCBNullEnablesDelegation(t *testing.T) {
+	sender, sm, sessionID := createTestBackchannelSender(t)
+	defer sm.Shutdown()
+
+	clientConn, pending := bindBackchannel(t, sm, sessionID, 2000)
+
+	gotProc := make(chan uint32, 1)
+	go func() {
+		xid, proc, err := readCBCall(clientConn)
+		if err != nil {
+			gotProc <- 0xFFFFFFFF
+			return
+		}
+		gotProc <- proc
+		pending.Deliver(xid, buildMockCBNullReplyBody(xid))
+	}()
+
+	if err := sender.probeCallbackPath(context.Background()); err != nil {
+		t.Fatalf("probeCallbackPath on a live back channel: %v", err)
+	}
+
+	if proc := <-gotProc; proc != types.CB_PROC_NULL {
+		t.Errorf("probe sent callback procedure %d, want CB_PROC_NULL (%d)", proc, types.CB_PROC_NULL)
+	}
+
+	sm.setCBPathUp(sender.clientID, true)
+
+	sm.mu.RLock()
+	record := sm.clientRecordLocked(sender.clientID)
+	sm.mu.RUnlock()
+	if record == nil {
+		t.Fatal("v4.1 client record not reachable through clientRecordLocked")
+	}
+	if !record.CBPathUp {
+		t.Fatal("CBPathUp not set on the v4.1 client record")
+	}
+
+	delegType, granted := sm.ShouldGrantDelegation(sender.clientID, []byte("probe-file"), types.OPEN4_SHARE_ACCESS_READ)
+	if !granted {
+		t.Fatal("no delegation offered to a v4.1 client with a verified callback path")
+	}
+	if delegType != types.OPEN_DELEGATE_READ {
+		t.Errorf("delegation type = %d, want OPEN_DELEGATE_READ", delegType)
+	}
+}
+
+// TestProbeCallbackPath_RefusesWhenBackchannelUnreachable is the half that
+// matters. A guard that has never refused anything is unverified, so each way
+// the back channel can be unusable is exercised and asserted to leave CBPathUp
+// false and delegations withheld.
+func TestProbeCallbackPath_RefusesWhenBackchannelUnreachable(t *testing.T) {
+	tests := []struct {
+		name string
+		// arrange makes the back channel unusable in one specific way.
+		arrange func(t *testing.T, sm *StateManager, sessionID types.SessionId4, sender *BackchannelSender)
+	}{
+		{
+			name: "no connection bound for the back channel",
+			arrange: func(*testing.T, *StateManager, types.SessionId4, *BackchannelSender) {
+				// Nothing bound: the session has back-channel slots from
+				// CREATE_SESSION but no connection to write them over.
+			},
+		},
+		{
+			name: "write to the bound connection fails",
+			arrange: func(t *testing.T, sm *StateManager, sessionID types.SessionId4, _ *BackchannelSender) {
+				sm.RegisterConnWriter(3000, func([]byte) error {
+					return fmt.Errorf("connection reset by peer")
+				})
+				if _, err := sm.BindConnToSession(3000, sessionID, types.CDFC4_FORE_OR_BOTH); err != nil {
+					t.Fatalf("BindConnToSession: %v", err)
+				}
+			},
+		},
+		{
+			name: "client never answers CB_NULL",
+			arrange: func(t *testing.T, sm *StateManager, sessionID types.SessionId4, sender *BackchannelSender) {
+				clientConn, _ := bindBackchannel(t, sm, sessionID, 4000)
+				// Drain the call so the write succeeds, then stay silent.
+				go func() { _, _, _ = readCBCall(clientConn) }()
+				sender.callbackTimeout = 150 * time.Millisecond
+			},
+		},
+		{
+			name: "client rejects the callback RPC",
+			arrange: func(t *testing.T, sm *StateManager, sessionID types.SessionId4, _ *BackchannelSender) {
+				clientConn, pending := bindBackchannel(t, sm, sessionID, 5000)
+				go func() {
+					xid, _, err := readCBCall(clientConn)
+					if err != nil {
+						return
+					}
+					var reply bytes.Buffer
+					_ = binary.Write(&reply, binary.BigEndian, xid)
+					_ = binary.Write(&reply, binary.BigEndian, uint32(rpc.RPCReply))
+					// reply_stat = MSG_DENIED (1)
+					_ = binary.Write(&reply, binary.BigEndian, uint32(1))
+					pending.Deliver(xid, reply.Bytes())
+				}()
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sender, sm, sessionID := createTestBackchannelSender(t)
+			defer sm.Shutdown()
+
+			// Prove the flag is not merely left at its zero value: set it, so
+			// only an observed refusal can bring it back down.
+			sm.setCBPathUp(sender.clientID, true)
+
+			tc.arrange(t, sm, sessionID, sender)
+
+			sm.probeV41CallbackPath(context.Background(), sender)
+
+			sm.mu.RLock()
+			record := sm.clientRecordLocked(sender.clientID)
+			sm.mu.RUnlock()
+			if record == nil {
+				t.Fatal("v4.1 client record disappeared")
+			}
+			if record.CBPathUp {
+				t.Fatal("CBPathUp stayed true after the probe could not reach the client")
+			}
+
+			if _, granted := sm.ShouldGrantDelegation(
+				sender.clientID, []byte("unreachable-file"), types.OPEN4_SHARE_ACCESS_READ,
+			); granted {
+				t.Fatal("delegation granted to a client whose callback path is down")
+			}
+		})
+	}
+}
+
+// TestSendRecallV41_ClearsCBPathUp checks that a v4.1 recall which cannot be
+// delivered takes the callback path back down, the way the v4.0 dial-out path
+// already did. Otherwise one grant to a client that then goes away keeps every
+// later OPEN eligible for a delegation nobody can recall.
+func TestSendRecallV41_ClearsCBPathUp(t *testing.T) {
+	sender, sm, sessionID := createTestBackchannelSender(t)
+	defer sm.Shutdown()
+
+	// Bound but broken: the write fails on every attempt.
+	sm.RegisterConnWriter(6000, func([]byte) error {
+		return fmt.Errorf("connection reset by peer")
+	})
+	if _, err := sm.BindConnToSession(6000, sessionID, types.CDFC4_FORE_OR_BOTH); err != nil {
+		t.Fatalf("BindConnToSession: %v", err)
+	}
+
+	sm.setCBPathUp(sender.clientID, true)
+
+	// Shorten the retry backoff: the assertion is about what happens once
+	// every attempt has failed, not about how long the waits between them are.
+	// No test in this package runs in parallel, so nothing else reads this.
+	savedDelays := backchannelRetryDelays
+	backchannelRetryDelays = [backchannelMaxRetries]time.Duration{
+		time.Millisecond, time.Millisecond, time.Millisecond,
+	}
+	t.Cleanup(func() { backchannelRetryDelays = savedDelays })
+
+	// Run the sender so the queued recall is actually attempted.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go sender.Run(ctx)
+
+	deleg := &DelegationState{
+		ClientID:   sender.clientID,
+		FileHandle: []byte("recall-file"),
+		DelegType:  types.OPEN_DELEGATE_READ,
+		Stateid:    types.Stateid4{Seqid: 1},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		sm.sendRecallV41(deleg, sender)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(60 * time.Second):
+		t.Fatal("sendRecallV41 did not return")
+	}
+	deleg.StopRecallTimer()
+
+	sm.mu.RLock()
+	record := sm.clientRecordLocked(sender.clientID)
+	sm.mu.RUnlock()
+	if record.CBPathUp {
+		t.Fatal("CBPathUp stayed true after every CB_RECALL attempt failed")
+	}
+}
+
+// ============================================================================
+// OPEN_DELEGATE_NONE_EXT
+// ============================================================================
+
+func TestDelegationWantReason(t *testing.T) {
+	tests := []struct {
+		name        string
+		shareAccess uint32
+		wantWhy     uint32
+		wantRefuse  bool
+	}{
+		{"no want bits leaves the decision to policy", types.OPEN4_SHARE_ACCESS_READ, 0, false},
+		{"no preference leaves the decision to policy", types.OPEN4_SHARE_ACCESS_READ | types.OPEN4_SHARE_ACCESS_WANT_NO_PREFERENCE, 0, false},
+		{"read want leaves the decision to policy", types.OPEN4_SHARE_ACCESS_READ | types.OPEN4_SHARE_ACCESS_WANT_READ_DELEG, 0, false},
+		{"any want leaves the decision to policy", types.OPEN4_SHARE_ACCESS_BOTH | types.OPEN4_SHARE_ACCESS_WANT_ANY_DELEG, 0, false},
+		{"no-deleg is an answer", types.OPEN4_SHARE_ACCESS_READ | types.OPEN4_SHARE_ACCESS_WANT_NO_DELEG, types.WND4_NOT_WANTED, true},
+		{"cancel is an answer", types.OPEN4_SHARE_ACCESS_READ | types.OPEN4_SHARE_ACCESS_WANT_CANCEL, types.WND4_CANCELLED, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			why, refuse := DelegationWantReason(tc.shareAccess)
+			if refuse != tc.wantRefuse {
+				t.Fatalf("refuse = %v, want %v", refuse, tc.wantRefuse)
+			}
+			if refuse && why != tc.wantWhy {
+				t.Errorf("why = %d, want %d", why, tc.wantWhy)
+			}
+		})
+	}
+}
+
+func TestEncodeNoDelegationExt(t *testing.T) {
+	tests := []struct {
+		name string
+		why  uint32
+		want []uint32
+	}{
+		{
+			name: "void reason is discriminant plus why",
+			why:  types.WND4_NOT_WANTED,
+			want: []uint32{types.OPEN_DELEGATE_NONE_EXT, types.WND4_NOT_WANTED},
+		},
+		{
+			name: "cancelled is also void",
+			why:  types.WND4_CANCELLED,
+			want: []uint32{types.OPEN_DELEGATE_NONE_EXT, types.WND4_CANCELLED},
+		},
+		{
+			name: "contention carries the will-push bool",
+			why:  types.WND4_CONTENTION,
+			want: []uint32{types.OPEN_DELEGATE_NONE_EXT, types.WND4_CONTENTION, 0},
+		},
+		{
+			name: "resource carries the will-signal bool",
+			why:  types.WND4_RESOURCE,
+			want: []uint32{types.OPEN_DELEGATE_NONE_EXT, types.WND4_RESOURCE, 0},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			EncodeNoDelegationExt(&buf, tc.why)
+
+			got := buf.Bytes()
+			if len(got) != len(tc.want)*4 {
+				t.Fatalf("encoded %d bytes, want %d: % x", len(got), len(tc.want)*4, got)
+			}
+			for i, wantWord := range tc.want {
+				if word := binary.BigEndian.Uint32(got[i*4 : i*4+4]); word != wantWord {
+					t.Errorf("word %d = %d, want %d", i, word, wantWord)
+				}
+			}
+		})
+	}
+}

--- a/internal/adapter/nfs/v4/state/v41_delegation_test.go
+++ b/internal/adapter/nfs/v4/state/v41_delegation_test.go
@@ -341,3 +341,47 @@ func TestEncodeNoDelegationExt(t *testing.T) {
 		})
 	}
 }
+
+// TestV41Delegation_GrantedStateidResolvesForClaimDelegateCur walks the chain
+// CLAIM_DELEGATE_CUR depends on, end to end, for a v4.1 client: a verified
+// callback path makes the grant policy say yes, the grant produces a stateid,
+// and that stateid resolves back to a delegation this same client owns -- which
+// is what OPEN checks before honouring the claim.
+//
+// Every step after the first was unreachable on v4.1 before the callback-path
+// probe existed, because the policy always said no.
+func TestV41Delegation_GrantedStateidResolvesForClaimDelegateCur(t *testing.T) {
+	sender, sm, _ := createTestBackchannelSender(t)
+	defer sm.Shutdown()
+
+	clientID := sender.clientID
+	fileHandle := []byte("claim-delegate-cur-file")
+
+	sm.setCBPathUp(clientID, true)
+
+	delegType, granted := sm.ShouldGrantDelegation(clientID, fileHandle, types.OPEN4_SHARE_ACCESS_WRITE)
+	if !granted {
+		t.Fatal("grant policy refused a v4.1 client with a verified callback path")
+	}
+	if delegType != types.OPEN_DELEGATE_WRITE {
+		t.Fatalf("delegation type = %d, want OPEN_DELEGATE_WRITE", delegType)
+	}
+
+	deleg := sm.GrantDelegation(clientID, fileHandle, delegType)
+	if deleg == nil {
+		t.Fatal("GrantDelegation returned nil for a client the policy approved")
+	}
+	t.Cleanup(deleg.StopRecallTimer)
+
+	resolved, err := sm.ValidateDelegationStateid(&deleg.Stateid)
+	if err != nil {
+		t.Fatalf("the stateid a v4.1 OPEN would return does not validate: %v", err)
+	}
+	if resolved.ClientID != clientID {
+		t.Errorf("delegation owner = 0x%x, want the granting v4.1 client 0x%x",
+			resolved.ClientID, clientID)
+	}
+	if !bytes.Equal(resolved.FileHandle, fileHandle) {
+		t.Errorf("delegation file handle = %q, want %q", resolved.FileHandle, fileHandle)
+	}
+}

--- a/internal/adapter/nfs/v4/types/constants.go
+++ b/internal/adapter/nfs/v4/types/constants.go
@@ -369,6 +369,22 @@ const (
 	OPEN4_SHARE_DENY_BOTH  = 0x03
 )
 
+// OPEN share_access delegation-want bits (RFC 8881 Section 18.16.3), v4.1 and
+// later. They occupy bits outside OPEN4_SHARE_ACCESS_BOTH, so a server that
+// masks share_access down to the access mode ignores them harmlessly.
+//
+// WANT_NO_PREFERENCE leaves the choice to the server, which is what a client
+// sending none of these bits gets.
+const (
+	OPEN4_SHARE_ACCESS_WANT_DELEG_MASK    = 0xFF00
+	OPEN4_SHARE_ACCESS_WANT_NO_PREFERENCE = 0x0000
+	OPEN4_SHARE_ACCESS_WANT_READ_DELEG    = 0x0100
+	OPEN4_SHARE_ACCESS_WANT_WRITE_DELEG   = 0x0200
+	OPEN4_SHARE_ACCESS_WANT_ANY_DELEG     = 0x0300
+	OPEN4_SHARE_ACCESS_WANT_NO_DELEG      = 0x0400
+	OPEN4_SHARE_ACCESS_WANT_CANCEL        = 0x0500
+)
+
 // OPEN create type
 const (
 	OPEN4_NOCREATE = 0
@@ -394,11 +410,35 @@ const (
 	OPEN4_RESULT_LOCKTYPE_POSIX = 0x04
 )
 
-// OPEN delegation types
+// OPEN delegation types (open_delegation_type4)
 const (
 	OPEN_DELEGATE_NONE  = 0
 	OPEN_DELEGATE_READ  = 1
 	OPEN_DELEGATE_WRITE = 2
+
+	// OPEN_DELEGATE_NONE_EXT carries a reason for withholding a delegation
+	// (RFC 8881 Section 18.16.3). It exists only from v4.1 on: a v4.0 client
+	// cannot decode the arm, so a v4.0 reply that grants nothing must stay
+	// OPEN_DELEGATE_NONE.
+	OPEN_DELEGATE_NONE_EXT = 3
+)
+
+// why_no_delegation4 reasons carried by OPEN_DELEGATE_NONE_EXT
+// (RFC 8881 Section 18.16.3).
+//
+// WND4_CONTENTION and WND4_RESOURCE each carry a trailing bool saying whether
+// the server will follow up when the obstacle clears; every other reason
+// encodes as void.
+const (
+	WND4_NOT_WANTED                 = 0
+	WND4_CONTENTION                 = 1
+	WND4_RESOURCE                   = 2
+	WND4_NOT_SUPP_FTYPE             = 3
+	WND4_WRITE_DELEG_NOT_SUPP_FTYPE = 4
+	WND4_NOT_SUPP_UPGRADE           = 5
+	WND4_NOT_SUPP_DOWNGRADE         = 6
+	WND4_CANCELLED                  = 7
+	WND4_IS_DIR                     = 8
 )
 
 // ============================================================================

--- a/internal/adapter/nfs/v4/types/current_stateid.go
+++ b/internal/adapter/nfs/v4/types/current_stateid.go
@@ -29,13 +29,6 @@ func (s *Stateid4) isCurrentStateidPlaceholder() bool {
 	return s.Seqid == 1 && s.Other == [NFS4_OTHER_SIZE]byte{}
 }
 
-// IsV41OrLater reports whether this COMPOUND arrived under a minor version
-// that understands the NFSv4.1 additions to the protocol. Encoding one of them
-// into a reply to a v4.0 client would hand it a union arm it cannot decode.
-func (c *CompoundContext) IsV41OrLater() bool {
-	return c.MinorVersionAccepted && c.MinorVersion >= 1
-}
-
 // tracksCurrentStateid reports whether the placeholder is meaningful in this
 // COMPOUND. It is an NFSv4.1 addition; in a v4.0 COMPOUND (1, 0) is just an
 // ordinary stateid the server never issued.

--- a/internal/adapter/nfs/v4/types/current_stateid.go
+++ b/internal/adapter/nfs/v4/types/current_stateid.go
@@ -29,11 +29,18 @@ func (s *Stateid4) isCurrentStateidPlaceholder() bool {
 	return s.Seqid == 1 && s.Other == [NFS4_OTHER_SIZE]byte{}
 }
 
+// IsV41OrLater reports whether this COMPOUND arrived under a minor version
+// that understands the NFSv4.1 additions to the protocol. Encoding one of them
+// into a reply to a v4.0 client would hand it a union arm it cannot decode.
+func (c *CompoundContext) IsV41OrLater() bool {
+	return c.MinorVersionAccepted && c.MinorVersion >= 1
+}
+
 // tracksCurrentStateid reports whether the placeholder is meaningful in this
 // COMPOUND. It is an NFSv4.1 addition; in a v4.0 COMPOUND (1, 0) is just an
 // ordinary stateid the server never issued.
 func (c *CompoundContext) tracksCurrentStateid() bool {
-	return c.MinorVersionAccepted && c.MinorVersion >= 1
+	return c.IsV41OrLater()
 }
 
 // SetCurrentStateid records the stateid an operation returned as the COMPOUND's

--- a/internal/adapter/nfs/v4/types/types.go
+++ b/internal/adapter/nfs/v4/types/types.go
@@ -188,6 +188,16 @@ type CompoundContext struct {
 	MinorVersionAccepted bool
 }
 
+// IsV41OrLater reports whether this COMPOUND arrived under a minor version
+// that understands the NFSv4.1 additions to the protocol. Encoding one of them
+// into a reply to a v4.0 client would hand it a union arm it cannot decode.
+//
+// It reads both fields together so a caller cannot mistake an unset
+// MinorVersion for NFSv4.0.
+func (c *CompoundContext) IsV41OrLater() bool {
+	return c.MinorVersionAccepted && c.MinorVersion >= 1
+}
+
 // EffectiveClientID returns the client ID an open-owner or lock-owner should be
 // keyed under, given the clientid decoded from the owner's wire representation.
 //

--- a/internal/adapter/nfs/v4/v41/handlers/create_session.go
+++ b/internal/adapter/nfs/v4/v41/handlers/create_session.go
@@ -79,11 +79,30 @@ func HandleCreateSession(d *Deps, ctx *types.CompoundContext, _ *types.V41Reques
 	// 18.36). Reuse those bytes directly; re-encoding here would reopen the
 	// replay window the state manager closed.
 
-	// Auto-bind the connection that created the session as fore-channel.
+	// Auto-bind the connection that created the session.
+	//
+	// It carries the back channel too when the client asked for one: RFC 8881
+	// Section 18.36.3 associates the connection CREATE_SESSION arrived on with
+	// the session in both directions when csa_flags requests
+	// CONN_BACK_CHAN. Binding it fore-only leaves a client that never sends
+	// BIND_CONN_TO_SESSION -- which is the normal mount flow for both the Linux
+	// client and pynfs -- with a session whose back-channel slot table exists
+	// but has no connection under it, so no callback can ever be sent and no
+	// delegation can ever be granted.
+	//
+	// The direction comes from the response flags rather than the request: the
+	// server clears CONN_BACK_CHAN when it did not set a back channel up, and
+	// binding a direction the session cannot serve would claim a channel that
+	// is not there.
+	bindDir := uint32(types.CDFC4_FORE)
+	if result.Flags&uint32(types.CREATE_SESSION4_FLAG_CONN_BACK_CHAN) != 0 {
+		bindDir = types.CDFC4_FORE_OR_BOTH
+	}
+
 	// This is best-effort: CREATE_SESSION already succeeded, so we only
 	// log a warning if the bind fails (e.g., connection ID not plumbed).
 	if ctx.ConnectionID != 0 {
-		if _, bindErr := d.StateManager.BindConnToSession(ctx.ConnectionID, result.SessionID, types.CDFC4_FORE); bindErr != nil {
+		if _, bindErr := d.StateManager.BindConnToSession(ctx.ConnectionID, result.SessionID, bindDir); bindErr != nil {
 			logger.Debug("CREATE_SESSION: auto-bind connection failed",
 				"connection_id", ctx.ConnectionID,
 				"session_id", result.SessionID.String(),

--- a/internal/adapter/nfs/v4/v41/handlers/create_session_backchannel_test.go
+++ b/internal/adapter/nfs/v4/v41/handlers/create_session_backchannel_test.go
@@ -1,0 +1,105 @@
+package v41handlers
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/state"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+)
+
+// TestHandleCreateSession_AutoBindDirection covers the connection CREATE_SESSION
+// binds to the session it just made.
+//
+// RFC 8881 Section 18.36.3 associates the connection CREATE_SESSION arrived on
+// with the new session, in both directions when csa_flags asks for
+// CONN_BACK_CHAN. The normal mount flow for both the Linux client and pynfs
+// stops there: neither sends BIND_CONN_TO_SESSION afterwards. Binding
+// fore-only therefore left every such session with a back-channel slot table
+// and no connection under it, so no callback could be sent and no delegation
+// could be granted -- the whole back-channel path was reachable only by a
+// client that volunteered an extra operation.
+func TestHandleCreateSession_AutoBindDirection(t *testing.T) {
+	tests := []struct {
+		name    string
+		flags   uint32
+		wantDir state.ConnectionDirection
+	}{
+		{
+			name:    "back channel requested binds both directions",
+			flags:   types.CREATE_SESSION4_FLAG_CONN_BACK_CHAN,
+			wantDir: state.ConnDirBoth,
+		},
+		{
+			name:    "no back channel requested stays fore-only",
+			flags:   0,
+			wantDir: state.ConnDirFore,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sm := state.NewStateManager(90 * time.Second)
+			defer sm.Shutdown()
+			d := &Deps{StateManager: sm}
+
+			var verifier [8]byte
+			copy(verifier[:], "csbcverf")
+			eid, err := sm.ExchangeID([]byte("create-session-autobind"), verifier, 0, nil, "10.0.0.1:12345")
+			if err != nil {
+				t.Fatalf("ExchangeID: %v", err)
+			}
+
+			args := types.CreateSessionArgs{
+				ClientID:   eid.ClientID,
+				SequenceID: eid.SequenceID,
+				Flags:      tc.flags,
+				ForeChannelAttrs: types.ChannelAttrs{
+					MaxRequestSize: 1 << 20, MaxResponseSize: 1 << 20,
+					MaxResponseSizeCached: 4096, MaxOperations: 16, MaxRequests: 16,
+				},
+				BackChannelAttrs: types.ChannelAttrs{
+					MaxRequestSize: 1 << 16, MaxResponseSize: 1 << 16,
+					MaxResponseSizeCached: 1 << 16, MaxOperations: 2, MaxRequests: 4,
+				},
+				CbProgram:  0x40000000,
+				CbSecParms: []types.CallbackSecParms4{{CbSecFlavor: 0}},
+			}
+			var buf bytes.Buffer
+			if err := args.Encode(&buf); err != nil {
+				t.Fatalf("encode args: %v", err)
+			}
+
+			const connID = uint64(7001)
+			ctx := &types.CompoundContext{
+				Context:      context.Background(),
+				ClientAddr:   "10.0.0.1:12345",
+				ConnectionID: connID,
+			}
+
+			res := HandleCreateSession(d, ctx, &types.V41RequestContext{}, bytes.NewReader(buf.Bytes()))
+			if res.Status != types.NFS4_OK {
+				t.Fatalf("CREATE_SESSION status = %d, want NFS4_OK", res.Status)
+			}
+
+			binding := sm.GetConnectionBinding(connID)
+			if binding == nil {
+				t.Fatal("CREATE_SESSION did not bind the connection it arrived on")
+			}
+			if binding.Direction != tc.wantDir {
+				t.Fatalf("bound direction = %v, want %v", binding.Direction, tc.wantDir)
+			}
+
+			// The direction is only interesting because of what it unlocks: a
+			// back-bound connection is the one thing standing between a session
+			// with back-channel slots and a callback that can actually be sent.
+			backUsable := binding.Direction == state.ConnDirBack || binding.Direction == state.ConnDirBoth
+			wantBackUsable := tc.flags&types.CREATE_SESSION4_FLAG_CONN_BACK_CHAN != 0
+			if backUsable != wantBackUsable {
+				t.Fatalf("back channel usable = %v, want %v", backUsable, wantBackUsable)
+			}
+		})
+	}
+}

--- a/test/nfs-conformance/pynfs/KNOWN_FAILURES_V41.md
+++ b/test/nfs-conformance/pynfs/KNOWN_FAILURES_V41.md
@@ -54,16 +54,14 @@ flake worth re-running.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| DELEG1 | bug | no delegation is granted | #2329 |
-| DELEG2 | bug | no delegation is granted | #2329 |
-| DELEG23 | bug | no delegation is granted | #2329 |
-| DELEG26 | bug | no delegation is granted | #2329 |
-| DELEG3 | bug | no delegation is granted | #2329 |
-| DELEG4 | bug | no delegation is granted | #2329 |
-| DELEG5 | bug | no delegation is granted | #2329 |
-| DELEG6 | bug | no delegation is granted | #2329 |
-| DELEG7 | bug | no delegation is granted | #2329 |
-| DELEG8 | bug | no delegation is granted | #2329 |
+| DELEG1 | bug | delegation granted, then pynfs errors reading the recall event: 'Event' object has no attribute 'stateid' | #2329 |
+| DELEG2 | bug | delegation withheld on this OPEN: the callback-path probe had not answered yet | #2329 |
+| DELEG23 | bug | delegation break not received: every CB_RECALL fails with no back-bound connection for the session | #2329 |
+| DELEG3 | bug | delegation granted, then pynfs errors reading the recall event: 'Event' object has no attribute 'stateid' | #2329 |
+| DELEG5 | bug | delegation granted, then pynfs errors reading the recall event: 'Event' object has no attribute 'stateid' | #2329 |
+| DELEG6 | bug | delegation granted, then pynfs errors reading the recall event: 'Event' object has no attribute 'stateid' | #2329 |
+| DELEG7 | bug | delegation granted, then pynfs errors reading the recall event: 'Event' object has no attribute 'stateid' | #2329 |
+| DELEG8 | bug | delegation withheld on this OPEN: the callback-path probe had not answered yet | #2329 |
 | CSESS15 | bug | EXCHANGE_ID/CREATE_SESSION/DESTROY_CLIENTID validation | #2340 |
 | CSESS16a | bug | EXCHANGE_ID/CREATE_SESSION/DESTROY_CLIENTID validation | #2340 |
 | CSESS23 | bug | EXCHANGE_ID/CREATE_SESSION/DESTROY_CLIENTID validation | #2340 |


### PR DESCRIPTION
NFSv4.1 and 4.2 clients never received a delegation. This grants them, on a callback path that was actually verified — and fixes the reason no callback path existed in the first place.

Builds on #2476, now merged; this branch is rebased onto develop and the diff is this PR alone.

## Root cause, in two layers

**The layer #2436 describes.** `ShouldGrantDelegation` refuses unless `client.CBPathUp` is true, and nothing on the v4.1 path ever set it. The refusal was one step earlier than the issue states: the lookup was `sm.clientsByID[clientID]`, the **v4.0** index. A v4.1 client ID lives in `v41ClientsByID` and never appears there, so a v4.1 OPEN failed the lookup and never reached the `CBPathUp` test at all. #2476 removed the type asymmetry underneath that; here the lookup goes through the version-agnostic `clientRecordLocked` and a CB_NULL probe supplies the liveness signal.

**The layer neither issue found, and the one that actually mattered.** `CREATE_SESSION`'s auto-bind hardcoded `CDFC4_FORE`:

```go
d.StateManager.BindConnToSession(ctx.ConnectionID, result.SessionID, types.CDFC4_FORE)
```

RFC 8881 Section 18.36.3 associates the connection CREATE_SESSION arrived on with the session **in both directions** when `csa_flags` requests `CONN_BACK_CHAN`. Binding it fore-only left every session with a back-channel slot table and no connection under it. `maybeRegisterBackchannel` then returned early on `Direction != ConnDirBack && != ConnDirBoth`, so `StartBackchannelSender` never ran.

The normal mount flow for both the Linux client and pynfs stops at CREATE_SESSION — neither sends `BIND_CONN_TO_SESSION` — and `BindConnToSession` is called from exactly one other place, that operation's handler. So the entire v4.1 back channel was reachable only by a client that volunteered an extra operation nobody sends.

This is measured, not inferred. In the pre-fix pynfs v4.1 run on this branch, `dittofs.log` contains **no `BackchannelSender started` line and no CB_NULL line at all** across 19,899 lines and 767 CREATE_SESSION mentions — the probe never fired once. The direction now comes from the *response* flags, since the server clears `CONN_BACK_CHAN` when it did not set a back channel up.

**This is very likely #2218's root cause too.** #2218 recorded that delegation recall never worked against a real Linux client despite the code appearing correct. If no connection is ever back-bound on the normal flow, CB_RECALL over the back channel could not have worked either. I have not re-tested #2218 against a kernel client, so I am reporting the overlap, not claiming it closed.

## `OPEN_DELEGATE_NONE_EXT`

Neither issue names this, but `OPEN_DELEGATE_NONE_EXT`, `why_no_delegation4` and the `WND4_*` constants were absent from the entire tree, and row `DELEG4` (`testNoDeleg`) expects that encoding. A v4.1 client setting `OPEN4_SHARE_ACCESS_WANT_NO_DELEG` now gets `OPEN_DELEGATE_NONE_EXT` + `WND4_NOT_WANTED`; `WANT_CANCEL` gets `WND4_CANCELLED`, since this server keeps no want queue and so has nothing outstanding to satisfy.

Those bits were being discarded before any handler saw them: `handleOpen` did `shareAccess = accessMode` with a comment saying the server ignores the v4.1 want hints. The want value is now read *before* that mask and threaded forward as an already-decided reason, so everything downstream still receives the masked access mode and share reservations are untouched.

A v4.0 client never gets the extended arm — it did not exist in RFC 7530 and the client cannot decode past the discriminant. `WND4_CONTENTION` and `WND4_RESOURCE` each promise a later callback when the obstacle clears, which this server does not make, so an ordinary refusal stays `OPEN_DELEGATE_NONE`.

## The probe can fail, and has been seen failing

#2218 is the warning this had to answer: a CB_NULL that cannot fail is not evidence of a working back channel. Every way the probe can come back negative is exercised, and each asserts `CBPathUp` stays false **and** that no delegation is granted:

| The back channel is | How the probe finds out |
| --- | --- |
| never bound | `getBackBoundConnWriter` reports no connection |
| bound but broken | the write to it returns an error |
| bound and silent | no reply within the callback timeout |
| bound and refusing | the reply is `MSG_DENIED` |

Each case sets `CBPathUp` **true** first, so a pass cannot come from the flag being left at its zero value — only an observed refusal brings it down.

All three guards were then checked against deliberately broken builds:

```
# probe rewritten to always report success -- the #2218 trap
-  sm.setCBPathUp(bs.clientID, err == nil)
+  sm.setCBPathUp(bs.clientID, true)
--- FAIL: TestProbeCallbackPath_RefusesWhenBackchannelUnreachable (0.15s)

# lookup reverted to the v4.0-only index -- the bug #2436 describes
-  client := sm.clientRecordLocked(clientID)
+  client, exists := sm.clientsByID[clientID]
--- FAIL: TestProbeCallbackPath_AnsweredCBNullEnablesDelegation (0.00s)

# back-channel bind reverted to fore-only -- the bug that made the rest dead
-  if result.Flags&uint32(types.CREATE_SESSION4_FLAG_CONN_BACK_CHAN) != 0 {
+  if false {
--- FAIL: TestHandleCreateSession_AutoBindDirection (0.00s)
    create_session_backchannel_test.go:92: bound direction = fore, want both
```

A failed CB_RECALL over the back channel now also clears `CBPathUp`, which the v4.0 dial-out path already did. Without it, one grant to a client that then goes away leaves every later OPEN eligible for a delegation nobody can recall.

The probe ends on a failed write rather than falling back to a second back-bound connection the way `sendCallback` does. That is deliberate and documented: it is stricter than a real CB_RECALL, and withholding a delegation is the safe direction.

## #2457's CLAIM_DELEGATE_CUR path

#2457 taught `CLAIM_DELEGATE_CUR` to resolve the v4.1 current-stateid placeholder. That path was unreachable in production precisely because no delegation was ever granted to a v4.1 client. `TestV41Delegation_GrantedStateidResolvesForClaimDelegateCur` walks the chain it depends on — verified callback path, policy says yes, grant, and the stateid resolving back to a delegation the same client owns, which is the ownership check OPEN makes before honouring the claim.

## Verification

```
go build ./... && go vet ./... && gofmt -l internal pkg cmd
go test ./...
go test -race ./internal/adapter/nfs/...
```

### pynfs v4.1 row verdicts

Read from this PR's own artifacts, both PR backends (memory and postgres-s3), which agree exactly.

Server-log event counts, memory backend, before and after the back-channel bind fix:

| | pre-fix | post-fix |
| --- | --- | --- |
| `BackchannelSender started` | 0 | 110 |
| `CB_NULL succeeded` | 0 | 51 |
| `CB_NULL failed` | 0 | 4 |
| `Delegation granted` | 0 | 7 |
| `CB_RECALL (v4.1) sent successfully` | 0 | 0 |
| `CB_RECALL (v4.1) failed` | 0 | 6 |

The back channel now exists, the probe both succeeds and refuses for real reasons in production rather than only under test, and delegations are granted. Two rows flip, identically on both backends:

```
DELEG4   st_delegation.testNoDeleg                : PASS
DELEG26  st_delegation.testDelegReadAfterClose    : PASS
```

42 failing / 42 known / 0 new on both. `DELEG4` was already passing before the bind fix, which attributes it to the `NONE_EXT` encoding alone; `DELEG26` is newly passing and is the grant working end to end.

### Why the remaining eight rows do not move

Not the probe/OPEN race I expected. Every CB_RECALL fails the same way:

```
CB_RECALL (v4.1) failed error=backchannel callback failed after 3 attempts:
  no back-bound connection for session cd045f769850cbb97b96aee76ccdaec2
```

Probe succeeds, delegation is granted, and by recall time the session has no back-bound connection. Six attempts, zero delivered. The eight rows now fail in three new ways, all downstream of a successful grant: five with `AttributeError: 'Event' object has no attribute 'stateid'` (pynfs reading a recall event that never arrived), two with `Could not get delegation`, one with `delegation break not received`. Only the two `Could not get delegation` rows fit the race.

**The blocker is now recall delivery, which is #2218's subject and observable here for the first time.** Whether the binding is torn down by pynfs closing connections or by a teardown bug on our side is not diagnosed in this PR.

`KNOWN_FAILURES_V41.md` therefore walks out `DELEG4` and `DELEG26` on those literal `: PASS` lines, and corrects the reason on the other eight: `no delegation is granted` is now false for every one of them and would send the next reader to the wrong cause. They stay `bug` / `#2329`. The `AttributeError` rows are deliberately **not** reclassified `suite` — only `DELEG24` and `DELEG25` appear in `baseline-knfsd.md`, and that file is the only thing that justifies a `suite` row.

One exposure worth stating: a PR runs pynfs on memory and postgres-s3 only, while postsubmit adds badger and postgres. `DELEG4` is pure wire encoding and so backend-independent by construction, but `DELEG26` involves grant plus close semantics and has no badger/postgres evidence behind it. If postsubmit reds on `DELEG26`, the row goes back with a backend-dependent reason rather than being re-run.

`DELEG24` / `DELEG25` are `suite` (knfsd fails them too; they need v4.2 `FATTR4_OPEN_ARGUMENTS`) and are out of scope.

Refs #2436, #2329, #2218
