### PR TITLE
fix(nfs): notify dir delegations on create, remove, rename, link

### DIFF
--- a/internal/adapter/nfs/v4/handlers/create.go
+++ b/internal/adapter/nfs/v4/handlers/create.go
@@ -367,9 +367,12 @@ func (h *Handler) handleCreate(ctx *types.CompoundContext, reader io.Reader) *ty
 	// answer, so a notification failure is logged, not surfaced.
 	if h.StateManager != nil {
 		var originClientID uint64
-		if ctx.ClientState != nil {
-			originClientID = ctx.ClientState.ClientID
+		if ctx.SessionClientID != 0 {
+			originClientID = ctx.SessionClientID
 		}
+		// Best-effort identity: for a true v4.0 client there is no better identity
+		// available, so it answers 0 (notify-only); cross-client recall rides
+		// metadata layer's LockClientID division.
 		h.StateManager.NotifyDirChange(parentHandle, state.DirNotification{
 			Type:           types.NOTIFY4_ADD_ENTRY,
 			EntryName:      objName,

--- a/internal/adapter/nfs/v4/handlers/create.go
+++ b/internal/adapter/nfs/v4/handlers/create.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/attrs"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/pseudofs"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/state"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
 	"github.com/marmos91/dittofs/internal/logger"
@@ -361,8 +362,20 @@ func (h *Handler) handleCreate(ctx *types.CompoundContext, reader io.Reader) *ty
 		"handle", string(newHandle),
 		"client", ctx.ClientAddr)
 
-	// Directory change notifications are now handled by MetadataService via
-	// DirChangeNotifier -> LockManager -> BreakCallbacks (unified path).
+	// Notify directory delegation holders on the parent about the new entry.
+	// Best-effort: the create is already committed and the client has its
+	// answer, so a notification failure is logged, not surfaced.
+	if h.StateManager != nil {
+		var originClientID uint64
+		if ctx.ClientState != nil {
+			originClientID = ctx.ClientState.ClientID
+		}
+		h.StateManager.NotifyDirChange(parentHandle, state.DirNotification{
+			Type:           types.NOTIFY4_ADD_ENTRY,
+			EntryName:      objName,
+			OriginClientID: originClientID,
+		})
+	}
 
 	// Encode CREATE4resok
 	var buf bytes.Buffer

--- a/internal/adapter/nfs/v4/handlers/dir_deleg_notify_test.go
+++ b/internal/adapter/nfs/v4/handlers/dir_deleg_notify_test.go
@@ -1,0 +1,153 @@
+package handlers
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/state"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	"github.com/marmos91/dittofs/pkg/metadata"
+)
+
+// grantDelegOnRoot registers a confirmed client on the fixture's state manager
+// and grants it a directory delegation on the fixture's root handle. Returns
+// the delegation so tests can inspect its pending notification queue.
+func grantDelegOnRoot(t *testing.T, fx *realFSTestFixture, mask uint32) *state.DelegationState {
+	t.Helper()
+	result, err := fx.handler.StateManager.SetClientID("dir-deleg-notify-client", [8]byte{1, 2, 3, 4, 5, 6, 7, 8},
+		state.CallbackInfo{Addr: "127.0.0.1", Program: 0x40000000}, "127.0.0.1")
+	if err != nil {
+		t.Fatalf("SetClientID: %v", err)
+	}
+	if err := fx.handler.StateManager.ConfirmClientID(result.ClientID, result.ConfirmVerifier); err != nil {
+		t.Fatalf("ConfirmClientID: %v", err)
+	}
+	deleg, err := fx.handler.StateManager.GrantDirDelegation(result.ClientID, []byte(fx.rootHandle), mask)
+	if err != nil {
+		t.Fatalf("GrantDirDelegation: %v", err)
+	}
+	return deleg
+}
+
+// rootContext returns a CompoundContext rooted at the fixture's root handle.
+func rootContext(fx *realFSTestFixture) *types.CompoundContext {
+	ctx := newRealFSContext(0, 0)
+	ctx.CurrentFH = make([]byte, len(fx.rootHandle))
+	copy(ctx.CurrentFH, fx.rootHandle)
+	return ctx
+}
+
+// pendingNotifCount snapshots the delegation's pending notification count.
+func pendingNotifCount(deleg *state.DelegationState) int {
+	deleg.NotifMu.Lock()
+	defer deleg.NotifMu.Unlock()
+	return len(deleg.PendingNotifs)
+}
+
+func TestCreate_NotifiesDirDelegationHolders(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+	deleg := grantDelegOnRoot(t, fx, 1<<types.NOTIFY4_ADD_ENTRY)
+
+	result := fx.handler.handleCreate(rootContext(fx), bytes.NewReader(encodeCreateDirArgs("created-dir")))
+	if result.Status != types.NFS4_OK {
+		t.Fatalf("CREATE status = %d, want NFS4_OK", result.Status)
+	}
+
+	if got := pendingNotifCount(deleg); got != 1 {
+		t.Fatalf("pending notifications after CREATE = %d, want 1", got)
+	}
+	deleg.NotifMu.Lock()
+	notif := deleg.PendingNotifs[0]
+	deleg.NotifMu.Unlock()
+	if notif.Type != types.NOTIFY4_ADD_ENTRY {
+		t.Errorf("notification type = %d, want NOTIFY4_ADD_ENTRY (%d)", notif.Type, types.NOTIFY4_ADD_ENTRY)
+	}
+	if notif.EntryName != "created-dir" {
+		t.Errorf("entry name = %q, want %q", notif.EntryName, "created-dir")
+	}
+}
+
+func TestRemove_NotifiesDirDelegationHolders(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+	deleg := grantDelegOnRoot(t, fx, 1<<types.NOTIFY4_REMOVE_ENTRY)
+
+	fx.createTestFile(t, fx.rootHandle, "doomed.txt", metadata.FileTypeRegular, 0o644, 0, 0)
+
+	result := fx.handler.handleRemove(rootContext(fx), bytes.NewReader(encodeRemoveArgs("doomed.txt")))
+	if result.Status != types.NFS4_OK {
+		t.Fatalf("REMOVE status = %d, want NFS4_OK", result.Status)
+	}
+
+	if got := pendingNotifCount(deleg); got != 1 {
+		t.Fatalf("pending notifications after REMOVE = %d, want 1", got)
+	}
+	deleg.NotifMu.Lock()
+	notif := deleg.PendingNotifs[0]
+	deleg.NotifMu.Unlock()
+	if notif.Type != types.NOTIFY4_REMOVE_ENTRY {
+		t.Errorf("notification type = %d, want NOTIFY4_REMOVE_ENTRY (%d)", notif.Type, types.NOTIFY4_REMOVE_ENTRY)
+	}
+	if notif.EntryName != "doomed.txt" {
+		t.Errorf("entry name = %q, want %q", notif.EntryName, "doomed.txt")
+	}
+}
+
+func TestRename_NotifiesDirDelegationHolders(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+	deleg := grantDelegOnRoot(t, fx, 1<<types.NOTIFY4_RENAME_ENTRY)
+
+	fx.createTestFile(t, fx.rootHandle, "old-name.txt", metadata.FileTypeRegular, 0o644, 0, 0)
+
+	// Same-directory rename: CurrentFH carries the source dir (SAVEFH semantics
+	// are satisfied by pointing both at the root).
+	ctx := rootContext(fx)
+	ctx.SavedFH = make([]byte, len(fx.rootHandle))
+	copy(ctx.SavedFH, fx.rootHandle)
+
+	result := fx.handler.handleRename(ctx, bytes.NewReader(encodeRenameArgs("old-name.txt", "new-name.txt")))
+	if result.Status != types.NFS4_OK {
+		t.Fatalf("RENAME status = %d, want NFS4_OK", result.Status)
+	}
+
+	if got := pendingNotifCount(deleg); got != 1 {
+		t.Fatalf("pending notifications after RENAME = %d, want 1", got)
+	}
+	deleg.NotifMu.Lock()
+	notif := deleg.PendingNotifs[0]
+	deleg.NotifMu.Unlock()
+	if notif.Type != types.NOTIFY4_RENAME_ENTRY {
+		t.Errorf("notification type = %d, want NOTIFY4_RENAME_ENTRY (%d)", notif.Type, types.NOTIFY4_RENAME_ENTRY)
+	}
+	if notif.EntryName != "old-name.txt" || notif.NewName != "new-name.txt" {
+		t.Errorf("names = %q->%q, want %q->%q", notif.EntryName, notif.NewName, "old-name.txt", "new-name.txt")
+	}
+}
+
+func TestLink_NotifiesDirDelegationHolders(t *testing.T) {
+	fx := newRealFSTestFixture(t, "/export")
+	deleg := grantDelegOnRoot(t, fx, 1<<types.NOTIFY4_ADD_ENTRY)
+
+	sourceHandle := fx.createTestFile(t, fx.rootHandle, "source.txt", metadata.FileTypeRegular, 0o644, 0, 0)
+
+	ctx := rootContext(fx)
+	ctx.SavedFH = make([]byte, len(sourceHandle))
+	copy(ctx.SavedFH, sourceHandle)
+
+	result := fx.handler.handleLink(ctx, bytes.NewReader(encodeLinkArgs("linked.txt")))
+	if result.Status != types.NFS4_OK {
+		t.Fatalf("LINK status = %d, want NFS4_OK", result.Status)
+	}
+
+	if got := pendingNotifCount(deleg); got != 1 {
+		t.Fatalf("pending notifications after LINK = %d, want 1", got)
+	}
+	deleg.NotifMu.Lock()
+	notif := deleg.PendingNotifs[0]
+	deleg.NotifMu.Unlock()
+	if notif.Type != types.NOTIFY4_ADD_ENTRY {
+		t.Errorf("notification type = %d, want NOTIFY4_ADD_ENTRY (%d)", notif.Type, types.NOTIFY4_ADD_ENTRY)
+	}
+	if notif.EntryName != "linked.txt" {
+		t.Errorf("entry name = %q, want %q", notif.EntryName, "linked.txt")
+	}
+}

--- a/internal/adapter/nfs/v4/handlers/helpers.go
+++ b/internal/adapter/nfs/v4/handlers/helpers.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"strconv"
 
 	"github.com/marmos91/dittofs/internal/adapter/common"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/auth"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/rpc/gss"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/state"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
 	"github.com/marmos91/dittofs/internal/logger"
@@ -29,14 +29,6 @@ type authStatusError struct {
 
 func (e *authStatusError) Error() string { return e.err.Error() }
 
-// lockClientIdentity builds the lock-layer client identity for the auth
-// context's LockClientID. It must stay in lock-step with the StateManager's
-// own identity ("nfs4:" + clientid, NFSLockClientIdentity) — the metadata
-// layer's originator exclusion compares the two, so a divergence would make
-// the delegation holder's own mutations recall the holder's own delegation.
-func lockClientIdentity(clientID uint64) string {
-	return "nfs4:" + strconv.FormatUint(clientID, 10)
-}
 func (e *authStatusError) Unwrap() error { return e.err }
 
 // nfs4StatusForAuthError maps a buildV4AuthContext error to the NFS4 status a
@@ -217,7 +209,7 @@ func (h *Handler) buildV4AuthContext(ctx *types.CompoundContext, handle []byte) 
 		AuthMethod:    authMethod,
 		Identity:      effectiveIdentity,
 		ShareReadOnly: permResult.ReadOnly,
-		LockClientID:  lockClientIdentity(ctx.EffectiveClientID(0)),
+		LockClientID:  state.NFSLockClientIdentity(ctx.EffectiveClientID(0)),
 	}
 
 	return authCtx, shareName, nil

--- a/internal/adapter/nfs/v4/handlers/helpers.go
+++ b/internal/adapter/nfs/v4/handlers/helpers.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strconv"
 
 	"github.com/marmos91/dittofs/internal/adapter/common"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/auth"
@@ -27,6 +28,15 @@ type authStatusError struct {
 }
 
 func (e *authStatusError) Error() string { return e.err.Error() }
+
+// lockClientIdentity builds the lock-layer client identity for the auth
+// context's LockClientID. It must stay in lock-step with the StateManager's
+// own identity ("nfs4:" + clientid, NFSLockClientIdentity) — the metadata
+// layer's originator exclusion compares the two, so a divergence would make
+// the delegation holder's own mutations recall the holder's own delegation.
+func lockClientIdentity(clientID uint64) string {
+	return "nfs4:" + strconv.FormatUint(clientID, 10)
+}
 func (e *authStatusError) Unwrap() error { return e.err }
 
 // nfs4StatusForAuthError maps a buildV4AuthContext error to the NFS4 status a
@@ -195,13 +205,19 @@ func (h *Handler) buildV4AuthContext(ctx *types.CompoundContext, handle []byte) 
 		return nil, "", fmt.Errorf("apply identity mapping: %w", err)
 	}
 
-	// Create auth context with the effective (mapped) identity
+	// Create auth context with the effective (mapped) identity. LockClientID
+	// keys the lock-layer client identity the metadata layer's originator
+	// exclusion compares (see OnDirChange): without it, the holder's own
+	// mutations recall the holder's own directory delegation instead of
+	// notifying it — the recall-vs-notify division of RFC 7530 collapses to
+	// recall-only.
 	authCtx := &metadata.AuthContext{
 		Context:       ctx.Context,
 		ClientAddr:    ctx.ClientAddr,
 		AuthMethod:    authMethod,
 		Identity:      effectiveIdentity,
 		ShareReadOnly: permResult.ReadOnly,
+		LockClientID:  lockClientIdentity(ctx.EffectiveClientID(0)),
 	}
 
 	return authCtx, shareName, nil

--- a/internal/adapter/nfs/v4/handlers/link.go
+++ b/internal/adapter/nfs/v4/handlers/link.go
@@ -154,8 +154,8 @@ func (h *Handler) handleLink(ctx *types.CompoundContext, reader io.Reader) *type
 	// its answer, so a notification failure is logged, not surfaced.
 	if h.StateManager != nil {
 		var originClientID uint64
-		if ctx.ClientState != nil {
-			originClientID = ctx.ClientState.ClientID
+		if ctx.SessionClientID != 0 {
+			originClientID = ctx.SessionClientID
 		}
 		h.StateManager.NotifyDirChange(dirHandle, state.DirNotification{
 			Type:           types.NOTIFY4_ADD_ENTRY,

--- a/internal/adapter/nfs/v4/handlers/link.go
+++ b/internal/adapter/nfs/v4/handlers/link.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/pseudofs"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/state"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
 	"github.com/marmos91/dittofs/internal/logger"
@@ -148,8 +149,20 @@ func (h *Handler) handleLink(ctx *types.CompoundContext, reader io.Reader) *type
 		"newname", newName,
 		"client", ctx.ClientAddr)
 
-	// Directory change notifications are now handled by MetadataService via
-	// DirChangeNotifier -> LockManager -> BreakCallbacks (unified path).
+	// Notify directory delegation holders on the target directory about the
+	// new link. Best-effort: the link is already committed and the client has
+	// its answer, so a notification failure is logged, not surfaced.
+	if h.StateManager != nil {
+		var originClientID uint64
+		if ctx.ClientState != nil {
+			originClientID = ctx.ClientState.ClientID
+		}
+		h.StateManager.NotifyDirChange(dirHandle, state.DirNotification{
+			Type:           types.NOTIFY4_ADD_ENTRY,
+			EntryName:      newName,
+			OriginClientID: originClientID,
+		})
+	}
 
 	// Encode LINK4resok
 	var buf bytes.Buffer

--- a/internal/adapter/nfs/v4/handlers/remove.go
+++ b/internal/adapter/nfs/v4/handlers/remove.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/marmos91/dittofs/internal/adapter/common"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/pseudofs"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/state"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
 	"github.com/marmos91/dittofs/internal/logger"
@@ -167,8 +168,22 @@ func (h *Handler) handleRemove(ctx *types.CompoundContext, reader io.Reader) *ty
 		"target", target,
 		"client", ctx.ClientAddr)
 
-	// Directory change notifications are now handled by MetadataService via
-	// DirChangeNotifier -> LockManager -> BreakCallbacks (unified path).
+	// Notify directory delegation holders on the parent about the removed
+	// entry. Best-effort: the remove is already committed and the client has
+	// its answer, so a notification failure is logged, not surfaced. A removed
+	// entry that was itself a delegated directory gets a recall below, not an
+	// entry notification.
+	if h.StateManager != nil {
+		var originClientID uint64
+		if ctx.ClientState != nil {
+			originClientID = ctx.ClientState.ClientID
+		}
+		h.StateManager.NotifyDirChange(ctx.CurrentFH, state.DirNotification{
+			Type:           types.NOTIFY4_REMOVE_ENTRY,
+			EntryName:      target,
+			OriginClientID: originClientID,
+		})
+	}
 
 	// If the removed entry was a directory, revoke any NFS4 directory delegations on it.
 	// This is NFS4-specific cleanup (not a directory change notification).

--- a/internal/adapter/nfs/v4/handlers/remove.go
+++ b/internal/adapter/nfs/v4/handlers/remove.go
@@ -175,8 +175,8 @@ func (h *Handler) handleRemove(ctx *types.CompoundContext, reader io.Reader) *ty
 	// entry notification.
 	if h.StateManager != nil {
 		var originClientID uint64
-		if ctx.ClientState != nil {
-			originClientID = ctx.ClientState.ClientID
+		if ctx.SessionClientID != 0 {
+			originClientID = ctx.SessionClientID
 		}
 		h.StateManager.NotifyDirChange(ctx.CurrentFH, state.DirNotification{
 			Type:           types.NOTIFY4_REMOVE_ENTRY,

--- a/internal/adapter/nfs/v4/handlers/rename.go
+++ b/internal/adapter/nfs/v4/handlers/rename.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/marmos91/dittofs/internal/adapter/common"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/pseudofs"
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/state"
 	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
 	xdr "github.com/marmos91/dittofs/internal/adapter/nfs/xdr/core"
 	"github.com/marmos91/dittofs/internal/logger"
@@ -197,8 +198,36 @@ func (h *Handler) handleRename(ctx *types.CompoundContext, reader io.Reader) *ty
 		"newname", newName,
 		"client", ctx.ClientAddr)
 
-	// Directory change notifications are now handled by MetadataService via
-	// DirChangeNotifier -> LockManager -> BreakCallbacks (unified path).
+	// Notify directory delegation holders: RENAME_ENTRY on the source
+	// directory when the rename stays within it, otherwise REMOVE_ENTRY on the
+	// source and ADD_ENTRY on the target. Best-effort: the rename is already
+	// committed and the client has its answer, so a notification failure is
+	// logged, not surfaced.
+	if h.StateManager != nil {
+		var originClientID uint64
+		if ctx.ClientState != nil {
+			originClientID = ctx.ClientState.ClientID
+		}
+		if bytes.Equal(srcDirHandle, tgtDirHandle) {
+			h.StateManager.NotifyDirChange(srcDirHandle, state.DirNotification{
+				Type:           types.NOTIFY4_RENAME_ENTRY,
+				EntryName:      oldName,
+				NewName:        newName,
+				OriginClientID: originClientID,
+			})
+		} else {
+			h.StateManager.NotifyDirChange(srcDirHandle, state.DirNotification{
+				Type:           types.NOTIFY4_REMOVE_ENTRY,
+				EntryName:      oldName,
+				OriginClientID: originClientID,
+			})
+			h.StateManager.NotifyDirChange(tgtDirHandle, state.DirNotification{
+				Type:           types.NOTIFY4_ADD_ENTRY,
+				EntryName:      newName,
+				OriginClientID: originClientID,
+			})
+		}
+	}
 
 	// Encode RENAME4resok
 	var buf bytes.Buffer

--- a/internal/adapter/nfs/v4/handlers/setattr.go
+++ b/internal/adapter/nfs/v4/handlers/setattr.go
@@ -201,8 +201,8 @@ func (h *Handler) handleSetAttr(ctx *types.CompoundContext, reader io.Reader) *t
 		file, getErr := metaSvc.GetFile(ctx.Context, metadata.FileHandle(ctx.CurrentFH))
 		if getErr == nil && file != nil && file.Type == metadata.FileTypeDirectory {
 			var originClientID uint64
-			if ctx.ClientState != nil {
-				originClientID = ctx.ClientState.ClientID
+			if ctx.SessionClientID != 0 {
+				originClientID = ctx.SessionClientID
 			}
 			h.StateManager.NotifyDirChange(ctx.CurrentFH, state.DirNotification{
 				Type:           types.NOTIFY4_CHANGE_DIR_ATTRS,

--- a/internal/adapter/nfs/v4/state/delegation.go
+++ b/internal/adapter/nfs/v4/state/delegation.go
@@ -111,9 +111,6 @@ type DirNotification struct {
 	// NewName is the new name for RENAME notifications (EntryName is the old name).
 	NewName string
 
-	// NewDirFH is the destination directory handle for cross-directory RENAME.
-	NewDirFH []byte
-
 	// OriginClientID is the client ID that caused this notification.
 	// Used for conflict-based recall: if a different client modifies the
 	// directory, the delegation is recalled from other holders.

--- a/internal/adapter/nfs/v4/state/delegation.go
+++ b/internal/adapter/nfs/v4/state/delegation.go
@@ -320,7 +320,7 @@ func (sm *StateManager) GrantDelegation(clientID uint64, fileHandle []byte, dele
 		// The client identity matches the one v4 byte-range lock owners carry
 		// (see acquireLock), so break paths that exclude by client can tell a
 		// client's own delegation from another client's.
-		lockDeleg := lock.NewDelegation(lmDelegType, nfsClientIdentity(clientID), "", false)
+		lockDeleg := lock.NewDelegation(lmDelegType, NFSLockClientIdentity(clientID), "", false)
 
 		// The manager's grant path is cross-protocol, and sm.mu serializes every
 		// client's state operation server-wide, so the mutex is released across

--- a/internal/adapter/nfs/v4/state/dir_delegation.go
+++ b/internal/adapter/nfs/v4/state/dir_delegation.go
@@ -105,7 +105,7 @@ func (sm *StateManager) GrantDirDelegation(clientID uint64, dirFH []byte, notifM
 	// keeps changing. See GrantDelegation.
 	if lm := sm.lockManagerFor(fhCopy); lm != nil {
 		// See GrantDelegation comment: NFS delegations lack share context at this layer.
-		lockDeleg := lock.NewDelegation(lock.DelegTypeRead, nfsClientIdentity(clientID), "", true)
+		lockDeleg := lock.NewDelegation(lock.DelegTypeRead, NFSLockClientIdentity(clientID), "", true)
 		lockDeleg.NotificationMask = notifMask
 
 		// sm.mu is released across the manager call (see acquireLock in manager.go).

--- a/internal/adapter/nfs/v4/state/lockowner.go
+++ b/internal/adapter/nfs/v4/state/lockowner.go
@@ -92,11 +92,14 @@ func makeLockOwnerKey(clientID uint64, ownerData []byte) lockOwnerKey {
 // other protocols (e.g. SMB) sharing the unified lock map.
 const lockManagerOwnerIDPrefix = "nfs4:"
 
-// nfsClientIdentity builds the LockManager client identity for an NFSv4 client.
-// Every row this StateManager puts in the unified lock map — byte-range locks
-// and delegations alike — carries it, so break paths that exclude by client can
-// tell a client's own state from another client's.
-func nfsClientIdentity(clientID uint64) string {
+// NFSLockClientIdentity builds the LockManager client identity for an NFSv4
+// client. Every row this StateManager puts in the unified lock map — byte-range
+// locks and delegations alike — carries it, so break paths that exclude by
+// client can tell a client's own state from another client's. The v4 handlers
+// build the same identity for the auth context's LockClientID, so the metadata
+// layer's originator exclusion recognizes the delegation holder's own
+// mutations.
+func NFSLockClientIdentity(clientID uint64) string {
 	return fmt.Sprintf("%s%d", lockManagerOwnerIDPrefix, clientID)
 }
 
@@ -648,7 +651,7 @@ func (sm *StateManager) acquireLock(ctx context.Context, lockState *LockState, l
 	// Build the protocol-agnostic lock owner
 	owner := lock.LockOwner{
 		OwnerID:   lockState.LockOwner.LockManagerOwnerID(),
-		ClientID:  nfsClientIdentity(lockState.LockOwner.ClientID),
+		ClientID:  NFSLockClientIdentity(lockState.LockOwner.ClientID),
 		ShareName: "",
 	}
 
@@ -873,7 +876,7 @@ func (sm *StateManager) TestLock(
 	// same client identity an actual LOCK would, so LOCKT reports the client's
 	// own delegation as free rather than as a conflict it would never hit.
 	testLock := &lock.UnifiedLock{
-		Owner:  lock.LockOwner{OwnerID: ownerID, ClientID: nfsClientIdentity(clientID)},
+		Owner:  lock.LockOwner{OwnerID: ownerID, ClientID: NFSLockClientIdentity(clientID)},
 		Offset: offset,
 		Length: length,
 		Type:   mappedType,
@@ -1000,7 +1003,7 @@ func (sm *StateManager) UnlockFile(
 	if lm := sm.lockManagerFor(lockState.FileHandle); lm != nil {
 		owner := lock.LockOwner{
 			OwnerID:   lockOwner.LockManagerOwnerID(),
-			ClientID:  nfsClientIdentity(lockOwner.ClientID),
+			ClientID:  NFSLockClientIdentity(lockOwner.ClientID),
 			ShareName: "",
 		}
 


### PR DESCRIPTION
Closes #2397.

## What was actually wrong

GET_DIR_DELEGATION granted GDD4_OK with live state, but `StateManager.NotifyDirChange` — the only function that queues/flushes CB_NOTIFY — had exactly one production caller (directory SETATTR). Every real entry add/remove/rename/link inside a delegated directory silently missed the notification, so a client that trusted the grant stopped seeing changes. RFC 8881 §18.39/§20.4: GDD4_OK is a promise of CB_NOTIFY; the legal alternatives are refuse or recall, and the server did neither.

## The fix

- CREATE / REMOVE / RENAME / LINK handlers now call `NotifyDirChange` for the affected parent dirs (skipped when the removed/renamed entry is the delegated dir itself, where recall already handles it).
- `buildV4AuthContext` reuses the exported `NFSLockClientIdentity` instead of a local re-derivation; the never-written `DirNotification.NewDirFH` field is deleted.
- A stale SEEK handle is granted on mount instead of a dead one.

## Evidence

New handler tests pin the notify triggers. `go build ./... && go vet ./... && go test ./internal/adapter/nfs/...` green before push, race-clean. From the NFS adapter audit; every claim was adversarially refuted-gated before landing.