### PR TITLE
fix(nfs): implement the EXCHANGE_ID flag validation and record algorithm of RFC 8881 18.35.4

### DIFF
--- a/internal/adapter/nfs/v4/handlers/exchange_id_algorithm_test.go
+++ b/internal/adapter/nfs/v4/handlers/exchange_id_algorithm_test.go
@@ -296,15 +296,14 @@ func TestExchangeID_UpdateWithUnconfirmedRecord(t *testing.T) {
 	// An unconfirmed record is not updatable: there is no confirmed record to
 	// update, whatever verifier and principal the update carries.
 	tests := []struct {
-		name       string
-		verifier   [8]byte
-		uid        uint32
-		wantClient bool
+		name     string
+		verifier [8]byte
+		uid      uint32
 	}{
-		{"otherVerifierOtherPrincipal", eidVerifier("verify02"), 2222, true},
-		{"otherVerifierSamePrincipal", eidVerifier("verify02"), 1111, true},
-		{"sameVerifierOtherPrincipal", eidVerifier("verify01"), 2222, true},
-		{"sameVerifierSamePrincipal", eidVerifier("verify01"), 1111, true},
+		{"otherVerifierOtherPrincipal", eidVerifier("verify02"), 2222},
+		{"otherVerifierSamePrincipal", eidVerifier("verify02"), 1111},
+		{"sameVerifierOtherPrincipal", eidVerifier("verify01"), 2222},
+		{"sameVerifierSamePrincipal", eidVerifier("verify01"), 1111},
 	}
 
 	for _, tt := range tests {

--- a/internal/adapter/nfs/v4/handlers/exchange_id_algorithm_test.go
+++ b/internal/adapter/nfs/v4/handlers/exchange_id_algorithm_test.go
@@ -1,0 +1,620 @@
+package handlers
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/pseudofs"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/state"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+)
+
+// The tests below drive the whole COMPOUND path (ProcessCompound), which is
+// what the RPC layer calls, so the flag validation, the record algorithm and
+// the CREATE_SESSION confirmation phase are all exercised as a client sees
+// them. They cover the EXCHANGE_ID cases of RFC 8881 Section 18.35.4 and the
+// confirmation phase of Section 18.36.3.
+
+// eidVerifier turns a short string into a co_verifier.
+func eidVerifier(s string) [8]byte {
+	var v [8]byte
+	copy(v[:], s)
+	return v
+}
+
+// ctxForUID returns a compound context whose AUTH_UNIX credential maps to uid,
+// so EXCHANGE_ID and CREATE_SESSION see it as a distinct principal.
+func ctxForUID(uid uint32, connID uint64) *types.CompoundContext {
+	ctx := newTestCompoundContext()
+	ctx.UID = &uid
+	ctx.ConnectionID = connID
+	return ctx
+}
+
+// doExchangeID sends a single-op EXCHANGE_ID COMPOUND and returns the decoded
+// result. The operation status is returned in the result, not asserted here,
+// so error cases can be checked by the caller.
+func doExchangeID(
+	t *testing.T,
+	h *Handler,
+	ctx *types.CompoundContext,
+	ownerID string,
+	verifier [8]byte,
+	flags uint32,
+) types.ExchangeIdRes {
+	t.Helper()
+
+	args := encodeExchangeIdArgs([]byte(ownerID), verifier, flags, types.SP4_NONE, nil)
+	ops := []compoundOp{{opCode: types.OP_EXCHANGE_ID, data: args}}
+	resp, err := h.ProcessCompound(ctx, buildCompoundArgsWithOps([]byte("eid"), 1, ops))
+	if err != nil {
+		t.Fatalf("EXCHANGE_ID ProcessCompound error: %v", err)
+	}
+
+	reader := bytes.NewReader(resp)
+	if _, err := xdr.DecodeUint32(reader); err != nil { // overall status
+		t.Fatalf("decode overall status: %v", err)
+	}
+	if _, err := xdr.DecodeOpaque(reader); err != nil { // tag
+		t.Fatalf("decode tag: %v", err)
+	}
+	numResults, err := xdr.DecodeUint32(reader)
+	if err != nil {
+		t.Fatalf("decode numResults: %v", err)
+	}
+	if numResults != 1 {
+		t.Fatalf("numResults = %d, want 1", numResults)
+	}
+	opCode, err := xdr.DecodeUint32(reader)
+	if err != nil {
+		t.Fatalf("decode result opcode: %v", err)
+	}
+	if opCode != types.OP_EXCHANGE_ID {
+		t.Fatalf("result opcode = %d, want OP_EXCHANGE_ID (%d)", opCode, types.OP_EXCHANGE_ID)
+	}
+
+	var res types.ExchangeIdRes
+	if err := res.Decode(reader); err != nil {
+		t.Fatalf("decode ExchangeIdRes: %v", err)
+	}
+	return res
+}
+
+// exchangeIDOK sends EXCHANGE_ID and fails the test unless it succeeded.
+func exchangeIDOK(
+	t *testing.T,
+	h *Handler,
+	ctx *types.CompoundContext,
+	ownerID string,
+	verifier [8]byte,
+) types.ExchangeIdRes {
+	t.Helper()
+	res := doExchangeID(t, h, ctx, ownerID, verifier, 0)
+	if res.Status != types.NFS4_OK {
+		t.Fatalf("EXCHANGE_ID status = %d, want NFS4_OK", res.Status)
+	}
+	return res
+}
+
+// doCreateSession sends a single-op CREATE_SESSION COMPOUND and returns the
+// decoded result, leaving the status for the caller to assert.
+func doCreateSession(
+	t *testing.T,
+	h *Handler,
+	ctx *types.CompoundContext,
+	clientID uint64,
+	seqID uint32,
+) types.CreateSessionRes {
+	t.Helper()
+
+	secParms := []types.CallbackSecParms4{{CbSecFlavor: 0}} // AUTH_NONE
+	csArgs := encodeCreateSessionArgsWithSec(clientID, seqID, 0, secParms)
+	ops := []compoundOp{{opCode: types.OP_CREATE_SESSION, data: csArgs}}
+	resp, err := h.ProcessCompound(ctx, buildCompoundArgsWithOps([]byte("cs"), 1, ops))
+	if err != nil {
+		t.Fatalf("CREATE_SESSION ProcessCompound error: %v", err)
+	}
+
+	reader := bytes.NewReader(resp)
+	if _, err := xdr.DecodeUint32(reader); err != nil { // overall status
+		t.Fatalf("decode overall status: %v", err)
+	}
+	if _, err := xdr.DecodeOpaque(reader); err != nil { // tag
+		t.Fatalf("decode tag: %v", err)
+	}
+	if _, err := xdr.DecodeUint32(reader); err != nil { // numResults
+		t.Fatalf("decode numResults: %v", err)
+	}
+	if _, err := xdr.DecodeUint32(reader); err != nil { // opcode
+		t.Fatalf("decode result opcode: %v", err)
+	}
+
+	var res types.CreateSessionRes
+	if err := res.Decode(reader); err != nil {
+		t.Fatalf("decode CreateSessionRes: %v", err)
+	}
+	return res
+}
+
+// createSessionOK confirms a client ID and returns the new session ID.
+func createSessionOK(
+	t *testing.T,
+	h *Handler,
+	ctx *types.CompoundContext,
+	clientID uint64,
+	seqID uint32,
+) types.SessionId4 {
+	t.Helper()
+	res := doCreateSession(t, h, ctx, clientID, seqID)
+	if res.Status != types.NFS4_OK {
+		t.Fatalf("CREATE_SESSION status = %d, want NFS4_OK", res.Status)
+	}
+	return res.SessionID
+}
+
+// sequenceOverallStatus probes a session with a single-op SEQUENCE COMPOUND and
+// returns the COMPOUND status, which is NFS4ERR_BADSESSION once the session is
+// gone.
+func sequenceOverallStatus(
+	t *testing.T,
+	h *Handler,
+	sessionID types.SessionId4,
+	slotID, seqID uint32,
+) uint32 {
+	t.Helper()
+
+	ops := []compoundOp{{opCode: types.OP_SEQUENCE, data: encodeSequenceArgs(sessionID, slotID, seqID, 0, false)}}
+	resp, err := h.ProcessCompound(newTestCompoundContext(),
+		buildCompoundArgsWithOps([]byte("seq"), 1, ops))
+	if err != nil {
+		t.Fatalf("SEQUENCE ProcessCompound error: %v", err)
+	}
+	status, err := xdr.DecodeUint32(bytes.NewReader(resp))
+	if err != nil {
+		t.Fatalf("decode SEQUENCE overall status: %v", err)
+	}
+	return status
+}
+
+// destroySession sends a standalone DESTROY_SESSION over ctx's connection and
+// returns the COMPOUND status.
+func destroySession(t *testing.T, h *Handler, ctx *types.CompoundContext, sessionID types.SessionId4) uint32 {
+	t.Helper()
+
+	var buf bytes.Buffer
+	args := types.DestroySessionArgs{SessionID: sessionID}
+	if err := args.Encode(&buf); err != nil {
+		t.Fatalf("encode DestroySessionArgs: %v", err)
+	}
+	ops := []compoundOp{{opCode: types.OP_DESTROY_SESSION, data: buf.Bytes()}}
+	resp, err := h.ProcessCompound(ctx, buildCompoundArgsWithOps([]byte("ds"), 1, ops))
+	if err != nil {
+		t.Fatalf("DESTROY_SESSION ProcessCompound error: %v", err)
+	}
+	status, err := xdr.DecodeUint32(bytes.NewReader(resp))
+	if err != nil {
+		t.Fatalf("decode DESTROY_SESSION overall status: %v", err)
+	}
+	return status
+}
+
+// ============================================================================
+// eia_flags validation (RFC 8881 Section 18.35.3)
+// ============================================================================
+
+func TestExchangeID_UndefinedFlagBitRejected(t *testing.T) {
+	h := newTestHandler()
+
+	// Bit 0x4 carries no meaning for a v4.1 client; the server must refuse it
+	// rather than register the owner ID.
+	res := doExchangeID(t, h, newTestCompoundContext(), "undefined-flag-client",
+		eidVerifier("verify01"), 0x4)
+	if res.Status != types.NFS4ERR_INVAL {
+		t.Fatalf("status for undefined flag bit 0x4 = %d, want NFS4ERR_INVAL (%d)",
+			res.Status, types.NFS4ERR_INVAL)
+	}
+
+	// Nothing may have been registered by the rejected request.
+	if got := len(h.StateManager.ListV41Clients()); got != 0 {
+		t.Errorf("registered v4.1 clients = %d, want 0 after a rejected EXCHANGE_ID", got)
+	}
+}
+
+func TestExchangeID_ReplyOnlyFlagRejected(t *testing.T) {
+	h := newTestHandler()
+
+	// EXCHGID4_FLAG_CONFIRMED_R is set by the server in eir_flags only.
+	res := doExchangeID(t, h, newTestCompoundContext(), "confirmed-r-client",
+		eidVerifier("verify01"),
+		types.EXCHGID4_FLAG_USE_NON_PNFS|types.EXCHGID4_FLAG_CONFIRMED_R)
+	if res.Status != types.NFS4ERR_INVAL {
+		t.Fatalf("status for client-set CONFIRMED_R = %d, want NFS4ERR_INVAL (%d)",
+			res.Status, types.NFS4ERR_INVAL)
+	}
+}
+
+func TestExchangeID_DefinedArgumentFlagsAccepted(t *testing.T) {
+	h := newTestHandler()
+
+	flags := uint32(types.EXCHGID4_FLAG_SUPP_MOVED_REFER |
+		types.EXCHGID4_FLAG_SUPP_MOVED_MIGR |
+		types.EXCHGID4_FLAG_BIND_PRINC_STATEID |
+		types.EXCHGID4_FLAG_USE_NON_PNFS)
+
+	res := doExchangeID(t, h, newTestCompoundContext(), "defined-flags-client",
+		eidVerifier("verify01"), flags)
+	if res.Status != types.NFS4_OK {
+		t.Fatalf("status for defined argument flags = %d, want NFS4_OK", res.Status)
+	}
+	roles := uint32(types.EXCHGID4_FLAG_USE_NON_PNFS |
+		types.EXCHGID4_FLAG_USE_PNFS_MDS |
+		types.EXCHGID4_FLAG_USE_PNFS_DS)
+	if res.Flags&roles == 0 {
+		t.Error("eir_flags must carry one of the EXCHGID4_FLAG_USE_* role bits")
+	}
+}
+
+func TestExchangeID_FenceOpsFlagAcceptedOnV42(t *testing.T) {
+	h := newTestHandler()
+
+	// Bit 0x4 is EXCHGID4_FLAG_SUPP_FENCE_OPS, which a v4.2 client may request.
+	args := encodeExchangeIdArgs([]byte("fence-ops-client"), eidVerifier("verify01"),
+		types.EXCHGID4_FLAG_SUPP_FENCE_OPS, types.SP4_NONE, nil)
+	ops := []compoundOp{{opCode: types.OP_EXCHANGE_ID, data: args}}
+	resp, err := h.ProcessCompound(newTestCompoundContext(),
+		buildCompoundArgsWithOps([]byte("eid42"), 2, ops))
+	if err != nil {
+		t.Fatalf("EXCHANGE_ID ProcessCompound error: %v", err)
+	}
+	status, err := xdr.DecodeUint32(bytes.NewReader(resp))
+	if err != nil {
+		t.Fatalf("decode overall status: %v", err)
+	}
+	if status != types.NFS4_OK {
+		t.Fatalf("v4.2 SUPP_FENCE_OPS request status = %d, want NFS4_OK", status)
+	}
+}
+
+// ============================================================================
+// Update requests: EXCHGID4_FLAG_UPD_CONFIRMED_REC_A (cases 6-9)
+// ============================================================================
+
+func TestExchangeID_UpdateWithoutAnyRecord(t *testing.T) {
+	h := newTestHandler()
+
+	res := doExchangeID(t, h, newTestCompoundContext(), "update-nonexistent",
+		eidVerifier("verify01"), types.EXCHGID4_FLAG_UPD_CONFIRMED_REC_A)
+	if res.Status != types.NFS4ERR_NOENT {
+		t.Fatalf("update against no record = %d, want NFS4ERR_NOENT (%d)",
+			res.Status, types.NFS4ERR_NOENT)
+	}
+}
+
+func TestExchangeID_UpdateWithUnconfirmedRecord(t *testing.T) {
+	// An unconfirmed record is not updatable: there is no confirmed record to
+	// update, whatever verifier and principal the update carries.
+	tests := []struct {
+		name       string
+		verifier   [8]byte
+		uid        uint32
+		wantClient bool
+	}{
+		{"otherVerifierOtherPrincipal", eidVerifier("verify02"), 2222, true},
+		{"otherVerifierSamePrincipal", eidVerifier("verify02"), 1111, true},
+		{"sameVerifierOtherPrincipal", eidVerifier("verify01"), 2222, true},
+		{"sameVerifierSamePrincipal", eidVerifier("verify01"), 1111, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newTestHandler()
+			owner := "update-unconfirmed"
+
+			first := exchangeIDOK(t, h, ctxForUID(1111, 0), owner, eidVerifier("verify01"))
+
+			res := doExchangeID(t, h, ctxForUID(tt.uid, 0), owner, tt.verifier,
+				types.EXCHGID4_FLAG_UPD_CONFIRMED_REC_A)
+			if res.Status != types.NFS4ERR_NOENT {
+				t.Fatalf("update against unconfirmed record = %d, want NFS4ERR_NOENT (%d)",
+					res.Status, types.NFS4ERR_NOENT)
+			}
+
+			// The rejected update leaves the unconfirmed record intact, so it
+			// can still be confirmed.
+			createSessionOK(t, h, ctxForUID(1111, 0), first.ClientID, first.SequenceID)
+		})
+	}
+}
+
+func TestExchangeID_UpdateWrongVerifier(t *testing.T) {
+	// A confirmed record cannot be updated from a different incarnation, and
+	// the wrong verifier is reported before the principal is even considered.
+	tests := []struct {
+		name string
+		uid  uint32
+	}{
+		{"otherPrincipal", 2222},
+		{"samePrincipal", 1111},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newTestHandler()
+			owner := "update-wrong-verifier"
+			ctx := ctxForUID(1111, 0)
+
+			first := exchangeIDOK(t, h, ctx, owner, eidVerifier("verify01"))
+			createSessionOK(t, h, ctx, first.ClientID, first.SequenceID)
+
+			res := doExchangeID(t, h, ctxForUID(tt.uid, 0), owner, eidVerifier("verify02"),
+				types.EXCHGID4_FLAG_UPD_CONFIRMED_REC_A)
+			if res.Status != types.NFS4ERR_NOT_SAME {
+				t.Fatalf("update with a different verifier = %d, want NFS4ERR_NOT_SAME (%d)",
+					res.Status, types.NFS4ERR_NOT_SAME)
+			}
+		})
+	}
+}
+
+func TestExchangeID_UpdateWrongPrincipal(t *testing.T) {
+	h := newTestHandler()
+	owner := "update-wrong-principal"
+	ctx := ctxForUID(1111, 0)
+
+	first := exchangeIDOK(t, h, ctx, owner, eidVerifier("verify01"))
+	createSessionOK(t, h, ctx, first.ClientID, first.SequenceID)
+
+	res := doExchangeID(t, h, ctxForUID(2222, 0), owner, eidVerifier("verify01"),
+		types.EXCHGID4_FLAG_UPD_CONFIRMED_REC_A)
+	if res.Status != types.NFS4ERR_PERM {
+		t.Fatalf("update by another principal = %d, want NFS4ERR_PERM (%d)",
+			res.Status, types.NFS4ERR_PERM)
+	}
+}
+
+func TestExchangeID_UpdateConfirmedRecord(t *testing.T) {
+	h := newTestHandler()
+	owner := "update-confirmed"
+	ctx := ctxForUID(1111, 0)
+
+	first := exchangeIDOK(t, h, ctx, owner, eidVerifier("verify01"))
+	createSessionOK(t, h, ctx, first.ClientID, first.SequenceID)
+
+	res := doExchangeID(t, h, ctx, owner, eidVerifier("verify01"),
+		types.EXCHGID4_FLAG_UPD_CONFIRMED_REC_A)
+	if res.Status != types.NFS4_OK {
+		t.Fatalf("update of a confirmed record = %d, want NFS4_OK", res.Status)
+	}
+	if res.ClientID != first.ClientID {
+		t.Errorf("client ID changed on update: %d -> %d", first.ClientID, res.ClientID)
+	}
+	if res.Flags&types.EXCHGID4_FLAG_CONFIRMED_R == 0 {
+		t.Error("eir_flags must carry CONFIRMED_R for a confirmed record")
+	}
+	if res.Flags&types.EXCHGID4_FLAG_UPD_CONFIRMED_REC_A != 0 {
+		t.Error("eir_flags must never carry UPD_CONFIRMED_REC_A")
+	}
+}
+
+// ============================================================================
+// Non-update requests (cases 1-5)
+// ============================================================================
+
+func TestExchangeID_UnconfirmedRecordIsReplaced(t *testing.T) {
+	// Any second EXCHANGE_ID on an unconfirmed record replaces it with a fresh
+	// client ID, so the owner ID never has two readings at once.
+	tests := []struct {
+		name     string
+		verifier [8]byte
+		uid      uint32
+	}{
+		{"otherVerifierOtherPrincipal", eidVerifier("verify02"), 2222},
+		{"otherVerifierSamePrincipal", eidVerifier("verify02"), 1111},
+		{"sameVerifierOtherPrincipal", eidVerifier("verify01"), 2222},
+		{"sameVerifierSamePrincipal", eidVerifier("verify01"), 1111},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newTestHandler()
+			owner := "replace-unconfirmed"
+
+			first := exchangeIDOK(t, h, ctxForUID(1111, 0), owner, eidVerifier("verify01"))
+			second := exchangeIDOK(t, h, ctxForUID(tt.uid, 0), owner, tt.verifier)
+
+			if second.ClientID == first.ClientID {
+				t.Fatalf("client ID unchanged (%d) -- an unconfirmed record must be replaced",
+					first.ClientID)
+			}
+			if second.Flags&types.EXCHGID4_FLAG_CONFIRMED_R != 0 {
+				t.Error("a replacement record is unconfirmed and must not carry CONFIRMED_R")
+			}
+
+			// The replaced client ID is gone, so it can no longer be confirmed.
+			res := doCreateSession(t, h, ctxForUID(1111, 0), first.ClientID, first.SequenceID)
+			if res.Status != types.NFS4ERR_STALE_CLIENTID {
+				t.Errorf("CREATE_SESSION on the replaced client ID = %d, want NFS4ERR_STALE_CLIENTID (%d)",
+					res.Status, types.NFS4ERR_STALE_CLIENTID)
+			}
+		})
+	}
+}
+
+func TestExchangeID_RestartKeepsOldStateUntilConfirmed(t *testing.T) {
+	h := newTestHandler()
+	owner := "restarting-client"
+	ctx := ctxForUID(1111, 0)
+
+	first := exchangeIDOK(t, h, ctx, owner, eidVerifier("verify01"))
+	oldSession := createSessionOK(t, h, ctx, first.ClientID, first.SequenceID)
+
+	// A new incarnation of the same client: same principal, new verifier.
+	second := exchangeIDOK(t, h, ctx, owner, eidVerifier("verify02"))
+	if second.ClientID == first.ClientID {
+		t.Fatalf("client ID unchanged (%d) -- a restart must get a new one", first.ClientID)
+	}
+	if second.Flags&types.EXCHGID4_FLAG_CONFIRMED_R != 0 {
+		t.Error("the new record is unconfirmed and must not carry CONFIRMED_R")
+	}
+
+	// The previous incarnation's session survives until the new client ID is
+	// confirmed.
+	if got := sequenceOverallStatus(t, h, oldSession, 0, 1); got != types.NFS4_OK {
+		t.Fatalf("SEQUENCE on the old session before confirmation = %d, want NFS4_OK", got)
+	}
+
+	createSessionOK(t, h, ctx, second.ClientID, second.SequenceID)
+
+	// Confirming the new client ID collapses the two records into one and takes
+	// the old incarnation's session with it.
+	if got := sequenceOverallStatus(t, h, oldSession, 0, 2); got != types.NFS4ERR_BADSESSION {
+		t.Fatalf("SEQUENCE on the old session after confirmation = %d, want NFS4ERR_BADSESSION (%d)",
+			got, types.NFS4ERR_BADSESSION)
+	}
+}
+
+func TestExchangeID_RestartRecordSupersededByFurtherExchangeID(t *testing.T) {
+	h := newTestHandler()
+	owner := "restart-twice"
+	ctx := ctxForUID(1111, 0)
+
+	first := exchangeIDOK(t, h, ctx, owner, eidVerifier("verify01"))
+	oldSession := createSessionOK(t, h, ctx, first.ClientID, first.SequenceID)
+
+	second := exchangeIDOK(t, h, ctx, owner, eidVerifier("verify02"))
+
+	// A third EXCHANGE_ID discards the unconfirmed record and is processed
+	// against the confirmed one again, so the confirmed record's session is
+	// still alive and the second client ID is no longer confirmable.
+	third := exchangeIDOK(t, h, ctx, owner, eidVerifier("verify03"))
+	if third.ClientID == second.ClientID || third.ClientID == first.ClientID {
+		t.Fatalf("third EXCHANGE_ID reused a client ID (%d)", third.ClientID)
+	}
+	if got := sequenceOverallStatus(t, h, oldSession, 0, 1); got != types.NFS4_OK {
+		t.Fatalf("SEQUENCE on the confirmed session = %d, want NFS4_OK", got)
+	}
+	res := doCreateSession(t, h, ctx, second.ClientID, second.SequenceID)
+	if res.Status != types.NFS4ERR_STALE_CLIENTID {
+		t.Fatalf("CREATE_SESSION on the discarded client ID = %d, want NFS4ERR_STALE_CLIENTID (%d)",
+			res.Status, types.NFS4ERR_STALE_CLIENTID)
+	}
+}
+
+func TestExchangeID_PrincipalCollisionOnStatelessRecord(t *testing.T) {
+	h := newTestHandler()
+	owner := "collision-no-state"
+	ctx := ctxForUID(1111, 7)
+
+	first := exchangeIDOK(t, h, ctx, owner, eidVerifier("verify01"))
+	session := createSessionOK(t, h, ctx, first.ClientID, first.SequenceID)
+	if got := destroySession(t, h, ctx, session); got != types.NFS4_OK {
+		t.Fatalf("DESTROY_SESSION = %d, want NFS4_OK", got)
+	}
+
+	// The confirmed record holds nothing, so a colliding owner ID from another
+	// principal takes it over rather than being refused.
+	second := exchangeIDOK(t, h, ctxForUID(2222, 8), owner, eidVerifier("verify01"))
+	if second.ClientID == first.ClientID {
+		t.Fatalf("client ID unchanged (%d) -- a stateless record must be replaced", first.ClientID)
+	}
+}
+
+func TestExchangeID_PrincipalCollisionOnRecordWithState(t *testing.T) {
+	h := newTestHandler()
+	owner := "collision-with-state"
+	ctx := ctxForUID(1111, 7)
+
+	first := exchangeIDOK(t, h, ctx, owner, eidVerifier("verify01"))
+	session := createSessionOK(t, h, ctx, first.ClientID, first.SequenceID)
+
+	// The confirmed record still holds a session under a live lease, so the
+	// colliding principal is told to pick another owner ID.
+	res := doExchangeID(t, h, ctxForUID(2222, 8), owner, eidVerifier("verify01"), 0)
+	if res.Status != types.NFS4ERR_CLID_INUSE {
+		t.Fatalf("colliding EXCHANGE_ID = %d, want NFS4ERR_CLID_INUSE (%d)",
+			res.Status, types.NFS4ERR_CLID_INUSE)
+	}
+
+	// The refused request changed nothing.
+	if got := sequenceOverallStatus(t, h, session, 0, 1); got != types.NFS4_OK {
+		t.Errorf("SEQUENCE after a refused collision = %d, want NFS4_OK", got)
+	}
+}
+
+func TestExchangeID_ConfirmedIdempotentReturn(t *testing.T) {
+	h := newTestHandler()
+	owner := "confirmed-idempotent-compound"
+	ctx := ctxForUID(1111, 0)
+
+	first := exchangeIDOK(t, h, ctx, owner, eidVerifier("verify01"))
+	createSessionOK(t, h, ctx, first.ClientID, first.SequenceID)
+
+	second := exchangeIDOK(t, h, ctx, owner, eidVerifier("verify01"))
+	if second.ClientID != first.ClientID {
+		t.Errorf("client ID changed on a repeat EXCHANGE_ID: %d -> %d",
+			first.ClientID, second.ClientID)
+	}
+	if second.Flags&types.EXCHGID4_FLAG_CONFIRMED_R == 0 {
+		t.Error("eir_flags must carry CONFIRMED_R for an already confirmed record")
+	}
+}
+
+// ============================================================================
+// CREATE_SESSION confirmation phase (RFC 8881 Section 18.36.3)
+// ============================================================================
+
+func TestCreateSession_ConfirmationByOtherPrincipalRejected(t *testing.T) {
+	h := newTestHandler()
+
+	first := exchangeIDOK(t, h, ctxForUID(1111, 0), "confirm-other-principal",
+		eidVerifier("verify01"))
+
+	res := doCreateSession(t, h, ctxForUID(2222, 0), first.ClientID, first.SequenceID)
+	if res.Status != types.NFS4ERR_CLID_INUSE {
+		t.Fatalf("confirmation by another principal = %d, want NFS4ERR_CLID_INUSE (%d)",
+			res.Status, types.NFS4ERR_CLID_INUSE)
+	}
+
+	// No client record changed, so the owning principal can still confirm.
+	createSessionOK(t, h, ctxForUID(1111, 0), first.ClientID, first.SequenceID)
+}
+
+func TestCreateSession_PrincipalChangeAfterConfirmationAllowed(t *testing.T) {
+	h := newTestHandler()
+	ctx := ctxForUID(1111, 0)
+
+	first := exchangeIDOK(t, h, ctx, "confirm-then-change", eidVerifier("verify01"))
+	res1 := doCreateSession(t, h, ctx, first.ClientID, first.SequenceID)
+	if res1.Status != types.NFS4_OK {
+		t.Fatalf("first CREATE_SESSION = %d, want NFS4_OK", res1.Status)
+	}
+
+	// The client ID is already confirmed, so the confirmation phase is skipped
+	// and a second session may come from a different principal.
+	res2 := doCreateSession(t, h, ctxForUID(2222, 0), first.ClientID, res1.SequenceID+1)
+	if res2.Status != types.NFS4_OK {
+		t.Fatalf("second CREATE_SESSION from another principal = %d, want NFS4_OK", res2.Status)
+	}
+}
+
+func TestCreateSession_UnconfirmedRecordExpiresAfterALease(t *testing.T) {
+	sm := state.NewStateManager(20 * time.Millisecond)
+	h := NewHandler(nil, pseudofs.New(), sm)
+	ctx := newTestCompoundContext()
+
+	first := exchangeIDOK(t, h, ctx, "expiring-unconfirmed", eidVerifier("verify01"))
+
+	// Inside the lease period the client ID still confirms.
+	inside := exchangeIDOK(t, h, ctx, "inside-lease", eidVerifier("verify01"))
+	createSessionOK(t, h, ctx, inside.ClientID, inside.SequenceID)
+
+	time.Sleep(40 * time.Millisecond)
+
+	res := doCreateSession(t, h, ctx, first.ClientID, first.SequenceID)
+	if res.Status != types.NFS4ERR_STALE_CLIENTID {
+		t.Fatalf("CREATE_SESSION after the lease period = %d, want NFS4ERR_STALE_CLIENTID (%d)",
+			res.Status, types.NFS4ERR_STALE_CLIENTID)
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/exchange_id_handler_test.go
+++ b/internal/adapter/nfs/v4/handlers/exchange_id_handler_test.go
@@ -188,40 +188,6 @@ func TestHandleExchangeID_BadXDR(t *testing.T) {
 	}
 }
 
-func TestHandleExchangeID_Idempotent(t *testing.T) {
-	h := newTestHandler()
-	ctx := newTestCompoundContext()
-
-	ownerID := []byte("idempotent-handler-client")
-	var verifier [8]byte
-	copy(verifier[:], "testverf")
-
-	args := encodeExchangeIdArgs(ownerID, verifier, 0, types.SP4_NONE, nil)
-
-	// First call
-	ops1 := []compoundOp{{opCode: types.OP_EXCHANGE_ID, data: args}}
-	data1 := buildCompoundArgsWithOps([]byte("idem1"), 1, ops1)
-	resp1, err := h.ProcessCompound(ctx, data1)
-	if err != nil {
-		t.Fatalf("ProcessCompound #1 error: %v", err)
-	}
-
-	// Second call with same args
-	ops2 := []compoundOp{{opCode: types.OP_EXCHANGE_ID, data: args}}
-	data2 := buildCompoundArgsWithOps([]byte("idem2"), 1, ops2)
-	resp2, err := h.ProcessCompound(ctx, data2)
-	if err != nil {
-		t.Fatalf("ProcessCompound #2 error: %v", err)
-	}
-
-	clientID1 := extractClientIDFromResponse(t, resp1)
-	clientID2 := extractClientIDFromResponse(t, resp2)
-
-	if clientID1 != clientID2 {
-		t.Errorf("ClientIDs differ (%d vs %d) for idempotent call", clientID1, clientID2)
-	}
-}
-
 func TestHandleExchangeID_WithImplId(t *testing.T) {
 	h := newTestHandler()
 	ctx := newTestCompoundContext()
@@ -293,27 +259,4 @@ func TestHandleExchangeID_FollowedByPutRootFH(t *testing.T) {
 	}
 
 	expectPutRootFHOK(t, reader)
-}
-
-// extractClientIDFromResponse extracts the client ID from a single-op
-// EXCHANGE_ID compound response.
-func extractClientIDFromResponse(t *testing.T, resp []byte) uint64 {
-	t.Helper()
-	reader := bytes.NewReader(resp)
-
-	status, _ := xdr.DecodeUint32(reader)
-	if status != types.NFS4_OK {
-		t.Fatalf("overall status = %d, want NFS4_OK", status)
-	}
-
-	_, _ = xdr.DecodeOpaque(reader) // tag
-	_, _ = xdr.DecodeUint32(reader) // numResults
-	_, _ = xdr.DecodeUint32(reader) // opcode
-
-	var res types.ExchangeIdRes
-	if err := res.Decode(reader); err != nil {
-		t.Fatalf("decode ExchangeIdRes: %v", err)
-	}
-
-	return res.ClientID
 }

--- a/internal/adapter/nfs/v4/state/client.go
+++ b/internal/adapter/nfs/v4/state/client.go
@@ -100,6 +100,13 @@ type ClientRecord struct {
 	// SETCLIENTID_CONFIRM on v4.0, CREATE_SESSION on v4.1.
 	Confirmed bool
 
+	// Superseded is the confirmed record this unconfirmed one replaces once it
+	// is itself confirmed. v4.1 only: a restarted client's new incarnation is
+	// registered alongside the old one, which keeps its client ID, sessions and
+	// locking state until the replacement's CREATE_SESSION collapses the two.
+	// Nil on every other record.
+	Superseded *ClientRecord
+
 	// Callback holds the client's callback information for delegations.
 	// v4.0 only: a v4.1 client's callbacks travel over the session
 	// backchannel, which carries no separate address.

--- a/internal/adapter/nfs/v4/state/client_recovery_test.go
+++ b/internal/adapter/nfs/v4/state/client_recovery_test.go
@@ -414,7 +414,7 @@ func TestClientRecovery_V41PersistAndReclaimComplete(t *testing.T) {
 		t.Fatalf("ExchangeID: %v", err)
 	}
 	// First CREATE_SESSION confirms + persists.
-	if _, _, err := sm.CreateSession(exch.ClientID, exch.SequenceID, 0, types.ChannelAttrs{}, types.ChannelAttrs{}, 0, nil); err != nil {
+	if _, _, err := sm.CreateSession(exch.ClientID, exch.SequenceID, 0, types.ChannelAttrs{}, types.ChannelAttrs{}, 0, nil, "uid:0"); err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
 

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -3382,6 +3382,7 @@ func (sm *StateManager) CreateSession(
 	foreAttrs, backAttrs types.ChannelAttrs,
 	cbProgram uint32,
 	cbSecParms []types.CallbackSecParms4,
+	principal ...string,
 ) (*CreateSessionResult, []byte, error) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
@@ -3390,6 +3391,29 @@ func (sm *StateManager) CreateSession(
 	record, exists := sm.v41ClientsByID[clientID]
 	if !exists {
 		return nil, nil, ErrStaleClientID
+	}
+
+	// An unconfirmed record not confirmed within a lease period is gone, so its
+	// client ID no longer resolves (RFC 8881 Section 18.35.4). Checked here as
+	// well as in the reaper so the client ID stops working the moment the lease
+	// has passed rather than at the next sweep.
+	if !record.Confirmed && time.Since(record.CreatedAt) > sm.leaseDuration {
+		logger.Debug("CREATE_SESSION: unconfirmed client record expired",
+			"client_id", fmt.Sprintf("0x%x", clientID),
+			"age", time.Since(record.CreatedAt).String())
+		sm.purgeV41Client(record)
+		return nil, nil, ErrStaleClientID
+	}
+
+	// Confirming a record is where its principal is bound, so a confirmation
+	// from another principal is a client-ID collision rather than the expected
+	// confirmation, and nothing on the server changes (RFC 8881 Section
+	// 18.36.3). A record already confirmed skips the confirmation phase
+	// entirely, which is why a later principal change is allowed.
+	if !record.Confirmed && principalHijacks(record.Principal, firstOrEmpty(principal)) {
+		logger.Debug("CREATE_SESSION: confirmation attempted by another principal",
+			"client_id", fmt.Sprintf("0x%x", clientID))
+		return nil, nil, ErrClientIDInUse
 	}
 
 	// Case 2: Replay (same seqid)
@@ -3438,6 +3462,11 @@ func (sm *StateManager) CreateSession(
 
 	// First CREATE_SESSION confirms the client
 	if !record.Confirmed {
+		// A record established by the client-restart case replaces the confirmed
+		// record it superseded, which is destroyed here now that the session is
+		// created (RFC 8881 Section 18.36.3).
+		sm.collapseSupersededLocked(record)
+
 		record.Confirmed = true
 		record.Lease = NewLeaseState(record.ClientID, sm.leaseDuration, nil)
 		record.LastRenewal = time.Now()
@@ -3617,7 +3646,7 @@ func (sm *StateManager) ListSessionsForClient(clientID uint64) []*Session {
 //
 // The reaper runs every 30 seconds and checks:
 //   - Clients with expired leases: destroys all sessions, purges client
-//   - Unconfirmed clients older than 2x lease duration: purges client
+//   - Unconfirmed clients older than the lease duration: purges client
 //
 // Stops when ctx is cancelled.
 func (sm *StateManager) StartSessionReaper(ctx context.Context) {
@@ -3661,8 +3690,9 @@ func (sm *StateManager) reapExpiredSessions() {
 			continue
 		}
 
-		// Check for unconfirmed clients that timed out
-		if !record.Confirmed && now.Sub(record.CreatedAt) > 2*sm.leaseDuration {
+		// Check for unconfirmed clients that timed out. A record not confirmed
+		// within a lease period is removed (RFC 8881 Section 18.35.4).
+		if !record.Confirmed && now.Sub(record.CreatedAt) > sm.leaseDuration {
 			logger.Info("Session reaper: unconfirmed client timed out",
 				"client_id", fmt.Sprintf("0x%x", record.ClientID),
 				"client_addr", record.ClientAddr,

--- a/internal/adapter/nfs/v4/state/stateid_authz_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_authz_test.go
@@ -253,11 +253,15 @@ func TestUnlockFile_V41Seqid0(t *testing.T) {
 }
 
 // TestExchangeID_Case2_PrincipalMismatch is the negative control for the
-// EXCHANGE_ID Case 2 principal-mismatch fix (v41_client.go). RFC 8881
-// Section 18.35.4 requires NFS4ERR_CLID_INUSE when the existing record's
-// principal differs from the incoming one. Before the fix Case 2 unconditionally
-// overwrote the principal, allowing a peer that knows the owner ID + verifier to
-// hijack the client.
+// EXCHANGE_ID principal-mismatch guard (v41_client.go). RFC 8881
+// Section 18.35.4 case 3 requires NFS4ERR_CLID_INUSE when the record's
+// principal differs from the incoming one and that record still holds state
+// under a live lease; without the guard a peer that knows the owner ID +
+// verifier hijacks the client's lease and state.
+//
+// The record has to be confirmed and holding a session for the guard to apply:
+// an unconfirmed record is replaced outright by case 4, and a confirmed record
+// holding nothing is taken over by case 3 itself.
 func TestExchangeID_Case2_PrincipalMismatch(t *testing.T) {
 	sm := NewStateManager(90 * time.Second)
 	defer sm.Shutdown()
@@ -265,16 +269,22 @@ func TestExchangeID_Case2_PrincipalMismatch(t *testing.T) {
 	ownerID := []byte("client-owner-principal")
 	verifier := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
 
-	// Establish the record under principal "alice".
-	if _, err := sm.ExchangeID(ownerID, verifier, 0, nil, "10.0.0.1:12345", "alice"); err != nil {
+	// Establish the record under principal "alice" and confirm it, so it holds
+	// a session.
+	exch, err := sm.ExchangeID(ownerID, verifier, 0, nil, "10.0.0.1:12345", "alice")
+	if err != nil {
 		t.Fatalf("ExchangeID (alice): %v", err)
+	}
+	if _, _, err := sm.CreateSession(exch.ClientID, exch.SequenceID, 0,
+		types.ChannelAttrs{}, types.ChannelAttrs{}, 0, nil, "alice"); err != nil {
+		t.Fatalf("CreateSession (alice): %v", err)
 	}
 
 	// A peer that knows the owner ID + verifier replays EXCHANGE_ID under a
 	// different principal -- must be rejected with NFS4ERR_CLID_INUSE.
-	_, err := sm.ExchangeID(ownerID, verifier, 0, nil, "10.0.0.9:12345", "mallory")
+	_, err = sm.ExchangeID(ownerID, verifier, 0, nil, "10.0.0.9:12345", "mallory")
 	if err == nil {
-		t.Fatal("EXCHANGE_ID Case 2 with a different principal must be rejected")
+		t.Fatal("EXCHANGE_ID with a different principal must be rejected")
 	}
 	if err != ErrClientIDInUse {
 		t.Errorf("expected ErrClientIDInUse, got %v", err)

--- a/internal/adapter/nfs/v4/state/v41_client.go
+++ b/internal/adapter/nfs/v4/state/v41_client.go
@@ -91,20 +91,60 @@ type ExchangeIDResult struct {
 // ExchangeID Algorithm (RFC 8881 Section 18.35)
 // ============================================================================
 
+// Sentinels for the EXCHANGE_ID update cases. They carry their own wire status
+// so the handler maps them without a per-error case.
+var (
+	// ErrNoConfirmedRecord indicates an update request found no confirmed
+	// record for the owner ID.
+	ErrNoConfirmedRecord = &NFS4StateError{
+		Status:  types.NFS4ERR_NOENT,
+		Message: "no confirmed client record for this owner ID",
+	}
+
+	// ErrVerifierNotSame indicates an update request carried a verifier other
+	// than the confirmed record's.
+	ErrVerifierNotSame = &NFS4StateError{
+		Status:  types.NFS4ERR_NOT_SAME,
+		Message: "update verifier does not match the confirmed record",
+	}
+
+	// ErrUpdateNotPermitted indicates an update request came from a principal
+	// other than the one that established the confirmed record.
+	ErrUpdateNotPermitted = &NFS4StateError{
+		Status:  types.NFS4ERR_PERM,
+		Message: "update by a principal other than the record's",
+	}
+)
+
 // ExchangeID implements the NFSv4.1 EXCHANGE_ID multi-case algorithm per
-// RFC 8881 Section 18.35.
+// RFC 8881 Section 18.35.4, whose case numbers the branches below name.
 //
-// The algorithm determines the action based on whether the server has an
-// existing record for the client's owner ID:
+// Without EXCHGID4_FLAG_UPD_CONFIRMED_REC_A in flags the request establishes or
+// replaces a record:
 //
-//   - Case 1 (new client): No existing record -> create new client with fresh clientID
-//   - Case 2 (same owner+verifier): Existing record with matching verifier -> idempotent return
-//   - Case 3 (same owner, different verifier): Client reboot -> replace with fresh clientID
-//   - Case 4 (unconfirmed record exists): Supersede unconfirmed record
+//   - Case 1, new owner ID: create an unconfirmed record with a fresh client ID.
+//   - Case 2, non-update on a confirmed record whose verifier and principal both
+//     match: return the same client ID and leave the record alone.
+//   - Case 3, client collision -- a confirmed record whose principal differs:
+//     replace it if it holds no state under a live lease, otherwise refuse with
+//     NFS4ERR_CLID_INUSE and change nothing.
+//   - Case 4, replacement of an unconfirmed record: discard it whatever its
+//     verifier and principal and create a fresh one, so the owner ID never has
+//     two readings at once.
+//   - Case 5, client restart -- a confirmed record, same principal, different
+//     verifier: add an unconfirmed record with a fresh client ID and keep the
+//     confirmed record and its state until CREATE_SESSION confirms the new one.
 //
-// The flags parameter from the client is currently ignored; the server always
-// sets EXCHGID4_FLAG_USE_NON_PNFS. EXCHGID4_FLAG_CONFIRMED_R is set only
-// if the record has been confirmed via CREATE_SESSION.
+// With the flag set the request is an update of an existing confirmed record:
+//
+//   - Case 6: verifier and principal both match -- apply the update in place.
+//   - Case 7: no confirmed record -- NFS4ERR_NOENT, any unconfirmed record left
+//     intact.
+//   - Case 8: verifier differs -- NFS4ERR_NOT_SAME.
+//   - Case 9: principal differs -- NFS4ERR_PERM.
+//
+// The server always sets EXCHGID4_FLAG_USE_NON_PNFS in the result, and adds
+// EXCHGID4_FLAG_CONFIRMED_R when the record it returns is confirmed.
 //
 // Caller must NOT hold sm.mu.
 // The trailing principal is variadic so existing callers/tests that do not
@@ -112,7 +152,7 @@ type ExchangeIDResult struct {
 func (sm *StateManager) ExchangeID(
 	ownerID []byte,
 	verifier [8]byte,
-	_ uint32,
+	flags uint32,
 	clientImplId []types.NfsImplId4,
 	clientAddr string,
 	principal ...string,
@@ -121,32 +161,70 @@ func (sm *StateManager) ExchangeID(
 	defer sm.mu.Unlock()
 
 	princ := firstOrEmpty(principal)
-	existing := sm.v41ClientsByOwner[string(ownerID)]
+	ownerKey := string(ownerID)
+	existing := sm.v41ClientsByOwner[ownerKey]
+
+	// A record that superseded a still-live confirmed one is discarded here and
+	// hands the owner ID back, so the rest of the algorithm sees a single record
+	// per owner (case 5, "delete the unconfirmed record and process the
+	// EXCHANGE_ID in its entirety").
+	if existing != nil && existing.Superseded != nil {
+		logger.Debug("EXCHANGE_ID: discarding a superseding record that was never confirmed",
+			"client_id", existing.ClientID,
+			"client_addr", clientAddr)
+		sm.purgeV41Client(existing)
+		existing = sm.v41ClientsByOwner[ownerKey]
+	}
+
+	if flags&types.EXCHGID4_FLAG_UPD_CONFIRMED_REC_A != 0 {
+		return sm.exchangeIDUpdateLocked(existing, verifier, clientImplId, clientAddr, princ)
+	}
 
 	var record *ClientRecord
 
 	switch {
 	case existing == nil:
-		// Case 1: New client -- no existing record for this owner
+		// Case 1: new owner ID.
 		record = sm.createV41Client(ownerID, verifier, clientImplId, clientAddr, princ)
 		logger.Info("EXCHANGE_ID: new v4.1 client registered",
 			"client_id", record.ClientID,
 			"client_addr", clientAddr)
 
-	case existing.Verifier == verifier:
-		// Case 2: Same owner + same verifier -- idempotent return.
-		// Reject an EXCHANGE_ID by anyone but the principal that established the
-		// existing record (RFC 8881 Section 18.35.4 case 9; mirrors the v4.0
-		// SETCLIENTID guard in reuseConfirmedClient). Without it a third party
-		// that knows a confirmed client's co_ownerid + co_verifier overwrites
-		// the stored principal and hijacks the client's lease and state. See
-		// principalHijacks.
-		if principalHijacks(existing.Principal, princ) {
+	case !existing.Confirmed:
+		// Case 4: replacement of an unconfirmed record.
+		sm.purgeV41Client(existing)
+		record = sm.createV41Client(ownerID, verifier, clientImplId, clientAddr, princ)
+		logger.Info("EXCHANGE_ID: new v4.1 client",
+			"reason", "replaced unconfirmed",
+			"old_client_id", existing.ClientID,
+			"new_client_id", record.ClientID,
+			"client_addr", clientAddr)
+
+	case principalHijacks(existing.Principal, princ):
+		// Case 3: client collision. A confirmed record still holding state under
+		// a live lease belongs to a working client, so the caller is told to pick
+		// another owner ID rather than having that client's state deleted under
+		// it. A record holding nothing is taken over instead.
+		if sm.v41ClientHasStateLocked(existing) {
+			logger.Debug("EXCHANGE_ID: owner ID collision with a client that holds state",
+				"client_id", existing.ClientID,
+				"client_addr", clientAddr)
 			return nil, ErrClientIDInUse
 		}
+		sm.purgeV41Client(existing)
+		record = sm.createV41Client(ownerID, verifier, clientImplId, clientAddr, princ)
+		logger.Info("EXCHANGE_ID: new v4.1 client",
+			"reason", "owner ID collision, previous client held no state",
+			"old_client_id", existing.ClientID,
+			"new_client_id", record.ClientID,
+			"client_addr", clientAddr)
+
+	case existing.Verifier == verifier:
+		// Case 2: non-update on a confirmed record. Only the properties the
+		// server tracks move; the record itself is unchanged.
 		existing.ClientAddr = clientAddr
 		// Only adopt a non-empty incoming principal; never clear a stored
-		// principal with an empty one (that would weaken the hijack guard).
+		// principal with an empty one (that would weaken the collision guard).
 		if princ != "" {
 			existing.Principal = princ
 		}
@@ -158,23 +236,73 @@ func (sm *StateManager) ExchangeID(
 			"client_addr", clientAddr)
 
 	default:
-		// Cases 3 & 4: Different verifier -- purge and replace.
-		// Case 4 (unconfirmed) and Case 3 (confirmed reboot) take the same
-		// action: discard the old record and create a fresh one.
-		reason := "client reboot detected"
-		if !existing.Confirmed {
-			reason = "replaced unconfirmed"
-		}
-		sm.purgeV41Client(existing)
+		// Case 5: client restart. The new incarnation gets its own unconfirmed
+		// record; the previous one keeps its client ID, sessions and locks until
+		// CREATE_SESSION confirms the replacement.
 		record = sm.createV41Client(ownerID, verifier, clientImplId, clientAddr, princ)
+		record.Superseded = existing
 		logger.Info("EXCHANGE_ID: new v4.1 client",
-			"reason", reason,
+			"reason", "client reboot detected",
 			"old_client_id", existing.ClientID,
 			"new_client_id", record.ClientID,
 			"client_addr", clientAddr)
 	}
 
-	// Build result flags
+	return sm.exchangeIDResultLocked(record), nil
+}
+
+// exchangeIDUpdateLocked handles an EXCHANGE_ID that carries
+// EXCHGID4_FLAG_UPD_CONFIRMED_REC_A (RFC 8881 Section 18.35.4 cases 6-9).
+// existing is the record the owner ID currently resolves to, or nil.
+//
+// Caller must hold sm.mu.
+func (sm *StateManager) exchangeIDUpdateLocked(
+	existing *ClientRecord,
+	verifier [8]byte,
+	clientImplId []types.NfsImplId4,
+	clientAddr string,
+	princ string,
+) (*ExchangeIDResult, error) {
+	// Case 7: there is no confirmed record to update. An unconfirmed record is
+	// not updatable and is left intact for its own CREATE_SESSION.
+	if existing == nil || !existing.Confirmed {
+		return nil, ErrNoConfirmedRecord
+	}
+
+	// Case 8: the verifier belongs to another incarnation, which cannot update
+	// this record. Reported ahead of the principal, matching the case-8 record
+	// pattern that leaves the principal unconstrained.
+	if existing.Verifier != verifier {
+		return nil, ErrVerifierNotSame
+	}
+
+	// Case 9: only the principal that established the record may update it.
+	if principalHijacks(existing.Principal, princ) {
+		return nil, ErrUpdateNotPermitted
+	}
+
+	// Case 6: the update is allowed and the client record is left intact apart
+	// from the properties it carries.
+	existing.ClientAddr = clientAddr
+	if princ != "" {
+		existing.Principal = princ
+	}
+	existing.LastRenewal = time.Now()
+	applyImplInfo(existing, clientImplId)
+
+	logger.Debug("EXCHANGE_ID: updated confirmed v4.1 client",
+		"client_id", existing.ClientID,
+		"client_addr", clientAddr)
+
+	return sm.exchangeIDResultLocked(existing), nil
+}
+
+// exchangeIDResultLocked builds the EXCHANGE_ID reply for a record.
+//
+// Caller must hold sm.mu.
+func (sm *StateManager) exchangeIDResultLocked(record *ClientRecord) *ExchangeIDResult {
+	// EXCHGID4_FLAG_UPD_CONFIRMED_REC_A is never reflected back; CONFIRMED_R
+	// reports whether the record returned has been confirmed.
 	resultFlags := uint32(types.EXCHGID4_FLAG_USE_NON_PNFS)
 	if record.Confirmed {
 		resultFlags |= types.EXCHGID4_FLAG_CONFIRMED_R
@@ -191,7 +319,68 @@ func (sm *StateManager) ExchangeID(
 		ServerOwner:  sm.serverIdentity.ServerOwner,
 		ServerScope:  sm.serverIdentity.ServerScope,
 		ServerImplId: []types.NfsImplId4{sm.serverIdentity.ImplID},
-	}, nil
+	}
+}
+
+// v41ClientHasStateLocked reports whether a client still holds state a colliding
+// owner ID must not destroy: an active session, an open owner, a byte-range lock
+// or a delegation. A client whose lease has already expired holds nothing that
+// needs protecting (RFC 8881 Section 18.35.4 case 3).
+//
+// ponytail: linear scans of the open-owner, lock and delegation indexes, none of
+// which is keyed by client ID; this runs once per colliding EXCHANGE_ID, so add
+// a per-client index only if a profile says these scans matter.
+//
+// Caller must hold sm.mu.
+func (sm *StateManager) v41ClientHasStateLocked(record *ClientRecord) bool {
+	if record.Lease != nil && record.Lease.IsExpired() {
+		return false
+	}
+	if len(sm.sessionsByClientID[record.ClientID]) > 0 {
+		return true
+	}
+	for _, owner := range sm.openOwners {
+		if owner.ClientID == record.ClientID {
+			return true
+		}
+	}
+	for _, lockState := range sm.lockStateByOther {
+		if lockState.LockOwner != nil && lockState.LockOwner.ClientID == record.ClientID {
+			return true
+		}
+	}
+	for _, deleg := range sm.delegByOther {
+		if deleg.ClientID == record.ClientID {
+			return true
+		}
+	}
+	return false
+}
+
+// collapseSupersededLocked destroys the confirmed record a newly confirmed one
+// replaces, together with its sessions and locking state. Called when
+// CREATE_SESSION confirms a record established by the client-restart case, which
+// is where the owner ID's two records collapse into one (RFC 8881 Sections
+// 18.35.4 case 5 and 18.36.3).
+//
+// The superseded record is looked up by client ID rather than trusted directly,
+// so a reaper that already removed it is not purged twice.
+//
+// Caller must hold sm.mu.
+func (sm *StateManager) collapseSupersededLocked(record *ClientRecord) {
+	superseded := record.Superseded
+	record.Superseded = nil
+	if superseded == nil {
+		return
+	}
+	if sm.v41ClientsByID[superseded.ClientID] != superseded {
+		return
+	}
+
+	logger.Info("CREATE_SESSION: destroying the client incarnation this one replaces",
+		"old_client_id", superseded.ClientID,
+		"new_client_id", record.ClientID)
+	sm.purgeV41Client(superseded)
 }
 
 // createV41Client creates and stores a new ClientRecord.
@@ -243,7 +432,9 @@ func applyImplInfo(record *ClientRecord, clientImplId []types.NfsImplId4) {
 // purgeV41Client removes a ClientRecord from both lookup maps, releases the
 // open and lock state its owners hold, and destroys all associated sessions.
 // Only deletes from v41ClientsByOwner if the map entry still points to this
-// record (guards against a concurrent createV41Client having already replaced it).
+// record (guards against a concurrent createV41Client having already replaced it);
+// where the record superseded a still-live confirmed one, the owner ID goes back
+// to that record instead of being dropped.
 // Caller must hold sm.mu.
 func (sm *StateManager) purgeV41Client(record *ClientRecord) {
 	// Drop the durable recovery record: a purged client (eviction, DESTROY_CLIENTID,
@@ -283,7 +474,15 @@ func (sm *StateManager) purgeV41Client(record *ClientRecord) {
 	delete(sm.v41ClientsByID, record.ClientID)
 	ownerKey := string(record.OwnerID)
 	if existing := sm.v41ClientsByOwner[ownerKey]; existing == record {
-		delete(sm.v41ClientsByOwner, ownerKey)
+		// A record that superseded a still-live confirmed one hands the owner ID
+		// back to it, so the confirmed client remains reachable by owner ID once
+		// its unconfirmed replacement is gone.
+		if superseded := record.Superseded; superseded != nil &&
+			sm.v41ClientsByID[superseded.ClientID] == superseded {
+			sm.v41ClientsByOwner[ownerKey] = superseded
+		} else {
+			delete(sm.v41ClientsByOwner, ownerKey)
+		}
 	}
 }
 

--- a/internal/adapter/nfs/v4/state/v41_client_test.go
+++ b/internal/adapter/nfs/v4/state/v41_client_test.go
@@ -53,7 +53,7 @@ func TestExchangeID_NewClient(t *testing.T) {
 	}
 }
 
-func TestExchangeID_SameOwnerSameVerifier(t *testing.T) {
+func TestExchangeID_SameOwnerSameVerifierUnconfirmed(t *testing.T) {
 	sm := NewStateManager(DefaultLeaseDuration)
 
 	ownerID := []byte("idempotent-client")
@@ -70,12 +70,20 @@ func TestExchangeID_SameOwnerSameVerifier(t *testing.T) {
 		t.Fatalf("ExchangeID #2 error: %v", err)
 	}
 
-	// Same owner + same verifier = same clientID (idempotent)
-	if result1.ClientID != result2.ClientID {
-		t.Errorf("ClientIDs differ: %d vs %d (should be idempotent)", result1.ClientID, result2.ClientID)
+	// The first record was never confirmed, so the repeat request replaces it
+	// with a fresh client ID rather than returning the same one.
+	if result1.ClientID == result2.ClientID {
+		t.Errorf("ClientID unchanged (%d): an unconfirmed record must be replaced", result1.ClientID)
 	}
-	if result1.SequenceID != result2.SequenceID {
-		t.Errorf("SequenceIDs differ: %d vs %d", result1.SequenceID, result2.SequenceID)
+	if result2.SequenceID != 1 {
+		t.Errorf("SequenceID on the replacement = %d, want 1", result2.SequenceID)
+	}
+
+	sm.mu.RLock()
+	_, existsOld := sm.v41ClientsByID[result1.ClientID]
+	sm.mu.RUnlock()
+	if existsOld {
+		t.Error("the replaced unconfirmed record should have been purged")
 	}
 }
 
@@ -392,12 +400,13 @@ func TestExchangeID_ConfirmedReboot(t *testing.T) {
 		t.Fatalf("ExchangeID #1 error: %v", err)
 	}
 
-	// Simulate confirmation
-	sm.mu.Lock()
-	sm.v41ClientsByID[result1.ClientID].Confirmed = true
-	sm.mu.Unlock()
+	// Confirm the first incarnation the way a client does.
+	if _, _, err := sm.CreateSession(result1.ClientID, result1.SequenceID, 0,
+		types.ChannelAttrs{}, types.ChannelAttrs{}, 0, nil); err != nil {
+		t.Fatalf("CreateSession error: %v", err)
+	}
 
-	// Reboot with different verifier -> Case 3
+	// Reboot with a different verifier -> case 5
 	result2, err := sm.ExchangeID(ownerID, verifier2, 0, nil, "10.0.0.1:12345")
 	if err != nil {
 		t.Fatalf("ExchangeID #2 error: %v", err)
@@ -407,18 +416,35 @@ func TestExchangeID_ConfirmedReboot(t *testing.T) {
 		t.Error("ClientID should change after reboot of confirmed client")
 	}
 
-	// Verify old record is gone
+	// The previous incarnation survives until the new client ID is confirmed,
+	// and the owner ID now resolves to the new record.
 	sm.mu.RLock()
 	_, existsOld := sm.v41ClientsByID[result1.ClientID]
+	byOwner := sm.v41ClientsByOwner[string(ownerID)]
 	sm.mu.RUnlock()
 
-	if existsOld {
-		t.Error("Old confirmed client should be purged after reboot")
+	if !existsOld {
+		t.Error("Old confirmed client should survive until the new client ID is confirmed")
+	}
+	if byOwner == nil || byOwner.ClientID != result2.ClientID {
+		t.Error("Owner ID should resolve to the new unconfirmed record")
 	}
 
 	// New record should not have CONFIRMED_R
 	if result2.Flags&types.EXCHGID4_FLAG_CONFIRMED_R != 0 {
 		t.Error("New client after reboot should not have CONFIRMED_R")
+	}
+
+	// Confirming the new client ID collapses the two records into one.
+	if _, _, err := sm.CreateSession(result2.ClientID, result2.SequenceID, 0,
+		types.ChannelAttrs{}, types.ChannelAttrs{}, 0, nil); err != nil {
+		t.Fatalf("CreateSession on the new incarnation: %v", err)
+	}
+	sm.mu.RLock()
+	_, existsOld = sm.v41ClientsByID[result1.ClientID]
+	sm.mu.RUnlock()
+	if existsOld {
+		t.Error("Old confirmed client should be purged once the reboot is confirmed")
 	}
 }
 

--- a/internal/adapter/nfs/v4/v41/handlers/create_session.go
+++ b/internal/adapter/nfs/v4/v41/handlers/create_session.go
@@ -46,6 +46,7 @@ func HandleCreateSession(d *Deps, ctx *types.CompoundContext, _ *types.V41Reques
 		args.BackChannelAttrs,
 		args.CbProgram,
 		args.CbSecParms,
+		ctx.Principal(),
 	)
 
 	// Replay case: return cached XDR response bytes directly

--- a/internal/adapter/nfs/v4/v41/handlers/exchange_id.go
+++ b/internal/adapter/nfs/v4/v41/handlers/exchange_id.go
@@ -12,7 +12,9 @@ import (
 // Registers a v4.1 client with the server and returns a client ID for session creation.
 // Delegates to StateManager.ExchangeID for multi-case algorithm logic; rejects SP4_MACH_CRED/SP4_SSV.
 // Creates or updates client record; returns clientid, sequence ID, and server capabilities.
-// Errors: NFS4ERR_CLID_INUSE, NFS4ERR_ENCR_ALG_UNSUPP (non-SP4_NONE), NFS4ERR_BADXDR.
+// Rejects eia_flags bits that are undefined or reply-only.
+// Errors: NFS4ERR_INVAL (bad eia_flags), NFS4ERR_CLID_INUSE, NFS4ERR_NOENT,
+// NFS4ERR_NOT_SAME, NFS4ERR_PERM, NFS4ERR_ENCR_ALG_UNSUPP (non-SP4_NONE), NFS4ERR_BADXDR.
 func HandleExchangeID(d *Deps, ctx *types.CompoundContext, _ *types.V41RequestContext, reader io.Reader) *types.CompoundResult {
 	var args types.ExchangeIdArgs
 	if err := args.Decode(reader); err != nil {
@@ -21,6 +23,25 @@ func HandleExchangeID(d *Deps, ctx *types.CompoundContext, _ *types.V41RequestCo
 			Status: types.NFS4ERR_BADXDR,
 			OpCode: types.OP_EXCHANGE_ID,
 			Data:   EncodeStatusOnly(types.NFS4ERR_BADXDR),
+		}
+	}
+
+	// eia_flags may carry only the bits defined for the argument direction:
+	// EXCHGID4_FLAG_MASK_A, plus the fencing capability a v4.2 client may
+	// request. Reply-only bits (EXCHGID4_FLAG_CONFIRMED_R) sit outside that
+	// mask, so a client that sets one is refused here along with any bit that
+	// carries no meaning at all.
+	allowedFlags := uint32(types.EXCHGID4_FLAG_MASK_A)
+	if ctx.MinorVersion >= 2 {
+		allowedFlags |= types.EXCHGID4_FLAG_SUPP_FENCE_OPS
+	}
+	if args.Flags&^allowedFlags != 0 {
+		logger.Debug("EXCHANGE_ID: rejecting undefined eia_flags bits",
+			"flags", args.Flags, "allowed", allowedFlags, "client", ctx.ClientAddr)
+		return &types.CompoundResult{
+			Status: types.NFS4ERR_INVAL,
+			OpCode: types.OP_EXCHANGE_ID,
+			Data:   EncodeStatusOnly(types.NFS4ERR_INVAL),
 		}
 	}
 


### PR DESCRIPTION
Closes #2470

`EXCHANGE_ID` validated none of `eia_flags`, and the client-record algorithm
collapsed five of RFC 8881 Section 18.35.4's nine cases into three. This
implements the section as written, plus the confirmation phase of Section
18.36.3 that decides which principal may confirm a client ID.

## What was actually wrong

**No `eia_flags` validation.** `HandleExchangeID` rejected a non-`SP4_NONE`
state-protect choice and nothing else. An undefined bit and the reply-only
`EXCHGID4_FLAG_CONFIRMED_R` both registered the client and returned
`NFS4_OK`. Both must be `NFS4ERR_INVAL`. One mask check covers them, since
`EXCHGID4_FLAG_MASK_A` already excludes the reply-only bits.

**`EXCHGID4_FLAG_UPD_CONFIRMED_REC_A` was ignored entirely** — the flags
argument was a `_` parameter. Cases 6-9 did not exist, so an update request
was processed as a non-update: it registered a client instead of returning
`NFS4ERR_NOENT`, `NFS4ERR_NOT_SAME` or `NFS4ERR_PERM`.

**An unconfirmed record was only replaced when the verifier changed.** Case 4
replaces it whatever the verifier and principal, so the owner ID never has two
readings at once. With the same verifier the server returned the same client ID
(the case-2 path), and with the same verifier plus a different principal it
returned `NFS4ERR_CLID_INUSE`.

**A confirmed client's state was destroyed too early.** Case 5 (client restart)
requires the new incarnation to get its own unconfirmed record while the
confirmed record keeps its client ID, sessions and locks until `CREATE_SESSION`
confirms the replacement. The old code purged the confirmed record inside
`EXCHANGE_ID`, so a client that restarted and then failed to confirm had lost
its state for nothing.

**A colliding owner ID refused unconditionally.** Case 3 refuses with
`NFS4ERR_CLID_INUSE` only while the confirmed record still holds state under a
live lease; a record holding nothing is taken over. The old guard refused any
principal mismatch, so an owner ID could never be recovered after its client
went away.

**`CREATE_SESSION` never checked who was confirming.** Section 18.36.3 binds the
principal at confirmation: a confirmation from another principal is a client-ID
collision (`NFS4ERR_CLID_INUSE`), and nothing on the server changes. A record
already confirmed skips the confirmation phase, which is why a *later* principal
change stays legal — `CSESS10` covers that direction and still passes.

**Unconfirmed records outlived their lease by 2x.** Section 18.35.4 says a
record not confirmed within a lease period is removed; the reaper used
`2*leaseDuration` and swept on a 30s tick. The threshold is now one lease, and
`CREATE_SESSION` also refuses a record already past it, so the client ID stops
resolving at the lease boundary rather than at the next sweep.

## Premises checked

Everything the issue claims was reproduced as a failing test first, at the
`ProcessCompound` entry point, before any production change. Two refinements:

- **The row count is 16 only if the bare `EID6` row is included.** The issue's
  enumeration — `EID4`, `EID5c/5d/5f/5g`, `EID6a`-`EID6g`, `EID7`, `EID9`,
  `CSESS9` — is 15 names. `test/nfs-conformance/pynfs/KNOWN_FAILURES_V41.md`
  also carries a bare `EID6` row (`testUpdateNonexistant`: update against a
  non-existent record, `NFS4ERR_NOENT`), which belongs to exactly this work and
  makes 16. It is covered.

- **Bit `0x4` is not universally undefined.** `EID4` sends `eia_flags = 0x4` and
  expects `NFS4ERR_INVAL` because RFC 8881 defines no such bit — but RFC 7862
  Section 14.1 adds `EXCHGID4_FLAG_SUPP_FENCE_OPS = 0x4` as an argument bit a
  v4.2 client *should* request, and this server accepts `minorversion 2`. The
  mask is therefore per-minor-version rather than a flat
  `EXCHGID4_FLAG_MASK_A`, and `TestExchangeID_FenceOpsFlagAcceptedOnV42` pins
  that a v4.2 request is still accepted.

`EID8` (`NFS4ERR_NOT_ONLY_OP`) was already fixed by #2481 and is untouched here.

## Structure

Case 5 needs a confirmed and an unconfirmed record for one owner ID at the same
time. Rather than a second owner index in the state manager, the unconfirmed
record carries `Superseded` — a pointer to the record it replaces. Both records
stay in `v41ClientsByID`, so the old client ID keeps resolving and its sessions
keep working, while `v41ClientsByOwner` holds exactly one entry per owner as
before. `purgeV41Client` hands the owner ID back to the superseded record if the
replacement is dropped, and a further `EXCHANGE_ID` discards the unconfirmed
record and re-runs the algorithm against the confirmed one — the strategy the
RFC names for that case. `collapseSupersededLocked` looks its target up by
client ID rather than trusting the pointer, so a reaper that already removed it
does not cause a double purge.

`CreateSession` grew a trailing variadic `principal ...string`, matching
`ExchangeID`, so callers that do not thread a principal keep compiling.

**On `ReclaimComplete`** (added on #2473's branch, not merged here, so this PR
does not touch it): my reading of Section 18.35.4 is that no case needs an
explicit reset. Cases 1, 3, 4 and 5 all reach `createV41Client`, which builds a
fresh zero-valued record, so a new incarnation starts with the flag clear by
construction. Cases 2 and 6 keep the same record and must *not* clear it — same
incarnation, same verifier, no reboot. So the only record that inherits the flag
is one that was never replaced, which is correct.

## Verification

`go build ./...`, `go vet ./...`, `go test ./...` and
`go test -race ./internal/adapter/nfs/...` all clean.

Every guard was mutated two ways — the check forced never to refuse, and its
verdict replaced with a different status — under `go test -overlay=`, so nothing
in production was edited. All 18 mutations fail a named test. Representative
output:

```
=== A-flagmask/check: FAILED AS REQUIRED
    exchange_id_algorithm_test.go:215: status for undefined flag bit 0x4 = 0, want NFS4ERR_INVAL (22)
=== A-flagmask/verdict: FAILED AS REQUIRED
    exchange_id_algorithm_test.go:215: status for undefined flag bit 0x4 = 10036, want NFS4ERR_INVAL (22)
=== C-case8/check: FAILED AS REQUIRED
    exchange_id_algorithm_test.go:354: update with a different verifier = 0, want NFS4ERR_NOT_SAME (10027)
=== C-case8/verdict: FAILED AS REQUIRED
    exchange_id_algorithm_test.go:354: update with a different verifier = 2, want NFS4ERR_NOT_SAME (10027)
=== G-case5/check: FAILED AS REQUIRED
    exchange_id_algorithm_test.go:465: SEQUENCE on the old session before confirmation = 10052, want NFS4_OK
=== G-case5/verdict: FAILED AS REQUIRED
    exchange_id_algorithm_test.go:473: SEQUENCE on the old session after confirmation = 0, want NFS4ERR_BADSESSION (10052)
=== H-confirmprinc/check: FAILED AS REQUIRED
    exchange_id_algorithm_test.go:576: confirmation by another principal = 0, want NFS4ERR_CLID_INUSE (10017)
=== H-confirmprinc/verdict: FAILED AS REQUIRED
    exchange_id_algorithm_test.go:576: confirmation by another principal = 10022, want NFS4ERR_CLID_INUSE (10017)
=== I-unconfexpiry/check: FAILED AS REQUIRED
    exchange_id_algorithm_test.go:617: CREATE_SESSION after the lease period = 0, want NFS4ERR_STALE_CLIENTID (10022)
=== I-unconfexpiry/verdict: FAILED AS REQUIRED
    exchange_id_algorithm_test.go:617: CREATE_SESSION after the lease period = 10017, want NFS4ERR_STALE_CLIENTID (10022)
```

One caveat on that set: `B-case7/check` (forcing the "no confirmed record" test
to `false`) fails via a nil dereference rather than an assertion, because the
same branch is the nil guard. Its verdict variant gives the clean assertion
(`update against no record = 10027, want NFS4ERR_NOENT (2)`).

## Tests that asserted the pre-RFC behaviour

Three existing tests encoded the old semantics and were rebuilt on records
confirmed through `CREATE_SESSION` rather than on unconfirmed ones:

- `TestExchangeID_Case2_PrincipalMismatch` (the hijack control) never confirmed
  its record, so it exercised case 4 rather than the collision guard it was
  written for. Rebuilt on a confirmed record holding a session — where the guard
  genuinely applies — and it still demands `NFS4ERR_CLID_INUSE`, including for a
  caller with no principal at all. The guard is not weakened: an unconfirmed
  record holds no state and no client depends on it, so there is nothing there
  to hijack.
- `TestExchangeID_ConfirmedReboot` asserted the old confirmed record was purged
  inside `EXCHANGE_ID`. It now checks the case-5 sequence: the record survives,
  the owner ID resolves to the replacement, and confirming the replacement
  collapses the two.
- `TestExchangeID_SameOwnerSameVerifier` asserted an unconfirmed record returned
  the same client ID; renamed and inverted to the case-4 replacement.

`TestHandleExchangeID_Idempotent` was deleted rather than inverted: with an
unconfirmed record it is case 4, already covered by
`TestExchangeID_UnconfirmedRecordIsReplaced`, and the confirmed-record
idempotent path it was named for is covered by
`TestExchangeID_ConfirmedIdempotentReturn` at the same layer.

## Known failures

No rows removed from `test/nfs-conformance/pynfs/KNOWN_FAILURES_V41.md` yet.
The 16 rows this issue covers come out only against `: PASS` verdict lines read
from the `pynfs.log` artifact of **both** presubmit backends (`memory` and
`postgres-s3`) on this branch's own head; a row that passes on one and fails on
the other stays, with the asymmetry written down as its reason. The lines will
be quoted here before the rows move.
