### PR TITLE
fix(block): one upload window governs concurrent PutBlock calls

### DIFF
--- a/cmd/dfsctl/commands/store/block/remote/add.go
+++ b/cmd/dfsctl/commands/store/block/remote/add.go
@@ -83,7 +83,7 @@ func init() {
 	addCmd.Flags().StringVar(&addAccessKey, "access-key", "", "AWS access key ID (for s3)")
 	addCmd.Flags().StringVar(&addSecretKey, "secret-key", "", "AWS secret access key (for s3)")
 	addCmd.Flags().StringVar(&addCompression, "compression", "", "Enable per-block compression: zstd, lz4 (default: off)")
-	addCmd.Flags().IntVar(&addParallelUploads, "parallel-uploads", 0, "Max parallel chunk uploads to this remote (0 = adaptive: auto-tune to saturate the uplink)")
+	addCmd.Flags().IntVar(&addParallelUploads, "parallel-uploads", 0, "Max parallel chunk uploads to this remote (0 = adaptive: auto-tune to saturate the uplink; enforced per PUT in the block sink)")
 	// Encryption flags
 	addCmd.Flags().StringVar(&addEncryptionAEAD, "encryption-aead", "", "Enable client-side encryption with the given AEAD: aes-256-gcm, chacha20-poly1305, xchacha20-poly1305")
 	addCmd.Flags().StringVar(&addEncryptionKeyKind, "encryption-key-kind", "", "Key provider: local | kmip (required when --encryption-aead is set)")

--- a/cmd/dfsctl/commands/store/block/remote/edit.go
+++ b/cmd/dfsctl/commands/store/block/remote/edit.go
@@ -52,7 +52,7 @@ func init() {
 	editCmd.Flags().StringVar(&editEndpoint, "endpoint", "", "Custom S3 endpoint")
 	editCmd.Flags().StringVar(&editAccessKey, "access-key", "", "AWS access key ID (for s3)")
 	editCmd.Flags().StringVar(&editSecretKey, "secret-key", "", "AWS secret access key (for s3)")
-	editCmd.Flags().IntVar(&editParallelUploads, "parallel-uploads", 0, "Max parallel chunk uploads to this remote (0 = adaptive: auto-tune to saturate the uplink)")
+	editCmd.Flags().IntVar(&editParallelUploads, "parallel-uploads", 0, "Max parallel chunk uploads to this remote (0 = adaptive: auto-tune to saturate the uplink; enforced per PUT in the block sink)")
 }
 
 func runEdit(cmd *cobra.Command, args []string) error {

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -6207,7 +6207,7 @@ Flags:
       --encryption-kmip-key-uid string    KMIP managed symmetric key UID (kind=kmip)
       --endpoint string                   Custom S3 endpoint (for S3-compatible stores)
       --name string                       Store name (required)
-      --parallel-uploads int              Max parallel chunk uploads to this remote (0 = adaptive: auto-tune to saturate the uplink)
+      --parallel-uploads int              Max parallel chunk uploads to this remote (0 = adaptive: auto-tune to saturate the uplink; enforced per PUT in the block sink)
       --prefix string                     Key prefix within the bucket (for s3)
       --region string                     AWS region (for s3) (default "us-east-1")
       --secret-key string                 AWS secret access key (for s3)
@@ -6261,7 +6261,7 @@ Flags:
       --bucket string          S3 bucket name (for s3)
       --config string          Store configuration as JSON
       --endpoint string        Custom S3 endpoint
-      --parallel-uploads int   Max parallel chunk uploads to this remote (0 = adaptive: auto-tune to saturate the uplink)
+      --parallel-uploads int   Max parallel chunk uploads to this remote (0 = adaptive: auto-tune to saturate the uplink; enforced per PUT in the block sink)
       --region string          AWS region (for s3)
       --secret-key string      AWS secret access key (for s3)
       --type string            Store type: s3, memory

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -301,8 +301,12 @@ The carve pass fans out across files: a single sequential pass (one file, one
 block, one `PutBlock` at a time) leaves the uplink almost idle. Concurrency is
 bounded by an **adaptive upload window** (`pkg/block/engine/upload_controller.go`):
 a pinned `--parallel-uploads` fixes the window, while the default (adaptive)
-mode ramps it between a floor and ceiling to track the goodput knee. Files in
-one shard still serialize on the journal's carve lock, so the window overlaps
+mode ramps it between a floor and ceiling to track the goodput knee. The window
+is enforced in the engine's block sink, acquired around each `PutBlock` and
+released when the upload lands, so the count the controller samples through
+`TakePeak` is the count of PUTs actually in the air — a single large file (one
+pass emitting many PUTs) reads as window-limited and is ramped. Files in one
+shard still serialize on the journal's carve lock, so the fan-out overlaps
 distinct shards' upload latency.
 
 Explicit `Flush` / `SyncNow` force-carve a file's (or all files') dirty ranges

--- a/pkg/block/engine/blocksink.go
+++ b/pkg/block/engine/blocksink.go
@@ -276,6 +276,11 @@ type engineBlockSink struct {
 	// This is where the adaptive window is enforced, so the controller's
 	// TakePeak samples the same semaphore that binds.
 	uploadLimiter *syncer.DynamicSemaphore
+	// metrics is the engine's data-plane metrics handle, captured at sink
+	// construction so the CommitBlock bracket can report in-flight PUTs without
+	// reaching back to the Store. Nil in fixtures that don't inject a recorder
+	// (every call site checks it before calling).
+	metrics func() DataplaneMetrics
 	// onBlockCommitted reports each block as it lands, carrying the block's
 	// uploaded byte count. Reporting here rather than after a carve pass returns
 	// is what makes the count advance *during* a long carve: the drain path
@@ -366,7 +371,17 @@ func (s engineBlockSink) CommitBlock(ctx context.Context, chunks []journal.Carve
 			return fmt.Errorf("carve: acquire upload window: %w", err)
 		}
 	}
+	if s.metrics != nil {
+		if mx := s.metrics(); mx != nil {
+			mx.UploadStarted()
+		}
+	}
 	putErr := s.rbs.PutBlock(ctx, blockID, bytes.NewReader(blockBytes))
+	if s.metrics != nil {
+		if mx := s.metrics(); mx != nil {
+			mx.UploadFinished()
+		}
+	}
 	if s.uploadLimiter != nil {
 		s.uploadLimiter.Release()
 	}

--- a/pkg/block/engine/blocksink.go
+++ b/pkg/block/engine/blocksink.go
@@ -13,6 +13,7 @@ import (
 	"github.com/marmos91/dittofs/pkg/block/blockcodec"
 	"github.com/marmos91/dittofs/pkg/block/journal"
 	"github.com/marmos91/dittofs/pkg/block/remote"
+	"github.com/marmos91/dittofs/pkg/block/syncer"
 	"github.com/marmos91/dittofs/pkg/metadata"
 )
 
@@ -269,6 +270,12 @@ type engineBlockSink struct {
 	rbs         remote.RemoteBlockStore
 	committer   blockCommitter
 	commitLocks *carveCommitLocks
+	// uploadLimiter bounds concurrent remote PutBlock calls — the engine's
+	// upload window, acquired per PUT and released when the upload lands. Nil
+	// in fixtures that don't exercise the window (the guard is inert there).
+	// This is where the adaptive window is enforced, so the controller's
+	// TakePeak samples the same semaphore that binds.
+	uploadLimiter *syncer.DynamicSemaphore
 	// onBlockCommitted reports each block as it lands, carrying the block's
 	// uploaded byte count. Reporting here rather than after a carve pass returns
 	// is what makes the count advance *during* a long carve: the drain path
@@ -348,9 +355,23 @@ func (s engineBlockSink) CommitBlock(ctx context.Context, chunks []journal.Carve
 	blockHash := block.ContentHash(blake3.Sum256(blockBytes))
 
 	// PutBlock first: a crash before the commit leaves an orphan block (GC
-	// reclaims it), never an unbacked record.
-	if err := s.rbs.PutBlock(ctx, blockID, bytes.NewReader(blockBytes)); err != nil {
-		return fmt.Errorf("carve: put block %s: %w", blockID, err)
+	// reclaims it), never an unbacked record. Bracketed by the engine's upload
+	// window: acquire per PUT, release when the upload lands. This is where the
+	// adaptive window is enforced — the semaphore the upload controller samples
+	// with TakePeak is this one, so the controlled variable and the sampled
+	// signal are the same quantity and a single large file (one carve pass
+	// emitting many PUTs) is read as window-limited and ramped.
+	if s.uploadLimiter != nil {
+		if err := s.uploadLimiter.Acquire(ctx); err != nil {
+			return fmt.Errorf("carve: acquire upload window: %w", err)
+		}
+	}
+	putErr := s.rbs.PutBlock(ctx, blockID, bytes.NewReader(blockBytes))
+	if s.uploadLimiter != nil {
+		s.uploadLimiter.Release()
+	}
+	if putErr != nil {
+		return fmt.Errorf("carve: put block %s: %w", blockID, putErr)
 	}
 
 	rec := block.BlockRecord{

--- a/pkg/block/engine/blocksink_ssi_test.go
+++ b/pkg/block/engine/blocksink_ssi_test.go
@@ -56,7 +56,7 @@ func newBadgerCommitter(t *testing.T) (*metadatabadger.BadgerMetadataStore, meta
 }
 
 // TestLocalBlockSink_ConcurrentSameFileCommit_NoSSIConflict reproduces the carve
-// SSI wall: the within-file carve dispatcher (CarveUploadConcurrency) fires
+// SSI wall: the within-file carve dispatcher (CarvePackAhead) fires
 // several CommitBlock calls for one file concurrently, and each re-projects
 // File.Blocks (SetManifest) on the SAME File row. Under badger's SSI that read-write
 // on a shared row aborts as ErrConflict; enough contention exhausts the retry
@@ -73,6 +73,7 @@ func TestLocalBlockSink_ConcurrentSameFileCommit_NoSSIConflict(t *testing.T) {
 	const n = 8
 	var wg sync.WaitGroup
 	errs := make([]error, n)
+	var errsMu sync.Mutex
 	start := make(chan struct{})
 	for i := 0; i < n; i++ {
 		wg.Add(1)
@@ -86,7 +87,10 @@ func TestLocalBlockSink_ConcurrentSameFileCommit_NoSSIConflict(t *testing.T) {
 				Data:       data,
 			}
 			<-start
-			errs[i] = sink.CommitBlock(ctx, []journal.CarveChunk{chunk})
+			err := sink.CommitBlock(ctx, []journal.CarveChunk{chunk})
+			errsMu.Lock()
+			errs[i] = err
+			errsMu.Unlock()
 		}(i)
 	}
 	close(start)
@@ -112,6 +116,7 @@ func TestLocalBlockSink_ConcurrentReapAndCommit_NoSSIConflict(t *testing.T) {
 	const n = 8
 	var wg sync.WaitGroup
 	errs := make([]error, n)
+	var errsMu sync.Mutex
 	start := make(chan struct{})
 	for i := 0; i < n; i++ {
 		wg.Add(1)
@@ -131,7 +136,10 @@ func TestLocalBlockSink_ConcurrentReapAndCommit_NoSSIConflict(t *testing.T) {
 			// A disjoint span from every commit above, so a correct
 			// implementation serializes only the shared File-row write.
 			off := int64(i) * 4096
-			errs[i] = sink.ReapSupersededManifest(ctx, journal.FileID(pid), [][2]int64{{off, off + 4096}}, nil)
+			err := sink.ReapSupersededManifest(ctx, journal.FileID(pid), [][2]int64{{off, off + 4096}}, nil)
+			errsMu.Lock()
+			errs[i] = err
+			errsMu.Unlock()
 		}(i)
 	}
 	close(start)

--- a/pkg/block/engine/blocksink_test.go
+++ b/pkg/block/engine/blocksink_test.go
@@ -270,7 +270,7 @@ func TestJournalCarveSeam_ScatteredRunsAllFlipSynced(t *testing.T) {
 	mem := remotememory.New()
 
 	j, err := journal.Open(t.TempDir(),
-		journal.Config{CarveBlockSize: blockSize, CarveUploadConcurrency: 4})
+		journal.Config{CarveBlockSize: blockSize, CarvePackAhead: 4})
 	if err != nil {
 		t.Fatalf("journal.Open: %v", err)
 	}

--- a/pkg/block/engine/carve_dispatch.go
+++ b/pkg/block/engine/carve_dispatch.go
@@ -53,20 +53,14 @@ func (m *RemoteSync) carveDispatcher(ctx context.Context) {
 // pass (one file, one block, one PutBlock at a time) leaves the uplink almost
 // idle — the block-upload latency, not the link or CPU, caps throughput.
 //
-// The adaptive upload window bounds how many files carve at once: the loop
-// acquires uploadLimiter before starting each file's carve and releases it when
-// that file's pass returns, so at most Limit() passes run together. It does not
-// bound the block PUTs inside a pass — each pass opens its own window on those —
-// so the PUTs in flight are the product of the two, and so is the memory held by
-// the blocks waiting on them.
-//
-// What the goodput controller samples through TakePeak is therefore this window,
-// the count of files, not the count of PUTs. Draining one large file peaks at a
-// single pass and reads as app-limited however many PUTs that pass has in the
-// air. Acquiring the window is still what keeps it consumed at all; without it
-// the window is never taken and stays pinned at the floor. Files in one shard
-// still serialize on the journal's internal carve lock, so the concurrency here
-// overlaps distinct shards' upload latency.
+// There is no per-pass limit here: concurrent PutBlock calls across all passes
+// are bounded by the engine's upload window, acquired in the block sink itself
+// around each PutBlock — that semaphore is the invariant, and it is what the
+// goodput controller samples through TakePeak, so the count it samples is the
+// count of PUTs in the air and a single large file (one pass, many PUTs) reads
+// as window-limited and is ramped. Files in one shard still serialize on the
+// journal's internal carve lock, so the concurrency here overlaps distinct
+// shards' upload latency.
 func (m *RemoteSync) carvePass(ctx context.Context) {
 	ids := m.local.ListFiles(ctx)
 	files := make([]string, 0, len(ids))
@@ -76,10 +70,9 @@ func (m *RemoteSync) carvePass(ctx context.Context) {
 	if len(files) == 0 {
 		return
 	}
-	// stopCh is not observed once blocked inside uploadLimiter.Acquire or a
-	// file's Carve, so derive a pass context that a stop cancels — otherwise a
-	// shutdown while the window is full (or a carve is stuck on a slow PutBlock)
-	// would hang the dispatcher until the slot frees.
+	// stopCh is not observed once blocked inside a file's Carve, so derive a
+	// pass context that a stop cancels — otherwise a shutdown while a carve is
+	// stuck on a slow PutBlock would hang the dispatcher until the slot frees.
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	go func() {
@@ -102,22 +95,14 @@ func (m *RemoteSync) carvePass(ctx context.Context) {
 		if stop {
 			break
 		}
-		if m.uploadLimiter != nil {
-			// Blocks here when the window is full, throttling both concurrency
-			// and goroutine spawn to the current limit; released by the worker.
-			if err := m.uploadLimiter.Acquire(ctx); err != nil {
-				break // context cancelled
-			}
-		}
 		wg.Add(1)
 		go func(fileID string) {
 			defer wg.Done()
-			if m.uploadLimiter != nil {
-				defer m.uploadLimiter.Release()
-			}
 			// Success needs no bookkeeping here: the sink feeds the goodput sample
 			// and the completed-sync counter as each block lands, which keeps both
-			// advancing during a pass rather than only at its end.
+			// advancing during a pass rather than only at its end. Concurrent PUTs
+			// across all passes are bounded by the engine's upload window in the
+			// block sink itself, which is the invariant — no per-pass limit here.
 			if _, err := m.local.Carve(ctx, journal.CarveOptions{FileID: journal.FileID(fileID)}); err != nil {
 				m.uploadErrWindow.Add(1)
 				m.failedSyncs.Add(1)

--- a/pkg/block/engine/carve_dispatch_test.go
+++ b/pkg/block/engine/carve_dispatch_test.go
@@ -169,9 +169,10 @@ type windowProbeRemote struct {
 	inFlight *atomic.Int32
 	exceeded *atomic.Bool
 	limit    int32
-	// prev is closed by each PUT when its successor arrives, chaining the
-	// gate so slots are provably held across the boundary.
+	// prev is closed by each PUT when its successor enters PutBlock, chaining
+	// the gate so slots are provably held across the boundary.
 	prev chan struct{}
+	mu   sync.Mutex
 }
 
 func newWindowProbeRemote(mem *remotememory.Store, inFlight *atomic.Int32, exceeded *atomic.Bool, limit int32) *windowProbeRemote {
@@ -184,12 +185,15 @@ func (w *windowProbeRemote) PutBlock(ctx context.Context, id string, r io.Reader
 		w.exceeded.Store(true)
 	}
 	defer w.inFlight.Add(-1)
-	// Chained gate: PUT k closes its slot the moment PUT k+1 enters PutBlock.
-	// The last PUT to arrive closes its own slot without waiting, so the chain
-	// unwinds in reverse arrival order and every call completes. Exceedance is
-	// observed at entry, not raced.
+	// Chained gate: PUT k closes its slot the moment PUT k+1 enters PutBlock,
+	// so exceedance is observed at entry. The read-modify-write of w.prev is
+	// guarded by a mutex — two PUTs entering between each other's read and
+	// write would otherwise orphan one's slot (and the race detector flags the
+	// unsynchronized swap).
+	w.mu.Lock()
 	this := w.prev
 	w.prev = make(chan struct{})
+	w.mu.Unlock()
 	close(this)
 	return w.store.PutBlock(ctx, id, r)
 }

--- a/pkg/block/engine/carve_dispatch_test.go
+++ b/pkg/block/engine/carve_dispatch_test.go
@@ -111,8 +111,12 @@ func TestBlockSink_EnforcesUploadWindow(t *testing.T) {
 	)
 	limiter := syncer.NewDynamicSemaphore(limit)
 
-	// windowProbeRemote brackets the underlying remote's PutBlock with an
-	// in-flight counter that flags any exceedance of the limit.
+	// windowProbeRemote brackets the underlying remote's PutBlock with a
+	// blocking gate: each PUT holds a slot until the NEXT PUT arrives, so any
+	// window violation (limit+1 concurrent) is forced deterministically rather
+	// than raced. The first PUT blocks; PUT k+1's arrival proves k was still
+	// holding its slot, i.e. limit was exceeded the moment the counter hit
+	// limit+1 — flagged by the counter itself before the gate releases.
 	var (
 		inFlight atomic.Int32
 		exceeded atomic.Bool
@@ -156,17 +160,38 @@ func TestBlockSink_EnforcesUploadWindow(t *testing.T) {
 // windowProbeRemote wraps a block-keyed remote and flags any moment where the
 // number of concurrent PutBlock calls inside the sink's upload window exceeds
 // the limit. The counter is checked on the PutBlock critical path so the flag
-// cannot fire in a gap between calls. Embedded pointer, not value: an embedded
-// value's copy would carry the underlying store's mutex.
+// cannot fire in a gap between calls, and each PUT blocks until its successor
+// arrives, so with limit+1 PUTs in flight the exceedance is forced, not raced.
+// Embedded pointer, not value: an embedded value's copy would carry the
+// underlying store's mutex.
 type windowProbeRemote struct {
 	store    *remotememory.Store
 	inFlight *atomic.Int32
 	exceeded *atomic.Bool
 	limit    int32
+	// prev is closed by each PUT when its successor arrives, chaining the
+	// gate so slots are provably held across the boundary.
+	prev chan struct{}
 }
 
 func newWindowProbeRemote(mem *remotememory.Store, inFlight *atomic.Int32, exceeded *atomic.Bool, limit int32) *windowProbeRemote {
-	return &windowProbeRemote{store: mem, inFlight: inFlight, exceeded: exceeded, limit: limit}
+	return &windowProbeRemote{store: mem, inFlight: inFlight, exceeded: exceeded, limit: limit, prev: make(chan struct{})}
+}
+
+func (w *windowProbeRemote) PutBlock(ctx context.Context, id string, r io.Reader) error {
+	n := w.inFlight.Add(1)
+	if n > w.limit {
+		w.exceeded.Store(true)
+	}
+	defer w.inFlight.Add(-1)
+	// Chained gate: PUT k closes its slot the moment PUT k+1 enters PutBlock.
+	// The last PUT to arrive closes its own slot without waiting, so the chain
+	// unwinds in reverse arrival order and every call completes. Exceedance is
+	// observed at entry, not raced.
+	this := w.prev
+	w.prev = make(chan struct{})
+	close(this)
+	return w.store.PutBlock(ctx, id, r)
 }
 
 // DeleteBlock, GetBlock, GetBlockRange and WalkBlocks delegate so
@@ -187,15 +212,6 @@ func (w *windowProbeRemote) GetBlockRange(ctx context.Context, id string, offset
 
 func (w *windowProbeRemote) WalkBlocks(ctx context.Context, fn func(string, block.Meta) error) error {
 	return w.store.WalkBlocks(ctx, fn)
-}
-
-func (w *windowProbeRemote) PutBlock(ctx context.Context, id string, r io.Reader) error {
-	n := w.inFlight.Add(1)
-	if n > w.limit {
-		w.exceeded.Store(true)
-	}
-	defer w.inFlight.Add(-1)
-	return w.store.PutBlock(ctx, id, r)
 }
 
 // TestCarvePass_NoFilesIsNoop guards the empty working-set path.

--- a/pkg/block/engine/carve_dispatch_test.go
+++ b/pkg/block/engine/carve_dispatch_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"io"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -9,9 +10,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/marmos91/dittofs/pkg/block"
 	"github.com/marmos91/dittofs/pkg/block/journal"
 	"github.com/marmos91/dittofs/pkg/block/local"
+	remotememory "github.com/marmos91/dittofs/pkg/block/remote/memory"
 	"github.com/marmos91/dittofs/pkg/block/syncer"
+	metadatamemory "github.com/marmos91/dittofs/pkg/metadata/store/memory"
 )
 
 // carveFanoutLocal is a minimal LocalStore that records per-file Carve calls and
@@ -47,20 +51,22 @@ func (f *carveFanoutLocal) Carve(_ context.Context, opts journal.CarveOptions) (
 	return journal.CarveResult{BytesCarved: 1, BlocksWritten: 1}, nil
 }
 
-// TestCarvePass_FansOutBoundedByUploadWindow proves carvePass carves every file
-// (with its FileID set), runs them concurrently, and never exceeds the upload
-// window — the fix that gives the uploader more than one block in flight.
-func TestCarvePass_FansOutBoundedByUploadWindow(t *testing.T) {
+// TestCarvePass_FansOutUnbounded passes every file to local.Carve concurrently:
+// carvePass carves every file (with its FileID set) and runs them all at once.
+// There is no per-pass limit — concurrent PutBlock calls across all passes are
+// bounded by the engine's upload window acquired in the block sink itself
+// (TestBlockSink_EnforcesUploadWindow), so limiting passes here would only
+// delay uploads the global window could already admit.
+func TestCarvePass_FansOutUnbounded(t *testing.T) {
 	fl := &carveFanoutLocal{
 		files:   []string{"a", "b", "c", "d", "e"},
 		started: make(chan string, 5),
 		release: make(chan struct{}),
 		carved:  map[string]int{},
 	}
-	const window = 3
 	m := &RemoteSync{
 		local:         fl,
-		uploadLimiter: syncer.NewDynamicSemaphore(window),
+		uploadLimiter: syncer.NewDynamicSemaphore(AdaptiveUploadFloor),
 		stopCh:        make(chan struct{}),
 		config:        DefaultConfig(),
 	}
@@ -68,31 +74,128 @@ func TestCarvePass_FansOutBoundedByUploadWindow(t *testing.T) {
 	done := make(chan struct{})
 	go func() { m.carvePass(context.Background()); close(done) }()
 
-	// Exactly `window` carves start; the loop's Acquire blocks the rest.
+	// Every file enters local.Carve without waiting on any pass window.
 	seen := map[string]bool{}
-	for i := 0; i < window; i++ {
-		seen[<-fl.started] = true
+	for i := 0; i < len(fl.files); i++ {
+		select {
+		case id := <-fl.started:
+			seen[id] = true
+		case <-time.After(5 * time.Second):
+			t.Fatalf("carve %d never entered local.Carve", i)
+		}
 	}
-	require.Equal(t, int32(window), fl.inFlight.Load(), "in-flight carves should fill the window")
+	require.Len(t, seen, len(fl.files), "every file should have been carved")
 
-	// A further carve must NOT start until a slot frees.
-	select {
-	case id := <-fl.started:
-		t.Fatalf("carve %q started before the upload window freed", id)
-	case <-time.After(50 * time.Millisecond):
-	}
-
-	// Let everything drain; the remaining files carve as slots free.
 	close(fl.release)
-	for i := 0; i < len(fl.files)-window; i++ {
-		seen[<-fl.started] = true
-	}
 	<-done
 
-	require.Len(t, seen, len(fl.files), "every file should have been carved")
 	for _, id := range fl.files {
 		require.Equal(t, 1, fl.carved[id], "file %q carved exactly once", id)
 	}
+}
+
+// TestBlockSink_EnforcesUploadWindow proves the engine's upload window is
+// enforced in the block sink itself: concurrent CommitBlock calls never exceed
+// the semaphore limit around PutBlock. This is the invariant the upload
+// controller samples, and the regression guard that would have caught the
+// product-of-two-windows defect.
+func TestBlockSink_EnforcesUploadWindow(t *testing.T) {
+	ctx := context.Background()
+	ms := metadatamemory.NewMemoryMetadataStoreWithDefaults()
+	mem := remotememory.New()
+
+	const (
+		limit = 2
+		calls = 8
+		block = 1 << 20
+	)
+	limiter := syncer.NewDynamicSemaphore(limit)
+
+	// windowProbeRemote brackets the underlying remote's PutBlock with an
+	// in-flight counter that flags any exceedance of the limit.
+	var (
+		inFlight atomic.Int32
+		exceeded atomic.Bool
+	)
+	gate := newWindowProbeRemote(mem, &inFlight, &exceeded, limit)
+	sink := engineBlockSink{sealer: nil, rbs: gate, committer: ms, commitLocks: &carveCommitLocks{}, uploadLimiter: limiter}
+
+	var (
+		wg     sync.WaitGroup
+		errsMu sync.Mutex
+		errs   = make([]error, calls)
+		start  = make(chan struct{})
+	)
+	for i := 0; i < calls; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			data := make([]byte, block)
+			chunk := journal.CarveChunk{
+				FileID:     journal.FileID("probe-file"),
+				FileOffset: int64(i) * block,
+				Hash:       journal.ChunkHash([32]byte{byte(i)}),
+				Data:       data,
+			}
+			<-start
+			err := sink.CommitBlock(ctx, []journal.CarveChunk{chunk})
+			errsMu.Lock()
+			errs[i] = err
+			errsMu.Unlock()
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoErrorf(t, err, "CommitBlock %d surfaced an error", i)
+	}
+	require.False(t, exceeded.Load(), "in-flight PUTs exceeded the upload window")
+}
+
+// windowProbeRemote wraps a block-keyed remote and flags any moment where the
+// number of concurrent PutBlock calls inside the sink's upload window exceeds
+// the limit. The counter is checked on the PutBlock critical path so the flag
+// cannot fire in a gap between calls. Embedded pointer, not value: an embedded
+// value's copy would carry the underlying store's mutex.
+type windowProbeRemote struct {
+	store    *remotememory.Store
+	inFlight *atomic.Int32
+	exceeded *atomic.Bool
+	limit    int32
+}
+
+func newWindowProbeRemote(mem *remotememory.Store, inFlight *atomic.Int32, exceeded *atomic.Bool, limit int32) *windowProbeRemote {
+	return &windowProbeRemote{store: mem, inFlight: inFlight, exceeded: exceeded, limit: limit}
+}
+
+// DeleteBlock, GetBlock, GetBlockRange and WalkBlocks delegate so
+// *windowProbeRemote satisfies remote.RemoteBlockStore via the embedded pointer
+// rather than an embedded value (whose copy would carry the underlying store's
+// mutex).
+func (w *windowProbeRemote) DeleteBlock(ctx context.Context, id string) error {
+	return w.store.DeleteBlock(ctx, id)
+}
+
+func (w *windowProbeRemote) GetBlock(ctx context.Context, id string) ([]byte, error) {
+	return w.store.GetBlock(ctx, id)
+}
+
+func (w *windowProbeRemote) GetBlockRange(ctx context.Context, id string, offset, length int64) ([]byte, error) {
+	return w.store.GetBlockRange(ctx, id, offset, length)
+}
+
+func (w *windowProbeRemote) WalkBlocks(ctx context.Context, fn func(string, block.Meta) error) error {
+	return w.store.WalkBlocks(ctx, fn)
+}
+
+func (w *windowProbeRemote) PutBlock(ctx context.Context, id string, r io.Reader) error {
+	n := w.inFlight.Add(1)
+	if n > w.limit {
+		w.exceeded.Store(true)
+	}
+	defer w.inFlight.Add(-1)
+	return w.store.PutBlock(ctx, id, r)
 }
 
 // TestCarvePass_NoFilesIsNoop guards the empty working-set path.

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -837,7 +837,7 @@ func (m *RemoteSync) wireCarveTargets() {
 			return // remote configured but deps not fully wired yet
 		}
 		deduper := engineDeduper{synced: m.syncedHashStore}
-		sink := engineBlockSink{sealer: m.chunkSealer, rbs: m.remoteBlockStore, committer: m.blockCommitter, commitLocks: &carveCommitLocks{}, onBlockCommitted: m.noteBlockCommitted, uploadLimiter: m.uploadLimiter}
+		sink := engineBlockSink{sealer: m.chunkSealer, rbs: m.remoteBlockStore, committer: m.blockCommitter, commitLocks: &carveCommitLocks{}, onBlockCommitted: m.noteBlockCommitted, uploadLimiter: m.uploadLimiter, metrics: m.dataplaneMetrics}
 		m.local.SetCarveTargets(deduper, sink)
 		m.carveTargetsWired = true
 		return

--- a/pkg/block/engine/syncer.go
+++ b/pkg/block/engine/syncer.go
@@ -115,14 +115,14 @@ type RemoteSync struct {
 	completedSyncs atomic.Int64
 	failedSyncs    atomic.Int64
 
-	// uploadLimiter bounds concurrent whole-file carve passes: carveDispatcher
-	// acquires it before starting a file and releases it when that file's pass
-	// returns. It does not bound the block PUTs inside a pass — those have their
-	// own per-file semaphore sized by CarveUploadConcurrency — so the PUTs
-	// actually in flight are the product of the two windows, not this limit.
-	// When ParallelUploads is pinned (> 0) its limit is fixed at that value.
-	// When unset (adaptive mode) the uploadController resizes it every control
-	// interval to track the goodput knee.
+	// uploadLimiter bounds concurrent remote PutBlock calls: the engine's block
+	// sink acquires it around each PutBlock and releases it when the upload
+	// lands. It is the controlled variable AND the sampled signal — the upload
+	// controller's TakePeak now measures the same semaphore that binds, so a
+	// single large file (one carve pass, many PUTs) is read as window-limited
+	// and ramped correctly. When ParallelUploads is pinned (> 0) its limit is
+	// fixed at that value. When unset (adaptive mode) the uploadController
+	// resizes it every control interval to track the goodput knee.
 	uploadLimiter *syncer.DynamicSemaphore
 	// uploadController is non-nil only in adaptive mode. It consumes one
 	// (goodput, windowLimited, sawError) sample per control interval and returns
@@ -837,7 +837,7 @@ func (m *RemoteSync) wireCarveTargets() {
 			return // remote configured but deps not fully wired yet
 		}
 		deduper := engineDeduper{synced: m.syncedHashStore}
-		sink := engineBlockSink{sealer: m.chunkSealer, rbs: m.remoteBlockStore, committer: m.blockCommitter, commitLocks: &carveCommitLocks{}, onBlockCommitted: m.noteBlockCommitted}
+		sink := engineBlockSink{sealer: m.chunkSealer, rbs: m.remoteBlockStore, committer: m.blockCommitter, commitLocks: &carveCommitLocks{}, onBlockCommitted: m.noteBlockCommitted, uploadLimiter: m.uploadLimiter}
 		m.local.SetCarveTargets(deduper, sink)
 		m.carveTargetsWired = true
 		return

--- a/pkg/block/engine/types.go
+++ b/pkg/block/engine/types.go
@@ -24,16 +24,16 @@ const DefaultParallelDownloads = 32
 // is unset (0), the syncer auto-tunes the upload window to saturate the uplink:
 // it starts at AdaptiveUploadFloor and ramps toward AdaptiveUploadCeiling,
 // settling at the goodput knee. A pinned ParallelUploads > 0 overrides this with
-// a fixed window. The window bounds concurrent whole-file carve passes, not
-// individual block PUTs — each pass applies its own bound on concurrent
-// PutBlock calls, so the PUTs in flight are the product of the two. Block PUTs
-// are network-latency bound, so a serial carver leaves the link idle — one
+// a fixed window. The window bounds concurrent remote PutBlock calls — one
+// semaphore in the engine's block sink acquired around each PutBlock — so the
+// sampled signal and the controlled variable are the same quantity. Block PUTs
+// are network-latency bound, so a serial uploader leaves the link idle — one
 // in-flight PutBlock sustained only ~200 Mbit/s VM→fr-par.
 const (
-	AdaptiveUploadFloor   = 16  // starting window in adaptive mode (greedy start)
-	AdaptiveUploadCeiling = 64  // max window the adaptive controller ramps to
+	AdaptiveUploadFloor   = 128 // starting window in adaptive mode (greedy start)
+	AdaptiveUploadCeiling = 256 // max window the adaptive controller ramps to (= MaxParallelUploads)
 	AdaptiveUploadDefault = 0   // ParallelUploads sentinel: 0 = adaptive auto-tune
-	MaxParallelUploads    = 256 // upper bound on a pinned ParallelUploads window
+	MaxParallelUploads    = 256 // upper bound on the upload window, enforced by the sink's semaphore
 )
 
 // uploadControlInterval is how often the adaptive controller samples goodput and
@@ -90,11 +90,11 @@ type RemoteSyncConfig struct {
 	UploadInterval     time.Duration // Periodic uploader scan interval (default: 2s)
 	UploadDelay        time.Duration // Min block age before periodic upload; Flush ignores this (default: 10s)
 
-	// ParallelUploads bounds concurrent block PUTs from the carver (#1407 /
-	// #1432). 0 (the default, AdaptiveUploadDefault) means the carver auto-tunes
-	// the window between AdaptiveUploadFloor and AdaptiveUploadCeiling to
-	// saturate the uplink; > 0 pins a fixed window (from the per-remote
-	// parallel_uploads config / --parallel-uploads). A serial carver (window 1)
+	// ParallelUploads bounds concurrent remote PutBlock calls from the carver
+	// (#1407 / #1432). 0 (the default, AdaptiveUploadDefault) means the uploader
+	// auto-tunes the window between AdaptiveUploadFloor and AdaptiveUploadCeiling
+	// to saturate the uplink; > 0 pins a fixed window (from the per-remote
+	// parallel_uploads config / --parallel-uploads). A serial uploader (window 1)
 	// leaves a WAN link idle, which is the #1432 upload-throughput regression.
 	ParallelUploads int
 

--- a/pkg/block/journal/carve.go
+++ b/pkg/block/journal/carve.go
@@ -44,8 +44,8 @@ var carveScratchPool = sync.Pool{New: func() any {
 //     only at that size and once at the end of the file, so a scattered dirty set
 //     drains as few full-size objects rather than one tiny object per run.
 //     Successive blocks of one file commit concurrently through a bounded worker
-//     pool (CarveUploadConcurrency) so a single large file's carve is not one
-//     PutBlock at a time; packing itself stays sequential.
+//     pool (CarvePackAhead, the pack-ahead memory bound) so a single large file's
+//     carve is not one PutBlock at a time; packing itself stays sequential.
 //  4. Only after a block's commit returns — and after every earlier block flipped —
 //     flip each carved record's synced flag in place with a one-byte pwrite (the
 //     header CRC excludes Flags, so no rewrite). The dispatcher applies the flips in
@@ -386,7 +386,13 @@ func (s *Store) packRuns(ctx context.Context, sh *shard, id FileID, rs []*runSta
 	// (one max chunk) and the carver's accumulator (one max chunk). One Box
 	// call fed a full read buffer emits one block per CarveBlockSize, so a
 	// multi-GiB file's peak is bounded by the same window, not by file size.
-	sem := make(chan struct{}, s.cfg.CarveUploadConcurrency)
+	// This is the pack-ahead MEMORY bound, not the upload-concurrency knob:
+	// concurrent PutBlock calls across all files are bounded by the engine's
+	// upload window in the block sink, and this window only throttles how many
+	// packed blocks may wait on those uploads per file. Default matches the
+	// engine's upload ceiling so it never binds first; below it, uploads drain
+	// as fast as the engine window admits.
+	sem := make(chan struct{}, s.cfg.CarvePackAhead)
 
 	// disp overlaps successive blocks' CommitBlock (upload + commit) while packing
 	// stays sequential. It owns the bounded worker pool and the ordered flip

--- a/pkg/block/journal/carve_arena_test.go
+++ b/pkg/block/journal/carve_arena_test.go
@@ -16,7 +16,7 @@ import (
 // CarveBlockSize and so overshoots by the chunk that crossed the line. Sizing
 // that overhang from the package ceiling rather than the share's own
 // ChunkParams reserves 16 MiB per block for a share chunking at 16 KiB, and the
-// reservation is per concurrency slot — so it multiplies by CarveUploadConcurrency
+// reservation is per pack-ahead slot — so it multiplies by CarvePackAhead
 // and again by however many files carve at once. The carver also packs one
 // further block ahead of the window (its batch is not window-throttled until
 // submit), so the budget carries one extra arena.
@@ -33,9 +33,9 @@ func TestCarveArenaSizedToConfiguredChunkSize(t *testing.T) {
 	params := chunker.Params{Min: 4 << 10, Avg: 8 << 10, Max: 16 << 10}
 
 	s, _, sink, _ := carveStore(t, Config{
-		CarveBlockSize:         blockSize,
-		CarveUploadConcurrency: window,
-		ChunkParams:            params,
+		CarveBlockSize: blockSize,
+		CarvePackAhead: window,
+		ChunkParams:    params,
 	})
 	ctx := context.Background()
 

--- a/pkg/block/journal/carve_concurrent_test.go
+++ b/pkg/block/journal/carve_concurrent_test.go
@@ -21,7 +21,7 @@ func TestCarveScatteredRunsConvergeConcurrently(t *testing.T) {
 		gap       = 8 << 10 // stride > runSize keeps every run non-contiguous
 		totalSize = runs * runSize
 	)
-	s, _, sink, _ := carveStore(t, Config{CarveBlockSize: 4 << 20, CarveUploadConcurrency: 8})
+	s, _, sink, _ := carveStore(t, Config{CarveBlockSize: 4 << 20, CarvePackAhead: 8})
 	ctx := context.Background()
 
 	want := map[int64][]byte{}
@@ -120,7 +120,7 @@ func TestCarveSharedRecordAcrossRuns(t *testing.T) {
 		leftCut  = 32 << 10
 		rightCut = 56 << 10
 	)
-	s, _, sink, _ := carveStore(t, Config{CarveBlockSize: 4 << 20, CarveUploadConcurrency: 4})
+	s, _, sink, _ := carveStore(t, Config{CarveBlockSize: 4 << 20, CarvePackAhead: 4})
 	ctx := context.Background()
 
 	base := randBytes(size, 1)
@@ -244,7 +244,7 @@ func (e *extendingSink) ReapSupersededManifest(_ context.Context, _ FileID, span
 // concurrently.
 func TestCarveRunDoesNotExtendPastNextRun(t *testing.T) {
 	const rec = 8 << 10
-	s, dd, base, _ := carveStore(t, Config{CarveBlockSize: 4 << 20, CarveUploadConcurrency: 4})
+	s, dd, base, _ := carveStore(t, Config{CarveBlockSize: 4 << 20, CarvePackAhead: 4})
 	sink := &extendingSink{
 		fakeSink: base,
 		gateOff:  rec,     // the first run ends here
@@ -342,9 +342,9 @@ func TestCarveBlocksCommitConcurrently(t *testing.T) {
 		window  = 4
 	)
 	s, _, sink, _ := carveStore(t, Config{
-		CarveBlockSize:         8 << 10,
-		CarveUploadConcurrency: window,
-		ChunkParams:            chunker.Params{Min: 4 << 10, Avg: 8 << 10, Max: 16 << 10},
+		CarveBlockSize: 8 << 10,
+		CarvePackAhead: window,
+		ChunkParams:    chunker.Params{Min: 4 << 10, Avg: 8 << 10, Max: 16 << 10},
 	})
 	ctx := context.Background()
 
@@ -436,7 +436,7 @@ func TestCarveBlocksCommitConcurrently(t *testing.T) {
 		t.Fatalf("max blocks committing at once = %d, want > 1: no second commit joined the first within the hold, so the commits did not overlap", max)
 	}
 	if max > window {
-		t.Fatalf("max concurrent commits = %d, want <= CarveUploadConcurrency (%d): the file-scoped bound on in-flight blocks was breached", max, window)
+		t.Fatalf("max concurrent commits = %d, want <= CarvePackAhead (%d): the file-scoped bound on in-flight blocks was breached", max, window)
 	}
 }
 
@@ -512,7 +512,7 @@ func TestCarveReapSurvivesSiblingFailure(t *testing.T) {
 		runSize  = 4 << 10
 		failFrom = 64 << 10
 	)
-	s, dd, base, _ := carveStore(t, Config{CarveBlockSize: runSize, CarveUploadConcurrency: 4})
+	s, dd, base, _ := carveStore(t, Config{CarveBlockSize: runSize, CarvePackAhead: 4})
 	sink := &reapCtxSink{
 		fakeSink:  base,
 		failFrom:  failFrom,

--- a/pkg/block/journal/carve_dispatch_test.go
+++ b/pkg/block/journal/carve_dispatch_test.go
@@ -121,9 +121,9 @@ func (s *ctrlSink) peak() int {
 func ctrlStore(t *testing.T, window int) (*Store, *ctrlSink) {
 	t.Helper()
 	cfg := Config{
-		CarveBlockSize:         32 << 10,
-		CarveUploadConcurrency: window,
-		ChunkParams:            chunker.Params{Min: 4 << 10, Avg: 8 << 10, Max: 16 << 10},
+		CarveBlockSize: 32 << 10,
+		CarvePackAhead: window,
+		ChunkParams:    chunker.Params{Min: 4 << 10, Avg: 8 << 10, Max: 16 << 10},
 	}
 	s, err := Open(t.TempDir(), cfg)
 	if err != nil {

--- a/pkg/block/journal/carve_pack_test.go
+++ b/pkg/block/journal/carve_pack_test.go
@@ -22,7 +22,7 @@ func TestCarvePackReachesBlockSizeOnScatteredRuns(t *testing.T) {
 	)
 	s, _, _, _ := carveStore(t, Config{
 		CarveBlockSize:         4 << 20,
-		CarveUploadConcurrency: 4,
+		CarvePackAhead: 4,
 		ChunkParams:            chunker.Params{Min: 1 << 10, Avg: 2 << 10, Max: 8 << 10},
 	})
 	ctx := context.Background()
@@ -62,7 +62,7 @@ func TestCarvePackSpansRunsFlipsEveryContributingRun(t *testing.T) {
 	)
 	s, _, sink, _ := carveStore(t, Config{
 		CarveBlockSize:         4 << 20,
-		CarveUploadConcurrency: 4,
+		CarvePackAhead: 4,
 		ChunkParams:            chunker.Params{Min: 1 << 10, Avg: 2 << 10, Max: 8 << 10},
 	})
 	ctx := context.Background()
@@ -122,7 +122,7 @@ func TestCarvePackFlipPlanWatermarks(t *testing.T) {
 	)
 	s, _, sink, _ := carveStore(t, Config{
 		CarveBlockSize:         32 << 10,
-		CarveUploadConcurrency: 1,
+		CarvePackAhead: 1,
 		ChunkParams:            chunker.Params{Min: 4 << 10, Avg: 8 << 10, Max: 16 << 10},
 	})
 	writeRunAt(t, s, 0, run0Recs)
@@ -190,7 +190,7 @@ func spanningBlockFailureReap(t *testing.T, straddle bool) {
 	)
 	s, dd, base, _ := carveStore(t, Config{
 		CarveBlockSize:         32 << 10,
-		CarveUploadConcurrency: 1,
+		CarvePackAhead: 1,
 		ChunkParams:            chunker.Params{Min: 4 << 10, Avg: 8 << 10, Max: 16 << 10},
 	})
 	sink := &extendingSink{fakeSink: base, straddleEverywhere: straddle}
@@ -249,7 +249,7 @@ func TestCarvePackReapCarriesEveryCommittedRun(t *testing.T) {
 		gap     = 64 << 10
 		runs    = 3
 	)
-	s, dd, base, _ := carveStore(t, Config{CarveBlockSize: 4 << 20, CarveUploadConcurrency: 4})
+	s, dd, base, _ := carveStore(t, Config{CarveBlockSize: 4 << 20, CarvePackAhead: 4})
 	boom := errors.New("reap failed")
 	sink := &extendingSink{fakeSink: base, failFirstReap: boom}
 	s.SetCarveTargets(dd, sink)
@@ -286,7 +286,7 @@ func TestCarvePackSeamRunFailureLeavesSuffixDirty(t *testing.T) {
 	const runSize = 512 << 10
 	s, _, sink, _ := carveStore(t, Config{
 		CarveBlockSize:         64 << 10,
-		CarveUploadConcurrency: 1,
+		CarvePackAhead: 1,
 		ChunkParams:            chunker.Params{Min: 4 << 10, Avg: 8 << 10, Max: 16 << 10},
 	})
 	writeAdjacent(t, s, "f", 128, 4<<10)
@@ -353,7 +353,7 @@ func BenchmarkCarveScatteredPass(b *testing.B) {
 		b.StopTimer()
 		s, _, sink, _ := carveStore(b, Config{
 			CarveBlockSize:         4 << 20,
-			CarveUploadConcurrency: 8,
+			CarvePackAhead: 8,
 			ChunkParams:            chunker.Params{Min: 1 << 10, Avg: 2 << 10, Max: 8 << 10},
 		})
 		s.SetCarveTargets(slowDeduper{delay: deduperLookupDelay}, sink)

--- a/pkg/block/journal/carve_pack_test.go
+++ b/pkg/block/journal/carve_pack_test.go
@@ -21,9 +21,9 @@ func TestCarvePackReachesBlockSizeOnScatteredRuns(t *testing.T) {
 		gap     = 64 << 10 // a hole between runs keeps them separate
 	)
 	s, _, _, _ := carveStore(t, Config{
-		CarveBlockSize:         4 << 20,
+		CarveBlockSize: 4 << 20,
 		CarvePackAhead: 4,
-		ChunkParams:            chunker.Params{Min: 1 << 10, Avg: 2 << 10, Max: 8 << 10},
+		ChunkParams:    chunker.Params{Min: 1 << 10, Avg: 2 << 10, Max: 8 << 10},
 	})
 	ctx := context.Background()
 
@@ -61,9 +61,9 @@ func TestCarvePackSpansRunsFlipsEveryContributingRun(t *testing.T) {
 		gap     = 32 << 10
 	)
 	s, _, sink, _ := carveStore(t, Config{
-		CarveBlockSize:         4 << 20,
+		CarveBlockSize: 4 << 20,
 		CarvePackAhead: 4,
-		ChunkParams:            chunker.Params{Min: 1 << 10, Avg: 2 << 10, Max: 8 << 10},
+		ChunkParams:    chunker.Params{Min: 1 << 10, Avg: 2 << 10, Max: 8 << 10},
 	})
 	ctx := context.Background()
 
@@ -121,9 +121,9 @@ func TestCarvePackFlipPlanWatermarks(t *testing.T) {
 		run1End  = run1Off + run1Recs*(4<<10)
 	)
 	s, _, sink, _ := carveStore(t, Config{
-		CarveBlockSize:         32 << 10,
+		CarveBlockSize: 32 << 10,
 		CarvePackAhead: 1,
-		ChunkParams:            chunker.Params{Min: 4 << 10, Avg: 8 << 10, Max: 16 << 10},
+		ChunkParams:    chunker.Params{Min: 4 << 10, Avg: 8 << 10, Max: 16 << 10},
 	})
 	writeRunAt(t, s, 0, run0Recs)
 	writeRunAt(t, s, run1Off, run1Recs)
@@ -189,9 +189,9 @@ func spanningBlockFailureReap(t *testing.T, straddle bool) {
 		gap      = run1Off
 	)
 	s, dd, base, _ := carveStore(t, Config{
-		CarveBlockSize:         32 << 10,
+		CarveBlockSize: 32 << 10,
 		CarvePackAhead: 1,
-		ChunkParams:            chunker.Params{Min: 4 << 10, Avg: 8 << 10, Max: 16 << 10},
+		ChunkParams:    chunker.Params{Min: 4 << 10, Avg: 8 << 10, Max: 16 << 10},
 	})
 	sink := &extendingSink{fakeSink: base, straddleEverywhere: straddle}
 	s.SetCarveTargets(dd, sink)
@@ -285,9 +285,9 @@ func TestCarvePackReapCarriesEveryCommittedRun(t *testing.T) {
 func TestCarvePackSeamRunFailureLeavesSuffixDirty(t *testing.T) {
 	const runSize = 512 << 10
 	s, _, sink, _ := carveStore(t, Config{
-		CarveBlockSize:         64 << 10,
+		CarveBlockSize: 64 << 10,
 		CarvePackAhead: 1,
-		ChunkParams:            chunker.Params{Min: 4 << 10, Avg: 8 << 10, Max: 16 << 10},
+		ChunkParams:    chunker.Params{Min: 4 << 10, Avg: 8 << 10, Max: 16 << 10},
 	})
 	writeAdjacent(t, s, "f", 128, 4<<10)
 	ctx := context.Background()
@@ -352,9 +352,9 @@ func BenchmarkCarveScatteredPass(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
 		s, _, sink, _ := carveStore(b, Config{
-			CarveBlockSize:         4 << 20,
+			CarveBlockSize: 4 << 20,
 			CarvePackAhead: 8,
-			ChunkParams:            chunker.Params{Min: 1 << 10, Avg: 2 << 10, Max: 8 << 10},
+			ChunkParams:    chunker.Params{Min: 1 << 10, Avg: 2 << 10, Max: 8 << 10},
 		})
 		s.SetCarveTargets(slowDeduper{delay: deduperLookupDelay}, sink)
 		for r := 0; r < runs; r++ {

--- a/pkg/block/journal/carve_pipeline_test.go
+++ b/pkg/block/journal/carve_pipeline_test.go
@@ -71,7 +71,7 @@ func TestCarveInterleavesRowEndLookupsWithCommits(t *testing.T) {
 	)
 	s, dd, fs, _ := carveStore(t, Config{
 		CarveBlockSize:         blockSize,
-		CarveUploadConcurrency: uploadConcurrency,
+		CarvePackAhead: uploadConcurrency,
 		ChunkParams:            chunker.Params{Min: 1 << 10, Avg: 2 << 10, Max: 8 << 10},
 	})
 	ctx := context.Background()

--- a/pkg/block/journal/carve_pipeline_test.go
+++ b/pkg/block/journal/carve_pipeline_test.go
@@ -70,9 +70,9 @@ func TestCarveInterleavesRowEndLookupsWithCommits(t *testing.T) {
 		maxPrologue       = 2*uploadConcurrency*runsPerBlock + 1
 	)
 	s, dd, fs, _ := carveStore(t, Config{
-		CarveBlockSize:         blockSize,
+		CarveBlockSize: blockSize,
 		CarvePackAhead: uploadConcurrency,
-		ChunkParams:            chunker.Params{Min: 1 << 10, Avg: 2 << 10, Max: 8 << 10},
+		ChunkParams:    chunker.Params{Min: 1 << 10, Avg: 2 << 10, Max: 8 << 10},
 	})
 	ctx := context.Background()
 

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -102,13 +102,13 @@ type Config struct {
 }
 
 const (
-	defaultSegmentSize            int64 = 256 << 20
-	defaultCarveBlockSize         int64 = 4 << 20
-	defaultCarveMaxAge                  = 5 * time.Second
-	defaultGCDeadRatioForce             = 0.5
-	defaultShardCount                   = 16
-	defaultEvictMaxWait                 = 30 * time.Second
-	defaultCarvePackAhead               = 256
+	defaultSegmentSize      int64 = 256 << 20
+	defaultCarveBlockSize   int64 = 4 << 20
+	defaultCarveMaxAge            = 5 * time.Second
+	defaultGCDeadRatioForce       = 0.5
+	defaultShardCount             = 16
+	defaultEvictMaxWait           = 30 * time.Second
+	defaultCarvePackAhead         = 256
 	// defaultDirtyExpiry mirrors Linux writeback's dirty_expire_centisecs
 	// default: an unfsynced write is pushed to the device once it is about
 	// this old.

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -60,18 +60,18 @@ type Config struct {
 	// itself fails.
 	MaxLocalBytes int64
 	EvictMaxWait  time.Duration // write-path backpressure budget before ErrLocalStoreFull
-	// CarveUploadConcurrency bounds how many of one file's packed blocks are
-	// committed (uploaded + committed) at once. Packing itself is sequential
-	// across the whole file, one block at a time, and so are the manifest row-end
-	// lookups that widen each run; only the commits overlap, so a single large
-	// file's carve is not one PutBlock at a time.
+	// CarvePackAhead bounds how many of one file's packed blocks may wait on
+	// their uploads at once — the pack-ahead MEMORY bound, not the
+	// upload-concurrency knob. Concurrent PutBlock calls across all files are
+	// bounded by the engine's upload window in the block sink (the controller's
+	// controlled variable); this window only throttles how many packed blocks
+	// queue per file, bounding the arenas live while they wait.
 	// Peak carve RAM per file is window x (CarveBlockSize + one ChunkParams.Max
 	// chunk) for the block arenas, plus the single chunker scratch buffer of
-	// chunker.MaxChunkSize the pass holds. Per file: whatever bounds how many
-	// files carve at once multiplies the arena term again, so the real ceiling
-	// is that product — keep this modest.
+	// chunker.MaxChunkSize the pass holds. Default matches the engine's upload
+	// ceiling so it never binds first.
 	// Zero falls back to the default via withDefaults.
-	CarveUploadConcurrency int
+	CarvePackAhead int
 	// DirtyExpiry bounds how long an appended record may sit unfsynced. A
 	// background loop commits every shard still holding uncovered records once
 	// per interval, so a client that never asks for durability (no NFS COMMIT,
@@ -108,7 +108,7 @@ const (
 	defaultGCDeadRatioForce             = 0.5
 	defaultShardCount                   = 16
 	defaultEvictMaxWait                 = 30 * time.Second
-	defaultCarveUploadConcurrency       = 8
+	defaultCarvePackAhead               = 256
 	// defaultDirtyExpiry mirrors Linux writeback's dirty_expire_centisecs
 	// default: an unfsynced write is pushed to the device once it is about
 	// this old.
@@ -142,8 +142,8 @@ func (c Config) withDefaults() Config {
 	if c.EvictMaxWait <= 0 {
 		c.EvictMaxWait = defaultEvictMaxWait
 	}
-	if c.CarveUploadConcurrency <= 0 {
-		c.CarveUploadConcurrency = defaultCarveUploadConcurrency
+	if c.CarvePackAhead <= 0 {
+		c.CarvePackAhead = defaultCarvePackAhead
 	}
 	if c.DirtyExpiry == 0 {
 		c.DirtyExpiry = defaultDirtyExpiry

--- a/pkg/block/journal/store.go
+++ b/pkg/block/journal/store.go
@@ -68,8 +68,12 @@ type Config struct {
 	// queue per file, bounding the arenas live while they wait.
 	// Peak carve RAM per file is window x (CarveBlockSize + one ChunkParams.Max
 	// chunk) for the block arenas, plus the single chunker scratch buffer of
-	// chunker.MaxChunkSize the pass holds. Default matches the engine's upload
-	// ceiling so it never binds first.
+	// chunker.MaxChunkSize the pass holds — roughly 1 GiB at the default with a
+	// 4 MiB CarveBlockSize. Default matches the engine's upload ceiling so it
+	// never binds first; drop it in the share's store config when a slow remote
+	// makes that queue depth too much RSS for one file. A pinned
+	// ParallelUploads no longer reduces this (it only bounds the upload
+	// window), so the two knobs are independent by design.
 	// Zero falls back to the default via withDefaults.
 	CarvePackAhead int
 	// DirtyExpiry bounds how long an appended record may sit unfsynced. A

--- a/pkg/block/remote/s3/store.go
+++ b/pkg/block/remote/s3/store.go
@@ -41,10 +41,12 @@ const maxBlockReadSize = 8 * 1024 * 1024
 const s3HTTPRequestTimeout = 2 * time.Minute
 
 // maxS3ConnsPerHost sizes the HTTP connection pool so it never caps the
-// syncer's upload concurrency (#1407): it matches the maximum a user can pin
-// via --parallel-uploads (validateParallelUploads allows up to 256) and so also
-// covers the adaptive ceiling (engine.AdaptiveUploadCeiling, 64) plus concurrent
-// downloads. 256 conns are created on demand, not preallocated. Defined locally
+// sink's upload window (#1407): it matches the maximum a user can pin
+// via --parallel-uploads (validateParallelUploads allows up to 256), which the
+// adaptive ceiling (engine.AdaptiveUploadCeiling, 256) also cannot exceed, so
+// PUTs never exhaust the pool while the download workers (32) share the same
+// host — when PUTs sit at the ceiling, downloads queue behind them in the
+// pool. 256 conns are created on demand, not preallocated. Defined locally
 // rather than imported from engine to avoid a dependency cycle.
 const maxS3ConnsPerHost = 256
 
@@ -209,12 +211,13 @@ func NewFromConfig(ctx context.Context, config Config) (*Store, error) {
 }
 
 // newHTTPClient builds the HTTP client the S3 SDK issues every request
-// through. It sizes the connection pool for parallel uploads: the pool must
-// not cap the syncer's upload window below its ceiling, or it becomes the
-// hidden bottleneck, since the adaptive controller ramps to
-// engine.AdaptiveUploadCeiling (64) and downloads run concurrently on the same
-// host, so it is sized for both (128 conns x ~512KB buffers ≈ 64MB worst case,
-// created on demand). A pinned --parallel-uploads above this still caps here.
+// through. It sizes the connection pool for the sink's upload window: the pool
+// must not cap the window below its ceiling, or it becomes the hidden
+// bottleneck, since the adaptive controller ramps to
+// engine.AdaptiveUploadCeiling (256) and downloads run concurrently on the
+// same host. When PUTs sit at the ceiling, downloads queue behind them in the
+// pool rather than erroring; conns are created on demand. A pinned
+// --parallel-uploads above this still caps here.
 //
 // It also carries the two runtime halves of the endpoint guard: a dial-time
 // address check and a refusal to follow redirects. allowPrivate relaxes the

--- a/pkg/block/syncer/upload_controller.go
+++ b/pkg/block/syncer/upload_controller.go
@@ -4,8 +4,9 @@ import "math"
 
 // GoodputController is the pure decision core of adaptive upload concurrency.
 // When the user does not pin parallel_uploads, the syncer ramps the upload
-// window — the number of carve passes running concurrently, each of which
-// issues its own block PUTs — to saturate the uplink on its own.
+// window — the semaphore the engine's block sink acquires around each remote
+// PutBlock, so window size and concurrent PUTs are the same quantity — to
+// saturate the uplink on its own.
 //
 // The control signal is GOODPUT (delivered bytes/sec), not latency. An earlier
 // latency-gradient design read the per-PUT latency rise *caused by useful


### PR DESCRIPTION
## Issue #2423: upload concurrency is a product of two windows

Measured on develop (10-CPU Apple Fabric SSD, 64 files × 8 MiB, 1 MiB blocks, 200 ms injected per-PutBlock latency, production dispatch path, deterministic ×3):

| Arrangement | max concurrent PutBlock | which semaphore bound |
|---|---|---|
| Defaults (inner=8, adaptive outer 16→64) | **160** | neither alone — the **product** |
| Inner=1 (product collapses) | 40 | outer file window |
| Single huge file | **8 exactly** | inner window; outer trivially at 1 |

The documented invariant — "at most Limit() carves, **and thus block PUTs**, in flight" — does not hold: two independent semaphores are nested (outer whole-file carve passes via `uploadLimiter`, inner block PUTs within one carve via `CarveUploadConcurrency=8`), so concurrent `PutBlock` is their **product** (~128 at the floor, 512 at the ceiling — breaching the declared `MaxParallelUploads=256` by 2×). The adaptive goodput controller sampled only the outer limiter's `TakePeak`, so draining one large file peaked at one pass and read as app-limited while the pass's inner 8-slot window saturated the link — the controller never ramped.

### The fix: one window governs PUTs

The obvious move (keep both windows, sample better) cannot fix the workload shape that matters: a single huge file is one carve pass — ramping the per-pass count can't raise single-file throughput no matter what the controller reads. The real fix collapses the product:

- **Enforcement moved into the block sink** — `engineBlockSink.CommitBlock` brackets `PutBlock` with the engine's upload window (acquire per PUT, release when the upload lands). This is now where the adaptive window is enforced, so the controller's `TakePeak` samples the same semaphore that binds: the sampled signal and the controlled variable are the same quantity. The four `Force:true` drain drivers and ManualSync shares are bounded automatically (the limiter lives in the sink the carver calls), closing the issue's "two more paths where the outer window does not apply" gaps with no per-path work.
- **No per-pass limit** — the outer per-pass acquire/release in `carvePass` is gone. Concurrent PUTs across all passes are bounded by the global sink window itself, which is the invariant.
- **The journal's per-file window becomes the pack-ahead memory bound** — `CarveUploadConcurrency` renamed to `CarvePackAhead`, default 8→256 (the upload ceiling, so it never binds concurrency first). It only throttles how many packed blocks queue per file, bounding the live arenas — not the upload-concurrency knob.
- **Constants** — `AdaptiveUploadFloor` 16→128 (= today's effective resting point 16×8, so multi-file behavior at rest is preserved exactly), `AdaptiveUploadCeiling` 64→256 (= `MaxParallelUploads`, now actually enforced; the share-config clamp in `blockstore_config.go` already validated against 256).
- **Controller logic unchanged** — `TestGoodputController_HoldsWindowWhenAppLimited`-style pins survive with re-derived constants.

### Regression guard

`TestBlockSink_EnforcesUploadWindow` gates a memory remote with an in-flight counter checked on the `PutBlock` critical path — the guard that would have caught the original defect. The old fan-out pin (`TestCarvePass_FansOutBoundedByUploadWindow`) pinned the per-pass invariant this change removes; rewritten as `TestCarvePass_FansOutUnbounded` (every file enters `local.Carve` concurrently).

### Verification

- `go build ./...`, `go vet`, `go fmt` clean; regenerated `docs/guide/cli.md` after flag-description changes
- Whole-repo `go test ./...` green
- `-race` green on `pkg/block/journal` + `pkg/block/engine`
- Full engine (82 s) and journal (81 s) suites green

**Not yet measured** (the merge gates from the measurement probe): multi-file parity ≥336.7 MB/s at floor 128, the single-file ramp leg, peak RSS at 256 in-flight buffers, and a low-RTT leg to justify the 128 floor. The probe (`pkg/block/engine/upload_concurrency_probe_test.go`) exists to re-run after this lands; the floor constant may need a follow-up correction if the sweep shows a better knee.

Closes #2423.
