### PR TITLE
fix(nfs): default max_version to 4.0 until full NFSv4.1 lands

### DIFF
--- a/pkg/controlplane/models/adapter_settings.go
+++ b/pkg/controlplane/models/adapter_settings.go
@@ -41,7 +41,10 @@ type NFSAdapterSettings struct {
 
 	// Version negotiation
 	MinVersion string `gorm:"default:3;size:10" json:"min_version"`
-	MaxVersion string `gorm:"default:4.1;size:10" json:"max_version"`
+	// MaxVersion defaults to 4.0: the server has no EXCHANGE_ID/CREATE_SESSION,
+	// so advertising 4.1 makes real 4.1 clients fail the session bind
+	// (NFS4ERR_CONN_NOT_BOUND_TO_SESSION). 4.1 stays selectable.
+	MaxVersion string `gorm:"default:4.0;size:10" json:"max_version"`
 
 	// Timeouts (seconds)
 	LeaseTime               int `gorm:"default:90" json:"lease_time"`
@@ -258,7 +261,7 @@ func NewDefaultNFSSettings(adapterID string) *NFSAdapterSettings {
 		ID:                           uuid.New().String(),
 		AdapterID:                    adapterID,
 		MinVersion:                   "3",
-		MaxVersion:                   "4.1",
+		MaxVersion:                   "4.0",
 		LeaseTime:                    90,
 		GracePeriod:                  90,
 		DelegationRecallTimeout:      90,


### PR DESCRIPTION
## Summary

The NFS adapter defaults to `max_version: "4.1"` but the server has no EXCHANGE_ID/CREATE_SESSION support, so advertising 4.1 makes real 4.1 clients fail:

- NULL probe on program 100003 → `SYSTEM_ERR`
- COMPOUND → `NFS4ERR_CONN_NOT_BOUND_TO_SESSION` (10071)
- macOS `mount_nfs -o vers=4.1` → "RPC prog. not avail"

NFSv4.0 works end-to-end, so the default is now `4.0`. `"4.1"` remains selectable in `ValidNFSVersions` — just not the default. Tracked downstream as marmos91/dittofs-pro#149.

Changes:
- gorm tag `default:4.1` → `default:4.0` on `NFSAdapterSettings.MaxVersion`
- `NewDefaultNFSSettings`: `MaxVersion: "4.1"` → `"4.0"`

`GetDefaults` in the adapter-settings API derives from `NewDefaultNFSSettings`, so the reported default follows automatically. No v4.1 dispatch machinery was touched.

(Supersedes #2508 and #2509 — both were closed when the branch was force-replaced to carry an SSH-signed commit, as required by the `main` signature ruleset.)

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/controlplane/models/... ./internal/controlplane/api/handlers/...` passing
- [x] No test pinned the old 4.1 default (store test compares against `defaults.MaxVersion` dynamically)
