### PR TITLE
refactor: journal hygiene sweep

### DIFF
--- a/cmd/dfs/commands/start.go
+++ b/cmd/dfs/commands/start.go
@@ -22,6 +22,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/adapter/smb"
 	"github.com/marmos91/dittofs/pkg/auth/kerberos"
 	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/journal"
 	"github.com/marmos91/dittofs/pkg/block/local/fs"
 	"github.com/marmos91/dittofs/pkg/config"
 	"github.com/marmos91/dittofs/pkg/controlplane/api"
@@ -879,7 +880,8 @@ func handleFormatMismatch(err error, stderr *os.File) bool {
 	if err == nil {
 		return false
 	}
-	if !errors.Is(err, block.ErrFutureFormat) && !errors.Is(err, fs.ErrLegacyLocalFormat) {
+	if !errors.Is(err, block.ErrFutureFormat) && !errors.Is(err, journal.ErrFutureFormat) &&
+		!errors.Is(err, fs.ErrLegacyLocalFormat) {
 		return false
 	}
 	_, _ = fmt.Fprintln(stderr, formatMismatchDirective(err))
@@ -951,7 +953,7 @@ func emitAdminPassword(password string) {
 // downgrade the operator can undo by going forward again, while a pre-journal
 // layout is an upgrade that has not run yet.
 func formatMismatchDirective(err error) string {
-	if errors.Is(err, block.ErrFutureFormat) {
+	if errors.Is(err, block.ErrFutureFormat) || errors.Is(err, journal.ErrFutureFormat) {
 		return fmt.Sprintf(`Refusing to start: %s.
 
 This state was written by a newer release of DittoFS. Opening it with this

--- a/pkg/block/doc.go
+++ b/pkg/block/doc.go
@@ -1,14 +1,16 @@
 // Package blockstore defines the unified content-addressed block storage
 // contract DittoFS uses across every storage tier. It is the
-// single source of truth for FileChunk, BlockState, ContentHash, BlockSize
+// single source of truth for FileChunk, BlockState, ContentHash, BlockSize,
 // the Store interface, the minimal Meta struct, the error sentinels
-// (ErrStopWalk, ErrFutureFormat
-// ErrChunkNotFound, …), and the on-disk format-version convention.
+// (ErrStopWalk, ErrFutureFormat, ErrChunkNotFound, …), and the on-disk
+// format-version convention.
 //
 // # Interface roles
 //
 // One hash-keyed interface replaces the earlier v0.15 split
-// (LocalStore: 22 methods, RemoteStore: 12 methods):
+// (LocalStore: 22 methods, RemoteStore: 12 methods) — the concrete split
+// itself now lives on pkg/block/remote.RemoteStore (block-keyed) and
+// pkg/block/local (payload-keyed):
 //
 //   - Store — the unified surface for content-addressed CRUD
 //     (Put / Get / GetRange / Has / Delete / Head / Walk). Idempotent
@@ -65,7 +67,9 @@
 // a record whose layout moved to a sibling key decodes cleanly into a file
 // with the right size and no content, and the store then serves zeros. Boot
 // treats the refusal as fatal for the whole daemon rather than skipping the
-// share, so a downgraded box cannot come up looking healthy.
+// share — matching both sentinels, block.ErrFutureFormat and
+// journal.ErrFutureFormat, so a downgraded box cannot come up looking
+// healthy.
 //
 // The reverse direction — state OLDER than the build — is a migration, not a
 // refusal, and runs automatically at share startup. It is one-way: once it
@@ -87,7 +91,8 @@
 //
 //   - ErrStopWalk — Walk callback early-exit signal.
 //   - ErrFutureFormat — a store refused on-disk state written by a
-//     newer release than this build can read.
+//     newer release than this build can read. The journal side-log
+//     names live on journal.ErrFutureFormat; boot matches both.
 //   - ErrChunkNotFound — content-addressed chunk is absent
 //     from the store (local or remote).
 //   - ErrChunkContentMismatch — recomputed BLAKE3 disagreed with the
@@ -102,7 +107,7 @@
 //
 //   - local: the payload-keyed LocalStore interface + the *fs.FSStore
 //     implementation.
-//   - remote: the block-keyed RemoteStore contract, its backend
+//   - remote: the block-keyed [remote.RemoteStore] contract, its backend
 //     implementations (s3, memory), and Passthrough, the forwarding
 //     base the compression / encryption decorators embed.
 //   - blockstoretest: conformance suites — BlockStoreConformance for

--- a/pkg/block/engine/blocksink_test.go
+++ b/pkg/block/engine/blocksink_test.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"context"
 	"errors"
-	"io"
 	"math/rand"
 	"sync"
 	"testing"
@@ -13,20 +12,6 @@ import (
 	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
 	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
-
-// stubJournalRemote satisfies journal.RemoteStore for a Store whose cold-read
-// path is never exercised (carve drives the injected sink, not this remote).
-type stubJournalRemote struct{}
-
-func (stubJournalRemote) PutBlock(context.Context, journal.BlockID, io.Reader, int64) error {
-	return errors.New("stub: PutBlock unused")
-}
-func (stubJournalRemote) GetBlock(context.Context, journal.BlockID) (io.ReadCloser, error) {
-	return nil, errors.New("stub: GetBlock unused")
-}
-func (stubJournalRemote) GetRange(context.Context, journal.BlockID, int64, int64) (io.ReadCloser, error) {
-	return nil, errors.New("stub: GetRange unused")
-}
 
 // seamFixture wires a live journal.Store to the production engineDeduper +
 // engineBlockSink, a memory metadata store (committer + synced oracle) and a
@@ -40,7 +25,7 @@ type seamFixture struct {
 
 func newSeamFixture(t *testing.T, dir string, ms *metadatamemory.MemoryMetadataStore, mem *remotememory.Store, sink journal.BlockSink) *seamFixture {
 	t.Helper()
-	j, err := journal.Open(dir, journal.Config{CarveBlockSize: 1 << 20}, stubJournalRemote{}, journal.SystemClock())
+	j, err := journal.Open(dir, journal.Config{CarveBlockSize: 1 << 20})
 	if err != nil {
 		t.Fatalf("journal.Open: %v", err)
 	}
@@ -285,8 +270,7 @@ func TestJournalCarveSeam_ScatteredRunsAllFlipSynced(t *testing.T) {
 	mem := remotememory.New()
 
 	j, err := journal.Open(t.TempDir(),
-		journal.Config{CarveBlockSize: blockSize, CarveUploadConcurrency: 4},
-		stubJournalRemote{}, journal.SystemClock())
+		journal.Config{CarveBlockSize: blockSize, CarveUploadConcurrency: 4})
 	if err != nil {
 		t.Fatalf("journal.Open: %v", err)
 	}

--- a/pkg/block/errors.go
+++ b/pkg/block/errors.go
@@ -217,8 +217,9 @@ var (
 	// Detection is per-share but the exit is fatal: a share that cannot be
 	// opened safely must not leave the daemon looking healthy.
 	//
-	// Both block stores and metadata stores return it, so the message carries
-	// no "blockstore:" prefix — unlike the sentinels above, it is not about
-	// blocks.
+	// The local and remote block tiers return it, and so does the metadata
+	// store (whose migrations in sqlite/postgres/badger wrap it for their
+	// side-log names), so the message carries no "blockstore:" prefix — unlike
+	// the sentinels above, it is not about blocks.
 	ErrFutureFormat = errors.New("store: on-disk format is newer than this build")
 )

--- a/pkg/block/journal/bounded_growth_test.go
+++ b/pkg/block/journal/bounded_growth_test.go
@@ -17,7 +17,7 @@ func TestOpenSetsDefaultLocalCapWhenUnset(t *testing.T) {
 	if free, err := diskFreeBytes(dir); err != nil || free == 0 {
 		t.Skipf("free-space probe unavailable (free=%d err=%v); default cap not expected", free, err)
 	}
-	s, err := Open(dir, Config{}, newFakeRemote(), SystemClock())
+	s, err := Open(dir, Config{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,7 +39,7 @@ func TestGCReclaimsDeadOverwrites(t *testing.T) {
 	// out of the way so this isolates the dead-ratio repack path.
 	const segSize = 1 << 20
 	cfg := Config{SegmentSize: segSize, ShardCount: 1, MaxLocalBytes: 1 << 30}
-	s, err := Open(t.TempDir(), cfg, newFakeRemote(), SystemClock())
+	s, err := Open(t.TempDir(), cfg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/block/journal/bounded_growth_test.go
+++ b/pkg/block/journal/bounded_growth_test.go
@@ -57,7 +57,7 @@ func TestGCReclaimsDeadOverwrites(t *testing.T) {
 	}
 
 	before := s.diskBytes.Load()
-	if _, err := s.GC(ctx, GCOptions{}); err != nil {
+	if _, err := s.gc(ctx, gcOptions{}); err != nil {
 		t.Fatalf("GC: %v", err)
 	}
 	after := s.diskBytes.Load()

--- a/pkg/block/journal/carve_dispatch_test.go
+++ b/pkg/block/journal/carve_dispatch_test.go
@@ -125,7 +125,7 @@ func ctrlStore(t *testing.T, window int) (*Store, *ctrlSink) {
 		CarveUploadConcurrency: window,
 		ChunkParams:            chunker.Params{Min: 4 << 10, Avg: 8 << 10, Max: 16 << 10},
 	}
-	s, err := Open(t.TempDir(), cfg, newFakeRemote(), newFakeClock())
+	s, err := Open(t.TempDir(), cfg)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}

--- a/pkg/block/journal/carve_test.go
+++ b/pkg/block/journal/carve_test.go
@@ -140,7 +140,8 @@ func (s *fakeSink) blockCount() int {
 func carveStore(t testing.TB, cfg Config) (*Store, *fakeDeduper, *fakeSink, *fakeClock) {
 	t.Helper()
 	clk := newFakeClock()
-	s, err := Open(t.TempDir(), cfg, newFakeRemote(), clk)
+	cfg.Clock = clk
+	s, err := Open(t.TempDir(), cfg)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -406,11 +407,10 @@ func TestCarveReopenReCarveIsNoOp(t *testing.T) {
 	// the records with the correct SegOffset so the re-flip lands on the record —
 	// not the segment header — and dedup must make the re-carve upload-free.
 	dir := t.TempDir()
-	clk := newFakeClock()
 	dd := newFakeDeduper()
 	data := randBytes(2<<20, 11)
 
-	s1, err := Open(dir, Config{CarveBlockSize: 1 << 20}, newFakeRemote(), clk)
+	s1, err := Open(dir, Config{CarveBlockSize: 1 << 20})
 	if err != nil {
 		t.Fatalf("Open s1: %v", err)
 	}
@@ -427,7 +427,7 @@ func TestCarveReopenReCarveIsNoOp(t *testing.T) {
 	_ = s1.Close()
 
 	// Reopen: recovery rebuilds the index from the (now dirty) records.
-	s2, err := Open(dir, Config{CarveBlockSize: 1 << 20}, newFakeRemote(), clk)
+	s2, err := Open(dir, Config{CarveBlockSize: 1 << 20})
 	if err != nil {
 		t.Fatalf("Open s2: %v", err)
 	}

--- a/pkg/block/journal/cold.go
+++ b/pkg/block/journal/cold.go
@@ -48,10 +48,9 @@ import (
 	"errors"
 	"fmt"
 	"hash/crc32"
+	"log/slog"
 	"os"
 	"path/filepath"
-
-	"github.com/marmos91/dittofs/internal/logger"
 )
 
 const (
@@ -264,7 +263,7 @@ func (s *Store) appendCold(entries []coldEntry) error {
 // and returns what precedes it, along with the byte offset just past the last
 // intact entry: anything between that offset and the end of the file is garbage
 // the caller is expected to drop with truncateColdTail before appending.
-func loadCold(dir string) ([]coldEntry, int64, error) {
+func loadCold(dir string, log *slog.Logger) ([]coldEntry, int64, error) {
 	raw, err := os.ReadFile(filepath.Join(dir, coldLogName))
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -277,7 +276,7 @@ func loadCold(dir string) ([]coldEntry, int64, error) {
 	for off < len(raw) {
 		e, n, derr := decodeColdEntry(raw[off:])
 		if derr != nil {
-			logger.Warn("journal: cold log torn, keeping the intact entries",
+			log.Warn("journal: cold log torn, keeping the intact entries",
 				"offset", off, "intact_entries", len(out), "err", derr)
 			break
 		}
@@ -292,7 +291,7 @@ func loadCold(dir string) ([]coldEntry, int64, error) {
 // left in place sits in front of every later entry: the next load stops at the
 // same offset and discards everything appended in between, turning one torn
 // write into the permanent loss of every cold interval recorded after it.
-func truncateColdTail(dir string, validUpTo int64) error {
+func truncateColdTail(dir string, validUpTo int64, log *slog.Logger) error {
 	fd, err := os.OpenFile(filepath.Join(dir, coldLogName), os.O_WRONLY, 0o644)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -308,7 +307,7 @@ func truncateColdTail(dir string, validUpTo int64) error {
 	if st.Size() <= validUpTo {
 		return nil
 	}
-	logger.Warn("journal: dropping torn cold log tail",
+	log.Warn("journal: dropping torn cold log tail",
 		"valid_up_to", validUpTo, "dropped_bytes", st.Size()-validUpTo)
 	if err := fd.Truncate(validUpTo); err != nil {
 		return fmt.Errorf("journal: truncate torn cold log tail: %w", err)

--- a/pkg/block/journal/cold_test.go
+++ b/pkg/block/journal/cold_test.go
@@ -31,7 +31,7 @@ func TestColdIntervalSurvivesReopen(t *testing.T) {
 	dir := t.TempDir()
 	cfg := Config{ShardCount: 1, SegmentSize: minSegmentSize}
 
-	s, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	s, err := Open(dir, cfg)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -57,7 +57,7 @@ func TestColdIntervalSurvivesReopen(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 
-	s2, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	s2, err := Open(dir, cfg)
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestSeedColdSurvivesReopen(t *testing.T) {
 	dir := t.TempDir()
 	cfg := Config{ShardCount: 1, SegmentSize: minSegmentSize}
 
-	s, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	s, err := Open(dir, cfg)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -96,7 +96,7 @@ func TestSeedColdSurvivesReopen(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 
-	s2, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	s2, err := Open(dir, cfg)
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
@@ -117,7 +117,7 @@ func TestColdLogSupersededByLaterWrite(t *testing.T) {
 	dir := t.TempDir()
 	cfg := Config{ShardCount: 1, SegmentSize: minSegmentSize}
 
-	s, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	s, err := Open(dir, cfg)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestColdLogSupersededByLaterWrite(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 
-	s2, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	s2, err := Open(dir, cfg)
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
@@ -161,7 +161,7 @@ func TestColdLogTornTailKeepsIntactEntries(t *testing.T) {
 	dir := t.TempDir()
 	cfg := Config{ShardCount: 1, SegmentSize: minSegmentSize}
 
-	s, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	s, err := Open(dir, cfg)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -185,7 +185,7 @@ func TestColdLogTornTailKeepsIntactEntries(t *testing.T) {
 		t.Fatalf("truncate cold log: %v", err)
 	}
 
-	s2, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	s2, err := Open(dir, cfg)
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
@@ -209,7 +209,7 @@ func TestColdLogTornTailIsRepairedOnOpen(t *testing.T) {
 	dir := t.TempDir()
 	cfg := Config{ShardCount: 1, SegmentSize: minSegmentSize}
 
-	s, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	s, err := Open(dir, cfg)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -233,7 +233,7 @@ func TestColdLogTornTailIsRepairedOnOpen(t *testing.T) {
 	}
 
 	// The process after the crash records another cold range.
-	s2, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	s2, err := Open(dir, cfg)
 	if err != nil {
 		t.Fatalf("reopen over the torn tail: %v", err)
 	}
@@ -244,7 +244,7 @@ func TestColdLogTornTailIsRepairedOnOpen(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 
-	s3, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	s3, err := Open(dir, cfg)
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
@@ -271,7 +271,7 @@ func TestSeedColdLeavesLocalBytesAlone(t *testing.T) {
 	dir := t.TempDir()
 	cfg := Config{ShardCount: 1, SegmentSize: minSegmentSize}
 
-	s, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	s, err := Open(dir, cfg)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -315,7 +315,7 @@ func TestSeedColdIsIdempotent(t *testing.T) {
 	dir := t.TempDir()
 	cfg := Config{ShardCount: 1, SegmentSize: minSegmentSize}
 
-	s, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	s, err := Open(dir, cfg)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -349,7 +349,7 @@ func TestColdSeededMarkerSurvivesReopen(t *testing.T) {
 	dir := t.TempDir()
 	cfg := Config{ShardCount: 1, SegmentSize: minSegmentSize}
 
-	s, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	s, err := Open(dir, cfg)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -366,7 +366,7 @@ func TestColdSeededMarkerSurvivesReopen(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 
-	s2, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	s2, err := Open(dir, cfg)
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
@@ -394,7 +394,7 @@ func TestEvictAppendsColdEntriesBeforeReturning(t *testing.T) {
 	dir := t.TempDir()
 	cfg := Config{ShardCount: 1, SegmentSize: minSegmentSize}
 
-	s, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	s, err := Open(dir, cfg)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -443,7 +443,7 @@ func TestSeedColdBatchIsDurableAndMatchesPerFileSeeding(t *testing.T) {
 	cfg := Config{ShardCount: 4, SegmentSize: minSegmentSize}
 
 	batchDir := t.TempDir()
-	batched, err := Open(batchDir, cfg, newFakeRemote(), newFakeClock())
+	batched, err := Open(batchDir, cfg)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -471,7 +471,7 @@ func TestSeedColdBatchIsDurableAndMatchesPerFileSeeding(t *testing.T) {
 	}
 
 	oneDir := t.TempDir()
-	oneAtATime, err := Open(oneDir, cfg, newFakeRemote(), newFakeClock())
+	oneAtATime, err := Open(oneDir, cfg)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}

--- a/pkg/block/journal/cold_test.go
+++ b/pkg/block/journal/cold_test.go
@@ -412,7 +412,7 @@ func TestEvictAppendsColdEntriesBeforeReturning(t *testing.T) {
 
 	// Deliberately no Close and no Sync from the test: whatever is on disk here,
 	// the eviction put there before it returned.
-	entries, _, err := loadCold(dir)
+	entries, _, err := loadCold(dir, nil)
 	if err != nil {
 		t.Fatalf("loadCold: %v", err)
 	}
@@ -453,7 +453,7 @@ func TestSeedColdBatchIsDurableAndMatchesPerFileSeeding(t *testing.T) {
 	}
 
 	// Again no Close: a batch that only becomes durable on shutdown is the bug.
-	got, _, err := loadCold(batchDir)
+	got, _, err := loadCold(batchDir, nil)
 	if err != nil {
 		t.Fatalf("loadCold after batch: %v", err)
 	}
@@ -481,7 +481,7 @@ func TestSeedColdBatchIsDurableAndMatchesPerFileSeeding(t *testing.T) {
 			t.Fatalf("SeedCold %q: %v", sd.ID, err)
 		}
 	}
-	want, _, err := loadCold(oneDir)
+	want, _, err := loadCold(oneDir, nil)
 	if err != nil {
 		t.Fatalf("loadCold after per-file seeding: %v", err)
 	}

--- a/pkg/block/journal/dirty_expire_test.go
+++ b/pkg/block/journal/dirty_expire_test.go
@@ -13,7 +13,7 @@ import (
 // write, so it can never observe it unset.
 func openDirtyExpireStore(t *testing.T, id FileID, expiry time.Duration) (*Store, *shard, *atomic.Int32) {
 	t.Helper()
-	s, err := Open(t.TempDir(), Config{DirtyExpiry: expiry}, newFakeRemote(), SystemClock())
+	s, err := Open(t.TempDir(), Config{DirtyExpiry: expiry})
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}

--- a/pkg/block/journal/disk_bytes_test.go
+++ b/pkg/block/journal/disk_bytes_test.go
@@ -51,7 +51,7 @@ func TestDiskBytesSeededOverCapConvergesDown(t *testing.T) {
 	ctx := context.Background()
 	cfg := Config{ShardCount: 1, SegmentSize: minSegmentSize}
 
-	first, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	first, err := Open(dir, cfg)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestDiskBytesSeededOverCapConvergesDown(t *testing.T) {
 	capBytes := onDisk / 4
 	reopened := Config{ShardCount: 1, SegmentSize: minSegmentSize, MaxLocalBytes: capBytes}
 
-	s, err := Open(dir, reopened, newFakeRemote(), newFakeClock())
+	s, err := Open(dir, reopened)
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}

--- a/pkg/block/journal/doc.go
+++ b/pkg/block/journal/doc.go
@@ -4,10 +4,10 @@
 // a remote store, pressure-gated eviction, and garbage collection.
 //
 // It owns all persistent local-cache state and depends only on the standard
-// library plus a pair of narrow injected interfaces (RemoteStore, Clock). It
-// knows nothing about namespaces, protocols, permissions, or the metadata
-// store — callers resolve logical offsets to FileIDs and hand journal opaque
-// byte ranges.
+// library plus narrow injected interfaces (the carve collaborators [Deduper]
+// and [BlockSink], and Clock). It knows nothing about namespaces, protocols,
+// permissions, or the metadata store — callers resolve logical offsets to
+// FileIDs and hand journal opaque byte ranges.
 //
 // The unifying model: client writes (WriteAt) and cold-read hydration
 // (Hydrate) both funnel through one internal append primitive, differing only

--- a/pkg/block/journal/durable_extent_test.go
+++ b/pkg/block/journal/durable_extent_test.go
@@ -24,7 +24,7 @@ func TestDurableExtent_PredictsWhatSurvivesDeviceLoss(t *testing.T) {
 	const rec = 4096
 	dir := t.TempDir()
 	cfg := Config{ShardCount: 1}
-	s, err := Open(dir, cfg, newFakeRemote(), SystemClock())
+	s, err := Open(dir, cfg)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -74,7 +74,7 @@ func TestDurableExtent_PredictsWhatSurvivesDeviceLoss(t *testing.T) {
 		t.Fatalf("truncate segment to the last fsync: %v", err)
 	}
 
-	r, err := Open(dir, cfg, newFakeRemote(), SystemClock())
+	r, err := Open(dir, cfg)
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}

--- a/pkg/block/journal/evict_test.go
+++ b/pkg/block/journal/evict_test.go
@@ -19,13 +19,14 @@ const chunk256 = 256 << 10
 func evictStore(t *testing.T, cfg Config) (*Store, *fakeClock) {
 	t.Helper()
 	clk := newFakeClock()
+	cfg.Clock = clk
 	if cfg.ShardCount == 0 {
 		cfg.ShardCount = 1
 	}
 	if cfg.SegmentSize == 0 {
 		cfg.SegmentSize = minSegmentSize
 	}
-	s, err := Open(t.TempDir(), cfg, newFakeRemote(), clk)
+	s, err := Open(t.TempDir(), cfg)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -498,7 +499,7 @@ func TestInvalidatedRangeSurvivesEviction(t *testing.T) {
 	cfg := Config{ShardCount: 1, SegmentSize: minSegmentSize}
 	ctx := context.Background()
 
-	s, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	s, err := Open(dir, cfg)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -517,7 +518,7 @@ func TestInvalidatedRangeSurvivesEviction(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 
-	s2, err := Open(dir, cfg, newFakeRemote(), newFakeClock())
+	s2, err := Open(dir, cfg)
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
@@ -654,10 +655,9 @@ func TestEvictPrefersOlderStampOverUnstamped(t *testing.T) {
 // approx-LRU stops approximating anything after a restart.
 func TestReopenedSegmentsHaveEvictionAge(t *testing.T) {
 	dir := t.TempDir()
-	clk := newFakeClock()
-	cfg := Config{ShardCount: 1, SegmentSize: minSegmentSize}
+	cfg := Config{ShardCount: 1, SegmentSize: minSegmentSize, Clock: newFakeClock()}
 
-	s, err := Open(dir, cfg, newFakeRemote(), clk)
+	s, err := Open(dir, cfg)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -666,7 +666,7 @@ func TestReopenedSegmentsHaveEvictionAge(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 
-	s2, err := Open(dir, cfg, newFakeRemote(), clk)
+	s2, err := Open(dir, cfg)
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}

--- a/pkg/block/journal/format.go
+++ b/pkg/block/journal/format.go
@@ -21,9 +21,11 @@ import (
 	"os"
 	"path/filepath"
 	"time"
-
-	"github.com/marmos91/dittofs/pkg/block"
 )
+
+// errFutureFormat is returned when a journal directory was written by a newer
+// layout than this build reads: opening it would serve stored ranges as holes.
+var errFutureFormat = errors.New("journal: on-disk format is from a newer release")
 
 const (
 	// formatVersion is the layout this build reads and writes. Bump it whenever
@@ -47,10 +49,10 @@ type formatStamp struct {
 	WrittenAt string `json:"written_at"`
 }
 
-// CheckFormat verifies that this build understands the journal directory's
+// checkFormat verifies that this build understands the journal directory's
 // on-disk layout, and brings the stamp up to what this build may write. An
 // unstamped directory predates stamping and is adopted; a stamp above
-// formatVersion fails with block.ErrFutureFormat.
+// formatVersion fails with errFutureFormat.
 //
 // A stamp *below* formatVersion is raised, not left alone. The stamp has to
 // describe what the directory may now contain, and this build starts writing
@@ -60,9 +62,9 @@ type formatStamp struct {
 // stamp exists to keep it away from, which for the cold log means reading a
 // remote-durable range as a hole and serving zeros.
 //
-// Call it before opening the journal: the point is to not touch state whose
-// shape is unknown.
-func CheckFormat(dir string) error {
+// Open runs it before anything else in the directory: the point is to not
+// touch state whose shape is unknown.
+func checkFormat(dir string) error {
 	raw, err := os.ReadFile(filepath.Join(dir, formatFileName))
 	if errors.Is(err, os.ErrNotExist) {
 		return writeFormat(dir)
@@ -78,7 +80,7 @@ func CheckFormat(dir string) error {
 	}
 	if st.Version > formatVersion {
 		return fmt.Errorf("%w: %s is at format version %d, this build reads up to %d",
-			block.ErrFutureFormat, dir, st.Version, formatVersion)
+			errFutureFormat, dir, st.Version, formatVersion)
 	}
 	if st.Version < formatVersion {
 		return writeFormat(dir)

--- a/pkg/block/journal/format.go
+++ b/pkg/block/journal/format.go
@@ -23,9 +23,11 @@ import (
 	"time"
 )
 
-// errFutureFormat is returned when a journal directory was written by a newer
+// ErrFutureFormat is returned when a journal directory was written by a newer
 // layout than this build reads: opening it would serve stored ranges as holes.
-var errFutureFormat = errors.New("journal: on-disk format is from a newer release")
+// Boot guards match it to stop the daemon rather than run with the share
+// silently absent.
+var ErrFutureFormat = errors.New("journal: on-disk format is from a newer release")
 
 const (
 	// formatVersion is the layout this build reads and writes. Bump it whenever
@@ -52,7 +54,7 @@ type formatStamp struct {
 // checkFormat verifies that this build understands the journal directory's
 // on-disk layout, and brings the stamp up to what this build may write. An
 // unstamped directory predates stamping and is adopted; a stamp above
-// formatVersion fails with errFutureFormat.
+// formatVersion fails with ErrFutureFormat.
 //
 // A stamp *below* formatVersion is raised, not left alone. The stamp has to
 // describe what the directory may now contain, and this build starts writing
@@ -80,7 +82,7 @@ func checkFormat(dir string) error {
 	}
 	if st.Version > formatVersion {
 		return fmt.Errorf("%w: %s is at format version %d, this build reads up to %d",
-			errFutureFormat, dir, st.Version, formatVersion)
+			ErrFutureFormat, dir, st.Version, formatVersion)
 	}
 	if st.Version < formatVersion {
 		return writeFormat(dir)

--- a/pkg/block/journal/gc_test.go
+++ b/pkg/block/journal/gc_test.go
@@ -271,7 +271,7 @@ func TestGCBelowThresholdNeedsForce(t *testing.T) {
 func TestGCCrashBeforeUnlinkOrphanSwept(t *testing.T) {
 	dir := t.TempDir()
 	cfg := Config{SegmentSize: minSegmentSize, ShardCount: 1}
-	s, err := Open(dir, cfg, newFakeRemote(), SystemClock())
+	s, err := Open(dir, cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -299,7 +299,7 @@ func TestGCCrashBeforeUnlinkOrphanSwept(t *testing.T) {
 	_ = s.Close()
 
 	// Restart: recovery replays both segments (identical Version -> byte-identical).
-	r, err := Open(dir, cfg, newFakeRemote(), SystemClock())
+	r, err := Open(dir, cfg)
 	if err != nil {
 		t.Fatalf("recovery after crash-before-unlink: %v", err)
 	}

--- a/pkg/block/journal/gc_test.go
+++ b/pkg/block/journal/gc_test.go
@@ -142,7 +142,7 @@ func TestGCForcedRepackPreservesData(t *testing.T) {
 	sh.mu.Unlock()
 
 	// 0.7 dead ratio >= default GCDeadRatioForce (0.5): an auto pass repacks it.
-	res, err := s.GC(ctx, GCOptions{})
+	res, err := s.gc(ctx, gcOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,7 +200,7 @@ func TestGCRepackDirtyTargetNotEvictable(t *testing.T) {
 	keep := seedRepackable(t, s, false)
 
 	// 0.7 dead ratio >= default GCDeadRatioForce (0.5): an auto pass repacks it.
-	res, err := s.GC(ctx, GCOptions{})
+	res, err := s.gc(ctx, gcOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -252,14 +252,14 @@ func TestGCBelowThresholdNeedsForce(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res, err := s.GC(ctx, GCOptions{}) // ~5% dead < 0.5: no-op
+	res, err := s.gc(ctx, gcOptions{}) // ~5% dead < 0.5: no-op
 	if err != nil {
 		t.Fatal(err)
 	}
 	if res.SegmentsRepacked != 0 {
 		t.Fatalf("auto GC repacked below threshold: %d", res.SegmentsRepacked)
 	}
-	res, err = s.GC(ctx, GCOptions{Force: true}) // Force repacks the worst offender
+	res, err = s.gc(ctx, gcOptions{Force: true}) // Force repacks the worst offender
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -281,7 +281,7 @@ func TestGCCrashBeforeUnlinkOrphanSwept(t *testing.T) {
 	// Repack but stop right before reclaiming the victim: on disk the target is
 	// durable while the victim still exists (crash-before-unlink).
 	testStopBeforeUnlink = true
-	if _, err := s.GC(ctx, GCOptions{Force: true}); err != nil {
+	if _, err := s.gc(ctx, gcOptions{Force: true}); err != nil {
 		testStopBeforeUnlink = false
 		t.Fatal(err)
 	}
@@ -325,7 +325,7 @@ func TestGCCrashBeforeUnlinkOrphanSwept(t *testing.T) {
 	}
 
 	// The redundant orphan is reclaimable: a forced pass frees it, leaving data intact.
-	if _, err := r.GC(ctx, GCOptions{Force: true}); err != nil {
+	if _, err := r.gc(ctx, gcOptions{Force: true}); err != nil {
 		t.Fatal(err)
 	}
 	got2 := make([]byte, len(keep))
@@ -362,7 +362,7 @@ func TestGCTombstoneOnlySegmentTerminates(t *testing.T) {
 	// Non-Force GC must terminate. With the bug it repacks the fully-dead segment
 	// into a tombstone-only one, then loops forever repacking that. Bound the pass.
 	done := make(chan error, 1)
-	go func() { _, err := s.GC(ctx, GCOptions{}); done <- err }()
+	go func() { _, err := s.gc(ctx, gcOptions{}); done <- err }()
 	select {
 	case err := <-done:
 		if err != nil {
@@ -373,7 +373,7 @@ func TestGCTombstoneOnlySegmentTerminates(t *testing.T) {
 	}
 
 	// A second pass finds nothing to reclaim in the tombstone-only segment.
-	res, err := s.GC(ctx, GCOptions{})
+	res, err := s.gc(ctx, gcOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -492,7 +492,7 @@ func TestGCConcurrentWithWrites(t *testing.T) {
 				return
 			default:
 			}
-			if _, err := s.GC(ctx, GCOptions{Force: true}); err != nil {
+			if _, err := s.gc(ctx, gcOptions{Force: true}); err != nil {
 				t.Errorf("GC: %v", err)
 				return
 			}

--- a/pkg/block/journal/index.go
+++ b/pkg/block/journal/index.go
@@ -11,10 +11,10 @@ import (
 	"github.com/marmos91/dittofs/pkg/block/chunker"
 )
 
-// SegmentLocation points at a record payload inside a shared segment. It
+// segmentLocation points at a record payload inside a shared segment. It
 // replaces the old one-file-per-payload location: because segments are shared,
 // an index entry can no longer assume it names its own file's blob.
-type SegmentLocation struct {
+type segmentLocation struct {
 	SegmentID uint64
 	Offset    int64 // byte offset of the payload within the segment
 	Length    int64 // payload length
@@ -30,7 +30,7 @@ type interval struct {
 	fileOff int64
 	length  int64
 	version uint64
-	loc     SegmentLocation
+	loc     segmentLocation
 	// recOff is the byte offset of the owning record's header start within its
 	// segment. Carve flips that record's synced flag in place at recOff, so it
 	// survives an interval split (trimming the live range never moves the record).
@@ -69,7 +69,7 @@ func (iv interval) clamp(lo, hi int64) interval {
 		// compaction rebuilds the log from the index, so a dropped provenance
 		// here comes back as coldFromUnknown on disk.
 		provenance: iv.provenance,
-		loc: SegmentLocation{
+		loc: segmentLocation{
 			SegmentID: iv.loc.SegmentID,
 			Offset:    iv.loc.Offset + frontTrim,
 			Length:    hi - lo,
@@ -245,7 +245,7 @@ func subtractAll(frags []interval, rs, re int64) []interval {
 type piece struct {
 	dstStart int64
 	dstEnd   int64
-	loc      SegmentLocation
+	loc      segmentLocation
 	subOff   int64
 	// recOff is the segment offset of the owning record's header, carried from the
 	// interval so a verified read can re-read the whole covering record and check

--- a/pkg/block/journal/index_invariant_test.go
+++ b/pkg/block/journal/index_invariant_test.go
@@ -57,7 +57,7 @@ func TestIntervalIndexStaysSortedAndDisjoint(t *testing.T) {
 	dir := t.TempDir()
 	ctx := context.Background()
 
-	s, err := Open(dir, Config{ShardCount: 1}, newFakeRemote(), SystemClock())
+	s, err := Open(dir, Config{ShardCount: 1})
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -111,7 +111,7 @@ func TestIntervalIndexStaysSortedAndDisjoint(t *testing.T) {
 	}
 	_ = s.Close()
 
-	r, err := Open(dir, Config{ShardCount: 1}, newFakeRemote(), SystemClock())
+	r, err := Open(dir, Config{ShardCount: 1})
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}

--- a/pkg/block/journal/index_test.go
+++ b/pkg/block/journal/index_test.go
@@ -22,8 +22,8 @@ func coveringSeg(fi *fileIndex, off int64) (uint64, bool) {
 // a higher-version one must not supersede it. This is the recovery/repack
 // out-of-order case (WriteAt itself assigns versions monotonically).
 func TestInsertNewestWinsByVersion(t *testing.T) {
-	locHi := SegmentLocation{SegmentID: 1, Offset: 100, Length: 10}
-	locLo := SegmentLocation{SegmentID: 2, Offset: 200, Length: 4}
+	locHi := segmentLocation{SegmentID: 1, Offset: 100, Length: 10}
+	locLo := segmentLocation{SegmentID: 2, Offset: 200, Length: 4}
 
 	// v5 then v3: the later-indexed older write loses the overlap.
 	var a fileIndex
@@ -51,12 +51,12 @@ func TestInsertNewestWinsByVersion(t *testing.T) {
 // segment offset so the surviving fragment still points at the right bytes.
 func TestInsertPartialOverlapSplitsLocation(t *testing.T) {
 	var fi fileIndex
-	fi.insert(interval{fileOff: 0, length: 10, version: 5, loc: SegmentLocation{SegmentID: 1, Offset: 100, Length: 10}})
-	fi.insert(interval{fileOff: 8, length: 7, version: 3, loc: SegmentLocation{SegmentID: 2, Offset: 200, Length: 7}})
+	fi.insert(interval{fileOff: 0, length: 10, version: 5, loc: segmentLocation{SegmentID: 1, Offset: 100, Length: 10}})
+	fi.insert(interval{fileOff: 8, length: 7, version: 3, loc: segmentLocation{SegmentID: 2, Offset: 200, Length: 7}})
 
 	want := []interval{
-		{fileOff: 0, length: 10, version: 5, loc: SegmentLocation{SegmentID: 1, Offset: 100, Length: 10}},
-		{fileOff: 10, length: 5, version: 3, loc: SegmentLocation{SegmentID: 2, Offset: 202, Length: 5}},
+		{fileOff: 0, length: 10, version: 5, loc: segmentLocation{SegmentID: 1, Offset: 100, Length: 10}},
+		{fileOff: 10, length: 5, version: 3, loc: segmentLocation{SegmentID: 2, Offset: 202, Length: 5}},
 	}
 	if len(fi.ivs) != len(want) {
 		t.Fatalf("ivs=%+v want %+v", fi.ivs, want)

--- a/pkg/block/journal/journal_bench_test.go
+++ b/pkg/block/journal/journal_bench_test.go
@@ -3,59 +3,9 @@ package journal
 import (
 	"bytes"
 	"context"
-	"errors"
-	"io"
-	"sync"
 	"testing"
 	"time"
 )
-
-// fakeRemote is an in-memory RemoteStore for tests and benchmarks. It buffers
-// each block whole — fine for a fake, never used on a hot path.
-type fakeRemote struct {
-	mu     sync.Mutex
-	blocks map[BlockID][]byte
-}
-
-func newFakeRemote() *fakeRemote { return &fakeRemote{blocks: make(map[BlockID][]byte)} }
-
-func (f *fakeRemote) PutBlock(_ context.Context, id BlockID, r io.Reader, _ int64) error {
-	b, err := io.ReadAll(r)
-	if err != nil {
-		return err
-	}
-	f.mu.Lock()
-	f.blocks[id] = b
-	f.mu.Unlock()
-	return nil
-}
-
-func (f *fakeRemote) GetBlock(_ context.Context, id BlockID) (io.ReadCloser, error) {
-	f.mu.Lock()
-	b, ok := f.blocks[id]
-	f.mu.Unlock()
-	if !ok {
-		return nil, errors.New("fakeRemote: block not found")
-	}
-	return io.NopCloser(bytes.NewReader(b)), nil
-}
-
-func (f *fakeRemote) GetRange(_ context.Context, id BlockID, off, length int64) (io.ReadCloser, error) {
-	f.mu.Lock()
-	b, ok := f.blocks[id]
-	f.mu.Unlock()
-	if !ok {
-		return nil, errors.New("fakeRemote: block not found")
-	}
-	if off < 0 || off > int64(len(b)) {
-		return nil, errors.New("fakeRemote: range out of bounds")
-	}
-	end := off + length
-	if end > int64(len(b)) {
-		end = int64(len(b))
-	}
-	return io.NopCloser(bytes.NewReader(b[off:end])), nil
-}
 
 func benchStore(b *testing.B) *Store {
 	b.Helper()
@@ -133,7 +83,7 @@ func BenchmarkReadWarm(b *testing.B) {
 // The deduper always misses and the sink is a no-op, so every pass does the full
 // chunk-hash-pack work (the worst case) rather than short-circuiting on dedup.
 func BenchmarkCarve(b *testing.B) {
-	s, err := Open(b.TempDir(), Config{}, newFakeRemote(), newFakeClock())
+	s, err := Open(b.TempDir(), Config{})
 	if err != nil {
 		b.Fatalf("Open: %v", err)
 	}

--- a/pkg/block/journal/journal_test.go
+++ b/pkg/block/journal/journal_test.go
@@ -12,7 +12,7 @@ func TestInputGuards(t *testing.T) {
 	ctx := context.Background()
 
 	// SegmentSize below the floor is rejected at Open.
-	if _, err := Open(t.TempDir(), Config{SegmentSize: 100}, newFakeRemote(), SystemClock()); err == nil {
+	if _, err := Open(t.TempDir(), Config{SegmentSize: 100}); err == nil {
 		t.Fatalf("expected too-small SegmentSize to be rejected")
 	}
 
@@ -42,7 +42,7 @@ func TestInputGuards(t *testing.T) {
 
 func testStore(t *testing.T, cfg Config) *Store {
 	t.Helper()
-	s, err := Open(t.TempDir(), cfg, newFakeRemote(), SystemClock())
+	s, err := Open(t.TempDir(), cfg)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -174,7 +174,7 @@ func TestShardForDeterministicAndMasked(t *testing.T) {
 
 func TestReopenPopulatedDirRecovers(t *testing.T) {
 	dir := t.TempDir()
-	s, err := Open(dir, Config{}, newFakeRemote(), SystemClock())
+	s, err := Open(dir, Config{})
 	if err != nil {
 		t.Fatalf("first Open: %v", err)
 	}
@@ -182,7 +182,7 @@ func TestReopenPopulatedDirRecovers(t *testing.T) {
 		t.Fatalf("WriteAt: %v", err)
 	}
 	_ = s.Close()
-	r, err := Open(dir, Config{}, newFakeRemote(), SystemClock())
+	r, err := Open(dir, Config{})
 	if err != nil {
 		t.Fatalf("reopen should recover, got: %v", err)
 	}

--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -513,16 +513,16 @@ func (s *Store) reclaimEmptied(sh *shard) error {
 // LOCAL records and marks LOCAL space dead; the deleted file's remote blocks are
 // freed later by that sweep, off this path.
 
-// GCOptions selects a GC pass's aggressiveness.
-type GCOptions struct {
+// gcOptions selects a GC pass's aggressiveness.
+type gcOptions struct {
 	// Force repacks the single highest-dead-ratio sealed segment in each shard
 	// even when its ratio is below GCDeadRatioForce (an explicit / test trigger).
 	// Without it, a pass repacks every segment at or above the force threshold.
 	Force bool
 }
 
-// GCResult reports what a GC pass reclaimed.
-type GCResult struct {
+// gcResult reports what a GC pass reclaimed.
+type gcResult struct {
 	SegmentsRepacked int
 	BytesReclaimed   int64 // net local bytes freed (victim size minus relocated live)
 }
@@ -530,17 +530,17 @@ type GCResult struct {
 // GC repacks sealed segments whose dead-byte fraction has grown, freeing the
 // space superseded writes and tombstones left behind. It is safe to call from a
 // background loop or explicitly; passes serialize on gcMu.
-func (s *Store) GC(ctx context.Context, opts GCOptions) (GCResult, error) {
+func (s *Store) gc(ctx context.Context, opts gcOptions) (gcResult, error) {
 	if err := ctx.Err(); err != nil {
-		return GCResult{}, err
+		return gcResult{}, err
 	}
 	if s.closed.Load() {
-		return GCResult{}, errClosed
+		return gcResult{}, errClosed
 	}
 	s.gcMu.Lock()
 	defer s.gcMu.Unlock()
 
-	var res GCResult
+	var res gcResult
 	for _, sh := range s.shards {
 		reclaimed, count, err := s.gcShard(ctx, sh, opts)
 		res.SegmentsRepacked += count
@@ -556,7 +556,7 @@ func (s *Store) GC(ctx context.Context, opts GCOptions) (GCResult, error) {
 // carveMu for the whole pass so carve — which flips synced bits by record offset
 // — never runs against a segment repack is relocating (the same segment-busy
 // discipline eviction takes).
-func (s *Store) gcShard(ctx context.Context, sh *shard, opts GCOptions) (reclaimed int64, count int, err error) {
+func (s *Store) gcShard(ctx context.Context, sh *shard, opts gcOptions) (reclaimed int64, count int, err error) {
 	sh.carveMu.Lock()
 	defer sh.carveMu.Unlock()
 
@@ -635,7 +635,7 @@ func shardLiveBytes(sh *shard) map[uint64]int64 {
 // (robust to the recovery-time deadBytes approximation and to the extra dead a
 // crash-during-repack leaves behind); a segment's dead fraction is
 // dead/occupied. Without Force, a victim must reach GCDeadRatioForce.
-func (s *Store) pickVictim(sh *shard, opts GCOptions, live map[uint64]int64) *segmentMeta {
+func (s *Store) pickVictim(sh *shard, opts gcOptions, live map[uint64]int64) *segmentMeta {
 	sh.mu.Lock()
 	defer sh.mu.Unlock()
 	if len(sh.sealed) == 0 {

--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"os"
 	"time"
-
-	"github.com/marmos91/dittofs/internal/logger"
 )
 
 // Segment reclamation: two distinct policies over one shared retirement tail.
@@ -376,7 +374,7 @@ func (s *Store) ensureSpace(ctx context.Context, needed int64) error {
 			// are reported apart because the operator's next move differs —
 			// suspended is a remote outage to fix, pinned is a retention policy to
 			// change. All zero and false leaves a snapshot pinning every candidate.
-			logger.Warn("journal local store full: nothing evictable, backpressuring writes",
+			s.log.Warn("journal local store full: nothing evictable, backpressuring writes",
 				"dir", s.dir,
 				"disk_bytes", s.diskBytes.Load(),
 				"max_local_bytes", s.cfg.MaxLocalBytes,
@@ -488,7 +486,7 @@ func (s *Store) reclaimEmptied(sh *shard) error {
 		}
 		if _, err := s.retireSegment(sh, seg); err != nil {
 			seg.busy.Store(false)
-			logger.Warn("journal: reclaim emptied segment", "segment", seg.id, "err", err)
+			s.log.Warn("journal: reclaim emptied segment", "segment", seg.id, "err", err)
 			return err
 		}
 	}
@@ -767,7 +765,7 @@ func (s *Store) repackSegment(sh *shard, victim *segmentMeta, live map[uint64]in
 	// by every later pass, so one damaged segment does not stall the shard.
 	quarantine := func(err error) error {
 		victim.corrupt.Store(true)
-		logger.Warn("journal: segment failed a repack integrity check; leaving it in place and skipping it",
+		s.log.Warn("journal: segment failed a repack integrity check; leaving it in place and skipping it",
 			"segment", victim.id, "err", err)
 		return err
 	}
@@ -894,7 +892,7 @@ func (s *Store) repackSegment(sh *shard, victim *segmentMeta, live map[uint64]in
 		// Defensive: nothing writes to a sealed segment, so this cannot happen;
 		// keep the victim to preserve those bytes rather than lose data. The
 		// target is a redundant orphan the next pass reclaims.
-		logger.Warn("journal: repack left live intervals in the victim segment; keeping it",
+		s.log.Warn("journal: repack left live intervals in the victim segment; keeping it",
 			"segment", victim.id, "live_intervals", remaining)
 		return 0, nil
 	}

--- a/pkg/block/journal/recovery.go
+++ b/pkg/block/journal/recovery.go
@@ -326,7 +326,7 @@ func (r *recoveryState) replayRecords(m *segmentMeta, sh, id uint64, recs []reco
 			version: rec.header.Version,
 			recOff:  rec.segOff,
 			synced:  synced,
-			loc: SegmentLocation{
+			loc: segmentLocation{
 				SegmentID: id,
 				Offset:    payloadOff,
 				Length:    int64(rec.header.PayloadLen),

--- a/pkg/block/journal/recovery.go
+++ b/pkg/block/journal/recovery.go
@@ -7,8 +7,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/marmos91/dittofs/internal/logger"
 )
 
 // orphanMinAge gates the recovery orphan sweep: a segment file that recovery
@@ -70,7 +68,7 @@ func (s *Store) recover() error {
 		return err
 	}
 	if r.missingIdx > 0 {
-		logger.Warn("journal: segments missing .idx sidecar, rebuilding from segment scan (recovery slower)",
+		r.s.log.Warn("journal: segments missing .idx sidecar, rebuilding from segment scan (recovery slower)",
 			"segments", r.missingIdx)
 	}
 	if err := r.applyColdLog(); err != nil {
@@ -222,7 +220,7 @@ func (r *recoveryState) loadSegment(id uint64) error {
 		// destroy the only remaining copy of whatever payload is still down
 		// there.
 		_ = fd.Close()
-		logger.Warn("journal: sealed segment scans as zero valid records (damaged first record), skipping it; left in place for inspection",
+		r.s.log.Warn("journal: sealed segment scans as zero valid records (damaged first record), skipping it; left in place for inspection",
 			"segment_path", path)
 		return nil
 	}
@@ -356,13 +354,13 @@ func (r *recoveryState) replayRecords(m *segmentMeta, sh, id uint64, recs []reco
 // each entry's original Version, so a later warm write shadows it and the
 // tombstone/truncate passes clip it exactly like a warm interval.
 func (r *recoveryState) applyColdLog() error {
-	coldLoaded, validUpTo, err := loadCold(r.s.dir)
+	coldLoaded, validUpTo, err := loadCold(r.s.dir, r.s.log)
 	if err != nil {
 		return err
 	}
 	// Repair before anything appends: recovery is the only point where the log
 	// is known to end at an intact entry.
-	if err := truncateColdTail(r.s.dir, validUpTo); err != nil {
+	if err := truncateColdTail(r.s.dir, validUpTo, r.s.log); err != nil {
 		return err
 	}
 	r.coldLoaded = len(coldLoaded)
@@ -407,7 +405,7 @@ func (r *recoveryState) compactColdLog() {
 	if werr := r.s.rewriteCold(live); werr != nil {
 		// Non-fatal: a stale-but-valid log costs redundant replay, not
 		// correctness, and refusing to open would strand the whole share.
-		logger.Warn("journal: cold log compaction failed, keeping the existing log", "err", werr)
+		r.s.log.Warn("journal: cold log compaction failed, keeping the existing log", "err", werr)
 	}
 }
 

--- a/pkg/block/journal/recovery_test.go
+++ b/pkg/block/journal/recovery_test.go
@@ -11,28 +11,32 @@ import (
 	"time"
 )
 
-// captureWarnings opens the store with a Config.Logger writing into a buffer
-// and returns an accessor for what was logged.
-func captureWarnings(t *testing.T) (Config, func() string) {
+// captureWarnings returns a *slog.Logger writing into a buffer and an accessor
+// for what was logged.
+func captureWarnings(t *testing.T) (*slog.Logger, func() string) {
 	t.Helper()
 	var buf bytes.Buffer
 	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
-	t.Cleanup(func() {})
-	return Config{Logger: log}, buf.String
+	return log, buf.String
 }
 
 // reopen closes s and opens a fresh Store over the same directory, exercising
-// the recovery path.
+// the recovery path. cfg's non-zero fields override s's config; zero fields
+// keep s's values.
 func reopen(t *testing.T, s *Store, cfg Config) *Store {
 	t.Helper()
 	dir := s.dir
-	if cfg.Logger == nil {
-		cfg = s.cfg
+	merged := s.cfg
+	if cfg.Logger != nil {
+		merged.Logger = cfg.Logger
+	}
+	if cfg.Clock != nil {
+		merged.Clock = cfg.Clock
 	}
 	if err := s.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	r, err := Open(dir, cfg)
+	r, err := Open(dir, merged)
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
@@ -246,9 +250,9 @@ func TestMissingIdxRebuilt(t *testing.T) {
 		t.Fatalf("remove sealed .idx: %v", err)
 	}
 
-	cfg, warned := captureWarnings(t)
+	logger, warned := captureWarnings(t)
 
-	r := reopen(t, s, cfg)
+	r := reopen(t, s, Config{Logger: logger})
 	if !strings.Contains(warned(), "missing .idx sidecar") {
 		t.Fatalf("expected a Warn for the missing .idx")
 	}
@@ -378,9 +382,9 @@ func TestSealedSegmentWithNoValidRecords(t *testing.T) {
 		t.Fatalf("chtimes: %v", err)
 	}
 
-	cfg, warned := captureWarnings(t)
+	logger, warned := captureWarnings(t)
 
-	r, err := Open(dir, Config{ShardCount: 1, Logger: cfg.Logger})
+	r, err := Open(dir, Config{ShardCount: 1, Logger: logger})
 	if err != nil {
 		t.Fatalf("reopen over damaged sealed segment: %v", err)
 	}

--- a/pkg/block/journal/recovery_test.go
+++ b/pkg/block/journal/recovery_test.go
@@ -270,11 +270,6 @@ func TestMissingIdxRebuilt(t *testing.T) {
 	_ = written
 }
 
-// fixedClock is a Clock pinned to a fixed instant, used to drive the age gate.
-type fixedClock struct{ t time.Time }
-
-func (c fixedClock) Now() time.Time { return c.t }
-
 // TestOrphanSweepAgeGated asserts an unattachable, aged segment file is
 // unlinked on reopen, while the store's real data is untouched.
 func TestOrphanSweepAgeGated(t *testing.T) {

--- a/pkg/block/journal/recovery_test.go
+++ b/pkg/block/journal/recovery_test.go
@@ -3,31 +3,32 @@ package journal
 import (
 	"bytes"
 	"context"
+	"log/slog"
 	"os"
 	"strings"
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/marmos91/dittofs/internal/logger"
 )
 
-// captureWarnings routes the process logger into a buffer for the duration of
-// the test and returns an accessor for what was logged.
-func captureWarnings(t *testing.T) func() string {
+// captureWarnings opens the store with a Config.Logger writing into a buffer
+// and returns an accessor for what was logged.
+func captureWarnings(t *testing.T) (Config, func() string) {
 	t.Helper()
 	var buf bytes.Buffer
-	logger.InitWithWriter(&buf, "WARN", "text", false)
-	t.Cleanup(func() { logger.InitWithWriter(os.Stdout, "INFO", "text", false) })
-	return buf.String
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	t.Cleanup(func() {})
+	return Config{Logger: log}, buf.String
 }
 
 // reopen closes s and opens a fresh Store over the same directory, exercising
 // the recovery path.
-func reopen(t *testing.T, s *Store) *Store {
+func reopen(t *testing.T, s *Store, cfg Config) *Store {
 	t.Helper()
 	dir := s.dir
-	cfg := s.cfg
+	if cfg.Logger == nil {
+		cfg = s.cfg
+	}
 	clock := s.clock
 	if err := s.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
@@ -79,7 +80,7 @@ func TestRecoveryRoundTrip(t *testing.T) {
 		t.Fatalf("Commit: %v", err)
 	}
 
-	r := reopen(t, s)
+	r := reopen(t, s, Config{})
 	for id, data := range want {
 		if got := readAll(t, r, id, len(data)); !bytes.Equal(got, data) {
 			t.Fatalf("file %s mismatch after recovery", id)
@@ -138,7 +139,7 @@ func TestTornWriteRecoveryLSL06(t *testing.T) {
 	}
 	_ = seg.fd.Sync()
 
-	r := reopen(t, s)
+	r := reopen(t, s, Config{})
 	if got := readAll(t, r, "f", len(good)); !bytes.Equal(got, good) {
 		t.Fatalf("valid prefix corrupted after torn recovery")
 	}
@@ -181,7 +182,7 @@ func TestCRCCoincidenceTornRecordGuarded(t *testing.T) {
 	}
 	_ = s.shards[0].active.fd.Sync()
 
-	r := reopen(t, s)
+	r := reopen(t, s, Config{})
 	if got := readAll(t, r, "f", len(good)); !bytes.Equal(got, good) {
 		t.Fatalf("valid prefix corrupted")
 	}
@@ -206,7 +207,7 @@ func TestVersionLSNMonotonicAfterReopen(t *testing.T) {
 	}
 	maxObserved := s.version.Load() // last issued version
 
-	r := reopen(t, s)
+	r := reopen(t, s, Config{})
 	// Next write must get a version strictly greater than any observed before.
 	if err := r.WriteAt(ctx, "f", 100, []byte("post")); err != nil {
 		t.Fatalf("post-reopen WriteAt: %v", err)
@@ -246,9 +247,9 @@ func TestMissingIdxRebuilt(t *testing.T) {
 		t.Fatalf("remove sealed .idx: %v", err)
 	}
 
-	warned := captureWarnings(t)
+	cfg, warned := captureWarnings(t)
 
-	r := reopen(t, s)
+	r := reopen(t, s, cfg)
 	if !strings.Contains(warned(), "missing .idx sidecar") {
 		t.Fatalf("expected a Warn for the missing .idx")
 	}
@@ -378,9 +379,9 @@ func TestSealedSegmentWithNoValidRecords(t *testing.T) {
 		t.Fatalf("chtimes: %v", err)
 	}
 
-	warned := captureWarnings(t)
+	cfg, warned := captureWarnings(t)
 
-	r, err := Open(dir, Config{ShardCount: 1}, newFakeRemote(), fixedClock{t: time.Now()})
+	r, err := Open(dir, Config{ShardCount: 1, Logger: cfg.Logger}, newFakeRemote(), fixedClock{t: time.Now()})
 	if err != nil {
 		t.Fatalf("reopen over damaged sealed segment: %v", err)
 	}
@@ -421,7 +422,7 @@ func TestConcurrentReadWriteAfterRecovery(t *testing.T) {
 			t.Fatalf("seed WriteAt: %v", err)
 		}
 	}
-	r := reopen(t, s)
+	r := reopen(t, s, Config{})
 
 	var wg sync.WaitGroup
 	for i := 0; i < 8; i++ {

--- a/pkg/block/journal/recovery_test.go
+++ b/pkg/block/journal/recovery_test.go
@@ -21,8 +21,8 @@ func captureWarnings(t *testing.T) (*slog.Logger, func() string) {
 }
 
 // reopen closes s and opens a fresh Store over the same directory, exercising
-// the recovery path. cfg's non-zero fields override s's config; zero fields
-// keep s's values.
+// the recovery path. cfg only overrides s's Logger and Clock; every other
+// field keeps s's value.
 func reopen(t *testing.T, s *Store, cfg Config) *Store {
 	t.Helper()
 	dir := s.dir

--- a/pkg/block/journal/recovery_test.go
+++ b/pkg/block/journal/recovery_test.go
@@ -29,11 +29,10 @@ func reopen(t *testing.T, s *Store, cfg Config) *Store {
 	if cfg.Logger == nil {
 		cfg = s.cfg
 	}
-	clock := s.clock
 	if err := s.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	r, err := Open(dir, cfg, newFakeRemote(), clock)
+	r, err := Open(dir, cfg)
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
@@ -54,7 +53,7 @@ func readAll(t *testing.T, s *Store, id FileID, n int) []byte {
 // asserts every byte survives recovery unchanged.
 func TestRecoveryRoundTrip(t *testing.T) {
 	dir := t.TempDir()
-	s, err := Open(dir, Config{ShardCount: 4}, newFakeRemote(), SystemClock())
+	s, err := Open(dir, Config{ShardCount: 4})
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -104,7 +103,7 @@ func segTail(t *testing.T, s *Store, id uint64) int64 {
 // record in segment 0.
 func TestTornWriteRecoveryLSL06(t *testing.T) {
 	dir := t.TempDir()
-	s, err := Open(dir, Config{ShardCount: 1}, newFakeRemote(), SystemClock())
+	s, err := Open(dir, Config{ShardCount: 1})
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -154,7 +153,7 @@ func TestTornWriteRecoveryLSL06(t *testing.T) {
 // reject it before any allocation, so recovery treats it as the torn boundary.
 func TestCRCCoincidenceTornRecordGuarded(t *testing.T) {
 	dir := t.TempDir()
-	s, err := Open(dir, Config{ShardCount: 1}, newFakeRemote(), SystemClock())
+	s, err := Open(dir, Config{ShardCount: 1})
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -195,7 +194,7 @@ func TestCRCCoincidenceTornRecordGuarded(t *testing.T) {
 // past every replayed record and never reissues an observed version.
 func TestVersionLSNMonotonicAfterReopen(t *testing.T) {
 	dir := t.TempDir()
-	s, err := Open(dir, Config{ShardCount: 1}, newFakeRemote(), SystemClock())
+	s, err := Open(dir, Config{ShardCount: 1})
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -222,7 +221,7 @@ func TestVersionLSNMonotonicAfterReopen(t *testing.T) {
 func TestMissingIdxRebuilt(t *testing.T) {
 	dir := t.TempDir()
 	// Small segment + single shard forces a seal after ~1 MiB of writes.
-	s, err := Open(dir, Config{ShardCount: 1, SegmentSize: minSegmentSize}, newFakeRemote(), SystemClock())
+	s, err := Open(dir, Config{ShardCount: 1, SegmentSize: minSegmentSize})
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -276,7 +275,7 @@ func (c fixedClock) Now() time.Time { return c.t }
 // unlinked on reopen, while the store's real data is untouched.
 func TestOrphanSweepAgeGated(t *testing.T) {
 	dir := t.TempDir()
-	s, err := Open(dir, Config{ShardCount: 1}, newFakeRemote(), SystemClock())
+	s, err := Open(dir, Config{ShardCount: 1})
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -302,7 +301,7 @@ func TestOrphanSweepAgeGated(t *testing.T) {
 		t.Fatalf("chtimes: %v", err)
 	}
 
-	r, err := Open(dir, Config{ShardCount: 1}, newFakeRemote(), fixedClock{t: time.Now()})
+	r, err := Open(dir, Config{ShardCount: 1})
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
@@ -319,7 +318,7 @@ func TestOrphanSweepAgeGated(t *testing.T) {
 // TestOrphanSweepSparesYoung asserts a fresh (young) orphan is left in place.
 func TestOrphanSweepSparesYoung(t *testing.T) {
 	dir := t.TempDir()
-	s, err := Open(dir, Config{ShardCount: 1}, newFakeRemote(), SystemClock())
+	s, err := Open(dir, Config{ShardCount: 1})
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -334,7 +333,7 @@ func TestOrphanSweepSparesYoung(t *testing.T) {
 	if err := os.WriteFile(s.segPath(orphanID), []byte("not a segment header at all!!!"), 0o644); err != nil {
 		t.Fatalf("write orphan: %v", err)
 	}
-	r, err := Open(dir, Config{ShardCount: 1}, newFakeRemote(), SystemClock())
+	r, err := Open(dir, Config{ShardCount: 1})
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
@@ -350,7 +349,7 @@ func TestOrphanSweepSparesYoung(t *testing.T) {
 // gate, warns about it, and serves the store's real data untouched.
 func TestSealedSegmentWithNoValidRecords(t *testing.T) {
 	dir := t.TempDir()
-	s, err := Open(dir, Config{ShardCount: 1}, newFakeRemote(), SystemClock())
+	s, err := Open(dir, Config{ShardCount: 1})
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -381,7 +380,7 @@ func TestSealedSegmentWithNoValidRecords(t *testing.T) {
 
 	cfg, warned := captureWarnings(t)
 
-	r, err := Open(dir, Config{ShardCount: 1, Logger: cfg.Logger}, newFakeRemote(), fixedClock{t: time.Now()})
+	r, err := Open(dir, Config{ShardCount: 1, Logger: cfg.Logger})
 	if err != nil {
 		t.Fatalf("reopen over damaged sealed segment: %v", err)
 	}
@@ -411,7 +410,7 @@ func TestSealedSegmentWithNoValidRecords(t *testing.T) {
 // race detector with concurrent readers and writers.
 func TestConcurrentReadWriteAfterRecovery(t *testing.T) {
 	dir := t.TempDir()
-	s, err := Open(dir, Config{ShardCount: 4}, newFakeRemote(), SystemClock())
+	s, err := Open(dir, Config{ShardCount: 4})
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -458,7 +457,7 @@ func TestConcurrentReadWriteAfterRecovery(t *testing.T) {
 // writes. Recovery must replay both and every byte must read back.
 func TestRecoveryReadsV1FramedRecords(t *testing.T) {
 	dir := t.TempDir()
-	s, err := Open(dir, Config{ShardCount: 1}, newFakeRemote(), SystemClock())
+	s, err := Open(dir, Config{ShardCount: 1})
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -472,7 +471,7 @@ func TestRecoveryReadsV1FramedRecords(t *testing.T) {
 		t.Fatalf("Commit: %v", err)
 	}
 	segPath := s.segPath(0)
-	cfg, clock := s.cfg, s.clock
+	cfg := s.cfg
 	if err := s.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
@@ -491,7 +490,7 @@ func TestRecoveryReadsV1FramedRecords(t *testing.T) {
 		t.Fatalf("close segment: %v", err)
 	}
 
-	r, err := Open(dir, cfg, newFakeRemote(), clock)
+	r, err := Open(dir, cfg)
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}

--- a/pkg/block/journal/restore_test.go
+++ b/pkg/block/journal/restore_test.go
@@ -116,7 +116,7 @@ func (f *restoreFixture) crashReopen() *Store {
 			f.t.Fatalf("close segment %d: %v", id, err)
 		}
 	}
-	return reopen(f.t, f.Store)
+	return reopen(f.t, f.Store, Config{})
 }
 
 // idsOnDistinctShards returns one FileID per shard index in [0, n), so a test
@@ -358,7 +358,7 @@ func TestRestoreToVersion_KeepsEvictedRange(t *testing.T) {
 	// A plain reopen is enough for this assertion: the re-asserted entry's
 	// durability comes from appendCold's own fsync of the cold log, not from
 	// buffered segment writes, so there is no page-cache masquerade to defeat.
-	r := reopen(t, s)
+	r := reopen(t, s, Config{})
 	assertColdAt(t, r, evicted, 0, chunk256, "post-reopen")
 	if got := readAll(t, r, peer, len(v1)); !bytes.Equal(got, v1) {
 		t.Fatalf("post-reopen %s: restore did not produce the V1 view", peer)

--- a/pkg/block/journal/segment.go
+++ b/pkg/block/journal/segment.go
@@ -401,7 +401,7 @@ func (s *Store) appendRecord(ctx context.Context, id FileID, offset int64, data 
 		version: version,
 		recOff:  segOff,
 		synced:  synced,
-		loc:     SegmentLocation{SegmentID: seg.id, Offset: payloadOff, Length: int64(len(data))},
+		loc:     segmentLocation{SegmentID: seg.id, Offset: payloadOff, Length: int64(len(data))},
 	})
 	// Charge superseded bytes to their segment's dead counter: this is the
 	// size-tiered GC victim signal. sh.segment needs sh.mu, held here.

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -18,9 +17,6 @@ import (
 // FileID identifies a file's byte stream inside the cache. It is the same
 // value space and hash keyspace as today's payloadID.
 type FileID string
-
-// BlockID is the opaque key of a packed block in the remote store.
-type BlockID string
 
 // errClosed is returned by every operation attempted on a closed Store.
 var errClosed = errors.New("journal: store closed")
@@ -38,15 +34,6 @@ var ErrColdProvenanceAmbiguous = errors.New("journal: cold entry provenance cann
 // hold its header plus real records; below this a single write could exceed the
 // cap. 1 MiB clears the largest protocol write plus framing with wide margin.
 const minSegmentSize int64 = 1 << 20
-
-// RemoteStore is the narrow remote contract journal carves to and hydrates
-// from. It mirrors the shape of pkg/block/remote's RemoteBlockStore but is
-// declared here so journal imports nothing from the block/remote package.
-type RemoteStore interface {
-	PutBlock(ctx context.Context, id BlockID, r io.Reader, size int64) error
-	GetBlock(ctx context.Context, id BlockID) (io.ReadCloser, error)
-	GetRange(ctx context.Context, id BlockID, off, length int64) (io.ReadCloser, error)
-}
 
 // Clock supplies the current time. Injected so tests can pin it.
 type Clock interface{ Now() time.Time }
@@ -115,6 +102,9 @@ type Config struct {
 	// chunker.DefaultParams — the historical 1M/4M/16M profile — so a
 	// misconfiguration is never a hard error, matching the fs store.
 	ChunkParams chunker.Params
+	// Clock supplies the store's time. Nil falls back to a system clock;
+	// tests pin it to drive age-based batching and expiry deterministically.
+	Clock Clock
 }
 
 const (
@@ -196,11 +186,10 @@ type Stats struct {
 // concurrent use; per-shard mutexes serialize appends and index mutation while
 // positioned reads run unlocked.
 type Store struct {
-	dir    string
-	cfg    Config
-	remote RemoteStore
-	clock  Clock
-	log    *slog.Logger
+	dir   string
+	cfg   Config
+	clock Clock
+	log   *slog.Logger
 
 	// deduper and sink are the carve collaborators, injected via SetCarveTargets
 	// at wiring time. They own every step that touches pkg/block, blockcodec and
@@ -296,16 +285,18 @@ func (s *Store) SetVerifyReads(v bool) { s.verifyReads.Store(v) }
 // segment of each shard is tail-scanned and its torn tail truncated, every
 // valid record is replayed into a fresh interval index, and the global Version
 // LSN is resumed past the highest observed record. See recover.
-func Open(dir string, cfg Config, remote RemoteStore, clock Clock) (*Store, error) {
+func Open(dir string, cfg Config) (*Store, error) {
+	// Check the format stamp before touching state whose shape is unknown: a
+	// directory a newer release wrote must be refused, not read as holes.
+	if err := checkFormat(dir); err != nil {
+		return nil, err
+	}
 	cfg = cfg.withDefaults()
 	if cfg.ShardCount&(cfg.ShardCount-1) != 0 {
 		return nil, fmt.Errorf("journal: ShardCount %d is not a power of two", cfg.ShardCount)
 	}
 	if cfg.SegmentSize < minSegmentSize {
 		return nil, fmt.Errorf("journal: SegmentSize %d below floor %d (header+record framing)", cfg.SegmentSize, minSegmentSize)
-	}
-	if clock == nil {
-		clock = SystemClock()
 	}
 	log := cfg.logger()
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -326,10 +317,14 @@ func Open(dir string, cfg Config, remote RemoteStore, clock Clock) (*Store, erro
 		}
 	}
 
+	clock := cfg.Clock
+	if clock == nil {
+		clock = SystemClock()
+	}
+
 	s := &Store{
 		dir:       dir,
 		cfg:       cfg,
-		remote:    remote,
 		clock:     clock,
 		log:       log,
 		shardMask: uint64(cfg.ShardCount - 1),
@@ -1164,7 +1159,6 @@ func (s *Store) JournalVersion() uint64 { return s.version.Load() }
 // marked ready / lowers it only after a delete commits, so GC only ever grows
 // more conservative. Reads are a single atomic load on the reclaim path.
 func (s *Store) SetPinVersion(v uint64) { s.pinVersion.Store(v) }
-
 
 // RestoreToVersion rewinds every file to its point-in-time view as of the global
 // LSN watermark V and re-materializes that view durably at the log head, so a

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -407,7 +407,7 @@ func (s *Store) gcLoop(ctx context.Context) {
 			// errClosed races Close (which sets s.closed before cancelling
 			// this loop's context); both it and context.Canceled are the
 			// normal shutdown signal, not a failure worth logging.
-			if _, err := s.GC(ctx, GCOptions{}); err != nil &&
+			if _, err := s.gc(ctx, gcOptions{}); err != nil &&
 				!errors.Is(err, context.Canceled) && !errors.Is(err, errClosed) {
 				logger.Warn("journal: background GC pass failed", "error", err)
 			}

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -5,13 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/block/chunker"
 )
 
@@ -50,6 +50,17 @@ type RemoteStore interface {
 
 // Clock supplies the current time. Injected so tests can pin it.
 type Clock interface{ Now() time.Time }
+
+// discardLog is where a Config without a Logger sends its warnings.
+var discardLog = slog.New(slog.DiscardHandler)
+
+// logger returns the configured warning sink, discarding when unset.
+func (c Config) logger() *slog.Logger {
+	if c.Logger != nil {
+		return c.Logger
+	}
+	return discardLog
+}
 
 // systemClock is the production Clock.
 type systemClock struct{}
@@ -94,6 +105,11 @@ type Config struct {
 	// synchronous durability point. Zero falls back to the default via
 	// withDefaults; negative disables the loop entirely.
 	DirtyExpiry time.Duration
+	// Logger receives the store's advisory warnings: recovery degradation,
+	// eviction backpressure, failed repack integrity checks. Nil discards
+	// them — the journal never reaches the process logger on its own, so
+	// wiring one is the caller's choice.
+	Logger *slog.Logger
 	// ChunkParams sets the per-share FastCDC sizing carve feeds the chunker.
 	// The zero value (or any params that fail Validate) degrades to
 	// chunker.DefaultParams — the historical 1M/4M/16M profile — so a
@@ -184,6 +200,7 @@ type Store struct {
 	cfg    Config
 	remote RemoteStore
 	clock  Clock
+	log    *slog.Logger
 
 	// deduper and sink are the carve collaborators, injected via SetCarveTargets
 	// at wiring time. They own every step that touches pkg/block, blockcodec and
@@ -290,6 +307,7 @@ func Open(dir string, cfg Config, remote RemoteStore, clock Clock) (*Store, erro
 	if clock == nil {
 		clock = SystemClock()
 	}
+	log := cfg.logger()
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("journal: mkdir %q: %w", dir, err)
 	}
@@ -303,7 +321,7 @@ func Open(dir string, cfg Config, remote RemoteStore, clock Clock) (*Store, erro
 		if free, ferr := diskFreeBytes(dir); ferr == nil && free > 0 {
 			cfg.MaxLocalBytes = int64(float64(free) * defaultMaxLocalBytesFreeFraction)
 		} else if ferr != nil {
-			logger.Warn("journal: could not determine free disk space; local store cap left unset (unbounded growth risk)",
+			log.Warn("journal: could not determine free disk space; local store cap left unset (unbounded growth risk)",
 				"dir", dir, "error", ferr)
 		}
 	}
@@ -313,6 +331,7 @@ func Open(dir string, cfg Config, remote RemoteStore, clock Clock) (*Store, erro
 		cfg:       cfg,
 		remote:    remote,
 		clock:     clock,
+		log:       log,
 		shardMask: uint64(cfg.ShardCount - 1),
 	}
 
@@ -409,7 +428,7 @@ func (s *Store) gcLoop(ctx context.Context) {
 			// normal shutdown signal, not a failure worth logging.
 			if _, err := s.gc(ctx, gcOptions{}); err != nil &&
 				!errors.Is(err, context.Canceled) && !errors.Is(err, errClosed) {
-				logger.Warn("journal: background GC pass failed", "error", err)
+				s.log.Warn("journal: background GC pass failed", "error", err)
 			}
 		}
 	}
@@ -428,7 +447,7 @@ func (s *Store) syncLoop(ctx context.Context) {
 			return
 		case <-t.C:
 			if err := s.commitDirtyShards(); err != nil {
-				logger.Warn("journal: dirty-age commit failed", "error", err)
+				s.log.Warn("journal: dirty-age commit failed", "error", err)
 			}
 		}
 	}
@@ -1292,7 +1311,7 @@ func (s *Store) RestoreToVersion(ctx context.Context, v uint64) error {
 	// branch. The residual case is a store seeded while it had a remote that was
 	// later detached, whose legacy entries cannot be distinguished — those logs
 	// re-stamp themselves as soon as this build appends or compacts.
-	coldEntries, _, cerr := loadCold(s.dir)
+	coldEntries, _, cerr := loadCold(s.dir, s.log)
 	if cerr != nil {
 		return fmt.Errorf("journal: restore: load cold log: %w", cerr)
 	}

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -1165,8 +1165,6 @@ func (s *Store) JournalVersion() uint64 { return s.version.Load() }
 // more conservative. Reads are a single atomic load on the reclaim path.
 func (s *Store) SetPinVersion(v uint64) { s.pinVersion.Store(v) }
 
-// PinVersion reports the current pin watermark (0 = no live snapshot).
-func (s *Store) PinVersion() uint64 { return s.pinVersion.Load() }
 
 // RestoreToVersion rewinds every file to its point-in-time view as of the global
 // LSN watermark V and re-materializes that view durably at the log head, so a
@@ -1270,7 +1268,7 @@ func (s *Store) RestoreToVersion(ctx context.Context, v uint64) error {
 						version: rec.header.Version,
 						synced:  rec.header.Flags&flagSynced != 0,
 						recOff:  rec.segOff,
-						loc: SegmentLocation{
+						loc: segmentLocation{
 							SegmentID: seg.id,
 							Offset:    rec.segOff + recordHeaderSize + int64(len(rec.fileID)),
 							Length:    int64(rec.header.PayloadLen),

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -41,21 +41,10 @@ type Clock interface{ Now() time.Time }
 // discardLog is where a Config without a Logger sends its warnings.
 var discardLog = slog.New(slog.DiscardHandler)
 
-// logger returns the configured warning sink, discarding when unset.
-func (c Config) logger() *slog.Logger {
-	if c.Logger != nil {
-		return c.Logger
-	}
-	return discardLog
-}
-
 // systemClock is the production Clock.
 type systemClock struct{}
 
 func (systemClock) Now() time.Time { return time.Now() }
-
-// SystemClock returns a Clock backed by time.Now.
-func SystemClock() Clock { return systemClock{} }
 
 // Config tunes a Store. Zero values fall back to defaults via withDefaults.
 type Config struct {
@@ -298,7 +287,10 @@ func Open(dir string, cfg Config) (*Store, error) {
 	if cfg.SegmentSize < minSegmentSize {
 		return nil, fmt.Errorf("journal: SegmentSize %d below floor %d (header+record framing)", cfg.SegmentSize, minSegmentSize)
 	}
-	log := cfg.logger()
+	if cfg.Logger == nil {
+		cfg.Logger = discardLog
+	}
+	log := cfg.Logger
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("journal: mkdir %q: %w", dir, err)
 	}
@@ -319,7 +311,7 @@ func Open(dir string, cfg Config) (*Store, error) {
 
 	clock := cfg.Clock
 	if clock == nil {
-		clock = SystemClock()
+		clock = systemClock{}
 	}
 
 	s := &Store{

--- a/pkg/block/journal/transition_bench_test.go
+++ b/pkg/block/journal/transition_bench_test.go
@@ -226,7 +226,7 @@ func BenchmarkGCRepack(b *testing.B) {
 		b.StopTimer()
 		seedRepackable(b, s, true)
 		b.StartTimer()
-		res, err := s.GC(ctx, GCOptions{Force: true})
+		res, err := s.gc(ctx, gcOptions{Force: true})
 		if err != nil {
 			b.Fatalf("GC: %v", err)
 		}

--- a/pkg/block/journal/transition_bench_test.go
+++ b/pkg/block/journal/transition_bench_test.go
@@ -31,7 +31,7 @@ import (
 func benchStoreDir(b *testing.B, cfg Config) (*Store, string) {
 	b.Helper()
 	dir := b.TempDir()
-	s, err := Open(dir, cfg, newFakeRemote(), SystemClock())
+	s, err := Open(dir, cfg)
 	if err != nil {
 		b.Fatalf("Open: %v", err)
 	}
@@ -252,7 +252,7 @@ func BenchmarkOpenRecovery(b *testing.B) {
 		span  = 64 << 10
 	)
 	dir := b.TempDir()
-	seed, err := Open(dir, Config{}, newFakeRemote(), SystemClock())
+	seed, err := Open(dir, Config{})
 	if err != nil {
 		b.Fatalf("Open: %v", err)
 	}
@@ -270,7 +270,7 @@ func BenchmarkOpenRecovery(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		s, err := Open(dir, Config{}, newFakeRemote(), SystemClock())
+		s, err := Open(dir, Config{})
 		if err != nil {
 			b.Fatalf("Open: %v", err)
 		}

--- a/pkg/block/journal/truncate_test.go
+++ b/pkg/block/journal/truncate_test.go
@@ -229,7 +229,7 @@ func TestTruncateDeadBytesReconstructedOnReopen(t *testing.T) {
 		t.Fatalf("pre-reopen DeadBytes = %d, want 600", d)
 	}
 
-	r := reopen(t, s)
+	r := reopen(t, s, Config{})
 	if d := r.Stats().DeadBytes; d != 600 {
 		t.Fatalf("recovered DeadBytes = %d, want 600 (deadBytes not reconstructed)", d)
 	}

--- a/pkg/block/journal/truncate_test.go
+++ b/pkg/block/journal/truncate_test.go
@@ -168,7 +168,7 @@ func TestTruncateSurvivesReopen(t *testing.T) {
 	dir := t.TempDir()
 	ctx := context.Background()
 
-	s, err := Open(dir, Config{}, newFakeRemote(), SystemClock())
+	s, err := Open(dir, Config{})
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -183,7 +183,7 @@ func TestTruncateSurvivesReopen(t *testing.T) {
 
 	// Recovery replays the still-full on-disk record, then re-applies the durable
 	// truncate marker so the truncated bytes never resurrect.
-	r, err := Open(dir, Config{}, newFakeRemote(), SystemClock())
+	r, err := Open(dir, Config{})
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
@@ -215,7 +215,7 @@ func TestTruncateDeadBytesReconstructedOnReopen(t *testing.T) {
 	dir := t.TempDir()
 	ctx := context.Background()
 
-	s, err := Open(dir, Config{}, newFakeRemote(), SystemClock())
+	s, err := Open(dir, Config{})
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}

--- a/pkg/block/journal/verify_copy_test.go
+++ b/pkg/block/journal/verify_copy_test.go
@@ -99,7 +99,7 @@ func TestRepackRefusesTruncatedRecordStream(t *testing.T) {
 	corruptFirstPayloadByte(t, s, "keep")
 	segsBefore := segFileCount(t, s)
 
-	res, err := s.GC(ctx, GCOptions{Force: true})
+	res, err := s.gc(ctx, gcOptions{Force: true})
 	if !errors.Is(err, errTornRecord) {
 		t.Fatalf("GC must refuse to repack a victim with a torn record, got err=%v res=%+v", err, res)
 	}
@@ -123,7 +123,7 @@ func TestRepackRefusesTruncatedRecordStream(t *testing.T) {
 	}
 	// Quarantined: a later pass skips it, so one damaged segment cannot stall
 	// reclamation for the rest of the shard.
-	if res, err := s.GC(ctx, GCOptions{Force: true}); err != nil || res.SegmentsRepacked != 0 {
+	if res, err := s.gc(ctx, gcOptions{Force: true}); err != nil || res.SegmentsRepacked != 0 {
 		t.Fatalf("second GC pass: err=%v res=%+v, want a clean no-op", err, res)
 	}
 }
@@ -142,7 +142,7 @@ func TestRepackRefusesRecordFramingAnotherFile(t *testing.T) {
 	flipSegByte(t, s, iv.loc.SegmentID, iv.recOff+recordHeaderSize) // first FileID byte
 	segsBefore := segFileCount(t, s)
 
-	res, err := s.GC(ctx, GCOptions{Force: true})
+	res, err := s.gc(ctx, gcOptions{Force: true})
 	if !errors.Is(err, errTornRecord) {
 		t.Fatalf("GC must refuse a record framing another file, got err=%v res=%+v", err, res)
 	}

--- a/pkg/block/local/fs/format_test.go
+++ b/pkg/block/local/fs/format_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/journal"
 )
 
 // stampPath is where the journal keeps its on-disk format marker, relative to a
@@ -66,8 +66,8 @@ func TestOpenRefusesFutureFormat(t *testing.T) {
 		_ = s.Close()
 		t.Fatal("New on a future-format directory succeeded, want refusal")
 	}
-	if !errors.Is(err, block.ErrFutureFormat) {
-		t.Fatalf("New error = %v, want it to wrap block.ErrFutureFormat", err)
+	if !errors.Is(err, journal.ErrFutureFormat) {
+		t.Fatalf("New error = %v, want it to wrap journal.ErrFutureFormat", err)
 	}
 }
 

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -8,6 +8,7 @@ package fs
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -160,6 +161,7 @@ func NewWithOptions(dir string, maxDisk int64, fileChunkStore block.EngineFileCh
 		ChunkParams:    opts.ChunkParams,
 		DirtyExpiry:    opts.DirtyExpiry,
 		CarveBlockSize: opts.CarveBlockSize,
+		Logger:         slog.Default(), // slog.SetDefault routes the configured process logger here
 	}
 	// Open checks the format stamp before touching the journal: a directory a
 	// newer release wrote would otherwise read as holes wherever the newer

--- a/pkg/block/local/fs/fs.go
+++ b/pkg/block/local/fs/fs.go
@@ -161,14 +161,11 @@ func NewWithOptions(dir string, maxDisk int64, fileChunkStore block.EngineFileCh
 		DirtyExpiry:    opts.DirtyExpiry,
 		CarveBlockSize: opts.CarveBlockSize,
 	}
-	// Check the format stamp before touching the journal: a directory a newer
-	// release wrote would otherwise read as holes wherever the newer format
-	// keeps state this binary does not scan.
+	// Open checks the format stamp before touching the journal: a directory a
+	// newer release wrote would otherwise read as holes wherever the newer
+	// format keeps state this binary does not scan.
 	journalDir := filepath.Join(dir, "journal")
-	if err := journal.CheckFormat(journalDir); err != nil {
-		return nil, err
-	}
-	js, err := journal.Open(journalDir, cfg, nil, journal.SystemClock())
+	js, err := journal.Open(journalDir, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controlplane/runtime/init.go
+++ b/pkg/controlplane/runtime/init.go
@@ -9,6 +9,7 @@ import (
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/internal/pathutil"
 	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/journal"
 	"github.com/marmos91/dittofs/pkg/block/local/fs"
 	"github.com/marmos91/dittofs/pkg/controlplane/models"
 	"github.com/marmos91/dittofs/pkg/controlplane/store"
@@ -261,8 +262,10 @@ func LoadSharesFromStore(ctx context.Context, rt *Runtime, s store.Store) error 
 			// the daemon running and looking healthy with the share silently
 			// absent. Surface it so cmd/dfs/commands/start.go can exit 78 with
 			// the operator directive. Every other AddShare failure stays a
-			// warn-and-skip.
-			if errors.Is(err, block.ErrFutureFormat) || errors.Is(err, fs.ErrLegacyLocalFormat) {
+			// warn-and-skip. The journal tier reports its own sentinel, so both
+			// are matched here.
+			if errors.Is(err, block.ErrFutureFormat) || errors.Is(err, journal.ErrFutureFormat) ||
+				errors.Is(err, fs.ErrLegacyLocalFormat) {
 				return fmt.Errorf("share %q: %w", share.Name, err)
 			}
 			logger.Warn("Failed to add share to runtime",


### PR DESCRIPTION
Six-part hygiene sweep of `pkg/block/journal` from the step-3 plan (Lane H), cutting the journal surface ahead of the carver/state-model lanes:

- **GC unexported** — `GC`/`GCOptions`/`GCResult` → `gc`/`gcOptions`/`gcResult`; the pass runs behind the background loop (`gcLoop`), its only trigger. Eviction is unaffected.
- **Warning sink over `Config.Logger`** — `internal/logger` import severed; warnings go to `Config.Logger` (`*slog.Logger`), discarding when unset. The production config (`local/fs`) wires `slog.Default()` so the migrated warnings keep reaching the operator's log.
- **`segmentLocation` unexported, `PinVersion()` getter dropped** — internal readers already used the field directly; the setter (`SetPinVersion`) is kept for its runtime callers.
- **`journal.RemoteStore` deleted, `Open` collapsed** — the interface and field were write-only (no reads anywhere, production passes nil); `Open(dir string, cfg Config)` now takes two args, with `checkFormat` folded inside as its first statement.
- **Journal-local `ErrFutureFormat` sentinel** — boot-guard sites (`controlplane/runtime/init.go`, `cmd/dfs start.go`, `local/fs/format_test.go`) match `block.ErrFutureFormat || journal.ErrFutureFormat`, preserving exit-78 semantics; the shared `block.ErrFutureFormat` stays for the metadata tiers.
- **Test-helper fixes from review** — `reopen` merges the caller's overrides into the store's config instead of dropping `ShardCount`/`SegmentSize`; `captureWarnings` returns the `*slog.Logger` directly.

Net −56 lines. Gates: build, vet, gofmt clean; 58 packages ok; `go test -race ./pkg/block/journal/` pass.

Reviews (three fresh-context, all APPROVE): correctness (boot exit-78 chain traced intact, gcLoop survival, no behaviour change — 12 migrated Warn sites byte-identical), self-containment (6 findings: recovery cfg merge, dead Cleanup, nil-logger wiring, one-caller helpers inlined, SystemClock export dropped), adversarial (all six prosecution counts clear, no counterexample found).
