### PR TITLE
nfs v4: route content-path failures through the shared content mapper

### DIFF
--- a/internal/adapter/nfs/v4/handlers/commit.go
+++ b/internal/adapter/nfs/v4/handlers/commit.go
@@ -108,7 +108,7 @@ func (h *Handler) handleCommit(ctx *types.CompoundContext, reader io.Reader) *ty
 			"error", flushErr,
 			"payloadID", file.PayloadID,
 			"client", ctx.ClientAddr)
-		return commitErr(types.NFS4ERR_IO)
+		return commitErr(common.MapContentToNFS4(flushErr))
 	}
 
 	// Flush pending metadata writes (deferred commit optimization)

--- a/internal/adapter/nfs/v4/handlers/content_errmap_wiring_test.go
+++ b/internal/adapter/nfs/v4/handlers/content_errmap_wiring_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/marmos91/dittofs/internal/adapter/common"
 	nfs4types "github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
-	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
 	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/engine"
 )
@@ -188,5 +187,3 @@ func TestRead_CanceledContext_FallsBackToIO(t *testing.T) {
 			got, nfs4types.NFS4ERR_IO)
 	}
 }
-
-var _ = xdr.DecodeUint32 // keep the xdr import if assertions move to encoded status

--- a/internal/adapter/nfs/v4/handlers/content_errmap_wiring_test.go
+++ b/internal/adapter/nfs/v4/handlers/content_errmap_wiring_test.go
@@ -1,0 +1,192 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/common"
+	nfs4types "github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/engine"
+)
+
+// The block store was closed under an in-flight op (share removed/hot-reloaded
+// mid-transfer): the reply must draw NFS4ERR_STALE via the shared content
+// mapper, not the literal NFS4ERR_IO the handlers used to return. Each test
+// closes the per-share store after setup, then drives the handler and asserts
+// the wire status.
+
+// mapperBoundary pins the seam this wiring depends on: the content mapper
+// keeps the established classification (unknown/ErrRemoteUnavailable → IO)
+// while lifting ErrStoreClosed to STALE. MapToNFS4 would not — its
+// lookupErrorRow defaults a non-StoreError to NFS4ERR_SERVERFAULT — which is
+// why the handlers route through MapContentToNFS4.
+func TestContentMapperBoundary_RemoteUnavailableStaysIO(t *testing.T) {
+	if got := common.MapContentToNFS4(block.ErrRemoteUnavailable); got != nfs4types.NFS4ERR_IO {
+		t.Errorf("MapContentToNFS4(ErrRemoteUnavailable) = %d, want NFS4ERR_IO (%d)",
+			got, nfs4types.NFS4ERR_IO)
+	}
+	if got := common.MapContentToNFS4(engine.ErrStoreClosed); got != nfs4types.NFS4ERR_STALE {
+		t.Errorf("MapContentToNFS4(ErrStoreClosed) = %d, want NFS4ERR_STALE (%d)",
+			got, nfs4types.NFS4ERR_STALE)
+	}
+}
+
+func TestRead_ClosedStore_ReturnsStale(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+
+	fileHandle := fx.createRegularFile(t, fx.rootHandle, "closed-read.txt", 0o644, 0, 0)
+	fx.writeContent(t, fileHandle, []byte("readable before the store closes"))
+
+	if err := fx.blockStore.Close(); err != nil {
+		t.Fatalf("close block store: %v", err)
+	}
+
+	ctx := newRealFSContext(0, 0)
+	ctx.CurrentFH = make([]byte, len(fileHandle))
+	copy(ctx.CurrentFH, fileHandle)
+
+	args := encodeReadArgs(&anonymousStateid, 0, 1024)
+	result := fx.handler.handleRead(ctx, bytes.NewReader(args))
+
+	if result.Status != nfs4types.NFS4ERR_STALE {
+		t.Fatalf("READ on closed store status = %d, want NFS4ERR_STALE (%d)",
+			result.Status, nfs4types.NFS4ERR_STALE)
+	}
+}
+
+func TestWrite_ClosedStore_ReturnsStale(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+
+	fileHandle := fx.createRegularFile(t, fx.rootHandle, "closed-write.txt", 0o644, 0, 0)
+
+	if err := fx.blockStore.Close(); err != nil {
+		t.Fatalf("close block store: %v", err)
+	}
+
+	ctx := newRealFSContext(0, 0)
+	ctx.CurrentFH = make([]byte, len(fileHandle))
+	copy(ctx.CurrentFH, fileHandle)
+
+	args := encodeWriteArgs(&anonymousStateid, 0, nfs4types.UNSTABLE4, []byte("arrives after close"))
+	result := fx.handler.handleWrite(ctx, bytes.NewReader(args))
+
+	if result.Status != nfs4types.NFS4ERR_STALE {
+		t.Fatalf("WRITE on closed store status = %d, want NFS4ERR_STALE (%d)",
+			result.Status, nfs4types.NFS4ERR_STALE)
+	}
+}
+
+func TestCommit_ClosedStore_ReturnsStale(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+
+	fileHandle := fx.createRegularFile(t, fx.rootHandle, "closed-commit.txt", 0o644, 0, 0)
+	fx.writeContent(t, fileHandle, []byte("dirty data awaiting the flush"))
+
+	if err := fx.blockStore.Close(); err != nil {
+		t.Fatalf("close block store: %v", err)
+	}
+
+	ctx := newRealFSContext(0, 0)
+	ctx.CurrentFH = make([]byte, len(fileHandle))
+	copy(ctx.CurrentFH, fileHandle)
+
+	args := encodeCommitArgs(0, 0)
+	result := fx.handler.handleCommit(ctx, bytes.NewReader(args))
+
+	if result.Status != nfs4types.NFS4ERR_STALE {
+		t.Fatalf("COMMIT on closed store status = %d, want NFS4ERR_STALE (%d)",
+			result.Status, nfs4types.NFS4ERR_STALE)
+	}
+}
+
+func TestReadPlus_ClosedStore_ReturnsStale(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+
+	fileHandle := fx.createRegularFile(t, fx.rootHandle, "closed-rp.txt", 0o644, 0, 0)
+	// Write through the handler so CommitWrite populates the metadata block
+	// list: the segmentation then yields a data segment whose read hits the
+	// closed store (a fixture-level write would leave file.Blocks empty and
+	// the window would succeed as all-hole).
+	wctx := newRealFSContext(0, 0)
+	wctx.CurrentFH = make([]byte, len(fileHandle))
+	copy(wctx.CurrentFH, fileHandle)
+	wres := fx.handler.handleWrite(wctx, bytes.NewReader(encodeWriteArgs(&anonymousStateid, 0, nfs4types.UNSTABLE4, bytes.Repeat([]byte("x"), 4096))))
+	if wres.Status != nfs4types.NFS4_OK {
+		t.Fatalf("WRITE for READ_PLUS setup: status = %d", wres.Status)
+	}
+	// Give the file a non-empty CAS block list (one row covering the payload):
+	// after a WRITE the bytes live only in the journal tier and the metadata
+	// projection is empty, so the segmentation would fall back to nothing and
+	// the window would succeed as all-hole without ever touching the store.
+	file, err := fx.metaSvc.GetFile(wctx.Context, fileHandle)
+	if err != nil {
+		t.Fatalf("get file for READ_PLUS setup: %v", err)
+	}
+	row := &block.FileChunk{
+		ID:        string(file.PayloadID) + "/0",
+		State:     block.BlockStateRemote,
+		DataSize:  4096,
+		RefCount:  1,
+		CreatedAt: time.Now(),
+	}
+	if err := fx.store.Put(context.Background(), row); err != nil {
+		t.Fatalf("put chunk row: %v", err)
+	}
+	file.Blocks = []block.ChunkRef{{Hash: row.Hash, Offset: 0, Size: 4096}}
+	if err := fx.store.SetManifest(context.Background(), file); err != nil {
+		t.Fatalf("set manifest: %v", err)
+	}
+
+	if err := fx.blockStore.Close(); err != nil {
+		t.Fatalf("close block store: %v", err)
+	}
+
+	ctx := newRealFSContext(0, 0)
+	ctx.CurrentFH = make([]byte, len(fileHandle))
+	copy(ctx.CurrentFH, fileHandle)
+
+	args := encodeReadArgs(&anonymousStateid, 0, 1024)
+	result := fx.handler.handleReadPlus(ctx, bytes.NewReader(args))
+
+	if result.Status != nfs4types.NFS4ERR_STALE {
+		t.Fatalf("READ_PLUS on closed store status = %d, want NFS4ERR_STALE (%d)",
+			result.Status, nfs4types.NFS4ERR_STALE)
+	}
+}
+
+func TestDeallocate_ClosedStore_ReturnsStale(t *testing.T) {
+	fx := newIOTestFixture(t, "/export")
+
+	fileHandle := fx.createRegularFile(t, fx.rootHandle, "closed-dealloc.txt", 0o644, 0, 0)
+	fx.writeContent(t, fileHandle, bytes.Repeat([]byte("punch me"), 512))
+
+	if err := fx.blockStore.Close(); err != nil {
+		t.Fatalf("close block store: %v", err)
+	}
+
+	ctx := newRealFSContext(0, 0)
+	ctx.CurrentFH = make([]byte, len(fileHandle))
+	copy(ctx.CurrentFH, fileHandle)
+
+	res := fx.handler.handleDeallocate(ctx, encAllocArgs(&anonymousStateid, 0, 1024))
+	if res.Status != nfs4types.NFS4ERR_STALE {
+		t.Fatalf("DEALLOCATE on closed store status = %d, want NFS4ERR_STALE (%d)",
+			res.Status, nfs4types.NFS4ERR_STALE)
+	}
+}
+
+// contextTests keep the raw context cancellation pass-through covered: a
+// canceled read still surfaces IO (the fallback), never STALE, because
+// cancellation is not a dead-handle signal.
+func TestRead_CanceledContext_FallsBackToIO(t *testing.T) {
+	if got := common.MapContentToNFS4(context.Canceled); got != nfs4types.NFS4ERR_IO {
+		t.Errorf("MapContentToNFS4(context.Canceled) = %d, want NFS4ERR_IO (%d)",
+			got, nfs4types.NFS4ERR_IO)
+	}
+}
+
+var _ = xdr.DecodeUint32 // keep the xdr import if assertions move to encoded status

--- a/internal/adapter/nfs/v4/handlers/deallocate.go
+++ b/internal/adapter/nfs/v4/handlers/deallocate.go
@@ -91,7 +91,7 @@ func (h *Handler) handleDeallocate(ctx *types.CompoundContext, reader io.Reader)
 		if _, pErr := blockStore.PunchHole(ctx.Context, string(res.PayloadID), res.PreOpBlocks, offset, punchLen(offset, length, res.File.Size)); pErr != nil {
 			logger.Error("NFSv4.2 DEALLOCATE: block store punch failed",
 				"handle", string(handle), "error", pErr)
-			return deallocErr(types.NFS4ERR_IO)
+			return deallocErr(common.MapContentToNFS4(pErr))
 		}
 	}
 

--- a/internal/adapter/nfs/v4/handlers/read.go
+++ b/internal/adapter/nfs/v4/handlers/read.go
@@ -140,7 +140,7 @@ func (h *Handler) handleRead(ctx *types.CompoundContext, reader io.Reader) *type
 	readResult, err := common.ReadFromBlockStore(ctx.Context, blockStore, file.PayloadID, offset, uint32(actualLen))
 	if err != nil {
 		logger.Debug("NFSv4 READ payload error", "error", err, "client", ctx.ClientAddr)
-		return readErr(types.NFS4ERR_IO)
+		return readErr(common.MapContentToNFS4(err))
 	}
 	// Release the pooled buffer after the compound result has been encoded.
 	// encodeRead4resok copies readResult.Data into a fresh bytes.Buffer before

--- a/internal/adapter/nfs/v4/handlers/read_plus.go
+++ b/internal/adapter/nfs/v4/handlers/read_plus.go
@@ -118,11 +118,12 @@ func (h *Handler) handleReadPlus(ctx *types.CompoundContext, reader io.Reader) *
 		logger.Debug("NFSv4.2 READ_PLUS content build failed", "error", err, "client", ctx.ClientAddr)
 		// A missing registry is a server misconfiguration, not an I/O fault —
 		// mirror READ's nil-Registry guard (NFS4ERR_SERVERFAULT). All other
-		// failures are block-store read errors → NFS4ERR_IO.
+		// failures are block-store read errors, mapped via the shared content
+		// mapper (ErrStoreClosed → STALE, the rest keep their I/O class).
 		if errors.Is(err, errNoRegistry) {
 			return readPlusErr(types.NFS4ERR_SERVERFAULT)
 		}
-		return readPlusErr(types.NFS4ERR_IO)
+		return readPlusErr(common.MapContentToNFS4(err))
 	}
 	eof := readEnd >= file.Size
 

--- a/internal/adapter/nfs/v4/handlers/write.go
+++ b/internal/adapter/nfs/v4/handlers/write.go
@@ -212,7 +212,7 @@ func (h *Handler) handleWrite(ctx *types.CompoundContext, reader io.Reader) *typ
 			"error", err,
 			"payloadID", intent.PayloadID,
 			"client", ctx.ClientAddr)
-		return writeErr(types.NFS4ERR_IO)
+		return writeErr(common.MapContentToNFS4(err))
 	}
 
 	_, err = metaSvc.CommitWrite(authCtx, intent)


### PR DESCRIPTION
Closes nothing. `#2467` checked and confirmed unrelated (auth-policy reload, not error wiring); referenced as related only.

## What

All five bypassing NFSv4 content-path sites now route block-store failures through the shared `common.MapContentToNFS4` mapper, so a store closed under an in-flight op draws `NFS4ERR_STALE` end to end while the established content classifications stay intact:

- `internal/adapter/nfs/v4/handlers/read.go` (one line)
- `internal/adapter/nfs/v4/handlers/read_plus.go` (wiring after the preserved `errNoRegistry` → `NFS4ERR_SERVERFAULT` carve-out)
- `internal/adapter/nfs/v4/handlers/write.go`
- `internal/adapter/nfs/v4/handlers/commit.go`
- `internal/adapter/nfs/v4/handlers/deallocate.go`
- NEW `internal/adapter/nfs/v4/handlers/content_errmap_wiring_test.go`: 5 closed-store handler tests + mapper-boundary regression guard

## Mapper-boundary choice (disclosed)

Routed through `MapContentToNFS4`, **not** `MapToNFS4`: `ReadFromBlockStore`/`WriteToBlockStore` wrap engine errors as `fmt.Errorf("ReadAt error: %w", …)` (`internal/adapter/common/read_payload.go`), which defeats `MapToNFS4`'s `*merrs.StoreError` lookup and would regress `ErrRemoteUnavailable`'s deliberate `NFS4ERR_IO` to `SERVERFAULT`. `MapContentToNFS4` classifies via `errors.Is`, which unwraps the production wrap; the adversarial panel verified the test drives real handlers against a real closed engine, not a synthetic injection. NFSv4 error replies carry no WCC attrs (v3-only), so no attr set can change — only the status value does.

## Test-shape discovery (disclosed)

READ_PLUS needed a real CAS block list (manifest row via `store.Put` + `SetManifest`) because journal-only bytes succeed as all-hole without touching the store — documented in the test.

## Verification

- Red-without-fix proven: all five handlers drew literal IO before the wiring.
- `go test -race -count=1` targeted: ok (7/7 green after wiring); `go build ./...` ok; `go vet ./...` clean; gofmt clean; full `go test -count=1 ./...` sweep all ok.
