### PR TITLE
test: lane H leftovers the #2535 squash left on its branch

### DIFF
--- a/cmd/dfs/commands/start_test.go
+++ b/cmd/dfs/commands/start_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/marmos91/dittofs/internal/logger"
 	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/journal"
 )
 
 // TestStart_FutureFormatExitCode asserts the boot-guard contract:
@@ -62,7 +63,10 @@ func TestStart_FutureFormatExitCode(t *testing.T) {
 
 	// Synthesize the exact wrap shape runtime.LoadSharesFromStore
 	// produces: `share %q: %w` around the fs.NewWithOptions output, which
-	// is itself `share %s: %w` around block.ErrFutureFormat.
+	// is itself `share %s: %w` around block.ErrFutureFormat. The second
+	// loadErr covers the journal-local sentinel branch: the OR must catch
+	// both sentinels, so a regression flipping it to block-only cannot
+	// silently downgrade a future journal directory to warn-and-skip.
 	sharePath := filepath.Join(t.TempDir(), "share-A")
 	innerErr := fmt.Errorf("share %s: %w", sharePath, block.ErrFutureFormat)
 	loadErr := fmt.Errorf("share %q: %w", "share-A", innerErr)
@@ -70,6 +74,11 @@ func TestStart_FutureFormatExitCode(t *testing.T) {
 	stop := handleLoadSharesError(loadErr, w)
 	if !stop {
 		t.Fatalf("handleLoadSharesError returned stop=false on future-format error")
+	}
+	journalErr := fmt.Errorf("share %q: %w", "share-J",
+		fmt.Errorf("share %s: %w", filepath.Join(t.TempDir(), "share-J"), journal.ErrFutureFormat))
+	if !handleLoadSharesError(journalErr, w) {
+		t.Fatalf("handleLoadSharesError returned stop=false on journal sentinel")
 	}
 
 	// Close the writer so the reader sees EOF, then drain.

--- a/pkg/block/journal/doc.go
+++ b/pkg/block/journal/doc.go
@@ -3,11 +3,12 @@
 // between dirty client writes, fsync-durable checkpoints, background carving to
 // a remote store, pressure-gated eviction, and garbage collection.
 //
-// It owns all persistent local-cache state and depends only on the standard
-// library plus narrow injected interfaces (the carve collaborators [Deduper]
-// and [BlockSink], and Clock). It knows nothing about namespaces, protocols,
-// permissions, or the metadata store — callers resolve logical offsets to
-// FileIDs and hand journal opaque byte ranges.
+// It owns all persistent local-cache state. Its imports are the standard
+// library, pkg/block/chunker (the FastCDC boundary search used in carve), and
+// blake3 (chunk content hashes) — with the carve collaborators ([Deduper] and
+// [BlockSink]) and Clock injected as narrow interfaces. It knows nothing about
+// namespaces, protocols, permissions, or the metadata store — callers resolve
+// logical offsets to FileIDs and hand journal opaque byte ranges.
 //
 // The unifying model: client writes (WriteAt) and cold-read hydration
 // (Hydrate) both funnel through one internal append primitive, differing only

--- a/pkg/controlplane/runtime/format_error_test.go
+++ b/pkg/controlplane/runtime/format_error_test.go
@@ -1,0 +1,88 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block"
+	"github.com/marmos91/dittofs/pkg/block/journal"
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+	"github.com/marmos91/dittofs/pkg/metadata"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
+)
+
+// futureFormatStore bubbles a caller-supplied sentinel from
+// CreateRootDirectory, the metadata call AddShare's prepareShare invokes
+// first — the wrapper pattern the snapshot fixtures use (embedded
+// MemoryMetadataStore, one method overridden).
+type futureFormatStore struct {
+	*metadatamemory.MemoryMetadataStore
+	sentinel error
+}
+
+func (s *futureFormatStore) CreateRootDirectory(ctx context.Context, shareName string, attr *metadata.FileAttr) (*metadata.File, error) {
+	return nil, s.sentinel
+}
+
+// TestLoadSharesFromStore_FormatErrorStops pins the boot-stop contract: a
+// share whose AddShare path bubbles a format sentinel must be surfaced by
+// LoadSharesFromStore (return the error), not warn-and-skipped — the OR
+// branch in LoadSharesFromStore exists so cmd/dfs/commands/start.go can exit
+// 78 with the operator directive. Covers both sentinels separately so a
+// regression flipping the OR to block-only cannot silently downgrade a
+// future journal directory to warn-and-skip.
+func TestLoadSharesFromStore_FormatErrorStops(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		sentinel error
+	}{
+		{"block", block.ErrFutureFormat},
+		{"journal", journal.ErrFutureFormat},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rt, s := setupTestRuntime(t)
+			ctx := context.Background()
+
+			// Register the broken store under the name the DB config carries;
+			// setupTestRuntime already registered a healthy "test-meta", so the
+			// broken store gets its own name and the share row references it.
+			metaName := "format-meta-" + tc.name
+			if _, err := s.CreateMetadataStore(ctx, &models.MetadataStoreConfig{
+				Name: metaName,
+				Type: "memory",
+			}); err != nil {
+				t.Fatalf("CreateMetadataStore: %v", err)
+			}
+			if err := rt.RegisterMetadataStore(metaName, &futureFormatStore{
+				MemoryMetadataStore: metadatamemory.NewMemoryMetadataStoreWithDefaults(),
+				sentinel:            tc.sentinel,
+			}); err != nil {
+				t.Fatalf("RegisterMetadataStore: %v", err)
+			}
+
+			// Persist a share row referencing test-meta; LoadSharesFromStore
+			// resolves it and AddShare bubbles the sentinel from
+			// CreateRootDirectory.
+			share := &models.Share{
+				Name: "/future-format-" + tc.name,
+			}
+			share.MetadataStoreID = "format-meta-" + tc.name
+			if _, err := s.CreateShare(ctx, share); err != nil {
+				t.Fatalf("CreateShare: %v", err)
+			}
+
+			err := LoadSharesFromStore(ctx, rt, s)
+			if err == nil {
+				t.Fatalf("LoadSharesFromStore returned nil on %v; want surfaced error", tc.sentinel)
+			}
+			if !errors.Is(err, tc.sentinel) {
+				t.Fatalf("surfaced error = %v; want errors.Is %v", err, tc.sentinel)
+			}
+			// The share was never added: nothing is serving.
+			if rt.ShareExists("/future-format-" + tc.name) {
+				t.Fatalf("share %s must not be registered after a surfaced format error", share.Name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Lane H (#2535) was squash-merged from its branch, and its branch then held three commits the squash did not carry — salvaged here by cherry-pick, gates green:

- **`pkg/controlplane/runtime/format_error_test.go`** (88 lines) — asserts the two format sentinels (block + journal) surface to the operator at load time, not warn-and-skip. Equivalent coverage did not exist on `develop`.
- **boot-guard test commit** (`cmd/dfs/commands/start_test.go`) — the OR must catch both sentinels, so a regression flipping it to block-only cannot silently downgrade a future journal directory to warn-and-skip.
- **doc fix** (`pkg/block/journal/doc.go`) — the dependency description matches the imports (chunker + blake3), replacing a false depends-only-on-stdlib claim.

Gates: build, vet, gofmt clean; `go test ./pkg/block/`, runtime load-shares tests, and `TestStart_FutureFormatExitCode` pass. Cherry-picks signed.

Original commits: ef8a86433, 7379c26f6, edc96f26e on the #2535 branch (closed unmerged after the squash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)