### PR TITLE
common: cover the full ErrorCode enum and drop the dead NFS lock columns

### DIFF
--- a/docs/internals/nfs-protocol.md
+++ b/docs/internals/nfs-protocol.md
@@ -54,7 +54,7 @@ NFS uses **ONC RPC (Open Network Computing Remote Procedure Call)**, defined in 
 **RPC Call Header Fields:**
 
 | Offset | Field |
-|--------|-------|
+| -------- | ------- |
 | 0-3 | XID (Transaction ID, echoed in reply) |
 | 4-7 | Message Type (0 = CALL, 1 = REPLY) |
 | 8-11 | RPC Version (must be 2) |
@@ -67,7 +67,7 @@ NFS uses **ONC RPC (Open Network Computing Remote Procedure Call)**, defined in 
 **RPC Reply Accept States:**
 
 | Code | Name |
-|------|------|
+| ------ | ------ |
 | 0 | SUCCESS |
 | 1 | PROG_UNAVAIL |
 | 2 | PROG_MISMATCH |
@@ -89,7 +89,7 @@ NFS uses **ONC RPC (Open Network Computing Remote Procedure Call)**, defined in 
 **Basic Types:**
 
 | Type | Size | Description |
-|------|------|-------------|
+| ------ | ------ | ------------- |
 | int | 4 bytes | Signed 32-bit integer |
 | unsigned int | 4 bytes | Unsigned 32-bit integer |
 | hyper | 8 bytes | Signed 64-bit integer |
@@ -113,7 +113,7 @@ The **Mount protocol** (Program 100005, Version 3) is a companion protocol to NF
 **Mount Procedures:**
 
 | Proc | Name | Purpose |
-|------|------|---------|
+| ------ | ------ | --------- |
 | 0 | NULL | Connectivity test (no-op) |
 | 1 | MNT | Mount an export, returns root file handle |
 | 2 | DUMP | List active mounts |
@@ -128,7 +128,7 @@ The **Mount protocol** (Program 100005, Version 3) is a companion protocol to NF
 **Mount Status Codes:**
 
 | Code | Name | Description |
-|------|------|-------------|
+| ------ | ------ | ------------- |
 | 0 | MNT_OK | Success |
 | 1 | MNT_EPERM | Permission denied |
 | 2 | MNT_ENOENT | Export path not found |
@@ -147,7 +147,7 @@ The **Mount protocol** (Program 100005, Version 3) is a companion protocol to NF
 NFSv3 defines 22 procedures (0-21):
 
 | Proc | Name | Description |
-|------|------|-------------|
+| ------ | ------ | ------------- |
 | 0 | NULL | No-op, connectivity test |
 | 1 | GETATTR | Get file attributes |
 | 2 | SETATTR | Set file attributes |
@@ -174,7 +174,7 @@ NFSv3 defines 22 procedures (0-21):
 **Write Stability Levels** (for WRITE procedure):
 
 | Level | Name | Description |
-|-------|------|-------------|
+| ------- | ------ | ------------- |
 | 0 | UNSTABLE | Data may be cached; requires COMMIT |
 | 1 | DATA_SYNC | Data committed, metadata may be cached |
 | 2 | FILE_SYNC | Both data and metadata committed |
@@ -205,7 +205,7 @@ When a handle becomes invalid (file deleted, server restarted with ephemeral sto
 NFS uses RPC authentication flavors:
 
 | Flavor | Value | Description |
-|--------|-------|-------------|
+| -------- | ------- | ------------- |
 | AUTH_NULL | 0 | No authentication |
 | AUTH_UNIX | 1 | Unix UID/GID credentials |
 | AUTH_SHORT | 2 | Short-hand credential |
@@ -223,7 +223,7 @@ NFS uses RPC authentication flavors:
 **NFS Status Codes:**
 
 | Code | Name | Description |
-|------|------|-------------|
+| ------ | ------ | ------------- |
 | 0 | NFS3_OK | Success |
 | 1 | NFS3ERR_PERM | Not owner |
 | 2 | NFS3ERR_NOENT | No such file/directory |
@@ -302,7 +302,7 @@ a test case fails `TestErrorMapCoverage` at CI time.
 ### Mount Protocol Status
 
 | Procedure | Status | Notes |
-|-----------|--------|-------|
+| ----------- | -------- | ------- |
 | NULL | Implemented | |
 | MNT | Implemented | |
 | UMNT | Implemented | |
@@ -315,7 +315,7 @@ a test case fails `TestErrorMapCoverage` at CI time.
 **Read Operations:**
 
 | Procedure | Status | Notes |
-|-----------|--------|-------|
+| ----------- | -------- | ------- |
 | NULL | Implemented | |
 | GETATTR | Implemented | |
 | SETATTR | Implemented | |
@@ -332,7 +332,7 @@ a test case fails `TestErrorMapCoverage` at CI time.
 **Write Operations:**
 
 | Procedure | Status | Notes |
-|-----------|--------|-------|
+| ----------- | -------- | ------- |
 | WRITE | Implemented | |
 | CREATE | Implemented | |
 | MKDIR | Implemented | |
@@ -351,7 +351,7 @@ a test case fails `TestErrorMapCoverage` at CI time.
 NFSv4.0 uses compound operations instead of individual RPC procedures. All operations are bundled into COMPOUND requests.
 
 | Operation | Status | Notes |
-|-----------|--------|-------|
+| ----------- | -------- | ------- |
 | ACCESS | Implemented | |
 | CLOSE | Implemented | |
 | COMMIT | Implemented | |
@@ -389,7 +389,7 @@ NFSv4.0 uses compound operations instead of individual RPC procedures. All opera
 NFSv4.1 extends v4.0 with session-based operation, backchannel callbacks, and additional operations.
 
 | Operation | Status | Notes |
-|-----------|--------|-------|
+| ----------- | -------- | ------- |
 | BACKCHANNEL_CTL | Implemented | |
 | BIND_CONN_TO_SESSION | Implemented | |
 | CREATE_SESSION | Implemented | |
@@ -410,7 +410,7 @@ NFSv4.2 extends v4.1 with sparse file operations (RFC 7862: ALLOCATE, DEALLOCATE
 **Sparse file operations (RFC 7862):**
 
 | Operation | Status | Notes |
-|-----------|--------|-------|
+| ----------- | -------- | ------- |
 | ALLOCATE | Implemented | Space pre-allocation via block store |
 | DEALLOCATE | Implemented | Punch holes in content-addressed/dedup-safe way via `pkg/block` |
 | SEEK | Implemented | SEEK_HOLE and SEEK_DATA ([#1303](https://github.com/marmos91/dittofs/issues/1303)) — returns `NFS4_CONTENT_HOLE` for unwritten regions ([#1304](https://github.com/marmos91/dittofs/issues/1304)) |
@@ -421,7 +421,7 @@ CLONE (reflink) **is** supported. Inter-server COPY (OP_COPY) is **not** — it 
 **Extended attribute operations (RFC 8276):**
 
 | Operation | Status | Notes |
-|-----------|--------|-------|
+| ----------- | -------- | ------- |
 | GETXATTR | Implemented | RFC 8276; metadata store holds xattr values |
 | SETXATTR | Implemented | RFC 8276; supports `SET` and `REPLACE` modes |
 | LISTXATTRS | Implemented | RFC 8276; cookie-based pagination |
@@ -649,7 +649,7 @@ A directory delegation grants a client the right to cache the contents of a dire
 Clients request directory delegations via the GET_DIR_DELEGATION operation, specifying a notification bitmask indicating which change types they want to receive:
 
 | Notification Type | Value | Trigger |
-|-------------------|-------|---------|
+| ------------------- | ------- | --------- |
 | NOTIFY4_CHANGE_CHILD_ATTRS | 0x01 | Child file/directory attributes changed |
 | NOTIFY4_CHANGE_DIR_ATTRS | 0x02 | Directory's own attributes changed (mode, owner, size) |
 | NOTIFY4_REMOVE_ENTRY | 0x04 | Entry removed from directory (REMOVE, RMDIR) |
@@ -674,7 +674,7 @@ This batching reduces backchannel traffic when many mutations happen in quick su
 Each directory-mutating NFSv4 operation triggers the appropriate notification:
 
 | Operation | Notification Type | Details |
-|-----------|-------------------|---------|
+| ----------- | ------------------- | --------- |
 | CREATE | NOTIFY4_ADD_ENTRY | Parent directory notified of new entry |
 | REMOVE | NOTIFY4_REMOVE_ENTRY | Parent directory notified; if removed entry is a directory with its own delegation, that delegation is immediately revoked |
 | RENAME (same dir) | NOTIFY4_RENAME_ENTRY | Single notification with old and new names |
@@ -702,7 +702,7 @@ When a directory is deleted (REMOVE/RMDIR), any directory delegations on that di
 Directory delegation settings are managed via `dfsctl adapter settings nfs`:
 
 | Setting | Default | Description |
-|---------|---------|-------------|
+| --------- | --------- | ------------- |
 | `delegations_enabled` | `true` | Enable/disable all delegations (file and directory) |
 | `max_delegations` | `10000` | Maximum concurrent delegations across all clients |
 | `dir_deleg_batch_window_ms` | `50` | Notification batch window in milliseconds |
@@ -723,7 +723,7 @@ dfsctl adapter settings nfs update --dir-deleg-batch-window-ms 100
 Directory delegation metrics are exposed alongside file delegation metrics with a `type` label:
 
 | Metric | Type | Labels | Description |
-|--------|------|--------|-------------|
+| -------- | ------ | -------- | ------------- |
 | `dittofs_nfs_delegations_granted_total` | Counter | `type` (file/directory) | Total delegations granted |
 | `dittofs_nfs_delegations_recalled_total` | Counter | `type`, `reason` | Total delegations recalled |
 | `dittofs_nfs_delegations_active` | Gauge | `type` (file/directory) | Currently active delegations |

--- a/docs/internals/nfs-protocol.md
+++ b/docs/internals/nfs-protocol.md
@@ -275,14 +275,15 @@ that want audit output call `xdr.MapStoreErrorToNFSStatus`.
 ### Lock-context translation
 
 `metadata.ErrLocked`, `ErrDeadlock`, `ErrGracePeriod`, and other
-lock-operation codes have different NFS status codes in lock context
-(NLM_LOCK / NFSv4 LOCK) versus general I/O context (READ/WRITE). The
-dedicated `common.MapLockToNFS3` / `common.MapLockToNFS4` accessors
-consult the parallel `lockErrorMap` table first and fall through to
-`errorMap` for non-lock codes. See `internal/adapter/common/lock_errmap.go`
-for the exact divergences (e.g., `ErrDeadlock` → `NFS4ERR_DEADLOCK` in
-lock context vs. `NFS4ERR_DEADLOCK` also in general context — NFSv4
-converged; SMB diverges).
+lock-operation codes have different status codes in lock context
+(SMB2 LOCK) versus general I/O context (READ/WRITE) on SMB: the
+`lockErrorMap` table in `internal/adapter/common/lock_errmap.go` holds the
+lock-context SMB deltas and falls through to `errorMap` for non-lock codes.
+The NFSv3/NFSv4 lock answers live in `errorMap` directly — its lock-class
+rows already carry the retry-class codes (e.g., `ErrLocked` →
+`NFS4ERR_LOCKED`/`NFS3ErrJukebox`, `ErrDeadlock` → `NFS4ERR_DEADLOCK`). SMB
+diverges (e.g., `ErrLocked` → `STATUS_LOCK_NOT_GRANTED` in lock context vs.
+`STATUS_FILE_LOCK_CONFLICT` in general context).
 
 ### Conformance testing
 

--- a/internal/adapter/common/errmap.go
+++ b/internal/adapter/common/errmap.go
@@ -222,11 +222,13 @@ var errorMap = map[merrs.ErrorCode]protoCodes{
 		SMB:  smbtypes.StatusInternalError,
 	},
 	merrs.ErrLockLimitExceeded: {
-		// NFSv3: no direct code — fallback NFS3ErrIO.
+		// NFSv3: no direct code — fallback NFS3ErrJukebox (transient retry,
+		// matching the lock-context table's retry-class intent for lock
+		// limits).
 		// NFSv4: NFS4ERR_DENIED (standard "lock request denied" code).
 		// SMB: fallback StatusInsufficientResources — closest SMB signal for
 		// "too many locks held".
-		NFS3: nfs3types.NFS3ErrIO,
+		NFS3: nfs3types.NFS3ErrJukebox,
 		NFS4: nfs4types.NFS4ERR_DENIED,
 		SMB:  smbtypes.StatusInsufficientResources,
 	},
@@ -236,6 +238,18 @@ var errorMap = map[merrs.ErrorCode]protoCodes{
 		NFS3: nfs3types.NFS3ErrJukebox,
 		NFS4: nfs4types.NFS4ERR_DENIED,
 		SMB:  smbtypes.StatusFileLockConflict,
+	},
+	merrs.ErrConflict: {
+		// Concurrent-write conflict on ObjectID secondary-index maintenance
+		// (store-transaction level; runtime coordinator wraps it into
+		// engine.ErrObjectIDConflict). Not client-actionable: the client's
+		// state is fine, the store lost a race. NFSv3: no direct code —
+		// fallback NFS3ErrJukebox (retry the request later). NFSv4:
+		// NFS4ERR_DELAY (retryable, no client state change implied). SMB:
+		// StatusInsufficientResources (transient server-side condition).
+		NFS3: nfs3types.NFS3ErrJukebox,
+		NFS4: nfs4types.NFS4ERR_DELAY,
+		SMB:  smbtypes.StatusInsufficientResources,
 	},
 	merrs.ErrConnectionLimitReached: {
 		// No protocol has a "connection limit" code at the file-I/O layer

--- a/internal/adapter/common/errmap_test.go
+++ b/internal/adapter/common/errmap_test.go
@@ -13,49 +13,30 @@ import (
 	merrs "github.com/marmos91/dittofs/pkg/metadata/errors"
 )
 
-// allErrorCodes enumerates every merrs.ErrorCode re-exported from
-// pkg/metadata/errors.go. This is the canonical list TestErrorMapCoverage
-// iterates over: adding a new ErrorCode without updating this list AND
-// adding a row in errorMap will fail the count-length assertion.
-func allErrorCodes() []merrs.ErrorCode {
-	return []merrs.ErrorCode{
-		merrs.ErrNotFound,
-		merrs.ErrAccessDenied,
-		merrs.ErrAuthRequired,
-		merrs.ErrPermissionDenied,
-		merrs.ErrAlreadyExists,
-		merrs.ErrNotEmpty,
-		merrs.ErrIsDirectory,
-		merrs.ErrNotDirectory,
-		merrs.ErrInvalidArgument,
-		merrs.ErrIOError,
-		merrs.ErrNoSpace,
-		merrs.ErrQuotaExceeded,
-		merrs.ErrReadOnly,
-		merrs.ErrNotSupported,
-		merrs.ErrInvalidHandle,
-		merrs.ErrStaleHandle,
-		merrs.ErrLocked,
-		merrs.ErrLockNotFound,
-		merrs.ErrPrivilegeRequired,
-		merrs.ErrNameTooLong,
-		merrs.ErrDeadlock,
-		merrs.ErrGracePeriod,
-		merrs.ErrLockLimitExceeded,
-		merrs.ErrLockConflict,
-		merrs.ErrConnectionLimitReached,
+// walkAllErrorCodes enumerates every merrs.ErrorCode by walking the
+// contiguous iota range in pkg/metadata/errors (ErrNotFound through
+// ErrConflict), the same pattern the errors package's own test uses.
+// Adding a new ErrorCode automatically extends the walk; adding a row in
+// errorMap is then enforced by TestErrorMapCoverage.
+func walkAllErrorCodes() []merrs.ErrorCode {
+	codes := make([]merrs.ErrorCode, 0, 26)
+	for c := merrs.ErrNotFound; c <= merrs.ErrConflict; c++ {
+		codes = append(codes, c)
 	}
+	return codes
 }
 
 // TestErrorMapCoverage asserts every merrs.ErrorCode constant has a row in
-// errorMap. Also asserts the enumeration itself has the expected count so a
-// drift in pkg/metadata/errors.go is caught by a failing test here.
+// errorMap. A literal count guard sits alongside the walk so the enum's
+// shape drifts loudly: if pkg/metadata/errors.go adds or removes a code,
+// both the walk range and this number must be confirmed together.
 func TestErrorMapCoverage(t *testing.T) {
-	const expectedCount = 25
-	if n := len(allErrorCodes()); n != expectedCount {
-		t.Fatalf("allErrorCodes has %d entries; update allErrorCodes() AND errorMap when adding ErrorCodes (expected %d)", n, expectedCount)
+	const expectedCount = 26
+	codes := walkAllErrorCodes()
+	if n := len(codes); n != expectedCount {
+		t.Fatalf("enum walk covers %d codes; update the walk range in walkAllErrorCodes() AND errorMap when the ErrorCode enum changes (expected %d)", n, expectedCount)
 	}
-	for _, code := range allErrorCodes() {
+	for _, code := range codes {
 		if _, ok := errorMap[code]; !ok {
 			t.Errorf("errorMap missing row for %v", code)
 		}
@@ -266,40 +247,6 @@ func TestMapLockToSMB(t *testing.T) {
 	}
 }
 
-// TestMapLockToNFS3 spot-checks a handful of lock-context rows.
-func TestMapLockToNFS3(t *testing.T) {
-	if got := MapLockToNFS3(nil); got != nfs3types.NFS3OK {
-		t.Errorf("MapLockToNFS3(nil) = %d, want NFS3OK", got)
-	}
-	locked := &merrs.StoreError{Code: merrs.ErrLocked}
-	if got := MapLockToNFS3(locked); got != nfs3types.NFS3ErrJukebox {
-		t.Errorf("MapLockToNFS3(ErrLocked) = %d, want NFS3ErrJukebox", got)
-	}
-	lnf := &merrs.StoreError{Code: merrs.ErrLockNotFound}
-	if got := MapLockToNFS3(lnf); got != nfs3types.NFS3ErrInval {
-		t.Errorf("MapLockToNFS3(ErrLockNotFound) = %d, want NFS3ErrInval", got)
-	}
-}
-
-// TestMapLockToNFS4 spot-checks a handful of lock-context rows.
-func TestMapLockToNFS4(t *testing.T) {
-	if got := MapLockToNFS4(nil); got != nfs4types.NFS4_OK {
-		t.Errorf("MapLockToNFS4(nil) = %d, want NFS4_OK", got)
-	}
-	locked := &merrs.StoreError{Code: merrs.ErrLocked}
-	if got := MapLockToNFS4(locked); got != nfs4types.NFS4ERR_DENIED {
-		t.Errorf("MapLockToNFS4(ErrLocked) = %d, want NFS4ERR_DENIED", got)
-	}
-	deadlock := &merrs.StoreError{Code: merrs.ErrDeadlock}
-	if got := MapLockToNFS4(deadlock); got != nfs4types.NFS4ERR_DEADLOCK {
-		t.Errorf("MapLockToNFS4(ErrDeadlock) = %d, want NFS4ERR_DEADLOCK", got)
-	}
-	grace := &merrs.StoreError{Code: merrs.ErrGracePeriod}
-	if got := MapLockToNFS4(grace); got != nfs4types.NFS4ERR_GRACE {
-		t.Errorf("MapLockToNFS4(ErrGracePeriod) = %d, want NFS4ERR_GRACE", got)
-	}
-}
-
 // ============================================================================
 // Unit-tier exotic codes.
 // ============================================================================
@@ -326,6 +273,7 @@ func exoticCodes() []merrs.ErrorCode {
 		merrs.ErrPrivilegeRequired,
 		merrs.ErrQuotaExceeded,
 		merrs.ErrLockConflict,
+		merrs.ErrConflict,
 	}
 }
 
@@ -365,18 +313,12 @@ func TestExoticErrorCodes(t *testing.T) {
 			}
 
 			// For codes that ALSO live in lockErrorMap, assert the
-			// lock-context mappers surface the lockErrorMap values (not
-			// errorMap's general-context values). This catches the
+			// lock-context mapper surfaces the lockErrorMap value (not
+			// errorMap's general-context value). This catches the
 			// lock-vs-general divergence called out for ErrDeadlock,
 			// ErrGracePeriod, ErrLockLimitExceeded, ErrLockConflict,
 			// ErrLockNotFound.
 			if lockRow, lockOK := lockErrorMap[code]; lockOK {
-				if got := MapLockToNFS3(storeErr); got != lockRow.NFS3 {
-					t.Errorf("MapLockToNFS3(%v) = %d, want lockRow.NFS3 = %d", code, got, lockRow.NFS3)
-				}
-				if got := MapLockToNFS4(storeErr); got != lockRow.NFS4 {
-					t.Errorf("MapLockToNFS4(%v) = %d, want lockRow.NFS4 = %d", code, got, lockRow.NFS4)
-				}
 				if got := MapLockToSMB(storeErr); got != lockRow.SMB {
 					t.Errorf("MapLockToSMB(%v) = %v, want lockRow.SMB = %v", code, got, lockRow.SMB)
 				}
@@ -427,7 +369,7 @@ func TestCrossProtocolUnitConformance(t *testing.T) {
 		exoticSet[c] = true
 	}
 
-	for _, code := range allErrorCodes() {
+	for _, code := range walkAllErrorCodes() {
 		inE2E := e2eTriggerableCodes[code]
 		inUnit := exoticSet[code]
 		if !inE2E && !inUnit {

--- a/internal/adapter/common/lock_errmap.go
+++ b/internal/adapter/common/lock_errmap.go
@@ -3,85 +3,63 @@ package common
 import (
 	goerrors "errors"
 
-	nfs3types "github.com/marmos91/dittofs/internal/adapter/nfs/types"
-	nfs4types "github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 	smbtypes "github.com/marmos91/dittofs/internal/adapter/smb/types"
 	merrs "github.com/marmos91/dittofs/pkg/metadata/errors"
 )
 
-// Lock-context mapping.
+// Lock-context mapping for the SMB LOCK path.
 //
-// In a LOCK request (SMB2 LOCK, NLM/NFSv3 NLM_LOCK, NFSv4 LOCK/LOCKU) the
-// same merrs.ErrorCode values map to different protocol codes than in the
-// general I/O path:
+// In a LOCK request the same merrs.ErrorCode values map to different SMB
+// codes than in the general I/O path:
 //
-//   - merrs.ErrLocked in LOCK context  →  STATUS_LOCK_NOT_GRANTED (SMB) /
-//     NFS3ERR_JUKEBOX / NFS4ERR_DENIED.
+//   - merrs.ErrLocked in LOCK context  →  STATUS_LOCK_NOT_GRANTED.
 //   - merrs.ErrLocked in general (READ/WRITE) context  →
-//     STATUS_FILE_LOCK_CONFLICT (SMB) — see errorMap in errmap.go.
+//     STATUS_FILE_LOCK_CONFLICT — see errorMap in errmap.go.
 //
-// Sources:
-//   - SMB column: internal/adapter/smb/handlers/lock.go
-//     (lockErrorToStatus — authoritative).
-//   - NFS3 column: internal/adapter/nfs/xdr/errors.go:140-146 (ErrLocked
-//     only; other lock-context codes did not have NFSv3 entries and fall
-//     back to the closest retry-class code).
-//   - NFS4 column: internal/adapter/nfs/v4/types/errors.go:59-64 for
-//     ErrLocked/Deadlock/Grace, extended here with ErrLockNotFound →
-//     NFS4ERR_LOCK_RANGE and ErrLockConflict → NFS4ERR_DENIED per RFC 7530.
+// The NFSv3/NFSv4 lock answers live in errorMap (errmap.go); its lock-class
+// rows already carry the retry-class codes the lock path needs
+// (ErrLocked → NFS4ERR_LOCKED/NFS3ErrJukebox, ErrDeadlock →
+// NFS4ERR_DEADLOCK, ErrLockNotFound → NFS4ERR_LOCK_RANGE). This table holds
+// only the deltas where the SMB lock answer diverges from the SMB general
+// answer.
+//
+// Source: internal/adapter/smb/handlers/lock.go (lockErrorToStatus —
+// authoritative).
 var lockErrorMap = map[merrs.ErrorCode]protoCodes{
 	merrs.ErrLocked: {
-		NFS3: nfs3types.NFS3ErrJukebox,
-		NFS4: nfs4types.NFS4ERR_DENIED,
-		SMB:  smbtypes.StatusLockNotGranted,
+		SMB: smbtypes.StatusLockNotGranted,
 	},
 	merrs.ErrLockNotFound: {
-		NFS3: nfs3types.NFS3ErrInval,
-		NFS4: nfs4types.NFS4ERR_LOCK_RANGE,
-		SMB:  smbtypes.StatusRangeNotLocked,
+		SMB: smbtypes.StatusRangeNotLocked,
 	},
 	merrs.ErrLockConflict: {
-		NFS3: nfs3types.NFS3ErrJukebox,
-		NFS4: nfs4types.NFS4ERR_DENIED,
-		SMB:  smbtypes.StatusLockNotGranted,
+		SMB: smbtypes.StatusLockNotGranted,
 	},
 	merrs.ErrDeadlock: {
-		// SMB: no direct code — StatusLockNotGranted (closest retry
+		// No direct SMB code — StatusLockNotGranted (closest retry
 		// semantic in LOCK context).
-		NFS3: nfs3types.NFS3ErrJukebox,
-		NFS4: nfs4types.NFS4ERR_DEADLOCK,
-		SMB:  smbtypes.StatusLockNotGranted,
+		SMB: smbtypes.StatusLockNotGranted,
 	},
 	merrs.ErrGracePeriod: {
-		// NFSv3 has no dedicated grace-period code — use JUKEBOX (retry
-		// later, matches the NFSv4 semantic).
-		NFS3: nfs3types.NFS3ErrJukebox,
-		NFS4: nfs4types.NFS4ERR_GRACE,
-		SMB:  smbtypes.StatusInternalError,
+		// SMB has no NFSv4-style grace-period concept; clients see a
+		// server-side fault.
+		SMB: smbtypes.StatusInternalError,
 	},
 	merrs.ErrLockLimitExceeded: {
-		NFS3: nfs3types.NFS3ErrJukebox,
-		NFS4: nfs4types.NFS4ERR_DENIED,
-		SMB:  smbtypes.StatusInsufficientResources,
+		SMB: smbtypes.StatusInsufficientResources,
 	},
 	// Lock-context overrides for general errors that SMB's lockErrorToStatus
 	// historically handled (lock.go:540-545). These differ from errorMap in
-	// the SMB column only — NFS3/NFS4 match errorMap, so callers that fall
-	// through to general context get consistent behavior.
+	// the SMB column only, so callers that fall through to general context
+	// get consistent behavior.
 	merrs.ErrNotFound: {
-		NFS3: nfs3types.NFS3ErrNoEnt,
-		NFS4: nfs4types.NFS4ERR_NOENT,
-		SMB:  smbtypes.StatusFileClosed,
+		SMB: smbtypes.StatusFileClosed,
 	},
 	merrs.ErrPermissionDenied: {
-		NFS3: nfs3types.NFS3ErrPerm,
-		NFS4: nfs4types.NFS4ERR_PERM,
-		SMB:  smbtypes.StatusAccessDenied,
+		SMB: smbtypes.StatusAccessDenied,
 	},
 	merrs.ErrIsDirectory: {
-		NFS3: nfs3types.NFS3ErrIsDir,
-		NFS4: nfs4types.NFS4ERR_ISDIR,
-		SMB:  smbtypes.StatusFileIsADirectory,
+		SMB: smbtypes.StatusFileIsADirectory,
 	},
 }
 
@@ -93,30 +71,18 @@ func lookupLockErrorRow(err error) protoCodes {
 	if !goerrors.As(err, &storeErr) {
 		return defaultCodes
 	}
-	if codes, ok := lockErrorMap[storeErr.Code]; ok {
+	if lock, ok := lockErrorMap[storeErr.Code]; ok {
+		// Start from the general row and overlay the lock-context SMB
+		// delta, so the NFS columns stay populated for any future
+		// lock-context caller.
+		codes := errorMap[storeErr.Code]
+		codes.SMB = lock.SMB
 		return codes
 	}
 	if codes, ok := errorMap[storeErr.Code]; ok {
 		return codes
 	}
 	return defaultCodes
-}
-
-// MapLockToNFS3 translates a lock-operation error to an NFS3 status code.
-// Fallback chain: lockErrorMap → errorMap (general) → defaultCodes.
-func MapLockToNFS3(err error) uint32 {
-	if err == nil {
-		return nfs3types.NFS3OK
-	}
-	return lookupLockErrorRow(err).NFS3
-}
-
-// MapLockToNFS4 translates a lock-operation error to an NFS4 status code.
-func MapLockToNFS4(err error) uint32 {
-	if err == nil {
-		return nfs4types.NFS4_OK
-	}
-	return lookupLockErrorRow(err).NFS4
 }
 
 // MapLockToSMB translates a lock-operation error to an SMB status code.

--- a/internal/adapter/common/lock_errmap.go
+++ b/internal/adapter/common/lock_errmap.go
@@ -4,6 +4,7 @@ import (
 	goerrors "errors"
 
 	smbtypes "github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/block/engine"
 	merrs "github.com/marmos91/dittofs/pkg/metadata/errors"
 )
 
@@ -67,6 +68,12 @@ var lockErrorMap = map[merrs.ErrorCode]protoCodes{
 // lockErrorMap → errorMap (general) → defaultCodes. Callers handle the nil
 // case separately so each protocol can return its own SUCCESS constant.
 func lookupLockErrorRow(err error) protoCodes {
+	// A store removed mid-lock-operation is not a *merrs.StoreError; map it
+	// to the same stale-handle row the general and content mappers use so
+	// the client observes the share going away rather than a server fault.
+	if goerrors.Is(err, engine.ErrStoreClosed) {
+		return errorMap[merrs.ErrStaleHandle]
+	}
 	var storeErr *merrs.StoreError
 	if !goerrors.As(err, &storeErr) {
 		return defaultCodes

--- a/internal/adapter/common/lock_errmap_test.go
+++ b/internal/adapter/common/lock_errmap_test.go
@@ -1,0 +1,49 @@
+package common
+
+import (
+	"fmt"
+	"testing"
+
+	smbtypes "github.com/marmos91/dittofs/internal/adapter/smb/types"
+	merrs "github.com/marmos91/dittofs/pkg/metadata/errors"
+)
+
+// TestMapLockToSMB_NilAndFallback pins the fallback chain of the surviving
+// lock-context mapper: nil → StatusSuccess, non-StoreError →
+// defaultCodes.SMB, wrapped StoreError unwraps via goerrors.As.
+func TestMapLockToSMB_NilAndFallback(t *testing.T) {
+	if got := MapLockToSMB(nil); got != smbtypes.StatusSuccess {
+		t.Errorf("MapLockToSMB(nil) = %v, want StatusSuccess", got)
+	}
+	if got := MapLockToSMB(fmt.Errorf("random")); got != defaultCodes.SMB {
+		t.Errorf("MapLockToSMB(non-StoreError) = %v, want defaultCodes.SMB = %v", got, defaultCodes.SMB)
+	}
+	wrapped := fmt.Errorf("wrap: %w", &merrs.StoreError{Code: merrs.ErrLocked})
+	if got := MapLockToSMB(wrapped); got != smbtypes.StatusLockNotGranted {
+		t.Errorf("MapLockToSMB(wrapped ErrLocked) = %v, want StatusLockNotGranted", got)
+	}
+}
+
+// TestMapLockToSMB_Table drives every lockErrorMap row through the mapper so
+// a row added without a pin (or with a typo'd SMB code) fails here. The
+// per-row lock-vs-general comparison documents the intended divergence: the
+// lock table holds only SMB deltas over errorMap, so codes whose lock answer
+// differs from the general answer must keep diverging.
+func TestMapLockToSMB_Table(t *testing.T) {
+	for code, lockRow := range lockErrorMap {
+		code := code
+		t.Run(code.String(), func(t *testing.T) {
+			storeErr := &merrs.StoreError{Code: code, Message: code.String()}
+			if got := MapLockToSMB(storeErr); got != lockRow.SMB {
+				t.Errorf("MapLockToSMB(%v) = %v, want lockErrorMap.SMB = %v", code, got, lockRow.SMB)
+			}
+			general, ok := errorMap[code]
+			if !ok {
+				t.Fatalf("lockErrorMap lists %v but errorMap has no general row", code)
+			}
+			if general.SMB != lockRow.SMB {
+				t.Logf("%v diverges lock-vs-general: general %v -> lock %v", code, general.SMB, lockRow.SMB)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes nothing — audit-finding guard PR that unguards the wave's other errmap fixes.

## What

- `TestErrorMapCoverage` now walks the contiguous `ErrorCode` enum (`ErrNotFound`→`ErrConflict`, `pkg/metadata/errors/errors.go`) with a literal `expectedCount = 26` sanity guard — a new code without an error-map row now fails the suite loudly instead of silently passing.
- `merrs.ErrConflict` gained its missing `errorMap` row (NFS3 `NFS3ErrJukebox` / NFS4 `NFS4ERR_DELAY` / SMB `StatusInsufficientResources` — retry-class, not client-actionable) and an `exoticCodes()` pin so `TestCrossProtocolUnitConformance` stays green.
- Dead `MapLockToNFS3`/`MapLockToNFS4` and the NFS3/NFS4 lock columns deleted; `MapLockToSMB` is the only surviving lock-context surface (live callers in `smb/handlers/lock.go`, `lock_async.go`), now pinned by new `lock_errmap_test.go`.
- `lookupLockErrorRow` overlays the SMB delta over the general row and now maps a store closed mid-lock-operation to the stale-handle row, aligning with the general/content mappers.
- `ErrLockLimitExceeded` NFS3 answer resolved to `NFS3ErrJukebox` — producers are lock-path-only (`pkg/metadata/lock/config.go:106`); no production consumer pinned IO.
- `docs/internals/nfs-protocol.md` lock-context section updated to match the SMB-only table exactly.

## Observing-caller reality

The runtime coordinator wraps ObjectID conflicts into `engine.ErrObjectIDConflict` via `errors.Join` (`internal/controlplane/runtime/shares/coordinator.go` ~290-303), so a raw `StoreError{ErrConflict}` reaches direct store-layer callers; producers are `NewConflictError` in the badger/memory transaction commit paths.

## Verification

- Red-without-fix proven: deleting the ErrConflict row fails the new coverage test; restored.
- `go build ./...` ok; `go vet ./...` clean; gofmt clean; `go test -race -count=1 ./internal/adapter/common/` ok (3.7s); full sweep ok.
- Phantom-symbol grep empty (`MapLockToNFS3|MapLockToNFS4` zero hits in internal/pkg/cmd/test).

## Limitations

- `ErrConflict`→`NFS4ERR_DELAY` maps a permanent ObjectID collision to a retryable code; reviewed and accepted as retry-class conformance (the SMB arm uses the non-retryable `StatusInsufficientResources`).
