### PR TITLE
refactor: carve the FastCDC carver out of the journal

### DIFF
--- a/pkg/block/carver/carver.go
+++ b/pkg/block/carver/carver.go
@@ -1,0 +1,257 @@
+// Package carver cuts a contiguous byte stream into FastCDC chunks, hashes
+// them, consults a per-chunk skip oracle, and accumulates the novel chunk bytes
+// into block-sized batches. It wraps pkg/block/chunker — the chunker supplies
+// the boundary search, the carver everything the journal's pack loop used to do
+// inline around it.
+//
+// The two-call contract: feed each contiguous stream with Box, with final set
+// on the stream's last call only — a chunk never spans the gap between two
+// streams, but a block does. Once the caller's last stream is over, one Drain
+// emits the trailing partial block; buffered chunk bytes never outlive the
+// carver. A single-stream consumer is Box(..., true) then Drain().
+package carver
+
+import (
+	"context"
+	"crypto/subtle"
+	"math"
+
+	"lukechampine.com/blake3"
+
+	"github.com/marmos91/dittofs/pkg/block/chunker"
+)
+
+// Hash is a content hash of one chunk.
+type Hash [32]byte
+
+// Equal reports whether two hashes are the same content, in constant time.
+func (h Hash) Equal(o Hash) bool { return subtle.ConstantTimeCompare(h[:], o[:]) == 1 }
+
+// Chunk is one cut of the stream, in caller-data space: Offset is where the
+// chunk lands in the caller's file, Size is its length, Hash its content. Data
+// carries the chunk's bytes for novel chunks (the skip oracle said they still
+// need uploading); skipped ones tile the range without carrying bytes.
+type Chunk struct {
+	Offset int64
+	Size   int64
+	Hash   Hash
+	Data   []byte
+}
+
+// Block is one batch of novel chunks: the bytes the skip oracle said still need
+// uploading, tiled by Chunks (deduped chunks included — they advance the tiling
+// without carrying bytes).
+type Block struct {
+	Chunks []Chunk
+	Bytes  int64
+}
+
+// Options configures a Carver. Params is the FastCDC sizing; BlockSize is the
+// batch cap a block is emitted at; Skip answers per chunk whether its content
+// is already durable remotely — novel chunks carry bytes, skipped ones only
+// tile. An error from Skip stops the current call, matching the pack loop's
+// first-error behaviour.
+type Options struct {
+	Params    chunker.Params
+	BlockSize int64
+	Skip      func(ctx context.Context, h Hash) (bool, error)
+}
+
+// Carver accumulates one file's novel chunk bytes into block-sized batches. It
+// is not safe for concurrent use: one Carver per file per pass.
+type Carver struct {
+	opts      Options
+	blockSize int64
+	params    chunker.Params
+
+	chunker *chunker.Chunker // fresh per stream, so a chunk never spans a gap
+	buf     []byte           // chunker accumulator, never exceeds one max chunk
+
+	pending    []Chunk // novel chunks of the batch being packed (skipped ones too)
+	arena      []byte  // backing for the pending chunk copies, if any
+	arenaOff   int     // fill cursor into arena
+	batchBytes int64
+
+	// The block currently being packed has not been emitted, so its Skip
+	// answers must never observe it as durable: Skip consults only chunks the
+	// caller has committed, never the carver's own pending batch.
+	//
+	// ponytail: the arena is one allocation per in-flight block, sized from the
+	// caller's ChunkParams.Max rather than the package ceiling, so a share
+	// chunking small does not reserve 16 MiB per slot. Sizing from the ceiling
+	// also means the read loop cannot borrow the same constant, or it asks for
+	// bytes past the arena's capacity.
+}
+
+// New returns a Carver configured with the given options. Invalid params fall
+// back to the default profile because that is what the chunker itself does with
+// them, so the arena matches the chunks actually cut; a non-positive BlockSize
+// is likewise replaced, or nothing would ever emit.
+func New(o Options) *Carver {
+	if o.Params.Validate() != nil {
+		o.Params = chunker.DefaultParams()
+	}
+	if o.BlockSize <= 0 {
+		o.BlockSize = 1 << 20
+	}
+	c := &Carver{
+		opts:      o,
+		blockSize: o.BlockSize,
+		params:    o.Params,
+		buf:       make([]byte, 0, chunker.MaxChunkSize),
+	}
+	return c
+}
+
+// Box cuts data into chunks landing at off in the caller's file, and returns
+// the blocks the batch reached BlockSize during this call, alongside how many
+// bytes of stream this call tiled (riding bytes from previous calls included,
+// below-Min riding bytes excluded) — the caller advances its file-offset cursor
+// by that answer. final marks the end of the current contiguous stream: the
+// below-Min tail is cut as a final chunk and the boundary search resets, so a
+// chunk never spans the gap between two streams — but a block does, since the
+// batch being packed carries over. final does not by itself emit the trailing
+// partial block; Drain does that once the caller's last stream is over.
+//
+// Every byte of data is consumed by the time this returns (final=true), or
+// buffered in the accumulator (final=false, below Min and more is coming).
+// An error from Skip stops this call and returns the blocks cut so far; the
+// first error is returned alongside them.
+func (c *Carver) Box(ctx context.Context, data []byte, off int64, final bool) ([]Block, int64, error) {
+	startOff := off
+	if len(data) == 0 && len(c.buf) == 0 {
+		return nil, 0, nil
+	}
+	// A fresh chunker per stream, and an empty accumulator, so a chunk never
+	// spans the hole between two streams.
+	if len(c.buf) == 0 {
+		c.chunker = chunker.NewChunkerWithParams(c.params)
+	}
+
+	var (
+		blocks []Block
+		boxErr error
+	)
+	eof := final
+	for {
+		if err := ctx.Err(); err != nil {
+			boxErr = err
+			break
+		}
+		if len(data) > 0 {
+			// Bound proof: buf never exceeds one max chunk, so the append below
+			// cannot grow it past cap — the accumulator is sized at the
+			// package-wide ceiling in New and the chunker never cuts longer
+			// than its own ceiling.
+			n := copy(c.buf[len(c.buf):cap(c.buf)], data)
+			c.buf = c.buf[:len(c.buf)+n]
+			data = data[n:]
+		}
+		if len(c.buf) == 0 {
+			break
+		}
+		boundary, _ := c.chunker.Next(c.buf, eof)
+		if boundary == 0 {
+			if !eof {
+				break // below Min and more is coming: caller feeds more
+			}
+			boundary = len(c.buf)
+		}
+
+		h := Hash(blake3.Sum256(c.buf[:boundary]))
+		skip := false
+		if c.opts.Skip != nil {
+			s, err := c.opts.Skip(ctx, h)
+			if err != nil {
+				boxErr = err
+				break
+			}
+			skip = s
+		}
+		ch := Chunk{Offset: off, Size: int64(boundary), Hash: h}
+		if !skip {
+			ch.Data = c.claim(c.buf[:boundary])
+		}
+		c.pending = append(c.pending, ch)
+		c.batchBytes += int64(boundary)
+		off += int64(boundary)
+		c.buf = append(c.buf[:0], c.buf[boundary:]...)
+
+		if c.batchBytes >= c.blockSize {
+			blocks = append(blocks, c.emit())
+		}
+		if eof && len(c.buf) == 0 {
+			break
+		}
+	}
+	// off advanced by exactly the bytes this call tiled into chunks — the
+	// caller advances its file-offset cursor by the same answer.
+	return blocks, off - startOff, boxErr
+}
+
+// Drain emits the trailing partial block once the caller's last stream is over,
+// flushing buffered chunk bytes so they never outlive the carver. An empty
+// batch (fully deduped, or nothing new) returns nothing — a bare watermark.
+func (c *Carver) Drain() []Block {
+	if len(c.pending) == 0 {
+		return nil
+	}
+	return []Block{c.emit()}
+}
+
+// emit returns the batch being packed as one block and resets the batch state.
+// The arena's backing moves to the block's chunks (still live while the caller
+// commits), so the local state resets to "no batch".
+func (c *Carver) emit() Block {
+	// Bytes reports only what needs uploading: skipped chunks tile the range
+	// without carrying bytes, so they cost the caller nothing to commit.
+	var novel int64
+	for _, ch := range c.pending {
+		if ch.Data != nil {
+			novel += ch.Size
+		}
+	}
+	b := Block{Chunks: c.pending, Bytes: novel}
+	c.pending, c.arena, c.arenaOff, c.batchBytes = nil, nil, 0, 0
+	return b
+}
+
+// claim copies one novel chunk's bytes into the arena backing the pending
+// batch, returning the data slice that ships with the chunk. The arena is
+// preallocated to one block plus one overhang chunk in New; the grow is a
+// fail-loud belt if that invariant ever breaks.
+func (c *Carver) claim(data []byte) []byte {
+	if c.arena == nil {
+		c.arena = make([]byte, 0, c.arenaCap())
+	}
+	if c.arenaOff+len(data) > cap(c.arena) {
+		// Already-pending slices keep pointing at the old backing (still
+		// live), so no copy is needed — the new chunk lands in the larger
+		// arena.
+		c.arena = make([]byte, c.arenaOff+len(data))
+	}
+	c.arena = c.arena[:c.arenaOff+len(data)]
+	copy(c.arena[c.arenaOff:], data)
+	c.arenaOff += len(data)
+	return c.arena[c.arenaOff-len(data) : c.arenaOff : c.arenaOff]
+}
+
+// arenaCap sizes the arena backing one in-flight block: one block plus the
+// overhang chunk that crossed the line. A block is emitted once it reaches
+// BlockSize, so it overshoots by at most one chunk, and no chunk exceeds
+// Params.Max.
+//
+// Clamp the block size before adding the overhang, not after: a pathological
+// BlockSize near the int64 ceiling would wrap to a negative sum and reach
+// make() as a negative length. BlockSize is positive (New replaces anything
+// <= 0) and the overhang is at most chunker.MaxChunkSize, so the subtraction
+// below cannot itself go negative.
+func (c *Carver) arenaCap() int {
+	overhang := c.params.Max
+	overhang64 := int64(overhang)
+	blockCap64 := c.blockSize
+	if blockCap64 > math.MaxInt-overhang64 {
+		blockCap64 = math.MaxInt - overhang64
+	}
+	return int(blockCap64 + overhang64)
+}

--- a/pkg/block/carver/carver_test.go
+++ b/pkg/block/carver/carver_test.go
@@ -1,0 +1,252 @@
+package carver
+
+import (
+	"context"
+	"math/rand"
+	"slices"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/block/chunker"
+)
+
+// Sizing small enough to run the sweeps cheaply, large enough that a chunk can
+// reach the Max ceiling — so every branch of the boundary search takes part.
+var smallParams = chunker.Params{Min: 4 << 10, Avg: 8 << 10, Max: 16 << 10}
+
+func allChunks(t testing.TB, o Options, data []byte) []Chunk {
+	t.Helper()
+	ctx := context.Background()
+	cv := New(o)
+	var chunks []Chunk
+	for off := 0; off < len(data); {
+		end := min(off+chunker.MaxChunkSize, len(data))
+		blocks, tiled, err := cv.Box(ctx, data[off:end], int64(off), end == len(data))
+		if err != nil {
+			t.Fatalf("Box: %v", err)
+		}
+		if want := int64(end - off); tiled != want {
+			t.Fatalf("Box tiled %d bytes of a %d-byte feed", tiled, want)
+		}
+		off = end
+		for _, b := range blocks {
+			chunks = append(chunks, b.Chunks...)
+		}
+	}
+	for _, b := range cv.Drain() {
+		chunks = append(chunks, b.Chunks...)
+	}
+	if len(chunks) == 0 {
+		t.Fatalf("no chunks cut from %d bytes", len(data))
+	}
+	// Chunks must tile the stream ascending and contiguous, and the hashes must
+	// identify the bytes they cover — dedup and the content-addressed commit key
+	// on them.
+	want := int64(0)
+	for _, ch := range chunks {
+		if ch.Offset != want {
+			t.Fatalf("chunk at %d, want %d — tiling is not contiguous", ch.Offset, want)
+		}
+		want += ch.Size
+	}
+	if want != int64(len(data)) {
+		t.Fatalf("chunks tile %d of %d bytes", want, len(data))
+	}
+	return chunks
+}
+
+// TestCarver_BoundaryIndependentOfBufferLength pins the property dedup rests
+// on: where a chunk ends is decided by its bytes alone, never by how many bytes
+// the caller happened to feed per Box call. Two writers of identical bytes feed
+// different buffer lengths (their readers do not deliver in lockstep); if the
+// cut moved with the feed, their chunk hashes would differ and dedup would
+// silently stop collapsing them.
+//
+// So: cut one blob with a large feed, then again sweeping every buffer length
+// from Min to the whole stream, and require identical chunk hashes.
+func TestCarver_BoundaryIndependentOfBufferLength(t *testing.T) {
+	data := randomBlob(t, 1<<20, 7)
+	want := allChunks(t, Options{Params: smallParams}, data)
+	wantHashes := make([]Hash, len(want))
+	for i, ch := range want {
+		wantHashes[i] = ch.Hash
+	}
+
+	for _, feed := range []int{smallParams.Min, smallParams.Min + 1, 3 * smallParams.Min, smallParams.Avg, smallParams.Max, 1 << 20} {
+		ctx := context.Background()
+		cv := New(Options{Params: smallParams})
+		var got []Hash
+		for off := 0; off < len(data); {
+			end := min(off+feed, len(data))
+			blocks, _, err := cv.Box(ctx, data[off:end], int64(off), end == len(data))
+			if err != nil {
+				t.Fatalf("feed %d: Box: %v", feed, err)
+			}
+			off = end
+			for _, b := range blocks {
+				for _, ch := range b.Chunks {
+					got = append(got, ch.Hash)
+				}
+			}
+		}
+		for _, b := range cv.Drain() {
+			for _, ch := range b.Chunks {
+				got = append(got, ch.Hash)
+			}
+		}
+		if !slices.Equal(wantHashes, got) {
+			t.Fatalf("feed %d cut %d chunks, the full-feed cut has %d, and they differ — "+
+				"the boundary moved with the buffer, not the content", feed, len(got), len(wantHashes))
+		}
+	}
+}
+
+// TestCarver_SkipCoversBytesWithoutData pins the dedup contract: a skipped
+// chunk still tiles its range (the caller needs the manifest row even when the
+// payload is redundant) but carries no bytes, and the block reports only what
+// actually needs uploading.
+func TestCarver_SkipCoversBytesWithoutData(t *testing.T) {
+	data := randomBlob(t, 256<<10, 3)
+	cv := New(Options{
+		Params:    smallParams,
+		BlockSize: 1 << 20,
+		Skip: func(_ context.Context, h Hash) (bool, error) {
+			// Skip every other chunk deterministically.
+			return h[0]%2 == 0, nil
+		},
+	})
+	ctx := context.Background()
+	blocks, tiled, err := cv.Box(ctx, data, 0, true)
+	if err != nil {
+		t.Fatalf("Box: %v", err)
+	}
+	if tiled != int64(len(data)) {
+		t.Fatalf("tiled %d of %d bytes", tiled, len(data))
+	}
+	blocks = append(blocks, cv.Drain()...)
+	covered := int64(0)
+	novel := int64(0)
+	for _, b := range blocks {
+		if b.Bytes != novelBytes(b) {
+			t.Fatalf("block reports %d bytes, has %d novel", b.Bytes, novelBytes(b))
+		}
+		for _, ch := range b.Chunks {
+			covered += ch.Size
+			if ch.Data != nil {
+				novel += ch.Size
+			}
+		}
+	}
+	if covered != int64(len(data)) {
+		t.Fatalf("skipped chunks dropped bytes: tiled %d of %d", covered, len(data))
+	}
+	if novel == 0 || novel == covered {
+		t.Fatalf("skip oracle did not split the stream: %d novel of %d", novel, covered)
+	}
+}
+
+// TestCarver_SkipErrorStopsCall pins the first-error behaviour: an error from
+// Skip ends the Box call with the blocks cut so far, and nothing after it.
+func TestCarver_SkipErrorStopsCall(t *testing.T) {
+	data := randomBlob(t, 512<<10, 5)
+	sentinel := context.DeadlineExceeded
+	calls := 0
+	cv := New(Options{
+		Params:    smallParams,
+		BlockSize: 1 << 20,
+		Skip: func(_ context.Context, _ Hash) (bool, error) {
+			calls++
+			if calls > 3 {
+				return false, sentinel
+			}
+			return false, nil
+		},
+	})
+	ctx := context.Background()
+	_, _, err := cv.Box(ctx, data, 0, true)
+	if err != sentinel {
+		t.Fatalf("Box err = %v, want the Skip error", err)
+	}
+}
+
+// TestCarver_DrainEmitsTrailingPartial pins the two-call contract: a batch
+// below BlockSize is not emitted by Box (final included), only by Drain — the
+// trailing partial block is the caller's, once its last stream is over.
+func TestCarver_DrainEmitsTrailingPartial(t *testing.T) {
+	data := randomBlob(t, 100<<10, 9) // below BlockSize: one trailing block only
+	cv := New(Options{Params: smallParams, BlockSize: 1 << 20})
+	ctx := context.Background()
+	blocks, tiled, err := cv.Box(ctx, data, 0, true)
+	if err != nil {
+		t.Fatalf("Box: %v", err)
+	}
+	if tiled != int64(len(data)) {
+		t.Fatalf("tiled %d of %d bytes", tiled, len(data))
+	}
+	if len(blocks) != 0 {
+		t.Fatalf("Box emitted %d blocks below BlockSize", len(blocks))
+	}
+	blocks = cv.Drain()
+	if len(blocks) != 1 || len(blocks[0].Chunks) == 0 {
+		t.Fatalf("Drain returned %d blocks, want the one trailing partial", len(blocks))
+	}
+	if cv.Drain() != nil {
+		t.Fatal("second Drain emitted something — batch state did not reset")
+	}
+}
+
+// TestCarver_ChunkNeverSpansStreams pins the gap rule: final=true resets the
+// boundary search, so the bytes before the gap and after it are chunked
+// independently — feeding the two halves separately cuts identically to one
+// contiguous feed.
+func TestCarver_ChunkNeverSpansStreams(t *testing.T) {
+	data := randomBlob(t, 512<<10, 13)
+	want := allChunks(t, Options{Params: smallParams}, data)
+	wantHashes := make([]Hash, len(want))
+	for i, ch := range want {
+		wantHashes[i] = ch.Hash
+	}
+
+	// Split at a point that would otherwise be mid-chunk: two streams, a final
+	// Box on each, one Drain at the end.
+	split := 200<<10 + 123
+	ctx := context.Background()
+	cv := New(Options{Params: smallParams})
+	var got []Hash
+	for i, parts := range [][]byte{data[:split], data[split:]} {
+		blocks, _, err := cv.Box(ctx, parts, int64(0), i == 1)
+		if err != nil {
+			t.Fatalf("Box: %v", err)
+		}
+		for _, b := range blocks {
+			for _, ch := range b.Chunks {
+				got = append(got, ch.Hash)
+			}
+		}
+	}
+	for _, b := range cv.Drain() {
+		for _, ch := range b.Chunks {
+			got = append(got, ch.Hash)
+		}
+	}
+	if !slices.Equal(wantHashes, got) {
+		t.Fatalf("split feed cut %d chunks vs %d — a chunk spanned the stream gap", len(got), len(wantHashes))
+	}
+}
+
+func novelBytes(b Block) int64 {
+	var n int64
+	for _, ch := range b.Chunks {
+		if ch.Data != nil {
+			n += ch.Size
+		}
+	}
+	return n
+}
+
+func randomBlob(t testing.TB, n int, seed int64) []byte {
+	t.Helper()
+	rng := rand.New(rand.NewSource(seed))
+	b := make([]byte, n)
+	rng.Read(b)
+	return b
+}

--- a/pkg/block/carver/carver_test.go
+++ b/pkg/block/carver/carver_test.go
@@ -24,7 +24,9 @@ func allChunks(t testing.TB, o Options, data []byte) []Chunk {
 		if err != nil {
 			t.Fatalf("Box: %v", err)
 		}
-		if want := int64(end - off); tiled != want {
+		// A non-final feed can retain a below-boundary tail (tiled < fed); the
+		// Drain below covers retained bytes, so only over-tiling is a defect.
+		if want := int64(end - off); tiled > want {
 			t.Fatalf("Box tiled %d bytes of a %d-byte feed", tiled, want)
 		}
 		off = end
@@ -196,24 +198,35 @@ func TestCarver_DrainEmitsTrailingPartial(t *testing.T) {
 
 // TestCarver_ChunkNeverSpansStreams pins the gap rule: final=true resets the
 // boundary search, so the bytes before the gap and after it are chunked
-// independently — feeding the two halves separately cuts identically to one
-// contiguous feed.
+// independently — cutting the two halves as separate streams must reproduce
+// the concatenation of each half cut alone.
 func TestCarver_ChunkNeverSpansStreams(t *testing.T) {
 	data := randomBlob(t, 512<<10, 13)
-	want := allChunks(t, Options{Params: smallParams}, data)
-	wantHashes := make([]Hash, len(want))
-	for i, ch := range want {
-		wantHashes[i] = ch.Hash
+	split := 200<<10 + 123
+
+	// Oracle: each half cut alone, with a final Box that ends its stream.
+	want := make([]Hash, 0, 64)
+	for _, half := range [][]byte{data[:split], data[split:]} {
+		cv := New(Options{Params: smallParams})
+		blocks, _, err := cv.Box(context.Background(), half, int64(0), true)
+		if err != nil {
+			t.Fatalf("Box: %v", err)
+		}
+		for _, b := range append(blocks, cv.Drain()...) {
+			for _, ch := range b.Chunks {
+				want = append(want, ch.Hash)
+			}
+		}
 	}
 
-	// Split at a point that would otherwise be mid-chunk: two streams, a final
-	// Box on each, one Drain at the end.
-	split := 200<<10 + 123
+	// A fresh chunker per stream, and an empty accumulator, so a chunk never
+	// spans the hole between two streams: one Carver, final Box on each half,
+	// one Drain at the end.
 	ctx := context.Background()
 	cv := New(Options{Params: smallParams})
 	var got []Hash
-	for i, parts := range [][]byte{data[:split], data[split:]} {
-		blocks, _, err := cv.Box(ctx, parts, int64(0), i == 1)
+	for _, half := range [][]byte{data[:split], data[split:]} {
+		blocks, _, err := cv.Box(ctx, half, int64(0), true)
 		if err != nil {
 			t.Fatalf("Box: %v", err)
 		}
@@ -228,8 +241,8 @@ func TestCarver_ChunkNeverSpansStreams(t *testing.T) {
 			got = append(got, ch.Hash)
 		}
 	}
-	if !slices.Equal(wantHashes, got) {
-		t.Fatalf("split feed cut %d chunks vs %d — a chunk spanned the stream gap", len(got), len(wantHashes))
+	if !slices.Equal(want, got) {
+		t.Fatalf("split feed cut %d chunks vs %d — a chunk spanned the stream gap", len(got), len(want))
 	}
 }
 

--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -10,8 +10,7 @@ import (
 	"sort"
 	"sync"
 
-	"lukechampine.com/blake3"
-
+	"github.com/marmos91/dittofs/pkg/block/carver"
 	"github.com/marmos91/dittofs/pkg/block/chunker"
 )
 
@@ -29,17 +28,6 @@ import (
 // bytes past the buffer's capacity and stops making progress.
 var carveScratchPool = sync.Pool{New: func() any {
 	b := make([]byte, 0, chunker.MaxChunkSize)
-	return &b
-}}
-
-// carveArenaPool recycles the per-block arenas backing the pending chunk copies
-// handed to the sink. Both production sinks consume CarveChunk.Data synchronously
-// inside CommitBlock (localBlockSink reads only len; engineBlockSink seals/frames
-// into its own buffer before returning) — neither retains it — so a block's arena
-// is safe to return to the pool once its CommitBlock has returned. Each concurrent
-// block owns a distinct arena so overlapping commits never share backing bytes.
-var carveArenaPool = sync.Pool{New: func() any {
-	var b []byte
 	return &b
 }}
 
@@ -100,9 +88,10 @@ type CarveChunk struct {
 // commit makes a re-carve after a crash (or a duplicate concurrent carve) a
 // no-op.
 //
-// Lifetime contract: CarveChunk.Data slices are backed by a pooled arena that
-// the next carve flush reuses. An implementation MUST NOT retain any Data slice
-// after CommitBlock returns; copy the bytes first if it needs them longer.
+// Lifetime contract: CarveChunk.Data slices are backed by the carving carver's
+// per-block arena, which covers only the blocks in flight. An implementation
+// MUST NOT retain any Data slice after CommitBlock returns; copy the bytes
+// first if it needs them longer.
 type BlockSink interface {
 	CommitBlock(ctx context.Context, chunks []CarveChunk) error
 }
@@ -390,87 +379,59 @@ func splitRuns(snap []interval) [][]interval {
 func (s *Store) packRuns(ctx context.Context, sh *shard, id FileID, rs []*runState) (CarveResult, error) {
 	var res CarveResult
 
-	// One semaphore for the whole file: it bounds the in-flight block arenas
-	// across every run, so that term stays cap(sem) x (CarveBlockSize + one
-	// overhang chunk) however many runs the file has. The chunker scratch buffer
-	// is a single pooled buffer for the whole pass, not one per run.
+	// One semaphore for the whole file: it bounds the blocks in flight across
+	// every run, so peak carve RAM stays cap(sem) x (CarveBlockSize + one
+	// overhang chunk) for the submitted blocks, plus one further block the
+	// carver has packed ahead of the window.
 	sem := make(chan struct{}, s.cfg.CarveUploadConcurrency)
 
 	// disp overlaps successive blocks' CommitBlock (upload + commit) while packing
-	// stays sequential. It owns the bounded worker pool, the per-block buffers and
-	// the ordered flip chain; flush hands it a completed block or a bare watermark.
+	// stays sequential. It owns the bounded worker pool and the ordered flip
+	// chain; submit hands it a completed block or a bare watermark.
 	disp := newCarveDispatcher(ctx, s, sh, id, rs, &res, sem)
 
-	// Each packed block gets its OWN buffer (cap one block plus one overhang chunk)
-	// so its bytes stay live while its CommitBlock runs concurrently with the next
-	// block's packing — the recycled arena of the sequential path can't do that.
-	//
-	// The overhang is one chunk at this share's configured size, not the largest
-	// chunk any share could ask for. A block is flushed once it reaches
-	// CarveBlockSize, so it overshoots by at most the chunk that crossed the line,
-	// and no chunk exceeds ChunkParams.Max. Sizing the overhang from the package
-	// ceiling instead reserves 16 MiB per in-flight block for a share chunking at
-	// 128 KiB — and that reservation is per slot, so it multiplies by the carve
-	// upload window and again by however many files carve at once.
-	//
-	// Invalid params fall back to the default profile because that is what the
-	// chunker itself does with them, so the arena matches the chunks actually cut.
-	//
-	// Clamp the block size before adding the overhang, not after: a pathological
-	// CarveBlockSize near the int64 ceiling would wrap to a negative sum, sail
-	// past a clamp that only tests the upper bound, and reach make() as a
-	// negative length. CarveBlockSize is positive by then (withDefaults replaces
-	// anything <= 0) and the overhang is at most chunker.MaxChunkSize, so the
-	// subtraction below cannot itself go negative.
-	overhang := s.cfg.ChunkParams.Max
-	if s.cfg.ChunkParams.Validate() != nil {
-		overhang = chunker.DefaultParams().Max
-	}
-	overhang64 := int64(overhang)
-	blockCap64 := s.cfg.CarveBlockSize
-	if blockCap64 > math.MaxInt-overhang64 {
-		blockCap64 = math.MaxInt - overhang64
-	}
-	arenaCap := int(blockCap64 + overhang64)
-
-	// The block currently being packed. arena is its private buffer (nil until the
-	// first novel chunk claims a pool buffer and a concurrency slot); arenaOff is
-	// the fill cursor. On any early exit these are returned to disp so the slot and
-	// buffer are not leaked.
-	// batchBytes counts the run bytes this batch tiles, deduped chunks included,
-	// so a fully deduped batch (empty arena) is still bounded and committed on the
-	// same cadence as one carrying bytes.
-	var (
-		pending    []CarveChunk
-		arenap     *[]byte
-		arena      []byte
-		arenaOff   int
-		batchBytes int64
-	)
-	ensureArena := func() error {
-		if arenap != nil {
-			return nil
-		}
-		p, err := disp.acquire(arenaCap)
-		if err != nil {
-			return err
-		}
-		arenap, arena, arenaOff = p, *p, 0
-		return nil
-	}
+	// One carver for the whole pass. Cutting and hashing are chunk-agnostic; the
+	// carver owns them, and the batch being packed carries across runs — that is
+	// what lets one block span runs. Its per-block arena backs the chunks' Data
+	// slices and stays live while the sink's CommitBlock runs concurrently with
+	// the next block's packing. The skip oracle is the committed synced-hash
+	// store: a block being committed concurrently has NOT yet marked its hashes
+	// durable, so the carver never observes a sibling block's uncommitted hash
+	// as durable — at worst a duplicate chunk is re-packed, which the
+	// content-addressed commit collapses to a no-op.
+	cv := carver.New(carver.Options{
+		Params:    s.cfg.ChunkParams,
+		BlockSize: s.cfg.CarveBlockSize,
+		Skip: func(ctx context.Context, h carver.Hash) (bool, error) {
+			return s.deduper.IsChunkDurable(ctx, ChunkHash(h))
+		},
+	})
 
 	// blockFirstRun is the index of the run the block being packed started in;
 	// every run from there to the one being packed contributes to it, which is
-	// what the flush's flipPlan names.
+	// what the submit's flipPlan names.
 	blockFirstRun := 0
 
-	// flush hands the packed block (if any) and its flip plan to the dispatcher,
-	// which commits then flips in submission order. Packing continues immediately;
-	// the commit and flip happen on the pool. Ownership of the buffer moves to the
-	// dispatcher, so the local arena state resets to "no block".
-	flush := func(plan flipPlan) {
-		disp.submit(pending, arenap, arena, plan)
-		pending, arenap, arena, arenaOff, batchBytes = nil, nil, nil, 0, 0
+	// submit converts one carved block to sink chunks and hands it to the
+	// dispatcher, which commits then flips in submission order. Packing
+	// continues immediately; the commit and flip happen on the dispatcher's
+	// workers. lastOff is the run-space offset the block's tiling reached: its
+	// last chunk's end, which is what the flip plan must cover.
+	submit := func(b carver.Block, plan flipPlan) {
+		chunks := make([]CarveChunk, len(b.Chunks))
+		for i, ch := range b.Chunks {
+			chunks[i] = CarveChunk{
+				Hash:       ChunkHash(ch.Hash),
+				FileID:     id,
+				FileOffset: ch.Offset,
+				Size:       int(ch.Size),
+				Data:       ch.Data,
+			}
+			if ch.Data != nil {
+				res.BytesCarved += ch.Size
+			}
+		}
+		disp.submit(chunks, plan)
 	}
 
 	// buf accumulates bytes for the chunker; it never exceeds one max chunk, so
@@ -530,14 +491,13 @@ func (s *Store) packRuns(ctx context.Context, sh *shard, id FileID, rs []*runSta
 			}
 		}
 
-		// A fresh chunker and reader per run, and an empty accumulator, so a chunk
-		// never spans the hole between two runs. The block being packed carries
-		// over: that is what lets one block span them.
-		c := chunker.NewChunkerWithParams(s.cfg.ChunkParams)
+		// A fresh reader per run; the carver's boundary search resets when the
+		// run's last Box call sets final, so a chunk never spans the hole between
+		// two runs. The block being packed carries over: that is what lets one
+		// block span them.
 		rr := &runReader{s: s, sh: sh, id: id, ivs: rs[ri].ivs}
 		fileOff := rs[ri].start()
 		rs[ri].newOffsets = make(map[int64]struct{})
-		buf = buf[:0]
 		eof := false
 
 		for {
@@ -567,66 +527,33 @@ func (s *Store) packRuns(ctx context.Context, sh *shard, id FileID, rs []*runSta
 			if packErr != nil {
 				break
 			}
-			if len(buf) == 0 {
-				break
-			}
-			boundary, _ := c.Next(buf, eof)
-			if boundary == 0 {
-				if !eof {
-					continue // below MinChunkSize and more is coming: read more
-				}
-				boundary = len(buf)
-			}
-
-			h := ChunkHash(blake3.Sum256(buf[:boundary]))
-			// Dedup consults the committed synced-hash oracle. A block being committed
-			// concurrently has NOT yet marked its hashes durable, so this never observes
-			// a sibling block's uncommitted hash as durable — at worst a duplicate chunk
-			// is re-packed, which the content-addressed commit collapses to a no-op.
-			durable, err := s.deduper.IsChunkDurable(ctx, h)
+			// final=true on the run's last call even with nothing read (the
+			// accumulator may hold the run's below-Min tail): the carver cuts it
+			// as the run's final chunk and resets its boundary search, so a chunk
+			// never spans the hole between two runs. An empty Box with an empty
+			// accumulator is a no-op.
+			blocks, tiled, err := cv.Box(ctx, buf, fileOff, eof)
+			buf = buf[:0]
 			if err != nil {
 				packErr = err
 				break
 			}
-			// A deduped chunk has nothing to upload but still needs its manifest row:
-			// the reap deletes every row in the run span the run did not write, so
-			// dropping it here leaves the range on a stale straddler or on nothing.
-			cc := CarveChunk{Hash: h, FileID: id, FileOffset: fileOff, Size: boundary}
-			if !durable {
-				if err := ensureArena(); err != nil {
-					packErr = err
-					break
+			fileOff += tiled
+			for _, b := range blocks {
+				for _, ch := range b.Chunks {
+					rs[ri].newOffsets[ch.Offset] = struct{}{}
 				}
-				// Bound proof: this block's bytes < CarveBlockSize before this append
-				// (else the prior iteration flushed and started a fresh arena), and
-				// boundary <= the configured ChunkParams.Max — the chunker never cuts
-				// longer than its own ceiling — so arenaOff+boundary <=
-				// CarveBlockSize-1+ChunkParams.Max <= cap, which is how the arena is
-				// sized above. The grow is a fail-loud belt: if that invariant
-				// ever breaks (e.g. a config change), realloc rather than slice out of
-				// bounds. Already-pending Data slices keep pointing at the old backing
-				// (still live), so no copy is needed — the new chunk lands in the larger
-				// arena and the grown slice ships to the dispatcher.
-				if arenaOff+boundary > cap(arena) {
-					arena = make([]byte, arenaOff+boundary)
-				}
-				data := arena[arenaOff : arenaOff+boundary : arenaOff+boundary]
-				copy(data, buf[:boundary])
-				arenaOff += boundary
-				cc.Data = data
-				res.BytesCarved += int64(boundary)
-			}
-			pending = append(pending, cc)
-			batchBytes += int64(boundary)
-			rs[ri].newOffsets[fileOff] = struct{}{}
-			fileOff += int64(boundary)
-			buf = append(buf[:0], buf[boundary:]...)
-
-			if batchBytes >= s.cfg.CarveBlockSize {
-				flush(flipPlan{first: blockFirstRun, last: ri, lastOff: fileOff})
+				// This block's tiling ends inside run ri (its last chunk's end),
+				// and every run from the one it started in to ri contributes to
+				// it — the runs earlier blocks of the batch already covered flip
+				// through their own ends on their own submissions.
+				submit(b, flipPlan{first: blockFirstRun, last: ri, lastOff: b.Chunks[len(b.Chunks)-1].Offset + b.Chunks[len(b.Chunks)-1].Size})
 				blockFirstRun = ri
 			}
-			if eof && len(buf) == 0 {
+			if disp.aborted() {
+				break
+			}
+			if eof {
 				break
 			}
 		}
@@ -637,21 +564,29 @@ func (s *Store) packRuns(ctx context.Context, sh *shard, id FileID, rs []*runSta
 
 	if packErr != nil || disp.aborted() {
 		// A read/dedup error (packErr) or an in-flight commit failure (aborted)
-		// ends the pass. Abandon the half-packed block (return its slot/buffer) and
-		// drain the blocks already in flight, but submit nothing more: advancing
-		// the watermark or committing the tail past a failure only adds orphan
-		// uploads. disp.wait returns the commit error in watermark order.
-		disp.discard(arenap, arena)
+		// ends the pass. Drop the carver's pending batch and drain the blocks
+		// already in flight, but submit nothing more: advancing the watermark or
+		// committing the tail past a failure only adds orphan uploads. The
+		// dropped batch has no committed manifest row, so its ranges stay dirty
+		// and the next pass re-carves them. disp.wait returns the commit error
+		// in watermark order.
 		if err := disp.wait(); err != nil {
 			return res, err
 		}
 		return res, packErr
 	}
 
-	// Tail: commit any remainder and flip through the end of the last run (records
-	// covered only by already-durable chunks flip here too, via the bare watermark).
+	// Tail: emit any remainder and flip through the end of the last run (records
+	// covered only by already-durable chunks flip here too, via the bare watermark
+	// when the tail is empty). The carver's chunker already reset at the last
+	// run's final=true Box call, so the trailing partial block is the batch's last.
 	last := len(rs) - 1
-	flush(flipPlan{first: blockFirstRun, last: last, lastOff: rs[last].end()})
+	for _, b := range cv.Drain() {
+		for _, ch := range b.Chunks {
+			rs[last].newOffsets[ch.Offset] = struct{}{}
+		}
+		submit(b, flipPlan{first: blockFirstRun, last: last, lastOff: b.Chunks[len(b.Chunks)-1].Offset + b.Chunks[len(b.Chunks)-1].Size})
+	}
 	if err := disp.wait(); err != nil {
 		return res, err
 	}

--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -382,7 +382,10 @@ func (s *Store) packRuns(ctx context.Context, sh *shard, id FileID, rs []*runSta
 	// One semaphore for the whole file: it bounds the blocks in flight across
 	// every run, so peak carve RAM stays cap(sem) x (CarveBlockSize + one
 	// overhang chunk) for the submitted blocks, plus one further block the
-	// carver has packed ahead of the window.
+	// carver has packed ahead of the window, plus the pass-level read buffer
+	// (one max chunk) and the carver's accumulator (one max chunk). One Box
+	// call fed a full read buffer emits one block per CarveBlockSize, so a
+	// multi-GiB file's peak is bounded by the same window, not by file size.
 	sem := make(chan struct{}, s.cfg.CarveUploadConcurrency)
 
 	// disp overlaps successive blocks' CommitBlock (upload + commit) while packing

--- a/pkg/block/journal/carve_arena_test.go
+++ b/pkg/block/journal/carve_arena_test.go
@@ -12,16 +12,18 @@ import (
 // blocks in flight.
 //
 // Each in-flight block owns a private arena of one CarveBlockSize plus one
-// chunk of overhang, because a block is flushed only once it crosses
+// chunk of overhang, because a block is emitted only once it crosses
 // CarveBlockSize and so overshoots by the chunk that crossed the line. Sizing
 // that overhang from the package ceiling rather than the share's own
 // ChunkParams reserves 16 MiB per block for a share chunking at 16 KiB, and the
 // reservation is per concurrency slot — so it multiplies by CarveUploadConcurrency
-// and again by however many files carve at once.
+// and again by however many files carve at once. The carver also packs one
+// further block ahead of the window (its batch is not window-throttled until
+// submit), so the budget carries one extra arena.
 //
-// The arenas come from a sync.Pool, which Go empties on GC, so collecting first
-// makes the allocation observable instead of served from a previous test's
-// leftovers.
+// The arenas are allocated fresh by the carver (one per emitted block), so
+// collecting first makes them observable instead of served from a previous
+// test's freed memory.
 func TestCarveArenaSizedToConfiguredChunkSize(t *testing.T) {
 	const (
 		blockSize = 1 << 20
@@ -59,12 +61,15 @@ func TestCarveArenaSizedToConfiguredChunkSize(t *testing.T) {
 	}
 
 	// What the arenas may cost: one per slot, each a block plus one configured
-	// chunk. Everything else the pass allocates — the file's own bytes, the
-	// chunker scratch buffer, the manifest rows — is bounded well inside the
-	// slack below, and sizing the overhang from chunker.MaxChunkSize instead
-	// would put the arenas alone an order of magnitude over it.
-	arenas := int64(window) * (blockSize + int64(params.Max))
-	limit := arenas + 8*fileSize
+	// chunk, plus the one block the carver packs ahead of the window. Everything
+	// else the pass allocates — the file's own bytes, the chunker scratch buffer,
+	// the manifest rows — is bounded well inside the slack below, and sizing the
+	// overhang from chunker.MaxChunkSize instead would put the arenas alone an
+	// order of magnitude over it. The extra megabyte absorbs allocator and race-
+	// detector instrumentation noise between the MemStats brackets — noise two
+	// orders of magnitude below the 16-MiB-per-slot overhang this test pins.
+	arenas := (int64(window) + 1) * (blockSize + int64(params.Max))
+	limit := arenas + 8*fileSize + 1<<20
 	if got := int64(after.TotalAlloc - before.TotalAlloc); got > limit {
 		t.Errorf("carve allocated %d bytes, over the %d-byte ceiling for %d slots of %d-byte arenas — "+
 			"the per-block overhang is not sized to this share's chunks",

--- a/pkg/block/journal/carve_dispatch.go
+++ b/pkg/block/journal/carve_dispatch.go
@@ -32,10 +32,11 @@ import (
 // keep being served from the journal, and the next carve re-carves the same
 // ranges and reaps them.
 //
-// Concurrency and peak RAM are bounded by sem: a block holds a slot (and its own
-// buffer) from the moment it starts packing until its flip completes, so at most
-// cap(sem) blocks — and thus CommitBlocks — are in flight, and peak carve RAM is
-// cap(sem) x (CarveBlockSize + one overhang chunk).
+// Concurrency and peak RAM are bounded by sem: a block holds a slot from the
+// moment it is submitted until its flip completes, so at most cap(sem) blocks —
+// and thus CommitBlocks — are in flight. Peak carve RAM is cap(sem) x
+// (CarveBlockSize + one overhang chunk) for the submitted blocks' arenas, plus
+// one further block the carver has packed ahead of the window.
 type carveDispatcher struct {
 	ctx context.Context
 	s   *Store
@@ -69,37 +70,29 @@ func newCarveDispatcher(ctx context.Context, s *Store, sh *shard, id FileID, rs 
 	}
 }
 
-// acquire reserves a concurrency slot and returns a pooled buffer with capacity
-// at least arenaCap for the next block being packed. It blocks while the window
-// is full and returns the context error if it is cancelled meanwhile. The slot
-// is released by the block's worker (or by discard for a block never submitted).
-func (d *carveDispatcher) acquire(arenaCap int) (*[]byte, error) {
-	select {
-	case d.sem <- struct{}{}:
-	case <-d.ctx.Done():
-		return nil, d.ctx.Err()
+// hasNovelBytes reports whether any chunk carries payload. A fully deduped
+// batch commits manifest rows but writes no block, so it must not count as one.
+func hasNovelBytes(chunks []CarveChunk) bool {
+	for _, cc := range chunks {
+		if cc.Data != nil {
+			return true
+		}
 	}
-	p := carveArenaPool.Get().(*[]byte)
-	a := *p
-	if cap(a) < arenaCap {
-		a = make([]byte, arenaCap)
-	}
-	*p = a[:cap(a)]
-	return p, nil
+	return false
 }
 
-// submit hands a packed block to the pool. chunks may be empty and arenap nil,
-// which submits a bare watermark advance (records covered only by already-durable
-// chunks flip there) — that carries no buffer and holds no slot. arena is the
-// block's final backing slice (it may have grown past the pooled buffer while
-// packing), stored back into the pool on completion. plan names the runs the
-// block covers and how far into the last of them it reached.
-func (d *carveDispatcher) submit(chunks []CarveChunk, arenap *[]byte, arena []byte, plan flipPlan) {
-	// A batch of only deduped chunks holds no arena and so has claimed no slot in
-	// acquire; take one here so its commit is throttled like any other. Giving up
-	// on a cancelled context is safe: the commit below fails on the same context.
-	slot := arenap != nil
-	if !slot && len(chunks) > 0 {
+// submit hands a packed block to the pool. chunks may be empty, which submits a
+// bare watermark advance (records covered only by already-durable chunks flip
+// there) — that carries no bytes and holds no slot. The chunks' Data slices are
+// backed by the carving carver's per-block arena and stay live until CommitBlock
+// returns. plan names the runs the block covers and how far into the last of
+// them it reached.
+func (d *carveDispatcher) submit(chunks []CarveChunk, plan flipPlan) {
+	// A batch of only deduped chunks carries no bytes but still commits manifest
+	// rows, so its commit is throttled like any other. Giving up on a cancelled
+	// context is safe: the commit below fails on the same context.
+	slot := false
+	if len(chunks) > 0 {
 		select {
 		case d.sem <- struct{}{}:
 			slot = true
@@ -110,21 +103,15 @@ func (d *carveDispatcher) submit(chunks []CarveChunk, arenap *[]byte, arena []by
 	prev := d.prev
 	d.prev = mine
 	d.wg.Add(1)
-	go d.commitAndFlip(chunks, arenap, arena, plan, prev, mine, slot)
+	go d.commitAndFlip(chunks, plan, prev, mine, slot)
 }
 
-func (d *carveDispatcher) commitAndFlip(chunks []CarveChunk, arenap *[]byte, arena []byte, plan flipPlan, prev, mine chan bool, slot bool) {
+func (d *carveDispatcher) commitAndFlip(chunks []CarveChunk, plan flipPlan, prev, mine chan bool, slot bool) {
 	defer d.wg.Done()
 	if slot {
 		// Release the slot only after CommitBlock has consumed the Data slices
 		// (the sink copies them before returning) and the flip ran.
 		defer func() { <-d.sem }()
-	}
-	if arenap != nil {
-		defer func() {
-			*arenap = arena
-			carveArenaPool.Put(arenap)
-		}()
 	}
 
 	var commitErr error
@@ -162,9 +149,9 @@ func (d *carveDispatcher) commitAndFlip(chunks []CarveChunk, arenap *[]byte, are
 				break
 			}
 		}
-		// An arena is claimed only by a chunk carrying bytes: a batch of purely
-		// deduped chunks writes manifest rows but no block.
-		if ok && arenap != nil {
+		// A batch carrying no novel bytes writes manifest rows but no block:
+		// deduped chunks tile the range without shipping payload.
+		if ok && hasNovelBytes(chunks) {
 			d.res.BlocksWritten++
 		}
 	case proceed && commitErr != nil:
@@ -173,17 +160,6 @@ func (d *carveDispatcher) commitAndFlip(chunks []CarveChunk, arenap *[]byte, are
 		d.setErr(commitErr)
 	}
 	mine <- ok
-}
-
-// discard returns an acquired-but-never-submitted buffer and its slot, used when
-// packing aborts mid-block.
-func (d *carveDispatcher) discard(arenap *[]byte, arena []byte) {
-	if arenap == nil {
-		return
-	}
-	*arenap = arena
-	carveArenaPool.Put(arenap)
-	<-d.sem
 }
 
 // wait blocks until every submitted block has committed and flipped (or drained

--- a/pkg/block/journal/carve_pipeline_test.go
+++ b/pkg/block/journal/carve_pipeline_test.go
@@ -57,16 +57,17 @@ func TestCarveInterleavesRowEndLookupsWithCommits(t *testing.T) {
 		blockSize = 64 << 10
 		// Each run contributes one cell, so a block fills after this many of them.
 		runsPerBlock = blockSize / cell
-		// Packing a block's first novel chunk claims an arena, and an arena is
-		// released only after that block's CommitBlock has returned. With one
-		// arena in flight the packer therefore cannot start a second block's
-		// bytes until the first block has committed, which caps the lookups it
-		// can do beforehand at one block's runs plus the run it stalls in — a
-		// bound the arena semaphore enforces, not one the scheduler happens to
-		// produce. Raising the concurrency multiplies the bound by it and makes
-		// the assertion a race against the commit goroutine.
+		// Packing a block submits it as soon as it reaches CarveBlockSize, and a
+		// submitted block holds its concurrency slot until its CommitBlock has
+		// returned. With one slot the packer therefore cannot submit a second
+		// block until the first has committed, which caps the lookups it can do
+		// beforehand at two blocks' runs — one packed ahead while the first is in
+		// flight, plus the run it stalls submitting in — a bound the semaphore
+		// enforces, not one the scheduler happens to produce. Raising the
+		// concurrency multiplies the bound by it and makes the assertion a race
+		// against the commit goroutine.
 		uploadConcurrency = 1
-		maxPrologue       = uploadConcurrency*runsPerBlock + 1
+		maxPrologue       = 2*uploadConcurrency*runsPerBlock + 1
 	)
 	s, dd, fs, _ := carveStore(t, Config{
 		CarveBlockSize:         blockSize,


### PR DESCRIPTION
Lane C of the step-3 journal refactor — carve the FastCDC carver out of the journal.

What was done:
- **`pkg/block/carver`** (new): FastCDC carving wrapping `pkg/block/chunker` — `Box`/`Drain` two-call contract, BLAKE3-256 `Hash` with constant-time `Equal`, per-chunk `Skip` dedup oracle, per-block arena backing novel chunks' `Data`.
- **Journal rewiring**: `packRuns` owns one Carver per pass (batch carries across runs → blocks span runs), calls `Box` with `final=true` at each run's EOF (chunks stay inside a run), submits per-block via the dispatcher with per-block `flipPlan\{first: blockFirstRun, last: ri\}`.
- **Dispatcher delta (Option B, supervisor-approved)**: `acquire`/`discard`/`carveArenaPool` removed; `submit(chunks, plan)` takes the sem slot itself when chunks are non-empty; `BlocksWritten` keyed on `hasNovelBytes(chunks)`. Fresh-arena-per-emitted-block replaces the pooled design — no pool-reuse corruption hazard.
- **blake3 removed from the journal** — hashing lives only in the carver.
- **Test premise updates**: arena-memory test budgets one extra block + 1 MB instrumentation slack; pipeline test's bound doubles to `2×uploadConcurrency×runsPerBlock+1` (stall moved from first-novel-chunk to submit time).

Fixed en route (latent bugs the new carver tests caught): nil `Skip` panicked (nil = pack everything per the contract); `Box`'s tiled-bytes return lost fed bytes; `Block.Bytes` double-counted skipped chunks.

Gates: build, vet, gofmt clean; `go test ./pkg/block/... -count=1` pass; `-race` on carver + journal pass. Net −83 lines in the journal.

Three fresh-context reviews: all APPROVE.