### PR TITLE
smb: route async credit grants through the per-session grant path

### DIFF
--- a/internal/adapter/smb/async_credit_wiring_test.go
+++ b/internal/adapter/smb/async_credit_wiring_test.go
@@ -1,0 +1,110 @@
+package smb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/handlers"
+	"github.com/marmos91/dittofs/internal/adapter/smb/session"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newAsyncCreditConnInfo builds a ConnInfo wired for async completion sends:
+// a real session manager shared with the handler, a live sequence window, and
+// a drained pipe so WriteNetBIOSFrame succeeds.
+func newAsyncCreditConnInfo(t *testing.T, mgr *session.Manager) (*ConnInfo, func()) {
+	t.Helper()
+	serverConn, cleanup := newTestConnPair(t)
+	ci := &ConnInfo{
+		Conn:           serverConn,
+		Handler:        handlers.NewHandlerWithSessionManager(mgr),
+		SessionManager: mgr,
+		WriteMu:        &LockedWriter{},
+		WriteTimeout:   2 * time.Second,
+		SequenceWindow: NewSequenceWindowForConnection(mgr),
+	}
+	return ci, cleanup
+}
+
+// TestSendAsyncCompletionResponse_AdvancesSessionCredits pins the async credit
+// wiring: a standalone async completion must advance BOTH the connection's
+// sequence window and the session's credit bookkeeping. The grantAdaptive
+// strategy throttles on Session.GetOutstanding, so an async grant that only
+// extends the wire window leaves that throttle input blind to async traffic.
+func TestSendAsyncCompletionResponse_AdvancesSessionCredits(t *testing.T) {
+	mgr := session.NewDefaultManager()
+	sess := mgr.CreateSession("10.0.0.1:1234", false, "async-client", "TEST")
+	ci, cleanup := newAsyncCreditConnInfo(t, mgr)
+	defer cleanup()
+
+	grantedBefore := mgr.GetSessionStats(sess.SessionID).Granted
+	outstandingBefore := mgr.GetSessionStats(sess.SessionID).Outstanding
+	windowBefore := ci.SequenceWindow.Size()
+
+	err := SendAsyncCompletionResponse(sess.SessionID, 100, 5,
+		types.SMB2Create, types.StatusSuccess, []byte{0x01}, ci)
+	require.NoError(t, err)
+
+	stats := mgr.GetSessionStats(sess.SessionID)
+	assert.Greater(t, stats.Granted, grantedBefore,
+		"async completion must record the grant in session credits (red without the wiring)")
+	assert.Greater(t, stats.Outstanding, outstandingBefore,
+		"async grant must advance the outstanding balance the adaptive strategy samples")
+	assert.Greater(t, ci.SequenceWindow.Size(), windowBefore,
+		"async grant must still extend the wire sequence window")
+}
+
+// TestSendAsyncChangeNotifyResponse_AdvancesSessionCredits pins the same
+// invariant for CHANGE_NOTIFY completions, which arrive without a correlated
+// client request.
+func TestSendAsyncChangeNotifyResponse_AdvancesSessionCredits(t *testing.T) {
+	mgr := session.NewDefaultManager()
+	sess := mgr.CreateSession("10.0.0.1:1234", false, "notify-client", "TEST")
+	ci, cleanup := newAsyncCreditConnInfo(t, mgr)
+	defer cleanup()
+
+	require.True(t, ci.TryReserveAsync(),
+		"CHANGE_NOTIFY reserves an async slot the sender releases")
+
+	grantedBefore := mgr.GetSessionStats(sess.SessionID).Granted
+	windowBefore := ci.SequenceWindow.Size()
+
+	notify := &handlers.ChangeNotifyResponse{}
+	err := SendAsyncChangeNotifyResponse(sess.SessionID, 200, 7, notify, ci)
+	require.NoError(t, err)
+
+	stats := mgr.GetSessionStats(sess.SessionID)
+	assert.Greater(t, stats.Granted, grantedBefore,
+		"async CHANGE_NOTIFY must record the grant in session credits")
+	assert.Greater(t, ci.SequenceWindow.Size(), windowBefore,
+		"async CHANGE_NOTIFY must still extend the wire sequence window")
+}
+
+// TestSendAsyncCompletionResponse_NilSessionManagerGuard proves async
+// completions tolerate a ConnInfo whose SessionManager is nil — the pre-fix
+// shape never touched the manager, and async completions can fire on
+// connections where the sync dispatch path never ran. The grant must fall
+// back to the wire window alone, not panic.
+func TestSendAsyncCompletionResponse_NilSessionManagerGuard(t *testing.T) {
+	serverConn, cleanup := newTestConnPair(t)
+	defer cleanup()
+
+	sw := session.NewCommandSequenceWindow(8192)
+	ci := &ConnInfo{
+		Conn:           serverConn,
+		Handler:        handlers.NewHandlerWithSessionManager(session.NewDefaultManager()),
+		SessionManager: nil,
+		WriteMu:        &LockedWriter{},
+		WriteTimeout:   2 * time.Second,
+		SequenceWindow: sw,
+	}
+
+	windowBefore := sw.Size()
+	err := SendAsyncCompletionResponse(42, 1, 1,
+		types.SMB2Create, types.StatusSuccess, []byte{0x01}, ci)
+	require.NoError(t, err)
+	assert.Greater(t, sw.Size(), windowBefore,
+		"grant must fall back to the wire window when no session manager is wired")
+}

--- a/internal/adapter/smb/response.go
+++ b/internal/adapter/smb/response.go
@@ -1222,14 +1222,26 @@ func SendAsyncChangeNotifyResponse(sessionID, messageID, asyncId uint64, respons
 	status := response.GetStatus()
 
 	// Build async response header with matching AsyncId.
-	// Grant credits through the connection window so the client's cur_credits
-	// counter stays in sync with the server's bookkeeping (#378). A CHANGE_NOTIFY
-	// completion normally arrives without a correlated client request, so ask
-	// for 1 credit — the window may deliver 0 if the connection is already at
-	// the client's uint16 cap.
+	// Grant credits through the same per-session path the synchronous
+	// completions use (grantConnectionCredits) so the client's cur_credits
+	// counter AND the session's credit bookkeeping stay in sync with the
+	// server's. A CHANGE_NOTIFY completion normally arrives without a
+	// correlated client request, so ask for 1 credit — the strategy may
+	// deliver more, and the window may deliver 0 if the connection is already
+	// at the client's uint16 cap. The SessionManager may be nil when the async
+	// completion fires on a connection whose sync dispatch path never ran; the
+	// grant then falls back to the wire window alone.
 	credits := uint16(0)
 	if connInfo.SequenceWindow != nil {
-		credits = connInfo.SequenceWindow.Grant(1)
+		if connInfo.SessionManager != nil {
+			credits = connInfo.SessionManager.GrantCredits(sessionID, 1, 0)
+		} else {
+			// Per MS-SMB2 3.3.1.2 the server MUST grant at least 1 credit in
+			// every response — Manager.GrantCredits enforces the same floor
+			// when it is wired.
+			credits = 1
+		}
+		credits = connInfo.SequenceWindow.Grant(credits)
 	}
 	respHeader := &header.SMB2Header{
 		Command:   types.SMB2ChangeNotify,
@@ -1296,11 +1308,17 @@ func SendAsyncChangeNotifyResponse(sessionID, messageID, asyncId uint64, respons
 // This is the general-purpose counterpart to SendAsyncChangeNotifyResponse --
 // it handles any command type, not just CHANGE_NOTIFY.
 func SendAsyncCompletionResponse(sessionID uint64, messageID uint64, asyncId uint64, command types.Command, status types.Status, body []byte, connInfo *ConnInfo) error {
-	// Route the credit grant through the connection window; see
-	// SendAsyncChangeNotifyResponse for the #378 rationale.
+	// Route the credit grant through the same per-session path the
+	// synchronous completions use; see SendAsyncChangeNotifyResponse for the
+	// rationale and the nil-SessionManager fallback.
 	credits := uint16(0)
 	if connInfo.SequenceWindow != nil {
-		credits = connInfo.SequenceWindow.Grant(1)
+		if connInfo.SessionManager != nil {
+			credits = connInfo.SessionManager.GrantCredits(sessionID, 1, 0)
+		} else {
+			credits = 1 // Manager.GrantCredits's per-response floor.
+		}
+		credits = connInfo.SequenceWindow.Grant(credits)
 	}
 	respHeader := &header.SMB2Header{
 		StructureSize: header.HeaderSize,


### PR DESCRIPTION
Closes nothing — audit finding (async credit-window grant bypass defeats grantAdaptive's throttle input).

## What

Both async completion grant sites (`SendAsyncChangeNotifyResponse`, `SendAsyncCompletionResponse` in `internal/adapter/smb/response.go`) now route through the per-session grant path instead of advancing only the wire window:

- `SessionManager.GrantCredits(sessionID, 1, 0)` then `SequenceWindow.Grant(credits)` — the same non-nested order as the sync `grantConnectionCredits` (`response.go` ~869→880).
- The value passed to `SequenceWindow.Grant` is `GrantCredits`'s return count, never a constant.
- Nil-`SessionManager` guard falls back to the per-response floor of 1 and still advances the window (CHANGE_NOTIFY cannot stall a client's window).
- The Manager's `MinimumCreditGrant = 1` floor guarantees the window grant input is ≥ 1 (MS-SMB2 3.3.1.2).

Previously, async CHANGE_NOTIFY/compound completions called `connInfo.SequenceWindow.Grant(1)` directly, leaving `Session.credits` under-counted — defeating `grantAdaptive`'s `GetOutstanding()` throttle input and skewing `GetStats`.

Tests (NEW `internal/adapter/smb/async_credit_wiring_test.go`):
- `TestSendAsyncCompletionResponse_AdvancesSessionCredits`
- `TestSendAsyncChangeNotifyResponse_AdvancesSessionCredits` (red-without-fix proven: failed `"0" is not greater than "0"` pre-fix)
- `TestSendAsyncCompletionResponse_NilSessionManagerGuard` (asserts `sw.Size()` grows)

## Verification

- Build/vet/gofmt clean; `go test -race -count=1 ./internal/adapter/smb/...` all ok (root smb 2.0s); full `go test -count=1 ./...` sweep no failures.
- Reviewer-verified: two distinct ledgers (session credits vs wire window), one grant each; no double-grant; no lock-order inversion; no caller re-entrancy (all senders dispatch from fresh goroutines).
