### PR TITLE
fix(nfs): guard sidecar config fields across settings-apply paths

### DIFF
--- a/pkg/adapter/nfs/adapter.go
+++ b/pkg/adapter/nfs/adapter.go
@@ -143,6 +143,13 @@ type NFSAdapter struct {
 	// reservation and tear down concurrently.
 	sidecarMu sync.Mutex
 
+	// configMu guards the sidecar config fields (Portmapper.Enabled/Port/
+	// RegisterWithSystem, UDP.Enabled) written by applyNFSSettings on the
+	// settings-watcher goroutine, on the accept loop per connection, and at
+	// startup — three concurrent writers — and read by the sysreg transition
+	// goroutine and the portmapper/UDP start paths.
+	configMu sync.Mutex
+
 	// portmapServer is the embedded portmapper server (RFC 1057).
 	// nil when portmapper is disabled.
 	portmapServer *portmap.Server

--- a/pkg/adapter/nfs/portmap.go
+++ b/pkg/adapter/nfs/portmap.go
@@ -31,6 +31,25 @@ func (s *NFSAdapter) isPortmapperEnabled() bool {
 	return *enabled
 }
 
+// snapshotSidecarConfig reads the sidecar config tuple (main NFS port,
+// portmapper port, UDP enabled) under one configMu critical section. Applies
+// run concurrently with starts, so every consumer that needs a coherent view
+// of the three values — the portmapper registry/server and the system-rpcbind
+// mappings — must go through this helper rather than reading the fields
+// separately. Reads UDP.Enabled directly: isUDPEnabled() would re-acquire the
+// same mutex inside this one (not reentrant) and self-deadlock.
+func (s *NFSAdapter) snapshotSidecarConfig() (nfsPort, portmapPort int, udpEnabled bool) {
+	s.configMu.Lock()
+	nfsPort = s.config.Port
+	portmapPort = s.config.Portmapper.Port
+	enabled := s.config.UDP.Enabled
+	s.configMu.Unlock()
+	if enabled != nil {
+		udpEnabled = *enabled
+	}
+	return nfsPort, portmapPort, udpEnabled
+}
+
 // startPortmapper creates and starts the embedded portmapper server.
 //
 // The portmapper (RFC 1057) enables NFS clients to discover DittoFS services
@@ -55,14 +74,13 @@ func (s *NFSAdapter) startPortmapper(ctx context.Context) error {
 
 	// Snapshot the sidecar config under configMu: applies run concurrently with
 	// this start, so the registry and server must see one coherent generation.
-	s.configMu.Lock()
-	nfsPort := s.config.Port
-	portmapPort := s.config.Portmapper.Port
-	s.configMu.Unlock()
+	// All three values (main port, portmapper port, UDP enabled) come from the
+	// same critical section so a concurrent apply cannot land between them.
+	nfsPort, portmapPort, udpEnabled := s.snapshotSidecarConfig()
 
 	// Create registry and register all DittoFS services
 	registry := portmap.NewRegistry()
-	registry.RegisterDittoFSServices(nfsPort, s.isUDPEnabled())
+	registry.RegisterDittoFSServices(nfsPort, udpEnabled)
 	registry.RegisterPortmapper(portmapPort)
 	// Create portmapper server
 	server := portmap.NewServer(portmap.ServerConfig{
@@ -152,9 +170,7 @@ const systemRegTimeout = 10 * time.Second
 // The kernel only needs NLM (and MOUNT/NFS) discovery to take v3 byte-range
 // locks; status monitoring continues via the host statd.
 func (s *NFSAdapter) systemRegMappings() []*xdr.Mapping {
-	s.configMu.Lock()
-	nfsPort := s.config.Port
-	s.configMu.Unlock()
+	nfsPort, _, _ := s.snapshotSidecarConfig()
 	all := portmap.DittoFSServiceMappings(nfsPort, s.isUDPEnabled())
 	out := all[:0:0]
 	for _, m := range all {

--- a/pkg/adapter/nfs/portmap.go
+++ b/pkg/adapter/nfs/portmap.go
@@ -22,10 +22,13 @@ import (
 //   - false (explicitly disabled) -> portmapper disabled
 //   - true (explicitly enabled) -> portmapper enabled
 func (s *NFSAdapter) isPortmapperEnabled() bool {
-	if s.config.Portmapper.Enabled == nil {
+	s.configMu.Lock()
+	enabled := s.config.Portmapper.Enabled
+	s.configMu.Unlock()
+	if enabled == nil {
 		return false // Default: disabled
 	}
-	return *s.config.Portmapper.Enabled
+	return *enabled
 }
 
 // startPortmapper creates and starts the embedded portmapper server.
@@ -50,13 +53,20 @@ func (s *NFSAdapter) startPortmapper(ctx context.Context) error {
 		return nil
 	}
 
+	// Snapshot the sidecar config under configMu: applies run concurrently with
+	// this start, so the registry and server must see one coherent generation.
+	s.configMu.Lock()
+	nfsPort := s.config.Port
+	portmapPort := s.config.Portmapper.Port
+	s.configMu.Unlock()
+
 	// Create registry and register all DittoFS services
 	registry := portmap.NewRegistry()
-	registry.RegisterDittoFSServices(s.config.Port, s.isUDPEnabled())
-	registry.RegisterPortmapper(s.config.Portmapper.Port)
+	registry.RegisterDittoFSServices(nfsPort, s.isUDPEnabled())
+	registry.RegisterPortmapper(portmapPort)
 	// Create portmapper server
 	server := portmap.NewServer(portmap.ServerConfig{
-		Port:      s.config.Portmapper.Port,
+		Port:      portmapPort,
 		EnableTCP: true,
 		EnableUDP: true,
 		Registry:  registry,
@@ -83,7 +93,10 @@ func (s *NFSAdapter) startPortmapper(ctx context.Context) error {
 		s.sidecarMu.Lock()
 		s.portmapServer = server
 		s.sidecarMu.Unlock()
-		logger.Info("Portmapper started", "port", s.config.Portmapper.Port, "services", registry.Count())
+		s.configMu.Lock()
+		loggedPort := s.config.Portmapper.Port
+		s.configMu.Unlock()
+		logger.Info("Portmapper started", "port", loggedPort, "services", registry.Count())
 		return nil
 	case err := <-errCh:
 		return err
@@ -109,10 +122,13 @@ func (s *NFSAdapter) startPortmapper(ctx context.Context) error {
 // services with the host's system rpcbind on port 111. Defaults to false when
 // unset (same *bool convention as isPortmapperEnabled).
 func (s *NFSAdapter) registerWithSystemEnabled() bool {
-	if s.config.Portmapper.RegisterWithSystem == nil {
+	s.configMu.Lock()
+	enabled := s.config.Portmapper.RegisterWithSystem
+	s.configMu.Unlock()
+	if enabled == nil {
 		return false
 	}
-	return *s.config.Portmapper.RegisterWithSystem
+	return *enabled
 }
 
 // systemPortmapAddr is the dial address of the host's system rpcbind.
@@ -139,7 +155,10 @@ const systemRegTimeout = 10 * time.Second
 // The kernel only needs NLM (and MOUNT/NFS) discovery to take v3 byte-range
 // locks; status monitoring continues via the host statd.
 func (s *NFSAdapter) systemRegMappings() []*xdr.Mapping {
-	all := portmap.DittoFSServiceMappings(s.config.Port, s.isUDPEnabled())
+	s.configMu.Lock()
+	nfsPort := s.config.Port
+	s.configMu.Unlock()
+	all := portmap.DittoFSServiceMappings(nfsPort, s.isUDPEnabled())
 	out := all[:0:0]
 	for _, m := range all {
 		if m.Prog == rpc.ProgramNSM {

--- a/pkg/adapter/nfs/portmap.go
+++ b/pkg/adapter/nfs/portmap.go
@@ -93,10 +93,7 @@ func (s *NFSAdapter) startPortmapper(ctx context.Context) error {
 		s.sidecarMu.Lock()
 		s.portmapServer = server
 		s.sidecarMu.Unlock()
-		s.configMu.Lock()
-		loggedPort := s.config.Portmapper.Port
-		s.configMu.Unlock()
-		logger.Info("Portmapper started", "port", loggedPort, "services", registry.Count())
+		logger.Info("Portmapper started", "port", portmapPort, "services", registry.Count())
 		return nil
 	case err := <-errCh:
 		return err

--- a/pkg/adapter/nfs/settings.go
+++ b/pkg/adapter/nfs/settings.go
@@ -76,26 +76,29 @@ func (s *NFSAdapter) applyNFSSettings(rt *runtime.Runtime) {
 			"blocked_ops", blockedOps)
 	}
 
-	// Portmapper settings -> adapter config
+	// Portmapper settings -> adapter config. configMu guards these four fields:
+	// applies run concurrently (settings-watcher goroutine, accept loop per
+	// connection, startup) and the sysreg transition goroutine plus the
+	// portmapper/UDP start paths read them.
 	// The DB model uses plain bool; the adapter config uses *bool pointer.
 	// We always set the pointer from the DB value so it's never nil.
 	enabled := settings.PortmapperEnabled
-	s.config.Portmapper.Enabled = &enabled
+	port := s.config.Portmapper.Port
 	if settings.PortmapperPort > 0 {
-		s.config.Portmapper.Port = settings.PortmapperPort
+		port = settings.PortmapperPort
 	}
 	registerWithSystem := settings.PortmapperRegisterWithSystem
-	s.config.Portmapper.RegisterWithSystem = &registerWithSystem
-	logger.Debug("NFS adapter: applied portmapper settings from DB",
-		"enabled", settings.PortmapperEnabled, "port", s.config.Portmapper.Port,
-		"register_with_system", settings.PortmapperRegisterWithSystem)
-
-	// UDP transport (NLM/NSM/MOUNT over UDP) -> adapter config. Same pattern as
-	// portmapper: DB plain bool drives the adapter config *bool. Takes effect on
-	// the next (re)start, when Serve() decides whether to bind the UDP listener.
 	udpEnabled := settings.UDPEnabled
+	s.configMu.Lock()
+	s.config.Portmapper.Enabled = &enabled
+	s.config.Portmapper.Port = port
+	s.config.Portmapper.RegisterWithSystem = &registerWithSystem
 	s.config.UDP.Enabled = &udpEnabled
-	logger.Debug("NFS adapter: applied UDP transport setting from DB", "enabled", settings.UDPEnabled)
+	s.configMu.Unlock()
+	logger.Debug("NFS adapter: applied sidecar settings from DB",
+		"enabled", settings.PortmapperEnabled, "port", port,
+		"register_with_system", settings.PortmapperRegisterWithSystem,
+		"udp_enabled", settings.UDPEnabled)
 
 	// The host-rpcbind registration and the mDNS advertiser are toggled live to
 	// match the settings; the embedded portmapper and the UDP listener still

--- a/pkg/adapter/nfs/settings.go
+++ b/pkg/adapter/nfs/settings.go
@@ -82,14 +82,17 @@ func (s *NFSAdapter) applyNFSSettings(rt *runtime.Runtime) {
 	// portmapper/UDP start paths read them.
 	// The DB model uses plain bool; the adapter config uses *bool pointer.
 	// We always set the pointer from the DB value so it's never nil.
+	// The Port read-decide-write stays inside the one critical section so two
+	// concurrent applies cannot race on the int either.
 	enabled := settings.PortmapperEnabled
-	port := s.config.Portmapper.Port
+	registerWithSystem := settings.PortmapperRegisterWithSystem
+	udpEnabled := settings.UDPEnabled
+	var port int
+	s.configMu.Lock()
+	port = s.config.Portmapper.Port
 	if settings.PortmapperPort > 0 {
 		port = settings.PortmapperPort
 	}
-	registerWithSystem := settings.PortmapperRegisterWithSystem
-	udpEnabled := settings.UDPEnabled
-	s.configMu.Lock()
 	s.config.Portmapper.Enabled = &enabled
 	s.config.Portmapper.Port = port
 	s.config.Portmapper.RegisterWithSystem = &registerWithSystem

--- a/pkg/adapter/nfs/sidecar_config_test.go
+++ b/pkg/adapter/nfs/sidecar_config_test.go
@@ -1,0 +1,67 @@
+package nfs
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/marmos91/dittofs/pkg/controlplane/models"
+)
+
+// applySidecarConfig writes the four sidecar config fields exactly as the
+// fixed applyNFSSettings does (settings.go:80-95): pointers prepared outside
+// configMu, all four fields stored under one critical section. Extracted here
+// because the real function needs a *runtime.Runtime; the races under test are
+// between these writes and the readers, not between settings sources.
+func applySidecarConfig(a *NFSAdapter, enabled, registerWithSystem, udpEnabled bool, port int) {
+	a.configMu.Lock()
+	a.config.Portmapper.Enabled = &enabled
+	a.config.Portmapper.Port = port
+	a.config.Portmapper.RegisterWithSystem = &registerWithSystem
+	a.config.UDP.Enabled = &udpEnabled
+	a.configMu.Unlock()
+}
+
+// The sidecar config fields (Portmapper.Enabled/Port/RegisterWithSystem,
+// UDP.Enabled) are written by applyNFSSettings on the settings-watcher
+// goroutine, on the accept loop per connection, and at startup — three
+// concurrent writers — and read by the sysreg transition goroutine
+// (registerWithSystemEnabled, isUDPEnabled) and the portmapper start path
+// (isPortmapperEnabled, Portmapper.Port). With -race this fails on any
+// unsynchronized concurrent write/read of the plain *bool/int fields.
+func TestSidecarConfigConcurrentApplyRead(t *testing.T) {
+	a := &NFSAdapter{}
+
+	const iterations = 2000
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	// Two concurrent writers, mirroring the settings poller and the accept
+	// loop both calling applyNFSSettings.
+	for writer := 0; writer < 2; writer++ {
+		go func(writer int) {
+			defer wg.Done()
+			settings := &models.NFSAdapterSettings{}
+			for i := 0; i < iterations; i++ {
+				applySidecarConfig(a, writer == 0, i%2 == 0, i%3 == 0, 10111+i)
+				_ = settings
+			}
+		}(writer)
+	}
+
+	// One reader spinning the exact reads the sysreg transition and the
+	// portmapper start path perform (snapshot under configMu, like the fixed
+	// production readers).
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_ = a.isPortmapperEnabled()
+			_ = a.isUDPEnabled()
+			_ = a.registerWithSystemEnabled()
+			a.configMu.Lock()
+			_ = a.config.Portmapper.Port
+			a.configMu.Unlock()
+		}
+	}()
+
+	wg.Wait()
+}

--- a/pkg/adapter/nfs/sidecar_config_test.go
+++ b/pkg/adapter/nfs/sidecar_config_test.go
@@ -57,17 +57,15 @@ func TestSidecarConfigConcurrentApplyRead(t *testing.T) {
 	}
 
 	// One reader spinning the exact reads the sysreg transition and the
-	// portmapper start path perform (snapshot under configMu, like the fixed
-	// production readers).
+	// portmapper start path perform (the production snapshotSidecarConfig
+	// helper, so removing configMu from startPortmapper's or
+	// systemRegMappings's snapshots turns this hammer -race red).
 	go func() {
 		defer wg.Done()
 		for i := 0; i < iterations; i++ {
 			_ = a.isPortmapperEnabled()
-			_ = a.isUDPEnabled()
+			_, _, _ = a.snapshotSidecarConfig()
 			_ = a.registerWithSystemEnabled()
-			a.configMu.Lock()
-			_ = a.config.Portmapper.Port
-			a.configMu.Unlock()
 		}
 	}()
 

--- a/pkg/adapter/nfs/sidecar_config_test.go
+++ b/pkg/adapter/nfs/sidecar_config_test.go
@@ -3,17 +3,22 @@ package nfs
 import (
 	"sync"
 	"testing"
-
-	"github.com/marmos91/dittofs/pkg/controlplane/models"
 )
 
 // applySidecarConfig writes the four sidecar config fields exactly as the
-// fixed applyNFSSettings does (settings.go:80-95): pointers prepared outside
-// configMu, all four fields stored under one critical section. Extracted here
-// because the real function needs a *runtime.Runtime; the races under test are
-// between these writes and the readers, not between settings sources.
-func applySidecarConfig(a *NFSAdapter, enabled, registerWithSystem, udpEnabled bool, port int) {
+// fixed applyNFSSettings does (settings.go:81-99): pointers prepared outside
+// configMu, the Port read-decide-write and all four fields stored under one
+// critical section. newPort <= 0 mirrors the DB fallback that keeps the
+// previously applied port. Extracted here because the real function needs a
+// *runtime.Runtime; the races under test are between these writes and the
+// readers, not between settings sources.
+func applySidecarConfig(a *NFSAdapter, enabled, registerWithSystem, udpEnabled bool, newPort int) {
+	var port int
 	a.configMu.Lock()
+	port = a.config.Portmapper.Port
+	if newPort > 0 {
+		port = newPort
+	}
 	a.config.Portmapper.Enabled = &enabled
 	a.config.Portmapper.Port = port
 	a.config.Portmapper.RegisterWithSystem = &registerWithSystem
@@ -36,14 +41,17 @@ func TestSidecarConfigConcurrentApplyRead(t *testing.T) {
 	wg.Add(3)
 
 	// Two concurrent writers, mirroring the settings poller and the accept
-	// loop both calling applyNFSSettings.
+	// loop both calling applyNFSSettings. Writer 0 alternates a zero port to
+	// exercise the keep-previous-port fallback; writer 1 always sets one.
 	for writer := 0; writer < 2; writer++ {
 		go func(writer int) {
 			defer wg.Done()
-			settings := &models.NFSAdapterSettings{}
 			for i := 0; i < iterations; i++ {
-				applySidecarConfig(a, writer == 0, i%2 == 0, i%3 == 0, 10111+i)
-				_ = settings
+				port := 10111 + i
+				if writer == 0 && i%2 == 0 {
+					port = 0
+				}
+				applySidecarConfig(a, writer == 0, i%2 == 0, i%3 == 0, port)
 			}
 		}(writer)
 	}

--- a/pkg/adapter/nfs/udp.go
+++ b/pkg/adapter/nfs/udp.go
@@ -30,7 +30,10 @@ const defaultUDPHandlerLimit = 100
 // isUDPEnabled reports whether the UDP transport for NLM/NSM/MOUNT should be
 // started. Disabled unless adapters.nfs.udp.enabled is explicitly true.
 func (s *NFSAdapter) isUDPEnabled() bool {
-	return s.config.UDP.Enabled != nil && *s.config.UDP.Enabled
+	s.configMu.Lock()
+	enabled := s.config.UDP.Enabled
+	s.configMu.Unlock()
+	return enabled != nil && *enabled
 }
 
 // startUDP binds the UDP transport on the NFS port and serves the lock-manager
@@ -38,9 +41,14 @@ func (s *NFSAdapter) isUDPEnabled() bool {
 // because READ/WRITE payloads do not fit a single datagram; only the small
 // lock/status/mount messages are. The listener is closed when ctx is cancelled.
 func (s *NFSAdapter) startUDP(ctx context.Context) error {
-	conn, err := net.ListenUDP("udp", &net.UDPAddr{Port: s.config.Port})
+	// Snapshot the port under configMu: applies run concurrently with this
+	// start (the accept loop re-applies settings per connection).
+	s.configMu.Lock()
+	nfsPort := s.config.Port
+	s.configMu.Unlock()
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{Port: nfsPort})
 	if err != nil {
-		return fmt.Errorf("listen udp :%d: %w", s.config.Port, err)
+		return fmt.Errorf("listen udp :%d: %w", nfsPort, err)
 	}
 	// Publish under sidecarMu so a concurrent disable (udpSidecar.Stop) either
 	// sees nothing bound yet (no-op) or closes a bound listener. stopCtx is
@@ -53,7 +61,7 @@ func (s *NFSAdapter) startUDP(ctx context.Context) error {
 	s.udpStop = stopCancel
 	s.sidecarMu.Unlock()
 
-	logger.Info("NFS UDP transport listening (NLM/NSM/MOUNT)", "port", s.config.Port)
+	logger.Info("NFS UDP transport listening (NLM/NSM/MOUNT)", "port", nfsPort)
 
 	// Close the socket on shutdown so the read loop unblocks and exits. Fires
 	// on Stop's per-generation cancel or the adapter ctx, whichever first.


### PR DESCRIPTION
## Issue #2548: NFS sidecar config fields written with no synchronization

`applyNFSSettings` writes `s.config.Portmapper.Enabled/Port/RegisterWithSystem` and `s.config.UDP.Enabled` (plain `*bool`/`int`) while running on **three concurrent goroutines**:

- the settings-watcher poller, via the `OnNFSSettingsChange` callback (`adapter.go:782`)
- the accept loop, per connection, via `preAcceptCheck` (`adapter.go:882`)
- startup, via `SetRuntime` (`adapter.go:769`)

and reads them concurrently from:

- the sysreg transition goroutine spawned by `reconcileSysreg` (`registerWithSystemEnabled`, `systemRegMappings` → `isUDPEnabled`)
- the portmapper/UDP start paths (`isPortmapperEnabled`, `isUDPEnabled`, `config.Port` reads)

That is a write/write race between concurrent applies plus reader/writer races — the same class as #2542, but on the config fields rather than the sidecar state fields.

### The fix

New `configMu sync.Mutex` on `NFSAdapter`, one lifecycle domain for the four sidecar config fields:

- **`settings.go`** — `applyNFSSettings` prepares the `*bool` values outside the lock, then performs the `Port` read-decide-write **and all four field stores inside one critical section**. The read-decide-write of `Port` must stay inside the section: two concurrent applies would otherwise race on the int even with the lock present. The two log lines merge into one emitted after unlock.
- **`portmap.go`** — `isPortmapperEnabled` / `registerWithSystemEnabled` snapshot the `*bool` under the lock and dereference outside (safe: applies always assign a fresh non-nil pointer and nothing nils them); `startPortmapper` snapshots `config.Port` + `Portmapper.Port` in one section so the registry/server see a coherent generation; `systemRegMappings` snapshots the port. The "Portmapper started" log uses the actually-bound `portmapPort` local rather than a re-read of config.
- **`udp.go`** — `isUDPEnabled` snapshots the `*bool`; `startUDP` snapshots `config.Port`.

Deadlock safety was reviewed: every `configMu` section holds only field loads/stores (no calls, no channel ops, no nested locks); all blocking waits happen with no lock held; `sidecarMu` sections never acquire `configMu` (no lock ordering inversion).

### Test

`sidecar_config_test.go` — a `-race` hammer: two writer goroutines calling `applySidecarConfig` (a mirror of the fixed apply, including the keep-previous-port fallback when the DB port is 0) against a reader goroutine spinning the real production readers. Confirmed **red under `-race` before the fix** on the exact write/write and read/write pairs; green after (repeated runs). The real `applyNFSSettings` cannot be used directly in the test because it needs a `*runtime.Runtime`.

### Review

Two independent reviewer passes. The first flagged the port read sitting outside the critical section (the initial version locked the stores but not the read-decide-write) — restructured per review, re-verified.

Closes #2548.
