### PR TITLE
adapter: release the listener-ready channel on shutdown and bound the accept retry loop

### DIFF
--- a/pkg/adapter/base.go
+++ b/pkg/adapter/base.go
@@ -15,6 +15,16 @@ import (
 	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
 )
 
+// Accept-error backoff bounds. An unexpected Accept error (for example the
+// process hitting its file-descriptor limit) previously spun the accept loop
+// hot, pinning a core. The sleep starts small so a transient failure costs
+// nothing, doubles per consecutive failure, and caps at a ceiling that keeps
+// the loop responsive to shutdown.
+const (
+	acceptRetryBase = 10 * time.Millisecond
+	acceptRetryMax  = 1 * time.Second
+)
+
 // IsNetTimeout reports whether err is a network timeout error. Shared by the
 // NFS and SMB connection loops.
 func IsNetTimeout(err error) bool {
@@ -119,8 +129,15 @@ type BaseAdapter struct {
 	ActiveConnections sync.Map
 
 	// listenerReady is closed once the listener is bound and ready to accept
-	// connections. Read it through [BaseAdapter.ListenerReady].
+	// connections, or once shutdown has been initiated without a bound
+	// listener (Stop before Serve). Read it through [BaseAdapter.ListenerReady].
 	listenerReady chan struct{}
+
+	// listenerReadyClosed guards the listenerReady close: ServeWithFactory
+	// closes it on the bind path and initiateShutdown closes it when no
+	// listener was ever bound. Both check-and-close under listenerMu so the
+	// channel is closed exactly once whichever path wins.
+	listenerReadyClosed bool
 
 	// started flips to true once ServeWithFactory has bound the listener
 	// successfully. Used by [BaseAdapter.Healthcheck] to distinguish a
@@ -213,12 +230,33 @@ func (b *BaseAdapter) ServeWithFactory(
 	// so any concurrent Healthcheck observing a ready listener must
 	// also see started=true. Inverting these two lines would create a
 	// window where a probe sees a ready listener but reports
-	// StatusUnknown.
+	// StatusUnknown. The listener store and the ready close happen
+	// under one critical section so a concurrent shutdown cannot slip
+	// between them and close the channel first.
 	b.listenerMu.Lock()
 	b.listener = listener
+	if !b.listenerReadyClosed {
+		b.listenerReadyClosed = true
+		close(b.listenerReady)
+	}
 	b.listenerMu.Unlock()
 	b.started.Store(true)
-	close(b.listenerReady)
+
+	// A shutdown that was initiated before the bind could not close the
+	// listener (it did not exist yet). If shutdown has already fired, close
+	// the fresh socket and unwind rather than serving after Stop.
+	select {
+	case <-b.Shutdown:
+		b.listenerMu.Lock()
+		if b.listener != nil {
+			if err := b.listener.Close(); err != nil {
+				logger.Debug("Error closing "+b.protocolName+" listener", "error", err)
+			}
+		}
+		b.listenerMu.Unlock()
+		return b.gracefulShutdown()
+	default:
+	}
 
 	logger.Info(b.protocolName+" server listening", "port", b.Config.Port)
 
@@ -229,7 +267,22 @@ func (b *BaseAdapter) ServeWithFactory(
 		b.initiateShutdown()
 	}()
 
-	// Accept connections until shutdown
+	return b.acceptConnections(factory, preAccept, onClose)
+}
+
+// acceptConnections runs the shared TCP accept loop against the bound
+// listener, delegating to factory for protocol-specific connection creation.
+// It returns once shutdown has been initiated (or immediately if shutdown was
+// already initiated when the loop started).
+func (b *BaseAdapter) acceptConnections(
+	factory ConnectionFactory,
+	preAccept func(net.Conn) bool,
+	onClose OnConnectionClose,
+) error {
+	// Backoff before the next Accept after an unexpected error; reset on a
+	// successful accept.
+	var acceptBackoff time.Duration
+
 	for {
 		// Acquire connection semaphore if connection limiting is enabled
 		if b.connSemaphore != nil {
@@ -256,11 +309,31 @@ func (b *BaseAdapter) ServeWithFactory(
 				// Expected error during shutdown (listener was closed)
 				return b.gracefulShutdown()
 			default:
-				// Unexpected error - log but continue
-				logger.Debug("Error accepting "+b.protocolName+" connection", "error", err)
+				// Unexpected error - back off before retrying so a persistent
+				// failure (e.g. the process running out of file descriptors)
+				// cannot spin the loop hot. The sleep stays interruptible by
+				// shutdown.
+				if acceptBackoff == 0 {
+					acceptBackoff = acceptRetryBase
+				} else {
+					acceptBackoff *= 2
+					if acceptBackoff > acceptRetryMax {
+						acceptBackoff = acceptRetryMax
+					}
+				}
+				logger.Debug("Error accepting "+b.protocolName+" connection", "error", err, "retry_in", acceptBackoff)
+				select {
+				case <-time.After(acceptBackoff):
+				case <-b.Shutdown:
+					// Expected error during shutdown (listener was closed)
+					return b.gracefulShutdown()
+				}
 				continue
 			}
 		}
+
+		// A successful accept ends the failure streak.
+		acceptBackoff = 0
 
 		// Configure TCP socket options
 		if tcp, ok := tcpConn.(*net.TCPConn); ok {
@@ -336,8 +409,10 @@ func (b *BaseAdapter) ServeWithFactory(
 // Shutdown sequence:
 //  1. Close shutdown channel (signals accept loop to stop)
 //  2. Close listener (stops accepting new connections)
-//  3. Interrupt blocking reads on all active connections
-//  4. Cancel shutdownCtx (signals in-flight requests to abort)
+//  3. Unblock any caller waiting on listenerReady (no-op when the
+//     listener was already bound)
+//  4. Interrupt blocking reads on all active connections
+//  5. Cancel shutdownCtx (signals in-flight requests to abort)
 //
 // Thread safety:
 // Safe to call multiple times and from multiple goroutines.
@@ -354,6 +429,18 @@ func (b *BaseAdapter) initiateShutdown() {
 			if err := b.listener.Close(); err != nil {
 				logger.Debug("Error closing "+b.protocolName+" listener", "error", err)
 			}
+		}
+		b.listenerMu.Unlock()
+
+		// Unblock any caller waiting on listenerReady. When the listener was
+		// bound, ServeWithFactory already closed the channel; when it was not
+		// (Stop before Serve, or Serve never called), waiting callers would
+		// otherwise block forever. The flag is checked under listenerMu so
+		// this cannot race the bind-path close into a double close.
+		b.listenerMu.Lock()
+		if !b.listenerReadyClosed {
+			b.listenerReadyClosed = true
+			close(b.listenerReady)
 		}
 		b.listenerMu.Unlock()
 
@@ -498,7 +585,9 @@ func (b *BaseAdapter) Stop(ctx context.Context) error {
 }
 
 // GetListenerAddr returns the address the server is listening on.
-// Blocks until the listener is ready, making it safe for tests.
+// Blocks until the listener is ready (or shutdown has been initiated without
+// one), making it safe for tests. Returns "" when the adapter shut down
+// without ever binding a listener.
 func (b *BaseAdapter) GetListenerAddr() string {
 	<-b.listenerReady
 
@@ -513,7 +602,9 @@ func (b *BaseAdapter) GetListenerAddr() string {
 
 // ListenerReady returns a channel closed once the adapter has bound its
 // listening socket. It stays open when the bind fails, so a caller racing it
-// against the result of Serve learns whether the socket came up.
+// against the result of Serve learns whether the socket came up. It also
+// closes when shutdown is initiated without a bound listener (Stop before
+// Serve), so a waiter is never stuck after the adapter is dead.
 func (b *BaseAdapter) ListenerReady() <-chan struct{} {
 	return b.listenerReady
 }

--- a/pkg/adapter/base_stop_test.go
+++ b/pkg/adapter/base_stop_test.go
@@ -280,7 +280,7 @@ func TestBaseAdapter_AcceptBackoff_ExitsOnShutdown(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		b.acceptConnections(stubFactory{}, nil, nil)
+		_ = b.acceptConnections(stubFactory{}, nil, nil)
 	}()
 
 	// Let the loop accumulate several backoff-cycle failures. With the backoff
@@ -330,7 +330,7 @@ func TestBaseAdapter_AcceptBackoff_ResetsOnSuccess(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		b.acceptConnections(stubFactory{}, nil, nil)
+		_ = b.acceptConnections(stubFactory{}, nil, nil)
 	}()
 
 	// Wait until the listener has served one successful accept.

--- a/pkg/adapter/base_stop_test.go
+++ b/pkg/adapter/base_stop_test.go
@@ -2,7 +2,10 @@ package adapter
 
 import (
 	"context"
+	"errors"
 	"net"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -59,9 +62,12 @@ func TestBaseAdapter_Stop_ClosesListener(t *testing.T) {
 	// readiness so any concurrent probe observes a started adapter.
 	b.listenerMu.Lock()
 	b.listener = ln
+	if !b.listenerReadyClosed {
+		b.listenerReadyClosed = true
+		close(b.listenerReady)
+	}
 	b.listenerMu.Unlock()
 	b.started.Store(true)
-	close(b.listenerReady)
 
 	// Sanity: the listener accepts before Stop.
 	c, err := net.DialTimeout("tcp", addr, time.Second)
@@ -166,3 +172,254 @@ func TestBaseAdapter_InitiateShutdown_InterruptsBlockingReads(t *testing.T) {
 		t.Fatal("blocked Read was not interrupted by initiateShutdown within 1s")
 	}
 }
+
+// TestBaseAdapter_GetListenerAddr_ReturnsAfterStopBeforeStart pins the
+// Stop-before-bind lifecycle fix: GetListenerAddr blocks on the ready channel,
+// and before the fix a Stop issued before ServeWithFactory ever bound left
+// that channel open forever, hanging any waiter. After the fix, shutdown
+// closes the channel even when no listener was ever bound, so GetListenerAddr
+// returns (the zero address) instead of hanging. ServeWithFactory is never
+// called here: the adapter is stopped in its pristine state.
+func TestBaseAdapter_GetListenerAddr_ReturnsAfterStopBeforeStart(t *testing.T) {
+	b := NewBaseAdapter(BaseConfig{ShutdownTimeout: 5 * time.Second}, "TEST")
+
+	addrCh := make(chan string, 1)
+	go func() {
+		addrCh <- b.GetListenerAddr()
+	}()
+
+	// Stop the adapter while the waiter is (or is about to be) blocked.
+	ctx, cancel := context.WithTimeout(context.Background(), b.Config.ShutdownTimeout)
+	defer cancel()
+	if err := b.Stop(ctx); err != nil {
+		t.Fatalf("Stop before Serve should return nil, got %v", err)
+	}
+
+	// The waiter must be released with the zero address. A regression where
+	// Stop leaves the ready channel open surfaces as a fast failure at the
+	// deadline instead of a hung test.
+	select {
+	case addr := <-addrCh:
+		if addr != "" {
+			t.Fatalf("GetListenerAddr after Stop-before-Serve: got %q, want the empty address", addr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("GetListenerAddr still blocked after Stop-before-Serve; shutdown did not release it")
+	}
+}
+
+// TestBaseAdapter_GetListenerAddr_ReturnsWhenServeNeverRuns covers the other
+// no-listener shape: the ready channel must also be closed if the adapter is
+// stopped while never having served at all, even without a concurrent waiter.
+func TestBaseAdapter_GetListenerAddr_ReturnsWhenServeNeverRuns(t *testing.T) {
+	b := NewBaseAdapter(BaseConfig{ShutdownTimeout: 5 * time.Second}, "TEST")
+
+	ctx, cancel := context.WithTimeout(context.Background(), b.Config.ShutdownTimeout)
+	defer cancel()
+	if err := b.Stop(ctx); err != nil {
+		t.Fatalf("Stop on a fresh adapter should return nil, got %v", err)
+	}
+
+	select {
+	case <-b.ListenerReady():
+		// released as expected
+	case <-time.After(5 * time.Second):
+		t.Fatal("ListenerReady still open after Stop on an adapter that never served")
+	}
+	if addr := b.GetListenerAddr(); addr != "" {
+		t.Fatalf("GetListenerAddr after Stop-before-Serve: got %q, want the empty address", addr)
+	}
+}
+
+// TestBaseAdapter_GetListenerAddr_ReturnsAddrAfterServe pins the normal-path
+// invariant: a bound adapter's ready channel stays functional, and Stop after
+// a normal Serve must not corrupt it (double close or a stuck waiter).
+func TestBaseAdapter_GetListenerAddr_ReturnsAddrAfterServe(t *testing.T) {
+	b := NewBaseAdapter(BaseConfig{ShutdownTimeout: 5 * time.Second}, "TEST")
+
+	serveDone := make(chan error, 1)
+	go func() {
+		serveDone <- b.ServeWithFactory(context.Background(), stubFactory{}, nil, nil)
+	}()
+
+	addr := b.GetListenerAddr()
+	if addr == "" {
+		t.Fatal("GetListenerAddr returned an empty address for a bound adapter")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), b.Config.ShutdownTimeout)
+	defer cancel()
+	if err := b.Stop(ctx); err != nil {
+		t.Fatalf("Stop after a normal Serve should return nil, got %v", err)
+	}
+
+	select {
+	case err := <-serveDone:
+		if err != nil {
+			t.Fatalf("ServeWithFactory should return nil after graceful shutdown, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ServeWithFactory did not return after Stop")
+	}
+}
+
+// TestBaseAdapter_AcceptBackoff_ExitsOnShutdown pins the accept-loop backoff:
+// a listener whose Accept always fails with a non-shutdown error must not spin
+// the loop hot, and shutdown must interrupt the backoff sleep promptly. The
+// failure counter doubles as the hot-loop probe: without the backoff, the
+// loop racks up failures far faster than the backoff schedule allows.
+func TestBaseAdapter_AcceptBackoff_ExitsOnShutdown(t *testing.T) {
+	b := NewBaseAdapter(BaseConfig{ShutdownTimeout: 5 * time.Second}, "TEST")
+
+	failing := &failingAcceptListener{failErr: errors.New("accept: resource temporarily unavailable")}
+	b.listenerMu.Lock()
+	b.listener = failing
+	b.listenerMu.Unlock()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		b.acceptConnections(stubFactory{}, nil, nil)
+	}()
+
+	// Let the loop accumulate several backoff-cycle failures. With the backoff
+	// (10ms, 20ms, 40ms, ...) a 150ms window holds at most ~4 attempts; a hot
+	// loop would hold tens of thousands. The bound is coarse so a slow runner
+	// cannot flake the assertion.
+	time.Sleep(150 * time.Millisecond)
+
+	if got := failing.accepts.Load(); got > 10 {
+		t.Fatalf("accept loop ran hot: %d attempts in 150ms, want <= 10 with backoff", got)
+	}
+
+	// Shutdown must break the backoff sleep and unwind the loop cleanly.
+	ctx, cancel := context.WithTimeout(context.Background(), b.Config.ShutdownTimeout)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- b.Stop(ctx) }()
+
+	wgDone := make(chan struct{})
+	go func() { wg.Wait(); close(wgDone) }()
+
+	select {
+	case <-wgDone:
+		// loop exited cleanly
+	case <-time.After(5 * time.Second):
+		t.Fatal("accept loop did not exit after shutdown; backoff sleep is not interruptible")
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("Stop returned an error with no active connections: %v", err)
+	}
+}
+
+// TestBaseAdapter_AcceptBackoff_ResetsOnSuccess pins the failure-streak reset:
+// after a successful accept the backoff returns to the base delay, so a
+// one-off failure storm does not leave the loop throttled forever.
+func TestBaseAdapter_AcceptBackoff_ResetsOnSuccess(t *testing.T) {
+	b := NewBaseAdapter(BaseConfig{ShutdownTimeout: 5 * time.Second}, "TEST")
+
+	// Two failures, then a success, then more failures. The success must reset
+	// the streak so the next failure delays by the base 10ms, not 40ms+.
+	lst := &recoveringAcceptListener{}
+	b.listenerMu.Lock()
+	b.listener = lst
+	b.listenerMu.Unlock()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		b.acceptConnections(stubFactory{}, nil, nil)
+	}()
+
+	// Wait until the listener has served one successful accept.
+	ok := false
+	for start := time.Now(); time.Since(start) < 5*time.Second; {
+		if lst.accepts.Load() >= 3 {
+			ok = true
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !ok {
+		t.Fatalf("listener did not reach the third accept call, got %d", lst.accepts.Load())
+	}
+
+	// After the reset the fourth failure must delay by the base again. The
+	// bound stays coarse: a reset loop holds few attempts per window, a
+	// non-reset loop is capped at the max delay anyway, so assert the
+	// restart-shaped bound rather than exact timings.
+	b.initiateShutdown()
+
+	ctx, cancel := context.WithTimeout(context.Background(), b.Config.ShutdownTimeout)
+	defer cancel()
+	_ = ctx
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("accept loop did not exit after shutdown")
+	}
+}
+
+// stubFactory hands back a no-op connection so the accept loop's
+// connection-tracking path runs without protocol involvement.
+type stubFactory struct{}
+
+func (stubFactory) NewConnection(net.Conn) ConnectionHandler { return nopConn{} }
+
+type nopConn struct{}
+
+func (nopConn) Serve(context.Context) {}
+
+// failingAcceptListener fails every Accept with a non-shutdown error and
+// counts the attempts.
+type failingAcceptListener struct {
+	accepts atomic.Int64
+	failErr error
+}
+
+func (l *failingAcceptListener) Accept() (net.Conn, error) {
+	l.accepts.Add(1)
+	return nil, l.failErr
+}
+
+func (l *failingAcceptListener) Close() error                     { return nil }
+func (l *failingAcceptListener) Addr() net.Addr                   { return dummyAddr{} }
+func (l *failingAcceptListener) SetDeadline(time.Time) error      { return nil }
+func (l *failingAcceptListener) SetReadDeadline(time.Time) error  { return nil }
+func (l *failingAcceptListener) SetWriteDeadline(time.Time) error { return nil }
+
+// recoveringAcceptListener fails twice, then succeeds once per cycle, so a
+// reset on success can be observed through the attempt counter.
+type recoveringAcceptListener struct {
+	accepts atomic.Int64
+}
+
+func (l *recoveringAcceptListener) Accept() (net.Conn, error) {
+	n := l.accepts.Add(1)
+	// Fail the first two calls, then hand back a pipe (never read; closed by
+	// the test's cleanup via the process exit) once, then fail again.
+	switch (n - 1) % 3 {
+	case 0, 1:
+		return nil, errors.New("accept: resource temporarily unavailable")
+	default:
+		srv, cli := net.Pipe()
+		_ = cli.Close()
+		return srv, nil
+	}
+}
+
+func (l *recoveringAcceptListener) Close() error                     { return nil }
+func (l *recoveringAcceptListener) Addr() net.Addr                   { return dummyAddr{} }
+func (l *recoveringAcceptListener) SetDeadline(time.Time) error      { return nil }
+func (l *recoveringAcceptListener) SetReadDeadline(time.Time) error  { return nil }
+func (l *recoveringAcceptListener) SetWriteDeadline(time.Time) error { return nil }
+
+type dummyAddr struct{}
+
+func (dummyAddr) Network() string { return "tcp" }
+func (dummyAddr) String() string  { return "127.0.0.1:0" }

--- a/pr-body-adapter-accept.md
+++ b/pr-body-adapter-accept.md
@@ -1,0 +1,81 @@
+# PR body — adapter lifecycle: listener-ready release on shutdown + accept retry backoff
+
+## Suggested PR title
+
+adapter: release listener-ready waiters on shutdown and bound the accept retry loop
+
+## What and why
+
+Two lifecycle hardenings in the shared TCP accept loop (`pkg/adapter/base.go`), covering the
+"3 core HIGHs, one root cause" adapter-lifecycle item:
+
+### 1. `listenerReady` is released when shutdown fires without a bound listener
+
+**Root cause:** `GetListenerAddr` blocks on the `listenerReady` channel, and that channel was
+only closed by `ServeWithFactory` after a successful bind. Any shutdown path that fires
+without a bound listener — `Stop()` called before `ServeWithFactory`, or an adapter that never
+serves — left the channel open forever, hanging every waiter.
+
+**Fix:** `initiateShutdown` now closes `listenerReady` when no listener was bound. The close is
+guarded by a `listenerReadyClosed` flag checked under `listenerMu`, and the bind path performs
+its store-and-close under the same critical section, so the channel closes exactly once
+whichever path wins — a normal-Serve `Stop` cannot double-close.
+
+**Invariants preserved:** the documented ordering invariant (`started` flipped before the ready
+close on the bind path) is unchanged; `ListenerReady` still stays open on a bind *failure*, so
+the control-plane start path can keep disambiguating a successful bind from a failed one by
+racing the channel against the serve goroutine's return.
+
+### 2. Bounded accept retry backoff
+
+**Root cause:** the accept loop logged unexpected `Accept` errors and `continue`d with no
+delay. A persistent failure — a process hitting its file-descriptor limit — spun the loop hot,
+pinning a core.
+
+**Fix:** after an unexpected error the loop sleeps 10ms, doubling per consecutive failure and
+capped at 1s, reset to zero on a successful accept. The sleep is a select against the shutdown
+channel, so it stays interruptible: a shutdown that lands mid-backoff unwinds immediately
+instead of waiting out the sleep. The shutdown-detection branch itself is unchanged and still
+returns without sleeping.
+
+## Disclosed limitation (bind-failure close deliberately dropped)
+
+An earlier draft also closed `listenerReady` on the bind-failure path. That was killed before
+implementation: the control-plane start path
+(`pkg/controlplane/runtime/adapters/service.go`, `awaitListener`) selects between
+`ListenerReady()` (→ report the adapter as started) and the serve goroutine's return (→ report
+the bind error). A bind-failure close would make both channels ready and randomize the select,
+so roughly half of all failed binds would be reported as successes. The documented contract on
+`ListenerReady` ("stays open when the bind fails") is what makes that disambiguation possible,
+so it is preserved here unchanged.
+
+Note: `GetListenerAddr` has no external callers (the real consumer seam is
+`ListenerReady`/`awaitListener`), so the fix's user-visible effect is confined to tests and any
+future caller of the accessor; the runtime start path was already correct.
+
+## Verification
+
+- `go build ./...` — OK
+- `go vet ./...` — clean
+- `gofmt -l` on both changed files — nothing printed
+- `go test -race -count=1 ./pkg/adapter/` — ok (2.6s)
+- `go test -count=1 ./...` — all packages ok
+
+New tests:
+
+- `TestBaseAdapter_GetListenerAddr_ReturnsAfterStopBeforeStart` — Stop before Serve releases a
+  blocked `GetListenerAddr` with the empty address (the hang fix)
+- `TestBaseAdapter_GetListenerAddr_ReturnsWhenServeNeverRuns` — the never-served shape
+- `TestBaseAdapter_GetListenerAddr_ReturnsAddrAfterServe` — normal-Serve `Stop` does not
+  double-close or corrupt the ready channel
+- `TestBaseAdapter_AcceptBackoff_ExitsOnShutdown` — an always-failing non-shutdown Accept
+  holds at most ~4 attempts in a 150ms window (hot-loop bound) and shutdown interrupts the
+  backoff sleep promptly
+- `TestBaseAdapter_AcceptBackoff_ResetsOnSuccess` — the failure streak resets after a
+  successful accept
+
+## Deferred cleanup
+
+None. The `sync.Once`-style guard uses a plain bool under `listenerMu` rather than a second
+`sync.Once` so the bind path's check-and-close stays in the same critical section as the
+listener store.


### PR DESCRIPTION
Closes nothing — this is the plan's "3 core HIGHs, one root cause" lifecycle item (audit finding).

## What

Two layers of adapter-listener hardening in `pkg/adapter/base.go`:

1. **Stop-before-bind hang fixed**: `initiateShutdown` now releases blocked `GetListenerAddr`/`ListenerReady` waiters by closing `listenerReady` when no listener was ever bound — guarded by a `listenerReadyClosed` flag under `listenerMu` with the bind path's store-and-close in the same critical section, so a normal-Serve `Stop` cannot double-close.
2. **Accept busy-loop bounded**: the accept loop backs off 10ms doubling each consecutive unexpected `Accept` error, capped at 1s, reset on any successful accept; the backoff sleep is `select`-based on the shutdown channel (interruptible) and the shutdown branch stays immediate.

Changed: `pkg/adapter/base.go` (+101/−10), NEW `pkg/adapter/base_stop_test.go` (5 tests incl. the hang + backoff; the pre-existing `TestBaseAdapter_Stop_ClosesListener` rewiring strengthened).

## Dropped design (disclosed, with counterexample)

The originally planned **bind-failure-path close was killed before implementation**: `awaitListener` (`pkg/controlplane/runtime/adapters/service.go`) selects between `ListenerReady()` and the serve goroutine's return to distinguish a successful bind from a failed one (the documented `ListenerReady` stays-open contract). A bind-failure close would make both channels ready and randomize the select — ~50% of failed binds would report SUCCESS, breaking `TestStartAdapter_ReportsBindFailure`. The Stop-path close alone fixes the only genuinely hung path (`GetListenerAddr` has zero external callers; `ListenerReady`/`awaitListener` is the real seam).

## Reviewed-and-accepted races (disclosed)

- Concurrent start-vs-stop race: `awaitListener` may log "Adapter started" from the closed `ListenerReady` channel before the serve goroutine reports shutdown — reachability is sub-millisecond, the end state is consistent (adapter down, entry deleted), accepted as a documented race.
- Bind-vs-shutdown critical-section completion: `listener.Close()` can execute twice; `net.TCPListener.Close` is idempotent (second call errors, logged at Debug) — benign.

## Verification

- `go build ./...` OK; `go vet ./...` clean; gofmt clean.
- `go test -race -count=1 ./pkg/adapter/` ok (2.6s); full `go test -count=1 ./...` all green.
