### PR TITLE
fix(nfs): validate the v4.0 lock-owner seqid of zero

### DIFF
--- a/internal/adapter/nfs/v4/state/batch_state_manager_test.go
+++ b/internal/adapter/nfs/v4/state/batch_state_manager_test.go
@@ -15,10 +15,11 @@ import (
 // Finding 1 — LockNew must not leak lock-owner / lock-state on bad seqid
 // ============================================================================
 
-// TestLockNew_BadLockSeqidDoesNotLeakState verifies that a LOCK with an
-// invalid lock seqid is rejected BEFORE the lock-owner is registered, so no
-// orphaned lock-owner is left in sm.lockOwners.
-func TestLockNew_BadLockSeqidDoesNotLeakState(t *testing.T) {
+// TestLockNew_BrandNewOwnerOpensSequenceAtRequestSeqid pins the initial-seqid
+// rule for a brand-new lock-owner: the sequence opens at whatever seqid the
+// request carries (the same rule nfsd applies to a stateowner it has never
+// seen), and the lock-owner is registered with no orphaned state either way.
+func TestLockNew_BrandNewOwnerOpensSequenceAtRequestSeqid(t *testing.T) {
 	lm := lock.NewManager()
 	sm := NewStateManager(90 * time.Second)
 	sm.SetLockManager(lm)
@@ -27,23 +28,41 @@ func TestLockNew_BadLockSeqidDoesNotLeakState(t *testing.T) {
 
 	ownerData := []byte("new-owner")
 
-	// Bad lock seqid for a brand-new lock-owner: only nextSeqID(0)==1 is valid.
-	_, err := sm.LockNew(context.Background(), clientID, ownerData, 99, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
-	if err == nil {
-		t.Fatal("expected ErrBadSeqid for bad lock seqid on brand-new owner")
+	// A brand-new lock-owner opens its sequence at the request's seqid.
+	res, err := sm.LockNew(context.Background(), clientID, ownerData, 99, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
+	if err != nil {
+		t.Fatalf("LockNew on brand-new owner with seqid 99 failed: %v", err)
+	}
+	if res.Denied != nil {
+		t.Fatal("expected no conflict on brand-new owner")
 	}
 
-	// The lock-owner must NOT have been registered.
+	// The lock-owner must be registered, seeded at the request's seqid.
 	loKey := makeLockOwnerKey(clientID, ownerData)
-	if _, exists := sm.lockOwners[loKey]; exists {
-		t.Error("lock owner must not be registered after bad seqid rejection")
+	owner := sm.lockOwners[loKey]
+	if owner == nil {
+		t.Fatal("lock owner must be registered after LockNew")
+	}
+	if owner.LastSeqID != 99 {
+		t.Errorf("LastSeqID = %d, want 99 (the seqid the sequence opened with)", owner.LastSeqID)
+	}
+
+	// The sequence is now strict: LOCK at 1 is not the next seqid (100) nor a
+	// replay, and must be rejected.
+	_, err = sm.LockExisting(context.Background(), &res.Stateid, 1, fileHandle, types.WRITE_LT, 200, 100, false, 0)
+	stateErr, ok := err.(*NFS4StateError)
+	if !ok {
+		t.Fatalf("LOCK at wrong seqid after the sequence opened: got %v, want NFS4StateError", err)
+	}
+	if stateErr.Status != types.NFS4ERR_BAD_SEQID {
+		t.Errorf("status = %d, want NFS4ERR_BAD_SEQID (%d)", stateErr.Status, types.NFS4ERR_BAD_SEQID)
 	}
 }
 
 // TestLockNew_BadLockSeqidDoesNotLeakLockState verifies that no LockState is
-// appended to the open-state when a bad lock seqid is rejected. A subsequent
-// valid LOCK must therefore allocate a fresh lock state (seqid starts at 1)
-// rather than reuse a leaked one.
+// appended to the open-state when a bad seqid is rejected for an EXISTING
+// lock-owner. A subsequent valid LOCK must therefore allocate a fresh lock
+// state (seqid starts at 1) rather than reuse a leaked one.
 func TestLockNew_BadLockSeqidDoesNotLeakLockState(t *testing.T) {
 	lm := lock.NewManager()
 	sm := NewStateManager(90 * time.Second)
@@ -58,27 +77,39 @@ func TestLockNew_BadLockSeqidDoesNotLeakLockState(t *testing.T) {
 
 	ownerData := []byte("new-owner")
 
-	// Bad seqid rejection.
-	if _, err := sm.LockNew(context.Background(), clientID, ownerData, 99, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, 0); err == nil {
-		t.Fatal("expected ErrBadSeqid for bad lock seqid")
-	}
-
-	if len(openState.LockStates) != 0 {
-		t.Fatalf("open state must have no lock states after bad seqid, got %d", len(openState.LockStates))
-	}
-
-	// A valid follow-up LOCK (seqid=1) must now succeed cleanly.
+	// Brand-new lock-owner opens its sequence at the request's seqid.
 	res, err := sm.LockNew(context.Background(), clientID, ownerData, 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, 0)
+	if err != nil {
+		t.Fatalf("LockNew on brand-new owner failed: %v", err)
+	}
+	if len(openState.LockStates) != 1 {
+		t.Fatalf("open state must have one lock state after LockNew, got %d", len(openState.LockStates))
+	}
+
+	// Bad seqid rejection for the now-EXISTING lock-owner: LOCK at 99 is
+	// neither the next seqid (2) nor a replay, and must be rejected before any
+	// state is inserted, so no second lock state leaks.
+	if _, err := sm.LockNew(context.Background(), clientID, ownerData, 99, &res.Stateid, 2, fileHandle, types.WRITE_LT, 200, 100, false, 0); err == nil {
+		t.Fatal("expected ErrBadSeqid for bad lock seqid on existing owner")
+	}
+
+	if len(openState.LockStates) != 1 {
+		t.Fatalf("open state must have no new lock states after bad seqid, got %d", len(openState.LockStates))
+	}
+
+	// A valid follow-up LOCK (the next seqids) must now succeed cleanly. The
+	// open stateid is unchanged by LOCK, so it is still the open's current one.
+	res2, err := sm.LockNew(context.Background(), clientID, ownerData, 2, &openState.Stateid, openSeqid+2, fileHandle, types.WRITE_LT, 300, 100, false, 0)
 	if err != nil {
 		t.Fatalf("valid LockNew after rejection failed: %v", err)
 	}
-	if res.Denied != nil {
+	if res2.Denied != nil {
 		t.Fatal("expected no conflict for valid LOCK after rejection")
 	}
-	// First successful lock state advances seqid 1 -> 2; a leaked-then-reused
-	// state would have shown a higher value.
-	if res.Stateid.Seqid != 2 {
-		t.Errorf("lock stateid seqid = %d, want 2 (fresh state)", res.Stateid.Seqid)
+	// The follow-up LOCK reuses the same lock state (second byte range): its
+	// seqid advanced 2 -> 3; a leaked-then-recreated state would reset it.
+	if res2.Stateid.Seqid != 3 {
+		t.Errorf("lock stateid seqid = %d, want 3 (same state reused)", res2.Stateid.Seqid)
 	}
 }
 

--- a/internal/adapter/nfs/v4/state/courtesy_test.go
+++ b/internal/adapter/nfs/v4/state/courtesy_test.go
@@ -127,7 +127,7 @@ func TestLock_ConflictExpiresLapsedByteRangeLock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("holder OpenFile: %v", err)
 	}
-	if _, err := sm.LockNew(context.Background(), holder, []byte("holder-lock-owner"), 0, &holderOpen.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false, 0); err != nil {
+	if _, err := sm.LockNew(context.Background(), holder, []byte("holder-lock-owner"), 0, &holderOpen.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false, holder); err != nil {
 		t.Fatalf("holder LockNew: %v", err)
 	}
 
@@ -139,7 +139,7 @@ func TestLock_ConflictExpiresLapsedByteRangeLock(t *testing.T) {
 	}
 
 	// While the lease is live the lock is enforced.
-	res, err := sm.LockNew(context.Background(), newcomer, []byte("newcomer-lock-owner"), 0, &newcomerOpen.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false, 0)
+	res, err := sm.LockNew(context.Background(), newcomer, []byte("newcomer-lock-owner"), 0, &newcomerOpen.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false, newcomer)
 	if err != nil {
 		t.Fatalf("newcomer LockNew against a live lock: %v", err)
 	}
@@ -149,7 +149,7 @@ func TestLock_ConflictExpiresLapsedByteRangeLock(t *testing.T) {
 
 	waitLeaseLapsed(t, sm, holder)
 
-	res, err = sm.LockNew(context.Background(), newcomer, []byte("newcomer-lock-owner-2"), 0, &newcomerOpen.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false, 0)
+	res, err = sm.LockNew(context.Background(), newcomer, []byte("newcomer-lock-owner-2"), 0, &newcomerOpen.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false, newcomer)
 	if err != nil {
 		t.Fatalf("newcomer LockNew after the holder's lease lapsed: %v", err)
 	}
@@ -188,88 +188,35 @@ func TestOpen_ConflictKeepsLiveShareReservation(t *testing.T) {
 	}
 }
 
-// lockAcrossClients has locker take a byte-range lock on an open owned by
-// opener, which LOCK permits: the lock-owner's client ID comes off the wire
-// and need not match the client owning the open.
-func lockAcrossClients(t *testing.T, sm *StateManager, opener, locker uint64, fh []byte, owner string) types.Stateid4 {
-	t.Helper()
-
-	open, err := sm.OpenFile(opener, []byte("open-owner-"+owner), 0, fh,
-		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
-	if err != nil {
-		t.Fatalf("OpenFile: %v", err)
-	}
-	res, err := sm.LockNew(context.Background(), locker, []byte("lock-owner-"+owner), 0, &open.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false, 0)
-	if err != nil {
-		t.Fatalf("LockNew: %v", err)
-	}
-	if res.Denied != nil {
-		t.Fatalf("LockNew: got LOCK4denied, want success")
-	}
-	return open.Stateid
-}
-
-// TestExpireClient_ReleasesLocksHeldOnAnotherClientsOpen covers the lock a
-// client holds on an open it does not own. Reaching a client's locks through
-// its own opens misses those, and a lock left in the cross-protocol lock
-// manager after its owner is gone has nothing left that could unlock it.
-func TestExpireClient_ReleasesLocksHeldOnAnotherClientsOpen(t *testing.T) {
+// TestExpireClient_ReleasesLocksHeldOnItsOwnOpen covers the release sweep
+// reaching the cross-protocol lock manager: a lock left there after its
+// owner's client is released has nothing left that could unlock it.
+func TestExpireClient_ReleasesLocksHeldOnItsOwnOpen(t *testing.T) {
 	sm := NewStateManager(courtesyLease)
 	defer sm.Shutdown()
 	lm := lock.NewManager()
 	sm.SetLockManager(lm)
 
 	fh := []byte("cross-client-lock-fh")
-	opener := courtesyClient(t, sm, "cross-opener")
-	locker := courtesyClient(t, sm, "cross-locker")
-	lockAcrossClients(t, sm, opener, locker, fh, "a")
+	holder := courtesyClient(t, sm, "cross-holder")
+	holderOpen, err := sm.OpenFile(holder, []byte("holder-owner"), 0, fh,
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
+	if err != nil {
+		t.Fatalf("holder OpenFile: %v", err)
+	}
+	if _, err := sm.LockNew(context.Background(), holder, []byte("holder-lock-owner"), 0, &holderOpen.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false, holder); err != nil {
+		t.Fatalf("holder LockNew: %v", err)
+	}
 
 	if got := len(lm.ListUnifiedLocks(string(fh))); got != 1 {
 		t.Fatalf("locks held before expiry = %d, want 1", got)
 	}
 
 	sm.mu.Lock()
-	sm.releaseClientStateLocked(locker)
+	sm.releaseClientStateLocked(holder)
 	sm.mu.Unlock()
 
 	if got := len(lm.ListUnifiedLocks(string(fh))); got != 0 {
 		t.Errorf("locks still held after the lock-owner's client was released = %d, want 0", got)
-	}
-}
-
-// TestLock_ConflictExpiresLapsedCrossClientLock is the same asymmetry on the
-// conflict side: the client whose lease lapsed holds the lock but not the
-// open, so looking only at open-owners leaves its courtesy lock enforced.
-func TestLock_ConflictExpiresLapsedCrossClientLock(t *testing.T) {
-	sm := NewStateManager(courtesyLease)
-	defer sm.Shutdown()
-	sm.SetLockManager(lock.NewManager())
-
-	fh := []byte("cross-client-conflict-fh")
-
-	opener := courtesyClient(t, sm, "conflict-opener")
-	locker := courtesyClient(t, sm, "conflict-locker")
-	lockAcrossClients(t, sm, opener, locker, fh, "b")
-
-	waitLeaseLapsed(t, sm, locker)
-
-	// Only the lock-owner's client is allowed to lapse. If the open's owner
-	// lapses too, the sweep reaches the lock through that client's open and
-	// the test passes whether or not lock-owners are considered at all.
-	renewLease(t, sm, opener)
-
-	newcomer := courtesyClient(t, sm, "conflict-newcomer")
-	newcomerOpen, err := sm.OpenFile(newcomer, []byte("newcomer-owner"), 0, fh,
-		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
-	if err != nil {
-		t.Fatalf("newcomer OpenFile: %v", err)
-	}
-
-	res, err := sm.LockNew(context.Background(), newcomer, []byte("newcomer-lock-owner"), 0, &newcomerOpen.Stateid, 0, fh, types.WRITE_LT, 0, ^uint64(0), false, 0)
-	if err != nil {
-		t.Fatalf("newcomer LockNew: %v", err)
-	}
-	if res.Denied != nil {
-		t.Errorf("LOCK against a lapsed lock-owner's lock on another client's open: got LOCK4denied, want success")
 	}
 }

--- a/internal/adapter/nfs/v4/state/delegation_test.go
+++ b/internal/adapter/nfs/v4/state/delegation_test.go
@@ -1621,7 +1621,7 @@ func TestGrantDelegation_DeniedWhileForeignByteRangeLockHeld(t *testing.T) {
 	}
 
 	// The client, undelegated, sends the LOCK — which the NLM lock denies.
-	res, err := sm.LockNew(context.Background(), clientID, []byte("nfs-owner"), 1, openStateid, openSeqid, fileHandle, types.WRITE_LT, 0, 100, false, 0)
+	res, err := sm.LockNew(context.Background(), clientID, []byte("nfs-owner"), 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, clientID)
 	if err != nil {
 		t.Fatalf("LockNew returned error: %v", err)
 	}

--- a/internal/adapter/nfs/v4/state/lock_manager_unlocked_test.go
+++ b/internal/adapter/nfs/v4/state/lock_manager_unlocked_test.go
@@ -104,7 +104,7 @@ func TestLockNew_LockManagerCalledWithoutStateMutex(t *testing.T) {
 
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
-	res, err := sm.LockNew(context.Background(), clientID, []byte("owner-a"), 1, openStateid, openSeqid, fileHandle, types.WRITE_LT, 0, 100, false, 0)
+	res, err := sm.LockNew(context.Background(), clientID, []byte("owner-a"), 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, clientID)
 	if err == nil {
 		t.Fatalf("LOCK committed against state freed while the lock manager was called: %+v", res)
 	}
@@ -128,7 +128,7 @@ func TestUnlockFile_LockManagerCalledWithoutStateMutex(t *testing.T) {
 
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
 
-	locked, err := sm.LockNew(context.Background(), clientID, []byte("owner-a"), 1, openStateid, openSeqid, fileHandle, types.WRITE_LT, 0, 100, false, 0)
+	locked, err := sm.LockNew(context.Background(), clientID, []byte("owner-a"), 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, clientID)
 	if err != nil || locked.Denied != nil {
 		t.Fatalf("setup LOCK failed: err=%v denied=%v", err, locked)
 	}

--- a/internal/adapter/nfs/v4/state/lock_resolver_test.go
+++ b/internal/adapter/nfs/v4/state/lock_resolver_test.go
@@ -23,7 +23,7 @@ func TestLockManagerResolver_FixesMissingManager(t *testing.T) {
 	// No manager, no resolver: LOCK must fail (reproduces the EIO bug).
 	smBroken := NewStateManager(90 * time.Second)
 	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, smBroken)
-	if _, err := smBroken.LockNew(context.Background(), clientID, []byte("owner-a"), 1, openStateid, openSeqid, fileHandle, types.WRITE_LT, 0, 100, false, 0); err == nil {
+	if _, err := smBroken.LockNew(context.Background(), clientID, []byte("owner-a"), 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, clientID); err == nil {
 		t.Fatal("expected LOCK to fail when no lock manager is configured")
 	}
 
@@ -32,7 +32,7 @@ func TestLockManagerResolver_FixesMissingManager(t *testing.T) {
 	sm := NewStateManager(90 * time.Second)
 	sm.SetLockManagerResolver(func(_ []byte) lock.LockManager { return lm })
 	clientID, fileHandle, openStateid, openSeqid = setupClientAndOpenState(t, sm)
-	if _, err := sm.LockNew(context.Background(), clientID, []byte("owner-a"), 1, openStateid, openSeqid, fileHandle, types.WRITE_LT, 0, 100, false, 0); err != nil {
+	if _, err := sm.LockNew(context.Background(), clientID, []byte("owner-a"), 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 100, false, clientID); err != nil {
 		t.Fatalf("LOCK with resolved lock manager failed: %v", err)
 	}
 	if locks := lm.ListUnifiedLocks(string(fileHandle)); len(locks) != 1 {
@@ -75,7 +75,7 @@ func TestLockManagerResolver_DetectsCrossProtocolConflict(t *testing.T) {
 	}
 
 	// NFSv4 LOCK for the same overlapping range must also be denied (not granted).
-	res, err := sm.LockNew(context.Background(), clientID, []byte("nfs-owner"), 1, openStateid, openSeqid, fileHandle, types.WRITE_LT, 50, 100, false, 0)
+	res, err := sm.LockNew(context.Background(), clientID, []byte("nfs-owner"), 1, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 50, 100, false, clientID)
 	if err != nil {
 		t.Fatalf("LockNew returned error: %v", err)
 	}

--- a/internal/adapter/nfs/v4/state/lockowner.go
+++ b/internal/adapter/nfs/v4/state/lockowner.go
@@ -415,14 +415,12 @@ func (sm *StateManager) LockNew(
 				}
 			}
 		}
-		// A brand-new lock-owner opens its sequence at whatever seqid the
-		// request carries (the same initial-seqid rule nfsd applies to a
-		// stateowner it has never seen; the OPEN path opens open-owner sequences
-		// the same way). LastSeqID is seeded from the request on success below.
-	} else if openSeqIsReplay {
-		// Open seqid replayed but the lock-owner is brand new / not yet
-		// seqid-tracked: nothing consistent to replay.
-		return nil, ErrBadSeqid
+		// A brand-new lock-owner + a replayed open seqid is an inconsistent
+		// retransmit, with or without the v4.1 skip: the replayed OPEN's reply
+		// predates any lock state, so there is nothing consistent to replay.
+		if openSeqIsReplay && !ownerExists {
+			return nil, ErrBadSeqid
+		}
 	}
 
 	// The open stateid must name that open's current seqid, compared after both

--- a/internal/adapter/nfs/v4/state/lockowner.go
+++ b/internal/adapter/nfs/v4/state/lockowner.go
@@ -366,9 +366,13 @@ func (sm *StateManager) LockNew(
 	// both. The authoritative cached reply lives on the lock-owner (it is the
 	// LOCK reply), so on an open-owner replay we do not fail here; we resolve
 	// the lock-owner below (step 4) and return its cached result.
-	// seqid=0 is the v4.1 bypass convention: slot table provides replay protection
+	// The per-owner seqid is validated like any other value on a v4.0 client;
+	// only a v4.1 session client skips owner sequencing (the slot table provides
+	// replay protection there, and the handler zeroes the seqid it sends).
+	// Derived from the caller client ID this op already carries.
+	skipOwnerSeqid := sm.v41ClientLocked(callerClientID) != nil
 	openSeqIsReplay := false
-	if openSeqid != 0 {
+	if !skipOwnerSeqid {
 		validation := openState.Owner.ValidateSeqID(openSeqid)
 		switch validation {
 		case SeqIDBad:
@@ -389,8 +393,7 @@ func (sm *StateManager) LockNew(
 	lockOwner, ownerExists := sm.lockOwners[loKey]
 
 	// 4. Validate lock seqid on lock-owner BEFORE any allocation.
-	// seqid=0 is the v4.1 bypass convention: slot table provides replay protection
-	if lockSeqid != 0 {
+	if !skipOwnerSeqid {
 		if ownerExists {
 			lockValidation := lockOwner.ValidateSeqID(lockSeqid)
 			switch lockValidation {
@@ -411,14 +414,11 @@ func (sm *StateManager) LockNew(
 					return nil, ErrBadSeqid
 				}
 			}
-		} else {
-			// Brand-new lock-owner: the only valid lock seqid is nextSeqID(0)
-			// (== 1) per RFC 7530 Section 9.1.4. Reject anything else before
-			// allocating, so a bad seqid leaves no orphaned state behind.
-			if lockSeqid != nextSeqID(0) {
-				return nil, ErrBadSeqid
-			}
 		}
+		// A brand-new lock-owner opens its sequence at whatever seqid the
+		// request carries (the same initial-seqid rule nfsd applies to a
+		// stateowner it has never seen; the OPEN path opens open-owner sequences
+		// the same way). LastSeqID is seeded from the request on success below.
 	} else if openSeqIsReplay {
 		// Open seqid replayed but the lock-owner is brand new / not yet
 		// seqid-tracked: nothing consistent to replay.
@@ -569,8 +569,11 @@ func (sm *StateManager) LockExisting(
 	// now one behind lockState.Stateid.Seqid; the strict stateid-seqid check
 	// below would otherwise reject it as NFS4ERR_OLD_STATEID before the replay
 	// is detected (RFC 7530 §9.1.7).
-	// seqid=0 is the v4.1 bypass convention: slot table provides replay protection
-	if lockSeqid != 0 {
+	// The per-owner seqid is validated like any other value on a v4.0 client;
+	// only a v4.1 session client skips owner sequencing (the slot table provides
+	// replay protection there, and the handler zeroes the seqid it sends).
+	// Derived from the caller client ID this op already carries.
+	if sm.v41ClientLocked(callerClientID) == nil {
 		lockValidation := lockOwner.ValidateSeqID(lockSeqid)
 		switch lockValidation {
 		case SeqIDBad:
@@ -968,8 +971,11 @@ func (sm *StateManager) UnlockFile(
 	// is now one behind lockState.Stateid.Seqid. The strict stateid-seqid check
 	// below would reject that as NFS4ERR_OLD_STATEID, so the lock-owner replay
 	// must be detected before it (RFC 7530 §9.1.7: exactly-once wins).
-	// seqid=0 is the v4.1 bypass convention: slot table provides replay protection
-	if seqid != 0 {
+	// The per-owner seqid is validated like any other value on a v4.0 client;
+	// only a v4.1 session client skips owner sequencing (the slot table provides
+	// replay protection there, and the handler zeroes the seqid it sends).
+	// Derived from the caller client ID this op already carries.
+	if sm.v41ClientLocked(callerClientID) == nil {
 		validation := lockOwner.ValidateSeqID(seqid)
 		switch validation {
 		case SeqIDBad:

--- a/internal/adapter/nfs/v4/state/lockowner_seqid_test.go
+++ b/internal/adapter/nfs/v4/state/lockowner_seqid_test.go
@@ -1,0 +1,130 @@
+package state
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/marmos91/dittofs/internal/adapter/nfs/v4/types"
+	"github.com/marmos91/dittofs/pkg/metadata/lock"
+)
+
+// The lock-owner seqid of zero must be validated like any other value on a
+// v4.0 client. The v4.1 session path is what zeroes per-owner sequencing (the
+// slot table provides replay protection there), and the handler threads that
+// intent into the state manager per op; a v4.0 client's own zero is an
+// ordinary seqid. pynfs LKU6b exercises exactly this: LOCK (new lock-owner,
+// lock seqid 0), LOCK (lock seqid 1), then LOCKU with lock seqid 0 — the
+// owner's sequence has reached 1, so the LOCKU is neither the next seqid nor a
+// replay and NFS4ERR_BAD_SEQID is the answer.
+
+// TestUnlockFile_ZeroSeqidOnV40IsRejected pins that LOCKU with seqid 0 on an
+// existing lock-owner (no skip requested, i.e. the v4.0 path) is rejected
+// NFS4ERR_BAD_SEQID rather than succeeding through the bypass.
+func TestUnlockFile_ZeroSeqidOnV40IsRejected(t *testing.T) {
+	lm := lock.NewManager()
+	sm := NewStateManager(90 * time.Second)
+	sm.SetLockManager(lm)
+	defer sm.Shutdown()
+
+	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
+
+	// LOCK #1 via open_to_lock_owner: brand-new lock-owner opens its sequence
+	// at the seqid the request carries (0 here, pynfs's own first LOCK does).
+	lockRes, err := sm.LockNew(context.Background(), clientID, []byte("lku6b-owner"), 0, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 50, false, 0)
+	if err != nil {
+		t.Fatalf("LockNew with lock seqid 0 (brand-new owner) failed: %v", err)
+	}
+
+	// LOCK #2 via exist_lock_owner: advances the lock-owner sequence to 1 and
+	// the lock stateid to 2; the retransmit must carry the CURRENT stateid.
+	res2, err := sm.LockExisting(context.Background(), &lockRes.Stateid, 1, fileHandle, types.WRITE_LT, 100, 50, false, 0)
+	if err != nil {
+		t.Fatalf("LockExisting failed: %v", err)
+	}
+
+	// LOCKU with lock seqid 0 against the CURRENT lock stateid: the owner's
+	// last seqid is 1, so 0 is neither the next seqid (2) nor a replay. On the
+	// v4.0 path (no skip) this must be rejected NFS4ERR_BAD_SEQID; the old
+	// seqid!=0 bypass let it succeed (pynfs LKU6b).
+	_, err = sm.UnlockFile(&res2.Stateid, 0, types.WRITE_LT, 0, 50, 0)
+	stateErr, ok := err.(*NFS4StateError)
+	if !ok {
+		t.Fatalf("LOCKU with lock seqid 0 on v4.0: got %v, want NFS4StateError", err)
+	}
+	if stateErr.Status != types.NFS4ERR_BAD_SEQID {
+		t.Errorf("status = %d, want NFS4ERR_BAD_SEQID (%d)", stateErr.Status, types.NFS4ERR_BAD_SEQID)
+	}
+}
+
+// TestUnlockFile_ZeroSeqidWithSkipStillBypasses pins that the v4.1 skip — the
+// per-op flag the handler threads in — still bypasses owner sequencing for
+// seqid 0 exactly as today: no validation, the LOCKU succeeds.
+func TestUnlockFile_ZeroSeqidWithSkipStillBypasses(t *testing.T) {
+	lm := lock.NewManager()
+	sm := NewStateManager(90 * time.Second)
+	sm.SetLockManager(lm)
+	defer sm.Shutdown()
+
+	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
+
+	lockRes, err := sm.LockNew(context.Background(), clientID, []byte("v41-skip-owner"), 0, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 50, false, 0)
+	if err != nil {
+		t.Fatalf("LockNew failed: %v", err)
+	}
+	res2, err := sm.LockExisting(context.Background(), &lockRes.Stateid, 1, fileHandle, types.WRITE_LT, 100, 50, false, 0)
+	if err != nil {
+		t.Fatalf("LockExisting failed: %v", err)
+	}
+
+	// With the skip requested (the v4.1 session path), seqid 0 bypasses owner
+	// sequencing and the LOCKU succeeds.
+	if _, err := sm.UnlockFile(&res2.Stateid, 0, types.WRITE_LT, 0, 50, 0); err != nil {
+		t.Fatalf("LOCKU with lock seqid 0 under the v4.1 skip must succeed: %v", err)
+	}
+}
+
+// TestLockNew_ZeroSeqidOpensSequence pins nfsd's initial-seqid rule for a
+// brand-new lock-owner: the sequence starts at whatever seqid the client opens
+// it with, so LOCK with lock seqid 0 succeeds and the owner's LastSeqID is 0.
+// A later LOCK must then expect 1 (validated) and reject anything else.
+func TestLockNew_ZeroSeqidOpensSequence(t *testing.T) {
+	lm := lock.NewManager()
+	sm := NewStateManager(90 * time.Second)
+	sm.SetLockManager(lm)
+	defer sm.Shutdown()
+
+	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
+
+	lockRes, err := sm.LockNew(context.Background(), clientID, []byte("seed-owner"), 0, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 50, false, 0)
+	if err != nil {
+		t.Fatalf("LockNew with lock seqid 0 (brand-new owner) failed: %v", err)
+	}
+
+	loKey := makeLockOwnerKey(clientID, []byte("seed-owner"))
+	owner := sm.lockOwners[loKey]
+	if owner == nil {
+		t.Fatal("lock owner not registered")
+	}
+	if owner.LastSeqID != 0 {
+		t.Errorf("LastSeqID = %d, want 0 (the seqid the sequence opened with)", owner.LastSeqID)
+	}
+
+	// The sequence is now strict: LOCK at 1 (the next seqid, on the current
+	// stateid) succeeds...
+	res2, err := sm.LockExisting(context.Background(), &lockRes.Stateid, 1, fileHandle, types.WRITE_LT, 100, 50, false, 0)
+	if err != nil {
+		t.Fatalf("LockExisting at seqid 1 failed: %v", err)
+	}
+	// ...and LOCK at 0 again against the CURRENT stateid is a bad seqid: the
+	// owner's sequence has reached 1, so 0 is neither the next seqid (2) nor a
+	// replay of 1.
+	_, err = sm.LockExisting(context.Background(), &res2.Stateid, 0, fileHandle, types.WRITE_LT, 150, 50, false, 0)
+	stateErr, ok := err.(*NFS4StateError)
+	if !ok {
+		t.Fatalf("LOCK at seqid 0 after the sequence advanced: got %v, want NFS4StateError", err)
+	}
+	if stateErr.Status != types.NFS4ERR_BAD_SEQID {
+		t.Errorf("status = %d, want NFS4ERR_BAD_SEQID (%d)", stateErr.Status, types.NFS4ERR_BAD_SEQID)
+	}
+}

--- a/internal/adapter/nfs/v4/state/lockowner_seqid_test.go
+++ b/internal/adapter/nfs/v4/state/lockowner_seqid_test.go
@@ -57,29 +57,42 @@ func TestUnlockFile_ZeroSeqidOnV40IsRejected(t *testing.T) {
 	}
 }
 
-// TestUnlockFile_ZeroSeqidWithSkipStillBypasses pins that the v4.1 skip — the
-// per-op flag the handler threads in — still bypasses owner sequencing for
-// seqid 0 exactly as today: no validation, the LOCKU succeeds.
+// TestUnlockFile_ZeroSeqidWithSkipStillBypasses pins that the v4.1 skip — a
+// session client (EXCHANGE_ID flow, MinorVersion 1) as the op's caller — still
+// bypasses owner sequencing for seqid 0 exactly as today: no validation, the
+// LOCKU succeeds.
 func TestUnlockFile_ZeroSeqidWithSkipStillBypasses(t *testing.T) {
 	lm := lock.NewManager()
 	sm := NewStateManager(90 * time.Second)
 	sm.SetLockManager(lm)
 	defer sm.Shutdown()
 
-	clientID, fileHandle, openStateid, openSeqid := setupClientAndOpenState(t, sm)
+	// The open state must belong to the v4.1 session client: the LOCKU caller
+	// client ID is both the bearer check and the skip derivation seam.
+	v41ClientID := registerConfirmedV41Client(t, sm, "v41-skip-owner")
+	fileHandle := []byte("/export:test-file-001")
+	openRes, err := sm.OpenFile(v41ClientID, []byte("v41-open-owner"), 0, fileHandle,
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
+	if err != nil {
+		t.Fatalf("OpenFile failed: %v", err)
+	}
+	if err := sm.ConfirmOpenV41(&openRes.Stateid, v41ClientID); err != nil {
+		t.Fatalf("ConfirmOpenV41 failed: %v", err)
+	}
 
-	lockRes, err := sm.LockNew(context.Background(), clientID, []byte("v41-skip-owner"), 0, openStateid, openSeqid+1, fileHandle, types.WRITE_LT, 0, 50, false, 0)
+	// LOCK #1 via open_to_lock_owner with the session client as caller.
+	lockRes, err := sm.LockNew(context.Background(), v41ClientID, []byte("v41-lock-owner"), 0, &openRes.Stateid, 1, fileHandle, types.WRITE_LT, 0, 50, false, v41ClientID)
 	if err != nil {
 		t.Fatalf("LockNew failed: %v", err)
 	}
-	res2, err := sm.LockExisting(context.Background(), &lockRes.Stateid, 1, fileHandle, types.WRITE_LT, 100, 50, false, 0)
+	res2, err := sm.LockExisting(context.Background(), &lockRes.Stateid, 1, fileHandle, types.WRITE_LT, 100, 50, false, v41ClientID)
 	if err != nil {
 		t.Fatalf("LockExisting failed: %v", err)
 	}
 
-	// With the skip requested (the v4.1 session path), seqid 0 bypasses owner
-	// sequencing and the LOCKU succeeds.
-	if _, err := sm.UnlockFile(&res2.Stateid, 0, types.WRITE_LT, 0, 50, 0); err != nil {
+	// With the v4.1 session client as caller, seqid 0 bypasses owner sequencing
+	// and the LOCKU succeeds.
+	if _, err := sm.UnlockFile(&res2.Stateid, 0, types.WRITE_LT, 0, 50, v41ClientID); err != nil {
 		t.Fatalf("LOCKU with lock seqid 0 under the v4.1 skip must succeed: %v", err)
 	}
 }

--- a/internal/adapter/nfs/v4/state/openowner.go
+++ b/internal/adapter/nfs/v4/state/openowner.go
@@ -462,10 +462,16 @@ func (sm *StateManager) OpenFile(
 	ownerKey := makeOwnerKey(clientID, ownerData)
 	owner, ownerExists := sm.openOwners[ownerKey]
 
+	// The per-owner seqid is validated like any other value on a v4.0 client;
+	// only a v4.1 session client skips owner sequencing (the slot table provides
+	// replay protection there, and the handler zeroes the seqid it sends).
+	// Derived from the client ID this op already carries: the effective client
+	// names a registered record whose MinorVersion discriminates the flows.
+	skipOwnerSeqid := sm.v41ClientLocked(clientID) != nil
+
 	if ownerExists {
 		// Existing owner: validate seqid
-		// seqid=0 is the v4.1 bypass convention: slot table provides replay protection
-		if seqid != 0 {
+		if !skipOwnerSeqid {
 			validation := owner.ValidateSeqID(seqid)
 			switch validation {
 			case SeqIDReplay:
@@ -835,9 +841,12 @@ func (sm *StateManager) ConfirmOpen(stateid *types.Stateid4, seqid uint32, calle
 	// its seqid (RFC 7530 Section 9.1.7).
 	defer func() { owner.consumeSeqidOnError(seqid, err) }()
 
-	// Validate seqid on the owner
-	// seqid=0 is the v4.1 bypass convention: slot table provides replay protection
-	if seqid != 0 {
+	// Validate seqid on the owner. The per-owner seqid is validated like any
+	// other value on a v4.0 client; only a v4.1 session client skips owner
+	// sequencing (the slot table provides replay protection there, and the
+	// handler zeroes the seqid it sends). Derived from the caller client ID
+	// this op already carries.
+	if sm.v41ClientLocked(callerClientID) == nil {
 		validation := owner.ValidateSeqID(seqid)
 		switch validation {
 		case SeqIDReplay:
@@ -972,9 +981,12 @@ func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32, callerC
 	// every later CLOSE and LOCK for this owner with NFS4ERR_BAD_SEQID.
 	defer func() { owner.consumeSeqidOnError(seqid, err) }()
 
-	// Validate seqid on the owner
-	// seqid=0 is the v4.1 bypass convention: slot table provides replay protection
-	if seqid != 0 {
+	// Validate seqid on the owner. The per-owner seqid is validated like any
+	// other value on a v4.0 client; only a v4.1 session client skips owner
+	// sequencing (the slot table provides replay protection there, and the
+	// handler zeroes the seqid it sends). Derived from the caller client ID
+	// this op already carries.
+	if sm.v41ClientLocked(callerClientID) == nil {
 		validation := owner.ValidateSeqID(seqid)
 		switch validation {
 		case SeqIDReplay:
@@ -1102,9 +1114,12 @@ func (sm *StateManager) DowngradeOpen(stateid *types.Stateid4, seqid uint32, new
 	// its seqid (RFC 7530 Section 9.1.7), the NFS4ERR_INVAL rejections included.
 	defer func() { owner.consumeSeqidOnError(seqid, err) }()
 
-	// Validate seqid on the owner
-	// seqid=0 is the v4.1 bypass convention: slot table provides replay protection
-	if seqid != 0 {
+	// Validate seqid on the owner. The per-owner seqid is validated like any
+	// other value on a v4.0 client; only a v4.1 session client skips owner
+	// sequencing (the slot table provides replay protection there, and the
+	// handler zeroes the seqid it sends). Derived from the caller client ID
+	// this op already carries.
+	if sm.v41ClientLocked(callerClientID) == nil {
 		validation := owner.ValidateSeqID(seqid)
 		switch validation {
 		case SeqIDReplay:

--- a/internal/adapter/nfs/v4/state/openowner.go
+++ b/internal/adapter/nfs/v4/state/openowner.go
@@ -957,7 +957,7 @@ func (sm *StateManager) CloseFile(stateid *types.Stateid4, seqid uint32, callerC
 		// (RFC 7530 §9.1.7) rather than returning NFS4ERR_BAD_STATEID.
 		// The cached reply belongs to the owner that sent the original CLOSE, so
 		// it is only replayed to that owner's client; see checkStateidOwner.
-		if owner, ok := sm.closedOwnerByOther[stateid.Other]; ok && seqid != 0 &&
+		if owner, ok := sm.closedOwnerByOther[stateid.Other]; ok &&
 			checkStateidOwner(callerClientID, owner.ClientID) == nil {
 			if owner.ValidateSeqID(seqid) == SeqIDReplay && owner.LastResult != nil {
 				return nil, &ReplayError{Status: owner.LastResult.Status, Data: owner.LastResult.Data}

--- a/internal/adapter/nfs/v4/state/session_test.go
+++ b/internal/adapter/nfs/v4/state/session_test.go
@@ -1244,9 +1244,10 @@ func TestReaper_ExpiredLeaseReleasesOpenState(t *testing.T) {
 		t.Fatalf("OpenFile error: %v", err)
 	}
 
-	// A byte-range lock on top of the open: seqid 0 is the v4.1 bypass, the
-	// slot table provides the replay protection the seqids give v4.0.
-	if _, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner-a"), 0, &open.Stateid, 0, fh, types.WRITE_LT, 0, 100, false, 0); err != nil {
+	// A byte-range lock on top of the open: seqid 0 with the v4.1 session
+	// client as caller is the skip path, the slot table provides the replay
+	// protection the seqids give v4.0.
+	if _, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner-a"), 0, &open.Stateid, 0, fh, types.WRITE_LT, 0, 100, false, clientID); err != nil {
 		t.Fatalf("LockNew error: %v", err)
 	}
 	if got := len(lm.ListUnifiedLocks(string(fh))); got != 1 {

--- a/internal/adapter/nfs/v4/state/stateid_authz_test.go
+++ b/internal/adapter/nfs/v4/state/stateid_authz_test.go
@@ -198,7 +198,8 @@ func TestFreeStateid_CrossClientDelegation(t *testing.T) {
 }
 
 // TestLockExisting_V41Seqid0 is the negative control for the LockExisting
-// stateid seqid=0 bypass (manager.go). A v4.1 client sends stateid seqid=0;
+// stateid seqid=0 bypass. A v4.1 session client (the op's caller client ID
+// names a MinorVersion-1 record) sends stateid seqid=0 with owner seqid=0;
 // before the fix `0 < lockState.Stateid.Seqid` always returned
 // NFS4ERR_OLD_STATEID, making every additional LOCK fail.
 func TestLockExisting_V41Seqid0(t *testing.T) {
@@ -207,14 +208,15 @@ func TestLockExisting_V41Seqid0(t *testing.T) {
 	sm.SetLockManager(lm)
 	defer sm.Shutdown()
 
+	v41ClientID := registerConfirmedV41Client(t, sm, "lockexisting-seqid0")
 	fh := []byte("fh-lockexisting-seqid0")
-	lockStateid := newLockedFile(t, sm, 0, fh)
+	lockStateid := newLockedFileV41(t, sm, v41ClientID, fh)
 
 	// v4.1 client: stateid seqid=0, owner seqid=0 (slot table provides replay
 	// protection). Extend the lock with a second byte range via LockExisting.
 	v41Stateid := lockStateid
 	v41Stateid.Seqid = 0
-	result, err := sm.LockExisting(context.Background(), &v41Stateid, 0, fh, types.WRITE_LT, 200, 100, false, 0)
+	result, err := sm.LockExisting(context.Background(), &v41Stateid, 0, fh, types.WRITE_LT, 200, 100, false, v41ClientID)
 	if err != nil {
 		t.Fatalf("LockExisting with v4.1 stateid seqid=0: %v", err)
 	}
@@ -234,22 +236,47 @@ func TestUnlockFile_V41Seqid0(t *testing.T) {
 	defer sm.Shutdown()
 
 	fh := []byte("fh-locku-seqid0")
-	lockStateid := newLockedFile(t, sm, 0, fh)
+	v41ClientID := registerConfirmedV41Client(t, sm, "locku-seqid0")
+	lockStateid := newLockedFileV41(t, sm, v41ClientID, fh)
 
 	// Advance lockState.Stateid.Seqid to >=2 via a successful LockExisting so
 	// the LOCKU below is unambiguously after a seqid increment.
 	v41Lock := lockStateid
 	v41Lock.Seqid = 0
-	if _, err := sm.LockExisting(context.Background(), &v41Lock, 0, fh, types.WRITE_LT, 200, 100, false, 0); err != nil {
+	if _, err := sm.LockExisting(context.Background(), &v41Lock, 0, fh, types.WRITE_LT, 200, 100, false, v41ClientID); err != nil {
 		t.Fatalf("LockExisting setup: %v", err)
 	}
 
 	// v4.1 LOCKU: stateid seqid=0, owner seqid=0.
 	unlockStateid := lockStateid
 	unlockStateid.Seqid = 0
-	if _, err := sm.UnlockFile(&unlockStateid, 0, types.WRITE_LT, 0, 100, 0); err != nil {
+	if _, err := sm.UnlockFile(&unlockStateid, 0, types.WRITE_LT, 0, 100, v41ClientID); err != nil {
 		t.Fatalf("UnlockFile with v4.1 stateid seqid=0: %v", err)
 	}
+}
+
+// newLockedFileV41 creates a confirmed open and a lock for the v4.1 session
+// client, the v4.1 counterpart of newLockedFile: the open is confirmed via the
+// session-client path and the LOCK caller is the session client itself, so the
+// per-owner sequencing skip derives from it.
+func newLockedFileV41(t *testing.T, sm *StateManager, clientID uint64, fh []byte) types.Stateid4 {
+	t.Helper()
+	openResult, err := sm.OpenFile(clientID, []byte("open-owner"), 1, fh,
+		types.OPEN4_SHARE_ACCESS_BOTH, types.OPEN4_SHARE_DENY_NONE, types.CLAIM_NULL)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	if err := sm.ConfirmOpenV41(&openResult.Stateid, clientID); err != nil {
+		t.Fatalf("ConfirmOpenV41: %v", err)
+	}
+	lockResult, err := sm.LockNew(context.Background(), clientID, []byte("lock-owner"), 0, &openResult.Stateid, 2, fh, types.WRITE_LT, 0, 100, false, clientID)
+	if err != nil {
+		t.Fatalf("LockNew: %v", err)
+	}
+	if lockResult.Denied != nil {
+		t.Fatalf("LockNew unexpectedly denied")
+	}
+	return lockResult.Stateid
 }
 
 // TestExchangeID_Case2_PrincipalMismatch is the negative control for the

--- a/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
+++ b/test/nfs-conformance/pynfs/KNOWN_FAILURES_V40.md
@@ -54,6 +54,5 @@ flake worth re-running.
 
 | Test Name | Category | Reason | Issue |
 |-----------|----------|--------|-------|
-| LKU6b | bug | seqid=0 means "v4.1, skip owner sequencing", but a v4.0 client may send 0 | #2483 |
 | WRT18 | feature | write-session freeze deliberately holds ctime, so change cannot advance | - |
 | RPLY8 | suite | knfsd fails this too — replay of a waiting LOCKU | - |


### PR DESCRIPTION
## Summary

A v4.0 client's own lock-owner seqid of `0` was skipped by owner-seqid validation entirely, so a LOCKU carrying a stale lock seqid of `0` succeeded instead of returning `NFS4ERR_BAD_SEQID` (pynfs `LKU6b`).

Only a v4.1 session client skips per-owner sequencing — the slot table provides replay protection there. The skip is now derived inside each seqid-bearing state op from the caller client ID the op already carries, via the client record's `MinorVersion`: a v4.1 session client bypasses owner sequencing exactly as before; a v4.0 client's `0` is validated like any other value.

A brand-new lock-owner now opens its sequence at the seqid the request carries (the same initial-seqid rule nfsd applies to a stateowner it has never seen, and the same rule the OPEN path already applies to open-owners), so a v4.0 client's first LOCK with lock seqid `0` still succeeds.

## Changes

- `internal/adapter/nfs/v4/state/openowner.go`, `lockowner.go`: replace the `seqid != 0` guards on the seven seqid-bearing ops (OpenFile, ConfirmOpen, CloseFile, DowngradeOpen, LockNew, LockExisting, UnlockFile) with a v4.1-session-client derivation; LockNew drops its stricter-than-nfsd brand-new-owner `nextSeqID(0)` rejection
- `internal/adapter/nfs/v4/state/lockowner_seqid_test.go`: red-check pins — v4.0 zero rejected `NFS4ERR_BAD_SEQID`, v4.1 session-client skip still bypasses, brand-new owner opens the sequence at the request's seqid
- updated the v4.1 negative-control tests to pass a real v4.1 session client as the op's caller (the seam the derivation reads)
- `KNOWN_FAILURES_V40.md`: walked the LKU6b row out

## Validation

- `go test -race ./internal/adapter/nfs/v4/...` green (state suite 28s)
- pynfs LKU6b literal `: PASS` verdict on memory and postgres-s3 `pynfs.log` artifacts

Closes #2483