### PR TITLE
docs: reattach doc comments stranded by the god-file splits

### DIFF
--- a/internal/adapter/nfs/v4/state/backchannel.go
+++ b/internal/adapter/nfs/v4/state/backchannel.go
@@ -508,6 +508,8 @@ func (sm *StateManager) setCBPathUp(clientID uint64, up bool) {
 	}
 }
 
+// SetMaxConnectionsPerSession sets the maximum number of connections per session.
+// A value of 0 means unlimited (no limit enforced).
 func (sm *StateManager) SetMaxConnectionsPerSession(max int) {
 	sm.connMu.Lock()
 	defer sm.connMu.Unlock()

--- a/internal/adapter/nfs/v4/state/client.go
+++ b/internal/adapter/nfs/v4/state/client.go
@@ -863,17 +863,9 @@ func (sm *StateManager) RemoveClient(clientID uint64) {
 		"client_id_str", record.ClientIDString)
 }
 
-// removeClientOpenStateLocked drops every open-owner belonging to clientID
-// together with its open states, its lock states, and the locks those hold in
-// the unified lock manager.
-//
-// It scans sm.openOwners by ClientID rather than walking the record's
-// OpenOwners map: that map is only populated on the v4.0 path, and it goes
-// stale even there because freeOpenStateidLocked removes owners from
-// sm.openOwners without removing them from it.
-//
-// Caller must hold sm.mu.
-
+// GetConfirmedClientIDs returns a list of all confirmed client IDs.
+// Used for saving client state before shutdown so the grace period
+// can identify which clients need to reclaim on restart.
 func (sm *StateManager) GetConfirmedClientIDs() []uint64 {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
@@ -917,24 +909,38 @@ func (sm *StateManager) SaveClientState() []ClientSnapshot {
 // Open File Operations
 // ============================================================================
 
-// OpenFile implements the state management side of OPEN.
+// renewPrincipalAllowed reports whether principal may renew record's lease.
 //
-// It looks up or creates an OpenOwner for (clientID, ownerData), validates
-// the seqid, and either creates a new OpenState or updates an existing one
-// (share_access/share_deny accumulation for same file).
+// RFC 7530 Section 16.28.5 names exactly two permitted callers: the principal
+// that established the client ID via SETCLIENTID_CONFIRM, and any principal
+// that currently has an OPEN file on the server under that client ID. A RENEW
+// from anyone else MUST be rejected with NFS4ERR_ACCESS.
 //
-// Grace period rules:
-//   - CLAIM_NULL (new open): blocked with NFS4ERR_GRACE during grace period
-//   - CLAIM_PREVIOUS (reclaim): allowed during grace period, blocked with
-//     NFS4ERR_NO_GRACE outside grace period
+// This does not put the lease out of a stranger's reach, and is not meant to.
+// Section 9.5 has DELEGPURGE, LOCK, LOCKT, OPEN and RELEASE_LOCKOWNER renew
+// every lease of the client whose clientid they carry, with no principal
+// restriction -- ValidateAndRenewClient does that on the OPEN path. The
+// restriction is scoped to the one operation whose only effect is the renewal.
 //
-// Per RFC 7530 Section 9.1.7:
-//   - First OPEN for a new owner creates unconfirmed state + sets OPEN4_RESULT_CONFIRM
-//   - Subsequent OPENs from a confirmed owner do not set CONFIRM
-//   - Same owner + same file => OR the share_access and share_deny bits
+// The second caller is what keeps a multi-user mount working: one client ID
+// covers every user on the client, and the RFC expects a lease held on behalf
+// of all of them to be renewable by any of them.
 //
-// Caller must NOT hold sm.mu.
-
+// One caller is admitted that the RFC does not name: a record with no
+// principal recorded. SETCLIENTID under AUTH_NONE stores no identity, and there
+// is nothing to compare a later RENEW against.
+//
+// Root gets no exemption. It would have to be an exemption for the string
+// "uid:0" rather than for a verified machine credential, because Principal()
+// renders a GSS-resolved uid and a client-asserted AUTH_SYS uid identically and
+// RENEW carries no filehandle for an export's sec= policy to judge -- so it
+// would hand any AUTH_SYS peer claiming uid 0 the lease of a client established
+// under Kerberos. Nothing needs it: the Linux client renews under the same
+// machine credential it established the client ID with, so the equality above
+// already matches, and a client that falls back to a state owner's credential
+// is covered by the open-holder scan below.
+//
+// Caller must hold sm.mu.
 func renewPrincipalAllowed(record *ClientRecord, principal string) bool {
 	if record.Principal == "" || principal == record.Principal {
 		return true
@@ -997,11 +1003,11 @@ func (sm *StateManager) RenewLease(clientID uint64, principal ...string) error {
 // Lock Manager Integration
 // ============================================================================
 
-// SetLockManager sets the static unified lock manager for byte-range conflict
-// detection. Init-only: must be called during construction, before any goroutine
-// serves requests, so lock-free reads in lockManagerFor are safe. Primarily used
-// by tests; production uses SetLockManagerResolver.
-
+// RenewV41Lease renews the lease for a v4.1 client by updating LastRenewal.
+// Called by the SEQUENCE handler on every successful validation, per
+// RFC 8881 Section 8.1.3 (implicit lease renewal).
+//
+// Thread-safe: acquires sm.mu.Lock.
 func (sm *StateManager) RenewV41Lease(clientID uint64) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
@@ -1066,25 +1072,3 @@ func (sm *StateManager) GetStatusFlags(session *Session) uint32 {
 }
 
 // ============================================================================
-// NFSv4.1 Session Management
-// ============================================================================
-
-// CreateSession implements the CREATE_SESSION algorithm per RFC 8881 Section 18.36.
-//
-// The algorithm uses the client's sequence ID to detect replays:
-//   - sequenceID == record.SequenceID: replay -- return cached response
-//   - sequenceID == record.SequenceID + 1: new request -- create session
-//   - otherwise: misordered -- return error
-//
-// On success, returns the CreateSessionResult and nil cached bytes. The encoded
-// XDR response is also cached on the client record under sm.mu in the same
-// critical section as the sequence-ID bump, so a concurrent retransmit that
-// matches record.SequenceID always observes a populated cache (RFC 8881
-// Section 18.36 replay requirement) — there is no window where the seqid has
-// advanced but the cache is still nil.
-// On replay, returns nil result and the cached XDR response bytes.
-// On error, returns an appropriate NFS4StateError.
-//
-// The first successful CREATE_SESSION confirms the client and starts its lease.
-//
-// Caller must NOT hold sm.mu.

--- a/internal/adapter/nfs/v4/state/client_recovery.go
+++ b/internal/adapter/nfs/v4/state/client_recovery.go
@@ -411,6 +411,16 @@ func (sm *StateManager) LoadClientRecovery(ctx context.Context, armGrace bool) i
 	return len(expectedStrings)
 }
 
+// removeClientOpenStateLocked drops every open-owner belonging to clientID
+// together with its open states, its lock states, and the locks those hold in
+// the unified lock manager.
+//
+// It scans sm.openOwners by ClientID rather than walking the record's
+// OpenOwners map: that map is only populated on the v4.0 path, and it goes
+// stale even there because freeOpenStateidLocked removes owners from
+// sm.openOwners without removing them from it.
+//
+// Caller must hold sm.mu.
 func (sm *StateManager) removeClientOpenStateLocked(clientID uint64) {
 	for key, owner := range sm.openOwners {
 		if owner.ClientID != clientID {

--- a/internal/adapter/nfs/v4/state/connection.go
+++ b/internal/adapter/nfs/v4/state/connection.go
@@ -129,6 +129,16 @@ func negotiateDirection(clientDir uint32) (ConnectionDirection, uint32) {
 	}
 }
 
+// BindConnToSession associates a TCP connection with a session.
+//
+// Per RFC 8881 Section 18.34, the server:
+//   - Validates the session exists
+//   - Negotiates the channel direction (generous policy)
+//   - Silently unbinds the connection from a previous session if needed
+//   - Enforces a per-session connection limit (NFS4ERR_RESOURCE)
+//   - Ensures at least one fore-channel connection remains (NFS4ERR_INVAL)
+//
+// Thread-safe: acquires sm.mu.RLock then sm.connMu.Lock.
 func (sm *StateManager) BindConnToSession(connectionID uint64, sessionID types.SessionId4, clientDir uint32) (*BindConnResult, error) {
 	// Validate session exists under sm.mu.RLock
 	sm.mu.RLock()
@@ -331,6 +341,3 @@ func (sm *StateManager) IsConnectionDraining(connectionID uint64) bool {
 	}
 	return false
 }
-
-// SetMaxConnectionsPerSession sets the maximum number of connections per session.
-// A value of 0 means unlimited (no limit enforced).

--- a/internal/adapter/nfs/v4/state/grace.go
+++ b/internal/adapter/nfs/v4/state/grace.go
@@ -387,6 +387,17 @@ type ClientSnapshot struct {
 	ClientAddr string
 }
 
+// StartGracePeriod creates and starts a grace period for server restart recovery.
+//
+// The NFS adapter should call this on startup if there were previous clients
+// (loaded from a saved client state file). During the grace period:
+//   - OPEN with CLAIM_NULL returns NFS4ERR_GRACE
+//   - OPEN with CLAIM_PREVIOUS is allowed (reclaim)
+//   - RENEW, CLOSE, READ/WRITE with existing stateids work normally
+//
+// The grace period ends automatically after graceDuration, or early if
+// all expectedClientIDs have reclaimed. If expectedClientIDs is empty,
+// the grace period is skipped entirely.
 func (sm *StateManager) StartGracePeriod(expectedClientIDs []uint64) {
 	sm.mu.Lock()
 	gp := NewGracePeriodState(sm.graceDuration, func() {
@@ -517,7 +528,3 @@ func (sm *StateManager) CheckGraceForNewState() error {
 	}
 	return nil
 }
-
-// GetConfirmedClientIDs returns a list of all confirmed client IDs.
-// Used for saving client state before shutdown so the grace period
-// can identify which clients need to reclaim on restart.

--- a/internal/adapter/nfs/v4/state/lease.go
+++ b/internal/adapter/nfs/v4/state/lease.go
@@ -111,6 +111,10 @@ func (ls *LeaseState) RemainingTime() time.Duration {
 	return ls.Duration - elapsed
 }
 
+// SetLockManager sets the static unified lock manager for byte-range conflict
+// detection. Init-only: must be called during construction, before any goroutine
+// serves requests, so lock-free reads in lockManagerFor are safe. Primarily used
+// by tests; production uses SetLockManagerResolver.
 func (sm *StateManager) SetLockManager(lm lock.LockManager) {
 	sm.lockManager = lm
 }
@@ -184,18 +188,3 @@ func (sm *StateManager) SetGracePeriodDuration(d time.Duration) {
 		sm.graceDuration = d
 	}
 }
-
-// LockNew implements the LOCK operation for a new lock-owner.
-//
-// This is the "open_to_lock_owner4" path where the client provides an open stateid
-// and creates a new lock-owner and lock stateid.
-//
-// Per RFC 7530 Section 16.10:
-//  1. Validate the open stateid and open-owner seqid
-//  2. Validate open mode compatibility with lock type
-//  3. Find or create the lock-owner
-//  4. Find or create the lock state (one per lock-owner + open-state pair)
-//  5. Acquire the lock via the unified lock manager
-//  6. Update state on success
-//
-// Caller must NOT hold sm.mu.

--- a/internal/adapter/nfs/v4/state/lockowner.go
+++ b/internal/adapter/nfs/v4/state/lockowner.go
@@ -239,6 +239,12 @@ func validateOpenModeForLock(openState *OpenState, lockType uint32) error {
 	return nil
 }
 
+// hasOutstandingLocksLocked reports whether any byte-range lock derived from
+// openState is still held in the lock manager. Not the same question as whether
+// openState has lock stateids: one stays valid after LOCKU frees its last range
+// (RFC 7530 Section 9.1.4.4), so that count never drops back to zero.
+//
+// Caller must hold sm.mu.
 func (sm *StateManager) hasOutstandingLocksLocked(openState *OpenState) bool {
 	for _, lockState := range openState.LockStates {
 		if lockState.LockOwner == nil {
@@ -296,17 +302,20 @@ func (sm *StateManager) dropLockOwnerIfUnreferencedLocked(lockOwner *LockOwner) 
 	delete(sm.lockOwners, lockOwner.Key())
 }
 
-// DowngradeOpen implements the OPEN_DOWNGRADE operation's state management.
+// LockNew implements the LOCK operation for a new lock-owner.
 //
-// Per RFC 7530 Section 16.19:
-//   - Validates the stateid
-//   - Validates the seqid on the owner
-//   - Verifies new access <= existing (can only remove bits, not add)
-//   - Updates ShareAccess and ShareDeny
-//   - Increments the stateid seqid
+// This is the "open_to_lock_owner4" path where the client provides an open stateid
+// and creates a new lock-owner and lock stateid.
+//
+// Per RFC 7530 Section 16.10:
+//  1. Validate the open stateid and open-owner seqid
+//  2. Validate open mode compatibility with lock type
+//  3. Find or create the lock-owner
+//  4. Find or create the lock state (one per lock-owner + open-state pair)
+//  5. Acquire the lock via the unified lock manager
+//  6. Update state on success
 //
 // Caller must NOT hold sm.mu.
-
 func (sm *StateManager) LockNew(
 	ctx context.Context,
 	lockClientID uint64, lockOwnerData []byte, lockSeqid uint32,
@@ -1139,9 +1148,3 @@ func parseConflictOwner(ownerID string, denied *LOCK4denied) {
 // ============================================================================
 // NFSv4.1 Lease and Status
 // ============================================================================
-
-// RenewV41Lease renews the lease for a v4.1 client by updating LastRenewal.
-// Called by the SEQUENCE handler on every successful validation, per
-// RFC 8881 Section 8.1.3 (implicit lease renewal).
-//
-// Thread-safe: acquires sm.mu.Lock.

--- a/internal/adapter/nfs/v4/state/manager.go
+++ b/internal/adapter/nfs/v4/state/manager.go
@@ -391,15 +391,3 @@ func (sm *StateManager) Shutdown() {
 // ============================================================================
 // Grace Period Operations
 // ============================================================================
-
-// StartGracePeriod creates and starts a grace period for server restart recovery.
-//
-// The NFS adapter should call this on startup if there were previous clients
-// (loaded from a saved client state file). During the grace period:
-//   - OPEN with CLAIM_NULL returns NFS4ERR_GRACE
-//   - OPEN with CLAIM_PREVIOUS is allowed (reclaim)
-//   - RENEW, CLOSE, READ/WRITE with existing stateids work normally
-//
-// The grace period ends automatically after graceDuration, or early if
-// all expectedClientIDs have reclaimed. If expectedClientIDs is empty,
-// the grace period is skipped entirely.

--- a/internal/adapter/nfs/v4/state/openowner.go
+++ b/internal/adapter/nfs/v4/state/openowner.go
@@ -374,6 +374,23 @@ func nextSeqID(current uint32) uint32 {
 	return current + 1
 }
 
+// OpenFile implements the state management side of OPEN.
+//
+// It looks up or creates an OpenOwner for (clientID, ownerData), validates
+// the seqid, and either creates a new OpenState or updates an existing one
+// (share_access/share_deny accumulation for same file).
+//
+// Grace period rules:
+//   - CLAIM_NULL (new open): blocked with NFS4ERR_GRACE during grace period
+//   - CLAIM_PREVIOUS (reclaim): allowed during grace period, blocked with
+//     NFS4ERR_NO_GRACE outside grace period
+//
+// Per RFC 7530 Section 9.1.7:
+//   - First OPEN for a new owner creates unconfirmed state + sets OPEN4_RESULT_CONFIRM
+//   - Subsequent OPENs from a confirmed owner do not set CONFIRM
+//   - Same owner + same file => OR the share_access and share_deny bits
+//
+// Caller must NOT hold sm.mu.
 func (sm *StateManager) OpenFile(
 	clientID uint64,
 	ownerData []byte,
@@ -1046,13 +1063,16 @@ func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32, callerC
 	}, nil
 }
 
-// hasOutstandingLocksLocked reports whether any byte-range lock derived from
-// openState is still held in the lock manager. Not the same question as whether
-// openState has lock stateids: one stays valid after LOCKU frees its last range
-// (RFC 7530 Section 9.1.4.4), so that count never drops back to zero.
+// DowngradeOpen implements the OPEN_DOWNGRADE operation's state management.
 //
-// Caller must hold sm.mu.
-
+// Per RFC 7530 Section 16.19:
+//   - Validates the stateid
+//   - Validates the seqid on the owner
+//   - Verifies new access <= existing (can only remove bits, not add)
+//   - Updates ShareAccess and ShareDeny
+//   - Increments the stateid seqid
+//
+// Caller must NOT hold sm.mu.
 func (sm *StateManager) DowngradeOpen(stateid *types.Stateid4, seqid uint32, newShareAccess, newShareDeny uint32, callerClientID uint64) (result *OpenSeqResult, err error) {
 	// A special stateid names no state at all, and RFC 7530 Section 9.1.4.3
 	// admits one only on READ, WRITE and SETATTR. stateidMissError documents
@@ -1174,40 +1194,3 @@ func (sm *StateManager) GetOpenState(other [types.NFS4_OTHER_SIZE]byte) *OpenSta
 	defer sm.mu.RUnlock()
 	return sm.openStateByOther[other]
 }
-
-// ============================================================================
-// Lease Operations (, Task 4)
-// ============================================================================
-
-// renewPrincipalAllowed reports whether principal may renew record's lease.
-//
-// RFC 7530 Section 16.28.5 names exactly two permitted callers: the principal
-// that established the client ID via SETCLIENTID_CONFIRM, and any principal
-// that currently has an OPEN file on the server under that client ID. A RENEW
-// from anyone else MUST be rejected with NFS4ERR_ACCESS.
-//
-// This does not put the lease out of a stranger's reach, and is not meant to.
-// Section 9.5 has DELEGPURGE, LOCK, LOCKT, OPEN and RELEASE_LOCKOWNER renew
-// every lease of the client whose clientid they carry, with no principal
-// restriction -- ValidateAndRenewClient does that on the OPEN path. The
-// restriction is scoped to the one operation whose only effect is the renewal.
-//
-// The second caller is what keeps a multi-user mount working: one client ID
-// covers every user on the client, and the RFC expects a lease held on behalf
-// of all of them to be renewable by any of them.
-//
-// One caller is admitted that the RFC does not name: a record with no
-// principal recorded. SETCLIENTID under AUTH_NONE stores no identity, and there
-// is nothing to compare a later RENEW against.
-//
-// Root gets no exemption. It would have to be an exemption for the string
-// "uid:0" rather than for a verified machine credential, because Principal()
-// renders a GSS-resolved uid and a client-asserted AUTH_SYS uid identically and
-// RENEW carries no filehandle for an export's sec= policy to judge -- so it
-// would hand any AUTH_SYS peer claiming uid 0 the lease of a client established
-// under Kerberos. Nothing needs it: the Linux client renews under the same
-// machine credential it established the client ID with, so the equality above
-// already matches, and a client that falls back to a state owner's credential
-// is covered by the open-holder scan below.
-//
-// Caller must hold sm.mu.

--- a/internal/adapter/nfs/v4/state/session.go
+++ b/internal/adapter/nfs/v4/state/session.go
@@ -115,6 +115,25 @@ func (s *Session) HasInFlightRequests() bool {
 	return s.ForeChannelSlots.HasInFlightRequests()
 }
 
+// CreateSession implements the CREATE_SESSION algorithm per RFC 8881 Section 18.36.
+//
+// The algorithm uses the client's sequence ID to detect replays:
+//   - sequenceID == record.SequenceID: replay -- return cached response
+//   - sequenceID == record.SequenceID + 1: new request -- create session
+//   - otherwise: misordered -- return error
+//
+// On success, returns the CreateSessionResult and nil cached bytes. The encoded
+// XDR response is also cached on the client record under sm.mu in the same
+// critical section as the sequence-ID bump, so a concurrent retransmit that
+// matches record.SequenceID always observes a populated cache (RFC 8881
+// Section 18.36 replay requirement) — there is no window where the seqid has
+// advanced but the cache is still nil.
+// On replay, returns nil result and the cached XDR response bytes.
+// On error, returns an appropriate NFS4StateError.
+//
+// The first successful CREATE_SESSION confirms the client and starts its lease.
+//
+// Caller must NOT hold sm.mu.
 func (sm *StateManager) CreateSession(
 	clientID uint64,
 	sequenceID uint32,
@@ -502,18 +521,3 @@ func (sm *StateManager) reapExpiredSessions() {
 	}
 	sm.connMu.Unlock()
 }
-
-// ============================================================================
-// Connection Binding
-// ============================================================================
-
-// BindConnToSession associates a TCP connection with a session.
-//
-// Per RFC 8881 Section 18.34, the server:
-//   - Validates the session exists
-//   - Negotiates the channel direction (generous policy)
-//   - Silently unbinds the connection from a previous session if needed
-//   - Enforces a per-session connection limit (NFS4ERR_RESOURCE)
-//   - Ensures at least one fore-channel connection remains (NFS4ERR_INVAL)
-//
-// Thread-safe: acquires sm.mu.RLock then sm.connMu.Lock.

--- a/internal/adapter/smb/handlers/create.go
+++ b/internal/adapter/smb/handlers/create.go
@@ -18,13 +18,15 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata/lock"
 )
 
+// CreateContextTagAllocationSize is the SMB2_CREATE_ALLOCATION_SIZE create
+// context tag ("AlSi") [MS-SMB2] 2.2.13.2.2. Its 8-byte little-endian Data is
+// the client-requested initial allocation size for the file.
 const CreateContextTagAllocationSize = "AlSi"
 
 // CreateContextTagExtendedAttributes is the SMB2_CREATE_EA_BUFFER create
 // context tag ("ExtA") [MS-SMB2] 2.2.13.2.1. Its Data is a
 // FILE_FULL_EA_INFORMATION chain (MS-FSCC §2.4.16 ("FileFullEaInformation")) of extended attributes the
 // client wants attached to the file at creation time.
-
 const CreateContextTagExtendedAttributes = "ExtA"
 
 // CreateRequest represents an SMB2 CREATE request from a client [MS-SMB2] 2.2.13.
@@ -1528,16 +1530,6 @@ func (h *Handler) Create(ctx *SMBHandlerContext, req *CreateRequest) (*CreateRes
 // ============================================================================
 // Named Pipe Handling (IPC$)
 // ============================================================================
-
-// storeCreateReplayIfApplicable mirrors the cache.Store call at the
-// bottom of completeCreateAfterBreak for CREATE return paths that
-// bypass it (notably handlePipeCreate and handleOpenRootCreate). It is
-// the single seam used by those bypass paths so a successful CREATE
-// carrying a DH2Q CreateGuid is recorded into the replay cache; a
-// FLAGS_REPLAY_OPERATION retry within the replay window can then return
-// the cached result. Cache.Store is itself a no-op when CreateGuid is
-// zero or when resp.Status != StatusSuccess, so it is safe to call
-// unconditionally here (MS-SMB2 §3.3.5.9).
 
 func isStatOnlyOpen(desiredAccess uint32) bool {
 	const statOpenBits uint32 = 0x00000080 | // FILE_READ_ATTRIBUTES

--- a/internal/adapter/smb/handlers/create_complete.go
+++ b/internal/adapter/smb/handlers/create_complete.go
@@ -17,6 +17,10 @@ import (
 
 // CREATE completion after a lease/oplock break: the post-break completion
 // state machine (recheck gates, re-encode, respond).
+// completeCreateAfterBreak runs the CREATE flow from the share-mode recheck
+// through the final response build. Split out of Create() so the same code
+// path serves both the synchronous break-wait path and the async-park resume
+// goroutine (MS-SMB2 §3.3.5.9 + §3.3.4.7).
 func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraft) *CreateResponse {
 	req := d.req
 	tree := d.tree
@@ -908,24 +912,3 @@ func (h *Handler) completeCreateAfterBreak(ctx *SMBHandlerContext, d *createDraf
 
 	return resp
 }
-
-// parkCreateOnLeaseBreak reserves an async slot, registers a pending CREATE,
-// and spawns a resume goroutine that waits for the break to drain and then
-// completes the CREATE via AsyncCreateCompleteCallback. Returns the generated
-// AsyncId on success, or 0 when async parking is not possible (e.g. no async
-// slots left; registry rejected the entry). Callers fall back to sync wait.
-//
-// breakWaitTimeout bounds the server-side wait for the break to drain (or
-// auto-downgrade on expiry). Callers pass TraditionalOplockBreakWaitTimeout
-// (~35 s, MS-SMB2 §3.3.4.6) when the holder is a traditional oplock and
-// AsyncCreateBreakWaitTimeout (~5 s) otherwise.
-//
-// shareConflictWait selects the deferred-open resume semantics for the
-// share-violation case (reason == BreakReasonSharingViolation): instead of
-// force-completing the holder's lease on timeout and rechecking once, the
-// resume goroutine waits for the live share-mode conflict to clear — the holder
-// CLOSEs (conflict gone → CREATE proceeds) or only ACKs the break (open kept →
-// SHARING_VIOLATION on the final recheck), and the holder's deferred ACK still
-// succeeds because the lease is never tombstoned here (smbtorture replay
-// dhv2-pending1n-vs-violation-lease-{close,ack}-sane, MS-SMB2 §3.3.5.9 /
-// Samba defer_open→retry_open).

--- a/internal/adapter/smb/handlers/create_post_break.go
+++ b/internal/adapter/smb/handlers/create_post_break.go
@@ -635,11 +635,26 @@ func (h *Handler) recheckExistingFileGates(d *createDraft, effectiveAccess uint3
 	return grantedAccess, grantedComputed, nil
 }
 
-// completeCreateAfterBreak runs the CREATE flow from the share-mode recheck
-// through the final response build. Split out of Create() so the same code
-// path serves both the synchronous break-wait path and the async-park resume
-// goroutine (MS-SMB2 §3.3.5.9 + §3.3.4.7).
-
+// parkCreateOnLeaseBreak reserves an async slot, registers a pending CREATE,
+// and spawns a resume goroutine that waits for the break to drain and then
+// completes the CREATE via AsyncCreateCompleteCallback. Returns the generated
+// AsyncId on success, or 0 when async parking is not possible (e.g. no async
+// slots left; registry rejected the entry). Callers fall back to sync wait.
+//
+// breakWaitTimeout bounds the server-side wait for the break to drain (or
+// auto-downgrade on expiry). Callers pass TraditionalOplockBreakWaitTimeout
+// (~35 s, MS-SMB2 §3.3.4.6) when the holder is a traditional oplock and
+// AsyncCreateBreakWaitTimeout (~5 s) otherwise.
+//
+// shareConflictWait selects the deferred-open resume semantics for the
+// share-violation case (reason == BreakReasonSharingViolation): instead of
+// force-completing the holder's lease on timeout and rechecking once, the
+// resume goroutine waits for the live share-mode conflict to clear — the holder
+// CLOSEs (conflict gone → CREATE proceeds) or only ACKs the break (open kept →
+// SHARING_VIOLATION on the final recheck), and the holder's deferred ACK still
+// succeeds because the lease is never tombstoned here (smbtorture replay
+// dhv2-pending1n-vs-violation-lease-{close,ack}-sane, MS-SMB2 §3.3.5.9 /
+// Samba defer_open→retry_open).
 func (h *Handler) parkCreateOnLeaseBreak(
 	ctx *SMBHandlerContext,
 	d *createDraft,

--- a/internal/adapter/smb/handlers/create_replay.go
+++ b/internal/adapter/smb/handlers/create_replay.go
@@ -9,6 +9,15 @@ import (
 
 // CREATE replay: durable-handle and lease replay caches, response caching,
 // and the create-context strip helpers.
+// storeCreateReplayIfApplicable mirrors the cache.Store call at the
+// bottom of completeCreateAfterBreak for CREATE return paths that
+// bypass it (notably handlePipeCreate and handleOpenRootCreate). It is
+// the single seam used by those bypass paths so a successful CREATE
+// carrying a DH2Q CreateGuid is recorded into the replay cache; a
+// FLAGS_REPLAY_OPERATION retry within the replay window can then return
+// the cached result. Cache.Store is itself a no-op when CreateGuid is
+// zero or when resp.Status != StatusSuccess, so it is safe to call
+// unconditionally here (MS-SMB2 §3.3.5.9).
 func (h *Handler) storeCreateReplayIfApplicable(ctx *SMBHandlerContext, req *CreateRequest, resp *CreateResponse) {
 	if h.CreateReplayCache == nil || resp == nil || resp.Status != types.StatusSuccess {
 		return

--- a/internal/adapter/smb/handlers/handler.go
+++ b/internal/adapter/smb/handlers/handler.go
@@ -662,9 +662,7 @@ func (h *Handler) generateAsyncId() uint64 {
 	return h.nextAsyncId.Add(1)
 }
 
-// notifyOpenFileModified emits a FileActionModified notification for the
-// handle, taking the parent path and stream name from one name snapshot.
-
+// GenerateFileID generates a new unique file ID
 func (h *Handler) GenerateFileID() [16]byte {
 	var fileID [16]byte
 	// Use persistent part for the ID counter
@@ -682,17 +680,27 @@ func (h *Handler) GenerateFileID() [16]byte {
 	return fileID
 }
 
-// CreateSession creates and stores a new session.
-// This replaces the old StoreSession method for unified session/credit management.
-
+// pendingAuthKey is the composite key for pendingAuth lookups. SessionID is
+// the session the handshake targets — the server-generated ID for an initial
+// NTLM NEGOTIATE, the bound session for a bind, or the existing session for
+// re-auth — and is the ID the client carries in the TYPE_3 header. ConnID
+// disambiguates concurrent handshakes on the same SessionID so that parallel
+// SESSION_SETUPs from different TCP connections do not clobber each other.
+// Without per-connection keying, the regression guarded by
+// smb2.multichannel.bugs.bug_15346 fails (Samba bug 15346): parallel binds
+// race on a single slot and the TYPE_3 of one channel picks up the
+// ServerChallenge of another.
 type pendingAuthKey struct {
 	SessionID uint64
 	ConnID    uint64
 }
 
-// StorePendingAuth stores a pending authentication. pending.SessionID and
-// pending.ConnID together form the lookup key.
-
+// adsBaseName extracts the base file name from a potentially ADS-qualified
+// parent-relative name. For "file.txt:stream" it returns "file.txt"; for
+// "file.txt" (not a stream) it returns "".
+//
+// Stream names cannot contain a path separator (rejected at CREATE), so this
+// operates on a single name component, never a path.
 func adsBaseName(fileName string) string {
 	colonIdx := strings.Index(fileName, ":")
 	if colonIdx <= 0 {
@@ -701,12 +709,11 @@ func adsBaseName(fileName string) string {
 	return fileName[:colonIdx]
 }
 
-// checkShareDeleteConflict checks if any other open handle on the same file
-// lacks FILE_SHARE_DELETE in its ShareAccess. MS-FSA 2.1.5.15.12
-// ("FileRenameInformation") states no share-mode check; requiring all other
-// opens to permit delete sharing follows Samba `can_rename`. Returns true if a conflict
-// exists (rename should be blocked with STATUS_SHARING_VIOLATION).
-
+// logRenameConflictHolder emits (at Debug) the full identity of the open handle
+// that tripped a rename share-mode gate, alongside the renamer. Fields chosen to
+// answer "is this a legitimate live sibling, or a stale/cross-connection leak?":
+// session/tree locate the owning connection, ShareAccess/DesiredAccess show why
+// it conflicted, IsDurable/DeletePending flag reconnect/teardown stubs.
 func logRenameConflictHolder(gate string, renamer, holder *OpenFile) {
 	logger.Debug("SET_INFO rename conflict holder",
 		"gate", gate,
@@ -725,23 +732,12 @@ func logRenameConflictHolder(gate string, renamer, holder *OpenFile) {
 		"holderDeletePending", holder.IsDeletePending())
 }
 
-// checkParentDirRenameConflict applies the destination-parent share-mode rule
-// from MS-FSA 2.1.5.15.12 ("FileRenameInformation"): the rename opens the destination directory
-// with DesiredAccess FILE_ADD_FILE|SYNCHRONIZE and ShareAccess
-// FILE_SHARE_READ|FILE_SHARE_WRITE. Linking a new name into a directory is
-// therefore a WRITE against that directory, not a delete of it, so an existing
-// open conflicts only when it denies write sharing, or already holds DELETE
-// access — which the rename's withheld share-delete is incompatible with. A
-// holder that merely lacks FILE_SHARE_DELETE does not conflict; nothing in the
-// rename asks to delete the destination parent.
-//
-// Only the renamer's own handle is excluded, by FileID. Another open on the
-// renamer's own session still counts, because the implicit open is a fresh
-// open evaluated against the whole open list.
-//
-// Caller passes the destination parent handle (same as source parent for a
-// same-directory rename). Returns true on conflict.
-
+// hasReadAccess reports whether the given access mask includes read access.
+// Checks FILE_READ_DATA, FILE_EXECUTE, GENERIC_READ, GENERIC_ALL, and
+// MAXIMUM_ALLOWED. FILE_EXECUTE is treated as read access because the
+// canonical SMB clients (Samba, Windows) allow READ on a handle opened with
+// only FILE_EXECUTE — execution implies read, and the smb2.read.access
+// torture test exercises that path.
 func hasReadAccess(access uint32) bool {
 	m := types.AccessMask(access)
 	return m&types.FileReadData != 0 ||

--- a/internal/adapter/smb/handlers/open_file.go
+++ b/internal/adapter/smb/handlers/open_file.go
@@ -12,8 +12,28 @@ import (
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
-// Open-file state: the OpenFile type, its accessors and frozen-timestamp
-// gates, the handle-op tracker, and the share-mode/delete-conflict checks.
+// OpenFile represents an open file handle created by the CREATE command.
+// It links the SMB2 FileID to the underlying metadata handle and payload ID,
+// tracks directory enumeration state, delete-on-close flags, and oplock level.
+// Stored in a sync.Map keyed by the 16-byte FileID.
+//
+// Concurrency: SMB clients legitimately pipeline operations on the same handle
+// (e.g. WRITE + QUERY_INFO; multi-channel sessions can also dispatch concurrent
+// QUERY_DIRECTORY on the same FileID). The exported mutable fields below are
+// guarded by `mu` — read-locked when surfacing state to the wire (QUERY_INFO,
+// override application) and write-locked when mutating (enumeration cursor,
+// freeze/thaw, delayed-write arm/flush). Hold the lock around the full
+// read-modify-write region; release before any I/O to the metadata store to
+// keep the critical section bounded. Atomic-typed fields
+// (NotifyOverflowed/NotifyMaxBufferSize/NotifyCompletionFilter) and immutable
+// fields (FileID/TreeID/SessionID/MetadataHandle/CreateOptions) are safe to
+// access without the mutex.
+//
+// PayloadID and the name triple are NOT immutable: the first WRITE on a file
+// created empty caches the payload the metadata store allocated,
+// SET_REPARSE_POINT and COPYCHUNK replace it, and SET_INFO rename rewrites the
+// name/path/parent triple. Reach the payload through GetPayloadID /
+// SetPayloadID and the triple through Name / SetName.
 type OpenFile struct {
 	// mu guards the mutable fields listed in the struct comment above. Held
 	// across QueryDirectory enumeration R-M-W, freeze/thaw bookkeeping in
@@ -395,6 +415,10 @@ type OpenFile struct {
 // parent, and parent directory handle. SET_INFO rename replaces all three at
 // once, so they are published and read as one immutable value.
 
+// handleOpTracker tracks in-flight operations on a FileID via a WaitGroup.
+// Created lazily by AcquireOpenFile; AcquireOpenFile adds and ReleaseOpenFile
+// calls Done. WaitAndDeleteOpenFile waits for the WaitGroup to drain before
+// removing the OpenFile from the map.
 type handleOpTracker struct {
 	wg sync.WaitGroup
 }
@@ -532,10 +556,15 @@ func (h *Handler) forgetReplayState(fileID [16]byte) {
 	}
 }
 
-// ReleaseAllLocksForSession releases all byte-range locks held by a session.
-// This is called during LOGOFF or connection cleanup to ensure locks are released
-// even if CLOSE was not called for all open files.
-
+// isFileDeletePending reports whether any existing open on the same file
+// (identified by its metadata handle) has DeletePending set. Per MS-FSA
+// 2.1.5.1.2 and MS-SMB2 3.3.5.9: a subsequent open on a delete-pending
+// file MUST fail with STATUS_DELETE_PENDING. The check runs BEFORE oplock
+// break dispatch so the holder's oplock remains intact.
+//
+// Required by smbtorture smb2.oplock.doc: tree1 opens with Batch oplock,
+// sets delete-on-close; tree2's open must return STATUS_DELETE_PENDING
+// without triggering a break.
 func (h *Handler) isFileDeletePending(fileHandle metadata.FileHandle) bool {
 	pending := false
 	h.files.Range(func(_, value any) bool {
@@ -803,13 +832,11 @@ func (h *Handler) lookupCaseInsensitive(
 	return metaSvc.LookupCaseInsensitive(authCtx, parentHandle, name)
 }
 
-// adsBaseName extracts the base file name from a potentially ADS-qualified
-// parent-relative name. For "file.txt:stream" it returns "file.txt"; for
-// "file.txt" (not a stream) it returns "".
-//
-// Stream names cannot contain a path separator (rejected at CREATE), so this
-// operates on a single name component, never a path.
-
+// checkShareDeleteConflict checks if any other open handle on the same file
+// lacks FILE_SHARE_DELETE in its ShareAccess. MS-FSA 2.1.5.15.12
+// ("FileRenameInformation") states no share-mode check; requiring all other
+// opens to permit delete sharing follows Samba `can_rename`. Returns true if a conflict
+// exists (rename should be blocked with STATUS_SHARING_VIOLATION).
 func (h *Handler) checkShareDeleteConflict(renameFile *OpenFile) bool {
 	const fileShareDelete = uint32(0x04) // FILE_SHARE_DELETE
 
@@ -847,12 +874,22 @@ func (h *Handler) checkShareDeleteConflict(renameFile *OpenFile) bool {
 	return false
 }
 
-// logRenameConflictHolder emits (at Debug) the full identity of the open handle
-// that tripped a rename share-mode gate, alongside the renamer. Fields chosen to
-// answer "is this a legitimate live sibling, or a stale/cross-connection leak?":
-// session/tree locate the owning connection, ShareAccess/DesiredAccess show why
-// it conflicted, IsDurable/DeletePending flag reconnect/teardown stubs. #1652.
-
+// checkParentDirRenameConflict applies the destination-parent share-mode rule
+// from MS-FSA 2.1.5.15.12 ("FileRenameInformation"): the rename opens the destination directory
+// with DesiredAccess FILE_ADD_FILE|SYNCHRONIZE and ShareAccess
+// FILE_SHARE_READ|FILE_SHARE_WRITE. Linking a new name into a directory is
+// therefore a WRITE against that directory, not a delete of it, so an existing
+// open conflicts only when it denies write sharing, or already holds DELETE
+// access — which the rename's withheld share-delete is incompatible with. A
+// holder that merely lacks FILE_SHARE_DELETE does not conflict; nothing in the
+// rename asks to delete the destination parent.
+//
+// Only the renamer's own handle is excluded, by FileID. Another open on the
+// renamer's own session still counts, because the implicit open is a fresh
+// open evaluated against the whole open list.
+//
+// Caller passes the destination parent handle (same as source parent for a
+// same-directory rename). Returns true on conflict.
 func (h *Handler) checkParentDirRenameConflict(renamer *OpenFile, dstParent metadata.FileHandle) bool {
 	if len(dstParent) == 0 {
 		return false
@@ -965,10 +1002,3 @@ func (h *Handler) hasOpenHandleOnFile(targetMeta metadata.FileHandle, excludeFil
 	})
 	return conflict
 }
-
-// hasReadAccess reports whether the given access mask includes read access.
-// Checks FILE_READ_DATA, FILE_EXECUTE, GENERIC_READ, GENERIC_ALL, and
-// MAXIMUM_ALLOWED. FILE_EXECUTE is treated as read access because the
-// canonical SMB clients (Samba, Windows) allow READ on a handle opened with
-// only FILE_EXECUTE — execution implies read, and the smb2.read.access
-// torture test exercises that path.

--- a/internal/adapter/smb/handlers/session_lifecycle.go
+++ b/internal/adapter/smb/handlers/session_lifecycle.go
@@ -88,29 +88,8 @@ type TreeConnection struct {
 	AllowMFsymlink bool
 }
 
-// OpenFile represents an open file handle created by the CREATE command.
-// It links the SMB2 FileID to the underlying metadata handle and payload ID,
-// tracks directory enumeration state, delete-on-close flags, and oplock level.
-// Stored in a sync.Map keyed by the 16-byte FileID.
-//
-// Concurrency: SMB clients legitimately pipeline operations on the same handle
-// (e.g. WRITE + QUERY_INFO; multi-channel sessions can also dispatch concurrent
-// QUERY_DIRECTORY on the same FileID). The exported mutable fields below are
-// guarded by `mu` — read-locked when surfacing state to the wire (QUERY_INFO,
-// override application) and write-locked when mutating (enumeration cursor,
-// freeze/thaw, delayed-write arm/flush). Hold the lock around the full
-// read-modify-write region; release before any I/O to the metadata store to
-// keep the critical section bounded. Atomic-typed fields
-// (NotifyOverflowed/NotifyMaxBufferSize/NotifyCompletionFilter) and immutable
-// fields (FileID/TreeID/SessionID/MetadataHandle/CreateOptions) are safe to
-// access without the mutex.
-//
-// PayloadID and the name triple are NOT immutable: the first WRITE on a file
-// created empty caches the payload the metadata store allocated,
-// SET_REPARSE_POINT and COPYCHUNK replace it, and SET_INFO rename rewrites the
-// name/path/parent triple. Reach the payload through GetPayloadID /
-// SetPayloadID and the triple through Name / SetName.
-
+// GetSession retrieves a session by ID.
+// Delegates to SessionManager for unified session/credit management.
 func (h *Handler) GetSession(sessionID uint64) (*session.Session, bool) {
 	return h.SessionManager.GetSession(sessionID)
 }
@@ -154,11 +133,9 @@ func (h *Handler) GetOpenFile(fileID [16]byte) (*OpenFile, bool) {
 	return v.(*OpenFile), true
 }
 
-// handleOpTracker tracks in-flight operations on a FileID via a WaitGroup.
-// Created lazily by AcquireOpenFile; AcquireOpenFile adds and ReleaseOpenFile
-// calls Done. WaitAndDeleteOpenFile waits for the WaitGroup to drain before
-// removing the OpenFile from the map.
-
+// ReleaseAllLocksForSession releases all byte-range locks held by a session.
+// This is called during LOGOFF or connection cleanup to ensure locks are released
+// even if CLOSE was not called for all open files.
 func (h *Handler) ReleaseAllLocksForSession(ctx context.Context, sessionID uint64) {
 	h.files.Range(func(key, value any) bool {
 		openFile := value.(*OpenFile)
@@ -1017,17 +994,8 @@ func (h *Handler) StoreOpenFile(file *OpenFile) {
 	h.files.Store(string(file.FileID[:]), file)
 }
 
-// pendingAuthKey is the composite key for pendingAuth lookups. SessionID is
-// the session the handshake targets — the server-generated ID for an initial
-// NTLM NEGOTIATE, the bound session for a bind, or the existing session for
-// re-auth — and is the ID the client carries in the TYPE_3 header. ConnID
-// disambiguates concurrent handshakes on the same SessionID so that parallel
-// SESSION_SETUPs from different TCP connections do not clobber each other.
-// Without per-connection keying, the regression guarded by
-// smb2.multichannel.bugs.bug_15346 fails (Samba bug 15346): parallel binds
-// race on a single slot and the TYPE_3 of one channel picks up the
-// ServerChallenge of another.
-
+// StorePendingAuth stores a pending authentication. pending.SessionID and
+// pending.ConnID together form the lookup key.
 func (h *Handler) StorePendingAuth(pending *PendingAuth) {
 	h.pendingAuth.Store(pendingAuthKey{pending.SessionID, pending.ConnID}, pending)
 }
@@ -1060,13 +1028,3 @@ func (h *Handler) DeleteAllPendingAuthForSession(sessionID uint64) {
 		return true
 	})
 }
-
-// isFileDeletePending reports whether any existing open on the same file
-// (identified by its metadata handle) has DeletePending set. Per MS-FSA
-// 2.1.5.1.2 and MS-SMB2 3.3.5.9: a subsequent open on a delete-pending
-// file MUST fail with STATUS_DELETE_PENDING. The check runs BEFORE oplock
-// break dispatch so the holder's oplock remains intact.
-//
-// Required by smbtorture smb2.oplock.doc: tree1 opens with Batch oplock,
-// sets delete-on-close; tree2's open must return STATUS_DELETE_PENDING
-// without triggering a break.

--- a/internal/adapter/smb/handlers/set_info_file.go
+++ b/internal/adapter/smb/handlers/set_info_file.go
@@ -349,7 +349,7 @@ func (h *Handler) setFileInfoFromStore(
 		// follow-up BasicInfo call mutates only FileAttributes (attrib=NORMAL)
 		// while sending zero timestamps, and asserts the previously-set values
 		// survive. Without sticky state the attribute-change path auto-bumps
-		// LastWriteTime (set_info.go) and ChangeTime (metadata file_modify.go),
+		// LastWriteTime (set_info_file.go) and ChangeTime (metadata file_modify.go),
 		// clobbering the explicit values. We reuse the existing freeze mechanism
 		// (Frozen* flags + Frozen* pointers): an explicit set freezes the field
 		// to the value just written, so the field==0 re-pin block above and the
@@ -1819,8 +1819,3 @@ func buildFrozenAttrs(openFile *OpenFile) *metadata.SetAttrs {
 	}
 	return attrs
 }
-
-// parseSDOptsForShare resolves the Security Descriptor parse options for the
-// share that owns openFile. Returns Windows-canonical defaults
-// (CanonicalizeAutoInherited=true) when the share lookup fails — the safe
-// fallback per MS-DTYP §2.5.3.4.2. Refs #514 T4.

--- a/internal/adapter/smb/handlers/set_info_security.go
+++ b/internal/adapter/smb/handlers/set_info_security.go
@@ -12,6 +12,10 @@ import (
 
 // SET_INFO security descriptors: SD parsing, DACL/SACL merge, and the
 // security-access gate.
+// parseSDOptsForShare resolves the Security Descriptor parse options for the
+// share that owns openFile. Returns Windows-canonical defaults
+// (CanonicalizeAutoInherited=true) when the share lookup fails — the safe
+// fallback per MS-DTYP §2.5.3.4.2.
 func (h *Handler) parseSDOptsForShare(shareName string) ParseSDOptions {
 	opts := ParseSDOptions{CanonicalizeAutoInherited: true}
 	if h.Registry == nil {

--- a/internal/adapter/smb/handlers/set_info_security.go
+++ b/internal/adapter/smb/handlers/set_info_security.go
@@ -13,7 +13,9 @@ import (
 // SET_INFO security descriptors: SD parsing, DACL/SACL merge, and the
 // security-access gate.
 // parseSDOptsForShare resolves the Security Descriptor parse options for the
-// share that owns openFile. Returns Windows-canonical defaults
+// named share. Callers pass the share the operation targets: the open file's
+// share from SET_INFO, or the tree's share from CREATE where no OpenFile
+// exists yet. Returns Windows-canonical defaults
 // (CanonicalizeAutoInherited=true) when the share lookup fails — the safe
 // fallback per MS-DTYP §2.5.3.4.2.
 func (h *Handler) parseSDOptsForShare(shareName string) ParseSDOptions {

--- a/internal/adapter/smb/handlers/share_state.go
+++ b/internal/adapter/smb/handlers/share_state.go
@@ -14,6 +14,8 @@ import (
 
 // Share state: cached shares, share security descriptors, durable-handle
 // seeding, and the share-change callback.
+// notifyOpenFileModified emits a FileActionModified notification for the
+// handle, taking the parent path and stream name from one name snapshot.
 func (h *Handler) notifyOpenFileModified(openFile *OpenFile, filter uint32) {
 	name := openFile.Name()
 	h.NotifyRegistry.NotifyChange(openFile.ShareName, GetParentPath(name.Path), notifyStreamName(name.FileName), FileActionModified, filter)


### PR DESCRIPTION
Reattaches the ~24 doc comments that the Wave 5 god-file splits left stranded at the end of the previous file or separated by blank lines, so every exported declaration carries its own documentation again.

## What happened

The Wave 5 same-package file splits (#2529 #2530 #2531 #2532) moved declarations without their doc blocks: a doc stranded at EOF of the previous file (or after a blank line) is dropped by `go doc`, leaving the exported API undocumented. This PR moves each block back next to its declaration — no code changes, comments only.

Fixed placements (each is a move, not a rewrite):

- `v4/state`: `SetMaxConnectionsPerSession` (backchannel.go, doc from connection.go), `GetConfirmedClientIDs` (client.go, doc from grace.go), `removeClientOpenStateLocked` (client_recovery.go, doc from client.go), `BindConnToSession` (connection.go, doc from session.go), `StartGracePeriod` (grace.go, doc from manager.go), `SetLockManager` (lease.go, doc from client.go), `RenewV41Lease` (client.go, doc from lockowner.go), `LockNew` (lockowner.go, doc from lease.go — it carried `DowngradeOpen`'s doc), `DowngradeOpen` (openowner.go, doc restored), `hasOutstandingLocksLocked` (lockowner.go, doc from openowner.go), `OpenFile` (openowner.go, doc from client.go), `CreateSession` (session.go, doc from client.go), `renewPrincipalAllowed` (client.go, doc from openowner.go).
- `smb/handlers`: `parseSDOptsForShare` doc (set_info_security.go, from set_info_file.go; also fixed a stale `set_info.go` pointer in the moved BasicInfo comment), `CreateContextTagAllocationSize` doc restored + stray blank lines removed (create.go), `completeCreateAfterBreak` (create_complete.go, doc from create_post_break.go), `parkCreateOnLeaseBreak` (create_post_break.go, doc from create_complete.go), `storeCreateReplayIfApplicable` (create_replay.go, doc from create.go), `handleOpTracker` (open_file.go, doc from session_lifecycle.go), `ReleaseAllLocksForSession` (session_lifecycle.go, doc from open_file.go), `isFileDeletePending` (open_file.go, doc from session_lifecycle.go), `adsBaseName` (handler.go, doc from open_file.go), `checkShareDeleteConflict` (open_file.go, doc from handler.go), `logRenameConflictHolder` (handler.go, doc from open_file.go), `checkParentDirRenameConflict` (open_file.go, doc from handler.go), `hasReadAccess` (handler.go, doc from open_file.go), `OpenFile` type (open_file.go, doc from session_lifecycle.go), `pendingAuthKey` (handler.go, doc from session_lifecycle.go — it carried `CreateSession`'s doc), `StorePendingAuth` (session_lifecycle.go, one-line doc restored), `GenerateFileID` (handler.go, doc restored), `notifyOpenFileModified` (share_state.go, doc from handler.go).

One dropped external reference: the moved `parseSDOptsForShare` doc cited an audit row ("Refs #514 T4"); the citation is dropped per the code-comment rules, the behaviour text is unchanged.

## Pre-existing correctness findings (verified, not regressions)

Copilot's review also flagged behavioural items. Each was checked against the pre-split tree and is **pre-existing behaviour moved verbatim**, not introduced by the splits — disclosed here rather than changed:

- `client_recovery.go` `removeClientOpenStateLocked` shared-`LockOwner` delete: false positive — `removeClientOpenStateLocked` removes **all** of the client's open states in the same loop, so every deleted lockOwner is fully orphaned; cross-client sharing is impossible because `lockOwners` keys are `clientID+ownerData`.
- `lockowner.go` unbacked lock state on `acquireLock` error: pre-existing minor self-healing state leak (moved verbatim from manager.go).
- `client.go` `RemoveClient` index-only delete: moved verbatim — callers route through the lease-expiry callback which performs the full teardown.
- `connection.go` `BindConnToSession` bind race and `session.go` orphan-binding sweep: moved verbatim; both were reviewed OK in the original split PR.
- `session.go` unconditional `backAttrs` floor check: the explicit #2494/#2471 design Copilot approved (CSESS26/27 remain known-fails).

## Verification

- `go build ./...` clean, `go vet` clean, `gofmt` clean
- Full `go test -count=1 ./...` green, including `v4/state` (25.9s) and all 12 `smb` packages

Follows the four merged Wave 5 splits; clears the "Changes recommended" state they carry.
