### PR TITLE
chore(pi): complete the migration from Claude Code to pi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ test/smb-conformance/dfs
 test/smb-conformance/dfsctl
 .claude/scheduled_tasks.lock
 .claude/worktrees/
+.pi/tasks/
 .agent-orphans/
 test/smb-conformance/docker-compose.override.yml
 

--- a/.pi/skills/fix-issue/SKILL.md
+++ b/.pi/skills/fix-issue/SKILL.md
@@ -1,0 +1,337 @@
+---
+name: fix-issue
+description: End-to-end workflow for taking a DittoFS GitHub issue from report to merged fix — read the issue, test its premise, reproduce, fix the root cause, verify, open a PR against develop, babysit Copilot and CI, squash-merge, and close the issue. Use this whenever a DittoFS issue is referenced by number or URL and any work on it is implied ("fix #1934", "address issue 1888", "look into 1923", "what's going on with https://github.com/.../issues/1956"), including when the ask is only to investigate — the investigation half applies either way. Also use when resuming an in-flight issue branch or PR.
+---
+
+# Fixing a DittoFS issue
+
+Take the issue from report to merged, autonomously. The stop conditions at the
+end are the only places to come back.
+
+The most expensive failure mode here is **a confident fix for the wrong
+problem**. Issues describe symptoms and often carry a theory about the cause;
+that theory is frequently wrong — sometimes written by a past agent that read
+code without running it.
+
+## 1. Set up an isolated workspace
+
+Other agents work this repo concurrently. Never build in the primary checkout.
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+git fetch origin && git log --oneline -1 origin/develop   # know your base
+git worktree add ~/dittofs-worktrees/<slug> -b fix/<issue>-<slug> origin/develop
+```
+
+`<slug>` is 2-4 words naming the defect (`1934-resolve-covering`,
+`1888-unplaceable-guard`); use `feat/` instead of `fix/` for feature issues.
+Branch from `origin/develop`, never from a local `develop` that may be stale and
+never from a stash. Worktrees live in `~/dittofs-worktrees/`, never `/tmp` —
+they outlive the session and you may need to come back to one.
+
+## 2. Read the issue, then distrust it
+
+```bash
+gh issue view <N> --comments
+```
+
+Keep three things separate:
+
+- **The observed symptom** — what someone actually saw. This is evidence.
+- **The claimed cause** — what the issue says is happening. This is a hypothesis.
+- **The claimed reachability** — "latent", "cannot happen today", "only affects
+  X". This is the most load-bearing and least verified claim in most issues.
+
+**Verify the premise before building on it.** Whether a defect is reachable
+decides which fix is correct, so a wrong premise doesn't just waste time — it
+produces a fix that is wrong in a way that passes review. #1934 was filed as
+latent-and-unreachable; a randomized mutation soak on unmodified `develop` hit
+it in 3 of 24 seeds, and that discovery flipped the fix from "return an error"
+(which broke live reads) to "resolve to the greatest start".
+
+Verify refutations with the same rigor as confirmations. Concluding "this can't
+happen" closes a door quietly, and a wrong refutation is invisible. Prefer
+structural arguments (this call path has no caller; this field is never written)
+over numeric ones (I ran it 100 times and it didn't reproduce).
+
+If the premise turns out to be wrong, say so plainly in the PR body — that
+finding is often worth more than the diff.
+
+## 3. Investigate
+
+Start with the knowledge graph; it returns a scoped subgraph far smaller than
+grep output or the full architecture report:
+
+```bash
+graphify query "<the question you actually have>"
+graphify path "<A>" "<B>"      # how two things relate
+graphify explain "<concept>"   # focused concept
+```
+
+Then read the specific code. `docs/internals/architecture.md` is the map;
+`docs/internals/debugging.md` has the SMB/NFS pcap-diff playbook. Use the
+`refute-root-cause` skill for a stubborn bug.
+
+Respect the invariants in `CLAUDE.md` — protocol handlers stay protocol-only,
+every op carries an `*metadata.AuthContext`, file handles are opaque, block
+stores are per-share, errors are `metadata.ExportError` values. A fix that
+violates one of these will be correct and still get rejected.
+
+**For protocol questions, go to the source of truth** — guessing at wire
+behaviour is how interop bugs are born:
+
+- RFCs for NFS — RFC 1813 (v3), RFC 7530 (v4.0), RFC 8881 (v4.1).
+- MS-SMB2 and MS-FSCC on Microsoft Learn for SMB2/3 — use the
+  `microsoft-docs` skill, which searches the official docs directly.
+- Samba and nfs-ganesha source for "what do real implementations actually do
+  when the spec is ambiguous". If Samba also fails a conformance case, that
+  case is likely testing something unimplementable, not a DittoFS bug (#1923,
+  #1832 both resolved this way).
+
+## 4. Reproduce deterministically before fixing
+
+A fix you cannot demonstrate failing before and passing after is a guess. Build
+the smallest reliable reproduction you can, and prefer one that lives in the
+repo afterward as a regression test. For races and CI-only failures, invest in
+determinism rather than retrying — #1701's dir-lease double-break only became
+fixable once it reproduced on demand.
+
+Two traps that have bitten repeatedly:
+
+- **Fake sinks and in-memory doubles do not validate durability or ordering
+  work.** A green unit suite (with `-race`) sat alongside a rig that wedged on
+  real hardware. If the change touches carve/flip, journal, fsync ordering, or
+  eviction, the reproduction has to run against something real.
+- **Reading code is not verifying behaviour.** Say "predicted" until a
+  checksummed read-back, a packet capture, or a failing assertion confirms it.
+
+### Put the root cause on trial before you fix it
+
+You now have a claimed root cause and, ideally, a reproduction. Before you design
+a fix around it, try to kill it. A root cause that survives a genuine attempt at
+refutation is worth far more than one that merely explains the symptom — several
+plausible causes usually explain the same symptom, and picking the wrong one
+produces a fix that passes review and leaves the bug in.
+
+Run the `refute-root-cause` skill (it is in the user-level skill list). It fans
+out an adversarial panel through the `subagent` tool: three refuters, one lens
+each — control flow, concurrency and ordering, evidence fit — plus an
+alternatives agent that names competing mechanisms from the symptom alone.
+Following this instruction **is** the opt-in — you do not need to ask.
+
+Invoke it with `subagent({ workflowScriptPath: "<skill-dir>/refute-root-cause.js",
+cwd: "<repo-or-worktree>", async: false })` after editing the CONFIG block at the
+top of the script — `CLAIM` (the root cause, stated as a falsifiable sentence),
+`EVIDENCE` (repro output, logs, file:line anchors), and `SYMPTOM` (what someone
+actually observed).
+
+**How to read the result.** Any refutation with a concrete counterexample kills
+the claim — go back to step 3, do not average the votes. Refutations without a
+counterexample are doubts, not kills: chase the specific thing they could not
+rule out. If it survives but the alternatives agent names a competing mechanism,
+run the distinguishing observation it suggests before you write any code.
+
+**When to run it:** the claimed cause rests on reading code rather than on a
+reproduction; the issue is a data-corruption, durability, or concurrency defect;
+the fix would change a shared seam; or the issue's own premise already turned out
+to be wrong once. **When to skip it:** the reproduction already pins the cause
+unambiguously (a failing assertion on the exact line), or the fix is mechanical
+and self-evident — a typo, a read-only variable, a missing invalidation call. A
+four-agent panel on a two-line CI fix is waste, and saying so is the right call.
+
+Keep the panel to three lenses plus the alternatives agent. Under
+`solve-issues` several `fix-issue` agents run concurrently and each panel
+multiplies against that budget.
+
+## 5. Fix the root cause
+
+Grep every caller of the function you are about to change. The symptom named in
+the issue is usually one of several paths through a shared seam, and patching
+only the named path leaves the siblings broken — one guard in the shared
+function is both smaller and more correct than a guard per caller.
+
+When the seam is an access point (a fault-in, a cache lookup, a handle
+resolution), enumerate **all** the operations that cross it — read, write,
+truncate, delete, clone — not just the one in the report. A review that checked
+only `ReadAt` shipped #1831 with `WriteAt`, `Delete` and `Truncate` still broken.
+
+Keep the change small and match the surrounding style. **Comments describe
+behaviour only** — no issue or PR numbers, no CI or OS names, no phase or plan
+IDs in source; that context belongs in the commit message and PR body.
+
+Commit signed as you go, in small steps — long runs get killed by watchdogs and
+rate limits, and uncommitted work dies with them:
+
+```bash
+git commit -S -m "fix(block): ..."
+# if SSH signing fails with "Couldn't get agent socket":
+git -c user.signingkey=$HOME/.ssh/id_rsa.pub commit -S -m "..."
+```
+
+## 6. Verify
+
+Climb only as far as the change requires — each tier costs an order of
+magnitude more than the last.
+
+```bash
+go build ./... && go vet ./... && go fmt ./...
+go test ./...            # then -race on anything concurrent
+```
+
+Docker is available locally for protocol conformance. Pick the suite that
+matches the change — they cover different things:
+
+```bash
+cd test/smb-conformance && ./run.sh     # SMB2/3: WPTS BVT, Samba-derived
+cd test/nfs-conformance && ./run.sh     # Kerberos/sec=krb5 mounts ONLY, not general NFS
+sudo ./test/posix/run-posix.sh          # pjdfstest: the real NFS-side FS-semantics suite
+```
+
+`test/posix/` is where an NFSv3/v4 semantics change gets proven — `setup-posix.sh`
+first, `teardown-posix.sh` after. `test/e2e/` needs sudo and a kernel NFS client:
+`cd test/e2e && sudo ./run-e2e.sh`. **Never run two suites concurrently** — they
+collide on ports and mounts.
+
+If the change is about crash behaviour, device loss, real kernel-client
+interaction, or throughput, a laptop cannot prove it. Read
+`references/scw-vm.md` before provisioning anything — it covers the recipe and
+the teardown check that keeps you from destroying a development VM.
+
+If a listed known-failure starts passing, or a new one fails, do not edit the
+list on a hunch — CI is the authority on what actually fails there. There are
+several, one per suite: `test/posix/KNOWN_FAILURES.md` and
+`KNOWN_FAILURES_V4.md`, `test/smb-conformance/KNOWN_FAILURES.md`, and
+`test/smb-conformance/smbtorture/KNOWN_FAILURES{,_KERBEROS}.md`. Flakes get
+fixed, never retried.
+
+## 7. Simplify and review before the PR
+
+Two reviewers, in this order, every time. They catch different things and both
+have caught real bugs that a self-review missed. Run each through the `subagent`
+tool with the built-in `reviewer` agent; hand each the actual diff content and
+absolute file paths, and frame the first pass around simplicity (dead code,
+needless abstraction, reinvented stdlib) and the second around correctness
+(bugs, edge cases, regression risk).
+
+```text
+subagent({ agent: "reviewer", task: "<simplicity review of this diff: ...>" })
+subagent({ agent: "reviewer", task: "<correctness review of this diff: ...>" })
+```
+
+The reviewer **cannot see a branch that exists only in your worktree** — it has
+no git access to your working state. Hand it the actual diff content and
+absolute file paths, not "review branch fix/1934-...". Otherwise it reviews
+`develop` and reports nothing.
+
+Then update whatever documentation the change invalidates. If any Cobra command
+or flag moved, regenerate — never hand-edit the generated file:
+
+```bash
+go run ./cmd/gendocs      # rewrites docs/guide/cli.md
+```
+
+## 8. Open the PR
+
+Rebase onto current `origin/develop` — never merge `develop` in.
+
+```bash
+git fetch origin && git rebase origin/develop
+git push -u origin fix/<issue>-<slug>
+gh pr create --base develop --assignee marmos91 --title "..." --body "..."
+```
+
+The PR body must contain a closing keyword (`Closes #<N>`). `develop` is the
+default branch, so GitHub's native auto-close fires on merge and the issue closes
+itself — do not also close it by hand. `gh issue close --comment` on an
+already-closed issue exits 0 and silently discards the comment, so verification
+notes posted that way are lost; use `gh issue comment` for those.
+`.github/workflows/close-linked-issues.yml` still runs at release time as a
+safety net for keywords that appear in a commit message but not a PR body.
+
+Write the body for a reviewer who has not read the issue: what was actually
+wrong, why the obvious fix is wrong if it is, and what evidence you have. If you
+refuted the issue's premise, lead with that. Include the reproduction output.
+Never mention Claude Code, AI tooling, or add `Co-Authored-By` lines for AI.
+
+## 9. Babysit the PR
+
+Stay with the PR until it merges.
+
+**Copilot review.** Wait for it and read every comment. It has repeatedly caught
+real bugs that both the reviewer agent and I missed (#1837, #1838, #1831).
+Address what is real; reply explaining why on what is not.
+
+```bash
+gh pr view <PR> --comments
+gh pr diff <PR>
+```
+
+**CI.** Ten workflows run per PR — `unit-tests`, `lint`, `integration-tests`,
+`posix-tests`, `smb-conformance`, `operator-tests`, `windows-build`,
+`secret-scan`, `ci-health`, and `nfs-kerberos` (path-scoped to the kerberos and
+NFS adapter trees). The protocol suites are slow.
+
+```bash
+gh pr checks <PR> --watch
+```
+
+Do not wait on `e2e-tests`, `smb-client-compat`, or `ad-dc` — they are
+postsubmit/nightly only and never appear on a PR. Waiting for them hangs step 9
+forever.
+
+When a check goes red, investigate the actual failure rather than re-running.
+Pull the failing job's log, find the assertion, and check whether the same job
+fails on `origin/develop` before assuming it is yours — `develop` is
+occasionally red for unrelated reasons, which is not cause for alarm.
+
+A flaky SMB-conformance run is a known condition and does not block. Everything
+else that is red gets fixed, on this branch, and the loop returns to step 6.
+
+## 10. Merge and close
+
+When CI is green and every Copilot comment is addressed:
+
+```bash
+gh pr merge <PR> --squash --delete-branch
+gh issue close <N> --comment "Fixed in #<PR>."     # manual — see step 8
+
+# Refresh the graph in the MAIN checkout, on the merged code — not in the worktree
+cd "$(git worktree list --porcelain | head -1 | cut -d' ' -f2)"   # the main checkout
+git checkout develop && git pull
+graphify update .                                   # AST-only, no API cost
+
+git worktree remove ~/dittofs-worktrees/<slug>
+```
+
+Closing is manual because that automation only fires when work reaches `main` at
+release time. An issue left open here stays open for weeks.
+
+Order matters in that block. `graphify-out/` lives in the main checkout, so
+`graphify update .` run from the worktree either builds a throwaway graph that
+dies with the worktree or refreshes the graph against the *pre-merge* tree —
+either way the canonical graph stays stale, and the next session's
+`graphify query` answers from code that no longer exists. That is not a cosmetic
+miss: a stale graph sends the next agent to the wrong files, and it degrades
+silently rather than erroring. Pull `develop` first so the graph reflects the
+squashed commit, not your branch.
+
+Under `solve-issues` you do not reach this step at all — the orchestrator holds
+the merge and refreshes the graph once after the whole batch lands, since
+rebuilding it per-PR across six merges is wasted work.
+
+## When to stop and come back
+
+Autonomy ends where a decision is not yours to make:
+
+- The fix contradicts a documented decision — a `KNOWN_FAILURES.md` entry
+  justified as architectural, an ADR, an invariant in `CLAUDE.md`. #1832's
+  replay6 case is mutually exclusive with conformant durable-handle behaviour
+  and Samba fails it too; re-attempting it wastes a day. Report, don't re-litigate.
+- The change needs to touch `main`, rewrite published history, or force-push a
+  protected branch.
+- The issue is a duplicate, already fixed, or its premise collapses entirely and
+  there is nothing left to fix.
+- A VM teardown target fails the identity check in `references/scw-vm.md`.
+
+In each case: post what you found on the issue, leave the worktree in place, and
+report back.

--- a/.pi/skills/fix-issue/SKILL.md
+++ b/.pi/skills/fix-issue/SKILL.md
@@ -123,7 +123,9 @@ Invoke it with `subagent({ workflowScriptPath: "<skill-dir>/refute-root-cause.js
 cwd: "<repo-or-worktree>", async: false })` after editing the CONFIG block at the
 top of the script — `CLAIM` (the root cause, stated as a falsifiable sentence),
 `EVIDENCE` (repro output, logs, file:line anchors), and `SYMPTOM` (what someone
-actually observed).
+actually observed). `<skill-dir>` is the user-level skill directory
+(`~/.pi/agent/skills/refute-root-cause/`) — the script ships with the skill, not
+with this repo, so passing a repo-relative path is the common mistake.
 
 **How to read the result.** Any refutation with a concrete counterexample kills
 the claim — go back to step 3, do not average the votes. Refutations without a
@@ -293,7 +295,9 @@ When CI is green and every Copilot comment is addressed:
 
 ```bash
 gh pr merge <PR> --squash --delete-branch
-gh issue close <N> --comment "Fixed in #<PR>."     # manual — see step 8
+# the issue auto-closed at merge (step 8); post verification notes with
+# `gh issue comment <N>` — `gh issue close` on a closed issue exits 0 and
+# silently discards the comment
 
 # Refresh the graph in the MAIN checkout, on the merged code — not in the worktree
 cd "$(git worktree list --porcelain | head -1 | cut -d' ' -f2)"   # the main checkout
@@ -302,9 +306,6 @@ graphify update .                                   # AST-only, no API cost
 
 git worktree remove ~/dittofs-worktrees/<slug>
 ```
-
-Closing is manual because that automation only fires when work reaches `main` at
-release time. An issue left open here stays open for weeks.
 
 Order matters in that block. `graphify-out/` lives in the main checkout, so
 `graphify update .` run from the worktree either builds a throwaway graph that

--- a/.pi/skills/fix-issue/references/scw-vm.md
+++ b/.pi/skills/fix-issue/references/scw-vm.md
@@ -1,0 +1,109 @@
+# Running a fix on real hardware (Scaleway)
+
+Read this only when a laptop genuinely cannot prove the fix: crash and
+device-loss behaviour, real kernel NFS/SMB client interaction, throughput, or
+anything where an in-memory double would lie. Everything else stays local —
+a VM costs real money per hour and adds an hour of setup.
+
+The `scw` CLI is already authenticated.
+
+## Before you touch any VM: the identity check
+
+`.bench-vm.json` in the repo root records the *most recent* provisioned VM. It
+is not necessarily yours. Development VMs have been recorded there, and
+`dfsbench teardown` will happily terminate whatever it finds.
+
+Destroying someone's development VM is unrecoverable, so the rule is absolute:
+**never tear down a server whose `server_id` you did not personally record when
+you created it.**
+
+```bash
+[ -f .bench-vm.json ] && cat .bench-vm.json || echo "no .bench-vm.json — nothing recorded"
+scw instance server list    # confirm name/tags match the VM you created
+```
+
+No `.bench-vm.json` means no VM is recorded, so there is nothing to tear down —
+that is a clean state, not an error.
+
+If the recorded `server_id` is not the one you provisioned, do not tear down.
+Stop and report — this is one of the skill's hard stop conditions.
+
+## Provisioning
+
+For benchmark-shaped work, `dfsbench` owns the whole lifecycle and writes
+`.bench-vm.json` itself:
+
+```bash
+dfsbench setup      # SCW_* env selects type/zone/image
+dfsbench teardown   # terminates the VM in .bench-vm.json — after the identity check
+```
+
+Environment that shapes the instance:
+
+```
+SCW_ZONE=fr-par-1
+SCW_INSTANCE_TYPE=POP2-8C-32G
+SCW_IMAGE=ubuntu_noble
+SCW_ROOT_VOLUME=sbs:100GB:5000
+SCW_NAME=<something identifying this issue, e.g. dfs-1909-crash>
+SCW_SSH_KEY=<key>
+```
+
+Name the VM after the issue — that name is how anyone later tells your VM from a
+development one.
+
+For a plain repro box unrelated to benchmarking, provision directly with
+`scw instance server create` and record the returned ID somewhere you control
+rather than overwriting `.bench-vm.json`.
+
+## SSH
+
+User is `root`. The Scaleway key lives in the **1Password agent**, which refuses
+to sign for ssh invoked from the Bash tool. Start a dedicated agent instead:
+
+```bash
+ssh-agent -a "$HOME/.dfsb.sock" >/dev/null
+SSH_AUTH_SOCK=$HOME/.dfsb.sock ssh-add ~/.ssh/<scw-key>
+SSH_AUTH_SOCK=$HOME/.dfsb.sock ssh root@<ip>
+```
+
+## Long runs
+
+Anything longer than a few minutes runs detached on the VM. Poll it; do not
+block on it — a `--remote` poller hangs silently when the remote side stalls.
+
+Aborting a detached `dfsbench` run needs two kills — the local poller and the
+remote binary:
+
+```bash
+pkill -f 'dfsbench run'                          # local
+ssh root@<ip> 'pkill -9 -x dfsbench; pkill -9 -x fio'   # remote
+```
+
+Use `-x` (exact name) on the remote side. `pkill -f dfsbench` matches your own
+ssh command line and kills the session before the command runs.
+
+## Two-build verification
+
+When the question is "does this fix actually change behaviour", one build proves
+nothing. Push both a pre-fix and a post-fix binary to the same VM and run the
+same reproduction against each. A repro that fails on the old build and passes
+on the new one is evidence; a repro that only passes on the new one is a guess.
+
+## Teardown
+
+Tear down as soon as the evidence is captured — pull results back first, because
+the VM's disk goes with it.
+
+```bash
+dfsbench teardown     # or: scw instance server terminate <your-server-id> with-block=true
+```
+
+Verify it is gone rather than trusting the exit code:
+
+```bash
+scw instance server list
+```
+
+If teardown fails because the server is already gone, that is fine. If it fails
+for any other reason, retry — a leaked VM bills until someone notices.

--- a/.pi/skills/solve-issues/SKILL.md
+++ b/.pi/skills/solve-issues/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: solve-issues
+description: Work several DittoFS issues at once by fanning out one subagent per issue group, each working the fix-issue skill in its own worktree, then serializing the merges back into develop. Use whenever more than one DittoFS issue number is handed over in a single ask ("/solve-issues 1823 1843", "fix 1888 and 1923", "clear these four issues", "work through the audit backlog"). For a single issue, work fix-issue directly instead.
+---
+
+# Solving several issues in parallel
+
+This is an orchestrator. All the actual work — investigation, reproduction,
+fixing, verification, PR authoring, CI babysitting — lives in the `fix-issue`
+skill (`.pi/skills/fix-issue/SKILL.md` in this repo), and each subagent
+works that skill unchanged. Your job is what a single issue's context cannot do:
+settle the open design questions with the user in one pass instead of six,
+decide what can safely run at once, broker shared resources, and land the
+results in an order that leaves `develop` green.
+
+## 1. Triage before fanning out
+
+Read every issue first, in one pass:
+
+```bash
+for n in <issues>; do gh issue view $n --json number,title,labels,state,body \
+  -q '"#\(.number) [\(.state)] \(.title)"'; done
+```
+
+Drop anything already closed or already covered by a PR before spending an
+agent on it. Search **all** PR states, not just open ones:
+
+```bash
+for n in <issues>; do gh pr list --state all --search "$n" \
+  --json number,state,title -q '.[] | "  #\(.number) [\(.state)] \(.title)"'; done
+```
+
+A merged PR means the fix may already be on `develop`. A **closed-unmerged** PR
+matters even more: someone already attempted this and abandoned it — read its
+diff and review comments and hand that context to the agent rather than letting
+it rediscover the dead end.
+
+Then group by the code they touch — `graphify query` on each issue's subject
+area is fast and tells you which ones land in the same files. **Issues that
+touch the same code go to one agent, sequentially.** Two agents editing the same
+file produce two PRs that each pass CI alone and conflict on merge. Independent
+issues each get their own agent.
+
+## 2. Settle the open questions with the user — before any agent starts
+
+Triage tells you what the issues are. It does not tell you what the user wants
+built. **Collect every open design question across all the issues and ask them
+in one pass, before fanning out.** An agent that guesses spends its whole run
+building the wrong thing, and you find out at PR review — after the tokens are
+gone and with a branch that has to be thrown away. Asking costs one round trip.
+
+Whatever the user decides, **write the decision into the agent's prompt as
+settled**, with an explicit "do not block on this" — otherwise the agent
+re-litigates it from the issue text, which still contains the open question.
+
+What NOT to ask: anything with a conventional default, anything the codebase
+already answers, anything you can verify yourself. Those are your calls.
+
+## 3. Fan out (pi-native)
+
+Call the `subagent` tool ONCE with a `workflowScript` that fans out one child
+per issue group — each child with `worktree: true` (isolated managed git
+worktree, branched from clean HEAD) and the `fix-issue` skill loaded:
+
+```js
+subagent({
+  workflowScript: `
+    const groups = [ /* one entry per independent issue group */ ];
+    const runs_ = groups.map((g, i) => ({
+      key: 'issue-' + i,
+      agent: 'worker',
+      task: g.prompt,
+      skill: 'fix-issue',
+      worktree: true,
+    }));
+    return runs.all(runs_);
+  `,
+  cwd: '/Users/marmos91/Projects/dittofs',
+  async: true,
+})
+```
+
+Each child prompt says explicitly which skill to work and where the boundaries
+are — the three genuinely shared resources below, plus this deviation:
+
+- **STOP after the PR is green and every Copilot comment is addressed. Do NOT
+  merge.** Report the PR number and a one-paragraph summary of the root cause.
+  Merges are serialized by the orchestrator (step 5).
+- **Scratchpad filenames must be issue-scoped** (`pr-body-1958.md`, not
+  `pr-body.md`) and re-read immediately before publishing — a generic filename
+  once carried the wrong `Closes #NNNN` onto a PR.
+
+The fan-out is independent items with no cross-item dependency, so plain
+`runs.all` is the whole orchestration.
+
+## 4. Broker the shared resources
+
+Children ask the parent through pi's `contact_supervisor` channel
+(`reason: "need_decision"`); check pending requests with
+`subagent_supervisor({ action: "pending" })` and reply with
+`subagent_supervisor({ action: "reply", replyTo, message })`. Before resuming a
+child that died mid-step, check ground truth yourself and put it in the reply —
+branch, commits ahead of develop, uncommitted file count, whether a PR exists —
+because the child resumes believing its last action succeeded:
+
+```bash
+for w in <slugs>; do d=~/dittofs-worktrees/$w; \
+  echo "$w: $(git -C $d rev-parse --abbrev-ref HEAD) | commits=$(git -C $d rev-list --count origin/develop..HEAD) | dirty=$(git -C $d status --porcelain | wc -l)"; done
+```
+
+Tell any agent with uncommitted files to commit before anything else.
+
+**Check for duplicate branches and worktrees per issue, not just per PR.** A
+stalled-and-resumed agent can create a second worktree under a name you did not
+assign and open a second PR from it. `git worktree list` and
+`git ls-remote --heads origin` catch it. Diff duplicates before closing either;
+the surviving PR should be the superset.
+
+While children run, you hold the contended resources. When one asks:
+
+- **Conformance or e2e suite** — grant to one agent at a time. Tell the others
+  to wait rather than skip; a skipped protocol suite is how interop regressions
+  ship.
+- **A VM** — read `.pi/skills/fix-issue/references/scw-vm.md`, provision one
+  yourself, and hand the agent the IP. You own the teardown, including the
+  identity check.
+
+## 5. Merge serially
+
+Never merge concurrently. Each squash-merge moves `develop`, which invalidates
+every other branch's base — CI green on a stale base proves nothing about the
+tree that actually results. Order by blast radius, smallest first. For each PR
+in turn:
+
+```bash
+gh pr checks <PR>                                  # still green on the current base?
+gh pr merge <PR> --squash --delete-branch
+```
+
+Then, before the next one, rebase it:
+
+```bash
+cd ~/dittofs-worktrees/<next-slug>
+git fetch origin && git rebase origin/develop && git push --force-with-lease
+```
+
+and wait for its checks again. If a rebase conflicts or turns a check red, hand
+it back to that issue's agent through the supervisor channel — it has the
+context you do not.
+
+Once everything is landed, in the MAIN checkout on merged code:
+
+```bash
+git checkout develop && git pull
+graphify update .
+git worktree remove ~/dittofs-worktrees/<slug>     # for each
+```
+
+## 6. Report
+
+A short table, one row per issue: number, what was actually wrong, PR, merged or
+blocked. Call out separately any issue whose **premise turned out to be false** —
+that finding often matters more than the fix. Do not report an issue as done
+until its PR is merged and the issue is closed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,6 @@ drowning the signal, and `-B2 -A2` instead of reading the whole file afterwards.
 Run `graphify update .` after merging, from the main checkout on the merged
 code — see the `fix-issue` skill, step 10.
 
-
 ## Frequent commands
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,8 +26,7 @@ Two binaries: `dfs` (server, `cmd/dfs/`) and `dfsctl` (REST client, `cmd/dfsctl/
 
 ## Finding your way around the code
 
-There is a graphify code graph at `graphify-out/`, and a `PreToolUse` hook in
-`.claude/settings.json` that reminds you about it. It is one tool among several,
+There is a graphify code graph at `graphify-out/`. It is one tool among several,
 not a gate you must pass through — route by the *shape* of the question, because
 the wrong tool costs either tokens or a round trip, and there is no prize for
 using the graph on a question it cannot answer.
@@ -37,7 +36,7 @@ using the graph on a question it cannot answer.
 | Who calls `X`? What breaks if I change it? How do `A` and `B` connect? | `graphify query` / `path` / `explain` |
 | Where is the identifier `X` — a symbol, error string, flag, `DITTOFS_*` key? | `rg` directly |
 | Something spanning many files whose names you don't know yet | an `Explore` / `Agent` subagent |
-| Anything in `test/`, `docs/`, `.planning/`, `.claude/`, or non-Go files | `rg` / `Read` — not in the graph |
+| Anything in `test/`, `docs/`, `.planning/`, `.pi/`, `.claude/`, or non-Go files | `rg` / `Read` — not in the graph |
 
 **The graph is AST-only.** `graphify update .` extracts symbols and edges; it
 runs no model and infers no intent. So a question phrased the way you'd ask a


### PR DESCRIPTION
## What

Completes the harness migration so the repo can be developed through pi.

**Missing migration pieces, now added:**

- `.pi/skills/fix-issue/` — the worker skill. The pi-native `solve-issues` orchestrator fans out one subagent per issue group, each running `fix-issue`; until now that skill only existed under `.claude/skills/`, so the orchestrator referenced a harness pi does not read. The port:
  - replaces the Claude Code `Workflow`-DSL refute-root-cause panel with the pi-native `refute-root-cause` skill (`subagent` + `workflowScriptPath`),
  - replaces the `code-simplifier`/`feature-dev` subagent types (which do not exist in pi) with the built-in `reviewer` agent for both pre-PR review passes,
  - copies `references/scw-vm.md` unchanged (harness-agnostic).
- `.pi/skills/solve-issues/` — existing pi-native orchestrator, now pointing at the `.pi/` skill paths.
- `CLAUDE.md` — drops the stale `.claude/settings.json` PreToolUse-hook reference (the hook does not exist in pi) and adds `.pi/` to the not-in-the-graph row.
- `.gitignore` — ignores `.pi/tasks/` (background-task session artifacts).

**Already in place, verified:** `CLAUDE.md` is loaded by pi natively as a context file, and the project-trust decision for this repo is saved.

**Also in this branch's working session (not part of this diff):** all stale worktrees and branches were cleaned — 25 worktrees removed, 130 local branches and 130 remote branches deleted, each verified first (content landed via squash, merged-PR pre-squash copies, or closed/superseded work). `develop`, `main`, and `fix/2471-create-session-wip` (open issue #2471's only test pin) were kept.

Closes none. Maintenance only.