### PR TITLE
fix(journal): size the carve block arena to the share's own chunk ceiling

### DIFF
--- a/pkg/block/engine/carve_dispatch.go
+++ b/pkg/block/engine/carve_dispatch.go
@@ -53,14 +53,20 @@ func (m *RemoteSync) carveDispatcher(ctx context.Context) {
 // pass (one file, one block, one PutBlock at a time) leaves the uplink almost
 // idle — the block-upload latency, not the link or CPU, caps throughput.
 //
-// Concurrency is bounded by the adaptive upload window: the loop acquires
-// uploadLimiter before starting each file's carve and releases it when that
-// file's blocks are committed, so at most Limit() carves — and thus block
-// PUTs — are in flight. Acquiring the window is also what lets the goodput
-// controller observe real in-flight concurrency (TakePeak) and ramp the window;
-// without it the window is never consumed and stays pinned at the floor. Files
-// in one shard still serialize on the journal's internal carve lock, so the
-// concurrency here overlaps distinct shards' upload latency.
+// The adaptive upload window bounds how many files carve at once: the loop
+// acquires uploadLimiter before starting each file's carve and releases it when
+// that file's pass returns, so at most Limit() passes run together. It does not
+// bound the block PUTs inside a pass — each pass opens its own window on those —
+// so the PUTs in flight are the product of the two, and so is the memory held by
+// the blocks waiting on them.
+//
+// What the goodput controller samples through TakePeak is therefore this window,
+// the count of files, not the count of PUTs. Draining one large file peaks at a
+// single pass and reads as app-limited however many PUTs that pass has in the
+// air. Acquiring the window is still what keeps it consumed at all; without it
+// the window is never taken and stays pinned at the floor. Files in one shard
+// still serialize on the journal's internal carve lock, so the concurrency here
+// overlaps distinct shards' upload latency.
 func (m *RemoteSync) carvePass(ctx context.Context) {
 	files := m.local.ListFiles(ctx)
 	if len(files) == 0 {

--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -415,17 +415,23 @@ func (s *Store) packRuns(ctx context.Context, sh *shard, id FileID, rs []*runSta
 	//
 	// Invalid params fall back to the default profile because that is what the
 	// chunker itself does with them, so the arena matches the chunks actually cut.
-	// Compute in int64 and clamp before the int conversion so a pathological
-	// CarveBlockSize can't silently wrap on 32-bit platforms.
+	//
+	// Clamp the block size before adding the overhang, not after: a pathological
+	// CarveBlockSize near the int64 ceiling would wrap to a negative sum, sail
+	// past a clamp that only tests the upper bound, and reach make() as a
+	// negative length. CarveBlockSize is positive by then (withDefaults replaces
+	// anything <= 0) and the overhang is at most chunker.MaxChunkSize, so the
+	// subtraction below cannot itself go negative.
 	overhang := s.cfg.ChunkParams.Max
 	if s.cfg.ChunkParams.Validate() != nil {
 		overhang = chunker.DefaultParams().Max
 	}
-	arenaCap64 := s.cfg.CarveBlockSize + int64(overhang)
-	if arenaCap64 > math.MaxInt {
-		arenaCap64 = math.MaxInt
+	overhang64 := int64(overhang)
+	blockCap64 := s.cfg.CarveBlockSize
+	if blockCap64 > math.MaxInt-overhang64 {
+		blockCap64 = math.MaxInt - overhang64
 	}
-	arenaCap := int(arenaCap64)
+	arenaCap := int(blockCap64 + overhang64)
 
 	// The block currently being packed. arena is its private buffer (nil until the
 	// first novel chunk claims a pool buffer and a concurrency slot); arenaOff is

--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -22,9 +22,11 @@ import (
 //
 // ponytail: the buffer is sized from the package-wide chunker.MaxChunkSize
 // rather than the share's ChunkParams.Max, so a share chunking small still
-// reserves 16 MiB for it — and the block arena adds the same overhang term on
-// top; size both from ChunkParams.Max if that headroom ever shows up in a
-// memory profile.
+// reserves 16 MiB for it. Unlike the block arena this is one buffer per carve
+// pass rather than one per in-flight block, so it scales with files carving at
+// once and not with the upload window on top. Sizing it from ChunkParams.Max
+// also means moving the read loop below off the same constant, or it asks for
+// bytes past the buffer's capacity and stops making progress.
 var carveScratchPool = sync.Pool{New: func() any {
 	b := make([]byte, 0, chunker.MaxChunkSize)
 	return &b
@@ -402,9 +404,24 @@ func (s *Store) packRuns(ctx context.Context, sh *shard, id FileID, rs []*runSta
 	// Each packed block gets its OWN buffer (cap one block plus one overhang chunk)
 	// so its bytes stay live while its CommitBlock runs concurrently with the next
 	// block's packing — the recycled arena of the sequential path can't do that.
+	//
+	// The overhang is one chunk at this share's configured size, not the largest
+	// chunk any share could ask for. A block is flushed once it reaches
+	// CarveBlockSize, so it overshoots by at most the chunk that crossed the line,
+	// and no chunk exceeds ChunkParams.Max. Sizing the overhang from the package
+	// ceiling instead reserves 16 MiB per in-flight block for a share chunking at
+	// 128 KiB — and that reservation is per slot, so it multiplies by the carve
+	// upload window and again by however many files carve at once.
+	//
+	// Invalid params fall back to the default profile because that is what the
+	// chunker itself does with them, so the arena matches the chunks actually cut.
 	// Compute in int64 and clamp before the int conversion so a pathological
 	// CarveBlockSize can't silently wrap on 32-bit platforms.
-	arenaCap64 := s.cfg.CarveBlockSize + int64(chunker.MaxChunkSize)
+	overhang := s.cfg.ChunkParams.Max
+	if s.cfg.ChunkParams.Validate() != nil {
+		overhang = chunker.DefaultParams().Max
+	}
+	arenaCap64 := s.cfg.CarveBlockSize + int64(overhang)
 	if arenaCap64 > math.MaxInt {
 		arenaCap64 = math.MaxInt
 	}
@@ -576,8 +593,10 @@ func (s *Store) packRuns(ctx context.Context, sh *shard, id FileID, rs []*runSta
 				}
 				// Bound proof: this block's bytes < CarveBlockSize before this append
 				// (else the prior iteration flushed and started a fresh arena), and
-				// boundary <= MaxChunkSize, so arenaOff+boundary <= CarveBlockSize-1+
-				// MaxChunkSize <= cap. The grow is a fail-loud belt: if that invariant
+				// boundary <= the configured ChunkParams.Max — the chunker never cuts
+				// longer than its own ceiling — so arenaOff+boundary <=
+				// CarveBlockSize-1+ChunkParams.Max <= cap, which is how the arena is
+				// sized above. The grow is a fail-loud belt: if that invariant
 				// ever breaks (e.g. a config change), realloc rather than slice out of
 				// bounds. Already-pending Data slices keep pointing at the old backing
 				// (still live), so no copy is needed — the new chunk lands in the larger

--- a/pkg/block/journal/carve_arena_test.go
+++ b/pkg/block/journal/carve_arena_test.go
@@ -1,0 +1,73 @@
+package journal
+
+import (
+	"context"
+	"runtime"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block/chunker"
+)
+
+// TestCarveArenaSizedToConfiguredChunkSize pins the memory a carve reserves for
+// blocks in flight.
+//
+// Each in-flight block owns a private arena of one CarveBlockSize plus one
+// chunk of overhang, because a block is flushed only once it crosses
+// CarveBlockSize and so overshoots by the chunk that crossed the line. Sizing
+// that overhang from the package ceiling rather than the share's own
+// ChunkParams reserves 16 MiB per block for a share chunking at 16 KiB, and the
+// reservation is per concurrency slot — so it multiplies by CarveUploadConcurrency
+// and again by however many files carve at once.
+//
+// The arenas come from a sync.Pool, which Go empties on GC, so collecting first
+// makes the allocation observable instead of served from a previous test's
+// leftovers.
+func TestCarveArenaSizedToConfiguredChunkSize(t *testing.T) {
+	const (
+		blockSize = 1 << 20
+		fileSize  = 6 << 20
+		window    = 4
+	)
+	params := chunker.Params{Min: 4 << 10, Avg: 8 << 10, Max: 16 << 10}
+
+	s, _, sink, _ := carveStore(t, Config{
+		CarveBlockSize:         blockSize,
+		CarveUploadConcurrency: window,
+		ChunkParams:            params,
+	})
+	ctx := context.Background()
+
+	if err := s.WriteAt(ctx, "f", 0, randBytes(fileSize, 1)); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+
+	runtime.GC()
+	runtime.GC()
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	if _, err := s.Carve(ctx, CarveOptions{Force: true}); err != nil {
+		t.Fatalf("Carve: %v", err)
+	}
+	runtime.ReadMemStats(&after)
+
+	sink.mu.Lock()
+	blocks := sink.blocks
+	sink.mu.Unlock()
+	if blocks < window {
+		t.Fatalf("carved %d blocks, need at least %d to fill the concurrency window", blocks, window)
+	}
+
+	// What the arenas may cost: one per slot, each a block plus one configured
+	// chunk. Everything else the pass allocates — the file's own bytes, the
+	// chunker scratch buffer, the manifest rows — is bounded well inside the
+	// slack below, and sizing the overhang from chunker.MaxChunkSize instead
+	// would put the arenas alone an order of magnitude over it.
+	arenas := int64(window) * (blockSize + int64(params.Max))
+	limit := arenas + 8*fileSize
+	if got := int64(after.TotalAlloc - before.TotalAlloc); got > limit {
+		t.Errorf("carve allocated %d bytes, over the %d-byte ceiling for %d slots of %d-byte arenas — "+
+			"the per-block overhang is not sized to this share's chunks",
+			got, limit, window, blockSize+params.Max)
+	}
+}

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -69,9 +69,11 @@ type Config struct {
 	// across the whole file, one block at a time, and so are the manifest row-end
 	// lookups that widen each run; only the commits overlap, so a single large
 	// file's carve is not one PutBlock at a time.
-	// Peak carve RAM per file is window x (CarveBlockSize + one overhang chunk)
-	// for the block arenas, plus the single chunker scratch buffer of
-	// chunker.MaxChunkSize the pass holds — so keep it modest.
+	// Peak carve RAM per file is window x (CarveBlockSize + one ChunkParams.Max
+	// chunk) for the block arenas, plus the single chunker scratch buffer of
+	// chunker.MaxChunkSize the pass holds. Per file: whatever bounds how many
+	// files carve at once multiplies the arena term again, so the real ceiling
+	// is that product — keep this modest.
 	// Zero falls back to the default via withDefaults.
 	CarveUploadConcurrency int
 	// DirtyExpiry bounds how long an appended record may sit unfsynced. A


### PR DESCRIPTION
Refs #2423 — the memory half of the two-window product. Does **not** close it: collapsing the windows and fixing the controller's signal remain semantics decisions, [analysed in the issue](https://github.com/marmos91/dittofs/issues/2423#issuecomment-5591814485).

## What the arena costs

Each in-flight block owns a private arena of one `CarveBlockSize` plus one chunk of overhang — a block flushes only once it crosses `CarveBlockSize`, so it overshoots by the chunk that crossed the line. The overhang came from the package-wide ceiling:

```go
arenaCap64 := s.cfg.CarveBlockSize + int64(chunker.MaxChunkSize)   // 16 MiB, always
```

But `chunk_size` derives the share's ceiling (`blockstore_config.go:1105`):

```go
cp := chunker.Params{Min: int(n), Avg: int(n) * 4, Max: int(n) * 8}
```

So a share at the 128 KiB recommended for random-access workloads (#1569) has `Max = 1 MiB` and reserved **16 MiB per block it could never fill**. A default share is unaffected — `DefaultParams().Max` *is* the package ceiling.

## Why it multiplies

The reservation is per concurrency slot, so it scales with both windows:

**peak carve memory = ParallelUploads x CarveUploadConcurrency x (CarveBlockSize + overhang)**

At defaults that is 20 MiB a slot: 2.5 GiB at the adaptive floor, 10.2 GiB at the ceiling. Worst case rather than typical — a file only holds 8 slots with 8 blocks' worth of dirty data ready — but nothing declares or bounds it. For a 128 KiB share the per-slot term drops 20 MiB → 5 MiB.

## This is a recorded debt, not a new idea

`carve.go:23` already carried a `ponytail:` marker naming it and the condition to act: *"size both from ChunkParams.Max if that headroom ever shows up in a memory profile."* It has. The marker stays on the scratch buffer half, with the reason that half is harder: shrinking it also means moving the read loop off the same constant, or it asks for bytes past its own capacity and stops making progress.

## Verification

New test pins the ceiling, and **fails against unpatched `carve.go`** — 6 MiB file, 1 MiB blocks, window 4, 16 KiB chunks:

```
carve allocated 121564840 bytes, over the 54591488-byte ceiling for 4 slots of 1064960-byte arenas
```

Patched: **36.7 MB**, down from 121.6 MB. The test collects before measuring, because Go empties `sync.Pool` on GC and the arenas would otherwise be served from a previous test's leftovers.

- `go test ./pkg/block/journal/` green
- `go test -race ./pkg/block/journal/ ./pkg/block/engine/` green (67.9s / 235.0s)
- Everything edited after that race run was comments only

## Also in the diff

`engine/carve_dispatch.go`'s comment claimed the upload window bounds block PUTs, and that the goodput controller observes real in-flight concurrency through it. It bounds carve *passes*, and what `TakePeak` counts is files — which is why draining one large file reads as app-limited however many PUTs are in the air. `engine/types.go` had the same error and was fixed in #2438; this was the remaining copy, and it is the same misdescription this PR's arithmetic depends on.

## Not touched

No behaviour change: same chunk boundaries, same PUTs, same ordering, same exit paths. The grow-belt at the append site still backstops the bound if a config ever breaks it.