### PR TITLE
smb: name the session-user UID/GID derivation for what it derives from

### DIFF
--- a/internal/adapter/smb/handlers/auth_helper.go
+++ b/internal/adapter/smb/handlers/auth_helper.go
@@ -95,11 +95,10 @@ func BuildAuthContext(ctx *SMBHandlerContext) (*metadata.AuthContext, error) {
 	return authCtx, nil
 }
 
-// getUserIdentity returns the UID/GID for a user.
-// UID comes from user.UID field.
-// GID comes from the user's group membership (lowest GID for root-level access).
-// Falls back to defaults if not configured.
-func getUserIdentity(user *models.User) (uid, gid uint32) {
+// uidGIDFromSessionUser returns the UID/GID a *models.User-derived identity
+// carries. UID comes from user.UID; GID comes from the user's group membership
+// (first group with a GID). Falls back to defaults if not configured.
+func uidGIDFromSessionUser(user *models.User) (uid, gid uint32) {
 	uid = defaultUID
 	gid = defaultGID
 
@@ -185,7 +184,7 @@ func BuildAuthContextFromUser(ctx *SMBHandlerContext, user *models.User) *metada
 // is treated as immutable — consumers only read it, so it is safe to share via the
 // per-session cache.
 func buildIdentity(ctx *SMBHandlerContext, user *models.User) *metadata.Identity {
-	uid, gid := getUserIdentity(user)
+	uid, gid := uidGIDFromSessionUser(user)
 	identity := &metadata.Identity{
 		UID:      &uid,
 		GID:      &gid,

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -2035,7 +2035,7 @@ func (h *Handler) buildCleanupAuthContext(ctx context.Context, sess *session.Ses
 
 	if sess != nil && sess.User != nil {
 		// Use session user's UID/GID from User object
-		uid, gid := getUserIdentity(sess.User)
+		uid, gid := uidGIDFromSessionUser(sess.User)
 		authCtx.Identity.UID = &uid
 		authCtx.Identity.GID = &gid
 		authCtx.Identity.Username = sess.User.Username

--- a/internal/adapter/smb/handlers/kerberos_auth.go
+++ b/internal/adapter/smb/handlers/kerberos_auth.go
@@ -546,7 +546,7 @@ func (h *Handler) resolveKerberosIdentity(ctx *SMBHandlerContext, principal, rea
 
 // synthUserFromResolved builds a transient, non-persisted *models.User from a
 // directory-resolved identity so an AD/LDAP user with no local control-plane
-// account can still establish an SMB session. getUserIdentity derives the
+// account can still establish an SMB session. uidGIDFromSessionUser derives the
 // primary GID from the first group, so the resolved primary GID is listed
 // first; the full resolved supplementary set follows so the SMB auth context
 // carries nested AD group GIDs for POSIX-mode group checks, mirroring the NFS

--- a/internal/adapter/smb/handlers/kerberos_identity_test.go
+++ b/internal/adapter/smb/handlers/kerberos_identity_test.go
@@ -38,10 +38,10 @@ func TestResolveSessionUser_DirectoryResolvedWhenNoLocalAccount(t *testing.T) {
 	if got.Username != "alice" || got.UID == nil || *got.UID != 10001 {
 		t.Fatalf("synthesized user wrong: %+v", got)
 	}
-	// getUserIdentity must derive the resolved UID + primary GID.
-	uid, gid := getUserIdentity(got)
+	// uidGIDFromSessionUser must derive the resolved UID + primary GID.
+	uid, gid := uidGIDFromSessionUser(got)
 	if uid != 10001 || gid != 10000 {
-		t.Fatalf("getUserIdentity = %d/%d, want 10001/10000", uid, gid)
+		t.Fatalf("uidGIDFromSessionUser = %d/%d, want 10001/10000", uid, gid)
 	}
 	if got.SID != "S-1-5-21-1-2-3-1104" || len(got.GroupSIDs) != 1 {
 		t.Fatalf("SID/GroupSIDs not carried: %+v", got)
@@ -49,7 +49,7 @@ func TestResolveSessionUser_DirectoryResolvedWhenNoLocalAccount(t *testing.T) {
 }
 
 // TestSynthUserFromResolved_CarriesSupplementaryGIDs verifies the synthesized
-// user lists the primary GID first (so getUserIdentity picks it) and also
+// user lists the primary GID first (so uidGIDFromSessionUser picks it) and also
 // carries the full resolved supplementary set, deduplicating the primary
 // (#1327).
 func TestSynthUserFromResolved_CarriesSupplementaryGIDs(t *testing.T) {
@@ -61,10 +61,10 @@ func TestSynthUserFromResolved_CarriesSupplementaryGIDs(t *testing.T) {
 
 	got := synthUserFromResolved(resolved)
 
-	// Primary GID must be first for getUserIdentity.
-	uid, gid := getUserIdentity(got)
+	// Primary GID must be first for uidGIDFromSessionUser.
+	uid, gid := uidGIDFromSessionUser(got)
 	if uid != 10001 || gid != 10000 {
-		t.Fatalf("getUserIdentity = %d/%d, want 10001/10000", uid, gid)
+		t.Fatalf("uidGIDFromSessionUser = %d/%d, want 10001/10000", uid, gid)
 	}
 	// All distinct GIDs present exactly once (primary not duplicated).
 	gotGIDs := map[uint32]int{}


### PR DESCRIPTION
Closes nothing — this lane maps to no open issue (audit finding: `getUserIdentity` was already superseded by the directory-resolved round-trip).

## What

`getUserIdentity` → `uidGIDFromSessionUser` — a pure rename stating what the helper derives from (the session's `models.User`), with zero behavior change:

- `internal/adapter/smb/handlers/auth_helper.go` — renamed; doc comment states the derivation source; `buildIdentity` call site converted
- `internal/adapter/smb/handlers/handler.go` — `buildCleanupAuthContext` call site converted
- `internal/adapter/smb/handlers/kerberos_auth.go` — one stale doc-comment reference updated
- `internal/adapter/smb/handlers/kerberos_identity_test.go` — all call sites (incl. the ~65 site) and failure messages updated; pinned semantics unchanged

## Decisions (disclosed)

- **AUTH_SYS/AUTH_UNIX exemption**: wire credentials are untouched — the client dictates UID/GID per RFC 5531.
- **Retained helper on the cleanup path**: `ResolvedIdentity` is not plumbed to `buildCleanupAuthContext`, so that path keeps deriving from `models.User` via the renamed helper.
- **Deferred follow-up**: consuming `ResolvedIdentity` directly at `buildIdentity` needs plumbing through `session/session.go` + `handlers/context.go` + `kerberos_auth.go` + `session_setup.go` — deferred to a follow-up PR.
- The `synthUserFromResolved` → helper round-trip is verified faithful (resolved UID preserved; primary GID first), so this is a naming/ownership cleanup, not a behavior fix.

## Verification

- `go build ./...` OK; `go vet` clean; gofmt clean on all four files.
- `go test -race -count=1 ./internal/adapter/smb/handlers/` ok (18.2s); full `go test -count=1 ./...` sweep all ok.
- Repo-wide grep: zero remaining `getUserIdentity` references in Go code; exactly one `func uidGIDFromSessionUser` declaration.
