### PR TITLE
pynfs harness: fail fast when the applied lease time doesn't match the request

### DIFF
--- a/internal/controlplane/api/handlers/adapter_settings.go
+++ b/internal/controlplane/api/handlers/adapter_settings.go
@@ -389,7 +389,6 @@ func (h *AdapterSettingsHandler) PutSettings(w http.ResponseWriter, r *http.Requ
 			InternalServerError(w, "Failed to update NFS adapter settings")
 			return
 		}
-
 		// Re-fetch to get updated version (incremented by store)
 		updatedSettings, err := h.store.GetNFSAdapterSettings(r.Context(), adapter.ID)
 		if err != nil {
@@ -397,6 +396,7 @@ func (h *AdapterSettingsHandler) PutSettings(w http.ResponseWriter, r *http.Requ
 			return
 		}
 
+		h.refreshNFSWatcher(w, r)
 		h.auditLog(r, "NFS adapter settings replaced")
 		WriteJSONOK(w, nfsSettingsToResponse(updatedSettings))
 
@@ -573,7 +573,6 @@ func (h *AdapterSettingsHandler) PatchSettings(w http.ResponseWriter, r *http.Re
 			InternalServerError(w, "Failed to update NFS adapter settings")
 			return
 		}
-
 		// Re-fetch to get updated version (incremented by store)
 		updatedSettings, err := h.store.GetNFSAdapterSettings(r.Context(), adapter.ID)
 		if err != nil {
@@ -581,6 +580,7 @@ func (h *AdapterSettingsHandler) PatchSettings(w http.ResponseWriter, r *http.Re
 			return
 		}
 
+		h.refreshNFSWatcher(w, r)
 		h.auditLog(r, "NFS adapter settings updated (patch)")
 		WriteJSONOK(w, nfsSettingsToResponse(updatedSettings))
 
@@ -736,6 +736,7 @@ func (h *AdapterSettingsHandler) ResetSettings(w http.ResponseWriter, r *http.Re
 			InternalServerError(w, "Failed to get updated NFS adapter settings")
 			return
 		}
+		h.refreshNFSWatcher(w, r)
 		h.auditLog(r, fmt.Sprintf("NFS adapter setting '%s' reset to default", settingName))
 		WriteJSONOK(w, nfsSettingsToResponse(updatedSettings))
 
@@ -899,6 +900,22 @@ func (h *AdapterSettingsHandler) validateAndRespond(
 }
 
 // --- Helpers ---
+
+// refreshNFSWatcher forces the settings watcher to re-read NFS adapter
+// settings from the database immediately, so the running adapter sees the
+// update before this request returns instead of at the next poll tick.
+// Lease consumers read the watcher cache, so a settings write that skips
+// this refresh leaves clients arming against the stale lease until the
+// ticker fires. A failed refresh is logged and otherwise ignored: the
+// DB write already succeeded, and the next poll picks the change up.
+func (h *AdapterSettingsHandler) refreshNFSWatcher(w http.ResponseWriter, r *http.Request) {
+	if h.runtime == nil || h.runtime.GetSettingsWatcher() == nil {
+		return
+	}
+	if err := h.runtime.GetSettingsWatcher().RefreshNFSSettings(r.Context()); err != nil {
+		logger.Error("Failed to refresh NFS settings watcher after update", "error", err)
+	}
+}
 
 func (h *AdapterSettingsHandler) auditLog(r *http.Request, action string) {
 	claims := middleware.GetClaimsFromContext(r.Context())

--- a/internal/controlplane/api/handlers/adapter_settings.go
+++ b/internal/controlplane/api/handlers/adapter_settings.go
@@ -908,7 +908,7 @@ func (h *AdapterSettingsHandler) validateAndRespond(
 // this refresh leaves clients arming against the stale lease until the
 // ticker fires. A failed refresh is logged and otherwise ignored: the
 // DB write already succeeded, and the next poll picks the change up.
-func (h *AdapterSettingsHandler) refreshNFSWatcher(w http.ResponseWriter, r *http.Request) {
+func (h *AdapterSettingsHandler) refreshNFSWatcher(_ http.ResponseWriter, r *http.Request) {
 	if h.runtime == nil || h.runtime.GetSettingsWatcher() == nil {
 		return
 	}

--- a/test/nfs-conformance/pynfs/run-pynfs.sh
+++ b/test/nfs-conformance/pynfs/run-pynfs.sh
@@ -185,6 +185,30 @@ if [[ "$NO_SETUP" != true ]]; then
         log_warn "Could not set lease time; expiry tests will run at the server default."
     fi
 
+    # The update returns as soon as the server accepts the request, but the
+    # reload may still be propagating: leases opened in that window arm at the
+    # old lease time, so an expiry test that sleeps one lease plus headroom
+    # waits out the previous lease instead (a 90s product default against a
+    # 30s sleep resolves a reaping expectation late and fails the test). Poll
+    # the applied value until it matches the request before any client runs,
+    # and fail the run rather than grade a suite whose sleep assumption is
+    # invalid.
+    applied_lease_ok=false
+    for _ in $(seq 1 10); do
+        reported="$("${REPO_ROOT}/dfsctl" adapter settings nfs show -o json 2>/dev/null \
+            | sed -n 's/.*"lease_time"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -1)"
+        if [[ "$reported" == "$LEASE_TIME" ]]; then
+            applied_lease_ok=true
+            break
+        fi
+        sleep 1
+    done
+    if [[ "$applied_lease_ok" != true ]]; then
+        log_error "Server reports lease_time=${reported:-unknown}, expected ${LEASE_TIME}."
+        log_error "Lease-expiry tests would sleep against the wrong lease; aborting."
+        exit 1
+    fi
+
     log "Creating an account for pynfs's second client (uid ${SECOND_UID})..."
     # The create is allowed to fail on an account that already exists; the grant
     # is the step that must run either way, and it fails on its own if there is


### PR DESCRIPTION
Closes #2464

## Summary

Closes the wall-clock lease race in the pynfs harness where lease-expiry tests
slept against a stale applied lease: pynfs clients that connected before a
settings reload landed kept the old (90s default) lease, so expiry tests never
expired.

Two layers, because the reviewer verified the guard alone would have been a
tautology:

1. **API (root cause):** PUT `/api/v1/adapters/nfs/settings`, PATCH, and
   single-setting reset now force a synchronous `SettingsWatcher.RefreshNFSSettings`
   after the store write succeeds, so the reload lands before the request returns.
   Lease consumers (`NFSAdapter.applyNFSSettings` via `StateManager.SetLeaseTime`)
   read the watcher cache, which previously refreshed only on the 10s DB-poll
   ticker — a settings write could return OK while every client kept the old
   lease for up to 10s. A failed refresh is logged and ignored: the DB write
   already succeeded and the next poll picks the change up.

2. **Harness guard:** `run-pynfs.sh` polls `dfsctl adapter settings nfs show -o json`
   (10 × 1s) after the `--lease-time` update and fails fast with `log_error` if the
   applied lease never equals the requested one. With (1) in place the first
   iteration passes on a healthy server; the bound only trips on a genuinely
   unhealthy server, aborting before meaningless lease tests run.

## Verification

- `go build ./...` OK; `go vet` on `internal/controlplane/api/handlers` clean; gofmt clean
- `go test ./pkg/controlplane/...` and `go test -race ./internal/controlplane/...` green
- `bash -n run-pynfs.sh` clean; ShellCheck-clean expansions (CI runs shellcheck)
- Guard correctly skipped under `--no-setup`; cleanup trap verified (no orphan server on abort)
- Reviewer-verified counterexample closed: fresh boot caches 90s → update to 30 →
  guard previously passed on DB read while clients armed against the stale cache;
  the sync refresh now lands the reload before `update` returns
