### PR TITLE
fix(nfs): reject bad, old and stale stateids in CLOSE, OPEN_CONFIRM, OPEN_DOWNGRADE and LOCK

### DIFF
--- a/internal/adapter/nfs/v4/handlers/io_test.go
+++ b/internal/adapter/nfs/v4/handlers/io_test.go
@@ -834,7 +834,29 @@ func TestClose_Success(t *testing.T) {
 	ctx.CurrentFH = make([]byte, len(fileHandle))
 	copy(ctx.CurrentFH, fileHandle)
 
-	args := encodeCloseArgs(1, &anonymousStateid)
+	// A real open to close. The anonymous stateid cannot stand in for one:
+	// RFC 7530 Section 9.1.4.3 admits a special stateid only on READ, WRITE
+	// and SETATTR, so CLOSE answers it NFS4ERR_BAD_STATEID.
+	sm := fx.handler.StateManager
+	clientRes, err := sm.SetClientID("close-success-client", [8]byte{1, 2, 3, 4, 5, 6, 7, 8},
+		state.CallbackInfo{Program: 0x40000000, NetID: "tcp", Addr: "10.0.0.1.8.1"}, "10.0.0.1:1234")
+	if err != nil {
+		t.Fatalf("SetClientID: %v", err)
+	}
+	if err := sm.ConfirmClientID(clientRes.ClientID, clientRes.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID: %v", err)
+	}
+	opened, err := sm.OpenFile(clientRes.ClientID, []byte("close-success-owner"), 1, ctx.CurrentFH,
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	confirmed, err := sm.ConfirmOpen(&opened.Stateid, 2, 0)
+	if err != nil {
+		t.Fatalf("ConfirmOpen: %v", err)
+	}
+
+	args := encodeCloseArgs(3, &confirmed.Stateid)
 	result := fx.handler.handleClose(ctx, bytes.NewReader(args))
 
 	if result.Status != types.NFS4_OK {
@@ -865,6 +887,27 @@ func TestClose_Success(t *testing.T) {
 	// CLOSE should NOT clear CurrentFH per RFC 7530
 	if ctx.CurrentFH == nil {
 		t.Error("CurrentFH should NOT be cleared by CLOSE")
+	}
+}
+
+// TestClose_AnonymousStateid pins the rejection of a special stateid on CLOSE.
+// RFC 7530 Section 9.1.4.3 admits one only on READ, WRITE and SETATTR, so CLOSE
+// names no open state and must not report success.
+func TestClose_AnonymousStateid(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+
+	fileHandle := fx.createRegularFile(t, fx.rootHandle, "closeanon.txt", 0o644, 0, 0)
+
+	ctx := newRealFSContext(0, 0)
+	ctx.CurrentFH = make([]byte, len(fileHandle))
+	copy(ctx.CurrentFH, fileHandle)
+
+	args := encodeCloseArgs(1, &anonymousStateid)
+	result := fx.handler.handleClose(ctx, bytes.NewReader(args))
+
+	if result.Status != types.NFS4ERR_BAD_STATEID {
+		t.Errorf("CLOSE with the anonymous stateid status = %d, want NFS4ERR_BAD_STATEID (%d)",
+			result.Status, types.NFS4ERR_BAD_STATEID)
 	}
 }
 

--- a/internal/adapter/nfs/v4/handlers/lock.go
+++ b/internal/adapter/nfs/v4/handlers/lock.go
@@ -133,6 +133,22 @@ func (h *Handler) handleLock(ctx *types.CompoundContext, reader io.Reader) *type
 		}
 		lockOwnerClientID = ctx.EffectiveClientID(lockOwnerClientID)
 
+		// Admit the clientid the lock-owner names before any lock-owner is
+		// keyed under it, as handleOpen does for open_owner4: a lock-owner
+		// behind an id no client record covers holds state no lease reaps.
+		if clientErr := h.StateManager.ValidateAndRenewClient(lockOwnerClientID); clientErr != nil {
+			nfsStatus := mapStateError(clientErr)
+			logger.Debug("NFSv4 LOCK rejected: invalid client id",
+				"client_id", lockOwnerClientID,
+				"error", clientErr,
+				"client", ctx.ClientAddr)
+			return &types.CompoundResult{
+				Status: nfsStatus,
+				OpCode: types.OP_LOCK,
+				Data:   encodeStatusOnly(nfsStatus),
+			}
+		}
+
 		lockOwnerData, decErr := xdr.DecodeOpaque(reader)
 		if decErr != nil {
 			return &types.CompoundResult{
@@ -317,6 +333,22 @@ func (h *Handler) handleLockT(ctx *types.CompoundContext, reader io.Reader) *typ
 		}
 	}
 	clientID = ctx.EffectiveClientID(clientID)
+
+	// LOCKT creates no state, but the clientid its lock_owner4 names is the
+	// identity the probe is made on behalf of: one no client record covers
+	// cannot be answered "no conflict".
+	if clientErr := h.StateManager.ValidateAndRenewClient(clientID); clientErr != nil {
+		nfsStatus := mapStateError(clientErr)
+		logger.Debug("NFSv4 LOCKT rejected: invalid client id",
+			"client_id", clientID,
+			"error", clientErr,
+			"client", ctx.ClientAddr)
+		return &types.CompoundResult{
+			Status: nfsStatus,
+			OpCode: types.OP_LOCKT,
+			Data:   encodeStatusOnly(nfsStatus),
+		}
+	}
 
 	ownerData, err := xdr.DecodeOpaque(reader)
 	if err != nil {

--- a/internal/adapter/nfs/v4/handlers/lock_test.go
+++ b/internal/adapter/nfs/v4/handlers/lock_test.go
@@ -1204,3 +1204,41 @@ func TestHandleLock_InvalidRange(t *testing.T) {
 		})
 	}
 }
+
+// TestHandleLock_UnknownClientID and TestHandleLockT_UnknownClientID pin the
+// admission of the clientid inside lock_owner4. Neither operation checked it,
+// so a LOCK keyed a lock-owner under an id no client record covers and a LOCKT
+// answered "no conflict" on behalf of an identity that does not exist. An id
+// whose high half is not this incarnation's boot epoch is stale rather than
+// merely unknown (RFC 7530 Section 13.1.10.2).
+func TestHandleLock_UnknownClientID(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+	handle := fx.createTestFile(t, fx.rootHandle, "lock-badclid.txt", metadata.FileTypeRegular, 0o644, 1000, 1000)
+
+	ctx := newRealFSContext(1000, 1000)
+	ctx.CurrentFH = append([]byte(nil), handle...)
+
+	args := encodeNewLockOwnerArgs(types.WRITE_LT, 0, 100, 2, &types.Stateid4{Seqid: 1}, 1, 0, []byte("lock-owner"))
+	result := fx.handler.handleLock(ctx, bytes.NewReader(args))
+
+	if result.Status != types.NFS4ERR_STALE_CLIENTID {
+		t.Errorf("LOCK with an unknown clientid status = %d, want NFS4ERR_STALE_CLIENTID (%d)",
+			result.Status, types.NFS4ERR_STALE_CLIENTID)
+	}
+}
+
+func TestHandleLockT_UnknownClientID(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+	handle := fx.createTestFile(t, fx.rootHandle, "lockt-badclid.txt", metadata.FileTypeRegular, 0o644, 1000, 1000)
+
+	ctx := newRealFSContext(1000, 1000)
+	ctx.CurrentFH = append([]byte(nil), handle...)
+
+	args := encodeLocktArgs(types.WRITE_LT, 0, 100, 0, []byte("lockt-owner"))
+	result := fx.handler.handleLockT(ctx, bytes.NewReader(args))
+
+	if result.Status != types.NFS4ERR_STALE_CLIENTID {
+		t.Errorf("LOCKT with an unknown clientid status = %d, want NFS4ERR_STALE_CLIENTID (%d)",
+			result.Status, types.NFS4ERR_STALE_CLIENTID)
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/stubs_test.go
+++ b/internal/adapter/nfs/v4/handlers/stubs_test.go
@@ -56,7 +56,10 @@ func TestHandleOpenDowngrade_BadStateid(t *testing.T) {
 		CurrentFH:  pfs.GetRootHandle(),
 	}
 
-	// Encode OPEN_DOWNGRADE args with an unknown stateid (no open state exists)
+	// Encode OPEN_DOWNGRADE args with an unknown stateid (no open state
+	// exists). Its all-zero "other" carries a boot-epoch fragment no
+	// incarnation of this server ever minted, which is what makes it stale
+	// rather than merely unknown.
 	var args bytes.Buffer
 	sid := &types.Stateid4{Seqid: 1}
 	types.EncodeStateid4(&args, sid)
@@ -66,10 +69,9 @@ func TestHandleOpenDowngrade_BadStateid(t *testing.T) {
 
 	result := h.handleOpenDowngrade(ctx, bytes.NewReader(args.Bytes()))
 
-	// Should return BAD_STATEID since the stateid is not tracked
-	if result.Status != types.NFS4ERR_BAD_STATEID {
-		t.Errorf("OPEN_DOWNGRADE with unknown stateid status = %d, want NFS4ERR_BAD_STATEID (%d)",
-			result.Status, types.NFS4ERR_BAD_STATEID)
+	if result.Status != types.NFS4ERR_STALE_STATEID {
+		t.Errorf("OPEN_DOWNGRADE with a foreign-epoch stateid status = %d, want NFS4ERR_STALE_STATEID (%d)",
+			result.Status, types.NFS4ERR_STALE_STATEID)
 	}
 	if result.OpCode != types.OP_OPEN_DOWNGRADE {
 		t.Errorf("OPEN_DOWNGRADE opCode = %d, want OP_OPEN_DOWNGRADE (%d)",

--- a/internal/adapter/nfs/v4/state/close_seqid_test.go
+++ b/internal/adapter/nfs/v4/state/close_seqid_test.go
@@ -144,7 +144,11 @@ func TestDowngradeOpen_ReplayLeavesOwnerSeqidUntouched(t *testing.T) {
 	clientID, _, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
 	seqid := openSeqid + 1
-	if _, err := sm.DowngradeOpen(openStateid, seqid, types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, 0); err != nil {
+	// The open behind these stateids was opened for BOTH and nothing else, so
+	// BOTH is the only share_access an OPEN_DOWNGRADE on it may name: RFC 7530
+	// Section 16.19.4 admits only a mode some OPEN actually asked for.
+	downgraded, err := sm.DowngradeOpen(openStateid, seqid, types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, 0)
+	if err != nil {
 		t.Fatalf("OPEN_DOWNGRADE failed: %v", err)
 	}
 
@@ -167,8 +171,10 @@ func TestDowngradeOpen_ReplayLeavesOwnerSeqidUntouched(t *testing.T) {
 		}
 	}
 
-	// The sequence is still where the successful OPEN_DOWNGRADE left it.
-	if _, err := sm.DowngradeOpen(openStateid, seqid+1, types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, 0); err != nil {
+	// The sequence is still where the successful OPEN_DOWNGRADE left it. A new
+	// request carries the stateid that OPEN_DOWNGRADE returned, not the one the
+	// retransmits above replayed.
+	if _, err := sm.DowngradeOpen(&downgraded.Stateid, seqid+1, types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, 0); err != nil {
 		t.Fatalf("OPEN_DOWNGRADE after replays failed: %v "+
 			"(a replay advanced the open-owner seqid; it must not)", err)
 	}

--- a/internal/adapter/nfs/v4/state/lockowner_test.go
+++ b/internal/adapter/nfs/v4/state/lockowner_test.go
@@ -230,8 +230,10 @@ func TestLockNew_BadOpenStateid(t *testing.T) {
 
 	clientID, fileHandle, _, _ := setupClientAndOpenState(t, sm)
 
-	// Use a bogus open stateid
-	bogusStateid := &types.Stateid4{Seqid: 1}
+	// An "other" this server could have issued but never did: minting it from
+	// the current boot epoch keeps the answer NFS4ERR_BAD_STATEID rather than
+	// the NFS4ERR_STALE_STATEID a foreign epoch earns.
+	bogusStateid := &types.Stateid4{Seqid: 1, Other: sm.generateStateidOther(StateTypeOpen)}
 
 	_, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner-1"), 1, bogusStateid, 1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
 	if err == nil {

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -1837,9 +1837,8 @@ func (sm *StateManager) CacheLockOwnerResult(clientID uint64, ownerData []byte, 
 // Caller must NOT hold sm.mu.
 func (sm *StateManager) ConfirmOpen(stateid *types.Stateid4, seqid uint32, callerClientID uint64) (result *OpenSeqResult, err error) {
 	// A special stateid names no state at all, and RFC 7530 Section 9.1.4.3
-	// admits one only on READ, WRITE and SETATTR. Rejecting it here also keeps
-	// its all-zeros / all-ones "other" out of the table-miss classifier, which
-	// would read that as another incarnation's boot epoch and answer stale.
+	// admits one only on READ, WRITE and SETATTR. stateidMissError documents
+	// why it must be rejected before a table miss is classified.
 	if stateid.IsSpecialStateid() {
 		return nil, ErrBadStateid
 	}
@@ -1883,9 +1882,8 @@ func (sm *StateManager) ConfirmOpen(stateid *types.Stateid4, seqid uint32, calle
 		}
 	}
 
-	// The stateid must be the one this open currently answers to. Compared only
-	// after the owner seqid check above, so a retransmit replays its cached
-	// reply instead of being rejected for the seqid it is one behind on.
+	// The stateid must name this open's current seqid, compared after the owner
+	// seqid above so a retransmit still replays; see checkStateidSeqid.
 	if err := checkStateidSeqid(stateid.Seqid, openState.Stateid.Seqid); err != nil {
 		return nil, err
 	}
@@ -1960,9 +1958,8 @@ func (sm *StateManager) ConfirmOpenV41(stateid *types.Stateid4, callerClientID u
 func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32, callerClientID uint64) (result *OpenSeqResult, err error) {
 	// A special stateid names no open state, and RFC 7530 Section 9.1.4.3
 	// admits one only on READ, WRITE and SETATTR, so CLOSE has nothing to act
-	// on. Rejecting it here also keeps its all-zeros / all-ones "other" out of
-	// the table-miss classifier, which would read that as another incarnation's
-	// boot epoch and answer stale.
+	// on. stateidMissError documents why it must be rejected before a table
+	// miss is classified.
 	if stateid.IsSpecialStateid() {
 		return nil, ErrBadStateid
 	}
@@ -2020,9 +2017,8 @@ func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32, callerC
 		}
 	}
 
-	// The stateid must be the one this open currently answers to. Compared only
-	// after the owner seqid check above, so a retransmit replays its cached
-	// reply instead of being rejected for the seqid it is one behind on.
+	// The stateid must name this open's current seqid, compared after the owner
+	// seqid above so a retransmit still replays; see checkStateidSeqid.
 	if err := checkStateidSeqid(stateid.Seqid, openState.Stateid.Seqid); err != nil {
 		return nil, err
 	}
@@ -2167,9 +2163,8 @@ func (sm *StateManager) dropLockOwnerIfUnreferencedLocked(lockOwner *LockOwner) 
 // Caller must NOT hold sm.mu.
 func (sm *StateManager) DowngradeOpen(stateid *types.Stateid4, seqid uint32, newShareAccess, newShareDeny uint32, callerClientID uint64) (result *OpenSeqResult, err error) {
 	// A special stateid names no state at all, and RFC 7530 Section 9.1.4.3
-	// admits one only on READ, WRITE and SETATTR. Rejecting it here also keeps
-	// its all-zeros / all-ones "other" out of the table-miss classifier, which
-	// would read that as another incarnation's boot epoch and answer stale.
+	// admits one only on READ, WRITE and SETATTR. stateidMissError documents
+	// why it must be rejected before a table miss is classified.
 	if stateid.IsSpecialStateid() {
 		return nil, ErrBadStateid
 	}
@@ -2214,9 +2209,8 @@ func (sm *StateManager) DowngradeOpen(stateid *types.Stateid4, seqid uint32, new
 		}
 	}
 
-	// The stateid must be the one this open currently answers to. Compared only
-	// after the owner seqid check above, so a retransmit replays its cached
-	// reply instead of being rejected for the seqid it is one behind on.
+	// The stateid must name this open's current seqid, compared after the owner
+	// seqid above so a retransmit still replays; see checkStateidSeqid.
 	if err := checkStateidSeqid(stateid.Seqid, openState.Stateid.Seqid); err != nil {
 		return nil, err
 	}
@@ -2252,11 +2246,11 @@ func (sm *StateManager) DowngradeOpen(stateid *types.Stateid4, seqid uint32, new
 	openState.ShareDeny = newShareDeny
 
 	// Forget the opened modes this downgrade drops: a later OPEN_DOWNGRADE may
-	// only name one that is still a subset of what this one kept.
-	for mode := uint32(types.OPEN4_SHARE_ACCESS_READ); mode <= types.OPEN4_SHARE_ACCESS_BOTH; mode++ {
-		if mode&newShareAccess != mode {
-			openState.openedAccessModes &^= shareModeBit(mode)
-		}
+	// only name one this one kept. Downgrading to a single mode leaves that
+	// mode as the only one opened; BOTH still covers all three, so it drops
+	// nothing.
+	if newShareAccess != types.OPEN4_SHARE_ACCESS_BOTH {
+		openState.openedAccessModes = shareModeBit(newShareAccess)
 	}
 
 	// Increment stateid seqid
@@ -2485,9 +2479,8 @@ func (sm *StateManager) LockNew(
 	}
 
 	// A special stateid names no state at all, and RFC 7530 Section 9.1.4.3
-	// admits one only on READ, WRITE and SETATTR. Rejecting it here also keeps
-	// its all-zeros / all-ones "other" out of the table-miss classifier, which
-	// would read that as another incarnation's boot epoch and answer stale.
+	// admits one only on READ, WRITE and SETATTR. stateidMissError documents
+	// why it must be rejected before a table miss is classified.
 	if openStateid.IsSpecialStateid() {
 		return nil, ErrBadStateid
 	}
@@ -2577,9 +2570,8 @@ func (sm *StateManager) LockNew(
 		return nil, ErrBadSeqid
 	}
 
-	// The open stateid must be the one that open currently answers to. Compared
-	// only after both seqid checks above, so a retransmit replays its cached
-	// reply instead of being rejected for the seqid it is one behind on.
+	// The open stateid must name that open's current seqid, compared after both
+	// seqid checks above so a retransmit still replays; see checkStateidSeqid.
 	if err := checkStateidSeqid(openStateid.Seqid, openState.Stateid.Seqid); err != nil {
 		return nil, err
 	}

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -1121,22 +1121,6 @@ func (sm *StateManager) markClientStateidsExpiredLocked(clientID uint64) {
 	}
 }
 
-// lockStateidMissError classifies a lock-stateid table miss: state freed by a
-// lease cancellation answers NFS4ERR_EXPIRED (RFC 7530 Section 9.6.3.2), a
-// stateid minted by an earlier server incarnation answers
-// NFS4ERR_STALE_STATEID, and anything else was never issued.
-//
-// Caller must hold sm.mu.
-func (sm *StateManager) lockStateidMissError(other [types.NFS4_OTHER_SIZE]byte) error {
-	if sm.isExpiredStateidLocked(other) {
-		return ErrExpired
-	}
-	if !sm.isCurrentEpoch(other) {
-		return ErrStaleStateid
-	}
-	return ErrBadStateid
-}
-
 // isExpiredStateidLocked reports whether the state this stateid named was freed
 // when the server cancelled the owning client's lease. Callers use it on a
 // table miss, before falling back to NFS4ERR_BAD_STATEID.
@@ -1850,19 +1834,21 @@ func (sm *StateManager) CacheLockOwnerResult(clientID uint64, ownerData []byte, 
 //
 // Caller must NOT hold sm.mu.
 func (sm *StateManager) ConfirmOpen(stateid *types.Stateid4, seqid uint32, callerClientID uint64) (result *OpenSeqResult, err error) {
+	// A special stateid names no state at all, and RFC 7530 Section 9.1.4.3
+	// admits one only on READ, WRITE and SETATTR. Rejecting it here also keeps
+	// its all-zeros / all-ones "other" out of the table-miss classifier, which
+	// would read that as another incarnation's boot epoch and answer stale.
+	if stateid.IsSpecialStateid() {
+		return nil, ErrBadStateid
+	}
+
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
 	// Look up the open state
 	openState, exists := sm.openStateByOther[stateid.Other]
 	if !exists {
-		if sm.isExpiredStateidLocked(stateid.Other) {
-			return nil, ErrExpired
-		}
-		return nil, &NFS4StateError{
-			Status:  types.NFS4ERR_BAD_STATEID,
-			Message: "stateid not found for OPEN_CONFIRM",
-		}
+		return nil, sm.stateidMissError(stateid.Other)
 	}
 
 	// A stateid is not a bearer token: reject one that names another client's
@@ -1893,6 +1879,20 @@ func (sm *StateManager) ConfirmOpen(stateid *types.Stateid4, seqid uint32, calle
 		case SeqIDOK:
 			// Continue
 		}
+	}
+
+	// The stateid must be the one this open currently answers to. Compared only
+	// after the owner seqid check above, so a retransmit replays its cached
+	// reply instead of being rejected for the seqid it is one behind on.
+	if err := checkStateidSeqid(stateid.Seqid, openState.Stateid.Seqid); err != nil {
+		return nil, err
+	}
+
+	// An open confirms once. A second OPEN_CONFIRM finds no unconfirmed state,
+	// so the stateid it carries no longer names anything OPEN_CONFIRM can act
+	// on (RFC 7530 Section 16.18.5).
+	if openState.Confirmed {
+		return nil, ErrBadStateid
 	}
 
 	// Promote to confirmed
@@ -1931,10 +1931,7 @@ func (sm *StateManager) ConfirmOpenV41(stateid *types.Stateid4, callerClientID u
 
 	openState, exists := sm.openStateByOther[stateid.Other]
 	if !exists {
-		return &NFS4StateError{
-			Status:  types.NFS4ERR_BAD_STATEID,
-			Message: "stateid not found for v4.1 auto-confirm",
-		}
+		return sm.stateidMissError(stateid.Other)
 	}
 
 	// A stateid is not a bearer token: another client's open must not be
@@ -1959,9 +1956,13 @@ func (sm *StateManager) ConfirmOpenV41(stateid *types.Stateid4, callerClientID u
 //
 // Caller must NOT hold sm.mu.
 func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32, callerClientID uint64) (result *OpenSeqResult, err error) {
-	// Handle special stateids (all-zeros, all-ones): no state to clean up
+	// A special stateid names no open state, and RFC 7530 Section 9.1.4.3
+	// admits one only on READ, WRITE and SETATTR, so CLOSE has nothing to act
+	// on. Rejecting it here also keeps its all-zeros / all-ones "other" out of
+	// the table-miss classifier, which would read that as another incarnation's
+	// boot epoch and answer stale.
 	if stateid.IsSpecialStateid() {
-		return &OpenSeqResult{}, nil
+		return nil, ErrBadStateid
 	}
 
 	sm.mu.Lock()
@@ -1981,13 +1982,7 @@ func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32, callerC
 				return nil, &ReplayError{Status: owner.LastResult.Status, Data: owner.LastResult.Data}
 			}
 		}
-		if sm.isExpiredStateidLocked(stateid.Other) {
-			return nil, ErrExpired
-		}
-		return nil, &NFS4StateError{
-			Status:  types.NFS4ERR_BAD_STATEID,
-			Message: "stateid not found for CLOSE",
-		}
+		return nil, sm.stateidMissError(stateid.Other)
 	}
 
 	// A stateid is not a bearer token: reject one that names another client's
@@ -2021,6 +2016,13 @@ func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32, callerC
 		case SeqIDOK:
 			// Continue
 		}
+	}
+
+	// The stateid must be the one this open currently answers to. Compared only
+	// after the owner seqid check above, so a retransmit replays its cached
+	// reply instead of being rejected for the seqid it is one behind on.
+	if err := checkStateidSeqid(stateid.Seqid, openState.Stateid.Seqid); err != nil {
+		return nil, err
 	}
 
 	// Refuse while ranges are genuinely held -- RFC 7530 Section 16.2.4 permits
@@ -2162,19 +2164,21 @@ func (sm *StateManager) dropLockOwnerIfUnreferencedLocked(lockOwner *LockOwner) 
 //
 // Caller must NOT hold sm.mu.
 func (sm *StateManager) DowngradeOpen(stateid *types.Stateid4, seqid uint32, newShareAccess, newShareDeny uint32, callerClientID uint64) (result *OpenSeqResult, err error) {
+	// A special stateid names no state at all, and RFC 7530 Section 9.1.4.3
+	// admits one only on READ, WRITE and SETATTR. Rejecting it here also keeps
+	// its all-zeros / all-ones "other" out of the table-miss classifier, which
+	// would read that as another incarnation's boot epoch and answer stale.
+	if stateid.IsSpecialStateid() {
+		return nil, ErrBadStateid
+	}
+
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
 	// Look up the open state
 	openState, exists := sm.openStateByOther[stateid.Other]
 	if !exists {
-		if sm.isExpiredStateidLocked(stateid.Other) {
-			return nil, ErrExpired
-		}
-		return nil, &NFS4StateError{
-			Status:  types.NFS4ERR_BAD_STATEID,
-			Message: "stateid not found for OPEN_DOWNGRADE",
-		}
+		return nil, sm.stateidMissError(stateid.Other)
 	}
 
 	// A stateid is not a bearer token: reject one that names another client's
@@ -2206,6 +2210,13 @@ func (sm *StateManager) DowngradeOpen(stateid *types.Stateid4, seqid uint32, new
 		case SeqIDOK:
 			// Continue
 		}
+	}
+
+	// The stateid must be the one this open currently answers to. Compared only
+	// after the owner seqid check above, so a retransmit replays its cached
+	// reply instead of being rejected for the seqid it is one behind on.
+	if err := checkStateidSeqid(stateid.Seqid, openState.Stateid.Seqid); err != nil {
+		return nil, err
 	}
 
 	// Verify the new access is a subset of current (can only remove bits)
@@ -2459,13 +2470,21 @@ func (sm *StateManager) LockNew(
 		}
 	}
 
+	// A special stateid names no state at all, and RFC 7530 Section 9.1.4.3
+	// admits one only on READ, WRITE and SETATTR. Rejecting it here also keeps
+	// its all-zeros / all-ones "other" out of the table-miss classifier, which
+	// would read that as another incarnation's boot epoch and answer stale.
+	if openStateid.IsSpecialStateid() {
+		return nil, ErrBadStateid
+	}
+
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
 	// 1. Validate open stateid
 	openState, exists := sm.openStateByOther[openStateid.Other]
 	if !exists {
-		return nil, ErrBadStateid
+		return nil, sm.stateidMissError(openStateid.Other)
 	}
 
 	// A stateid is not a bearer token: reject one that names another client's
@@ -2542,6 +2561,13 @@ func (sm *StateManager) LockNew(
 		// Open seqid replayed but the lock-owner is brand new / not yet
 		// seqid-tracked: nothing consistent to replay.
 		return nil, ErrBadSeqid
+	}
+
+	// The open stateid must be the one that open currently answers to. Compared
+	// only after both seqid checks above, so a retransmit replays its cached
+	// reply instead of being rejected for the seqid it is one behind on.
+	if err := checkStateidSeqid(openStateid.Seqid, openState.Stateid.Seqid); err != nil {
+		return nil, err
 	}
 
 	// 5. Find or create lock-owner -- only after seqid validation passes.
@@ -2658,7 +2684,7 @@ func (sm *StateManager) LockExisting(
 	// stateid that is not the caller's before any cross-protocol work happens.
 	lockState, exists := sm.lockStateByOther[lockStateid.Other]
 	if !exists {
-		return nil, sm.lockStateidMissError(lockStateid.Other)
+		return nil, sm.stateidMissError(lockStateid.Other)
 	}
 	if err := sm.revalidateLockStateLocked(lockState, callerClientID); err != nil {
 		return nil, err
@@ -2694,18 +2720,8 @@ func (sm *StateManager) LockExisting(
 	}
 
 	// 3. Validate stateid seqid (only for non-replay LOCK).
-	// Per RFC 8881 Section 8.2.2, a v4.1 client may send stateid seqid=0 to
-	// mean "the most recent seqid"; the slot table already provides replay
-	// protection, so the server MUST bypass the seqid comparison in that case.
-	// lockState.Stateid.Seqid starts at 1 after LockNew, so without this bypass
-	// every v4.1 LOCK via LockExisting would return NFS4ERR_OLD_STATEID.
-	if lockStateid.Seqid != 0 {
-		if lockStateid.Seqid < lockState.Stateid.Seqid {
-			return nil, ErrOldStateid
-		}
-		if lockStateid.Seqid > lockState.Stateid.Seqid {
-			return nil, ErrBadStateid
-		}
+	if err := checkStateidSeqid(lockStateid.Seqid, lockState.Stateid.Seqid); err != nil {
+		return nil, err
 	}
 
 	// 4. Validate the byte range and the open mode for the lock type
@@ -2848,7 +2864,7 @@ func (sm *StateManager) acquireLock(ctx context.Context, lockState *LockState, l
 // Caller must hold sm.mu.
 func (sm *StateManager) revalidateLockStateLocked(lockState *LockState, callerClientID uint64) error {
 	if sm.lockStateByOther[lockState.Stateid.Other] != lockState {
-		return sm.lockStateidMissError(lockState.Stateid.Other)
+		return sm.stateidMissError(lockState.Stateid.Other)
 	}
 	lockOwner := lockState.LockOwner
 	if lockOwner == nil || sm.lockOwners[lockOwner.Key()] != lockOwner {
@@ -3062,7 +3078,7 @@ func (sm *StateManager) UnlockFile(
 	// lock manager is touched.
 	lockState, exists := sm.lockStateByOther[lockStateid.Other]
 	if !exists {
-		return nil, sm.lockStateidMissError(lockStateid.Other)
+		return nil, sm.stateidMissError(lockStateid.Other)
 	}
 	if err := sm.revalidateLockStateLocked(lockState, callerClientID); err != nil {
 		return nil, err
@@ -3099,17 +3115,8 @@ func (sm *StateManager) UnlockFile(
 	}
 
 	// 3. Validate stateid seqid (only for non-replay LOCKU).
-	// Per RFC 8881 Section 8.2.2, a v4.1 client may send stateid seqid=0;
-	// bypass the seqid comparison as in LockExisting. lockState.Stateid.Seqid
-	// is >=2 after any prior LOCK, so without this bypass every v4.1 LOCKU
-	// would return NFS4ERR_OLD_STATEID, making unlock impossible.
-	if lockStateid.Seqid != 0 {
-		if lockStateid.Seqid < lockState.Stateid.Seqid {
-			return nil, ErrOldStateid
-		}
-		if lockStateid.Seqid > lockState.Stateid.Seqid {
-			return nil, ErrBadStateid
-		}
+	if err := checkStateidSeqid(lockStateid.Seqid, lockState.Stateid.Seqid); err != nil {
+		return nil, err
 	}
 
 	// 4. Validate the byte range

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -1591,6 +1591,7 @@ func (sm *StateManager) OpenFile(
 		// Accumulate share_access and share_deny (Pitfall 7)
 		existingState.ShareAccess |= shareAccess
 		existingState.ShareDeny |= shareDeny
+		existingState.openedAccessModes |= shareModeBit(shareAccess)
 
 		// Increment the stateid seqid for this operation
 		existingState.Stateid.Seqid = nextSeqID(existingState.Stateid.Seqid)
@@ -1607,12 +1608,13 @@ func (sm *StateManager) OpenFile(
 		copy(fhCopy, fileHandle)
 
 		openState := &OpenState{
-			Stateid:     resultStateid,
-			Owner:       owner,
-			FileHandle:  fhCopy,
-			ShareAccess: shareAccess,
-			ShareDeny:   shareDeny,
-			Confirmed:   owner.Confirmed,
+			Stateid:           resultStateid,
+			Owner:             owner,
+			FileHandle:        fhCopy,
+			ShareAccess:       shareAccess,
+			ShareDeny:         shareDeny,
+			openedAccessModes: shareModeBit(shareAccess),
+			Confirmed:         owner.Confirmed,
 		}
 
 		owner.OpenStates = append(owner.OpenStates, openState)
@@ -2219,11 +2221,15 @@ func (sm *StateManager) DowngradeOpen(stateid *types.Stateid4, seqid uint32, new
 		return nil, err
 	}
 
-	// Verify the new access is a subset of current (can only remove bits)
-	if newShareAccess & ^openState.ShareAccess != 0 {
+	// The new share_access must be a mode some OPEN behind this state actually
+	// asked for, which is stricter than being a subset of the accumulated
+	// union: one OPEN for BOTH leaves READ and WRITE standing in that union
+	// with neither ever opened, and downgrading to one of them would name a
+	// mode the client never held (RFC 7530 Section 16.19.4).
+	if openState.openedAccessModes&shareModeBit(newShareAccess) == 0 {
 		return nil, &NFS4StateError{
 			Status:  types.NFS4ERR_INVAL,
-			Message: "OPEN_DOWNGRADE cannot add share_access bits",
+			Message: "OPEN_DOWNGRADE to a share_access mode no OPEN asked for",
 		}
 	}
 	if newShareDeny & ^openState.ShareDeny != 0 {
@@ -2244,6 +2250,14 @@ func (sm *StateManager) DowngradeOpen(stateid *types.Stateid4, seqid uint32, new
 	// Update share modes
 	openState.ShareAccess = newShareAccess
 	openState.ShareDeny = newShareDeny
+
+	// Forget the opened modes this downgrade drops: a later OPEN_DOWNGRADE may
+	// only name one that is still a subset of what this one kept.
+	for mode := uint32(types.OPEN4_SHARE_ACCESS_READ); mode <= types.OPEN4_SHARE_ACCESS_BOTH; mode++ {
+		if mode&newShareAccess != mode {
+			openState.openedAccessModes &^= shareModeBit(mode)
+		}
+	}
 
 	// Increment stateid seqid
 	openState.Stateid.Seqid = nextSeqID(openState.Stateid.Seqid)

--- a/internal/adapter/nfs/v4/state/openowner.go
+++ b/internal/adapter/nfs/v4/state/openowner.go
@@ -258,6 +258,16 @@ func (e *ReplayError) Error() string { return "replay of cached owner-seqid resu
 // OpenState
 // ============================================================================
 
+// shareModeBit maps a share_access value to its bit in
+// OpenState.openedAccessModes. A value outside 0..3 is not a share mode at all
+// and gets no bit, so it can never satisfy an OPEN_DOWNGRADE.
+func shareModeBit(mode uint32) uint8 {
+	if mode > types.OPEN4_SHARE_ACCESS_BOTH {
+		return 0
+	}
+	return 1 << mode
+}
+
 // OpenState represents the state of a single open file for an open-owner.
 // Created by OPEN, removed by CLOSE.
 //
@@ -280,6 +290,15 @@ type OpenState struct {
 
 	// ShareDeny is the accumulated share deny mode (OR'd across OPENs).
 	ShareDeny uint32
+
+	// openedAccessModes records the share_access value every OPEN behind this
+	// state asked for, one bit per value (bit 1 READ, bit 2 WRITE, bit 3 BOTH).
+	// OPEN_DOWNGRADE may only name a mode that was actually opened, and the
+	// accumulated ShareAccess union cannot tell that apart: a single OPEN for
+	// BOTH leaves READ and WRITE standing in the union with neither ever
+	// opened. Linux nfsd keeps the same bitmap (st_access_bmap) for the same
+	// reason.
+	openedAccessModes uint8
 
 	// Confirmed indicates whether OPEN_CONFIRM has been called for this state.
 	Confirmed bool

--- a/internal/adapter/nfs/v4/state/replay_cache_test.go
+++ b/internal/adapter/nfs/v4/state/replay_cache_test.go
@@ -91,7 +91,10 @@ func TestReplay_OpenDowngrade_ReturnsCachedReply(t *testing.T) {
 	owner := []byte("downgrade-replay-owner")
 	stateid, clientID := setupConfirmedOpen(t, sm, owner, []byte("fh-downgrade"), types.OPEN4_SHARE_ACCESS_BOTH)
 
-	dg, err := sm.DowngradeOpen(stateid, 3, types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, 0)
+	// The open behind these stateids was opened for BOTH and nothing else, so
+	// BOTH is the only share_access an OPEN_DOWNGRADE on it may name: RFC 7530
+	// Section 16.19.4 admits only a mode some OPEN actually asked for.
+	dg, err := sm.DowngradeOpen(stateid, 3, types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, 0)
 	if err != nil {
 		t.Fatalf("DowngradeOpen: %v", err)
 	}

--- a/internal/adapter/nfs/v4/state/stateid.go
+++ b/internal/adapter/nfs/v4/state/stateid.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
@@ -41,6 +42,14 @@ type NFS4StateError struct {
 
 func (e *NFS4StateError) Error() string {
 	return e.Message
+}
+
+// Is matches two state errors on their NFS4 status alone, so errors.Is against
+// one of the sentinels below also matches an error of the same status carrying
+// a more specific message.
+func (e *NFS4StateError) Is(target error) bool {
+	var other *NFS4StateError
+	return errors.As(target, &other) && other.Status == e.Status
 }
 
 // Common state errors used throughout the state package.

--- a/internal/adapter/nfs/v4/state/stateid.go
+++ b/internal/adapter/nfs/v4/state/stateid.go
@@ -154,6 +154,51 @@ func checkStateidOwner(callerClientID, ownerClientID uint64) error {
 	}
 }
 
+// stateidMissError classifies a stateid that names no live state: state freed
+// when a lease was cancelled answers NFS4ERR_EXPIRED (RFC 7530 Section 9.6.3.2),
+// a stateid minted by an earlier server incarnation answers
+// NFS4ERR_STALE_STATEID, and anything else was never issued at all.
+//
+// A special stateid must be rejected before it reaches here. Its "other" is
+// all-zeros or all-ones, so the boot-epoch fragment reads as some other
+// incarnation's and the miss would be answered stale rather than bad.
+//
+// Caller must hold sm.mu (read or write).
+func (sm *StateManager) stateidMissError(other [types.NFS4_OTHER_SIZE]byte) error {
+	if sm.isExpiredStateidLocked(other) {
+		return ErrExpired
+	}
+	if !sm.isCurrentEpoch(other) {
+		return ErrStaleStateid
+	}
+	return ErrBadStateid
+}
+
+// checkStateidSeqid compares the seqid a client presented against the current
+// seqid of the state its stateid names: an earlier one is NFS4ERR_OLD_STATEID
+// and a later one NFS4ERR_BAD_STATEID (RFC 7530 Section 9.1.4). Seqid zero asks
+// for "the most recent seqid" (RFC 8881 Section 8.2.2) and skips the comparison.
+//
+// An operation that also sequences an owner must compare here only AFTER the
+// owner's own seqid check. A retransmission carries the pre-operation stateid,
+// whose seqid is by then one behind, and RFC 7530 Section 9.1.7 wants it
+// answered from the owner's reply cache rather than rejected as old.
+func checkStateidSeqid(presented, current uint32) error {
+	if presented == 0 || presented == current {
+		return nil
+	}
+	if presented < current {
+		return &NFS4StateError{
+			Status:  types.NFS4ERR_OLD_STATEID,
+			Message: fmt.Sprintf("stateid seqid %d < current %d", presented, current),
+		}
+	}
+	return &NFS4StateError{
+		Status:  types.NFS4ERR_BAD_STATEID,
+		Message: fmt.Sprintf("stateid seqid %d > current %d", presented, current),
+	}
+}
+
 // ValidateStateid validates a stateid for the given operation family and
 // returns the associated OpenState.
 //
@@ -219,19 +264,7 @@ func (sm *StateManager) ValidateStateid(stateid *types.Stateid4, currentFH []byt
 	// Open stateids (type 0x01) use openStateByOther.
 	openState, exists := sm.openStateByOther[stateid.Other]
 	if !exists {
-		if sm.isExpiredStateidLocked(stateid.Other) {
-			return nil, ErrExpired
-		}
-		if !sm.isCurrentEpoch(stateid.Other) {
-			return nil, &NFS4StateError{
-				Status:  types.NFS4ERR_STALE_STATEID,
-				Message: "stateid from previous server incarnation",
-			}
-		}
-		return nil, &NFS4StateError{
-			Status:  types.NFS4ERR_BAD_STATEID,
-			Message: "stateid not found",
-		}
+		return nil, sm.stateidMissError(stateid.Other)
 	}
 
 	// Step 4: the state must belong to the calling client.
@@ -244,23 +277,8 @@ func (sm *StateManager) ValidateStateid(stateid *types.Stateid4, currentFH []byt
 	}
 
 	// Step 5: Compare seqid.
-	// Per RFC 8881 Section 8.2.2 (NFSv4.1): if the client sends seqid=0
-	// in a non-special stateid, the server MUST accept it regardless of
-	// the current seqid value.  This is safe for v4.0 too since v4.0
-	// clients never legitimately send seqid=0 for real stateids.
-	if stateid.Seqid != 0 {
-		if stateid.Seqid < openState.Stateid.Seqid {
-			return nil, &NFS4StateError{
-				Status:  types.NFS4ERR_OLD_STATEID,
-				Message: fmt.Sprintf("stateid seqid %d < current %d", stateid.Seqid, openState.Stateid.Seqid),
-			}
-		}
-		if stateid.Seqid > openState.Stateid.Seqid {
-			return nil, &NFS4StateError{
-				Status:  types.NFS4ERR_BAD_STATEID,
-				Message: fmt.Sprintf("stateid seqid %d > current %d", stateid.Seqid, openState.Stateid.Seqid),
-			}
-		}
+	if err := checkStateidSeqid(stateid.Seqid, openState.Stateid.Seqid); err != nil {
+		return nil, err
 	}
 
 	// Step 6: Verify filehandle matches (if provided)
@@ -296,19 +314,7 @@ func (sm *StateManager) ValidateStateid(stateid *types.Stateid4, currentFH []byt
 func (sm *StateManager) validateDelegStateid(stateid *types.Stateid4, currentFH []byte, clientID uint64) (*OpenState, error) {
 	deleg, exists := sm.delegByOther[stateid.Other]
 	if !exists {
-		if sm.isExpiredStateidLocked(stateid.Other) {
-			return nil, ErrExpired
-		}
-		if !sm.isCurrentEpoch(stateid.Other) {
-			return nil, &NFS4StateError{
-				Status:  types.NFS4ERR_STALE_STATEID,
-				Message: "stateid from previous server incarnation",
-			}
-		}
-		return nil, &NFS4StateError{
-			Status:  types.NFS4ERR_BAD_STATEID,
-			Message: "delegation stateid not found",
-		}
+		return nil, sm.stateidMissError(stateid.Other)
 	}
 
 	// Revoked delegations are no longer valid
@@ -323,20 +329,9 @@ func (sm *StateManager) validateDelegStateid(stateid *types.Stateid4, currentFH 
 		return nil, err
 	}
 
-	// Compare seqid (seqid=0 means "any" per RFC 8881 Section 8.2.2)
-	if stateid.Seqid != 0 {
-		if stateid.Seqid < deleg.Stateid.Seqid {
-			return nil, &NFS4StateError{
-				Status:  types.NFS4ERR_OLD_STATEID,
-				Message: fmt.Sprintf("delegation stateid seqid %d < current %d", stateid.Seqid, deleg.Stateid.Seqid),
-			}
-		}
-		if stateid.Seqid > deleg.Stateid.Seqid {
-			return nil, &NFS4StateError{
-				Status:  types.NFS4ERR_BAD_STATEID,
-				Message: fmt.Sprintf("delegation stateid seqid %d > current %d", stateid.Seqid, deleg.Stateid.Seqid),
-			}
-		}
+	// Compare seqid.
+	if err := checkStateidSeqid(stateid.Seqid, deleg.Stateid.Seqid); err != nil {
+		return nil, err
 	}
 
 	// Verify filehandle matches
@@ -369,19 +364,7 @@ func (sm *StateManager) validateDelegStateid(stateid *types.Stateid4, currentFH 
 func (sm *StateManager) validateLockStateid(stateid *types.Stateid4, currentFH []byte, clientID uint64) (*OpenState, error) {
 	lockState, exists := sm.lockStateByOther[stateid.Other]
 	if !exists {
-		if sm.isExpiredStateidLocked(stateid.Other) {
-			return nil, ErrExpired
-		}
-		if !sm.isCurrentEpoch(stateid.Other) {
-			return nil, &NFS4StateError{
-				Status:  types.NFS4ERR_STALE_STATEID,
-				Message: "stateid from previous server incarnation",
-			}
-		}
-		return nil, &NFS4StateError{
-			Status:  types.NFS4ERR_BAD_STATEID,
-			Message: "lock stateid not found",
-		}
+		return nil, sm.stateidMissError(stateid.Other)
 	}
 
 	var ownerClientID uint64
@@ -392,21 +375,9 @@ func (sm *StateManager) validateLockStateid(stateid *types.Stateid4, currentFH [
 		return nil, err
 	}
 
-	// Compare seqid. Per RFC 8881 Section 8.2.2, seqid=0 in a non-special
-	// stateid bypasses the seqid comparison entirely.
-	if stateid.Seqid != 0 {
-		if stateid.Seqid < lockState.Stateid.Seqid {
-			return nil, &NFS4StateError{
-				Status:  types.NFS4ERR_OLD_STATEID,
-				Message: fmt.Sprintf("lock stateid seqid %d < current %d", stateid.Seqid, lockState.Stateid.Seqid),
-			}
-		}
-		if stateid.Seqid > lockState.Stateid.Seqid {
-			return nil, &NFS4StateError{
-				Status:  types.NFS4ERR_BAD_STATEID,
-				Message: fmt.Sprintf("lock stateid seqid %d > current %d", stateid.Seqid, lockState.Stateid.Seqid),
-			}
-		}
+	// Compare seqid.
+	if err := checkStateidSeqid(stateid.Seqid, lockState.Stateid.Seqid); err != nil {
+		return nil, err
 	}
 
 	// Verify filehandle matches the locked file.

--- a/internal/adapter/nfs/v4/state/stateid.go
+++ b/internal/adapter/nfs/v4/state/stateid.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/hex"
-	"errors"
 	"fmt"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
@@ -48,8 +47,8 @@ func (e *NFS4StateError) Error() string {
 // one of the sentinels below also matches an error of the same status carrying
 // a more specific message.
 func (e *NFS4StateError) Is(target error) bool {
-	var other *NFS4StateError
-	return errors.As(target, &other) && other.Status == e.Status
+	other, ok := target.(*NFS4StateError)
+	return ok && other.Status == e.Status
 }
 
 // Common state errors used throughout the state package.
@@ -338,7 +337,6 @@ func (sm *StateManager) validateDelegStateid(stateid *types.Stateid4, currentFH 
 		return nil, err
 	}
 
-	// Compare seqid.
 	if err := checkStateidSeqid(stateid.Seqid, deleg.Stateid.Seqid); err != nil {
 		return nil, err
 	}
@@ -384,7 +382,6 @@ func (sm *StateManager) validateLockStateid(stateid *types.Stateid4, currentFH [
 		return nil, err
 	}
 
-	// Compare seqid.
 	if err := checkStateidSeqid(stateid.Seqid, lockState.Stateid.Seqid); err != nil {
 		return nil, err
 	}

--- a/internal/adapter/nfs/v4/state/stateid_authz_state_ops_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_authz_state_ops_test.go
@@ -94,11 +94,14 @@ func TestOpenDowngrade_CrossClient(t *testing.T) {
 
 	sid, seqid := newConfirmedOpen(t, sm, authzClientA, []byte("fh-downgrade"))
 
-	if _, err := sm.DowngradeOpen(&sid, seqid, types.OPEN4_SHARE_ACCESS_READ,
+	// The open behind these stateids was opened for BOTH and nothing else, so
+	// BOTH is the only share_access an OPEN_DOWNGRADE on it may name: RFC 7530
+	// Section 16.19.4 admits only a mode some OPEN actually asked for.
+	if _, err := sm.DowngradeOpen(&sid, seqid, types.OPEN4_SHARE_ACCESS_BOTH,
 		types.OPEN4_SHARE_DENY_NONE, authzClientB); !isStatus(err, types.NFS4ERR_BAD_STATEID) {
 		t.Errorf("client B downgrading client A's open: err = %v, want NFS4ERR_BAD_STATEID", err)
 	}
-	if _, err := sm.DowngradeOpen(&sid, seqid, types.OPEN4_SHARE_ACCESS_READ,
+	if _, err := sm.DowngradeOpen(&sid, seqid, types.OPEN4_SHARE_ACCESS_BOTH,
 		types.OPEN4_SHARE_DENY_NONE, authzClientA); err != nil {
 		t.Errorf("owning client rejected: %v", err)
 	}

--- a/internal/adapter/nfs/v4/state/stateid_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_test.go
@@ -768,17 +768,23 @@ func TestCloseFile_Success(t *testing.T) {
 	}
 }
 
+// TestCloseFile_SpecialStateid rejects both special stateids on CLOSE. RFC 7530
+// Section 9.1.4.3 admits a special stateid only on READ, WRITE and SETATTR, so
+// CLOSE has no open state to act on and must not report success.
 func TestCloseFile_SpecialStateid(t *testing.T) {
 	sm := NewStateManager(90 * time.Second)
 
-	// Close with anonymous (all-zeros) stateid
-	zeroed := &types.Stateid4{Seqid: 0}
-	closed, err := sm.CloseFile(zeroed, 1, 0)
-	if err != nil {
-		t.Fatalf("CloseFile with special stateid: %v", err)
+	anonymous := &types.Stateid4{Seqid: 0}
+	if _, err := sm.CloseFile(anonymous, 1, 0); !errors.Is(err, ErrBadStateid) {
+		t.Errorf("CLOSE with the anonymous stateid: err = %v, want NFS4ERR_BAD_STATEID", err)
 	}
-	if closed.Stateid.Seqid != 0 {
-		t.Errorf("closed seqid = %d, want 0", closed.Stateid.Seqid)
+
+	readBypass := &types.Stateid4{Seqid: 0xFFFFFFFF}
+	for i := range readBypass.Other {
+		readBypass.Other[i] = 0xFF
+	}
+	if _, err := sm.CloseFile(readBypass, 1, 0); !errors.Is(err, ErrBadStateid) {
+		t.Errorf("CLOSE with the READ-bypass stateid: err = %v, want NFS4ERR_BAD_STATEID", err)
 	}
 }
 
@@ -871,20 +877,31 @@ func TestDowngradeOpen_Success(t *testing.T) {
 	}
 
 	// Confirm
-	confirmed, err := sm.ConfirmOpen(&result.Stateid, 2, 0)
-	if err != nil {
+	if _, err := sm.ConfirmOpen(&result.Stateid, 2, 0); err != nil {
 		t.Fatalf("ConfirmOpen: %v", err)
 	}
 
+	// A second OPEN for READ alone, so READ is a mode this state was actually
+	// opened for and OPEN_DOWNGRADE may name it.
+	reopened, err := sm.OpenFile(0, []byte("owner1"), 3,
+		[]byte("fh"),
+		types.OPEN4_SHARE_ACCESS_READ,
+		types.OPEN4_SHARE_DENY_NONE,
+		types.CLAIM_NULL,
+	)
+	if err != nil {
+		t.Fatalf("OpenFile (READ): %v", err)
+	}
+
 	// Downgrade to READ only
-	downgraded, err := sm.DowngradeOpen(&confirmed.Stateid, 3, types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, 0)
+	downgraded, err := sm.DowngradeOpen(&reopened.Stateid, 4, types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, 0)
 	if err != nil {
 		t.Fatalf("DowngradeOpen: %v", err)
 	}
 
 	// Seqid should be incremented
-	if downgraded.Stateid.Seqid != confirmed.Stateid.Seqid+1 {
-		t.Errorf("downgraded seqid = %d, want %d", downgraded.Stateid.Seqid, confirmed.Stateid.Seqid+1)
+	if downgraded.Stateid.Seqid != reopened.Stateid.Seqid+1 {
+		t.Errorf("downgraded seqid = %d, want %d", downgraded.Stateid.Seqid, reopened.Stateid.Seqid+1)
 	}
 
 	// Verify share_access was updated

--- a/internal/adapter/nfs/v4/state/stateid_validity_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_validity_test.go
@@ -1,0 +1,213 @@
+package state
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// The operations that resolve an open state themselves -- CLOSE, OPEN_CONFIRM,
+// OPEN_DOWNGRADE and the open_to_lock_owner4 path of LOCK -- hold sm.mu for
+// writing, so they cannot reuse ValidateStateid. These pin the checks they
+// perform instead: a stateid from another server incarnation is stale, a
+// stateid whose seqid is behind the one the open now answers to is old, and a
+// special stateid names nothing any of them can act on.
+
+// validityFixture opens and confirms one file, returning the confirmed stateid
+// and the open-owner seqid the next request must carry.
+func validityFixture(t *testing.T, sm *StateManager, owner string) (fh []byte, opened, confirmed types.Stateid4, nextSeqid uint32) {
+	t.Helper()
+
+	fh = []byte("fh-" + owner)
+	res, err := sm.OpenFile(0, []byte(owner), 1, fh,
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	conf, err := sm.ConfirmOpen(&res.Stateid, 2, 0)
+	if err != nil {
+		t.Fatalf("ConfirmOpen: %v", err)
+	}
+	return fh, res.Stateid, conf.Stateid, 3
+}
+
+// foreignEpoch rewrites only the boot-epoch fragment of a stateid, leaving its
+// type tag and random bytes alone, so a rejection can only be the epoch's
+// doing. It is what the pynfs suite's makeStaleId simulates: a stateid a client
+// held across a server restart.
+func foreignEpoch(sid types.Stateid4) *types.Stateid4 {
+	stale := sid
+	stale.Other[1], stale.Other[2], stale.Other[3] = 0xFE, 0xED, 0xFA
+	return &stale
+}
+
+func TestCloseFile_ForeignEpochStateidIsStale(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	defer sm.Shutdown()
+
+	_, _, confirmed, seqid := validityFixture(t, sm, "close-stale")
+
+	if _, err := sm.CloseFile(foreignEpoch(confirmed), seqid, 0); !errors.Is(err, ErrStaleStateid) {
+		t.Errorf("CLOSE with a stateid from another incarnation: err = %v, want NFS4ERR_STALE_STATEID", err)
+	}
+}
+
+func TestCloseFile_OldStateidIsRejected(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	defer sm.Shutdown()
+
+	// OPEN_CONFIRM advanced the seqid, so the stateid OPEN returned is now one
+	// behind the one the open answers to.
+	_, opened, confirmed, seqid := validityFixture(t, sm, "close-old")
+	if opened.Seqid == confirmed.Seqid {
+		t.Fatal("OPEN_CONFIRM must advance the stateid seqid for this to test anything")
+	}
+
+	if _, err := sm.CloseFile(&opened, seqid, 0); !errors.Is(err, ErrOldStateid) {
+		t.Errorf("CLOSE with the pre-OPEN_CONFIRM stateid: err = %v, want NFS4ERR_OLD_STATEID", err)
+	}
+}
+
+func TestConfirmOpen_ForeignEpochStateidIsStale(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	defer sm.Shutdown()
+
+	res, err := sm.OpenFile(0, []byte("confirm-stale"), 1, []byte("fh-confirm-stale"),
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+
+	if _, err := sm.ConfirmOpen(foreignEpoch(res.Stateid), 2, 0); !errors.Is(err, ErrStaleStateid) {
+		t.Errorf("OPEN_CONFIRM with a stateid from another incarnation: err = %v, want NFS4ERR_STALE_STATEID", err)
+	}
+}
+
+// TestConfirmOpen_TwiceIsBadStateid covers RFC 7530 Section 16.18.5: the second
+// OPEN_CONFIRM finds the open already confirmed, so its stateid no longer names
+// anything OPEN_CONFIRM can act on.
+func TestConfirmOpen_TwiceIsBadStateid(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	defer sm.Shutdown()
+
+	_, _, confirmed, seqid := validityFixture(t, sm, "confirm-twice")
+
+	if _, err := sm.ConfirmOpen(&confirmed, seqid, 0); !errors.Is(err, ErrBadStateid) {
+		t.Errorf("second OPEN_CONFIRM: err = %v, want NFS4ERR_BAD_STATEID", err)
+	}
+}
+
+func TestDowngradeOpen_ForeignEpochStateidIsStale(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	defer sm.Shutdown()
+
+	_, _, confirmed, seqid := validityFixture(t, sm, "downgrade-stale")
+
+	if _, err := sm.DowngradeOpen(foreignEpoch(confirmed), seqid,
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, 0); !errors.Is(err, ErrStaleStateid) {
+		t.Errorf("OPEN_DOWNGRADE with a stateid from another incarnation: err = %v, want NFS4ERR_STALE_STATEID", err)
+	}
+}
+
+func TestDowngradeOpen_OldStateidIsRejected(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	defer sm.Shutdown()
+
+	_, opened, _, seqid := validityFixture(t, sm, "downgrade-old")
+
+	if _, err := sm.DowngradeOpen(&opened, seqid,
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, 0); !errors.Is(err, ErrOldStateid) {
+		t.Errorf("OPEN_DOWNGRADE with the pre-OPEN_CONFIRM stateid: err = %v, want NFS4ERR_OLD_STATEID", err)
+	}
+}
+
+// TestDowngradeOpen_NeverOpenedMode covers RFC 7530 Section 16.19.4. READ is a
+// subset of the accumulated share_access of an OPEN for BOTH, but no OPEN asked
+// for READ, so downgrading to it names a mode the client never held. Once an
+// OPEN does ask for READ the same downgrade is legal.
+func TestDowngradeOpen_NeverOpenedMode(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	defer sm.Shutdown()
+
+	fh, _, confirmed, seqid := validityFixture(t, sm, "downgrade-mode")
+
+	if _, err := sm.DowngradeOpen(&confirmed, seqid,
+		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, 0); !isStatus(err, types.NFS4ERR_INVAL) {
+		t.Fatalf("OPEN_DOWNGRADE to a never-opened mode: err = %v, want NFS4ERR_INVAL", err)
+	}
+
+	reopened, err := sm.OpenFile(0, []byte("downgrade-mode"), seqid+1, fh,
+		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
+	if err != nil {
+		t.Fatalf("OpenFile (READ): %v", err)
+	}
+	if _, err := sm.DowngradeOpen(&reopened.Stateid, seqid+2,
+		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, 0); err != nil {
+		t.Fatalf("OPEN_DOWNGRADE to a mode that was opened: %v", err)
+	}
+}
+
+func TestLockNew_ForeignEpochOpenStateidIsStale(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	sm.SetLockManager(lock.NewManager())
+	defer sm.Shutdown()
+
+	fh, _, confirmed, seqid := validityFixture(t, sm, "lock-stale")
+
+	_, err := sm.LockNew(context.Background(), 0, []byte("lock-owner"), 1,
+		foreignEpoch(confirmed), seqid, fh, types.WRITE_LT, 0, 100, false, 0)
+	if !errors.Is(err, ErrStaleStateid) {
+		t.Errorf("LOCK with an open stateid from another incarnation: err = %v, want NFS4ERR_STALE_STATEID", err)
+	}
+}
+
+func TestLockNew_OldOpenStateidIsRejected(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	sm.SetLockManager(lock.NewManager())
+	defer sm.Shutdown()
+
+	fh, opened, _, seqid := validityFixture(t, sm, "lock-old")
+
+	_, err := sm.LockNew(context.Background(), 0, []byte("lock-owner"), 1,
+		&opened, seqid, fh, types.WRITE_LT, 0, 100, false, 0)
+	if !errors.Is(err, ErrOldStateid) {
+		t.Errorf("LOCK with the pre-OPEN_CONFIRM open stateid: err = %v, want NFS4ERR_OLD_STATEID", err)
+	}
+}
+
+func TestLockNew_SpecialOpenStateidIsBad(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	sm.SetLockManager(lock.NewManager())
+	defer sm.Shutdown()
+
+	fh, _, _, seqid := validityFixture(t, sm, "lock-special")
+
+	anonymous := &types.Stateid4{Seqid: 0}
+	_, err := sm.LockNew(context.Background(), 0, []byte("lock-owner"), 1,
+		anonymous, seqid, fh, types.WRITE_LT, 0, 100, false, 0)
+	if !errors.Is(err, ErrBadStateid) {
+		t.Errorf("LOCK with the anonymous stateid: err = %v, want NFS4ERR_BAD_STATEID", err)
+	}
+}
+
+// TestStateidMissError_CurrentEpochIsBadNotStale is the negative control for the
+// epoch checks above: an "other" this incarnation could have issued but never
+// did stays NFS4ERR_BAD_STATEID, so the stale answer is the epoch's doing and
+// not a blanket rename of the miss.
+func TestStateidMissError_CurrentEpochIsBadNotStale(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	defer sm.Shutdown()
+
+	_, _, confirmed, seqid := validityFixture(t, sm, "miss-current")
+
+	unissued := confirmed
+	unissued.Other = sm.generateStateidOther(StateTypeOpen)
+
+	if _, err := sm.CloseFile(&unissued, seqid, 0); !errors.Is(err, ErrBadStateid) {
+		t.Errorf("CLOSE with an unissued stateid of this incarnation: err = %v, want NFS4ERR_BAD_STATEID", err)
+	}
+}

--- a/internal/adapter/nfs/v4/state/stateid_validity_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_validity_test.go
@@ -145,9 +145,22 @@ func TestDowngradeOpen_NeverOpenedMode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenFile (READ): %v", err)
 	}
-	if _, err := sm.DowngradeOpen(&reopened.Stateid, seqid+2,
-		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, 0); err != nil {
+	downgraded, err := sm.DowngradeOpen(&reopened.Stateid, seqid+2,
+		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, 0)
+	if err != nil {
 		t.Fatalf("OPEN_DOWNGRADE to a mode that was opened: %v", err)
+	}
+
+	// That downgrade kept READ and dropped the modes it did not, so READ is the
+	// only mode a further OPEN_DOWNGRADE may name.
+	again, err := sm.DowngradeOpen(&downgraded.Stateid, seqid+3,
+		types.OPEN4_SHARE_ACCESS_READ, types.OPEN4_SHARE_DENY_NONE, 0)
+	if err != nil {
+		t.Fatalf("second OPEN_DOWNGRADE to READ: %v", err)
+	}
+	if _, err := sm.DowngradeOpen(&again.Stateid, seqid+4,
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, 0); !isStatus(err, types.NFS4ERR_INVAL) {
+		t.Fatalf("OPEN_DOWNGRADE back up to BOTH: err = %v, want NFS4ERR_INVAL", err)
 	}
 }
 

--- a/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
+++ b/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
@@ -54,19 +54,6 @@ flake worth re-running.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| CLOSE4 | bug | bad/old/stale stateid accepted | #2341 |
-| CLOSE5 | bug | bad/old/stale stateid accepted | #2341 |
-| CLOSE6 | bug | bad/old/stale stateid accepted | #2341 |
-| LKT9 | bug | bad/old/stale stateid accepted | #2341 |
-| LKU6b | bug | bad/old/stale stateid accepted | #2341 |
-| LOCK10 | bug | bad/old/stale stateid accepted | #2341 |
-| LOCK9b | bug | bad/old/stale stateid accepted | #2341 |
-| LOCK9c | bug | bad/old/stale stateid accepted | #2341 |
-| OPCF1 | bug | bad/old/stale stateid accepted | #2341 |
-| OPCF6 | bug | bad/old/stale stateid accepted | #2341 |
-| OPDG2 | bug | bad/old/stale stateid accepted | #2341 |
-| OPDG3 | bug | bad/old/stale stateid accepted | #2341 |
-| OPDG6 | bug | bad/old/stale stateid accepted | #2341 |
-| OPDG7 | bug | bad/old/stale stateid accepted | #2341 |
+| LKU6b | bug | seqid=0 means "v4.1, skip owner sequencing", but a v4.0 client may send 0 | #2483 |
 | WRT18 | feature | write-session freeze deliberately holds ctime, so change cannot advance | - |
 | RPLY8 | suite | knfsd fails this too — replay of a waiting LOCKU | - |


### PR DESCRIPTION
NFSv4.0 accepted stateids it must refuse. Four operations resolve an open state
with a raw `openStateByOther` lookup instead of going through `ValidateStateid`,
and so skipped two of the checks it performs.

## What was wrong

`ValidateStateid` cannot be reused from `CloseFile`, `ConfirmOpen`,
`DowngradeOpen` or `LockNew`: those hold `sm.mu` for **writing** while they
resolve and mutate the state, and `ValidateStateid` takes the read lock and
renews the lease. So each grew its own inline lookup, and each lost:

- **the boot-epoch classification of a table miss** — a stateid a client held
  across a server restart fell through to `NFS4ERR_BAD_STATEID` where RFC 7530
  Section 9.1.4 requires `NFS4ERR_STALE_STATEID`;
- **the stateid seqid comparison** — a stateid whose seqid is behind the one the
  open now answers to was accepted and acted on, instead of answered
  `NFS4ERR_OLD_STATEID`.

Three further defects in the same operations:

- `CloseFile` returned `&OpenSeqResult{}, nil` for a special stateid. RFC 7530
  Section 9.1.4.3 admits a special stateid only on READ, WRITE and SETATTR, so
  CLOSE names no open state and must answer `NFS4ERR_BAD_STATEID` — it was
  reporting a successful close of nothing.
- `ConfirmOpen` confirmed an already-confirmed open. RFC 7530 Section 16.18.5
  leaves the second OPEN_CONFIRM nothing to act on; Linux nfsd answers
  `NFS4ERR_BAD_STATEID` there (`nfsd4_open_confirm`, `NFS4_OO_CONFIRMED`).
- LOCK and LOCKT never admitted the clientid inside `lock_owner4`, so a
  lock-owner could be keyed under a client id no record covers and a LOCKT on
  behalf of a nonexistent identity answered "no conflict".

## The premise that changed: OPDG2 / OPDG3

These two rows were expected to be already fixed by the subset check #2377 added
to `DowngradeOpen` (`newShareAccess & ^openState.ShareAccess != 0`). **They were
not, and the subset check is not the rule the RFC states.** Both still fail on
`5f05f50bf` — see the baseline below.

RFC 7530 Section 16.19.4 requires the new share_access to equal the union of the
share_access bits of *some subset of the OPENs in effect*, which is stricter than
"a subset of the accumulated union". One OPEN for BOTH leaves READ and WRITE
standing in `ShareAccess` with neither ever opened, so downgrading to READ names
a mode the client never held. Linux nfsd keeps a bit per opened share_access
*value* for exactly this (`st_access_bmap`, tested by `test_access` and pruned by
`nfs4_stateid_downgrade`); `OpenState.openedAccessModes` is that bitmap.

Four existing DittoFS tests changed because they encoded the behaviour being
corrected — three OPEN_DOWNGRADE fixtures downgraded to a mode their open had
never asked for, and `TestClose_Success` was the only handler-level CLOSE success
case and was only "successful" because CLOSE accepted the anonymous stateid. It
now drives a real OPEN/OPEN_CONFIRM/CLOSE, and the anonymous stateid gets its own
test asserting the rejection.

## Shape of the fix

Two helpers next to `checkStateidOwner` in `state/stateid.go`, working off state
the caller already read under its own lock:

- `stateidMissError` — classifies a table miss as expired / from another
  incarnation / never issued. This is the former `lockStateidMissError`, which
  never touched the lock table and is now shared.
- `checkStateidSeqid` — the `<` / `>` comparison with the seqid-0 bypass.

The four duplicated copies of each check inside `ValidateStateid`,
`validateDelegStateid`, `validateLockStateid`, `LockExisting` and `UnlockFile` now
route through them, which is why the source diff is net negative in `stateid.go`.

**The ordering is load-bearing.** The stateid seqid comparison must run *after*
the owner's seqid check: a retransmission carries the pre-operation stateid,
whose seqid is by then one behind, and RFC 7530 Section 9.1.7 wants it answered
from the owner's reply cache rather than rejected as old.
`TestDowngradeOpen_ReplayLeavesOwnerSeqidUntouched` exercises exactly that path.

`NFS4StateError` also gained an `Is` matching on status, so `errors.Is(err,
ErrBadStateid)` now matches a BAD_STATEID error carrying a specific message —
which those comparisons already meant, and silently did not do.

The clientid admission went into `handlers/lock.go` rather than the state
manager, mirroring `handleOpen`, which already calls `ValidateAndRenewClient` on
the clientid inside `open_owner4`.

## Evidence

Baseline on `5f05f50bf` (memory profile, `--tests "INIT LOOKFILE MKFILE <the 14>
OPDG1 OPDG10 OPDG11"`): **all 14 `bug` rows FAIL**, including OPDG2 and OPDG3.
None of the 14 was already passing. OPDG1 / OPDG10 / OPDG11 pass and are the
regression guard on the share-mode change.

After, on this branch (same profile, the full 4.0 suite): **13 of the 14 pass**.
Read from the `pynfs.log` artifact of run `pynfs-v4.0-memory-20260908-230500`:

```
CLOSE4   st_close.testBadStateid                                  : PASS
CLOSE5   st_close.testOldStateid                                  : PASS
CLOSE6   st_close.testStaleStateid                                : PASS
LKT9     st_lockt.testStaleClientid                               : PASS
LOCK9b   st_lock.testOldOpenStateid                               : PASS
LOCK9c   st_lock.testOldOpenStateid2                              : PASS
LOCK10   st_lock.testStaleClientid                                : PASS
OPCF1    st_openconfirm.testConfirmCreate                         : PASS
OPCF6    st_openconfirm.testStaleStateid                          : PASS
OPDG2    st_opendowngrade.testNewState1                           : PASS
OPDG3    st_opendowngrade.testNewState2                           : PASS
OPDG6    st_opendowngrade.testStaleStateid                        : PASS
OPDG7    st_opendowngrade.testOldStateid                          : PASS
LKU6b    st_locku.testBadLockSeqid2                               : FAILURE
```

Grader: `Of those: 8 Skipped, 2 Failed, 3 Warned, 588 Passed` — `PASSED (no new
failures)`. The two failures are `WRT18` (a `feature` row) and `LKU6b`.

A second run after the rebase onto `58dc7c2bb` re-checked those rows together
with their neighbours, to make sure the special-stateid rejections and the
epoch classification did not overshoot: `CLOSE1 CLOSE2 CLOSE3 CLOSE10 CLOSE11
CLOSE12 LOCK9a LOCK11 LOCK12a LOCK12b OPCF2 OPCF4 OPCF5 OPDG1 OPDG4 OPDG5
OPDG8 OPDG10 OPDG11` all PASS — 35 of 36, LKU6b the only failure. `OPCF5`,
`OPDG5` and `LOCK11` are the ones that pass `stateid4(0, b'')` and expect
BAD_STATEID, so they are the guard against the epoch classifier swallowing a
special stateid and answering stale.

`RPLY8`, the one `suite` row, also passes now. It stays on the list: it is
justified by knfsd evidence for a replay race and one green observation is not
grounds to stop grading it.


Every guard has a test that fails when the guard is neutralized, verified with
`go test -overlay` copies that stub out each check in turn:

| neutralized | test that then fails |
| --- | --- |
| `isCurrentEpoch` | `TestCloseFile_ForeignEpochStateidIsStale`, `TestConfirmOpen_…`, `TestDowngradeOpen_…`, `TestLockNew_ForeignEpochOpenStateidIsStale` |
| `checkStateidSeqid` | `TestCloseFile_OldStateidIsRejected`, `TestDowngradeOpen_OldStateidIsRejected`, `TestLockNew_OldOpenStateidIsRejected` |
| CLOSE special-stateid rejection | `TestCloseFile_SpecialStateid` |
| LOCK special-stateid rejection | `TestLockNew_SpecialOpenStateidIsBad` |
| already-confirmed gate | `TestConfirmOpen_TwiceIsBadStateid` |
| `openedAccessModes` test | `TestDowngradeOpen_NeverOpenedMode` |
| LOCK clientid admission | `TestHandleLock_UnknownClientID` |
| LOCKT clientid admission | `TestHandleLockT_UnknownClientID` |

`TestStateidMissError_CurrentEpochIsBadNotStale` is the negative control: an
"other" this incarnation could have issued but never did stays BAD_STATEID, so
the stale answers are the epoch's doing and not a blanket rename of the miss.

`go test -race ./internal/adapter/nfs/...` clean.

## LKU6b is a different defect and stays on the list

`LKU6b` (LOCKU with lockseqid=1 should be `NFS4ERR_BAD_SEQID`, got `NFS4_OK`) is
grouped with the others in the issue but has nothing to do with stateid validity.
Its cause is the `seqid != 0` convention the state manager uses to mean "NFSv4.1,
the slot table provides replay protection". In v4.1 the handler forces the owner
seqids to 0 (`ctx.SkipOwnerSeqid`), but a v4.0 client may legitimately send 0 —
pynfs's own first LOCK does — so the state manager cannot tell "v4.0 sent 0" from
"v4.1 forced 0" and skips sequencing for both. Fixing it means replacing that
convention with the handler's `SkipOwnerSeqid` signal plus nfsd's "a brand-new
owner accepts any initial seqid" rule, across every seqid-bearing operation. That
is a separate change with its own regression surface; filed as #2483 and
the row's reason updated to name the real mechanism.

## The surprising consequence of the share-mode change, stated plainly

Because the bitmap is keyed by the share_access **value** each OPEN asked for,
`OPEN(READ)` followed by `OPEN(WRITE)` leaves `ShareAccess == BOTH` but the
bitmap holding only the READ and WRITE bits, never the BOTH bit. An
`OPEN_DOWNGRADE(BOTH)` after that sequence is therefore `NFS4ERR_INVAL` even
though BOTH is what the state currently grants.

That is not an accident of this implementation: it is exactly what Linux nfsd
does — `set_access` keys `st_access_bmap` by the literal `share_access` of each
OPEN — and knfsd passes the whole `st_opendowngrade` group, Linux clients
included, so the shape is load-bearing rather than incidental. `OPDG10`, the
complex upgrade/downgrade sequence, walks READ / WRITE / downgrade-READ
repeatedly and passes.

## Two notes for review

- `DowngradeOpen`'s `newShareAccess == 0` guard is now largely shadowed by the
  `openedAccessModes` test above it — bit 0 is never set by an OPEN, so both
  answer `NFS4ERR_INVAL` and only the message differs. Left in place: removing it
  changes nothing on the wire and it is the clearer statement of the rule.
- Rebased onto `58dc7c2bb`, so this sits on top of #2476's single `ClientRecord`.
  The clientid admission goes through `ValidateAndRenewClient`, which reads the
  record via the version-agnostic `clientRecordLocked`, so it sees v4.1 clients
  too — neither lookup map is indexed directly here.

Closes #2341
