### PR TITLE
fold the v4.0 and v4.1 client indexes into one version-filtered map (#2482)

### DIFF
--- a/.planning/2026-09-08-adapter-convergence-TODO.md
+++ b/.planning/2026-09-08-adapter-convergence-TODO.md
@@ -21,7 +21,8 @@ Legend: `[ ]` open · `[~]` in flight · `[x]` done · `[!]` blocked/needs a dec
 - [x] Deleted `~/dittofs-worktrees/{2340-session-validation,2341-stateid-classes}` and their branches.
       Nothing was unmerged: both branches pointed at the **same** commit `c5ba24c49`, a strict ancestor
       of develop — 0 unique commits, never pushed, no PR ever opened
-- [ ] Re-derive #2340's 32 pynfs rows — the peer's sizing context died with it.
+- [ ] Re-derive #2340's 32 pynfs rows — the peer's sizing context died with it. (Still open —
+      blocks the #2340 residual in Wave 2.)
       Count with `^\| *[A-Z]+[0-9]+[a-z]? *\|`; a trailing-digit regex silently drops
       `CSESS16a`, `EID5c/5d/5f/5g`, `EID6a`–`EID6g`
 
@@ -142,26 +143,31 @@ directory-only to real coverage. Not a reason to reopen #2396.
   caller re-compares at `open.go:894`; `freeLockStateidLocked` (`stateid.go:513`) compares inline and
   rejects even for clientID 0; the 14 per-handler `GetTree` sites stay existence-only by design.
 
-## Wave 2 — `sm.mu`, then the pynfs conformance wave (goal 1)
+## Wave 2 — `sm.mu`, then the pynfs conformance wave (goal 1) — ~90% LANDED as of 2026-09-09
 
-- [ ] **#2398 decided first** — #2341/#2340 add *write-side* work under the contended lock.
-      Criterion (settled, on the issue): release-call-recommit is safe without re-validation only if the
-      post-gap write is **idempotent, keyed by something stable, and records a fact the gap cannot
-      falsify**. `ReclaimComplete` meets all three; a stateid/seqid commit meets **none** and owes a CAS
-- [ ] #2341 (14 v4.0 rows) · #2340 (**32** v4.1) · #2329 (10 v4.1)
-- [~] Singles **in flight 2026-09-08**, one agent each, disjoint files: #2362 (`attrs/encode.go`) ·
-      #2369 (`handlers/secinfo.go` + `helpers.go`) · #2399 (`handlers/open.go`) · #2382
-      (`pending_writes.go`). Decisions taken by the user before fan-out, settled in each prompt:
-      **#2382** document the change-attr freeze as intended (ponytail marker + faq.md + reclassify
-      WRT18; #2342 stays open), do *not* build the per-client freeze · **#2369** reject
-      `RequireKerberos` with no Kerberos configured at share add, so SECINFO can never return an
-      empty flavor list; a junction reports the target share's policy · **#2399** ship now with a
-      decode-level test rather than folding into #2329 · **#2398** hoist all four LockManager sites,
-      not just the two blocking LOCK paths
-- [ ] Blocked behind #2398 (all touch `state/manager.go`): #2371, #2359, #2389, #2329, #2340, #2341
+Status re-verified against GitHub 2026-09-09 (see `.planning/2026-09-09-adapter-convergence-ROADMAP.md`
+for the landed-via table). Remaining work:
+
+- [x] **#2398 decided and landed** — hoisted via #2459 + #2466; closed 2026-09-08
+- [x] #2341 (14 v4.0 rows) — closed 2026-09-08 (#2484, #2481)
+- [x] Singles: #2362 (#2458) · #2369 (#2460) · #2399 (#2457) · #2382 (#2456, documented per decision)
+- [x] Blocked-behind-#2398 singles: #2359, #2389 — closed 2026-09-08/09
+- [x] #2340 partially: #2491 (EXCHANGE_ID), #2489 (DESTROY_CLIENTID), #2486 (RECLAIM_COMPLETE),
+      #2485 (boot epoch) merged; closed 2026-09-09
+- [x] #2329's root cause landed: #2476 (client-record unify) + #2479 (grant delegations on a
+      verified callback path, incl. the CREATE_SESSION auto-bind fore-only fix)
+- [ ] #2340 remaining v4.1 rows — re-derive the 32-row sizing first (Wave 0 item below)
+- [ ] #2329 — confirm with an actual pynfs run that delegations now flow, then close
+- [ ] #2471 CREATE_SESSION negotiated reply sizes (NFS4ERR_RESOURCE where invalid) — last #2340-class gap
+- [ ] #2371 NFS4ERR_RESOURCE on two v4.1-only paths — unblocked now that #2398 hoisted `sm.mu`
+- [ ] Post-merge churn from the landed wave: #2482 (fold client indexes — do FIRST, unblocks
+      #2490/#2483), #2483 (seqid=0 bypass leaks into v4.0), #2487 (reclaim persist never retried),
+      #2490 (BAD vs STALE on `exist_lock_owner4`), #2467 (persisted require_kerberos at load time),
+      #2464 (COUR6 flake — diagnose, needs postgres-s3)
 - [ ] Run against **memory AND postgres-s3** — memory-passes/SQL-fails is a persistence diagnosis,
       not a protocol one
 - [ ] Read verdicts from the **CI artifact**; the local pynfs harness reports ~2× CI's failures on the same SHA
+- [ ] One writer: all remaining work touches `state/manager.go` / `v4/state` — sequential PRs, no stacking
 
 ## Wave 3 — Reuse the shared layer, delete bypasses (goals 2 + 4)
 

--- a/.planning/2026-09-09-adapter-convergence-ROADMAP.md
+++ b/.planning/2026-09-09-adapter-convergence-ROADMAP.md
@@ -1,0 +1,130 @@
+# Adapter convergence — roadmap as of 2026-09-09
+
+Source of truth: `.planning/2026-09-08-adapter-convergence-MASTER-PLAN.md` (waves, corrections
+ledger) and `.planning/2026-09-08-adapter-convergence-TODO.md` (execution tracking). This file is
+the point-in-time status + proposed order. If the two disagree, the plan wins.
+
+Verified against GitHub on 2026-09-09: 40 open issues, 0 open PRs, `origin/develop` at
+`71d56bc37` (post-#2493). Issue states below re-checked live, not carried from the TODO file.
+
+---
+
+## Where the program stands
+
+| Wave | Scope | State |
+| --- | --- | --- |
+| 0 — Coordination | peer takeover, worktree cleanup | ✅ done (only #2340's 32-row re-derivation left) |
+| 1 — Ownership class | #2393–#2396, #2413, #2414 | ✅ **LANDED 2026-09-08** — 7 PRs, soundness-audited; follow-ups #2449, #2451, #2436 closed; doc rule merged (#2468) |
+| 2 — `sm.mu` + pynfs | #2398 + singles | ~90% landed — see below |
+| 3 — Shared-layer reuse | errmap, identity, lifecycle | ❌ not started |
+| 4 — SMB triage | ~155 untriaged findings | ❌ not started (plan moved it *before* the SMB fix waves) |
+| 5 — God objects | `manager.go` 3,985, `Create()` 1,016… | ❌ blocked behind 1–4 |
+| 6 — Dispatch-core finish line | acceptance test | lands inside 1/3/5 |
+| 7 — Perf lens | bufpool, measurement plan | ❌ not started |
+
+### Wave 2 — what actually landed (the TODO file is stale here)
+
+| Issue | State | Landed via |
+| --- | --- | --- |
+| #2398 `sm.mu` serialization | CLOSED 2026-09-08 | #2459 + #2466 |
+| #2362 FATTR4 numbers | CLOSED | #2458 |
+| #2369 SECINFO flavor list | CLOSED | #2460 |
+| #2382 change-attr freeze | CLOSED | #2456 (documented, per decision) |
+| #2399 CLAIM_DELEGATE_CUR | CLOSED | #2457 |
+| #2341 14 v4.0 rows | CLOSED 2026-09-08 | #2484, #2481 |
+| #2340 32 v4.1 rows | **OPEN** — partially | #2491 (EXCHANGE_ID), #2489 (DESTROY_CLIENTID), #2486 (RECLAIM_COMPLETE), #2485 (boot epoch) |
+| #2329 v4.1 delegations | **OPEN** — but the root cause landed | #2476 (client-record unify) + #2479 (grant on verified callback path) |
+| #2389, #2359 singles | CLOSED 2026-09-08/09 | — |
+
+Fresh issues opened against the landed code (post-merge finding churn — expected): 2490, 2487, 2483, 2482, 2471, 2467, 2464.
+
+**Wave 2 residual:** #2340's remaining rows, #2329's pynfs confirmation, #2482/#2483/#2487/#2490/#2471/#2467
+(stateid semantics + CREATE_SESSION sizes), plus the 32-row re-derivation from Wave 0.
+
+---
+
+## Proposed order (next sessions)
+
+### Step 1 — Close Wave 2: NFSv4.0/4.1 stateid correctness (goal 1)
+
+One cluster, one lens: special-stateid answers, seqid bypass, CREATE_SESSION reply sizes,
+client-index fold.
+
+- #2490 LOCK on `exist_lock_owner4` answers STALE where BAD is required
+- #2483 seqid=0 v4.1 bypass applied to v4.0 (LOCKU with bad lockseqid succeeds)
+- #2482 fold v4.0/v4.1 client indexes into one map with version filters (companion to #2476)
+- #2487 failed reclaim-complete persist never retried (grace re-waits)
+- #2471 CREATE_SESSION negotiated reply sizes unenforced, NFS4ERR_RESOURCE where invalid
+- #2340 remaining v4.1 rows; #2329 confirm pynfs now gets a delegation (#2479 landed)
+- #2464 COUR6 postgres-s3 flake (courtesy-client reaping vs lease_time) — diagnose, don't mask
+
+Order within: #2482 first (index fold unblocks #2490/#2483 fixes); #2464 last (flake, needs
+postgres-s3 run). All touch `state/manager.go` / `v4/state` — **one writer**, sequential PRs, no
+stacking (Wave-1 trap: a stacked PR runs zero checks).
+
+### Step 2 — Wave 3: shared-layer reuse + lifecycle (goals 2 + 4)
+
+Small, mostly independent PRs; good for a parallel fan-out (disjoint files):
+
+1. Wire all five bypassing content paths to the shared error mapper; restore `ErrStoreClosed → STALE`
+2. `TestErrorMapCoverage` enum rewrite (5-line PR, unguards everything else in this wave) — land FIRST
+3. Delete dead `MapLockToNFS3/4`; fix `ErrLockLimitExceeded` Jukebox-vs-IO; add `ErrConflict` row
+4. Delete `getUserIdentity` (SMB uses the `ResolvedIdentity` it already has); scope to resolved identities
+5. Listener stop-before-bind leak + EMFILE/ENFILE accept busy-loop (`pkg/adapter/base.go:246-263`)
+6. `CheckExportAccess` stale-citation fix in `CLAUDE.md:105` + `create.go:1874`
+7. Delete `grantAdaptive` dead branch
+
+Guards from the plan: a dead function does not make its file dead (check `init()`-filled tables
+before deleting); audits predate #2356 — re-verify each premise on develop.
+
+### Step 3 — Wave 4: SMB triage (before the SMB fix waves)
+
+- File an SMB umbrella (#2407 mirror) + area tranches for the ~155 untriaged findings
+- Quote the audit's *diagnosis*, re-derive the *fix* (`Verified: CONFIRMED` covers only the diagnosis)
+- Triage "duplicate/boilerplate" findings by diffing — the Kerberos AP-REP copies have already drifted
+- Credit/sequencing: the plan's `smb/state/` + `handlers/create/` + `handlers/info/` split is Wave 5;
+  triage decides what joins it
+
+### Step 4 — Wave 5: god objects, one package per move-only PR
+
+`manager.go` 3,985 → `setFileInfoFromStore` 1,538 → `Create()` 1,016 → `open.go` 1,103 →
+`completeCreateAfterBreak` 853 → `Handler` 56 fields. Apparatus is load-bearing (119 test files /
+42,810 LOC in `smb/handlers`): move-only, `git diff -M --color-moved` zero body edits, one package
+per PR merged same day, `graphify update .` after each, CI guard requiring a `_test.go` per new
+package. Every extracted function gets its own test (no 150-LOC ceiling).
+
+### Step 5 — Wave 7: perf lens (goal 3)
+
+No measurement plan exists. Build it before touching anything: connection ramp both protocols,
+v4.1 >64 concurrent ops per session, large-I/O allocation rate toward 16MB. Then `bufpool` tier
+sizing (large tier `1<<20` == advertised max I/O; every max-size READ/WRITE falls off the pool).
+Issue 2423 (adaptive controller samples the wrong window) belongs here with #2398's axis.
+
+### Continuously (cross-cutting, slot into any lull)
+
+- `auxsvc` lock fix (`Group.Start` holds `g.mu` across `s.Start()`); rename → `sidecar`
+- Conformance CI gate: non-empty Reason+Issue per known-failure row (`kf_load`); knfsd/Samba
+  comparison per SMB suite; #2322 suite unification
+- Instrumentation: per-op RED inside the NFSv4 COMPOUND loop; pprof on `pkg/metrics/server.go`
+- Hygiene sweeps: 962 banner separators, signature-restating doc comments, phantom-symbol citations
+- #2437 (v4.0 has no trusted client identity) — the known ceiling on Wave 1's guards; needs a
+  design decision, not a patch. Schedule it after Step 1 settles stateid semantics.
+- #2441 (`ErrCrossShare` code + errmap rows so SMB matches NFS's XDEV) — small, pairs with Step 2
+- #2397 (GDD4_OK but no CB_NOTIFY) and #2442 (SEEK ISDIR for non-regular files) — protocol gaps,
+  slot alongside Step 1
+
+Not this quarter: #2423 beyond the measurement, #2353 (RAG substrate), #2324, #2320, #2322 (beyond
+the gate), #2345, #2258, #2215, #2263, #117, and the pre-audit backwalog (issues 1417, 1418,
+1454, 1489, 1290, 1199, 1603).
+
+---
+
+## Standing hazards (unchanged, carry into every prompt)
+
+- Audits pinned at `40884ad4f`, predating #2356 — re-verify premises on develop
+- Postgres tests are `//go:build integration`; a green `go test ./...` proves nothing about postgres
+- #2345: DSN is a boolean gate; check `pg_stat_activity` before any dropdb — sessions may be live
+- Count `gh pr checks`, not failures; a stacked PR runs zero checks
+- Merge via `PUT pulls/{n}/merge -f sha=<re-read head>`; sign every commit; rebase, never merge
+- Protocol/e2e suites are exclusive — brokered, one agent at a time
+- Never re-count the known-failures ledger files: read each file's own tally (178 = SMB 86 + NFS 92)

--- a/internal/adapter/nfs/v4/state/client.go
+++ b/internal/adapter/nfs/v4/state/client.go
@@ -68,15 +68,22 @@ func principalHijacks(stored, incoming string) bool {
 // because they index different lookup maps and different durable
 // client-recovery keys; the wire formats they carry are not interchangeable.
 //
-// Fields that apply to only one minor version are marked as such and are left
-// at their zero value for the other. Anything version-independent — lease
-// timing, principal, callback-path liveness — is shared, so a policy decision
-// that reads it does not have to know which registration flow created the
-// record.
+// MinorVersion discriminates the two registration flows, and fields that
+// apply to only one minor version are marked as such and are left at their
+// zero value for the other. Anything version-independent — lease timing,
+// principal, callback-path liveness — is shared, so a policy decision that
+// reads it does not have to know which registration flow created the record.
 type ClientRecord struct {
 	// ClientID is the server-assigned 64-bit client identifier.
 	// Generated using boot epoch (high 32) + sequence counter (low 32).
 	ClientID uint64
+
+	// MinorVersion is the NFSv4 minor version that minted this record: 0 for
+	// the SETCLIENTID flow, 1 for the EXCHANGE_ID flow. generateClientID draws
+	// both flows from one sequence, so client IDs never collide across the
+	// shared numeric index; this field is what keeps a version-sensitive
+	// operation from reaching a record the other flow created.
+	MinorVersion uint32
 
 	// ClientIDString is the client-provided opaque identifier
 	// (nfs_client_id4.id). v4.0 only. This is the stable identity that

--- a/internal/adapter/nfs/v4/state/client_recovery.go
+++ b/internal/adapter/nfs/v4/state/client_recovery.go
@@ -50,16 +50,19 @@ func v41RecoveryKey(ownerID []byte) string {
 }
 
 // recoveryKeyForClientLocked resolves the durable recovery key for a confirmed
-// client by numeric clientID, checking the v4.0 then v4.1 tables. Returns ""
-// when the client is unknown. Caller must hold sm.mu (R or W).
+// client by numeric clientID. The key shape carries the minor version (v4.0 =
+// the raw nfs_client_id4 string, v4.1 = the prefixed co_ownerid hex), so the
+// record's version decides it. Returns "" when the client is unknown. Caller
+// must hold sm.mu (R or W).
 func (sm *StateManager) recoveryKeyForClientLocked(clientID uint64) string {
-	if rec, ok := sm.clientsByID[clientID]; ok {
-		return rec.ClientIDString
+	rec := sm.clientRecordLocked(clientID)
+	if rec == nil {
+		return ""
 	}
-	if rec, ok := sm.v41ClientsByID[clientID]; ok {
+	if rec.MinorVersion == 1 {
 		return v41RecoveryKey(rec.OwnerID)
 	}
-	return ""
+	return rec.ClientIDString
 }
 
 // persistClientRecoveryLocked stores a durable recovery record for a confirmed

--- a/internal/adapter/nfs/v4/state/client_test.go
+++ b/internal/adapter/nfs/v4/state/client_test.go
@@ -631,7 +631,7 @@ func TestValidateAndRenewClient_V41LapsedLeaseBeforeReaping_ReturnsExpired(t *te
 	// Age the lease past its duration without running the reaper, which is the
 	// state a v4.1 client is in for up to one reaper interval.
 	sm.mu.RLock()
-	lease := sm.v41ClientsByID[clientID].Lease
+	lease := sm.v41ClientLocked(clientID).Lease
 	sm.mu.RUnlock()
 	lease.mu.Lock()
 	lease.LastRenew = time.Now().Add(-2 * lease.Duration)
@@ -677,7 +677,7 @@ func TestValidateAndRenewClient_StampsLastRenewal(t *testing.T) {
 			lastRenewal: func(sm *StateManager, clientID uint64) time.Time {
 				sm.mu.RLock()
 				defer sm.mu.RUnlock()
-				return sm.v41ClientsByID[clientID].LastRenewal
+				return sm.v41ClientLocked(clientID).LastRenewal
 			},
 		},
 	}

--- a/internal/adapter/nfs/v4/state/courtesy_test.go
+++ b/internal/adapter/nfs/v4/state/courtesy_test.go
@@ -68,8 +68,8 @@ func renewLease(t *testing.T, sm *StateManager, clientID uint64) {
 
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
-	record, ok := sm.v41ClientsByID[clientID]
-	if !ok || record.Lease == nil {
+	record := sm.v41ClientLocked(clientID)
+	if record == nil || record.Lease == nil {
 		t.Fatalf("no v4.1 lease for client %d", clientID)
 	}
 	record.Lease.Renew()

--- a/internal/adapter/nfs/v4/state/dir_delegation_test.go
+++ b/internal/adapter/nfs/v4/state/dir_delegation_test.go
@@ -542,14 +542,15 @@ func registerTestV41Client(t *testing.T, sm *StateManager) uint64 {
 
 	clientID := sm.generateClientID()
 	record := &ClientRecord{
-		ClientID:   clientID,
-		OwnerID:    []byte("test-v41-client-dir-deleg"),
-		Confirmed:  true,
-		ClientAddr: "127.0.0.1",
-		CreatedAt:  time.Now(),
-		Lease:      NewLeaseState(clientID, 90*time.Second, nil),
+		ClientID:     clientID,
+		MinorVersion: 1,
+		OwnerID:      []byte("test-v41-client-dir-deleg"),
+		Confirmed:    true,
+		ClientAddr:   "127.0.0.1",
+		CreatedAt:    time.Now(),
+		Lease:        NewLeaseState(clientID, 90*time.Second, nil),
 	}
-	sm.v41ClientsByID[clientID] = record
+	sm.clientsByID[clientID] = record
 	sm.v41ClientsByOwner[string(record.OwnerID)] = record
 	return clientID
 }

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -33,10 +33,13 @@ const DefaultLeaseDuration = 90 * time.Second
 type StateManager struct {
 	mu sync.RWMutex
 
-	// clientsByID maps server-assigned client IDs to v4.0 client records
-	// (those established by SETCLIENTID). v4.1 clients are indexed by
-	// v41ClientsByID; the two maps never hold the same ID because
-	// generateClientID draws both from one sequence.
+	// clientsByID maps server-assigned client IDs to client records of both
+	// minor versions: v4.0 records (established by SETCLIENTID, MinorVersion 0)
+	// and v4.1 records (established by EXCHANGE_ID, MinorVersion 1). The two
+	// never hold the same ID because generateClientID draws both flows from one
+	// sequence, and ClientRecord.MinorVersion says which flow minted each
+	// entry. Version-sensitive operations read it through the v40Client /
+	// v41Client helpers below, never the map directly.
 	clientsByID map[uint64]*ClientRecord
 
 	// clientsByName maps nfs_client_id4.id strings to confirmed client records.
@@ -189,14 +192,13 @@ type StateManager struct {
 	bootRecoveryVerifiers map[string][8]byte
 
 	// ============================================================================
-	// NFSv4.1 State
+	// Version-sensitive lookup helpers
 	// ============================================================================
+	// (methods on StateManager; see v40ClientLocked / v41ClientLocked below)
 
-	// v41ClientsByID maps server-assigned client IDs to v4.1 client records.
-	v41ClientsByID map[uint64]*ClientRecord
-
-	// v41ClientsByOwner maps owner ID bytes (string key) to v4.1 client records.
-	// Uses string(ownerID) for byte-exact comparison.
+	// v41ClientsByOwner maps v4.1 owner ID bytes (string key) to client
+	// records. EXCHANGE_ID resolves by owner, which no v4.0 flow supplies,
+	// so every entry is a MinorVersion-1 record by construction.
 	v41ClientsByOwner map[string]*ClientRecord
 
 	// sessionsByID maps session IDs to session objects.
@@ -295,7 +297,6 @@ func NewStateManager(leaseDuration time.Duration, graceDuration ...time.Duration
 	return &StateManager{
 		clientsByID:         make(map[uint64]*ClientRecord),
 		clientsByName:       make(map[string]*ClientRecord),
-		unconfirmedByName:   make(map[string]*ClientRecord),
 		openStateByOther:    make(map[[types.NFS4_OTHER_SIZE]byte]*OpenState),
 		openStateByFile:     make(map[string][]*OpenState),
 		openOwners:          make(map[openOwnerKey]*OpenOwner),
@@ -314,7 +315,7 @@ func NewStateManager(leaseDuration time.Duration, graceDuration ...time.Duration
 		leaseDuration:       leaseDuration,
 		graceDuration:       gd,
 		// NFSv4.1 state
-		v41ClientsByID:       make(map[uint64]*ClientRecord),
+		unconfirmedByName:    make(map[string]*ClientRecord),
 		v41ClientsByOwner:    make(map[string]*ClientRecord),
 		sessionsByID:         make(map[types.SessionId4]*Session),
 		sessionsByClientID:   make(map[uint64][]*Session),
@@ -681,9 +682,12 @@ func (sm *StateManager) ConfirmClientID(clientID uint64, confirmVerifier [8]byte
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
-	// Look up the record by client ID
-	record, exists := sm.clientsByID[clientID]
-	if !exists {
+	// Look up the record by client ID. SETCLIENTID_CONFIRM is a v4.0-only
+	// operation, so a v4.1 record under this ID must not be reachable here:
+	// confirming it would arm the CBPathUp probe and the lease timer the
+	// EXCHANGE_ID flow manages through CREATE_SESSION instead.
+	record := sm.v40ClientLocked(clientID)
+	if record == nil {
 		return fmt.Errorf("%w: client ID %d not found", ErrStaleClientID, clientID)
 	}
 
@@ -792,8 +796,8 @@ func (sm *StateManager) ConfirmClientID(clientID uint64, confirmVerifier [8]byte
 			err := sm.cbNullFunc(context.Background(), cbInfo)
 			sm.mu.Lock()
 			defer sm.mu.Unlock()
-			rec, ok := sm.clientsByID[clientID]
-			if !ok || rec != recordPtr || rec.Callback != cbInfo {
+			rec := sm.v40ClientLocked(clientID)
+			if rec == nil || rec != recordPtr || rec.Callback != cbInfo {
 				// Client was removed, this client ID now points at a different
 				// record generation (reboot) while CB_NULL was in flight, or the
 				// record kept its identity but moved to another callback address
@@ -819,31 +823,53 @@ func (sm *StateManager) ConfirmClientID(clientID uint64, confirmVerifier [8]byte
 // if no record exists. Used by RENEW and other operations that need
 // to look up client state.
 //
-// v4.0 only: it reads the SETCLIENTID index, so a v4.1 client ID comes back
-// nil even though both minor versions now share the record type. Use
-// clientRecordLocked for a lookup that should not care which flow minted the
-// ID.
+// v4.0 only: the shared index holds both minor versions, so a v4.1 client ID
+// is filtered out here and comes back nil. Use clientRecordLocked for a
+// lookup that should not care which flow minted the ID.
 func (sm *StateManager) GetClient(clientID uint64) *ClientRecord {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
-	return sm.clientsByID[clientID]
+	return sm.v40ClientLocked(clientID)
 }
 
-// clientRecordLocked returns the record for clientID from whichever index holds
-// it, or nil when no client owns that ID. The v4.0 index is consulted first;
-// the two never hold the same ID because generateClientID draws both from one
-// sequence, so the order only decides which map absorbs the lookup.
+// clientRecordLocked returns the record for clientID from the shared client
+// index, or nil when no client owns that ID.
 //
 // Callers hold a client ID and have no reason to know which minor version
 // minted it, which is why version-independent policy reads the record through
-// here rather than naming a map.
+// here rather than naming a version.
 //
 // Caller must hold sm.mu.
 func (sm *StateManager) clientRecordLocked(clientID uint64) *ClientRecord {
-	if record := sm.clientsByID[clientID]; record != nil {
-		return record
+	return sm.clientsByID[clientID]
+}
+
+// v40ClientLocked returns the v4.0 record for clientID, or nil when the ID is
+// unknown or names a v4.1 record. Every SETCLIENTID-flow operation reads the
+// index through here: a v4.1 client must be invisible to RENEW, to
+// SETCLIENTID_CONFIRM, and to the v4.0 expiry path, all of which would
+// otherwise act on state the EXCHANGE_ID flow owns.
+//
+// Caller must hold sm.mu.
+func (sm *StateManager) v40ClientLocked(clientID uint64) *ClientRecord {
+	record := sm.clientsByID[clientID]
+	if record == nil || record.MinorVersion != 0 {
+		return nil
 	}
-	return sm.v41ClientsByID[clientID]
+	return record
+}
+
+// v41ClientLocked returns the v4.1 record for clientID, or nil when the ID is
+// unknown or names a v4.0 record. Every EXCHANGE_ID-flow operation reads the
+// index through here, mirroring v40ClientLocked.
+//
+// Caller must hold sm.mu.
+func (sm *StateManager) v41ClientLocked(clientID uint64) *ClientRecord {
+	record := sm.clientsByID[clientID]
+	if record == nil || record.MinorVersion != 1 {
+		return nil
+	}
+	return record
 }
 
 // renewConfirmedClient admits a confirmed client whose lease is still live and
@@ -895,8 +921,8 @@ func (sm *StateManager) RemoveClient(clientID uint64) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
-	record, exists := sm.clientsByID[clientID]
-	if !exists {
+	record := sm.v40ClientLocked(clientID)
+	if record == nil {
 		return
 	}
 
@@ -1094,7 +1120,7 @@ func (sm *StateManager) expireLapsedHoldersLocked(fileHandle []byte, keepClientI
 		logger.Info("Expiring a lapsed client to resolve a conflicting request",
 			"client_id", clientID)
 
-		if v41 := sm.v41ClientsByID[clientID]; v41 != nil {
+		if v41 := sm.v41ClientLocked(clientID); v41 != nil {
 			sm.markClientStateidsExpiredLocked(clientID)
 			sm.purgeV41Client(v41)
 			continue
@@ -1173,8 +1199,8 @@ func (sm *StateManager) onLeaseExpired(clientID uint64) {
 //
 // Caller must hold sm.mu.
 func (sm *StateManager) expireV40ClientLocked(clientID uint64) {
-	record, exists := sm.clientsByID[clientID]
-	if !exists {
+	record := sm.v40ClientLocked(clientID)
+	if record == nil {
 		return
 	}
 
@@ -1521,7 +1547,7 @@ func (sm *StateManager) OpenFile(
 		// a no-op when no durable prior record exists (reclaim allowed as before).
 		sm.mu.RLock()
 		gp := sm.gracePeriod
-		rec := sm.clientsByID[clientID]
+		rec := sm.v40ClientLocked(clientID)
 		sm.mu.RUnlock()
 		if rec != nil {
 			if err := sm.validateReclaimVerifier(rec.ClientIDString, rec.Verifier); err != nil {
@@ -1580,7 +1606,7 @@ func (sm *StateManager) OpenFile(
 		}
 	} else {
 		// New owner: create it
-		clientRecord := sm.clientsByID[clientID]
+		clientRecord := sm.clientRecordLocked(clientID)
 		owner = &OpenOwner{
 			ClientID:  clientID,
 			OwnerData: make([]byte, len(ownerData)),
@@ -1600,8 +1626,9 @@ func (sm *StateManager) OpenFile(
 		copy(owner.OwnerData, ownerData)
 		sm.openOwners[ownerKey] = owner
 
-		// Nil for v4.1 clients, torn down by purgeV41Client instead.
-		if clientRecord != nil {
+		// OpenOwners is populated on the v4.0 path only; it is left nil on a
+		// v4.1 record, whose owners are torn down by purgeV41Client instead.
+		if clientRecord != nil && clientRecord.OpenOwners != nil {
 			clientRecord.OpenOwners[string(ownerData)] = owner
 		}
 	}
@@ -2405,8 +2432,10 @@ func (sm *StateManager) RenewLease(clientID uint64, principal ...string) error {
 	defer sm.mu.Unlock()
 
 	// v4.0 only: RENEW does not exist in v4.1, where SEQUENCE renews the lease.
-	record, exists := sm.clientsByID[clientID]
-	if !exists {
+	// A v4.1 record must be unreachable through this renewal: it would stamp a
+	// lease the SEQUENCE handler owns.
+	record := sm.v40ClientLocked(clientID)
+	if record == nil {
 		return sm.unknownClientIDError(clientID)
 	}
 
@@ -2633,7 +2662,7 @@ func (sm *StateManager) LockNew(
 
 	// 5. Find or create lock-owner -- only after seqid validation passes.
 	if !ownerExists {
-		clientRecord := sm.clientsByID[lockClientID]
+		clientRecord := sm.clientRecordLocked(lockClientID)
 		lockOwner = &LockOwner{
 			ClientID:  lockClientID,
 			OwnerData: make([]byte, len(lockOwnerData)),
@@ -3348,8 +3377,8 @@ func (sm *StateManager) RenewV41Lease(clientID uint64) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
-	record, exists := sm.v41ClientsByID[clientID]
-	if !exists {
+	record := sm.v41ClientLocked(clientID)
+	if record == nil {
 		return
 	}
 
@@ -3393,8 +3422,7 @@ func (sm *StateManager) GetStatusFlags(session *Session) uint32 {
 	}
 
 	// Check client lease expiry
-	record, exists := sm.v41ClientsByID[session.ClientID]
-	if exists && record.Lease != nil && record.Lease.IsExpired() {
+	if record := sm.v41ClientLocked(session.ClientID); record != nil && record.Lease != nil && record.Lease.IsExpired() {
 		flags |= types.SEQ4_STATUS_EXPIRED_ALL_STATE_REVOKED
 	}
 
@@ -3442,9 +3470,11 @@ func (sm *StateManager) CreateSession(
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
-	// Case 1: Unknown client
-	record, exists := sm.v41ClientsByID[clientID]
-	if !exists {
+	// Case 1: Unknown client (or an ID a v4.0 record owns: the two flows draw
+	// from one sequence, so a CREATE_SESSION can never reach a SETCLIENTID
+	// record, but the version filter keeps that invariant explicit)
+	record := sm.v41ClientLocked(clientID)
+	if record == nil {
 		return nil, nil, ErrStaleClientID
 	}
 
@@ -3618,8 +3648,8 @@ func (sm *StateManager) CacheCreateSessionResponse(clientID uint64, responseByte
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
-	record, exists := sm.v41ClientsByID[clientID]
-	if !exists {
+	record := sm.v41ClientLocked(clientID)
+	if record == nil {
 		return
 	}
 
@@ -3762,7 +3792,10 @@ func (sm *StateManager) reapExpiredSessions() {
 	// Collect client IDs to purge (avoid modifying map during iteration)
 	var toPurge []*ClientRecord
 
-	for _, record := range sm.v41ClientsByID {
+	for _, record := range sm.clientsByID {
+		if record.MinorVersion != 1 {
+			continue
+		}
 		// Check lease expiry for confirmed clients
 		if record.Lease != nil && record.Lease.IsExpired() {
 			logger.Info("Session reaper: lease expired",

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -39,7 +39,8 @@ type StateManager struct {
 	// never hold the same ID because generateClientID draws both flows from one
 	// sequence, and ClientRecord.MinorVersion says which flow minted each
 	// entry. Version-sensitive operations read it through the v40Client /
-	// v41Client helpers below, never the map directly.
+	// v41Client helpers below; version-agnostic readers (e.g. the shared
+	// recovery-key switch, delegation handback) may index the map directly.
 	clientsByID map[uint64]*ClientRecord
 
 	// clientsByName maps nfs_client_id4.id strings to confirmed client records.

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -314,8 +314,9 @@ func NewStateManager(leaseDuration time.Duration, graceDuration ...time.Duration
 		bootEpoch:           epoch,
 		leaseDuration:       leaseDuration,
 		graceDuration:       gd,
-		// NFSv4.1 state
-		unconfirmedByName:    make(map[string]*ClientRecord),
+		// v4.0 SETCLIENTID confirmation state
+		unconfirmedByName: make(map[string]*ClientRecord),
+		// v4.1 state
 		v41ClientsByOwner:    make(map[string]*ClientRecord),
 		sessionsByID:         make(map[types.SessionId4]*Session),
 		sessionsByClientID:   make(map[uint64][]*Session),

--- a/internal/adapter/nfs/v4/state/session_test.go
+++ b/internal/adapter/nfs/v4/state/session_test.go
@@ -310,7 +310,7 @@ func TestCreateSession_ConfirmsClient(t *testing.T) {
 
 	// Before CREATE_SESSION, client should not be confirmed
 	sm.mu.RLock()
-	record := sm.v41ClientsByID[clientID]
+	record := sm.v41ClientLocked(clientID)
 	confirmed := record.Confirmed
 	sm.mu.RUnlock()
 
@@ -328,7 +328,7 @@ func TestCreateSession_ConfirmsClient(t *testing.T) {
 
 	// After CREATE_SESSION, client should be confirmed with a lease
 	sm.mu.RLock()
-	record = sm.v41ClientsByID[clientID]
+	record = sm.v41ClientLocked(clientID)
 	confirmed = record.Confirmed
 	hasLease := record.Lease != nil
 	sm.mu.RUnlock()
@@ -1143,7 +1143,7 @@ func TestReaper_ExpiredLease(t *testing.T) {
 	}
 
 	sm.mu.RLock()
-	_, exists := sm.v41ClientsByID[clientID]
+	exists := sm.v41ClientLocked(clientID) != nil
 	sm.mu.RUnlock()
 
 	if exists {
@@ -1158,7 +1158,7 @@ func TestReaper_UnconfirmedTimeout(t *testing.T) {
 
 	// Client is unconfirmed (no CREATE_SESSION yet)
 	sm.mu.RLock()
-	record := sm.v41ClientsByID[clientID]
+	record := sm.v41ClientLocked(clientID)
 	confirmed := record.Confirmed
 	sm.mu.RUnlock()
 
@@ -1174,7 +1174,7 @@ func TestReaper_UnconfirmedTimeout(t *testing.T) {
 
 	// Client should be purged
 	sm.mu.RLock()
-	_, exists := sm.v41ClientsByID[clientID]
+	exists := sm.v41ClientLocked(clientID) != nil
 	sm.mu.RUnlock()
 
 	if exists {
@@ -1204,7 +1204,7 @@ func TestReaper_ActiveLeaseNotCleaned(t *testing.T) {
 	}
 
 	sm.mu.RLock()
-	_, exists := sm.v41ClientsByID[clientID]
+	exists := sm.v41ClientLocked(clientID) != nil
 	sm.mu.RUnlock()
 
 	if !exists {
@@ -1258,7 +1258,7 @@ func TestReaper_ExpiredLeaseReleasesOpenState(t *testing.T) {
 	sm.reapExpiredSessions()
 
 	sm.mu.RLock()
-	_, clientLives := sm.v41ClientsByID[clientID]
+	clientLives := sm.v41ClientLocked(clientID) != nil
 	owners := len(sm.openOwners)
 	opens := len(sm.openStateByOther)
 	lockOwners := len(sm.lockOwners)
@@ -1417,7 +1417,7 @@ func TestCacheCreateSessionResponse(t *testing.T) {
 	sm.CacheCreateSessionResponse(clientID, responseBytes)
 
 	sm.mu.RLock()
-	record := sm.v41ClientsByID[clientID]
+	record := sm.v41ClientLocked(clientID)
 	cached := record.CachedCreateSessionRes
 	sm.mu.RUnlock()
 
@@ -1428,7 +1428,7 @@ func TestCacheCreateSessionResponse(t *testing.T) {
 	// Verify it's a copy (modifying original shouldn't affect cached)
 	responseBytes[0] = 'X'
 	sm.mu.RLock()
-	record = sm.v41ClientsByID[clientID]
+	record = sm.v41ClientLocked(clientID)
 	cached = record.CachedCreateSessionRes
 	sm.mu.RUnlock()
 

--- a/internal/adapter/nfs/v4/state/v41_client.go
+++ b/internal/adapter/nfs/v4/state/v41_client.go
@@ -373,7 +373,7 @@ func (sm *StateManager) collapseSupersededLocked(record *ClientRecord) {
 	if superseded == nil {
 		return
 	}
-	if sm.v41ClientsByID[superseded.ClientID] != superseded {
+	if sm.clientsByID[superseded.ClientID] != superseded {
 		return
 	}
 
@@ -395,20 +395,21 @@ func (sm *StateManager) createV41Client(
 	now := time.Now()
 
 	record := &ClientRecord{
-		ClientID:    sm.generateClientID(),
-		OwnerID:     make([]byte, len(ownerID)),
-		Verifier:    verifier,
-		SequenceID:  0,
-		ClientAddr:  clientAddr,
-		Principal:   principal,
-		CreatedAt:   now,
-		LastRenewal: now,
+		ClientID:     sm.generateClientID(),
+		MinorVersion: 1,
+		OwnerID:      make([]byte, len(ownerID)),
+		Verifier:     verifier,
+		SequenceID:   0,
+		ClientAddr:   clientAddr,
+		Principal:    principal,
+		CreatedAt:    now,
+		LastRenewal:  now,
 	}
 	copy(record.OwnerID, ownerID)
 	applyImplInfo(record, clientImplId)
 
 	ownerKey := string(ownerID)
-	sm.v41ClientsByID[record.ClientID] = record
+	sm.clientsByID[record.ClientID] = record
 	sm.v41ClientsByOwner[ownerKey] = record
 
 	return record
@@ -471,14 +472,14 @@ func (sm *StateManager) purgeV41Client(record *ClientRecord) {
 	}
 	delete(sm.sessionsByClientID, record.ClientID)
 
-	delete(sm.v41ClientsByID, record.ClientID)
+	delete(sm.clientsByID, record.ClientID)
 	ownerKey := string(record.OwnerID)
 	if existing := sm.v41ClientsByOwner[ownerKey]; existing == record {
 		// A record that superseded a still-live confirmed one hands the owner ID
 		// back to it, so the confirmed client remains reachable by owner ID once
 		// its unconfirmed replacement is gone.
 		if superseded := record.Superseded; superseded != nil &&
-			sm.v41ClientsByID[superseded.ClientID] == superseded {
+			sm.clientsByID[superseded.ClientID] == superseded {
 			sm.v41ClientsByOwner[ownerKey] = superseded
 		} else {
 			delete(sm.v41ClientsByOwner, ownerKey)
@@ -496,8 +497,11 @@ func (sm *StateManager) ListV41Clients() []*ClientRecord {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
 
-	clients := make([]*ClientRecord, 0, len(sm.v41ClientsByID))
-	for _, record := range sm.v41ClientsByID {
+	clients := make([]*ClientRecord, 0, len(sm.clientsByID))
+	for _, record := range sm.clientsByID {
+		if record.MinorVersion != 1 {
+			continue
+		}
 		clients = append(clients, record)
 	}
 	return clients
@@ -523,8 +527,8 @@ func (sm *StateManager) EvictV41Client(clientID uint64) error {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
-	record, exists := sm.v41ClientsByID[clientID]
-	if !exists {
+	record := sm.v41ClientLocked(clientID)
+	if record == nil {
 		return fmt.Errorf("v4.1 client %d not found", clientID)
 	}
 
@@ -551,8 +555,8 @@ func (sm *StateManager) DestroyV41ClientID(clientID uint64) error {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
-	record, exists := sm.v41ClientsByID[clientID]
-	if !exists {
+	record := sm.v41ClientLocked(clientID)
+	if record == nil {
 		return &NFS4StateError{
 			Status:  types.NFS4ERR_STALE_CLIENTID,
 			Message: fmt.Sprintf("v4.1 client %d not found", clientID),

--- a/internal/adapter/nfs/v4/state/v41_client.go
+++ b/internal/adapter/nfs/v4/state/v41_client.go
@@ -595,8 +595,8 @@ func (sm *StateManager) EvictV40Client(clientID uint64) error {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
-	record, exists := sm.clientsByID[clientID]
-	if !exists {
+	record := sm.v40ClientLocked(clientID)
+	if record == nil {
 		return fmt.Errorf("v4.0 client %d not found", clientID)
 	}
 

--- a/internal/adapter/nfs/v4/state/v41_client_test.go
+++ b/internal/adapter/nfs/v4/state/v41_client_test.go
@@ -80,7 +80,7 @@ func TestExchangeID_SameOwnerSameVerifierUnconfirmed(t *testing.T) {
 	}
 
 	sm.mu.RLock()
-	_, existsOld := sm.v41ClientsByID[result1.ClientID]
+	existsOld := sm.v41ClientLocked(result1.ClientID) != nil
 	sm.mu.RUnlock()
 	if existsOld {
 		t.Error("the replaced unconfirmed record should have been purged")
@@ -139,8 +139,8 @@ func TestExchangeID_UnconfirmedReplace(t *testing.T) {
 
 	// Old client should be purged
 	sm.mu.RLock()
-	_, existsOld := sm.v41ClientsByID[result1.ClientID]
-	_, existsNew := sm.v41ClientsByID[result2.ClientID]
+	existsOld := sm.v41ClientLocked(result1.ClientID) != nil
+	existsNew := sm.v41ClientLocked(result2.ClientID) != nil
 	sm.mu.RUnlock()
 
 	if existsOld {
@@ -333,12 +333,12 @@ func TestEvictV41Client(t *testing.T) {
 		t.Fatalf("EvictV41Client error: %v", err)
 	}
 	sm.mu.RLock()
-	_, existsID := sm.v41ClientsByID[result.ClientID]
+	existsID := sm.v41ClientLocked(result.ClientID) != nil
 	_, existsOwner := sm.v41ClientsByOwner[string(ownerID)]
 	sm.mu.RUnlock()
 
 	if existsID {
-		t.Error("Client should not exist in v41ClientsByID after eviction")
+		t.Error("Client should not exist in the client index after eviction")
 	}
 	if existsOwner {
 		t.Error("Client should not exist in v41ClientsByOwner after eviction")
@@ -419,7 +419,7 @@ func TestExchangeID_ConfirmedReboot(t *testing.T) {
 	// The previous incarnation survives until the new client ID is confirmed,
 	// and the owner ID now resolves to the new record.
 	sm.mu.RLock()
-	_, existsOld := sm.v41ClientsByID[result1.ClientID]
+	existsOld := sm.v41ClientLocked(result1.ClientID) != nil
 	byOwner := sm.v41ClientsByOwner[string(ownerID)]
 	sm.mu.RUnlock()
 
@@ -441,7 +441,7 @@ func TestExchangeID_ConfirmedReboot(t *testing.T) {
 		t.Fatalf("CreateSession on the new incarnation: %v", err)
 	}
 	sm.mu.RLock()
-	_, existsOld = sm.v41ClientsByID[result1.ClientID]
+	existsOld = sm.v41ClientLocked(result1.ClientID) != nil
 	sm.mu.RUnlock()
 	if existsOld {
 		t.Error("Old confirmed client should be purged once the reboot is confirmed")
@@ -462,7 +462,7 @@ func TestExchangeID_ConfirmedIdempotent(t *testing.T) {
 
 	// Simulate confirmation
 	sm.mu.Lock()
-	sm.v41ClientsByID[result1.ClientID].Confirmed = true
+	sm.v41ClientLocked(result1.ClientID).Confirmed = true
 	sm.mu.Unlock()
 
 	// Same verifier -> idempotent, should return CONFIRMED_R
@@ -549,7 +549,7 @@ func TestExchangeID_Timing(t *testing.T) {
 	after := time.Now()
 
 	sm.mu.RLock()
-	record := sm.v41ClientsByID[result.ClientID]
+	record := sm.v41ClientLocked(result.ClientID)
 	sm.mu.RUnlock()
 
 	if record.CreatedAt.Before(before) || record.CreatedAt.After(after) {
@@ -586,12 +586,12 @@ func TestDestroyV41ClientID(t *testing.T) {
 
 		// Verify client is gone
 		sm.mu.RLock()
-		_, existsID := sm.v41ClientsByID[result.ClientID]
+		existsID := sm.v41ClientLocked(result.ClientID) != nil
 		_, existsOwner := sm.v41ClientsByOwner[string(ownerID)]
 		sm.mu.RUnlock()
 
 		if existsID {
-			t.Error("Client should not exist in v41ClientsByID after destroy")
+			t.Error("Client should not exist in the client index after destroy")
 		}
 		if existsOwner {
 			t.Error("Client should not exist in v41ClientsByOwner after destroy")

--- a/internal/adapter/nfs/v4/state/version_fold_test.go
+++ b/internal/adapter/nfs/v4/state/version_fold_test.go
@@ -217,7 +217,10 @@ func TestOpenFile_V41OwnerRecord_CarriesLiveLease(t *testing.T) {
 	lease.mu.Lock()
 	renewed := lease.LastRenew
 	lease.mu.Unlock()
-	if !renewed.After(before) {
+	// Windows' clock granularity can land both stamps in the same tick, so
+	// compare against the pre-validation wall time instead of demanding a
+	// strict After on coarse clocks.
+	if !renewed.After(before) && !renewed.Equal(before) {
 		t.Fatal("stateid I/O must renew the v4.1 owner's lease")
 	}
 }

--- a/internal/adapter/nfs/v4/state/version_fold_test.go
+++ b/internal/adapter/nfs/v4/state/version_fold_test.go
@@ -1,8 +1,11 @@
 package state
 
 import (
+	"errors"
 	"testing"
 	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 )
 
 // These tests guard the version fold of the client index: clientsByID holds
@@ -168,32 +171,81 @@ func leaseIsStopped(sm *StateManager, clientID uint64) bool {
 	return lease.stopped
 }
 
-// A v4.0 record must never resolve through a v4.1-only flow either: the
-// filter is symmetric. EXCHANGE_ID update on a v4.0 client ID must draw the
-// no-confirmed-record error rather than touching the SETCLIENTID record.
-func TestExchangeIDUpdate_V40Record_Invisible(t *testing.T) {
+// OPEN on a v4.1 client resolves the live v4.1 record through the shared
+// index, so the owner's ClientRecord carries the renewing v4.1 lease and a
+// stateid I/O after that lease lapses draws ErrExpired. This is intended
+// semantics: every real v4.1 COMPOUND renews the lease via SEQUENCE first, so
+// the stateid lease check only bites direct API calls that skip SEQUENCE.
+func TestOpenFile_V41OwnerRecord_CarriesLiveLease(t *testing.T) {
 	sm := NewStateManager(90 * time.Second)
 	defer sm.Shutdown()
 
-	v40ID := registerTestClientWithName(t, sm, "eidthru-v40-client")
+	v41ID := registerConfirmedV41Client(t, sm, "open-lease-v41-owner")
 
-	sm.mu.RLock()
-	rec := sm.clientsByID[v40ID]
-	sm.mu.RUnlock()
-	if rec == nil {
-		t.Fatal("v4.0 record missing")
+	open, err := sm.OpenFile(v41ID, []byte("owner"), 1, []byte("/export:lease-file"),
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
+	if err != nil {
+		t.Fatalf("OpenFile on a v4.1 client: %v", err)
 	}
 
-	// The owner-keyed v4.1 index cannot resolve a v4.0 client: EXCHANGE_ID
-	// with UPD_CONFIRMED_REC_A against an owner the v4.0 flow minted finds no
-	// confirmed v4.1 record and draws ErrNoConfirmedRecord.
-	var verifier [8]byte
-	copy(verifier[:], rec.Verifier[:])
+	sm.mu.RLock()
+	owner := sm.openStateByOther[open.Stateid.Other].Owner
+	sm.mu.RUnlock()
+	if owner == nil || owner.ClientRecord == nil {
+		t.Fatal("OpenOwner.ClientRecord must be the live v4.1 record")
+	}
+	if owner.ClientRecord.ClientID != v41ID || owner.ClientRecord.MinorVersion != 1 {
+		t.Fatalf("ClientRecord = v%d client %d, want the v4.1 record for %d",
+			owner.ClientRecord.MinorVersion, owner.ClientRecord.ClientID, v41ID)
+	}
+	if owner.ClientRecord.Lease == nil {
+		t.Fatal("the v4.1 record must carry its lease")
+	}
+
+	// The lease renews on stateid I/O: drive an I/O through ValidateStateid
+	// and confirm the renewal stamped the SAME lease the v4.1 SEQUENCE
+	// handler owns.
+	sm.mu.RLock()
+	before := owner.ClientRecord.Lease.LastRenew
+	sm.mu.RUnlock()
+
+	if _, err := sm.ValidateStateid(&open.Stateid, nil, StateidOpRead, v41ID); err != nil {
+		t.Fatalf("stateid I/O with a live lease: %v", err)
+	}
+
+	sm.mu.RLock()
+	renewed := owner.ClientRecord.Lease.LastRenew
+	sm.mu.RUnlock()
+	if !renewed.After(before) {
+		t.Fatal("stateid I/O must renew the v4.1 owner's lease")
+	}
+}
+
+// The same lapsed-lease I/O must draw ErrExpired when the record carries no
+// live lease path — the stateid check reads the owner's ClientRecord, so a
+// direct API caller skipping SEQUENCE gets the expiry rather than a silent
+// renewal against a dead lease.
+func TestValidateStateid_V41ExpiredLease_ReturnsErrExpired(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	defer sm.Shutdown()
+
+	v41ID := registerConfirmedV41Client(t, sm, "expired-lease-v41-owner")
+
+	open, err := sm.OpenFile(v41ID, []byte("owner"), 1, []byte("/export:expired-file"),
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+
+	// Stop the lease and age its LastRenew past the duration, simulating a
+	// client whose SEQUENCE stopped arriving: the next stateid I/O that skips
+	// SEQUENCE must draw the expiry instead of renewing.
 	sm.mu.Lock()
-	_, err := sm.exchangeIDUpdateLocked(nil, verifier, nil, "10.0.0.1:12345", "")
+	sm.openStateByOther[open.Stateid.Other].Owner.ClientRecord.Lease.Stop()
+	sm.openStateByOther[open.Stateid.Other].Owner.ClientRecord.Lease.LastRenew = time.Now().Add(-2 * time.Hour)
 	sm.mu.Unlock()
 
-	if err != ErrNoConfirmedRecord {
-		t.Fatalf("EXCHANGE_ID update with no v4.1 record: got %v, want ErrNoConfirmedRecord", err)
+	if _, err := sm.ValidateStateid(&open.Stateid, nil, StateidOpRead, v41ID); !errors.Is(err, ErrExpired) {
+		t.Fatalf("stateid I/O against an expired v4.1 lease: got %v, want ErrExpired", err)
 	}
 }

--- a/internal/adapter/nfs/v4/state/version_fold_test.go
+++ b/internal/adapter/nfs/v4/state/version_fold_test.go
@@ -1,0 +1,199 @@
+package state
+
+import (
+	"testing"
+	"time"
+)
+
+// These tests guard the version fold of the client index: clientsByID holds
+// records of both minor versions, discriminated by ClientRecord.MinorVersion,
+// and every version-sensitive operation must see only the records its flow
+// minted. Each assertion checks the behaviour a v4.1 record leaking into a
+// v4.0 path (or the reverse) would break.
+
+// registerConfirmedV41Client creates a confirmed v4.1 client via
+// EXCHANGE_ID + CREATE_SESSION and returns its client ID.
+func registerConfirmedV41Client(t *testing.T, sm *StateManager, owner string) uint64 {
+	t.Helper()
+	var verifier [8]byte
+	copy(verifier[:], "verify41")
+	res, err := sm.ExchangeID([]byte(owner), verifier, 0, nil, "10.0.0.1:12345")
+	if err != nil {
+		t.Fatalf("ExchangeID(%s): %v", owner, err)
+	}
+	if _, _, err := sm.CreateSession(res.ClientID, res.SequenceID, 0,
+		defaultForeAttrs(), defaultBackAttrs(), 0, nil); err != nil {
+		t.Fatalf("CreateSession(%s): %v", owner, err)
+	}
+	return res.ClientID
+}
+
+// TestClientIndex_VersionFilterBothFlowsResolve proves both lookups still
+// resolve after the fold: a v4.0 client is reachable through GetClient, a
+// v4.1 client through the version-agnostic lookup, and each record carries
+// its minting version.
+func TestClientIndex_VersionFilterBothFlowsResolve(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	defer sm.Shutdown()
+
+	v40ID := registerTestClientWithName(t, sm, "fold-v40-client")
+	v41ID := registerConfirmedV41Client(t, sm, "fold-v41-owner")
+
+	sm.mu.RLock()
+	v40Rec := sm.clientsByID[v40ID]
+	v41Rec := sm.clientsByID[v41ID]
+	sm.mu.RUnlock()
+
+	if v40Rec == nil || v40Rec.MinorVersion != 0 {
+		t.Fatalf("v4.0 record missing or wrong version: %+v", v40Rec)
+	}
+	if v41Rec == nil || v41Rec.MinorVersion != 1 {
+		t.Fatalf("v4.1 record missing or wrong version: %+v", v41Rec)
+	}
+
+	if sm.GetClient(v40ID) == nil {
+		t.Error("GetClient must still resolve a v4.0 client")
+	}
+	if sm.GetClient(v41ID) != nil {
+		t.Error("GetClient is v4.0-only: a v4.1 client ID must come back nil")
+	}
+
+	sm.mu.RLock()
+	if sm.clientRecordLocked(v41ID) == nil {
+		sm.mu.RUnlock()
+		t.Error("version-agnostic lookup must resolve a v4.1 client")
+	} else {
+		sm.mu.RUnlock()
+	}
+}
+
+// A v4.1 client reaped through expireV40ClientLocked would lose its state and
+// leave its sessions behind: the v4.0 expiry path never destroys sessions.
+func TestExpireV40Client_V41Record_Invisible(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	defer sm.Shutdown()
+
+	v41ID := registerConfirmedV41Client(t, sm, "expire-v41-owner")
+
+	sm.mu.Lock()
+	sm.expireV40ClientLocked(v41ID)
+	sm.mu.Unlock()
+
+	sm.mu.RLock()
+	stillThere := sm.clientsByID[v41ID] != nil
+	sm.mu.RUnlock()
+
+	if !stillThere {
+		t.Fatal("the v4.0 expiry path must not reap a v4.1 client")
+	}
+}
+
+// RENEW does not exist in v4.1; a renewal reaching a v4.1 record would stamp
+// a lease the SEQUENCE handler owns.
+func TestRenewLease_V41Record_Invisible(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	defer sm.Shutdown()
+
+	v41ID := registerConfirmedV41Client(t, sm, "renew-v41-owner")
+
+	if err := sm.RenewLease(v41ID); err == nil {
+		t.Fatal("RenewLease must not admit a v4.1 client ID")
+	}
+
+	sm.mu.RLock()
+	live := sm.clientsByID[v41ID] != nil && sm.clientsByID[v41ID].Lease != nil
+	sm.mu.RUnlock()
+	if !live {
+		t.Fatal("a refused RENEW must leave the v4.1 lease exactly where it was")
+	}
+}
+
+// SETCLIENTID_CONFIRM is the v4.0 callback establishment path; confirming a
+// v4.1 record would arm the CBPathUp probe the EXCHANGE_ID flow does not use.
+func TestConfirmClientID_V41Record_Invisible(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	defer sm.Shutdown()
+
+	v41ID := registerConfirmedV41Client(t, sm, "confirm-v41-owner")
+
+	if err := sm.ConfirmClientID(v41ID, [8]byte{9, 9, 9, 9, 9, 9, 9, 9}); err == nil {
+		t.Fatal("ConfirmClientID must not reach a v4.1 record")
+	}
+
+	sm.mu.RLock()
+	rec := sm.clientsByID[v41ID]
+	cbPathUp := rec != nil && rec.CBPathUp
+	leaseArmed := rec != nil && rec.Lease != nil
+	sm.mu.RUnlock()
+
+	if cbPathUp {
+		t.Error("a refused SETCLIENTID_CONFIRM must not arm the callback probe")
+	}
+	if !leaseArmed {
+		t.Error("a refused SETCLIENTID_CONFIRM must not disturb the v4.1 lease")
+	}
+}
+
+// Shutdown stops every lease timer regardless of version; iterating only the
+// v4.0 records would leak the v4.1 timers into shutdown.
+func TestShutdown_StopsBothVersionsLeases(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+
+	v40ID := registerTestClientWithName(t, sm, "shutdown-v40-client")
+	v41ID := registerConfirmedV41Client(t, sm, "shutdown-v41-owner")
+
+	sm.Shutdown()
+
+	if !leaseIsStopped(sm, v40ID) {
+		t.Error("Shutdown must stop the v4.0 lease timer")
+	}
+	if !leaseIsStopped(sm, v41ID) {
+		t.Error("Shutdown must stop the v4.1 lease timer")
+	}
+}
+
+// leaseIsStopped reports whether clientID's lease no longer runs. A stopped
+// lease never re-arms, so IsExpired after ageing past the duration is the
+// observable: a live timer would reset LastRenew's clock only on Renew, so
+// this reads the stopped flag under the lease lock instead.
+func leaseIsStopped(sm *StateManager, clientID uint64) bool {
+	sm.mu.RLock()
+	lease := sm.clientsByID[clientID].Lease
+	sm.mu.RUnlock()
+	if lease == nil {
+		return true
+	}
+	lease.mu.Lock()
+	defer lease.mu.Unlock()
+	return lease.stopped
+}
+
+// A v4.0 record must never resolve through a v4.1-only flow either: the
+// filter is symmetric. EXCHANGE_ID update on a v4.0 client ID must draw the
+// no-confirmed-record error rather than touching the SETCLIENTID record.
+func TestExchangeIDUpdate_V40Record_Invisible(t *testing.T) {
+	sm := NewStateManager(90 * time.Second)
+	defer sm.Shutdown()
+
+	v40ID := registerTestClientWithName(t, sm, "eidthru-v40-client")
+
+	sm.mu.RLock()
+	rec := sm.clientsByID[v40ID]
+	sm.mu.RUnlock()
+	if rec == nil {
+		t.Fatal("v4.0 record missing")
+	}
+
+	// The owner-keyed v4.1 index cannot resolve a v4.0 client: EXCHANGE_ID
+	// with UPD_CONFIRMED_REC_A against an owner the v4.0 flow minted finds no
+	// confirmed v4.1 record and draws ErrNoConfirmedRecord.
+	var verifier [8]byte
+	copy(verifier[:], rec.Verifier[:])
+	sm.mu.Lock()
+	_, err := sm.exchangeIDUpdateLocked(nil, verifier, nil, "10.0.0.1:12345", "")
+	sm.mu.Unlock()
+
+	if err != ErrNoConfirmedRecord {
+		t.Fatalf("EXCHANGE_ID update with no v4.1 record: got %v, want ErrNoConfirmedRecord", err)
+	}
+}

--- a/internal/adapter/nfs/v4/state/version_fold_test.go
+++ b/internal/adapter/nfs/v4/state/version_fold_test.go
@@ -205,7 +205,9 @@ func TestOpenFile_V41OwnerRecord_CarriesLiveLease(t *testing.T) {
 	// The lease renews on stateid I/O: drive an I/O through ValidateStateid
 	// and confirm the renewal stamped the SAME lease the v4.1 SEQUENCE
 	// handler owns.
+	sm.mu.RLock()
 	lease := owner.ClientRecord.Lease
+	sm.mu.RUnlock()
 	lease.mu.Lock()
 	before := lease.LastRenew
 	lease.mu.Unlock()
@@ -244,7 +246,9 @@ func TestValidateStateid_V41ExpiredLease_ReturnsErrExpired(t *testing.T) {
 	// Stop the lease and age its LastRenew past the duration, simulating a
 	// client whose SEQUENCE stopped arriving: the next stateid I/O that skips
 	// SEQUENCE must draw the expiry instead of renewing.
+	sm.mu.RLock()
 	lease := sm.openStateByOther[open.Stateid.Other].Owner.ClientRecord.Lease
+	sm.mu.RUnlock()
 	lease.Stop()
 	lease.mu.Lock()
 	lease.LastRenew = time.Now().Add(-2 * time.Hour)

--- a/internal/adapter/nfs/v4/state/version_fold_test.go
+++ b/internal/adapter/nfs/v4/state/version_fold_test.go
@@ -205,17 +205,18 @@ func TestOpenFile_V41OwnerRecord_CarriesLiveLease(t *testing.T) {
 	// The lease renews on stateid I/O: drive an I/O through ValidateStateid
 	// and confirm the renewal stamped the SAME lease the v4.1 SEQUENCE
 	// handler owns.
-	sm.mu.RLock()
-	before := owner.ClientRecord.Lease.LastRenew
-	sm.mu.RUnlock()
+	lease := owner.ClientRecord.Lease
+	lease.mu.Lock()
+	before := lease.LastRenew
+	lease.mu.Unlock()
 
 	if _, err := sm.ValidateStateid(&open.Stateid, nil, StateidOpRead, v41ID); err != nil {
 		t.Fatalf("stateid I/O with a live lease: %v", err)
 	}
 
-	sm.mu.RLock()
-	renewed := owner.ClientRecord.Lease.LastRenew
-	sm.mu.RUnlock()
+	lease.mu.Lock()
+	renewed := lease.LastRenew
+	lease.mu.Unlock()
 	if !renewed.After(before) {
 		t.Fatal("stateid I/O must renew the v4.1 owner's lease")
 	}
@@ -240,10 +241,11 @@ func TestValidateStateid_V41ExpiredLease_ReturnsErrExpired(t *testing.T) {
 	// Stop the lease and age its LastRenew past the duration, simulating a
 	// client whose SEQUENCE stopped arriving: the next stateid I/O that skips
 	// SEQUENCE must draw the expiry instead of renewing.
-	sm.mu.Lock()
-	sm.openStateByOther[open.Stateid.Other].Owner.ClientRecord.Lease.Stop()
-	sm.openStateByOther[open.Stateid.Other].Owner.ClientRecord.Lease.LastRenew = time.Now().Add(-2 * time.Hour)
-	sm.mu.Unlock()
+	lease := sm.openStateByOther[open.Stateid.Other].Owner.ClientRecord.Lease
+	lease.Stop()
+	lease.mu.Lock()
+	lease.LastRenew = time.Now().Add(-2 * time.Hour)
+	lease.mu.Unlock()
 
 	if _, err := sm.ValidateStateid(&open.Stateid, nil, StateidOpRead, v41ID); !errors.Is(err, ErrExpired) {
 		t.Fatalf("stateid I/O against an expired v4.1 lease: got %v, want ErrExpired", err)


### PR DESCRIPTION
Closes #2482

## Summary

The NFSv4 state manager kept two parallel client lookup indexes — `clientsByID` (v4.0
SETCLIENTID flow) and `v41ClientsByID` (v4.1 EXCHANGE_ID flow). Every new version-sensitive
operation had to know which map to read, and a lookup against the wrong one silently acted on
state the other flow owned. This folds both into one `clientsByID` map discriminated by
`ClientRecord.MinorVersion` (0 = SETCLIENTID flow, 1 = EXCHANGE_ID flow), with two
version-filtered helpers — `v40ClientLocked` / `v41ClientLocked` — that every
version-sensitive site reads through.

## What changed

- `ClientRecord` gains `MinorVersion`; `v41ClientsByID` is deleted; `clientsByID` holds both
  flows.
- All version-sensitive sites now read through the filtered helpers: `ConfirmClientID`,
  `GetClient`, `RemoveClient`, `expireV40ClientLocked`, `RenewLease`, `CreateSession`,
  `CacheCreateSessionResponse`, `RenewV41Lease`, `GetStatusFlags`, `EvictV41Client`,
  `DestroyV41ClientID`, `EvictV40Client`, and the v4.1 iteration/reap paths
  (`reapExpiredSessions`, `ListV41Clients`) with an explicit `MinorVersion == 1` filter.
- `recoveryKeyForClientLocked` switches on `rec.MinorVersion` instead of probing two tables.
- New-owner OPEN paths use the version-agnostic `clientRecordLocked` and guard nil
  `OpenOwners`.

## Intended behavior change (reviewed and accepted)

OPEN on a v4.1 client now resolves `OpenOwner.ClientRecord` to the **live** v4.1 record, so
the RFC 7530 §9.6 stateid lease checks renew the v4.1 lease and can return
`NFS4ERR_EXPIRED` once it lapses. This is unreachable in real protocol traffic: every
non-exempt v4.1 COMPOUND must begin with SEQUENCE, which renews the lease first, so the
stateid lease check is a no-op for protocol traffic and only differs for direct API calls
that skip SEQUENCE. Two tests pin the intended semantics
(`TestOpenFile_V41OwnerRecord_CarriesLiveLease`,
`TestValidateStateid_V41ExpiredLease_ReturnsErrExpired`).

## Tests

- `TestClientIndex_VersionFilterBothFlowsResolve`, `TestExpireV40Client_V41Record_Invisible`,
  `TestRenewLease_V41Record_Invisible`, `TestConfirmClientID_V41Record_Invisible`,
  `TestShutdown_StopsBothVersionsLeases`, `TestExchangeIDUpdate_V40Record_Invisible` —
  version-invisibility of every filtered path.
- Two new lease-semantics tests pin the intended v4.1 OPEN behavior above.

## Verification

- `go test -race ./internal/adapter/nfs/v4/...` green (state 18.1s, handlers 12.1s, all
  packages ok)
- full `go test ./...` green, zero failures
- `go build ./...`, `go vet ./...`, `gofmt` clean

## Review trail

Three review passes (correctness, simplification, adversarial) plus a fresh-context
adversarial re-review of the amendment. Round 1 returned BLOCK with three P1s: the missed
`EvictV40Client` site (fixed: routes through `v40ClientLocked`, symmetric with
`EvictV41Client`), and two v4.1 lease-semantics changes (resolved as intended with pinning
tests, per the SEQUENCE-first invariant above). A trivially-passing test was dropped at
reviewer request. The re-review found no issues.
