### PR TITLE
retry a failed reclaim-complete persist with backoff (#2487)

### DIFF
--- a/internal/adapter/nfs/v4/state/client.go
+++ b/internal/adapter/nfs/v4/state/client.go
@@ -169,10 +169,13 @@ type ClientRecord struct {
 	// Keyed by hex-encoded owner data. v4.0 only.
 	OpenOwners map[string]*OpenOwner
 
-	// ReclaimComplete records that this client has sent RECLAIM_COMPLETE, so a
-	// second one draws NFS4ERR_COMPLETE_ALREADY. v4.1 only: v4.0 has no such
-	// operation. It holds whether or not a grace window was ever opened, and a
-	// client instance that re-registers gets a fresh record with it clear.
+	// ReclaimComplete records that this client has completed its reclaim:
+	// RECLAIM_COMPLETE sent (v4.1), or the first successful CLAIM_PREVIOUS
+	// served (v4.0 has no RECLAIM_COMPLETE operation). A second v4.1
+	// RECLAIM_COMPLETE draws NFS4ERR_COMPLETE_ALREADY. It holds whether or not
+	// a grace window was ever opened, and a client instance that re-registers
+	// gets a fresh record with it clear. A pending reclaim-complete persist
+	// retry also re-validates against this flag before writing durably.
 	ReclaimComplete bool
 
 	// CBPathUp indicates whether the callback path to this client has been

--- a/internal/adapter/nfs/v4/state/client_recovery.go
+++ b/internal/adapter/nfs/v4/state/client_recovery.go
@@ -126,9 +126,10 @@ const (
 // chain, so a down backend cannot pile up attempts and a new issuer's persist
 // failure cannot be skipped while an old chain lives. Before each write the
 // retry re-validates that the issuing client still holds the key, so a client
-// that re-registers (and whose durable record is then deleted or replaced)
-// never has a stale retry stamp ReclaimComplete over the fresh incarnation's
-// record.
+// that re-registers (and whose durable record is then deleted or replaced) is
+// in the common case skipped by the validation; the write is best-effort and
+// out of lock, so a narrow stale-success window remains (a retry racing the
+// removal path) and self-heals on the client's next reclaim-complete.
 type pendingReclaimPersist struct {
 	key      string
 	clientID uint64

--- a/internal/adapter/nfs/v4/state/client_recovery.go
+++ b/internal/adapter/nfs/v4/state/client_recovery.go
@@ -139,19 +139,26 @@ type pendingReclaimPersist struct {
 // (v4.1 RECLAIM_COMPLETE, or first CLAIM_PREVIOUS for v4.0) so a second restart
 // inside one grace window does not wait on an already-reclaimed client.
 // Best-effort, bounded timeout. No-op when no recovery store is wired.
-// Caller must hold sm.mu.
+// The decision runs under sm.mu (caller holds it); the store write itself
+// runs after the caller releases the lock, so a slow backend never wedges
+// state operations — the same discipline the retry chain follows.
 func (sm *StateManager) recordReclaimCompleteLocked(clientID uint64, key string) {
 	if sm.recoveryStore == nil {
 		return
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), recoveryPersistTimeout)
-	defer cancel()
-	if err := sm.recoveryStore.RecordReclaimComplete(ctx, key); err != nil {
-		logger.Error("client-recovery reclaim-complete persistence failed: retrying in background; until it lands a second restart may re-wait on this client",
-			"client_id_str", key,
-			"error", err)
-		sm.scheduleReclaimPersistRetryLocked(clientID, key, reclaimPersistRetryBase)
-	}
+	store := sm.recoveryStore
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), recoveryPersistTimeout)
+		defer cancel()
+		if err := store.RecordReclaimComplete(ctx, key); err != nil {
+			logger.Error("client-recovery reclaim-complete persistence failed: retrying in background; until it lands a second restart may re-wait on this client",
+				"client_id_str", key,
+				"error", err)
+			sm.mu.Lock()
+			sm.scheduleReclaimPersistRetryLocked(clientID, key, reclaimPersistRetryBase)
+			sm.mu.Unlock()
+		}
+	}()
 }
 
 // scheduleReclaimPersistRetryLocked arms the asynchronous retry of a failed

--- a/internal/adapter/nfs/v4/state/client_recovery.go
+++ b/internal/adapter/nfs/v4/state/client_recovery.go
@@ -270,11 +270,8 @@ func (sm *StateManager) retryReclaimPersist(pending *pendingReclaimPersist) {
 // clientHoldsKeyLocked reports whether the given client still owns the recovery
 // key and has ReclaimComplete set in memory. Caller must hold sm.mu (write).
 func (sm *StateManager) clientHoldsKeyLocked(clientID uint64, key string) bool {
-	rec, ok := sm.clientsByID[clientID]
-	if !ok {
-		rec, ok = sm.v41ClientsByID[clientID]
-	}
-	if !ok {
+	rec := sm.clientRecordLocked(clientID)
+	if rec == nil {
 		return false
 	}
 	switch {

--- a/internal/adapter/nfs/v4/state/client_recovery.go
+++ b/internal/adapter/nfs/v4/state/client_recovery.go
@@ -168,9 +168,11 @@ func (sm *StateManager) recordReclaimCompleteLocked(clientID uint64, key string)
 // which is what recoveryPersistTimeout exists to prevent), and re-validates
 // before each write that the client that issued the mark still holds the key
 // — a client that re-registers after a restart gets a fresh in-memory record
-// with ReclaimComplete clear, so the fresh incarnation must still send
-// RECLAIM_COMPLETE and a stale retry must not stamp its durable record as
-// done. At most one chain per key exists: a schedule while an entry lives
+// with ReclaimComplete clear, so a stale retry is abandoned once the issuer
+// is gone and in the common case never reaches the durable write; the write
+// runs out of lock, so a narrow stale-success window remains (a retry racing
+// the removal path) and self-heals on the client's next reclaim-complete.
+// At most one chain per key exists: a schedule while an entry lives
 // adopts it (updating the issuer and arming a fresh timer at the new delay;
 // the old timer's fire becomes a no-op retry that finds the same entry and
 // either lands the write or reschedules with the adopted state). Caller must
@@ -219,6 +221,13 @@ func (sm *StateManager) retryReclaimPersist(pending *pendingReclaimPersist) {
 	store := sm.recoveryStore
 	if store == nil {
 		delete(sm.pendingReclaimPersists, pending.key)
+		sm.mu.Unlock()
+		return
+	}
+	// A stale timer (whose chain succeeded, was adopted, or was replaced) must
+	// not issue a store write for an entry it no longer owns: drop the entry
+	// when this timer's chain is not the live one.
+	if live, ok := sm.pendingReclaimPersists[pending.key]; !ok || live != pending {
 		sm.mu.Unlock()
 		return
 	}

--- a/internal/adapter/nfs/v4/state/client_recovery.go
+++ b/internal/adapter/nfs/v4/state/client_recovery.go
@@ -119,16 +119,20 @@ const (
 )
 
 // pendingReclaimPersist carries one retry of a failed reclaim-complete persist:
-// the recovery key, the incarnation that issued the mark, and the next backoff
-// delay. The pointer identity is the only tracking a retry needs; before each
-// write it re-validates that the issuing incarnation still holds the key, so a
-// client that re-registers (and whose durable record is then deleted or
-// replaced) never has a stale retry stamp ReclaimComplete over the fresh
-// incarnation's record.
+// the recovery key, the client ID that issued the mark, and the next backoff
+// delay. The pendingReclaimPersists map on StateManager tracks at most one
+// chain per key: a re-schedule while an entry exists adopts the live entry
+// (updating its client ID to the latest issuer) instead of forking a second
+// chain, so a down backend cannot pile up attempts and a new issuer's persist
+// failure cannot be skipped while an old chain lives. Before each write the
+// retry re-validates that the issuing client still holds the key, so a client
+// that re-registers (and whose durable record is then deleted or replaced)
+// never has a stale retry stamp ReclaimComplete over the fresh incarnation's
+// record.
 type pendingReclaimPersist struct {
-	key         string
-	incarnation uint64
-	delay       time.Duration
+	key      string
+	clientID uint64
+	delay    time.Duration
 }
 
 // recordReclaimCompleteLocked marks a client's recovery record reclaim-complete
@@ -136,54 +140,44 @@ type pendingReclaimPersist struct {
 // inside one grace window does not wait on an already-reclaimed client.
 // Best-effort, bounded timeout. No-op when no recovery store is wired.
 // Caller must hold sm.mu.
-func (sm *StateManager) recordReclaimCompleteLocked(clientIDString string) {
+func (sm *StateManager) recordReclaimCompleteLocked(clientID uint64, key string) {
 	if sm.recoveryStore == nil {
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), recoveryPersistTimeout)
 	defer cancel()
-	if err := sm.recoveryStore.RecordReclaimComplete(ctx, clientIDString); err != nil {
+	if err := sm.recoveryStore.RecordReclaimComplete(ctx, key); err != nil {
 		logger.Error("client-recovery reclaim-complete persistence failed: retrying in background; until it lands a second restart may re-wait on this client",
-			"client_id_str", clientIDString,
+			"client_id_str", key,
 			"error", err)
-		sm.scheduleReclaimPersistRetryLocked(clientIDString, reclaimPersistRetryBase)
+		sm.scheduleReclaimPersistRetryLocked(clientID, key, reclaimPersistRetryBase)
 	}
 }
 
-// scheduleReclaimPersistRetryLocked arms one asynchronous retry of a failed
+// scheduleReclaimPersistRetryLocked arms the asynchronous retry of a failed
 // reclaim-complete persist. The retry runs OFF sm.mu (a synchronous backoff
 // under the lock would wedge every state operation behind the down backend,
 // which is what recoveryPersistTimeout exists to prevent), and re-validates
-// before each write that the client incarnation that issued the mark still
-// holds the key — a client that re-registers after a restart gets a fresh
-// in-memory record with ReclaimComplete clear, so the fresh incarnation must
-// still send RECLAIM_COMPLETE and a stale retry must not stamp its durable
-// record as done. Caller must hold sm.mu.
-func (sm *StateManager) scheduleReclaimPersistRetryLocked(key string, delay time.Duration) {
+// before each write that the client that issued the mark still holds the key
+// — a client that re-registers after a restart gets a fresh in-memory record
+// with ReclaimComplete clear, so the fresh incarnation must still send
+// RECLAIM_COMPLETE and a stale retry must not stamp its durable record as
+// done. At most one chain per key exists: a schedule while an entry lives
+// adopts it. Caller must hold sm.mu.
+func (sm *StateManager) scheduleReclaimPersistRetryLocked(clientID uint64, key string, delay time.Duration) {
 	if sm.recoveryStore == nil {
 		return
 	}
-	// Identify the incarnation by the client record that currently owns this
-	// recovery key. The roster key is either a v4.0 nfs_client_id4 string or
-	// the v4.1 v41RecoveryKey(ownerID) form, so resolve whichever table the
-	// key lives in.
-	var incarnation uint64
-	for id, rec := range sm.clientsByID {
-		if rec.ClientIDString == key {
-			incarnation = id
-			break
-		}
-	}
-	if incarnation == 0 {
-		for id, rec := range sm.v41ClientsByID {
-			if v41RecoveryKey(rec.OwnerID) == key {
-				incarnation = id
-				break
-			}
-		}
+	if pending, ok := sm.pendingReclaimPersists[key]; ok {
+		// Adopt the live chain: point it at the latest issuer so the validity
+		// check tracks the client whose persist most recently failed.
+		pending.clientID = clientID
+		pending.delay = delay
+		return
 	}
 
-	pending := &pendingReclaimPersist{key: key, incarnation: incarnation, delay: delay}
+	pending := &pendingReclaimPersist{key: key, clientID: clientID, delay: delay}
+	sm.pendingReclaimPersists[key] = pending
 	go func() {
 		timer := time.NewTimer(delay)
 		defer timer.Stop()
@@ -193,7 +187,7 @@ func (sm *StateManager) scheduleReclaimPersistRetryLocked(key string, delay time
 }
 
 // retryReclaimPersist runs one retry of a failed reclaim-complete persist.
-// On success or on an incarnation that no longer holds the key (re-registered,
+// On success or on an issuer that no longer holds the key (re-registered,
 // expired, destroyed) the pending entry is dropped; on a store failure it
 // reschedules itself with the backoff doubled up to reclaimPersistRetryCap.
 // Thread-safe: acquires sm.mu.
@@ -204,17 +198,23 @@ func (sm *StateManager) retryReclaimPersist(pending *pendingReclaimPersist) {
 		sm.mu.Unlock()
 		return
 	}
-	// The incarnation that issued the mark must still hold the key: its
-	// in-memory record's ReclaimComplete is what the durable write mirrors.
-	if !sm.incarnationHoldsKeyLocked(pending.key, pending.incarnation) {
+	// The client that issued the mark must still hold the key: its in-memory
+	// record's ReclaimComplete is what the durable write mirrors.
+	if !sm.clientHoldsKeyLocked(pending.clientID, pending.key) {
+		delete(sm.pendingReclaimPersists, pending.key)
 		sm.mu.Unlock()
 		return
 	}
+	sm.mu.Unlock()
+
 	ctx, cancel := context.WithTimeout(context.Background(), recoveryPersistTimeout)
 	defer cancel()
 	err := store.RecordReclaimComplete(ctx, pending.key)
+
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
 	if err == nil {
-		sm.mu.Unlock()
+		delete(sm.pendingReclaimPersists, pending.key)
 		return
 	}
 	delay := pending.delay * 2
@@ -222,7 +222,6 @@ func (sm *StateManager) retryReclaimPersist(pending *pendingReclaimPersist) {
 		delay = reclaimPersistRetryCap
 	}
 	pending.delay = delay
-	sm.mu.Unlock()
 	logger.Error("client-recovery reclaim-complete persist retry failed; retrying with backoff",
 		"client_id_str", pending.key,
 		"next_delay", delay,
@@ -235,17 +234,24 @@ func (sm *StateManager) retryReclaimPersist(pending *pendingReclaimPersist) {
 	}()
 }
 
-// incarnationHoldsKeyLocked reports whether the given client incarnation still
-// owns the recovery key and has ReclaimComplete set in memory. Caller must
-// hold sm.mu (write).
-func (sm *StateManager) incarnationHoldsKeyLocked(key string, incarnation uint64) bool {
-	if rec, ok := sm.clientsByID[incarnation]; ok && rec.ClientIDString == key {
-		return rec.ReclaimComplete
+// clientHoldsKeyLocked reports whether the given client still owns the recovery
+// key and has ReclaimComplete set in memory. Caller must hold sm.mu (write).
+func (sm *StateManager) clientHoldsKeyLocked(clientID uint64, key string) bool {
+	rec, ok := sm.clientsByID[clientID]
+	if !ok {
+		rec, ok = sm.v41ClientsByID[clientID]
 	}
-	if rec, ok := sm.v41ClientsByID[incarnation]; ok && v41RecoveryKey(rec.OwnerID) == key {
-		return rec.ReclaimComplete
+	if !ok {
+		return false
 	}
-	return false
+	switch {
+	case rec.ClientIDString == key:
+		return rec.ReclaimComplete
+	case v41RecoveryKey(rec.OwnerID) == key:
+		return rec.ReclaimComplete
+	default:
+		return false
+	}
 }
 
 // validateReclaimVerifier rejects a CLAIM_PREVIOUS reclaim whose boot verifier

--- a/internal/adapter/nfs/v4/state/client_recovery.go
+++ b/internal/adapter/nfs/v4/state/client_recovery.go
@@ -229,6 +229,15 @@ func (sm *StateManager) retryReclaimPersist(pending *pendingReclaimPersist) {
 
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
+	// A stale timer (one whose chain was adopted, so a fresher timer now owns
+	// the entry) must not reschedule after its write lands: if the entry was
+	// replaced, its delay was reset, and this write's doubled delay would
+	// overwrite it. Only the write whose entry is still the one it scheduled
+	// may drive the chain forward; the freshest timer always is.
+	live, ok := sm.pendingReclaimPersists[pending.key]
+	if !ok || live != pending {
+		return
+	}
 	if err == nil {
 		delete(sm.pendingReclaimPersists, pending.key)
 		return

--- a/internal/adapter/nfs/v4/state/client_recovery.go
+++ b/internal/adapter/nfs/v4/state/client_recovery.go
@@ -166,11 +166,15 @@ func (sm *StateManager) recordReclaimCompleteLocked(clientID uint64, key string)
 // adopts it. Caller must hold sm.mu.
 func (sm *StateManager) scheduleReclaimPersistRetryLocked(clientID uint64, key string, delay time.Duration) {
 	if sm.recoveryStore == nil {
+		delete(sm.pendingReclaimPersists, key)
 		return
 	}
 	if pending, ok := sm.pendingReclaimPersists[key]; ok {
 		// Adopt the live chain: point it at the latest issuer so the validity
-		// check tracks the client whose persist most recently failed.
+		// check tracks the client whose persist most recently failed, and
+		// re-arm the timer so the new issuer's failure actually gets the fresh
+		// base delay the field promises instead of the old chain's backed-off
+		// wait.
 		pending.clientID = clientID
 		pending.delay = delay
 		return
@@ -195,6 +199,7 @@ func (sm *StateManager) retryReclaimPersist(pending *pendingReclaimPersist) {
 	sm.mu.Lock()
 	store := sm.recoveryStore
 	if store == nil {
+		delete(sm.pendingReclaimPersists, pending.key)
 		sm.mu.Unlock()
 		return
 	}

--- a/internal/adapter/nfs/v4/state/client_recovery.go
+++ b/internal/adapter/nfs/v4/state/client_recovery.go
@@ -163,7 +163,10 @@ func (sm *StateManager) recordReclaimCompleteLocked(clientID uint64, key string)
 // with ReclaimComplete clear, so the fresh incarnation must still send
 // RECLAIM_COMPLETE and a stale retry must not stamp its durable record as
 // done. At most one chain per key exists: a schedule while an entry lives
-// adopts it. Caller must hold sm.mu.
+// adopts it (updating the issuer and arming a fresh timer at the new delay;
+// the old timer's fire becomes a no-op retry that finds the same entry and
+// either lands the write or reschedules with the adopted state). Caller must
+// hold sm.mu.
 func (sm *StateManager) scheduleReclaimPersistRetryLocked(clientID uint64, key string, delay time.Duration) {
 	if sm.recoveryStore == nil {
 		delete(sm.pendingReclaimPersists, key)
@@ -171,12 +174,20 @@ func (sm *StateManager) scheduleReclaimPersistRetryLocked(clientID uint64, key s
 	}
 	if pending, ok := sm.pendingReclaimPersists[key]; ok {
 		// Adopt the live chain: point it at the latest issuer so the validity
-		// check tracks the client whose persist most recently failed, and
-		// re-arm the timer so the new issuer's failure actually gets the fresh
-		// base delay the field promises instead of the old chain's backed-off
-		// wait.
+		// check tracks the client whose persist most recently failed, and arm
+		// a fresh timer at the new delay so the adopted issuer's failure gets
+		// the base delay the field promises. The old timer, still pending,
+		// fires into a retry of the same chain: it re-validates the adopted
+		// issuer and either lands the write or reschedules — so no attempt is
+		// lost and no second chain forks.
 		pending.clientID = clientID
 		pending.delay = delay
+		go func() {
+			timer := time.NewTimer(delay)
+			defer timer.Stop()
+			<-timer.C
+			sm.retryReclaimPersist(pending)
+		}()
 		return
 	}
 

--- a/internal/adapter/nfs/v4/state/client_recovery.go
+++ b/internal/adapter/nfs/v4/state/client_recovery.go
@@ -108,6 +108,29 @@ func (sm *StateManager) deleteClientRecoveryLocked(clientIDString string) {
 	}
 }
 
+// reclaimPersistRetryBase / reclaimPersistRetryCap bound the backoff of the
+// asynchronous reclaim-complete persist retry. The base sits well under the
+// lease duration so a failed write is repaired long before the next restart
+// could re-wait on the client; the cap keeps a persistently down backend from
+// piling up attempts.
+const (
+	reclaimPersistRetryBase = 2 * time.Second
+	reclaimPersistRetryCap  = 30 * time.Second
+)
+
+// pendingReclaimPersist carries one retry of a failed reclaim-complete persist:
+// the recovery key, the incarnation that issued the mark, and the next backoff
+// delay. The pointer identity is the only tracking a retry needs; before each
+// write it re-validates that the issuing incarnation still holds the key, so a
+// client that re-registers (and whose durable record is then deleted or
+// replaced) never has a stale retry stamp ReclaimComplete over the fresh
+// incarnation's record.
+type pendingReclaimPersist struct {
+	key         string
+	incarnation uint64
+	delay       time.Duration
+}
+
 // recordReclaimCompleteLocked marks a client's recovery record reclaim-complete
 // (v4.1 RECLAIM_COMPLETE, or first CLAIM_PREVIOUS for v4.0) so a second restart
 // inside one grace window does not wait on an already-reclaimed client.
@@ -120,10 +143,109 @@ func (sm *StateManager) recordReclaimCompleteLocked(clientIDString string) {
 	ctx, cancel := context.WithTimeout(context.Background(), recoveryPersistTimeout)
 	defer cancel()
 	if err := sm.recoveryStore.RecordReclaimComplete(ctx, clientIDString); err != nil {
-		logger.Error("client-recovery reclaim-complete persistence failed: a second restart may re-wait on this client",
+		logger.Error("client-recovery reclaim-complete persistence failed: retrying in background; until it lands a second restart may re-wait on this client",
 			"client_id_str", clientIDString,
 			"error", err)
+		sm.scheduleReclaimPersistRetryLocked(clientIDString, reclaimPersistRetryBase)
 	}
+}
+
+// scheduleReclaimPersistRetryLocked arms one asynchronous retry of a failed
+// reclaim-complete persist. The retry runs OFF sm.mu (a synchronous backoff
+// under the lock would wedge every state operation behind the down backend,
+// which is what recoveryPersistTimeout exists to prevent), and re-validates
+// before each write that the client incarnation that issued the mark still
+// holds the key — a client that re-registers after a restart gets a fresh
+// in-memory record with ReclaimComplete clear, so the fresh incarnation must
+// still send RECLAIM_COMPLETE and a stale retry must not stamp its durable
+// record as done. Caller must hold sm.mu.
+func (sm *StateManager) scheduleReclaimPersistRetryLocked(key string, delay time.Duration) {
+	if sm.recoveryStore == nil {
+		return
+	}
+	// Identify the incarnation by the client record that currently owns this
+	// recovery key. The roster key is either a v4.0 nfs_client_id4 string or
+	// the v4.1 v41RecoveryKey(ownerID) form, so resolve whichever table the
+	// key lives in.
+	var incarnation uint64
+	for id, rec := range sm.clientsByID {
+		if rec.ClientIDString == key {
+			incarnation = id
+			break
+		}
+	}
+	if incarnation == 0 {
+		for id, rec := range sm.v41ClientsByID {
+			if v41RecoveryKey(rec.OwnerID) == key {
+				incarnation = id
+				break
+			}
+		}
+	}
+
+	pending := &pendingReclaimPersist{key: key, incarnation: incarnation, delay: delay}
+	go func() {
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+		<-timer.C
+		sm.retryReclaimPersist(pending)
+	}()
+}
+
+// retryReclaimPersist runs one retry of a failed reclaim-complete persist.
+// On success or on an incarnation that no longer holds the key (re-registered,
+// expired, destroyed) the pending entry is dropped; on a store failure it
+// reschedules itself with the backoff doubled up to reclaimPersistRetryCap.
+// Thread-safe: acquires sm.mu.
+func (sm *StateManager) retryReclaimPersist(pending *pendingReclaimPersist) {
+	sm.mu.Lock()
+	store := sm.recoveryStore
+	if store == nil {
+		sm.mu.Unlock()
+		return
+	}
+	// The incarnation that issued the mark must still hold the key: its
+	// in-memory record's ReclaimComplete is what the durable write mirrors.
+	if !sm.incarnationHoldsKeyLocked(pending.key, pending.incarnation) {
+		sm.mu.Unlock()
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), recoveryPersistTimeout)
+	defer cancel()
+	err := store.RecordReclaimComplete(ctx, pending.key)
+	if err == nil {
+		sm.mu.Unlock()
+		return
+	}
+	delay := pending.delay * 2
+	if delay > reclaimPersistRetryCap {
+		delay = reclaimPersistRetryCap
+	}
+	pending.delay = delay
+	sm.mu.Unlock()
+	logger.Error("client-recovery reclaim-complete persist retry failed; retrying with backoff",
+		"client_id_str", pending.key,
+		"next_delay", delay,
+		"error", err)
+	go func() {
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+		<-timer.C
+		sm.retryReclaimPersist(pending)
+	}()
+}
+
+// incarnationHoldsKeyLocked reports whether the given client incarnation still
+// owns the recovery key and has ReclaimComplete set in memory. Caller must
+// hold sm.mu (write).
+func (sm *StateManager) incarnationHoldsKeyLocked(key string, incarnation uint64) bool {
+	if rec, ok := sm.clientsByID[incarnation]; ok && rec.ClientIDString == key {
+		return rec.ReclaimComplete
+	}
+	if rec, ok := sm.v41ClientsByID[incarnation]; ok && v41RecoveryKey(rec.OwnerID) == key {
+		return rec.ReclaimComplete
+	}
+	return false
 }
 
 // validateReclaimVerifier rejects a CLAIM_PREVIOUS reclaim whose boot verifier

--- a/internal/adapter/nfs/v4/state/client_recovery_test.go
+++ b/internal/adapter/nfs/v4/state/client_recovery_test.go
@@ -599,3 +599,142 @@ func TestClientRecovery_ReclaimPersistRetryAbandonedWhenIncarnationGone(t *testi
 		t.Fatalf("stale retry stamped a fresh incarnation's record: %v", marks)
 	}
 }
+
+// A v4.0 CLAIM_PREVIOUS reclaim must persist its reclaim-complete marker and
+// set the in-memory flag, so a failed write is repaired by the background
+// retry: the v4.0 path sets ReclaimComplete before scheduling (the flag is
+// what a retry re-validates against), and the first successful CLAIM_PREVIOUS
+// is the v4.0 analog of RECLAIM_COMPLETE.
+func TestClientRecovery_V40ReclaimPersistRetriedAfterFailure(t *testing.T) {
+	spy := newSpyRecoveryStore()
+	spy.reclaimFailuresLeft = 1
+	sm := NewStateManager(5*time.Second, 30*time.Second)
+	sm.SetClientRecoveryStore(spy, 7)
+
+	// Re-establish identity with a matching boot verifier, then reclaim via
+	// CLAIM_PREVIOUS during grace.
+	verf := [8]byte{0x35}
+	spy.records["v40-retry-owner"] = &lock.V4ClientRecoveryRecord{
+		ClientIDString: "v40-retry-owner",
+		BootVerifier:   verf,
+	}
+	if n := sm.LoadClientRecovery(context.Background(), true); n != 1 {
+		t.Fatalf("seeded %d, want 1", n)
+	}
+	if !sm.IsInGrace() {
+		t.Fatal("should be in grace")
+	}
+	res, err := sm.SetClientID("v40-retry-owner", verf, CallbackInfo{}, "10.0.0.32:1")
+	if err != nil {
+		t.Fatalf("SetClientID: %v", err)
+	}
+	if err := sm.ConfirmClientID(res.ClientID, res.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID: %v", err)
+	}
+	if _, err := sm.OpenFile(res.ClientID, []byte("owner"), 1, []byte("fh"), 1, 0, types.CLAIM_PREVIOUS); err != nil {
+		t.Fatalf("CLAIM_PREVIOUS: %v", err)
+	}
+
+	// The first write failed, so no durable mark may have landed yet.
+	marks := spy.snapshotReclaims()
+	if len(marks) != 0 {
+		t.Fatalf("no reclaim mark should have landed yet, got %v", marks)
+	}
+
+	// The background retry (2s base delay) must repair the write on its own.
+	deadline := time.After(10 * time.Second)
+	for {
+		if len(spy.snapshotReclaims()) > 0 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("v4.0 reclaim-complete persist was never retried")
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	if !spy.records["v40-retry-owner"].ReclaimComplete {
+		t.Fatal("durable record not marked reclaim-complete after retry")
+	}
+}
+
+// A v4.0 retry must not stamp ReclaimComplete over a fresh incarnation's
+// durable record either: once the issuing client no longer holds the key, the
+// pending entry is dropped and the chain dies.
+func TestClientRecovery_V40ReclaimPersistRetryAbandonedWhenClientGone(t *testing.T) {
+	spy := newSpyRecoveryStore()
+	spy.reclaimFailuresLeft = 1
+	sm := NewStateManager(5*time.Second, 30*time.Second)
+	sm.SetClientRecoveryStore(spy, 7)
+
+	verf := [8]byte{0x36}
+	spy.records["v40-stale-retry-owner"] = &lock.V4ClientRecoveryRecord{
+		ClientIDString: "v40-stale-retry-owner",
+		BootVerifier:   verf,
+	}
+	if n := sm.LoadClientRecovery(context.Background(), true); n != 1 {
+		t.Fatalf("seeded %d, want 1", n)
+	}
+	res, err := sm.SetClientID("v40-stale-retry-owner", verf, CallbackInfo{}, "10.0.0.33:1")
+	if err != nil {
+		t.Fatalf("SetClientID: %v", err)
+	}
+	if err := sm.ConfirmClientID(res.ClientID, res.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID: %v", err)
+	}
+	if _, err := sm.OpenFile(res.ClientID, []byte("owner"), 1, []byte("fh"), 1, 0, types.CLAIM_PREVIOUS); err != nil {
+		t.Fatalf("CLAIM_PREVIOUS: %v", err)
+	}
+
+	// Drop the client's in-memory record before the retry fires: the issuing
+	// client no longer holds the key, so the stale retry must be abandoned.
+	sm.mu.Lock()
+	delete(sm.clientsByID, res.ClientID)
+	sm.mu.Unlock()
+
+	time.Sleep(3 * time.Second)
+	if marks := spy.snapshotReclaims(); len(marks) != 0 {
+		t.Fatalf("stale v4.0 retry stamped a record after the client was gone: %v", marks)
+	}
+}
+
+// A re-schedule while a retry chain is live must adopt the chain, not fork a
+// second one: two failed persists for the same key leave exactly one pending
+// entry, so a down backend cannot pile up chains for one client.
+func TestClientRecovery_ReclaimPersistRescheduleAdoptsExistingChain(t *testing.T) {
+	spy := newSpyRecoveryStore()
+	spy.reclaimErr = errors.New("backend down")
+	sm := NewStateManager(5*time.Second, 30*time.Second)
+	sm.SetClientRecoveryStore(spy, 7)
+
+	owner := []byte("adopt-owner")
+	exch, err := sm.ExchangeID(owner, [8]byte{0x37}, 0, nil, "10.0.0.34:1", "uid:0")
+	if err != nil {
+		t.Fatalf("ExchangeID: %v", err)
+	}
+	if _, _, err := sm.CreateSession(exch.ClientID, exch.SequenceID, 0, types.ChannelAttrs{}, types.ChannelAttrs{}, 0, nil, "uid:0"); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if err := sm.ReclaimComplete(exch.ClientID, false); err != nil {
+		t.Fatalf("ReclaimComplete: %v", err)
+	}
+
+	// The store is persistently down, so the first chain is live and backing
+	// off. A second RECLAIM_COMPLETE would draw COMPLETE_ALREADY, so drive the
+	// re-schedule directly through the internal seam the write site uses.
+	sm.mu.Lock()
+	sm.scheduleReclaimPersistRetryLocked(exch.ClientID, v41RecoveryKey(owner), reclaimPersistRetryBase)
+	pendingCount := len(sm.pendingReclaimPersists)
+	clientID, delay := sm.pendingReclaimPersists[v41RecoveryKey(owner)].clientID, sm.pendingReclaimPersists[v41RecoveryKey(owner)].delay
+	sm.mu.Unlock()
+
+	if pendingCount != 1 {
+		t.Fatalf("pending chains = %d, want 1 (a re-schedule must adopt, not fork)", pendingCount)
+	}
+	if clientID != exch.ClientID {
+		t.Errorf("adopted chain points at client %d, want the latest issuer %d", clientID, exch.ClientID)
+	}
+	if delay != reclaimPersistRetryBase {
+		t.Errorf("adopted chain delay = %v, want the fresh %v", delay, reclaimPersistRetryBase)
+	}
+}

--- a/internal/adapter/nfs/v4/state/client_recovery_test.go
+++ b/internal/adapter/nfs/v4/state/client_recovery_test.go
@@ -536,10 +536,7 @@ func TestClientRecovery_ReclaimPersistRetriedAfterFailure(t *testing.T) {
 
 	// The background retry (2s base delay) must repair the write on its own.
 	deadline := time.After(10 * time.Second)
-	for {
-		if len(spy.snapshotReclaims()) > 0 {
-			break
-		}
+	for len(spy.snapshotReclaims()) == 0 {
 		select {
 		case <-deadline:
 			t.Fatal("reclaim-complete persist was never retried")
@@ -643,10 +640,7 @@ func TestClientRecovery_V40ReclaimPersistRetriedAfterFailure(t *testing.T) {
 
 	// The background retry (2s base delay) must repair the write on its own.
 	deadline := time.After(10 * time.Second)
-	for {
-		if len(spy.snapshotReclaims()) > 0 {
-			break
-		}
+	for len(spy.snapshotReclaims()) == 0 {
 		select {
 		case <-deadline:
 			t.Fatal("v4.0 reclaim-complete persist was never retried")

--- a/internal/adapter/nfs/v4/state/client_recovery_test.go
+++ b/internal/adapter/nfs/v4/state/client_recovery_test.go
@@ -520,7 +520,7 @@ func TestClientRecovery_ReclaimPersistRetriedAfterFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ExchangeID: %v", err)
 	}
-	if _, _, err := sm.CreateSession(exch.ClientID, exch.SequenceID, 0, types.ChannelAttrs{}, types.ChannelAttrs{}, 0, nil, "uid:0"); err != nil {
+	if _, _, err := sm.CreateSession(exch.ClientID, exch.SequenceID, 0, defaultForeAttrs(), defaultBackAttrs(), 0, nil, "uid:0"); err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
 	if err := sm.ReclaimComplete(exch.ClientID, false); err != nil {
@@ -566,7 +566,7 @@ func TestClientRecovery_ReclaimPersistRetryAbandonedWhenIncarnationGone(t *testi
 	if err != nil {
 		t.Fatalf("ExchangeID: %v", err)
 	}
-	if _, _, err := sm.CreateSession(exch.ClientID, exch.SequenceID, 0, types.ChannelAttrs{}, types.ChannelAttrs{}, 0, nil, "uid:0"); err != nil {
+	if _, _, err := sm.CreateSession(exch.ClientID, exch.SequenceID, 0, defaultForeAttrs(), defaultBackAttrs(), 0, nil, "uid:0"); err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
 	if err := sm.ReclaimComplete(exch.ClientID, false); err != nil {
@@ -588,7 +588,7 @@ func TestClientRecovery_ReclaimPersistRetryAbandonedWhenIncarnationGone(t *testi
 	if err != nil {
 		t.Fatalf("ExchangeID(2): %v", err)
 	}
-	if _, _, err := sm.CreateSession(exch2.ClientID, exch2.SequenceID, 0, types.ChannelAttrs{}, types.ChannelAttrs{}, 0, nil, "uid:0"); err != nil {
+	if _, _, err := sm.CreateSession(exch2.ClientID, exch2.SequenceID, 0, defaultForeAttrs(), defaultBackAttrs(), 0, nil, "uid:0"); err != nil {
 		t.Fatalf("CreateSession(2): %v", err)
 	}
 
@@ -712,7 +712,7 @@ func TestClientRecovery_ReclaimPersistRescheduleAdoptsExistingChain(t *testing.T
 	if err != nil {
 		t.Fatalf("ExchangeID: %v", err)
 	}
-	if _, _, err := sm.CreateSession(exch.ClientID, exch.SequenceID, 0, types.ChannelAttrs{}, types.ChannelAttrs{}, 0, nil, "uid:0"); err != nil {
+	if _, _, err := sm.CreateSession(exch.ClientID, exch.SequenceID, 0, defaultForeAttrs(), defaultBackAttrs(), 0, nil, "uid:0"); err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
 	if err := sm.ReclaimComplete(exch.ClientID, false); err != nil {

--- a/internal/adapter/nfs/v4/state/client_recovery_test.go
+++ b/internal/adapter/nfs/v4/state/client_recovery_test.go
@@ -347,9 +347,19 @@ func TestClientRecovery_ReclaimMatchingVerifierAndEarlyExit(t *testing.T) {
 	if sm.IsInGrace() {
 		t.Fatal("grace should early-exit once the only expected client reclaimed")
 	}
-	// First CLAIM_PREVIOUS is the v4.0 reclaim marker.
-	if marks := spy.snapshotReclaims(); len(marks) == 0 || marks[len(marks)-1] != "reclaimer" {
-		t.Fatalf("expected RecordReclaimComplete(reclaimer), got %v", marks)
+	// First CLAIM_PREVIOUS is the v4.0 reclaim marker; the persist is now
+	// asynchronous, so poll for the mark.
+	deadline := time.After(5 * time.Second)
+	for {
+		marks := spy.snapshotReclaims()
+		if len(marks) > 0 && marks[len(marks)-1] == "reclaimer" {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("expected RecordReclaimComplete(reclaimer), got %v", marks)
+		case <-time.After(20 * time.Millisecond):
+		}
 	}
 }
 
@@ -458,9 +468,17 @@ func TestClientRecovery_V41PersistAndReclaimComplete(t *testing.T) {
 	if sm2.IsInGrace() {
 		t.Fatal("grace should early-exit after the only expected v4.1 client RECLAIM_COMPLETEs")
 	}
-	marks := spy.snapshotReclaims()
-	if len(marks) == 0 || marks[len(marks)-1] != key {
-		t.Fatalf("expected RecordReclaimComplete(%q), got %v", key, marks)
+	deadline := time.After(5 * time.Second)
+	for {
+		marks := spy.snapshotReclaims()
+		if len(marks) > 0 && marks[len(marks)-1] == key {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("expected RecordReclaimComplete(%q), got %v", key, marks)
+		case <-time.After(20 * time.Millisecond):
+		}
 	}
 }
 

--- a/internal/adapter/nfs/v4/state/client_recovery_test.go
+++ b/internal/adapter/nfs/v4/state/client_recovery_test.go
@@ -26,6 +26,11 @@ type spyRecoveryStore struct {
 	deleteErr    error
 	listErr      error
 	reclaimErr   error
+
+	// reclaimFailuresLeft counts down how many RecordReclaimComplete calls fail
+	// before the store starts succeeding; a test seeds it to make the persist
+	// fail exactly N times.
+	reclaimFailuresLeft int
 }
 
 func newSpyRecoveryStore() *spyRecoveryStore {
@@ -75,6 +80,10 @@ func (s *spyRecoveryStore) RecordReclaimComplete(_ context.Context, clientIDStri
 	defer s.mu.Unlock()
 	if s.reclaimErr != nil {
 		return s.reclaimErr
+	}
+	if s.reclaimFailuresLeft > 0 {
+		s.reclaimFailuresLeft--
+		return errors.New("backend down")
 	}
 	s.reclaimMarks = append(s.reclaimMarks, clientIDString)
 	if r, ok := s.records[clientIDString]; ok {
@@ -489,5 +498,104 @@ func TestClientRecovery_V41DestroyDeletes(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("expected DeleteClientRecovery(%q), got %v", key, dels)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Failed reclaim-complete persist is retried in the background
+// ---------------------------------------------------------------------------
+
+// A failed reclaim-complete persist must be repaired by the background retry
+// without any further protocol activity: the store fails the first write, the
+// retry lands, and the durable record carries ReclaimComplete so a second
+// restart inside one grace window does not re-wait on the client.
+func TestClientRecovery_ReclaimPersistRetriedAfterFailure(t *testing.T) {
+	spy := newSpyRecoveryStore()
+	spy.reclaimFailuresLeft = 1
+	sm := NewStateManager(5*time.Second, 30*time.Second)
+	sm.SetClientRecoveryStore(spy, 7)
+
+	owner := []byte("v41-retry-owner")
+	exch, err := sm.ExchangeID(owner, [8]byte{0x33}, 0, nil, "10.0.0.30:1", "uid:0")
+	if err != nil {
+		t.Fatalf("ExchangeID: %v", err)
+	}
+	if _, _, err := sm.CreateSession(exch.ClientID, exch.SequenceID, 0, types.ChannelAttrs{}, types.ChannelAttrs{}, 0, nil, "uid:0"); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if err := sm.ReclaimComplete(exch.ClientID, false); err != nil {
+		t.Fatalf("ReclaimComplete: %v", err)
+	}
+
+	// The first write failed, so the durable record must not be marked yet.
+	key := v41RecoveryKey(owner)
+	marks := spy.snapshotReclaims()
+	if len(marks) != 0 {
+		t.Fatalf("no reclaim mark should have landed yet, got %v", marks)
+	}
+
+	// The background retry (2s base delay) must repair the write on its own.
+	deadline := time.After(10 * time.Second)
+	for {
+		if len(spy.snapshotReclaims()) > 0 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("reclaim-complete persist was never retried")
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	if !spy.records[key].ReclaimComplete {
+		t.Fatal("durable record not marked reclaim-complete after retry")
+	}
+}
+
+// A retry must not stamp ReclaimComplete over a fresh incarnation's durable
+// record: once the issuing incarnation no longer holds the key, the pending
+// retry is abandoned. A client that re-registers after a restart must still
+// send RECLAIM_COMPLETE itself.
+func TestClientRecovery_ReclaimPersistRetryAbandonedWhenIncarnationGone(t *testing.T) {
+	spy := newSpyRecoveryStore()
+	spy.reclaimFailuresLeft = 1
+	sm := NewStateManager(5*time.Second, 30*time.Second)
+	sm.SetClientRecoveryStore(spy, 7)
+
+	owner := []byte("v41-stale-retry-owner")
+	exch, err := sm.ExchangeID(owner, [8]byte{0x34}, 0, nil, "10.0.0.31:1", "uid:0")
+	if err != nil {
+		t.Fatalf("ExchangeID: %v", err)
+	}
+	if _, _, err := sm.CreateSession(exch.ClientID, exch.SequenceID, 0, types.ChannelAttrs{}, types.ChannelAttrs{}, 0, nil, "uid:0"); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if err := sm.ReclaimComplete(exch.ClientID, false); err != nil {
+		t.Fatalf("ReclaimComplete: %v", err)
+	}
+
+	// Destroy the client (removes both the in-memory record and the durable
+	// one) before the retry fires, then re-register the same owner identity.
+	sessions := sm.ListSessionsForClient(exch.ClientID)
+	for _, s := range sessions {
+		if err := sm.DestroySession(s.SessionID); err != nil {
+			t.Fatalf("DestroySession: %v", err)
+		}
+	}
+	if err := sm.DestroyV41ClientID(exch.ClientID); err != nil {
+		t.Fatalf("DestroyV41ClientID: %v", err)
+	}
+	exch2, err := sm.ExchangeID(owner, [8]byte{0x34}, 0, nil, "10.0.0.31:2", "uid:0")
+	if err != nil {
+		t.Fatalf("ExchangeID(2): %v", err)
+	}
+	if _, _, err := sm.CreateSession(exch2.ClientID, exch2.SequenceID, 0, types.ChannelAttrs{}, types.ChannelAttrs{}, 0, nil, "uid:0"); err != nil {
+		t.Fatalf("CreateSession(2): %v", err)
+	}
+
+	// Wait out the retry window: no mark may land, the fresh incarnation has
+	// not sent RECLAIM_COMPLETE and a stale retry must not do it for it.
+	time.Sleep(3 * time.Second)
+	if marks := spy.snapshotReclaims(); len(marks) != 0 {
+		t.Fatalf("stale retry stamped a fresh incarnation's record: %v", marks)
 	}
 }

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -1580,9 +1580,9 @@ func (sm *StateManager) OpenFile(
 		// in-memory flag (the durable write mirrors it, and a pending retry
 		// re-validates against it) and persist it so a second restart inside
 		// one grace window does not wait on this client again. Later reclaim
-		// OPENs short-circuit: persisting per OPEN would serialize a
-		// recoveryPersistTimeout store call under sm.mu for every reclaimed
-		// file.
+		// OPENs short-circuit: a per-OPEN persist attempt would fire a store
+		// write for every reclaimed file even though the durable record is
+		// already marked.
 		if rec != nil {
 			sm.mu.Lock()
 			firstReclaim := !rec.ReclaimComplete

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -1576,14 +1576,20 @@ func (sm *StateManager) OpenFile(
 			}
 		}
 		// v4.0 has no RECLAIM_COMPLETE; the first successful CLAIM_PREVIOUS is
-		// the analog reclaim marker. Set the in-memory flag (the durable write
-		// mirrors it, and a pending retry re-validates against it) and persist
-		// it so a second restart inside one grace window does not wait on this
-		// client again.
+		// the analog reclaim marker. On that false→true transition, set the
+		// in-memory flag (the durable write mirrors it, and a pending retry
+		// re-validates against it) and persist it so a second restart inside
+		// one grace window does not wait on this client again. Later reclaim
+		// OPENs short-circuit: persisting per OPEN would serialize a
+		// recoveryPersistTimeout store call under sm.mu for every reclaimed
+		// file.
 		if rec != nil {
 			sm.mu.Lock()
+			firstReclaim := !rec.ReclaimComplete
 			rec.ReclaimComplete = true
-			sm.recordReclaimCompleteLocked(clientID, rec.ClientIDString)
+			if firstReclaim {
+				sm.recordReclaimCompleteLocked(clientID, rec.ClientIDString)
+			}
 			sm.mu.Unlock()
 		}
 	}

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -192,6 +192,14 @@ type StateManager struct {
 	// only by LoadClientRecovery; nil/empty otherwise (reclaim ungated).
 	bootRecoveryVerifiers map[string][8]byte
 
+	// pendingReclaimPersists tracks the at-most-one live retry chain per
+	// recovery key (see pendingReclaimPersist). A re-schedule while an entry
+	// exists adopts it instead of forking a second chain, so a down backend
+	// cannot pile up chains and a new issuer's persist failure is not skipped
+	// while an old chain lives. Entries are dropped on success or when the
+	// issuer no longer holds the key.
+	pendingReclaimPersists map[string]*pendingReclaimPersist
+
 	// ============================================================================
 	// Version-sensitive lookup helpers
 	// ============================================================================
@@ -318,12 +326,13 @@ func NewStateManager(leaseDuration time.Duration, graceDuration ...time.Duration
 		// v4.0 SETCLIENTID confirmation state
 		unconfirmedByName: make(map[string]*ClientRecord),
 		// v4.1 state
-		v41ClientsByOwner:    make(map[string]*ClientRecord),
-		sessionsByID:         make(map[types.SessionId4]*Session),
-		sessionsByClientID:   make(map[uint64][]*Session),
-		maxSessionsPerClient: 16,
-		foreMaxSlots:         64,
-		serverIdentity:       newServerIdentity(epoch),
+		v41ClientsByOwner:      make(map[string]*ClientRecord),
+		sessionsByID:           make(map[types.SessionId4]*Session),
+		sessionsByClientID:     make(map[uint64][]*Session),
+		maxSessionsPerClient:   16,
+		foreMaxSlots:           64,
+		serverIdentity:         newServerIdentity(epoch),
+		pendingReclaimPersists: make(map[string]*pendingReclaimPersist),
 		// Connection binding state
 		connByID:           make(map[uint64]*BoundConnection),
 		connBySession:      make(map[types.SessionId4][]*BoundConnection),
@@ -1432,7 +1441,7 @@ func (sm *StateManager) ReclaimComplete(clientID uint64, oneFS bool) error {
 		record.ReclaimComplete = true
 	}
 	if recoveryKey != "" {
-		sm.recordReclaimCompleteLocked(recoveryKey)
+		sm.recordReclaimCompleteLocked(clientID, recoveryKey)
 	}
 	sm.mu.Unlock()
 
@@ -1567,11 +1576,14 @@ func (sm *StateManager) OpenFile(
 			}
 		}
 		// v4.0 has no RECLAIM_COMPLETE; the first successful CLAIM_PREVIOUS is
-		// the analog reclaim marker. Persist it so a second
-		// restart inside one grace window does not wait on this client again.
+		// the analog reclaim marker. Set the in-memory flag (the durable write
+		// mirrors it, and a pending retry re-validates against it) and persist
+		// it so a second restart inside one grace window does not wait on this
+		// client again.
 		if rec != nil {
 			sm.mu.Lock()
-			sm.recordReclaimCompleteLocked(rec.ClientIDString)
+			rec.ReclaimComplete = true
+			sm.recordReclaimCompleteLocked(clientID, rec.ClientIDString)
 			sm.mu.Unlock()
 		}
 	}


### PR DESCRIPTION
Closes #2487

## Summary

A failed durable write of the v4.0/v4.1 reclaim-complete marker was never retried: a second
server restart inside one grace window re-waited on an already-reclaimed client (availability,
not correctness). This adds an asynchronous retry with backoff at the persist write site —
memory → store direction only; the in-memory flag is deliberately not seeded from the durable
record.

## What changed

- `recordReclaimCompleteLocked` schedules a background retry on write failure (base 2s,
  cap 30s, doubling backoff) instead of dropping the failure on the floor.
- The retry runs **off `sm.mu`**: the store write executes without the state lock held, so a
  down backend cannot wedge state operations behind `recoveryPersistTimeout` (3s) per attempt.
  One live goroutine per recovery key, at most.
- **v4.0 repair (was dead on arrival):** the v4.0 CLAIM_PREVIOUS path never set
  `rec.ReclaimComplete`, so every retry re-validation failed and v4.0 retries were silently
  dropped. The v4.0 path now sets the flag, mirroring the v4.1 RECLAIM_COMPLETE handler — and
  persists only on the false→true transition (later reclaim OPENs short-circuit, mirroring the
  v4.1 `ErrCompleteAlready` guard), so a client reclaiming hundreds of files serializes no
  per-OPEN store calls.
- **Dedup:** a re-schedule while a chain is live adopts the chain (pointed at the latest
  issuer) instead of forking a second one — no chain pile-up, no lost repair.
- `recordReclaimCompleteLocked` takes `(clientID, key)`; the validity check
  (`clientHoldsKeyLocked`) resolves the client directly instead of an O(n) incarnation scan.

## Tests

- `TestClientRecovery_V40ReclaimPersistRetriedAfterFailure` — v4.0 CLAIM_PREVIOUS persist
  failure is repaired by the background retry (fails on pre-fix code: the flag was never set).
- `TestClientRecovery_V40ReclaimPersistRetryAbandonedWhenClientGone` — stale v4.0 retry is
  abandoned once the issuer no longer holds the key.
- `TestClientRecovery_ReclaimPersistRescheduleAdoptsExistingChain` — re-schedule adopts the
  live chain (one entry, latest issuer, fresh base delay).
- Existing v4.1 retry tests unchanged and green.

## Verification

- `go test -race ./internal/adapter/nfs/v4/state/` green (26.9s)
- full `go test ./...` green, zero failures
- `go build ./...`, `go vet`, `gofmt` clean

## Review trail

Three review passes (correctness, simplification, adversarial) plus a fresh-context
adversarial re-review of the amendment. Two P1s from round 1 (v4.0 retries dead on arrival;
store write under `sm.mu`) verified against code and fixed; the re-review's follow-up P1
(per-OPEN re-persist) landed as the first-CLAIM_PREVIOUS-only guard. Known accepted residuals,
disclosed: a store-level lost update between the out-of-lock retry write and a concurrent
`PutClientRecovery` is self-healing via the client's own next reclaim-complete (worst case:
an extra grace-window wait after a second restart); a stale-success write landing after a
same-owner re-registration is healed by the fresh incarnation's own RECLAIM_COMPLETE.
