### PR TITLE
fix(nfs): draw the server boot epoch at random instead of reading the clock

### DIFF
--- a/internal/adapter/nfs/v4/state/client_test.go
+++ b/internal/adapter/nfs/v4/state/client_test.go
@@ -719,16 +719,3 @@ func TestNewStateManager_CustomLease(t *testing.T) {
 		t.Errorf("LeaseDuration = %v, want %v", sm.LeaseDuration(), 30*time.Second)
 	}
 }
-
-func TestNewStateManager_BootEpochReasonable(t *testing.T) {
-	sm := NewStateManager(90 * time.Second)
-	now := uint32(time.Now().Unix())
-	// Boot epoch should be within 2 seconds of current time
-	diff := int64(now) - int64(sm.BootEpoch())
-	if diff < 0 {
-		diff = -diff
-	}
-	if diff > 2 {
-		t.Errorf("BootEpoch %d is too far from current time %d", sm.BootEpoch(), now)
-	}
-}

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"slices"
@@ -144,8 +145,9 @@ type StateManager struct {
 	// handle, taking precedence over lockManager. See SetLockManagerResolver.
 	lockManagerResolver func(handle []byte) lock.LockManager
 
-	// bootEpoch is the server boot epoch, used as the high 32 bits of
-	// client IDs to ensure uniqueness across server restarts.
+	// bootEpoch identifies this incarnation of the server. It is the high 32
+	// bits of every client ID and a 24-bit fragment of every stateid, and both
+	// readers only ever test it for equality, never for order.
 	bootEpoch uint32
 
 	// nextClientSeq is an atomic counter for the low 32 bits of client IDs.
@@ -255,7 +257,7 @@ type StateManager struct {
 }
 
 // NewStateManager creates a new StateManager with the given lease duration.
-// The boot epoch is derived from the current time.
+// The boot epoch is drawn at random.
 // An optional graceDuration parameter controls the grace period length;
 // if omitted or zero, the lease duration is used.
 func NewStateManager(leaseDuration time.Duration, graceDuration ...time.Duration) *StateManager {
@@ -268,7 +270,22 @@ func NewStateManager(leaseDuration time.Duration, graceDuration ...time.Duration
 		gd = graceDuration[0]
 	}
 
-	epoch := uint32(time.Now().Unix())
+	// The boot epoch has to differ from the last incarnation's, because
+	// generateClientID restarts its sequence at 0 every boot: two runs sharing
+	// an epoch hand out byte-identical client IDs, and a stale one is then
+	// admitted as a live client rather than refused. A clock read at seconds
+	// resolution guaranteed that collision for any restart inside one second,
+	// which is well within a supervisor's restart time.
+	//
+	// ponytail: random and not persisted, so nothing rules out drawing the same
+	// epoch twice -- the 24-bit stateid fragment puts that at roughly one
+	// restart in 16 million before a stale stateid could read as current.
+	// Persisting the epoch and reloading it incremented removes the chance
+	// outright; the durable client-recovery store is already handed this value,
+	// so the seam to persist it through exists.
+	var epochBytes [4]byte
+	_, _ = rand.Read(epochBytes[:])
+	epoch := binary.BigEndian.Uint32(epochBytes[:])
 
 	return &StateManager{
 		clientsByID:         make(map[uint64]*ClientRecord),

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -283,6 +283,11 @@ func NewStateManager(leaseDuration time.Duration, graceDuration ...time.Duration
 	// Persisting the epoch and reloading it incremented removes the chance
 	// outright; the durable client-recovery store is already handed this value,
 	// so the seam to persist it through exists.
+	// From Go 1.24 the default crypto/rand Reader calls fatal() rather than
+	// returning an error, so a partial fill that would leave this epoch zeroed
+	// is not reachable and the error is dead, exactly as at the other draw in
+	// generateStateidOther. If the module ever drops below Go 1.24 both must
+	// become real error checks.
 	var epochBytes [4]byte
 	_, _ = rand.Read(epochBytes[:])
 	epoch := binary.BigEndian.Uint32(epochBytes[:])

--- a/internal/adapter/nfs/v4/state/stateid_validity_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_validity_test.go
@@ -39,9 +39,16 @@ func validityFixture(t *testing.T, sm *StateManager, owner string) (fh []byte, o
 // type tag and random bytes alone, so a rejection can only be the epoch's
 // doing. It is what the pynfs suite's makeStaleId simulates: a stateid a client
 // held across a server restart.
+//
+// The fragment is complemented rather than set to a fixed value. No byte equals
+// its own complement, so the result differs from whatever epoch the manager
+// drew, for every epoch -- a hard-coded fragment would instead read as current
+// on the one epoch that happens to match it.
 func foreignEpoch(sid types.Stateid4) *types.Stateid4 {
 	stale := sid
-	stale.Other[1], stale.Other[2], stale.Other[3] = 0xFE, 0xED, 0xFA
+	stale.Other[1] = ^stale.Other[1]
+	stale.Other[2] = ^stale.Other[2]
+	stale.Other[3] = ^stale.Other[3]
 	return &stale
 }
 

--- a/internal/adapter/nfs/v4/state/stateid_validity_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_validity_test.go
@@ -224,3 +224,32 @@ func TestStateidMissError_CurrentEpochIsBadNotStale(t *testing.T) {
 		t.Errorf("CLOSE with an unissued stateid of this incarnation: err = %v, want NFS4ERR_BAD_STATEID", err)
 	}
 }
+
+// TestBootEpoch_DiffersAcrossIncarnations pins what separates one run of the
+// server from the next. generateClientID restarts its sequence at 0 every boot,
+// so two incarnations sharing a boot epoch hand out byte-identical client IDs
+// and unknownClientIDError then reads a stale one as merely expired rather than
+// from another incarnation. A clock read at seconds resolution collided for
+// every restart inside one second, which is what this many managers in a loop
+// reproduces.
+func TestBootEpoch_DiffersAcrossIncarnations(t *testing.T) {
+	const incarnations = 8
+
+	seen := make(map[uint32]struct{}, incarnations)
+	firstClientIDs := make(map[uint64]struct{}, incarnations)
+	for range incarnations {
+		sm := NewStateManager(90 * time.Second)
+		seen[sm.BootEpoch()] = struct{}{}
+		firstClientIDs[sm.generateClientID()] = struct{}{}
+		sm.Shutdown()
+	}
+
+	if len(seen) != incarnations {
+		t.Errorf("%d incarnations produced %d distinct boot epochs, want %d",
+			incarnations, len(seen), incarnations)
+	}
+	if len(firstClientIDs) != incarnations {
+		t.Errorf("%d incarnations produced %d distinct first client IDs, want %d",
+			incarnations, len(firstClientIDs), incarnations)
+	}
+}


### PR DESCRIPTION
Rebased onto `develop` now that #2484 has merged (`2acb10da9`); this branch
carries only the epoch change. It had to come second: #2484 added
`isCurrentEpoch` checks at six operations, and this changes how the epoch is
derived. Its tests build a wrong-epoch stateid by rewriting the fragment
relative to whatever the manager drew, so they hold either way — but the
ordering was not worth gambling on.

## What was wrong

`state/manager.go` derived the boot epoch as `uint32(time.Now().Unix())`. It is
the high 32 bits of every client ID (`generateClientID`) and a 24-bit fragment of
every stateid (`generateStateidOther`), and it is what tells this incarnation of
the server apart from the last one.

`generateClientID` restarts its low-half sequence at 0 every boot. So two
incarnations that start inside the same second share an epoch and hand out
byte-identical client IDs — and then:

- `unknownClientIDError` reads a client ID from the dead incarnation as merely
  `NFS4ERR_EXPIRED` instead of `NFS4ERR_STALE_CLIENTID`, telling the client to
  renew state that is gone rather than to get a new client ID; worse, the ID may
  now belong to a *different* live client;
- `isCurrentEpoch` reads a stateid minted before the restart as current.

A supervisor restart is comfortably inside one second, so this is not a
theoretical window.

## The fix, and the alternative that was rejected

32 bits from `crypto/rand`.

Persisting a monotonic counter was the issue's suggestion and is not needed:
**both readers test the epoch for equality only, never for order** —
`unknownClientIDError` (`manager.go`) compares `uint32(clientID>>32) ==
sm.bootEpoch`, and `isCurrentEpoch` (`stateid.go`) compares the three fragment
bytes. Nothing asks whether one epoch precedes another, so a persisted counter
buys nothing here that a draw does not, at the cost of a durable write on the
startup path.

Randomizing also retires a second defect the clock carried: the stateid fragment
is only the low 24 bits of the epoch, so a seconds counter wrapped it every 194
days and two restarts 194 days apart minted colliding fragments.

A `ponytail:` marker at the draw records the ceiling — nothing rules out drawing
the same epoch twice, which the 24-bit stateid fragment puts at roughly one
restart in 16 million — and names persistence as the upgrade path, noting that
the durable client-recovery store is already handed this value
(`pkg/adapter/nfs/adapter.go` passes `BootEpoch()` into
`SetClientRecoveryStore`), so the seam to persist it through already exists.

Checked before relying on that: `ClientRecoveryRecord.ServerEpoch` is written
into the durable record and read back, but never compared — nothing orders it,
and the SQL column is an `int64`, so a full-range `uint32` fits.

## Evidence

`TestBootEpoch_DiffersAcrossIncarnations` builds eight managers in a loop and
asserts eight distinct boot epochs and eight distinct first client IDs. Against
the clock derivation, restored through a `go test -overlay` copy:

```
--- FAIL: TestBootEpoch_DiffersAcrossIncarnations (0.00s)
    stateid_validity_test.go:248: 8 incarnations produced 1 distinct boot epochs, want 8
    stateid_validity_test.go:252: 8 incarnations produced 1 distinct first client IDs, want 8
```

That second line is the defect stated as a number: one distinct client ID across
eight restarts.

The second mutation checks the test is not vacuous: drop the epoch out of
`generateClientID`'s high half and leave the draw alone, and only the client-ID
assertion fails —

```
--- FAIL: TestBootEpoch_DiffersAcrossIncarnations (0.00s)
    stateid_validity_test.go:252: 8 incarnations produced 1 distinct first client IDs, want 8
```

— so the two assertions are independent and neither is riding on the other.

`TestNewStateManager_BootEpochReasonable` asserted the epoch lands within two
seconds of `time.Now()` — the behaviour being removed — and is deleted rather
than adjusted; the new test pins the property that actually matters.

`go test ./internal/adapter/nfs/...`, `./pkg/adapter/...` and
`./pkg/metadata/lock/...` clean.

## No known-failures row moves

This change removes no row from any `KNOWN_FAILURES` table, so there is nothing
here that needs per-backend verdict lines. It does not touch
`KNOWN_FAILURES_V40.md` at all — the `LKU6b` reclassification to #2483 that
#2484 landed is untouched (`git diff --name-only` against `develop` lists only
the three Go files).

One flake surface worth naming, unchanged in size: pynfs's `makeStaleId` forges
a stale stateid by writing the epoch fragment `00 00 01`, so a drawn epoch whose
low 24 bits happen to be `0x000001` would make `CLOSE6` / `OPCF6` / `OPDG6` read
that forgery as current. That is one restart in 16.7 million. The clock
derivation had the same exposure for one second every 194 days.

Closes #2389
