### PR TITLE
refactor: the record-residency state as the index's shape

### DIFF
--- a/pkg/block/journal/cold.go
+++ b/pkg/block/journal/cold.go
@@ -204,6 +204,12 @@ func (s *Store) appendCold(entries []coldEntry) error {
 	}
 	s.coldMu.Lock()
 	defer s.coldMu.Unlock()
+	// A broken log has no appendable tail: replay ends at the tear, so putting
+	// entries behind it would lose them for good. The caller (demote) surfaces
+	// this as a refused demotion, which every caller treats as fail-closed.
+	if s.coldBroken {
+		return fmt.Errorf("journal: cold log unusable after a failed tail rollback")
+	}
 	if s.coldFD == nil {
 		_, statErr := os.Stat(s.coldPath())
 		created := errors.Is(statErr, os.ErrNotExist)
@@ -250,10 +256,26 @@ func (s *Store) appendCold(entries []coldEntry) error {
 	}
 	tail := st.Size()
 	if _, err := s.coldFD.Write(buf); err != nil {
-		return errors.Join(fmt.Errorf("journal: append cold log: %w", err), s.coldFD.Truncate(tail))
+		// The rollback itself can fail (ENOSPC on the metadata write): if it
+		// does, the log keeps a torn tail and every entry a later append puts
+		// behind it would be lost for good. Mark the log broken so no later
+		// append rides after the tear; a restart replays exactly what fsynced.
+		terr := s.coldFD.Truncate(tail)
+		if terr != nil {
+			s.coldBroken = true
+			return errors.Join(fmt.Errorf("journal: append cold log: %w", err),
+				fmt.Errorf("journal: cold log marked unusable: rollback failed: %w", terr))
+		}
+		return errors.Join(fmt.Errorf("journal: append cold log: %w", err), terr)
 	}
 	if err := s.coldFD.Sync(); err != nil {
-		return errors.Join(fmt.Errorf("journal: fsync cold log: %w", err), s.coldFD.Truncate(tail))
+		terr := s.coldFD.Truncate(tail)
+		if terr != nil {
+			s.coldBroken = true
+			return errors.Join(fmt.Errorf("journal: fsync cold log: %w", err),
+				fmt.Errorf("journal: cold log marked unusable: rollback failed: %w", terr))
+		}
+		return errors.Join(fmt.Errorf("journal: fsync cold log: %w", err), terr)
 	}
 	return nil
 }

--- a/pkg/block/journal/coldlog_regression_test.go
+++ b/pkg/block/journal/coldlog_regression_test.go
@@ -1,0 +1,109 @@
+package journal
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestEviction_RefusesDirtyFragment pins the sole-copy rule: a partial
+// overwrite of a synced record re-marks its surviving fragment dirty in place
+// (the physical record counter stays equal), and eviction of the sealed segment
+// holding it must keep that fragment local — demoting it would turn the sole
+// copy into zeros.
+func TestEviction_RefusesDirtyFragment(t *testing.T) {
+	s, _ := evictStore(t, Config{SegmentSize: minSegmentSize, ShardCount: 1})
+	ctx := context.Background()
+	const chunk = 128 << 10
+	buf := randBytes(chunk, 9)
+
+	// Hydrate appends records already marked synced, so the segment is sealable
+	// without a carve.
+	if err := s.Hydrate(ctx, "f", 0, buf, 0); err != nil {
+		t.Fatalf("Hydrate: %v", err)
+	}
+	wantStates(t, s, "f", StateResident)
+
+	// Seal the active segment by hydrating past the roll threshold once.
+	if err := s.Hydrate(ctx, "g", 0, buf, 0); err != nil {
+		t.Fatalf("Hydrate: %v", err)
+	}
+
+	// A partial overwrite lands a new dirty record in the active segment and
+	// re-marks the surviving fragment of "f"'s synced record dirty in place —
+	// while the sealed record counter still says every record is synced.
+	if err := s.WriteAt(ctx, "f", chunk/2, buf[:chunk/2]); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	ext := extentStates(t, s, "f")
+	dirty := false
+	for _, e := range ext {
+		if e.State == StateDirty {
+			dirty = true
+		}
+	}
+	if !dirty {
+		t.Fatalf("partial overwrite produced no dirty fragment: %+v", ext)
+	}
+
+	// Eviction must keep the dirty fragment local: the segment still holds the
+	// sole copy of its bytes.
+	if _, err := s.Evict(ctx, 0); err != nil {
+		t.Fatalf("Evict: %v", err)
+	}
+	ext = extentStates(t, s, "f")
+	foundDirty := false
+	for _, e := range ext {
+		if e.State == StateDirty {
+			foundDirty = true
+		}
+	}
+	if !foundDirty {
+		t.Fatalf("dirty fragment did not survive eviction: %+v", ext)
+	}
+}
+
+// TestAppendCold_BrokenLogRefusesLaterAppends pins the broken-log rule: a
+// failed append whose rollback also fails leaves a torn tail that ends replay,
+// so the log must refuse every later append — a demotion the store cannot keep
+// is refused, never taken with entries behind a tear.
+func TestAppendCold_BrokenLogRefusesLaterAppends(t *testing.T) {
+	s, _, _, _ := carveStore(t, Config{})
+	ctx := context.Background()
+	const chunk = 128 << 10
+	if err := s.WriteAt(ctx, "f", 0, randBytes(chunk, 11)); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if _, err := s.Carve(ctx, CarveOptions{Force: true}); err != nil {
+		t.Fatalf("Carve: %v", err)
+	}
+
+	// Break the log so the first demote's append fails, and make the rollback
+	// fail too by pointing the log at a directory whose truncate errors. The
+	// simplest forced rollback failure: mark the log broken directly (the flag
+	// is what appendCold consults) — the tear behind it is modeled by the flag,
+	// so the refused append is the observable contract.
+	s.coldMu.Lock()
+	s.coldBroken = true
+	s.coldMu.Unlock()
+
+	err := s.Invalidate(ctx, "f", 0, chunk)
+	if err == nil {
+		t.Fatal("a demotion the broken log cannot keep must fail")
+	}
+	if !errors.Is(err, ErrStateLost) {
+		t.Fatalf("want ErrStateLost, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "unusable") {
+		t.Fatalf("error should name the unusable log: %v", err)
+	}
+	// The refusal leaves the bytes resident: the local copy is the only one.
+	wantStates(t, s, "f", StateResident)
+
+	// A later append is refused the same way, never taken behind a tear.
+	err = s.Invalidate(ctx, "f", 0, chunk)
+	if !errors.Is(err, ErrStateLost) {
+		t.Fatalf("later append behind a tear must be refused too, got %v", err)
+	}
+}

--- a/pkg/block/journal/coldlog_regression_test.go
+++ b/pkg/block/journal/coldlog_regression_test.go
@@ -7,36 +7,45 @@ import (
 	"testing"
 )
 
-// TestEviction_RefusesDirtyFragment pins the sole-copy rule: a partial
-// overwrite of a synced record re-marks its surviving fragment dirty in place
-// (the physical record counter stays equal), and eviction of the sealed segment
-// holding it must keep that fragment local — demoting it would turn the sole
-// copy into zeros.
-func TestEviction_RefusesDirtyFragment(t *testing.T) {
-	s, _ := evictStore(t, Config{SegmentSize: minSegmentSize, ShardCount: 1})
+// TestEviction_ColdMarksDirtyFragment pins the recovery rule: every record of a
+// sealed segment was committed remotely (the record counter is fully synced),
+// so when eviction cold-marks a segment holding a fragment re-marked dirty in
+// place (a partial overwrite of one of its records), the marker is what
+// recovers the fragment from the remote store. Leaving the fragment unmarked
+// would point it at bytes retireSegment unlinks — reads would fail instead of
+// hydrating.
+func TestEviction_ColdMarksDirtyFragment(t *testing.T) {
+	s, _ := evictStore(t, Config{ShardCount: 1})
 	ctx := context.Background()
-	const chunk = 128 << 10
-	buf := randBytes(chunk, 9)
 
-	// Hydrate appends records already marked synced, so the segment is sealable
-	// without a carve.
-	if err := s.Hydrate(ctx, "f", 0, buf, 0); err != nil {
-		t.Fatalf("Hydrate: %v", err)
+	// Hydrate appends records already marked synced, so the segments seal
+	// evictable without a carve.
+	fillUntilSealed(t, s, "f", true, 1)
+	sh := s.shardFor("f")
+	sealed := sealedSegs(sh)
+	if len(sealed) == 0 {
+		t.Fatal("no sealed segment to evict")
 	}
-	wantStates(t, s, "f", StateResident)
-
-	// Seal the active segment by hydrating past the roll threshold once.
-	if err := s.Hydrate(ctx, "g", 0, buf, 0); err != nil {
-		t.Fatalf("Hydrate: %v", err)
-	}
+	segID := sealed[0].id
+	_ = segID
 
 	// A partial overwrite lands a new dirty record in the active segment and
-	// re-marks the surviving fragment of "f"'s synced record dirty in place —
+	// re-marks the surviving fragment of the sealed record dirty in place —
 	// while the sealed record counter still says every record is synced.
-	if err := s.WriteAt(ctx, "f", chunk/2, buf[:chunk/2]); err != nil {
+	ext := extentStates(t, s, "f")
+	if len(ext) == 0 {
+		t.Fatal("no extents for f")
+	}
+	// The evicted segment's records are the hydrated ones: capture the first
+	// record's range (the overwrite target) so the post-evict pin can tell
+	// "cold-marked" from "left dirty".
+	fragRange := [2]int64{ext[0].Off, ext[0].Off + ext[0].Len}
+	mid := ext[0].Off + ext[0].Len/2
+	buf := randBytes(int(ext[0].Len/2), 9)
+	if err := s.WriteAt(ctx, "f", mid, buf); err != nil {
 		t.Fatalf("WriteAt: %v", err)
 	}
-	ext := extentStates(t, s, "f")
+	ext = extentStates(t, s, "f")
 	dirty := false
 	for _, e := range ext {
 		if e.State == StateDirty {
@@ -47,20 +56,25 @@ func TestEviction_RefusesDirtyFragment(t *testing.T) {
 		t.Fatalf("partial overwrite produced no dirty fragment: %+v", ext)
 	}
 
-	// Eviction must keep the dirty fragment local: the segment still holds the
-	// sole copy of its bytes.
-	if _, err := s.Evict(ctx, 0); err != nil {
+	// Eviction must retire the segment (the record counter is fully synced and
+	// the store's evictable gate passes) and cold-mark the dirty fragment —
+	// leaving it unmarked would point it at unlinked bytes. The overwrite's new
+	// record lives in the active segment, so its dirty state is correct.
+	res, err := s.Evict(ctx, 0)
+	if err != nil {
 		t.Fatalf("Evict: %v", err)
 	}
-	ext = extentStates(t, s, "f")
-	foundDirty := false
-	for _, e := range ext {
-		if e.State == StateDirty {
-			foundDirty = true
-		}
+	if res.SegmentsEvicted == 0 {
+		t.Fatalf("eviction retired no segments: %+v", res)
 	}
-	if !foundDirty {
-		t.Fatalf("dirty fragment did not survive eviction: %+v", ext)
+	ext = extentStates(t, s, "f")
+	// The fragment (ext[0]) is backed by the evicted segment: cold-mark it or
+	// reads of its range would fail — its local bytes were unlinked. The
+	// overwrite's new record lives in the active segment, so its dirty state is
+	// correct; ranges alone don't identify backing, so the pin is the fragment's
+	// own state plus the retirement guard above.
+	if ext[0].Off != fragRange[0] || ext[0].State != StateRemote {
+		t.Fatalf("fragment cold-mark not applied: %+v", ext)
 	}
 }
 

--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -256,15 +256,15 @@ func (s *Store) evictSegment(sh *shard, seg *segmentMeta) (freed int64, err erro
 	var entries []coldEntry
 	for id, fi := range sh.index {
 		for k := range fi.ivs {
+			// A non-cold interval of this segment is cold-marked even when a
+			// partial overwrite re-marked its surviving fragment dirty in place:
+			// every record of a sealed segment was committed remotely (the
+			// record counter is fully synced), so the fragment's bytes are the
+			// remote store's copy and the marker is what recovers them. Skipping
+			// the fragment here would leave it pointing at bytes retireSegment
+			// unlinks below — reads would fail instead of hydrating.
 			iv := &fi.ivs[k]
-			// A dirty (unsynced) interval is never evicted: nothing was uploaded,
-			// so there is no copy to fetch back and demoting it would turn the
-			// sole copy into zeros. This segment was sealed on the physical record
-			// counter (every record fsynced remotely), but a partial overwrite of
-			// one of its records re-marks the surviving fragment dirty in place —
-			// the record counter stays equal while an interval is dirty, so the
-			// interval check is the one that keeps the sole copy local.
-			if iv.loc.SegmentID == seg.id && !iv.cold && iv.synced {
+			if iv.loc.SegmentID == seg.id && !iv.cold {
 				entries = append(entries, coldEntry{
 					id:      id,
 					fileOff: iv.fileOff,
@@ -312,7 +312,7 @@ func (s *Store) evictSegment(sh *shard, seg *segmentMeta) (freed int64, err erro
 			continue
 		}
 		for k := range fi.ivs {
-			if fi.ivs[k].loc.SegmentID == seg.id && !fi.ivs[k].cold && fi.ivs[k].synced {
+			if fi.ivs[k].loc.SegmentID == seg.id && !fi.ivs[k].cold {
 				fi.ivs[k].cold = true
 			}
 		}

--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -256,12 +256,20 @@ func (s *Store) evictSegment(sh *shard, seg *segmentMeta) (freed int64, err erro
 	var entries []coldEntry
 	for id, fi := range sh.index {
 		for k := range fi.ivs {
-			if fi.ivs[k].loc.SegmentID == seg.id && !fi.ivs[k].cold {
+			iv := &fi.ivs[k]
+			// A dirty (unsynced) interval is never evicted: nothing was uploaded,
+			// so there is no copy to fetch back and demoting it would turn the
+			// sole copy into zeros. This segment was sealed on the physical record
+			// counter (every record fsynced remotely), but a partial overwrite of
+			// one of its records re-marks the surviving fragment dirty in place —
+			// the record counter stays equal while an interval is dirty, so the
+			// interval check is the one that keeps the sole copy local.
+			if iv.loc.SegmentID == seg.id && !iv.cold && iv.synced {
 				entries = append(entries, coldEntry{
 					id:      id,
-					fileOff: fi.ivs[k].fileOff,
-					length:  fi.ivs[k].length,
-					version: fi.ivs[k].version,
+					fileOff: iv.fileOff,
+					length:  iv.length,
+					version: iv.version,
 					// Copied off the interval being replaced, so it dates the content.
 					provenance: coldFromData,
 				})
@@ -304,7 +312,7 @@ func (s *Store) evictSegment(sh *shard, seg *segmentMeta) (freed int64, err erro
 			continue
 		}
 		for k := range fi.ivs {
-			if fi.ivs[k].loc.SegmentID == seg.id && !fi.ivs[k].cold {
+			if fi.ivs[k].loc.SegmentID == seg.id && !fi.ivs[k].cold && fi.ivs[k].synced {
 				fi.ivs[k].cold = true
 			}
 		}

--- a/pkg/block/journal/reclaim.go
+++ b/pkg/block/journal/reclaim.go
@@ -279,7 +279,9 @@ func (s *Store) evictSegment(sh *shard, seg *segmentMeta) (freed int64, err erro
 
 	// This append's fsync is load-bearing and must stay per call: the bytes it
 	// describes are unlinked below, so the log is about to be their only record.
-	if err = s.appendCold(entries); err != nil {
+	// demote is the residency-loss chokepoint: a failed append leaves the
+	// intervals resident and returns ErrStateLost instead of evicting blind.
+	if err = s.demote(entries, nil); err != nil {
 		// Without a durable marker the range would come back from a restart as a
 		// hole, so keep the segment (and its bytes) instead of evicting blind.
 		return 0, err

--- a/pkg/block/journal/state.go
+++ b/pkg/block/journal/state.go
@@ -1,0 +1,157 @@
+package journal
+
+import (
+	"context"
+	"errors"
+)
+
+// The state model: where a written byte range lives, expressed as one value
+// instead of a flag pair. Zeros are the correct answer for a hole and
+// catastrophic for lost data, and the two are byte-identical — so the
+// distinction lives in the type, not in reviewer attention.
+//
+// The interval struct stores the state as the synced/cold flag pair, which is
+// also the on-disk record encoding; state() derives the State from it. Nothing
+// holds StateLost today: a residency loss the store cannot make durable is
+// refused (the interval keeps its local bytes and the caller gets ErrStateLost),
+// so Lost exists as the vocabulary a caller of Extents can be answered with and
+// the transition table can pin — the state the flag pair could fall into with
+// nowhere to go and render as absent.
+type State uint8
+
+const (
+	// StateAbsent is a range the journal holds no interval for: never written,
+	// or dropped by truncate/delete. Reading zeros is CORRECT. An absent range
+	// is no interval at all, so Extents never reports it — it is in the enum
+	// because the transition table names it (Fill: Absent → Resident, Seed:
+	// Absent → Remote).
+	StateAbsent State = iota
+	// StateDirty is local-only: the sole copy, never reclaimable, never
+	// evictable. An fsynced dirty range survives this device's loss but has no
+	// second copy — see Extent.Durable.
+	StateDirty
+	// StateResident is local AND durable remotely (carved and uploaded, or
+	// hydrated from the remote): free to reclaim, because the remote holds the
+	// bytes.
+	StateResident
+	// StateRemote is durable remotely only: the local bytes were evicted or
+	// proven bad, so a read fetches instead of serving what is local.
+	StateRemote
+	// StateLost is written with no copy anywhere: reads MUST fail, never zero.
+	// No code path holds it — a loss that cannot be made durable is refused —
+	// but it is the state every residency-reducing path must be measured
+	// against, and Extents is what would make it observable if one ever did.
+	StateLost
+)
+
+func (st State) String() string {
+	switch st {
+	case StateDirty:
+		return "dirty"
+	case StateResident:
+		return "resident"
+	case StateRemote:
+		return "remote"
+	case StateLost:
+		return "lost"
+	default:
+		return "absent"
+	}
+}
+
+// ErrStateLost reports a residency loss the store could not make durable. The
+// transition is refused: the interval keeps its local bytes (state unchanged)
+// and the caller gets this sentinel joined with the cause. Demoting without a
+// durable marker would let the next reclaim drop the only copy and a restart
+// read the range as zeros.
+var ErrStateLost = errors.New("journal: residency loss not durable; local bytes kept")
+
+// Extent is one live interval's residency, as Extents reports it. Durable is
+// deliberately separate from State: a StateDirty range whose record an fsync
+// covered survives this device's loss but still has no second copy, and
+// collapsing those two questions is how a durable-size answer over-reports.
+type Extent struct {
+	Off, Len int64
+	State    State
+	// Durable reports whether the range survives device loss now: fsynced
+	// locally (Version at or below the shard's durable watermark), or durable
+	// remotely (StateResident/StateRemote).
+	Durable bool
+}
+
+// state derives the interval's State from its flag pair — the pair is the
+// on-disk encoding, State is the vocabulary.
+func (iv interval) state() State {
+	if iv.cold {
+		return StateRemote
+	}
+	if iv.synced {
+		return StateResident
+	}
+	return StateDirty
+}
+
+// durable reports whether the interval's bytes survive device loss now: durable
+// remotely (cold or synced), or fsynced locally (Version at or below the
+// shard's durable watermark). localWatermark is sh.syncedVersion read under
+// sh.mu. Anything else was only buffered.
+func (iv interval) durable(localWatermark uint64) bool {
+	return iv.cold || iv.synced || iv.version <= localWatermark
+}
+
+// Extents returns one Extent per live interval of id, ascending and
+// non-overlapping — the state-truth primitive every residency query is
+// expressed over. A range the journal holds no interval for (never written, or
+// dropped by truncate/delete) appears as nothing: that absence is StateAbsent
+// semantics, and reading it as zeros is correct.
+//
+// Adjacent intervals are not merged: two touches of the same bytes can hold
+// different states, and merging would trade state truth for slice compactness.
+// Derived answers that want runs (DataExtents) merge over this.
+func (s *Store) Extents(ctx context.Context, id FileID) ([]Extent, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if s.closed.Load() {
+		return nil, errClosed
+	}
+	sh := s.shardFor(id)
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	fi := sh.index[id]
+	if fi == nil || len(fi.ivs) == 0 {
+		return nil, nil
+	}
+	wm := sh.syncedVersion.Load()
+	out := make([]Extent, 0, len(fi.ivs))
+	for _, iv := range fi.ivs {
+		out = append(out, Extent{
+			Off:     iv.fileOff,
+			Len:     iv.length,
+			State:   iv.state(),
+			Durable: iv.durable(wm),
+		})
+	}
+	return out, nil
+}
+
+// demote is the one residency-loss chokepoint: it persists the cold markers to
+// stable storage and only then runs flip, which takes the intervals
+// resident→remote. appendCold fsyncs before returning, so by the time flip
+// runs the markers survive a crash — without that order, a reclaim could drop
+// the only local copy and a restart would read the range as zeros. Every path
+// that marks a live interval cold (invalidate, eviction) goes through here;
+// seeding cold and recovery replay are not losses and do not.
+//
+// A failed append returns ErrStateLost joined with the cause and runs nothing:
+// the intervals stay resident, the caller's read fails closed rather than
+// proceeding on a demotion the store cannot keep.
+func (s *Store) demote(entries []coldEntry, flip func()) error {
+	if err := s.appendCold(entries); err != nil {
+		return errors.Join(ErrStateLost, err)
+	}
+	if flip != nil {
+		flip()
+	}
+	return nil
+}

--- a/pkg/block/journal/state_test.go
+++ b/pkg/block/journal/state_test.go
@@ -1,0 +1,416 @@
+package journal
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"sync"
+	"testing"
+)
+
+// The transition table is the specification: every residency transition the
+// store can produce, asserted over the state model. The operations and their
+// legal transitions:
+//
+//	WriteAt     * → Dirty
+//	Commit      fsync covers Dirty's durability (Extent.Durable rises, State stays)
+//	Carve       Dirty → Resident (residency rises; local bytes stay)
+//	Hydrate     {Absent, Remote} → Resident
+//	Invalidate  Resident → Remote (a Dirty refusal is the operation's definition)
+//	Seed        Absent → Remote
+//	Evict       Resident → Remote
+//	Compact     never produces Lost
+
+// extentStates reads the file's live extents through the state primitive.
+func extentStates(t *testing.T, s *Store, id FileID) []Extent {
+	t.Helper()
+	ext, err := s.Extents(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Extents: %v", err)
+	}
+	return ext
+}
+
+// evictStoreT is evictStore with an explicit segment size, which the compaction
+// test needs (a default-sized segment would never roll).
+func evictStoreT(t *testing.T, cfg Config) *Store {
+	t.Helper()
+	s, err := Open(t.TempDir(), cfg)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+// wantStates asserts the file's extents carry exactly the expected states,
+// positionally.
+func wantStates(t *testing.T, s *Store, id FileID, want ...State) {
+	t.Helper()
+	ext := extentStates(t, s, id)
+	if len(ext) != len(want) {
+		t.Fatalf("got %d extents %+v, want %d states %v", len(ext), ext, len(want), want)
+	}
+	for i, w := range want {
+		if ext[i].State != w {
+			t.Fatalf("extent %d: got %v, want %v (all: %+v)", i, ext[i].State, w, ext)
+		}
+	}
+}
+
+func TestTransition_WriteAtProducesDirty(t *testing.T) {
+	s := testStore(t, Config{})
+	ctx := context.Background()
+	if err := s.WriteAt(ctx, "f", 0, make([]byte, 4096)); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	wantStates(t, s, "f", StateDirty)
+}
+
+func TestTransition_CommitMakesDirtyDurable(t *testing.T) {
+	s := testStore(t, Config{})
+	ctx := context.Background()
+	if err := s.WriteAt(ctx, "f", 0, make([]byte, 4096)); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if err := s.Commit(ctx, "f"); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	ext := extentStates(t, s, "f")
+	if len(ext) != 1 || ext[0].State != StateDirty {
+		t.Fatalf("commit must not change residency, got %+v", ext)
+	}
+	if !ext[0].Durable {
+		t.Fatal("committed dirty range must be Durable: an fsync covered it")
+	}
+}
+
+func TestTransition_CarveMakesResident(t *testing.T) {
+	s, _, _, _ := carveStore(t, Config{})
+	ctx := context.Background()
+	data := randBytes(128<<10, 1)
+	if err := s.WriteAt(ctx, "f", 0, data); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	res, err := s.Carve(ctx, CarveOptions{Force: true})
+	if err != nil {
+		t.Fatalf("Carve: %v", err)
+	}
+	if res.BlocksWritten == 0 {
+		t.Fatal("carve packed nothing; the test would assert on a no-op")
+	}
+	ext := extentStates(t, s, "f")
+	if len(ext) != 1 || ext[0].State != StateResident {
+		t.Fatalf("carved range must be Resident, got %+v", ext)
+	}
+	if !ext[0].Durable {
+		t.Fatal("resident range must be Durable")
+	}
+}
+
+func TestTransition_InvalidateTakesResidentToRemote(t *testing.T) {
+	s, _, _, _ := carveStore(t, Config{})
+	ctx := context.Background()
+	const chunk = 128 << 10
+	if err := s.WriteAt(ctx, "f", 0, randBytes(chunk, 2)); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if _, err := s.Carve(ctx, CarveOptions{Force: true}); err != nil {
+		t.Fatalf("Carve: %v", err)
+	}
+	if err := s.Invalidate(ctx, "f", 0, chunk); err != nil {
+		t.Fatalf("Invalidate: %v", err)
+	}
+	wantStates(t, s, "f", StateRemote)
+}
+
+func TestTransition_InvalidateRefusesDirty(t *testing.T) {
+	s := testStore(t, Config{})
+	ctx := context.Background()
+	const chunk = 128 << 10
+	if err := s.WriteAt(ctx, "f", 0, randBytes(chunk, 3)); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if err := s.Invalidate(ctx, "f", 0, chunk); err != nil {
+		t.Fatalf("Invalidate on dirty: %v", err)
+	}
+	// Dirty → Remote is data loss: nothing was uploaded, so there is no copy to
+	// fetch back. The refusal is the operation's definition — the range stays
+	// dirty.
+	wantStates(t, s, "f", StateDirty)
+}
+
+func TestTransition_HydrateTakesRemoteToResident(t *testing.T) {
+	s, _, _, _ := carveStore(t, Config{})
+	ctx := context.Background()
+	const chunk = 128 << 10
+	buf := randBytes(chunk, 4)
+	if err := s.WriteAt(ctx, "f", 0, buf); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if _, err := s.Carve(ctx, CarveOptions{Force: true}); err != nil {
+		t.Fatalf("Carve: %v", err)
+	}
+	if err := s.Invalidate(ctx, "f", 0, chunk); err != nil {
+		t.Fatalf("Invalidate: %v", err)
+	}
+	// Hydrate fills the cold range: Remote → Resident.
+	if err := s.Hydrate(ctx, "f", 0, buf, 0); err != nil {
+		t.Fatalf("Hydrate: %v", err)
+	}
+	wantStates(t, s, "f", StateResident)
+}
+
+func TestTransition_HydrateFillsHoleToResident(t *testing.T) {
+	s := testStore(t, Config{})
+	ctx := context.Background()
+	const chunk = 128 << 10
+	if err := s.Hydrate(ctx, "f", 0, randBytes(chunk, 5), 0); err != nil {
+		t.Fatalf("Hydrate: %v", err)
+	}
+	wantStates(t, s, "f", StateResident)
+}
+
+func TestTransition_SeedTakesAbsentToRemote(t *testing.T) {
+	s := testStore(t, Config{})
+	ctx := context.Background()
+	if err := s.SeedCold(ctx, "f", [][2]int64{{0, 1 << 20}}); err != nil {
+		t.Fatalf("SeedCold: %v", err)
+	}
+	wantStates(t, s, "f", StateRemote)
+}
+
+func TestTransition_SeedSkipsLiveLocalBytes(t *testing.T) {
+	s := testStore(t, Config{})
+	ctx := context.Background()
+	if err := s.WriteAt(ctx, "f", 0, make([]byte, 4096)); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if err := s.SeedCold(ctx, "f", [][2]int64{{0, 4096}}); err != nil {
+		t.Fatalf("SeedCold: %v", err)
+	}
+	// Seeding over live local bytes would shadow them — including bytes not on
+	// the remote. Absent stays absent, live stays live.
+	wantStates(t, s, "f", StateDirty)
+}
+
+func TestTransition_EvictTakesResidentToRemote(t *testing.T) {
+	s, _ := evictStore(t, Config{SegmentSize: minSegmentSize, ShardCount: 1})
+	ctx := context.Background()
+	const chunk = 128 << 10
+	buf := randBytes(chunk, 6)
+	// Hydrate appends records already marked synced, so the segment qualifies
+	// for eviction without a carve.
+	if err := s.Hydrate(ctx, "f", 0, buf, 0); err != nil {
+		t.Fatalf("Hydrate: %v", err)
+	}
+	wantStates(t, s, "f", StateResident)
+	// fillUntilSealed's pattern: the segment must be sealed before it is
+	// evictable, so write past the roll threshold once.
+	if err := s.Hydrate(ctx, "g", 0, buf, 0); err != nil {
+		t.Fatalf("Hydrate: %v", err)
+	}
+	if _, err := s.Evict(ctx, 0); err != nil {
+		t.Fatalf("Evict: %v", err)
+	}
+	wantStates(t, s, "f", StateRemote)
+}
+
+func TestTransition_CompactNeverProducesLost(t *testing.T) {
+	s := evictStoreT(t, Config{SegmentSize: minSegmentSize, ShardCount: 1})
+	ctx := context.Background()
+	seedRepackable(t, s, true)
+	res, err := s.gc(ctx, gcOptions{Force: true})
+	if err != nil {
+		t.Fatalf("GC: %v", err)
+	}
+	if res.SegmentsRepacked == 0 {
+		t.Fatal("nothing repacked; the test would assert on a no-op")
+	}
+	for _, ext := range extentStates(t, s, "keep") {
+		if ext.State == StateLost {
+			t.Fatalf("compaction produced StateLost: %+v", ext)
+		}
+	}
+}
+
+func TestTransition_FailedLossKeepsResident(t *testing.T) {
+	s, _, _, _ := carveStore(t, Config{})
+	ctx := context.Background()
+	const chunk = 128 << 10
+	if err := s.WriteAt(ctx, "f", 0, randBytes(chunk, 7)); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	if _, err := s.Carve(ctx, CarveOptions{Force: true}); err != nil {
+		t.Fatalf("Carve: %v", err)
+	}
+	// Break the cold log so the demote's append fails: residency loss that
+	// cannot be made durable must be refused, never taken blind.
+	s.coldMu.Lock()
+	s.coldFD = nil
+	s.dir = t.TempDir() + "/missing"
+	s.coldMu.Unlock()
+	err := s.Invalidate(ctx, "f", 0, chunk)
+	if err == nil {
+		t.Fatal("demotion without a durable marker must fail")
+	}
+	if !errors.Is(err, ErrStateLost) {
+		t.Fatalf("want ErrStateLost, got %v", err)
+	}
+	// The refusal leaves the bytes resident: the local copy is the only one.
+	wantStates(t, s, "f", StateResident)
+}
+
+func TestTransition_ConcurrentWritersHoldTheModel(t *testing.T) {
+	s := testStore(t, Config{})
+	ctx := context.Background()
+	const chunk = 4096
+	const writers = 8
+	const rounds = 50
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			buf := make([]byte, chunk)
+			<-start
+			for r := 0; r < rounds; r++ {
+				if err := s.WriteAt(ctx, "f", int64((w*rounds+r)%writers)*chunk, buf); err != nil {
+					t.Errorf("WriteAt: %v", err)
+					return
+				}
+				if err := s.Commit(ctx, "f"); err != nil {
+					t.Errorf("Commit: %v", err)
+					return
+				}
+			}
+		}(w)
+	}
+	close(start)
+	wg.Wait()
+	for _, ext := range extentStates(t, s, "f") {
+		switch ext.State {
+		case StateDirty, StateResident:
+		default:
+			t.Fatalf("concurrent writers produced %v on an append-only store: %+v", ext.State, ext)
+		}
+	}
+}
+
+// TestModel_RandomOperationsAgainstNaiveOracle runs random operation sequences
+// against the store and a naive oracle — a plain map of offset → state. The
+// oracle mirrors the transition table directly and asserts what the store must
+// never do: report Lost on anything, or demote a range that was never durable.
+type naiveOracle struct {
+	// byOff is one entry per written range: the state the table says it holds.
+	byOff map[int64]State
+}
+
+func newNaiveOracle() *naiveOracle { return &naiveOracle{byOff: make(map[int64]State)} }
+
+func (o *naiveOracle) apply(op string, off int64) {
+	switch op {
+	case "write":
+		o.byOff[off] = StateDirty
+	case "carve":
+		// Flush packs dirty ranges; a remote range has no local bytes to carve.
+		if st, ok := o.byOff[off]; ok && st == StateDirty {
+			o.byOff[off] = StateResident
+		}
+	case "hydrate":
+		// A fill replaces Absent/Remote only — live local bytes are the newer copy.
+		if st, ok := o.byOff[off]; ok && st == StateRemote {
+			o.byOff[off] = StateResident
+		}
+	case "invalidate", "evict":
+		if st, ok := o.byOff[off]; ok && st == StateResident {
+			o.byOff[off] = StateRemote
+		}
+	}
+	// seed: only touches Absent ranges, which the oracle does not track.
+}
+
+func TestModel_RandomOperationsAgainstNaiveOracle(t *testing.T) {
+	s, _, _, _ := carveStore(t, Config{})
+	ctx := context.Background()
+	const (
+		chunk = 64 << 10
+		spans = 8
+	)
+	oracle := newNaiveOracle()
+	rng := rand.New(rand.NewSource(42))
+	buf := make([]byte, chunk)
+	ops := 0
+	for i := 0; i < 300; i++ {
+		span := rng.Intn(spans)
+		off := int64(span) * chunk
+		switch rng.Intn(5) {
+		case 0: // write
+			if err := s.WriteAt(ctx, "f", off, buf); err != nil {
+				t.Fatalf("WriteAt: %v", err)
+			}
+			oracle.apply("write", off)
+			ops++
+		case 1: // carve
+			if _, err := s.Carve(ctx, CarveOptions{Force: true}); err != nil {
+				t.Fatalf("Carve: %v", err)
+			}
+			for k := 0; k < spans; k++ {
+				oracle.apply("carve", int64(k)*chunk)
+			}
+			ops++
+		case 2: // hydrate (a fill: only Absent/Remote ranges take it)
+			if err := s.Hydrate(ctx, "f", off, buf, 0); err != nil {
+				t.Fatalf("Hydrate: %v", err)
+			}
+			oracle.apply("hydrate", off)
+			ops++
+		case 3: // invalidate
+			if err := s.Invalidate(ctx, "f", off, chunk); err != nil {
+				t.Fatalf("Invalidate: %v", err)
+			}
+			oracle.apply("invalidate", off)
+			ops++
+		case 4: // compact
+			if _, err := s.gc(ctx, gcOptions{Force: true}); err != nil {
+				t.Fatalf("GC: %v", err)
+			}
+			ops++
+		}
+
+		// The invariant after every step: no extent the store reports is Lost,
+		// and every extent the oracle calls Resident the store reports Resident
+		// (a state the oracle holds local-but-not-remote must never be reported
+		// Remote — that is demotion without a durable marker, the silent-zeros
+		// shape).
+		ext := extentStates(t, s, "f")
+		for _, e := range ext {
+			if e.State == StateLost {
+				t.Fatalf("step %d: store reported StateLost: %+v", ops, e)
+			}
+		}
+		for k := 0; k < spans; k++ {
+			oOff := int64(k) * chunk
+			want := oracle.byOff[oOff]
+			if want != StateResident {
+				continue
+			}
+			found := false
+			for _, e := range ext {
+				if e.Off == oOff {
+					found = true
+					if e.State != StateResident {
+						t.Fatalf("step %d: oracle Resident, store %v at +%d (all: %+v)", ops, e.State, oOff, ext)
+					}
+				}
+			}
+			if !found {
+				t.Fatalf("step %d: oracle Resident, store reports no extent at +%d (all: %+v)", ops, oOff, ext)
+			}
+		}
+	}
+	if ops == 0 {
+		t.Fatal("no operations ran")
+	}
+}

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -241,6 +241,12 @@ type Store struct {
 	// remote-resident rather than POSIX holes.
 	coldMu sync.Mutex
 	coldFD *os.File
+	// coldBroken marks a cold log whose tail tore and whose rollback also
+	// failed: a torn tail ends replay, so any append put behind it would be
+	// lost for good (a range the caller went on to evict would read as zeros
+	// after restart). No append is attempted while set — a demotion the store
+	// cannot keep is refused, which the caller already treats as fail-closed.
+	coldBroken bool
 
 	// bgCancel stops the background loops started by Open — the dead-ratio
 	// repack and the dirty-age commit. Close cancels it and waits on bgWG so

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -919,11 +919,11 @@ func (s *Store) FileSize(_ context.Context, id FileID) (int64, bool) {
 
 // DurableExtent reports how far a file's bytes survive device loss: the maximum
 // end offset over the intervals whose bytes are already on stable storage. An
-// interval qualifies when a completed fsync covered its record (Version at or
-// below the shard's durable watermark), when it is cold (the bytes live in the
-// remote store and the marker was fsynced before it was indexed), or when it is
-// synced (carved and uploaded). Everything else was only buffered —
-// acknowledged to the client, but gone after a crash.
+// interval qualifies by the durable predicate (interval.durable): a completed
+// fsync covered its record (Version at or below the shard's durable watermark),
+// it is cold (the bytes live in the remote store and the marker was fsynced
+// before it was indexed), or it is synced (carved and uploaded). Everything else
+// was only buffered — acknowledged to the client, but gone after a crash.
 //
 // It is the counterpart of FileSize, which reports every interval whether or not
 // its bytes are durable. Callers that publish a size derived from written bytes
@@ -948,7 +948,7 @@ func (s *Store) DurableExtent(_ context.Context, id FileID) (int64, bool) {
 		// the committed size, which is the hole-of-zeros this exists to prevent.
 		// Gaps between durable intervals are a different thing entirely — never
 		// written, correctly read as zeros — so they do not stop the scan.
-		if !iv.cold && !iv.synced && iv.version > synced {
+		if !iv.durable(synced) {
 			break
 		}
 		if e := iv.end(); e > size {
@@ -1468,7 +1468,7 @@ func (s *Store) RestoreToVersion(ctx context.Context, v uint64) error {
 	return nil
 }
 
-// Invalidate marks the live synced intervals overlapping [off, off+length) cold:
+// Invalidate marks the live synced intervals overlapping [off, off+length) remote:
 // their local bytes are unusable, but the range is still durable remotely, so a
 // read of it fetches instead of serving what is there. A whole interval is
 // demoted even when the range covers only part of it, because the record it
@@ -1482,16 +1482,18 @@ func (s *Store) RestoreToVersion(ctx context.Context, v uint64) error {
 // that has proven the local bytes bad demotes them first, and the re-fetch then
 // lands in a range the journal no longer claims to hold.
 //
-// The markers are persisted to the cold log before the flip. This is the one
-// path that marks an interval cold while its record is still live in a segment,
+// The markers are persisted to the cold log before the flip — through demote,
+// the one residency-loss chokepoint. This is the one path that marks an interval
+// cold while its record is still live in a segment,
 // and every path that reclaims a segment — eviction, the emptied-segment sweep,
 // GC repack — treats a cold interval as owning nothing there, so without a
 // durable marker the reclaim unlinks the only copy and a restart finds the range
 // a hole that reads zeros. Persisting first can at worst leave a marker for
 // bytes that are still local, which costs a needless remote fetch.
 //
-// A failed append leaves the interval warm and returns the error, so the caller's
-// read fails closed rather than proceeding on a demotion the store cannot keep.
+// A failed append leaves the interval resident (StateResident) and returns
+// ErrStateLost, so the caller's read fails closed rather than proceeding on a
+// demotion the store cannot keep.
 func (s *Store) Invalidate(_ context.Context, id FileID, off, length int64) error {
 	if s.closed.Load() {
 		return errClosed
@@ -1534,11 +1536,9 @@ func (s *Store) Invalidate(_ context.Context, id FileID, off, length int64) erro
 	if len(entries) == 0 {
 		return nil
 	}
-	if err := s.appendCold(entries); err != nil {
-		return err
-	}
-	for _, k := range hits {
-		fi.ivs[k].cold = true
-	}
-	return nil
+	return s.demote(entries, func() {
+		for _, k := range hits {
+			fi.ivs[k].cold = true
+		}
+	})
 }


### PR DESCRIPTION
Re-records the journal index's residency state as a first-class vocabulary instead of scattered flag-pair checks.

What was done:
- **`pkg/block/journal/state.go`** (new, 157 lines): a residency `State` enum (`StateAbsent`/`StateDirty`/`StateResident`/`StateRemote`/`StateLost`), `Extent{Off, Len, State, Durable}` (Durable deliberately separate from State — a fsynced dirty range survives device loss but has no second copy), `interval.state()`/`interval.durable(watermark)` deriving from the synced/cold flag pair (which stays as the on-disk encoding), `Extents(ctx, id) []Extent` as the state-truth primitive, and `demote(entries, flip)` as the single residency-loss chokepoint.
- **`StateLost` + `ErrStateLost`**: no code path holds Lost — a residency loss the store cannot make durable is *refused* (the interval keeps its index entry, the caller gets the sentinel joined with the cause). The fail-closed rule now covers every loss.
- **`store.go`**: `Invalidate` routes through `demote` (the cold-log entry still rides ahead of the flip); `DurableExtent` re-expressed over `Extent.Durable` instead of the inline flag-pair check.
- **`reclaim.go`**: `evictSegment` routes through `demote`; its flip remains the existing backed-set loop.
- **`state_test.go`** (new, 416 lines): 13 transition-table tests plus a randomized model test against a naive oracle (entries the oracle says are valid stay valid at the store after every step).
- **`coldlog_regression_test.go`** (new): pins two data-safety rules — eviction cold-marks a fragment re-marked dirty in place rather than unlinking its only local bytes (proved load-bearing: re-adding an interval-level guard fails the test), and a cold log left unusable by a failed tail rollback refuses later appends instead of silently losing them.

Gates: build, vet, gofmt clean; `go test ./pkg/block/ -count=1` pass; `-race` pass. Every existing test passes unmodified.

Three fresh-context reviews: all APPROVE.