### PR TITLE
fix(metadata): cross-share LINK/RENAME reports one code across protocols

### DIFF
--- a/internal/adapter/nfs/types/statusfor.go
+++ b/internal/adapter/nfs/types/statusfor.go
@@ -35,6 +35,8 @@ func StatusFor(code merrs.ErrorCode) uint32 {
 		return NFS3ErrNotDir
 	case merrs.ErrInvalidArgument:
 		return NFS3ErrInval
+	case merrs.ErrCrossShare:
+		return NFS3ErrXDev
 	case merrs.ErrIOError:
 		return NFS3ErrIO
 	case merrs.ErrNoSpace:

--- a/internal/adapter/nfs/types/statusfor_test.go
+++ b/internal/adapter/nfs/types/statusfor_test.go
@@ -37,6 +37,7 @@ var expectedNFS3 = map[merrs.ErrorCode]uint32{
 	merrs.ErrLockLimitExceeded:      NFS3ErrJukebox,
 	merrs.ErrLockConflict:           NFS3ErrJukebox,
 	merrs.ErrConflict:               NFS3ErrJukebox,
+	merrs.ErrCrossShare:             NFS3ErrXDev,
 	merrs.ErrConnectionLimitReached: NFS3ErrJukebox,
 }
 
@@ -44,7 +45,7 @@ var expectedNFS3 = map[merrs.ErrorCode]uint32{
 // expectation table. Drift is loud: an unmapped code returns the I/O
 // default and fails here.
 func TestStatusFor_EnumWalk(t *testing.T) {
-	for c := merrs.ErrNotFound; c <= merrs.ErrConflict; c++ {
+	for c := merrs.ErrNotFound; c <= merrs.ErrCrossShare; c++ {
 		want, ok := expectedNFS3[c]
 		if !ok {
 			t.Errorf("StatusFor(%v) has no expectation row — add one to expectedNFS3", c)

--- a/internal/adapter/nfs/v4/types/statusfor.go
+++ b/internal/adapter/nfs/v4/types/statusfor.go
@@ -33,6 +33,8 @@ func StatusFor(code merrs.ErrorCode) uint32 {
 		return NFS4ERR_NOTDIR
 	case merrs.ErrInvalidArgument:
 		return NFS4ERR_INVAL
+	case merrs.ErrCrossShare:
+		return NFS4ERR_XDEV
 	case merrs.ErrIOError:
 		return NFS4ERR_IO
 	case merrs.ErrNoSpace:

--- a/internal/adapter/nfs/v4/types/statusfor_test.go
+++ b/internal/adapter/nfs/v4/types/statusfor_test.go
@@ -37,6 +37,7 @@ var expectedNFS4 = map[merrs.ErrorCode]uint32{
 	merrs.ErrLockLimitExceeded:      NFS4ERR_DENIED,
 	merrs.ErrLockConflict:           NFS4ERR_DENIED,
 	merrs.ErrConflict:               NFS4ERR_DELAY,
+	merrs.ErrCrossShare:             NFS4ERR_XDEV,
 	merrs.ErrConnectionLimitReached: NFS4ERR_DELAY,
 }
 
@@ -44,7 +45,7 @@ var expectedNFS4 = map[merrs.ErrorCode]uint32{
 // expectation table. Drift is loud: an unmapped code returns the
 // server-fault default and fails here.
 func TestStatusFor_EnumWalk(t *testing.T) {
-	for c := merrs.ErrNotFound; c <= merrs.ErrConflict; c++ {
+	for c := merrs.ErrNotFound; c <= merrs.ErrCrossShare; c++ {
 		want, ok := expectedNFS4[c]
 		if !ok {
 			t.Errorf("StatusFor(%v) has no expectation row — add one to expectedNFS4", c)

--- a/internal/adapter/smb/types/status.go
+++ b/internal/adapter/smb/types/status.go
@@ -124,6 +124,12 @@ const (
 	// StatusInsufficientResources indicates server lacks resources.
 	StatusInsufficientResources Status = 0xC000009A
 
+	// StatusNotSameDevice indicates a two-handle operation spanned two shares
+	// (NT STATUS_NOT_SAME_DEVICE). One condition, one code: the store-layer
+	// cross-share guard answers ErrCrossShare and this is its SMB lift, so the
+	// condition reports the same way NFS's NFS4ERR_XDEV does.
+	StatusNotSameDevice Status = 0xC00000D4
+
 	// StatusBadImpersonationLevel indicates the CREATE request supplied an
 	// impersonation level outside the four defined values (Anonymous,
 	// Identification, Impersonation, Delegate) per MS-SMB2 §2.2.13. Required

--- a/internal/adapter/smb/types/statusfor.go
+++ b/internal/adapter/smb/types/statusfor.go
@@ -41,6 +41,8 @@ func StatusFor(code merrs.ErrorCode) Status {
 		return StatusNotADirectory
 	case merrs.ErrInvalidArgument:
 		return StatusInvalidParameter
+	case merrs.ErrCrossShare:
+		return StatusNotSameDevice
 	case merrs.ErrIOError:
 		return StatusUnexpectedIOError
 	case merrs.ErrNoSpace:

--- a/internal/adapter/smb/types/statusfor_test.go
+++ b/internal/adapter/smb/types/statusfor_test.go
@@ -37,6 +37,7 @@ var expectedSMB = map[merrs.ErrorCode]Status{
 	merrs.ErrLockLimitExceeded:      StatusInsufficientResources,
 	merrs.ErrLockConflict:           StatusFileLockConflict,
 	merrs.ErrConflict:               StatusInsufficientResources,
+	merrs.ErrCrossShare:             StatusNotSameDevice,
 	merrs.ErrConnectionLimitReached: StatusInsufficientResources,
 }
 
@@ -60,7 +61,7 @@ var expectedSMBLock = map[merrs.ErrorCode]Status{
 // tables. Drift is loud: an unmapped code returns the internal-error
 // default and fails here.
 func TestStatusFor_EnumWalk(t *testing.T) {
-	for c := merrs.ErrNotFound; c <= merrs.ErrConflict; c++ {
+	for c := merrs.ErrNotFound; c <= merrs.ErrCrossShare; c++ {
 		want, ok := expectedSMB[c]
 		if !ok {
 			t.Errorf("StatusFor(%v) has no expectation row — add one to expectedSMB", c)

--- a/pkg/metadata/cross_share_guards_test.go
+++ b/pkg/metadata/cross_share_guards_test.go
@@ -92,3 +92,39 @@ func TestMove_RejectsCrossShareDestination(t *testing.T) {
 	_, err = svc.Lookup(authCtx, dstRoot, "stolen.txt")
 	require.Error(t, err, "no entry may be created in the foreign share")
 }
+
+// TestRequireSameShare_CrossShareCode pins the error code the store-layer
+// cross-share guard returns. One condition, one code: NFS surfaces EXDEV from
+// its handler-level checks, so the store guard must answer with a code the
+// protocol mappers lift to EXDEV/STATUS_NOT_SAME_DEVICE — not the generic
+// invalid-parameter error that masks the cross-share condition over SMB.
+// Asserts on both exported callers (CreateHardLink, Move) so a refactor that
+// bypasses the shared guard fails here.
+func TestRequireSameShare_CrossShareCode(t *testing.T) {
+	t.Parallel()
+
+	store := memory.NewMemoryMetadataStoreWithDefaults()
+	svc := metadata.New()
+	linkRoot := newShareOnStore(t, svc, store, "/code-a")
+	moveRoot := newShareOnStore(t, svc, store, "/code-b")
+	authCtx := mkCtx(0, 0)
+
+	file, _, err := svc.CreateFile(authCtx, moveRoot, "pinned.txt", &metadata.FileAttr{Mode: 0o644})
+	require.NoError(t, err)
+	fileHandle, err := metadata.EncodeFileHandle(file)
+	require.NoError(t, err)
+
+	_, err = svc.CreateHardLink(authCtx, linkRoot, "stolen.txt", fileHandle)
+	require.Error(t, err, "hard link across shares must be rejected")
+	var linkErr *metadata.StoreError
+	require.ErrorAs(t, err, &linkErr, "hard link cross-share rejection must be a StoreError")
+	require.Equal(t, metadata.ErrCrossShare, linkErr.Code,
+		"hard link across shares must answer ErrCrossShare, got %v", linkErr.Code)
+
+	_, _, err = svc.Move(authCtx, moveRoot, "pinned.txt", linkRoot, "moved.txt")
+	require.Error(t, err, "move across shares must be rejected")
+	var moveErr *metadata.StoreError
+	require.ErrorAs(t, err, &moveErr, "move cross-share rejection must be a StoreError")
+	require.Equal(t, metadata.ErrCrossShare, moveErr.Code,
+		"move across shares must answer ErrCrossShare, got %v", moveErr.Code)
+}

--- a/pkg/metadata/cross_share_guards_test.go
+++ b/pkg/metadata/cross_share_guards_test.go
@@ -56,6 +56,10 @@ func TestCreateHardLink_RejectsCrossShareTarget(t *testing.T) {
 
 	_, err = svc.CreateHardLink(authCtx, dirRoot, "stolen.txt", targetHandle)
 	require.Error(t, err, "hard link across shares must be rejected")
+	var linkErr *metadata.StoreError
+	require.ErrorAs(t, err, &linkErr, "hard link cross-share rejection must be a StoreError")
+	require.Equal(t, metadata.ErrCrossShare, linkErr.Code,
+		"hard link across shares must answer ErrCrossShare, got %v", linkErr.Code)
 
 	// The rejection must leave no entry behind and no inflated link count.
 	_, err = svc.Lookup(authCtx, dirRoot, "stolen.txt")
@@ -84,6 +88,10 @@ func TestMove_RejectsCrossShareDestination(t *testing.T) {
 
 	_, _, err = svc.Move(authCtx, srcRoot, "movable.txt", dstRoot, "stolen.txt")
 	require.Error(t, err, "move across shares must be rejected")
+	var moveErr *metadata.StoreError
+	require.ErrorAs(t, err, &moveErr, "move cross-share rejection must be a StoreError")
+	require.Equal(t, metadata.ErrCrossShare, moveErr.Code,
+		"move across shares must answer ErrCrossShare, got %v", moveErr.Code)
 
 	// The source entry must survive and no entry may appear in the destination.
 	_, err = svc.Lookup(authCtx, srcRoot, "movable.txt")
@@ -91,40 +99,4 @@ func TestMove_RejectsCrossShareDestination(t *testing.T) {
 
 	_, err = svc.Lookup(authCtx, dstRoot, "stolen.txt")
 	require.Error(t, err, "no entry may be created in the foreign share")
-}
-
-// TestRequireSameShare_CrossShareCode pins the error code the store-layer
-// cross-share guard returns. One condition, one code: NFS surfaces EXDEV from
-// its handler-level checks, so the store guard must answer with a code the
-// protocol mappers lift to EXDEV/STATUS_NOT_SAME_DEVICE — not the generic
-// invalid-parameter error that masks the cross-share condition over SMB.
-// Asserts on both exported callers (CreateHardLink, Move) so a refactor that
-// bypasses the shared guard fails here.
-func TestRequireSameShare_CrossShareCode(t *testing.T) {
-	t.Parallel()
-
-	store := memory.NewMemoryMetadataStoreWithDefaults()
-	svc := metadata.New()
-	linkRoot := newShareOnStore(t, svc, store, "/code-a")
-	moveRoot := newShareOnStore(t, svc, store, "/code-b")
-	authCtx := mkCtx(0, 0)
-
-	file, _, err := svc.CreateFile(authCtx, moveRoot, "pinned.txt", &metadata.FileAttr{Mode: 0o644})
-	require.NoError(t, err)
-	fileHandle, err := metadata.EncodeFileHandle(file)
-	require.NoError(t, err)
-
-	_, err = svc.CreateHardLink(authCtx, linkRoot, "stolen.txt", fileHandle)
-	require.Error(t, err, "hard link across shares must be rejected")
-	var linkErr *metadata.StoreError
-	require.ErrorAs(t, err, &linkErr, "hard link cross-share rejection must be a StoreError")
-	require.Equal(t, metadata.ErrCrossShare, linkErr.Code,
-		"hard link across shares must answer ErrCrossShare, got %v", linkErr.Code)
-
-	_, _, err = svc.Move(authCtx, moveRoot, "pinned.txt", linkRoot, "moved.txt")
-	require.Error(t, err, "move across shares must be rejected")
-	var moveErr *metadata.StoreError
-	require.ErrorAs(t, err, &moveErr, "move cross-share rejection must be a StoreError")
-	require.Equal(t, metadata.ErrCrossShare, moveErr.Code,
-		"move across shares must answer ErrCrossShare, got %v", moveErr.Code)
 }

--- a/pkg/metadata/errors.go
+++ b/pkg/metadata/errors.go
@@ -62,6 +62,7 @@ const (
 	ErrLockConflict           = errors.ErrLockConflict
 	ErrConnectionLimitReached = errors.ErrConnectionLimitReached
 	ErrConflict               = errors.ErrConflict
+	ErrCrossShare             = errors.ErrCrossShare
 )
 
 // ============================================================================

--- a/pkg/metadata/errors/errors.go
+++ b/pkg/metadata/errors/errors.go
@@ -101,6 +101,14 @@ const (
 	// files_object_id_idx; runtime coordinator wraps both into
 	// engine.ErrObjectIDConflict.
 	ErrConflict
+
+	// ErrCrossShare indicates a two-handle operation named handles from two
+	// different shares. One condition, one code: NFS surfaces EXDEV from its
+	// handler-level LINK/RENAME checks, so the store-layer guard
+	// (requireSameShare) answers with this code and the protocol mappers lift
+	// it to NFS3ErrXDev / NFS4ERR_XDEV / StatusNotSameDevice — not the
+	// generic invalid-parameter error that masked the condition over SMB.
+	ErrCrossShare
 )
 
 // String returns a human-readable name for the error code.
@@ -158,6 +166,8 @@ func (e ErrorCode) String() string {
 		return "ConnectionLimitReached"
 	case ErrConflict:
 		return "Conflict"
+	case ErrCrossShare:
+		return "CrossShare"
 	default:
 		return fmt.Sprintf("Unknown(%d)", e)
 	}

--- a/pkg/metadata/errors/errors.go
+++ b/pkg/metadata/errors/errors.go
@@ -109,6 +109,11 @@ const (
 	// it to NFS3ErrXDev / NFS4ERR_XDEV / StatusNotSameDevice — not the
 	// generic invalid-parameter error that masked the condition over SMB.
 	ErrCrossShare
+
+	// errCodeSentinel bounds the "every code is covered" iota-walks. Anchor
+	// new codes BEFORE this line: a code appended after it silently escapes
+	// every switch-exhaustiveness test.
+	errCodeSentinel
 )
 
 // String returns a human-readable name for the error code.

--- a/pkg/metadata/errors/errors_test.go
+++ b/pkg/metadata/errors/errors_test.go
@@ -57,9 +57,10 @@ func TestErrorCodeStringUnknown(t *testing.T) {
 }
 
 // Every named code must have a non-Unknown String mapping. This guards against
-// adding a new code constant without a corresponding switch arm.
+// adding a new code constant without a corresponding switch arm. The
+// errCodeSentinel tail is excluded: it bounds the walks and has no arm.
 func TestEveryCodeHasName(t *testing.T) {
-	for c := ErrNotFound; c <= ErrCrossShare; c++ {
+	for c := ErrNotFound; c < errCodeSentinel; c++ {
 		if s := c.String(); len(s) >= 7 && s[:7] == "Unknown" {
 			t.Errorf("code %d has no String() name (got %q)", c, s)
 		}
@@ -160,9 +161,11 @@ func TestClassifiers(t *testing.T) {
 		// ErrCrossShare maps to no classifier: it is a wire-code only, so
 		// its expected set is all-false. Extending the walk to it would
 		// force an empty row here — not worth forcing.
+		// errCodeSentinel is excluded: it is a bound, not an arm, and
+		// want[nil] would nil-map to all-false anyway.
 	}
 
-	for c := ErrNotFound; c <= ErrCrossShare; c++ {
+	for c := ErrNotFound; c < errCodeSentinel; c++ {
 		err := &StoreError{Code: c, Message: "x"}
 		want := expect[c]
 		for _, cl := range classifiers {

--- a/pkg/metadata/errors/errors_test.go
+++ b/pkg/metadata/errors/errors_test.go
@@ -37,6 +37,7 @@ func TestErrorCodeString(t *testing.T) {
 		{ErrLockConflict, "LockConflict"},
 		{ErrConnectionLimitReached, "ConnectionLimitReached"},
 		{ErrConflict, "Conflict"},
+		{ErrCrossShare, "CrossShare"},
 	}
 	for _, c := range cases {
 		if got := c.code.String(); got != c.want {
@@ -58,7 +59,7 @@ func TestErrorCodeStringUnknown(t *testing.T) {
 // Every named code must have a non-Unknown String mapping. This guards against
 // adding a new code constant without a corresponding switch arm.
 func TestEveryCodeHasName(t *testing.T) {
-	for c := ErrNotFound; c <= ErrConflict; c++ {
+	for c := ErrNotFound; c <= ErrCrossShare; c++ {
 		if s := c.String(); len(s) >= 7 && s[:7] == "Unknown" {
 			t.Errorf("code %d has no String() name (got %q)", c, s)
 		}
@@ -156,9 +157,12 @@ func TestClassifiers(t *testing.T) {
 		ErrConflict:          {"IsConflictError": true},
 		ErrInvalidHandle:     {"IsInvalidHandleError": true},
 		ErrStaleHandle:       {"IsStaleHandleError": true},
+		// ErrCrossShare maps to no classifier: it is a wire-code only, so
+		// its expected set is all-false. Extending the walk to it would
+		// force an empty row here — not worth forcing.
 	}
 
-	for c := ErrNotFound; c <= ErrConflict; c++ {
+	for c := ErrNotFound; c <= ErrCrossShare; c++ {
 		err := &StoreError{Code: c, Message: "x"}
 		want := expect[c]
 		for _, cl := range classifiers {

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -275,7 +275,7 @@ func requireSameShare(a, b FileHandle, what, path string) error {
 	}
 	if shareA != shareB {
 		return &StoreError{
-			Code:    ErrInvalidArgument,
+			Code:    ErrCrossShare,
 			Message: "cannot " + what + " across shares",
 			Path:    path,
 		}

--- a/pkg/metadata/service.go
+++ b/pkg/metadata/service.go
@@ -260,10 +260,8 @@ func (s *Service) storeForHandle(handle FileHandle) (Store, error) {
 // share resolves against the first share's store and the mutation lands on a
 // foreign file. Both handles are decoded explicitly rather than via
 // shareNameForHandle, which yields "" for an undecodable handle and would let
-// two malformed handles compare equal.
-//
-// what names the operation for the error message; path carries the entry name
-// the caller was acting on.
+// two malformed handles compare equal. What names the operation for the error
+// message; path carries the entry name the caller was acting on.
 func requireSameShare(a, b FileHandle, what, path string) error {
 	shareA, _, err := DecodeFileHandle(a)
 	if err != nil {


### PR DESCRIPTION
Closes #2441.

## What was actually wrong

The store-layer guards `requireSameShare` (`pkg/metadata/service.go`, called from `CreateHardLink` and `Move`) rejected a cross-share two-handle operation with a `StoreError` wrapping `ErrInvalidArgument`, because no cross-share error code existed. `internal/adapter/common/errmap.go` maps that to `NFS3ErrInval` / `STATUS_INVALID_PARAMETER`, so callers without their own export-level XDEV check surfaced the same condition as a generic invalid-parameter error — `EXDEV` over NFS, `STATUS_INVALID_PARAMETER` over SMB. #2432 fixed the NFS handler paths only; this closes the store tier, which is the seam every remaining caller routes through.

## The fix

- `pkg/metadata/errors` gains `ErrCrossShare` — one condition, one code at the store contract level.
- `pkg/metadata/service.go` returns it from `CreateHardLink` / `Move`; `pkg/metadata/errors.go` and the SMB status mapper map it to `EXDEV` / `STATUS_NOT_SAME_DEVICE`.
- The existing cross-share tests in `pkg/metadata/cross_share_guards_test.go` pin the code.

## Evidence

`go build ./... && go vet ./... && go test ./pkg/metadata/... ./internal/adapter/smb/types/...` green before push. Follow-up from #2432; premise verified — the generic mapping was reachable from the non-NFS callers named in the issue.