### PR TITLE
fix(nfs): DESTROY_CLIENTID must not gate on the requester's client ID, and must report an unrecognized target first

### DIFF
--- a/internal/adapter/nfs/v4/handlers/destroy_clientid_handler_test.go
+++ b/internal/adapter/nfs/v4/handlers/destroy_clientid_handler_test.go
@@ -248,9 +248,12 @@ func TestDestroyClientID_UnrecognizedTargetBeatsRequesterIdentity(t *testing.T) 
 	if decoded.NumResults != 2 {
 		t.Fatalf("numResults = %d, want 2", decoded.NumResults)
 	}
-	if decoded.Results[1].Status != types.NFS4ERR_STALE_CLIENTID {
-		t.Errorf("result[1] status = %d, want NFS4ERR_STALE_CLIENTID (%d)",
-			decoded.Results[1].Status, types.NFS4ERR_STALE_CLIENTID)
+	// The SEQUENCE succeeded, so the requester was identifiable and distinct
+	// from the target: the reply above is the target-recognition verdict, not a
+	// side effect of the request failing before DESTROY_CLIENTID ran.
+	if decoded.Results[0].OpCode != types.OP_SEQUENCE || decoded.Results[0].Status != types.NFS4_OK {
+		t.Fatalf("result[0] = op %d status %d, want OP_SEQUENCE with NFS4_OK",
+			decoded.Results[0].OpCode, decoded.Results[0].Status)
 	}
 }
 

--- a/internal/adapter/nfs/v4/handlers/destroy_clientid_handler_test.go
+++ b/internal/adapter/nfs/v4/handlers/destroy_clientid_handler_test.go
@@ -196,3 +196,145 @@ func encodeSetClientIDArgsForTest() []byte {
 	_ = xdr.WriteUint32(&buf, 1)
 	return buf.Bytes()
 }
+
+// runDestroyClientID sends the given operations as one v4.1 COMPOUND and
+// returns the decoded reply. It drives ProcessCompound, the same entry point
+// the RPC layer uses, so COMPOUND-level gating is in force.
+func runDestroyClientID(t *testing.T, h *Handler, ctx *types.CompoundContext, tag string, ops []compoundOp) *decodedCompoundResponse {
+	t.Helper()
+	resp, err := h.ProcessCompound(ctx, buildCompoundArgsWithOps([]byte(tag), 1, ops))
+	if err != nil {
+		t.Fatalf("ProcessCompound(%s) error: %v", tag, err)
+	}
+	decoded, err := decodeCompoundResponse(resp)
+	if err != nil {
+		t.Fatalf("decode response(%s) error: %v", tag, err)
+	}
+	return decoded
+}
+
+func encodeDestroyClientIDArgsForTest(t *testing.T, clientID uint64) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := (&types.DestroyClientidArgs{ClientID: clientID}).Encode(&buf); err != nil {
+		t.Fatalf("encode DESTROY_CLIENTID args: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// TestDestroyClientID_UnrecognizedTargetBeatsRequesterIdentity pins the order in
+// which DESTROY_CLIENTID answers a request that trips two checks at once: the
+// requester is identifiable and is a different client from the target (so any
+// requester-identity check would fire), and the target client ID is not one the
+// server has handed out (so the target-recognition check fires too). RFC 8881
+// Section 18.50 makes the target-recognition verdict the answer -- the reply is
+// NFS4ERR_STALE_CLIENTID. A single-fault request cannot tell the two orders
+// apart, which is why this one carries both faults.
+func TestDestroyClientID_UnrecognizedTargetBeatsRequesterIdentity(t *testing.T) {
+	h, sessionID := createTestSessionWithConnectionID(t, 9500)
+	ctx := newTestCompoundContext()
+	ctx.ConnectionID = 9500
+
+	const unknownClientID = 0xDEADBEEF
+	decoded := runDestroyClientID(t, h, ctx, "dc-order", []compoundOp{
+		{opCode: types.OP_SEQUENCE, data: encodeSequenceArgs(sessionID, 0, 1, 0, false)},
+		{opCode: types.OP_DESTROY_CLIENTID, data: encodeDestroyClientIDArgsForTest(t, unknownClientID)},
+	})
+
+	if decoded.Status != types.NFS4ERR_STALE_CLIENTID {
+		t.Fatalf("status = %d, want NFS4ERR_STALE_CLIENTID (%d)",
+			decoded.Status, types.NFS4ERR_STALE_CLIENTID)
+	}
+	if decoded.NumResults != 2 {
+		t.Fatalf("numResults = %d, want 2", decoded.NumResults)
+	}
+	if decoded.Results[1].Status != types.NFS4ERR_STALE_CLIENTID {
+		t.Errorf("result[1] status = %d, want NFS4ERR_STALE_CLIENTID (%d)",
+			decoded.Results[1].Status, types.NFS4ERR_STALE_CLIENTID)
+	}
+}
+
+// TestDestroyClientID_TargetsAnotherClientBehindSequence covers the case
+// RFC 8881 Section 18.50 explicitly permits: a DESTROY_CLIENTID preceded by a
+// SEQUENCE whose session belongs to a different client than the one being
+// destroyed. The target holds no session and no state, so it is destroyed and
+// the reply is NFS4_OK; a second attempt then reports the client ID as no
+// longer recognized.
+func TestDestroyClientID_TargetsAnotherClientBehindSequence(t *testing.T) {
+	h, sessionID := createTestSessionWithConnectionID(t, 9600)
+	ctx := newTestCompoundContext()
+	ctx.ConnectionID = 9600
+
+	targetClientID, _ := registerExchangeID(t, h, "dc-other-client")
+	targetArgs := encodeDestroyClientIDArgsForTest(t, targetClientID)
+
+	decoded := runDestroyClientID(t, h, ctx, "dc-other", []compoundOp{
+		{opCode: types.OP_SEQUENCE, data: encodeSequenceArgs(sessionID, 0, 1, 0, false)},
+		{opCode: types.OP_DESTROY_CLIENTID, data: targetArgs},
+	})
+	if decoded.Status != types.NFS4_OK {
+		t.Fatalf("status = %d, want NFS4_OK", decoded.Status)
+	}
+
+	// The client ID is gone: destroying it again is answered as unrecognized.
+	again := runDestroyClientID(t, h, ctx, "dc-other2", []compoundOp{
+		{opCode: types.OP_SEQUENCE, data: encodeSequenceArgs(sessionID, 0, 2, 0, false)},
+		{opCode: types.OP_DESTROY_CLIENTID, data: targetArgs},
+	})
+	if again.Status != types.NFS4ERR_STALE_CLIENTID {
+		t.Fatalf("second destroy status = %d, want NFS4ERR_STALE_CLIENTID (%d)",
+			again.Status, types.NFS4ERR_STALE_CLIENTID)
+	}
+}
+
+// TestDestroyClientID_SelfTargetBehindOwnSequenceIsBusy covers the converse of
+// the cross-client case: when the client ID derived from the preceding
+// SEQUENCE is the same one being destroyed, the client still holds the session
+// that carried the request, so the reply is NFS4ERR_CLIENTID_BUSY (RFC 8881
+// Section 18.50).
+func TestDestroyClientID_SelfTargetBehindOwnSequenceIsBusy(t *testing.T) {
+	h := newTestHandler()
+	clientID, seqID := registerExchangeID(t, h, "dc-self-client")
+	ctx := newTestCompoundContext()
+	ctx.ConnectionID = 9700
+
+	secParms := []types.CallbackSecParms4{{CbSecFlavor: 0}}
+	sessionID := runCreateSession(t, h, encodeCreateSessionArgsWithSec(clientID, seqID, 0, secParms)).SessionID
+
+	decoded := runDestroyClientID(t, h, ctx, "dc-self", []compoundOp{
+		{opCode: types.OP_SEQUENCE, data: encodeSequenceArgs(sessionID, 0, 1, 0, false)},
+		{opCode: types.OP_DESTROY_CLIENTID, data: encodeDestroyClientIDArgsForTest(t, clientID)},
+	})
+	if decoded.Status != types.NFS4ERR_CLIENTID_BUSY {
+		t.Fatalf("status = %d, want NFS4ERR_CLIENTID_BUSY (%d)",
+			decoded.Status, types.NFS4ERR_CLIENTID_BUSY)
+	}
+}
+
+// TestDestroyClientID_StandaloneOnConnectionBoundToAnotherClient covers the
+// standalone form of the operation: a sole-op COMPOUND with no SEQUENCE,
+// arriving on a connection that is bound to a different client's session. The
+// connection binding names a client, but that identity does not gate the
+// operation: the target holds no state, so it is destroyed and the second
+// attempt reports it as no longer recognized.
+func TestDestroyClientID_StandaloneOnConnectionBoundToAnotherClient(t *testing.T) {
+	h, _ := createTestSessionWithConnectionID(t, 9800)
+	ctx := newTestCompoundContext()
+	ctx.ConnectionID = 9800
+
+	targetClientID, _ := registerExchangeID(t, h, "dc-standalone-client")
+	ops := []compoundOp{
+		{opCode: types.OP_DESTROY_CLIENTID, data: encodeDestroyClientIDArgsForTest(t, targetClientID)},
+	}
+
+	decoded := runDestroyClientID(t, h, ctx, "dc-alone", ops)
+	if decoded.Status != types.NFS4_OK {
+		t.Fatalf("status = %d, want NFS4_OK", decoded.Status)
+	}
+
+	again := runDestroyClientID(t, h, ctx, "dc-alone2", ops)
+	if again.Status != types.NFS4ERR_STALE_CLIENTID {
+		t.Fatalf("second destroy status = %d, want NFS4ERR_STALE_CLIENTID (%d)",
+			again.Status, types.NFS4ERR_STALE_CLIENTID)
+	}
+}

--- a/internal/adapter/nfs/v4/v41/handlers/destroy_clientid.go
+++ b/internal/adapter/nfs/v4/v41/handlers/destroy_clientid.go
@@ -5,6 +5,26 @@
 // if it has sessions (NFS4ERR_CLIENTID_BUSY).
 // DESTROY_CLIENTID is session-exempt (can be the only op in a COMPOUND
 // without SEQUENCE).
+//
+// The checks below run in a fixed order, and which error a request carrying
+// more than one fault is answered with depends on that order (RFC 8881
+// Section 18.50.3, and the operation's valid-error list in Section 15.2):
+//
+//  1. Sharing a COMPOUND with another operation while not preceded by a
+//     SEQUENCE -> NFS4ERR_NOT_ONLY_OP. Enforced by the COMPOUND dispatcher
+//     before this handler runs, so it outranks every check here.
+//  2. Undecodable arguments -> NFS4ERR_BADXDR. Nothing about the target is
+//     knowable until the client ID is off the wire.
+//  3. A target client ID the server does not recognize ->
+//     NFS4ERR_STALE_CLIENTID. This precedes any judgement about the target's
+//     state, because NFS4ERR_CLIENTID_BUSY (Section 15.1.13.1) is a statement
+//     about state held by a client the server does know.
+//  4. A recognized target holding sessions or unexpired state ->
+//     NFS4ERR_CLIENTID_BUSY.
+//
+// NFS4ERR_NOT_SAME is not in the operation's valid-error list and must not be
+// returned: an ownership mismatch between requester and target is not an error
+// for this operation at all.
 package v41handlers
 
 import (
@@ -20,7 +40,8 @@ import (
 // Destroys a client ID and all associated state (sessions, opens, locks, delegations).
 // Delegates to StateManager.PurgeV41Client for state teardown and cleanup.
 // Removes all client state; session-exempt (no SEQUENCE required); fails if sessions exist.
-// Errors: NFS4ERR_CLIENTID_BUSY (has sessions), NFS4ERR_STALE_CLIENTID, NFS4ERR_BADXDR.
+// Errors: NFS4ERR_CLIENTID_BUSY (has sessions), NFS4ERR_STALE_CLIENTID, NFS4ERR_BADXDR,
+// in the order the package comment records.
 func HandleDestroyClientID(
 	d *Deps,
 	ctx *types.CompoundContext,
@@ -37,35 +58,24 @@ func HandleDestroyClientID(
 		}
 	}
 
-	// Verify the requester owns the target client ID (RFC 8881 Section 18.50.3).
+	// Which client sent the request does not gate the operation. RFC 8881
+	// Section 18.50.3 permits a DESTROY_CLIENTID preceded by a SEQUENCE
+	// precisely while the client ID derived from that SEQUENCE's session is
+	// *not* the target, so a request naming a client other than the requester's
+	// own is well formed and must be carried out. When the two client IDs are
+	// the same, the requester still holds the session that carried the request,
+	// which is already state on the target and so is answered below as
+	// NFS4ERR_CLIENTID_BUSY.
 	//
-	// DESTROY_CLIENTID is session-exempt: it may be sent standalone (without a
-	// preceding SEQUENCE) so a client can tear down its own session-less client
-	// ID. The principal attack the audit identified is a client operating inside
-	// its OWN session (or over a connection bound to one of its sessions) that
-	// targets a DIFFERENT client's ID to destroy the victim's state. When the
-	// requester's identity resolves to a different client, reject with
-	// NFS4ERR_NOT_SAME, mirroring DESTROY_SESSION (Section 18.37.3).
-	//
-	// If the requester cannot be associated with any client (no SEQUENCE, no
-	// bound connection, no v4.0 client state) we do NOT reject: that is the
-	// legitimate standalone self-destroy of a session-less client the RFC
-	// permits, and the binding layer offers no stronger identity to check
-	// against in that case. The NFS4ERR_CLIENTID_BUSY guard below still prevents
-	// destroying any client that holds active sessions.
-	if requestingClientID, identified := resolveRequestingClientID(d, v41ctx, ctx); identified && requestingClientID != args.ClientID {
-		logger.Debug("DESTROY_CLIENTID: ownership mismatch -- not same client",
-			"target_client_id", fmt.Sprintf("0x%016x", args.ClientID),
-			"requesting_client_id", fmt.Sprintf("0x%016x", requestingClientID),
-			"client", ctx.ClientAddr)
-		return &types.CompoundResult{
-			Status: types.NFS4ERR_NOT_SAME,
-			OpCode: types.OP_DESTROY_CLIENTID,
-			Data:   EncodeStatusOnly(types.NFS4ERR_NOT_SAME),
-		}
-	}
+	// ponytail: an unconfirmed or idle client ID is therefore destroyable by
+	// anyone who names its 64-bit value; the RFC gates that with SP4_MACH_CRED
+	// or SP4_SSV state protection (NFS4ERR_WRONG_CRED), which this server does
+	// not enforce. Add the credential check to the operation once state
+	// protection is negotiated at EXCHANGE_ID.
 
-	// Delegate to StateManager
+	// Delegate to StateManager, which recognizes the target client ID before it
+	// weighs the client's state, so an unrecognized target is answered
+	// NFS4ERR_STALE_CLIENTID and never NFS4ERR_CLIENTID_BUSY.
 	err := d.StateManager.DestroyV41ClientID(args.ClientID)
 	if err != nil {
 		nfsStatus := MapStateError(err)

--- a/internal/adapter/nfs/v4/v41/handlers/destroy_clientid.go
+++ b/internal/adapter/nfs/v4/v41/handlers/destroy_clientid.go
@@ -38,7 +38,7 @@ import (
 
 // HandleDestroyClientID implements the DESTROY_CLIENTID operation (RFC 8881 Section 18.50).
 // Destroys a client ID and all associated state (sessions, opens, locks, delegations).
-// Delegates to StateManager.PurgeV41Client for state teardown and cleanup.
+// Delegates to StateManager.DestroyV41ClientID for state teardown and cleanup.
 // Removes all client state; session-exempt (no SEQUENCE required); fails if sessions exist.
 // Errors: NFS4ERR_CLIENTID_BUSY (has sessions), NFS4ERR_STALE_CLIENTID, NFS4ERR_BADXDR,
 // in the order the package comment records.

--- a/internal/adapter/nfs/v4/v41/handlers/destroy_clientid_test.go
+++ b/internal/adapter/nfs/v4/v41/handlers/destroy_clientid_test.go
@@ -53,42 +53,40 @@ func encodeDestroyClientidArgs(t *testing.T, clientID uint64) *bytes.Reader {
 	return bytes.NewReader(buf.Bytes())
 }
 
-// TestHandleDestroyClientID_CrossClientRejected is the core security regression
-// test: a request whose identity resolves to client A must NOT be able to
-// destroy client B's client ID. Before the fix DESTROY_CLIENTID performed no
-// ownership check, so any peer operating its own session could tear down a
-// victim's state by targeting the victim's 64-bit client ID. The server must
-// now return NFS4ERR_NOT_SAME and leave the victim intact.
-func TestHandleDestroyClientID_CrossClientRejected(t *testing.T) {
+// TestHandleDestroyClientID_CrossClientTargetPermitted pins the behaviour
+// RFC 8881 Section 18.50.3 requires when the client ID derived from the
+// preceding SEQUENCE is not the one being destroyed: the operation proceeds.
+// The target here holds no session and no state, so it is destroyed.
+func TestHandleDestroyClientID_CrossClientTargetPermitted(t *testing.T) {
 	sm := state.NewStateManager(90 * time.Second)
 	d := &Deps{StateManager: sm}
 
-	_, attackerSession := makeV41Client(t, sm, "attacker")
-	victimClientID, _ := makeV41Client(t, sm, "victim")
+	_, requesterSession := makeV41Client(t, sm, "requester")
 
-	ctx := &types.CompoundContext{Context: context.Background(), ClientAddr: "10.0.0.9:1"}
-	// The attacker identifies via its own SEQUENCE (v41ctx points at its session)
-	// but targets the victim's client ID.
-	v41ctx := &types.V41RequestContext{SessionID: attackerSession}
-
-	res := HandleDestroyClientID(d, ctx, v41ctx, encodeDestroyClientidArgs(t, victimClientID))
-	if res.Status != types.NFS4ERR_NOT_SAME {
-		t.Fatalf("cross-client DESTROY_CLIENTID: status = %d, want NFS4ERR_NOT_SAME (%d)",
-			res.Status, types.NFS4ERR_NOT_SAME)
+	var verifier [8]byte
+	copy(verifier[:], "verify01")
+	target, err := sm.ExchangeID([]byte("destroy-clientid-test-target"), verifier, 0, nil, "10.0.0.2:12345")
+	if err != nil {
+		t.Fatalf("ExchangeID(target): %v", err)
 	}
 
-	// The victim's client record must still exist -- it was NOT destroyed.
-	if !v41ClientExists(sm, victimClientID) {
-		t.Fatal("victim client was destroyed despite ownership mismatch")
+	ctx := &types.CompoundContext{Context: context.Background(), ClientAddr: "10.0.0.9:1"}
+	v41ctx := &types.V41RequestContext{SessionID: requesterSession}
+
+	res := HandleDestroyClientID(d, ctx, v41ctx, encodeDestroyClientidArgs(t, target.ClientID))
+	if res.Status != types.NFS4_OK {
+		t.Fatalf("cross-client DESTROY_CLIENTID: status = %d, want NFS4_OK", res.Status)
+	}
+	if v41ClientExists(sm, target.ClientID) {
+		t.Fatal("target client still exists after a successful DESTROY_CLIENTID")
 	}
 }
 
-// TestHandleDestroyClientID_OwnerPassesOwnershipCheck verifies the owner is not
-// wrongly blocked: a request whose SEQUENCE identifies the same client that owns
-// the target client ID clears the ownership gate. Because the owner still holds
-// the identifying session, the operation then correctly returns
-// NFS4ERR_CLIENTID_BUSY (RFC 8881 Section 18.50) rather than an authz error.
-func TestHandleDestroyClientID_OwnerPassesOwnershipCheck(t *testing.T) {
+// TestHandleDestroyClientID_SelfTargetIsBusy verifies the converse: when the
+// SEQUENCE identifies the same client the request targets, that client still
+// holds the session carrying the request, so the reply is
+// NFS4ERR_CLIENTID_BUSY (RFC 8881 Section 18.50).
+func TestHandleDestroyClientID_SelfTargetIsBusy(t *testing.T) {
 	sm := state.NewStateManager(90 * time.Second)
 	d := &Deps{StateManager: sm}
 
@@ -99,7 +97,7 @@ func TestHandleDestroyClientID_OwnerPassesOwnershipCheck(t *testing.T) {
 
 	res := HandleDestroyClientID(d, ctx, v41ctx, encodeDestroyClientidArgs(t, ownerClientID))
 	if res.Status != types.NFS4ERR_CLIENTID_BUSY {
-		t.Fatalf("owner DESTROY_CLIENTID with active session: status = %d, want NFS4ERR_CLIENTID_BUSY (%d)",
+		t.Fatalf("self-target DESTROY_CLIENTID with active session: status = %d, want NFS4ERR_CLIENTID_BUSY (%d)",
 			res.Status, types.NFS4ERR_CLIENTID_BUSY)
 	}
 }


### PR DESCRIPTION
Closes #2472

## The defect is a check that should not exist, not only a wrong code

RFC 8881 Section 18.50.3 says the opposite of what the handler enforced:

> DESTROY_CLIENTID MAY be preceded by a SEQUENCE operation **as long as the client ID derived from the session ID of the SEQUENCE is not the same as the client ID to be destroyed**. If the client IDs are the same, then the server MUST return NFS4ERR_CLIENTID_BUSY.

A DESTROY_CLIENTID naming a client other than the requester's own is therefore well formed and must be carried out. The handler rejected exactly that case with `NFS4ERR_NOT_SAME` — and `NFS4ERR_NOT_SAME` is not in the operation's valid-error list at all (Section 15.2):

> | DESTROY_CLIENTID | NFS4ERR_BADXDR, NFS4ERR_CLIENTID_BUSY, NFS4ERR_DEADSESSION, NFS4ERR_DELAY, NFS4ERR_NOT_ONLY_OP, NFS4ERR_REP_TOO_BIG, NFS4ERR_REP_TOO_BIG_TO_CACHE, NFS4ERR_REQ_TOO_BIG, NFS4ERR_RETRY_UNCACHED_REP, NFS4ERR_SERVERFAULT, NFS4ERR_STALE_CLIENTID, NFS4ERR_TOO_MANY_OPS, NFS4ERR_WRONG_CRED |

The RFC's protection for this operation is state protection negotiated at EXCHANGE_ID (`SP4_MACH_CRED` / `SP4_SSV`, answered with `NFS4ERR_WRONG_CRED`), which this server does not enforce; that ceiling is now recorded as a `ponytail:` marker where the deleted check used to be. The fix is a deletion: the requester's identity does not gate the operation, and the same-client case is already answered `NFS4ERR_CLIENTID_BUSY` because the requester still holds the session that carried the request.

## The order, written down next to the checks

The package comment now records it as an invariant about the reply, because an ordering rule is invisible in a diff:

1. Sharing a COMPOUND with another operation while not preceded by SEQUENCE -> `NFS4ERR_NOT_ONLY_OP` (enforced by the dispatcher before the handler runs, so it outranks everything here).
2. Undecodable arguments -> `NFS4ERR_BADXDR`.
3. Unrecognized target client ID -> `NFS4ERR_STALE_CLIENTID`. This precedes any judgement about the target's state, because `NFS4ERR_CLIENTID_BUSY` (Section 15.1.13.1) is a statement about state held by a client the server *does* know.
4. Recognized target holding sessions or unexpired state -> `NFS4ERR_CLIENTID_BUSY`.

## Testing order specifically

`TestDestroyClientID_UnrecognizedTargetBeatsRequesterIdentity` sends a **sole-op-equivalent** request — `[SEQUENCE(client A), DESTROY_CLIENTID(0xDEADBEEF)]`, never a second non-exempt op — that trips two checks at once: the requester is identifiable and is a different client from the target, *and* the target is unrecognized. A single-fault request passes under either order and would certify the bug. On `develop` it answers `10027` (`NFS4ERR_NOT_SAME`); the required answer is `10022` (`NFS4ERR_STALE_CLIENTID`). It also asserts `result[0]` is `OP_SEQUENCE` with `NFS4_OK`, so the verdict cannot be a side effect of the request failing before DESTROY_CLIENTID ran.

All new tests drive `Handler.ProcessCompound`, the entry point the RPC layer calls, so COMPOUND-level gating is in force and no state is hand-set.

### Premise proven before the fix (against `develop`)

```
--- FAIL: TestDestroyClientID_UnrecognizedTargetBeatsRequesterIdentity
    status = 10027, want NFS4ERR_STALE_CLIENTID (10022)
--- FAIL: TestDestroyClientID_TargetsAnotherClientBehindSequence
    status = 10027, want NFS4_OK
--- FAIL: TestDestroyClientID_StandaloneOnConnectionBoundToAnotherClient
    status = 10027, want NFS4_OK
```

### Guard verification: each check mutated both ways

Each mutation is a `go test -overlay` substitution, so the repo is untouched.

| Mutation | Named test that fails | Literal output |
| --- | --- | --- |
| BADXDR check always passes | `TestHandleDestroyClientID/bad_xdr` | `status = 10022, want NFS4ERR_BADXDR (10036)` |
| BADXDR verdict returns success | `TestHandleDestroyClientID/bad_xdr` | `status = 0, want NFS4ERR_BADXDR (10036)` |
| Requester-identity gate re-introduced ahead of the delegate | `TestDestroyClientID_UnrecognizedTargetBeatsRequesterIdentity` | `status = 10027, want NFS4ERR_STALE_CLIENTID (10022)` |
| (same) | `TestDestroyClientID_TargetsAnotherClientBehindSequence` | `status = 10027, want NFS4_OK` |
| (same) | `TestHandleDestroyClientID_CrossClientTargetPermitted` | `cross-client DESTROY_CLIENTID: status = 10027, want NFS4_OK` |
| Target-recognition check always passes | `TestHandleDestroyClientID/stale_clientid` | `status = 0, want NFS4ERR_STALE_CLIENTID (10022)` |
| (same) | `TestDestroyClientID_UnrecognizedTargetBeatsRequesterIdentity` | `status = 0, want NFS4ERR_STALE_CLIENTID (10022)` |
| Target-recognition verdict returns nil | `TestDestroyClientID_TargetsAnotherClientBehindSequence` | `second destroy status = 0, want NFS4ERR_STALE_CLIENTID (10022)` |
| Busy check always passes | `TestDestroyClientID_SelfTargetBehindOwnSequenceIsBusy` | `status = 0, want NFS4ERR_CLIENTID_BUSY (10074)` |
| Busy verdict returns nil | `TestHandleDestroyClientID_SelfTargetIsBusy` | `self-target DESTROY_CLIENTID with active session: status = 0, want NFS4ERR_CLIENTID_BUSY (10074)` |

The first attempt at the "target-recognition always passes" mutation silently survived: the same `record, exists := sm.v41ClientsByID[clientID]; if !exists` shape appears in `EvictV41Client` immediately above `DestroyV41ClientID`, and the substitution hit that one instead. Re-anchored on the `NFS4ERR_STALE_CLIENTID` body it kills four named tests.

## Tests removed

`TestHandleDestroyClientID_CrossClientRejected` pinned the behaviour the RFC forbids — it is the reason DESCID2 fails — and is replaced by `TestHandleDestroyClientID_CrossClientTargetPermitted`. `TestHandleDestroyClientID_OwnerPassesOwnershipCheck` is renamed to `TestHandleDestroyClientID_SelfTargetIsBusy`, since there is no ownership gate to pass; its assertion is unchanged.

## Known failures

**No rows removed in this push.** `DESCID1`, `DESCID2`, `DESCID4`, `DESCID8` stay until this branch's own presubmit produces `pynfs.log` for **both** `memory` and `postgres-s3`, and each row shows a literal `: PASS` verdict line on both. Rows will be moved in a follow-up commit with the per-backend lines quoted here. `DESCID7` was already walked out by #2481 and is not part of this change.

Note on `DESCID8` (`testDestroyCIDTwice`): only its *first* destroy expects `NFS4_OK`. The suite source asserts the second one explicitly:

```python
res = env.c1.compound([op.destroy_clientid(c.clientid)])
check(res)
res = env.c1.compound([op.destroy_clientid(c.clientid)])
check(res, NFS4ERR_STALE_CLIENTID)
```

so a second DESTROY_CLIENTID must still fail, and both new success-path tests assert that follow-up `NFS4ERR_STALE_CLIENTID` rather than assuming idempotence.

## Gates

`go build ./...`, `go test ./...`, `go test -race ./internal/adapter/nfs/...`, `go fmt ./...`, `go vet ./...` — all clean.
