### PR TITLE
fix(nfs): sync sidecar shutdown state outside the group lock

### DIFF
--- a/internal/adapter/nfs/portmap/server.go
+++ b/internal/adapter/nfs/portmap/server.go
@@ -67,7 +67,8 @@ func NewServer(cfg ServerConfig) *Server {
 
 // Serve starts the portmapper server on both TCP and UDP.
 // It blocks until the context is cancelled or Stop is called.
-// After both TCP and UDP listeners are bound, WaitReady() unblocks.
+// After both TCP and UDP listeners are bound and every goroutine is launched,
+// WaitReady() unblocks.
 func (s *Server) Serve(ctx context.Context) error {
 	addr := fmt.Sprintf(":%d", s.config.Port)
 
@@ -99,12 +100,10 @@ func (s *Server) Serve(ctx context.Context) error {
 		s.udpConn = udpConn
 	}
 
-	// Signal that listeners are ready
-	close(s.listenerReady)
-
-	logger.Info("Portmapper server started", "address", addr, "tcp", s.config.EnableTCP, "udp", s.config.EnableUDP)
-
-	// Launch TCP and UDP goroutines
+	// Signal that listeners are ready — AFTER the serve goroutines and the
+	// cancellation monitor are launched, so a caller that observes readiness
+	// (WaitReady) knows all wg.Adds are done and Stop's wg.Wait sees the true
+	// counter instead of returning at zero (or racing the concurrent Add).
 	if s.config.EnableTCP {
 		s.wg.Add(1)
 		go s.serveTCP(ctx)
@@ -122,6 +121,8 @@ func (s *Server) Serve(ctx context.Context) error {
 		case <-s.shutdown:
 		}
 	}()
+
+	close(s.listenerReady)
 
 	// Block until both goroutines complete
 	s.wg.Wait()

--- a/pkg/adapter/nfs/adapter.go
+++ b/pkg/adapter/nfs/adapter.go
@@ -137,13 +137,15 @@ type NFSAdapter struct {
 	// auxservices.go.
 	sidecars *auxsvc.Group
 
+	// sidecarMu guards the sidecar shutdown state published by Start and read
+	// by Stop and the NLM async-result send path (portmapServer, udpConn): the
+	// group runs Start outside its lock, so a disable can steal a mid-bind
+	// reservation and tear down concurrently.
+	sidecarMu sync.Mutex
+
 	// portmapServer is the embedded portmapper server (RFC 1057).
 	// nil when portmapper is disabled.
 	portmapServer *portmap.Server
-
-	// portmapRegistry holds the portmap service registry.
-	// nil when portmapper is disabled.
-	portmapRegistry *portmap.Registry
 
 	// sysregActive is true once DittoFS's services have been registered with the
 	// host's system rpcbind (adapters.nfs.portmapper.register_with_system), so
@@ -164,6 +166,12 @@ type NFSAdapter struct {
 	// udpConn is the UDP listener serving NLM/NSM/MOUNT when the UDP transport
 	// is enabled (adapters.nfs.udp.enabled). nil when UDP is disabled.
 	udpConn *net.UDPConn
+
+	// udpStop cancels the current UDP generation's shutdown context (the one
+	// that closes udpConn on teardown). Published with udpConn under sidecarMu;
+	// claimed-and-cleared by udpSidecar.Stop so each generation's waiter fires
+	// exactly once and no waiter parks until adapter shutdown after a toggle.
+	udpStop context.CancelFunc
 
 	// nsmClientStore persists client registrations for crash recovery
 	nsmClientStore lock.ClientRegistrationStore

--- a/pkg/adapter/nfs/auxservices.go
+++ b/pkg/adapter/nfs/auxservices.go
@@ -167,16 +167,30 @@ func (r sysregSidecar) Start(ctx context.Context) error {
 func (r sysregSidecar) Stop(context.Context) error { r.a.stopSystemPortmapRegistration(); return nil }
 
 // udpSidecar wraps the NLM/NSM/MOUNT-over-UDP transport. Start binds the socket
-// and launches the read loop; Stop closes the socket so the loop unblocks and
-// exits (startUDP also closes it on ctx cancel, so a double close is possible
-// and harmless).
+// and launches the read loop; Stop claims the conn and its shutdown cancel,
+// then closes the socket so the loop unblocks and exits (startUDP also closes
+// it when the per-generation ctx or the adapter ctx fires, so a double close
+// is possible and harmless).
 type udpSidecar struct{ a *NFSAdapter }
 
 func (u udpSidecar) Name() string                    { return "nfs-udp" }
 func (u udpSidecar) Start(ctx context.Context) error { return u.a.startUDP(ctx) }
 func (u udpSidecar) Stop(context.Context) error {
-	if u.a.udpConn != nil {
-		_ = u.a.udpConn.Close()
+	// Claim conn and cancel func together: each generation is stopped exactly
+	// once (a disable racing a re-enable can no longer snapshot the newer conn)
+	// and the per-generation shutdown ctx fires so the conn-close waiter and
+	// the read loop exit instead of parking until adapter shutdown.
+	u.a.sidecarMu.Lock()
+	udpConn := u.a.udpConn
+	udpStop := u.a.udpStop
+	u.a.udpConn = nil
+	u.a.udpStop = nil
+	u.a.sidecarMu.Unlock()
+	if udpStop != nil {
+		udpStop()
+	}
+	if udpConn != nil {
+		_ = udpConn.Close()
 	}
 	return nil
 }

--- a/pkg/adapter/nfs/handlers.go
+++ b/pkg/adapter/nfs/handlers.go
@@ -298,7 +298,11 @@ func (c *NFSConnection) handleNLMProcedure(ctx context.Context, call *rpc.RPCCal
 // from the NLM listening socket (so the source address matches the peer lockd
 // is connected to).
 func (c *NFSConnection) sendNLMAsyncResult(ctx context.Context, vers uint32, clientAddr, procName string, async *nlm.AsyncResult) {
+	// Snapshot under sidecarMu so the read does not race the transport's
+	// publish (startUDP) or its shutdown snapshot (udpSidecar.Stop).
+	c.server.sidecarMu.Lock()
 	udpConn := c.server.udpConn
+	c.server.sidecarMu.Unlock()
 	if udpConn == nil {
 		logger.WarnCtx(ctx, "NLM async result: no UDP listener; cannot deliver *_RES",
 			"procedure", procName, "client", clientAddr)

--- a/pkg/adapter/nfs/portmap.go
+++ b/pkg/adapter/nfs/portmap.go
@@ -54,7 +54,6 @@ func (s *NFSAdapter) startPortmapper(ctx context.Context) error {
 	registry := portmap.NewRegistry()
 	registry.RegisterDittoFSServices(s.config.Port, s.isUDPEnabled())
 	registry.RegisterPortmapper(s.config.Portmapper.Port)
-
 	// Create portmapper server
 	server := portmap.NewServer(portmap.ServerConfig{
 		Port:      s.config.Portmapper.Port,
@@ -62,10 +61,6 @@ func (s *NFSAdapter) startPortmapper(ctx context.Context) error {
 		EnableUDP: true,
 		Registry:  registry,
 	})
-
-	// Store references for shutdown
-	s.portmapRegistry = registry
-	s.portmapServer = server
 
 	// Start in background goroutine
 	errCh := make(chan error, 1)
@@ -76,14 +71,36 @@ func (s *NFSAdapter) startPortmapper(ctx context.Context) error {
 		}
 	}()
 
-	// Wait for listeners to be ready (or fail) with a timeout
+	// Wait for listeners to be ready (or fail) with a timeout. Publish the
+	// server only once WaitReady has fired: the server writes its listeners
+	// inside Serve, before closing that channel, so publishing any earlier
+	// would let a concurrent disable (stopPortmapper -> server.Stop) read the
+	// listeners mid-bind or nil and either race Serve or leak a late-bound
+	// port. Before WaitReady the field stays nil, so stopPortmapper is a
+	// correct no-op.
 	select {
 	case <-server.WaitReady():
+		s.sidecarMu.Lock()
+		s.portmapServer = server
+		s.sidecarMu.Unlock()
 		logger.Info("Portmapper started", "port", s.config.Portmapper.Port, "services", registry.Count())
 		return nil
 	case err := <-errCh:
 		return err
 	case <-time.After(2 * time.Second):
+		// Abandoned before ready: nothing published, so no Stop can reach this
+		// server later — stop it ourselves once the bind lands (WaitReady closed
+		// implies the cancellation monitor exists, so Stop closes the listeners
+		// instead of leaking them; Serve's own return also drains errCh). Bounded
+		// by Serve returning, which the adapter shutdown ctx guarantees.
+		go func() {
+			select {
+			case <-server.WaitReady():
+				server.Stop()
+				logger.Info("Portmapper start abandoned; late bind stopped")
+			case <-errCh:
+			}
+		}()
 		return nil // Timeout waiting for ready, but non-fatal
 	}
 }
@@ -195,9 +212,19 @@ func (s *NFSAdapter) stopSystemPortmapRegistration() {
 //
 // Safe to call when portmapper is nil (disabled or never started).
 func (s *NFSAdapter) stopPortmapper() {
-	if s.portmapServer == nil {
+	// Claim and clear: each generation is stopped exactly once. Without the
+	// clear, a disable racing a re-enable snapshots the newer server and shuts
+	// it down even though its reservation says running.
+	// Snapshot then Stop outside the lock: Stop() blocks until all portmapper
+	// goroutines exit, and the send-path snapshot must not stall behind a
+	// teardown. Idempotent via the server's shutdown-once.
+	s.sidecarMu.Lock()
+	server := s.portmapServer
+	s.portmapServer = nil
+	s.sidecarMu.Unlock()
+	if server == nil {
 		return
 	}
-	s.portmapServer.Stop()
+	server.Stop()
 	logger.Info("Portmapper stopped")
 }

--- a/pkg/adapter/nfs/sidecar_state_test.go
+++ b/pkg/adapter/nfs/sidecar_state_test.go
@@ -1,0 +1,72 @@
+package nfs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/adapter/auxsvc"
+)
+
+// The lifecycle group reserves the sidecar name under the lock and runs Start
+// outside it (Start binds listeners and can block), so a disable can steal the
+// reservation mid-Start and tear down concurrently. These hammers Start and
+// Stop of the same sidecar; with -race this fails on any unsynchronized
+// concurrent access to the adapter's sidecar shutdown state.
+func TestUDPSidecarStateConcurrentStartStop(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	a := &NFSAdapter{sidecars: auxsvc.NewGroup()}
+	a.sidecars.SetBaseContext(ctx)
+	udpEnabled := true
+	a.config.UDP.Enabled = &udpEnabled
+
+	const iterations = 20
+	for i := 0; i < iterations; i++ {
+		startDone := make(chan struct{})
+		go func() {
+			defer close(startDone)
+			if err := a.startUDP(ctx); err != nil {
+				t.Errorf("startUDP: %v", err)
+			}
+		}()
+		if err := (udpSidecar{a}).Stop(context.Background()); err != nil {
+			t.Errorf("udpSidecar.Stop: %v", err)
+		}
+		<-startDone
+		// Idempotent: repeat Stop sees the cleared conn and is a no-op.
+		if err := (udpSidecar{a}).Stop(context.Background()); err != nil {
+			t.Errorf("udpSidecar.Stop (repeat): %v", err)
+		}
+	}
+}
+
+// Same shape for the embedded portmapper: the server is published only once
+// WaitReady has fired, so a concurrent disable either sees nothing (no-op —
+// the abandoned start tears itself down via its per-start cancellation) or
+// claims a ready server (which handles a closed listener) — never a server
+// mid-bind.
+func TestPortmapSidecarStateConcurrentStartStop(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	a := &NFSAdapter{sidecars: auxsvc.NewGroup()}
+	a.sidecars.SetBaseContext(ctx)
+	enabled := true
+	a.config.Portmapper.Enabled = &enabled
+
+	const iterations = 20
+	for i := 0; i < iterations; i++ {
+		startDone := make(chan struct{})
+		go func() {
+			defer close(startDone)
+			if err := a.startPortmapper(ctx); err != nil {
+				t.Errorf("startPortmapper: %v", err)
+			}
+		}()
+		if err := (portmapSidecar{a}).Stop(context.Background()); err != nil {
+			t.Errorf("portmapSidecar.Stop: %v", err)
+		}
+		<-startDone
+		// Idempotent: repeat stopPortmapper sees the cleared server and is a no-op.
+		(a.stopPortmapper())
+	}
+}

--- a/pkg/adapter/nfs/udp.go
+++ b/pkg/adapter/nfs/udp.go
@@ -42,13 +42,23 @@ func (s *NFSAdapter) startUDP(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("listen udp :%d: %w", s.config.Port, err)
 	}
+	// Publish under sidecarMu so a concurrent disable (udpSidecar.Stop) either
+	// sees nothing bound yet (no-op) or closes a bound listener. stopCtx is
+	// published with the conn and cancelled by Stop: without it the ctx-wait
+	// goroutine below parks until adapter shutdown on every enable/disable
+	// toggle, leaking one parked goroutine per generation.
+	stopCtx, stopCancel := context.WithCancel(ctx)
+	s.sidecarMu.Lock()
 	s.udpConn = conn
+	s.udpStop = stopCancel
+	s.sidecarMu.Unlock()
 
 	logger.Info("NFS UDP transport listening (NLM/NSM/MOUNT)", "port", s.config.Port)
 
-	// Close the socket on shutdown so the read loop unblocks and exits.
+	// Close the socket on shutdown so the read loop unblocks and exits. Fires
+	// on Stop's per-generation cancel or the adapter ctx, whichever first.
 	go func() {
-		<-ctx.Done()
+		<-stopCtx.Done()
 		_ = conn.Close()
 	}()
 


### PR DESCRIPTION
## What was wrong

Issue #2542: two NFS sidecars published adapter fields from `Start` and read them from `Stop` with no synchronization:

1. **portmapper** — `startPortmapper` wrote `NFSAdapter.portmapServer` (`portmap.go:68`) while `stopPortmapper` read it (`portmap.go:198`)
2. **nfs-udp** — `startUDP` wrote `NFSAdapter.udpConn` (`udp.go:45`) while `udpSidecar.Stop` (`auxservices.go:178`) and `sendNLMAsyncResult` (`handlers.go:301`, the steady-state NLM request path) read it

The races became reachable when `auxsvc.Group.Start` moved `Service.Start` outside the group mutex (the wedge fix, #2540): a live settings-disable can now steal a mid-bind sidecar reservation and tear down concurrently with its in-flight `Start`. The `Service.Stop` contract documents implementations must synchronize their own fields for that ordering.

## Evidence

A `-race` hammer (added as `sidecar_state_test.go`) running concurrent `startUDP`/`startPortmapper` against `udpSidecar.Stop`/`portmapSidecar.Stop` reproduced data races at the exact lines above before the fix:

```
WARNING: DATA RACE
Write at 0x00c000518e60 by goroutine 22:
  pkg/adapter/nfs/portmap.go:68
Previous read at 0x00c000518e60 by goroutine 21:
  pkg/adapter/nfs/portmap.go:198
```

After the fix, the same hammer is green under `-race` (3 consecutive full runs).

## The fix

One new `sync.Mutex` (`sidecarMu`) on `NFSAdapter` — the struct already uses this shape (`resolverMu`):

- **Publishes under the lock**: `startUDP` stores `udpConn`; `startPortmapper` stores `portmapServer` **only after `server.WaitReady()` fires**
- **Snapshot at every reader**: `udpSidecar.Stop` snapshots the pointer then closes outside the lock; `sendNLMAsyncResult` snapshots then uses it; `stopPortmapper` snapshots then calls `server.Stop()` outside the lock (so the request path never stalls behind a portmapper teardown)

The publish-after-`WaitReady` point is load-bearing, found in review: `portmap.Server.Serve` writes its internal listeners inside itself, before closing `WaitReady`, so publishing earlier would let a concurrent `stopPortmapper -> server.Stop` read the listeners mid-bind (race inside `portmap.Server`) or nil (leaking a late-bound port and stuck `serveTCP` goroutines). Before `WaitReady`, the field stays nil so `stopPortmapper` is a correct no-op, and the unready server is torn down by the lifecycle ctx instead. A disable that steals a mid-start reservation is torn down by `auxsvc.Group.Start`'s rollback itself, after the server is fully ready — clean.

Also deleted `NFSAdapter.portmapRegistry` — write-only since its introduction, zero readers anywhere in the repo.

## Verification

- `-race` hammer green, 3 consecutive runs
- Full repo suite (`go test ./...`) green
- `go build ./...`, `go vet ./...`, `go fmt ./...` clean
- No Cobra command or flag moved — no docs regeneration needed

Closes #2542
