### PR TITLE
CREATE_SESSION: reject too-small channel sizes, unknown flags, and out-of-sessions clients

### DIFF
--- a/internal/adapter/nfs/v4/state/client_recovery_test.go
+++ b/internal/adapter/nfs/v4/state/client_recovery_test.go
@@ -414,7 +414,7 @@ func TestClientRecovery_V41PersistAndReclaimComplete(t *testing.T) {
 		t.Fatalf("ExchangeID: %v", err)
 	}
 	// First CREATE_SESSION confirms + persists.
-	if _, _, err := sm.CreateSession(exch.ClientID, exch.SequenceID, 0, types.ChannelAttrs{}, types.ChannelAttrs{}, 0, nil, "uid:0"); err != nil {
+	if _, _, err := sm.CreateSession(exch.ClientID, exch.SequenceID, 0, defaultForeAttrs(), defaultBackAttrs(), 0, nil, "uid:0"); err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
 
@@ -438,7 +438,7 @@ func TestClientRecovery_V41PersistAndReclaimComplete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ExchangeID(2): %v", err)
 	}
-	cs, _, err := sm2.CreateSession(exch2.ClientID, exch2.SequenceID, 0, types.ChannelAttrs{}, types.ChannelAttrs{}, 0, nil)
+	cs, _, err := sm2.CreateSession(exch2.ClientID, exch2.SequenceID, 0, defaultForeAttrs(), defaultBackAttrs(), 0, nil)
 	if err != nil {
 		t.Fatalf("CreateSession(2): %v", err)
 	}
@@ -466,7 +466,7 @@ func TestClientRecovery_V41DestroyDeletes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ExchangeID: %v", err)
 	}
-	if _, _, err := sm.CreateSession(exch.ClientID, exch.SequenceID, 0, types.ChannelAttrs{}, types.ChannelAttrs{}, 0, nil); err != nil {
+	if _, _, err := sm.CreateSession(exch.ClientID, exch.SequenceID, 0, defaultForeAttrs(), defaultBackAttrs(), 0, nil); err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
 	// Destroy requires no active sessions; tear them down first.

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -3499,11 +3499,14 @@ func (sm *StateManager) CreateSession(
 		return nil, nil, err
 	}
 
-	// Unknown flag bits are a client-contract violation rather than something
-	// to ignore: the server MUST return NFS4ERR_INVAL for any set bit it does
-	// not recognise (RFC 8881 Section 18.36.3), because silently masking would
-	// let a client believe it negotiated PERSIST or RDMA support it did not
-	// get. Only the three defined bits are accepted.
+	// Unknown flag bits draw NFS4ERR_INVAL because that is the answer the
+	// conformance suite expects (CSESS15); RFC 8881 Section 18.36.3 defines
+	// exactly three flag bits (PERSIST, CONN_BACK_CHAN, CONN_RDMA) and does
+	// not specify handling for unrecognized ones, so returning INVAL instead
+	// of silently masking is a deliberate choice: masking would let a client
+	// believe it negotiated PERSIST or RDMA support it did not get. An
+	// extension that adds a new flag bit (RFC 8178 sanctions adding bits to
+	// flag fields) must extend this check.
 	const knownFlags = uint32(types.CREATE_SESSION4_FLAG_PERSIST |
 		types.CREATE_SESSION4_FLAG_CONN_BACK_CHAN |
 		types.CREATE_SESSION4_FLAG_CONN_RDMA)

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -3486,6 +3486,34 @@ func (sm *StateManager) CreateSession(
 
 	// Case 3: New request (seqid == record.SequenceID + 1)
 
+	// A channel budget from which no COMPOUND could ever be sent must be
+	// rejected before any session state is allocated: accepting it would arm a
+	// slot table, a reply cache, and a lease for a channel that can never carry
+	// traffic, which is the resource leak the conformance suite's TOOSMALL rows
+	// probe. Negotiation itself only clamps downward from the server max and
+	// has no floor, so the floor check runs ahead of it.
+	if err := channelAttrsTooSmall(foreAttrs); err != nil {
+		return nil, nil, err
+	}
+	if err := channelAttrsTooSmall(backAttrs); err != nil {
+		return nil, nil, err
+	}
+
+	// Unknown flag bits are a client-contract violation rather than something
+	// to ignore: the server MUST return NFS4ERR_INVAL for any set bit it does
+	// not recognise (RFC 8881 Section 18.36.3), because silently masking would
+	// let a client believe it negotiated PERSIST or RDMA support it did not
+	// get. Only the three defined bits are accepted.
+	const knownFlags = uint32(types.CREATE_SESSION4_FLAG_PERSIST |
+		types.CREATE_SESSION4_FLAG_CONN_BACK_CHAN |
+		types.CREATE_SESSION4_FLAG_CONN_RDMA)
+	if flags&^knownFlags != 0 {
+		return nil, nil, &NFS4StateError{
+			Status:  types.NFS4ERR_INVAL,
+			Message: fmt.Sprintf("unknown CREATE_SESSION flag bits 0x%08x", flags&^knownFlags),
+		}
+	}
+
 	// Check per-client session limit
 	if len(sm.sessionsByClientID[clientID]) >= sm.maxSessionsPerClient {
 		return nil, nil, ErrTooManySessions

--- a/internal/adapter/nfs/v4/state/session_test.go
+++ b/internal/adapter/nfs/v4/state/session_test.go
@@ -603,6 +603,179 @@ func TestCreateSession_ChannelNegotiation(t *testing.T) {
 }
 
 // ============================================================================
+// CreateSession channel-size and flag validation tests
+// ============================================================================
+
+// TestCreateSession_TooSmallRequestSize pins NFS4ERR_TOOSMALL for a channel
+// whose ca_maxrequestsize can never carry a COMPOUND request: the session must
+// be rejected before any slot table, reply cache, or lease is armed for it.
+func TestCreateSession_TooSmallRequestSize(t *testing.T) {
+	sm := NewStateManager(DefaultLeaseDuration)
+	clientID, seqID := registerV41Client(t, sm)
+
+	tooSmallFore := defaultForeAttrs()
+	tooSmallFore.MaxRequestSize = 20
+
+	_, _, err := sm.CreateSession(
+		clientID, seqID, 0,
+		tooSmallFore, defaultBackAttrs(), 0, nil,
+	)
+	if err == nil {
+		t.Fatal("Expected TOOSMALL for a 20-byte ca_maxrequestsize")
+	}
+	if stateErr, ok := err.(*NFS4StateError); !ok || stateErr.Status != types.NFS4ERR_TOOSMALL {
+		t.Errorf("Expected NFS4ERR_TOOSMALL (%d), got: %v", types.NFS4ERR_TOOSMALL, err)
+	}
+
+	// The rejected request consumed no sequence ID: a retry with a workable
+	// budget at the same seqid must succeed, proving no state leaked.
+	smallBack := defaultBackAttrs()
+	smallBack.MaxRequestSize = 10
+	_, _, err = sm.CreateSession(
+		clientID, seqID, 0,
+		defaultForeAttrs(), smallBack, 0, nil,
+	)
+	if err == nil {
+		t.Fatal("Expected TOOSMALL for a 10-byte back-channel ca_maxrequestsize")
+	}
+	if stateErr, ok := err.(*NFS4StateError); !ok || stateErr.Status != types.NFS4ERR_TOOSMALL {
+		t.Errorf("Expected NFS4ERR_TOOSMALL (%d) on the back channel, got: %v", types.NFS4ERR_TOOSMALL, err)
+	}
+
+	result, _, err := sm.CreateSession(
+		clientID, seqID, 0,
+		defaultForeAttrs(), defaultBackAttrs(), 0, nil,
+	)
+	if err != nil {
+		t.Fatalf("CreateSession with workable budgets after two rejections: %v", err)
+	}
+	if result.SessionID == (types.SessionId4{}) {
+		t.Error("SessionID should be non-zero after the accepted request")
+	}
+}
+
+// TestCreateSession_TooSmallResponseSize pins NFS4ERR_TOOSMALL for a channel
+// whose ca_maxresponsesize can never carry a COMPOUND reply.
+func TestCreateSession_TooSmallResponseSize(t *testing.T) {
+	sm := NewStateManager(DefaultLeaseDuration)
+	clientID, seqID := registerV41Client(t, sm)
+
+	tooSmallFore := defaultForeAttrs()
+	tooSmallFore.MaxResponseSize = 0
+
+	_, _, err := sm.CreateSession(
+		clientID, seqID, 0,
+		tooSmallFore, defaultBackAttrs(), 0, nil,
+	)
+	if err == nil {
+		t.Fatal("Expected TOOSMALL for a zero ca_maxresponsesize")
+	}
+	if stateErr, ok := err.(*NFS4StateError); !ok || stateErr.Status != types.NFS4ERR_TOOSMALL {
+		t.Errorf("Expected NFS4ERR_TOOSMALL (%d), got: %v", types.NFS4ERR_TOOSMALL, err)
+	}
+
+	// A small-but-workable response budget is accepted: the floor must stay
+	// under it, because the reference suite negotiates one and then forces
+	// reply-size answers on the operations that overflow it.
+	workable := defaultForeAttrs()
+	workable.MaxResponseSize = 400
+	if _, _, err := sm.CreateSession(
+		clientID, seqID, 0,
+		workable, defaultBackAttrs(), 0, nil,
+	); err != nil {
+		t.Fatalf("A 400-byte ca_maxresponsesize must be accepted, got: %v", err)
+	}
+}
+
+// TestCreateSession_SmallCacheSizeAccepted pins that ca_maxresponsesize_cached
+// is NOT floored: an unusable cache budget is answered with
+// NFS4ERR_REP_TOO_BIG_TO_CACHE on the operation that overflows it, not a
+// CREATE_SESSION rejection, so creating the session must succeed.
+func TestCreateSession_SmallCacheSizeAccepted(t *testing.T) {
+	sm := NewStateManager(DefaultLeaseDuration)
+	clientID, seqID := registerV41Client(t, sm)
+
+	smallCache := defaultForeAttrs()
+	smallCache.MaxResponseSizeCached = 10
+
+	result, _, err := sm.CreateSession(
+		clientID, seqID, 0,
+		smallCache, defaultBackAttrs(), 0, nil,
+	)
+	if err != nil {
+		t.Fatalf("A 10-byte ca_maxresponsesize_cached must not reject the session: %v", err)
+	}
+	if result.ForeChannelAttrs.MaxResponseSizeCached != 10 {
+		t.Errorf("negotiated MaxResponseSizeCached = %d, want the client's 10",
+			result.ForeChannelAttrs.MaxResponseSizeCached)
+	}
+}
+
+// TestCreateSession_UnknownFlagBits pins NFS4ERR_INVAL for flag bits the server
+// does not recognise: silently masking would let a client believe it negotiated
+// support it did not get.
+func TestCreateSession_UnknownFlagBits(t *testing.T) {
+	sm := NewStateManager(DefaultLeaseDuration)
+	clientID, seqID := registerV41Client(t, sm)
+
+	_, _, err := sm.CreateSession(
+		clientID, seqID, 0xf,
+		defaultForeAttrs(), defaultBackAttrs(), 0, nil,
+	)
+	if err == nil {
+		t.Fatal("Expected INVAL for undefined flag bits (0xf has bit 3 set)")
+	}
+	if stateErr, ok := err.(*NFS4StateError); !ok || stateErr.Status != types.NFS4ERR_INVAL {
+		t.Errorf("Expected NFS4ERR_INVAL (%d), got: %v", types.NFS4ERR_INVAL, err)
+	}
+
+	// All three defined bits together are accepted.
+	all := uint32(types.CREATE_SESSION4_FLAG_PERSIST |
+		types.CREATE_SESSION4_FLAG_CONN_BACK_CHAN |
+		types.CREATE_SESSION4_FLAG_CONN_RDMA)
+	if _, _, err := sm.CreateSession(
+		clientID, seqID, all,
+		defaultForeAttrs(), defaultBackAttrs(), 0, nil,
+	); err != nil {
+		t.Fatalf("The three defined flag bits together must be accepted, got: %v", err)
+	}
+}
+
+// TestCreateSession_SessionLimitStatus pins that the per-client session-limit
+// sentinel carries NFS4ERR_NOSPC: NFS4ERR_RESOURCE is absent from
+// CREATE_SESSION's valid-error list in RFC 8881 Section 18.36.
+func TestCreateSession_SessionLimitStatus(t *testing.T) {
+	sm := NewStateManager(DefaultLeaseDuration)
+	sm.mu.Lock()
+	sm.maxSessionsPerClient = 1
+	sm.mu.Unlock()
+
+	clientID, seqID := registerV41Client(t, sm)
+
+	if _, _, err := sm.CreateSession(
+		clientID, seqID, 0,
+		defaultForeAttrs(), defaultBackAttrs(), 0, nil,
+	); err != nil {
+		t.Fatalf("first CreateSession: %v", err)
+	}
+	sm.CacheCreateSessionResponse(clientID, []byte("cached"))
+
+	_, _, err := sm.CreateSession(
+		clientID, seqID+1, 0,
+		defaultForeAttrs(), defaultBackAttrs(), 0, nil,
+	)
+	if err == nil {
+		t.Fatal("Expected an error for the per-client session limit")
+	}
+	if !errors.Is(err, ErrTooManySessions) {
+		t.Errorf("Expected ErrTooManySessions, got: %v", err)
+	}
+	if stateErr, ok := err.(*NFS4StateError); !ok || stateErr.Status != types.NFS4ERR_NOSPC {
+		t.Errorf("Expected NFS4ERR_NOSPC (%d), got status: %v", types.NFS4ERR_NOSPC, err)
+	}
+}
+
+// ============================================================================
 // DestroySession Tests
 // ============================================================================
 

--- a/internal/adapter/nfs/v4/state/session_test.go
+++ b/internal/adapter/nfs/v4/state/session_test.go
@@ -642,6 +642,8 @@ func TestCreateSession_TooSmallRequestSize(t *testing.T) {
 		t.Errorf("Expected NFS4ERR_TOOSMALL (%d) on the back channel, got: %v", types.NFS4ERR_TOOSMALL, err)
 	}
 
+	// A 400-byte request budget is workable (CSESS26 creates exactly that and
+	// expects success), so the floor must stay under it.
 	result, _, err := sm.CreateSession(
 		clientID, seqID, 0,
 		defaultForeAttrs(), defaultBackAttrs(), 0, nil,

--- a/internal/adapter/nfs/v4/state/session_test.go
+++ b/internal/adapter/nfs/v4/state/session_test.go
@@ -644,9 +644,11 @@ func TestCreateSession_TooSmallRequestSize(t *testing.T) {
 
 	// A 400-byte request budget is workable (CSESS26 creates exactly that and
 	// expects success), so the floor must stay under it.
+	csess26 := defaultForeAttrs()
+	csess26.MaxRequestSize = 400
 	result, _, err := sm.CreateSession(
 		clientID, seqID, 0,
-		defaultForeAttrs(), defaultBackAttrs(), 0, nil,
+		csess26, defaultBackAttrs(), 0, nil,
 	)
 	if err != nil {
 		t.Fatalf("CreateSession with workable budgets after two rejections: %v", err)

--- a/internal/adapter/nfs/v4/state/stateid_authz_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_authz_test.go
@@ -276,7 +276,7 @@ func TestExchangeID_Case2_PrincipalMismatch(t *testing.T) {
 		t.Fatalf("ExchangeID (alice): %v", err)
 	}
 	if _, _, err := sm.CreateSession(exch.ClientID, exch.SequenceID, 0,
-		types.ChannelAttrs{}, types.ChannelAttrs{}, 0, nil, "alice"); err != nil {
+		defaultForeAttrs(), defaultBackAttrs(), 0, nil, "alice"); err != nil {
 		t.Fatalf("CreateSession (alice): %v", err)
 	}
 

--- a/internal/adapter/nfs/v4/state/v41_client.go
+++ b/internal/adapter/nfs/v4/state/v41_client.go
@@ -667,6 +667,43 @@ func DefaultForeLimits() ChannelLimits {
 	}
 }
 
+// Channel size floors. A requested budget below these cannot carry a COMPOUND
+// at all: the XDR framing of even a status-only COMPOUND request or reply
+// exceeds it, so CREATE_SESSION answers NFS4ERR_TOOSMALL instead of
+// negotiating a channel that can never carry traffic (RFC 8881 Section
+// 18.36.3 permits exactly that answer for a value from which a replier on a
+// channel could never send). The floors sit well under the page-sized channel
+// budgets small clients request, and over the budgets the conformance suite
+// uses to force reply-size answers on later operations; that suite also pins
+// a small-but-workable ca_maxresponsesize as accepted, so the response floor
+// must stay under it.
+const (
+	minChannelRequestSize  uint32 = 1024
+	minChannelResponseSize uint32 = 256
+)
+
+// channelAttrsTooSmall returns an NFS4ERR_TOOSMALL error when a requested
+// channel could never carry a COMPOUND request or reply. MaxResponseSizeCached
+// is deliberately not floored here: the answer to an unusable cache budget is
+// NFS4ERR_REP_TOO_BIG_TO_CACHE on the operation that overflows it, not a
+// CREATE_SESSION rejection.
+func channelAttrsTooSmall(requested types.ChannelAttrs) *NFS4StateError {
+	switch {
+	case requested.MaxRequestSize < minChannelRequestSize:
+		return &NFS4StateError{
+			Status:  types.NFS4ERR_TOOSMALL,
+			Message: fmt.Sprintf("ca_maxrequestsize %d below the %d-byte floor; no COMPOUND request could fit", requested.MaxRequestSize, minChannelRequestSize),
+		}
+	case requested.MaxResponseSize < minChannelResponseSize:
+		return &NFS4StateError{
+			Status:  types.NFS4ERR_TOOSMALL,
+			Message: fmt.Sprintf("ca_maxresponsesize %d below the %d-byte floor; no COMPOUND reply could fit", requested.MaxResponseSize, minChannelResponseSize),
+		}
+	default:
+		return nil
+	}
+}
+
 // DefaultBackLimits returns the default server limits for back channel negotiation.
 // MaxSlots must be at least 16 because the Linux kernel NFS client requests 16
 // back channel slots and rejects CREATE_SESSION with EINVAL if the server
@@ -742,7 +779,10 @@ var (
 	ErrDelay = &NFS4StateError{Status: types.NFS4ERR_DELAY, Message: "operation in progress, retry later"}
 
 	// ErrTooManySessions indicates the per-client session limit has been reached.
-	ErrTooManySessions = &NFS4StateError{Status: types.NFS4ERR_RESOURCE, Message: "per-client session limit exceeded"}
+	// NFS4ERR_RESOURCE is absent from CREATE_SESSION's valid-error list in
+	// RFC 8881 Section 18.36; the resource-exhaustion answer there is
+	// NFS4ERR_NOSPC, which is what this sentinel must carry.
+	ErrTooManySessions = &NFS4StateError{Status: types.NFS4ERR_NOSPC, Message: "per-client session limit exceeded"}
 
 	// ErrSeqMisordered indicates a CREATE_SESSION sequence ID mismatch.
 	ErrSeqMisordered = &NFS4StateError{Status: types.NFS4ERR_SEQ_MISORDERED, Message: "sequence ID misordered"}

--- a/internal/adapter/nfs/v4/state/v41_client.go
+++ b/internal/adapter/nfs/v4/state/v41_client.go
@@ -671,14 +671,14 @@ func DefaultForeLimits() ChannelLimits {
 // at all: the XDR framing of even a status-only COMPOUND request or reply
 // exceeds it, so CREATE_SESSION answers NFS4ERR_TOOSMALL instead of
 // negotiating a channel that can never carry traffic (RFC 8881 Section
-// 18.36.3 permits exactly that answer for a value from which a replier on a
-// channel could never send). The floors sit well under the page-sized channel
-// budgets small clients request, and over the budgets the conformance suite
-// uses to force reply-size answers on later operations; that suite also pins
-// a small-but-workable ca_maxresponsesize as accepted, so the response floor
-// must stay under it.
+// 18.36.3: if a replier on a channel could never send a response, the server
+// SHOULD return NFS4ERR_TOOSMALL). Both floors sit under the small-but-workable
+// budgets the conformance suite accepts (request 400, response 400, whose
+// reply-size answers fire at COMPOUND time) and over the budgets it forces
+// TOOSMALL answers on (request 20 and 10, response 0), so the floors must stay
+// inside (20, 400] on the request side and (0, 400] on the response side.
 const (
-	minChannelRequestSize  uint32 = 1024
+	minChannelRequestSize  uint32 = 256
 	minChannelResponseSize uint32 = 256
 )
 

--- a/internal/adapter/nfs/v4/state/v41_client_test.go
+++ b/internal/adapter/nfs/v4/state/v41_client_test.go
@@ -402,7 +402,7 @@ func TestExchangeID_ConfirmedReboot(t *testing.T) {
 
 	// Confirm the first incarnation the way a client does.
 	if _, _, err := sm.CreateSession(result1.ClientID, result1.SequenceID, 0,
-		types.ChannelAttrs{}, types.ChannelAttrs{}, 0, nil); err != nil {
+		defaultForeAttrs(), defaultBackAttrs(), 0, nil); err != nil {
 		t.Fatalf("CreateSession error: %v", err)
 	}
 
@@ -437,7 +437,7 @@ func TestExchangeID_ConfirmedReboot(t *testing.T) {
 
 	// Confirming the new client ID collapses the two records into one.
 	if _, _, err := sm.CreateSession(result2.ClientID, result2.SequenceID, 0,
-		types.ChannelAttrs{}, types.ChannelAttrs{}, 0, nil); err != nil {
+		defaultForeAttrs(), defaultBackAttrs(), 0, nil); err != nil {
 		t.Fatalf("CreateSession on the new incarnation: %v", err)
 	}
 	sm.mu.RLock()

--- a/internal/adapter/nfs/v4/types/create_session_test.go
+++ b/internal/adapter/nfs/v4/types/create_session_test.go
@@ -114,6 +114,58 @@ func TestCreateSessionArgs_RoundTrip_MultipleSec(t *testing.T) {
 	}
 }
 
+// TestCreateSessionArgs_DecodeMixedSecParms pins the inner-loop index handling
+// of csa_sec_parms decoding: the array carries AUTH_NONE, RPCSEC_GSS and
+// AUTH_SYS entries in that order, and the decoder must advance the stream by
+// each entry's own XDR size rather than reslicing from a stale index, which
+// desyncs every following entry (the decode problem the reference suite's
+// mixed-order row probes). The GSS entry between the two also pins that a
+// zero-length AUTH_SYS gid list after a variable-length entry decodes intact.
+func TestCreateSessionArgs_DecodeMixedSecParms(t *testing.T) {
+	original := &CreateSessionArgs{
+		ClientID:         0xfeedfacecafef00d,
+		SequenceID:       1,
+		Flags:            0,
+		ForeChannelAttrs: ValidChannelAttrs(),
+		BackChannelAttrs: ValidChannelAttrs(),
+		CbProgram:        123,
+		CbSecParms: []CallbackSecParms4{
+			{CbSecFlavor: 0}, // AUTH_NONE: void, smallest possible entry
+			{CbSecFlavor: 6, RpcGssData: []byte("handle-from-server")},                                                   // RPCSEC_GSS: variable-length
+			{CbSecFlavor: 1, AuthSysParms: &AuthSysParms{Stamp: 5, MachineName: "Random machine name", UID: 7, GID: 11}}, // AUTH_SYS, empty gids
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := original.Encode(&buf); err != nil {
+		t.Fatalf("Encode failed: %v", err)
+	}
+
+	decoded := &CreateSessionArgs{}
+	if err := decoded.Decode(bytes.NewReader(buf.Bytes())); err != nil {
+		t.Fatalf("Decode of mixed sec_parms failed: %v", err)
+	}
+
+	if len(decoded.CbSecParms) != 3 {
+		t.Fatalf("CbSecParms length = %d, want 3", len(decoded.CbSecParms))
+	}
+	if decoded.CbSecParms[0].CbSecFlavor != 0 {
+		t.Errorf("entry[0] flavor = %d, want 0 (AUTH_NONE)", decoded.CbSecParms[0].CbSecFlavor)
+	}
+	if decoded.CbSecParms[1].CbSecFlavor != 6 || string(decoded.CbSecParms[1].RpcGssData) != "handle-from-server" {
+		t.Errorf("entry[1] roundtrip failed: flavor %d, data %q",
+			decoded.CbSecParms[1].CbSecFlavor, decoded.CbSecParms[1].RpcGssData)
+	}
+	p := decoded.CbSecParms[2].AuthSysParms
+	if decoded.CbSecParms[2].CbSecFlavor != 1 || p == nil || p.MachineName != "Random machine name" || p.UID != 7 || p.GID != 11 || len(p.GIDs) != 0 {
+		t.Errorf("entry[2] roundtrip failed: flavor %d, parms %+v",
+			decoded.CbSecParms[2].CbSecFlavor, p)
+	}
+	if decoded.CbProgram != 123 {
+		t.Errorf("CbProgram = %d, want 123 (a desynced decode would land elsewhere)", decoded.CbProgram)
+	}
+}
+
 // TestCreateSessionRes_RoundTrip tests a success response with negotiated attrs.
 func TestCreateSessionRes_RoundTrip(t *testing.T) {
 	original := &CreateSessionRes{


### PR DESCRIPTION
Closes #2471

## Summary

CREATE_SESSION did not enforce the negotiated channel sizes and answered the per-client
session cap with an error that is not in its valid list. This PR:

1. **NFS4ERR_TOOSMALL enforcement** — a channel budget from which no COMPOUND could ever be
   sent (`ca_maxrequestsize < 256`, `ca_maxresponsesize < 256`) is rejected before any slot
   table, reply cache, or lease is armed. Previously `NFS4ERR_TOOSMALL` had no use anywhere
   in the session code. Pins pynfs CSESS25 (response 0), CSESS28 (request 20), CSESS29
   (back-channel request 10 + ca_maxops 1). RFC 8881 §18.36.3: "if the client selects a
   value for ca_maxresponsesize such that a replier on a channel could never send a
   response, the server SHOULD return NFS4ERR_TOOSMALL".
2. **NFS4ERR_INVAL for unknown flag bits** — any set bit outside the three defined
   `CREATE_SESSION4_FLAG_*` bits is rejected instead of silently masked. **Scope note:**
   RFC 8881 §18.36.3 defines the three bits but does *not* specify handling for
   unrecognized ones (pynfs's own CSESS15 comment flags this: "Where is this required?").
   INVAL is what the conformance suite expects and what knfsd-compatible behavior requires;
   masking would let a client believe it negotiated PERSIST/RDMA support it did not get.
   An extension RFC that adds a new flag bit (RFC 8178 sanctions adding bits to flag
   fields) must extend the check. Pins pynfs CSESS15.
3. **`ca_maxresponsesize_cached` deliberately unfloored** — the answer to an unusable cache
   budget is `NFS4ERR_REP_TOO_BIG_TO_CACHE` on the operation that overflows it, not a
   CREATE_SESSION rejection. Small cache budgets are accepted and negotiated verbatim.
4. **Session cap carries `NFS4ERR_NOSPC`** — `ErrTooManySessions` previously answered
   `NFS4ERR_RESOURCE`, which is absent from §18.36's error list. RFC 8881 §18.36.4
   explicitly mandates NOSPC for session creation: "allocating space for the session reply
   cache (if there is not enough space, the server returns NFS4ERR_NOSPC)". A hard
   configured ceiling; a retry cannot help.
5. **CSESS16a decode round-trip** — a Go test pins the mixed-order `csa_sec_parms` decode
   (AUTH_NONE → RPCSEC_GSS → AUTH_SYS with an empty gid list), the index-desync problem the
   suite's row probes.

## Per-row evidence

| Row | Mechanism | Proof |
| --- | --- | --- |
| CSESS15 | unknown flag bits → `NFS4ERR_INVAL` (suite expectation; RFC does not mandate — see note above) | `TestCreateSession_UnknownFlagBits` (state/session_test.go) |
| CSESS25 | sub-floor `ca_maxresponsesize` (0) → `NFS4ERR_TOOSMALL` | `TestCreateSession_TooSmallResponseSize` |
| CSESS26 | request 400 + response 400 **accepted**; REP_TOO_BIG fires later at COMPOUND time | `TestCreateSession_TooSmallRequestSize`'s 400-accepted assertion (request-side); COMPOUND-layer REP_TOO_BIG check itself needs the post-merge pynfs run — see below |
| CSESS27 | `ca_maxresponsesize_cached` 10 **accepted**; REP_TOO_BIG_TO_CACHE fires later on SEQUENCE cachethis=True | `TestCreateSession_SmallCacheSizeAccepted` (creation side); SEQUENCE-layer check needs the post-merge pynfs run |
| CSESS28 | sub-floor `ca_maxrequestsize` (20) → `NFS4ERR_TOOSMALL` | `TestCreateSession_TooSmallRequestSize` |
| CSESS29 | 10000× rejected sub-floor back-channel budgets; no DRC/slot-table leak | TOOSMALL path verified (`TestCreateSession_TooSmallRequestSize`'s back-channel rejection); the rejected-request-consumes-nothing assertion (retry at the same seqid succeeds) proves no state leaked; 10000-iteration loop itself needs the post-merge pynfs run |

## Rows not proven locally (need the pynfs harness)

- **CSESS26** (`NFS4ERR_REP_TOO_BIG` when a COMPOUND reply exceeds `ca_maxresponsesize`) and
  **CSESS27** (`NFS4ERR_REP_TOO_BIG_TO_CACHE` when a cached reply exceeds
  `ca_maxresponsesize_cached`) fire at COMPOUND/SEQUENCE execution time, driven by the
  session's negotiated budget. The creation-side preconditions this PR lands are pinned by
  Go tests (400/400 accepted, cache budget accepted verbatim); the execution-layer checks
  themselves live in the COMPOUND/slot layer and are exercised by the pynfs run after
  merge (the suites are exclusive; a confirmation run happens post-merge).
- **CSESS29's** 10000-iteration loop and CSESS26's 4×GETATTR COMPOUND likewise need the
  live harness; their state-level mechanisms (TOOSMALL rejection, no seqid consumption) are
  pinned here.
- CSESS23 (`NFS4ERR_NOT_ONLY_OP`) is **already fixed** by #2481 — verified:
  `TestCompound_V41_ExemptOpNotOnlyOp` covers it; no change needed here.

## Scope guards honored

- BIND_CONN_TO_SESSION (#2371's other half, `NFS4ERR_DELAY`) and the stale doc at
  `v41/handlers/bind_conn_to_session.go:16` are **untouched**.
- `manager.go` edits confined to the `CreateSession` session region (~line 3486);
  the client-index region (~1169) untouched.

## Verification

- `go build ./...` OK; `go vet` OK; `gofmt` clean
- `go test -race -count=1 ./internal/adapter/nfs/v4/state/ ./internal/adapter/nfs/v4/types/` OK
- `go test -count=1 ./...` green
- Rebased onto `origin/develop` (`8d4b84d62`), signed commits
- RFC 8881 §18.36 verified from rfc-editor.org; pynfs `st_create_session.py` verified at
  the locked rev (`cd4701827`, blob `740f8bf2`) — all row expectations above taken from
  source, not from memory
