### PR TITLE
LOCK: reject special stateids on the exist path with NFS4ERR_BAD_STATEID

### DIFF
--- a/internal/adapter/nfs/v4/state/lockowner_test.go
+++ b/internal/adapter/nfs/v4/state/lockowner_test.go
@@ -425,13 +425,17 @@ func TestLockExisting_SpecialStateid_BadStateid(t *testing.T) {
 
 	_, fileHandle, _, _ := setupClientAndOpenState(t, sm)
 
-	special := &types.Stateid4{} // all-zeros special stateid
-	_, err := sm.LockExisting(context.Background(), special, 1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
-	if !errors.Is(err, ErrBadStateid) {
-		t.Fatalf("LockExisting with a special stateid: got %v, want ErrBadStateid", err)
-	}
-	if errors.Is(err, ErrStaleStateid) {
-		t.Fatal("a special stateid must not reach the epoch classifier (STALE_STATEID)")
+	for name, special := range map[string]*types.Stateid4{
+		"anonymous (all-zeros)":  {},
+		"READ bypass (all-ones)": {Other: [12]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}, Seqid: 0xffffffff},
+	} {
+		_, err := sm.LockExisting(context.Background(), special, 1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
+		if !errors.Is(err, ErrBadStateid) {
+			t.Fatalf("%s: LockExisting with a special stateid: got %v, want ErrBadStateid", name, err)
+		}
+		if errors.Is(err, ErrStaleStateid) {
+			t.Fatalf("%s: a special stateid must not reach the epoch classifier (STALE_STATEID)", name)
+		}
 	}
 }
 

--- a/internal/adapter/nfs/v4/state/lockowner_test.go
+++ b/internal/adapter/nfs/v4/state/lockowner_test.go
@@ -414,6 +414,27 @@ func TestLockExisting_BadStateid(t *testing.T) {
 	}
 }
 
+// A special stateid names no lock state at all: RFC 7530 Section 9.1.4.3
+// admits one only on READ, WRITE and SETATTR, so LOCK must answer
+// NFS4ERR_BAD_STATEID — like every sibling op — and never the STALE that
+// the epoch classifier would draw from a miss.
+func TestLockExisting_SpecialStateid_BadStateid(t *testing.T) {
+	lm := lock.NewManager()
+	sm := NewStateManager(90 * time.Second)
+	sm.SetLockManager(lm)
+
+	_, fileHandle, _, _ := setupClientAndOpenState(t, sm)
+
+	special := &types.Stateid4{} // all-zeros special stateid
+	_, err := sm.LockExisting(context.Background(), special, 1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
+	if !errors.Is(err, ErrBadStateid) {
+		t.Fatalf("LockExisting with a special stateid: got %v, want ErrBadStateid", err)
+	}
+	if errors.Is(err, ErrStaleStateid) {
+		t.Fatal("a special stateid must not reach the epoch classifier (STALE_STATEID)")
+	}
+}
+
 func TestLockExisting_BadSeqid(t *testing.T) {
 	lm := lock.NewManager()
 	sm := NewStateManager(90 * time.Second)

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -2761,6 +2761,11 @@ func (sm *StateManager) LockExisting(
 	fileHandle []byte, lockType uint32, offset, length uint64, reclaim bool,
 	callerClientID uint64,
 ) (result *LockResult, err error) {
+	// Special stateids cannot be used with LOCK
+	if lockStateid.IsSpecialStateid() {
+		return nil, ErrBadStateid
+	}
+
 	// Grace period check
 	if !reclaim {
 		if err := sm.CheckGraceForNewState(); err != nil {


### PR DESCRIPTION
Closes #2490

## Summary

`LockExisting` (the `exist_lock_owner4` LOCK path) lacked the special-stateid
guard every sibling op has, answering NFS4ERR_STALE_STATEID where RFC 7530
§9.1.4.3 requires NFS4ERR_BAD_STATEID: a special stateid fell through to the
table miss, and the boot-epoch classifier drew STALE from the miss because an
all-zeros/all-ones `other` never matches the current epoch.

The fix answers NFS4ERR_BAD_STATEID for both special forms (anonymous and
READ-bypass) at the very top of `LockExisting`, before the grace check —
a GRACE reply would oblige the client to retry with the same invalid stateid.

## Reviewer notes

Adversarial review returned OK WITH NOTES:

- All three kill-risks failed on evidence: `LockExisting`'s only production
  caller resolves or rejects the v4.1 placeholder before the call (no
  special-form stateid reaches it); guard-before-grace is RFC-compliant and no
  conformance test depends on grace-first; the test pins the regression with an
  explicit negative STALE assertion and no `SetGracePeriod`.
- **P2 note (disclosed, deliberate):** the guard runs before the grace check
  here, while sibling `LockNew` runs grace first and its guard second — during
  grace the two paths answer differently for a special stateid (BAD_STATEID vs
  GRACE). Both orders are RFC-compliant (a GRACE client retries and then gets
  BAD_STATEID); aligning `LockNew` would be a separate cleanup.

## Verification

- `go build ./...` OK; vet + gofmt clean
- `go test -race -run TestLockExisting` green on the rebased branch
- Red-without-fix proven by the worker lane (reverting the guard drew
  "got stale stateid, want ErrBadStateid")
