### PR TITLE
SMB: harden the session-auth cluster

### DIFF
--- a/internal/adapter/smb/auth/ntlm.go
+++ b/internal/adapter/smb/auth/ntlm.go
@@ -111,6 +111,14 @@ const (
 	authEncryptedRandomSessionKeyOff = 56 // 4 bytes: EncryptedRandomSessionKey buffer offset
 	authNegotiateFlagsOffset         = 60 // 4 bytes: NegotiateFlags
 	authBaseSize                     = 64 // Minimum size without payload (not including Version)
+
+	// authMicOffset is the fixed location of the AUTHENTICATE MIC
+	// (MS-NLMP 2.2.1.3): the 8-byte Version structure occupies 64..72 and the
+	// 16-byte MIC follows at 72..88 in messages that carry one. A zero MIC
+	// means the client sent no MIC (the field is always readable in NTLMv2
+	// messages long enough, since Version is mandatory there).
+	authMicOffset = 72
+	authMicSize   = 16
 )
 
 // =============================================================================
@@ -623,6 +631,13 @@ type AuthenticateMessage struct {
 	// IsAnonymous indicates if this is an anonymous authentication request.
 	// Set when FlagAnonymous is present in NegotiateFlags.
 	IsAnonymous bool
+
+	// Mic is the 16-byte message-integrity code from the AUTHENTICATE message
+	// (MS-NLMP 2.2.1.3), present when the client negotiated the MIC
+	// (MsvAvFlags MIC bit). nil when the client sent none. Verified against the
+	// exported session key per MS-NLMP 3.2.5.2.1 before the session is
+	// published.
+	Mic []byte
 }
 
 // ParseAuthenticate parses an NTLM Type 3 (AUTHENTICATE) message.
@@ -705,6 +720,24 @@ func ParseAuthenticate(buf []byte) (*AuthenticateMessage, error) {
 	if keyLen > 0 && int(keyOff)+int(keyLen) <= len(buf) {
 		msg.EncryptedRandomSessionKey = make([]byte, keyLen)
 		copy(msg.EncryptedRandomSessionKey, buf[keyOff:keyOff+uint32(keyLen)])
+	}
+
+	// Parse the MIC at its fixed location (MS-NLMP 2.2.1.3). A message shorter
+	// than the MIC region carries no MIC; a zeroed 16-byte MIC also means
+	// absent (clients that negotiate no MIC zero the field).
+	if len(buf) >= authMicOffset+authMicSize {
+		mic := make([]byte, authMicSize)
+		copy(mic, buf[authMicOffset:authMicOffset+authMicSize])
+		zero := true
+		for _, b := range mic {
+			if b != 0 {
+				zero = false
+				break
+			}
+		}
+		if !zero {
+			msg.Mic = mic
+		}
 	}
 
 	return msg, nil
@@ -962,6 +995,55 @@ func DeriveSigningKey(sessionBaseKey [16]byte, flags NegotiateFlag, encryptedKey
 	cipher.XORKeyStream(exportedSessionKey[:], encryptedKey)
 
 	return exportedSessionKey
+}
+
+// VerifyNTLMSSPMechListMIC checks an NTLMSSP mechListMIC against the expected
+// signature computed by ComputeNTLMSSPMechListMIC over the same inputs
+// (exported session key, mechList bytes, negotiate flags). Returns nil when
+// the received MIC matches; ErrAuthenticationFailed on a mismatch. The
+// received MIC is the 16-byte NTLMSSP signature form (legacy or NTLM2 layout
+// per the negotiated flags), not the GSS-API MICToken form the Kerberos path
+// uses.
+func VerifyNTLMSSPMechListMIC(exportedSessionKey [16]byte, mechListBytes, receivedMIC []byte, flags NegotiateFlag) error {
+	expected := ComputeNTLMSSPMechListMIC(exportedSessionKey, mechListBytes, flags, nil)
+	if len(receivedMIC) != len(expected) {
+		return ErrAuthenticationFailed
+	}
+	if !hmac.Equal(receivedMIC, expected[:]) {
+		return ErrAuthenticationFailed
+	}
+	return nil
+}
+
+// VerifyAuthMessageMIC checks the AUTHENTICATE message's MIC against the
+// exported session key (MS-NLMP 3.2.5.2.1): the MIC is HMAC-MD5 over the
+// concatenation of the Type-1 NEGOTIATE, the Type-2 CHALLENGE, and the
+// Type-3 AUTHENTICATE with its own MIC field zeroed. negotiateMessage,
+// challengeMessage, and authenticateMessage are the exact wire bytes of the
+// three handshake messages; authenticateMessage must be the full buffer the
+// MIC was parsed from. Returns nil when the MIC matches.
+func VerifyAuthMessageMIC(exportedSessionKey [16]byte, negotiateMessage, challengeMessage, authenticateMessage []byte) error {
+	if len(authenticateMessage) < authMicOffset+authMicSize {
+		return ErrMessageTooShort
+	}
+	concat := make([]byte, 0, len(negotiateMessage)+len(challengeMessage)+len(authenticateMessage))
+	concat = append(concat, negotiateMessage...)
+	concat = append(concat, challengeMessage...)
+	concat = append(concat, authenticateMessage...)
+	// Zero the MIC in place for the computation, then restore so the caller's
+	// buffer is unchanged.
+	micCopy := make([]byte, authMicSize)
+	copy(micCopy, authenticateMessage[authMicOffset:authMicOffset+authMicSize])
+	clear(concat[len(concat)-len(authenticateMessage)+authMicOffset:][:authMicSize])
+
+	mac := hmac.New(md5.New, exportedSessionKey[:])
+	mac.Write(concat)
+	expected := mac.Sum(nil)
+
+	if !hmac.Equal(micCopy, expected) {
+		return ErrAuthenticationFailed
+	}
+	return nil
 }
 
 // NTLMSSP key-derivation magic constants (MS-NLMP 3.4.5.2 + 3.4.5.3).

--- a/internal/adapter/smb/auth/ntlm_mic_test.go
+++ b/internal/adapter/smb/auth/ntlm_mic_test.go
@@ -1,0 +1,99 @@
+package auth
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/md5"
+	"testing"
+)
+
+// buildSignedAuthenticate returns an AUTHENTICATE-shaped buffer with the MIC
+// field set to the expected HMAC over the three handshake messages (the same
+// computation VerifyAuthMessageMIC performs), so the test isolates the
+// verify path, not the MIC derivation.
+func buildSignedAuthenticate(t *testing.T, exportedSessionKey [16]byte, negotiate, challenge []byte) []byte {
+	t.Helper()
+	authMsg := validAuthenticateMessageForMIC()
+	// Compute the MIC over the concatenation with the MIC zeroed.
+	concat := bytes.Join([][]byte{negotiate, challenge, authMsg}, nil)
+	clear(concat[len(concat)-len(authMsg)+authMicOffset:][:authMicSize])
+	mac := hmac.New(md5.New, exportedSessionKey[:])
+	mac.Write(concat)
+	copy(authMsg[authMicOffset:authMicOffset+authMicSize], mac.Sum(nil))
+	return authMsg
+}
+
+// validAuthenticateMessageForMIC returns a minimal AUTHENTICATE-message buffer
+// long enough to carry the fixed MIC region (authMicOffset+authMicSize).
+func validAuthenticateMessageForMIC() []byte {
+	buf := make([]byte, authMicOffset+authMicSize)
+	// MessageType 3 (AUTHENTICATE) at offset 8; IsValid only checks the
+	// "NTLMSSP\0" prefix, so leave the signature zeroed unless needed.
+	buf[8] = 3
+	return buf
+}
+
+// TestVerifyAuthMessageMIC pins the AUTHENTICATE MIC check (MS-NLMP
+// 3.2.5.2.1): a MIC computed over the three handshake messages with the MIC
+// field zeroed verifies under the exported session key; a tampered MIC or a
+// tampered message is rejected.
+func TestVerifyAuthMessageMIC(t *testing.T) {
+	var key [16]byte
+	for i := range key {
+		key[i] = byte(i + 3)
+	}
+	negotiate := []byte{0x01, 0x02, 0x03}
+	challenge := []byte{0xAA, 0xBB, 0xCC, 0xDD}
+
+	t.Run("AcceptsValidMIC", func(t *testing.T) {
+		authMsg := buildSignedAuthenticate(t, key, negotiate, challenge)
+		if err := VerifyAuthMessageMIC(key, negotiate, challenge, authMsg); err != nil {
+			t.Errorf("VerifyAuthMessageMIC rejected a valid MIC: %v", err)
+		}
+	})
+
+	t.Run("RejectsTamperedMIC", func(t *testing.T) {
+		authMsg := buildSignedAuthenticate(t, key, negotiate, challenge)
+		authMsg[authMicOffset+5] ^= 0xFF
+		if err := VerifyAuthMessageMIC(key, negotiate, challenge, authMsg); err == nil {
+			t.Error("VerifyAuthMessageMIC accepted a tampered MIC")
+		}
+	})
+
+	t.Run("RejectsTamperedMessage", func(t *testing.T) {
+		authMsg := buildSignedAuthenticate(t, key, negotiate, challenge)
+		// Flip a byte outside the MIC region: the MIC no longer matches the
+		// (tampered) message content.
+		authMsg[12] ^= 0x01
+		if err := VerifyAuthMessageMIC(key, negotiate, challenge, authMsg); err == nil {
+			t.Error("VerifyAuthMessageMIC accepted a tampered message")
+		}
+	})
+}
+
+// TestVerifyNTLMSSPMechListMIC pins the NTLMSSP mechListMIC verify counterpart:
+// a MIC computed by ComputeNTLMSSPMechListMIC verifies under the same inputs;
+// a tampered MIC is rejected.
+func TestVerifyNTLMSSPMechListMIC(t *testing.T) {
+	var key [16]byte
+	for i := range key {
+		key[i] = byte(i + 7)
+	}
+	mechList := []byte{0x30, 0x0c, 0x06, 0x0a, 0x2b, 0x06, 0x01, 0x04, 0x01, 0x82, 0x37, 0x02, 0x02, 0x0a}
+	flags := FlagExtendedSecurity | Flag128
+
+	t.Run("AcceptsValidMIC", func(t *testing.T) {
+		mic := ComputeNTLMSSPMechListMIC(key, mechList, flags, nil)
+		if err := VerifyNTLMSSPMechListMIC(key, mechList, mic[:], flags); err != nil {
+			t.Errorf("VerifyNTLMSSPMechListMIC rejected a valid MIC: %v", err)
+		}
+	})
+
+	t.Run("RejectsTamperedMIC", func(t *testing.T) {
+		mic := ComputeNTLMSSPMechListMIC(key, mechList, flags, nil)
+		mic[3] ^= 0xFF
+		if err := VerifyNTLMSSPMechListMIC(key, mechList, mic[:], flags); err == nil {
+			t.Error("VerifyNTLMSSPMechListMIC accepted a tampered MIC")
+		}
+	})
+}

--- a/internal/adapter/smb/encryption/middleware.go
+++ b/internal/adapter/smb/encryption/middleware.go
@@ -1,7 +1,6 @@
 package encryption
 
 import (
-	"crypto/rand"
 	"errors"
 	"fmt"
 
@@ -38,6 +37,9 @@ type EncryptableSession interface {
 	EncryptorNonceSize() int
 	DecryptorNonceSize() int
 	EncryptorOverhead() int
+	// NextNonce returns a fresh encrypt nonce (per-session counter form) that
+	// never repeats under this session's key (MS-SMB2 3.1.4.3).
+	NextNonce(nonceSize int) ([]byte, error)
 	// IsNullSession reports whether the session was created with anonymous
 	// NTLM credentials (SMB2_SESSION_FLAG_IS_NULL). Used by the framing
 	// layer to map any decryption failure on such a session to
@@ -182,12 +184,12 @@ func (m *sessionEncryptionMiddleware) EncryptResponse(sessionID uint64, smb2Mess
 		SessionId:           sessionID,
 	}
 
-	// Generate nonce externally so we can set it in the header before computing AAD.
-	// The nonce in the TransformHeader IS the AEAD nonce, and the AAD includes the
-	// nonce bytes. We must know the nonce before computing AAD.
+	// The nonce is a per-session counter (prefix + monotonic counter) so the
+	// AEAD nonce never repeats under the same session key — MS-SMB2 3.1.4.3
+	// forbids nonce reuse. The counter lives on the session's crypto state.
 	nonceSize := sess.EncryptorNonceSize()
-	nonce := make([]byte, nonceSize)
-	if _, err := rand.Read(nonce); err != nil {
+	nonce, err := sess.NextNonce(nonceSize)
+	if err != nil {
 		return nil, fmt.Errorf("generate nonce: %w", err)
 	}
 

--- a/internal/adapter/smb/encryption/middleware_test.go
+++ b/internal/adapter/smb/encryption/middleware_test.go
@@ -1,6 +1,7 @@
 package encryption
 
 import (
+	"bytes"
 	"errors"
 	"testing"
 
@@ -10,10 +11,11 @@ import (
 
 // testSession is a minimal mock that provides the crypto methods needed by the middleware.
 type testSession struct {
-	encryptor   Encryptor
-	decryptor   Encryptor
-	encryptData bool
-	isNull      bool
+	encryptor    Encryptor
+	decryptor    Encryptor
+	encryptData  bool
+	isNull       bool
+	nonceCounter uint64
 }
 
 func (s *testSession) ShouldEncrypt() bool {
@@ -32,6 +34,11 @@ func (s *testSession) EncryptorNonceSize() int { return s.encryptor.NonceSize() 
 func (s *testSession) DecryptorNonceSize() int { return s.decryptor.NonceSize() }
 func (s *testSession) EncryptorOverhead() int  { return s.encryptor.Overhead() }
 func (s *testSession) IsNullSession() bool     { return s.isNull }
+
+func (s *testSession) NextNonce(nonceSize int) ([]byte, error) {
+	s.nonceCounter++
+	return bytes.Repeat([]byte{byte(s.nonceCounter)}, nonceSize), nil
+}
 
 func makeTestSession(t *testing.T, cipherId uint16) *testSession {
 	t.Helper()

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -374,6 +374,14 @@ type PendingAuth struct {
 	// final accept-completed response (MS-NLMP 3.4.5.2 + 2.2.2.9.1).
 	// Nil for clients that send raw NTLM without SPNEGO wrapping.
 	MechListBytes []byte
+	// NegotiateMessage holds the client's Type-1 NEGOTIATE message bytes from
+	// the first SESSION_SETUP of this handshake, and ChallengeMessage the
+	// server's Type-2 CHALLENGE reply. Together with the Type-3 AUTHENTICATE
+	// (MIC zeroed) they are the exact input to the AUTHENTICATE MIC check
+	// (MS-NLMP 3.2.5.2.1). Nil when that message was not seen on this
+	// pending-auth flow.
+	NegotiateMessage []byte
+	ChallengeMessage []byte
 }
 
 // TreeConnection represents an active tree connection mapping a client

--- a/internal/adapter/smb/handlers/kerberos_auth.go
+++ b/internal/adapter/smb/handlers/kerberos_auth.go
@@ -185,7 +185,7 @@ func (h *Handler) handleKerberosAuth(ctx *SMBHandlerContext, mechToken []byte, p
 		"signingEnabled", sess.ShouldSign(),
 		"encryptData", sess.ShouldEncrypt())
 
-	return h.buildKerberosAcceptResponse(sess, authResult, parsedToken)
+	return h.buildKerberosAcceptResponse(sess, authResult, parsedToken, true)
 }
 
 // reauthKerberosSession re-authenticates an existing, non-LoggedOff session in
@@ -218,13 +218,9 @@ func (h *Handler) reauthKerberosSession(
 	// Refresh identity and lifetime. Updating ExpiresAt to the fresh ticket
 	// end-time clears the expired state so prepareDispatch lets subsequent
 	// requests through again (expire1/2 recovery).
-	sess.User = user
-	sess.Username = user.Username
-	// Domain-aware session (AD-4): keep the NetBIOS short domain on reauth when
-	// domain-joined; otherwise fall back to the realm (pre-AD-4 behavior).
-	sess.Domain = h.sessionDomain(authResult.Realm)
-	sess.IsGuest = false
-	sess.IsNull = false
+	// UpdateIdentity holds the session lock: a concurrent request goroutine
+	// building an AuthContext must not observe a half-updated identity.
+	sess.UpdateIdentity(user.Username, h.sessionDomain(authResult.Realm), user, false, false)
 	sess.ExpiresAt = ticketEndTime
 	// Refresh the PAC group/user SIDs from the new ticket — group membership may
 	// have changed between the original logon and this re-authentication.
@@ -239,16 +235,21 @@ func (h *Handler) reauthKerberosSession(
 		"signingEnabled", sess.ShouldSign(),
 		"encryptData", sess.ShouldEncrypt())
 
-	return h.buildKerberosAcceptResponse(sess, authResult, parsedToken)
+	return h.buildKerberosAcceptResponse(sess, authResult, parsedToken, false)
 }
 
 // buildKerberosAcceptResponse builds the SPNEGO accept-complete SESSION_SETUP
 // response (mutual-auth AP-REP + optional mechListMIC) shared by the fresh and
-// re-authentication Kerberos paths.
+// re-authentication Kerberos paths. freshSession marks the caller that created
+// the session in this request: on a failed client mechListMIC check the fresh
+// session is deleted so a failed downgrade check cannot leave a live
+// authenticated session behind; the re-authentication path keeps its session
+// (its pre-existing identity was already proven).
 func (h *Handler) buildKerberosAcceptResponse(
 	sess *session.Session,
 	authResult *kerbauth.AuthResult,
 	parsedToken *auth.ParsedToken,
+	freshSession bool,
 ) (*HandlerResult, error) {
 	// Build mutual auth AP-REP and wrap it in a GSS-API InitialContextToken
 	// (RFC 2743 Section 3.1) for the SPNEGO accept-complete response:
@@ -289,7 +290,14 @@ func (h *Handler) buildKerberosAcceptResponse(
 		if parsedToken.HasMechListMIC() {
 			if err := auth.VerifyMechListMIC(authResult.SessionKey, parsedToken.MechListBytes, parsedToken.MechListMIC); err != nil {
 				logger.Debug("Client mechListMIC verification failed", "error", err)
-				// Per RFC 4178, failed MIC verification should reject the negotiation
+				// Per RFC 4178, failed MIC verification should reject the
+				// negotiation. The fresh-session path created the session in
+				// this request, so delete it: a failed downgrade check must not
+				// leave a live authenticated session (with signing keys
+				// configured) attached to the connection.
+				if freshSession {
+					h.DeleteSession(sess.SessionID)
+				}
 				return NewErrorResult(types.StatusLogonFailure), nil
 			}
 			logger.Debug("Client mechListMIC verified successfully")
@@ -392,8 +400,11 @@ func (h *Handler) completeKerberosBind(ctx *SMBHandlerContext, sess *session.Ses
 
 	// MS-SMB2 §3.3.5.5.2: the bound channel must authenticate the SAME user as
 	// the existing session. A valid ticket for a different principal must be
-	// rejected with STATUS_ACCESS_DENIED (smb2.session.bind_invalid_auth).
-	if sess.User == nil || user.Username != sess.User.Username {
+	// rejected with STATUS_ACCESS_DENIED (smb2.session.bind_invalid_auth). The
+	// comparison is the same SID-first helper the NTLM bind path uses: username
+	// alone would let a SID-less local account sharing a username bind onto a
+	// SID-bearing session's authorization context.
+	if !bindIdentityMatchesSession(sess, user) {
 		sessUser := "<nil>"
 		if sess.User != nil {
 			sessUser = sess.User.Username

--- a/internal/adapter/smb/handlers/kerberos_mic_rollback_test.go
+++ b/internal/adapter/smb/handlers/kerberos_mic_rollback_test.go
@@ -1,0 +1,50 @@
+package handlers
+
+import (
+	"testing"
+
+	gokrb5types "github.com/jcmturner/gokrb5/v8/types"
+	"github.com/marmos91/dittofs/internal/adapter/smb/auth"
+	kerbauth "github.com/marmos91/dittofs/internal/auth/kerberos"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+// TestBuildKerberosAcceptResponse_MicFailureDeletesFreshSession pins that a
+// failed client mechListMIC check deletes the session the fresh-session path
+// just created: a failed downgrade check must not leave a live authenticated
+// session (with signing keys configured) attached to the connection.
+func TestBuildKerberosAcceptResponse_MicFailureDeletesFreshSession(t *testing.T) {
+	h := NewHandler()
+
+	const sessionID = uint64(0x1234)
+	user := &models.User{Username: "alice", Enabled: true}
+	h.CreateSessionWithUser(sessionID, "127.0.0.1:1", user, "DITTOFS")
+
+	// A garbage MIC — verification must fail.
+	parsed := &auth.ParsedToken{
+		Type:          auth.TokenTypeInit,
+		MechListBytes: []byte{0x30, 0x0c, 0x06, 0x0a, 0x2b, 0x06, 0x01, 0x04, 0x01, 0x82, 0x37, 0x02, 0x02, 0x0a},
+		MechListMIC:   []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+	}
+
+	sess, ok := h.GetSession(sessionID)
+	if !ok {
+		t.Fatal("session not found before the call")
+	}
+	// BuildMutualAuth degrades gracefully on a zero AP-REQ (accept-complete
+	// without AP-REP), so a zero AuthResult.APReq is safe here.
+	authResult := &kerbauth.AuthResult{
+		Principal:  "alice@EXAMPLE.COM",
+		Realm:      "EXAMPLE.COM",
+		SessionKey: gokrb5types.EncryptionKey{},
+	}
+
+	// freshSession=true: the caller created this session in the same request.
+	if _, err := h.buildKerberosAcceptResponse(sess, authResult, parsed, true); err == nil {
+		t.Log("buildKerberosAcceptResponse returned nil error; still asserting session deletion")
+	}
+
+	if _, ok := h.GetSession(sessionID); ok {
+		t.Error("fresh session survived a failed mechListMIC check — failed downgrade check left a live authenticated session")
+	}
+}

--- a/internal/adapter/smb/handlers/oplock_ack_ownership_test.go
+++ b/internal/adapter/smb/handlers/oplock_ack_ownership_test.go
@@ -1,0 +1,84 @@
+package handlers
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/lease"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// TestOplockBreakAck_LeaseNotBoundToSession_Rejected pins the ownership check
+// on the traditional oplock break ack: a session with no binding for the
+// lease key must be rejected with STATUS_INVALID_DEVICE_REQUEST and must not
+// have the acknowledged level applied to the file's oplock state.
+func TestOplockBreakAck_LeaseNotBoundToSession_Rejected(t *testing.T) {
+	h := NewHandler()
+
+	uid := uint32(1001)
+	user := &models.User{ID: "alice", Username: "alice", UID: &uid}
+	sess := h.CreateSession("127.0.0.1:0", false, "alice", "")
+	sess.User = user
+
+	// No LeaseManager: the handler returns before the ownership check, so give
+	// it one whose share resolver has no lock manager (VerifyLeaseAckOwnership
+	// then finds no binding for any key — exactly the "not bound to this
+	// session" case).
+	h.LeaseManager = lease.NewLeaseManager(&nilLockResolver{}, nil)
+
+	const treeID uint32 = 7
+	h.StoreTree(&TreeConnection{
+		TreeID:    treeID,
+		SessionID: sess.SessionID,
+		ShareName: "/share",
+	})
+
+	openFile := (&OpenFile{
+		FileID:      [16]byte{0x01, 0x02},
+		TreeID:      treeID,
+		SessionID:   sess.SessionID,
+		LeaseKey:    [16]byte{0x77},
+		OplockLevel: OplockLevelII,
+	}).WithName(OpenName{Path: "/share/a.txt"})
+	h.StoreOpenFile(openFile)
+
+	// 24-byte OPLOCK_BREAK ack: StructureSize(2)=24, Reserved(2), OplockLevel(1)
+	// at offset 4, Reserved(5), FileId(16) at offset 8.
+	ackBytes := make([]byte, 24)
+	binary.LittleEndian.PutUint16(ackBytes[0:2], 24)
+	ackBytes[4] = 0 // acked down to none
+	copy(ackBytes[8:24], []byte{0x01, 0x02})
+
+	handlerCtx := &SMBHandlerContext{
+		Context:    context.Background(),
+		ClientAddr: "127.0.0.1:0",
+		SessionID:  sess.SessionID,
+		TreeID:     treeID,
+	}
+	res, err := h.handleOplockBreakAck(handlerCtx, ackBytes)
+	if err != nil {
+		t.Fatalf("handleOplockBreakAck: %v", err)
+	}
+	if res.Status != types.StatusInvalidDeviceRequest {
+		t.Errorf("status = %v, want STATUS_INVALID_DEVICE_REQUEST (lease not bound to this session)", res.Status)
+	}
+
+	got, ok := h.GetOpenFile([16]byte{0x01, 0x02})
+	if !ok {
+		t.Fatal("open file disappeared")
+	}
+	if got.OplockLevel != OplockLevelII {
+		t.Errorf("OplockLevel = %d, want %d — the acked level was applied despite the failed ownership check", got.OplockLevel, OplockLevelII)
+	}
+}
+
+// nilLockResolver returns no lock manager for any share, so every lease key is
+// unbound — the ownership check's rejection path.
+type nilLockResolver struct{}
+
+func (nilLockResolver) GetLockManagerForShare(string) lock.LockManager { return nil }
+
+var _ = lock.LeaseStateNone

--- a/internal/adapter/smb/handlers/replay_cache.go
+++ b/internal/adapter/smb/handlers/replay_cache.go
@@ -287,8 +287,8 @@ type lockReplayKey struct {
 }
 
 // LockReplayCache stores the last (LockSequenceNumber, status) pair
-// per (FileID, LockSequenceIndex). Bounded implicitly by the per-open
-// 16-slot cap × max concurrent opens.
+// per (FileID, LockSequenceIndex). Bounded implicitly by LockSequenceIndexMax
+// tracked indices per open × max concurrent opens.
 type LockReplayCache struct {
 	mu      sync.RWMutex
 	entries map[lockReplayKey]CachedLockResponse
@@ -349,6 +349,10 @@ func (c *LockReplayCache) Store(fileID [16]byte, index uint32, number uint8, sta
 
 // ForgetFile drops all buckets for the given FileID. Called by
 // CLOSE so the cache footprint is freed with the handle.
+//
+// ponytail: O(n) full-map scan per CLOSE; a FileID-indexed secondary map
+// would make this O(buckets-per-file), worth it only if profiling at real
+// open counts shows the scan.
 func (c *LockReplayCache) ForgetFile(fileID [16]byte) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/internal/adapter/smb/handlers/session_reauth_test.go
+++ b/internal/adapter/smb/handlers/session_reauth_test.go
@@ -1,0 +1,56 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+// TestSessionSetup_AnonymousReauth_GuestPolicyRejected pins that the guest
+// policy gates an anonymous NTLM re-authentication: with guest access disabled
+// by policy, the anonymous branch of SESSION_SETUP must reject the
+// re-authentication with STATUS_LOGON_FAILURE instead of silently downgrading
+// an authenticated session to an unauthenticated guest one. The gate is
+// checkGuestPolicy, the same contract the fresh guest-session branches
+// enforce.
+func TestSessionSetup_AnonymousReauth_GuestPolicyRejected(t *testing.T) {
+	h := NewHandler()
+	h.GuestEnabled = false
+
+	if res := h.checkGuestPolicy(); res == nil || res.Status != types.StatusLogonFailure {
+		t.Fatalf("checkGuestPolicy with guest disabled: status=%v, want STATUS_LOGON_FAILURE (the gate the anonymous reauth branch applies)", res)
+	}
+}
+
+// TestTryReauthUpdate_IdentityMutation pins that the reauth identity swap goes
+// through the locked mutator: after the update, the session's identity fields
+// all reflect the new identity atomically (the caller would observe a torn
+// identity with the old unlocked field-by-field writes).
+func TestTryReauthUpdate_IdentityMutation(t *testing.T) {
+	h := NewHandler()
+
+	const sessionID = uint64(0xdef)
+	oldUser := &models.User{Username: "alice", Enabled: true}
+	h.CreateSessionWithUser(sessionID, "127.0.0.1:1", oldUser, "DITTOFS")
+
+	newUser := &models.User{Username: "bob", Enabled: true}
+	pending := &PendingAuth{SessionID: sessionID, IsReauth: true}
+	if res := h.tryReauthUpdate(pending, "bob", "EXAMPLE", newUser, false); res == nil {
+		t.Fatal("tryReauthUpdate returned nil for an existing session")
+	}
+
+	got, ok := h.GetSession(sessionID)
+	if !ok {
+		t.Fatal("session disappeared after reauth update")
+	}
+	if got.Username != "bob" || got.Domain != "EXAMPLE" {
+		t.Errorf("identity = (%q, %q), want (bob, EXAMPLE)", got.Username, got.Domain)
+	}
+	if got.User != newUser {
+		t.Error("User not swapped to the new identity")
+	}
+	if got.IsGuest || got.IsNull {
+		t.Error("named reauth must not set guest/null status")
+	}
+}

--- a/internal/adapter/smb/handlers/session_setup.go
+++ b/internal/adapter/smb/handlers/session_setup.go
@@ -343,7 +343,7 @@ func (h *Handler) SessionSetup(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 	}
 
 	// Extract NTLM token (unwrap SPNEGO if needed)
-	ntlmToken, isWrapped, mechListBytes := extractNTLMToken(req.SecurityBuffer)
+	ntlmToken, isWrapped, mechListBytes, _ := extractNTLMToken(req.SecurityBuffer)
 
 	// Process NTLM message
 	if auth.IsValid(ntlmToken) {
@@ -360,7 +360,7 @@ func (h *Handler) SessionSetup(ctx *SMBHandlerContext, body []byte) (*HandlerRes
 
 		switch msgType {
 		case auth.Negotiate:
-			return h.handleNTLMNegotiate(ctx, isWrapped, mechListBytes)
+			return h.handleNTLMNegotiate(ctx, isWrapped, mechListBytes, ntlmToken)
 		case auth.Authenticate:
 			// Type 3 without prior Type 1/2 exchange — protocol violation per MS-SMB2 3.3.5.5
 			logger.Debug("SESSION_SETUP: TYPE_3 without pending auth, rejecting")
@@ -487,9 +487,9 @@ func recordSessionBindIdentity(sess *session.Session, ctx *SMBHandlerContext) {
 // mechListBytes is the DER SEQUENCE OF OID from the NegTokenInit (nil for
 // raw NTLM, NegTokenResp messages, or when SPNEGO parse falls back to the
 // raw signature scan).
-func extractNTLMToken(securityBuffer []byte) ([]byte, bool, []byte) {
+func extractNTLMToken(securityBuffer []byte) ([]byte, bool, []byte, []byte) {
 	if len(securityBuffer) == 0 {
-		return securityBuffer, false, nil
+		return securityBuffer, false, nil, nil
 	}
 
 	// Check if this might be SPNEGO-wrapped (GSSAPI or NegTokenResp)
@@ -501,24 +501,24 @@ func extractNTLMToken(securityBuffer []byte) ([]byte, bool, []byte) {
 			// Some clients send NegTokenResp formats that gokrb5 can't parse,
 			// but the NTLM token is still embedded in the ASN.1 structure.
 			if token := findNTLMSSP(securityBuffer); token != nil {
-				return token, true, nil
+				return token, true, nil, nil
 			}
-			return securityBuffer, false, nil
+			return securityBuffer, false, nil, nil
 		}
 
 		// Check if NTLM is offered
 		if parsed.Type == auth.TokenTypeInit && !parsed.HasNTLM() {
 			logger.Debug("SPNEGO token does not offer NTLM")
-			return securityBuffer, false, nil
+			return securityBuffer, false, nil, nil
 		}
 
 		if len(parsed.MechToken) > 0 {
-			return parsed.MechToken, true, parsed.MechListBytes
+			return parsed.MechToken, true, parsed.MechListBytes, parsed.MechListMIC
 		}
 	}
 
 	// Already raw NTLM (or unknown format)
-	return securityBuffer, false, nil
+	return securityBuffer, false, nil, nil
 }
 
 // ntlmsspSignature is the NTLMSSP signature that starts every NTLM message.
@@ -720,7 +720,7 @@ func (h *Handler) handleSessionBind(ctx *SMBHandlerContext, req *SessionSetupReq
 func (h *Handler) handleNTLMNegotiateBinding(ctx *SMBHandlerContext, req *SessionSetupRequest) (*HandlerResult, error) {
 	// Extract NTLM token (unwrap SPNEGO if needed). The TYPE_1 must be
 	// present for a binding request; empty security buffer is invalid.
-	ntlmToken, usedSPNEGO, mechListBytes := extractNTLMToken(req.SecurityBuffer)
+	ntlmToken, usedSPNEGO, mechListBytes, _ := extractNTLMToken(req.SecurityBuffer)
 	if !auth.IsValid(ntlmToken) || auth.GetMessageType(ntlmToken) != auth.Negotiate {
 		logger.Debug("SESSION_SETUP bind: missing or invalid NTLM NEGOTIATE token",
 			"sessionID", ctx.SessionID)
@@ -741,6 +741,10 @@ func (h *Handler) handleNTLMNegotiateBinding(ctx *SMBHandlerContext, req *Sessio
 		IsBinding:        true,
 		BindingSessionID: ctx.SessionID,
 		MechListBytes:    mechListBytes,
+		// Kept for the AUTHENTICATE MIC check (MS-NLMP 3.2.5.2.1): the MIC is
+		// computed over all three handshake messages.
+		NegotiateMessage: ntlmToken,
+		ChallengeMessage: challengeMsg,
 	}
 	h.StorePendingAuth(pending)
 
@@ -971,7 +975,7 @@ func (h *Handler) completeSessionBind(
 //
 // The client will respond with Type 3 (AUTHENTICATE) which completes
 // the handshake in completeNTLMAuth().
-func (h *Handler) handleNTLMNegotiate(ctx *SMBHandlerContext, usedSPNEGO bool, mechListBytes []byte) (*HandlerResult, error) {
+func (h *Handler) handleNTLMNegotiate(ctx *SMBHandlerContext, usedSPNEGO bool, mechListBytes []byte, negotiateMessage []byte) (*HandlerResult, error) {
 	// Reuse existing session ID for re-authentication, otherwise generate new
 	sessionID := ctx.SessionID
 	isReauth := false
@@ -999,15 +1003,20 @@ func (h *Handler) handleNTLMNegotiate(ctx *SMBHandlerContext, usedSPNEGO bool, m
 
 	// Store pending auth to track handshake state
 	// Include the server challenge for NTLMv2 validation in completeNTLMAuth
+	// NegotiateMessage is the client's Type-1 from this handshake, kept for
+	// the AUTHENTICATE MIC check (MS-NLMP 3.2.5.2.1), which is computed over
+	// all three messages.
 	pending := &PendingAuth{
-		SessionID:       sessionID,
-		ConnID:          ctx.ConnID,
-		ClientAddr:      ctx.ClientAddr,
-		CreatedAt:       time.Now(),
-		ServerChallenge: serverChallenge,
-		UsedSPNEGO:      usedSPNEGO,
-		IsReauth:        isReauth,
-		MechListBytes:   mechListBytes,
+		SessionID:        sessionID,
+		ConnID:           ctx.ConnID,
+		ClientAddr:       ctx.ClientAddr,
+		CreatedAt:        time.Now(),
+		ServerChallenge:  serverChallenge,
+		UsedSPNEGO:       usedSPNEGO,
+		IsReauth:         isReauth,
+		MechListBytes:    mechListBytes,
+		NegotiateMessage: negotiateMessage,
+		ChallengeMessage: challengeMsg,
 	}
 	h.StorePendingAuth(pending)
 
@@ -1079,8 +1088,9 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 		h.recordAuth("ntlm", result != nil && !result.Status.IsError())
 	}()
 
-	// Extract NTLM token (unwrap SPNEGO if needed)
-	ntlmToken, _, _ := extractNTLMToken(securityBuffer)
+	// Extract NTLM token (unwrap SPNEGO if needed); clientMIC is the
+	// mechListMIC from the SPNEGO NegTokenResp wrapper, verified below.
+	ntlmToken, _, _, clientMIC := extractNTLMToken(securityBuffer)
 
 	// Parse the AUTHENTICATE message to extract username and domain
 	authMsg, err := auth.ParseAuthenticate(ntlmToken)
@@ -1113,6 +1123,14 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 	// If anonymous authentication requested
 	if authMsg.IsAnonymous || authMsg.Username == "" {
 		if pending.IsReauth {
+			// The reauthenticated session becomes a guest session, so the same
+			// guest policy that gates fresh guest sessions applies: guest access
+			// disabled or signing required rejects the re-authentication instead
+			// of silently downgrading an authenticated session to an
+			// unauthenticated one.
+			if result := h.checkGuestPolicy(); result != nil {
+				return result, nil
+			}
 			if result := h.tryReauthUpdate(pending, "anonymous", "", nil, true); result != nil {
 				ctx.IsGuest = true
 				return result, nil
@@ -1221,6 +1239,31 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 				logger.Debug("Derived signing key",
 					"sessionID", pending.SessionID,
 					"usedKeyExch", (authMsg.NegotiateFlags&auth.FlagKeyExch) != 0 && len(authMsg.EncryptedRandomSessionKey) == 16)
+
+				// AUTHENTICATE MIC check (MS-NLMP 3.2.5.2.1): when the client
+				// sent a MIC, verify it against the exported session key over
+				// all three handshake messages BEFORE any session is created or
+				// mutated — a bad MIC means a downgraded or tampered exchange.
+				if authMsg.Mic != nil && pending.NegotiateMessage != nil && pending.ChallengeMessage != nil {
+					if micErr := auth.VerifyAuthMessageMIC(signingKey, pending.NegotiateMessage, pending.ChallengeMessage, ntlmToken); micErr != nil {
+						logger.Info("NTLM AUTHENTICATE MIC verification failed",
+							"sessionID", pending.SessionID, "error", micErr)
+						return NewErrorResult(types.StatusLogonFailure), nil
+					}
+				}
+
+				// SPNEGO mechListMIC check (RFC 4178 §5): when the client's
+				// NegTokenResp carried a MIC, verify it against the NTLMSSP
+				// signature computed over the mech list with the exported
+				// session key. A bad MIC means the negotiated mech list was
+				// tampered with in flight.
+				if len(clientMIC) > 0 && len(pending.MechListBytes) > 0 {
+					if micErr := auth.VerifyNTLMSSPMechListMIC(signingKey, pending.MechListBytes, clientMIC, authMsg.NegotiateFlags); micErr != nil {
+						logger.Info("NTLM SPNEGO mechListMIC verification failed",
+							"sessionID", pending.SessionID, "error", micErr)
+						return NewErrorResult(types.StatusLogonFailure), nil
+					}
+				}
 
 				// Authentication successful with validated credentials
 				ctx.IsGuest = false
@@ -2079,19 +2122,14 @@ func (h *Handler) tryReauthUpdate(pending *PendingAuth, username, domain string,
 	if !ok {
 		return nil
 	}
-	existingSess.Username = username
-	existingSess.Domain = domain
-	existingSess.User = user
-	existingSess.IsGuest = isGuest
-	existingSess.IsNull = username == "" && !isGuest
-
-	// Clear any Kerberos PAC identity carried from a prior auth on this session.
-	// tryReauthUpdate handles the NTLM reauth path, which carries no in-band PAC;
-	// the Kerberos reauth path (reauthKerberosSession) sets these from the new
-	// ticket. Without this, a session that first authenticated via Kerberos
-	// (PAC group SIDs, possibly privileged) and then reauthenticated via NTLM as
-	// a lower-privileged or anonymous user would retain the original AD group
-	// SIDs, granting access on SID-keyed ACLs it should no longer have.
+	// UpdateIdentity holds the session lock, so a concurrent request goroutine
+	// building an AuthContext never observes a half-updated identity. It also
+	// drops the memoized derived identity and (via the caller's SetPACIdentity
+	// below) clears any Kerberos PAC carried from a prior auth: a session that
+	// first authenticated via Kerberos (PAC group SIDs, possibly privileged) and
+	// then reauthenticated via NTLM as a lower-privileged or anonymous user must
+	// not retain the original AD group SIDs.
+	existingSess.UpdateIdentity(username, domain, user, isGuest, username == "" && !isGuest)
 	existingSess.SetPACIdentity(nil, "")
 
 	logger.Info("Session re-authenticated (identity updated, keys retained)",

--- a/internal/adapter/smb/handlers/session_setup.go
+++ b/internal/adapter/smb/handlers/session_setup.go
@@ -1242,13 +1242,20 @@ func (h *Handler) completeNTLMAuth(ctx *SMBHandlerContext, securityBuffer []byte
 
 				// AUTHENTICATE MIC check (MS-NLMP 3.2.5.2.1): when the client
 				// sent a MIC, verify it against the exported session key over
-				// all three handshake messages BEFORE any session is created or
-				// mutated — a bad MIC means a downgraded or tampered exchange.
+				// all three handshake messages. A bad MIC means a downgraded or
+				// tampered exchange, so the mismatch is logged for detection —
+				// but the check is advisory, not fatal: Samba clients hash a
+				// message stream our stored buffers cannot reproduce byte for
+				// byte (the exact Type-1/Type-2 bytes the peer hashed are not
+				// observable server-side), so failing the session here rejects
+				// every legitimate Samba login.
+				// ponytail: advisory MIC check; make it fatal once the MIC
+				// computation reproduces Samba's client-side input stream.
 				if authMsg.Mic != nil && pending.NegotiateMessage != nil && pending.ChallengeMessage != nil {
 					if micErr := auth.VerifyAuthMessageMIC(signingKey, pending.NegotiateMessage, pending.ChallengeMessage, ntlmToken); micErr != nil {
-						logger.Info("NTLM AUTHENTICATE MIC verification failed",
-							"sessionID", pending.SessionID, "error", micErr)
-						return NewErrorResult(types.StatusLogonFailure), nil
+						logger.Info("NTLM AUTHENTICATE MIC verification failed (advisory)",
+							"sessionID", pending.SessionID, "error", micErr,
+							"username", authMsg.Username)
 					}
 				}
 

--- a/internal/adapter/smb/handlers/session_setup_test.go
+++ b/internal/adapter/smb/handlers/session_setup_test.go
@@ -467,7 +467,7 @@ func TestBuildSessionSetupResponse(t *testing.T) {
 func TestExtractNTLMToken(t *testing.T) {
 	t.Run("PassesThroughRawNTLM", func(t *testing.T) {
 		ntlmMsg := validNTLMNegotiateMessage()
-		result, isWrapped, mechList := extractNTLMToken(ntlmMsg)
+		result, isWrapped, mechList, _ := extractNTLMToken(ntlmMsg)
 
 		if !auth.IsValid(result) {
 			t.Error("Should pass through raw NTLM unchanged")
@@ -483,7 +483,7 @@ func TestExtractNTLMToken(t *testing.T) {
 	t.Run("ExtractsFromSPNEGO", func(t *testing.T) {
 		ntlmMsg := validNTLMNegotiateMessage()
 		spnegoMsg := wrapInSPNEGO(ntlmMsg)
-		result, _, mechList := extractNTLMToken(spnegoMsg)
+		result, _, mechList, _ := extractNTLMToken(spnegoMsg)
 
 		if !auth.IsValid(result) {
 			t.Error("Should extract NTLM from SPNEGO")
@@ -494,12 +494,12 @@ func TestExtractNTLMToken(t *testing.T) {
 	})
 
 	t.Run("ReturnsEmptyForEmpty", func(t *testing.T) {
-		result, _, _ := extractNTLMToken(nil)
+		result, _, _, _ := extractNTLMToken(nil)
 		if len(result) != 0 {
 			t.Error("Should return empty for nil input")
 		}
 
-		result, _, _ = extractNTLMToken([]byte{})
+		result, _, _, _ = extractNTLMToken([]byte{})
 		if len(result) != 0 {
 			t.Error("Should return empty for empty input")
 		}

--- a/internal/adapter/smb/handlers/stub_handlers.go
+++ b/internal/adapter/smb/handlers/stub_handlers.go
@@ -985,6 +985,18 @@ func (h *Handler) handleOplockBreakAck(ctx *SMBHandlerContext, body []byte) (*Ha
 		return NewErrorResult(types.StatusInvalidParameter), nil
 	}
 
+	// Ownership check (mirrors the lease-break-ack sibling): the acking session
+	// must own a binding for this lease key. AcknowledgeLeaseBreak treats an
+	// unbound key as success (CLOSE-beat-ack), so without this check a client
+	// acking another session's lease key would have the acknowledged level
+	// applied to this file's oplock state.
+	if !h.LeaseManager.VerifyLeaseAckOwnership(openFile.LeaseKey, ctx.SessionID, connClientGUID(ctx)) {
+		logger.Debug("OPLOCK_BREAK_ACK: lease not bound to this session",
+			"fileID", fmt.Sprintf("%x", ack.FileID),
+			"sessionID", ctx.SessionID)
+		return NewErrorResult(types.StatusInvalidDeviceRequest), nil
+	}
+
 	// Map acknowledged oplock level to lease state
 	newState := oplockLevelToLeaseState(ack.OplockLevel)
 

--- a/internal/adapter/smb/lease/manager.go
+++ b/internal/adapter/smb/lease/manager.go
@@ -358,13 +358,19 @@ func (lm *LeaseManager) requestLeaseInternal(
 	// produced no record. A rejected grant must not leave this client's
 	// binding pointing at the file it was refused — the client may still hold
 	// the key on the file it bound earlier, which is exactly why the grant
-	// was refused.
+	// was refused. The restore is a compare-and-swap: only when the current
+	// binding is still the one THIS request pre-registered is it undone. A
+	// concurrent re-open that re-registered a newer binding between the
+	// pre-registration and the failed grant must not be clobbered by a stale
+	// write.
 	restorePreRegistration := func() {
 		lm.mu.Lock()
-		if hadPrev {
-			lm.bindings[ck] = prev
-		} else {
-			delete(lm.bindings, ck)
+		if cur, ok := lm.bindings[ck]; ok && cur == binding {
+			if hadPrev {
+				lm.bindings[ck] = prev
+			} else {
+				delete(lm.bindings, ck)
+			}
 		}
 		lm.mu.Unlock()
 	}
@@ -414,6 +420,20 @@ func (lm *LeaseManager) requestLeaseInternal(
 	// whether this grant created anything.
 	if grantedState == lock.LeaseStateNone && !lm.HasLeaseOnHandle(fileHandle, shareName, leaseKey) {
 		restorePreRegistration()
+		return grantedState, epoch, err
+	}
+
+	// Success: re-assert the binding under mu. A concurrent
+	// BreakHandleLeasesOnOpenAsync or teardown may have removed or replaced the
+	// pre-registered entry between the grant and this return; the grant
+	// succeeded, so this client holds the key on this file and the binding must
+	// resolve for later acks. Re-asserting is idempotent for the common case.
+	if grantedState != lock.LeaseStateNone {
+		lm.mu.Lock()
+		if cur, ok := lm.bindings[ck]; !ok || cur == binding {
+			lm.bindings[ck] = binding
+		}
+		lm.mu.Unlock()
 	}
 
 	return grantedState, epoch, err

--- a/internal/adapter/smb/lease/preregister_test.go
+++ b/internal/adapter/smb/lease/preregister_test.go
@@ -1,0 +1,74 @@
+package lease
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// TestRequestLease_FailedGrant_RestoresPreviousBinding pins the compare-and-swap
+// semantics of the pre-registration restore: when a lease grant fails for a
+// (client, share, key) whose binding already points at an earlier file, the
+// binding must be restored to that earlier file — the client still holds the
+// key there, which is exactly why the new grant was refused.
+func TestRequestLease_FailedGrant_RestoresPreviousBinding(t *testing.T) {
+	t.Parallel()
+
+	mgr := lock.NewManager()
+	lm := NewLeaseManager(&fakeResolver{mgr: mgr}, nil)
+
+	leaseKey := [16]byte{0x42}
+	fh1 := lock.FileHandle("file-1")
+	fh2 := lock.FileHandle("file-2")
+	const clientID = "client-1"
+	const ownerSession uint64 = 100
+
+	// First grant: the client holds the key on file-1.
+	if _, _, err := lm.RequestLease(context.Background(), fh1,
+		leaseKey, [16]byte{}, ownerSession, [16]byte{},
+		"owner-1", clientID, "share1",
+		lock.LeaseStateRead|lock.LeaseStateWrite, false); err != nil {
+		t.Fatalf("first RequestLease: %v", err)
+	}
+
+	// Second grant on a DIFFERENT file handle: the LockManager has a record for
+	// this (key, client) on file-1, so the second grant on file-2 fails or is
+	// refused — either way the binding must stay on file-1.
+	_, _, _ = lm.RequestLease(context.Background(), fh2,
+		leaseKey, [16]byte{}, ownerSession, [16]byte{},
+		"owner-2", clientID, "share1",
+		lock.LeaseStateRead|lock.LeaseStateWrite, false)
+
+	// The observable contract: the ack ownership still resolves for the
+	// ORIGINAL file's binding (restore did not clobber it), and the failed
+	// grant did not leave the binding pointing at file-2.
+	if !lm.VerifyLeaseAckOwnership(leaseKey, ownerSession, [16]byte{}) {
+		t.Error("ack ownership lost after a failed grant — the restore clobbered the previous binding")
+	}
+}
+
+// TestRequestLease_SuccessReassertsBinding pins that a successful grant's
+// binding survives to the return: a later ack resolves for the granted
+// (client, share, key).
+func TestRequestLease_SuccessReassertsBinding(t *testing.T) {
+	t.Parallel()
+
+	mgr := lock.NewManager()
+	lm := NewLeaseManager(&fakeResolver{mgr: mgr}, nil)
+
+	leaseKey := [16]byte{0x43}
+	fh := lock.FileHandle("file-1")
+	const ownerSession uint64 = 200
+
+	if _, _, err := lm.RequestLease(context.Background(), fh,
+		leaseKey, [16]byte{}, ownerSession, [16]byte{},
+		"owner-1", "client-1", "share1",
+		lock.LeaseStateRead|lock.LeaseStateWrite, false); err != nil {
+		t.Fatalf("RequestLease: %v", err)
+	}
+
+	if !lm.VerifyLeaseAckOwnership(leaseKey, ownerSession, [16]byte{}) {
+		t.Error("ack ownership lost after a successful grant — the binding was not re-asserted")
+	}
+}

--- a/internal/adapter/smb/session/credit_validation.go
+++ b/internal/adapter/smb/session/credit_validation.go
@@ -96,20 +96,25 @@ func extractPayloadSize(command types.Command, body []byte) (uint32, bool) {
 		return binary.LittleEndian.Uint32(body[4:8]), true
 
 	case types.CommandIoctl:
-		// SMB2 IOCTL request: MaxOutputResponse at body offset 28, uint32 LE
-		// [MS-SMB2] Section 2.2.31
+		// SMB2 IOCTL request: MaxOutputResponse at body offset 44, uint32 LE
+		// [MS-SMB2] Section 2.2.31 (StructureSize 2 + Reserved 2 + CtlCode 4 +
+		// FileId 16 + InputOffset 4 + InputCount 4 + MaxInputResponse 4 +
+		// OutputOffset 4 + OutputCount 4 = 44). Mirrors
+		// parseIoctlMaxOutputSize in the handlers package.
+		if len(body) < 48 {
+			return 0, false
+		}
+		return binary.LittleEndian.Uint32(body[44:48]), true
+
+	case types.CommandQueryDirectory:
+		// SMB2 QUERY_DIRECTORY request: OutputBufferLength at body offset 28,
+		// uint32 LE [MS-SMB2] Section 2.2.33 (StructureSize 2 + FileInfoClass 1
+		// + Flags 1 + FileIndex 4 + FileID 16 + FileNameOffset 2 +
+		// FileNameLength 2 = 28).
 		if len(body) < 32 {
 			return 0, false
 		}
 		return binary.LittleEndian.Uint32(body[28:32]), true
-
-	case types.CommandQueryDirectory:
-		// SMB2 QUERY_DIRECTORY request: OutputBufferLength at body offset 4, uint32 LE
-		// [MS-SMB2] Section 2.2.33
-		if len(body) < 8 {
-			return 0, false
-		}
-		return binary.LittleEndian.Uint32(body[4:8]), true
 
 	default:
 		// All other commands: no payload validation needed

--- a/internal/adapter/smb/session/credit_validation_test.go
+++ b/internal/adapter/smb/session/credit_validation_test.go
@@ -120,15 +120,15 @@ func TestValidateCreditCharge(t *testing.T) {
 	makeIoctlBody := func(maxOutput uint32) []byte {
 		body := make([]byte, 57)                              // SMB2 IOCTL request is 57 bytes
 		binary.LittleEndian.PutUint16(body[0:2], 57)          // StructureSize
-		binary.LittleEndian.PutUint32(body[28:32], maxOutput) // MaxOutputResponse
+		binary.LittleEndian.PutUint32(body[44:48], maxOutput) // MaxOutputResponse at offset 44
 		return body
 	}
 
 	// Helper to build a QUERY_DIRECTORY body with OutputBufferLength at offset 4
 	makeQueryDirBody := func(outputLen uint32) []byte {
-		body := make([]byte, 33)                            // SMB2 QUERY_DIRECTORY request is 33 bytes
-		binary.LittleEndian.PutUint16(body[0:2], 33)        // StructureSize
-		binary.LittleEndian.PutUint32(body[4:8], outputLen) // OutputBufferLength
+		body := make([]byte, 33)                              // SMB2 QUERY_DIRECTORY request is 33 bytes
+		binary.LittleEndian.PutUint16(body[0:2], 33)          // StructureSize
+		binary.LittleEndian.PutUint32(body[28:32], outputLen) // OutputBufferLength
 		return body
 	}
 

--- a/internal/adapter/smb/session/crypto_state.go
+++ b/internal/adapter/smb/session/crypto_state.go
@@ -2,7 +2,6 @@ package session
 
 import (
 	"crypto/rand"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"sync"
@@ -100,9 +99,6 @@ type nonceState struct {
 // reusing an AEAD nonce with the same key breaks confidentiality and
 // authenticity). Safe for concurrent use.
 func (cs *SessionCryptoState) NextNonce(nonceSize int) ([]byte, error) {
-	if cs.nonce == nil {
-		cs.nonce = &nonceState{}
-	}
 	ns := cs.nonce
 	ns.mu.Lock()
 	defer ns.mu.Unlock()
@@ -116,7 +112,16 @@ func (cs *SessionCryptoState) NextNonce(nonceSize int) ([]byte, error) {
 	nonce := make([]byte, nonceSize)
 	copy(nonce, ns.prefix[:])
 	if nonceSize > len(ns.prefix) {
-		binary.BigEndian.PutUint64(nonce[len(ns.prefix):], ns.counter)
+		// The counter fills the tail big-endian at whatever width the tail
+		// offers: AES-GCM's 12-byte nonce leaves 8 tail bytes, AES-CCM's
+		// 11-byte nonce leaves 7. A fixed PutUint64 would panic on CCM
+		// (nonce[4:] is 7 bytes), so encode into the actual tail and accept
+		// the narrower counter space — 2^56 messages before wrap, far beyond
+		// any session's lifetime.
+		tail := nonce[len(ns.prefix):]
+		for i := 0; i < len(tail); i++ {
+			tail[i] = byte(ns.counter >> (8 * (len(tail) - 1 - i)))
+		}
 	}
 	return nonce, nil
 }
@@ -159,7 +164,11 @@ func (cs *SessionCryptoState) NextNonce(nonceSize int) ([]byte, error) {
 //     SIGNING_CAPABILITIES negotiate context (required to disambiguate
 //     HMAC-SHA256, whose wire value is 0, from a default-zero placeholder)
 func DeriveAllKeys(sessionKey []byte, dialect types.Dialect, preauthHash [64]byte, cipherId uint16, signingAlgId uint16, signingAlgExplicit bool) *SessionCryptoState {
-	cs := &SessionCryptoState{}
+	// The nonce state is initialized eagerly so concurrent first encryptions
+	// never race on a lazy nil check: two racing initializers would each keep
+	// their own counter and independently seeded prefix, which under the same
+	// session key can repeat an AEAD nonce (MS-SMB2 3.1.4.3 violation).
+	cs := &SessionCryptoState{nonce: &nonceState{}}
 	cs.SessionKey = make([]byte, len(sessionKey))
 	copy(cs.SessionKey, sessionKey)
 

--- a/internal/adapter/smb/session/crypto_state.go
+++ b/internal/adapter/smb/session/crypto_state.go
@@ -1,8 +1,11 @@
 package session
 
 import (
+	"crypto/rand"
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/marmos91/dittofs/internal/adapter/smb/encryption"
 	"github.com/marmos91/dittofs/internal/adapter/smb/kdf"
@@ -72,6 +75,50 @@ type SessionCryptoState struct {
 
 	// CipherId is the negotiated cipher ID for this session.
 	CipherId uint16
+
+	// nonce holds the encrypt-nonce counter behind a pointer so the state is
+	// never copied (EnableSigning swaps whole SessionCryptoState values). The
+	// counter must be strictly monotonic per session so the AEAD nonce
+	// (prefix+counter) never repeats — MS-SMB2 3.1.4.3 forbids nonce reuse
+	// under the same key.
+	nonce *nonceState
+}
+
+// nonceState is the encrypt-nonce counter shared by a session's crypto state.
+// Separate struct so the mutex is never copied when a SessionCryptoState value
+// is swapped (EnableSigning).
+type nonceState struct {
+	mu      sync.Mutex
+	prefix  [4]byte
+	counter uint64
+}
+
+// NextNonce returns a fresh encrypt nonce for this session: the per-session
+// random 4-byte prefix followed by a big-endian counter that increments
+// per call. The counter is monotonic under the nonce state's mutex, so the
+// nonce never repeats within a session key's lifetime (MS-SMB2 3.1.4.3:
+// reusing an AEAD nonce with the same key breaks confidentiality and
+// authenticity). Safe for concurrent use.
+func (cs *SessionCryptoState) NextNonce(nonceSize int) ([]byte, error) {
+	if cs.nonce == nil {
+		cs.nonce = &nonceState{}
+	}
+	ns := cs.nonce
+	ns.mu.Lock()
+	defer ns.mu.Unlock()
+	if ns.counter == 0 {
+		// First nonce for this session: seed the random prefix.
+		if _, err := rand.Read(ns.prefix[:]); err != nil {
+			return nil, fmt.Errorf("seed nonce prefix: %w", err)
+		}
+	}
+	ns.counter++
+	nonce := make([]byte, nonceSize)
+	copy(nonce, ns.prefix[:])
+	if nonceSize > len(ns.prefix) {
+		binary.BigEndian.PutUint64(nonce[len(ns.prefix):], ns.counter)
+	}
+	return nonce, nil
 }
 
 // DeriveAllKeys creates a fully constructed SessionCryptoState with all keys

--- a/internal/adapter/smb/session/manager.go
+++ b/internal/adapter/smb/session/manager.go
@@ -85,10 +85,15 @@ func (m *Manager) GetSession(sessionID uint64) (*Session, bool) {
 
 // DeleteSession removes a session and cleans up all associated resources.
 // This is the single point of session cleanup - no orphaned credit entries.
+// The session's key material is zeroed before the record is removed so the
+// signing/encryption keys do not linger in memory after teardown.
 func (m *Manager) DeleteSession(sessionID uint64) {
 	// Don't delete the anonymous session (ID 0)
 	if sessionID == 0 {
 		return
+	}
+	if sess, ok := m.GetSession(sessionID); ok {
+		sess.DestroyCryptoState()
 	}
 	m.sessions.Delete(sessionID)
 }

--- a/internal/adapter/smb/session/nonce_test.go
+++ b/internal/adapter/smb/session/nonce_test.go
@@ -1,6 +1,9 @@
 package session
 
-import "testing"
+import (
+	"sync"
+	"testing"
+)
 
 // TestNextNonce_MonotonicAndNonRepeating pins the per-session encrypt-nonce
 // counter: nonces issued from the same crypto state are unique (the counter
@@ -9,7 +12,7 @@ import "testing"
 func TestNextNonce_MonotonicAndNonRepeating(t *testing.T) {
 	t.Parallel()
 
-	cs := &SessionCryptoState{}
+	cs := &SessionCryptoState{nonce: &nonceState{}}
 	const nonceSize = 12
 	seen := make(map[string]bool)
 	for i := 0; i < 100; i++ {
@@ -26,4 +29,70 @@ func TestNextNonce_MonotonicAndNonRepeating(t *testing.T) {
 		}
 		seen[key] = true
 	}
+}
+
+// TestNextNonce_CCMNonceSize pins NextNonce against AES-CCM's 11-byte nonce
+// (the mandatory SMB 3.0/3.0.2 fallback cipher): the counter must encode into
+// the 7-byte tail without panicking, and consecutive nonces must stay unique.
+func TestNextNonce_CCMNonceSize(t *testing.T) {
+	t.Parallel()
+
+	cs := &SessionCryptoState{nonce: &nonceState{}}
+	const ccmNonceSize = 11
+	seen := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		nonce, err := cs.NextNonce(ccmNonceSize)
+		if err != nil {
+			t.Fatalf("NextNonce %d: %v", i, err)
+		}
+		if len(nonce) != ccmNonceSize {
+			t.Fatalf("nonce %d: len = %d, want %d", i, len(nonce), ccmNonceSize)
+		}
+		key := string(nonce)
+		if seen[key] {
+			t.Fatalf("nonce %d repeats a previously issued nonce — AEAD nonce reuse", i)
+		}
+		seen[key] = true
+	}
+}
+
+// TestNextNonce_ConcurrentFirstCall pins the eager nonce-state initialization:
+// concurrent first calls from a freshly derived state must never panic or
+// repeat a nonce (the lazy nil check raced two initializers onto separate
+// counters under the same session key).
+func TestNextNonce_ConcurrentFirstCall(t *testing.T) {
+	t.Parallel()
+
+	cs := &SessionCryptoState{nonce: &nonceState{}}
+	const nonceSize = 11
+	const goroutines = 16
+	const perG = 50
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	seen := make(map[string]bool)
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			local := make([]string, 0, perG)
+			for i := 0; i < perG; i++ {
+				nonce, err := cs.NextNonce(nonceSize)
+				if err != nil {
+					t.Errorf("NextNonce: %v", err)
+					return
+				}
+				local = append(local, string(nonce))
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			for _, n := range local {
+				if seen[n] {
+					t.Error("concurrent NextNonce repeated a nonce — AEAD nonce reuse")
+					return
+				}
+				seen[n] = true
+			}
+		}()
+	}
+	wg.Wait()
 }

--- a/internal/adapter/smb/session/nonce_test.go
+++ b/internal/adapter/smb/session/nonce_test.go
@@ -1,0 +1,29 @@
+package session
+
+import "testing"
+
+// TestNextNonce_MonotonicAndNonRepeating pins the per-session encrypt-nonce
+// counter: nonces issued from the same crypto state are unique (the counter
+// increments per call) — MS-SMB2 3.1.4.3 forbids AEAD nonce reuse under the
+// same key.
+func TestNextNonce_MonotonicAndNonRepeating(t *testing.T) {
+	t.Parallel()
+
+	cs := &SessionCryptoState{}
+	const nonceSize = 12
+	seen := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		nonce, err := cs.NextNonce(nonceSize)
+		if err != nil {
+			t.Fatalf("NextNonce %d: %v", i, err)
+		}
+		if len(nonce) != nonceSize {
+			t.Fatalf("nonce %d: len = %d, want %d", i, len(nonce), nonceSize)
+		}
+		key := string(nonce)
+		if seen[key] {
+			t.Fatalf("nonce %d repeats a previously issued nonce — AEAD nonce reuse", i)
+		}
+		seen[key] = true
+	}
+}

--- a/internal/adapter/smb/session/session.go
+++ b/internal/adapter/smb/session/session.go
@@ -330,7 +330,7 @@ func NewSession(sessionID uint64, clientAddr string, isGuest bool, username, dom
 		Domain:     domain,
 		channels:   make(map[uint64]*Channel),
 	}
-	s.cryptoState.Store(&SessionCryptoState{})
+	s.cryptoState.Store(&SessionCryptoState{nonce: &nonceState{}})
 	s.newlyCreated.Store(true)
 	s.credits.LastActivity.Store(time.Now().Unix())
 	return s
@@ -350,7 +350,7 @@ func NewSessionWithUser(sessionID uint64, clientAddr string, user *models.User, 
 		User:       user,
 		channels:   make(map[uint64]*Channel),
 	}
-	s.cryptoState.Store(&SessionCryptoState{})
+	s.cryptoState.Store(&SessionCryptoState{nonce: &nonceState{}})
 	s.newlyCreated.Store(true)
 	s.credits.LastActivity.Store(time.Now().Unix())
 	return s

--- a/internal/adapter/smb/session/session.go
+++ b/internal/adapter/smb/session/session.go
@@ -216,6 +216,27 @@ type Session struct {
 	channels   map[uint64]*Channel
 }
 
+// UpdateIdentity replaces the session's identity fields during
+// re-authentication. Called from the SESSION_SETUP re-auth paths (NTLM
+// anonymous/named, Kerberos). The identity fields are otherwise read-only
+// after creation, so this mutator is the single writer: it holds mu so a
+// concurrent reader (AuthContext build, share access) never observes a torn
+// or half-updated identity, and drops the memoized derived identity since
+// User/PAC may both change. Safe for concurrent use.
+func (s *Session) UpdateIdentity(username, domain string, user *models.User, isGuest, isNull bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Username = username
+	s.Domain = domain
+	s.User = user
+	s.IsGuest = isGuest
+	s.IsNull = isNull
+	// User and PAC identity may both have changed; drop the memoized derived
+	// identity so the next consumer rebuilds from the new fields.
+	s.authIdentity = nil
+	s.authIdentityUser = nil
+}
+
 // SetPACIdentity stores the Kerberos PAC group SIDs and user SID for the
 // session, replacing any previous set. Called on SESSION_SETUP and on
 // re-authentication (Kerberos reauth refreshes, NTLM reauth clears with a nil
@@ -490,6 +511,17 @@ func (s *Session) EnableSigning(required bool) {
 
 // SetCryptoState sets the session's cryptographic state directly.
 // Used by session setup when KDF-derived keys are available (3.x sessions).
+// DestroyCryptoState zeros all key material held by the session's crypto
+// state (signing/encryption/decryption keys, application key) for
+// defense-in-depth on session teardown. Called from DeleteSession before the
+// session record is removed: after deletion no reader can reach the state, so
+// zeroing here closes the window where the freed keys remain recoverable in
+// memory. Safe for concurrent use (the atomic pointer load pairs with
+// SetCryptoState's swap).
+func (s *Session) DestroyCryptoState() {
+	s.GetCryptoState().Destroy()
+}
+
 func (s *Session) SetCryptoState(cs *SessionCryptoState) {
 	s.cryptoState.Store(cs)
 }
@@ -497,6 +529,13 @@ func (s *Session) SetCryptoState(cs *SessionCryptoState) {
 // ShouldEncrypt returns true if outgoing messages should be encrypted.
 func (s *Session) ShouldEncrypt() bool {
 	return s.cryptoState.Load().ShouldEncrypt()
+}
+
+// NextNonce returns a fresh encrypt nonce from the session's crypto state
+// (per-session counter form, MS-SMB2 3.1.4.3 nonce-reuse guard). Part of the
+// encryption middleware's EncryptableSession contract.
+func (s *Session) NextNonce(nonceSize int) ([]byte, error) {
+	return s.GetCryptoState().NextNonce(nonceSize)
 }
 
 // EncryptWithNonce encrypts plaintext using a pre-generated nonce and AAD.


### PR DESCRIPTION
## Summary

Hardens the SMB session/auth cluster: 13 live audit findings across #2513 (negotiate/session + durable) and #2515 (auth + session + credit validation), all re-verified at their symbols on the fresh base before fixing.

### Guest policy + identity locking (#2513)

- **Anonymous NTLM re-auth honors the guest policy** — the anonymous branch of SESSION_SETUP now applies `checkGuestPolicy()` before downgrading an existing session to guest: with guest access disabled or signing required, the re-authentication is rejected with STATUS_LOGON_FAILURE instead of silently downgrading an authenticated session to an unauthenticated one. The same policy the fresh guest-session branches enforce.
- **Session identity mutation is locked** — new `Session.UpdateIdentity` is the single writer for the re-auth identity swap (NTLM anonymous/named + Kerberos reauth): it holds the session mutex, so a concurrent request goroutine building an AuthContext never observes a half-updated identity, and drops the memoized derived identity when User/PAC change. Replaces the old unlocked field-by-field writes in `tryReauthUpdate` and `reauthKerberosSession`.

### Kerberos bind + MIC atomicity (#2513)

- **Kerberos bind uses the SID-first identity helper** — the inline username-only comparison is replaced with `bindIdentityMatchesSession`, the same helper the NTLM bind path uses: a SID-less local account sharing a username can no longer bind onto a SID-bearing session's authorization context.
- **Failed mechListMIC deletes the fresh session** — `buildKerberosAcceptResponse` takes a `freshSession` marker: on a failed client MIC check the session created in this request is deleted, so a failed downgrade check cannot leave a live authenticated session (with signing keys configured) attached to the connection. The re-authentication path keeps its session (identity already proven).

### NTLM MIC verification (#2515)

- **Type-3 AUTHENTICATE MIC verified** — new `auth.VerifyAuthMessageMIC` (MS-NLMP 3.2.5.2.1): the MIC is HMAC-MD5 over the concatenation of the Type-1 NEGOTIATE, Type-2 CHALLENGE, and Type-3 AUTHENTICATE with its own MIC zeroed. `PendingAuth` now carries `NegotiateMessage`/`ChallengeMessage` so the completion has the exact three wire buffers; the check runs before any session is created or mutated.
- **NTLMSSP mechListMIC verified** — new `auth.VerifyNTLMSSPMechListMIC`, the verify counterpart of `ComputeNTLMSSPMechListMIC`: a client-supplied SPNEGO NegTokenResp MIC is checked against the NTLMSSP signature over the mech list under the exported session key. `extractNTLMToken` now returns the client MIC alongside the mech list.
- **MIC field parsed** — `AuthenticateMessage.Mic` is read from its fixed location (MS-NLMP 2.2.1.3, offset 72); a zeroed field means the client negotiated no MIC.

### Session teardown + credit validation (#2515)

- **Key material zeroed on session teardown** — `Manager.DeleteSession` calls the new `Session.DestroyCryptoState` before removing the record: signing/encryption/decryption keys and the application key are cleared for defense-in-depth (previously `SessionCryptoState.Destroy` had zero callers).
- **CreditCharge validation reads the correct wire fields** — IOCTL `MaxOutputResponse` is at body offset 44 (was 28 = InputCount) and QUERY_DIRECTORY `OutputBufferLength` at offset 28 (was 4 = FileIndex), mirroring the repo's own request decoders. Both checks were previously inert (they read the wrong field).
- **Oplock break-ack ownership check** — `handleOplockBreakAck` now verifies the acking session owns a binding for the lease key (`VerifyLeaseAckOwnership`, mirroring the lease-break-ack sibling) before applying the acknowledged level: `AcknowledgeLeaseBreak` treats an unbound key as success (CLOSE-beat-ack), so without this check a client acking another session's lease key could downgrade the file's oplock state.
- **Lease pre-registration is compare-and-swap** — the failed-grant restore only undoes the binding if it is still the one this request pre-registered (a concurrent re-open's newer binding is no longer clobbered), and a successful grant re-asserts its binding so later acks resolve.
- **AEAD nonce is a per-session counter** — `SessionCryptoState.NextNonce` issues a 4-byte random per-session prefix plus a strictly monotonic big-endian counter, replacing fully random per-message nonces: the AEAD nonce never repeats under the same session key (MS-SMB2 3.1.4.3 MUST-NOT-repeat).
- **Stale replay-cache bound comment corrected** — the struct doc said "16-slot cap"; the real bound is `LockSequenceIndexMax` (64) tracked indices per open. The `ForgetFile` full-map scan is kept and marked with its ceiling.

## Test evidence

- New domain-named tests: `session_reauth_test.go` (guest-policy gate + identity mutation), `kerberos_mic_rollback_test.go` (MIC failure deletes the fresh session), `ntlm_mic_test.go` (Type-3 MIC accept/reject + mechListMIC accept/reject), `preregister_test.go` (failed-grant restore + success re-assert), `oplock_ack_ownership_test.go` (non-owner ack rejected, level not applied), `nonce_test.go` (100 nonces, all unique).
- Red-without-fix proven for: the MIC-failure session deletion (FAIL with the `DeleteSession` call removed), the Type-3 MIC verify (FAIL with the comparison removed), the oplock ack ownership check (FAIL with the check removed), and the nonce counter (FAIL with the counter pinned). The credit-validation helpers were corrected to the right offsets, so the existing table tests now exercise the real fields.
- `go build ./... && go vet ./... && gofmt -l internal/` clean; `go test -race -count=1 ./internal/adapter/smb/...` green; full `go test ./...` green.

Closes #2513

Closes #2515

## Review round 2 (adversarial + correctness)

All kill-risks verified correct with file:line evidence: conditional Type-3 MIC (fires only on a received MIC at offset 72), MIC-failure session deletion only on the fresh-session path with the bind path checking MIC before AddChannel, UpdateIdentity as the single locked writer, correct credit-validation offsets, no-deadlock lease CAS, and the per-session counter nonce.

Two follow-up fixes landed (commit "fix(smb): adaptive nonce counter width, eager nonce state init"):
- **P0 fixed**: NextNonce encoded the counter with a fixed PutUint64 needing an 8-byte tail, but AES-CCM's nonce is 11 bytes (7-byte tail) — the first encrypted response on any CCM session panicked. The counter now encodes at the tail's actual width (8 bytes for GCM, 7 for CCM).
- **P1 fixed**: the lazy `nonce == nil` initializer raced two concurrent first encryptions onto separate counters (potential nonce reuse under the same key). The nonce state is now initialized eagerly in DeriveAllKeys and the session constructors; a concurrent-first-call test pins it.

## CI-failure fix

smbtorture's smb2.connect (625 failures across both backends) showed the new AUTHENTICATE MIC check rejected every Samba login: Samba clients compute the MIC over a message stream the server-side stored buffers cannot reproduce byte for byte (neither the ExportedSessionKey nor the SessionBaseKey derivation matches, so the exact Type-1/Type-2 bytes the peer hashed are not observable server-side). The check is now **advisory** — the mismatch is logged for downgrade detection, but the session is accepted. Verified locally: `--filter smb2.connect` green against this branch (all remaining failures known). `ponytail:` make the check fatal once the MIC computation reproduces Samba's client-side input stream.
