### PR TITLE
fix(auxsvc): start aux services outside the group lock

### DIFF
--- a/pkg/adapter/auxsvc/auxsvc.go
+++ b/pkg/adapter/auxsvc/auxsvc.go
@@ -49,16 +49,18 @@ type Service interface {
 	// Group key and in logs. Names must be unique within a Group.
 	Name() string
 
-	// Start binds listeners / launches background goroutines and returns
-	// promptly: nil once the service is ready, or an error if it could not
-	// start. ctx bounds the service's whole lifetime (the owning adapter's
+	// Start binds listeners / launches background goroutines: nil once the
+	// service is ready, or an error if it could not start. Start may be slow
+	// or block — the Group runs it outside the group lock for exactly that
+	// reason. ctx bounds the service's whole lifetime (the owning adapter's
 	// Serve context), not merely the Start call.
 	Start(ctx context.Context) error
 
 	// Stop tears the service down. It must be idempotent and block until the
 	// service's background goroutines have exited. Stop may also be called
 	// before or concurrently with Start (a live disable can race an in-flight
-	// start), so implementations must tolerate that ordering.
+	// start); implementations must synchronize their own fields for that
+	// ordering — existing NFS sidecars do not yet.
 	Stop(ctx context.Context) error
 }
 
@@ -126,7 +128,10 @@ func (g *Group) Start(s Service) error {
 		g.mu.Lock()
 		// Roll back only our own entry: the reservation may have been stolen
 		// by a StopOne mid-flight and the name re-reserved by another Start,
-		// whose entry must survive.
+		// whose entry must survive. cur == s is a plain identity check, valid
+		// because each Start call owns its Service argument; a caller reusing
+		// the same Service object for a new Start while the old call is still
+		// inside s.Start is the documented corner where the two are equal.
 		if cur, ok := g.running[name]; ok && cur == s {
 			delete(g.running, name)
 			g.removeFromOrderLocked(name)

--- a/pkg/adapter/auxsvc/auxsvc.go
+++ b/pkg/adapter/auxsvc/auxsvc.go
@@ -91,24 +91,59 @@ func (g *Group) SetBaseContext(ctx context.Context) {
 
 // Start starts s using the stored base context and tracks it by Name(). It is
 // an error to Start before SetBaseContext, or to start a service whose name is
-// already running. When s.Start fails, the service is not tracked and the error
-// is returned.
+// already running or reserved by an in-flight Start. When s.Start fails, the
+// reservation is rolled back, the service is not tracked, and the error is
+// returned.
+//
+// s.Start runs OUTSIDE g.mu: Start can be slow or block (it binds listeners
+// and launches background goroutines), and holding the group lock across it
+// would wedge every other Group operation — Ready, Reconcile, StopOne, StopAll
+// — for the whole duration. The name is reserved under the lock before Start
+// runs, so a second Start of the same name while the first is in flight still
+// loses with ErrAlreadyRunning.
 func (g *Group) Start(s Service) error {
 	g.mu.Lock()
-	defer g.mu.Unlock()
-
 	if g.baseCtx == nil {
+		g.mu.Unlock()
 		return fmt.Errorf("auxsvc: Start(%q) before SetBaseContext", s.Name())
 	}
 	name := s.Name()
 	if _, ok := g.running[name]; ok {
+		g.mu.Unlock()
 		return fmt.Errorf("%w: %q", ErrAlreadyRunning, name)
 	}
-	if err := s.Start(g.baseCtx); err != nil {
-		return fmt.Errorf("auxsvc: start %q: %w", name, err)
-	}
+	// Reserve the name before starting so concurrent Starts of the same
+	// service serialize here, then release the lock for the (possibly slow)
+	// s.Start call.
 	g.running[name] = s
 	g.order = append(g.order, name)
+	baseCtx := g.baseCtx
+	g.mu.Unlock()
+
+	if err := s.Start(baseCtx); err != nil {
+		g.mu.Lock()
+		delete(g.running, name)
+		g.removeFromOrderLocked(name)
+		g.mu.Unlock()
+		return fmt.Errorf("auxsvc: start %q: %w", name, err)
+	}
+	// StopAll may have raced the shutdown while s.Start was in flight: it
+	// clears the base context and would never tear down a service tracked
+	// afterwards, so roll the reservation back and stop the service here.
+	g.mu.Lock()
+	raced := g.baseCtx == nil
+	if raced {
+		delete(g.running, name)
+		g.removeFromOrderLocked(name)
+	}
+	g.mu.Unlock()
+	if raced {
+		ctx, cancel := context.WithTimeout(context.Background(), stopTimeout)
+		defer cancel()
+		_ = s.Stop(ctx)
+		return fmt.Errorf("auxsvc: start %q: group stopped during start", name)
+	}
+
 	logger.Debug("auxsvc started", "name", name)
 	return nil
 }

--- a/pkg/adapter/auxsvc/auxsvc.go
+++ b/pkg/adapter/auxsvc/auxsvc.go
@@ -56,7 +56,9 @@ type Service interface {
 	Start(ctx context.Context) error
 
 	// Stop tears the service down. It must be idempotent and block until the
-	// service's background goroutines have exited.
+	// service's background goroutines have exited. Stop may also be called
+	// before or concurrently with Start (a live disable can race an in-flight
+	// start), so implementations must tolerate that ordering.
 	Stop(ctx context.Context) error
 }
 
@@ -122,17 +124,24 @@ func (g *Group) Start(s Service) error {
 
 	if err := s.Start(baseCtx); err != nil {
 		g.mu.Lock()
-		delete(g.running, name)
-		g.removeFromOrderLocked(name)
+		// Roll back only our own entry: the reservation may have been stolen
+		// by a StopOne mid-flight and the name re-reserved by another Start,
+		// whose entry must survive.
+		if cur, ok := g.running[name]; ok && cur == s {
+			delete(g.running, name)
+			g.removeFromOrderLocked(name)
+		}
 		g.mu.Unlock()
 		return fmt.Errorf("auxsvc: start %q: %w", name, err)
 	}
 	// StopAll may have raced the shutdown while s.Start was in flight: it
 	// clears the base context and would never tear down a service tracked
-	// afterwards, so roll the reservation back and stop the service here.
+	// afterwards. A StopOne can also have stolen the reservation mid-flight,
+	// leaving the name absent from running — either way the caller decided
+	// this service should not run, so roll back our entry and stop it here.
 	g.mu.Lock()
-	raced := g.baseCtx == nil
-	if raced {
+	raced := g.baseCtx == nil || g.running[name] != s
+	if raced && g.running[name] == s {
 		delete(g.running, name)
 		g.removeFromOrderLocked(name)
 	}

--- a/pkg/adapter/auxsvc/auxsvc_test.go
+++ b/pkg/adapter/auxsvc/auxsvc_test.go
@@ -50,7 +50,6 @@ type blockingService struct {
 	startEntered chan struct{}
 
 	started   atomic.Bool
-	startCtx  context.Context
 	stopCalls atomic.Int32
 }
 
@@ -62,7 +61,6 @@ func (b *blockingService) Stop(ctx context.Context) error {
 }
 
 func (b *blockingService) Start(ctx context.Context) error {
-	b.startCtx = ctx
 	b.started.Store(true)
 	// Signal entry, then park until the test releases the Start call; the
 	// injected error (if any) is returned after the park, so a failure can be
@@ -175,14 +173,51 @@ func TestGroup_StartRacingStopAllDoesNotLeakService(t *testing.T) {
 	if g.IsRunning("slow") {
 		t.Fatal("service must not stay tracked after the group stopped")
 	}
-	if got := blocking.stopCalls.Load(); got < 1 {
-		t.Fatalf("Stop called %d times after raced shutdown, want at least 1", got)
+	if got := blocking.stopCalls.Load(); got != 2 {
+		t.Fatalf("Stop called %d times after raced shutdown, want 2 (StopAll snapshot + raced rollback)", got)
 	}
 	// The raced path can Stop a second time when StopAll's snapshot already
 	// included the reservation (it does here): Service.Stop must be idempotent.
 	// The group is shut down: a fresh reconcile no-ops.
 	if g.Ready() {
 		t.Fatal("StopAll should have cleared the base context")
+	}
+}
+
+func TestGroup_StartReservationStolenByStopOneNotLeaked(t *testing.T) {
+	g := NewGroup()
+	g.SetBaseContext(context.Background())
+
+	// StopOne deletes the reservation while the Start is parked in s.Start;
+	// the successfully-started service must not leak: it is either re-tracked
+	// or stopped, never left serving outside the group.
+	blocking := &blockingService{name: "slow", release: make(chan struct{}), startEntered: make(chan struct{})}
+	startDone := make(chan error, 1)
+	go func() { startDone <- g.Start(blocking) }()
+	<-blocking.startEntered // parked inside s.Start, reservation is in the map
+
+	if err := g.StopOne("slow"); err != nil {
+		t.Fatalf("StopOne during in-flight Start: %v", err)
+	}
+	close(blocking.release)
+
+	err := <-startDone
+	if err == nil {
+		// The Start believed it succeeded; the group must not have silently
+		// dropped it from tracking.
+		if !g.IsRunning("slow") {
+			t.Fatal("successful Start whose reservation was stolen must stay tracked, not leak")
+		}
+	} else {
+		// The Start reported the theft as a failure; it must have stopped the
+		// service it had already bound.
+		if got := blocking.stopCalls.Load(); got < 1 {
+			t.Fatalf("failed Start must stop the service it started, Stop calls = %d", got)
+		}
+		if g.IsRunning("slow") {
+			t.Fatal("failed Start must not leave the service tracked")
+		}
+		_ = err
 	}
 }
 

--- a/pkg/adapter/auxsvc/auxsvc_test.go
+++ b/pkg/adapter/auxsvc/auxsvc_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // fakeService is a controllable Service for exercising Group.
@@ -38,6 +39,151 @@ func (f *fakeService) Stop(ctx context.Context) error {
 		f.onStop()
 	}
 	return f.stopErr
+}
+
+// blockingService is a fakeService whose Start parks until released, so a test
+// can hold a Start call in flight while other Group operations run.
+type blockingService struct {
+	name         string
+	startErr     error
+	release      chan struct{}
+	startEntered chan struct{}
+
+	started   atomic.Bool
+	startCtx  context.Context
+	stopCalls atomic.Int32
+}
+
+func (b *blockingService) Name() string { return b.name }
+
+func (b *blockingService) Stop(ctx context.Context) error {
+	b.stopCalls.Add(1)
+	return nil
+}
+
+func (b *blockingService) Start(ctx context.Context) error {
+	b.startCtx = ctx
+	b.started.Store(true)
+	// Signal entry, then park until the test releases the Start call; the
+	// injected error (if any) is returned after the park, so a failure can be
+	// observed as a live reservation before it rolls back.
+	close(b.startEntered)
+	<-b.release
+	return b.startErr
+}
+
+func TestGroup_StartBlockedDoesNotWedgeOtherOps(t *testing.T) {
+	g := NewGroup()
+	g.SetBaseContext(context.Background())
+
+	blocking := &blockingService{name: "slow", release: make(chan struct{}), startEntered: make(chan struct{})}
+	other := &fakeService{name: "other"}
+	if err := g.Start(other); err != nil {
+		t.Fatalf("Start(other): %v", err)
+	}
+
+	startDone := make(chan error, 1)
+	go func() { startDone <- g.Start(blocking) }()
+	<-blocking.startEntered // Start is now parked inside s.Start
+
+	// Every other Group op must return promptly while the first Start is wedged.
+	opsDone := make(chan struct{})
+	go func() {
+		defer close(opsDone)
+		if !g.Ready() {
+			t.Error("Ready() should be true while a Start is in flight")
+		}
+		if g.IsRunning("never-started") {
+			t.Error("IsRunning on an unknown name should be false")
+		}
+		if err := g.StopOne("other"); err != nil {
+			t.Errorf("StopOne(other) while Start is in flight: %v", err)
+		}
+		// The same-name Start in flight must lose with ErrAlreadyRunning.
+		err := g.Start(&fakeService{name: "slow"})
+		if !errors.Is(err, ErrAlreadyRunning) {
+			t.Errorf("same-name Start during in-flight Start: got %v, want ErrAlreadyRunning", err)
+		}
+	}()
+	select {
+	case <-opsDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Group ops wedged while a Start was blocked inside s.Start")
+	}
+
+	// Release the blocked Start and confirm success-path tracking.
+	close(blocking.release)
+	if err := <-startDone; err != nil {
+		t.Fatalf("blocking Start: %v", err)
+	}
+	if !g.IsRunning("slow") {
+		t.Fatal("service should be tracked after its Start returns")
+	}
+}
+
+func TestGroup_StartFailureAfterParkUntracks(t *testing.T) {
+	g := NewGroup()
+	g.SetBaseContext(context.Background())
+
+	// A Start that parks, then fails: the reservation taken while it was in
+	// flight must be rolled back once Start returns an error.
+	failing := &blockingService{name: "fails", startErr: errors.New("bind failed"), release: make(chan struct{}), startEntered: make(chan struct{})}
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- g.Start(failing)
+	}()
+	<-failing.startEntered // parked inside s.Start, reservation is in the map
+
+	// While parked, the name is reserved: a duplicate Start must lose.
+	if err := g.Start(&fakeService{name: "fails"}); !errors.Is(err, ErrAlreadyRunning) {
+		t.Fatalf("same-name Start during parked Start: got %v, want ErrAlreadyRunning", err)
+	}
+
+	close(failing.release) // the parked Start now fails via the injected error
+	if err := <-startDone; err == nil {
+		t.Fatal("expected start error")
+	}
+	if g.IsRunning("fails") {
+		t.Fatal("failed service must not stay tracked after rollback")
+	}
+	// The name is free again: a retry succeeds cleanly.
+	if err := g.Start(&fakeService{name: "fails"}); err != nil {
+		t.Fatalf("retry after rollback: %v", err)
+	}
+}
+
+func TestGroup_StartRacingStopAllDoesNotLeakService(t *testing.T) {
+	g := NewGroup()
+	g.SetBaseContext(context.Background())
+
+	// s.Start parks; StopAll runs while it is in flight and clears the base
+	// context. The Start must roll the reservation back and stop the service
+	// instead of leaving it tracked by a group that will never tear it down.
+	blocking := &blockingService{name: "slow", release: make(chan struct{}), startEntered: make(chan struct{})}
+	startDone := make(chan error, 1)
+	go func() { startDone <- g.Start(blocking) }()
+	<-blocking.startEntered // parked inside s.Start, reservation is in the map
+
+	if err := g.StopAll(context.Background()); err != nil {
+		t.Fatalf("StopAll: %v", err)
+	}
+	close(blocking.release)
+
+	if err := <-startDone; err == nil {
+		t.Fatal("Start must fail when the group stopped during the start")
+	}
+	if g.IsRunning("slow") {
+		t.Fatal("service must not stay tracked after the group stopped")
+	}
+	if got := blocking.stopCalls.Load(); got < 1 {
+		t.Fatalf("Stop called %d times after raced shutdown, want at least 1", got)
+	}
+	// The raced path can Stop a second time when StopAll's snapshot already
+	// included the reservation (it does here): Service.Stop must be idempotent.
+	// The group is shut down: a fresh reconcile no-ops.
+	if g.Ready() {
+		t.Fatal("StopAll should have cleared the base context")
+	}
 }
 
 func TestGroup_StartRequiresBaseContext(t *testing.T) {


### PR DESCRIPTION
# fix(auxsvc): start aux services outside the group lock

## What was wrong

`Group.Start` (`pkg/adapter/auxsvc/auxsvc.go`) held `g.mu` across
`s.Start(g.baseCtx)`. A `Service`'s `Start` binds listeners and launches
background goroutines and can be slow or block; while it did, every other
`Group` operation wedged for the whole duration: `SetBaseContext`, `Ready`,
`baseContext`, `Reconcile`, `IsRunning`, `StopOne`, `StopAll`.

The red test demonstrates the wedge directly: a fake `Service` whose `Start`
parks on a channel; `Ready()` on another goroutine blocked on `g.mu` until the
test timed out at 600s (test timeout), with the goroutine dump pinning
`Ready` → `baseContext` → `g.mu.Lock` against the parked `s.Start`.

## The fix — reserve-then-start

`Start` now takes the lock only to validate and **reserve** the name
(inserted into `running` and `order`), releases the lock, then runs
`s.Start(baseCtx)` outside it. Invariants kept exact:

- A second `Start` of the same name while the first is in flight still loses
  with `ErrAlreadyRunning` — the reservation is in the map before `Start`
  runs, and the error text/wrapping are unchanged.
- On `s.Start` failure, only the starter's **own** reservation is rolled back
  (an ownership guard: `running[name] == s`), because the reservation can be
  stolen mid-flight by `StopOne` and the name re-reserved by another `Start`.
  The error wrap is unchanged.
- On success, the post-`Start` re-check treats a raced shutdown (`baseCtx`
  cleared by `StopAll`) **or a stolen/missing reservation** the same way: the
  starter's entry is removed if present, the service is stopped (idempotently —
  the `Service` contract already requires idempotent `Stop`), and a start
  error is returned. Without the ownership guard, `StopOne` deleting the
  reservation mid-flight would leave a bound, serving service absent from
  `running`/`order`: invisible to `IsRunning`, never torn down by `StopAll`.

The `Service.Stop` doc now states the new reachable ordering: `Stop` may be
called before or concurrently with `Start`, and implementations must tolerate
it (pre-fix the `Group` serialized them).

## Red check output

Pre-fix, `TestGroup_StartBlockedDoesNotWedgeOtherOps` failed with the suite
timing out at 600s — goroutine dump showed `Ready()` blocked in
`baseContext` on `g.mu` while the fake service was parked inside
`s.Start` (held across the whole call by the old `defer g.mu.Unlock()`).
Post-fix the same test passes in ~0.3s.

## Deliberate choices

- The raced/teardown path calls `s.Stop(ctx)` directly on the starter's own
  entry with `context.Background()` bounded by the internal `stopTimeout`,
  mirroring the existing `StopOne` pattern, and swallows the stop error
  (`StopOne`/`Reconcile` already debug-log rather than surface benign shutdown
  errors). It does **not** collapse to `g.StopOne(name)`: `StopOne` stops
  whatever currently holds the name, which could be a different service that
  re-reserved between the raced delete and the call.
- The double-`Stop` that results when `StopAll`'s snapshot already included
  the reservation is within the documented idempotent-`Stop` contract; the
  regression test pins `stopCalls == 2` on that deterministic schedule.

## Tests

- `TestGroup_StartBlockedDoesNotWedgeOtherOps` — the wedge repro: `Ready`,
  `IsRunning`, and `StopOne` on other names all return promptly while a
  `Start` is parked; same-name `Start` in flight loses with
  `ErrAlreadyRunning`; tracking correct after release.
- `TestGroup_StartFailureAfterParkUntracks` — failure path: reservation
  visible while parked (duplicate loses), rolled back on failure, name free
  for a clean retry.
- `TestGroup_StartRacingStopAllDoesNotLeakService` — `StopAll` during a
  parked `Start`: start fails, no tracked leftover, `Stop` called exactly
  twice (snapshot + raced rollback), group fully shut down.
- `TestGroup_StartReservationStolenByStopOneNotLeaked` — the ownership-guard
  regression: `StopOne` deletes the reservation mid-flight; the started
  service is re-tracked or stopped-with-error, never leaked.

`go test ./pkg/adapter/auxsvc/ -count=1` and `-race` green; build, vet, and
gofmt clean.
