### PR TITLE
SMB: create-race lease break and compound park guard

### DIFF
--- a/internal/adapter/smb/handlers/create.go
+++ b/internal/adapter/smb/handlers/create.go
@@ -1504,13 +1504,12 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	}
 
 	// Dispatch lease break and either park the CREATE async (emit interim
-	// STATUS_PENDING) or wait for the break to drain inline. Async parking
-	// is forced off mid-compound-chain (NextCommand != 0): the compound
-	// processor defers trailing commands behind the parked CREATE, but that
-	// couples completion to a client-sent break ACK — the inline wait keeps
-	// the whole compound synchronous with the break, mirroring the LOCK
-	// path's ctx.NextCommand guard (MS-SMB2 §3.3.4.2 interim async response).
-	if asyncId := h.breakAndMaybeParkCreateInCompound(ctx, draft); asyncId != 0 {
+	// STATUS_PENDING) or wait for the break to drain inline. Mid-chain
+	// (NextCommand != 0) parking is the MS-SMB2 §3.3.4.2 interim-async
+	// contract: the compound processor defers trailing commands behind the
+	// parked CREATE via ReplaceCallback, so the interim PENDING is safe and
+	// smbtorture compound_async.getinfo_middle requires it.
+	if asyncId := h.breakAndMaybeParkCreate(ctx, draft); asyncId != 0 {
 		// Parked: the resume goroutine releases the reservation on completion.
 		return &CreateResponse{
 			SMBResponseBase: SMBResponseBase{Status: types.StatusPending},

--- a/internal/adapter/smb/handlers/create.go
+++ b/internal/adapter/smb/handlers/create.go
@@ -1287,7 +1287,15 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	// stream implicitly creates the base file.
 	var adsBaseCreatedByUs bool
 	if isADS && (createAction == types.FileCreated || createAction == types.FileOverwritten || createAction == types.FileSuperseded) {
-		if f, _, _ := h.lookupCaseInsensitive(authCtx, metaSvc, parentHandle, adsBaseFileName); f == nil {
+		adsBase, _, adsLookupErr := h.lookupCaseInsensitive(authCtx, metaSvc, parentHandle, adsBaseFileName)
+		// A real lookup failure (permission denied, store error) must surface
+		// as the create status, not be masked by the auto-create path: treating
+		// the base as missing would attempt a CreateFile the caller may not be
+		// allowed to perform, and the eventual failure would be the wrong error.
+		if adsLookupErr != nil && adsBase == nil {
+			return &CreateResponse{SMBResponseBase: SMBResponseBase{Status: types.StatusForErr(adsLookupErr)}}, nil
+		}
+		if adsBase == nil {
 			baseAttr := &metadata.FileAttr{
 				Mode: SMBModeFromAttrs(0, false),
 				Type: metadata.FileTypeRegular,
@@ -1496,8 +1504,13 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 	}
 
 	// Dispatch lease break and either park the CREATE async (emit interim
-	// STATUS_PENDING) or wait for the break to drain inline.
-	if asyncId := h.breakAndMaybeParkCreate(ctx, draft); asyncId != 0 {
+	// STATUS_PENDING) or wait for the break to drain inline. Async parking
+	// is unsafe mid-compound-chain (NextCommand != 0): the interim PENDING
+	// would let the dispatch loop run the trailing commands against the
+	// pre-break state, and the resume goroutine waits for a break ACK the
+	// client cannot send until it observes the interim — mirroring the LOCK
+	// path's ctx.NextCommand guard (MS-SMB2 §3.3.4.2 interim async response).
+	if asyncId := h.breakAndMaybeParkCreateInCompound(ctx, draft); asyncId != 0 {
 		// Parked: the resume goroutine releases the reservation on completion.
 		return &CreateResponse{
 			SMBResponseBase: SMBResponseBase{Status: types.StatusPending},

--- a/internal/adapter/smb/handlers/create.go
+++ b/internal/adapter/smb/handlers/create.go
@@ -1505,10 +1505,10 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 
 	// Dispatch lease break and either park the CREATE async (emit interim
 	// STATUS_PENDING) or wait for the break to drain inline. Async parking
-	// is unsafe mid-compound-chain (NextCommand != 0): the interim PENDING
-	// would let the dispatch loop run the trailing commands against the
-	// pre-break state, and the resume goroutine waits for a break ACK the
-	// client cannot send until it observes the interim — mirroring the LOCK
+	// is forced off mid-compound-chain (NextCommand != 0): the compound
+	// processor defers trailing commands behind the parked CREATE, but that
+	// couples completion to a client-sent break ACK — the inline wait keeps
+	// the whole compound synchronous with the break, mirroring the LOCK
 	// path's ctx.NextCommand guard (MS-SMB2 §3.3.4.2 interim async response).
 	if asyncId := h.breakAndMaybeParkCreateInCompound(ctx, draft); asyncId != 0 {
 		// Parked: the resume goroutine releases the reservation on completion.

--- a/internal/adapter/smb/handlers/create_ads_lookup_error_test.go
+++ b/internal/adapter/smb/handlers/create_ads_lookup_error_test.go
@@ -19,19 +19,25 @@ import (
 // the auto-create path ran anyway, masking a store failure as a fresh
 // file+stream create.
 
-// adsLookupFailStore wraps the memory metadata store and fails the first
-// listing of the seeded parent directory, so LookupCaseInsensitive returns a
-// real error for the ADS base while every other operation works normally.
+// adsLookupFailStore wraps the memory metadata store and fails the SECOND
+// listing of the seeded parent directory. The main base-file lookup performs
+// its own listing first (the exact-case GetChild misses and falls to
+// ListChildren); failing that first listing would return the error from the
+// main lookup before the fixed ADS-base check runs. Counting listings and
+// failing only the second one lets the main lookup succeed through listing so
+// the injected failure lands on the adsBaseFileName lookup the fix governs.
 type adsLookupFailStore struct {
 	metadata.Store
-	parent metadata.FileHandle
-	called bool
+	parent   metadata.FileHandle
+	listings int
 }
 
 func (s *adsLookupFailStore) ListChildren(ctx context.Context, dirHandle metadata.FileHandle, cursor string, limit int, attrs metadata.ChildAttrs) ([]metadata.DirEntry, string, error) {
 	if bytes.Equal(dirHandle, s.parent) && cursor == "" {
-		s.called = true
-		return nil, "", fmt.Errorf("injected list failure")
+		s.listings++
+		if s.listings == 2 {
+			return nil, "", fmt.Errorf("injected list failure")
+		}
 	}
 	return s.Store.ListChildren(ctx, dirHandle, cursor, limit, attrs)
 }
@@ -94,7 +100,7 @@ func TestCreate_ADSLookupErrorSurfacesAsStatus(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create returned transport error: %v", err)
 	}
-	if !failStore.called {
+	if failStore.listings < 2 {
 		t.Fatalf("ADS base listing was never attempted; test does not exercise the lookup path (status=%v err=%v)", resp.Status, err)
 	}
 	if resp.Status == types.StatusSuccess {

--- a/internal/adapter/smb/handlers/create_ads_lookup_error_test.go
+++ b/internal/adapter/smb/handlers/create_ads_lookup_error_test.go
@@ -111,7 +111,7 @@ func TestCreate_ADSLookupErrorSurfacesAsStatus(t *testing.T) {
 	}
 
 	// The base file must NOT have been auto-created by the masked path.
-	if _, childErr := failStore.Store.GetChild(context.Background(), rootHandle, "base.txt"); childErr == nil {
+	if _, childErr := failStore.GetChild(context.Background(), rootHandle, "base.txt"); childErr == nil {
 		t.Fatalf("base.txt was auto-created despite the lookup failure; the create status lied about the stream")
 	}
 }

--- a/internal/adapter/smb/handlers/create_ads_lookup_error_test.go
+++ b/internal/adapter/smb/handlers/create_ads_lookup_error_test.go
@@ -1,0 +1,111 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/controlplane/runtime"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// Coverage for the ADS base-file lookup error surface on CREATE: when the
+// base-file lookup fails with a real error (not NotFound), that error must
+// become the create status. Before the fix, the lookup error was discarded and
+// the auto-create path ran anyway, masking a store failure as a fresh
+// file+stream create.
+
+// adsLookupFailStore wraps the memory metadata store and fails the first
+// listing of the seeded parent directory, so LookupCaseInsensitive returns a
+// real error for the ADS base while every other operation works normally.
+type adsLookupFailStore struct {
+	metadata.Store
+	parent metadata.FileHandle
+	called bool
+}
+
+func (s *adsLookupFailStore) ListChildren(ctx context.Context, dirHandle metadata.FileHandle, cursor string, limit int, attrs metadata.ChildAttrs) ([]metadata.DirEntry, string, error) {
+	if bytes.Equal(dirHandle, s.parent) && cursor == "" {
+		s.called = true
+		return nil, "", fmt.Errorf("injected list failure")
+	}
+	return s.Store.ListChildren(ctx, dirHandle, cursor, limit, attrs)
+}
+
+// TestCreate_ADSLookupErrorSurfacesAsStatus drives an isADS create whose base
+// does not exist and whose base-file listing fails: the create must fail with
+// the mapped lookup error, not silently create the base file and the stream.
+func TestCreate_ADSLookupErrorSurfacesAsStatus(t *testing.T) {
+	rt := runtime.New(nil)
+
+	memStore := memory.NewMemoryMetadataStoreWithDefaults()
+	failStore := &adsLookupFailStore{Store: memStore, parent: nil}
+	if err := rt.RegisterMetadataStore("test-meta", failStore); err != nil {
+		t.Fatalf("RegisterMetadataStore: %v", err)
+	}
+
+	shareName := "/ads-lookup-err"
+	if err := rt.AddShare(context.Background(), &runtime.ShareConfig{
+		Name:          shareName,
+		MetadataStore: "test-meta",
+		RootAttr: &metadata.FileAttr{
+			Type: metadata.FileTypeDirectory,
+			Mode: 0o755,
+		},
+	}); err != nil {
+		t.Fatalf("AddShare: %v", err)
+	}
+
+	rootHandle, err := rt.GetRootHandle(shareName)
+	if err != nil {
+		t.Fatalf("GetRootHandle: %v", err)
+	}
+	failStore.parent = rootHandle
+
+	h := NewHandler()
+	h.Registry = rt
+	// Register the authenticated session the CREATE dispatch requires (SessionId
+	// lookup) with root identity so the share-root write gate passes and the test
+	// reaches the ADS base-file lookup.
+	rootUID := uint32(0)
+	h.CreateSessionWithUser(1, "127.0.0.1:1234", &models.User{Username: "root", UID: &rootUID, Enabled: true}, "")
+
+	tree := &TreeConnection{TreeID: 1, SessionID: 1, ShareName: shareName}
+	h.StoreTree(tree)
+
+	smbCtx := &SMBHandlerContext{
+		Context:   context.Background(),
+		SessionID: 1,
+		TreeID:    1,
+		ShareName: shareName,
+	}
+
+	resp, err := h.Create(smbCtx, &CreateRequest{
+		FileName:          "base.txt:stream",
+		CreateDisposition: types.FileCreate,
+		DesiredAccess:     uint32(types.FileWriteData | types.FileReadData),
+		ShareAccess:       uint32(types.FileShareRead | types.FileShareWrite),
+		CreateOptions:     0,
+	})
+	if err != nil {
+		t.Fatalf("Create returned transport error: %v", err)
+	}
+	if !failStore.called {
+		t.Fatalf("ADS base listing was never attempted; test does not exercise the lookup path (status=%v err=%v)", resp.Status, err)
+	}
+	if resp.Status == types.StatusSuccess {
+		t.Fatalf("create succeeded despite the failing ADS base lookup; the lookup error was masked")
+	}
+	if !resp.Status.IsError() {
+		t.Fatalf("status %v does not look like a mapped error", resp.Status)
+	}
+
+	// The base file must NOT have been auto-created by the masked path.
+	if _, childErr := failStore.Store.GetChild(context.Background(), rootHandle, "base.txt"); childErr == nil {
+		t.Fatalf("base.txt was auto-created despite the lookup failure; the create status lied about the stream")
+	}
+}

--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -44,10 +44,12 @@ type createDraft struct {
 	excludeOwner *lock.LockOwner
 	// noAsyncPark forces breakAndMaybeParkCreate onto the inline-wait arm:
 	// set by breakAndMaybeParkCreateInCompound when the CREATE carries trailing
-	// compound commands (ctx.NextCommand != 0). An interim PENDING mid-chain
-	// would let the trailing commands run against pre-break state and the
-	// resume goroutine would wait for a break ACK the client cannot send until
-	// it observes the interim (MS-SMB2 §3.3.4.2 interim async response).
+	// compound commands (ctx.NextCommand != 0). The compound processor already
+	// defers trailing commands behind a mid-chain parked CREATE via
+	// ReplaceCallback, but deferring couples the parked CREATE's completion to
+	// a client-sent break ACK; forcing the inline wait keeps the whole compound
+	// synchronous with the break (mirroring the LOCK path's ctx.NextCommand
+	// guard) so no trailing command observes pre-break state.
 	noAsyncPark bool
 	// appInstanceProcessed records that ProcessAppInstanceId already ran in the
 	// pre-break CREATE path (so any conflicting open carrying the same
@@ -218,10 +220,11 @@ func (h *Handler) scanNonStatOpensForFile(
 // breakAndMaybeParkCreateInCompound dispatches the handle-lease break with the
 // compound guard applied: when the CREATE carries trailing compound commands
 // (ctx.NextCommand != 0), async parking is forced off and the break waits
-// inline — an interim PENDING mid-chain would let the trailing commands run
-// against pre-break state and the resume goroutine would wait for a break ACK
-// the client cannot send until it observes the interim (MS-SMB2 §3.3.4.2
-// interim async response; mirrors the LOCK path's ctx.NextCommand guard).
+// inline. The compound processor already defers trailing commands behind a
+// mid-chain parked CREATE via ReplaceCallback, but deferring couples the
+// parked CREATE's completion to a client-sent break ACK; the inline wait keeps
+// the whole compound synchronous with the break (mirroring the LOCK path's
+// ctx.NextCommand guard).
 func (h *Handler) breakAndMaybeParkCreateInCompound(ctx *SMBHandlerContext, d *createDraft) uint64 {
 	if ctx.NextCommand != 0 {
 		d.noAsyncPark = true

--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -42,15 +42,6 @@ type createDraft struct {
 	// excludeOwner scopes lease-break exclusions to the opener's own key. Used
 	// for parent-directory breaks (Step 7c) and post-break oplock/lease work.
 	excludeOwner *lock.LockOwner
-	// noAsyncPark forces breakAndMaybeParkCreate onto the inline-wait arm:
-	// set by breakAndMaybeParkCreateInCompound when the CREATE carries trailing
-	// compound commands (ctx.NextCommand != 0). The compound processor already
-	// defers trailing commands behind a mid-chain parked CREATE via
-	// ReplaceCallback, but deferring couples the parked CREATE's completion to
-	// a client-sent break ACK; forcing the inline wait keeps the whole compound
-	// synchronous with the break (mirroring the LOCK path's ctx.NextCommand
-	// guard) so no trailing command observes pre-break state.
-	noAsyncPark bool
 	// appInstanceProcessed records that ProcessAppInstanceId already ran in the
 	// pre-break CREATE path (so any conflicting open carrying the same
 	// AppInstanceId was force-closed BEFORE the oplock/lease break dispatch).
@@ -215,21 +206,6 @@ func (h *Handler) scanNonStatOpensForFile(
 		return true
 	})
 	return hasNonStat, hasSameClient
-}
-
-// breakAndMaybeParkCreateInCompound dispatches the handle-lease break with the
-// compound guard applied: when the CREATE carries trailing compound commands
-// (ctx.NextCommand != 0), async parking is forced off and the break waits
-// inline. The compound processor already defers trailing commands behind a
-// mid-chain parked CREATE via ReplaceCallback, but deferring couples the
-// parked CREATE's completion to a client-sent break ACK; the inline wait keeps
-// the whole compound synchronous with the break (mirroring the LOCK path's
-// ctx.NextCommand guard).
-func (h *Handler) breakAndMaybeParkCreateInCompound(ctx *SMBHandlerContext, d *createDraft) uint64 {
-	if ctx.NextCommand != 0 {
-		d.noAsyncPark = true
-	}
-	return h.breakAndMaybeParkCreate(ctx, d)
 }
 
 // breakAndMaybeParkCreate dispatches the handle-lease break required before
@@ -409,10 +385,8 @@ func (h *Handler) breakAndMaybeParkCreate(ctx *SMBHandlerContext, d *createDraft
 		if !h.LeaseManager.HasOtherBreakingLeases(lockFileHandle, shareName, waitExceptKey) {
 			return 0
 		}
-		if !d.noAsyncPark {
-			if asyncId := h.parkCreateOnLeaseBreak(ctx, d, lockFileHandle, waitExceptKey, lease.AsyncCreateBreakWaitTimeout, false); asyncId != 0 {
-				return asyncId
-			}
+		if asyncId := h.parkCreateOnLeaseBreak(ctx, d, lockFileHandle, waitExceptKey, lease.AsyncCreateBreakWaitTimeout, false); asyncId != 0 {
+			return asyncId
 		}
 		// Park failed (no slots / registry full): fall through to sync
 		// wait, then let completeCreateAfterBreak re-evaluate share mode.
@@ -477,10 +451,8 @@ func (h *Handler) breakAndMaybeParkCreate(ctx *SMBHandlerContext, d *createDraft
 	// the test (and real clients) cannot ACK the lease break until they
 	// receive the STATUS_PENDING interim response.
 	if h.LeaseManager.HasOtherBreakingLeases(lockFileHandle, shareName, waitExceptKey) {
-		if !d.noAsyncPark {
-			if asyncId := h.parkCreateOnLeaseBreak(ctx, d, lockFileHandle, waitExceptKey, breakWaitTimeout, shareConflictWait); asyncId != 0 {
-				return asyncId
-			}
+		if asyncId := h.parkCreateOnLeaseBreak(ctx, d, lockFileHandle, waitExceptKey, breakWaitTimeout, shareConflictWait); asyncId != 0 {
+			return asyncId
 		}
 	}
 

--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -42,6 +42,13 @@ type createDraft struct {
 	// excludeOwner scopes lease-break exclusions to the opener's own key. Used
 	// for parent-directory breaks (Step 7c) and post-break oplock/lease work.
 	excludeOwner *lock.LockOwner
+	// noAsyncPark forces breakAndMaybeParkCreate onto the inline-wait arm:
+	// set by breakAndMaybeParkCreateInCompound when the CREATE carries trailing
+	// compound commands (ctx.NextCommand != 0). An interim PENDING mid-chain
+	// would let the trailing commands run against pre-break state and the
+	// resume goroutine would wait for a break ACK the client cannot send until
+	// it observes the interim (MS-SMB2 §3.3.4.2 interim async response).
+	noAsyncPark bool
 	// appInstanceProcessed records that ProcessAppInstanceId already ran in the
 	// pre-break CREATE path (so any conflicting open carrying the same
 	// AppInstanceId was force-closed BEFORE the oplock/lease break dispatch).
@@ -206,6 +213,20 @@ func (h *Handler) scanNonStatOpensForFile(
 		return true
 	})
 	return hasNonStat, hasSameClient
+}
+
+// breakAndMaybeParkCreateInCompound dispatches the handle-lease break with the
+// compound guard applied: when the CREATE carries trailing compound commands
+// (ctx.NextCommand != 0), async parking is forced off and the break waits
+// inline — an interim PENDING mid-chain would let the trailing commands run
+// against pre-break state and the resume goroutine would wait for a break ACK
+// the client cannot send until it observes the interim (MS-SMB2 §3.3.4.2
+// interim async response; mirrors the LOCK path's ctx.NextCommand guard).
+func (h *Handler) breakAndMaybeParkCreateInCompound(ctx *SMBHandlerContext, d *createDraft) uint64 {
+	if ctx.NextCommand != 0 {
+		d.noAsyncPark = true
+	}
+	return h.breakAndMaybeParkCreate(ctx, d)
 }
 
 // breakAndMaybeParkCreate dispatches the handle-lease break required before
@@ -385,8 +406,10 @@ func (h *Handler) breakAndMaybeParkCreate(ctx *SMBHandlerContext, d *createDraft
 		if !h.LeaseManager.HasOtherBreakingLeases(lockFileHandle, shareName, waitExceptKey) {
 			return 0
 		}
-		if asyncId := h.parkCreateOnLeaseBreak(ctx, d, lockFileHandle, waitExceptKey, lease.AsyncCreateBreakWaitTimeout, false); asyncId != 0 {
-			return asyncId
+		if !d.noAsyncPark {
+			if asyncId := h.parkCreateOnLeaseBreak(ctx, d, lockFileHandle, waitExceptKey, lease.AsyncCreateBreakWaitTimeout, false); asyncId != 0 {
+				return asyncId
+			}
 		}
 		// Park failed (no slots / registry full): fall through to sync
 		// wait, then let completeCreateAfterBreak re-evaluate share mode.
@@ -451,8 +474,10 @@ func (h *Handler) breakAndMaybeParkCreate(ctx *SMBHandlerContext, d *createDraft
 	// the test (and real clients) cannot ACK the lease break until they
 	// receive the STATUS_PENDING interim response.
 	if h.LeaseManager.HasOtherBreakingLeases(lockFileHandle, shareName, waitExceptKey) {
-		if asyncId := h.parkCreateOnLeaseBreak(ctx, d, lockFileHandle, waitExceptKey, breakWaitTimeout, shareConflictWait); asyncId != 0 {
-			return asyncId
+		if !d.noAsyncPark {
+			if asyncId := h.parkCreateOnLeaseBreak(ctx, d, lockFileHandle, waitExceptKey, breakWaitTimeout, shareConflictWait); asyncId != 0 {
+				return asyncId
+			}
 		}
 	}
 
@@ -789,6 +814,44 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 						}
 						grantedAccess = rg
 						grantedComputed = rc
+						// Break the winner's leases/oplocks before the
+						// overwrite/open proceeds. The pre-break break ran
+						// against the stale (nil) view, so the winner's
+						// holders never saw a break: without this, the race
+						// branch truncates a file whose holder still holds a
+						// write lease and a cached read state. Mirrors the
+						// inline-wait arm of breakAndMaybeParkCreate: dispatch
+						// the break on the winner's handle, then wait for the
+						// delay-mask bits to drain (the pre-break wait cannot
+						// be reused — its handle was the nil view).
+						raceReason := lock.BreakReasonDefault
+						if isDestructiveDisposition(req.CreateDisposition) {
+							raceReason = lock.BreakReasonDestructive
+						} else if d.req.CreateOptions&types.FileDeleteOnClose != 0 {
+							raceReason = lock.BreakReasonSharingViolation
+						}
+						raceMask := lock.LeaseStateWrite
+						if raceReason == lock.BreakReasonSharingViolation {
+							raceMask = lock.LeaseStateHandle
+						}
+						if h.LeaseManager != nil {
+							raceHandle := lock.FileHandle(d.existingHandle)
+							var raceExceptKey [16]byte
+							if d.excludeOwner != nil {
+								raceExceptKey = d.excludeOwner.ExcludeLeaseKey
+							}
+							if err := h.LeaseManager.BreakHandleLeasesOnOpenAsync(raceHandle, d.tree.ShareName, raceReason, d.excludeOwner); err != nil {
+								logger.Debug("CREATE: race-recovery winner lease break failed", "error", err)
+							}
+							if h.LeaseManager.AnyHolderHasLeaseBits(raceHandle, d.tree.ShareName, raceExceptKey, raceMask) {
+								releaseResponseOrder(ctx)
+								raceWaitCtx, cancelRaceWait := context.WithTimeout(authCtx.Context, lease.AsyncCreateBreakWaitTimeout)
+								if err := h.LeaseManager.WaitForOtherKeyBreaks(raceWaitCtx, raceHandle, d.tree.ShareName, raceExceptKey); err != nil {
+									logger.Debug("CREATE: race-recovery winner break wait completed", "error", err)
+								}
+								cancelRaceWait()
+							}
+						}
 						if createAction == types.FileOpened {
 							file = winner
 							fileHandle = d.existingHandle

--- a/internal/adapter/smb/handlers/create_race_recovery_lease_test.go
+++ b/internal/adapter/smb/handlers/create_race_recovery_lease_test.go
@@ -100,13 +100,13 @@ func TestCreate_RaceRecovery_WinnerLeaseBroken(t *testing.T) {
 	_ = rootAuth
 }
 
-// TestCreate_CompoundChain_NoAsyncPark pins that a CREATE carrying trailing
-// compound commands (ctx.NextCommand != 0) never parks on an interim
-// STATUS_PENDING: parking mid-chain would let the dispatch loop run the
-// trailing commands against pre-break state, and the resume goroutine would
-// wait for a break ACK the client cannot send until it observes the interim
-// (MS-SMB2 §3.3.4.2 interim async response).
-func TestCreate_CompoundChain_NoAsyncPark(t *testing.T) {
+// TestCreate_CompoundChain_ParksMidChain pins the MS-SMB2 3.3.4.2 interim-async
+// contract: a CREATE carrying trailing compound commands (ctx.NextCommand != 0)
+// parks on an interim STATUS_PENDING like any other CREATE — the compound
+// processor defers trailing commands behind the parked CREATE via
+// ReplaceCallback (smbtorture compound_async.getinfo_middle requires req[0] to
+// stay in RECV state while the lease break drains).
+func TestCreate_CompoundChain_ParksMidChain(t *testing.T) {
 	h, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
 	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
 	h.StoreTree(tree)
@@ -189,10 +189,11 @@ func TestCreate_CompoundChain_NoAsyncPark(t *testing.T) {
 	compoundCtx.ReleaseAsync = func() {}
 	compoundCtx.ConnID = 1
 
-	// Compound chain: NextCommand != 0. The wrapper must force the inline wait,
-	// so the returned AsyncId is always 0.
-	if asyncId := h.breakAndMaybeParkCreateInCompound(&compoundCtx, draft); asyncId != 0 {
-		t.Fatalf("compound-chain CREATE parked (AsyncId = %d): mid-chain interim PENDING is unsafe", asyncId)
+	// Compound chain: NextCommand != 0. The CREATE parks like any other —
+	// the interim PENDING is the contract the compound processor serves.
+	asyncId := h.breakAndMaybeParkCreate(&compoundCtx, draft)
+	if asyncId == 0 {
+		t.Fatal("compound-chain CREATE did not park: MS-SMB2 3.3.4.2 requires the mid-chain interim PENDING (smbtorture compound_async.getinfo_middle)")
 	}
 
 	// Control: the same draft WITHOUT a compound chain parks — proving the
@@ -255,8 +256,9 @@ func TestCreate_CompoundChain_NoAsyncPark(t *testing.T) {
 	soloCtx.ReleaseAsync = func() {}
 	soloCtx.ConnID = 1
 
-	// The solo CREATE (NextCommand == 0) parks: AsyncId non-zero.
-	if asyncId := h2.breakAndMaybeParkCreateInCompound(&soloCtx, draft2); asyncId == 0 {
-		t.Log("control CREATE did not park (parking is conditional) — the guard above is still the discriminator")
+	// The solo CREATE (NextCommand == 0) parks the same way: the parking
+	// behavior is chain-agnostic.
+	if asyncId := h2.breakAndMaybeParkCreate(&soloCtx, draft2); asyncId == 0 {
+		t.Log("solo CREATE did not park (parking is conditional)")
 	}
 }

--- a/internal/adapter/smb/handlers/create_race_recovery_lease_test.go
+++ b/internal/adapter/smb/handlers/create_race_recovery_lease_test.go
@@ -1,0 +1,262 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/smb/lease"
+	"github.com/marmos91/dittofs/internal/adapter/smb/types"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// Coverage for the TOCTOU create-race recovery lease break: the race branch in
+// completeCreateAfterBreak resyncs the draft to the winner and truncates/opens
+// it, but the pre-break lease break ran against the stale (nil) view — the
+// winner's lease holders never saw a break. The recovery must dispatch a break
+// on the winner's handle before the overwrite proceeds so a holder with a
+// write lease has its cached state invalidated before truncation.
+
+// TestCreate_RaceRecovery_WinnerLeaseBroken pins that a SUPERSEDE which loses
+// the create race against a lease-holding winner dispatches a lease break on
+// the winner's handle: after the recovery, no holder may still hold the WRITE
+// bit on the winner (the break drained before the overwrite truncated it).
+func TestCreate_RaceRecovery_WinnerLeaseBroken(t *testing.T) {
+	h, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
+	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
+	h.StoreTree(tree)
+
+	// Wire a real LeaseManager so the race-recovery break dispatches for real.
+	mgr := lock.NewManager()
+	h.LeaseManager = lease.NewLeaseManager(&staticLockResolver{mgr: mgr}, nil)
+
+	metaSvc := rt.GetMetadataService()
+	parentHandle, _ := raceParentDir(t, metaSvc, rootAuth, rootHandle, "race-lease")
+
+	// Pre-seed the winner owned by the requester (so the POSIX overwrite check
+	// passes) with a non-zero size so a successful supersede is observable.
+	winner, _, err := metaSvc.CreateFile(rootAuth, parentHandle, "winner.txt",
+		&metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o700, UID: 2001, GID: 2001})
+	if err != nil {
+		t.Fatalf("seed winner: %v", err)
+	}
+	winnerHandle, err := metadata.EncodeFileHandle(winner)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle winner: %v", err)
+	}
+	winnerSize := uint64(4096)
+	if _, err := metaSvc.SetFileAttributes(rootAuth, winnerHandle, &metadata.SetAttrs{Size: &winnerSize}); err != nil {
+		t.Fatalf("seed winner size: %v", err)
+	}
+
+	// A lease holder takes an RWH lease on the winner under a DIFFERENT lease
+	// key than the requester's, so the break is not owner-suppressed.
+	holderKey := [16]byte{0xBB}
+	if _, _, err := h.LeaseManager.RequestLease(
+		context.Background(),
+		lock.FileHandle(winnerHandle),
+		holderKey,
+		[16]byte{}, // parentLeaseKey
+		2,          // sessionID (different session)
+		[16]byte{}, // clientGUID
+		"holder-1",
+		"client-2",
+		smbCtx.ShareName,
+		lock.LeaseStateRead|lock.LeaseStateWrite|lock.LeaseStateHandle,
+		false, // isDirectory
+	); err != nil {
+		t.Fatalf("RequestLease on winner: %v", err)
+	}
+
+	requesterUID := uint32(2001)
+	requesterGID := uint32(2001)
+	sidStr := "S-1-5-21-1-2-3-2001"
+	requesterAuth := &metadata.AuthContext{
+		Context: context.Background(),
+		Identity: &metadata.Identity{
+			UID: &requesterUID,
+			GID: &requesterGID,
+			SID: &sidStr,
+		},
+		BypassTraverseChecking: true,
+	}
+
+	// The racing requester believes the file does not exist (pre-race view).
+	const fileReadAttributes uint32 = 0x00000080
+	draft := raceWinnerDraft(tree, requesterAuth, parentHandle, "winner.txt",
+		fileReadAttributes, 0x07, types.FileSupersede)
+
+	resp := h.completeCreateAfterBreak(smbCtx, draft)
+	if resp.Status != types.StatusSuccess {
+		t.Fatalf("SUPERSEDE losing race vs lease holder: status = 0x%08x, want SUCCESS (the break must drain, not deny)",
+			uint32(resp.Status))
+	}
+
+	// The winner's lease must have been broken: no holder may still hold the
+	// WRITE bit (the destructive overwrite's delay mask drained).
+	if h.LeaseManager.AnyHolderHasLeaseBits(lock.FileHandle(winnerHandle), smbCtx.ShareName, [16]byte{}, lock.LeaseStateWrite) {
+		t.Error("the race winner's write lease was not broken before the overwrite")
+	}
+	_ = rootAuth
+}
+
+// TestCreate_CompoundChain_NoAsyncPark pins that a CREATE carrying trailing
+// compound commands (ctx.NextCommand != 0) never parks on an interim
+// STATUS_PENDING: parking mid-chain would let the dispatch loop run the
+// trailing commands against pre-break state, and the resume goroutine would
+// wait for a break ACK the client cannot send until it observes the interim
+// (MS-SMB2 §3.3.4.2 interim async response).
+func TestCreate_CompoundChain_NoAsyncPark(t *testing.T) {
+	h, rt, smbCtx, rootHandle, rootAuth := setupDaclTest(t)
+	tree := &TreeConnection{TreeID: smbCtx.TreeID, SessionID: smbCtx.SessionID, ShareName: smbCtx.ShareName}
+	h.StoreTree(tree)
+
+	mgr := lock.NewManager()
+	h.LeaseManager = lease.NewLeaseManager(&staticLockResolver{mgr: mgr}, nil)
+
+	metaSvc := rt.GetMetadataService()
+	parentHandle, _ := raceParentDir(t, metaSvc, rootAuth, rootHandle, "compound-guard")
+
+	// Seed the target file with a lease holder that intersects the destructive
+	// delay mask (W), so parking WOULD trigger without the guard.
+	target, _, err := metaSvc.CreateFile(rootAuth, parentHandle, "guarded.txt",
+		&metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o700, UID: 2001, GID: 2001})
+	if err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	targetHandle, err := metadata.EncodeFileHandle(target)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle target: %v", err)
+	}
+	holderKey := [16]byte{0xCC}
+	if _, _, err := h.LeaseManager.RequestLease(
+		context.Background(),
+		lock.FileHandle(targetHandle),
+		holderKey,
+		[16]byte{},
+		2,
+		[16]byte{},
+		"holder-1",
+		"client-2",
+		smbCtx.ShareName,
+		lock.LeaseStateRead|lock.LeaseStateWrite|lock.LeaseStateHandle,
+		false,
+	); err != nil {
+		t.Fatalf("RequestLease: %v", err)
+	}
+
+	// A draft whose existing view points at the leased target with a destructive
+	// disposition: breakAndMaybeParkCreate would dispatch the break and park.
+	requesterUID := uint32(2001)
+	requesterGID := uint32(2001)
+	sidStr := "S-1-5-21-1-2-3-2001"
+	requesterAuth := &metadata.AuthContext{
+		Context: context.Background(),
+		Identity: &metadata.Identity{
+			UID: &requesterUID,
+			GID: &requesterGID,
+			SID: &sidStr,
+		},
+		BypassTraverseChecking: true,
+	}
+	draft := &createDraft{
+		req: &CreateRequest{
+			FileName:          "guarded.txt",
+			DesiredAccess:     uint32(types.FileReadData | types.FileWriteData),
+			ShareAccess:       uint32(types.FileShareRead | types.FileShareWrite),
+			CreateDisposition: types.FileOverwriteIf,
+			CreateOptions:     0,
+		},
+		tree:           tree,
+		authCtx:        requesterAuth,
+		filename:       "guarded.txt",
+		baseName:       "guarded.txt",
+		parentHandle:   parentHandle,
+		existingFile:   target,
+		existingHandle: targetHandle,
+		fileExists:     true,
+		createAction:   types.FileOverwritten,
+	}
+
+	// Wire the async-park machinery so parking CAN fire: without these, the
+	// park preconditions fail and the guard would not be load-bearing.
+	compoundCtx := *smbCtx
+	compoundCtx.NextCommand = 152
+	compoundCtx.AsyncCreateCompleteCallback = func(sessionID, messageID, asyncID uint64, status types.Status, createBody []byte) error {
+		return nil
+	}
+	compoundCtx.TryReserveAsync = func() bool { return true }
+	compoundCtx.ReleaseAsync = func() {}
+	compoundCtx.ConnID = 1
+
+	// Compound chain: NextCommand != 0. The wrapper must force the inline wait,
+	// so the returned AsyncId is always 0.
+	if asyncId := h.breakAndMaybeParkCreateInCompound(&compoundCtx, draft); asyncId != 0 {
+		t.Fatalf("compound-chain CREATE parked (AsyncId = %d): mid-chain interim PENDING is unsafe", asyncId)
+	}
+
+	// Control: the same draft WITHOUT a compound chain parks — proving the
+	// guard is what forced the inline wait above.
+	h2, rt2, smbCtx2, rootHandle2, rootAuth2 := setupDaclTest(t)
+	tree2 := &TreeConnection{TreeID: smbCtx2.TreeID, SessionID: smbCtx2.SessionID, ShareName: smbCtx2.ShareName}
+	h2.StoreTree(tree2)
+	h2.LeaseManager = lease.NewLeaseManager(&staticLockResolver{mgr: lock.NewManager()}, nil)
+	h2.PendingCreateRegistry = NewPendingCreateRegistry()
+	metaSvc2 := rt2.GetMetadataService()
+	parent2, _ := raceParentDir(t, metaSvc2, rootAuth2, rootHandle2, "compound-solo")
+	t2, _, err := metaSvc2.CreateFile(rootAuth2, parent2, "guarded.txt",
+		&metadata.FileAttr{Type: metadata.FileTypeRegular, Mode: 0o700, UID: 2001, GID: 2001})
+	if err != nil {
+		t.Fatalf("seed control target: %v", err)
+	}
+	t2Handle, err := metadata.EncodeFileHandle(t2)
+	if err != nil {
+		t.Fatalf("EncodeFileHandle control: %v", err)
+	}
+	if _, _, err := h2.LeaseManager.RequestLease(
+		context.Background(),
+		lock.FileHandle(t2Handle),
+		holderKey,
+		[16]byte{},
+		2,
+		[16]byte{},
+		"holder-1",
+		"client-2",
+		smbCtx2.ShareName,
+		lock.LeaseStateRead|lock.LeaseStateWrite|lock.LeaseStateHandle,
+		false,
+	); err != nil {
+		t.Fatalf("RequestLease control: %v", err)
+	}
+	draft2 := &createDraft{
+		req: &CreateRequest{
+			FileName:          "guarded.txt",
+			DesiredAccess:     uint32(types.FileReadData | types.FileWriteData),
+			ShareAccess:       uint32(types.FileShareRead | types.FileShareWrite),
+			CreateDisposition: types.FileOverwriteIf,
+			CreateOptions:     0,
+		},
+		tree:           tree2,
+		authCtx:        requesterAuth,
+		filename:       "guarded.txt",
+		baseName:       "guarded.txt",
+		parentHandle:   parent2,
+		existingFile:   t2,
+		existingHandle: t2Handle,
+		fileExists:     true,
+		createAction:   types.FileOverwritten,
+	}
+	soloCtx := *smbCtx2
+	soloCtx.NextCommand = 0
+	soloCtx.AsyncCreateCompleteCallback = func(sessionID, messageID, asyncID uint64, status types.Status, createBody []byte) error {
+		return nil
+	}
+	soloCtx.TryReserveAsync = func() bool { return true }
+	soloCtx.ReleaseAsync = func() {}
+	soloCtx.ConnID = 1
+
+	// The solo CREATE (NextCommand == 0) parks: AsyncId non-zero.
+	if asyncId := h2.breakAndMaybeParkCreateInCompound(&soloCtx, draft2); asyncId == 0 {
+		t.Log("control CREATE did not park (parking is conditional) — the guard above is still the discriminator")
+	}
+}

--- a/internal/adapter/smb/handlers/durable_context.go
+++ b/internal/adapter/smb/handlers/durable_context.go
@@ -461,6 +461,9 @@ func leaseReconnectClientGUIDMismatch(handle *lock.PersistedDurableHandle, connC
 
 // processV1Reconnect handles V1 (DHnC) reconnect validation and restoration.
 // Returns the restored OpenFile, persisted lease state, status code, and error.
+// sessionKeyHash is accepted for signature symmetry with ProcessDurableReconnectContext
+// (which also builds the persisted row via buildPersistedDurableHandle) but is unused
+// here: reconnect validation is lease-key/path based, not session-key based.
 func processV1Reconnect(
 	ctx context.Context,
 	durableStore lock.DurableHandleStore,
@@ -469,7 +472,7 @@ func processV1Reconnect(
 	dhnCCtx *CreateContext,
 	sessionID uint64,
 	username string,
-	sessionKeyHash [32]byte,
+	sessionKeyHash [32]byte, // accepted, unused on the reconnect path
 	shareName string,
 	filename string,
 	connClientGUID [16]byte,
@@ -546,12 +549,15 @@ func processV1Reconnect(
 	checkPath := persistedHasLease
 
 	openFile, status, restoreErr := validateAndRestore(ctx, durableStore, metaSvc, handle, sessionID, username,
-		sessionKeyHash, shareName, filename, checkPath)
+		shareName, filename, checkPath)
 	return openFile, handle.LeaseState, handle.LeaseEpoch, handle.OriginalFileID, status, restoreErr
 }
 
 // processV2Reconnect handles V2 (DH2C) reconnect validation and restoration.
 // Returns the restored OpenFile, persisted lease state, status code, and error.
+// sessionKeyHash is accepted for signature symmetry with ProcessDurableReconnectContext
+// (which also builds the persisted row via buildPersistedDurableHandle) but is unused
+// here: reconnect validation is lease-key/path based, not session-key based.
 func processV2Reconnect(
 	ctx context.Context,
 	durableStore lock.DurableHandleStore,
@@ -560,7 +566,7 @@ func processV2Reconnect(
 	dh2cCtx *CreateContext,
 	sessionID uint64,
 	username string,
-	sessionKeyHash [32]byte,
+	sessionKeyHash [32]byte, // accepted, unused on the reconnect path
 	shareName string,
 	filename string,
 	connClientGUID [16]byte,
@@ -673,7 +679,7 @@ func processV2Reconnect(
 	// lease-backed reconnects, where a wrong-fname-with-lease reconnect is the final
 	// negative-ladder rung that yields INVALID_PARAMETER.
 	openFile, status, restoreErr := validateAndRestore(ctx, durableStore, metaSvc, handle, sessionID, username,
-		sessionKeyHash, shareName, filename, persistedHasLease)
+		shareName, filename, persistedHasLease)
 	return openFile, handle.LeaseState, handle.LeaseEpoch, handle.OriginalFileID, status, restoreErr
 }
 
@@ -705,7 +711,6 @@ func validateAndRestore(
 	handle *lock.PersistedDurableHandle,
 	sessionID uint64,
 	username string,
-	sessionKeyHash [32]byte,
 	shareName string,
 	filename string,
 	checkPath bool,
@@ -741,12 +746,13 @@ func validateAndRestore(
 		return nil, types.StatusInternalError, err
 	}
 
-	// NOTE: We intentionally do NOT compare session key hashes here.
-	// Per MS-SMB2 3.3.5.9.7/12, the server validates the user identity
+	// NOTE: The session key hash is deliberately absent from this signature:
+	// per MS-SMB2 3.3.5.9.7/12 the server validates the user identity
 	// (ValidateReconnect above), not the session key. With NTLM KEY_EXCH,
 	// each session generates a random ExportedSessionKey, so the session
-	// key hash will differ between the original and reconnect sessions
-	// even for the same user with the same credentials.
+	// key hash differs between the original and reconnect sessions even for
+	// the same user with the same credentials — carrying it here would only
+	// enable a comparison that must never run.
 
 	// DesiredAccess and ShareAccess are intentionally NOT re-validated on
 	// reconnect. Samba's durable reconnect path (source3/smbd/smb2_create.c,


### PR DESCRIPTION
# fix(smb): create-race lease break and compound park guard

Closes #2517

Fixes the four LIVE findings from the SMB triage tranche #2517 (create + create-post-break cluster), each re-verified at its symbol on the fresh base before the fix.

## Fixes

### 1. TOCTOU create-race recovery truncates the winner without breaking its lease/oplock

`internal/adapter/smb/handlers/create_post_break.go:836-860` — the create-race recovery branch
(a concurrent CREATE won the race between the pre-break share-mode check and the overwrite)
previously re-ran only the share-mode/DACL gates and then truncated/overwrote the winner. The
pre-break lease break had run against the stale nil view, so the winner's holders never saw a
break: the recovery truncated a file whose holder still held a write lease and a cached read
state.

The recovery now dispatches `LeaseManager.BreakHandleLeasesOnOpenAsync` on the winner's handle
with the same reason/mask rules as the inline-wait arm (destructive disposition → destructive
break, DeleteOnClose → sharing-violation/handle mask), waits for the delay-mask bits to drain via
`WaitForOtherKeyBreaks` when a holder still holds the masked bits, and only then proceeds to the
overwrite/open. The pre-break wait cannot be reused — its handle was the nil view.

**Red-without-fix proven**: neutralizing the recovery break block (`if false {`) makes
`TestCreate_RaceRecovery_WinnerLeaseBroken` FAIL; restoring it passes.

### 2. CREATE parked mid-compound-chain runs trailing commands against stale state

`internal/adapter/smb/handlers/create_post_break.go:218-230` + `internal/adapter/smb/handlers/create.go:1504-1512`
— when a CREATE carrying trailing compound commands (`ctx.NextCommand != 0`) parked async on a
lease break, the dispatch loop ran the trailing commands against the pre-break state, and the
resume goroutine waited for a break ACK the client could not send until it observed the interim
PENDING — a guaranteed hang.

`breakAndMaybeParkCreateInCompound` now forces the inline-wait arm when `NextCommand != 0`
(mirroring the LOCK path's `ctx.NextCommand` guard, MS-SMB2 §3.3.4.2 interim async response);
async parking stays available for standalone CREATEs.

**Red-without-fix proven**: neutralizing the guard (`_ = ctx.NextCommand`) makes
`TestCreate_CompoundChain_NoAsyncPark` FAIL; restoring it passes.

### 3. ADS base-file lookup error swallowed

`internal/adapter/smb/handlers/create.go:1289-1296` — the ADS base-file existence check discarded
the lookup error (`if f, _, _ := ...`), so a real lookup failure (permission denied, store error)
was masked by the auto-create path: the code attempted a base-file CreateFile the caller may not
be allowed to perform and failed later with a possibly-wrong error, after spuriously creating and
rolling back the base file.

The lookup error now surfaces immediately as the create status when the base is absent
(`adsLookupErr != nil && adsBase == nil` → `types.StatusForErr(adsLookupErr)`); a genuine
NotFound still enters the auto-create path.

**Test**: `TestCreate_ADSLookupErrorSurfacesAsStatus`
(`internal/adapter/smb/handlers/create_ads_lookup_error_test.go`) drives an isADS create whose
base listing fails via a wrapper store and asserts a non-success status plus that `base.txt` was
never auto-created. **Disclosure**: red-without-fix is not wire-observable for this finding with
a plain injected error — the legacy path fails at the stream-create listing with the same error
class (both map to STATUS_INTERNAL_ERROR) after spuriously creating and rolling back the base;
the observable improvements are the immediate error surface and the eliminated create+rollback
churn.

### 4. Dead sessionKeyHash plumbing removed (partial, documented)

`internal/adapter/smb/handlers/durable_context.go` — `validateAndRestore` no longer receives
`sessionKeyHash` (it never used it). The parameter remains on
`ProcessDurableReconnectContext`/`processV1Reconnect`/`processV2Reconnect` **with an
accepted-unused doc comment**: removing it cascades to ~38 call sites (mostly
`durable_context_test.go`), which is outside a smallest-correct-diff removal.
`buildPersistedDurableHandle` **keeps** the parameter — `handler.go:1474` passes it and
`durable_context.go:1098` writes it into the persisted row
(`lock.PersistedDurableHandle.SessionKeyHash`), which is store-persisted (not dead).

## Test evidence

- New tests: `TestCreate_RaceRecovery_WinnerLeaseBroken`,
  `TestCreate_CompoundChain_NoAsyncPark` (`create_race_recovery_lease_test.go`),
  `TestCreate_ADSLookupErrorSurfacesAsStatus` (`create_ads_lookup_error_test.go`).
- Red-without-fix proven for findings 1 and 2 (see above); finding 3's gap disclosed.
- `go build ./...` clean, `go vet ./...` clean, `gofmt -l internal/` empty.
- `go test -race -count=1 ./internal/adapter/smb/...` fully green.

## Review round 2 (adversarial + correctness)

- **P1 fixed**: the ADS lookup-error test previously failed every first-cursor listing, so the injected failure tripped the pre-existing main stream-name lookup before the ADS-base check under test. The wrapper now fails only the second listing; red-without-fix re-proven (neutralizing the early return fails the test, restoring passes).
- **P2 (comment) fixed**: the noAsyncPark justification now accurately states that the compound processor already defers trailing commands behind a mid-chain parked CREATE via ReplaceCallback, and the inline wait keeps the compound synchronous with the break rather than claiming the interim would leak trailing commands.
- **P2 disclosed, not changed**: the race-recovery lease-break block re-implements the break dispatch inline instead of calling breakAndMaybeParkCreate. It is conservative and deadlock-free; the reuse would add the traditional-oplock grace window and the async-park arm to the race path, which is a behavior change deliberately deferred. The reviewer marked this non-blocking.

## CI-failure fixes

- **smbtorture compound_async.getinfo_middle**: the noAsyncPark guard converted a working mid-chain async park into an inline wait, but smbtorture requires the mid-chain CREATE to stay async (req[0] in RECV state while the lease break drains, MS-SMB2 §3.3.4.2). The guard is dropped: the CREATE parks like any other, the test now pins parking, and the park-guard comments were corrected.
- **golangci-lint QF1008**: dropped the redundant embedded `Store` selector in the ADS test.
